### PR TITLE
MAINT: Remove testing.assert_isinstance

### DIFF
--- a/pandas/tests/test_testing.py
+++ b/pandas/tests/test_testing.py
@@ -765,9 +765,6 @@ class TestDeprecatedTests(tm.TestCase):
         with tm.assert_produces_warning(FutureWarning, check_stacklevel=False):
             self.assertNotAlmostEquals(1, 2)
 
-        with tm.assert_produces_warning(FutureWarning, check_stacklevel=False):
-            tm.assert_isinstance(Series([1, 2]), Series, msg='xxx')
-
 
 class TestLocale(tm.TestCase):
 

--- a/pandas/util/testing.py
+++ b/pandas/util/testing.py
@@ -991,11 +991,6 @@ def assertIsInstance(obj, cls, msg=''):
         raise AssertionError(err_msg.format(msg, cls, type(obj)))
 
 
-def assert_isinstance(obj, class_type_or_tuple, msg=''):
-    return deprecate('assert_isinstance', assertIsInstance)(
-        obj, class_type_or_tuple, msg=msg)
-
-
 def assertNotIsInstance(obj, cls, msg=''):
     """Test that obj is not an instance of cls
     (which can be a class or a tuple of classes,


### PR DESCRIPTION
Deprecated in 0.17.0

xref #10458
