### PR TITLE
BUG: Fix nansum overflow on Windows with bottleneck

### DIFF
--- a/doc/source/whatsnew/v0.20.0.txt
+++ b/doc/source/whatsnew/v0.20.0.txt
@@ -632,3 +632,5 @@ Bug Fixes
 - Bug in ``pd.melt()`` where passing a tuple value for ``value_vars`` caused a ``TypeError`` (:issue:`15348`)
 - Bug in ``.eval()`` which caused multiline evals to fail with local variables not on the first line (:issue:`15342`)
 - Bug in ``pd.read_msgpack`` which did not allow to load dataframe with an index of type ``CategoricalIndex`` (:issue:`15487`)
+
+- Bug in ``nanops.py`` due to bottleneck, which produces overflow in nansum on Windows (:issue:`15453`)

--- a/pandas/core/nanops.py
+++ b/pandas/core/nanops.py
@@ -131,9 +131,9 @@ def _bn_ok_dtype(dt, name):
         if name == 'nansum':
             if dt.itemsize < 8:
                 return False
-            elif os.name == 'nt': # bottleneck has overflow issue in Windows
+            elif os.name == 'nt':  # bottleneck has overflow issue in Windows
                 return False
-            
+
         return True
     return False
 

--- a/pandas/core/nanops.py
+++ b/pandas/core/nanops.py
@@ -129,10 +129,7 @@ def _bn_ok_dtype(dt, name):
         # bottleneck does not properly upcast during the sum
         # so can overflow
         if name == 'nansum':
-            if dt.itemsize < 8:
-                return False
-            elif os.name == 'nt':  # bottleneck has overflow issue in Windows
-                return False
+            return False
 
         return True
     return False

--- a/pandas/core/nanops.py
+++ b/pandas/core/nanops.py
@@ -2,6 +2,7 @@ import itertools
 import functools
 import numpy as np
 import operator
+import os
 
 try:
     import bottleneck as bn
@@ -130,7 +131,9 @@ def _bn_ok_dtype(dt, name):
         if name == 'nansum':
             if dt.itemsize < 8:
                 return False
-
+            elif os.name == 'nt': # bottleneck has overflow issue in Windows
+                return False
+            
         return True
     return False
 

--- a/pandas/core/nanops.py
+++ b/pandas/core/nanops.py
@@ -2,7 +2,6 @@ import itertools
 import functools
 import numpy as np
 import operator
-import os
 
 try:
     import bottleneck as bn

--- a/pandas/tests/test_nanops.py
+++ b/pandas/tests/test_nanops.py
@@ -327,6 +327,12 @@ class TestnanopsDataFrame(tm.TestCase):
         self.check_funs(nanops.nansum, np.sum, allow_str=False,
                         allow_date=False, allow_tdelta=True, check_dtype=False)
 
+    def test_nansum_overflow(self):
+        s = Series([2**31])
+        self.assertEqual(s.sum(),2147483648)
+        s = Series([2**31-1,1])
+        self.assertEqual(s.sum(),2147483648)
+    
     def test_nanmean(self):
         self.check_funs(nanops.nanmean, np.mean, allow_complex=False,
                         allow_obj=False, allow_str=False, allow_date=False,

--- a/pandas/tests/test_nanops.py
+++ b/pandas/tests/test_nanops.py
@@ -329,10 +329,10 @@ class TestnanopsDataFrame(tm.TestCase):
 
     def test_nansum_overflow(self):
         s = Series([2**31])
-        self.assertEqual(s.sum(),2147483648)
-        s = Series([2**31-1,1])
-        self.assertEqual(s.sum(),2147483648)
-    
+        self.assertEqual(s.sum(), 2147483648)
+        s = Series([2**31 - 1, 1])
+        self.assertEqual(s.sum(), 2147483648)
+
     def test_nanmean(self):
         self.check_funs(nanops.nanmean, np.mean, allow_complex=False,
                         allow_obj=False, allow_str=False, allow_date=False,


### PR DESCRIPTION
Bottleneck used in nansum produces overflow error on Windows. Temporary fix that could be undone once the error in bottleneck is fixed and released, to avoid platform specificity.

 - [x] closes #15453 
 - [x] tests added / passed
 - [x] passes ``git diff upstream/master | flake8 --diff``
 - [x] whatsnew entry