### PR TITLE
DEPR: deprecate relableling dicts in groupby.agg

### DIFF
--- a/doc/source/computation.rst
+++ b/doc/source/computation.rst
@@ -610,14 +610,6 @@ aggregation with, outputting a DataFrame:
 
    r['A'].agg([np.sum, np.mean, np.std])
 
-If a dict is passed, the keys will be used to name the columns. Otherwise the
-function's name (stored in the function object) will be used.
-
-.. ipython:: python
-
-   r['A'].agg({'result1' : np.sum,
-               'result2' : np.mean})
-
 On a widowed DataFrame, you can pass a list of functions to apply to each
 column, which produces an aggregated result with a hierarchical index:
 

--- a/doc/source/groupby.rst
+++ b/doc/source/groupby.rst
@@ -502,7 +502,7 @@ index are the group names and whose values are the sizes of each group.
 Applying multiple functions at once
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-With grouped Series you can also pass a list or dict of functions to do
+With grouped ``Series`` you can also pass a list or dict of functions to do
 aggregation with, outputting a DataFrame:
 
 .. ipython:: python
@@ -510,23 +510,35 @@ aggregation with, outputting a DataFrame:
    grouped = df.groupby('A')
    grouped['C'].agg([np.sum, np.mean, np.std])
 
-If a dict is passed, the keys will be used to name the columns. Otherwise the
-function's name (stored in the function object) will be used.
-
-.. ipython:: python
-
-   grouped['D'].agg({'result1' : np.sum,
-                     'result2' : np.mean})
-
-On a grouped DataFrame, you can pass a list of functions to apply to each
+On a grouped ``DataFrame``, you can pass a list of functions to apply to each
 column, which produces an aggregated result with a hierarchical index:
 
 .. ipython:: python
 
    grouped.agg([np.sum, np.mean, np.std])
 
-Passing a dict of functions has different behavior by default, see the next
-section.
+
+The resulting aggregations are named for the functions themselves. If you
+need to rename, then you can add in a chained operation for a ``Series`` like this:
+
+.. ipython:: python
+
+   (grouped['C'].agg([np.sum, np.mean, np.std])
+                .rename(columns={'sum': 'foo',
+                                 'mean': 'bar',
+                                 'std': 'baz'})
+   )
+
+For a grouped ``DataFrame``, you can rename in a similar manner:
+
+.. ipython:: python
+
+   (grouped.agg([np.sum, np.mean, np.std])
+           .rename(columns={'sum': 'foo',
+                            'mean': 'bar',
+                            'std': 'baz'})
+    )
+
 
 Applying different functions to DataFrame columns
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/source/timeseries.rst
+++ b/doc/source/timeseries.rst
@@ -1549,14 +1549,6 @@ You can pass a list or dict of functions to do aggregation with, outputting a Da
 
    r['A'].agg([np.sum, np.mean, np.std])
 
-If a dict is passed, the keys will be used to name the columns. Otherwise the
-function's name (stored in the function object) will be used.
-
-.. ipython:: python
-
-   r['A'].agg({'result1' : np.sum,
-               'result2' : np.mean})
-
 On a resampled DataFrame, you can pass a list of functions to apply to each
 column, which produces an aggregated result with a hierarchical index:
 

--- a/doc/source/whatsnew/v0.20.0.txt
+++ b/doc/source/whatsnew/v0.20.0.txt
@@ -429,7 +429,6 @@ Using ``.iloc``. Here we will get the location of the 'A' column, then use *posi
   df.iloc[[0, 2], df.columns.get_loc('A')]
 
 
-<<<<<<< c25fbde09272f369f280212e5216441d5975687c
 .. _whatsnew_0200.api_breaking.deprecate_panel:
 
 Deprecate Panel
@@ -462,23 +461,30 @@ Convert to an xarray DataArray
 Deprecate groupby.agg() with a dictionary when renaming
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The ``.groupby(..).agg(..)`` syntax can accept a variable of inputs, including scalars, list, and a dictionary of column names to scalars or lists.
-This provides a useful syntax for constructing multiple (potentially different) aggregations for a groupby.
+The ``.groupby(..).agg(..)``, ``.rolling(..).agg(..)``, and ``.resample(..).agg(..)``  syntax can accept a variable of inputs, including scalars,
+list, and a dict of column names to scalars or lists. This provides a useful syntax for constructing multiple
+(potentially different) aggregations.
 
-1) We are deprecating passing a dictionary to a grouped ``Series``. This allowed one to ``rename`` the resulting aggregation, but this had a completely different
-meaning that passing a dictionary to a grouped ``DataFrame``, which accepts column-to-aggregations.
-2) We are deprecating passing a dict-of-dict to a grouped ``DataFrame`` in a similar manner.
+However, ``.agg(..)`` can *also* accept a dict that allows 'renaming' of the result columns. This is a complicated and confusing syntax, as well as not consistent
+between ``Series`` and ``DataFrame``. We are deprecating this 'renaming' functionarility.
 
-Here's an example of 1), passing a dict to a grouped ``Series``:
+1) We are deprecating passing a dict to a grouped/rolled/resampled ``Series``. This allowed
+one to ``rename`` the resulting aggregation, but this had a completely different
+meaning than passing a dictionary to a grouped ``DataFrame``, which accepts column-to-aggregations.
+2) We are deprecating passing a dict-of-dict to a grouped/rolled/resampled ``DataFrame`` in a similar manner.
+
+This is an illustrative example:
 
 .. ipython:: python
 
     df = pd.DataFrame({'A': [1, 1, 1, 2, 2],
                        'B': range(5),
-                       'C':range(5)})
+                       'C': range(5)})
     df
 
-Aggregating a DataFrame with column selection.
+Here is a typical useful syntax for computing different aggregations for different columns. This
+is a natural (and useful) syntax. We aggregate from the dict-to-list by taking the specified
+columns and applying the list of functions. This returns a ``MultiIndex`` for the columns.
 
 .. ipython:: python
 
@@ -486,9 +492,10 @@ Aggregating a DataFrame with column selection.
                         'C': ['count', 'min']})
 
 
-We are deprecating the following
+Here's an example of the first deprecation (1), passing a dict to a grouped ``Series``. This
+is a combination aggregation & renaming:
 
-.. code-block:: ipython. Which is a combination aggregation & renaming.
+.. code-block:: ipython
 
    In [6]: df.groupby('A').B.agg({'foo': 'count'})
    FutureWarning: using a dictionary on a Series for aggregation
@@ -507,7 +514,7 @@ You can accomplish the same operation, more idiomatically by:
    df.groupby('A').B.agg(['count']).rename({'count': 'foo'})
 
 
-Here's an example of 2), passing a dict-of-dict to a grouped ``DataFrame``:
+Here's an example of the second deprecation (2), passing a dict-of-dict to a grouped ``DataFrame``:
 
 .. code-block:: python
 

--- a/doc/source/whatsnew/v0.20.0.txt
+++ b/doc/source/whatsnew/v0.20.0.txt
@@ -466,12 +466,12 @@ list, and a dict of column names to scalars or lists. This provides a useful syn
 (potentially different) aggregations.
 
 However, ``.agg(..)`` can *also* accept a dict that allows 'renaming' of the result columns. This is a complicated and confusing syntax, as well as not consistent
-between ``Series`` and ``DataFrame``. We are deprecating this 'renaming' functionarility.
+between ``Series`` and ``DataFrame``. We are deprecating this 'renaming' functionaility.
 
 1) We are deprecating passing a dict to a grouped/rolled/resampled ``Series``. This allowed
 one to ``rename`` the resulting aggregation, but this had a completely different
 meaning than passing a dictionary to a grouped ``DataFrame``, which accepts column-to-aggregations.
-2) We are deprecating passing a dict-of-dict to a grouped/rolled/resampled ``DataFrame`` in a similar manner.
+2) We are deprecating passing a dict-of-dicts to a grouped/rolled/resampled ``DataFrame`` in a similar manner.
 
 This is an illustrative example:
 
@@ -488,9 +488,7 @@ columns and applying the list of functions. This returns a ``MultiIndex`` for th
 
 .. ipython:: python
 
-   df.groupby('A').agg({'B': ['sum', 'max'],
-                        'C': ['count', 'min']})
-
+   df.groupby('A').agg({'B': 'sum', 'C': 'min'})
 
 Here's an example of the first deprecation (1), passing a dict to a grouped ``Series``. This
 is a combination aggregation & renaming:
@@ -498,7 +496,7 @@ is a combination aggregation & renaming:
 .. code-block:: ipython
 
    In [6]: df.groupby('A').B.agg({'foo': 'count'})
-   FutureWarning: using a dictionary on a Series for aggregation
+   FutureWarning: using a dict on a Series for aggregation
    is deprecated and will be removed in a future version
 
    Out[6]:
@@ -518,24 +516,27 @@ Here's an example of the second deprecation (2), passing a dict-of-dict to a gro
 
 .. code-block:: python
 
-   In [23]: df.groupby('A').agg({'B': {'foo': ['sum', 'max']}, 'C': {'bar': ['count', 'min']}})
-   FutureWarning: using a dictionary on a Series for aggregation
-   is deprecated and will be removed in a future version
+   In [23]: (df.groupby('A')
+               .agg({'B': {'foo': 'sum'}, 'C': {'bar': 'min'}})
+            )
+   FutureWarning: using a dict with renaming is deprecated and will be removed in a future version
 
    Out[23]:
-     foo       bar
-     sum max count min
+        B   C
+      foo bar
    A
-   1   3   2     3   0
-   2   7   4     2   3
+   1   3   0
+   2   7   3
 
-You can accomplish the same by:
+
+You can accomplish nearly the same by:
 
 .. ipython:: python
 
-   r = df.groupby('A').agg({'B': ['sum', 'max'], 'C': ['count', 'min']})
-   r.columns = r.columns.set_levels(['foo', 'bar'], level=0)
-   r
+   (df.groupby('A')
+      .agg({'B': 'sum', 'C': 'min'})
+      .rename(columns={'B': 'foo', 'C': 'bar'})
+   )
 
 .. _whatsnew.api_breaking.io_compat:
 

--- a/doc/source/whatsnew/v0.20.0.txt
+++ b/doc/source/whatsnew/v0.20.0.txt
@@ -429,6 +429,7 @@ Using ``.iloc``. Here we will get the location of the 'A' column, then use *posi
   df.iloc[[0, 2], df.columns.get_loc('A')]
 
 
+<<<<<<< c25fbde09272f369f280212e5216441d5975687c
 .. _whatsnew_0200.api_breaking.deprecate_panel:
 
 Deprecate Panel
@@ -455,6 +456,79 @@ Convert to an xarray DataArray
 .. ipython:: python
 
    p.to_xarray()
+
+.. _whatsnew_0200.api_breaking.deprecate_group_agg_dict:
+
+Deprecate groupby.agg() with a dictionary when renaming
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The ``.groupby(..).agg(..)`` syntax can accept a variable of inputs, including scalars, list, and a dictionary of column names to scalars or lists.
+This provides a useful syntax for constructing multiple (potentially different) aggregations for a groupby.
+
+1) We are deprecating passing a dictionary to a grouped ``Series``. This allowed one to ``rename`` the resulting aggregation, but this had a completely different
+meaning that passing a dictionary to a grouped ``DataFrame``, which accepts column-to-aggregations.
+2) We are deprecating passing a dict-of-dict to a grouped ``DataFrame`` in a similar manner.
+
+Here's an example of 1), passing a dict to a grouped ``Series``:
+
+.. ipython:: python
+
+    df = pd.DataFrame({'A': [1, 1, 1, 2, 2],
+                       'B': range(5),
+                       'C':range(5)})
+    df
+
+Aggregating a DataFrame with column selection.
+
+.. ipython:: python
+
+   df.groupby('A').agg({'B': ['sum', 'max'],
+                        'C': ['count', 'min']})
+
+
+We are deprecating the following
+
+.. code-block:: ipython. Which is a combination aggregation & renaming.
+
+   In [6]: df.groupby('A').B.agg({'foo': 'count'})
+   FutureWarning: using a dictionary on a Series for aggregation
+   is deprecated and will be removed in a future version
+
+   Out[6]:
+      foo
+   A
+   1    3
+   2    2
+
+You can accomplish the same operation, more idiomatically by:
+
+.. ipython:: python
+
+   df.groupby('A').B.agg(['count']).rename({'count': 'foo'})
+
+
+Here's an example of 2), passing a dict-of-dict to a grouped ``DataFrame``:
+
+.. code-block:: python
+
+   In [23]: df.groupby('A').agg({'B': {'foo': ['sum', 'max']}, 'C': {'bar': ['count', 'min']}})
+   FutureWarning: using a dictionary on a Series for aggregation
+   is deprecated and will be removed in a future version
+
+   Out[23]:
+     foo       bar
+     sum max count min
+   A
+   1   3   2     3   0
+   2   7   4     2   3
+
+You can accomplish the same by:
+
+.. ipython:: python
+
+   r = df.groupby('A').agg({'B': ['sum', 'max'], 'C': ['count', 'min']})
+   r.columns = r.columns.set_levels(['foo', 'bar'], level=0)
+   r
 
 .. _whatsnew.api_breaking.io_compat:
 

--- a/pandas/core/base.py
+++ b/pandas/core/base.py
@@ -292,8 +292,11 @@ class SelectionMixin(object):
 
     @property
     def _selection_name(self):
-        """ return a name for myself; this would ideally be the 'name' property, but
-        we cannot conflict with the Series.name property which can be set """
+        """
+        return a name for myself; this would ideally be called
+        the 'name' property, but we cannot conflict with the
+        Series.name property which can be set
+        """
         if self._selection is None:
             return None  # 'result'
         else:
@@ -502,7 +505,7 @@ pandas.DataFrame.%(name)s
                             ("using a dict with renaming "
                              "is deprecated and will be removed in a future "
                              "version"),
-                            FutureWarning, stacklevel=3)
+                            FutureWarning, stacklevel=4)
 
                 arg = new_arg
 
@@ -516,7 +519,7 @@ pandas.DataFrame.%(name)s
                         ("using a dict with renaming "
                          "is deprecated and will be removed in a future "
                          "version"),
-                        FutureWarning, stacklevel=3)
+                        FutureWarning, stacklevel=4)
 
             from pandas.tools.concat import concat
 

--- a/pandas/core/base.py
+++ b/pandas/core/base.py
@@ -497,6 +497,7 @@ pandas.DataFrame.%(name)s
                                                      'dictionary'.format(k))
 
                         # deprecation of nested renaming
+                        # GH 15931
                         warnings.warn(
                             ("using a dict with renaming "
                              "is deprecated and will be removed in a future "
@@ -506,7 +507,8 @@ pandas.DataFrame.%(name)s
                 arg = new_arg
 
             else:
-                # we may have renaming keys
+                # deprecation of renaming keys
+                # GH 15931
                 keys = list(compat.iterkeys(arg))
                 if (isinstance(obj, ABCDataFrame) and
                         len(obj.columns.intersection(keys)) != len(keys)):

--- a/pandas/core/base.py
+++ b/pandas/core/base.py
@@ -447,7 +447,6 @@ pandas.DataFrame.%(name)s
         how can be a string describe the required post-processing, or
         None if not required
         """
-
         is_aggregator = lambda x: isinstance(x, (list, tuple, dict))
         is_nested_renamer = False
 
@@ -482,7 +481,7 @@ pandas.DataFrame.%(name)s
                     # the keys must be in the columns
                     # for ndim=2, or renamers for ndim=1
 
-                    # ok
+                    # ok for now, but deprecated
                     # {'A': { 'ra': 'mean' }}
                     # {'A': { 'ra': ['mean'] }}
                     # {'ra': ['mean']}
@@ -497,7 +496,25 @@ pandas.DataFrame.%(name)s
                                                      'for {0} with a nested '
                                                      'dictionary'.format(k))
 
+                        # deprecation of nested renaming
+                        warnings.warn(
+                            ("using a dict with renaming "
+                             "is deprecated and will be removed in a future "
+                             "version"),
+                            FutureWarning, stacklevel=3)
+
                 arg = new_arg
+
+            else:
+                # we may have renaming keys
+                keys = list(compat.iterkeys(arg))
+                if (isinstance(obj, ABCDataFrame) and
+                        len(obj.columns.intersection(keys)) != len(keys)):
+                    warnings.warn(
+                        ("using a dict with renaming "
+                         "is deprecated and will be removed in a future "
+                         "version"),
+                        FutureWarning, stacklevel=3)
 
             from pandas.tools.concat import concat
 
@@ -532,16 +549,6 @@ pandas.DataFrame.%(name)s
             # set the final keys
             keys = list(compat.iterkeys(arg))
             result = compat.OrderedDict()
-
-            # renaming keys
-            if isinstance(self._selected_obj, ABCDataFrame):
-                if len(self._selected_obj.columns.intersection(
-                        keys)) != len(keys):
-                    warnings.warn(
-                        ("using a dict with renaming"
-                         "is deprecated and will be removed in a future "
-                         "version"),
-                        FutureWarning, stacklevel=3)
 
             # nested renamer
             if is_nested_renamer:

--- a/pandas/core/base.py
+++ b/pandas/core/base.py
@@ -1,6 +1,7 @@
 """
 Base and utility classes for pandas objects.
 """
+import warnings
 from pandas import compat
 from pandas.compat import builtins
 import numpy as np
@@ -290,7 +291,9 @@ class SelectionMixin(object):
     }
 
     @property
-    def name(self):
+    def _selection_name(self):
+        """ return a name for myself; this would ideally be the 'name' property, but
+        we cannot conflict with the Series.name property which can be set """
         if self._selection is None:
             return None  # 'result'
         else:
@@ -405,6 +408,26 @@ pandas.DataFrame.%(name)s
 
     agg = aggregate
 
+    def _try_aggregate_string_function(self, arg, *args, **kwargs):
+        """
+        if arg is a string, then try to operate on it:
+        - try to find a function on ourselves
+        - try to find a numpy function
+        - raise
+
+        """
+        assert isinstance(arg, compat.string_types)
+
+        f = getattr(self, arg, None)
+        if f is not None:
+            return f(*args, **kwargs)
+
+        f = getattr(np, arg, None)
+        if f is not None:
+            return f(self, *args, **kwargs)
+
+        raise ValueError("{} is an unknown string function".format(arg))
+
     def _aggregate(self, arg, *args, **kwargs):
         """
         provide an implementation for the aggregators
@@ -428,14 +451,19 @@ pandas.DataFrame.%(name)s
         is_aggregator = lambda x: isinstance(x, (list, tuple, dict))
         is_nested_renamer = False
 
+        _axis = kwargs.pop('_axis', None)
+        if _axis is None:
+            _axis = getattr(self, 'axis', 0)
         _level = kwargs.pop('_level', None)
+
         if isinstance(arg, compat.string_types):
-            return getattr(self, arg)(*args, **kwargs), None
+            return self._try_aggregate_string_function(arg, *args,
+                                                       **kwargs), None
 
         if isinstance(arg, dict):
 
             # aggregate based on the passed dict
-            if self.axis != 0:  # pragma: no cover
+            if _axis != 0:  # pragma: no cover
                 raise ValueError('Can only pass dict with axis=0')
 
             obj = self._selected_obj
@@ -505,6 +533,16 @@ pandas.DataFrame.%(name)s
             keys = list(compat.iterkeys(arg))
             result = compat.OrderedDict()
 
+            # renaming keys
+            if isinstance(self._selected_obj, ABCDataFrame):
+                if len(self._selected_obj.columns.intersection(
+                        keys)) != len(keys):
+                    warnings.warn(
+                        ("using a dict with renaming"
+                         "is deprecated and will be removed in a future "
+                         "version"),
+                        FutureWarning, stacklevel=3)
+
             # nested renamer
             if is_nested_renamer:
                 result = list(_agg(arg, _agg_1dim).values())
@@ -534,7 +572,7 @@ pandas.DataFrame.%(name)s
                                   agg_how: _agg_1dim(self._selection, agg_how))
 
                 # we are selecting the same set as we are aggregating
-                elif not len(sl - set(compat.iterkeys(arg))):
+                elif not len(sl - set(keys)):
 
                     result = _agg(arg, _agg_1dim)
 
@@ -555,32 +593,74 @@ pandas.DataFrame.%(name)s
                     result = _agg(arg, _agg_2dim)
 
             # combine results
+
+            def is_any_series():
+                # return a boolean if we have *any* nested series
+                return any([isinstance(r, ABCSeries)
+                            for r in compat.itervalues(result)])
+
+            def is_any_frame():
+                # return a boolean if we have *any* nested series
+                return any([isinstance(r, ABCDataFrame)
+                            for r in compat.itervalues(result)])
+
             if isinstance(result, list):
-                result = concat(result, keys=keys, axis=1)
-            elif isinstance(list(compat.itervalues(result))[0],
-                            ABCDataFrame):
-                result = concat([result[k] for k in keys], keys=keys, axis=1)
-            else:
-                from pandas import DataFrame
+                return concat(result, keys=keys, axis=1), True
+
+            elif is_any_frame():
+                # we have a dict of DataFrames
+                # return a MI DataFrame
+
+                return concat([result[k] for k in keys],
+                              keys=keys, axis=1), True
+
+            elif isinstance(self, ABCSeries) and is_any_series():
+
+                # we have a dict of Series
+                # return a MI Series
+                try:
+                    result = concat(result)
+                except TypeError:
+                    # we want to give a nice error here if
+                    # we have non-same sized objects, so
+                    # we don't automatically broadcast
+
+                    raise ValueError("cannot perform both aggregation "
+                                     "and transformation operations "
+                                     "simultaneously")
+
+                return result, True
+
+            # fall thru
+            from pandas import DataFrame, Series
+            try:
                 result = DataFrame(result)
+            except ValueError:
+
+                # we have a dict of scalars
+                result = Series(result,
+                                name=getattr(self, 'name', None))
 
             return result, True
-        elif hasattr(arg, '__iter__'):
-            return self._aggregate_multiple_funcs(arg, _level=_level), None
+        elif is_list_like(arg) and arg not in compat.string_types:
+            # we require a list, but not an 'str'
+            return self._aggregate_multiple_funcs(arg,
+                                                  _level=_level,
+                                                  _axis=_axis), None
         else:
             result = None
 
-        cy_func = self._is_cython_func(arg)
-        if cy_func and not args and not kwargs:
-            return getattr(self, cy_func)(), None
+        f = self._is_cython_func(arg)
+        if f and not args and not kwargs:
+            return getattr(self, f)(), None
 
         # caller can react
         return result, True
 
-    def _aggregate_multiple_funcs(self, arg, _level):
+    def _aggregate_multiple_funcs(self, arg, _level, _axis):
         from pandas.tools.concat import concat
 
-        if self.axis != 0:
+        if _axis != 0:
             raise NotImplementedError("axis other than 0 is not supported")
 
         if self._selected_obj.ndim == 1:
@@ -615,10 +695,30 @@ pandas.DataFrame.%(name)s
                     keys.append(col)
                 except (TypeError, DataError):
                     pass
+                except ValueError:
+                    # cannot aggregate
+                    continue
                 except SpecificationError:
                     raise
 
-        return concat(results, keys=keys, axis=1)
+        # if we are empty
+        if not len(results):
+            raise ValueError("no results")
+
+        try:
+            return concat(results, keys=keys, axis=1)
+        except TypeError:
+
+            # we are concatting non-NDFrame objects,
+            # e.g. a list of scalars
+
+            from pandas.types.cast import is_nested_object
+            from pandas import Series
+            result = Series(results, index=keys, name=self.name)
+            if is_nested_object(result):
+                raise ValueError("cannot combine transform and "
+                                 "aggregation operations")
+            return result
 
     def _shallow_copy(self, obj=None, obj_type=None, **kwargs):
         """ return a new object with the replacement attributes """

--- a/pandas/core/groupby.py
+++ b/pandas/core/groupby.py
@@ -2835,9 +2835,11 @@ class SeriesGroupBy(GroupBy):
     def _aggregate_multiple_funcs(self, arg, _level):
         if isinstance(arg, dict):
 
-            if isinstance(self._selected_obj, Series):
+            # show the deprecation, but only if we
+            # have not shown a higher level one
+            if isinstance(self._selected_obj, Series) and _level <= 1:
                 warnings.warn(
-                    ("using a dictionary on a Series for aggregation\n"
+                    ("using a dict on a Series for aggregation\n"
                      "is deprecated and will be removed in a future "
                      "version"),
                     FutureWarning, stacklevel=7)

--- a/pandas/core/groupby.py
+++ b/pandas/core/groupby.py
@@ -2837,6 +2837,7 @@ class SeriesGroupBy(GroupBy):
 
             # show the deprecation, but only if we
             # have not shown a higher level one
+            # GH 15931
             if isinstance(self._selected_obj, Series) and _level <= 1:
                 warnings.warn(
                     ("using a dict on a Series for aggregation\n"

--- a/pandas/core/groupby.py
+++ b/pandas/core/groupby.py
@@ -2843,7 +2843,7 @@ class SeriesGroupBy(GroupBy):
                     ("using a dict on a Series for aggregation\n"
                      "is deprecated and will be removed in a future "
                      "version"),
-                    FutureWarning, stacklevel=7)
+                    FutureWarning, stacklevel=4)
 
             columns = list(arg.keys())
             arg = list(arg.items())

--- a/pandas/tests/groupby/test_aggregate.py
+++ b/pandas/tests/groupby/test_aggregate.py
@@ -14,7 +14,7 @@ from numpy import nan
 import pandas as pd
 
 from pandas import (date_range, MultiIndex, DataFrame,
-                    Series, Index, bdate_range)
+                    Series, Index, bdate_range, concat)
 from pandas.util.testing import assert_frame_equal, assert_series_equal
 from pandas.core.groupby import SpecificationError, DataError
 from pandas.compat import OrderedDict
@@ -291,8 +291,10 @@ class TestGroupByAggregate(tm.TestCase):
         expected.columns = MultiIndex.from_product([['C', 'D'],
                                                     ['mean', 'sum']])
 
-        result = grouped[['D', 'C']].agg({'r': np.sum,
-                                          'r2': np.mean})
+        with tm.assert_produces_warning(FutureWarning,
+                                        check_stacklevel=False):
+            result = grouped[['D', 'C']].agg({'r': np.sum,
+                                              'r2': np.mean})
         expected = pd.concat([d_sum,
                               c_sum,
                               d_mean,
@@ -320,14 +322,19 @@ class TestGroupByAggregate(tm.TestCase):
                              axis=1)
         expected.columns = MultiIndex.from_tuples([('C', 'sum'),
                                                    ('C', 'std')])
-        result = g['D'].agg({'C': ['sum', 'std']})
+        with tm.assert_produces_warning(FutureWarning,
+                                        check_stacklevel=False):
+            result = g['D'].agg({'C': ['sum', 'std']})
         assert_frame_equal(result, expected, check_like=True)
 
         expected = pd.concat([g['D'].sum(),
                               g['D'].std()],
                              axis=1)
         expected.columns = ['C', 'D']
-        result = g['D'].agg({'C': 'sum', 'D': 'std'})
+
+        with tm.assert_produces_warning(FutureWarning,
+                                        check_stacklevel=False):
+            result = g['D'].agg({'C': 'sum', 'D': 'std'})
         assert_frame_equal(result, expected, check_like=True)
 
     def test_agg_nested_dicts(self):
@@ -348,8 +355,10 @@ class TestGroupByAggregate(tm.TestCase):
 
         self.assertRaises(SpecificationError, f)
 
-        result = g.agg({'C': {'ra': ['mean', 'std']},
-                        'D': {'rb': ['mean', 'std']}})
+        with tm.assert_produces_warning(FutureWarning,
+                                        check_stacklevel=False):
+            result = g.agg({'C': {'ra': ['mean', 'std']},
+                            'D': {'rb': ['mean', 'std']}})
         expected = pd.concat([g['C'].mean(), g['C'].std(), g['D'].mean(),
                               g['D'].std()], axis=1)
         expected.columns = pd.MultiIndex.from_tuples([('ra', 'mean'), (
@@ -358,9 +367,14 @@ class TestGroupByAggregate(tm.TestCase):
 
         # same name as the original column
         # GH9052
-        expected = g['D'].agg({'result1': np.sum, 'result2': np.mean})
+        with tm.assert_produces_warning(FutureWarning,
+                                        check_stacklevel=False):
+            expected = g['D'].agg({'result1': np.sum, 'result2': np.mean})
         expected = expected.rename(columns={'result1': 'D'})
-        result = g['D'].agg({'D': np.sum, 'result2': np.mean})
+
+        with tm.assert_produces_warning(FutureWarning,
+                                        check_stacklevel=False):
+            result = g['D'].agg({'D': np.sum, 'result2': np.mean})
         assert_frame_equal(result, expected, check_like=True)
 
     def test_agg_python_multiindex(self):
@@ -627,7 +641,6 @@ class TestGroupByAggregate(tm.TestCase):
         self.assertRaises(SpecificationError, grouped.agg, funcs)
 
     def test_more_flexible_frame_multi_function(self):
-        from pandas import concat
 
         grouped = self.df.groupby('A')
 
@@ -655,9 +668,12 @@ class TestGroupByAggregate(tm.TestCase):
         def bar(x):
             return np.std(x, ddof=1)
 
-        d = OrderedDict([['C', np.mean], ['D', OrderedDict(
-            [['foo', np.mean], ['bar', np.std]])]])
-        result = grouped.aggregate(d)
+        # this uses column selection & renaming
+        with tm.assert_produces_warning(FutureWarning,
+                                        check_stacklevel=False):
+            d = OrderedDict([['C', np.mean], ['D', OrderedDict(
+                [['foo', np.mean], ['bar', np.std]])]])
+            result = grouped.aggregate(d)
 
         d = OrderedDict([['C', [np.mean]], ['D', [foo, bar]]])
         expected = grouped.aggregate(d)
@@ -671,16 +687,29 @@ class TestGroupByAggregate(tm.TestCase):
         d = OrderedDict([['C', OrderedDict([['foo', 'mean'], [
             'bar', 'std'
         ]])], ['D', 'sum']])
-        result = grouped.aggregate(d)
+
+        # this uses column selection & renaming
+        with tm.assert_produces_warning(FutureWarning,
+                                        check_stacklevel=False):
+            result = grouped.aggregate(d)
+
         d2 = OrderedDict([['C', OrderedDict([['foo', 'mean'], [
             'bar', 'std'
         ]])], ['D', ['sum']]])
-        result2 = grouped.aggregate(d2)
+
+        # this uses column selection & renaming
+        with tm.assert_produces_warning(FutureWarning,
+                                        check_stacklevel=False):
+            result2 = grouped.aggregate(d2)
 
         d3 = OrderedDict([['C', OrderedDict([['foo', 'mean'], [
             'bar', 'std'
         ]])], ['D', {'sum': 'sum'}]])
-        expected = grouped.aggregate(d3)
+
+        # this uses column selection & renaming
+        with tm.assert_produces_warning(FutureWarning,
+                                        check_stacklevel=False):
+            expected = grouped.aggregate(d3)
 
         assert_frame_equal(result, expected)
         assert_frame_equal(result2, expected)

--- a/pandas/tests/groupby/test_aggregate.py
+++ b/pandas/tests/groupby/test_aggregate.py
@@ -317,6 +317,10 @@ class TestGroupByAggregate(tm.TestCase):
             assert "using a dict with renaming" in str(w[0].message)
 
         with tm.assert_produces_warning(FutureWarning,
+                                        check_stacklevel=False):
+            df.groupby('A')[['B', 'C']].agg({'ma': 'max'})
+
+        with tm.assert_produces_warning(FutureWarning,
                                         check_stacklevel=False) as w:
             df.groupby('A').B.agg({'foo': 'count'})
             assert "using a dict on a Series for aggregation" in str(

--- a/pandas/tests/groupby/test_aggregate.py
+++ b/pandas/tests/groupby/test_aggregate.py
@@ -304,6 +304,24 @@ class TestGroupByAggregate(tm.TestCase):
                                                     ['D', 'C']])
         assert_frame_equal(result, expected, check_like=True)
 
+    def test_agg_dict_renaming_deprecation(self):
+        # 15931
+        df = pd.DataFrame({'A': [1, 1, 1, 2, 2],
+                           'B': range(5),
+                           'C': range(5)})
+
+        with tm.assert_produces_warning(FutureWarning,
+                                        check_stacklevel=False) as w:
+            df.groupby('A').agg({'B': {'foo': ['sum', 'max']},
+                                 'C': {'bar': ['count', 'min']}})
+            assert "using a dict with renaming" in str(w[0].message)
+
+        with tm.assert_produces_warning(FutureWarning,
+                                        check_stacklevel=False) as w:
+            df.groupby('A').B.agg({'foo': 'count'})
+            assert "using a dict on a Series for aggregation" in str(
+                w[0].message)
+
     def test_agg_compat(self):
 
         # GH 12334

--- a/pandas/tests/groupby/test_groupby.py
+++ b/pandas/tests/groupby/test_groupby.py
@@ -59,7 +59,10 @@ class TestGroupBy(MixIn, tm.TestCase):
 
             # complex agg
             agged = grouped.aggregate([np.mean, np.std])
-            agged = grouped.aggregate({'one': np.mean, 'two': np.std})
+
+            with tm.assert_produces_warning(FutureWarning,
+                                            check_stacklevel=False):
+                agged = grouped.aggregate({'one': np.mean, 'two': np.std})
 
             group_constants = {0: 10, 1: 20, 2: 30}
             agged = grouped.agg(lambda x: group_constants[x.name] + x.mean())
@@ -1262,7 +1265,9 @@ class TestGroupBy(MixIn, tm.TestCase):
         result = grouped['C'].agg([np.mean, np.std])
         self.assertEqual(result.index.name, 'A')
 
-        result = grouped['C'].agg({'foo': np.mean, 'bar': np.std})
+        with tm.assert_produces_warning(FutureWarning,
+                                        check_stacklevel=False):
+            result = grouped['C'].agg({'foo': np.mean, 'bar': np.std})
         self.assertEqual(result.index.name, 'A')
 
     def test_multi_iter(self):
@@ -1438,7 +1443,10 @@ class TestGroupBy(MixIn, tm.TestCase):
         grouped = self.df.groupby('A', as_index=True)
         expected3 = grouped['C'].sum()
         expected3 = DataFrame(expected3).rename(columns={'C': 'Q'})
-        result3 = grouped['C'].agg({'Q': np.sum})
+
+        with tm.assert_produces_warning(FutureWarning,
+                                        check_stacklevel=False):
+            result3 = grouped['C'].agg({'Q': np.sum})
         assert_frame_equal(result3, expected3)
 
         # multi-key

--- a/pandas/tests/groupby/test_whitelist.py
+++ b/pandas/tests/groupby/test_whitelist.py
@@ -233,7 +233,7 @@ def test_tab_completion(mframe):
     expected = set(
         ['A', 'B', 'C', 'agg', 'aggregate', 'apply', 'boxplot', 'filter',
          'first', 'get_group', 'groups', 'hist', 'indices', 'last', 'max',
-         'mean', 'median', 'min', 'name', 'ngroups', 'nth', 'ohlc', 'plot',
+         'mean', 'median', 'min', 'ngroups', 'nth', 'ohlc', 'plot',
          'prod', 'size', 'std', 'sum', 'transform', 'var', 'sem', 'count',
          'nunique', 'head', 'describe', 'cummax', 'quantile',
          'rank', 'cumprod', 'tail', 'resample', 'cummin', 'fillna',

--- a/pandas/tests/test_window.py
+++ b/pandas/tests/test_window.py
@@ -134,16 +134,18 @@ class TestApi(Base):
         expected.columns = ['mean', 'sum']
         tm.assert_frame_equal(result, expected)
 
-        result = r.aggregate({'A': {'mean': 'mean', 'sum': 'sum'}})
+        with catch_warnings(record=True):
+            result = r.aggregate({'A': {'mean': 'mean', 'sum': 'sum'}})
         expected = pd.concat([a_mean, a_sum], axis=1)
         expected.columns = pd.MultiIndex.from_tuples([('A', 'mean'),
                                                       ('A', 'sum')])
         tm.assert_frame_equal(result, expected, check_like=True)
 
-        result = r.aggregate({'A': {'mean': 'mean',
-                                    'sum': 'sum'},
-                              'B': {'mean2': 'mean',
-                                    'sum2': 'sum'}})
+        with catch_warnings(record=True):
+            result = r.aggregate({'A': {'mean': 'mean',
+                                        'sum': 'sum'},
+                                  'B': {'mean2': 'mean',
+                                        'sum2': 'sum'}})
         expected = pd.concat([a_mean, a_sum, b_mean, b_sum], axis=1)
         exp_cols = [('A', 'mean'), ('A', 'sum'), ('B', 'mean2'), ('B', 'sum2')]
         expected.columns = pd.MultiIndex.from_tuples(exp_cols)
@@ -195,12 +197,14 @@ class TestApi(Base):
                               r['B'].std()], axis=1)
         expected.columns = pd.MultiIndex.from_tuples([('ra', 'mean'), (
             'ra', 'std'), ('rb', 'mean'), ('rb', 'std')])
-        result = r[['A', 'B']].agg({'A': {'ra': ['mean', 'std']},
-                                    'B': {'rb': ['mean', 'std']}})
+        with catch_warnings(record=True):
+            result = r[['A', 'B']].agg({'A': {'ra': ['mean', 'std']},
+                                        'B': {'rb': ['mean', 'std']}})
         tm.assert_frame_equal(result, expected, check_like=True)
 
-        result = r.agg({'A': {'ra': ['mean', 'std']},
-                        'B': {'rb': ['mean', 'std']}})
+        with catch_warnings(record=True):
+            result = r.agg({'A': {'ra': ['mean', 'std']},
+                            'B': {'rb': ['mean', 'std']}})
         expected.columns = pd.MultiIndex.from_tuples([('A', 'ra', 'mean'), (
             'A', 'ra', 'std'), ('B', 'rb', 'mean'), ('B', 'rb', 'std')])
         tm.assert_frame_equal(result, expected, check_like=True)

--- a/pandas/tests/tseries/test_resample.py
+++ b/pandas/tests/tseries/test_resample.py
@@ -394,8 +394,10 @@ class TestResampleAPI(tm.TestCase):
 
         r = df.resample('3T')
 
-        expected = r[['A', 'B', 'C']].agg({'r1': 'mean', 'r2': 'sum'})
-        result = r.agg({'r1': 'mean', 'r2': 'sum'})
+        with tm.assert_produces_warning(FutureWarning,
+                                        check_stacklevel=False):
+            expected = r[['A', 'B', 'C']].agg({'r1': 'mean', 'r2': 'sum'})
+            result = r.agg({'r1': 'mean', 'r2': 'sum'})
         assert_frame_equal(result, expected)
 
     # TODO: once GH 14008 is fixed, move these tests into
@@ -459,7 +461,9 @@ class TestResampleAPI(tm.TestCase):
         expected.columns = pd.MultiIndex.from_tuples([('A', 'mean'),
                                                       ('A', 'sum')])
         for t in cases:
-            result = t.aggregate({'A': {'mean': 'mean', 'sum': 'sum'}})
+            with tm.assert_produces_warning(FutureWarning,
+                                            check_stacklevel=False):
+                result = t.aggregate({'A': {'mean': 'mean', 'sum': 'sum'}})
             assert_frame_equal(result, expected, check_like=True)
 
         expected = pd.concat([a_mean, a_sum, b_mean, b_sum], axis=1)
@@ -468,8 +472,10 @@ class TestResampleAPI(tm.TestCase):
                                                       ('B', 'mean2'),
                                                       ('B', 'sum2')])
         for t in cases:
-            result = t.aggregate({'A': {'mean': 'mean', 'sum': 'sum'},
-                                  'B': {'mean2': 'mean', 'sum2': 'sum'}})
+            with tm.assert_produces_warning(FutureWarning,
+                                            check_stacklevel=False):
+                result = t.aggregate({'A': {'mean': 'mean', 'sum': 'sum'},
+                                      'B': {'mean2': 'mean', 'sum2': 'sum'}})
             assert_frame_equal(result, expected, check_like=True)
 
         expected = pd.concat([a_mean, a_std, b_mean, b_std], axis=1)
@@ -529,9 +535,12 @@ class TestResampleAPI(tm.TestCase):
                                                       ('result1', 'B'),
                                                       ('result2', 'A'),
                                                       ('result2', 'B')])
+
         for t in cases:
-            result = t[['A', 'B']].agg(OrderedDict([('result1', np.sum),
-                                                    ('result2', np.mean)]))
+            with tm.assert_produces_warning(FutureWarning,
+                                            check_stacklevel=False):
+                result = t[['A', 'B']].agg(OrderedDict([('result1', np.sum),
+                                                        ('result2', np.mean)]))
             assert_frame_equal(result, expected, check_like=True)
 
         # agg with different hows
@@ -557,7 +566,9 @@ class TestResampleAPI(tm.TestCase):
 
         # series like aggs
         for t in cases:
-            result = t['A'].agg({'A': ['sum', 'std']})
+            with tm.assert_produces_warning(FutureWarning,
+                                            check_stacklevel=False):
+                result = t['A'].agg({'A': ['sum', 'std']})
             expected = pd.concat([t['A'].sum(),
                                   t['A'].std()],
                                  axis=1)
@@ -572,15 +583,20 @@ class TestResampleAPI(tm.TestCase):
                                                           ('A', 'std'),
                                                           ('B', 'mean'),
                                                           ('B', 'std')])
-            result = t['A'].agg({'A': ['sum', 'std'], 'B': ['mean', 'std']})
+            with tm.assert_produces_warning(FutureWarning,
+                                            check_stacklevel=False):
+                result = t['A'].agg({'A': ['sum', 'std'],
+                                     'B': ['mean', 'std']})
             assert_frame_equal(result, expected, check_like=True)
 
         # errors
         # invalid names in the agg specification
         for t in cases:
             def f():
-                t[['A']].agg({'A': ['sum', 'std'],
-                              'B': ['mean', 'std']})
+                with tm.assert_produces_warning(FutureWarning,
+                                                check_stacklevel=False):
+                    t[['A']].agg({'A': ['sum', 'std'],
+                                  'B': ['mean', 'std']})
 
             self.assertRaises(SpecificationError, f)
 
@@ -617,12 +633,16 @@ class TestResampleAPI(tm.TestCase):
             expected.columns = pd.MultiIndex.from_tuples([('ra', 'mean'), (
                 'ra', 'std'), ('rb', 'mean'), ('rb', 'std')])
 
-            result = t[['A', 'B']].agg({'A': {'ra': ['mean', 'std']},
-                                        'B': {'rb': ['mean', 'std']}})
+            with tm.assert_produces_warning(FutureWarning,
+                                            check_stacklevel=False):
+                result = t[['A', 'B']].agg({'A': {'ra': ['mean', 'std']},
+                                            'B': {'rb': ['mean', 'std']}})
             assert_frame_equal(result, expected, check_like=True)
 
-            result = t.agg({'A': {'ra': ['mean', 'std']},
-                            'B': {'rb': ['mean', 'std']}})
+            with tm.assert_produces_warning(FutureWarning,
+                                            check_stacklevel=False):
+                result = t.agg({'A': {'ra': ['mean', 'std']},
+                                'B': {'rb': ['mean', 'std']}})
             assert_frame_equal(result, expected, check_like=True)
 
     def test_selection_api_validation(self):
@@ -752,16 +772,7 @@ class Base(object):
                 expected.index = s.index._shallow_copy(freq=freq)
                 assert_index_equal(result.index, expected.index)
                 self.assertEqual(result.index.freq, expected.index.freq)
-
-                if (method == 'size' and
-                    isinstance(result.index, PeriodIndex) and
-                        freq in ['M', 'D']):
-                    # GH12871 - TODO: name should propagate, but currently
-                    # doesn't on lower / same frequency with PeriodIndex
-                    assert_series_equal(result, expected, check_dtype=False)
-
-                else:
-                    assert_series_equal(result, expected, check_dtype=False)
+                assert_series_equal(result, expected, check_dtype=False)
 
     def test_resample_empty_dataframe(self):
         # GH13212
@@ -1846,10 +1857,12 @@ class TestDatetimeIndex(Base, tm.TestCase):
         tm.assert_series_equal(result['foo'], foo_exp)
         tm.assert_series_equal(result['bar'], bar_exp)
 
+        # this is a MI Series, so comparing the names of the results
+        # doesn't make sense
         result = ts.resample('M').aggregate({'foo': lambda x: x.mean(),
                                              'bar': lambda x: x.std(ddof=1)})
-        tm.assert_series_equal(result['foo'], foo_exp)
-        tm.assert_series_equal(result['bar'], bar_exp)
+        tm.assert_series_equal(result['foo'], foo_exp, check_names=False)
+        tm.assert_series_equal(result['bar'], bar_exp, check_names=False)
 
     def test_resample_unequal_times(self):
         # #1772

--- a/pandas/types/cast.py
+++ b/pandas/types/cast.py
@@ -45,6 +45,23 @@ def maybe_convert_platform(values):
     return values
 
 
+def is_nested_object(obj):
+    """
+    return a boolean if we have a nested object, e.g. a Series with 1 or
+    more Series elements
+
+    This may not be necessarily be performant.
+
+    """
+
+    if isinstance(obj, ABCSeries) and is_object_dtype(obj):
+
+        if any(isinstance(v, ABCSeries) for v in obj.values):
+            return True
+
+    return False
+
+
 def maybe_downcast_to_dtype(result, dtype):
     """ try to cast to the specified dtype (e.g. convert back to bool/int
     or could be an astype of float64->float32


### PR DESCRIPTION
pre-curser to #14668 

This is basically in the whatsnew, but:

```
In [1]:     df = pd.DataFrame({'A': [1, 1, 1, 2, 2],
   ...:                        'B': range(5),
   ...:                        'C':range(5)})
   ...:     df
   ...: 
Out[1]: 
   A  B  C
0  1  0  0
1  1  1  1
2  1  2  2
3  2  3  3
4  2  4  4
```

This is good; multiple aggregations on a dataframe with a dict-of-lists
```
In [2]:    df.groupby('A').agg({'B': ['sum', 'max'],
   ...:                         'C': ['count', 'min']})
   ...: 
Out[2]: 
    B         C    
  sum max count min
A                  
1   3   2     3   0
2   7   4     2   3
```

This is a dict on a grouped Series -> deprecated
```
In [3]: df.groupby('A').B.agg({'foo': 'count'})
FutureWarning: using a dictionary on a Series for aggregation
is deprecated and will be removed in a future version
Out[3]: 
   foo
A     
1    3
2    2
```

Further this has to go as well, a nested dict that does renaming.
Note once we fix https://github.com/pandas-dev/pandas/issues/4160 (renaming with a level); the following becomes almost trivial to rename in-line.
```
In [4]: df.groupby('A').agg({'B': {'foo': ['sum', 'max']}, 
                             'C': {'bar': ['count', 'min']}})
FutureWarning: using a dictionary on a Series for aggregation
is deprecated and will be removed in a future version
Out[4]: 
  foo       bar    
  sum max count min
A                  
1   3   2     3   0
2   7   4     2   3
```
Note: I will fix this message (as it doesn't actually apply here)
