### PR TITLE
BUG: Don't convert uint64 to object in DataFrame init

### DIFF
--- a/doc/source/whatsnew/v0.20.0.txt
+++ b/doc/source/whatsnew/v0.20.0.txt
@@ -235,6 +235,7 @@ Bug Fixes
 ~~~~~~~~~
 
 - Bug in ``TimedeltaIndex`` addition where overflow was being allowed without error (:issue:`14816`)
+- Bug in ``DataFrame`` construction in which unsigned 64-bit integer elements were being converted to objects (:issue:`14881`)
 - Bug in ``astype()`` where ``inf`` values were incorrectly converted to integers. Now raises error now with ``astype()`` for Series and DataFrames (:issue:`14265`)
 
 

--- a/pandas/core/internals.py
+++ b/pandas/core/internals.py
@@ -4314,11 +4314,6 @@ def form_blocks(arrays, names, axes):
         elif is_datetimetz(v):
             datetime_tz_items.append((i, k, v))
         elif issubclass(v.dtype.type, np.integer):
-            if v.dtype == np.uint64:
-                # HACK #2355 definite overflow
-                if (v > 2**63 - 1).any():
-                    object_items.append((i, k, v))
-                    continue
             int_items.append((i, k, v))
         elif v.dtype == np.bool_:
             bool_items.append((i, k, v))

--- a/pandas/tests/frame/test_constructors.py
+++ b/pandas/tests/frame/test_constructors.py
@@ -183,13 +183,14 @@ class TestDataFrameConstructors(tm.TestCase, TestData):
         self.assertEqual(df.values.dtype, np.bool_)
 
     def test_constructor_overflow_int64(self):
+        # see gh-14881
         values = np.array([2 ** 64 - i for i in range(1, 10)],
                           dtype=np.uint64)
 
         result = DataFrame({'a': values})
-        self.assertEqual(result['a'].dtype, object)
+        self.assertEqual(result['a'].dtype, np.uint64)
 
-        # #2355
+        # see gh-2355
         data_scores = [(6311132704823138710, 273), (2685045978526272070, 23),
                        (8921811264899370420, 45),
                        (long(17019687244989530680), 270),
@@ -198,7 +199,7 @@ class TestDataFrameConstructors(tm.TestCase, TestData):
         data = np.zeros((len(data_scores),), dtype=dtype)
         data[:] = data_scores
         df_crawls = DataFrame(data)
-        self.assertEqual(df_crawls['uid'].dtype, object)
+        self.assertEqual(df_crawls['uid'].dtype, np.uint64)
 
     def test_constructor_ordereddict(self):
         import random

--- a/pandas/tests/frame/test_operators.py
+++ b/pandas/tests/frame/test_operators.py
@@ -378,10 +378,10 @@ class TestDataFrameOperators(tm.TestCase, TestData):
                     result = getattr(self.mixed_int, op)(2 + self.mixed_int)
                     exp = f(self.mixed_int, 2 + self.mixed_int)
 
-                    # overflow in the uint
+                    # no overflow in the uint
                     dtype = None
                     if op in ['sub']:
-                        dtype = dict(B='object', C=None)
+                        dtype = dict(B='uint64', C=None)
                     elif op in ['add', 'mul']:
                         dtype = dict(C=None)
                     assert_frame_equal(result, exp)
@@ -410,10 +410,10 @@ class TestDataFrameOperators(tm.TestCase, TestData):
                             2 + self.mixed_int)
                         exp = f(self.mixed_int, 2 + self.mixed_int)
 
-                        # overflow in the uint
+                        # no overflow in the uint
                         dtype = None
                         if op in ['sub']:
-                            dtype = dict(B='object', C=None)
+                            dtype = dict(B='uint64', C=None)
                         elif op in ['add', 'mul']:
                             dtype = dict(C=None)
                         assert_frame_equal(result, exp)


### PR DESCRIPTION
The hack used to resolve #2355 is no longer needed. Removes the hack and patches several tests that relied on this hacky (and buggy) behavior.

Closes #14881.