### PR TITLE
COMPAT: NaT accessors

### DIFF
--- a/doc/source/whatsnew/v0.20.0.txt
+++ b/doc/source/whatsnew/v0.20.0.txt
@@ -771,7 +771,8 @@ Other API Changes
   since pandas version 0.13.0 and can be done with the ``Series.str.extract``
   method (:issue:`5224`). As a consequence, the ``as_indexer`` keyword is
   ignored (no longer needed to specify the new behaviour) and is deprecated.
-
+- ``NaT`` will now correctly report ``False`` for datetimelike boolean operations such as ``is_month_start`` (:issue:`15781`)
+- ``NaT`` will now correctly return ``np.nan`` for ``Timedelta`` and ``Period`` accessors such as ``days`` and ``quarter`` (:issue:`15782`)
 
 .. _whatsnew_0200.deprecations:
 

--- a/pandas/_libs/tslib.pyx
+++ b/pandas/_libs/tslib.pyx
@@ -849,6 +849,30 @@ class NaTType(_NaT):
     def is_leap_year(self):
         return False
 
+    @property
+    def is_month_start(self):
+        return False
+
+    @property
+    def is_quarter_start(self):
+        return False
+
+    @property
+    def is_year_start(self):
+        return False
+
+    @property
+    def is_month_end(self):
+        return False
+
+    @property
+    def is_quarter_end(self):
+        return False
+
+    @property
+    def is_year_end(self):
+        return False
+
     def __rdiv__(self, other):
         return _nat_rdivide_op(self, other)
 
@@ -3799,8 +3823,9 @@ def array_strptime(ndarray[object] values, object fmt,
 # these by definition return np.nan
 fields = ['year', 'quarter', 'month', 'day', 'hour',
           'minute', 'second', 'millisecond', 'microsecond', 'nanosecond',
-          'week', 'dayofyear', 'days_in_month', 'daysinmonth', 'dayofweek',
-          'weekday_name']
+          'week', 'dayofyear', 'weekofyear', 'days_in_month', 'daysinmonth',
+          'dayofweek', 'weekday_name', 'days', 'seconds', 'microseconds',
+          'nanoseconds', 'qyear', 'quarter']
 for field in fields:
     prop = property(fget=lambda self: np.nan)
     setattr(NaTType, field, prop)
@@ -4810,7 +4835,7 @@ def get_start_end_field(ndarray[int64_t] dtindex, object field,
     if field == 'is_month_start':
         if is_business:
             for i in range(count):
-                if dtindex[i] == NPY_NAT: out[i] = -1; continue
+                if dtindex[i] == NPY_NAT: out[i] = 0; continue
 
                 pandas_datetime_to_datetimestruct(
                     dtindex[i], PANDAS_FR_ns, &dts)
@@ -4823,7 +4848,7 @@ def get_start_end_field(ndarray[int64_t] dtindex, object field,
             return out.view(bool)
         else:
             for i in range(count):
-                if dtindex[i] == NPY_NAT: out[i] = -1; continue
+                if dtindex[i] == NPY_NAT: out[i] = 0; continue
 
                 pandas_datetime_to_datetimestruct(
                     dtindex[i], PANDAS_FR_ns, &dts)
@@ -4836,7 +4861,7 @@ def get_start_end_field(ndarray[int64_t] dtindex, object field,
     elif field == 'is_month_end':
         if is_business:
             for i in range(count):
-                if dtindex[i] == NPY_NAT: out[i] = -1; continue
+                if dtindex[i] == NPY_NAT: out[i] = 0; continue
 
                 pandas_datetime_to_datetimestruct(
                     dtindex[i], PANDAS_FR_ns, &dts)
@@ -4854,7 +4879,7 @@ def get_start_end_field(ndarray[int64_t] dtindex, object field,
             return out.view(bool)
         else:
             for i in range(count):
-                if dtindex[i] == NPY_NAT: out[i] = -1; continue
+                if dtindex[i] == NPY_NAT: out[i] = 0; continue
 
                 pandas_datetime_to_datetimestruct(
                     dtindex[i], PANDAS_FR_ns, &dts)
@@ -4871,7 +4896,7 @@ def get_start_end_field(ndarray[int64_t] dtindex, object field,
     elif field == 'is_quarter_start':
         if is_business:
             for i in range(count):
-                if dtindex[i] == NPY_NAT: out[i] = -1; continue
+                if dtindex[i] == NPY_NAT: out[i] = 0; continue
 
                 pandas_datetime_to_datetimestruct(
                     dtindex[i], PANDAS_FR_ns, &dts)
@@ -4885,7 +4910,7 @@ def get_start_end_field(ndarray[int64_t] dtindex, object field,
             return out.view(bool)
         else:
             for i in range(count):
-                if dtindex[i] == NPY_NAT: out[i] = -1; continue
+                if dtindex[i] == NPY_NAT: out[i] = 0; continue
 
                 pandas_datetime_to_datetimestruct(
                     dtindex[i], PANDAS_FR_ns, &dts)
@@ -4898,7 +4923,7 @@ def get_start_end_field(ndarray[int64_t] dtindex, object field,
     elif field == 'is_quarter_end':
         if is_business:
             for i in range(count):
-                if dtindex[i] == NPY_NAT: out[i] = -1; continue
+                if dtindex[i] == NPY_NAT: out[i] = 0; continue
 
                 pandas_datetime_to_datetimestruct(
                     dtindex[i], PANDAS_FR_ns, &dts)
@@ -4917,7 +4942,7 @@ def get_start_end_field(ndarray[int64_t] dtindex, object field,
             return out.view(bool)
         else:
             for i in range(count):
-                if dtindex[i] == NPY_NAT: out[i] = -1; continue
+                if dtindex[i] == NPY_NAT: out[i] = 0; continue
 
                 pandas_datetime_to_datetimestruct(
                     dtindex[i], PANDAS_FR_ns, &dts)
@@ -4934,7 +4959,7 @@ def get_start_end_field(ndarray[int64_t] dtindex, object field,
     elif field == 'is_year_start':
         if is_business:
             for i in range(count):
-                if dtindex[i] == NPY_NAT: out[i] = -1; continue
+                if dtindex[i] == NPY_NAT: out[i] = 0; continue
 
                 pandas_datetime_to_datetimestruct(
                     dtindex[i], PANDAS_FR_ns, &dts)
@@ -4948,7 +4973,7 @@ def get_start_end_field(ndarray[int64_t] dtindex, object field,
             return out.view(bool)
         else:
             for i in range(count):
-                if dtindex[i] == NPY_NAT: out[i] = -1; continue
+                if dtindex[i] == NPY_NAT: out[i] = 0; continue
 
                 pandas_datetime_to_datetimestruct(
                     dtindex[i], PANDAS_FR_ns, &dts)
@@ -4961,7 +4986,7 @@ def get_start_end_field(ndarray[int64_t] dtindex, object field,
     elif field == 'is_year_end':
         if is_business:
             for i in range(count):
-                if dtindex[i] == NPY_NAT: out[i] = -1; continue
+                if dtindex[i] == NPY_NAT: out[i] = 0; continue
 
                 pandas_datetime_to_datetimestruct(
                     dtindex[i], PANDAS_FR_ns, &dts)
@@ -4980,7 +5005,7 @@ def get_start_end_field(ndarray[int64_t] dtindex, object field,
             return out.view(bool)
         else:
             for i in range(count):
-                if dtindex[i] == NPY_NAT: out[i] = -1; continue
+                if dtindex[i] == NPY_NAT: out[i] = 0; continue
 
                 pandas_datetime_to_datetimestruct(
                     dtindex[i], PANDAS_FR_ns, &dts)

--- a/pandas/tests/indexes/datetimes/test_misc.py
+++ b/pandas/tests/indexes/datetimes/test_misc.py
@@ -259,19 +259,14 @@ class TestDatetime64(tm.TestCase):
             dti.name = 'name'
 
             # non boolean accessors -> return Index
-            for accessor in ['year', 'month', 'day', 'hour', 'minute',
-                             'second', 'microsecond', 'nanosecond',
-                             'dayofweek', 'dayofyear', 'weekofyear',
-                             'quarter', 'weekday_name']:
+            for accessor in DatetimeIndex._field_ops:
                 res = getattr(dti, accessor)
                 assert len(res) == 365
                 assert isinstance(res, Index)
                 assert res.name == 'name'
 
             # boolean accessors -> return array
-            for accessor in ['is_month_start', 'is_month_end',
-                             'is_quarter_start', 'is_quarter_end',
-                             'is_year_start', 'is_year_end']:
+            for accessor in DatetimeIndex._bool_ops:
                 res = getattr(dti, accessor)
                 assert len(res) == 365
                 assert isinstance(res, np.ndarray)

--- a/pandas/tests/indexes/datetimes/test_ops.py
+++ b/pandas/tests/indexes/datetimes/test_ops.py
@@ -31,15 +31,10 @@ class TestDatetimeIndexOps(Ops):
         self.not_valid_objs = [o for o in self.objs if not mask(o)]
 
     def test_ops_properties(self):
-        self.check_ops_properties(
-            ['year', 'month', 'day', 'hour', 'minute', 'second', 'weekofyear',
-             'week', 'dayofweek', 'dayofyear', 'quarter'])
-        self.check_ops_properties(['date', 'time', 'microsecond', 'nanosecond',
-                                   'is_month_start', 'is_month_end',
-                                   'is_quarter_start',
-                                   'is_quarter_end', 'is_year_start',
-                                   'is_year_end', 'weekday_name'],
-                                  lambda x: isinstance(x, DatetimeIndex))
+        f = lambda x: isinstance(x, DatetimeIndex)
+        self.check_ops_properties(DatetimeIndex._field_ops, f)
+        self.check_ops_properties(DatetimeIndex._object_ops, f)
+        self.check_ops_properties(DatetimeIndex._bool_ops, f)
 
     def test_ops_properties_basic(self):
 

--- a/pandas/tests/indexes/period/test_ops.py
+++ b/pandas/tests/indexes/period/test_ops.py
@@ -21,11 +21,10 @@ class TestPeriodIndexOps(Ops):
         self.not_valid_objs = [o for o in self.objs if not mask(o)]
 
     def test_ops_properties(self):
-        self.check_ops_properties(
-            ['year', 'month', 'day', 'hour', 'minute', 'second', 'weekofyear',
-             'week', 'dayofweek', 'dayofyear', 'quarter'])
-        self.check_ops_properties(['qyear'],
-                                  lambda x: isinstance(x, PeriodIndex))
+        f = lambda x: isinstance(x, PeriodIndex)
+        self.check_ops_properties(PeriodIndex._field_ops, f)
+        self.check_ops_properties(PeriodIndex._object_ops, f)
+        self.check_ops_properties(PeriodIndex._bool_ops, f)
 
     def test_asobject_tolist(self):
         idx = pd.period_range(start='2013-01-01', periods=4, freq='M',

--- a/pandas/tests/indexes/period/test_period.py
+++ b/pandas/tests/indexes/period/test_period.py
@@ -394,8 +394,8 @@ class TestPeriodIndex(DatetimeLike, tm.TestCase):
 
     def _check_all_fields(self, periodindex):
         fields = ['year', 'month', 'day', 'hour', 'minute', 'second',
-                  'weekofyear', 'week', 'dayofweek', 'weekday', 'dayofyear',
-                  'quarter', 'qyear', 'days_in_month', 'is_leap_year']
+                  'weekofyear', 'week', 'dayofweek', 'dayofyear',
+                  'quarter', 'qyear', 'days_in_month']
 
         periods = list(periodindex)
         s = pd.Series(periodindex)

--- a/pandas/tests/indexes/timedeltas/test_ops.py
+++ b/pandas/tests/indexes/timedeltas/test_ops.py
@@ -21,9 +21,9 @@ class TestTimedeltaIndexOps(Ops):
         self.not_valid_objs = []
 
     def test_ops_properties(self):
-        self.check_ops_properties(['days', 'hours', 'minutes', 'seconds',
-                                   'milliseconds'])
-        self.check_ops_properties(['microseconds', 'nanoseconds'])
+        f = lambda x: isinstance(x, TimedeltaIndex)
+        self.check_ops_properties(TimedeltaIndex._field_ops, f)
+        self.check_ops_properties(TimedeltaIndex._object_ops, f)
 
     def test_asobject_tolist(self):
         idx = timedelta_range(start='1 days', periods=4, freq='D', name='idx')

--- a/pandas/tests/scalar/test_nat.py
+++ b/pandas/tests/scalar/test_nat.py
@@ -1,0 +1,248 @@
+import pytest
+
+from datetime import datetime, timedelta
+import pytz
+
+import numpy as np
+from pandas import (NaT, Index, Timestamp, Timedelta, Period,
+                    DatetimeIndex, PeriodIndex,
+                    TimedeltaIndex, Series, isnull)
+from pandas.util import testing as tm
+from pandas._libs.tslib import iNaT
+
+
+@pytest.mark.parametrize('nat, idx', [(Timestamp('NaT'), DatetimeIndex),
+                                      (Timedelta('NaT'), TimedeltaIndex),
+                                      (Period('NaT', freq='M'), PeriodIndex)])
+def test_nat_fields(nat, idx):
+
+    for field in idx._field_ops:
+
+        # weekday is a property of DTI, but a method
+        # on NaT/Timestamp for compat with datetime
+        if field == 'weekday':
+            continue
+
+        result = getattr(NaT, field)
+        assert np.isnan(result)
+
+        result = getattr(nat, field)
+        assert np.isnan(result)
+
+    for field in idx._bool_ops:
+
+        result = getattr(NaT, field)
+        assert result is False
+
+        result = getattr(nat, field)
+        assert result is False
+
+
+def test_nat_vector_field_access():
+    idx = DatetimeIndex(['1/1/2000', None, None, '1/4/2000'])
+
+    for field in DatetimeIndex._field_ops:
+        # weekday is a property of DTI, but a method
+        # on NaT/Timestamp for compat with datetime
+        if field == 'weekday':
+            continue
+
+        result = getattr(idx, field)
+        expected = Index([getattr(x, field) for x in idx])
+        tm.assert_index_equal(result, expected)
+
+    s = Series(idx)
+
+    for field in DatetimeIndex._field_ops:
+
+        # weekday is a property of DTI, but a method
+        # on NaT/Timestamp for compat with datetime
+        if field == 'weekday':
+            continue
+
+        result = getattr(s.dt, field)
+        expected = [getattr(x, field) for x in idx]
+        tm.assert_series_equal(result, Series(expected))
+
+    for field in DatetimeIndex._bool_ops:
+        result = getattr(s.dt, field)
+        expected = [getattr(x, field) for x in idx]
+        tm.assert_series_equal(result, Series(expected))
+
+
+@pytest.mark.parametrize('klass', [Timestamp, Timedelta, Period])
+def test_identity(klass):
+    assert klass(None) is NaT
+
+    result = klass(np.nan)
+    assert result is NaT
+
+    result = klass(None)
+    assert result is NaT
+
+    result = klass(iNaT)
+    assert result is NaT
+
+    result = klass(np.nan)
+    assert result is NaT
+
+    result = klass(float('nan'))
+    assert result is NaT
+
+    result = klass(NaT)
+    assert result is NaT
+
+    result = klass('NaT')
+    assert result is NaT
+
+    assert isnull(klass('nat'))
+
+
+@pytest.mark.parametrize('klass', [Timestamp, Timedelta, Period])
+def test_equality(klass):
+
+    # nat
+    if klass is not Period:
+        klass('').value == iNaT
+    klass('nat').value == iNaT
+    klass('NAT').value == iNaT
+    klass(None).value == iNaT
+    klass(np.nan).value == iNaT
+    assert isnull(klass('nat'))
+
+
+@pytest.mark.parametrize('klass', [Timestamp, Timedelta])
+def test_round_nat(klass):
+    # GH14940
+    ts = klass('nat')
+    for method in ["round", "floor", "ceil"]:
+        round_method = getattr(ts, method)
+        for freq in ["s", "5s", "min", "5min", "h", "5h"]:
+            assert round_method(freq) is ts
+
+
+def test_NaT_methods():
+    # GH 9513
+    raise_methods = ['astimezone', 'combine', 'ctime', 'dst',
+                     'fromordinal', 'fromtimestamp', 'isocalendar',
+                     'strftime', 'strptime', 'time', 'timestamp',
+                     'timetuple', 'timetz', 'toordinal', 'tzname',
+                     'utcfromtimestamp', 'utcnow', 'utcoffset',
+                     'utctimetuple']
+    nat_methods = ['date', 'now', 'replace', 'to_datetime', 'today']
+    nan_methods = ['weekday', 'isoweekday']
+
+    for method in raise_methods:
+        if hasattr(NaT, method):
+            with pytest.raises(ValueError):
+                getattr(NaT, method)()
+
+    for method in nan_methods:
+        if hasattr(NaT, method):
+            assert np.isnan(getattr(NaT, method)())
+
+    for method in nat_methods:
+        if hasattr(NaT, method):
+            # see gh-8254
+            exp_warning = None
+            if method == 'to_datetime':
+                exp_warning = FutureWarning
+            with tm.assert_produces_warning(
+                    exp_warning, check_stacklevel=False):
+                assert getattr(NaT, method)() is NaT
+
+    # GH 12300
+    assert NaT.isoformat() == 'NaT'
+
+
+@pytest.mark.parametrize('klass', [Timestamp, Timedelta])
+def test_isoformat(klass):
+
+    result = klass('NaT').isoformat()
+    expected = 'NaT'
+    assert result == expected
+
+
+def test_nat_arithmetic():
+    # GH 6873
+    i = 2
+    f = 1.5
+
+    for (left, right) in [(NaT, i), (NaT, f), (NaT, np.nan)]:
+        assert left / right is NaT
+        assert left * right is NaT
+        assert right * left is NaT
+        with pytest.raises(TypeError):
+            right / left
+
+    # Timestamp / datetime
+    t = Timestamp('2014-01-01')
+    dt = datetime(2014, 1, 1)
+    for (left, right) in [(NaT, NaT), (NaT, t), (NaT, dt)]:
+        # NaT __add__ or __sub__ Timestamp-like (or inverse) returns NaT
+        assert right + left is NaT
+        assert left + right is NaT
+        assert left - right is NaT
+        assert right - left is NaT
+
+    # timedelta-like
+    # offsets are tested in test_offsets.py
+
+    delta = timedelta(3600)
+    td = Timedelta('5s')
+
+    for (left, right) in [(NaT, delta), (NaT, td)]:
+        # NaT + timedelta-like returns NaT
+        assert right + left is NaT
+        assert left + right is NaT
+        assert right - left is NaT
+        assert left - right is NaT
+
+    # GH 11718
+    t_utc = Timestamp('2014-01-01', tz='UTC')
+    t_tz = Timestamp('2014-01-01', tz='US/Eastern')
+    dt_tz = pytz.timezone('Asia/Tokyo').localize(dt)
+
+    for (left, right) in [(NaT, t_utc), (NaT, t_tz),
+                          (NaT, dt_tz)]:
+        # NaT __add__ or __sub__ Timestamp-like (or inverse) returns NaT
+        assert right + left is NaT
+        assert left + right is NaT
+        assert left - right is NaT
+        assert right - left is NaT
+
+    # int addition / subtraction
+    for (left, right) in [(NaT, 2), (NaT, 0), (NaT, -3)]:
+        assert right + left is NaT
+        assert left + right is NaT
+        assert left - right is NaT
+        assert right - left is NaT
+
+
+def test_nat_arithmetic_index():
+    # GH 11718
+
+    dti = DatetimeIndex(['2011-01-01', '2011-01-02'], name='x')
+    exp = DatetimeIndex([NaT, NaT], name='x')
+    tm.assert_index_equal(dti + NaT, exp)
+    tm.assert_index_equal(NaT + dti, exp)
+
+    dti_tz = DatetimeIndex(['2011-01-01', '2011-01-02'],
+                           tz='US/Eastern', name='x')
+    exp = DatetimeIndex([NaT, NaT], name='x', tz='US/Eastern')
+    tm.assert_index_equal(dti_tz + NaT, exp)
+    tm.assert_index_equal(NaT + dti_tz, exp)
+
+    exp = TimedeltaIndex([NaT, NaT], name='x')
+    for (left, right) in [(NaT, dti), (NaT, dti_tz)]:
+        tm.assert_index_equal(left - right, exp)
+        tm.assert_index_equal(right - left, exp)
+
+    # timedelta
+    tdi = TimedeltaIndex(['1 day', '2 day'], name='x')
+    exp = DatetimeIndex([NaT, NaT], name='x')
+    for (left, right) in [(NaT, tdi)]:
+        tm.assert_index_equal(left + right, exp)
+        tm.assert_index_equal(right + left, exp)
+        tm.assert_index_equal(left - right, exp)
+        tm.assert_index_equal(right - left, exp)

--- a/pandas/tests/scalar/test_period.py
+++ b/pandas/tests/scalar/test_period.py
@@ -110,20 +110,6 @@ class TestPeriodProperties(tm.TestCase):
         p = Period(tslib.iNaT)
         self.assertIs(p, pd.NaT)
 
-    def test_cons_null_like(self):
-        # check Timestamp compat
-        self.assertIs(Timestamp('NaT'), pd.NaT)
-        self.assertIs(Period('NaT'), pd.NaT)
-
-        self.assertIs(Timestamp(None), pd.NaT)
-        self.assertIs(Period(None), pd.NaT)
-
-        self.assertIs(Timestamp(float('nan')), pd.NaT)
-        self.assertIs(Period(float('nan')), pd.NaT)
-
-        self.assertIs(Timestamp(np.nan), pd.NaT)
-        self.assertIs(Period(np.nan), pd.NaT)
-
     def test_period_cons_mult(self):
         p1 = Period('2011-01', freq='3M')
         p2 = Period('2011-01', freq='M')
@@ -853,17 +839,6 @@ class TestPeriodProperties(tm.TestCase):
         self.assertEqual(s_date.days_in_month, 31)
         self.assertEqual(Period(freq='Min', year=2012, month=2, day=1, hour=0,
                                 minute=0, second=0).days_in_month, 29)
-
-    def test_properties_nat(self):
-        p_nat = Period('NaT', freq='M')
-        t_nat = pd.Timestamp('NaT')
-        self.assertIs(p_nat, t_nat)
-
-        # confirm Period('NaT') work identical with Timestamp('NaT')
-        for f in ['year', 'month', 'day', 'hour', 'minute', 'second', 'week',
-                  'dayofyear', 'quarter', 'days_in_month']:
-            self.assertTrue(np.isnan(getattr(p_nat, f)))
-            self.assertTrue(np.isnan(getattr(t_nat, f)))
 
     def test_pnow(self):
 

--- a/pandas/tests/scalar/test_timedelta.py
+++ b/pandas/tests/scalar/test_timedelta.py
@@ -6,7 +6,7 @@ import pandas as pd
 import pandas.util.testing as tm
 from pandas.tseries.timedeltas import _coerce_scalar_to_timedelta_type as ct
 from pandas import (Timedelta, TimedeltaIndex, timedelta_range, Series,
-                    to_timedelta, compat, isnull)
+                    to_timedelta, compat)
 from pandas._libs.tslib import iNaT, NaTType
 
 
@@ -150,14 +150,6 @@ class TestTimedeltas(tm.TestCase):
             10, 's').astype('m8[ns]').view('i8') + np.timedelta64(
                 500, 'ms').astype('m8[ns]').view('i8')
         self.assertEqual(Timedelta(10.5, unit='s').value, expected)
-
-        # nat
-        self.assertEqual(Timedelta('').value, iNaT)
-        self.assertEqual(Timedelta('nat').value, iNaT)
-        self.assertEqual(Timedelta('NAT').value, iNaT)
-        self.assertEqual(Timedelta(None).value, iNaT)
-        self.assertEqual(Timedelta(np.nan).value, iNaT)
-        self.assertTrue(isnull(Timedelta('nat')))
 
         # offset
         self.assertEqual(to_timedelta(pd.offsets.Hour(2)),
@@ -684,11 +676,6 @@ class TestTimedeltas(tm.TestCase):
         td = Timedelta(milliseconds=1)
         result = td.isoformat()
         expected = 'P0DT0H0M0.001S'
-        self.assertEqual(result, expected)
-
-        # NaT
-        result = Timedelta('NaT').isoformat()
-        expected = 'NaT'
         self.assertEqual(result, expected)
 
         # don't strip every 0

--- a/pandas/tests/series/test_datetime_values.py
+++ b/pandas/tests/series/test_datetime_values.py
@@ -8,10 +8,8 @@ import pandas as pd
 
 from pandas.types.common import is_integer_dtype, is_list_like
 from pandas import (Index, Series, DataFrame, bdate_range,
-                    date_range, period_range, timedelta_range)
-from pandas.tseries.period import PeriodIndex
-from pandas.tseries.index import Timestamp, DatetimeIndex
-from pandas.tseries.tdi import TimedeltaIndex
+                    date_range, period_range, timedelta_range,
+                    PeriodIndex, Timestamp, DatetimeIndex, TimedeltaIndex)
 import pandas.core.common as com
 
 from pandas.util.testing import assert_series_equal
@@ -27,21 +25,13 @@ class TestSeriesDatetimeValues(TestData, tm.TestCase):
         # GH 7207, 11128
         # test .dt namespace accessor
 
-        ok_for_base = ['year', 'month', 'day', 'hour', 'minute', 'second',
-                       'weekofyear', 'week', 'dayofweek', 'weekday',
-                       'dayofyear', 'quarter', 'freq', 'days_in_month',
-                       'daysinmonth', 'is_leap_year']
-        ok_for_period = ok_for_base + ['qyear', 'start_time', 'end_time']
+        ok_for_period = PeriodIndex._datetimelike_ops
         ok_for_period_methods = ['strftime', 'to_timestamp', 'asfreq']
-        ok_for_dt = ok_for_base + ['date', 'time', 'microsecond', 'nanosecond',
-                                   'is_month_start', 'is_month_end',
-                                   'is_quarter_start', 'is_quarter_end',
-                                   'is_year_start', 'is_year_end', 'tz',
-                                   'weekday_name']
+        ok_for_dt = DatetimeIndex._datetimelike_ops
         ok_for_dt_methods = ['to_period', 'to_pydatetime', 'tz_localize',
                              'tz_convert', 'normalize', 'strftime', 'round',
                              'floor', 'ceil', 'weekday_name']
-        ok_for_td = ['days', 'seconds', 'microseconds', 'nanoseconds']
+        ok_for_td = TimedeltaIndex._datetimelike_ops
         ok_for_td_methods = ['components', 'to_pytimedelta', 'total_seconds',
                              'round', 'floor', 'ceil']
 

--- a/pandas/tests/test_base.py
+++ b/pandas/tests/test_base.py
@@ -219,7 +219,7 @@ class Ops(tm.TestCase):
                     self.assertEqual(result, expected)
 
             # freq raises AttributeError on an Int64Index because its not
-            # defined we mostly care about Series hwere anyhow
+            # defined we mostly care about Series here anyhow
             if not ignore_failures:
                 for o in self.not_valid_objs:
 

--- a/pandas/tseries/common.py
+++ b/pandas/tseries/common.py
@@ -168,8 +168,7 @@ DatetimeProperties._add_delegate_accessors(
     typ='property')
 DatetimeProperties._add_delegate_accessors(
     delegate=DatetimeIndex,
-    accessors=["to_period", "tz_localize", "tz_convert",
-               "normalize", "strftime", "round", "floor", "ceil"],
+    accessors=DatetimeIndex._datetimelike_methods,
     typ='method')
 
 
@@ -208,7 +207,7 @@ TimedeltaProperties._add_delegate_accessors(
     typ='property')
 TimedeltaProperties._add_delegate_accessors(
     delegate=TimedeltaIndex,
-    accessors=["to_pytimedelta", "total_seconds", "round", "floor", "ceil"],
+    accessors=TimedeltaIndex._datetimelike_methods,
     typ='method')
 
 
@@ -230,9 +229,10 @@ PeriodProperties._add_delegate_accessors(
     delegate=PeriodIndex,
     accessors=PeriodIndex._datetimelike_ops,
     typ='property')
-PeriodProperties._add_delegate_accessors(delegate=PeriodIndex,
-                                         accessors=["strftime"],
-                                         typ='method')
+PeriodProperties._add_delegate_accessors(
+    delegate=PeriodIndex,
+    accessors=PeriodIndex._datetimelike_methods,
+    typ='method')
 
 
 class CombinedDatetimelikeProperties(DatetimeProperties, TimedeltaProperties):

--- a/pandas/tseries/period.py
+++ b/pandas/tseries/period.py
@@ -174,12 +174,18 @@ class PeriodIndex(DatelikeOps, DatetimeIndexOpsMixin, Int64Index):
     _box_scalars = True
     _typ = 'periodindex'
     _attributes = ['name', 'freq']
-    _datetimelike_ops = ['year', 'month', 'day', 'hour', 'minute', 'second',
-                         'weekofyear', 'week', 'dayofweek', 'weekday',
-                         'dayofyear', 'quarter', 'qyear', 'freq',
-                         'days_in_month', 'daysinmonth',
-                         'to_timestamp', 'asfreq', 'start_time', 'end_time',
-                         'is_leap_year']
+
+    # define my properties & methods for delegation
+    _other_ops = []
+    _bool_ops = ['is_leap_year']
+    _object_ops = ['start_time', 'end_time', 'freq']
+    _field_ops = ['year', 'month', 'day', 'hour', 'minute', 'second',
+                  'weekofyear', 'weekday', 'week', 'dayofweek',
+                  'dayofyear', 'quarter', 'qyear',
+                  'days_in_month', 'daysinmonth']
+    _datetimelike_ops = _field_ops + _object_ops + _bool_ops
+    _datetimelike_methods = ['strftime', 'to_timestamp', 'asfreq']
+
     _is_numeric_dtype = False
     _infer_as_myclass = True
 

--- a/pandas/tseries/tdi.py
+++ b/pandas/tseries/tdi.py
@@ -127,8 +127,15 @@ class TimedeltaIndex(DatetimeIndexOpsMixin, TimelikeOps, Int64Index):
     _left_indexer_unique = _join_i8_wrapper(
         libjoin.left_join_indexer_unique_int64, with_indexers=False)
     _arrmap = None
-    _datetimelike_ops = ['days', 'seconds', 'microseconds', 'nanoseconds',
-                         'freq', 'components']
+
+    # define my properties & methods for delegation
+    _other_ops = []
+    _bool_ops = []
+    _object_ops = ['freq']
+    _field_ops = ['days', 'seconds', 'microseconds', 'nanoseconds']
+    _datetimelike_ops = _field_ops + _object_ops + _bool_ops
+    _datetimelike_methods = ["to_pytimedelta", "total_seconds",
+                             "round", "floor", "ceil"]
 
     __eq__ = _td_index_cmp('__eq__')
     __ne__ = _td_index_cmp('__ne__', nat_result=True)


### PR DESCRIPTION
closes #15781

PR
```
In [1]: idx = DatetimeIndex(['1/1/2000', None, None, '1/4/2000'])

In [2]: idx.is_month_start
Out[2]: array([ True, False, False, False], dtype=bool)

In [3]: idx.is_leap_year
Out[3]: array([ True, False, False,  True], dtype=bool)
```

0.19.2
```
In [1]: idx = DatetimeIndex(['1/1/2000', None, None, '1/4/2000'])

In [3]: idx.is_month_start
Out[3]: array([  1.,  nan,  nan,   0.])

In [2]: idx.is_leap_year
Out[2]: array([ True, False, False,  True], dtype=bool)

```
mimics ``is_leap_year`` to return a boolean (inlcuding for ``NaT``).