### PR TITLE
ENH: str.replace accepts a compiled expression

### DIFF
--- a/doc/source/text.rst
+++ b/doc/source/text.rst
@@ -184,7 +184,7 @@ regular expression object will raise a ``ValueError``.
     @verbatim
     In [1]: s3.str.replace(regex_pat, 'XX-XX ', flags=re.IGNORECASE)
     ---------------------------------------------------------------------------
-    ValueError: case and flags must be default values when pat is a compiled regex
+    ValueError: case and flags cannot be set when pat is a compiled regex
 
 Indexing with ``.str``
 ----------------------

--- a/doc/source/text.rst
+++ b/doc/source/text.rst
@@ -164,6 +164,27 @@ positional argument (a regex object) and return a string.
    repl = lambda m: m.group('two').swapcase()
    pd.Series(['Foo Bar Baz', np.nan]).str.replace(pat, repl)
 
+The ``replace`` method also accepts a compiled regular expression object
+from :func:`re.compile` as a pattern. All flags should be included in the
+compiled regular expression object.
+
+.. versionadded:: 0.20.0
+
+.. ipython:: python
+
+   import re
+   regex_pat = re.compile(r'^.a|dog', flags=re.IGNORECASE)
+   s3.str.replace(regex_pat, 'XX-XX ')
+
+Including a ``flags`` argument when calling ``replace`` with a compiled
+regular expression object will raise a ``ValueError``.
+
+.. ipython::
+
+    @verbatim
+    In [1]: s3.str.replace(regex_pat, 'XX-XX ', flags=re.IGNORECASE)
+    ---------------------------------------------------------------------------
+    ValueError: case and flags must be default values when pat is a compiled regex
 
 Indexing with ``.str``
 ----------------------

--- a/doc/source/whatsnew/v0.20.0.txt
+++ b/doc/source/whatsnew/v0.20.0.txt
@@ -28,7 +28,8 @@ New features
 ~~~~~~~~~~~~
 
 - Integration with the ``feather-format``, including a new top-level ``pd.read_feather()`` and ``DataFrame.to_feather()`` method, see :ref:`here <io.feather>`.
-- ``.str.replace`` now accepts a callable, as replacement, which is passed to ``re.sub`` (:issue:`15055`)
+- ``Series.str.replace()`` now accepts a callable, as replacement, which is passed to ``re.sub`` (:issue:`15055`)
+- ``Series.str.replace()`` now accepts a compiled regular expression as a pattern (:issue:`15446`)
 
 
 

--- a/pandas/core/strings.py
+++ b/pandas/core/strings.py
@@ -329,8 +329,8 @@ def str_replace(arr, pat, repl, n=-1, case=None, flags=0):
     n : int, default -1 (all)
         Number of replacements to make from start
     case : boolean, default None
-        - If True, case sensitive
-        - Defaults to True if `pat` is a string
+        - If True, case sensitive (the default if `pat` is a string)
+        - Set to False for case insensitive
         - Cannot be set if `pat` is a compiled regex
     flags : int, default 0 (no flags)
         - re module flags, e.g. re.IGNORECASE
@@ -404,7 +404,7 @@ def str_replace(arr, pat, repl, n=-1, case=None, flags=0):
     is_compiled_re = is_re(pat)
     if is_compiled_re:
         if (case is not None) or (flags != 0):
-            raise ValueError("case and flags must be default values"
+            raise ValueError("case and flags cannot be set"
                              " when pat is a compiled regex")
     else:
         # not a compiled regex


### PR DESCRIPTION
.str.replace now accepts a compiled regular expression.

See #15446

 - [x] closes #15446
 - [x] tests added / passed
 - [x] passes ``git diff upstream/master | flake8 --diff``
 - [x] whatsnew entry
