### PR TITLE
DOC: Cleanup for nbsphinx output

### DIFF
--- a/doc/source/style.ipynb
+++ b/doc/source/style.ipynb
@@ -49,6 +49,20 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
+    "collapsed": true,
+    "nbsphinx": "hidden"
+   },
+   "outputs": [],
+   "source": [
+    "import matplotlib\n",
+    "# We have this here to trigger matplotlib's font cache stuff.\n",
+    "# This cell is hidden from the output"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
     "collapsed": true
    },
    "outputs": [],

--- a/doc/source/themes/nature_with_gtoc/static/nature.css_t
+++ b/doc/source/themes/nature_with_gtoc/static/nature.css_t
@@ -330,6 +330,12 @@ tbody tr:nth-child(odd) {
     background: #f5f5f5;
 }
 
+table td.data, table th.row_heading table th.col_heading {
+    font-family: monospace;
+    text-align: right;
+}
+
+
 /**
  * See also
  */


### PR DESCRIPTION
Followup to https://github.com/pandas-dev/pandas/pull/15581

Using the `nbsphinx: hidden` metadata to hide the ouptut, so
readers don't see matplotlib's fc-list warning.

Make the tables monospaced in CSS.