### PR TITLE
BUG: repr SparseDataFrame after setting a value

### DIFF
--- a/doc/source/whatsnew/v0.20.0.txt
+++ b/doc/source/whatsnew/v0.20.0.txt
@@ -564,7 +564,7 @@ Bug Fixes
 
 - Bug in ``to_sql`` when writing a DataFrame with numeric index names (:issue:`15404`).
 - Bug in ``Series.iloc`` where a ``Categorical`` object for list-like indexes input was returned, where a ``Series`` was expected. (:issue:`14580`)
-
+- Bug in repr-formatting a ``SparseDataFrame`` after a value was set on (a copy of) one of its series (:issue:`15488`)
 
 
 - Bug in  groupby operations with timedelta64 when passing ``numeric_only=False`` (:issue:`5724`)

--- a/pandas/formats/format.py
+++ b/pandas/formats/format.py
@@ -712,9 +712,6 @@ class DataFrameFormatter(TableFormatter):
     def _get_formatted_column_labels(self, frame):
         from pandas.core.index import _sparsify
 
-        def is_numeric_dtype(dtype):
-            return issubclass(dtype.type, np.number)
-
         columns = frame.columns
 
         if isinstance(columns, MultiIndex):

--- a/pandas/tests/sparse/test_format.py
+++ b/pandas/tests/sparse/test_format.py
@@ -116,3 +116,15 @@ class TestSparseDataFrameFormatting(tm.TestCase):
 
         with option_context("display.max_rows", 3):
             self.assertEqual(repr(sparse), repr(df))
+
+    def test_sparse_repr_after_set(self):
+        # GH 15488
+        sdf = pd.SparseDataFrame([[np.nan, 1], [2, np.nan]])
+        res = sdf.copy()
+
+        # Ignore the warning
+        with pd.option_context('mode.chained_assignment', None):
+            sdf[0][1] = 2  # This line triggers the bug
+
+        repr(sdf)
+        tm.assert_sp_frame_equal(sdf, res)


### PR DESCRIPTION
 - [x] closes #15488
 - [x] tests added / passed
 - [X] passes ``git diff upstream/master | flake8 --diff``
 - [x] whatsnew entry
