### PR TITLE
BUG: fix SparseSeries reindex by using Series implementation

### DIFF
--- a/doc/source/whatsnew/v0.20.0.txt
+++ b/doc/source/whatsnew/v0.20.0.txt
@@ -542,6 +542,10 @@ Bug Fixes
 - Bug in ``Rolling.quantile`` function that caused a segmentation fault when called with a quantile value outside of the range [0, 1] (:issue:`15463`)
 
 
+- Bug in ``SparseSeries.reindex`` on single level with list of length 1 (:issue:`15447`)
+
+
+
 - Bug in the display of ``.info()`` where a qualifier (+) would always be displayed with a ``MultiIndex`` that contains only non-strings (:issue:`15245`)
 - Bug in ``pd.read_msgpack()`` in which ``Series`` categoricals were being improperly processed (:issue:`14901`)
 - Bug in ``Series.ffill()`` with mixed dtypes containing tz-aware datetimes. (:issue:`14956`)

--- a/pandas/sparse/series.py
+++ b/pandas/sparse/series.py
@@ -570,8 +570,7 @@ class SparseSeries(Series):
         return self._constructor(new_data, sparse_index=self.sp_index,
                                  fill_value=self.fill_value).__finalize__(self)
 
-    def reindex(self, index=None, method=None, copy=True, limit=None,
-                **kwargs):
+    def reindex(self, index=None, **kwargs):
         """
         Conform SparseSeries to new Index
 
@@ -581,16 +580,7 @@ class SparseSeries(Series):
         -------
         reindexed : SparseSeries
         """
-        new_index = _ensure_index(index)
-
-        if self.index.equals(new_index):
-            if copy:
-                return self.copy()
-            else:
-                return self
-        return self._constructor(self._data.reindex(new_index, method=method,
-                                                    limit=limit, copy=copy),
-                                 index=new_index).__finalize__(self)
+        return super(SparseSeries, self).reindex(index, **kwargs)
 
     def sparse_reindex(self, new_index):
         """

--- a/pandas/sparse/series.py
+++ b/pandas/sparse/series.py
@@ -32,7 +32,7 @@ from pandas.sparse.scipy_sparse import (_sparse_series_to_coo,
                                         _coo_to_sparse_series)
 
 
-_shared_doc_kwargs = dict(klass='SparseSeries',
+_shared_doc_kwargs = dict(axes='index', klass='SparseSeries',
                           axes_single_arg="{0, 'index'}")
 
 # -----------------------------------------------------------------------------
@@ -570,17 +570,13 @@ class SparseSeries(Series):
         return self._constructor(new_data, sparse_index=self.sp_index,
                                  fill_value=self.fill_value).__finalize__(self)
 
-    def reindex(self, index=None, **kwargs):
-        """
-        Conform SparseSeries to new Index
+    @Appender(generic._shared_docs['reindex'] % _shared_doc_kwargs)
+    def reindex(self, index=None, method=None, copy=True, limit=None,
+                **kwargs):
 
-        See Series.reindex docstring for general behavior
-
-        Returns
-        -------
-        reindexed : SparseSeries
-        """
-        return super(SparseSeries, self).reindex(index, **kwargs)
+        return super(SparseSeries, self).reindex(index=index, method=method,
+                                                 copy=copy, limit=limit,
+                                                 **kwargs)
 
     def sparse_reindex(self, new_index):
         """

--- a/pandas/tests/sparse/test_indexing.py
+++ b/pandas/tests/sparse/test_indexing.py
@@ -543,6 +543,7 @@ class TestSparseSeriesMultiIndexing(TestSparseSeriesIndexing):
         tm.assert_sp_series_equal(sparse.loc[:'B'], orig.loc[:'B'].to_sparse())
 
     def test_reindex(self):
+        # GH 15447
         orig = self.orig
         sparse = self.sparse
 
@@ -563,6 +564,12 @@ class TestSparseSeriesMultiIndexing(TestSparseSeriesIndexing):
         with tm.assertRaises(TypeError):
             # Incomplete keys are not accepted for reindexing:
             sparse.reindex(['A', 'C'])
+
+        # "copy" argument:
+        res = sparse.reindex(sparse.index, copy=True)
+        exp = orig.reindex(orig.index, copy=True).to_sparse()
+        tm.assert_sp_series_equal(res, exp)
+        self.assertIsNot(sparse, res)
 
 
 class TestSparseDataFrameIndexing(tm.TestCase):

--- a/pandas/tests/sparse/test_indexing.py
+++ b/pandas/tests/sparse/test_indexing.py
@@ -366,7 +366,7 @@ class TestSparseSeriesIndexing(tm.TestCase):
         exp = orig.reindex(['A', 'E', 'C', 'D']).to_sparse()
         tm.assert_sp_series_equal(res, exp)
 
-    def test_reindex_fill_value(self):
+    def test_fill_value_reindex(self):
         orig = pd.Series([1, np.nan, 0, 3, 0], index=list('ABCDE'))
         sparse = orig.to_sparse(fill_value=0)
 
@@ -396,6 +396,23 @@ class TestSparseSeriesIndexing(tm.TestCase):
         res = sparse.reindex(['A', 'E', 'C', 'D'])
         exp = orig.reindex(['A', 'E', 'C', 'D']).to_sparse(fill_value=0)
         tm.assert_sp_series_equal(res, exp)
+
+    def test_reindex_fill_value(self):
+        floats = pd.Series([1., 2., 3.]).to_sparse()
+        result = floats.reindex([1, 2, 3], fill_value=0)
+        expected = pd.Series([2., 3., 0], index=[1, 2, 3]).to_sparse()
+        tm.assert_sp_series_equal(result, expected)
+
+    def test_reindex_nearest(self):
+        s = pd.Series(np.arange(10, dtype='float64')).to_sparse()
+        target = [0.1, 0.9, 1.5, 2.0]
+        actual = s.reindex(target, method='nearest')
+        expected = pd.Series(np.around(target), target).to_sparse()
+        tm.assert_sp_series_equal(expected, actual)
+
+        actual = s.reindex(target, method='nearest', tolerance=0.2)
+        expected = pd.Series([0, 1, np.nan, 2], target).to_sparse()
+        tm.assert_sp_series_equal(expected, actual)
 
     def tests_indexing_with_sparse(self):
         # GH 13985

--- a/pandas/tests/sparse/test_indexing.py
+++ b/pandas/tests/sparse/test_indexing.py
@@ -504,6 +504,11 @@ class TestSparseSeriesMultiIndexing(TestSparseSeriesIndexing):
         exp = orig.loc[[1, 3, 4, 5]].to_sparse()
         tm.assert_sp_series_equal(result, exp)
 
+        # single element list (GH 15447)
+        result = sparse.loc[['A']]
+        exp = orig.loc[['A']].to_sparse()
+        tm.assert_sp_series_equal(result, exp)
+
         # dense array
         result = sparse.loc[orig % 2 == 1]
         exp = orig.loc[orig % 2 == 1].to_sparse()
@@ -536,6 +541,28 @@ class TestSparseSeriesMultiIndexing(TestSparseSeriesIndexing):
         tm.assert_sp_series_equal(sparse.loc['A':'B'],
                                   orig.loc['A':'B'].to_sparse())
         tm.assert_sp_series_equal(sparse.loc[:'B'], orig.loc[:'B'].to_sparse())
+
+    def test_reindex(self):
+        orig = self.orig
+        sparse = self.sparse
+
+        res = sparse.reindex([('A', 0), ('C', 1)])
+        exp = orig.reindex([('A', 0), ('C', 1)]).to_sparse()
+        tm.assert_sp_series_equal(res, exp)
+
+        # On specific level:
+        res = sparse.reindex(['A', 'C', 'B'], level=0)
+        exp = orig.reindex(['A', 'C', 'B'], level=0).to_sparse()
+        tm.assert_sp_series_equal(res, exp)
+
+        # single element list (GH 15447)
+        res = sparse.reindex(['A'], level=0)
+        exp = orig.reindex(['A'], level=0).to_sparse()
+        tm.assert_sp_series_equal(res, exp)
+
+        with tm.assertRaises(TypeError):
+            # Incomplete keys are not accepted for reindexing:
+            sparse.reindex(['A', 'C'])
 
 
 class TestSparseDataFrameIndexing(tm.TestCase):


### PR DESCRIPTION
 - [x] closes #15447
 - [x] tests added / passed
 - [x] passes ``git diff master | flake8 --diff``
 - [x] whatsnew entry

I abunded a bit with the tests for ``.reindex()`` (for ``.loc`` there were already quite a bit).

This is completely independent from the approach in #15448 , which also made sense but on which I will come back in a different PR. In the current PR, I'm just exploiting the fact that sparse ``SparseBlock``s "know what to do", and the ``SparseSeries`` itself has nothing particular to do for reindexing.