### PR TITLE
CLN: move _na_value to DatetimeIndexOpsMixin

### DIFF
--- a/pandas/tseries/base.py
+++ b/pandas/tseries/base.py
@@ -353,6 +353,9 @@ class DatetimeIndexOpsMixin(object):
         values = Index.get_duplicates(self)
         return self._simple_new(values)
 
+    _na_value = tslib.NaT
+    """The expected NA value to use with this index."""
+
     @cache_readonly
     def _isnan(self):
         """ return if each value is nan"""

--- a/pandas/tseries/index.py
+++ b/pandas/tseries/index.py
@@ -667,9 +667,6 @@ class DatetimeIndex(DatelikeOps, TimelikeOps, DatetimeIndexOpsMixin,
         # how to represent ourselves to matplotlib
         return tslib.ints_to_pydatetime(self.asi8, self.tz)
 
-    _na_value = tslib.NaT
-    """The expected NA value to use with this index."""
-
     @cache_readonly
     def _is_dates_only(self):
         from pandas.formats.format import _is_dates_only

--- a/pandas/tseries/period.py
+++ b/pandas/tseries/period.py
@@ -320,10 +320,6 @@ class PeriodIndex(DatelikeOps, DatetimeIndexOpsMixin, Int64Index):
         """
         return PeriodIndex([item], **self._get_attributes_dict())
 
-    @property
-    def _na_value(self):
-        return self._box_func(tslib.iNaT)
-
     def __contains__(self, key):
         if isinstance(key, Period):
             if key.freq != self.freq:

--- a/pandas/tseries/tdi.py
+++ b/pandas/tseries/tdi.py
@@ -282,9 +282,6 @@ class TimedeltaIndex(DatetimeIndexOpsMixin, TimelikeOps, Int64Index):
         result._reset_identity()
         return result
 
-    _na_value = tslib.NaT
-    """The expected NA value to use with this index."""
-
     @property
     def _formatter_func(self):
         from pandas.formats.format import _get_format_timedelta64

--- a/pandas/tseries/tests/test_base.py
+++ b/pandas/tseries/tests/test_base.py
@@ -798,6 +798,10 @@ Freq: D"""
                                     '2011-01-01 09:00'], name='xxx', tz=tz)
             tm.assert_index_equal(idx.shift(-3, freq='H'), exp)
 
+    def test_na_value(self):
+        self.assertIs(pd.DatetimeIndex._na_value, pd.NaT)
+        self.assertIs(pd.DatetimeIndex([])._na_value, pd.NaT)
+
 
 class TestTimedeltaIndexOps(Ops):
     def setUp(self):
@@ -1640,6 +1644,10 @@ Freq: D"""
         for res in [index.repeat(3), np.repeat(index, 3)]:
             tm.assert_index_equal(res, exp)
             self.assertIsNone(res.freq)
+
+    def test_na_value(self):
+        self.assertIs(pd.TimedeltaIndex._na_value, pd.NaT)
+        self.assertIs(pd.TimedeltaIndex([])._na_value, pd.NaT)
 
 
 class TestPeriodIndexOps(Ops):
@@ -2580,6 +2588,10 @@ Freq: Q-DEC"""
                               '2003-01', '2003-01', '2003-01'], freq='M')
         for res in [index.repeat(3), np.repeat(index, 3)]:
             tm.assert_index_equal(res, exp)
+
+    def test_na_value(self):
+        self.assertIs(pd.PeriodIndex._na_value, pd.NaT)
+        self.assertIs(pd.PeriodIndex([], freq='M')._na_value, pd.NaT)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
- [x] tests added / passed
- [x] passes `git diff upstream/master | flake8 --diff`

Because `PeriodIndex` now shares the same `NaT` repr (#13609), can use the same definition on `DatetimeIndexOpsMixin`
