### PR TITLE
ENH: support "nrows" and "chunksize" together

### DIFF
--- a/doc/source/whatsnew/v0.20.0.txt
+++ b/doc/source/whatsnew/v0.20.0.txt
@@ -291,6 +291,7 @@ Other enhancements
 - ``Series`` provides a ``to_excel`` method to output Excel files (:issue:`8825`)
 - The ``usecols`` argument in ``pd.read_csv`` now accepts a callable function as a value  (:issue:`14154`)
 - The ``skiprows`` argument in ``pd.read_csv`` now accepts a callable function as a value  (:issue:`10882`)
+- The ``nrows`` and ``chunksize`` arguments in ``pd.read_csv`` are supported if both are passed (:issue:`15755`)
 - ``pd.DataFrame.plot`` now prints a title above each subplot if ``suplots=True`` and ``title`` is a list of strings (:issue:`14753`)
 - ``pd.Series.interpolate`` now supports timedelta as an index type with ``method='time'`` (:issue:`6424`)
 - ``Timedelta.isoformat`` method added for formatting Timedeltas as an `ISO 8601 duration`_. See the :ref:`Timedelta docs <timedeltas.isoformat>` (:issue:`15136`)

--- a/pandas/tests/io/parser/common.py
+++ b/pandas/tests/io/parser/common.py
@@ -402,6 +402,30 @@ bar,foo"""
         tm.assert_frame_equal(chunks[1], df[2:4])
         tm.assert_frame_equal(chunks[2], df[4:])
 
+        # With nrows
+        reader = self.read_csv(StringIO(self.data1), index_col=0,
+                               chunksize=2, nrows=5)
+        df = self.read_csv(StringIO(self.data1), index_col=0, nrows=5)
+
+        tm.assert_frame_equal(pd.concat(reader), df)
+
+        # chunksize > nrows
+        reader = self.read_csv(StringIO(self.data1), index_col=0,
+                               chunksize=8, nrows=5)
+        df = self.read_csv(StringIO(self.data1), index_col=0, nrows=5)
+
+        tm.assert_frame_equal(pd.concat(reader), df)
+
+        # with changing "size":
+        reader = self.read_csv(StringIO(self.data1), index_col=0,
+                               chunksize=8, nrows=5)
+        df = self.read_csv(StringIO(self.data1), index_col=0, nrows=5)
+
+        tm.assert_frame_equal(reader.get_chunk(size=2), df.iloc[:2])
+        tm.assert_frame_equal(reader.get_chunk(size=4), df.iloc[2:5])
+        with tm.assertRaises(StopIteration):
+            reader.get_chunk(size=3)
+
     def test_read_chunksize_named(self):
         reader = self.read_csv(
             StringIO(self.data1), index_col='index', chunksize=2)

--- a/pandas/tests/io/parser/test_unsupported.py
+++ b/pandas/tests/io/parser/test_unsupported.py
@@ -29,15 +29,6 @@ class TestUnsupportedFeatures(tm.TestCase):
                 read_csv(StringIO(data), engine=engine,
                          mangle_dupe_cols=False)
 
-    def test_nrows_and_chunksize(self):
-        data = 'a b c'
-        msg = "cannot be used together yet"
-
-        for engine in ('c', 'python'):
-            with tm.assertRaisesRegexp(NotImplementedError, msg):
-                read_csv(StringIO(data), engine=engine,
-                         nrows=10, chunksize=5)
-
     def test_c_engine(self):
         # see gh-6607
         data = 'a b c\n1 2 3'


### PR DESCRIPTION
 - [x] closes #15755
 - [x] tests added / passed
 - [x] passes ``git diff master | flake8 --diff`` (except for ``whatsnew/v0.20.0.txt``, I don't know why)
 - [x] whatsnew entry
