### PR TITLE
BUG: Support empty dict-likes in replace()

### DIFF
--- a/doc/source/whatsnew/v0.20.0.txt
+++ b/doc/source/whatsnew/v0.20.0.txt
@@ -512,3 +512,4 @@ Bug Fixes
 
 
 - Bug in ``DataFrame.boxplot`` where ``fontsize`` was not applied to the tick labels on both axes (:issue:`15108`)
+- Bug in ``Series.replace`` and ``DataFrame.replace`` which failed on empty replacement dicts (:issue:`15289`)

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -48,7 +48,7 @@ from pandas.formats.format import format_percentiles
 from pandas.tseries.frequencies import to_offset
 from pandas import compat
 from pandas.compat.numpy import function as nv
-from pandas.compat import (map, zip, lrange, string_types,
+from pandas.compat import (map, zip, lzip, lrange, string_types,
                            isidentifier, set_function_name)
 import pandas.core.nanops as nanops
 from pandas.util.decorators import Appender, Substitution, deprecate_kwarg
@@ -3509,7 +3509,7 @@ class NDFrame(PandasObject):
                 regex = True
 
             items = list(compat.iteritems(to_replace))
-            keys, values = zip(*items)
+            keys, values = lzip(*items) or ([], [])
 
             are_mappings = [is_dict_like(v) for v in values]
 
@@ -3523,7 +3523,7 @@ class NDFrame(PandasObject):
                 value_dict = {}
 
                 for k, v in items:
-                    keys, values = zip(*v.items())
+                    keys, values = lzip(*v.items()) or ([], [])
                     if set(keys) & set(values):
                         raise ValueError("Replacement not allowed with "
                                          "overlapping keys and values")

--- a/pandas/tests/frame/test_replace.py
+++ b/pandas/tests/frame/test_replace.py
@@ -1055,3 +1055,13 @@ class TestDataFrameReplace(tm.TestCase, TestData):
                                     Timestamp('20130103', tz='US/Eastern')],
                               'B': [0, np.nan, 2]})
         assert_frame_equal(result, expected)
+
+    def test_replace_with_empty_dictlike(self):
+        # GH 15289
+        mix = {'a': lrange(4), 'b': list('ab..'), 'c': ['a', 'b', nan, 'd']}
+        df = DataFrame(mix)
+        assert_frame_equal(df, df.replace({}))
+        assert_frame_equal(df, df.replace(Series([])))
+
+        assert_frame_equal(df, df.replace({'b': {}}))
+        assert_frame_equal(df, df.replace(Series({'b': {}})))

--- a/pandas/tests/series/test_replace.py
+++ b/pandas/tests/series/test_replace.py
@@ -223,3 +223,9 @@ class TestSeriesReplace(TestData, tm.TestCase):
         self.assertTrue((ser[:5] == -1).all())
         self.assertTrue((ser[6:10] == -1).all())
         self.assertTrue((ser[20:30] == -1).all())
+
+    def test_replace_with_empty_dictlike(self):
+        # GH 15289
+        s = pd.Series(list('abcd'))
+        tm.assert_series_equal(s, s.replace(dict()))
+        tm.assert_series_equal(s, s.replace(pd.Series([])))


### PR DESCRIPTION
 - [x] closes #15289
 - [x] tests added / passed
 - [x] passes ``git diff upstream/master | flake8 --diff``
 - [x] whatsnew entry