### PR TITLE
WIP: Rework IndexEngine to better support hashtable-free algorithms.

### DIFF
--- a/pandas/index.pyx
+++ b/pandas/index.pyx
@@ -121,7 +121,6 @@ cdef class IndexEngine:
         """
         cdef:
             object loc
-            void* data_ptr
 
         loc = self.get_loc(key)
         if PySlice_Check(loc) or cnp.PyArray_Check(loc):
@@ -149,7 +148,6 @@ cdef class IndexEngine:
         # XXX: Why does get_value take a tz but this method doesn't?
         cdef:
             object loc
-            void* data_ptr
 
         loc = self.get_loc(key)
         value = convert_scalar(arr, value)

--- a/pandas/index.pyx
+++ b/pandas/index.pyx
@@ -104,7 +104,20 @@ cdef class IndexEngine:
 
     cpdef get_value(self, ndarray arr, object key, object tz=None):
         """
-        arr : 1-dimensional ndarray
+        Look up value(s) from ``arr`` at the index(es) of ``key``.
+
+        Roughly equivalent to ``arr[self.get_loc(key)]``, with special handling
+        for datetime types.
+
+        Parameters
+        ----------
+        arr : ndarray
+            Array from which to look up values.
+        key : object
+            Index key to use to find values in ``arr``.
+        tz : object, optional
+            Timezone to associate with ``key``.  Ignored unless ``arr`` is of
+            datetime dtype.
         """
         cdef:
             object loc
@@ -122,8 +135,18 @@ cdef class IndexEngine:
 
     cpdef set_value(self, ndarray arr, object key, object value):
         """
-        arr : 1-dimensional ndarray
+        Set ``value`` into ``arr`` at the index(es) of ``key``.
+
+        Roughly equivalent to ``arr[self.get_loc(key)] = value``.
+
+        Parameters
+        ----------
+        arr : ndarray
+            Array from which to look up values.
+        key : object
+            Index key to use to find values in ``arr``.
         """
+        # XXX: Why does get_value take a tz but this method doesn't?
         cdef:
             object loc
             void* data_ptr

--- a/pandas/indexes/numeric.py
+++ b/pandas/indexes/numeric.py
@@ -125,6 +125,13 @@ class Int64Index(NumericIndex):
 
     _default_dtype = np.int64
 
+    def __contains__(self, key):
+        # This is necessary to make expressions like
+        # `3.0 in Int64Index([1, 2,3])` evaluate to True.
+        return super(Int64Index, self).__contains__(
+            self._maybe_cast_indexer(key)
+        )
+
     @property
     def inferred_type(self):
         return 'integer'

--- a/pandas/src/algos_common_helper.pxi
+++ b/pandas/src/algos_common_helper.pxi
@@ -340,13 +340,20 @@ def is_monotonic_float64(ndarray[float64_t] arr, bint timelike):
     Returns
     -------
     is_monotonic_inc, is_monotonic_dec, is_unique
+        Tuple of (bool, bool, bool or None). is_unique is None when the
+        uniqueness of the array was not determined by the monotonicity check.
     """
     cdef:
         Py_ssize_t i, n
         float64_t prev, cur
         bint is_monotonic_inc = 1
         bint is_monotonic_dec = 1
+
+        # We short-circuit the loop once we know for sure that we're
+        # non-monotonic in both directions. In such cases, we don't know if the
+        # input values are unique, so we return is_unique=None.
         bint is_unique = 1
+        bint short_circuited = 0
 
     n = len(arr)
 
@@ -369,6 +376,7 @@ def is_monotonic_float64(ndarray[float64_t] arr, bint timelike):
             if timelike and cur == iNaT:
                 is_monotonic_inc = 0
                 is_monotonic_dec = 0
+                short_circuited = 1
                 break
             if cur < prev:
                 is_monotonic_inc = 0
@@ -380,14 +388,20 @@ def is_monotonic_float64(ndarray[float64_t] arr, bint timelike):
                 # cur or prev is NaN
                 is_monotonic_inc = 0
                 is_monotonic_dec = 0
+                short_circuited = 1
                 break
             if not is_monotonic_inc and not is_monotonic_dec:
                 is_monotonic_inc = 0
                 is_monotonic_dec = 0
+                short_circuited = 1
                 break
             prev = cur
-    return is_monotonic_inc, is_monotonic_dec, \
-           is_unique and (is_monotonic_inc or is_monotonic_dec)
+
+    return (
+        is_monotonic_inc,
+        is_monotonic_dec,
+        is_unique if not short_circuited else None,
+    )
 
 
 @cython.wraparound(False)
@@ -726,13 +740,20 @@ def is_monotonic_float32(ndarray[float32_t] arr, bint timelike):
     Returns
     -------
     is_monotonic_inc, is_monotonic_dec, is_unique
+        Tuple of (bool, bool, bool or None). is_unique is None when the
+        uniqueness of the array was not determined by the monotonicity check.
     """
     cdef:
         Py_ssize_t i, n
         float32_t prev, cur
         bint is_monotonic_inc = 1
         bint is_monotonic_dec = 1
+
+        # We short-circuit the loop once we know for sure that we're
+        # non-monotonic in both directions. In such cases, we don't know if the
+        # input values are unique, so we return is_unique=None.
         bint is_unique = 1
+        bint short_circuited = 0
 
     n = len(arr)
 
@@ -755,6 +776,7 @@ def is_monotonic_float32(ndarray[float32_t] arr, bint timelike):
             if timelike and cur == iNaT:
                 is_monotonic_inc = 0
                 is_monotonic_dec = 0
+                short_circuited = 1
                 break
             if cur < prev:
                 is_monotonic_inc = 0
@@ -766,14 +788,20 @@ def is_monotonic_float32(ndarray[float32_t] arr, bint timelike):
                 # cur or prev is NaN
                 is_monotonic_inc = 0
                 is_monotonic_dec = 0
+                short_circuited = 1
                 break
             if not is_monotonic_inc and not is_monotonic_dec:
                 is_monotonic_inc = 0
                 is_monotonic_dec = 0
+                short_circuited = 1
                 break
             prev = cur
-    return is_monotonic_inc, is_monotonic_dec, \
-           is_unique and (is_monotonic_inc or is_monotonic_dec)
+
+    return (
+        is_monotonic_inc,
+        is_monotonic_dec,
+        is_unique if not short_circuited else None,
+    )
 
 
 @cython.wraparound(False)
@@ -1112,13 +1140,20 @@ def is_monotonic_object(ndarray[object] arr, bint timelike):
     Returns
     -------
     is_monotonic_inc, is_monotonic_dec, is_unique
+        Tuple of (bool, bool, bool or None). is_unique is None when the
+        uniqueness of the array was not determined by the monotonicity check.
     """
     cdef:
         Py_ssize_t i, n
         object prev, cur
         bint is_monotonic_inc = 1
         bint is_monotonic_dec = 1
+
+        # We short-circuit the loop once we know for sure that we're
+        # non-monotonic in both directions. In such cases, we don't know if the
+        # input values are unique, so we return is_unique=None.
         bint is_unique = 1
+        bint short_circuited = 0
 
     n = len(arr)
 
@@ -1141,6 +1176,7 @@ def is_monotonic_object(ndarray[object] arr, bint timelike):
         if timelike and cur == iNaT:
             is_monotonic_inc = 0
             is_monotonic_dec = 0
+            short_circuited = 1
             break
         if cur < prev:
             is_monotonic_inc = 0
@@ -1152,14 +1188,20 @@ def is_monotonic_object(ndarray[object] arr, bint timelike):
             # cur or prev is NaN
             is_monotonic_inc = 0
             is_monotonic_dec = 0
+            short_circuited = 1
             break
         if not is_monotonic_inc and not is_monotonic_dec:
             is_monotonic_inc = 0
             is_monotonic_dec = 0
+            short_circuited = 1
             break
         prev = cur
-    return is_monotonic_inc, is_monotonic_dec, \
-           is_unique and (is_monotonic_inc or is_monotonic_dec)
+
+    return (
+        is_monotonic_inc,
+        is_monotonic_dec,
+        is_unique if not short_circuited else None,
+    )
 
 
 @cython.wraparound(False)
@@ -1498,13 +1540,20 @@ def is_monotonic_int32(ndarray[int32_t] arr, bint timelike):
     Returns
     -------
     is_monotonic_inc, is_monotonic_dec, is_unique
+        Tuple of (bool, bool, bool or None). is_unique is None when the
+        uniqueness of the array was not determined by the monotonicity check.
     """
     cdef:
         Py_ssize_t i, n
         int32_t prev, cur
         bint is_monotonic_inc = 1
         bint is_monotonic_dec = 1
+
+        # We short-circuit the loop once we know for sure that we're
+        # non-monotonic in both directions. In such cases, we don't know if the
+        # input values are unique, so we return is_unique=None.
         bint is_unique = 1
+        bint short_circuited = 0
 
     n = len(arr)
 
@@ -1527,6 +1576,7 @@ def is_monotonic_int32(ndarray[int32_t] arr, bint timelike):
             if timelike and cur == iNaT:
                 is_monotonic_inc = 0
                 is_monotonic_dec = 0
+                short_circuited = 1
                 break
             if cur < prev:
                 is_monotonic_inc = 0
@@ -1538,14 +1588,20 @@ def is_monotonic_int32(ndarray[int32_t] arr, bint timelike):
                 # cur or prev is NaN
                 is_monotonic_inc = 0
                 is_monotonic_dec = 0
+                short_circuited = 1
                 break
             if not is_monotonic_inc and not is_monotonic_dec:
                 is_monotonic_inc = 0
                 is_monotonic_dec = 0
+                short_circuited = 1
                 break
             prev = cur
-    return is_monotonic_inc, is_monotonic_dec, \
-           is_unique and (is_monotonic_inc or is_monotonic_dec)
+
+    return (
+        is_monotonic_inc,
+        is_monotonic_dec,
+        is_unique if not short_circuited else None,
+    )
 
 
 @cython.wraparound(False)
@@ -1884,13 +1940,20 @@ def is_monotonic_int64(ndarray[int64_t] arr, bint timelike):
     Returns
     -------
     is_monotonic_inc, is_monotonic_dec, is_unique
+        Tuple of (bool, bool, bool or None). is_unique is None when the
+        uniqueness of the array was not determined by the monotonicity check.
     """
     cdef:
         Py_ssize_t i, n
         int64_t prev, cur
         bint is_monotonic_inc = 1
         bint is_monotonic_dec = 1
+
+        # We short-circuit the loop once we know for sure that we're
+        # non-monotonic in both directions. In such cases, we don't know if the
+        # input values are unique, so we return is_unique=None.
         bint is_unique = 1
+        bint short_circuited = 0
 
     n = len(arr)
 
@@ -1913,6 +1976,7 @@ def is_monotonic_int64(ndarray[int64_t] arr, bint timelike):
             if timelike and cur == iNaT:
                 is_monotonic_inc = 0
                 is_monotonic_dec = 0
+                short_circuited = 1
                 break
             if cur < prev:
                 is_monotonic_inc = 0
@@ -1924,14 +1988,20 @@ def is_monotonic_int64(ndarray[int64_t] arr, bint timelike):
                 # cur or prev is NaN
                 is_monotonic_inc = 0
                 is_monotonic_dec = 0
+                short_circuited = 1
                 break
             if not is_monotonic_inc and not is_monotonic_dec:
                 is_monotonic_inc = 0
                 is_monotonic_dec = 0
+                short_circuited = 1
                 break
             prev = cur
-    return is_monotonic_inc, is_monotonic_dec, \
-           is_unique and (is_monotonic_inc or is_monotonic_dec)
+
+    return (
+        is_monotonic_inc,
+        is_monotonic_dec,
+        is_unique if not short_circuited else None,
+    )
 
 
 @cython.wraparound(False)
@@ -2270,13 +2340,20 @@ def is_monotonic_bool(ndarray[uint8_t] arr, bint timelike):
     Returns
     -------
     is_monotonic_inc, is_monotonic_dec, is_unique
+        Tuple of (bool, bool, bool or None). is_unique is None when the
+        uniqueness of the array was not determined by the monotonicity check.
     """
     cdef:
         Py_ssize_t i, n
         uint8_t prev, cur
         bint is_monotonic_inc = 1
         bint is_monotonic_dec = 1
+
+        # We short-circuit the loop once we know for sure that we're
+        # non-monotonic in both directions. In such cases, we don't know if the
+        # input values are unique, so we return is_unique=None.
         bint is_unique = 1
+        bint short_circuited = 0
 
     n = len(arr)
 
@@ -2299,6 +2376,7 @@ def is_monotonic_bool(ndarray[uint8_t] arr, bint timelike):
             if timelike and cur == iNaT:
                 is_monotonic_inc = 0
                 is_monotonic_dec = 0
+                short_circuited = 1
                 break
             if cur < prev:
                 is_monotonic_inc = 0
@@ -2310,14 +2388,20 @@ def is_monotonic_bool(ndarray[uint8_t] arr, bint timelike):
                 # cur or prev is NaN
                 is_monotonic_inc = 0
                 is_monotonic_dec = 0
+                short_circuited = 1
                 break
             if not is_monotonic_inc and not is_monotonic_dec:
                 is_monotonic_inc = 0
                 is_monotonic_dec = 0
+                short_circuited = 1
                 break
             prev = cur
-    return is_monotonic_inc, is_monotonic_dec, \
-           is_unique and (is_monotonic_inc or is_monotonic_dec)
+
+    return (
+        is_monotonic_inc,
+        is_monotonic_dec,
+        is_unique if not short_circuited else None,
+    )
 
 
 @cython.wraparound(False)

--- a/pandas/src/algos_common_helper.pxi.in
+++ b/pandas/src/algos_common_helper.pxi.in
@@ -362,13 +362,20 @@ def is_monotonic_{{name}}(ndarray[{{c_type}}] arr, bint timelike):
     Returns
     -------
     is_monotonic_inc, is_monotonic_dec, is_unique
+        Tuple of (bool, bool, bool or None). is_unique is None when the
+        uniqueness of the array was not determined by the monotonicity check.
     """
     cdef:
         Py_ssize_t i, n
         {{c_type}} prev, cur
         bint is_monotonic_inc = 1
         bint is_monotonic_dec = 1
+
+        # We short-circuit the loop once we know for sure that we're
+        # non-monotonic in both directions. In such cases, we don't know if the
+        # input values are unique, so we return is_unique=None.
         bint is_unique = 1
+        bint short_circuited = 0
 
     n = len(arr)
 
@@ -391,6 +398,7 @@ def is_monotonic_{{name}}(ndarray[{{c_type}}] arr, bint timelike):
     {{tab}}    if timelike and cur == iNaT:
     {{tab}}        is_monotonic_inc = 0
     {{tab}}        is_monotonic_dec = 0
+    {{tab}}        short_circuited = 1
     {{tab}}        break
     {{tab}}    if cur < prev:
     {{tab}}        is_monotonic_inc = 0
@@ -402,14 +410,20 @@ def is_monotonic_{{name}}(ndarray[{{c_type}}] arr, bint timelike):
     {{tab}}        # cur or prev is NaN
     {{tab}}        is_monotonic_inc = 0
     {{tab}}        is_monotonic_dec = 0
+    {{tab}}        short_circuited = 1
     {{tab}}        break
     {{tab}}    if not is_monotonic_inc and not is_monotonic_dec:
     {{tab}}        is_monotonic_inc = 0
     {{tab}}        is_monotonic_dec = 0
+    {{tab}}        short_circuited = 1
     {{tab}}        break
     {{tab}}    prev = cur
-    return is_monotonic_inc, is_monotonic_dec, \
-           is_unique and (is_monotonic_inc or is_monotonic_dec)
+
+    return (
+        is_monotonic_inc,
+        is_monotonic_dec,
+        is_unique if not short_circuited else None,
+    )
 
 
 @cython.wraparound(False)


### PR DESCRIPTION
Initial work toward #14273.  This makes `__contains__` behave uniformly across all index types by making it simply defer to `get_loc` (we can and probably should go back and put in a fast path for the case that a hash table has already been populated).  Assuming this general path seems reasonable, the next step would be to update `get_indexer` to do binary-search-based lookups on large indices.

A few high-level design questions:
- I haven't benchmarked yet to see how big the difference is, but theoretically these changes are trading slower lookups for a smaller memory footprint.  Depending on users' usage patterns and resource constraints, the tradeoffs made here may or may not be an improvement for them.  I added an `avoid_hashtable` keyword to IndexEngine to make it easier to test the new behavior interactively without having to work with giant indices.  Do we want to support a user-configurable toggle like this for cases where people know that they really do or don't want a hash table?  If so, where would they pass that option?  Alternatively, should _SIZE_CUTOFF be configurable, perhaps via `pandas.set_option`?
- One odd behavior I ran into while working on this is that `Int64Index.__contains__` silently truncates floats to integers before doing lookups, while `Int64Index.get_loc` does not.  On this branch, that behavior is only preserved for integral-valued floats (the behavior of coercing integral floats to ints was explicitly tested).  This also happens for `DatetimeIndex`.  Is there any concern about "breaking" the behavior of `Int64Index.__contains__` for non-integral floats?

<details>

```
In [11]: pd.__version__
Out[11]: u'0.19.0'

In [12]: i
Out[12]: Int64Index([1, 2, 3, 5], dtype='int64')

In [13]: 1.5 in i
Out[13]: True

In [14]: i.get_loc(1.5)
---------------------------------------------------------------------------
KeyError                                  Traceback (most recent call last)
<ipython-input-14-c37f93fbd72a> in <module>()
----> 1 i.get_loc(1.5)

/home/ssanderson/.virtualenvs/pandas-19/local/lib/python2.7/site-packages/pandas/indexes/base.pyc in get_loc(self, key, method, tolerance)
   2104                 return self._engine.get_loc(key)
   2105             except KeyError:
-> 2106                 return self._engine.get_loc(self._maybe_cast_indexer(key))
   2107
   2108         indexer = self.get_indexer([key], method=method, tolerance=tolerance)

pandas/index.pyx in pandas.index.IndexEngine.get_loc (pandas/index.c:4160)()

pandas/index.pyx in pandas.index.IndexEngine.get_loc (pandas/index.c:3983)()

pandas/index.pyx in pandas.index.Int64Engine._check_type (pandas/index.c:7773)()

KeyError: 1.5
```

</details>
- [ ] closes #14273
- [ ] tests added / passed
- [ ] passes `git diff upstream/master | flake8 --diff`
- [ ] whatsnew entry
