### PR TITLE
TST: Concat MultiIndex dataframes with deepcopy (#9967)

### DIFF
--- a/pandas/tools/tests/test_concat.py
+++ b/pandas/tools/tests/test_concat.py
@@ -2151,6 +2151,27 @@ bar2,12,13,14,15
         exp = df.iloc[[2, 3, 4, 5], :]
         tm.assert_frame_equal(res, exp)
 
+    def test_concat_multiindex_dfs_with_deepcopy(self):
+        # GH 9967
+        from copy import deepcopy
+        example_multiindex1 = pd.MultiIndex.from_product([['a'], ['b']])
+        example_dataframe1 = pd.DataFrame([0], index=example_multiindex1)
+
+        example_multiindex2 = pd.MultiIndex.from_product([['a'], ['c']])
+        example_dataframe2 = pd.DataFrame([1], index=example_multiindex2)
+
+        example_dict = {'s1': example_dataframe1, 's2': example_dataframe2}
+        expected_index = pd.MultiIndex(levels=[['s1', 's2'],
+                                               ['a'],
+                                               ['b', 'c']],
+                                       labels=[[0, 1], [0, 0], [0, 1]],
+                                       names=['testname', None, None])
+        expected = pd.DataFrame([[0], [1]], index=expected_index)
+        result_copy = pd.concat(deepcopy(example_dict), names=['testname'])
+        tm.assert_frame_equal(result_copy, expected)
+        result_no_copy = pd.concat(example_dict, names=['testname'])
+        tm.assert_frame_equal(result_no_copy, expected)
+
 
 if __name__ == '__main__':
     nose.runmodule(argv=[__file__, '-vvs', '-x', '--pdb', '--pdb-failure'],


### PR DESCRIPTION
 - [x] closes #9967
 - [x] tests added / passed
 - [x] passes ``git diff upstream/master | flake8 --diff``

Potentially related to #10638? Otherwise, don't think this was fixed recently