### PR TITLE
Categoricals hash consistently

### DIFF
--- a/doc/source/whatsnew/v0.20.0.txt
+++ b/doc/source/whatsnew/v0.20.0.txt
@@ -309,6 +309,7 @@ Bug Fixes
 - Bug in ``pd.read_csv()`` in which the ``dialect`` parameter was not being verified before processing (:issue:`14898`)
 - Bug in ``pd.read_fwf`` where the skiprows parameter was not being respected during column width inference (:issue:`11256`)
 - Bug in ``pd.read_csv()`` in which missing data was being improperly handled with ``usecols`` (:issue:`6710`)
+- Bug in ``pandas.tools.hashing.hash_pandas_object`` in which hashing of categoricals depended on the ordering of categories, instead of just their values.
 
 - Bug in ``DataFrame.loc`` with indexing a ``MultiIndex`` with a ``Series`` indexer (:issue:`14730`)
 

--- a/doc/source/whatsnew/v0.20.0.txt
+++ b/doc/source/whatsnew/v0.20.0.txt
@@ -309,7 +309,7 @@ Bug Fixes
 - Bug in ``pd.read_csv()`` in which the ``dialect`` parameter was not being verified before processing (:issue:`14898`)
 - Bug in ``pd.read_fwf`` where the skiprows parameter was not being respected during column width inference (:issue:`11256`)
 - Bug in ``pd.read_csv()`` in which missing data was being improperly handled with ``usecols`` (:issue:`6710`)
-- Bug in ``pandas.tools.hashing.hash_pandas_object`` in which hashing of categoricals depended on the ordering of categories, instead of just their values.
+- Bug in ``pd.tools.hashing.hash_pandas_object()`` in which hashing of categoricals depended on the ordering of categories, instead of just their values. (:issue:`15143`)
 
 - Bug in ``DataFrame.loc`` with indexing a ``MultiIndex`` with a ``Series`` indexer (:issue:`14730`)
 

--- a/pandas/tools/tests/test_hashing.py
+++ b/pandas/tools/tests/test_hashing.py
@@ -90,6 +90,20 @@ class TestHashing(tm.TestCase):
             # these are by-definition the same with
             # or w/o the index as the data is empty
 
+    def test_categorical_consistency(self):
+        # Check that categoricals hash consistent with their values, not codes
+        # This should work for categoricals of any dtype
+        for data in [['a', 'b', 'c', 'd'], [1000, 2000, 3000, 4000]]:
+            s1 = Series(data)
+            s2 = s1.astype('category').cat.set_categories(data)
+            s3 = s2.cat.set_categories(list(reversed(data)))
+            # These should all hash identically
+            h1 = hash_pandas_object(s1)
+            h2 = hash_pandas_object(s2)
+            h3 = hash_pandas_object(s3)
+            tm.assert_series_equal(h1, h2)
+            tm.assert_series_equal(h1, h3)
+
     def test_errors(self):
 
         for obj in [pd.Timestamp('20130101'), tm.makePanel()]:

--- a/pandas/tools/tests/test_hashing.py
+++ b/pandas/tools/tests/test_hashing.py
@@ -93,16 +93,18 @@ class TestHashing(tm.TestCase):
     def test_categorical_consistency(self):
         # Check that categoricals hash consistent with their values, not codes
         # This should work for categoricals of any dtype
-        for data in [['a', 'b', 'c', 'd'], [1000, 2000, 3000, 4000]]:
-            s1 = Series(data)
-            s2 = s1.astype('category').cat.set_categories(data)
-            s3 = s2.cat.set_categories(list(reversed(data)))
-            # These should all hash identically
-            h1 = hash_pandas_object(s1)
-            h2 = hash_pandas_object(s2)
-            h3 = hash_pandas_object(s3)
-            tm.assert_series_equal(h1, h2)
-            tm.assert_series_equal(h1, h3)
+        for s1 in [Series(['a', 'b', 'c', 'd']),
+                   Series([1000, 2000, 3000, 4000]),
+                   Series(pd.date_range(0, periods=4))]:
+            s2 = s1.astype('category').cat.set_categories(s1)
+            s3 = s2.cat.set_categories(list(reversed(s1)))
+            for categorize in [True, False]:
+                # These should all hash identically
+                h1 = hash_pandas_object(s1, categorize=categorize)
+                h2 = hash_pandas_object(s2, categorize=categorize)
+                h3 = hash_pandas_object(s3, categorize=categorize)
+                tm.assert_series_equal(h1, h2)
+                tm.assert_series_equal(h1, h3)
 
     def test_errors(self):
 


### PR DESCRIPTION
Previously categorical values were hashed using just their codes. This
meant that the hash value depended on the ordering of the categories,
rather than on the values the series represented. This caused problems
in dask, where different partitions might have different categorical
mappings.

This PR makes the hashing dependent on the values the categorical
represents, rather than on the codes. The categories are first hashed,
and then the codes are remapped to the hashed values. This is slightly
slower than before (still need to hash the categories, where we didn't
before), but allows for more consistent hashing.

Related to this work in dask: https://github.com/dask/dask/pull/1877.