### PR TITLE
Small documentation fix for MultiIndex.sortlevel

### DIFF
--- a/pandas/indexes/multi.py
+++ b/pandas/indexes/multi.py
@@ -1399,7 +1399,7 @@ class MultiIndex(Index):
 
         Returns
         -------
-        sorted_index : MultiIndex
+        (sorted_index, index_array) : (MultiIndex, ndarray)
         """
         from pandas.core.groupby import _indexer_from_factorized
 

--- a/pandas/indexes/multi.py
+++ b/pandas/indexes/multi.py
@@ -1399,7 +1399,11 @@ class MultiIndex(Index):
 
         Returns
         -------
-        (sorted_index, index_array) : (MultiIndex, ndarray)
+        sorted_index : pd.MultiIndex
+            Resulting index
+        indexer : np.ndarray
+            Indices of output values in original index
+
         """
         from pandas.core.groupby import _indexer_from_factorized
 


### PR DESCRIPTION
MultiIndex.sortlevel returns two values (MultiIndex and indices that sort the MultiIndex). Only the MultiIndex was described in the documentation. 
