### PR TITLE
BUG: GH11847 Unstack with mixed dtypes coerces everything to object

### DIFF
--- a/doc/source/whatsnew/v0.19.2.txt
+++ b/doc/source/whatsnew/v0.19.2.txt
@@ -68,3 +68,5 @@ Bug Fixes
 
 
 - Explicit check in ``to_stata`` and ``StataWriter`` for out-of-range values when writing doubles (:issue:`14618`)
+
+- Bug in ``unstack()`` if called with a list of column(s) as an argument, regardless of the dtypes of all columns, they get coerced to ``object`` (:issue:`11847`)

--- a/pandas/core/reshape.py
+++ b/pandas/core/reshape.py
@@ -277,7 +277,8 @@ def _unstack_multiple(data, clocs):
                              verify_integrity=False)
 
     if isinstance(data, Series):
-        dummy = Series(data.values, index=dummy_index)
+        dummy = data.copy()
+        dummy.index = dummy_index
         unstacked = dummy.unstack('__placeholder__')
         new_levels = clevels
         new_names = cnames
@@ -292,7 +293,8 @@ def _unstack_multiple(data, clocs):
 
             return result
 
-        dummy = DataFrame(data.values, index=dummy_index, columns=data.columns)
+        dummy = data.copy()
+        dummy.index = dummy_index
 
         unstacked = dummy.unstack('__placeholder__')
         if isinstance(unstacked, Series):


### PR DESCRIPTION
- [x] closes #11847
- [x] tests added / passed
- [x] passes `git diff upstream/master | flake8 --diff`
- [x] whatsnew entry

Changed the way in which the original data frame is copied (dropped use of .values, since it does not preserve dtypes).
