### PR TITLE
DOC: Patch new flake8 command grep

### DIFF
--- a/doc/source/contributing.rst
+++ b/doc/source/contributing.rst
@@ -529,6 +529,11 @@ run this command, though it will take longer::
 
    git diff master --name-only -- '*.py' | grep 'pandas/' | xargs -r flake8
 
+Note that on OSX, the ``-r`` flag is not available, so you have to omit it and
+run this slightly modified command::
+
+   git diff master --name-only -- '*.py' | grep 'pandas/' | xargs flake8
+
 Backwards Compatibility
 ~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/doc/source/contributing.rst
+++ b/doc/source/contributing.rst
@@ -527,7 +527,7 @@ unused function. However, style-checking the diff will not catch this because
 the actual import is not part of the diff. Thus, for completeness, you should
 run this command, though it will take longer::
 
-   git diff master --name-only -- '*.py' | grep 'pandas' | xargs -r flake8
+   git diff master --name-only -- '*.py' | grep 'pandas/' | xargs -r flake8
 
 Backwards Compatibility
 ~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
The grep was initially matching to "pandas," which is incorrect because that was also matching files containing "pandas" in the name but that were not in the main `pandas` directory (e.g. performance test code).  This change enforces that we match to any Python files in the main `pandas` directory.

Also picked up compatibility issue with OSX, in which the `-r` flag does not exist.  However, `xargs` terminates if the argument list is empty, which was the whole point of passing in `-r` in the first place.

Follow-up to #15712