### PR TITLE
BUG: Categoricals shouldn't allow non-strings when object dtype is passed (#13919)

### DIFF
--- a/doc/source/whatsnew/v0.19.0.txt
+++ b/doc/source/whatsnew/v0.19.0.txt
@@ -1071,3 +1071,4 @@ Bug Fixes
 - Bug in ``Index`` raises ``KeyError`` displaying incorrect column when column is not in the df and columns contains duplicate values (:issue:`13822`)
 - Bug in ``Period`` and ``PeriodIndex`` creating wrong dates when frequency has combined offset aliases (:issue:`13874`)
 - Bug in ``.to_string()`` when called with an integer ``line_width`` and ``index=False`` raises an UnboundLocalError exception because ``idx`` referenced before assignment.
+- Bug in ``Categorical`` would allow creation when ``object`` dtype was passed in with non-string values


### PR DESCRIPTION
- [ ] closes #13919
- [ ] tests added / passed
- [x] passes `git diff upstream/master | flake8 --diff`
- [x] whatsnew entry

**Why this change is needed:** Categorical variables are by definition single types, so to allow them to take on various different kinds of values is misleading. Object dtypes should only be allowed when ALL strings or ALL periods are passed (due to the way there are handled internally).

**The result of this PR** will raise a `TypeError` when a categorical is created that has an object dtype but doesn't contain all `string` or all `period` values. 

I have a couple questions:
When using `MultiIndex.from_arrays`, it creates Categories [here](https://github.com/pydata/pandas/blob/master/pandas/indexes/multi.py#L867), which can have mixed dtypes, and unfortunately my code disallows this. Any tips on how to circumvent this?

Also, [this test in `test_constructor`](https://github.com/pydata/pandas/blob/master/pandas/tests/test_categorical.py#L209) is problematic bc it converts the catergories  `dtype` to `object` if `NaN` is in the categories (although this is deprecated). Should I change my code to allow this, or can I assert that this produces a TypeError

Any feedback is appreciated, thanks
