### PR TITLE
BUG: ufunc with PeriodIndex may raise IncompatibleFrequency

### DIFF
--- a/doc/source/whatsnew/v0.19.0.txt
+++ b/doc/source/whatsnew/v0.19.0.txt
@@ -1065,6 +1065,7 @@ Bug Fixes
 - Bug in ``concat`` and ``groupby`` for hierarchical frames with ``RangeIndex`` levels (:issue:`13542`).
 
 - Bug in ``agg()`` function on groupby dataframe changes dtype of ``datetime64[ns]`` column to ``float64`` (:issue:`12821`)
+- Bug in using NumPy ufunc with ``PeriodIndex`` to add or subtract integer raise ``IncompatibleFrequency``. Note that using standard operator like ``+`` or ``-`` is recommended, because standard operators use more efficient path (:issue:`13980`)
 
 - Bug in operations on ``NaT`` returning ``float`` instead of ``datetime64[ns]`` (:issue:`12941`)
 

--- a/pandas/tseries/tests/test_base.py
+++ b/pandas/tseries/tests/test_base.py
@@ -1758,12 +1758,11 @@ class TestPeriodIndexOps(Ops):
         idx1 = PeriodIndex([], freq='D')
         idx2 = PeriodIndex(['2011-01-01'], freq='D')
         idx3 = PeriodIndex(['2011-01-01', '2011-01-02'], freq='D')
-        idx4 = PeriodIndex(
-            ['2011-01-01', '2011-01-02', '2011-01-03'], freq='D')
+        idx4 = PeriodIndex(['2011-01-01', '2011-01-02', '2011-01-03'],
+                           freq='D')
         idx5 = PeriodIndex(['2011', '2012', '2013'], freq='A')
-        idx6 = PeriodIndex(
-            ['2011-01-01 09:00', '2012-02-01 10:00', 'NaT'], freq='H')
-
+        idx6 = PeriodIndex(['2011-01-01 09:00', '2012-02-01 10:00',
+                            'NaT'], freq='H')
         idx7 = pd.period_range('2013Q1', periods=1, freq="Q")
         idx8 = pd.period_range('2013Q1', periods=2, freq="Q")
         idx9 = pd.period_range('2013Q1', periods=3, freq="Q")

--- a/pandas/tseries/tests/test_period.py
+++ b/pandas/tseries/tests/test_period.py
@@ -4125,6 +4125,7 @@ class TestPeriodIndexSeriesMethods(tm.TestCase):
         s = pd.Series(idx)
 
         msg = "unsupported operand type\(s\)"
+
         for obj in [idx, s]:
             for ng in ["str", 1.5]:
                 with tm.assertRaisesRegexp(TypeError, msg):
@@ -4137,6 +4138,20 @@ class TestPeriodIndexSeriesMethods(tm.TestCase):
                 with tm.assertRaisesRegexp(TypeError, msg):
                     obj - ng
 
+            # ToDo: currently, it accepts float because PeriodIndex.values
+            # is internally int. Should be fixed after GH13988
+            # msg is different depending on NumPy version
+            if not _np_version_under1p9:
+                for ng in ["str"]:
+                    with tm.assertRaises(TypeError):
+                        np.add(obj, ng)
+
+                    with tm.assertRaises(TypeError):
+                        np.add(ng, obj)
+
+                    with tm.assertRaises(TypeError):
+                            np.subtract(ng, obj)
+
     def test_pi_ops_nat(self):
         idx = PeriodIndex(['2011-01', '2011-02', 'NaT',
                            '2011-04'], freq='M', name='idx')
@@ -4144,8 +4159,22 @@ class TestPeriodIndexSeriesMethods(tm.TestCase):
                                 'NaT', '2011-06'], freq='M', name='idx')
         self._check(idx, lambda x: x + 2, expected)
         self._check(idx, lambda x: 2 + x, expected)
+        self._check(idx, lambda x: np.add(x, 2), expected)
 
         self._check(idx + 2, lambda x: x - 2, idx)
+        self._check(idx + 2, lambda x: np.subtract(x, 2), idx)
+
+        # freq with mult
+        idx = PeriodIndex(['2011-01', '2011-02', 'NaT',
+                           '2011-04'], freq='2M', name='idx')
+        expected = PeriodIndex(['2011-07', '2011-08',
+                                'NaT', '2011-10'], freq='2M', name='idx')
+        self._check(idx, lambda x: x + 3, expected)
+        self._check(idx, lambda x: 3 + x, expected)
+        self._check(idx, lambda x: np.add(x, 3), expected)
+
+        self._check(idx + 3, lambda x: x - 3, idx)
+        self._check(idx + 3, lambda x: np.subtract(x, 3), idx)
 
     def test_pi_ops_array_int(self):
         idx = PeriodIndex(['2011-01', '2011-02', 'NaT',


### PR DESCRIPTION
- [x] tests added / passed
- [x] passes `git diff upstream/master | flake8 --diff`
- [x] whatsnew entry

`PeriodIndex` supportds addition / subtraction with integer.

```
# OK
pi = pd.PeriodIndex(['2011-01'], freq='M')
pi + 1
# PeriodIndex(['2011-02'], dtype='int64', freq='M')
pi - 1
# PeriodIndex(['2010-12'], dtype='int64', freq='M')
```

but raises if op is performed via ufunc.

```
# NG
np.add(pi, 1)
# pandas._period.IncompatibleFrequency: Input has different freq from PeriodIndex(freq=M)

np.subtract(pi, 1)
# pandas._period.IncompatibleFrequency: Input has different freq from PeriodIndex(freq=M)
```
