### PR TITLE
ENH: Sparse int64 and bool dtype support enhancement

### DIFF
--- a/doc/source/sparse.rst
+++ b/doc/source/sparse.rst
@@ -132,6 +132,61 @@ keeps an arrays of all of the locations where the data are not equal to the
 fill value. The ``block`` format tracks only the locations and sizes of blocks
 of data.
 
+.. _sparse.dtype:
+
+Sparse Dtypes
+-------------
+
+Sparse data should have the same dtype as its dense representation. Currently,
+``float64``, ``int64`` and ``bool`` dtypes are supported. Depending on the original
+dtype, ``fill_value`` default changes:
+
+- ``float64``: ``np.nan``
+- ``int64``: ``0``
+- ``bool``: ``False``
+
+.. ipython:: python
+
+   s = pd.Series([1, np.nan, np.nan])
+   s
+   s.to_sparse()
+
+   s = pd.Series([1, 0, 0])
+   s
+   s.to_sparse()
+
+   s = pd.Series([True, False, True])
+   s
+   s.to_sparse()
+
+You can change the dtype using ``.astype()``, the result is also sparse. Note that
+``.astype()`` also affects to the ``fill_value`` to keep its dense represantation.
+
+
+.. ipython:: python
+
+   s = pd.Series([1, 0, 0, 0, 0])
+   s
+   ss = s.to_sparse()
+   ss
+   ss.astype(np.float64)
+
+It raises if any value cannot be coerced to specified dtype.
+
+.. code-block:: ipython
+
+   In [1]: ss = pd.Series([1, np.nan, np.nan]).to_sparse()
+   0    1.0
+   1    NaN
+   2    NaN
+   dtype: float64
+   BlockIndex
+   Block locations: array([0], dtype=int32)
+   Block lengths: array([1], dtype=int32)
+
+   In [2]: ss.astype(np.int64)
+   ValueError: unable to coerce current fill_value nan to int64 dtype
+
 .. _sparse.calculation:
 
 Sparse Calculation

--- a/doc/source/whatsnew/v0.19.0.txt
+++ b/doc/source/whatsnew/v0.19.0.txt
@@ -17,6 +17,7 @@ Highlights include:
 - ``.rolling()`` are now time-series aware, see :ref:`here <whatsnew_0190.enhancements.rolling_ts>`
 - pandas development api, see :ref:`here <whatsnew_0190.dev_api>`
 - ``PeriodIndex`` now has its own ``period`` dtype, and changed to be more consistent with other ``Index`` classes. See ref:`here <whatsnew_0190.api.period>`
+- Sparse data structures now gained enhanced support of ``int`` and ``bool`` dtypes, see :ref:`here <whatsnew_0190.sparse>`
 
 .. contents:: What's new in v0.19.0
     :local:
@@ -975,6 +976,51 @@ Sparse Changes
 
 These changes allow pandas to handle sparse data with more dtypes, and for work to make a smoother experience with data handling.
 
+
+``int64`` and ``bool`` support enhancements
+"""""""""""""""""""""""""""""""""""""""""""
+
+Sparse data structures now gained enhanced support of ``int64`` and ``bool`` ``dtype`` (:issue:`667`, :issue:`13849`)
+
+Previously, sparse data were ``float64`` dtype by default, even if all inputs were ``int`` or ``bool`` dtype. You had to specify ``dtype`` explicitly to create sparse data with ``int64`` dtype. Also, ``fill_value`` had to be specified explicitly becuase it's default was ``np.nan`` which doesn't appear in ``int64`` or ``bool`` data.
+
+.. code-block:: ipython
+
+   In [1]: pd.SparseArray([1, 2, 0, 0])
+   Out[1]:
+   [1.0, 2.0, 0.0, 0.0]
+   Fill: nan
+   IntIndex
+   Indices: array([0, 1, 2, 3], dtype=int32)
+
+   # specifying int64 dtype, but all values are stored in sp_values because
+   # fill_value default is np.nan
+   In [2]: pd.SparseArray([1, 2, 0, 0], dtype=np.int64)
+   Out[2]:
+   [1, 2, 0, 0]
+   Fill: nan
+   IntIndex
+   Indices: array([0, 1, 2, 3], dtype=int32)
+
+   In [3]: pd.SparseArray([1, 2, 0, 0], dtype=np.int64, fill_value=0)
+   Out[3]:
+   [1, 2, 0, 0]
+   Fill: 0
+   IntIndex
+   Indices: array([0, 1], dtype=int32)
+
+As of v0.19.0, sparse data keeps the input dtype, and assign more appropriate ``fill_value`` default (``0`` for ``int64`` dtype, ``False`` for ``bool`` dtype).
+
+.. ipython :: python
+
+   pd.SparseArray([1, 2, 0, 0], dtype=np.int64)
+   pd.SparseArray([True, False, False, False])
+
+See the :ref:`docs <sparse.dtype>` for more details.
+
+Operators now preserve dtypes
+"""""""""""""""""""""""""""""
+
 - Sparse data structure now can preserve ``dtype`` after arithmetic ops (:issue:`13848`)
 
 .. ipython:: python
@@ -1001,6 +1047,9 @@ Note that the limitation is applied to ``fill_value`` which default is ``np.nan`
    Out[7]:
    ValueError: unable to coerce current fill_value nan to int64 dtype
 
+Other sparse fixes
+""""""""""""""""""
+
 - Subclassed ``SparseDataFrame`` and ``SparseSeries`` now preserve class types when slicing or transposing. (:issue:`13787`)
 - ``SparseArray`` with ``bool`` dtype now supports logical (bool) operators (:issue:`14000`)
 - Bug in ``SparseSeries`` with ``MultiIndex`` ``[]`` indexing may raise ``IndexError`` (:issue:`13144`)
@@ -1011,6 +1060,11 @@ Note that the limitation is applied to ``fill_value`` which default is ``np.nan`
 - Bug in ``SparseArray`` and ``SparseSeries`` don't apply ufunc to ``fill_value`` (:issue:`13853`)
 - Bug in ``SparseSeries.abs`` incorrectly keeps negative ``fill_value`` (:issue:`13853`)
 - Bug in single row slicing on multi-type ``SparseDataFrame``s, types were previously forced to float (:issue:`13917`)
+- Bug in ``SparseSeries`` slicing changes integer dtype to float (:issue:`8292`)
+- Bug in ``SparseDataFarme`` comparison ops may raise ``TypeError`` (:issue:`13001`)
+- Bug in ``SparseDataFarme.isnull`` raises ``ValueError`` (:issue:`8276`)
+- Bug in ``SparseSeries`` representation with ``bool`` dtype may raise ``IndexError`` (:issue:`13110`)
+- Bug in ``SparseSeries`` and ``SparseDataFrame`` of ``bool`` or ``int64`` dtype may display its values like ``float64`` dtype (:issue:`13110`)
 - Bug in sparse indexing using ``SparseArray`` with ``bool`` dtype may return incorrect result  (:issue:`13985`)
 - Bug in ``SparseArray`` created from ``SparseSeries`` may lose ``dtype`` (:issue:`13999`)
 - Bug in ``SparseSeries`` comparison with dense returns normal ``Series`` rather than ``SparseSeries`` (:issue:`13999`)
@@ -1052,7 +1106,6 @@ New behaviour:
 
    In [2]: i.get_indexer(['b', 'b', 'c']).dtype
    Out[2]: dtype('int64')
-
 
 .. _whatsnew_0190.deprecations:
 

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -3779,24 +3779,29 @@ class NDFrame(PandasObject):
     # ----------------------------------------------------------------------
     # Action Methods
 
-    def isnull(self):
-        """
+    _shared_docs['isnull'] = """
         Return a boolean same-sized object indicating if the values are null.
 
         See Also
         --------
         notnull : boolean inverse of isnull
         """
+
+    @Appender(_shared_docs['isnull'])
+    def isnull(self):
         return isnull(self).__finalize__(self)
 
-    def notnull(self):
-        """Return a boolean same-sized object indicating if the values are
+    _shared_docs['isnotnull'] = """
+        Return a boolean same-sized object indicating if the values are
         not null.
 
         See Also
         --------
         isnull : boolean inverse of notnull
         """
+
+    @Appender(_shared_docs['isnotnull'])
+    def notnull(self):
         return notnull(self).__finalize__(self)
 
     def clip(self, lower=None, upper=None, axis=None, *args, **kwargs):

--- a/pandas/core/internals.py
+++ b/pandas/core/internals.py
@@ -2478,9 +2478,6 @@ class SparseBlock(NonConsolidatableMixIn, Block):
 
     @fill_value.setter
     def fill_value(self, v):
-        # we may need to upcast our fill to match our dtype
-        if issubclass(self.dtype.type, np.floating):
-            v = float(v)
         self.values.fill_value = v
 
     def to_dense(self):

--- a/pandas/formats/format.py
+++ b/pandas/formats/format.py
@@ -21,6 +21,7 @@ from pandas.types.common import (is_categorical_dtype,
                                  is_numeric_dtype,
                                  is_datetime64_dtype,
                                  is_timedelta64_dtype)
+from pandas.types.generic import ABCSparseArray
 
 from pandas.core.base import PandasObject
 from pandas.core.index import Index, MultiIndex, _ensure_index
@@ -1966,6 +1967,8 @@ class GenericArrayFormatter(object):
         vals = self.values
         if isinstance(vals, Index):
             vals = vals._values
+        elif isinstance(vals, ABCSparseArray):
+            vals = vals.values
 
         is_float_type = lib.map_infer(vals, is_float) & notnull(vals)
         leading_space = is_float_type.any()

--- a/pandas/io/tests/test_pickle.py
+++ b/pandas/io/tests/test_pickle.py
@@ -163,6 +163,13 @@ class TestPickle():
         tm.assert_equal(result.freqstr, 'M')
         tm.assert_index_equal(result.shift(2), expected.shift(2))
 
+    def compare_sp_frame_float(self, result, expected, typ, version):
+        if LooseVersion(version) <= '0.18.1':
+            tm.assert_sp_frame_equal(result, expected, exact_indices=False,
+                                     check_dtype=False)
+        else:
+            tm.assert_sp_frame_equal(result, expected)
+
     def read_pickles(self, version):
         if not is_platform_little_endian():
             raise nose.SkipTest("known failure on non-little endian")

--- a/pandas/sparse/tests/test_arithmetics.py
+++ b/pandas/sparse/tests/test_arithmetics.py
@@ -357,6 +357,65 @@ class TestSparseArrayArithmetics(tm.TestCase):
                                 fill_value=fill_value)
                 self._check_logical_ops(a, b, values, rvalues)
 
+    def test_mixed_array_float_int(self):
+
+        for rdtype in ['int64']:
+            values = self._base([np.nan, 1, 2, 0, np.nan, 0, 1, 2, 1, np.nan])
+            rvalues = self._base([2, 0, 2, 3, 0, 0, 1, 5, 2, 0], dtype=rdtype)
+
+            for kind in ['integer', 'block']:
+                a = self._klass(values, kind=kind)
+                b = self._klass(rvalues, kind=kind)
+                self.assertEqual(b.dtype, rdtype)
+
+                self._check_numeric_ops(a, b, values, rvalues)
+                self._check_numeric_ops(a, b * 0, values, rvalues * 0)
+
+                a = self._klass(values, kind=kind, fill_value=0)
+                b = self._klass(rvalues, kind=kind)
+                self.assertEqual(b.dtype, rdtype)
+                self._check_numeric_ops(a, b, values, rvalues)
+
+                a = self._klass(values, kind=kind, fill_value=0)
+                b = self._klass(rvalues, kind=kind, fill_value=0)
+                self.assertEqual(b.dtype, rdtype)
+                self._check_numeric_ops(a, b, values, rvalues)
+
+                a = self._klass(values, kind=kind, fill_value=1)
+                b = self._klass(rvalues, kind=kind, fill_value=2)
+                self.assertEqual(b.dtype, rdtype)
+                self._check_numeric_ops(a, b, values, rvalues)
+
+    def test_mixed_array_comparison(self):
+
+        # int32 NI ATM
+        for rdtype in ['int64']:
+            values = self._base([np.nan, 1, 2, 0, np.nan, 0, 1, 2, 1, np.nan])
+            rvalues = self._base([2, 0, 2, 3, 0, 0, 1, 5, 2, 0], dtype=rdtype)
+
+            for kind in ['integer', 'block']:
+                a = self._klass(values, kind=kind)
+                b = self._klass(rvalues, kind=kind)
+                self.assertEqual(b.dtype, rdtype)
+
+                self._check_comparison_ops(a, b, values, rvalues)
+                self._check_comparison_ops(a, b * 0, values, rvalues * 0)
+
+                a = self._klass(values, kind=kind, fill_value=0)
+                b = self._klass(rvalues, kind=kind)
+                self.assertEqual(b.dtype, rdtype)
+                self._check_comparison_ops(a, b, values, rvalues)
+
+                a = self._klass(values, kind=kind, fill_value=0)
+                b = self._klass(rvalues, kind=kind, fill_value=0)
+                self.assertEqual(b.dtype, rdtype)
+                self._check_comparison_ops(a, b, values, rvalues)
+
+                a = self._klass(values, kind=kind, fill_value=1)
+                b = self._klass(rvalues, kind=kind, fill_value=2)
+                self.assertEqual(b.dtype, rdtype)
+                self._check_comparison_ops(a, b, values, rvalues)
+
 
 class TestSparseSeriesArithmetic(TestSparseArrayArithmetics):
 

--- a/pandas/sparse/tests/test_array.py
+++ b/pandas/sparse/tests/test_array.py
@@ -30,9 +30,13 @@ class TestSparseArray(tm.TestCase):
         self.assertEqual(arr.dtype, np.float64)
         self.assertEqual(arr.fill_value, 0)
 
+        arr = SparseArray([0, 1, 2, 4], dtype=np.float64)
+        self.assertEqual(arr.dtype, np.float64)
+        self.assertTrue(np.isnan(arr.fill_value))
+
         arr = SparseArray([0, 1, 2, 4], dtype=np.int64)
         self.assertEqual(arr.dtype, np.int64)
-        self.assertTrue(np.isnan(arr.fill_value))
+        self.assertEqual(arr.fill_value, 0)
 
         arr = SparseArray([0, 1, 2, 4], fill_value=0, dtype=np.int64)
         self.assertEqual(arr.dtype, np.int64)
@@ -40,7 +44,7 @@ class TestSparseArray(tm.TestCase):
 
         arr = SparseArray([0, 1, 2, 4], dtype=None)
         self.assertEqual(arr.dtype, np.int64)
-        self.assertTrue(np.isnan(arr.fill_value))
+        self.assertEqual(arr.fill_value, 0)
 
         arr = SparseArray([0, 1, 2, 4], fill_value=0, dtype=None)
         self.assertEqual(arr.dtype, np.int64)
@@ -63,13 +67,13 @@ class TestSparseArray(tm.TestCase):
         self.assertEqual(arr.dtype, np.float64)
         self.assertTrue(np.isnan(arr.fill_value))
 
-        arr = SparseArray(data=[0, 1, 2, 3],
-                          sparse_index=IntIndex(4, [0, 1, 2, 3]),
-                          dtype=np.int64)
-        exp = SparseArray([0, 1, 2, 3], dtype=np.int64)
+        arr = SparseArray(data=[1, 2, 3],
+                          sparse_index=IntIndex(4, [1, 2, 3]),
+                          dtype=np.int64, fill_value=0)
+        exp = SparseArray([0, 1, 2, 3], dtype=np.int64, fill_value=0)
         tm.assert_sp_array_equal(arr, exp)
         self.assertEqual(arr.dtype, np.int64)
-        self.assertTrue(np.isnan(arr.fill_value))
+        self.assertEqual(arr.fill_value, 0)
 
         arr = SparseArray(data=[1, 2], sparse_index=IntIndex(4, [1, 2]),
                           fill_value=0, dtype=np.int64)
@@ -78,22 +82,20 @@ class TestSparseArray(tm.TestCase):
         self.assertEqual(arr.dtype, np.int64)
         self.assertEqual(arr.fill_value, 0)
 
-        arr = SparseArray(data=[0, 1, 2, 3],
-                          sparse_index=IntIndex(4, [0, 1, 2, 3]),
-                          dtype=None)
+        arr = SparseArray(data=[1, 2, 3],
+                          sparse_index=IntIndex(4, [1, 2, 3]),
+                          dtype=None, fill_value=0)
         exp = SparseArray([0, 1, 2, 3], dtype=None)
         tm.assert_sp_array_equal(arr, exp)
         self.assertEqual(arr.dtype, np.int64)
-        self.assertTrue(np.isnan(arr.fill_value))
+        self.assertEqual(arr.fill_value, 0)
 
         # scalar input
-        arr = SparseArray(data=1,
-                          sparse_index=IntIndex(1, [0]),
-                          dtype=None)
+        arr = SparseArray(data=1, sparse_index=IntIndex(1, [0]), dtype=None)
         exp = SparseArray([1], dtype=None)
         tm.assert_sp_array_equal(arr, exp)
         self.assertEqual(arr.dtype, np.int64)
-        self.assertTrue(np.isnan(arr.fill_value))
+        self.assertEqual(arr.fill_value, 0)
 
         arr = SparseArray(data=[1, 2], sparse_index=IntIndex(4, [1, 2]),
                           fill_value=0, dtype=None)
@@ -576,42 +578,61 @@ class TestSparseArray(tm.TestCase):
     def test_fillna(self):
         s = SparseArray([1, np.nan, np.nan, 3, np.nan])
         res = s.fillna(-1)
-        exp = SparseArray([1, -1, -1, 3, -1], fill_value=-1)
+        exp = SparseArray([1, -1, -1, 3, -1], fill_value=-1, dtype=np.float64)
         tm.assert_sp_array_equal(res, exp)
 
         s = SparseArray([1, np.nan, np.nan, 3, np.nan], fill_value=0)
         res = s.fillna(-1)
-        exp = SparseArray([1, -1, -1, 3, -1], fill_value=0)
+        exp = SparseArray([1, -1, -1, 3, -1], fill_value=0, dtype=np.float64)
         tm.assert_sp_array_equal(res, exp)
 
         s = SparseArray([1, np.nan, 0, 3, 0])
         res = s.fillna(-1)
-        exp = SparseArray([1, -1, 0, 3, 0], fill_value=-1)
+        exp = SparseArray([1, -1, 0, 3, 0], fill_value=-1, dtype=np.float64)
         tm.assert_sp_array_equal(res, exp)
 
         s = SparseArray([1, np.nan, 0, 3, 0], fill_value=0)
         res = s.fillna(-1)
-        exp = SparseArray([1, -1, 0, 3, 0], fill_value=0)
+        exp = SparseArray([1, -1, 0, 3, 0], fill_value=0, dtype=np.float64)
         tm.assert_sp_array_equal(res, exp)
 
         s = SparseArray([np.nan, np.nan, np.nan, np.nan])
         res = s.fillna(-1)
-        exp = SparseArray([-1, -1, -1, -1], fill_value=-1)
+        exp = SparseArray([-1, -1, -1, -1], fill_value=-1, dtype=np.float64)
         tm.assert_sp_array_equal(res, exp)
 
         s = SparseArray([np.nan, np.nan, np.nan, np.nan], fill_value=0)
         res = s.fillna(-1)
-        exp = SparseArray([-1, -1, -1, -1], fill_value=0)
+        exp = SparseArray([-1, -1, -1, -1], fill_value=0, dtype=np.float64)
         tm.assert_sp_array_equal(res, exp)
 
-        s = SparseArray([0, 0, 0, 0])
+        # float dtype's fill_value is np.nan, replaced by -1
+        s = SparseArray([0., 0., 0., 0.])
         res = s.fillna(-1)
-        exp = SparseArray([0, 0, 0, 0], fill_value=-1)
+        exp = SparseArray([0., 0., 0., 0.], fill_value=-1)
         tm.assert_sp_array_equal(res, exp)
+
+        # int dtype shouldn't have missing. No changes.
+        s = SparseArray([0, 0, 0, 0])
+        self.assertEqual(s.dtype, np.int64)
+        self.assertEqual(s.fill_value, 0)
+        res = s.fillna(-1)
+        tm.assert_sp_array_equal(res, s)
 
         s = SparseArray([0, 0, 0, 0], fill_value=0)
+        self.assertEqual(s.dtype, np.int64)
+        self.assertEqual(s.fill_value, 0)
         res = s.fillna(-1)
         exp = SparseArray([0, 0, 0, 0], fill_value=0)
+        tm.assert_sp_array_equal(res, exp)
+
+        # fill_value can be nan if there is no missing hole.
+        # only fill_value will be changed
+        s = SparseArray([0, 0, 0, 0], fill_value=np.nan)
+        self.assertEqual(s.dtype, np.int64)
+        self.assertTrue(np.isnan(s.fill_value))
+        res = s.fillna(-1)
+        exp = SparseArray([0, 0, 0, 0], fill_value=-1)
         tm.assert_sp_array_equal(res, exp)
 
     def test_fillna_overlap(self):
@@ -624,7 +645,7 @@ class TestSparseArray(tm.TestCase):
 
         s = SparseArray([1, np.nan, np.nan, 3, np.nan], fill_value=0)
         res = s.fillna(3)
-        exp = SparseArray([1, 3, 3, 3, 3], fill_value=0)
+        exp = SparseArray([1, 3, 3, 3, 3], fill_value=0, dtype=np.float64)
         tm.assert_sp_array_equal(res, exp)
 
 

--- a/pandas/sparse/tests/test_frame.py
+++ b/pandas/sparse/tests/test_frame.py
@@ -25,10 +25,9 @@ class TestSparseDataFrame(tm.TestCase, SharedWithSparse):
     _multiprocess_can_split_ = True
 
     def setUp(self):
-
         self.data = {'A': [nan, nan, nan, 0, 1, 2, 3, 4, 5, 6],
                      'B': [0, 1, 2, nan, nan, nan, 3, 4, 5, 6],
-                     'C': np.arange(10),
+                     'C': np.arange(10, dtype=np.float64),
                      'D': [0, 1, 2, 3, 4, 5, nan, nan, nan, nan]}
 
         self.dates = bdate_range('1/1/2011', periods=10)
@@ -125,10 +124,12 @@ class TestSparseDataFrame(tm.TestCase, SharedWithSparse):
             default_fill_value=self.frame.default_fill_value,
             default_kind=self.frame.default_kind, copy=True)
         reindexed = self.frame.reindex(idx)
+
         tm.assert_sp_frame_equal(cons, reindexed, exact_indices=False)
 
         # assert level parameter breaks reindex
-        self.assertRaises(TypeError, self.frame.reindex, idx, level=0)
+        with tm.assertRaises(TypeError):
+            self.frame.reindex(idx, level=0)
 
         repr(self.frame)
 
@@ -569,18 +570,23 @@ class TestSparseDataFrame(tm.TestCase, SharedWithSparse):
                                self.frame.to_dense().apply(nanops.nansum))
 
     def test_apply_nonuq(self):
-        df_orig = DataFrame(
-            [[1, 2, 3], [4, 5, 6], [7, 8, 9]], index=['a', 'a', 'c'])
-        df = df_orig.to_sparse()
-        rs = df.apply(lambda s: s[0], axis=1)
-        xp = Series([1., 4., 7.], ['a', 'a', 'c'])
-        tm.assert_series_equal(rs, xp)
+        orig = DataFrame([[1, 2, 3], [4, 5, 6], [7, 8, 9]],
+                         index=['a', 'a', 'c'])
+        sparse = orig.to_sparse()
+        res = sparse.apply(lambda s: s[0], axis=1)
+        exp = orig.apply(lambda s: s[0], axis=1)
+        # dtype must be kept
+        self.assertEqual(res.dtype, np.int64)
+        # ToDo: apply must return subclassed dtype
+        self.assertIsInstance(res, pd.Series)
+        tm.assert_series_equal(res.to_dense(), exp)
 
         # df.T breaks
-        df = df_orig.T.to_sparse()
-        rs = df.apply(lambda s: s[0], axis=0)  # noqa
+        sparse = orig.T.to_sparse()
+        res = sparse.apply(lambda s: s[0], axis=0)  # noqa
+        exp = orig.T.apply(lambda s: s[0], axis=0)
         # TODO: no non-unique columns supported in sparse yet
-        # assert_series_equal(rs, xp)
+        # tm.assert_series_equal(res.to_dense(), exp)
 
     def test_applymap(self):
         # just test that it works
@@ -596,8 +602,10 @@ class TestSparseDataFrame(tm.TestCase, SharedWithSparse):
         self.assertEqual(sparse['B'].dtype, np.int64)
 
         res = sparse.astype(np.float64)
-        exp = pd.SparseDataFrame({'A': SparseArray([1., 2., 3., 4.]),
-                                  'B': SparseArray([4., 5., 6., 7.])},
+        exp = pd.SparseDataFrame({'A': SparseArray([1., 2., 3., 4.],
+                                                   fill_value=0.),
+                                  'B': SparseArray([4., 5., 6., 7.],
+                                                   fill_value=0.)},
                                  default_fill_value=np.nan)
         tm.assert_sp_frame_equal(res, exp)
         self.assertEqual(res['A'].dtype, np.float64)
@@ -612,8 +620,10 @@ class TestSparseDataFrame(tm.TestCase, SharedWithSparse):
         self.assertEqual(sparse['B'].dtype, np.int64)
 
         res = sparse.astype(np.float64)
-        exp = pd.SparseDataFrame({'A': SparseArray([0., 2., 0., 4.]),
-                                  'B': SparseArray([0., 5., 0., 7.])},
+        exp = pd.SparseDataFrame({'A': SparseArray([0., 2., 0., 4.],
+                                                   fill_value=0.),
+                                  'B': SparseArray([0., 5., 0., 7.],
+                                                   fill_value=0.)},
                                  default_fill_value=0.)
         tm.assert_sp_frame_equal(res, exp)
         self.assertEqual(res['A'].dtype, np.float64)
@@ -813,6 +823,10 @@ class TestSparseDataFrame(tm.TestCase, SharedWithSparse):
             untransposed = transposed.T
             tm.assert_sp_frame_equal(frame, untransposed)
 
+            tm.assert_frame_equal(frame.T.to_dense(), orig.T)
+            tm.assert_frame_equal(frame.T.T.to_dense(), orig.T.T)
+            tm.assert_sp_frame_equal(frame, frame.T.T, exact_indices=False)
+
         self._check_all(_check)
 
     def test_shift(self):
@@ -821,8 +835,8 @@ class TestSparseDataFrame(tm.TestCase, SharedWithSparse):
 
             shifted = frame.shift(0)
             exp = orig.shift(0)
-            # int is coerced to float dtype
-            tm.assert_frame_equal(shifted.to_dense(), exp, check_dtype=False)
+            tm.assert_frame_equal(shifted.to_dense(), exp)
+
             shifted = frame.shift(1)
             exp = orig.shift(1)
             tm.assert_frame_equal(shifted, exp)
@@ -932,12 +946,85 @@ class TestSparseDataFrame(tm.TestCase, SharedWithSparse):
         nan_colname_sparse = nan_colname.to_sparse()
         self.assertTrue(np.isnan(nan_colname_sparse.columns[0]))
 
+    def test_isnull(self):
+        # GH 8276
+        df = pd.SparseDataFrame({'A': [np.nan, np.nan, 1, 2, np.nan],
+                                 'B': [0, np.nan, np.nan, 2, np.nan]})
+
+        res = df.isnull()
+        exp = pd.SparseDataFrame({'A': [True, True, False, False, True],
+                                  'B': [False, True, True, False, True]},
+                                 default_fill_value=True)
+        exp._default_fill_value = np.nan
+        tm.assert_sp_frame_equal(res, exp)
+
+        # if fill_value is not nan, True can be included in sp_values
+        df = pd.SparseDataFrame({'A': [0, 0, 1, 2, np.nan],
+                                 'B': [0, np.nan, 0, 2, np.nan]},
+                                default_fill_value=0.)
+        res = df.isnull()
+        tm.assertIsInstance(res, pd.SparseDataFrame)
+        exp = pd.DataFrame({'A': [False, False, False, False, True],
+                            'B': [False, True, False, False, True]})
+        tm.assert_frame_equal(res.to_dense(), exp)
+
+    def test_isnotnull(self):
+        # GH 8276
+        df = pd.SparseDataFrame({'A': [np.nan, np.nan, 1, 2, np.nan],
+                                 'B': [0, np.nan, np.nan, 2, np.nan]})
+
+        res = df.isnotnull()
+        exp = pd.SparseDataFrame({'A': [False, False, True, True, False],
+                                  'B': [True, False, False, True, False]},
+                                 default_fill_value=False)
+        exp._default_fill_value = np.nan
+        tm.assert_sp_frame_equal(res, exp)
+
+        # if fill_value is not nan, True can be included in sp_values
+        df = pd.SparseDataFrame({'A': [0, 0, 1, 2, np.nan],
+                                 'B': [0, np.nan, 0, 2, np.nan]},
+                                default_fill_value=0.)
+        res = df.isnotnull()
+        tm.assertIsInstance(res, pd.SparseDataFrame)
+        exp = pd.DataFrame({'A': [True, True, True, True, False],
+                            'B': [True, False, True, True, False]})
+        tm.assert_frame_equal(res.to_dense(), exp)
+
+
+class TestSparseDataFrameArithmetic(tm.TestCase):
+
+    def test_numeric_op_scalar(self):
+        df = pd.DataFrame({'A': [nan, nan, 0, 1, ],
+                           'B': [0, 1, 2, nan],
+                           'C': [1., 2., 3., 4.],
+                           'D': [nan, nan, nan, nan]})
+        sparse = df.to_sparse()
+
+        tm.assert_sp_frame_equal(sparse + 1, (df + 1).to_sparse())
+
+    def test_comparison_op_scalar(self):
+        # GH 13001
+        df = pd.DataFrame({'A': [nan, nan, 0, 1, ],
+                           'B': [0, 1, 2, nan],
+                           'C': [1., 2., 3., 4.],
+                           'D': [nan, nan, nan, nan]})
+        sparse = df.to_sparse()
+
+        # comparison changes internal repr, compare with dense
+        res = sparse > 1
+        tm.assertIsInstance(res, pd.SparseDataFrame)
+        tm.assert_frame_equal(res.to_dense(), df > 1)
+
+        res = sparse != 0
+        tm.assertIsInstance(res, pd.SparseDataFrame)
+        tm.assert_frame_equal(res.to_dense(), df != 0)
+
 
 class TestSparseDataFrameAnalytics(tm.TestCase):
     def setUp(self):
         self.data = {'A': [nan, nan, nan, 0, 1, 2, 3, 4, 5, 6],
                      'B': [0, 1, 2, nan, nan, nan, 3, 4, 5, 6],
-                     'C': np.arange(10),
+                     'C': np.arange(10, dtype=float),
                      'D': [0, 1, 2, 3, 4, 5, nan, nan, nan, nan]}
 
         self.dates = bdate_range('1/1/2011', periods=10)

--- a/pandas/sparse/tests/test_indexing.py
+++ b/pandas/sparse/tests/test_indexing.py
@@ -49,6 +49,21 @@ class TestSparseSeriesIndexing(tm.TestCase):
         tm.assert_sp_series_equal(sparse[::2], orig[::2].to_sparse())
         tm.assert_sp_series_equal(sparse[-5:], orig[-5:].to_sparse())
 
+    def test_getitem_int_dtype(self):
+        # GH 8292
+        s = pd.SparseSeries([0, 1, 2, 3, 4, 5, 6], name='xxx')
+        res = s[::2]
+        exp = pd.SparseSeries([0, 2, 4, 6], index=[0, 2, 4, 6], name='xxx')
+        tm.assert_sp_series_equal(res, exp)
+        self.assertEqual(res.dtype, np.int64)
+
+        s = pd.SparseSeries([0, 1, 2, 3, 4, 5, 6], fill_value=0, name='xxx')
+        res = s[::2]
+        exp = pd.SparseSeries([0, 2, 4, 6], index=[0, 2, 4, 6],
+                              fill_value=0, name='xxx')
+        tm.assert_sp_series_equal(res, exp)
+        self.assertEqual(res.dtype, np.int64)
+
     def test_getitem_fill_value(self):
         orig = pd.Series([1, np.nan, 0, 3, 0])
         sparse = orig.to_sparse(fill_value=0)

--- a/pandas/sparse/tests/test_libsparse.py
+++ b/pandas/sparse/tests/test_libsparse.py
@@ -243,6 +243,61 @@ class TestSparseIndexCommon(tm.TestCase):
 
     _multiprocess_can_split_ = True
 
+    def test_int_internal(self):
+        idx = _make_index(4, np.array([2, 3], dtype=np.int32), kind='integer')
+        self.assertIsInstance(idx, IntIndex)
+        self.assertEqual(idx.npoints, 2)
+        tm.assert_numpy_array_equal(idx.indices,
+                                    np.array([2, 3], dtype=np.int32))
+
+        idx = _make_index(4, np.array([], dtype=np.int32), kind='integer')
+        self.assertIsInstance(idx, IntIndex)
+        self.assertEqual(idx.npoints, 0)
+        tm.assert_numpy_array_equal(idx.indices,
+                                    np.array([], dtype=np.int32))
+
+        idx = _make_index(4, np.array([0, 1, 2, 3], dtype=np.int32),
+                          kind='integer')
+        self.assertIsInstance(idx, IntIndex)
+        self.assertEqual(idx.npoints, 4)
+        tm.assert_numpy_array_equal(idx.indices,
+                                    np.array([0, 1, 2, 3], dtype=np.int32))
+
+    def test_block_internal(self):
+        idx = _make_index(4, np.array([2, 3], dtype=np.int32), kind='block')
+        self.assertIsInstance(idx, BlockIndex)
+        self.assertEqual(idx.npoints, 2)
+        tm.assert_numpy_array_equal(idx.blocs,
+                                    np.array([2], dtype=np.int32))
+        tm.assert_numpy_array_equal(idx.blengths,
+                                    np.array([2], dtype=np.int32))
+
+        idx = _make_index(4, np.array([], dtype=np.int32), kind='block')
+        self.assertIsInstance(idx, BlockIndex)
+        self.assertEqual(idx.npoints, 0)
+        tm.assert_numpy_array_equal(idx.blocs,
+                                    np.array([], dtype=np.int32))
+        tm.assert_numpy_array_equal(idx.blengths,
+                                    np.array([], dtype=np.int32))
+
+        idx = _make_index(4, np.array([0, 1, 2, 3], dtype=np.int32),
+                          kind='block')
+        self.assertIsInstance(idx, BlockIndex)
+        self.assertEqual(idx.npoints, 4)
+        tm.assert_numpy_array_equal(idx.blocs,
+                                    np.array([0], dtype=np.int32))
+        tm.assert_numpy_array_equal(idx.blengths,
+                                    np.array([4], dtype=np.int32))
+
+        idx = _make_index(4, np.array([0, 2, 3], dtype=np.int32),
+                          kind='block')
+        self.assertIsInstance(idx, BlockIndex)
+        self.assertEqual(idx.npoints, 3)
+        tm.assert_numpy_array_equal(idx.blocs,
+                                    np.array([0, 2], dtype=np.int32))
+        tm.assert_numpy_array_equal(idx.blengths,
+                                    np.array([1, 2], dtype=np.int32))
+
     def test_lookup(self):
         for kind in ['integer', 'block']:
             idx = _make_index(4, np.array([2, 3], dtype=np.int32), kind=kind)

--- a/pandas/tests/series/test_subclass.py
+++ b/pandas/tests/series/test_subclass.py
@@ -40,16 +40,33 @@ class TestSparseSeriesSubclassing(tm.TestCase):
     _multiprocess_can_split_ = True
 
     def test_subclass_sparse_slice(self):
+        # int64
         s = tm.SubclassedSparseSeries([1, 2, 3, 4, 5])
-        tm.assert_sp_series_equal(s.loc[1:3],
-                                  tm.SubclassedSparseSeries([2.0, 3.0, 4.0],
-                                                            index=[1, 2, 3]))
-        tm.assert_sp_series_equal(s.iloc[1:3],
-                                  tm.SubclassedSparseSeries([2.0, 3.0],
-                                                            index=[1, 2]))
-        tm.assert_sp_series_equal(s[1:3],
-                                  tm.SubclassedSparseSeries([2.0, 3.0],
-                                                            index=[1, 2]))
+        exp = tm.SubclassedSparseSeries([2, 3, 4], index=[1, 2, 3])
+        tm.assert_sp_series_equal(s.loc[1:3], exp)
+        self.assertEqual(s.loc[1:3].dtype, np.int64)
+
+        exp = tm.SubclassedSparseSeries([2, 3], index=[1, 2])
+        tm.assert_sp_series_equal(s.iloc[1:3], exp)
+        self.assertEqual(s.iloc[1:3].dtype, np.int64)
+
+        exp = tm.SubclassedSparseSeries([2, 3], index=[1, 2])
+        tm.assert_sp_series_equal(s[1:3], exp)
+        self.assertEqual(s[1:3].dtype, np.int64)
+
+        # float64
+        s = tm.SubclassedSparseSeries([1., 2., 3., 4., 5.])
+        exp = tm.SubclassedSparseSeries([2., 3., 4.], index=[1, 2, 3])
+        tm.assert_sp_series_equal(s.loc[1:3], exp)
+        self.assertEqual(s.loc[1:3].dtype, np.float64)
+
+        exp = tm.SubclassedSparseSeries([2., 3.], index=[1, 2])
+        tm.assert_sp_series_equal(s.iloc[1:3], exp)
+        self.assertEqual(s.iloc[1:3].dtype, np.float64)
+
+        exp = tm.SubclassedSparseSeries([2., 3.], index=[1, 2])
+        tm.assert_sp_series_equal(s[1:3], exp)
+        self.assertEqual(s[1:3].dtype, np.float64)
 
     def test_subclass_sparse_addition(self):
         s1 = tm.SubclassedSparseSeries([1, 3, 5])
@@ -66,9 +83,17 @@ class TestSparseSeriesSubclassing(tm.TestCase):
         s = tm.SubclassedSparseSeries([1, 2], index=list('abcd'), name='xxx')
         res = s.to_frame()
 
-        exp_arr = pd.SparseArray([1, 2], dtype=np.int64, kind='block')
+        exp_arr = pd.SparseArray([1, 2], dtype=np.int64, kind='block',
+                                 fill_value=0)
         exp = tm.SubclassedSparseDataFrame({'xxx': exp_arr},
-                                           index=list('abcd'))
+                                           index=list('abcd'),
+                                           default_fill_value=0)
+        tm.assert_sp_frame_equal(res, exp)
+
+        # create from int dict
+        res = tm.SubclassedSparseDataFrame({'xxx': [1, 2]},
+                                           index=list('abcd'),
+                                           default_fill_value=0)
         tm.assert_sp_frame_equal(res, exp)
 
         s = tm.SubclassedSparseSeries([1.1, 2.1], index=list('abcd'),

--- a/pandas/util/testing.py
+++ b/pandas/util/testing.py
@@ -1404,9 +1404,8 @@ def assert_sp_array_equal(left, right):
     assert_numpy_array_equal(left.values, right.values)
 
 
-def assert_sp_series_equal(left, right, exact_indices=True,
-                           check_series_type=True,
-                           check_names=True,
+def assert_sp_series_equal(left, right, check_dtype=True, exact_indices=True,
+                           check_series_type=True, check_names=True,
                            obj='SparseSeries'):
     """Check that the left and right SparseSeries are equal.
 
@@ -1414,6 +1413,8 @@ def assert_sp_series_equal(left, right, exact_indices=True,
     ----------
     left : SparseSeries
     right : SparseSeries
+    check_dtype : bool, default True
+        Whether to check the Series dtype is identical.
     exact_indices : bool, default True
     check_series_type : bool, default True
         Whether to check the SparseSeries class is identical.
@@ -1436,20 +1437,22 @@ def assert_sp_series_equal(left, right, exact_indices=True,
 
     if check_names:
         assert_attr_equal('name', left, right)
-    assert_attr_equal('dtype', left, right)
+    if check_dtype:
+        assert_attr_equal('dtype', left, right)
 
     assert_numpy_array_equal(left.values, right.values)
 
 
-def assert_sp_frame_equal(left, right, exact_indices=True,
-                          check_frame_type=True,
-                          obj='SparseDataFrame'):
+def assert_sp_frame_equal(left, right, check_dtype=True, exact_indices=True,
+                          check_frame_type=True, obj='SparseDataFrame'):
     """Check that the left and right SparseDataFrame are equal.
 
     Parameters
     ----------
     left : SparseDataFrame
     right : SparseDataFrame
+    check_dtype : bool, default True
+        Whether to check the Series dtype is identical.
     exact_indices : bool, default True
         SparseSeries SparseIndex objects must be exactly the same,
         otherwise just compare dense representations.
@@ -1475,9 +1478,11 @@ def assert_sp_frame_equal(left, right, exact_indices=True,
         # trade-off?
 
         if exact_indices:
-            assert_sp_series_equal(series, right[col])
+            assert_sp_series_equal(series, right[col],
+                                   check_dtype=check_dtype)
         else:
-            assert_series_equal(series.to_dense(), right[col].to_dense())
+            assert_series_equal(series.to_dense(), right[col].to_dense(),
+                                check_dtype=check_dtype)
 
     assert_attr_equal('default_fill_value', left, right, obj=obj)
 


### PR DESCRIPTION
- [x] closes #667, closes #8292, closes #13001, closes #8276, closes #13110
  - [x] tests added / passed
  - [x] passes `git diff upstream/master | flake8 --diff`
  - [x] whatsnew entry

Currently, sparse doesn't support `int64` and `bool` dtypes actually. When `int` or `bool` values are passed, it is coerced to `float64` if `dtype`kw  is not explicitly specified. 

**on current master**

```
pd.SparseArray([1, 2, 0, 0 ])
# [1.0, 2.0, 0.0, 0.0]
# Fill: nan
# IntIndex
# Indices: array([0, 1, 2, 3], dtype=int32)

pd.SparseArray([True, False, True])
# [1.0, 0.0, 1.0]
# Fill: nan
# IntIndex
# Indices: array([0, 1, 2], dtype=int32)
```

**after this PR**

The created data should have the `dtype` of passed values (as the same as normal `Series`). 

```
pd.SparseArray([1, 2, 0, 0 ])
# [1, 2, 0, 0]
# Fill: 0
# IntIndex
# Indices: array([0, 1], dtype=int32)

pd.SparseArray([True, False, True])
# [True, False, True]
# Fill: False
# IntIndex
# Indices: array([0, 2], dtype=int32)
```

Also, `fill_value` is automatically specified according to the following rules (because `np.nan` cannot appear in `int` or `bool` dtype):

Basic rule: sparse `dtype` must not be changed when it is converted to dense. 
- If `sparse_index` is specified and data has a hole (missing values):
  - `fill_value` is np.nan
  - `dtype` is `float64` or `object` (which can store both `data` and `fill_value`)
- If `sparse_index` is None (all values are provided via `data`, no missing values)
  - if `fill_value` is not explicitly passed, following default will be used depending on its dtype.
    - `float`: `np.nan`
    - `int`: `0`
    - `bool`: `False`
