### PR TITLE
BUG: Avoid trying to graft missing examples directory

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -7,7 +7,6 @@ include setup.py
 graft doc
 prune doc/build
 
-graft examples
 graft pandas
 
 global-exclude *.so


### PR DESCRIPTION
The examples directory was removed by #9391. Remove it from the MANIFEST too.