### PR TITLE
DOC: Ensure basic flake8 diff checks only Python

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,4 @@
  - [ ] closes #xxxx
  - [ ] tests added / passed
- - [ ] passes ``git diff upstream/master | flake8 --diff``
+ - [ ] passes ``git diff upstream/master --name-only -- '*.py' | flake8 --diff``
  - [ ] whatsnew entry

--- a/doc/source/contributing.rst
+++ b/doc/source/contributing.rst
@@ -518,7 +518,7 @@ Travis-CI will run the `flake8 <http://pypi.python.org/pypi/flake8>`_ tool
 and report any stylistic errors in your code. Therefore, it is helpful before
 submitting code to run the check yourself on the diff::
 
-   git diff master | flake8 --diff
+   git diff master --name-only -- '*.py' | flake8 --diff
 
 This command will catch any stylistic errors in your changes specifically, but
 be beware it may not catch all of them. For example, if you delete the only


### PR DESCRIPTION
Let's make sure all of the `flake8` commands in our documentation check only Python files (will be applicable to majority of contributions and PR's).

Follow-up to #15749