### PR TITLE
API: change default behaviour of str.match from deprecated extract to match (GH5224)

### DIFF
--- a/doc/source/text.rst
+++ b/doc/source/text.rst
@@ -385,18 +385,6 @@ or match a pattern:
 The distinction between ``match`` and ``contains`` is strictness: ``match``
 relies on strict ``re.match``, while ``contains`` relies on ``re.search``.
 
-.. warning::
-
-   In previous versions, ``match`` was for *extracting* groups,
-   returning a not-so-convenient Series of tuples. The new method ``extract``
-   (described in the previous section) is now preferred.
-
-   This old, deprecated behavior of ``match`` is still the default. As
-   demonstrated above, use the new behavior by setting ``as_indexer=True``.
-   In this mode, ``match`` is analogous to ``contains``, returning a boolean
-   Series. The new behavior will become the default behavior in a future
-   release.
-
 Methods like ``match``, ``contains``, ``startswith``, and ``endswith`` take
  an extra ``na`` argument so missing values can be considered True or False:
 

--- a/doc/source/whatsnew/v0.20.0.txt
+++ b/doc/source/whatsnew/v0.20.0.txt
@@ -729,6 +729,11 @@ Other API Changes
 - ``Series.sort_values()`` accepts a one element list of bool for consistency with the behavior of ``DataFrame.sort_values()`` (:issue:`15604`)
 - ``.merge()`` and ``.join()`` on ``category`` dtype columns will now preserve the category dtype when possible (:issue:`10409`)
 - ``SparseDataFrame.default_fill_value`` will be 0, previously was ``nan`` in the return from ``pd.get_dummies(..., sparse=True)`` (:issue:`15594`)
+- The default behaviour of ``Series.str.match`` has changed from extracting
+  groups to matching the pattern. The extracting behaviour was deprecated
+  since pandas version 0.13.0 and can be done with the ``Series.str.extract``
+  method (:issue:`5224`).
+
 
 .. _whatsnew_0200.deprecations:
 

--- a/doc/source/whatsnew/v0.20.0.txt
+++ b/doc/source/whatsnew/v0.20.0.txt
@@ -732,7 +732,8 @@ Other API Changes
 - The default behaviour of ``Series.str.match`` has changed from extracting
   groups to matching the pattern. The extracting behaviour was deprecated
   since pandas version 0.13.0 and can be done with the ``Series.str.extract``
-  method (:issue:`5224`).
+  method (:issue:`5224`). As a consequence, the ``as_indexer`` keyword is
+  ignored (no longer needed to specify the new behaviour) and is deprecated.
 
 
 .. _whatsnew_0200.deprecations:
@@ -750,6 +751,7 @@ Deprecations
 - ``Series.sortlevel`` and ``DataFrame.sortlevel`` have been deprecated in favor of ``Series.sort_index`` and ``DataFrame.sort_index`` (:issue:`15099`)
 - importing ``concat`` from ``pandas.tools.merge`` has been deprecated in favor of imports from the ``pandas`` namespace. This should only affect explict imports (:issue:`15358`)
 - ``Series/DataFrame/Panel.consolidate()`` been deprecated as a public method. (:issue:`15483`)
+- The ``as_indexer`` keyword of ``Series.str.match()`` has been deprecated (ignored keyword) (:issue:`15257`).
 - The following top-level pandas functions have been deprecated and will be removed in a future version (:issue:`13790`)
   * ``pd.pnow()``, replaced by ``Period.now()``
   * ``pd.Term``, is removed, as it is not applicable to user code. Instead use in-line string expressions in the where clause when searching in HDFStore

--- a/pandas/core/strings.py
+++ b/pandas/core/strings.py
@@ -477,7 +477,6 @@ def str_match(arr, pat, case=True, flags=0, na=np.nan, as_indexer=None):
     flags : int, default 0 (no flags)
         re module flags, e.g. re.IGNORECASE
     na : default NaN, fill value for missing values.
-    as_indexer : ignored
 
     Returns
     -------
@@ -495,7 +494,10 @@ def str_match(arr, pat, case=True, flags=0, na=np.nan, as_indexer=None):
 
     regex = re.compile(pat, flags=flags)
 
-    if as_indexer is not None:
+    if (as_indexer is False) and (regex.groups > 0):
+        raise ValueError("as_indexer=False with a pattern with groups is no "
+                         "longer supported. Use '.str.extract(pat)' instead")
+    elif as_indexer is not None:
         # Previously, this keyword was used for changing the default but
         # deprecated behaviour. This keyword is now no longer needed.
         warnings.warn("'as_indexer' keyword was specified but will be ignored;"
@@ -1558,7 +1560,7 @@ class StringMethods(NoNewAttributesMixin):
         return self._wrap_result(result)
 
     @copy(str_match)
-    def match(self, pat, case=True, flags=0, na=np.nan, as_indexer=False):
+    def match(self, pat, case=True, flags=0, na=np.nan, as_indexer=None):
         result = str_match(self._data, pat, case=case, flags=flags, na=na,
                            as_indexer=as_indexer)
         return self._wrap_result(result)

--- a/pandas/core/strings.py
+++ b/pandas/core/strings.py
@@ -477,6 +477,7 @@ def str_match(arr, pat, case=True, flags=0, na=np.nan, as_indexer=None):
     flags : int, default 0 (no flags)
         re module flags, e.g. re.IGNORECASE
     na : default NaN, fill value for missing values.
+    as_indexer : ignored and deprecated
 
     Returns
     -------
@@ -500,9 +501,10 @@ def str_match(arr, pat, case=True, flags=0, na=np.nan, as_indexer=None):
     elif as_indexer is not None:
         # Previously, this keyword was used for changing the default but
         # deprecated behaviour. This keyword is now no longer needed.
-        warnings.warn("'as_indexer' keyword was specified but will be ignored;"
-                      " match now returns a boolean indexer by default.",
-                      UserWarning, stacklevel=3)
+        warnings.warn("'as_indexer' keyword was specified but is ignored "
+                      "(match now returns a boolean indexer by default), "
+                      "and will be removed in a future version.",
+                      FutureWarning, stacklevel=3)
 
     dtype = bool
     f = lambda x: bool(regex.match(x))

--- a/pandas/core/strings.py
+++ b/pandas/core/strings.py
@@ -464,11 +464,9 @@ def str_repeat(arr, repeats):
         return result
 
 
-def str_match(arr, pat, case=True, flags=0, na=np.nan, as_indexer=False):
+def str_match(arr, pat, case=True, flags=0, na=np.nan, as_indexer=None):
     """
-    Deprecated: Find groups in each string in the Series/Index
-    using passed regular expression.
-    If as_indexer=True, determine if each string matches a regular expression.
+    Determine if each string matches a regular expression.
 
     Parameters
     ----------
@@ -479,60 +477,33 @@ def str_match(arr, pat, case=True, flags=0, na=np.nan, as_indexer=False):
     flags : int, default 0 (no flags)
         re module flags, e.g. re.IGNORECASE
     na : default NaN, fill value for missing values.
-    as_indexer : False, by default, gives deprecated behavior better achieved
-        using str_extract. True return boolean indexer.
+    as_indexer : ignored
 
     Returns
     -------
     Series/array of boolean values
-        if as_indexer=True
-    Series/Index of tuples
-        if as_indexer=False, default but deprecated
 
     See Also
     --------
     contains : analogous, but less strict, relying on re.search instead of
         re.match
-    extract : now preferred to the deprecated usage of match (as_indexer=False)
+    extract : extract matched groups
 
-    Notes
-    -----
-    To extract matched groups, which is the deprecated behavior of match, use
-    str.extract.
     """
-
     if not case:
         flags |= re.IGNORECASE
 
     regex = re.compile(pat, flags=flags)
 
-    if (not as_indexer) and regex.groups > 0:
-        # Do this first, to make sure it happens even if the re.compile
-        # raises below.
-        warnings.warn("In future versions of pandas, match will change to"
-                      " always return a bool indexer.", FutureWarning,
-                      stacklevel=3)
+    if as_indexer is not None:
+        # Previously, this keyword was used for changing the default but
+        # deprecated behaviour. This keyword is now no longer needed.
+        warnings.warn("'as_indexer' keyword was specified but will be ignored;"
+                      " match now returns a boolean indexer by default.",
+                      UserWarning, stacklevel=3)
 
-    if as_indexer and regex.groups > 0:
-        warnings.warn("This pattern has match groups. To actually get the"
-                      " groups, use str.extract.", UserWarning, stacklevel=3)
-
-    # If not as_indexer and regex.groups == 0, this returns empty lists
-    # and is basically useless, so we will not warn.
-
-    if (not as_indexer) and regex.groups > 0:
-        dtype = object
-
-        def f(x):
-            m = regex.match(x)
-            if m:
-                return m.groups()
-            else:
-                return []
-    else:
-        # This is the new behavior of str_match.
-        dtype = bool
-        f = lambda x: bool(regex.match(x))
+    dtype = bool
+    f = lambda x: bool(regex.match(x))
 
     return _na_map(f, arr, na, dtype=dtype)
 

--- a/pandas/tests/test_strings.py
+++ b/pandas/tests/test_strings.py
@@ -2585,8 +2585,8 @@ class TestStringMethods(tm.TestCase):
 
         pat = r'([A-Z0-9._%+-]+)@([A-Z0-9.-]+)\.([A-Z]{2,4})'
 
-        result = data.str.extract(pat, flags=re.IGNORECASE)
-        self.assertEqual(result[0], ('dave', 'google', 'com'))
+        result = data.str.extract(pat, flags=re.IGNORECASE, expand=True)
+        self.assertEqual(result.iloc[0].tolist(), ['dave', 'google', 'com'])
 
         result = data.str.match(pat, flags=re.IGNORECASE)
         self.assertEqual(result[0], True)

--- a/pandas/tests/test_strings.py
+++ b/pandas/tests/test_strings.py
@@ -580,6 +580,11 @@ class TestStringMethods(tm.TestCase):
         with tm.assert_produces_warning(UserWarning):
             result = values.str.match('.*BAD[_]+.*BAD', as_indexer=False)
         tm.assert_series_equal(result, exp)
+        with tm.assert_produces_warning(UserWarning):
+            result = values.str.match('.*(BAD[_]+).*(BAD)', as_indexer=True)
+        tm.assert_series_equal(result, exp)
+        self.assertRaises(ValueError, values.str.match, '.*(BAD[_]+).*(BAD)',
+                          as_indexer=False)
 
         # mixed
         mixed = Series(['aBAD_BAD', NA, 'BAD_b_BAD', True, datetime.today(),

--- a/pandas/tests/test_strings.py
+++ b/pandas/tests/test_strings.py
@@ -574,13 +574,13 @@ class TestStringMethods(tm.TestCase):
         # test passing as_indexer still works but is ignored
         values = Series(['fooBAD__barBAD', NA, 'foo'])
         exp = Series([True, NA, False])
-        with tm.assert_produces_warning(UserWarning):
+        with tm.assert_produces_warning(FutureWarning):
             result = values.str.match('.*BAD[_]+.*BAD', as_indexer=True)
         tm.assert_series_equal(result, exp)
-        with tm.assert_produces_warning(UserWarning):
+        with tm.assert_produces_warning(FutureWarning):
             result = values.str.match('.*BAD[_]+.*BAD', as_indexer=False)
         tm.assert_series_equal(result, exp)
-        with tm.assert_produces_warning(UserWarning):
+        with tm.assert_produces_warning(FutureWarning):
             result = values.str.match('.*(BAD[_]+).*(BAD)', as_indexer=True)
         tm.assert_series_equal(result, exp)
         self.assertRaises(ValueError, values.str.match, '.*(BAD[_]+).*(BAD)',


### PR DESCRIPTION
I just stumbled on this, and seems we didn't have this in our deprecations to do list (https://github.com/pandas-dev/pandas/issues/6581).

This PR changes the default behaviour of `str.match` from extracting groups to just a match (True/False). The previous default behaviour was deprecated since 0.13.0 (https://github.com/pandas-dev/pandas/pull/5224)