### PR TITLE
BUG:Floating point accuracy with DatetimeIndex.round (#14440)

### DIFF
--- a/doc/source/whatsnew/v0.20.0.txt
+++ b/doc/source/whatsnew/v0.20.0.txt
@@ -651,6 +651,7 @@ Bug Fixes
 - Bug in ``Index`` power operations with reversed operands (:issue:`14973`)
 - Bug in ``TimedeltaIndex`` addition where overflow was being allowed without error (:issue:`14816`)
 - Bug in ``TimedeltaIndex`` raising a ``ValueError`` when boolean indexing with ``loc`` (:issue:`14946`)
+- Bug in ``DatetimeIndex.round()`` and ``Timestamp.round()`` floating point accuracy when rounding by milliseconds (:issue: `14440`)
 - Bug in ``astype()`` where ``inf`` values were incorrectly converted to integers. Now raises error now with ``astype()`` for Series and DataFrames (:issue:`14265`)
 - Bug in ``DataFrame(..).apply(to_numeric)`` when values are of type decimal.Decimal. (:issue:`14827`)
 - Bug in ``describe()`` when passing a numpy array which does not contain the median to the ``percentiles`` keyword argument (:issue:`14908`)

--- a/pandas/tests/indexes/datetimes/test_ops.py
+++ b/pandas/tests/indexes/datetimes/test_ops.py
@@ -175,6 +175,17 @@ class TestDatetimeIndexOps(Ops):
             tm.assertRaisesRegexp(ValueError, msg, rng.round, freq='M')
             tm.assertRaisesRegexp(ValueError, msg, elt.round, freq='M')
 
+            # GH 14440
+            index = pd.DatetimeIndex(['2016-10-17 12:00:00.0015'], tz=tz)
+            result = index.round('ms')
+            expected = pd.DatetimeIndex(['2016-10-17 12:00:00.002000'], tz=tz)
+            tm.assert_index_equal(result, expected)
+
+            index = pd.DatetimeIndex(['2016-10-17 12:00:00.00149'], tz=tz)
+            result = index.round('ms')
+            expected = pd.DatetimeIndex(['2016-10-17 12:00:00.001000'], tz=tz)
+            tm.assert_index_equal(result, expected)
+
     def test_repeat_range(self):
         rng = date_range('1/1/2000', '1/1/2001')
 

--- a/pandas/tests/scalar/test_timestamp.py
+++ b/pandas/tests/scalar/test_timestamp.py
@@ -732,6 +732,15 @@ class TestTimestamp(tm.TestCase):
         for freq in ['Y', 'M', 'foobar']:
             self.assertRaises(ValueError, lambda: dti.round(freq))
 
+        # GH 14440
+        result = pd.Timestamp('2016-10-17 12:00:00.0015').round('ms')
+        expected = pd.Timestamp('2016-10-17 12:00:00.002000')
+        self.assertEqual(result, expected)
+
+        result = pd.Timestamp('2016-10-17 12:00:00.00149').round('ms')
+        expected = pd.Timestamp('2016-10-17 12:00:00.001000')
+        self.assertEqual(result, expected)
+
     def test_class_ops_pytz(self):
         tm._skip_if_no_pytz()
         from pytz import timezone

--- a/pandas/tseries/base.py
+++ b/pandas/tseries/base.py
@@ -83,7 +83,7 @@ class TimelikeOps(object):
         # round the local times
         values = _ensure_datetimelike_to_i8(self)
 
-        result = (unit * rounder(values / float(unit))).astype('i8')
+        result = (unit * rounder(values / float(unit)).astype('i8'))
         result = self._maybe_mask_results(result, fill_value=tslib.NaT)
         attribs = self._get_attributes_dict()
         if 'freq' in attribs:

--- a/pandas/tslib.pyx
+++ b/pandas/tslib.pyx
@@ -421,7 +421,8 @@ class Timestamp(_Timestamp):
             value = self.tz_localize(None).value
         else:
             value = self.value
-        result = Timestamp(unit * rounder(value / float(unit)), unit='ns')
+        result = (unit * rounder(value / float(unit)).astype('i8'))
+        result = Timestamp(result, unit='ns')
         if self.tz is not None:
             result = result.tz_localize(self.tz)
         return result


### PR DESCRIPTION
 - [x] closes #14440
 - [x] tests added / passed
 - [x] passes ``git diff upstream/master | flake8 --diff``
 - [x] whatsnew entry

Employs @eoincondron's fix for float point inaccuracies when rounding by milliseconds for `DatetimeIndex.round` and `Timestamp.round`  