### PR TITLE
BUG: fixes #12405 by eliding values index by NaT in MPLPlot._get_xticks

### DIFF
--- a/doc/source/whatsnew/v0.20.2.txt
+++ b/doc/source/whatsnew/v0.20.2.txt
@@ -60,6 +60,7 @@ Plotting
 ^^^^^^^^
 
 - Bug in ``DataFrame.plot`` with a single column and a list-like ``color`` (:issue:`3486`)
+- Bug in ``plot`` where ``NaT`` in ``DatetimeIndex`` results in ``Timestamp.min`` (:issue: `12405`)
 
 
 

--- a/pandas/plotting/_core.py
+++ b/pandas/plotting/_core.py
@@ -11,6 +11,7 @@ import numpy as np
 
 from pandas.util._decorators import cache_readonly
 from pandas.core.base import PandasObject
+from pandas.core.dtypes.missing import notnull
 from pandas.core.dtypes.common import (
     is_list_like,
     is_integer,
@@ -538,6 +539,7 @@ class MPLPlot(object):
                 """
                 x = index._mpl_repr()
             elif is_datetype:
+                self.data = self.data[notnull(self.data.index)]
                 self.data = self.data.sort_index()
                 x = self.data.index._mpl_repr()
             else:

--- a/pandas/tests/plotting/test_datetimelike.py
+++ b/pandas/tests/plotting/test_datetimelike.py
@@ -6,7 +6,7 @@ import pytest
 from pandas.compat import lrange, zip
 
 import numpy as np
-from pandas import Index, Series, DataFrame
+from pandas import Index, Series, DataFrame, NaT
 from pandas.compat import is_platform_mac
 from pandas.core.indexes.datetimes import date_range, bdate_range
 from pandas.core.indexes.timedeltas import timedelta_range
@@ -810,6 +810,20 @@ class TestTSPlot(TestPlotBase):
         # s1.plot(ax=ax2)
         # assert (ax1.lines[0].get_xydata()[0, 0] ==
         #         ax2.lines[0].get_xydata()[0, 0])
+
+    def test_nat_handling(self):
+
+        fig = self.plt.gcf()
+        # self.plt.clf()
+        ax = fig.add_subplot(111)
+
+        dti = DatetimeIndex(['2015-01-01', NaT, '2015-01-03'])
+        s = Series(range(len(dti)), dti)
+        s.plot(ax=ax)
+        xdata = ax.get_lines()[0].get_xdata()
+        # plot x data is bounded by index values
+        assert s.index.min() <= Series(xdata).min()
+        assert Series(xdata).max() <= s.index.max()
 
     @slow
     def test_to_weekly_resampling(self):


### PR DESCRIPTION
- [ ] closes #12405
- [x] tests added / passed
- [x] passes `git diff upstream/master | flake8 --diff`
- [x] whatsnew entry

Proposed solution: elide rows where x value would be `NaT` in [MPLPlot._get_xticks](https://github.com/pandas-dev/pandas/blob/7f5a45c1b388b3f7f309f82bfa0733b7b9980c3a/pandas/tools/plotting.py#L1328) (which seems like a minor misnomer: its getting x values, not what will ultimately be ticks).

Reordering occurs in MPLPlot._get_xticks and it has a block that is conditional on `use_index` and `is_datetype`, so seems like a reasonable place to elide the values.  Mutation of `self.data` already occurs there (reordering) and a read through suggests nothing has saved info related to `self.data`'s shape before this point.
