### PR TITLE
BUG: ufunc is not applied to sparse.fill_value

### DIFF
--- a/doc/source/sparse.rst
+++ b/doc/source/sparse.rst
@@ -130,6 +130,28 @@ keeps an arrays of all of the locations where the data are not equal to the
 fill value. The ``block`` format tracks only the locations and sizes of blocks
 of data.
 
+.. _sparse.calculation:
+
+Sparse Calculation
+------------------
+
+You can apply NumPy ufuncs to ``SparseArray`` and get ``SparseArray`` result.
+
+.. ipython:: python
+
+   arr = pd.SparseArray([1., np.nan, np.nan, -2., np.nan])
+   np.abs(arr)
+
+
+Note that ufunc is also applied to ``fill_value``. This is needed to get
+the correct dense result.
+
+.. ipython:: python
+
+   arr = pd.SparseArray([1., -1, -1, -2., -1], fill_value=-1)
+   np.abs(arr)
+   np.abs(arr).to_dense()
+
 .. _sparse.scipysparse:
 
 Interaction with scipy.sparse

--- a/doc/source/whatsnew/v0.19.0.txt
+++ b/doc/source/whatsnew/v0.19.0.txt
@@ -759,6 +759,8 @@ Bug Fixes
 - Bug in ``SparseDataFrame`` in which ``axis=None`` did not default to ``axis=0`` (:issue:`13048`)
 - Bug in ``SparseSeries`` and ``SparseDataFrame`` creation with ``object`` dtype may raise ``TypeError`` (:issue:`11633`)
 - Bug in ``SparseDataFrame`` doesn't respect passed ``SparseArray`` or ``SparseSeries`` 's dtype and ``fill_value``  (:issue:`13866`)
+- Bug in ``SparseArray`` and ``SparseSeries`` don't apply ufunc to ``fill_value`` (:issue:`13853`)
+- Bug in ``SparseSeries.abs`` incorrectly keeps negative ``fill_value`` (:issue:`13853`)
 - Bug when passing a not-default-indexed ``Series`` as ``xerr`` or ``yerr`` in ``.plot()`` (:issue:`11858`)
 - Bug in matplotlib ``AutoDataFormatter``; this restores the second scaled formatting and re-adds micro-second scaled formatting (:issue:`13131`)
 - Bug in selection from a ``HDFStore`` with a fixed format and ``start`` and/or ``stop`` specified will now return the selected range (:issue:`8287`)

--- a/pandas/sparse/frame.py
+++ b/pandas/sparse/frame.py
@@ -706,7 +706,7 @@ class SparseDataFrame(DataFrame):
             new_series = {}
             for k, v in compat.iteritems(self):
                 applied = func(v)
-                applied.fill_value = func(applied.fill_value)
+                applied.fill_value = func(v.fill_value)
                 new_series[k] = applied
             return self._constructor(
                 new_series, index=self.index, columns=self.columns,

--- a/pandas/sparse/tests/test_array.py
+++ b/pandas/sparse/tests/test_array.py
@@ -829,6 +829,52 @@ class TestSparseArrayAnalytics(tm.TestCase):
         tm.assertRaisesRegexp(ValueError, msg, np.mean,
                               SparseArray(data), out=out)
 
+    def test_ufunc(self):
+        # GH 13853 make sure ufunc is applied to fill_value
+        sparse = SparseArray([1, np.nan, 2, np.nan, -2])
+        result = SparseArray([1, np.nan, 2, np.nan, 2])
+        tm.assert_sp_array_equal(abs(sparse), result)
+        tm.assert_sp_array_equal(np.abs(sparse), result)
+
+        sparse = SparseArray([1, -1, 2, -2], fill_value=1)
+        result = SparseArray([1, 2, 2], sparse_index=sparse.sp_index,
+                             fill_value=1)
+        tm.assert_sp_array_equal(abs(sparse), result)
+        tm.assert_sp_array_equal(np.abs(sparse), result)
+
+        sparse = SparseArray([1, -1, 2, -2], fill_value=-1)
+        result = SparseArray([1, 2, 2], sparse_index=sparse.sp_index,
+                             fill_value=1)
+        tm.assert_sp_array_equal(abs(sparse), result)
+        tm.assert_sp_array_equal(np.abs(sparse), result)
+
+        sparse = SparseArray([1, np.nan, 2, np.nan, -2])
+        result = SparseArray(np.sin([1, np.nan, 2, np.nan, -2]))
+        tm.assert_sp_array_equal(np.sin(sparse), result)
+
+        sparse = SparseArray([1, -1, 2, -2], fill_value=1)
+        result = SparseArray(np.sin([1, -1, 2, -2]), fill_value=np.sin(1))
+        tm.assert_sp_array_equal(np.sin(sparse), result)
+
+        sparse = SparseArray([1, -1, 0, -2], fill_value=0)
+        result = SparseArray(np.sin([1, -1, 0, -2]), fill_value=np.sin(0))
+        tm.assert_sp_array_equal(np.sin(sparse), result)
+
+    def test_ufunc_args(self):
+        # GH 13853 make sure ufunc is applied to fill_value, including its arg
+        sparse = SparseArray([1, np.nan, 2, np.nan, -2])
+        result = SparseArray([2, np.nan, 3, np.nan, -1])
+        tm.assert_sp_array_equal(np.add(sparse, 1), result)
+
+        sparse = SparseArray([1, -1, 2, -2], fill_value=1)
+        result = SparseArray([2, 0, 3, -1], fill_value=2)
+        tm.assert_sp_array_equal(np.add(sparse, 1), result)
+
+        sparse = SparseArray([1, -1, 0, -2], fill_value=0)
+        result = SparseArray([2, 0, 1, -1], fill_value=1)
+        tm.assert_sp_array_equal(np.add(sparse, 1), result)
+
+
 if __name__ == '__main__':
     import nose
     nose.runmodule(argv=[__file__, '-vvs', '-x', '--pdb', '--pdb-failure'],

--- a/pandas/sparse/tests/test_series.py
+++ b/pandas/sparse/tests/test_series.py
@@ -589,6 +589,21 @@ class TestSparseSeries(tm.TestCase, SharedWithSparse):
         tm.assert_sp_series_equal(result, expected)
         self.assertEqual(result.name, 'x')
 
+        s = SparseSeries([1, -2, 2, -3], fill_value=-2, name='x')
+        expected = SparseSeries([1, 2, 3], sparse_index=s.sp_index,
+                                fill_value=2, name='x')
+        result = s.abs()
+        tm.assert_sp_series_equal(result, expected)
+        self.assertEqual(result.name, 'x')
+
+        result = abs(s)
+        tm.assert_sp_series_equal(result, expected)
+        self.assertEqual(result.name, 'x')
+
+        result = np.abs(s)
+        tm.assert_sp_series_equal(result, expected)
+        self.assertEqual(result.name, 'x')
+
     def test_reindex(self):
         def _compare_with_series(sps, new_index):
             spsre = sps.reindex(new_index)
@@ -1287,6 +1302,7 @@ class TestSparseSeriesAnalytics(tm.TestCase):
         for func in funcs:
             for series in ('bseries', 'zbseries'):
                 getattr(np, func)(getattr(self, series))
+
 
 if __name__ == '__main__':
     import nose


### PR DESCRIPTION
- [x] tests added / passed
- [x] passes `git diff upstream/master | flake8 --diff`
- [x] whatsnew entry

When ufunc is applied to sparse, it is not applied to `fill_value`. Thus results are incorrect.

**on current master:**

```
np.abs(pd.SparseArray([1, -2, -1], fill_value=-2))
# [1.0, -2, 1.0]
# Fill: -2
# IntIndex
# Indices: array([0, 2], dtype=int32)

np.add(pd.SparseArray([1, -2, -1], fill_value=-2), 1)
# [2.0, -2, 0.0]
# Fill: -2
# IntIndex
# Indices: array([0, 2], dtype=int32)
```

cc @gfyoung 
