### PR TITLE
TST: Correct results with np.size and crosstab (#4003)

### DIFF
--- a/pandas/tools/tests/test_pivot.py
+++ b/pandas/tools/tests/test_pivot.py
@@ -1281,6 +1281,41 @@ class TestCrosstab(tm.TestCase):
                                 columns=expected_columns)
         tm.assert_frame_equal(result, expected)
 
+    def test_crosstab_with_numpy_size(self):
+        # GH 4003
+        df = pd.DataFrame({'A': ['one', 'one', 'two', 'three'] * 6,
+                           'B': ['A', 'B', 'C'] * 8,
+                           'C': ['foo', 'foo', 'foo', 'bar', 'bar', 'bar'] * 4,
+                           'D': np.random.randn(24),
+                           'E': np.random.randn(24)})
+        result = pd.crosstab(index=[df['A'], df['B']],
+                             columns=[df['C']],
+                             margins=True,
+                             aggfunc=np.size,
+                             values=df['D'])
+        expected_index = pd.MultiIndex(levels=[['All', 'one', 'three', 'two'],
+                                               ['', 'A', 'B', 'C']],
+                                       labels=[[1, 1, 1, 2, 2, 2, 3, 3, 3, 0],
+                                               [1, 2, 3, 1, 2, 3, 1, 2, 3, 0]],
+                                       names=['A', 'B'])
+        expected_column = pd.Index(['bar', 'foo', 'All'],
+                                   dtype='object',
+                                   name='C')
+        expected_data = np.array([[2., 2., 4.],
+                                  [2., 2., 4.],
+                                  [2., 2., 4.],
+                                  [2., np.nan, 2.],
+                                  [np.nan, 2., 2.],
+                                  [2., np.nan, 2.],
+                                  [np.nan, 2., 2.],
+                                  [2., np.nan, 2.],
+                                  [np.nan, 2., 2.],
+                                  [12., 12., 24.]])
+        expected = pd.DataFrame(expected_data,
+                                index=expected_index,
+                                columns=expected_column)
+        tm.assert_frame_equal(result, expected)
+
 
 if __name__ == '__main__':
     import nose


### PR DESCRIPTION
 - [x] closes #4003
 - [x] tests added / passed
 - [x] passes ``git diff upstream/master | flake8 --diff``

