### PR TITLE
TST: Test empty method and simplify logic

### DIFF
--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -909,7 +909,7 @@ class NDFrame(PandasObject):
         pandas.Series.dropna
         pandas.DataFrame.dropna
         """
-        return not all(len(self._get_axis(a)) > 0 for a in self._AXIS_ORDERS)
+        return any(len(self._get_axis(a)) == 0 for a in self._AXIS_ORDERS)
 
     def __nonzero__(self):
         raise ValueError("The truth value of a {0} is ambiguous. "

--- a/pandas/tests/frame/test_misc_api.py
+++ b/pandas/tests/frame/test_misc_api.py
@@ -410,9 +410,18 @@ class TestDataFrameMisc(tm.TestCase, SharedWithSparse, TestData):
     def test_empty_nonzero(self):
         df = DataFrame([1, 2, 3])
         self.assertFalse(df.empty)
+        df = pd.DataFrame(index=[1], columns=[1])
+        self.assertFalse(df.empty)
         df = DataFrame(index=['a', 'b'], columns=['c', 'd']).dropna()
         self.assertTrue(df.empty)
         self.assertTrue(df.T.empty)
+        empty_frames = [pd.DataFrame(),
+                        pd.DataFrame(index=[1]),
+                        pd.DataFrame(columns=[1]),
+                        pd.DataFrame({1: []})]
+        for df in empty_frames:
+            self.assertTrue(df.empty)
+            self.assertTrue(df.T.empty)
 
     def test_inplace_return_self(self):
         # re #1893

--- a/pandas/tests/series/test_misc_api.py
+++ b/pandas/tests/series/test_misc_api.py
@@ -343,3 +343,10 @@ class TestSeriesMisc(TestData, SharedWithSparse, tm.TestCase):
         s = Series(range(5))
         with self.assertRaisesRegexp(AttributeError, 'only use .str accessor'):
             s.str.repeat(2)
+
+    def test_empty_method(self):
+        s_empty = pd.Series()
+        tm.assert_equal(s_empty.empty, True)
+
+        for full_series in [pd.Series([1]), pd.Series(index=[1])]:
+            tm.assert_equal(full_series.empty, False)


### PR DESCRIPTION
 - [x] tests added / passed
 - [x] passes ``git diff upstream/master | flake8 --diff``

Since the docstring of `.empty` states

>  True if NDFrame is entirely empty [no items], meaning any of the axes are of length 0.

I was wondering if the logic could be changed accordingly for code clarity. Unless it was set as `not all(len(self._get_axis(a)) > 0 for a in self._AXIS_ORDERS)` for a particular reason.

Also this method did not appear to have any test. 