### PR TITLE
DEPR: deprecate .ix in favor of .loc/.iloc

### DIFF
--- a/doc/source/advanced.rst
+++ b/doc/source/advanced.rst
@@ -230,7 +230,7 @@ of tuples:
 Advanced indexing with hierarchical index
 -----------------------------------------
 
-Syntactically integrating ``MultiIndex`` in advanced indexing with ``.loc/.ix`` is a
+Syntactically integrating ``MultiIndex`` in advanced indexing with ``.loc`` is a
 bit challenging, but we've made every effort to do so. for example the
 following works as you would expect:
 
@@ -258,7 +258,7 @@ Passing a list of labels or tuples works similar to reindexing:
 
 .. ipython:: python
 
-   df.ix[[('bar', 'two'), ('qux', 'one')]]
+   df.loc[[('bar', 'two'), ('qux', 'one')]]
 
 .. _advanced.mi_slicers:
 
@@ -604,7 +604,7 @@ intended to work on boolean indices and may return unexpected results.
 
    ser = pd.Series(np.random.randn(10))
    ser.take([False, False, True, True])
-   ser.ix[[0, 1]]
+   ser.iloc[[0, 1]]
 
 Finally, as a small note on performance, because the ``take`` method handles
 a narrower range of inputs, it can offer performance that is a good deal
@@ -620,7 +620,7 @@ faster than fancy indexing.
    timeit arr.take(indexer, axis=0)
 
    ser = pd.Series(arr[:, 0])
-   timeit ser.ix[indexer]
+   timeit ser.iloc[indexer]
    timeit ser.take(indexer)
 
 .. _indexing.index_types:
@@ -661,7 +661,7 @@ Setting the index, will create create a ``CategoricalIndex``
    df2 = df.set_index('B')
    df2.index
 
-Indexing with ``__getitem__/.iloc/.loc/.ix`` works similarly to an ``Index`` with duplicates.
+Indexing with ``__getitem__/.iloc/.loc`` works similarly to an ``Index`` with duplicates.
 The indexers MUST be in the category or the operation will raise.
 
 .. ipython:: python
@@ -759,14 +759,12 @@ same.
    sf = pd.Series(range(5), index=indexf)
    sf
 
-Scalar selection for ``[],.ix,.loc`` will always be label based. An integer will match an equal float index (e.g. ``3`` is equivalent to ``3.0``)
+Scalar selection for ``[],.loc`` will always be label based. An integer will match an equal float index (e.g. ``3`` is equivalent to ``3.0``)
 
 .. ipython:: python
 
    sf[3]
    sf[3.0]
-   sf.ix[3]
-   sf.ix[3.0]
    sf.loc[3]
    sf.loc[3.0]
 
@@ -783,7 +781,6 @@ Slicing is ALWAYS on the values of the index, for ``[],ix,loc`` and ALWAYS posit
 .. ipython:: python
 
    sf[2:4]
-   sf.ix[2:4]
    sf.loc[2:4]
    sf.iloc[2:4]
 
@@ -813,14 +810,6 @@ In non-float indexes, slicing using floats will raise a ``TypeError``
       In [3]: pd.Series(range(5)).iloc[3.0]
       TypeError: cannot do positional indexing on <class 'pandas.indexes.range.RangeIndex'> with these indexers [3.0] of <type 'float'>
 
-   Further the treatment of ``.ix`` with a float indexer on a non-float index, will be label based, and thus coerce the index.
-
-   .. ipython:: python
-
-      s2 = pd.Series([1, 2, 3], index=list('abc'))
-      s2
-      s2.ix[1.0] = 10
-      s2
 
 Here is a typical use-case for using this type of indexing. Imagine that you have a somewhat
 irregular timedelta-like indexing scheme, but the data is recorded as floats. This could for

--- a/doc/source/api.rst
+++ b/doc/source/api.rst
@@ -268,13 +268,12 @@ Indexing, iteration
    Series.get
    Series.at
    Series.iat
-   Series.ix
    Series.loc
    Series.iloc
    Series.__iter__
    Series.iteritems
 
-For more information on ``.at``, ``.iat``, ``.ix``, ``.loc``, and
+For more information on ``.at``, ``.iat``, ``.loc``, and
 ``.iloc``,  see the :ref:`indexing documentation <indexing>`.
 
 Binary operator functions
@@ -774,7 +773,6 @@ Indexing, iteration
    DataFrame.head
    DataFrame.at
    DataFrame.iat
-   DataFrame.ix
    DataFrame.loc
    DataFrame.iloc
    DataFrame.insert
@@ -791,7 +789,7 @@ Indexing, iteration
    DataFrame.mask
    DataFrame.query
 
-For more information on ``.at``, ``.iat``, ``.ix``, ``.loc``, and
+For more information on ``.at``, ``.iat``, ``.loc``, and
 ``.iloc``,  see the :ref:`indexing documentation <indexing>`.
 
 
@@ -1090,7 +1088,6 @@ Indexing, iteration, slicing
 
    Panel.at
    Panel.iat
-   Panel.ix
    Panel.loc
    Panel.iloc
    Panel.__iter__
@@ -1100,7 +1097,7 @@ Indexing, iteration, slicing
    Panel.major_xs
    Panel.minor_xs
 
-For more information on ``.at``, ``.iat``, ``.ix``, ``.loc``, and
+For more information on ``.at``, ``.iat``, ``.loc``, and
 ``.iloc``,  see the :ref:`indexing documentation <indexing>`.
 
 Binary operator functions

--- a/doc/source/basics.rst
+++ b/doc/source/basics.rst
@@ -145,7 +145,7 @@ either match on the *index* or *columns* via the **axis** keyword:
                       'two' : pd.Series(np.random.randn(4), index=['a', 'b', 'c', 'd']),
                       'three' : pd.Series(np.random.randn(3), index=['b', 'c', 'd'])})
    df
-   row = df.ix[1]
+   row = df.iloc[1]
    column = df['two']
 
    df.sub(row, axis='columns')
@@ -556,7 +556,7 @@ course):
     series[::2] = np.nan
     series.describe()
     frame = pd.DataFrame(np.random.randn(1000, 5), columns=['a', 'b', 'c', 'd', 'e'])
-    frame.ix[::2] = np.nan
+    frame.iloc[::2] = np.nan
     frame.describe()
 
 You can select specific percentiles to include in the output:
@@ -1081,7 +1081,7 @@ objects either on the DataFrame's index or columns using the ``axis`` argument:
 
 .. ipython:: python
 
-   df.align(df2.ix[0], axis=1)
+   df.align(df2.iloc[0], axis=1)
 
 .. _basics.reindex_fill:
 

--- a/doc/source/categorical.rst
+++ b/doc/source/categorical.rst
@@ -482,7 +482,7 @@ Pivot tables:
 Data munging
 ------------
 
-The optimized pandas data access methods  ``.loc``, ``.iloc``, ``.ix`` ``.at``, and ``.iat``,
+The optimized pandas data access methods  ``.loc``, ``.iloc``, ``.at``, and ``.iat``,
 work as normal. The only difference is the return type (for getting) and
 that only values already in `categories` can be assigned.
 
@@ -501,7 +501,6 @@ the ``category`` dtype is preserved.
     df.iloc[2:4,:]
     df.iloc[2:4,:].dtypes
     df.loc["h":"j","cats"]
-    df.ix["h":"j",0:1]
     df[df["cats"] == "b"]
 
 An example where the category type is not preserved is if you take one single row: the

--- a/doc/source/computation.rst
+++ b/doc/source/computation.rst
@@ -84,8 +84,8 @@ in order to have a valid result.
 .. ipython:: python
 
    frame = pd.DataFrame(np.random.randn(20, 3), columns=['a', 'b', 'c'])
-   frame.ix[:5, 'a'] = np.nan
-   frame.ix[5:10, 'b'] = np.nan
+   frame.loc[frame.index[:5], 'a'] = np.nan
+   frame.loc[frame.index[5:10], 'b'] = np.nan
 
    frame.cov()
 
@@ -120,7 +120,7 @@ All of these are currently computed using pairwise complete observations.
 .. ipython:: python
 
    frame = pd.DataFrame(np.random.randn(1000, 5), columns=['a', 'b', 'c', 'd', 'e'])
-   frame.ix[::2] = np.nan
+   frame.iloc[::2] = np.nan
 
    # Series with Series
    frame['a'].corr(frame['b'])
@@ -137,8 +137,8 @@ Like ``cov``, ``corr`` also supports the optional ``min_periods`` keyword:
 .. ipython:: python
 
    frame = pd.DataFrame(np.random.randn(20, 3), columns=['a', 'b', 'c'])
-   frame.ix[:5, 'a'] = np.nan
-   frame.ix[5:10, 'b'] = np.nan
+   frame.loc[frame.index[:5], 'a'] = np.nan
+   frame.loc[frame.index[5:10], 'b'] = np.nan
 
    frame.corr()
 

--- a/doc/source/cookbook.rst
+++ b/doc/source/cookbook.rst
@@ -66,19 +66,19 @@ An if-then on one column
 
 .. ipython:: python
 
-   df.ix[df.AAA >= 5,'BBB'] = -1; df
+   df.loc[df.AAA >= 5,'BBB'] = -1; df
 
 An if-then with assignment to 2 columns:
 
 .. ipython:: python
 
-   df.ix[df.AAA >= 5,['BBB','CCC']] = 555; df
+   df.loc[df.AAA >= 5,['BBB','CCC']] = 555; df
 
 Add another line with different logic, to do the -else
 
 .. ipython:: python
 
-   df.ix[df.AAA < 5,['BBB','CCC']] = 2000; df
+   df.loc[df.AAA < 5,['BBB','CCC']] = 2000; df
 
 Or use pandas where after you've set up a mask
 
@@ -149,7 +149,7 @@ Building Criteria
         {'AAA' : [4,5,6,7], 'BBB' : [10,20,30,40],'CCC' : [100,50,-30,-50]}); df
 
    aValue = 43.0
-   df.ix[(df.CCC-aValue).abs().argsort()]
+   df.loc[(df.CCC-aValue).abs().argsort()]
 
 `Dynamically reduce a list of criteria using a binary operators
 <http://stackoverflow.com/questions/21058254/pandas-boolean-operation-in-a-python-list/21058331>`__
@@ -217,9 +217,9 @@ There are 2 explicit slicing methods, with a third general case
 
    df.loc['bar':'kar'] #Label
 
-   #Generic
-   df.ix[0:3] #Same as .iloc[0:3]
-   df.ix['bar':'kar'] #Same as .loc['bar':'kar']
+   # Generic
+   df.iloc[0:3]
+   df.loc['bar':'kar']
 
 Ambiguity arises when an index consists of integers with a non-zero start or non-unit increment.
 
@@ -230,9 +230,6 @@ Ambiguity arises when an index consists of integers with a non-zero start or non
    df2.iloc[1:3] #Position-oriented
 
    df2.loc[1:3] #Label-oriented
-
-   df2.ix[1:3] #General, will mimic loc (label-oriented)
-   df2.ix[0:3] #General, will mimic iloc (position-oriented), as loc[0:3] would raise a KeyError
 
 `Using inverse operator (~) to take the complement of a mask
 <http://stackoverflow.com/questions/14986510/picking-out-elements-based-on-complement-of-indices-in-python-pandas>`__
@@ -440,7 +437,7 @@ Fill forward a reversed timeseries
 .. ipython:: python
 
    df = pd.DataFrame(np.random.randn(6,1), index=pd.date_range('2013-08-01', periods=6, freq='B'), columns=list('A'))
-   df.ix[3,'A'] = np.nan
+   df.loc[df.index[3], 'A'] = np.nan
    df
    df.reindex(df.index[::-1]).ffill()
 
@@ -545,7 +542,7 @@ Unlike agg, apply's callable is passed a sub-DataFrame which gives you access to
 
    agg_n_sort_order = code_groups[['data']].transform(sum).sort_values(by='data')
 
-   sorted_df = df.ix[agg_n_sort_order.index]
+   sorted_df = df.loc[agg_n_sort_order.index]
 
    sorted_df
 

--- a/doc/source/gotchas.rst
+++ b/doc/source/gotchas.rst
@@ -221,7 +221,7 @@ Label-based indexing with integer axis labels is a thorny topic. It has been
 discussed heavily on mailing lists and among various members of the scientific
 Python community. In pandas, our general viewpoint is that labels matter more
 than integer locations. Therefore, with an integer axis index *only*
-label-based indexing is possible with the standard tools like ``.ix``. The
+label-based indexing is possible with the standard tools like ``.loc``. The
 following code will generate exceptions:
 
 .. code-block:: python
@@ -230,7 +230,7 @@ following code will generate exceptions:
    s[-1]
    df = pd.DataFrame(np.random.randn(5, 4))
    df
-   df.ix[-2:]
+   df.loc[-2:]
 
 This deliberate decision was made to prevent ambiguities and subtle bugs (many
 users reported finding bugs when the API change was made to stop "falling back"
@@ -305,7 +305,7 @@ index can be somewhat complicated. For example, the following does not work:
 
 ::
 
-    s.ix['c':'e'+1]
+    s.loc['c':'e'+1]
 
 A very common use case is to limit a time series to start and end at two
 specific dates. To enable this, we made the design design to make label-based
@@ -313,7 +313,7 @@ slicing include both endpoints:
 
 .. ipython:: python
 
-    s.ix['c':'e']
+    s.loc['c':'e']
 
 This is most definitely a "practicality beats purity" sort of thing, but it is
 something to watch out for if you expect label-based slicing to behave exactly
@@ -321,58 +321,6 @@ in the way that standard Python integer slicing works.
 
 Miscellaneous indexing gotchas
 ------------------------------
-
-Reindex versus ix gotchas
-~~~~~~~~~~~~~~~~~~~~~~~~~
-
-Many users will find themselves using the ``ix`` indexing capabilities as a
-concise means of selecting data from a pandas object:
-
-.. ipython:: python
-
-   df = pd.DataFrame(np.random.randn(6, 4), columns=['one', 'two', 'three', 'four'],
-                     index=list('abcdef'))
-   df
-   df.ix[['b', 'c', 'e']]
-
-This is, of course, completely equivalent *in this case* to using the
-``reindex`` method:
-
-.. ipython:: python
-
-   df.reindex(['b', 'c', 'e'])
-
-Some might conclude that ``ix`` and ``reindex`` are 100% equivalent based on
-this. This is indeed true **except in the case of integer indexing**. For
-example, the above operation could alternately have been expressed as:
-
-.. ipython:: python
-
-   df.ix[[1, 2, 4]]
-
-If you pass ``[1, 2, 4]`` to ``reindex`` you will get another thing entirely:
-
-.. ipython:: python
-
-   df.reindex([1, 2, 4])
-
-So it's important to remember that ``reindex`` is **strict label indexing
-only**. This can lead to some potentially surprising results in pathological
-cases where an index contains, say, both integers and strings:
-
-.. ipython:: python
-
-   s = pd.Series([1, 2, 3], index=['a', 0, 1])
-   s
-   s.ix[[0, 1]]
-   s.reindex([0, 1])
-
-Because the index in this case does not contain solely integers, ``ix`` falls
-back on integer indexing. By contrast, ``reindex`` only looks for the values
-passed in the index, thus finding the integers ``0`` and ``1``. While it would
-be possible to insert some logic to check whether a passed sequence is all
-contained in the index, that logic would exact a very high cost in large data
-sets.
 
 Reindex potentially changes underlying Series dtype
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/source/indexing.rst
+++ b/doc/source/indexing.rst
@@ -61,6 +61,8 @@ See the :ref:`MultiIndex / Advanced Indexing <advanced>` for ``MultiIndex`` and 
 
 See the :ref:`cookbook<cookbook.selection>` for some advanced strategies
 
+.. _indexing.choice:
+
 Different Choices for Indexing
 ------------------------------
 
@@ -104,24 +106,13 @@ of multi-axis indexing.
 
   See more at :ref:`Selection by Position <indexing.integer>`
 
-- ``.ix`` supports mixed integer and label based access. It is primarily label
-  based, but will fall back to integer positional access unless the corresponding
-  axis is of integer type. ``.ix`` is the most general and will
-  support any of the inputs in ``.loc`` and ``.iloc``. ``.ix`` also supports floating point
-  label schemes. ``.ix`` is exceptionally useful when dealing with mixed positional
-  and label based hierarchical indexes.
-
-  However, when an axis is integer based, ONLY
-  label based access and not positional access is supported.
-  Thus, in such cases, it's usually better to be explicit and use ``.iloc`` or ``.loc``.
-
   See more at :ref:`Advanced Indexing <advanced>` and :ref:`Advanced
   Hierarchical <advanced.advanced_hierarchical>`.
 
-- ``.loc``, ``.iloc``, ``.ix`` and also ``[]`` indexing can accept a ``callable`` as indexer. See more at :ref:`Selection By Callable <indexing.callable>`.
+- ``.loc``, ``.iloc``, and also ``[]`` indexing can accept a ``callable`` as indexer. See more at :ref:`Selection By Callable <indexing.callable>`.
 
 Getting values from an object with multi-axes selection uses the following
-notation (using ``.loc`` as an example, but applies to ``.iloc`` and ``.ix`` as
+notation (using ``.loc`` as an example, but applies to ``.iloc`` as
 well). Any of the axes accessors may be the null slice ``:``. Axes left out of
 the specification are assumed to be ``:``. (e.g. ``p.loc['a']`` is equiv to
 ``p.loc['a', :, :]``)
@@ -193,7 +184,7 @@ columns.
 
 .. warning::
 
-   pandas aligns all AXES when setting ``Series`` and ``DataFrame`` from ``.loc``, ``.iloc`` and ``.ix``.
+   pandas aligns all AXES when setting ``Series`` and ``DataFrame`` from ``.loc``, and ``.iloc``.
 
    This will **not** modify ``df`` because the column alignment is before value assignment.
 
@@ -526,7 +517,7 @@ Selection By Callable
 
 .. versionadded:: 0.18.1
 
-``.loc``, ``.iloc``, ``.ix`` and also ``[]`` indexing can accept a ``callable`` as indexer.
+``.loc``, ``.iloc``, and also ``[]`` indexing can accept a ``callable`` as indexer.
 The ``callable`` must be a function with one argument (the calling Series, DataFrame or Panel) and that returns valid output for indexing.
 
 .. ipython:: python
@@ -558,6 +549,58 @@ without using temporary variable.
    bb = pd.read_csv('data/baseball.csv', index_col='id')
    (bb.groupby(['year', 'team']).sum()
       .loc[lambda df: df.r > 100])
+
+.. _indexing.deprecate_ix:
+
+IX Indexer is Deprecated
+------------------------
+
+.. warning::
+
+  Starting in 0.20.0, the ``.ix`` indexer is deprecated, in favor of the more strict ``.iloc``
+and ``.loc`` indexers. ``.ix`` offers a lot of magic on the inference of what the user wants to
+do. To wit, ``.ix`` can decide to index *positionally* OR via *labels*. This has caused
+quite a bit of user confusion over the years.
+
+The recommended methods of indexing are:
+
+.. ipython:: python
+
+  dfd = pd.DataFrame({'A': [1, 2, 3],
+                      'B': [4, 5, 6]},
+                     index=list('abc'))
+
+  dfd
+
+Previous Behavior, where you wish to get the 0th and the 2nd elements from the index in the 'A' column.
+
+.. code-block:: ipython
+
+  In [3]: dfd.ix[[0, 2], 'A']
+  Out[3]:
+  a    1
+  c    3
+  Name: A, dtype: int64
+
+Using ``.loc``. Here we will select the appropriate indexes from the index, then use *label* indexing.
+
+.. ipython:: python
+
+  dfd.loc[df.index[[0, 2]], 'A']
+
+This can also be expressed using ``.iloc``, by explicitly getting locations on the indexers, and using
+*positional* indexing to select things.
+
+.. ipython:: python
+
+  dfd.iloc[[0, 2], dfd.columns.get_loc('A')]
+
+For getting *multiple* indexers, using ``.get_indexer``
+
+.. ipython:: python
+
+  dfd.iloc[[0, 2], dfd.columns.get_indexer(['A', 'B'])]
+
 
 .. _indexing.basics.partial_setting:
 
@@ -641,7 +684,7 @@ Setting With Enlargement
 
 .. versionadded:: 0.13
 
-The ``.loc/.ix/[]`` operations can perform enlargement when setting a non-existant key for that axis.
+The ``.loc/[]`` operations can perform enlargement when setting a non-existant key for that axis.
 
 In the ``Series`` case this is effectively an appending operation
 
@@ -906,7 +949,7 @@ without creating a copy:
 
 Furthermore, ``where`` aligns the input boolean condition (ndarray or DataFrame),
 such that partial selection with setting is possible. This is analogous to
-partial setting via ``.ix`` (but on the contents rather than the axis labels)
+partial setting via ``.loc`` (but on the contents rather than the axis labels)
 
 .. ipython:: python
 
@@ -1716,7 +1759,7 @@ A chained assignment can also crop up in setting in a mixed dtype frame.
 
 .. note::
 
-   These setting rules apply to all of ``.loc/.iloc/.ix``
+   These setting rules apply to all of ``.loc/.iloc``
 
 This is the correct access method
 

--- a/doc/source/io.rst
+++ b/doc/source/io.rst
@@ -1400,7 +1400,7 @@ returned object:
 
    df = pd.read_csv("data/mindex_ex.csv", index_col=[0,1])
    df
-   df.ix[1978]
+   df.iloc[1978]
 
 .. _io.multi_index_columns:
 
@@ -3280,7 +3280,7 @@ defaults to `nan`.
                               'bool' : True,
                               'datetime64' : pd.Timestamp('20010102')},
                             index=list(range(8)))
-    df_mixed.ix[3:5,['A', 'B', 'string', 'datetime64']] = np.nan
+    df_mixed.loc[df_mixed.index[3:5], ['A', 'B', 'string', 'datetime64']] = np.nan
 
     store.append('df_mixed', df_mixed, min_itemsize = {'values': 50})
     df_mixed1 = store.select('df_mixed')
@@ -3560,10 +3560,10 @@ be data_columns
 
    df_dc = df.copy()
    df_dc['string'] = 'foo'
-   df_dc.ix[4:6,'string'] = np.nan
-   df_dc.ix[7:9,'string'] = 'bar'
+   df_dc.loc[df_dc.index[4:6], 'string'] = np.nan
+   df_dc.loc[df_dc.index[7:9], 'string'] = 'bar'
    df_dc['string2'] = 'cool'
-   df_dc.ix[1:3,['B','C']] = 1.0
+   df_dc.loc[df_dc.index[1:3], ['B','C']] = 1.0
    df_dc
 
    # on-disk operations
@@ -3727,7 +3727,7 @@ results.
    df_mt = pd.DataFrame(randn(8, 6), index=pd.date_range('1/1/2000', periods=8),
                                      columns=['A', 'B', 'C', 'D', 'E', 'F'])
    df_mt['foo'] = 'bar'
-   df_mt.ix[1, ('A', 'B')] = np.nan
+   df_mt.loc[df_mt.index[1], ('A', 'B')] = np.nan
 
    # you can also create the tables individually
    store.append_to_multiple({'df1_mt': ['A', 'B'], 'df2_mt': None },
@@ -4686,7 +4686,7 @@ destination DataFrame as well as a preferred column order as follows:
 
 
 Starting with 0.20.0, you can specify the query config as parameter to use additional options of your job.
-For more information about query configuration parameters see 
+For more information about query configuration parameters see
 `here <https://cloud.google.com/bigquery/docs/reference/rest/v2/jobs#configuration.query>`__.
 
 .. code-block:: python

--- a/doc/source/merging.rst
+++ b/doc/source/merging.rst
@@ -132,7 +132,7 @@ means that we can now do stuff like select out each chunk by key:
 
 .. ipython:: python
 
-   result.ix['y']
+   result.loc['y']
 
 It's not a stretch to see how this can be very useful. More detail on this
 functionality below.
@@ -692,7 +692,7 @@ either the left or right tables, the values in the joined table will be
    p.plot([left, right], result,
           labels=['left', 'right'], vertical=False);
    plt.close('all');
-   
+
 Here is another example with duplicate join keys in DataFrames:
 
 .. ipython:: python
@@ -710,10 +710,10 @@ Here is another example with duplicate join keys in DataFrames:
    p.plot([left, right], result,
           labels=['left', 'right'], vertical=False);
    plt.close('all');
-   
+
 .. warning::
 
-  Joining / merging on duplicate keys can cause a returned frame that is the multiplication of the row dimensions, 
+  Joining / merging on duplicate keys can cause a returned frame that is the multiplication of the row dimensions,
   may result in memory overflow. It is the user' s responsibility to manage duplicate values in keys before joining large DataFrames.
 
 .. _merging.indicator:

--- a/doc/source/missing_data.rst
+++ b/doc/source/missing_data.rst
@@ -113,7 +113,7 @@ pandas objects provide intercompatibility between ``NaT`` and ``NaN``.
    df2 = df.copy()
    df2['timestamp'] = pd.Timestamp('20120101')
    df2
-   df2.ix[['a','c','h'],['one','timestamp']] = np.nan
+   df2.loc[['a','c','h'],['one','timestamp']] = np.nan
    df2
    df2.get_dtype_counts()
 
@@ -155,9 +155,9 @@ objects.
 .. ipython:: python
    :suppress:
 
-   df = df2.ix[:, ['one', 'two', 'three']]
-   a = df2.ix[:5, ['one', 'two']].fillna(method='pad')
-   b = df2.ix[:5, ['one', 'two', 'three']]
+   df = df2.loc[:, ['one', 'two', 'three']]
+   a = df2.loc[df2.index[:5], ['one', 'two']].fillna(method='pad')
+   b = df2.loc[df2.index[:5], ['one', 'two', 'three']]
 
 .. ipython:: python
 
@@ -237,7 +237,7 @@ we can use the `limit` keyword:
 .. ipython:: python
    :suppress:
 
-   df.ix[2:4, :] = np.nan
+   df.iloc[2:4, :] = np.nan
 
 .. ipython:: python
 

--- a/doc/source/reshaping.rst
+++ b/doc/source/reshaping.rst
@@ -217,7 +217,7 @@ calling ``sort_index``, of course). Here is a more complex example:
                                        ('one', 'two')],
                                       names=['first', 'second'])
    df = pd.DataFrame(np.random.randn(8, 4), index=index, columns=columns)
-   df2 = df.ix[[0, 1, 2, 4, 5, 7]]
+   df2 = df.iloc[[0, 1, 2, 4, 5, 7]]
    df2
 
 As mentioned above, ``stack`` can be called with a ``level`` argument to select

--- a/doc/source/sparse.rst
+++ b/doc/source/sparse.rst
@@ -45,7 +45,7 @@ large, mostly NA DataFrame:
 .. ipython:: python
 
    df = pd.DataFrame(randn(10000, 4))
-   df.ix[:9998] = np.nan
+   df.iloc[:9998] = np.nan
    sdf = df.to_sparse()
    sdf
    sdf.density

--- a/doc/source/visualization.rst
+++ b/doc/source/visualization.rst
@@ -134,7 +134,7 @@ For example, a bar plot can be created the following way:
    plt.figure();
 
    @savefig bar_plot_ex.png
-   df.ix[5].plot(kind='bar'); plt.axhline(0, color='k')
+   df.iloc[5].plot(kind='bar'); plt.axhline(0, color='k')
 
 .. versionadded:: 0.17.0
 
@@ -179,7 +179,7 @@ For labeled, non-time series data, you may wish to produce a bar plot:
    plt.figure();
 
    @savefig bar_plot_ex.png
-   df.ix[5].plot.bar(); plt.axhline(0, color='k')
+   df.iloc[5].plot.bar(); plt.axhline(0, color='k')
 
 Calling a DataFrame's :meth:`plot.bar() <DataFrame.plot.bar>` method produces a multiple
 bar plot:

--- a/doc/source/whatsnew/v0.20.0.txt
+++ b/doc/source/whatsnew/v0.20.0.txt
@@ -10,6 +10,7 @@ users upgrade to this version.
 Highlights include:
 
 - Building pandas for development now requires ``cython >= 0.23`` (:issue:`14831`)
+- The ``.ix`` indexer has been deprecated, see :ref:`here <whatsnew.api_breaking.deprecate_ix>`
 
 Check the :ref:`API Changes <whatsnew_0200.api_breaking>` and :ref:`deprecations <whatsnew_0200.deprecations>` before updating.
 
@@ -141,6 +142,54 @@ Other enhancements
 
 Backwards incompatible API changes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+
+.. _whatsnew.api_breaking.deprecate_ix
+
+Deprecate .ix
+^^^^^^^^^^^^^
+
+The ``.ix`` indexer is deprecated, in favor of the more strict ``.iloc`` and ``.loc`` indexers. ``.ix`` offers a lot of magic on the inference of what the user wants to do. To wit, ``.ix`` can decide to index *positionally* OR via *labels*. This has caused quite a bit of user confusion over the years. The full indexing documentation are :ref:`here <indexing>`. (:issue:`14218`)
+
+
+The recommended methods of indexing are:
+
+- ``.loc`` if you want to *label* index
+- ``.iloc`` if you want to *positionally* index.
+
+Using ``.ix`` will now show a ``DeprecationWarning`` with a link to some examples of how to convert code `here <http://pandas.pydata.org/pandas-docs/stable/indexing.html#deprecate_ix>`_
+
+
+.. ipython:: python
+
+  df = pd.DataFrame({'A': [1, 2, 3],
+                     'B': [4, 5, 6]},
+                    index=list('abc'))
+
+  df
+
+Previous Behavior, where you wish to get the 0th and the 2nd elements from the index in the 'A' column.
+
+.. code-block:: ipython
+
+  In [3]: df.ix[[0, 2], 'A']
+  Out[3]:
+  a    1
+  c    3
+  Name: A, dtype: int64
+
+Using ``.loc``. Here we will select the appropriate indexes from the index, then use *label* indexing.
+
+.. ipython:: python
+
+  df.loc[df.index[[0, 2]], 'A']
+
+Using ``.iloc``. Here we will get the location of the 'A' column, then use *positional* indexing to select things.
+
+.. ipython:: python
+
+  df.iloc[[0, 2], df.columns.get_loc('A')]
+
 
 .. _whatsnew.api_breaking.index_map
 

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -1961,7 +1961,7 @@ class DataFrame(NDFrame):
             if isinstance(i, slice):
                 # need to return view
                 lab_slice = slice(label[0], label[-1])
-                return self.ix[:, lab_slice]
+                return self.loc[:, lab_slice]
             else:
                 if isinstance(label, Index):
                     return self.take(i, axis=1, convert=True)
@@ -2056,7 +2056,7 @@ class DataFrame(NDFrame):
             indexer = key.nonzero()[0]
             return self.take(indexer, axis=0, convert=False)
         else:
-            indexer = self.ix._convert_to_indexer(key, axis=1)
+            indexer = self.loc._convert_to_indexer(key, axis=1)
             return self.take(indexer, axis=1, convert=True)
 
     def _getitem_multilevel(self, key):
@@ -2389,7 +2389,7 @@ class DataFrame(NDFrame):
 
     def _setitem_slice(self, key, value):
         self._check_setitem_copy()
-        self.ix._setitem_with_indexer(key, value)
+        self.loc._setitem_with_indexer(key, value)
 
     def _setitem_array(self, key, value):
         # also raises Exception if object array with NA values
@@ -2400,7 +2400,7 @@ class DataFrame(NDFrame):
             key = check_bool_indexer(self.index, key)
             indexer = key.nonzero()[0]
             self._check_setitem_copy()
-            self.ix._setitem_with_indexer(indexer, value)
+            self.loc._setitem_with_indexer(indexer, value)
         else:
             if isinstance(value, DataFrame):
                 if len(value.columns) != len(key):
@@ -2408,9 +2408,9 @@ class DataFrame(NDFrame):
                 for k1, k2 in zip(key, value.columns):
                     self[k1] = value[k2]
             else:
-                indexer = self.ix._convert_to_indexer(key, axis=1)
+                indexer = self.loc._convert_to_indexer(key, axis=1)
                 self._check_setitem_copy()
-                self.ix._setitem_with_indexer((slice(None), indexer), value)
+                self.loc._setitem_with_indexer((slice(None), indexer), value)
 
     def _setitem_frame(self, key, value):
         # support boolean setting with DataFrame input, e.g.
@@ -4403,7 +4403,7 @@ class DataFrame(NDFrame):
         elif isinstance(other, list) and not isinstance(other[0], DataFrame):
             other = DataFrame(other)
             if (self.columns.get_indexer(other.columns) >= 0).all():
-                other = other.ix[:, self.columns]
+                other = other.loc[:, self.columns]
 
         from pandas.tools.merge import concat
         if isinstance(other, (list, tuple)):

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -1809,18 +1809,12 @@ class NDFrame(PandasObject):
             loc, new_ax = labels.get_loc_level(key, level=level,
                                                drop_level=drop_level)
 
-            # convert to a label indexer if needed
-            if isinstance(loc, slice):
-                lev_num = labels._get_level_number(level)
-                if labels.levels[lev_num].inferred_type == 'integer':
-                    loc = labels[loc]
-
             # create the tuple of the indexer
             indexer = [slice(None)] * self.ndim
             indexer[axis] = loc
             indexer = tuple(indexer)
 
-            result = self.ix[indexer]
+            result = self.iloc[indexer]
             setattr(result, result._get_axis_name(axis), new_ax)
             return result
 
@@ -1983,7 +1977,7 @@ class NDFrame(PandasObject):
             slicer = [slice(None)] * self.ndim
             slicer[self._get_axis_number(axis_name)] = indexer
 
-            result = self.ix[tuple(slicer)]
+            result = self.loc[tuple(slicer)]
 
         if inplace:
             self._update_inplace(result)
@@ -4332,8 +4326,9 @@ class NDFrame(PandasObject):
         if not offset.isAnchored() and hasattr(offset, '_inc'):
             if end_date in self.index:
                 end = self.index.searchsorted(end_date, side='left')
+                return self.iloc[:end]
 
-        return self.ix[:end]
+        return self.loc[:end]
 
     def last(self, offset):
         """
@@ -4364,7 +4359,7 @@ class NDFrame(PandasObject):
 
         start_date = start = self.index[-1] - offset
         start = self.index.searchsorted(start_date, side='right')
-        return self.ix[start:]
+        return self.iloc[start:]
 
     def rank(self, axis=0, method='average', numeric_only=None,
              na_option='keep', ascending=True, pct=False):
@@ -5078,7 +5073,7 @@ class NDFrame(PandasObject):
 
         slicer = [slice(None, None)] * self._AXIS_LEN
         slicer[axis] = slice(before, after)
-        result = self.ix[tuple(slicer)]
+        result = self.loc[tuple(slicer)]
 
         if isinstance(ax, MultiIndex):
             setattr(result, self._get_axis_name(axis),

--- a/pandas/core/groupby.py
+++ b/pandas/core/groupby.py
@@ -4103,7 +4103,7 @@ class FrameSplitter(DataSplitter):
         if self.axis == 0:
             return sdata.iloc[slice_obj]
         else:
-            return sdata._slice(slice_obj, axis=1)  # ix[:, slice_obj]
+            return sdata._slice(slice_obj, axis=1)  # .loc[:, slice_obj]
 
 
 class NDFrameSplitter(DataSplitter):

--- a/pandas/core/panel.py
+++ b/pandas/core/panel.py
@@ -272,7 +272,7 @@ class Panel(NDFrame):
             return self._getitem_multilevel(key)
         if not (is_list_like(key) or isinstance(key, slice)):
             return super(Panel, self).__getitem__(key)
-        return self.ix[key]
+        return self.loc[key]
 
     def _getitem_multilevel(self, key):
         info = self._info_axis

--- a/pandas/core/reshape.py
+++ b/pandas/core/reshape.py
@@ -450,7 +450,7 @@ def _unstack_frame(obj, level, fill_value=None):
 
         result = DataFrame(BlockManager(new_blocks, new_axes))
         mask_frame = DataFrame(BlockManager(mask_blocks, new_axes))
-        return result.ix[:, mask_frame.sum(0) > 0]
+        return result.loc[:, mask_frame.sum(0) > 0]
     else:
         unstacker = _Unstacker(obj.values, obj.index, level=level,
                                value_columns=obj.columns,
@@ -625,12 +625,12 @@ def _stack_multi_columns(frame, level_num=-1, dropna=True):
             drop_cols.append(key)
             continue
         elif slice_len != levsize:
-            chunk = this.ix[:, this.columns[loc]]
+            chunk = this.loc[:, this.columns[loc]]
             chunk.columns = level_vals.take(chunk.columns.labels[-1])
             value_slice = chunk.reindex(columns=level_vals_used).values
         else:
             if frame._is_mixed_type:
-                value_slice = this.ix[:, this.columns[loc]].values
+                value_slice = this.loc[:, this.columns[loc]].values
             else:
                 value_slice = this.values[:, loc]
 
@@ -771,7 +771,7 @@ def melt(frame, id_vars=None, value_vars=None, var_name=None,
     if value_vars is not None:
         if not isinstance(value_vars, (tuple, list, np.ndarray)):
             value_vars = [value_vars]
-        frame = frame.ix[:, id_vars + value_vars]
+        frame = frame.loc[:, id_vars + value_vars]
     else:
         frame = frame.copy()
 

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -685,7 +685,7 @@ class Series(base.IndexOpsMixin, strings.StringAccessorMixin,
                 try:
                     # handle the dup indexing case (GH 4246)
                     if isinstance(key, (list, tuple)):
-                        return self.ix[key]
+                        return self.loc[key]
 
                     return self.reindex(key)
                 except Exception:

--- a/pandas/io/pytables.py
+++ b/pandas/io/pytables.py
@@ -1040,7 +1040,7 @@ class HDFStore(StringMixin):
             valid_index = next(idxs)
             for index in idxs:
                 valid_index = valid_index.intersection(index)
-            value = value.ix[valid_index]
+            value = value.loc[valid_index]
 
         # append
         for k, v in d.items():
@@ -3576,8 +3576,8 @@ class Table(Fixed):
                                 filt = filt.union(Index(self.levels))
 
                             takers = op(axis_values, filt)
-                            return obj.ix._getitem_axis(takers,
-                                                        axis=axis_number)
+                            return obj.loc._getitem_axis(takers,
+                                                         axis=axis_number)
 
                         # this might be the name of a file IN an axis
                         elif field in axis_values:
@@ -3590,8 +3590,8 @@ class Table(Fixed):
                             if isinstance(obj, DataFrame):
                                 axis_number = 1 - axis_number
                             takers = op(values, filt)
-                            return obj.ix._getitem_axis(takers,
-                                                        axis=axis_number)
+                            return obj.loc._getitem_axis(takers,
+                                                         axis=axis_number)
 
                     raise ValueError(
                         "cannot find the field [%s] for filtering!" % field)

--- a/pandas/io/tests/json/test_pandas.py
+++ b/pandas/io/tests/json/test_pandas.py
@@ -438,9 +438,9 @@ class TestPandasContainer(tm.TestCase):
             columns=['A', 'B', 'C', 'D'],
             index=pd.date_range('2000-01-03', '2000-01-07'))
         df['date'] = pd.Timestamp('19920106 18:21:32.12')
-        df.ix[3, 'date'] = pd.Timestamp('20130101')
+        df.iloc[3, df.columns.get_loc('date')] = pd.Timestamp('20130101')
         df['modified'] = df['date']
-        df.ix[1, 'modified'] = pd.NaT
+        df.iloc[1, df.columns.get_loc('modified')] = pd.NaT
 
         v12_json = os.path.join(self.dirpath, 'tsframe_v012.json')
         df_unser = pd.read_json(v12_json)
@@ -650,8 +650,8 @@ class TestPandasContainer(tm.TestCase):
 
         def test_w_date(date, date_unit=None):
             df['date'] = Timestamp(date)
-            df.ix[1, 'date'] = pd.NaT
-            df.ix[5, 'date'] = pd.NaT
+            df.iloc[1, df.columns.get_loc('date')] = pd.NaT
+            df.iloc[5, df.columns.get_loc('date')] = pd.NaT
             if date_unit:
                 json = df.to_json(date_format='iso', date_unit=date_unit)
             else:
@@ -671,8 +671,8 @@ class TestPandasContainer(tm.TestCase):
     def test_date_format_series(self):
         def test_w_date(date, date_unit=None):
             ts = Series(Timestamp(date), index=self.ts.index)
-            ts.ix[1] = pd.NaT
-            ts.ix[5] = pd.NaT
+            ts.iloc[1] = pd.NaT
+            ts.iloc[5] = pd.NaT
             if date_unit:
                 json = ts.to_json(date_format='iso', date_unit=date_unit)
             else:
@@ -693,9 +693,10 @@ class TestPandasContainer(tm.TestCase):
     def test_date_unit(self):
         df = self.tsframe.copy()
         df['date'] = Timestamp('20130101 20:43:42')
-        df.ix[1, 'date'] = Timestamp('19710101 20:43:42')
-        df.ix[2, 'date'] = Timestamp('21460101 20:43:42')
-        df.ix[4, 'date'] = pd.NaT
+        dl = df.columns.get_loc('date')
+        df.iloc[1, dl] = Timestamp('19710101 20:43:42')
+        df.iloc[2, dl] = Timestamp('21460101 20:43:42')
+        df.iloc[4, dl] = pd.NaT
 
         for unit in ('s', 'ms', 'us', 'ns'):
             json = df.to_json(date_format='epoch', date_unit=unit)
@@ -894,14 +895,14 @@ DataFrame\\.index values are different \\(100\\.0 %\\)
     def test_sparse(self):
         # GH4377 df.to_json segfaults with non-ndarray blocks
         df = pd.DataFrame(np.random.randn(10, 4))
-        df.ix[:8] = np.nan
+        df.loc[:8] = np.nan
 
         sdf = df.to_sparse()
         expected = df.to_json()
         self.assertEqual(expected, sdf.to_json())
 
         s = pd.Series(np.random.randn(10))
-        s.ix[:8] = np.nan
+        s.loc[:8] = np.nan
         ss = s.to_sparse()
 
         expected = s.to_json()

--- a/pandas/io/tests/parser/common.py
+++ b/pandas/io/tests/parser/common.py
@@ -275,7 +275,7 @@ c,4,5
                                 pd.Index(['A', 'B', 'C', 'D', 'E']))
         self.assertIsInstance(df.index[0],
                               (datetime, np.datetime64, Timestamp))
-        self.assertEqual(df.ix[:, ['A', 'B', 'C', 'D']].values.dtype,
+        self.assertEqual(df.loc[:, ['A', 'B', 'C', 'D']].values.dtype,
                          np.float64)
         tm.assert_frame_equal(df, df2)
 
@@ -666,7 +666,7 @@ bar"""
         # it's 33 columns
         result = self.read_csv(sfile, names=lrange(33), na_values=['-9999.0'],
                                header=None, skipinitialspace=True)
-        self.assertTrue(pd.isnull(result.ix[0, 29]))
+        self.assertTrue(pd.isnull(result.iloc[0, 29]))
 
     def test_utf16_bom_skiprows(self):
         # #2298

--- a/pandas/io/tests/parser/parse_dates.py
+++ b/pandas/io/tests/parser/parse_dates.py
@@ -64,7 +64,7 @@ KORD,19990127, 23:00:00, 22:56:00, -0.5900, 1.7100, 4.6000, 0.0000, 280.0000
         self.assertNotIn('X3', df)
 
         d = datetime(1999, 1, 27, 19, 0)
-        self.assertEqual(df.ix[0, 'nominal'], d)
+        self.assertEqual(df.loc[0, 'nominal'], d)
 
         df = self.read_csv(StringIO(data), header=None,
                            date_parser=func,
@@ -96,7 +96,7 @@ KORD,19990127, 23:00:00, 22:56:00, -0.5900, 1.7100, 4.6000, 0.0000, 280.0000
         self.assertNotIn('X3', df)
 
         d = datetime(1999, 1, 27, 19, 0)
-        self.assertEqual(df.ix[0, 'X1_X2'], d)
+        self.assertEqual(df.loc[0, 'X1_X2'], d)
 
         df = self.read_csv(StringIO(data), header=None,
                            parse_dates=[[1, 2], [1, 3]], keep_date_col=True)

--- a/pandas/io/tests/test_date_converters.py
+++ b/pandas/io/tests/test_date_converters.py
@@ -40,7 +40,7 @@ date, time, a, b
         df = read_table(StringIO(data), sep=',', header=0,
                         parse_dates=datecols, date_parser=conv.parse_date_time)
         self.assertIn('date_time', df)
-        self.assertEqual(df.date_time.ix[0], datetime(2001, 1, 5, 10, 0, 0))
+        self.assertEqual(df.date_time.loc[0], datetime(2001, 1, 5, 10, 0, 0))
 
         data = ("KORD,19990127, 19:00:00, 18:56:00, 0.8100\n"
                 "KORD,19990127, 20:00:00, 19:56:00, 0.0100\n"
@@ -65,7 +65,7 @@ date, time, a, b
                         parse_dates=datecols,
                         date_parser=conv.parse_date_fields)
         self.assertIn('ymd', df)
-        self.assertEqual(df.ymd.ix[0], datetime(2001, 1, 10))
+        self.assertEqual(df.ymd.loc[0], datetime(2001, 1, 10))
 
     def test_datetime_six_col(self):
         result = conv.parse_all_fields(self.years, self.months, self.days,
@@ -82,7 +82,7 @@ year, month, day, hour, minute, second, a, b
                         parse_dates=datecols,
                         date_parser=conv.parse_all_fields)
         self.assertIn('ymdHMS', df)
-        self.assertEqual(df.ymdHMS.ix[0], datetime(2001, 1, 5, 10, 0, 0))
+        self.assertEqual(df.ymdHMS.loc[0], datetime(2001, 1, 5, 10, 0, 0))
 
     def test_datetime_fractional_seconds(self):
         data = """\
@@ -95,10 +95,10 @@ year, month, day, hour, minute, second, a, b
                         parse_dates=datecols,
                         date_parser=conv.parse_all_fields)
         self.assertIn('ymdHMS', df)
-        self.assertEqual(df.ymdHMS.ix[0], datetime(2001, 1, 5, 10, 0, 0,
-                                                   microsecond=123456))
-        self.assertEqual(df.ymdHMS.ix[1], datetime(2001, 1, 5, 10, 0, 0,
-                                                   microsecond=500000))
+        self.assertEqual(df.ymdHMS.loc[0], datetime(2001, 1, 5, 10, 0, 0,
+                                                    microsecond=123456))
+        self.assertEqual(df.ymdHMS.loc[1], datetime(2001, 1, 5, 10, 0, 0,
+                                                    microsecond=500000))
 
     def test_generic(self):
         data = "year, month, day, a\n 2001, 01, 10, 10.\n 2001, 02, 1, 11."
@@ -108,7 +108,7 @@ year, month, day, hour, minute, second, a, b
                         parse_dates=datecols,
                         date_parser=dateconverter)
         self.assertIn('ym', df)
-        self.assertEqual(df.ym.ix[0], date(2001, 1, 1))
+        self.assertEqual(df.ym.loc[0], date(2001, 1, 1))
 
     def test_dateparser_resolution_if_not_ns(self):
         # issue 10245

--- a/pandas/io/tests/test_excel.py
+++ b/pandas/io/tests/test_excel.py
@@ -276,12 +276,12 @@ class ReadingTestsBase(SharedItems):
 
         df3 = read_excel(excel, 0, index_col=0, skipfooter=1)
         df4 = read_excel(excel, 0, index_col=0, skip_footer=1)
-        tm.assert_frame_equal(df3, df1.ix[:-1])
+        tm.assert_frame_equal(df3, df1.iloc[:-1])
         tm.assert_frame_equal(df3, df4)
 
         df3 = excel.parse(0, index_col=0, skipfooter=1)
         df4 = excel.parse(0, index_col=0, skip_footer=1)
-        tm.assert_frame_equal(df3, df1.ix[:-1])
+        tm.assert_frame_equal(df3, df1.iloc[:-1])
         tm.assert_frame_equal(df3, df4)
 
         import xlrd
@@ -302,7 +302,7 @@ class ReadingTestsBase(SharedItems):
                                skipfooter=1)
         df4 = self.get_exceldf('test1', 'Sheet1', index_col=0,
                                skip_footer=1)
-        tm.assert_frame_equal(df3, df1.ix[:-1])
+        tm.assert_frame_equal(df3, df1.iloc[:-1])
         tm.assert_frame_equal(df3, df4)
 
     def test_reader_special_dtypes(self):
@@ -328,7 +328,7 @@ class ReadingTestsBase(SharedItems):
         # if not coercing number, then int comes in as float
         float_expected = expected.copy()
         float_expected["IntCol"] = float_expected["IntCol"].astype(float)
-        float_expected.loc[1, "Str2Col"] = 3.0
+        float_expected.loc[float_expected.index[1], "Str2Col"] = 3.0
         actual = self.get_exceldf(basename, 'Sheet1', convert_float=False)
         tm.assert_frame_equal(actual, float_expected)
 
@@ -1670,15 +1670,15 @@ class ExcelWriterBase(SharedItems):
                     # no nans
                     for r in range(len(res.index)):
                         for c in range(len(res.columns)):
-                            self.assertTrue(res.ix[r, c] is not np.nan)
+                            self.assertTrue(res.iloc[r, c] is not np.nan)
 
         res = roundtrip(DataFrame([0]))
         self.assertEqual(res.shape, (1, 1))
-        self.assertTrue(res.ix[0, 0] is not np.nan)
+        self.assertTrue(res.iloc[0, 0] is not np.nan)
 
         res = roundtrip(DataFrame([0]), False, None)
         self.assertEqual(res.shape, (1, 2))
-        self.assertTrue(res.ix[0, 0] is not np.nan)
+        self.assertTrue(res.iloc[0, 0] is not np.nan)
 
     def test_excel_010_hemstring_raises_NotImplementedError(self):
         # This test was failing only for j>1 and header=False,

--- a/pandas/io/tests/test_html.py
+++ b/pandas/io/tests/test_html.py
@@ -144,7 +144,7 @@ class TestReadHtml(tm.TestCase, ReadHtmlMixin):
         df2 = self.read_html(self.spam_data, 'Unit')
         assert_framelist_equal(df1, df2)
 
-        self.assertEqual(df1[0].ix[0, 0], 'Proximates')
+        self.assertEqual(df1[0].iloc[0, 0], 'Proximates')
         self.assertEqual(df1[0].columns[0], 'Nutrient')
 
     def test_spam_with_types(self):
@@ -152,7 +152,7 @@ class TestReadHtml(tm.TestCase, ReadHtmlMixin):
         df2 = self.read_html(self.spam_data, 'Unit')
         assert_framelist_equal(df1, df2)
 
-        self.assertEqual(df1[0].ix[0, 0], 'Proximates')
+        self.assertEqual(df1[0].iloc[0, 0], 'Proximates')
         self.assertEqual(df1[0].columns[0], 'Nutrient')
 
     def test_spam_no_match(self):

--- a/pandas/io/tests/test_packers.py
+++ b/pandas/io/tests/test_packers.py
@@ -531,8 +531,8 @@ class TestSparse(TestPackers):
     def test_sparse_frame(self):
 
         s = tm.makeDataFrame()
-        s.ix[3:5, 1:3] = np.nan
-        s.ix[8:10, -2] = np.nan
+        s.loc[3:5, 1:3] = np.nan
+        s.loc[8:10, -2] = np.nan
         ss = s.to_sparse()
 
         self._check_roundtrip(ss, tm.assert_frame_equal,

--- a/pandas/io/tests/test_pytables.py
+++ b/pandas/io/tests/test_pytables.py
@@ -426,7 +426,7 @@ class TestHDFStore(Base, tm.TestCase):
             df['timestamp2'] = Timestamp('20010103')
             df['datetime1'] = datetime.datetime(2001, 1, 2, 0, 0)
             df['datetime2'] = datetime.datetime(2001, 1, 3, 0, 0)
-            df.ix[3:6, ['obj1']] = np.nan
+            df.loc[3:6, ['obj1']] = np.nan
             df = df.consolidate()._convert(datetime=True)
 
             warnings.filterwarnings('ignore', category=PerformanceWarning)
@@ -770,7 +770,7 @@ class TestHDFStore(Base, tm.TestCase):
         df['timestamp2'] = Timestamp('20010103')
         df['datetime1'] = datetime.datetime(2001, 1, 2, 0, 0)
         df['datetime2'] = datetime.datetime(2001, 1, 3, 0, 0)
-        df.ix[3:6, ['obj1']] = np.nan
+        df.loc[3:6, ['obj1']] = np.nan
         df = df.consolidate()._convert(datetime=True)
 
         with ensure_clean_store(self.path) as store:
@@ -815,8 +815,8 @@ class TestHDFStore(Base, tm.TestCase):
             # panel
             wp = tm.makePanel()
             _maybe_remove(store, 'wp1')
-            store.append('wp1', wp.ix[:, :10, :])
-            store.append('wp1', wp.ix[:, 10:, :])
+            store.append('wp1', wp.iloc[:, :10, :])
+            store.append('wp1', wp.iloc[:, 10:, :])
             assert_panel_equal(store['wp1'], wp)
 
             # ndim
@@ -824,15 +824,15 @@ class TestHDFStore(Base, tm.TestCase):
                                             check_stacklevel=False):
                 p4d = tm.makePanel4D()
                 _maybe_remove(store, 'p4d')
-                store.append('p4d', p4d.ix[:, :, :10, :])
-                store.append('p4d', p4d.ix[:, :, 10:, :])
+                store.append('p4d', p4d.iloc[:, :, :10, :])
+                store.append('p4d', p4d.iloc[:, :, 10:, :])
                 assert_panel4d_equal(store['p4d'], p4d)
 
                 # test using axis labels
                 _maybe_remove(store, 'p4d')
-                store.append('p4d', p4d.ix[:, :, :10, :], axes=[
+                store.append('p4d', p4d.iloc[:, :, :10, :], axes=[
                     'items', 'major_axis', 'minor_axis'])
-                store.append('p4d', p4d.ix[:, :, 10:, :], axes=[
+                store.append('p4d', p4d.iloc[:, :, 10:, :], axes=[
                     'items', 'major_axis', 'minor_axis'])
                 assert_panel4d_equal(store['p4d'], p4d)
 
@@ -847,16 +847,16 @@ class TestHDFStore(Base, tm.TestCase):
 
             # test using differt order of items on the non-index axes
             _maybe_remove(store, 'wp1')
-            wp_append1 = wp.ix[:, :10, :]
+            wp_append1 = wp.iloc[:, :10, :]
             store.append('wp1', wp_append1)
-            wp_append2 = wp.ix[:, 10:, :].reindex(items=wp.items[::-1])
+            wp_append2 = wp.iloc[:, 10:, :].reindex(items=wp.items[::-1])
             store.append('wp1', wp_append2)
             assert_panel_equal(store['wp1'], wp)
 
             # dtype issues - mizxed type in a single object column
             df = DataFrame(data=[[1, 2], [0, 1], [1, 2], [0, 0]])
             df['mixed_column'] = 'testing'
-            df.ix[2, 'mixed_column'] = np.nan
+            df.loc[2, 'mixed_column'] = np.nan
             _maybe_remove(store, 'df')
             store.append('df', df)
             tm.assert_frame_equal(store['df'], df)
@@ -1040,14 +1040,14 @@ class TestHDFStore(Base, tm.TestCase):
                            index=np.arange(20))
             # some nans
             _maybe_remove(store, 'df1')
-            df.ix[0:15, ['A1', 'B', 'D', 'E']] = np.nan
+            df.loc[0:15, ['A1', 'B', 'D', 'E']] = np.nan
             store.append('df1', df[:10])
             store.append('df1', df[10:])
             tm.assert_frame_equal(store['df1'], df)
 
             # first column
             df1 = df.copy()
-            df1.ix[:, 'A1'] = np.nan
+            df1.loc[:, 'A1'] = np.nan
             _maybe_remove(store, 'df1')
             store.append('df1', df1[:10])
             store.append('df1', df1[10:])
@@ -1055,7 +1055,7 @@ class TestHDFStore(Base, tm.TestCase):
 
             # 2nd column
             df2 = df.copy()
-            df2.ix[:, 'A2'] = np.nan
+            df2.loc[:, 'A2'] = np.nan
             _maybe_remove(store, 'df2')
             store.append('df2', df2[:10])
             store.append('df2', df2[10:])
@@ -1063,7 +1063,7 @@ class TestHDFStore(Base, tm.TestCase):
 
             # datetimes
             df3 = df.copy()
-            df3.ix[:, 'E'] = np.nan
+            df3.loc[:, 'E'] = np.nan
             _maybe_remove(store, 'df3')
             store.append('df3', df3[:10])
             store.append('df3', df3[10:])
@@ -1076,7 +1076,7 @@ class TestHDFStore(Base, tm.TestCase):
             df = DataFrame({'A1': np.random.randn(20),
                             'A2': np.random.randn(20)},
                            index=np.arange(20))
-            df.ix[0:15, :] = np.nan
+            df.loc[0:15, :] = np.nan
 
             # nan some entire rows (dropna=True)
             _maybe_remove(store, 'df')
@@ -1109,7 +1109,7 @@ class TestHDFStore(Base, tm.TestCase):
                             'B': 'foo', 'C': 'bar'},
                            index=np.arange(20))
 
-            df.ix[0:15, :] = np.nan
+            df.loc[0:15, :] = np.nan
 
             _maybe_remove(store, 'df')
             store.append('df', df[:10], dropna=True)
@@ -1130,7 +1130,7 @@ class TestHDFStore(Base, tm.TestCase):
                             'E': datetime.datetime(2001, 1, 2, 0, 0)},
                            index=np.arange(20))
 
-            df.ix[0:15, :] = np.nan
+            df.loc[0:15, :] = np.nan
 
             _maybe_remove(store, 'df')
             store.append('df', df[:10], dropna=True)
@@ -1173,8 +1173,8 @@ class TestHDFStore(Base, tm.TestCase):
             # column oriented
             df = tm.makeTimeDataFrame()
             _maybe_remove(store, 'df1')
-            store.append('df1', df.ix[:, :2], axes=['columns'])
-            store.append('df1', df.ix[:, 2:])
+            store.append('df1', df.iloc[:, :2], axes=['columns'])
+            store.append('df1', df.iloc[:, 2:])
             tm.assert_frame_equal(store['df1'], df)
 
             result = store.select('df1', 'columns=A')
@@ -1250,37 +1250,37 @@ class TestHDFStore(Base, tm.TestCase):
                 indexers = ['items', 'major_axis', 'minor_axis']
 
                 _maybe_remove(store, 'p4d')
-                store.append('p4d', p4d.ix[:, :, :10, :], axes=indexers)
-                store.append('p4d', p4d.ix[:, :, 10:, :])
+                store.append('p4d', p4d.iloc[:, :, :10, :], axes=indexers)
+                store.append('p4d', p4d.iloc[:, :, 10:, :])
                 assert_panel4d_equal(store.select('p4d'), p4d)
                 check_indexers('p4d', indexers)
 
                 # same as above, but try to append with differnt axes
                 _maybe_remove(store, 'p4d')
-                store.append('p4d', p4d.ix[:, :, :10, :], axes=indexers)
-                store.append('p4d', p4d.ix[:, :, 10:, :], axes=[
+                store.append('p4d', p4d.iloc[:, :, :10, :], axes=indexers)
+                store.append('p4d', p4d.iloc[:, :, 10:, :], axes=[
                     'labels', 'items', 'major_axis'])
                 assert_panel4d_equal(store.select('p4d'), p4d)
                 check_indexers('p4d', indexers)
 
                 # pass incorrect number of axes
                 _maybe_remove(store, 'p4d')
-                self.assertRaises(ValueError, store.append, 'p4d', p4d.ix[
+                self.assertRaises(ValueError, store.append, 'p4d', p4d.iloc[
                     :, :, :10, :], axes=['major_axis', 'minor_axis'])
 
                 # different than default indexables #1
                 indexers = ['labels', 'major_axis', 'minor_axis']
                 _maybe_remove(store, 'p4d')
-                store.append('p4d', p4d.ix[:, :, :10, :], axes=indexers)
-                store.append('p4d', p4d.ix[:, :, 10:, :])
+                store.append('p4d', p4d.iloc[:, :, :10, :], axes=indexers)
+                store.append('p4d', p4d.iloc[:, :, 10:, :])
                 assert_panel4d_equal(store['p4d'], p4d)
                 check_indexers('p4d', indexers)
 
                 # different than default indexables #2
                 indexers = ['major_axis', 'labels', 'minor_axis']
                 _maybe_remove(store, 'p4d')
-                store.append('p4d', p4d.ix[:, :, :10, :], axes=indexers)
-                store.append('p4d', p4d.ix[:, :, 10:, :])
+                store.append('p4d', p4d.iloc[:, :, :10, :], axes=indexers)
+                store.append('p4d', p4d.iloc[:, :, 10:, :])
                 assert_panel4d_equal(store['p4d'], p4d)
                 check_indexers('p4d', indexers)
 
@@ -1392,11 +1392,11 @@ class TestHDFStore(Base, tm.TestCase):
             _maybe_remove(store, 'df')
             df = tm.makeTimeDataFrame()
             df['string'] = 'foo'
-            df.ix[1:4, 'string'] = np.nan
+            df.loc[1:4, 'string'] = np.nan
             df['string2'] = 'bar'
-            df.ix[4:8, 'string2'] = np.nan
+            df.loc[4:8, 'string2'] = np.nan
             df['string3'] = 'bah'
-            df.ix[1:, 'string3'] = np.nan
+            df.loc[1:, 'string3'] = np.nan
             store.append('df', df)
             result = store.select('df')
             tm.assert_frame_equal(result, df)
@@ -1466,7 +1466,7 @@ class TestHDFStore(Base, tm.TestCase):
 
         with ensure_clean_store(self.path) as store:
             df = tm.makeTimeDataFrame()
-            df.loc[:, 'B'].iloc[0] = 1.
+            df.iloc[0, df.columns.get_loc('B')] = 1.
             _maybe_remove(store, 'df')
             store.append('df', df[:2], data_columns=['B'])
             store.append('df', df[2:])
@@ -1533,14 +1533,18 @@ class TestHDFStore(Base, tm.TestCase):
         with ensure_clean_store(self.path) as store:
             # multiple data columns
             df_new = df.copy()
-            df_new.ix[0, 'A'] = 1.
-            df_new.ix[0, 'B'] = -1.
+            df_new.iloc[0, df_new.columns.get_loc('A')] = 1.
+            df_new.iloc[0, df_new.columns.get_loc('B')] = -1.
             df_new['string'] = 'foo'
-            df_new.loc[1:4, 'string'] = np.nan
-            df_new.loc[5:6, 'string'] = 'bar'
+
+            sl = df_new.columns.get_loc('string')
+            df_new.iloc[1:4, sl] = np.nan
+            df_new.iloc[5:6, sl] = 'bar'
+
             df_new['string2'] = 'foo'
-            df_new.loc[2:5, 'string2'] = np.nan
-            df_new.loc[7:8, 'string2'] = 'bar'
+            sl = df_new.columns.get_loc('string2')
+            df_new.iloc[2:5, sl] = np.nan
+            df_new.iloc[7:8, sl] = 'bar'
             _maybe_remove(store, 'df')
             store.append(
                 'df', df_new, data_columns=['A', 'B', 'string', 'string2'])
@@ -1561,12 +1565,12 @@ class TestHDFStore(Base, tm.TestCase):
             # doc example
             df_dc = df.copy()
             df_dc['string'] = 'foo'
-            df_dc.ix[4:6, 'string'] = np.nan
-            df_dc.ix[7:9, 'string'] = 'bar'
+            df_dc.loc[4:6, 'string'] = np.nan
+            df_dc.loc[7:9, 'string'] = 'bar'
             df_dc['string2'] = 'cool'
             df_dc['datetime'] = Timestamp('20010102')
             df_dc = df_dc._convert(datetime=True)
-            df_dc.ix[3:5, ['A', 'B', 'datetime']] = np.nan
+            df_dc.loc[3:5, ['A', 'B', 'datetime']] = np.nan
 
             _maybe_remove(store, 'df_dc')
             store.append('df_dc', df_dc,
@@ -1590,9 +1594,9 @@ class TestHDFStore(Base, tm.TestCase):
             df_dc = DataFrame(np.random.randn(8, 3), index=index,
                               columns=['A', 'B', 'C'])
             df_dc['string'] = 'foo'
-            df_dc.ix[4:6, 'string'] = np.nan
-            df_dc.ix[7:9, 'string'] = 'bar'
-            df_dc.ix[:, ['B', 'C']] = df_dc.ix[:, ['B', 'C']].abs()
+            df_dc.loc[4:6, 'string'] = np.nan
+            df_dc.loc[7:9, 'string'] = 'bar'
+            df_dc.loc[:, ['B', 'C']] = df_dc.loc[:, ['B', 'C']].abs()
             df_dc['string2'] = 'cool'
 
             # on-disk operations
@@ -1695,8 +1699,9 @@ class TestHDFStore(Base, tm.TestCase):
     def test_append_diff_item_order(self):
 
         wp = tm.makePanel()
-        wp1 = wp.ix[:, :10, :]
-        wp2 = wp.ix[['ItemC', 'ItemB', 'ItemA'], 10:, :]
+        wp1 = wp.iloc[:, :10, :]
+        wp2 = wp.iloc[wp.items.get_indexer(['ItemC', 'ItemB', 'ItemA']),
+                      10:, :]
 
         with ensure_clean_store(self.path) as store:
             store.put('panel', wp1, format='table')
@@ -2080,7 +2085,7 @@ class TestHDFStore(Base, tm.TestCase):
         df['timestamp2'] = Timestamp('20010103')
         df['datetime1'] = datetime.datetime(2001, 1, 2, 0, 0)
         df['datetime2'] = datetime.datetime(2001, 1, 3, 0, 0)
-        df.ix[3:6, ['obj1']] = np.nan
+        df.loc[3:6, ['obj1']] = np.nan
         df = df.consolidate()._convert(datetime=True)
 
         with ensure_clean_store(self.path) as store:
@@ -2177,7 +2182,7 @@ class TestHDFStore(Base, tm.TestCase):
         df = DataFrame(dict(A=Timestamp('20130101'), B=[Timestamp(
             '20130101') + timedelta(days=i, seconds=10) for i in range(10)]))
         df['C'] = df['A'] - df['B']
-        df.ix[3:5, 'C'] = np.nan
+        df.loc[3:5, 'C'] = np.nan
 
         with ensure_clean_store(self.path) as store:
 
@@ -2439,7 +2444,7 @@ class TestHDFStore(Base, tm.TestCase):
 
                 df = tm.makeTimeDataFrame()
                 df['string'] = 'foo'
-                df.ix[0:4, 'string'] = 'bar'
+                df.loc[0:4, 'string'] = 'bar'
                 wp = tm.makePanel()
 
                 p4d = tm.makePanel4D()
@@ -2726,7 +2731,7 @@ class TestHDFStore(Base, tm.TestCase):
     def test_sparse_series(self):
 
         s = tm.makeStringSeries()
-        s[3:5] = np.nan
+        s.iloc[3:5] = np.nan
         ss = s.to_sparse()
         self._check_roundtrip(ss, tm.assert_series_equal,
                               check_series_type=True)
@@ -2742,8 +2747,8 @@ class TestHDFStore(Base, tm.TestCase):
     def test_sparse_frame(self):
 
         s = tm.makeDataFrame()
-        s.ix[3:5, 1:3] = np.nan
-        s.ix[8:10, -2] = np.nan
+        s.iloc[3:5, 1:3] = np.nan
+        s.iloc[8:10, -2] = np.nan
         ss = s.to_sparse()
 
         self._check_double_roundtrip(ss, tm.assert_frame_equal,
@@ -3199,7 +3204,7 @@ class TestHDFStore(Base, tm.TestCase):
             # bool columns (GH #2849)
             df = DataFrame(np.random.randn(5, 2), columns=['A', 'B'])
             df['object'] = 'foo'
-            df.ix[4:5, 'object'] = 'bar'
+            df.loc[4:5, 'object'] = 'bar'
             df['boolv'] = df['A'] > 0
             _maybe_remove(store, 'df')
             store.append('df', df, data_columns=True)
@@ -3718,11 +3723,11 @@ class TestHDFStore(Base, tm.TestCase):
             crit3 = ('columns=A')
 
             result = store.select('frame', [crit1, crit2])
-            expected = df.ix[date:, ['A', 'D']]
+            expected = df.loc[date:, ['A', 'D']]
             tm.assert_frame_equal(result, expected)
 
             result = store.select('frame', [crit3])
-            expected = df.ix[:, ['A']]
+            expected = df.loc[:, ['A']]
             tm.assert_frame_equal(result, expected)
 
             # invalid terms
@@ -3881,7 +3886,7 @@ class TestHDFStore(Base, tm.TestCase):
 
             # test string ==/!=
             df['x'] = 'none'
-            df.ix[2:7, 'x'] = ''
+            df.loc[2:7, 'x'] = ''
 
             store.append('df', df, data_columns=['x'])
 
@@ -3908,7 +3913,7 @@ class TestHDFStore(Base, tm.TestCase):
 
             # int ==/!=
             df['int'] = 1
-            df.ix[2:7, 'int'] = 2
+            df.loc[2:7, 'int'] = 2
 
             store.append('df3', df, data_columns=['int'])
 
@@ -3954,7 +3959,7 @@ class TestHDFStore(Base, tm.TestCase):
             # a data column with NaNs, result excludes the NaNs
             df3 = df.copy()
             df3['string'] = 'foo'
-            df3.ix[4:6, 'string'] = np.nan
+            df3.loc[4:6, 'string'] = np.nan
             store.append('df3', df3, data_columns=['string'])
             result = store.select_column('df3', 'string')
             tm.assert_almost_equal(result.values, df3['string'].values)
@@ -4005,13 +4010,13 @@ class TestHDFStore(Base, tm.TestCase):
             c = store.select_as_coordinates('df', ['index<3'])
             assert((c.values == np.arange(3)).all())
             result = store.select('df', where=c)
-            expected = df.ix[0:2, :]
+            expected = df.loc[0:2, :]
             tm.assert_frame_equal(result, expected)
 
             c = store.select_as_coordinates('df', ['index>=3', 'index<=4'])
             assert((c.values == np.arange(2) + 3).all())
             result = store.select('df', where=c)
-            expected = df.ix[3:4, :]
+            expected = df.loc[3:4, :]
             tm.assert_frame_equal(result, expected)
             self.assertIsInstance(c, Index)
 
@@ -4113,7 +4118,7 @@ class TestHDFStore(Base, tm.TestCase):
     def test_append_to_multiple_dropna(self):
         df1 = tm.makeTimeDataFrame()
         df2 = tm.makeTimeDataFrame().rename(columns=lambda x: "%s_2" % x)
-        df1.ix[1, ['A', 'B']] = np.nan
+        df1.iloc[1, df1.columns.get_indexer(['A', 'B'])] = np.nan
         df = concat([df1, df2], axis=1)
 
         with ensure_clean_store(self.path) as store:
@@ -4226,14 +4231,14 @@ class TestHDFStore(Base, tm.TestCase):
 
             result = store.select(
                 'df', [Term("columns=['A']")], start=0, stop=5)
-            expected = df.ix[0:4, ['A']]
+            expected = df.loc[0:4, ['A']]
             tm.assert_frame_equal(result, expected)
 
             # out of range
             result = store.select(
                 'df', [Term("columns=['A']")], start=30, stop=40)
             self.assertTrue(len(result) == 0)
-            expected = df.ix[30:40, ['A']]
+            expected = df.loc[30:40, ['A']]
             tm.assert_frame_equal(result, expected)
 
     def test_start_stop_fixed(self):
@@ -4275,8 +4280,8 @@ class TestHDFStore(Base, tm.TestCase):
 
             # sparse; not implemented
             df = tm.makeDataFrame()
-            df.ix[3:5, 1:3] = np.nan
-            df.ix[8:10, -2] = np.nan
+            df.iloc[3:5, 1:3] = np.nan
+            df.iloc[8:10, -2] = np.nan
             dfs = df.to_sparse()
             store.put('dfs', dfs)
             with self.assertRaises(NotImplementedError):
@@ -4293,11 +4298,11 @@ class TestHDFStore(Base, tm.TestCase):
 
             crit = Term('columns=df.columns[:75]')
             result = store.select('frame', [crit])
-            tm.assert_frame_equal(result, df.ix[:, df.columns[:75]])
+            tm.assert_frame_equal(result, df.loc[:, df.columns[:75]])
 
             crit = Term('columns=df.columns[:75:2]')
             result = store.select('frame', [crit])
-            tm.assert_frame_equal(result, df.ix[:, df.columns[:75:2]])
+            tm.assert_frame_equal(result, df.loc[:, df.columns[:75:2]])
 
     def _check_roundtrip(self, obj, comparator, compression=False, **kwargs):
 

--- a/pandas/io/tests/test_sql.py
+++ b/pandas/io/tests/test_sql.py
@@ -2140,7 +2140,7 @@ class TestXSQLite(SQLiteMixIn, tm.TestCase):
     def test_write_row_by_row(self):
 
         frame = tm.makeTimeDataFrame()
-        frame.ix[0, 0] = np.nan
+        frame.iloc[0, 0] = np.nan
         create_sql = sql.get_schema(frame, 'test')
         cur = self.conn.cursor()
         cur.execute(create_sql)
@@ -2165,7 +2165,7 @@ class TestXSQLite(SQLiteMixIn, tm.TestCase):
         cur.execute(create_sql)
         ins = "INSERT INTO test VALUES (?, ?, ?, ?)"
 
-        row = frame.ix[0]
+        row = frame.iloc[0]
         sql.execute(ins, self.conn, params=tuple(row))
         self.conn.commit()
 
@@ -2430,7 +2430,7 @@ class TestXMySQL(MySQLMixIn, tm.TestCase):
 
         _skip_if_no_pymysql()
         frame = tm.makeTimeDataFrame()
-        frame.ix[0, 0] = np.nan
+        frame.iloc[0, 0] = np.nan
         drop_sql = "DROP TABLE IF EXISTS test"
         create_sql = sql.get_schema(frame, 'test')
         cur = self.conn.cursor()
@@ -2474,7 +2474,7 @@ class TestXMySQL(MySQLMixIn, tm.TestCase):
         cur.execute(create_sql)
         ins = "INSERT INTO test VALUES (%s, %s, %s, %s)"
 
-        row = frame.ix[0].values.tolist()
+        row = frame.iloc[0].values.tolist()
         sql.execute(ins, self.conn, params=tuple(row))
         self.conn.commit()
 

--- a/pandas/io/tests/test_stata.py
+++ b/pandas/io/tests/test_stata.py
@@ -336,7 +336,7 @@ class TestStata(tm.TestCase):
         # 9795
         np.random.seed(423)
         df = pd.DataFrame(np.random.randn(5, 4), columns=list('abcd'))
-        df.ix[2, 'a':'c'] = np.nan
+        df.loc[2, 'a':'c'] = np.nan
         df_copy = df.copy()
         with tm.ensure_clean() as path:
             df.to_stata(path, write_index=False)

--- a/pandas/sparse/tests/test_frame.py
+++ b/pandas/sparse/tests/test_frame.py
@@ -180,14 +180,14 @@ class TestSparseDataFrame(tm.TestCase, SharedWithSparse):
         x = Series(np.random.randn(10000), name='a')
         y = Series(np.random.randn(10000), name='b')
         x2 = x.astype(float)
-        x2.ix[:9998] = np.NaN
+        x2.loc[:9998] = np.NaN
         # TODO: x_sparse is unused...fix
         x_sparse = x2.to_sparse(fill_value=np.NaN)  # noqa
 
         # Currently fails too with weird ufunc error
         # df1 = SparseDataFrame([x_sparse, y])
 
-        y.ix[:9998] = 0
+        y.loc[:9998] = 0
         # TODO: y_sparse is unsused...fix
         y_sparse = y.to_sparse(fill_value=0)  # noqa
         # without sparse value raises error
@@ -232,7 +232,7 @@ class TestSparseDataFrame(tm.TestCase, SharedWithSparse):
 
     def test_dtypes(self):
         df = DataFrame(np.random.randn(10000, 4))
-        df.ix[:9998] = np.nan
+        df.loc[:9998] = np.nan
         sdf = df.to_sparse()
 
         result = sdf.get_dtype_counts()
@@ -248,7 +248,7 @@ class TestSparseDataFrame(tm.TestCase, SharedWithSparse):
 
     def test_str(self):
         df = DataFrame(np.random.randn(10000, 4))
-        df.ix[:9998] = np.nan
+        df.loc[:9998] = np.nan
 
         sdf = df.to_sparse()
         str(sdf)
@@ -364,7 +364,7 @@ class TestSparseDataFrame(tm.TestCase, SharedWithSparse):
                 _compare_to_dense(s, frame, s, frame.to_dense(), op)
 
         # it works!
-        result = self.frame + self.frame.ix[:, ['A', 'B']]  # noqa
+        result = self.frame + self.frame.loc[:, ['A', 'B']]  # noqa
 
     def test_op_corners(self):
         empty = self.empty + self.empty
@@ -427,12 +427,12 @@ class TestSparseDataFrame(tm.TestCase, SharedWithSparse):
 
     def test_fancy_index_misc(self):
         # axis = 0
-        sliced = self.frame.ix[-2:, :]
+        sliced = self.frame.iloc[-2:, :]
         expected = self.frame.reindex(index=self.frame.index[-2:])
         tm.assert_sp_frame_equal(sliced, expected)
 
         # axis = 1
-        sliced = self.frame.ix[:, -2:]
+        sliced = self.frame.iloc[:, -2:]
         expected = self.frame.reindex(columns=self.frame.columns[-2:])
         tm.assert_sp_frame_equal(sliced, expected)
 
@@ -556,10 +556,10 @@ class TestSparseDataFrame(tm.TestCase, SharedWithSparse):
         appended = a.append(b)
         tm.assert_sp_frame_equal(appended, self.frame, exact_indices=False)
 
-        a = self.frame.ix[:5, :3]
-        b = self.frame.ix[5:]
+        a = self.frame.iloc[:5, :3]
+        b = self.frame.iloc[5:]
         appended = a.append(b)
-        tm.assert_sp_frame_equal(appended.ix[:, :3], self.frame.ix[:, :3],
+        tm.assert_sp_frame_equal(appended.iloc[:, :3], self.frame.iloc[:, :3],
                                  exact_indices=False)
 
     def test_apply(self):
@@ -721,12 +721,12 @@ class TestSparseDataFrame(tm.TestCase, SharedWithSparse):
         desc = self.frame.describe()  # noqa
 
     def test_join(self):
-        left = self.frame.ix[:, ['A', 'B']]
-        right = self.frame.ix[:, ['C', 'D']]
+        left = self.frame.loc[:, ['A', 'B']]
+        right = self.frame.loc[:, ['C', 'D']]
         joined = left.join(right)
         tm.assert_sp_frame_equal(joined, self.frame, exact_indices=False)
 
-        right = self.frame.ix[:, ['B', 'D']]
+        right = self.frame.loc[:, ['B', 'D']]
         self.assertRaises(Exception, left.join, right)
 
         with tm.assertRaisesRegexp(ValueError,

--- a/pandas/sparse/tests/test_indexing.py
+++ b/pandas/sparse/tests/test_indexing.py
@@ -562,8 +562,8 @@ class TestSparseDataFrameIndexing(tm.TestCase):
         tm.assert_sp_frame_equal(sparse[[True, False, True, True]],
                                  orig[[True, False, True, True]].to_sparse())
 
-        tm.assert_sp_frame_equal(sparse[[1, 2]],
-                                 orig[[1, 2]].to_sparse())
+        tm.assert_sp_frame_equal(sparse.iloc[[1, 2]],
+                                 orig.iloc[[1, 2]].to_sparse())
 
     def test_getitem_fill_value(self):
         orig = pd.DataFrame([[1, np.nan, 0],
@@ -589,9 +589,9 @@ class TestSparseDataFrameIndexing(tm.TestCase):
         exp._default_fill_value = np.nan
         tm.assert_sp_frame_equal(sparse[indexer], exp)
 
-        exp = orig[[1, 2]].to_sparse(fill_value=0)
+        exp = orig.iloc[[1, 2]].to_sparse(fill_value=0)
         exp._default_fill_value = np.nan
-        tm.assert_sp_frame_equal(sparse[[1, 2]], exp)
+        tm.assert_sp_frame_equal(sparse.iloc[[1, 2]], exp)
 
     def test_loc(self):
         orig = pd.DataFrame([[1, np.nan, np.nan],

--- a/pandas/sparse/tests/test_series.py
+++ b/pandas/sparse/tests/test_series.py
@@ -295,8 +295,8 @@ class TestSparseSeries(tm.TestCase, SharedWithSparse):
         data = 5
         sp = SparseSeries(data, np.arange(100))
         sp = sp.reindex(np.arange(200))
-        self.assertTrue((sp.ix[:99] == data).all())
-        self.assertTrue(isnull(sp.ix[100:]).all())
+        self.assertTrue((sp.loc[:99] == data).all())
+        self.assertTrue(isnull(sp.loc[100:]).all())
 
         data = np.nan
         sp = SparseSeries(data, np.arange(100))

--- a/pandas/stats/tests/test_ols.py
+++ b/pandas/stats/tests/test_ols.py
@@ -111,7 +111,7 @@ class TestOLS(BaseTest):
 
         self._check_wls(X, Y, weights)
 
-        weights.ix[[5, 15]] = np.nan
+        weights.loc[[5, 15]] = np.nan
         Y[[2, 21]] = np.nan
         self._check_wls(X, Y, weights)
 
@@ -421,8 +421,8 @@ class TestOLSMisc(tm.TestCase):
         model._results
 
     def test_catch_regressor_overlap(self):
-        df1 = tm.makeTimeDataFrame().ix[:, ['A', 'B']]
-        df2 = tm.makeTimeDataFrame().ix[:, ['B', 'C', 'D']]
+        df1 = tm.makeTimeDataFrame().loc[:, ['A', 'B']]
+        df2 = tm.makeTimeDataFrame().loc[:, ['B', 'C', 'D']]
         y = tm.makeTimeSeries()
 
         data = {'foo': df1, 'bar': df2}
@@ -562,10 +562,10 @@ class TestPanelOLS(BaseTest):
         x = Panel({'x1': tm.makeTimeDataFrame(),
                    'x2': tm.makeTimeDataFrame()})
 
-        y.ix[[1, 7], 'A'] = np.nan
-        y.ix[[6, 15], 'B'] = np.nan
-        y.ix[[3, 20], 'C'] = np.nan
-        y.ix[[5, 11], 'D'] = np.nan
+        y.iloc[[1, 7], y.columns.get_loc('A')] = np.nan
+        y.iloc[[6, 15], y.columns.get_loc('B')] = np.nan
+        y.iloc[[3, 20], y.columns.get_loc('C')] = np.nan
+        y.iloc[[5, 11], y.columns.get_loc('D')] = np.nan
 
         stack_y = y.stack()
         stack_x = DataFrame(dict((k, v.stack())
@@ -615,7 +615,7 @@ class TestPanelOLS(BaseTest):
                           index=result._x.index, columns=['FE_B', 'x1', 'x2',
                                                           'intercept'],
                           dtype=float)
-        tm.assert_frame_equal(result._x, exp_x.ix[:, result._x.columns])
+        tm.assert_frame_equal(result._x, exp_x.loc[:, result._x.columns])
         # _check_non_raw_results(result)
 
     def testWithEntityEffectsAndDroppedDummies(self):
@@ -630,7 +630,7 @@ class TestPanelOLS(BaseTest):
                           index=result._x.index, columns=['FE_A', 'x1', 'x2',
                                                           'intercept'],
                           dtype=float)
-        tm.assert_frame_equal(result._x, exp_x.ix[:, result._x.columns])
+        tm.assert_frame_equal(result._x, exp_x.loc[:, result._x.columns])
         # _check_non_raw_results(result)
 
     def testWithXEffects(self):

--- a/pandas/tests/formats/test_format.py
+++ b/pandas/tests/formats/test_format.py
@@ -136,7 +136,7 @@ class TestDataFrameFormatting(tm.TestCase):
         df.to_string()
 
     def test_eng_float_formatter(self):
-        self.frame.ix[5] = 0
+        self.frame.loc[5] = 0
 
         fmt.set_eng_float_format()
         repr(self.frame)
@@ -1884,7 +1884,7 @@ class TestDataFrameFormatting(tm.TestCase):
 
         # all-nan in mi
         df2 = df.copy()
-        df2.ix[:, 'id2'] = np.nan
+        df2.loc[:, 'id2'] = np.nan
         y = df2.set_index('id2')
         result = y.to_string()
         expected = u(
@@ -1893,7 +1893,7 @@ class TestDataFrameFormatting(tm.TestCase):
 
         # partial nan in mi
         df2 = df.copy()
-        df2.ix[:, 'id2'] = np.nan
+        df2.loc[:, 'id2'] = np.nan
         y = df2.set_index(['id2', 'id3'])
         result = y.to_string()
         expected = u(
@@ -3715,7 +3715,7 @@ class TestSeriesFormatting(tm.TestCase):
         df = DataFrame({'A': [1, 2], 'B': ['2012-01-01', '2012-01-02']})
         df['B'] = pd.to_datetime(df.B)
 
-        result = repr(df.ix[0])
+        result = repr(df.loc[0])
         self.assertTrue('2012-01-01' in result)
 
     def test_period(self):

--- a/pandas/tests/frame/test_alter_axes.py
+++ b/pandas/tests/frame/test_alter_axes.py
@@ -39,10 +39,10 @@ class TestDataFrameAlterAxes(tm.TestCase, TestData):
         # issue casting an index then set_index
         df = DataFrame({'A': [1.1, 2.2, 3.3], 'B': [5.0, 6.1, 7.2]},
                        index=[2010, 2011, 2012])
-        expected = df.ix[2010]
+        expected = df.loc[2010]
         new_index = df.index.astype(np.int32)
         df.index = new_index
-        result = df.ix[2010]
+        result = df.loc[2010]
         assert_series_equal(result, expected)
 
     def test_set_index2(self):
@@ -58,7 +58,7 @@ class TestDataFrameAlterAxes(tm.TestCase, TestData):
 
         index = Index(df['C'], name='C')
 
-        expected = df.ix[:, ['A', 'B', 'D', 'E']]
+        expected = df.loc[:, ['A', 'B', 'D', 'E']]
         expected.index = index
 
         expected_nodrop = df.copy()
@@ -86,7 +86,7 @@ class TestDataFrameAlterAxes(tm.TestCase, TestData):
 
         index = MultiIndex.from_arrays([df['A'], df['B']], names=['A', 'B'])
 
-        expected = df.ix[:, ['C', 'D', 'E']]
+        expected = df.loc[:, ['C', 'D', 'E']]
         expected.index = index
 
         expected_nodrop = df.copy()
@@ -301,8 +301,8 @@ class TestDataFrameAlterAxes(tm.TestCase, TestData):
         columns = MultiIndex.from_tuples([('foo', 1), ('foo', 2), ('bar', 1)])
         df = DataFrame(np.random.randn(3, 3), columns=columns)
         rs = df.set_index(df.columns[0])
-        xp = df.ix[:, 1:]
-        xp.index = df.ix[:, 0].values
+        xp = df.iloc[:, 1:]
+        xp.index = df.iloc[:, 0].values
         xp.index.names = [df.columns[0]]
         assert_frame_equal(rs, xp)
 

--- a/pandas/tests/frame/test_analytics.py
+++ b/pandas/tests/frame/test_analytics.py
@@ -58,7 +58,7 @@ class TestDataFrameAnalytics(tm.TestCase, TestData):
         else:
             result = self.frame.corr(min_periods=len(self.frame) - 8)
             expected = self.frame.corr()
-            expected.ix['A', 'B'] = expected.ix['B', 'A'] = nan
+            expected.loc['A', 'B'] = expected.loc['B', 'A'] = nan
             tm.assert_frame_equal(result, expected)
 
     def test_corr_non_numeric(self):
@@ -68,7 +68,7 @@ class TestDataFrameAnalytics(tm.TestCase, TestData):
 
         # exclude non-numeric types
         result = self.mixed_frame.corr()
-        expected = self.mixed_frame.ix[:, ['A', 'B', 'C', 'D']].corr()
+        expected = self.mixed_frame.loc[:, ['A', 'B', 'C', 'D']].corr()
         tm.assert_frame_equal(result, expected)
 
     def test_corr_nooverlap(self):
@@ -81,11 +81,11 @@ class TestDataFrameAnalytics(tm.TestCase, TestData):
                             'C': [np.nan, np.nan, np.nan, np.nan,
                                   np.nan, np.nan]})
             rs = df.corr(meth)
-            self.assertTrue(isnull(rs.ix['A', 'B']))
-            self.assertTrue(isnull(rs.ix['B', 'A']))
-            self.assertEqual(rs.ix['A', 'A'], 1)
-            self.assertEqual(rs.ix['B', 'B'], 1)
-            self.assertTrue(isnull(rs.ix['C', 'C']))
+            self.assertTrue(isnull(rs.loc['A', 'B']))
+            self.assertTrue(isnull(rs.loc['B', 'A']))
+            self.assertEqual(rs.loc['A', 'A'], 1)
+            self.assertEqual(rs.loc['B', 'B'], 1)
+            self.assertTrue(isnull(rs.loc['C', 'C']))
 
     def test_corr_constant(self):
         tm._skip_if_no_scipy()
@@ -135,8 +135,8 @@ class TestDataFrameAnalytics(tm.TestCase, TestData):
         frame['B'][5:10] = nan
         result = self.frame.cov(min_periods=len(self.frame) - 8)
         expected = self.frame.cov()
-        expected.ix['A', 'B'] = np.nan
-        expected.ix['B', 'A'] = np.nan
+        expected.loc['A', 'B'] = np.nan
+        expected.loc['B', 'A'] = np.nan
 
         # regular
         self.frame['A'][:5] = nan
@@ -148,7 +148,7 @@ class TestDataFrameAnalytics(tm.TestCase, TestData):
 
         # exclude non-numeric types
         result = self.mixed_frame.cov()
-        expected = self.mixed_frame.ix[:, ['A', 'B', 'C', 'D']].cov()
+        expected = self.mixed_frame.loc[:, ['A', 'B', 'C', 'D']].cov()
         tm.assert_frame_equal(result, expected)
 
         # Single column frame
@@ -157,7 +157,7 @@ class TestDataFrameAnalytics(tm.TestCase, TestData):
         expected = DataFrame(np.cov(df.values.T).reshape((1, 1)),
                              index=df.columns, columns=df.columns)
         tm.assert_frame_equal(result, expected)
-        df.ix[0] = np.nan
+        df.loc[0] = np.nan
         result = df.cov()
         expected = DataFrame(np.cov(df.values[1:].T).reshape((1, 1)),
                              index=df.columns, columns=df.columns)
@@ -193,7 +193,8 @@ class TestDataFrameAnalytics(tm.TestCase, TestData):
         df2 = DataFrame(randn(4, 4), index=index[:4], columns=columns)
         correls = df1.corrwith(df2, axis=1)
         for row in index[:4]:
-            tm.assert_almost_equal(correls[row], df1.ix[row].corr(df2.ix[row]))
+            tm.assert_almost_equal(correls[row],
+                                   df1.loc[row].corr(df2.loc[row]))
 
     def test_corrwith_with_objects(self):
         df1 = tm.makeTimeDataFrame()
@@ -204,11 +205,11 @@ class TestDataFrameAnalytics(tm.TestCase, TestData):
         df2['obj'] = 'bar'
 
         result = df1.corrwith(df2)
-        expected = df1.ix[:, cols].corrwith(df2.ix[:, cols])
+        expected = df1.loc[:, cols].corrwith(df2.loc[:, cols])
         tm.assert_series_equal(result, expected)
 
         result = df1.corrwith(df2, axis=1)
-        expected = df1.ix[:, cols].corrwith(df2.ix[:, cols], axis=1)
+        expected = df1.loc[:, cols].corrwith(df2.loc[:, cols], axis=1)
         tm.assert_series_equal(result, expected)
 
     def test_corrwith_series(self):
@@ -463,9 +464,9 @@ class TestDataFrameAnalytics(tm.TestCase, TestData):
         self._check_stat_op('min', np.min, frame=self.intframe)
 
     def test_cummin(self):
-        self.tsframe.ix[5:10, 0] = nan
-        self.tsframe.ix[10:15, 1] = nan
-        self.tsframe.ix[15:, 2] = nan
+        self.tsframe.loc[5:10, 0] = nan
+        self.tsframe.loc[10:15, 1] = nan
+        self.tsframe.loc[15:, 2] = nan
 
         # axis = 0
         cummin = self.tsframe.cummin()
@@ -486,9 +487,9 @@ class TestDataFrameAnalytics(tm.TestCase, TestData):
         self.assertEqual(np.shape(cummin_xs), np.shape(self.tsframe))
 
     def test_cummax(self):
-        self.tsframe.ix[5:10, 0] = nan
-        self.tsframe.ix[10:15, 1] = nan
-        self.tsframe.ix[15:, 2] = nan
+        self.tsframe.loc[5:10, 0] = nan
+        self.tsframe.loc[10:15, 1] = nan
+        self.tsframe.loc[15:, 2] = nan
 
         # axis = 0
         cummax = self.tsframe.cummax()
@@ -545,11 +546,11 @@ class TestDataFrameAnalytics(tm.TestCase, TestData):
         methods = ['sem', 'var', 'std']
         df1 = DataFrame(np.random.randn(5, 3), columns=['foo', 'bar', 'baz'])
         # set one entry to a number in str format
-        df1.ix[0, 'foo'] = '100'
+        df1.loc[0, 'foo'] = '100'
 
         df2 = DataFrame(np.random.randn(5, 3), columns=['foo', 'bar', 'baz'])
         # set one entry to a non-number str
-        df2.ix[0, 'foo'] = 'a'
+        df2.loc[0, 'foo'] = 'a'
 
         for meth in methods:
             result = getattr(df1, meth)(axis=1, numeric_only=True)
@@ -567,9 +568,9 @@ class TestDataFrameAnalytics(tm.TestCase, TestData):
                               (axis=1, numeric_only=False))
 
     def test_cumsum(self):
-        self.tsframe.ix[5:10, 0] = nan
-        self.tsframe.ix[10:15, 1] = nan
-        self.tsframe.ix[15:, 2] = nan
+        self.tsframe.loc[5:10, 0] = nan
+        self.tsframe.loc[10:15, 1] = nan
+        self.tsframe.loc[15:, 2] = nan
 
         # axis = 0
         cumsum = self.tsframe.cumsum()
@@ -590,9 +591,9 @@ class TestDataFrameAnalytics(tm.TestCase, TestData):
         self.assertEqual(np.shape(cumsum_xs), np.shape(self.tsframe))
 
     def test_cumprod(self):
-        self.tsframe.ix[5:10, 0] = nan
-        self.tsframe.ix[10:15, 1] = nan
-        self.tsframe.ix[15:, 2] = nan
+        self.tsframe.loc[5:10, 0] = nan
+        self.tsframe.loc[10:15, 1] = nan
+        self.tsframe.loc[15:, 2] = nan
 
         # axis = 0
         cumprod = self.tsframe.cumprod()
@@ -864,8 +865,8 @@ class TestDataFrameAnalytics(tm.TestCase, TestData):
         if frame is None:
             frame = self.frame
             # set some NAs
-            frame.ix[5:10] = np.nan
-            frame.ix[15:20, -2:] = np.nan
+            frame.loc[5:10] = np.nan
+            frame.loc[15:20, -2:] = np.nan
 
         f = getattr(frame, name)
 
@@ -1008,16 +1009,16 @@ class TestDataFrameAnalytics(tm.TestCase, TestData):
 
         # min
         result = diffs.min()
-        self.assertEqual(result[0], diffs.ix[0, 'A'])
-        self.assertEqual(result[1], diffs.ix[0, 'B'])
+        self.assertEqual(result[0], diffs.loc[0, 'A'])
+        self.assertEqual(result[1], diffs.loc[0, 'B'])
 
         result = diffs.min(axis=1)
-        self.assertTrue((result == diffs.ix[0, 'B']).all())
+        self.assertTrue((result == diffs.loc[0, 'B']).all())
 
         # max
         result = diffs.max()
-        self.assertEqual(result[0], diffs.ix[2, 'A'])
-        self.assertEqual(result[1], diffs.ix[2, 'B'])
+        self.assertEqual(result[0], diffs.loc[2, 'A'])
+        self.assertEqual(result[1], diffs.loc[2, 'B'])
 
         result = diffs.max(axis=1)
         self.assertTrue((result == diffs['A']).all())
@@ -1153,8 +1154,8 @@ class TestDataFrameAnalytics(tm.TestCase, TestData):
 
     def test_idxmin(self):
         frame = self.frame
-        frame.ix[5:10] = np.nan
-        frame.ix[15:20, -2:] = np.nan
+        frame.loc[5:10] = np.nan
+        frame.loc[15:20, -2:] = np.nan
         for skipna in [True, False]:
             for axis in [0, 1]:
                 for df in [frame, self.intframe]:
@@ -1167,8 +1168,8 @@ class TestDataFrameAnalytics(tm.TestCase, TestData):
 
     def test_idxmax(self):
         frame = self.frame
-        frame.ix[5:10] = np.nan
-        frame.ix[15:20, -2:] = np.nan
+        frame.loc[5:10] = np.nan
+        frame.loc[15:20, -2:] = np.nan
         for skipna in [True, False]:
             for axis in [0, 1]:
                 for df in [frame, self.intframe]:
@@ -1219,8 +1220,8 @@ class TestDataFrameAnalytics(tm.TestCase, TestData):
             # set some NAs
             frame = DataFrame(frame.values.astype(object), frame.index,
                               frame.columns)
-            frame.ix[5:10] = np.nan
-            frame.ix[15:20, -2:] = np.nan
+            frame.loc[5:10] = np.nan
+            frame.loc[15:20, -2:] = np.nan
 
         f = getattr(frame, name)
 
@@ -1495,43 +1496,43 @@ class TestDataFrameAnalytics(tm.TestCase, TestData):
         tm.assert_frame_equal(result, expected)
 
         result = df.drop_duplicates('AAA', keep='last')
-        expected = df.ix[[6, 7]]
+        expected = df.loc[[6, 7]]
         tm.assert_frame_equal(result, expected)
 
         result = df.drop_duplicates('AAA', keep=False)
-        expected = df.ix[[]]
+        expected = df.loc[[]]
         tm.assert_frame_equal(result, expected)
         self.assertEqual(len(result), 0)
 
         # deprecate take_last
         with tm.assert_produces_warning(FutureWarning):
             result = df.drop_duplicates('AAA', take_last=True)
-            expected = df.ix[[6, 7]]
+            expected = df.loc[[6, 7]]
             tm.assert_frame_equal(result, expected)
 
         # multi column
-        expected = df.ix[[0, 1, 2, 3]]
+        expected = df.loc[[0, 1, 2, 3]]
         result = df.drop_duplicates(np.array(['AAA', 'B']))
         tm.assert_frame_equal(result, expected)
         result = df.drop_duplicates(['AAA', 'B'])
         tm.assert_frame_equal(result, expected)
 
         result = df.drop_duplicates(('AAA', 'B'), keep='last')
-        expected = df.ix[[0, 5, 6, 7]]
+        expected = df.loc[[0, 5, 6, 7]]
         tm.assert_frame_equal(result, expected)
 
         result = df.drop_duplicates(('AAA', 'B'), keep=False)
-        expected = df.ix[[0]]
+        expected = df.loc[[0]]
         tm.assert_frame_equal(result, expected)
 
         # deprecate take_last
         with tm.assert_produces_warning(FutureWarning):
             result = df.drop_duplicates(('AAA', 'B'), take_last=True)
-        expected = df.ix[[0, 5, 6, 7]]
+        expected = df.loc[[0, 5, 6, 7]]
         tm.assert_frame_equal(result, expected)
 
         # consider everything
-        df2 = df.ix[:, ['AAA', 'B', 'C']]
+        df2 = df.loc[:, ['AAA', 'B', 'C']]
 
         result = df2.drop_duplicates()
         # in this case only
@@ -1643,22 +1644,22 @@ class TestDataFrameAnalytics(tm.TestCase, TestData):
         tm.assert_frame_equal(result, expected)
 
         result = df.drop_duplicates(('AA', 'AB'), keep='last')
-        expected = df.ix[[6, 7]]
+        expected = df.loc[[6, 7]]
         tm.assert_frame_equal(result, expected)
 
         result = df.drop_duplicates(('AA', 'AB'), keep=False)
-        expected = df.ix[[]]  # empty df
+        expected = df.loc[[]]  # empty df
         self.assertEqual(len(result), 0)
         tm.assert_frame_equal(result, expected)
 
         # deprecate take_last
         with tm.assert_produces_warning(FutureWarning):
             result = df.drop_duplicates(('AA', 'AB'), take_last=True)
-        expected = df.ix[[6, 7]]
+        expected = df.loc[[6, 7]]
         tm.assert_frame_equal(result, expected)
 
         # multi column
-        expected = df.ix[[0, 1, 2, 3]]
+        expected = df.loc[[0, 1, 2, 3]]
         result = df.drop_duplicates((('AA', 'AB'), 'B'))
         tm.assert_frame_equal(result, expected)
 
@@ -1673,41 +1674,41 @@ class TestDataFrameAnalytics(tm.TestCase, TestData):
 
         # single column
         result = df.drop_duplicates('A')
-        expected = df.ix[[0, 2, 3]]
+        expected = df.loc[[0, 2, 3]]
         tm.assert_frame_equal(result, expected)
 
         result = df.drop_duplicates('A', keep='last')
-        expected = df.ix[[1, 6, 7]]
+        expected = df.loc[[1, 6, 7]]
         tm.assert_frame_equal(result, expected)
 
         result = df.drop_duplicates('A', keep=False)
-        expected = df.ix[[]]  # empty df
+        expected = df.loc[[]]  # empty df
         tm.assert_frame_equal(result, expected)
         self.assertEqual(len(result), 0)
 
         # deprecate take_last
         with tm.assert_produces_warning(FutureWarning):
             result = df.drop_duplicates('A', take_last=True)
-        expected = df.ix[[1, 6, 7]]
+        expected = df.loc[[1, 6, 7]]
         tm.assert_frame_equal(result, expected)
 
         # multi column
         result = df.drop_duplicates(['A', 'B'])
-        expected = df.ix[[0, 2, 3, 6]]
+        expected = df.loc[[0, 2, 3, 6]]
         tm.assert_frame_equal(result, expected)
 
         result = df.drop_duplicates(['A', 'B'], keep='last')
-        expected = df.ix[[1, 5, 6, 7]]
+        expected = df.loc[[1, 5, 6, 7]]
         tm.assert_frame_equal(result, expected)
 
         result = df.drop_duplicates(['A', 'B'], keep=False)
-        expected = df.ix[[6]]
+        expected = df.loc[[6]]
         tm.assert_frame_equal(result, expected)
 
         # deprecate take_last
         with tm.assert_produces_warning(FutureWarning):
             result = df.drop_duplicates(['A', 'B'], take_last=True)
-        expected = df.ix[[1, 5, 6, 7]]
+        expected = df.loc[[1, 5, 6, 7]]
         tm.assert_frame_equal(result, expected)
 
         # nan
@@ -1724,37 +1725,37 @@ class TestDataFrameAnalytics(tm.TestCase, TestData):
         tm.assert_frame_equal(result, expected)
 
         result = df.drop_duplicates('C', keep='last')
-        expected = df.ix[[3, 7]]
+        expected = df.loc[[3, 7]]
         tm.assert_frame_equal(result, expected)
 
         result = df.drop_duplicates('C', keep=False)
-        expected = df.ix[[]]  # empty df
+        expected = df.loc[[]]  # empty df
         tm.assert_frame_equal(result, expected)
         self.assertEqual(len(result), 0)
 
         # deprecate take_last
         with tm.assert_produces_warning(FutureWarning):
             result = df.drop_duplicates('C', take_last=True)
-        expected = df.ix[[3, 7]]
+        expected = df.loc[[3, 7]]
         tm.assert_frame_equal(result, expected)
 
         # multi column
         result = df.drop_duplicates(['C', 'B'])
-        expected = df.ix[[0, 1, 2, 4]]
+        expected = df.loc[[0, 1, 2, 4]]
         tm.assert_frame_equal(result, expected)
 
         result = df.drop_duplicates(['C', 'B'], keep='last')
-        expected = df.ix[[1, 3, 6, 7]]
+        expected = df.loc[[1, 3, 6, 7]]
         tm.assert_frame_equal(result, expected)
 
         result = df.drop_duplicates(['C', 'B'], keep=False)
-        expected = df.ix[[1]]
+        expected = df.loc[[1]]
         tm.assert_frame_equal(result, expected)
 
         # deprecate take_last
         with tm.assert_produces_warning(FutureWarning):
             result = df.drop_duplicates(['C', 'B'], take_last=True)
-        expected = df.ix[[1, 3, 6, 7]]
+        expected = df.loc[[1, 3, 6, 7]]
         tm.assert_frame_equal(result, expected)
 
     def test_drop_duplicates_NA_for_take_all(self):
@@ -1808,13 +1809,13 @@ class TestDataFrameAnalytics(tm.TestCase, TestData):
 
         df = orig.copy()
         df.drop_duplicates('A', keep='last', inplace=True)
-        expected = orig.ix[[6, 7]]
+        expected = orig.loc[[6, 7]]
         result = df
         tm.assert_frame_equal(result, expected)
 
         df = orig.copy()
         df.drop_duplicates('A', keep=False, inplace=True)
-        expected = orig.ix[[]]
+        expected = orig.loc[[]]
         result = df
         tm.assert_frame_equal(result, expected)
         self.assertEqual(len(df), 0)
@@ -1823,26 +1824,26 @@ class TestDataFrameAnalytics(tm.TestCase, TestData):
         df = orig.copy()
         with tm.assert_produces_warning(FutureWarning):
             df.drop_duplicates('A', take_last=True, inplace=True)
-        expected = orig.ix[[6, 7]]
+        expected = orig.loc[[6, 7]]
         result = df
         tm.assert_frame_equal(result, expected)
 
         # multi column
         df = orig.copy()
         df.drop_duplicates(['A', 'B'], inplace=True)
-        expected = orig.ix[[0, 1, 2, 3]]
+        expected = orig.loc[[0, 1, 2, 3]]
         result = df
         tm.assert_frame_equal(result, expected)
 
         df = orig.copy()
         df.drop_duplicates(['A', 'B'], keep='last', inplace=True)
-        expected = orig.ix[[0, 5, 6, 7]]
+        expected = orig.loc[[0, 5, 6, 7]]
         result = df
         tm.assert_frame_equal(result, expected)
 
         df = orig.copy()
         df.drop_duplicates(['A', 'B'], keep=False, inplace=True)
-        expected = orig.ix[[0]]
+        expected = orig.loc[[0]]
         result = df
         tm.assert_frame_equal(result, expected)
 
@@ -1850,12 +1851,12 @@ class TestDataFrameAnalytics(tm.TestCase, TestData):
         df = orig.copy()
         with tm.assert_produces_warning(FutureWarning):
             df.drop_duplicates(['A', 'B'], take_last=True, inplace=True)
-        expected = orig.ix[[0, 5, 6, 7]]
+        expected = orig.loc[[0, 5, 6, 7]]
         result = df
         tm.assert_frame_equal(result, expected)
 
         # consider everything
-        orig2 = orig.ix[:, ['A', 'B', 'C']].copy()
+        orig2 = orig.loc[:, ['A', 'B', 'C']].copy()
 
         df2 = orig2.copy()
         df2.drop_duplicates(inplace=True)
@@ -2160,10 +2161,10 @@ class TestDataFrameAnalytics(tm.TestCase, TestData):
         self.assertTrue(result.name is None)
 
         # can pass correct-length arrays
-        row = a.ix[0].values
+        row = a.iloc[0].values
 
         result = a.dot(row)
-        exp = a.dot(a.ix[0])
+        exp = a.dot(a.iloc[0])
         tm.assert_series_equal(result, exp)
 
         with tm.assertRaisesRegexp(ValueError, 'Dot product shape mismatch'):

--- a/pandas/tests/frame/test_apply.py
+++ b/pandas/tests/frame/test_apply.py
@@ -70,7 +70,7 @@ class TestDataFrameApply(tm.TestCase, TestData):
         expected = Series(np.nan, index=self.frame.columns)
         assert_series_equal(result, expected)
 
-        no_cols = self.frame.ix[:, []]
+        no_cols = self.frame.loc[:, []]
         result = no_cols.apply(lambda x: x.mean(), axis=1)
         expected = Series(np.nan, index=self.frame.index)
         assert_series_equal(result, expected)
@@ -224,7 +224,7 @@ class TestDataFrameApply(tm.TestCase, TestData):
         assert_frame_equal(result, self.frame)
 
     def test_apply_reduce_Series(self):
-        self.frame.ix[::2, 'A'] = np.nan
+        self.frame.loc[::2, 'A'] = np.nan
         expected = self.frame.mean(1)
         result = self.frame.apply(np.mean, axis=1)
         assert_series_equal(result, expected)

--- a/pandas/tests/frame/test_asof.py
+++ b/pandas/tests/frame/test_asof.py
@@ -23,7 +23,7 @@ class TestFrameAsof(TestData, tm.TestCase):
     def test_basic(self):
 
         df = self.df.copy()
-        df.ix[15:30, 'A'] = np.nan
+        df.loc[15:30, 'A'] = np.nan
         dates = date_range('1/1/1990', periods=self.N * 3,
                            freq='25s')
 
@@ -46,7 +46,7 @@ class TestFrameAsof(TestData, tm.TestCase):
         rng = date_range('1/1/1990', periods=N, freq='53s')
         df = DataFrame({'A': np.arange(N), 'B': np.arange(N)},
                        index=rng)
-        df.ix[4:8, 'A'] = np.nan
+        df.loc[4:8, 'A'] = np.nan
         dates = date_range('1/1/1990', periods=N * 3,
                            freq='25s')
 

--- a/pandas/tests/frame/test_axis_select_reindex.py
+++ b/pandas/tests/frame/test_axis_select_reindex.py
@@ -80,9 +80,9 @@ class TestDataFrameSelectReindex(tm.TestCase, TestData):
         assert_frame_equal(simple.drop("A", axis=1), simple[['B']])
         assert_frame_equal(simple.drop(["A", "B"], axis='columns'),
                            simple[[]])
-        assert_frame_equal(simple.drop([0, 1, 3], axis=0), simple.ix[[2], :])
+        assert_frame_equal(simple.drop([0, 1, 3], axis=0), simple.loc[[2], :])
         assert_frame_equal(simple.drop(
-            [0, 3], axis='index'), simple.ix[[1, 2], :])
+            [0, 3], axis='index'), simple.loc[[1, 2], :])
 
         self.assertRaises(ValueError, simple.drop, 5)
         self.assertRaises(ValueError, simple.drop, 'C', 1)
@@ -92,7 +92,7 @@ class TestDataFrameSelectReindex(tm.TestCase, TestData):
         # errors = 'ignore'
         assert_frame_equal(simple.drop(5, errors='ignore'), simple)
         assert_frame_equal(simple.drop([0, 5], errors='ignore'),
-                           simple.ix[[1, 2, 3], :])
+                           simple.loc[[1, 2, 3], :])
         assert_frame_equal(simple.drop('C', axis=1, errors='ignore'), simple)
         assert_frame_equal(simple.drop(['A', 'C'], axis=1, errors='ignore'),
                            simple[['B']])
@@ -105,8 +105,8 @@ class TestDataFrameSelectReindex(tm.TestCase, TestData):
 
         nu_df = nu_df.set_index(pd.Index(['X', 'Y', 'X']))
         nu_df.columns = list('abc')
-        assert_frame_equal(nu_df.drop('X', axis='rows'), nu_df.ix[["Y"], :])
-        assert_frame_equal(nu_df.drop(['X', 'Y'], axis=0), nu_df.ix[[], :])
+        assert_frame_equal(nu_df.drop('X', axis='rows'), nu_df.loc[["Y"], :])
+        assert_frame_equal(nu_df.drop(['X', 'Y'], axis=0), nu_df.loc[[], :])
 
         # inplace cache issue
         # GH 5628
@@ -417,7 +417,7 @@ class TestDataFrameSelectReindex(tm.TestCase, TestData):
         self.assertIs(af._data, self.frame._data)
 
         # axis = 0
-        other = self.frame.ix[:-5, :3]
+        other = self.frame.iloc[:-5, :3]
         af, bf = self.frame.align(other, axis=0, fill_value=-1)
         self.assert_index_equal(bf.columns, other.columns)
         # test fill value
@@ -434,7 +434,7 @@ class TestDataFrameSelectReindex(tm.TestCase, TestData):
         self.assert_index_equal(af.index, other.index)
 
         # axis = 1
-        other = self.frame.ix[:-5, :3].copy()
+        other = self.frame.iloc[:-5, :3].copy()
         af, bf = self.frame.align(other, axis=1)
         self.assert_index_equal(bf.columns, self.frame.columns)
         self.assert_index_equal(bf.index, other.index)
@@ -464,25 +464,25 @@ class TestDataFrameSelectReindex(tm.TestCase, TestData):
                                         join='inner', axis=1, method='pad')
         self.assert_index_equal(bf.columns, self.mixed_frame.columns)
 
-        af, bf = self.frame.align(other.ix[:, 0], join='inner', axis=1,
+        af, bf = self.frame.align(other.iloc[:, 0], join='inner', axis=1,
                                   method=None, fill_value=None)
         self.assert_index_equal(bf.index, Index([]))
 
-        af, bf = self.frame.align(other.ix[:, 0], join='inner', axis=1,
+        af, bf = self.frame.align(other.iloc[:, 0], join='inner', axis=1,
                                   method=None, fill_value=0)
         self.assert_index_equal(bf.index, Index([]))
 
         # mixed floats/ints
-        af, bf = self.mixed_float.align(other.ix[:, 0], join='inner', axis=1,
+        af, bf = self.mixed_float.align(other.iloc[:, 0], join='inner', axis=1,
                                         method=None, fill_value=0)
         self.assert_index_equal(bf.index, Index([]))
 
-        af, bf = self.mixed_int.align(other.ix[:, 0], join='inner', axis=1,
+        af, bf = self.mixed_int.align(other.iloc[:, 0], join='inner', axis=1,
                                       method=None, fill_value=0)
         self.assert_index_equal(bf.index, Index([]))
 
         # try to align dataframe to series along bad axis
-        self.assertRaises(ValueError, self.frame.align, af.ix[0, :3],
+        self.assertRaises(ValueError, self.frame.align, af.iloc[0, :3],
                           join='inner', axis=2)
 
         # align dataframe to series with broadcast or not
@@ -561,9 +561,9 @@ class TestDataFrameSelectReindex(tm.TestCase, TestData):
                     self._check_align_fill('right', meth, ax, fax)
 
     def _check_align_fill(self, kind, meth, ax, fax):
-        left = self.frame.ix[0:4, :10]
-        right = self.frame.ix[2:, 6:]
-        empty = self.frame.ix[:0, :0]
+        left = self.frame.iloc[0:4, :10]
+        right = self.frame.iloc[2:, 6:]
+        empty = self.frame.iloc[:0, :0]
 
         self._check_align(left, right, axis=ax, fill_axis=fax,
                           how=kind, method=meth)
@@ -779,7 +779,7 @@ class TestDataFrameSelectReindex(tm.TestCase, TestData):
 
             # axis = 1
             result = df.take(order, axis=1)
-            expected = df.ix[:, ['D', 'B', 'C', 'A']]
+            expected = df.loc[:, ['D', 'B', 'C', 'A']]
             assert_frame_equal(result, expected, check_names=False)
 
         # neg indicies
@@ -792,7 +792,7 @@ class TestDataFrameSelectReindex(tm.TestCase, TestData):
 
             # axis = 1
             result = df.take(order, axis=1)
-            expected = df.ix[:, ['C', 'B', 'D']]
+            expected = df.loc[:, ['C', 'B', 'D']]
             assert_frame_equal(result, expected, check_names=False)
 
         # illegal indices
@@ -811,7 +811,7 @@ class TestDataFrameSelectReindex(tm.TestCase, TestData):
 
             # axis = 1
             result = df.take(order, axis=1)
-            expected = df.ix[:, ['foo', 'B', 'C', 'A', 'D']]
+            expected = df.loc[:, ['foo', 'B', 'C', 'A', 'D']]
             assert_frame_equal(result, expected)
 
         # neg indicies
@@ -824,7 +824,7 @@ class TestDataFrameSelectReindex(tm.TestCase, TestData):
 
             # axis = 1
             result = df.take(order, axis=1)
-            expected = df.ix[:, ['foo', 'B', 'D']]
+            expected = df.loc[:, ['foo', 'B', 'D']]
             assert_frame_equal(result, expected)
 
         # by dtype
@@ -837,7 +837,7 @@ class TestDataFrameSelectReindex(tm.TestCase, TestData):
 
             # axis = 1
             result = df.take(order, axis=1)
-            expected = df.ix[:, ['B', 'C', 'A', 'D']]
+            expected = df.loc[:, ['B', 'C', 'A', 'D']]
             assert_frame_equal(result, expected)
 
     def test_reindex_boolean(self):

--- a/pandas/tests/frame/test_block_internals.py
+++ b/pandas/tests/frame/test_block_internals.py
@@ -318,7 +318,7 @@ class TestDataFrameBlockInternals(tm.TestCase, TestData):
         blocks = df.as_blocks()
         for dtype, _df in blocks.items():
             if column in _df:
-                _df.ix[:, column] = _df[column] + 1
+                _df.loc[:, column] = _df[column] + 1
 
         # make sure we did not change the original DataFrame
         self.assertFalse(_df[column].equals(df[column]))
@@ -332,7 +332,7 @@ class TestDataFrameBlockInternals(tm.TestCase, TestData):
         blocks = df.as_blocks(copy=False)
         for dtype, _df in blocks.items():
             if column in _df:
-                _df.ix[:, column] = _df[column] + 1
+                _df.loc[:, column] = _df[column] + 1
 
         # make sure we did change the original DataFrame
         self.assertTrue(_df[column].equals(df[column]))
@@ -423,12 +423,12 @@ starting,ending,measure
                        index=np.arange(10))
 
         result = df._get_numeric_data()
-        expected = df.ix[:, ['a', 'b', 'd', 'e', 'f']]
+        expected = df.loc[:, ['a', 'b', 'd', 'e', 'f']]
         assert_frame_equal(result, expected)
 
-        only_obj = df.ix[:, ['c', 'g']]
+        only_obj = df.loc[:, ['c', 'g']]
         result = only_obj._get_numeric_data()
-        expected = df.ix[:, []]
+        expected = df.loc[:, []]
         assert_frame_equal(result, expected)
 
         df = DataFrame.from_dict(
@@ -457,7 +457,7 @@ starting,ending,measure
         l = len(self.mixed_frame)
         self.mixed_frame['J'] = '1.'
         self.mixed_frame['K'] = '1'
-        self.mixed_frame.ix[0:5, ['J', 'K']] = 'garbled'
+        self.mixed_frame.loc[0:5, ['J', 'K']] = 'garbled'
         converted = self.mixed_frame._convert(datetime=True, numeric=True)
         self.assertEqual(converted['H'].dtype, 'float64')
         self.assertEqual(converted['I'].dtype, 'int64')
@@ -535,6 +535,6 @@ starting,ending,measure
 
         myid = 100
 
-        first = len(df.ix[pd.isnull(df[myid]), [myid]])
-        second = len(df.ix[pd.isnull(df[myid]), [myid]])
+        first = len(df.loc[pd.isnull(df[myid]), [myid]])
+        second = len(df.loc[pd.isnull(df[myid]), [myid]])
         self.assertTrue(first == second == 0)

--- a/pandas/tests/frame/test_combine_concat.py
+++ b/pandas/tests/frame/test_combine_concat.py
@@ -79,7 +79,7 @@ class TestDataFrameConcatCommon(tm.TestCase, TestData):
         df = DataFrame(np.random.randn(5, 4),
                        columns=['foo', 'bar', 'baz', 'qux'])
 
-        series = df.ix[4]
+        series = df.loc[4]
         with assertRaisesRegexp(ValueError, 'Indexes have overlapping values'):
             df.append(series, verify_integrity=True)
         series.name = None
@@ -99,10 +99,10 @@ class TestDataFrameConcatCommon(tm.TestCase, TestData):
         result = df.append(series[::-1][:3], ignore_index=True)
         expected = df.append(DataFrame({0: series[::-1][:3]}).T,
                              ignore_index=True)
-        assert_frame_equal(result, expected.ix[:, result.columns])
+        assert_frame_equal(result, expected.loc[:, result.columns])
 
         # can append when name set
-        row = df.ix[4]
+        row = df.loc[4]
         row.name = 5
         result = df.append(row)
         expected = df.append(df[-1:], ignore_index=True)
@@ -534,9 +534,9 @@ class TestDataFrameCombineFirst(tm.TestCase, TestData):
         result = df.combine_first(other)
         assert_frame_equal(result, df)
 
-        df.ix[0, 'A'] = np.nan
+        df.loc[0, 'A'] = np.nan
         result = df.combine_first(other)
-        df.ix[0, 'A'] = 45
+        df.loc[0, 'A'] = 45
         assert_frame_equal(result, df)
 
         # doc example

--- a/pandas/tests/frame/test_constructors.py
+++ b/pandas/tests/frame/test_constructors.py
@@ -96,8 +96,8 @@ class TestDataFrameConstructors(tm.TestCase, TestData):
     def test_constructor_dtype_list_data(self):
         df = DataFrame([[1, '2'],
                         [None, 'a']], dtype=object)
-        self.assertIsNone(df.ix[1, 0])
-        self.assertEqual(df.ix[0, 1], '2')
+        self.assertIsNone(df.loc[1, 0])
+        self.assertEqual(df.loc[0, 1], '2')
 
     def test_constructor_list_frames(self):
 
@@ -1147,7 +1147,7 @@ class TestDataFrameConstructors(tm.TestCase, TestData):
 
         # pass some columns
         recons = DataFrame.from_items(items, columns=['C', 'B', 'A'])
-        tm.assert_frame_equal(recons, self.frame.ix[:, ['C', 'B', 'A']])
+        tm.assert_frame_equal(recons, self.frame.loc[:, ['C', 'B', 'A']])
 
         # orient='index'
 
@@ -1186,7 +1186,7 @@ class TestDataFrameConstructors(tm.TestCase, TestData):
     def test_constructor_mix_series_nonseries(self):
         df = DataFrame({'A': self.frame['A'],
                         'B': list(self.frame['B'])}, columns=['A', 'B'])
-        tm.assert_frame_equal(df, self.frame.ix[:, ['A', 'B']])
+        tm.assert_frame_equal(df, self.frame.loc[:, ['A', 'B']])
 
         with tm.assertRaisesRegexp(ValueError, 'does not match index length'):
             DataFrame({'A': self.frame['A'], 'B': list(self.frame['B'])[:-2]})

--- a/pandas/tests/frame/test_misc_api.py
+++ b/pandas/tests/frame/test_misc_api.py
@@ -47,10 +47,10 @@ class SharedWithSparse(object):
         s = self.frame.pop('A')
         self.assertEqual(s.name, 'A')
 
-        s = self.frame.ix[:, 'B']
+        s = self.frame.loc[:, 'B']
         self.assertEqual(s.name, 'B')
 
-        s2 = s.ix[:]
+        s2 = s.loc[:]
         self.assertEqual(s2.name, 'B')
 
     def test_get_value(self):
@@ -105,8 +105,8 @@ class SharedWithSparse(object):
                 self.frame.join(self.frame, how=how)
 
     def test_join_index_more(self):
-        af = self.frame.ix[:, ['A', 'B']]
-        bf = self.frame.ix[::2, ['C', 'D']]
+        af = self.frame.loc[:, ['A', 'B']]
+        bf = self.frame.loc[::2, ['C', 'D']]
 
         expected = af.copy()
         expected['C'] = self.frame['C'][::2]
@@ -119,7 +119,7 @@ class SharedWithSparse(object):
         assert_frame_equal(result, expected[::2])
 
         result = bf.join(af, how='right')
-        assert_frame_equal(result, expected.ix[:, result.columns])
+        assert_frame_equal(result, expected.loc[:, result.columns])
 
     def test_join_index_series(self):
         df = self.frame.copy()
@@ -133,18 +133,18 @@ class SharedWithSparse(object):
         assertRaisesRegexp(ValueError, 'must have a name', df.join, s)
 
     def test_join_overlap(self):
-        df1 = self.frame.ix[:, ['A', 'B', 'C']]
-        df2 = self.frame.ix[:, ['B', 'C', 'D']]
+        df1 = self.frame.loc[:, ['A', 'B', 'C']]
+        df2 = self.frame.loc[:, ['B', 'C', 'D']]
 
         joined = df1.join(df2, lsuffix='_df1', rsuffix='_df2')
-        df1_suf = df1.ix[:, ['B', 'C']].add_suffix('_df1')
-        df2_suf = df2.ix[:, ['B', 'C']].add_suffix('_df2')
+        df1_suf = df1.loc[:, ['B', 'C']].add_suffix('_df1')
+        df2_suf = df2.loc[:, ['B', 'C']].add_suffix('_df2')
 
-        no_overlap = self.frame.ix[:, ['A', 'D']]
+        no_overlap = self.frame.loc[:, ['A', 'D']]
         expected = df1_suf.join(df2_suf).join(no_overlap)
 
         # column order not necessarily sorted
-        assert_frame_equal(joined, expected.ix[:, joined.columns])
+        assert_frame_equal(joined, expected.loc[:, joined.columns])
 
     def test_add_prefix_suffix(self):
         with_prefix = self.frame.add_prefix('foo#')
@@ -258,7 +258,7 @@ class TestDataFrameMisc(tm.TestCase, SharedWithSparse, TestData):
         for i, tup in enumerate(self.frame.itertuples()):
             s = Series(tup[1:])
             s.name = tup[0]
-            expected = self.frame.ix[i, :].reset_index(drop=True)
+            expected = self.frame.iloc[i, :].reset_index(drop=True)
             assert_series_equal(s, expected)
 
         df = DataFrame({'floats': np.random.randn(5),

--- a/pandas/tests/frame/test_missing.py
+++ b/pandas/tests/frame/test_missing.py
@@ -83,14 +83,14 @@ class TestDataFrameMissingData(tm.TestCase, TestData):
         df[2][:2] = nan
 
         dropped = df.dropna(axis=1)
-        expected = df.ix[:, [0, 1, 3]]
+        expected = df.loc[:, [0, 1, 3]]
         inp = df.copy()
         inp.dropna(axis=1, inplace=True)
         assert_frame_equal(dropped, expected)
         assert_frame_equal(inp, expected)
 
         dropped = df.dropna(axis=0)
-        expected = df.ix[lrange(2, 6)]
+        expected = df.loc[lrange(2, 6)]
         inp = df.copy()
         inp.dropna(axis=0, inplace=True)
         assert_frame_equal(dropped, expected)
@@ -98,14 +98,14 @@ class TestDataFrameMissingData(tm.TestCase, TestData):
 
         # threshold
         dropped = df.dropna(axis=1, thresh=5)
-        expected = df.ix[:, [0, 1, 3]]
+        expected = df.loc[:, [0, 1, 3]]
         inp = df.copy()
         inp.dropna(axis=1, thresh=5, inplace=True)
         assert_frame_equal(dropped, expected)
         assert_frame_equal(inp, expected)
 
         dropped = df.dropna(axis=0, thresh=4)
-        expected = df.ix[lrange(2, 6)]
+        expected = df.loc[lrange(2, 6)]
         inp = df.copy()
         inp.dropna(axis=0, thresh=4, inplace=True)
         assert_frame_equal(dropped, expected)
@@ -130,7 +130,7 @@ class TestDataFrameMissingData(tm.TestCase, TestData):
 
         df[2] = nan
         dropped = df.dropna(axis=1, how='all')
-        expected = df.ix[:, [0, 1, 3]]
+        expected = df.loc[:, [0, 1, 3]]
         assert_frame_equal(dropped, expected)
 
         # bad input
@@ -177,19 +177,23 @@ class TestDataFrameMissingData(tm.TestCase, TestData):
         assert_frame_equal(inp, expected)
 
     def test_fillna(self):
-        self.tsframe.ix[:5, 'A'] = nan
-        self.tsframe.ix[-5:, 'A'] = nan
+        tf = self.tsframe
+        tf.loc[tf.index[:5], 'A'] = nan
+        tf.loc[tf.index[-5:], 'A'] = nan
 
         zero_filled = self.tsframe.fillna(0)
-        self.assertTrue((zero_filled.ix[:5, 'A'] == 0).all())
+        self.assertTrue((zero_filled.loc[zero_filled.index[:5], 'A'] == 0
+                         ).all())
 
         padded = self.tsframe.fillna(method='pad')
-        self.assertTrue(np.isnan(padded.ix[:5, 'A']).all())
-        self.assertTrue((padded.ix[-5:, 'A'] == padded.ix[-5, 'A']).all())
+        self.assertTrue(np.isnan(padded.loc[padded.index[:5], 'A']).all())
+        self.assertTrue((padded.loc[padded.index[-5:], 'A'] ==
+                         padded.loc[padded.index[-5], 'A']).all())
 
         # mixed type
-        self.mixed_frame.ix[5:20, 'foo'] = nan
-        self.mixed_frame.ix[-10:, 'A'] = nan
+        mf = self.mixed_frame
+        mf.loc[mf.index[5:20], 'foo'] = nan
+        mf.loc[mf.index[-10:], 'A'] = nan
         result = self.mixed_frame.fillna(value=0)
         result = self.mixed_frame.fillna(method='pad')
 
@@ -198,7 +202,7 @@ class TestDataFrameMissingData(tm.TestCase, TestData):
 
         # mixed numeric (but no float16)
         mf = self.mixed_float.reindex(columns=['A', 'B', 'D'])
-        mf.ix[-10:, 'A'] = nan
+        mf.loc[mf.index[-10:], 'A'] = nan
         result = mf.fillna(value=0)
         _check_mixed_float(result, dtype=dict(C=None))
 
@@ -243,7 +247,8 @@ class TestDataFrameMissingData(tm.TestCase, TestData):
         })
 
         expected = df.copy()
-        expected['Date'] = expected['Date'].fillna(df.ix[0, 'Date2'])
+        expected['Date'] = expected['Date'].fillna(
+            df.loc[df.index[0], 'Date2'])
         result = df.fillna(value={'Date': df['Date2']})
         assert_frame_equal(result, expected)
 
@@ -425,11 +430,12 @@ class TestDataFrameMissingData(tm.TestCase, TestData):
         self.assertEqual(df.columns.tolist(), filled.columns.tolist())
 
     def test_fill_corner(self):
-        self.mixed_frame.ix[5:20, 'foo'] = nan
-        self.mixed_frame.ix[-10:, 'A'] = nan
+        mf = self.mixed_frame
+        mf.loc[mf.index[5:20], 'foo'] = nan
+        mf.loc[mf.index[-10:], 'A'] = nan
 
         filled = self.mixed_frame.fillna(value=0)
-        self.assertTrue((filled.ix[5:20, 'foo'] == 0).all())
+        self.assertTrue((filled.loc[filled.index[5:20], 'foo'] == 0).all())
         del self.mixed_frame['foo']
 
         empty_float = self.frame.reindex(columns=[])
@@ -543,8 +549,8 @@ class TestDataFrameInterpolate(tm.TestCase, TestData):
                         'C': [1, 2, 3, 5, 8, 13, 21]})
         result = df.interpolate(method='barycentric')
         expected = df.copy()
-        expected.ix[2, 'A'] = 3
-        expected.ix[5, 'A'] = 6
+        expected.loc[2, 'A'] = 3
+        expected.loc[5, 'A'] = 6
         assert_frame_equal(result, expected)
 
         result = df.interpolate(method='barycentric', downcast='infer')
@@ -558,12 +564,12 @@ class TestDataFrameInterpolate(tm.TestCase, TestData):
         _skip_if_no_pchip()
         import scipy
         result = df.interpolate(method='pchip')
-        expected.ix[2, 'A'] = 3
+        expected.loc[2, 'A'] = 3
 
         if LooseVersion(scipy.__version__) >= '0.17.0':
-            expected.ix[5, 'A'] = 6.0
+            expected.loc[5, 'A'] = 6.0
         else:
-            expected.ix[5, 'A'] = 6.125
+            expected.loc[5, 'A'] = 6.125
 
         assert_frame_equal(result, expected)
 

--- a/pandas/tests/frame/test_nonunique_indexes.py
+++ b/pandas/tests/frame/test_nonunique_indexes.py
@@ -353,13 +353,13 @@ class TestDataFrameNonuniqueIndexes(tm.TestCase, TestData):
                        index=['a', 'b', 'c', 'd', 'e'],
                        columns=['A', 'B', 'C', 'D', 'E'])
         z = df[['A', 'C', 'A']].copy()
-        expected = z.ix[['a', 'c', 'a']]
+        expected = z.loc[['a', 'c', 'a']]
 
         df = DataFrame(np.arange(25.).reshape(5, 5),
                        index=['a', 'b', 'c', 'd', 'e'],
                        columns=['A', 'B', 'C', 'D', 'E'])
         z = df[['A', 'C', 'A']]
-        result = z.ix[['a', 'c', 'a']]
+        result = z.loc[['a', 'c', 'a']]
         check(result, expected)
 
     def test_column_dups_indexing2(self):

--- a/pandas/tests/frame/test_operators.py
+++ b/pandas/tests/frame/test_operators.py
@@ -570,7 +570,7 @@ class TestDataFrameOperators(tm.TestCase, TestData):
 
         # Unaligned
         def _check_unaligned_frame(meth, op, df, other):
-            part_o = other.ix[3:, 1:].copy()
+            part_o = other.loc[3:, 1:].copy()
             rs = meth(part_o)
             xp = op(df, part_o.reindex(index=df.index, columns=df.columns))
             assert_frame_equal(rs, xp)
@@ -635,19 +635,19 @@ class TestDataFrameOperators(tm.TestCase, TestData):
         _test_seq(df, idx_ser.values, col_ser.values)
 
         # NA
-        df.ix[0, 0] = np.nan
+        df.loc[0, 0] = np.nan
         rs = df.eq(df)
-        self.assertFalse(rs.ix[0, 0])
+        self.assertFalse(rs.loc[0, 0])
         rs = df.ne(df)
-        self.assertTrue(rs.ix[0, 0])
+        self.assertTrue(rs.loc[0, 0])
         rs = df.gt(df)
-        self.assertFalse(rs.ix[0, 0])
+        self.assertFalse(rs.loc[0, 0])
         rs = df.lt(df)
-        self.assertFalse(rs.ix[0, 0])
+        self.assertFalse(rs.loc[0, 0])
         rs = df.ge(df)
-        self.assertFalse(rs.ix[0, 0])
+        self.assertFalse(rs.loc[0, 0])
         rs = df.le(df)
-        self.assertFalse(rs.ix[0, 0])
+        self.assertFalse(rs.loc[0, 0])
 
         # complex
         arr = np.array([np.nan, 1, 6, np.nan])
@@ -941,12 +941,12 @@ class TestDataFrameOperators(tm.TestCase, TestData):
     def test_string_comparison(self):
         df = DataFrame([{"a": 1, "b": "foo"}, {"a": 2, "b": "bar"}])
         mask_a = df.a > 1
-        assert_frame_equal(df[mask_a], df.ix[1:1, :])
-        assert_frame_equal(df[-mask_a], df.ix[0:0, :])
+        assert_frame_equal(df[mask_a], df.loc[1:1, :])
+        assert_frame_equal(df[-mask_a], df.loc[0:0, :])
 
         mask_b = df.b == "foo"
-        assert_frame_equal(df[mask_b], df.ix[0:0, :])
-        assert_frame_equal(df[-mask_b], df.ix[1:1, :])
+        assert_frame_equal(df[mask_b], df.loc[0:0, :])
+        assert_frame_equal(df[-mask_b], df.loc[1:1, :])
 
     def test_float_none_comparison(self):
         df = DataFrame(np.random.randn(8, 3), index=lrange(8),
@@ -1094,17 +1094,18 @@ class TestDataFrameOperators(tm.TestCase, TestData):
 
     def test_combine_generic(self):
         df1 = self.frame
-        df2 = self.frame.ix[:-5, ['A', 'B', 'C']]
+        df2 = self.frame.loc[self.frame.index[:-5], ['A', 'B', 'C']]
 
         combined = df1.combine(df2, np.add)
         combined2 = df2.combine(df1, np.add)
         self.assertTrue(combined['D'].isnull().all())
         self.assertTrue(combined2['D'].isnull().all())
 
-        chunk = combined.ix[:-5, ['A', 'B', 'C']]
-        chunk2 = combined2.ix[:-5, ['A', 'B', 'C']]
+        chunk = combined.loc[combined.index[:-5], ['A', 'B', 'C']]
+        chunk2 = combined2.loc[combined2.index[:-5], ['A', 'B', 'C']]
 
-        exp = self.frame.ix[:-5, ['A', 'B', 'C']].reindex_like(chunk) * 2
+        exp = self.frame.loc[self.frame.index[:-5],
+                             ['A', 'B', 'C']].reindex_like(chunk) * 2
         assert_frame_equal(chunk, exp)
         assert_frame_equal(chunk2, exp)
 

--- a/pandas/tests/frame/test_replace.py
+++ b/pandas/tests/frame/test_replace.py
@@ -37,8 +37,9 @@ class TestDataFrameReplace(tm.TestCase, TestData):
         self.assertRaises(TypeError, self.tsframe.replace, nan)
 
         # mixed type
-        self.mixed_frame.ix[5:20, 'foo'] = nan
-        self.mixed_frame.ix[-10:, 'A'] = nan
+        mf = self.mixed_frame
+        mf.iloc[5:20, mf.columns.get_loc('foo')] = nan
+        mf.iloc[-10:, mf.columns.get_loc('A')] = nan
 
         result = self.mixed_frame.replace(np.nan, 0)
         expected = self.mixed_frame.fillna(value=0)
@@ -639,8 +640,9 @@ class TestDataFrameReplace(tm.TestCase, TestData):
         assert_series_equal(expec, res)
 
     def test_replace_mixed(self):
-        self.mixed_frame.ix[5:20, 'foo'] = nan
-        self.mixed_frame.ix[-10:, 'A'] = nan
+        mf = self.mixed_frame
+        mf.iloc[5:20, mf.columns.get_loc('foo')] = nan
+        mf.iloc[-10:, mf.columns.get_loc('A')] = nan
 
         result = self.mixed_frame.replace(np.nan, -18)
         expected = self.mixed_frame.fillna(value=-18)

--- a/pandas/tests/frame/test_reshape.py
+++ b/pandas/tests/frame/test_reshape.py
@@ -659,7 +659,7 @@ class TestDataFrameReshape(tm.TestCase, TestData):
         right = DataFrame(vals, columns=cols, index=idx)
         assert_frame_equal(left, right)
 
-        left = df.ix[17264:].copy().set_index(['s_id', 'dosage', 'agent'])
+        left = df.loc[17264:].copy().set_index(['s_id', 'dosage', 'agent'])
         assert_frame_equal(left.unstack(), right)
 
         # GH9497 - multiple unstack with nulls

--- a/pandas/tests/frame/test_sorting.py
+++ b/pandas/tests/frame/test_sorting.py
@@ -28,7 +28,7 @@ class TestDataFrameSorting(tm.TestCase, TestData):
                           columns=['A', 'B', 'C', 'D'])
 
         # axis=0 : sort rows by index labels
-        unordered = frame.ix[[3, 2, 4, 1]]
+        unordered = frame.loc[[3, 2, 4, 1]]
         result = unordered.sort_index(axis=0)
         expected = frame
         assert_frame_equal(result, expected)
@@ -38,12 +38,12 @@ class TestDataFrameSorting(tm.TestCase, TestData):
         assert_frame_equal(result, expected)
 
         # axis=1 : sort columns by column names
-        unordered = frame.ix[:, [2, 1, 3, 0]]
+        unordered = frame.iloc[:, [2, 1, 3, 0]]
         result = unordered.sort_index(axis=1)
         assert_frame_equal(result, frame)
 
         result = unordered.sort_index(axis=1, ascending=False)
-        expected = frame.ix[:, ::-1]
+        expected = frame.iloc[:, ::-1]
         assert_frame_equal(result, expected)
 
     def test_sort_index_multiindex(self):
@@ -79,12 +79,12 @@ class TestDataFrameSorting(tm.TestCase, TestData):
         # by column (axis=0)
         sorted_df = frame.sort_values(by='A')
         indexer = frame['A'].argsort().values
-        expected = frame.ix[frame.index[indexer]]
+        expected = frame.loc[frame.index[indexer]]
         assert_frame_equal(sorted_df, expected)
 
         sorted_df = frame.sort_values(by='A', ascending=False)
         indexer = indexer[::-1]
-        expected = frame.ix[frame.index[indexer]]
+        expected = frame.loc[frame.index[indexer]]
         assert_frame_equal(sorted_df, expected)
 
         sorted_df = frame.sort_values(by='A', ascending=False)
@@ -336,7 +336,7 @@ class TestDataFrameSorting(tm.TestCase, TestData):
                           columns=['A', 'B', 'C', 'D'])
 
         # axis=0
-        unordered = frame.ix[[3, 2, 4, 1]]
+        unordered = frame.loc[[3, 2, 4, 1]]
         a_id = id(unordered['A'])
         df = unordered.copy()
         df.sort_index(inplace=True)
@@ -350,7 +350,7 @@ class TestDataFrameSorting(tm.TestCase, TestData):
         assert_frame_equal(df, expected)
 
         # axis=1
-        unordered = frame.ix[:, ['D', 'B', 'C', 'A']]
+        unordered = frame.loc[:, ['D', 'B', 'C', 'A']]
         df = unordered.copy()
         df.sort_index(axis=1, inplace=True)
         expected = frame
@@ -358,7 +358,7 @@ class TestDataFrameSorting(tm.TestCase, TestData):
 
         df = unordered.copy()
         df.sort_index(axis=1, ascending=False, inplace=True)
-        expected = frame.ix[:, ::-1]
+        expected = frame.iloc[:, ::-1]
         assert_frame_equal(df, expected)
 
     def test_sort_index_different_sortorder(self):

--- a/pandas/tests/frame/test_subclass.py
+++ b/pandas/tests/frame/test_subclass.py
@@ -107,7 +107,7 @@ class TestDataFrameSubclassing(tm.TestCase, TestData):
         tm.assert_series_equal(res, exp)
         tm.assertIsInstance(res, tm.SubclassedSeries)
 
-        res = df.ix[:, 'Z']
+        res = df.loc[:, 'Z']
         exp = tm.SubclassedSeries([7, 8, 9], index=list('abc'), name='Z')
         tm.assert_series_equal(res, exp)
         tm.assertIsInstance(res, tm.SubclassedSeries)
@@ -122,7 +122,7 @@ class TestDataFrameSubclassing(tm.TestCase, TestData):
         tm.assert_series_equal(res, exp)
         tm.assertIsInstance(res, tm.SubclassedSeries)
 
-        res = df.ix['c', :]
+        res = df.loc['c', :]
         exp = tm.SubclassedSeries([3, 6, 9], index=list('XYZ'), name='c')
         tm.assert_series_equal(res, exp)
         tm.assertIsInstance(res, tm.SubclassedSeries)

--- a/pandas/tests/frame/test_timeseries.py
+++ b/pandas/tests/frame/test_timeseries.py
@@ -156,8 +156,8 @@ class TestDataFrameTimeSeriesMethods(tm.TestCase, TestData):
         unshifted = shifted.shift(-1)
         self.assert_index_equal(shifted.index, ps.index)
         self.assert_index_equal(unshifted.index, ps.index)
-        tm.assert_numpy_array_equal(unshifted.ix[:, 0].valid().values,
-                                    ps.ix[:-1, 0].values)
+        tm.assert_numpy_array_equal(unshifted.iloc[:, 0].valid().values,
+                                    ps.iloc[:-1, 0].values)
 
         shifted2 = ps.shift(1, 'B')
         shifted3 = ps.shift(1, offsets.BDay())
@@ -244,7 +244,7 @@ class TestDataFrameTimeSeriesMethods(tm.TestCase, TestData):
         assert_frame_equal(shifted, self.tsframe.tshift(1))
         assert_frame_equal(unshifted, inferred_ts)
 
-        no_freq = self.tsframe.ix[[0, 5, 7], :]
+        no_freq = self.tsframe.iloc[[0, 5, 7], :]
         self.assertRaises(ValueError, no_freq.tshift)
 
     def test_truncate(self):

--- a/pandas/tests/frame/test_to_csv.py
+++ b/pandas/tests/frame/test_to_csv.py
@@ -646,10 +646,10 @@ class TestDataFrameToCSV(tm.TestCase, TestData):
                           index=df_float.index, columns=create_cols('date'))
 
         # add in some nans
-        df_float.ix[30:50, 1:3] = np.nan
+        df_float.loc[30:50, 1:3] = np.nan
 
         # ## this is a bug in read_csv right now ####
-        # df_dt.ix[30:50,1:3] = np.nan
+        # df_dt.loc[30:50,1:3] = np.nan
 
         df = pd.concat([df_float, df_int, df_bool, df_object, df_dt], axis=1)
 

--- a/pandas/tests/groupby/test_filters.py
+++ b/pandas/tests/groupby/test_filters.py
@@ -130,7 +130,7 @@ class TestGroupByFilter(tm.TestCase):
         grouper = df['A'].apply(lambda x: x % 2)
         grouped = df.groupby(grouper)
         assert_frame_equal(
-            grouped.filter(lambda x: x['A'].sum() > 1000), df.ix[[]])
+            grouped.filter(lambda x: x['A'].sum() > 1000), df.loc[[]])
 
     def test_filter_out_no_groups(self):
         s = pd.Series([1, 3, 20, 5, 22, 24, 7])
@@ -278,7 +278,7 @@ class TestGroupByFilter(tm.TestCase):
         assert_frame_equal(actual, expected)
 
         actual = grouped.filter(lambda x: len(x) > 4)
-        expected = df.ix[[]]
+        expected = df.loc[[]]
         assert_frame_equal(actual, expected)
 
         # Series have always worked properly, but we'll test anyway.

--- a/pandas/tests/groupby/test_groupby.py
+++ b/pandas/tests/groupby/test_groupby.py
@@ -135,7 +135,7 @@ class TestGroupBy(tm.TestCase):
         # tests for first / last / nth
         grouped = self.df.groupby('A')
         first = grouped.first()
-        expected = self.df.ix[[1, 0], ['B', 'C', 'D']]
+        expected = self.df.loc[[1, 0], ['B', 'C', 'D']]
         expected.index = Index(['bar', 'foo'], name='A')
         expected = expected.sort_index()
         assert_frame_equal(first, expected)
@@ -144,7 +144,7 @@ class TestGroupBy(tm.TestCase):
         assert_frame_equal(nth, expected)
 
         last = grouped.last()
-        expected = self.df.ix[[5, 7], ['B', 'C', 'D']]
+        expected = self.df.loc[[5, 7], ['B', 'C', 'D']]
         expected.index = Index(['bar', 'foo'], name='A')
         assert_frame_equal(last, expected)
 
@@ -152,7 +152,7 @@ class TestGroupBy(tm.TestCase):
         assert_frame_equal(nth, expected)
 
         nth = grouped.nth(1)
-        expected = self.df.ix[[2, 3], ['B', 'C', 'D']].copy()
+        expected = self.df.loc[[2, 3], ['B', 'C', 'D']].copy()
         expected.index = Index(['foo', 'bar'], name='A')
         expected = expected.sort_index()
         assert_frame_equal(nth, expected)
@@ -187,19 +187,19 @@ class TestGroupBy(tm.TestCase):
         # tests for first / last / nth
         grouped = df.groupby('A')
         first = grouped.first()
-        expected = df.ix[[1, 0], ['B', 'C', 'D', 'E', 'F']]
+        expected = df.loc[[1, 0], ['B', 'C', 'D', 'E', 'F']]
         expected.index = Index(['bar', 'foo'], name='A')
         expected = expected.sort_index()
         assert_frame_equal(first, expected)
 
         last = grouped.last()
-        expected = df.ix[[5, 7], ['B', 'C', 'D', 'E', 'F']]
+        expected = df.loc[[5, 7], ['B', 'C', 'D', 'E', 'F']]
         expected.index = Index(['bar', 'foo'], name='A')
         expected = expected.sort_index()
         assert_frame_equal(last, expected)
 
         nth = grouped.nth(1)
-        expected = df.ix[[3, 2], ['B', 'C', 'D', 'E', 'F']]
+        expected = df.loc[[3, 2], ['B', 'C', 'D', 'E', 'F']]
         expected.index = Index(['bar', 'foo'], name='A')
         expected = expected.sort_index()
         assert_frame_equal(nth, expected)
@@ -225,7 +225,7 @@ class TestGroupBy(tm.TestCase):
         assert_series_equal(g.B.nth(0), df.set_index('A').B.iloc[[0, 2]])
         assert_series_equal(g.B.nth(1), df.set_index('A').B.iloc[[1]])
         assert_frame_equal(g[['B']].nth(0),
-                           df.ix[[0, 2], ['A', 'B']].set_index('A'))
+                           df.loc[[0, 2], ['A', 'B']].set_index('A'))
 
         exp = df.set_index('A')
         assert_frame_equal(g.nth(0, dropna='any'), exp.iloc[[1, 2]])
@@ -763,7 +763,7 @@ class TestGroupBy(tm.TestCase):
         df['value'] = lrange(len(df))
 
         def max_value(group):
-            return group.ix[group['value'].idxmax()]
+            return group.loc[group['value'].idxmax()]
 
         applied = df.groupby('A').apply(max_value)
         result = applied.get_dtype_counts().sort_values()
@@ -1024,14 +1024,14 @@ class TestGroupBy(tm.TestCase):
         self.assertIs(groups, grouped.groups)  # caching works
 
         for k, v in compat.iteritems(grouped.groups):
-            self.assertTrue((self.df.ix[v]['A'] == k).all())
+            self.assertTrue((self.df.loc[v]['A'] == k).all())
 
         grouped = self.df.groupby(['A', 'B'])
         groups = grouped.groups
         self.assertIs(groups, grouped.groups)  # caching works
         for k, v in compat.iteritems(grouped.groups):
-            self.assertTrue((self.df.ix[v]['A'] == k[0]).all())
-            self.assertTrue((self.df.ix[v]['B'] == k[1]).all())
+            self.assertTrue((self.df.loc[v]['A'] == k[0]).all())
+            self.assertTrue((self.df.loc[v]['B'] == k[1]).all())
 
     def test_basic_regression(self):
         # regression
@@ -1471,7 +1471,7 @@ class TestGroupBy(tm.TestCase):
         assert_series_equal(result, expected)
 
     def test_series_index_name(self):
-        grouped = self.df.ix[:, ['C']].groupby(self.df['A'])
+        grouped = self.df.loc[:, ['C']].groupby(self.df['A'])
         result = grouped.agg(lambda x: x.mean())
         self.assertEqual(result.index.name, 'A')
 
@@ -1625,10 +1625,10 @@ class TestGroupBy(tm.TestCase):
         # things get sorted!
         iterated = list(grouped)
         idx = df.index
-        expected = [('a', '1', df.ix[idx[[4]]]),
-                    ('a', '2', df.ix[idx[[3, 5]]]),
-                    ('b', '1', df.ix[idx[[0, 2]]]),
-                    ('b', '2', df.ix[idx[[1]]])]
+        expected = [('a', '1', df.loc[idx[[4]]]),
+                    ('a', '2', df.loc[idx[[3, 5]]]),
+                    ('b', '1', df.loc[idx[[0, 2]]]),
+                    ('b', '2', df.loc[idx[[1]]])]
         for i, ((one, two), three) in enumerate(iterated):
             e1, e2, e3 = expected[i]
             self.assertEqual(e1, one)
@@ -1669,8 +1669,11 @@ class TestGroupBy(tm.TestCase):
         grouped = self.df.groupby([col1.get, col2.get])
         agged = grouped.mean()
         expected = self.df.groupby(['A', 'B']).mean()
-        assert_frame_equal(agged.ix[:, ['C', 'D']], expected.ix[:, ['C', 'D']],
-                           check_names=False)  # TODO groupby get drops names
+
+        # TODO groupby get drops names
+        assert_frame_equal(agged.loc[:, ['C', 'D']],
+                           expected.loc[:, ['C', 'D']],
+                           check_names=False)
 
         # some "groups" with no data
         df = DataFrame({'v1': np.random.randn(6),
@@ -1723,7 +1726,7 @@ class TestGroupBy(tm.TestCase):
             expected = defaultdict(dict)
             for n1, gp1 in data.groupby('A'):
                 for n2, gp2 in gp1.groupby('B'):
-                    expected[n1][n2] = op(gp2.ix[:, ['C', 'D']])
+                    expected[n1][n2] = op(gp2.loc[:, ['C', 'D']])
             expected = dict((k, DataFrame(v))
                             for k, v in compat.iteritems(expected))
             expected = Panel.fromDict(expected).swapaxes(0, 1)
@@ -1931,22 +1934,22 @@ class TestGroupBy(tm.TestCase):
         grouped2 = self.df.groupby(['A', 'B'], as_index=False)
 
         result = grouped['C'].agg(np.sum)
-        expected = grouped.agg(np.sum).ix[:, ['A', 'C']]
+        expected = grouped.agg(np.sum).loc[:, ['A', 'C']]
         tm.assertIsInstance(result, DataFrame)
         assert_frame_equal(result, expected)
 
         result2 = grouped2['C'].agg(np.sum)
-        expected2 = grouped2.agg(np.sum).ix[:, ['A', 'B', 'C']]
+        expected2 = grouped2.agg(np.sum).loc[:, ['A', 'B', 'C']]
         tm.assertIsInstance(result2, DataFrame)
         assert_frame_equal(result2, expected2)
 
         result = grouped['C'].sum()
-        expected = grouped.sum().ix[:, ['A', 'C']]
+        expected = grouped.sum().loc[:, ['A', 'C']]
         tm.assertIsInstance(result, DataFrame)
         assert_frame_equal(result, expected)
 
         result2 = grouped2['C'].sum()
-        expected2 = grouped2.sum().ix[:, ['A', 'B', 'C']]
+        expected2 = grouped2.sum().loc[:, ['A', 'B', 'C']]
         tm.assertIsInstance(result2, DataFrame)
         assert_frame_equal(result2, expected2)
 
@@ -1981,7 +1984,7 @@ class TestGroupBy(tm.TestCase):
         # GH #421
 
         result = grouped['C'].agg(len)
-        expected = grouped.agg(len).ix[:, ['A', 'B', 'C']]
+        expected = grouped.agg(len).loc[:, ['A', 'B', 'C']]
         assert_frame_equal(result, expected)
 
     def test_groupby_as_index_corner(self):
@@ -2106,14 +2109,14 @@ class TestGroupBy(tm.TestCase):
         grouped = self.df.groupby('A')
 
         result = grouped.mean()
-        expected = self.df.ix[:, ['A', 'C', 'D']].groupby('A').mean()
+        expected = self.df.loc[:, ['A', 'C', 'D']].groupby('A').mean()
         assert_frame_equal(result, expected)
 
         agged = grouped.agg(np.mean)
         exp = grouped.mean()
         assert_frame_equal(agged, exp)
 
-        df = self.df.ix[:, ['A', 'C', 'D']]
+        df = self.df.loc[:, ['A', 'C', 'D']]
         df['E'] = datetime.now()
         grouped = df.groupby('A')
         result = grouped.agg(np.sum)
@@ -2568,7 +2571,7 @@ class TestGroupBy(tm.TestCase):
 
         result = grouped.apply(f)
         for key, group in grouped:
-            assert_frame_equal(result.ix[key], f(group))
+            assert_frame_equal(result.loc[key], f(group))
 
     def test_mutate_groups(self):
 
@@ -3025,7 +3028,7 @@ class TestGroupBy(tm.TestCase):
         with option_context('mode.chained_assignment', None):
             for key, group in grouped:
                 res = f(group)
-                assert_frame_equal(res, result.ix[key])
+                assert_frame_equal(res, result.loc[key])
 
     def test_groupby_wrong_multi_labels(self):
         from pandas import read_csv
@@ -3623,7 +3626,7 @@ class TestGroupBy(tm.TestCase):
                 return ser.sum()
 
         result = grouped.aggregate(func)
-        exp_grouped = self.three_group.ix[:, self.three_group.columns != 'C']
+        exp_grouped = self.three_group.loc[:, self.three_group.columns != 'C']
         expected = exp_grouped.groupby(['A', 'B']).aggregate(func)
         assert_frame_equal(result, expected)
 
@@ -3662,7 +3665,7 @@ class TestGroupBy(tm.TestCase):
         result2 = df.groupby('A')['C', 'D'].mean()
         result3 = df.groupby('A')[df.columns[2:4]].mean()
 
-        expected = df.ix[:, ['A', 'C', 'D']].groupby('A').mean()
+        expected = df.loc[:, ['A', 'C', 'D']].groupby('A').mean()
 
         assert_frame_equal(result, expected)
         assert_frame_equal(result2, expected)
@@ -3678,7 +3681,7 @@ class TestGroupBy(tm.TestCase):
         result2 = df.groupby(0)[2, 4].mean()
         result3 = df.groupby(0)[[2, 4]].mean()
 
-        expected = df.ix[:, [0, 2, 4]].groupby(0).mean()
+        expected = df.loc[:, [0, 2, 4]].groupby(0).mean()
 
         assert_frame_equal(result, expected)
         assert_frame_equal(result2, expected)
@@ -5091,8 +5094,8 @@ class TestGroupBy(tm.TestCase):
                            names=['first', 'second'])
         raw_frame = DataFrame(np.random.randn(10, 3), index=index,
                               columns=Index(['A', 'B', 'C'], name='exp'))
-        raw_frame.ix[1, [1, 2]] = np.nan
-        raw_frame.ix[7, [0, 1]] = np.nan
+        raw_frame.iloc[1, [1, 2]] = np.nan
+        raw_frame.iloc[7, [0, 1]] = np.nan
 
         for op, level, axis, skipna in cart_product(self.AGG_FUNCTIONS,
                                                     lrange(2), lrange(2),

--- a/pandas/tests/indexes/test_datetimelike.py
+++ b/pandas/tests/indexes/test_datetimelike.py
@@ -954,8 +954,8 @@ class TestPeriodIndex(DatetimeLike, tm.TestCase):
         # GH4125
         idx = pd.period_range('2002-01', '2003-12', freq='M')
         df = pd.DataFrame(pd.np.random.randn(24, 10), index=idx)
-        self.assert_frame_equal(df, df.ix[idx])
-        self.assert_frame_equal(df, df.ix[list(idx)])
+        self.assert_frame_equal(df, df.loc[idx])
+        self.assert_frame_equal(df, df.loc[list(idx)])
         self.assert_frame_equal(df, df.loc[list(idx)])
         self.assert_frame_equal(df.iloc[0:5], df.loc[idx[0:5]])
         self.assert_frame_equal(df, df.loc[list(idx)])

--- a/pandas/tests/indexes/test_multi.py
+++ b/pandas/tests/indexes/test_multi.py
@@ -1820,7 +1820,7 @@ class TestMultiIndex(Base, tm.TestCase):
                          pd.MultiIndex.from_tuples(idx[:-2]))
 
         left.loc[('test', 17)] = 11
-        left.ix[('test', 18)] = 12
+        left.loc[('test', 18)] = 12
 
         right = pd.Series(np.linspace(0, 12, 13),
                           pd.MultiIndex.from_tuples(idx))

--- a/pandas/tests/indexing/test_callable.py
+++ b/pandas/tests/indexing/test_callable.py
@@ -21,51 +21,51 @@ class TestIndexingCallable(tm.TestCase):
         res = df.loc[lambda x: x.A > 2]
         tm.assert_frame_equal(res, df.loc[df.A > 2])
 
-        res = df.ix[lambda x: x.A > 2]
-        tm.assert_frame_equal(res, df.ix[df.A > 2])
+        res = df.loc[lambda x: x.A > 2]
+        tm.assert_frame_equal(res, df.loc[df.A > 2])
 
         res = df.loc[lambda x: x.A > 2, ]
         tm.assert_frame_equal(res, df.loc[df.A > 2, ])
 
-        res = df.ix[lambda x: x.A > 2, ]
-        tm.assert_frame_equal(res, df.ix[df.A > 2, ])
+        res = df.loc[lambda x: x.A > 2, ]
+        tm.assert_frame_equal(res, df.loc[df.A > 2, ])
 
         res = df.loc[lambda x: x.B == 'b', :]
         tm.assert_frame_equal(res, df.loc[df.B == 'b', :])
 
-        res = df.ix[lambda x: x.B == 'b', :]
-        tm.assert_frame_equal(res, df.ix[df.B == 'b', :])
+        res = df.loc[lambda x: x.B == 'b', :]
+        tm.assert_frame_equal(res, df.loc[df.B == 'b', :])
 
         res = df.loc[lambda x: x.A > 2, lambda x: x.columns == 'B']
         tm.assert_frame_equal(res, df.loc[df.A > 2, [False, True, False]])
 
-        res = df.ix[lambda x: x.A > 2, lambda x: x.columns == 'B']
-        tm.assert_frame_equal(res, df.ix[df.A > 2, [False, True, False]])
+        res = df.loc[lambda x: x.A > 2, lambda x: x.columns == 'B']
+        tm.assert_frame_equal(res, df.loc[df.A > 2, [False, True, False]])
 
         res = df.loc[lambda x: x.A > 2, lambda x: 'B']
         tm.assert_series_equal(res, df.loc[df.A > 2, 'B'])
 
-        res = df.ix[lambda x: x.A > 2, lambda x: 'B']
-        tm.assert_series_equal(res, df.ix[df.A > 2, 'B'])
+        res = df.loc[lambda x: x.A > 2, lambda x: 'B']
+        tm.assert_series_equal(res, df.loc[df.A > 2, 'B'])
 
         res = df.loc[lambda x: x.A > 2, lambda x: ['A', 'B']]
         tm.assert_frame_equal(res, df.loc[df.A > 2, ['A', 'B']])
 
-        res = df.ix[lambda x: x.A > 2, lambda x: ['A', 'B']]
-        tm.assert_frame_equal(res, df.ix[df.A > 2, ['A', 'B']])
+        res = df.loc[lambda x: x.A > 2, lambda x: ['A', 'B']]
+        tm.assert_frame_equal(res, df.loc[df.A > 2, ['A', 'B']])
 
         res = df.loc[lambda x: x.A == 2, lambda x: ['A', 'B']]
         tm.assert_frame_equal(res, df.loc[df.A == 2, ['A', 'B']])
 
-        res = df.ix[lambda x: x.A == 2, lambda x: ['A', 'B']]
-        tm.assert_frame_equal(res, df.ix[df.A == 2, ['A', 'B']])
+        res = df.loc[lambda x: x.A == 2, lambda x: ['A', 'B']]
+        tm.assert_frame_equal(res, df.loc[df.A == 2, ['A', 'B']])
 
         # scalar
         res = df.loc[lambda x: 1, lambda x: 'A']
         self.assertEqual(res, df.loc[1, 'A'])
 
-        res = df.ix[lambda x: 1, lambda x: 'A']
-        self.assertEqual(res, df.ix[1, 'A'])
+        res = df.loc[lambda x: 1, lambda x: 'A']
+        self.assertEqual(res, df.loc[1, 'A'])
 
     def test_frame_loc_ix_callable_mixture(self):
         # GH 11485
@@ -75,20 +75,20 @@ class TestIndexingCallable(tm.TestCase):
         res = df.loc[lambda x: x.A > 2, ['A', 'B']]
         tm.assert_frame_equal(res, df.loc[df.A > 2, ['A', 'B']])
 
-        res = df.ix[lambda x: x.A > 2, ['A', 'B']]
-        tm.assert_frame_equal(res, df.ix[df.A > 2, ['A', 'B']])
+        res = df.loc[lambda x: x.A > 2, ['A', 'B']]
+        tm.assert_frame_equal(res, df.loc[df.A > 2, ['A', 'B']])
 
         res = df.loc[[2, 3], lambda x: ['A', 'B']]
         tm.assert_frame_equal(res, df.loc[[2, 3], ['A', 'B']])
 
-        res = df.ix[[2, 3], lambda x: ['A', 'B']]
-        tm.assert_frame_equal(res, df.ix[[2, 3], ['A', 'B']])
+        res = df.loc[[2, 3], lambda x: ['A', 'B']]
+        tm.assert_frame_equal(res, df.loc[[2, 3], ['A', 'B']])
 
         res = df.loc[3, lambda x: ['A', 'B']]
         tm.assert_series_equal(res, df.loc[3, ['A', 'B']])
 
-        res = df.ix[3, lambda x: ['A', 'B']]
-        tm.assert_series_equal(res, df.ix[3, ['A', 'B']])
+        res = df.loc[3, lambda x: ['A', 'B']]
+        tm.assert_series_equal(res, df.loc[3, ['A', 'B']])
 
     def test_frame_loc_callable(self):
         # GH 11485

--- a/pandas/tests/indexing/test_categorical.py
+++ b/pandas/tests/indexing/test_categorical.py
@@ -190,22 +190,22 @@ class TestCategoricalIndex(tm.TestCase):
         cdf.index = pd.CategoricalIndex(df.index)
         cdf.columns = pd.CategoricalIndex(df.columns)
 
-        expect = pd.Series(df.ix['A', :], index=cdf.columns, name='A')
-        assert_series_equal(cdf.ix['A', :], expect)
+        expect = pd.Series(df.loc['A', :], index=cdf.columns, name='A')
+        assert_series_equal(cdf.loc['A', :], expect)
 
-        expect = pd.Series(df.ix[:, 'X'], index=cdf.index, name='X')
-        assert_series_equal(cdf.ix[:, 'X'], expect)
+        expect = pd.Series(df.loc[:, 'X'], index=cdf.index, name='X')
+        assert_series_equal(cdf.loc[:, 'X'], expect)
 
         exp_index = pd.CategoricalIndex(list('AB'), categories=['A', 'B', 'C'])
-        expect = pd.DataFrame(df.ix[['A', 'B'], :], columns=cdf.columns,
+        expect = pd.DataFrame(df.loc[['A', 'B'], :], columns=cdf.columns,
                               index=exp_index)
-        assert_frame_equal(cdf.ix[['A', 'B'], :], expect)
+        assert_frame_equal(cdf.loc[['A', 'B'], :], expect)
 
         exp_columns = pd.CategoricalIndex(list('XY'),
                                           categories=['X', 'Y', 'Z'])
-        expect = pd.DataFrame(df.ix[:, ['X', 'Y']], index=cdf.index,
+        expect = pd.DataFrame(df.loc[:, ['X', 'Y']], index=cdf.index,
                               columns=exp_columns)
-        assert_frame_equal(cdf.ix[:, ['X', 'Y']], expect)
+        assert_frame_equal(cdf.loc[:, ['X', 'Y']], expect)
 
         # non-unique
         df = pd.DataFrame(np.random.randn(3, 3),
@@ -215,22 +215,22 @@ class TestCategoricalIndex(tm.TestCase):
         cdf.columns = pd.CategoricalIndex(df.columns)
 
         exp_index = pd.CategoricalIndex(list('AA'), categories=['A', 'B'])
-        expect = pd.DataFrame(df.ix['A', :], columns=cdf.columns,
+        expect = pd.DataFrame(df.loc['A', :], columns=cdf.columns,
                               index=exp_index)
-        assert_frame_equal(cdf.ix['A', :], expect)
+        assert_frame_equal(cdf.loc['A', :], expect)
 
         exp_columns = pd.CategoricalIndex(list('XX'), categories=['X', 'Y'])
-        expect = pd.DataFrame(df.ix[:, 'X'], index=cdf.index,
+        expect = pd.DataFrame(df.loc[:, 'X'], index=cdf.index,
                               columns=exp_columns)
-        assert_frame_equal(cdf.ix[:, 'X'], expect)
+        assert_frame_equal(cdf.loc[:, 'X'], expect)
 
-        expect = pd.DataFrame(df.ix[['A', 'B'], :], columns=cdf.columns,
+        expect = pd.DataFrame(df.loc[['A', 'B'], :], columns=cdf.columns,
                               index=pd.CategoricalIndex(list('AAB')))
-        assert_frame_equal(cdf.ix[['A', 'B'], :], expect)
+        assert_frame_equal(cdf.loc[['A', 'B'], :], expect)
 
-        expect = pd.DataFrame(df.ix[:, ['X', 'Y']], index=cdf.index,
+        expect = pd.DataFrame(df.loc[:, ['X', 'Y']], index=cdf.index,
                               columns=pd.CategoricalIndex(list('XXY')))
-        assert_frame_equal(cdf.ix[:, ['X', 'Y']], expect)
+        assert_frame_equal(cdf.loc[:, ['X', 'Y']], expect)
 
     def test_read_only_source(self):
         # GH 10043

--- a/pandas/tests/indexing/test_floats.py
+++ b/pandas/tests/indexing/test_floats.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+from warnings import catch_warnings
 import numpy as np
 from pandas import Series, DataFrame, Index, Float64Index
 from pandas.util.testing import assert_series_equal, assert_almost_equal
@@ -77,7 +78,8 @@ class TestFloatIndexers(tm.TestCase):
                                       (lambda x: x, True)]:
 
                     def f():
-                        idxr(s)[3.0]
+                        with catch_warnings(record=True):
+                            idxr(s)[3.0]
 
                     # gettitem on a DataFrame is a KeyError as it is indexing
                     # via labels on the columns
@@ -131,7 +133,8 @@ class TestFloatIndexers(tm.TestCase):
                     for idxr in [lambda x: x.ix,
                                  lambda x: x]:
                         s2 = s.copy()
-                        idxr(s2)[3.0] = 0
+                        with catch_warnings(record=True):
+                            idxr(s2)[3.0] = 0
                         self.assertTrue(s2.index.is_object())
 
             # fallsback to position selection, series only
@@ -151,7 +154,8 @@ class TestFloatIndexers(tm.TestCase):
                      lambda x: x.iloc]:
 
             def f():
-                idxr(s2)[1.0]
+                with catch_warnings(record=True):
+                    idxr(s2)[1.0]
 
             self.assertRaises(TypeError, f)
 
@@ -167,7 +171,8 @@ class TestFloatIndexers(tm.TestCase):
                      lambda x: x]:
 
             def f():
-                idxr(s3)[1.0]
+                with catch_warnings(record=True):
+                    idxr(s3)[1.0]
 
             self.assertRaises(TypeError, f)
 
@@ -199,7 +204,8 @@ class TestFloatIndexers(tm.TestCase):
                                       (lambda x: x.loc, False),
                                       (lambda x: x, True)]:
 
-                    result = idxr(s)[3.0]
+                    with catch_warnings(record=True):
+                        result = idxr(s)[3.0]
                     self.check(result, s, 3, getitem)
 
                 # coerce to equal int
@@ -220,13 +226,14 @@ class TestFloatIndexers(tm.TestCase):
                                               index=range(len(s)), name=3)
 
                     s2 = s.copy()
-                    idxr(s2)[3.0] = 100
+                    with catch_warnings(record=True):
+                        idxr(s2)[3.0] = 100
 
-                    result = idxr(s2)[3.0]
-                    compare(result, expected)
+                        result = idxr(s2)[3.0]
+                        compare(result, expected)
 
-                    result = idxr(s2)[3]
-                    compare(result, expected)
+                        result = idxr(s2)[3]
+                        compare(result, expected)
 
                 # contains
                 # coerce to equal int
@@ -247,19 +254,23 @@ class TestFloatIndexers(tm.TestCase):
                                   (lambda x: x, True)]:
 
                 # getting
-                result = idxr(s)[indexer]
+                with catch_warnings(record=True):
+                    result = idxr(s)[indexer]
                 self.check(result, s, 3, getitem)
 
                 # setting
                 s2 = s.copy()
 
                 def f():
-                    idxr(s2)[indexer] = expected
-                result = idxr(s2)[indexer]
+                    with catch_warnings(record=True):
+                        idxr(s2)[indexer] = expected
+                with catch_warnings(record=True):
+                    result = idxr(s2)[indexer]
                 self.check(result, s, 3, getitem)
 
                 # random integer is a KeyError
-                self.assertRaises(KeyError, lambda: idxr(s)[3.5])
+                with catch_warnings(record=True):
+                    self.assertRaises(KeyError, lambda: idxr(s)[3.5])
 
             # contains
             self.assertTrue(3.0 in s)
@@ -308,7 +319,8 @@ class TestFloatIndexers(tm.TestCase):
                                  lambda x: x]:
 
                         def f():
-                            idxr(s)[l]
+                            with catch_warnings(record=True):
+                                idxr(s)[l]
                         self.assertRaises(TypeError, f)
 
                 # setitem
@@ -325,7 +337,8 @@ class TestFloatIndexers(tm.TestCase):
                                  lambda x: x.iloc,
                                  lambda x: x]:
                         def f():
-                            idxr(s)[l] = 0
+                            with catch_warnings(record=True):
+                                idxr(s)[l] = 0
                         self.assertRaises(TypeError, f)
 
     def test_slice_integer(self):
@@ -349,7 +362,8 @@ class TestFloatIndexers(tm.TestCase):
                 for idxr in [lambda x: x.loc,
                              lambda x: x.ix]:
 
-                    result = idxr(s)[l]
+                    with catch_warnings(record=True):
+                        result = idxr(s)[l]
 
                     # these are all label indexing
                     # except getitem which is positional
@@ -372,7 +386,8 @@ class TestFloatIndexers(tm.TestCase):
 
                 for idxr in [lambda x: x.loc,
                              lambda x: x.ix]:
-                    result = idxr(s)[l]
+                    with catch_warnings(record=True):
+                        result = idxr(s)[l]
 
                     # these are all label indexing
                     # except getitem which is positional
@@ -397,7 +412,8 @@ class TestFloatIndexers(tm.TestCase):
                 for idxr in [lambda x: x.loc,
                              lambda x: x.ix]:
 
-                    result = idxr(s)[l]
+                    with catch_warnings(record=True):
+                        result = idxr(s)[l]
                     if oob:
                         res = slice(0, 0)
                     else:
@@ -419,8 +435,9 @@ class TestFloatIndexers(tm.TestCase):
                 for idxr in [lambda x: x.loc,
                              lambda x: x.ix]:
                     sc = s.copy()
-                    idxr(sc)[l] = 0
-                    result = idxr(sc)[l].values.ravel()
+                    with catch_warnings(record=True):
+                        idxr(sc)[l] = 0
+                        result = idxr(sc)[l].values.ravel()
                     self.assertTrue((result == 0).all())
 
                 # positional indexing
@@ -467,7 +484,8 @@ class TestFloatIndexers(tm.TestCase):
                           slice(0, 1.0),
                           slice(0.0, 1.0)]:
 
-                    result = idxr(s)[l]
+                    with catch_warnings(record=True):
+                        result = idxr(s)[l]
                     indexer = slice(0, 2)
                     self.check(result, s, indexer, False)
 
@@ -495,7 +513,8 @@ class TestFloatIndexers(tm.TestCase):
                                (slice(0, 0.5), slice(0, 1)),
                                (slice(0.5, 1.5), slice(1, 2))]:
 
-                    result = idxr(s)[l]
+                    with catch_warnings(record=True):
+                        result = idxr(s)[l]
                     self.check(result, s, res, False)
 
                     # positional indexing
@@ -510,8 +529,9 @@ class TestFloatIndexers(tm.TestCase):
                           slice(3.0, 4.0)]:
 
                     sc = s.copy()
-                    idxr(sc)[l] = 0
-                    result = idxr(sc)[l].values.ravel()
+                    with catch_warnings(record=True):
+                        idxr(sc)[l] = 0
+                        result = idxr(sc)[l].values.ravel()
                     self.assertTrue((result == 0).all())
 
                     # positional indexing
@@ -537,15 +557,17 @@ class TestFloatIndexers(tm.TestCase):
                              lambda x: x]:
 
                     # getitem
-                    result = idxr(s)[l]
+                    with catch_warnings(record=True):
+                        result = idxr(s)[l]
                     if isinstance(s, Series):
                         self.assert_series_equal(result, expected)
                     else:
                         self.assert_frame_equal(result, expected)
                     # setitem
                     s2 = s.copy()
-                    idxr(s2)[l] = 0
-                    result = idxr(s2)[l].values.ravel()
+                    with catch_warnings(record=True):
+                        idxr(s2)[l] = 0
+                        result = idxr(s2)[l].values.ravel()
                     self.assertTrue((result == 0).all())
 
     def test_floating_index_doc_example(self):
@@ -553,7 +575,7 @@ class TestFloatIndexers(tm.TestCase):
         index = Index([1.5, 2, 3, 4.5, 5])
         s = Series(range(5), index=index)
         self.assertEqual(s[3], 2)
-        self.assertEqual(s.ix[3], 2)
+        self.assertEqual(s.loc[3], 2)
         self.assertEqual(s.loc[3], 2)
         self.assertEqual(s.iloc[3], 3)
 
@@ -565,7 +587,7 @@ class TestFloatIndexers(tm.TestCase):
 
         # label based slicing
         result1 = s[1.0:3.0]
-        result2 = s.ix[1.0:3.0]
+        result2 = s.loc[1.0:3.0]
         result3 = s.loc[1.0:3.0]
         assert_series_equal(result1, result2)
         assert_series_equal(result1, result3)
@@ -573,13 +595,13 @@ class TestFloatIndexers(tm.TestCase):
         # exact indexing when found
         result1 = s[5.0]
         result2 = s.loc[5.0]
-        result3 = s.ix[5.0]
+        result3 = s.loc[5.0]
         self.assertEqual(result1, result2)
         self.assertEqual(result1, result3)
 
         result1 = s[5]
         result2 = s.loc[5]
-        result3 = s.ix[5]
+        result3 = s.loc[5]
         self.assertEqual(result1, result2)
         self.assertEqual(result1, result3)
 
@@ -589,7 +611,7 @@ class TestFloatIndexers(tm.TestCase):
 
         # scalar integers
         self.assertRaises(KeyError, lambda: s.loc[4])
-        self.assertRaises(KeyError, lambda: s.ix[4])
+        self.assertRaises(KeyError, lambda: s.loc[4])
         self.assertRaises(KeyError, lambda: s[4])
 
         # fancy floats/integers create the correct entry (as nan)
@@ -598,13 +620,13 @@ class TestFloatIndexers(tm.TestCase):
         for fancy_idx in [[5.0, 0.0], np.array([5.0, 0.0])]:  # float
             assert_series_equal(s[fancy_idx], expected)
             assert_series_equal(s.loc[fancy_idx], expected)
-            assert_series_equal(s.ix[fancy_idx], expected)
+            assert_series_equal(s.loc[fancy_idx], expected)
 
         expected = Series([2, 0], index=Index([5, 0], dtype='int64'))
         for fancy_idx in [[5, 0], np.array([5, 0])]:  # int
             assert_series_equal(s[fancy_idx], expected)
             assert_series_equal(s.loc[fancy_idx], expected)
-            assert_series_equal(s.ix[fancy_idx], expected)
+            assert_series_equal(s.loc[fancy_idx], expected)
 
         # all should return the same as we are slicing 'the same'
         result1 = s.loc[2:5]
@@ -624,17 +646,17 @@ class TestFloatIndexers(tm.TestCase):
         assert_series_equal(result1, result3)
         assert_series_equal(result1, result4)
 
-        result1 = s.ix[2:5]
-        result2 = s.ix[2.0:5.0]
-        result3 = s.ix[2.0:5]
-        result4 = s.ix[2.1:5]
+        result1 = s.loc[2:5]
+        result2 = s.loc[2.0:5.0]
+        result3 = s.loc[2.0:5]
+        result4 = s.loc[2.1:5]
         assert_series_equal(result1, result2)
         assert_series_equal(result1, result3)
         assert_series_equal(result1, result4)
 
         # combined test
         result1 = s.loc[2:5]
-        result2 = s.ix[2:5]
+        result2 = s.loc[2:5]
         result3 = s[2:5]
 
         assert_series_equal(result1, result2)
@@ -643,7 +665,7 @@ class TestFloatIndexers(tm.TestCase):
         # list selection
         result1 = s[[0.0, 5, 10]]
         result2 = s.loc[[0.0, 5, 10]]
-        result3 = s.ix[[0.0, 5, 10]]
+        result3 = s.loc[[0.0, 5, 10]]
         result4 = s.iloc[[0, 2, 4]]
         assert_series_equal(result1, result2)
         assert_series_equal(result1, result3)
@@ -651,14 +673,14 @@ class TestFloatIndexers(tm.TestCase):
 
         result1 = s[[1.6, 5, 10]]
         result2 = s.loc[[1.6, 5, 10]]
-        result3 = s.ix[[1.6, 5, 10]]
+        result3 = s.loc[[1.6, 5, 10]]
         assert_series_equal(result1, result2)
         assert_series_equal(result1, result3)
         assert_series_equal(result1, Series(
             [np.nan, 2, 4], index=[1.6, 5, 10]))
 
         result1 = s[[0, 1, 2]]
-        result2 = s.ix[[0, 1, 2]]
+        result2 = s.loc[[0, 1, 2]]
         result3 = s.loc[[0, 1, 2]]
         assert_series_equal(result1, result2)
         assert_series_equal(result1, result3)
@@ -666,12 +688,12 @@ class TestFloatIndexers(tm.TestCase):
             [0.0, np.nan, np.nan], index=[0, 1, 2]))
 
         result1 = s.loc[[2.5, 5]]
-        result2 = s.ix[[2.5, 5]]
+        result2 = s.loc[[2.5, 5]]
         assert_series_equal(result1, result2)
         assert_series_equal(result1, Series([1, 2], index=[2.5, 5.0]))
 
         result1 = s[[2.5]]
-        result2 = s.ix[[2.5]]
+        result2 = s.loc[[2.5]]
         result3 = s.loc[[2.5]]
         assert_series_equal(result1, result2)
         assert_series_equal(result1, result3)

--- a/pandas/tests/plotting/test_datetimelike.py
+++ b/pandas/tests/plotting/test_datetimelike.py
@@ -273,7 +273,7 @@ class TestTSPlot(TestPlotBase):
         idx = date_range('2012-6-22 21:59:51', freq='S', periods=100)
         df = DataFrame(np.random.randn(len(idx), 2), idx)
 
-        irreg = df.ix[[0, 1, 3, 4]]
+        irreg = df.iloc[[0, 1, 3, 4]]
         ax = irreg.plot()
         diffs = Series(ax.get_lines()[0].get_xydata()[:, 0]).diff()
 

--- a/pandas/tests/plotting/test_frame.py
+++ b/pandas/tests/plotting/test_frame.py
@@ -699,7 +699,7 @@ class TestDataFramePlots(TestPlotBase):
         self._check_colors(ax.patches[::5], facecolors=rgba_colors)
         tm.close()
 
-        ax = df.ix[:, [0]].plot.bar(color='DodgerBlue')
+        ax = df.loc[:, [0]].plot.bar(color='DodgerBlue')
         self._check_colors([ax.patches[0]], facecolors=['DodgerBlue'])
         tm.close()
 
@@ -1594,7 +1594,7 @@ class TestDataFramePlots(TestPlotBase):
 
         # make color a list if plotting one column frame
         # handles cases like df.plot(color='DodgerBlue')
-        ax = df.ix[:, [0]].plot(color='DodgerBlue')
+        ax = df.loc[:, [0]].plot(color='DodgerBlue')
         self._check_colors(ax.lines, linecolors=['DodgerBlue'])
 
         ax = df.plot(color='red')
@@ -1681,7 +1681,7 @@ class TestDataFramePlots(TestPlotBase):
 
         # make color a list if plotting one column frame
         # handles cases like df.plot(color='DodgerBlue')
-        axes = df.ix[:, [0]].plot(color='DodgerBlue', subplots=True)
+        axes = df.loc[:, [0]].plot(color='DodgerBlue', subplots=True)
         self._check_colors(axes[0].lines, linecolors=['DodgerBlue'])
 
         # single character style
@@ -1784,7 +1784,7 @@ class TestDataFramePlots(TestPlotBase):
         self._check_colors(ax.patches[::10], facecolors=rgba_colors)
         tm.close()
 
-        ax = df.ix[:, [0]].plot.hist(color='DodgerBlue')
+        ax = df.loc[:, [0]].plot.hist(color='DodgerBlue')
         self._check_colors([ax.patches[0]], facecolors=['DodgerBlue'])
 
         ax = df.plot(kind='hist', color='green')
@@ -1856,8 +1856,8 @@ class TestDataFramePlots(TestPlotBase):
 
         # make color a list if plotting one column frame
         # handles cases like df.plot(color='DodgerBlue')
-        axes = df.ix[:, [0]].plot(kind='kde', color='DodgerBlue',
-                                  subplots=True)
+        axes = df.loc[:, [0]].plot(kind='kde', color='DodgerBlue',
+                                   subplots=True)
         self._check_colors(axes[0].lines, linecolors=['DodgerBlue'])
 
         # single character style

--- a/pandas/tests/series/test_analytics.py
+++ b/pandas/tests/series/test_analytics.py
@@ -1033,7 +1033,7 @@ class TestSeriesAnalytics(TestData, tm.TestCase):
 
         rng = date_range('1/1/1990', periods=5)
         iseries = Series(np.arange(5), rng) + 1
-        iseries.ix[4] = np.nan
+        iseries.iloc[4] = np.nan
         exp = iseries / 4.0
         iranks = iseries.rank(pct=True)
         assert_series_equal(iranks, exp)

--- a/pandas/tests/series/test_constructors.py
+++ b/pandas/tests/series/test_constructors.py
@@ -368,7 +368,7 @@ class TestSeriesConstructors(TestData, tm.TestCase):
         s = Series(dates)
         self.assertEqual(s.dtype, 'M8[ns]')
 
-        s.ix[0] = np.nan
+        s.iloc[0] = np.nan
         self.assertEqual(s.dtype, 'M8[ns]')
 
         # invalid astypes
@@ -581,8 +581,8 @@ class TestSeriesConstructors(TestData, tm.TestCase):
         d = {pidx[0]: 0, pidx[1]: 1}
         result = Series(d, index=pidx)
         expected = Series(np.nan, pidx)
-        expected.ix[0] = 0
-        expected.ix[1] = 1
+        expected.iloc[0] = 0
+        expected.iloc[1] = 1
         assert_series_equal(result, expected)
 
     def test_constructor_dict_multiindex(self):

--- a/pandas/tests/series/test_indexing.py
+++ b/pandas/tests/series/test_indexing.py
@@ -185,7 +185,7 @@ class TestSeriesIndexing(TestData, tm.TestCase):
 
         # pass a slice
         result = s.iloc[slice(1, 3)]
-        expected = s.ix[2:4]
+        expected = s.loc[2:4]
         assert_series_equal(result, expected)
 
         # test slice is a view
@@ -330,10 +330,10 @@ class TestSeriesIndexing(TestData, tm.TestCase):
         # ts[mask_shifted]
         # ts[mask_shifted] = 1
 
-        self.assertRaises(Exception, ts.ix.__getitem__, mask_shifted)
-        self.assertRaises(Exception, ts.ix.__setitem__, mask_shifted, 1)
-        # ts.ix[mask_shifted]
-        # ts.ix[mask_shifted] = 2
+        self.assertRaises(Exception, ts.loc.__getitem__, mask_shifted)
+        self.assertRaises(Exception, ts.loc.__setitem__, mask_shifted, 1)
+        # ts.loc[mask_shifted]
+        # ts.loc[mask_shifted] = 2
 
     def test_getitem_setitem_slice_integers(self):
         s = Series(np.random.randn(8), index=[2, 4, 6, 8, 10, 12, 14, 16])
@@ -358,8 +358,8 @@ class TestSeriesIndexing(TestData, tm.TestCase):
         # caused bug without test
         s = Series([1, 2, 3], ['a', 'b', 'c'])
 
-        self.assertEqual(s.ix[0], s['a'])
-        s.ix[0] = 5
+        self.assertEqual(s.iloc[0], s['a'])
+        s.iloc[0] = 5
         self.assertAlmostEqual(s['a'], 5)
 
     def test_getitem_box_float64(self):
@@ -369,7 +369,7 @@ class TestSeriesIndexing(TestData, tm.TestCase):
     def test_getitem_ambiguous_keyerror(self):
         s = Series(lrange(10), index=lrange(0, 20, 2))
         self.assertRaises(KeyError, s.__getitem__, 1)
-        self.assertRaises(KeyError, s.ix.__getitem__, 1)
+        self.assertRaises(KeyError, s.loc.__getitem__, 1)
 
     def test_getitem_unordered_dup(self):
         obj = Series(lrange(5), index=['c', 'a', 'a', 'b', 'b'])
@@ -378,10 +378,10 @@ class TestSeriesIndexing(TestData, tm.TestCase):
 
     def test_getitem_dups_with_missing(self):
 
-        # breaks reindex, so need to use .ix internally
+        # breaks reindex, so need to use .loc internally
         # GH 4246
         s = Series([1, 2, 3, 4], ['foo', 'bar', 'foo', 'bah'])
-        expected = s.ix[['foo', 'bar', 'bah', 'bam']]
+        expected = s.loc[['foo', 'bar', 'bah', 'bam']]
         result = s[['foo', 'bar', 'bah', 'bam']]
         assert_series_equal(result, expected)
 
@@ -419,7 +419,7 @@ class TestSeriesIndexing(TestData, tm.TestCase):
         assert_series_equal(s2, expected)
 
         s2 = s.copy()
-        s2.ix[1] = 5
+        s2.loc[1] = 5
         expected = s.append(Series([5], index=[1]))
         assert_series_equal(s2, expected)
 
@@ -428,7 +428,7 @@ class TestSeriesIndexing(TestData, tm.TestCase):
         s = Series(['a', 'b', 'c'], index=[0, 0.5, 1])
         tmp = s.copy()
 
-        s.ix[1] = 'zoo'
+        s.loc[1] = 'zoo'
         tmp.iloc[2] = 'zoo'
 
         assert_series_equal(s, tmp)
@@ -490,14 +490,14 @@ class TestSeriesIndexing(TestData, tm.TestCase):
     def test_slice_floats2(self):
         s = Series(np.random.rand(10), index=np.arange(10, 20, dtype=float))
 
-        self.assertEqual(len(s.ix[12.0:]), 8)
-        self.assertEqual(len(s.ix[12.5:]), 7)
+        self.assertEqual(len(s.loc[12.0:]), 8)
+        self.assertEqual(len(s.loc[12.5:]), 7)
 
         i = np.arange(10, 20, dtype=float)
         i[2] = 12.2
         s.index = i
-        self.assertEqual(len(s.ix[12.0:]), 8)
-        self.assertEqual(len(s.ix[12.5:]), 7)
+        self.assertEqual(len(s.loc[12.0:]), 8)
+        self.assertEqual(len(s.loc[12.5:]), 7)
 
     def test_slice_float64(self):
 
@@ -635,7 +635,7 @@ class TestSeriesIndexing(TestData, tm.TestCase):
         assert_series_equal(result, expected)
 
         result = self.ts[indices[0]:indices[2]]
-        expected = self.ts.ix[indices[0]:indices[2]]
+        expected = self.ts.loc[indices[0]:indices[2]]
         assert_series_equal(result, expected)
 
         # integer indexes, be careful
@@ -668,13 +668,13 @@ class TestSeriesIndexing(TestData, tm.TestCase):
         cp = self.ts.copy()
         exp = self.ts.copy()
         cp[indices] = 0
-        exp.ix[indices] = 0
+        exp.loc[indices] = 0
         assert_series_equal(cp, exp)
 
         cp = self.ts.copy()
         exp = self.ts.copy()
         cp[indices[0]:indices[2]] = 0
-        exp.ix[indices[0]:indices[2]] = 0
+        exp.loc[indices[0]:indices[2]] = 0
         assert_series_equal(cp, exp)
 
         # integer indexes, be careful
@@ -685,13 +685,13 @@ class TestSeriesIndexing(TestData, tm.TestCase):
         cp = s.copy()
         exp = s.copy()
         s[inds] = 0
-        s.ix[inds] = 0
+        s.loc[inds] = 0
         assert_series_equal(cp, exp)
 
         cp = s.copy()
         exp = s.copy()
         s[arr_inds] = 0
-        s.ix[arr_inds] = 0
+        s.loc[arr_inds] = 0
         assert_series_equal(cp, exp)
 
         inds_notfound = [0, 4, 5, 6]
@@ -719,48 +719,48 @@ class TestSeriesIndexing(TestData, tm.TestCase):
         result = s2['a']
         self.assertEqual(result, expected)
 
-    def test_ix_getitem(self):
+    def test_loc_getitem(self):
         inds = self.series.index[[3, 4, 7]]
-        assert_series_equal(self.series.ix[inds], self.series.reindex(inds))
-        assert_series_equal(self.series.ix[5::2], self.series[5::2])
+        assert_series_equal(self.series.loc[inds], self.series.reindex(inds))
+        assert_series_equal(self.series.iloc[5::2], self.series[5::2])
 
         # slice with indices
         d1, d2 = self.ts.index[[5, 15]]
-        result = self.ts.ix[d1:d2]
+        result = self.ts.loc[d1:d2]
         expected = self.ts.truncate(d1, d2)
         assert_series_equal(result, expected)
 
         # boolean
         mask = self.series > self.series.median()
-        assert_series_equal(self.series.ix[mask], self.series[mask])
+        assert_series_equal(self.series.loc[mask], self.series[mask])
 
         # ask for index value
-        self.assertEqual(self.ts.ix[d1], self.ts[d1])
-        self.assertEqual(self.ts.ix[d2], self.ts[d2])
+        self.assertEqual(self.ts.loc[d1], self.ts[d1])
+        self.assertEqual(self.ts.loc[d2], self.ts[d2])
 
-    def test_ix_getitem_not_monotonic(self):
+    def test_loc_getitem_not_monotonic(self):
         d1, d2 = self.ts.index[[5, 15]]
 
         ts2 = self.ts[::2][[1, 2, 0]]
 
-        self.assertRaises(KeyError, ts2.ix.__getitem__, slice(d1, d2))
-        self.assertRaises(KeyError, ts2.ix.__setitem__, slice(d1, d2), 0)
+        self.assertRaises(KeyError, ts2.loc.__getitem__, slice(d1, d2))
+        self.assertRaises(KeyError, ts2.loc.__setitem__, slice(d1, d2), 0)
 
-    def test_ix_getitem_setitem_integer_slice_keyerrors(self):
+    def test_loc_getitem_setitem_integer_slice_keyerrors(self):
         s = Series(np.random.randn(10), index=lrange(0, 20, 2))
 
         # this is OK
         cp = s.copy()
-        cp.ix[4:10] = 0
-        self.assertTrue((cp.ix[4:10] == 0).all())
+        cp.iloc[4:10] = 0
+        self.assertTrue((cp.iloc[4:10] == 0).all())
 
         # so is this
         cp = s.copy()
-        cp.ix[3:11] = 0
-        self.assertTrue((cp.ix[3:11] == 0).values.all())
+        cp.iloc[3:11] = 0
+        self.assertTrue((cp.iloc[3:11] == 0).values.all())
 
-        result = s.ix[4:10]
-        result2 = s.ix[3:11]
+        result = s.iloc[2:6]
+        result2 = s.loc[3:11]
         expected = s.reindex([4, 6, 8, 10])
 
         assert_series_equal(result, expected)
@@ -768,12 +768,12 @@ class TestSeriesIndexing(TestData, tm.TestCase):
 
         # non-monotonic, raise KeyError
         s2 = s.iloc[lrange(5) + lrange(5, 10)[::-1]]
-        self.assertRaises(KeyError, s2.ix.__getitem__, slice(3, 11))
-        self.assertRaises(KeyError, s2.ix.__setitem__, slice(3, 11), 0)
+        self.assertRaises(KeyError, s2.loc.__getitem__, slice(3, 11))
+        self.assertRaises(KeyError, s2.loc.__setitem__, slice(3, 11), 0)
 
-    def test_ix_getitem_iterator(self):
+    def test_loc_getitem_iterator(self):
         idx = iter(self.series.index[:10])
-        result = self.series.ix[idx]
+        result = self.series.loc[idx]
         assert_series_equal(result, self.series[:10])
 
     def test_setitem_with_tz(self):
@@ -883,7 +883,7 @@ class TestSeriesIndexing(TestData, tm.TestCase):
         assert_series_equal(rs, expected)
 
         expected = s2.abs()
-        expected.ix[0] = s2[0]
+        expected.iloc[0] = s2[0]
         rs = s2.where(cond[:3], -s2)
         assert_series_equal(rs, expected)
 
@@ -1228,25 +1228,25 @@ class TestSeriesIndexing(TestData, tm.TestCase):
         inds = self.series.index[[3, 4, 7]]
 
         result = self.series.copy()
-        result.ix[inds] = 5
+        result.loc[inds] = 5
 
         expected = self.series.copy()
         expected[[3, 4, 7]] = 5
         assert_series_equal(result, expected)
 
-        result.ix[5:10] = 10
+        result.iloc[5:10] = 10
         expected[5:10] = 10
         assert_series_equal(result, expected)
 
         # set slice with indices
         d1, d2 = self.series.index[[5, 15]]
-        result.ix[d1:d2] = 6
+        result.loc[d1:d2] = 6
         expected[5:16] = 6  # because it's inclusive
         assert_series_equal(result, expected)
 
         # set index value
-        self.series.ix[d1] = 4
-        self.series.ix[d2] = 6
+        self.series.loc[d1] = 4
+        self.series.loc[d2] = 6
         self.assertEqual(self.series[d1], 4)
         self.assertEqual(self.series[d2], 6)
 
@@ -1295,15 +1295,15 @@ class TestSeriesIndexing(TestData, tm.TestCase):
         mask = self.series > self.series.median()
 
         result = self.series.copy()
-        result.ix[mask] = 0
+        result.loc[mask] = 0
         expected = self.series
         expected[mask] = 0
         assert_series_equal(result, expected)
 
     def test_ix_setitem_corner(self):
         inds = list(self.series.index[[5, 8, 12]])
-        self.series.ix[inds] = 5
-        self.assertRaises(Exception, self.series.ix.__setitem__,
+        self.series.loc[inds] = 5
+        self.assertRaises(Exception, self.series.loc.__setitem__,
                           inds + ['foo'], 5)
 
     def test_get_set_boolean_different_order(self):
@@ -1494,7 +1494,7 @@ class TestSeriesIndexing(TestData, tm.TestCase):
         result = s.drop('bc', errors='ignore')
         assert_series_equal(result, s)
         result = s.drop(['a', 'd'], errors='ignore')
-        expected = s.ix[1:]
+        expected = s.iloc[1:]
         assert_series_equal(result, expected)
 
         # bad axis
@@ -1943,7 +1943,7 @@ class TestSeriesIndexing(TestData, tm.TestCase):
         s = Series(np.random.randn(len(index)), index=index, name='sth')
 
         result = s['foo']
-        result2 = s.ix['foo']
+        result2 = s.loc['foo']
         self.assertEqual(result.name, s.name)
         self.assertEqual(result2.name, s.name)
 

--- a/pandas/tests/series/test_repr.py
+++ b/pandas/tests/series/test_repr.py
@@ -178,5 +178,5 @@ class TestSeriesRepr(TestData, tm.TestCase):
         ts = tm.makeTimeSeries(1000)
         self.assertTrue(repr(ts).splitlines()[-1].startswith('Freq:'))
 
-        ts2 = ts.ix[np.random.randint(0, len(ts) - 1, 400)]
+        ts2 = ts.iloc[np.random.randint(0, len(ts) - 1, 400)]
         repr(ts2).splitlines()[-1]

--- a/pandas/tests/series/test_subclass.py
+++ b/pandas/tests/series/test_subclass.py
@@ -22,7 +22,7 @@ class TestSeriesSubclassing(tm.TestCase):
         tm.assert_series_equal(res, exp)
         tm.assertIsInstance(res, tm.SubclassedSeries)
 
-        res = s.ix[['a', 'b']]
+        res = s.loc[['a', 'b']]
         exp = tm.SubclassedSeries([1, 2], index=list('ab'))
         tm.assert_series_equal(res, exp)
         tm.assertIsInstance(res, tm.SubclassedSeries)

--- a/pandas/tests/test_categorical.py
+++ b/pandas/tests/test_categorical.py
@@ -3367,23 +3367,23 @@ Categories (10, timedelta64[ns]): [0 days 01:00:00 < 1 days 01:00:00 < 2 days 01
 
         # ix
         # frame
-        # res_df = df.ix["j":"k",[0,1]] # doesn't work?
-        res_df = df.ix["j":"k", :]
+        # res_df = df.loc["j":"k",[0,1]] # doesn't work?
+        res_df = df.loc["j":"k", :]
         tm.assert_frame_equal(res_df, exp_df)
         self.assertTrue(is_categorical_dtype(res_df["cats"]))
 
         # row
-        res_row = df.ix["j", :]
+        res_row = df.loc["j", :]
         tm.assert_series_equal(res_row, exp_row)
         tm.assertIsInstance(res_row["cats"], compat.string_types)
 
         # col
-        res_col = df.ix[:, "cats"]
+        res_col = df.loc[:, "cats"]
         tm.assert_series_equal(res_col, exp_col)
         self.assertTrue(is_categorical_dtype(res_col))
 
         # single value
-        res_val = df.ix["j", 0]
+        res_val = df.loc["j", df.columns[0]]
         self.assertEqual(res_val, exp_val)
 
         # iat
@@ -3456,7 +3456,7 @@ Categories (10, timedelta64[ns]): [0 days 01:00:00 < 1 days 01:00:00 < 2 days 01
                           index=['h', 'i', 'j'], name='cats')
         tm.assert_series_equal(result, expected)
 
-        result = df.ix["h":"j", 0:1]
+        result = df.loc["h":"j", df.columns[0:1]]
         expected = DataFrame({'cats': Categorical(['a', 'b', 'b'],
                                                   categories=['a', 'b', 'c'])},
                              index=['h', 'i', 'j'])
@@ -3657,73 +3657,73 @@ Categories (10, timedelta64[ns]): [0 days 01:00:00 < 1 days 01:00:00 < 2 days 01
         with tm.assertRaises(ValueError):
             df.loc["j":"k", "cats"] = ["c", "c"]
 
-        #  ix
+        #  loc
         # ##############
         #   - assign a single value -> exp_single_cats_value
         df = orig.copy()
-        df.ix["j", 0] = "b"
+        df.loc["j", df.columns[0]] = "b"
         tm.assert_frame_equal(df, exp_single_cats_value)
 
         df = orig.copy()
-        df.ix[df.index == "j", 0] = "b"
+        df.loc[df.index == "j", df.columns[0]] = "b"
         tm.assert_frame_equal(df, exp_single_cats_value)
 
         #   - assign a single value not in the current categories set
         def f():
             df = orig.copy()
-            df.ix["j", 0] = "c"
+            df.loc["j", df.columns[0]] = "c"
 
         self.assertRaises(ValueError, f)
 
         #   - assign a complete row (mixed values) -> exp_single_row
         df = orig.copy()
-        df.ix["j", :] = ["b", 2]
+        df.loc["j", :] = ["b", 2]
         tm.assert_frame_equal(df, exp_single_row)
 
         #   - assign a complete row (mixed values) not in categories set
         def f():
             df = orig.copy()
-            df.ix["j", :] = ["c", 2]
+            df.loc["j", :] = ["c", 2]
 
         self.assertRaises(ValueError, f)
 
         #   - assign multiple rows (mixed values) -> exp_multi_row
         df = orig.copy()
-        df.ix["j":"k", :] = [["b", 2], ["b", 2]]
+        df.loc["j":"k", :] = [["b", 2], ["b", 2]]
         tm.assert_frame_equal(df, exp_multi_row)
 
         def f():
             df = orig.copy()
-            df.ix["j":"k", :] = [["c", 2], ["c", 2]]
+            df.loc["j":"k", :] = [["c", 2], ["c", 2]]
 
         self.assertRaises(ValueError, f)
 
         # assign a part of a column with dtype == categorical ->
         # exp_parts_cats_col
         df = orig.copy()
-        df.ix["j":"k", 0] = pd.Categorical(["b", "b"], categories=["a", "b"])
+        df.loc["j":"k", df.columns[0]] = pd.Categorical(["b", "b"], categories=["a", "b"])
         tm.assert_frame_equal(df, exp_parts_cats_col)
 
         with tm.assertRaises(ValueError):
             # different categories -> not sure if this should fail or pass
             df = orig.copy()
-            df.ix["j":"k", 0] = pd.Categorical(
+            df.loc["j":"k", df.columns[0]] = pd.Categorical(
                 ["b", "b"], categories=["a", "b", "c"])
 
         with tm.assertRaises(ValueError):
             # different values
             df = orig.copy()
-            df.ix["j":"k", 0] = pd.Categorical(["c", "c"],
-                                               categories=["a", "b", "c"])
+            df.loc["j":"k", df.columns[0]] = pd.Categorical(
+                ["c", "c"], categories=["a", "b", "c"])
 
         # assign a part of a column with dtype != categorical ->
         # exp_parts_cats_col
         df = orig.copy()
-        df.ix["j":"k", 0] = ["b", "b"]
+        df.loc["j":"k", df.columns[0]] = ["b", "b"]
         tm.assert_frame_equal(df, exp_parts_cats_col)
 
         with tm.assertRaises(ValueError):
-            df.ix["j":"k", 0] = ["c", "c"]
+            df.loc["j":"k", df.columns[0]] = ["c", "c"]
 
         # iat
         df = orig.copy()

--- a/pandas/tests/test_generic.py
+++ b/pandas/tests/test_generic.py
@@ -1119,7 +1119,7 @@ class TestDataFrame(tm.TestCase, Generic):
         desc = df[df[0] < 0].describe()  # works
         assert_series_equal(desc.xs('count'),
                             Series([0, 0], dtype=float, name='count'))
-        self.assertTrue(isnull(desc.ix[1:]).all().all())
+        self.assertTrue(isnull(desc.iloc[1:]).all().all())
 
     def test_describe_objects(self):
         df = DataFrame({"C1": ['a', 'a', 'c'], "C2": ['d', 'd', 'f']})
@@ -1751,7 +1751,7 @@ class TestNDFrame(tm.TestCase):
         tm.assert_frame_equal(p.squeeze(), p['ItemA'])
 
         p = tm.makePanel().reindex(items=['ItemA'], minor_axis=['A'])
-        tm.assert_series_equal(p.squeeze(), p.ix['ItemA', :, 'A'])
+        tm.assert_series_equal(p.squeeze(), p.loc['ItemA', :, 'A'])
 
         with tm.assert_produces_warning(FutureWarning, check_stacklevel=False):
             p4d = tm.makePanel4D().reindex(labels=['label1'])
@@ -1759,7 +1759,7 @@ class TestNDFrame(tm.TestCase):
 
         with tm.assert_produces_warning(FutureWarning, check_stacklevel=False):
             p4d = tm.makePanel4D().reindex(labels=['label1'], items=['ItemA'])
-            tm.assert_frame_equal(p4d.squeeze(), p4d.ix['label1', 'ItemA'])
+            tm.assert_frame_equal(p4d.squeeze(), p4d.loc['label1', 'ItemA'])
 
         # don't fail with 0 length dimensions GH11229 & GH8999
         empty_series = pd.Series([], name='five')
@@ -1915,7 +1915,7 @@ class TestNDFrame(tm.TestCase):
         df1['end'] = date_range('2000-1-1', periods=10, freq='D')
         df1['diff'] = df1['end'] - df1['start']
         df1['bool'] = (np.arange(10) % 3 == 0)
-        df1.ix[::2] = nan
+        df1.loc[::2] = nan
         df2 = df1.copy()
         self.assertTrue(df1['text'].equals(df2['text']))
         self.assertTrue(df1['start'].equals(df2['start']))

--- a/pandas/tests/test_internals.py
+++ b/pandas/tests/test_internals.py
@@ -822,7 +822,7 @@ class TestBlockManager(tm.TestCase):
     def test_missing_unicode_key(self):
         df = DataFrame({"a": [1]})
         try:
-            df.ix[:, u("\u05d0")]  # should not raise UnicodeEncodeError
+            df.loc[:, u("\u05d0")]  # should not raise UnicodeEncodeError
         except KeyError:
             pass  # this is the expected exception
 

--- a/pandas/tests/test_multilevel.py
+++ b/pandas/tests/test_multilevel.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 # pylint: disable-msg=W0612,E1101,W0141
+from warnings import catch_warnings
 import datetime
 import itertools
 import nose
@@ -188,8 +189,12 @@ class TestMultiLevel(tm.TestCase):
         _test_roundtrip(self.ymd.T)
 
     def test_reindex(self):
-        reindexed = self.frame.ix[[('foo', 'one'), ('bar', 'one')]]
-        expected = self.frame.ix[[0, 3]]
+        expected = self.frame.iloc[[0, 3]]
+        reindexed = self.frame.loc[[('foo', 'one'), ('bar', 'one')]]
+        assert_frame_equal(reindexed, expected)
+
+        with catch_warnings(record=True):
+            reindexed = self.frame.ix[[('foo', 'one'), ('bar', 'one')]]
         assert_frame_equal(reindexed, expected)
 
     def test_reindex_preserve_levels(self):
@@ -197,14 +202,18 @@ class TestMultiLevel(tm.TestCase):
         chunk = self.ymd.reindex(new_index)
         self.assertIs(chunk.index, new_index)
 
-        chunk = self.ymd.ix[new_index]
+        chunk = self.ymd.loc[new_index]
+        self.assertIs(chunk.index, new_index)
+
+        with catch_warnings(record=True):
+            chunk = self.ymd.ix[new_index]
         self.assertIs(chunk.index, new_index)
 
         ymdT = self.ymd.T
         chunk = ymdT.reindex(columns=new_index)
         self.assertIs(chunk.columns, new_index)
 
-        chunk = ymdT.ix[:, new_index]
+        chunk = ymdT.loc[:, new_index]
         self.assertIs(chunk.columns, new_index)
 
     def test_sort_index_preserve_levels(self):
@@ -286,7 +295,7 @@ class TestMultiLevel(tm.TestCase):
         result = s[2000, 3]
 
         # TODO(wesm): unused?
-        # result2 = s.ix[2000, 3]
+        # result2 = s.loc[2000, 3]
 
         expected = s.reindex(s.index[42:65])
         expected.index = expected.index.droplevel(0).droplevel(0)
@@ -297,8 +306,12 @@ class TestMultiLevel(tm.TestCase):
         self.assertEqual(result, expected)
 
         # fancy
-        result = s.ix[[(2000, 3, 10), (2000, 3, 13)]]
         expected = s.reindex(s.index[49:51])
+        result = s.loc[[(2000, 3, 10), (2000, 3, 13)]]
+        assert_series_equal(result, expected)
+
+        with catch_warnings(record=True):
+            result = s.ix[[(2000, 3, 10), (2000, 3, 13)]]
         assert_series_equal(result, expected)
 
         # key error
@@ -356,13 +369,13 @@ class TestMultiLevel(tm.TestCase):
 
     def test_frame_getitem_setitem_slice(self):
         # getitem
-        result = self.frame.ix[:4]
+        result = self.frame.iloc[:4]
         expected = self.frame[:4]
         assert_frame_equal(result, expected)
 
         # setitem
         cp = self.frame.copy()
-        cp.ix[:4] = 0
+        cp.iloc[:4] = 0
 
         self.assertTrue((cp.values[:4] == 0).all())
         self.assertTrue((cp.values[4:] != 0).all())
@@ -373,21 +386,25 @@ class TestMultiLevel(tm.TestCase):
         midx = MultiIndex(labels=labels, levels=levels, names=[None, 'id'])
         df = DataFrame({'value': [1, 2, 3, 7, 8]}, index=midx)
 
-        result = df.ix[:, 'value']
+        result = df.loc[:, 'value']
         assert_series_equal(df['value'], result)
 
-        result = df.ix[1:3, 'value']
+        with catch_warnings(record=True):
+            result = df.ix[:, 'value']
+        assert_series_equal(df['value'], result)
+
+        result = df.loc[df.index[1:3], 'value']
         assert_series_equal(df['value'][1:3], result)
 
-        result = df.ix[:, :]
+        result = df.loc[:, :]
         assert_frame_equal(df, result)
 
         result = df
-        df.ix[:, 'value'] = 10
+        df.loc[:, 'value'] = 10
         result['value'] = 10
         assert_frame_equal(df, result)
 
-        df.ix[:, :] = 10
+        df.loc[:, :] = 10
         assert_frame_equal(df, result)
 
     def test_frame_getitem_multicolumn_empty_level(self):
@@ -444,20 +461,23 @@ class TestMultiLevel(tm.TestCase):
 
         idf = df.set_index(['a', 'b'])
 
-        result = idf.ix[(0, 0), :]
-        expected = idf.ix[0, 0]
+        result = idf.loc[(0, 0), :]
+        expected = idf.loc[0, 0]
         expected2 = idf.xs((0, 0))
+        with catch_warnings(record=True):
+            expected3 = idf.ix[0, 0]
 
         assert_series_equal(result, expected)
         assert_series_equal(result, expected2)
+        assert_series_equal(result, expected3)
 
     def test_getitem_setitem_tuple_plus_columns(self):
         # GH #1013
 
         df = self.ymd[:5]
 
-        result = df.ix[(2000, 1, 6), ['A', 'B', 'C']]
-        expected = df.ix[2000, 1, 6][['A', 'B', 'C']]
+        result = df.loc[(2000, 1, 6), ['A', 'B', 'C']]
+        expected = df.loc[2000, 1, 6][['A', 'B', 'C']]
         assert_series_equal(result, expected)
 
     def test_getitem_multilevel_index_tuple_unsorted(self):
@@ -466,7 +486,7 @@ class TestMultiLevel(tm.TestCase):
                        columns=index_columns + ["data"])
         df = df.set_index(index_columns)
         query_index = df.index[:1]
-        rs = df.ix[query_index, "data"]
+        rs = df.loc[query_index, "data"]
 
         xp_idx = MultiIndex.from_tuples([(0, 1, 0)], names=['a', 'b', 'c'])
         xp = Series(['x'], index=xp_idx, name='data')
@@ -474,7 +494,7 @@ class TestMultiLevel(tm.TestCase):
 
     def test_xs(self):
         xs = self.frame.xs(('bar', 'two'))
-        xs2 = self.frame.ix[('bar', 'two')]
+        xs2 = self.frame.loc[('bar', 'two')]
 
         assert_series_equal(xs, xs2)
         assert_almost_equal(xs.values, self.frame.values[4])
@@ -500,13 +520,13 @@ class TestMultiLevel(tm.TestCase):
 
     def test_xs_partial(self):
         result = self.frame.xs('foo')
-        result2 = self.frame.ix['foo']
+        result2 = self.frame.loc['foo']
         expected = self.frame.T['foo'].T
         assert_frame_equal(result, expected)
         assert_frame_equal(result, result2)
 
         result = self.ymd.xs((2000, 4))
-        expected = self.ymd.ix[2000, 4]
+        expected = self.ymd.loc[2000, 4]
         assert_frame_equal(result, expected)
 
         # ex from #1796
@@ -518,7 +538,7 @@ class TestMultiLevel(tm.TestCase):
                        columns=list('abcd'))
 
         result = df.xs(['foo', 'one'])
-        expected = df.ix['foo', 'one']
+        expected = df.loc['foo', 'one']
         assert_frame_equal(result, expected)
 
     def test_xs_level(self):
@@ -576,8 +596,9 @@ x   q   30      3    -0.6662 -0.5243 -0.3580  0.89145  2.5838"""
         idx = MultiIndex.from_tuples([x for x in cart_product(dates, ids)])
         idx.names = ['date', 'secid']
         df = DataFrame(np.random.randn(len(idx), 3), idx, ['X', 'Y', 'Z'])
+
         rs = df.xs(20111201, level='date')
-        xp = df.ix[20111201, :]
+        xp = df.loc[20111201, :]
         assert_frame_equal(rs, xp)
 
     def test_xs_level0(self):
@@ -603,7 +624,7 @@ x   q   30      3    -0.6662 -0.5243 -0.3580  0.89145  2.5838"""
 
         s = self.ymd['A']
         result = s[2000, 5]
-        expected = self.ymd.ix[2000, 5]['A']
+        expected = self.ymd.loc[2000, 5]['A']
         assert_series_equal(result, expected)
 
         # not implementing this for now
@@ -633,7 +654,7 @@ x   q   30      3    -0.6662 -0.5243 -0.3580  0.89145  2.5838"""
         assert_frame_equal(result, expected)
 
         result = df['bar']
-        result2 = df.ix[:, 'bar']
+        result2 = df.loc[:, 'bar']
 
         expected = df.reindex(columns=df.columns[3:5])
         expected.columns = expected.columns.droplevel(0)
@@ -646,21 +667,21 @@ x   q   30      3    -0.6662 -0.5243 -0.3580  0.89145  2.5838"""
 
         frame = DataFrame(np.random.randn(len(index), 4), index=index,
                           columns=['a', 'b', 'c', 'd'])
-        res = frame.ix[1:2]
+        res = frame.loc[1:2]
         exp = frame.reindex(frame.index[2:])
         assert_frame_equal(res, exp)
 
-        frame.ix[1:2] = 7
-        self.assertTrue((frame.ix[1:2] == 7).values.all())
+        frame.loc[1:2] = 7
+        self.assertTrue((frame.loc[1:2] == 7).values.all())
 
         series = Series(np.random.randn(len(index)), index=index)
 
-        res = series.ix[1:2]
+        res = series.loc[1:2]
         exp = series.reindex(series.index[2:])
         assert_series_equal(res, exp)
 
-        series.ix[1:2] = 7
-        self.assertTrue((series.ix[1:2] == 7).values.all())
+        series.loc[1:2] = 7
+        self.assertTrue((series.loc[1:2] == 7).values.all())
 
     def test_getitem_int(self):
         levels = [[0, 1], [0, 1, 2]]
@@ -669,16 +690,16 @@ x   q   30      3    -0.6662 -0.5243 -0.3580  0.89145  2.5838"""
 
         frame = DataFrame(np.random.randn(6, 2), index=index)
 
-        result = frame.ix[1]
+        result = frame.loc[1]
         expected = frame[-3:]
         expected.index = expected.index.droplevel(0)
         assert_frame_equal(result, expected)
 
         # raises exception
-        self.assertRaises(KeyError, frame.ix.__getitem__, 3)
+        self.assertRaises(KeyError, frame.loc.__getitem__, 3)
 
         # however this will work
-        result = self.frame.ix[2]
+        result = self.frame.iloc[2]
         expected = self.frame.xs(self.frame.index[2])
         assert_series_equal(result, expected)
 
@@ -694,7 +715,7 @@ x   q   30      3    -0.6662 -0.5243 -0.3580  0.89145  2.5838"""
         df = self.frame.sort_index(level=1).T
 
         # buglet with int typechecking
-        result = df.ix[:, :np.int32(3)]
+        result = df.iloc[:, :np.int32(3)]
         expected = df.reindex(columns=df.columns[:3])
         assert_frame_equal(result, expected)
 
@@ -709,21 +730,27 @@ x   q   30      3    -0.6662 -0.5243 -0.3580  0.89145  2.5838"""
         assert_series_equal(reindexed['foo', 'two'], s > s.median())
 
     def test_frame_setitem_ix(self):
-        self.frame.ix[('bar', 'two'), 'B'] = 5
-        self.assertEqual(self.frame.ix[('bar', 'two'), 'B'], 5)
+        self.frame.loc[('bar', 'two'), 'B'] = 5
+        self.assertEqual(self.frame.loc[('bar', 'two'), 'B'], 5)
 
         # with integer labels
         df = self.frame.copy()
         df.columns = lrange(3)
-        df.ix[('bar', 'two'), 1] = 7
-        self.assertEqual(df.ix[('bar', 'two'), 1], 7)
+        df.loc[('bar', 'two'), 1] = 7
+        self.assertEqual(df.loc[('bar', 'two'), 1], 7)
+
+        with catch_warnings(record=True):
+            df = self.frame.copy()
+            df.columns = lrange(3)
+            df.ix[('bar', 'two'), 1] = 7
+        self.assertEqual(df.loc[('bar', 'two'), 1], 7)
 
     def test_fancy_slice_partial(self):
-        result = self.frame.ix['bar':'baz']
+        result = self.frame.loc['bar':'baz']
         expected = self.frame[3:7]
         assert_frame_equal(result, expected)
 
-        result = self.ymd.ix[(2000, 2):(2000, 4)]
+        result = self.ymd.loc[(2000, 2):(2000, 4)]
         lev = self.ymd.index.labels[1]
         expected = self.ymd[(lev >= 1) & (lev <= 3)]
         assert_frame_equal(result, expected)
@@ -733,15 +760,19 @@ x   q   30      3    -0.6662 -0.5243 -0.3580  0.89145  2.5838"""
                          levels=[['a', 'b'], ['x', 'y'], ['p', 'q']])
         df = DataFrame(np.random.rand(3, 2), index=idx)
 
-        result = df.ix[('a', 'y'), :]
-        expected = df.ix[('a', 'y')]
+        result = df.loc[('a', 'y'), :]
+        expected = df.loc[('a', 'y')]
         assert_frame_equal(result, expected)
 
-        result = df.ix[('a', 'y'), [1, 0]]
-        expected = df.ix[('a', 'y')][[1, 0]]
+        result = df.loc[('a', 'y'), [1, 0]]
+        expected = df.loc[('a', 'y')][[1, 0]]
         assert_frame_equal(result, expected)
 
-        self.assertRaises(KeyError, df.ix.__getitem__,
+        with catch_warnings(record=True):
+            result = df.ix[('a', 'y'), [1, 0]]
+        assert_frame_equal(result, expected)
+
+        self.assertRaises(KeyError, df.loc.__getitem__,
                           (('a', 'foo'), slice(None, None)))
 
     def test_sort_index_level(self):
@@ -834,10 +865,10 @@ x   q   30      3    -0.6662 -0.5243 -0.3580  0.89145  2.5838"""
                 expected = expected.reindex_like(result).astype('i8')
                 assert_frame_equal(result, expected)
 
-        self.frame.ix[1, [1, 2]] = np.nan
-        self.frame.ix[7, [0, 1]] = np.nan
-        self.ymd.ix[1, [1, 2]] = np.nan
-        self.ymd.ix[7, [0, 1]] = np.nan
+        self.frame.iloc[1, [1, 2]] = np.nan
+        self.frame.iloc[7, [0, 1]] = np.nan
+        self.ymd.iloc[1, [1, 2]] = np.nan
+        self.ymd.iloc[7, [0, 1]] = np.nan
 
         _check_counts(self.frame)
         _check_counts(self.ymd)
@@ -953,7 +984,7 @@ x   q   30      3    -0.6662 -0.5243 -0.3580  0.89145  2.5838"""
         assert_frame_equal(result, expected)
 
         # not all levels present in each echelon
-        unstacked = self.ymd.unstack(2).ix[:, ::3]
+        unstacked = self.ymd.unstack(2).loc[:, ::3]
         stacked = unstacked.stack().stack()
         ymd_stacked = self.ymd.stack()
         assert_series_equal(stacked, ymd_stacked.reindex(stacked.index))
@@ -1096,7 +1127,7 @@ Thur,Lunch,Yes,51.51,17"""
 
         unstacked = self.ymd.unstack([2, 1])
         expected = self.ymd.unstack(2).unstack(1).dropna(axis=1, how='all')
-        assert_frame_equal(unstacked, expected.ix[:, unstacked.columns])
+        assert_frame_equal(unstacked, expected.loc[:, unstacked.columns])
 
     def test_stack_names_and_numbers(self):
         unstacked = self.ymd.unstack(['year', 'month'])
@@ -1214,7 +1245,7 @@ Thur,Lunch,Yes,51.51,17"""
         down = unst.resample('W-THU').mean()
 
         rs = down.stack('ID')
-        xp = unst.ix[:, ['VAR1']].resample('W-THU').mean().stack('ID')
+        xp = unst.loc[:, ['VAR1']].resample('W-THU').mean().stack('ID')
         xp.columns.name = 'Params'
         assert_frame_equal(rs, xp)
 
@@ -1306,8 +1337,8 @@ Thur,Lunch,Yes,51.51,17"""
         self.assertTrue((result.columns == ['f2', 'f3']).all())
 
     def test_join(self):
-        a = self.frame.ix[:5, ['A']]
-        b = self.frame.ix[2:, ['B', 'C']]
+        a = self.frame.loc[self.frame.index[:5], ['A']]
+        b = self.frame.loc[self.frame.index[2:], ['B', 'C']]
 
         joined = a.join(b, how='outer').reindex(self.frame.index)
         expected = self.frame.copy()
@@ -1443,7 +1474,7 @@ Thur,Lunch,Yes,51.51,17"""
         arrays = [np.array(x) for x in zip(*df.columns._tuple_index)]
 
         result = df['foo']
-        result2 = df.ix[:, 'foo']
+        result2 = df.loc[:, 'foo']
         expected = df.reindex(columns=df.columns[arrays[0] == 'foo'])
         expected.columns = expected.columns.droplevel(0)
         assert_frame_equal(result, expected)
@@ -1451,7 +1482,7 @@ Thur,Lunch,Yes,51.51,17"""
 
         df = df.T
         result = df.xs('foo')
-        result2 = df.ix['foo']
+        result2 = df.loc['foo']
         expected = df.reindex(df.index[arrays[0] == 'foo'])
         expected.index = expected.index.droplevel(0)
         assert_frame_equal(result, expected)
@@ -1467,7 +1498,7 @@ Thur,Lunch,Yes,51.51,17"""
         arrays = [np.array(x) for x in zip(*index._tuple_index)]
 
         result = s['qux']
-        result2 = s.ix['qux']
+        result2 = s.loc['qux']
         expected = s[arrays[0] == 'qux']
         expected.index = expected.index.droplevel(0)
         assert_series_equal(result, expected)
@@ -1515,8 +1546,8 @@ Thur,Lunch,Yes,51.51,17"""
             assert_series_equal(leftside, rightside)
 
     def test_frame_group_ops(self):
-        self.frame.ix[1, [1, 2]] = np.nan
-        self.frame.ix[7, [0, 1]] = np.nan
+        self.frame.iloc[1, [1, 2]] = np.nan
+        self.frame.iloc[7, [0, 1]] = np.nan
 
         for op, level, axis, skipna in cart_product(self.AGG_FUNCTIONS,
                                                     lrange(2), lrange(2),
@@ -1620,13 +1651,13 @@ Thur,Lunch,Yes,51.51,17"""
         df = df.consolidate()
 
     def test_ix_preserve_names(self):
-        result = self.ymd.ix[2000]
-        result2 = self.ymd['A'].ix[2000]
+        result = self.ymd.loc[2000]
+        result2 = self.ymd['A'].loc[2000]
         self.assertEqual(result.index.names, self.ymd.index.names[1:])
         self.assertEqual(result2.index.names, self.ymd.index.names[1:])
 
-        result = self.ymd.ix[2000, 2]
-        result2 = self.ymd['A'].ix[2000, 2]
+        result = self.ymd.loc[2000, 2]
+        result2 = self.ymd['A'].loc[2000, 2]
         self.assertEqual(result.index.name, self.ymd.index.names[2])
         self.assertEqual(result2.index.name, self.ymd.index.names[2])
 
@@ -1634,20 +1665,20 @@ Thur,Lunch,Yes,51.51,17"""
         # GH #397
         df = self.ymd.copy()
         exp = self.ymd.copy()
-        df.ix[2000, 4] = 0
-        exp.ix[2000, 4].values[:] = 0
+        df.loc[2000, 4] = 0
+        exp.loc[2000, 4].values[:] = 0
         assert_frame_equal(df, exp)
 
-        df['A'].ix[2000, 4] = 1
-        exp['A'].ix[2000, 4].values[:] = 1
+        df['A'].loc[2000, 4] = 1
+        exp['A'].loc[2000, 4].values[:] = 1
         assert_frame_equal(df, exp)
 
-        df.ix[2000] = 5
-        exp.ix[2000].values[:] = 5
+        df.loc[2000] = 5
+        exp.loc[2000].values[:] = 5
         assert_frame_equal(df, exp)
 
         # this works...for now
-        df['A'].ix[14] = 5
+        df['A'].iloc[14] = 5
         self.assertEqual(df['A'][14], 5)
 
     def test_unstack_preserve_types(self):
@@ -1693,12 +1724,12 @@ Thur,Lunch,Yes,51.51,17"""
         self.assertEqual(result.shape, (500, 2))
 
     def test_getitem_lowerdim_corner(self):
-        self.assertRaises(KeyError, self.frame.ix.__getitem__,
+        self.assertRaises(KeyError, self.frame.loc.__getitem__,
                           (('bar', 'three'), 'B'))
 
         # in theory should be inserting in a sorted space????
-        self.frame.ix[('bar', 'three'), 'B'] = 0
-        self.assertEqual(self.frame.sort_index().ix[('bar', 'three'), 'B'], 0)
+        self.frame.loc[('bar', 'three'), 'B'] = 0
+        self.assertEqual(self.frame.sort_index().loc[('bar', 'three'), 'B'], 0)
 
     # ---------------------------------------------------------------------
     # AMBIGUOUS CASES!
@@ -1706,18 +1737,18 @@ Thur,Lunch,Yes,51.51,17"""
     def test_partial_ix_missing(self):
         raise nose.SkipTest("skipping for now")
 
-        result = self.ymd.ix[2000, 0]
-        expected = self.ymd.ix[2000]['A']
+        result = self.ymd.loc[2000, 0]
+        expected = self.ymd.loc[2000]['A']
         assert_series_equal(result, expected)
 
         # need to put in some work here
 
-        # self.ymd.ix[2000, 0] = 0
-        # self.assertTrue((self.ymd.ix[2000]['A'] == 0).all())
+        # self.ymd.loc[2000, 0] = 0
+        # self.assertTrue((self.ymd.loc[2000]['A'] == 0).all())
 
         # Pretty sure the second (and maybe even the first) is already wrong.
-        self.assertRaises(Exception, self.ymd.ix.__getitem__, (2000, 6))
-        self.assertRaises(Exception, self.ymd.ix.__getitem__, (2000, 6), 0)
+        self.assertRaises(Exception, self.ymd.loc.__getitem__, (2000, 6))
+        self.assertRaises(Exception, self.ymd.loc.__getitem__, (2000, 6), 0)
 
     # ---------------------------------------------------------------------
 
@@ -1735,7 +1766,7 @@ Thur,Lunch,Yes,51.51,17"""
         frame = DataFrame(np.random.randn(6, 4), index=index)
 
         result = series[('foo', 'bar', 0)]
-        result2 = series.ix[('foo', 'bar', 0)]
+        result2 = series.loc[('foo', 'bar', 0)]
         expected = series[:2]
         expected.index = expected.index.droplevel(0)
         assert_series_equal(result, expected)
@@ -1743,7 +1774,7 @@ Thur,Lunch,Yes,51.51,17"""
 
         self.assertRaises(KeyError, series.__getitem__, (('foo', 'bar', 0), 2))
 
-        result = frame.ix[('foo', 'bar', 0)]
+        result = frame.loc[('foo', 'bar', 0)]
         result2 = frame.xs(('foo', 'bar', 0))
         expected = frame[:2]
         expected.index = expected.index.droplevel(0)
@@ -1758,13 +1789,13 @@ Thur,Lunch,Yes,51.51,17"""
         frame = DataFrame(np.random.randn(6, 4), index=index)
 
         result = series[('foo', 'bar')]
-        result2 = series.ix[('foo', 'bar')]
+        result2 = series.loc[('foo', 'bar')]
         expected = series[:2]
         expected.index = expected.index.droplevel(0)
         assert_series_equal(result, expected)
         assert_series_equal(result2, expected)
 
-        result = frame.ix[('foo', 'bar')]
+        result = frame.loc[('foo', 'bar')]
         result2 = frame.xs(('foo', 'bar'))
         expected = frame[:2]
         expected.index = expected.index.droplevel(0)
@@ -1859,7 +1890,7 @@ Thur,Lunch,Yes,51.51,17"""
                        columns=["var1", "var2", "var3", "var4"])
 
         grp_size = df.groupby("var1").size()
-        drop_idx = grp_size.ix[grp_size == 1]
+        drop_idx = grp_size.loc[grp_size == 1]
 
         idf = df.set_index(["var1", "var2", "var3"])
 
@@ -1896,65 +1927,65 @@ Thur,Lunch,Yes,51.51,17"""
 
     def test_reindex_level_partial_selection(self):
         result = self.frame.reindex(['foo', 'qux'], level=0)
-        expected = self.frame.ix[[0, 1, 2, 7, 8, 9]]
+        expected = self.frame.iloc[[0, 1, 2, 7, 8, 9]]
         assert_frame_equal(result, expected)
 
         result = self.frame.T.reindex_axis(['foo', 'qux'], axis=1, level=0)
         assert_frame_equal(result, expected.T)
 
-        result = self.frame.ix[['foo', 'qux']]
+        result = self.frame.loc[['foo', 'qux']]
         assert_frame_equal(result, expected)
 
-        result = self.frame['A'].ix[['foo', 'qux']]
+        result = self.frame['A'].loc[['foo', 'qux']]
         assert_series_equal(result, expected['A'])
 
-        result = self.frame.T.ix[:, ['foo', 'qux']]
+        result = self.frame.T.loc[:, ['foo', 'qux']]
         assert_frame_equal(result, expected.T)
 
     def test_setitem_multiple_partial(self):
         expected = self.frame.copy()
         result = self.frame.copy()
-        result.ix[['foo', 'bar']] = 0
-        expected.ix['foo'] = 0
-        expected.ix['bar'] = 0
+        result.loc[['foo', 'bar']] = 0
+        expected.loc['foo'] = 0
+        expected.loc['bar'] = 0
         assert_frame_equal(result, expected)
 
         expected = self.frame.copy()
         result = self.frame.copy()
-        result.ix['foo':'bar'] = 0
-        expected.ix['foo'] = 0
-        expected.ix['bar'] = 0
+        result.loc['foo':'bar'] = 0
+        expected.loc['foo'] = 0
+        expected.loc['bar'] = 0
         assert_frame_equal(result, expected)
 
         expected = self.frame['A'].copy()
         result = self.frame['A'].copy()
-        result.ix[['foo', 'bar']] = 0
-        expected.ix['foo'] = 0
-        expected.ix['bar'] = 0
+        result.loc[['foo', 'bar']] = 0
+        expected.loc['foo'] = 0
+        expected.loc['bar'] = 0
         assert_series_equal(result, expected)
 
         expected = self.frame['A'].copy()
         result = self.frame['A'].copy()
-        result.ix['foo':'bar'] = 0
-        expected.ix['foo'] = 0
-        expected.ix['bar'] = 0
+        result.loc['foo':'bar'] = 0
+        expected.loc['foo'] = 0
+        expected.loc['bar'] = 0
         assert_series_equal(result, expected)
 
     def test_drop_level(self):
         result = self.frame.drop(['bar', 'qux'], level='first')
-        expected = self.frame.ix[[0, 1, 2, 5, 6]]
+        expected = self.frame.iloc[[0, 1, 2, 5, 6]]
         assert_frame_equal(result, expected)
 
         result = self.frame.drop(['two'], level='second')
-        expected = self.frame.ix[[0, 2, 3, 6, 7, 9]]
+        expected = self.frame.iloc[[0, 2, 3, 6, 7, 9]]
         assert_frame_equal(result, expected)
 
         result = self.frame.T.drop(['bar', 'qux'], axis=1, level='first')
-        expected = self.frame.ix[[0, 1, 2, 5, 6]].T
+        expected = self.frame.iloc[[0, 1, 2, 5, 6]].T
         assert_frame_equal(result, expected)
 
         result = self.frame.T.drop(['two'], axis=1, level='second')
-        expected = self.frame.ix[[0, 2, 3, 6, 7, 9]].T
+        expected = self.frame.iloc[[0, 2, 3, 6, 7, 9]].T
         assert_frame_equal(result, expected)
 
     def test_drop_level_nonunique_datetime(self):
@@ -2028,12 +2059,12 @@ Thur,Lunch,Yes,51.51,17"""
     def test_set_column_scalar_with_ix(self):
         subset = self.frame.index[[1, 4, 5]]
 
-        self.frame.ix[subset] = 99
-        self.assertTrue((self.frame.ix[subset].values == 99).all())
+        self.frame.loc[subset] = 99
+        self.assertTrue((self.frame.loc[subset].values == 99).all())
 
         col = self.frame['B']
         col[subset] = 97
-        self.assertTrue((self.frame.ix[subset, 'B'] == 97).all())
+        self.assertTrue((self.frame.loc[subset, 'B'] == 97).all())
 
     def test_frame_dict_constructor_empty_series(self):
         s1 = Series([
@@ -2057,7 +2088,7 @@ Thur,Lunch,Yes,51.51,17"""
         frame = DataFrame(np.arange(12).reshape((4, 3)), index=index,
                           columns=columns)
 
-        result = frame.ix[:, 1]
+        result = frame.iloc[:, 1]
         exp = frame.loc[:, ('Ohio', 'Red')]
         tm.assertIsInstance(result, Series)
         assert_series_equal(result, exp)
@@ -2069,7 +2100,7 @@ Thur,Lunch,Yes,51.51,17"""
         df = df.set_index(['A', 'B'])
         ix = MultiIndex.from_tuples([(1, 1)])
 
-        df.ix[ix, "C"] = '_'
+        df.loc[ix, "C"] = '_'
 
         self.assertTrue((df.xs((1, 1))['C'] == '_').all())
 

--- a/pandas/tests/test_panel.py
+++ b/pandas/tests/test_panel.py
@@ -140,8 +140,8 @@ class SafeForLongAndSparse(object):
             obj = self.panel
 
             # # set some NAs
-            # obj.ix[5:10] = np.nan
-            # obj.ix[15:20, -2:] = np.nan
+            # obj.loc[5:10] = np.nan
+            # obj.loc[15:20, -2:] = np.nan
 
         f = getattr(obj, name)
 
@@ -358,7 +358,7 @@ class SafeForSparse(object):
                   items=['ItemA', 'ItemB', 'ItemC'],
                   major_axis=pd.date_range('20130101', periods=4),
                   minor_axis=list('ABCDE'))
-        d = p.sum(axis=1).ix[0]
+        d = p.sum(axis=1).iloc[0]
         ops = ['add', 'sub', 'mul', 'truediv', 'floordiv', 'div', 'mod', 'pow']
         for op in ops:
             with self.assertRaises(NotImplementedError):
@@ -491,7 +491,7 @@ class CheckIndexing(object):
         self.assertEqual(self.panel['ItemP'].values.dtype, np.bool_)
 
         self.assertRaises(TypeError, self.panel.__setitem__, 'foo',
-                          self.panel.ix[['ItemP']])
+                          self.panel.loc[['ItemP']])
 
         # bad shape
         p = Panel(np.random.randn(4, 3, 2))
@@ -591,25 +591,25 @@ class CheckIndexing(object):
         cols = ['D', 'C', 'F']
 
         # all 3 specified
-        assert_panel_equal(p.ix[items, dates, cols],
+        assert_panel_equal(p.loc[items, dates, cols],
                            p.reindex(items=items, major=dates, minor=cols))
 
         # 2 specified
-        assert_panel_equal(p.ix[:, dates, cols],
+        assert_panel_equal(p.loc[:, dates, cols],
                            p.reindex(major=dates, minor=cols))
 
-        assert_panel_equal(p.ix[items, :, cols],
+        assert_panel_equal(p.loc[items, :, cols],
                            p.reindex(items=items, minor=cols))
 
-        assert_panel_equal(p.ix[items, dates, :],
+        assert_panel_equal(p.loc[items, dates, :],
                            p.reindex(items=items, major=dates))
 
         # only 1
-        assert_panel_equal(p.ix[items, :, :], p.reindex(items=items))
+        assert_panel_equal(p.loc[items, :, :], p.reindex(items=items))
 
-        assert_panel_equal(p.ix[:, dates, :], p.reindex(major=dates))
+        assert_panel_equal(p.loc[:, dates, :], p.reindex(major=dates))
 
-        assert_panel_equal(p.ix[:, :, cols], p.reindex(minor=cols))
+        assert_panel_equal(p.loc[:, :, cols], p.reindex(minor=cols))
 
     def test_getitem_fancy_slice(self):
         pass
@@ -618,8 +618,8 @@ class CheckIndexing(object):
         p = self.panel
 
         # #1603
-        result = p.ix[:, -1, :]
-        expected = p.ix[:, p.major_axis[-1], :]
+        result = p.iloc[:, -1, :]
+        expected = p.loc[:, p.major_axis[-1], :]
         assert_frame_equal(result, expected)
 
     def test_getitem_fancy_xs(self):
@@ -631,22 +631,22 @@ class CheckIndexing(object):
 
         # get DataFrame
         # item
-        assert_frame_equal(p.ix[item], p[item])
-        assert_frame_equal(p.ix[item, :], p[item])
-        assert_frame_equal(p.ix[item, :, :], p[item])
+        assert_frame_equal(p.loc[item], p[item])
+        assert_frame_equal(p.loc[item, :], p[item])
+        assert_frame_equal(p.loc[item, :, :], p[item])
 
         # major axis, axis=1
-        assert_frame_equal(p.ix[:, date], p.major_xs(date))
-        assert_frame_equal(p.ix[:, date, :], p.major_xs(date))
+        assert_frame_equal(p.loc[:, date], p.major_xs(date))
+        assert_frame_equal(p.loc[:, date, :], p.major_xs(date))
 
         # minor axis, axis=2
-        assert_frame_equal(p.ix[:, :, 'C'], p.minor_xs('C'))
+        assert_frame_equal(p.loc[:, :, 'C'], p.minor_xs('C'))
 
         # get Series
-        assert_series_equal(p.ix[item, date], p[item].ix[date])
-        assert_series_equal(p.ix[item, date, :], p[item].ix[date])
-        assert_series_equal(p.ix[item, :, col], p[item][col])
-        assert_series_equal(p.ix[:, date, col], p.major_xs(date).ix[col])
+        assert_series_equal(p.loc[item, date], p[item].loc[date])
+        assert_series_equal(p.loc[item, date, :], p[item].loc[date])
+        assert_series_equal(p.loc[item, :, col], p[item][col])
+        assert_series_equal(p.loc[:, date, col], p.major_xs(date).loc[col])
 
     def test_getitem_fancy_xs_check_view(self):
         item = 'ItemB'
@@ -685,9 +685,9 @@ class CheckIndexing(object):
         b = DataFrame(np.random.randn(2, 3), index=[111, 333],
                       columns=[1, 2, 3])
 
-        a.ix[:, 22, [111, 333]] = b
+        a.loc[:, 22, [111, 333]] = b
 
-        assert_frame_equal(a.ix[:, 22, [111, 333]], b)
+        assert_frame_equal(a.loc[:, 22, [111, 333]], b)
 
     def test_ix_align(self):
         from pandas import Series
@@ -696,28 +696,28 @@ class CheckIndexing(object):
         df_orig = Panel(np.random.randn(3, 10, 2))
         df = df_orig.copy()
 
-        df.ix[0, :, 0] = b
-        assert_series_equal(df.ix[0, :, 0].reindex(b.index), b)
+        df.loc[0, :, 0] = b
+        assert_series_equal(df.loc[0, :, 0].reindex(b.index), b)
 
         df = df_orig.swapaxes(0, 1)
-        df.ix[:, 0, 0] = b
-        assert_series_equal(df.ix[:, 0, 0].reindex(b.index), b)
+        df.loc[:, 0, 0] = b
+        assert_series_equal(df.loc[:, 0, 0].reindex(b.index), b)
 
         df = df_orig.swapaxes(1, 2)
-        df.ix[0, 0, :] = b
-        assert_series_equal(df.ix[0, 0, :].reindex(b.index), b)
+        df.loc[0, 0, :] = b
+        assert_series_equal(df.loc[0, 0, :].reindex(b.index), b)
 
     def test_ix_frame_align(self):
         p_orig = tm.makePanel()
-        df = p_orig.ix[0].copy()
+        df = p_orig.iloc[0].copy()
         assert_frame_equal(p_orig['ItemA'], df)
 
         p = p_orig.copy()
-        p.ix[0, :, :] = df
+        p.iloc[0, :, :] = df
         assert_panel_equal(p, p_orig)
 
         p = p_orig.copy()
-        p.ix[0] = df
+        p.iloc[0] = df
         assert_panel_equal(p, p_orig)
 
         p = p_orig.copy()
@@ -741,8 +741,8 @@ class CheckIndexing(object):
         assert_panel_equal(p, p_orig)
 
         p = p_orig.copy()
-        p.ix[0, [0, 1, 3, 5], -2:] = df
-        out = p.ix[0, [0, 1, 3, 5], -2:]
+        p.iloc[0, [0, 1, 3, 5], -2:] = df
+        out = p.iloc[0, [0, 1, 3, 5], -2:]
         assert_frame_equal(out, df.iloc[[0, 1, 3, 5], [2, 3]])
 
         # GH3830, panel assignent by values/frame
@@ -773,10 +773,10 @@ class CheckIndexing(object):
 
     def _check_view(self, indexer, comp):
         cp = self.panel.copy()
-        obj = cp.ix[indexer]
+        obj = cp.loc[indexer]
         obj.values[:] = 0
         self.assertTrue((obj.values == 0).all())
-        comp(cp.ix[indexer].reindex_like(obj), obj)
+        comp(cp.loc[indexer].reindex_like(obj), obj)
 
     def test_logical_with_nas(self):
         d = Panel({'ItemA': {'a': [np.nan, False]},
@@ -1757,7 +1757,7 @@ class TestPanel(tm.TestCase, PanelTests, CheckIndexing, SafeForLongAndSparse,
                               [0, 1, 2, 3, 4, 5, 2, 3, 4, 5]])
 
         panel = df.to_panel()
-        self.assertTrue(isnull(panel[0].ix[1, [0, 1]]).all())
+        self.assertTrue(isnull(panel[0].loc[1, [0, 1]]).all())
 
     def test_to_panel_duplicates(self):
         # #2441
@@ -1900,7 +1900,7 @@ class TestPanel(tm.TestCase, PanelTests, CheckIndexing, SafeForLongAndSparse,
         assert_panel_equal(shifted, panel.tshift(1))
         assert_panel_equal(unshifted, inferred_ts)
 
-        no_freq = panel.ix[:, [0, 5, 7], :]
+        no_freq = panel.iloc[:, [0, 5, 7], :]
         self.assertRaises(ValueError, no_freq.tshift)
 
     def test_pct_change(self):
@@ -2000,7 +2000,7 @@ class TestPanel(tm.TestCase, PanelTests, CheckIndexing, SafeForLongAndSparse,
                    major_axis=np.arange(5),
                    minor_axis=np.arange(5))
         f1 = wp['a']
-        f2 = wp.ix['a']
+        f2 = wp.loc['a']
         assert_panel_equal(f1, f2)
 
         self.assertTrue((f1.items == [1, 2]).all())
@@ -2099,10 +2099,10 @@ class TestPanel(tm.TestCase, PanelTests, CheckIndexing, SafeForLongAndSparse,
 
     def test_dropna(self):
         p = Panel(np.random.randn(4, 5, 6), major_axis=list('abcde'))
-        p.ix[:, ['b', 'd'], 0] = np.nan
+        p.loc[:, ['b', 'd'], 0] = np.nan
 
         result = p.dropna(axis=1)
-        exp = p.ix[:, ['a', 'c', 'e'], :]
+        exp = p.loc[:, ['a', 'c', 'e'], :]
         assert_panel_equal(result, exp)
         inp = p.copy()
         inp.dropna(axis=1, inplace=True)
@@ -2111,24 +2111,24 @@ class TestPanel(tm.TestCase, PanelTests, CheckIndexing, SafeForLongAndSparse,
         result = p.dropna(axis=1, how='all')
         assert_panel_equal(result, p)
 
-        p.ix[:, ['b', 'd'], :] = np.nan
+        p.loc[:, ['b', 'd'], :] = np.nan
         result = p.dropna(axis=1, how='all')
-        exp = p.ix[:, ['a', 'c', 'e'], :]
+        exp = p.loc[:, ['a', 'c', 'e'], :]
         assert_panel_equal(result, exp)
 
         p = Panel(np.random.randn(4, 5, 6), items=list('abcd'))
-        p.ix[['b'], :, 0] = np.nan
+        p.loc[['b'], :, 0] = np.nan
 
         result = p.dropna()
-        exp = p.ix[['a', 'c', 'd']]
+        exp = p.loc[['a', 'c', 'd']]
         assert_panel_equal(result, exp)
 
         result = p.dropna(how='all')
         assert_panel_equal(result, p)
 
-        p.ix['b'] = np.nan
+        p.loc['b'] = np.nan
         result = p.dropna(how='all')
-        exp = p.ix[['a', 'c', 'd']]
+        exp = p.loc[['a', 'c', 'd']]
         assert_panel_equal(result, exp)
 
     def test_drop(self):
@@ -2334,7 +2334,7 @@ class TestLongPanel(tm.TestCase):
         expected = DataFrame.add(self.panel, s, axis=0)
         assert_frame_equal(result, expected)
 
-        s = self.panel.ix[5]
+        s = self.panel.iloc[5]
         result = self.panel + s
         expected = DataFrame.add(self.panel, s, axis=1)
         assert_frame_equal(result, expected)

--- a/pandas/tests/test_panel4d.py
+++ b/pandas/tests/test_panel4d.py
@@ -116,8 +116,8 @@ class SafeForLongAndSparse(object):
             obj = self.panel4d
 
             # # set some NAs
-            # obj.ix[5:10] = np.nan
-            # obj.ix[15:20, -2:] = np.nan
+            # obj.loc[5:10] = np.nan
+            # obj.loc[15:20, -2:] = np.nan
 
         f = getattr(obj, name)
 
@@ -531,33 +531,33 @@ class CheckIndexing(object):
             cols = ['D', 'C', 'F']
 
             # all 4 specified
-            assert_panel4d_equal(panel4d.ix[labels, items, dates, cols],
+            assert_panel4d_equal(panel4d.loc[labels, items, dates, cols],
                                  panel4d.reindex(labels=labels, items=items,
                                                  major=dates, minor=cols))
 
             # 3 specified
-            assert_panel4d_equal(panel4d.ix[:, items, dates, cols],
+            assert_panel4d_equal(panel4d.loc[:, items, dates, cols],
                                  panel4d.reindex(items=items, major=dates,
                                                  minor=cols))
 
             # 2 specified
-            assert_panel4d_equal(panel4d.ix[:, :, dates, cols],
+            assert_panel4d_equal(panel4d.loc[:, :, dates, cols],
                                  panel4d.reindex(major=dates, minor=cols))
 
-            assert_panel4d_equal(panel4d.ix[:, items, :, cols],
+            assert_panel4d_equal(panel4d.loc[:, items, :, cols],
                                  panel4d.reindex(items=items, minor=cols))
 
-            assert_panel4d_equal(panel4d.ix[:, items, dates, :],
+            assert_panel4d_equal(panel4d.loc[:, items, dates, :],
                                  panel4d.reindex(items=items, major=dates))
 
             # only 1
-            assert_panel4d_equal(panel4d.ix[:, items, :, :],
+            assert_panel4d_equal(panel4d.loc[:, items, :, :],
                                  panel4d.reindex(items=items))
 
-            assert_panel4d_equal(panel4d.ix[:, :, dates, :],
+            assert_panel4d_equal(panel4d.loc[:, :, dates, :],
                                  panel4d.reindex(major=dates))
 
-            assert_panel4d_equal(panel4d.ix[:, :, :, cols],
+            assert_panel4d_equal(panel4d.loc[:, :, :, cols],
                                  panel4d.reindex(minor=cols))
 
     def test_getitem_fancy_slice(self):
@@ -693,12 +693,13 @@ class TestPanel4d(tm.TestCase, CheckIndexing, SafeForSparse,
             l1 = self.panel4d['l1']
             l2 = self.panel4d['l2']
 
-            d = {'A': l1, 'B': l2.ix[['ItemB'], :, :]}
+            d = {'A': l1, 'B': l2.loc[['ItemB'], :, :]}
             panel4d = Panel4D(d)
 
             assert_panel_equal(panel4d['A'], self.panel4d['l1'])
-            assert_frame_equal(panel4d.ix['B', 'ItemB', :, :],
-                               self.panel4d.ix['l2', ['ItemB'], :, :]['ItemB'])
+            assert_frame_equal(panel4d.loc['B', 'ItemB', :, :],
+                               self.panel4d.loc['l2', ['ItemB'],
+                                                :, :]['ItemB'])
 
     def test_constructor_dict_mixed(self):
         with tm.assert_produces_warning(FutureWarning, check_stacklevel=False):
@@ -807,8 +808,8 @@ class TestPanel4d(tm.TestCase, CheckIndexing, SafeForSparse,
             larger = smaller.reindex(major=self.panel4d.major_axis,
                                      method='pad')
 
-            assert_panel_equal(larger.ix[:, :, self.panel4d.major_axis[1], :],
-                               smaller.ix[:, :, smaller_major[0], :])
+            assert_panel_equal(larger.loc[:, :, self.panel4d.major_axis[1], :],
+                               smaller.loc[:, :, smaller_major[0], :])
 
             # don't necessarily copy
             result = self.panel4d.reindex(

--- a/pandas/tests/test_panelnd.py
+++ b/pandas/tests/test_panelnd.py
@@ -94,8 +94,8 @@ class TestPanelnd(tm.TestCase):
             p5d = Panel5D(dict(C1=p4d))
 
             # slice back to 4d
-            results = p5d.ix['C1', :, :, 0:3, :]
-            expected = p4d.ix[:, :, 0:3, :]
+            results = p5d.iloc[p5d.cool1.get_loc('C1'), :, :, 0:3, :]
+            expected = p4d.iloc[:, :, 0:3, :]
             assert_panel_equal(results['L1'], expected['L1'])
 
             # test a transpose

--- a/pandas/tests/test_strings.py
+++ b/pandas/tests/test_strings.py
@@ -229,7 +229,7 @@ class TestStringMethods(tm.TestCase):
         # na
         values = Series(['om', 'foo', np.nan])
         res = values.str.contains('foo', na="foo")
-        self.assertEqual(res.ix[2], "foo")
+        self.assertEqual(res.loc[2], "foo")
 
     def test_startswith(self):
         values = Series(['om', NA, 'foo_nom', 'nom', 'bar_foo', NA, 'foo'])

--- a/pandas/tests/test_window.py
+++ b/pandas/tests/test_window.py
@@ -2190,7 +2190,7 @@ class TestMomentsConsistency(Base):
             return getattr(getattr(obj, dispatch)(**kwargs), name)(obj2)
 
         panel = get_result(self.frame)
-        actual = panel.ix[:, 1, 5]
+        actual = panel.loc[:, 1, 5]
         expected = get_result(self.frame[1], self.frame[5])
         tm.assert_series_equal(actual, expected, check_names=False)
         self.assertEqual(actual.name, 5)

--- a/pandas/tools/tests/test_concat.py
+++ b/pandas/tools/tests/test_concat.py
@@ -785,8 +785,8 @@ class TestAppend(ConcatenateBase):
                         'floats': np.random.randn(10),
                         'strings': ['foo', 'bar'] * 5})
 
-        a = df[:5].ix[:, ['bools', 'ints', 'floats']]
-        b = df[5:].ix[:, ['strings', 'ints', 'floats']]
+        a = df[:5].loc[:, ['bools', 'ints', 'floats']]
+        b = df[5:].loc[:, ['strings', 'ints', 'floats']]
 
         appended = a.append(b)
         self.assertTrue(isnull(appended['strings'][0:4]).all())
@@ -802,7 +802,7 @@ class TestAppend(ConcatenateBase):
         chunks[-1] = chunks[-1].copy()
         chunks[-1]['foo'] = 'bar'
         result = chunks[0].append(chunks[1:])
-        tm.assert_frame_equal(result.ix[:, self.frame.columns], self.frame)
+        tm.assert_frame_equal(result.loc[:, self.frame.columns], self.frame)
         self.assertTrue((result['foo'][15:] == 'bar').all())
         self.assertTrue(result['foo'][:15].isnull().all())
 
@@ -929,7 +929,7 @@ class TestConcatenate(ConcatenateBase):
 
     def test_concat_keys_specific_levels(self):
         df = DataFrame(np.random.randn(10, 4))
-        pieces = [df.ix[:, [0, 1]], df.ix[:, [2]], df.ix[:, [3]]]
+        pieces = [df.iloc[:, [0, 1]], df.iloc[:, [2]], df.iloc[:, [3]]]
         level = ['three', 'two', 'one', 'zero']
         result = concat(pieces, axis=1, keys=['one', 'two', 'three'],
                         levels=[level],
@@ -1024,8 +1024,8 @@ class TestConcatenate(ConcatenateBase):
         result = concat([frame, frame], keys=[0, 1], names=['iteration'])
 
         self.assertEqual(result.index.names, ('iteration',) + index.names)
-        tm.assert_frame_equal(result.ix[0], frame)
-        tm.assert_frame_equal(result.ix[1], frame)
+        tm.assert_frame_equal(result.loc[0], frame)
+        tm.assert_frame_equal(result.loc[1], frame)
         self.assertEqual(result.index.nlevels, 3)
 
     def test_concat_multiindex_with_tz(self):
@@ -1202,7 +1202,7 @@ class TestConcatenate(ConcatenateBase):
         frames = [baz, empty, empty, df[5:]]
         concatted = concat(frames, axis=0)
 
-        expected = df.ix[:, ['a', 'b', 'c', 'd', 'foo']]
+        expected = df.loc[:, ['a', 'b', 'c', 'd', 'foo']]
         expected['foo'] = expected['foo'].astype('O')
         expected.loc[0:4, 'foo'] = 'bar'
 
@@ -1326,28 +1326,28 @@ class TestConcatenate(ConcatenateBase):
     def test_panel_concat_other_axes(self):
         panel = tm.makePanel()
 
-        p1 = panel.ix[:, :5, :]
-        p2 = panel.ix[:, 5:, :]
+        p1 = panel.iloc[:, :5, :]
+        p2 = panel.iloc[:, 5:, :]
 
         result = concat([p1, p2], axis=1)
         tm.assert_panel_equal(result, panel)
 
-        p1 = panel.ix[:, :, :2]
-        p2 = panel.ix[:, :, 2:]
+        p1 = panel.iloc[:, :, :2]
+        p2 = panel.iloc[:, :, 2:]
 
         result = concat([p1, p2], axis=2)
         tm.assert_panel_equal(result, panel)
 
         # if things are a bit misbehaved
-        p1 = panel.ix[:2, :, :2]
-        p2 = panel.ix[:, :, 2:]
+        p1 = panel.iloc[:2, :, :2]
+        p2 = panel.iloc[:, :, 2:]
         p1['ItemC'] = 'baz'
 
         result = concat([p1, p2], axis=2)
 
         expected = panel.copy()
         expected['ItemC'] = expected['ItemC'].astype('O')
-        expected.ix['ItemC', :, :2] = 'baz'
+        expected.loc['ItemC', :, :2] = 'baz'
         tm.assert_panel_equal(result, expected)
 
     def test_panel_concat_buglet(self):
@@ -1379,14 +1379,14 @@ class TestConcatenate(ConcatenateBase):
         with tm.assert_produces_warning(FutureWarning, check_stacklevel=False):
             p4d = tm.makePanel4D()
 
-            p1 = p4d.ix[:, :, :5, :]
-            p2 = p4d.ix[:, :, 5:, :]
+            p1 = p4d.iloc[:, :, :5, :]
+            p2 = p4d.iloc[:, :, 5:, :]
 
             result = concat([p1, p2], axis=2)
             tm.assert_panel4d_equal(result, p4d)
 
-            p1 = p4d.ix[:, :, :, :2]
-            p2 = p4d.ix[:, :, :, 2:]
+            p1 = p4d.iloc[:, :, :, :2]
+            p2 = p4d.iloc[:, :, :, 2:]
 
             result = concat([p1, p2], axis=3)
             tm.assert_panel4d_equal(result, p4d)
@@ -1396,15 +1396,15 @@ class TestConcatenate(ConcatenateBase):
             p4d = tm.makePanel4D()
 
             # if things are a bit misbehaved
-            p1 = p4d.ix[:, :2, :, :2]
-            p2 = p4d.ix[:, :, :, 2:]
+            p1 = p4d.iloc[:, :2, :, :2]
+            p2 = p4d.iloc[:, :, :, 2:]
             p1['L5'] = 'baz'
 
             result = concat([p1, p2], axis=3)
 
             p2['L5'] = np.nan
             expected = concat([p1, p2], axis=3)
-            expected = expected.ix[result.labels]
+            expected = expected.loc[result.labels]
 
             tm.assert_panel4d_equal(result, expected)
 

--- a/pandas/tools/tests/test_join.py
+++ b/pandas/tools/tests/test_join.py
@@ -428,7 +428,7 @@ class TestJoin(tm.TestCase):
         self.assertTrue(joined.index.is_monotonic)
         assert_frame_equal(joined, expected)
 
-        # _assert_same_contents(expected, expected2.ix[:, expected.columns])
+        # _assert_same_contents(expected, expected2.loc[:, expected.columns])
 
     def test_join_hierarchical_mixed(self):
         # GH 2024
@@ -500,7 +500,7 @@ class TestJoin(tm.TestCase):
 
         result = result.reset_index()
 
-        assert_frame_equal(result, expected.ix[:, result.columns])
+        assert_frame_equal(result, expected.loc[:, result.columns])
 
         # GH 11519
         df = DataFrame({'A': ['foo', 'bar', 'foo', 'bar',
@@ -597,9 +597,9 @@ class TestJoin(tm.TestCase):
     def test_join_many_mixed(self):
         df = DataFrame(np.random.randn(8, 4), columns=['A', 'B', 'C', 'D'])
         df['key'] = ['foo', 'bar'] * 4
-        df1 = df.ix[:, ['A', 'B']]
-        df2 = df.ix[:, ['C', 'D']]
-        df3 = df.ix[:, ['key']]
+        df1 = df.loc[:, ['A', 'B']]
+        df2 = df.loc[:, ['C', 'D']]
+        df3 = df.loc[:, ['key']]
 
         result = df1.join([df2, df3])
         assert_frame_equal(result, df)
@@ -637,8 +637,8 @@ class TestJoin(tm.TestCase):
         panel = tm.makePanel()
         tm.add_nans(panel)
 
-        p1 = panel.ix[:2, :10, :3]
-        p2 = panel.ix[2:, 5:, 2:]
+        p1 = panel.iloc[:2, :10, :3]
+        p2 = panel.iloc[2:, 5:, 2:]
 
         # left join
         result = p1.join(p2)
@@ -656,7 +656,7 @@ class TestJoin(tm.TestCase):
 
         # inner join
         result = p1.join(p2, how='inner')
-        expected = panel.ix[:, 5:10, 2:3]
+        expected = panel.iloc[:, 5:10, 2:3]
         tm.assert_panel_equal(result, expected)
 
         # outer join
@@ -671,16 +671,16 @@ class TestJoin(tm.TestCase):
         panel = tm.makePanel()
         tm.add_nans(panel)
 
-        p1 = panel.ix[['ItemA', 'ItemB', 'ItemC']]
-        p2 = panel.ix[['ItemB', 'ItemC']]
+        p1 = panel.loc[['ItemA', 'ItemB', 'ItemC']]
+        p2 = panel.loc[['ItemB', 'ItemC']]
 
         # Expected index is
         #
         # ItemA, ItemB_p1, ItemC_p1, ItemB_p2, ItemC_p2
         joined = p1.join(p2, lsuffix='_p1', rsuffix='_p2')
-        p1_suf = p1.ix[['ItemB', 'ItemC']].add_suffix('_p1')
-        p2_suf = p2.ix[['ItemB', 'ItemC']].add_suffix('_p2')
-        no_overlap = panel.ix[['ItemA']]
+        p1_suf = p1.loc[['ItemB', 'ItemC']].add_suffix('_p1')
+        p2_suf = p2.loc[['ItemB', 'ItemC']].add_suffix('_p2')
+        no_overlap = panel.loc[['ItemA']]
         expected = no_overlap.join(p1_suf.join(p2_suf))
         tm.assert_panel_equal(joined, expected)
 
@@ -689,12 +689,14 @@ class TestJoin(tm.TestCase):
         panel = tm.makePanel()
         tm.K = 4
 
-        panels = [panel.ix[:2], panel.ix[2:6], panel.ix[6:]]
+        panels = [panel.iloc[:2], panel.iloc[2:6], panel.iloc[6:]]
 
         joined = panels[0].join(panels[1:])
         tm.assert_panel_equal(joined, panel)
 
-        panels = [panel.ix[:2, :-5], panel.ix[2:6, 2:], panel.ix[6:, 5:-7]]
+        panels = [panel.iloc[:2, :-5],
+                  panel.iloc[2:6, 2:],
+                  panel.iloc[6:, 5:-7]]
 
         data_dict = {}
         for p in panels:
@@ -757,13 +759,13 @@ def _restrict_to_columns(group, columns, suffix):
              if c in columns or c.replace(suffix, '') in columns]
 
     # filter
-    group = group.ix[:, found]
+    group = group.loc[:, found]
 
     # get rid of suffixes, if any
     group = group.rename(columns=lambda x: x.replace(suffix, ''))
 
     # put in the right order...
-    group = group.ix[:, columns]
+    group = group.loc[:, columns]
 
     return group
 

--- a/pandas/tools/tests/test_merge.py
+++ b/pandas/tools/tests/test_merge.py
@@ -72,13 +72,13 @@ class TestMerge(tm.TestCase):
                         right_index=True, how='left', sort=False)
         merged2 = merge(right, left, right_on='key',
                         left_index=True, how='right', sort=False)
-        assert_frame_equal(merged1, merged2.ix[:, merged1.columns])
+        assert_frame_equal(merged1, merged2.loc[:, merged1.columns])
 
         merged1 = merge(left, right, left_on='key',
                         right_index=True, how='left', sort=True)
         merged2 = merge(right, left, right_on='key',
                         left_index=True, how='right', sort=True)
-        assert_frame_equal(merged1, merged2.ix[:, merged1.columns])
+        assert_frame_equal(merged1, merged2.loc[:, merged1.columns])
 
     def test_merge_index_singlekey_inner(self):
         left = DataFrame({'key': ['a', 'b', 'c', 'd', 'e', 'e', 'a'],
@@ -89,13 +89,13 @@ class TestMerge(tm.TestCase):
         # inner join
         result = merge(left, right, left_on='key', right_index=True,
                        how='inner')
-        expected = left.join(right, on='key').ix[result.index]
+        expected = left.join(right, on='key').loc[result.index]
         assert_frame_equal(result, expected)
 
         result = merge(right, left, right_on='key', left_index=True,
                        how='inner')
-        expected = left.join(right, on='key').ix[result.index]
-        assert_frame_equal(result, expected.ix[:, result.columns])
+        expected = left.join(right, on='key').loc[result.index]
+        assert_frame_equal(result, expected.loc[:, result.columns])
 
     def test_merge_misspecified(self):
         self.assertRaises(ValueError, merge, self.left, self.right,
@@ -763,11 +763,11 @@ class TestMergeMulti(tm.TestCase):
                                             columns=self.to_join.columns))
 
         # TODO: columns aren't in the same order yet
-        assert_frame_equal(joined, expected.ix[:, joined.columns])
+        assert_frame_equal(joined, expected.loc[:, joined.columns])
 
         left = self.data.join(self.to_join, on=['key1', 'key2'], sort=True)
-        right = expected.ix[:, joined.columns].sort_values(['key1', 'key2'],
-                                                           kind='mergesort')
+        right = expected.loc[:, joined.columns].sort_values(['key1', 'key2'],
+                                                            kind='mergesort')
         assert_frame_equal(left, right)
 
     def test_left_join_multi_index(self):
@@ -840,7 +840,7 @@ class TestMergeMulti(tm.TestCase):
                                          left_index=True, how='right',
                                          sort=sort)
 
-            merged2 = merged2.ix[:, merged1.columns]
+            merged2 = merged2.loc[:, merged1.columns]
             assert_frame_equal(merged1, merged2)
 
     def test_compress_group_combinations(self):
@@ -904,7 +904,7 @@ class TestMergeMulti(tm.TestCase):
         # do a right join for an extra test
         joined = merge(right, left, left_index=True,
                        right_on=['k1', 'k2'], how='right')
-        tm.assert_frame_equal(joined.ix[:, expected.columns], expected)
+        tm.assert_frame_equal(joined.loc[:, expected.columns], expected)
 
     def test_left_join_index_multi_match_multiindex(self):
         left = DataFrame([

--- a/pandas/tools/tests/test_merge_ordered.py
+++ b/pandas/tools/tests/test_merge_ordered.py
@@ -54,11 +54,11 @@ class TestOrderedMerge(tm.TestCase):
                               'rvalue': [nan, 1, 2, 3, 3, 4] * 2})
         expected['group'] = ['a'] * 6 + ['b'] * 6
 
-        assert_frame_equal(result, expected.ix[:, result.columns])
+        assert_frame_equal(result, expected.loc[:, result.columns])
 
         result2 = merge_ordered(self.right, left, on='key', right_by='group',
                                 fill_method='ffill')
-        assert_frame_equal(result, result2.ix[:, result.columns])
+        assert_frame_equal(result, result2.loc[:, result.columns])
 
         result = merge_ordered(left, self.right, on='key', left_by='group')
         self.assertTrue(result['group'].notnull().all())

--- a/pandas/tools/tests/test_pivot.py
+++ b/pandas/tools/tests/test_pivot.py
@@ -301,14 +301,15 @@ class TestPivotTable(tm.TestCase):
         def _check_output(result, values_col, index=['A', 'B'],
                           columns=['C'],
                           margins_col='All'):
-            col_margins = result.ix[:-1, margins_col]
+            col_margins = result.loc[result.index[:-1], margins_col]
             expected_col_margins = self.data.groupby(index)[values_col].mean()
             tm.assert_series_equal(col_margins, expected_col_margins,
                                    check_names=False)
             self.assertEqual(col_margins.name, margins_col)
 
             result = result.sort_index()
-            index_margins = result.ix[(margins_col, '')].iloc[:-1]
+            index_margins = result.loc[(margins_col, '')].iloc[:-1]
+
             expected_ix_margins = self.data.groupby(columns)[values_col].mean()
             tm.assert_series_equal(index_margins, expected_ix_margins,
                                    check_names=False)
@@ -987,7 +988,7 @@ class TestCrosstab(tm.TestCase):
 
         tm.assert_series_equal(all_cols, exp_cols)
 
-        all_rows = result.ix['All']
+        all_rows = result.loc['All']
         exp_rows = df.groupby(['b', 'c']).size().astype('i8')
         exp_rows = exp_rows.append(Series([len(df)], index=[('All', '')]))
         exp_rows.name = 'All'

--- a/pandas/tseries/tests/test_period.py
+++ b/pandas/tseries/tests/test_period.py
@@ -2187,7 +2187,7 @@ class TestPeriodIndex(tm.TestCase):
         def assert_slices_equivalent(l_slc, i_slc):
             tm.assert_series_equal(ts[l_slc], ts.iloc[i_slc])
             tm.assert_series_equal(ts.loc[l_slc], ts.iloc[i_slc])
-            tm.assert_series_equal(ts.ix[l_slc], ts.iloc[i_slc])
+            tm.assert_series_equal(ts.loc[l_slc], ts.iloc[i_slc])
 
         assert_slices_equivalent(SLC[Period('2014-10')::-1], SLC[9::-1])
         assert_slices_equivalent(SLC['2014-10'::-1], SLC[9::-1])
@@ -2213,7 +2213,7 @@ class TestPeriodIndex(tm.TestCase):
         self.assertRaisesRegexp(ValueError, 'slice step cannot be zero',
                                 lambda: ts.loc[::0])
         self.assertRaisesRegexp(ValueError, 'slice step cannot be zero',
-                                lambda: ts.ix[::0])
+                                lambda: ts.loc[::0])
 
     def test_contains(self):
         rng = period_range('2007-01', freq='M', periods=10)
@@ -2399,13 +2399,13 @@ class TestPeriodIndex(tm.TestCase):
         df = DataFrame(randn(10, 5), columns=rng)
 
         ts = df[rng[0]]
-        tm.assert_series_equal(ts, df.ix[:, 0])
+        tm.assert_series_equal(ts, df.iloc[:, 0])
 
         # GH # 1211
         repr(df)
 
         ts = df['1/1/2000']
-        tm.assert_series_equal(ts, df.ix[:, 0])
+        tm.assert_series_equal(ts, df.iloc[:, 0])
 
     def test_indexing(self):
 

--- a/pandas/tseries/tests/test_resample.py
+++ b/pandas/tseries/tests/test_resample.py
@@ -110,7 +110,7 @@ class TestResampleAPI(tm.TestCase):
         r = self.series.resample('H')
         self.assertRaises(ValueError, lambda: r.iloc[0])
         self.assertRaises(ValueError, lambda: r.iat[0])
-        self.assertRaises(ValueError, lambda: r.ix[0])
+        self.assertRaises(ValueError, lambda: r.loc[0])
         self.assertRaises(ValueError, lambda: r.loc[
             Timestamp('2013-01-01 00:00:00', offset='H')])
         self.assertRaises(ValueError, lambda: r.at[
@@ -1410,13 +1410,13 @@ class TestDatetimeIndex(Base, tm.TestCase):
         resampled = ts.resample('5min', closed='right',
                                 label='right').ohlc()
 
-        self.assertTrue((resampled.ix['1/1/2000 00:00'] == ts[0]).all())
+        self.assertTrue((resampled.loc['1/1/2000 00:00'] == ts[0]).all())
 
         exp = _ohlc(ts[1:31])
-        self.assertTrue((resampled.ix['1/1/2000 00:05'] == exp).all())
+        self.assertTrue((resampled.loc['1/1/2000 00:05'] == exp).all())
 
         exp = _ohlc(ts['1/1/2000 5:55:01':])
-        self.assertTrue((resampled.ix['1/1/2000 6:00:00'] == exp).all())
+        self.assertTrue((resampled.loc['1/1/2000 6:00:00'] == exp).all())
 
     def test_downsample_non_unique(self):
         rng = date_range('1/1/2000', '2/29/2000')
@@ -2495,7 +2495,7 @@ class TestPeriodIndex(Base, tm.TestCase):
         subset = s[:'2012-01-04 06:55']
 
         result = subset.resample('10min').apply(len)
-        expected = s.resample('10min').apply(len).ix[result.index]
+        expected = s.resample('10min').apply(len).loc[result.index]
         assert_series_equal(result, expected)
 
     def test_resample_weekly_all_na(self):

--- a/pandas/tseries/tests/test_timedeltas.py
+++ b/pandas/tseries/tests/test_timedeltas.py
@@ -1914,7 +1914,7 @@ class TestSlicing(tm.TestCase):
         def assert_slices_equivalent(l_slc, i_slc):
             assert_series_equal(ts[l_slc], ts.iloc[i_slc])
             assert_series_equal(ts.loc[l_slc], ts.iloc[i_slc])
-            assert_series_equal(ts.ix[l_slc], ts.iloc[i_slc])
+            assert_series_equal(ts.loc[l_slc], ts.iloc[i_slc])
 
         assert_slices_equivalent(SLC[Timedelta(hours=7)::-1], SLC[7::-1])
         assert_slices_equivalent(SLC['7 hours'::-1], SLC[7::-1])
@@ -1939,7 +1939,7 @@ class TestSlicing(tm.TestCase):
         self.assertRaisesRegexp(ValueError, 'slice step cannot be zero',
                                 lambda: ts.loc[::0])
         self.assertRaisesRegexp(ValueError, 'slice step cannot be zero',
-                                lambda: ts.ix[::0])
+                                lambda: ts.loc[::0])
 
     def test_tdi_ops_attributes(self):
         rng = timedelta_range('2 days', periods=5, freq='2D', name='x')

--- a/pandas/tseries/tests/test_timeseries.py
+++ b/pandas/tseries/tests/test_timeseries.py
@@ -173,8 +173,8 @@ class TestTimeSeriesDuplicates(tm.TestCase):
             self.assertIn(timestamp, df.index)
 
             # it works!
-            df.ix[timestamp]
-            self.assertTrue(len(df.ix[[timestamp]]) > 0)
+            df.loc[timestamp]
+            self.assertTrue(len(df.loc[[timestamp]]) > 0)
         finally:
             _index._SIZE_CUTOFF = old_cutoff
 
@@ -1373,7 +1373,7 @@ class TestTimeSeries(tm.TestCase):
         df = DataFrame(np.random.randn(len(rng), 3), index=rng)
 
         result = ts[time(9, 30)]
-        result_df = df.ix[time(9, 30)]
+        result_df = df.loc[time(9, 30)]
         expected = ts[(rng.hour == 9) & (rng.minute == 30)]
         exp_df = df[(rng.hour == 9) & (rng.minute == 30)]
 
@@ -1382,8 +1382,8 @@ class TestTimeSeries(tm.TestCase):
         assert_series_equal(result, expected)
         tm.assert_frame_equal(result_df, exp_df)
 
-        chunk = df.ix['1/4/2000':]
-        result = chunk.ix[time(9, 30)]
+        chunk = df.loc['1/4/2000':]
+        result = chunk.loc[time(9, 30)]
         expected = result_df[-1:]
         tm.assert_frame_equal(result, expected)
 
@@ -1412,8 +1412,8 @@ class TestTimeSeries(tm.TestCase):
         expected = ts.at_time(time(9, 30))
         assert_frame_equal(result, expected)
 
-        result = ts.ix[time(9, 30)]
-        expected = ts.ix[(rng.hour == 9) & (rng.minute == 30)]
+        result = ts.loc[time(9, 30)]
+        expected = ts.loc[(rng.hour == 9) & (rng.minute == 30)]
 
         assert_frame_equal(result, expected)
 
@@ -3192,7 +3192,7 @@ class TestDatetimeIndex(tm.TestCase):
         df = DataFrame(np.random.randn(10, 4),
                        index=date_range('1/1/2000', periods=10))
 
-        result = df.ix['1/3/2000']
+        result = df.loc['1/3/2000']
         self.assertEqual(result.name, df.index[2])
 
         result = df.T['1/3/2000']
@@ -3916,7 +3916,7 @@ class TestDatetimeIndex(tm.TestCase):
         def assert_slices_equivalent(l_slc, i_slc):
             assert_series_equal(ts[l_slc], ts.iloc[i_slc])
             assert_series_equal(ts.loc[l_slc], ts.iloc[i_slc])
-            assert_series_equal(ts.ix[l_slc], ts.iloc[i_slc])
+            assert_series_equal(ts.loc[l_slc], ts.iloc[i_slc])
 
         assert_slices_equivalent(SLC[Timestamp('2014-10-01')::-1], SLC[9::-1])
         assert_slices_equivalent(SLC['2014-10-01'::-1], SLC[9::-1])
@@ -3943,7 +3943,7 @@ class TestDatetimeIndex(tm.TestCase):
         self.assertRaisesRegexp(ValueError, 'slice step cannot be zero',
                                 lambda: ts.loc[::0])
         self.assertRaisesRegexp(ValueError, 'slice step cannot be zero',
-                                lambda: ts.ix[::0])
+                                lambda: ts.loc[::0])
 
     def test_slice_bounds_empty(self):
         # GH 14354
@@ -4313,7 +4313,7 @@ class TestDatetime64(tm.TestCase):
         times = [datetime(2000, 1, 1) + timedelta(minutes=i * 10)
                  for i in range(100000)]
         s = Series(lrange(100000), times)
-        s.ix[datetime(1900, 1, 1):datetime(2100, 1, 1)]
+        s.loc[datetime(1900, 1, 1):datetime(2100, 1, 1)]
 
     def test_slicing_datetimes(self):
 
@@ -4323,17 +4323,17 @@ class TestDatetime64(tm.TestCase):
         df = DataFrame(np.arange(4., dtype='float64'),
                        index=[datetime(2001, 1, i, 10, 00)
                               for i in [1, 2, 3, 4]])
-        result = df.ix[datetime(2001, 1, 1, 10):]
+        result = df.loc[datetime(2001, 1, 1, 10):]
         assert_frame_equal(result, df)
-        result = df.ix[:datetime(2001, 1, 4, 10)]
+        result = df.loc[:datetime(2001, 1, 4, 10)]
         assert_frame_equal(result, df)
-        result = df.ix[datetime(2001, 1, 1, 10):datetime(2001, 1, 4, 10)]
+        result = df.loc[datetime(2001, 1, 1, 10):datetime(2001, 1, 4, 10)]
         assert_frame_equal(result, df)
 
-        result = df.ix[datetime(2001, 1, 1, 11):]
+        result = df.loc[datetime(2001, 1, 1, 11):]
         expected = df.iloc[1:]
         assert_frame_equal(result, expected)
-        result = df.ix['20010101 11':]
+        result = df.loc['20010101 11':]
         assert_frame_equal(result, expected)
 
         # duplicates
@@ -4341,17 +4341,17 @@ class TestDatetime64(tm.TestCase):
                           index=[datetime(2001, 1, i, 10, 00)
                                  for i in [1, 2, 2, 3, 4]])
 
-        result = df.ix[datetime(2001, 1, 1, 10):]
+        result = df.loc[datetime(2001, 1, 1, 10):]
         assert_frame_equal(result, df)
-        result = df.ix[:datetime(2001, 1, 4, 10)]
+        result = df.loc[:datetime(2001, 1, 4, 10)]
         assert_frame_equal(result, df)
-        result = df.ix[datetime(2001, 1, 1, 10):datetime(2001, 1, 4, 10)]
+        result = df.loc[datetime(2001, 1, 1, 10):datetime(2001, 1, 4, 10)]
         assert_frame_equal(result, df)
 
-        result = df.ix[datetime(2001, 1, 1, 11):]
+        result = df.loc[datetime(2001, 1, 1, 11):]
         expected = df.iloc[1:]
         assert_frame_equal(result, expected)
-        result = df.ix['20010101 11':]
+        result = df.loc['20010101 11':]
         assert_frame_equal(result, expected)
 
 
@@ -4890,7 +4890,7 @@ class TestSlicing(tm.TestCase):
         assert_series_equal(result, expected)
 
         df = DataFrame(np.random.rand(len(dti), 5), index=dti)
-        result = df.ix['2005']
+        result = df.loc['2005']
         expected = df[df.index.year == 2005]
         assert_frame_equal(result, expected)
 
@@ -4907,7 +4907,7 @@ class TestSlicing(tm.TestCase):
         self.assertEqual(len(s['2001Q1']), 90)
 
         df = DataFrame(np.random.rand(len(dti), 5), index=dti)
-        self.assertEqual(len(df.ix['1Q01']), 90)
+        self.assertEqual(len(df.loc['1Q01']), 90)
 
     def test_slice_month(self):
         dti = DatetimeIndex(freq='D', start=datetime(2005, 1, 1), periods=500)
@@ -4915,7 +4915,7 @@ class TestSlicing(tm.TestCase):
         self.assertEqual(len(s['2005-11']), 30)
 
         df = DataFrame(np.random.rand(len(dti), 5), index=dti)
-        self.assertEqual(len(df.ix['2005-11']), 30)
+        self.assertEqual(len(df.loc['2005-11']), 30)
 
         assert_series_equal(s['2005-11'], s['11-2005'])
 
@@ -4945,7 +4945,7 @@ class TestSlicing(tm.TestCase):
         s = Series(np.arange(len(rng)), index=rng)
 
         result = s['2005-1-31']
-        assert_series_equal(result, s.ix[:24])
+        assert_series_equal(result, s.iloc[:24])
 
         self.assertRaises(Exception, s.__getitem__, '2004-12-31 00')
 
@@ -4955,12 +4955,12 @@ class TestSlicing(tm.TestCase):
         s = Series(np.arange(len(rng)), index=rng)
 
         result = s['2005-1-1']
-        assert_series_equal(result, s.ix[:60 * 4])
+        assert_series_equal(result, s.iloc[:60 * 4])
 
         result = s['2005-1-1 20']
-        assert_series_equal(result, s.ix[:60])
+        assert_series_equal(result, s.iloc[:60])
 
-        self.assertEqual(s['2005-1-1 20:00'], s.ix[0])
+        self.assertEqual(s['2005-1-1 20:00'], s.iloc[0])
         self.assertRaises(Exception, s.__getitem__, '2004-12-31 00:15')
 
     def test_partial_slice_minutely(self):
@@ -4969,12 +4969,12 @@ class TestSlicing(tm.TestCase):
         s = Series(np.arange(len(rng)), index=rng)
 
         result = s['2005-1-1 23:59']
-        assert_series_equal(result, s.ix[:60])
+        assert_series_equal(result, s.iloc[:60])
 
         result = s['2005-1-1']
-        assert_series_equal(result, s.ix[:60])
+        assert_series_equal(result, s.iloc[:60])
 
-        self.assertEqual(s[Timestamp('2005-1-1 23:59:00')], s.ix[0])
+        self.assertEqual(s[Timestamp('2005-1-1 23:59:00')], s.iloc[0])
         self.assertRaises(Exception, s.__getitem__, '2004-12-31 00:00:00')
 
     def test_partial_slice_second_precision(self):
@@ -5104,8 +5104,8 @@ class TestSlicing(tm.TestCase):
         assert_series_equal(result, expected)
 
         df2 = pd.DataFrame(s)
-        expected = df2.ix['2000-1-4']
-        result = df2.ix[pd.Timestamp('2000-1-4')]
+        expected = df2.xs('2000-1-4')
+        result = df2.loc[pd.Timestamp('2000-1-4')]
         assert_frame_equal(result, expected)
 
     def test_date_range_normalize(self):
@@ -5283,10 +5283,10 @@ class TestSlicing(tm.TestCase):
                                 r"Timestamp\('2014-01-10 00:00:00'\)",
                                 lambda: nonmonotonic[timestamp:])
 
-        assert_series_equal(nonmonotonic.ix['2014-01-10':], expected)
+        assert_series_equal(nonmonotonic.loc['2014-01-10':], expected)
         self.assertRaisesRegexp(KeyError,
                                 r"Timestamp\('2014-01-10 00:00:00'\)",
-                                lambda: nonmonotonic.ix[timestamp:])
+                                lambda: nonmonotonic.loc[timestamp:])
 
 
 class TimeConversionFormats(tm.TestCase):


### PR DESCRIPTION
closes #14218 
closes #15116 

This shows a pretty big deprecation message, though its instructive.
```
In [1]: df = pd.DataFrame({'A': [1, 2, 3],
   ...:                        'B': [4, 5, 6]},
   ...:                       index=list('abc'))
   ...: df
   ...: 
Out[1]: 
   A  B
a  1  4
b  2  5
c  3  6

In [2]: df.ix[[0, 2], 'A']
/Users/jreback/miniconda3/envs/pandas/bin/ipython:1: FutureWarning: 
.ix is deprecated. Please use
.loc for label based indexing or
.iloc for positional indexing

You an do multi-axes indexing like the following
>>> df = pd.DataFrame({'A': [1, 2, 3],
                       'B': [4, 5, 6]},
                      index=list('abc'))
>>> df
   A  B
a  1  4
b  2  5
c  3  6

From prior versions
>>> df.ix[[0, 2], 'A']
a    1
c    3
Name: A, dtype: int64

Using .loc
>>> df.loc[df.index[[0, 2]], 'A']
a    1
c    3
Name: A, dtype: int64

Using .iloc
>>> df.iloc[[0, 2]], df.columns.get_loc('A')]
a    1
c    3
Name: A, dtype: int64
```