### PR TITLE
BUG: DataFrame.quantile with NaNs (GH14357)

### DIFF
--- a/doc/source/whatsnew/v0.19.1.txt
+++ b/doc/source/whatsnew/v0.19.1.txt
@@ -63,7 +63,7 @@ Bug Fixes
 
 
 - Bug in ``Timestamp`` where dates very near the minimum (1677-09) could underflow on creation (:issue:`14415`)
-
+- Regression in ``DataFrame.quantile`` when missing values where present in some columns (:issue:`14357`).
 - Bug in ``pd.concat`` where names of the ``keys`` were not propagated to the resulting ``MultiIndex`` (:issue:`14252`)
 - Bug in ``pd.concat`` where ``axis`` cannot take string parameters ``'rows'`` or ``'columns'`` (:issue:`14369`)
 - Bug in ``pd.concat`` with dataframes heterogeneous in length and tuple ``keys`` (:issue:`14438`)

--- a/pandas/core/internals.py
+++ b/pandas/core/internals.py
@@ -1319,7 +1319,7 @@ class Block(PandasObject):
             values = values[~mask]
 
             if len(values) == 0:
-                if lib.isscalar(q):
+                if is_scalar(q):
                     return self._na_value
                 else:
                     return np.array([self._na_value] * len(q),
@@ -1330,7 +1330,7 @@ class Block(PandasObject):
         def _nanpercentile(values, q, axis, **kw):
 
             mask = isnull(self.values)
-            if not lib.isscalar(mask) and mask.any():
+            if not is_scalar(mask) and mask.any():
                 if self.ndim == 1:
                     return _nanpercentile1D(values, mask, q, **kw)
                 else:

--- a/pandas/tests/series/test_quantile.py
+++ b/pandas/tests/series/test_quantile.py
@@ -184,3 +184,35 @@ class TestSeriesQuantile(TestData, tm.TestCase):
 
         res = Series([pd.NaT, pd.NaT]).quantile([0.5])
         tm.assert_series_equal(res, pd.Series([pd.NaT], index=[0.5]))
+
+    def test_quantile_empty(self):
+
+        # floats
+        s = Series([], dtype='float64')
+
+        res = s.quantile(0.5)
+        self.assertTrue(np.isnan(res))
+
+        res = s.quantile([0.5])
+        exp = Series([np.nan], index=[0.5])
+        tm.assert_series_equal(res, exp)
+
+        # int
+        s = Series([], dtype='int64')
+
+        res = s.quantile(0.5)
+        self.assertTrue(np.isnan(res))
+
+        res = s.quantile([0.5])
+        exp = Series([np.nan], index=[0.5])
+        tm.assert_series_equal(res, exp)
+
+        # datetime
+        s = Series([], dtype='datetime64[ns]')
+
+        res = s.quantile(0.5)
+        self.assertTrue(res is pd.NaT)
+
+        res = s.quantile([0.5])
+        exp = Series([pd.NaT], index=[0.5])
+        tm.assert_series_equal(res, exp)


### PR DESCRIPTION
Closes #14357

I first used `nanpercentile` when available (np >= 1.9), but this only can handle numeric data, not datetimes. So therefore included a custom `_nanpercentile`

I also added some tests regarding empty dataframes/series in comments, as these are still failing (but are also failing on 0.19.0)
