### PR TITLE
PERF: improved perf in .to_json when lines=True

### DIFF
--- a/doc/source/whatsnew/v0.19.1.txt
+++ b/doc/source/whatsnew/v0.19.1.txt
@@ -21,7 +21,7 @@ Performance Improvements
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
 
-
+- Improved Performance in ``.to_json()`` when ``lines=True`` (:issue:`14408`)
 
 
 

--- a/pandas/io/json.py
+++ b/pandas/io/json.py
@@ -605,25 +605,9 @@ def _convert_to_line_delimits(s):
     if not s[0] == '[' and s[-1] == ']':
         return s
     s = s[1:-1]
-    num_open_brackets_seen = 0
-    commas_to_replace = []
-    in_quotes = False
-    for idx, char in enumerate(s):              # iter through to find all
-        if char == '"' and idx > 0 and s[idx - 1] != '\\':
-            in_quotes = ~in_quotes
-        elif char == ',':                         # commas that should be \n
-            if num_open_brackets_seen == 0 and not in_quotes:
-                commas_to_replace.append(idx)
-        elif char == '{':
-            if not in_quotes:
-                num_open_brackets_seen += 1
-        elif char == '}':
-            if not in_quotes:
-                num_open_brackets_seen -= 1
-    s_arr = np.array(list(s))                  # Turn to an array to set
-    s_arr[commas_to_replace] = '\n'            # all commas at once.
-    s = ''.join(s_arr)
-    return s
+
+    from pandas.lib import convert_json_to_lines
+    return convert_json_to_lines(s)
 
 
 def nested_to_record(ds, prefix="", level=0):


### PR DESCRIPTION
closes #14408

master

```
In [1]: np.random.seed(1234)

In [2]: N = 100000
   ...: C = 5
   ...: df = DataFrame(dict([('float{0}'.format(i), np.random.randn(N)) for i in range(C)]))

In [3]: %timeit df.to_json('foo.json',orient='records',lines=True)
1 loop, best of 3: 3.67 s per loop
```

PR (with proper encoding/decoding, IOW work directly on the bytes and minimize copies)

```
In [5]: %timeit df.to_json('foo.json',orient='records',lines=True)
10 loops, best of 3: 137 ms per loop
```
