### PR TITLE
BUG: pd.to_datetime doesn't raises AttributeError with specific input…

### DIFF
--- a/doc/source/whatsnew/v0.19.0.txt
+++ b/doc/source/whatsnew/v0.19.0.txt
@@ -858,6 +858,7 @@ Bug Fixes
 - Bug in ``factorize`` raises ``AmbiguousTimeError`` if data contains datetime near DST boundary (:issue:`13750`)
 - Bug in ``.set_index`` raises ``AmbiguousTimeError`` if new index contains DST boundary and multi levels (:issue:`12920`)
 - Bug in ``pd.read_hdf()`` returns incorrect result when a ``DataFrame`` with a ``categorical`` column and a query which doesn't match any values (:issue:`13792`)
+- Bug in ``pd.to_datetime()`` raise ``AttributeError`` with NaN and the other string is not valid when errors='ignore' (:issue:`12424`)
 
 
 - Bug in ``Series`` comparison operators when dealing with zero dim NumPy arrays (:issue:`13006`)

--- a/pandas/tests/test_algos.py
+++ b/pandas/tests/test_algos.py
@@ -568,6 +568,12 @@ class TestValueCounts(tm.TestCase):
         exp = pd.Series([3, 2, 1], index=exp_index)
         tm.assert_series_equal(res, exp)
 
+        # GH 12424
+        res = pd.to_datetime(pd.Series(['2362-01-01', np.nan]),
+                             errors='ignore')
+        exp = pd.Series(['2362-01-01', np.nan], dtype=object)
+        tm.assert_series_equal(res, exp)
+
     def test_categorical(self):
         s = Series(pd.Categorical(list('aaabbc')))
         result = s.value_counts()

--- a/pandas/tslib.pyx
+++ b/pandas/tslib.pyx
@@ -2396,10 +2396,10 @@ cpdef array_to_datetime(ndarray[object] values, errors='raise',
 
             # set as nan except if its a NaT
             if _checknull_with_nat(val):
-                if val.view('i8') == NPY_NAT:
-                    oresult[i] = NaT
-                else:
+                if PyFloat_Check(val):
                     oresult[i] = np.nan
+                else:
+                    oresult[i] = NaT
             elif util.is_datetime64_object(val):
                 if get_datetime64_value(val) == NPY_NAT:
                     oresult[i] = NaT


### PR DESCRIPTION
- [x] closes #12424
- [x] tests added / passed
- [ ] passes `git diff upstream/master | flake8 --diff`
- [x] whatsnew entry

…s when errors='ignore'(#12424)
