### PR TITLE
ERR: Disallow multi-char quotechar for C engine

### DIFF
--- a/doc/source/whatsnew/v0.20.0.txt
+++ b/doc/source/whatsnew/v0.20.0.txt
@@ -246,6 +246,7 @@ Other API Changes
 - ``DataFrame.applymap()`` with an empty ``DataFrame`` will return a copy of the empty ``DataFrame`` instead of a ``Series`` (:issue:`8222`)
 
 - ``pd.read_csv()`` will now issue a ``ParserWarning`` whenever there are conflicting values provided by the ``dialect`` parameter and the user (:issue:`14898`)
+- ``pd.read_csv()`` will now raise a ``ValueError`` for the C engine if the quote character is larger than than one byte (:issue:`11592`)
 
 .. _whatsnew_0200.deprecations:
 

--- a/pandas/io/parsers.py
+++ b/pandas/io/parsers.py
@@ -841,6 +841,17 @@ class TextFileReader(BaseIterator):
                                       encoding=encoding)
                 engine = 'python'
 
+        quotechar = options['quotechar']
+        if (quotechar is not None and
+                isinstance(quotechar, (str, compat.text_type, bytes))):
+            if (len(quotechar) == 1 and ord(quotechar) > 127 and
+                    engine not in ('python', 'python-fwf')):
+                fallback_reason = ("ord(quotechar) > 127, meaning the "
+                                   "quotechar is larger than one byte, "
+                                   "and the 'c' engine does not support "
+                                   "such quotechars")
+                engine = 'python'
+
         if fallback_reason and engine_specified:
             raise ValueError(fallback_reason)
 

--- a/pandas/io/tests/parser/quoting.py
+++ b/pandas/io/tests/parser/quoting.py
@@ -149,5 +149,5 @@ class QuotingTests(object):
 
         # Compared to Python 3.x, Python 2.x does not handle unicode well.
         if PY3:
-            result = self.read_csv(StringIO(data), quotechar=u('\u0394'))
+            result = self.read_csv(StringIO(data), quotechar=u('\u0001'))
             tm.assert_frame_equal(result, expected)

--- a/pandas/io/tests/parser/test_unsupported.py
+++ b/pandas/io/tests/parser/test_unsupported.py
@@ -51,11 +51,15 @@ class TestUnsupportedFeatures(tm.TestCase):
         with tm.assertRaisesRegexp(ValueError, msg):
             read_table(StringIO(data), engine='c', sep=r'\s')
         with tm.assertRaisesRegexp(ValueError, msg):
+            read_table(StringIO(data), engine='c', quotechar=chr(128))
+        with tm.assertRaisesRegexp(ValueError, msg):
             read_table(StringIO(data), engine='c', skipfooter=1)
 
         # specify C-unsupported options without python-unsupported options
         with tm.assert_produces_warning(parsers.ParserWarning):
             read_table(StringIO(data), sep=None, delim_whitespace=False)
+        with tm.assert_produces_warning(parsers.ParserWarning):
+            read_table(StringIO(data), quotechar=chr(128))
         with tm.assert_produces_warning(parsers.ParserWarning):
             read_table(StringIO(data), sep=r'\s')
         with tm.assert_produces_warning(parsers.ParserWarning):


### PR DESCRIPTION
Raise `ValueError` or issue `ParserWarning` (as we do with other unsupported features) when a multi-char `quotechar` is passed in, and the C engine is used.

Closes #11592.