### PR TITLE
BUG: Error upon Series.Groupby.nunique with empty Series (#12553)

### DIFF
--- a/doc/source/whatsnew/v0.19.2.txt
+++ b/doc/source/whatsnew/v0.19.2.txt
@@ -57,7 +57,7 @@ Bug Fixes
 - Bug in resampling a ``DatetimeIndex`` in local TZ, covering a DST change, which would raise ``AmbiguousTimeError`` (:issue:`14682`)
 
 
-
+- Bug in ``Series.groupby.nunique()`` raising an ``IndexError`` for an empty ``Series`` (:issue:`12553`)
 
 
 

--- a/pandas/core/groupby.py
+++ b/pandas/core/groupby.py
@@ -2898,6 +2898,7 @@ class SeriesGroupBy(GroupBy):
     def nunique(self, dropna=True):
         """ Returns number of unique elements in the group """
         ids, _, _ = self.grouper.group_info
+
         val = self.obj.get_values()
 
         try:
@@ -2928,7 +2929,10 @@ class SeriesGroupBy(GroupBy):
             inc[idx] = 1
 
         out = np.add.reduceat(inc, idx).astype('int64', copy=False)
-        res = out if ids[0] != -1 else out[1:]
+        if len(ids):
+            res = out if ids[0] != -1 else out[1:]
+        else:
+            res = out[1:]
         ri = self.grouper.result_index
 
         # we might have duplications among the bins

--- a/pandas/tests/test_groupby.py
+++ b/pandas/tests/test_groupby.py
@@ -6754,6 +6754,13 @@ class TestGroupBy(tm.TestCase):
         expected = pd.Series([1] * 5, name='name', index=index)
         tm.assert_series_equal(result, expected)
 
+    def test_nunique_with_empty_series(self):
+        # GH 12553
+        data = pd.Series(name='name')
+        result = data.groupby(level=0).nunique()
+        expected = pd.Series(name='name', dtype='int64')
+        tm.assert_series_equal(result, expected)
+
     def test_transform_with_non_scalar_group(self):
         # GH 10165
         cols = pd.MultiIndex.from_tuples([


### PR DESCRIPTION
 - [x] closes #12553
 - [x] tests added / passed
 - [x] passes ``git diff upstream/master | flake8 --diff``
 - [x] whatsnew entry

Similar to #12560, but it has appeared to stall. Wanted to push it along.  