### PR TITLE
Fix overflow error in cartesian_product

### DIFF
--- a/doc/source/whatsnew/v0.19.2.txt
+++ b/doc/source/whatsnew/v0.19.2.txt
@@ -80,3 +80,4 @@ Bug Fixes
 - Explicit check in ``to_stata`` and ``StataWriter`` for out-of-range values when writing doubles (:issue:`14618`)
 - Bug in ``.plot(kind='kde')`` which did not drop missing values to generate the KDE Plot, instead generating an empty plot. (:issue:`14821`)
 - Bug in ``unstack()`` if called with a list of column(s) as an argument, regardless of the dtypes of all columns, they get coerced to ``object`` (:issue:`11847`)
+- Fix bug (:issue:`15265`) in ``cartesian_product`` in ``pandas.tools.util`` that caused an uncaught overflow error when using large arguments.

--- a/pandas/tools/tests/test_util.py
+++ b/pandas/tools/tests/test_util.py
@@ -57,15 +57,6 @@ class TestCartesianProduct(tm.TestCase):
         msg = "Input must be a list-like of list-likes"
         for X in invalid_inputs:
             tm.assertRaisesRegexp(TypeError, msg, cartesian_product, X=X)
-            
-    def test_large_input(self):
-        # test failure of large inputs on windows OS
-        X = np.arange(65536)
-        Y = np.arange(65535)
-        result1, result2 = cartesian_product([X, Y])
-        expected_size = X.size * Y.size
-        tm.assert_equal(result1.size, expected_size)
-        tm.assert_equal(result2.size, expected_size)
 
 
 class TestLocaleUtils(tm.TestCase):

--- a/pandas/tools/tests/test_util.py
+++ b/pandas/tools/tests/test_util.py
@@ -63,9 +63,9 @@ class TestCartesianProduct(tm.TestCase):
         X = np.arange(65536)
         Y = np.arange(65535)
         result1, result2 = cartesian_product([X, Y])
-        expected1, expected2 = np.asarray(list(pd.compat.product(X, Y))).T
-        tm.assert_numpy_array_equal(result1, expected1)
-        tm.assert_numpy_array_equal(result2, expected2)
+        expected_size = X.size * Y.size
+        tm.assert_equal(result1.size, expected_size)
+        tm.assert_equal(result2.size, expected_size)
 
 
 class TestLocaleUtils(tm.TestCase):

--- a/pandas/tools/tests/test_util.py
+++ b/pandas/tools/tests/test_util.py
@@ -57,6 +57,15 @@ class TestCartesianProduct(tm.TestCase):
         msg = "Input must be a list-like of list-likes"
         for X in invalid_inputs:
             tm.assertRaisesRegexp(TypeError, msg, cartesian_product, X=X)
+            
+    def test_large_input(self):
+        # test failure of large inputs on windows OS
+        X = np.arange(65536)
+        Y = np.arange(65535)
+        result1, result2 = cartesian_product([X, Y])
+        expected1, expected2 = np.asarray(list(pd.compat.product(X, Y))).T
+        tm.assert_numpy_array_equal(result1, expected1)
+        tm.assert_numpy_array_equal(result2, expected2)
 
 
 class TestLocaleUtils(tm.TestCase):

--- a/pandas/tools/util.py
+++ b/pandas/tools/util.py
@@ -55,7 +55,7 @@ def cartesian_product(X):
     if len(X) == 0:
         return []
 
-    lenX = np.fromiter((len(x) for x in X), dtype=int)
+    lenX = np.fromiter((len(x) for x in X), dtype=np.intp)
     cumprodX = np.cumproduct(lenX)
 
     a = np.roll(cumprodX, 1)


### PR DESCRIPTION
When the numbers in `X` are large it can cause an overflow error on windows machine where the native `int` is 32 bit. Switching to np.intp alleviates this problem.

Other fixes would include switching to np.uint32 or np.uint64.

#15234 
