### PR TITLE
BUG: yield correct Series subclass in df.iterrows() (#13977)

### DIFF
--- a/doc/source/whatsnew/v0.19.0.txt
+++ b/doc/source/whatsnew/v0.19.0.txt
@@ -1097,3 +1097,5 @@ Bug Fixes
 - Bug in ``.to_string()`` when called with an integer ``line_width`` and ``index=False`` raises an UnboundLocalError exception because ``idx`` referenced before assignment.
 
 - Bug in ``read_csv()``, where aliases for utf-xx (e.g. UTF-xx, UTF_xx, utf_xx) raised UnicodeDecodeError (:issue:`13549`)
+
+- Bug in ``DataFrame.iterrows()`` not yielding proper ``Series`` subclasses (:issue:`13898`)

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -694,8 +694,9 @@ class DataFrame(NDFrame):
 
         """
         columns = self.columns
+        klass = self._constructor_sliced
         for k, v in zip(self.index, self.values):
-            s = Series(v, index=columns, name=k)
+            s = klass(v, index=columns, name=k)
             yield k, s
 
     def itertuples(self, index=True, name="Pandas"):

--- a/pandas/tests/frame/test_subclass.py
+++ b/pandas/tests/frame/test_subclass.py
@@ -211,6 +211,13 @@ class TestDataFrameSubclassing(tm.TestCase, TestData):
         tm.assertIsInstance(res2, tm.SubclassedDataFrame)
         tm.assert_frame_equal(res2, exp1)
 
+    def test_subclass_iterrows(self):
+        # GH 13977
+        df = tm.SubclassedDataFrame({'a': [1]})
+        for i, row in df.iterrows():
+            tm.assertIsInstance(row, tm.SubclassedSeries)
+            tm.assert_series_equal(row, df.loc[i])
+
     def test_subclass_sparse_slice(self):
         rows = [[1.0, 2.0, 3.0], [4.0, 5.0, 6.0], [7.0, 8.0, 9.0]]
         ssdf = tm.SubclassedSparseDataFrame(rows)

--- a/pandas/util/testing.py
+++ b/pandas/util/testing.py
@@ -1104,10 +1104,10 @@ def assert_series_equal(left, right, check_dtype=True,
     right : Series
     check_dtype : bool, default True
         Whether to check the Series dtype is identical.
-    check_index_type : bool / string {'equiv'}, default False
+    check_index_type : bool / string {'equiv'}, default 'equiv'
         Whether to check the Index class, dtype and inferred_type
         are identical.
-    check_series_type : bool, default False
+    check_series_type : bool, default True
         Whether to check the Series class is identical.
     check_less_precise : bool or int, default False
         Specify comparison precision. Only used when check_exact is False.


### PR DESCRIPTION
- [x] closes #13977
- [x] tests added / passed
- [x] passes `git diff upstream/master | flake8 --diff`
- [x] whatsnew entry
