### PR TITLE
BUG/API: Return a Series from DataFrame.asof with no match

### DIFF
--- a/doc/source/whatsnew/v0.20.0.txt
+++ b/doc/source/whatsnew/v0.20.0.txt
@@ -327,7 +327,7 @@ Other API Changes
 - ``pd.read_csv()`` will now raise a ``ValueError`` for the C engine if the quote character is larger than than one byte (:issue:`11592`)
 - ``inplace`` arguments now require a boolean value, else a ``ValueError`` is thrown (:issue:`14189`)
 - ``pandas.api.types.is_datetime64_ns_dtype`` will now report ``True`` on a tz-aware dtype, similar to ``pandas.api.types.is_datetime64_any_dtype``
- - ``DataFrame.asof`` will return a null filled ``Series`` instead the scalar ``NaN`` if a match is not found (:issue:`15118`)
+ - ``DataFrame.asof()`` will return a null filled ``Series`` instead the scalar ``NaN`` if a match is not found (:issue:`15118`)
 .. _whatsnew_0200.deprecations:
 
 Deprecations

--- a/doc/source/whatsnew/v0.20.0.txt
+++ b/doc/source/whatsnew/v0.20.0.txt
@@ -327,7 +327,7 @@ Other API Changes
 - ``pd.read_csv()`` will now raise a ``ValueError`` for the C engine if the quote character is larger than than one byte (:issue:`11592`)
 - ``inplace`` arguments now require a boolean value, else a ``ValueError`` is thrown (:issue:`14189`)
 - ``pandas.api.types.is_datetime64_ns_dtype`` will now report ``True`` on a tz-aware dtype, similar to ``pandas.api.types.is_datetime64_any_dtype``
-
+ - ``DataFrame.asof`` will return a null filled ``Series`` instead the scalar ``NaN`` if a match is not found (:issue:`15118`)
 .. _whatsnew_0200.deprecations:
 
 Deprecations

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -3783,7 +3783,8 @@ class NDFrame(PandasObject):
 
         .. versionadded:: 0.19.0 For DataFrame
 
-        If there is no good value, NaN is returned.
+        If there is no good value, NaN is returned for a Series
+        a Series of NaN values for a DataFrame
 
         Parameters
         ----------
@@ -3839,6 +3840,9 @@ class NDFrame(PandasObject):
                 start = start.ordinal
 
             if where < start:
+                if not is_series:
+                    from pandas import Series
+                    return Series(index=self.columns, name=where)
                 return np.nan
 
             # It's always much faster to use a *while* loop here for

--- a/pandas/tests/frame/test_asof.py
+++ b/pandas/tests/frame/test_asof.py
@@ -70,6 +70,7 @@ class TestFrameAsof(TestData, tm.TestCase):
 
     def test_missing(self):
         # GH 15118
+        # no match found - `where` value before earliest date in index
         N = 10
         rng = date_range('1/1/1990', periods=N, freq='53s')
         df = DataFrame({'A': np.arange(N), 'B': np.arange(N)},


### PR DESCRIPTION
 - [x] closes #15118
 - [x] tests added / passed
 - [x] passes ``git diff upstream/master | flake8 --diff``
 - [x] whatsnew entry

Technically this is an API change, but more of a bug so didn't think there was a need to warn / deprecate?

Also there seems to be room to clean up the whole `asof` implementation, xref #10343, but wanted to keep that separate