### PR TITLE
BF(TST): use = (native) instead of < (little endian) for target data types

### DIFF
--- a/pandas/io/tests/parser/common.py
+++ b/pandas/io/tests/parser/common.py
@@ -1453,7 +1453,7 @@ j,-inF"""
                 FutureWarning, check_stacklevel=False):
             data = 'a,b\n1,a\n2,b'
             expected = np.array([(1, 'a'), (2, 'b')],
-                                dtype=[('a', '<i8'), ('b', 'O')])
+                                dtype=[('a', '=i8'), ('b', 'O')])
             out = self.read_csv(StringIO(data), as_recarray=True)
             tm.assert_numpy_array_equal(out, expected)
 
@@ -1462,7 +1462,7 @@ j,-inF"""
                 FutureWarning, check_stacklevel=False):
             data = 'a,b\n1,a\n2,b'
             expected = np.array([(1, 'a'), (2, 'b')],
-                                dtype=[('a', '<i8'), ('b', 'O')])
+                                dtype=[('a', '=i8'), ('b', 'O')])
             out = self.read_csv(StringIO(data), as_recarray=True, index_col=0)
             tm.assert_numpy_array_equal(out, expected)
 
@@ -1471,7 +1471,7 @@ j,-inF"""
                 FutureWarning, check_stacklevel=False):
             data = '1,a\n2,b'
             expected = np.array([(1, 'a'), (2, 'b')],
-                                dtype=[('a', '<i8'), ('b', 'O')])
+                                dtype=[('a', '=i8'), ('b', 'O')])
             out = self.read_csv(StringIO(data), names=['a', 'b'],
                                 header=None, as_recarray=True)
             tm.assert_numpy_array_equal(out, expected)
@@ -1482,7 +1482,7 @@ j,-inF"""
                 FutureWarning, check_stacklevel=False):
             data = 'b,a\n1,a\n2,b'
             expected = np.array([(1, 'a'), (2, 'b')],
-                                dtype=[('b', '<i8'), ('a', 'O')])
+                                dtype=[('b', '=i8'), ('a', 'O')])
             out = self.read_csv(StringIO(data), as_recarray=True)
             tm.assert_numpy_array_equal(out, expected)
 
@@ -1490,7 +1490,7 @@ j,-inF"""
         with tm.assert_produces_warning(
                 FutureWarning, check_stacklevel=False):
             data = 'a\n1'
-            expected = np.array([(1,)], dtype=[('a', '<i8')])
+            expected = np.array([(1,)], dtype=[('a', '=i8')])
             out = self.read_csv(StringIO(data), as_recarray=True, squeeze=True)
             tm.assert_numpy_array_equal(out, expected)
 
@@ -1500,7 +1500,7 @@ j,-inF"""
             data = 'a,b\n1,a\n2,b'
             conv = lambda x: int(x) + 1
             expected = np.array([(2, 'a'), (3, 'b')],
-                                dtype=[('a', '<i8'), ('b', 'O')])
+                                dtype=[('a', '=i8'), ('b', 'O')])
             out = self.read_csv(StringIO(data), as_recarray=True,
                                 converters={'a': conv})
             tm.assert_numpy_array_equal(out, expected)
@@ -1509,7 +1509,7 @@ j,-inF"""
         with tm.assert_produces_warning(
                 FutureWarning, check_stacklevel=False):
             data = 'a,b\n1,a\n2,b'
-            expected = np.array([(1,), (2,)], dtype=[('a', '<i8')])
+            expected = np.array([(1,), (2,)], dtype=[('a', '=i8')])
             out = self.read_csv(StringIO(data), as_recarray=True,
                                 usecols=['a'])
             tm.assert_numpy_array_equal(out, expected)

--- a/pandas/tests/series/test_datetime_values.py
+++ b/pandas/tests/series/test_datetime_values.py
@@ -326,7 +326,7 @@ class TestSeriesDatetimeValues(TestData, tm.TestCase):
         period_index = period_range('20150301', periods=5)
         result = period_index.strftime("%Y/%m/%d")
         expected = np.array(['2015/03/01', '2015/03/02', '2015/03/03',
-                             '2015/03/04', '2015/03/05'], dtype='<U10')
+                             '2015/03/04', '2015/03/05'], dtype='=U10')
         self.assert_numpy_array_equal(result, expected)
 
         s = Series([datetime(2013, 1, 1, 2, 32, 59), datetime(2013, 1, 2, 14,

--- a/pandas/tseries/tests/test_timeseries.py
+++ b/pandas/tseries/tests/test_timeseries.py
@@ -2991,7 +2991,7 @@ class TestDatetimeIndex(tm.TestCase):
 
         f = lambda x: x.strftime('%Y%m%d')
         result = rng.map(f)
-        exp = np.array([f(x) for x in rng], dtype='<U8')
+        exp = np.array([f(x) for x in rng], dtype='=U8')
         tm.assert_almost_equal(result, exp)
 
     def test_iteration_preserves_tz(self):


### PR DESCRIPTION
 - [ ] closes #14830
 - [ ] tests added / passed
 - [ ] passes ``git diff upstream/master | flake8 --diff``
 - [ ] whatsnew entry

It is still WiP -- just thought to submit a PR to see how travis etc reacts on typical platforms