### PR TITLE
Bug: Error when key-only Grouper is passed to groupby in a list (GH14334)

### DIFF
--- a/doc/source/whatsnew/v0.19.1.txt
+++ b/doc/source/whatsnew/v0.19.1.txt
@@ -54,6 +54,7 @@ Bug Fixes
 - Bug in ``MultiIndex.set_levels`` where illegal level values were still set after raising an error (:issue:`13754`)
 - Bug in ``DataFrame.to_json`` where ``lines=True`` and a value contained a ``}`` character (:issue:`14391`)
 - Bug in ``df.groupby`` causing an ``AttributeError`` when grouping a single index frame by a column and the index level (:issue`14327`)
+- Bug in ``df.groupby`` where ``TypeError`` raised when ``pd.Grouper(key=...)`` is passed in a list (:issue:`14334`)
 
 - Bug in ``pd.pivot_table`` may raise ``TypeError`` or ``ValueError`` when ``index`` or ``columns``
   is not scalar and ``values`` is not specified (:issue:`14380`)

--- a/doc/source/whatsnew/v0.20.0.txt
+++ b/doc/source/whatsnew/v0.20.0.txt
@@ -80,4 +80,3 @@ Performance Improvements
 
 Bug Fixes
 ~~~~~~~~~
-- Bug in ``df.groupby`` where ``TypeError`` raised when key-only Grouper is passed in a list (:issue:`14334`)

--- a/doc/source/whatsnew/v0.20.0.txt
+++ b/doc/source/whatsnew/v0.20.0.txt
@@ -80,3 +80,4 @@ Performance Improvements
 
 Bug Fixes
 ~~~~~~~~~
+- Bug in ``df.groupby`` where ``TypeError`` raised when key-only Grouper is passed in a list (:issue:`14334`)

--- a/pandas/core/groupby.py
+++ b/pandas/core/groupby.py
@@ -2208,7 +2208,10 @@ class Grouping(object):
                 index._get_grouper_for_level(self.grouper, level)
 
         else:
-            if isinstance(self.grouper, (list, tuple)):
+            if self.grouper is None and self.name is not None:
+                self.grouper = self.obj[self.name]
+
+            elif isinstance(self.grouper, (list, tuple)):
                 self.grouper = com._asarray_tuplesafe(self.grouper)
 
             # a passed Categorical
@@ -2448,7 +2451,10 @@ def _get_grouper(obj, key=None, axis=0, level=None, sort=True,
         elif is_in_axis(gpr):  # df.groupby('name')
             in_axis, name, gpr = True, gpr, obj[gpr]
             exclusions.append(name)
-
+        elif isinstance(gpr, Grouper) and gpr.key is not None:
+            # Add key to exclusions
+            exclusions.append(gpr.key)
+            in_axis, name = False, None
         else:
             in_axis, name = False, None
 

--- a/pandas/tests/test_groupby.py
+++ b/pandas/tests/test_groupby.py
@@ -442,6 +442,11 @@ class TestGroupBy(tm.TestCase):
         result = g.sum()
         assert_frame_equal(result, expected)
 
+        # GH14334
+        g = df.groupby([pd.Grouper(key='A')])
+        result = g.sum()
+        assert_frame_equal(result, expected)
+
         # GH8866
         s = Series(np.arange(8, dtype='int64'),
                    index=pd.MultiIndex.from_product(

--- a/pandas/tests/test_groupby.py
+++ b/pandas/tests/test_groupby.py
@@ -444,7 +444,31 @@ class TestGroupBy(tm.TestCase):
 
         # GH14334
         # pd.Grouper(key=...) may be passed in a list
+        df = DataFrame({'A': [0, 0, 0, 1, 1, 1],
+                        'B': [1, 1, 2, 2, 3, 3],
+                        'C': [1, 2, 3, 4, 5, 6]})
+        # Group by single column
+        expected = df.groupby('A').sum()
         g = df.groupby([pd.Grouper(key='A')])
+        result = g.sum()
+        assert_frame_equal(result, expected)
+
+        # Group by two columns
+        # using a combination of strings and Grouper objects
+        expected = df.groupby(['A', 'B']).sum()
+
+        # Group with two Grouper objects
+        g = df.groupby([pd.Grouper(key='A'), pd.Grouper(key='B')])
+        result = g.sum()
+        assert_frame_equal(result, expected)
+
+        # Group with a string and a Grouper object
+        g = df.groupby(['A', pd.Grouper(key='B')])
+        result = g.sum()
+        assert_frame_equal(result, expected)
+
+        # Group with a Grouper object and a string
+        g = df.groupby([pd.Grouper(key='A'), 'B'])
         result = g.sum()
         assert_frame_equal(result, expected)
 

--- a/pandas/tests/test_groupby.py
+++ b/pandas/tests/test_groupby.py
@@ -443,6 +443,7 @@ class TestGroupBy(tm.TestCase):
         assert_frame_equal(result, expected)
 
         # GH14334
+        # pd.Grouper(key=...) may be passed in a list
         g = df.groupby([pd.Grouper(key='A')])
         result = g.sum()
         assert_frame_equal(result, expected)


### PR DESCRIPTION
- [x] closes #14334
- [x] tests added / passed
- [x] passes `git diff upstream/master | flake8 --diff`
- [x] whatsnew entry
