### PR TITLE
CLN: remove bare excepts

### DIFF
--- a/doc/source/whatsnew/v0.19.2.txt
+++ b/doc/source/whatsnew/v0.19.2.txt
@@ -64,4 +64,4 @@ Bug Fixes
 
 
 - Explicit check in ``to_stata`` and ``StataWriter`` for out-of-range values when writing doubles (:issue:`14618`)
-- Bug in indexing causing RecursionError to be coerced into a KeyError or IndexError. (:issue:`14554`)
+- Bug in indexing caused RecursionError to be coerced into a KeyError or IndexError. (:issue:`14554`)

--- a/doc/source/whatsnew/v0.19.2.txt
+++ b/doc/source/whatsnew/v0.19.2.txt
@@ -64,3 +64,4 @@ Bug Fixes
 
 
 - Explicit check in ``to_stata`` and ``StataWriter`` for out-of-range values when writing doubles (:issue:`14618`)
+- Bug in indexing causing RecursionError to be coerced into a KeyError or IndexError. (:issue:`14554`)

--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -848,7 +848,7 @@ class _NDFrameIndexer(object):
                 [(a, self._convert_for_reindex(t, axis=o._get_axis_number(a)))
                  for t, a in zip(tup, o._AXIS_ORDERS)])
             return o.reindex(**d)
-        except:
+        except(KeyError, IndexError):
             raise self._exception
 
     def _convert_for_reindex(self, key, axis=0):


### PR DESCRIPTION
 - [x] closes #14554 
 - [ ] tests added / passed: updated test_indexing.py
 - [x] passes ``git diff upstream/master | flake8 --diff``
 - [x] whatsnew entry

Errors in indexing no longer forced into KeyError