### PR TITLE
BUG: Patch maybe_convert_objects uint64 handling

### DIFF
--- a/pandas/src/inference.pyx
+++ b/pandas/src/inference.pyx
@@ -810,7 +810,7 @@ def maybe_convert_objects(ndarray[object] objects, bint try_float=0,
             floats[i] = <float64_t> val
             complexes[i] = <double complex> val
             if not seen_null:
-                seen_uint = seen_uint or (val > npy_int64_max)
+                seen_uint = seen_uint or (int(val) > npy_int64_max)
                 seen_sint = seen_sint or (val < 0)
 
                 if seen_uint and seen_sint:

--- a/pandas/tests/types/test_inference.py
+++ b/pandas/tests/types/test_inference.py
@@ -260,6 +260,13 @@ class TestInference(tm.TestCase):
         exp = np.array([2**63], dtype=np.uint64)
         tm.assert_numpy_array_equal(lib.maybe_convert_objects(arr), exp)
 
+        # NumPy bug: can't compare uint64 to int64, as that
+        # results in both casting to float64, so we should
+        # make sure that this function is robust against it
+        arr = np.array([np.uint64(2**63)], dtype=object)
+        exp = np.array([2**63], dtype=np.uint64)
+        tm.assert_numpy_array_equal(lib.maybe_convert_objects(arr), exp)
+
         arr = np.array([2, -1], dtype=object)
         exp = np.array([2, -1], dtype=np.int64)
         tm.assert_numpy_array_equal(lib.maybe_convert_objects(arr), exp)


### PR DESCRIPTION
Makes method robust against known `numpy` bug that you can't compare `uint64` against `int64`
because they are casted to `float64` during the comparison, causing truncation.

xref #14937.
Follow-up to #14916.