### PR TITLE
BUG: Fix Empty DataFrame.style.render raises IndexError

### DIFF
--- a/pandas/formats/style.py
+++ b/pandas/formats/style.py
@@ -218,8 +218,8 @@ class Styler(object):
 
         cell_context = dict()
 
-        n_rlvls = self.data.index.nlevels
-        n_clvls = self.data.columns.nlevels
+        n_rlvls = 0 if self.data.empty else self.data.index.nlevels
+        n_clvls = 0 if self.data.empty else self.data.columns.nlevels
         rlabels = self.data.index.tolist()
         clabels = self.data.columns.tolist()
 


### PR DESCRIPTION
Fix attempt for Issue #15953

Handles DataFrames and Series with no rows or columns
using `pd.DataFrame().empty` or `pd.Series().empty`

```python
In [1]: import pandas as pd

In [2]: pd.DataFrame().style.render()
Out[2]: '\n        <style  type="text/css" >\n        \n        \n        </style>\n\n        <table id="T_de3b3e8c_1e30_11e7_9abb_a8667f1b25b4" None>\n        \n\n        <thead>\n            \n        </thead>\n        <tbody>\n            \n        </tbody>\n        </table>\n        '
```

 - [ ] closes #15953 
 - [ ] tests added / passed
 - [ ] passes ``git diff upstream/master --name-only -- '*.py' | flake8 --diff``
 - [ ] whatsnew entry
