### PR TITLE
msgpack supports CategoricalIndex 

### DIFF
--- a/doc/source/whatsnew/v0.20.0.txt
+++ b/doc/source/whatsnew/v0.20.0.txt
@@ -627,4 +627,4 @@ Bug Fixes
 - Bug in ``Series.replace`` and ``DataFrame.replace`` which failed on empty replacement dicts (:issue:`15289`)
 - Bug in ``pd.melt()`` where passing a tuple value for ``value_vars`` caused a ``TypeError`` (:issue:`15348`)
 - Bug in ``.eval()`` which caused multiline evals to fail with local variables not on the first line (:issue:`15342`)
-- Bug in ``DataFrame.read_msgpack`` which did not allow to load DataFrames with a CategoricalIndex (:issue:`15487`)
+- Bug in ``pd.read_msgpack`` which did not allow to load dataframe with an index of type ``CategoricalIndex`` (:issue:`15487`)

--- a/doc/source/whatsnew/v0.20.0.txt
+++ b/doc/source/whatsnew/v0.20.0.txt
@@ -627,3 +627,4 @@ Bug Fixes
 - Bug in ``Series.replace`` and ``DataFrame.replace`` which failed on empty replacement dicts (:issue:`15289`)
 - Bug in ``pd.melt()`` where passing a tuple value for ``value_vars`` caused a ``TypeError`` (:issue:`15348`)
 - Bug in ``.eval()`` which caused multiline evals to fail with local variables not on the first line (:issue:`15342`)
+- Bug in ``DataFrame.read_msgpack`` which did not allow to load DataFrames with a CategoricalIndex (:issue:`15487`)

--- a/pandas/io/packers.py
+++ b/pandas/io/packers.py
@@ -54,7 +54,7 @@ from pandas.types.common import (is_categorical_dtype, is_object_dtype,
 from pandas import (Timestamp, Period, Series, DataFrame,  # noqa
                     Index, MultiIndex, Float64Index, Int64Index,
                     Panel, RangeIndex, PeriodIndex, DatetimeIndex, NaT,
-                    Categorical)
+                    Categorical, CategoricalIndex)
 from pandas.tslib import NaTType
 from pandas.sparse.api import SparseSeries, SparseDataFrame
 from pandas.sparse.array import BlockIndex, IntIndex

--- a/pandas/tests/io/test_packers.py
+++ b/pandas/tests/io/test_packers.py
@@ -123,10 +123,10 @@ class TestAPI(TestPackers):
         result = read_msgpack(s)
         tm.assert_frame_equal(result, df)
 
-        df2 = df.astype({0:'category'}).set_index(0)
-        s = to_msgpack(None, df)
+        df2 = df.astype({0: 'category'}).set_index(0)
+        s = to_msgpack(None, df2)
         result = read_msgpack(s)
-        tm.assert_frame_equal(result, df)
+        tm.assert_frame_equal(result, df2)
 
         with ensure_clean(self.path) as p:
 

--- a/pandas/tests/io/test_packers.py
+++ b/pandas/tests/io/test_packers.py
@@ -123,11 +123,6 @@ class TestAPI(TestPackers):
         result = read_msgpack(s)
         tm.assert_frame_equal(result, df)
 
-        df2 = df.astype({0: 'category'}).set_index(0)
-        s = to_msgpack(None, df2)
-        result = read_msgpack(s)
-        tm.assert_frame_equal(result, df2)
-
         with ensure_clean(self.path) as p:
 
             s = df.to_msgpack()
@@ -154,6 +149,14 @@ class TestAPI(TestPackers):
         tm.assertRaises(ValueError, read_msgpack, path_or_buf=None)
         tm.assertRaises(ValueError, read_msgpack, path_or_buf={})
         tm.assertRaises(ValueError, read_msgpack, path_or_buf=A())
+
+    def test_msgpack_categorical_index(self):
+        # GH15487        
+        df = DataFrame(np.random.randn(10, 2))
+        df = df.astype({0: 'category'}).set_index(0)
+        s = to_msgpack(None, df)
+        result = read_msgpack(s)
+        tm.assert_frame_equal(result, df)
 
 
 class TestNumpy(TestPackers):

--- a/pandas/tests/io/test_packers.py
+++ b/pandas/tests/io/test_packers.py
@@ -123,6 +123,11 @@ class TestAPI(TestPackers):
         result = read_msgpack(s)
         tm.assert_frame_equal(result, df)
 
+        df2 = df.astype({0:'category'}).set_index(0)
+        s = to_msgpack(None, df)
+        result = read_msgpack(s)
+        tm.assert_frame_equal(result, df)
+
         with ensure_clean(self.path) as p:
 
             s = df.to_msgpack()

--- a/pandas/tests/msgpack/test_unpack.py
+++ b/pandas/tests/msgpack/test_unpack.py
@@ -3,7 +3,6 @@ import sys
 from pandas.msgpack import Unpacker, packb, OutOfData, ExtType
 import pandas.util.testing as tm
 import pytest
-from pandas import DataFrame, read_msgpack
 
 
 class TestUnpack(tm.TestCase):
@@ -63,14 +62,3 @@ class TestUnpack(tm.TestCase):
         assert unpacker.unpack() == {'a': 123}
         unpacker.feed(packb({'a': ExtType(2, b'321')}, encoding='utf-8'))
         assert unpacker.unpack() == {'a': ExtType(2, b'321')}
-
-    def test_unpack_categorical_index(self):
-        '''dataframe with CategoricalIndex can be read and written'''
-        pdf = DataFrame(dict(A=[1, 1, 1, 2, 2, 2], B=[1, 2, 3, 4, 5, 6]))
-        pdf['A'] = pdf['A'].astype('category')
-        pdf.set_index('A', inplace=True)
-        f = BytesIO()
-        pdf.to_msgpack(f)
-        f.seek(0)
-        pdf2 = read_msgpack(f)
-        tm.assert_frame_equal(pdf, pdf2)

--- a/pandas/tests/msgpack/test_unpack.py
+++ b/pandas/tests/msgpack/test_unpack.py
@@ -3,7 +3,7 @@ import sys
 from pandas.msgpack import Unpacker, packb, OutOfData, ExtType
 import pandas.util.testing as tm
 import pytest
-
+from pandas import DataFrame
 
 class TestUnpack(tm.TestCase):
 
@@ -62,3 +62,14 @@ class TestUnpack(tm.TestCase):
         assert unpacker.unpack() == {'a': 123}
         unpacker.feed(packb({'a': ExtType(2, b'321')}, encoding='utf-8'))
         assert unpacker.unpack() == {'a': ExtType(2, b'321')}
+        
+    def test_unpack_categorical_index(self):
+        '''dataframe with CategoricalIndex can be read and written'''
+        pdf = pd.DataFrame(dict(A=[1,1,1,2,2,2], B = [1,2,3,4,5,6]))
+        pdf['A'] = pdf['A'].astype('category')
+        pdf.set_index('A', inplace = True)
+        f = BytesIO()
+        pdf.to_msgpack(f)
+        f.seek(0)
+        pdf2 = pd.read_msgpack(f)
+        tm.assert_frame_equal(pdf, pdf2)

--- a/pandas/tests/msgpack/test_unpack.py
+++ b/pandas/tests/msgpack/test_unpack.py
@@ -3,7 +3,7 @@ import sys
 from pandas.msgpack import Unpacker, packb, OutOfData, ExtType
 import pandas.util.testing as tm
 import pytest
-from pandas import DataFrame
+from pandas import DataFrame, read_msgpack
 
 class TestUnpack(tm.TestCase):
 
@@ -65,11 +65,11 @@ class TestUnpack(tm.TestCase):
         
     def test_unpack_categorical_index(self):
         '''dataframe with CategoricalIndex can be read and written'''
-        pdf = pd.DataFrame(dict(A=[1,1,1,2,2,2], B = [1,2,3,4,5,6]))
+        pdf = DataFrame(dict(A=[1,1,1,2,2,2], B = [1,2,3,4,5,6]))
         pdf['A'] = pdf['A'].astype('category')
         pdf.set_index('A', inplace = True)
         f = BytesIO()
         pdf.to_msgpack(f)
         f.seek(0)
-        pdf2 = pd.read_msgpack(f)
+        pdf2 = read_msgpack(f)
         tm.assert_frame_equal(pdf, pdf2)

--- a/pandas/tests/msgpack/test_unpack.py
+++ b/pandas/tests/msgpack/test_unpack.py
@@ -5,6 +5,7 @@ import pandas.util.testing as tm
 import pytest
 from pandas import DataFrame, read_msgpack
 
+
 class TestUnpack(tm.TestCase):
 
     def test_unpack_array_header_from_file(self):
@@ -62,12 +63,12 @@ class TestUnpack(tm.TestCase):
         assert unpacker.unpack() == {'a': 123}
         unpacker.feed(packb({'a': ExtType(2, b'321')}, encoding='utf-8'))
         assert unpacker.unpack() == {'a': ExtType(2, b'321')}
-        
+
     def test_unpack_categorical_index(self):
         '''dataframe with CategoricalIndex can be read and written'''
-        pdf = DataFrame(dict(A=[1,1,1,2,2,2], B = [1,2,3,4,5,6]))
+        pdf = DataFrame(dict(A=[1, 1, 1, 2, 2, 2], B=[1, 2, 3, 4, 5, 6]))
         pdf['A'] = pdf['A'].astype('category')
-        pdf.set_index('A', inplace = True)
+        pdf.set_index('A', inplace=True)
         f = BytesIO()
         pdf.to_msgpack(f)
         f.seek(0)


### PR DESCRIPTION
 - [x] closes #15487
 - [x] tests added / passed
 - [x] passes ``git diff upstream/master | flake8 --diff``
 - [x] whatsnew entry

This allows `read_msgpack`  to read DataFrames with a categorical index. I'd assume that my testcase needs some improvement. Where can I find some information where and how to add the "whatsnew entry"?

