### PR TITLE
BUG: Multiline Eval broken for local variables after first line

### DIFF
--- a/doc/source/whatsnew/v0.20.0.txt
+++ b/doc/source/whatsnew/v0.20.0.txt
@@ -516,3 +516,4 @@ Bug Fixes
 
 - Bug in ``DataFrame.boxplot`` where ``fontsize`` was not applied to the tick labels on both axes (:issue:`15108`)
 - Bug in ``Series.replace`` and ``DataFrame.replace`` which failed on empty replacement dicts (:issue:`15289`)
+- Bug in ``.eval()`` which caused multiline evals to fail with local variables not on the first line (:issue:`15342`)

--- a/pandas/computation/eval.py
+++ b/pandas/computation/eval.py
@@ -236,7 +236,7 @@ def eval(expr, parser='pandas', engine=None, truediv=True,
     first_expr = True
     if isinstance(expr, string_types):
         _check_expression(expr)
-        exprs = [e for e in expr.splitlines() if e != '']
+        exprs = [e.strip() for e in expr.splitlines() if e.strip() != '']
     else:
         exprs = [expr]
     multi_line = len(exprs) > 1
@@ -254,8 +254,7 @@ def eval(expr, parser='pandas', engine=None, truediv=True,
         _check_for_locals(expr, level, parser)
 
         # get our (possibly passed-in) scope
-        level += 1
-        env = _ensure_scope(level, global_dict=global_dict,
+        env = _ensure_scope(level + 1, global_dict=global_dict,
                             local_dict=local_dict, resolvers=resolvers,
                             target=target)
 

--- a/pandas/computation/tests/test_eval.py
+++ b/pandas/computation/tests/test_eval.py
@@ -1274,7 +1274,6 @@ class TestOperationsNumExprPandas(tm.TestCase):
                           local_dict={'df': df, 'df2': df2})
 
     def test_assignment_column(self):
-        tm.skip_if_no_ne('numexpr')
         df = DataFrame(np.random.randn(5, 2), columns=list('ab'))
         orig_df = df.copy()
 
@@ -1346,7 +1345,6 @@ class TestOperationsNumExprPandas(tm.TestCase):
 
     def assignment_not_inplace(self):
         # GH 9297
-        tm.skip_if_no_ne('numexpr')
         df = DataFrame(np.random.randn(5, 2), columns=list('ab'))
 
         actual = df.eval('c = a + b', inplace=False)
@@ -1365,7 +1363,6 @@ class TestOperationsNumExprPandas(tm.TestCase):
 
     def test_multi_line_expression(self):
         # GH 11149
-        tm.skip_if_no_ne('numexpr')
         df = pd.DataFrame({'a': [1, 2, 3], 'b': [4, 5, 6]})
         expected = df.copy()
 
@@ -1393,7 +1390,6 @@ class TestOperationsNumExprPandas(tm.TestCase):
 
     def test_multi_line_expression_not_inplace(self):
         # GH 11149
-        tm.skip_if_no_ne('numexpr')
         df = pd.DataFrame({'a': [1, 2, 3], 'b': [4, 5, 6]})
         expected = df.copy()
 
@@ -1410,6 +1406,21 @@ class TestOperationsNumExprPandas(tm.TestCase):
         a = a - 1
         e = a + 2""", inplace=False)
         assert_frame_equal(expected, df)
+
+    def test_multi_line_expression_local_variable(self):
+        # GH 15342
+        df = pd.DataFrame({'a': [1, 2, 3], 'b': [4, 5, 6]})
+        expected = df.copy()
+
+        local_var = 7
+        expected['c'] = expected['a'] * local_var
+        expected['d'] = expected['c'] + local_var
+        ans = df.eval("""
+        c = a * @local_var
+        d = c + @local_var
+        """, inplace=True)
+        assert_frame_equal(expected, df)
+        self.assertIsNone(ans)
 
     def test_assignment_in_query(self):
         # GH 8664


### PR DESCRIPTION
Also fixes the code which attempted to ignore any blank lines in the
multiline expression.

 - [x] closes #15342 
 - [x] tests added / passed
 - [x] passes ``git diff upstream/master | flake8 --diff``
 - [x] whatsnew entry
