### PR TITLE
PERF: Cythonize Groupby.cummin/cummax (#15048)

### DIFF
--- a/asv_bench/benchmarks/groupby.py
+++ b/asv_bench/benchmarks/groupby.py
@@ -690,6 +690,3 @@ class groupby_transform_series2(object):
     def time_transform_dataframe(self):
         # GH 12737
         self.df_nans.groupby('key').transform('first')
-
-
-

--- a/doc/source/whatsnew/v0.20.0.txt
+++ b/doc/source/whatsnew/v0.20.0.txt
@@ -283,7 +283,7 @@ Performance Improvements
 - Increased performance of ``pd.factorize()`` by releasing the GIL with ``object`` dtype when inferred as strings (:issue:`14859`)
 - Improved performance of timeseries plotting with an irregular DatetimeIndex
   (or with ``compat_x=True``) (:issue:`15073`).
-
+- Improved performance of ``groupby().cummin()`` and ``groupby().cummax()`` (:issue:`15048`)
 
 - When reading buffer object in ``read_sas()`` method without specified format, filepath string is inferred rather than buffer object.
 

--- a/pandas/src/algos_groupby_helper.pxi.in
+++ b/pandas/src/algos_groupby_helper.pxi.in
@@ -568,6 +568,76 @@ def group_min_{{name}}(ndarray[{{dest_type2}}, ndim=2] out,
                 else:
                     out[i, j] = minx[i, j]
 
+
+@cython.boundscheck(False)
+@cython.wraparound(False)
+def group_cummin_{{name}}(ndarray[{{dest_type2}}, ndim=2] out,
+                          ndarray[{{dest_type2}}, ndim=2] values,
+                          ndarray[int64_t] labels,
+                          ndarray[{{dest_type2}}, ndim=2] accum):
+    """
+    Only transforms on axis=0
+    """
+    cdef:
+        Py_ssize_t i, j, N, K, size
+        {{dest_type2}} val, min_val
+        int64_t lab
+
+    N, K = (<object> values).shape
+    accum.fill({{inf_val}})
+
+    with nogil:
+        for i in range(N):
+            lab = labels[i]
+
+            if lab < 0:
+                continue
+            for j in range(K):
+                val = values[i, j]
+                if val == val:
+                    if val < accum[lab, j]:
+                        min_val = val
+                    accum[lab, j] = min_val
+                    out[i, j] = accum[lab, j]
+                # val = nan
+                else:
+                    out[i, j] = {{nan_val}}
+
+
+@cython.boundscheck(False)
+@cython.wraparound(False)
+def group_cummax_{{name}}(ndarray[{{dest_type2}}, ndim=2] out,
+                          ndarray[{{dest_type2}}, ndim=2] values,
+                          ndarray[int64_t] labels,
+                          ndarray[{{dest_type2}}, ndim=2] accum):
+    """
+    Only transforms on axis=0
+    """
+    cdef:
+        Py_ssize_t i, j, N, K, size
+        {{dest_type2}} val, max_val
+        int64_t lab
+
+    N, K = (<object> values).shape
+    accum.fill(-{{inf_val}})
+
+    with nogil:
+        for i in range(N):
+            lab = labels[i]
+
+            if lab < 0:
+                continue
+            for j in range(K):
+                val = values[i, j]
+                if val == val:
+                    if val > accum[lab, j]:
+                        max_val = val
+                    accum[lab, j] = max_val
+                    out[i, j] = accum[lab, j]
+                # val = nan
+                else:
+                    out[i, j] = {{nan_val}}
+
 {{endfor}}
 
 #----------------------------------------------------------------------


### PR DESCRIPTION
 - [x] closes #15048
 - [x] tests added / passed
 - [x] passes ``git diff upstream/master | flake8 --diff``
 - [x] whatsnew entry

```

   before     after       ratio
  [6eb705f5] [e8115142]
-     1.08s     1.74ms      0.00  groupby.groupby_cummax_cummin.time_cummax
-     1.09s     1.73ms      0.00  groupby.groupby_cummax_cummin.time_cummin

SOME BENCHMARKS HAVE CHANGED SIGNIFICANTLY.

```

Still need to add some tests to see if this is equivalent to the old implimentation (numpy.minimum.accumulate?). Any early feedback appreciated.