### PR TITLE
DEPR: correct locations to access public tslib objects

### DIFF
--- a/pandas/__init__.py
+++ b/pandas/__init__.py
@@ -64,7 +64,11 @@ json = _DeprecatedModule(deprmod='pandas.json', deprmodto='pandas.io.json.libjso
 parser = _DeprecatedModule(deprmod='pandas.parser', deprmodto='pandas.io.libparsers')
 lib = _DeprecatedModule(deprmod='pandas.lib', deprmodto='pandas._libs.lib',
                         moved={'infer_dtype': 'pandas.api.lib.infer_dtype'})
-tslib = _DeprecatedModule(deprmod='pandas.tslib', deprmodto='pandas._libs.tslib')
+tslib = _DeprecatedModule(deprmod='pandas.tslib', deprmodto='pandas._libs.tslib',
+                          moved={'Timestamp': 'pandas.Timestamp',
+                                 'Timedelta': 'pandas.Timedelta',
+                                 'NaT': 'pandas.NaT',
+                                 'OutOfBoundsDatetime': 'pandas.errors.OutOfBoundsDatetime'})
 
 # use the closest tagged version if possible
 from ._version import get_versions


### PR DESCRIPTION
You got currently:

```
In [4]: pd.tslib.Timestamp
/home/joris/miniconda3/envs/dev/bin/ipython:1: FutureWarning: pandas.tslib.Timestamp is deprecated. 
Please use pandas._libs.tslib.Timestamp instead.
  #!/home/joris/miniconda3/envs/dev/bin/python
Out[4]: pandas._libs.tslib.Timestamp
```

and 

```
In [2]: tslib.OutOfBoundsDatetime
/home/joris/miniconda3/envs/dev/bin/ipython:1: FutureWarning: pandas.tslib.OutOfBoundsDatetime is deprecated. 
Please use pandas._libs.tslib.OutOfBoundsDatetime instead.
  #!/home/joris/miniconda3/envs/dev/bin/python
Out[2]: pandas._libs.tslib.OutOfBoundsDatetime
```

