### PR TITLE
CI: have 34_SLOW build use matplotlib latest from conda-forge

### DIFF
--- a/ci/requirements-3.4_SLOW.build
+++ b/ci/requirements-3.4_SLOW.build
@@ -1,4 +1,4 @@
 python-dateutil
 pytz
-numpy=1.9.3
+numpy=1.10*
 cython

--- a/ci/requirements-3.4_SLOW.run
+++ b/ci/requirements-3.4_SLOW.run
@@ -1,6 +1,6 @@
 python-dateutil
 pytz
-numpy=1.9.3
+numpy=1.10*
 openpyxl
 xlsxwriter
 xlrd

--- a/ci/requirements-3.4_SLOW.sh
+++ b/ci/requirements-3.4_SLOW.sh
@@ -4,4 +4,4 @@ source activate pandas
 
 echo "install 34_slow"
 
-conda install -n pandas -c conda-forge/label/rc -c conda-forge matplotlib
+conda install -n pandas -c conda-forge matplotlib


### PR DESCRIPTION
CI: change 34_SLOW to use numpy 1.10* as mpl 2.0 requires anyhow
