### PR TITLE
The roll_quantile function now throws an exception instead of causing a segfault

### DIFF
--- a/doc/source/whatsnew/v0.20.0.txt
+++ b/doc/source/whatsnew/v0.20.0.txt
@@ -504,7 +504,7 @@ Bug Fixes
 - Bug in using ``__deepcopy__`` on empty NDFrame objects (:issue:`15370`)
 - Bug in ``DataFrame.loc`` with indexing a ``MultiIndex`` with a ``Series`` indexer (:issue:`14730`, :issue:`15424`)
 - Bug in ``DataFrame.loc`` with indexing a ``MultiIndex`` with a numpy array (:issue:`15434`)
-
+- Bug in ``Rolling.quantile`` function that caused a segmentation fault when called with a quantile value outside of the range [0, 1] (:issue:`15463`)
 
 
 - Bug in the display of ``.info()`` where a qualifier (+) would always be displayed with a ``MultiIndex`` that contains only non-strings (:issue:`15245`)

--- a/pandas/tests/test_window.py
+++ b/pandas/tests/test_window.py
@@ -1063,7 +1063,7 @@ class TestMoments(Base):
                               window=3, min_periods=5)
 
     def test_rolling_quantile(self):
-        qs = [.1, .5, .9]
+        qs = [0.0, .1, .5, .9, 1.0]
 
         def scoreatpercentile(a, per):
             values = np.sort(a, axis=0)
@@ -1083,6 +1083,12 @@ class TestMoments(Base):
                 return scoreatpercentile(x, q)
 
             self._check_moment_func(f, alt, name='quantile', quantile=q)
+
+            self.assertRaises(ValueError, mom.rolling_quantile,
+                              np.array([1, 2, 3]), window=3, quantile=-0.1)
+
+            self.assertRaises(ValueError, mom.rolling_quantile,
+                              np.array([1, 2, 3]), window=3, quantile=10)
 
     def test_rolling_apply(self):
         # suppress warnings about empty slices, as we are deliberately testing

--- a/pandas/tests/test_window.py
+++ b/pandas/tests/test_window.py
@@ -1084,14 +1084,15 @@ class TestMoments(Base):
 
             self._check_moment_func(f, alt, name='quantile', quantile=q)
 
-            self.assertRaises(ValueError, mom.rolling_quantile,
-                              np.array([1, 2, 3]), window=3, quantile=-0.1)
+    def test_rolling_quantile_param(self):
+        ser = Series([0.0, .1, .5, .9, 1.0])
 
-            self.assertRaises(ValueError, mom.rolling_quantile,
-                              np.array([1, 2, 3]), window=3, quantile=10)
+        with self.assertRaises(ValueError):
+            ser.rolling(3).quantile(-0.1)
+            ser.rolling(3).quantile(10.0)
 
-            self.assertRaises(TypeError, mom.rolling_quantile,
-                              np.array([1, 2, 3]), window=3, quantile='foo')
+        with self.assertRaises(TypeError):
+            ser.rolling(3).quantile('foo')
 
     def test_rolling_apply(self):
         # suppress warnings about empty slices, as we are deliberately testing

--- a/pandas/tests/test_window.py
+++ b/pandas/tests/test_window.py
@@ -1090,6 +1090,9 @@ class TestMoments(Base):
             self.assertRaises(ValueError, mom.rolling_quantile,
                               np.array([1, 2, 3]), window=3, quantile=10)
 
+            self.assertRaises(TypeError, mom.rolling_quantile,
+                              np.array([1, 2, 3]), window=3, quantile='foo')
+
     def test_rolling_apply(self):
         # suppress warnings about empty slices, as we are deliberately testing
         # with a 0-length Series

--- a/pandas/tests/test_window.py
+++ b/pandas/tests/test_window.py
@@ -1089,6 +1089,8 @@ class TestMoments(Base):
 
         with self.assertRaises(ValueError):
             ser.rolling(3).quantile(-0.1)
+
+        with self.assertRaises(ValueError):
             ser.rolling(3).quantile(10.0)
 
         with self.assertRaises(TypeError):

--- a/pandas/window.pyx
+++ b/pandas/window.pyx
@@ -134,8 +134,8 @@ cdef class WindowIndexer:
         bint is_variable
 
     def get_data(self):
-        return (self.start, self.end, <int64_t>self.N, 
-                <int64_t>self.win, <int64_t>self.minp, 
+        return (self.start, self.end, <int64_t>self.N,
+                <int64_t>self.win, <int64_t>self.minp,
                 self.is_variable)
 
 
@@ -1284,6 +1284,9 @@ def roll_quantile(ndarray[float64_t, cast=True] input, int64_t win,
         bint is_variable
         ndarray[int64_t] start, end
         ndarray[double_t] output
+
+    if quantile < 0.0 or quantile > 1.0:
+        raise ValueError("quantile value {0} not in [0, 1]".format(quantile))
 
     # we use the Fixed/Variable Indexer here as the
     # actual skiplist ops outweigh any window computation costs


### PR DESCRIPTION
The roll_quantile function in window.pyx now raises a ValueError when the quantile value is not in [0.0, 1.0]. Also added tests for the new exception and extended test cases for the roll_quantile function.

 - [x] closes #15463
 - [x] tests added / passed
 - [ ] does not pass ``git diff upstream/master | flake8 --diff`` because of some cdef code blocks in the file but my code does not generate any errors
 - [x] two EOL spaces removed by my editor
