### PR TITLE
BUG: Indexing MultiIndex with Series failed.

### DIFF
--- a/doc/source/whatsnew/v0.20.0.txt
+++ b/doc/source/whatsnew/v0.20.0.txt
@@ -297,7 +297,7 @@ Bug Fixes
 - Bug in ``pd.to_numeric()`` in which float and unsigned integer elements were being improperly casted (:issue:`14941`, :issue:`15005`)
 - Bug in ``pd.read_csv()`` in which the ``dialect`` parameter was not being verified before processing (:issue:`14898`)
 
-
+- Bug in ``DataFrame`` where indexing a ``MultiIndex`` using a ``Series`` failed (:issue:`14730`)
 
 - Bug in ``pd.read_msgpack()`` in which ``Series`` categoricals were being improperly processed (:issue:`14901`)
 - Bug in ``Series.ffill()`` with mixed dtypes containing tz-aware datetimes. (:issue:`14956`)

--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -1461,6 +1461,9 @@ class _LocIndexer(_LocationIndexer):
             if isinstance(labels, MultiIndex):
                 if (not isinstance(key, tuple) and len(key) > 1 and
                         not isinstance(key[0], tuple)):
+                    if isinstance(key, ABCSeries):
+                        # GH 14730
+                        key = key.values.tolist()
                     key = tuple([key])
 
             # an iterable multi-selection

--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -1463,7 +1463,7 @@ class _LocIndexer(_LocationIndexer):
                         not isinstance(key[0], tuple)):
                     if isinstance(key, ABCSeries):
                         # GH 14730
-                        key = key.values.tolist()
+                        key = list(key)
                     key = tuple([key])
 
             # an iterable multi-selection

--- a/pandas/tests/indexes/test_multi.py
+++ b/pandas/tests/indexes/test_multi.py
@@ -1,26 +1,29 @@
 # -*- coding: utf-8 -*-
 
-from datetime import timedelta
-from itertools import product
-import nose
 import re
 import warnings
 
-from pandas import (DataFrame, date_range, period_range, MultiIndex, Index,
-                    CategoricalIndex, compat)
-from pandas.core.common import PerformanceWarning, UnsortedIndexError
-from pandas.indexes.base import InvalidIndexError
-from pandas.compat import range, lrange, u, PY3, long, lzip
+from datetime import timedelta
+from itertools import product
+
+import nose
 
 import numpy as np
 
-from pandas.util.testing import (assert_almost_equal, assertRaises,
-                                 assertRaisesRegexp, assert_copy)
+import pandas as pd
+
+from pandas import (CategoricalIndex, DataFrame, Index, MultiIndex, Series,
+                    compat, date_range, period_range)
+from pandas.compat import PY3, long, lrange, lzip, range, u
+from pandas.core.common import PerformanceWarning, UnsortedIndexError
+from pandas.indexes.base import InvalidIndexError
+from pandas.lib import Timestamp
 
 import pandas.util.testing as tm
 
-import pandas as pd
-from pandas.lib import Timestamp
+from pandas.util.testing import (assertRaises, assertRaisesRegexp,
+                                 assert_almost_equal, assert_copy)
+
 
 from .common import Base
 
@@ -342,6 +345,19 @@ class TestMultiIndex(Base, tm.TestCase):
 
         with tm.assertRaisesRegexp(TypeError, 'string'):
             self.index.set_names(names, level=0)
+
+    def test_series_index(self):
+        # GH14730
+        index = MultiIndex.from_product([[1, 2, 3], ['A', 'B', 'C']])
+        x = Series(index=index, data=range(9))
+        y = Series([1, 3])
+        expected = Series(
+            data=[0, 1, 2, 6, 7, 8],
+            index=MultiIndex.from_product([[1, 3], ['A', 'B', 'C']]))
+        actual_from_series = x.loc[y]
+        actual_from_list = x.loc[[1, 3]]
+        tm.assert_series_equal(expected, actual_from_list)
+        tm.assert_series_equal(expected, actual_from_series)
 
     def test_set_levels_categorical(self):
         # GH13854

--- a/pandas/tests/indexes/test_multi.py
+++ b/pandas/tests/indexes/test_multi.py
@@ -12,7 +12,7 @@ import numpy as np
 
 import pandas as pd
 
-from pandas import (CategoricalIndex, DataFrame, Index, MultiIndex, Series,
+from pandas import (CategoricalIndex, DataFrame, Index, MultiIndex,
                     compat, date_range, period_range)
 from pandas.compat import PY3, long, lrange, lzip, range, u
 from pandas.core.common import PerformanceWarning, UnsortedIndexError
@@ -345,19 +345,6 @@ class TestMultiIndex(Base, tm.TestCase):
 
         with tm.assertRaisesRegexp(TypeError, 'string'):
             self.index.set_names(names, level=0)
-
-    def test_series_index(self):
-        # GH14730
-        index = MultiIndex.from_product([[1, 2, 3], ['A', 'B', 'C']])
-        x = Series(index=index, data=range(9))
-        y = Series([1, 3])
-        expected = Series(
-            data=[0, 1, 2, 6, 7, 8],
-            index=MultiIndex.from_product([[1, 3], ['A', 'B', 'C']]))
-        actual_from_series = x.loc[y]
-        actual_from_list = x.loc[[1, 3]]
-        tm.assert_series_equal(expected, actual_from_list)
-        tm.assert_series_equal(expected, actual_from_series)
 
     def test_set_levels_categorical(self):
         # GH13854

--- a/pandas/tests/test_multilevel.py
+++ b/pandas/tests/test_multilevel.py
@@ -709,7 +709,6 @@ x   q   30      3    -0.6662 -0.5243 -0.3580  0.89145  2.5838"""
         result3 = x.loc[empty_series]
         tm.assert_series_equal(result3, expected2)
 
-
     def test_getitem_slice_not_sorted(self):
         df = self.frame.sortlevel(1).T
 

--- a/pandas/tests/test_multilevel.py
+++ b/pandas/tests/test_multilevel.py
@@ -690,6 +690,25 @@ x   q   30      3    -0.6662 -0.5243 -0.3580  0.89145  2.5838"""
         expected.columns = expected.columns.droplevel(0).droplevel(0)
         assert_frame_equal(result, expected)
 
+    def test_series_index(self):
+        # GH14730
+        index = MultiIndex.from_product([[1, 2, 3], ['A', 'B', 'C']])
+        x = Series(index=index, data=range(9), dtype=np.float64)
+        y = Series([1, 3])
+        expected = Series(
+            data=[0, 1, 2, 6, 7, 8],
+            index=MultiIndex.from_product([[1, 3], ['A', 'B', 'C']]),
+            dtype=np.float64)
+        result = x.loc[y]
+        result2 = x.loc[[1, 3]]
+        tm.assert_series_equal(result, expected)
+        tm.assert_series_equal(result2, expected)
+        empty_series = Series(data=[], dtype=np.float64)
+        expected2 = Series([], index=MultiIndex(
+            levels=index.levels, labels=[[], []], dtype=np.float64))
+        result3 = x.loc[empty_series]
+        tm.assert_series_equal(result3, expected2)
+
     def test_getitem_slice_not_sorted(self):
         df = self.frame.sortlevel(1).T
 

--- a/pandas/tests/test_multilevel.py
+++ b/pandas/tests/test_multilevel.py
@@ -709,6 +709,7 @@ x   q   30      3    -0.6662 -0.5243 -0.3580  0.89145  2.5838"""
         result3 = x.loc[empty_series]
         tm.assert_series_equal(result3, expected2)
 
+
     def test_getitem_slice_not_sorted(self):
         df = self.frame.sortlevel(1).T
 


### PR DESCRIPTION
Previously, accessing elements of a MultiIndex-indexed DataFrame with a Series
failed. This changes that behavior so that it is possible to use a Series to
access elements from a MultiIndex-indexed DataFrame, just as one would use
a list.

 - [x] closes #14730
 - [x] tests added / passed
 - [x] passes ``git diff upstream/master | flake8 --diff``
 - [x] whatsnew entry