### PR TITLE
ENH: support cut/qcut for datetime/timedelta (GH14714)

### DIFF
--- a/doc/source/whatsnew/v0.20.0.txt
+++ b/doc/source/whatsnew/v0.20.0.txt
@@ -50,7 +50,7 @@ Other enhancements
 
 - ``pd.read_excel`` now preserves sheet order when using ``sheetname=None`` (:issue:`9930`)
 
-ENH: support cut/qcut for datetime/timedelta (GH14714)
+- pd.cut and qcut now support datetime64 and timedelta64 dtypes (issue:`14714`)
 
 .. _whatsnew_0200.api_breaking:
 

--- a/doc/source/whatsnew/v0.20.0.txt
+++ b/doc/source/whatsnew/v0.20.0.txt
@@ -50,6 +50,7 @@ Other enhancements
 
 - ``pd.read_excel`` now preserves sheet order when using ``sheetname=None`` (:issue:`9930`)
 
+ENH: support cut/qcut for datetime/timedelta (GH14714)
 
 .. _whatsnew_0200.api_breaking:
 

--- a/doc/source/whatsnew/v0.20.0.txt
+++ b/doc/source/whatsnew/v0.20.0.txt
@@ -50,7 +50,7 @@ Other enhancements
 
 - ``pd.read_excel`` now preserves sheet order when using ``sheetname=None`` (:issue:`9930`)
 
-- pd.cut and qcut now support datetime64 and timedelta64 dtypes (issue:`14714`)
+- ``pd.cut`` and ``pd.qcut`` now support datetime64 and timedelta64 dtypes (issue:`14714`)
 
 .. _whatsnew_0200.api_breaking:
 

--- a/pandas/tools/tests/test_tile.py
+++ b/pandas/tools/tests/test_tile.py
@@ -294,6 +294,29 @@ class TestCut(tm.TestCase):
                           ).astype("category", ordered=True)
         tm.assert_series_equal(result, expected)
 
+    def test_datetime_list_cut(self):
+        # GH 14714
+        data = [np.datetime64('2013-01-01'), np.datetime64('2013-01-02'),
+                np.datetime64('2013-01-03')]
+        result, bins = cut(data, 3, retbins=True)
+        expected = Series(['(2012-12-31 23:57:07.200000, 2013-01-01 16:00:00]',
+                          '(2013-01-01 16:00:00, 2013-01-02 08:00:00]',
+                           '(2013-01-02 08:00:00, 2013-01-03 00:00:00]'],
+                          ).astype("category", ordered=True)
+        tm.assert_almost_equal(Series(result), expected)
+
+    def test_datetime_ndarray_cut(self):
+        # GH 14714
+        data = np.array([np.datetime64('2013-01-01'), 
+                        np.datetime64('2013-01-02'),
+                        np.datetime64('2013-01-03')])
+        result, bins = cut(data, 3, retbins=True)
+        expected = Series(['(2012-12-31 23:57:07.200000, 2013-01-01 16:00:00]',
+                          '(2013-01-01 16:00:00, 2013-01-02 08:00:00]',
+                           '(2013-01-02 08:00:00, 2013-01-03 00:00:00]'],
+                          ).astype("category", ordered=True)
+        tm.assert_almost_equal(Series(result), expected)
+
 
 def curpath():
     pth, _ = os.path.split(os.path.abspath(__file__))

--- a/pandas/tools/tests/test_tile.py
+++ b/pandas/tools/tests/test_tile.py
@@ -286,6 +286,7 @@ class TestCut(tm.TestCase):
 
     def test_datetime_cut(self):
         # GH 14714
+        # testing for time data to be present as series
         data = to_datetime(Series(['2013-01-01', '2013-01-02', '2013-01-03']))
         result, bins = cut(data, 3, retbins=True)
         expected = Series(['(2012-12-31 23:57:07.200000, 2013-01-01 16:00:00]',
@@ -294,37 +295,23 @@ class TestCut(tm.TestCase):
                           ).astype("category", ordered=True)
         tm.assert_series_equal(result, expected)
 
-    def test_datetime_list_cut(self):
-        # GH 14714
+        # testing for time data to be present as list
         data = [np.datetime64('2013-01-01'), np.datetime64('2013-01-02'),
                 np.datetime64('2013-01-03')]
         result, bins = cut(data, 3, retbins=True)
-        expected = Series(['(2012-12-31 23:57:07.200000, 2013-01-01 16:00:00]',
-                          '(2013-01-01 16:00:00, 2013-01-02 08:00:00]',
-                           '(2013-01-02 08:00:00, 2013-01-03 00:00:00]'],
-                          ).astype("category", ordered=True)
         tm.assert_series_equal(Series(result), expected)
 
-    def test_datetime_ndarray_cut(self):
-        # GH 14714
+        # testing for time data to be present as ndarray
+
         data = np.array([np.datetime64('2013-01-01'), 
                         np.datetime64('2013-01-02'),
                         np.datetime64('2013-01-03')])
         result, bins = cut(data, 3, retbins=True)
-        expected = Series(['(2012-12-31 23:57:07.200000, 2013-01-01 16:00:00]',
-                          '(2013-01-01 16:00:00, 2013-01-02 08:00:00]',
-                           '(2013-01-02 08:00:00, 2013-01-03 00:00:00]'],
-                          ).astype("category", ordered=True)
         tm.assert_series_equal(Series(result), expected)
 
-    def test_datetime_index_cut(self):
-        # GH 14714
+        # testing for time data to be present as datetime index
         data = DatetimeIndex(['2013-01-01', '2013-01-02', '2013-01-03'])
         result, bins = cut(data, 3, retbins=True)
-        expected = Series(['(2012-12-31 23:57:07.200000, 2013-01-01 16:00:00]',
-                          '(2013-01-01 16:00:00, 2013-01-02 08:00:00]',
-                           '(2013-01-02 08:00:00, 2013-01-03 00:00:00]'],
-                          ).astype("category", ordered=True)
         tm.assert_series_equal(Series(result), expected)
 
 

--- a/pandas/tools/tests/test_tile.py
+++ b/pandas/tools/tests/test_tile.py
@@ -303,7 +303,7 @@ class TestCut(tm.TestCase):
 
         # testing for time data to be present as ndarray
 
-        data = np.array([np.datetime64('2013-01-01'), 
+        data = np.array([np.datetime64('2013-01-01'),
                         np.datetime64('2013-01-02'),
                         np.datetime64('2013-01-03')])
         result, bins = cut(data, 3, retbins=True)

--- a/pandas/tools/tests/test_tile.py
+++ b/pandas/tools/tests/test_tile.py
@@ -12,7 +12,7 @@ import pandas.core.common as com
 from pandas.core.algorithms import quantile
 from pandas.tools.tile import cut, qcut
 import pandas.tools.tile as tmod
-from pandas import to_datetime
+from pandas import to_datetime, DatetimeIndex
 
 
 class TestCut(tm.TestCase):
@@ -303,7 +303,7 @@ class TestCut(tm.TestCase):
                           '(2013-01-01 16:00:00, 2013-01-02 08:00:00]',
                            '(2013-01-02 08:00:00, 2013-01-03 00:00:00]'],
                           ).astype("category", ordered=True)
-        tm.assert_almost_equal(Series(result), expected)
+        tm.assert_series_equal(Series(result), expected)
 
     def test_datetime_ndarray_cut(self):
         # GH 14714
@@ -315,7 +315,17 @@ class TestCut(tm.TestCase):
                           '(2013-01-01 16:00:00, 2013-01-02 08:00:00]',
                            '(2013-01-02 08:00:00, 2013-01-03 00:00:00]'],
                           ).astype("category", ordered=True)
-        tm.assert_almost_equal(Series(result), expected)
+        tm.assert_series_equal(Series(result), expected)
+
+    def test_datetime_index_cut(self):
+        # GH 14714
+        data = DatetimeIndex(['2013-01-01', '2013-01-02', '2013-01-03'])
+        result, bins = cut(data, 3, retbins=True)
+        expected = Series(['(2012-12-31 23:57:07.200000, 2013-01-01 16:00:00]',
+                          '(2013-01-01 16:00:00, 2013-01-02 08:00:00]',
+                           '(2013-01-02 08:00:00, 2013-01-03 00:00:00]'],
+                          ).astype("category", ordered=True)
+        tm.assert_series_equal(Series(result), expected)
 
 
 def curpath():

--- a/pandas/tools/tests/test_tile.py
+++ b/pandas/tools/tests/test_tile.py
@@ -12,6 +12,7 @@ import pandas.core.common as com
 from pandas.core.algorithms import quantile
 from pandas.tools.tile import cut, qcut
 import pandas.tools.tile as tmod
+from pandas import to_datetime
 
 
 class TestCut(tm.TestCase):
@@ -282,6 +283,16 @@ class TestCut(tm.TestCase):
         s = Series([-9., -9.])
         result = cut(s, 1, labels=False)
         tm.assert_series_equal(result, expected)
+
+    def test_datetime_cut(self):
+        data = to_datetime(Series(['2013-01-01', '2013-01-02', '2013-01-03']))
+        result = cut(data, 3)
+        self.assertEqual(result[0],
+                         '(2012-12-31 23:57:07.200000, 2013-01-01 16:00:00]')
+        self.assertEqual(result[1],
+                         '(2013-01-01 16:00:00, 2013-01-02 08:00:00]')
+        self.assertEqual(result[2],
+                         '(2013-01-02 08:00:00, 2013-01-03 00:00:00]')
 
 
 def curpath():

--- a/pandas/tools/tests/test_tile.py
+++ b/pandas/tools/tests/test_tile.py
@@ -302,7 +302,6 @@ class TestCut(tm.TestCase):
         tm.assert_series_equal(Series(result), expected)
 
         # testing for time data to be present as ndarray
-
         data = np.array([np.datetime64('2013-01-01'),
                         np.datetime64('2013-01-02'),
                         np.datetime64('2013-01-03')])

--- a/pandas/tools/tests/test_tile.py
+++ b/pandas/tools/tests/test_tile.py
@@ -285,14 +285,14 @@ class TestCut(tm.TestCase):
         tm.assert_series_equal(result, expected)
 
     def test_datetime_cut(self):
+        # GH 14714
         data = to_datetime(Series(['2013-01-01', '2013-01-02', '2013-01-03']))
-        result = cut(data, 3)
-        self.assertEqual(result[0],
-                         '(2012-12-31 23:57:07.200000, 2013-01-01 16:00:00]')
-        self.assertEqual(result[1],
-                         '(2013-01-01 16:00:00, 2013-01-02 08:00:00]')
-        self.assertEqual(result[2],
-                         '(2013-01-02 08:00:00, 2013-01-03 00:00:00]')
+        result, bins = cut(data, 3, retbins=True)
+        expected = Series(['(2012-12-31 23:57:07.200000, 2013-01-01 16:00:00]',
+                          '(2013-01-01 16:00:00, 2013-01-02 08:00:00]',
+                           '(2013-01-02 08:00:00, 2013-01-03 00:00:00]'],
+                          ).astype("category", ordered=True)
+        tm.assert_series_equal(result, expected)
 
 
 def curpath():

--- a/pandas/tools/tile.py
+++ b/pandas/tools/tile.py
@@ -83,6 +83,7 @@ def cut(x, bins, right=True, labels=None, retbins=False, precision=3,
     """
     # NOTE: this binning code is changed a bit from histogram for var(x) == 0
     # for handling the cut for datetime and timedelta objects
+    x_is_series, series_index, name, x = _preprocess_for_cut(x)
 
     original, x, dtype = _coerce_to_type(x)
 
@@ -118,8 +119,6 @@ def cut(x, bins, right=True, labels=None, retbins=False, precision=3,
         bins = np.asarray(bins)
         if (np.diff(bins) < 0).any():
             raise ValueError('bins must increase monotonically.')
-
-    x_is_series, series_index, name, x = _preprocess_for_cut(x)
 
     fac, bins = _bins_to_cuts(x, bins, right=right, labels=labels,
                               retbins=retbins, precision=precision,
@@ -176,9 +175,9 @@ def qcut(x, q, labels=None, retbins=False, precision=3):
     >>> pd.qcut(range(5), 4, labels=False)
     array([0, 0, 1, 2, 3], dtype=int64)
     """
-    original, x, dtype = _coerce_to_type(x)
-
     x_is_series, series_index, name, x = _preprocess_for_cut(x)
+
+    original, x, dtype = _coerce_to_type(x)
 
     if is_integer(q):
         quantiles = np.linspace(0, 1, q + 1)

--- a/pandas/tools/tile.py
+++ b/pandas/tools/tile.py
@@ -87,11 +87,11 @@ def cut(x, bins, right=True, labels=None, retbins=False, precision=3,
 
     dtype = None
     if is_timedelta64_dtype(x):
-        x = x.astype(np.int64)
+        x = x.view(np.int64)
         dtype = np.timedelta64
 
     if is_datetime64_dtype(x):
-        x = x.astype(np.int64)
+        x = x.view(np.int64)
         dtype = np.datetime64
 
     if not np.iterable(bins):
@@ -181,11 +181,11 @@ def qcut(x, q, labels=None, retbins=False, precision=3):
     """
     dtype = None
     if is_timedelta64_dtype(x):
-        x = x.astype(np.int64)
+        x = x.view(np.int64)
         dtype = np.timedelta64
 
     if is_datetime64_dtype(x):
-        x = x.astype(np.int64)
+        x = x.view(np.int64)
         dtype = np.datetime64
 
     if is_integer(q):
@@ -289,9 +289,9 @@ def _format_levels(bins, prec, right=True,
 def _format_label(x, precision=3, dtype=None):
     fmt_str = '%%.%dg' % precision
 
-    if dtype == np.datetime64:
+    if is_datetime64_dtype(dtype):
         return to_datetime(x, unit='ns')
-    if dtype == np.timedelta64:
+    if is_timedelta64_dtype(dtype):
         return to_timedelta(x, unit='ns')
     if np.isinf(x):
         return str(x)

--- a/pandas/tools/tile.py
+++ b/pandas/tools/tile.py
@@ -83,9 +83,9 @@ def cut(x, bins, right=True, labels=None, retbins=False, precision=3,
     array([1, 1, 1, 1, 1], dtype=int64)
     """
     # NOTE: this binning code is changed a bit from histogram for var(x) == 0
+
     # for handling the cut for datetime and timedelta objects
     x_is_series, series_index, name, x = _preprocess_for_cut(x)
-
     x, dtype = _coerce_to_type(x)
 
     if not np.iterable(bins):
@@ -316,13 +316,14 @@ def _coerce_to_type(x):
     handle it
     """
     dtype = None
+
     if is_timedelta64_dtype(x):
         x = to_timedelta(x).view(np.int64)
         dtype = np.timedelta64
-
     elif is_datetime64_dtype(x):
         x = to_datetime(x).view(np.int64)
         dtype = np.datetime64
+
     return x, dtype
 
 
@@ -334,8 +335,8 @@ def _preprocess_for_cut(x):
     """
     x_is_series = isinstance(x, Series)
     series_index = None
-
     name = None
+
     if x_is_series:
         series_index = x.index
         name = x.name

--- a/pandas/tools/tile.py
+++ b/pandas/tools/tile.py
@@ -179,13 +179,23 @@ def qcut(x, q, labels=None, retbins=False, precision=3):
     >>> pd.qcut(range(5), 4, labels=False)
     array([0, 0, 1, 2, 3], dtype=int64)
     """
+    dtype = None
+    if is_timedelta64_dtype(x):
+        x = x.astype(np.int64)
+        dtype = np.timedelta64
+
+    if is_datetime64_dtype(x):
+        x = x.astype(np.int64)
+        dtype = np.datetime64
+
     if is_integer(q):
         quantiles = np.linspace(0, 1, q + 1)
     else:
         quantiles = q
     bins = algos.quantile(x, quantiles)
     return _bins_to_cuts(x, bins, labels=labels, retbins=retbins,
-                         precision=precision, include_lowest=True)
+                         precision=precision, include_lowest=True,
+                         dtype=dtype)
 
 
 def _bins_to_cuts(x, bins, right=True, labels=None, retbins=False,

--- a/pandas/tools/tile.py
+++ b/pandas/tools/tile.py
@@ -255,7 +255,7 @@ def _bins_to_cuts(x, bins, right=True, labels=None, retbins=False,
 
 def _format_levels(bins, prec, right=True,
                    include_lowest=False, dtype=None):
-    fmt = lambda v: _format_label(v, precision=prec)
+    fmt = lambda v: _format_label(v, precision=prec, dtype=dtype)
     if right:
         levels = []
         for a, b in zip(bins, bins[1:]):
@@ -264,36 +264,25 @@ def _format_levels(bins, prec, right=True,
             if a != b and fa == fb:
                 raise ValueError('precision too low')
 
-            if dtype == np.datetime64:
-                formatted = '(%s, %s]' % (to_datetime(float(fa), unit='ns'),
-                                          to_datetime(float(fb), unit='ns'))
-            elif dtype == np.timedelta64:
-                formatted = '(%s, %s]' % (to_timedelta(float(fa), unit='ns'),
-                                          to_timedelta(float(fb), unit='ns'))
-            else:
-                formatted = '(%s, %s]' % (fa, fb)
+            formatted = '(%s, %s]' % (fa, fb)
 
             levels.append(formatted)
 
         if include_lowest:
             levels[0] = '[' + levels[0][1:]
     else:
-        if dtype == np.datetime64:
-            levels = ['[%s, %s)' % (to_datetime(float(fmt(fa)), unit='ns'),
-                      to_datetime(float(fmt(b)), unit='ns'))
-                      for a, b in zip(bins, bins[1:])]
-        elif dtype == np.timedelta64:
-            levels = ['[%s, %s)' % (to_timedelta(float(fmt(fa)), unit='ns'),
-                      to_timedelta(float(fmt(b)), unit='ns'))
-                      for a, b in zip(bins, bins[1:])]
-        else:
-            levels = ['[%s, %s)' % (fmt(a), fmt(b))
-                      for a, b in zip(bins, bins[1:])]
+        levels = ['[%s, %s)' % (fmt(a), fmt(b))
+                  for a, b in zip(bins, bins[1:])]
     return levels
 
 
-def _format_label(x, precision=3):
+def _format_label(x, precision=3, dtype=None):
     fmt_str = '%%.%dg' % precision
+
+    if dtype == np.datetime64:
+        return to_datetime(x, unit='ns')
+    if dtype == np.timedelta64:
+        return to_timedelta(x, unit='ns')
     if np.isinf(x):
         return str(x)
     elif is_float(x):

--- a/pandas/tools/tile.py
+++ b/pandas/tools/tile.py
@@ -311,11 +311,11 @@ def _trim_zeros(x):
 
 
 def _coerce_to_type(x):
-    '''
+    """
     if the passed data is of datetime/timedelta type,
     this method converts it to integer so that cut method can
     handle it
-    '''
+    """
     dtype = None
     original = x
     if is_timedelta64_dtype(x):
@@ -329,11 +329,11 @@ def _coerce_to_type(x):
 
 
 def _preprocess_for_cut(x):
-    '''
+    """
     handles preprocessing for cut where we convert passed
     input to array, strip the index information and store it
     seperately
-    '''
+    """
     x_is_series = isinstance(x, Series)
     series_index = None
 
@@ -349,11 +349,11 @@ def _preprocess_for_cut(x):
 
 
 def _postprocess_for_cut(fac, bins, retbins, x_is_series, series_index, name):
-    '''
+    """
     handles post processing for the cut method where
     we combine the index information if the originally passed
     datatype was a series
-    '''
+    """
     if x_is_series:
         fac = Series(fac, index=series_index, name=name)
 

--- a/pandas/tools/tile.py
+++ b/pandas/tools/tile.py
@@ -11,7 +11,8 @@ from pandas.core.categorical import Categorical
 import pandas.core.algorithms as algos
 import pandas.core.nanops as nanops
 from pandas.compat import zip
-
+from pandas.tseries.timedeltas import to_timedelta
+from pandas.types.common import (needs_i8_conversion)
 import numpy as np
 
 
@@ -81,6 +82,13 @@ def cut(x, bins, right=True, labels=None, retbins=False, precision=3,
     array([1, 1, 1, 1, 1], dtype=int64)
     """
     # NOTE: this binning code is changed a bit from histogram for var(x) == 0
+    # for handling the cut for datetime and timedelta objects
+    if needs_i8_conversion(x):
+        x = x.values.view('i8')
+        time_data = True
+    else:
+        time_data = False
+
     if not np.iterable(bins):
         if is_scalar(bins) and bins < 1:
             raise ValueError("`bins` should be a positive integer.")
@@ -116,7 +124,7 @@ def cut(x, bins, right=True, labels=None, retbins=False, precision=3,
 
     return _bins_to_cuts(x, bins, right=right, labels=labels,
                          retbins=retbins, precision=precision,
-                         include_lowest=include_lowest)
+                         include_lowest=include_lowest, time_data=time_data)
 
 
 def qcut(x, q, labels=None, retbins=False, precision=3):
@@ -176,7 +184,8 @@ def qcut(x, q, labels=None, retbins=False, precision=3):
 
 
 def _bins_to_cuts(x, bins, right=True, labels=None, retbins=False,
-                  precision=3, name=None, include_lowest=False):
+                  precision=3, name=None, include_lowest=False,
+                  time_data=False):
     x_is_series = isinstance(x, Series)
     series_index = None
 
@@ -205,7 +214,8 @@ def _bins_to_cuts(x, bins, right=True, labels=None, retbins=False,
             while True:
                 try:
                     levels = _format_levels(bins, precision, right=right,
-                                            include_lowest=include_lowest)
+                                            include_lowest=include_lowest,
+                                            time_data=time_data)
                 except ValueError:
                     increases += 1
                     precision += 1
@@ -239,7 +249,7 @@ def _bins_to_cuts(x, bins, right=True, labels=None, retbins=False,
 
 
 def _format_levels(bins, prec, right=True,
-                   include_lowest=False):
+                   include_lowest=False, time_data=False):
     fmt = lambda v: _format_label(v, precision=prec)
     if right:
         levels = []
@@ -249,16 +259,24 @@ def _format_levels(bins, prec, right=True,
             if a != b and fa == fb:
                 raise ValueError('precision too low')
 
-            formatted = '(%s, %s]' % (fa, fb)
+            if time_data:
+                formatted = '(%s, %s]' % (to_timedelta(float(fa), unit='ns'),
+                                          to_timedelta(float(fb), unit='ns'))
+            else:
+                formatted = '(%s, %s]' % (fa, fb)
 
             levels.append(formatted)
 
         if include_lowest:
             levels[0] = '[' + levels[0][1:]
     else:
-        levels = ['[%s, %s)' % (fmt(a), fmt(b))
-                  for a, b in zip(bins, bins[1:])]
-
+        if time_data:
+            levels = ['[%s, %s)' % (to_timedelta(float(fmt(fa)), unit='ns'),
+                      to_timedelta(float(fmt(b)), unit='ns'))
+                      for a, b in zip(bins, bins[1:])]
+        else:
+            levels = ['[%s, %s)' % (fmt(a), fmt(b))
+                      for a, b in zip(bins, bins[1:])]
     return levels
 
 

--- a/pandas/tools/tile.py
+++ b/pandas/tools/tile.py
@@ -314,11 +314,11 @@ def _coerce_to_type(x):
     dtype = None
     original = x
     if is_timedelta64_dtype(x):
-        x = x.view(np.int64)
+        x = to_timedelta(x).view(np.int64)
         dtype = np.timedelta64
 
     elif is_datetime64_dtype(x):
-        x = x.view(np.int64)
+        x = to_datetime(x).view(np.int64)
         dtype = np.datetime64
     return original, x, dtype
 

--- a/pandas/tools/tile.py
+++ b/pandas/tools/tile.py
@@ -11,10 +11,9 @@ from pandas.core.categorical import Categorical
 import pandas.core.algorithms as algos
 import pandas.core.nanops as nanops
 from pandas.compat import zip
-from pandas import to_timedelta
-from pandas import to_datetime
+from pandas import to_timedelta, to_datetime
 import numpy as np
-from pandas.types.common import (is_datetime64_dtype, is_timedelta64_dtype)
+from pandas.types.common import is_datetime64_dtype, is_timedelta64_dtype
 
 
 def cut(x, bins, right=True, labels=None, retbins=False, precision=3,
@@ -85,14 +84,7 @@ def cut(x, bins, right=True, labels=None, retbins=False, precision=3,
     # NOTE: this binning code is changed a bit from histogram for var(x) == 0
     # for handling the cut for datetime and timedelta objects
 
-    dtype = None
-    if is_timedelta64_dtype(x):
-        x = x.view(np.int64)
-        dtype = np.timedelta64
-
-    elif is_datetime64_dtype(x):
-        x = x.view(np.int64)
-        dtype = np.datetime64
+    original, x, dtype = _coerce_to_type(x)
 
     if not np.iterable(bins):
         if is_scalar(bins) and bins < 1:
@@ -179,14 +171,7 @@ def qcut(x, q, labels=None, retbins=False, precision=3):
     >>> pd.qcut(range(5), 4, labels=False)
     array([0, 0, 1, 2, 3], dtype=int64)
     """
-    dtype = None
-    if is_timedelta64_dtype(x):
-        x = x.view(np.int64)
-        dtype = np.timedelta64
-
-    elif is_datetime64_dtype(x):
-        x = x.view(np.int64)
-        dtype = np.datetime64
+    original, x, dtype = _coerce_to_type(x)
 
     if is_integer(q):
         quantiles = np.linspace(0, 1, q + 1)
@@ -329,3 +314,16 @@ def _trim_zeros(x):
     if len(x) > 1 and x[-1] == '.':
         x = x[:-1]
     return x
+
+
+def _coerce_to_type(x):
+    dtype = None
+    original = x
+    if is_timedelta64_dtype(x):
+        x = x.view(np.int64)
+        dtype = np.timedelta64
+
+    elif is_datetime64_dtype(x):
+        x = x.view(np.int64)
+        dtype = np.datetime64
+    return original, x, dtype

--- a/pandas/tools/tile.py
+++ b/pandas/tools/tile.py
@@ -332,6 +332,9 @@ def _preprocess_for_cut(x):
         series_index = x.index
         if name is None:
             name = x.name
+
+    x = np.asarray(x)
+
     return x_is_series, series_index, name, x
 
 

--- a/pandas/tools/tile.py
+++ b/pandas/tools/tile.py
@@ -311,6 +311,11 @@ def _trim_zeros(x):
 
 
 def _coerce_to_type(x):
+    '''
+    if the passed data is of datetime/timedelta type,
+    this method converts it to integer so that cut method can
+    handle it
+    '''
     dtype = None
     original = x
     if is_timedelta64_dtype(x):
@@ -324,6 +329,11 @@ def _coerce_to_type(x):
 
 
 def _preprocess_for_cut(x):
+    '''
+    handles preprocessing for cut where we convert passed
+    input to array, strip the index information and store it
+    seperately
+    '''
     x_is_series = isinstance(x, Series)
     series_index = None
 
@@ -339,6 +349,11 @@ def _preprocess_for_cut(x):
 
 
 def _postprocess_for_cut(fac, bins, retbins, x_is_series, series_index, name):
+    '''
+    handles post processing for the cut method where
+    we combine the index information if the originally passed
+    datatype was a series
+    '''
     if x_is_series:
         fac = Series(fac, index=series_index, name=name)
 

--- a/pandas/tools/tile.py
+++ b/pandas/tools/tile.py
@@ -11,7 +11,7 @@ from pandas.core.categorical import Categorical
 import pandas.core.algorithms as algos
 import pandas.core.nanops as nanops
 from pandas.compat import zip
-from pandas.tseries.timedeltas import to_timedelta
+from pandas import to_timedelta
 from pandas import to_datetime
 import numpy as np
 from pandas.types.common import (is_datetime64_dtype, is_timedelta64_dtype)
@@ -90,7 +90,7 @@ def cut(x, bins, right=True, labels=None, retbins=False, precision=3,
         x = x.view(np.int64)
         dtype = np.timedelta64
 
-    if is_datetime64_dtype(x):
+    elif is_datetime64_dtype(x):
         x = x.view(np.int64)
         dtype = np.datetime64
 
@@ -184,7 +184,7 @@ def qcut(x, q, labels=None, retbins=False, precision=3):
         x = x.view(np.int64)
         dtype = np.timedelta64
 
-    if is_datetime64_dtype(x):
+    elif is_datetime64_dtype(x):
         x = x.view(np.int64)
         dtype = np.datetime64
 


### PR DESCRIPTION
 - [x] closes #14714
 - [x] tests added / passed
 - [x] passes ``git diff upstream/master | flake8 --diff``
 - [x] whatsnew entry

