### PR TITLE
BUG: Categoricals shouldn't allow non-strings when object dtype is passed (#13919)

### DIFF
--- a/doc/source/whatsnew/v0.19.0.txt
+++ b/doc/source/whatsnew/v0.19.0.txt
@@ -1075,3 +1075,4 @@ Bug Fixes
 - Bug in ``Index`` raises ``KeyError`` displaying incorrect column when column is not in the df and columns contains duplicate values (:issue:`13822`)
 - Bug in ``Period`` and ``PeriodIndex`` creating wrong dates when frequency has combined offset aliases (:issue:`13874`)
 - Bug in ``.to_string()`` when called with an integer ``line_width`` and ``index=False`` raises an UnboundLocalError exception because ``idx`` referenced before assignment.
+- Bug in ``Categorical`` would allow creation when ``object`` dtype was passed in with  categories not containing either all non-string or all non-period values

--- a/doc/source/whatsnew/v0.19.0.txt
+++ b/doc/source/whatsnew/v0.19.0.txt
@@ -1075,4 +1075,4 @@ Bug Fixes
 - Bug in ``Index`` raises ``KeyError`` displaying incorrect column when column is not in the df and columns contains duplicate values (:issue:`13822`)
 - Bug in ``Period`` and ``PeriodIndex`` creating wrong dates when frequency has combined offset aliases (:issue:`13874`)
 - Bug in ``.to_string()`` when called with an integer ``line_width`` and ``index=False`` raises an UnboundLocalError exception because ``idx`` referenced before assignment.
-- Bug in ``Categorical`` would allow creation when ``object`` dtype was passed in with  categories not containing either all non-string or all non-period values
+- Bug in ``Categorical`` would allow creation when ``object`` dtype was passed in with  categories not containing either all string or all period values

--- a/pandas/core/categorical.py
+++ b/pandas/core/categorical.py
@@ -20,7 +20,8 @@ from pandas.types.common import (_ensure_int64,
                                  is_categorical_dtype,
                                  is_integer_dtype, is_bool,
                                  is_list_like, is_sequence,
-                                 is_scalar)
+                                 is_scalar,
+                                 is_object_dtype)
 from pandas.core.common import is_null_slice
 
 from pandas.core.algorithms import factorize, take_1d
@@ -191,6 +192,8 @@ class Categorical(PandasObject):
         If an explicit ``ordered=True`` is given but no `categories` and the
         `values` are not sortable.
 
+        If an `object` dtype is passed and `values` contains dtypes other
+        than all strings or all periods.
 
     Examples
     --------
@@ -323,6 +326,18 @@ class Categorical(PandasObject):
                 warn("None of the categories were found in values. Did you "
                      "mean to use\n'Categorical.from_codes(codes, "
                      "categories)'?", RuntimeWarning, stacklevel=2)
+
+        # TODO: disallow period when they stop being handled as object dtype
+        # categoricals w/ object dtype shouldn't allow non-strings
+        if is_object_dtype(categories) and len(categories) > 0:
+            from pandas.lib import infer_dtype
+            mask = notnull(categories)
+            if infer_dtype(categories[mask]) not in ['period',
+                                                     'unicode',
+                                                     'string']:
+                raise TypeError(
+                    "Categoricals cannot be object dtype unless"
+                    " all values are strings or all are periods.")
 
         self.set_ordered(ordered or False, inplace=True)
         self._categories = categories


### PR DESCRIPTION
- [ ] closes #13919
- [ ] tests added / passed
- [x] passes `git diff upstream/master | flake8 --diff`
- [x] whatsnew entry

**Why this change is needed:** Categorical variables are by definition single types, so to allow them to take on  different types of values is misleading. Object dtypes should only be allowed when ALL strings or ALL periods are passed (due to the way there are handled internally).

**The result of this PR** will raise a `TypeError` when a categorical is created that has an object dtype but doesn't contain all `string` or all `period` values. 
