### PR TITLE
Require a problem description in issues

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,3 +1,7 @@
+#### Problem description
+
+[this should explain **why** the current behaviour is a problem and why the expected output is a better solution.] 
+
 #### Code Sample, a copy-pastable example if possible
 
 #### Expected Output


### PR DESCRIPTION
Currently some issues are just code examples without a description **why** a change should be done. This leads to problems when (years later) the current behaviour is questioned and no one can remember why it was changed.
