### PR TITLE
BUG: Fixed DataFrame.describe percentiles are ndarray w/ no median

### DIFF
--- a/doc/source/whatsnew/v0.20.0.txt
+++ b/doc/source/whatsnew/v0.20.0.txt
@@ -236,7 +236,7 @@ Bug Fixes
 
 - Bug in ``TimedeltaIndex`` addition where overflow was being allowed without error (:issue:`14816`)
 - Bug in ``astype()`` where ``inf`` values were incorrectly converted to integers. Now raises error now with ``astype()`` for Series and DataFrames (:issue:`14265`)
-
+- Bug in ``describe()`` when passing a numpy array which does not contain the median to the ``percentiles`` keyword argument (:issue:`14908`)
 
 
 

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -5255,6 +5255,9 @@ class NDFrame(PandasObject):
 
     @Appender(_shared_docs['describe'] % _shared_doc_kwargs)
     def describe(self, percentiles=None, include=None, exclude=None):
+	    # explicit conversion of `percentiles` to list
+	    percentiles = list(percentiles)
+
         if self.ndim >= 3:
             msg = "describe is not implemented on Panel or PanelND objects."
             raise NotImplementedError(msg)

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -5255,9 +5255,6 @@ class NDFrame(PandasObject):
 
     @Appender(_shared_docs['describe'] % _shared_doc_kwargs)
     def describe(self, percentiles=None, include=None, exclude=None):
-        # explicit conversion of `percentiles` to list
-        percentiles = list(percentiles)
-
         if self.ndim >= 3:
             msg = "describe is not implemented on Panel or PanelND objects."
             raise NotImplementedError(msg)
@@ -5265,6 +5262,9 @@ class NDFrame(PandasObject):
             raise ValueError("Cannot describe a DataFrame without columns")
 
         if percentiles is not None:
+            # explicit conversion of `percentiles` to list
+            percentiles = list(percentiles)
+
             # get them all to be in [0, 1]
             self._check_percentile(percentiles)
 

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -5255,8 +5255,8 @@ class NDFrame(PandasObject):
 
     @Appender(_shared_docs['describe'] % _shared_doc_kwargs)
     def describe(self, percentiles=None, include=None, exclude=None):
-	    # explicit conversion of `percentiles` to list
-	    percentiles = list(percentiles)
+        # explicit conversion of `percentiles` to list
+        percentiles = list(percentiles)
 
         if self.ndim >= 3:
             msg = "describe is not implemented on Panel or PanelND objects."

--- a/pandas/tests/test_generic.py
+++ b/pandas/tests/test_generic.py
@@ -996,6 +996,15 @@ class TestDataFrame(tm.TestCase, Generic):
         self.assertTrue('0%' in d1.index)
         self.assertTrue('100%' in d2.index)
 
+    def test_describe_percentiles_insert_median_ndarray(self):
+        df = tm.makeDataFrame()
+        try:
+            d1 = df.describe(percentiles=np.array([.25, .75]))
+        except AttributeError:
+            self.fail
+        d2 = df.describe(percentiles=[.25, .75])
+        assert_frame_equal(d1, d2)
+
     def test_describe_percentiles_unique(self):
         # GH13104
         df = tm.makeDataFrame()

--- a/pandas/tests/test_generic.py
+++ b/pandas/tests/test_generic.py
@@ -997,13 +997,11 @@ class TestDataFrame(tm.TestCase, Generic):
         self.assertTrue('100%' in d2.index)
 
     def test_describe_percentiles_insert_median_ndarray(self):
+        # GH14908
         df = tm.makeDataFrame()
-        try:
-            d1 = df.describe(percentiles=np.array([.25, .75]))
-        except AttributeError:
-            self.fail
-        d2 = df.describe(percentiles=[.25, .75])
-        assert_frame_equal(d1, d2)
+        result = df.describe(percentiles=np.array([.25, .75]))
+        expected = df.describe(percentiles=[.25, .75])
+        assert_frame_equal(result, expected)
 
     def test_describe_percentiles_unique(self):
         # GH13104


### PR DESCRIPTION
Explicit conversion to list for `percentiles`. Fixes the case where `percentiles` is passed as a numpy with no median (0.5) present. Closes #14908.
