### PR TITLE
Checks for left_index and right_index merge parameters

### DIFF
--- a/doc/source/whatsnew/v0.19.1.txt
+++ b/doc/source/whatsnew/v0.19.1.txt
@@ -25,6 +25,13 @@ Performance Improvements
 
 
 
+.. _whatsnew_0191.new_features:
+
+New features
+~~~~~~~~~~~~
+- Add checks to assure that left_index and right_index are of type bool
+
+
 
 .. _whatsnew_0191.bug_fixes:
 

--- a/pandas/tools/merge.py
+++ b/pandas/tools/merge.py
@@ -472,6 +472,15 @@ class _MergeOperation(object):
                 'can not merge DataFrame with instance of '
                 'type {0}'.format(type(right)))
 
+        if not is_bool(left_index):
+            raise ValueError(
+                'left_index parameter must be of type bool, not '
+                '{0}'.format(type(left_index)))
+        if not is_bool(right_index):
+            raise ValueError(
+                'right_index parameter must be of type bool, not '
+                '{0}'.format(type(right_index)))
+
         # warn user when merging between different levels
         if left.columns.nlevels != right.columns.nlevels:
             msg = ('merging between different levels can give an unintended '

--- a/pandas/tools/tests/test_merge.py
+++ b/pandas/tools/tests/test_merge.py
@@ -109,6 +109,15 @@ class TestMerge(tm.TestCase):
         self.assertRaises(ValueError, merge, self.df, self.df2,
                           left_on=['key1'], right_on=['key1', 'key2'])
 
+    def test_index_and_on_parameters_confusion(self):
+        self.assertRaises(ValueError, merge, self.df, self.df2, how='left',
+                          left_index=False, right_index=['key1', 'key2'])
+        self.assertRaises(ValueError, merge, self.df, self.df2, how='left',
+                          left_index=['key1', 'key2'], right_index=False)
+        self.assertRaises(ValueError, merge, self.df, self.df2, how='left',
+                          left_index=['key1', 'key2'],
+                          right_index=['key1', 'key2'])
+
     def test_merge_overlap(self):
         merged = merge(self.left, self.left, on='key')
         exp_len = (self.left['key'].value_counts() ** 2).sum()


### PR DESCRIPTION
Hi,

I just committed an error when I was doing an analysis using pandas and this motivated me to implement two checks which in my opinion are necessary. 

I was trying to perform a merge and I confused the parameters "left_on" and "right_on" for "left_index" and "right_index". I ran the code and it did not raised me any error. It produced a table which seem to be fine in terms of shape. I suspect that what happened is that the tables got merged by the index of the data frame. I think it would be a great idea to check if right_index and left_index are of type bool, if not, raise an error. This way we will avoid that more people got the same error as mine :D.

Tests passed 

Thanks!
