### PR TITLE
frame_methods benchmarking sum instead of mean

### DIFF
--- a/asv_bench/benchmarks/frame_methods.py
+++ b/asv_bench/benchmarks/frame_methods.py
@@ -299,7 +299,7 @@ class Apply(object):
         self.df.apply((lambda x: (x + 1)), axis=1)
 
     def time_apply_lambda_mean(self):
-        self.df.apply((lambda x: x.sum()))
+        self.df.apply((lambda x: x.mean()))
 
     def time_apply_np_mean(self):
         self.df.apply(np.mean)


### PR DESCRIPTION
Not sure if the function name or the method call is incorrect, but it looks like this should be benchmarking `mean` instead of `sum`

