### PR TITLE
MAINT: Drop take_last kwarg from method signatures

### DIFF
--- a/asv_bench/benchmarks/series_methods.py
+++ b/asv_bench/benchmarks/series_methods.py
@@ -68,8 +68,8 @@ class series_nlargest1(object):
         self.s4 = self.s3.astype('object')
 
     def time_series_nlargest1(self):
-        self.s1.nlargest(3, take_last=True)
-        self.s1.nlargest(3, take_last=False)
+        self.s1.nlargest(3, keep='last')
+        self.s1.nlargest(3, keep='first')
 
 
 class series_nlargest2(object):
@@ -83,8 +83,8 @@ class series_nlargest2(object):
         self.s4 = self.s3.astype('object')
 
     def time_series_nlargest2(self):
-        self.s2.nlargest(3, take_last=True)
-        self.s2.nlargest(3, take_last=False)
+        self.s2.nlargest(3, keep='last')
+        self.s2.nlargest(3, keep='first')
 
 
 class series_nsmallest2(object):
@@ -98,8 +98,8 @@ class series_nsmallest2(object):
         self.s4 = self.s3.astype('object')
 
     def time_series_nsmallest2(self):
-        self.s2.nsmallest(3, take_last=True)
-        self.s2.nsmallest(3, take_last=False)
+        self.s2.nsmallest(3, keep='last')
+        self.s2.nsmallest(3, keep='first')
 
 
 class series_dropna_int64(object):

--- a/doc/source/whatsnew/v0.20.0.txt
+++ b/doc/source/whatsnew/v0.20.0.txt
@@ -769,6 +769,7 @@ Removal of prior version deprecations/changes
   in favor of ``iloc`` and ``iat`` as explained :ref:`here <whatsnew_0170.deprecations>` (:issue:`10711`).
 - The deprecated ``DataFrame.iterkv()`` has been removed in favor of ``DataFrame.iteritems()`` (:issue:`10711`)
 - The ``Categorical`` constructor has dropped the ``name`` parameter (:issue:`10632`)
+- The ``take_last`` parameter has been dropped from ``duplicated()``, ``drop_duplicates()``, ``nlargest()``, and ``nsmallest()`` methods (:issue:`10236`, :issue:`10792`, :issue:`10920`)
 
 .. _whatsnew_0200.performance:
 

--- a/pandas/core/base.py
+++ b/pandas/core/base.py
@@ -1065,7 +1065,6 @@ class IndexOpsMixin(object):
             - ``first`` : Drop duplicates except for the first occurrence.
             - ``last`` : Drop duplicates except for the last occurrence.
             - False : Drop all duplicates.
-        take_last : deprecated
         %(inplace)s
 
         Returns
@@ -1073,8 +1072,6 @@ class IndexOpsMixin(object):
         deduplicated : %(klass)s
         """)
 
-    @deprecate_kwarg('take_last', 'keep', mapping={True: 'last',
-                                                   False: 'first'})
     @Appender(_shared_docs['drop_duplicates'] % _indexops_doc_kwargs)
     def drop_duplicates(self, keep='first', inplace=False):
         inplace = validate_bool_kwarg(inplace, 'inplace')
@@ -1100,15 +1097,12 @@ class IndexOpsMixin(object):
             - ``last`` : Mark duplicates as ``True`` except for the last
               occurrence.
             - False : Mark all duplicates as ``True``.
-        take_last : deprecated
 
         Returns
         -------
         duplicated : %(duplicated)s
         """)
 
-    @deprecate_kwarg('take_last', 'keep', mapping={True: 'last',
-                                                   False: 'first'})
     @Appender(_shared_docs['duplicated'] % _indexops_doc_kwargs)
     def duplicated(self, keep='first'):
         from pandas.core.algorithms import duplicated

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -77,8 +77,7 @@ from pandas.compat import (range, map, zip, lrange, lmap, lzip, StringIO, u,
                            OrderedDict, raise_with_traceback)
 from pandas import compat
 from pandas.compat.numpy import function as nv
-from pandas.util.decorators import (deprecate_kwarg, Appender,
-                                    Substitution)
+from pandas.util.decorators import Appender, Substitution
 from pandas.util.validators import validate_bool_kwarg
 
 from pandas.tseries.period import PeriodIndex
@@ -3169,8 +3168,6 @@ it is assumed to be aliases for the column names.')
         else:
             return result
 
-    @deprecate_kwarg('take_last', 'keep', mapping={True: 'last',
-                                                   False: 'first'})
     def drop_duplicates(self, subset=None, keep='first', inplace=False):
         """
         Return DataFrame with duplicate rows removed, optionally only
@@ -3185,7 +3182,6 @@ it is assumed to be aliases for the column names.')
             - ``first`` : Drop duplicates except for the first occurrence.
             - ``last`` : Drop duplicates except for the last occurrence.
             - False : Drop all duplicates.
-        take_last : deprecated
         inplace : boolean, default False
             Whether to drop duplicates in place or to return a copy
 
@@ -3203,8 +3199,6 @@ it is assumed to be aliases for the column names.')
         else:
             return self[-duplicated]
 
-    @deprecate_kwarg('take_last', 'keep', mapping={True: 'last',
-                                                   False: 'first'})
     def duplicated(self, subset=None, keep='first'):
         """
         Return boolean Series denoting duplicate rows, optionally only
@@ -3221,7 +3215,6 @@ it is assumed to be aliases for the column names.')
             - ``last`` : Mark duplicates as ``True`` except for the
               last occurrence.
             - False : Mark all duplicates as ``True``.
-        take_last : deprecated
 
         Returns
         -------

--- a/pandas/core/groupby.py
+++ b/pandas/core/groupby.py
@@ -51,8 +51,8 @@ from pandas.core.panel import Panel
 from pandas.core.sorting import (get_group_index_sorter, get_group_index,
                                  compress_group_index, get_flattened_iterator,
                                  decons_obs_group_ids, get_indexer_dict)
-from pandas.util.decorators import (cache_readonly, Substitution, Appender,
-                                    make_signature, deprecate_kwarg)
+from pandas.util.decorators import (cache_readonly, Substitution,
+                                    Appender, make_signature)
 from pandas.formats.printing import pprint_thing
 from pandas.util.validators import validate_kwargs
 
@@ -94,12 +94,12 @@ _common_apply_whitelist = frozenset([
     'corr', 'cov', 'diff',
 ]) | _plotting_methods
 
-_series_apply_whitelist = \
-    (_common_apply_whitelist - set(['boxplot'])) | \
-    frozenset(['dtype', 'unique'])
+_series_apply_whitelist = ((_common_apply_whitelist |
+                            {'nlargest', 'nsmallest'}) -
+                           {'boxplot'}) | frozenset(['dtype', 'unique'])
 
-_dataframe_apply_whitelist = \
-    _common_apply_whitelist | frozenset(['dtypes', 'corrwith'])
+_dataframe_apply_whitelist = (_common_apply_whitelist |
+                              frozenset(['dtypes', 'corrwith']))
 
 _cython_transforms = frozenset(['cumprod', 'cumsum', 'shift',
                                 'cummin', 'cummax'])
@@ -3024,20 +3024,6 @@ class SeriesGroupBy(GroupBy):
         return Series(res,
                       index=ri,
                       name=self.name)
-
-    @deprecate_kwarg('take_last', 'keep',
-                     mapping={True: 'last', False: 'first'})
-    @Appender(Series.nlargest.__doc__)
-    def nlargest(self, n=5, keep='first'):
-        # ToDo: When we remove deprecate_kwargs, we can remote these methods
-        # and include nlargest and nsmallest to _series_apply_whitelist
-        return self.apply(lambda x: x.nlargest(n=n, keep=keep))
-
-    @deprecate_kwarg('take_last', 'keep',
-                     mapping={True: 'last', False: 'first'})
-    @Appender(Series.nsmallest.__doc__)
-    def nsmallest(self, n=5, keep='first'):
-        return self.apply(lambda x: x.nsmallest(n=n, keep=keep))
 
     @Appender(Series.describe.__doc__)
     def describe(self, **kwargs):

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -1211,14 +1211,10 @@ class Series(base.IndexOpsMixin, strings.StringAccessorMixin,
             return result.asobject.values
         return result
 
-    @deprecate_kwarg('take_last', 'keep', mapping={True: 'last',
-                                                   False: 'first'})
     @Appender(base._shared_docs['drop_duplicates'] % _shared_doc_kwargs)
     def drop_duplicates(self, keep='first', inplace=False):
         return super(Series, self).drop_duplicates(keep=keep, inplace=inplace)
 
-    @deprecate_kwarg('take_last', 'keep', mapping={True: 'last',
-                                                   False: 'first'})
     @Appender(base._shared_docs['duplicated'] % _shared_doc_kwargs)
     def duplicated(self, keep='first'):
         return super(Series, self).duplicated(keep=keep)
@@ -1888,8 +1884,6 @@ class Series(base.IndexOpsMixin, strings.StringAccessorMixin,
                 np.argsort(values, kind=kind), index=self.index,
                 dtype='int64').__finalize__(self)
 
-    @deprecate_kwarg('take_last', 'keep', mapping={True: 'last',
-                                                   False: 'first'})
     def nlargest(self, n=5, keep='first'):
         """Return the largest `n` elements.
 
@@ -1901,7 +1895,6 @@ class Series(base.IndexOpsMixin, strings.StringAccessorMixin,
             Where there are duplicate values:
             - ``first`` : take the first occurrence.
             - ``last`` : take the last occurrence.
-        take_last : deprecated
 
         Returns
         -------
@@ -1938,8 +1931,6 @@ class Series(base.IndexOpsMixin, strings.StringAccessorMixin,
         return algorithms.select_n_series(self, n=n, keep=keep,
                                           method='nlargest')
 
-    @deprecate_kwarg('take_last', 'keep', mapping={True: 'last',
-                                                   False: 'first'})
     def nsmallest(self, n=5, keep='first'):
         """Return the smallest `n` elements.
 
@@ -1951,7 +1942,6 @@ class Series(base.IndexOpsMixin, strings.StringAccessorMixin,
             Where there are duplicate values:
             - ``first`` : take the first occurrence.
             - ``last`` : take the last occurrence.
-        take_last : deprecated
 
         Returns
         -------

--- a/pandas/indexes/base.py
+++ b/pandas/indexes/base.py
@@ -3500,14 +3500,10 @@ class Index(IndexOpsMixin, StringAccessorMixin, PandasObject):
         result = super(Index, self).unique()
         return self._shallow_copy(result)
 
-    @deprecate_kwarg('take_last', 'keep', mapping={True: 'last',
-                                                   False: 'first'})
     @Appender(base._shared_docs['drop_duplicates'] % _index_doc_kwargs)
     def drop_duplicates(self, keep='first'):
         return super(Index, self).drop_duplicates(keep=keep)
 
-    @deprecate_kwarg('take_last', 'keep', mapping={True: 'last',
-                                                   False: 'first'})
     @Appender(base._shared_docs['duplicated'] % _index_doc_kwargs)
     def duplicated(self, keep='first'):
         return super(Index, self).duplicated(keep=keep)

--- a/pandas/indexes/category.py
+++ b/pandas/indexes/category.py
@@ -11,8 +11,7 @@ from pandas.types.common import (is_categorical_dtype,
 from pandas.types.missing import array_equivalent
 
 
-from pandas.util.decorators import (Appender, cache_readonly,
-                                    deprecate_kwarg)
+from pandas.util.decorators import Appender, cache_readonly
 from pandas.core.config import get_option
 from pandas.indexes.base import Index, _index_shared_docs
 import pandas.core.base as base
@@ -301,8 +300,6 @@ class CategoricalIndex(Index, base.PandasDelegate):
         return self._shallow_copy(result, categories=result.categories,
                                   ordered=result.ordered)
 
-    @deprecate_kwarg('take_last', 'keep', mapping={True: 'last',
-                                                   False: 'first'})
     @Appender(base._shared_docs['duplicated'] % _index_doc_kwargs)
     def duplicated(self, keep='first'):
         from pandas._libs.hashtable import duplicated_int64

--- a/pandas/indexes/multi.py
+++ b/pandas/indexes/multi.py
@@ -755,8 +755,6 @@ class MultiIndex(Index):
                      for k, stringify in zip(key, self._have_mixed_levels)])
         return hash_tuples(key)
 
-    @deprecate_kwarg('take_last', 'keep', mapping={True: 'last',
-                                                   False: 'first'})
     @Appender(base._shared_docs['duplicated'] % _index_doc_kwargs)
     def duplicated(self, keep='first'):
         from pandas.core.sorting import get_group_index

--- a/pandas/tests/frame/test_analytics.py
+++ b/pandas/tests/frame/test_analytics.py
@@ -1381,12 +1381,6 @@ class TestDataFrameAnalytics(tm.TestCase, TestData):
         tm.assert_frame_equal(result, expected)
         self.assertEqual(len(result), 0)
 
-        # deprecate take_last
-        with tm.assert_produces_warning(FutureWarning):
-            result = df.drop_duplicates('AAA', take_last=True)
-            expected = df.loc[[6, 7]]
-            tm.assert_frame_equal(result, expected)
-
         # multi column
         expected = df.loc[[0, 1, 2, 3]]
         result = df.drop_duplicates(np.array(['AAA', 'B']))
@@ -1400,12 +1394,6 @@ class TestDataFrameAnalytics(tm.TestCase, TestData):
 
         result = df.drop_duplicates(('AAA', 'B'), keep=False)
         expected = df.loc[[0]]
-        tm.assert_frame_equal(result, expected)
-
-        # deprecate take_last
-        with tm.assert_produces_warning(FutureWarning):
-            result = df.drop_duplicates(('AAA', 'B'), take_last=True)
-        expected = df.loc[[0, 5, 6, 7]]
         tm.assert_frame_equal(result, expected)
 
         # consider everything
@@ -1422,13 +1410,6 @@ class TestDataFrameAnalytics(tm.TestCase, TestData):
 
         result = df2.drop_duplicates(keep=False)
         expected = df2.drop_duplicates(['AAA', 'B'], keep=False)
-        tm.assert_frame_equal(result, expected)
-
-        # deprecate take_last
-        with tm.assert_produces_warning(FutureWarning):
-            result = df2.drop_duplicates(take_last=True)
-        with tm.assert_produces_warning(FutureWarning):
-            expected = df2.drop_duplicates(['AAA', 'B'], take_last=True)
         tm.assert_frame_equal(result, expected)
 
         # integers
@@ -1529,12 +1510,6 @@ class TestDataFrameAnalytics(tm.TestCase, TestData):
         self.assertEqual(len(result), 0)
         tm.assert_frame_equal(result, expected)
 
-        # deprecate take_last
-        with tm.assert_produces_warning(FutureWarning):
-            result = df.drop_duplicates(('AA', 'AB'), take_last=True)
-        expected = df.loc[[6, 7]]
-        tm.assert_frame_equal(result, expected)
-
         # multi column
         expected = df.loc[[0, 1, 2, 3]]
         result = df.drop_duplicates((('AA', 'AB'), 'B'))
@@ -1563,12 +1538,6 @@ class TestDataFrameAnalytics(tm.TestCase, TestData):
         tm.assert_frame_equal(result, expected)
         self.assertEqual(len(result), 0)
 
-        # deprecate take_last
-        with tm.assert_produces_warning(FutureWarning):
-            result = df.drop_duplicates('A', take_last=True)
-        expected = df.loc[[1, 6, 7]]
-        tm.assert_frame_equal(result, expected)
-
         # multi column
         result = df.drop_duplicates(['A', 'B'])
         expected = df.loc[[0, 2, 3, 6]]
@@ -1580,12 +1549,6 @@ class TestDataFrameAnalytics(tm.TestCase, TestData):
 
         result = df.drop_duplicates(['A', 'B'], keep=False)
         expected = df.loc[[6]]
-        tm.assert_frame_equal(result, expected)
-
-        # deprecate take_last
-        with tm.assert_produces_warning(FutureWarning):
-            result = df.drop_duplicates(['A', 'B'], take_last=True)
-        expected = df.loc[[1, 5, 6, 7]]
         tm.assert_frame_equal(result, expected)
 
         # nan
@@ -1610,12 +1573,6 @@ class TestDataFrameAnalytics(tm.TestCase, TestData):
         tm.assert_frame_equal(result, expected)
         self.assertEqual(len(result), 0)
 
-        # deprecate take_last
-        with tm.assert_produces_warning(FutureWarning):
-            result = df.drop_duplicates('C', take_last=True)
-        expected = df.loc[[3, 7]]
-        tm.assert_frame_equal(result, expected)
-
         # multi column
         result = df.drop_duplicates(['C', 'B'])
         expected = df.loc[[0, 1, 2, 4]]
@@ -1627,12 +1584,6 @@ class TestDataFrameAnalytics(tm.TestCase, TestData):
 
         result = df.drop_duplicates(['C', 'B'], keep=False)
         expected = df.loc[[1]]
-        tm.assert_frame_equal(result, expected)
-
-        # deprecate take_last
-        with tm.assert_produces_warning(FutureWarning):
-            result = df.drop_duplicates(['C', 'B'], take_last=True)
-        expected = df.loc[[1, 3, 6, 7]]
         tm.assert_frame_equal(result, expected)
 
     def test_drop_duplicates_NA_for_take_all(self):
@@ -1697,14 +1648,6 @@ class TestDataFrameAnalytics(tm.TestCase, TestData):
         tm.assert_frame_equal(result, expected)
         self.assertEqual(len(df), 0)
 
-        # deprecate take_last
-        df = orig.copy()
-        with tm.assert_produces_warning(FutureWarning):
-            df.drop_duplicates('A', take_last=True, inplace=True)
-        expected = orig.loc[[6, 7]]
-        result = df
-        tm.assert_frame_equal(result, expected)
-
         # multi column
         df = orig.copy()
         df.drop_duplicates(['A', 'B'], inplace=True)
@@ -1721,14 +1664,6 @@ class TestDataFrameAnalytics(tm.TestCase, TestData):
         df = orig.copy()
         df.drop_duplicates(['A', 'B'], keep=False, inplace=True)
         expected = orig.loc[[0]]
-        result = df
-        tm.assert_frame_equal(result, expected)
-
-        # deprecate take_last
-        df = orig.copy()
-        with tm.assert_produces_warning(FutureWarning):
-            df.drop_duplicates(['A', 'B'], take_last=True, inplace=True)
-        expected = orig.loc[[0, 5, 6, 7]]
         result = df
         tm.assert_frame_equal(result, expected)
 
@@ -1754,17 +1689,7 @@ class TestDataFrameAnalytics(tm.TestCase, TestData):
         result = df2
         tm.assert_frame_equal(result, expected)
 
-        # deprecate take_last
-        df2 = orig2.copy()
-        with tm.assert_produces_warning(FutureWarning):
-            df2.drop_duplicates(take_last=True, inplace=True)
-        with tm.assert_produces_warning(FutureWarning):
-            expected = orig2.drop_duplicates(['A', 'B'], take_last=True)
-        result = df2
-        tm.assert_frame_equal(result, expected)
-
     # Rounding
-
     def test_round(self):
         # GH 2665
 

--- a/pandas/tests/groupby/test_groupby.py
+++ b/pandas/tests/groupby/test_groupby.py
@@ -3816,7 +3816,8 @@ class TestGroupBy(MixIn, tm.TestCase):
             'cov',
             'diff',
             'unique',
-            # 'nlargest', 'nsmallest',
+            'nlargest',
+            'nsmallest',
         ])
 
         for obj, whitelist in zip((df, s), (df_whitelist, s_whitelist)):
@@ -4025,8 +4026,6 @@ class TestGroupBy(MixIn, tm.TestCase):
             3, 2, 1, 3, 3, 2
         ], index=MultiIndex.from_arrays([list('aaabbb'), [2, 3, 1, 6, 5, 7]]))
         assert_series_equal(gb.nlargest(3, keep='last'), e)
-        with tm.assert_produces_warning(FutureWarning):
-            assert_series_equal(gb.nlargest(3, take_last=True), e)
 
     def test_nsmallest(self):
         a = Series([1, 3, 5, 7, 2, 9, 0, 4, 6, 10])
@@ -4044,8 +4043,6 @@ class TestGroupBy(MixIn, tm.TestCase):
             0, 1, 1, 0, 1, 2
         ], index=MultiIndex.from_arrays([list('aaabbb'), [4, 1, 0, 9, 8, 7]]))
         assert_series_equal(gb.nsmallest(3, keep='last'), e)
-        with tm.assert_produces_warning(FutureWarning):
-            assert_series_equal(gb.nsmallest(3, take_last=True), e)
 
     def test_transform_doesnt_clobber_ints(self):
         # GH 7972

--- a/pandas/tests/series/test_analytics.py
+++ b/pandas/tests/series/test_analytics.py
@@ -917,17 +917,6 @@ class TestSeriesAnalytics(TestData, tm.TestCase):
             sc.drop_duplicates(keep='last', inplace=True)
             assert_series_equal(sc, s[~expected])
 
-            # deprecate take_last
-            with tm.assert_produces_warning(FutureWarning):
-                assert_series_equal(s.duplicated(take_last=True), expected)
-            with tm.assert_produces_warning(FutureWarning):
-                assert_series_equal(
-                    s.drop_duplicates(take_last=True), s[~expected])
-            sc = s.copy()
-            with tm.assert_produces_warning(FutureWarning):
-                sc.drop_duplicates(take_last=True, inplace=True)
-            assert_series_equal(sc, s[~expected])
-
             expected = Series([False, False, True, True])
             assert_series_equal(s.duplicated(keep=False), expected)
             assert_series_equal(s.drop_duplicates(keep=False), s[~expected])
@@ -949,17 +938,6 @@ class TestSeriesAnalytics(TestData, tm.TestCase):
             assert_series_equal(s.drop_duplicates(keep='last'), s[~expected])
             sc = s.copy()
             sc.drop_duplicates(keep='last', inplace=True)
-            assert_series_equal(sc, s[~expected])
-
-            # deprecate take_last
-            with tm.assert_produces_warning(FutureWarning):
-                assert_series_equal(s.duplicated(take_last=True), expected)
-            with tm.assert_produces_warning(FutureWarning):
-                assert_series_equal(
-                    s.drop_duplicates(take_last=True), s[~expected])
-            sc = s.copy()
-            with tm.assert_produces_warning(FutureWarning):
-                sc.drop_duplicates(take_last=True, inplace=True)
             assert_series_equal(sc, s[~expected])
 
             expected = Series([False, True, True, False, True, True, False])
@@ -1443,18 +1421,7 @@ class TestSeriesAnalytics(TestData, tm.TestCase):
         for s in s_list:
 
             assert_series_equal(s.nsmallest(2), s.iloc[[2, 1]])
-
             assert_series_equal(s.nsmallest(2, keep='last'), s.iloc[[2, 3]])
-            with tm.assert_produces_warning(FutureWarning):
-                assert_series_equal(
-                    s.nsmallest(2, take_last=True), s.iloc[[2, 3]])
-
-            assert_series_equal(s.nlargest(3), s.iloc[[4, 0, 1]])
-
-            assert_series_equal(s.nlargest(3, keep='last'), s.iloc[[4, 0, 3]])
-            with tm.assert_produces_warning(FutureWarning):
-                assert_series_equal(
-                    s.nlargest(3, take_last=True), s.iloc[[4, 0, 3]])
 
             empty = s.iloc[0:0]
             assert_series_equal(s.nsmallest(0), empty)

--- a/pandas/tests/test_base.py
+++ b/pandas/tests/test_base.py
@@ -816,15 +816,6 @@ class TestIndexOps(Ops):
                 result = idx.drop_duplicates(keep='last')
                 tm.assert_index_equal(result, idx[~expected])
 
-                # deprecate take_last
-                with tm.assert_produces_warning(FutureWarning):
-                    duplicated = idx.duplicated(take_last=True)
-                tm.assert_numpy_array_equal(duplicated, expected)
-                self.assertTrue(duplicated.dtype == bool)
-                with tm.assert_produces_warning(FutureWarning):
-                    result = idx.drop_duplicates(take_last=True)
-                tm.assert_index_equal(result, idx[~expected])
-
                 base = [False] * len(original) + [True, True]
                 base[3] = True
                 base[5] = True
@@ -867,13 +858,6 @@ class TestIndexOps(Ops):
                 tm.assert_series_equal(s.drop_duplicates(keep='last'),
                                        s[~np.array(base)])
 
-                # deprecate take_last
-                with tm.assert_produces_warning(FutureWarning):
-                    tm.assert_series_equal(
-                        s.duplicated(take_last=True), expected)
-                with tm.assert_produces_warning(FutureWarning):
-                    tm.assert_series_equal(s.drop_duplicates(take_last=True),
-                                           s[~np.array(base)])
                 base = [False] * len(original) + [True, True]
                 base[3] = True
                 base[5] = True

--- a/pandas/tests/test_multilevel.py
+++ b/pandas/tests/test_multilevel.py
@@ -2037,17 +2037,6 @@ Thur,Lunch,Yes,51.51,17"""
         expected = MultiIndex.from_arrays(([2, 3, 2, 3], [1, 1, 2, 2]))
         tm.assert_index_equal(idx.drop_duplicates(keep=False), expected)
 
-        # deprecate take_last
-        expected = np.array([True, False, False, False, False, False])
-        with tm.assert_produces_warning(FutureWarning):
-            duplicated = idx.duplicated(take_last=True)
-        tm.assert_numpy_array_equal(duplicated, expected)
-        self.assertTrue(duplicated.dtype == bool)
-        expected = MultiIndex.from_arrays(([2, 3, 1, 2, 3], [1, 1, 1, 2, 2]))
-        with tm.assert_produces_warning(FutureWarning):
-            tm.assert_index_equal(
-                idx.drop_duplicates(take_last=True), expected)
-
     def test_multiindex_set_index(self):
         # segfault in #3308
         d = {'t1': [2, 2.5, 3], 't2': [4, 5, 6]}

--- a/vb_suite/series_methods.py
+++ b/vb_suite/series_methods.py
@@ -12,22 +12,22 @@ values = [1,2]
 s4 = s3.astype('object')
 """
 
-series_nlargest1 = Benchmark('s1.nlargest(3, take_last=True);'
-                             's1.nlargest(3, take_last=False)',
+series_nlargest1 = Benchmark("s1.nlargest(3, keep='last');"
+                             "s1.nlargest(3, keep='first')",
                              setup,
                              start_date=datetime(2014, 1, 25))
-series_nlargest2 = Benchmark('s2.nlargest(3, take_last=True);'
-                             's2.nlargest(3, take_last=False)',
+series_nlargest2 = Benchmark("s2.nlargest(3, keep='last');"
+                             "s2.nlargest(3, keep='first')",
                              setup,
                              start_date=datetime(2014, 1, 25))
 
-series_nsmallest2 = Benchmark('s1.nsmallest(3, take_last=True);'
-                              's1.nsmallest(3, take_last=False)',
+series_nsmallest2 = Benchmark("s1.nsmallest(3, keep='last');"
+                              "s1.nsmallest(3, keep='first')",
                               setup,
                               start_date=datetime(2014, 1, 25))
 
-series_nsmallest2 = Benchmark('s2.nsmallest(3, take_last=True);'
-                              's2.nsmallest(3, take_last=False)',
+series_nsmallest2 = Benchmark("s2.nsmallest(3, keep='last');"
+                              "s2.nsmallest(3, keep='first')",
                               setup,
                               start_date=datetime(2014, 1, 25))
 


### PR DESCRIPTION
Affected methods:

1) `nlargest`
2) `nsmallest`
3) `duplicated`
4) `drop_duplicates`

xref #10236, #10792, #10920.