### PR TITLE
MAINT: Strip internals from TestCase class

### DIFF
--- a/pandas/tests/core/dtypes/test_dtypes.py
+++ b/pandas/tests/core/dtypes/test_dtypes.py
@@ -40,7 +40,7 @@ class Base(object):
         self.assertNotEqual(np.str_, self.dtype)
 
     def test_pickle(self):
-        result = self.round_trip_pickle(self.dtype)
+        result = tm.round_trip_pickle(self.dtype)
         self.assertEqual(result, self.dtype)
 
 

--- a/pandas/tests/core/sparse/test_array.py
+++ b/pandas/tests/core/sparse/test_array.py
@@ -562,7 +562,7 @@ class TestSparseArray(tm.TestCase):
 
     def test_pickle(self):
         def _check_roundtrip(obj):
-            unpickled = self.round_trip_pickle(obj)
+            unpickled = tm.round_trip_pickle(obj)
             tm.assert_sp_array_equal(unpickled, obj)
 
         _check_roundtrip(self.arr)

--- a/pandas/tests/core/sparse/test_frame.py
+++ b/pandas/tests/core/sparse/test_frame.py
@@ -278,7 +278,7 @@ class TestSparseDataFrame(tm.TestCase, SharedWithSparse):
     def test_pickle(self):
 
         def _test_roundtrip(frame, orig):
-            result = self.round_trip_pickle(frame)
+            result = tm.round_trip_pickle(frame)
             tm.assert_sp_frame_equal(frame, result)
             tm.assert_frame_equal(result.to_dense(), orig, check_dtype=False)
 

--- a/pandas/tests/core/sparse/test_series.py
+++ b/pandas/tests/core/sparse/test_series.py
@@ -390,7 +390,7 @@ class TestSparseSeries(tm.TestCase, SharedWithSparse):
 
     def test_pickle(self):
         def _test_roundtrip(series):
-            unpickled = self.round_trip_pickle(series)
+            unpickled = tm.round_trip_pickle(series)
             tm.assert_sp_series_equal(series, unpickled)
             tm.assert_series_equal(series.to_dense(), unpickled.to_dense())
 

--- a/pandas/tests/frame/test_block_internals.py
+++ b/pandas/tests/frame/test_block_internals.py
@@ -350,18 +350,18 @@ class TestDataFrameBlockInternals(tm.TestCase, TestData):
         self.assertIsNot(copy._data, self.mixed_frame._data)
 
     def test_pickle(self):
-        unpickled = self.round_trip_pickle(self.mixed_frame)
+        unpickled = tm.round_trip_pickle(self.mixed_frame)
         assert_frame_equal(self.mixed_frame, unpickled)
 
         # buglet
         self.mixed_frame._data.ndim
 
         # empty
-        unpickled = self.round_trip_pickle(self.empty)
+        unpickled = tm.round_trip_pickle(self.empty)
         repr(unpickled)
 
         # tz frame
-        unpickled = self.round_trip_pickle(self.tzframe)
+        unpickled = tm.round_trip_pickle(self.tzframe)
         assert_frame_equal(self.tzframe, unpickled)
 
     def test_consolidate_datetime64(self):

--- a/pandas/tests/frame/test_repr_info.py
+++ b/pandas/tests/frame/test_repr_info.py
@@ -118,7 +118,7 @@ class TestDataFrameReprInfoEtc(tm.TestCase, TestData):
         fmt.set_option('display.max_rows', 1000, 'display.max_columns', 1000)
         repr(self.frame)
 
-        self.reset_display_options()
+        tm.reset_display_options()
 
         warnings.filters = warn_filters
 

--- a/pandas/tests/frame/test_subclass.py
+++ b/pandas/tests/frame/test_subclass.py
@@ -85,7 +85,7 @@ class TestDataFrameSubclassing(tm.TestCase, TestData):
         self.assertEqual(df.iloc[0:1, :].testattr, 'XXX')
 
         # GH10553
-        unpickled = self.round_trip_pickle(df)
+        unpickled = tm.round_trip_pickle(df)
         tm.assert_frame_equal(df, unpickled)
         self.assertEqual(df._metadata, unpickled._metadata)
         self.assertEqual(df.testattr, unpickled.testattr)

--- a/pandas/tests/indexes/common.py
+++ b/pandas/tests/indexes/common.py
@@ -28,7 +28,7 @@ class Base(object):
             setattr(self, name, idx)
 
     def verify_pickle(self, index):
-        unpickled = self.round_trip_pickle(index)
+        unpickled = tm.round_trip_pickle(index)
         self.assertTrue(index.equals(unpickled))
 
     def test_pickle_compat_construction(self):

--- a/pandas/tests/indexes/datetimes/test_datetime.py
+++ b/pandas/tests/indexes/datetimes/test_datetime.py
@@ -106,7 +106,7 @@ class TestDatetimeIndex(tm.TestCase):
         # GH 8367
         # round-trip of timezone
         index = date_range('20130101', periods=3, tz='US/Eastern', name='foo')
-        unpickled = self.round_trip_pickle(index)
+        unpickled = tm.round_trip_pickle(index)
         self.assert_index_equal(index, unpickled)
 
     def test_reindex_preserves_tz_if_target_is_empty_list_or_array(self):

--- a/pandas/tests/indexes/datetimes/test_ops.py
+++ b/pandas/tests/indexes/datetimes/test_ops.py
@@ -1121,7 +1121,7 @@ class TestBusinessDatetimeIndex(tm.TestCase):
         self.assertFalse(comp[9])
 
     def test_pickle_unpickle(self):
-        unpickled = self.round_trip_pickle(self.rng)
+        unpickled = tm.round_trip_pickle(self.rng)
         self.assertIsNotNone(unpickled.offset)
 
     def test_copy(self):
@@ -1272,7 +1272,7 @@ class TestCustomDatetimeIndex(tm.TestCase):
             self.assertEqual(shifted[0], rng[0] + CDay())
 
     def test_pickle_unpickle(self):
-        unpickled = self.round_trip_pickle(self.rng)
+        unpickled = tm.round_trip_pickle(self.rng)
         self.assertIsNotNone(unpickled.offset)
 
     def test_summary(self):

--- a/pandas/tests/indexes/period/test_period.py
+++ b/pandas/tests/indexes/period/test_period.py
@@ -58,7 +58,7 @@ class TestPeriodIndex(DatetimeLike, tm.TestCase):
     def test_pickle_round_trip(self):
         for freq in ['D', 'M', 'Y']:
             idx = PeriodIndex(['2016-05-16', 'NaT', NaT, np.NaN], freq='D')
-            result = self.round_trip_pickle(idx)
+            result = tm.round_trip_pickle(idx)
             tm.assert_index_equal(result, idx)
 
     def test_get_loc(self):
@@ -761,7 +761,7 @@ class TestPeriodIndex(DatetimeLike, tm.TestCase):
     def test_pickle_freq(self):
         # GH2891
         prng = period_range('1/1/2011', '1/1/2012', freq='M')
-        new_prng = self.round_trip_pickle(prng)
+        new_prng = tm.round_trip_pickle(prng)
         self.assertEqual(new_prng.freq, offsets.MonthEnd())
         self.assertEqual(new_prng.freqstr, 'M')
 

--- a/pandas/tests/indexes/test_multi.py
+++ b/pandas/tests/indexes/test_multi.py
@@ -1044,7 +1044,7 @@ class TestMultiIndex(Base, tm.TestCase):
             [[1, 2], ['a', 'b'], date_range('20130101', periods=3,
                                             tz='US/Eastern')
              ], names=['one', 'two', 'three'])
-        unpickled = self.round_trip_pickle(index)
+        unpickled = tm.round_trip_pickle(index)
         self.assertTrue(index.equal_levels(unpickled))
 
     def test_from_tuples_index_values(self):

--- a/pandas/tests/indexes/test_multi.py
+++ b/pandas/tests/indexes/test_multi.py
@@ -1392,7 +1392,7 @@ class TestMultiIndex(Base, tm.TestCase):
         result = self.index.format()
         self.assertEqual(result[1], 'foo  two')
 
-        self.reset_display_options()
+        tm.reset_display_options()
 
         warnings.filters = warn_filters
 

--- a/pandas/tests/indexes/timedeltas/test_timedelta.py
+++ b/pandas/tests/indexes/timedeltas/test_timedelta.py
@@ -454,7 +454,7 @@ class TestTimedeltaIndex(DatetimeLike, tm.TestCase):
     def test_pickle(self):
 
         rng = timedelta_range('1 days', periods=10)
-        rng_p = self.round_trip_pickle(rng)
+        rng_p = tm.round_trip_pickle(rng)
         tm.assert_index_equal(rng, rng_p)
 
     def test_hash_error(self):

--- a/pandas/tests/io/formats/test_eng_formatting.py
+++ b/pandas/tests/io/formats/test_eng_formatting.py
@@ -38,7 +38,7 @@ class TestEngFormatter(tm.TestCase):
                     '3    1E+06')
         self.assertEqual(result, expected)
 
-        self.reset_display_options()
+        tm.reset_display_options()
 
     def compare(self, formatter, input, output):
         formatted_input = formatter(input)
@@ -185,7 +185,7 @@ class TestEngFormatter(tm.TestCase):
         fmt.set_eng_float_format(accuracy=1)
         result = pt.to_string()
         self.assertTrue('NaN' in result)
-        self.reset_display_options()
+        tm.reset_display_options()
 
     def test_inf(self):
         # Issue #11981

--- a/pandas/tests/io/formats/test_format.py
+++ b/pandas/tests/io/formats/test_format.py
@@ -138,7 +138,7 @@ class TestDataFrameFormatting(tm.TestCase):
 
         fmt.set_eng_float_format(accuracy=0)
         repr(self.frame)
-        self.reset_display_options()
+        tm.reset_display_options()
 
     def test_show_null_counts(self):
 
@@ -1197,7 +1197,7 @@ class TestDataFrameFormatting(tm.TestCase):
         self.assertEqual(df_s, expected)
 
     def test_to_string_float_formatting(self):
-        self.reset_display_options()
+        tm.reset_display_options()
         fmt.set_option('display.precision', 5, 'display.column_space', 12,
                        'display.notebook_repr_html', False)
 
@@ -1226,7 +1226,7 @@ class TestDataFrameFormatting(tm.TestCase):
         expected = ('          x\n' '0  3234.000\n' '1     0.253')
         self.assertEqual(df_s, expected)
 
-        self.reset_display_options()
+        tm.reset_display_options()
         self.assertEqual(get_option("display.precision"), 6)
 
         df = DataFrame({'x': [1e9, 0.2512]})
@@ -1310,14 +1310,14 @@ c  10  11  12  13  14\
         self.assertEqual(rs, xp)
 
     def test_to_string_left_justify_cols(self):
-        self.reset_display_options()
+        tm.reset_display_options()
         df = DataFrame({'x': [3234, 0.253]})
         df_s = df.to_string(justify='left')
         expected = ('   x       \n' '0  3234.000\n' '1     0.253')
         self.assertEqual(df_s, expected)
 
     def test_to_string_format_na(self):
-        self.reset_display_options()
+        tm.reset_display_options()
         df = DataFrame({'A': [np.nan, -1, -2.1234, 3, 4],
                         'B': [np.nan, 'foo', 'foooo', 'fooooo', 'bar']})
         result = df.to_string()
@@ -1380,7 +1380,7 @@ c  10  11  12  13  14\
         fmt.set_option('display.notebook_repr_html', False)
         self.frame._repr_html_()
 
-        self.reset_display_options()
+        tm.reset_display_options()
 
         df = DataFrame([[1, 2], [3, 4]])
         fmt.set_option('display.show_dimensions', True)
@@ -1388,7 +1388,7 @@ c  10  11  12  13  14\
         fmt.set_option('display.show_dimensions', False)
         self.assertFalse('2 rows' in df._repr_html_())
 
-        self.reset_display_options()
+        tm.reset_display_options()
 
     def test_repr_html_wide(self):
         max_cols = get_option('display.max_columns')
@@ -1552,7 +1552,7 @@ c  10  11  12  13  14\
         repstr = self.frame._repr_html_()
         self.assertIn('class', repstr)  # info fallback
 
-        self.reset_display_options()
+        tm.reset_display_options()
 
     def test_pprint_pathological_object(self):
         """

--- a/pandas/tests/scalar/test_period.py
+++ b/pandas/tests/scalar/test_period.py
@@ -909,7 +909,7 @@ class TestPeriodProperties(tm.TestCase):
     def test_round_trip(self):
 
         p = Period('2000Q1')
-        new_p = self.round_trip_pickle(p)
+        new_p = tm.round_trip_pickle(p)
         self.assertEqual(new_p, p)
 
 

--- a/pandas/tests/scalar/test_timedelta.py
+++ b/pandas/tests/scalar/test_timedelta.py
@@ -559,7 +559,7 @@ class TestTimedeltas(tm.TestCase):
     def test_pickle(self):
 
         v = Timedelta('1 days 10:11:12.0123456')
-        v_p = self.round_trip_pickle(v)
+        v_p = tm.round_trip_pickle(v)
         self.assertEqual(v, v_p)
 
     def test_timedelta_hash_equality(self):

--- a/pandas/tests/series/test_io.py
+++ b/pandas/tests/series/test_io.py
@@ -134,7 +134,7 @@ class TestSeriesIO(TestData, tm.TestCase):
         from pandas import period_range
         prng = period_range('1/1/2011', '1/1/2012', freq='M')
         ts = Series(np.random.randn(len(prng)), prng)
-        new_ts = self.round_trip_pickle(ts)
+        new_ts = tm.round_trip_pickle(ts)
         self.assertEqual(new_ts.index.freq, 'M')
 
     def test_pickle_preserve_name(self):

--- a/pandas/tests/series/test_timeseries.py
+++ b/pandas/tests/series/test_timeseries.py
@@ -827,11 +827,11 @@ class TestTimeSeries(TestData, tm.TestCase):
     def test_pickle(self):
 
         # GH4606
-        p = self.round_trip_pickle(NaT)
+        p = tm.round_trip_pickle(NaT)
         self.assertTrue(p is NaT)
 
         idx = pd.to_datetime(['2013-01-01', NaT, '2014-01-06'])
-        idx_p = self.round_trip_pickle(idx)
+        idx_p = tm.round_trip_pickle(idx)
         self.assertTrue(idx_p[0] == idx[0])
         self.assertTrue(idx_p[1] is NaT)
         self.assertTrue(idx_p[2] == idx[2])
@@ -839,7 +839,7 @@ class TestTimeSeries(TestData, tm.TestCase):
         # GH11002
         # don't infer freq
         idx = date_range('1750-1-1', '2050-1-1', freq='7D')
-        idx_p = self.round_trip_pickle(idx)
+        idx_p = tm.round_trip_pickle(idx)
         tm.assert_index_equal(idx, idx_p)
 
     def test_setops_preserve_freq(self):

--- a/pandas/tests/test_multilevel.py
+++ b/pandas/tests/test_multilevel.py
@@ -179,7 +179,7 @@ class TestMultiLevel(Base, tm.TestCase):
 
     def test_pickle(self):
         def _test_roundtrip(frame):
-            unpickled = self.round_trip_pickle(frame)
+            unpickled = tm.round_trip_pickle(frame)
             tm.assert_frame_equal(frame, unpickled)
 
         _test_roundtrip(self.frame)

--- a/pandas/tests/test_panel.py
+++ b/pandas/tests/test_panel.py
@@ -43,7 +43,7 @@ class PanelTests(object):
 
     def test_pickle(self):
         with catch_warnings(record=True):
-            unpickled = self.round_trip_pickle(self.panel)
+            unpickled = tm.round_trip_pickle(self.panel)
             assert_frame_equal(unpickled['ItemA'], self.panel['ItemA'])
 
     def test_rank(self):

--- a/pandas/tests/test_testing.py
+++ b/pandas/tests/test_testing.py
@@ -746,26 +746,6 @@ class TestRNGContext(unittest.TestCase):
             self.assertEqual(np.random.randn(), expected0)
 
 
-class TestDeprecatedTests(tm.TestCase):
-
-    def test_warning(self):
-
-        with tm.assert_produces_warning(FutureWarning, check_stacklevel=False):
-            self.assertEquals(1, 1)
-
-        with tm.assert_produces_warning(FutureWarning, check_stacklevel=False):
-            self.assertNotEquals(1, 2)
-
-        with tm.assert_produces_warning(FutureWarning, check_stacklevel=False):
-            self.assert_(True)
-
-        with tm.assert_produces_warning(FutureWarning, check_stacklevel=False):
-            self.assertAlmostEquals(1.0, 1.0000000001)
-
-        with tm.assert_produces_warning(FutureWarning, check_stacklevel=False):
-            self.assertNotAlmostEquals(1, 2)
-
-
 class TestLocale(tm.TestCase):
 
     def test_locale(self):

--- a/pandas/tests/tseries/test_offsets.py
+++ b/pandas/tests/tseries/test_offsets.py
@@ -1906,7 +1906,7 @@ class TestCustomBusinessDay(Base):
 
     def test_roundtrip_pickle(self):
         def _check_roundtrip(obj):
-            unpickled = self.round_trip_pickle(obj)
+            unpickled = tm.round_trip_pickle(obj)
             self.assertEqual(unpickled, obj)
 
         _check_roundtrip(self.offset)
@@ -1967,7 +1967,7 @@ class CustomBusinessMonthBase(object):
 
     def test_roundtrip_pickle(self):
         def _check_roundtrip(obj):
-            unpickled = self.round_trip_pickle(obj)
+            unpickled = tm.round_trip_pickle(obj)
             self.assertEqual(unpickled, obj)
 
         _check_roundtrip(self._object())

--- a/pandas/util/decorators.py
+++ b/pandas/util/decorators.py
@@ -24,7 +24,7 @@ def deprecate_kwarg(old_arg_name, new_arg_name, mapping=None, stacklevel=2):
     old_arg_name : str
         Name of argument in function to deprecate
     new_arg_name : str
-        Name of prefered argument in function
+        Name of preferred argument in function
     mapping : dict or callable
         If mapping is present, use it to translate old arguments to
         new arguments. A callable must do its own value checking;

--- a/pandas/util/testing.py
+++ b/pandas/util/testing.py
@@ -92,27 +92,6 @@ class TestCase(unittest.TestCase):
     def tearDownClass(cls):
         pass
 
-    # https://docs.python.org/3/library/unittest.html#deprecated-aliases
-    def assertEquals(self, *args, **kwargs):
-        return deprecate('assertEquals',
-                         self.assertEqual)(*args, **kwargs)
-
-    def assertNotEquals(self, *args, **kwargs):
-        return deprecate('assertNotEquals',
-                         self.assertNotEqual)(*args, **kwargs)
-
-    def assert_(self, *args, **kwargs):
-        return deprecate('assert_',
-                         self.assertTrue)(*args, **kwargs)
-
-    def assertAlmostEquals(self, *args, **kwargs):
-        return deprecate('assertAlmostEquals',
-                         self.assertAlmostEqual)(*args, **kwargs)
-
-    def assertNotAlmostEquals(self, *args, **kwargs):
-        return deprecate('assertNotAlmostEquals',
-                         self.assertNotAlmostEqual)(*args, **kwargs)
-
 
 def reset_display_options():
     """

--- a/pandas/util/testing.py
+++ b/pandas/util/testing.py
@@ -50,7 +50,6 @@ from pandas import (bdate_range, CategoricalIndex, Categorical, IntervalIndex,
                     Index, MultiIndex,
                     Series, DataFrame, Panel, Panel4D)
 
-from pandas.util.decorators import deprecate
 from pandas.util import libtesting
 from pandas.io.common import urlopen
 slow = pytest.mark.slow
@@ -83,6 +82,14 @@ set_testing_mode()
 
 
 class TestCase(unittest.TestCase):
+    """
+    The test case class that we originally used when using the
+    nosetests framework. Under the new pytest framework, we are
+    moving away from this class.
+
+    Do not create new test classes derived from this one. Rather,
+    they should inherit from object directly.
+    """
 
     @classmethod
     def setUpClass(cls):

--- a/pandas/util/testing.py
+++ b/pandas/util/testing.py
@@ -92,9 +92,6 @@ class TestCase(unittest.TestCase):
     def tearDownClass(cls):
         pass
 
-    def round_trip_pickle(self, obj, path=None):
-        return round_trip_pickle(obj, path=path)
-
     # https://docs.python.org/3/library/unittest.html#deprecated-aliases
     def assertEquals(self, *args, **kwargs):
         return deprecate('assertEquals',
@@ -126,6 +123,22 @@ def reset_display_options():
 
 
 def round_trip_pickle(obj, path=None):
+    """
+    Pickle an object and then read it again.
+
+    Parameters
+    ----------
+    obj : pandas object
+        The object to pickle and then re-read.
+    path : str, default None
+        The path where the pickled object is written and then read.
+
+    Returns
+    -------
+    round_trip_pickled_object : pandas object
+        The original object that was pickled and then re-read.
+    """
+
     if path is None:
         path = u('__%s__.pickle' % rands(10))
     with ensure_clean(path) as path:

--- a/pandas/util/testing.py
+++ b/pandas/util/testing.py
@@ -92,10 +92,6 @@ class TestCase(unittest.TestCase):
     def tearDownClass(cls):
         pass
 
-    def reset_display_options(self):
-        # reset the display options
-        pd.reset_option('^display.', silent=True)
-
     def round_trip_pickle(self, obj, path=None):
         return round_trip_pickle(obj, path=path)
 
@@ -119,6 +115,14 @@ class TestCase(unittest.TestCase):
     def assertNotAlmostEquals(self, *args, **kwargs):
         return deprecate('assertNotAlmostEquals',
                          self.assertNotAlmostEqual)(*args, **kwargs)
+
+
+def reset_display_options():
+    """
+    Reset the display options for printing and representing objects.
+    """
+
+    pd.reset_option('^display.', silent=True)
 
 
 def round_trip_pickle(obj, path=None):


### PR DESCRIPTION
`TestCase` is a vestige from the `nosetest` framework.  We want to discourage usage of `self.*` method calls under our new `pytest` framework, so this PR strips as much as possible from the class.

Partially addresses #15990.