### PR TITLE
BUG: handle empty lists in json_normalize

### DIFF
--- a/doc/source/whatsnew/v0.20.0.txt
+++ b/doc/source/whatsnew/v0.20.0.txt
@@ -190,6 +190,7 @@ Other enhancements
 - HTML table output skips ``colspan`` or ``rowspan`` attribute if equal to 1. (:issue:`15403`)
 - ``pd.TimedeltaIndex`` now has a custom datetick formatter specifically designed for nanosecond level precision (:issue:`8711`)
 - ``pd.types.concat.union_categoricals`` gained the ``ignore_ordered`` argument to allow ignoring the ordered attribute of unioned categoricals (:issue:`13410`). See the :ref:`categorical union docs <categorical.union>` for more information.
+- ``pandas.io.json.json_normalize()`` with an empty ``list`` will return an empty ``DataFrame`` (:issue:`15534`)
 
 .. _ISO 8601 duration: https://en.wikipedia.org/wiki/ISO_8601#Durations
 

--- a/pandas/io/json/normalize.py
+++ b/pandas/io/json/normalize.py
@@ -157,6 +157,9 @@ def json_normalize(data, record_path=None, meta=None,
 
         return result
 
+    if isinstance(data, list) and len(data) is 0:
+        return DataFrame()
+
     # A bit of a hackjob
     if isinstance(data, dict):
         data = [data]

--- a/pandas/tests/io/json/test_normalize.py
+++ b/pandas/tests/io/json/test_normalize.py
@@ -62,6 +62,11 @@ class TestJSONNormalize(tm.TestCase):
 
         tm.assert_frame_equal(result, expected)
 
+    def test_empty_array(self):
+        result = json_normalize([])
+        expected = DataFrame()
+        tm.assert_frame_equal(result, expected)
+
     def test_more_deeply_nested(self):
         data = [{'country': 'USA',
                  'states': [{'name': 'California',


### PR DESCRIPTION
 - [x] closes #15534
 - [x] tests added / passed
 - [x] passes ``git diff upstream/master | flake8 --diff``
 - [x] whatsnew entry
