### PR TITLE
DOC: Disambiguate 'where' in boolean indexing-10min.rst (#12661)

### DIFF
--- a/doc/source/10min.rst
+++ b/doc/source/10min.rst
@@ -282,7 +282,7 @@ Using a single column's values to select data.
 
    df[df.A > 0]
 
-A ``where`` operation for getting.
+Selecting values from a DataFrame where a boolean condition is met.
 
 .. ipython:: python
 


### PR DESCRIPTION
 - [x] closes #12661

Per @jorisvandenbossche comment in this thread (https://github.com/pandas-dev/pandas/pull/12671), remove code markdown from 'where' to not confuse the example with the `where()` method.
