### PR TITLE
DOC: Explain differences further for sep parameter

### DIFF
--- a/doc/source/io.rst
+++ b/doc/source/io.rst
@@ -91,11 +91,12 @@ filepath_or_buffer : various
   locations), or any object with a ``read()`` method (such as an open file or
   :class:`~python:io.StringIO`).
 sep : str, defaults to ``','`` for :func:`read_csv`, ``\t`` for :func:`read_table`
-  Delimiter to use. If sep is ``None``,
-  will try to automatically determine this. Separators longer than 1 character
-  and different from ``'\s+'`` will be interpreted as regular expressions, will
-  force use of the python parsing engine and will ignore quotes in the data.
-  Regex example: ``'\\r\\t'``.
+  Delimiter to use. If sep is ``None``, the C engine cannot automatically detect
+  the separator, but the Python parsing engine can, meaning the latter will be
+  used automatically. In addition, separators longer than 1 character and
+  different from ``'\s+'`` will be interpreted as regular expressions and
+  will also force the use of the Python parsing engine. Note that regex
+  delimiters are prone to ignoring quoted data. Regex example: ``'\\r\\t'``.
 delimiter : str, default ``None``
   Alternative argument name for sep.
 delim_whitespace : boolean, default False

--- a/pandas/io/parsers.py
+++ b/pandas/io/parsers.py
@@ -305,10 +305,12 @@ _engine_doc = """engine : {'c', 'python'}, optional
     currently more feature-complete."""
 
 _sep_doc = r"""sep : str, default {default}
-    Delimiter to use. If sep is None, will try to automatically determine
-    this. Separators longer than 1 character and different from ``'\s+'`` will
-    be interpreted as regular expressions, will force use of the python parsing
-    engine and will ignore quotes in the data. Regex example: ``'\r\t'``"""
+    Delimiter to use. If sep is None, the C engine cannot automatically detect
+    the separator, but the Python parsing engine can, meaning the latter will
+    be used automatically. In addition, separators longer than 1 character and
+    different from ``'\s+'`` will be interpreted as regular expressions and
+    will also force the use of the Python parsing engine. Note that regex
+    delimiters are prone to ignoring quoted data. Regex example: ``'\r\t'``"""
 
 _read_csv_doc = """
 Read CSV (comma-separated) file into DataFrame


### PR DESCRIPTION
Per comment in <a href="https://github.com/pandas-dev/pandas/issues/12686#issuecomment-288843261">#12686</a>.  This is the only documentation issue that I found amongst the differences that still exist between the C and Python engines in `parsers.py`
