### PR TITLE
BUG: DataFrame.isin empty datetimelike

### DIFF
--- a/doc/source/whatsnew/v0.20.0.txt
+++ b/doc/source/whatsnew/v0.20.0.txt
@@ -676,7 +676,7 @@ Bug Fixes
 - Bug in ``pd.read_msgpack()`` in which ``Series`` categoricals were being improperly processed (:issue:`14901`)
 - Bug in ``Series.ffill()`` with mixed dtypes containing tz-aware datetimes. (:issue:`14956`)
 
-
+- Bug in ``DataFrame.isin`` comparing datetimelike to empty frame (:issue:`15473`)
 
 - Bug in ``Series.where()`` and ``DataFrame.where()`` where array-like conditionals were being rejected (:issue:`15414`)
 - Bug in ``Series`` construction with a datetimetz (:issue:`14928`)

--- a/pandas/core/ops.py
+++ b/pandas/core/ops.py
@@ -1249,7 +1249,7 @@ def _flex_comp_method_FRAME(op, name, str_rep=None, default_axis='columns',
             result = op(x, y)
         except TypeError:
             xrav = x.ravel()
-            result = np.empty(x.size, dtype=x.dtype)
+            result = np.empty(x.size, dtype=bool)
             if isinstance(y, (np.ndarray, ABCSeries)):
                 yrav = y.ravel()
                 mask = notnull(xrav) & notnull(yrav)

--- a/pandas/tests/frame/test_analytics.py
+++ b/pandas/tests/frame/test_analytics.py
@@ -1502,6 +1502,27 @@ class TestDataFrameAnalytics(tm.TestCase, TestData):
         result = df1.isin(df2)
         tm.assert_frame_equal(result, expected)
 
+    def test_isin_empty_datetimelike(self):
+        # GH 15473
+        df1_ts = DataFrame({'date':
+                            pd.to_datetime(['2014-01-01', '2014-01-02'])})
+        df1_td = DataFrame({'date':
+                            [pd.Timedelta(1, 's'), pd.Timedelta(2, 's')]})
+        df2 = DataFrame({'date': []})
+        df3 = DataFrame()
+
+        expected = DataFrame({'date': [False, False]})
+
+        result = df1_ts.isin(df2)
+        tm.assert_frame_equal(result, expected)
+        result = df1_ts.isin(df3)
+        tm.assert_frame_equal(result, expected)
+
+        result = df1_td.isin(df2)
+        tm.assert_frame_equal(result, expected)
+        result = df1_td.isin(df3)
+        tm.assert_frame_equal(result, expected)
+
     # ----------------------------------------------------------------------
     # Row deduplication
 


### PR DESCRIPTION
 - [x] closes #15473
 - [x] tests added / passed
 - [x] passes ``git diff upstream/master | flake8 --diff``
 - [x] whatsnew entry
