### PR TITLE
Rolling window endpoints inclusion

### DIFF
--- a/doc/source/computation.rst
+++ b/doc/source/computation.rst
@@ -466,19 +466,35 @@ Rolling window endpoint inclusion
 
 .. versionadded:: 0.20.0
 
-New in version 0.19.0 are the ability to pass an offset (or convertible) to a ``.rolling()`` method and have it produce
-variable sized windows based on the passed time window. For each time point, this includes all preceding values occurring
-within the indicated time delta.
+The inclusion of the interval endpoints in rolling window calculations can be specified with the ``closed``
+parameter:
 
-This can be particularly useful for a non-regular time frequency index.
+  - ``right`` : close right endpoint (default for time-based windows)
+  - ``left`` : close left endpoint
+  - ``both`` : close both endpoints (default for fixed windows)
+  - ``neither`` : open endpoints
+
+For example, having the right endpoint open is useful in many problems that require that there is no contamination
+from present information back to past information. This allows the rolling window to compute statistics
+"up to that point in time", but not including that point in time.
 
 .. ipython:: python
 
-   dft = pd.DataFrame({'B': [0, 1, 2, np.nan, 4]},
-                      index=pd.date_range('20130101 09:00:00', periods=5, freq='s'))
-   dft
+   df = pd.DataFrame({'x': [1]*5},
+                     index = [pd.Timestamp('20130101 09:00:01'),
+                              pd.Timestamp('20130101 09:00:02'),
+                              pd.Timestamp('20130101 09:00:03'),
+                              pd.Timestamp('20130101 09:00:04'),
+                              pd.Timestamp('20130101 09:00:06')])
 
-This is a regular frequency index. Using an integer window parameter works to roll along the window frequency.
+   df["right"] = df.rolling('2s', closed='right').x.sum() # default
+   df["both"] = df.rolling('2s', closed='both').x.sum()
+   df["left"] = df.rolling('2s', closed='left').x.sum()
+   df["open"] = df.rolling('2s', closed='neither').x.sum()
+
+   df
+
+Currently, this feature is only implemented for time-based windows.
 
 .. _stats.moments.ts-versus-resampling:
 

--- a/doc/source/computation.rst
+++ b/doc/source/computation.rst
@@ -459,6 +459,27 @@ default of the index) in a DataFrame.
    dft
    dft.rolling('2s', on='foo').sum()
 
+.. _stats.rolling_window.endpoints:
+
+Rolling window endpoint inclusion
+~~~~~~~~~~~~~~~~~~
+
+.. versionadded:: 0.20.0
+
+New in version 0.19.0 are the ability to pass an offset (or convertible) to a ``.rolling()`` method and have it produce
+variable sized windows based on the passed time window. For each time point, this includes all preceding values occurring
+within the indicated time delta.
+
+This can be particularly useful for a non-regular time frequency index.
+
+.. ipython:: python
+
+   dft = pd.DataFrame({'B': [0, 1, 2, np.nan, 4]},
+                      index=pd.date_range('20130101 09:00:00', periods=5, freq='s'))
+   dft
+
+This is a regular frequency index. Using an integer window parameter works to roll along the window frequency.
+
 .. _stats.moments.ts-versus-resampling:
 
 Time-aware Rolling vs. Resampling

--- a/doc/source/computation.rst
+++ b/doc/source/computation.rst
@@ -490,7 +490,7 @@ from present information back to past information. This allows the rolling windo
    df["right"] = df.rolling('2s', closed='right').x.sum() # default
    df["both"] = df.rolling('2s', closed='both').x.sum()
    df["left"] = df.rolling('2s', closed='left').x.sum()
-   df["open"] = df.rolling('2s', closed='neither').x.sum()
+   df["neither"] = df.rolling('2s', closed='neither').x.sum()
 
    df
 

--- a/doc/source/computation.rst
+++ b/doc/source/computation.rst
@@ -461,18 +461,22 @@ default of the index) in a DataFrame.
 
 .. _stats.rolling_window.endpoints:
 
-Rolling window endpoint inclusion
-~~~~~~~~~~~~~~~~~~
+Rolling Window Endpoints
+~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. versionadded:: 0.20.0
 
 The inclusion of the interval endpoints in rolling window calculations can be specified with the ``closed``
 parameter:
 
-  - ``right`` : close right endpoint (default for time-based windows)
-  - ``left`` : close left endpoint
-  - ``both`` : close both endpoints (default for fixed windows)
-  - ``neither`` : open endpoints
+.. csv-table::
+    :header: "``closed``", "Description", "Default for"
+    :widths: 20, 30, 30
+
+    ``right``, close right endpoint, time-based windows
+    ``left``, close left endpoint,
+    ``both``, close both endpoints, fixed windows
+    ``neither``, open endpoints,
 
 For example, having the right endpoint open is useful in many problems that require that there is no contamination
 from present information back to past information. This allows the rolling window to compute statistics
@@ -495,6 +499,7 @@ from present information back to past information. This allows the rolling windo
    df
 
 Currently, this feature is only implemented for time-based windows.
+For fixed windows, the closed parameter cannot be set and the rolling window will always have both endpoints closed.
 
 .. _stats.moments.ts-versus-resampling:
 

--- a/doc/source/computation.rst
+++ b/doc/source/computation.rst
@@ -487,7 +487,7 @@ from present information back to past information. This allows the rolling windo
                               pd.Timestamp('20130101 09:00:04'),
                               pd.Timestamp('20130101 09:00:06')])
 
-   df["right"] = df.rolling('2s', closed='right').x.sum() # default
+   df["right"] = df.rolling('2s', closed='right').x.sum()  # default
    df["both"] = df.rolling('2s', closed='both').x.sum()
    df["left"] = df.rolling('2s', closed='left').x.sum()
    df["neither"] = df.rolling('2s', closed='neither').x.sum()

--- a/doc/source/whatsnew/v0.20.0.txt
+++ b/doc/source/whatsnew/v0.20.0.txt
@@ -319,7 +319,7 @@ To convert a ``SparseDataFrame`` back to sparse SciPy matrix in COO format, you 
 Other Enhancements
 ^^^^^^^^^^^^^^^^^^
 
-- ``DataFrame.rolling()`` now accepts the parameter ``closed='right'|'left'|'both'|'neither'`` to choose the rolling window endpoint closedness. (:issue:`13965`)
+- ``DataFrame.rolling()`` now accepts the parameter ``closed='right'|'left'|'both'|'neither'`` to choose the rolling window endpoint closedness. See :ref:`documentation <stats.rolling_window.endpoints>` (:issue:`13965`)
 - Integration with the ``feather-format``, including a new top-level ``pd.read_feather()`` and ``DataFrame.to_feather()`` method, see :ref:`here <io.feather>`.
 - ``Series.str.replace()`` now accepts a callable, as replacement, which is passed to ``re.sub`` (:issue:`15055`)
 - ``Series.str.replace()`` now accepts a compiled regular expression as a pattern (:issue:`15446`)

--- a/doc/source/whatsnew/v0.20.0.txt
+++ b/doc/source/whatsnew/v0.20.0.txt
@@ -319,7 +319,7 @@ To convert a ``SparseDataFrame`` back to sparse SciPy matrix in COO format, you 
 Other Enhancements
 ^^^^^^^^^^^^^^^^^^
 
-- ``DataFrame.rolling()`` now accepts the parameter ``closed='right'|'left'|'both'|'neither'`` to choose the rolling window endpoint closedness. See :ref:`documentation <stats.rolling_window.endpoints>` (:issue:`13965`)
+- ``DataFrame.rolling()`` now accepts the parameter ``closed='right'|'left'|'both'|'neither'`` to choose the rolling window endpoint closedness. See the :ref:`documentation <stats.rolling_window.endpoints>` (:issue:`13965`)
 - Integration with the ``feather-format``, including a new top-level ``pd.read_feather()`` and ``DataFrame.to_feather()`` method, see :ref:`here <io.feather>`.
 - ``Series.str.replace()`` now accepts a callable, as replacement, which is passed to ``re.sub`` (:issue:`15055`)
 - ``Series.str.replace()`` now accepts a compiled regular expression as a pattern (:issue:`15446`)

--- a/doc/source/whatsnew/v0.20.0.txt
+++ b/doc/source/whatsnew/v0.20.0.txt
@@ -319,6 +319,7 @@ To convert a ``SparseDataFrame`` back to sparse SciPy matrix in COO format, you 
 Other Enhancements
 ^^^^^^^^^^^^^^^^^^
 
+- ``DataFrame.rolling()`` now accepts the parameter ``closed='right'|'left'|'both'|'neither'`` to choose the rolling window endpoint closedness. (:issue:`13965`)
 - Integration with the ``feather-format``, including a new top-level ``pd.read_feather()`` and ``DataFrame.to_feather()`` method, see :ref:`here <io.feather>`.
 - ``Series.str.replace()`` now accepts a callable, as replacement, which is passed to ``re.sub`` (:issue:`15055`)
 - ``Series.str.replace()`` now accepts a compiled regular expression as a pattern (:issue:`15446`)

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -5962,7 +5962,7 @@ class NDFrame(PandasObject):
 
         @Appender(rwindow.rolling.__doc__)
         def rolling(self, window, min_periods=None, freq=None, center=False,
-                    win_type=None, on=None, axis=0, closed='right'):
+                    win_type=None, on=None, axis=0, closed=None):
             axis = self._get_axis_number(axis)
             return rwindow.rolling(self, window=window,
                                    min_periods=min_periods, freq=freq,

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -5962,12 +5962,12 @@ class NDFrame(PandasObject):
 
         @Appender(rwindow.rolling.__doc__)
         def rolling(self, window, min_periods=None, freq=None, center=False,
-                    win_type=None, on=None, axis=0):
+                    win_type=None, on=None, axis=0, closed='right'):
             axis = self._get_axis_number(axis)
             return rwindow.rolling(self, window=window,
                                    min_periods=min_periods, freq=freq,
                                    center=center, win_type=win_type,
-                                   on=on, axis=axis)
+                                   on=on, axis=axis, closed=closed)
 
         cls.rolling = rolling
 

--- a/pandas/core/window.py
+++ b/pandas/core/window.py
@@ -1060,7 +1060,7 @@ class Rolling(_Rolling_and_Expanding):
 
         if not self.is_datetimelike and self.closed is not None:
             raise ValueError("closed only implemented for datetimelike "
-                                         "and offset based windows")
+                             "and offset based windows")
 
     def _validate_monotonic(self):
         """ validate on is monotonic """

--- a/pandas/core/window.py
+++ b/pandas/core/window.py
@@ -60,7 +60,7 @@ class _Window(PandasObject, SelectionMixin):
     exclusions = set()
 
     def __init__(self, obj, window=None, min_periods=None, freq=None,
-                 center=False, win_type=None, axis=0, on=None, closed='right',
+                 center=False, win_type=None, axis=0, on=None, closed=None,
                  **kwargs):
 
         if freq is not None:
@@ -379,10 +379,12 @@ class Window(_Window):
     on : string, optional
         For a DataFrame, column on which to calculate
         the rolling window, rather than the index
-    closed : 'right', 'left', 'both', 'neither'
-        For offset-based windows, make the interval closed on the right, left,
-        or on both endpoints. Can also make the interval open on both endpoints
-        (neither).
+    closed : string, default None
+        Make the interval closed on the 'right', 'left', 'both' or
+        'neither' endpoints.
+        For offset-based windows, it defaults to 'right'.
+        For fixed windows, defaults to 'both'. Remaining cases not implemented
+        for fixed windows.
 
         .. versionadded:: 0.20.0
 

--- a/pandas/core/window.py
+++ b/pandas/core/window.py
@@ -779,7 +779,8 @@ class _Rolling_and_Expanding(_Rolling):
         for b in blocks:
             result = b.notnull().astype(int)
             result = self._constructor(result, window=window, min_periods=0,
-                                       center=self.center).sum()
+                                       center=self.center,
+                                       closed=self.closed).sum()
             results.append(result)
 
         return self._wrap_results(results, blocks, obj)
@@ -801,11 +802,10 @@ class _Rolling_and_Expanding(_Rolling):
         index, indexi = self._get_index()
         closed = self.closed
 
-        def f(arg, window, min_periods):
+        def f(arg, window, min_periods, closed):
             minp = _use_window(min_periods, window)
-            return _window.roll_generic(arg, window, minp, indexi,
-                                        offset, func, args,
-                                        kwargs, closed)
+            return _window.roll_generic(arg, window, minp, indexi, closed,
+                                        offset, func, args, kwargs)
 
         return self._apply(f, func, args=args, kwargs=kwargs,
                            center=False)
@@ -876,7 +876,7 @@ class _Rolling_and_Expanding(_Rolling):
         def f(arg, *args, **kwargs):
             minp = _require_min_periods(1)(self.min_periods, window)
             return _zsqrt(_window.roll_var(arg, window, minp, indexi,
-                                           ddof))
+                                           self.closed, ddof))
 
         return self._apply(f, 'std', check_minp=_require_min_periods(1),
                            ddof=ddof, **kwargs)
@@ -923,7 +923,7 @@ class _Rolling_and_Expanding(_Rolling):
         def f(arg, *args, **kwargs):
             minp = _use_window(self.min_periods, window)
             return _window.roll_quantile(arg, window, minp, indexi,
-                                         quantile)
+                                         self.closed, quantile)
 
         return self._apply(f, 'quantile', quantile=quantile,
                            **kwargs)

--- a/pandas/core/window.py
+++ b/pandas/core/window.py
@@ -1057,7 +1057,8 @@ class Rolling(_Rolling_and_Expanding):
             raise ValueError("window must be an integer")
         elif self.window < 0:
             raise ValueError("window must be non-negative")
-        elif self.closed is not None:
+
+        if not self.is_datetimelike and self.closed is not None:
             raise ValueError("closed only implemented for datetimelike "
                                          "and offset based windows")
 

--- a/pandas/core/window.py
+++ b/pandas/core/window.py
@@ -103,7 +103,8 @@ class _Window(PandasObject, SelectionMixin):
         if self.min_periods is not None and not \
            is_integer(self.min_periods):
             raise ValueError("min_periods must be an integer")
-        if self.closed not in ['right', 'both', 'left', 'neither']:
+        if self.closed is not None and self.closed not in \
+           ['right', 'both', 'left', 'neither']:
             raise ValueError("closed must be 'right', 'left', 'both' or "
                              "'neither'")
 
@@ -1056,6 +1057,9 @@ class Rolling(_Rolling_and_Expanding):
             raise ValueError("window must be an integer")
         elif self.window < 0:
             raise ValueError("window must be non-negative")
+        elif self.closed is not None:
+            raise ValueError("closed only implemented for datetimelike "
+                                         "and offset based windows")
 
     def _validate_monotonic(self):
         """ validate on is monotonic """

--- a/pandas/core/window.py
+++ b/pandas/core/window.py
@@ -800,7 +800,6 @@ class _Rolling_and_Expanding(_Rolling):
         window = self._get_window()
         offset = _offset(window, self.center)
         index, indexi = self._get_index()
-        closed = self.closed
 
         def f(arg, window, min_periods, closed):
             minp = _use_window(min_periods, window)

--- a/pandas/core/window.pyx
+++ b/pandas/core/window.pyx
@@ -165,8 +165,8 @@ cdef class MockFixedWindowIndexer(WindowIndexer):
 
     """
     def __init__(self, ndarray input, int64_t win, int64_t minp,
-                 object index=None, object floor=None,
-                 bint left_closed=False, bint right_closed=True):
+                 bint left_closed, bint right_closed,
+                 object index=None, object floor=None):
 
         assert index is None
         self.is_variable = 0
@@ -203,8 +203,8 @@ cdef class FixedWindowIndexer(WindowIndexer):
 
     """
     def __init__(self, ndarray input, int64_t win, int64_t minp,
-                 object index=None, object floor=None,
-                 bint left_closed=False, bint right_closed=True):
+                 bint left_closed, bint right_closed,
+                 object index=None, object floor=None):
         cdef ndarray start_s, start_e, end_s, end_e
 
         assert index is None
@@ -352,7 +352,11 @@ def get_window_indexer(input, win, minp, index, closed,
         bint left_closed = False
         bint right_closed = False
 
-    assert closed in ['right', 'left', 'both', 'neither']
+    assert closed is None or closed in ['right', 'left', 'both', 'neither']
+
+    # if windows is variable, default is 'right', otherwise default is 'both'
+    if closed is None:
+        closed = 'right' if index is not None else 'both'
 
     if closed in ['right', 'both']:
         right_closed = True

--- a/pandas/core/window.pyx
+++ b/pandas/core/window.pyx
@@ -333,8 +333,7 @@ def get_window_indexer(input, win, minp, index, closed,
         bint l_closed = False
         bint r_closed = False
 
-    if closed not in ['right', 'left', 'both', 'neither']:
-        closed = 'right'
+    assert closed in ['right', 'left', 'both', 'neither']
 
     if closed in ['right', 'both']:
         r_closed = True
@@ -359,7 +358,7 @@ def get_window_indexer(input, win, minp, index, closed,
 
 
 def roll_count(ndarray[double_t] input, int64_t win, int64_t minp,
-               object index, closed='right'):
+               object index, object closed):
     cdef:
         double val, count_x = 0.0
         int64_t s, e, nobs, N
@@ -440,7 +439,7 @@ cdef inline void remove_sum(double val, int64_t *nobs, double *sum_x) nogil:
 
 
 def roll_sum(ndarray[double_t] input, int64_t win, int64_t minp,
-             object index, str closed):
+             object index, object closed):
     cdef:
         double val, prev_x, sum_x = 0
         int64_t s, e
@@ -556,7 +555,7 @@ cdef inline void remove_mean(double val, Py_ssize_t *nobs, double *sum_x,
 
 
 def roll_mean(ndarray[double_t] input, int64_t win, int64_t minp,
-              object index, str closed):
+              object index, object closed):
     cdef:
         double val, prev_x, result, sum_x = 0
         int64_t s, e
@@ -681,7 +680,7 @@ cdef inline void remove_var(double val, double *nobs, double *mean_x,
 
 
 def roll_var(ndarray[double_t] input, int64_t win, int64_t minp,
-             object index, str closed, int ddof=1):
+             object index, object closed, int ddof=1):
     """
     Numerically stable implementation using Welford's method.
     """
@@ -824,7 +823,7 @@ cdef inline void remove_skew(double val, int64_t *nobs, double *x, double *xx,
 
 
 def roll_skew(ndarray[double_t] input, int64_t win, int64_t minp,
-              object index, str closed):
+              object index, object closed):
     cdef:
         double val, prev
         double x = 0, xx = 0, xxx = 0
@@ -952,7 +951,7 @@ cdef inline void remove_kurt(double val, int64_t *nobs, double *x, double *xx,
 
 
 def roll_kurt(ndarray[double_t] input, int64_t win, int64_t minp,
-              object index, str closed):
+              object index, object closed):
     cdef:
         double val, prev
         double x = 0, xx = 0, xxx = 0, xxxx = 0
@@ -1022,7 +1021,7 @@ def roll_kurt(ndarray[double_t] input, int64_t win, int64_t minp,
 
 
 def roll_median_c(ndarray[float64_t] input, int64_t win, int64_t minp,
-                  object index, str closed):
+                  object index, object closed):
     cdef:
         double val, res, prev
         bint err=0, is_variable
@@ -1148,7 +1147,7 @@ cdef inline numeric calc_mm(int64_t minp, Py_ssize_t nobs,
 
 
 def roll_max(ndarray[numeric] input, int64_t win, int64_t minp,
-             object index, str closed):
+             object index, object closed):
     """
     Moving max of 1d array of any numeric type along axis=0 ignoring NaNs.
 
@@ -1168,7 +1167,7 @@ def roll_max(ndarray[numeric] input, int64_t win, int64_t minp,
 
 
 def roll_min(ndarray[numeric] input, int64_t win, int64_t minp,
-             object index, str closed):
+             object index, object closed):
     """
     Moving max of 1d array of any numeric type along axis=0 ignoring NaNs.
 
@@ -1185,7 +1184,7 @@ def roll_min(ndarray[numeric] input, int64_t win, int64_t minp,
 
 
 cdef _roll_min_max(ndarray[numeric] input, int64_t win, int64_t minp,
-                   object index, str closed, bint is_max):
+                   object index, object closed, bint is_max):
     """
     Moving min/max of 1d array of any numeric type along axis=0
     ignoring NaNs.
@@ -1312,7 +1311,7 @@ cdef _roll_min_max(ndarray[numeric] input, int64_t win, int64_t minp,
 
 
 def roll_quantile(ndarray[float64_t, cast=True] input, int64_t win,
-                  int64_t minp, object index, str closed,
+                  int64_t minp, object index, object closed,
                   double quantile):
     """
     O(N log(window)) implementation using skip list
@@ -1376,7 +1375,7 @@ def roll_quantile(ndarray[float64_t, cast=True] input, int64_t win,
 
 
 def roll_generic(ndarray[float64_t, cast=True] input,
-                 int64_t win, int64_t minp, object index, str closed,
+                 int64_t win, int64_t minp, object index, object closed,
                  int offset, object func,
                  object args, object kwargs):
     cdef:

--- a/pandas/core/window.pyx
+++ b/pandas/core/window.pyx
@@ -248,7 +248,7 @@ cdef class VariableWindowIndexer(WindowIndexer):
 
     """
     def __init__(self, ndarray input, int64_t win, int64_t minp,
-                 ndarray index, bint left_closed, bint right_closed):
+                 bint left_closed, bint right_closed, ndarray index):
 
         self.is_variable = 1
         self.N = len(index)
@@ -330,9 +330,10 @@ def get_window_indexer(input, win, minp, index, closed,
     minp: integer, minimum periods
     index: 1d ndarray, optional
         index to the input array
-    closed: string, default 'right'
+    closed: string, default None
         {'right', 'left', 'both', 'neither'}
-        window endpoint closedness
+        window endpoint closedness. Defaults to 'right' in
+        VariableWindowIndexer and to 'both' in FixedWindowIndexer
     floor: optional
         unit for flooring the unit
     use_mock: boolean, default True
@@ -365,14 +366,14 @@ def get_window_indexer(input, win, minp, index, closed,
         left_closed = True
 
     if index is not None:
-        indexer = VariableWindowIndexer(input, win, minp, index, left_closed,
-                                        right_closed)
+        indexer = VariableWindowIndexer(input, win, minp, left_closed,
+                                        right_closed, index)
     elif use_mock:
-        indexer = MockFixedWindowIndexer(input, win, minp, index, floor,
-                                         left_closed, right_closed)
+        indexer = MockFixedWindowIndexer(input, win, minp, left_closed,
+                                         right_closed, index, floor)
     else:
-        indexer = FixedWindowIndexer(input, win, minp, index, floor, left_closed,
-                                     right_closed)
+        indexer = FixedWindowIndexer(input, win, minp, left_closed,
+                                     right_closed, index, floor)
     return indexer.get_data()
 
 # ----------------------------------------------------------------------

--- a/pandas/tests/test_window.py
+++ b/pandas/tests/test_window.py
@@ -3405,6 +3405,10 @@ class TestRollingTS(tm.TestCase):
         result = df.rolling('2s', closed='right').sum()
         tm.assert_frame_equal(result, expected)
 
+        # default should be 'right'
+        result = df.rolling('2s').sum()
+        tm.assert_frame_equal(result, expected)
+
         expected = df.copy()
         expected["A"] = [1.0, 2, 3, 3, 2]
         result = df.rolling('2s', closed='both').sum()

--- a/pandas/tests/test_window.py
+++ b/pandas/tests/test_window.py
@@ -3396,6 +3396,10 @@ class TestRollingTS(tm.TestCase):
                               pd.Timestamp('20130101 09:00:04'),
                               pd.Timestamp('20130101 09:00:06')])
 
+        # closed only allowed for datetimelike
+        with self.assertRaises(ValueError):
+             self.regular.rolling(window=3, closed='both')
+
         # closed must be 'right', 'left', 'both', 'neither'
         with self.assertRaises(ValueError):
             self.regular.rolling(window='2s', closed="blabla")

--- a/pandas/tests/test_window.py
+++ b/pandas/tests/test_window.py
@@ -3386,12 +3386,12 @@ class TestRollingTS(tm.TestCase):
         tm.assert_frame_equal(result, expected)
 
     def test_closed(self):
-        df = DataFrame({'A': [1]*5},
-                        index = [pd.Timestamp('20130101 09:00:01'),
-                                 pd.Timestamp('20130101 09:00:02'),
-                                 pd.Timestamp('20130101 09:00:03'),
-                                 pd.Timestamp('20130101 09:00:04'),
-                                 pd.Timestamp('20130101 09:00:06')])
+        df = DataFrame({'A': [1] * 5},
+                       index=[pd.Timestamp('20130101 09:00:01'),
+                              pd.Timestamp('20130101 09:00:02'),
+                              pd.Timestamp('20130101 09:00:03'),
+                              pd.Timestamp('20130101 09:00:04'),
+                              pd.Timestamp('20130101 09:00:06')])
 
         # closed must be 'right', 'left', 'both', 'neither'
         with self.assertRaises(ValueError):

--- a/pandas/tests/test_window.py
+++ b/pandas/tests/test_window.py
@@ -435,7 +435,7 @@ class TestRolling(Base):
         df = DataFrame({'A': [0, 1, 2, 3, 4]})
         # closed only allowed for datetimelike
         with self.assertRaises(ValueError):
-             df.rolling(window=3, closed='both')
+            df.rolling(window=3, closed='both')
 
 
 class TestExpanding(Base):

--- a/pandas/tests/test_window.py
+++ b/pandas/tests/test_window.py
@@ -3386,6 +3386,9 @@ class TestRollingTS(tm.TestCase):
         tm.assert_frame_equal(result, expected)
 
     def test_closed(self):
+
+        # xref GH13965
+
         df = DataFrame({'A': [1] * 5},
                        index=[pd.Timestamp('20130101 09:00:01'),
                               pd.Timestamp('20130101 09:00:02'),

--- a/pandas/tests/test_window.py
+++ b/pandas/tests/test_window.py
@@ -3410,7 +3410,7 @@ class TestRollingTS(tm.TestCase):
 
         expected = df.copy()
         expected["A"] = [np.nan, 1.0, 1, 1, np.nan]
-        result = df.rolling('2s', closed='left').sum()
+        result = df.rolling('2s', closed='neither').sum()
         tm.assert_frame_equal(result, expected)
 
     def test_ragged_sum(self):

--- a/pandas/tests/test_window.py
+++ b/pandas/tests/test_window.py
@@ -431,6 +431,12 @@ class TestRolling(Base):
             tm.assertRaisesRegexp(UnsupportedFunctionCall, msg,
                                   getattr(r, func), dtype=np.float64)
 
+    def test_closed(self):
+        df = DataFrame({'A': [0, 1, 2, 3, 4]})
+        # closed only allowed for datetimelike
+        with self.assertRaises(ValueError):
+             df.rolling(window=3, closed='both')
+
 
 class TestExpanding(Base):
 
@@ -3395,10 +3401,6 @@ class TestRollingTS(tm.TestCase):
                               pd.Timestamp('20130101 09:00:03'),
                               pd.Timestamp('20130101 09:00:04'),
                               pd.Timestamp('20130101 09:00:06')])
-
-        # closed only allowed for datetimelike
-        with self.assertRaises(ValueError):
-             self.regular.rolling(window=3, closed='both')
 
         # closed must be 'right', 'left', 'both', 'neither'
         with self.assertRaises(ValueError):

--- a/pandas/tests/test_window.py
+++ b/pandas/tests/test_window.py
@@ -435,7 +435,7 @@ class TestRolling(Base):
         df = DataFrame({'A': [0, 1, 2, 3, 4]})
         # closed only allowed for datetimelike
         with self.assertRaises(ValueError):
-            df.rolling(window=3, closed='both')
+            df.rolling(window=3, closed='neither')
 
 
 class TestExpanding(Base):

--- a/pandas/tests/test_window.py
+++ b/pandas/tests/test_window.py
@@ -3385,6 +3385,34 @@ class TestRollingTS(tm.TestCase):
         result = df.rolling('2s', min_periods=1).sum()
         tm.assert_frame_equal(result, expected)
 
+    def test_closed(self):
+        df = DataFrame({'A': [1]*5},
+                        index = [pd.Timestamp('20130101 09:00:01'),
+                                 pd.Timestamp('20130101 09:00:02'),
+                                 pd.Timestamp('20130101 09:00:03'),
+                                 pd.Timestamp('20130101 09:00:04'),
+                                 pd.Timestamp('20130101 09:00:06')])
+
+        expected = df.copy()
+        expected["A"] = [1.0, 2, 2, 2, 1]
+        result = df.rolling('2s', closed='right').sum()
+        tm.assert_frame_equal(result, expected)
+
+        expected = df.copy()
+        expected["A"] = [1.0, 2, 3, 3, 2]
+        result = df.rolling('2s', closed='both').sum()
+        tm.assert_frame_equal(result, expected)
+
+        expected = df.copy()
+        expected["A"] = [np.nan, 1.0, 2, 2, 1]
+        result = df.rolling('2s', closed='left').sum()
+        tm.assert_frame_equal(result, expected)
+
+        expected = df.copy()
+        expected["A"] = [np.nan, 1.0, 1, 1, np.nan]
+        result = df.rolling('2s', closed='left').sum()
+        tm.assert_frame_equal(result, expected)
+
     def test_ragged_sum(self):
 
         df = self.ragged

--- a/pandas/tests/test_window.py
+++ b/pandas/tests/test_window.py
@@ -3393,6 +3393,10 @@ class TestRollingTS(tm.TestCase):
                                  pd.Timestamp('20130101 09:00:04'),
                                  pd.Timestamp('20130101 09:00:06')])
 
+        # closed must be 'right', 'left', 'both', 'neither'
+        with self.assertRaises(ValueError):
+            self.regular.rolling(window='2s', closed="blabla")
+
         expected = df.copy()
         expected["A"] = [1.0, 2, 2, 2, 1]
         result = df.rolling('2s', closed='right').sum()


### PR DESCRIPTION
 - [x] closes #13965 
 - [x] time-based window tests added / passed
 - [x] fixed window tests added / passed
 - [x] passes ``git diff upstream/master --name-only -- '*.py' | flake8 --diff``
 - [x] whatsnew entry
