### PR TITLE
BUG: properly close files opened by parsers

### DIFF
--- a/doc/source/whatsnew/v0.19.0.txt
+++ b/doc/source/whatsnew/v0.19.0.txt
@@ -975,7 +975,4 @@ Bug Fixes
 
 - Bug in ``Index`` raises ``KeyError`` displaying incorrect column when column is not in the df and columns contains duplicate values (:issue:`13822`)
 - Bug in ``Period`` and ``PeriodIndex`` creating wrong dates when frequency has combined offset aliases (:issue:`13874`)
-<<<<<<< 30b61e60f358677289d8325df6a06f5cf98453bc
 - Bug in ``pd.to_datetime()`` did not cast floats correctly when ``unit`` was specified, resulting in truncated datetime (:issue:`13845`)
-=======
->>>>>>> Fix whatsnew entries

--- a/doc/source/whatsnew/v0.19.0.txt
+++ b/doc/source/whatsnew/v0.19.0.txt
@@ -904,6 +904,7 @@ Bug Fixes
 - Bug in ``pd.read_csv()`` with ``engine='c'`` in which fields were not properly cast to float when quoting was specified as non-numeric (:issue:`13411`)
 - Bug in ``pd.read_csv``, ``pd.read_table`` and ``pd.read_stata`` where files were opened by parsers but not closed if both ``chunksize`` and ``iterator`` were ``None``. (:issue:`13940`)
 - Bug in ``StataReader`` and ``StataWriter`` where a file was not properly closed when an error was raised. (:issue:`13940`)
+
 - Bug in ``pd.pivot_table()`` where ``margins_name`` is ignored when ``aggfunc`` is a list (:issue:`13354`)
 - Bug in ``pd.Series.str.zfill``, ``center``, ``ljust``, ``rjust``, and ``pad`` when passing non-integers, did not raise ``TypeError`` (:issue:`13598`)
 - Bug in checking for any null objects in a ``TimedeltaIndex``, which always returned ``True`` (:issue:`13603`)
@@ -974,4 +975,7 @@ Bug Fixes
 
 - Bug in ``Index`` raises ``KeyError`` displaying incorrect column when column is not in the df and columns contains duplicate values (:issue:`13822`)
 - Bug in ``Period`` and ``PeriodIndex`` creating wrong dates when frequency has combined offset aliases (:issue:`13874`)
+<<<<<<< 30b61e60f358677289d8325df6a06f5cf98453bc
 - Bug in ``pd.to_datetime()`` did not cast floats correctly when ``unit`` was specified, resulting in truncated datetime (:issue:`13845`)
+=======
+>>>>>>> Fix whatsnew entries

--- a/doc/source/whatsnew/v0.19.0.txt
+++ b/doc/source/whatsnew/v0.19.0.txt
@@ -902,6 +902,8 @@ Bug Fixes
 - Bug in ``pd.read_csv()`` that prevents ``usecols`` from being an empty set (:issue:`13402`)
 - Bug in ``pd.read_csv()`` with ``engine='c'`` in which null ``quotechar`` was not accepted even though ``quoting`` was specified as ``None`` (:issue:`13411`)
 - Bug in ``pd.read_csv()`` with ``engine='c'`` in which fields were not properly cast to float when quoting was specified as non-numeric (:issue:`13411`)
+- Bug in ``pd.read_csv``, ``pd.read_table`` and ``pd.read_stata`` where files were opened by parsers but not closed if both ``chunksize`` and ``iterator`` were ``None``. (:issue:`13940`)
+- Bug in ``StataReader`` and ``StataWriter`` where a file was not properly closed when an error was raised. (:issue:`13940`)
 - Bug in ``pd.pivot_table()`` where ``margins_name`` is ignored when ``aggfunc`` is a list (:issue:`13354`)
 - Bug in ``pd.Series.str.zfill``, ``center``, ``ljust``, ``rjust``, and ``pad`` when passing non-integers, did not raise ``TypeError`` (:issue:`13598`)
 - Bug in checking for any null objects in a ``TimedeltaIndex``, which always returned ``True`` (:issue:`13603`)

--- a/doc/source/whatsnew/v0.19.0.txt
+++ b/doc/source/whatsnew/v0.19.0.txt
@@ -902,8 +902,8 @@ Bug Fixes
 - Bug in ``pd.read_csv()`` that prevents ``usecols`` from being an empty set (:issue:`13402`)
 - Bug in ``pd.read_csv()`` with ``engine='c'`` in which null ``quotechar`` was not accepted even though ``quoting`` was specified as ``None`` (:issue:`13411`)
 - Bug in ``pd.read_csv()`` with ``engine='c'`` in which fields were not properly cast to float when quoting was specified as non-numeric (:issue:`13411`)
-- Bug in ``pd.read_csv``, ``pd.read_table`` and ``pd.read_stata`` where files were opened by parsers but not closed if both ``chunksize`` and ``iterator`` were ``None``. (:issue:`13940`)
-- Bug in ``StataReader`` and ``StataWriter`` where a file was not properly closed when an error was raised. (:issue:`13940`)
+- Bug in ``pd.read_csv``, ``pd.read_table``, ``pd.read_fwf``, ``pd.read_stata`` and ``pd.read_sas`` where files were opened by parsers but not closed if both ``chunksize`` and ``iterator`` were ``None``. (:issue:`13940`)
+- Bug in ``StataReader``, ``StataWriter``, ``XportReader`` and ``SAS7BDATReader`` where a file was not properly closed when an error was raised. (:issue:`13940`)
 
 - Bug in ``pd.pivot_table()`` where ``margins_name`` is ignored when ``aggfunc`` is a list (:issue:`13354`)
 - Bug in ``pd.Series.str.zfill``, ``center``, ``ljust``, ``rjust``, and ``pad`` when passing non-integers, did not raise ``TypeError`` (:issue:`13598`)

--- a/pandas/io/common.py
+++ b/pandas/io/common.py
@@ -327,7 +327,9 @@ def _get_handle(path, mode, encoding=None, compression=None, memory_map=False):
 
     if memory_map and hasattr(f, 'fileno'):
         try:
-            f = MMapWrapper(f)
+            g = MMapWrapper(f)
+            f.close()
+            f = g
         except Exception:
             # we catch any errors that may have occurred
             # because that is consistent with the lower-level

--- a/pandas/io/parsers.py
+++ b/pandas/io/parsers.py
@@ -1766,16 +1766,18 @@ class PythonParser(ParserBase):
             f = _get_handle(f, 'r', encoding=self.encoding,
                             compression=self.compression,
                             memory_map=self.memory_map)
+            self.handles.append(f)
         elif self.compression:
             f = _wrap_compressed(f, self.compression, self.encoding)
+            self.handles.append(f)
         # in Python 3, convert BytesIO or fileobjects passed with an encoding
         elif compat.PY3 and isinstance(f, compat.BytesIO):
             from io import TextIOWrapper
 
             f = TextIOWrapper(f, encoding=self.encoding)
+            self.handles.append(f)
 
         # Set self.data to something that can read lines.
-        self.handles.append(f)
         if hasattr(f, 'readline'):
             self._make_reader(f)
         else:

--- a/pandas/io/parsers.py
+++ b/pandas/io/parsers.py
@@ -1436,6 +1436,14 @@ class CParserWrapper(ParserBase):
 
         self._implicit_index = self._reader.leading_cols > 0
 
+    def close(self):
+        for f in self.handles:
+            f.close()
+        try:
+            self._reader.close()
+        except:
+            pass
+
     def _set_noconvert_columns(self):
         names = self.orig_names
         usecols = self.usecols

--- a/pandas/io/parsers.py
+++ b/pandas/io/parsers.py
@@ -899,7 +899,11 @@ class TextFileReader(BaseIterator):
         return result, engine
 
     def __next__(self):
-        return self.get_chunk()
+        try:
+            return self.get_chunk()
+        except StopIteration:
+            self.close()
+            raise
 
     def _make_engine(self, engine='c'):
         if engine == 'c':

--- a/pandas/io/sas/sasreader.py
+++ b/pandas/io/sas/sasreader.py
@@ -58,4 +58,6 @@ def read_sas(filepath_or_buffer, format=None, index=None, encoding=None,
     if iterator or chunksize:
         return reader
 
-    return reader.read()
+    data = reader.read()
+    reader.close()
+    return data

--- a/pandas/io/stata.py
+++ b/pandas/io/stata.py
@@ -1515,8 +1515,7 @@ class StataReader(StataParser, BaseIterator):
             if self.dtyplist[i] is not None:
                 col = data.columns[i]
                 dtype = data[col].dtype
-                if ((dtype != np.dtype(object)) and
-                    (dtype != self.dtyplist[i])):
+                if dtype != np.dtype(object) and dtype != self.dtyplist[i]:
                     requires_type_conversion = True
                     data_formatted.append(
                         (col, Series(data[col], index, self.dtyplist[i])))

--- a/pandas/io/stata.py
+++ b/pandas/io/stata.py
@@ -167,15 +167,11 @@ def read_stata(filepath_or_buffer, convert_dates=True,
                          chunksize=chunksize, encoding=encoding)
 
     if iterator or chunksize:
-        try:
-            return reader
-        except StopIteration:
-            reader.close()
-
-    try:
-        return reader.read()
-    finally:
+        data = reader
+    else:
+        data = reader.read()
         reader.close()
+    return data
 
 _date_formats = ["%tc", "%tC", "%td", "%d", "%tw", "%tm", "%tq", "%th", "%ty"]
 
@@ -1411,150 +1407,154 @@ class StataReader(StataParser, BaseIterator):
              convert_categoricals=None, index=None,
              convert_missing=None, preserve_dtypes=None,
              columns=None, order_categoricals=None):
-
         # Handle empty file or chunk.  If reading incrementally raise
         # StopIteration.  If reading the whole thing return an empty
         # data frame.
         if (self.nobs == 0) and (nrows is None):
             self._can_read_value_labels = True
             self._data_read = True
+            self.close()
             return DataFrame(columns=self.varlist)
 
-        # Handle options
-        if convert_dates is None:
-            convert_dates = self._convert_dates
-        if convert_categoricals is None:
-            convert_categoricals = self._convert_categoricals
-        if convert_missing is None:
-            convert_missing = self._convert_missing
-        if preserve_dtypes is None:
-            preserve_dtypes = self._preserve_dtypes
-        if columns is None:
-            columns = self._columns
-        if order_categoricals is None:
-            order_categoricals = self._order_categoricals
+        try:
+            # Handle options
+            if convert_dates is None:
+                convert_dates = self._convert_dates
+            if convert_categoricals is None:
+                convert_categoricals = self._convert_categoricals
+            if convert_missing is None:
+                convert_missing = self._convert_missing
+            if preserve_dtypes is None:
+                preserve_dtypes = self._preserve_dtypes
+            if columns is None:
+                columns = self._columns
+            if order_categoricals is None:
+                order_categoricals = self._order_categoricals
 
-        if nrows is None:
-            nrows = self.nobs
+            if nrows is None:
+                nrows = self.nobs
 
-        if (self.format_version >= 117) and (self._dtype is None):
-            self._can_read_value_labels = True
-            self._read_strls()
+            if (self.format_version >= 117) and (self._dtype is None):
+                self._can_read_value_labels = True
+                self._read_strls()
 
-        # Setup the dtype.
-        if self._dtype is None:
-            dtype = []  # Convert struct data types to numpy data type
-            for i, typ in enumerate(self.typlist):
-                if typ in self.NUMPY_TYPE_MAP:
-                    dtype.append(('s' + str(i), self.byteorder +
-                                  self.NUMPY_TYPE_MAP[typ]))
-                else:
-                    dtype.append(('s' + str(i), 'S' + str(typ)))
-            dtype = np.dtype(dtype)
-            self._dtype = dtype
+            # Setup the dtype.
+            if self._dtype is None:
+                dtype = []  # Convert struct data types to numpy data type
+                for i, typ in enumerate(self.typlist):
+                    if typ in self.NUMPY_TYPE_MAP:
+                        dtype.append(('s' + str(i), self.byteorder +
+                                      self.NUMPY_TYPE_MAP[typ]))
+                    else:
+                        dtype.append(('s' + str(i), 'S' + str(typ)))
+                dtype = np.dtype(dtype)
+                self._dtype = dtype
 
-        # Read data
-        dtype = self._dtype
-        max_read_len = (self.nobs - self._lines_read) * dtype.itemsize
-        read_len = nrows * dtype.itemsize
-        read_len = min(read_len, max_read_len)
-        if read_len <= 0:
-            # Iterator has finished, should never be here unless
-            # we are reading the file incrementally
+            # Read data
+            dtype = self._dtype
+            max_read_len = (self.nobs - self._lines_read) * dtype.itemsize
+            read_len = nrows * dtype.itemsize
+            read_len = min(read_len, max_read_len)
+            if read_len <= 0:
+                # Iterator has finished, should never be here unless
+                # we are reading the file incrementally
+                if convert_categoricals:
+                    self._read_value_labels()
+                raise StopIteration
+            offset = self._lines_read * dtype.itemsize
+            self.path_or_buf.seek(self.data_location + offset)
+            read_lines = min(nrows, self.nobs - self._lines_read)
+            data = np.frombuffer(self.path_or_buf.read(read_len), dtype=dtype,
+                                 count=read_lines)
+
+            self._lines_read += read_lines
+            if self._lines_read == self.nobs:
+                self._can_read_value_labels = True
+                self._data_read = True
+            # if necessary, swap the byte order to native here
+            if self.byteorder != self._native_byteorder:
+                data = data.byteswap().newbyteorder()
+
             if convert_categoricals:
                 self._read_value_labels()
-            raise StopIteration
-        offset = self._lines_read * dtype.itemsize
-        self.path_or_buf.seek(self.data_location + offset)
-        read_lines = min(nrows, self.nobs - self._lines_read)
-        data = np.frombuffer(self.path_or_buf.read(read_len), dtype=dtype,
-                             count=read_lines)
 
-        self._lines_read += read_lines
-        if self._lines_read == self.nobs:
-            self._can_read_value_labels = True
-            self._data_read = True
-        # if necessary, swap the byte order to native here
-        if self.byteorder != self._native_byteorder:
-            data = data.byteswap().newbyteorder()
+            if len(data) == 0:
+                data = DataFrame(columns=self.varlist, index=index)
+            else:
+                data = DataFrame.from_records(data, index=index)
+                data.columns = self.varlist
 
-        if convert_categoricals:
-            self._read_value_labels()
+            # If index is not specified, use actual row number rather than
+            # restarting at 0 for each chunk.
+            if index is None:
+                ix = np.arange(self._lines_read - read_lines, self._lines_read)
+                data = data.set_index(ix)
 
-        if len(data) == 0:
-            data = DataFrame(columns=self.varlist, index=index)
-        else:
-            data = DataFrame.from_records(data, index=index)
-            data.columns = self.varlist
+            if columns is not None:
+                data = self._do_select_columns(data, columns)
 
-        # If index is not specified, use actual row number rather than
-        # restarting at 0 for each chunk.
-        if index is None:
-            ix = np.arange(self._lines_read - read_lines, self._lines_read)
-            data = data.set_index(ix)
+            # Decode strings
+            for col, typ in zip(data, self.typlist):
+                if type(typ) is int:
+                    data[col] = data[col].apply(
+                        self._null_terminate, convert_dtype=True)
 
-        if columns is not None:
-            data = self._do_select_columns(data, columns)
+            data = self._insert_strls(data)
 
-        # Decode strings
-        for col, typ in zip(data, self.typlist):
-            if type(typ) is int:
-                data[col] = data[col].apply(
-                    self._null_terminate, convert_dtype=True)
+            cols_ = np.where(self.dtyplist)[0]
 
-        data = self._insert_strls(data)
+            # Convert columns (if needed) to match input type
+            index = data.index
+            requires_type_conversion = False
+            data_formatted = []
+            for i in cols_:
+                if self.dtyplist[i] is not None:
+                    col = data.columns[i]
+                    dtype = data[col].dtype
+                    if (dtype != np.dtype(object)) and (dtype != self.dtyplist[i]):
+                        requires_type_conversion = True
+                        data_formatted.append(
+                            (col, Series(data[col], index, self.dtyplist[i])))
+                    else:
+                        data_formatted.append((col, data[col]))
+            if requires_type_conversion:
+                data = DataFrame.from_items(data_formatted)
+            del data_formatted
 
-        cols_ = np.where(self.dtyplist)[0]
+            self._do_convert_missing(data, convert_missing)
 
-        # Convert columns (if needed) to match input type
-        index = data.index
-        requires_type_conversion = False
-        data_formatted = []
-        for i in cols_:
-            if self.dtyplist[i] is not None:
-                col = data.columns[i]
-                dtype = data[col].dtype
-                if (dtype != np.dtype(object)) and (dtype != self.dtyplist[i]):
-                    requires_type_conversion = True
-                    data_formatted.append(
-                        (col, Series(data[col], index, self.dtyplist[i])))
-                else:
-                    data_formatted.append((col, data[col]))
-        if requires_type_conversion:
-            data = DataFrame.from_items(data_formatted)
-        del data_formatted
+            if convert_dates:
+                cols = np.where(lmap(lambda x: x in _date_formats,
+                                     self.fmtlist))[0]
+                for i in cols:
+                    col = data.columns[i]
+                    data[col] = _stata_elapsed_date_to_datetime_vec(
+                        data[col],
+                        self.fmtlist[i])
 
-        self._do_convert_missing(data, convert_missing)
+            if convert_categoricals and self.format_version > 108:
+                data = self._do_convert_categoricals(data,
+                                                     self.value_label_dict,
+                                                     self.lbllist,
+                                                     order_categoricals)
 
-        if convert_dates:
-            cols = np.where(lmap(lambda x: x in _date_formats,
-                                 self.fmtlist))[0]
-            for i in cols:
-                col = data.columns[i]
-                data[col] = _stata_elapsed_date_to_datetime_vec(
-                    data[col],
-                    self.fmtlist[i])
-
-        if convert_categoricals and self.format_version > 108:
-            data = self._do_convert_categoricals(data,
-                                                 self.value_label_dict,
-                                                 self.lbllist,
-                                                 order_categoricals)
-
-        if not preserve_dtypes:
-            retyped_data = []
-            convert = False
-            for col in data:
-                dtype = data[col].dtype
-                if dtype in (np.float16, np.float32):
-                    dtype = np.float64
-                    convert = True
-                elif dtype in (np.int8, np.int16, np.int32):
-                    dtype = np.int64
-                    convert = True
-                retyped_data.append((col, data[col].astype(dtype)))
-            if convert:
-                data = DataFrame.from_items(retyped_data)
+            if not preserve_dtypes:
+                retyped_data = []
+                convert = False
+                for col in data:
+                    dtype = data[col].dtype
+                    if dtype in (np.float16, np.float32):
+                        dtype = np.float64
+                        convert = True
+                    elif dtype in (np.int8, np.int16, np.int32):
+                        dtype = np.int64
+                        convert = True
+                    retyped_data.append((col, data[col].astype(dtype)))
+                if convert:
+                    data = DataFrame.from_items(retyped_data)
+        except:
+            self.close()
+            raise
 
         return data
 

--- a/pandas/io/stata.py
+++ b/pandas/io/stata.py
@@ -1511,7 +1511,8 @@ class StataReader(StataParser, BaseIterator):
                 if self.dtyplist[i] is not None:
                     col = data.columns[i]
                     dtype = data[col].dtype
-                    if (dtype != np.dtype(object)) and (dtype != self.dtyplist[i]):
+                    if ((dtype != np.dtype(object)) and
+                        (dtype != self.dtyplist[i])):
                         requires_type_conversion = True
                         data_formatted.append(
                             (col, Series(data[col], index, self.dtyplist[i])))

--- a/pandas/io/stata.py
+++ b/pandas/io/stata.py
@@ -1881,9 +1881,7 @@ class StataWriter(StataParser):
         if byteorder is None:
             byteorder = sys.byteorder
         self._byteorder = _set_endianness(byteorder)
-        self._file = _open_file_binary_write(
-            fname, self._encoding or self._default_encoding
-        )
+        self._fname = fname
         self.type_converters = {253: np.int32, 252: np.int16, 251: np.int8}
 
     def _write(self, to_write):
@@ -2078,16 +2076,21 @@ class StataWriter(StataParser):
                 self.fmtlist[key] = self._convert_dates[key]
 
     def write_file(self):
-        self._write_header(time_stamp=self._time_stamp,
-                           data_label=self._data_label)
-        self._write_descriptors()
-        self._write_variable_labels()
-        # write 5 zeros for expansion fields
-        self._write(_pad_bytes("", 5))
-        self._prepare_data()
-        self._write_data()
-        self._write_value_labels()
-        self._file.close()
+        self._file = _open_file_binary_write(
+            self._fname, self._encoding or self._default_encoding
+        )
+        try:
+            self._write_header(time_stamp=self._time_stamp,
+                               data_label=self._data_label)
+            self._write_descriptors()
+            self._write_variable_labels()
+            # write 5 zeros for expansion fields
+            self._write(_pad_bytes("", 5))
+            self._prepare_data()
+            self._write_data()
+            self._write_value_labels()
+        finally:
+            self._file.close()
 
     def _write_value_labels(self):
         for vl in self._value_labels:

--- a/pandas/io/tests/parser/common.py
+++ b/pandas/io/tests/parser/common.py
@@ -1580,5 +1580,6 @@ j,-inF"""
         new_file.seek(0)
 
         result = self.read_csv(new_file, sep='\s+', header=None)
+        new_file.close()
         expected = DataFrame([[0, 0]])
         tm.assert_frame_equal(result, expected)

--- a/pandas/io/tests/parser/python_parser_only.py
+++ b/pandas/io/tests/parser/python_parser_only.py
@@ -130,7 +130,8 @@ also also skip this
         except ImportError:
             raise nose.SkipTest('need gzip and bz2 to run')
 
-        data = open(self.csv1, 'rb').read()
+        with open(self.csv1, 'rb') as f:
+            data = f.read()
         data = data.replace(b',', b'::')
         expected = self.read_csv(self.csv1)
 

--- a/pandas/io/tests/parser/test_textreader.py
+++ b/pandas/io/tests/parser/test_textreader.py
@@ -54,7 +54,8 @@ class TestTextReader(tm.TestCase):
             f.close()
 
     def test_StringIO(self):
-        text = open(self.csv1, 'rb').read()
+        with open(self.csv1, 'rb') as f:
+            text = f.read()
         src = BytesIO(text)
         reader = TextReader(src, header=None)
         reader.read()

--- a/pandas/io/tests/sas/test_sas7bdat.py
+++ b/pandas/io/tests/sas/test_sas7bdat.py
@@ -81,6 +81,7 @@ def test_encoding_options():
     from pandas.io.sas.sas7bdat import SAS7BDATReader
     rdr = SAS7BDATReader(fname, convert_header_text=False)
     df3 = rdr.read()
+    rdr.close()
     for x, y in zip(df1.columns, df3.columns):
         assert(x == y.decode())
 

--- a/pandas/io/tests/sas/test_sas7bdat.py
+++ b/pandas/io/tests/sas/test_sas7bdat.py
@@ -44,7 +44,8 @@ class TestSAS7BDAT(tm.TestCase):
             df0 = self.data[j]
             for k in self.test_ix[j]:
                 fname = os.path.join(self.dirpath, "test%d.sas7bdat" % k)
-                byts = open(fname, 'rb').read()
+                with open(fname, 'rb') as f:
+                    byts = f.read()
                 buf = io.BytesIO(byts)
                 df = pd.read_sas(buf, format="sas7bdat", encoding='utf-8')
                 tm.assert_frame_equal(df, df0, check_exact=False)
@@ -54,7 +55,8 @@ class TestSAS7BDAT(tm.TestCase):
             df0 = self.data[j]
             for k in self.test_ix[j]:
                 fname = os.path.join(self.dirpath, "test%d.sas7bdat" % k)
-                byts = open(fname, 'rb').read()
+                with open(fname, 'rb') as f:
+                    byts = f.read()
                 buf = io.BytesIO(byts)
                 rdr = pd.read_sas(buf, format="sas7bdat",
                                   iterator=True, encoding='utf-8')

--- a/pandas/io/tests/sas/test_xport.py
+++ b/pandas/io/tests/sas/test_xport.py
@@ -39,11 +39,13 @@ class TestXport(tm.TestCase):
         # Test incremental read with `read` method.
         reader = read_sas(self.file01, format="xport", iterator=True)
         data = reader.read(10)
+        reader.close()
         tm.assert_frame_equal(data, data_csv.iloc[0:10, :])
 
         # Test incremental read with `get_chunk` method.
         reader = read_sas(self.file01, format="xport", chunksize=10)
         data = reader.get_chunk()
+        reader.close()
         tm.assert_frame_equal(data, data_csv.iloc[0:10, :])
 
         # Read full file with `read_sas` method
@@ -66,6 +68,7 @@ class TestXport(tm.TestCase):
         reader = read_sas(self.file01, index="SEQN", format="xport",
                           iterator=True)
         data = reader.read(10)
+        reader.close()
         tm.assert_frame_equal(data, data_csv.iloc[0:10, :],
                               check_index_type=False)
 
@@ -73,6 +76,7 @@ class TestXport(tm.TestCase):
         reader = read_sas(self.file01, index="SEQN", format="xport",
                           chunksize=10)
         data = reader.get_chunk()
+        reader.close()
         tm.assert_frame_equal(data, data_csv.iloc[0:10, :],
                               check_index_type=False)
 

--- a/pandas/io/tests/test_common.py
+++ b/pandas/io/tests/test_common.py
@@ -116,8 +116,8 @@ class TestMMapWrapper(tm.TestCase):
         tm.assertRaisesRegexp(ValueError, msg, common.MMapWrapper, target)
 
     def test_get_attr(self):
-        target = open(self.mmap_file, 'r')
-        wrapper = common.MMapWrapper(target)
+        with open(self.mmap_file, 'r') as target:
+            wrapper = common.MMapWrapper(target)
 
         attrs = dir(wrapper.mmap)
         attrs = [attr for attr in attrs
@@ -130,10 +130,9 @@ class TestMMapWrapper(tm.TestCase):
         self.assertFalse(hasattr(wrapper, 'foo'))
 
     def test_next(self):
-        target = open(self.mmap_file, 'r')
-        wrapper = common.MMapWrapper(target)
-
-        lines = target.readlines()
+        with open(self.mmap_file, 'r') as target:
+            wrapper = common.MMapWrapper(target)
+            lines = target.readlines()
 
         for line in lines:
             next_line = next(wrapper)

--- a/pandas/tests/series/test_io.py
+++ b/pandas/tests/series/test_io.py
@@ -64,7 +64,8 @@ class TestSeriesToCSV(TestData, tm.TestCase):
         with ensure_clean() as path:
             self.ts.to_csv(path)
 
-            lines = io.open(path, newline=None).readlines()
+            with io.open(path, newline=None) as f:
+                lines = f.readlines()
             assert (lines[1] != '\n')
 
             self.ts.to_csv(path, index=False)


### PR DESCRIPTION
- [x] closes #13932 
- [x] tests passed
- [x] passes `git diff upstream/master | flake8 --diff`
- [x] whatsnew entry

Addresses all ~~most~~ of the `ResourceWarning`s from #13932. There were three tests that opened files but did not close them. The rest were due to parsers (`CParserWrapper` and `PythonParser`) opening files or streams but never closing them. There was one case &mdash; the `mmap` one &mdash; that was tricky because there was a file handle going into it and immediately reaching a refcount of zero.

I am at a loss about writing new tests for this. Is it even possible?
