### PR TITLE
Fix scalar iloc

### DIFF
--- a/doc/source/whatsnew/v0.20.2.txt
+++ b/doc/source/whatsnew/v0.20.2.txt
@@ -46,7 +46,7 @@ Indexing
 ^^^^^^^^
 
 - Bug in ``DataFrame.reset_index(level=)`` with single level index (:issue:`16263`)
-
+- Bug in ``DataFrame.iloc`` with duplicate labels (:issue:`15686`)
 
 I/O
 ^^^

--- a/pandas/core/dtypes/cast.py
+++ b/pandas/core/dtypes/cast.py
@@ -1026,3 +1026,24 @@ def find_common_type(types):
             return np.object
 
     return np.find_common_type(types, [])
+
+
+def _maybe_convert_indexer(indexer, until):
+    """
+    Convert slice, tuple, list or scalar "indexer" to 1-d array of indices,
+    using "until" as maximum for upwards open slices.
+    """
+
+    if is_scalar(indexer):
+        return np.array([indexer], dtype=int)
+
+    if isinstance(indexer, np.ndarray):
+        if indexer.dtype == bool:
+            return np.where(indexer)[0]
+        return indexer
+
+    if isinstance(indexer, slice):
+        stop = until if indexer.stop is None else indexer.stop
+        return np.arange(stop, dtype=int)[indexer]
+
+    return np.array(indexer, dtype=int)

--- a/pandas/tests/indexing/test_iloc.py
+++ b/pandas/tests/indexing/test_iloc.py
@@ -332,6 +332,17 @@ class TestiLoc(Base):
             drop=True)
         tm.assert_frame_equal(df, expected)
 
+    @pytest.mark.xfail(reason="BlockManager.setitem() broken")
+    def test_iloc_setitem_dups_mixed_df(self):
+        # GH 12991
+        df1 = DataFrame([{'A': None, 'B': 1}, {'A': 2, 'B': 2}])
+        df2 = DataFrame([{'A': 3, 'B': 3}, {'A': 4, 'B': 4}])
+        df = concat([df1, df2], axis=1)
+
+        expected = df.fillna(15)
+        df.iloc[0, 0] = 15
+        tm.assert_frame_equal(df, expected)
+
     def test_iloc_getitem_frame(self):
         df = DataFrame(np.random.randn(10, 4), index=lrange(0, 20, 2),
                        columns=lrange(0, 8, 2))

--- a/pandas/tests/indexing/test_iloc.py
+++ b/pandas/tests/indexing/test_iloc.py
@@ -288,13 +288,31 @@ class TestiLoc(Base):
         # iloc with a mask aligning from another iloc
         df1 = DataFrame([{'A': None, 'B': 1}, {'A': 2, 'B': 2}])
         df2 = DataFrame([{'A': 3, 'B': 3}, {'A': 4, 'B': 4}])
-        df = concat([df1, df2], axis=1)
+        df_orig = concat([df1, df2], axis=1)
+        df = df_orig.copy()
 
+        # GH 15686
+        # iloc with mask, duplicated index and multiple blocks
         expected = df.fillna(3)
-        expected['A'] = expected['A'].astype('float64')
+        expected.iloc[:, 0] = expected.iloc[:, 0].astype('float64')
         inds = np.isnan(df.iloc[:, 0])
         mask = inds[inds].index
         df.iloc[mask, 0] = df.iloc[mask, 2]
+        tm.assert_frame_equal(df, expected)
+
+        # GH 15686
+        # iloc with scalar, duplicated index and multiple blocks
+        df = df_orig.copy()
+        expected = df.fillna(15)
+        df.iloc[0, 0] = 15
+        tm.assert_frame_equal(df, expected)
+
+        # GH 15686
+        # iloc with repeated value, duplicated index and multiple blocks
+        df = df_orig.copy()
+        expected = concat([DataFrame([{'A': 15, 'B': 1}, {'A': 15, 'B': 2}]),
+                          df2], axis=1)
+        df.iloc[:, 0] = 15
         tm.assert_frame_equal(df, expected)
 
         # del a dup column across blocks


### PR DESCRIPTION
 - [x] closes #15686
 - [x] tests added / passed
 - [x] passes ``git diff master --name-only -- '*.py' | flake8 --diff``
 - [x] whatsnew entry

Unless I'm missing anything, all code for indexers (inside ``pandas/core/indexing.py``) resorts to one of the following for setting values:
- if we can work directly on ``BlockManager.setitem`` (simple case, e.g. no multiple dtypes involved), do so
- otherwise, rely on methods provided by the object (mainly ``__setitem__``), _which are label based_

This makes it impossible, in the "non-simple case", to index positionally in the correct way with duplicated labels (by the way, it's also plain ugly).

I can see three (four) possible solutions:
1. temporarily strip an object from (some of) its labels - what this PR does. Arguably the simplest approach (doesn't require changing objects/``BlockManager`` code), arguably not very elegant (although we could already expect some efficiency gains compared to current master, since this removes some equality checks on labels)
2. add methods to the different objects that do position-based setting. Not trivial as it sounds, I'm afraid - such methods should talk directly the the ``BlockManager``s, hence for instance taking care of dtype changes
3. seriously improving ``BlockManager.setitem`` so that it is able to take care of multiple dtypes. Probably the best approach (would allow to enormously simplify indexing code), and the one requiring most work
4. (completely rewrite all setting code in ``indexing.py`` currently relying on ``self.obj.__setitem__`` so it directly talks to ``BlockManager.setitem``)

Notice that ``BlockManager.setitem`` must be fixed in order to fix #12991, but the fix for that bug is significantly simpler than 3. (it is just a matter of shifting indices, not of working with different dtypes).

The current PR... works, and does clean a bit the ``_setter`` interface (i.e. concerning the difference between ``iloc`` and ``loc``), which might be a good thing even in case we later decide to drop the less elegant ``InfoCleaner``. My preferred approach would be to apply it, then start working on 3., then come back to the indexing code and simplify it by profiting of 3. But if you prefer to start directly with 2. or 3., I can have a try in that direction. I don't think I'm willing to try 4. because current indexing code is already too complicated.