### PR TITLE
DEPR: Patch to_dense behaviour for sparse.

### DIFF
--- a/doc/source/whatsnew/v0.20.0.txt
+++ b/doc/source/whatsnew/v0.20.0.txt
@@ -64,6 +64,8 @@ Removal of prior version deprecations/changes
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 - ``pd.to_datetime`` and ``pd.to_timedelta`` have dropped the ``coerce`` parameter in favor of ``errors`` (:issue:`13602`)
+- ``SparseArray.to_dense()`` has deprecated the ``fill`` parameter, as that parameter was not being respected (:issue:`14647`)
+- ``SparseSeries.to_dense()`` has deprecated the ``sparse_only`` parameter (:issue:`14647`)
 
 
 

--- a/pandas/sparse/array.py
+++ b/pandas/sparse/array.py
@@ -5,6 +5,7 @@ from __future__ import division
 # pylint: disable=E1101,E1103,W0231
 
 import numpy as np
+import warnings
 
 import pandas as pd
 from pandas.core.base import PandasObject
@@ -381,8 +382,22 @@ class SparseArray(PandasObject, np.ndarray):
 
     def to_dense(self, fill=None):
         """
-        Convert SparseSeries to (dense) Series
+        Convert SparseArray to a NumPy array.
+
+        Parameters
+        ----------
+        fill: float, default None
+            DEPRECATED: this argument will be removed in a future version
+            because it is not respected by this function.
+
+        Returns
+        -------
+        arr : NumPy array
         """
+        if fill is not None:
+            warnings.warn(("The 'fill' parameter has been deprecated and "
+                           "will be removed in a future version."),
+                          FutureWarning, stacklevel=2)
         return self.values
 
     def __iter__(self):

--- a/pandas/sparse/series.py
+++ b/pandas/sparse/series.py
@@ -528,9 +528,24 @@ class SparseSeries(Series):
 
     def to_dense(self, sparse_only=False):
         """
-        Convert SparseSeries to (dense) Series
+        Convert SparseSeries to a Series.
+
+        Parameters
+        ----------
+        sparse_only: bool, default False
+            DEPRECATED: this argument will be removed in a future version.
+
+            If True, return just the non-sparse values, or the dense version
+            of `self.values` if False.
+
+        Returns
+        -------
+        s : Series
         """
         if sparse_only:
+            warnings.warn(("The 'sparse_only' parameter has been deprecated "
+                           "and will be removed in a future version."),
+                          FutureWarning, stacklevel=2)
             int_index = self.sp_index.to_int_index()
             index = self.index.take(int_index.indices)
             return Series(self.sp_values, index=index, name=self.name)

--- a/pandas/sparse/tests/test_array.py
+++ b/pandas/sparse/tests/test_array.py
@@ -453,6 +453,11 @@ class TestSparseArray(tm.TestCase):
         res = SparseArray(vals, fill_value=0).to_dense()
         tm.assert_numpy_array_equal(res, vals)
 
+        # see gh-14647
+        with tm.assert_produces_warning(FutureWarning,
+                                        check_stacklevel=False):
+            SparseArray(vals).to_dense(fill=2)
+
     def test_getitem(self):
         def _checkit(i):
             assert_almost_equal(self.arr[i], self.arr.values[i])

--- a/pandas/sparse/tests/test_series.py
+++ b/pandas/sparse/tests/test_series.py
@@ -161,7 +161,10 @@ class TestSparseSeries(tm.TestCase, SharedWithSparse):
         series = self.bseries.to_dense()
         tm.assert_series_equal(series, Series(arr, name='bseries'))
 
-        series = self.bseries.to_dense(sparse_only=True)
+        # see gh-14647
+        with tm.assert_produces_warning(FutureWarning,
+                                        check_stacklevel=False):
+            series = self.bseries.to_dense(sparse_only=True)
 
         indexer = np.isfinite(arr)
         exp = Series(arr[indexer], index=index[indexer], name='bseries')


### PR DESCRIPTION
Patches the following for `to_dense`:

1) Fix `SparseArray.to_dense` documentation to refer to `SparseArray` and not `SparseSeries`.

2) Deprecate the fill parameter in `SparseArray.to_dense`, as that parameter was not being respected.

3) Deprecate the sparse_only parameter in `SparseSeries.to_dense`, as that parameter is inconsistent with the `to_dense` API we want, which is no parameters.

Closes #14647.