### PR TITLE
Use old Cython build_ext until includes are fixed.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -85,7 +85,7 @@ from distutils.command.build_ext import build_ext as _build_ext
 try:
     if not _CYTHON_INSTALLED:
         raise ImportError('No supported version of Cython installed.')
-    from Cython.Distutils import build_ext as _build_ext
+    from Cython.Distutils.old_build_ext import old_build_ext as _build_ext
     cython = True
 except ImportError:
     cython = False

--- a/setup.py
+++ b/setup.py
@@ -85,7 +85,11 @@ from distutils.command.build_ext import build_ext as _build_ext
 try:
     if not _CYTHON_INSTALLED:
         raise ImportError('No supported version of Cython installed.')
-    from Cython.Distutils.old_build_ext import old_build_ext as _build_ext
+    try:
+        from Cython.Distutils.old_build_ext import old_build_ext as _build_ext
+    except ImportError:
+        # Pre 0.25
+        from Cython.Distutils import build_ext as _build_ext
     cython = True
 except ImportError:
     cython = False


### PR DESCRIPTION
This change in Cython 0.25

The distutils extension Cython.Distutils.build_ext has now been updated to use cythonize which properly handles dependencies. The old extension can still be found in Cython.Distutils.old_build_ext and is now deprecated.

seems to have broken the include of auto-generated algos_common_helper.pxi. As a temporary workaround, the old build_ext can be used.
