### PR TITLE
ERR: Fix GH13139: better error message on invalid pd.eval and df.query input

### DIFF
--- a/doc/source/whatsnew/v0.19.1.txt
+++ b/doc/source/whatsnew/v0.19.1.txt
@@ -57,4 +57,4 @@ Bug Fixes
 
 - Bug in ``pd.pivot_table`` may raise ``TypeError`` or ``ValueError`` when ``index`` or ``columns``
   is not scalar and ``values`` is not specified (:issue:`14380`)
-- pd.eval('') and df.query('') now show better error message and raise ``ValueError`` (:issue: `13139`)
+- corrrecly raise ``ValueError`` on empty input to pd.eval() and df.query() (:issue: `13139`)

--- a/doc/source/whatsnew/v0.19.1.txt
+++ b/doc/source/whatsnew/v0.19.1.txt
@@ -57,3 +57,4 @@ Bug Fixes
 
 - Bug in ``pd.pivot_table`` may raise ``TypeError`` or ``ValueError`` when ``index`` or ``columns``
   is not scalar and ``values`` is not specified (:issue:`14380`)
+- pd.eval('') and df.query('') now show better error message and raise ``ValueError`` (:issue: `13139`)

--- a/pandas/computation/eval.py
+++ b/pandas/computation/eval.py
@@ -233,6 +233,7 @@ def eval(expr, parser='pandas', engine=None, truediv=True,
     """
     first_expr = True
     if isinstance(expr, string_types):
+        _check_expression(expr)
         exprs = [e for e in expr.splitlines() if e != '']
     else:
         exprs = [expr]

--- a/pandas/computation/tests/test_eval.py
+++ b/pandas/computation/tests/test_eval.py
@@ -1891,6 +1891,17 @@ def test_bad_resolver_raises():
         yield check_bad_resolver_raises, engine, parser
 
 
+def check_empty_string_raises(engine, parser):
+    tm.skip_if_no_ne(engine)
+    with tm.assertRaisesRegexp(ValueError, 'expr cannot be an empty string'):
+        pd.eval('', engine=engine, parser=parser)
+
+
+def test_empty_string_raises():
+    for engine, parser in ENGINES_PARSERS:
+        yield check_empty_string_raises, engine, parser
+
+
 def check_more_than_one_expression_raises(engine, parser):
     tm.skip_if_no_ne(engine)
     with tm.assertRaisesRegexp(SyntaxError,

--- a/pandas/computation/tests/test_eval.py
+++ b/pandas/computation/tests/test_eval.py
@@ -1892,6 +1892,7 @@ def test_bad_resolver_raises():
 
 
 def check_empty_string_raises(engine, parser):
+    # GH 13139
     tm.skip_if_no_ne(engine)
     with tm.assertRaisesRegexp(ValueError, 'expr cannot be an empty string'):
         pd.eval('', engine=engine, parser=parser)

--- a/pandas/tests/frame/test_query_eval.py
+++ b/pandas/tests/frame/test_query_eval.py
@@ -147,6 +147,14 @@ class TestDataFrameEval(tm.TestCase, TestData):
         with tm.assertRaisesRegexp(ValueError, msg):
             df.query(111)
 
+    def test_query_empty_string(self):
+        # GH 13139
+        df = pd.DataFrame({'A': [1, 2, 3]})
+
+        msg = "expr cannot be an empty string"
+        with tm.assertRaisesRegexp(ValueError, msg):
+            df.query('')
+
     def test_eval_resolvers_as_list(self):
         # GH 14095
         df = DataFrame(randn(10, 2), columns=list('ab'))


### PR DESCRIPTION
- [x] closes #13139 
- [x] tests added / passed
- [x] passes `git diff upstream/master | flake8 --diff`
- [x] whatsnew entry

Added test case to check for invalid input(empy string) on pd.eval('') and df.query('').
Used existing helper function(_check_expression) 
