### PR TITLE
Require numexpr 2.6.2

### DIFF
--- a/doc/source/whatsnew/v0.20.0.txt
+++ b/doc/source/whatsnew/v0.20.0.txt
@@ -1,11 +1,15 @@
 .. _whatsnew_0200:
 
-v0.20.0 (????, 2016)
+v0.20.0 (????, 2017)
 --------------------
 
 This is a major release from 0.19 and includes a small number of API changes, several new features,
 enhancements, and performance improvements along with a large number of bug fixes. We recommend that all
 users upgrade to this version.
+
+.. warning::
+
+   Due to important fixes and performance improvements, ``numexpr`` version is now required to be >= 2.6.2 and it will not be used at all if this requisite is not fullfilled (:issue:`15213`).
 
 Highlights include:
 

--- a/pandas/computation/__init__.py
+++ b/pandas/computation/__init__.py
@@ -7,22 +7,13 @@ _NUMEXPR_INSTALLED = False
 try:
     import numexpr as ne
     ver = ne.__version__
-    _NUMEXPR_INSTALLED = ver >= LooseVersion('2.1')
+    _NUMEXPR_INSTALLED = ver >= LooseVersion('2.6.2')
 
-    # we specifically disallow 2.4.4 as
-    # has some hard-to-diagnose bugs
-    if ver == LooseVersion('2.4.4'):
-        _NUMEXPR_INSTALLED = False
-        warnings.warn(
-            "The installed version of numexpr {ver} is not supported "
-            "in pandas and will be not be used\n".format(ver=ver),
-            UserWarning)
-
-    elif not _NUMEXPR_INSTALLED:
+    if not _NUMEXPR_INSTALLED:
         warnings.warn(
             "The installed version of numexpr {ver} is not supported "
             "in pandas and will be not be used\nThe minimum supported "
-            "version is 2.1\n".format(ver=ver), UserWarning)
+            "version is 2.6.2\n".format(ver=ver), UserWarning)
 
 except ImportError:  # pragma: no cover
     pass


### PR DESCRIPTION
 - [x] closes #15213
 - [x] passes ``git diff upstream/master | flake8 --diff``
 - [x] whatsnew entry

This addresses #15213.  Numexpr 2.6.2 has [wheels for all major platforms already](https://pypi.python.org/pypi/numexpr), and although conda is still at 2.6.1, the [fixes in 2.6.2](https://github.com/pydata/numexpr/blob/master/RELEASE_NOTES.rst#changes-from-261-to-262) makes it strongly recommended for everyone.