### PR TITLE
BUG: Convert uint64 in maybe_convert_numeric

### DIFF
--- a/asv_bench/benchmarks/inference.py
+++ b/asv_bench/benchmarks/inference.py
@@ -96,3 +96,22 @@ class to_numeric_downcast(object):
 
     def time_downcast(self, dtype, downcast):
         pd.to_numeric(self.data, downcast=downcast)
+
+
+class MaybeConvertNumeric(object):
+
+    def setup(self):
+        n = 1000000
+        arr = np.repeat([2**63], n)
+        arr = arr + np.arange(n).astype('uint64')
+        arr = np.array([arr[i] if i%2 == 0 else
+                        str(arr[i]) for i in range(n)],
+                       dtype=object)
+
+        arr[-1] = -1
+        self.data = arr
+        self.na_values = set()
+
+    def time_convert(self):
+        pd.lib.maybe_convert_numeric(self.data, self.na_values,
+                                     coerce_numeric=False)

--- a/doc/source/whatsnew/v0.20.0.txt
+++ b/doc/source/whatsnew/v0.20.0.txt
@@ -319,5 +319,5 @@ Bug Fixes
 
 
 - Require at least 0.23 version of cython to avoid problems with character encodings (:issue:`14699`)
-- Bug in converting object elements of array-like objects to unsigned 64-bit integers (:issue:`4471`)
+- Bug in converting object elements of array-like objects to unsigned 64-bit integers (:issue:`4471`, :issue:`14982`)
 - Bug in ``pd.pivot_table()`` where no error was raised when values argument was not in the columns (:issue:`14938`)


### PR DESCRIPTION
Add handling for `uint64` elements in an array with the follow behavior specifications:

1) If `uint64` and `NaN` are both detected, the original input will be returned if `coerce_numeric`
is `False`. Otherwise, an `Exception` is raised.

2) If `uint64` and negative numbers are both detected, the original input be returned if `coerce_numeric` is `False`. Otherwise, an `Exception` is raised.

Closes #14982.
Partial fix for #14983.