### PR TITLE
TST: Groupby.groups of datetimeindex (#11442)

### DIFF
--- a/pandas/tests/groupby/test_groupby.py
+++ b/pandas/tests/groupby/test_groupby.py
@@ -3933,6 +3933,27 @@ class TestGroupBy(tm.TestCase):
         groups = grouped.groups
         tm.assertIsInstance(list(groups.keys())[0], datetime)
 
+        # GH 11442
+        index = pd.date_range('2015/01/01', periods=5, name='date')
+        df = pd.DataFrame({'A': [5, 6, 7, 8, 9],
+                           'B': [1, 2, 3, 4, 5]}, index=index)
+        result = df.groupby(level='date').groups
+        dates = ['2015-01-05', '2015-01-04', '2015-01-03',
+                 '2015-01-02', '2015-01-01']
+        expected = {pd.Timestamp(date): pd.DatetimeIndex([date], name='date')
+                    for date in dates}
+        tm.assert_dict_equal(result, expected)
+
+        grouped = df.groupby(level='date')
+        for date in dates:
+            result = grouped.get_group(date)
+            data = [[df.loc[date, 'A'], df.loc[date, 'B']]]
+            expected_index = pd.DatetimeIndex([date], name='date')
+            expected = pd.DataFrame(data,
+                                    columns=list('AB'),
+                                    index=expected_index)
+            tm.assert_frame_equal(result, expected)
+
     def test_groupby_groups_datetimeindex_tz(self):
         # GH 3950
         dates = ['2011-07-19 07:00:00', '2011-07-19 08:00:00',


### PR DESCRIPTION
 - [x] closes #11442
 - [x] tests added / passed
 - [x] passes ``git diff upstream/master | flake8 --diff``

Doesn't look a PR in 0.19.2 and 0.20.0 addressed this, but it works on master 0.19.1