### PR TITLE
BUG: GH15429 transform result of timedelta from datetime

### DIFF
--- a/doc/source/whatsnew/v0.20.0.txt
+++ b/doc/source/whatsnew/v0.20.0.txt
@@ -626,6 +626,7 @@ Bug Fixes
 
 
 - Bug in ``.read_csv()`` with ``parse_dates`` when multiline headers are specified (:issue:`15376`)
+- Bug in ``groupby.transform()`` that would coerce the resultant dtypes back to the original (:issue:`10972`)
 
 
 - Bug in ``DataFrame.boxplot`` where ``fontsize`` was not applied to the tick labels on both axes (:issue:`15108`)

--- a/pandas/core/groupby.py
+++ b/pandas/core/groupby.py
@@ -31,7 +31,7 @@ from pandas.types.common import (is_numeric_dtype,
                                  _ensure_object,
                                  _ensure_categorical,
                                  _ensure_float)
-from pandas.types.cast import _possibly_downcast_to_dtype
+from pandas.types.cast import _possibly_downcast_to_dtype, _find_common_type
 from pandas.types.missing import isnull, notnull, _maybe_fill
 
 from pandas.core.common import (_values_from_object, AbstractMethodError,
@@ -2906,8 +2906,15 @@ class SeriesGroupBy(GroupBy):
                 common_type = np.common_type(np.array(res), result)
                 if common_type != result.dtype:
                     result = result.astype(common_type)
-            except:
-                pass
+            except Exception as exc:
+                # date math can cause type of result to change
+                if i == 0 and (is_datetime64_dtype(result.dtype) or
+                               is_timedelta64_dtype(result.dtype)):
+                    try:
+                        dtype = res.dtype
+                    except Exception as exc:
+                        dtype = type(res)
+                    result = np.empty_like(result, dtype)
 
             indexer = self._get_index(name)
             result[indexer] = res

--- a/pandas/core/groupby.py
+++ b/pandas/core/groupby.py
@@ -31,7 +31,7 @@ from pandas.types.common import (is_numeric_dtype,
                                  _ensure_object,
                                  _ensure_categorical,
                                  _ensure_float)
-from pandas.types.cast import _possibly_downcast_to_dtype, _find_common_type
+from pandas.types.cast import _possibly_downcast_to_dtype
 from pandas.types.missing import isnull, notnull, _maybe_fill
 
 from pandas.core.common import (_values_from_object, AbstractMethodError,

--- a/pandas/tests/groupby/test_filters.py
+++ b/pandas/tests/groupby/test_filters.py
@@ -216,6 +216,7 @@ class TestGroupByFilter(tm.TestCase):
         grouper = s.apply(lambda x: np.round(x, -1))
         grouped = s.groupby(grouper)
         f = lambda x: x.mean() > 10
+
         old_way = s[grouped.transform(f).astype('bool')]
         new_way = grouped.filter(f)
         assert_series_equal(new_way.sort_values(), old_way.sort_values())


### PR DESCRIPTION
The transform() operation needs to return a like-indexed. To facilitate this, transform starts with a copy of the original series. Then, after the computation for each group, sets the appropriate elements of the copied series equal to the result. At that point is does a type comparison, and discovers that the timedelta is not cast-able to a datetime.

 - [x] closes #10972
 - [x] tests added / passed
 - [x] passes ``git diff upstream/master | flake8 --diff``
 - [x] whatsnew entry
