### PR TITLE
BUG: rolling not accepting Timedelta-like window args (#15440)

### DIFF
--- a/doc/source/whatsnew/v0.20.0.txt
+++ b/doc/source/whatsnew/v0.20.0.txt
@@ -551,6 +551,7 @@ Bug Fixes
 - Bug in ``.to_json()`` causing single byte ascii characters to be expanded to four byte unicode (:issue:`15344`)
 - Bug in ``.read_json()`` for Python 2 where ``lines=True`` and contents contain non-ascii unicode characters (:issue:`15132`)
 - Bug in ``.rolling/expanding()`` functions where ``count()`` was not counting ``np.Inf``, nor handling ``object`` dtypes (:issue:`12541`)
+- Bug in ``.rolling()`` where ``pd.Timedelta`` or ``datetime.timedelta`` was not accepted as a ``window`` argument (:issue:`15440`)
 - Bug in ``DataFrame.resample().median()`` if duplicate column names are present (:issue:`14233`)
 
 - Bug in ``DataFrame.groupby().describe()`` when grouping on ``Index`` containing tuples (:issue:`14848`)

--- a/pandas/core/window.py
+++ b/pandas/core/window.py
@@ -10,6 +10,7 @@ from __future__ import division
 import warnings
 import numpy as np
 from collections import defaultdict
+from datetime import timedelta
 
 from pandas.types.generic import (ABCSeries,
                                   ABCDataFrame,
@@ -1014,7 +1015,8 @@ class Rolling(_Rolling_and_Expanding):
 
         # we allow rolling on a datetimelike index
         if (self.is_datetimelike and
-                isinstance(self.window, (compat.string_types, DateOffset))):
+                isinstance(self.window, (compat.string_types, DateOffset,
+                                         timedelta))):
 
             self._validate_monotonic()
             freq = self._validate_freq()


### PR DESCRIPTION
 - [x] closes #15440
 - [x] tests added / passed
 - [x] passes ``git diff upstream/master | flake8 --diff``
 - [x] whatsnew entry

Allow `rolling()` to accept `pd.Timedelta` or `datetime.timedelta` as a `window` argument.