### PR TITLE
ENH: support kind and na_position kwargs in Series.sort_index

### DIFF
--- a/doc/source/whatsnew/v0.19.1.txt
+++ b/doc/source/whatsnew/v0.19.1.txt
@@ -30,10 +30,10 @@ Performance Improvements
 
 Bug Fixes
 ~~~~~~~~~
-
-
-
 - Bug in ``Series.sort_index`` where parameters ``kind`` and ``na_position`` did not exist (:issue:`13589`, :issue:`14444`)
+
+
+
 
 - Bug in localizing an ambiguous timezone when a boolean is passed (:issue:`14402`)
 

--- a/doc/source/whatsnew/v0.19.1.txt
+++ b/doc/source/whatsnew/v0.19.1.txt
@@ -30,7 +30,6 @@ Performance Improvements
 
 Bug Fixes
 ~~~~~~~~~
-- Bug in ``Series.sort_index`` where parameters ``kind`` and ``na_position`` did not exist (:issue:`13589`, :issue:`14444`)
 
 
 

--- a/doc/source/whatsnew/v0.19.1.txt
+++ b/doc/source/whatsnew/v0.19.1.txt
@@ -33,6 +33,7 @@ Bug Fixes
 
 
 
+- Bug in ``Series.sort_index`` where parameters ``kind`` and ``na_position`` did not exist (:issue:`13589`, :issue:`14444`)
 
 - Bug in localizing an ambiguous timezone when a boolean is passed (:issue:`14402`)
 

--- a/doc/source/whatsnew/v0.20.0.txt
+++ b/doc/source/whatsnew/v0.20.0.txt
@@ -29,6 +29,7 @@ New features
 
 Other enhancements
 ^^^^^^^^^^^^^^^^^^
+- ``Series.sort_index`` accepts parameters ``kind`` and ``na_position`` (:issue:`13589`, :issue:`14444`)
 
 
 

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -2029,7 +2029,8 @@ class NDFrame(PandasObject):
              DataFrames, this option is only applied when sorting on a single
              column or label.
         na_position : {'first', 'last'}, default 'last'
-             `first` puts NaNs at the beginning, `last` puts NaNs at the end
+             `first` puts NaNs at the beginning, `last` puts NaNs at the end.
+             Not implemented for MultiIndex.
         sort_remaining : bool, default True
             if true and sorting by level and index is multilevel, sort by other
             levels too (in order) after sorting by specified level

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -1782,7 +1782,8 @@ class Series(base.IndexOpsMixin, strings.StringAccessorMixin,
                                                  sort_remaining=sort_remaining)
         elif isinstance(index, MultiIndex):
             from pandas.core.groupby import _lexsort_indexer
-            indexer = _lexsort_indexer(index.labels, orders=ascending)
+            indexer = _lexsort_indexer(index.labels, orders=ascending,
+                                       na_position=na_position)
 
         else:
             from pandas.core.groupby import _nargsort

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -1773,7 +1773,7 @@ class Series(base.IndexOpsMixin, strings.StringAccessorMixin,
 
     @Appender(generic._shared_docs['sort_index'] % _shared_doc_kwargs)
     def sort_index(self, axis=0, level=None, ascending=True, inplace=False,
-                   sort_remaining=True):
+                   kind='quicksort', na_position='last', sort_remaining=True):
 
         axis = self._get_axis_number(axis)
         index = self.index
@@ -1786,8 +1786,11 @@ class Series(base.IndexOpsMixin, strings.StringAccessorMixin,
             indexer = _ensure_platform_int(indexer)
             new_index = index.take(indexer)
         else:
-            new_index, indexer = index.sort_values(return_indexer=True,
-                                                   ascending=ascending)
+            from pandas.core.groupby import _nargsort
+
+            indexer = _nargsort(index, kind=kind, ascending=ascending,
+                                na_position=na_position)
+            new_index = index.take(indexer)
 
         new_values = self._values.take(indexer)
         result = self._constructor(new_values, index=new_index)

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -1783,14 +1783,14 @@ class Series(base.IndexOpsMixin, strings.StringAccessorMixin,
         elif isinstance(index, MultiIndex):
             from pandas.core.groupby import _lexsort_indexer
             indexer = _lexsort_indexer(index.labels, orders=ascending)
-            indexer = _ensure_platform_int(indexer)
-            new_index = index.take(indexer)
+
         else:
             from pandas.core.groupby import _nargsort
-
             indexer = _nargsort(index, kind=kind, ascending=ascending,
                                 na_position=na_position)
-            new_index = index.take(indexer)
+
+        indexer = _ensure_platform_int(indexer)
+        new_index = index.take(indexer)
 
         new_values = self._values.take(indexer)
         result = self._constructor(new_values, index=new_index)

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -1782,9 +1782,7 @@ class Series(base.IndexOpsMixin, strings.StringAccessorMixin,
                                                  sort_remaining=sort_remaining)
         elif isinstance(index, MultiIndex):
             from pandas.core.groupby import _lexsort_indexer
-            indexer = _lexsort_indexer(index.labels, orders=ascending,
-                                       na_position=na_position)
-
+            indexer = _lexsort_indexer(index.labels, orders=ascending)
         else:
             from pandas.core.groupby import _nargsort
             indexer = _nargsort(index, kind=kind, ascending=ascending,

--- a/pandas/tests/series/test_sorting.py
+++ b/pandas/tests/series/test_sorting.py
@@ -144,3 +144,28 @@ class TestSeriesSorting(TestData, tm.TestCase):
         # rows share same level='A': sort has no effect without remaining lvls
         res = s.sort_index(level='A', sort_remaining=False)
         assert_series_equal(s, res)
+
+    def test_sort_index_kind(self):
+        # GH #14444 & #13589:  Add support for sort algo choosing
+        series = Series(index=[3, 2, 1, 4, 3])
+        expected_series = Series(index=[1, 2, 3, 3, 4])
+
+        index_sorted_series = series.sort_index(kind='mergesort')
+        assert_series_equal(expected_series, index_sorted_series)
+
+        index_sorted_series = series.sort_index(kind='quicksort')
+        assert_series_equal(expected_series, index_sorted_series)
+
+        index_sorted_series = series.sort_index(kind='heapsort')
+        assert_series_equal(expected_series, index_sorted_series)
+
+    def test_sort_index_na_position(self):
+        series = Series(index=[3, 2, 1, 4, 3, np.nan])
+
+        expected_series_first = Series(index=[np.nan, 1, 2, 3, 3, 4])
+        index_sorted_series = series.sort_index(na_position='first')
+        assert_series_equal(expected_series_first, index_sorted_series)
+
+        expected_series_last = Series(index=[1, 2, 3, 3, 4, np.nan])
+        index_sorted_series = series.sort_index(na_position='last')
+        assert_series_equal(expected_series_last, index_sorted_series)


### PR DESCRIPTION
closes #13589
closes #13729

I'm waiting on adding the whatsnew entry.  I'm not sure if this is a BUG (the [documentation](http://pandas.pydata.org/pandas-docs/stable/generated/pandas.Series.sort_index.html) says these parameters exist) or an ENH (we're adding support for these parameters).  It depends on how you look at it!
