### PR TITLE
ENH: Citing source in README file

### DIFF
--- a/doc/cheatsheet/README.txt
+++ b/doc/cheatsheet/README.txt
@@ -3,3 +3,8 @@ To create the PDF version, within Powerpoint, simply do a "Save As"
 and pick "PDF' as the format.
 
 The original PDF source is located at: https://www.rstudio.com/wp-content/uploads/2015/02/data-wrangling-cheatsheet.pdf
+
+This cheat sheet was inspired by RstudioData Wrangling Cheatsheet[1], written by Irv Lustig, Princeton Consultants[2].
+
+[1]: https://www.rstudio.com/wp-content/uploads/2015/02/data-wrangling-cheatsheet.pdf
+[2]: http://www.princetonoptimization.com/

--- a/doc/cheatsheet/README.txt
+++ b/doc/cheatsheet/README.txt
@@ -2,8 +2,6 @@ The Pandas Cheat Sheet was created using Microsoft Powerpoint 2013.
 To create the PDF version, within Powerpoint, simply do a "Save As"
 and pick "PDF' as the format.
 
-The original PDF source is located at: https://www.rstudio.com/wp-content/uploads/2015/02/data-wrangling-cheatsheet.pdf
-
 This cheat sheet was inspired by RstudioData Wrangling Cheatsheet[1], written by Irv Lustig, Princeton Consultants[2].
 
 [1]: https://www.rstudio.com/wp-content/uploads/2015/02/data-wrangling-cheatsheet.pdf

--- a/doc/cheatsheet/README.txt
+++ b/doc/cheatsheet/README.txt
@@ -2,7 +2,7 @@ The Pandas Cheat Sheet was created using Microsoft Powerpoint 2013.
 To create the PDF version, within Powerpoint, simply do a "Save As"
 and pick "PDF' as the format.
 
-This cheat sheet was inspired by RstudioData Wrangling Cheatsheet[1], written by Irv Lustig, Princeton Consultants[2].
+This cheat sheet was inspired by the RstudioData Wrangling Cheatsheet[1], written by Irv Lustig, Princeton Consultants[2].
 
 [1]: https://www.rstudio.com/wp-content/uploads/2015/02/data-wrangling-cheatsheet.pdf
 [2]: http://www.princetonoptimization.com/

--- a/doc/cheatsheet/README.txt
+++ b/doc/cheatsheet/README.txt
@@ -2,3 +2,4 @@ The Pandas Cheat Sheet was created using Microsoft Powerpoint 2013.
 To create the PDF version, within Powerpoint, simply do a "Save As"
 and pick "PDF' as the format.
 
+The original PDF source is located at: https://www.rstudio.com/wp-content/uploads/2015/02/data-wrangling-cheatsheet.pdf


### PR DESCRIPTION
For GH users who strictly or heavily use the web-view instead of a local Git, having a direct link is handy, as it does not require downloading the PDF _if_ the user wanted to go to the source of it directly. It's an alternative that allows those interested in more uploads similar to this PDF from the same author(s).

 - [ ] closes: N/A
 - [ ] tests added / passed: N/A
 - [ ] whatsnew: Added source of PDF to README file for the cheatsheet
