### PR TITLE
BUG: Check integrity of sparse int indices

### DIFF
--- a/doc/source/whatsnew/v0.20.0.txt
+++ b/doc/source/whatsnew/v0.20.0.txt
@@ -944,6 +944,7 @@ Indexing
 ^^^^^^^^
 
 - Bug in ``Index`` power operations with reversed operands (:issue:`14973`)
+- Bug in sparse array indexing in which indices were not being validated (:issue:`15863`)
 - Bug in ``DataFrame.sort_values()`` when sorting by multiple columns where one column is of type ``int64`` and contains ``NaT`` (:issue:`14922`)
 - Bug in ``DataFrame.reindex()`` in which ``method`` was ignored when passing ``columns`` (:issue:`14992`)
 - Bug in ``DataFrame.loc`` with indexing a ``MultiIndex`` with a ``Series`` indexer (:issue:`14730`, :issue:`15424`)

--- a/pandas/tests/sparse/test_libsparse.py
+++ b/pandas/tests/sparse/test_libsparse.py
@@ -474,6 +474,44 @@ class TestBlockIndex(tm.TestCase):
 
 class TestIntIndex(tm.TestCase):
 
+    def test_check_integrity(self):
+
+        # Too many indices than specified in self.length
+        msg = "Too many indices"
+
+        with tm.assertRaisesRegexp(ValueError, msg):
+            IntIndex(length=1, indices=[1, 2, 3])
+
+        # No index can be negative.
+        msg = "No index can be less than zero"
+
+        with tm.assertRaisesRegexp(ValueError, msg):
+            IntIndex(length=5, indices=[1, -2, 3])
+
+        # No index can be negative.
+        msg = "No index can be less than zero"
+
+        with tm.assertRaisesRegexp(ValueError, msg):
+            IntIndex(length=5, indices=[1, -2, 3])
+
+        # All indices must be less than the length.
+        msg = "All indices must be less than the length"
+
+        with tm.assertRaisesRegexp(ValueError, msg):
+            IntIndex(length=5, indices=[1, 2, 5])
+
+        with tm.assertRaisesRegexp(ValueError, msg):
+            IntIndex(length=5, indices=[1, 2, 6])
+
+        # Indices must be strictly ascending.
+        msg = "Indices must be strictly increasing"
+
+        with tm.assertRaisesRegexp(ValueError, msg):
+            IntIndex(length=5, indices=[1, 3, 2])
+
+        with tm.assertRaisesRegexp(ValueError, msg):
+            IntIndex(length=5, indices=[1, 3, 3])
+
     def test_int_internal(self):
         idx = _make_index(4, np.array([2, 3], dtype=np.int32), kind='integer')
         self.assertIsInstance(idx, IntIndex)


### PR DESCRIPTION
The `check_integrity` method of `IntIndex` in `pandas.sparse` was un-implemented despite having documentation.  This PR implements the method and calls it when initializing `IntIndex`.

xref <a href="https://github.com/pandas-dev/pandas/pull/15844#discussion_r108840154">#15844 (comment)</a>