### PR TITLE
CLN: Removed DataFrame.to_wide

### DIFF
--- a/doc/source/whatsnew/v0.19.0.txt
+++ b/doc/source/whatsnew/v0.19.0.txt
@@ -894,6 +894,7 @@ Removal of prior version deprecations/changes
 - ``Panel.shift()`` has dropped the ``lags`` parameter in favour of ``periods`` (:issue:`14041`)
 - ``pd.Index`` has dropped the ``diff`` method in favour of ``difference`` (:issue:`13669`)
 
+- ``pd.DataFrame`` has dropped the ``to_wide`` method in favour of ``to_panel`` (:issue:`14039`)
 - ``Series.to_csv`` has dropped the ``nanRep`` parameter in favor of ``na_rep`` (:issue:`13804`)
 - ``Series.xs``, ``DataFrame.xs``, ``Panel.xs``, ``Panel.major_xs``, and ``Panel.minor_xs`` have dropped the ``copy`` parameter (:issue:`13781`)
 - ``str.split`` has dropped the ``return_type`` parameter in favor of ``expand`` (:issue:`13701`)

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -78,8 +78,7 @@ from pandas.compat import (range, map, zip, lrange, lmap, lzip, StringIO, u,
                            OrderedDict, raise_with_traceback)
 from pandas import compat
 from pandas.compat.numpy import function as nv
-from pandas.util.decorators import (deprecate, Appender, Substitution,
-                                    deprecate_kwarg)
+from pandas.util.decorators import deprecate_kwarg, Appender, Substitution
 
 from pandas.tseries.period import PeriodIndex
 from pandas.tseries.index import DatetimeIndex
@@ -1299,8 +1298,6 @@ class DataFrame(NDFrame):
                                               ref_items=selfsorted.columns)
 
         return self._constructor_expanddim(new_mgr)
-
-    to_wide = deprecate('to_wide', to_panel)
 
     def to_csv(self, path_or_buf=None, sep=",", na_rep='', float_format=None,
                columns=None, header=True, index=True, index_label=None,


### PR DESCRIPTION
`to_wide` was deprecated since 2011 (https://github.com/pydata/pandas/commit/1134c9f6c40398d8eba37c312c88ce294e31c6c5)

xref https://github.com/pydata/pandas/issues/13777

No tests for this deprecation beforehand to remove :disappointed: 
