### PR TITLE
TST: Removed regex warning for read_csv

### DIFF
--- a/pandas/io/tests/parser/common.py
+++ b/pandas/io/tests/parser/common.py
@@ -1568,3 +1568,17 @@ j,-inF"""
                             encoding=utf8, names=['a'],
                             skip_blank_lines=False)
         tm.assert_frame_equal(out, expected)
+
+    def test_temporary_file(self):
+        # see gh-13398
+        data1 = "0 0"
+
+        from tempfile import TemporaryFile
+        new_file = TemporaryFile("w+")
+        new_file.write(data1)
+        new_file.flush()
+        new_file.seek(0)
+
+        result = self.read_csv(new_file, sep='\s+', header=None)
+        expected = DataFrame([[0, 0]])
+        tm.assert_frame_equal(result, expected)

--- a/pandas/io/tests/parser/python_parser_only.py
+++ b/pandas/io/tests/parser/python_parser_only.py
@@ -172,20 +172,6 @@ x   q   30      3    -0.6662 -0.5243 -0.3580  0.89145  2.5838"""
         actual = self.read_table(StringIO(data), sep='\s+')
         tm.assert_frame_equal(actual, expected)
 
-    def test_temporary_file(self):
-        # GH13398
-        data1 = "0 0"
-
-        from tempfile import TemporaryFile
-        new_file = TemporaryFile("w+")
-        new_file.write(data1)
-        new_file.flush()
-        new_file.seek(0)
-
-        result = self.read_csv(new_file, sep=r"\s*", header=None)
-        expected = DataFrame([[0, 0]])
-        tm.assert_frame_equal(result, expected)
-
     def test_skipfooter_with_decimal(self):
         # see gh-6971
         data = '1#2\n3#4'


### PR DESCRIPTION
Follow-up to #13481 and partially fixes #13932.  Regex mistakenly matches to the empty string, which will cause Python 3.x to issue a warning.  In addition, not sure why this test was placed in `python_parsers_only.py`...
