### PR TITLE
BUG: Fix for .str.replace with repl function

### DIFF
--- a/doc/source/text.rst
+++ b/doc/source/text.rst
@@ -146,6 +146,25 @@ following code will cause trouble because of the regular expression meaning of
    # We need to escape the special character (for >1 len patterns)
    dollars.str.replace(r'-\$', '-')
 
+The ``replace`` method can also take a callable as replacement. It is called 
+on every ``pat`` using :func:`re.sub`. The callable should expect one 
+positional argument (a regex object) and return a string.
+
+.. versionadded:: 0.20.0
+
+.. ipython:: python
+
+   # Reverse every lowercase alphabetic word
+   pat = r'[a-z]+'
+   repl = lambda m: m.group(0)[::-1]
+   pd.Series(['foo 123', 'bar baz', np.nan]).str.replace(pat, repl)
+
+   # Using regex groups
+   pat = r"(?P<one>\w+) (?P<two>\w+) (?P<three>\w+)"
+   repl = lambda m: m.group('two').swapcase()
+   pd.Series(['Foo Bar Baz', np.nan]).str.replace(pat, repl)
+
+
 Indexing with ``.str``
 ----------------------
 
@@ -406,7 +425,7 @@ Method Summary
     :meth:`~Series.str.join`;Join strings in each element of the Series with passed separator
     :meth:`~Series.str.get_dummies`;Split strings on the delimiter returning DataFrame of dummy variables
     :meth:`~Series.str.contains`;Return boolean array if each string contains pattern/regex
-    :meth:`~Series.str.replace`;Replace occurrences of pattern/regex with some other string
+    :meth:`~Series.str.replace`;Replace occurrences of pattern/regex with some other string or the return value of a callable given the occurrence
     :meth:`~Series.str.repeat`;Duplicate values (``s.str.repeat(3)`` equivalent to ``x * 3``)
     :meth:`~Series.str.pad`;"Add whitespace to left, right, or both sides of strings"
     :meth:`~Series.str.center`;Equivalent to ``str.center``

--- a/doc/source/whatsnew/v0.20.0.txt
+++ b/doc/source/whatsnew/v0.20.0.txt
@@ -23,7 +23,7 @@ New features
 ~~~~~~~~~~~~
 
 - Integration with the ``feather-format``, including a new top-level ``pd.read_feather()`` and ``DataFrame.to_feather()`` method, see :ref:`here <io.feather>`.
-- ``.str.replace`` now accepts a callable replacement which is passed to ``re.sub`` (:issue:`15055`)
+- ``.str.replace`` now accepts a callable, as replacement, which is passed to ``re.sub`` (:issue:`15055`)
 
 
 

--- a/doc/source/whatsnew/v0.20.0.txt
+++ b/doc/source/whatsnew/v0.20.0.txt
@@ -23,6 +23,7 @@ New features
 ~~~~~~~~~~~~
 
 - Integration with the ``feather-format``, including a new top-level ``pd.read_feather()`` and ``DataFrame.to_feather()`` method, see :ref:`here <io.feather>`.
+- ``.str.replace`` now accepts a callable replacement which is passed to ``re.sub`` (:issue:`15055`)
 
 
 

--- a/pandas/core/strings.py
+++ b/pandas/core/strings.py
@@ -303,8 +303,9 @@ def str_replace(arr, pat, repl, n=-1, case=True, flags=0):
     ----------
     pat : string
         Character sequence or regular expression
-    repl : string
-        Replacement sequence
+    repl : string or function
+        Replacement string or a function, which passed the match object and 
+        must return a replacement string to be used. See :func:`re.sub`.
     n : int, default -1 (all)
         Number of replacements to make from start
     case : boolean, default True
@@ -318,9 +319,9 @@ def str_replace(arr, pat, repl, n=-1, case=True, flags=0):
     """
 
     # Check whether repl is valid (GH 13438)
-    if not is_string_like(repl):
-        raise TypeError("repl must be a string")
-    use_re = not case or len(pat) > 1 or flags
+    if not is_string_like(repl) or not callable(repl):
+        raise TypeError("repl must be a string or function")
+    use_re = not case or len(pat) > 1 or flags or callable(repl)
 
     if use_re:
         if not case:

--- a/pandas/core/strings.py
+++ b/pandas/core/strings.py
@@ -319,7 +319,7 @@ def str_replace(arr, pat, repl, n=-1, case=True, flags=0):
     """
 
     # Check whether repl is valid (GH 13438)
-    if not is_string_like(repl) or not callable(repl):
+    if not (is_string_like(repl) or callable(repl)):
         raise TypeError("repl must be a string or function")
     use_re = not case or len(pat) > 1 or flags or callable(repl)
 

--- a/pandas/core/strings.py
+++ b/pandas/core/strings.py
@@ -310,8 +310,8 @@ def str_replace(arr, pat, repl, n=-1, case=True, flags=0):
     pat : string
         Character sequence or regular expression
     repl : string or callable
-        Replacement string or a callable. The callable is passed the regex 
-        match object and must return a replacement string to be used. 
+        Replacement string or a callable. The callable is passed the regex
+        match object and must return a replacement string to be used.
         See :func:`re.sub`.
 
     .. versionadded:: 0.20.0
@@ -329,7 +329,7 @@ def str_replace(arr, pat, repl, n=-1, case=True, flags=0):
 
     Examples
     --------
-    When ``repl`` is a string, every ``pat`` is replaced as with 
+    When ``repl`` is a string, every ``pat`` is replaced as with
     :meth:`str.replace`. NaN value(s) in the Series are left as is.
 
     >>> Series(['foo', 'fuz', np.nan]).str.replace('f', 'b')
@@ -338,8 +338,8 @@ def str_replace(arr, pat, repl, n=-1, case=True, flags=0):
     2    NaN
     dtype: object
 
-    When ``repl`` is a callable, it is called on every ``pat`` using 
-    :func:`re.sub`. The callable should expect one positional argument 
+    When ``repl`` is a callable, it is called on every ``pat`` using
+    :func:`re.sub`. The callable should expect one positional argument
     (a regex object) and return a string.
 
     To get the idea:

--- a/pandas/core/strings.py
+++ b/pandas/core/strings.py
@@ -170,12 +170,9 @@ def _map(f, arr, na_mask=False, na_value=np.nan, dtype=object):
         except (TypeError, AttributeError) as e:
             # Reraise the exception if callable `f` got wrong number of args.
             # The user may want to be warned by this, instead of getting NaN
-            re_missing = (r'missing \d+ required (positional|keyword-only) '
-                           'arguments?')
-            re_takes = (r'takes (from)?\d+ (to \d+)?positional arguments? '
-                         'but \d+ (was|were) given')
-            if len(e.args) >= 1 and (re.search(re_missing, e.args[0]) 
-                                     or re.search(re_takes, e.args[0])):
+            re_error = (r'(takes|(missing)) (no|(exactly )?\d+) '
+                        r'(?(2)required )(positional )?arguments?')
+            if len(e.args) >= 1 and re.search(re_error, e.args[0]):
                 raise e
 
             def g(x):

--- a/pandas/core/strings.py
+++ b/pandas/core/strings.py
@@ -167,7 +167,14 @@ def _map(f, arr, na_mask=False, na_value=np.nan, dtype=object):
         try:
             convert = not all(mask)
             result = lib.map_infer_mask(arr, f, mask.view(np.uint8), convert)
-        except (TypeError, AttributeError):
+        except (TypeError, AttributeError) as e:
+            re_missing = (r'missing \d+ required (positional|keyword-only) '
+                           'arguments?')
+            re_takes = (r'takes (from)?\d+ (to \d+)?positional arguments? '
+                         'but \d+ (was|were) given')
+            if len(e.args) >= 1 and (re.search(re_missing, e.args[0]) 
+                                     or re.search(re_takes, e.args[0])):
+                raise e
 
             def g(x):
                 try:

--- a/pandas/core/strings.py
+++ b/pandas/core/strings.py
@@ -170,9 +170,13 @@ def _map(f, arr, na_mask=False, na_value=np.nan, dtype=object):
         except (TypeError, AttributeError) as e:
             # Reraise the exception if callable `f` got wrong number of args.
             # The user may want to be warned by this, instead of getting NaN
-            re_error = (r'(takes|(missing)) (no|(exactly )?\d+) '
-                        r'(?(2)required )(positional )?arguments?')
-            if len(e.args) >= 1 and re.search(re_error, e.args[0]):
+            if compat.PY2:
+                p_err = r'takes (no|(exactly|at (least|most)) ?\d+) arguments?'
+            else:
+                p_err = (r'((takes)|(missing)) (?(2)from \d+ to )?\d+ '
+                         r'(?(3)required )positional arguments?')
+
+            if len(e.args) >= 1 and re.search(p_err, e.args[0]):
                 raise e
 
             def g(x):

--- a/pandas/core/strings.py
+++ b/pandas/core/strings.py
@@ -303,8 +303,8 @@ def str_replace(arr, pat, repl, n=-1, case=True, flags=0):
     ----------
     pat : string
         Character sequence or regular expression
-    repl : string or function
-        Replacement string or a function, which passed the match object and 
+    repl : string or callable
+        Replacement string or a callable, it's passed the match object and 
         must return a replacement string to be used. See :func:`re.sub`.
     n : int, default -1 (all)
         Number of replacements to make from start

--- a/pandas/tests/test_strings.py
+++ b/pandas/tests/test_strings.py
@@ -435,9 +435,9 @@ class TestStringMethods(tm.TestCase):
                 for data in (['a', 'b', None], ['a', 'b', 'c', 'ad']):
                     values = klass(data)
                     self.assertRaises(TypeError, values.str.replace, 'a', repl)
-        
+
     def test_replace_callable(self):
-        ## GH 15055
+        # GH 15055
         values = Series(['fooBAD__barBAD', NA])
 
         # test with callable

--- a/pandas/tests/test_strings.py
+++ b/pandas/tests/test_strings.py
@@ -446,15 +446,23 @@ class TestStringMethods(tm.TestCase):
         exp = Series(['foObaD__baRbaD', NA])
         tm.assert_series_equal(result, exp)
 
-        # test with wrong number of arguments
-        repl = lambda m, bad: None
-        re_msg = "^<lambda>\(\) missing 1 required positional argument: 'bad'$"
-        with tm.assertRaisesRegexp(TypeError, re_msg):
-            values.str.replace('a', repl)
+        # test with wrong number of arguments, raising an error
+        if compat.PY2:
+            p_err = r'takes (no|(exactly|at (least|most)) ?\d+) arguments?'
+        else:
+            p_err = (r'((takes)|(missing)) (?(2)from \d+ to )?\d+ '
+                     r'(?(3)required )positional arguments?')
 
         repl = lambda: None
-        re_msg = '^<lambda>\(\) takes 0 positional arguments but 1 was given$'
-        with tm.assertRaisesRegexp(TypeError, re_msg):
+        with tm.assertRaisesRegexp(TypeError, p_err):
+            values.str.replace('a', repl)
+
+        repl = lambda m, x: None
+        with tm.assertRaisesRegexp(TypeError, p_err):
+            values.str.replace('a', repl)
+
+        repl = lambda m, x, y=None: None
+        with tm.assertRaisesRegexp(TypeError, p_err):
             values.str.replace('a', repl)
 
         # test regex named groups

--- a/pandas/tests/test_strings.py
+++ b/pandas/tests/test_strings.py
@@ -436,7 +436,7 @@ class TestStringMethods(tm.TestCase):
                     values = klass(data)
                     self.assertRaises(TypeError, values.str.replace, 'a', repl)
         
-        ## GH 15055, callable repl
+        ## GH 15055
         values = Series(['fooBAD__barBAD', NA])
 
         # test with callable
@@ -445,10 +445,20 @@ class TestStringMethods(tm.TestCase):
         exp = Series(['foObaD__baRbaD', NA])
         tm.assert_series_equal(result, exp)
 
-        # test with wrong type
-        repl = lambda m: m.group(0).swapcase()
-        result = values.str.replace('[a-z][A-Z]{2}', repl, n=2)
-        exp = Series(['foObaD__baRbaD', NA])
+        # test with wrong number of arguments
+        repl = lambda m, bad: None
+        re_msg = "^<lambda>\(\) missing 1 required positional argument: 'bad'$"
+        self.assertRaisesRegex(TypeError, re_msg, values.str.replace, 'a', repl)
+
+        repl = lambda: None
+        re_msg = '^<lambda>\(\) takes 0 positional arguments but 1 was given$'
+        self.assertRaisesRegex(TypeError, re_msg, values.str.replace, 'a', repl)
+
+        # test regex named groups
+        values = Series(['Foo Bar Baz', NA])
+        repl = lambda m: m.group('middle').swapcase()
+        result = values.str.replace(r"(?P<first>\w+) (?P<middle>\w+) (?P<last>\w+)", repl)
+        exp = Series(['bAR', NA])
         tm.assert_series_equal(result, exp)
 
     def test_repeat(self):

--- a/pandas/tests/test_strings.py
+++ b/pandas/tests/test_strings.py
@@ -435,6 +435,12 @@ class TestStringMethods(tm.TestCase):
                 for data in (['a', 'b', None], ['a', 'b', 'c', 'ad']):
                     values = klass(data)
                     self.assertRaises(TypeError, values.str.replace, 'a', repl)
+        
+        # GH 15055, callable repl
+        repl = lambda m: m.group(0).swapcase()
+        result = values.str.replace('[a-z][A-Z]{2}', repl, n=2)
+        exp = Series([u('foObaD__baRbaD'), NA])
+        tm.assert_series_equal(result, exp)
 
     def test_repeat(self):
         values = Series(['a', 'b', NA, 'c', NA, 'd'])

--- a/pandas/tests/test_strings.py
+++ b/pandas/tests/test_strings.py
@@ -436,10 +436,19 @@ class TestStringMethods(tm.TestCase):
                     values = klass(data)
                     self.assertRaises(TypeError, values.str.replace, 'a', repl)
         
-        # GH 15055, callable repl
+        ## GH 15055, callable repl
+        values = Series(['fooBAD__barBAD', NA])
+
+        # test with callable
         repl = lambda m: m.group(0).swapcase()
         result = values.str.replace('[a-z][A-Z]{2}', repl, n=2)
-        exp = Series([u('foObaD__baRbaD'), NA])
+        exp = Series(['foObaD__baRbaD', NA])
+        tm.assert_series_equal(result, exp)
+
+        # test with wrong type
+        repl = lambda m: m.group(0).swapcase()
+        result = values.str.replace('[a-z][A-Z]{2}', repl, n=2)
+        exp = Series(['foObaD__baRbaD', NA])
         tm.assert_series_equal(result, exp)
 
     def test_repeat(self):

--- a/pandas/tests/test_strings.py
+++ b/pandas/tests/test_strings.py
@@ -436,6 +436,7 @@ class TestStringMethods(tm.TestCase):
                     values = klass(data)
                     self.assertRaises(TypeError, values.str.replace, 'a', repl)
         
+    def test_replace_callable(self):
         ## GH 15055
         values = Series(['fooBAD__barBAD', NA])
 
@@ -448,16 +449,19 @@ class TestStringMethods(tm.TestCase):
         # test with wrong number of arguments
         repl = lambda m, bad: None
         re_msg = "^<lambda>\(\) missing 1 required positional argument: 'bad'$"
-        self.assertRaisesRegex(TypeError, re_msg, values.str.replace, 'a', repl)
+        with tm.assertRaisesRegexp(TypeError, re_msg):
+            values.str.replace('a', repl)
 
         repl = lambda: None
         re_msg = '^<lambda>\(\) takes 0 positional arguments but 1 was given$'
-        self.assertRaisesRegex(TypeError, re_msg, values.str.replace, 'a', repl)
+        with tm.assertRaisesRegexp(TypeError, re_msg):
+            values.str.replace('a', repl)
 
         # test regex named groups
         values = Series(['Foo Bar Baz', NA])
+        pat = r"(?P<first>\w+) (?P<middle>\w+) (?P<last>\w+)"
         repl = lambda m: m.group('middle').swapcase()
-        result = values.str.replace(r"(?P<first>\w+) (?P<middle>\w+) (?P<last>\w+)", repl)
+        result = values.str.replace(pat, repl)
         exp = Series(['bAR', NA])
         tm.assert_series_equal(result, exp)
 


### PR DESCRIPTION
.str.replace now accepts a callable (function) as replacement string. It now raises a TypeError when repl is not string like nor a callable. Docstring updated accordingly.

  - [x] tests added / passed
 - [x] passes ``git diff upstream/master | flake8 --diff``
 - [x] whatsnew entry
- [x] closes #15055
