### PR TITLE
BUG: Fix Period and PeriodIndex support of combined offsets aliases

### DIFF
--- a/doc/source/whatsnew/v0.19.0.txt
+++ b/doc/source/whatsnew/v0.19.0.txt
@@ -783,6 +783,8 @@ Deprecations
 - ``pd.tseries.util.pivot_annual`` is deprecated. Use ``pivot_table`` as alternative, an example is :ref:`here <cookbook.pivot>` (:issue:`736`)
 - ``pd.tseries.util.isleapyear`` has been deprecated and will be removed in a subsequent release. Datetime-likes now have a ``.is_leap_year`` property. (:issue:`13727`)
 - ``Panel4D`` and ``PanelND`` constructors are deprecated and will be removed in a future version. The recommended way to represent these types of n-dimensional data are with the `xarray package <http://xarray.pydata.org/en/stable/>`__. Pandas provides a :meth:`~Panel4D.to_xarray` method to automate this conversion. (:issue:`13564`)
+- ``pandas.tseries.frequencies.get_standard_freq`` is deprecated. Use  ``pandas.tseries.frequencies.to_offset(freq).rule_code`` instead. (:issue:`13874`)
+- ``pandas.tseries.frequencies.to_offset``'s ``freqstr`` keyword is deprecated in favor of ``freq``. (:issue:`13874`)
 
 .. _whatsnew_0190.prior_deprecations:
 
@@ -968,3 +970,4 @@ Bug Fixes
 - Bug in ``pd.read_csv`` in Python 2.x with non-UTF8 encoded, multi-character separated data (:issue:`3404`)
 
 - Bug in ``Index`` raises ``KeyError`` displaying incorrect column when column is not in the df and columns contains duplicate values (:issue:`13822`)
+- Bug in ``Period`` and ``PeriodIndex`` creating wrong dates when frequency has combined offset aliases (:issue:`13874`)

--- a/pandas/src/period.pyx
+++ b/pandas/src/period.pyx
@@ -739,7 +739,7 @@ cdef class _Period(object):
             msg = 'Input cannot be converted to Period(freq={0})'
             raise IncompatibleFrequency(msg.format(self.freqstr))
         elif isinstance(other, offsets.DateOffset):
-            freqstr = frequencies.get_standard_freq(other)
+            freqstr = other.rule_code
             base = frequencies.get_base_alias(freqstr)
             if base == self.freq.rule_code:
                 ordinal = self.ordinal + other.n
@@ -806,6 +806,7 @@ cdef class _Period(object):
         -------
         resampled : Period
         """
+        freq = self._maybe_convert_freq(freq)
         how = _validate_end_alias(how)
         base1, mult1 = frequencies.get_freq_code(self.freq)
         base2, mult2 = frequencies.get_freq_code(freq)
@@ -849,6 +850,8 @@ cdef class _Period(object):
         -------
         Timestamp
         """
+        if freq is not None:
+            freq = self._maybe_convert_freq(freq)
         how = _validate_end_alias(how)
 
         if freq is None:
@@ -1121,6 +1124,9 @@ class Period(_Period):
         # ordinal is the period offset from the gregorian proleptic epoch
 
         cdef _Period self
+
+        if freq is not None:
+            freq = cls._maybe_convert_freq(freq)
 
         if ordinal is not None and value is not None:
             raise ValueError(("Only value or ordinal but not both should be "

--- a/pandas/tseries/tests/test_offsets.py
+++ b/pandas/tseries/tests/test_offsets.py
@@ -4591,21 +4591,30 @@ class TestParseTimeString(tm.TestCase):
 
 
 def test_get_standard_freq():
-    fstr = get_standard_freq('W')
-    assert fstr == get_standard_freq('w')
-    assert fstr == get_standard_freq('1w')
-    assert fstr == get_standard_freq(('W', 1))
+    with tm.assert_produces_warning(FutureWarning, check_stacklevel=False):
+        fstr = get_standard_freq('W')
+    with tm.assert_produces_warning(FutureWarning, check_stacklevel=False):
+        assert fstr == get_standard_freq('w')
+    with tm.assert_produces_warning(FutureWarning, check_stacklevel=False):
+        assert fstr == get_standard_freq('1w')
+    with tm.assert_produces_warning(FutureWarning, check_stacklevel=False):
+        assert fstr == get_standard_freq(('W', 1))
 
     with tm.assertRaisesRegexp(ValueError, _INVALID_FREQ_ERROR):
-        get_standard_freq('WeEk')
+        with tm.assert_produces_warning(FutureWarning, check_stacklevel=False):
+            get_standard_freq('WeEk')
 
-    fstr = get_standard_freq('5Q')
-    assert fstr == get_standard_freq('5q')
+    with tm.assert_produces_warning(FutureWarning, check_stacklevel=False):
+        fstr = get_standard_freq('5Q')
+    with tm.assert_produces_warning(FutureWarning, check_stacklevel=False):
+        assert fstr == get_standard_freq('5q')
 
     with tm.assertRaisesRegexp(ValueError, _INVALID_FREQ_ERROR):
-        get_standard_freq('5QuarTer')
+        with tm.assert_produces_warning(FutureWarning, check_stacklevel=False):
+            get_standard_freq('5QuarTer')
 
-    assert fstr == get_standard_freq(('q', 5))
+    with tm.assert_produces_warning(FutureWarning, check_stacklevel=False):
+        assert fstr == get_standard_freq(('q', 5))
 
 
 def test_quarterly_dont_normalize():

--- a/pandas/tseries/tests/test_timeseries.py
+++ b/pandas/tseries/tests/test_timeseries.py
@@ -4700,7 +4700,8 @@ class TestTimestamp(tm.TestCase):
 
         self.assertRaises(ValueError, frequencies.to_offset, ('', ''))
 
-        result = frequencies.get_standard_freq(offsets.Hour())
+        with tm.assert_produces_warning(FutureWarning, check_stacklevel=False):
+            result = frequencies.get_standard_freq(offsets.Hour())
         self.assertEqual(result, 'H')
 
     def test_hash_equivalent(self):


### PR DESCRIPTION
- [x] closes #13730
- [x] tests added / passed
- [x] passes `git diff upstream/master | flake8 --diff`
- [x] whatsnew entry

Essentially, makes sure any `freq` string passed to a `Period` or `PeriodIndex` goes through [`_Period._maybe_convert_freq()`](https://github.com/pydata/pandas/blob/master/pandas/src/period.pyx#L682-L697), which calls [`to_offset()`](https://github.com/pydata/pandas/blob/master/pandas/tseries/frequencies.py#L389-L451), which is where the logic for combining aliases is.

All the examples in #13730 result in the correct output, and all existing tests pass. I have not written any new ones yet &mdash; I first wanted to get the opinion of the maintainers.

This PR builds on #13868 (without it, some existing tests fail).
