### PR TITLE
Apply fontsize to both x- and y-axis tick labels

### DIFF
--- a/doc/source/whatsnew/v0.20.0.txt
+++ b/doc/source/whatsnew/v0.20.0.txt
@@ -439,6 +439,9 @@ Bug Fixes
 - Bug in ``pd.read_csv()`` for the C engine where ``usecols`` were being indexed incorrectly with ``parse_dates`` (:issue:`14792`)
 
 - Bug in ``Series.dt.round`` inconsistent behaviour on NAT's with different arguments (:issue:`14940`)
+
 - Bug in ``.read_json()`` for Python 2 where ``lines=True`` and contents contain non-ascii unicode characters (:issue:`15132`)
 
 - Bug in ``pd.read_csv()`` with ``float_precision='round_trip'`` which caused a segfault when a text entry is parsed (:issue:`15140`)
+
+- Bug in ``DataFrame.boxplot`` where ``fontsize`` was not applied to the tick labels on both axes (:issue:`15108`)

--- a/pandas/tests/plotting/test_boxplot_method.py
+++ b/pandas/tests/plotting/test_boxplot_method.py
@@ -158,6 +158,11 @@ class TestDataFramePlots(TestPlotBase):
         df.loc[:, 0] = np.nan
         _check_plot_works(df.boxplot, return_type='axes')
 
+    def test_fontsize(self):
+        df = DataFrame({"a": [1, 2, 3, 4, 5, 6]})
+        self._check_ticks_props(df.boxplot("a", fontsize=16),
+                                xlabelsize=16, ylabelsize=16)
+
 
 @tm.mplskip
 class TestDataFrameGroupByPlots(TestPlotBase):
@@ -368,6 +373,11 @@ class TestDataFrameGroupByPlots(TestPlotBase):
             # pass different number of axes from required
             with tm.assert_produces_warning(UserWarning):
                 axes = df.groupby('classroom').boxplot(ax=axes)
+
+    def test_fontsize(self):
+        df = DataFrame({"a": [1, 2, 3, 4, 5, 6], "b": [0, 0, 0, 1, 1, 1]})
+        self._check_ticks_props(df.boxplot("a", by="b", fontsize=16),
+                                xlabelsize=16, ylabelsize=16)
 
 
 if __name__ == '__main__':

--- a/pandas/tools/plotting.py
+++ b/pandas/tools/plotting.py
@@ -2768,10 +2768,12 @@ def boxplot(data, column=None, by=None, ax=None, fontsize=None,
         keys = [pprint_thing(x) for x in keys]
         values = [remove_na(v) for v in values]
         bp = ax.boxplot(values, **kwds)
+        if fontsize is not None:
+            ax.tick_params(axis='both', labelsize=fontsize)
         if kwds.get('vert', 1):
-            ax.set_xticklabels(keys, rotation=rot, fontsize=fontsize)
+            ax.set_xticklabels(keys, rotation=rot)
         else:
-            ax.set_yticklabels(keys, rotation=rot, fontsize=fontsize)
+            ax.set_yticklabels(keys, rotation=rot)
         maybe_color_bp(bp)
 
         # Return axes in multiplot case, maybe revisit later # 985


### PR DESCRIPTION
 - [x] closes #15108
 - [x] tests added / passed
 - [x] passes ``git diff upstream/master | flake8 --diff``
 - [x] whatsnew entry
