### PR TITLE
BUG: Properly read Categorical msgpacks

### DIFF
--- a/doc/source/whatsnew/v0.20.0.txt
+++ b/doc/source/whatsnew/v0.20.0.txt
@@ -278,6 +278,7 @@ Bug Fixes
 
 
 
+- Bug in ``pd.read_msgpack()`` in which ``Series`` categoricals were being improperly processed (:issue:`14901`)
 
 
 

--- a/pandas/io/packers.py
+++ b/pandas/io/packers.py
@@ -593,17 +593,13 @@ def decode(obj):
     elif typ == u'series':
         dtype = dtype_for(obj[u'dtype'])
         pd_dtype = pandas_dtype(dtype)
-        np_dtype = pandas_dtype(dtype).base
 
         index = obj[u'index']
         result = globals()[obj[u'klass']](unconvert(obj[u'data'], dtype,
                                                     obj[u'compress']),
                                           index=index,
-                                          dtype=np_dtype,
+                                          dtype=pd_dtype,
                                           name=obj[u'name'])
-        tz = getattr(pd_dtype, 'tz', None)
-        if tz:
-            result = result.dt.tz_localize('UTC').dt.tz_convert(tz)
         return result
 
     elif typ == u'block_manager':

--- a/pandas/io/tests/test_packers.py
+++ b/pandas/io/tests/test_packers.py
@@ -363,6 +363,8 @@ class TestSeries(TestPackers):
             'F': [Timestamp('20130102', tz='US/Eastern')] * 2 +
                  [Timestamp('20130603', tz='CET')] * 3,
             'G': [Timestamp('20130102', tz='US/Eastern')] * 5,
+            'H': Categorical([1, 2, 3, 4, 5]),
+            'I': Categorical([1, 2, 3, 4, 5], ordered=True),
         }
 
         self.d['float'] = Series(data['A'])
@@ -370,6 +372,8 @@ class TestSeries(TestPackers):
         self.d['mixed'] = Series(data['E'])
         self.d['dt_tz_mixed'] = Series(data['F'])
         self.d['dt_tz'] = Series(data['G'])
+        self.d['cat_ordered'] = Series(data['H'])
+        self.d['cat_unordered'] = Series(data['I'])
 
     def test_basic(self):
 


### PR DESCRIPTION
Patches bug in `read_msgpack` in which `Series` categoricals were accidentally being constructed with a non-categorical dtype, resulting in an error.

Closes #14901.