### PR TITLE
BUG: TimedeltaIndex raising ValueError when boolean indexing (#14946)

### DIFF
--- a/doc/source/whatsnew/v0.20.0.txt
+++ b/doc/source/whatsnew/v0.20.0.txt
@@ -380,6 +380,7 @@ Bug Fixes
 
 - Bug in ``Index`` power operations with reversed operands (:issue:`14973`)
 - Bug in ``TimedeltaIndex`` addition where overflow was being allowed without error (:issue:`14816`)
+- Bug in ``TimedeltaIndex`` raising a ``ValueError`` when boolean indexing with ``loc`` (:issue:`14946`)
 - Bug in ``astype()`` where ``inf`` values were incorrectly converted to integers. Now raises error now with ``astype()`` for Series and DataFrames (:issue:`14265`)
 - Bug in ``DataFrame(..).apply(to_numeric)`` when values are of type decimal.Decimal. (:issue:`14827`)
 - Bug in ``describe()`` when passing a numpy array which does not contain the median to the ``percentiles`` keyword argument (:issue:`14908`)

--- a/pandas/tests/indexing/test_indexing.py
+++ b/pandas/tests/indexing/test_indexing.py
@@ -5498,6 +5498,25 @@ class TestDataframeNoneCoercion(tm.TestCase):
         tm.assert_frame_equal(start_dataframe, exp)
 
 
+class TestTimedeltaIndexing(tm.TestCase):
+
+    def test_boolean_indexing(self):
+        # GH 14946
+        df = pd.DataFrame({'x': range(10)})
+        df.index = pd.to_timedelta(range(10), unit='s')
+        conditions = [df['x'] > 3, df['x'] == 3, df['x'] < 3]
+        expected_data = [[0, 1, 2, 3, 10, 10, 10, 10, 10, 10],
+                         [0, 1, 2, 10, 4, 5, 6, 7, 8, 9],
+                         [10, 10, 10, 3, 4, 5, 6, 7, 8, 9]]
+        for cond, data in zip(conditions, expected_data):
+            result = df.copy()
+            result.loc[cond, 'x'] = 10
+            expected = pd.DataFrame(data,
+                                    index=pd.to_timedelta(range(10), unit='s'),
+                                    columns=['x'])
+            tm.assert_frame_equal(expected, result)
+
+
 if __name__ == '__main__':
     nose.runmodule(argv=[__file__, '-vvs', '-x', '--pdb', '--pdb-failure'],
                    exit=False)

--- a/pandas/tseries/tdi.py
+++ b/pandas/tseries/tdi.py
@@ -14,7 +14,7 @@ from pandas.types.common import (_TD_DTYPE,
                                  _ensure_int64)
 from pandas.types.missing import isnull
 from pandas.types.generic import ABCSeries
-from pandas.core.common import _maybe_box, _values_from_object
+from pandas.core.common import _maybe_box, _values_from_object, is_bool_indexer
 
 from pandas.core.index import Index, Int64Index
 import pandas.compat as compat
@@ -672,6 +672,9 @@ class TimedeltaIndex(DatetimeIndexOpsMixin, TimelikeOps, Int64Index):
         -------
         loc : int
         """
+
+        if is_bool_indexer(key):
+            raise TypeError
 
         if isnull(key):
             key = tslib.NaT


### PR DESCRIPTION
 - [x] closes #14946
 - [x] tests added / passed
 - [x] passes ``git diff upstream/master | flake8 --diff``
 - [x] whatsnew entry

Implementing patch suggested by @jreback [here](https://github.com/pandas-dev/pandas/issues/14946#issuecomment-268666453) that prevents raising a `ValueError` when boolean indexing with a `TimedeltaIndex`