### PR TITLE
BUG: disallow 'w' mode in pd.read_hdf (#13623)

### DIFF
--- a/doc/source/whatsnew/v0.19.0.txt
+++ b/doc/source/whatsnew/v0.19.0.txt
@@ -379,6 +379,7 @@ API changes
 - The ``pd.read_json`` and ``DataFrame.to_json`` has gained support for reading and writing json lines with ``lines`` option see :ref:`Line delimited json <io.jsonl>` (:issue:`9180`)
 - ``pd.Timedelta(None)`` is now accepted and will return ``NaT``, mirroring ``pd.Timestamp`` (:issue:`13687`)
 - ``Timestamp``, ``Period``, ``DatetimeIndex``, ``PeriodIndex`` and ``.dt`` accessor have gained a ``.is_leap_year`` property to check whether the date belongs to a leap year. (:issue:`13727`)
+- ``pd.read_hdf`` will now raise a ``ValueError`` instead of ``KeyError``, if a mode other than ``r``, ``r+`` and ``a`` is supplied. (:issue:`13623`)
 
 
 .. _whatsnew_0190.api.tolist:

--- a/pandas/io/pytables.py
+++ b/pandas/io/pytables.py
@@ -303,6 +303,10 @@ def read_hdf(path_or_buf, key=None, **kwargs):
 
         """
 
+    if kwargs.get('mode', 'a') not in ['r', 'r+', 'a']:
+        raise ValueError('mode {0} is not allowed while performing a read. '
+                         'Allowed modes are r, r+ and a.'
+                         .format(kwargs.get('mode')))
     # grab the scope
     if 'where' in kwargs:
         kwargs['where'] = _ensure_term(kwargs['where'], scope_level=1)

--- a/pandas/io/tests/test_pytables.py
+++ b/pandas/io/tests/test_pytables.py
@@ -531,16 +531,25 @@ class TestHDFStore(Base, tm.TestCase):
 
                 # conv read
                 if mode in ['w']:
-                    self.assertRaises(KeyError, read_hdf,
+                    self.assertRaises(ValueError, read_hdf,
                                       path, 'df', mode=mode)
                 else:
                     result = read_hdf(path, 'df', mode=mode)
                     assert_frame_equal(result, df)
 
+        def check_default_mode():
+
+            # read_hdf uses default mode
+            with ensure_clean_path(self.path) as path:
+                df.to_hdf(path, 'df', mode='w')
+                result = read_hdf(path, 'df')
+                assert_frame_equal(result, df)
+
         check('r')
         check('r+')
         check('a')
         check('w')
+        check_default_mode()
 
     def test_reopen_handle(self):
 


### PR DESCRIPTION
- [x] closes #13623 
- [x] tests added / passed
- [x] passes `git diff upstream/master | flake8 --diff`
- [x] whatsnew entry
  
  Passing mode='w' to read_hdf raises ValueError.
