### PR TITLE
BUG: Fix for GH #14848 for groupby().describe() with tuples as the Index

### DIFF
--- a/doc/source/whatsnew/v0.20.0.txt
+++ b/doc/source/whatsnew/v0.20.0.txt
@@ -351,6 +351,7 @@ Bug Fixes
 - Bug in converting object elements of array-like objects to unsigned 64-bit integers (:issue:`4471`, :issue:`14982`)
 - Bug in ``pd.pivot_table()`` where no error was raised when values argument was not in the columns (:issue:`14938`)
 
+- Bug in ``DataFrame.groupby().describe()`` when grouping on  ``Index`` containing tuples (:issue:`14848`)
 
 
 

--- a/doc/source/whatsnew/v0.20.0.txt
+++ b/doc/source/whatsnew/v0.20.0.txt
@@ -351,7 +351,7 @@ Bug Fixes
 - Bug in converting object elements of array-like objects to unsigned 64-bit integers (:issue:`4471`, :issue:`14982`)
 - Bug in ``pd.pivot_table()`` where no error was raised when values argument was not in the columns (:issue:`14938`)
 
-- Bug in ``DataFrame.groupby().describe()`` when grouping on  ``Index`` containing tuples (:issue:`14848`)
+- Bug in ``DataFrame.groupby().describe()`` when grouping on ``Index`` containing tuples. Raise `ValueError` if creating an `Index` with tuples and not passing a list of names (:issue:`14848`)
 
 
 

--- a/doc/source/whatsnew/v0.20.0.txt
+++ b/doc/source/whatsnew/v0.20.0.txt
@@ -351,7 +351,8 @@ Bug Fixes
 - Bug in converting object elements of array-like objects to unsigned 64-bit integers (:issue:`4471`, :issue:`14982`)
 - Bug in ``pd.pivot_table()`` where no error was raised when values argument was not in the columns (:issue:`14938`)
 
-- Bug in ``DataFrame.groupby().describe()`` when grouping on ``Index`` containing tuples. Raise `ValueError` if creating an `Index` with tuples and not passing a list of names (:issue:`14848`)
+- Bug in ``DataFrame.groupby().describe()`` when grouping on ``Index`` containing tuples (:issue:`14848`)
+- Raise `ValueError` if creating a `MultiIndex` with tuples and not passing a list of names (:issue:`15110`)
 
 
 

--- a/pandas/indexes/multi.py
+++ b/pandas/indexes/multi.py
@@ -20,7 +20,6 @@ from pandas.types.common import (_ensure_int64,
                                  is_object_dtype,
                                  is_iterator,
                                  is_list_like,
-                                 is_string_like,
                                  is_scalar)
 from pandas.types.missing import isnull, array_equivalent
 from pandas.core.common import (_values_from_object,
@@ -493,9 +492,8 @@ class MultiIndex(Index):
 
         # GH 15110
         # Don't allow a single string for names in a MultiIndex
-        if names is not None and is_string_like(names):
-            raise ValueError('Names should not be a single string for a '
-                             'MultiIndex.')
+        if names is not None and not is_list_like(names):
+            raise ValueError('Names should be list-like for a MultiIndex')
         names = list(names)
 
         if validate and level is not None and len(names) != len(level):

--- a/pandas/indexes/multi.py
+++ b/pandas/indexes/multi.py
@@ -20,6 +20,7 @@ from pandas.types.common import (_ensure_int64,
                                  is_object_dtype,
                                  is_iterator,
                                  is_list_like,
+                                 is_string_like,
                                  is_scalar)
 from pandas.types.missing import isnull, array_equivalent
 from pandas.core.common import (_values_from_object,
@@ -490,6 +491,11 @@ class MultiIndex(Index):
         that it only acts on copies
         """
 
+        # GH 15110
+        # Don't allow a single string for names in a MultiIndex
+        if names is not None and is_string_like(names):
+            raise ValueError('Names should not be a single string for a '
+                             'MultiIndex.')
         names = list(names)
 
         if validate and level is not None and len(names) != len(level):

--- a/pandas/tests/groupby/test_groupby.py
+++ b/pandas/tests/groupby/test_groupby.py
@@ -1490,18 +1490,18 @@ class TestGroupBy(tm.TestCase):
         for name, group in groupedT:
             assert_frame_equal(result[name], group.describe())
 
-    # GH #14848
     def test_frame_describe_tupleindex(self):
+
+        # GH 14848 - regression from 0.19.0 to 0.19.1
         df1 = DataFrame({'x': [1, 2, 3, 4, 5] * 3,
                          'y': [10, 20, 30, 40, 50] * 3,
                          'z': [100, 200, 300, 400, 500] * 3})
         df1['k'] = [(0, 0, 1), (0, 1, 0), (1, 0, 0)] * 5
         df2 = df1.rename(columns={'k': 'key'})
-        des1 = df1.groupby('k').describe()
-        des2 = df2.groupby('key').describe()
-        if len(des1) > 0:
-            des2.index.set_names(des1.index.names, inplace=True)
-        assert_frame_equal(des1, des2)
+        result = df1.groupby('k').describe()
+        expected = df2.groupby('key').describe()
+        expected.index.set_names(result.index.names, inplace=True)
+        assert_frame_equal(result, expected)
 
     def test_frame_groupby(self):
         grouped = self.tsframe.groupby(lambda x: x.weekday())

--- a/pandas/tests/groupby/test_groupby.py
+++ b/pandas/tests/groupby/test_groupby.py
@@ -1490,6 +1490,19 @@ class TestGroupBy(tm.TestCase):
         for name, group in groupedT:
             assert_frame_equal(result[name], group.describe())
 
+    # GH #14848
+    def test_frame_describe_tupleindex(self):
+        df1 = DataFrame({'x': [1, 2, 3, 4, 5] * 3,
+                         'y': [10, 20, 30, 40, 50] * 3,
+                         'z': [100, 200, 300, 400, 500] * 3})
+        df1['k'] = [(0, 0, 1), (0, 1, 0), (1, 0, 0)] * 5
+        df2 = df1.rename(columns={'k': 'key'})
+        des1 = df1.groupby('k').describe()
+        des2 = df2.groupby('key').describe()
+        if len(des1) > 0:
+            des2.index.set_names(des1.index.names, inplace=True)
+        assert_frame_equal(des1, des2)
+
     def test_frame_groupby(self):
         grouped = self.tsframe.groupby(lambda x: x.weekday())
 

--- a/pandas/tests/indexes/test_multi.py
+++ b/pandas/tests/indexes/test_multi.py
@@ -2554,3 +2554,12 @@ class TestMultiIndex(Base, tm.TestCase):
 
         with assertRaises(KeyError):
             df.loc(axis=0)['q', :]
+
+    def test_tuples_with_name_string(self):
+        # GH 15110 and GH 14848
+
+        li = [(0, 0, 1), (0, 1, 0), (1, 0, 0)]
+        with assertRaises(ValueError):
+            pd.Index(li, name='abc')
+        with assertRaises(ValueError):
+            pd.Index(li, name='a')

--- a/pandas/tools/merge.py
+++ b/pandas/tools/merge.py
@@ -1627,10 +1627,10 @@ class _Concatenator(object):
             objs = clean_objs
             name = getattr(keys, 'name', None)
             # GH 14848
-            # Don't pass name when creating index (# GH 14252)
-            # So that if keys are tuples, name isn't checked
-            keys = Index(clean_keys)
-            keys.name = name
+            # If you already have an Index, no need
+            # to recreate it
+            if not isinstance(keys, Index):
+                keys = Index(clean_keys, name=name)
 
         if len(objs) == 0:
             raise ValueError('All objects passed were None')

--- a/pandas/tools/merge.py
+++ b/pandas/tools/merge.py
@@ -1626,7 +1626,11 @@ class _Concatenator(object):
                 clean_objs.append(v)
             objs = clean_objs
             name = getattr(keys, 'name', None)
-            keys = Index(clean_keys, name=name)
+            # GH 14848
+            # Don't pass name when creating index (# GH 14252)
+            # So that if keys are tuples, name isn't checked
+            keys = Index(clean_keys)
+            keys.name = name
 
         if len(objs) == 0:
             raise ValueError('All objects passed were None')

--- a/pandas/tools/merge.py
+++ b/pandas/tools/merge.py
@@ -1626,11 +1626,7 @@ class _Concatenator(object):
                 clean_objs.append(v)
             objs = clean_objs
             name = getattr(keys, 'name', None)
-            # GH 14848
-            # If you already have an Index, no need
-            # to recreate it
-            if not isinstance(keys, Index):
-                keys = Index(clean_keys, name=name)
+            keys = Index(clean_keys, name=name)
 
         if len(objs) == 0:
             raise ValueError('All objects passed were None')


### PR DESCRIPTION
 - [x] closes #14848 
 - [x ] tests added / passed
 - [x ] passes ``git diff upstream/master | flake8 --diff``
 - [x ] whatsnew entry

This isn't the most elegant fix for the bug, but all the tests pass.  There is probably a bigger issue to deal with here, which is to support tuples as an `Index` (as opposed to a `MultiIndex`) throughout, but at least this fix clears the bug.