### PR TITLE
BUG: preserve DatetimeIndex.name in HDFStore/read_hdf() with tz (#13884)

### DIFF
--- a/doc/source/whatsnew/v0.19.0.txt
+++ b/doc/source/whatsnew/v0.19.0.txt
@@ -858,7 +858,7 @@ Bug Fixes
 - Bug in ``isnull`` ``notnull`` raise ``TypeError`` if input datetime-like has other unit than ``ns`` (:issue:`13389`)
 - Bug in ``.merge`` may raise ``TypeError`` if input datetime-like has other unit than ``ns`` (:issue:`13389`)
 
-
+- Bug in ``HDFStore``/``read_hdf()`` discarded ``DatetimeIndex.name`` if ``tz`` was set (:issue:`13884`)
 
 - Bug in ``Categorical.remove_unused_categories()`` changes ``.codes`` dtype to platform int (:issue:`13261`)
 - Bug in ``groupby`` with ``as_index=False`` returns all NaN's when grouping on multiple columns including a categorical one (:issue:`13204`)

--- a/pandas/io/pytables.py
+++ b/pandas/io/pytables.py
@@ -4339,9 +4339,10 @@ def _set_tz(values, tz, preserve_UTC=False, coerce=False):
     coerce : if we do not have a passed timezone, coerce to M8[ns] ndarray
     """
     if tz is not None:
+        name = getattr(values, 'name', None)
         values = values.ravel()
         tz = tslib.get_timezone(_ensure_decoded(tz))
-        values = DatetimeIndex(values)
+        values = DatetimeIndex(values, name=name)
         if values.tz is None:
             values = values.tz_localize('UTC').tz_convert(tz)
         if preserve_UTC:

--- a/pandas/io/tests/test_pytables.py
+++ b/pandas/io/tests/test_pytables.py
@@ -2862,6 +2862,18 @@ class TestHDFStore(Base, tm.TestCase):
             recons = store['frame']
             assert(recons.index.name == 'foo')
 
+    def test_store_index_name_with_tz(self):
+        # GH 13884
+        df = pd.DataFrame({'A': [1, 2]})
+        df.index = pd.DatetimeIndex([1234567890123456787, 1234567890123456788])
+        df.index = df.index.tz_localize('UTC')
+        df.index.name = 'foo'
+
+        with ensure_clean_store(self.path) as store:
+            store.put('frame', df, format='table')
+            recons = store['frame']
+            assert(recons.index.name == 'foo')
+
     def test_store_series_name(self):
         df = tm.makeDataFrame()
         series = df['A']


### PR DESCRIPTION
- [x] closes #13884
- [x] tests added / passed
- [x] passes `git diff upstream/master | flake8 --diff`
- [x] whatsnew entry
