### PR TITLE
PERF: performance regression in Series.asof

### DIFF
--- a/doc/source/whatsnew/v0.19.1.txt
+++ b/doc/source/whatsnew/v0.19.1.txt
@@ -21,8 +21,9 @@ Performance Improvements
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
 - Fixed performance regression in factorization of ``Period`` data (:issue:`14338`)
-- Improved Performance in ``.to_json()`` when ``lines=True`` (:issue:`14408`)
-
+- Improved performance in ``.to_json()`` when ``lines=True`` (:issue:`14408`)
+- Improved performance in ``Series.asof(where)`` when ``where`` is a scalar (:issue:`14461)
+- Improved performance in ``DataFrame.asof(where)`` when ``where`` is a scalar (:issue:`14461)
 
 
 


### PR DESCRIPTION
Fix performance regression in Series.asof by avoiding pre-computing nulls and returning value by indexing the underlying ndarray.
- [x] closes #14461 
- [x] add asv benchmark
