### PR TITLE
BUG: Fix linux clipboard QApplication() creation

### DIFF
--- a/pandas/util/clipboard/clipboards.py
+++ b/pandas/util/clipboard/clipboards.py
@@ -50,7 +50,7 @@ def init_qt_clipboard():
     # $DISPLAY should exist
     from PyQt4.QtGui import QApplication
 
-    app = QApplication([])
+    app = QApplication.instance() or QApplication([])
 
     def copy_qt(text):
         cb = app.clipboard()


### PR DESCRIPTION
 - [x] closes #14372

A Qt application cannot instantiate multiple `QApplication` instances,
so we create a new `QApplication` only when the global
`QApplication.instance()` is None.

Failing sample (gtk should not be installed for pandas to use qt clipboard):

```
from PyQt4.QtGui import QApplication
myapp = QApplication([])
from pandas.util.clipboard import clipboard_get  # <--- ERROR

  File "prefix/lib/python2.7/site-packages/pandas/util/clipboard.py", line 164, in <module>

    app = qt4.QtGui.QApplication([])

RuntimeError: A QApplication instance already exists.

```