### PR TITLE
BUG: Fix issue with inserting duplicate columns in a dataframe (GH14291)

### DIFF
--- a/doc/source/whatsnew/v0.19.1.txt
+++ b/doc/source/whatsnew/v0.19.1.txt
@@ -45,3 +45,4 @@ Bug Fixes
 
 - Bug in ``pd.concat`` where names of the ``keys`` were not propagated to the resulting ``MultiIndex`` (:issue:`14252`)
 - Bug in ``MultiIndex.set_levels`` where illegal level values were still set after raising an error (:issue:`13754`)
+- Bug in ``DataFrame.insert`` where multiple calls with duplicate columns can fail (:issue:`14291`)

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -2487,7 +2487,7 @@ class DataFrame(NDFrame):
 
         # check if we are modifying a copy
         # try to set first as we want an invalid
-        # value exeption to occur first
+        # value exception to occur first
         if len(self):
             self._check_setitem_copy()
 
@@ -2506,7 +2506,7 @@ class DataFrame(NDFrame):
         value : int, Series, or array-like
         """
         self._ensure_valid_index(value)
-        value = self._sanitize_column(column, value)
+        value = self._sanitize_column(column, value, broadcast=False)
         self._data.insert(loc, column, value,
                           allow_duplicates=allow_duplicates)
 
@@ -2590,9 +2590,15 @@ class DataFrame(NDFrame):
 
         return data
 
-    def _sanitize_column(self, key, value):
-        # Need to make sure new columns (which go into the BlockManager as new
-        # blocks) are always copied
+    def _sanitize_column(self, key, value, broadcast=True):
+        """
+        Ensures new columns (which go into the BlockManager as new blocks) are
+        always copied.
+
+        The "broadcast" parameter indicates whether all columns with the given
+        key should be returned. The default behavior is desirable when
+        calling this method prior to modifying existing values in a DataFrame.
+        """
 
         def reindexer(value):
             # reindex if necessary
@@ -2665,7 +2671,7 @@ class DataFrame(NDFrame):
             return value
 
         # broadcast across multiple columns if necessary
-        if key in self.columns and value.ndim == 1:
+        if broadcast and key in self.columns and value.ndim == 1:
             if (not self.columns.is_unique or
                     isinstance(self.columns, MultiIndex)):
                 existing_piece = self[key]

--- a/pandas/sparse/frame.py
+++ b/pandas/sparse/frame.py
@@ -302,7 +302,12 @@ class SparseDataFrame(DataFrame):
     # ----------------------------------------------------------------------
     # Support different internal representation of SparseDataFrame
 
-    def _sanitize_column(self, key, value):
+    def _sanitize_column(self, key, value, broadcast=True):
+        """
+        The "broadcast" parameter was added to match the method signature of
+        DataFrame._sanitize_column. However, this method does not make use of
+        broadcasting.
+        """
         sp_maker = lambda x, index=None: SparseArray(
             x, index=index, fill_value=self._default_fill_value,
             kind=self._default_kind)

--- a/pandas/tests/frame/test_mutate_columns.py
+++ b/pandas/tests/frame/test_mutate_columns.py
@@ -163,6 +163,15 @@ class TestDataFrameMutateColumns(tm.TestCase, TestData):
         exp = DataFrame(data={'X': ['x', 'y', 'z']}, index=['A', 'B', 'C'])
         assert_frame_equal(df, exp)
 
+        # GH 14291
+        df = DataFrame()
+        df.insert(0, 'A', ['a', 'b', 'c'], allow_duplicates=True)
+        df.insert(0, 'A', ['a', 'b', 'c'], allow_duplicates=True)
+        df.insert(0, 'A', ['a', 'b', 'c'], allow_duplicates=True)
+        exp = DataFrame([['a', 'a', 'a'], ['b', 'b', 'b'],
+                         ['c', 'c', 'c']], columns=['A', 'A', 'A'])
+        assert_frame_equal(df, exp)
+
     def test_delitem(self):
         del self.frame['A']
         self.assertNotIn('A', self.frame)


### PR DESCRIPTION
- [x] closes #14291
- [x] tests added / passed
- [x] passes `git diff upstream/master | flake8 --diff`
- [x] whatsnew entry

I've been sitting on this simple fix because it seems a little kludgy. SparseDataFrame doesn't do anything parallel to broadcasting in its _sanitize_column method... should it?
