### PR TITLE
DOC: fix link to offset strings in resample method

### DIFF
--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -4359,7 +4359,9 @@ class NDFrame(PandasObject):
             resampling.  Level must be datetime-like.
 
             .. versionadded:: 0.19.0
-
+	
+	Notes
+	-----
         To learn more about the offset strings, please see `this link
         <http://pandas.pydata.org/pandas-docs/stable/timeseries.html#offset-aliases>`__.
 

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -4359,9 +4359,9 @@ class NDFrame(PandasObject):
             resampling.  Level must be datetime-like.
 
             .. versionadded:: 0.19.0
-	
-	Notes
-	-----
+
+        Notes
+        -----
         To learn more about the offset strings, please see `this link
         <http://pandas.pydata.org/pandas-docs/stable/timeseries.html#offset-aliases>`__.
 


### PR DESCRIPTION
 - [ ] closes #xxxx

The link to offset strings was not rendered correctly, I've made a sections ```Notes```, and placed the link there.
Part of issue #14843 