### PR TITLE
Test for Python 3.5 with C locale

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -116,15 +116,14 @@ matrix:
           packages:
           - xsel
 #    In allow_failures
-    - python: 3.4
+    - python: 3.5
       env:
-        - JOB_NAME: "34_slow_ascii"
-        - JOB_TAG=_SLOW
-        - NOSE_ARGS="slow and not network and not disabled"
+        - JOB_NAME: "35_ascii"
+        - NOSE_ARGS="not slow and not network and not disabled"
         - LOCALE_OVERRIDE="C"
         - FULL_DEPS=true
         - CLIPBOARD=xsel
-        - CACHE_NAME="34_slow_ascii"
+        - CACHE_NAME="35_ascii"
         - USE_CACHE=true
       addons:
         apt:
@@ -199,15 +198,14 @@ matrix:
           apt:
             packages:
             - xsel
-      - python: 3.4
+      - python: 3.5
         env:
-        - JOB_NAME: "34_slow_ascii"
-        - JOB_TAG=_SLOW
+        - JOB_NAME: "35_ascii"
         - NOSE_ARGS="slow and not network and not disabled"
         - LOCALE_OVERRIDE="C"
         - FULL_DEPS=true
         - CLIPBOARD=xsel
-        - CACHE_NAME="34_slow_ascii"
+        - CACHE_NAME="35_ascii"
         - USE_CACHE=true
         addons:
           apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -116,6 +116,21 @@ matrix:
           packages:
           - xsel
 #    In allow_failures
+    - python: 3.4
+      env:
+        - JOB_NAME: "34_slow_ascii"
+        - JOB_TAG=_SLOW
+        - NOSE_ARGS="slow and not network and not disabled"
+        - LOCALE_OVERRIDE="C"
+        - FULL_DEPS=true
+        - CLIPBOARD=xsel
+        - CACHE_NAME="34_slow_ascii"
+        - USE_CACHE=true
+      addons:
+        apt:
+          packages:
+          - xsel
+#    In allow_failures
     - python: 2.7
       env:
         - JOB_NAME: "27_build_test_conda"
@@ -179,6 +194,20 @@ matrix:
         - FULL_DEPS=true
         - CLIPBOARD=xsel
         - CACHE_NAME="34_slow"
+        - USE_CACHE=true
+        addons:
+          apt:
+            packages:
+            - xsel
+      - python: 3.4
+        env:
+        - JOB_NAME: "34_slow_ascii"
+        - JOB_TAG=_SLOW
+        - NOSE_ARGS="slow and not network and not disabled"
+        - LOCALE_OVERRIDE="C"
+        - FULL_DEPS=true
+        - CLIPBOARD=xsel
+        - CACHE_NAME="34_slow_ascii"
         - USE_CACHE=true
         addons:
           apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -154,6 +154,21 @@ matrix:
           packages:
           - language-pack-it
 #    In allow_failures
+    - python: 3.5
+      env:
+        - JOB_NAME: "35_ascii"
+        - JOB_TAG=_ASCII
+        - NOSE_ARGS="not slow and not network and not disabled"
+        - LOCALE_OVERRIDE="C"
+        - FULL_DEPS=true
+        - CLIPBOARD=xsel
+        - CACHE_NAME="35_ascii"
+        - USE_CACHE=true
+      addons:
+        apt:
+          packages:
+          - xsel
+#    In allow_failures
     - python: 2.7
       env:
         - JOB_NAME: "doc_build"

--- a/.travis.yml
+++ b/.travis.yml
@@ -160,14 +160,8 @@ matrix:
         - JOB_TAG=_ASCII
         - NOSE_ARGS="not slow and not network and not disabled"
         - LOCALE_OVERRIDE="C"
-        - FULL_DEPS=true
-        - CLIPBOARD=xsel
         - CACHE_NAME="35_ascii"
         - USE_CACHE=true
-      addons:
-        apt:
-          packages:
-          - xsel
 #    In allow_failures
     - python: 2.7
       env:
@@ -240,14 +234,8 @@ matrix:
         - JOB_TAG=_ASCII
         - NOSE_ARGS="not slow and not network and not disabled"
         - LOCALE_OVERRIDE="C"
-        - FULL_DEPS=true
-        - CLIPBOARD=xsel
         - CACHE_NAME="35_ascii"
         - USE_CACHE=true
-        addons:
-          apt:
-            packages:
-            - xsel
       - python: 2.7
         env:
         - JOB_NAME: "doc_build"

--- a/.travis.yml
+++ b/.travis.yml
@@ -116,20 +116,6 @@ matrix:
           packages:
           - xsel
 #    In allow_failures
-    - python: 3.5
-      env:
-        - JOB_NAME: "35_ascii"
-        - NOSE_ARGS="not slow and not network and not disabled"
-        - LOCALE_OVERRIDE="C"
-        - FULL_DEPS=true
-        - CLIPBOARD=xsel
-        - CACHE_NAME="35_ascii"
-        - USE_CACHE=true
-      addons:
-        apt:
-          packages:
-          - xsel
-#    In allow_failures
     - python: 2.7
       env:
         - JOB_NAME: "27_build_test_conda"
@@ -198,19 +184,6 @@ matrix:
           apt:
             packages:
             - xsel
-      - python: 3.5
-        env:
-        - JOB_NAME: "35_ascii"
-        - NOSE_ARGS="slow and not network and not disabled"
-        - LOCALE_OVERRIDE="C"
-        - FULL_DEPS=true
-        - CLIPBOARD=xsel
-        - CACHE_NAME="35_ascii"
-        - USE_CACHE=true
-        addons:
-          apt:
-            packages:
-            - xsel
       - python: 2.7
         env:
         - JOB_NAME: "27_build_test_conda"
@@ -246,6 +219,20 @@ matrix:
           apt:
             packages:
             - language-pack-it
+      - python: 3.5
+        env:
+        - JOB_NAME: "35_ascii"
+        - JOB_TAG=_ASCII
+        - NOSE_ARGS="not slow and not network and not disabled"
+        - LOCALE_OVERRIDE="C"
+        - FULL_DEPS=true
+        - CLIPBOARD=xsel
+        - CACHE_NAME="35_ascii"
+        - USE_CACHE=true
+        addons:
+          apt:
+            packages:
+            - xsel
       - python: 2.7
         env:
         - JOB_NAME: "doc_build"

--- a/ci/requirements-3.5_ASCII.build
+++ b/ci/requirements-3.5_ASCII.build
@@ -1,0 +1,4 @@
+python-dateutil
+pytz
+numpy
+cython

--- a/ci/requirements-3.5_ASCII.run
+++ b/ci/requirements-3.5_ASCII.run
@@ -1,0 +1,3 @@
+python-dateutil
+pytz
+numpy

--- a/pandas/tests/formats/test_format.py
+++ b/pandas/tests/formats/test_format.py
@@ -2820,7 +2820,7 @@ c  10  11  12  13  14\
                 self.assertEqual(df.to_latex(), f.read())
 
         # test with utf-8 without encoding option
-        if compat.PY3:  # python3 default encoding is utf-8
+        if compat.PY3:  # python3: pandas default encoding is utf-8
             with tm.ensure_clean('test.tex') as path:
                 df.to_latex(path)
                 with codecs.open(path, 'r') as f:
@@ -4295,7 +4295,7 @@ class TestDatetime64Formatter(tm.TestCase):
         formatter = fmt.Datetime64Formatter(x, formatter=format_func)
         result = formatter.get_result()
         self.assertEqual(result, ['2016-01', '2016-02'])
-                       
+
     def test_datetime64formatter_hoursecond(self):
 
         x = Series(pd.to_datetime(['10:10:10.100', '12:12:12.120'],

--- a/pandas/tools/tests/test_util.py
+++ b/pandas/tools/tests/test_util.py
@@ -68,10 +68,12 @@ class TestLocaleUtils(tm.TestCase):
             raise nose.SkipTest("Only a single locale found, no point in "
                                 "trying to test setting another locale")
 
-        if LOCALE_OVERRIDE is not None:
-            lang, enc = LOCALE_OVERRIDE.split('.')
-        else:
+        if LOCALE_OVERRIDE is None:
             lang, enc = 'it_CH', 'UTF-8'
+        elif LOCALE_OVERRIDE == 'C':
+            lang, enc = 'en_US', 'ascii'
+        else:
+            lang, enc = LOCALE_OVERRIDE.split('.')
 
         enc = codecs.lookup(enc).name
         new_locale = lang, enc


### PR DESCRIPTION
As @jreback suggested, I'm adding an alternate py3 build to change LOCALE, based on the 3.4 slow build, to reveal some encoding bugs (see #12337)

I'm new to configuring Travis, I just hope this will work as I expect and that the tests will fail.
- [ ] closes #12337 
- [x] tests added but not passed?
- [ ] passes `git diff upstream/master | flake8 --diff`
- [ ] whatsnew entry
