### PR TITLE
BUG: Incorrect value updating for groupby.cummin/max (#15635)

### DIFF
--- a/doc/source/whatsnew/v0.20.0.txt
+++ b/doc/source/whatsnew/v0.20.0.txt
@@ -716,7 +716,7 @@ Performance Improvements
 - Increased performance of ``pd.factorize()`` by releasing the GIL with ``object`` dtype when inferred as strings (:issue:`14859`)
 - Improved performance of timeseries plotting with an irregular DatetimeIndex
   (or with ``compat_x=True``) (:issue:`15073`).
-- Improved performance of ``groupby().cummin()`` and ``groupby().cummax()`` (:issue:`15048`, :issue:`15109`, :issue:`15561`)
+- Improved performance of ``groupby().cummin()`` and ``groupby().cummax()`` (:issue:`15048`, :issue:`15109`, :issue:`15561`, :issue:`15635`)
 - Improved performance and reduced memory when indexing with a ``MultiIndex`` (:issue:`15245`)
 - When reading buffer object in ``read_sas()`` method without specified format, filepath string is inferred rather than buffer object. (:issue:`14947`)
 - Improved performance of ``.rank()`` for categorical data (:issue:`15498`)

--- a/pandas/_libs/algos_groupby_helper.pxi.in
+++ b/pandas/_libs/algos_groupby_helper.pxi.in
@@ -603,7 +603,7 @@ def group_cummin_{{name}}(ndarray[{{dest_type2}}, ndim=2] out,
     """
     cdef:
         Py_ssize_t i, j, N, K, size
-        {{dest_type2}} val, min_val = 0
+        {{dest_type2}} val
         ndarray[{{dest_type2}}, ndim=2] accum
         int64_t lab
 
@@ -629,8 +629,7 @@ def group_cummin_{{name}}(ndarray[{{dest_type2}}, ndim=2] out,
                 if val == val:
                 {{endif}}
                     if val < accum[lab, j]:
-                        min_val = val
-                    accum[lab, j] = min_val
+                        accum[lab, j] = val
                     out[i, j] = accum[lab, j]
 
 
@@ -645,7 +644,7 @@ def group_cummax_{{name}}(ndarray[{{dest_type2}}, ndim=2] out,
     """
     cdef:
         Py_ssize_t i, j, N, K, size
-        {{dest_type2}} val, max_val = 0
+        {{dest_type2}} val
         ndarray[{{dest_type2}}, ndim=2] accum
         int64_t lab
 
@@ -670,8 +669,7 @@ def group_cummax_{{name}}(ndarray[{{dest_type2}}, ndim=2] out,
                 if val == val:
                 {{endif}}
                     if val > accum[lab, j]:
-                        max_val = val
-                    accum[lab, j] = max_val
+                        accum[lab, j] = val
                     out[i, j] = accum[lab, j]
 
 {{endfor}}

--- a/pandas/tests/groupby/test_groupby.py
+++ b/pandas/tests/groupby/test_groupby.py
@@ -4303,6 +4303,17 @@ class TestGroupBy(MixIn, tm.TestCase):
             result = getattr(df.groupby('a')['b'], method)()
             tm.assert_series_equal(expected, result)
 
+        # GH 15635
+        df = pd.DataFrame(dict(a=[1, 2, 1], b=[2, 1, 1]))
+        result = df.groupby('a').b.cummax()
+        expected = pd.Series([2, 1, 2], name='b')
+        tm.assert_series_equal(result, expected)
+
+        df = pd.DataFrame(dict(a=[1, 2, 1], b=[1, 2, 2]))
+        result = df.groupby('a').b.cummin()
+        expected = pd.Series([1, 2, 1], name='b')
+        tm.assert_series_equal(result, expected)
+
 
 def _check_groupby(df, result, keys, field, f=lambda x: x.sum()):
     tups = lmap(tuple, df[keys].values)


### PR DESCRIPTION
 - [x] closes #15635
 - [x] tests added / passed
 - [x] passes ``git diff upstream/master | flake8 --diff``
 
Nice catch @adbull. The original implementation was incorrectly setting the incorrect cummin/max value.