### PR TITLE
CLN: used np.__version__ and removed instantiation

### DIFF
--- a/pandas/compat/numpy/__init__.py
+++ b/pandas/compat/numpy/__init__.py
@@ -7,7 +7,7 @@ from pandas.compat import string_types, string_and_binary_types
 
 
 # numpy versioning
-_np_version = np.version.short_version
+_np_version = np.__version__
 _nlv = LooseVersion(_np_version)
 _np_version_under1p8 = _nlv < '1.8'
 _np_version_under1p9 = _nlv < '1.9'
@@ -15,7 +15,7 @@ _np_version_under1p10 = _nlv < '1.10'
 _np_version_under1p11 = _nlv < '1.11'
 _np_version_under1p12 = _nlv < '1.12'
 
-if LooseVersion(_np_version) < '1.7.0':
+if _nlv < '1.7.0':
     raise ImportError('this version of pandas is incompatible with '
                       'numpy < 1.7.0\n'
                       'your numpy version is {0}.\n'


### PR DESCRIPTION
@rkern and others [recommend](http://stackoverflow.com/questions/1520234/how-to-check-which-version-of-numpy-im-using) using `np.__version__` instead of `np.version`. However I realize this is pandas "internals" so there may be some reason for using `np.version` over `np.__version__`. I could not find any such reason. I also removed  a duplicate `LooseVersion(_np_version)` and reused the existing `_nlv` instance.

 - [x] doesn't close any issue, that I'm aware of
 - [x] I ran `nosetests .\pandas\tests\test_compat.py` and 5 tests passed
 - [x] couldn't get the `git` command to work, but `flake8 .\compat\numpy\__init__.py` passes fine
 - [x] whatsnew entry should be covered by `several new features, enhancements, and performance improvements` in the v0.20.0.txt file
