### PR TITLE
DEPR: Deprecate pandas.core.datetools

### DIFF
--- a/doc/source/timeseries.rst
+++ b/doc/source/timeseries.rst
@@ -7,7 +7,7 @@
    from datetime import datetime, timedelta, time
    import numpy as np
    import pandas as pd
-   from pandas import datetools
+   from pandas import offsets
    np.random.seed(123456)
    randn = np.random.randn
    randint = np.random.randint
@@ -1223,7 +1223,7 @@ The shift method accepts an ``freq`` argument which can accept a
 
 .. ipython:: python
 
-   ts.shift(5, freq=datetools.bday)
+   ts.shift(5, freq=offsets.BDay())
    ts.shift(5, freq='BM')
 
 Rather than changing the alignment of the data and the index, ``DataFrame`` and
@@ -1246,7 +1246,7 @@ around ``reindex`` which generates a ``date_range`` and calls ``reindex``.
 
 .. ipython:: python
 
-   dr = pd.date_range('1/1/2010', periods=3, freq=3 * datetools.bday)
+   dr = pd.date_range('1/1/2010', periods=3, freq=3 * offsets.BDay())
    ts = pd.Series(randn(3), index=dr)
    ts
    ts.asfreq(BDay())

--- a/doc/source/whatsnew/v0.19.0.txt
+++ b/doc/source/whatsnew/v0.19.0.txt
@@ -1231,6 +1231,7 @@ Deprecations
 
 - ``PeriodIndex.to_datetime`` has been deprecated in favour of ``PeriodIndex.to_timestamp`` (:issue:`8254`)
 - ``Timestamp.to_datetime`` has been deprecated in favour of ``Timestamp.to_pydatetime`` (:issue:`8254`)
+- ``pandas.core.datetools`` module has been deprecated and will be removed in a subsequent release (:issue:`14094`)
 - ``Index.to_datetime`` and ``DatetimeIndex.to_datetime`` have been deprecated in favour of ``pd.to_datetime`` (:issue:`8254`)
 - ``SparseList`` has been deprecated and will be removed in a future version (:issue:`13784`)
 - ``DataFrame.to_html()`` and ``DataFrame.to_latex()`` have dropped the ``colSpace`` parameter in favor of ``col_space`` (:issue:`13857`)

--- a/pandas/api/tests/test_api.py
+++ b/pandas/api/tests/test_api.py
@@ -42,7 +42,7 @@ class TestPDApi(Base, tm.TestCase):
                      'json', 'lib', 'index', 'parser']
 
     # these are already deprecated; awaiting removal
-    deprecated_modules = ['ols', 'stats']
+    deprecated_modules = ['ols', 'stats', 'datetools']
 
     # misc
     misc = ['IndexSlice', 'NaT']
@@ -61,14 +61,14 @@ class TestPDApi(Base, tm.TestCase):
                           'SparseTimeSeries', 'Panel4D',
                           'SparseList']
 
-    # these should be deperecated in the future
+    # these should be deprecated in the future
     deprecated_classes_in_future = ['Term', 'Panel']
 
     # these should be removed from top-level namespace
     remove_classes_from_top_level_namespace = ['Expr']
 
     # external modules exposed in pandas namespace
-    modules = ['np', 'datetime', 'datetools']
+    modules = ['np', 'datetime']
 
     # top-level functions
     funcs = ['bdate_range', 'concat', 'crosstab', 'cut',
@@ -99,7 +99,7 @@ class TestPDApi(Base, tm.TestCase):
     funcs_to = ['to_datetime', 'to_msgpack',
                 'to_numeric', 'to_pickle', 'to_timedelta']
 
-    # these should be deperecated in the future
+    # these should be deprecated in the future
     deprecated_funcs_in_future = ['pnow', 'groupby', 'info']
 
     # these are already deprecated; awaiting removal
@@ -207,6 +207,19 @@ class TestTypes(Base, tm.TestCase):
         for t in ['is_null_datelike_scalar',
                   'ensure_float']:
             self.assertRaises(AttributeError, lambda: getattr(com, t))
+
+
+class TestDatetools(tm.TestCase):
+
+    def test_deprecation_access_func(self):
+        with tm.assert_produces_warning(FutureWarning,
+                                        check_stacklevel=False):
+            pd.datetools.to_datetime('2016-01-01')
+
+    def test_deprecation_access_obj(self):
+        with tm.assert_produces_warning(FutureWarning,
+                                        check_stacklevel=False):
+            pd.datetools.monthEnd
 
 if __name__ == '__main__':
     import nose

--- a/pandas/core/api.py
+++ b/pandas/core/api.py
@@ -28,8 +28,18 @@ from pandas.tseries.index import (DatetimeIndex, Timestamp,
 from pandas.tseries.tdi import TimedeltaIndex, Timedelta
 from pandas.tseries.period import Period, PeriodIndex
 
-# legacy
-import pandas.core.datetools as datetools
+# see gh-14094.
+from pandas.util.depr_module import _DeprecatedModule
+
+_alts = ['pandas.tseries.tools', 'pandas.tseries.offsets',
+         'pandas.tseries.frequencies']
+_removals = ['day', 'bday', 'businessDay', 'cday', 'customBusinessDay',
+             'customBusinessMonthEnd', 'customBusinessMonthBegin',
+             'monthEnd', 'yearEnd', 'yearBegin', 'bmonthEnd', 'bmonthBegin',
+             'cbmonthEnd', 'cbmonthBegin', 'bquarterEnd', 'quarterEnd',
+             'byearEnd', 'week']
+datetools = _DeprecatedModule(deprmod='pandas.core.datetools', alts=_alts,
+                              removals=_removals)
 
 from pandas.core.config import (get_option, set_option, reset_option,
                                 describe_option, option_context, options)

--- a/pandas/core/datetools.py
+++ b/pandas/core/datetools.py
@@ -2,9 +2,15 @@
 
 # flake8: noqa
 
+import warnings
+
 from pandas.tseries.tools import *
 from pandas.tseries.offsets import *
 from pandas.tseries.frequencies import *
+
+warnings.warn("The pandas.core.datetools module is deprecated and will be "
+              "removed in a future version. Please use the pandas.tseries "
+              "module instead.", FutureWarning, stacklevel=2)
 
 day = DateOffset()
 bday = BDay()

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -42,9 +42,9 @@ from pandas.core.internals import BlockManager
 import pandas.core.algorithms as algos
 import pandas.core.common as com
 import pandas.core.missing as missing
-import pandas.core.datetools as datetools
 from pandas.formats.printing import pprint_thing
 from pandas.formats.format import format_percentiles
+from pandas.tseries.frequencies import to_offset
 from pandas import compat
 from pandas.compat.numpy import function as nv
 from pandas.compat import (map, zip, lrange, string_types,
@@ -4792,7 +4792,7 @@ class NDFrame(PandasObject):
         periods : int
             Number of periods to move, can be positive or negative
         freq : DateOffset, timedelta, or time rule string, optional
-            Increment to use from datetools module or time rule (e.g. 'EOM').
+            Increment to use from the tseries module or time rule (e.g. 'EOM').
             See Notes.
         axis : %(axes_single_arg)s
 
@@ -4865,7 +4865,7 @@ class NDFrame(PandasObject):
         periods : int
             Number of periods to move, can be positive or negative
         freq : DateOffset, timedelta, or time rule string, default None
-            Increment to use from datetools module or time rule (e.g. 'EOM')
+            Increment to use from the tseries module or time rule (e.g. 'EOM')
         axis : int or basestring
             Corresponds to the axis that contains the Index
 
@@ -4895,11 +4895,11 @@ class NDFrame(PandasObject):
             return self
 
         if isinstance(freq, string_types):
-            freq = datetools.to_offset(freq)
+            freq = to_offset(freq)
 
         block_axis = self._get_block_manager_axis(axis)
         if isinstance(index, PeriodIndex):
-            orig_freq = datetools.to_offset(index.freq)
+            orig_freq = to_offset(index.freq)
             if freq == orig_freq:
                 new_data = self._data.copy()
                 new_data.axes[block_axis] = index.shift(periods)

--- a/pandas/io/tests/test_sql.py
+++ b/pandas/io/tests/test_sql.py
@@ -37,7 +37,7 @@ from pandas import DataFrame, Series, Index, MultiIndex, isnull, concat
 from pandas import date_range, to_datetime, to_timedelta, Timestamp
 import pandas.compat as compat
 from pandas.compat import StringIO, range, lrange, string_types
-from pandas.core.datetools import format as date_format
+from pandas.tseries.tools import format as date_format
 
 import pandas.io.sql as sql
 from pandas.io.sql import read_sql_table, read_sql_query

--- a/pandas/sparse/tests/test_frame.py
+++ b/pandas/sparse/tests/test_frame.py
@@ -8,7 +8,7 @@ import pandas as pd
 
 from pandas import Series, DataFrame, bdate_range, Panel
 from pandas.tseries.index import DatetimeIndex
-import pandas.core.datetools as datetools
+from pandas.tseries.offsets import BDay
 import pandas.util.testing as tm
 from pandas.compat import lrange
 from pandas import compat
@@ -850,8 +850,8 @@ class TestSparseDataFrame(tm.TestCase, SharedWithSparse):
             exp = exp.to_sparse(frame.default_fill_value)
             tm.assert_frame_equal(shifted, exp)
 
-            shifted = frame.shift(2, freq=datetools.bday)
-            exp = orig.shift(2, freq=datetools.bday)
+            shifted = frame.shift(2, freq=BDay())
+            exp = orig.shift(2, freq=BDay())
             exp = exp.to_sparse(frame.default_fill_value)
             tm.assert_frame_equal(shifted, exp)
 

--- a/pandas/sparse/tests/test_series.py
+++ b/pandas/sparse/tests/test_series.py
@@ -7,9 +7,8 @@ import numpy as np
 import pandas as pd
 
 from pandas import Series, DataFrame, bdate_range
-from pandas.core.datetools import BDay
-import pandas.core.datetools as datetools
 from pandas.core.common import isnull
+from pandas.tseries.offsets import BDay
 import pandas.util.testing as tm
 from pandas.compat import range
 from pandas import compat
@@ -843,7 +842,7 @@ class TestSparseSeries(tm.TestCase, SharedWithSparse):
         f = lambda s: s.shift(2, freq='B')
         _dense_series_compare(series, f)
 
-        f = lambda s: s.shift(2, freq=datetools.bday)
+        f = lambda s: s.shift(2, freq=BDay())
         _dense_series_compare(series, f)
 
     def test_shift_nan(self):

--- a/pandas/stats/tests/test_ols.py
+++ b/pandas/stats/tests/test_ols.py
@@ -16,7 +16,7 @@ import numpy as np
 
 from pandas import date_range, bdate_range
 from pandas.core.panel import Panel
-from pandas import DataFrame, Index, Series, notnull, datetools
+from pandas import DataFrame, Index, Series, notnull, offsets
 from pandas.stats.api import ols
 from pandas.stats.ols import _filter_data
 from pandas.stats.plm import NonPooledPanelOLS, PanelOLS
@@ -24,7 +24,7 @@ from pandas.util.testing import (assert_almost_equal, assert_series_equal,
                                  assert_frame_equal, assertRaisesRegexp, slow)
 import pandas.util.testing as tm
 import pandas.compat as compat
-from .common import BaseTest
+from pandas.stats.tests.common import BaseTest
 
 _have_statsmodels = True
 try:
@@ -898,22 +898,22 @@ class TestOLSFilter(tm.TestCase):
 
     def setUp(self):
         date_index = date_range(datetime(2009, 12, 11), periods=3,
-                                freq=datetools.bday)
+                                freq=offsets.BDay())
         ts = Series([3, 1, 4], index=date_index)
         self.TS1 = ts
 
         date_index = date_range(datetime(2009, 12, 11), periods=5,
-                                freq=datetools.bday)
+                                freq=offsets.BDay())
         ts = Series([1, 5, 9, 2, 6], index=date_index)
         self.TS2 = ts
 
         date_index = date_range(datetime(2009, 12, 11), periods=3,
-                                freq=datetools.bday)
+                                freq=offsets.BDay())
         ts = Series([5, np.nan, 3], index=date_index)
         self.TS3 = ts
 
         date_index = date_range(datetime(2009, 12, 11), periods=5,
-                                freq=datetools.bday)
+                                freq=offsets.BDay())
         ts = Series([np.nan, 5, 8, 9, 7], index=date_index)
         self.TS4 = ts
 

--- a/pandas/tests/frame/test_indexing.py
+++ b/pandas/tests/frame/test_indexing.py
@@ -17,6 +17,7 @@ from pandas import (DataFrame, Index, Series, notnull, isnull,
                     date_range)
 import pandas as pd
 
+from pandas.tseries.offsets import BDay
 from pandas.types.common import (is_float_dtype,
                                  is_integer,
                                  is_scalar)
@@ -2068,8 +2069,6 @@ class TestDataFrameIndexing(tm.TestCase, TestData):
         assert_frame_equal(result, df)
 
     def test_xs(self):
-        from pandas.core.datetools import bday
-
         idx = self.frame.index[5]
         xs = self.frame.xs(idx)
         for item, value in compat.iteritems(xs):
@@ -2090,7 +2089,7 @@ class TestDataFrameIndexing(tm.TestCase, TestData):
         self.assertEqual(xs['B'], '1')
 
         with tm.assertRaises(KeyError):
-            self.tsframe.xs(self.tsframe.index[0] - bday)
+            self.tsframe.xs(self.tsframe.index[0] - BDay())
 
         # xs get column
         series = self.frame.xs('A', axis=1)
@@ -2772,3 +2771,9 @@ class TestDataFrameIndexingDatetimeWithTZ(tm.TestCase, TestData):
         expected = DataFrame(self.df.values.T)
         expected.index = ['A', 'B']
         assert_frame_equal(result, expected)
+
+
+if __name__ == '__main__':
+    import nose
+    nose.runmodule(argv=[__file__, '-vvs', '-x', '--pdb', '--pdb-failure'],
+                   exit=False)

--- a/pandas/tests/frame/test_timeseries.py
+++ b/pandas/tests/frame/test_timeseries.py
@@ -10,7 +10,7 @@ import numpy as np
 
 from pandas import DataFrame, Series, Index, Timestamp, DatetimeIndex
 import pandas as pd
-import pandas.core.datetools as datetools
+import pandas.tseries.offsets as offsets
 
 from pandas.util.testing import (assert_almost_equal,
                                  assert_series_equal,
@@ -136,14 +136,14 @@ class TestDataFrameTimeSeriesMethods(tm.TestCase, TestData):
         assert_frame_equal(unshifted, self.tsframe)
 
         # shift by DateOffset
-        shiftedFrame = self.tsframe.shift(5, freq=datetools.BDay())
+        shiftedFrame = self.tsframe.shift(5, freq=offsets.BDay())
         self.assertEqual(len(shiftedFrame), len(self.tsframe))
 
         shiftedFrame2 = self.tsframe.shift(5, freq='B')
         assert_frame_equal(shiftedFrame, shiftedFrame2)
 
         d = self.tsframe.index[0]
-        shifted_d = d + datetools.BDay(5)
+        shifted_d = d + offsets.BDay(5)
         assert_series_equal(self.tsframe.xs(d),
                             shiftedFrame.xs(shifted_d), check_names=False)
 
@@ -160,7 +160,7 @@ class TestDataFrameTimeSeriesMethods(tm.TestCase, TestData):
                                     ps.ix[:-1, 0].values)
 
         shifted2 = ps.shift(1, 'B')
-        shifted3 = ps.shift(1, datetools.bday)
+        shifted3 = ps.shift(1, offsets.BDay())
         assert_frame_equal(shifted2, shifted3)
         assert_frame_equal(ps, shifted2.shift(-1, 'B'))
 
@@ -222,7 +222,7 @@ class TestDataFrameTimeSeriesMethods(tm.TestCase, TestData):
         shifted2 = ps.tshift(freq='B')
         assert_frame_equal(shifted, shifted2)
 
-        shifted3 = ps.tshift(freq=datetools.bday)
+        shifted3 = ps.tshift(freq=offsets.BDay())
         assert_frame_equal(shifted, shifted3)
 
         assertRaisesRegexp(ValueError, 'does not match', ps.tshift, freq='M')
@@ -297,7 +297,7 @@ class TestDataFrameTimeSeriesMethods(tm.TestCase, TestData):
         self.assertFalse((self.tsframe.values[5:11] == 5).any())
 
     def test_asfreq(self):
-        offset_monthly = self.tsframe.asfreq(datetools.bmonthEnd)
+        offset_monthly = self.tsframe.asfreq(offsets.BMonthEnd())
         rule_monthly = self.tsframe.asfreq('BM')
 
         assert_almost_equal(offset_monthly['A'], rule_monthly['A'])
@@ -365,3 +365,9 @@ class TestDataFrameTimeSeriesMethods(tm.TestCase, TestData):
         res = df.max()
         exp = pd.Series([pd.NaT], index=["foo"])
         tm.assert_series_equal(res, exp)
+
+
+if __name__ == '__main__':
+    import nose
+    nose.runmodule(argv=[__file__, '-vvs', '-x', '--pdb', '--pdb-failure'],
+                   exit=False)

--- a/pandas/tests/series/test_indexing.py
+++ b/pandas/tests/series/test_indexing.py
@@ -12,15 +12,15 @@ from pandas import Index, Series, DataFrame, isnull, date_range
 from pandas.core.index import MultiIndex
 from pandas.core.indexing import IndexingError
 from pandas.tseries.index import Timestamp
+from pandas.tseries.offsets import BDay
 from pandas.tseries.tdi import Timedelta
 
-import pandas.core.datetools as datetools
 from pandas.compat import lrange, range
 from pandas import compat
 from pandas.util.testing import assert_series_equal, assert_almost_equal
 import pandas.util.testing as tm
 
-from .common import TestData
+from pandas.tests.series.common import TestData
 
 JOIN_TYPES = ['inner', 'outer', 'left', 'right']
 
@@ -153,7 +153,7 @@ class TestSeriesIndexing(TestData, tm.TestCase):
         self.assertEqual(self.series[5], self.series.get(self.series.index[5]))
 
         # missing
-        d = self.ts.index[0] - datetools.bday
+        d = self.ts.index[0] - BDay()
         self.assertRaises(KeyError, self.ts.__getitem__, d)
 
         # None
@@ -321,7 +321,7 @@ class TestSeriesIndexing(TestData, tm.TestCase):
 
     def test_getitem_setitem_boolean_corner(self):
         ts = self.ts
-        mask_shifted = ts.shift(1, freq=datetools.bday) > ts.median()
+        mask_shifted = ts.shift(1, freq=BDay()) > ts.median()
 
         # these used to raise...??
 
@@ -1856,3 +1856,8 @@ class TestSeriesIndexing(TestData, tm.TestCase):
         result2 = s.ix['foo']
         self.assertEqual(result.name, s.name)
         self.assertEqual(result2.name, s.name)
+
+if __name__ == '__main__':
+    import nose
+    nose.runmodule(argv=[__file__, '-vvs', '-x', '--pdb', '--pdb-failure'],
+                   exit=False)

--- a/pandas/tests/series/test_timeseries.py
+++ b/pandas/tests/series/test_timeseries.py
@@ -7,14 +7,13 @@ import numpy as np
 
 from pandas import Index, Series, date_range, NaT
 from pandas.tseries.index import DatetimeIndex
+from pandas.tseries.offsets import BDay, BMonthEnd
 from pandas.tseries.tdi import TimedeltaIndex
-
-import pandas.core.datetools as datetools
 
 from pandas.util.testing import assert_series_equal, assert_almost_equal
 import pandas.util.testing as tm
 
-from .common import TestData
+from pandas.tests.series.common import TestData
 
 
 class TestSeriesTimeSeries(TestData, tm.TestCase):
@@ -29,7 +28,7 @@ class TestSeriesTimeSeries(TestData, tm.TestCase):
         tm.assert_numpy_array_equal(unshifted.valid().values,
                                     self.ts.values[:-1])
 
-        offset = datetools.bday
+        offset = BDay()
         shifted = self.ts.shift(1, freq=offset)
         unshifted = shifted.shift(-1, freq=offset)
 
@@ -56,7 +55,7 @@ class TestSeriesTimeSeries(TestData, tm.TestCase):
         tm.assert_numpy_array_equal(unshifted.valid().values, ps.values[:-1])
 
         shifted2 = ps.shift(1, 'B')
-        shifted3 = ps.shift(1, datetools.bday)
+        shifted3 = ps.shift(1, BDay())
         assert_series_equal(shifted2, shifted3)
         assert_series_equal(ps, shifted2.shift(-1, 'B'))
 
@@ -66,7 +65,7 @@ class TestSeriesTimeSeries(TestData, tm.TestCase):
         shifted4 = ps.shift(1, freq='B')
         assert_series_equal(shifted2, shifted4)
 
-        shifted5 = ps.shift(1, freq=datetools.bday)
+        shifted5 = ps.shift(1, freq=BDay())
         assert_series_equal(shifted5, shifted4)
 
         # 32-bit taking
@@ -131,7 +130,7 @@ class TestSeriesTimeSeries(TestData, tm.TestCase):
         shifted2 = ps.tshift(freq='B')
         assert_series_equal(shifted, shifted2)
 
-        shifted3 = ps.tshift(freq=datetools.bday)
+        shifted3 = ps.tshift(freq=BDay())
         assert_series_equal(shifted, shifted3)
 
         self.assertRaises(ValueError, ps.tshift, freq='M')
@@ -156,7 +155,7 @@ class TestSeriesTimeSeries(TestData, tm.TestCase):
         self.assertRaises(ValueError, no_freq.tshift)
 
     def test_truncate(self):
-        offset = datetools.bday
+        offset = BDay()
 
         ts = self.ts[::3]
 
@@ -417,8 +416,8 @@ class TestSeriesTimeSeries(TestData, tm.TestCase):
         monthly_ts = daily_ts.asfreq('BM')
         self.assert_series_equal(monthly_ts, ts)
 
-        daily_ts = ts.asfreq(datetools.bday)
-        monthly_ts = daily_ts.asfreq(datetools.bmonthEnd)
+        daily_ts = ts.asfreq(BDay())
+        monthly_ts = daily_ts.asfreq(BMonthEnd())
         self.assert_series_equal(monthly_ts, ts)
 
         result = ts[:0].asfreq('M')
@@ -561,3 +560,9 @@ class TestSeriesTimeSeries(TestData, tm.TestCase):
         assert_series_equal(a, a - b)
         assert_series_equal(a, b + a)
         self.assertRaises(TypeError, lambda x, y: x - y, b, a)
+
+
+if __name__ == '__main__':
+    import nose
+    nose.runmodule(argv=[__file__, '-vvs', '-x', '--pdb', '--pdb-failure'],
+                   exit=False)

--- a/pandas/tests/test_panel.py
+++ b/pandas/tests/test_panel.py
@@ -10,8 +10,8 @@ import numpy as np
 import pandas as pd
 
 from pandas.types.common import is_float_dtype
-from pandas import Series, DataFrame, Index, isnull, notnull, pivot, MultiIndex
-from pandas.core.datetools import bday
+from pandas import (Series, DataFrame, Index, date_range, isnull, notnull,
+                    pivot, MultiIndex)
 from pandas.core.nanops import nanall, nanany
 from pandas.core.panel import Panel
 from pandas.core.series import remove_na
@@ -20,6 +20,7 @@ from pandas.formats.printing import pprint_thing
 from pandas import compat
 from pandas.compat import range, lrange, StringIO, OrderedDict, signature
 
+from pandas.tseries.offsets import BDay, MonthEnd
 from pandas.util.testing import (assert_panel_equal, assert_frame_equal,
                                  assert_series_equal, assert_almost_equal,
                                  ensure_clean, assertRaisesRegexp,
@@ -500,11 +501,9 @@ class CheckIndexing(object):
             p[0] = np.random.randn(4, 2)
 
     def test_setitem_ndarray(self):
-        from pandas import date_range, datetools
-
         timeidx = date_range(start=datetime(2009, 1, 1),
                              end=datetime(2009, 12, 31),
-                             freq=datetools.MonthEnd())
+                             freq=MonthEnd())
         lons_coarse = np.linspace(-177.5, 177.5, 72)
         lats_coarse = np.linspace(-87.5, 87.5, 36)
         P = Panel(items=timeidx, major_axis=lons_coarse,
@@ -542,7 +541,7 @@ class CheckIndexing(object):
         self.assertEqual(result.name, 'ItemA')
 
         # not contained
-        idx = self.panel.major_axis[0] - bday
+        idx = self.panel.major_axis[0] - BDay()
         self.assertRaises(Exception, self.panel.major_xs, idx)
 
     def test_major_xs_mixed(self):
@@ -1878,7 +1877,7 @@ class TestPanel(tm.TestCase, PanelTests, CheckIndexing, SafeForLongAndSparse,
         shifted2 = ps.tshift(freq='B')
         assert_panel_equal(shifted, shifted2)
 
-        shifted3 = ps.tshift(freq=bday)
+        shifted3 = ps.tshift(freq=BDay())
         assert_panel_equal(shifted, shifted3)
 
         assertRaisesRegexp(ValueError, 'does not match', ps.tshift, freq='M')

--- a/pandas/tests/test_panel4d.py
+++ b/pandas/tests/test_panel4d.py
@@ -8,10 +8,10 @@ import numpy as np
 
 from pandas.types.common import is_float_dtype
 from pandas import Series, Index, isnull, notnull
-from pandas.core.datetools import bday
 from pandas.core.panel import Panel
 from pandas.core.panel4d import Panel4D
 from pandas.core.series import remove_na
+from pandas.tseries.offsets import BDay
 
 from pandas.util.testing import (assert_panel_equal,
                                  assert_panel4d_equal,
@@ -479,7 +479,7 @@ class CheckIndexing(object):
                             ref.xs(idx), check_names=False)
 
         # not contained
-        idx = self.panel4d.major_axis[0] - bday
+        idx = self.panel4d.major_axis[0] - BDay()
         self.assertRaises(Exception, self.panel4d.major_xs, idx)
 
     def test_major_xs_mixed(self):

--- a/pandas/tests/test_window.py
+++ b/pandas/tests/test_window.py
@@ -12,9 +12,9 @@ from distutils.version import LooseVersion
 import pandas as pd
 from pandas import (Series, DataFrame, Panel, bdate_range, isnull,
                     notnull, concat, Timestamp)
-import pandas.core.datetools as datetools
 import pandas.stats.moments as mom
 import pandas.core.window as rwindow
+import pandas.tseries.offsets as offsets
 from pandas.core.base import SpecificationError
 from pandas.core.common import UnsupportedFunctionCall
 import pandas.util.testing as tm
@@ -1321,7 +1321,7 @@ class TestMoments(Base):
                                           freq='B')
 
             last_date = series_result.index[-1]
-            prev_date = last_date - 24 * datetools.bday
+            prev_date = last_date - 24 * offsets.BDay()
 
             trunc_series = self.series[::2].truncate(prev_date, last_date)
             trunc_frame = self.frame[::2].truncate(prev_date, last_date)

--- a/pandas/tseries/tests/test_period.py
+++ b/pandas/tseries/tests/test_period.py
@@ -16,7 +16,6 @@ from pandas.tseries.tools import to_datetime
 import pandas.tseries.period as period
 import pandas.tseries.offsets as offsets
 
-import pandas.core.datetools as datetools
 import pandas as pd
 import numpy as np
 from numpy.random import randn
@@ -2910,9 +2909,9 @@ class TestPeriodIndex(tm.TestCase):
         tm.assert_index_equal(result.index, index.asfreq('D', how='start'))
 
     def test_badinput(self):
-        self.assertRaises(datetools.DateParseError, Period, '1/1/-2000', 'A')
-        # self.assertRaises(datetools.DateParseError, Period, '-2000', 'A')
-        # self.assertRaises(datetools.DateParseError, Period, '0', 'A')
+        self.assertRaises(ValueError, Period, '-2000', 'A')
+        self.assertRaises(tslib.DateParseError, Period, '0', 'A')
+        self.assertRaises(tslib.DateParseError, Period, '1/1/-2000', 'A')
 
     def test_negative_ordinals(self):
         Period(ordinal=-1000, freq='A')

--- a/pandas/tseries/tests/test_timeseries.py
+++ b/pandas/tseries/tests/test_timeseries.py
@@ -16,7 +16,6 @@ from pandas.types.common import is_datetime64_ns_dtype
 import pandas as pd
 import pandas.compat as compat
 import pandas.core.common as com
-import pandas.core.datetools as datetools
 import pandas.tseries.frequencies as frequencies
 import pandas.tseries.offsets as offsets
 import pandas.tseries.tools as tools
@@ -566,7 +565,7 @@ class TestTimeSeries(tm.TestCase):
     def test_frame_setitem_timestamp(self):
         # 2155
         columns = DatetimeIndex(start='1/1/2012', end='2/1/2012',
-                                freq=datetools.bday)
+                                freq=offsets.BDay())
         index = lrange(10)
         data = DataFrame(columns=columns, index=index)
         t = datetime(2012, 11, 1)
@@ -1918,7 +1917,7 @@ class TestTimeSeries(tm.TestCase):
         self.assertEqual(casted.tolist(), exp_values)
 
     def test_catch_infinite_loop(self):
-        offset = datetools.DateOffset(minute=5)
+        offset = offsets.DateOffset(minute=5)
         # blow up, don't loop forever
         self.assertRaises(Exception, date_range, datetime(2011, 11, 11),
                           datetime(2011, 11, 12), freq=offset)
@@ -2544,7 +2543,7 @@ class TestToDatetime(tm.TestCase):
         with tm.assert_produces_warning(FutureWarning,
                                         check_stacklevel=False):
             result = idx.to_datetime()
-            expected = DatetimeIndex(datetools.to_datetime(idx.values))
+            expected = DatetimeIndex(pd.to_datetime(idx.values))
             tm.assert_index_equal(result, expected)
 
         with tm.assert_produces_warning(FutureWarning,
@@ -3779,7 +3778,7 @@ class TestDatetimeIndex(tm.TestCase):
         dtstart = np.datetime64('2012-09-20T00:00:00')
 
         dt = dtstart + np.arange(nsamples) * np.timedelta64(ns, 'ns')
-        freq = ns * pd.datetools.Nano()
+        freq = ns * offsets.Nano()
         index = pd.DatetimeIndex(dt, freq=freq, name='time')
         self.assert_index_parameters(index)
 
@@ -4134,7 +4133,7 @@ class TestDatetime64(tm.TestCase):
         edate = datetime(2000, 1, 1)
         idx = DatetimeIndex(start=sdate, freq='1B', periods=20)
         self.assertEqual(len(idx), 20)
-        self.assertEqual(idx[0], sdate + 0 * datetools.bday)
+        self.assertEqual(idx[0], sdate + 0 * offsets.BDay())
         self.assertEqual(idx.freq, 'B')
 
         idx = DatetimeIndex(end=edate, freq=('D', 5), periods=20)
@@ -4144,19 +4143,19 @@ class TestDatetime64(tm.TestCase):
 
         idx1 = DatetimeIndex(start=sdate, end=edate, freq='W-SUN')
         idx2 = DatetimeIndex(start=sdate, end=edate,
-                             freq=datetools.Week(weekday=6))
+                             freq=offsets.Week(weekday=6))
         self.assertEqual(len(idx1), len(idx2))
         self.assertEqual(idx1.offset, idx2.offset)
 
         idx1 = DatetimeIndex(start=sdate, end=edate, freq='QS')
         idx2 = DatetimeIndex(start=sdate, end=edate,
-                             freq=datetools.QuarterBegin(startingMonth=1))
+                             freq=offsets.QuarterBegin(startingMonth=1))
         self.assertEqual(len(idx1), len(idx2))
         self.assertEqual(idx1.offset, idx2.offset)
 
         idx1 = DatetimeIndex(start=sdate, end=edate, freq='BQ')
         idx2 = DatetimeIndex(start=sdate, end=edate,
-                             freq=datetools.BQuarterEnd(startingMonth=12))
+                             freq=offsets.BQuarterEnd(startingMonth=12))
         self.assertEqual(len(idx1), len(idx2))
         self.assertEqual(idx1.offset, idx2.offset)
 
@@ -5019,7 +5018,7 @@ class TestSlicing(tm.TestCase):
 
         # GH #1063, multiple of same base
         result = ts.shift(1, freq='4H')
-        exp_index = ts.index + datetools.Hour(4)
+        exp_index = ts.index + offsets.Hour(4)
         tm.assert_index_equal(result.index, exp_index)
 
         idx = DatetimeIndex(['2000-01-01', '2000-01-02', '2000-01-04'])

--- a/pandas/tseries/tests/test_timeseries_legacy.py
+++ b/pandas/tseries/tests/test_timeseries_legacy.py
@@ -8,8 +8,8 @@ import numpy as np
 from pandas import (Index, Series, date_range, Timestamp,
                     DatetimeIndex, Int64Index, to_datetime)
 
-import pandas.core.datetools as datetools
-import pandas.tseries.offsets as offsets
+from pandas.tseries.frequencies import get_offset, to_offset
+from pandas.tseries.offsets import BDay, Micro, Milli, MonthBegin
 import pandas as pd
 
 from pandas.util.testing import assert_series_equal, assert_almost_equal
@@ -19,12 +19,11 @@ from pandas.compat import StringIO, cPickle as pickle
 from pandas import read_pickle
 from numpy.random import rand
 import pandas.compat as compat
-from pandas.core.datetools import BDay
 
 randn = np.random.randn
 
 
-# infortunately, too much has changed to handle these legacy pickles
+# Unfortunately, too much has changed to handle these legacy pickles
 # class TestLegacySupport(unittest.TestCase):
 class LegacySupport(object):
 
@@ -65,8 +64,6 @@ class LegacySupport(object):
         self.assertEqual(unpickled.index.offset, BDay(1, normalize=True))
 
     def test_unpickle_legacy_series(self):
-        from pandas.core.datetools import BDay
-
         unpickled = self.series
 
         dtindex = DatetimeIndex(start='1/3/2005', end='1/14/2005',
@@ -86,7 +83,7 @@ class LegacySupport(object):
         ex_index = DatetimeIndex([], freq='B')
 
         self.assert_index_equal(result.index, ex_index)
-        tm.assertIsInstance(result.index.freq, offsets.BDay)
+        tm.assertIsInstance(result.index.freq, BDay)
         self.assertEqual(len(result), 0)
 
     def test_arithmetic_interaction(self):
@@ -140,7 +137,7 @@ class LegacySupport(object):
 
         rng = read_pickle(filepath)
         tm.assertIsInstance(rng[0], datetime)
-        tm.assertIsInstance(rng.offset, offsets.BDay)
+        tm.assertIsInstance(rng.offset, BDay)
         self.assertEqual(rng.values.dtype, object)
 
     def test_setops(self):
@@ -213,20 +210,15 @@ class LegacySupport(object):
             new_rng = date_range(start, end, freq=new_freq)
             self.assert_index_equal(old_rng, new_rng)
 
-            # test get_legacy_offset_name
-            offset = datetools.get_offset(new_freq)
-            old_name = datetools.get_legacy_offset_name(offset)
-            self.assertEqual(old_name, old_freq)
-
     def test_ms_vs_MS(self):
-        left = datetools.get_offset('ms')
-        right = datetools.get_offset('MS')
-        self.assertEqual(left, datetools.Milli())
-        self.assertEqual(right, datetools.MonthBegin())
+        left = get_offset('ms')
+        right = get_offset('MS')
+        self.assertEqual(left, Milli())
+        self.assertEqual(right, MonthBegin())
 
     def test_rule_aliases(self):
-        rule = datetools.to_offset('10us')
-        self.assertEqual(rule, datetools.Micro(10))
+        rule = to_offset('10us')
+        self.assertEqual(rule, Micro(10))
 
 
 if __name__ == '__main__':

--- a/pandas/tseries/tests/test_timezones.py
+++ b/pandas/tseries/tests/test_timezones.py
@@ -11,7 +11,6 @@ from pandas import (Index, Series, DataFrame, isnull, Timestamp)
 from pandas import DatetimeIndex, to_datetime, NaT
 from pandas import tslib
 
-import pandas.core.datetools as datetools
 import pandas.tseries.offsets as offsets
 from pandas.tseries.index import bdate_range, date_range
 import pandas.tseries.tools as tools
@@ -371,7 +370,7 @@ class TestTimeZoneSupportPytz(tm.TestCase):
 
         # just want it to work
         start = datetime(2011, 3, 12, tzinfo=pytz.utc)
-        dr = bdate_range(start, periods=50, freq=datetools.Hour())
+        dr = bdate_range(start, periods=50, freq=offsets.Hour())
         self.assertIs(dr.tz, pytz.utc)
 
         # DateRange with naive datetimes
@@ -409,33 +408,33 @@ class TestTimeZoneSupportPytz(tm.TestCase):
 
         # March 13, 2011, spring forward, skip from 2 AM to 3 AM
         dr = date_range(datetime(2011, 3, 13, 1, 30), periods=3,
-                        freq=datetools.Hour())
+                        freq=offsets.Hour())
         self.assertRaises(pytz.NonExistentTimeError, dr.tz_localize, tz)
 
         # after dst transition, it works
         dr = date_range(datetime(2011, 3, 13, 3, 30), periods=3,
-                        freq=datetools.Hour(), tz=tz)
+                        freq=offsets.Hour(), tz=tz)
 
         # November 6, 2011, fall back, repeat 2 AM hour
         dr = date_range(datetime(2011, 11, 6, 1, 30), periods=3,
-                        freq=datetools.Hour())
+                        freq=offsets.Hour())
         self.assertRaises(pytz.AmbiguousTimeError, dr.tz_localize, tz)
 
         # UTC is OK
         dr = date_range(datetime(2011, 3, 13), periods=48,
-                        freq=datetools.Minute(30), tz=pytz.utc)
+                        freq=offsets.Minute(30), tz=pytz.utc)
 
     def test_ambiguous_infer(self):
         # November 6, 2011, fall back, repeat 2 AM hour
         # With no repeated hours, we cannot infer the transition
         tz = self.tz('US/Eastern')
         dr = date_range(datetime(2011, 11, 6, 0), periods=5,
-                        freq=datetools.Hour())
+                        freq=offsets.Hour())
         self.assertRaises(pytz.AmbiguousTimeError, dr.tz_localize, tz)
 
         # With repeated hours, we can infer the transition
         dr = date_range(datetime(2011, 11, 6, 0), periods=5,
-                        freq=datetools.Hour(), tz=tz)
+                        freq=offsets.Hour(), tz=tz)
         times = ['11/06/2011 00:00', '11/06/2011 01:00', '11/06/2011 01:00',
                  '11/06/2011 02:00', '11/06/2011 03:00']
         di = DatetimeIndex(times)
@@ -449,7 +448,7 @@ class TestTimeZoneSupportPytz(tm.TestCase):
 
         # When there is no dst transition, nothing special happens
         dr = date_range(datetime(2011, 6, 1, 0), periods=10,
-                        freq=datetools.Hour())
+                        freq=offsets.Hour())
         localized = dr.tz_localize(tz)
         localized_infer = dr.tz_localize(tz, ambiguous='infer')
         self.assert_index_equal(localized, localized_infer)
@@ -463,7 +462,7 @@ class TestTimeZoneSupportPytz(tm.TestCase):
 
         # Pass in flags to determine right dst transition
         dr = date_range(datetime(2011, 11, 6, 0), periods=5,
-                        freq=datetools.Hour(), tz=tz)
+                        freq=offsets.Hour(), tz=tz)
         times = ['11/06/2011 00:00', '11/06/2011 01:00', '11/06/2011 01:00',
                  '11/06/2011 02:00', '11/06/2011 03:00']
 
@@ -501,7 +500,7 @@ class TestTimeZoneSupportPytz(tm.TestCase):
 
         # When there is no dst transition, nothing special happens
         dr = date_range(datetime(2011, 6, 1, 0), periods=10,
-                        freq=datetools.Hour())
+                        freq=offsets.Hour())
         is_dst = np.array([1] * 10)
         localized = dr.tz_localize(tz)
         localized_is_dst = dr.tz_localize(tz, ambiguous=is_dst)

--- a/pandas/util/depr_module.py
+++ b/pandas/util/depr_module.py
@@ -1,0 +1,79 @@
+"""
+This module houses a utility class for mocking deprecated modules.
+It is for internal use only and should not be used beyond this purpose.
+"""
+
+import warnings
+import importlib
+
+
+class _DeprecatedModule(object):
+    """ Class for mocking deprecated modules.
+
+    Parameters
+    ----------
+    deprmod : name of module to be deprecated.
+    alts : alternative modules to be used to access objects or methods
+           available in module.
+    removals : objects or methods in module that will no longer be
+               accessible once module is removed.
+    """
+    def __init__(self, deprmod, alts=None, removals=None):
+        self.deprmod = deprmod
+
+        self.alts = alts
+        if self.alts is not None:
+            self.alts = frozenset(self.alts)
+
+        self.removals = removals
+        if self.removals is not None:
+            self.removals = frozenset(self.removals)
+
+        # For introspection purposes.
+        self.self_dir = frozenset(dir(self.__class__))
+
+    def __dir__(self):
+        _dir = object.__dir__(self)
+
+        if self.removals is not None:
+            _dir.extend(list(self.removals))
+
+        if self.alts is not None:
+            for modname in self.alts:
+                module = importlib.import_module(modname)
+                _dir.extend(dir(module))
+
+        return _dir
+
+    def __getattr__(self, name):
+        if name in self.self_dir:
+            return object.__getattribute__(self, name)
+
+        if self.removals is not None and name in self.removals:
+            with warnings.catch_warnings():
+                warnings.filterwarnings('ignore', category=FutureWarning)
+                module = importlib.import_module(self.deprmod)
+
+            warnings.warn(
+                "{deprmod}.{name} is deprecated and will be removed in "
+                "a future version.".format(deprmod=self.deprmod, name=name),
+                FutureWarning, stacklevel=2)
+
+            return object.__getattribute__(module, name)
+
+        if self.alts is not None:
+            for modname in self.alts:
+                module = importlib.import_module(modname)
+
+                if hasattr(module, name):
+                    warnings.warn(
+                        "{deprmod}.{name} is deprecated. Please use "
+                        "{modname}.{name} instead.".format(
+                            deprmod=self.deprmod, modname=modname, name=name),
+                        FutureWarning, stacklevel=2)
+
+                    return getattr(module, name)
+
+        raise AttributeError("module '{deprmod}' has no attribute "
+                             "'{name}'".format(deprmod=self.deprmod,
+                                               name=name))

--- a/scripts/bench_join.py
+++ b/scripts/bench_join.py
@@ -12,9 +12,9 @@ pct_overlap = 0.2
 a = np.arange(n, dtype=np.int64)
 b = np.arange(n * pct_overlap, n * (1 + pct_overlap), dtype=np.int64)
 
-dr1 = DatetimeIndex('1/1/2000', periods=n, offset=datetools.Minute())
+dr1 = DatetimeIndex('1/1/2000', periods=n, offset=offsets.Minute())
 dr2 = DatetimeIndex(
-    dr1[int(pct_overlap * n)], periods=n, offset=datetools.Minute(2))
+    dr1[int(pct_overlap * n)], periods=n, offset=offsets.Minute(2))
 
 aobj = a.astype(object)
 bobj = b.astype(object)

--- a/scripts/groupby_speed.py
+++ b/scripts/groupby_speed.py
@@ -1,12 +1,12 @@
 from __future__ import print_function
 from pandas import *
 
-rng = DatetimeIndex('1/3/2011', '11/30/2011', offset=datetools.Minute())
+rng = DatetimeIndex('1/3/2011', '11/30/2011', offset=offsets.Minute())
 
 df = DataFrame(np.random.randn(len(rng), 5), index=rng,
                columns=list('OHLCV'))
 
-rng5 = DatetimeIndex('1/3/2011', '11/30/2011', offset=datetools.Minute(5))
+rng5 = DatetimeIndex('1/3/2011', '11/30/2011', offset=offsets.Minute(5))
 gp = rng5.asof
 grouped = df.groupby(gp)
 

--- a/scripts/hdfstore_panel_perf.py
+++ b/scripts/hdfstore_panel_perf.py
@@ -7,7 +7,7 @@ i, j, k = 7, 771, 5532
 panel = Panel(np.random.randn(i, j, k),
               items=[rands(10) for _ in range(i)],
               major_axis=DatetimeIndex('1/1/2000', periods=j,
-                                   offset=datetools.Minute()),
+                                       offset=offsets.Minute()),
               minor_axis=[rands(10) for _ in range(k)])
 
 


### PR DESCRIPTION
Title is self-explanatory.  Closes #14094.
