### PR TITLE
COMPAT: Cast to string before raise in read_stata

### DIFF
--- a/pandas/io/stata.py
+++ b/pandas/io/stata.py
@@ -1210,18 +1210,18 @@ class StataReader(StataParser, BaseIterator):
                 if tp in self.OLD_TYPE_MAPPING:
                     typlist.append(self.OLD_TYPE_MAPPING[tp])
                 else:
-                    typlist.append(tp - 127)  # string
+                    typlist.append(tp - 127)  # py2 string, py3 bytes
 
         try:
             self.typlist = [self.TYPE_MAP[typ] for typ in typlist]
         except:
             raise ValueError("cannot convert stata types [{0}]"
-                             .format(','.join(typlist)))
+                             .format(','.join(str(x) for x in typlist)))
         try:
             self.dtyplist = [self.DTYPE_MAP[typ] for typ in typlist]
         except:
             raise ValueError("cannot convert stata dtypes [{0}]"
-                             .format(','.join(typlist)))
+                             .format(','.join(str(x) for x in typlist)))
 
         if self.format_version > 108:
             self.varlist = [self._null_terminate(self.path_or_buf.read(33))


### PR DESCRIPTION
In `pandas.io.stata::StataReader::_read_old_header` we
try to raise a ValueError.

I'm working on making a test, but this is buried pretty deep.
For now, `typlist` has type `List[int]`. We call

```python
','.join(typlist)
```

which errors on py3 (and python 2 I guess?). This came up in #13856, see https://travis-ci.org/pandas-dev/pandas/jobs/175705122#L1284 for the failure.

@kshedden any memory of writing this code? This is a bare `except` but it looks like the only exception that would trigger this is an `IndexError` when something in `typlist` is out of bounds on `self.TYPE_MAP`. Any hints on writing a test to exercise this code? If not I'll dig in more tonight.