### PR TITLE
CLN: move PeriodIndex.__getitem__ to DatetimeIndexOpsMixin

### DIFF
--- a/pandas/tseries/base.py
+++ b/pandas/tseries/base.py
@@ -236,16 +236,25 @@ class DatetimeIndexOpsMixin(object):
 
             attribs = self._get_attributes_dict()
 
-            freq = None
-            if isinstance(key, slice):
-                if self.freq is not None and key.step is not None:
-                    freq = key.step * self.freq
-                else:
-                    freq = self.freq
+            is_period = isinstance(self, ABCPeriodIndex)
+            if is_period:
+                freq = self.freq
+            else:
+                freq = None
+                if isinstance(key, slice):
+                    if self.freq is not None and key.step is not None:
+                        freq = key.step * self.freq
+                    else:
+                        freq = self.freq
+
             attribs['freq'] = freq
 
             result = getitem(key)
             if result.ndim > 1:
+                # To support MPL which performs slicing with 2 dim
+                # even though it only has 1 dim by definition
+                if is_period:
+                    return self._simple_new(result, **attribs)
                 return result
 
             return self._simple_new(result, **attribs)

--- a/pandas/tseries/period.py
+++ b/pandas/tseries/period.py
@@ -862,25 +862,6 @@ class PeriodIndex(DatelikeOps, DatetimeIndexOpsMixin, Int64Index):
             rawarr = PeriodIndex(rawarr, freq=self.freq)
         return rawarr
 
-    def __getitem__(self, key):
-        getitem = self._data.__getitem__
-        if is_scalar(key):
-            val = getitem(key)
-            return Period(ordinal=val, freq=self.freq)
-        else:
-            if com.is_bool_indexer(key):
-                key = np.asarray(key)
-
-            result = getitem(key)
-            if result.ndim > 1:
-                # MPL kludge
-                # values = np.asarray(list(values), dtype=object)
-                # return values.reshape(result.shape)
-
-                return PeriodIndex(result, name=self.name, freq=self.freq)
-
-            return PeriodIndex(result, name=self.name, freq=self.freq)
-
     def _format_native_types(self, na_rep=u('NaT'), date_format=None,
                              **kwargs):
 

--- a/pandas/tseries/tests/test_period.py
+++ b/pandas/tseries/tests/test_period.py
@@ -2060,8 +2060,23 @@ class TestPeriodIndex(tm.TestCase):
         idx = period_range('2007-01', periods=3, freq='M')
 
         result = idx[:, None]
-        # MPL kludge
+        # MPL kludge, internally has incorrect shape
         tm.assertIsInstance(result, PeriodIndex)
+        self.assertEqual(result.shape, (len(idx), 1))
+
+    def test_getitem_index(self):
+        idx = period_range('2007-01', periods=10, freq='M', name='x')
+
+        result = idx[[1, 3, 5]]
+        exp = pd.PeriodIndex(['2007-02', '2007-04', '2007-06'],
+                             freq='M', name='x')
+        tm.assert_index_equal(result, exp)
+
+        result = idx[[True, True, False, False, False,
+                      True, True, False, False, False]]
+        exp = pd.PeriodIndex(['2007-01', '2007-02', '2007-06', '2007-07'],
+                             freq='M', name='x')
+        tm.assert_index_equal(result, exp)
 
     def test_getitem_partial(self):
         rng = period_range('2007-01', periods=50, freq='M')


### PR DESCRIPTION
- [x] related to #6469
- [x] tests added / passed
- [x] passes `git diff upstream/master | flake8 --diff`

merge `PeriodIndex.__getitem__` to `DatetimeIndexOpsMixin`
