### PR TITLE
TST: Parametrize simple yield tests

### DIFF
--- a/ci/script_multi.sh
+++ b/ci/script_multi.sh
@@ -17,6 +17,12 @@ if [ -n "$LOCALE_OVERRIDE" ]; then
     python -c "$pycmd"
 fi
 
+# Workaround for pytest-xdist flaky collection order
+# https://github.com/pytest-dev/pytest/issues/920
+# https://github.com/pytest-dev/pytest/issues/1075
+export PYTHONHASHSEED=$(python -c 'import random; print(random.randint(1, 4294967295))')
+echo PYTHONHASHSEED=$PYTHONHASHSEED
+
 if [ "$BUILD_TEST" ]; then
     echo "We are not running pytest as this is simply a build test."
 elif [ "$COVERAGE" ]; then

--- a/pandas/tests/computation/test_compat.py
+++ b/pandas/tests/computation/test_compat.py
@@ -12,8 +12,6 @@ from pandas.computation.engines import _engines
 import pandas.computation.expr as expr
 from pandas.computation import _MIN_NUMEXPR_VERSION
 
-ENGINES_PARSERS = list(product(_engines, expr._parsers))
-
 
 def test_compat():
     # test we have compat with our version of nu
@@ -30,12 +28,9 @@ def test_compat():
         pytest.skip("not testing numexpr version compat")
 
 
-def test_invalid_numexpr_version():
-    for engine, parser in ENGINES_PARSERS:
-        yield check_invalid_numexpr_version, engine, parser
-
-
-def check_invalid_numexpr_version(engine, parser):
+@pytest.mark.parametrize('engine', _engines)
+@pytest.mark.parametrize('parser', expr._parsers)
+def test_invalid_numexpr_version(engine, parser):
     def testit():
         a, b = 1, 2
         res = pd.eval('a + b', engine=engine, parser=parser)

--- a/pandas/util/testing.py
+++ b/pandas/util/testing.py
@@ -307,12 +307,21 @@ def _skip_if_scipy_0_17():
         pytest.skip("scipy 0.17")
 
 
-def _skip_if_no_lzma():
+def _check_if_lzma():
     try:
         return compat.import_lzma()
     except ImportError:
-        import pytest
-        pytest.skip('need backports.lzma to run')
+        return False
+
+
+def _skip_if_no_lzma():
+    return _check_if_lzma() or pytest.skip('need backports.lzma to run')
+
+
+_mark_skipif_no_lzma = pytest.mark.skipif(
+    not _check_if_lzma(),
+    reason='need backports.lzma to run'
+)
 
 
 def _skip_if_no_xarray():


### PR DESCRIPTION
Simple `yield` tests are those that do `for x in y: yield test, x` where `y` is some constant list/tuple. It also requires the tests to be in a simple class that doesn't subclass `unittest`'s classes (because parametrization doesn't work there).

There are still `yield` tests in 
 * frame/test_query_eval.py
 * io/test_packers.py
 * io/test_pickle.py
 * test_internals.py
 * test_window.py

but I haven't changed them since they don't conform to the requirements above.

This is also not an attempt to parametrize any and all test loops.

 - [x] cf #15341
 - [ ] tests added / passed
 - [x] passes ``git diff upstream/master | flake8 --diff``
 - [ ] whatsnew entry
