### PR TITLE
BUG: reindex_like after shape comparison

### DIFF
--- a/pandas/tests/test_testing.py
+++ b/pandas/tests/test_testing.py
@@ -593,6 +593,17 @@ class TestAssertFrameEqual(tm.TestCase):
     def _assert_not_equal(self, a, b, **kwargs):
         self.assertRaises(AssertionError, assert_frame_equal, a, b, **kwargs)
         self.assertRaises(AssertionError, assert_frame_equal, b, a, **kwargs)
+    
+    def test_equal_with_different_row_order(self):
+        self._assert_equal(pd.DataFrame({'A': [1, 2, 3], 'B': [4, 5, 6]},
+                                        index=['a', 'b', 'c']),
+                           pd.DataFrame({'A': [3, 2, 1], 'B': [6, 5, 4]},
+                                        index=['c', 'b', 'a']), 
+                           check_like=True)
+
+    def test_not_equal_with_different_shape(self):
+        self._assert_not_equal(pd.DataFrame({'A': [1, 2, 3]}),
+                               pd.DataFrame({'A': [1, 2, 3, 4]}))
 
     def test_index_dtype(self):
         df1 = DataFrame.from_records(
@@ -621,19 +632,9 @@ class TestAssertFrameEqual(tm.TestCase):
 
         expected = """DataFrame are different
 
-DataFrame shape \\(number of rows\\) are different
-\\[left\\]:  3, RangeIndex\\(start=0, stop=3, step=1\\)
-\\[right\\]: 4, RangeIndex\\(start=0, stop=4, step=1\\)"""
-
-        with assertRaisesRegexp(AssertionError, expected):
-            assert_frame_equal(pd.DataFrame({'A': [1, 2, 3]}),
-                               pd.DataFrame({'A': [1, 2, 3, 4]}))
-
-        expected = """DataFrame are different
-
-DataFrame shape \\(number of columns\\) are different
-\\[left\\]:  2, Index\\(\\[u?'A', u?'B'\\], dtype='object'\\)
-\\[right\\]: 1, Index\\(\\[u?'A'\\], dtype='object'\\)"""
+DataFrame shape mismatch
+\\[left\\]:  \\(3, 2\\)
+\\[right\\]: \\(4, 1\\)"""
 
         with assertRaisesRegexp(AssertionError, expected):
             assert_frame_equal(pd.DataFrame({'A': [1, 2, 3], 'B': [4, 5, 6]}),

--- a/pandas/tests/test_testing.py
+++ b/pandas/tests/test_testing.py
@@ -634,7 +634,7 @@ class TestAssertFrameEqual(tm.TestCase):
 
 DataFrame shape mismatch
 \\[left\\]:  \\(3, 2\\)
-\\[right\\]: \\(4, 1\\)"""
+\\[right\\]: \\(3, 1\\)"""
 
         with assertRaisesRegexp(AssertionError, expected):
             assert_frame_equal(pd.DataFrame({'A': [1, 2, 3], 'B': [4, 5, 6]}),

--- a/pandas/util/testing.py
+++ b/pandas/util/testing.py
@@ -1270,21 +1270,12 @@ def assert_frame_equal(left, right, check_dtype=True,
         assertIsInstance(left, type(right))
         # assert_class_equal(left, right, obj=obj)
 
-    # shape comparison (row)
-    if left.shape[0] != right.shape[0]:
+    # shape comparison
+    if left.shape != right.shape:
         raise_assert_detail(obj,
-                            'DataFrame shape (number of rows) are different',
-                            '{0}, {1}'.format(left.shape[0], left.index),
-                            '{0}, {1}'.format(right.shape[0], right.index))
-    # shape comparison (columns)
-    if left.shape[1] != right.shape[1]:
-        raise_assert_detail(obj,
-                            'DataFrame shape (number of columns) '
-                            'are different',
-                            '{0}, {1}'.format(left.shape[1],
-                                              left.columns),
-                            '{0}, {1}'.format(right.shape[1],
-                                              right.columns))
+                            'DataFrame shape mismatch',
+                            '({0}, {1})'.format(*left.shape),
+                            '({0}, {1})'.format(*right.shape))
     
     if check_like:
         left, right = left.reindex_like(right), right

--- a/pandas/util/testing.py
+++ b/pandas/util/testing.py
@@ -1270,9 +1270,6 @@ def assert_frame_equal(left, right, check_dtype=True,
         assertIsInstance(left, type(right))
         # assert_class_equal(left, right, obj=obj)
 
-    if check_like:
-        left, right = left.reindex_like(right), right
-
     # shape comparison (row)
     if left.shape[0] != right.shape[0]:
         raise_assert_detail(obj,
@@ -1288,6 +1285,9 @@ def assert_frame_equal(left, right, check_dtype=True,
                                               left.columns),
                             '{0}, {1}'.format(right.shape[1],
                                               right.columns))
+    
+    if check_like:
+        left, right = left.reindex_like(right), right
 
     # index comparison
     assert_index_equal(left.index, right.index, exact=check_index_type,

--- a/pandas/util/testing.py
+++ b/pandas/util/testing.py
@@ -1254,7 +1254,7 @@ def assert_frame_equal(left, right, check_dtype=True,
     check_categorical : bool, default True
         Whether to compare internal Categorical exactly.
     check_like : bool, default False
-        If true, then reindex_like operands
+        If true, ignore the order of rows & columns
     obj : str, default 'DataFrame'
         Specify object name being compared, internally used to show appropriate
         assertion message


### PR DESCRIPTION
in assert_frame_equal, if check_like, the former code reindex_like before shape comparison.
for example:
if left.shape=(2,2), right.shpae=(2.0), after reindex_like, left.shape=(2,0),right.shape=(2,0),then the shape comparison will not find out that the two dataframes are different. For that, the assert_frame_equal will not raise assertion errors. But in fact it should raise.
@jreback 
