### PR TITLE
BUG: GH14233 resample().median() failed if duplicate column names wer…

### DIFF
--- a/doc/source/whatsnew/v0.20.0.txt
+++ b/doc/source/whatsnew/v0.20.0.txt
@@ -464,3 +464,6 @@ Bug Fixes
 
 
 - Bug in ``DataFrame.boxplot`` where ``fontsize`` was not applied to the tick labels on both axes (:issue:`15108`)
+
+- Bug in ``resample().median()`` if duplicate column names were present (:issue:`14233`)
+

--- a/pandas/core/groupby.py
+++ b/pandas/core/groupby.py
@@ -2203,7 +2203,6 @@ class BinGrouper(BaseGrouper):
     # cython aggregation
 
     _cython_functions = copy.deepcopy(BaseGrouper._cython_functions)
-    _cython_functions['aggregate'].pop('median')
 
 
 class Grouping(object):

--- a/pandas/tseries/tests/test_resample.py
+++ b/pandas/tseries/tests/test_resample.py
@@ -2934,9 +2934,8 @@ class TestResamplerGrouper(tm.TestCase):
     def test_median_duplicate_columns(self):
         # GH 14233
 
-        df = pd.DataFrame(np.array([[i + j for i in range(20)]
-                                    for j in [0, 100, 1000]])
-                          .T, columns=list('aaa'),
+        df = pd.DataFrame(np.random.randn(20, 3),
+                          columns=list('aaa'),
                           index=pd.date_range('2012-01-01',
                                               periods=20, freq='s'))
         df2 = df.copy()

--- a/pandas/tseries/tests/test_resample.py
+++ b/pandas/tseries/tests/test_resample.py
@@ -2931,6 +2931,21 @@ class TestResamplerGrouper(tm.TestCase):
         self.assertEqual(result.index.nlevels, 2)
         tm.assert_index_equal(result.index.levels[0], expected)
 
+    def test_median_duplicate_columns(self):
+        # GH 14233
+
+        df = pd.DataFrame(np.array([[i + j for i in range(20)]
+                                    for j in [0, 100, 1000]])
+                          .T, columns=list('aaa'),
+                          index=pd.date_range('2012-01-01',
+                                              periods=20, freq='s'))
+        df2 = df.copy()
+        df2.columns = ['a', 'b', 'c']
+        expected = df2.resample('5s').median()
+        result = df.resample('5s').median()
+        expected.columns = result.columns
+        assert_frame_equal(result, expected)
+
 
 class TestTimeGrouper(tm.TestCase):
     def setUp(self):


### PR DESCRIPTION
Simple fix for  median issue.  Should use cython implementation.

 - [X] closes #14233
 - [X] tests added / passed
 - [X] passes ``git diff upstream/master | flake8 --diff``
 - [X] whatsnew entry
