### PR TITLE
DOC: remove Categorical.unique refs from doc-strings

### DIFF
--- a/doc/source/api.rst
+++ b/doc/source/api.rst
@@ -660,14 +660,6 @@ the Categorical back to a numpy array, so categories and order information is no
 
    Categorical.__array__
 
-Categorical methods
-
-.. autosummary::
-   :toctree: generated/
-
-   Categorical.unique
-   Categorical.value_counts
-
 Plotting
 ~~~~~~~~
 

--- a/pandas/core/base.py
+++ b/pandas/core/base.py
@@ -871,8 +871,9 @@ class IndexOpsMixin(object):
 
         See Also
         --------
-        pandas.unique
-        pandas.Categorical.unique
+        unique
+        Index.unique
+        Series.unique
         """)
 
     @Appender(_shared_docs['unique'] % _indexops_doc_kwargs)


### PR DESCRIPTION
closes #15957
