### PR TITLE
DEPR: Deprecated PeriodIndex.to_datetime

### DIFF
--- a/doc/source/whatsnew/v0.19.0.txt
+++ b/doc/source/whatsnew/v0.19.0.txt
@@ -1061,6 +1061,7 @@ Deprecations
 - ``Categorical.reshape`` has been deprecated and will be removed in a subsequent release (:issue:`12882`)
 - ``Series.reshape`` has been deprecated and will be removed in a subsequent release (:issue:`12882`)
 
+- ``PeriodIndex.to_datetime`` has been deprecated in favour of ``PeriodIndex.to_timestamp`` (:issue:`8254`)
 - ``Timestamp.to_datetime`` has been deprecated in favour of ``Timestamp.to_pydatetime`` (:issue:`8254`)
 - ``Index.to_datetime`` and ``DatetimeIndex.to_datetime`` have been deprecated in favour of ``pd.to_datetime`` (:issue:`8254`)
 - ``SparseList`` has been deprecated and will be removed in a future version (:issue:`13784`)

--- a/pandas/tests/frame/test_to_csv.py
+++ b/pandas/tests/frame/test_to_csv.py
@@ -291,7 +291,7 @@ class TestDataFrameToCSV(tm.TestCase, TestData):
                 elif r_dtype == 'p':
                     r_dtype = 'O'
                     recons.index = np.array(
-                        list(map(Timestamp, recons.index.to_datetime())),
+                        list(map(Timestamp, to_datetime(recons.index))),
                         dtype=r_dtype)
                     df.index = np.array(
                         list(map(Timestamp, df.index.to_datetime())),
@@ -316,7 +316,7 @@ class TestDataFrameToCSV(tm.TestCase, TestData):
                 elif c_dtype == 'p':
                     c_dtype = 'O'
                     recons.columns = np.array(
-                        lmap(Timestamp, recons.columns.to_datetime()),
+                        lmap(Timestamp, to_datetime(recons.columns)),
                         dtype=c_dtype)
                     df.columns = np.array(
                         lmap(Timestamp, df.columns.to_datetime()),
@@ -1157,3 +1157,9 @@ class TestDataFrameToCSV(tm.TestCase, TestData):
         df = df.set_index(['a', 'b'])
         expected = '"a","b","c"\n"1","3","5"\n"2","4","6"\n'
         self.assertEqual(df.to_csv(quoting=csv.QUOTE_ALL), expected)
+
+
+if __name__ == '__main__':
+    import nose
+    nose.runmodule(argv=[__file__, '-vvs', '-x', '--pdb', '--pdb-failure'],
+                   exit=False)

--- a/pandas/tests/frame/test_to_csv.py
+++ b/pandas/tests/frame/test_to_csv.py
@@ -294,7 +294,7 @@ class TestDataFrameToCSV(tm.TestCase, TestData):
                         list(map(Timestamp, to_datetime(recons.index))),
                         dtype=r_dtype)
                     df.index = np.array(
-                        list(map(Timestamp, df.index.to_datetime())),
+                        list(map(Timestamp, df.index.to_timestamp())),
                         dtype=r_dtype)
                 else:
                     r_dtype = type_map.get(r_dtype)
@@ -319,7 +319,7 @@ class TestDataFrameToCSV(tm.TestCase, TestData):
                         lmap(Timestamp, to_datetime(recons.columns)),
                         dtype=c_dtype)
                     df.columns = np.array(
-                        lmap(Timestamp, df.columns.to_datetime()),
+                        lmap(Timestamp, df.columns.to_timestamp()),
                         dtype=c_dtype)
                 else:
                     c_dtype = type_map.get(c_dtype)

--- a/pandas/tseries/period.py
+++ b/pandas/tseries/period.py
@@ -1,6 +1,7 @@
 # pylint: disable=E1101,E1103,W0232
 from datetime import datetime, timedelta
 import numpy as np
+import warnings
 
 
 from pandas.core import common as com
@@ -550,6 +551,13 @@ class PeriodIndex(DatelikeOps, DatetimeIndexOpsMixin, Int64Index):
         return self._simple_new(new_data, self.name, freq=freq)
 
     def to_datetime(self, dayfirst=False):
+        """
+        DEPRECATED: use :meth:`to_timestamp` instead.
+
+        Cast to DatetimeIndex.
+        """
+        warnings.warn("to_datetime is deprecated. Use self.to_timestamp(...)",
+                      FutureWarning, stacklevel=2)
         return self.to_timestamp()
 
     year = _field_accessor('year', 0, "The year of the period")

--- a/pandas/tseries/tests/test_period.py
+++ b/pandas/tseries/tests/test_period.py
@@ -3560,11 +3560,19 @@ class TestPeriodIndex(tm.TestCase):
 
         tm.assertIsInstance(s.index.values[0][0], Period)
 
-    def test_to_datetime_1703(self):
+    def test_to_timestamp_1703(self):
         index = period_range('1/1/2012', periods=4, freq='D')
 
-        result = index.to_datetime()
+        result = index.to_timestamp()
         self.assertEqual(result[0], Timestamp('1/1/2012'))
+
+    def test_to_datetime_depr(self):
+        index = period_range('1/1/2012', periods=4, freq='D')
+
+        with tm.assert_produces_warning(FutureWarning,
+                                        check_stacklevel=False):
+            result = index.to_datetime()
+            self.assertEqual(result[0], Timestamp('1/1/2012'))
 
     def test_get_loc_msg(self):
         idx = period_range('2000-1-1', freq='A', periods=10)


### PR DESCRIPTION
Continuation of #14096 by deprecating `PeriodIndex.to_datetime` in favour of `PeriodIndex.to_timestamp`.

Also addresses #8254.
