### PR TITLE
BF: (re)raise the exception always unless returning

### DIFF
--- a/pandas/io/tests/json/test_pandas.py
+++ b/pandas/io/tests/json/test_pandas.py
@@ -167,7 +167,7 @@ class TestPandasContainer(tm.TestCase):
                 if raise_ok is not None:
                     if isinstance(detail, raise_ok):
                         return
-                    raise
+                raise
 
             if sort is not None and sort in unser.columns:
                 unser = unser.sort_values(sort)


### PR DESCRIPTION
coding logic flaw is obvious (leaves unser used later undefined), so no dedicated test was found

otherwise leads atm to masking of this error while testing on i386 and then failling with

UnboundLocalError: local variable unser referenced before assignment

More detail: https://buildd.debian.org/status/fetch.php?pkg=pandas&arch=i386&ver=0.19.1-1&stamp=1479504883