### PR TITLE
BUG: fix for GH14252

### DIFF
--- a/doc/source/whatsnew/v0.19.0.txt
+++ b/doc/source/whatsnew/v0.19.0.txt
@@ -1576,3 +1576,4 @@ Bug Fixes
 - Bugs in ``stack``, ``get_dummies``, ``make_axis_dummies`` which don't preserve categorical dtypes in (multi)indexes (:issue:`13854`)
 - ``PeridIndex`` can now accept ``list`` and ``array`` which contains ``pd.NaT`` (:issue:`13430`)
 - Bug in ``df.groupby`` where ``.median()`` returns arbitrary values if grouped dataframe contains empty bins (:issue:`13629`)
+- Bug in ``pandas.concat`` does not preserve Index name (:issue:`14252`)

--- a/pandas/indexes/multi.py
+++ b/pandas/indexes/multi.py
@@ -152,9 +152,10 @@ class MultiIndex(Index):
             raise ValueError('Length of levels must match length of level.')
 
         if level is None:
-            new_levels = FrozenList(
-                _ensure_index(lev, copy=copy)._shallow_copy()
-                for lev in levels)
+            new_levels = []
+            for lev in levels:
+                new_levels.append(
+                    _ensure_index(lev, copy=copy)._shallow_copy())
         else:
             level = [self._get_level_number(l) for l in level]
             new_levels = list(self._levels)

--- a/pandas/tools/merge.py
+++ b/pandas/tools/merge.py
@@ -1369,7 +1369,7 @@ class _Concatenator(object):
                 clean_keys.append(k)
                 clean_objs.append(v)
             objs = clean_objs
-            keys = clean_keys
+            keys = Index(clean_keys, name=keys.name)
 
         if len(objs) == 0:
             raise ValueError('All objects passed were None')
@@ -1685,7 +1685,6 @@ def _make_concat_multiindex(indexes, keys, levels=None, names=None):
 
             # also copies
             names = names + _get_consensus_names(indexes)
-
         return MultiIndex(levels=levels, labels=label_list, names=names,
                           verify_integrity=False)
 
@@ -1694,8 +1693,8 @@ def _make_concat_multiindex(indexes, keys, levels=None, names=None):
     kpieces = len(indexes)
 
     # also copies
-    new_names = list(names)
-    new_levels = list(levels)
+    new_names = names
+    new_levels = levels
 
     # construct labels
     new_labels = []
@@ -1723,8 +1722,12 @@ def _make_concat_multiindex(indexes, keys, levels=None, names=None):
     if len(new_names) < len(new_levels):
         new_names.extend(new_index.names)
 
-    return MultiIndex(levels=new_levels, labels=new_labels, names=new_names,
-                      verify_integrity=False)
+    if any(new_names):
+        return MultiIndex(levels=new_levels, labels=new_labels,
+                          names=new_names, verify_integrity=False)
+    else:
+        return MultiIndex(levels=new_levels, labels=new_labels,
+                          verify_integrity=False)
 
 
 def _should_fill(lname, rname):

--- a/pandas/tools/tests/test_merge.py
+++ b/pandas/tools/tests/test_merge.py
@@ -11,6 +11,7 @@ import random
 import pandas as pd
 from pandas.compat import lrange, lzip
 from pandas.tools.merge import merge, concat, MergeError
+from pandas.core.base import FrozenList
 from pandas.util.testing import (assert_frame_equal,
                                  assert_series_equal,
                                  slow)
@@ -833,6 +834,14 @@ class TestMergeMulti(tm.TestCase):
 
             merged2 = merged2.ix[:, merged1.columns]
             assert_frame_equal(merged1, merged2)
+
+    def test_concat_keys(self):
+        df = pd.DataFrame({'foo': [1, 2, 3, 4],
+                           'bar': [0.1, 0.2, 0.3, 0.4]})
+        index = pd.Index(['a', 'b'], name='baz')
+
+        concatted = pd.concat([df, df], keys=index)
+        self.assertEqual(FrozenList(['baz', None]), concatted.index.names)
 
     def test_compress_group_combinations(self):
 


### PR DESCRIPTION
- [x] closes #14252 
- [x] tests added / passed
- [x] passes `git diff upstream/master | flake8 --diff`
- [x] whatsnew entry

This should fix #14252 .  It's possible that not every one of these changes is needed, or there is a better way to fix it, but I think this should do it.
