### PR TITLE
CLN: Resubmit of GH14700.  Fixes GH14554.  Errors other than Indexing…

### DIFF
--- a/doc/source/whatsnew/v0.19.2.txt
+++ b/doc/source/whatsnew/v0.19.2.txt
@@ -96,3 +96,5 @@ Bug Fixes
 - Bug in ``.plot(kind='kde')`` which did not drop missing values to generate the KDE Plot, instead generating an empty plot. (:issue:`14821`)
 
 - Bug in ``unstack()`` if called with a list of column(s) as an argument, regardless of the dtypes of all columns, they get coerced to ``object`` (:issue:`11847`)
+
+-Bug in indexing that transformed ``RecursionError`` into ``KeyError`` or ``IndexingError`` (:issue:`14554`) 

--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -848,7 +848,7 @@ class _NDFrameIndexer(object):
                 [(a, self._convert_for_reindex(t, axis=o._get_axis_number(a)))
                  for t, a in zip(tup, o._AXIS_ORDERS)])
             return o.reindex(**d)
-        except:
+        except(KeyError, IndexingError):
             raise self._exception
 
     def _convert_for_reindex(self, key, axis=0):


### PR DESCRIPTION
…Error and KeyError now bubble up appropriately.

 - [x] closes #14554
 - [ ] tests added / passed (Not required per GH14700 discussion)
 - [x] passes ``git diff upstream/master | flake8 --diff``
 - [x] whatsnew entry
