### PR TITLE
BUG: pandas.cut and negative values #14652

### DIFF
--- a/doc/source/whatsnew/v0.19.2.txt
+++ b/doc/source/whatsnew/v0.19.2.txt
@@ -25,4 +25,4 @@ Bug Fixes
 
 - compat with ``dateutil==2.6.0`` for testing (:issue:`14621`)
 - allow ``nanoseconds`` in ``Timestamp.replace`` kwargs (:issue:`14621`)
-- fix ``pandas.cut`` with one negative value and one bin (:issue:`14652`)
+- Bug in ``pd.cut`` (:issue:`14652`)

--- a/doc/source/whatsnew/v0.19.2.txt
+++ b/doc/source/whatsnew/v0.19.2.txt
@@ -25,3 +25,4 @@ Bug Fixes
 
 - compat with ``dateutil==2.6.0`` for testing (:issue:`14621`)
 - allow ``nanoseconds`` in ``Timestamp.replace`` kwargs (:issue:`14621`)
+- fix ``pandas.cut`` with one negative value and one bin (:issue:`14652`)

--- a/pandas/tests/test_base.py
+++ b/pandas/tests/test_base.py
@@ -1095,6 +1095,7 @@ class TestNoNewAttributesMixin(tm.TestCase):
         self.assertRaises(AttributeError, f)
         self.assertFalse(hasattr(t, "b"))
 
+
 class TestTile(tm.TestCase):
 
     def test_single_bin(self):

--- a/pandas/tests/test_base.py
+++ b/pandas/tests/test_base.py
@@ -1096,21 +1096,6 @@ class TestNoNewAttributesMixin(tm.TestCase):
         self.assertFalse(hasattr(t, "b"))
 
 
-class TestTile(tm.TestCase):
-
-    def test_single_bin(self):
-
-        expected = pd.Series([0, 0])
-
-        s = pd.Series([9., 9.])
-        result = pd.cut(s, 1, labels=False)
-        tm.assert_series_equal(result, expected)
-
-        s = pd.Series([-9., -9.])
-        result = pd.cut(s, 1, labels=False)
-        tm.assert_series_equal(result, expected)
-
-
 if __name__ == '__main__':
     import nose
 

--- a/pandas/tests/test_base.py
+++ b/pandas/tests/test_base.py
@@ -1095,6 +1095,20 @@ class TestNoNewAttributesMixin(tm.TestCase):
         self.assertRaises(AttributeError, f)
         self.assertFalse(hasattr(t, "b"))
 
+class TestTile(tm.TestCase):
+
+    def test_single_bin(self):
+
+        expected = pd.Series([0, 0])
+
+        s = pd.Series([9., 9.])
+        result = pd.cut(s, 1, labels=False)
+        tm.assert_series_equal(result, expected)
+
+        s = pd.Series([-9., -9.])
+        result = pd.cut(s, 1, labels=False)
+        tm.assert_series_equal(result, expected)
+
 
 if __name__ == '__main__':
     import nose

--- a/pandas/tools/tests/test_tile.py
+++ b/pandas/tools/tests/test_tile.py
@@ -271,6 +271,18 @@ class TestCut(tm.TestCase):
                                     np.array([0, 0, 1, 1], dtype=np.int8))
         tm.assert_numpy_array_equal(bins, np.array([0, 1.5, 3]))
 
+    def test_single_bin(self):
+        # issue 14652
+        expected = Series([0, 0])
+
+        s = Series([9., 9.])
+        result = cut(s, 1, labels=False)
+        tm.assert_series_equal(result, expected)
+
+        s = Series([-9., -9.])
+        result = cut(s, 1, labels=False)
+        tm.assert_series_equal(result, expected)
+
 
 def curpath():
     pth, _ = os.path.split(os.path.abspath(__file__))

--- a/pandas/tools/tile.py
+++ b/pandas/tools/tile.py
@@ -98,8 +98,8 @@ def cut(x, bins, right=True, labels=None, retbins=False, precision=3,
         mn, mx = [mi + 0.0 for mi in rng]
 
         if mn == mx:  # adjust end points before binning
-            mn -= .001 * mn
-            mx += .001 * mx
+            mn -= .001 * abs(mn)
+            mx += .001 * abs(mx)
             bins = np.linspace(mn, mx, bins + 1, endpoint=True)
         else:  # adjust end points after binning
             bins = np.linspace(mn, mx, bins + 1, endpoint=True)


### PR DESCRIPTION
 - [OK ] closes #14652
 - [OK] tests passed
 - [OK ] passes ``git diff upstream/master | flake8 --diff``

