### PR TITLE
COMPAT/BLD: int dtype in json tests

### DIFF
--- a/pandas/io/tests/json/test_ujson.py
+++ b/pandas/io/tests/json/test_ujson.py
@@ -1321,20 +1321,22 @@ class PandasJSONTests(TestCase):
                                        numpy=True))
         outp = Series(**dec)
 
+        exp_np = Series(np.array([10, 20, 30, 40, 50, 60]))
+        exp_pd = Series([10, 20, 30, 40, 50, 60])
         outp = Series(ujson.decode(ujson.encode(s, orient="records"),
                                    numpy=True))
-        exp = Series([10, 20, 30, 40, 50, 60])
-        tm.assert_series_equal(outp, exp)
+        tm.assert_series_equal(outp, exp_np)
 
         outp = Series(ujson.decode(ujson.encode(s, orient="records")))
-        tm.assert_series_equal(outp, exp)
+        exp = Series([10, 20, 30, 40, 50, 60])
+        tm.assert_series_equal(outp, exp_pd)
 
         outp = Series(ujson.decode(ujson.encode(s, orient="values"),
                                    numpy=True))
-        tm.assert_series_equal(outp, exp)
+        tm.assert_series_equal(outp, exp_np)
 
         outp = Series(ujson.decode(ujson.encode(s, orient="values")))
-        tm.assert_series_equal(outp, exp)
+        tm.assert_series_equal(outp, exp_pd)
 
         outp = Series(ujson.decode(ujson.encode(
             s, orient="index"))).sort_values()


### PR DESCRIPTION
Fixes failing windows build
https://ci.appveyor.com/project/jreback/pandas-465/build/job/p8hju341jyhnkogc
