### PR TITLE
BUG: DatetimeTZBlock can't assign values near dst boundary

### DIFF
--- a/doc/source/whatsnew/v0.19.0.txt
+++ b/doc/source/whatsnew/v0.19.0.txt
@@ -1559,7 +1559,7 @@ Bug Fixes
 - Bug in ``Series`` flexible arithmetic methods (like ``.add()``) raises ``ValueError`` when ``axis=None`` (:issue:`13894`)
 - Bug in ``DataFrame.to_csv()`` with ``MultiIndex`` columns in which a stray empty line was added (:issue:`6618`)
 - Bug in ``DatetimeIndex``, ``TimedeltaIndex`` and ``PeriodIndex.equals()`` may return ``True`` when input isn't ``Index`` but contains the same values (:issue:`13107`)
-
+- Bug in assignment against datetime with timezone may not work if it contains datetime near DST boundary (:issue:`14146`)
 
 - Bug in ``Index`` raises ``KeyError`` displaying incorrect column when column is not in the df and columns contains duplicate values (:issue:`13822`)
 - Bug in ``Period`` and ``PeriodIndex`` creating wrong dates when frequency has combined offset aliases (:issue:`13874`)

--- a/pandas/tests/indexing/test_coercion.py
+++ b/pandas/tests/indexing/test_coercion.py
@@ -229,7 +229,7 @@ class TestSetitemCoercion(CoercionBase, tm.TestCase):
         # datetime64 + int -> object
         # ToDo: The result must be object
         exp = pd.Series([pd.Timestamp('2011-01-01', tz=tz),
-                         pd.Timestamp(1).tz_localize(tz),
+                         pd.Timestamp(1, tz=tz),
                          pd.Timestamp('2011-01-03', tz=tz),
                          pd.Timestamp('2011-01-04', tz=tz)])
         self._assert_setitem_series_conversion(obj, 1, exp,
@@ -1038,7 +1038,7 @@ class TestFillnaSeriesCoercion(CoercionBase, tm.TestCase):
         # datetime64tz + int => datetime64tz
         # ToDo: must be object
         exp = pd.Series([pd.Timestamp('2011-01-01', tz=tz),
-                         pd.Timestamp(1).tz_localize(tz=tz),
+                         pd.Timestamp(1, tz=tz),
                          pd.Timestamp('2011-01-03', tz=tz),
                          pd.Timestamp('2011-01-04', tz=tz)])
         self._assert_fillna_conversion(obj, 1, exp,

--- a/pandas/tests/series/test_misc_api.py
+++ b/pandas/tests/series/test_misc_api.py
@@ -241,7 +241,6 @@ class TestSeriesMisc(TestData, SharedWithSparse, tm.TestCase):
                 self.assertTrue(np.isnan(s2[0]))
                 self.assertFalse(np.isnan(s[0]))
             else:
-
                 # we DID modify the original Series
                 self.assertTrue(np.isnan(s2[0]))
                 self.assertTrue(np.isnan(s[0]))
@@ -252,6 +251,7 @@ class TestSeriesMisc(TestData, SharedWithSparse, tm.TestCase):
         expected2 = Series([Timestamp('1999/01/01', tz='UTC')])
 
         for deep in [None, False, True]:
+
             s = Series([Timestamp('2012/01/01', tz='UTC')])
 
             if deep is None:
@@ -263,11 +263,13 @@ class TestSeriesMisc(TestData, SharedWithSparse, tm.TestCase):
 
             # default deep is True
             if deep is None or deep is True:
+                # Did not modify original Series
+                assert_series_equal(s2, expected2)
                 assert_series_equal(s, expected)
-                assert_series_equal(s2, expected2)
             else:
-                assert_series_equal(s, expected2)
+                # we DID modify the original Series
                 assert_series_equal(s2, expected2)
+                assert_series_equal(s, expected2)
 
     def test_axis_alias(self):
         s = Series([1, 2, np.nan])

--- a/pandas/tests/series/test_missing.py
+++ b/pandas/tests/series/test_missing.py
@@ -130,49 +130,66 @@ class TestSeriesMissingData(TestData, tm.TestCase):
     def test_datetime64_tz_fillna(self):
         for tz in ['US/Eastern', 'Asia/Tokyo']:
             # DatetimeBlock
-            s = Series([Timestamp('2011-01-01 10:00'), pd.NaT, Timestamp(
-                '2011-01-03 10:00'), pd.NaT])
+            s = Series([Timestamp('2011-01-01 10:00'), pd.NaT,
+                        Timestamp('2011-01-03 10:00'), pd.NaT])
+            null_loc = pd.Series([False, True, False, True])
+
             result = s.fillna(pd.Timestamp('2011-01-02 10:00'))
-            expected = Series([Timestamp('2011-01-01 10:00'), Timestamp(
-                '2011-01-02 10:00'), Timestamp('2011-01-03 10:00'), Timestamp(
-                    '2011-01-02 10:00')])
+            expected = Series([Timestamp('2011-01-01 10:00'),
+                               Timestamp('2011-01-02 10:00'),
+                               Timestamp('2011-01-03 10:00'),
+                               Timestamp('2011-01-02 10:00')])
             self.assert_series_equal(expected, result)
+            # check s is not changed
+            self.assert_series_equal(pd.isnull(s), null_loc)
 
             result = s.fillna(pd.Timestamp('2011-01-02 10:00', tz=tz))
-            expected = Series([Timestamp('2011-01-01 10:00'), Timestamp(
-                '2011-01-02 10:00', tz=tz), Timestamp('2011-01-03 10:00'),
-                Timestamp('2011-01-02 10:00', tz=tz)])
+            expected = Series([Timestamp('2011-01-01 10:00'),
+                               Timestamp('2011-01-02 10:00', tz=tz),
+                               Timestamp('2011-01-03 10:00'),
+                               Timestamp('2011-01-02 10:00', tz=tz)])
             self.assert_series_equal(expected, result)
+            self.assert_series_equal(pd.isnull(s), null_loc)
 
             result = s.fillna('AAA')
             expected = Series([Timestamp('2011-01-01 10:00'), 'AAA',
                                Timestamp('2011-01-03 10:00'), 'AAA'],
                               dtype=object)
             self.assert_series_equal(expected, result)
+            self.assert_series_equal(pd.isnull(s), null_loc)
 
             result = s.fillna({1: pd.Timestamp('2011-01-02 10:00', tz=tz),
                                3: pd.Timestamp('2011-01-04 10:00')})
-            expected = Series([Timestamp('2011-01-01 10:00'), Timestamp(
-                '2011-01-02 10:00', tz=tz), Timestamp('2011-01-03 10:00'),
-                Timestamp('2011-01-04 10:00')])
+            expected = Series([Timestamp('2011-01-01 10:00'),
+                               Timestamp('2011-01-02 10:00', tz=tz),
+                               Timestamp('2011-01-03 10:00'),
+                               Timestamp('2011-01-04 10:00')])
             self.assert_series_equal(expected, result)
+            self.assert_series_equal(pd.isnull(s), null_loc)
 
             result = s.fillna({1: pd.Timestamp('2011-01-02 10:00'),
                                3: pd.Timestamp('2011-01-04 10:00')})
-            expected = Series([Timestamp('2011-01-01 10:00'), Timestamp(
-                '2011-01-02 10:00'), Timestamp('2011-01-03 10:00'), Timestamp(
-                    '2011-01-04 10:00')])
+            expected = Series([Timestamp('2011-01-01 10:00'),
+                               Timestamp('2011-01-02 10:00'),
+                               Timestamp('2011-01-03 10:00'),
+                               Timestamp('2011-01-04 10:00')])
             self.assert_series_equal(expected, result)
+            self.assert_series_equal(pd.isnull(s), null_loc)
 
             # DatetimeBlockTZ
             idx = pd.DatetimeIndex(['2011-01-01 10:00', pd.NaT,
                                     '2011-01-03 10:00', pd.NaT], tz=tz)
             s = pd.Series(idx)
+            self.assertEqual(s.dtype, 'datetime64[ns, {0}]'.format(tz))
+            self.assert_series_equal(pd.isnull(s), null_loc)
+
             result = s.fillna(pd.Timestamp('2011-01-02 10:00'))
-            expected = Series([Timestamp('2011-01-01 10:00', tz=tz), Timestamp(
-                '2011-01-02 10:00'), Timestamp('2011-01-03 10:00', tz=tz),
-                Timestamp('2011-01-02 10:00')])
+            expected = Series([Timestamp('2011-01-01 10:00', tz=tz),
+                               Timestamp('2011-01-02 10:00'),
+                               Timestamp('2011-01-03 10:00', tz=tz),
+                               Timestamp('2011-01-02 10:00')])
             self.assert_series_equal(expected, result)
+            self.assert_series_equal(pd.isnull(s), null_loc)
 
             result = s.fillna(pd.Timestamp('2011-01-02 10:00', tz=tz))
             idx = pd.DatetimeIndex(['2011-01-01 10:00', '2011-01-02 10:00',
@@ -180,42 +197,50 @@ class TestSeriesMissingData(TestData, tm.TestCase):
                                    tz=tz)
             expected = Series(idx)
             self.assert_series_equal(expected, result)
+            self.assert_series_equal(pd.isnull(s), null_loc)
 
-            result = s.fillna(pd.Timestamp(
-                '2011-01-02 10:00', tz=tz).to_pydatetime())
+            result = s.fillna(pd.Timestamp('2011-01-02 10:00',
+                                           tz=tz).to_pydatetime())
             idx = pd.DatetimeIndex(['2011-01-01 10:00', '2011-01-02 10:00',
                                     '2011-01-03 10:00', '2011-01-02 10:00'],
                                    tz=tz)
             expected = Series(idx)
             self.assert_series_equal(expected, result)
+            self.assert_series_equal(pd.isnull(s), null_loc)
 
             result = s.fillna('AAA')
             expected = Series([Timestamp('2011-01-01 10:00', tz=tz), 'AAA',
                                Timestamp('2011-01-03 10:00', tz=tz), 'AAA'],
                               dtype=object)
             self.assert_series_equal(expected, result)
+            self.assert_series_equal(pd.isnull(s), null_loc)
 
             result = s.fillna({1: pd.Timestamp('2011-01-02 10:00', tz=tz),
                                3: pd.Timestamp('2011-01-04 10:00')})
-            expected = Series([Timestamp('2011-01-01 10:00', tz=tz), Timestamp(
-                '2011-01-02 10:00', tz=tz), Timestamp(
-                    '2011-01-03 10:00', tz=tz), Timestamp('2011-01-04 10:00')])
+            expected = Series([Timestamp('2011-01-01 10:00', tz=tz),
+                               Timestamp('2011-01-02 10:00', tz=tz),
+                               Timestamp('2011-01-03 10:00', tz=tz),
+                               Timestamp('2011-01-04 10:00')])
             self.assert_series_equal(expected, result)
+            self.assert_series_equal(pd.isnull(s), null_loc)
 
             result = s.fillna({1: pd.Timestamp('2011-01-02 10:00', tz=tz),
                                3: pd.Timestamp('2011-01-04 10:00', tz=tz)})
-            expected = Series([Timestamp('2011-01-01 10:00', tz=tz), Timestamp(
-                '2011-01-02 10:00', tz=tz), Timestamp(
-                    '2011-01-03 10:00', tz=tz), Timestamp('2011-01-04 10:00',
-                                                          tz=tz)])
+            expected = Series([Timestamp('2011-01-01 10:00', tz=tz),
+                               Timestamp('2011-01-02 10:00', tz=tz),
+                               Timestamp('2011-01-03 10:00', tz=tz),
+                               Timestamp('2011-01-04 10:00', tz=tz)])
             self.assert_series_equal(expected, result)
+            self.assert_series_equal(pd.isnull(s), null_loc)
 
             # filling with a naive/other zone, coerce to object
             result = s.fillna(Timestamp('20130101'))
-            expected = Series([Timestamp('2011-01-01 10:00', tz=tz), Timestamp(
-                '2013-01-01'), Timestamp('2011-01-03 10:00', tz=tz), Timestamp(
-                    '2013-01-01')])
+            expected = Series([Timestamp('2011-01-01 10:00', tz=tz),
+                               Timestamp('2013-01-01'),
+                               Timestamp('2011-01-03 10:00', tz=tz),
+                               Timestamp('2013-01-01')])
             self.assert_series_equal(expected, result)
+            self.assert_series_equal(pd.isnull(s), null_loc)
 
             result = s.fillna(Timestamp('20130101', tz='US/Pacific'))
             expected = Series([Timestamp('2011-01-01 10:00', tz=tz),
@@ -223,6 +248,7 @@ class TestSeriesMissingData(TestData, tm.TestCase):
                                Timestamp('2011-01-03 10:00', tz=tz),
                                Timestamp('2013-01-01', tz='US/Pacific')])
             self.assert_series_equal(expected, result)
+            self.assert_series_equal(pd.isnull(s), null_loc)
 
     def test_fillna_int(self):
         s = Series(np.random.randint(-100, 100, 50))


### PR DESCRIPTION
- [x] tests added / passed
- [x] passes `git diff upstream/master | flake8 --diff`
- [x] whatsnew entry

Value assignment doesn't work if data contains DST boundary because of internal `.localize(None)`. 

```
s = pd.Series(pd.date_range('2016-11-06', freq='H', periods=3, tz='US/Eastern'))
s[1] = pd.Timestamp('2011-01-01', tz='US/Eastern')
s
#0   2016-11-06 00:00:00-04:00
#1   2016-11-06 01:00:00-04:00
#2   2016-11-06 01:00:00-05:00
# dtype: datetime64[ns, US/Eastern]
```
