### PR TITLE
BUG: don't allow users to move from an interned string

### DIFF
--- a/pandas/util/move.c
+++ b/pandas/util/move.c
@@ -7,6 +7,9 @@
 #define PyString_CheckExact PyBytes_CheckExact
 #define PyString_AS_STRING PyBytes_AS_STRING
 #define PyString_GET_SIZE PyBytes_GET_SIZE
+
+/* in python 3, we cannot intern bytes objects so this is always false */
+#define PyString_CHECK_INTERNED(cs) 0
 #endif  /* !COMPILING_IN_PY2 */
 
 #ifndef Py_TPFLAGS_HAVE_GETCHARBUFFER
@@ -113,8 +116,9 @@ stolenbuf_new(PyObject *self, PyObject *args, PyObject *kwargs)
         return NULL;
     }
 
-    if (Py_REFCNT(bytes_rvalue) != 1) {
-        /* there is a reference other than the caller's stack */
+    if (Py_REFCNT(bytes_rvalue) != 1 || PyString_CHECK_INTERNED(bytes_rvalue)) {
+        /* there is a reference other than the caller's stack or the string is
+           interned */
         PyErr_SetObject(badmove, bytes_rvalue);
         return NULL;
     }


### PR DESCRIPTION
- [ ] closes #xxxx
- [x] tests added / passed
- [x] passes `git diff upstream/master | flake8 --diff`
- [ ] whatsnew entry

I was thinking about code paths that give away borrowed references to strings and realized that interned strings can be accessed even when their refcount is 1. This is because the intern table holds a "weak ref" to the string. This allows the string to be garbage collected normally; however, if a user creates an interned string with exactly one reference and feeds it to move, you could later get a second reference to the **same** string object by calling intern with a copy of the old string. The data backing the old string may have been mutated so you will get very strange results. I am almost certain that no on has run into this since `move_into_mutable_buffer` was added but it doesn't hurt to add this quick check to prevent broken usage like this in the future.

This only affects python 2 because bytes objects cannot be interned in python 3.
