### PR TITLE
ENH: allow exact matches in time-based .rolling()

### DIFF
--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -5567,11 +5567,12 @@ class NDFrame(PandasObject):
         from pandas.core import window as rwindow
 
         @Appender(rwindow.rolling.__doc__)
-        def rolling(self, window, min_periods=None, freq=None, center=False,
-                    win_type=None, on=None, axis=0):
+        def rolling(self, window, min_periods=None, left_closed=None,
+                    freq=None, center=False, win_type=None, on=None, axis=0):
             axis = self._get_axis_number(axis)
             return rwindow.rolling(self, window=window,
-                                   min_periods=min_periods, freq=freq,
+                                   min_periods=min_periods,
+                                   left_closed=left_closed, freq=freq,
                                    center=center, win_type=win_type,
                                    on=on, axis=axis)
 

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -5568,12 +5568,12 @@ class NDFrame(PandasObject):
 
         @Appender(rwindow.rolling.__doc__)
         def rolling(self, window, min_periods=None, freq=None, center=False,
-                    win_type=None, on=None, axis=0, left_closed=None):
+                    win_type=None, on=None, axis=0, closed='right'):
             axis = self._get_axis_number(axis)
             return rwindow.rolling(self, window=window,
                                    min_periods=min_periods, freq=freq,
                                    center=center, win_type=win_type,
-                                   on=on, axis=axis, left_closed=left_closed)
+                                   on=on, axis=axis, closed=closed)
 
         cls.rolling = rolling
 

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -5567,14 +5567,13 @@ class NDFrame(PandasObject):
         from pandas.core import window as rwindow
 
         @Appender(rwindow.rolling.__doc__)
-        def rolling(self, window, min_periods=None, left_closed=None,
-                    freq=None, center=False, win_type=None, on=None, axis=0):
+        def rolling(self, window, min_periods=None, freq=None, center=False,
+                    win_type=None, on=None, axis=0, left_closed=None):
             axis = self._get_axis_number(axis)
             return rwindow.rolling(self, window=window,
-                                   min_periods=min_periods,
-                                   left_closed=left_closed, freq=freq,
+                                   min_periods=min_periods, freq=freq,
                                    center=center, win_type=win_type,
-                                   on=on, axis=axis)
+                                   on=on, axis=axis, left_closed=left_closed)
 
         cls.rolling = rolling
 

--- a/pandas/core/window.py
+++ b/pandas/core/window.py
@@ -376,6 +376,9 @@ class Window(_Window):
         .. versionadded:: 0.19.0
 
     axis : int or string, default 0
+    closed: 'right' or 'both', default 'right'
+        For offset-based windows, make the interval closed only on the right
+        or on both endpoints.
 
     Returns
     -------
@@ -453,6 +456,14 @@ class Window(_Window):
     2013-01-01 09:00:02  1.0
     2013-01-01 09:00:03  3.0
     2013-01-01 09:00:05  NaN
+    2013-01-01 09:00:06  4.0
+
+    >>> df.rolling('2s', closed='both').sum()
+                           B
+    2013-01-01 09:00:00  0.0
+    2013-01-01 09:00:02  1.0
+    2013-01-01 09:00:03  3.0
+    2013-01-01 09:00:05  2.0
     2013-01-01 09:00:06  4.0
 
     Notes

--- a/pandas/core/window.py
+++ b/pandas/core/window.py
@@ -998,12 +998,12 @@ class _Rolling_and_Expanding(_Rolling):
 
 class Rolling(_Rolling_and_Expanding):
     _attributes = ['window', 'min_periods', 'freq', 'center', 'win_type',
-                   'axis', 'on', 'left_closed']
+                   'axis', 'on', 'closed']
 
     def __init__(self, obj, window=None, min_periods=None, freq=None,
                  center=False, win_type=None, axis=0, on=None,
-                 left_closed=None, **kwargs):
-        self.left_closed = left_closed
+                 closed='right', **kwargs):
+        self.closed = closed
         super(Rolling, self).__init__(obj=obj, window=window,
                                       min_periods=min_periods, freq=freq,
                                       center=center, win_type=win_type,
@@ -1032,6 +1032,9 @@ class Rolling(_Rolling_and_Expanding):
     def validate(self):
         super(Rolling, self).validate()
 
+        if self.closed not in ['right', 'both']:
+            raise ValueError("closed must be right or both")
+
         # we allow rolling on a datetimelike index
         if (self.is_datetimelike and
                 isinstance(self.window, (compat.string_types, DateOffset))):
@@ -1056,12 +1059,9 @@ class Rolling(_Rolling_and_Expanding):
                                           "for datetimelike and offset "
                                           "based windows")
 
-            if self.left_closed is not None and not is_bool(self.left_closed):
-                raise ValueError("left_closed must be a boolean")
-
             # this will raise ValueError on non-fixed freqs
             self.window = freq.nanos
-            if self.left_closed:
+            if self.closed == 'both':
                 self.window += 1
             self.win_type = 'freq'
 
@@ -1069,8 +1069,8 @@ class Rolling(_Rolling_and_Expanding):
             if self.min_periods is None:
                 self.min_periods = 1
         else:
-            if self.left_closed is not None:
-                raise ValueError("left_closed only valid for datetimelike "
+            if self.closed == 'both':
+                raise ValueError("closed=both only valid for datetimelike "
                                  "and offset based windows")
             elif not is_integer(self.window):
                 raise ValueError("window must be an integer")

--- a/pandas/core/window.py
+++ b/pandas/core/window.py
@@ -997,12 +997,12 @@ class _Rolling_and_Expanding(_Rolling):
 
 
 class Rolling(_Rolling_and_Expanding):
-    _attributes = ['window', 'min_periods', 'left_closed', 'freq',
-                   'center', 'win_type', 'axis', 'on']
+    _attributes = ['window', 'min_periods', 'freq', 'center', 'win_type',
+                   'axis', 'on', 'left_closed']
 
-    def __init__(self, obj, window=None, min_periods=None, left_closed=None,
-                 freq=None, center=False, win_type=None, axis=0, on=None,
-                 **kwargs):
+    def __init__(self, obj, window=None, min_periods=None, freq=None,
+                 center=False, win_type=None, axis=0, on=None,
+                 left_closed=None, **kwargs):
         self.left_closed = left_closed
         super(Rolling, self).__init__(obj=obj, window=window,
                                       min_periods=min_periods, freq=freq,

--- a/pandas/tests/test_window.py
+++ b/pandas/tests/test_window.py
@@ -3347,9 +3347,9 @@ class TestRollingTS(tm.TestCase):
         tm.assert_frame_equal(result, expected)
 
         df = DataFrame({'B': [1] * 3},
-                        index=[Timestamp('20130101 09:00:30'),
-                               Timestamp('20130101 09:01:00'),
-                               Timestamp('20130101 09:02:00')])
+                       index=[Timestamp('20130101 09:00:30'),
+                              Timestamp('20130101 09:01:00'),
+                              Timestamp('20130101 09:02:00')])
         expected = DataFrame({'B': [1., 2., 2.]},
                              index=[Timestamp('20130101 09:00:30'),
                                     Timestamp('20130101 09:01:00'),

--- a/pandas/tests/test_window.py
+++ b/pandas/tests/test_window.py
@@ -3351,9 +3351,9 @@ class TestRollingTS(tm.TestCase):
                                Timestamp('20130101 09:01:00'),
                                Timestamp('20130101 09:02:00')])
         expected = DataFrame({'B': [1., 2., 2.]},
-                        index=[Timestamp('20130101 09:00:30'),
-                               Timestamp('20130101 09:01:00'),
-                               Timestamp('20130101 09:02:00')])
+                             index=[Timestamp('20130101 09:00:30'),
+                                    Timestamp('20130101 09:01:00'),
+                                    Timestamp('20130101 09:02:00')])
         result = df.rolling('1min', left_closed=True).sum()
         tm.assert_frame_equal(result, expected)
 

--- a/pandas/tests/test_window.py
+++ b/pandas/tests/test_window.py
@@ -3307,9 +3307,6 @@ class TestRollingTS(tm.TestCase):
         expected = df.rolling('4s').count()
         result = df.rolling('3s', closed='both').count()
         tm.assert_frame_equal(result, expected)
-        expected = df.rolling('4s').sum()
-        result = df.rolling('3s', closed='both').sum()
-        tm.assert_frame_equal(result, expected)
         expected = df.rolling('3s').count()
         result = df.rolling('3s', closed='right').count()
         tm.assert_frame_equal(result, expected)
@@ -3317,12 +3314,6 @@ class TestRollingTS(tm.TestCase):
         df.index = df.index - Timestamp('20130101 09:00:00')
         expected = df.rolling('4s').count()
         result = df.rolling('3s', closed='both').count()
-        tm.assert_frame_equal(result, expected)
-        expected = df.rolling('4s').sum()
-        result = df.rolling('3s', closed='both').sum()
-        tm.assert_frame_equal(result, expected)
-        expected = df.rolling('3s').sum()
-        result = df.rolling('3s', closed='right').sum()
         tm.assert_frame_equal(result, expected)
 
         df = DataFrame({'B': [1, 1, 2, np.nan, 4],
@@ -3334,17 +3325,6 @@ class TestRollingTS(tm.TestCase):
         expected = df.rolling('4s', on='timestamp').count()
         result = df.rolling('3s', on='timestamp', closed='both').count()
         tm.assert_frame_equal(result, expected)
-        expected = df.rolling('4s', on='timestamp').sum()
-        result = df.rolling('3s', on='timestamp', closed='both').sum()
-        tm.assert_frame_equal(result, expected)
-
-        df['timestamp'] = df['timestamp'] - Timestamp('20130101 09:00:00')
-        expected = df.rolling('4s', on='timestamp').count()
-        result = df.rolling('3s', on='timestamp', closed='both').count()
-        tm.assert_frame_equal(result, expected)
-        expected = df.rolling('4s', on='timestamp').sum()
-        result = df.rolling('3s', on='timestamp', closed='both').sum()
-        tm.assert_frame_equal(result, expected)
 
         df = DataFrame({'B': [1, 1, 2, np.nan, 4]},
                        index=[Timestamp('20130101'),
@@ -3355,75 +3335,16 @@ class TestRollingTS(tm.TestCase):
         expected = df.rolling('4d').count()
         result = df.rolling('3d', closed='both').count()
         tm.assert_frame_equal(result, expected)
-        expected = df.rolling('4d').sum()
-        result = df.rolling('3d', closed='both').sum()
-        tm.assert_frame_equal(result, expected)
-        expected = df.rolling('3d').count()
-        result = df.rolling('3d', closed='right').count()
-        tm.assert_frame_equal(result, expected)
-
-        df.index = df.index - Timestamp('20130101')
-        expected = df.rolling('4d').count()
-        result = df.rolling('3d', closed='both').count()
-        tm.assert_frame_equal(result, expected)
-        expected = df.rolling('4d').sum()
-        result = df.rolling('3d', closed='both').sum()
-        tm.assert_frame_equal(result, expected)
-        expected = df.rolling('3d').count()
-        result = df.rolling('3d', closed='right').count()
-        tm.assert_frame_equal(result, expected)
-
-        df = DataFrame({'B': [1, 1, 2, np.nan, 4],
-                       'timestamp': [Timestamp('20130101'),
-                                     Timestamp('20130103'),
-                                     Timestamp('20130104'),
-                                     Timestamp('20130106'),
-                                     Timestamp('20130107')]})
-        expected = df.rolling('4d', on='timestamp').count()
-        result = df.rolling('3d', on='timestamp', closed='both').count()
-        tm.assert_frame_equal(result, expected)
-        expected = df.rolling('4d', on='timestamp').sum()
-        result = df.rolling('3d', on='timestamp', closed='both').sum()
-        tm.assert_frame_equal(result, expected)
-
-        df['timestamp'] = df['timestamp'] - Timestamp('20130101')
-        expected = df.rolling('4d', on='timestamp').count()
-        result = df.rolling('3d', on='timestamp', closed='both').count()
-        tm.assert_frame_equal(result, expected)
-        expected = df.rolling('4d', on='timestamp').sum()
-        result = df.rolling('3d', on='timestamp', closed='both').sum()
-        tm.assert_frame_equal(result, expected)
 
         df = DataFrame({'B': [1] * 3},
                        index=[Timestamp('20130101 09:00:30'),
                               Timestamp('20130101 09:01:00'),
                               Timestamp('20130101 09:02:00')])
-        expected = DataFrame({'B': [1, 2, 2]},
-                             index=[Timestamp('20130101 09:00:30'),
-                                    Timestamp('20130101 09:01:00'),
-                                    Timestamp('20130101 09:02:00')])
-        result = df.rolling('1min', closed='both').count()
         expected = DataFrame({'B': [1., 2., 2.]},
                              index=[Timestamp('20130101 09:00:30'),
                                     Timestamp('20130101 09:01:00'),
                                     Timestamp('20130101 09:02:00')])
-        result = df.rolling('1min', closed='both').sum()
-        tm.assert_frame_equal(result, expected)
-
-        df = DataFrame({'B': [1] * 3,
-                        'timestamp': [Timestamp('20130101 09:00:30'),
-                                      Timestamp('20130101 09:01:00'),
-                                      Timestamp('20130101 09:02:00')]})
-        expected = DataFrame({'B': [1, 2, 2],
-                              'timestamp': [Timestamp('20130101 09:00:30'),
-                                            Timestamp('20130101 09:01:00'),
-                                            Timestamp('20130101 09:02:00')]})
-        result = df.rolling('1min', on='timestamp', closed='both').count()
-        expected = DataFrame({'B': [1., 2., 2.],
-                              'timestamp': [Timestamp('20130101 09:00:30'),
-                                            Timestamp('20130101 09:01:00'),
-                                            Timestamp('20130101 09:02:00')]})
-        result = df.rolling('1min', on='timestamp', closed='both').sum()
+        result = df.rolling('1min', closed='both').count()
         tm.assert_frame_equal(result, expected)
 
     def test_ragged_sum(self):

--- a/pandas/tests/test_window.py
+++ b/pandas/tests/test_window.py
@@ -3357,6 +3357,9 @@ class TestRollingTS(tm.TestCase):
         result = df.rolling('1min', left_closed=True).sum()
         tm.assert_frame_equal(result, expected)
 
+        with self.assertRaises(ValueError):
+            df.rolling('1min', left_closed="'tis wrong")
+
     def test_ragged_sum(self):
 
         df = self.ragged

--- a/pandas/tests/test_window.py
+++ b/pandas/tests/test_window.py
@@ -3310,6 +3310,9 @@ class TestRollingTS(tm.TestCase):
         expected = df.rolling('4s').sum()
         result = df.rolling('3s', closed='both').sum()
         tm.assert_frame_equal(result, expected)
+        expected = df.rolling('3s').count()
+        result = df.rolling('3s', closed='right').count()
+        tm.assert_frame_equal(result, expected)
 
         df.index = df.index - Timestamp('20130101 09:00:00')
         expected = df.rolling('4s').count()
@@ -3317,6 +3320,9 @@ class TestRollingTS(tm.TestCase):
         tm.assert_frame_equal(result, expected)
         expected = df.rolling('4s').sum()
         result = df.rolling('3s', closed='both').sum()
+        tm.assert_frame_equal(result, expected)
+        expected = df.rolling('3s').sum()
+        result = df.rolling('3s', closed='right').sum()
         tm.assert_frame_equal(result, expected)
 
         df = DataFrame({'B': [1, 1, 2, np.nan, 4],
@@ -3352,6 +3358,9 @@ class TestRollingTS(tm.TestCase):
         expected = df.rolling('4d').sum()
         result = df.rolling('3d', closed='both').sum()
         tm.assert_frame_equal(result, expected)
+        expected = df.rolling('3d').count()
+        result = df.rolling('3d', closed='right').count()
+        tm.assert_frame_equal(result, expected)
 
         df.index = df.index - Timestamp('20130101')
         expected = df.rolling('4d').count()
@@ -3359,6 +3368,9 @@ class TestRollingTS(tm.TestCase):
         tm.assert_frame_equal(result, expected)
         expected = df.rolling('4d').sum()
         result = df.rolling('3d', closed='both').sum()
+        tm.assert_frame_equal(result, expected)
+        expected = df.rolling('3d').count()
+        result = df.rolling('3d', closed='right').count()
         tm.assert_frame_equal(result, expected)
 
         df = DataFrame({'B': [1, 1, 2, np.nan, 4],

--- a/pandas/tests/test_window.py
+++ b/pandas/tests/test_window.py
@@ -3346,6 +3346,16 @@ class TestRollingTS(tm.TestCase):
                             on='timestamp').sum()
         tm.assert_frame_equal(result, expected)
 
+        df = DataFrame({'B': [1] * 3},
+                        index=[Timestamp('20130101 09:00:30'),
+                               Timestamp('20130101 09:01:00'),
+                               Timestamp('20130101 09:02:00')])
+        expected = DataFrame({'B': [1., 2., 2.]},
+                        index=[Timestamp('20130101 09:00:30'),
+                               Timestamp('20130101 09:01:00'),
+                               Timestamp('20130101 09:02:00')])
+        result = df.rolling('1min', left_closed=True).sum()
+        tm.assert_frame_equal(result, expected)
 
     def test_ragged_sum(self):
 

--- a/pandas/tests/test_window.py
+++ b/pandas/tests/test_window.py
@@ -3288,7 +3288,7 @@ class TestRollingTS(tm.TestCase):
         result = df.rolling('2s', min_periods=1).sum()
         tm.assert_frame_equal(result, expected)
 
-    def test_left_closed(self):
+    def test_closed(self):
 
         df = DataFrame({'B': [1, 1, 2, np.nan, 4]},
                        index=[Timestamp('20130101 09:00:00'),
@@ -3297,10 +3297,10 @@ class TestRollingTS(tm.TestCase):
                               Timestamp('20130101 09:00:05'),
                               Timestamp('20130101 09:00:06')])
         expected = df.rolling('4s').count()
-        result = df.rolling('3s', left_closed=True).count()
+        result = df.rolling('3s', closed='both').count()
         tm.assert_frame_equal(result, expected)
         expected = df.rolling('4s').sum()
-        result = df.rolling('3s', left_closed=True).sum()
+        result = df.rolling('3s', closed='both').sum()
         tm.assert_frame_equal(result, expected)
 
         df = DataFrame({'B': [1, 1, 2, np.nan, 4],
@@ -3310,11 +3310,11 @@ class TestRollingTS(tm.TestCase):
                                       Timestamp('20130101 09:00:05'),
                                       Timestamp('20130101 09:00:06')]})
         expected = df.rolling('4s', on='timestamp').count()
-        result = df.rolling('3s', left_closed=True,
+        result = df.rolling('3s', closed='both',
                             on='timestamp').count()
         tm.assert_frame_equal(result, expected)
         expected = df.rolling('4s', on='timestamp').sum()
-        result = df.rolling('3s', left_closed=True,
+        result = df.rolling('3s', closed='both',
                             on='timestamp').sum()
         tm.assert_frame_equal(result, expected)
 
@@ -3325,10 +3325,10 @@ class TestRollingTS(tm.TestCase):
                               Timestamp('20130106'),
                               Timestamp('20130107')])
         expected = df.rolling('4d').count()
-        result = df.rolling('3d', left_closed=True).count()
+        result = df.rolling('3d', closed='both').count()
         tm.assert_frame_equal(result, expected)
         expected = df.rolling('4d').sum()
-        result = df.rolling('3d', left_closed=True).sum()
+        result = df.rolling('3d', closed='both').sum()
         tm.assert_frame_equal(result, expected)
 
         df = DataFrame({'B': [1, 1, 2, np.nan, 4],
@@ -3338,11 +3338,11 @@ class TestRollingTS(tm.TestCase):
                                      Timestamp('20130106'),
                                      Timestamp('20130107')]})
         expected = df.rolling('4d', on='timestamp').count()
-        result = df.rolling('3d', left_closed=True,
+        result = df.rolling('3d', closed='both',
                             on='timestamp').count()
         tm.assert_frame_equal(result, expected)
         expected = df.rolling('4d', on='timestamp').sum()
-        result = df.rolling('3d', left_closed=True,
+        result = df.rolling('3d', closed='both',
                             on='timestamp').sum()
         tm.assert_frame_equal(result, expected)
 
@@ -3354,11 +3354,11 @@ class TestRollingTS(tm.TestCase):
                              index=[Timestamp('20130101 09:00:30'),
                                     Timestamp('20130101 09:01:00'),
                                     Timestamp('20130101 09:02:00')])
-        result = df.rolling('1min', left_closed=True).sum()
+        result = df.rolling('1min', closed='both').sum()
         tm.assert_frame_equal(result, expected)
 
         with self.assertRaises(ValueError):
-            df.rolling('1min', left_closed="'tis wrong")
+            df.rolling('1min', closed="'tis wrong")
 
     def test_ragged_sum(self):
 

--- a/pandas/tests/test_window.py
+++ b/pandas/tests/test_window.py
@@ -3288,6 +3288,65 @@ class TestRollingTS(tm.TestCase):
         result = df.rolling('2s', min_periods=1).sum()
         tm.assert_frame_equal(result, expected)
 
+    def test_left_closed(self):
+
+        df = DataFrame({'B': [1, 1, 2, np.nan, 4]},
+                       index=[Timestamp('20130101 09:00:00'),
+                              Timestamp('20130101 09:00:02'),
+                              Timestamp('20130101 09:00:03'),
+                              Timestamp('20130101 09:00:05'),
+                              Timestamp('20130101 09:00:06')])
+        expected = df.rolling('4s').count()
+        result = df.rolling('3s', left_closed=True).count()
+        tm.assert_frame_equal(result, expected)
+        expected = df.rolling('4s').sum()
+        result = df.rolling('3s', left_closed=True).sum()
+        tm.assert_frame_equal(result, expected)
+
+        df = DataFrame({'B': [1, 1, 2, np.nan, 4],
+                        'timestamp': [Timestamp('20130101 09:00:00'),
+                                      Timestamp('20130101 09:00:02'),
+                                      Timestamp('20130101 09:00:03'),
+                                      Timestamp('20130101 09:00:05'),
+                                      Timestamp('20130101 09:00:06')]})
+        expected = df.rolling('4s', on='timestamp').count()
+        result = df.rolling('3s', left_closed=True,
+                            on='timestamp').count()
+        tm.assert_frame_equal(result, expected)
+        expected = df.rolling('4s', on='timestamp').sum()
+        result = df.rolling('3s', left_closed=True,
+                            on='timestamp').sum()
+        tm.assert_frame_equal(result, expected)
+
+        df = DataFrame({'B': [1, 1, 2, np.nan, 4]},
+                       index=[Timestamp('20130101'),
+                              Timestamp('20130103'),
+                              Timestamp('20130104'),
+                              Timestamp('20130106'),
+                              Timestamp('20130107')])
+        expected = df.rolling('4d').count()
+        result = df.rolling('3d', left_closed=True).count()
+        tm.assert_frame_equal(result, expected)
+        expected = df.rolling('4d').sum()
+        result = df.rolling('3d', left_closed=True).sum()
+        tm.assert_frame_equal(result, expected)
+
+        df = DataFrame({'B': [1, 1, 2, np.nan, 4],
+                       'timestamp': [Timestamp('20130101'),
+                                     Timestamp('20130103'),
+                                     Timestamp('20130104'),
+                                     Timestamp('20130106'),
+                                     Timestamp('20130107')]})
+        expected = df.rolling('4d', on='timestamp').count()
+        result = df.rolling('3d', left_closed=True,
+                            on='timestamp').count()
+        tm.assert_frame_equal(result, expected)
+        expected = df.rolling('4d', on='timestamp').sum()
+        result = df.rolling('3d', left_closed=True,
+                            on='timestamp').sum()
+        tm.assert_frame_equal(result, expected)
+
+
     def test_ragged_sum(self):
 
         df = self.ragged

--- a/pandas/tests/test_window.py
+++ b/pandas/tests/test_window.py
@@ -3290,12 +3290,28 @@ class TestRollingTS(tm.TestCase):
 
     def test_closed(self):
 
+        # closed=both only valid for datetimelike
+        with self.assertRaises(ValueError):
+            self.regular.rolling(window=3, closed='both')
+
+        # closed must be 'right' or 'both'
+        with self.assertRaises(ValueError):
+            self.regular.rolling(window='1min', closed="'tis wrong")
+
         df = DataFrame({'B': [1, 1, 2, np.nan, 4]},
                        index=[Timestamp('20130101 09:00:00'),
                               Timestamp('20130101 09:00:02'),
                               Timestamp('20130101 09:00:03'),
                               Timestamp('20130101 09:00:05'),
                               Timestamp('20130101 09:00:06')])
+        expected = df.rolling('4s').count()
+        result = df.rolling('3s', closed='both').count()
+        tm.assert_frame_equal(result, expected)
+        expected = df.rolling('4s').sum()
+        result = df.rolling('3s', closed='both').sum()
+        tm.assert_frame_equal(result, expected)
+
+        df.index = df.index - Timestamp('20130101 09:00:00')
         expected = df.rolling('4s').count()
         result = df.rolling('3s', closed='both').count()
         tm.assert_frame_equal(result, expected)
@@ -3310,12 +3326,18 @@ class TestRollingTS(tm.TestCase):
                                       Timestamp('20130101 09:00:05'),
                                       Timestamp('20130101 09:00:06')]})
         expected = df.rolling('4s', on='timestamp').count()
-        result = df.rolling('3s', closed='both',
-                            on='timestamp').count()
+        result = df.rolling('3s', on='timestamp', closed='both').count()
         tm.assert_frame_equal(result, expected)
         expected = df.rolling('4s', on='timestamp').sum()
-        result = df.rolling('3s', closed='both',
-                            on='timestamp').sum()
+        result = df.rolling('3s', on='timestamp', closed='both').sum()
+        tm.assert_frame_equal(result, expected)
+
+        df['timestamp'] = df['timestamp'] - Timestamp('20130101 09:00:00')
+        expected = df.rolling('4s', on='timestamp').count()
+        result = df.rolling('3s', on='timestamp', closed='both').count()
+        tm.assert_frame_equal(result, expected)
+        expected = df.rolling('4s', on='timestamp').sum()
+        result = df.rolling('3s', on='timestamp', closed='both').sum()
         tm.assert_frame_equal(result, expected)
 
         df = DataFrame({'B': [1, 1, 2, np.nan, 4]},
@@ -3331,6 +3353,14 @@ class TestRollingTS(tm.TestCase):
         result = df.rolling('3d', closed='both').sum()
         tm.assert_frame_equal(result, expected)
 
+        df.index = df.index - Timestamp('20130101')
+        expected = df.rolling('4d').count()
+        result = df.rolling('3d', closed='both').count()
+        tm.assert_frame_equal(result, expected)
+        expected = df.rolling('4d').sum()
+        result = df.rolling('3d', closed='both').sum()
+        tm.assert_frame_equal(result, expected)
+
         df = DataFrame({'B': [1, 1, 2, np.nan, 4],
                        'timestamp': [Timestamp('20130101'),
                                      Timestamp('20130103'),
@@ -3338,18 +3368,29 @@ class TestRollingTS(tm.TestCase):
                                      Timestamp('20130106'),
                                      Timestamp('20130107')]})
         expected = df.rolling('4d', on='timestamp').count()
-        result = df.rolling('3d', closed='both',
-                            on='timestamp').count()
+        result = df.rolling('3d', on='timestamp', closed='both').count()
         tm.assert_frame_equal(result, expected)
         expected = df.rolling('4d', on='timestamp').sum()
-        result = df.rolling('3d', closed='both',
-                            on='timestamp').sum()
+        result = df.rolling('3d', on='timestamp', closed='both').sum()
+        tm.assert_frame_equal(result, expected)
+
+        df['timestamp'] = df['timestamp'] - Timestamp('20130101')
+        expected = df.rolling('4d', on='timestamp').count()
+        result = df.rolling('3d', on='timestamp', closed='both').count()
+        tm.assert_frame_equal(result, expected)
+        expected = df.rolling('4d', on='timestamp').sum()
+        result = df.rolling('3d', on='timestamp', closed='both').sum()
         tm.assert_frame_equal(result, expected)
 
         df = DataFrame({'B': [1] * 3},
                        index=[Timestamp('20130101 09:00:30'),
                               Timestamp('20130101 09:01:00'),
                               Timestamp('20130101 09:02:00')])
+        expected = DataFrame({'B': [1, 2, 2]},
+                             index=[Timestamp('20130101 09:00:30'),
+                                    Timestamp('20130101 09:01:00'),
+                                    Timestamp('20130101 09:02:00')])
+        result = df.rolling('1min', closed='both').count()
         expected = DataFrame({'B': [1., 2., 2.]},
                              index=[Timestamp('20130101 09:00:30'),
                                     Timestamp('20130101 09:01:00'),
@@ -3357,8 +3398,21 @@ class TestRollingTS(tm.TestCase):
         result = df.rolling('1min', closed='both').sum()
         tm.assert_frame_equal(result, expected)
 
-        with self.assertRaises(ValueError):
-            df.rolling('1min', closed="'tis wrong")
+        df = DataFrame({'B': [1] * 3,
+                        'timestamp': [Timestamp('20130101 09:00:30'),
+                                      Timestamp('20130101 09:01:00'),
+                                      Timestamp('20130101 09:02:00')]})
+        expected = DataFrame({'B': [1, 2, 2],
+                              'timestamp': [Timestamp('20130101 09:00:30'),
+                                            Timestamp('20130101 09:01:00'),
+                                            Timestamp('20130101 09:02:00')]})
+        result = df.rolling('1min', on='timestamp', closed='both').count()
+        expected = DataFrame({'B': [1., 2., 2.],
+                              'timestamp': [Timestamp('20130101 09:00:30'),
+                                            Timestamp('20130101 09:01:00'),
+                                            Timestamp('20130101 09:02:00')]})
+        result = df.rolling('1min', on='timestamp', closed='both').sum()
+        tm.assert_frame_equal(result, expected)
 
     def test_ragged_sum(self):
 


### PR DESCRIPTION
- [x] closes #13965
- [x] tests added / passed
- [x] passes `git diff upstream/master | flake8 --diff`
- [ ] whatsnew entry

TODO: update docs.
