### PR TITLE
DEPR: rename to _consolidate and create deprecation warning

### DIFF
--- a/doc/source/whatsnew/v0.20.0.txt
+++ b/doc/source/whatsnew/v0.20.0.txt
@@ -484,6 +484,7 @@ Deprecations
 - ``DataFrame.astype()`` has deprecated the ``raise_on_error`` parameter in favor of ``errors`` (:issue:`14878`)
 - ``Series.sortlevel`` and ``DataFrame.sortlevel`` have been deprecated in favor of ``Series.sort_index`` and ``DataFrame.sort_index`` (:issue:`15099`)
 - importing ``concat`` from ``pandas.tools.merge`` has been deprecated in favor of imports from the ``pandas`` namespace. This should only affect explict imports (:issue:`15358`)
+- ``Series/DataFrame/Panel.consolidate()`` been deprecated as a public method. (:issue:`15483`)
 
 .. _whatsnew_0200.prior_deprecations:
 

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -2874,11 +2874,10 @@ class NDFrame(PandasObject):
 
         self._protect_consolidate(f)
 
-    def consolidate(self, inplace=False):
+    def _consolidate(self, inplace=False):
         """
         Compute NDFrame with "consolidated" internals (data of each dtype
-        grouped together in a single ndarray). Mainly an internal API function,
-        but available here to the savvy user
+        grouped together in a single ndarray).
 
         Parameters
         ----------
@@ -2896,6 +2895,15 @@ class NDFrame(PandasObject):
             f = lambda: self._data.consolidate()
             cons_data = self._protect_consolidate(f)
             return self._constructor(cons_data).__finalize__(self)
+
+    def consolidate(self, inplace=False):
+        """
+        DEPRECATED: consolidate will be an internal implmentation only.
+        """
+        # 15483
+        warnings.warn("consolidate is deprecated and will be removed in a "
+                      "future release.", FutureWarning, stacklevel=2)
+        return self._consolidate(inplace)
 
     @property
     def _is_mixed_type(self):

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -2898,7 +2898,7 @@ class NDFrame(PandasObject):
 
     def consolidate(self, inplace=False):
         """
-        DEPRECATED: consolidate will be an internal implmentation only.
+        DEPRECATED: consolidate will be an internal implementation only.
         """
         # 15483
         warnings.warn("consolidate is deprecated and will be removed in a "

--- a/pandas/core/groupby.py
+++ b/pandas/core/groupby.py
@@ -3893,7 +3893,7 @@ class DataFrameGroupBy(NDFrameGroupBy):
         if not self.as_index:
             result = DataFrame(output, columns=output_keys)
             self._insert_inaxis_grouper_inplace(result)
-            result = result.consolidate()
+            result = result._consolidate()
         else:
             index = self.grouper.result_index
             result = DataFrame(output, index=index, columns=output_keys)
@@ -3913,7 +3913,7 @@ class DataFrameGroupBy(NDFrameGroupBy):
             result = DataFrame(mgr)
 
             self._insert_inaxis_grouper_inplace(result)
-            result = result.consolidate()
+            result = result._consolidate()
         else:
             index = self.grouper.result_index
             mgr = BlockManager(blocks, [items, index])

--- a/pandas/io/pytables.py
+++ b/pandas/io/pytables.py
@@ -835,7 +835,7 @@ class HDFStore(StringMixin):
 
             # concat and return
             return concat(objs, axis=axis,
-                          verify_integrity=False).consolidate()
+                          verify_integrity=False)._consolidate()
 
         # create the iterator
         it = TableIterator(self, s, func, where=where, nrows=nrows,
@@ -3442,7 +3442,7 @@ class Table(Fixed):
             return [mgr.items.take(blk.mgr_locs) for blk in blocks]
 
         # figure out data_columns and get out blocks
-        block_obj = self.get_object(obj).consolidate()
+        block_obj = self.get_object(obj)._consolidate()
         blocks = block_obj._data.blocks
         blk_items = get_blk_items(block_obj._data, blocks)
         if len(self.non_index_axes):
@@ -3809,7 +3809,7 @@ class LegacyTable(Table):
         if len(objs) == 1:
             wp = objs[0]
         else:
-            wp = concat(objs, axis=0, verify_integrity=False).consolidate()
+            wp = concat(objs, axis=0, verify_integrity=False)._consolidate()
 
         # apply the selection filters & axis orderings
         wp = self.process_axes(wp, columns=columns)

--- a/pandas/tests/frame/test_block_internals.py
+++ b/pandas/tests/frame/test_block_internals.py
@@ -40,18 +40,23 @@ class TestDataFrameBlockInternals(tm.TestCase, TestData):
 
     def test_consolidate(self):
         self.frame['E'] = 7.
-        consolidated = self.frame.consolidate()
+        consolidated = self.frame._consolidate()
         self.assertEqual(len(consolidated._data.blocks), 1)
 
         # Ensure copy, do I want this?
-        recons = consolidated.consolidate()
+        recons = consolidated._consolidate()
         self.assertIsNot(recons, consolidated)
         assert_frame_equal(recons, consolidated)
 
         self.frame['F'] = 8.
         self.assertEqual(len(self.frame._data.blocks), 3)
-        self.frame.consolidate(inplace=True)
+        self.frame._consolidate(inplace=True)
         self.assertEqual(len(self.frame._data.blocks), 1)
+
+    def test_consolidate_deprecation(self):
+        self.frame['E'] = 7
+        with tm.assert_produces_warning(FutureWarning):
+            self.frame.consolidate()
 
     def test_consolidate_inplace(self):
         frame = self.frame.copy()  # noqa

--- a/pandas/tests/frame/test_nonunique_indexes.py
+++ b/pandas/tests/frame/test_nonunique_indexes.py
@@ -87,7 +87,7 @@ class TestDataFrameNonuniqueIndexes(tm.TestCase, TestData):
         check(df, expected)
 
         # consolidate
-        df = df.consolidate()
+        df = df._consolidate()
         expected = DataFrame([[1, 1, 'bah', 3], [1, 2, 'bah', 3],
                               [2, 3, 'bah', 3]],
                              columns=['foo', 'foo', 'string', 'foo2'])

--- a/pandas/tests/io/test_pytables.py
+++ b/pandas/tests/io/test_pytables.py
@@ -418,7 +418,7 @@ class TestHDFStore(Base, tm.TestCase):
             df['datetime1'] = datetime.datetime(2001, 1, 2, 0, 0)
             df['datetime2'] = datetime.datetime(2001, 1, 3, 0, 0)
             df.loc[3:6, ['obj1']] = np.nan
-            df = df.consolidate()._convert(datetime=True)
+            df = df._consolidate()._convert(datetime=True)
 
             warnings.filterwarnings('ignore', category=PerformanceWarning)
             store['df'] = df
@@ -762,7 +762,7 @@ class TestHDFStore(Base, tm.TestCase):
         df['datetime1'] = datetime.datetime(2001, 1, 2, 0, 0)
         df['datetime2'] = datetime.datetime(2001, 1, 3, 0, 0)
         df.loc[3:6, ['obj1']] = np.nan
-        df = df.consolidate()._convert(datetime=True)
+        df = df._consolidate()._convert(datetime=True)
 
         with ensure_clean_store(self.path) as store:
             _maybe_remove(store, 'df')
@@ -2077,7 +2077,7 @@ class TestHDFStore(Base, tm.TestCase):
         df['datetime1'] = datetime.datetime(2001, 1, 2, 0, 0)
         df['datetime2'] = datetime.datetime(2001, 1, 3, 0, 0)
         df.loc[3:6, ['obj1']] = np.nan
-        df = df.consolidate()._convert(datetime=True)
+        df = df._consolidate()._convert(datetime=True)
 
         with ensure_clean_store(self.path) as store:
             store.append('df1_mixed', df)
@@ -2091,7 +2091,7 @@ class TestHDFStore(Base, tm.TestCase):
         wp['bool2'] = wp['ItemB'] > 0
         wp['int1'] = 1
         wp['int2'] = 2
-        wp = wp.consolidate()
+        wp = wp._consolidate()
 
         with ensure_clean_store(self.path) as store:
             store.append('p1_mixed', wp)
@@ -2106,7 +2106,7 @@ class TestHDFStore(Base, tm.TestCase):
             wp['bool2'] = wp['l2'] > 0
             wp['int1'] = 1
             wp['int2'] = 2
-            wp = wp.consolidate()
+            wp = wp._consolidate()
 
             with ensure_clean_store(self.path) as store:
                 store.append('p4d_mixed', wp)
@@ -2134,7 +2134,7 @@ class TestHDFStore(Base, tm.TestCase):
         df['obj1'] = 'foo'
         df['obj2'] = 'bar'
         df['datetime1'] = datetime.date(2001, 1, 2)
-        df = df.consolidate()._convert(datetime=True)
+        df = df._consolidate()._convert(datetime=True)
 
         with ensure_clean_store(self.path) as store:
             # this fails because we have a date in the object block......
@@ -2949,7 +2949,7 @@ class TestHDFStore(Base, tm.TestCase):
             df['bool2'] = df['B'] > 0
             df['int1'] = 1
             df['int2'] = 2
-            return df.consolidate()
+            return df._consolidate()
 
         df1 = _make_one()
         df2 = _make_one()

--- a/pandas/tests/test_generic.py
+++ b/pandas/tests/test_generic.py
@@ -658,7 +658,7 @@ class Generic(object):
                 super(DataFrame, df).sort_index(inplace=value)
 
             with self.assertRaises(ValueError):
-                super(DataFrame, df).consolidate(inplace=value)
+                super(DataFrame, df)._consolidate(inplace=value)
 
             with self.assertRaises(ValueError):
                 super(DataFrame, df).fillna(value=0, inplace=value)

--- a/pandas/tests/test_panel4d.py
+++ b/pandas/tests/test_panel4d.py
@@ -677,7 +677,7 @@ class TestPanel4d(tm.TestCase, CheckIndexing, SafeForSparse,
             self.panel4d['foo'] = 1.
             self.assertFalse(self.panel4d._data.is_consolidated())
 
-            panel4d = self.panel4d.consolidate()
+            panel4d = self.panel4d._consolidate()
             self.assertTrue(panel4d._data.is_consolidated())
 
     def test_ctor_dict(self):

--- a/pandas/tools/concat.py
+++ b/pandas/tools/concat.py
@@ -263,7 +263,7 @@ class _Concatenator(object):
                 raise TypeError("cannot concatenate a non-NDFrame object")
 
             # consolidate
-            obj.consolidate(inplace=True)
+            obj._consolidate(inplace=True)
             ndims.add(obj.ndim)
 
         # get the sample

--- a/pandas/tseries/resample.py
+++ b/pandas/tseries/resample.py
@@ -221,7 +221,7 @@ class Resampler(_GroupBy):
         -------
         obj : converted object
         """
-        obj = obj.consolidate()
+        obj = obj._consolidate()
         return obj
 
     def _get_binner_for_time(self):


### PR DESCRIPTION
 - [x] closes #15483 
 - [x] tests added / passed
 - [x] passes ``git diff upstream/master | flake8 --diff``
 - [x] whatsnew entry

Test output:
```
running: pytest --skip-slow --skip-network pandas
============================= test session starts ==============================
platform linux2 -- Python 2.7.13, pytest-3.0.6, py-1.4.32, pluggy-0.4.0
rootdir: /home/sfoo/pandas, inifile: setup.cfg
collected 11882 items / 4 skipped

 10147 passed, 1662 skipped, 77 xfailed, 2084 pytest-warnings in 407.18 seconds  
```