### PR TITLE
TST: use types.api in plotting

### DIFF
--- a/pandas/tests/plotting/common.py
+++ b/pandas/tests/plotting/common.py
@@ -8,7 +8,7 @@ import warnings
 from pandas import DataFrame
 from pandas.compat import zip, iteritems, OrderedDict
 from pandas.util.decorators import cache_readonly
-import pandas.core.common as com
+from pandas.types.api import is_list_like
 import pandas.util.testing as tm
 from pandas.util.testing import (ensure_clean,
                                  assert_is_valid_plot_return_object)
@@ -157,7 +157,7 @@ class TestPlotBase(tm.TestCase):
         """
         from matplotlib.collections import Collection
         if not isinstance(collections,
-                          Collection) and not com.is_list_like(collections):
+                          Collection) and not is_list_like(collections):
             collections = [collections]
 
         for patch in collections:
@@ -242,7 +242,7 @@ class TestPlotBase(tm.TestCase):
         expected : str or list-like which has the same length as texts
             expected text label, or its list
         """
-        if not com.is_list_like(texts):
+        if not is_list_like(texts):
             self.assertEqual(texts.get_text(), expected)
         else:
             labels = [t.get_text() for t in texts]

--- a/pandas/tests/plotting/test_frame.py
+++ b/pandas/tests/plotting/test_frame.py
@@ -1152,7 +1152,8 @@ class TestDataFramePlots(TestPlotBase):
 
         # different warning on py3
         if not PY3:
-            axes = _check_plot_works(df.plot.box, subplots=True, logy=True)
+            with tm.assert_produces_warning(UserWarning):
+                axes = _check_plot_works(df.plot.box, subplots=True, logy=True)
 
             self._check_axes_shape(axes, axes_num=3, layout=(1, 3))
             self._check_ax_scales(axes, yaxis='log')


### PR DESCRIPTION
- [x] tests added / passed
- [x] passes `git diff upstream/master | flake8 --diff`

remove warning related to #13147 and #13621 
