### PR TITLE
DOC: Remove old warning from dsintro.rst

### DIFF
--- a/doc/source/dsintro.rst
+++ b/doc/source/dsintro.rst
@@ -41,12 +41,6 @@ categories of functionality and methods in separate sections.
 Series
 ------
 
-.. warning::
-
-   In 0.13.0 ``Series`` has internally been refactored to no longer sub-class ``ndarray``
-   but instead subclass ``NDFrame``, similarly to the rest of the pandas containers. This should be
-   a transparent change with only very limited API implications (See the :ref:`Internal Refactoring<whatsnew_0130.refactoring>`)
-
 :class:`Series` is a one-dimensional labeled array capable of holding any data
 type (integers, strings, floating point numbers, Python objects, etc.). The axis
 labels are collectively referred to as the **index**. The basic method to create a Series is to call:


### PR DESCRIPTION
- [ ] closes #xxxx
- [ ] tests added / passed
- [ ] passes `git diff upstream/master | flake8 --diff`
- [ ] whatsnew entry

The warning is about something that have been fixed for almost 3 years. Every time a new user excited about pandas start reading the docs, they have to waste brain-cycles ignoring that big red warning bubble.
