### PR TITLE
COMPAT: numpy master compat for groupby-filter

### DIFF
--- a/pandas/core/groupby.py
+++ b/pandas/core/groupby.py
@@ -3805,7 +3805,8 @@ class NDFrameGroupBy(GroupBy):
             res = func(group, *args, **kwargs)
 
             try:
-                res = res.squeeze()
+                if not is_scalar(res):
+                    res = res.squeeze()
             except AttributeError:  # allow e.g., scalars and frames to pass
                 pass
 


### PR DESCRIPTION
xref https://github.com/numpy/numpy/pull/8591

I think we were relying on some sketchy behavior

https://travis-ci.org/pandas-dev/pandas/jobs/200459486

in ``pandas/core/groupby.py``
```
        for name, group in gen:
            object.__setattr__(group, 'name', name)
    
            res = func(group, *args, **kwargs)
    
            try:
                res = res.squeeze()
            except AttributeError:  # allow e.g., scalars and frames to pass
                pass
    
            # interpret the result of the filter
            if is_bool(res) or (is_scalar(res) and isnull(res)):
                if res and notnull(res):
                    indices.append(self._get_index(name))
            else:
                # non scalars aren't allowed
                raise TypeError("filter function returned a %s, "
                                "but expected a scalar bool" %
>                               type(res).__name__)
E               TypeError: filter function returned a ndarray, but expected a scalar bool
```