### PR TITLE
Clean up construction of Series with dictionary and datetime index

### DIFF
--- a/asv_bench/benchmarks/series_methods.py
+++ b/asv_bench/benchmarks/series_methods.py
@@ -15,6 +15,21 @@ class series_constructor_no_data_datetime_index(object):
         Series(data=None, index=self.dr)
 
 
+class series_constructor_dict_data_datetime_index(object):
+    goal_time = 0.2
+
+    def setup(self):
+        self.dr = pd.date_range(
+            start=datetime(2015, 10, 26),
+            end=datetime(2016, 1, 1),
+            freq='10s'
+        )  # ~500k long
+        self.data = {d: v for d, v in zip(self.dr, range(len(self.dr)))}
+
+    def time_series_constructor_no_data_datetime_index(self):
+        Series(data=self.data, index=self.dr)
+
+
 class series_isin_int64(object):
     goal_time = 0.2
 

--- a/doc/source/whatsnew/v0.19.2.txt
+++ b/doc/source/whatsnew/v0.19.2.txt
@@ -22,6 +22,7 @@ Performance Improvements
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
 - Improved performance of ``.replace()`` (:issue:`12745`)
+- Improved performance ``Series`` creation with a datetime index and dictionary data (:issue:`14894`)
 
 .. _whatsnew_0192.enhancements.other:
 

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -188,7 +188,7 @@ class Series(base.IndexOpsMixin, strings.StringAccessorMixin,
                         if len(data):
                             # coerce back to datetime objects for lookup
                             data = _dict_compat(data)
-                            data = lib.fast_multiget(data, index.astype('O'),
+                            data = lib.fast_multiget(data, index.asobject.values,
                                                      default=np.nan)
                         else:
                             data = np.nan

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -188,7 +188,8 @@ class Series(base.IndexOpsMixin, strings.StringAccessorMixin,
                         if len(data):
                             # coerce back to datetime objects for lookup
                             data = _dict_compat(data)
-                            data = lib.fast_multiget(data, index.asobject.values,
+                            data = lib.fast_multiget(data,
+                                                     index.asobject.values,
                                                      default=np.nan)
                         else:
                             data = np.nan


### PR DESCRIPTION
 - [X] closes #14894
 - [X] tests added / passed
 - [X] passes ``git diff upstream/master | flake8 --diff``
 - [x] whatsnew entry

Fix usage of fast_multiget with index which was always throwing an exception that was then caught; add ASV that show slight improvement