### PR TITLE
BUG: Allow TZ-aware DatetimeIndex in merge_asof() (#14844)

### DIFF
--- a/doc/source/whatsnew/v0.19.2.txt
+++ b/doc/source/whatsnew/v0.19.2.txt
@@ -74,5 +74,6 @@ Bug Fixes
 - Bug in ``pd.read_csv()`` in which the ``nrows`` parameter was not being respected for large input when using the C engine for parsing (:issue:`7626`)
 
 
+- Bug in ``pd.merge_asof()`` could not handle timezone-aware DatetimeIndex when a tolerance was specified (:issue:`14844`)
 
 - Explicit check in ``to_stata`` and ``StataWriter`` for out-of-range values when writing doubles (:issue:`14618`)

--- a/pandas/tools/merge.py
+++ b/pandas/tools/merge.py
@@ -1021,7 +1021,7 @@ class _AsOfMerge(_OrderedMerge):
             msg = "incompatible tolerance, must be compat " \
                   "with type {0}".format(type(lt))
 
-            if is_datetime64_dtype(lt):
+            if is_datetime64_dtype(lt) or is_datetime64tz_dtype(lt):
                 if not isinstance(self.tolerance, Timedelta):
                     raise MergeError(msg)
                 if self.tolerance < Timedelta(0):
@@ -1034,7 +1034,7 @@ class _AsOfMerge(_OrderedMerge):
                     raise MergeError("tolerance must be positive")
 
             else:
-                raise MergeError(msg)
+                raise MergeError("key must be integer or timestamp")
 
         # validate allow_exact_matches
         if not is_bool(self.allow_exact_matches):

--- a/pandas/tools/tests/test_merge_asof.py
+++ b/pandas/tools/tests/test_merge_asof.py
@@ -293,6 +293,30 @@ class TestAsOfMerge(tm.TestCase):
         expected = self.tolerance
         assert_frame_equal(result, expected)
 
+    def test_tolerance_tz(self):
+        # GH 14844
+        import pytz
+        left = pd.DataFrame(
+            {'date': pd.DatetimeIndex(start=pd.to_datetime('2016-01-02'),
+                                      freq='D', periods=5,
+                                      tz=pytz.timezone('UTC')),
+             'value1': np.arange(5)})
+        right = pd.DataFrame(
+            {'date': pd.DatetimeIndex(start=pd.to_datetime('2016-01-01'),
+                                      freq='D', periods=5,
+                                      tz=pytz.timezone('UTC')),
+             'value2': list("ABCDE")})
+        result = pd.merge_asof(left, right, on='date',
+                               tolerance=pd.Timedelta('1 day'))
+
+        expected = pd.DataFrame(
+            {'date': pd.DatetimeIndex(start=pd.to_datetime('2016-01-02'),
+                                      freq='D', periods=5,
+                                      tz=pytz.timezone('UTC')),
+             'value1': np.arange(5),
+             'value2': list("BCDEE")})
+        assert_frame_equal(result, expected)
+
     def test_allow_exact_matches(self):
 
         result = merge_asof(self.trades, self.quotes,


### PR DESCRIPTION
 - [x] closes #14844 
 - [x] tests added / passed
 - [x] passes ``git diff upstream/master | flake8 --diff``
 - [x] whatsnew entry

