### PR TITLE
BUG/API: Index.append with mixed object/Categorical indices

### DIFF
--- a/pandas/indexes/base.py
+++ b/pandas/indexes/base.py
@@ -1464,6 +1464,11 @@ class Index(IndexOpsMixin, StringAccessorMixin, PandasObject):
         names = set([obj.name for obj in to_concat])
         name = None if len(names) > 1 else self.name
 
+        if self.is_categorical():
+            # if calling index is category, don't check dtype of others
+            from pandas.indexes.category import CategoricalIndex
+            return CategoricalIndex._append_same_dtype(self, to_concat, name)
+
         typs = _concat.get_dtype_kinds(to_concat)
 
         if len(typs) == 1:

--- a/pandas/indexes/base.py
+++ b/pandas/indexes/base.py
@@ -1466,11 +1466,6 @@ class Index(IndexOpsMixin, StringAccessorMixin, PandasObject):
 
         typs = _concat.get_dtype_kinds(to_concat)
 
-        if 'category' in typs:
-            # if any of the to_concat is category
-            from pandas.indexes.category import CategoricalIndex
-            return CategoricalIndex._append_same_dtype(self, to_concat, name)
-
         if len(typs) == 1:
             return self._append_same_dtype(to_concat, name=name)
         return _concat._concat_index_asobject(to_concat, name=name)

--- a/pandas/tests/frame/test_repr_info.py
+++ b/pandas/tests/frame/test_repr_info.py
@@ -405,3 +405,11 @@ class TestDataFrameReprInfoEtc(tm.TestCase, TestData):
 
         # high upper bound
         self.assertTrue(memory_usage(unstacked) - memory_usage(df) < 2000)
+
+    def test_info_categorical(self):
+        # GH14298
+        idx = pd.CategoricalIndex(['a', 'b'])
+        df = pd.DataFrame(np.zeros((2, 2)), index=idx, columns=idx)
+
+        buf = StringIO()
+        df.info(buf=buf)

--- a/pandas/tests/indexes/test_category.py
+++ b/pandas/tests/indexes/test_category.py
@@ -272,12 +272,11 @@ class TestCategoricalIndex(Base, tm.TestCase):
 
         # with objects
         result = ci.append(Index(['c', 'a']))
-        #expected = CategoricalIndex(list('aabbcaca'), categories=categories)
-        expected = Index(list('aabbcaca'))
+        expected = CategoricalIndex(list('aabbcaca'), categories=categories)
         tm.assert_index_equal(result, expected, exact=True)
 
         # invalid objects
-        #self.assertRaises(TypeError, lambda: ci.append(Index(['a', 'd'])))
+        self.assertRaises(TypeError, lambda: ci.append(Index(['a', 'd'])))
 
         # GH14298 - if base object is not categorical -> coerce to object
         result = Index(['c', 'a']).append(ci)

--- a/pandas/tests/indexes/test_category.py
+++ b/pandas/tests/indexes/test_category.py
@@ -272,11 +272,17 @@ class TestCategoricalIndex(Base, tm.TestCase):
 
         # with objects
         result = ci.append(Index(['c', 'a']))
-        expected = CategoricalIndex(list('aabbcaca'), categories=categories)
+        #expected = CategoricalIndex(list('aabbcaca'), categories=categories)
+        expected = Index(list('aabbcaca'))
         tm.assert_index_equal(result, expected, exact=True)
 
         # invalid objects
-        self.assertRaises(TypeError, lambda: ci.append(Index(['a', 'd'])))
+        #self.assertRaises(TypeError, lambda: ci.append(Index(['a', 'd'])))
+
+        # GH14298 - if base object is not categorical -> coerce to object
+        result = Index(['c', 'a']).append(ci)
+        expected = Index(list('caaabbca'))
+        tm.assert_index_equal(result, expected, exact=True)
 
     def test_insert(self):
 


### PR DESCRIPTION
Closes #14298, related to #13660 and #13767

This closes the `info()` issue with CategoricalIndex, but the underlying issue is actually related to Index.append, when appending mixed dtype index objects: 

```
In [11]: pd.Index(['a']).append(pd.CategoricalIndex(['a', 'b']))
...
AttributeError: 'Index' object has no attribute '_is_dtype_compat'
```

This error occurs when the calling index is not a Categorical (because of https://github.com/pandas-dev/pandas/blob/v0.19.0/pandas/indexes/base.py#L1439 the Categorical `_is_dtype_compat` method is used anyway).

But the question is, what should the result be of the above expression?

- a `CategoricalIndex` ? -> IMO not, as the calling index is not a CategoricalIndex, the result should also not be one (regardless of what is appended) -> so the intention of the code is IMO also not correct
- an object Index ? -> yes, this is also what 0.18.1 does

But, the more important discussion is *what to do when the calling index is a CategoricalIndex* ? In 0.18 (and in 0.19.0) this either returned a CategoricalIndex or raised an error:

```
In [13]: pd.__version__
Out[13]: u'0.18.1'

In [104]: pd.CategoricalIndex(['a', 'b']).append(pd.Index(['a']))
Out[104]: CategoricalIndex([u'a', u'b', u'a'], categories=[u'a', u'b'], ordered=False, dtype='category')

In [105]: pd.CategoricalIndex(['a', 'b']).append(pd.Index(['c']))
...
TypeError: cannot append a non-category item to a CategoricalIndex
```

But, for the `concat` case we decided to return an object dtyped Index in those cases instead of coercing or raising (see discussion in #13767 and the summary table with rules in https://github.com/pandas-dev/pandas/pull/13767#issuecomment-237806603). So the question is, do think that `append` should follow the same rules as `concat`. Or, do we want to be more flexible for `append`, and let it depend on the type of the calling Index?


cc @sinhrks 
