### PR TITLE
BUG: resample with tz-aware: Values falls after last bin

### DIFF
--- a/pandas/tests/tseries/test_resample.py
+++ b/pandas/tests/tseries/test_resample.py
@@ -2670,6 +2670,11 @@ class TestPeriodIndex(Base, tm.TestCase):
         # it works!
         df.resample('W-MON', closed='left', label='left').first()
 
+    def test_resample_tz_aware_bug_15549(self):
+        index = pd.DatetimeIndex([1450137600000000000, 1474059600000000000], tz='UTC').tz_convert('America/Chicago')
+        df = pd.DataFrame([1, 2], index=index)
+        df.resample('12h', closed='right', label='right').last().ffill()
+
     def test_resample_bms_2752(self):
         # GH2753
         foo = pd.Series(index=pd.bdate_range('20000101', '20000201'))

--- a/pandas/tseries/resample.py
+++ b/pandas/tseries/resample.py
@@ -1144,7 +1144,7 @@ class TimeGrouper(Grouper):
         if not isinstance(ax, DatetimeIndex):
             raise TypeError('axis must be a DatetimeIndex, but got '
                             'an instance of %r' % type(ax).__name__)
-        
+  
         if len(ax) == 0:
             binner = labels = DatetimeIndex(
                 data=[], freq=self.freq, name=ax.name)

--- a/pandas/tseries/resample.py
+++ b/pandas/tseries/resample.py
@@ -1144,6 +1144,7 @@ class TimeGrouper(Grouper):
         if not isinstance(ax, DatetimeIndex):
             raise TypeError('axis must be a DatetimeIndex, but got '
                             'an instance of %r' % type(ax).__name__)
+        
         if len(ax) == 0:
             binner = labels = DatetimeIndex(
                 data=[], freq=self.freq, name=ax.name)

--- a/pandas/tseries/resample.py
+++ b/pandas/tseries/resample.py
@@ -1165,6 +1165,7 @@ class TimeGrouper(Grouper):
         binner = labels = DatetimeIndex(freq=self.freq,
                                         start=first,
                                         end=last,
+                                        tz='UTC',
                                         name=ax.name).tz_convert(tz)
 
         # a little hack

--- a/pandas/tseries/resample.py
+++ b/pandas/tseries/resample.py
@@ -1144,17 +1144,18 @@ class TimeGrouper(Grouper):
         if not isinstance(ax, DatetimeIndex):
             raise TypeError('axis must be a DatetimeIndex, but got '
                             'an instance of %r' % type(ax).__name__)
-
         if len(ax) == 0:
             binner = labels = DatetimeIndex(
                 data=[], freq=self.freq, name=ax.name)
             return binner, [], labels
-
+        
+        tz = ax.tz
+        ax = ax.tz_convert('UTC')
+        
         first, last = ax.min(), ax.max()
         first, last = _get_range_edges(first, last, self.freq,
                                        closed=self.closed,
                                        base=self.base)
-        tz = ax.tz
         # GH #12037
         # use first/last directly instead of call replace() on them
         # because replace() will swallow the nanosecond part
@@ -1163,8 +1164,7 @@ class TimeGrouper(Grouper):
         binner = labels = DatetimeIndex(freq=self.freq,
                                         start=first,
                                         end=last,
-                                        tz=tz,
-                                        name=ax.name)
+                                        name=ax.name).tz_convert(tz)
 
         # a little hack
         trimmed = False

--- a/pandas/tseries/resample.py
+++ b/pandas/tseries/resample.py
@@ -1144,7 +1144,7 @@ class TimeGrouper(Grouper):
         if not isinstance(ax, DatetimeIndex):
             raise TypeError('axis must be a DatetimeIndex, but got '
                             'an instance of %r' % type(ax).__name__)
-  
+
         if len(ax) == 0:
             binner = labels = DatetimeIndex(
                 data=[], freq=self.freq, name=ax.name)

--- a/pandas/tseries/resample.py
+++ b/pandas/tseries/resample.py
@@ -1151,7 +1151,8 @@ class TimeGrouper(Grouper):
             return binner, [], labels
         
         tz = ax.tz
-        ax = ax.tz_convert('UTC')
+        if tz:
+            ax = ax.tz_convert('UTC')
         
         first, last = ax.min(), ax.max()
         first, last = _get_range_edges(first, last, self.freq,


### PR DESCRIPTION
 - [ ] closes https://github.com/pandas-dev/pandas/issues/15549
 - [ ] tests added / passed
 - [ ] passes ``git diff upstream/master | flake8 --diff``
 - [ ] whatsnew entry: resampling will now always produce bins alligned by UTC instead of custom time zone. so for example if you resampling by 12 hours frequency in UTC-5 timezone, you will get bins like
7:00 19:00 7:00 19:00
instead of 
00:00 12:00 00:00 12:00
