### PR TITLE
BUG: pd.cut with bins=1 and input all 0s

### DIFF
--- a/doc/source/whatsnew/v0.20.0.txt
+++ b/doc/source/whatsnew/v0.20.0.txt
@@ -677,6 +677,7 @@ Bug Fixes
 
 
 
+
 - Bug in the display of ``.info()`` where a qualifier (+) would always be displayed with a ``MultiIndex`` that contains only non-strings (:issue:`15245`)
 
 - Bug in ``.asfreq()``, where frequency was not set for empty ``Series` (:issue:`14320`)

--- a/doc/source/whatsnew/v0.20.0.txt
+++ b/doc/source/whatsnew/v0.20.0.txt
@@ -670,7 +670,7 @@ Bug Fixes
 - Bug in ``DataFrame.loc`` with indexing a ``MultiIndex`` with a ``Series`` indexer (:issue:`14730`, :issue:`15424`)
 - Bug in ``DataFrame.loc`` with indexing a ``MultiIndex`` with a numpy array (:issue:`15434`)
 - Bug in ``Rolling.quantile`` function that caused a segmentation fault when called with a quantile value outside of the range [0, 1] (:issue:`15463`)
-
+- Bug in ``pd.cut()`` single bin on all 0s array raises ``ValueError`` (:issue:`15428`)
 
 - Bug in ``SparseSeries.reindex`` on single level with list of length 1 (:issue:`15447`)
 

--- a/doc/source/whatsnew/v0.20.0.txt
+++ b/doc/source/whatsnew/v0.20.0.txt
@@ -672,9 +672,7 @@ Bug Fixes
 - Bug in ``Rolling.quantile`` function that caused a segmentation fault when called with a quantile value outside of the range [0, 1] (:issue:`15463`)
 - Bug in ``pd.cut()`` single bin on all 0s array raises ``ValueError`` (:issue:`15428`)
 - Bug in ``pd.qcut()`` single quantile and array with identical values raises ``ValueError`` (:issue:`15431`)
-
 - Bug in ``SparseSeries.reindex`` on single level with list of length 1 (:issue:`15447`)
-
 
 
 

--- a/doc/source/whatsnew/v0.20.0.txt
+++ b/doc/source/whatsnew/v0.20.0.txt
@@ -671,6 +671,7 @@ Bug Fixes
 - Bug in ``DataFrame.loc`` with indexing a ``MultiIndex`` with a numpy array (:issue:`15434`)
 - Bug in ``Rolling.quantile`` function that caused a segmentation fault when called with a quantile value outside of the range [0, 1] (:issue:`15463`)
 - Bug in ``pd.cut()`` single bin on all 0s array raises ``ValueError`` (:issue:`15428`)
+- Bug in ``pd.qcut()`` single quantile and array with identical values raises ``ValueError`` (:issue:`15431`)
 
 - Bug in ``SparseSeries.reindex`` on single level with list of length 1 (:issue:`15447`)
 

--- a/pandas/tests/tools/test_tile.py
+++ b/pandas/tests/tools/test_tile.py
@@ -285,6 +285,36 @@ class TestCut(tm.TestCase):
         # invalid
         self.assertRaises(ValueError, qcut, values, 3, duplicates='foo')
 
+    def test_single_quantile(self):
+        # issue 15431
+        expected = Series([0, 0])
+
+        s = Series([9., 9.])
+        result = qcut(s, 1, labels=False)
+        tm.assert_series_equal(result, expected)
+
+        s = Series([-9., -9.])
+        result = qcut(s, 1, labels=False)
+        tm.assert_series_equal(result, expected)
+
+        s = Series([0., 0.])
+        result = qcut(s, 1, labels=False)
+        tm.assert_series_equal(result, expected)
+
+        expected = Series([0])
+
+        s = Series([9])
+        result = qcut(s, 1, labels=False)
+        tm.assert_series_equal(result, expected)
+
+        s = Series([-9])
+        result = qcut(s, 1, labels=False)
+        tm.assert_series_equal(result, expected)
+
+        s = Series([0])
+        result = qcut(s, 1, labels=False)
+        tm.assert_series_equal(result, expected)
+
     def test_single_bin(self):
         # issue 14652
         expected = Series([0, 0])
@@ -297,8 +327,26 @@ class TestCut(tm.TestCase):
         result = cut(s, 1, labels=False)
         tm.assert_series_equal(result, expected)
 
+        expected = Series([0])
+
+        s = Series([9])
+        result = cut(s, 1, labels=False)
+        tm.assert_series_equal(result, expected)
+
+        s = Series([-9])
+        result = cut(s, 1, labels=False)
+        tm.assert_series_equal(result, expected)
+
         # issue 15428
+        expected = Series([0, 0])
+
         s = Series([0., 0.])
+        result = cut(s, 1, labels=False)
+        tm.assert_series_equal(result, expected)
+
+        expected = Series([0])
+
+        s = Series([0])
         result = cut(s, 1, labels=False)
         tm.assert_series_equal(result, expected)
 

--- a/pandas/tests/tools/test_tile.py
+++ b/pandas/tests/tools/test_tile.py
@@ -3,7 +3,7 @@ import os
 import numpy as np
 from pandas.compat import zip
 
-from pandas import Series, Index
+from pandas import Series, Index, Categorical
 import pandas.util.testing as tm
 from pandas.util.testing import assertRaisesRegexp
 import pandas.core.common as com
@@ -239,7 +239,6 @@ class TestCut(tm.TestCase):
             self.assertTrue(ep <= sn)
 
     def test_cut_return_categorical(self):
-        from pandas import Categorical
         s = Series([0, 1, 2, 3, 4, 5, 6, 7, 8])
         res = cut(s, 3)
         exp = Series(Categorical.from_codes([0, 0, 0, 1, 1, 1, 2, 2, 2],
@@ -249,7 +248,6 @@ class TestCut(tm.TestCase):
         tm.assert_series_equal(res, exp)
 
     def test_qcut_return_categorical(self):
-        from pandas import Categorical
         s = Series([0, 1, 2, 3, 4, 5, 6, 7, 8])
         res = qcut(s, [0, 0.333, 0.666, 1])
         exp = Series(Categorical.from_codes([0, 0, 0, 1, 1, 1, 2, 2, 2],
@@ -292,28 +290,52 @@ class TestCut(tm.TestCase):
         s = Series([9., 9.])
         result = qcut(s, 1, labels=False)
         tm.assert_series_equal(result, expected)
+        result = qcut(s, 1)
+        exp_lab = Series(Categorical.from_codes([0, 0], ["[9, 9]"],
+                                                ordered=True))
+        tm.assert_series_equal(result, exp_lab)
 
         s = Series([-9., -9.])
         result = qcut(s, 1, labels=False)
         tm.assert_series_equal(result, expected)
+        result = qcut(s, 1)
+        exp_lab = Series(Categorical.from_codes([0, 0], ["[-9, -9]"],
+                                                ordered=True))
+        tm.assert_series_equal(result, exp_lab)
 
         s = Series([0., 0.])
         result = qcut(s, 1, labels=False)
         tm.assert_series_equal(result, expected)
+        result = qcut(s, 1)
+        exp_lab = Series(Categorical.from_codes([0, 0], ["[0, 0]"],
+                                                ordered=True))
+        tm.assert_series_equal(result, exp_lab)
 
         expected = Series([0])
 
         s = Series([9])
         result = qcut(s, 1, labels=False)
         tm.assert_series_equal(result, expected)
+        result = qcut(s, 1)
+        exp_lab = Series(Categorical.from_codes([0], ["[9, 9]"],
+                                                ordered=True))
+        tm.assert_series_equal(result, exp_lab)
 
         s = Series([-9])
         result = qcut(s, 1, labels=False)
         tm.assert_series_equal(result, expected)
+        result = qcut(s, 1)
+        exp_lab = Series(Categorical.from_codes([0], ["[-9, -9]"],
+                                                ordered=True))
+        tm.assert_series_equal(result, exp_lab)
 
         s = Series([0])
         result = qcut(s, 1, labels=False)
         tm.assert_series_equal(result, expected)
+        result = qcut(s, 1)
+        exp_lab = Series(Categorical.from_codes([0], ["[0, 0]"],
+                                                ordered=True))
+        tm.assert_series_equal(result, exp_lab)
 
     def test_single_bin(self):
         # issue 14652

--- a/pandas/tests/tools/test_tile.py
+++ b/pandas/tests/tools/test_tile.py
@@ -297,6 +297,11 @@ class TestCut(tm.TestCase):
         result = cut(s, 1, labels=False)
         tm.assert_series_equal(result, expected)
 
+        # issue 15428
+        s = Series([0., 0.])
+        result = cut(s, 1, labels=False)
+        tm.assert_series_equal(result, expected)
+
     def test_datetime_cut(self):
         # GH 14714
         # testing for time data to be present as series

--- a/pandas/tools/tile.py
+++ b/pandas/tools/tile.py
@@ -104,8 +104,8 @@ def cut(x, bins, right=True, labels=None, retbins=False, precision=3,
         mn, mx = [mi + 0.0 for mi in rng]
 
         if mn == mx:  # adjust end points before binning
-            mn -= .001 * abs(mn)
-            mx += .001 * abs(mx)
+            mn -= .001 * abs(mn) if mn != 0 else .001
+            mx += .001 * abs(mx) if mx != 0 else .001
             bins = np.linspace(mn, mx, bins + 1, endpoint=True)
         else:  # adjust end points after binning
             bins = np.linspace(mn, mx, bins + 1, endpoint=True)

--- a/pandas/tools/tile.py
+++ b/pandas/tools/tile.py
@@ -186,15 +186,12 @@ def qcut(x, q, labels=None, retbins=False, precision=3, duplicates='raise'):
 
     if is_integer(q):
         quantiles = np.linspace(0, 1, q + 1)
+
+        if q == 1:
+            duplicates = 'allow'
     else:
         quantiles = q
     bins = algos.quantile(x, quantiles)
-
-    # fix special case: q=1 and all identical values
-    if q == 1 and len(bins) == 2 and bins[0] == bins[1]:
-        bins = np.asarray(bins, np.float64)
-        bins[0] -= .001 * abs(bins[0]) if bins[0] != 0 else .001
-        bins[1] += .001 * abs(bins[1]) if bins[1] != 0 else .001
 
     fac, bins = _bins_to_cuts(x, bins, labels=labels,
                               precision=precision, include_lowest=True,
@@ -208,7 +205,7 @@ def _bins_to_cuts(x, bins, right=True, labels=None,
                   precision=3, include_lowest=False,
                   dtype=None, duplicates='raise'):
 
-    if duplicates not in ['raise', 'drop']:
+    if duplicates not in ['raise', 'drop', 'allow']:
         raise ValueError("invalid value for 'duplicates' parameter, "
                          "valid options are: raise, drop")
 
@@ -218,7 +215,7 @@ def _bins_to_cuts(x, bins, right=True, labels=None,
             raise ValueError("Bin edges must be unique: {}.\nYou "
                              "can drop duplicate edges by setting "
                              "the 'duplicates' kwarg".format(repr(bins)))
-        else:
+        elif duplicates == 'drop':
             bins = unique_bins
 
     side = 'left' if right else 'right'

--- a/pandas/tools/tile.py
+++ b/pandas/tools/tile.py
@@ -185,14 +185,17 @@ def qcut(x, q, labels=None, retbins=False, precision=3, duplicates='raise'):
     x, dtype = _coerce_to_type(x)
 
     if is_integer(q):
-        quantiles = np.linspace(0, 1, q + 1)
+        if x.size == 0:
+            raise ValueError('Cannot qcut empty array')
 
-        if q == 1:
+        rng = (nanops.nanmin(x), nanops.nanmax(x))
+        if rng[0] == rng[1] and q == 1:
             duplicates = 'allow'
+
+        quantiles = np.linspace(0, 1, q + 1)
     else:
         quantiles = q
     bins = algos.quantile(x, quantiles)
-
     fac, bins = _bins_to_cuts(x, bins, labels=labels,
                               precision=precision, include_lowest=True,
                               dtype=dtype, duplicates=duplicates)

--- a/pandas/tools/tile.py
+++ b/pandas/tools/tile.py
@@ -185,13 +185,6 @@ def qcut(x, q, labels=None, retbins=False, precision=3, duplicates='raise'):
     x, dtype = _coerce_to_type(x)
 
     if is_integer(q):
-        if x.size == 0:
-            raise ValueError('Cannot qcut empty array')
-
-        rng = (nanops.nanmin(x), nanops.nanmax(x))
-        if rng[0] == rng[1] and q == 1:
-            duplicates = 'allow'
-
         quantiles = np.linspace(0, 1, q + 1)
     else:
         quantiles = q
@@ -208,17 +201,17 @@ def _bins_to_cuts(x, bins, right=True, labels=None,
                   precision=3, include_lowest=False,
                   dtype=None, duplicates='raise'):
 
-    if duplicates not in ['raise', 'drop', 'allow']:
+    if duplicates not in ['raise', 'drop']:
         raise ValueError("invalid value for 'duplicates' parameter, "
                          "valid options are: raise, drop")
 
     unique_bins = algos.unique(bins)
-    if len(unique_bins) < len(bins):
+    if len(unique_bins) < len(bins) and len(bins) != 2:
         if duplicates == 'raise':
             raise ValueError("Bin edges must be unique: {}.\nYou "
                              "can drop duplicate edges by setting "
                              "the 'duplicates' kwarg".format(repr(bins)))
-        elif duplicates == 'drop':
+        else:
             bins = unique_bins
 
     side = 'left' if right else 'right'

--- a/pandas/tools/tile.py
+++ b/pandas/tools/tile.py
@@ -189,6 +189,13 @@ def qcut(x, q, labels=None, retbins=False, precision=3, duplicates='raise'):
     else:
         quantiles = q
     bins = algos.quantile(x, quantiles)
+
+    # fix special case: q=1 and all identical values
+    if q == 1 and len(bins) == 2 and bins[0] == bins[1]:
+        bins = np.asarray(bins, np.float64)
+        bins[0] -= .001 * abs(bins[0]) if bins[0] != 0 else .001
+        bins[1] += .001 * abs(bins[1]) if bins[1] != 0 else .001
+
     fac, bins = _bins_to_cuts(x, bins, labels=labels,
                               precision=precision, include_lowest=True,
                               dtype=dtype, duplicates=duplicates)


### PR DESCRIPTION
The special case of running pd.cut() qith bins=1 an input containing all
0s raises a ValueError

 - [x] closes #15428
closes #15431 
 - [X] tests added / passed
 - [X] passes ``git diff upstream/master | flake8 --diff``
 - [X] whatsnew entry
