### PR TITLE
BUG: DataFrame.sort_index broken if not both lexsorted and monotonic in levels

### DIFF
--- a/asv_bench/benchmarks/timeseries.py
+++ b/asv_bench/benchmarks/timeseries.py
@@ -292,7 +292,10 @@ class TimeSeries(object):
         self.rng3 = date_range(start='1/1/2000', periods=1500000, freq='S')
         self.ts3 = Series(1, index=self.rng3)
 
-    def time_sort_index(self):
+    def time_sort_index_monotonic(self):
+        self.ts2.sort_index()
+
+    def time_sort_index_non_monotonic(self):
         self.ts.sort_index()
 
     def time_timeseries_slice_minutely(self):

--- a/doc/source/advanced.rst
+++ b/doc/source/advanced.rst
@@ -136,7 +136,7 @@ can find yourself working with hierarchically-indexed data without creating a
 may wish to generate your own ``MultiIndex`` when preparing the data set.
 
 Note that how the index is displayed by be controlled using the
-``multi_sparse`` option in ``pandas.set_printoptions``:
+``multi_sparse`` option in ``pandas.set_options()``:
 
 .. ipython:: python
 
@@ -288,7 +288,7 @@ As usual, **both sides** of the slicers are included as this is label indexing.
 
    .. code-block:: python
 
-      df.loc[(slice('A1','A3'),.....),:]
+      df.loc[(slice('A1','A3'),.....), :]
 
    rather than this:
 
@@ -317,43 +317,43 @@ Basic multi-index slicing using slices, lists, and labels.
 
 .. ipython:: python
 
-   dfmi.loc[(slice('A1','A3'),slice(None), ['C1','C3']),:]
+   dfmi.loc[(slice('A1','A3'), slice(None), ['C1', 'C3']), :]
 
 You can use a ``pd.IndexSlice`` to have a more natural syntax using ``:`` rather than using ``slice(None)``
 
 .. ipython:: python
 
    idx = pd.IndexSlice
-   dfmi.loc[idx[:,:,['C1','C3']],idx[:,'foo']]
+   dfmi.loc[idx[:, :, ['C1', 'C3']], idx[:, 'foo']]
 
 It is possible to perform quite complicated selections using this method on multiple
 axes at the same time.
 
 .. ipython:: python
 
-   dfmi.loc['A1',(slice(None),'foo')]
-   dfmi.loc[idx[:,:,['C1','C3']],idx[:,'foo']]
+   dfmi.loc['A1', (slice(None), 'foo')]
+   dfmi.loc[idx[:, :, ['C1', 'C3']], idx[:, 'foo']]
 
 Using a boolean indexer you can provide selection related to the *values*.
 
 .. ipython:: python
 
-   mask = dfmi[('a','foo')]>200
-   dfmi.loc[idx[mask,:,['C1','C3']],idx[:,'foo']]
+   mask = dfmi[('a', 'foo')] > 200
+   dfmi.loc[idx[mask, :, ['C1', 'C3']], idx[:, 'foo']]
 
 You can also specify the ``axis`` argument to ``.loc`` to interpret the passed
 slicers on a single axis.
 
 .. ipython:: python
 
-   dfmi.loc(axis=0)[:,:,['C1','C3']]
+   dfmi.loc(axis=0)[:, :, ['C1', 'C3']]
 
 Furthermore you can *set* the values using these methods
 
 .. ipython:: python
 
    df2 = dfmi.copy()
-   df2.loc(axis=0)[:,:,['C1','C3']] = -10
+   df2.loc(axis=0)[:, :, ['C1', 'C3']] = -10
    df2
 
 You can use a right-hand-side of an alignable object as well.
@@ -361,7 +361,7 @@ You can use a right-hand-side of an alignable object as well.
 .. ipython:: python
 
    df2 = dfmi.copy()
-   df2.loc[idx[:,:,['C1','C3']],:] = df2*1000
+   df2.loc[idx[:, :, ['C1', 'C3']], :] = df2 * 1000
    df2
 
 .. _advanced.xs:

--- a/doc/source/advanced.rst
+++ b/doc/source/advanced.rst
@@ -175,35 +175,40 @@ completely analogous way to selecting a column in a regular DataFrame:
 See :ref:`Cross-section with hierarchical index <advanced.xs>` for how to select
 on a deeper level.
 
-.. note::
+.. _advanced.shown_levels:
 
-   The repr of a ``MultiIndex`` shows ALL the defined levels of an index, even
-   if the they are not actually used. When slicing an index, you may notice this.
-   For example:
+Defined Levels
+~~~~~~~~~~~~~~
 
-   .. ipython:: python
+The repr of a ``MultiIndex`` shows ALL the defined levels of an index, even
+if the they are not actually used. When slicing an index, you may notice this.
+For example:
 
-      # original multi-index
-      df.columns
+.. ipython:: python
 
-      # sliced
-      df[['foo','qux']].columns
+   # original multi-index
+   df.columns
 
-   This is done to avoid a recomputation of the levels in order to make slicing
-   highly performant. If you want to see the actual used levels.
+   # sliced
+   df[['foo','qux']].columns
 
-   .. ipython:: python
+This is done to avoid a recomputation of the levels in order to make slicing
+highly performant. If you want to see the actual used levels.
 
-      df[['foo','qux']].columns.values
+.. ipython:: python
 
-      # for a specific level
-      df[['foo','qux']].columns.get_level_values(0)
+   df[['foo','qux']].columns.values
 
-   To reconstruct the multiindex with only the used levels
+   # for a specific level
+   df[['foo','qux']].columns.get_level_values(0)
 
-   .. ipython:: python
+To reconstruct the multiindex with only the used levels
 
-      pd.MultiIndex.from_tuples(df[['foo','qux']].columns.values)
+.. versionadded:: 0.20.0
+
+.. ipython:: python
+
+   df[['foo','qux']].columns.remove_unused_levels()
 
 Data alignment and using ``reindex``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/source/api.rst
+++ b/doc/source/api.rst
@@ -1432,6 +1432,7 @@ MultiIndex Components
    MultiIndex.droplevel
    MultiIndex.swaplevel
    MultiIndex.reorder_levels
+   MultiIndex.remove_unused_levels
 
 .. _api.datetimeindex:
 

--- a/doc/source/whatsnew/v0.20.0.txt
+++ b/doc/source/whatsnew/v0.20.0.txt
@@ -720,7 +720,7 @@ DataFrame.sort_index changes
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 In certain cases, calling ``.sort_index()`` on a MultiIndexed DataFrame would return the *same* DataFrame without seeming to sort.
-This would happen with a ``lexsorted``, but non-montonic levels. (:issue:`15622`, :issue:`15687`, :issue:`14015`, :issue:`13431`)
+This would happen with a ``lexsorted``, but non-monotonic levels. (:issue:`15622`, :issue:`15687`, :issue:`14015`, :issue:`13431`)
 
 This is UNCHANGED between versions, but showing for illustration purposes:
 
@@ -777,15 +777,6 @@ New Behavior:
    df.sort_index()
    df.sort_index().index.is_lexsorted()
    df.sort_index().index.is_monotonic
-
-Previous Behavior:
-
-.. code-block:: ipython
-
-New Behavior:
-
-.. ipython:: python
-
 
 .. _whatsnew_0200.api_breaking.groupby_describe:
 

--- a/doc/source/whatsnew/v0.20.0.txt
+++ b/doc/source/whatsnew/v0.20.0.txt
@@ -714,6 +714,78 @@ If indicated, a deprecation warning will be issued if you reference that module.
     "pandas._hash", "pandas.tools.libhash", ""
     "pandas._window", "pandas.core.libwindow", ""
 
+.. _whatsnew_0200.api_breaking.sort_index:
+
+DataFrame.sort_index changes
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+In certain cases, calling ``.sort_index()`` on a MultiIndexed DataFrame would return the *same* DataFrame without seeming to sort.
+This would happen with a ``lexsorted``, but non-montonic levels. (:issue:`15622`, :issue:`15687`, :issue:`14015`, :issue:`13431`)
+
+This is UNCHANGED between versions, but showing for illustration purposes:
+
+.. ipython:: python
+
+    df = DataFrame(np.arange(6), columns=['value'], index=MultiIndex.from_product([list('BA'), range(3)]))
+    df
+
+.. ipython:: python
+
+    df.index.is_lexsorted()
+    df.index.is_monotonic
+
+Sorting works as expected
+
+.. ipython:: python
+
+    df.sort_index()
+
+.. ipython:: python
+
+    df.sort_index().index.is_lexsorted()
+    df.sort_index().index.is_monotonic
+
+However, this example, which has a monotonic level, doesn't behave as desired.
+
+.. ipython:: python
+   df = pd.DataFrame({'value': [1, 2, 3, 4]},
+                      index=pd.MultiIndex(levels=[['a', 'b'], ['bb', 'aa']],
+                                         labels=[[0, 0, 1, 1], [0, 1, 0, 1]]))
+
+Previous Behavior:
+
+.. ipython:: python
+
+   In [11]: df.sort_index()
+   Out[11]:
+         value
+   a bb      1
+     aa      2
+   b bb      3
+     aa      4
+
+   In [14]: df.sort_index().index.is_lexsorted()
+   Out[14]: True
+
+   In [15]: df.sort_index().index.is_monotonic
+   Out[15]: False
+
+New Behavior:
+
+.. ipython:: python
+
+   df.sort_index()
+   df.sort_index().index.is_lexsorted()
+   df.sort_index().index.is_monotonic
+
+Previous Behavior:
+
+.. code-block:: ipython
+
+New Behavior:
+
+.. ipython:: python
+
 
 .. _whatsnew_0200.api_breaking.groupby_describe:
 
@@ -965,7 +1037,7 @@ Performance Improvements
 - Improve performance of ``pd.core.groupby.GroupBy.apply`` when the applied
   function used the ``.name`` attribute of the group DataFrame (:issue:`15062`).
 - Improved performance of ``iloc`` indexing with a list or array (:issue:`15504`).
-
+- Improved performance of ``Series.sort_index()`` with a monotonic index (:issue:`15694`)
 
 .. _whatsnew_0200.bug_fixes:
 

--- a/doc/source/whatsnew/v0.20.0.txt
+++ b/doc/source/whatsnew/v0.20.0.txt
@@ -366,6 +366,7 @@ Other Enhancements
 - ``pandas.io.json.json_normalize()`` with an empty ``list`` will return an empty ``DataFrame`` (:issue:`15534`)
 - ``pandas.io.json.json_normalize()`` has gained a ``sep`` option that accepts ``str`` to separate joined fields; the default is ".", which is backward compatible. (:issue:`14883`)
 - ``pd.read_csv()`` will now raise a ``csv.Error`` error whenever an end-of-file character is encountered in the middle of a data row (:issue:`15913`)
+- A new function has been added to a ``MultiIndex`` to facilitate :ref:`Removing Unused Levels <advanced.shown_levels>`. (:issue:`15694`)
 
 
 .. _ISO 8601 duration: https://en.wikipedia.org/wiki/ISO_8601#Durations
@@ -777,6 +778,7 @@ New Behavior:
    df.sort_index()
    df.sort_index().index.is_lexsorted()
    df.sort_index().index.is_monotonic
+
 
 .. _whatsnew_0200.api_breaking.groupby_describe:
 

--- a/doc/source/whatsnew/v0.20.0.txt
+++ b/doc/source/whatsnew/v0.20.0.txt
@@ -367,6 +367,7 @@ Other Enhancements
 - ``pandas.io.json.json_normalize()`` has gained a ``sep`` option that accepts ``str`` to separate joined fields; the default is ".", which is backward compatible. (:issue:`14883`)
 - ``pd.read_csv()`` will now raise a ``csv.Error`` error whenever an end-of-file character is encountered in the middle of a data row (:issue:`15913`)
 - A new function has been added to a ``MultiIndex`` to facilitate :ref:`Removing Unused Levels <advanced.shown_levels>`. (:issue:`15694`)
+- :func:`MultiIndex.remove_unused_levels` has been added to facilitate :ref:`removing unused levels <advanced.shown_levels>`. (:issue:`15694`)
 
 
 .. _ISO 8601 duration: https://en.wikipedia.org/wiki/ISO_8601#Durations
@@ -746,12 +747,14 @@ Sorting works as expected
     df.sort_index().index.is_lexsorted()
     df.sort_index().index.is_monotonic
 
-However, this example, which has a monotonic level, doesn't behave as desired.
+However, this example, which has a non-monotonic 2nd level,
+doesn't behave as desired.
 
 .. ipython:: python
-   df = pd.DataFrame({'value': [1, 2, 3, 4]},
-                      index=pd.MultiIndex(levels=[['a', 'b'], ['bb', 'aa']],
-                                         labels=[[0, 0, 1, 1], [0, 1, 0, 1]]))
+   df = pd.DataFrame(
+           {'value': [1, 2, 3, 4]},
+            index=pd.MultiIndex(levels=[['a', 'b'], ['bb', 'aa']],
+                                labels=[[0, 0, 1, 1], [0, 1, 0, 1]]))
 
 Previous Behavior:
 

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -3349,7 +3349,7 @@ it is assumed to be aliases for the column names.')
 
             # make sure that the axis is lexsorted to start
             # if not we need to reconstruct to get the correct indexer
-            labels = labels._reconstruct(sort=True)
+            labels = labels.sort_monotonic()
 
             indexer = lexsort_indexer(labels.labels, orders=ascending,
                                       na_position=na_position)

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -3349,8 +3349,7 @@ it is assumed to be aliases for the column names.')
 
             # make sure that the axis is lexsorted to start
             # if not we need to reconstruct to get the correct indexer
-            labels = labels.sort_levels_monotonic()
-
+            labels = labels._sort_levels_monotonic()
             indexer = lexsort_indexer(labels.labels, orders=ascending,
                                       na_position=na_position)
         else:

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -3349,7 +3349,7 @@ it is assumed to be aliases for the column names.')
 
             # make sure that the axis is lexsorted to start
             # if not we need to reconstruct to get the correct indexer
-            labels = labels.sort_monotonic()
+            labels = labels.sort_levels_monotonic()
 
             indexer = lexsort_indexer(labels.labels, orders=ascending,
                                       na_position=na_position)

--- a/pandas/core/groupby.py
+++ b/pandas/core/groupby.py
@@ -1882,6 +1882,13 @@ class BaseGrouper(object):
         'ohlc': lambda *args: ['open', 'high', 'low', 'close']
     }
 
+    def _is_builtin_func(self, arg):
+        """
+        if we define an builtin function for this argument, return it,
+        otherwise return the arg
+        """
+        return SelectionMixin._builtin_table.get(arg, arg)
+
     def _get_cython_function(self, kind, how, values, is_numeric):
 
         dtype_str = values.dtype.name
@@ -2107,7 +2114,7 @@ class BaseGrouper(object):
         # avoids object / Series creation overhead
         dummy = obj._get_values(slice(None, 0)).to_dense()
         indexer = get_group_index_sorter(group_index, ngroups)
-        obj = obj.take(indexer, convert=False)
+        obj = obj.take(indexer, convert=False).to_dense()
         group_index = algorithms.take_nd(
             group_index, indexer, allow_fill=False)
         grouper = lib.SeriesGrouper(obj, func, group_index, ngroups,

--- a/pandas/core/reshape.py
+++ b/pandas/core/reshape.py
@@ -22,8 +22,8 @@ from pandas.sparse.array import SparseArray
 from pandas.sparse.libsparse import IntIndex
 
 from pandas.core.categorical import Categorical, _factorize_from_iterable
-from pandas.core.sorting import (get_group_index, compress_group_index,
-                                 decons_obs_group_ids)
+from pandas.core.sorting import (get_group_index, get_compressed_ids,
+                                 compress_group_index, decons_obs_group_ids)
 
 import pandas.core.algorithms as algos
 from pandas._libs import algos as _algos, reshape as _reshape
@@ -494,11 +494,6 @@ def _unstack_frame(obj, level, fill_value=None):
                                value_columns=obj.columns,
                                fill_value=fill_value)
         return unstacker.get_result()
-
-
-def get_compressed_ids(labels, sizes):
-    ids = get_group_index(labels, sizes, sort=True, xnull=False)
-    return compress_group_index(ids, sort=True)
 
 
 def stack(frame, level=-1, dropna=True):

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -1762,7 +1762,7 @@ class Series(base.IndexOpsMixin, strings.StringAccessorMixin,
                                                  sort_remaining=sort_remaining)
         elif isinstance(index, MultiIndex):
             from pandas.core.sorting import lexsort_indexer
-            labels = index.sort_levels_monotonic()
+            labels = index._sort_levels_monotonic()
             indexer = lexsort_indexer(labels.labels, orders=ascending)
         else:
             from pandas.core.sorting import nargsort

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -1762,7 +1762,7 @@ class Series(base.IndexOpsMixin, strings.StringAccessorMixin,
                                                  sort_remaining=sort_remaining)
         elif isinstance(index, MultiIndex):
             from pandas.core.sorting import lexsort_indexer
-            labels = index.sort_monotonic()
+            labels = index.sort_levels_monotonic()
             indexer = lexsort_indexer(labels.labels, orders=ascending)
         else:
             from pandas.core.sorting import nargsort

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -1762,7 +1762,7 @@ class Series(base.IndexOpsMixin, strings.StringAccessorMixin,
                                                  sort_remaining=sort_remaining)
         elif isinstance(index, MultiIndex):
             from pandas.core.sorting import lexsort_indexer
-            labels = index._reconstruct(sort=True)
+            labels = index.sort_monotonic()
             indexer = lexsort_indexer(labels.labels, orders=ascending)
         else:
             from pandas.core.sorting import nargsort

--- a/pandas/core/sorting.py
+++ b/pandas/core/sorting.py
@@ -94,6 +94,22 @@ def get_group_index(labels, shape, sort, xnull):
 
 
 def get_compressed_ids(labels, sizes):
+    """
+
+    Group_index is offsets into cartesian product of all possible labels. This
+    space can be huge, so this function compresses it, by computing offsets
+    (comp_ids) into the list of unique labels (obs_group_ids).
+
+    Parameters
+    ----------
+    labels : list of label arrays
+    sizes : list of size of the levels
+
+    Returns
+    -------
+    tuple of (comp_ids, obs_group_ids)
+
+    """
     ids = get_group_index(labels, sizes, sort=True, xnull=False)
     return compress_group_index(ids, sort=True)
 

--- a/pandas/core/sorting.py
+++ b/pandas/core/sorting.py
@@ -93,6 +93,11 @@ def get_group_index(labels, shape, sort, xnull):
     return loop(list(labels), list(shape))
 
 
+def get_compressed_ids(labels, sizes):
+    ids = get_group_index(labels, sizes, sort=True, xnull=False)
+    return compress_group_index(ids, sort=True)
+
+
 def is_int64_overflow_possible(shape):
     the_prod = long(1)
     for x in shape:

--- a/pandas/indexes/multi.py
+++ b/pandas/indexes/multi.py
@@ -1175,10 +1175,14 @@ class MultiIndex(Index):
 
     def _reconstruct(self, sort=False, remove_unused=False):
         """
-        reconstruct the MultiIndex
+        create a new MultiIndex from the current to provide either:
+          - monotonically sorted items IN the levels
+          - removing unused levels (meaning that they are not expressed
+            in the labels)
 
-        The MultiIndex will have the same outward appearance (e.g. values)
-        and will also .equals()
+        The resulting MultiIndex will have the same outward
+        appearance, meaning the same .values and ordering. It will also
+        be .equals() to the original.
 
         Parameters
         ----------
@@ -1189,7 +1193,7 @@ class MultiIndex(Index):
 
         Returns
         -------
-        MultiIndex
+        new MultiIndex
 
         """
 

--- a/pandas/indexes/multi.py
+++ b/pandas/indexes/multi.py
@@ -1792,9 +1792,10 @@ class MultiIndex(Index):
 
     def _partial_tup_index(self, tup, side='left'):
         if len(tup) > self.lexsort_depth:
-            raise KeyError('Key length (%d) was greater than MultiIndex'
-                           ' lexsort depth (%d)' %
-                           (len(tup), self.lexsort_depth))
+            raise UnsortedIndexError(
+                'Key length (%d) was greater than MultiIndex'
+                ' lexsort depth (%d)' %
+                (len(tup), self.lexsort_depth))
 
         n = len(tup)
         start, end = 0, len(self)

--- a/pandas/indexes/multi.py
+++ b/pandas/indexes/multi.py
@@ -1240,20 +1240,21 @@ class MultiIndex(Index):
         new_levels = []
         new_labels = []
 
-        changed = np.zeros(self.nlevels, dtype=bool)
+        changed = np.ones(self.nlevels, dtype=bool)
         for i, (lev, lab) in enumerate(zip(self.levels, self.labels)):
 
-            uniques = np.sort(algos.unique(lab))
+            uniques = algos.unique(lab)
 
             # nothing unused
             if len(uniques) == len(lev):
                 new_levels.append(lev)
                 new_labels.append(lab)
-                changed[i] = True
+                changed[i] = False
                 continue
 
-            unused = list(reversed(sorted(set(
-                np.arange(len(lev))) - set(uniques))))
+            # set difference, then reverse sort
+            diff = Index(np.arange(len(lev))).difference(uniques)
+            unused = diff.sort_values(ascending=False)
 
             # new levels are simple
             lev = lev.take(uniques)

--- a/pandas/indexes/multi.py
+++ b/pandas/indexes/multi.py
@@ -1235,6 +1235,23 @@ class MultiIndex(Index):
         -------
         MultiIndex
 
+        Examples
+        --------
+        >>> i = MultiIndex.from_product([range(2), list('ab')])
+        MultiIndex(levels=[[0, 1], ['a', 'b']],
+                   labels=[[0, 0, 1, 1], [0, 1, 0, 1]])
+
+
+        >>> i[2:]
+        MultiIndex(levels=[[0, 1], ['a', 'b']],
+                   labels=[[1, 1], [0, 1]])
+
+        # the 0 from the first level is not represented
+        # and can be removed
+        >>> i[2:].remove_unused_levels()
+        MultiIndex(levels=[[1], ['a', 'b']],
+                   labels=[[0, 0], [0, 1]])
+
         """
 
         new_levels = []

--- a/pandas/indexes/multi.py
+++ b/pandas/indexes/multi.py
@@ -1175,6 +1175,10 @@ class MultiIndex(Index):
 
     def sort_monotonic(self):
         """
+        .. versionadded:: 0.20.0
+
+        This is an *internal* function.
+
         create a new MultiIndex from the current to monotonically sorted
         items IN the levels
 
@@ -1218,6 +1222,8 @@ class MultiIndex(Index):
 
     def remove_unused_levels(self):
         """
+        .. versionadded:: 0.20.0
+
         create a new MultiIndex from the current that removesing
         unused levels, meaning that they are not expressed in the labels
 

--- a/pandas/indexes/multi.py
+++ b/pandas/indexes/multi.py
@@ -1173,14 +1173,15 @@ class MultiIndex(Index):
         labels = cartesian_product(labels)
         return MultiIndex(levels, labels, sortorder=sortorder, names=names)
 
-    def sort_monotonic(self):
+    def sort_levels_monotonic(self):
         """
         .. versionadded:: 0.20.0
 
         This is an *internal* function.
 
         create a new MultiIndex from the current to monotonically sorted
-        items IN the levels
+        items IN the levels. This does not actually make the entire MultiIndex
+        monotonic, JUST the levels.
 
         The resulting MultiIndex will have the same outward
         appearance, meaning the same .values and ordering. It will also
@@ -1189,6 +1190,19 @@ class MultiIndex(Index):
         Returns
         -------
         MultiIndex
+
+        Examples
+        --------
+
+        >>> i = pd.MultiIndex(levels=[['a', 'b'], ['bb', 'aa']],
+                              labels=[[0, 0, 1, 1], [0, 1, 0, 1]])
+        >>> i
+        MultiIndex(levels=[['a', 'b'], ['bb', 'aa']],
+                   labels=[[0, 0, 1, 1], [0, 1, 0, 1]])
+
+        >>> i.sort_monotonic()
+        MultiIndex(levels=[['a', 'b'], ['aa', 'bb']],
+                   labels=[[0, 0, 1, 1], [1, 0, 1, 0]])
 
         """
 
@@ -1237,7 +1251,7 @@ class MultiIndex(Index):
 
         Examples
         --------
-        >>> i = MultiIndex.from_product([range(2), list('ab')])
+        >>> i = pd.MultiIndex.from_product([range(2), list('ab')])
         MultiIndex(levels=[[0, 1], ['a', 'b']],
                    labels=[[0, 0, 1, 1], [0, 1, 0, 1]])
 

--- a/pandas/indexes/multi.py
+++ b/pandas/indexes/multi.py
@@ -1173,7 +1173,7 @@ class MultiIndex(Index):
         labels = cartesian_product(labels)
         return MultiIndex(levels, labels, sortorder=sortorder, names=names)
 
-    def sort_levels_monotonic(self):
+    def _sort_levels_monotonic(self):
         """
         .. versionadded:: 0.20.0
 
@@ -1236,14 +1236,14 @@ class MultiIndex(Index):
 
     def remove_unused_levels(self):
         """
-        .. versionadded:: 0.20.0
-
-        create a new MultiIndex from the current that removesing
+        create a new MultiIndex from the current that removing
         unused levels, meaning that they are not expressed in the labels
 
         The resulting MultiIndex will have the same outward
         appearance, meaning the same .values and ordering. It will also
         be .equals() to the original.
+
+        .. versionadded:: 0.20.0
 
         Returns
         -------

--- a/pandas/indexes/multi.py
+++ b/pandas/indexes/multi.py
@@ -1171,9 +1171,57 @@ class MultiIndex(Index):
 
         labels, levels = _factorize_from_iterables(iterables)
         labels = cartesian_product(labels)
+        return MultiIndex(levels, labels, sortorder=sortorder, names=names)
 
-        return MultiIndex(levels=levels, labels=labels, sortorder=sortorder,
-                          names=names)
+    def _reconstruct(self, sort=False):
+        """
+        reconstruct the MultiIndex
+
+        The MultiIndex will have the same outward appearance (e.g. values)
+        and will also .equals()
+
+        Parameters
+        ----------
+        sort: boolean, default False
+            monotonically sort the levels
+
+        Returns
+        -------
+        MultiIndex
+
+        """
+        new_levels = []
+        new_labels = []
+
+        if sort:
+
+            if self.is_monotonic:
+                return self
+
+            for lev, lab in zip(self.levels, self.labels):
+
+                if lev.is_monotonic:
+                    new_levels.append(lev)
+                    new_labels.append(lab)
+                    continue
+
+                # indexer to reorder the levels
+                indexer = lev.argsort()
+                lev = lev.take(indexer)
+
+                # indexer to reorder the labels
+                ri = lib.get_reverse_indexer(indexer, len(indexer))
+                lab = algos.take_1d(ri, lab)
+
+                new_levels.append(lev)
+                new_labels.append(lab)
+
+        else:
+            return self
+
+        return MultiIndex(new_levels, new_labels,
+                          names=self.names, sortorder=self.sortorder,
+                          verify_integrity=False)
 
     @property
     def nlevels(self):

--- a/pandas/tests/indexes/test_multi.py
+++ b/pandas/tests/indexes/test_multi.py
@@ -2411,6 +2411,59 @@ class TestMultiIndex(Base, tm.TestCase):
 
         self.assertFalse(i.is_monotonic)
 
+    def test_reconstruct_sort(self):
+
+        # starts off lexsorted & monotonic
+        mi = MultiIndex.from_arrays([
+            ['A', 'A', 'B', 'B', 'B'], [1, 2, 1, 2, 3]
+        ])
+        assert mi.is_lexsorted()
+        assert mi.is_monotonic
+
+        recons = mi._reconstruct(sort=True)
+        assert recons.is_lexsorted()
+        assert recons.is_monotonic
+        assert mi is recons
+
+        assert mi.equals(recons)
+        assert Index(mi.values).equals(Index(recons.values))
+
+        recons = mi._reconstruct(sort=False)
+        assert recons.is_lexsorted()
+        assert recons.is_monotonic
+        assert mi is recons
+
+        assert mi.equals(recons)
+        assert Index(mi.values).equals(Index(recons.values))
+
+        # cannot convert to lexsorted
+        mi = pd.MultiIndex.from_tuples([('z', 'a'), ('x', 'a'), ('y', 'b'),
+                                        ('x', 'b'), ('y', 'a'), ('z', 'b')],
+                                       names=['one', 'two'])
+        assert not mi.is_lexsorted()
+        assert not mi.is_monotonic
+
+        recons = mi._reconstruct(sort=True)
+        assert not recons.is_lexsorted()
+        assert not recons.is_monotonic
+
+        assert mi.equals(recons)
+        assert Index(mi.values).equals(Index(recons.values))
+
+        # cannot convert to lexsorted
+        mi = MultiIndex(levels=[['b', 'd', 'a'], [1, 2, 3]],
+                        labels=[[0, 1, 0, 2], [2, 0, 0, 1]],
+                        names=['col1', 'col2'])
+        assert not mi.is_lexsorted()
+        assert not mi.is_monotonic
+
+        recons = mi._reconstruct(sort=True)
+        assert not recons.is_lexsorted()
+        assert not recons.is_monotonic
+
+        assert mi.equals(recons)
+        assert Index(mi.values).equals(Index(recons.values))
+
     def test_isin(self):
         values = [('foo', 2), ('bar', 3), ('quux', 4)]
 

--- a/pandas/tests/indexes/test_multi.py
+++ b/pandas/tests/indexes/test_multi.py
@@ -2411,18 +2411,6 @@ class TestMultiIndex(Base, tm.TestCase):
 
         self.assertFalse(i.is_monotonic)
 
-    def test_reconstruct_api(self):
-
-        mi = MultiIndex.from_arrays([
-            ['A', 'A', 'B', 'B', 'B'], [1, 2, 1, 2, 3]
-        ])
-
-        with pytest.raises(ValueError):
-            mi._reconstruct()
-
-        with pytest.raises(ValueError):
-            mi._reconstruct(sort=True, remove_unused=True)
-
     def test_reconstruct_sort(self):
 
         # starts off lexsorted & monotonic
@@ -2432,7 +2420,7 @@ class TestMultiIndex(Base, tm.TestCase):
         assert mi.is_lexsorted()
         assert mi.is_monotonic
 
-        recons = mi._reconstruct(sort=True)
+        recons = mi.sort_monotonic()
         assert recons.is_lexsorted()
         assert recons.is_monotonic
         assert mi is recons
@@ -2447,7 +2435,7 @@ class TestMultiIndex(Base, tm.TestCase):
         assert not mi.is_lexsorted()
         assert not mi.is_monotonic
 
-        recons = mi._reconstruct(sort=True)
+        recons = mi.sort_monotonic()
         assert not recons.is_lexsorted()
         assert not recons.is_monotonic
 
@@ -2461,7 +2449,7 @@ class TestMultiIndex(Base, tm.TestCase):
         assert not mi.is_lexsorted()
         assert not mi.is_monotonic
 
-        recons = mi._reconstruct(sort=True)
+        recons = mi.sort_monotonic()
         assert not recons.is_lexsorted()
         assert not recons.is_monotonic
 
@@ -2489,11 +2477,11 @@ class TestMultiIndex(Base, tm.TestCase):
                                       [2, 3]],
                               labels=[[0, 1], [0, 1]],
                               names=['first', 'second'])
-        result = df2.index._reconstruct(remove_unused=True)
+        result = df2.index.remove_unused_levels()
         tm.assert_index_equal(result, expected)
 
         # idempotent
-        result2 = result._reconstruct(remove_unused=True)
+        result2 = result.remove_unused_levels()
         tm.assert_index_equal(result2, expected)
         assert result2 is result
 

--- a/pandas/tests/indexes/test_multi.py
+++ b/pandas/tests/indexes/test_multi.py
@@ -2752,6 +2752,30 @@ class TestMultiIndex(Base, tm.TestCase):
         with assertRaises(KeyError):
             df.loc(axis=0)['q', :]
 
+    def test_unsortedindex_doc_examples(self):
+        # http://pandas.pydata.org/pandas-docs/stable/advanced.html#sorting-a-multiindex  # noqa
+        dfm = DataFrame({'jim': [0, 0, 1, 1],
+                         'joe': ['x', 'x', 'z', 'y'],
+                         'jolie': np.random.rand(4)})
+
+        dfm = dfm.set_index(['jim', 'joe'])
+        with tm.assert_produces_warning(PerformanceWarning):
+            dfm.loc[(1, 'z')]
+
+        with pytest.raises(UnsortedIndexError):
+            dfm.loc[(0, 'y'):(1, 'z')]
+
+        assert not dfm.index.is_lexsorted()
+        assert dfm.index.lexsort_depth == 1
+
+        # sort it
+        dfm = dfm.sort_index()
+        dfm.loc[(1, 'z')]
+        dfm.loc[(0, 'y'):(1, 'z')]
+
+        assert dfm.index.is_lexsorted()
+        assert dfm.index.lexsort_depth == 2
+
     def test_tuples_with_name_string(self):
         # GH 15110 and GH 14848
 

--- a/pandas/tests/indexes/test_multi.py
+++ b/pandas/tests/indexes/test_multi.py
@@ -2420,7 +2420,7 @@ class TestMultiIndex(Base, tm.TestCase):
         assert mi.is_lexsorted()
         assert mi.is_monotonic
 
-        recons = mi.sort_monotonic()
+        recons = mi.sort_levels_monotonic()
         assert recons.is_lexsorted()
         assert recons.is_monotonic
         assert mi is recons
@@ -2435,7 +2435,7 @@ class TestMultiIndex(Base, tm.TestCase):
         assert not mi.is_lexsorted()
         assert not mi.is_monotonic
 
-        recons = mi.sort_monotonic()
+        recons = mi.sort_levels_monotonic()
         assert not recons.is_lexsorted()
         assert not recons.is_monotonic
 
@@ -2449,7 +2449,7 @@ class TestMultiIndex(Base, tm.TestCase):
         assert not mi.is_lexsorted()
         assert not mi.is_monotonic
 
-        recons = mi.sort_monotonic()
+        recons = mi.sort_levels_monotonic()
         assert not recons.is_lexsorted()
         assert not recons.is_monotonic
 

--- a/pandas/tests/indexes/test_multi.py
+++ b/pandas/tests/indexes/test_multi.py
@@ -2420,7 +2420,7 @@ class TestMultiIndex(Base, tm.TestCase):
         assert mi.is_lexsorted()
         assert mi.is_monotonic
 
-        recons = mi.sort_levels_monotonic()
+        recons = mi._sort_levels_monotonic()
         assert recons.is_lexsorted()
         assert recons.is_monotonic
         assert mi is recons
@@ -2435,7 +2435,7 @@ class TestMultiIndex(Base, tm.TestCase):
         assert not mi.is_lexsorted()
         assert not mi.is_monotonic
 
-        recons = mi.sort_levels_monotonic()
+        recons = mi._sort_levels_monotonic()
         assert not recons.is_lexsorted()
         assert not recons.is_monotonic
 
@@ -2449,7 +2449,7 @@ class TestMultiIndex(Base, tm.TestCase):
         assert not mi.is_lexsorted()
         assert not mi.is_monotonic
 
-        recons = mi.sort_levels_monotonic()
+        recons = mi._sort_levels_monotonic()
         assert not recons.is_lexsorted()
         assert not recons.is_monotonic
 

--- a/pandas/tests/series/test_analytics.py
+++ b/pandas/tests/series/test_analytics.py
@@ -1526,7 +1526,7 @@ class TestSeriesAnalytics(TestData, tm.TestCase):
                                labels=[[0, 1, 2, 0, 1, 2], [0, 1, 0, 1, 0, 1]])
         expected = DataFrame({'bar': s.values},
                              index=exp_index).sort_index(level=0)
-        unstacked = s.unstack(0)
+        unstacked = s.unstack(0).sort_index()
         assert_frame_equal(unstacked, expected)
 
         # GH5873

--- a/pandas/tests/test_multilevel.py
+++ b/pandas/tests/test_multilevel.py
@@ -2582,7 +2582,7 @@ class TestSorted(Base, tm.TestCase):
 
         # reconstruct
         result = df.sort_index().copy()
-        result.index = result.index.sort_monotonic()
+        result.index = result.index.sort_levels_monotonic()
         assert result.index.is_lexsorted()
         assert result.index.is_monotonic
 

--- a/pandas/tests/test_multilevel.py
+++ b/pandas/tests/test_multilevel.py
@@ -2582,7 +2582,7 @@ class TestSorted(Base, tm.TestCase):
 
         # reconstruct
         result = df.sort_index().copy()
-        result.index = result.index.sort_levels_monotonic()
+        result.index = result.index._sort_levels_monotonic()
         assert result.index.is_lexsorted()
         assert result.index.is_monotonic
 

--- a/pandas/tests/test_multilevel.py
+++ b/pandas/tests/test_multilevel.py
@@ -2582,7 +2582,7 @@ class TestSorted(Base, tm.TestCase):
 
         # reconstruct
         result = df.sort_index().copy()
-        result.index = result.index._reconstruct(sort=True)
+        result.index = result.index.sort_monotonic()
         assert result.index.is_lexsorted()
         assert result.index.is_monotonic
 

--- a/pandas/tests/test_multilevel.py
+++ b/pandas/tests/test_multilevel.py
@@ -2559,16 +2559,32 @@ class TestSorted(Base, tm.TestCase):
         assert result.columns.is_lexsorted()
         assert result.columns.is_monotonic
 
+    def test_sort_index_and_reconstruction_doc_example(self):
         # doc example
         df = DataFrame({'value': [1, 2, 3, 4]},
                        index=MultiIndex(
                            levels=[['a', 'b'], ['bb', 'aa']],
-                           labels=[[0, 0, 1, 1], [1, 0, 1, 0]]))
-        result = df.sort_index()
+                           labels=[[0, 0, 1, 1], [0, 1, 0, 1]]))
+        assert df.index.is_lexsorted()
+        assert not df.index.is_monotonic
+
+        # sort it
         expected = DataFrame({'value': [2, 1, 4, 3]},
                              index=MultiIndex(
                                  levels=[['a', 'b'], ['aa', 'bb']],
-                                 labels=[[0, 0, 1, 1], [1, 0, 1, 0]]))
+                                 labels=[[0, 0, 1, 1], [0, 1, 0, 1]]))
+        result = df.sort_index()
+        assert not result.index.is_lexsorted()
+        assert result.index.is_monotonic
+
+        tm.assert_frame_equal(result, expected)
+
+        # reconstruct
+        result = df.sort_index().copy()
+        result.index = result.index._reconstruct(sort=True)
+        assert result.index.is_lexsorted()
+        assert result.index.is_monotonic
+
         tm.assert_frame_equal(result, expected)
 
     def test_sort_index_reorder_on_ops(self):

--- a/pandas/tests/test_multilevel.py
+++ b/pandas/tests/test_multilevel.py
@@ -2438,6 +2438,30 @@ class TestSorted(Base, tm.TestCase):
         expected = df.reindex(columns=df.columns[:3])
         tm.assert_frame_equal(result, expected)
 
+    def test_frame_getitem_not_sorted2(self):
+        # 13431
+        df = DataFrame({'col1': ['b', 'd', 'b', 'a'],
+                        'col2': [3, 1, 1, 2],
+                        'data': ['one', 'two', 'three', 'four']})
+
+        df2 = df.set_index(['col1', 'col2'])
+        df2_original = df2.copy()
+
+        df2.index.set_levels(['b', 'd', 'a'], level='col1', inplace=True)
+        df2.index.set_labels([0, 1, 0, 2], level='col1', inplace=True)
+        assert not df2.index.is_lexsorted()
+        assert not df2.index.is_monotonic
+
+        assert df2_original.index.equals(df2.index)
+        expected = df2.sort_index()
+        assert not expected.index.is_lexsorted()
+        assert expected.index.is_monotonic
+
+        result = df2.sort_index(level=0)
+        assert not result.index.is_lexsorted()
+        assert result.index.is_monotonic
+        tm.assert_frame_equal(result, expected)
+
     def test_frame_getitem_not_sorted(self):
         df = self.frame.T
         df['foo', 'four'] = 'foo'
@@ -2474,3 +2498,101 @@ class TestSorted(Base, tm.TestCase):
         expected.index = expected.index.droplevel(0)
         tm.assert_series_equal(result, expected)
         tm.assert_series_equal(result2, expected)
+
+    def test_sort_index_and_reconstruction(self):
+
+        # 15622
+        # lexsortedness should be identical
+        # across MultiIndex consruction methods
+
+        df = DataFrame([[1, 1], [2, 2]], index=list('ab'))
+        expected = DataFrame([[1, 1], [2, 2], [1, 1], [2, 2]],
+                             index=MultiIndex.from_tuples([(0.5, 'a'),
+                                                           (0.5, 'b'),
+                                                           (0.8, 'a'),
+                                                           (0.8, 'b')]))
+        assert expected.index.is_lexsorted()
+
+        result = DataFrame(
+            [[1, 1], [2, 2], [1, 1], [2, 2]],
+            index=MultiIndex.from_product([[0.5, 0.8], list('ab')]))
+        result = result.sort_index()
+        assert result.index.is_lexsorted()
+        assert result.index.is_monotonic
+
+        tm.assert_frame_equal(result, expected)
+
+        result = DataFrame(
+            [[1, 1], [2, 2], [1, 1], [2, 2]],
+            index=MultiIndex(levels=[[0.5, 0.8], ['a', 'b']],
+                             labels=[[0, 0, 1, 1], [0, 1, 0, 1]]))
+        result = result.sort_index()
+        assert result.index.is_lexsorted()
+
+        tm.assert_frame_equal(result, expected)
+
+        concatted = pd.concat([df, df], keys=[0.8, 0.5])
+        result = concatted.sort_index()
+
+        # this will be monotonic, but not lexsorted!
+        assert not result.index.is_lexsorted()
+        assert result.index.is_monotonic
+
+        tm.assert_frame_equal(result, expected)
+
+        # 14015
+        df = DataFrame([[1, 2], [6, 7]],
+                       columns=MultiIndex.from_tuples(
+                           [(0, '20160811 12:00:00'),
+                            (0, '20160809 12:00:00')],
+                           names=['l1', 'Date']))
+
+        df.columns.set_levels(pd.to_datetime(df.columns.levels[1]),
+                              level=1,
+                              inplace=True)
+        assert not df.columns.is_lexsorted()
+        assert not df.columns.is_monotonic
+        result = df.sort_index(axis=1)
+        assert result.columns.is_lexsorted()
+        assert result.columns.is_monotonic
+        result = df.sort_index(axis=1, level=1)
+        assert result.columns.is_lexsorted()
+        assert result.columns.is_monotonic
+
+        # doc example
+        df = DataFrame({'value': [1, 2, 3, 4]},
+                       index=MultiIndex(
+                           levels=[['a', 'b'], ['bb', 'aa']],
+                           labels=[[0, 0, 1, 1], [1, 0, 1, 0]]))
+        result = df.sort_index()
+        expected = DataFrame({'value': [2, 1, 4, 3]},
+                             index=MultiIndex(
+                                 levels=[['a', 'b'], ['aa', 'bb']],
+                                 labels=[[0, 0, 1, 1], [1, 0, 1, 0]]))
+        tm.assert_frame_equal(result, expected)
+
+    def test_sort_index_reorder_on_ops(self):
+        # 15687
+        df = pd.DataFrame(
+            np.random.randn(8, 2),
+            index=MultiIndex.from_product(
+                [['a', 'b'],
+                 ['big', 'small'],
+                 ['red', 'blu']],
+                names=['letter', 'size', 'color']),
+            columns=['near', 'far'])
+        df = df.sort_index()
+
+        def my_func(group):
+            group.index = ['newz', 'newa']
+            return group
+
+        result = df.groupby(level=['letter', 'size']).apply(
+            my_func).sort_index()
+        expected = MultiIndex.from_product(
+            [['a', 'b'],
+             ['big', 'small'],
+             ['newa', 'newz']],
+            names=['letter', 'size', None])
+
+        tm.assert_index_equal(result.index, expected)

--- a/pandas/tests/tools/test_hashing.py
+++ b/pandas/tests/tools/test_hashing.py
@@ -91,7 +91,7 @@ class TestHashing(tm.TestCase):
         mi = MultiIndex(levels=[['b', 'd', 'a'], [1, 2, 3]],
                         labels=[[0, 1, 0, 2], [2, 0, 0, 1]],
                         names=['col1', 'col2'])
-        recons = mi.sort_monotonic()
+        recons = mi.sort_levels_monotonic()
 
         # these are equal
         assert mi.equals(recons)

--- a/pandas/tests/tools/test_hashing.py
+++ b/pandas/tests/tools/test_hashing.py
@@ -87,6 +87,35 @@ class TestHashing(tm.TestCase):
         result = hash_pandas_object(mi)
         self.assertTrue(result.is_unique)
 
+    def test_multiindex_objects(self):
+        mi = MultiIndex(levels=[['b', 'd', 'a'], [1, 2, 3]],
+                        labels=[[0, 1, 0, 2], [2, 0, 0, 1]],
+                        names=['col1', 'col2'])
+        recons = mi._reconstruct(sort=True)
+
+        # these are equal
+        assert mi.equals(recons)
+        assert Index(mi.values).equals(Index(recons.values))
+
+        # _hashed_values and hash_pandas_object(..., index=False)
+        # equivalency
+        expected = hash_pandas_object(
+            mi, index=False).values
+        result = mi._hashed_values
+        tm.assert_numpy_array_equal(result, expected)
+
+        expected = hash_pandas_object(
+            recons, index=False).values
+        result = recons._hashed_values
+        tm.assert_numpy_array_equal(result, expected)
+
+        expected = mi._hashed_values
+        result = recons._hashed_values
+
+        # values should match, but in different order
+        tm.assert_numpy_array_equal(np.sort(result),
+                                    np.sort(expected))
+
     def test_hash_pandas_object(self):
 
         for obj in [Series([1, 2, 3]),

--- a/pandas/tests/tools/test_hashing.py
+++ b/pandas/tests/tools/test_hashing.py
@@ -91,7 +91,7 @@ class TestHashing(tm.TestCase):
         mi = MultiIndex(levels=[['b', 'd', 'a'], [1, 2, 3]],
                         labels=[[0, 1, 0, 2], [2, 0, 0, 1]],
                         names=['col1', 'col2'])
-        recons = mi.sort_levels_monotonic()
+        recons = mi._sort_levels_monotonic()
 
         # these are equal
         assert mi.equals(recons)

--- a/pandas/tests/tools/test_hashing.py
+++ b/pandas/tests/tools/test_hashing.py
@@ -91,7 +91,7 @@ class TestHashing(tm.TestCase):
         mi = MultiIndex(levels=[['b', 'd', 'a'], [1, 2, 3]],
                         labels=[[0, 1, 0, 2], [2, 0, 0, 1]],
                         names=['col1', 'col2'])
-        recons = mi._reconstruct(sort=True)
+        recons = mi.sort_monotonic()
 
         # these are equal
         assert mi.equals(recons)

--- a/pandas/tests/tools/test_pivot.py
+++ b/pandas/tests/tools/test_pivot.py
@@ -2,6 +2,7 @@ from datetime import datetime, date, timedelta
 
 import numpy as np
 
+from collections import OrderedDict
 import pandas as pd
 from pandas import (DataFrame, Series, Index, MultiIndex,
                     Grouper, date_range, concat)
@@ -513,7 +514,7 @@ class TestPivotTable(tm.TestCase):
         self.assertTrue(pivoted.columns.is_monotonic)
 
     def test_pivot_complex_aggfunc(self):
-        f = {'D': ['std'], 'E': ['sum']}
+        f = OrderedDict([('D', ['std']), ('E', ['sum'])])
         expected = self.data.groupby(['A', 'B']).agg(f).unstack('B')
         result = self.data.pivot_table(index='A', columns='B', aggfunc=f)
 


### PR DESCRIPTION
closes #15622
closes #15687 
closes #14015
closes #13431

nice bump on Series.sort_index for monotonic
```
    before     after       ratio
  [37e5f78b] [a6f352c0]
-    1.86ms   100.07μs      0.05  timeseries.TimeSeries.time_sort_index_monotonic
```

