### PR TITLE
BUG: GH15426 timezone lost in groupby-agg with cython functions

### DIFF
--- a/doc/source/whatsnew/v0.20.0.txt
+++ b/doc/source/whatsnew/v0.20.0.txt
@@ -622,6 +622,7 @@ Bug Fixes
 
 - Bug in ``DataFrame.to_stata()`` and ``StataWriter`` which produces incorrectly formatted files to be produced for some locales (:issue:`13856`)
 - Bug in ``pd.concat()`` in which concatting with an empty dataframe with ``join='inner'`` was being improperly handled (:issue:`15328`)
+- Bug in ``groupby.agg()`` incorrectly localizing timezone on ``datetime`` (:issue:`15426`, :issue:`10668`)
 
 
 

--- a/pandas/tests/types/test_cast.py
+++ b/pandas/tests/types/test_cast.py
@@ -8,7 +8,7 @@ These test the private routines in types/cast.py
 from datetime import datetime
 import numpy as np
 
-from pandas import Timedelta, Timestamp
+from pandas import Timedelta, Timestamp, DatetimeIndex
 from pandas.types.cast import (_possibly_downcast_to_dtype,
                                _possibly_convert_objects,
                                _infer_dtype_from_scalar,
@@ -70,6 +70,13 @@ class TestPossiblyDowncast(tm.TestCase):
         exp = np.array([1, 2, np.timedelta64('NaT')], dtype='timedelta64[ns]')
         res = _possibly_downcast_to_dtype(arr, 'timedelta64[ns]')
         tm.assert_numpy_array_equal(res, exp)
+
+    def test_datetime_downcast(self):
+        # GH 15426
+        ts = Timestamp("2016-01-01 12:00:00", tz='US/Pacific')
+        exp = DatetimeIndex([ts, ts])
+        res = _possibly_downcast_to_dtype(exp.asi8, exp.dtype)
+        tm.assert_index_equal(res, exp)
 
 
 class TestInferDtype(tm.TestCase):

--- a/pandas/types/cast.py
+++ b/pandas/types/cast.py
@@ -133,7 +133,8 @@ def _possibly_downcast_to_dtype(result, dtype):
                 if dtype.tz:
                     # convert to datetime and change timezone
                     from pandas import to_datetime
-                    result = to_datetime(result).tz_localize(dtype.tz)
+                    result = to_datetime(result).tz_localize('utc')
+                    result = result.tz_convert(dtype.tz)
 
     except:
         pass


### PR DESCRIPTION
 - [x] closes #15426
 - [x] tests added / passed
 - [x] passes ``git diff upstream/master | flake8 --diff``
 - [x] whatsnew entry
