### PR TITLE
BUG: Don't overflow PeriodIndex in to_csv

### DIFF
--- a/doc/source/whatsnew/v0.20.0.txt
+++ b/doc/source/whatsnew/v0.20.0.txt
@@ -1344,6 +1344,7 @@ I/O
 - Bug in ``pd.read_csv()`` in which invalid values for ``nrows`` and ``chunksize`` were allowed (:issue:`15767`)
 - Bug in ``pd.read_csv()`` for the Python engine in which unhelpful error messages were being raised when parsing errors occurred (:issue:`15910`)
 - Bug in ``pd.read_csv()`` in which the ``skipfooter`` parameter was not being properly validated (:issue:`15925`)
+- Bug in ``pd.to_csv()`` in which there was numeric overflow when a timestamp index was being written (:issue:`15982`)
 - Bug in ``pd.tools.hashing.hash_pandas_object()`` in which hashing of categoricals depended on the ordering of categories, instead of just their values. (:issue:`15143`)
 - Bug in ``.to_json()`` where ``lines=True`` and contents (keys or values) contain escaped characters (:issue:`15096`)
 - Bug in ``.to_json()`` causing single byte ascii characters to be expanded to four byte unicode (:issue:`15344`)

--- a/pandas/formats/format.py
+++ b/pandas/formats/format.py
@@ -1564,10 +1564,7 @@ class CSVFormatter(object):
         self.chunksize = int(chunksize)
 
         self.data_index = obj.index
-        if isinstance(obj.index, PeriodIndex):
-            self.data_index = obj.index.to_timestamp()
-
-        if (isinstance(self.data_index, DatetimeIndex) and
+        if (isinstance(self.data_index, (DatetimeIndex, PeriodIndex)) and
                 date_format is not None):
             self.data_index = Index([x.strftime(date_format) if notnull(x) else
                                      '' for x in self.data_index])

--- a/pandas/indexes/base.py
+++ b/pandas/indexes/base.py
@@ -1820,7 +1820,26 @@ class Index(IndexOpsMixin, StringAccessorMixin, PandasObject):
         return header + result
 
     def to_native_types(self, slicer=None, **kwargs):
-        """ slice and dice then format """
+        """
+        Format specified values of `self` and return them.
+
+        Parameters
+        ----------
+        slicer : int, array-like
+            An indexer into `self` that specifies which values
+            are used in the formatting process.
+        kwargs : dict
+            Options for specifying how the values should be formatted.
+            These options include the following:
+
+            1) na_rep : str
+                The value that serves as a placeholder for NULL values
+            2) quoting : bool or None
+                Whether or not there are quoted values in `self`
+            3) date_format : str
+                The format used to represent date-like values
+        """
+
         values = self
         if slicer is not None:
             values = values[slicer]

--- a/pandas/tests/indexes/datetimes/test_formats.py
+++ b/pandas/tests/indexes/datetimes/test_formats.py
@@ -1,0 +1,47 @@
+from pandas import DatetimeIndex
+
+import numpy as np
+
+import pandas.util.testing as tm
+import pandas as pd
+
+
+def test_to_native_types():
+    index = DatetimeIndex(freq='1D', periods=3, start='2017-01-01')
+
+    # First, with no arguments.
+    expected = np.array(['2017-01-01', '2017-01-02',
+                         '2017-01-03'], dtype=object)
+
+    result = index.to_native_types()
+    tm.assert_numpy_array_equal(result, expected)
+
+    # No NaN values, so na_rep has no effect
+    result = index.to_native_types(na_rep='pandas')
+    tm.assert_numpy_array_equal(result, expected)
+
+    # Make sure slicing works
+    expected = np.array(['2017-01-01', '2017-01-03'], dtype=object)
+
+    result = index.to_native_types([0, 2])
+    tm.assert_numpy_array_equal(result, expected)
+
+    # Make sure date formatting works
+    expected = np.array(['01-2017-01', '01-2017-02',
+                         '01-2017-03'], dtype=object)
+
+    result = index.to_native_types(date_format='%m-%Y-%d')
+    tm.assert_numpy_array_equal(result, expected)
+
+    # NULL object handling should work
+    index = DatetimeIndex(['2017-01-01', pd.NaT, '2017-01-03'])
+    expected = np.array(['2017-01-01', 'NaT', '2017-01-03'], dtype=object)
+
+    result = index.to_native_types()
+    tm.assert_numpy_array_equal(result, expected)
+
+    expected = np.array(['2017-01-01', 'pandas',
+                         '2017-01-03'], dtype=object)
+
+    result = index.to_native_types(na_rep='pandas')
+    tm.assert_numpy_array_equal(result, expected)

--- a/pandas/tests/indexes/period/test_formats.py
+++ b/pandas/tests/indexes/period/test_formats.py
@@ -1,0 +1,48 @@
+from pandas import PeriodIndex
+
+import numpy as np
+
+import pandas.util.testing as tm
+import pandas as pd
+
+
+def test_to_native_types():
+    index = PeriodIndex(['2017-01-01', '2017-01-02',
+                         '2017-01-03'], freq='D')
+
+    # First, with no arguments.
+    expected = np.array(['2017-01-01', '2017-01-02',
+                         '2017-01-03'], dtype='<U10')
+
+    result = index.to_native_types()
+    tm.assert_numpy_array_equal(result, expected)
+
+    # No NaN values, so na_rep has no effect
+    result = index.to_native_types(na_rep='pandas')
+    tm.assert_numpy_array_equal(result, expected)
+
+    # Make sure slicing works
+    expected = np.array(['2017-01-01', '2017-01-03'], dtype='<U10')
+
+    result = index.to_native_types([0, 2])
+    tm.assert_numpy_array_equal(result, expected)
+
+    # Make sure date formatting works
+    expected = np.array(['01-2017-01', '01-2017-02',
+                         '01-2017-03'], dtype='<U10')
+
+    result = index.to_native_types(date_format='%m-%Y-%d')
+    tm.assert_numpy_array_equal(result, expected)
+
+    # NULL object handling should work
+    index = PeriodIndex(['2017-01-01', pd.NaT, '2017-01-03'], freq='D')
+    expected = np.array(['2017-01-01', 'NaT', '2017-01-03'], dtype=object)
+
+    result = index.to_native_types()
+    tm.assert_numpy_array_equal(result, expected)
+
+    expected = np.array(['2017-01-01', 'pandas',
+                         '2017-01-03'], dtype=object)
+
+    result = index.to_native_types(na_rep='pandas')
+    tm.assert_numpy_array_equal(result, expected)


### PR DESCRIPTION
Don't overflow time-stamp objects if being used as index in `to_csv`.

Closes #15982.