### PR TITLE
API: Drop DataFrame.iterkv()

### DIFF
--- a/doc/source/whatsnew/v0.20.0.txt
+++ b/doc/source/whatsnew/v0.20.0.txt
@@ -692,6 +692,7 @@ Other API Changes
 - Reorganization of timeseries development tests (:issue:`14854`)
 - Specific support for ``copy.copy()`` and ``copy.deepcopy()`` functions on NDFrame objects (:issue:`15444`)
 - ``Series.sort_values()`` accepts a one element list of bool for consistency with the behavior of ``DataFrame.sort_values()`` (:issue:`15604`)
+- ``DataFrame.iterkv()`` has been removed in favor of ``DataFrame.iteritems()`` (:issue:`11121`)
 
 .. _whatsnew_0200.deprecations:
 

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -899,16 +899,6 @@ class NDFrame(PandasObject):
         for h in self._info_axis:
             yield h, self[h]
 
-    # originally used to get around 2to3's changes to iteritems.
-    # Now unnecessary. Sidenote: don't want to deprecate this for a while,
-    # otherwise libraries that use 2to3 will have issues.
-    def iterkv(self, *args, **kwargs):
-        "iteritems alias used to get around 2to3. Deprecated"
-        warnings.warn("iterkv is deprecated and will be removed in a future "
-                      "release, use ``iteritems`` instead.", FutureWarning,
-                      stacklevel=2)
-        return self.iteritems(*args, **kwargs)
-
     def __len__(self):
         """Returns length of info axis"""
         return len(self._info_axis)

--- a/pandas/tests/frame/test_misc_api.py
+++ b/pandas/tests/frame/test_misc_api.py
@@ -389,10 +389,6 @@ class TestDataFrameMisc(tm.TestCase, SharedWithSparse, TestData):
         exp = '              X\nNaT        a  1\n2013-01-01 b  2'
         self.assertEqual(res, exp)
 
-    def test_iterkv_deprecation(self):
-        with tm.assert_produces_warning(FutureWarning):
-            self.mixed_float.iterkv()
-
     def test_iterkv_names(self):
         for k, v in compat.iteritems(self.mixed_frame):
             self.assertEqual(v.name, k)


### PR DESCRIPTION
Deprecated since 0.17.0

xref #10711
