### PR TITLE
ENH: use constant f32 eps, not np.finfo() during import

### DIFF
--- a/doc/source/whatsnew/v0.20.0.txt
+++ b/doc/source/whatsnew/v0.20.0.txt
@@ -920,3 +920,4 @@ Bug Fixes
 - Bug in ``pd.melt()`` where passing a tuple value for ``value_vars`` caused a ``TypeError`` (:issue:`15348`)
 - Bug in ``.eval()`` which caused multiline evals to fail with local variables not on the first line (:issue:`15342`)
 - Bug in ``pd.read_msgpack`` which did not allow to load dataframe with an index of type ``CategoricalIndex`` (:issue:`15487`)
+- Use of ``np.finfo()`` during `import pandas` removed to mitigate deadlock on Python GIL misuse (:issue:`14641`)

--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -1852,7 +1852,7 @@ class _iAtIndexer(_ScalarAccessIndexer):
 
 
 # 32-bit floating point machine epsilon
-_eps = np.finfo('f4').eps
+_eps = 1.1920929e-07
 
 
 def length_of_indexer(indexer, target=None):


### PR DESCRIPTION
NumPy docs for `np.finfo()` say not to call it during import (at module scope).
It's a relatively expensive call, and it modifies the GIL state.
Now we just hard-code it, because it is always the value anyway.
This avoids touching the GIL at import, which helps avoid deadlocks in practice.

 - [x] closes #14641
 - [ ] tests added / passed
 - [ ] passes ``git diff upstream/master | flake8 --diff``
 - [x] whatsnew entry
