### PR TITLE
Catch SystemError thrown in 3.6

### DIFF
--- a/pandas/tseries/index.py
+++ b/pandas/tseries/index.py
@@ -1416,7 +1416,7 @@ class DatetimeIndex(DatelikeOps, TimelikeOps, DatetimeIndexOpsMixin,
             try:
                 stamp = Timestamp(key, tz=self.tz)
                 return Index.get_loc(self, stamp, method, tolerance)
-            except (KeyError, ValueError):
+            except (KeyError, ValueError, SystemError):
                 raise KeyError(key)
 
     def _maybe_cast_slice_bound(self, label, side, kind):


### PR DESCRIPTION
Trying to set an attribute on a non-empty timeseries now on 3.6
causes an SystemError here, which it didn't used to, which breaks
things.

In [28]: s = pandas.Series()

In [29]: s.test = 'test'

In [30]: s = pandas.Series([0] * 100, pandas.to_datetime(list(range(100)), unit='s'))

In [31]: s
Out[31]:
1970-01-01 00:00:00    0
1970-01-01 00:00:01    0
1970-01-01 00:00:02    0
1970-01-01 00:00:03    0
1970-01-01 00:00:04    0
1970-01-01 00:00:05    0
1970-01-01 00:00:06    0
1970-01-01 00:00:07    0
1970-01-01 00:00:08    0
1970-01-01 00:00:09    0
1970-01-01 00:00:10    0
1970-01-01 00:00:11    0
1970-01-01 00:00:12    0
1970-01-01 00:00:13    0
1970-01-01 00:00:14    0
1970-01-01 00:00:15    0
1970-01-01 00:00:16    0
1970-01-01 00:00:17    0
1970-01-01 00:00:18    0
1970-01-01 00:00:19    0
1970-01-01 00:00:20    0
1970-01-01 00:00:21    0
1970-01-01 00:00:22    0
1970-01-01 00:00:23    0
1970-01-01 00:00:24    0
1970-01-01 00:00:25    0
1970-01-01 00:00:26    0
1970-01-01 00:00:27    0
1970-01-01 00:00:28    0
1970-01-01 00:00:29    0
                      ..
1970-01-01 00:01:10    0
1970-01-01 00:01:11    0
1970-01-01 00:01:12    0
1970-01-01 00:01:13    0
1970-01-01 00:01:14    0
1970-01-01 00:01:15    0
1970-01-01 00:01:16    0
1970-01-01 00:01:17    0
1970-01-01 00:01:18    0
1970-01-01 00:01:19    0
1970-01-01 00:01:20    0
1970-01-01 00:01:21    0
1970-01-01 00:01:22    0
1970-01-01 00:01:23    0
1970-01-01 00:01:24    0
1970-01-01 00:01:25    0
1970-01-01 00:01:26    0
1970-01-01 00:01:27    0
1970-01-01 00:01:28    0
1970-01-01 00:01:29    0
1970-01-01 00:01:30    0
1970-01-01 00:01:31    0
1970-01-01 00:01:32    0
1970-01-01 00:01:33    0
1970-01-01 00:01:34    0
1970-01-01 00:01:35    0
1970-01-01 00:01:36    0
1970-01-01 00:01:37    0
1970-01-01 00:01:38    0
1970-01-01 00:01:39    0
dtype: int64

In [32]: s.test = 'test'
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
pandas/index.pyx in pandas.index.DatetimeEngine.get_loc (pandas/index.c:11572)()

pandas/hashtable.pyx in pandas.hashtable.Int64HashTable.get_item (pandas/hashtable.c:6931)()

TypeError: an integer is required

During handling of the above exception, another exception occurred:

KeyError                                  Traceback (most recent call last)
pandas/indexes/base.py in get_loc(self, key, method, tolerance)
   1944             try:
-> 1945                 return self._engine.get_loc(key)
   1946             except KeyError:

pandas/index.pyx in pandas.index.DatetimeEngine.get_loc (pandas/index.c:11740)()

pandas/index.pyx in pandas.index.DatetimeEngine.get_loc (pandas/index.c:11646)()

pandas/index.pyx in pandas.index.DatetimeEngine._date_check_type (pandas/index.c:11810)()

KeyError: 'test'

During handling of the above exception, another exception occurred:

TypeError                                 Traceback (most recent call last)
pandas/index.pyx in pandas.index.DatetimeEngine.get_loc (pandas/index.c:11572)()

pandas/hashtable.pyx in pandas.hashtable.Int64HashTable.get_item (pandas/hashtable.c:6931)()

TypeError: an integer is required

During handling of the above exception, another exception occurred:

KeyError                                  Traceback (most recent call last)
pandas/tseries/index.py in get_loc(self, key, method, tolerance)
   1430         try:
-> 1431             return Index.get_loc(self, key, method, tolerance)
   1432         except (KeyError, ValueError, TypeError):

pandas/indexes/base.py in get_loc(self, key, method, tolerance)
   1946             except KeyError:
-> 1947                 return self._engine.get_loc(self._maybe_cast_indexer(key))
   1948

pandas/index.pyx in pandas.index.DatetimeEngine.get_loc (pandas/index.c:11740)()

pandas/index.pyx in pandas.index.DatetimeEngine.get_loc (pandas/index.c:11646)()

pandas/index.pyx in pandas.index.DatetimeEngine._date_check_type (pandas/index.c:11810)()

KeyError: 'test'

During handling of the above exception, another exception occurred:

ValueError                                Traceback (most recent call last)
ValueError: Error parsing datetime string "test" at position 0

The above exception was the direct cause of the following exception:

SystemError                               Traceback (most recent call last)
<ipython-input-32-753b248023e5> in <module>()
----> 1 s.test = 'test'

pandas/core/generic.py in __setattr__(self, name, value)
   2695         else:
   2696             try:
-> 2697                 existing = getattr(self, name)
   2698                 if isinstance(existing, Index):
   2699                     object.__setattr__(self, name, value)

pandas/core/generic.py in __getattr__(self, name)
   2668             return object.__getattribute__(self, name)
   2669         else:
-> 2670             if name in self._info_axis:
   2671                 return self[name]
   2672             return object.__getattribute__(self, name)

pandas/tseries/base.py in __contains__(self, key)
    182     def __contains__(self, key):
    183         try:
--> 184             res = self.get_loc(key)
    185             return lib.isscalar(res) or type(res) == slice or np.any(res)
    186         except (KeyError, TypeError, ValueError):

/dpandas/tseries/index.py in get_loc(self, key, method, tolerance)
   1437
   1438             try:
-> 1439                 stamp = Timestamp(key, tz=self.tz)
   1440                 return Index.get_loc(self, stamp, method, tolerance)
   1441             except (KeyError, ValueError):

pandas/tslib.pyx in pandas.tslib.Timestamp.__new__ (pandas/tslib.c:9668)()

pandas/tslib.pyx in pandas.tslib.convert_to_tsobject (pandas/tslib.c:26065)()

pandas/tslib.pyx in pandas.tslib.convert_str_to_tsobject (pandas/tslib.c:27849)()

pandas/src/datetime.pxd in datetime._string_to_dts (pandas/tslib.c:92986)()

SystemError: <class 'str'> returned a result with an error set

 - [ ] closes #xxxx
 - [ ] tests added / passed
 - [ ] passes ``git diff upstream/master | flake8 --diff``
 - [ ] whatsnew entry
