### PR TITLE
BUG: pivot_table may raise TypeError without values

### DIFF
--- a/doc/source/whatsnew/v0.19.1.txt
+++ b/doc/source/whatsnew/v0.19.1.txt
@@ -48,3 +48,6 @@ Bug Fixes
 - Bug in ``MultiIndex.set_levels`` where illegal level values were still set after raising an error (:issue:`13754`)
 - Bug in ``DataFrame.to_json`` where ``lines=True`` and a value contained a ``}`` character (:issue:`14391`)
 - Bug in ``df.groupby`` causing an ``AttributeError`` when grouping a single index frame by a column and the index level (:issue`14327`)
+
+- Bug in ``pd.pivot_table`` may raise ``TypeError`` or ``ValueError`` when ``index`` or ``columns``
+  is not scalar and ``values`` is not specified (:issue:`14380`)

--- a/pandas/tools/pivot.py
+++ b/pandas/tools/pivot.py
@@ -101,10 +101,7 @@ def pivot_table(data, values=None, index=None, columns=None, aggfunc='mean',
         else:
             values_multi = False
             values = [values]
-    else:
-        values = list(data.columns.drop(keys))
 
-    if values_passed:
         to_filter = []
         for x in keys + values:
             if isinstance(x, Grouper):
@@ -116,6 +113,15 @@ def pivot_table(data, values=None, index=None, columns=None, aggfunc='mean',
                 pass
         if len(to_filter) < len(data.columns):
             data = data[to_filter]
+
+    else:
+        values = data.columns
+        for key in keys:
+            try:
+                values = values.drop(key)
+            except (TypeError, ValueError):
+                pass
+        values = list(values)
 
     grouped = data.groupby(keys)
     agged = grouped.agg(aggfunc)


### PR DESCRIPTION
- [x] tests added / passed
- [x] passes `git diff upstream/master | flake8 --diff`
- [x] whatsnew entry

`pivot_table` raises `TypeError` when `index` or `columns` is array-like and `values` is not specified.

```
df = pd.DataFrame({'A': [1, 2, 3, 4, 5]},
                  index=pd.DatetimeIndex(['2011-01-01', '2011-02-01', '2011-01-02', '2011-01-01', '2011-01-02']))
df.pivot_table(index=df.index.month, columns=df.index.day)
# TypeError: unhashable type: 'numpy.ndarray'
```
