### PR TITLE
 allowing datetime and timedelta datatype in pd cut bins

### DIFF
--- a/pandas/tools/tests/test_tile.py
+++ b/pandas/tools/tests/test_tile.py
@@ -313,6 +313,18 @@ class TestCut(tm.TestCase):
         result, bins = cut(data, 3, retbins=True)
         tm.assert_series_equal(Series(result), expected)
 
+    def test_datetime_bin(self):
+        data = [np.datetime64('2012-12-13'), np.datetime64('2012-12-15')]
+        bins = [np.datetime64('2012-12-12'), np.datetime64('2012-12-14'),
+                np.datetime64('2012-12-16')]
+        result = cut(data, bins=bins)
+
+        expected = Series(['(2012-12-12 00:00:00, 2012-12-14 00:00:00]',
+                           '(2012-12-14 00:00:00, 2012-12-16 00:00:00]'],
+                          ).astype("category", ordered=True)
+
+        tm.assert_series_equal(Series(result), expected)
+
 
 def curpath():
     pth, _ = os.path.split(os.path.abspath(__file__))

--- a/pandas/tools/tests/test_tile.py
+++ b/pandas/tools/tests/test_tile.py
@@ -12,7 +12,7 @@ import pandas.core.common as com
 from pandas.core.algorithms import quantile
 from pandas.tools.tile import cut, qcut
 import pandas.tools.tile as tmod
-from pandas import to_datetime, DatetimeIndex
+from pandas import to_datetime, DatetimeIndex, Timestamp
 
 
 class TestCut(tm.TestCase):
@@ -315,14 +315,22 @@ class TestCut(tm.TestCase):
 
     def test_datetime_bin(self):
         data = [np.datetime64('2012-12-13'), np.datetime64('2012-12-15')]
-        bins = [np.datetime64('2012-12-12'), np.datetime64('2012-12-14'),
-                np.datetime64('2012-12-16')]
-        result = cut(data, bins=bins)
-
+        bin_data = ['2012-12-12', '2012-12-14', '2012-12-16']
         expected = Series(['(2012-12-12 00:00:00, 2012-12-14 00:00:00]',
-                           '(2012-12-14 00:00:00, 2012-12-16 00:00:00]'],
+                          '(2012-12-14 00:00:00, 2012-12-16 00:00:00]'],
                           ).astype("category", ordered=True)
 
+        for conv in [Timestamp, Timestamp, np.datetime64]:
+            bins = [conv(v) for v in bin_data]
+            result = cut(data, bins=bins)
+            tm.assert_series_equal(Series(result), expected)
+
+        bin_pydatetime = [Timestamp(v).to_pydatetime() for v in bin_data]
+        result = cut(data, bins=bin_pydatetime)
+        tm.assert_series_equal(Series(result), expected)
+
+        bins = to_datetime(bin_data)
+        result = cut(data, bins=bin_pydatetime)
         tm.assert_series_equal(Series(result), expected)
 
 

--- a/pandas/tools/tile.py
+++ b/pandas/tools/tile.py
@@ -13,6 +13,7 @@ import pandas.core.nanops as nanops
 from pandas.compat import zip
 from pandas import to_timedelta, to_datetime
 from pandas.types.common import is_datetime64_dtype, is_timedelta64_dtype
+from pandas.lib import infer_dtype
 
 import numpy as np
 
@@ -116,7 +117,7 @@ def cut(x, bins, right=True, labels=None, retbins=False, precision=3,
 
     else:
         bins = np.asarray(bins)
-        bins, bin_dtype = _coerce_to_type(bins)
+        bins = _convert_bin_to_numeric_type(bins)
         if (np.diff(bins) < 0).any():
             raise ValueError('bins must increase monotonically.')
 
@@ -326,6 +327,19 @@ def _coerce_to_type(x):
         dtype = np.datetime64
 
     return x, dtype
+
+
+def _convert_bin_to_numeric_type(x):
+    """
+    if the passed bin is of datetime/timedelta type,
+    this method converts it to integer
+    """
+    dtype = infer_dtype(x)
+    if dtype == 'timedelta' or dtype == 'timedelta64':
+        x = to_timedelta(x).view(np.int64)
+    elif dtype == 'datetime' or dtype == 'datetime64':
+        x = to_datetime(x).view(np.int64)
+    return x
 
 
 def _preprocess_for_cut(x):

--- a/pandas/tools/tile.py
+++ b/pandas/tools/tile.py
@@ -116,6 +116,7 @@ def cut(x, bins, right=True, labels=None, retbins=False, precision=3,
 
     else:
         bins = np.asarray(bins)
+        bins, bin_dtype = _coerce_to_type(bins)
         if (np.diff(bins) < 0).any():
             raise ValueError('bins must increase monotonically.')
 


### PR DESCRIPTION
xref #14714, follow-on to #14737