### PR TITLE
ENH: Add empty property to Index.

### DIFF
--- a/doc/source/whatsnew/v0.20.0.txt
+++ b/doc/source/whatsnew/v0.20.0.txt
@@ -155,6 +155,7 @@ Other enhancements
 - ``Series/DataFrame.squeeze()`` have gained the ``axis`` parameter. (:issue:`15339`)
 - ``DataFrame.to_excel()`` has a new ``freeze_panes`` parameter to turn on Freeze Panes when exporting to Excel (:issue:`15160`)
 - HTML table output skips ``colspan`` or ``rowspan`` attribute if equal to 1. (:issue:`15403`)
+- Added ``.empty`` property to subclasses of ``Index``. (:issue:`15270`)
 
 .. _ISO 8601 duration: https://en.wikipedia.org/wiki/ISO_8601#Durations
 

--- a/pandas/core/base.py
+++ b/pandas/core/base.py
@@ -879,6 +879,10 @@ class IndexOpsMixin(object):
         """ the internal implementation """
         return self.values
 
+    @property
+    def empty(self):
+        return not self.size
+
     def max(self):
         """ The maximum value of the object """
         return nanops.nanmax(self.values)

--- a/pandas/tests/indexes/common.py
+++ b/pandas/tests/indexes/common.py
@@ -904,3 +904,9 @@ class Base(object):
                     result = isnull(index)
                     self.assert_numpy_array_equal(index.isnull(), result)
                     self.assert_numpy_array_equal(index.notnull(), ~result)
+
+    def test_empty(self):
+        # GH 15270
+        index = self.create_index()
+        self.assertFalse(index.empty)
+        self.assertTrue(index[:0].empty)


### PR DESCRIPTION
Previously, attempting to evaluate an Index in a boolean context prints
an error message listing various alternatives, one of which is `.empty`,
which was not actually implemented on `Index`.

 - [x] closes #13207
 - [x] tests added / passed
 - [x] passes ``git diff upstream/master | flake8 --diff``
 - [x] whatsnew entry
