### PR TITLE
API: return Index instead of array from DatetimeIndex field accessors (GH15022)

### DIFF
--- a/doc/source/whatsnew/v0.20.0.txt
+++ b/doc/source/whatsnew/v0.20.0.txt
@@ -471,6 +471,36 @@ New Behavior:
 
    s.map(lambda x: x.hour)
 
+
+Accessing datetime fields of Index now return Index
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The several datetime-related attributes (see :ref:`here <timeseries.components>`
+for an overview) of DatetimeIndex, PeriodIndex and TimedeltaIndex previously
+returned numpy arrays, now they will return a new Index object (:issue:`15022`).
+
+Previous behaviour:
+
+.. code-block:: ipython
+
+    In [1]: idx = pd.date_range("2015-01-01", periods=5, freq='10H')
+
+    In [2]: idx.hour
+    Out[2]: array([ 0, 10, 20,  6, 16], dtype=int32)
+
+New Behavior:
+
+.. ipython:: python
+
+    idx = pd.date_range("2015-01-01", periods=5, freq='10H')
+    idx.hour
+
+This has the advantage that specific Index methods are still available on the
+result. On the other hand, this might have backward incompatibilities: e.g.
+compared to numpy arrays, Index objects are not mutable (values cannot be set
+by indexing). To get the original result, you can convert to a nunpy array
+explicitly using ``np.asarray(idx.hour)``.
+
 .. _whatsnew_0200.api_breaking.s3:
 
 S3 File Handling

--- a/doc/source/whatsnew/v0.20.0.txt
+++ b/doc/source/whatsnew/v0.20.0.txt
@@ -478,6 +478,8 @@ Accessing datetime fields of Index now return Index
 The several datetime-related attributes (see :ref:`here <timeseries.components>`
 for an overview) of DatetimeIndex, PeriodIndex and TimedeltaIndex previously
 returned numpy arrays, now they will return a new Index object (:issue:`15022`).
+Only in case of a boolean field, still a boolean array is returned to support
+boolean indexing.
 
 Previous behaviour:
 
@@ -498,7 +500,7 @@ New Behavior:
 This has the advantage that specific Index methods are still available on the
 result. On the other hand, this might have backward incompatibilities: e.g.
 compared to numpy arrays, Index objects are not mutable (values cannot be set
-by indexing). To get the original result, you can convert to a nunpy array
+by indexing). To get the original result, you can convert to a numpy array
 explicitly using ``np.asarray(idx.hour)``.
 
 .. _whatsnew_0200.api_breaking.s3:

--- a/doc/source/whatsnew/v0.20.0.txt
+++ b/doc/source/whatsnew/v0.20.0.txt
@@ -472,14 +472,16 @@ New Behavior:
    s.map(lambda x: x.hour)
 
 
+.. _whatsnew_0200.api_breaking.index_dt_field:
+
 Accessing datetime fields of Index now return Index
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 The several datetime-related attributes (see :ref:`here <timeseries.components>`
-for an overview) of DatetimeIndex, PeriodIndex and TimedeltaIndex previously
+for an overview) of ``DatetimeIndex``, ``PeriodIndex`` and ``TimedeltaIndex`` previously
 returned numpy arrays, now they will return a new Index object (:issue:`15022`).
-Only in case of a boolean field, still a boolean array is returned to support
-boolean indexing.
+Only in the case of a boolean field, a the return value is still a boolean array
+instead of an Index (to support boolean indexing).
 
 Previous behaviour:
 

--- a/pandas/tests/indexes/datetimes/test_misc.py
+++ b/pandas/tests/indexes/datetimes/test_misc.py
@@ -172,7 +172,7 @@ class TestTimeSeries(tm.TestCase):
 class TestDatetime64(tm.TestCase):
 
     def test_datetimeindex_accessors(self):
-<<<<<<< f2831e2a2074e27e5cd3cfc0728d989742ee4680
+
         dti_naive = DatetimeIndex(freq='D', start=datetime(1998, 1, 1),
                                   periods=365)
         # GH 13303
@@ -258,16 +258,31 @@ class TestDatetime64(tm.TestCase):
 
             dti.name = 'name'
 
-            for accessor in ['year', 'month', 'day', 'hour', 'minute', 'second',
-                             'microsecond', 'nanosecond', 'dayofweek', 'dayofyear',
-                             'weekofyear', 'quarter',
-                             'is_month_start', 'is_month_end',
-                             'is_quarter_start', 'is_quarter_end',
-                             'is_year_start', 'is_year_end', 'weekday_name']:
+            # non boolean accessors -> return Index
+            for accessor in ['year', 'month', 'day', 'hour', 'minute',
+                             'second',  'microsecond', 'nanosecond',
+                             'dayofweek', 'dayofyear', 'weekofyear',
+                             'quarter', 'weekday_name']:
                 res = getattr(dti, accessor)
-                self.assertEqual(len(res), 365)
-                self.assertIsInstance(res, Index)
-                self.assertEqual(res.name, 'name')
+                assert len(res) == 365
+                assert isinstance(res, Index)
+                assert res.name == 'name'
+
+            # boolean accessors -> return array
+            for accessor in ['is_month_start', 'is_month_end',
+                             'is_quarter_start', 'is_quarter_end',
+                             'is_year_start', 'is_year_end']:
+                res = getattr(dti, accessor)
+                assert len(res) == 365
+                assert isinstance(res, np.ndarray)
+
+            # test boolean indexing
+            res = dti[dti.is_quarter_start]
+            exp = dti[[0, 90, 181, 273]]
+            tm.assert_index_equal(res, exp)
+            res = dti[dti.is_leap_year]
+            exp = DatetimeIndex([], freq='D', tz=dti.tz, name='name')
+            tm.assert_index_equal(res, exp)
 
         dti = DatetimeIndex(freq='BQ-FEB', start=datetime(1998, 1, 1),
                             periods=4)

--- a/pandas/tests/indexes/datetimes/test_misc.py
+++ b/pandas/tests/indexes/datetimes/test_misc.py
@@ -172,6 +172,7 @@ class TestTimeSeries(tm.TestCase):
 class TestDatetime64(tm.TestCase):
 
     def test_datetimeindex_accessors(self):
+<<<<<<< f2831e2a2074e27e5cd3cfc0728d989742ee4680
         dti_naive = DatetimeIndex(freq='D', start=datetime(1998, 1, 1),
                                   periods=365)
         # GH 13303
@@ -254,6 +255,19 @@ class TestDatetime64(tm.TestCase):
             self.assertEqual(len(dti.is_year_start), 365)
             self.assertEqual(len(dti.is_year_end), 365)
             self.assertEqual(len(dti.weekday_name), 365)
+
+            dti.name = 'name'
+
+            for accessor in ['year', 'month', 'day', 'hour', 'minute', 'second',
+                             'microsecond', 'nanosecond', 'dayofweek', 'dayofyear',
+                             'weekofyear', 'quarter',
+                             'is_month_start', 'is_month_end',
+                             'is_quarter_start', 'is_quarter_end',
+                             'is_year_start', 'is_year_end', 'weekday_name']:
+                res = getattr(dti, accessor)
+                self.assertEqual(len(res), 365)
+                self.assertIsInstance(res, Index)
+                self.assertEqual(res.name, 'name')
 
         dti = DatetimeIndex(freq='BQ-FEB', start=datetime(1998, 1, 1),
                             periods=4)

--- a/pandas/tests/indexes/datetimes/test_misc.py
+++ b/pandas/tests/indexes/datetimes/test_misc.py
@@ -260,7 +260,7 @@ class TestDatetime64(tm.TestCase):
 
             # non boolean accessors -> return Index
             for accessor in ['year', 'month', 'day', 'hour', 'minute',
-                             'second',  'microsecond', 'nanosecond',
+                             'second', 'microsecond', 'nanosecond',
                              'dayofweek', 'dayofyear', 'weekofyear',
                              'quarter', 'weekday_name']:
                 res = getattr(dti, accessor)

--- a/pandas/tests/indexes/datetimes/test_misc.py
+++ b/pandas/tests/indexes/datetimes/test_misc.py
@@ -313,5 +313,5 @@ class TestDatetime64(tm.TestCase):
     def test_nanosecond_field(self):
         dti = DatetimeIndex(np.arange(10))
 
-        self.assert_numpy_array_equal(dti.nanosecond,
-                                      np.arange(10, dtype=np.int32))
+        self.assert_index_equal(dti.nanosecond,
+                                pd.Index(np.arange(10, dtype=np.int64)))

--- a/pandas/tests/indexes/period/test_construction.py
+++ b/pandas/tests/indexes/period/test_construction.py
@@ -91,8 +91,8 @@ class TestPeriodIndex(tm.TestCase):
 
         pindex = PeriodIndex(year=years, quarter=quarters)
 
-        self.assert_numpy_array_equal(pindex.year, years)
-        self.assert_numpy_array_equal(pindex.quarter, quarters)
+        self.assert_index_equal(pindex.year, pd.Index(years))
+        self.assert_index_equal(pindex.quarter, pd.Index(quarters))
 
     def test_constructor_invalid_quarters(self):
         self.assertRaises(ValueError, PeriodIndex, year=lrange(2000, 2004),

--- a/pandas/tests/indexes/period/test_period.py
+++ b/pandas/tests/indexes/period/test_period.py
@@ -658,11 +658,11 @@ class TestPeriodIndex(DatetimeLike, tm.TestCase):
 
     def test_pindex_fieldaccessor_nat(self):
         idx = PeriodIndex(['2011-01', '2011-02', 'NaT',
-                           '2012-03', '2012-04'], freq='D')
+                           '2012-03', '2012-04'], freq='D', name='name')
 
-        exp = Index([2011, 2011, -1, 2012, 2012], dtype=np.int64)
+        exp = Index([2011, 2011, -1, 2012, 2012], dtype=np.int64, name='name')
         self.assert_index_equal(idx.year, exp)
-        exp = Index([1, 2, -1, 3, 4], dtype=np.int64)
+        exp = Index([1, 2, -1, 3, 4], dtype=np.int64, name='name')
         self.assert_index_equal(idx.month, exp)
 
     def test_pindex_qaccess(self):

--- a/pandas/tests/indexes/period/test_period.py
+++ b/pandas/tests/indexes/period/test_period.py
@@ -660,10 +660,10 @@ class TestPeriodIndex(DatetimeLike, tm.TestCase):
         idx = PeriodIndex(['2011-01', '2011-02', 'NaT',
                            '2012-03', '2012-04'], freq='D')
 
-        exp = np.array([2011, 2011, -1, 2012, 2012], dtype=np.int64)
-        self.assert_numpy_array_equal(idx.year, exp)
-        exp = np.array([1, 2, -1, 3, 4], dtype=np.int64)
-        self.assert_numpy_array_equal(idx.month, exp)
+        exp = Index([2011, 2011, -1, 2012, 2012], dtype=np.int64)
+        self.assert_index_equal(idx.year, exp)
+        exp = Index([1, 2, -1, 3, 4], dtype=np.int64)
+        self.assert_index_equal(idx.month, exp)
 
     def test_pindex_qaccess(self):
         pi = PeriodIndex(['2Q05', '3Q05', '4Q05', '1Q06', '2Q06'], freq='Q')

--- a/pandas/tests/indexes/timedeltas/test_timedelta.py
+++ b/pandas/tests/indexes/timedeltas/test_timedelta.py
@@ -424,7 +424,7 @@ class TestTimedeltaIndex(DatetimeLike, tm.TestCase):
                               freq='s')
         expt = [1 * 86400 + 10 * 3600 + 11 * 60 + 12 + 100123456. / 1e9,
                 1 * 86400 + 10 * 3600 + 11 * 60 + 13 + 100123456. / 1e9]
-        tm.assert_almost_equal(rng.total_seconds(), np.array(expt))
+        tm.assert_almost_equal(rng.total_seconds(), Index(expt))
 
         # test Series
         s = Series(rng)
@@ -486,16 +486,16 @@ class TestTimedeltaIndex(DatetimeLike, tm.TestCase):
     def test_fields(self):
         rng = timedelta_range('1 days, 10:11:12.100123456', periods=2,
                               freq='s')
-        self.assert_numpy_array_equal(rng.days, np.array(
-            [1, 1], dtype='int64'))
-        self.assert_numpy_array_equal(
+        self.assert_index_equal(rng.days, Index([1, 1], dtype='int64'))
+        self.assert_index_equal(
             rng.seconds,
-            np.array([10 * 3600 + 11 * 60 + 12, 10 * 3600 + 11 * 60 + 13],
-                     dtype='int64'))
-        self.assert_numpy_array_equal(rng.microseconds, np.array(
-            [100 * 1000 + 123, 100 * 1000 + 123], dtype='int64'))
-        self.assert_numpy_array_equal(rng.nanoseconds, np.array(
-            [456, 456], dtype='int64'))
+            Index([10 * 3600 + 11 * 60 + 12, 10 * 3600 + 11 * 60 + 13],
+                  dtype='int64'))
+        self.assert_index_equal(
+            rng.microseconds,
+            Index([100 * 1000 + 123, 100 * 1000 + 123], dtype='int64'))
+        self.assert_index_equal(rng.nanoseconds,
+                                Index([456, 456], dtype='int64'))
 
         self.assertRaises(AttributeError, lambda: rng.hours)
         self.assertRaises(AttributeError, lambda: rng.minutes)
@@ -508,6 +508,10 @@ class TestTimedeltaIndex(DatetimeLike, tm.TestCase):
         tm.assert_series_equal(s.dt.days, Series([1, np.nan], index=[0, 1]))
         tm.assert_series_equal(s.dt.seconds, Series(
             [10 * 3600 + 11 * 60 + 12, np.nan], index=[0, 1]))
+
+        # preserve name (GH15589)
+        rng.name = 'name'
+        assert rng.days.name == 'name'
 
     def test_freq_conversion(self):
 

--- a/pandas/tests/scalar/test_timestamp.py
+++ b/pandas/tests/scalar/test_timestamp.py
@@ -597,14 +597,25 @@ class TestTimestamp(tm.TestCase):
     def test_nat_vector_field_access(self):
         idx = DatetimeIndex(['1/1/2000', None, None, '1/4/2000'])
 
+        # non boolean fields
         fields = ['year', 'quarter', 'month', 'day', 'hour', 'minute',
                   'second', 'microsecond', 'nanosecond', 'week', 'dayofyear',
-                  'days_in_month', 'is_leap_year']
+                  'days_in_month']
 
         for field in fields:
             result = getattr(idx, field)
             expected = [getattr(x, field) for x in idx]
             self.assert_index_equal(result, pd.Index(expected))
+
+        # boolean fields
+        fields = ['is_leap_year']
+        # other boolean fields like 'is_month_start' and 'is_month_end'
+        # not yet supported by NaT
+
+        for field in fields:
+            result = getattr(idx, field)
+            expected = [getattr(x, field) for x in idx]
+            self.assert_numpy_array_equal(result, np.array(expected))
 
         s = pd.Series(idx)
 

--- a/pandas/tests/scalar/test_timestamp.py
+++ b/pandas/tests/scalar/test_timestamp.py
@@ -604,7 +604,7 @@ class TestTimestamp(tm.TestCase):
         for field in fields:
             result = getattr(idx, field)
             expected = [getattr(x, field) for x in idx]
-            self.assert_numpy_array_equal(result, np.array(expected))
+            self.assert_index_equal(result, pd.Index(expected))
 
         s = pd.Series(idx)
 

--- a/pandas/tests/tools/test_pivot.py
+++ b/pandas/tests/tools/test_pivot.py
@@ -1367,7 +1367,7 @@ class TestPivotAnnual(tm.TestCase):
         with tm.assert_produces_warning(FutureWarning, check_stacklevel=False):
             annual = pivot_annual(ts, 'D')
 
-        doy = ts.index.dayofyear
+        doy = np.asarray(ts.index.dayofyear)
 
         with tm.assert_produces_warning(FutureWarning, check_stacklevel=False):
             doy[(~isleapyear(ts.index.year)) & (doy >= 60)] += 1

--- a/pandas/tests/tools/test_util.py
+++ b/pandas/tests/tools/test_util.py
@@ -31,10 +31,10 @@ class TestCartesianProduct(tm.TestCase):
         # make sure that the ordering on datetimeindex is consistent
         x = date_range('2000-01-01', periods=2)
         result1, result2 = [Index(y).day for y in cartesian_product([x, x])]
-        expected1 = np.array([1, 1, 2, 2], dtype=np.int32)
-        expected2 = np.array([1, 2, 1, 2], dtype=np.int32)
-        tm.assert_numpy_array_equal(result1, expected1)
-        tm.assert_numpy_array_equal(result2, expected2)
+        expected1 = Index([1, 1, 2, 2])
+        expected2 = Index([1, 2, 1, 2])
+        tm.assert_index_equal(result1, expected1)
+        tm.assert_index_equal(result2, expected2)
 
     def test_empty(self):
         # product of empty factors

--- a/pandas/tests/tseries/test_timezones.py
+++ b/pandas/tests/tseries/test_timezones.py
@@ -358,8 +358,8 @@ class TestTimeZoneSupportPytz(tm.TestCase):
         dr = date_range('2011-10-02 00:00', freq='h', periods=10,
                         tz=self.tzstr('America/Atikokan'))
 
-        expected = np.arange(10, dtype=np.int32)
-        self.assert_numpy_array_equal(dr.hour, expected)
+        expected = pd.Index(np.arange(10, dtype=np.int64))
+        self.assert_index_equal(dr.hour, expected)
 
     def test_with_tz(self):
         tz = self.tz('US/Central')
@@ -947,8 +947,8 @@ class TestTimeZoneSupportDateutil(TestTimeZoneSupportPytz):
               '2009-05-12 09:50:32']
         tt = to_datetime(ts).tz_localize('US/Eastern')
         ut = tt.tz_convert('UTC')
-        expected = np.array([13, 14, 13], dtype=np.int32)
-        self.assert_numpy_array_equal(ut.hour, expected)
+        expected = Index([13, 14, 13])
+        self.assert_index_equal(ut.hour, expected)
 
         # sorted case UTC -> US/Eastern
         ts = ['2008-05-12 13:50:00',
@@ -956,8 +956,8 @@ class TestTimeZoneSupportDateutil(TestTimeZoneSupportPytz):
               '2009-05-12 13:50:32']
         tt = to_datetime(ts).tz_localize('UTC')
         ut = tt.tz_convert('US/Eastern')
-        expected = np.array([9, 9, 9], dtype=np.int32)
-        self.assert_numpy_array_equal(ut.hour, expected)
+        expected = Index([9, 9, 9])
+        self.assert_index_equal(ut.hour, expected)
 
         # unsorted case US/Eastern -> UTC
         ts = ['2008-05-12 09:50:00',
@@ -965,8 +965,8 @@ class TestTimeZoneSupportDateutil(TestTimeZoneSupportPytz):
               '2008-05-12 09:50:32']
         tt = to_datetime(ts).tz_localize('US/Eastern')
         ut = tt.tz_convert('UTC')
-        expected = np.array([13, 14, 13], dtype=np.int32)
-        self.assert_numpy_array_equal(ut.hour, expected)
+        expected = Index([13, 14, 13])
+        self.assert_index_equal(ut.hour, expected)
 
         # unsorted case UTC -> US/Eastern
         ts = ['2008-05-12 13:50:00',
@@ -974,8 +974,8 @@ class TestTimeZoneSupportDateutil(TestTimeZoneSupportPytz):
               '2008-05-12 13:50:32']
         tt = to_datetime(ts).tz_localize('UTC')
         ut = tt.tz_convert('US/Eastern')
-        expected = np.array([9, 9, 9], dtype=np.int32)
-        self.assert_numpy_array_equal(ut.hour, expected)
+        expected = Index([9, 9, 9])
+        self.assert_index_equal(ut.hour, expected)
 
     def test_tz_convert_hour_overflow_dst_timestamps(self):
         # Regression test for:
@@ -989,8 +989,8 @@ class TestTimeZoneSupportDateutil(TestTimeZoneSupportPytz):
               Timestamp('2009-05-12 09:50:32', tz=tz)]
         tt = to_datetime(ts)
         ut = tt.tz_convert('UTC')
-        expected = np.array([13, 14, 13], dtype=np.int32)
-        self.assert_numpy_array_equal(ut.hour, expected)
+        expected = Index([13, 14, 13])
+        self.assert_index_equal(ut.hour, expected)
 
         # sorted case UTC -> US/Eastern
         ts = [Timestamp('2008-05-12 13:50:00', tz='UTC'),
@@ -998,8 +998,8 @@ class TestTimeZoneSupportDateutil(TestTimeZoneSupportPytz):
               Timestamp('2009-05-12 13:50:32', tz='UTC')]
         tt = to_datetime(ts)
         ut = tt.tz_convert('US/Eastern')
-        expected = np.array([9, 9, 9], dtype=np.int32)
-        self.assert_numpy_array_equal(ut.hour, expected)
+        expected = Index([9, 9, 9])
+        self.assert_index_equal(ut.hour, expected)
 
         # unsorted case US/Eastern -> UTC
         ts = [Timestamp('2008-05-12 09:50:00', tz=tz),
@@ -1007,8 +1007,8 @@ class TestTimeZoneSupportDateutil(TestTimeZoneSupportPytz):
               Timestamp('2008-05-12 09:50:32', tz=tz)]
         tt = to_datetime(ts)
         ut = tt.tz_convert('UTC')
-        expected = np.array([13, 14, 13], dtype=np.int32)
-        self.assert_numpy_array_equal(ut.hour, expected)
+        expected = Index([13, 14, 13])
+        self.assert_index_equal(ut.hour, expected)
 
         # unsorted case UTC -> US/Eastern
         ts = [Timestamp('2008-05-12 13:50:00', tz='UTC'),
@@ -1016,8 +1016,8 @@ class TestTimeZoneSupportDateutil(TestTimeZoneSupportPytz):
               Timestamp('2008-05-12 13:50:32', tz='UTC')]
         tt = to_datetime(ts)
         ut = tt.tz_convert('US/Eastern')
-        expected = np.array([9, 9, 9], dtype=np.int32)
-        self.assert_numpy_array_equal(ut.hour, expected)
+        expected = Index([9, 9, 9])
+        self.assert_index_equal(ut.hour, expected)
 
     def test_tslib_tz_convert_trans_pos_plus_1__bug(self):
         # Regression test for tslib.tz_convert(vals, tz1, tz2).
@@ -1028,9 +1028,8 @@ class TestTimeZoneSupportDateutil(TestTimeZoneSupportPytz):
             idx = idx.tz_localize('UTC')
             idx = idx.tz_convert('Europe/Moscow')
 
-            expected = np.repeat(np.array([3, 4, 5], dtype=np.int32),
-                                 np.array([n, n, 1]))
-            self.assert_numpy_array_equal(idx.hour, expected)
+            expected = np.repeat(np.array([3, 4, 5]), np.array([n, n, 1]))
+            self.assert_index_equal(idx.hour, Index(expected))
 
     def test_tslib_tz_convert_dst(self):
         for freq, n in [('H', 1), ('T', 60), ('S', 3600)]:
@@ -1039,62 +1038,57 @@ class TestTimeZoneSupportDateutil(TestTimeZoneSupportPytz):
                              tz='UTC')
             idx = idx.tz_convert('US/Eastern')
             expected = np.repeat(np.array([18, 19, 20, 21, 22, 23,
-                                           0, 1, 3, 4, 5], dtype=np.int32),
+                                           0, 1, 3, 4, 5]),
                                  np.array([n, n, n, n, n, n, n, n, n, n, 1]))
-            self.assert_numpy_array_equal(idx.hour, expected)
+            self.assert_index_equal(idx.hour, Index(expected))
 
             idx = date_range('2014-03-08 18:00', '2014-03-09 05:00', freq=freq,
                              tz='US/Eastern')
             idx = idx.tz_convert('UTC')
-            expected = np.repeat(np.array([23, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9],
-                                          dtype=np.int32),
+            expected = np.repeat(np.array([23, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9]),
                                  np.array([n, n, n, n, n, n, n, n, n, n, 1]))
-            self.assert_numpy_array_equal(idx.hour, expected)
+            self.assert_index_equal(idx.hour, Index(expected))
 
             # End DST
             idx = date_range('2014-11-01 23:00', '2014-11-02 09:00', freq=freq,
                              tz='UTC')
             idx = idx.tz_convert('US/Eastern')
             expected = np.repeat(np.array([19, 20, 21, 22, 23,
-                                           0, 1, 1, 2, 3, 4], dtype=np.int32),
+                                           0, 1, 1, 2, 3, 4]),
                                  np.array([n, n, n, n, n, n, n, n, n, n, 1]))
-            self.assert_numpy_array_equal(idx.hour, expected)
+            self.assert_index_equal(idx.hour, Index(expected))
 
             idx = date_range('2014-11-01 18:00', '2014-11-02 05:00', freq=freq,
                              tz='US/Eastern')
             idx = idx.tz_convert('UTC')
             expected = np.repeat(np.array([22, 23, 0, 1, 2, 3, 4, 5, 6,
-                                           7, 8, 9, 10], dtype=np.int32),
+                                           7, 8, 9, 10]),
                                  np.array([n, n, n, n, n, n, n, n, n,
                                            n, n, n, 1]))
-            self.assert_numpy_array_equal(idx.hour, expected)
+            self.assert_index_equal(idx.hour, Index(expected))
 
         # daily
         # Start DST
         idx = date_range('2014-03-08 00:00', '2014-03-09 00:00', freq='D',
                          tz='UTC')
         idx = idx.tz_convert('US/Eastern')
-        self.assert_numpy_array_equal(idx.hour,
-                                      np.array([19, 19], dtype=np.int32))
+        self.assert_index_equal(idx.hour, Index([19, 19]))
 
         idx = date_range('2014-03-08 00:00', '2014-03-09 00:00', freq='D',
                          tz='US/Eastern')
         idx = idx.tz_convert('UTC')
-        self.assert_numpy_array_equal(idx.hour,
-                                      np.array([5, 5], dtype=np.int32))
+        self.assert_index_equal(idx.hour, Index([5, 5]))
 
         # End DST
         idx = date_range('2014-11-01 00:00', '2014-11-02 00:00', freq='D',
                          tz='UTC')
         idx = idx.tz_convert('US/Eastern')
-        self.assert_numpy_array_equal(idx.hour,
-                                      np.array([20, 20], dtype=np.int32))
+        self.assert_index_equal(idx.hour, Index([20, 20]))
 
         idx = date_range('2014-11-01 00:00', '2014-11-02 000:00', freq='D',
                          tz='US/Eastern')
         idx = idx.tz_convert('UTC')
-        self.assert_numpy_array_equal(idx.hour,
-                                      np.array([4, 4], dtype=np.int32))
+        self.assert_index_equal(idx.hour, Index([4, 4]))
 
     def test_tzlocal(self):
         # GH 13583

--- a/pandas/tests/tseries/test_timezones.py
+++ b/pandas/tests/tseries/test_timezones.py
@@ -358,7 +358,7 @@ class TestTimeZoneSupportPytz(tm.TestCase):
         dr = date_range('2011-10-02 00:00', freq='h', periods=10,
                         tz=self.tzstr('America/Atikokan'))
 
-        expected = pd.Index(np.arange(10, dtype=np.int64))
+        expected = Index(np.arange(10, dtype=np.int64))
         self.assert_index_equal(dr.hour, expected)
 
     def test_with_tz(self):

--- a/pandas/tseries/common.py
+++ b/pandas/tseries/common.py
@@ -105,6 +105,8 @@ class Properties(PandasDelegate, NoNewAttributesMixin):
         elif not is_list_like(result):
             return result
 
+        result = np.asarray(result)
+
         # blow up if we operate on categories
         if self.orig is not None:
             result = take_1d(result, self.orig.cat.codes)

--- a/pandas/tseries/converter.py
+++ b/pandas/tseries/converter.py
@@ -455,7 +455,7 @@ def period_break(dates, period):
     """
     current = getattr(dates, period)
     previous = getattr(dates - 1, period)
-    return (current - previous).nonzero()[0]
+    return np.nonzero(current - previous)[0]
 
 
 def has_level_label(label_flags, vmin):

--- a/pandas/tseries/index.py
+++ b/pandas/tseries/index.py
@@ -73,16 +73,19 @@ def _field_accessor(name, field, docstring=None):
 
             result = libts.get_start_end_field(values, field, self.freqstr,
                                                month_kw)
+            result = self._maybe_mask_results(result, convert='float64')
+
         elif field in ['weekday_name']:
             result = libts.get_date_name_field(values, field)
-            return self._maybe_mask_results(result)
+            result = self._maybe_mask_results(result)
         elif field in ['is_leap_year']:
             # no need to mask NaT
-            return libts.get_date_field(values, field)
+            result = libts.get_date_field(values, field)
         else:
             result = libts.get_date_field(values, field)
+            result = self._maybe_mask_results(result, convert='float64')
 
-        return self._maybe_mask_results(result, convert='float64')
+        return Index(result)
 
     f.__name__ = name
     f.__doc__ = docstring
@@ -1909,9 +1912,9 @@ class DatetimeIndex(DatelikeOps, TimelikeOps, DatetimeIndexOpsMixin,
         """
 
         # http://mysite.verizon.net/aesir_research/date/jdalg2.htm
-        year = self.year
-        month = self.month
-        day = self.day
+        year = np.asarray(self.year)
+        month = np.asarray(self.month)
+        day = np.asarray(self.day)
         testarr = month < 3
         year[testarr] -= 1
         month[testarr] += 12

--- a/pandas/tseries/index.py
+++ b/pandas/tseries/index.py
@@ -64,6 +64,7 @@ def _field_accessor(name, field, docstring=None):
             if self.tz is not utc:
                 values = self._local_timestamps()
 
+        # boolean accessors -> return array
         if field in ['is_month_start', 'is_month_end',
                      'is_quarter_start', 'is_quarter_end',
                      'is_year_start', 'is_year_end']:
@@ -73,14 +74,15 @@ def _field_accessor(name, field, docstring=None):
 
             result = libts.get_start_end_field(values, field, self.freqstr,
                                                month_kw)
-            result = self._maybe_mask_results(result, convert='float64')
+            return self._maybe_mask_results(result, convert='float64')
+        elif field in ['is_leap_year']:
+            # no need to mask NaT
+            return libts.get_date_field(values, field)
 
+        # non-boolean accessors -> return Index
         elif field in ['weekday_name']:
             result = libts.get_date_name_field(values, field)
             result = self._maybe_mask_results(result)
-        elif field in ['is_leap_year']:
-            # no need to mask NaT
-            result = libts.get_date_field(values, field)
         else:
             result = libts.get_date_field(values, field)
             result = self._maybe_mask_results(result, convert='float64')

--- a/pandas/tseries/index.py
+++ b/pandas/tseries/index.py
@@ -85,7 +85,7 @@ def _field_accessor(name, field, docstring=None):
             result = libts.get_date_field(values, field)
             result = self._maybe_mask_results(result, convert='float64')
 
-        return Index(result)
+        return Index(result, name=self.name)
 
     f.__name__ = name
     f.__doc__ = docstring

--- a/pandas/tseries/period.py
+++ b/pandas/tseries/period.py
@@ -53,7 +53,7 @@ def _field_accessor(name, alias, docstring=None):
     def f(self):
         base, mult = _gfc(self.freq)
         result = get_period_field_arr(alias, self._values, base)
-        return Index(result)
+        return Index(result, name=self.name)
     f.__name__ = name
     f.__doc__ = docstring
     return property(f)

--- a/pandas/tseries/period.py
+++ b/pandas/tseries/period.py
@@ -52,7 +52,8 @@ _index_doc_kwargs.update(
 def _field_accessor(name, alias, docstring=None):
     def f(self):
         base, mult = _gfc(self.freq)
-        return get_period_field_arr(alias, self._values, base)
+        result = get_period_field_arr(alias, self._values, base)
+        return Index(result)
     f.__name__ = name
     f.__doc__ = docstring
     return property(f)
@@ -585,7 +586,7 @@ class PeriodIndex(DatelikeOps, DatetimeIndexOpsMixin, Int64Index):
     @property
     def is_leap_year(self):
         """ Logical indicating if the date belongs to a leap year """
-        return tslib._isleapyear_arr(self.year)
+        return tslib._isleapyear_arr(np.asarray(self.year))
 
     @property
     def start_time(self):

--- a/pandas/tseries/tdi.py
+++ b/pandas/tseries/tdi.py
@@ -374,7 +374,7 @@ class TimedeltaIndex(DatetimeIndexOpsMixin, TimelikeOps, Int64Index):
         else:
             result = np.array([getattr(Timedelta(val), m)
                                for val in values], dtype='int64')
-        return result
+        return Index(result, name=self.name)
 
     @property
     def days(self):
@@ -437,7 +437,8 @@ class TimedeltaIndex(DatetimeIndexOpsMixin, TimelikeOps, Int64Index):
 
         .. versionadded:: 0.17.0
         """
-        return self._maybe_mask_results(1e-9 * self.asi8)
+        return Index(self._maybe_mask_results(1e-9 * self.asi8),
+                     name=self.name)
 
     def to_pytimedelta(self):
         """

--- a/pandas/tseries/util.py
+++ b/pandas/tseries/util.py
@@ -54,7 +54,7 @@ def pivot_annual(series, freq=None):
 
     if freq == 'D':
         width = 366
-        offset = index.dayofyear - 1
+        offset = np.asarray(index.dayofyear) - 1
 
         # adjust for leap year
         offset[(~isleapyear(year)) & (offset >= 59)] += 1
@@ -63,7 +63,7 @@ def pivot_annual(series, freq=None):
         # todo: strings like 1/1, 1/25, etc.?
     elif freq in ('M', 'BM'):
         width = 12
-        offset = index.month - 1
+        offset = np.asarray(index.month) - 1
         columns = lrange(1, 13)
     elif freq == 'H':
         width = 8784


### PR DESCRIPTION
 - [x] closes #15022
 - [x] tests added / passed
 - [x] passes ``git diff upstream/master | flake8 --diff``
 - [x] whatsnew entry

This changes the datetime field accessors of a DatetimeIndex (and PeriodIndex, etc) to return an Index object instead of a plain array:

So for example:
```
# PR

In [1]: idx = pd.date_range("2015-01-01", periods=5, freq='10H')

In [2]: idx
Out[2]: 
DatetimeIndex(['2015-01-01 00:00:00', '2015-01-01 10:00:00',
               '2015-01-01 20:00:00', '2015-01-02 06:00:00',
               '2015-01-02 16:00:00'],
              dtype='datetime64[ns]', freq='10H')

In [3]: idx.hour
Out[3]: Int64Index([0, 10, 20, 6, 16], dtype='int64')

```

instead of

```
# master

In [1]: idx = pd.date_range("2015-01-01", periods=5, freq='10H')

In [2]: idx.hour
Out[2]: array([ 0, 10, 20,  6, 16], dtype=int32)
```