### PR TITLE
Clarified error in read_sas method when buffer object provided withou…

### DIFF
--- a/doc/source/whatsnew/v0.20.0.txt
+++ b/doc/source/whatsnew/v0.20.0.txt
@@ -271,6 +271,7 @@ Performance Improvements
 - Improved performance of ``pd.wide_to_long()`` (:issue:`14779`)
 - Increased performance of ``pd.factorize()`` by releasing the GIL with ``object`` dtype when inferred as strings (:issue:`14859`)
 
+- When reading buffer object in ``read_sas()`` method without specified format, filepath string is inferred rather than buffer object. Error is now thrown if buffer object is provided without format {sas7bdat|xport} specification.
 
 
 .. _whatsnew_0200.bug_fixes:

--- a/doc/source/whatsnew/v0.20.0.txt
+++ b/doc/source/whatsnew/v0.20.0.txt
@@ -271,7 +271,7 @@ Performance Improvements
 - Improved performance of ``pd.wide_to_long()`` (:issue:`14779`)
 - Increased performance of ``pd.factorize()`` by releasing the GIL with ``object`` dtype when inferred as strings (:issue:`14859`)
 
-- When reading buffer object in ``read_sas()`` method without specified format, filepath string is inferred rather than buffer object. Error is now thrown if buffer object is provided without format {sas7bdat|xport} specification.
+- When reading buffer object in ``read_sas()`` method without specified format, filepath string is inferred rather than buffer object.
 
 
 .. _whatsnew_0200.bug_fixes:

--- a/pandas/io/sas/sasreader.py
+++ b/pandas/io/sas/sasreader.py
@@ -33,8 +33,8 @@ def read_sas(filepath_or_buffer, format=None, index=None, encoding=None,
     if format is None:
         buffer_error_msg = ("If this is a buffer object rather"
                             "than a string name, you must specify"
-                            " a format string")    
-        if not isinstance(filepath_or_buffer,compat.string_types):
+                            " a format string")
+        if not isinstance(filepath_or_buffer, compat.string_types):
             raise TypeError(buffer_error_msg)
         try:
             fname = filepath_or_buffer.lower()

--- a/pandas/io/sas/sasreader.py
+++ b/pandas/io/sas/sasreader.py
@@ -3,6 +3,7 @@ Read SAS sas7bdat or xport files.
 """
 from pandas import compat
 
+
 def read_sas(filepath_or_buffer, format=None, index=None, encoding=None,
              chunksize=None, iterator=False):
 

--- a/pandas/io/sas/sasreader.py
+++ b/pandas/io/sas/sasreader.py
@@ -1,7 +1,7 @@
 """
 Read SAS sas7bdat or xport files.
 """
-
+from pandas import compat
 
 def read_sas(filepath_or_buffer, format=None, index=None, encoding=None,
              chunksize=None, iterator=False):
@@ -29,11 +29,11 @@ def read_sas(filepath_or_buffer, format=None, index=None, encoding=None,
     DataFrame if iterator=False and chunksize=None, else SAS7BDATReader
     or XportReader
     """
-    from pandas import compat
     if format is None:
-        buffErr = "Format unrecognized. If buffer object, specify format"
+        buffer_error_msg = "If this is a buffer object rather\
+                than a string name, you must specify a format string"
         if not isinstance(filepath_or_buffer,compat.string_types):
-            raise TypeError(buffErr)
+            raise TypeError(buffer_error_msg)
         try:
             fname = filepath_or_buffer.lower()
             if fname.endswith(".xpt"):

--- a/pandas/io/sas/sasreader.py
+++ b/pandas/io/sas/sasreader.py
@@ -29,11 +29,11 @@ def read_sas(filepath_or_buffer, format=None, index=None, encoding=None,
     DataFrame if iterator=False and chunksize=None, else SAS7BDATReader
     or XportReader
     """
-
+    from pandas import compat
     if format is None:
-        bufferr = "Format unrecognized. If buffer object, specify format")
-        if type(filesize_or_buffer) != str:
-            raise TypeError(bufferr)
+        buffErr = "Format unrecognized. If buffer object, specify format")
+        if not isinstance(filepath_or_buffer,compat.string_types):
+            raise TypeError(buffErr)
         try:
             fname = filepath_or_buffer.lower()
             if fname.endswith(".xpt"):

--- a/pandas/io/sas/sasreader.py
+++ b/pandas/io/sas/sasreader.py
@@ -31,7 +31,7 @@ def read_sas(filepath_or_buffer, format=None, index=None, encoding=None,
     """
     from pandas import compat
     if format is None:
-        buffErr = "Format unrecognized. If buffer object, specify format")
+        buffErr = "Format unrecognized. If buffer object, specify format"
         if not isinstance(filepath_or_buffer,compat.string_types):
             raise TypeError(buffErr)
         try:

--- a/pandas/io/sas/sasreader.py
+++ b/pandas/io/sas/sasreader.py
@@ -30,8 +30,9 @@ def read_sas(filepath_or_buffer, format=None, index=None, encoding=None,
     or XportReader
     """
     if format is None:
-        buffer_error_msg = "If this is a buffer object rather\
-                than a string name, you must specify a format string"
+        buffer_error_msg = ("If this is a buffer object rather"
+                            "than a string name, you must specify"
+                            " a format string")
         if not isinstance(filepath_or_buffer,compat.string_types):
             raise TypeError(buffer_error_msg)
         try:

--- a/pandas/io/sas/sasreader.py
+++ b/pandas/io/sas/sasreader.py
@@ -5,6 +5,7 @@ from pandas import compat
 
 def read_sas(filepath_or_buffer, format=None, index=None, encoding=None,
              chunksize=None, iterator=False):
+
     """
     Read SAS files stored as either XPORT or SAS7BDAT format files.
 
@@ -32,7 +33,7 @@ def read_sas(filepath_or_buffer, format=None, index=None, encoding=None,
     if format is None:
         buffer_error_msg = ("If this is a buffer object rather"
                             "than a string name, you must specify"
-                            " a format string")
+                            " a format string")    
         if not isinstance(filepath_or_buffer,compat.string_types):
             raise TypeError(buffer_error_msg)
         try:

--- a/pandas/io/sas/sasreader.py
+++ b/pandas/io/sas/sasreader.py
@@ -31,6 +31,9 @@ def read_sas(filepath_or_buffer, format=None, index=None, encoding=None,
     """
 
     if format is None:
+        bufferr = "Format unrecognized. If buffer object, specify format")
+        if type(filesize_or_buffer) != str:
+            raise TypeError(bufferr)
         try:
             fname = filepath_or_buffer.lower()
             if fname.endswith(".xpt"):

--- a/pandas/io/tests/sas/test_sas.py
+++ b/pandas/io/tests/sas/test_sas.py
@@ -1,5 +1,13 @@
-def test_sas_buffer_format(self):
-    import StringIO
-    b = StringIO.StringIO("")
-    with self.assertRaises(TypeError):
-        result=pd.read_sas(b)
+from pandas.io.sas.sasreader import read_sas
+import pandas.util.testing as tm
+import pandas as pd
+
+class TestSasBuff(tm.TestCase):
+
+    def test_sas_buffer_format(self):
+        import StringIO
+        from pandas.io.sas.sasreader import read_sas
+        b = StringIO.StringIO("")
+        with self.assertRaises(TypeError):
+            result=read_sas(b)
+

--- a/pandas/io/tests/sas/test_sas.py
+++ b/pandas/io/tests/sas/test_sas.py
@@ -2,6 +2,7 @@ import pandas.util.testing as tm
 from pandas.compat import StringIO
 from pandas import read_sas
 
+
 class TestSas(tm.TestCase):
 
     def test_sas_buffer_format(self):

--- a/pandas/io/tests/sas/test_sas.py
+++ b/pandas/io/tests/sas/test_sas.py
@@ -1,9 +1,9 @@
 import pandas.util.testing as tm
+from pandas.compat import StringIO
+from pandas import read_sas
 
 class TestSasBuff(tm.TestCase):
     def test_sas_buffer_format(self):
-        import StringIO
-        from pandas.io.sas.sasreader import read_sas
-        b = StringIO.StringIO("")
+        b = StringIO("")
         with self.assertRaises(TypeError):
             read_sas(b)

--- a/pandas/io/tests/sas/test_sas.py
+++ b/pandas/io/tests/sas/test_sas.py
@@ -1,13 +1,9 @@
-from pandas.io.sas.sasreader import read_sas
 import pandas.util.testing as tm
-import pandas as pd
 
 class TestSasBuff(tm.TestCase):
-
     def test_sas_buffer_format(self):
         import StringIO
         from pandas.io.sas.sasreader import read_sas
         b = StringIO.StringIO("")
         with self.assertRaises(TypeError):
-            result=read_sas(b)
-
+            read_sas(b)

--- a/pandas/io/tests/sas/test_sas.py
+++ b/pandas/io/tests/sas/test_sas.py
@@ -1,0 +1,5 @@
+def test_sas_buffer_format(self):
+    import StringIO
+    b = StringIO.StringIO("")
+    with self.assertRaises(TypeError):
+        result=pd.read_sas(b)

--- a/pandas/io/tests/sas/test_sas.py
+++ b/pandas/io/tests/sas/test_sas.py
@@ -2,7 +2,8 @@ import pandas.util.testing as tm
 from pandas.compat import StringIO
 from pandas import read_sas
 
-class TestSasBuff(tm.TestCase):
+class TestSas(tm.TestCase):
+
     def test_sas_buffer_format(self):
         b = StringIO("")
         with self.assertRaises(TypeError):


### PR DESCRIPTION
…t format

 - [x] closes #14947
 - [x] tests added / passed
 - [X] passes ``git diff upstream/master | flake8 --diff``
 - [X] whatsnew entry

Added three lines to sasreader.py immediately following line 33 (if format==None:) to handle the case when a buffer object is provided without a format='sas7bdat' or format='xport' situation. Method otherwise works splendidly when a filepath is provided, but a buffer object fails. This is an issue when using sasreader directly on SFTP file objects. I am unaware of any bug request (and am happy to open one), but I came across this issue when using the library.