### PR TITLE
DOC: suppress warnings for Panel4D deprecation

### DIFF
--- a/doc/source/dsintro.rst
+++ b/doc/source/dsintro.rst
@@ -1042,6 +1042,7 @@ The following creates a Panel5D. A new panel type object must be sliceable into 
 Here we slice to a Panel4D.
 
 .. ipython:: python
+    :okwarning:
 
     from pandas.core import panelnd
     Panel5D = panelnd.create_nd_panel_factory(

--- a/doc/source/io.rst
+++ b/doc/source/io.rst
@@ -4012,6 +4012,7 @@ number of options, please see the docstring.
    legacy_file_path = os.path.abspath('source/_static/legacy_0.10.h5')
 
 .. ipython:: python
+   :okwarning:
 
    # a legacy store
    legacy_store = HDFStore(legacy_file_path,'r')
@@ -4059,6 +4060,7 @@ Experimental
 HDFStore supports ``Panel4D`` storage.
 
 .. ipython:: python
+   :okwarning:
 
    p4d = Panel4D({ 'l1' : wp })
    p4d
@@ -4073,6 +4075,7 @@ store your data. Pass the ``axes`` keyword with a list of dimensions
 object). This cannot be changed after table creation.
 
 .. ipython:: python
+   :okwarning:
 
    store.append('p4d2', p4d, axes=['labels', 'major_axis', 'minor_axis'])
    store

--- a/doc/source/whatsnew/v0.10.0.txt
+++ b/doc/source/whatsnew/v0.10.0.txt
@@ -383,6 +383,7 @@ Adding experimental support for Panel4D and factory functions to create n-dimens
 :ref:`Docs <dsintro.panel4d>` for NDim. Here is a taste of what to expect.
 
      .. ipython:: python
+        :okwarning:
 
         p4d = Panel4D(randn(2, 2, 5, 4),
               labels=['Label1','Label2'],


### PR DESCRIPTION
Other options is to just remove those sections in the latest docs ... (they are always available in the older ones).

The example in the HDF5 docs with a legacy file will have to be updated to not include Panel4D, or the reading of such files will have to be adapted in the future to handle those when Panel4D is actually removed (@jreback)
