### PR TITLE
BUG: Segfault due to float_precision='round_trip'

### DIFF
--- a/doc/source/whatsnew/v0.20.0.txt
+++ b/doc/source/whatsnew/v0.20.0.txt
@@ -437,3 +437,5 @@ Bug Fixes
 
 - Bug in ``Series.dt.round`` inconsistent behaviour on NAT's with different arguments (:issue:`14940`)
 - Bug in ``.read_json()`` for Python 2 where ``lines=True`` and contents contain non-ascii unicode characters (:issue:`15132`)
+
+- Bug in ``pd.read_csv()`` with ``float_precision='round_trip'`` which caused a segfault when a text entry is parsed (:issue:`15140`)

--- a/pandas/io/tests/parser/c_parser_only.py
+++ b/pandas/io/tests/parser/c_parser_only.py
@@ -388,3 +388,10 @@ No,No,No"""
         df = self.read_csv(StringIO(test_input), sep='\t', nrows=1010)
 
         self.assertTrue(df.size == 1010 * 10)
+
+    def test_float_precision_round_trip_with_text(self):
+        # gh-15140 - This should not segfault on Python 2.7+
+        df = self.read_csv(StringIO('a'),
+                           float_precision='round_trip',
+                           header=None)
+        tm.assert_frame_equal(df, DataFrame({0: ['a']}))

--- a/pandas/src/parser/tokenizer.c
+++ b/pandas/src/parser/tokenizer.c
@@ -1773,11 +1773,9 @@ double precise_xstrtod(const char *str, char **endptr, char decimal, char sci,
 
 double round_trip(const char *p, char **q, char decimal, char sci, char tsep,
                   int skip_trailing) {
-#if PY_VERSION_HEX >= 0x02070000
-    return PyOS_string_to_double(p, q, 0);
-#else
-    return strtod(p, q);
-#endif
+    double r = PyOS_string_to_double(p, q, 0);
+    PyErr_Clear();
+    return r;
 }
 
 // End of xstrtod code

--- a/pandas/src/parser/tokenizer.h
+++ b/pandas/src/parser/tokenizer.h
@@ -201,7 +201,11 @@ typedef struct parser_t {
     PyObject *skipfunc;
     int64_t skip_first_N_rows;
     int skip_footer;
-    double (*converter)(const char *, char **, char, char, char, int);
+    // pick one, depending on whether the converter requires GIL
+    double (*double_converter_nogil)(const char *, char **,
+                                     char, char, char, int);
+    double (*double_converter_withgil)(const char *, char **,
+                                       char, char, char, int);
 
     // error handling
     char *warn_msg;


### PR DESCRIPTION
`round_trip` calls back into Python, so the GIL must be held.  It also fails to silence the Python exception, leading to spurious errors.

Closes #15140.

 - [x] closes #xxxx
 - [x] tests added / passed
 - [x] passes ``git diff upstream/master | flake8 --diff`` (*Most of them are false positives because flake8 doesn't understand Cython or it was code I didn't even touch*)
 - [x] whatsnew entry
