### PR TITLE
DOC: make it possible to run doctests

### DIFF
--- a/pandas/conftest.py
+++ b/pandas/conftest.py
@@ -1,5 +1,8 @@
 import pytest
 
+import numpy
+import pandas
+
 
 def pytest_addoption(parser):
     parser.addoption("--skip-slow", action="store_true",
@@ -19,3 +22,11 @@ def pytest_runtest_setup(item):
 
     if 'skip' in item.keywords and item.config.getoption("--skip-network"):
         pytest.skip("skipping due to --skip-network")
+
+
+# For running doctests: make np and pd names available
+
+@pytest.fixture(autouse=True)
+def add_imports(doctest_namespace):
+    doctest_namespace['np'] = numpy
+    doctest_namespace['pd'] = pandas


### PR DESCRIPTION
This adds a small entry in the conftest.py file, which makes it possible to run doctests with eg

```
pytest --doctests-module pandas/core/series.py
```

We are far from being able to run them all without error, and if we would want that is even another question (it may be too much small details to pay attention to), but this let's you at least run specific doctests.