### PR TITLE
BUG: Dataframe constructor when given dict with None value

### DIFF
--- a/doc/source/whatsnew/v0.19.1.txt
+++ b/doc/source/whatsnew/v0.19.1.txt
@@ -32,6 +32,7 @@ Bug Fixes
 ~~~~~~~~~
 
 
+- Bug in ``pd.DataFrame`` where constructor fails when given dict with ``None`` value (:issue:`14381`)
 
 
 

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -2915,8 +2915,8 @@ def _sanitize_array(data, index, dtype=None, copy=False,
 
         return subarr
 
-    # scalar like
-    if subarr.ndim == 0:
+    # scalar like, GH
+    if getattr(subarr, 'ndim', 0) == 0:
         if isinstance(data, list):  # pragma: no cover
             subarr = np.array(data, dtype=object)
         elif index is not None:

--- a/pandas/tests/frame/test_constructors.py
+++ b/pandas/tests/frame/test_constructors.py
@@ -259,6 +259,14 @@ class TestDataFrameConstructors(tm.TestCase, TestData):
         frame = DataFrame({'A': [], 'B': []}, columns=['A', 'B'])
         self.assert_index_equal(frame.index, Index([], dtype=np.int64))
 
+        # GH 14381
+        # Dict with None value
+        frame_none = DataFrame(dict(a=None), index=[0])
+        frame_none_list = DataFrame(dict(a=[None]), index=[0])
+        tm.assert_equal(frame_none.get_value(0, 'a'), None)
+        tm.assert_equal(frame_none_list.get_value(0, 'a'), None)
+        tm.assert_frame_equal(frame_none, frame_none_list)
+
         # GH10856
         # dict with scalar values should raise error, even if columns passed
         with tm.assertRaises(ValueError):


### PR DESCRIPTION
- [x] closes #14381
- [x] tests added / passed
- [x] passes `git diff upstream/master | flake8 --diff`
- [x] whatsnew entry
