### PR TITLE
BUG: Allow concat to take string axis names

### DIFF
--- a/doc/source/whatsnew/v0.19.1.txt
+++ b/doc/source/whatsnew/v0.19.1.txt
@@ -44,4 +44,5 @@ Bug Fixes
 
 
 - Bug in ``pd.concat`` where names of the ``keys`` were not propagated to the resulting ``MultiIndex`` (:issue:`14252`)
+- Bug in ``pd.concat`` where ``axis`` cannot take string parameters ``rows`` or ``columns (:issue:`14369`)
 - Bug in ``MultiIndex.set_levels`` where illegal level values were still set after raising an error (:issue:`13754`)

--- a/doc/source/whatsnew/v0.19.1.txt
+++ b/doc/source/whatsnew/v0.19.1.txt
@@ -44,5 +44,5 @@ Bug Fixes
 
 
 - Bug in ``pd.concat`` where names of the ``keys`` were not propagated to the resulting ``MultiIndex`` (:issue:`14252`)
-- Bug in ``pd.concat`` where ``axis`` cannot take string parameters ``rows`` or ``columns (:issue:`14369`)
+- Bug in ``pd.concat`` where ``axis`` cannot take string parameters ``'rows'`` or ``'columns'`` (:issue:`14369`)
 - Bug in ``MultiIndex.set_levels`` where illegal level values were still set after raising an error (:issue:`13754`)

--- a/pandas/tests/frame/test_combine_concat.py
+++ b/pandas/tests/frame/test_combine_concat.py
@@ -361,6 +361,18 @@ class TestDataFrameConcatCommon(tm.TestCase, TestData):
         concatted_columns = pd.concat([df1, df2], axis='columns')
         assert_frame_equal(concatted_columns, expected_columns)
 
+        series1 = pd.Series([0.1, 0.2])
+        series2 = pd.Series([0.3, 0.4])
+
+        expected_row_series = pd.Series(
+            [0.1, 0.2, 0.3, 0.4], index=[0, 1, 0, 1])
+        concatted_row_series = pd.concat([series1, series2], axis='rows')
+        assert_series_equal(concatted_row_series, expected_row_series)
+
+        # A Series has no 'columns' axis
+        with assertRaisesRegexp(ValueError, 'No axis named columns'):
+            pd.concat([series1, series2], axis='columns')
+
 
 class TestDataFrameCombineFirst(tm.TestCase, TestData):
 

--- a/pandas/tests/frame/test_combine_concat.py
+++ b/pandas/tests/frame/test_combine_concat.py
@@ -347,6 +347,20 @@ class TestDataFrameConcatCommon(tm.TestCase, TestData):
                                              names=[None, None]))
         assert_frame_equal(concatted_unnamed, expected_unnamed)
 
+    def test_concat_axis_parameter(self):
+        # GH 14369
+        df1 = pd.DataFrame({'A': [0.1, 0.2]}, index=range(2))
+        df2 = pd.DataFrame({'A': [0.3, 0.4]}, index=range(2))
+        expected_row = pd.DataFrame(
+            {'A': [0.1, 0.2, 0.3, 0.4]}, index=[0, 1, 0, 1])
+        concatted_row = pd.concat([df1, df2], axis='rows')
+        assert_frame_equal(concatted_row, expected_row)
+
+        expected_columns = pd.DataFrame(
+            [[0.1, 0.3], [0.2, 0.4]], index=[0, 1], columns=['A', 'A'])
+        concatted_columns = pd.concat([df1, df2], axis='columns')
+        assert_frame_equal(concatted_columns, expected_columns)
+
 
 class TestDataFrameCombineFirst(tm.TestCase, TestData):
 

--- a/pandas/tests/frame/test_combine_concat.py
+++ b/pandas/tests/frame/test_combine_concat.py
@@ -356,10 +356,25 @@ class TestDataFrameConcatCommon(tm.TestCase, TestData):
         concatted_row = pd.concat([df1, df2], axis='rows')
         assert_frame_equal(concatted_row, expected_row)
 
+        expected_index = pd.DataFrame(
+            {'A': [0.1, 0.2, 0.3, 0.4]}, index=[0, 1, 0, 1])
+        concatted_index = pd.concat([df1, df2], axis='index')
+        assert_frame_equal(concatted_index, expected_index)
+
+        expected_0 = pd.DataFrame(
+            {'A': [0.1, 0.2, 0.3, 0.4]}, index=[0, 1, 0, 1])
+        concatted_0 = pd.concat([df1, df2], axis=0)
+        assert_frame_equal(concatted_0, expected_0)
+
         expected_columns = pd.DataFrame(
             [[0.1, 0.3], [0.2, 0.4]], index=[0, 1], columns=['A', 'A'])
         concatted_columns = pd.concat([df1, df2], axis='columns')
         assert_frame_equal(concatted_columns, expected_columns)
+
+        expected_1 = pd.DataFrame(
+            [[0.1, 0.3], [0.2, 0.4]], index=[0, 1], columns=['A', 'A'])
+        concatted_1 = pd.concat([df1, df2], axis=1)
+        assert_frame_equal(concatted_1, expected_1)
 
         series1 = pd.Series([0.1, 0.2])
         series2 = pd.Series([0.3, 0.4])

--- a/pandas/tests/frame/test_combine_concat.py
+++ b/pandas/tests/frame/test_combine_concat.py
@@ -351,30 +351,25 @@ class TestDataFrameConcatCommon(tm.TestCase, TestData):
         # GH 14369
         df1 = pd.DataFrame({'A': [0.1, 0.2]}, index=range(2))
         df2 = pd.DataFrame({'A': [0.3, 0.4]}, index=range(2))
-        expected_row = pd.DataFrame(
-            {'A': [0.1, 0.2, 0.3, 0.4]}, index=[0, 1, 0, 1])
-        concatted_row = pd.concat([df1, df2], axis='rows')
-        assert_frame_equal(concatted_row, expected_row)
 
         expected_index = pd.DataFrame(
             {'A': [0.1, 0.2, 0.3, 0.4]}, index=[0, 1, 0, 1])
         concatted_index = pd.concat([df1, df2], axis='index')
         assert_frame_equal(concatted_index, expected_index)
 
-        expected_0 = pd.DataFrame(
-            {'A': [0.1, 0.2, 0.3, 0.4]}, index=[0, 1, 0, 1])
+        concatted_row = pd.concat([df1, df2], axis='rows')
+        assert_frame_equal(concatted_row, expected_index)
+
         concatted_0 = pd.concat([df1, df2], axis=0)
-        assert_frame_equal(concatted_0, expected_0)
+        assert_frame_equal(concatted_0, expected_index)
 
         expected_columns = pd.DataFrame(
             [[0.1, 0.3], [0.2, 0.4]], index=[0, 1], columns=['A', 'A'])
         concatted_columns = pd.concat([df1, df2], axis='columns')
         assert_frame_equal(concatted_columns, expected_columns)
 
-        expected_1 = pd.DataFrame(
-            [[0.1, 0.3], [0.2, 0.4]], index=[0, 1], columns=['A', 'A'])
         concatted_1 = pd.concat([df1, df2], axis=1)
-        assert_frame_equal(concatted_1, expected_1)
+        assert_frame_equal(concatted_1, expected_columns)
 
         series1 = pd.Series([0.1, 0.2])
         series2 = pd.Series([0.3, 0.4])

--- a/pandas/tools/merge.py
+++ b/pandas/tools/merge.py
@@ -1283,7 +1283,7 @@ def concat(objs, axis=0, join='outer', join_axes=None, ignore_index=False,
         argument, unless it is passed, in which case the values will be
         selected (see below). Any None objects will be dropped silently unless
         they are all None in which case a ValueError will be raised
-    axis : {0/'index'/'rows', 1/'columns'}, default 0
+    axis : {0/'index', 1/'columns'}, default 0
         The axis to concatenate along
     join : {'inner', 'outer'}, default 'outer'
         How to handle indexes on other axis(es)

--- a/pandas/tools/merge.py
+++ b/pandas/tools/merge.py
@@ -1283,7 +1283,7 @@ def concat(objs, axis=0, join='outer', join_axes=None, ignore_index=False,
         argument, unless it is passed, in which case the values will be
         selected (see below). Any None objects will be dropped silently unless
         they are all None in which case a ValueError will be raised
-    axis : {0, 1, 'rows', 'columns', ...}, default 0
+    axis : {0/'index'/'rows', 1/'columns'}, default 0
         The axis to concatenate along
     join : {'inner', 'outer'}, default 'outer'
         How to handle indexes on other axis(es)

--- a/pandas/tools/merge.py
+++ b/pandas/tools/merge.py
@@ -1283,7 +1283,7 @@ def concat(objs, axis=0, join='outer', join_axes=None, ignore_index=False,
         argument, unless it is passed, in which case the values will be
         selected (see below). Any None objects will be dropped silently unless
         they are all None in which case a ValueError will be raised
-    axis : {0, 1, ...}, default 0
+    axis : {0, 1, 'rows', 'columns', ...}, default 0
         The axis to concatenate along
     join : {'inner', 'outer'}, default 'outer'
         How to handle indexes on other axis(es)
@@ -1410,6 +1410,10 @@ class _Concatenator(object):
         if sample is None:
             sample = objs[0]
         self.objs = objs
+
+        # Check for string axis parameter
+        if isinstance(axis, str):
+            axis = objs[0]._get_axis_number(axis)
 
         # Need to flip BlockManager axis in the DataFrame special case
         self._is_frame = isinstance(sample, DataFrame)


### PR DESCRIPTION
Continued in #14416 

---
- [x] closes #14369 
- [x] tests added / passed
- [x] passes `git diff upstream/master | flake8 --diff`
- [x] whatsnew entry

This uses [`_get_axis_number`](https://github.com/pydata/pandas/blob/master/pandas/core/generic.py#L327-L338) to convert a string `axis` parameter to an integer.  This will allow the `concat` method to use any other aliases given to dataframes axes in the future while not disrupting other uses of `axis` in the `concat` method.  If this pattern works well, it could be used for the other [merge functions](https://github.com/pydata/pandas/blob/master/pandas/tools/merge.py) also.
