### PR TITLE
MAINT: Expand lint for *.py

### DIFF
--- a/ci/lint.sh
+++ b/ci/lint.sh
@@ -7,16 +7,10 @@ source activate pandas
 RET=0
 
 if [ "$LINT" ]; then
-    echo "Linting"
-    for path in 'api' 'core' 'indexes' 'types' 'formats' 'io' 'stats' 'compat' 'sparse' 'tools' 'tseries' 'tests' 'computation' 'util'
-    do
-        echo "linting -> pandas/$path"
-        flake8 pandas/$path --filename '*.py'
-        if [ $? -ne "0" ]; then
-            RET=1
-        fi
-
-    done
+    # pandas/rpy is deprecated and will be removed.
+    # pandas/src is C code, so no need to search there.
+    echo "Linting  *.py"
+    flake8 pandas --filename '*.py' --exclude pandas/rpy,pandas/src
     echo "Linting *.py DONE"
 
     echo "Linting *.pyx"

--- a/pandas/core/groupby.py
+++ b/pandas/core/groupby.py
@@ -6,7 +6,7 @@ import collections
 import warnings
 import copy
 
-from pandas.compat import(
+from pandas.compat import (
     zip, range, long, lzip,
     callable, map
 )

--- a/pandas/core/internals.py
+++ b/pandas/core/internals.py
@@ -1147,8 +1147,9 @@ class Block(PandasObject):
         def handle_error():
 
             if raise_on_error:
+                # The 'detail' variable is defined in outer scope.
                 raise TypeError('Could not operate %s with block values %s' %
-                                (repr(other), str(detail)))
+                                (repr(other), str(detail)))  # noqa
             else:
                 # return the values
                 result = np.empty(values.shape, dtype='O')

--- a/pandas/io/parsers.py
+++ b/pandas/io/parsers.py
@@ -2194,16 +2194,16 @@ class PythonParser(ParserBase):
         usecols_key is used if there are string usecols.
         """
         if self.usecols is not None:
-            if any([isinstance(u, string_types) for u in self.usecols]):
+            if any([isinstance(col, string_types) for col in self.usecols]):
                 if len(columns) > 1:
                     raise ValueError("If using multiple headers, usecols must "
                                      "be integers.")
                 col_indices = []
-                for u in self.usecols:
-                    if isinstance(u, string_types):
-                        col_indices.append(usecols_key.index(u))
+                for col in self.usecols:
+                    if isinstance(col, string_types):
+                        col_indices.append(usecols_key.index(col))
                     else:
-                        col_indices.append(u)
+                        col_indices.append(col)
             else:
                 col_indices = self.usecols
 

--- a/pandas/io/tests/parser/common.py
+++ b/pandas/io/tests/parser/common.py
@@ -17,8 +17,8 @@ import pandas as pd
 import pandas.util.testing as tm
 from pandas import DataFrame, Series, Index, MultiIndex
 from pandas import compat
-from pandas.compat import(StringIO, BytesIO, PY3,
-                          range, lrange, u)
+from pandas.compat import (StringIO, BytesIO, PY3,
+                           range, lrange, u)
 from pandas.io.common import DtypeWarning, EmptyDataError, URLError
 from pandas.io.parsers import TextFileReader, TextParser
 

--- a/pandas/msgpack/__init__.py
+++ b/pandas/msgpack/__init__.py
@@ -1,10 +1,9 @@
 # coding: utf-8
-# flake8: noqa
-
-from pandas.msgpack._version import version
-from pandas.msgpack.exceptions import *
 
 from collections import namedtuple
+
+from pandas.msgpack.exceptions import *  # noqa
+from pandas.msgpack._version import version  # noqa
 
 
 class ExtType(namedtuple('ExtType', 'code data')):
@@ -18,11 +17,10 @@ class ExtType(namedtuple('ExtType', 'code data')):
             raise ValueError("code must be 0~127")
         return super(ExtType, cls).__new__(cls, code, data)
 
+import os  # noqa
 
-import os
-from pandas.msgpack._packer import Packer
-from pandas.msgpack._unpacker import unpack, unpackb, Unpacker
-
+from pandas.msgpack._packer import Packer  # noqa
+from pandas.msgpack._unpacker import unpack, unpackb, Unpacker  # noqa
 
 
 def pack(o, stream, **kwargs):

--- a/pandas/tests/indexes/test_base.py
+++ b/pandas/tests/indexes/test_base.py
@@ -1576,11 +1576,10 @@ class TestIndex(Base, tm.TestCase):
         # py3/py2 repr can differ because of "u" prefix
         # which also affects to displayed element size
 
-        # suppress flake8 warnings
         if PY3:
             coerce = lambda x: x
         else:
-            coerce = unicode
+            coerce = unicode  # noqa
 
         # short
         idx = pd.Index(['a', 'bb', 'ccc'])

--- a/pandas/util/testing.py
+++ b/pandas/util/testing.py
@@ -35,7 +35,7 @@ from pandas.formats.printing import pprint_thing
 from pandas.core.algorithms import take_1d
 
 import pandas.compat as compat
-from pandas.compat import(
+from pandas.compat import (
     filter, map, zip, range, unichr, lrange, lmap, lzip, u, callable, Counter,
     raise_with_traceback, httplib, is_platform_windows, is_platform_32bit,
     PY3


### PR DESCRIPTION
Expand lint to include all Python files, excluding the directories `pandas/rpy` (deprecated and soon to be removed) and `pandas/src` (C code).
