### PR TITLE
BUG: Avoid sentinel-infinity comparison problems (#13445)

### DIFF
--- a/doc/source/whatsnew/v0.19.0.txt
+++ b/doc/source/whatsnew/v0.19.0.txt
@@ -893,6 +893,7 @@ Bug Fixes
 - Bug in ``.rolling()`` that allowed a negative integer window in contruction of the ``Rolling()`` object, but would later fail on aggregation (:issue:`13383`)
 
 - Bug in printing ``pd.DataFrame`` where unusual elements with the ``object`` dtype were causing segfaults (:issue:`13717`)
+- Bug in ranking ``Series`` which could result in segfaults (:issue:`13445`)
 - Bug in various index types, which did not propagate the name of passed index (:issue:`12309`)
 - Bug in ``DatetimeIndex``, which did not honour the ``copy=True`` (:issue:`13205`)
 - Bug in ``DatetimeIndex.is_normalized`` returns incorrectly for normalized date_range in case of local timezones (:issue:`13459`)

--- a/pandas/algos.pyx
+++ b/pandas/algos.pyx
@@ -567,28 +567,25 @@ cdef inline are_diff(object left, object right):
     except TypeError:
         return left != right
 
-_return_false = lambda self, other: False
-_return_true = lambda self, other: True
 
 class Infinity(object):
 
-    __lt__ = _return_false
-    __le__ = _return_false
-    __eq__ = _return_false
-    __ne__ = _return_true
-    __gt__ = _return_true
-    __ge__ = _return_true
-    __cmp__ = _return_false
+    __lt__ = lambda self, other: False
+    __le__ = lambda self, other: self is other
+    __eq__ = lambda self, other: self is other
+    __ne__ = lambda self, other: self is not other
+    __gt__ = lambda self, other: self is not other
+    __ge__ = lambda self, other: True
 
 class NegInfinity(object):
 
-    __lt__ = _return_true
-    __le__ = _return_true
-    __eq__ = _return_false
-    __ne__ = _return_true
-    __gt__ = _return_false
-    __ge__ = _return_false
-    __cmp__ = _return_true
+    __lt__ = lambda self, other: self is not other
+    __le__ = lambda self, other: True
+    __eq__ = lambda self, other: self is other
+    __ne__ = lambda self, other: self is not other
+    __gt__ = lambda self, other: False
+    __ge__ = lambda self, other: self is other
+    
 
 def rank_2d_generic(object in_arr, axis=0, ties_method='average',
                     ascending=True, na_option='keep', pct=False):

--- a/pandas/tests/test_stats.py
+++ b/pandas/tests/test_stats.py
@@ -179,6 +179,13 @@ class TestRank(tm.TestCase):
             expected.index = result.index
             assert_series_equal(result, expected)
 
+    def test_rank_object_bug(self):
+        # GH 13445
+
+        # smoke tests
+        Series([np.nan] * 32).astype(object).rank(ascending=True)
+        Series([np.nan] * 32).astype(object).rank(ascending=False)
+
 
 if __name__ == '__main__':
     nose.runmodule(argv=[__file__, '-vvs', '-x', '--pdb', '--pdb-failure'],


### PR DESCRIPTION
The problem causing #13445 ultimately traces to the fact that our Infinity/NegInfinity objects were greater than/less than themselves, which violates an assumption numpy makes when sorting.  This was separately reported as https://github.com/numpy/numpy/issues/7934, but we can fix and test downstream as well.
- [X] closes #13445
- [X] tests added / passed
- [X] passes `git diff upstream/master | flake8 --diff`
- [X] whatsnew entry
