### PR TITLE
Bug in groupby.get_group on categoricalindex

### DIFF
--- a/doc/source/whatsnew/v0.20.0.txt
+++ b/doc/source/whatsnew/v0.20.0.txt
@@ -389,6 +389,7 @@ Bug Fixes
 
 - Bug in compat for passing long integers to ``Timestamp.replace`` (:issue:`15030`)
 - Bug in ``.loc`` that would not return the correct dtype for scalar access for a DataFrame (:issue:`11617`)
+- Bug in ``GroupBy.get_group`` failing with a categorical grouper (:issue:`15155`)
 
 
 

--- a/pandas/indexes/category.py
+++ b/pandas/indexes/category.py
@@ -255,6 +255,9 @@ class CategoricalIndex(Index, base.PandasDelegate):
     def ordered(self):
         return self._data.ordered
 
+    def _reverse_indexer(self):
+        return self._data._reverse_indexer()
+
     def __contains__(self, key):
         hash(key)
         return key in self.values

--- a/pandas/tests/groupby/test_categorical.py
+++ b/pandas/tests/groupby/test_categorical.py
@@ -67,6 +67,22 @@ class TestGroupByCategorical(tm.TestCase):
              'E': np.random.randn(11),
              'F': np.random.randn(11)})
 
+    def test_level_groupby_get_group(self):
+        # gh15155
+        test = DataFrame(data=np.arange(2, 22, 2),
+                         index=MultiIndex(levels=[pd.CategoricalIndex(
+                             ["a", "b"]), range(10)],
+            labels=[[0] * 5 + [1] * 5, range(10)],
+            names=["Index1", "Index2"]))
+        testGroupedBy = test.groupby(level=["Index1"])
+        # expected should equal test.loc[["a"]], but does not - see gh15166
+        expected = DataFrame(data=np.arange(2, 12, 2),
+                             index=pd.MultiIndex(levels=[pd.CategoricalIndex(
+                                 ["a", "b"]), range(5)],
+            labels=[[0] * 5, range(5)],
+            names=["Index1", "Index2"]))
+        assert_frame_equal(testGroupedBy.get_group("a"), expected)
+
     def test_apply_use_categorical_name(self):
         from pandas import qcut
         cats = qcut(self.df.C, 4)


### PR DESCRIPTION
 - [x] closes #15155
 - [x] tests added / passed
 - [x] passes ``git diff upstream/master | flake8 --diff``
 - [x] whatsnew entry
