### PR TITLE
Changed pandas-qt python2/3 friendly qtpandas.

### DIFF
--- a/doc/source/faq.rst
+++ b/doc/source/faq.rst
@@ -111,5 +111,5 @@ Visualizing Data in Qt applications
 -----------------------------------
 
 There is no support for such visualization in pandas. However, the external
-package `pandas-qt <https://github.com/datalyze-solutions/pandas-qt>`_ does
+package `qtpandas <https://github.com/draperjames/qtpandas>`_ does
 provide this functionality.


### PR DESCRIPTION
Just changed the link to the abandoned repository python 2 only pandas-qt to the new functional Python 2/3 friendly qtpandas.