### PR TITLE
MAINT: Remove assert_equal from testing.py

### DIFF
--- a/pandas/tests/core/computation/test_compat.py
+++ b/pandas/tests/core/computation/test_compat.py
@@ -30,7 +30,7 @@ def test_invalid_numexpr_version(engine, parser):
     def testit():
         a, b = 1, 2  # noqa
         res = pd.eval('a + b', engine=engine, parser=parser)
-        tm.assert_equal(res, 3)
+        assert res == 3
 
     if engine == 'numexpr':
         try:

--- a/pandas/tests/core/computation/test_eval.py
+++ b/pandas/tests/core/computation/test_eval.py
@@ -1020,7 +1020,7 @@ class TestAlignment(object):
                                       parser=parser)
                 else:
                     res = pd.eval('df2 + s + df', engine=engine, parser=parser)
-                tm.assert_equal(res.shape, expected.shape)
+                assert res.shape == expected.shape
                 assert_frame_equal(res, expected)
 
     def test_performance_warning_for_poor_alignment(self, engine, parser):
@@ -1057,13 +1057,13 @@ class TestAlignment(object):
             pd.eval('df + s', engine=engine, parser=parser)
 
             if not is_python_engine:
-                tm.assert_equal(len(w), 1)
+                assert len(w) == 1
                 msg = str(w[0].message)
                 expected = ("Alignment difference on axis {0} is larger"
                             " than an order of magnitude on term {1!r}, "
                             "by more than {2:.4g}; performance may suffer"
                             "".format(1, 'df', np.log10(s.size - df.shape[1])))
-                tm.assert_equal(msg, expected)
+                assert msg == expected
 
 
 # ------------------------------------
@@ -1104,17 +1104,17 @@ class TestOperationsNumExprPandas(tm.TestCase):
             else:
                 expec = _eval_single_bin(1, op, 1, self.engine)
                 x = self.eval(ex, engine=self.engine, parser=self.parser)
-                tm.assert_equal(x, expec)
+                assert x == expec
 
                 expec = _eval_single_bin(x, op, 1, self.engine)
                 y = self.eval(ex2, local_dict={'x': x}, engine=self.engine,
                               parser=self.parser)
-                tm.assert_equal(y, expec)
+                assert y == expec
 
                 expec = _eval_single_bin(1, op, x + 1, self.engine)
                 y = self.eval(ex3, local_dict={'x': x},
                               engine=self.engine, parser=self.parser)
-                tm.assert_equal(y, expec)
+                assert y == expec
 
     def test_simple_bool_ops(self):
         for op, lhs, rhs in product(expr._bool_ops_syms, (True, False),
@@ -1149,7 +1149,7 @@ class TestOperationsNumExprPandas(tm.TestCase):
 
     def test_constant(self):
         x = self.eval('1')
-        tm.assert_equal(x, 1)
+        assert x == 1
 
     def test_single_variable(self):
         df = DataFrame(randn(10, 2))
@@ -1508,7 +1508,7 @@ class TestOperationsNumExprPython(TestOperationsNumExprPandas):
         expr = ' * '.join('a' * 33)
         expected = 1
         res = pd.eval(expr, engine=self.engine, parser=self.parser)
-        tm.assert_equal(res, expected)
+        assert res == expected
 
     def test_fails_and(self):
         df = DataFrame(np.random.randn(5, 3))
@@ -1736,14 +1736,14 @@ class TestScope(object):
         pd.eval('x + 1', local_dict=lcls, engine=engine, parser=parser)
         lcls2 = locals().copy()
         lcls2.pop('lcls')
-        tm.assert_equal(lcls, lcls2)
+        assert lcls == lcls2
 
     def test_no_new_globals(self, engine, parser):
         x = 1  # noqa
         gbls = globals().copy()
         pd.eval('x + 1', engine=engine, parser=parser)
         gbls2 = globals().copy()
-        tm.assert_equal(gbls, gbls2)
+        assert gbls == gbls2
 
 
 def test_invalid_engine():
@@ -1810,7 +1810,7 @@ def test_numexpr_builtin_raises(engine, parser):
             pd.eval('sin + dotted_line', engine=engine, parser=parser)
     else:
         res = pd.eval('sin + dotted_line', engine=engine, parser=parser)
-        tm.assert_equal(res, sin + dotted_line)
+        assert res == sin + dotted_line
 
 
 def test_bad_resolver_raises(engine, parser):
@@ -1854,7 +1854,7 @@ def test_inf(engine, parser):
     s = 'inf + 1'
     expected = np.inf
     result = pd.eval(s, engine=engine, parser=parser)
-    tm.assert_equal(result, expected)
+    assert result == expected
 
 
 def test_negate_lt_eq_le(engine, parser):

--- a/pandas/tests/core/sparse/test_frame.py
+++ b/pandas/tests/core/sparse/test_frame.py
@@ -1183,7 +1183,7 @@ def test_from_to_scipy(spmatrix, index, columns, fill_value, dtype):
     tm.assert_frame_equal(sdf_obj.to_dense(), expected.to_dense())
 
     # Assert spmatrices equal
-    tm.assert_equal(dict(sdf.to_coo().todok()), dict(spm.todok()))
+    assert dict(sdf.to_coo().todok()) == dict(spm.todok())
 
     # Ensure dtype is preserved if possible
     was_upcast = ((fill_value is None or is_float(fill_value)) and
@@ -1193,11 +1193,11 @@ def test_from_to_scipy(spmatrix, index, columns, fill_value, dtype):
                  float if was_upcast else
                  dtype)
     tm.assert_contains_all(sdf.dtypes, {np.dtype(res_dtype)})
-    tm.assert_equal(sdf.to_coo().dtype, res_dtype)
+    assert sdf.to_coo().dtype == res_dtype
 
     # However, adding a str column results in an upcast to object
     sdf['strings'] = np.arange(len(sdf)).astype(str)
-    tm.assert_equal(sdf.to_coo().dtype, np.object_)
+    assert sdf.to_coo().dtype == np.object_
 
 
 @pytest.mark.parametrize('fill_value', [None, 0, np.nan])  # noqa: F811
@@ -1237,12 +1237,12 @@ def test_from_to_scipy_object(spmatrix, fill_value):
     tm.assert_frame_equal(sdf_obj.to_dense(), expected.to_dense())
 
     # Assert spmatrices equal
-    tm.assert_equal(dict(sdf.to_coo().todok()), dict(spm.todok()))
+    assert dict(sdf.to_coo().todok()) == dict(spm.todok())
 
     # Ensure dtype is preserved if possible
     res_dtype = object
     tm.assert_contains_all(sdf.dtypes, {np.dtype(res_dtype)})
-    tm.assert_equal(sdf.to_coo().dtype, res_dtype)
+    assert sdf.to_coo().dtype == res_dtype
 
 
 class TestSparseDataFrameArithmetic(tm.TestCase):

--- a/pandas/tests/frame/test_constructors.py
+++ b/pandas/tests/frame/test_constructors.py
@@ -259,8 +259,8 @@ class TestDataFrameConstructors(tm.TestCase, TestData):
         # Dict with None value
         frame_none = DataFrame(dict(a=None), index=[0])
         frame_none_list = DataFrame(dict(a=[None]), index=[0])
-        tm.assert_equal(frame_none.get_value(0, 'a'), None)
-        tm.assert_equal(frame_none_list.get_value(0, 'a'), None)
+        assert frame_none.get_value(0, 'a') is None
+        assert frame_none_list.get_value(0, 'a') is None
         tm.assert_frame_equal(frame_none, frame_none_list)
 
         # GH10856

--- a/pandas/tests/frame/test_replace.py
+++ b/pandas/tests/frame/test_replace.py
@@ -974,7 +974,7 @@ class TestDataFrameReplace(tm.TestCase, TestData):
                            'out_augmented_MAY_2011.json',
                            'out_augmented_AUG_2011.json',
                            'out_augmented_JAN_2011.json'], columns=['fname'])
-        tm.assert_equal(set(df.fname.values), set(d['fname'].keys()))
+        assert set(df.fname.values) == set(d['fname'].keys())
         expected = DataFrame({'fname': [d['fname'][k]
                                         for k in df.fname.values]})
         result = df.replace(d)
@@ -997,7 +997,7 @@ class TestDataFrameReplace(tm.TestCase, TestData):
                            'out_augmented_MAY_2011.json',
                            'out_augmented_AUG_2011.json',
                            'out_augmented_JAN_2011.json'], columns=['fname'])
-        tm.assert_equal(set(df.fname.values), set(d['fname'].keys()))
+        assert set(df.fname.values) == set(d['fname'].keys())
         expected = DataFrame({'fname': [d['fname'][k]
                                         for k in df.fname.values]})
         result = df.replace(d)

--- a/pandas/tests/frame/test_subclass.py
+++ b/pandas/tests/frame/test_subclass.py
@@ -229,9 +229,9 @@ class TestDataFrameSubclassing(tm.TestCase, TestData):
                                  tm.SubclassedSparseDataFrame(rows[:2]))
         tm.assert_sp_frame_equal(ssdf[:2],
                                  tm.SubclassedSparseDataFrame(rows[:2]))
-        tm.assert_equal(ssdf.loc[:2].testattr, "testattr")
-        tm.assert_equal(ssdf.iloc[:2].testattr, "testattr")
-        tm.assert_equal(ssdf[:2].testattr, "testattr")
+        assert ssdf.loc[:2].testattr == "testattr"
+        assert ssdf.iloc[:2].testattr == "testattr"
+        assert ssdf[:2].testattr == "testattr"
 
         tm.assert_sp_series_equal(ssdf.loc[1],
                                   tm.SubclassedSparseSeries(rows[1]),

--- a/pandas/tests/groupby/test_groupby.py
+++ b/pandas/tests/groupby/test_groupby.py
@@ -3275,7 +3275,7 @@ class TestGroupBy(MixIn, tm.TestCase):
         # we expect 2 zeros because we call ``f`` once to see if a faster route
         # can be used.
         expected_names = [0, 0, 1, 2]
-        tm.assert_equal(names, expected_names)
+        assert names == expected_names
 
     def test_no_dummy_key_names(self):
         # GH #1291
@@ -3987,7 +3987,7 @@ class TestGroupBy(MixIn, tm.TestCase):
 
         result = gr.grouper.groupings[0].__repr__()
         expected = "Grouping(('A', 'a'))"
-        tm.assert_equal(result, expected)
+        assert result == expected
 
     def test_group_shift_with_null_key(self):
         # This test is designed to replicate the segfault in issue #13813.

--- a/pandas/tests/indexes/datetimes/test_tools.py
+++ b/pandas/tests/indexes/datetimes/test_tools.py
@@ -1295,7 +1295,7 @@ class TestDatetimeParsingWrappers(tm.TestCase):
 
         res = tools.to_time(np.array(arg))
         self.assertIsInstance(res, list)
-        self.assert_equal(res, expected_arr)
+        assert res == expected_arr
 
     def test_parsers_monthfreq(self):
         cases = {'201101': datetime(2011, 1, 1, 0, 0),

--- a/pandas/tests/io/formats/test_format.py
+++ b/pandas/tests/io/formats/test_format.py
@@ -2536,11 +2536,11 @@ class TestStringRepTimestamp(tm.TestCase):
 def test_format_percentiles():
     result = fmt.format_percentiles([0.01999, 0.02001, 0.5, 0.666666, 0.9999])
     expected = ['1.999%', '2.001%', '50%', '66.667%', '99.99%']
-    tm.assert_equal(result, expected)
+    assert result == expected
 
     result = fmt.format_percentiles([0, 0.5, 0.02001, 0.5, 0.666666, 0.9999])
     expected = ['0%', '50%', '2.0%', '50%', '66.67%', '99.99%']
-    tm.assert_equal(result, expected)
+    assert result == expected
 
     tm.assertRaises(ValueError, fmt.format_percentiles, [0.1, np.nan, 0.5])
     tm.assertRaises(ValueError, fmt.format_percentiles, [-0.001, 0.1, 0.5])

--- a/pandas/tests/io/formats/test_printing.py
+++ b/pandas/tests/io/formats/test_printing.py
@@ -27,9 +27,9 @@ def test_repr_binary_type():
         raw = btype(letters)
     b = compat.text_type(compat.bytes_to_str(raw))
     res = printing.pprint_thing(b, quote_strings=True)
-    tm.assert_equal(res, repr(b))
+    assert res == repr(b)
     res = printing.pprint_thing(b, quote_strings=False)
-    tm.assert_equal(res, b)
+    assert res == b
 
 
 class TestFormattBase(tm.TestCase):

--- a/pandas/tests/io/json/test_pandas.py
+++ b/pandas/tests/io/json/test_pandas.py
@@ -420,7 +420,7 @@ class TestPandasContainer(tm.TestCase):
         # GH 7445
         result = pd.DataFrame({'test': []}, index=[]).to_json(orient='columns')
         expected = '{"test":{}}'
-        tm.assert_equal(result, expected)
+        assert result == expected
 
     def test_frame_empty_mixedtype(self):
         # mixed type

--- a/pandas/tests/io/parser/common.py
+++ b/pandas/tests/io/parser/common.py
@@ -1332,9 +1332,9 @@ eight,1,2,3"""
             'C': [5, 10.]
         })
 
-        tm.assert_equal(expected.A.dtype, 'int64')
-        tm.assert_equal(expected.B.dtype, 'float')
-        tm.assert_equal(expected.C.dtype, 'float')
+        assert expected.A.dtype == 'int64'
+        assert expected.B.dtype == 'float'
+        assert expected.C.dtype == 'float'
 
         df = self.read_csv(StringIO(data), sep='|', thousands=',', decimal='.')
         tm.assert_frame_equal(df, expected)

--- a/pandas/tests/io/test_excel.py
+++ b/pandas/tests/io/test_excel.py
@@ -412,7 +412,7 @@ class ReadingTestsBase(SharedItems):
         tm.assert_contains_all(expected_keys, dfs.keys())
         # Issue 9930
         # Ensure sheet order is preserved
-        tm.assert_equal(expected_keys, list(dfs.keys()))
+        assert expected_keys == list(dfs.keys())
 
     def test_reading_multiple_specific_sheets(self):
         # Test reading specific sheetnames by specifying a mixed list

--- a/pandas/tests/io/test_pickle.py
+++ b/pandas/tests/io/test_pickle.py
@@ -50,8 +50,8 @@ def compare_element(result, expected, typ, version=None):
         if expected is pd.NaT:
             assert result is pd.NaT
         else:
-            tm.assert_equal(result, expected)
-            tm.assert_equal(result.freq, expected.freq)
+            assert result == expected
+            assert result.freq == expected.freq
     else:
         comparator = getattr(tm, "assert_%s_equal" %
                              typ, tm.assert_almost_equal)
@@ -102,21 +102,21 @@ def compare_sp_series_ts(res, exp, typ, version):
 def compare_series_ts(result, expected, typ, version):
     # GH 7748
     tm.assert_series_equal(result, expected)
-    tm.assert_equal(result.index.freq, expected.index.freq)
-    tm.assert_equal(result.index.freq.normalize, False)
+    assert result.index.freq == expected.index.freq
+    assert not result.index.freq.normalize
     tm.assert_series_equal(result > 0, expected > 0)
 
     # GH 9291
     freq = result.index.freq
-    tm.assert_equal(freq + Day(1), Day(2))
+    assert freq + Day(1) == Day(2)
 
     res = freq + pandas.Timedelta(hours=1)
-    tm.assert_equal(isinstance(res, pandas.Timedelta), True)
-    tm.assert_equal(res, pandas.Timedelta(days=1, hours=1))
+    assert isinstance(res, pandas.Timedelta)
+    assert res == pandas.Timedelta(days=1, hours=1)
 
     res = freq + pandas.Timedelta(nanoseconds=1)
-    tm.assert_equal(isinstance(res, pandas.Timedelta), True)
-    tm.assert_equal(res, pandas.Timedelta(days=1, nanoseconds=1))
+    assert isinstance(res, pandas.Timedelta)
+    assert res == pandas.Timedelta(days=1, nanoseconds=1)
 
 
 def compare_series_dt_tz(result, expected, typ, version):
@@ -170,8 +170,8 @@ def compare_frame_cat_and_float(result, expected, typ, version):
 def compare_index_period(result, expected, typ, version):
     tm.assert_index_equal(result, expected)
     tm.assertIsInstance(result.freq, MonthEnd)
-    tm.assert_equal(result.freq, MonthEnd())
-    tm.assert_equal(result.freqstr, 'M')
+    assert result.freq == MonthEnd()
+    assert result.freqstr == 'M'
     tm.assert_index_equal(result.shift(2), expected.shift(2))
 
 

--- a/pandas/tests/io/test_pytables.py
+++ b/pandas/tests/io/test_pytables.py
@@ -3516,7 +3516,7 @@ class TestHDFStore(Base, tm.TestCase):
             results = [s for s in store.select(
                 'df', where=where, chunksize=chunksize)]
 
-            tm.assert_equal(1, len(results))
+            assert len(results) == 1
             result = concat(results)
             rexpected = expected[expected.index <= end_dt]
             tm.assert_frame_equal(rexpected, result)
@@ -3527,7 +3527,7 @@ class TestHDFStore(Base, tm.TestCase):
                 'df', where=where, chunksize=chunksize)]
 
             # should be 1, is 10
-            tm.assert_equal(1, len(results))
+            assert len(results) == 1
             result = concat(results)
             rexpected = expected[(expected.index >= beg_dt) &
                                  (expected.index <= end_dt)]
@@ -3545,7 +3545,7 @@ class TestHDFStore(Base, tm.TestCase):
                 'df', where=where, chunksize=chunksize)]
 
             # should be []
-            tm.assert_equal(0, len(results))
+            assert len(results) == 0
 
     def test_retain_index_attributes(self):
 

--- a/pandas/tests/io/test_stata.py
+++ b/pandas/tests/io/test_stata.py
@@ -1129,14 +1129,14 @@ class TestStata(tm.TestCase):
                                'a': 'City Rank',
                                'b': 'City Exponent',
                                'c': 'City'}
-            tm.assert_equal(read_labels, expected_labels)
+            assert read_labels == expected_labels
 
         variable_labels['index'] = 'The Index'
         with tm.ensure_clean() as path:
             original.to_stata(path, variable_labels=variable_labels)
             with StataReader(path) as sr:
                 read_labels = sr.variable_labels()
-            tm.assert_equal(read_labels, variable_labels)
+            assert read_labels == variable_labels
 
     def test_write_variable_label_errors(self):
         original = pd.DataFrame({'a': [1, 2, 3, 4],

--- a/pandas/tests/plotting/test_converter.py
+++ b/pandas/tests/plotting/test_converter.py
@@ -153,8 +153,7 @@ class TestPeriodConverter(tm.TestCase):
     def test_convert_accepts_unicode(self):
         r1 = self.pc.convert("2012-1-1", None, self.axis)
         r2 = self.pc.convert(u("2012-1-1"), None, self.axis)
-        self.assert_equal(r1, r2,
-                          "PeriodConverter.convert should accept unicode")
+        assert r1 == r2
 
     def test_conversion(self):
         rs = self.pc.convert(['2012-1-1'], None, self.axis)[0]

--- a/pandas/tests/series/test_api.py
+++ b/pandas/tests/series/test_api.py
@@ -344,7 +344,7 @@ class TestSeriesMisc(TestData, SharedWithSparse, tm.TestCase):
 
     def test_empty_method(self):
         s_empty = pd.Series()
-        tm.assert_equal(s_empty.empty, True)
+        assert s_empty.empty
 
         for full_series in [pd.Series([1]), pd.Series(index=[1])]:
-            tm.assert_equal(full_series.empty, False)
+            assert not full_series.empty

--- a/pandas/tests/test_common.py
+++ b/pandas/tests/test_common.py
@@ -142,12 +142,12 @@ def test_random_state():
     import numpy.random as npr
     # Check with seed
     state = com._random_state(5)
-    tm.assert_equal(state.uniform(), npr.RandomState(5).uniform())
+    assert state.uniform() == npr.RandomState(5).uniform()
 
     # Check with random state object
     state2 = npr.RandomState(10)
-    tm.assert_equal(
-        com._random_state(state2).uniform(), npr.RandomState(10).uniform())
+    assert (com._random_state(state2).uniform() ==
+            npr.RandomState(10).uniform())
 
     # check with no arg random state
     assert com._random_state() is np.random

--- a/pandas/tests/test_generic.py
+++ b/pandas/tests/test_generic.py
@@ -1810,12 +1810,12 @@ class TestNDFrame(tm.TestCase):
 
         # axis argument
         df = tm.makeTimeDataFrame(nper=1).iloc[:, :1]
-        tm.assert_equal(df.shape, (1, 1))
+        assert df.shape == (1, 1)
         tm.assert_series_equal(df.squeeze(axis=0), df.iloc[0])
         tm.assert_series_equal(df.squeeze(axis='index'), df.iloc[0])
         tm.assert_series_equal(df.squeeze(axis=1), df.iloc[:, 0])
         tm.assert_series_equal(df.squeeze(axis='columns'), df.iloc[:, 0])
-        tm.assert_equal(df.squeeze(), df.iloc[0, 0])
+        assert df.squeeze() == df.iloc[0, 0]
         tm.assertRaises(ValueError, df.squeeze, axis=2)
         tm.assertRaises(ValueError, df.squeeze, axis='x')
 

--- a/pandas/tests/test_util.py
+++ b/pandas/tests/test_util.py
@@ -213,7 +213,7 @@ class TestValidateKwargs(tm.TestCase):
                     validate_bool_kwarg(value, name)
 
             for value in valid_values:
-                tm.assert_equal(validate_bool_kwarg(value, name), value)
+                assert validate_bool_kwarg(value, name) == value
 
 
 class TestValidateKwargsAndArgs(tm.TestCase):
@@ -400,4 +400,4 @@ def test_numpy_errstate_is_default():
     import numpy as np
     from pandas.compat import numpy  # noqa
     # The errstate should be unchanged after that import.
-    tm.assert_equal(np.geterr(), expected)
+    assert np.geterr() == expected

--- a/pandas/tests/tools/test_util.py
+++ b/pandas/tests/tools/test_util.py
@@ -50,7 +50,7 @@ class TestCartesianProduct(tm.TestCase):
         # empty product (empty input):
         result = cartesian_product([])
         expected = []
-        tm.assert_equal(result, expected)
+        assert result == expected
 
     def test_invalid_input(self):
         invalid_inputs = [1, [1], [1, 2], [[1], 2],
@@ -482,4 +482,4 @@ class TestToNumeric(tm.TestCase):
 
         for dtype, downcast, min_max in dtype_downcast_min_max:
             series = pd.to_numeric(pd.Series(min_max), downcast=downcast)
-            tm.assert_equal(series.dtype, dtype)
+            assert series.dtype == dtype

--- a/pandas/util/testing.py
+++ b/pandas/util/testing.py
@@ -833,23 +833,6 @@ def equalContents(arr1, arr2):
     return frozenset(arr1) == frozenset(arr2)
 
 
-def assert_equal(a, b, msg=""):
-    """asserts that a equals b, like nose's assert_equal,
-    but allows custom message to start. Passes a and b to
-    format string as well. So you can use '{0}' and '{1}'
-    to display a and b.
-
-    Examples
-    --------
-    >>> assert_equal(2, 2, "apples")
-    >>> assert_equal(5.2, 1.2, "{0} was really a dead parrot")
-    Traceback (most recent call last):
-        ...
-    AssertionError: 5.2 was really a dead parrot: 5.2 != 1.2
-    """
-    assert a == b, "%s: %r != %r" % (msg.format(a, b), a, b)
-
-
 def assert_index_equal(left, right, exact='equiv', check_names=True,
                        check_less_precise=False, check_exact=True,
                        check_categorical=True, obj='Index'):
@@ -862,7 +845,7 @@ def assert_index_equal(left, right, exact='equiv', check_names=True,
     exact : bool / string {'equiv'}, default False
         Whether to check the Index class, dtype and inferred_type
         are identical. If 'equiv', then RangeIndex can be substituted for
-        Int64Index as well
+        Int64Index as well.
     check_names : bool, default True
         Whether to check the names attribute.
     check_less_precise : bool or int, default False


### PR DESCRIPTION
Title is self-explanatory.

Partially addresses #15990.
