### PR TITLE
BUG: String indexing against object dtype may raise AttributeError

### DIFF
--- a/doc/source/whatsnew/v0.19.1.txt
+++ b/doc/source/whatsnew/v0.19.1.txt
@@ -37,6 +37,7 @@ Bug Fixes
 - Bug in localizing an ambiguous timezone when a boolean is passed (:issue:`14402`)
 
 
+- Bug in string indexing against data with ``object`` ``Index`` may raise ``AttributeError`` (:issue:`14424`)
 
 
 

--- a/pandas/indexes/base.py
+++ b/pandas/indexes/base.py
@@ -2936,6 +2936,11 @@ class Index(IndexOpsMixin, StringAccessorMixin, PandasObject):
         name = self.name if self.name == other.name else None
         return Index(joined, name=name)
 
+    def _get_string_slice(self, key, use_lhs=True, use_rhs=True):
+        # this is for partial string indexing,
+        # overridden in DatetimeIndex, TimedeltaIndex and PeriodIndex
+        raise NotImplementedError
+
     def slice_indexer(self, start=None, end=None, step=None, kind=None):
         """
         For an ordered Index, compute the slice indexer for input labels and

--- a/pandas/tests/indexing/test_indexing.py
+++ b/pandas/tests/indexing/test_indexing.py
@@ -3613,6 +3613,27 @@ Region_1,Site_2,3977723089,A,5/20/2015 8:33,5/20/2015 9:09,Yes,No"""
         result = df2.loc[idx]
         tm.assert_frame_equal(result, expected, check_index_type=False)
 
+    def test_string_slice(self):
+        # GH 14424
+        # string indexing against datetimelike with object
+        # dtype should properly raises KeyError
+        df = pd.DataFrame([1], pd.Index([pd.Timestamp('2011-01-01')],
+                                        dtype=object))
+        self.assertTrue(df.index.is_all_dates)
+        with tm.assertRaises(KeyError):
+            df['2011']
+
+        with tm.assertRaises(KeyError):
+            df.loc['2011', 0]
+
+        df = pd.DataFrame()
+        self.assertFalse(df.index.is_all_dates)
+        with tm.assertRaises(KeyError):
+            df['2011']
+
+        with tm.assertRaises(KeyError):
+            df.loc['2011', 0]
+
     def test_mi_access(self):
 
         # GH 4145


### PR DESCRIPTION
- [x] tests added / passed
- [x] passes `git diff upstream/master | flake8 --diff`
- [x] whatsnew entry

String indexing may raise `AttributeError`, rather than `KeyError`.

```
df = pd.DataFrame([1], pd.Index([pd.Timestamp('2011-01-01')], dtype=object))
df.index.is_all_dates
# True
df['2011']
# AttributeError: 'Index' object has no attribute '_get_string_slice'
```
