### PR TITLE
MAINT: Enforce string type for where parameter

### DIFF
--- a/doc/source/whatsnew/v0.20.0.txt
+++ b/doc/source/whatsnew/v0.20.0.txt
@@ -812,6 +812,7 @@ Removal of prior version deprecations/changes
 - The ``Categorical`` constructor has dropped the ``name`` parameter (:issue:`10632`)
 - The ``take_last`` parameter has been dropped from ``duplicated()``, ``drop_duplicates()``, ``nlargest()``, and ``nsmallest()`` methods (:issue:`10236`, :issue:`10792`, :issue:`10920`)
 - ``Series``, ``Index``, and ``DataFrame`` have dropped the ``sort`` and ``order`` methods (:issue:`10726`)
+- Where clauses in ``pytables`` are only accepted as strings and expressions types and not other data-types (:issue:`12027`)
 - The ``LongPanel`` and ``WidePanel`` classes have been removed (:issue:`10892`)
 
 .. _whatsnew_0200.performance:

--- a/pandas/tests/io/test_pytables.py
+++ b/pandas/tests/io/test_pytables.py
@@ -2585,59 +2585,6 @@ class TestHDFStore(Base, tm.TestCase):
             expected = wp.loc[:, :, ['A', 'B']]
             assert_panel_equal(result, expected)
 
-    def test_backwards_compat_without_term_object(self):
-        with ensure_clean_store(self.path) as store:
-
-            wp = Panel(np.random.randn(2, 5, 4), items=['Item1', 'Item2'],
-                       major_axis=date_range('1/1/2000', periods=5),
-                       minor_axis=['A', 'B', 'C', 'D'])
-            store.append('wp', wp)
-            with catch_warnings(record=True):
-                result = store.select('wp', [('major_axis>20000102'),
-                                             ('minor_axis', '=', ['A', 'B'])])
-            expected = wp.loc[:,
-                              wp.major_axis > Timestamp('20000102'),
-                              ['A', 'B']]
-            assert_panel_equal(result, expected)
-
-            store.remove('wp', ('major_axis>20000103'))
-            result = store.select('wp')
-            expected = wp.loc[:, wp.major_axis <= Timestamp('20000103'), :]
-            assert_panel_equal(result, expected)
-
-        with ensure_clean_store(self.path) as store:
-
-            wp = Panel(np.random.randn(2, 5, 4), items=['Item1', 'Item2'],
-                       major_axis=date_range('1/1/2000', periods=5),
-                       minor_axis=['A', 'B', 'C', 'D'])
-            store.append('wp', wp)
-
-            # stringified datetimes
-            with catch_warnings(record=True):
-                result = store.select('wp',
-                                      [('major_axis',
-                                        '>',
-                                        datetime.datetime(2000, 1, 2))])
-            expected = wp.loc[:, wp.major_axis > Timestamp('20000102')]
-            assert_panel_equal(result, expected)
-            with catch_warnings(record=True):
-                result = store.select('wp',
-                                      [('major_axis',
-                                        '>',
-                                        datetime.datetime(2000, 1, 2, 0, 0))])
-            expected = wp.loc[:, wp.major_axis > Timestamp('20000102')]
-            assert_panel_equal(result, expected)
-            with catch_warnings(record=True):
-                result = store.select('wp',
-                                      [('major_axis',
-                                        '=',
-                                        [datetime.datetime(2000, 1, 2, 0, 0),
-                                         datetime.datetime(2000, 1, 3, 0, 0)])]
-                                      )
-            expected = wp.loc[:, [Timestamp('20000102'),
-                                  Timestamp('20000103')]]
-            assert_panel_equal(result, expected)
-
     def test_same_name_scoping(self):
 
         with ensure_clean_store(self.path) as store:


### PR DESCRIPTION
Deprecated in 0.11.0.

xref #12027.
