### PR TITLE
DOC: Added examples to pandas.concat documentation

### DIFF
--- a/pandas/tools/merge.py
+++ b/pandas/tools/merge.py
@@ -1402,7 +1402,7 @@ def concat(objs, axis=0, join='outer', join_axes=None, ignore_index=False,
 
     Can also add a layer of hierarchical indexing on the concatenation axis,
     which may be useful if the labels are the same (or overlapping) on
-    the passed axis number
+    the passed axis number.
 
     Parameters
     ----------
@@ -1473,8 +1473,6 @@ def concat(objs, axis=0, join='outer', join_axes=None, ignore_index=False,
     Clear the existing index and reset it in the result
     by setting the ``ignore_index`` option to ``True``.
 
-    >>> s1 = pd.Series(['a', 'b'])
-    >>> s2 = pd.Series(['c', 'd'])
     >>> pd.concat([s1, s2], ignore_index=True)
     0    a
     1    b
@@ -1485,49 +1483,34 @@ def concat(objs, axis=0, join='outer', join_axes=None, ignore_index=False,
     Add a hierarchical index at the outermost level of
     the data with the ``keys`` option.
 
-    >>> s1 = pd.Series(['a', 'b', 'c'])
-    >>> s2 = pd.Series(['c', 'd', 'e'])
     >>> pd.concat([s1, s2], keys=['s1', 's2',])
     s1  0    a
         1    b
-        2    c
     s2  0    c
         1    d
-        2    e
     dtype: object
 
     Label the index keys you create with the ``names`` option.
 
-    >>> s1 = pd.Series(['a', 'b', 'c'])
-    >>> s2 = pd.Series(['c', 'd', 'e'])
-    >>> pd.concat(
-    ...     [s1, s2],
-    ...     keys=['s1', 's2',],
-    ...     names=['Series name', 'Row ID']
-    ... )
+    >>> pd.concat([s1, s2], keys=['s1', 's2'],
+    ...           names=['Series name', 'Row ID'])
     Series name  Row ID
     s1           0         a
                  1         b
-                 2         c
     s2           0         c
                  1         d
-                 2         e
     dtype: object
 
     Combine two ``DataFrame`` objects with identical columns.
 
-    >>> df1 = pd.DataFrame(
-    ...     [['a', 1], ['b', 2]],
-    ...     columns=['letter', 'number']
-    ... )
+    >>> df1 = pd.DataFrame([['a', 1], ['b', 2]],
+    ...                    columns=['letter', 'number'])
     >>> df1
       letter  number
     0      a       1
     1      b       2
-    >>> df2 = pd.DataFrame(
-    ...     [['c', 3], ['d', 4]],
-    ...     columns=['letter', 'number']
-    ... )
+    >>> df2 = pd.DataFrame([['c', 3], ['d', 4]],
+    ...                    columns=['letter', 'number'])
     >>> df2
       letter  number
     0      c       3
@@ -1543,23 +1526,15 @@ def concat(objs, axis=0, join='outer', join_axes=None, ignore_index=False,
     and return everything. Columns outside the intersection will
     be filled with ``NaN`` values.
 
-    >>> df1 = pd.DataFrame(
-    ...     [['a', 1], ['b', 2]],
-    ...     columns=['letter', 'number']
-    ... )
-    >>> df1
-      letter  number
-    0      a       1
-    1      b       2
-    >>> df2 = pd.DataFrame(
+    >>> df3 = pd.DataFrame(
     ...     [['c', 3, 'cat'], ['d', 4, 'dog']],
     ...     columns=['letter', 'number', 'animal']
     ... )
-    >>> df2
+    >>> df3
       letter  number animal
     0      c       3    cat
     1      d       4    dog
-    >>> pd.concat([df1, df2])
+    >>> pd.concat([df1, df3])
       animal letter  number
     0    NaN      a       1
     1    NaN      b       2
@@ -1570,23 +1545,7 @@ def concat(objs, axis=0, join='outer', join_axes=None, ignore_index=False,
     and return only those that are shared by passing ``inner`` to
     the ``join`` keyword argument.
 
-    >>> df1 = pd.DataFrame(
-    ...     [['a', 1], ['b', 2]],
-    ...     columns=['letter', 'number']
-    ... )
-    >>> df1
-      letter  number
-    0      a       1
-    1      b       2
-    >>> df2 = pd.DataFrame(
-    ...     [['c', 3, 'cat'], ['d', 4, 'dog']],
-    ...     columns=['letter', 'number', 'animal']
-    ... )
-    >>> df2
-      letter  number animal
-    0      c       3    cat
-    1      d       4    dog
-    >>> pd.concat([df1, df2], join="inner")
+    >>> pd.concat([df1, df3], join="inner")
       letter  number
     0      a       1
     1      b       2
@@ -1596,39 +1555,25 @@ def concat(objs, axis=0, join='outer', join_axes=None, ignore_index=False,
     Combine ``DataFrame`` objects horizonally along the x axis by
     passing in ``axis=1``.
 
-    >>> df1 = pd.DataFrame(
-    ...     [['a', 1], ['b', 2]],
-    ...     columns=['letter', 'number']
-    ... )
-    >>> df1
-      letter  number
-    0      a       1
-    1      b       2
-    >>> df2 = pd.DataFrame(
-    ...     [['c', 3], ['d', 4]],
-    ...     columns=['letter', 'number']
-    ... )
-    >>> df2
-      letter  number
-    0      c       3
-    1      d       4
-    >>> pd.concat([df1, df2], axis=1)
-      letter  number letter  number
-    0      a       1      c       3
-    1      b       2      d       4
+    >>> df4 = pd.DataFrame([['bird', 'polly'], ['monkey', 'george']],
+    ...                    columns=['animal', 'name'])
+    >>> pd.concat([df1, df4], axis=1)
+      letter  number  animal    name
+    0      a       1    bird   polly
+    1      b       2  monkey  george
 
     Prevent the result from including duplicate index values with the
     ``verify_integrity`` option.
 
-    >>> df1 = pd.DataFrame([1], index=['a'])
-    >>> df1
+    >>> df5 = pd.DataFrame([1], index=['a'])
+    >>> df5
        0
     a  1
-    >>> df2 = pd.DataFrame([2], index=['a'])
-    >>> df2
+    >>> df6 = pd.DataFrame([2], index=['a'])
+    >>> df6
        0
     a  2
-    >>> pd.concat([df1, df2], verify_integrity=True)
+    >>> pd.concat([df5, df6], verify_integrity=True)
     ValueError: Indexes have overlapping values: ['a']
     """
     op = _Concatenator(objs, axis=axis, join_axes=join_axes,

--- a/pandas/tools/merge.py
+++ b/pandas/tools/merge.py
@@ -1471,13 +1471,12 @@ def concat(objs, axis=0, join='outer', join_axes=None, ignore_index=False,
     3    d
     dtype: object
 
-    Add a ``hierarchical index`` at the outermost level of
+    Add a hierarchical index at the outermost level of
     the data.
 
     >>> s1 = pd.Series(['a', 'b', 'c'])
     >>> s2 = pd.Series(['c', 'd', 'e'])
-    >>> c = pd.concat([s1, s2], keys=["s1", 's2',])
-    >>> c
+    >>> pd.concat([s1, s2], keys=['s1', 's2',])
     s1  0    a
         1    b
         2    c
@@ -1485,25 +1484,16 @@ def concat(objs, axis=0, join='outer', join_axes=None, ignore_index=False,
         1    d
         2    e
     dtype: object
-    >>> c.ix['s1']
-    0    a
-    1    b
-    2    c
-    dtype: object
-    >>> c.ix['s2']
-    0    c
-    1    d
-    2    e
-    dtype: object
-    >>> c.ix['s1'].ix[0]
-    'a'
 
     Label the index keys with the ``names`` option.
 
     >>> s1 = pd.Series(['a', 'b', 'c'])
     >>> s2 = pd.Series(['c', 'd', 'e'])
-    >>> c = pd.concat([s1, s2], keys=["s1", 's2',], names=["Series name", "Row ID"])
-    >>> c
+    >>> pd.concat(
+    ...     [s1, s2],
+    ...     keys=['s1', 's2',],
+    ...     names=['Series name', 'Row ID']
+    ... )
     Series name  Row ID
     s1           0         a
                  1         b
@@ -1511,12 +1501,6 @@ def concat(objs, axis=0, join='outer', join_axes=None, ignore_index=False,
     s2           0         c
                  1         d
                  2         e
-    dtype: object
-    >>> c.loc('Series name')['s1']
-    Row ID
-    0    a
-    1    b
-    2    c
     dtype: object
 
     Combine two ``DataFrame`` objects with identical columns.

--- a/pandas/tools/merge.py
+++ b/pandas/tools/merge.py
@@ -1447,7 +1447,8 @@ def concat(objs, axis=0, join='outer', join_axes=None, ignore_index=False,
     The keys, levels, and names arguments are all optional.
 
     A walkthrough of how this method fits in with other tools for combining
-    panda objects can be found `here </pandas-docs/stable/merging.html>`_.
+    panda objects can be found `here
+    <http://pandas.pydata.org/pandas-docs/stable/merging.html>`__.
 
     See Also
     --------
@@ -1455,7 +1456,6 @@ def concat(objs, axis=0, join='outer', join_axes=None, ignore_index=False,
     DataFrame.append
     DataFrame.join
     DataFrame.merge
-    Panel.join
 
     Examples
     --------
@@ -1550,7 +1550,7 @@ def concat(objs, axis=0, join='outer', join_axes=None, ignore_index=False,
     0      c       3
     1      d       4
 
-    Combine ``DataFrame`` objects horizonally along the x axis by
+    Combine ``DataFrame`` objects horizontally along the x axis by
     passing in ``axis=1``.
 
     >>> df4 = pd.DataFrame([['bird', 'polly'], ['monkey', 'george']],

--- a/pandas/tools/merge.py
+++ b/pandas/tools/merge.py
@@ -1498,6 +1498,27 @@ def concat(objs, axis=0, join='outer', join_axes=None, ignore_index=False,
     >>> c.ix['s1'].ix[0]
     'a'
 
+    Label the index keys with the ``names`` option.
+
+    >>> s1 = pd.Series(['a', 'b', 'c'])
+    >>> s2 = pd.Series(['c', 'd', 'e'])
+    >>> c = pd.concat([s1, s2], keys=["s1", 's2',], names=["Series name", "Row ID"])
+    >>> c
+    Series name  Row ID
+    s1           0         a
+                 1         b
+                 2         c
+    s2           0         c
+                 1         d
+                 2         e
+    dtype: object
+    >>> c.loc('Series name')['s1']
+    Row ID
+    0    a
+    1    b
+    2    c
+    dtype: object
+
     Combine two ``DataFrame`` objects with identical columns.
 
     >>> df1 = pd.DataFrame(

--- a/pandas/tools/merge.py
+++ b/pandas/tools/merge.py
@@ -1398,9 +1398,11 @@ def concat(objs, axis=0, join='outer', join_axes=None, ignore_index=False,
            copy=True):
     """
     Concatenate pandas objects along a particular axis with optional set logic
-    along the other axes. Can also add a layer of hierarchical indexing on the
-    concatenation axis, which may be useful if the labels are the same (or
-    overlapping) on the passed axis number
+    along the other axes.
+
+    Can also add a layer of hierarchical indexing on the concatenation axis,
+    which may be useful if the labels are the same (or overlapping) on
+    the passed axis number
 
     Parameters
     ----------
@@ -1436,13 +1438,51 @@ def concat(objs, axis=0, join='outer', join_axes=None, ignore_index=False,
     copy : boolean, default True
         If False, do not copy data unnecessarily
 
-    Notes
-    -----
-    The keys, levels, and names arguments are all optional
-
     Returns
     -------
     concatenated : type of objects
+
+    Notes
+    -----
+    The keys, levels, and names arguments are all optional.
+
+    Examples
+    --------
+    Combine two ``Series``.
+
+        >>> import pandas as pd
+        >>> s1 = pd.Series(['a', 'b'])
+        >>> s2 = pd.Series(['c', 'd'])
+        >>> pd.concat([s1, s2])
+        0    a
+        1    b
+        0    c
+        1    d
+
+    Combine two ``DataFrame`` objects with identical columns.
+
+        >>> df1 = pd.DataFrame(
+        ...     [['a', 1], ['b', 2]],
+        ...     columns=['letter', 'number']
+        ... )
+        >>> df1
+          letter  number
+        0      a       1
+        1      b       2
+        >>> df2 = pd.DataFrame(
+        ...     [['c', 3], ['d', 4]],
+        ...     columns=['letter', 'number']
+        ... )
+        >>> df2
+          letter  number
+        0      c       3
+        1      d       4
+        >>> pd.concat([df1, df2])
+          letter  number
+        0      a       1
+        1      b       2
+        0      c       3
+        1      d       4
     """
     op = _Concatenator(objs, axis=axis, join_axes=join_axes,
                        ignore_index=ignore_index, join=join,

--- a/pandas/tools/merge.py
+++ b/pandas/tools/merge.py
@@ -1471,6 +1471,33 @@ def concat(objs, axis=0, join='outer', join_axes=None, ignore_index=False,
     3    d
     dtype: object
 
+    Add a ``hierarchical index`` at the outermost level of
+    the data.
+
+    >>> s1 = pd.Series(['a', 'b', 'c'])
+    >>> s2 = pd.Series(['c', 'd', 'e'])
+    >>> c = pd.concat([s1, s2], keys=["s1", 's2',])
+    >>> c
+    s1  0    a
+        1    b
+        2    c
+    s2  0    c
+        1    d
+        2    e
+    dtype: object
+    >>> c.ix['s1']
+    0    a
+    1    b
+    2    c
+    dtype: object
+    >>> c.ix['s2']
+    0    c
+    1    d
+    2    e
+    dtype: object
+    >>> c.ix['s1'].ix[0]
+    'a'
+
     Combine two ``DataFrame`` objects with identical columns.
 
     >>> df1 = pd.DataFrame(

--- a/pandas/tools/merge.py
+++ b/pandas/tools/merge.py
@@ -1526,10 +1526,8 @@ def concat(objs, axis=0, join='outer', join_axes=None, ignore_index=False,
     and return everything. Columns outside the intersection will
     be filled with ``NaN`` values.
 
-    >>> df3 = pd.DataFrame(
-    ...     [['c', 3, 'cat'], ['d', 4, 'dog']],
-    ...     columns=['letter', 'number', 'animal']
-    ... )
+    >>> df3 = pd.DataFrame([['c', 3, 'cat'], ['d', 4, 'dog']],
+    ...                    columns=['letter', 'number', 'animal'])
     >>> df3
       letter  number animal
     0      c       3    cat

--- a/pandas/tools/merge.py
+++ b/pandas/tools/merge.py
@@ -1446,6 +1446,17 @@ def concat(objs, axis=0, join='outer', join_axes=None, ignore_index=False,
     -----
     The keys, levels, and names arguments are all optional.
 
+    A walkthrough of how this method fits in with other tools for combining
+    panda objects can be found `here </pandas-docs/stable/merging.html>`_.
+
+    See Also
+    --------
+    Series.append
+    DataFrame.append
+    DataFrame.join
+    DataFrame.merge
+    Panel.join
+
     Examples
     --------
     Combine two ``Series``.
@@ -1472,7 +1483,7 @@ def concat(objs, axis=0, join='outer', join_axes=None, ignore_index=False,
     dtype: object
 
     Add a hierarchical index at the outermost level of
-    the data.
+    the data with the ``keys`` option.
 
     >>> s1 = pd.Series(['a', 'b', 'c'])
     >>> s2 = pd.Series(['c', 'd', 'e'])
@@ -1485,7 +1496,7 @@ def concat(objs, axis=0, join='outer', join_axes=None, ignore_index=False,
         2    e
     dtype: object
 
-    Label the index keys with the ``names`` option.
+    Label the index keys you create with the ``names`` option.
 
     >>> s1 = pd.Series(['a', 'b', 'c'])
     >>> s2 = pd.Series(['c', 'd', 'e'])
@@ -1529,7 +1540,8 @@ def concat(objs, axis=0, join='outer', join_axes=None, ignore_index=False,
     1      d       4
 
     Combine ``DataFrame`` objects with overlapping columns
-    and return everything.
+    and return everything. Columns outside the intersection will
+    be filled with ``NaN`` values.
 
     >>> df1 = pd.DataFrame(
     ...     [['a', 1], ['b', 2]],
@@ -1555,7 +1567,7 @@ def concat(objs, axis=0, join='outer', join_axes=None, ignore_index=False,
     1    dog      d       4
 
     Combine ``DataFrame`` objects with overlapping columns
-    and return only those that are shared pass ``inner`` to
+    and return only those that are shared by passing ``inner`` to
     the ``join`` keyword argument.
 
     >>> df1 = pd.DataFrame(
@@ -1581,9 +1593,9 @@ def concat(objs, axis=0, join='outer', join_axes=None, ignore_index=False,
     0      c       3
     1      d       4
 
-    Combine ``DataFrame`` objects horizonally along the x axis using the index.
+    Combine ``DataFrame`` objects horizonally along the x axis by
+    passing in ``axis=1``.
 
-    >>> import pandas as pd
     >>> df1 = pd.DataFrame(
     ...     [['a', 1], ['b', 2]],
     ...     columns=['letter', 'number']
@@ -1597,6 +1609,20 @@ def concat(objs, axis=0, join='outer', join_axes=None, ignore_index=False,
       letter  number letter  number
     0      a       1      b     3.0
     1      b       2    NaN     NaN
+
+    Prevent the result from including duplicate index values with the
+    ``verify_integrity`` option.
+
+    >>> df1 = pd.DataFrame([1], index=['a'])
+    >>> df1
+       0
+    a  1
+    >>> df2 = pd.DataFrame([2], index=['a'])
+    >>> df2
+       0
+    a  2
+    >>> pd.concat([df1, df2], verify_integrity=True)
+    ValueError: Indexes have overlapping values: ['a']
     """
     op = _Concatenator(objs, axis=axis, join_axes=join_axes,
                        ignore_index=ignore_index, join=join,

--- a/pandas/tools/merge.py
+++ b/pandas/tools/merge.py
@@ -705,7 +705,7 @@ class _MergeOperation(object):
                 _left_join_on_index(left_ax, right_ax, self.left_join_keys,
                                     sort=self.sort)
 
-        elif self.tleft_index and self.how == 'right':
+        elif self.left_index and self.how == 'right':
             join_index, right_indexer, left_indexer = \
                 _left_join_on_index(right_ax, left_ax, self.right_join_keys,
                                     sort=self.sort)

--- a/pandas/tools/merge.py
+++ b/pandas/tools/merge.py
@@ -1600,15 +1600,22 @@ def concat(objs, axis=0, join='outer', join_axes=None, ignore_index=False,
     ...     [['a', 1], ['b', 2]],
     ...     columns=['letter', 'number']
     ... )
-    >>>
+    >>> df1
+      letter  number
+    0      a       1
+    1      b       2
     >>> df2 = pd.DataFrame(
-    ...     [['b', 3],],
+    ...     [['c', 3], ['d', 4]],
     ...     columns=['letter', 'number']
     ... )
+    >>> df2
+      letter  number
+    0      c       3
+    1      d       4
     >>> pd.concat([df1, df2], axis=1)
       letter  number letter  number
-    0      a       1      b     3.0
-    1      b       2    NaN     NaN
+    0      a       1      c       3
+    1      b       2      d       4
 
     Prevent the result from including duplicate index values with the
     ``verify_integrity`` option.

--- a/pandas/tools/merge.py
+++ b/pandas/tools/merge.py
@@ -1528,6 +1528,59 @@ def concat(objs, axis=0, join='outer', join_axes=None, ignore_index=False,
     0      c       3
     1      d       4
 
+    Combine ``DataFrame`` objects with overlapping columns
+    and return everything.
+
+    >>> df1 = pd.DataFrame(
+    ...     [['a', 1], ['b', 2]],
+    ...     columns=['letter', 'number']
+    ... )
+    >>> df1
+      letter  number
+    0      a       1
+    1      b       2
+    >>> df2 = pd.DataFrame(
+    ...     [['c', 3, 'cat'], ['d', 4, 'dog']],
+    ...     columns=['letter', 'number', 'animal']
+    ... )
+    >>> df2
+      letter  number animal
+    0      c       3    cat
+    1      d       4    dog
+    >>> pd.concat([df1, df2])
+      animal letter  number
+    0    NaN      a       1
+    1    NaN      b       2
+    0    cat      c       3
+    1    dog      d       4
+
+    Combine ``DataFrame`` objects with overlapping columns
+    and return only those that are shared pass ``inner`` to
+    the ``join`` keyword argument.
+
+    >>> df1 = pd.DataFrame(
+    ...     [['a', 1], ['b', 2]],
+    ...     columns=['letter', 'number']
+    ... )
+    >>> df1
+      letter  number
+    0      a       1
+    1      b       2
+    >>> df2 = pd.DataFrame(
+    ...     [['c', 3, 'cat'], ['d', 4, 'dog']],
+    ...     columns=['letter', 'number', 'animal']
+    ... )
+    >>> df2
+      letter  number animal
+    0      c       3    cat
+    1      d       4    dog
+    >>> pd.concat([df1, df2], join="inner")
+      letter  number
+    0      a       1
+    1      b       2
+    0      c       3
+    1      d       4
+
     Combine ``DataFrame`` objects horizonally along the x axis using the index.
 
     >>> import pandas as pd

--- a/pandas/tools/merge.py
+++ b/pandas/tools/merge.py
@@ -1527,6 +1527,29 @@ def concat(objs, axis=0, join='outer', join_axes=None, ignore_index=False,
     1      b       2
     0      c       3
     1      d       4
+
+    Combine ``DataFrame`` objects horizonally along the x axis.
+
+    >>> df1 = pd.DataFrame(
+    ...     [['a', 1], ['b', 2]],
+    ...     columns=['letter', 'number']
+    ... )
+    >>> df1
+      letter  number
+    0      a       1
+    1      b       2
+    >>> df2 = pd.DataFrame(
+    ...     [['c', 3], ['d', 4]],
+    ...     columns=['letter', 'number']
+    ... )
+    >>> df2
+      letter  number
+    0      c       3
+    1      d       4
+    >>> pd.concat([df1, df2], axis=1)
+      letter  number letter  number
+    0      a       1      b       3
+    1      b       2      c       4
     """
     op = _Concatenator(objs, axis=axis, join_axes=join_axes,
                        ignore_index=ignore_index, join=join,

--- a/pandas/tools/merge.py
+++ b/pandas/tools/merge.py
@@ -1450,7 +1450,6 @@ def concat(objs, axis=0, join='outer', join_axes=None, ignore_index=False,
     --------
     Combine two ``Series``.
 
-    >>> import pandas as pd
     >>> s1 = pd.Series(['a', 'b'])
     >>> s2 = pd.Series(['c', 'd'])
     >>> pd.concat([s1, s2])

--- a/pandas/tools/merge.py
+++ b/pandas/tools/merge.py
@@ -1528,28 +1528,22 @@ def concat(objs, axis=0, join='outer', join_axes=None, ignore_index=False,
     0      c       3
     1      d       4
 
-    Combine ``DataFrame`` objects horizonally along the x axis.
+    Combine ``DataFrame`` objects horizonally along the x axis using the index.
 
+    >>> import pandas as pd
     >>> df1 = pd.DataFrame(
     ...     [['a', 1], ['b', 2]],
     ...     columns=['letter', 'number']
     ... )
-    >>> df1
-      letter  number
-    0      a       1
-    1      b       2
+    >>>
     >>> df2 = pd.DataFrame(
-    ...     [['c', 3], ['d', 4]],
+    ...     [['b', 3],],
     ...     columns=['letter', 'number']
     ... )
-    >>> df2
-      letter  number
-    0      c       3
-    1      d       4
     >>> pd.concat([df1, df2], axis=1)
       letter  number letter  number
-    0      a       1      b       3
-    1      b       2      c       4
+    0      a       1      b     3.0
+    1      b       2    NaN     NaN
     """
     op = _Concatenator(objs, axis=axis, join_axes=join_axes,
                        ignore_index=ignore_index, join=join,

--- a/pandas/tools/merge.py
+++ b/pandas/tools/merge.py
@@ -705,7 +705,7 @@ class _MergeOperation(object):
                 _left_join_on_index(left_ax, right_ax, self.left_join_keys,
                                     sort=self.sort)
 
-        elif self.left_index and self.how == 'right':
+        elif self.tleft_index and self.how == 'right':
             join_index, right_indexer, left_indexer = \
                 _left_join_on_index(right_ax, left_ax, self.right_join_keys,
                                     sort=self.sort)
@@ -1450,39 +1450,52 @@ def concat(objs, axis=0, join='outer', join_axes=None, ignore_index=False,
     --------
     Combine two ``Series``.
 
-        >>> import pandas as pd
-        >>> s1 = pd.Series(['a', 'b'])
-        >>> s2 = pd.Series(['c', 'd'])
-        >>> pd.concat([s1, s2])
-        0    a
-        1    b
-        0    c
-        1    d
+    >>> import pandas as pd
+    >>> s1 = pd.Series(['a', 'b'])
+    >>> s2 = pd.Series(['c', 'd'])
+    >>> pd.concat([s1, s2])
+    0    a
+    1    b
+    0    c
+    1    d
+    dtype: object
+
+    Ignore the existing index and reset it in the result
+    by setting the ``ignore_index`` option to ``True``.
+
+    >>> s1 = pd.Series(['a', 'b'])
+    >>> s2 = pd.Series(['c', 'd'])
+    >>> pd.concat([s1, s2], ignore_index=True)
+    0    a
+    1    b
+    2    c
+    3    d
+    dtype: object
 
     Combine two ``DataFrame`` objects with identical columns.
 
-        >>> df1 = pd.DataFrame(
-        ...     [['a', 1], ['b', 2]],
-        ...     columns=['letter', 'number']
-        ... )
-        >>> df1
-          letter  number
-        0      a       1
-        1      b       2
-        >>> df2 = pd.DataFrame(
-        ...     [['c', 3], ['d', 4]],
-        ...     columns=['letter', 'number']
-        ... )
-        >>> df2
-          letter  number
-        0      c       3
-        1      d       4
-        >>> pd.concat([df1, df2])
-          letter  number
-        0      a       1
-        1      b       2
-        0      c       3
-        1      d       4
+    >>> df1 = pd.DataFrame(
+    ...     [['a', 1], ['b', 2]],
+    ...     columns=['letter', 'number']
+    ... )
+    >>> df1
+      letter  number
+    0      a       1
+    1      b       2
+    >>> df2 = pd.DataFrame(
+    ...     [['c', 3], ['d', 4]],
+    ...     columns=['letter', 'number']
+    ... )
+    >>> df2
+      letter  number
+    0      c       3
+    1      d       4
+    >>> pd.concat([df1, df2])
+      letter  number
+    0      a       1
+    1      b       2
+    0      c       3
+    1      d       4
     """
     op = _Concatenator(objs, axis=axis, join_axes=join_axes,
                        ignore_index=ignore_index, join=join,

--- a/pandas/tools/merge.py
+++ b/pandas/tools/merge.py
@@ -1459,7 +1459,7 @@ def concat(objs, axis=0, join='outer', join_axes=None, ignore_index=False,
     1    d
     dtype: object
 
-    Ignore the existing index and reset it in the result
+    Clear the existing index and reset it in the result
     by setting the ``ignore_index`` option to ``True``.
 
     >>> s1 = pd.Series(['a', 'b'])


### PR DESCRIPTION
I've added two simple examples to the ``pd.concat`` documentation. I've also done a very small amount of clean up on the rest of the docstring.

 - [x] passes ``git diff upstream/master | flake8 --diff``