### PR TITLE
DOC: Correct uniqueness of index for Series

### DIFF
--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -102,11 +102,11 @@ class Series(base.IndexOpsMixin, strings.StringAccessorMixin,
     """
     One-dimensional ndarray with axis labels (including time series).
 
-    Labels need not be unique but must be a hashable type. The object supports
-    both integer- and label-based indexing and provides a host of methods for
-    performing operations involving the index. Statistical methods from ndarray
-    have been overridden to automatically exclude missing data (currently
-    represented as NaN).
+    Labels need not be unique but must be a hashable type. The object
+    supports both integer- and label-based indexing and provides a host of
+    methods for performing operations involving the index. Statistical
+    methods from ndarray have been overridden to automatically exclude
+    missing data (currently represented as NaN).
 
     Operations between Series (+, -, /, *, **) align values based on their
     associated index values-- they need not be the same length. The result
@@ -117,9 +117,11 @@ class Series(base.IndexOpsMixin, strings.StringAccessorMixin,
     data : array-like, dict, or scalar value
         Contains data stored in Series
     index : array-like or Index (1d)
-        Values must be hashable and the same length as data. Will default to
+        Values must be hashable and have the same length as `data`.
+        Non-unique index values are allowed. Will default to
         RangeIndex(len(data)) if not provided. If both a dict and index
-        sequence are used, the index will override the keys found in the dict.
+        sequence are used, the index will override the keys found in the
+        dict.
     dtype : numpy.dtype or None
         If None, dtype will be inferred
     copy : boolean, default False

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -118,8 +118,8 @@ class Series(base.IndexOpsMixin, strings.StringAccessorMixin,
         Contains data stored in Series
     index : array-like or Index (1d)
         Values must be hashable and the same length as data. Will default to
-        RangeIndex(len(data)) if not provided. If both a dict and index sequence
-        are used, the index will override the keys found in the dict.
+        RangeIndex(len(data)) if not provided. If both a dict and index
+        sequence are used, the index will override the keys found in the dict.
     dtype : numpy.dtype or None
         If None, dtype will be inferred
     copy : boolean, default False

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -117,7 +117,7 @@ class Series(base.IndexOpsMixin, strings.StringAccessorMixin,
     data : array-like, dict, or scalar value
         Contains data stored in Series
     index : array-like or Index (1d)
-        Values must be unique and hashable, same length as data. Index
+        Values must be same length as data. Index
         object (or other iterable of same length as data) Will default to
         RangeIndex(len(data)) if not provided. If both a dict and index
         sequence are used, the index will override the keys found in the

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -102,11 +102,11 @@ class Series(base.IndexOpsMixin, strings.StringAccessorMixin,
     """
     One-dimensional ndarray with axis labels (including time series).
 
-    Labels need not be unique but must be any hashable type. The object
-    supports both integer- and label-based indexing and provides a host of
-    methods for performing operations involving the index. Statistical
-    methods from ndarray have been overridden to automatically exclude
-    missing data (currently represented as NaN)
+    Labels need not be unique. The object supports both integer- and
+    label-based indexing and provides a host of methods for performing
+    operations involving the index. Statistical methods from ndarray have
+    been overridden to automatically exclude missing data (currently
+    represented as NaN)
 
     Operations between Series (+, -, /, *, **) align values based on their
     associated index values-- they need not be the same length. The result
@@ -117,8 +117,7 @@ class Series(base.IndexOpsMixin, strings.StringAccessorMixin,
     data : array-like, dict, or scalar value
         Contains data stored in Series
     index : array-like or Index (1d)
-        Values must be same length as data. Index
-        object (or other iterable of same length as data) Will default to
+        Values must be same length as data. Will default to
         RangeIndex(len(data)) if not provided. If both a dict and index
         sequence are used, the index will override the keys found in the
         dict.

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -102,11 +102,11 @@ class Series(base.IndexOpsMixin, strings.StringAccessorMixin,
     """
     One-dimensional ndarray with axis labels (including time series).
 
-    Labels need not be unique. The object supports both integer- and
-    label-based indexing and provides a host of methods for performing
-    operations involving the index. Statistical methods from ndarray have
-    been overridden to automatically exclude missing data (currently
-    represented as NaN)
+    Labels need not be unique but must be a hashable type. The object supports
+    both integer- and label-based indexing and provides a host of methods for
+    performing operations involving the index. Statistical methods from ndarray
+    have been overridden to automatically exclude missing data (currently
+    represented as NaN).
 
     Operations between Series (+, -, /, *, **) align values based on their
     associated index values-- they need not be the same length. The result
@@ -117,10 +117,9 @@ class Series(base.IndexOpsMixin, strings.StringAccessorMixin,
     data : array-like, dict, or scalar value
         Contains data stored in Series
     index : array-like or Index (1d)
-        Values must be same length as data. Will default to
-        RangeIndex(len(data)) if not provided. If both a dict and index
-        sequence are used, the index will override the keys found in the
-        dict.
+	Values must be hashable and the same length as data. Will default to
+        RangeIndex(len(data)) if not provided. If both a dict and index sequence are
+        used, the index will override the keys found in the dict.
     dtype : numpy.dtype or None
         If None, dtype will be inferred
     copy : boolean, default False

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -117,9 +117,9 @@ class Series(base.IndexOpsMixin, strings.StringAccessorMixin,
     data : array-like, dict, or scalar value
         Contains data stored in Series
     index : array-like or Index (1d)
-	Values must be hashable and the same length as data. Will default to
-        RangeIndex(len(data)) if not provided. If both a dict and index sequence are
-        used, the index will override the keys found in the dict.
+        Values must be hashable and the same length as data. Will default to
+        RangeIndex(len(data)) if not provided. If both a dict and index sequence
+        are used, the index will override the keys found in the dict.
     dtype : numpy.dtype or None
         If None, dtype will be inferred
     copy : boolean, default False


### PR DESCRIPTION
closes #7808

Just wanted to fix the docstring to reflect the fact that the index labels neither need to be unique ~~nor hashable~~.
