### PR TITLE
Require a problem description in PRs

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,3 +1,5 @@
+ [Add description of the problem and **why** this change is needed (what is the problem, how does this change fix that problem). This text ends up in the commit of the change and should help comprehend why a change was made, even years later.]
+ 
  - [ ] closes #xxxx
  - [ ] tests added / passed
  - [ ] passes ``git diff upstream/master | flake8 --diff``


### PR DESCRIPTION
A lot of time I can't find out why a change in a commit was made because it either has no proper commit message or the commit message just says what was changed, but not why. 

Add text to the PR template to require such a problem description, so that one can comprehend why a change was made even years later.
