### PR TITLE
PERF: faster unstacking

### DIFF
--- a/asv_bench/benchmarks/reshape.py
+++ b/asv_bench/benchmarks/reshape.py
@@ -59,6 +59,27 @@ class reshape_unstack_simple(object):
         self.df.unstack(1)
 
 
+class reshape_unstack_large_single_dtype(object):
+    goal_time = 0.2
+
+    def setup(self):
+        m = 100
+        n = 1000
+
+        levels = np.arange(m)
+        index = pd.MultiIndex.from_product([levels]*2)
+        columns = np.arange(n)
+        values = np.arange(m*m*n).reshape(m*m, n)
+        self.df = pd.DataFrame(values, index, columns)
+        self.df2 = self.df.iloc[:-1]
+
+    def time_unstack_full_product(self):
+        self.df.unstack()
+
+    def time_unstack_with_mask(self):
+        self.df2.unstack()
+
+
 class unstack_sparse_keyspace(object):
     goal_time = 0.2
 

--- a/doc/source/whatsnew/v0.20.0.txt
+++ b/doc/source/whatsnew/v0.20.0.txt
@@ -567,7 +567,7 @@ Performance Improvements
 - Improved performance and reduced memory when indexing with a ``MultiIndex`` (:issue:`15245`)
 - When reading buffer object in ``read_sas()`` method without specified format, filepath string is inferred rather than buffer object. (:issue:`14947`)
 - Improved performance of `rank()` for categorical data (:issue:`15498`)
-
+- Improved performance when using ``.unstack()`` (:issue:`15503`)
 
 
 .. _whatsnew_0200.bug_fixes:

--- a/pandas/src/reshape.pyx
+++ b/pandas/src/reshape.pyx
@@ -1,0 +1,35 @@
+# cython: profile=False
+
+from numpy cimport *
+cimport numpy as np
+import numpy as np
+
+cimport cython
+
+import_array()
+
+cimport util
+
+from numpy cimport NPY_INT8 as NPY_int8
+from numpy cimport NPY_INT16 as NPY_int16
+from numpy cimport NPY_INT32 as NPY_int32
+from numpy cimport NPY_INT64 as NPY_int64
+from numpy cimport NPY_FLOAT16 as NPY_float16
+from numpy cimport NPY_FLOAT32 as NPY_float32
+from numpy cimport NPY_FLOAT64 as NPY_float64
+
+from numpy cimport (int8_t, int16_t, int32_t, int64_t, uint8_t, uint16_t,
+                    uint32_t, uint64_t, float16_t, float32_t, float64_t)
+
+int8 = np.dtype(np.int8)
+int16 = np.dtype(np.int16)
+int32 = np.dtype(np.int32)
+int64 = np.dtype(np.int64)
+float16 = np.dtype(np.float16)
+float32 = np.dtype(np.float32)
+float64 = np.dtype(np.float64)
+
+cdef double NaN = <double> np.NaN
+cdef double nan = NaN
+
+include "reshape_helper.pxi"

--- a/pandas/src/reshape_helper.pxi.in
+++ b/pandas/src/reshape_helper.pxi.in
@@ -1,0 +1,81 @@
+"""
+Template for each `dtype` helper function for take
+
+WARNING: DO NOT edit .pxi FILE directly, .pxi is generated from .pxi.in
+"""
+
+# ----------------------------------------------------------------------
+# reshape
+# ----------------------------------------------------------------------
+
+{{py:
+
+# name, c_type
+dtypes = [('uint8', 'uint8_t'),
+          ('uint16', 'uint16_t'),
+          ('uint32', 'uint32_t'),
+          ('uint64', 'uint64_t'),
+          ('int8', 'int8_t'),
+          ('int16', 'int16_t'),
+          ('int32', 'int32_t'),
+          ('int64', 'int64_t'),
+          ('float32', 'float32_t'),
+          ('float64', 'float64_t'),
+          ('object', 'object')]
+}}
+
+{{for dtype, c_type in dtypes}}
+
+
+@cython.wraparound(False)
+@cython.boundscheck(False)
+def unstack_{{dtype}}(ndarray[{{c_type}}, ndim=2] values,
+                      ndarray[uint8_t, ndim=1] mask,
+                      Py_ssize_t stride,
+                      Py_ssize_t length,
+                      Py_ssize_t width,
+                      ndarray[{{c_type}}, ndim=2] new_values,
+                      ndarray[uint8_t, ndim=2] new_mask):
+    """
+    transform long sorted_values to wide new_values
+
+    Parameters
+    ----------
+    values : typed ndarray
+    mask : boolean ndarray
+    stride : int
+    length : int
+    width : int
+    new_values : typed ndarray
+        result array
+    new_mask : boolean ndarray
+        result mask
+
+    """
+
+    cdef:
+        Py_ssize_t i, j, w, nulls, s, offset
+
+    {{if dtype == 'object'}}
+    if True:
+    {{else}}
+    with nogil:
+    {{endif}}
+
+        for i in range(stride):
+
+            nulls = 0
+            for j in range(length):
+
+                for w in range(width):
+
+                    offset = j * width + w
+
+                    if mask[offset]:
+                        s = i * width + w
+                        new_values[j, s] = values[offset - nulls, i]
+                        new_mask[j, s] = 1
+                    else:
+                        nulls += 1
+
+{{endfor}}

--- a/pandas/tests/frame/test_reshape.py
+++ b/pandas/tests/frame/test_reshape.py
@@ -121,19 +121,22 @@ class TestDataFrameReshape(tm.TestCase, TestData):
         assert_frame_equal(result, expected)
 
     def test_stack_unstack(self):
-        stacked = self.frame.stack()
+        f = self.frame.copy()
+        f[:] = np.arange(np.prod(f.shape)).reshape(f.shape)
+
+        stacked = f.stack()
         stacked_df = DataFrame({'foo': stacked, 'bar': stacked})
 
         unstacked = stacked.unstack()
         unstacked_df = stacked_df.unstack()
 
-        assert_frame_equal(unstacked, self.frame)
-        assert_frame_equal(unstacked_df['bar'], self.frame)
+        assert_frame_equal(unstacked, f)
+        assert_frame_equal(unstacked_df['bar'], f)
 
         unstacked_cols = stacked.unstack(0)
         unstacked_cols_df = stacked_df.unstack(0)
-        assert_frame_equal(unstacked_cols.T, self.frame)
-        assert_frame_equal(unstacked_cols_df['bar'].T, self.frame)
+        assert_frame_equal(unstacked_cols.T, f)
+        assert_frame_equal(unstacked_cols_df['bar'].T, f)
 
     def test_unstack_fill(self):
 

--- a/setup.py
+++ b/setup.py
@@ -113,6 +113,7 @@ _pxipath = pjoin('pandas', 'src')
 _pxi_dep_template = {
     'algos': ['algos_common_helper.pxi.in', 'algos_groupby_helper.pxi.in',
               'algos_take_helper.pxi.in', 'algos_rank_helper.pxi.in'],
+    '_reshape': ['reshape_helper.pxi.in'],
     '_join': ['join_helper.pxi.in', 'joins_func_helper.pxi.in'],
     'hashtable': ['hashtable_class_helper.pxi.in',
                   'hashtable_func_helper.pxi.in'],
@@ -496,6 +497,8 @@ ext_data = dict(
     algos={'pyxfile': 'algos',
            'pxdfiles': ['src/util', 'hashtable'],
            'depends': _pxi_dep['algos']},
+    _reshape={'pyxfile': 'src/reshape',
+              'depends': _pxi_dep['_reshape']},
     _join={'pyxfile': 'src/join',
            'pxdfiles': ['src/util', 'hashtable'],
            'depends': _pxi_dep['_join']},


### PR DESCRIPTION
closes #15503

so on a non-masked unstack (IOW, a fully product multi-index for example), this is now just
a simple reshape. On a masked unstack, it now will have a much lower O constant, as its in cython, and with release the GIL.

0.19.2 / master
```
In [2]: m = 100
   ...: n = 1000
   ...: 
   ...: levels = np.arange(m)
   ...: index = pd.MultiIndex.from_product([levels]*2)
   ...: columns = np.arange(n)
   ...: values = np.arange(m*m*n).reshape(m*m, n)
   ...: df = pd.DataFrame(values, index, columns)
   ...: 

In [3]: %timeit df.unstack()
1 loop, best of 3: 285 ms per loop

In [4]: df2 = df.iloc[:-1]

In [5]: %timeit df2.unstack()
1 loop, best of 3: 306 ms per loop
```

PR
```
In [2]: %timeit df.unstack()
10 loops, best of 3: 70 ms per loop

In [3]: df2 = df.iloc[:-1]

# & releasing the GIL here.
In [4]: %timeit df2.unstack()
1 loop, best of 3: 191 ms per loop
```
