### PR TITLE
BUG: use entire size of DatetimeTZBlock when coercing result (#15855)

### DIFF
--- a/doc/source/whatsnew/v0.20.0.txt
+++ b/doc/source/whatsnew/v0.20.0.txt
@@ -999,6 +999,7 @@ Conversion
 - Bug in ``DataFrame.fillna()`` where the argument ``downcast`` was ignored when fillna value was of type ``dict`` (:issue:`15277`)
 - Bug in ``.asfreq()``, where frequency was not set for empty ``Series`` (:issue:`14320`)
 - Bug in ``DataFrame`` construction with nulls and datetimes in a list-like (:issue:`15869`)
+- Bug in ``DataFrame.fillna()`` with tz-aware datetimes (:issue:`15855`)
 
 Indexing
 ^^^^^^^^

--- a/pandas/core/internals.py
+++ b/pandas/core/internals.py
@@ -2475,7 +2475,7 @@ class DatetimeTZBlock(NonConsolidatableMixIn, DatetimeBlock):
         if isinstance(result, np.ndarray):
             # allow passing of > 1dim if its trivial
             if result.ndim > 1:
-                result = result.reshape(len(result))
+                result = result.reshape(np.prod(result.shape))
             result = self.values._shallow_copy(result)
 
         return result

--- a/pandas/tests/frame/test_missing.py
+++ b/pandas/tests/frame/test_missing.py
@@ -263,13 +263,13 @@ class TestDataFrameMissingData(tm.TestCase, TestData):
                                  pd.NaT]})
         exp = pd.DataFrame({'A': [pd.Timestamp('2012-11-11 00:00:00+01:00'),
                                   pd.Timestamp('2012-11-11 00:00:00+01:00')]})
-        self.assert_frame_equal(df.fillna(method='pad'), exp)
+        assert_frame_equal(df.fillna(method='pad'), exp)
 
         df = pd.DataFrame({'A': [pd.NaT,
                                  pd.Timestamp('2012-11-11 00:00:00+01:00')]})
         exp = pd.DataFrame({'A': [pd.Timestamp('2012-11-11 00:00:00+01:00'),
                                   pd.Timestamp('2012-11-11 00:00:00+01:00')]})
-        self.assert_frame_equal(df.fillna(method='bfill'), exp)
+        assert_frame_equal(df.fillna(method='bfill'), exp)
 
     def test_fillna_downcast(self):
         # GH 15277

--- a/pandas/tests/frame/test_missing.py
+++ b/pandas/tests/frame/test_missing.py
@@ -257,6 +257,20 @@ class TestDataFrameMissingData(tm.TestCase, TestData):
         result = df.fillna(value={'Date': df['Date2']})
         assert_frame_equal(result, expected)
 
+        # with timezone
+        # GH 15855
+        df = pd.DataFrame({'A': [pd.Timestamp('2012-11-11 00:00:00+01:00'),
+                                 pd.NaT]})
+        exp = pd.DataFrame({'A': [pd.Timestamp('2012-11-11 00:00:00+01:00'),
+                                  pd.Timestamp('2012-11-11 00:00:00+01:00')]})
+        self.assert_frame_equal(df.fillna(method='pad'), exp)
+
+        df = pd.DataFrame({'A': [pd.NaT,
+                                 pd.Timestamp('2012-11-11 00:00:00+01:00')]})
+        exp = pd.DataFrame({'A': [pd.Timestamp('2012-11-11 00:00:00+01:00'),
+                                  pd.Timestamp('2012-11-11 00:00:00+01:00')]})
+        self.assert_frame_equal(df.fillna(method='bfill'), exp)
+
     def test_fillna_downcast(self):
         # GH 15277
         # infer int64 from float64

--- a/pandas/tests/indexes/datetimes/test_missing.py
+++ b/pandas/tests/indexes/datetimes/test_missing.py
@@ -48,3 +48,11 @@ class TestDatetimeIndex(tm.TestCase):
                             pd.Timestamp('2011-01-01 11:00', tz=tz)],
                            dtype=object)
             self.assert_index_equal(idx.fillna('x'), exp)
+
+    def test_fillna_timezone(self):
+        # GH 15855
+        df = pd.DataFrame({'A': [pd.Timestamp('2012-11-11 00:00:00+01:00'),
+                                 pd.NaT]})
+        exp = pd.DataFrame({'A': [pd.Timestamp('2012-11-11 00:00:00+01:00'),
+                                  pd.Timestamp('2012-11-11 00:00:00+01:00')]})
+        self.assert_frame_equal(df.fillna(method='pad'), exp)

--- a/pandas/tests/indexes/datetimes/test_missing.py
+++ b/pandas/tests/indexes/datetimes/test_missing.py
@@ -48,11 +48,3 @@ class TestDatetimeIndex(tm.TestCase):
                             pd.Timestamp('2011-01-01 11:00', tz=tz)],
                            dtype=object)
             self.assert_index_equal(idx.fillna('x'), exp)
-
-    def test_fillna_timezone(self):
-        # GH 15855
-        df = pd.DataFrame({'A': [pd.Timestamp('2012-11-11 00:00:00+01:00'),
-                                 pd.NaT]})
-        exp = pd.DataFrame({'A': [pd.Timestamp('2012-11-11 00:00:00+01:00'),
-                                  pd.Timestamp('2012-11-11 00:00:00+01:00')]})
-        self.assert_frame_equal(df.fillna(method='pad'), exp)

--- a/pandas/tests/series/test_missing.py
+++ b/pandas/tests/series/test_missing.py
@@ -258,6 +258,18 @@ class TestSeriesMissingData(TestData, tm.TestCase):
             self.assert_series_equal(expected, result)
             self.assert_series_equal(pd.isnull(s), null_loc)
 
+        # with timezone
+        # GH 15855
+        df = pd.Series([pd.Timestamp('2012-11-11 00:00:00+01:00'), pd.NaT])
+        exp = pd.Series([pd.Timestamp('2012-11-11 00:00:00+01:00'),
+                         pd.Timestamp('2012-11-11 00:00:00+01:00')])
+        self.assert_series_equal(df.fillna(method='pad'), exp)
+
+        df = pd.Series([pd.NaT, pd.Timestamp('2012-11-11 00:00:00+01:00')])
+        exp = pd.Series([pd.Timestamp('2012-11-11 00:00:00+01:00'),
+                         pd.Timestamp('2012-11-11 00:00:00+01:00')])
+        self.assert_series_equal(df.fillna(method='bfill'), exp)
+
     def test_datetime64tz_fillna_round_issue(self):
         # GH 14872
 

--- a/pandas/tests/series/test_missing.py
+++ b/pandas/tests/series/test_missing.py
@@ -263,12 +263,12 @@ class TestSeriesMissingData(TestData, tm.TestCase):
         df = pd.Series([pd.Timestamp('2012-11-11 00:00:00+01:00'), pd.NaT])
         exp = pd.Series([pd.Timestamp('2012-11-11 00:00:00+01:00'),
                          pd.Timestamp('2012-11-11 00:00:00+01:00')])
-        self.assert_series_equal(df.fillna(method='pad'), exp)
+        assert_series_equal(df.fillna(method='pad'), exp)
 
         df = pd.Series([pd.NaT, pd.Timestamp('2012-11-11 00:00:00+01:00')])
         exp = pd.Series([pd.Timestamp('2012-11-11 00:00:00+01:00'),
                          pd.Timestamp('2012-11-11 00:00:00+01:00')])
-        self.assert_series_equal(df.fillna(method='bfill'), exp)
+        assert_series_equal(df.fillna(method='bfill'), exp)
 
     def test_datetime64tz_fillna_round_issue(self):
         # GH 14872


### PR DESCRIPTION
 - [x] closes #15855 
 - [x] tests added / passed
 - [x] passes ``git diff upstream/master --name-only -- '*.py' | flake8 --diff``
 - [x] whatsnew entry
