### PR TITLE
DEPR: add deprecation warning for com.array_equivalent

### DIFF
--- a/doc/source/whatsnew/v0.19.1.txt
+++ b/doc/source/whatsnew/v0.19.1.txt
@@ -34,7 +34,7 @@ Bug Fixes
 ~~~~~~~~~
 
 - Compat with Cython 0.25 for building (:issue:`14496`)
-
+- Added back ``pandas.core.common.array_equivalent`` with a deprecation warning (:issue:`14555`).
 
 - Bug in ``pd.read_csv`` for the C engine in which quotation marks were improperly parsed in skipped rows (:issue:`14459`)
 - Bug in ``pd.read_csv`` for Python 2.x in which Unicode quote characters were no longer being respected (:issue:`14477`)

--- a/pandas/api/tests/test_api.py
+++ b/pandas/api/tests/test_api.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 
+import numpy as np
+
 import pandas as pd
 from pandas.core import common as com
 from pandas import api
@@ -183,6 +185,11 @@ class TestTypes(Base, tm.TestCase):
         # the pandas.core.common introspectors
         for t in self.allowed:
             self.check_deprecation(getattr(com, t), getattr(types, t))
+
+    def test_deprecation_core_common_array_equivalent(self):
+
+        with tm.assert_produces_warning(DeprecationWarning):
+            com.array_equivalent(np.array([1, 2]), np.array([1, 2]))
 
     def test_deprecation_core_common_moved(self):
 

--- a/pandas/core/common.py
+++ b/pandas/core/common.py
@@ -64,6 +64,15 @@ for t in ['is_datetime_arraylike',
     setattr(m, t, outer(t))
 
 
+# deprecate array_equivalent
+
+def array_equivalent(*args, **kwargs):
+    warnings.warn("'pandas.core.common.array_equivalent' is deprecated and "
+                  "is no longer public API", DeprecationWarning, stacklevel=2)
+    from pandas.types import missing
+    return missing.array_equivalent(*args, **kwargs)
+
+
 class PandasError(Exception):
     pass
 


### PR DESCRIPTION
xref https://github.com/pandas-dev/pandas/issues/14555

pandas.core.common.array_equivalent was removed without deprecation warning.
This commits adds it back to the core.common namespace with deprecation warning

We should still decide on the usefulness to add to the public API (in this commit I didn't add any pointer to alternative import location)