### PR TITLE
BUG: pass *args and **kwargs for wrapped methods in Groupby (#14107)

### DIFF
--- a/pandas/core/groupby.py
+++ b/pandas/core/groupby.py
@@ -2554,7 +2554,7 @@ def %(name)s(self) :
             # GroupBy._make_wrapper won't know whether
             # we passed in an axis parameter.
             args_by_name = ['{0}={0}'.format(arg) for arg in args[1:]]
-            # if the original signature takes either *args or **kwargs, pass them along in the same manner
+            # include *args or **kwargs if the original signature takes them
             args_by_name.extend(
                 declitem for declitem in decl if declitem.startswith('*')
             )

--- a/pandas/core/groupby.py
+++ b/pandas/core/groupby.py
@@ -2554,6 +2554,10 @@ def %(name)s(self) :
             # GroupBy._make_wrapper won't know whether
             # we passed in an axis parameter.
             args_by_name = ['{0}={0}'.format(arg) for arg in args[1:]]
+            # if the original signature takes either *args or **kwargs, pass them along in the same manner
+            args_by_name.extend(
+                declitem for declitem in decl if declitem.startswith('*')
+            )
             params = {'name': name,
                       'doc': doc,
                       'sig': ','.join(decl),

--- a/pandas/tests/test_groupby.py
+++ b/pandas/tests/test_groupby.py
@@ -5947,6 +5947,18 @@ class TestGroupBy(tm.TestCase):
                 with tm.assertRaisesRegexp(AttributeError, msg):
                     getattr(gb, bl)
 
+    def test_groupby_varargs(self):
+        # GH 14107
+        # we want to make sure **kwargs arguments are passed on correctly
+        # in this example, `take` uses **kwargs to pass on the 'mode' argument
+        # it should fail both when used directly and when via grouped object
+        s = Series([1,2,3])
+        g = s.groupby(int)
+        with tm.assertRaises(ValueError):
+            s.take([0], mode='INVALID_MODE_SHOULD_RAISE')
+        with tm.assertRaises(ValueError):
+            g.take([0], mode='INVALID_MODE_SHOULD_RAISE')
+
     def test_tab_completion(self):
         grp = self.mframe.groupby(level='second')
         results = set([v for v in dir(grp) if not v.startswith('_')])

--- a/pandas/tests/test_groupby.py
+++ b/pandas/tests/test_groupby.py
@@ -5952,7 +5952,7 @@ class TestGroupBy(tm.TestCase):
         # we want to make sure **kwargs arguments are passed on correctly
         # in this example, `take` uses **kwargs to pass on the 'mode' argument
         # it should fail both when used directly and when via grouped object
-        s = Series([1,2,3])
+        s = Series([1, 2, 3])
         g = s.groupby(int)
         with tm.assertRaises(ValueError):
             s.take([0], mode='INVALID_MODE_SHOULD_RAISE')

--- a/pandas/tseries/tests/test_tslib.py
+++ b/pandas/tseries/tests/test_tslib.py
@@ -662,7 +662,6 @@ class TestDatetimeParsingWrappers(tm.TestCase):
                  '00-Q4': datetime.datetime(2000, 10, 1),
                  '4Q-2000': datetime.datetime(2000, 10, 1),
                  '4Q-00': datetime.datetime(2000, 10, 1),
-                 '2000q4': datetime.datetime(2000, 10, 1),
                  '00q4': datetime.datetime(2000, 10, 1),
                  '2005': datetime.datetime(2005, 1, 1),
                  '2005-11': datetime.datetime(2005, 11, 1),


### PR DESCRIPTION
- [x] closes #14107 
- [ ] tests added / passed
- [ ] passes `git diff upstream/master | flake8 --diff`
- [ ] whatsnew entry

Methods such as 'hist' that take keyword arguments would now be able to be called via a Groupby object and the keyword args would be passed onwards to matplotlib as the user expects.
