### PR TITLE
Mi indexing

### DIFF
--- a/doc/source/whatsnew/v0.20.0.txt
+++ b/doc/source/whatsnew/v0.20.0.txt
@@ -505,6 +505,10 @@ Bug Fixes
 
 
 
+- Bug in ``DataFrame.loc`` with indexing a ``MultiIndex`` with a numpy array (:issue:`15434`)
+
+
+
 - Bug in the display of ``.info()`` where a qualifier (+) would always be displayed with a ``MultiIndex`` that contains only non-strings (:issue:`15245`)
 - Bug in ``pd.read_msgpack()`` in which ``Series`` categoricals were being improperly processed (:issue:`14901`)
 - Bug in ``Series.ffill()`` with mixed dtypes containing tz-aware datetimes. (:issue:`14956`)

--- a/doc/source/whatsnew/v0.20.0.txt
+++ b/doc/source/whatsnew/v0.20.0.txt
@@ -501,7 +501,7 @@ Bug Fixes
 - Bug in ``pd.tools.hashing.hash_pandas_object()`` in which hashing of categoricals depended on the ordering of categories, instead of just their values. (:issue:`15143`)
 - Bug in ``.groupby(..).resample()`` when passed the ``on=`` kwarg. (:issue:`15021`)
 
-- Bug in ``DataFrame.loc`` with indexing a ``MultiIndex`` with a ``Series`` indexer (:issue:`14730`)
+- Bug in ``DataFrame.loc`` with indexing a ``MultiIndex`` with a ``Series`` indexer (:issue:`14730`, :issue:`15424`)
 
 
 

--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -1537,6 +1537,8 @@ class _LocIndexer(_LocationIndexer):
                     raise NotImplementedError("Indexing a MultiIndex with a "
                                               "multidimensional key is not "
                                               "implemented")
+                elif isinstance(key, np.ndarray):
+                    key = key.tolist()
                 if (not isinstance(key, tuple) and len(key) > 1 and
                         not isinstance(key[0], tuple)):
                     key = tuple([key])

--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -1521,9 +1521,7 @@ class _LocIndexer(_LocationIndexer):
             return self._getbool_axis(key, axis=axis)
         elif is_list_like_indexer(key):
 
-            # GH 7349
-            # possibly convert a list-like into a nested tuple
-            # but don't convert a list-like of tuples
+            # convert various datatypes to a list of keys
             if isinstance(labels, MultiIndex):
                 if isinstance(key, ABCSeries):
                     # GH 14730

--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -1525,11 +1525,20 @@ class _LocIndexer(_LocationIndexer):
             # possibly convert a list-like into a nested tuple
             # but don't convert a list-like of tuples
             if isinstance(labels, MultiIndex):
+                if isinstance(key, ABCSeries):
+                    # GH 14730
+                    key = key.values.tolist()
+                elif isinstance(key, ABCDataFrame):
+                    # GH 15438
+                    raise NotImplementedError("Indexing a MultiIndex with a "
+                                              "DataFrame key is not "
+                                              "implemented")
+                elif hasattr(key, 'ndim') and key.ndim > 1:
+                    raise NotImplementedError("Indexing a MultiIndex with a "
+                                              "multidimensional key is not "
+                                              "implemented")
                 if (not isinstance(key, tuple) and len(key) > 1 and
                         not isinstance(key[0], tuple)):
-                    if isinstance(key, ABCSeries):
-                        # GH 14730
-                        key = list(key)
                     key = tuple([key])
 
             # an iterable multi-selection

--- a/pandas/tests/indexing/test_multiindex.py
+++ b/pandas/tests/indexing/test_multiindex.py
@@ -169,6 +169,35 @@ class TestMultiIndexBasic(tm.TestCase):
         result = x.loc[empty]
         tm.assert_series_equal(result, expected)
 
+    def test_loc_getitem_array(self):
+        # GH15434
+        # passing an array as a key with a MultiIndex
+        index = MultiIndex.from_product([[1, 2, 3], ['A', 'B', 'C']])
+        x = Series(index=index, data=range(9), dtype=np.float64)
+        y = np.array([1, 3])
+        expected = Series(
+            data=[0, 1, 2, 6, 7, 8],
+            index=MultiIndex.from_product([[1, 3], ['A', 'B', 'C']]),
+            dtype=np.float64)
+        result = x.loc[y]
+        tm.assert_series_equal(result, expected)
+
+        # empty array:
+        empty = np.array([])
+        expected = Series([], index=MultiIndex(
+            levels=index.levels, labels=[[], []], dtype=np.float64))
+        result = x.loc[empty]
+        tm.assert_series_equal(result, expected)
+
+        # 0-dim array (scalar):
+        scalar = np.int64(1)
+        expected = Series(
+            data=[0, 1, 2],
+            index=['A', 'B', 'C'],
+            dtype=np.float64)
+        result = x.loc[scalar]
+        tm.assert_series_equal(result, expected)
+
     def test_iloc_getitem_multiindex(self):
         mi_labels = DataFrame(np.random.randn(4, 3),
                               columns=[['i', 'i', 'j'], ['A', 'A', 'B']],

--- a/pandas/tests/indexing/test_multiindex.py
+++ b/pandas/tests/indexing/test_multiindex.py
@@ -158,6 +158,11 @@ class TestMultiIndexBasic(tm.TestCase):
         result = x.loc[[1, 3]]
         tm.assert_series_equal(result, expected)
 
+        # GH15424
+        y1 = Series([1, 3], index=[1, 2])
+        result = x.loc[y1]
+        tm.assert_series_equal(result, expected)
+
         empty = Series(data=[], dtype=np.float64)
         expected = Series([], index=MultiIndex(
             levels=index.levels, labels=[[], []], dtype=np.float64))


### PR DESCRIPTION
 - [x] closes #15424
 - [x] closes #15434
 - [x] tests added / passed
 - [x] passes ``git diff upstream/master | flake8 --diff``
 - [x] whatsnew entry

This also fixes indexing with a ``DataFrame``, which was actually not mentioned in #15424 (but it's a twoliner)