### PR TITLE
BUG: Fix concat key name

### DIFF
--- a/doc/source/whatsnew/v0.19.0.txt
+++ b/doc/source/whatsnew/v0.19.0.txt
@@ -1563,3 +1563,4 @@ Bug Fixes
 - ``PeridIndex`` can now accept ``list`` and ``array`` which contains ``pd.NaT`` (:issue:`13430`)
 - Bug in ``df.groupby`` where ``.median()`` returns arbitrary values if grouped dataframe contains empty bins (:issue:`13629`)
 - Bug in ``Index.copy()`` where ``name`` parameter was ignored (:issue:`14302`)
+- Bug in ``concat`` where names of keys were not propagated to the resulting MultiIndex (:issue:`14252`)

--- a/doc/source/whatsnew/v0.19.0.txt
+++ b/doc/source/whatsnew/v0.19.0.txt
@@ -1563,4 +1563,3 @@ Bug Fixes
 - ``PeridIndex`` can now accept ``list`` and ``array`` which contains ``pd.NaT`` (:issue:`13430`)
 - Bug in ``df.groupby`` where ``.median()`` returns arbitrary values if grouped dataframe contains empty bins (:issue:`13629`)
 - Bug in ``Index.copy()`` where ``name`` parameter was ignored (:issue:`14302`)
-- Bug in ``concat`` where names of keys were not propagated to the resulting MultiIndex (:issue:`14252`)

--- a/doc/source/whatsnew/v0.19.1.txt
+++ b/doc/source/whatsnew/v0.19.1.txt
@@ -30,3 +30,4 @@ Performance Improvements
 
 Bug Fixes
 ~~~~~~~~~
+- Bug in ``concat`` where names of keys were not propagated to the resulting MultiIndex (:issue:`14252`)

--- a/pandas/tests/frame/test_combine_concat.py
+++ b/pandas/tests/frame/test_combine_concat.py
@@ -4,20 +4,23 @@ from __future__ import print_function
 
 from datetime import datetime
 
-from numpy import nan
 import numpy as np
+from numpy import nan
 
-from pandas.compat import lrange
-from pandas import DataFrame, Series, Index, Timestamp
 import pandas as pd
 
-from pandas.util.testing import (assert_series_equal,
-                                 assert_frame_equal,
-                                 assertRaisesRegexp)
+from pandas import DataFrame, Index, Series, Timestamp
+from pandas.compat import lrange
 
-import pandas.util.testing as tm
+from pandas.core.base import FrozenList
 
 from pandas.tests.frame.common import TestData
+
+import pandas.util.testing as tm
+from pandas.util.testing import (assertRaisesRegexp,
+                                 assert_equal,
+                                 assert_frame_equal,
+                                 assert_series_equal)
 
 
 class TestDataFrameConcatCommon(tm.TestCase, TestData):
@@ -323,6 +326,14 @@ class TestDataFrameConcatCommon(tm.TestCase, TestData):
         assert_frame_equal(df1.join(df2, how='right'), exp)
         assert_frame_equal(df2.join(df1, how='left'),
                            exp[['value2', 'value1']])
+
+    def test_concat_named_keys(self):
+        # GH 14252
+        df = DataFrame({'foo': [1, 2, 3, 4],
+                        'bar': [0.1, 0.2, 0.3, 0.4]})
+        index = Index(['a', 'b'], name='baz')
+        concatted = pd.concat([df, df], keys=index)
+        assert_equal(concatted.index.names, FrozenList(['baz', None]))
 
 
 class TestDataFrameCombineFirst(tm.TestCase, TestData):

--- a/pandas/tests/frame/test_combine_concat.py
+++ b/pandas/tests/frame/test_combine_concat.py
@@ -327,17 +327,25 @@ class TestDataFrameConcatCommon(tm.TestCase, TestData):
     def test_concat_named_keys(self):
         # GH 14252
         df = pd.DataFrame({'foo': [1, 2], 'bar': [0.1, 0.2]})
-        df_concatted = pd.DataFrame(
+        index = Index(['a', 'b'], name='baz')
+        concatted_named_from_keys = pd.concat([df, df], keys=index)
+        expected_named = pd.DataFrame(
             {'foo': [1, 2, 1, 2], 'bar': [0.1, 0.2, 0.1, 0.2]},
             index=pd.MultiIndex.from_product((['a', 'b'], [0, 1]),
                                              names=['baz', None]))
-        index = Index(['a', 'b'], name='baz')
-        concatted_named_from_keys = pd.concat([df, df], keys=index)
-        assert_frame_equal(concatted_named_from_keys, df_concatted)
-        index_no_name = ['a', 'b']
+        assert_frame_equal(concatted_named_from_keys, expected_named)
+
+        index_no_name = Index(['a', 'b'], name=None)
         concatted_named_from_names = pd.concat(
             [df, df], keys=index_no_name, names=['baz'])
-        assert_frame_equal(concatted_named_from_names, df_concatted)
+        assert_frame_equal(concatted_named_from_names, expected_named)
+
+        concatted_unnamed = pd.concat([df, df], keys=index_no_name)
+        expected_unnamed = pd.DataFrame(
+            {'foo': [1, 2, 1, 2], 'bar': [0.1, 0.2, 0.1, 0.2]},
+            index=pd.MultiIndex.from_product((['a', 'b'], [0, 1]),
+                                             names=[None, None]))
+        assert_frame_equal(concatted_unnamed, expected_unnamed)
 
 
 class TestDataFrameCombineFirst(tm.TestCase, TestData):

--- a/pandas/tests/frame/test_combine_concat.py
+++ b/pandas/tests/frame/test_combine_concat.py
@@ -332,8 +332,11 @@ class TestDataFrameConcatCommon(tm.TestCase, TestData):
         df = DataFrame({'foo': [1, 2, 3, 4],
                         'bar': [0.1, 0.2, 0.3, 0.4]})
         index = Index(['a', 'b'], name='baz')
-        concatted = pd.concat([df, df], keys=index)
-        assert_equal(concatted.index.names, FrozenList(['baz', None]))
+        concatted_named_from_keys = pd.concat([df, df], keys=index)
+        assert_equal(concatted_named_from_keys.index.names, FrozenList(['baz', None]))
+        index_no_name = ['a', 'b']
+        concatted_named_from_names = pd.concat([df, df], keys=index_no_name, names=['baz'])
+        assert_equal(concatted_named_from_names.index.names, FrozenList(['baz', None]))
 
 
 class TestDataFrameCombineFirst(tm.TestCase, TestData):

--- a/pandas/tests/frame/test_combine_concat.py
+++ b/pandas/tests/frame/test_combine_concat.py
@@ -12,13 +12,10 @@ import pandas as pd
 from pandas import DataFrame, Index, Series, Timestamp
 from pandas.compat import lrange
 
-from pandas.core.base import FrozenList
-
 from pandas.tests.frame.common import TestData
 
 import pandas.util.testing as tm
 from pandas.util.testing import (assertRaisesRegexp,
-                                 assert_equal,
                                  assert_frame_equal,
                                  assert_series_equal)
 
@@ -329,14 +326,18 @@ class TestDataFrameConcatCommon(tm.TestCase, TestData):
 
     def test_concat_named_keys(self):
         # GH 14252
-        df = DataFrame({'foo': [1, 2, 3, 4],
-                        'bar': [0.1, 0.2, 0.3, 0.4]})
+        df = pd.DataFrame({'foo': [1, 2], 'bar': [0.1, 0.2]})
+        df_concatted = pd.DataFrame(
+            {'foo': [1, 2, 1, 2], 'bar': [0.1, 0.2, 0.1, 0.2]},
+            index=pd.MultiIndex.from_product((['a', 'b'], [0, 1]),
+                                             names=['baz', None]))
         index = Index(['a', 'b'], name='baz')
         concatted_named_from_keys = pd.concat([df, df], keys=index)
-        assert_equal(concatted_named_from_keys.index.names, FrozenList(['baz', None]))
+        assert_frame_equal(concatted_named_from_keys, df_concatted)
         index_no_name = ['a', 'b']
-        concatted_named_from_names = pd.concat([df, df], keys=index_no_name, names=['baz'])
-        assert_equal(concatted_named_from_names.index.names, FrozenList(['baz', None]))
+        concatted_named_from_names = pd.concat(
+            [df, df], keys=index_no_name, names=['baz'])
+        assert_frame_equal(concatted_named_from_names, df_concatted)
 
 
 class TestDataFrameCombineFirst(tm.TestCase, TestData):

--- a/pandas/tools/merge.py
+++ b/pandas/tools/merge.py
@@ -1370,7 +1370,7 @@ class _Concatenator(object):
                 clean_objs.append(v)
             objs = clean_objs
             name = getattr(keys, 'name', None)
-            keys = _ensure_index(clean_keys)
+            keys = _ensure_index(Index(clean_keys))
             keys.name = name
 
         if len(objs) == 0:

--- a/pandas/tools/merge.py
+++ b/pandas/tools/merge.py
@@ -1370,7 +1370,7 @@ class _Concatenator(object):
                 clean_objs.append(v)
             objs = clean_objs
             name = getattr(keys, 'name', None)
-            keys = _ensure_index(Index(clean_keys))
+            keys = Index(clean_keys)
             keys.name = name
 
         if len(objs) == 0:

--- a/pandas/tools/merge.py
+++ b/pandas/tools/merge.py
@@ -1361,18 +1361,18 @@ class _Concatenator(object):
             objs = [obj for obj in objs if obj is not None]
         else:
             # #1649
-            clean_keys_list = []
+            clean_keys = []
             clean_objs = []
             for k, v in zip(keys, objs):
                 if v is None:
                     continue
-                clean_keys_list.append(k)
+                clean_keys.append(k)
                 clean_objs.append(v)
             objs = clean_objs
-            clean_keys_index = Index(clean_keys_list)
             if isinstance(keys, Index):
-                clean_keys_index.name = keys.name
-            keys = clean_keys_index
+                keys = Index(clean_keys, name=keys.name)
+            else:
+                keys = clean_keys
 
         if len(objs) == 0:
             raise ValueError('All objects passed were None')

--- a/pandas/tools/merge.py
+++ b/pandas/tools/merge.py
@@ -1361,15 +1361,18 @@ class _Concatenator(object):
             objs = [obj for obj in objs if obj is not None]
         else:
             # #1649
-            clean_keys = []
+            clean_keys_list = []
             clean_objs = []
             for k, v in zip(keys, objs):
                 if v is None:
                     continue
-                clean_keys.append(k)
+                clean_keys_list.append(k)
                 clean_objs.append(v)
             objs = clean_objs
-            keys = clean_keys
+            clean_keys_index = Index(clean_keys_list)
+            if isinstance(keys, Index):
+                clean_keys_index.name = keys.name
+            keys = clean_keys_index
 
         if len(objs) == 0:
             raise ValueError('All objects passed were None')
@@ -1454,7 +1457,10 @@ class _Concatenator(object):
         self.axis = axis
         self.join_axes = join_axes
         self.keys = keys
-        self.names = names
+        if hasattr(keys, 'names'):
+            self.names = names or keys.names
+        else:
+            self.names = names
         self.levels = levels
 
         self.ignore_index = ignore_index

--- a/pandas/tools/merge.py
+++ b/pandas/tools/merge.py
@@ -1370,7 +1370,7 @@ class _Concatenator(object):
                 clean_objs.append(v)
             objs = clean_objs
             if isinstance(keys, Index):
-                keys = Index(_ensure_index(keys), name=keys.name)
+                keys = Index(_ensure_index(clean_keys), name=keys.name)
             else:
                 keys = clean_keys
 

--- a/pandas/tools/merge.py
+++ b/pandas/tools/merge.py
@@ -1370,7 +1370,7 @@ class _Concatenator(object):
                 clean_objs.append(v)
             objs = clean_objs
             name = getattr(keys, 'name', None)
-            keys = _ensure_index(Index(clean_keys))
+            keys = _ensure_index(clean_keys)
             keys.name = name
 
         if len(objs) == 0:

--- a/pandas/tools/merge.py
+++ b/pandas/tools/merge.py
@@ -1370,7 +1370,7 @@ class _Concatenator(object):
                 clean_objs.append(v)
             objs = clean_objs
             if isinstance(keys, Index):
-                keys = Index(clean_keys, name=keys.name)
+                keys = Index(_ensure_index(keys), name=keys.name)
             else:
                 keys = clean_keys
 

--- a/pandas/tools/merge.py
+++ b/pandas/tools/merge.py
@@ -1457,10 +1457,7 @@ class _Concatenator(object):
         self.axis = axis
         self.join_axes = join_axes
         self.keys = keys
-        if names is None and hasattr(keys, 'names'):
-            self.names = keys.names
-        else:
-            self.names = names
+        self.names = names or getattr(keys, 'names', None)
         self.levels = levels
 
         self.ignore_index = ignore_index

--- a/pandas/tools/merge.py
+++ b/pandas/tools/merge.py
@@ -1369,10 +1369,9 @@ class _Concatenator(object):
                 clean_keys.append(k)
                 clean_objs.append(v)
             objs = clean_objs
-            if isinstance(keys, Index):
-                keys = Index(_ensure_index(clean_keys), name=keys.name)
-            else:
-                keys = clean_keys
+            name = getattr(keys, 'name', None)
+            keys = _ensure_index(clean_keys)
+            keys.name = name
 
         if len(objs) == 0:
             raise ValueError('All objects passed were None')

--- a/pandas/tools/merge.py
+++ b/pandas/tools/merge.py
@@ -1457,8 +1457,8 @@ class _Concatenator(object):
         self.axis = axis
         self.join_axes = join_axes
         self.keys = keys
-        if hasattr(keys, 'names'):
-            self.names = names or keys.names
+        if names is None and hasattr(keys, 'names'):
+            self.names = keys.names
         else:
             self.names = names
         self.levels = levels


### PR DESCRIPTION
- [x] closes #14252
- [x] tests added / passed
- [x] passes `git diff upstream/master | flake8 --diff`
- [x] whatsnew entry

Fixes a bug where `pd.concat` didn't propagate the names of keys used to create
a hierarchical index.
