### PR TITLE
BUG: Don't error when usecols is a numpy array

### DIFF
--- a/doc/source/whatsnew/v0.19.0.txt
+++ b/doc/source/whatsnew/v0.19.0.txt
@@ -945,6 +945,7 @@ Bug Fixes
 - Bug in ``groupby().cumsum()`` calculating ``cumprod`` when ``axis=1``. (:issue:`13994`)
 - Bug in ``pd.read_csv()``, which may cause a segfault or corruption when iterating in large chunks over a stream/file under rare circumstances (:issue:`13703`)
 - Bug in ``pd.read_csv()``, which caused BOM files to be incorrectly parsed by not ignoring the BOM (:issue:`4793`)
+- Bug in ``pd.read_csv()`` with ``engine='python'`` which raised errors when a numpy array was passed in for ``usecols`` (:issue:`12546`)
 - Bug in ``pd.to_timedelta()`` in which the ``errors`` parameter was not being respected (:issue:`13613`)
 - Bug in ``io.json.json_normalize()``, where non-ascii keys raised an exception (:issue:`13213`)
 - Bug when passing a not-default-indexed ``Series`` as ``xerr`` or ``yerr`` in ``.plot()`` (:issue:`11858`)

--- a/pandas/io/parsers.py
+++ b/pandas/io/parsers.py
@@ -972,6 +972,7 @@ def _validate_usecols_arg(usecols):
                                  'string', 'unicode'):
             raise ValueError(msg)
 
+        return set(usecols)
     return usecols
 
 

--- a/pandas/io/tests/parser/usecols.py
+++ b/pandas/io/tests/parser/usecols.py
@@ -8,6 +8,7 @@ for all of the parsers defined in parsers.py
 from datetime import datetime
 import nose
 
+import numpy as np
 import pandas.util.testing as tm
 
 from pandas import DataFrame
@@ -360,4 +361,13 @@ a,b,c
         data = 'a,b,c\n1,2,3\n4,5,6'
         expected = DataFrame()
         result = self.read_csv(StringIO(data), usecols=set([]))
+        tm.assert_frame_equal(result, expected)
+
+    def test_np_array_usecols(self):
+        # See gh-12546
+        data = 'a,b,c\n1,2,3'
+        usecols = np.array(['a', 'b'])
+
+        expected = DataFrame([[1, 2]], columns=usecols)
+        result = self.read_csv(StringIO(data), usecols=usecols)
         tm.assert_frame_equal(result, expected)


### PR DESCRIPTION
Converts `usecols` to a `set` just like we do on the C engine side.

Closes #12546.
