### PR TITLE
CLN: move assignment from header into cython

### DIFF
--- a/pandas/src/datetime.pxd
+++ b/pandas/src/datetime.pxd
@@ -42,9 +42,6 @@ cdef extern from "datetime.h":
     object PyDateTime_FromDateAndTime(int year, int month, int day, int hour,
                                       int minute, int second, int us)
 
-cdef extern from "datetime_helper.h":
-    void mangle_nat(object o)
-
 cdef extern from "numpy/ndarrayobject.h":
 
     ctypedef int64_t npy_timedelta

--- a/pandas/src/datetime_helper.h
+++ b/pandas/src/datetime_helper.h
@@ -7,11 +7,6 @@
 #define PyInt_AS_LONG PyLong_AsLong
 #endif
 
-void mangle_nat(PyObject *val) {
-  PyDateTime_GET_MONTH(val) = -1;
-  PyDateTime_GET_DAY(val) = -1;
-}
-
 npy_int64 get_long_attr(PyObject *o, const char *attr) {
   npy_int64 long_val;
   PyObject *value = PyObject_GetAttrString(o, attr);

--- a/pandas/tslib.pyx
+++ b/pandas/tslib.pyx
@@ -738,7 +738,8 @@ class NaTType(_NaT):
         cdef _NaT base
 
         base = _NaT.__new__(cls, 1, 1, 1)
-        mangle_nat(base)
+        base._day = -1
+        base._month = -1
         base.value = NPY_NAT
 
         return base


### PR DESCRIPTION
an insignificant refactoring that allows PyPy2.7  to build and import Pandas. The original code uses functions that are macros in CPython but actual c-functions in PyPy and one cannot assign to a function result

Note that while PyPy imports Pandas, it very quickly segfaults, Apparently PyPy does not yet play well with enough of Cython, I suspect strange interactions with tp_new and tp_deallocate