### PR TITLE
TST: Groupby/transform with grouped NaN (#9941)

### DIFF
--- a/pandas/tests/groupby/test_groupby.py
+++ b/pandas/tests/groupby/test_groupby.py
@@ -1374,6 +1374,15 @@ class TestGroupBy(tm.TestCase):
         expected = DataFrame(dict(B=1, C=[2, 3, 4, 10, 5, -1]))
         assert_frame_equal(result, expected)
 
+    def test_groupby_transform_with_nan_group(self):
+        # GH 9941
+        df = pd.DataFrame({'a': range(10),
+                           'b': [1, 1, 2, 3, np.nan, 4, 4, 5, 5, 5]})
+        result = df.groupby(df.b)['a'].transform(max)
+        expected = pd.Series([1., 1., 2., 3., np.nan, 6., 6., 9., 9., 9.],
+                             name='a')
+        assert_series_equal(result, expected)
+
     def test_indices_concatenation_order(self):
 
         # GH 2808


### PR DESCRIPTION
 - [x] closes #9941
 - [x] tests added / passed
 - [x] passes ``git diff upstream/master | flake8 --diff``

The original issue works on 0.19.1 as expected (resulting value is `nan`). Doesn't look like this was fixed in a PR for 0.19.2 or 0.20