### PR TITLE
BUG: Index.insert may not coerced to correct dtype

### DIFF
--- a/doc/source/whatsnew/v0.19.2.txt
+++ b/doc/source/whatsnew/v0.19.2.txt
@@ -52,6 +52,8 @@ Bug Fixes
 
 
 
+- Bug in ``Index.insert`` may have incorrect ``dtype`` or raises ``TypeError`` (:issue:`14535`)
+
 
 
 

--- a/pandas/indexes/base.py
+++ b/pandas/indexes/base.py
@@ -33,7 +33,8 @@ from pandas.types.common import (_ensure_int64,
                                  needs_i8_conversion,
                                  is_iterator, is_list_like,
                                  is_scalar)
-from pandas.types.cast import _coerce_indexer_dtype
+from pandas.types.cast import (_coerce_indexer_dtype, _find_common_type,
+                               _infer_dtype_from_scalar)
 from pandas.core.common import (is_bool_indexer,
                                 _values_from_object,
                                 _asarray_tuplesafe)
@@ -618,16 +619,6 @@ class Index(IndexOpsMixin, StringAccessorMixin, PandasObject):
         if isinstance(result, Index):
             result._id = self._id
         return result
-
-    def _coerce_scalar_to_index(self, item):
-        """
-        we need to coerce a scalar to a compat for our index type
-
-        Parameters
-        ----------
-        item : scalar item to coerce
-        """
-        return Index([item], dtype=self.dtype, **self._get_attributes_dict())
 
     _index_shared_docs['copy'] = """
         Make a copy of this object.  Name and dtype sets those attributes on
@@ -3234,10 +3225,56 @@ class Index(IndexOpsMixin, StringAccessorMixin, PandasObject):
         -------
         new_index : Index
         """
-        _self = np.asarray(self)
-        item = self._coerce_scalar_to_index(item)._values
-        idx = np.concatenate((_self[:loc], item, _self[loc:]))
-        return self._shallow_copy_with_infer(idx)
+
+        if not is_integer(loc):
+            msg = 'loc must be int, {0} given'
+            raise ValueError(msg.format(type(loc).__name__))
+
+        if isnull(item) and self._can_hold_na:
+            # if myself can hold NaN, regard NaN as the same type
+            # as myself (for NaT handling)
+            dtype = self.dtype
+            val = self._na_value
+        else:
+            dtype, val = _infer_dtype_from_scalar(item, pandas_dtype=True)
+            if is_bool_dtype(dtype):
+                # index can't store bool
+                dtype = np.object_
+
+        if is_dtype_equal(self.dtype, dtype):
+            return self._insert_same_dtype(loc, val)
+        else:
+            # When index is object dtype and its length is 0, use dtype
+            # as it is. Otherwise, find common dtype
+            if not (is_object_dtype(self) and len(self) == 0):
+                dtype = _find_common_type([self.dtype, dtype])
+
+            self = self.astype(dtype)
+            # we cannnot use np.insert to handle tuple as it is
+            # idx = np.insert(self._values, loc, item)
+            idx = np.concatenate([self._values[:loc],
+                                 Index([item], dtype=dtype)._values,
+                                 self._values[loc:]])
+            return self._shallow_copy_with_infer(idx, dtype=dtype)
+
+    def _insert_same_dtype(self, loc, item):
+        """
+        Make new Index which has the same dtype as the original
+        inserting new item at location.
+
+        Parameters
+        ----------
+        loc : int
+        item : object
+            item's internal representation which can be directly
+            inserted to myself
+
+        """
+
+        idx = np.concatenate([self._values[:loc],
+                             Index([item])._values,
+                             self._values[loc:]])
+        return self._shallow_copy(idx)
 
     def drop(self, labels, errors='raise'):
         """

--- a/pandas/indexes/multi.py
+++ b/pandas/indexes/multi.py
@@ -2219,6 +2219,7 @@ class MultiIndex(Index):
         -------
         new_index : Index
         """
+
         # Pad the key with empty strings if lower levels of the key
         # aren't specified:
         if not isinstance(item, tuple):

--- a/pandas/tests/indexes/test_base.py
+++ b/pandas/tests/indexes/test_base.py
@@ -434,6 +434,31 @@ class TestIndex(Base, tm.TestCase):
         null_index = Index([])
         self.assert_index_equal(Index(['a']), null_index.insert(0, 'a'))
 
+    def test_insert_empty(self):
+        # empty object index must coerce to value's dtype
+        idx = pd.Index([], dtype=object, name='x')
+
+        tm.assert_index_equal(idx.insert(0, 1), Index([1], name='x'))
+        tm.assert_index_equal(idx.insert(0, 'a'), Index(['a'], name='x'))
+
+        tm.assert_index_equal(idx.insert(0, pd.Timestamp('2011-01-01')),
+                              pd.DatetimeIndex(['2011-01-01'], name='x'))
+
+        # keep dtype if possible
+        for klass in [pd.DatetimeIndex, pd.TimedeltaIndex]:
+            idx = klass([], name='x')
+            tm.assert_index_equal(idx.insert(0, pd.NaT),
+                                  klass([pd.NaT], name='x'))
+
+        # tuple must be inserted as it is to handle MI
+        res = idx.insert(0, ('a', 'b'))
+        exp = Index(np.array([('a', 'b')], dtype=object), name='x')
+        tm.assert_index_equal(res, exp)
+
+        res = res.insert(1, ('c', 'd'))
+        exp = Index(np.array([('a', 'b'), ('c', 'd')], dtype=object), name='x')
+        tm.assert_index_equal(res, exp)
+
     def test_delete(self):
         idx = Index(['a', 'b', 'c', 'd'], name='idx')
 

--- a/pandas/tseries/base.py
+++ b/pandas/tseries/base.py
@@ -777,6 +777,27 @@ class DatetimeIndexOpsMixin(object):
         return self._shallow_copy(self.asi8.repeat(repeats),
                                   freq=freq)
 
+    def _insert_same_dtype(self, loc, item):
+
+        freq = None
+        if isinstance(self, ABCPeriodIndex):
+            freq = self.freq
+        else:
+            # check whether freq can be preserved
+            if self.size and self.freq is not None:
+                if ((loc == 0 or loc == -len(self)) and
+                        (self[0] - self.freq).value == item):
+                    freq = self.freq
+                elif ((loc == len(self)) and
+                      (self[-1] + self.freq).value == item):
+                    freq = self.freq
+
+        if isnull(item):
+            item = tslib.iNaT
+
+        new_dates = np.insert(self.asi8, loc, item)
+        return self._shallow_copy(new_dates, freq=freq)
+
     def where(self, cond, other=None):
         """
         .. versionadded:: 0.19.0

--- a/pandas/tseries/index.py
+++ b/pandas/tseries/index.py
@@ -1660,53 +1660,6 @@ class DatetimeIndex(DatelikeOps, TimelikeOps, DatetimeIndexOpsMixin,
     def _resolution(self):
         return period.resolution(self.asi8, self.tz)
 
-    def insert(self, loc, item):
-        """
-        Make new Index inserting new item at location
-
-        Parameters
-        ----------
-        loc : int
-        item : object
-            if not either a Python datetime or a numpy integer-like, returned
-            Index dtype will be object rather than datetime.
-
-        Returns
-        -------
-        new_index : Index
-        """
-
-        freq = None
-
-        if isinstance(item, (datetime, np.datetime64)):
-            self._assert_can_do_op(item)
-            if not self._has_same_tz(item):
-                raise ValueError(
-                    'Passed item and index have different timezone')
-            # check freq can be preserved on edge cases
-            if self.size and self.freq is not None:
-                if ((loc == 0 or loc == -len(self)) and
-                        item + self.freq == self[0]):
-                    freq = self.freq
-                elif (loc == len(self)) and item - self.freq == self[-1]:
-                    freq = self.freq
-            item = _to_m8(item, tz=self.tz)
-        try:
-            new_dates = np.concatenate((self[:loc].asi8, [item.view(np.int64)],
-                                        self[loc:].asi8))
-            if self.tz is not None:
-                new_dates = tslib.tz_convert(new_dates, 'UTC', self.tz)
-            return DatetimeIndex(new_dates, name=self.name, freq=freq,
-                                 tz=self.tz)
-
-        except (AttributeError, TypeError):
-
-            # fall back to object index
-            if isinstance(item, compat.string_types):
-                return self.asobject.insert(loc, item)
-            raise TypeError(
-                "cannot insert DatetimeIndex with incompatible label")
-
     def delete(self, loc):
         """
         Make a new DatetimeIndex with passed location(s) deleted.

--- a/pandas/tseries/tdi.py
+++ b/pandas/tseries/tdi.py
@@ -810,54 +810,6 @@ class TimedeltaIndex(DatetimeIndexOpsMixin, TimelikeOps, Int64Index):
     def is_all_dates(self):
         return True
 
-    def insert(self, loc, item):
-        """
-        Make new Index inserting new item at location
-
-        Parameters
-        ----------
-        loc : int
-        item : object
-            if not either a Python datetime or a numpy integer-like, returned
-            Index dtype will be object rather than datetime.
-
-        Returns
-        -------
-        new_index : Index
-        """
-
-        # try to convert if possible
-        if _is_convertible_to_td(item):
-            try:
-                item = Timedelta(item)
-            except:
-                pass
-
-        freq = None
-        if isinstance(item, (Timedelta, tslib.NaTType)):
-
-            # check freq can be preserved on edge cases
-            if self.freq is not None:
-                if ((loc == 0 or loc == -len(self)) and
-                        item + self.freq == self[0]):
-                    freq = self.freq
-                elif (loc == len(self)) and item - self.freq == self[-1]:
-                    freq = self.freq
-            item = _to_m8(item)
-
-        try:
-            new_tds = np.concatenate((self[:loc].asi8, [item.view(np.int64)],
-                                      self[loc:].asi8))
-            return TimedeltaIndex(new_tds, name=self.name, freq=freq)
-
-        except (AttributeError, TypeError):
-
-            # fall back to object index
-            if isinstance(item, compat.string_types):
-                return self.asobject.insert(loc, item)
-            raise TypeError(
-                "cannot insert TimedeltaIndex with incompatible label")
-
     def delete(self, loc):
         """
         Make a new DatetimeIndex with passed location(s) deleted.

--- a/pandas/tseries/tests/test_base.py
+++ b/pandas/tseries/tests/test_base.py
@@ -908,6 +908,44 @@ Freq: D"""
             self.assertFalse(idx.equals(list(idx3)))
             self.assertFalse(idx.equals(pd.Series(idx3)))
 
+    def test_insert(self):
+        # insert tests also locates
+        # - each index classes paired with delete
+        # - indexing/test_coercion.py
+        # this cases are intended for timedelta / period compat
+
+        idx = DatetimeIndex(['2000-01-01', '2000-01-02',
+                             '2000-01-03'], freq='D')
+        res = idx.insert(0, pd.Timestamp('1999-12-31'))
+
+        # freq is kept
+        exp = DatetimeIndex(['1999-12-31', '2000-01-01', '2000-01-02',
+                             '2000-01-03'], freq='D')
+        tm.assert_index_equal(res, exp)
+        self.assertEqual(res.freq, 'D')
+
+        # str is inserted as it is
+        res = idx.insert(0, '1999-12-31')
+        exp = Index(['1999-12-31', pd.Timestamp('2000-01-01'),
+                     pd.Timestamp('2000-01-02'), pd.Timestamp('2000-01-03')],
+                    dtype=object)
+        tm.assert_index_equal(res, exp)
+
+        # str is inserted as it is
+        res = idx.insert(0, 3)
+        exp = Index([3, pd.Timestamp('2000-01-01'),
+                     pd.Timestamp('2000-01-02'), pd.Timestamp('2000-01-03')],
+                    dtype=object)
+        tm.assert_index_equal(res, exp)
+
+    def test_insert_null(self):
+        idx = DatetimeIndex(['2000-01-01', '2000-01-02',
+                             '2000-01-03'], freq='D')
+        exp = DatetimeIndex(['2000-01-01', 'NaT', '2000-01-02', '2000-01-03'])
+        for n in [None, np.nan, float('nan'), pd.NaT]:
+            res = idx.insert(1, n)
+            tm.assert_index_equal(res, exp)
+
 
 class TestTimedeltaIndexOps(Ops):
     def setUp(self):


### PR DESCRIPTION
- [x] tests added / passed
- [x] passes `git diff upstream/master | flake8 --diff`
- [x] whatsnew entry
### on current master

```
# NG, must be float dtype
pd.Index([1]).insert(1, 1.0)
# Int64Index([1, 1], dtype='int64')

# NG, must be object dtype
pd.DatetimeIndex(['2011-01-01']).insert(1, 1)
# TypeError: cannot insert DatetimeIndex with incompatible label
```
## after the PR

```
pd.Index([1]).insert(1, 1.0)
# Float64Index([1.0, 1.0], dtype='float64')

pd.DatetimeIndex(['2011-01-01']).insert(1, 1)
# Index([2011-01-01 00:00:00, 1], dtype='object')
```
