### PR TITLE
COMPAT: 3.6.1 compat for change in PySlice_GetIndices_Ex

### DIFF
--- a/pandas/_libs/lib.pyx
+++ b/pandas/_libs/lib.pyx
@@ -3,6 +3,7 @@ cimport numpy as np
 cimport cython
 import numpy as np
 import sys
+
 cdef bint PY3 = (sys.version_info[0] >= 3)
 
 from numpy cimport *
@@ -26,7 +27,8 @@ from cpython cimport (PyDict_New, PyDict_GetItem, PyDict_SetItem,
                       PyObject_SetAttrString,
                       PyObject_RichCompareBool,
                       PyBytes_GET_SIZE,
-                      PyUnicode_GET_SIZE)
+                      PyUnicode_GET_SIZE,
+                      PyObject)
 
 try:
     from cpython cimport PyString_GET_SIZE
@@ -36,11 +38,10 @@ except ImportError:
 cdef extern from "Python.h":
     Py_ssize_t PY_SSIZE_T_MAX
 
-    ctypedef struct PySliceObject:
-        pass
+cdef extern from "compat_helper.h":
 
-    cdef int PySlice_GetIndicesEx(
-        PySliceObject* s, Py_ssize_t length,
+    cdef int slice_get_indices(
+        PyObject* s, Py_ssize_t length,
         Py_ssize_t *start, Py_ssize_t *stop, Py_ssize_t *step,
         Py_ssize_t *slicelength) except -1
 
@@ -1658,8 +1659,8 @@ cpdef slice_get_indices_ex(slice slc, Py_ssize_t objlen=PY_SSIZE_T_MAX):
     if slc is None:
         raise TypeError("slc should be a slice")
 
-    PySlice_GetIndicesEx(<PySliceObject *>slc, objlen,
-                         &start, &stop, &step, &length)
+    slice_get_indices(<PyObject *>slc, objlen,
+                      &start, &stop, &step, &length)
 
     return start, stop, step, length
 
@@ -1683,8 +1684,8 @@ cpdef Py_ssize_t slice_len(
     if slc is None:
         raise TypeError("slc must be slice")
 
-    PySlice_GetIndicesEx(<PySliceObject *>slc, objlen,
-                         &start, &stop, &step, &length)
+    slice_get_indices(<PyObject *>slc, objlen,
+                      &start, &stop, &step, &length)
 
     return length
 

--- a/pandas/_libs/src/compat_helper.h
+++ b/pandas/_libs/src/compat_helper.h
@@ -1,0 +1,32 @@
+/*
+Copyright (c) 2016, PyData Development Team
+All rights reserved.
+
+Distributed under the terms of the BSD Simplified License.
+
+The full license is in the LICENSE file, distributed with this software.
+*/
+
+#ifndef PANDAS__LIBS_SRC_COMPAT_HELPER_H_
+#define PANDAS__LIBS_SRC_COMPAT_HELPER_H_
+
+#include "Python.h"
+#include "numpy_helper.h"
+
+/*
+PySlice_GetIndicesEx changes signature in PY3
+but 3.6.1 in particular changes the behavior of this function slightly
+https://bugs.python.org/issue27867
+*/
+
+PANDAS_INLINE int slice_get_indices(PyObject *s, Py_ssize_t length,
+                                    Py_ssize_t *start, Py_ssize_t *stop, Py_ssize_t *step,
+                                    Py_ssize_t *slicelength) {
+#if PY_VERSION_HEX >= 0x03060000
+  return PySlice_GetIndicesEx(s, length, start, stop, step, slicelength);
+#else
+  return PySlice_GetIndicesEx(<PySliceObject *>s, length, start, stop, step, slicelength);
+#endif
+}
+
+#endif  // PANDAS__LIBS_SRC_COMPAT_HELPER_H_

--- a/pandas/_libs/src/compat_helper.h
+++ b/pandas/_libs/src/compat_helper.h
@@ -19,13 +19,18 @@ but 3.6.1 in particular changes the behavior of this function slightly
 https://bugs.python.org/issue27867
 */
 
-PANDAS_INLINE int slice_get_indices(PyObject *s, Py_ssize_t length,
-                                    Py_ssize_t *start, Py_ssize_t *stop, Py_ssize_t *step,
+PANDAS_INLINE int slice_get_indices(PyObject *s,
+                                    Py_ssize_t length,
+                                    Py_ssize_t *start,
+                                    Py_ssize_t *stop,
+                                    Py_ssize_t *step,
                                     Py_ssize_t *slicelength) {
-#if PY_VERSION_HEX >= 0x03060000
-  return PySlice_GetIndicesEx(s, length, start, stop, step, slicelength);
+#if PY_VERSION_HEX >= 0x03000000
+  return PySlice_GetIndicesEx(s, length, start, stop,
+                              step, slicelength);
 #else
-  return PySlice_GetIndicesEx(<PySliceObject *>s, length, start, stop, step, slicelength);
+  return PySlice_GetIndicesEx((PySliceObject *)s, length, start,
+                              stop, step, slicelength);
 #endif
 }
 

--- a/setup.py
+++ b/setup.py
@@ -460,7 +460,8 @@ else:
     extra_compile_args=['-Wno-unused-function']
 
 lib_depends = lib_depends + ['pandas/_libs/src/numpy_helper.h',
-                             'pandas/_libs/src/parse_helper.h']
+                             'pandas/_libs/src/parse_helper.h',
+                             'pandas/_libs/src/compat_helper.h']
 
 
 tseries_depends = ['pandas/_libs/src/datetime/np_datetime.h',


### PR DESCRIPTION
This doesn't actually matter to any tests except for some internal consistency ones.
Bonus is that it eliminates a warning :<

note that we aren't actually testing this (yet) on Travis as our 3.6 build uses conda-forge and 3.6.1 is not there as of yet. Its in defaults though (and shows up on appveyor build).