### PR TITLE
CLN: remove deprecated irow, icol, iget, iget_value (GH10711)

### DIFF
--- a/doc/source/whatsnew/v0.20.0.txt
+++ b/doc/source/whatsnew/v0.20.0.txt
@@ -548,6 +548,8 @@ Removal of prior version deprecations/changes
 - ``pd.to_datetime`` and ``pd.to_timedelta`` have dropped the ``coerce`` parameter in favor of ``errors`` (:issue:`13602`)
 - ``pandas.stats.fama_macbeth``, ``pandas.stats.ols``, ``pandas.stats.plm`` and ``pandas.stats.var``, as well as the top-level ``pandas.fama_macbeth`` and ``pandas.ols`` routines are removed. Similar functionaility can be found in the `statsmodels <shttp://www.statsmodels.org/dev/>`__ package. (:issue:`11898`)
 - ``Series.is_time_series`` is dropped in favor of ``Series.index.is_all_dates`` (:issue:``)
+- The deprecated ``irow``, ``icol``, ``iget`` and ``iget_value`` methods are removed
+  in favor of ``iloc`` and ``iat`` as explained :ref:`here <whatsnew_0170.deprecations>` (:issue:`10711`).
 
 
 .. _whatsnew_0200.performance:

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -1916,23 +1916,6 @@ class DataFrame(NDFrame):
 
             return self
 
-    def irow(self, i, copy=False):
-        """
-        DEPRECATED. Use ``.iloc[i]`` instead
-        """
-
-        warnings.warn("irow(i) is deprecated. Please use .iloc[i]",
-                      FutureWarning, stacklevel=2)
-        return self._ixs(i, axis=0)
-
-    def icol(self, i):
-        """
-        DEPRECATED. Use ``.iloc[:, i]`` instead
-        """
-        warnings.warn("icol(i) is deprecated. Please use .iloc[:,i]",
-                      FutureWarning, stacklevel=2)
-        return self._ixs(i, axis=1)
-
     def _ixs(self, i, axis=0):
         """
         i : int, slice, or sequence of integers
@@ -2006,14 +1989,6 @@ class DataFrame(NDFrame):
                 result._set_as_cached(label, self)
 
                 return result
-
-    def iget_value(self, i, j):
-        """
-        DEPRECATED. Use ``.iat[i, j]`` instead
-        """
-        warnings.warn("iget_value(i, j) is deprecated. Please use .iat[i, j]",
-                      FutureWarning, stacklevel=2)
-        return self.iat[i, j]
 
     def __getitem__(self, key):
         key = com._apply_if_callable(key, self)

--- a/pandas/core/groupby.py
+++ b/pandas/core/groupby.py
@@ -1004,16 +1004,6 @@ class GroupBy(_GroupBy):
     """
     _apply_whitelist = _common_apply_whitelist
 
-    def irow(self, i):
-        """
-        DEPRECATED. Use ``.nth(i)`` instead
-        """
-
-        # 10177
-        warnings.warn("irow(i) is deprecated. Please use .nth(i)",
-                      FutureWarning, stacklevel=2)
-        return self.nth(i)
-
     @Substitution(name='groupby')
     @Appender(_doc_template)
     def count(self):

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -875,31 +875,6 @@ class Series(base.IndexOpsMixin, strings.StringAccessorMixin,
 
         return self._values.reshape(shape, **kwargs)
 
-    def iget_value(self, i, axis=0):
-        """
-        DEPRECATED. Use ``.iloc[i]`` or ``.iat[i]`` instead
-        """
-        warnings.warn("iget_value(i) is deprecated. Please use .iloc[i] or "
-                      ".iat[i]", FutureWarning, stacklevel=2)
-        return self._ixs(i)
-
-    def iget(self, i, axis=0):
-        """
-        DEPRECATED. Use ``.iloc[i]`` or ``.iat[i]`` instead
-        """
-
-        warnings.warn("iget(i) is deprecated. Please use .iloc[i] or .iat[i]",
-                      FutureWarning, stacklevel=2)
-        return self._ixs(i)
-
-    def irow(self, i, axis=0):
-        """
-        DEPRECATED. Use ``.iloc[i]`` or ``.iat[i]`` instead
-        """
-        warnings.warn("irow(i) is deprecated. Please use .iloc[i] or .iat[i]",
-                      FutureWarning, stacklevel=2)
-        return self._ixs(i)
-
     def get_value(self, label, takeable=False):
         """
         Quickly retrieve single value at passed index label

--- a/pandas/tests/frame/test_indexing.py
+++ b/pandas/tests/frame/test_indexing.py
@@ -1761,12 +1761,8 @@ class TestDataFrameIndexing(tm.TestCase, TestData):
         result = df.loc[[0], "b"]
         assert_series_equal(result, expected)
 
-    def test_irow(self):
+    def test_iloc_row(self):
         df = DataFrame(np.random.randn(10, 4), index=lrange(0, 20, 2))
-
-        # 10711, deprecated
-        with tm.assert_produces_warning(FutureWarning):
-            df.irow(1)
 
         result = df.iloc[1]
         exp = df.loc[2]
@@ -1795,13 +1791,9 @@ class TestDataFrameIndexing(tm.TestCase, TestData):
         expected = df.reindex(df.index[[1, 2, 4, 6]])
         assert_frame_equal(result, expected)
 
-    def test_icol(self):
+    def test_iloc_col(self):
 
         df = DataFrame(np.random.randn(4, 10), columns=lrange(0, 20, 2))
-
-        # 10711, deprecated
-        with tm.assert_produces_warning(FutureWarning):
-            df.icol(1)
 
         result = df.iloc[:, 1]
         exp = df.loc[:, 2]
@@ -1828,8 +1820,7 @@ class TestDataFrameIndexing(tm.TestCase, TestData):
         expected = df.reindex(columns=df.columns[[1, 2, 4, 6]])
         assert_frame_equal(result, expected)
 
-    def test_irow_icol_duplicates(self):
-        # 10711, deprecated
+    def test_iloc_duplicates(self):
 
         df = DataFrame(np.random.rand(3, 3), columns=list('ABC'),
                        index=list('aab'))
@@ -1874,16 +1865,12 @@ class TestDataFrameIndexing(tm.TestCase, TestData):
         expected = df.take([0], axis=1)
         assert_frame_equal(result, expected)
 
-    def test_icol_sparse_propegate_fill_value(self):
+    def test_iloc_sparse_propegate_fill_value(self):
         from pandas.sparse.api import SparseDataFrame
         df = SparseDataFrame({'A': [999, 1]}, default_fill_value=999)
         self.assertTrue(len(df['A'].sp_values) == len(df.iloc[:, 0].sp_values))
 
-    def test_iget_value(self):
-        # 10711 deprecated
-
-        with tm.assert_produces_warning(FutureWarning):
-            self.frame.iget_value(0, 0)
+    def test_iat(self):
 
         for i, row in enumerate(self.frame.index):
             for j, col in enumerate(self.frame.columns):

--- a/pandas/tests/frame/test_nonunique_indexes.py
+++ b/pandas/tests/frame/test_nonunique_indexes.py
@@ -429,7 +429,7 @@ class TestDataFrameNonuniqueIndexes(tm.TestCase, TestData):
         self.assertEqual(len(df._data._blknos), len(df.columns))
         self.assertEqual(len(df._data._blklocs), len(df.columns))
 
-        # testing iget
+        # testing iloc
         for i in range(len(df.columns)):
             df.iloc[:, i]
 

--- a/pandas/tests/groupby/test_groupby.py
+++ b/pandas/tests/groupby/test_groupby.py
@@ -3828,20 +3828,6 @@ class TestGroupBy(MixIn, tm.TestCase):
                      'mad', 'std', 'var', 'sem']
     AGG_FUNCTIONS_WITH_SKIPNA = ['skew', 'mad']
 
-    def test_groupby_whitelist_deprecations(self):
-        from string import ascii_lowercase
-        letters = np.array(list(ascii_lowercase))
-        N = 10
-        random_letters = letters.take(np.random.randint(0, 26, N))
-        df = DataFrame({'floats': N / 10 * Series(np.random.random(N)),
-                        'letters': Series(random_letters)})
-
-        # 10711 deprecated
-        with tm.assert_produces_warning(FutureWarning):
-            df.groupby('letters').irow(0)
-        with tm.assert_produces_warning(FutureWarning):
-            df.groupby('letters').floats.irow(0)
-
     def test_regression_whitelist_methods(self):
 
         # GH6944
@@ -3917,7 +3903,7 @@ class TestGroupBy(MixIn, tm.TestCase):
              'first', 'get_group', 'groups', 'hist', 'indices', 'last', 'max',
              'mean', 'median', 'min', 'name', 'ngroups', 'nth', 'ohlc', 'plot',
              'prod', 'size', 'std', 'sum', 'transform', 'var', 'sem', 'count',
-             'nunique', 'head', 'irow', 'describe', 'cummax', 'quantile',
+             'nunique', 'head', 'describe', 'cummax', 'quantile',
              'rank', 'cumprod', 'tail', 'resample', 'cummin', 'fillna',
              'cumsum', 'cumcount', 'all', 'shift', 'skew', 'bfill', 'ffill',
              'take', 'tshift', 'pct_change', 'any', 'mad', 'corr', 'corrwith',

--- a/pandas/tests/series/test_indexing.py
+++ b/pandas/tests/series/test_indexing.py
@@ -164,21 +164,9 @@ class TestSeriesIndexing(TestData, tm.TestCase):
             result = s.get(None)
             self.assertIsNone(result)
 
-    def test_iget(self):
+    def test_iloc(self):
 
         s = Series(np.random.randn(10), index=lrange(0, 20, 2))
-
-        # 10711, deprecated
-        with tm.assert_produces_warning(FutureWarning):
-            s.iget(1)
-
-        # 10711, deprecated
-        with tm.assert_produces_warning(FutureWarning):
-            s.irow(1)
-
-        # 10711, deprecated
-        with tm.assert_produces_warning(FutureWarning):
-            s.iget_value(1)
 
         for i in range(len(s)):
             result = s.iloc[i]
@@ -199,7 +187,7 @@ class TestSeriesIndexing(TestData, tm.TestCase):
         expected = s.reindex(s.index[[0, 2, 3, 4, 5]])
         assert_series_equal(result, expected)
 
-    def test_iget_nonunique(self):
+    def test_iloc_nonunique(self):
         s = Series([0, 1, 2], index=[0, 1, 0])
         self.assertEqual(s.iloc[2], 2)
 

--- a/pandas/tests/sparse/test_frame.py
+++ b/pandas/tests/sparse/test_frame.py
@@ -389,8 +389,7 @@ class TestSparseDataFrame(tm.TestCase, SharedWithSparse):
 
         self.assertRaises(Exception, sdf.__getitem__, ['a', 'd'])
 
-    def test_icol(self):
-        # 10711 deprecated
+    def test_iloc(self):
 
         # 2227
         result = self.frame.iloc[:, 0]


### PR DESCRIPTION
xref https://github.com/pandas-dev/pandas/issues/6581