### PR TITLE
BUG/API: .merge() and .join() on category dtype columns will now preserve category dtype

### DIFF
--- a/asv_bench/benchmarks/join_merge.py
+++ b/asv_bench/benchmarks/join_merge.py
@@ -6,7 +6,7 @@ except ImportError:
     from pandas import ordered_merge as merge_ordered
 
 
-#----------------------------------------------------------------------
+# ----------------------------------------------------------------------
 # Append
 
 class Append(object):
@@ -35,7 +35,7 @@ class Append(object):
         self.mdf1.append(self.mdf2)
 
 
-#----------------------------------------------------------------------
+# ----------------------------------------------------------------------
 # Concat
 
 class Concat(object):
@@ -120,7 +120,7 @@ class ConcatFrames(object):
         concat(self.frames_f, axis=1, ignore_index=True)
 
 
-#----------------------------------------------------------------------
+# ----------------------------------------------------------------------
 # Joins
 
 class Join(object):
@@ -202,7 +202,7 @@ class join_non_unique_equal(object):
         (self.fracofday * self.temp[self.fracofday.index])
 
 
-#----------------------------------------------------------------------
+# ----------------------------------------------------------------------
 # Merges
 
 class Merge(object):
@@ -257,7 +257,31 @@ class i8merge(object):
         merge(self.left, self.right, how='outer')
 
 
-#----------------------------------------------------------------------
+class MergeCategoricals(object):
+    goal_time = 0.2
+
+    def setup(self):
+        self.left_object = pd.DataFrame(
+            {'X': np.random.choice(range(0, 10), size=(10000,)),
+             'Y': np.random.choice(['one', 'two', 'three'], size=(10000,))})
+
+        self.right_object = pd.DataFrame(
+            {'X': np.random.choice(range(0, 10), size=(10000,)),
+             'Z': np.random.choice(['jjj', 'kkk', 'sss'], size=(10000,))})
+
+        self.left_cat = self.left_object.assign(
+            Y=self.left_object['Y'].astype('category'))
+        self.right_cat = self.right_object.assign(
+            Z=self.right_object['Z'].astype('category'))
+
+    def time_merge_object(self):
+        merge(self.left_object, self.right_object, on='X')
+
+    def time_merge_cat(self):
+        merge(self.left_cat, self.right_cat, on='X')
+
+
+# ----------------------------------------------------------------------
 # Ordered merge
 
 class MergeOrdered(object):
@@ -332,7 +356,7 @@ class MergeAsof(object):
         merge_asof(self.df1e, self.df2e, on='time', by=['key', 'key2'])
 
 
-#----------------------------------------------------------------------
+# ----------------------------------------------------------------------
 # data alignment
 
 class Align(object):

--- a/doc/source/categorical.rst
+++ b/doc/source/categorical.rst
@@ -646,6 +646,9 @@ In this case the categories are not the same and so an error is raised:
 
 The same applies to ``df.append(df_different)``.
 
+See also the section on :ref:`merge dtypes<merging.dtypes>` for notes about preserving merge dtypes and performance.
+
+
 .. _categorical.union:
 
 Unioning

--- a/doc/source/merging.rst
+++ b/doc/source/merging.rst
@@ -746,6 +746,79 @@ The ``indicator`` argument will also accept string arguments, in which case the 
    pd.merge(df1, df2, on='col1', how='outer', indicator='indicator_column')
 
 
+.. _merging.dtypes:
+
+Merge Dtypes
+~~~~~~~~~~~~
+
+.. versionadded:: 0.19.0
+
+Merging will preserve the dtype of the join keys.
+
+.. ipython:: python
+
+   left = pd.DataFrame({'key': [1], 'v1': [10]})
+   left
+   right = pd.DataFrame({'key': [1, 2], 'v1': [20, 30]})
+   right
+
+We are able to preserve the join keys
+
+.. ipython:: python
+
+   pd.merge(left, right, how='outer')
+   pd.merge(left, right, how='outer').dtypes
+
+Of course if you have missing values that are introduced, then the
+resulting dtype will be upcast.
+
+.. ipython:: python
+
+   pd.merge(left, right, how='outer', on='key')
+   pd.merge(left, right, how='outer', on='key').dtypes
+
+.. versionadded:: 0.20.0
+
+Merging will preserve ``category`` dtypes of the mergands.
+
+The left frame.
+
+.. ipython:: python
+
+   X = pd.Series(np.random.choice(['foo', 'bar'], size=(10,)))
+   X = X.astype('category', categories=['foo', 'bar'])
+
+   left = DataFrame({'X': X,
+                     'Y': np.random.choice(['one', 'two', 'three'], size=(10,))})
+   left
+   left.dtypes
+
+The right frame.
+
+.. ipython:: python
+
+   right = DataFrame({'X': Series(['foo', 'bar']).astype('category', categories=['foo', 'bar']),
+                      'Z': [1, 2]})
+   right
+   right.dtypes
+
+The merged result
+
+.. ipython:: python
+
+   result = pd.merge(left, right, how='outer')
+   result
+   result.dtypes
+
+.. note::
+
+   The category dtypes must be *exactly* the same, meaning the same categories and the ordered attribute.
+   Otherwise the result will coerce to ``object`` dtype.
+
+.. note::
+
+   Merging on ``category`` dtypes that are the same can be quite performant compared to ``object`` dtype merging.
+
 .. _merging.join.index:
 
 Joining on index

--- a/doc/source/whatsnew/v0.20.0.txt
+++ b/doc/source/whatsnew/v0.20.0.txt
@@ -692,7 +692,7 @@ Other API Changes
 - Reorganization of timeseries development tests (:issue:`14854`)
 - Specific support for ``copy.copy()`` and ``copy.deepcopy()`` functions on NDFrame objects (:issue:`15444`)
 - ``Series.sort_values()`` accepts a one element list of bool for consistency with the behavior of ``DataFrame.sort_values()`` (:issue:`15604`)
-- ``DataFrame.iterkv()`` has been removed in favor of ``DataFrame.iteritems()`` (:issue:`10711`)
+- ``.merge()`` and ``.join()`` on ``category`` dtype columns will now preserve the category dtype when possible (:issue:`10409`)
 
 .. _whatsnew_0200.deprecations:
 
@@ -733,6 +733,7 @@ Removal of prior version deprecations/changes
 - ``Series.is_time_series`` is dropped in favor of ``Series.index.is_all_dates`` (:issue:`15098`)
 - The deprecated ``irow``, ``icol``, ``iget`` and ``iget_value`` methods are removed
   in favor of ``iloc`` and ``iat`` as explained :ref:`here <whatsnew_0170.deprecations>` (:issue:`10711`).
+- The deprecated ``DataFrame.iterkv()`` has been removed in favor of ``DataFrame.iteritems()`` (:issue:`10711`)
 
 
 .. _whatsnew_0200.performance:
@@ -749,6 +750,7 @@ Performance Improvements
 - When reading buffer object in ``read_sas()`` method without specified format, filepath string is inferred rather than buffer object. (:issue:`14947`)
 - Improved performance of ``.rank()`` for categorical data (:issue:`15498`)
 - Improved performance when using ``.unstack()`` (:issue:`15503`)
+- Improved performance of merge/join on ``category`` columns (:issue:`10409`)
 
 
 .. _whatsnew_0200.bug_fixes:

--- a/pandas/core/internals.py
+++ b/pandas/core/internals.py
@@ -5227,6 +5227,8 @@ class JoinUnit(object):
                 # External code requested filling/upcasting, bool values must
                 # be upcasted to object to avoid being upcasted to numeric.
                 values = self.block.astype(np.object_).values
+            elif self.block.is_categorical:
+                values = self.block.values
             else:
                 # No dtype upcasting is done here, it will be performed during
                 # concatenation itself.

--- a/pandas/tests/test_categorical.py
+++ b/pandas/tests/test_categorical.py
@@ -4097,9 +4097,12 @@ Categories (10, timedelta64[ns]): [0 days 01:00:00 < 1 days 01:00:00 < 2 days 01
         expected = df.copy()
 
         # object-cat
+        # note that we propogate the category
+        # because we don't have any matching rows
         cright = right.copy()
         cright['d'] = cright['d'].astype('category')
         result = pd.merge(left, cright, how='left', left_on='b', right_on='c')
+        expected['d'] = expected['d'].astype('category', categories=['null'])
         tm.assert_frame_equal(result, expected)
 
         # cat-object

--- a/pandas/tests/tools/test_merge.py
+++ b/pandas/tests/tools/test_merge.py
@@ -1,5 +1,6 @@
 # pylint: disable=E1103
 
+import pytest
 from datetime import datetime
 from numpy.random import randn
 from numpy import nan
@@ -11,6 +12,8 @@ from pandas.compat import lrange, lzip
 from pandas.tools.concat import concat
 from pandas.tools.merge import merge, MergeError
 from pandas.util.testing import assert_frame_equal, assert_series_equal
+from pandas.types.dtypes import CategoricalDtype
+from pandas.types.common import is_categorical_dtype, is_object_dtype
 from pandas import DataFrame, Index, MultiIndex, Series, Categorical
 import pandas.util.testing as tm
 
@@ -1024,38 +1027,6 @@ class TestMergeMulti(tm.TestCase):
         expected.index = np.arange(len(expected))
         tm.assert_frame_equal(result, expected)
 
-    def test_join_multi_dtypes(self):
-
-        # test with multi dtypes in the join index
-        def _test(dtype1, dtype2):
-            left = DataFrame({'k1': np.array([0, 1, 2] * 8, dtype=dtype1),
-                              'k2': ['foo', 'bar'] * 12,
-                              'v': np.array(np.arange(24), dtype=np.int64)})
-
-            index = MultiIndex.from_tuples([(2, 'bar'), (1, 'foo')])
-            right = DataFrame(
-                {'v2': np.array([5, 7], dtype=dtype2)}, index=index)
-
-            result = left.join(right, on=['k1', 'k2'])
-
-            expected = left.copy()
-
-            if dtype2.kind == 'i':
-                dtype2 = np.dtype('float64')
-            expected['v2'] = np.array(np.nan, dtype=dtype2)
-            expected.loc[(expected.k1 == 2) & (expected.k2 == 'bar'), 'v2'] = 5
-            expected.loc[(expected.k1 == 1) & (expected.k2 == 'foo'), 'v2'] = 7
-
-            tm.assert_frame_equal(result, expected)
-
-            result = left.join(right, on=['k1', 'k2'], sort=True)
-            expected.sort_values(['k1', 'k2'], kind='mergesort', inplace=True)
-            tm.assert_frame_equal(result, expected)
-
-        for d1 in [np.int64, np.int32, np.int16, np.int8, np.uint8]:
-            for d2 in [np.int64, np.float64, np.float32, np.float16]:
-                _test(np.dtype(d1), np.dtype(d2))
-
     def test_left_merge_na_buglet(self):
         left = DataFrame({'id': list('abcde'), 'v1': randn(5),
                           'v2': randn(5), 'dummy': list('abcde'),
@@ -1242,3 +1213,145 @@ class TestMergeMulti(tm.TestCase):
         def f():
             household.join(log_return, how='outer')
         self.assertRaises(NotImplementedError, f)
+
+
+@pytest.fixture
+def df():
+    return DataFrame(
+        {'A': ['foo', 'bar'],
+         'B': Series(['foo', 'bar']).astype('category'),
+         'C': [1, 2],
+         'D': [1.0, 2.0],
+         'E': Series([1, 2], dtype='uint64'),
+         'F': Series([1, 2], dtype='int32')})
+
+
+class TestMergeDtypes(object):
+
+    def test_different(self, df):
+
+        # we expect differences by kind
+        # to be ok, while other differences should return object
+
+        left = df
+        for col in df.columns:
+            right = DataFrame({'A': df[col]})
+            result = pd.merge(left, right, on='A')
+            assert is_object_dtype(result.A.dtype)
+
+    @pytest.mark.parametrize('d1', [np.int64, np.int32,
+                                    np.int16, np.int8, np.uint8])
+    @pytest.mark.parametrize('d2', [np.int64, np.float64,
+                                    np.float32, np.float16])
+    def test_join_multi_dtypes(self, d1, d2):
+
+        dtype1 = np.dtype(d1)
+        dtype2 = np.dtype(d2)
+
+        left = DataFrame({'k1': np.array([0, 1, 2] * 8, dtype=dtype1),
+                          'k2': ['foo', 'bar'] * 12,
+                          'v': np.array(np.arange(24), dtype=np.int64)})
+
+        index = MultiIndex.from_tuples([(2, 'bar'), (1, 'foo')])
+        right = DataFrame({'v2': np.array([5, 7], dtype=dtype2)}, index=index)
+
+        result = left.join(right, on=['k1', 'k2'])
+
+        expected = left.copy()
+
+        if dtype2.kind == 'i':
+            dtype2 = np.dtype('float64')
+        expected['v2'] = np.array(np.nan, dtype=dtype2)
+        expected.loc[(expected.k1 == 2) & (expected.k2 == 'bar'), 'v2'] = 5
+        expected.loc[(expected.k1 == 1) & (expected.k2 == 'foo'), 'v2'] = 7
+
+        tm.assert_frame_equal(result, expected)
+
+        result = left.join(right, on=['k1', 'k2'], sort=True)
+        expected.sort_values(['k1', 'k2'], kind='mergesort', inplace=True)
+        tm.assert_frame_equal(result, expected)
+
+
+@pytest.fixture
+def left():
+    np.random.seed(1234)
+    return DataFrame(
+        {'X': Series(np.random.choice(
+            ['foo', 'bar'],
+            size=(10,))).astype('category', categories=['foo', 'bar']),
+         'Y': np.random.choice(['one', 'two', 'three'], size=(10,))})
+
+
+@pytest.fixture
+def right():
+    np.random.seed(1234)
+    return DataFrame(
+        {'X': Series(['foo', 'bar']).astype('category',
+                                            categories=['foo', 'bar']),
+         'Z': [1, 2]})
+
+
+class TestMergeCategorical(object):
+
+    def test_identical(self, left):
+        # merging on the same, should preserve dtypes
+        merged = pd.merge(left, left, on='X')
+        result = merged.dtypes.sort_index()
+        expected = Series([CategoricalDtype(),
+                           np.dtype('O'),
+                           np.dtype('O')],
+                          index=['X', 'Y_x', 'Y_y'])
+        assert_series_equal(result, expected)
+
+    def test_basic(self, left, right):
+        # we have matching Categorical dtypes in X
+        # so should preserve the merged column
+        merged = pd.merge(left, right, on='X')
+        result = merged.dtypes.sort_index()
+        expected = Series([CategoricalDtype(),
+                           np.dtype('O'),
+                           np.dtype('int64')],
+                          index=['X', 'Y', 'Z'])
+        assert_series_equal(result, expected)
+
+    def test_other_columns(self, left, right):
+        # non-merge columns should preserve if possible
+        right = right.assign(Z=right.Z.astype('category'))
+
+        merged = pd.merge(left, right, on='X')
+        result = merged.dtypes.sort_index()
+        expected = Series([CategoricalDtype(),
+                           np.dtype('O'),
+                           CategoricalDtype()],
+                          index=['X', 'Y', 'Z'])
+        assert_series_equal(result, expected)
+
+        # categories are preserved
+        assert left.X.values.is_dtype_equal(merged.X.values)
+        assert right.Z.values.is_dtype_equal(merged.Z.values)
+
+    @pytest.mark.parametrize(
+        'change', [lambda x: x,
+                   lambda x: x.astype('category',
+                                      categories=['bar', 'foo']),
+                   lambda x: x.astype('category',
+                                      categories=['foo', 'bar', 'bah']),
+                   lambda x: x.astype('category', ordered=True)])
+    @pytest.mark.parametrize('how', ['inner', 'outer', 'left', 'right'])
+    def test_dtype_on_merged_different(self, change, how, left, right):
+        # our merging columns, X now has 2 different dtypes
+        # so we must be object as a result
+
+        X = change(right.X.astype('object'))
+        right = right.assign(X=X)
+        assert is_categorical_dtype(left.X.values)
+        assert not left.X.values.is_dtype_equal(right.X.values)
+
+        merged = pd.merge(left, right, on='X', how=how)
+
+        result = merged.dtypes.sort_index()
+        expected = Series([np.dtype('O'),
+                           np.dtype('O'),
+                           np.dtype('int64')],
+                          index=['X', 'Y', 'Z'])
+        assert_series_equal(result, expected)

--- a/pandas/tests/tools/test_merge_asof.py
+++ b/pandas/tests/tools/test_merge_asof.py
@@ -147,6 +147,7 @@ class TestAsOfMerge(tm.TestCase):
         trades.ticker = trades.ticker.astype('category')
         quotes = self.quotes.copy()
         quotes.ticker = quotes.ticker.astype('category')
+        expected.ticker = expected.ticker.astype('category')
 
         result = merge_asof(trades, quotes,
                             on='time',

--- a/pandas/tools/merge.py
+++ b/pandas/tools/merge.py
@@ -18,8 +18,10 @@ from pandas.types.common import (is_datetime64tz_dtype,
                                  is_datetime64_dtype,
                                  needs_i8_conversion,
                                  is_int64_dtype,
+                                 is_categorical_dtype,
                                  is_integer_dtype,
                                  is_float_dtype,
+                                 is_numeric_dtype,
                                  is_integer,
                                  is_int_or_datetime_dtype,
                                  is_dtype_equal,
@@ -37,7 +39,7 @@ from pandas.util.decorators import Appender, Substitution
 from pandas.core.sorting import is_int64_overflow_possible
 import pandas.core.algorithms as algos
 import pandas.core.common as com
-from pandas._libs import hashtable as libhashtable, join as libjoin
+from pandas._libs import hashtable as libhashtable, join as libjoin, lib
 
 
 # back-compat of pseudo-public API
@@ -570,6 +572,10 @@ class _MergeOperation(object):
          self.right_join_keys,
          self.join_names) = self._get_merge_keys()
 
+        # validate the merge keys dtypes. We may need to coerce
+        # to avoid incompat dtypes
+        self._maybe_coerce_merge_keys()
+
     def get_result(self):
         if self.indicator:
             self.left, self.right = self._indicator_pre_merge(
@@ -760,26 +766,6 @@ class _MergeOperation(object):
             join_index = join_index.astype(object)
         return join_index, left_indexer, right_indexer
 
-    def _get_merge_data(self):
-        """
-        Handles overlapping column names etc.
-        """
-        ldata, rdata = self.left._data, self.right._data
-        lsuf, rsuf = self.suffixes
-
-        llabels, rlabels = items_overlap_with_suffix(
-            ldata.items, lsuf, rdata.items, rsuf)
-
-        if not llabels.equals(ldata.items):
-            ldata = ldata.copy(deep=False)
-            ldata.set_axis(0, llabels)
-
-        if not rlabels.equals(rdata.items):
-            rdata = rdata.copy(deep=False)
-            rdata.set_axis(0, rlabels)
-
-        return ldata, rdata
-
     def _get_merge_keys(self):
         """
         Note: has side effects (copy/delete key columns)
@@ -891,6 +877,51 @@ class _MergeOperation(object):
 
         return left_keys, right_keys, join_names
 
+    def _maybe_coerce_merge_keys(self):
+        # we have valid mergee's but we may have to further
+        # coerce these if they are originally incompatible types
+        #
+        # for example if these are categorical, but are not dtype_equal
+        # or if we have object and integer dtypes
+
+        for lk, rk, name in zip(self.left_join_keys,
+                                self.right_join_keys,
+                                self.join_names):
+            if (len(lk) and not len(rk)) or (not len(lk) and len(rk)):
+                continue
+
+            # if either left or right is a categorical
+            # then the must match exactly in categories & ordered
+            if is_categorical_dtype(lk) and is_categorical_dtype(rk):
+                if lk.is_dtype_equal(rk):
+                    continue
+            elif is_categorical_dtype(lk) or is_categorical_dtype(rk):
+                pass
+
+            elif is_dtype_equal(lk.dtype, rk.dtype):
+                continue
+
+            # if we are numeric, then allow differing
+            # kinds to proceed, eg. int64 and int8
+            # further if we are object, but we infer to
+            # the same, then proceed
+            if (is_numeric_dtype(lk) and is_numeric_dtype(rk)):
+                if lk.dtype.kind == rk.dtype.kind:
+                    continue
+
+                # let's infer and see if we are ok
+                if lib.infer_dtype(lk) == lib.infer_dtype(rk):
+                    continue
+
+            # Houston, we have a problem!
+            # let's coerce to object
+            if name in self.left.columns:
+                self.left = self.left.assign(
+                    **{name: self.left[name].astype(object)})
+            if name in self.right.columns:
+                self.right = self.right.assign(
+                    **{name: self.right[name].astype(object)})
+
     def _validate_specification(self):
         # Hm, any way to make this logic less complicated??
         if self.on is None and self.left_on is None and self.right_on is None:
@@ -942,9 +973,15 @@ def _get_join_indexers(left_keys, right_keys, sort=False, how='inner',
 
     Parameters
     ----------
+    left_keys: ndarray, Index, Series
+    right_keys: ndarray, Index, Series
+    sort: boolean, default False
+    how: string {'inner', 'outer', 'left', 'right'}, default 'inner'
 
     Returns
     -------
+    tuple of (left_indexer, right_indexer)
+        indexers into the left_keys, right_keys
 
     """
     from functools import partial
@@ -1349,6 +1386,13 @@ def _factorize_keys(lk, rk, sort=True):
     if is_datetime64tz_dtype(lk) and is_datetime64tz_dtype(rk):
         lk = lk.values
         rk = rk.values
+
+    # if we exactly match in categories, allow us to use codes
+    if (is_categorical_dtype(lk) and
+            is_categorical_dtype(rk) and
+            lk.is_dtype_equal(rk)):
+        return lk.codes, rk.codes, len(lk.categories)
+
     if is_int_or_datetime_dtype(lk) and is_int_or_datetime_dtype(rk):
         klass = libhashtable.Int64Factorizer
         lk = _ensure_int64(com._values_from_object(lk))


### PR DESCRIPTION
closes #10409

```
    before     after       ratio
  [6d2293f7] [c352573f]
-  410.11ms   260.46ms      0.64  join_merge.MergeCategoricals.time_merge_cat

SOME BENCHMARKS HAVE CHANGED SIGNIFICANTLY.
```