### PR TITLE
BUG: fix categorical searchsorted bug (#14522)

### DIFF
--- a/pandas/core/categorical.py
+++ b/pandas/core/categorical.py
@@ -1085,8 +1085,11 @@ class Categorical(PandasObject):
                              "ordered one")
 
         from pandas.core.series import Series
-        values_as_codes = self.categories.values.searchsorted(
-            Series(v).values, side=side)
+        cvalues = self.categories.values
+        values_as_codes = np.where(cvalues == Series(v).values)[0]
+
+        if side == 'right':
+            values_as_codes = cvalues.size - values_as_codes
 
         return self.codes.searchsorted(values_as_codes, sorter=sorter)
 


### PR DESCRIPTION
 - [ ] closes #14522 
 - [ ] tests added / passed
 - [ ] passes ``git diff upstream/master | flake8 --diff``
 - [ ] whatsnew entry

the bug is cause by `x.categories.values.searchsorted`, where the search should not be performed.