### PR TITLE
BUG: groupby cumsum with axis=1 computes cumprod

### DIFF
--- a/doc/source/whatsnew/v0.19.0.txt
+++ b/doc/source/whatsnew/v0.19.0.txt
@@ -850,6 +850,7 @@ Bug Fixes
 ~~~~~~~~~
 
 - Bug in ``groupby().shift()``, which could cause a segfault or corruption in rare circumstances when grouping by columns with missing values (:issue:`13813`)
+- Bug in ``groupby().cumsum()`` calculating ``cumprod`` when ``axis=1``. (:issue:`13994`)
 - Bug in ``pd.read_csv()``, which may cause a segfault or corruption when iterating in large chunks over a stream/file under rare circumstances (:issue:`13703`)
 - Bug in ``pd.read_csv()``, which caused BOM files to be incorrectly parsed by not ignoring the BOM (:issue:`4793`)
 - Bug in ``io.json.json_normalize()``, where non-ascii keys raised an exception (:issue:`13213`)

--- a/pandas/core/groupby.py
+++ b/pandas/core/groupby.py
@@ -1397,7 +1397,7 @@ class GroupBy(_GroupBy):
         """Cumulative sum for each group"""
         nv.validate_groupby_func('cumsum', args, kwargs)
         if axis != 0:
-            return self.apply(lambda x: x.cumprod(axis=axis))
+            return self.apply(lambda x: x.cumsum(axis=axis))
 
         return self._cython_transform('cumsum')
 

--- a/pandas/tests/test_groupby.py
+++ b/pandas/tests/test_groupby.py
@@ -2973,6 +2973,14 @@ class TestGroupBy(tm.TestCase):
         result = df.groupby('A', as_index=False).cumsum()
         assert_frame_equal(result, expected)
 
+        # GH 13994
+        result = df.groupby('A').cumsum(axis=1)
+        expected = df.cumsum(axis=1)
+        assert_frame_equal(result, expected)
+        result = df.groupby('A').cumprod(axis=1)
+        expected = df.cumprod(axis=1)
+        assert_frame_equal(result, expected)
+
     def test_grouping_ndarray(self):
         grouped = self.df.groupby(self.df['A'].values)
 


### PR DESCRIPTION
- [x] closes #13993
- [x] tests added / passed
- [x] passes `git diff upstream/master | flake8 --diff`
- [x] whatsnew entry
