### PR TITLE
Bug:DataFrame index & column returned by corr & cov are the same (#14617)

### DIFF
--- a/doc/source/whatsnew/v0.20.0.txt
+++ b/doc/source/whatsnew/v0.20.0.txt
@@ -590,7 +590,7 @@ Bug Fixes
 
 
 - Bug in ``.rank()`` which incorrectly ranks ordered categories (:issue:`15420`)
-
+- Bug in ``.corr()`` and ``.cov()`` where the column and index were the same object (:issue:`14617`)
 
 
 - Require at least 0.23 version of cython to avoid problems with character encodings (:issue:`14699`)

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -4725,6 +4725,7 @@ class DataFrame(NDFrame):
         """
         numeric_df = self._get_numeric_data()
         cols = numeric_df.columns
+        idx = cols.copy()
         mat = numeric_df.values
 
         if method == 'pearson':
@@ -4757,7 +4758,7 @@ class DataFrame(NDFrame):
                     correl[i, j] = c
                     correl[j, i] = c
 
-        return self._constructor(correl, index=cols, columns=cols)
+        return self._constructor(correl, index=idx, columns=cols)
 
     def cov(self, min_periods=None):
         """
@@ -4780,6 +4781,7 @@ class DataFrame(NDFrame):
         """
         numeric_df = self._get_numeric_data()
         cols = numeric_df.columns
+        idx = cols.copy()
         mat = numeric_df.values
 
         if notnull(mat).all():
@@ -4793,7 +4795,7 @@ class DataFrame(NDFrame):
             baseCov = _algos.nancorr(_ensure_float64(mat), cov=True,
                                      minp=min_periods)
 
-        return self._constructor(baseCov, index=cols, columns=cols)
+        return self._constructor(baseCov, index=idx, columns=cols)
 
     def corrwith(self, other, axis=0, drop=False):
         """

--- a/pandas/tests/frame/test_analytics.py
+++ b/pandas/tests/frame/test_analytics.py
@@ -118,6 +118,14 @@ class TestDataFrameAnalytics(tm.TestCase, TestData):
         for meth in ['pearson', 'kendall', 'spearman']:
             tm.assert_frame_equal(df.corr(meth), expected)
 
+    def test_corr_cov_independent_index_column(self):
+        # GH 14617
+        df = pd.DataFrame(np.random.randn(4 * 10).reshape(10, 4),
+                          columns=list("abcd"))
+        for method in ['cov', 'corr']:
+            result = getattr(df, method)()
+            self.assertFalse(result.index is result.columns)
+
     def test_cov(self):
         # min_periods no NAs (corner case)
         expected = self.frame.cov()


### PR DESCRIPTION

 - [x] closes #14617
 - [x] tests added / passed
 - [x] passes ``git diff upstream/master | flake8 --diff``
 - [x] whatsnew entry

This picks up PR #14667. Ensures that the column and index returned by `cov()` and `corr()` are not the same object. 