### PR TITLE
API: Expanded resample

### DIFF
--- a/doc/source/timeseries.rst
+++ b/doc/source/timeseries.rst
@@ -1473,8 +1473,9 @@ Furthermore, you can also specify multiple aggregation functions for each column
    r.agg({'A' : ['sum','std'], 'B' : ['mean','std'] })
 
 
-If a ``DataFrame`` does not have a ``DatetimeIndex``, but instead you want
-to resample based on column in the frame, it can passed to the ``on`` keyword.
+If a ``DataFrame`` does not have a datetimelike index, but instead you want
+to resample based on datetimelike column in the frame, it can passed to the
+``on`` keyword.
 
 .. ipython:: python
 
@@ -1487,8 +1488,9 @@ to resample based on column in the frame, it can passed to the ``on`` keyword.
    df
    df.resample('M', on='date').sum()
 
-Similarly, if you instead want to resample by a level of ``MultiIndex``, its
-name or location can be passed to the ``level`` keyword.
+Similarly, if you instead want to resample by a datetimelike
+level of ``MultiIndex``, its name or location can be passed to the
+``level`` keyword.
 
 .. ipython:: python
 

--- a/doc/source/timeseries.rst
+++ b/doc/source/timeseries.rst
@@ -1473,6 +1473,28 @@ Furthermore, you can also specify multiple aggregation functions for each column
    r.agg({'A' : ['sum','std'], 'B' : ['mean','std'] })
 
 
+If a ``DataFrame`` does not have a ``DatetimeIndex``, but instead you want
+to resample based on column in the frame, it can passed to the ``on`` keyword.
+
+.. ipython:: python
+
+   df = pd.DataFrame({'date': pd.date_range('2015-01-01', freq='W', periods=5),
+                      'a': np.arange(5)},
+                     index=pd.MultiIndex.from_arrays([
+                              [1,2,3,4,5],
+                              pd.date_range('2015-01-01', freq='W', periods=5)],
+                          names=['v','d']))
+   df
+   df.resample('M', on='date').sum()
+
+Similarly, if you instead want to resample by a level of ``MultiIndex``, its
+name or location can be passed to the ``level`` keyword.
+
+.. ipython:: python
+
+   df.resample(level='d').sum()
+
+
 .. _timeseries.periods:
 
 Time Span Representation

--- a/doc/source/whatsnew/v0.19.0.txt
+++ b/doc/source/whatsnew/v0.19.0.txt
@@ -377,7 +377,7 @@ Other enhancements
 
     pd.Timestamp(year=2012, month=1, day=1, hour=8, minute=30)
 
-- the ``.resample()`` function now accepts a ``on=`` or ``level=`` parameter for resampling on a column or ``MultiIndex`` level (:issue:`13500`)
+- the ``.resample()`` function now accepts a ``on=`` or ``level=`` parameter for resampling on a datetimelike column or ``MultiIndex`` level (:issue:`13500`)
 
   .. ipython:: python
 

--- a/doc/source/whatsnew/v0.19.0.txt
+++ b/doc/source/whatsnew/v0.19.0.txt
@@ -948,7 +948,7 @@ Bug Fixes
 - Bug in ``pd.read_hdf()`` returns incorrect result when a ``DataFrame`` with a ``categorical`` column and a query which doesn't match any values (:issue:`13792`)
 - Bug in ``pd.to_datetime()`` raise ``AttributeError`` with NaN and the other string is not valid when errors='ignore' (:issue:`12424`)
 
-- Bug in ``groupby`` where a ``TimeGrouper`` selection is used with the ``key`` or ``level`` arguments with a ``PeriodIndex`` (:issue:`14008`)
+
 - Bug in ``Series`` comparison operators when dealing with zero dim NumPy arrays (:issue:`13006`)
 - Bug in ``groupby`` where ``apply`` returns different result depending on whether first result is ``None`` or not (:issue:`12824`)
 - Bug in ``groupby(..).nth()`` where the group key is included inconsistently if called after ``.head()/.tail()`` (:issue:`12839`)

--- a/doc/source/whatsnew/v0.19.0.txt
+++ b/doc/source/whatsnew/v0.19.0.txt
@@ -377,7 +377,7 @@ Other enhancements
 
     pd.Timestamp(year=2012, month=1, day=1, hour=8, minute=30)
 
-- the ``.resample()`` function now accepts a ``on=`` or ``key=`` parameter for resampling on a column or ``MultiIndex`` level (:issue:`13500`)
+- the ``.resample()`` function now accepts a ``on=`` or ``level=`` parameter for resampling on a column or ``MultiIndex`` level (:issue:`13500`)
 
   .. ipython:: python
 

--- a/doc/source/whatsnew/v0.19.0.txt
+++ b/doc/source/whatsnew/v0.19.0.txt
@@ -377,6 +377,20 @@ Other enhancements
 
     pd.Timestamp(year=2012, month=1, day=1, hour=8, minute=30)
 
+- the ``.resample()`` function now accepts a ``on=`` or ``key=`` parameter for resampling on a column or ``MultiIndex`` level (:issue:`13500`)
+
+  .. ipython:: python
+
+     df = pd.DataFrame({'date': pd.date_range('2015-01-01', freq='W', periods=5),
+                        'a': np.arange(5)},
+                       index=pd.MultiIndex.from_arrays([
+                                [1,2,3,4,5],
+                                pd.date_range('2015-01-01', freq='W', periods=5)],
+                            names=['v','d']))
+     df
+     df.resample('M', on='date').sum()
+     df.resample('M', level='d').sum()
+
 - The ``pd.read_csv()`` with ``engine='python'`` has gained support for the ``decimal`` option (:issue:`12933`)
 - The ``pd.read_csv()`` with ``engine='python'`` has gained support for the ``na_filter`` option (:issue:`13321`)
 - The ``pd.read_csv()`` with ``engine='python'`` has gained support for the ``memory_map`` option (:issue:`13381`)

--- a/doc/source/whatsnew/v0.19.0.txt
+++ b/doc/source/whatsnew/v0.19.0.txt
@@ -948,7 +948,7 @@ Bug Fixes
 - Bug in ``pd.read_hdf()`` returns incorrect result when a ``DataFrame`` with a ``categorical`` column and a query which doesn't match any values (:issue:`13792`)
 - Bug in ``pd.to_datetime()`` raise ``AttributeError`` with NaN and the other string is not valid when errors='ignore' (:issue:`12424`)
 
-
+- Bug in ``groupby`` where a ``TimeGrouper`` selection is used with the ``key`` or ``level`` arguments with a ``PeriodIndex`` (:issue:`14008`)
 - Bug in ``Series`` comparison operators when dealing with zero dim NumPy arrays (:issue:`13006`)
 - Bug in ``groupby`` where ``apply`` returns different result depending on whether first result is ``None`` or not (:issue:`12824`)
 - Bug in ``groupby(..).nth()`` where the group key is included inconsistently if called after ``.head()/.tail()`` (:issue:`12839`)

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -4038,7 +4038,7 @@ class NDFrame(PandasObject):
 
     def resample(self, rule, how=None, axis=0, fill_method=None, closed=None,
                  label=None, convention='start', kind=None, loffset=None,
-                 limit=None, base=0):
+                 limit=None, base=0, on=None, level=None):
         """
         Convenience method for frequency conversion and resampling of regular
         time-series data.
@@ -4059,7 +4059,12 @@ class NDFrame(PandasObject):
             For frequencies that evenly subdivide 1 day, the "origin" of the
             aggregated intervals. For example, for '5min' frequency, base could
             range from 0 through 4. Defaults to 0
-
+        on : string, optional
+            For a DataFrame, column to use for resampling, rather than
+            the index
+        level : string or int, optional
+            For a MultiIndex, level (name or number) to use for
+            resampling
 
         To learn more about the offset strings, please see `this link
         <http://pandas.pydata.org/pandas-docs/stable/timeseries.html#offset-aliases>`__.
@@ -4164,12 +4169,16 @@ class NDFrame(PandasObject):
         """
         from pandas.tseries.resample import (resample,
                                              _maybe_process_deprecations)
+        if is_list_like(on):
+            raise ValueError("Only a single column may be passed to on")
+        if is_list_like(level):
+            raise ValueError("Only a single column may be passed to level")
 
         axis = self._get_axis_number(axis)
         r = resample(self, freq=rule, label=label, closed=closed,
                      axis=axis, kind=kind, loffset=loffset,
                      convention=convention,
-                     base=base)
+                     base=base, key=on, level=level)
         return _maybe_process_deprecations(r,
                                            how=how,
                                            fill_method=fill_method,

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -4169,11 +4169,6 @@ class NDFrame(PandasObject):
         """
         from pandas.tseries.resample import (resample,
                                              _maybe_process_deprecations)
-        if is_list_like(on):
-            raise ValueError("Only a single column may be passed to on")
-        if is_list_like(level):
-            raise ValueError("Only a single column may be passed to level")
-
         axis = self._get_axis_number(axis)
         r = resample(self, freq=rule, label=label, closed=closed,
                      axis=axis, kind=kind, loffset=loffset,

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -4064,9 +4064,14 @@ class NDFrame(PandasObject):
         on : string, optional
             For a DataFrame, column to use instead of index for resampling.
             Column must be datetime-like.
+
+            .. versionadded:: 0.19.0
+
         level : string or int, optional
             For a MultiIndex, level (name or number) to use for
             resampling.  Level must be datetime-like.
+
+            .. versionadded:: 0.19.0
 
         To learn more about the offset strings, please see `this link
         <http://pandas.pydata.org/pandas-docs/stable/timeseries.html#offset-aliases>`__.

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -4040,8 +4040,10 @@ class NDFrame(PandasObject):
                  label=None, convention='start', kind=None, loffset=None,
                  limit=None, base=0, on=None, level=None):
         """
-        Convenience method for frequency conversion and resampling of regular
-        time-series data.
+        Convenience method for frequency conversion and resampling of time
+        series.  Object must have a datetime-like index (DatetimeIndex,
+        PeriodIndex, or TimedeltaIndex), or pass datetime-like values
+        to the on or level keyword.
 
         Parameters
         ----------
@@ -4060,11 +4062,11 @@ class NDFrame(PandasObject):
             aggregated intervals. For example, for '5min' frequency, base could
             range from 0 through 4. Defaults to 0
         on : string, optional
-            For a DataFrame, column to use for resampling, rather than
-            the index
+            For a DataFrame, column to use instead of index for resampling.
+            Column must be datetime-like.
         level : string or int, optional
             For a MultiIndex, level (name or number) to use for
-            resampling
+            resampling.  Level must be datetime-like.
 
         To learn more about the offset strings, please see `this link
         <http://pandas.pydata.org/pandas-docs/stable/timeseries.html#offset-aliases>`__.

--- a/pandas/core/groupby.py
+++ b/pandas/core/groupby.py
@@ -257,8 +257,6 @@ class Grouper(object):
         obj : the subject object
         sort : bool, default False
             whether the resulting grouper should be sorted
-        converter : callable, optional
-            conversion to apply the grouper after selection
         """
 
         if self.key is not None and self.level is not None:
@@ -298,8 +296,6 @@ class Grouper(object):
                            convert=False, is_copy=False)
 
         self.obj = obj
-        if converter is not None:
-            ax = converter(ax)
         self.grouper = ax
         return self.grouper
 

--- a/pandas/core/groupby.py
+++ b/pandas/core/groupby.py
@@ -247,7 +247,7 @@ class Grouper(object):
                                                           sort=self.sort)
         return self.binner, self.grouper, self.obj
 
-    def _set_grouper(self, obj, sort=False):
+    def _set_grouper(self, obj, sort=False, converter=None):
         """
         given an object and the specifications, setup the internal grouper
         for this particular specification
@@ -255,7 +255,10 @@ class Grouper(object):
         Parameters
         ----------
         obj : the subject object
-
+        sort : bool, default False
+            whether the resulting grouper should be sorted
+        converter : callable, optional
+            conversion to apply the grouper after selection
         """
 
         if self.key is not None and self.level is not None:
@@ -295,6 +298,8 @@ class Grouper(object):
                            convert=False, is_copy=False)
 
         self.obj = obj
+        if converter is not None:
+            ax = converter(ax)
         self.grouper = ax
         return self.grouper
 

--- a/pandas/core/groupby.py
+++ b/pandas/core/groupby.py
@@ -247,7 +247,7 @@ class Grouper(object):
                                                           sort=self.sort)
         return self.binner, self.grouper, self.obj
 
-    def _set_grouper(self, obj, sort=False, converter=None):
+    def _set_grouper(self, obj, sort=False):
         """
         given an object and the specifications, setup the internal grouper
         for this particular specification

--- a/pandas/tseries/resample.py
+++ b/pandas/tseries/resample.py
@@ -64,7 +64,7 @@ class Resampler(_GroupBy):
                                         'binner', 'grouper', 'groupby',
                                         'sort', 'kind', 'squeeze', 'keys',
                                         'group_keys', 'as_index', 'exclusions',
-                                        '_groupby', '_from_selection']
+                                        '_groupby']
 
     # don't raise deprecation warning on attributes starting with these
     # patterns - prevents warnings caused by IPython introspection
@@ -85,14 +85,8 @@ class Resampler(_GroupBy):
         self.exclusions = set()
         self.binner = None
         self.grouper = None
-        self._from_selection = False
 
         if self.groupby is not None:
-            # upsampling and PeriodIndex resampling do not work
-            # if resampling on a column or mi level
-            # this state used to catch and raise an error
-            self._from_selection = (self.groupby.key is not None or
-                                    self.groupby.level is not None)
             self.groupby._set_grouper(self._convert_obj(obj), sort=True)
 
     def __unicode__(self):
@@ -117,6 +111,15 @@ class Resampler(_GroupBy):
         if isinstance(self._selected_obj, pd.Series):
             return 'series'
         return 'dataframe'
+
+    @property
+    def _from_selection(self):
+        """ is the resampling from a DataFrame column or MultiIndex level """
+        # upsampling and PeriodIndex resampling do not work
+        # with selection, this state used to catch and raise an error
+        return (self.groupby is not None and
+                (self.groupby.key is not None or
+                 self.groupby.level is not None))
 
     def _deprecated(self, op):
         warnings.warn(("\n.resample() is now a deferred operation\n"

--- a/pandas/tseries/resample.py
+++ b/pandas/tseries/resample.py
@@ -719,10 +719,10 @@ class DatetimeIndexResampler(Resampler):
         if self.axis:
             raise AssertionError('axis must be 0')
         if self.from_selection:
-            raise NotImplementedError("Upsampling from level= or on= selection "
-                                      "is not supported, use .set_index(...) "
-                                      "to explicitly set index to "
-                                      "datetime-like")
+            raise NotImplementedError("Upsampling from level= or on= selection"
+                                      " is not supported, use .set_index(...)"
+                                      " to explicitly set index to"
+                                      " datetime-like")
 
         ax = self.ax
         obj = self._selected_obj
@@ -864,12 +864,11 @@ class PeriodIndexResampler(DatetimeIndexResampler):
         .fillna
 
         """
-        # import pdb; pdb.set_trace()
         if self.from_selection:
-            raise NotImplementedError("Upsampling from level= or on= selection "
-                                      "is not supported, use .set_index(...) "
-                                      "to explicitly set index to "
-                                      "datetime-like")
+            raise NotImplementedError("Upsampling from level= or on= selection"
+                                      " is not supported, use .set_index(...)"
+                                      " to explicitly set index to"
+                                      " datetime-like")
         # we may need to actually resample as if we are timestamps
         if self.kind == 'timestamp':
             return super(PeriodIndexResampler, self)._upsample(method,

--- a/pandas/tseries/resample.py
+++ b/pandas/tseries/resample.py
@@ -64,7 +64,7 @@ class Resampler(_GroupBy):
                                         'binner', 'grouper', 'groupby',
                                         'sort', 'kind', 'squeeze', 'keys',
                                         'group_keys', 'as_index', 'exclusions',
-                                        '_groupby', 'from_selection']
+                                        '_groupby', '_from_selection']
 
     # don't raise deprecation warning on attributes starting with these
     # patterns - prevents warnings caused by IPython introspection
@@ -85,14 +85,14 @@ class Resampler(_GroupBy):
         self.exclusions = set()
         self.binner = None
         self.grouper = None
-        self.from_selection = False
+        self._from_selection = False
 
         if self.groupby is not None:
             # upsampling and PeriodIndex resampling do not work
             # if resampling on a column or mi level
             # this state used to catch and raise an error
-            self.from_selection = (self.groupby.key is not None or
-                                   self.groupby.level is not None)
+            self._from_selection = (self.groupby.key is not None or
+                                    self.groupby.level is not None)
             self.groupby._set_grouper(self._convert_obj(obj), sort=True)
 
     def __unicode__(self):
@@ -716,11 +716,11 @@ class DatetimeIndexResampler(Resampler):
         self._set_binner()
         if self.axis:
             raise AssertionError('axis must be 0')
-        if self.from_selection:
-            raise NotImplementedError("Upsampling from level= or on= selection"
-                                      " is not supported, use .set_index(...)"
-                                      " to explicitly set index to"
-                                      " datetime-like")
+        if self._from_selection:
+            raise ValueError("Upsampling from level= or on= selection"
+                             " is not supported, use .set_index(...)"
+                             " to explicitly set index to"
+                             " datetime-like")
 
         ax = self.ax
         obj = self._selected_obj
@@ -778,7 +778,7 @@ class PeriodIndexResampler(DatetimeIndexResampler):
 
         # convert to timestamp
         if not (self.kind is None or self.kind == 'period'):
-            if self.from_selection:
+            if self._from_selection:
                 # see GH 14008, GH 12871
                 msg = ("Resampling from level= or on= selection"
                        " with a PeriodIndex is not currently supported,"
@@ -863,11 +863,11 @@ class PeriodIndexResampler(DatetimeIndexResampler):
         .fillna
 
         """
-        if self.from_selection:
-            raise NotImplementedError("Upsampling from level= or on= selection"
-                                      " is not supported, use .set_index(...)"
-                                      " to explicitly set index to"
-                                      " datetime-like")
+        if self._from_selection:
+            raise ValueError("Upsampling from level= or on= selection"
+                             " is not supported, use .set_index(...)"
+                             " to explicitly set index to"
+                             " datetime-like")
         # we may need to actually resample as if we are timestamps
         if self.kind == 'timestamp':
             return super(PeriodIndexResampler, self)._upsample(method,

--- a/pandas/tseries/resample.py
+++ b/pandas/tseries/resample.py
@@ -1002,6 +1002,7 @@ class TimeGrouper(Grouper):
         TypeError if incompatible axis
 
         """
+        import pdb; pdb.set_trace()
         self._set_grouper(obj)
 
         ax = self.ax

--- a/pandas/tseries/resample.py
+++ b/pandas/tseries/resample.py
@@ -90,11 +90,10 @@ class Resampler(_GroupBy):
         if self.groupby is not None:
             # upsampling and PeriodIndex resampling do not work
             # if resampling on a column or mi level
-            # this is state used to catch and raise an error
+            # this state used to catch and raise an error
             self.from_selection = (self.groupby.key is not None or
                                    self.groupby.level is not None)
-            obj = self._convert_obj(obj)
-            self.groupby._set_grouper(obj, sort=True)
+            self.groupby._set_grouper(self._convert_obj(obj), sort=True)
 
     def __unicode__(self):
         """ provide a nice str repr of our rolling object """

--- a/pandas/tseries/tests/test_resample.py
+++ b/pandas/tseries/tests/test_resample.py
@@ -741,16 +741,22 @@ class Base(object):
 
         # non DatetimeIndex
         with tm.assertRaises(TypeError):
-            df.resample('M', level='v')
+            df.resample('2D', level='v')
 
         with tm.assertRaises(ValueError):
-            df.resample('M', on='date', level='d')
+            df.resample('2D', on='date', level='d')
 
         with tm.assertRaises(TypeError):
-            df.resample('M', on=['a', 'date'])
+            df.resample('2D', on=['a', 'date'])
 
         with tm.assertRaises(KeyError):
-            df.resample('M', level=['a', 'date'])
+            df.resample('2D', level=['a', 'date'])
+
+        with tm.assertRaises(NotImplementedError):
+            df.resample('2D', level='d').asfreq()
+
+        with tm.assertRaises(NotImplementedError):
+            df.resample('2D', on='date').asfreq()
 
         exp = df_exp.resample('2D').sum()
         exp.index.name = 'date'

--- a/pandas/tseries/tests/test_resample.py
+++ b/pandas/tseries/tests/test_resample.py
@@ -608,17 +608,24 @@ class TestResampleAPI(tm.TestCase):
         actual = df.resample('M', on='date').sum()
         assert_frame_equal(actual, expected)
 
-        actual = df.resample('M', level='d').sum()
         expected.index.name = 'd'
+        actual = df.resample('M', level='d').sum()
         assert_frame_equal(actual, expected)
+
+        actual = df.resample('M', level=1).sum()
+        assert_frame_equal(actual, expected)
+
+        # non DatetimeIndex
+        with tm.assertRaises(TypeError):
+            df.resample('M', level='v')
 
         with tm.assertRaises(ValueError):
             df.resample('M', on='date', level='d')
 
-        with tm.assertRaises(ValueError):
+        with tm.assertRaises(TypeError):
             df.resample('M', on=['a', 'date'])
 
-        with tm.assertRaises(ValueError):
+        with tm.assertRaises(KeyError):
             df.resample('M', level=['a', 'date'])
 
 

--- a/pandas/tseries/tests/test_resample.py
+++ b/pandas/tseries/tests/test_resample.py
@@ -385,6 +385,269 @@ class TestResampleAPI(tm.TestCase):
         result = r.agg({'r1': 'mean', 'r2': 'sum'})
         assert_frame_equal(result, expected)
 
+    def test_agg(self):
+        # test with all three Resampler apis and TimeGrouper
+
+        np.random.seed(1234)
+        index = date_range(datetime(2005, 1, 1),
+                           datetime(2005, 1, 10), freq='D')
+        index.name = 'date'
+        df = pd.DataFrame(np.random.rand(10, 2),
+                          columns=list('AB'),
+                          index=index)
+        df_col = df.reset_index()
+        df_mult = df_col.copy()
+        df_mult.index = pd.MultiIndex.from_arrays([range(10), df.index],
+                                                  names=['index', 'date'])
+        r = df.resample('2D')
+        cases = [
+            r,
+            df_col.resample('2D', on='date'),
+            df_mult.resample('2D', level='date'),
+            df.groupby(pd.Grouper(freq='2D'))
+        ]
+
+        a_mean = r['A'].mean()
+        a_std = r['A'].std()
+        a_sum = r['A'].sum()
+        b_mean = r['B'].mean()
+        b_std = r['B'].std()
+        b_sum = r['B'].sum()
+
+        expected = pd.concat([a_mean, a_std, b_mean, b_std], axis=1)
+        expected.columns = pd.MultiIndex.from_product([['A', 'B'],
+                                                       ['mean', 'std']])
+        for t in cases:
+            result = t.aggregate([np.mean, np.std])
+            assert_frame_equal(result, expected)
+
+        expected = pd.concat([a_mean, b_std], axis=1)
+        for t in cases:
+            result = t.aggregate({'A': np.mean,
+                                  'B': np.std})
+            assert_frame_equal(result, expected, check_like=True)
+
+        expected = pd.concat([a_mean, a_std], axis=1)
+        expected.columns = pd.MultiIndex.from_tuples([('A', 'mean'),
+                                                      ('A', 'std')])
+        for t in cases:
+            result = t.aggregate({'A': ['mean', 'std']})
+            assert_frame_equal(result, expected)
+
+        expected = pd.concat([a_mean, a_sum], axis=1)
+        expected.columns = ['mean', 'sum']
+        for t in cases:
+            result = t['A'].aggregate(['mean', 'sum'])
+        assert_frame_equal(result, expected)
+
+        expected = pd.concat([a_mean, a_sum], axis=1)
+        expected.columns = pd.MultiIndex.from_tuples([('A', 'mean'),
+                                                      ('A', 'sum')])
+        for t in cases:
+            result = t.aggregate({'A': {'mean': 'mean', 'sum': 'sum'}})
+            assert_frame_equal(result, expected, check_like=True)
+
+        expected = pd.concat([a_mean, a_sum, b_mean, b_sum], axis=1)
+        expected.columns = pd.MultiIndex.from_tuples([('A', 'mean'),
+                                                      ('A', 'sum'),
+                                                      ('B', 'mean2'),
+                                                      ('B', 'sum2')])
+        for t in cases:
+            result = t.aggregate({'A': {'mean': 'mean', 'sum': 'sum'},
+                                  'B': {'mean2': 'mean', 'sum2': 'sum'}})
+            assert_frame_equal(result, expected, check_like=True)
+
+        expected = pd.concat([a_mean, a_std, b_mean, b_std], axis=1)
+        expected.columns = pd.MultiIndex.from_tuples([('A', 'mean'),
+                                                      ('A', 'std'),
+                                                      ('B', 'mean'),
+                                                      ('B', 'std')])
+        for t in cases:
+            result = t.aggregate({'A': ['mean', 'std'],
+                                  'B': ['mean', 'std']})
+            assert_frame_equal(result, expected, check_like=True)
+
+        expected = pd.concat([a_mean, a_sum, b_mean, b_sum], axis=1)
+        expected.columns = pd.MultiIndex.from_tuples([('r1', 'A', 'mean'),
+                                                      ('r1', 'A', 'sum'),
+                                                      ('r2', 'B', 'mean'),
+                                                      ('r2', 'B', 'sum')])
+
+    def test_agg_misc(self):
+        # test with all three Resampler apis and TimeGrouper
+
+        np.random.seed(1234)
+        index = date_range(datetime(2005, 1, 1),
+                           datetime(2005, 1, 10), freq='D')
+        index.name = 'date'
+        df = pd.DataFrame(np.random.rand(10, 2),
+                          columns=list('AB'),
+                          index=index)
+        df_col = df.reset_index()
+        df_mult = df_col.copy()
+        df_mult.index = pd.MultiIndex.from_arrays([range(10), df.index],
+                                                  names=['index', 'date'])
+
+        r = df.resample('2D')
+        cases = [
+            r,
+            df_col.resample('2D', on='date'),
+            df_mult.resample('2D', level='date'),
+            df.groupby(pd.Grouper(freq='2D'))
+        ]
+
+        # passed lambda
+        for t in cases:
+            result = t.agg({'A': np.sum,
+                            'B': lambda x: np.std(x, ddof=1)})
+            rcustom = t['B'].apply(lambda x: np.std(x, ddof=1))
+            expected = pd.concat([r['A'].sum(), rcustom], axis=1)
+            assert_frame_equal(result, expected, check_like=True)
+
+        # agg with renamers
+        expected = pd.concat([t['A'].sum(),
+                              t['B'].sum(),
+                              t['A'].mean(),
+                              t['B'].mean()],
+                             axis=1)
+        expected.columns = pd.MultiIndex.from_tuples([('result1', 'A'),
+                                                      ('result1', 'B'),
+                                                      ('result2', 'A'),
+                                                      ('result2', 'B')])
+        for t in cases:
+            result = t[['A', 'B']].agg(OrderedDict([('result1', np.sum),
+                                                    ('result2', np.mean)]))
+            assert_frame_equal(result, expected, check_like=True)
+
+        # agg with different hows
+        expected = pd.concat([t['A'].sum(),
+                              t['A'].std(),
+                              t['B'].mean(),
+                              t['B'].std()],
+                             axis=1)
+        expected.columns = pd.MultiIndex.from_tuples([('A', 'sum'),
+                                                      ('A', 'std'),
+                                                      ('B', 'mean'),
+                                                      ('B', 'std')])
+        for t in cases:
+            result = t.agg(OrderedDict([('A', ['sum', 'std']),
+                                        ('B', ['mean', 'std'])]))
+            assert_frame_equal(result, expected, check_like=True)
+
+        # equivalent of using a selection list / or not
+        for t in cases:
+            result = t[['A', 'B']].agg({'A': ['sum', 'std'],
+                                        'B': ['mean', 'std']})
+            assert_frame_equal(result, expected, check_like=True)
+
+        # series like aggs
+        for t in cases:
+            result = t['A'].agg({'A': ['sum', 'std']})
+            expected = pd.concat([t['A'].sum(),
+                                  t['A'].std()],
+                                 axis=1)
+            expected.columns = pd.MultiIndex.from_tuples([('A', 'sum'),
+                                                          ('A', 'std')])
+            assert_frame_equal(result, expected, check_like=True)
+
+            expected = pd.concat([t['A'].agg(['sum', 'std']),
+                                  t['A'].agg(['mean', 'std'])],
+                                 axis=1)
+            expected.columns = pd.MultiIndex.from_tuples([('A', 'sum'),
+                                                          ('A', 'std'),
+                                                          ('B', 'mean'),
+                                                          ('B', 'std')])
+            result = t['A'].agg({'A': ['sum', 'std'], 'B': ['mean', 'std']})
+            assert_frame_equal(result, expected, check_like=True)
+
+        # errors
+        # invalid names in the agg specification
+        for t in cases:
+            def f():
+                t[['A']].agg({'A': ['sum', 'std'],
+                              'B': ['mean', 'std']})
+
+            self.assertRaises(SpecificationError, f)
+
+    def test_agg_nested_dicts(self):
+
+        np.random.seed(1234)
+        index = date_range(datetime(2005, 1, 1),
+                           datetime(2005, 1, 10), freq='D')
+        index.name = 'date'
+        df = pd.DataFrame(np.random.rand(10, 2),
+                          columns=list('AB'),
+                          index=index)
+        df_col = df.reset_index()
+        df_mult = df_col.copy()
+        df_mult.index = pd.MultiIndex.from_arrays([range(10), df.index],
+                                                  names=['index', 'date'])
+        r = df.resample('2D')
+        cases = [
+            r,
+            df_col.resample('2D', on='date'),
+            df_mult.resample('2D', level='date'),
+            df.groupby(pd.Grouper(freq='2D'))
+        ]
+
+        for t in cases:
+            def f():
+                t.aggregate({'r1': {'A': ['mean', 'sum']},
+                             'r2': {'B': ['mean', 'sum']}})
+                self.assertRaises(ValueError, f)
+
+        for t in cases:
+            expected = pd.concat([t['A'].mean(), t['A'].std(), t['B'].mean(),
+                                  t['B'].std()], axis=1)
+            expected.columns = pd.MultiIndex.from_tuples([('ra', 'mean'), (
+                'ra', 'std'), ('rb', 'mean'), ('rb', 'std')])
+
+            result = t[['A', 'B']].agg({'A': {'ra': ['mean', 'std']},
+                                        'B': {'rb': ['mean', 'std']}})
+            assert_frame_equal(result, expected, check_like=True)
+
+            result = t.agg({'A': {'ra': ['mean', 'std']},
+                            'B': {'rb': ['mean', 'std']}})
+            assert_frame_equal(result, expected, check_like=True)
+
+    def test_selection_api_validation(self):
+        # GH 13500
+        index = date_range(datetime(2005, 1, 1),
+                           datetime(2005, 1, 10), freq='D')
+        df = pd.DataFrame({'date': index,
+                           'a': np.arange(len(index), dtype=np.int64)},
+                          index=pd.MultiIndex.from_arrays([
+                              np.arange(len(index), dtype=np.int64),
+                              index], names=['v', 'd']))
+        df_exp = pd.DataFrame({'a': np.arange(len(index), dtype=np.int64)},
+                              index=index)
+
+        # non DatetimeIndex
+        with tm.assertRaises(TypeError):
+            df.resample('2D', level='v')
+
+        with tm.assertRaises(ValueError):
+            df.resample('2D', on='date', level='d')
+
+        with tm.assertRaises(TypeError):
+            df.resample('2D', on=['a', 'date'])
+
+        with tm.assertRaises(KeyError):
+            df.resample('2D', level=['a', 'date'])
+
+        with tm.assertRaises(NotImplementedError):
+            df.resample('2D', level='d').asfreq()
+
+        with tm.assertRaises(NotImplementedError):
+            df.resample('2D', on='date').asfreq()
+
+        exp = df_exp.resample('2D').sum()
+        exp.index.name = 'date'
+        assert_frame_equal(exp, df.resample('2D', on='date').sum())
+
+        exp.index.name = 'd'
+        assert_frame_equal(exp, df.resample('2D', level='d').sum())
+
 
 class Base(object):
     """
@@ -502,265 +765,6 @@ class Base(object):
                         # Ignore these since some combinations are invalid
                         # (ex: doing mean with dtype of np.object)
                         pass
-
-    def test_agg(self):
-        # test with all three Resampler apis and TimeGrouper
-
-        np.random.seed(1234)
-        index = self.create_series().index
-        index.name = 'date'
-        df = pd.DataFrame(np.random.rand(10, 2),
-                          columns=list('AB'),
-                          index=index)
-        df_col = df.reset_index()
-        df_mult = df_col.copy()
-        df_mult.index = pd.MultiIndex.from_arrays([range(10), df.index],
-                                                  names=['index', 'date'])
-        r = df.resample('2D')
-        cases = [
-            r,
-            df_col.resample('2D', on='date'),
-            df_mult.resample('2D', level='date'),
-            df.groupby(pd.Grouper(freq='2D'))
-        ]
-
-        a_mean = r['A'].mean()
-        a_std = r['A'].std()
-        a_sum = r['A'].sum()
-        b_mean = r['B'].mean()
-        b_std = r['B'].std()
-        b_sum = r['B'].sum()
-
-        expected = pd.concat([a_mean, a_std, b_mean, b_std], axis=1)
-        expected.columns = pd.MultiIndex.from_product([['A', 'B'],
-                                                       ['mean', 'std']])
-        for t in cases:
-            result = t.aggregate([np.mean, np.std])
-            assert_frame_equal(result, expected)
-
-        expected = pd.concat([a_mean, b_std], axis=1)
-        for t in cases:
-            result = t.aggregate({'A': np.mean,
-                                  'B': np.std})
-            assert_frame_equal(result, expected, check_like=True)
-
-        expected = pd.concat([a_mean, a_std], axis=1)
-        expected.columns = pd.MultiIndex.from_tuples([('A', 'mean'),
-                                                      ('A', 'std')])
-        for t in cases:
-            result = t.aggregate({'A': ['mean', 'std']})
-            assert_frame_equal(result, expected)
-
-        expected = pd.concat([a_mean, a_sum], axis=1)
-        expected.columns = ['mean', 'sum']
-        for t in cases:
-            result = t['A'].aggregate(['mean', 'sum'])
-        assert_frame_equal(result, expected)
-
-        expected = pd.concat([a_mean, a_sum], axis=1)
-        expected.columns = pd.MultiIndex.from_tuples([('A', 'mean'),
-                                                      ('A', 'sum')])
-        for t in cases:
-            result = t.aggregate({'A': {'mean': 'mean', 'sum': 'sum'}})
-            assert_frame_equal(result, expected, check_like=True)
-
-        expected = pd.concat([a_mean, a_sum, b_mean, b_sum], axis=1)
-        expected.columns = pd.MultiIndex.from_tuples([('A', 'mean'),
-                                                      ('A', 'sum'),
-                                                      ('B', 'mean2'),
-                                                      ('B', 'sum2')])
-        for t in cases:
-            result = t.aggregate({'A': {'mean': 'mean', 'sum': 'sum'},
-                                  'B': {'mean2': 'mean', 'sum2': 'sum'}})
-            assert_frame_equal(result, expected, check_like=True)
-
-        expected = pd.concat([a_mean, a_std, b_mean, b_std], axis=1)
-        expected.columns = pd.MultiIndex.from_tuples([('A', 'mean'),
-                                                      ('A', 'std'),
-                                                      ('B', 'mean'),
-                                                      ('B', 'std')])
-        for t in cases:
-            result = t.aggregate({'A': ['mean', 'std'],
-                                  'B': ['mean', 'std']})
-            assert_frame_equal(result, expected, check_like=True)
-
-        expected = pd.concat([a_mean, a_sum, b_mean, b_sum], axis=1)
-        expected.columns = pd.MultiIndex.from_tuples([('r1', 'A', 'mean'),
-                                                      ('r1', 'A', 'sum'),
-                                                      ('r2', 'B', 'mean'),
-                                                      ('r2', 'B', 'sum')])
-
-    def test_agg_misc(self):
-        # test with all three Resampler apis and TimeGrouper
-
-        np.random.seed(1234)
-        index = self.create_series().index
-        index.name = 'date'
-        df = pd.DataFrame(np.random.rand(10, 2),
-                          columns=list('AB'),
-                          index=index)
-        df_col = df.reset_index()
-        df_mult = df_col.copy()
-        df_mult.index = pd.MultiIndex.from_arrays([range(10), df.index],
-                                                  names=['index', 'date'])
-
-        r = df.resample('2D')
-        cases = [
-            r,
-            df_col.resample('2D', on='date'),
-            df_mult.resample('2D', level='date'),
-            df.groupby(pd.Grouper(freq='2D'))
-        ]
-
-        # passed lambda
-        for t in cases:
-            result = t.agg({'A': np.sum,
-                            'B': lambda x: np.std(x, ddof=1)})
-            rcustom = t['B'].apply(lambda x: np.std(x, ddof=1))
-            expected = pd.concat([r['A'].sum(), rcustom], axis=1)
-            assert_frame_equal(result, expected, check_like=True)
-
-        # agg with renamers
-        expected = pd.concat([t['A'].sum(),
-                              t['B'].sum(),
-                              t['A'].mean(),
-                              t['B'].mean()],
-                             axis=1)
-        expected.columns = pd.MultiIndex.from_tuples([('result1', 'A'),
-                                                      ('result1', 'B'),
-                                                      ('result2', 'A'),
-                                                      ('result2', 'B')])
-        for t in cases:
-            result = t[['A', 'B']].agg(OrderedDict([('result1', np.sum),
-                                                    ('result2', np.mean)]))
-            assert_frame_equal(result, expected, check_like=True)
-
-        # agg with different hows
-        expected = pd.concat([t['A'].sum(),
-                              t['A'].std(),
-                              t['B'].mean(),
-                              t['B'].std()],
-                             axis=1)
-        expected.columns = pd.MultiIndex.from_tuples([('A', 'sum'),
-                                                      ('A', 'std'),
-                                                      ('B', 'mean'),
-                                                      ('B', 'std')])
-        for t in cases:
-            result = t.agg(OrderedDict([('A', ['sum', 'std']),
-                                        ('B', ['mean', 'std'])]))
-            assert_frame_equal(result, expected, check_like=True)
-
-        # equivalent of using a selection list / or not
-        for t in cases:
-            result = t[['A', 'B']].agg({'A': ['sum', 'std'],
-                                        'B': ['mean', 'std']})
-            assert_frame_equal(result, expected, check_like=True)
-
-        # series like aggs
-        for t in cases:
-            result = t['A'].agg({'A': ['sum', 'std']})
-            expected = pd.concat([t['A'].sum(),
-                                  t['A'].std()],
-                                 axis=1)
-            expected.columns = pd.MultiIndex.from_tuples([('A', 'sum'),
-                                                          ('A', 'std')])
-            assert_frame_equal(result, expected, check_like=True)
-
-            expected = pd.concat([t['A'].agg(['sum', 'std']),
-                                  t['A'].agg(['mean', 'std'])],
-                                 axis=1)
-            expected.columns = pd.MultiIndex.from_tuples([('A', 'sum'),
-                                                          ('A', 'std'),
-                                                          ('B', 'mean'),
-                                                          ('B', 'std')])
-            result = t['A'].agg({'A': ['sum', 'std'], 'B': ['mean', 'std']})
-            assert_frame_equal(result, expected, check_like=True)
-
-        # errors
-        # invalid names in the agg specification
-        for t in cases:
-            def f():
-                t[['A']].agg({'A': ['sum', 'std'],
-                              'B': ['mean', 'std']})
-
-            self.assertRaises(SpecificationError, f)
-
-    def test_agg_nested_dicts(self):
-
-        np.random.seed(1234)
-        index = self.create_series().index
-        index.name = 'date'
-        df = pd.DataFrame(np.random.rand(10, 2),
-                          columns=list('AB'),
-                          index=index)
-        df_col = df.reset_index()
-        df_mult = df_col.copy()
-        df_mult.index = pd.MultiIndex.from_arrays([range(10), df.index],
-                                                  names=['index', 'date'])
-        r = df.resample('2D')
-        cases = [
-            r,
-            df_col.resample('2D', on='date'),
-            df_mult.resample('2D', level='date'),
-            df.groupby(pd.Grouper(freq='2D'))
-        ]
-
-        for t in cases:
-            def f():
-                t.aggregate({'r1': {'A': ['mean', 'sum']},
-                             'r2': {'B': ['mean', 'sum']}})
-                self.assertRaises(ValueError, f)
-
-        for t in cases:
-            expected = pd.concat([t['A'].mean(), t['A'].std(), t['B'].mean(),
-                                  t['B'].std()], axis=1)
-            expected.columns = pd.MultiIndex.from_tuples([('ra', 'mean'), (
-                'ra', 'std'), ('rb', 'mean'), ('rb', 'std')])
-
-            result = t[['A', 'B']].agg({'A': {'ra': ['mean', 'std']},
-                                        'B': {'rb': ['mean', 'std']}})
-            assert_frame_equal(result, expected, check_like=True)
-
-            result = t.agg({'A': {'ra': ['mean', 'std']},
-                            'B': {'rb': ['mean', 'std']}})
-            assert_frame_equal(result, expected, check_like=True)
-
-    def test_selection_api_validation(self):
-        # GH 13500
-        index = self.create_series().index
-        df = pd.DataFrame({'date': index,
-                           'a': np.arange(len(index), dtype=np.int64)},
-                          index=pd.MultiIndex.from_arrays([
-                              np.arange(len(index), dtype=np.int64),
-                              index], names=['v', 'd']))
-        df_exp = pd.DataFrame({'a': np.arange(len(index), dtype=np.int64)},
-                              index=index)
-
-        # non DatetimeIndex
-        with tm.assertRaises(TypeError):
-            df.resample('2D', level='v')
-
-        with tm.assertRaises(ValueError):
-            df.resample('2D', on='date', level='d')
-
-        with tm.assertRaises(TypeError):
-            df.resample('2D', on=['a', 'date'])
-
-        with tm.assertRaises(KeyError):
-            df.resample('2D', level=['a', 'date'])
-
-        with tm.assertRaises(NotImplementedError):
-            df.resample('2D', level='d').asfreq()
-
-        with tm.assertRaises(NotImplementedError):
-            df.resample('2D', on='date').asfreq()
-
-        exp = df_exp.resample('2D').sum()
-        exp.index.name = 'date'
-        assert_frame_equal(exp, df.resample('2D', on='date').sum())
-
-        exp.index.name = 'd'
-        assert_frame_equal(exp, df.resample('2D', level='d').sum())
 
 
 class TestDatetimeIndex(Base, tm.TestCase):
@@ -2054,6 +2058,22 @@ class TestPeriodIndex(Base, tm.TestCase):
         expected = frame.to_timestamp().reindex(new_index).to_period()
         result = frame.resample('1H').asfreq()
         assert_frame_equal(result, expected)
+
+    def test_selection(self):
+        index = self.create_series().index
+        # This is a bug, these should be implemented
+        # GH 14008
+        df = pd.DataFrame({'date': index,
+                           'a': np.arange(len(index), dtype=np.int64)},
+                          index=pd.MultiIndex.from_arrays([
+                              np.arange(len(index), dtype=np.int64),
+                              index], names=['v', 'd']))
+
+        with tm.assertRaises(NotImplementedError):
+            df.resample('2D', on='date')
+
+        with tm.assertRaises(NotImplementedError):
+            df.resample('2D', level='d')
 
     def test_annual_upsample_D_s_f(self):
         self._check_annual_upsample_cases('D', 'start', 'ffill')

--- a/pandas/tseries/tests/test_resample.py
+++ b/pandas/tseries/tests/test_resample.py
@@ -386,8 +386,6 @@ class TestResampleAPI(tm.TestCase):
         assert_frame_equal(result, expected)
 
 
-
-
 class Base(object):
     """
     base class for resampling testing, calling
@@ -515,7 +513,6 @@ class Base(object):
                           columns=list('AB'),
                           index=index)
         df_col = df.reset_index()
-        print df_col
         df_mult = df_col.copy()
         df_mult.index = pd.MultiIndex.from_arrays([range(10), df.index],
                                                   names=['index', 'date'])
@@ -733,11 +730,11 @@ class Base(object):
         index = self.create_series().index
         df = pd.DataFrame({'date': index,
                            'a': np.arange(len(index), dtype=np.int64)},
-                           index=pd.MultiIndex.from_arrays([
-                               np.arange(len(index), dtype=np.int64),
-                               index], names=['v', 'd']))
+                          index=pd.MultiIndex.from_arrays([
+                              np.arange(len(index), dtype=np.int64),
+                              index], names=['v', 'd']))
         df_exp = pd.DataFrame({'a': np.arange(len(index), dtype=np.int64)},
-                               index=index)
+                              index=index)
 
         # non DatetimeIndex
         with tm.assertRaises(TypeError):

--- a/pandas/tseries/tests/test_resample.py
+++ b/pandas/tseries/tests/test_resample.py
@@ -385,6 +385,8 @@ class TestResampleAPI(tm.TestCase):
         result = r.agg({'r1': 'mean', 'r2': 'sum'})
         assert_frame_equal(result, expected)
 
+    # TODO: once GH 14008 is fixed, move these tests into
+    # `Base` test class
     def test_agg(self):
         # test with all three Resampler apis and TimeGrouper
 
@@ -635,10 +637,11 @@ class TestResampleAPI(tm.TestCase):
         with tm.assertRaises(KeyError):
             df.resample('2D', level=['a', 'date'])
 
-        with tm.assertRaises(NotImplementedError):
+        # upsampling not allowed
+        with tm.assertRaises(ValueError):
             df.resample('2D', level='d').asfreq()
 
-        with tm.assertRaises(NotImplementedError):
+        with tm.assertRaises(ValueError):
             df.resample('2D', on='date').asfreq()
 
         exp = df_exp.resample('2D').sum()


### PR DESCRIPTION
- [x] closes #13500
- [x] tests added / passed
- [x] passes `git diff upstream/master | flake8 --diff`
- [x] whatsnew entry

My only question here is if `on=` is the keyword name for picking a column - in a `TimeGrouper` that's called `key`.  But `on` is what was used in the rolling selection (and elsewhere) so seems consistent.

```
In [63]: df = pd.DataFrame({'date': pd.date_range('2015-01-01', freq='W', periods=5),
   ....:                    'a': np.arange(5)},
   ....:                   index=pd.MultiIndex.from_arrays([
   ....:                            [1,2,3,4,5],
   ....:                            pd.date_range('2015-01-01', freq='W', periods=5)],
   ....:                        names=['v','d']))
   ....: 

In [64]: df
Out[64]: 
              a       date
v d                       
1 2015-01-04  0 2015-01-04
2 2015-01-11  1 2015-01-11
3 2015-01-18  2 2015-01-18
4 2015-01-25  3 2015-01-25
5 2015-02-01  4 2015-02-01

In [65]: df.resample('M', on='date').sum()
Out[65]: 
            a
date         
2015-01-31  6
2015-02-28  4

In [66]: df.resample('M', level='d').sum()
Out[66]: 
            a
d            
2015-01-31  6
2015-02-28  4
```
