### PR TITLE
COMPAT: free parser memory at close() for non-refcnt gc

### DIFF
--- a/pandas/_libs/src/parser/tokenizer.c
+++ b/pandas/_libs/src/parser/tokenizer.c
@@ -162,6 +162,7 @@ int parser_cleanup(parser_t *self) {
         if (self->cb_cleanup(self->source) < 0) {
             status = -1;
         }
+        self->cb_cleanup = NULL;
     }
 
     return status;
@@ -239,6 +240,9 @@ int parser_init(parser_t *self) {
 void parser_free(parser_t *self) {
     // opposite of parser_init
     parser_cleanup(self);
+}
+
+void parser_del(parser_t *self) {
     free(self);
 }
 

--- a/pandas/_libs/src/parser/tokenizer.h
+++ b/pandas/_libs/src/parser/tokenizer.h
@@ -243,6 +243,8 @@ int parser_set_skipfirstnrows(parser_t *self, int64_t nrows);
 
 void parser_free(parser_t *self);
 
+void parser_del(parser_t *self);
+
 void parser_set_default_options(parser_t *self);
 
 void debug_print_parser(parser_t *self);


### PR DESCRIPTION
relying on ``__dealloc__`` to clean up ``malloc()``ed memory can lead to a perceived "leak" on PyPy since the garbage collector will not necessarily collect the object as soon as its ``refcnt`` reaches 0. 

Instead, pre-emptively release memory when ``close()`` is called

The code still maintains backward compatibility for the case where ``close()`` is never called