### PR TITLE
BUG: Categorical constructor not idempotent with ext dtype

### DIFF
--- a/doc/source/whatsnew/v0.19.0.txt
+++ b/doc/source/whatsnew/v0.19.0.txt
@@ -1427,7 +1427,7 @@ Bug Fixes
 
 - Bug in ``SeriesGroupBy.transform`` with datetime values and missing groups (:issue:`13191`)
 - Bug where empty ``Series`` were incorrectly coerced in datetime-like numeric operations (:issue:`13844`)
-
+- Bug in ``Categorical`` constructor when passed a ``Categorical`` containing datetimes with timezones (:issue:`14190`)
 - Bug in ``Series.str.extractall()`` with ``str`` index raises ``ValueError``  (:issue:`13156`)
 - Bug in ``Series.str.extractall()`` with single group and quantifier  (:issue:`13382`)
 - Bug in ``DatetimeIndex`` and ``Period`` subtraction raises ``ValueError`` or ``AttributeError`` rather than ``TypeError`` (:issue:`13078`)

--- a/pandas/core/categorical.py
+++ b/pandas/core/categorical.py
@@ -259,7 +259,7 @@ class Categorical(PandasObject):
                 ordered = values.ordered
             if categories is None:
                 categories = values.categories
-            values = values.__array__()
+            values = values.get_values()
 
         elif isinstance(values, (ABCIndexClass, ABCSeries)):
             pass

--- a/pandas/tests/test_categorical.py
+++ b/pandas/tests/test_categorical.py
@@ -362,6 +362,21 @@ class TestCategorical(tm.TestCase):
         result = pd.Categorical(pd.Series(idx))
         tm.assert_index_equal(result.categories, idx)
 
+    def test_constructor_invariant(self):
+        # GH 14190
+        vals = [
+            np.array([1., 1.2, 1.8]),
+            np.array([1, 2, 3], dtype='int64'),
+            ['a', 'b', 'c'],
+            pd.period_range('2014-01-01', '2014-01-05'),
+            pd.date_range('2014-01-01', '2014-01-05'),
+            pd.date_range('2014-01-01', '2014-01-05', tz='US/Eastern')
+        ]
+        for val in vals:
+            c = Categorical(val)
+            c2 = Categorical(c)
+            tm.assert_categorical_equal(c, c2)
+
     def test_from_codes(self):
 
         # too few categories

--- a/pandas/tests/test_categorical.py
+++ b/pandas/tests/test_categorical.py
@@ -365,12 +365,13 @@ class TestCategorical(tm.TestCase):
     def test_constructor_invariant(self):
         # GH 14190
         vals = [
-            np.array([1., 1.2, 1.8]),
+            np.array([1., 1.2, 1.8, np.nan]),
             np.array([1, 2, 3], dtype='int64'),
-            ['a', 'b', 'c'],
-            pd.period_range('2014-01-01', '2014-01-05'),
-            pd.date_range('2014-01-01', '2014-01-05'),
-            pd.date_range('2014-01-01', '2014-01-05', tz='US/Eastern')
+            ['a', 'b', 'c', np.nan],
+            [pd.Period('2014-01'), pd.Period('2014-02'), pd.NaT],
+            [pd.Timestamp('2014-01-01'), pd.Timestamp('2014-01-02'), pd.NaT],
+            [pd.Timestamp('2014-01-01', tz='US/Eastern'),
+             pd.Timestamp('2014-01-02', tz='US/Eastern'), pd.NaT],
         ]
         for val in vals:
             c = Categorical(val)


### PR DESCRIPTION
- [x] closes #14190
- [ ] tests added / passed
- [x] passes `git diff upstream/master | flake8 --diff`
- [x] whatsnew entry
