### PR TITLE
DOC: Fix grammar and formatting typos 

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -2483,7 +2483,7 @@ class DataFrame(NDFrame):
         Notes
         -----
         Since ``kwargs`` is a dictionary, the order of your
-        arguments may not be preserved. The make things predicatable,
+        arguments may not be preserved. To make things predicatable,
         the columns are inserted in alphabetical order, at the end of
         your DataFrame. Assigning multiple columns within the same
         ``assign`` is possible, but you cannot reference other columns

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -3635,14 +3635,17 @@ class NDFrame(PandasObject):
               require that you also specify an `order` (int),
               e.g. df.interpolate(method='polynomial', order=4).
               These use the actual numerical values of the index.
-            * 'krogh', 'piecewise_polynomial', 'spline', 'pchip' and 'akima' are all
-              wrappers around the scipy interpolation methods of similar
-              names. These use the actual numerical values of the index. See
-              the scipy documentation for more on their behavior
-              `here <http://docs.scipy.org/doc/scipy/reference/interpolate.html#univariate-interpolation>`__  # noqa
-              `and here <http://docs.scipy.org/doc/scipy/reference/tutorial/interpolate.html>`__  # noqa
+            * 'krogh', 'piecewise_polynomial', 'spline', 'pchip' and 'akima'
+              are all wrappers around the scipy interpolation methods of
+              similar names. These use the actual numerical values of the
+              index. For more information on their behavior, see the
+              `scipy documentation
+              <http://docs.scipy.org/doc/scipy/reference/interpolate.html#univariate-interpolation>`__
+              and `tutorial documentation
+              <http://docs.scipy.org/doc/scipy/reference/tutorial/interpolate.html>`__
             * 'from_derivatives' refers to BPoly.from_derivatives which
-              replaces 'piecewise_polynomial' interpolation method in scipy 0.18
+              replaces 'piecewise_polynomial' interpolation method in
+              scipy 0.18
 
             .. versionadded:: 0.18.1
 
@@ -3656,7 +3659,7 @@ class NDFrame(PandasObject):
             * 1: fill row-by-row
         limit : int, default None.
             Maximum number of consecutive NaNs to fill.
-        limit_direction : {'forward', 'backward', 'both'}, defaults to 'forward'
+        limit_direction : {'forward', 'backward', 'both'}, default 'forward'
             If limit is specified, consecutive NaNs will be filled in this
             direction.
 
@@ -4159,6 +4162,9 @@ class NDFrame(PandasObject):
 
             .. versionadded:: 0.19.0
 
+        Notes
+        -----
+
         To learn more about the offset strings, please see `this link
         <http://pandas.pydata.org/pandas-docs/stable/timeseries.html#offset-aliases>`__.
 
@@ -4346,7 +4352,7 @@ class NDFrame(PandasObject):
 
         Parameters
         ----------
-        axis: {0 or 'index', 1 or 'columns'}, default 0
+        axis : {0 or 'index', 1 or 'columns'}, default 0
             index to direct ranking
         method : {'average', 'min', 'max', 'first', 'dense'}
             * average: average rank of group

--- a/pandas/core/ops.py
+++ b/pandas/core/ops.py
@@ -1006,7 +1006,7 @@ missing data in one of the inputs.
 
 Parameters
 ----------
-other: Series or scalar value
+other : Series or scalar value
 fill_value : None or float value, default None (NaN)
     Fill missing (NaN) values with this value. If both Series are
     missing, the result will be missing

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -2033,9 +2033,9 @@ class Series(base.IndexOpsMixin, strings.StringAccessorMixin,
 
         Parameters
         ----------
-        order: list of int representing new level order.
+        order : list of int representing new level order.
                (reference level by number or key)
-        axis: where to reorder levels
+        axis : where to reorder levels
 
         Returns
         -------

--- a/pandas/tools/plotting.py
+++ b/pandas/tools/plotting.py
@@ -2893,8 +2893,9 @@ def hist_frame(data, column=None, by=None, grid=True, xlabelsize=None,
         invisible
     figsize : tuple
         The size of the figure to create in inches by default
-    layout: (optional) a tuple (rows, columns) for the layout of the histograms
-    bins: integer, default 10
+    layout : tuple, optional
+        Tuple of (rows, columns) for the layout of the histograms
+    bins : integer, default 10
         Number of histogram bins to be used
     kwds : other plotting keyword arguments
         To be passed to hist function

--- a/pandas/tseries/index.py
+++ b/pandas/tseries/index.py
@@ -2000,7 +2000,7 @@ def date_range(start=None, end=None, periods=None, freq='D', tz=None,
         Frequency strings can have multiples, e.g. '5H'
     tz : string or None
         Time zone name for returning localized DatetimeIndex, for example
-    Asia/Hong_Kong
+        Asia/Hong_Kong
     normalize : bool, default False
         Normalize start/end dates to midnight before generating date range
     name : str, default None


### PR DESCRIPTION
One grammatical typo, and the rest address small formatting typos when rendering online.  