### PR TITLE
Revert "CI: add jdcal to 3.6 build as openpyxl >= 2.4.5 is broken"

### DIFF
--- a/ci/requirements-3.6.run
+++ b/ci/requirements-3.6.run
@@ -2,10 +2,7 @@ python-dateutil
 pytz
 numpy
 scipy
-# openpyxl >= 2.4.5 should be dependent on jdcal
-# but is not for some reason
 openpyxl
-jdcal
 xlsxwriter
 xlrd
 xlwt


### PR DESCRIPTION
This reverts commit d1e1ba08ef259724ba71e0953c52e8e4ad81bd17.

closes #15861
