### PR TITLE
BUG/ERR: raise correct error when sql driver is not installed

### DIFF
--- a/pandas/io/sql.py
+++ b/pandas/io/sql.py
@@ -507,10 +507,11 @@ def _engine_builder(con):
     if isinstance(con, string_types):
         try:
             import sqlalchemy
-            con = sqlalchemy.create_engine(con)
-            return con
         except ImportError:
             _SQLALCHEMY_INSTALLED = False
+        else:
+            con = sqlalchemy.create_engine(con)
+            return con
 
     return con
 

--- a/pandas/io/tests/test_sql.py
+++ b/pandas/io/tests/test_sql.py
@@ -944,7 +944,7 @@ class TestSQLApi(SQLAlchemyMixIn, _TestSQLApi):
         self.assertTrue(isinstance(
             table.table.c['time'].type, sqltypes.DateTime))
 
-    def test_to_sql_read_sql_with_database_uri(self):
+    def test_database_uri_string(self):
 
         # Test read_sql and .to_sql method with a database URI (GH10654)
         test_frame1 = self.test_frame1
@@ -962,6 +962,12 @@ class TestSQLApi(SQLAlchemyMixIn, _TestSQLApi):
         tm.assert_frame_equal(test_frame1, test_frame2)
         tm.assert_frame_equal(test_frame1, test_frame3)
         tm.assert_frame_equal(test_frame1, test_frame4)
+
+        # using driver that will not be installed on Travis to trigger error
+        # in sqlalchemy.create_engine -> test passing of this error to user
+        db_uri = "postgresql+pg8000://user:pass@host/dbname"
+        with tm.assertRaisesRegexp(ImportError, "pg8000"):
+            sql.read_sql("select * from table", db_uri)
 
     def _make_iris_table_metadata(self):
         sa = sqlalchemy


### PR DESCRIPTION
Closes #14513

When the driver was not installed, but sqlalchemy itself was, when passing a URI string, you got an error indicating that SQLAlchemy was not installed, instead of the driver not being installed. This was because the import error for the driver was captured as import error for sqlalchemy.
