### PR TITLE
TST: fix tests catching unorderable errors for python 3.6

### DIFF
--- a/pandas/tests/indexes/test_base.py
+++ b/pandas/tests/indexes/test_base.py
@@ -1807,8 +1807,7 @@ class TestMixedIntIndex(Base, tm.TestCase):
         idx = self.create_index()
         # 9816 deprecated
         if PY36:
-            with tm.assertRaisesRegexp(TypeError, "'>' not supported "
-                                       "between instances of 'str' and 'int'"):
+            with tm.assertRaisesRegexp(TypeError, "'>' not supported"):
                 with tm.assert_produces_warning(FutureWarning):
                     idx.order()
         elif PY3:
@@ -1822,8 +1821,7 @@ class TestMixedIntIndex(Base, tm.TestCase):
     def test_argsort(self):
         idx = self.create_index()
         if PY36:
-            with tm.assertRaisesRegexp(TypeError, "'>' not supported "
-                                       "between instances of 'str' and 'int'"):
+            with tm.assertRaisesRegexp(TypeError, "'>' not supported"):
                 result = idx.argsort()
         elif PY3:
             with tm.assertRaisesRegexp(TypeError, "unorderable types"):
@@ -1836,8 +1834,7 @@ class TestMixedIntIndex(Base, tm.TestCase):
     def test_numpy_argsort(self):
         idx = self.create_index()
         if PY36:
-            with tm.assertRaisesRegexp(TypeError, "'>' not supported "
-                                       "between instances of 'str' and 'int'"):
+            with tm.assertRaisesRegexp(TypeError, "'>' not supported"):
                 result = np.argsort(idx)
         elif PY3:
             with tm.assertRaisesRegexp(TypeError, "unorderable types"):


### PR DESCRIPTION
See also https://github.com/MacPython/pandas-wheels/pull/8, seems that the order of int and str is switched in some cases (eg https://travis-ci.org/MacPython/pandas-wheels/jobs/187223139). Therefore making the test here more robust.

Related to https://github.com/pandas-dev/pandas/pull/14684
