### PR TITLE
DOC: add example for DataFrame.resample: keywords on and level

### DIFF
--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -4460,6 +4460,30 @@ class NDFrame(PandasObject):
         2000-01-01 00:06:00    26
         Freq: 3T, dtype: int64
 
+        For DataFrame objects, the keyword ``on`` can be used to specify the
+        column instead of the index for resampling.
+
+        >>> df = pd.DataFrame(data=9*[range(4)], columns=['a', 'b', 'c', 'd'])
+        >>> df['time'] = pd.date_range('1/1/2000', periods=9, freq='T')
+        >>> df.resample('3T', on='time').sum()
+                             a  b  c  d
+        time
+        2000-01-01 00:00:00  0  3  6  9
+        2000-01-01 00:03:00  0  3  6  9
+        2000-01-01 00:06:00  0  3  6  9
+
+        For a DataFrame with MultiIndex, the keyword ``level`` can be used to
+        specify on level the resampling needs to take place.
+
+        >>> time = pd.date_range('1/1/2000', periods=5, freq='T')
+        >>> df2 = pd.DataFrame(data=10*[range(4)],
+                               columns=['a', 'b', 'c', 'd'],
+                               index=pd.MultiIndex.from_product([time, [1, 2]])
+                               )
+        >>> df2.resample('3T', level=0).sum()
+                             a  b   c   d
+        2000-01-01 00:00:00  0  6  12  18
+        2000-01-01 00:03:00  0  4   8  12
         """
         from pandas.tseries.resample import (resample,
                                              _maybe_process_deprecations)


### PR DESCRIPTION
 - [ ] closes #xxxx

add examples for DataFrame specific keywords: on and level.
This can possibly fix issue #14843 

See attached picture for details

![screenshot - 080317 - 21 34 00](https://cloud.githubusercontent.com/assets/10461030/23722782/fad80f30-0446-11e7-8ebe-e0caff835f01.png)

