### PR TITLE
DOC: reset table_schema option after example

### DIFF
--- a/doc/source/options.rst
+++ b/doc/source/options.rst
@@ -533,3 +533,9 @@ by default. False by default, this can be enabled globally with the
   pd.set_option('display.html.table_schema', True)
 
 Only ``'display.max_rows'`` are serialized and published.
+
+
+.. ipython:: python
+    :suppress:
+
+    pd.reset_option('display.html.table_schema')


### PR DESCRIPTION
@jreback I think this should fix the errors you noticed here https://github.com/pandas-dev/pandas/issues/15559#issuecomment-284166380 (let's see if travis agrees with me)

The table schema repr was activated due to the example (the ipython environment lives on between different documents; it would actually be a good idea to completely reset them for each rst file)

cc @TomAugspurger in any case an example that it's not yet ready to be default on True :-) 