### PR TITLE
API: Drop the name parameter from Categorical

### DIFF
--- a/doc/source/whatsnew/v0.20.0.txt
+++ b/doc/source/whatsnew/v0.20.0.txt
@@ -734,7 +734,7 @@ Removal of prior version deprecations/changes
 - The deprecated ``irow``, ``icol``, ``iget`` and ``iget_value`` methods are removed
   in favor of ``iloc`` and ``iat`` as explained :ref:`here <whatsnew_0170.deprecations>` (:issue:`10711`).
 - The deprecated ``DataFrame.iterkv()`` has been removed in favor of ``DataFrame.iteritems()`` (:issue:`10711`)
-
+- The ``Categorical`` constructor has dropped the ``name`` parameter (:issue:`10632`)
 
 .. _whatsnew_0200.performance:
 

--- a/pandas/core/categorical.py
+++ b/pandas/core/categorical.py
@@ -231,8 +231,7 @@ class Categorical(PandasObject):
     __array_priority__ = 1000
     _typ = 'categorical'
 
-    def __init__(self, values, categories=None, ordered=False,
-                 name=None, fastpath=False):
+    def __init__(self, values, categories=None, ordered=False, fastpath=False):
 
         self._validate_ordered(ordered)
 
@@ -243,12 +242,6 @@ class Categorical(PandasObject):
                 categories, fastpath=isinstance(categories, ABCIndexClass))
             self._ordered = ordered
             return
-
-        if name is not None:
-            msg = ("the 'name' keyword is removed, use 'name' with consumers "
-                   "of the categorical instead (e.g. 'Series(cat, "
-                   "name=\"something\")'")
-            warn(msg, UserWarning, stacklevel=2)
 
         # sanitize input
         if is_categorical_dtype(values):
@@ -431,7 +424,7 @@ class Categorical(PandasObject):
         return cls(data, **kwargs)
 
     @classmethod
-    def from_codes(cls, codes, categories, ordered=False, name=None):
+    def from_codes(cls, codes, categories, ordered=False):
         """
         Make a Categorical type from codes and categories arrays.
 
@@ -454,12 +447,6 @@ class Categorical(PandasObject):
             categorical. If not given, the resulting categorical will be
             unordered.
         """
-        if name is not None:
-            msg = ("the 'name' keyword is removed, use 'name' with consumers "
-                   "of the categorical instead (e.g. 'Series(cat, "
-                   "name=\"something\")'")
-            warn(msg, UserWarning, stacklevel=2)
-
         try:
             codes = np.asarray(codes, np.int64)
         except:

--- a/pandas/io/packers.py
+++ b/pandas/io/packers.py
@@ -589,8 +589,7 @@ def decode(obj):
         from_codes = globals()[obj[u'klass']].from_codes
         return from_codes(codes=obj[u'codes'],
                           categories=obj[u'categories'],
-                          ordered=obj[u'ordered'],
-                          name=obj[u'name'])
+                          ordered=obj[u'ordered'])
 
     elif typ == u'series':
         dtype = dtype_for(obj[u'dtype'])

--- a/pandas/tests/io/test_pickle.py
+++ b/pandas/tests/io/test_pickle.py
@@ -265,12 +265,8 @@ def test_round_trip_current(current_pickle_data):
 
 def test_pickle_v0_14_1():
 
-    # we have the name warning
-    # 10482
-    with tm.assert_produces_warning(UserWarning):
-        cat = pd.Categorical(values=['a', 'b', 'c'],
-                             categories=['a', 'b', 'c', 'd'],
-                             name='foobar', ordered=False)
+    cat = pd.Categorical(values=['a', 'b', 'c'], ordered=False,
+                         categories=['a', 'b', 'c', 'd'])
     pickle_path = os.path.join(tm.get_data_path(),
                                'categorical_0_14_1.pickle')
     # This code was executed once on v0.14.1 to generate the pickle:
@@ -286,12 +282,8 @@ def test_pickle_v0_15_2():
     # ordered -> _ordered
     # GH 9347
 
-    # we have the name warning
-    # 10482
-    with tm.assert_produces_warning(UserWarning):
-        cat = pd.Categorical(values=['a', 'b', 'c'],
-                             categories=['a', 'b', 'c', 'd'],
-                             name='foobar', ordered=False)
+    cat = pd.Categorical(values=['a', 'b', 'c'], ordered=False,
+                         categories=['a', 'b', 'c', 'd'])
     pickle_path = os.path.join(tm.get_data_path(),
                                'categorical_0_15_2.pickle')
     # This code was executed once on v0.15.2 to generate the pickle:

--- a/pandas/tests/test_categorical.py
+++ b/pandas/tests/test_categorical.py
@@ -682,7 +682,7 @@ class TestCategorical(tm.TestCase):
 
     def test_big_print(self):
         factor = Categorical([0, 1, 2, 0, 1, 2] * 100, ['a', 'b', 'c'],
-                             name='cat', fastpath=True)
+                             fastpath=True)
         expected = ["[a, b, c, a, b, ..., b, c, a, b, c]", "Length: 600",
                     "Categories (3, object): [a, b, c]"]
         expected = "\n".join(expected)
@@ -1634,15 +1634,6 @@ Categories (3, object): [ああああ, いいいいい, ううううううう]""
         # GH13854, `.from_array` is deprecated
         with tm.assert_produces_warning(FutureWarning):
             Categorical.from_array([0, 1])
-
-    def test_removed_names_produces_warning(self):
-
-        # 10482
-        with tm.assert_produces_warning(UserWarning):
-            Categorical([0, 1], name="a")
-
-        with tm.assert_produces_warning(UserWarning):
-            Categorical.from_codes([1, 2], ["a", "b", "c"], name="a")
 
     def test_datetime_categorical_comparison(self):
         dt_cat = pd.Categorical(


### PR DESCRIPTION
Deprecated in 0.17.0

xref #10632
