### PR TITLE
DOC GH15643 Removed pytest-xdist from requirements_dev.txt file

### DIFF
--- a/ci/requirements_dev.txt
+++ b/ci/requirements_dev.txt
@@ -4,5 +4,4 @@ numpy
 cython
 pytest
 pytest-cov
-pytest-xdist
 flake8


### PR DESCRIPTION
 - [ x] closes #15643
 - [ ] tests added / passed
 - [ ] passes ``git diff upstream/master | flake8 --diff``
 - [ ] whatsnew entry
