### PR TITLE
BUG: Fix linux Qt clipboard QApplication() creation

### DIFF
--- a/pandas/util/clipboard.py
+++ b/pandas/util/clipboard.py
@@ -244,7 +244,7 @@ elif os.name == 'posix' or platform.system() == 'Linux':
         copy = _copyGtk
     elif qtBindingInstalled:
         _functions = 'PyQt4 module'  # for debugging
-        app = QtGui.QApplication([])
+        app = QtGui.QApplication.instance() or QtGui.QApplication([])
         cb = QtGui.QApplication.clipboard()
         paste = _pasteQt
         copy = _copyQt


### PR DESCRIPTION
Fixes #14372

A Qt application cannot instantiate multiple `QApplication` instances,
so we create a new `QApplication` only when the global
`QApplication.instance()` is None.

Failing sample:

```
from PyQt4.QtGui import QApplication
myapp = QApplication([])
from pandas.util.clipboard import clipboard_get  # <--- ERROR

  File "prefix/lib/python2.7/site-packages/pandas/util/clipboard.py", line 164, in <module>

    app = qt4.QtGui.QApplication([])

RuntimeError: A QApplication instance already exists.

```
