### PR TITLE
COMPAT: py2.7 compat for Timestamp.replace

### DIFF
--- a/doc/source/whatsnew/v0.20.0.txt
+++ b/doc/source/whatsnew/v0.20.0.txt
@@ -305,7 +305,7 @@ Bug Fixes
 
 - Bug in ``Series`` construction with a datetimetz (:issue:`14928`)
 
-
+- Bug in compat for passing long integers to ``Timestamp.replace`` (:issue:`15030`)
 
 
 

--- a/pandas/tseries/tests/test_timeseries.py
+++ b/pandas/tseries/tests/test_timeseries.py
@@ -1883,6 +1883,17 @@ class TestTimeSeries(tm.TestCase):
         self.assertRaises(ValueError, DatetimeIndex, ['1400-01-01'])
         self.assertRaises(ValueError, DatetimeIndex, [datetime(1400, 1, 1)])
 
+    def test_compat_replace(self):
+        # https://github.com/statsmodels/statsmodels/issues/3349
+        # replace should take ints/longs for compat
+
+        for f in [compat.long, int]:
+            result = date_range(Timestamp('1960-04-01 00:00:00',
+                                          freq='QS-JAN'),
+                                periods=f(76),
+                                freq='QS-JAN')
+            self.assertEqual(len(result), 76)
+
     def test_timestamp_repr(self):
         # pre-1900
         stamp = Timestamp('1850-01-01', tz='US/Eastern')

--- a/pandas/tslib.pyx
+++ b/pandas/tslib.pyx
@@ -687,7 +687,7 @@ class Timestamp(_Timestamp):
         # replace
         def validate(k, v):
             """ validate integers """
-            if not isinstance(v, int):
+            if not is_integer_object(v):
                 raise ValueError("value must be an integer, received "
                                  "{v} for {k}".format(v=type(v), k=k))
             return v


### PR DESCRIPTION
compat in Timestamp.replace when passing longs (and not ints)

xref https://github.com/statsmodels/statsmodels/issues/3349