### PR TITLE
Do not cast .transform() output back to input dtype (closes #10972)

### DIFF
--- a/doc/source/whatsnew/v0.20.0.txt
+++ b/doc/source/whatsnew/v0.20.0.txt
@@ -502,7 +502,7 @@ Bug Fixes
 
 - Bug in ``DataFrame.to_stata()`` and ``StataWriter`` which produces incorrectly formatted files to be produced for some locales (:issue:`13856`)
 
-
+- Bug in ``DataFrame.groupby().transform()`` dtype of output is cast to dtype of input (:issue:`10972`)
 
 
 

--- a/pandas/tests/groupby/test_groupby.py
+++ b/pandas/tests/groupby/test_groupby.py
@@ -1308,7 +1308,8 @@ class TestGroupBy(tm.TestCase):
     def test_with_na(self):
         index = Index(np.arange(10))
 
-        for dtype in ['float64', 'float32', 'int64', 'int32', 'int16', 'int8']:
+        for dtype in ['float64', 'float32', 'int64', 'int32', 'int16', 'int8',
+                      'datetime64[ns]']:
             values = Series(np.ones(10), index, dtype=dtype)
             labels = Series([nan, 'foo', 'bar', 'bar', nan, nan, 'bar',
                              'bar', nan, 'foo'], index=index)
@@ -1316,9 +1317,13 @@ class TestGroupBy(tm.TestCase):
             # this SHOULD be an int
             grouped = values.groupby(labels)
             agged = grouped.agg(len)
-            expected = Series([4, 2], index=['bar', 'foo'])
 
-            assert_series_equal(agged, expected, check_dtype=False)
+            if dtype != "datetime64[ns]":
+                expected = Series([4, 2], index=['bar', 'foo'], dtype=dtype)
+            else:
+                expected = Series([4, 2], index=['bar', 'foo'])
+
+            assert_series_equal(agged, expected)
 
             # self.assertTrue(issubclass(agged.dtype.type, np.integer))
 
@@ -1328,8 +1333,11 @@ class TestGroupBy(tm.TestCase):
 
             agged = grouped.agg(f)
             expected = Series([4, 2], index=['bar', 'foo'])
-
             assert_series_equal(agged, expected, check_dtype=False)
+
+            if dtype == "datetime64[ns]":
+                continue
+
             self.assertTrue(issubclass(agged.dtype.type, np.dtype(dtype).type))
 
     def test_groupby_transform_with_int(self):

--- a/pandas/tseries/tests/test_resample.py
+++ b/pandas/tseries/tests/test_resample.py
@@ -1805,11 +1805,19 @@ class TestDatetimeIndex(Base, tm.TestCase):
                                           datetime(2012, 1, 1, 0, 5, 0)],
                            dtype=dtype)
 
+            result = df.resample("T").mean()
+            exp = df.asfreq('T')
+            tm.assert_frame_equal(result, exp)
+
             result = df.resample("T").apply(lambda x: x.mean())
             exp = df.asfreq('T')
             tm.assert_frame_equal(result, exp)
 
             result = df.resample("T").median()
+            exp = df.asfreq('T')
+            tm.assert_frame_equal(result, exp)
+
+            result = df.resample("T").apply(lambda x: x.median())
             exp = df.asfreq('T')
             tm.assert_frame_equal(result, exp)
 


### PR DESCRIPTION
 - [x] closes #10972
 - [x] tests added / passed
 - [x] passes ``git diff upstream/master | flake8 --diff``
 - [x] whatsnew entry

Maybe need more tests, and check performance?