### PR TITLE
DOC: #14195. to_csv warns regarding quoting behaviour for floats

### DIFF
--- a/doc/source/io.rst
+++ b/doc/source/io.rst
@@ -1481,7 +1481,7 @@ function takes a number of arguments. Only the first is required.
   - ``encoding``: a string representing the encoding to use if the contents are
     non-ASCII, for python versions prior to 3
   - ``line_terminator``: Character sequence denoting line end (default '\\n')
-  - ``quoting``: Set quoting rules as in csv module (default csv.QUOTE_MINIMAL)
+  - ``quoting``: Set quoting rules as in csv module (default csv.QUOTE_MINIMAL). Note that if you have set a `float_format` then floats are converted to strings and csv.QUOTE_NONNUMERIC will treat them as non-numeric
   - ``quotechar``: Character used to quote fields (default '"')
   - ``doublequote``: Control quoting of ``quotechar`` in fields (default True)
   - ``escapechar``: Character used to escape ``sep`` and ``quotechar`` when

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -1345,7 +1345,9 @@ class DataFrame(NDFrame):
             The newline character or character sequence to use in the output
             file
         quoting : optional constant from csv module
-            defaults to csv.QUOTE_MINIMAL
+            defaults to csv.QUOTE_MINIMAL. If you have set a `float_format`
+            then floats are comverted to strings and thus csv.QUOTE_NONNUMERIC 
+            will treat them as non-numeric
         quotechar : string (length 1), default '\"'
             character used to quote fields
         doublequote : boolean, default True

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -1346,7 +1346,7 @@ class DataFrame(NDFrame):
             file
         quoting : optional constant from csv module
             defaults to csv.QUOTE_MINIMAL. If you have set a `float_format`
-            then floats are comverted to strings and thus csv.QUOTE_NONNUMERIC 
+            then floats are comverted to strings and thus csv.QUOTE_NONNUMERIC
             will treat them as non-numeric
         quotechar : string (length 1), default '\"'
             character used to quote fields


### PR DESCRIPTION
- [x] closes #14195
- [ ] passes `git diff upstream/master | flake8 --diff`

Added a small warning that if `float_format` is set then floats will be quoted even if csv.QUOTE_NONNUMERIC is set
