### PR TITLE
PERF: improve iloc list indexing

### DIFF
--- a/doc/source/whatsnew/v0.20.0.txt
+++ b/doc/source/whatsnew/v0.20.0.txt
@@ -905,7 +905,7 @@ Performance Improvements
 - Improved performance of ``drop_duplicates()`` on ``bool`` columns (:issue:`12963`)
 - Improve performance of ``pd.core.groupby.GroupBy.apply`` when the applied
   function used the ``.name`` attribute of the group DataFrame (:issue:`15062`).
-
+- Improved performance of ``iloc`` indexing with a list or array (:issue:`15504`).
 
 
 .. _whatsnew_0200.bug_fixes:

--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -1699,11 +1699,11 @@ class _iLocIndexer(_LocationIndexer):
 
     def _get_list_axis(self, key, axis=0):
         """
-        Return Series values by array of integers
+        Return Series values by list or array of integers
 
         Parameters
         ----------
-        key : list-like positional indexer (already converted to array)
+        key : list-like positional indexer
         axis : int (can only be zero)
 
         Returns
@@ -1738,7 +1738,6 @@ class _iLocIndexer(_LocationIndexer):
 
         # a single integer
         else:
-
             key = self._convert_scalar_indexer(key, axis)
 
             if not is_integer(key):

--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -1697,26 +1697,24 @@ class _iLocIndexer(_LocationIndexer):
         else:
             return self.obj.take(slice_obj, axis=axis, convert=False)
 
-    def _get_list_axis(self, key_list, axis=0):
+    def _get_list_axis(self, key, axis=0):
         """
-        Return Series values by list or array of integers
+        Return Series values by array of integers
 
         Parameters
         ----------
-        key_list : list-like positional indexer
+        key : list-like positional indexer (already converted to array)
         axis : int (can only be zero)
 
         Returns
         -------
         Series object
         """
-
-        # validate list bounds
-        self._is_valid_list_like(key_list, axis)
-
-        # force an actual list
-        key_list = list(key_list)
-        return self.obj.take(key_list, axis=axis, convert=False)
+        try:
+            return self.obj.take(key, axis=axis, convert=False)
+        except IndexError:
+            # re-raise with different error message
+            raise IndexError("positional indexers are out-of-bounds")
 
     def _getitem_axis(self, key, axis=0):
 
@@ -1724,7 +1722,13 @@ class _iLocIndexer(_LocationIndexer):
             self._has_valid_type(key, axis)
             return self._get_slice_axis(key, axis=axis)
 
-        elif is_bool_indexer(key):
+        if isinstance(key, list):
+            try:
+                key = np.asarray(key)
+            except TypeError:  # pragma: no cover
+                pass
+
+        if is_bool_indexer(key):
             self._has_valid_type(key, axis)
             return self._getbool_axis(key, axis=axis)
 
@@ -1734,6 +1738,7 @@ class _iLocIndexer(_LocationIndexer):
 
         # a single integer
         else:
+
             key = self._convert_scalar_indexer(key, axis)
 
             if not is_integer(key):

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -2378,7 +2378,7 @@ class Series(base.IndexOpsMixin, strings.StringAccessorMixin,
         --------
         numpy.ndarray.take
         """
-        nv.validate_take(tuple(), kwargs)
+        #nv.validate_take(tuple(), kwargs)
 
         # check/convert indicies here
         if convert:
@@ -2388,7 +2388,7 @@ class Series(base.IndexOpsMixin, strings.StringAccessorMixin,
         new_index = self.index.take(indices)
         new_values = self._values.take(indices)
         return self._constructor(new_values,
-                                 index=new_index).__finalize__(self)
+                                 index=new_index, fastpath=True).__finalize__(self)
 
     def isin(self, values):
         """

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -2378,7 +2378,8 @@ class Series(base.IndexOpsMixin, strings.StringAccessorMixin,
         --------
         numpy.ndarray.take
         """
-        #nv.validate_take(tuple(), kwargs)
+        if kwargs:
+            nv.validate_take(tuple(), kwargs)
 
         # check/convert indicies here
         if convert:

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -2388,8 +2388,8 @@ class Series(base.IndexOpsMixin, strings.StringAccessorMixin,
         indices = _ensure_platform_int(indices)
         new_index = self.index.take(indices)
         new_values = self._values.take(indices)
-        return self._constructor(new_values,
-                                 index=new_index, fastpath=True).__finalize__(self)
+        return (self._constructor(new_values, index=new_index, fastpath=True)
+                    .__finalize__(self))
 
     def isin(self, values):
         """

--- a/pandas/indexes/base.py
+++ b/pandas/indexes/base.py
@@ -1668,7 +1668,7 @@ class Index(IndexOpsMixin, StringAccessorMixin, PandasObject):
     @Appender(_index_shared_docs['take'] % _index_doc_kwargs)
     def take(self, indices, axis=0, allow_fill=True,
              fill_value=None, **kwargs):
-        nv.validate_take(tuple(), kwargs)
+        #nv.validate_take(tuple(), kwargs)
         indices = _ensure_platform_int(indices)
         if self._can_hold_na:
             taken = self._assert_take_fillable(self.values, indices,

--- a/pandas/indexes/base.py
+++ b/pandas/indexes/base.py
@@ -1668,7 +1668,8 @@ class Index(IndexOpsMixin, StringAccessorMixin, PandasObject):
     @Appender(_index_shared_docs['take'] % _index_doc_kwargs)
     def take(self, indices, axis=0, allow_fill=True,
              fill_value=None, **kwargs):
-        #nv.validate_take(tuple(), kwargs)
+        if kwargs:
+            nv.validate_take(tuple(), kwargs)
         indices = _ensure_platform_int(indices)
         if self._can_hold_na:
             taken = self._assert_take_fillable(self.values, indices,

--- a/pandas/tests/test_generic.py
+++ b/pandas/tests/test_generic.py
@@ -1870,7 +1870,7 @@ class TestNDFrame(tm.TestCase):
                   tm.makeObjectSeries()]:
             out = s.take(indices)
             expected = Series(data=s.values.take(indices),
-                              index=s.index.take(indices))
+                              index=s.index.take(indices), dtype=s.dtype)
             tm.assert_series_equal(out, expected)
         for df in [tm.makeTimeDataFrame()]:
             out = df.take(indices)


### PR DESCRIPTION
Did a profile of `iloc` using a list indexer, and noticed a few parts that seemingly can be optimized rather easily:

- convert early to array, and keep as array
- do not validate the input for out of bounds (this validation is also (and much faster) done in `np.take`)
- do not validate kwargs (for numpy compat) (-> could define a `_take` method that does not do this for internal usage?)
- use fastpath for resulting Series creation

The failing tests are currently just the ones that checked for the kwarg validation (and one failing test due to the fastpath taken where object datetimes are not coerced to datetime64).

Compared to master, I get up to 40 to 60% improvement on some simple tests:

PR:
```
In [1]: s = pd.Series(np.random.randn(10000))

In [2]: s.iloc[10]
Out[2]: 0.91268983379322421

In [3]: %timeit s.iloc[[10]]
The slowest run took 14.18 times longer than the fastest. This could mean that an intermediate result is being cached.
10000 loops, best of 3: 47.3 µs per loop

In [4]: indexer = list(range(10, 30)) + list(range(50,80))

In [5]: %timeit s.iloc[indexer]
The slowest run took 5.92 times longer than the fastest. This could mean that an intermediate result is being cached.
10000 loops, best of 3: 49.8 µs per loop

In [6]: indexer = list(range(10, 30)) + list(range(50,800))

In [7]: %timeit s.iloc[indexer]
10000 loops, best of 3: 104 µs per loop
```

master:
```
In [1]: s = pd.Series(np.random.randn(10000))

In [2]: s.iloc[10]
Out[2]: -1.4152272792497846

In [3]: %timeit s.iloc[[10]]
The slowest run took 6.70 times longer than the fastest. This could mean that an intermediate result is being cached.
10000 loops, best of 3: 103 µs per loop

In [4]: indexer = list(range(10, 30)) + list(range(50,80))

In [5]: %timeit s.iloc[indexer]
The slowest run took 4.12 times longer than the fastest. This could mean that an intermediate result is being cached.
10000 loops, best of 3: 131 µs per loop

In [6]: indexer = list(range(10, 30)) + list(range(50,800))

In [7]: %timeit s.iloc[indexer]
The slowest run took 17.01 times longer than the fastest. This could mean that an intermediate result is being cached.
1000 loops, best of 3: 247 µs per loop
```

There are some details to work out, but already putting it up here for discussion (and need to run the benchmark suite).

From the remaining time that iloc takes, a large part is spent in the creation of the actual result (the new series): creating a new index (~ 17%), creating a new series based on the values and index (~ 32%). So in total almost half of the time, and thus wondering if this is not possible to speedup.