### PR TITLE
TST: Test datetime array assignment with different units (#7492)

### DIFF
--- a/pandas/tests/frame/test_timeseries.py
+++ b/pandas/tests/frame/test_timeseries.py
@@ -366,6 +366,19 @@ class TestDataFrameTimeSeriesMethods(tm.TestCase, TestData):
         exp = pd.Series([pd.NaT], index=["foo"])
         tm.assert_series_equal(res, exp)
 
+    def test_datetime_assignment_with_NaT_and_diff_time_units(self):
+        # GH 7492
+        data_ns = np.array([1, 'nat'], dtype='datetime64[ns]')
+        result = pd.Series(data_ns).to_frame()
+        result['new'] = data_ns
+        expected = pd.DataFrame({0: data_ns, 'new': data_ns})
+        tm.assert_frame_equal(result, expected)
+        # OutOfBoundsDatetime error shouldn't occur
+        data_s = np.array([1, 'nat'], dtype='datetime64[s]')
+        result['new'] = data_s
+        expected = pd.DataFrame({0: data_ns, 'new': data_s})
+        tm.assert_frame_equal(result, expected)
+
 
 if __name__ == '__main__':
     import nose

--- a/pandas/tests/frame/test_timeseries.py
+++ b/pandas/tests/frame/test_timeseries.py
@@ -371,12 +371,14 @@ class TestDataFrameTimeSeriesMethods(tm.TestCase, TestData):
         data_ns = np.array([1, 'nat'], dtype='datetime64[ns]')
         result = pd.Series(data_ns).to_frame()
         result['new'] = data_ns
-        expected = pd.DataFrame({0: data_ns, 'new': data_ns})
+        expected = pd.DataFrame({0: [1, None],
+                                'new': [1, None]}, dtype='datetime64[ns]')
         tm.assert_frame_equal(result, expected)
         # OutOfBoundsDatetime error shouldn't occur
         data_s = np.array([1, 'nat'], dtype='datetime64[s]')
         result['new'] = data_s
-        expected = pd.DataFrame({0: data_ns, 'new': data_s})
+        expected = pd.DataFrame({0: [1, None],
+                                'new': [1e9, None]}, dtype='datetime64[ns]')
         tm.assert_frame_equal(result, expected)
 
 


### PR DESCRIPTION
 - [x] closes #7492
 - [x] tests added / passed
 - [x] passes ``git diff upstream/master | flake8 --diff``

The example in this issue currently works in master. Added a test to confirm. Based on a quick skim of the recent PRs, doesn't look like it was fixed recently. 
