### PR TITLE
BUG: Series creation with datetime64 with non-ns unit as object dtype

### DIFF
--- a/doc/source/whatsnew/v0.19.0.txt
+++ b/doc/source/whatsnew/v0.19.0.txt
@@ -842,6 +842,8 @@ Bug Fixes
 - Bug in ``RangeIndex`` can be created without no arguments rather than raises ``TypeError`` (:issue:`13793`)
 - Bug in ``.value_counts`` raises ``OutOfBoundsDatetime`` if data exceeds ``datetime64[ns]`` bounds (:issue:`13663`)
 - Bug in ``DatetimeIndex`` may raise ``OutOfBoundsDatetime`` if input ``np.datetime64`` has other unit than ``ns`` (:issue:`9114`)
+- Bug in ``Series`` creation with ``np.datetime64`` which has other unit than ``ns`` as ``object`` dtype results in incorrect values (:issue:`13876`)
+
 - Bug in ``isnull`` ``notnull`` raise ``TypeError`` if input datetime-like has other unit than ``ns`` (:issue:`13389`)
 - Bug in ``.merge`` may raise ``TypeError`` if input datetime-like has other unit than ``ns`` (:issue:`13389`)
 

--- a/pandas/tests/series/test_constructors.py
+++ b/pandas/tests/series/test_constructors.py
@@ -381,11 +381,19 @@ class TestSeriesConstructors(TestData, tm.TestCase):
         # coerce datetime64 non-ns properly
         dates = date_range('01-Jan-2015', '01-Dec-2015', freq='M')
         values2 = dates.view(np.ndarray).astype('datetime64[ns]')
-        expected = Series(values2, dates)
+        expected = Series(values2, index=dates)
 
         for dtype in ['s', 'D', 'ms', 'us', 'ns']:
             values1 = dates.view(np.ndarray).astype('M8[{0}]'.format(dtype))
             result = Series(values1, dates)
+            assert_series_equal(result, expected)
+
+        # GH 13876
+        # coerce to non-ns to object properly
+        expected = Series(values2, index=dates, dtype=object)
+        for dtype in ['s', 'D', 'ms', 'us', 'ns']:
+            values1 = dates.view(np.ndarray).astype('M8[{0}]'.format(dtype))
+            result = Series(values1, index=dates, dtype=object)
             assert_series_equal(result, expected)
 
         # leave datetime.date alone

--- a/pandas/tests/test_algos.py
+++ b/pandas/tests/test_algos.py
@@ -777,7 +777,6 @@ class TestDuplicated(tm.TestCase):
         exp_false = exp_first | exp_last
 
         for case in cases:
-            print(case)
             res_first = algos.duplicated(case, keep='first')
             tm.assert_numpy_array_equal(res_first, exp_first)
 
@@ -788,7 +787,8 @@ class TestDuplicated(tm.TestCase):
             tm.assert_numpy_array_equal(res_false, exp_false)
 
             # index
-            for idx in [pd.Index(case), pd.Index(case, dtype='category')]:
+            for idx in [pd.Index(case), pd.Index(case, dtype='category'),
+                        pd.Index(case, dtype=object)]:
                 res_first = idx.duplicated(keep='first')
                 tm.assert_numpy_array_equal(res_first, exp_first)
 
@@ -799,7 +799,8 @@ class TestDuplicated(tm.TestCase):
                 tm.assert_numpy_array_equal(res_false, exp_false)
 
             # series
-            for s in [pd.Series(case), pd.Series(case, dtype='category')]:
+            for s in [pd.Series(case), pd.Series(case, dtype='category'),
+                      pd.Series(case, dtype=object)]:
                 res_first = s.duplicated(keep='first')
                 tm.assert_series_equal(res_first, pd.Series(exp_first))
 

--- a/pandas/types/cast.py
+++ b/pandas/types/cast.py
@@ -829,6 +829,8 @@ def _possibly_cast_to_datetime(value, dtype, errors='raise'):
         # coerce datetimelike to object
         elif is_datetime64_dtype(value) and not is_datetime64_dtype(dtype):
             if is_object_dtype(dtype):
+                if value.dtype != _NS_DTYPE:
+                    value = value.astype(_NS_DTYPE)
                 ints = np.asarray(value).view('i8')
                 return tslib.ints_to_pydatetime(ints)
 


### PR DESCRIPTION
- [x] tests added / passed
- [x] passes `git diff upstream/master | flake8 --diff`
- [x] whatsnew entry

found a bug related to `datetime64` with non-ns unit.

```
# OK
pd.Series(np.array([np.datetime64('2011-01-01')]))
#0   2011-01-01
# dtype: datetime64[ns]

# OK
pd.Series([np.datetime64('2011-01-01')], dtype=object)
#0    2011-01-01
# dtype: object

# NG
pd.Series(np.array([np.datetime64('2011-01-01')]), dtype=object)
#0    1970-01-01 00:00:00.000014
# dtype: object

# OK
pd.Series(np.array([np.datetime64('2011-01-01', 'ns')]), dtype=object)
#0    2011-01-01 00:00:00
# dtype: object
```
