### PR TITLE
ENH: Allow parameters method and min_periods in DataFrame.corrwith() 

### DIFF
--- a/doc/source/computation.rst
+++ b/doc/source/computation.rst
@@ -157,6 +157,7 @@ objects.
    df2 = pd.DataFrame(np.random.randn(4, 4), index=index[:4], columns=columns)
    df1.corrwith(df2)
    df2.corrwith(df1, axis=1)
+   df2.corrwith(df1, axis=1, method='kendall')
 
 .. _computation.ranking:
 

--- a/doc/source/whatsnew/v0.20.0.txt
+++ b/doc/source/whatsnew/v0.20.0.txt
@@ -227,6 +227,7 @@ Other enhancements
 - ``pd.TimedeltaIndex`` now has a custom datetick formatter specifically designed for nanosecond level precision (:issue:`8711`)
 - ``pd.types.concat.union_categoricals`` gained the ``ignore_ordered`` argument to allow ignoring the ordered attribute of unioned categoricals (:issue:`13410`). See the :ref:`categorical union docs <categorical.union>` for more information.
 - ``pandas.io.json.json_normalize()`` with an empty ``list`` will return an empty ``DataFrame`` (:issue:`15534`)
+- ``pd.DataFrame.corrwith()`` now accepts ``method`` and ``min_periods`` as optional arguments, as in pd.DataFrame.corr() and pd.Series.corr() (:issue:`9490`)
 
 .. _ISO 8601 duration: https://en.wikipedia.org/wiki/ISO_8601#Durations
 

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -4819,7 +4819,8 @@ class DataFrame(NDFrame):
 
         return self._constructor(baseCov, index=idx, columns=cols)
 
-    def corrwith(self, other, axis=0, drop=False):
+    def corrwith(self, other, axis=0, drop=False, method='pearson',
+                 min_periods=1):
         """
         Compute pairwise correlation between rows or columns of two DataFrame
         objects.
@@ -4831,6 +4832,17 @@ class DataFrame(NDFrame):
             0 or 'index' to compute column-wise, 1 or 'columns' for row-wise
         drop : boolean, default False
             Drop missing indices from result, default returns union of all
+        method : {'pearson', 'kendall', 'spearman'}
+            * pearson : standard correlation coefficient
+            * kendall : Kendall Tau correlation coefficient
+            * spearman : Spearman rank correlation
+
+            .. versionadded:: 0.20.0
+
+        min_periods : int, optional
+            Minimum number of observations needed to have a valid result
+
+            .. versionadded:: 0.20.0
 
         Returns
         -------
@@ -4838,29 +4850,23 @@ class DataFrame(NDFrame):
         """
         axis = self._get_axis_number(axis)
         if isinstance(other, Series):
-            return self.apply(other.corr, axis=axis)
+            return self.apply(other.corr, axis=axis,
+                              method=method, min_periods=min_periods)
 
         this = self._get_numeric_data()
         other = other._get_numeric_data()
 
         left, right = this.align(other, join='inner', copy=False)
 
-        # mask missing values
-        left = left + right * 0
-        right = right + left * 0
-
         if axis == 1:
             left = left.T
             right = right.T
 
-        # demeaned data
-        ldem = left - left.mean()
-        rdem = right - right.mean()
-
-        num = (ldem * rdem).sum()
-        dom = (left.count() - 1) * left.std() * right.std()
-
-        correl = num / dom
+        correl = Series({col: nanops.nancorr(left[col].values,
+                                             right[col].values,
+                                             method=method,
+                                             min_periods=min_periods)
+                         for col in left.columns})
 
         if not drop:
             raxis = 1 if axis == 0 else 0


### PR DESCRIPTION
Added new keyword parameters for `DataFrame.corrwith()`, which allows methods other than Pearson to be used. See #9490.

 - [x] closes #9490
 - [x] tests added / passed
 - [x] passes ``git diff upstream/master | flake8 --diff``
 - [x] whatsnew entry
