### PR TITLE
Fix: F999 dictionary key '2000q4' repeated with different values

### DIFF
--- a/pandas/tseries/tests/test_tslib.py
+++ b/pandas/tseries/tests/test_tslib.py
@@ -687,7 +687,6 @@ class TestDatetimeParsingWrappers(tm.TestCase):
                  '00-Q4': datetime.datetime(2000, 10, 1),
                  '4Q-2000': datetime.datetime(2000, 10, 1),
                  '4Q-00': datetime.datetime(2000, 10, 1),
-                 '2000q4': datetime.datetime(2000, 10, 1),
                  '00q4': datetime.datetime(2000, 10, 1),
                  '2005': datetime.datetime(2005, 1, 1),
                  '2005-11': datetime.datetime(2005, 11, 1),


### PR DESCRIPTION
Removal of duplicate line to fix lint error

```
pandas/tseries/tests/test_tslib.py:685:18: F999 dictionary key '2000q4' repeated with different values
pandas/tseries/tests/test_tslib.py:690:18: F999 dictionary key '2000q4' repeated with different values
```
