### PR TITLE
BUG: select_dtypes now allows 'datetimetz' for generically selecting datetimes with timezones

### DIFF
--- a/doc/source/whatsnew/v0.20.0.txt
+++ b/doc/source/whatsnew/v0.20.0.txt
@@ -106,6 +106,7 @@ Other enhancements
 - ``pd.Series.interpolate`` now supports timedelta as an index type with ``method='time'`` (:issue:`6424`)
 - ``pandas.io.json.json_normalize()`` gained the option ``errors='ignore'|'raise'``; the default is ``errors='raise'`` which is backward compatible. (:issue:`14583`)
 
+- ``.select_dtypes()`` now allows `datetimetz` to generically select datetimes with tz (:issue:`14910`)
 
 .. _whatsnew_0200.api_breaking:
 
@@ -236,7 +237,6 @@ Bug Fixes
 
 - Bug in ``TimedeltaIndex`` addition where overflow was being allowed without error (:issue:`14816`)
 - Bug in ``astype()`` where ``inf`` values were incorrectly converted to integers. Now raises error now with ``astype()`` for Series and DataFrames (:issue:`14265`)
-
 
 
 

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -2257,7 +2257,12 @@ class DataFrame(NDFrame):
           this will return *all* object dtype columns
         * See the `numpy dtype hierarchy
           <http://docs.scipy.org/doc/numpy/reference/arrays.scalars.html>`__
+        * To select datetimes, use np.datetime64, 'datetime' or 'datetime64'
+        * To select timedeltas, use np.timedelta64, 'timedelta' or
+          'timedelta64'
         * To select Pandas categorical dtypes, use 'category'
+        * To select Pandas datetimetz dtypes, use 'datetimetz' (new in 0.20.0),
+          or a 'datetime64[ns, tz]' string
 
         Examples
         --------

--- a/pandas/tests/frame/test_dtypes.py
+++ b/pandas/tests/frame/test_dtypes.py
@@ -109,14 +109,47 @@ class TestDataFrameDataTypes(tm.TestCase, TestData):
                         'c': np.arange(3, 6).astype('u1'),
                         'd': np.arange(4.0, 7.0, dtype='float64'),
                         'e': [True, False, True],
-                        'f': pd.Categorical(list('abc'))})
+                        'f': pd.Categorical(list('abc')),
+                        'g': pd.date_range('20130101', periods=3),
+                        'h': pd.date_range('20130101', periods=3,
+                                           tz='US/Eastern'),
+                        'i': pd.date_range('20130101', periods=3,
+                                           tz='CET'),
+                        'j': pd.period_range('2013-01', periods=3,
+                                             freq='M'),
+                        'k': pd.timedelta_range('1 day', periods=3)})
+
         ri = df.select_dtypes(include=[np.number])
+        ei = df[['b', 'c', 'd', 'k']]
+        assert_frame_equal(ri, ei)
+
+        ri = df.select_dtypes(include=[np.number], exclude=['timedelta'])
         ei = df[['b', 'c', 'd']]
         assert_frame_equal(ri, ei)
 
-        ri = df.select_dtypes(include=[np.number, 'category'])
+        ri = df.select_dtypes(include=[np.number, 'category'],
+                              exclude=['timedelta'])
         ei = df[['b', 'c', 'd', 'f']]
         assert_frame_equal(ri, ei)
+
+        ri = df.select_dtypes(include=['datetime'])
+        ei = df[['g']]
+        assert_frame_equal(ri, ei)
+
+        ri = df.select_dtypes(include=['datetime64'])
+        ei = df[['g']]
+        assert_frame_equal(ri, ei)
+
+        ri = df.select_dtypes(include=['datetimetz'])
+        ei = df[['h', 'i']]
+        assert_frame_equal(ri, ei)
+
+        ri = df.select_dtypes(include=['timedelta'])
+        ei = df[['k']]
+        assert_frame_equal(ri, ei)
+
+        self.assertRaises(NotImplementedError,
+                          lambda: df.select_dtypes(include=['period']))
 
     def test_select_dtypes_exclude(self):
         df = DataFrame({'a': list('abc'),

--- a/pandas/types/common.py
+++ b/pandas/types/common.py
@@ -400,6 +400,11 @@ def _get_dtype_from_object(dtype):
             pass
         return dtype.type
     elif isinstance(dtype, string_types):
+        if dtype in ['datetimetz', 'datetime64tz']:
+            return DatetimeTZDtype.type
+        elif dtype in ['period']:
+            raise NotImplementedError
+
         if dtype == 'datetime' or dtype == 'timedelta':
             dtype += '64'
 


### PR DESCRIPTION
was missing a generic way to use select_dtypes to select *any* datetime with tz.