### PR TITLE
COMPAT: Updated method call for _Openpyxl22Write.write_cells() for Openpyxl =>2.4.0 #14519

### DIFF
--- a/pandas/io/excel.py
+++ b/pandas/io/excel.py
@@ -1308,10 +1308,8 @@ class _Openpyxl22Writer(_Openpyxl20Writer):
             self.sheets[sheet_name] = wks
 
         for cell in cells:
-            xcell = wks.cell(
-                row=startrow + cell.row + 1,
-                column=startcol + cell.col + 1
-            )
+            xcell = wks['%s%s' %
+                        (startrow + cell.row + 1, startcol + cell.col + 1)]
             xcell.value = _conv_value(cell.val)
 
             style_kwargs = {}
@@ -1349,7 +1347,7 @@ class _Openpyxl22Writer(_Openpyxl20Writer):
                             if row == first_row and col == first_col:
                                 # Ignore first cell. It is already handled.
                                 continue
-                            xcell = wks.cell(column=col, row=row)
+                            xcell = wks['%s%s' % (col, row)]
                             for k, v in style_kwargs.items():
                                 setattr(xcell, k, v)
 

--- a/pandas/io/excel.py
+++ b/pandas/io/excel.py
@@ -902,7 +902,7 @@ class _Openpyxl20Writer(_Openpyxl1Writer):
 
         for cell in cells:
             colletter = get_column_letter(startcol + cell.col + 1)
-            xcell = wks.cell("%s%s" % (colletter, startrow + cell.row + 1))
+            xcell = wks.cell(row=startrow + cell.row + 1, column=colletter)
             xcell.value = _conv_value(cell.val)
             style_kwargs = {}
 
@@ -943,7 +943,7 @@ class _Openpyxl20Writer(_Openpyxl1Writer):
                                 # Ignore first cell. It is already handled.
                                 continue
                             colletter = get_column_letter(col)
-                            xcell = wks.cell("%s%s" % (colletter, row))
+                            xcell = wks.cell(row=row, column=colletter)
                             xcell.style = xcell.style.copy(**style_kwargs)
 
     @classmethod
@@ -1308,8 +1308,7 @@ class _Openpyxl22Writer(_Openpyxl20Writer):
             self.sheets[sheet_name] = wks
 
         for cell in cells:
-            xcell = wks['%s%s' %
-                        (startrow + cell.row + 1, startcol + cell.col + 1)]
+            xcell = wks.cell(row=startrow + cell.row + 1, column=startcol + cell.col + 1)
             xcell.value = _conv_value(cell.val)
 
             style_kwargs = {}
@@ -1347,7 +1346,7 @@ class _Openpyxl22Writer(_Openpyxl20Writer):
                             if row == first_row and col == first_col:
                                 # Ignore first cell. It is already handled.
                                 continue
-                            xcell = wks['%s%s' % (col, row)]
+                            xcell = wks.cell(row=row, column=col)
                             for k, v in style_kwargs.items():
                                 setattr(xcell, k, v)
 

--- a/pandas/io/tests/test_excel.py
+++ b/pandas/io/tests/test_excel.py
@@ -1940,6 +1940,7 @@ class Openpyxl20Tests(ExcelWriterBase, tm.TestCase):
         self.assertEqual(kw['protection'], protection)
 
     def test_write_cells_merge_styled(self):
+        import warnings
         from pandas.formats.format import ExcelCell
         from openpyxl import styles
 
@@ -1962,13 +1963,14 @@ class Openpyxl20Tests(ExcelWriterBase, tm.TestCase):
         ]
 
         with ensure_clean('.xlsx') as path:
+            warnings.simplefilter('error', UserWarning)
             writer = _Openpyxl20Writer(path)
             writer.write_cells(initial_cells, sheet_name=sheet_name)
             writer.write_cells(merge_cells, sheet_name=sheet_name)
 
             wks = writer.sheets[sheet_name]
-            xcell_b1 = wks.cell('B1')
-            xcell_a2 = wks.cell('A2')
+            xcell_b1 = wks['B1']
+            xcell_a2 = wks['A2']
             self.assertEqual(xcell_b1.style, openpyxl_sty_merged)
             self.assertEqual(xcell_a2.style, openpyxl_sty_merged)
 
@@ -2052,7 +2054,8 @@ class Openpyxl22Tests(ExcelWriterBase, tm.TestCase):
     def test_write_cells_merge_styled(self):
         if not openpyxl_compat.is_compat(major_ver=2):
             raise nose.SkipTest('incompatiable openpyxl version')
-
+        
+        import warnings
         from pandas.formats.format import ExcelCell
 
         sheet_name = 'merge_styled'
@@ -2074,13 +2077,14 @@ class Openpyxl22Tests(ExcelWriterBase, tm.TestCase):
         ]
 
         with ensure_clean('.xlsx') as path:
+            warnings.simplefilter('error', UserWarning)
             writer = _Openpyxl22Writer(path)
             writer.write_cells(initial_cells, sheet_name=sheet_name)
             writer.write_cells(merge_cells, sheet_name=sheet_name)
 
             wks = writer.sheets[sheet_name]
-            xcell_b1 = wks.cell('B1')
-            xcell_a2 = wks.cell('A2')
+            xcell_b1 = wks['B1']
+            xcell_a2 = wks['A2']
             self.assertEqual(xcell_b1.font, openpyxl_sty_merged)
             self.assertEqual(xcell_a2.font, openpyxl_sty_merged)
 
@@ -2176,9 +2180,9 @@ class XlsxWriterTests(ExcelWriterBase, tm.TestCase):
             read_workbook = openpyxl.load_workbook(path)
             read_worksheet = read_workbook.get_sheet_by_name(name='Sheet1')
 
-            # Get the number format from the cell. This method is backward
-            # compatible with older versions of openpyxl.
-            cell = read_worksheet.cell('B2')
+            # Get the number format from the cell. This method is current
+            # with openpyxl latest release.
+            cell = read_worksheet['B2']
 
             try:
                 read_num_format = cell.number_format


### PR DESCRIPTION
- [X] closes #14519
- [X] tests added / passed
- [X] passes `git diff upstream/master | flake8 --diff`
- [ ] whatsnew entry

Updated _Openpyxl22Writer.write_cells() to use new coordinate call method wks['coordinate']
instead of wks.cell() in accordance with https://openpyxl.readthedocs.io/en/default/tutorial.html#accessing-one-cell
in the newest release of Openpyxl (2.4.0 and later).

I did not know how to write a true test for this fix since it involves Excel file I/O and pandas does not currently supporting reading in .xlsx as far as I know. The best I could do is use it with openpyxl 2.4.0 install on my machine and passing a small dataframe into an .xlsx. Please let me know if you have any suggestions on how to better test this. 
