### PR TITLE
API: Warn or raise for > 1 char encoded sep

### DIFF
--- a/doc/source/whatsnew/v0.19.0.txt
+++ b/doc/source/whatsnew/v0.19.0.txt
@@ -457,6 +457,7 @@ API changes
 - ``pd.Timedelta(None)`` is now accepted and will return ``NaT``, mirroring ``pd.Timestamp`` (:issue:`13687`)
 - ``Timestamp``, ``Period``, ``DatetimeIndex``, ``PeriodIndex`` and ``.dt`` accessor have gained a ``.is_leap_year`` property to check whether the date belongs to a leap year. (:issue:`13727`)
 - ``pd.read_hdf`` will now raise a ``ValueError`` instead of ``KeyError``, if a mode other than ``r``, ``r+`` and ``a`` is supplied. (:issue:`13623`)
+- ``pd.read_csv()`` in the C engine will now issue a ``ParserWarning`` or raise a ``ValueError`` when ``sep`` encoded is more than one character long (:issue:`14065`)
 - ``DataFrame.values`` will now return ``float64`` with a ``DataFrame`` of mixed ``int64`` and ``uint64`` dtypes, conforming to ``np.find_common_type`` (:issue:`10364`, :issue:`13917`)
 - ``Series.unique()`` with datetime and timezone now returns return array of ``Timestamp`` with timezone (:issue:`13565`)
 

--- a/pandas/io/parsers.py
+++ b/pandas/io/parsers.py
@@ -5,6 +5,7 @@ from __future__ import print_function
 from collections import defaultdict
 import re
 import csv
+import sys
 import warnings
 import datetime
 
@@ -782,6 +783,7 @@ class TextFileReader(BaseIterator):
                                   " skipfooter"
                 engine = 'python'
 
+        encoding = sys.getfilesystemencoding() or 'utf-8'
         if sep is None and not delim_whitespace:
             if engine == 'c':
                 fallback_reason = "the 'c' engine does not support"\
@@ -797,6 +799,14 @@ class TextFileReader(BaseIterator):
                                   " regex separators (separators > 1 char and"\
                                   " different from '\s+' are"\
                                   " interpreted as regex)"
+                engine = 'python'
+
+        elif len(sep.encode(encoding)) > 1:
+            if engine not in ('python', 'python-fwf'):
+                fallback_reason = "the separator encoded in {encoding}"\
+                                  " is > 1 char long, and the 'c' engine"\
+                                  " does not support such separators".format(
+                                      encoding=encoding)
                 engine = 'python'
         elif delim_whitespace:
             if 'python' in engine:

--- a/pandas/io/tests/parser/test_unsupported.py
+++ b/pandas/io/tests/parser/test_unsupported.py
@@ -61,6 +61,8 @@ class TestUnsupportedFeatures(tm.TestCase):
         with tm.assertRaisesRegexp(ValueError, msg):
             read_table(StringIO(data), engine='c', sep='\s')
         with tm.assertRaisesRegexp(ValueError, msg):
+            read_table(StringIO(data), engine='c', sep='§')
+        with tm.assertRaisesRegexp(ValueError, msg):
             read_table(StringIO(data), engine='c', skipfooter=1)
 
         # specify C-unsupported options without python-unsupported options


### PR DESCRIPTION
The system file encoding can cause a separator to be encoded as more than one character even though it maybe provided as one character.  Multi-char separators are not supported by the C engine, so we need to catch this case.

Closes #14065.
