### PR TITLE
BUG: series resample with timedelta values looses dtype (GH13119)

### DIFF
--- a/doc/source/whatsnew/v0.19.0.txt
+++ b/doc/source/whatsnew/v0.19.0.txt
@@ -1260,7 +1260,7 @@ Bug Fixes
 - Bug in ``.value_counts`` raises ``OutOfBoundsDatetime`` if data exceeds ``datetime64[ns]`` bounds (:issue:`13663`)
 - Bug in ``DatetimeIndex`` may raise ``OutOfBoundsDatetime`` if input ``np.datetime64`` has other unit than ``ns`` (:issue:`9114`)
 - Bug in ``Series`` creation with ``np.datetime64`` which has other unit than ``ns`` as ``object`` dtype results in incorrect values (:issue:`13876`)
-
+- Bug in ``resample`` with timedelta data where data were casted to float when (:issue:`13119`).
 - Bug in ``pd.isnull()`` ``pd.notnull()`` raise ``TypeError`` if input datetime-like has other unit than ``ns`` (:issue:`13389`)
 - Bug in ``pd.merge()`` may raise ``TypeError`` if input datetime-like has other unit than ``ns`` (:issue:`13389`)
 

--- a/doc/source/whatsnew/v0.19.0.txt
+++ b/doc/source/whatsnew/v0.19.0.txt
@@ -1260,7 +1260,7 @@ Bug Fixes
 - Bug in ``.value_counts`` raises ``OutOfBoundsDatetime`` if data exceeds ``datetime64[ns]`` bounds (:issue:`13663`)
 - Bug in ``DatetimeIndex`` may raise ``OutOfBoundsDatetime`` if input ``np.datetime64`` has other unit than ``ns`` (:issue:`9114`)
 - Bug in ``Series`` creation with ``np.datetime64`` which has other unit than ``ns`` as ``object`` dtype results in incorrect values (:issue:`13876`)
-- Bug in ``resample`` with timedelta data where data were casted to float when (:issue:`13119`).
+- Bug in ``resample`` with timedelta data where data was casted to float (:issue:`13119`).
 - Bug in ``pd.isnull()`` ``pd.notnull()`` raise ``TypeError`` if input datetime-like has other unit than ``ns`` (:issue:`13389`)
 - Bug in ``pd.merge()`` may raise ``TypeError`` if input datetime-like has other unit than ``ns`` (:issue:`13389`)
 

--- a/pandas/tests/types/test_cast.py
+++ b/pandas/tests/types/test_cast.py
@@ -24,44 +24,56 @@ from pandas.util import testing as tm
 _multiprocess_can_split_ = True
 
 
-def test_downcast_conv():
-    # test downcasting
+class TestPossiblyDowncast(tm.TestCase):
 
-    arr = np.array([8.5, 8.6, 8.7, 8.8, 8.9999999999995])
-    result = _possibly_downcast_to_dtype(arr, 'infer')
-    assert (np.array_equal(result, arr))
+    def test_downcast_conv(self):
+        # test downcasting
 
-    arr = np.array([8., 8., 8., 8., 8.9999999999995])
-    result = _possibly_downcast_to_dtype(arr, 'infer')
-    expected = np.array([8, 8, 8, 8, 9])
-    assert (np.array_equal(result, expected))
-
-    arr = np.array([8., 8., 8., 8., 9.0000000000005])
-    result = _possibly_downcast_to_dtype(arr, 'infer')
-    expected = np.array([8, 8, 8, 8, 9])
-    assert (np.array_equal(result, expected))
-
-    # conversions
-
-    expected = np.array([1, 2])
-    for dtype in [np.float64, object, np.int64]:
-        arr = np.array([1.0, 2.0], dtype=dtype)
+        arr = np.array([8.5, 8.6, 8.7, 8.8, 8.9999999999995])
         result = _possibly_downcast_to_dtype(arr, 'infer')
-        tm.assert_almost_equal(result, expected, check_dtype=False)
+        assert (np.array_equal(result, arr))
 
-    for dtype in [np.float64, object]:
-        expected = np.array([1.0, 2.0, np.nan], dtype=dtype)
-        arr = np.array([1.0, 2.0, np.nan], dtype=dtype)
+        arr = np.array([8., 8., 8., 8., 8.9999999999995])
         result = _possibly_downcast_to_dtype(arr, 'infer')
-        tm.assert_almost_equal(result, expected)
+        expected = np.array([8, 8, 8, 8, 9])
+        assert (np.array_equal(result, expected))
 
-    # empties
-    for dtype in [np.int32, np.float64, np.float32, np.bool_,
-                  np.int64, object]:
-        arr = np.array([], dtype=dtype)
-        result = _possibly_downcast_to_dtype(arr, 'int64')
-        tm.assert_almost_equal(result, np.array([], dtype=np.int64))
-        assert result.dtype == np.int64
+        arr = np.array([8., 8., 8., 8., 9.0000000000005])
+        result = _possibly_downcast_to_dtype(arr, 'infer')
+        expected = np.array([8, 8, 8, 8, 9])
+        assert (np.array_equal(result, expected))
+
+        # conversions
+
+        expected = np.array([1, 2])
+        for dtype in [np.float64, object, np.int64]:
+            arr = np.array([1.0, 2.0], dtype=dtype)
+            result = _possibly_downcast_to_dtype(arr, 'infer')
+            tm.assert_almost_equal(result, expected, check_dtype=False)
+
+        for dtype in [np.float64, object]:
+            expected = np.array([1.0, 2.0, np.nan], dtype=dtype)
+            arr = np.array([1.0, 2.0, np.nan], dtype=dtype)
+            result = _possibly_downcast_to_dtype(arr, 'infer')
+            tm.assert_almost_equal(result, expected)
+
+        # empties
+        for dtype in [np.int32, np.float64, np.float32, np.bool_,
+                      np.int64, object]:
+            arr = np.array([], dtype=dtype)
+            result = _possibly_downcast_to_dtype(arr, 'int64')
+            tm.assert_almost_equal(result, np.array([], dtype=np.int64))
+            assert result.dtype == np.int64
+
+    def test_datetimelikes_nan(self):
+        arr = np.array([1, 2, np.nan])
+        exp = np.array([1, 2, np.datetime64('NaT')], dtype='datetime64[ns]')
+        res = _possibly_downcast_to_dtype(arr, 'datetime64[ns]')
+        tm.assert_numpy_array_equal(res, exp)
+
+        exp = np.array([1, 2, np.timedelta64('NaT')], dtype='timedelta64[ns]')
+        res = _possibly_downcast_to_dtype(arr, 'timedelta64[ns]')
+        tm.assert_numpy_array_equal(res, exp)
 
 
 class TestInferDtype(tm.TestCase):

--- a/pandas/tseries/tests/test_resample.py
+++ b/pandas/tseries/tests/test_resample.py
@@ -1935,6 +1935,23 @@ class TestDatetimeIndex(Base, tm.TestCase):
 
         assert_frame_equal(frame.resample('60s').mean(), frame_3s)
 
+    def test_resample_timedelta_values(self):
+        # GH 13119
+        # check that timedelta dtype is preserved when NaT values are
+        # introduced by the resampling
+
+        times = timedelta_range('1 day', '4 day', freq='4D')
+        df = DataFrame({'time': times}, index=times)
+
+        times2 = timedelta_range('1 day', '4 day', freq='2D')
+        exp = Series(times2, index=times2, name='time')
+        exp.iloc[1] = pd.NaT
+
+        res = df.resample('2D').first()['time']
+        tm.assert_series_equal(res, exp)
+        res = df['time'].resample('2D').first()
+        tm.assert_series_equal(res, exp)
+
 
 class TestPeriodIndex(Base, tm.TestCase):
     _multiprocess_can_split_ = True

--- a/pandas/types/cast.py
+++ b/pandas/types/cast.py
@@ -12,7 +12,7 @@ from .common import (_ensure_object, is_bool, is_integer, is_float,
                      is_timedelta64_dtype, is_dtype_equal,
                      is_float_dtype, is_complex_dtype,
                      is_integer_dtype, is_datetime_or_timedelta_dtype,
-                     is_scalar,
+                     is_bool_dtype, is_scalar,
                      _string_dtypes,
                      _coerce_to_dtype,
                      _ensure_int8, _ensure_int16,
@@ -89,8 +89,7 @@ def _possibly_downcast_to_dtype(result, dtype):
 
         if issubclass(dtype.type, np.floating):
             return result.astype(dtype)
-        elif (dtype == np.bool_ or issubclass(dtype.type, np.integer) and
-                dtype.kind != 'm'):
+        elif is_bool_dtype(dtype) or is_integer_dtype(dtype):
 
             # if we don't have any elements, just astype it
             if not np.prod(result.shape):

--- a/pandas/types/cast.py
+++ b/pandas/types/cast.py
@@ -89,7 +89,8 @@ def _possibly_downcast_to_dtype(result, dtype):
 
         if issubclass(dtype.type, np.floating):
             return result.astype(dtype)
-        elif dtype == np.bool_ or issubclass(dtype.type, np.integer):
+        elif (dtype == np.bool_ or issubclass(dtype.type, np.integer) and
+                dtype.kind != 'm'):
 
             # if we don't have any elements, just astype it
             if not np.prod(result.shape):


### PR DESCRIPTION
- [x] closes #13119
- [x] tests added / passed
- [x] passes `git diff upstream/master | flake8 --diff`
- [x] whatsnew entry
