### PR TITLE
TST: #14345 fixes TestDatetimeIndexOps test_nat AssertionErrors on 32-bit

### DIFF
--- a/pandas/tseries/tests/test_base.py
+++ b/pandas/tseries/tests/test_base.py
@@ -861,26 +861,21 @@ Freq: D"""
         self.assertIs(pd.DatetimeIndex([])._na_value, pd.NaT)
 
         for tz in [None, 'US/Eastern', 'UTC']:
-
             idx = pd.DatetimeIndex(['2011-01-01', '2011-01-02'], tz=tz)
             self.assertTrue(idx._can_hold_na)
 
             tm.assert_numpy_array_equal(idx._isnan, np.array([False, False]))
             self.assertFalse(idx.hasnans)
-
-            tm.assert_numpy_array_equal(idx._nan_idxs, np.array([], dtype=np.intp))
+            tm.assert_numpy_array_equal(idx._nan_idxs,
+                                        np.array([], dtype=np.intp))
 
             idx = pd.DatetimeIndex(['2011-01-01', 'NaT'], tz=tz)
             self.assertTrue(idx._can_hold_na)
 
-
-            self.assertTrue(idx.hasnans)
-
             tm.assert_numpy_array_equal(idx._isnan, np.array([False, True]))
-
-
-            tm.assert_numpy_array_equal(idx._nan_idxs, np.array([1], dtype=np.intp))
-
+            self.assertTrue(idx.hasnans)
+            tm.assert_numpy_array_equal(idx._nan_idxs,
+                                        np.array([1], dtype=np.intp))
 
     def test_equals(self):
         # GH 13107
@@ -1712,25 +1707,25 @@ Freq: D"""
             tm.assert_index_equal(res, exp)
             self.assertIsNone(res.freq)
 
-    # def test_nat(self):
-    #     self.assertIs(pd.TimedeltaIndex._na_value, pd.NaT)
-    #     self.assertIs(pd.TimedeltaIndex([])._na_value, pd.NaT)
-    #
-    #     idx = pd.TimedeltaIndex(['1 days', '2 days'])
-    #     self.assertTrue(idx._can_hold_na)
-    #
-    #     tm.assert_numpy_array_equal(idx._isnan, np.array([False, False]))
-    #     self.assertFalse(idx.hasnans)
-    #     tm.assert_numpy_array_equal(idx._nan_idxs,
-    #                                 np.array([], dtype=np.int64))
-    #
-    #     idx = pd.TimedeltaIndex(['1 days', 'NaT'])
-    #     self.assertTrue(idx._can_hold_na)
-    #
-    #     tm.assert_numpy_array_equal(idx._isnan, np.array([False, True]))
-    #     self.assertTrue(idx.hasnans)
-    #     tm.assert_numpy_array_equal(idx._nan_idxs,
-    #                                 np.array([1], dtype=np.int64))
+    def test_nat(self):
+        self.assertIs(pd.TimedeltaIndex._na_value, pd.NaT)
+        self.assertIs(pd.TimedeltaIndex([])._na_value, pd.NaT)
+
+        idx = pd.TimedeltaIndex(['1 days', '2 days'])
+        self.assertTrue(idx._can_hold_na)
+
+        tm.assert_numpy_array_equal(idx._isnan, np.array([False, False]))
+        self.assertFalse(idx.hasnans)
+        tm.assert_numpy_array_equal(idx._nan_idxs,
+                                    np.array([], dtype=np.intp))
+
+        idx = pd.TimedeltaIndex(['1 days', 'NaT'])
+        self.assertTrue(idx._can_hold_na)
+
+        tm.assert_numpy_array_equal(idx._isnan, np.array([False, True]))
+        self.assertTrue(idx.hasnans)
+        tm.assert_numpy_array_equal(idx._nan_idxs,
+                                    np.array([1], dtype=np.intp))
 
     def test_equals(self):
         # GH 13107
@@ -2709,25 +2704,25 @@ Freq: Q-DEC"""
         for res in [index.repeat(3), np.repeat(index, 3)]:
             tm.assert_index_equal(res, exp)
 
-    # def test_nat(self):
-    #     self.assertIs(pd.PeriodIndex._na_value, pd.NaT)
-    #     self.assertIs(pd.PeriodIndex([], freq='M')._na_value, pd.NaT)
-    #
-    #     idx = pd.PeriodIndex(['2011-01-01', '2011-01-02'], freq='D')
-    #     self.assertTrue(idx._can_hold_na)
-    #
-    #     tm.assert_numpy_array_equal(idx._isnan, np.array([False, False]))
-    #     self.assertFalse(idx.hasnans)
-    #     tm.assert_numpy_array_equal(idx._nan_idxs,
-    #                                 np.array([], dtype=np.int64))
-    #
-    #     idx = pd.PeriodIndex(['2011-01-01', 'NaT'], freq='D')
-    #     self.assertTrue(idx._can_hold_na)
-    #
-    #     tm.assert_numpy_array_equal(idx._isnan, np.array([False, True]))
-    #     self.assertTrue(idx.hasnans)
-    #     tm.assert_numpy_array_equal(idx._nan_idxs,
-    #                                 np.array([1], dtype=np.int64))
+    def test_nat(self):
+        self.assertIs(pd.PeriodIndex._na_value, pd.NaT)
+        self.assertIs(pd.PeriodIndex([], freq='M')._na_value, pd.NaT)
+        
+        idx = pd.PeriodIndex(['2011-01-01', '2011-01-02'], freq='D')
+        self.assertTrue(idx._can_hold_na)
+
+        tm.assert_numpy_array_equal(idx._isnan, np.array([False, False]))
+        self.assertFalse(idx.hasnans)
+        tm.assert_numpy_array_equal(idx._nan_idxs,
+                                    np.array([], dtype=np.intp))
+
+        idx = pd.PeriodIndex(['2011-01-01', 'NaT'], freq='D')
+        self.assertTrue(idx._can_hold_na)
+
+        tm.assert_numpy_array_equal(idx._isnan, np.array([False, True]))
+        self.assertTrue(idx.hasnans)
+        tm.assert_numpy_array_equal(idx._nan_idxs,
+                                    np.array([1], dtype=np.intp))
 
     def test_equals(self):
         # GH 13107

--- a/pandas/tseries/tests/test_base.py
+++ b/pandas/tseries/tests/test_base.py
@@ -861,21 +861,26 @@ Freq: D"""
         self.assertIs(pd.DatetimeIndex([])._na_value, pd.NaT)
 
         for tz in [None, 'US/Eastern', 'UTC']:
+
             idx = pd.DatetimeIndex(['2011-01-01', '2011-01-02'], tz=tz)
             self.assertTrue(idx._can_hold_na)
 
             tm.assert_numpy_array_equal(idx._isnan, np.array([False, False]))
             self.assertFalse(idx.hasnans)
-            tm.assert_numpy_array_equal(idx._nan_idxs,
-                                        np.array([], dtype=np.int64))
+
+            tm.assert_numpy_array_equal(idx._nan_idxs, np.array([], dtype=np.intp))
 
             idx = pd.DatetimeIndex(['2011-01-01', 'NaT'], tz=tz)
             self.assertTrue(idx._can_hold_na)
 
-            tm.assert_numpy_array_equal(idx._isnan, np.array([False, True]))
+
             self.assertTrue(idx.hasnans)
-            tm.assert_numpy_array_equal(idx._nan_idxs,
-                                        np.array([1], dtype=np.int64))
+
+            tm.assert_numpy_array_equal(idx._isnan, np.array([False, True]))
+
+
+            tm.assert_numpy_array_equal(idx._nan_idxs, np.array([1], dtype=np.intp))
+
 
     def test_equals(self):
         # GH 13107
@@ -1707,25 +1712,25 @@ Freq: D"""
             tm.assert_index_equal(res, exp)
             self.assertIsNone(res.freq)
 
-    def test_nat(self):
-        self.assertIs(pd.TimedeltaIndex._na_value, pd.NaT)
-        self.assertIs(pd.TimedeltaIndex([])._na_value, pd.NaT)
-
-        idx = pd.TimedeltaIndex(['1 days', '2 days'])
-        self.assertTrue(idx._can_hold_na)
-
-        tm.assert_numpy_array_equal(idx._isnan, np.array([False, False]))
-        self.assertFalse(idx.hasnans)
-        tm.assert_numpy_array_equal(idx._nan_idxs,
-                                    np.array([], dtype=np.int64))
-
-        idx = pd.TimedeltaIndex(['1 days', 'NaT'])
-        self.assertTrue(idx._can_hold_na)
-
-        tm.assert_numpy_array_equal(idx._isnan, np.array([False, True]))
-        self.assertTrue(idx.hasnans)
-        tm.assert_numpy_array_equal(idx._nan_idxs,
-                                    np.array([1], dtype=np.int64))
+    # def test_nat(self):
+    #     self.assertIs(pd.TimedeltaIndex._na_value, pd.NaT)
+    #     self.assertIs(pd.TimedeltaIndex([])._na_value, pd.NaT)
+    #
+    #     idx = pd.TimedeltaIndex(['1 days', '2 days'])
+    #     self.assertTrue(idx._can_hold_na)
+    #
+    #     tm.assert_numpy_array_equal(idx._isnan, np.array([False, False]))
+    #     self.assertFalse(idx.hasnans)
+    #     tm.assert_numpy_array_equal(idx._nan_idxs,
+    #                                 np.array([], dtype=np.int64))
+    #
+    #     idx = pd.TimedeltaIndex(['1 days', 'NaT'])
+    #     self.assertTrue(idx._can_hold_na)
+    #
+    #     tm.assert_numpy_array_equal(idx._isnan, np.array([False, True]))
+    #     self.assertTrue(idx.hasnans)
+    #     tm.assert_numpy_array_equal(idx._nan_idxs,
+    #                                 np.array([1], dtype=np.int64))
 
     def test_equals(self):
         # GH 13107
@@ -2704,25 +2709,25 @@ Freq: Q-DEC"""
         for res in [index.repeat(3), np.repeat(index, 3)]:
             tm.assert_index_equal(res, exp)
 
-    def test_nat(self):
-        self.assertIs(pd.PeriodIndex._na_value, pd.NaT)
-        self.assertIs(pd.PeriodIndex([], freq='M')._na_value, pd.NaT)
-
-        idx = pd.PeriodIndex(['2011-01-01', '2011-01-02'], freq='D')
-        self.assertTrue(idx._can_hold_na)
-
-        tm.assert_numpy_array_equal(idx._isnan, np.array([False, False]))
-        self.assertFalse(idx.hasnans)
-        tm.assert_numpy_array_equal(idx._nan_idxs,
-                                    np.array([], dtype=np.int64))
-
-        idx = pd.PeriodIndex(['2011-01-01', 'NaT'], freq='D')
-        self.assertTrue(idx._can_hold_na)
-
-        tm.assert_numpy_array_equal(idx._isnan, np.array([False, True]))
-        self.assertTrue(idx.hasnans)
-        tm.assert_numpy_array_equal(idx._nan_idxs,
-                                    np.array([1], dtype=np.int64))
+    # def test_nat(self):
+    #     self.assertIs(pd.PeriodIndex._na_value, pd.NaT)
+    #     self.assertIs(pd.PeriodIndex([], freq='M')._na_value, pd.NaT)
+    #
+    #     idx = pd.PeriodIndex(['2011-01-01', '2011-01-02'], freq='D')
+    #     self.assertTrue(idx._can_hold_na)
+    #
+    #     tm.assert_numpy_array_equal(idx._isnan, np.array([False, False]))
+    #     self.assertFalse(idx.hasnans)
+    #     tm.assert_numpy_array_equal(idx._nan_idxs,
+    #                                 np.array([], dtype=np.int64))
+    #
+    #     idx = pd.PeriodIndex(['2011-01-01', 'NaT'], freq='D')
+    #     self.assertTrue(idx._can_hold_na)
+    #
+    #     tm.assert_numpy_array_equal(idx._isnan, np.array([False, True]))
+    #     self.assertTrue(idx.hasnans)
+    #     tm.assert_numpy_array_equal(idx._nan_idxs,
+    #                                 np.array([1], dtype=np.int64))
 
     def test_equals(self):
         # GH 13107

--- a/pandas/tseries/tests/test_base.py
+++ b/pandas/tseries/tests/test_base.py
@@ -2707,7 +2707,7 @@ Freq: Q-DEC"""
     def test_nat(self):
         self.assertIs(pd.PeriodIndex._na_value, pd.NaT)
         self.assertIs(pd.PeriodIndex([], freq='M')._na_value, pd.NaT)
-        
+
         idx = pd.PeriodIndex(['2011-01-01', '2011-01-02'], freq='D')
         self.assertTrue(idx._can_hold_na)
 


### PR DESCRIPTION
- [ ] closes #14345 
     Changed tm.assert_numpy_array_equal(idx._nan_idxs, np.array([], dtype=np.int64)
     np.int64 to npintp
    All tests now pass on 32bit linux install.
