### PR TITLE
Bug: Made it so that 0 was included in uint8

### DIFF
--- a/doc/source/whatsnew/v0.19.1.txt
+++ b/doc/source/whatsnew/v0.19.1.txt
@@ -50,3 +50,4 @@ Bug Fixes
 - Bug in ``df.groupby`` causing an ``AttributeError`` when grouping a single index frame by a column and the index level (:issue`14327`)
 - Bug in ``pd.to_numeric`` where it would not downcast a 0 to a uint8 (:issue:`14404`)
 - Bug in ``pd.to_numeric`` where it would not downcast a 0 properly. (:issue:`14401`)
+- Bug in ``pd.to_numeric`` where a 0 was not unsigned on a downcast = 'unsigned' argument (:issue:`14401`)

--- a/doc/source/whatsnew/v0.19.1.txt
+++ b/doc/source/whatsnew/v0.19.1.txt
@@ -49,3 +49,4 @@ Bug Fixes
 - Bug in ``DataFrame.to_json`` where ``lines=True`` and a value contained a ``}`` character (:issue:`14391`)
 - Bug in ``df.groupby`` causing an ``AttributeError`` when grouping a single index frame by a column and the index level (:issue`14327`)
 - Bug in ``pd.to_numeric`` where it would not downcast a 0 to a uint8 (:issue:`14404`)
+- Bug in ``pd.to_numeric`` where it would not downcast a 0 properly. (:issue:`14401`)

--- a/doc/source/whatsnew/v0.19.1.txt
+++ b/doc/source/whatsnew/v0.19.1.txt
@@ -48,3 +48,4 @@ Bug Fixes
 - Bug in ``MultiIndex.set_levels`` where illegal level values were still set after raising an error (:issue:`13754`)
 - Bug in ``DataFrame.to_json`` where ``lines=True`` and a value contained a ``}`` character (:issue:`14391`)
 - Bug in ``df.groupby`` causing an ``AttributeError`` when grouping a single index frame by a column and the index level (:issue`14327`)
+- Bug in ``pd.to_numeric`` where it would not downcast a 0 to a uint8 (:issue:`14404`)

--- a/pandas/tools/tests/test_util.py
+++ b/pandas/tools/tests/test_util.py
@@ -391,14 +391,6 @@ class TestToNumeric(tm.TestCase):
             res = pd.to_numeric(data, downcast=downcast)
             tm.assert_numpy_array_equal(res, expected)
 
-        #check that 0 works as a unsigned downcast
-
-        data = [0, 1, 2, 3]
-        res = pd.to_numeric(data, downcast=downcast)
-        expected = np.array(data, dtype=np.uint8)
-        tm.assert_numpy_array_equal(res, expected)
-        
-
         # the smallest integer dtype need not be np.(u)int8
         data = ['256', 257, 258]
 
@@ -408,6 +400,32 @@ class TestToNumeric(tm.TestCase):
             expected = np.array([256, 257, 258], dtype=expected_dtype)
             res = pd.to_numeric(data, downcast=downcast)
             tm.assert_numpy_array_equal(res, expected)
+
+        # check that the smallest and largest values in each integer type pass to each type.
+        int8 = [-128, 127]
+        int8_Series = pd.to_numeric(int8, downcast = 'integer')
+        tm.assert_equal(int8_Series.dtype, 'int8')
+        int16 = [-32768, 32767]
+        int16_Series = pd.to_numeric(int16, downcast = 'integer')
+        tm.assert_equal(int16_Series.dtype, 'int16')
+        int32 = [-2147483648, 2147483647]
+        int32_Series = pd.to_numeric(int32, downcast = 'integer')
+        tm.assert_equal(int32_Series.dtype, 'int32')
+        int64 = [-9223372036854775808, 9223372036854775807]
+        int64_Series = pd.to_numeric(int64, downcast = 'integer')
+        tm.assert_equal(int64_Series.dtype, 'int64')
+        uint8 = [0, 255]
+        uint8_Series = pd.to_numeric(uint8, downcast = 'unsigned')
+        tm.assert_equal(uint8_Series.dtype, 'uint8')
+        uint16 = [0, 65535]
+        uint16_Series = pd.to_numeric(uint16, downcast = 'unsigned')
+        tm.assert_equal(uint16_Series.dtype, 'uint16')
+        uint32 = [0, 4294967295]
+        uint32_Series = pd.to_numeric(uint32, downcast = 'unsigned')
+        tm.assert_equal(uint32_Series.dtype, 'uint32')
+        # uint64 = [0, 18446744073709551615]
+        # uint64_Series = pd.to_numeric(uint64, downcast = 'unsigned')
+        # tm.assert_equal(uint64_Series.dtype, 'uint64')
 
 if __name__ == '__main__':
     nose.runmodule(argv=[__file__, '-vvs', '-x', '--pdb', '--pdb-failure'],

--- a/pandas/tools/tests/test_util.py
+++ b/pandas/tools/tests/test_util.py
@@ -391,6 +391,14 @@ class TestToNumeric(tm.TestCase):
             res = pd.to_numeric(data, downcast=downcast)
             tm.assert_numpy_array_equal(res, expected)
 
+        #check that 0 works as a unsigned downcast
+
+        data = [0, 1, 2, 3]
+        res = pd.to_numeric(data, downcast=downcast)
+        expected = np.array(data, dtype=np.uint8)
+        tm.assert_numpy_array_equal(res, expected)
+        
+
         # the smallest integer dtype need not be np.(u)int8
         data = ['256', 257, 258]
 

--- a/pandas/tools/tests/test_util.py
+++ b/pandas/tools/tests/test_util.py
@@ -409,7 +409,7 @@ class TestToNumeric(tm.TestCase):
                 'int64': [np.iinfo(np.int64).min, np.iinfo(np.int64).max]
                 }
 
-        for dtype, min_max in integer_dtype_min_max.iteritems(): 
+        for dtype, min_max in integer_dtype_min_max.items(): 
             series = pd.to_numeric(pd.Series(min_max), downcast = 'integer')
             tm.assert_equal(series.dtype, dtype)
 
@@ -421,7 +421,7 @@ class TestToNumeric(tm.TestCase):
                 # 'uint64': [np.iinfo(np.uint64).min, np.iinfo(np.uint64).max]
                 }
 
-        for dtype, min_max in unsigned_dtype_min_max.iteritems():
+        for dtype, min_max in unsigned_dtype_min_max.items():
             series = pd.to_numeric(pd.Series(min_max), downcast = 'unsigned')
             tm.assert_equal(series.dtype, dtype)
 
@@ -433,7 +433,7 @@ class TestToNumeric(tm.TestCase):
                 'int64': [np.iinfo(np.int32).min, np.iinfo(np.int32).max + 1],
                 }
 
-        for dtype, min_max in integer_dtype_min_max_plus.iteritems(): 
+        for dtype, min_max in integer_dtype_min_max_plus.items(): 
             series = pd.to_numeric(pd.Series(min_max), downcast = 'integer')
             tm.assert_equal(series.dtype, dtype)
 
@@ -443,7 +443,7 @@ class TestToNumeric(tm.TestCase):
                 'int64': [np.iinfo(np.int32).min - 1, np.iinfo(np.int64).max]
                 }
 
-        for dtype, min_max in integer_dtype_min_max_minus.iteritems(): 
+        for dtype, min_max in integer_dtype_min_max_minus.items(): 
             series = pd.to_numeric(pd.Series(min_max), downcast = 'integer')
             tm.assert_equal(series.dtype, dtype)
 
@@ -453,7 +453,7 @@ class TestToNumeric(tm.TestCase):
                 # 'uint64': [np.iinfo(np.uint32).min, np.iinfo(np.uint32).max + 1],
                 }
 
-        for dtype, min_max in unsigned_dtype_min_max_plus.iteritems():
+        for dtype, min_max in unsigned_dtype_min_max_plus.items():
             series = pd.to_numeric(pd.Series(min_max), downcast = 'unsigned')
             tm.assert_equal(series.dtype, dtype)
 

--- a/pandas/tools/tests/test_util.py
+++ b/pandas/tools/tests/test_util.py
@@ -402,30 +402,60 @@ class TestToNumeric(tm.TestCase):
             tm.assert_numpy_array_equal(res, expected)
 
         # check that the smallest and largest values in each integer type pass to each type.
-        int8 = [-128, 127]
-        int8_Series = pd.to_numeric(int8, downcast = 'integer')
-        tm.assert_equal(int8_Series.dtype, 'int8')
-        int16 = [-32768, 32767]
-        int16_Series = pd.to_numeric(int16, downcast = 'integer')
-        tm.assert_equal(int16_Series.dtype, 'int16')
-        int32 = [-2147483648, 2147483647]
-        int32_Series = pd.to_numeric(int32, downcast = 'integer')
-        tm.assert_equal(int32_Series.dtype, 'int32')
-        int64 = [-9223372036854775808, 9223372036854775807]
-        int64_Series = pd.to_numeric(int64, downcast = 'integer')
-        tm.assert_equal(int64_Series.dtype, 'int64')
-        uint8 = [0, 255]
-        uint8_Series = pd.to_numeric(uint8, downcast = 'unsigned')
-        tm.assert_equal(uint8_Series.dtype, 'uint8')
-        uint16 = [0, 65535]
-        uint16_Series = pd.to_numeric(uint16, downcast = 'unsigned')
-        tm.assert_equal(uint16_Series.dtype, 'uint16')
-        uint32 = [0, 4294967295]
-        uint32_Series = pd.to_numeric(uint32, downcast = 'unsigned')
-        tm.assert_equal(uint32_Series.dtype, 'uint32')
-        # uint64 = [0, 18446744073709551615]
-        # uint64_Series = pd.to_numeric(uint64, downcast = 'unsigned')
-        # tm.assert_equal(uint64_Series.dtype, 'uint64')
+        integer_dtype_min_max = {
+                'int8': [np.iinfo(np.int8).min, np.iinfo(np.int8).max],
+                'int16': [np.iinfo(np.int16).min, np.iinfo(np.int16).max],
+                'int32': [np.iinfo(np.int32).min, np.iinfo(np.int32).max],
+                'int64': [np.iinfo(np.int64).min, np.iinfo(np.int64).max]
+                }
+
+        for dtype, min_max in integer_dtype_min_max.iteritems(): 
+            series = pd.to_numeric(pd.Series(min_max), downcast = 'integer')
+            tm.assert_equal(series.dtype, dtype)
+
+        
+        unsigned_dtype_min_max = {
+                'uint8': [np.iinfo(np.uint8).min, np.iinfo(np.uint8).max],
+                'uint16': [np.iinfo(np.uint16).min, np.iinfo(np.uint16).max],
+                'uint32': [np.iinfo(np.uint32).min, np.iinfo(np.uint32).max],
+                # 'uint64': [np.iinfo(np.uint64).min, np.iinfo(np.uint64).max]
+                }
+
+        for dtype, min_max in unsigned_dtype_min_max.iteritems():
+            series = pd.to_numeric(pd.Series(min_max), downcast = 'unsigned')
+            tm.assert_equal(series.dtype, dtype)
+
+        #check to see if the minimum number to shift integer types actually shifts
+
+        integer_dtype_min_max_plus = {
+                'int16': [np.iinfo(np.int8).min, np.iinfo(np.int8).max + 1],
+                'int32': [np.iinfo(np.int16).min, np.iinfo(np.int16).max + 1],
+                'int64': [np.iinfo(np.int32).min, np.iinfo(np.int32).max + 1],
+                }
+
+        for dtype, min_max in integer_dtype_min_max_plus.iteritems(): 
+            series = pd.to_numeric(pd.Series(min_max), downcast = 'integer')
+            tm.assert_equal(series.dtype, dtype)
+
+        integer_dtype_min_max_minus = {
+                'int16': [np.iinfo(np.int8).min - 1, np.iinfo(np.int16).max],
+                'int32': [np.iinfo(np.int16).min - 1, np.iinfo(np.int32).max],
+                'int64': [np.iinfo(np.int32).min - 1, np.iinfo(np.int64).max]
+                }
+
+        for dtype, min_max in integer_dtype_min_max_minus.iteritems(): 
+            series = pd.to_numeric(pd.Series(min_max), downcast = 'integer')
+            tm.assert_equal(series.dtype, dtype)
+
+        unsigned_dtype_min_max_plus = {
+                'uint16': [np.iinfo(np.uint8).min, np.iinfo(np.uint8).max + 1],
+                'uint32': [np.iinfo(np.uint16).min, np.iinfo(np.uint16).max + 1],
+                # 'uint64': [np.iinfo(np.uint32).min, np.iinfo(np.uint32).max + 1],
+                }
+
+        for dtype, min_max in unsigned_dtype_min_max_plus.iteritems():
+            series = pd.to_numeric(pd.Series(min_max), downcast = 'unsigned')
+            tm.assert_equal(series.dtype, dtype)
 
 if __name__ == '__main__':
     nose.runmodule(argv=[__file__, '-vvs', '-x', '--pdb', '--pdb-failure'],

--- a/pandas/tools/util.py
+++ b/pandas/tools/util.py
@@ -205,7 +205,7 @@ def to_numeric(arg, errors='raise', downcast=None):
 
         if downcast in ('integer', 'signed'):
             typecodes = np.typecodes['Integer']
-        elif downcast == 'unsigned' and np.min(values) > 0:
+        elif downcast == 'unsigned' and np.min(values) >= 0:
             typecodes = np.typecodes['UnsignedInteger']
         elif downcast == 'float':
             typecodes = np.typecodes['Float']


### PR DESCRIPTION
- [ ] closes #14401 
- [ ] tests added / passed
- [ ] passes `git diff upstream/master | flake8 --diff`
- [ ] whatsnew entry

Decided to restart. Sorry for the inconvenience. -> #14472
