### PR TITLE
DOC: remove Panel4D from the API docs #15579

### DIFF
--- a/doc/source/api.rst
+++ b/doc/source/api.rst
@@ -1237,58 +1237,7 @@ Serialization / IO / Conversion
    Panel.to_frame
    Panel.to_xarray
    Panel.to_clipboard
-
-.. _api.panel4d:
-
-Panel4D
--------
-
-Constructor
-~~~~~~~~~~~
-.. autosummary::
-   :toctree: generated/
-
-   Panel4D
-
-Serialization / IO / Conversion
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-.. autosummary::
-   :toctree: generated/
-
-   Panel4D.to_xarray
-
-Attributes and underlying data
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-**Axes**
-
-  * **labels**: axis 1; each label corresponds to a Panel contained inside
-  * **items**: axis 2; each item corresponds to a DataFrame contained inside
-  * **major_axis**: axis 3; the index (rows) of each of the DataFrames
-  * **minor_axis**: axis 4; the columns of each of the DataFrames
-
-.. autosummary::
-   :toctree: generated/
-
-   Panel4D.values
-   Panel4D.axes
-   Panel4D.ndim
-   Panel4D.size
-   Panel4D.shape
-   Panel4D.dtypes
-   Panel4D.ftypes
-   Panel4D.get_dtype_counts
-   Panel4D.get_ftype_counts
-
-Conversion
-~~~~~~~~~~
-.. autosummary::
-   :toctree: generated/
-
-   Panel4D.astype
-   Panel4D.copy
-   Panel4D.isnull
-   Panel4D.notnull
-
+   
 .. _api.index:
 
 Index

--- a/scripts/api_rst_coverage.py
+++ b/scripts/api_rst_coverage.py
@@ -4,11 +4,11 @@ import re
 
 def main():
     # classes whose members to check
-    classes = [pd.Series, pd.DataFrame, pd.Panel, pd.Panel4D]
+    classes = [pd.Series, pd.DataFrame, pd.Panel]
 
     def class_name_sort_key(x):
         if x.startswith('Series'):
-            # make sure Series precedes DataFrame, Panel, and Panel4D
+            # make sure Series precedes DataFrame, and Panel.
             return ' ' + x
         else:
             return x


### PR DESCRIPTION
Hi this is my first PR to Pandas
I'm pretty sure this is what @jorisvandenbossche was getting at on ticket <a href='https://github.com/pandas-dev/pandas/issues/15579'>#15579<a/>.

I noticed that <a href='https://github.com/pandas-dev/pandas/blob/be4a63fe791e27c2f8a9ae4f3a419ccc255c1b5b/pandas/tests/test_expressions.py#L206'>tests</a> for panel4D also still exist, is that something that should remain?

Thanks!
