### PR TITLE
Added errors{'raise','ignore'} for keys not found in meta for json_normalize

### DIFF
--- a/doc/source/whatsnew/v0.20.0.txt
+++ b/doc/source/whatsnew/v0.20.0.txt
@@ -62,6 +62,7 @@ Other enhancements
 - ``pd.DataFrame.plot`` now prints a title above each subplot if ``suplots=True`` and ``title`` is a list of strings (:issue:`14753`)
 - ``pd.Series.interpolate`` now supports timedelta as an index type with ``method='time'`` (:issue:`6424`)
 - ``pandas.io.json.json_normalize`` If meta keys are not always present a new option to set errors="ignore" (:issue:`14583`)
+- ``pandas.io.json.json_normalize`` gained the option ``errors='ignore'|raise``; the default is raise and is backward compatible. (:issue:`14583`)
 
 
 .. _whatsnew_0200.api_breaking:

--- a/doc/source/whatsnew/v0.20.0.txt
+++ b/doc/source/whatsnew/v0.20.0.txt
@@ -9,7 +9,6 @@ users upgrade to this version.
 
 Highlights include:
 
-- Building pandas for development now requires ``cython >= 0.23`` (:issue:`14831`)
 
 Check the :ref:`API Changes <whatsnew_0200.api_breaking>` and :ref:`deprecations <whatsnew_0200.deprecations>` before updating.
 
@@ -61,7 +60,6 @@ Other enhancements
 - The ``usecols`` argument in ``pd.read_csv`` now accepts a callable function as a value  (:issue:`14154`)
 - ``pd.DataFrame.plot`` now prints a title above each subplot if ``suplots=True`` and ``title`` is a list of strings (:issue:`14753`)
 - ``pd.Series.interpolate`` now supports timedelta as an index type with ``method='time'`` (:issue:`6424`)
-- ``pandas.io.json.json_normalize`` If meta keys are not always present a new option to set errors="ignore" (:issue:`14583`)
 - ``pandas.io.json.json_normalize`` gained the option ``errors='ignore'|raise``; the default is raise and is backward compatible. (:issue:`14583`)
 
 

--- a/doc/source/whatsnew/v0.20.0.txt
+++ b/doc/source/whatsnew/v0.20.0.txt
@@ -61,6 +61,8 @@ Other enhancements
 - The ``usecols`` argument in ``pd.read_csv`` now accepts a callable function as a value  (:issue:`14154`)
 - ``pd.DataFrame.plot`` now prints a title above each subplot if ``suplots=True`` and ``title`` is a list of strings (:issue:`14753`)
 - ``pd.Series.interpolate`` now supports timedelta as an index type with ``method='time'`` (:issue:`6424`)
+- ``pandas.io.json.json_normalize`` If meta keys are not always present a new option to set errors="ignore" (:issue:`14583`)
+
 
 .. _whatsnew_0200.api_breaking:
 

--- a/pandas/io/json.py
+++ b/pandas/io/json.py
@@ -743,8 +743,12 @@ def json_normalize(data, record_path=None, meta=None,
         path to records is ['foo', 'bar']
     meta_prefix : string, default None
     error: {'raise', 'ignore'}, default 'raise'
-        * ignore: will ignore KeyError if keys listed in meta are not always present
-        * raise: will raise KeyError if keys listed in meta are not always present
+        * ignore: will ignore KeyError if keys listed in meta are not
+        always present
+        * raise: will raise KeyError if keys listed in meta are not
+        always present
+        
+        .. versionadded:: 0.20.0
 
     Returns
     -------
@@ -850,7 +854,8 @@ def json_normalize(data, record_path=None, meta=None,
                             if errors == 'ignore':
                                 meta_val = np.nan
                             else:
-                                raise KeyError("Try running with errors='ignore' as key %s is not always present.", e)
+                                raise KeyError("Try running with errors='ignore'"
+                                               "as key %s is not always present.", e)
                     meta_vals[key].append(meta_val)
 
                 records.extend(recs)

--- a/pandas/io/json.py
+++ b/pandas/io/json.py
@@ -723,7 +723,9 @@ def nested_to_record(ds, prefix="", level=0):
 
 def json_normalize(data, record_path=None, meta=None,
                    meta_prefix=None,
-                   record_prefix=None):
+                   record_prefix=None,
+                   errors='raise'):
+
     """
     "Normalize" semi-structured JSON data into a flat table
 
@@ -740,6 +742,8 @@ def json_normalize(data, record_path=None, meta=None,
         If True, prefix records with dotted (?) path, e.g. foo.bar.field if
         path to records is ['foo', 'bar']
     meta_prefix : string, default None
+    error: {'raise', 'ignore'}, default 'raise'
+        * ignore: will ignore keyErrors if keys listed in meta are not always present
 
     Returns
     -------
@@ -839,7 +843,14 @@ def json_normalize(data, record_path=None, meta=None,
                     if level + 1 > len(val):
                         meta_val = seen_meta[key]
                     else:
-                        meta_val = _pull_field(obj, val[level:])
+                        try:
+                            meta_val = _pull_field(obj, val[level:])
+                        except KeyError as e:
+                            if errors == 'ignore':
+                                meta_val = np.nan
+                            else:
+                                raise KeyError(
+                                    "Try running with errors='ignore' as the following key may not always be present: " + str(e))
                     meta_vals[key].append(meta_val)
 
                 records.extend(recs)

--- a/pandas/io/json.py
+++ b/pandas/io/json.py
@@ -743,7 +743,8 @@ def json_normalize(data, record_path=None, meta=None,
         path to records is ['foo', 'bar']
     meta_prefix : string, default None
     error: {'raise', 'ignore'}, default 'raise'
-        * ignore: will ignore keyErrors if keys listed in meta are not always present
+        * ignore: will ignore KeyError if keys listed in meta are not always present
+        * raise: will raise KeyError if keys listed in meta are not always present
 
     Returns
     -------
@@ -849,9 +850,7 @@ def json_normalize(data, record_path=None, meta=None,
                             if errors == 'ignore':
                                 meta_val = np.nan
                             else:
-                                raise \
-                                    KeyError(
-                                    "Try running with errors='ignore' as key may not always be present: %s", e)
+                                raise KeyError("Try running with errors='ignore' as key %s is not always present.", e)
                     meta_vals[key].append(meta_val)
 
                 records.extend(recs)

--- a/pandas/io/json.py
+++ b/pandas/io/json.py
@@ -747,7 +747,6 @@ def json_normalize(data, record_path=None, meta=None,
         always present
         * raise: will raise KeyError if keys listed in meta are not
         always present
-        
         .. versionadded:: 0.20.0
 
     Returns
@@ -854,8 +853,10 @@ def json_normalize(data, record_path=None, meta=None,
                             if errors == 'ignore':
                                 meta_val = np.nan
                             else:
-                                raise KeyError("Try running with errors='ignore'"
-                                               "as key %s is not always present.", e)
+                                raise \
+                                    KeyError("Try running with "
+                                             "errors='ignore' as key "
+                                             "%s is not always present", e)
                     meta_vals[key].append(meta_val)
 
                 records.extend(recs)

--- a/pandas/io/json.py
+++ b/pandas/io/json.py
@@ -849,8 +849,9 @@ def json_normalize(data, record_path=None, meta=None,
                             if errors == 'ignore':
                                 meta_val = np.nan
                             else:
-                                raise KeyError(
-                                    "Try running with errors='ignore' as the following key may not always be present: " + str(e))
+                                raise \
+                                    KeyError(
+                                    "Try running with errors='ignore' as key may not always be present: %s", e)
                     meta_vals[key].append(meta_val)
 
                 records.extend(recs)

--- a/pandas/io/tests/json/test_json_norm.py
+++ b/pandas/io/tests/json/test_json_norm.py
@@ -227,7 +227,7 @@ class TestNestedToRecord(tm.TestCase):
 
 
     def test_json_normalize_errors(self):
-        # If meta keys are not always present a new option to set errors='ignore' has been implemented (:issue:`14583`)
+        # GH14583: If meta keys are not always present a new option to set errors='ignore' has been implemented
         i = {
             "Trades": [{
                 "general": {

--- a/pandas/io/tests/json/test_json_norm.py
+++ b/pandas/io/tests/json/test_json_norm.py
@@ -227,7 +227,8 @@ class TestNestedToRecord(tm.TestCase):
 
 
     def test_json_normalize_errors(self):
-        # GH14583: If meta keys are not always present a new option to set errors='ignore' has been implemented
+        # GH14583: If meta keys are not always present
+        # a new option to set errors='ignore' has been implemented
         i = {
             "Trades": [{
                 "general": {
@@ -238,13 +239,10 @@ class TestNestedToRecord(tm.TestCase):
                         "symbol": "AAPL",
                         "name": "Apple",
                         "price": "0"
-
                     }, {
-
                         "symbol": "GOOG",
                         "name": "Google",
                         "price": "0"
-
                     }
                     ]
                 }
@@ -252,16 +250,13 @@ class TestNestedToRecord(tm.TestCase):
                 "general": {
                     "tradeid": 100,
                     "stocks": [{
-
                         "symbol": "AAPL",
                         "name": "Apple",
                         "price": "0"
-
                     }, {
                         "symbol": "GOOG",
                         "name": "Google",
                         "price": "0"
-
                     }
                     ]
                 }
@@ -269,7 +264,8 @@ class TestNestedToRecord(tm.TestCase):
             ]
         }
         j = json_normalize(data=i['Trades'], record_path=[['general', 'stocks']],
-                           meta=[['general', 'tradeid'], ['general', 'trade_version']], errors='ignore')
+                           meta=[['general', 'tradeid'], ['general', 'trade_version']],
+                           errors='ignore')
         expected={'general.trade_version': {0: 1.0, 1: 1.0, 2: '', 3: ''},
          'general.tradeid': {0: 100, 1: 100, 2: 100, 3: 100},
          'name': {0: 'Apple', 1: 'Google', 2: 'Apple', 3: 'Google'},
@@ -280,7 +276,8 @@ class TestNestedToRecord(tm.TestCase):
 
         self.assertRaises(KeyError,
                 json_normalize, data=i['Trades'], record_path=[['general', 'stocks']],
-                           meta=[['general', 'tradeid'], ['general', 'trade_version']], errors='raise'
+                           meta=[['general', 'tradeid'], ['general', 'trade_version']],
+                          errors='raise'
                           )
 
 

--- a/pandas/io/tests/json/test_json_norm.py
+++ b/pandas/io/tests/json/test_json_norm.py
@@ -225,7 +225,6 @@ class TestNestedToRecord(tm.TestCase):
 
         self.assertEqual(result, expected)
 
-
     def test_json_normalize_errors(self):
         # GH14583: If meta keys are not always present
         # a new option to set errors='ignore' has been implemented
@@ -263,20 +262,24 @@ class TestNestedToRecord(tm.TestCase):
             }
             ]
         }
-        j = json_normalize(data=i['Trades'], record_path=[['general', 'stocks']],
-                           meta=[['general', 'tradeid'], ['general', 'trade_version']],
+        j = json_normalize(data=i['Trades'],
+                           record_path=[['general', 'stocks']],
+                           meta=[['general', 'tradeid'],
+                                 ['general', 'trade_version']],
                            errors='ignore')
-        expected={'general.trade_version': {0: 1.0, 1: 1.0, 2: '', 3: ''},
-         'general.tradeid': {0: 100, 1: 100, 2: 100, 3: 100},
-         'name': {0: 'Apple', 1: 'Google', 2: 'Apple', 3: 'Google'},
-         'price': {0: '0', 1: '0', 2: '0', 3: '0'},
-         'symbol': {0: 'AAPL', 1: 'GOOG', 2: 'AAPL', 3: 'GOOG'}}
+        expected = {'general.trade_version': {0: 1.0, 1: 1.0, 2: '', 3: ''},
+                    'general.tradeid': {0: 100, 1: 100, 2: 100, 3: 100},
+                    'name': {0: 'Apple', 1: 'Google', 2: 'Apple', 3: 'Google'},
+                    'price': {0: '0', 1: '0', 2: '0', 3: '0'},
+                    'symbol': {0: 'AAPL', 1: 'GOOG', 2: 'AAPL', 3: 'GOOG'}}
 
         self.assertEqual(j.fillna('').to_dict(), expected)
 
         self.assertRaises(KeyError,
-                json_normalize, data=i['Trades'], record_path=[['general', 'stocks']],
-                           meta=[['general', 'tradeid'], ['general', 'trade_version']],
+                          json_normalize, data=i['Trades'],
+                          record_path=[['general', 'stocks']],
+                          meta=[['general', 'tradeid'],
+                                ['general', 'trade_version']],
                           errors='raise'
                           )
 

--- a/pandas/io/tests/json/test_json_norm.py
+++ b/pandas/io/tests/json/test_json_norm.py
@@ -225,6 +225,59 @@ class TestNestedToRecord(tm.TestCase):
 
         self.assertEqual(result, expected)
 
+
+    def test_json_normalise_fix(self):
+        # issue 14505
+        j = {
+            "Trades": [{
+                "general": {
+                    "tradeid": 100,
+                    "trade_version": 1,
+                    "stocks": [{
+
+                        "symbol": "AAPL",
+                        "name": "Apple",
+                        "price": "0"
+
+                    }, {
+
+                        "symbol": "GOOG",
+                        "name": "Google",
+                        "price": "0"
+
+                    }
+                    ]
+                }
+            }, {
+                "general": {
+                    "tradeid": 100,
+                    "stocks": [{
+
+                        "symbol": "AAPL",
+                        "name": "Apple",
+                        "price": "0"
+
+                    }, {
+                        "symbol": "GOOG",
+                        "name": "Google",
+                        "price": "0"
+
+                    }
+                    ]
+                }
+            }
+            ]
+        }
+        j = json_normalize(data=j['Trades'], record_path=[['general', 'stocks']],
+                           meta=[['general', 'tradeid'], ['general', 'trade_version']], errors='ignore')
+        expected={'general.trade_version': {0: 1.0, 1: 1.0, 2: '', 3: ''},
+         'general.tradeid': {0: 100, 1: 100, 2: 100, 3: 100},
+         'name': {0: 'Apple', 1: 'Google', 2: 'Apple', 3: 'Google'},
+         'price': {0: '0', 1: '0', 2: '0', 3: '0'},
+         'symbol': {0: 'AAPL', 1: 'GOOG', 2: 'AAPL', 3: 'GOOG'}}
+
+        self.assertEqual(j.fillna('').to_dict(), expected)
+
 if __name__ == '__main__':
     nose.runmodule(argv=[__file__, '-vvs', '-x', '--pdb',
                          '--pdb-failure', '-s'], exit=False)

--- a/pandas/io/tests/json/test_json_norm.py
+++ b/pandas/io/tests/json/test_json_norm.py
@@ -226,9 +226,9 @@ class TestNestedToRecord(tm.TestCase):
         self.assertEqual(result, expected)
 
 
-    def test_json_normalise_fix(self):
-        # issue 14505
-        j = {
+    def test_json_normalize_errors(self):
+        # If meta keys are not always present a new option to set errors='ignore' has been implemented (:issue:`14583`)
+        i = {
             "Trades": [{
                 "general": {
                     "tradeid": 100,
@@ -268,7 +268,7 @@ class TestNestedToRecord(tm.TestCase):
             }
             ]
         }
-        j = json_normalize(data=j['Trades'], record_path=[['general', 'stocks']],
+        j = json_normalize(data=i['Trades'], record_path=[['general', 'stocks']],
                            meta=[['general', 'tradeid'], ['general', 'trade_version']], errors='ignore')
         expected={'general.trade_version': {0: 1.0, 1: 1.0, 2: '', 3: ''},
          'general.tradeid': {0: 100, 1: 100, 2: 100, 3: 100},
@@ -277,6 +277,12 @@ class TestNestedToRecord(tm.TestCase):
          'symbol': {0: 'AAPL', 1: 'GOOG', 2: 'AAPL', 3: 'GOOG'}}
 
         self.assertEqual(j.fillna('').to_dict(), expected)
+
+        self.assertRaises(KeyError,
+                json_normalize, data=i['Trades'], record_path=[['general', 'stocks']],
+                           meta=[['general', 'tradeid'], ['general', 'trade_version']], errors='raise'
+                          )
+
 
 if __name__ == '__main__':
     nose.runmodule(argv=[__file__, '-vvs', '-x', '--pdb',


### PR DESCRIPTION
Continuation of https://github.com/pandas-dev/pandas/pull/14505

Added errors{'raise','ignore'} for keys not found in meta for json_normalize