### PR TITLE
MAINT: test with manylinux numpy/scipy pre-release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -123,11 +123,6 @@ matrix:
         - PANDAS_TESTING_MODE="deprecate"
         - CACHE_NAME="35_numpy_dev"
         - USE_CACHE=true
-      addons:
-        apt:
-          packages:
-          - libatlas-base-dev
-          - gfortran
 #    In allow_failures
     - python: 3.5
       env:
@@ -167,11 +162,6 @@ matrix:
           - PANDAS_TESTING_MODE="deprecate"
           - CACHE_NAME="35_numpy_dev"
           - USE_CACHE=true
-        addons:
-          apt:
-            packages:
-            - libatlas-base-dev
-            - gfortran
       - python: 3.5
         env:
         - PYTHON_VERSION=3.5

--- a/ci/requirements-3.5_NUMPY_DEV.build.sh
+++ b/ci/requirements-3.5_NUMPY_DEV.build.sh
@@ -8,6 +8,7 @@ echo "install numpy master wheel"
 pip uninstall numpy -y
 
 # install numpy wheel from master
-pip install --pre --upgrade --no-index --timeout=60 --trusted-host travis-dev-wheels.scipy.org -f http://travis-dev-wheels.scipy.org/ numpy
+PRE_WHEELS="https://7933911d6844c6c53a7d-47bd50c35cd79bd838daf386af554a83.ssl.cf2.rackcdn.com"
+pip install --pre --upgrade --timeout=60 -f $PRE_WHEELS numpy scipy
 
 true


### PR DESCRIPTION
Numpy / Scipy switching to daily manylinux wheels of trunk, instead of building
wheels specific to Ubuntu 12.04 for every commit.  Use these new wheels
for numpy and scipy pre-release testing.

See: #15699, #15689 and https://github.com/scipy/scipy/issues/7188.