### PR TITLE
Subclassed reshape

### DIFF
--- a/doc/source/internals.rst
+++ b/doc/source/internals.rst
@@ -128,7 +128,7 @@ Property Attributes          ``Series``              ``DataFrame``       ``Panel
 ``_constructor_expanddim``   ``DataFrame``           ``Panel``           ``NotImplementedError``
 ===========================  ======================= =================== =======================
 
-Below example shows how to define ``SubclassedSeries`` and ``SubclassedDataFrame`` overriding constructor properties.
+The below example shows how to define ``SubclassedSeries`` and ``SubclassedDataFrame`` overriding constructor properties:
 
 .. code-block:: python
 
@@ -152,6 +152,8 @@ Below example shows how to define ``SubclassedSeries`` and ``SubclassedDataFrame
        def _constructor_sliced(self):
            return SubclassedSeries
 
+Overriding constructor properties allows subclass families to be preserved across slice and reshape operations:
+
 .. code-block:: python
 
    >>> s = SubclassedSeries([1, 2, 3])
@@ -162,7 +164,7 @@ Below example shows how to define ``SubclassedSeries`` and ``SubclassedDataFrame
    >>> type(to_framed)
    <class '__main__.SubclassedDataFrame'>
 
-   >>> df = SubclassedDataFrame({'A', [1, 2, 3], 'B': [4, 5, 6], 'C': [7, 8, 9]})
+   >>> df = SubclassedDataFrame({'A': [1, 2, 3], 'B': [4, 5, 6], 'C': [7, 8, 9]})
    >>> df
       A  B  C
    0  1  4  7
@@ -188,6 +190,21 @@ Below example shows how to define ``SubclassedSeries`` and ``SubclassedDataFrame
    2    3
    Name: A, dtype: int64
    >>> type(sliced2)
+   <class '__main__.SubclassedSeries'>
+
+   >>> stacked = df.stack()
+   >>> stacked
+   0  A    1
+      B    4
+      C    7
+   1  A    2
+      B    5
+      C    8
+   2  A    3
+      B    6
+      C    9
+   dtype: int64
+   >>> type(stacked)
    <class '__main__.SubclassedSeries'>
 
 Define Original Properties

--- a/doc/source/whatsnew/v0.20.0.txt
+++ b/doc/source/whatsnew/v0.20.0.txt
@@ -192,8 +192,8 @@ Other enhancements
 - HTML table output skips ``colspan`` or ``rowspan`` attribute if equal to 1. (:issue:`15403`)
 - ``pd.TimedeltaIndex`` now has a custom datetick formatter specifically designed for nanosecond level precision (:issue:`8711`)
 - ``pd.types.concat.union_categoricals`` gained the ``ignore_ordered`` argument to allow ignoring the ordered attribute of unioned categoricals (:issue:`13410`). See the :ref:`categorical union docs <categorical.union>` for more information.
-
 .. _ISO 8601 duration: https://en.wikipedia.org/wiki/ISO_8601#Durations
+- `stack`, `unstack`, and `pivot` operations now preserve subclass family (:issue:`15563`)
 
 
 .. _whatsnew_0200.api_breaking:

--- a/doc/source/whatsnew/v0.9.1.txt
+++ b/doc/source/whatsnew/v0.9.1.txt
@@ -105,6 +105,8 @@ New features
   - DataFrame.drop now supports non-unique indexes (:issue:`2101`)
   - Panel.shift now supports negative periods (:issue:`2164`)
   - DataFrame now support unary ~ operator (:issue:`2110`)
+  - `stack`, `unstack`, and `pivot` operations now preserve subclass family
+    (:issue:`15563`) 
 
 API changes
 ~~~~~~~~~~~

--- a/doc/source/whatsnew/v0.9.1.txt
+++ b/doc/source/whatsnew/v0.9.1.txt
@@ -105,8 +105,6 @@ New features
   - DataFrame.drop now supports non-unique indexes (:issue:`2101`)
   - Panel.shift now supports negative periods (:issue:`2164`)
   - DataFrame now support unary ~ operator (:issue:`2110`)
-  - `stack`, `unstack`, and `pivot` operations now preserve subclass family
-    (:issue:`15563`) 
 
 API changes
 ~~~~~~~~~~~

--- a/pandas/core/reshape.py
+++ b/pandas/core/reshape.py
@@ -333,7 +333,7 @@ def pivot(self, index=None, columns=None, values=None):
             index = self.index
         else:
             index = self[index]
-        indexed = Series(self[values].values,
+        indexed = self._constructor_sliced(self[values].values,
                          index=MultiIndex.from_arrays([index, self[columns]]))
         return indexed.unstack(columns)
 
@@ -665,7 +665,7 @@ def _stack_multi_columns(frame, level_num=-1, dropna=True):
     new_index = MultiIndex(levels=new_levels, labels=new_labels,
                            names=new_names, verify_integrity=False)
 
-    result = DataFrame(new_data, index=new_index, columns=new_columns)
+    result = frame._constructor(new_data, index=new_index, columns=new_columns)
 
     # more efficient way to go about this? can do the whole masking biz but
     # will only save a small amount of time...
@@ -825,7 +825,7 @@ def melt(frame, id_vars=None, value_vars=None, var_name=None,
         mdata[col] = np.asanyarray(frame.columns
                                    ._get_level_values(i)).repeat(N)
 
-    return DataFrame(mdata, columns=mcolumns)
+    return frame._constructor(mdata, columns=mcolumns)
 
 
 def lreshape(data, groups, dropna=True, label=None):
@@ -894,7 +894,7 @@ def lreshape(data, groups, dropna=True, label=None):
         if not mask.all():
             mdata = dict((k, v[mask]) for k, v in compat.iteritems(mdata))
 
-    return DataFrame(mdata, columns=id_cols + pivot_cols)
+    return data._constructor(mdata, columns=id_cols + pivot_cols)
 
 
 def wide_to_long(df, stubnames, i, j, sep="", suffix='\d+'):

--- a/pandas/core/reshape.py
+++ b/pandas/core/reshape.py
@@ -333,8 +333,11 @@ def pivot(self, index=None, columns=None, values=None):
             index = self.index
         else:
             index = self[index]
-        indexed = self._constructor_sliced(self[values].values,
-                         index=MultiIndex.from_arrays([index, self[columns]]))
+
+        indexed = self._constructor_sliced(
+            self[values].values,
+            index=MultiIndex.from_arrays([index, self[columns]]))
+
         return indexed.unstack(columns)
 
 

--- a/pandas/tests/frame/test_subclass.py
+++ b/pandas/tests/frame/test_subclass.py
@@ -4,7 +4,7 @@ from __future__ import print_function
 
 import numpy as np
 
-from pandas import DataFrame, Series, MultiIndex, Panel
+from pandas import DataFrame, Series, MultiIndex, Panel, Index
 import pandas as pd
 import pandas.util.testing as tm
 
@@ -145,10 +145,10 @@ class TestDataFrameSubclassing(tm.TestCase, TestData):
             [30, 31, 32, 33],
             [40, 41, 42, 43]],
             index=MultiIndex.from_tuples(
-                zip(list('AABB'), list('cdcd')),
+                list(zip(list('AABB'), list('cdcd'))),
                 names=['aaa', 'ccc']),
             columns=MultiIndex.from_tuples(
-                zip(list('WWXX'), list('yzyz')),
+                list(zip(list('WWXX'), list('yzyz'))),
                 names=['www', 'yyy']))
 
         exp = tm.SubclassedDataFrame([
@@ -161,10 +161,9 @@ class TestDataFrameSubclassing(tm.TestCase, TestData):
             [40, 42],
             [41, 43]],
             index=MultiIndex.from_tuples(
-                zip(list('AAAABBBB'), list('ccddccdd'), list('yzyzyzyz')),
+                list(zip(list('AAAABBBB'), list('ccddccdd'), list('yzyzyzyz'))),
                 names=['aaa', 'ccc', 'yyy']),
-            columns=MultiIndex.from_tuples(
-                zip(list('WX')), names=['www']))
+            columns=Index(['W', 'X'], name='www'))
 
         res = df.stack()
         tm.assert_frame_equal(res, exp)
@@ -183,11 +182,10 @@ class TestDataFrameSubclassing(tm.TestCase, TestData):
             [32, 33],
             [40, 41],
             [42, 43]],
-            index=MultiIndex.from_tuples(
-                zip(list('AAAABBBB'), list('ccddccdd'), list('WXWXWXWX')),
+            index=MultiIndex.from_tuples(list(zip(
+                    list('AAAABBBB'), list('ccddccdd'), list('WXWXWXWX'))),
                 names=['aaa', 'ccc', 'www']),
-            columns=MultiIndex.from_tuples(
-                zip(list('yz')), names=['yyy']))
+            columns=Index(['y', 'z'], name='yyy'))
 
         res = df.stack('www')
         tm.assert_frame_equal(res, exp)
@@ -213,19 +211,18 @@ class TestDataFrameSubclassing(tm.TestCase, TestData):
             [30, 31, 32, 33],
             [40, 41, 42, 43]],
             index=MultiIndex.from_tuples(
-                zip(list('AABB'), list('cdcd')),
+                list(zip(list('AABB'), list('cdcd'))),
                 names=['aaa', 'ccc']),
             columns=MultiIndex.from_tuples(
-                zip(list('WWXX'), list('yzyz')),
+                list(zip(list('WWXX'), list('yzyz'))),
                 names=['www', 'yyy']))
 
         exp = tm.SubclassedDataFrame([
             [10, 20, 11, 21, 12, 22, 13, 23],
             [30, 40, 31, 41, 32, 42, 33, 43]],
-            index=MultiIndex.from_tuples(
-                zip(list('AB')), names=['aaa']),
-            columns=MultiIndex.from_tuples(
-                zip(list('WWWWXXXX'), list('yyzzyyzz'), list('cdcdcdcd')),
+            index=Index(['A', 'B'], name='aaa'),
+            columns=MultiIndex.from_tuples(list(zip(
+                    list('WWWWXXXX'), list('yyzzyyzz'), list('cdcdcdcd'))),
                 names=['www', 'yyy', 'ccc']))
 
         res = df.unstack()
@@ -239,10 +236,9 @@ class TestDataFrameSubclassing(tm.TestCase, TestData):
         exp = tm.SubclassedDataFrame([
             [10, 30, 11, 31, 12, 32, 13, 33],
             [20, 40, 21, 41, 22, 42, 23, 43]],
-            index=MultiIndex.from_tuples(
-                zip(list('cd')), names=['ccc']),
-            columns=MultiIndex.from_tuples(
-                zip(list('WWWWXXXX'), list('yyzzyyzz'), list('ABABABAB')),
+            index=Index(['c', 'd'], name='ccc'),
+            columns=MultiIndex.from_tuples(list(zip(
+                    list('WWWWXXXX'), list('yyzzyyzz'), list('ABABABAB'))),
                 names=['www', 'yyy', 'aaa']))
 
         res = df.unstack('aaa')

--- a/pandas/tests/frame/test_subclass.py
+++ b/pandas/tests/frame/test_subclass.py
@@ -126,6 +126,7 @@ class TestDataFrameSubclassing(tm.TestCase, TestData):
         tm.assertIsInstance(res, tm.SubclassedSeries)
 
     def test_subclass_stack(self):
+        # GH 15564
         df = tm.SubclassedDataFrame([[1, 2, 3], [4, 5, 6], [7, 8, 9]],
                                     index=['a', 'b', 'c'],
                                     columns=['X', 'Y', 'Z'])
@@ -139,6 +140,7 @@ class TestDataFrameSubclassing(tm.TestCase, TestData):
         tm.assertIsInstance(res, tm.SubclassedSeries)
 
     def test_subclass_stack_multi(self):
+        # GH 15564
         df = tm.SubclassedDataFrame([
             [10, 11, 12, 13],
             [20, 21, 22, 23],
@@ -192,6 +194,7 @@ class TestDataFrameSubclassing(tm.TestCase, TestData):
         tm.assertIsInstance(res, tm.SubclassedDataFrame)
 
     def test_subclass_unstack(self):
+        # GH 15564
         df = tm.SubclassedDataFrame([[1, 2, 3], [4, 5, 6], [7, 8, 9]],
                                     index=['a', 'b', 'c'],
                                     columns=['X', 'Y', 'Z'])
@@ -205,6 +208,7 @@ class TestDataFrameSubclassing(tm.TestCase, TestData):
         tm.assertIsInstance(res, tm.SubclassedSeries)
 
     def test_subclass_unstack_multi(self):
+        # GH 15564
         df = tm.SubclassedDataFrame([
             [10, 11, 12, 13],
             [20, 21, 22, 23],
@@ -246,6 +250,7 @@ class TestDataFrameSubclassing(tm.TestCase, TestData):
         tm.assertIsInstance(res, tm.SubclassedDataFrame)
 
     def test_subclass_pivot(self):
+        # GH 15564
         df = tm.SubclassedDataFrame({
             'index': ['A', 'B', 'C', 'C', 'B', 'A'],
             'columns': ['One', 'One', 'One', 'Two', 'Two', 'Two'],

--- a/pandas/tests/frame/test_subclass.py
+++ b/pandas/tests/frame/test_subclass.py
@@ -160,8 +160,8 @@ class TestDataFrameSubclassing(tm.TestCase, TestData):
             [31, 33],
             [40, 42],
             [41, 43]],
-            index=MultiIndex.from_tuples(
-                list(zip(list('AAAABBBB'), list('ccddccdd'), list('yzyzyzyz'))),
+            index=MultiIndex.from_tuples(list(zip(
+                list('AAAABBBB'), list('ccddccdd'), list('yzyzyzyz'))),
                 names=['aaa', 'ccc', 'yyy']),
             columns=Index(['W', 'X'], name='www'))
 
@@ -183,7 +183,7 @@ class TestDataFrameSubclassing(tm.TestCase, TestData):
             [40, 41],
             [42, 43]],
             index=MultiIndex.from_tuples(list(zip(
-                    list('AAAABBBB'), list('ccddccdd'), list('WXWXWXWX'))),
+                list('AAAABBBB'), list('ccddccdd'), list('WXWXWXWX'))),
                 names=['aaa', 'ccc', 'www']),
             columns=Index(['y', 'z'], name='yyy'))
 
@@ -222,8 +222,8 @@ class TestDataFrameSubclassing(tm.TestCase, TestData):
             [30, 40, 31, 41, 32, 42, 33, 43]],
             index=Index(['A', 'B'], name='aaa'),
             columns=MultiIndex.from_tuples(list(zip(
-                    list('WWWWXXXX'), list('yyzzyyzz'), list('cdcdcdcd'))),
-                names=['www', 'yyy', 'ccc']))
+                list('WWWWXXXX'), list('yyzzyyzz'), list('cdcdcdcd'))),
+            names=['www', 'yyy', 'ccc']))
 
         res = df.unstack()
         tm.assert_frame_equal(res, exp)
@@ -238,7 +238,7 @@ class TestDataFrameSubclassing(tm.TestCase, TestData):
             [20, 40, 21, 41, 22, 42, 23, 43]],
             index=Index(['c', 'd'], name='ccc'),
             columns=MultiIndex.from_tuples(list(zip(
-                    list('WWWWXXXX'), list('yyzzyyzz'), list('ABABABAB'))),
+                list('WWWWXXXX'), list('yyzzyyzz'), list('ABABABAB'))),
                 names=['www', 'yyy', 'aaa']))
 
         res = df.unstack('aaa')

--- a/pandas/tests/frame/test_subclass.py
+++ b/pandas/tests/frame/test_subclass.py
@@ -125,6 +125,148 @@ class TestDataFrameSubclassing(tm.TestCase, TestData):
         tm.assert_series_equal(res, exp)
         tm.assertIsInstance(res, tm.SubclassedSeries)
 
+    def test_subclass_stack(self):
+        df = tm.SubclassedDataFrame([[1, 2, 3], [4, 5, 6], [7, 8, 9]],
+                                    index=['a', 'b', 'c'],
+                                    columns=['X', 'Y', 'Z'])
+
+        res = df.stack()
+        exp = tm.SubclassedSeries(
+            [1, 2, 3, 4, 5, 6, 7, 8, 9],
+            index=[list('aaabbbccc'), list('XYZXYZXYZ')])
+
+        tm.assert_series_equal(res, exp)
+        tm.assertIsInstance(res, tm.SubclassedSeries)
+
+    def test_subclass_stack_multi(self):
+        df = tm.SubclassedDataFrame([
+            [10, 11, 12, 13],
+            [20, 21, 22, 23],
+            [30, 31, 32, 33],
+            [40, 41, 42, 43]],
+            index=MultiIndex.from_tuples(
+                zip(list('AABB'), list('cdcd')),
+                names=['aaa', 'ccc']),
+            columns=MultiIndex.from_tuples(
+                zip(list('WWXX'), list('yzyz')),
+                names=['www', 'yyy']))
+
+        exp = tm.SubclassedDataFrame([
+            [10, 12],
+            [11, 13],
+            [20, 22],
+            [21, 23],
+            [30, 32],
+            [31, 33],
+            [40, 42],
+            [41, 43]],
+            index=MultiIndex.from_tuples(
+                zip(list('AAAABBBB'), list('ccddccdd'), list('yzyzyzyz')),
+                names=['aaa', 'ccc', 'yyy']),
+            columns=MultiIndex.from_tuples(
+                zip(list('WX')), names=['www']))
+
+        res = df.stack()
+        tm.assert_frame_equal(res, exp)
+        tm.assertIsInstance(res, tm.SubclassedDataFrame)
+
+        res = df.stack('yyy')
+        tm.assert_frame_equal(res, exp)
+        tm.assertIsInstance(res, tm.SubclassedDataFrame)
+
+        exp = tm.SubclassedDataFrame([
+            [10, 11],
+            [12, 13],
+            [20, 21],
+            [22, 23],
+            [30, 31],
+            [32, 33],
+            [40, 41],
+            [42, 43]],
+            index=MultiIndex.from_tuples(
+                zip(list('AAAABBBB'), list('ccddccdd'), list('WXWXWXWX')),
+                names=['aaa', 'ccc', 'www']),
+            columns=MultiIndex.from_tuples(
+                zip(list('yz')), names=['yyy']))
+
+        res = df.stack('www')
+        tm.assert_frame_equal(res, exp)
+        tm.assertIsInstance(res, tm.SubclassedDataFrame)
+
+    def test_subclass_unstack(self):
+        df = tm.SubclassedDataFrame([[1, 2, 3], [4, 5, 6], [7, 8, 9]],
+                                    index=['a', 'b', 'c'],
+                                    columns=['X', 'Y', 'Z'])
+
+        res = df.unstack()
+        exp = tm.SubclassedSeries(
+            [1, 4, 7, 2, 5, 8, 3, 6, 9],
+            index=[list('XXXYYYZZZ'), list('abcabcabc')])
+
+        tm.assert_series_equal(res, exp)
+        tm.assertIsInstance(res, tm.SubclassedSeries)
+
+    def test_subclass_unstack_multi(self):
+        df = tm.SubclassedDataFrame([
+            [10, 11, 12, 13],
+            [20, 21, 22, 23],
+            [30, 31, 32, 33],
+            [40, 41, 42, 43]],
+            index=MultiIndex.from_tuples(
+                zip(list('AABB'), list('cdcd')),
+                names=['aaa', 'ccc']),
+            columns=MultiIndex.from_tuples(
+                zip(list('WWXX'), list('yzyz')),
+                names=['www', 'yyy']))
+
+        exp = tm.SubclassedDataFrame([
+            [10, 20, 11, 21, 12, 22, 13, 23],
+            [30, 40, 31, 41, 32, 42, 33, 43]],
+            index=MultiIndex.from_tuples(
+                zip(list('AB')), names=['aaa']),
+            columns=MultiIndex.from_tuples(
+                zip(list('WWWWXXXX'), list('yyzzyyzz'), list('cdcdcdcd')),
+                names=['www', 'yyy', 'ccc']))
+
+        res = df.unstack()
+        tm.assert_frame_equal(res, exp)
+        tm.assertIsInstance(res, tm.SubclassedDataFrame)
+
+        res = df.unstack('ccc')
+        tm.assert_frame_equal(res, exp)
+        tm.assertIsInstance(res, tm.SubclassedDataFrame)
+
+        exp = tm.SubclassedDataFrame([
+            [10, 30, 11, 31, 12, 32, 13, 33],
+            [20, 40, 21, 41, 22, 42, 23, 43]],
+            index=MultiIndex.from_tuples(
+                zip(list('cd')), names=['ccc']),
+            columns=MultiIndex.from_tuples(
+                zip(list('WWWWXXXX'), list('yyzzyyzz'), list('ABABABAB')),
+                names=['www', 'yyy', 'aaa']))
+
+        res = df.unstack('aaa')
+        tm.assert_frame_equal(res, exp)
+        tm.assertIsInstance(res, tm.SubclassedDataFrame)
+
+    def test_subclass_pivot(self):
+        df = tm.SubclassedDataFrame({
+            'index': ['A', 'B', 'C', 'C', 'B', 'A'],
+            'columns': ['One', 'One', 'One', 'Two', 'Two', 'Two'],
+            'values': [1., 2., 3., 3., 2., 1.]})
+
+        pivoted = df.pivot(
+            index='index', columns='columns', values='values')
+
+        expected = tm.SubclassedDataFrame({
+            'One': {'A': 1., 'B': 2., 'C': 3.},
+            'Two': {'A': 1., 'B': 2., 'C': 3.}})
+
+        expected.index.name, expected.columns.name = 'index', 'columns'
+
+        tm.assert_frame_equal(pivoted, expected)
+        tm.assertIsInstance(pivoted, tm.SubclassedDataFrame)
+
     def test_to_panel_expanddim(self):
         # GH 9762
 

--- a/pandas/tests/frame/test_subclass.py
+++ b/pandas/tests/frame/test_subclass.py
@@ -126,7 +126,10 @@ class TestDataFrameSubclassing(tm.TestCase, TestData):
         tm.assertIsInstance(res, tm.SubclassedSeries)
 
     def test_subclass_stack(self):
+<<<<<<< HEAD
         # GH 15564
+=======
+>>>>>>> bug fix; test stack, unstack, pivot for series and df with Index, MultiIndex
         df = tm.SubclassedDataFrame([[1, 2, 3], [4, 5, 6], [7, 8, 9]],
                                     index=['a', 'b', 'c'],
                                     columns=['X', 'Y', 'Z'])
@@ -140,17 +143,27 @@ class TestDataFrameSubclassing(tm.TestCase, TestData):
         tm.assertIsInstance(res, tm.SubclassedSeries)
 
     def test_subclass_stack_multi(self):
+<<<<<<< HEAD
         # GH 15564
+=======
+>>>>>>> bug fix; test stack, unstack, pivot for series and df with Index, MultiIndex
         df = tm.SubclassedDataFrame([
             [10, 11, 12, 13],
             [20, 21, 22, 23],
             [30, 31, 32, 33],
             [40, 41, 42, 43]],
             index=MultiIndex.from_tuples(
+<<<<<<< HEAD
                 list(zip(list('AABB'), list('cdcd'))),
                 names=['aaa', 'ccc']),
             columns=MultiIndex.from_tuples(
                 list(zip(list('WWXX'), list('yzyz'))),
+=======
+                zip(list('AABB'), list('cdcd')),
+                names=['aaa', 'ccc']),
+            columns=MultiIndex.from_tuples(
+                zip(list('WWXX'), list('yzyz')),
+>>>>>>> bug fix; test stack, unstack, pivot for series and df with Index, MultiIndex
                 names=['www', 'yyy']))
 
         exp = tm.SubclassedDataFrame([
@@ -162,10 +175,18 @@ class TestDataFrameSubclassing(tm.TestCase, TestData):
             [31, 33],
             [40, 42],
             [41, 43]],
+<<<<<<< HEAD
             index=MultiIndex.from_tuples(list(zip(
                 list('AAAABBBB'), list('ccddccdd'), list('yzyzyzyz'))),
                 names=['aaa', 'ccc', 'yyy']),
             columns=Index(['W', 'X'], name='www'))
+=======
+            index=MultiIndex.from_tuples(
+                zip(list('AAAABBBB'), list('ccddccdd'), list('yzyzyzyz')),
+                names=['aaa', 'ccc', 'yyy']),
+            columns=MultiIndex.from_tuples(
+                zip(list('WX')), names=['www']))
+>>>>>>> bug fix; test stack, unstack, pivot for series and df with Index, MultiIndex
 
         res = df.stack()
         tm.assert_frame_equal(res, exp)
@@ -184,17 +205,28 @@ class TestDataFrameSubclassing(tm.TestCase, TestData):
             [32, 33],
             [40, 41],
             [42, 43]],
+<<<<<<< HEAD
             index=MultiIndex.from_tuples(list(zip(
                 list('AAAABBBB'), list('ccddccdd'), list('WXWXWXWX'))),
                 names=['aaa', 'ccc', 'www']),
             columns=Index(['y', 'z'], name='yyy'))
+=======
+            index=MultiIndex.from_tuples(
+                zip(list('AAAABBBB'), list('ccddccdd'), list('WXWXWXWX')),
+                names=['aaa', 'ccc', 'www']),
+            columns=MultiIndex.from_tuples(
+                zip(list('yz')), names=['yyy']))
+>>>>>>> bug fix; test stack, unstack, pivot for series and df with Index, MultiIndex
 
         res = df.stack('www')
         tm.assert_frame_equal(res, exp)
         tm.assertIsInstance(res, tm.SubclassedDataFrame)
 
     def test_subclass_unstack(self):
+<<<<<<< HEAD
         # GH 15564
+=======
+>>>>>>> bug fix; test stack, unstack, pivot for series and df with Index, MultiIndex
         df = tm.SubclassedDataFrame([[1, 2, 3], [4, 5, 6], [7, 8, 9]],
                                     index=['a', 'b', 'c'],
                                     columns=['X', 'Y', 'Z'])
@@ -208,26 +240,44 @@ class TestDataFrameSubclassing(tm.TestCase, TestData):
         tm.assertIsInstance(res, tm.SubclassedSeries)
 
     def test_subclass_unstack_multi(self):
+<<<<<<< HEAD
         # GH 15564
+=======
+>>>>>>> bug fix; test stack, unstack, pivot for series and df with Index, MultiIndex
         df = tm.SubclassedDataFrame([
             [10, 11, 12, 13],
             [20, 21, 22, 23],
             [30, 31, 32, 33],
             [40, 41, 42, 43]],
             index=MultiIndex.from_tuples(
+<<<<<<< HEAD
                 list(zip(list('AABB'), list('cdcd'))),
                 names=['aaa', 'ccc']),
             columns=MultiIndex.from_tuples(
                 list(zip(list('WWXX'), list('yzyz'))),
+=======
+                zip(list('AABB'), list('cdcd')),
+                names=['aaa', 'ccc']),
+            columns=MultiIndex.from_tuples(
+                zip(list('WWXX'), list('yzyz')),
+>>>>>>> bug fix; test stack, unstack, pivot for series and df with Index, MultiIndex
                 names=['www', 'yyy']))
 
         exp = tm.SubclassedDataFrame([
             [10, 20, 11, 21, 12, 22, 13, 23],
             [30, 40, 31, 41, 32, 42, 33, 43]],
+<<<<<<< HEAD
             index=Index(['A', 'B'], name='aaa'),
             columns=MultiIndex.from_tuples(list(zip(
                 list('WWWWXXXX'), list('yyzzyyzz'), list('cdcdcdcd'))),
             names=['www', 'yyy', 'ccc']))
+=======
+            index=MultiIndex.from_tuples(
+                zip(list('AB')), names=['aaa']),
+            columns=MultiIndex.from_tuples(
+                zip(list('WWWWXXXX'), list('yyzzyyzz'), list('cdcdcdcd')),
+                names=['www', 'yyy', 'ccc']))
+>>>>>>> bug fix; test stack, unstack, pivot for series and df with Index, MultiIndex
 
         res = df.unstack()
         tm.assert_frame_equal(res, exp)
@@ -240,9 +290,16 @@ class TestDataFrameSubclassing(tm.TestCase, TestData):
         exp = tm.SubclassedDataFrame([
             [10, 30, 11, 31, 12, 32, 13, 33],
             [20, 40, 21, 41, 22, 42, 23, 43]],
+<<<<<<< HEAD
             index=Index(['c', 'd'], name='ccc'),
             columns=MultiIndex.from_tuples(list(zip(
                 list('WWWWXXXX'), list('yyzzyyzz'), list('ABABABAB'))),
+=======
+            index=MultiIndex.from_tuples(
+                zip(list('cd')), names=['ccc']),
+            columns=MultiIndex.from_tuples(
+                zip(list('WWWWXXXX'), list('yyzzyyzz'), list('ABABABAB')),
+>>>>>>> bug fix; test stack, unstack, pivot for series and df with Index, MultiIndex
                 names=['www', 'yyy', 'aaa']))
 
         res = df.unstack('aaa')
@@ -250,7 +307,10 @@ class TestDataFrameSubclassing(tm.TestCase, TestData):
         tm.assertIsInstance(res, tm.SubclassedDataFrame)
 
     def test_subclass_pivot(self):
+<<<<<<< HEAD
         # GH 15564
+=======
+>>>>>>> bug fix; test stack, unstack, pivot for series and df with Index, MultiIndex
         df = tm.SubclassedDataFrame({
             'index': ['A', 'B', 'C', 'C', 'B', 'A'],
             'columns': ['One', 'One', 'One', 'Two', 'Two', 'Two'],

--- a/pandas/tests/series/test_subclass.py
+++ b/pandas/tests/series/test_subclass.py
@@ -33,6 +33,7 @@ class TestSeriesSubclassing(tm.TestCase):
         tm.assertIsInstance(res, tm.SubclassedDataFrame)
 
     def test_subclass_unstack(self):
+        # GH 15564
         s = tm.SubclassedSeries(
             [1, 2, 3, 4], index=[list('aabb'), list('xyxy')])
 
@@ -87,6 +88,7 @@ class TestSparseSeriesSubclassing(tm.TestCase):
         tm.assert_sp_series_equal(s1 + s2, exp)
 
     def test_subclass_sparse_to_frame(self):
+        # GH 15564
         s = tm.SubclassedSparseSeries([1, 2], index=list('abcd'), name='xxx')
         res = s.to_frame()
 

--- a/pandas/tests/series/test_subclass.py
+++ b/pandas/tests/series/test_subclass.py
@@ -32,6 +32,17 @@ class TestSeriesSubclassing(tm.TestCase):
         tm.assert_frame_equal(res, exp)
         tm.assertIsInstance(res, tm.SubclassedDataFrame)
 
+    def test_subclass_unstack(self):
+        s = tm.SubclassedSeries(
+            [1, 2, 3, 4], index=[list('aabb'), list('xyxy')])
+
+        res = s.unstack()
+        exp = tm.SubclassedDataFrame(
+            {'x': [1, 3], 'y': [2, 4]}, index=['a', 'b'])
+
+        tm.assert_frame_equal(res, exp)
+        tm.assertIsInstance(res, tm.SubclassedDataFrame)
+
 
 class TestSparseSeriesSubclassing(tm.TestCase):
 


### PR DESCRIPTION
 - [x] closes #15563
 - [x] tests added / passed
 - [x] passes ``git diff upstream/master | flake8 --diff``
 - [x] whatsnew entry

Reshape operations in pandas/core/reshape.py modified to use `obj._constructor`, `obj._constructor_sliced`, and `obj._constructor_expanddim` for Series and DataFrame. This preserves a subclass family on `stack`, `unstack`, and `pivot` operations.