### PR TITLE
BUG: make Series.sort_values(ascending=[False]) behave as ascending=False (#15604)

### DIFF
--- a/doc/source/whatsnew/v0.20.0.txt
+++ b/doc/source/whatsnew/v0.20.0.txt
@@ -228,7 +228,7 @@ Other enhancements
 - ``pd.TimedeltaIndex`` now has a custom datetick formatter specifically designed for nanosecond level precision (:issue:`8711`)
 - ``pd.types.concat.union_categoricals`` gained the ``ignore_ordered`` argument to allow ignoring the ordered attribute of unioned categoricals (:issue:`13410`). See the :ref:`categorical union docs <categorical.union>` for more information.
 - ``pandas.io.json.json_normalize()`` with an empty ``list`` will return an empty ``DataFrame`` (:issue:`15534`)
-
+- ``Series.sort_values`` accepts a one element list of bool for consistency with the behavior of ``DataFrame.sort_values`` (:issue:`15604`)
 .. _ISO 8601 duration: https://en.wikipedia.org/wiki/ISO_8601#Durations
 
 

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -14,6 +14,7 @@ import numpy as np
 import numpy.ma as ma
 
 from pandas.types.common import (_coerce_to_dtype, is_categorical_dtype,
+                                 is_bool,
                                  is_integer, is_integer_dtype,
                                  is_float_dtype,
                                  is_extension_type, is_datetimetz,
@@ -1721,6 +1722,15 @@ class Series(base.IndexOpsMixin, strings.StringAccessorMixin,
         idx = _default_index(len(self))
 
         argsorted = _try_kind_sort(arr[good])
+
+        if is_list_like(ascending):
+            if len(ascending) != 1:
+                raise ValueError('Length of ascending (%d) must be 1 '
+                                 'for Series' % (len(ascending)))
+            ascending = ascending[0]
+
+        if not is_bool(ascending):
+            raise ValueError('ascending must be boolean')
 
         if not ascending:
             argsorted = argsorted[::-1]

--- a/pandas/tests/series/test_sorting.py
+++ b/pandas/tests/series/test_sorting.py
@@ -64,6 +64,25 @@ class TestSeriesSorting(TestData, tm.TestCase):
         ordered = ts.sort_values(ascending=False, na_position='first')
         assert_almost_equal(expected, ordered.valid().values)
 
+        # ascending=[False] should behave the same as ascending=False
+        ordered = ts.sort_values(ascending=[False])
+        expected = ts.sort_values(ascending=False)
+        assert_series_equal(expected, ordered)
+        ordered = ts.sort_values(ascending=[False], na_position='first')
+        expected = ts.sort_values(ascending=False, na_position='first')
+        assert_series_equal(expected, ordered)
+
+        self.assertRaises(ValueError,
+                          lambda: ts.sort_values(ascending=None))
+        self.assertRaises(ValueError,
+                          lambda: ts.sort_values(ascending=[]))
+        self.assertRaises(ValueError,
+                          lambda: ts.sort_values(ascending=[1, 2, 3]))
+        self.assertRaises(ValueError,
+                          lambda: ts.sort_values(ascending=[False, False]))
+        self.assertRaises(ValueError,
+                          lambda: ts.sort_values(ascending='foobar'))
+
         # inplace=True
         ts = self.ts.copy()
         ts.sort_values(ascending=False, inplace=True)


### PR DESCRIPTION
 - [X ] closes #15604 
 - [ X] tests added / passed
 - [X] passes ``git diff upstream/master | flake8 --diff``
 - [X] whatsnew entry