### PR TITLE
CI: remove caching for miniconda itself

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ language: python
 # The cash directories will be deleted if anything in ci/ changes in a commit
 cache:
  directories:
-  - $HOME/miniconda3 # miniconda cache
   - $HOME/.cache # cython cache
   - $HOME/.ccache # compiler cache
 

--- a/ci/install_travis.sh
+++ b/ci/install_travis.sh
@@ -35,24 +35,19 @@ echo "[home_dir: $home_dir]"
 # install miniconda
 MINICONDA_DIR="$HOME/miniconda3"
 
-if [ "$USE_CACHE" ] && [ -d "$MINICONDA_DIR/bin" ]; then
-    echo "[Using cached Miniconda install]"
+echo "[Using clean Miniconda install]"
 
-else
-    echo "[Using clean Miniconda install]"
-
-    if [ -d "$MINICONDA_DIR" ]; then
-        rm -rf "$MINICONDA_DIR"
-    fi
-
-    # install miniconda
-    if [ "${TRAVIS_OS_NAME}" == "osx" ]; then
-        time wget http://repo.continuum.io/miniconda/Miniconda3-latest-MacOSX-x86_64.sh -O miniconda.sh || exit 1
-    else
-        time wget http://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh || exit 1
-    fi
-    time bash miniconda.sh -b -p "$MINICONDA_DIR" || exit 1
+if [ -d "$MINICONDA_DIR" ]; then
+    rm -rf "$MINICONDA_DIR"
 fi
+
+# install miniconda
+if [ "${TRAVIS_OS_NAME}" == "osx" ]; then
+    time wget http://repo.continuum.io/miniconda/Miniconda3-latest-MacOSX-x86_64.sh -O miniconda.sh || exit 1
+else
+    time wget http://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh || exit 1
+fi
+time bash miniconda.sh -b -p "$MINICONDA_DIR" || exit 1
 
 echo "[show conda]"
 which conda


### PR DESCRIPTION
well got this to work, and it *does* cache, but the cache file is so huge that its just not worth it. going back to clean installs for miniconda itself.