### PR TITLE
BUG: #14095. Amend eval() resolvers kwarg to accept lists

### DIFF
--- a/doc/source/whatsnew/v0.19.0.txt
+++ b/doc/source/whatsnew/v0.19.0.txt
@@ -1290,3 +1290,4 @@ Bug Fixes
 - Bug in ``.to_string()`` when called with an integer ``line_width`` and ``index=False`` raises an UnboundLocalError exception because ``idx`` referenced before assignment.
 
 - Bug in ``read_csv()``, where aliases for utf-xx (e.g. UTF-xx, UTF_xx, utf_xx) raised UnicodeDecodeError (:issue:`13549`)
+- Bug in ``eval()`` where the ``resolvers`` argument would not accept a list (:issue`14095`)

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -2266,7 +2266,7 @@ class DataFrame(NDFrame):
             resolvers = dict(self.iteritems()), index_resolvers
         if 'target' not in kwargs:
             kwargs['target'] = self
-        kwargs['resolvers'] = kwargs.get('resolvers', ()) + resolvers
+        kwargs['resolvers'] = kwargs.get('resolvers', ()) + tuple(resolvers)
         return _eval(expr, inplace=inplace, **kwargs)
 
     def select_dtypes(self, include=None, exclude=None):

--- a/pandas/tests/frame/test_query_eval.py
+++ b/pandas/tests/frame/test_query_eval.py
@@ -151,7 +151,8 @@ class TestDataFrameEval(tm.TestCase, TestData):
         df = DataFrame(randn(10, 2), columns=list('ab'))
         dict1 = {'a': 1}
         dict2 = {'b': 2}
-        self.assertTrue(df.eval('a + b', resolvers=[dict1, dict2]) == dict1['a'] + dict2['b'])
+        self.assertTrue(df.eval('a + b', resolvers=[dict1, dict2])
+                        == dict1['a'] + dict2['b'])
 
 
 class TestDataFrameQueryWithMultiIndex(tm.TestCase):

--- a/pandas/tests/frame/test_query_eval.py
+++ b/pandas/tests/frame/test_query_eval.py
@@ -147,6 +147,12 @@ class TestDataFrameEval(tm.TestCase, TestData):
         with tm.assertRaisesRegexp(ValueError, msg):
             df.query(111)
 
+    def test_eval_resolvers_as_list(self):
+        df = DataFrame(randn(10, 2), columns=list('ab'))
+        dict1 = {'a': 1}
+        dict2 = {'b': 2}
+        self.assertTrue(df.eval('a + b', resolvers=[dict1, dict2]) == dict1['a'] + dict2['b'])
+
 
 class TestDataFrameQueryWithMultiIndex(tm.TestCase):
 

--- a/pandas/tests/frame/test_query_eval.py
+++ b/pandas/tests/frame/test_query_eval.py
@@ -151,8 +151,8 @@ class TestDataFrameEval(tm.TestCase, TestData):
         df = DataFrame(randn(10, 2), columns=list('ab'))
         dict1 = {'a': 1}
         dict2 = {'b': 2}
-        self.assertTrue(df.eval('a + b', resolvers=[dict1, dict2])
-                        == dict1['a'] + dict2['b'])
+        self.assertTrue(df.eval('a + b', resolvers=[dict1, dict2]) ==
+                        dict1['a'] + dict2['b'])
 
 
 class TestDataFrameQueryWithMultiIndex(tm.TestCase):

--- a/pandas/tests/frame/test_query_eval.py
+++ b/pandas/tests/frame/test_query_eval.py
@@ -153,6 +153,8 @@ class TestDataFrameEval(tm.TestCase, TestData):
         dict2 = {'b': 2}
         self.assertTrue(df.eval('a + b', resolvers=[dict1, dict2]) ==
                         dict1['a'] + dict2['b'])
+        self.assertTrue(pd.eval('a + b', resolvers=[dict1, dict2]) ==
+                        dict1['a'] + dict2['b'])
 
 
 class TestDataFrameQueryWithMultiIndex(tm.TestCase):


### PR DESCRIPTION
- [x] closes #14095
- [x] tests added / passed
- [ ] passes `git diff upstream/master | flake8 --diff`
- [x] whatsnew entry
