### PR TITLE
BUG: Fixed to_html with index=False and max_rows

### DIFF
--- a/doc/source/whatsnew/v0.20.0.txt
+++ b/doc/source/whatsnew/v0.20.0.txt
@@ -313,6 +313,12 @@ Bug Fixes
 
 
 
+- Bug in ``DataFrame.to_html`` with ``index=False`` and ``max_rows`` raising in ``IndexError`` (:issue:`14998`)
+
+
+
+
+
 
 
 

--- a/pandas/formats/format.py
+++ b/pandas/formats/format.py
@@ -1182,7 +1182,7 @@ class HTMLFormatter(TableFormatter):
             else:
                 self._write_regular_rows(fmt_values, indent)
         else:
-            for i in range(len(self.frame)):
+            for i in range(min(len(self.frame), self.max_rows)):
                 row = [fmt_values[j][i] for j in range(len(self.columns))]
                 self.write_tr(row, indent, self.indent_delta, tags=None)
 

--- a/pandas/tests/formats/test_format.py
+++ b/pandas/tests/formats/test_format.py
@@ -2771,6 +2771,25 @@ c  10  11  12  13  14\
         result = df.to_html(classes=["sortable", "draggable"])
         self.assertEqual(result, expected)
 
+    def test_to_html_no_index_max_rows(self):
+        # GH https://github.com/pandas-dev/pandas/issues/14998
+        df = DataFrame({"A": [1, 2, 3, 4]})
+        result = df.to_html(index=False, max_rows=1)
+        expected = dedent("""\
+        <table border="1" class="dataframe">
+          <thead>
+            <tr style="text-align: right;">
+              <th>A</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>1</td>
+            </tr>
+          </tbody>
+        </table>""")
+        self.assertEqual(result, expected)
+
     def test_pprint_pathological_object(self):
         """
         if the test fails, the stack will overflow and nose crash,


### PR DESCRIPTION
closes https://github.com/pandas-dev/pandas/issues/14998

Previously raised an IndexError by assuming that
`len(fmt_values)` was always the same length as `len(self.data)`.