### PR TITLE
BUG: fix tz-aware datetime convert to DatetimeIndex (GH 14088)

### DIFF
--- a/doc/source/whatsnew/v0.19.0.txt
+++ b/doc/source/whatsnew/v0.19.0.txt
@@ -1236,6 +1236,7 @@ Bug Fixes
 - Bug where ``pd.read_gbq()`` could throw ``ImportError: No module named discovery`` as a result of a naming conflict with another python package called apiclient  (:issue:`13454`)
 - Bug in ``Index.union`` returns an incorrect result with a named empty index (:issue:`13432`)
 - Bugs in ``Index.difference`` and ``DataFrame.join`` raise in Python3 when using mixed-integer indexes (:issue:`13432`, :issue:`12814`)
+- Bug in subtract tz-aware ``datetime.datetime`` from tz-aware ``datetime64`` series (:issue:`14088`)
 - Bug in ``.to_excel()`` when DataFrame contains a MultiIndex which contains a label with a NaN value (:issue:`13511`)
 - Bug in invalid frequency offset string like "D1", "-2-3H" may not raise ``ValueError (:issue:`13930`)
 - Bug in ``concat`` and ``groupby`` for hierarchical frames with ``RangeIndex`` levels (:issue:`13542`).

--- a/pandas/core/ops.py
+++ b/pandas/core/ops.py
@@ -453,7 +453,7 @@ class _TimeOp(_Op):
                 values = values.to_series()
             # datetime with tz
             elif (isinstance(ovalues, datetime.datetime) and
-                  hasattr(ovalues, 'tz')):
+                  hasattr(ovalues, 'tzinfo')):
                 values = pd.DatetimeIndex(values)
             # datetime array with tz
             elif is_datetimetz(values):

--- a/pandas/tests/series/test_operators.py
+++ b/pandas/tests/series/test_operators.py
@@ -267,6 +267,14 @@ class TestSeriesOperators(TestData, tm.TestCase):
         rs[2] += np.timedelta64(timedelta(minutes=5, seconds=1))
         self.assertEqual(rs[2], value)
 
+        # GH 14088
+        import pytz
+        s = Series([datetime(2016, 8, 23, 12, tzinfo=pytz.utc), pd.NaT])
+        dt = datetime(2016, 8, 22, 12, tzinfo=pytz.utc)
+        exp = Series([Timedelta('1 days'), pd.NaT])
+        self.assert_series_equal(s - dt, exp)
+        self.assert_series_equal(s - Timestamp(dt), exp)
+
     def test_operator_series_comparison_zerorank(self):
         # GH 13006
         result = np.float64(0) > pd.Series([1, 2, 3])


### PR DESCRIPTION
- [x] closes #14088
- [x] tests added / passed
- [x] passes `git diff upstream/master | flake8 --diff`
- [x] whatsnew entry
