### PR TITLE
BUG: float truncation in eval with py 2

### DIFF
--- a/doc/source/whatsnew/v0.19.0.txt
+++ b/doc/source/whatsnew/v0.19.0.txt
@@ -1567,7 +1567,7 @@ Bug Fixes
 - Bug in ``DataFrame.to_csv()`` with ``MultiIndex`` columns in which a stray empty line was added (:issue:`6618`)
 - Bug in ``DatetimeIndex``, ``TimedeltaIndex`` and ``PeriodIndex.equals()`` may return ``True`` when input isn't ``Index`` but contains the same values (:issue:`13107`)
 - Bug in assignment against datetime with timezone may not work if it contains datetime near DST boundary (:issue:`14146`)
-- Bug in ``pd.eval()`` truncating long float literals with python 2 (:issue:`14241`)
+- Bug in ``pd.eval()`` and ``HDFStore`` query truncating long float literals with python 2 (:issue:`14241`)
 - Bug in ``Index`` raises ``KeyError`` displaying incorrect column when column is not in the df and columns contains duplicate values (:issue:`13822`)
 - Bug in ``Period`` and ``PeriodIndex`` creating wrong dates when frequency has combined offset aliases (:issue:`13874`)
 - Bug in ``.to_string()`` when called with an integer ``line_width`` and ``index=False`` raises an UnboundLocalError exception because ``idx`` referenced before assignment.

--- a/doc/source/whatsnew/v0.19.0.txt
+++ b/doc/source/whatsnew/v0.19.0.txt
@@ -1567,7 +1567,7 @@ Bug Fixes
 - Bug in ``DataFrame.to_csv()`` with ``MultiIndex`` columns in which a stray empty line was added (:issue:`6618`)
 - Bug in ``DatetimeIndex``, ``TimedeltaIndex`` and ``PeriodIndex.equals()`` may return ``True`` when input isn't ``Index`` but contains the same values (:issue:`13107`)
 - Bug in assignment against datetime with timezone may not work if it contains datetime near DST boundary (:issue:`14146`)
-
+- Bug in ``pd.eval()`` truncating long float literals with python 2 (:issue:`14241`)
 - Bug in ``Index`` raises ``KeyError`` displaying incorrect column when column is not in the df and columns contains duplicate values (:issue:`13822`)
 - Bug in ``Period`` and ``PeriodIndex`` creating wrong dates when frequency has combined offset aliases (:issue:`13874`)
 - Bug in ``.to_string()`` when called with an integer ``line_width`` and ``index=False`` raises an UnboundLocalError exception because ``idx`` referenced before assignment.

--- a/pandas/computation/ops.py
+++ b/pandas/computation/ops.py
@@ -166,6 +166,11 @@ class Constant(Term):
     def name(self):
         return self.value
 
+    def __unicode__(self):
+        # in python 2 str() of float
+        # can truncate shorter than repr()
+        return repr(self.name)
+
 
 _bool_op_map = {'not': '~', 'and': '&', 'or': '|'}
 

--- a/pandas/computation/pytables.py
+++ b/pandas/computation/pytables.py
@@ -611,10 +611,14 @@ class TermValue(object):
     def tostring(self, encoding):
         """ quote the string if not encoded
             else encode and return """
-        if self.kind == u('string'):
+        if self.kind == u'string':
             if encoding is not None:
                 return self.converted
             return '"%s"' % self.converted
+        elif self.kind == u'float':
+            # python 2 str(float) is not always
+            # round-trippable so use repr()
+            return repr(self.converted)
         return self.converted
 
 

--- a/pandas/computation/tests/test_eval.py
+++ b/pandas/computation/tests/test_eval.py
@@ -685,10 +685,23 @@ class TestEvalNumexprPandas(tm.TestCase):
         expected = np.float64(exp)
         self.assertEqual(result, expected)
 
-        df = pd.DataFrame([{"A": 1000000000.0099}])
-        cutoff = 1000000000.006
-        result = df.query("A < %.3f" % cutoff)
+        df = pd.DataFrame({'A': [1000000000.0009,
+                                 1000000000.0011,
+                                 1000000000.0015]})
+        cutoff = 1000000000.0006
+        result = df.query("A < %.4f" % cutoff)
         self.assertTrue(result.empty)
+
+        cutoff = 1000000000.0010
+        result = df.query("A > %.4f" % cutoff)
+        expected = df.loc[[1,2], :]
+        tm.assert_frame_equal(expected, result)
+
+        exact = 1000000000.0011
+        result = df.query('A == %.4f' % exact)
+        expected = df.loc[[1], :]
+        tm.assert_frame_equal(expected, result)
+
 
 
 class TestEvalNumexprPython(TestEvalNumexprPandas):

--- a/pandas/computation/tests/test_eval.py
+++ b/pandas/computation/tests/test_eval.py
@@ -678,6 +678,18 @@ class TestEvalNumexprPandas(tm.TestCase):
         result = pd.eval(exp, engine=self.engine, parser=self.parser)
         self.assertEqual(result, 12)
 
+    def test_float_truncation(self):
+        # GH 14241
+        exp = '1000000000.006'
+        result = pd.eval(exp, engine=self.engine, parser=self.parser)
+        expected = np.float64(exp)
+        self.assertEqual(result, expected)
+
+        df = pd.DataFrame([{"A": 1000000000.0099}])
+        cutoff = 1000000000.006
+        result = df.query("A < %.3f" % cutoff)
+        self.assertTrue(result.empty)
+
 
 class TestEvalNumexprPython(TestEvalNumexprPandas):
 

--- a/pandas/computation/tests/test_eval.py
+++ b/pandas/computation/tests/test_eval.py
@@ -694,7 +694,7 @@ class TestEvalNumexprPandas(tm.TestCase):
 
         cutoff = 1000000000.0010
         result = df.query("A > %.4f" % cutoff)
-        expected = df.loc[[1,2], :]
+        expected = df.loc[[1, 2], :]
         tm.assert_frame_equal(expected, result)
 
         exact = 1000000000.0011

--- a/pandas/io/tests/test_pytables.py
+++ b/pandas/io/tests/test_pytables.py
@@ -5003,6 +5003,16 @@ class TestHDFStore(Base, tm.TestCase):
         tm.assert_frame_equal(expected, actual)
 
 
+    def test_query_long_float_literal(self):
+        # GH 14241
+        df = pd.DataFrame([{"A": 1000000000.0099}])
+        cutoff = 1000000000.006
+        with ensure_clean_store(self.path) as store:
+            store.append('test', df, format='table', data_columns=True)
+            result = store.select('test', "A < %.3f" % cutoff)
+        self.assertTrue(result.empty)
+
+
 class TestHDFComplexValues(Base):
     # GH10447
 

--- a/pandas/io/tests/test_pytables.py
+++ b/pandas/io/tests/test_pytables.py
@@ -5002,7 +5002,6 @@ class TestHDFStore(Base, tm.TestCase):
 
         tm.assert_frame_equal(expected, actual)
 
-
     def test_query_long_float_literal(self):
         # GH 14241
         df = pd.DataFrame([{"A": 1000000000.0099}])

--- a/pandas/io/tests/test_pytables.py
+++ b/pandas/io/tests/test_pytables.py
@@ -5017,7 +5017,7 @@ class TestHDFStore(Base, tm.TestCase):
 
             cutoff = 1000000000.0010
             result = store.select('test', "A > %.4f" % cutoff)
-            expected = df.loc[[1,2], :]
+            expected = df.loc[[1, 2], :]
             tm.assert_frame_equal(expected, result)
 
             exact = 1000000000.0011

--- a/pandas/io/tests/test_pytables.py
+++ b/pandas/io/tests/test_pytables.py
@@ -5004,12 +5004,26 @@ class TestHDFStore(Base, tm.TestCase):
 
     def test_query_long_float_literal(self):
         # GH 14241
-        df = pd.DataFrame([{"A": 1000000000.0099}])
-        cutoff = 1000000000.006
+        df = pd.DataFrame({'A': [1000000000.0009,
+                                 1000000000.0011,
+                                 1000000000.0015]})
+
         with ensure_clean_store(self.path) as store:
             store.append('test', df, format='table', data_columns=True)
-            result = store.select('test', "A < %.3f" % cutoff)
-        self.assertTrue(result.empty)
+
+            cutoff = 1000000000.0006
+            result = store.select('test', "A < %.4f" % cutoff)
+            self.assertTrue(result.empty)
+
+            cutoff = 1000000000.0010
+            result = store.select('test', "A > %.4f" % cutoff)
+            expected = df.loc[[1,2], :]
+            tm.assert_frame_equal(expected, result)
+
+            exact = 1000000000.0011
+            result = store.select('test', 'A == %.4f' % exact)
+            expected = df.loc[[1], :]
+            tm.assert_frame_equal(expected, result)
 
 
 class TestHDFComplexValues(Base):


### PR DESCRIPTION
- [x] closes #14241
- [x] tests added / passed
- [x] passes `git diff upstream/master | flake8 --diff`
- [x] whatsnew entry

Python 2 only - apparently `str()` rounds shorter than `repr()`

```
In [1]: f = 1000000000.006

In [2]: str(f)
Out[2]: '1000000000.01'

In [3]: repr(f)
Out[3]: '1000000000.006'
```
