### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -278,7 +278,7 @@ Please try to maintain backward compatibility. *pandas* has lots of users with l
 
 Adding tests is one of the most common requests after code is pushed to *pandas*. Therefore, it is worth getting in the habit of writing tests ahead of time so this is never an issue.
 
-Like many packages, *pandas* uses the [Nose testing system](http://nose.readthedocs.org/en/latest/index.html) and the convenient extensions in [numpy.testing](http://docs.scipy.org/doc/numpy/reference/routines.testing.html).
+Like many packages, *pandas* uses the [Nose testing system](https://nose.readthedocs.io/en/latest/index.html) and the convenient extensions in [numpy.testing](http://docs.scipy.org/doc/numpy/reference/routines.testing.html).
 
 #### Writing tests
 
@@ -323,7 +323,7 @@ Performance matters and it is worth considering whether your code has introduced
 >
 > The asv benchmark suite was translated from the previous framework, vbench, so many stylistic issues are likely a result of automated transformation of the code.
 
-To use asv you will need either `conda` or `virtualenv`. For more details please check the [asv installation webpage](http://asv.readthedocs.org/en/latest/installing.html).
+To use asv you will need either `conda` or `virtualenv`. For more details please check the [asv installation webpage](https://asv.readthedocs.io/en/latest/installing.html).
 
 To install asv:
 
@@ -360,7 +360,7 @@ This command is equivalent to:
 
 This will launch every test only once, display stderr from the benchmarks, and use your local `python` that comes from your `$PATH`.
 
-Information on how to write a benchmark can be found in the [asv documentation](http://asv.readthedocs.org/en/latest/writing_benchmarks.html).
+Information on how to write a benchmark can be found in the [asv documentation](https://asv.readthedocs.io/en/latest/writing_benchmarks.html).
 
 #### Running the vbench performance test suite (phasing out)
 

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -295,7 +295,7 @@ intersphinx_mapping = {
     'python': ('http://docs.python.org/3', None),
     'numpy': ('http://docs.scipy.org/doc/numpy', None),
     'scipy': ('http://docs.scipy.org/doc/scipy/reference', None),
-    'py': ('http://pylib.readthedocs.org/en/latest/', None)
+    'py': ('https://pylib.readthedocs.io/en/latest/', None)
 }
 import glob
 autosummary_generate = glob.glob("*.rst")

--- a/doc/source/contributing.rst
+++ b/doc/source/contributing.rst
@@ -360,7 +360,7 @@ follow the Numpy Docstring Standard (see above), but you don't need to install
 this because a local copy of numpydoc is included in the *pandas* source
 code.
 `nbconvert <https://nbconvert.readthedocs.io/en/latest/>`_ and
-`nbformat <http://nbformat.readthedocs.io/en/latest/>`_ are required to build
+`nbformat <https://nbformat.readthedocs.io/en/latest/>`_ are required to build
 the Jupyter notebooks included in the documentation.
 
 If you have a conda environment named ``pandas_dev``, you can install the extra
@@ -490,7 +490,7 @@ Adding tests is one of the most common requests after code is pushed to *pandas*
 it is worth getting in the habit of writing tests ahead of time so this is never an issue.
 
 Like many packages, *pandas* uses the `Nose testing system
-<http://nose.readthedocs.org/en/latest/index.html>`_ and the convenient
+<https://nose.readthedocs.io/en/latest/index.html>`_ and the convenient
 extensions in `numpy.testing
 <http://docs.scipy.org/doc/numpy/reference/routines.testing.html>`_.
 
@@ -569,7 +569,7 @@ supports both python2 and python3.
 
 To use all features of asv, you will need either ``conda`` or
 ``virtualenv``. For more details please check the `asv installation
-webpage <http://asv.readthedocs.org/en/latest/installing.html>`_.
+webpage <https://asv.readthedocs.io/en/latest/installing.html>`_.
 
 To install asv::
 
@@ -624,7 +624,7 @@ This will display stderr from the benchmarks, and use your local
 ``python`` that comes from your ``$PATH``.
 
 Information on how to write a benchmark and how to use asv can be found in the
-`asv documentation <http://asv.readthedocs.org/en/latest/writing_benchmarks.html>`_.
+`asv documentation <https://asv.readthedocs.io/en/latest/writing_benchmarks.html>`_.
 
 .. _contributing.gbq_integration_tests:
 

--- a/doc/source/cookbook.rst
+++ b/doc/source/cookbook.rst
@@ -877,7 +877,7 @@ The :ref:`Plotting <visualization>` docs.
 <http://stackoverflow.com/questions/17891493/annotating-points-from-a-pandas-dataframe-in-matplotlib-plot>`__
 
 `Generate Embedded plots in excel files using Pandas, Vincent and xlsxwriter
-<http://pandas-xlsxwriter-charts.readthedocs.org/en/latest/introduction.html>`__
+<https://pandas-xlsxwriter-charts.readthedocs.io/>`__
 
 `Boxplot for each quartile of a stratifying variable
 <http://stackoverflow.com/questions/23232989/boxplot-stratified-by-column-in-python-pandas>`__

--- a/doc/source/ecosystem.rst
+++ b/doc/source/ecosystem.rst
@@ -145,7 +145,7 @@ API
 
 `pandas-datareader <https://github.com/pydata/pandas-datareader>`__
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-``pandas-datareader`` is a remote data access library for pandas. ``pandas.io`` from pandas < 0.17.0 is now refactored/split-off to and importable from ``pandas_datareader`` (PyPI:``pandas-datareader``). Many/most of the supported APIs have at least a documentation paragraph in the `pandas-datareader docs <https://pandas-datareader.readthedocs.org/en/latest/>`_:
+``pandas-datareader`` is a remote data access library for pandas. ``pandas.io`` from pandas < 0.17.0 is now refactored/split-off to and importable from ``pandas_datareader`` (PyPI:``pandas-datareader``). Many/most of the supported APIs have at least a documentation paragraph in the `pandas-datareader docs <https://pandas-datareader.readthedocs.io/en/latest/>`_:
 
 The following data feeds are available:
 
@@ -170,7 +170,7 @@ PyDatastream is a Python interface to the
 SOAP API to return indexed Pandas DataFrames or Panels with financial data.
 This package requires valid credentials for this API (non free).
 
-`pandaSDMX <http://pandasdmx.readthedocs.org>`__
+`pandaSDMX <https://pandasdmx.readthedocs.io>`__
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 pandaSDMX is an extensible library to retrieve and acquire statistical data
 and metadata disseminated in
@@ -215,7 +215,7 @@ dimensional arrays, rather than the tabular data for which pandas excels.
 Out-of-core
 -------------
 
-`Dask <https://dask.readthedocs.org/en/latest/>`__
+`Dask <https://dask.readthedocs.io/en/latest/>`__
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Dask is a flexible parallel computing library for analytics. Dask

--- a/doc/source/install.rst
+++ b/doc/source/install.rst
@@ -189,7 +189,7 @@ pandas is equipped with an exhaustive set of unit tests covering about 97% of
 the codebase as of this writing. To run it on your machine to verify that
 everything is working (and you have all of the dependencies, soft and hard,
 installed), make sure you have `nose
-<http://readthedocs.org/docs/nose/en/latest/>`__ and run:
+<https://nose.readthedocs.io/en/latest/>`__ and run:
 
 ::
 

--- a/doc/source/io.rst
+++ b/doc/source/io.rst
@@ -2639,8 +2639,8 @@ config options <options>` ``io.excel.xlsx.writer`` and
 ``io.excel.xls.writer``. pandas will fall back on `openpyxl`_ for ``.xlsx``
 files if `Xlsxwriter`_ is not available.
 
-.. _XlsxWriter: http://xlsxwriter.readthedocs.org
-.. _openpyxl: http://openpyxl.readthedocs.org/
+.. _XlsxWriter: https://xlsxwriter.readthedocs.io
+.. _openpyxl: https://openpyxl.readthedocs.io/
 .. _xlwt: http://www.python-excel.org
 
 To specify which writer you want to use, you can pass an engine keyword

--- a/doc/source/r_interface.rst
+++ b/doc/source/r_interface.rst
@@ -17,7 +17,7 @@ rpy2 / R interface
 
    In v0.16.0, the ``pandas.rpy`` interface has been **deprecated and will be
    removed in a future version**. Similar functionality can be accessed
-   through the `rpy2 <http://rpy2.readthedocs.io/>`__ project.
+   through the `rpy2 <https://rpy2.readthedocs.io/>`__ project.
    See the :ref:`updating <rpy.updating>` section for a guide to port your
    code from the ``pandas.rpy`` to ``rpy2`` functions.
 

--- a/doc/source/tutorials.rst
+++ b/doc/source/tutorials.rst
@@ -138,7 +138,7 @@ Modern Pandas
 Excel charts with pandas, vincent and xlsxwriter
 ------------------------------------------------
 
--  `Using Pandas and XlsxWriter to create Excel charts <http://pandas-xlsxwriter-charts.readthedocs.org/>`_
+-  `Using Pandas and XlsxWriter to create Excel charts <https://pandas-xlsxwriter-charts.readthedocs.io/>`_
 
 Various Tutorials
 -----------------

--- a/doc/source/whatsnew/v0.14.0.txt
+++ b/doc/source/whatsnew/v0.14.0.txt
@@ -401,7 +401,7 @@ through SQLAlchemy (:issue:`2717`, :issue:`4163`, :issue:`5950`, :issue:`6292`).
 All databases supported by SQLAlchemy can be used, such
 as PostgreSQL, MySQL, Oracle, Microsoft SQL server (see documentation of
 SQLAlchemy on `included dialects
-<http://sqlalchemy.readthedocs.org/en/latest/dialects/index.html>`_).
+<https://sqlalchemy.readthedocs.io/en/latest/dialects/index.html>`_).
 
 The functionality of providing DBAPI connection objects will only be supported
 for sqlite3 in the future. The ``'mysql'`` flavor is deprecated.

--- a/doc/source/whatsnew/v0.17.0.txt
+++ b/doc/source/whatsnew/v0.17.0.txt
@@ -141,7 +141,7 @@ as well as the ``.sum()`` operation.
 
 Releasing of the GIL could benefit an application that uses threads for user interactions (e.g. QT_), or performing multi-threaded computations. A nice example of a library that can handle these types of computation-in-parallel is the dask_ library.
 
-.. _dask: https://dask.readthedocs.org/en/latest/
+.. _dask: https://dask.readthedocs.io/en/latest/
 .. _QT: https://wiki.python.org/moin/PyQt
 
 .. _whatsnew_0170.plot:


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.
