### PR TITLE
BUG: Timestamp.round precision error for ns (#15578)

### DIFF
--- a/doc/source/whatsnew/v0.20.0.txt
+++ b/doc/source/whatsnew/v0.20.0.txt
@@ -652,7 +652,7 @@ Bug Fixes
 - Bug in ``Index`` power operations with reversed operands (:issue:`14973`)
 - Bug in ``TimedeltaIndex`` addition where overflow was being allowed without error (:issue:`14816`)
 - Bug in ``TimedeltaIndex`` raising a ``ValueError`` when boolean indexing with ``loc`` (:issue:`14946`)
-- Bug in ``DatetimeIndex.round()`` and ``Timestamp.round()`` floating point accuracy when rounding by milliseconds (:issue: `14440`)
+- Bug in ``DatetimeIndex.round()`` and ``Timestamp.round()`` floating point accuracy when rounding by milliseconds or less (:issue: `14440`, :issue:`15578`)
 - Bug in ``astype()`` where ``inf`` values were incorrectly converted to integers. Now raises error now with ``astype()`` for Series and DataFrames (:issue:`14265`)
 - Bug in ``DataFrame(..).apply(to_numeric)`` when values are of type decimal.Decimal. (:issue:`14827`)
 - Bug in ``describe()`` when passing a numpy array which does not contain the median to the ``percentiles`` keyword argument (:issue:`14908`)

--- a/pandas/tests/indexes/datetimes/test_ops.py
+++ b/pandas/tests/indexes/datetimes/test_ops.py
@@ -175,16 +175,28 @@ class TestDatetimeIndexOps(Ops):
             tm.assertRaisesRegexp(ValueError, msg, rng.round, freq='M')
             tm.assertRaisesRegexp(ValueError, msg, elt.round, freq='M')
 
-            # GH 14440
+            # GH 14440 & 15578
             index = pd.DatetimeIndex(['2016-10-17 12:00:00.0015'], tz=tz)
             result = index.round('ms')
             expected = pd.DatetimeIndex(['2016-10-17 12:00:00.002000'], tz=tz)
             tm.assert_index_equal(result, expected)
 
+            for freq in ['us', 'ns']:
+                tm.assert_index_equal(index, index.round(freq))
+
             index = pd.DatetimeIndex(['2016-10-17 12:00:00.00149'], tz=tz)
             result = index.round('ms')
             expected = pd.DatetimeIndex(['2016-10-17 12:00:00.001000'], tz=tz)
             tm.assert_index_equal(result, expected)
+
+            index = pd.DatetimeIndex(['2016-10-17 12:00:00.001501031'])
+            result = index.round('10ns')
+            expected = pd.DatetimeIndex(['2016-10-17 12:00:00.001501030'])
+            tm.assert_index_equal(result, expected)
+
+            with tm.assert_produces_warning():
+                ts = '2016-10-17 12:00:00.001501031'
+                pd.DatetimeIndex([ts]).round('1010ns')
 
     def test_repeat_range(self):
         rng = date_range('1/1/2000', '1/1/2001')

--- a/pandas/tests/scalar/test_timestamp.py
+++ b/pandas/tests/scalar/test_timestamp.py
@@ -732,7 +732,7 @@ class TestTimestamp(tm.TestCase):
         for freq in ['Y', 'M', 'foobar']:
             self.assertRaises(ValueError, lambda: dti.round(freq))
 
-        # GH 14440
+        # GH 14440 & 15578
         result = pd.Timestamp('2016-10-17 12:00:00.0015').round('ms')
         expected = pd.Timestamp('2016-10-17 12:00:00.002000')
         self.assertEqual(result, expected)
@@ -740,6 +740,17 @@ class TestTimestamp(tm.TestCase):
         result = pd.Timestamp('2016-10-17 12:00:00.00149').round('ms')
         expected = pd.Timestamp('2016-10-17 12:00:00.001000')
         self.assertEqual(result, expected)
+
+        ts = pd.Timestamp('2016-10-17 12:00:00.0015')
+        for freq in ['us', 'ns']:
+            self.assertEqual(ts, ts.round(freq))
+
+        result = pd.Timestamp('2016-10-17 12:00:00.001501031').round('10ns')
+        expected = pd.Timestamp('2016-10-17 12:00:00.001501030')
+        self.assertEqual(result, expected)
+
+        with tm.assert_produces_warning():
+            pd.Timestamp('2016-10-17 12:00:00.001501031').round('1010ns')
 
     def test_class_ops_pytz(self):
         tm._skip_if_no_pytz()


### PR DESCRIPTION
 - [x] closes #15578
 - [x] tests added / passed
 - [x] passes ``git diff upstream/master | flake8 --diff``

Nice trick @jreback! `round()` patched for `DatetimeIndex` and `Timestamp` when rounding by ns. 