### PR TITLE
BUG: allow describe() for DataFrames with only boolean columns

### DIFF
--- a/doc/source/whatsnew/v0.19.0.txt
+++ b/doc/source/whatsnew/v0.19.0.txt
@@ -885,6 +885,7 @@ Bug Fixes
 - Bug in ``DatetimeIndex.is_normalized`` returns incorrectly for normalized date_range in case of local timezones (:issue:`13459`)
 
 - Bug in ``DataFrame.to_csv()`` in which float values were being quoted even though quotations were specified for non-numeric values only (:issue:`12922`, :issue:`13259`)
+- Bug in ``DataFrame.describe()`` raising ``ValueError`` with only boolean columns (:issue:`13898`)
 - Bug in ``MultiIndex`` slicing where extra elements were returned when level is non-unique (:issue:`12896`)
 - Bug in ``.str.replace`` does not raise ``TypeError`` for invalid replacement (:issue:`13438`)
 - Bug in ``MultiIndex.from_arrays`` which didn't check for input array lengths matching (:issue:`13599`)

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -5138,10 +5138,9 @@ class NDFrame(PandasObject):
         if self.ndim == 1:
             return describe_1d(self)
         elif (include is None) and (exclude is None):
-            if len(self._get_numeric_data()._info_axis) > 0:
-                # when some numerics are found, keep only numerics
-                data = self.select_dtypes(include=[np.number])
-            else:
+            # when some numerics are found, keep only numerics
+            data = self.select_dtypes(include=[np.number])
+            if len(data.columns) == 0:
                 data = self
         elif include == 'all':
             if exclude is not None:

--- a/pandas/tests/frame/test_analytics.py
+++ b/pandas/tests/frame/test_analytics.py
@@ -249,6 +249,39 @@ class TestDataFrameAnalytics(tm.TestCase, TestData):
                              index=['count', 'unique', 'top', 'freq'])
         tm.assert_frame_equal(result, expected)
 
+    def test_describe_bool_frame(self):
+        # GH 13891
+        df = pd.DataFrame({
+            'bool_data_1': [False, False, True, True],
+            'bool_data_2': [False, True, True, True]
+        })
+        result = df.describe()
+        expected = DataFrame({'bool_data_1': [4, 2, True, 2],
+                              'bool_data_2': [4, 2, True, 3]},
+                             index=['count', 'unique', 'top', 'freq'])
+        tm.assert_frame_equal(result, expected)
+
+        df = pd.DataFrame({
+            'bool_data': [False, False, True, True, False],
+            'int_data': [0, 1, 2, 3, 4]
+        })
+        result = df.describe()
+        expected = DataFrame({'int_data': [5, 2, df.int_data.std(), 0, 1,
+                                           2, 3, 4]},
+                             index=['count', 'mean', 'std', 'min', '25%',
+                                    '50%', '75%', 'max'])
+        tm.assert_frame_equal(result, expected)
+
+        df = pd.DataFrame({
+            'bool_data': [False, False, True, True],
+            'str_data': ['a', 'b', 'c', 'a']
+        })
+        result = df.describe()
+        expected = DataFrame({'bool_data': [4, 2, True, 2],
+                              'str_data': [4, 3, 'a', 2]},
+                             index=['count', 'unique', 'top', 'freq'])
+        tm.assert_frame_equal(result, expected)
+
     def test_describe_categorical_columns(self):
         # GH 11558
         columns = pd.CategoricalIndex(['int1', 'int2', 'obj'],

--- a/pandas/tests/series/test_analytics.py
+++ b/pandas/tests/series/test_analytics.py
@@ -260,6 +260,27 @@ class TestSeriesAnalytics(TestData, tm.TestCase):
                 self.assertEqual(0, s.kurt())
                 self.assertTrue((df.kurt() == 0).all())
 
+    def test_describe(self):
+        s = Series([0, 1, 2, 3, 4], name='int_data')
+        result = s.describe()
+        expected = Series([5, 2, s.std(), 0, 1, 2, 3, 4],
+                          name='int_data',
+                          index=['count', 'mean', 'std', 'min', '25%',
+                                 '50%', '75%', 'max'])
+        self.assert_series_equal(result, expected)
+
+        s = Series([True, True, False, False, False], name='bool_data')
+        result = s.describe()
+        expected = Series([5, 2, False, 3], name='bool_data',
+                          index=['count', 'unique', 'top', 'freq'])
+        self.assert_series_equal(result, expected)
+
+        s = Series(['a', 'a', 'b', 'c', 'd'], name='str_data')
+        result = s.describe()
+        expected = Series([5, 4, 'a', 2], name='str_data',
+                          index=['count', 'unique', 'top', 'freq'])
+        self.assert_series_equal(result, expected)
+
     def test_argsort(self):
         self._check_accum_op('argsort', check_dtype=False)
         argsorted = self.ts.argsort()


### PR DESCRIPTION
- [x] closes #13891
- [x] tests added / passed
- [x] passes `git diff upstream/master | flake8 --diff`
- [x] whatsnew entry

Closes #13891. Existing tests pass. ~~No new tests added yet.~~
