### PR TITLE
Test: use xdist

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -320,7 +320,8 @@ before_script:
 script:
   - echo "script start"
   - ci/run_build_docs.sh
-  - ci/script.sh
+  - ci/script_single.sh
+  - ci/script_multi.sh
   - ci/lint.sh
   - echo "script done"
 

--- a/ci/script_multi.sh
+++ b/ci/script_multi.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-echo "inside $0"
+echo "[script multi]"
 
 source activate pandas
 
@@ -20,11 +20,11 @@ fi
 if [ "$BUILD_TEST" ]; then
     echo "We are not running pytest as this is simply a build test."
 elif [ "$COVERAGE" ]; then
-    echo pytest -s --cov=pandas --cov-report xml:/tmp/pytest.xml $TEST_ARGS pandas
-    pytest -s --cov=pandas --cov-report xml:/tmp/pytest.xml $TEST_ARGS pandas
+    echo pytest -s -n 4 -m "not single" --cov=pandas --cov-append --cov-report xml:/tmp/pytest.xml $TEST_ARGS pandas
+    pytest -s -n 4 -m "not single" --cov=pandas --cov-append --cov-report xml:/tmp/pytest.xml $TEST_ARGS pandas
 else
-    echo pytest $TEST_ARGS pandas
-    pytest $TEST_ARGS pandas # TODO: doctest
+    echo pytest -n 4 -m "not single" $TEST_ARGS pandas
+    pytest -n 4 -m "not single" $TEST_ARGS pandas # TODO: doctest
 fi
 
 RET="$?"

--- a/ci/script_single.sh
+++ b/ci/script_single.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+echo "[script_single]"
+
+source activate pandas
+
+# don't run the tests for the doc build
+if [ x"$DOC_BUILD" != x"" ]; then
+    exit 0
+fi
+
+if [ -n "$LOCALE_OVERRIDE" ]; then
+    export LC_ALL="$LOCALE_OVERRIDE";
+    echo "Setting LC_ALL to $LOCALE_OVERRIDE"
+
+    pycmd='import pandas; print("pandas detected console encoding: %s" % pandas.get_option("display.encoding"))'
+    python -c "$pycmd"
+fi
+
+if [ "$BUILD_TEST" ]; then
+    echo "We are not running pytest as this is simply a build test."
+elif [ "$COVERAGE" ]; then
+    echo pytest -s -m "single" --cov=pandas --cov-report xml:/tmp/pytest.xml $TEST_ARGS pandas
+    pytest -s -m "single" --cov=pandas --cov-report xml:/tmp/pytest.xml $TEST_ARGS pandas
+else
+    echo pytest -m "single" $TEST_ARGS pandas
+    pytest -m "single" $TEST_ARGS pandas # TODO: doctest
+fi
+
+RET="$?"
+
+exit "$RET"

--- a/doc/source/whatsnew/v0.20.0.txt
+++ b/doc/source/whatsnew/v0.20.0.txt
@@ -91,7 +91,7 @@ support for bz2 compression in the python 2 c-engine improved (:issue:`14874`).
    url = 'https://github.com/{repo}/raw/{branch}/{path}'.format(
        repo = 'pandas-dev/pandas',
        branch = 'master',
-       path = 'pandas/io/tests/parser/data/salaries.csv.bz2',
+       path = 'pandas/tests/io/parser/data/salaries.csv.bz2',
    )
    df = pd.read_table(url, compression='infer')  # default, infer compression
    df = pd.read_table(url, compression='bz2')  # explicitly specify compression

--- a/pandas/tests/indexes/datetimes/test_ops.py
+++ b/pandas/tests/indexes/datetimes/test_ops.py
@@ -1,7 +1,9 @@
+import pytest
 import warnings
 import numpy as np
 from datetime import timedelta
 
+from itertools import product
 import pandas as pd
 import pandas.tslib as tslib
 import pandas.util.testing as tm
@@ -958,134 +960,134 @@ class TestDateTimeIndexToJulianDate(tm.TestCase):
         tm.assert_index_equal(r1, r2)
 
 
-class TestDatetimeIndex(tm.TestCase):
+# GH 10699
+@pytest.mark.parametrize('klass,assert_func', zip([Series, DatetimeIndex],
+                                                  [tm.assert_series_equal,
+                                                   tm.assert_index_equal]))
+def test_datetime64_with_DateOffset(klass, assert_func):
+    s = klass(date_range('2000-01-01', '2000-01-31'), name='a')
+    result = s + pd.DateOffset(years=1)
+    result2 = pd.DateOffset(years=1) + s
+    exp = klass(date_range('2001-01-01', '2001-01-31'), name='a')
+    assert_func(result, exp)
+    assert_func(result2, exp)
 
-    # GH 10699
-    def test_datetime64_with_DateOffset(self):
-        for klass, assert_func in zip([Series, DatetimeIndex],
-                                      [self.assert_series_equal,
-                                       tm.assert_index_equal]):
-            s = klass(date_range('2000-01-01', '2000-01-31'), name='a')
-            result = s + pd.DateOffset(years=1)
-            result2 = pd.DateOffset(years=1) + s
-            exp = klass(date_range('2001-01-01', '2001-01-31'), name='a')
+    result = s - pd.DateOffset(years=1)
+    exp = klass(date_range('1999-01-01', '1999-01-31'), name='a')
+    assert_func(result, exp)
+
+    s = klass([Timestamp('2000-01-15 00:15:00', tz='US/Central'),
+               pd.Timestamp('2000-02-15', tz='US/Central')], name='a')
+    result = s + pd.offsets.Day()
+    result2 = pd.offsets.Day() + s
+    exp = klass([Timestamp('2000-01-16 00:15:00', tz='US/Central'),
+                 Timestamp('2000-02-16', tz='US/Central')], name='a')
+    assert_func(result, exp)
+    assert_func(result2, exp)
+
+    s = klass([Timestamp('2000-01-15 00:15:00', tz='US/Central'),
+               pd.Timestamp('2000-02-15', tz='US/Central')], name='a')
+    result = s + pd.offsets.MonthEnd()
+    result2 = pd.offsets.MonthEnd() + s
+    exp = klass([Timestamp('2000-01-31 00:15:00', tz='US/Central'),
+                 Timestamp('2000-02-29', tz='US/Central')], name='a')
+    assert_func(result, exp)
+    assert_func(result2, exp)
+
+    # array of offsets - valid for Series only
+    if klass is Series:
+        with tm.assert_produces_warning(PerformanceWarning):
+            s = klass([Timestamp('2000-1-1'), Timestamp('2000-2-1')])
+            result = s + Series([pd.offsets.DateOffset(years=1),
+                                 pd.offsets.MonthEnd()])
+            exp = klass([Timestamp('2001-1-1'), Timestamp('2000-2-29')
+                         ])
             assert_func(result, exp)
-            assert_func(result2, exp)
 
-            result = s - pd.DateOffset(years=1)
-            exp = klass(date_range('1999-01-01', '1999-01-31'), name='a')
+            # same offset
+            result = s + Series([pd.offsets.DateOffset(years=1),
+                                 pd.offsets.DateOffset(years=1)])
+            exp = klass([Timestamp('2001-1-1'), Timestamp('2001-2-1')])
             assert_func(result, exp)
 
-            s = klass([Timestamp('2000-01-15 00:15:00', tz='US/Central'),
-                       pd.Timestamp('2000-02-15', tz='US/Central')], name='a')
-            result = s + pd.offsets.Day()
-            result2 = pd.offsets.Day() + s
-            exp = klass([Timestamp('2000-01-16 00:15:00', tz='US/Central'),
-                         Timestamp('2000-02-16', tz='US/Central')], name='a')
-            assert_func(result, exp)
-            assert_func(result2, exp)
+    s = klass([Timestamp('2000-01-05 00:15:00'),
+               Timestamp('2000-01-31 00:23:00'),
+               Timestamp('2000-01-01'),
+               Timestamp('2000-03-31'),
+               Timestamp('2000-02-29'),
+               Timestamp('2000-12-31'),
+               Timestamp('2000-05-15'),
+               Timestamp('2001-06-15')])
 
-            s = klass([Timestamp('2000-01-15 00:15:00', tz='US/Central'),
-                       pd.Timestamp('2000-02-15', tz='US/Central')], name='a')
-            result = s + pd.offsets.MonthEnd()
-            result2 = pd.offsets.MonthEnd() + s
-            exp = klass([Timestamp('2000-01-31 00:15:00', tz='US/Central'),
-                         Timestamp('2000-02-29', tz='US/Central')], name='a')
-            assert_func(result, exp)
-            assert_func(result2, exp)
+    # DateOffset relativedelta fastpath
+    relative_kwargs = [('years', 2), ('months', 5), ('days', 3),
+                       ('hours', 5), ('minutes', 10), ('seconds', 2),
+                       ('microseconds', 5)]
+    for i, kwd in enumerate(relative_kwargs):
+        op = pd.DateOffset(**dict([kwd]))
+        assert_func(klass([x + op for x in s]), s + op)
+        assert_func(klass([x - op for x in s]), s - op)
+        op = pd.DateOffset(**dict(relative_kwargs[:i + 1]))
+        assert_func(klass([x + op for x in s]), s + op)
+        assert_func(klass([x - op for x in s]), s - op)
 
-            # array of offsets - valid for Series only
-            if klass is Series:
-                with tm.assert_produces_warning(PerformanceWarning):
-                    s = klass([Timestamp('2000-1-1'), Timestamp('2000-2-1')])
-                    result = s + Series([pd.offsets.DateOffset(years=1),
-                                         pd.offsets.MonthEnd()])
-                    exp = klass([Timestamp('2001-1-1'), Timestamp('2000-2-29')
-                                 ])
-                    assert_func(result, exp)
+    # assert these are equal on a piecewise basis
+    offsets = ['YearBegin', ('YearBegin', {'month': 5}),
+               'YearEnd', ('YearEnd', {'month': 5}),
+               'MonthBegin', 'MonthEnd',
+               'SemiMonthEnd', 'SemiMonthBegin',
+               'Week', ('Week', {'weekday': 3}),
+               'BusinessDay', 'BDay', 'QuarterEnd', 'QuarterBegin',
+               'CustomBusinessDay', 'CDay', 'CBMonthEnd',
+               'CBMonthBegin', 'BMonthBegin', 'BMonthEnd',
+               'BusinessHour', 'BYearBegin', 'BYearEnd',
+               'BQuarterBegin', ('LastWeekOfMonth', {'weekday': 2}),
+               ('FY5253Quarter', {'qtr_with_extra_week': 1,
+                                  'startingMonth': 1,
+                                  'weekday': 2,
+                                  'variation': 'nearest'}),
+               ('FY5253', {'weekday': 0,
+                           'startingMonth': 2,
+                           'variation':
+                           'nearest'}),
+               ('WeekOfMonth', {'weekday': 2,
+                                'week': 2}),
+               'Easter', ('DateOffset', {'day': 4}),
+               ('DateOffset', {'month': 5})]
 
-                    # same offset
-                    result = s + Series([pd.offsets.DateOffset(years=1),
-                                         pd.offsets.DateOffset(years=1)])
-                    exp = klass([Timestamp('2001-1-1'), Timestamp('2001-2-1')])
-                    assert_func(result, exp)
+    with warnings.catch_warnings(record=True):
+        for normalize in (True, False):
+            for do in offsets:
+                if isinstance(do, tuple):
+                    do, kwargs = do
+                else:
+                    do = do
+                    kwargs = {}
 
-            s = klass([Timestamp('2000-01-05 00:15:00'),
+                    for n in [0, 5]:
+                        if (do in ['WeekOfMonth', 'LastWeekOfMonth',
+                                   'FY5253Quarter', 'FY5253'] and n == 0):
+                            continue
+                    op = getattr(pd.offsets, do)(n,
+                                                 normalize=normalize,
+                                                 **kwargs)
+                    assert_func(klass([x + op for x in s]), s + op)
+                    assert_func(klass([x - op for x in s]), s - op)
+                    assert_func(klass([op + x for x in s]), op + s)
+
+
+@pytest.mark.parametrize('years,months', product([-1, 0, 1], [-2, 0, 2]))
+def test_shift_months(years, months):
+    s = DatetimeIndex([Timestamp('2000-01-05 00:15:00'),
                        Timestamp('2000-01-31 00:23:00'),
                        Timestamp('2000-01-01'),
-                       Timestamp('2000-03-31'),
                        Timestamp('2000-02-29'),
-                       Timestamp('2000-12-31'),
-                       Timestamp('2000-05-15'),
-                       Timestamp('2001-06-15')])
-
-            # DateOffset relativedelta fastpath
-            relative_kwargs = [('years', 2), ('months', 5), ('days', 3),
-                               ('hours', 5), ('minutes', 10), ('seconds', 2),
-                               ('microseconds', 5)]
-            for i, kwd in enumerate(relative_kwargs):
-                op = pd.DateOffset(**dict([kwd]))
-                assert_func(klass([x + op for x in s]), s + op)
-                assert_func(klass([x - op for x in s]), s - op)
-                op = pd.DateOffset(**dict(relative_kwargs[:i + 1]))
-                assert_func(klass([x + op for x in s]), s + op)
-                assert_func(klass([x - op for x in s]), s - op)
-
-            # assert these are equal on a piecewise basis
-            offsets = ['YearBegin', ('YearBegin', {'month': 5}), 'YearEnd',
-                       ('YearEnd', {'month': 5}), 'MonthBegin', 'MonthEnd',
-                       'SemiMonthEnd', 'SemiMonthBegin',
-                       'Week', ('Week', {
-                           'weekday': 3
-                       }), 'BusinessDay', 'BDay', 'QuarterEnd', 'QuarterBegin',
-                       'CustomBusinessDay', 'CDay', 'CBMonthEnd',
-                       'CBMonthBegin', 'BMonthBegin', 'BMonthEnd',
-                       'BusinessHour', 'BYearBegin', 'BYearEnd',
-                       'BQuarterBegin', ('LastWeekOfMonth', {
-                           'weekday': 2
-                       }), ('FY5253Quarter', {'qtr_with_extra_week': 1,
-                                              'startingMonth': 1,
-                                              'weekday': 2,
-                                              'variation': 'nearest'}),
-                       ('FY5253', {'weekday': 0,
-                                   'startingMonth': 2,
-                                   'variation':
-                                   'nearest'}), ('WeekOfMonth', {'weekday': 2,
-                                                                 'week': 2}),
-                       'Easter', ('DateOffset', {'day': 4}),
-                       ('DateOffset', {'month': 5})]
-
-            with warnings.catch_warnings(record=True):
-                for normalize in (True, False):
-                    for do in offsets:
-                        if isinstance(do, tuple):
-                            do, kwargs = do
-                        else:
-                            do = do
-                            kwargs = {}
-
-                        for n in [0, 5]:
-                            if (do in ['WeekOfMonth', 'LastWeekOfMonth',
-                                       'FY5253Quarter', 'FY5253'] and n == 0):
-                                continue
-                            op = getattr(pd.offsets, do)(n,
-                                                         normalize=normalize,
-                                                         **kwargs)
-                            assert_func(klass([x + op for x in s]), s + op)
-                            assert_func(klass([x - op for x in s]), s - op)
-                            assert_func(klass([op + x for x in s]), op + s)
-
-    def test_shift_months(self):
-        s = DatetimeIndex([Timestamp('2000-01-05 00:15:00'), Timestamp(
-            '2000-01-31 00:23:00'), Timestamp('2000-01-01'), Timestamp(
-                '2000-02-29'), Timestamp('2000-12-31')])
-        for years in [-1, 0, 1]:
-            for months in [-2, 0, 2]:
-                actual = DatetimeIndex(tslib.shift_months(s.asi8, years * 12 +
-                                                          months))
-                expected = DatetimeIndex([x + offsets.DateOffset(
-                    years=years, months=months) for x in s])
-                tm.assert_index_equal(actual, expected)
+                       Timestamp('2000-12-31')])
+    actual = DatetimeIndex(tslib.shift_months(s.asi8, years * 12 +
+                                              months))
+    expected = DatetimeIndex([x + offsets.DateOffset(
+        years=years, months=months) for x in s])
+    tm.assert_index_equal(actual, expected)
 
 
 class TestBusinessDatetimeIndex(tm.TestCase):

--- a/pandas/tests/io/test_clipboard.py
+++ b/pandas/tests/io/test_clipboard.py
@@ -20,6 +20,7 @@ except PyperclipException:
     _DEPS_INSTALLED = 0
 
 
+@pytest.mark.single
 @pytest.mark.skipif(not _DEPS_INSTALLED,
                     reason="clipboard primitives not installed")
 class TestClipboard(tm.TestCase):

--- a/pandas/tests/io/test_pytables.py
+++ b/pandas/tests/io/test_pytables.py
@@ -36,12 +36,6 @@ from pandas.util.testing import (assert_panel4d_equal,
 from pandas import concat, Timestamp
 from pandas import compat
 from pandas.compat import range, lrange, u
-
-try:
-    import tables
-except ImportError:
-    pytest.skip('no pytables')
-
 from distutils.version import LooseVersion
 
 _default_compressor = ('blosc' if LooseVersion(tables.__version__) >= '2.2'
@@ -165,6 +159,7 @@ class Base(tm.TestCase):
         pass
 
 
+@pytest.mark.single
 class TestHDFStore(Base, tm.TestCase):
 
     def test_factory_fun(self):

--- a/pandas/tests/io/test_sql.py
+++ b/pandas/tests/io/test_sql.py
@@ -18,13 +18,13 @@ The SQL tests are broken down in different classes:
 """
 
 from __future__ import print_function
+import pytest
 import unittest
 import sqlite3
 import csv
 import os
 import sys
 
-import pytest
 import warnings
 import numpy as np
 import pandas as pd
@@ -839,6 +839,7 @@ class _TestSQLApi(PandasSQLTest):
         df.to_sql('test_unicode', self.conn, index=False)
 
 
+@pytest.mark.single
 class TestSQLApi(SQLAlchemyMixIn, _TestSQLApi, unittest.TestCase):
     """
     Test the public API as it would be used directly
@@ -1024,10 +1025,12 @@ class _EngineToConnMixin(object):
         super(_EngineToConnMixin, self).tearDown()
 
 
+@pytest.mark.single
 class TestSQLApiConn(_EngineToConnMixin, TestSQLApi, unittest.TestCase):
     pass
 
 
+@pytest.mark.single
 class TestSQLiteFallbackApi(SQLiteMixIn, _TestSQLApi, unittest.TestCase):
     """
     Test the public sqlite connection fallback API
@@ -1875,30 +1878,36 @@ class _TestPostgreSQLAlchemy(object):
             tm.assert_frame_equal(res1, res2)
 
 
+@pytest.mark.single
 class TestMySQLAlchemy(_TestMySQLAlchemy, _TestSQLAlchemy, unittest.TestCase):
     pass
 
 
+@pytest.mark.single
 class TestMySQLAlchemyConn(_TestMySQLAlchemy, _TestSQLAlchemyConn,
                            unittest.TestCase):
     pass
 
 
+@pytest.mark.single
 class TestPostgreSQLAlchemy(_TestPostgreSQLAlchemy, _TestSQLAlchemy,
                             unittest.TestCase):
     pass
 
 
+@pytest.mark.single
 class TestPostgreSQLAlchemyConn(_TestPostgreSQLAlchemy, _TestSQLAlchemyConn,
                                 unittest.TestCase):
     pass
 
 
+@pytest.mark.single
 class TestSQLiteAlchemy(_TestSQLiteAlchemy, _TestSQLAlchemy,
                         unittest.TestCase):
     pass
 
 
+@pytest.mark.single
 class TestSQLiteAlchemyConn(_TestSQLiteAlchemy, _TestSQLAlchemyConn,
                             unittest.TestCase):
     pass
@@ -1907,6 +1916,7 @@ class TestSQLiteAlchemyConn(_TestSQLiteAlchemy, _TestSQLAlchemyConn,
 # -----------------------------------------------------------------------------
 # -- Test Sqlite / MySQL fallback
 
+@pytest.mark.single
 class TestSQLiteFallback(SQLiteMixIn, PandasSQLTest, unittest.TestCase):
     """
     Test the fallback mode against an in-memory sqlite database.
@@ -2133,6 +2143,7 @@ def _skip_if_no_pymysql():
         pytest.skip('pymysql not installed, skipping')
 
 
+@pytest.mark.single
 class TestXSQLite(SQLiteMixIn, tm.TestCase):
 
     def setUp(self):
@@ -2343,6 +2354,7 @@ class TestXSQLite(SQLiteMixIn, tm.TestCase):
         clean_up(table_name)
 
 
+@pytest.mark.single
 class TestSQLFlavorDeprecation(tm.TestCase):
     """
     gh-13611: test that the 'flavor' parameter
@@ -2367,8 +2379,9 @@ class TestSQLFlavorDeprecation(tm.TestCase):
                 getattr(sql, func)(self.con, flavor='sqlite')
 
 
-@unittest.skip("gh-13611: there is no support for MySQL "
-               "if SQLAlchemy is not installed")
+@pytest.mark.single
+@pytest.mark.skip(reason="gh-13611: there is no support for MySQL "
+                  "if SQLAlchemy is not installed")
 class TestXMySQL(MySQLMixIn, tm.TestCase):
 
     @classmethod

--- a/pandas/tests/test_window.py
+++ b/pandas/tests/test_window.py
@@ -2,6 +2,7 @@ from itertools import product
 import pytest
 import sys
 import warnings
+from warnings import catch_warnings
 
 from datetime import datetime
 from numpy.random import randn
@@ -291,8 +292,7 @@ class TestApi(Base):
             for op in ['mean', 'sum', 'std', 'var', 'kurt', 'skew']:
                 for t in ['rolling', 'expanding']:
 
-                    with tm.assert_produces_warning(FutureWarning,
-                                                    check_stacklevel=False):
+                    with catch_warnings(record=True):
 
                         dfunc = getattr(pd, "{0}_{1}".format(t, op))
                         if dfunc is None:
@@ -526,7 +526,7 @@ class TestDeprecations(Base):
 
     def test_deprecations(self):
 
-        with tm.assert_produces_warning(FutureWarning, check_stacklevel=False):
+        with catch_warnings(record=True):
             mom.rolling_mean(np.ones(10), 3, center=True, axis=0)
             mom.rolling_mean(Series(np.ones(10)), 3, center=True, axis=0)
 
@@ -791,7 +791,7 @@ class TestMoments(Base):
         xp = np.array([np.nan, np.nan, 9.962, 11.27, 11.564, 12.516, 12.818,
                        12.952, np.nan, np.nan])
 
-        with tm.assert_produces_warning(FutureWarning, check_stacklevel=False):
+        with catch_warnings(record=True):
             rs = mom.rolling_mean(vals, 5, center=True)
             tm.assert_almost_equal(xp, rs)
 
@@ -808,7 +808,7 @@ class TestMoments(Base):
         xp = np.array([np.nan, np.nan, 9.962, 11.27, 11.564, 12.516, 12.818,
                        12.952, np.nan, np.nan])
 
-        with tm.assert_produces_warning(FutureWarning, check_stacklevel=False):
+        with catch_warnings(record=True):
             rs = mom.rolling_window(vals, 5, 'boxcar', center=True)
             tm.assert_almost_equal(xp, rs)
 
@@ -823,19 +823,19 @@ class TestMoments(Base):
         # all nan
         vals = np.empty(10, dtype=float)
         vals.fill(np.nan)
-        with tm.assert_produces_warning(FutureWarning, check_stacklevel=False):
+        with catch_warnings(record=True):
             rs = mom.rolling_window(vals, 5, 'boxcar', center=True)
             self.assertTrue(np.isnan(rs).all())
 
         # empty
         vals = np.array([])
-        with tm.assert_produces_warning(FutureWarning, check_stacklevel=False):
+        with catch_warnings(record=True):
             rs = mom.rolling_window(vals, 5, 'boxcar', center=True)
             self.assertEqual(len(rs), 0)
 
         # shorter than window
         vals = np.random.randn(5)
-        with tm.assert_produces_warning(FutureWarning, check_stacklevel=False):
+        with catch_warnings(record=True):
             rs = mom.rolling_window(vals, 10, 'boxcar')
             self.assertTrue(np.isnan(rs).all())
             self.assertEqual(len(rs), 5)
@@ -1014,16 +1014,16 @@ class TestMoments(Base):
             tm.assert_series_equal(xp, rs)
 
     def test_rolling_median(self):
-        with tm.assert_produces_warning(FutureWarning, check_stacklevel=False):
+        with catch_warnings(record=True):
             self._check_moment_func(mom.rolling_median, np.median,
                                     name='median')
 
     def test_rolling_min(self):
 
-        with tm.assert_produces_warning(FutureWarning, check_stacklevel=False):
+        with catch_warnings(record=True):
             self._check_moment_func(mom.rolling_min, np.min, name='min')
 
-        with tm.assert_produces_warning(FutureWarning, check_stacklevel=False):
+        with catch_warnings(record=True):
             a = np.array([1, 2, 3, 4, 5])
             b = mom.rolling_min(a, window=100, min_periods=1)
             tm.assert_almost_equal(b, np.ones(len(a)))
@@ -1033,10 +1033,10 @@ class TestMoments(Base):
 
     def test_rolling_max(self):
 
-        with tm.assert_produces_warning(FutureWarning, check_stacklevel=False):
+        with catch_warnings(record=True):
             self._check_moment_func(mom.rolling_max, np.max, name='max')
 
-        with tm.assert_produces_warning(FutureWarning, check_stacklevel=False):
+        with catch_warnings(record=True):
             a = np.array([1, 2, 3, 4, 5], dtype=np.float64)
             b = mom.rolling_max(a, window=100, min_periods=1)
             tm.assert_almost_equal(a, b)
@@ -1102,11 +1102,11 @@ class TestMoments(Base):
         arr = np.arange(4)
 
         # it works!
-        with tm.assert_produces_warning(FutureWarning, check_stacklevel=False):
+        with catch_warnings(record=True):
             result = mom.rolling_apply(arr, 10, np.sum)
         self.assertTrue(isnull(result).all())
 
-        with tm.assert_produces_warning(FutureWarning, check_stacklevel=False):
+        with catch_warnings(record=True):
             result = mom.rolling_apply(arr, 10, np.sum, min_periods=1)
         tm.assert_almost_equal(result, result)
 
@@ -1117,19 +1117,19 @@ class TestMoments(Base):
                                 name='std', ddof=0)
 
     def test_rolling_std_1obs(self):
-        with tm.assert_produces_warning(FutureWarning, check_stacklevel=False):
+        with catch_warnings(record=True):
             result = mom.rolling_std(np.array([1., 2., 3., 4., 5.]),
                                      1, min_periods=1)
         expected = np.array([np.nan] * 5)
         tm.assert_almost_equal(result, expected)
 
-        with tm.assert_produces_warning(FutureWarning, check_stacklevel=False):
+        with catch_warnings(record=True):
             result = mom.rolling_std(np.array([1., 2., 3., 4., 5.]),
                                      1, min_periods=1, ddof=0)
         expected = np.zeros(5)
         tm.assert_almost_equal(result, expected)
 
-        with tm.assert_produces_warning(FutureWarning, check_stacklevel=False):
+        with catch_warnings(record=True):
             result = mom.rolling_std(np.array([np.nan, np.nan, 3., 4., 5.]),
                                      3, min_periods=2)
         self.assertTrue(np.isnan(result[2]))
@@ -1142,11 +1142,11 @@ class TestMoments(Base):
         a = np.array([0.0011448196318903589, 0.00028718669878572767,
                       0.00028718669878572767, 0.00028718669878572767,
                       0.00028718669878572767])
-        with tm.assert_produces_warning(FutureWarning, check_stacklevel=False):
+        with catch_warnings(record=True):
             b = mom.rolling_std(a, window=3)
         self.assertTrue(np.isfinite(b[2:]).all())
 
-        with tm.assert_produces_warning(FutureWarning, check_stacklevel=False):
+        with catch_warnings(record=True):
             b = mom.ewmstd(a, span=3)
         self.assertTrue(np.isfinite(b[2:]).all())
 
@@ -1184,25 +1184,25 @@ class TestMoments(Base):
         if sys.byteorder != "little":
             arr = arr.byteswap().newbyteorder()
 
-        with tm.assert_produces_warning(FutureWarning, check_stacklevel=False):
+        with catch_warnings(record=True):
             result = mom.rolling_sum(arr, 2)
         self.assertTrue((result[1:] >= 0).all())
 
-        with tm.assert_produces_warning(FutureWarning, check_stacklevel=False):
+        with catch_warnings(record=True):
             result = mom.rolling_mean(arr, 2)
         self.assertTrue((result[1:] >= 0).all())
 
-        with tm.assert_produces_warning(FutureWarning, check_stacklevel=False):
+        with catch_warnings(record=True):
             result = mom.rolling_var(arr, 2)
         self.assertTrue((result[1:] >= 0).all())
 
         # #2527, ugh
         arr = np.array([0.00012456, 0.0003, 0])
-        with tm.assert_produces_warning(FutureWarning, check_stacklevel=False):
+        with catch_warnings(record=True):
             result = mom.rolling_mean(arr, 1)
         self.assertTrue(result[-1] >= 0)
 
-        with tm.assert_produces_warning(FutureWarning, check_stacklevel=False):
+        with catch_warnings(record=True):
             result = mom.rolling_mean(-arr, 1)
         self.assertTrue(result[-1] <= 0)
 
@@ -1327,15 +1327,13 @@ class TestMoments(Base):
 
                 # catch a freq deprecation warning if freq is provided and not
                 # None
-                w = FutureWarning if freq is not None else None
-                with tm.assert_produces_warning(w, check_stacklevel=False):
+                with catch_warnings(record=True):
                     r = obj.rolling(window=window, min_periods=min_periods,
                                     freq=freq, center=center)
                 return getattr(r, name)(**kwargs)
 
             # check via the moments API
-            with tm.assert_produces_warning(FutureWarning,
-                                            check_stacklevel=False):
+            with catch_warnings(record=True):
                 return f(obj, window=window, min_periods=min_periods,
                          freq=freq, center=center, **kwargs)
 
@@ -1419,7 +1417,7 @@ class TestMoments(Base):
 
         arr = np.zeros(1000)
         arr[5] = 1
-        with tm.assert_produces_warning(FutureWarning, check_stacklevel=False):
+        with catch_warnings(record=True):
             result = mom.ewma(arr, span=100, adjust=False).sum()
         self.assertTrue(np.abs(result - 1) < 1e-2)
 
@@ -1506,7 +1504,7 @@ class TestMoments(Base):
         self._check_ew(mom.ewmvol, name='vol')
 
     def test_ewma_span_com_args(self):
-        with tm.assert_produces_warning(FutureWarning, check_stacklevel=False):
+        with catch_warnings(record=True):
             A = mom.ewma(self.arr, com=9.5)
             B = mom.ewma(self.arr, span=20)
             tm.assert_almost_equal(A, B)
@@ -1515,7 +1513,7 @@ class TestMoments(Base):
             self.assertRaises(ValueError, mom.ewma, self.arr)
 
     def test_ewma_halflife_arg(self):
-        with tm.assert_produces_warning(FutureWarning, check_stacklevel=False):
+        with catch_warnings(record=True):
             A = mom.ewma(self.arr, com=13.932726172912965)
             B = mom.ewma(self.arr, halflife=10.0)
             tm.assert_almost_equal(A, B)
@@ -1530,7 +1528,7 @@ class TestMoments(Base):
 
     def test_ewma_alpha_old_api(self):
         # GH 10789
-        with tm.assert_produces_warning(FutureWarning, check_stacklevel=False):
+        with catch_warnings(record=True):
             a = mom.ewma(self.arr, alpha=0.61722699889169674)
             b = mom.ewma(self.arr, com=0.62014947789973052)
             c = mom.ewma(self.arr, span=2.240298955799461)
@@ -1541,7 +1539,7 @@ class TestMoments(Base):
 
     def test_ewma_alpha_arg_old_api(self):
         # GH 10789
-        with tm.assert_produces_warning(FutureWarning, check_stacklevel=False):
+        with catch_warnings(record=True):
             self.assertRaises(ValueError, mom.ewma, self.arr)
             self.assertRaises(ValueError, mom.ewma, self.arr,
                               com=10.0, alpha=0.5)
@@ -1598,13 +1596,12 @@ class TestMoments(Base):
 
         funcs = [mom.ewma, mom.ewmvol, mom.ewmvar]
         for f in funcs:
-            with tm.assert_produces_warning(FutureWarning,
-                                            check_stacklevel=False):
+            with catch_warnings(record=True):
                 result = f(arr, 3)
             tm.assert_almost_equal(result, arr)
 
     def _check_ew(self, func, name=None):
-        with tm.assert_produces_warning(FutureWarning, check_stacklevel=False):
+        with catch_warnings(record=True):
             self._check_ew_ndarray(func, name=name)
         self._check_ew_structures(func, name=name)
 
@@ -2870,7 +2867,7 @@ class TestMomentsConsistency(Base):
 
         expected = Series([1.0, 2.0, 6.0, 4.0, 5.0],
                           index=[datetime(1975, 1, i, 0) for i in range(1, 6)])
-        with tm.assert_produces_warning(FutureWarning, check_stacklevel=False):
+        with catch_warnings(record=True):
             x = series.rolling(window=1, freq='D').max()
         tm.assert_series_equal(expected, x)
 
@@ -2889,14 +2886,14 @@ class TestMomentsConsistency(Base):
         # Default how should be max
         expected = Series([0.0, 1.0, 2.0, 3.0, 20.0],
                           index=[datetime(1975, 1, i, 0) for i in range(1, 6)])
-        with tm.assert_produces_warning(FutureWarning, check_stacklevel=False):
+        with catch_warnings(record=True):
             x = series.rolling(window=1, freq='D').max()
         tm.assert_series_equal(expected, x)
 
         # Now specify median (10.0)
         expected = Series([0.0, 1.0, 2.0, 3.0, 10.0],
                           index=[datetime(1975, 1, i, 0) for i in range(1, 6)])
-        with tm.assert_produces_warning(FutureWarning, check_stacklevel=False):
+        with catch_warnings(record=True):
             x = series.rolling(window=1, freq='D').max(how='median')
         tm.assert_series_equal(expected, x)
 
@@ -2904,7 +2901,7 @@ class TestMomentsConsistency(Base):
         v = (4.0 + 10.0 + 20.0) / 3.0
         expected = Series([0.0, 1.0, 2.0, 3.0, v],
                           index=[datetime(1975, 1, i, 0) for i in range(1, 6)])
-        with tm.assert_produces_warning(FutureWarning, check_stacklevel=False):
+        with catch_warnings(record=True):
             x = series.rolling(window=1, freq='D').max(how='mean')
             tm.assert_series_equal(expected, x)
 
@@ -2923,7 +2920,7 @@ class TestMomentsConsistency(Base):
         # Default how should be min
         expected = Series([0.0, 1.0, 2.0, 3.0, 4.0],
                           index=[datetime(1975, 1, i, 0) for i in range(1, 6)])
-        with tm.assert_produces_warning(FutureWarning, check_stacklevel=False):
+        with catch_warnings(record=True):
             r = series.rolling(window=1, freq='D')
             tm.assert_series_equal(expected, r.min())
 
@@ -2942,7 +2939,7 @@ class TestMomentsConsistency(Base):
         # Default how should be median
         expected = Series([0.0, 1.0, 2.0, 3.0, 10],
                           index=[datetime(1975, 1, i, 0) for i in range(1, 6)])
-        with tm.assert_produces_warning(FutureWarning, check_stacklevel=False):
+        with catch_warnings(record=True):
             x = series.rolling(window=1, freq='D').median()
             tm.assert_series_equal(expected, x)
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,3 +25,5 @@ split_penalty_logical_operator = 30
 # Silencing the warning until then
 addopts = --disable-pytest-warnings
 testpaths = pandas
+markers =
+    single: mark a test as single cpu only

--- a/test_fast.sh
+++ b/test_fast.sh
@@ -1,2 +1,1 @@
-# nosetests -A "not slow and not network" pandas --with-id $*
-pytest pandas --skip-slow
+pytest pandas --skip-slow --skip-network -m "not single" -n 4


### PR DESCRIPTION
on top of #15369
xref #15341

``pytest pandas --skip-slow --skip-network -m "not single" -n 4``

```
(pandas) bash-3.2$ ./test_fast.sh 
==================================================================================================== test session starts ====================================================================================================
platform darwin -- Python 3.5.2, pytest-3.0.5, py-1.4.31, pluggy-0.4.0
rootdir: /Users/jreback/pandas, inifile: setup.cfg
plugins: cov-2.4.0, xdist-1.15.0
gw0 [11470] / gw1 [11470] / gw2 [11470] / gw3 [11470]
scheduling tests via LoadScheduling
.....s...ss......s...s....s....s.....s...s...s.s......................s..............s......s...s................s......s...ss.....s......................................................................................................................................s..s.s.s......................................................................................................................................................................................s.```

```
=============== 11046 passed, 424 skipped in 170.96 seconds 
```