### PR TITLE
BUG: .groupby on Series' values without reindexing

### DIFF
--- a/doc/source/whatsnew/v0.20.0.txt
+++ b/doc/source/whatsnew/v0.20.0.txt
@@ -462,6 +462,7 @@ Bug Fixes
 
 - Bug in  groupby operations with timedelta64 when passing ``numeric_only=False`` (:issue:`5724`)
 
+- Bug in ``.groupby()`` when grouping on a ``Series`` with same-length but incompatible index (:issue:`15338`)
 
 - Bug in ``DataFrame.to_html`` with ``index=False`` and ``max_rows`` raising in ``IndexError`` (:issue:`14998`)
 

--- a/pandas/core/groupby.py
+++ b/pandas/core/groupby.py
@@ -2574,7 +2574,7 @@ def _convert_grouper(axis, grouper):
     if isinstance(grouper, dict):
         return grouper.get
     elif isinstance(grouper, Series):
-        if grouper.index.equals(axis):
+        if len(grouper.index) == len(axis):
             return grouper._values
         else:
             return grouper.reindex(axis)._values

--- a/pandas/tests/groupby/test_groupby.py
+++ b/pandas/tests/groupby/test_groupby.py
@@ -2764,6 +2764,17 @@ class TestGroupBy(tm.TestCase):
         exp = s1.groupby(s2.reindex(s1.index).get).mean()
         assert_series_equal(agged, exp)
 
+    def test_groupby_series_values(self):
+        # GH-15338
+        s = pd.Series([1, 2, 3], index=range(3))
+        df = pd.DataFrame(np.arange(6).reshape(3, 2), index=range(3))
+        key = pd.Series([0, 0, 1], index=range(3, 6))  # Disjunct index
+
+        assert_series_equal(s.groupby(key).sum(),
+                            s.groupby(key.values).sum())
+        assert_frame_equal(df.groupby(key).sum(),
+                           df.groupby(key.values).sum())
+
     def test_groupby_with_hier_columns(self):
         tuples = list(zip(*[['bar', 'bar', 'baz', 'baz', 'foo', 'foo', 'qux',
                              'qux'], ['one', 'two', 'one', 'two', 'one', 'two',


### PR DESCRIPTION
 - [X] closes #15338
 - [X] tests added / passed
 - [X] passes ``git diff upstream/master | flake8 --diff``
 - [X] whatsnew entry
