### PR TITLE
ERR: fix exception propogation for datetime parsing functions, noted in python 3.6

### DIFF
--- a/doc/source/whatsnew/v0.19.2.txt
+++ b/doc/source/whatsnew/v0.19.2.txt
@@ -38,7 +38,7 @@ Bug Fixes
 
 
 
-
+- Bug in not propogating exceptions in parsing invalid datetimes, noted in python 3.6 (:issue:`14561`)
 
 
 

--- a/pandas/src/datetime.pxd
+++ b/pandas/src/datetime.pxd
@@ -126,8 +126,8 @@ cdef extern from "datetime/np_datetime_strings.h":
 
 
 
-cdef inline _string_to_dts(object val, pandas_datetimestruct* dts,
-                           int* out_local, int* out_tzoffset):
+cdef inline int _string_to_dts(object val, pandas_datetimestruct* dts,
+                           int* out_local, int* out_tzoffset) except? -1:
     cdef int result
     cdef char *tmp
 
@@ -139,10 +139,11 @@ cdef inline _string_to_dts(object val, pandas_datetimestruct* dts,
 
     if result == -1:
         raise ValueError('Unable to parse %s' % str(val))
+    return result
 
 cdef inline int _cstring_to_dts(char *val, int length,
                                 pandas_datetimestruct* dts,
-                                int* out_local, int* out_tzoffset):
+                                int* out_local, int* out_tzoffset) except? -1:
     cdef:
         npy_bool special
         PANDAS_DATETIMEUNIT out_bestunit
@@ -195,4 +196,3 @@ cdef inline int64_t _date_to_datetime64(object val,
     dts.hour = dts.min = dts.sec = dts.us = 0
     dts.ps = dts.as = 0
     return pandas_datetimestruct_to_datetime(PANDAS_FR_ns, dts)
-

--- a/setup.py
+++ b/setup.py
@@ -454,7 +454,8 @@ lib_depends = lib_depends + ['pandas/src/numpy_helper.h',
 
 tseries_depends = ['pandas/src/datetime/np_datetime.h',
                    'pandas/src/datetime/np_datetime_strings.h',
-                   'pandas/src/period_helper.h']
+                   'pandas/src/period_helper.h',
+                   'pandas/src/datetime.pxd']
 
 
 # some linux distros require it


### PR DESCRIPTION
 closes #14561