### PR TITLE
DOC: fixed using IP.prompt_manager which is removed from IPython 5.x

### DIFF
--- a/doc/source/whatsnew/v0.20.0.txt
+++ b/doc/source/whatsnew/v0.20.0.txt
@@ -81,4 +81,3 @@ Performance Improvements
 
 Bug Fixes
 ~~~~~~~~~
-Bug when building docs with IPython 5.x (:issue:`14003`)

--- a/doc/source/whatsnew/v0.20.0.txt
+++ b/doc/source/whatsnew/v0.20.0.txt
@@ -81,3 +81,4 @@ Performance Improvements
 
 Bug Fixes
 ~~~~~~~~~
+Bug when building docs with IPython 5.x (:issue:`14003`)

--- a/doc/sphinxext/ipython_sphinxext/ipython_directive.py
+++ b/doc/sphinxext/ipython_sphinxext/ipython_directive.py
@@ -799,7 +799,6 @@ class IPythonDirective(Directive):
             # Store IPython directive to enable better error messages
             self.shell.directive = self
 
-        
         # reset the execution count if we haven't processed this doc
         #NOTE: this may be borked if there are multiple seen_doc tmp files
         #check time stamp?

--- a/doc/sphinxext/ipython_sphinxext/ipython_directive.py
+++ b/doc/sphinxext/ipython_sphinxext/ipython_directive.py
@@ -799,13 +799,19 @@ class IPythonDirective(Directive):
             # Store IPython directive to enable better error messages
             self.shell.directive = self
 
-        # reset the execution count if we haven't processed this doc
-        #NOTE: this may be borked if there are multiple seen_doc tmp files
-        #check time stamp?
-        if not self.state.document.current_source in self.seen_docs:
+        """
+        reset the execution count if we haven't processed this doc
+        NOTE: this may be borked if there are multiple seen_doc tmp files
+        check time stamp?
+        """
+        if self.state.document.current_source not in self.seen_docs:
             self.shell.IP.history_manager.reset()
             self.shell.IP.execution_count = 1
-            self.shell.IP.prompt_manager.width = 0
+            try:
+                self.shell.IP.prompt_manager.width = 0
+            except AttributeError:
+                # GH14003: class promptManager has removed after IPython 5.x
+                pass
             self.seen_docs.add(self.state.document.current_source)
 
         # and attach to shell so we don't have to pass them around

--- a/doc/sphinxext/ipython_sphinxext/ipython_directive.py
+++ b/doc/sphinxext/ipython_sphinxext/ipython_directive.py
@@ -799,11 +799,10 @@ class IPythonDirective(Directive):
             # Store IPython directive to enable better error messages
             self.shell.directive = self
 
-        """
-        reset the execution count if we haven't processed this doc
-        NOTE: this may be borked if there are multiple seen_doc tmp files
-        check time stamp?
-        """
+        
+        # reset the execution count if we haven't processed this doc
+        #NOTE: this may be borked if there are multiple seen_doc tmp files
+        #check time stamp?
         if self.state.document.current_source not in self.seen_docs:
             self.shell.IP.history_manager.reset()
             self.shell.IP.execution_count = 1


### PR DESCRIPTION
- [x] closes #14003, #13639
- [ ] tests added / passed (there's no test on building docs)
- [x] passes `git diff upstream/master | flake8 --diff`
- [ ] whatsnew entry (it's not user facing bug fix)

this PR was made during PyCon APAC, pandas sprint

thanks
