### PR TITLE
ENH: enabled 'on' keyword for groupby(..).resample()

### DIFF
--- a/doc/source/whatsnew/v0.20.0.txt
+++ b/doc/source/whatsnew/v0.20.0.txt
@@ -149,6 +149,7 @@ Other enhancements
 - ``Series/DataFrame.asfreq()`` have gained a ``fill_value`` parameter, to fill missing values (:issue:`3715`).
 - ``Series/DataFrame.resample.asfreq`` have gained a ``fill_value`` parameter, to fill missing values during resampling (:issue:`3715`).
 - ``pandas.tools.hashing`` has gained a ``hash_tuples`` routine, and ``hash_pandas_object`` has gained the ability to hash a ``MultiIndex`` (:issue:`15224`)
+- ``groupby(..).resample()`` is now able to use the ``on`` argument. (:issue:`15021`)
 
 .. _ISO 8601 duration: https://en.wikipedia.org/wiki/ISO_8601#Durations
 

--- a/pandas/core/groupby.py
+++ b/pandas/core/groupby.py
@@ -1140,13 +1140,13 @@ class GroupBy(_GroupBy):
 
     @Substitution(name='groupby')
     @Appender(_doc_template)
-    def resample(self, rule, *args, **kwargs):
+    def resample(self, rule, on=None, *args, **kwargs):
         """
         Provide resampling when using a TimeGrouper
         Return a new grouper with our resampler appended
         """
         from pandas.tseries.resample import get_resampler_for_grouping
-        return get_resampler_for_grouping(self, rule, *args, **kwargs)
+        return get_resampler_for_grouping(self, rule, key=on, *args, **kwargs)
 
     @Substitution(name='groupby')
     @Appender(_doc_template)

--- a/pandas/tseries/tests/test_resample.py
+++ b/pandas/tseries/tests/test_resample.py
@@ -217,6 +217,20 @@ class TestResampleAPI(tm.TestCase):
             lambda x: x.resample('1D').ffill())[['val']]
         assert_frame_equal(result, expected)
 
+    def test_grouby_resample_on_api(self):
+
+        # GH 15021
+        # .groupby(...).resample(on=...) results in an unexpected
+        # keyword warning.
+        df = pd.DataFrame({'key': ['A', 'B'] * 5,
+                           'dates': pd.date_range('2016-01-01', periods=10),
+                           'values': np.random.randn(10)})
+
+        expected = df.set_index('dates').groupby('key').resample('D').mean()
+
+        result = df.groupby('key').resample('D', on='dates').mean()
+        assert_frame_equal(result, expected)
+
     def test_plot_api(self):
         tm._skip_if_no_mpl()
 


### PR DESCRIPTION
 - [x] closes #15021 
 - [x] tests added / passed
 - [x] passes ``git diff upstream/master | flake8 --diff``
 - [x] whatsnew entry
