### PR TITLE
BUG: Spurious IncompatibleFrequency error prevented plotting of non-standard intervals (Fixes #14763)

### DIFF
--- a/pandas/src/period.pyx
+++ b/pandas/src/period.pyx
@@ -468,7 +468,7 @@ def extract_ordinals(ndarray[object] values, freq):
         ndarray[int64_t] ordinals = np.empty(n, dtype=np.int64)
         object p
 
-    freqstr = Period._maybe_convert_freq(freq).freqstr
+    rule_code = Period._maybe_convert_freq(freq).rule_code
 
     for i in range(n):
         p = values[i]
@@ -478,9 +478,9 @@ def extract_ordinals(ndarray[object] values, freq):
         else:
             try:
                 ordinals[i] = p.ordinal
-
-                if p.freqstr != freqstr:
-                    msg = _DIFFERENT_FREQ_INDEX.format(freqstr, p.freqstr)
+                ordinal_rule_code = Period._maybe_convert_freq(p.freq).rule_code
+                if ordinal_rule_code != rule_code:
+                    msg = _DIFFERENT_FREQ_INDEX.format(ordinal_rule_code, rule_code)
                     raise IncompatibleFrequency(msg)
 
             except AttributeError:

--- a/pandas/src/period.pyx
+++ b/pandas/src/period.pyx
@@ -468,7 +468,8 @@ def extract_ordinals(ndarray[object] values, freq):
         ndarray[int64_t] ordinals = np.empty(n, dtype=np.int64)
         object p
 
-    rule_code = Period._maybe_convert_freq(freq).rule_code
+    freqstr = Period._maybe_convert_freq(freq).freqstr
+    base_freq = frequencies.get_base_alias(freqstr)
 
     for i in range(n):
         p = values[i]
@@ -478,9 +479,10 @@ def extract_ordinals(ndarray[object] values, freq):
         else:
             try:
                 ordinals[i] = p.ordinal
-                ordinal_rule_code = Period._maybe_convert_freq(p.freq).rule_code
-                if ordinal_rule_code != rule_code:
-                    msg = _DIFFERENT_FREQ_INDEX.format(ordinal_rule_code, rule_code)
+
+                p_base_freq = frequencies.get_base_alias(p.freqstr)
+                if p_base_freq != base_freq:
+                    msg = _DIFFERENT_FREQ_INDEX.format(base_freq, p_base_freq)
                     raise IncompatibleFrequency(msg)
 
             except AttributeError:

--- a/pandas/tests/plotting/test_series.py
+++ b/pandas/tests/plotting/test_series.py
@@ -805,7 +805,7 @@ class TestSeriesPlots(TestPlotBase):
     def test_non_standard_intervals(self):
         idx = pd.period_range('2000-01-01', '2000-01-05', freq='6H')
         s = Series(np.random.randn(len(idx)), index=idx)
-        ax = _check_plot_works(s.plot)
+        _check_plot_works(s.plot)
 
 
 if __name__ == '__main__':

--- a/pandas/tests/plotting/test_series.py
+++ b/pandas/tests/plotting/test_series.py
@@ -802,6 +802,11 @@ class TestSeriesPlots(TestPlotBase):
 
         _check_plot_works(s.plot)
 
+    def test_non_standard_intervals(self):
+        idx = pd.period_range('2000-01-01', '2000-01-05', freq='6H')
+        s = Series(np.random.randn(len(idx)), index=idx)
+        ax = _check_plot_works(s.plot)
+
 
 if __name__ == '__main__':
     nose.runmodule(argv=[__file__, '-vvs', '-x', '--pdb', '--pdb-failure'],


### PR DESCRIPTION
 - [x] closes #14763 
 - [x] tests added: tests/plotting/test_series.py: test_non_standard_intervals
 - [x] passes ``git diff upstream/master | flake8 --diff``
 - [ ] whatsnew entry - Confirm version and I'll add

Fix Summary: A check on frequency compatibility was unnecessarily strict. Now IncompatibleFrequency exceptions will only get raised if the unit types differ.