### PR TITLE
BUG: Series.ffill() with mixed dtypes containing tz-aware datetimes f…

### DIFF
--- a/doc/source/whatsnew/v0.20.0.txt
+++ b/doc/source/whatsnew/v0.20.0.txt
@@ -300,3 +300,4 @@ Bug Fixes
 - Bug in ``Series.unique()`` in which unsigned 64-bit integers were causing overflow (:issue:`14721`)
 - Require at least 0.23 version of cython to avoid problems with character encodings (:issue:`14699`)
 - Bug in converting object elements of array-like objects to unsigned 64-bit integers (:issue:`4471`)
+- Bug in Series.ffill() with mixed dtypes containing tz-aware datetimes. (:issue:`14956`)

--- a/pandas/src/inference.pyx
+++ b/pandas/src/inference.pyx
@@ -859,7 +859,7 @@ def maybe_convert_objects(ndarray[object] objects, bint try_float=0,
 
     # we try to coerce datetime w/tz but must all have the same tz
     if seen_datetimetz:
-        if len(set([ getattr(val, 'tz', None) for val in objects ])) == 1:
+        if len(set([getattr(val, 'tzinfo', None) for val in objects])) == 1:
             from pandas import DatetimeIndex
             return DatetimeIndex(objects)
         seen_object = 1

--- a/pandas/tests/series/test_missing.py
+++ b/pandas/tests/series/test_missing.py
@@ -386,6 +386,12 @@ class TestSeriesMissingData(TestData, tm.TestCase):
         ts[2] = np.NaN
         assert_series_equal(ts.ffill(), ts.fillna(method='ffill'))
 
+    def test_ffill_mixed_dtypes_without_missing_data(self):
+        # GH14956
+        series = pd.Series([datetime(2015, 1, 1, tzinfo=pytz.utc), 1])
+        result = series.ffill()
+        assert_series_equal(series, result)
+
     def test_bfill(self):
         ts = Series([0., 1., 2., 3., 4.], index=tm.makeDateIndex(5))
         ts[2] = np.NaN

--- a/pandas/tests/types/test_inference.py
+++ b/pandas/tests/types/test_inference.py
@@ -11,6 +11,7 @@ import collections
 import re
 from datetime import datetime, date, timedelta, time
 import numpy as np
+import pytz
 
 import pandas as pd
 from pandas import lib, tslib
@@ -274,6 +275,14 @@ class TestInference(tm.TestCase):
         arr = np.array([2**63, -1], dtype=object)
         exp = np.array([2**63, -1], dtype=object)
         tm.assert_numpy_array_equal(lib.maybe_convert_objects(arr), exp)
+
+    def test_mixed_dtypes_remain_object_array(self):
+        # GH14956
+        array = np.array([datetime(2015, 1, 1, tzinfo=pytz.utc), 1],
+                         dtype=object)
+        result = lib.maybe_convert_objects(array)
+        tm.assert_numpy_array_equal(result, array)
+        self.assertTrue(result.dtype == object)
 
 
 class TestTypeInference(tm.TestCase):


### PR DESCRIPTION
…ails. (GH14956)

Seems to work with all the datetime classes usually encountered, although 'tz' seems to be the idiom in the codebase (not sure why?). If both need to be supported I can replace `getattr(val, 'tzinfo', None)` with `getattr(val, 'tz', None) or getattr(val, 'tzinfo', None)`, thus also giving precedence to the former (if available).

(breaking commit was 4de83d25d751d8ca102867b2d46a5547c01d7248)

 - [ x] closes #14956 
 - [x] tests added / passed
 - [x ] passes ``git diff upstream/master | flake8 --diff``
 - [x ] whatsnew entry
