### PR TITLE
BUG: Remove locale conversion from Stata file date

### DIFF
--- a/doc/source/whatsnew/v0.20.0.txt
+++ b/doc/source/whatsnew/v0.20.0.txt
@@ -458,6 +458,7 @@ Bug Fixes
 
 - Bug in ``pd.read_csv()`` with ``float_precision='round_trip'`` which caused a segfault when a text entry is parsed (:issue:`15140`)
 
+- Bug in ``DataFrame.to_stata()`` and ``StataWriter`` which produces incorrectly formatted files to be produced for some locales (:issue:`13856`)
 
 
 

--- a/pandas/io/stata.py
+++ b/pandas/io/stata.py
@@ -2157,9 +2157,15 @@ class StataWriter(StataParser):
             time_stamp = datetime.datetime.now()
         elif not isinstance(time_stamp, datetime.datetime):
             raise ValueError("time_stamp should be datetime type")
-        self._file.write(
-            self._null_terminate(time_stamp.strftime("%d %b %Y %H:%M"))
-        )
+        # GH #13856
+        # Avoid locale-specific month conversion
+        months = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug',
+                  'Sep', 'Oct', 'Nov', 'Dec']
+        month_lookup = {i + 1: month for i, month in enumerate(months)}
+        ts = (time_stamp.strftime("%d ") +
+              month_lookup[time_stamp.month] +
+              time_stamp.strftime(" %Y %H:%M"))
+        self._file.write(self._null_terminate(ts))
 
     def _write_descriptors(self, typlist=None, varlist=None, srtlist=None,
                            fmtlist=None, lbllist=None):

--- a/pandas/io/tests/test_stata.py
+++ b/pandas/io/tests/test_stata.py
@@ -484,9 +484,7 @@ class TestStata(tm.TestCase):
                               data_label=data_label)
 
             with StataReader(path) as reader:
-                parsed_time_stamp = dt.datetime.strptime(
-                    reader.time_stamp, ('%d %b %Y %H:%M'))
-                assert parsed_time_stamp == time_stamp
+                assert reader.time_stamp == '29 Feb 2000 14:21'
                 assert reader.data_label == data_label
 
     def test_numeric_column_names(self):


### PR DESCRIPTION
Prevent locale from affecting Stata file date creation, which must
be en_US.

xref #13856

 - [x] tests added / passed
 - [x] passes ``git diff upstream/master | flake8 --diff``
 - [x] whatsnew entry
