### PR TITLE
BUG: applymap on empty DataFrame returns Series (#8222)

### DIFF
--- a/doc/source/whatsnew/v0.20.0.txt
+++ b/doc/source/whatsnew/v0.20.0.txt
@@ -237,6 +237,7 @@ Other API Changes
 
 - ``CParserError`` has been renamed to ``ParserError`` in ``pd.read_csv`` and will be removed in the future (:issue:`12665`)
 - ``SparseArray.cumsum()`` and ``SparseSeries.cumsum()`` will now always return ``SparseArray`` and ``SparseSeries`` respectively (:issue:`12855`)
+- ``DataFrame.applymap()`` with an empty ``DataFrame`` will return a copy of the empty ``DataFrame`` instead of a ``Series`` (:issue:`8222`)
 
 .. _whatsnew_0200.deprecations:
 
@@ -284,7 +285,6 @@ Bug Fixes
 - Bug in ``DataFrame(..).apply(to_numeric)`` when values are of type decimal.Decimal. (:issue:`14827`)
 - Bug in ``describe()`` when passing a numpy array which does not contain the median to the ``percentiles`` keyword argument (:issue:`14908`)
 - Bug in ``DataFrame.sort_values()`` when sorting by multiple columns where one column is of type ``int64`` and contains ``NaT`` (:issue:`14922`)
-
 
 
 - Bug in ``pd.read_msgpack()`` in which ``Series`` categoricals were being improperly processed (:issue:`14901`)

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -4288,6 +4288,8 @@ class DataFrame(NDFrame):
 
         # if we have a dtype == 'M8[ns]', provide boxed values
         def infer(x):
+            if x.empty:
+                return lib.map_infer(x, func)
             return lib.map_infer(x.asobject, func)
 
         return self.apply(infer)

--- a/pandas/tests/frame/test_apply.py
+++ b/pandas/tests/frame/test_apply.py
@@ -405,6 +405,16 @@ class TestDataFrameApply(tm.TestCase, TestData):
         for f in ['datetime', 'timedelta']:
             self.assertEqual(result.loc[0, f], str(df.loc[0, f]))
 
+        # GH 8222
+        empty_frames = [pd.DataFrame(),
+                        pd.DataFrame(columns=list('ABC')),
+                        pd.DataFrame(index=list('ABC')),
+                        pd.DataFrame({'A': [], 'B': [], 'C': []})]
+        for frame in empty_frames:
+            for func in [round, lambda x: x]:
+                result = frame.applymap(func)
+                tm.assert_frame_equal(result, frame)
+
     def test_applymap_box(self):
         # ufunc will not be boxed. Same test cases as the test_map_box
         df = pd.DataFrame({'a': [pd.Timestamp('2011-01-01'),


### PR DESCRIPTION
 - [x] closes #8222
 - [x] tests added / passed
 - [x] passes ``git diff upstream/master | flake8 --diff``
 - [x] whatsnew entry for 0.20.0

Within `applymap`, the data is converted into a numpy array with `asobject` [here](https://github.com/pandas-dev/pandas/blob/master/pandas/core/frame.py#L4291) and evaluated with the `apply` method `_apply_empty_result` since this frame is empty. The numpy array is compared to an `Series` [here](https://github.com/pandas-dev/pandas/blob/master/pandas/core/frame.py#L4112) which proceeds to get returned as a `Series` [here](https://github.com/pandas-dev/pandas/blob/master/pandas/core/frame.py#L4118). 

Found that passing in the data without using `asobject` allows the logic to return a copy of the empty dataframe [here](https://github.com/pandas-dev/pandas/blob/master/pandas/core/frame.py#L4120).
