### PR TITLE
COMPAT: pickle compat for Timestamp in py3.6

### DIFF
--- a/doc/source/whatsnew/v0.19.2.txt
+++ b/doc/source/whatsnew/v0.19.2.txt
@@ -42,8 +42,9 @@ Bug Fixes
 
 
 - Compat with python 3.6 for pickling of some offsets (:issue:`14685`)
-- Compat with python 3.6 for some indexing exception types (:issue:`14684`)
+- Compat with python 3.6 for some indexing exception types (:issue:`14684`, :issue:`14689`)
 - Compat with python 3.6 for deprecation warnings in the test suite (:issue:`14681`)
+- Compat with python 3.6 for Timestamp pickles (:issue:`14689`)
 
 
 

--- a/pandas/tslib.pyx
+++ b/pandas/tslib.pyx
@@ -1105,6 +1105,12 @@ cdef class _Timestamp(datetime):
         self._assert_tzawareness_compat(other)
         return _cmp_scalar(self.value, ots.value, op)
 
+    def __reduce_ex__(self, protocol):
+        # python 3.6 compat
+        # http://bugs.python.org/issue28730
+        # now __reduce_ex__ is defined and higher priority than __reduce__
+        return self.__reduce__()
+
     def __repr__(self):
         stamp = self._repr_base
         zone = None

--- a/pandas/types/common.py
+++ b/pandas/types/common.py
@@ -196,8 +196,8 @@ def _is_unorderable_exception(e):
     These are different error message for PY>=3<=3.5 and PY>=3.6
     """
     if PY36:
-        return ("'>' not supported between instances "
-                "of 'str' and 'int'" in str(e))
+        return "'>' not supported between instances of" in str(e)
+
     elif PY3:
         return 'unorderable' in str(e)
     return False


### PR DESCRIPTION
 BUG: fix unorderable exception types in py3.6
xref #14679 
xref http://bugs.python.org/issue28730