### PR TITLE
Use DeprecationWarning for core.common deprecations (GH13634)

### DIFF
--- a/pandas/api/tests/test_api.py
+++ b/pandas/api/tests/test_api.py
@@ -163,7 +163,7 @@ class TestTypes(Base, tm.TestCase):
         self.check(types, self.allowed)
 
     def check_deprecation(self, fold, fnew):
-        with tm.assert_produces_warning(FutureWarning):
+        with tm.assert_produces_warning(DeprecationWarning):
             try:
                 result = fold('foo')
                 expected = fnew('foo')

--- a/pandas/core/common.py
+++ b/pandas/core/common.py
@@ -31,7 +31,7 @@ for t in [t for t in dir(types) if not t.startswith('_')]:
             warnings.warn("pandas.core.common.{t} is deprecated. "
                           "import from the public API: "
                           "pandas.api.types.{t} instead".format(t=t),
-                          FutureWarning, stacklevel=3)
+                          DeprecationWarning, stacklevel=3)
             return getattr(types, t)(*args, **kwargs)
         return wrapper
 
@@ -57,7 +57,7 @@ for t in ['is_datetime_arraylike',
                           "These are not longer public API functions, "
                           "but can be imported from "
                           "pandas.types.common.{t} instead".format(t=t),
-                          FutureWarning, stacklevel=3)
+                          DeprecationWarning, stacklevel=3)
             return getattr(common, t)(*args, **kwargs)
         return wrapper
 


### PR DESCRIPTION
Related to second question in #13634 (whether to use FutureWarning or DeprecationWarning in deprecating the public pandas.core.common functions).

As those functions are mostly used in library code, and less directly by users in their own code, I think a DeprecationWarning is more appropriate in this case. 
For example, in our own docs, we started to get warnings due to an example with a statsmodels regression that uses patsy using one of those functions. Note that recent IPython also shows DeprecationWarnings when using a deprecated function interactively.
