### PR TITLE
added 'separator' argument to json_normalize

### DIFF
--- a/pandas/io/json.py
+++ b/pandas/io/json.py
@@ -24,8 +24,8 @@ def to_json(path_or_buf, obj, orient=None, date_format='epoch',
             default_handler=None, lines=False):
 
     if lines and orient != 'records':
-            raise ValueError(
-                "'lines' keyword only valid when 'orient' is records")
+        raise ValueError(
+            "'lines' keyword only valid when 'orient' is records")
 
     if isinstance(obj, Series):
         s = SeriesWriter(
@@ -726,8 +726,8 @@ def nested_to_record(ds, prefix="", level=0):
 def json_normalize(data, record_path=None, meta=None,
                    meta_prefix=None,
                    record_prefix=None,
+                   separator='.',
                    errors='raise'):
-
     """
     "Normalize" semi-structured JSON data into a flat table
 
@@ -744,6 +744,9 @@ def json_normalize(data, record_path=None, meta=None,
         If True, prefix records with dotted (?) path, e.g. foo.bar.field if
         path to records is ['foo', 'bar']
     meta_prefix : string, default None
+    separator : string, default '.'
+        Nested records will generate names separated by separator,
+        e.g., for separator='.', { 'foo' : { 'bar' : 0 } } -> foo.bar
     errors : {'raise', 'ignore'}, default 'raise'
         * ignore : will ignore KeyError if keys listed in meta are not
         always present
@@ -828,7 +831,7 @@ def json_normalize(data, record_path=None, meta=None,
     lengths = []
 
     meta_vals = defaultdict(list)
-    meta_keys = ['.'.join(val) for val in meta]
+    meta_keys = [separator.join(val) for val in meta]
 
     def _recursive_extract(data, path, seen_meta, level=0):
         if len(path) > 1:


### PR DESCRIPTION
 - [x] closes #14883
 - [ ] tests added / passed (added 3 tests: `test_simple_normalize_with_{default, user_specified, user_specified_unicode}_separator`)
 - [x] passes ``git diff upstream/master | flake8 --diff``
 - [x] whatsnew entry (v0.20.0)

However, this doesn't work, even after making the fixes suggested in https://github.com/pandas-dev/pandas/pull/14891. I thought replacing `'.'` in `meta_keys = ['.'.join(val) for val in meta]` with `sep` would do the trick. It doesn't, so I'm a little puzzled. Happy to take a suggestion.