### PR TITLE
BUG: sorting with large float and multiple columns incorrect

### DIFF
--- a/doc/source/whatsnew/v0.20.0.txt
+++ b/doc/source/whatsnew/v0.20.0.txt
@@ -246,6 +246,7 @@ Bug Fixes
 - Bug in ``DataFrame`` construction in which unsigned 64-bit integer elements were being converted to objects (:issue:`14881`)
 - Bug in ``astype()`` where ``inf`` values were incorrectly converted to integers. Now raises error now with ``astype()`` for Series and DataFrames (:issue:`14265`)
 - Bug in ``describe()`` when passing a numpy array which does not contain the median to the ``percentiles`` keyword argument (:issue:`14908`)
+- Bug in ``sort_values()`` when sorting by multiple columns where one colums is of type `int64` and contains `NaT` (:issue:`14922`)
 
 
 

--- a/doc/source/whatsnew/v0.20.0.txt
+++ b/doc/source/whatsnew/v0.20.0.txt
@@ -246,7 +246,7 @@ Bug Fixes
 - Bug in ``DataFrame`` construction in which unsigned 64-bit integer elements were being converted to objects (:issue:`14881`)
 - Bug in ``astype()`` where ``inf`` values were incorrectly converted to integers. Now raises error now with ``astype()`` for Series and DataFrames (:issue:`14265`)
 - Bug in ``describe()`` when passing a numpy array which does not contain the median to the ``percentiles`` keyword argument (:issue:`14908`)
-- Bug in ``sort_values()`` when sorting by multiple columns where one colums is of type `int64` and contains `NaT` (:issue:`14922`)
+- Bug in ``sort_values()`` when sorting by multiple columns where one column is of type ``int64`` and contains ``NaT`` (:issue:`14922`)
 
 
 

--- a/pandas/core/algorithms.py
+++ b/pandas/core/algorithms.py
@@ -343,7 +343,8 @@ def factorize(values, sort=False, order=None, na_sentinel=-1, size_hint=None):
 
     table = hash_klass(size_hint or len(vals))
     uniques = vec_klass()
-    labels = table.get_labels(vals, uniques, 0, na_sentinel, True)
+    check_nulls = not is_integer_dtype(values)
+    labels = table.get_labels(vals, uniques, 0, na_sentinel, check_nulls)
 
     labels = _ensure_platform_int(labels)
 

--- a/pandas/tests/frame/test_sorting.py
+++ b/pandas/tests/frame/test_sorting.py
@@ -6,7 +6,7 @@ import numpy as np
 
 from pandas.compat import lrange
 from pandas import (DataFrame, Series, MultiIndex, Timestamp,
-                    date_range)
+                    date_range, NaT)
 
 from pandas.util.testing import (assert_series_equal,
                                  assert_frame_equal,
@@ -491,3 +491,18 @@ class TestDataFrameSorting(tm.TestCase, TestData):
 
         cp = s.copy()
         cp.sort_values()  # it works!
+
+    def test_sort_nat_values_in_int_column(self):
+
+        # GH 14922, sorting with large float and multiple columns incorrect
+        int_values = (2, int(NaT))
+        float_values = (2.0, -1.797693e308)
+
+        df = DataFrame(dict(int=int_values, float=float_values),
+                       columns=["int", "float"])
+
+        df_sorted = df.sort_values(["int", "float"])
+        df_expected = DataFrame(dict(int=int_values[::-1], float=float_values[::-1]),
+                                columns=["int", "float"], index=[1, 0])
+
+        assert_frame_equal(df_sorted, df_expected)

--- a/pandas/tests/frame/test_sorting.py
+++ b/pandas/tests/frame/test_sorting.py
@@ -524,13 +524,9 @@ class TestDataFrameSorting(tm.TestCase, TestData):
 
         # and now check if NaT is still considered as "na" for datetime64
         # columns:
-        df = DataFrame(dict(int=int_values, float=float_values),
-                       columns=["int", "float"])
-
         df = DataFrame(dict(datetime=[Timestamp("2016-01-01"), NaT],
                             float=float_values), columns=["datetime", "float"])
 
-        # check if the dtype is datetime64[ns]:
         assert df["datetime"].dtypes == np.dtype("datetime64[ns]"),\
             "this test function is not reliable anymore"
 

--- a/pandas/tests/frame/test_sorting.py
+++ b/pandas/tests/frame/test_sorting.py
@@ -6,11 +6,12 @@ import numpy as np
 
 from pandas.compat import lrange
 from pandas import (DataFrame, Series, MultiIndex, Timestamp,
-                    date_range)
+                    date_range, NaT)
 
 from pandas.util.testing import (assert_series_equal,
                                  assert_frame_equal,
-                                 assertRaisesRegexp)
+                                 assertRaisesRegexp,
+                                 is_sorted)
 
 import pandas.util.testing as tm
 
@@ -491,3 +492,18 @@ class TestDataFrameSorting(tm.TestCase, TestData):
 
         cp = s.copy()
         cp.sort_values()  # it works!
+
+    def test_sort_nat_values_in_int_column(self):
+
+        # GH 14922, sorting with large float and multiple columns incorrect
+        int_values = (2, int(NaT))
+        float_values = (2.0, -1.797693e308)
+
+        df = DataFrame(dict(int=int_values, float=float_values),
+                       columns=["int", "float"])
+
+        df_sorted = df.sort_values(["int", "float"])
+        df_expected = DataFrame(dict(int=int_values[::-1], float=float_values[::-1]),
+                                columns=["int", "float"], index=[1, 0])
+
+        assert_frame_equal(df_sorted, df_expected)

--- a/pandas/tests/frame/test_sorting.py
+++ b/pandas/tests/frame/test_sorting.py
@@ -527,9 +527,6 @@ class TestDataFrameSorting(tm.TestCase, TestData):
         df = DataFrame(dict(datetime=[Timestamp("2016-01-01"), NaT],
                             float=float_values), columns=["datetime", "float"])
 
-        assert df["datetime"].dtypes == np.dtype("datetime64[ns]"),\
-            "this test function is not reliable anymore"
-
         df_reversed = DataFrame(dict(datetime=[NaT, Timestamp("2016-01-01")],
                                      float=float_values[::-1]),
                                 columns=["datetime", "float"],


### PR DESCRIPTION
Fixes https://github.com/pandas-dev/pandas/issues/14922
    
Having the `int` equivalent of `NaT` in an `int64` column caused wrong sorting because this special value was considered as "missing value".

 - [ ] closes #xxxx
 - [X] tests added / passed
 - [X] passes ``git diff upstream/master | flake8 --diff``
 - [x] whatsnew entry
