### PR TITLE
Don't add rowspan/colspan if it's 1.

### DIFF
--- a/doc/source/whatsnew/v0.20.0.txt
+++ b/doc/source/whatsnew/v0.20.0.txt
@@ -154,6 +154,7 @@ Other enhancements
 - ``pandas.tools.hashing`` has gained a ``hash_tuples`` routine, and ``hash_pandas_object`` has gained the ability to hash a ``MultiIndex`` (:issue:`15224`)
 - ``Series/DataFrame.squeeze()`` have gained the ``axis`` parameter. (:issue:`15339`)
 - ``DataFrame.to_excel()`` has a new ``freeze_panes`` parameter to turn on Freeze Panes when exporting to Excel (:issue:`15160`)
+- HTML table output skips ``colspan`` or ``rowspan`` attribute if equal to 1. (:issue:`15403`)
 
 .. _ISO 8601 duration: https://en.wikipedia.org/wiki/ISO_8601#Durations
 

--- a/pandas/formats/style.py
+++ b/pandas/formats/style.py
@@ -251,21 +251,23 @@ class Styler(object):
                            "class": " ".join(cs),
                            "is_visible": True})
 
-            for c in range(len(clabels[0])):
+            for c, value in enumerate(clabels[r]):
                 cs = [COL_HEADING_CLASS, "level%s" % r, "col%s" % c]
                 cs.extend(cell_context.get(
                     "col_headings", {}).get(r, {}).get(c, []))
-                value = clabels[r][c]
-                row_es.append({"type": "th",
-                               "value": value,
-                               "display_value": value,
-                               "class": " ".join(cs),
-                               "is_visible": _is_visible(c, r, col_lengths),
-                               "attributes": [
-                                   format_attr({"key": "colspan",
-                                                "value": col_lengths.get(
-                                                    (r, c), 1)})
-                               ]})
+                es = {
+                    "type": "th",
+                    "value": value,
+                    "display_value": value,
+                    "class": " ".join(cs),
+                    "is_visible": _is_visible(c, r, col_lengths),
+                }
+                colspan = col_lengths.get((r, c), 0)
+                if colspan > 1:
+                    es["attributes"] = [
+                        format_attr({"key": "colspan", "value": colspan})
+                    ]
+                row_es.append(es)
             head.append(row_es)
 
         if self.data.index.names and not all(x is None
@@ -289,19 +291,22 @@ class Styler(object):
 
         body = []
         for r, idx in enumerate(self.data.index):
-            #  cs.extend(
-            #    cell_context.get("row_headings", {}).get(r, {}).get(c, []))
-            row_es = [{"type": "th",
-                       "is_visible": _is_visible(r, c, idx_lengths),
-                       "attributes": [
-                           format_attr({"key": "rowspan",
-                                        "value": idx_lengths.get((c, r), 1)})
-                       ],
-                       "value": rlabels[r][c],
-                       "class": " ".join([ROW_HEADING_CLASS, "level%s" % c,
-                                          "row%s" % r]),
-                       "display_value": rlabels[r][c]}
-                      for c in range(len(rlabels[r]))]
+            row_es = []
+            for c, value in enumerate(rlabels[r]):
+                es = {
+                    "type": "th",
+                    "is_visible": _is_visible(r, c, idx_lengths),
+                    "value": value,
+                    "display_value": value,
+                    "class": " ".join([ROW_HEADING_CLASS, "level%s" % c,
+                                       "row%s" % r]),
+                }
+                rowspan = idx_lengths.get((c, r), 0)
+                if rowspan > 1:
+                    es["attributes"] = [
+                        format_attr({"key": "rowspan", "value": rowspan})
+                    ]
+                row_es.append(es)
 
             for c, col in enumerate(self.data.columns):
                 cs = [DATA_CLASS, "row%s" % r, "col%s" % c]

--- a/pandas/tests/formats/test_style.py
+++ b/pandas/tests/formats/test_style.py
@@ -141,21 +141,18 @@ class TestStyler(TestCase):
                       'type': 'th',
                       'value': 'A',
                       'is_visible': True,
-                      'attributes': ["colspan=1"],
                       },
                      {'class': 'col_heading level0 col1',
                       'display_value': 'B',
                       'type': 'th',
                       'value': 'B',
                       'is_visible': True,
-                      'attributes': ["colspan=1"],
                       },
                      {'class': 'col_heading level0 col2',
                       'display_value': 'C',
                       'type': 'th',
                       'value': 'C',
                       'is_visible': True,
-                      'attributes': ["colspan=1"],
                       }]]
 
         self.assertEqual(result['head'], expected)
@@ -168,11 +165,9 @@ class TestStyler(TestCase):
         expected = [[{'class': 'blank level0', 'type': 'th', 'value': '',
                       'display_value': '', 'is_visible': True},
                      {'class': 'col_heading level0 col0', 'type': 'th',
-                      'value': 'B', 'display_value': 'B',
-                      'is_visible': True, 'attributes': ['colspan=1']},
+                      'value': 'B', 'display_value': 'B', 'is_visible': True},
                      {'class': 'col_heading level0 col1', 'type': 'th',
-                      'value': 'C', 'display_value': 'C',
-                      'is_visible': True, 'attributes': ['colspan=1']}],
+                      'value': 'C', 'display_value': 'C', 'is_visible': True}],
                     [{'class': 'index_name level0', 'type': 'th',
                       'value': 'A'},
                      {'class': 'blank', 'type': 'th', 'value': ''},
@@ -191,9 +186,7 @@ class TestStyler(TestCase):
             {'class': 'blank level0', 'type': 'th', 'value': '',
              'display_value': '', 'is_visible': True},
             {'class': 'col_heading level0 col0', 'type': 'th',
-             'value': 'C', 'display_value': 'C',
-             'is_visible': True, 'attributes': ['colspan=1'],
-             }],
+             'value': 'C', 'display_value': 'C', 'is_visible': True}],
             [{'class': 'index_name level0', 'type': 'th',
               'value': 'A'},
              {'class': 'index_name level1', 'type': 'th',
@@ -618,16 +611,14 @@ class TestStyler(TestCase):
         body_1 = result['body'][0][1]
         expected_1 = {
             "value": 0, "display_value": 0, "is_visible": True,
-            "type": "th", "attributes": ["rowspan=1"],
-            "class": "row_heading level1 row0",
+            "type": "th", "class": "row_heading level1 row0",
         }
         tm.assert_dict_equal(body_1, expected_1)
 
         body_10 = result['body'][1][0]
         expected_10 = {
             "value": 'a', "display_value": 'a', "is_visible": False,
-            "type": "th", "attributes": ["rowspan=1"],
-            "class": "row_heading level0 row1",
+            "type": "th", "class": "row_heading level0 row1",
         }
         tm.assert_dict_equal(body_10, expected_10)
 
@@ -637,9 +628,8 @@ class TestStyler(TestCase):
              'is_visible': True, "display_value": ''},
             {'type': 'th', 'class': 'blank level0', 'value': '',
              'is_visible': True, 'display_value': ''},
-            {'attributes': ['colspan=1'], 'class': 'col_heading level0 col0',
-             'is_visible': True, 'type': 'th', 'value': 'A',
-             'display_value': 'A'}]
+            {'type': 'th', 'class': 'col_heading level0 col0', 'value': 'A',
+             'is_visible': True, 'display_value': 'A'}]
         self.assertEqual(head, expected)
 
     def test_mi_sparse_disabled(self):
@@ -650,7 +640,7 @@ class TestStyler(TestCase):
             result = df.style._translate()
         body = result['body']
         for row in body:
-            self.assertEqual(row[0]['attributes'], ['rowspan=1'])
+            assert 'attributes' not in row[0]
 
     def test_mi_sparse_index_names(self):
         df = pd.DataFrame({'A': [1, 2]}, index=pd.MultiIndex.from_arrays(
@@ -686,28 +676,24 @@ class TestStyler(TestCase):
              'type': 'th', 'is_visible': True},
             {'class': 'index_name level1', 'value': 'col_1',
              'display_value': 'col_1', 'is_visible': True, 'type': 'th'},
-            {'attributes': ['colspan=1'],
-             'class': 'col_heading level1 col0',
+            {'class': 'col_heading level1 col0',
              'display_value': 1,
              'is_visible': True,
              'type': 'th',
              'value': 1},
-            {'attributes': ['colspan=1'],
-             'class': 'col_heading level1 col1',
+            {'class': 'col_heading level1 col1',
              'display_value': 0,
              'is_visible': True,
              'type': 'th',
              'value': 0},
 
-            {'attributes': ['colspan=1'],
-             'class': 'col_heading level1 col2',
+            {'class': 'col_heading level1 col2',
              'display_value': 1,
              'is_visible': True,
              'type': 'th',
              'value': 1},
 
-            {'attributes': ['colspan=1'],
-             'class': 'col_heading level1 col3',
+            {'class': 'col_heading level1 col3',
              'display_value': 0,
              'is_visible': True,
              'type': 'th',


### PR DESCRIPTION
Just a small thing I noticed in a [footnote here](https://danluu.com/web-bloat/#appendix-irony). Probably can't do much about the extra classes, but rowspan/colspan seem like easy fixes to save a few bytes per row/col and it's already done in the other code path.

Don't really know if this is major enough to deserve a what's new entry.

 - [ ] ~~closes #xxxx~~ - N/A
 - [x] tests added / passed
 - [x] passes ``git diff upstream/master | flake8 --diff``
 - [ ] whatsnew entry
