### PR TITLE
DOC: Typing error in ExcelFile class example

### DIFF
--- a/doc/source/io.rst
+++ b/doc/source/io.rst
@@ -2372,7 +2372,7 @@ read into memory only once.
 
 .. code-block:: python
 
-   xlsx = pd.ExcelFile('path_to_file.xls)
+   xlsx = pd.ExcelFile('path_to_file.xls')
    df = pd.read_excel(xlsx, 'Sheet1')
 
 The ``ExcelFile`` class can also be used as a context manager.


### PR DESCRIPTION
 - [x] closes #15037
 - [ ] tests added / passed
 - [ ] passes ``git diff upstream/master | flake8 --diff``
 - [ ] whatsnew entry

- Tests with local build of documentation passed
- Flake8 seems to be relevant for source code changes, only
- Thought that a whatsnew entry is not relevant in this case