### PR TITLE
BUG : assignment of non-ns timedelta64 value (GH14155)

### DIFF
--- a/doc/source/whatsnew/v0.19.0.txt
+++ b/doc/source/whatsnew/v0.19.0.txt
@@ -1478,3 +1478,4 @@ Bug Fixes
 
 - Bug in ``eval()`` where the ``resolvers`` argument would not accept a list (:issue:`14095`)
 - Bugs in ``stack``, ``get_dummies``, ``make_axis_dummies`` which don't preserve categorical dtypes in (multi)indexes (:issue:`13854`)
+- Bug in ```Series``` of ```np.timedelta64``` when setting a slice using an indexer   (:issue:`14155`)

--- a/pandas/core/internals.py
+++ b/pandas/core/internals.py
@@ -1696,7 +1696,7 @@ class TimeDeltaBlock(DatetimeLikeBlockMixin, IntBlock):
             other = other.value
         elif isinstance(other, np.timedelta64):
             other_mask = isnull(other)
-            other = other.view('i8')
+            other = Timedelta(other).value
         elif isinstance(other, timedelta):
             other = Timedelta(other).value
         elif isinstance(other, np.ndarray):

--- a/pandas/tests/series/test_indexing.py
+++ b/pandas/tests/series/test_indexing.py
@@ -1324,6 +1324,13 @@ class TestSeriesIndexing(TestData, tm.TestCase):
         s.loc['A'] = timedelta(1)
         tm.assert_series_equal(s, expected)
 
+        # GH 14155
+        s = Series(10 * [np.timedelta64(10, 'm')])
+        s.loc[[1, 2, 3]] = np.timedelta64(20, 'm')
+        expected = pd.Series(10 * [np.timedelta64(10, 'm')])
+        expected.loc[[1, 2, 3]] = pd.Timedelta(np.timedelta64(20, 'm'))
+        tm.assert_series_equal(s, expected)
+
     def test_underlying_data_conversion(self):
 
         # GH 4080


### PR DESCRIPTION
- [x] closes #14155 
- [x] tests added / passed
- [x] passes `git diff upstream/master | flake8 --diff`
- [x] whatsnew entry
