### PR TITLE
BUG: Float64Index.get_value() for tuples.

### DIFF
--- a/doc/source/whatsnew/v0.19.0.txt
+++ b/doc/source/whatsnew/v0.19.0.txt
@@ -1253,3 +1253,4 @@ Bug Fixes
 - Bug in ``.to_string()`` when called with an integer ``line_width`` and ``index=False`` raises an UnboundLocalError exception because ``idx`` referenced before assignment.
 
 - Bug in ``read_csv()``, where aliases for utf-xx (e.g. UTF-xx, UTF_xx, utf_xx) raised UnicodeDecodeError (:issue:`13549`)
+- Bug in ``Float64Index.get_value()`` where trying to access one tuple-valued entry in a ``Series`` failed (:issue:`13509`)

--- a/pandas/indexes/numeric.py
+++ b/pandas/indexes/numeric.py
@@ -293,19 +293,11 @@ class Float64Index(NumericIndex):
         if not is_scalar(key):
             raise InvalidIndexError
 
-        from pandas.core.indexing import maybe_droplevels
-        from pandas.core.series import Series
-
         k = _values_from_object(key)
         loc = self.get_loc(k)
         new_values = _values_from_object(series)[loc]
 
-        if is_scalar(new_values) or new_values is None:
-            return new_values
-
-        new_index = self[loc]
-        new_index = maybe_droplevels(new_index, k)
-        return Series(new_values, index=new_index, name=series.name)
+        return new_values
 
     def equals(self, other):
         """

--- a/pandas/tests/indexing/test_floats.py
+++ b/pandas/tests/indexing/test_floats.py
@@ -676,3 +676,8 @@ class TestFloatIndexers(tm.TestCase):
         assert_series_equal(result1, result2)
         assert_series_equal(result1, result3)
         assert_series_equal(result1, Series([1], index=[2.5]))
+
+    def test_floating_tuples(self):
+        s = Series([(1, 1), (2, 2), (3, 3)], index=[0.0, 0.1, 0.2])
+        result = s[0.0]
+        assert result == (1, 1)


### PR DESCRIPTION
- [x] closes #13509
- [x] tests added / passed
- [x] passes `git diff upstream/master | flake8 --diff`
- [x] whatsnew entry

Currently, trying to retrieve one tuple-valued entry in a `Series` with
a `Float64Index` will fail (GH 13509). This fixes that bug.
