### PR TITLE
PERF: Improve drop_duplicates for bool columns (#12963)

### DIFF
--- a/asv_bench/benchmarks/reindex.py
+++ b/asv_bench/benchmarks/reindex.py
@@ -132,6 +132,9 @@ class Duplicates(object):
         self.K = 10000
         self.key1 = np.random.randint(0, self.K, size=self.N)
         self.df_int = DataFrame({'key1': self.key1})
+        self.df_bool = DataFrame({i: np.random.randint(0, 2, size=self.K,
+                                                       dtype=bool)
+                                  for i in range(10)})
 
     def time_frame_drop_dups(self):
         self.df.drop_duplicates(['key1', 'key2'])
@@ -154,6 +157,8 @@ class Duplicates(object):
     def time_frame_drop_dups_int(self):
         self.df_int.drop_duplicates()
 
+    def time_frame_drop_dups_bool(self):
+        self.df_bool.drop_duplicates()
 
 #----------------------------------------------------------------------
 # blog "pandas escaped the zoo"

--- a/doc/source/whatsnew/v0.20.0.txt
+++ b/doc/source/whatsnew/v0.20.0.txt
@@ -788,6 +788,7 @@ Performance Improvements
 - Improved performance of ``.rank()`` for categorical data (:issue:`15498`)
 - Improved performance when using ``.unstack()`` (:issue:`15503`)
 - Improved performance of merge/join on ``category`` columns (:issue:`10409`)
+- Improved performance of ``drop_duplicates()`` on ``bool`` columns (:issue:`12963`)
 
 
 .. _whatsnew_0200.bug_fixes:

--- a/pandas/core/algorithms.py
+++ b/pandas/core/algorithms.py
@@ -19,6 +19,7 @@ from pandas.types.common import (is_unsigned_integer_dtype,
                                  is_period_dtype,
                                  is_period_arraylike,
                                  is_float_dtype,
+                                 is_bool_dtype,
                                  needs_i8_conversion,
                                  is_categorical,
                                  is_datetime64_dtype,
@@ -341,6 +342,10 @@ def factorize(values, sort=False, order=None, na_sentinel=-1, size_hint=None):
             # numpy dtype
             dtype = values.dtype
             vals = values.view(np.int64)
+    elif is_bool_dtype(values):
+        dtype = bool
+        # transform to int dtype to avoid object path
+        vals = np.asarray(values).view('uint8')
     else:
         vals = np.asarray(values)
 


### PR DESCRIPTION
 - [x] closes #12963
 - [x] tests passed
 - [x] passes ``git diff upstream/master | flake8 --diff``
 - [x] whatsnew entry

Converts `bool` columns to `int` when calling `drop_duplicates()` so the factorization does not go down the `object` path.
 
```
      before           after         ratio
     [9ab57dc5]       [4b05fccb]
-     10.2±0.01ms      4.68±0.01ms     0.46  reindex.Duplicates.time_frame_drop_dups_bool

SOME BENCHMARKS HAVE CHANGED SIGNIFICANTLY.
```
