### PR TITLE
BUG: #14016. Preserve categorical keys through concat

### DIFF
--- a/pandas/tools/merge.py
+++ b/pandas/tools/merge.py
@@ -1367,7 +1367,10 @@ class _Concatenator(object):
                 clean_keys.append(k)
                 clean_objs.append(v)
             objs = clean_objs
-            keys = clean_keys
+            if isinstance(keys, cat.CategoricalIndex):
+                keys = keys._shallow_copy(clean_keys)
+            else:
+                keys = clean_keys
 
         if len(objs) == 0:
             raise ValueError('All objects passed were None')
@@ -1637,7 +1640,10 @@ def _make_concat_multiindex(indexes, keys, levels=None, names=None):
         else:
             levels = [_ensure_index(x) for x in levels]
     else:
-        zipped = [keys]
+        if isinstance(keys, cat.CategoricalIndex):
+            zipped = lzip(*keys)
+        else:
+            zipped = [keys]
         if names is None:
             names = [None]
 

--- a/pandas/tools/tests/test_merge.py
+++ b/pandas/tools/tests/test_merge.py
@@ -709,6 +709,18 @@ class TestMerge(tm.TestCase):
                           how='outer', indicator=True)
         assert_frame_equal(test5, hand_coded_result)
 
+    def test_categorical_index_merge(self):
+        cat_index = pd.CategoricalIndex(['y', 'x'], categories=list("xyz"), ordered=True)
+        df = pd.DataFrame([[10, 11, 12]])
+
+        idx = pd.MultiIndex(levels=[cat_index, [0]], labels=[[0, 1], [0, 0]])
+        expected = pd.DataFrame([[10, 11, 12], [10, 11, 12]], index=idx)
+
+        result = pd.concat([df, df], keys=cat_index)
+
+        self.assertIsInstance(result.index.levels[0], pd.CategoricalIndex)
+        assert_frame_equal(result, expected)
+
 
 def _check_merge(x, y):
     for how in ['inner', 'left', 'outer']:

--- a/pandas/tools/tests/test_merge.py
+++ b/pandas/tools/tests/test_merge.py
@@ -719,6 +719,7 @@ class TestMerge(tm.TestCase):
         result = pd.concat([df, df], keys=cat_index)
 
         self.assertIsInstance(result.index.levels[0], pd.CategoricalIndex)
+        self.assertTrue(cat_index.equals(result.index.levels[0]))
         assert_frame_equal(result, expected)
 
 


### PR DESCRIPTION
- [x] closes #14016 
- [x] tests added / passed
- [ ] passes `git diff upstream/master | flake8 --diff`
- [ ] whatsnew entry
