### PR TITLE
BUG: iloc fails with non lex-sorted MultiIndex #13797

### DIFF
--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -903,6 +903,8 @@ class _NDFrameIndexer(object):
 
         # we maybe be using a tuple to represent multiple dimensions here
         ax0 = self.obj._get_axis(0)
+        # ...but iloc should handle the tuple as simple integer-location
+        # instead of checking it as multiindex representation (GH 13797)
         if isinstance(ax0, MultiIndex) and self.name != 'iloc':
             result = self._handle_lowerdim_multi_index_axis0(tup)
             if result is not None:

--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -903,7 +903,7 @@ class _NDFrameIndexer(object):
 
         # we maybe be using a tuple to represent multiple dimensions here
         ax0 = self.obj._get_axis(0)
-        if isinstance(ax0, MultiIndex):
+        if isinstance(ax0, MultiIndex) and self.name != 'iloc':
             result = self._handle_lowerdim_multi_index_axis0(tup)
             if result is not None:
                 return result

--- a/pandas/tests/test_multilevel.py
+++ b/pandas/tests/test_multilevel.py
@@ -2424,26 +2424,27 @@ Thur,Lunch,Yes,51.51,17"""
         # GH 13797
         # Test if iloc can handle integer locations in MultiIndexed DataFrame
 
-        data =[
-                ['str00', 'str01'],
-                ['str10', 'str11'],
-                ['str20', 'srt21'],
-                ['str30', 'str31'],
-                ['str40', 'str41']
-            ]
+        data = [
+            ['str00', 'str01'],
+            ['str10', 'str11'],
+            ['str20', 'srt21'],
+            ['str30', 'str31'],
+            ['str40', 'str41']
+        ]
 
-        mi= pd.MultiIndex.from_tuples(
-            [('CC','A'),
-             ('CC','B'),
-             ('CC','B'),
-             ('BB','a'),
-             ('BB','b')
-            ])
+        mi = pd.MultiIndex.from_tuples(
+            [('CC', 'A'),
+             ('CC', 'B'),
+             ('CC', 'B'),
+             ('BB', 'a'),
+             ('BB', 'b')
+             ])
 
         ans = pd.DataFrame(data)
-        df_mi = pd.DataFrame(data, index = mi)
+        df_mi = pd.DataFrame(data, index=mi)
 
-        res = pd.DataFrame([[df_mi.iloc[r,c] for c in range(2)] for r in range(5)])
+        res = pd.DataFrame([[df_mi.iloc[r, c] for c in range(2)]
+                            for r in range(5)])
 
         assert_frame_equal(res, ans)
 

--- a/pandas/tests/test_multilevel.py
+++ b/pandas/tests/test_multilevel.py
@@ -2420,6 +2420,25 @@ Thur,Lunch,Yes,51.51,17"""
         m_df = pd.Series(data, index=m_idx)
         assert m_df.repeat(3).shape == (3 * len(data), )
 
+    def test_iloc_mi(self):
+        # GH 13797
+
+        ind_nonLex = [
+            ['CC', 'CC', 'CC', 'BB', 'BB'],
+            ['A', 'B', 'B', 'a', 'b']
+        ]
+
+        strCol = pd.DataFrame(
+            ['fooA', 'fooB', 'fooC', 'fooD', 'fooE'])
+
+        dat = np.arange(1, 26).reshape(5, 5)
+        df = pd.concat([strCol, pd.DataFrame(dat)], axis=1)
+        df1 = pd.DataFrame(df.values, index=ind_nonLex)
+
+        assert df1.iloc[0, 0] == 'fooA'
+        assert df1.iloc[4, 0] == 'fooE'
+        assert df1.iloc[4, 5] == 25
+
 
 if __name__ == '__main__':
     nose.runmodule(argv=[__file__, '-vvs', '-x', '--pdb', '--pdb-failure'],

--- a/pandas/tests/test_multilevel.py
+++ b/pandas/tests/test_multilevel.py
@@ -2422,22 +2422,30 @@ Thur,Lunch,Yes,51.51,17"""
 
     def test_iloc_mi(self):
         # GH 13797
+        # Test if iloc can handle integer locations in MultiIndexed DataFrame
 
-        ind_nonLex = [
-            ['CC', 'CC', 'CC', 'BB', 'BB'],
-            ['A', 'B', 'B', 'a', 'b']
-        ]
+        data =[
+                ['str00', 'str01'],
+                ['str10', 'str11'],
+                ['str20', 'srt21'],
+                ['str30', 'str31'],
+                ['str40', 'str41']
+            ]
 
-        strCol = pd.DataFrame(
-            ['fooA', 'fooB', 'fooC', 'fooD', 'fooE'])
+        mi= pd.MultiIndex.from_tuples(
+            [('CC','A'),
+             ('CC','B'),
+             ('CC','B'),
+             ('BB','a'),
+             ('BB','b')
+            ])
 
-        dat = np.arange(1, 26).reshape(5, 5)
-        df = pd.concat([strCol, pd.DataFrame(dat)], axis=1)
-        df1 = pd.DataFrame(df.values, index=ind_nonLex)
+        ans = pd.DataFrame(data)
+        df_mi = pd.DataFrame(data, index = mi)
 
-        assert df1.iloc[0, 0] == 'fooA'
-        assert df1.iloc[4, 0] == 'fooE'
-        assert df1.iloc[4, 5] == 25
+        res = pd.DataFrame([[df_mi.iloc[r,c] for c in range(2)] for r in range(5)])
+
+        assert_frame_equal(res, ans)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
- [x] closes #13797
- [x] tests added / passed pandas/tests/test_multilevel.py
- [x] passes `git diff upstream/master | flake8 --diff`
- [ ] whatsnew entry

corrected how iloc handles tuple-keys for multiindex
