### PR TITLE
PERF: casting loc to labels dtype before searchsorted

### DIFF
--- a/doc/source/whatsnew/v0.19.1.txt
+++ b/doc/source/whatsnew/v0.19.1.txt
@@ -24,7 +24,7 @@ Performance Improvements
 - Improved performance in ``.to_json()`` when ``lines=True`` (:issue:`14408`)
 - Improved performance in ``Series.asof(where)`` when ``where`` is a scalar (:issue:`14461)
 - Improved performance in ``DataFrame.asof(where)`` when ``where`` is a scalar (:issue:`14461)
-
+- Improved performance in certain types of `loc` indexing with a MultiIndex (:issue:`14551`).
 
 
 

--- a/pandas/indexes/multi.py
+++ b/pandas/indexes/multi.py
@@ -1907,6 +1907,7 @@ class MultiIndex(Index):
                 return np.array(labels == loc, dtype=bool)
             else:
                 # sorted, so can return slice object -> view
+                loc = labels.dtype.type(loc)
                 i = labels.searchsorted(loc, side='left')
                 j = labels.searchsorted(loc, side='right')
                 return slice(i, j)

--- a/pandas/indexes/multi.py
+++ b/pandas/indexes/multi.py
@@ -1907,7 +1907,13 @@ class MultiIndex(Index):
                 return np.array(labels == loc, dtype=bool)
             else:
                 # sorted, so can return slice object -> view
-                loc = labels.dtype.type(loc)
+                try:
+                    loc = labels.dtype.type(loc)
+                except TypeError:
+                    # this occurs when loc is a slice (partial string indexing)
+                    # but the TypeError raised by searchsorted in this case
+                    # is catched in Index._has_valid_type()
+                    pass
                 i = labels.searchsorted(loc, side='left')
                 j = labels.searchsorted(loc, side='right')
                 return slice(i, j)


### PR DESCRIPTION
Intrigued by the profiling results of the below example (Multi-index `loc` indexing, based on the example in https://github.com/pandas-dev/pandas/issues/14549), where `searchsorted` seemed to take the majority of the computation time. 
And it seems that `searchsorted` casts both inputs (in this case `labels` and `loc`) to a common dtype, and the `labels` of the MultiIndex were in this case `int16`, while `loc` (output from `Index.get_loc`) is a python int.

By casting `loc` to the dtype of `labels`, the specific example gets a ca 20 x speed improvement

```
df = pd.DataFrame({'a': np.random.randn(500*5000)}, index=pd.MultiIndex.from_product([date_range("2014-01-01", periods=500), range(5000)]))
dt = pd.Timestamp('2015-01-01')
%timeit df.loc[dt]
```

On master:
```
In [3]: %timeit df.loc[dt]
The slowest run took 5.70 times longer than the fastest. This could mean that an intermediate result is being cached.
100 loops, best of 3: 9.39 ms per loop
```

with this PR:
```
In [3]: %timeit df.loc[dt]
The slowest run took 122.51 times longer than the fastest. This could mean that an intermediate result is being cached.
1000 loops, best of 3: 422 µs per loop
```

Just putting it here as a showcase. 
Actual PR probably needs some more work (other places where this can be done, can loc ever be out of bound for that dtype?, benchmarks, ..)
