### PR TITLE
BUG: Fix Series constructor when copy=True

### DIFF
--- a/doc/source/whatsnew/v0.20.0.txt
+++ b/doc/source/whatsnew/v0.20.0.txt
@@ -366,7 +366,7 @@ Bug Fixes
 
 
 
-
+- Bug in ``Series`` constructor when both ``copy=True`` and ``dtype`` arguments are provided (:issue:`15125`)
 - Bug in ``pd.read_csv()`` for the C engine where ``usecols`` were being indexed incorrectly with ``parse_dates`` (:issue:`14792`)
 
 - Bug in ``Series.dt.round`` inconsistent behaviour on NAT's with different arguments (:issue:`14940`)

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -237,7 +237,8 @@ class Series(base.IndexOpsMixin, strings.StringAccessorMixin,
             # create/copy the manager
             if isinstance(data, SingleBlockManager):
                 if dtype is not None:
-                    data = data.astype(dtype=dtype, raise_on_error=False)
+                    data = data.astype(dtype=dtype, raise_on_error=False,
+                                       copy=copy)
                 elif copy:
                     data = data.copy()
             else:

--- a/pandas/tests/series/test_constructors.py
+++ b/pandas/tests/series/test_constructors.py
@@ -251,6 +251,22 @@ class TestSeriesConstructors(TestData, tm.TestCase):
         s = Series(np.array([1., 1., np.nan]), copy=True, dtype='i8')
         self.assertEqual(s.dtype, np.dtype('f8'))
 
+    def test_constructor_copy(self):
+        # GH15125
+        # test dtype parameter has no side effects on copy=True
+        for data in [[1.], np.array([1.])]:
+            x = Series(data)
+            y = pd.Series(x, copy=True, dtype=float)
+
+            # copy=True maintains original data in Series
+            tm.assert_series_equal(x, y)
+
+            # changes to origin of copy does not affect the copy
+            x[0] = 2.
+            self.assertFalse(x.equals(y))
+            self.assertEqual(x[0], 2.)
+            self.assertEqual(y[0], 1.)
+
     def test_constructor_pass_none(self):
         s = Series(None, index=lrange(5))
         self.assertEqual(s.dtype, np.float64)


### PR DESCRIPTION
Updates Series constructor to include copy argument when dtype argument
is also provided. Adds tests for copy parameter.

xref #15125

 - [x] closes #15125
 - [x] tests added / passed
 - [x] passes ``git diff upstream/master | flake8 --diff``
 - [x] whatsnew entry
