### PR TITLE
DEPR: correct locations to access public json/parser objects in depr message

### DIFF
--- a/pandas/__init__.py
+++ b/pandas/__init__.py
@@ -60,7 +60,9 @@ from pandas.util._tester import test
 # extension module deprecations
 from pandas.util.depr_module import _DeprecatedModule
 
-json = _DeprecatedModule(deprmod='pandas.json', deprmodto='pandas.io.json.libjson')
+json = _DeprecatedModule(deprmod='pandas.json', deprmodto='pandas.io.json.libjson',
+                         moved={'dumps': 'pandas.io.json.dumps',
+                                'loads': 'pandas.io.json.loads'})
 parser = _DeprecatedModule(deprmod='pandas.parser', deprmodto='pandas.io.libparsers')
 lib = _DeprecatedModule(deprmod='pandas.lib', deprmodto='pandas._libs.lib',
                         moved={'infer_dtype': 'pandas.api.lib.infer_dtype'})

--- a/pandas/__init__.py
+++ b/pandas/__init__.py
@@ -60,13 +60,15 @@ from pandas.util._tester import test
 # extension module deprecations
 from pandas.util.depr_module import _DeprecatedModule
 
-json = _DeprecatedModule(deprmod='pandas.json', deprmodto='pandas.io.json.libjson',
+json = _DeprecatedModule(deprmod='pandas.json',
                          moved={'dumps': 'pandas.io.json.dumps',
                                 'loads': 'pandas.io.json.loads'})
-parser = _DeprecatedModule(deprmod='pandas.parser', deprmodto='pandas.io.libparsers')
+parser = _DeprecatedModule(deprmod='pandas.parser',
+                           removals=['na_values'],
+                           moved={'CParserError': 'pandas.errors.ParserError'})
 lib = _DeprecatedModule(deprmod='pandas.lib', deprmodto='pandas._libs.lib',
                         moved={'infer_dtype': 'pandas.api.lib.infer_dtype'})
-tslib = _DeprecatedModule(deprmod='pandas.tslib', deprmodto='pandas._libs.tslib',
+tslib = _DeprecatedModule(deprmod='pandas.tslib',
                           moved={'Timestamp': 'pandas.Timestamp',
                                  'Timedelta': 'pandas.Timedelta',
                                  'NaT': 'pandas.NaT',

--- a/pandas/tslib.py
+++ b/pandas/tslib.py
@@ -2,7 +2,6 @@
 
 import warnings
 warnings.warn("The pandas.tslib module is deprecated and will be "
-              "removed in a future version. Please import from "
-              "the pandas or pandas.errors instead", FutureWarning, stacklevel=2)
+              "removed in a future version.", FutureWarning, stacklevel=2)
 from pandas._libs.tslib import (Timestamp, Timedelta,
                                NaT, OutOfBoundsDatetime)

--- a/pandas/util/depr_module.py
+++ b/pandas/util/depr_module.py
@@ -68,7 +68,7 @@ class _DeprecatedModule(object):
         elif self.moved is not None and name in self.moved:
             warnings.warn(
                 "{deprmod} is deprecated and will be removed in "
-                "a future version.\nYou can access {name} in {moved}".format(
+                "a future version.\nYou can access {name} as {moved}".format(
                     deprmod=self.deprmod,
                     name=name,
                     moved=self.moved[name]),


### PR DESCRIPTION

Another one remaining is `pd.parser.na_values`

```
In [2]: pd.parser.na_values
/home/joris/miniconda3/envs/dev/bin/ipython:1: FutureWarning: pandas.parser.na_values is deprecated. 
Please use pandas.io.libparsers.na_values instead.
  #!/home/joris/miniconda3/envs/dev/bin/python
Out[2]: 
{numpy.bool_: 255,
 dtype('bool'): 255,
 numpy.uint64: 18446744073709551615,
 numpy.int64: -9223372036854775808,
 dtype('int16'): -32768,
 dtype('uint64'): 18446744073709551615,
 numpy.int8: -128,
 dtype('int32'): -2147483648,
 numpy.uint8: 255,
 dtype('int8'): -128,
 numpy.object_: nan,
 numpy.float64: nan,
 numpy.uint32: 4294967295,
 dtype('O'): nan,
 numpy.int32: -2147483648,
 dtype('uint32'): 4294967295,
 dtype('uint16'): 65535,
 dtype('uint8'): 255,
 dtype('int64'): -9223372036854775808,
 dtype('float64'): nan,
 numpy.uint16: 65535,
 numpy.int16: -32768}
```

I don't think we should refer to `libparsers`, but for now it is not imported in `pandas.io.parsers` as alternative. I could add it there, but the question is maybe whether this is actually useful for users? Maybe we should say that it will be removed without giving alternative?