### PR TITLE
DOC: Update Series.mode docstring

### DIFF
--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -1216,16 +1216,10 @@ class Series(base.IndexOpsMixin, strings.StringAccessorMixin,
                                  dtype='int64').__finalize__(self)
 
     def mode(self):
-        """Returns the mode(s) of the dataset.
+        """Return the mode(s) of the dataset.
 
-        Empty if nothing occurs at least 2 times.  Always returns Series even
-        if only one value.
-
-        Parameters
-        ----------
-        sort : bool, default True
-            If True, will lexicographically sort values, if False skips
-            sorting. Result ordering when ``sort=False`` is not defined.
+        Empty if nothing occurs at least 2 times. Always returns Series even
+        if only one value is returned.
 
         Returns
         -------


### PR DESCRIPTION
 - [ ] closes #xxxx
 - [x] tests added / passed
 - [x] passes ``git diff upstream/master | flake8 --diff``
 - [ ] whatsnew entry

Series mode method does not support sort parameter, even though the documentation says so. Neither does the underlying function from pandas.core.algorithms.