### PR TITLE
DEPR/CLN: remove SparseTimeSeries class (follow-up GH15098)

### DIFF
--- a/doc/source/whatsnew/v0.20.0.txt
+++ b/doc/source/whatsnew/v0.20.0.txt
@@ -585,6 +585,8 @@ Removal of prior version deprecations/changes
   Similar functionality can be found in the `Google2Pandas <https://github.com/panalysis/Google2Pandas>`__ package.
 - ``pd.to_datetime`` and ``pd.to_timedelta`` have dropped the ``coerce`` parameter in favor of ``errors`` (:issue:`13602`)
 - ``pandas.stats.fama_macbeth``, ``pandas.stats.ols``, ``pandas.stats.plm`` and ``pandas.stats.var``, as well as the top-level ``pandas.fama_macbeth`` and ``pandas.ols`` routines are removed. Similar functionaility can be found in the `statsmodels <shttp://www.statsmodels.org/dev/>`__ package. (:issue:`11898`)
+- The ``TimeSeries`` and ``SparseTimeSeries`` classes, aliases of ``Series``
+  and ``SparseSeries``, are removed (:issue:`10890`, :issue:`15098`).
 - ``Series.is_time_series`` is dropped in favor of ``Series.index.is_all_dates`` (:issue:``)
 - The deprecated ``irow``, ``icol``, ``iget`` and ``iget_value`` methods are removed
   in favor of ``iloc`` and ``iat`` as explained :ref:`here <whatsnew_0170.deprecations>` (:issue:`10711`).

--- a/pandas/compat/pickle_compat.py
+++ b/pandas/compat/pickle_compat.py
@@ -61,7 +61,8 @@ _class_locations_map = {
     ('pandas.core.base', 'FrozenList'): ('pandas.indexes.frozen', 'FrozenList'),
 
     # 10890
-    ('pandas.core.series', 'TimeSeries'): ('pandas.core.series', 'Series')
+    ('pandas.core.series', 'TimeSeries'): ('pandas.core.series', 'Series'),
+    ('pandas.sparse.series', 'SparseTimeSeries'): ('pandas.sparse.series', 'SparseSeries')
     }
 
 

--- a/pandas/sparse/api.py
+++ b/pandas/sparse/api.py
@@ -2,5 +2,5 @@
 # flake8: noqa
 from pandas.sparse.array import SparseArray
 from pandas.sparse.list import SparseList
-from pandas.sparse.series import SparseSeries, SparseTimeSeries
+from pandas.sparse.series import SparseSeries
 from pandas.sparse.frame import SparseDataFrame

--- a/pandas/sparse/series.py
+++ b/pandas/sparse/series.py
@@ -844,14 +844,3 @@ ops.add_special_arithmetic_methods(SparseSeries, _arith_method,
                                    comp_method=_arith_method,
                                    bool_method=None, use_numexpr=False,
                                    force=True)
-
-
-# backwards compatiblity
-class SparseTimeSeries(SparseSeries):
-
-    def __init__(self, *args, **kwargs):
-        # deprecation TimeSeries, #10890
-        warnings.warn("SparseTimeSeries is deprecated. Please use "
-                      "SparseSeries", FutureWarning, stacklevel=2)
-
-        super(SparseTimeSeries, self).__init__(*args, **kwargs)

--- a/pandas/tests/api/test_api.py
+++ b/pandas/tests/api/test_api.py
@@ -57,8 +57,7 @@ class TestPDApi(Base, tm.TestCase):
                'TimedeltaIndex', 'Timestamp']
 
     # these are already deprecated; awaiting removal
-    deprecated_classes = ['WidePanel',
-                          'SparseTimeSeries', 'Panel4D',
+    deprecated_classes = ['WidePanel', 'Panel4D',
                           'SparseList', 'Expr', 'Term']
 
     # these should be deprecated in the future

--- a/pandas/tests/sparse/test_series.py
+++ b/pandas/tests/sparse/test_series.py
@@ -112,12 +112,6 @@ class TestSparseSeries(tm.TestCase, SharedWithSparse):
         [x for x in self.bseries]
         str(self.bseries)
 
-    def test_TimeSeries_deprecation(self):
-
-        # deprecation TimeSeries, #10890
-        with tm.assert_produces_warning(FutureWarning):
-            pd.SparseTimeSeries(1, index=pd.date_range('20130101', periods=3))
-
     def test_construct_DataFrame_with_sp_series(self):
         # it works!
         df = DataFrame({'col': self.bseries})


### PR DESCRIPTION
#15098 removed the TimeSeries alias, but we also deprecated SparseTimeSeries (#10890), so this makes the removal complete.