### PR TITLE
BUG: Error when specifying int index containing NaN

### DIFF
--- a/doc/source/whatsnew/v0.20.0.txt
+++ b/doc/source/whatsnew/v0.20.0.txt
@@ -765,6 +765,7 @@ Bug Fixes
 - Bug in ``DataFrame.isin`` comparing datetimelike to empty frame (:issue:`15473`)
 
 - Bug in ``Series.where()`` and ``DataFrame.where()`` where array-like conditionals were being rejected (:issue:`15414`)
+- Bug in ``Index`` construction with ``NaN`` elements and integer dtype specified (:issue:`15187`)
 - Bug in ``Series`` construction with a datetimetz (:issue:`14928`)
 - Bug in output formatting of a ``MultiIndex`` when names are integers (:issue:`12223`, :issue:`15262`)
 

--- a/pandas/tests/indexes/test_base.py
+++ b/pandas/tests/indexes/test_base.py
@@ -199,6 +199,23 @@ class TestIndex(Base, tm.TestCase):
             result = pd.Index(ArrayLike(array))
             self.assert_index_equal(result, expected)
 
+    def test_constructor_int_dtype_nan(self):
+        # see gh-15187
+        data = [np.nan]
+        msg = "cannot convert"
+
+        with tm.assertRaisesRegexp(ValueError, msg):
+            Index(data, dtype='int64')
+
+        with tm.assertRaisesRegexp(ValueError, msg):
+            Index(data, dtype='uint64')
+
+        # This, however, should not break
+        # because NaN is float.
+        expected = Float64Index(data)
+        result = Index(data, dtype='float')
+        tm.assert_index_equal(result, expected)
+
     def test_index_ctor_infer_nan_nat(self):
         # GH 13467
         exp = pd.Float64Index([np.nan, np.nan])

--- a/pandas/tests/indexes/test_numeric.py
+++ b/pandas/tests/indexes/test_numeric.py
@@ -5,7 +5,7 @@ from pandas.compat import range, PY3
 
 import numpy as np
 
-from pandas import (date_range, Series, Index, Float64Index,
+from pandas import (date_range, notnull, Series, Index, Float64Index,
                     Int64Index, UInt64Index, RangeIndex)
 
 import pandas.util.testing as tm
@@ -685,6 +685,31 @@ class TestInt64Index(NumericInt, tm.TestCase):
         # but not if explicit dtype passed
         arr = Index([1, 2, 3, 4], dtype=object)
         tm.assertIsInstance(arr, Index)
+
+    def test_where(self):
+        i = self.create_index()
+        result = i.where(notnull(i))
+        expected = i
+        tm.assert_index_equal(result, expected)
+
+        _nan = i._na_value
+        cond = [False] + [True] * len(i[1:])
+        expected = pd.Index([_nan] + i[1:].tolist())
+
+        result = i.where(cond)
+        tm.assert_index_equal(result, expected)
+
+    def test_where_array_like(self):
+        i = self.create_index()
+
+        _nan = i._na_value
+        cond = [False] + [True] * (len(i) - 1)
+        klasses = [list, tuple, np.array, pd.Series]
+        expected = pd.Index([_nan] + i[1:].tolist())
+
+        for klass in klasses:
+            result = i.where(klass(cond))
+            tm.assert_index_equal(result, expected)
 
     def test_get_indexer(self):
         target = Int64Index(np.arange(10))

--- a/pandas/tests/indexes/test_range.py
+++ b/pandas/tests/indexes/test_range.py
@@ -8,7 +8,8 @@ from pandas.compat import range, u, PY3
 
 import numpy as np
 
-from pandas import (Series, Index, Float64Index, Int64Index, RangeIndex)
+from pandas import (notnull, Series, Index, Float64Index,
+                    Int64Index, RangeIndex)
 from pandas.util.testing import assertRaisesRegexp
 
 import pandas.util.testing as tm
@@ -915,3 +916,28 @@ class TestRangeIndex(Numeric, tm.TestCase):
 
             i = RangeIndex(0, 5, step)
             self.assertEqual(len(i), 0)
+
+    def test_where(self):
+        i = self.create_index()
+        result = i.where(notnull(i))
+        expected = i
+        tm.assert_index_equal(result, expected)
+
+        _nan = i._na_value
+        cond = [False] + [True] * len(i[1:])
+        expected = pd.Index([_nan] + i[1:].tolist())
+
+        result = i.where(cond)
+        tm.assert_index_equal(result, expected)
+
+    def test_where_array_like(self):
+        i = self.create_index()
+
+        _nan = i._na_value
+        cond = [False] + [True] * (len(i) - 1)
+        klasses = [list, tuple, np.array, pd.Series]
+        expected = pd.Index([_nan] + i[1:].tolist())
+
+        for klass in klasses:
+            result = i.where(klass(cond))
+            tm.assert_index_equal(result, expected)


### PR DESCRIPTION
Finally got around to patching this.  Partially addresses #15187.