### PR TITLE
PERF: DataFrame.groupby.nunique

### DIFF
--- a/doc/source/whatsnew/v0.20.0.txt
+++ b/doc/source/whatsnew/v0.20.0.txt
@@ -121,7 +121,7 @@ Other enhancements
 - ``Series.sort_index`` accepts parameters ``kind`` and ``na_position`` (:issue:`13589`, :issue:`14444`)
 
 - ``DataFrame`` has gained a ``nunique()`` method to count the distinct values over an axis (:issue:`14336`).
-- ``DataFrame.groupby()`` has gained a ``.nunique()`` method to count the distinct values for all columns within each group (:issue:`14336`).
+- ``DataFrame.groupby()`` has gained a ``.nunique()`` method to count the distinct values for all columns within each group (:issue:`14336`, :issue:`15197`).
 
 - ``pd.read_excel`` now preserves sheet order when using ``sheetname=None`` (:issue:`9930`)
 - Multiple offset aliases with decimal points are now supported (e.g. '0.5min' is parsed as '30s') (:issue:`8419`)

--- a/pandas/tests/groupby/test_groupby.py
+++ b/pandas/tests/groupby/test_groupby.py
@@ -2,6 +2,7 @@
 from __future__ import print_function
 import nose
 
+from string import ascii_lowercase
 from datetime import datetime
 from numpy import nan
 
@@ -1807,22 +1808,22 @@ class TestGroupBy(tm.TestCase):
             assert_frame_equal(left, right)
 
     def test_series_groupby_nunique(self):
-        from itertools import product
-        from string import ascii_lowercase
 
-        def check_nunique(df, keys):
-            for sort, dropna in product((False, True), repeat=2):
-                gr = df.groupby(keys, sort=sort)
+        def check_nunique(df, keys, as_index=True):
+            for sort, dropna in cart_product((False, True), repeat=2):
+                gr = df.groupby(keys, as_index=as_index, sort=sort)
                 left = gr['julie'].nunique(dropna=dropna)
 
-                gr = df.groupby(keys, sort=sort)
+                gr = df.groupby(keys, as_index=as_index, sort=sort)
                 right = gr['julie'].apply(Series.nunique, dropna=dropna)
+                if not as_index:
+                    right = right.reset_index(drop=True)
 
-                assert_series_equal(left, right)
+                assert_series_equal(left, right, check_names=False)
 
         days = date_range('2015-08-23', periods=10)
 
-        for n, m in product(10 ** np.arange(2, 6), (10, 100, 1000)):
+        for n, m in cart_product(10 ** np.arange(2, 6), (10, 100, 1000)):
             frame = DataFrame({
                 'jim': np.random.choice(
                     list(ascii_lowercase), n),
@@ -1841,6 +1842,8 @@ class TestGroupBy(tm.TestCase):
 
             check_nunique(frame, ['jim'])
             check_nunique(frame, ['jim', 'joe'])
+            check_nunique(frame, ['jim'], as_index=False)
+            check_nunique(frame, ['jim', 'joe'], as_index=False)
 
     def test_series_groupby_value_counts(self):
         from itertools import product


### PR DESCRIPTION
closes #15197

```
In [2]: %timeit df.groupby(['key1', 'key2']).nunique()
100 loops, best of 3: 9.31 ms per loop
```

```
    before     after       ratio
  [be3f2aea] [6d026165]
-  473.67μs   427.27μs      0.90  groupby.GroupBySuite.time_nunique('float', 100)
-     4.41s     9.53ms      0.00  groupby.groupby_nunique.time_groupby_nunique

SOME BENCHMARKS HAVE CHANGED SIGNIFICANTLY.
```