### PR TITLE
BUG: union_categorical fastpath sort

### DIFF
--- a/pandas/tools/tests/test_concat.py
+++ b/pandas/tools/tests/test_concat.py
@@ -1006,6 +1006,13 @@ class TestConcatenate(ConcatenateBase):
                                categories=['a', 'b', 'c'])
         tm.assert_categorical_equal(result, expected)
 
+        c1 = Categorical(['a', 'b'], categories=['c', 'a', 'b'])
+        c2 = Categorical(['b', 'c'], categories=['c', 'a', 'b'])
+        result = union_categoricals([c1, c2], sort_categories=True)
+        expected = Categorical(['a', 'b', 'b', 'c'],
+                               categories=['a', 'b', 'c'])
+        tm.assert_categorical_equal(result, expected)
+
         # fastpath - skip resort
         c1 = Categorical(['a', 'b'], categories=['a', 'b', 'c'])
         c2 = Categorical(['b', 'c'], categories=['a', 'b', 'c'])

--- a/pandas/types/concat.py
+++ b/pandas/types/concat.py
@@ -263,7 +263,7 @@ def union_categoricals(to_union, sort_categories=False):
 
         if sort_categories and not categories.is_monotonic_increasing:
             categories = categories.sort_values()
-            indexer = first.categories.get_indexer(categories)
+            indexer = categories.get_indexer(first.categories)
             new_codes = take_1d(indexer, new_codes, fill_value=-1)
     elif all(not c.ordered for c in to_union):
         # different categories - union and recode


### PR DESCRIPTION
Follow up to a problem with #13846.   This path was tested, but the test just happened to be constructed in such a way it worked with the buggy implementation.
