### PR TITLE
add check for infinity in __call__ of EngFormatter

### DIFF
--- a/pandas/formats/format.py
+++ b/pandas/formats/format.py
@@ -2586,6 +2586,9 @@ class EngFormatter(object):
         if decimal.Decimal.is_nan(dnum):
             return 'NaN'
 
+        if decimal.Decimal.is_infinite(dnum):
+            return 'inf'
+
         sign = 1
 
         if dnum < 0:  # pragma: no cover

--- a/pandas/tests/formats/test_format.py
+++ b/pandas/tests/formats/test_format.py
@@ -4047,6 +4047,14 @@ class TestEngFormatter(tm.TestCase):
         self.assertTrue('NaN' in result)
         self.reset_display_options()
 
+    def test_inf(self):
+        # Issue #11981
+
+        formatter = fmt.EngFormatter(accuracy=1, use_eng_prefix=True)
+        result = formatter(np.inf)
+        self.assertEqual(result, u('inf'))
+
+
 def _three_digit_exp():
     return '%.4g' % 1.7e8 == '1.7e+008'
 


### PR DESCRIPTION
EngFormatter throws an exception if passed 'inf' as below.

This patch checks for infinity and just returns 'inf' in that case.  The fix is analagous to the recent fix for NaN: 

https://github.com/pydata/pandas/commit/d0734ba4d0f4c228110dc3974943ce4ec2adeea4

``` python

import pandas
import pandas.core.format as fmt

ef = fmt.EngFormatter()
ef(pandas.np.inf)

...
```

---

OverflowError                             Traceback (most recent call last)
<ipython-input-17-c4aa659346ee> in <module>()
      3 
      4 ef = fmt.EngFormatter()
----> 5 ef(pandas.np.inf)

/usr/lib/python3/dist-packages/pandas/core/format.py in **call**(self, num)
   2485 
   2486         if dnum != 0:
-> 2487             pow10 = decimal.Decimal(int(math.floor(dnum.log10() / 3) \* 3))
   2488         else:
   2489             pow10 = decimal.Decimal(0)

OverflowError: cannot convert Infinity to integer
