### PR TITLE
BUG: fix precision to specify decimal places

### DIFF
--- a/pandas/formats/style.py
+++ b/pandas/formats/style.py
@@ -155,7 +155,7 @@ class Styler(object):
 
         def default_display_func(x):
             if is_float(x):
-                return '{:>.{precision}g}'.format(x, precision=self.precision)
+                return '{:>.{precision}f}'.format(x, precision=self.precision)
             else:
                 return x
 

--- a/pandas/tests/formats/test_style.py
+++ b/pandas/tests/formats/test_style.py
@@ -507,37 +507,37 @@ class TestStyler(TestCase):
         ctx = df.style.format({"a": "{:0.1f}", "b": "{0:.2%}"},
                               subset=pd.IndexSlice[0, :])._translate()
         expected = '0.1'
+        precise_11 = '1.123400'  # with the default precision
         self.assertEqual(ctx['body'][0][1]['display_value'], expected)
-        self.assertEqual(ctx['body'][1][1]['display_value'], '1.1234')
+        self.assertEqual(ctx['body'][1][1]['display_value'], precise_11)
         self.assertEqual(ctx['body'][0][2]['display_value'], '12.34%')
 
-        raw_11 = '1.1234'
         ctx = df.style.format("{:0.1f}",
                               subset=pd.IndexSlice[0, :])._translate()
         self.assertEqual(ctx['body'][0][1]['display_value'], expected)
-        self.assertEqual(ctx['body'][1][1]['display_value'], raw_11)
+        self.assertEqual(ctx['body'][1][1]['display_value'], precise_11)
 
         ctx = df.style.format("{:0.1f}",
                               subset=pd.IndexSlice[0, :])._translate()
         self.assertEqual(ctx['body'][0][1]['display_value'], expected)
-        self.assertEqual(ctx['body'][1][1]['display_value'], raw_11)
+        self.assertEqual(ctx['body'][1][1]['display_value'], precise_11)
 
         ctx = df.style.format("{:0.1f}",
                               subset=pd.IndexSlice['a'])._translate()
         self.assertEqual(ctx['body'][0][1]['display_value'], expected)
-        self.assertEqual(ctx['body'][0][2]['display_value'], '0.1234')
+        self.assertEqual(ctx['body'][0][2]['display_value'], '0.123400')
 
         ctx = df.style.format("{:0.1f}",
                               subset=pd.IndexSlice[0, 'a'])._translate()
         self.assertEqual(ctx['body'][0][1]['display_value'], expected)
-        self.assertEqual(ctx['body'][1][1]['display_value'], raw_11)
+        self.assertEqual(ctx['body'][1][1]['display_value'], precise_11)
 
         ctx = df.style.format("{:0.1f}",
                               subset=pd.IndexSlice[[0, 1], ['a']])._translate()
         self.assertEqual(ctx['body'][0][1]['display_value'], expected)
         self.assertEqual(ctx['body'][1][1]['display_value'], '1.1')
-        self.assertEqual(ctx['body'][0][2]['display_value'], '0.1234')
-        self.assertEqual(ctx['body'][1][2]['display_value'], '1.1234')
+        self.assertEqual(ctx['body'][0][2]['display_value'], '0.123400')
+        self.assertEqual(ctx['body'][1][2]['display_value'], '1.123400')
 
     def test_display_dict(self):
         df = pd.DataFrame([[.1234, .1234], [1.1234, 1.1234]],


### PR DESCRIPTION
- [x] closes #13257 
- [x] tests added / passed
- [x] passes `git diff upstream/master | flake8 --diff`
- [ ] whatsnew entry

Use 'f' as a string conversion type to specify the number of decimals to
represent. The 'g' format will instead fall back to the 'e' format
causing the unexpected behavior seen in GHI13257.

See: [old-string-formatting](https://docs.python.org/3.5/library/stdtypes.html#old-string-formatting)

Replicated code from the issue, with output:
<img width="702" alt="example output with precision" src="https://cloud.githubusercontent.com/assets/7526790/17386623/77eb83f4-59ba-11e6-8193-fde0e839a184.png">
