### PR TITLE
Clean multiindex keys

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -2214,7 +2214,7 @@ it is assumed to be aliases for the column names')
 
         try:
             new_data = self.loc[res]
-        except ValueError:
+        except (ValueError, NotImplementedError):
             # when res is multi-dimensional loc raises, but this is sometimes a
             # valid query
             new_data = self[res]

--- a/pandas/tests/indexing/test_multiindex.py
+++ b/pandas/tests/indexing/test_multiindex.py
@@ -203,6 +203,27 @@ class TestMultiIndexBasic(object):
         result = x.loc[scalar]
         tm.assert_series_equal(result, expected)
 
+    def test_loc_generator(self):
+        index = MultiIndex.from_product([[1, 2, 3], ['A', 'B', 'C']])
+        x = Series(index=index, data=range(9), dtype=np.float64)
+        y = [1, 3]
+
+        # getitem:
+        expected = Series(
+            data=[0, 1, 2, 6, 7, 8],
+            index=MultiIndex.from_product([[1, 3], ['A', 'B', 'C']]),
+            dtype=np.float64)
+        result = x.loc[iter(y)]
+        tm.assert_series_equal(result, expected)
+
+        # setitem:
+        expected = Series(
+            data=[9, 10, 11, 3, 4, 5, 12, 13, 14],
+            index=index,
+            dtype=np.float64)
+        x.loc[iter(y)] = range(9, 15)
+        tm.assert_series_equal(x, expected)
+
     def test_iloc_getitem_multiindex(self):
         mi_labels = DataFrame(np.random.randn(4, 3),
                               columns=[['i', 'i', 'j'], ['A', 'A', 'B']],

--- a/pandas/tests/indexing/test_multiindex.py
+++ b/pandas/tests/indexing/test_multiindex.py
@@ -174,6 +174,10 @@ class TestMultiIndexBasic(object):
         result = x.loc[empty]
         tm.assert_series_equal(result, expected)
 
+        with tm.assertRaises(KeyError):
+            # GH15452
+            x.loc[[4, 5]]
+
     def test_loc_getitem_array(self):
         # GH15434
         # passing an array as a key with a MultiIndex

--- a/pandas/tests/series/test_indexing.py
+++ b/pandas/tests/series/test_indexing.py
@@ -4,6 +4,7 @@
 import pytest
 
 from datetime import datetime, timedelta
+import pytest
 
 from numpy import nan
 import numpy as np
@@ -289,6 +290,44 @@ class TestSeriesIndexing(TestData):
         expected = self.series[self.series > 0]
         assert_series_equal(result, expected)
         assert_series_equal(result2, expected)
+
+    def test_setitem_generator(self):
+        bool_idx = self.series > 0
+        idces = self.series[bool_idx].index
+
+        values = range(bool_idx.sum())
+
+        expected = self.series.copy()
+        expected[bool_idx] = values
+
+        # list of labels:
+        s1 = self.series.copy()
+        s1[iter(idces)] = values
+        assert_series_equal(s1, expected)
+
+        # list of labels with .loc:
+        s2 = self.series.copy()
+        s2.loc[iter(idces)] = values
+        assert_series_equal(s2, expected)
+
+    @pytest.mark.xfail(reason="Setitem with booleans generators unsupported")
+    def test_setitem_boolean_generator(self):
+        bool_idx = self.series > 0
+
+        values = range(bool_idx.sum())
+
+        expected = self.series.copy()
+        expected[bool_idx] = values
+
+        # boolean generator (fails)
+        s1 = self.series.copy()
+        s1[iter(bool_idx)] = values
+        assert_series_equal(s1, expected)
+
+        # boolean generator with .loc (fails)
+        s2 = self.series.copy()
+        s2.loc[iter(bool_idx)] = values
+        assert_series_equal(s2, expected)
 
     def test_type_promotion(self):
         # GH12599

--- a/pandas/tests/sparse/test_indexing.py
+++ b/pandas/tests/sparse/test_indexing.py
@@ -512,13 +512,17 @@ class TestSparseSeriesMultiIndexing(TestSparseSeriesIndexing):
         tm.assert_sp_series_equal(sparse.loc['B'],
                                   orig.loc['B'].to_sparse())
 
-        result = sparse.loc[[1, 3, 4]]
-        exp = orig.loc[[1, 3, 4]].to_sparse()
+        with tm.assertRaises(KeyError):
+            # GH15452
+            sparse.loc[['D', 'E', 'F']]
+
+        result = sparse.loc[['A', 'B']]
+        exp = orig.loc[['A', 'B']].to_sparse()
         tm.assert_sp_series_equal(result, exp)
 
         # exceeds the bounds
-        result = sparse.loc[[1, 3, 4, 5]]
-        exp = orig.loc[[1, 3, 4, 5]].to_sparse()
+        result = sparse.loc[['A', 'B', 'C', 'D']]
+        exp = orig.loc[['A', 'B', 'C', 'D']].to_sparse()
         tm.assert_sp_series_equal(result, exp)
 
         # single element list (GH 15447)


### PR DESCRIPTION
 - [x] closes #15452
 - [x] tests added / passed
 - [x] passes ``git diff master | flake8 --diff``
 - [x] whatsnew entry

Most of the change to code is mere refactoring (the small change in ``pandas/core/frame.py`` can be undone once we decide about #15438), but I did suppress three obsolete (the same job [is already done](https://github.com/toobaz/pandas/blob/clean_multiindex_keys/pandas/core/indexing.py#L1076) in the right way in ``_getitem_iterable``) and buggy [lines](https://github.com/pandas-dev/pandas/blob/master/pandas/core/indexing.py#L1544) which actually not only caused #15452, but were the real explanation for #15424.

As a side consequence, generators can now be used to index a ``MultiIndex``. This is not documented, as far as I know, but it was already possible with a flat ``Index``, and it was [actually also tested](https://github.com/pandas-dev/pandas/blob/master/pandas/tests/series/test_indexing.py#L270), so I added tests for ``MultiIndex`` too and to setitem (except that not all of them currently work). Once this PR goes through, I plan to open three separate issues for
- the failing tests with setitem and generators (of boolean values)
- ``df.loc[['missing', 'keys'], :]``, which still erroneously returns an empty ``DataFrame`` rather than raising (as ``df.loc[['missing', 'keys']]`` does)
- [my proposal](https://github.com/pandas-dev/pandas/issues/15452#issuecomment-281542685) about a change in behaviour for missing keys

Feel free to tell me if any of this is not worth discussing.