### PR TITLE
BUG: TZ-aware Series.where() appropriately handles default other=nan (#15701)

### DIFF
--- a/doc/source/whatsnew/v0.20.0.txt
+++ b/doc/source/whatsnew/v0.20.0.txt
@@ -829,6 +829,7 @@ Bug Fixes
 - Bug in ``DataFrame.isin`` comparing datetimelike to empty frame (:issue:`15473`)
 
 - Bug in ``Series.where()`` and ``DataFrame.where()`` where array-like conditionals were being rejected (:issue:`15414`)
+- Bug in ``Series.where()`` where TZ-aware data was converted to float representation (:issue:`15701`)
 - Bug in ``Index`` construction with ``NaN`` elements and integer dtype specified (:issue:`15187`)
 - Bug in ``Series`` construction with a datetimetz (:issue:`14928`)
 - Bug in output formatting of a ``MultiIndex`` when names are integers (:issue:`12223`, :issue:`15262`)

--- a/pandas/core/internals.py
+++ b/pandas/core/internals.py
@@ -2440,7 +2440,8 @@ class DatetimeTZBlock(NonConsolidatableMixIn, DatetimeBlock):
 
         if isinstance(other, bool):
             raise TypeError
-        elif is_null_datelike_scalar(other):
+        elif (is_null_datelike_scalar(other) or
+              (is_scalar(other) and isnull(other))):
             other = tslib.iNaT
             other_mask = True
         elif isinstance(other, self._holder):

--- a/pandas/tests/series/test_indexing.py
+++ b/pandas/tests/series/test_indexing.py
@@ -1385,6 +1385,14 @@ class TestSeriesIndexing(TestData, tm.TestCase):
         expected = Series([10, None], dtype='datetime64[ns]')
         assert_series_equal(rs, expected)
 
+        # GH 15701
+        timestamps = ['2016-12-31 12:00:04+00:00',
+                      '2016-12-31 12:00:04.010000+00:00']
+        s = Series([pd.Timestamp(s) for s in timestamps])
+        rs = s.where(Series([False, True]))
+        expected = Series([pd.NaT, s[1]])
+        assert_series_equal(rs, expected)
+
     def test_where_timedelta(self):
         s = Series([1, 2], dtype='timedelta64[ns]')
         expected = Series([10, 10], dtype='timedelta64[ns]')


### PR DESCRIPTION
 - [x] closes #15701 
 - [x] tests added / passed
 - [x] passes ``git diff upstream/master | flake8 --diff``
 - [x] whatsnew entry
