### PR TITLE
BUG: Ensure min_itemsize is always a list (#11412)

### DIFF
--- a/doc/source/whatsnew/v0.19.2.txt
+++ b/doc/source/whatsnew/v0.19.2.txt
@@ -59,6 +59,7 @@ Bug Fixes
 
 
 - Bug ``HDFStore`` writing a ``MultiIndex`` when using ``data_columns=True`` (:issue:`14435`)
+- Bug in ``HDFStore.append()`` when writing a ``Series`` and passing a ``min_itemsize`` argument containing a value for ``index`` (:issue:`11412`)
 - Bug in ``Series.groupby.nunique()`` raising an ``IndexError`` for an empty ``Series`` (:issue:`12553`)
 
 

--- a/pandas/io/pytables.py
+++ b/pandas/io/pytables.py
@@ -3315,7 +3315,7 @@ class Table(Fixed):
         # evaluate the passed data_columns, True == use all columns
         # take only valide axis labels
         if data_columns is True:
-            data_columns = axis_labels
+            data_columns = list(axis_labels)
         elif data_columns is None:
             data_columns = []
 
@@ -4153,7 +4153,7 @@ class AppendableSeriesTable(AppendableFrameTable):
             obj = DataFrame({name: obj}, index=obj.index)
             obj.columns = [name]
         return super(AppendableSeriesTable, self).write(
-            obj=obj, data_columns=obj.columns, **kwargs)
+            obj=obj, data_columns=obj.columns.tolist(), **kwargs)
 
     def read(self, columns=None, **kwargs):
 

--- a/pandas/io/tests/test_pytables.py
+++ b/pandas/io/tests/test_pytables.py
@@ -1362,6 +1362,16 @@ class TestHDFStore(Base, tm.TestCase):
                 [[124, 'abcdefqhij'], [346, 'abcdefghijklmnopqrtsuvwxyz']])
             self.assertRaises(ValueError, store.append, 'df_new', df_new)
 
+            # min_itemsize on Series index (GH 11412)
+            df = tm.makeMixedDataFrame().set_index('C')
+            store.append('ss', df['B'], min_itemsize={'index': 4})
+            tm.assert_series_equal(store.select('ss'), df['B'])
+
+            # same as above, with data_columns=True
+            store.append('ss2', df['B'], data_columns=True,
+                         min_itemsize={'index': 4})
+            tm.assert_series_equal(store.select('ss2'), df['B'])
+
             # with nans
             _maybe_remove(store, 'df')
             df = tm.makeTimeDataFrame()


### PR DESCRIPTION
 - [x] closes #11412
 - [x] passes ``git diff upstream/master | flake8 --diff``
 - [x] tests added / passed
 - [x] whatsnew entry

(I plan to fix #10381 and #12154 next, but first we need coherence on ``type(data_columns)`` - and ``Index`` seems to me the best option.)