### PR TITLE
DOC: Update contributing for test_fast, fix doc Windows build

### DIFF
--- a/doc/make.py
+++ b/doc/make.py
@@ -202,8 +202,8 @@ def html():
         raise SystemExit("Building HTML failed.")
     try:
         # remove stale file
-        os.system('rm source/html-styling.html')
-        os.system('cd build; rm -f html/pandas.zip;')
+        os.remove('source/html-styling.html')
+        os.remove('build/html/pandas.zip')
     except:
         pass
 

--- a/doc/source/contributing.rst
+++ b/doc/source/contributing.rst
@@ -520,15 +520,6 @@ submitting code to run the check yourself on the diff::
 
    git diff master | flake8 --diff
 
-Furthermore, we've written a tool to check that your commits are PEP8 great, `pip install pep8radius
-<https://github.com/hayd/pep8radius>`_. Look at PEP8 fixes in your branch vs master with::
-
-    pep8radius master --diff
-
-and make these changes with::
-
-    pep8radius master --diff --in-place
-
 Backwards Compatibility
 ~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -610,6 +601,21 @@ Or with one of the following constructs::
     pytest pandas/tests/[test-module].py
     pytest pandas/tests/[test-module].py::[TestClass]
     pytest pandas/tests/[test-module].py::[TestClass]::[test_method]
+
+Using `pytest-xdist <https://pypi.python.org/pypi/pytest-xdist>`_, one can 
+speed up local testing on multicore machines. Two scripts are provided to
+assist with this.  These scripts distribute testing across 4 threads.
+
+On Unix variants, one can type::
+
+    test_fast.sh
+    
+On Windows, one can type::
+
+    test_fast.bat
+    
+This can significantly reduce the time it takes to locally run tests before
+submitting a pull request.
 
 For more, see the `pytest <http://doc.pytest.org/en/latest/>`_ documentation.
 

--- a/doc/source/contributing.rst
+++ b/doc/source/contributing.rst
@@ -603,8 +603,13 @@ Or with one of the following constructs::
     pytest pandas/tests/[test-module].py::[TestClass]::[test_method]
 
 Using `pytest-xdist <https://pypi.python.org/pypi/pytest-xdist>`_, one can 
-speed up local testing on multicore machines. Two scripts are provided to
-assist with this.  These scripts distribute testing across 4 threads.
+speed up local testing on multicore machines. To use this feature, you will
+need to install `pytest-xdist` via::
+
+    pip install pytest-xdist
+    
+Two scripts are provided to assist with this.  These scripts distribute 
+testing across 4 threads.
 
 On Unix variants, one can type::
 

--- a/test_fast.bat
+++ b/test_fast.bat
@@ -1,0 +1,3 @@
+:: test on windows
+set PYTHONHASHSEED=314159265
+pytest --skip-slow --skip-network -m "not single" -n 4 pandas


### PR DESCRIPTION
- Add `test_fast.bat` for Windows developers.
- Update `contributing.rst` to refer to `pytest-xdist` and reference fast testing scripts
- Update `contributing.rst` to delete references to `pep8radius`
- Fix `doc\make.py` to not spit out error message about `rm` on Windows by using `os.remove()`

No code changes!
