### PR TITLE
BUG: iloc misbehavior with pd.Series: sometimes returns pd.Categorical, fixes #14580

### DIFF
--- a/doc/source/whatsnew/v0.19.2.txt
+++ b/doc/source/whatsnew/v0.19.2.txt
@@ -94,3 +94,5 @@ Bug Fixes
 - Bug in ``.plot(kind='kde')`` which did not drop missing values to generate the KDE Plot, instead generating an empty plot. (:issue:`14821`)
 
 - Bug in ``unstack()`` if called with a list of column(s) as an argument, regardless of the dtypes of all columns, they get coerced to ``object`` (:issue:`11847`)
+
+- Bug in ``pd.Series`` iloc returned Categorical object for list-like indexes input, while Series object was expected. (:issue:`14580`)

--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -1596,6 +1596,27 @@ class _iLocIndexer(_LocationIndexer):
         else:
             return self.obj.take(slice_obj, axis=axis, convert=False)
 
+    def _get_list_axis(self, key_list, axis=0):
+        """
+        Return Series values by list or array of integers
+
+        Parameters
+        ----------
+        key_list : list-like positional indexer
+        axis : int (can only be zero)
+
+        Returns
+        -------
+        Series object
+        """
+
+        # validate list bounds
+        self._is_valid_list_like(key_list, axis)
+
+        # force an actual list
+        key_list = list(key_list)
+        return self.obj.take(key_list, axis=axis, convert=False)
+
     def _getitem_axis(self, key, axis=0):
 
         if isinstance(key, slice):
@@ -1606,27 +1627,20 @@ class _iLocIndexer(_LocationIndexer):
             self._has_valid_type(key, axis)
             return self._getbool_axis(key, axis=axis)
 
-        # a single integer or a list of integers
+        # a list of integers
+        elif is_list_like_indexer(key):
+            return self._get_list_axis(key, axis=axis)
+
+        # a single integer
         else:
+            key = self._convert_scalar_indexer(key, axis)
 
-            if is_list_like_indexer(key):
+            if not is_integer(key):
+                raise TypeError("Cannot index by location index with a "
+                                "non-integer key")
 
-                # validate list bounds
-                self._is_valid_list_like(key, axis)
-
-                # force an actual list
-                key = list(key)
-                return self.obj.take(key, axis=axis, convert=False)
-
-            else:
-                key = self._convert_scalar_indexer(key, axis)
-
-                if not is_integer(key):
-                    raise TypeError("Cannot index by location index with a "
-                                    "non-integer key")
-
-                # validate the location
-                self._is_valid_integer(key, axis)
+            # validate the location
+            self._is_valid_integer(key, axis)
 
             return self._get_loc(key, axis=axis)
 

--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -1616,6 +1616,7 @@ class _iLocIndexer(_LocationIndexer):
 
                 # force an actual list
                 key = list(key)
+                return self.obj.take(key, axis=axis, convert=False)
 
             else:
                 key = self._convert_scalar_indexer(key, axis)

--- a/pandas/tests/test_categorical.py
+++ b/pandas/tests/test_categorical.py
@@ -54,6 +54,27 @@ class TestCategorical(tm.TestCase):
         expected = c[np.array([100000]).astype(np.int64)].codes
         self.assert_numpy_array_equal(result, expected)
 
+    def test_getitem_category_type(self):
+        # GH 14580
+        # test iloc() on Series with Categorical data
+
+        s = pd.Series([1, 2, 3]).astype('category')
+
+        # get slice
+        result = s.iloc[0:2]
+        expected = pd.Series([1, 2]).astype('category', categories=[1, 2, 3])
+        tm.assert_series_equal(result, expected)
+
+        # get list of indexes
+        result = s.iloc[[0, 1]]
+        expected = pd.Series([1, 2]).astype('category', categories=[1, 2, 3])
+        tm.assert_series_equal(result, expected)
+
+        # get boolean array
+        result = s.iloc[[True, False, False]]
+        expected = pd.Series([1]).astype('category', categories=[1, 2, 3])
+        tm.assert_series_equal(result, expected)
+
     def test_setitem(self):
 
         # int/positional


### PR DESCRIPTION
 - [x] closes #xxxx
 - [x] tests added / passed
 - [x] passes ``git diff upstream/master | flake8 --diff``
 - [x] whatsnew entry

closes https://github.com/pandas-dev/pandas/issues/14580
