### PR TITLE
MAINT: Remove tm.assertIsNot from testing

### DIFF
--- a/pandas/tests/core/sparse/test_frame.py
+++ b/pandas/tests/core/sparse/test_frame.py
@@ -422,24 +422,24 @@ class TestSparseDataFrame(tm.TestCase, SharedWithSparse):
 
     def test_set_value(self):
 
-        # ok as the index gets conver to object
+        # ok, as the index gets converted to object
         frame = self.frame.copy()
         res = frame.set_value('foobar', 'B', 1.5)
-        self.assertEqual(res.index.dtype, 'object')
+        assert res.index.dtype == 'object'
 
         res = self.frame
         res.index = res.index.astype(object)
 
         res = self.frame.set_value('foobar', 'B', 1.5)
-        self.assertIsNot(res, self.frame)
-        self.assertEqual(res.index[-1], 'foobar')
-        self.assertEqual(res.get_value('foobar', 'B'), 1.5)
+        assert res is not self.frame
+        assert res.index[-1] == 'foobar'
+        assert res.get_value('foobar', 'B') == 1.5
 
         res2 = res.set_value('foobar', 'qux', 1.5)
-        self.assertIsNot(res2, res)
-        self.assert_index_equal(res2.columns,
-                                pd.Index(list(self.frame.columns) + ['qux']))
-        self.assertEqual(res2.get_value('foobar', 'qux'), 1.5)
+        assert res2 is not res
+        tm.assert_index_equal(res2.columns,
+                              pd.Index(list(self.frame.columns) + ['qux']))
+        assert res2.get_value('foobar', 'qux') == 1.5
 
     def test_fancy_index_misc(self):
         # axis = 0

--- a/pandas/tests/core/sparse/test_indexing.py
+++ b/pandas/tests/core/sparse/test_indexing.py
@@ -1,6 +1,6 @@
 # pylint: disable-msg=E1101,W0612
 
-import pytest  # noqa
+import pytest
 import numpy as np
 import pandas as pd
 import pandas.util.testing as tm
@@ -578,7 +578,7 @@ class TestSparseSeriesMultiIndexing(TestSparseSeriesIndexing):
         exp = orig.reindex(['A'], level=0).to_sparse()
         tm.assert_sp_series_equal(res, exp)
 
-        with tm.assertRaises(TypeError):
+        with pytest.raises(TypeError):
             # Incomplete keys are not accepted for reindexing:
             sparse.reindex(['A', 'C'])
 
@@ -586,7 +586,7 @@ class TestSparseSeriesMultiIndexing(TestSparseSeriesIndexing):
         res = sparse.reindex(sparse.index, copy=True)
         exp = orig.reindex(orig.index, copy=True).to_sparse()
         tm.assert_sp_series_equal(res, exp)
-        self.assertIsNot(sparse, res)
+        assert sparse is not res
 
 
 class TestSparseDataFrameIndexing(tm.TestCase):

--- a/pandas/tests/core/sparse/test_series.py
+++ b/pandas/tests/core/sparse/test_series.py
@@ -314,9 +314,9 @@ class TestSparseSeries(tm.TestCase, SharedWithSparse):
 
     def test_copy_astype(self):
         cop = self.bseries.astype(np.float64)
-        self.assertIsNot(cop, self.bseries)
-        self.assertIs(cop.sp_index, self.bseries.sp_index)
-        self.assertEqual(cop.dtype, np.float64)
+        assert cop is not self.bseries
+        assert cop.sp_index is self.bseries.sp_index
+        assert cop.dtype == np.float64
 
         cop2 = self.iseries.copy()
 
@@ -325,8 +325,8 @@ class TestSparseSeries(tm.TestCase, SharedWithSparse):
 
         # test that data is copied
         cop[:5] = 97
-        self.assertEqual(cop.sp_values[0], 97)
-        self.assertNotEqual(self.bseries.sp_values[0], 97)
+        assert cop.sp_values[0] == 97
+        assert self.bseries.sp_values[0] != 97
 
         # correct fill value
         zbcop = self.zbseries.copy()
@@ -338,7 +338,7 @@ class TestSparseSeries(tm.TestCase, SharedWithSparse):
         # no deep copy
         view = self.bseries.copy(deep=False)
         view.sp_values[:5] = 5
-        self.assertTrue((self.bseries.sp_values[:5] == 5).all())
+        assert (self.bseries.sp_values[:5] == 5).all()
 
     def test_shape(self):
         # GH 10452
@@ -639,7 +639,7 @@ class TestSparseSeries(tm.TestCase, SharedWithSparse):
         # special cases
         same_index = self.bseries.reindex(self.bseries.index)
         tm.assert_sp_series_equal(self.bseries, same_index)
-        self.assertIsNot(same_index, self.bseries)
+        assert same_index is not self.bseries
 
         # corner cases
         sp = SparseSeries([], index=[])
@@ -650,7 +650,7 @@ class TestSparseSeries(tm.TestCase, SharedWithSparse):
         # with copy=False
         reindexed = self.bseries.reindex(self.bseries.index, copy=True)
         reindexed.sp_values[:] = 1.
-        self.assertTrue((self.bseries.sp_values != 1.).all())
+        assert (self.bseries.sp_values != 1.).all()
 
         reindexed = self.bseries.reindex(self.bseries.index, copy=False)
         reindexed.sp_values[:] = 1.
@@ -824,7 +824,7 @@ class TestSparseSeries(tm.TestCase, SharedWithSparse):
         series = SparseSeries([nan, 1., 2., 3., nan, nan], index=np.arange(6))
 
         shifted = series.shift(0)
-        self.assertIsNot(shifted, series)
+        assert shifted is not series
         tm.assert_sp_series_equal(shifted, series)
 
         f = lambda s: s.shift(1)

--- a/pandas/tests/frame/test_block_internals.py
+++ b/pandas/tests/frame/test_block_internals.py
@@ -41,17 +41,18 @@ class TestDataFrameBlockInternals(tm.TestCase, TestData):
     def test_consolidate(self):
         self.frame['E'] = 7.
         consolidated = self.frame._consolidate()
-        self.assertEqual(len(consolidated._data.blocks), 1)
+        assert len(consolidated._data.blocks) == 1
 
         # Ensure copy, do I want this?
         recons = consolidated._consolidate()
-        self.assertIsNot(recons, consolidated)
-        assert_frame_equal(recons, consolidated)
+        assert recons is not consolidated
+        tm.assert_frame_equal(recons, consolidated)
 
         self.frame['F'] = 8.
-        self.assertEqual(len(self.frame._data.blocks), 3)
+        assert len(self.frame._data.blocks) == 3
+
         self.frame._consolidate(inplace=True)
-        self.assertEqual(len(self.frame._data.blocks), 1)
+        assert len(self.frame._data.blocks) == 1
 
     def test_consolidate_deprecation(self):
         self.frame['E'] = 7
@@ -343,11 +344,11 @@ class TestDataFrameBlockInternals(tm.TestCase, TestData):
     def test_copy(self):
         cop = self.frame.copy()
         cop['E'] = cop['A']
-        self.assertNotIn('E', self.frame)
+        assert 'E' not in self.frame
 
         # copy objects
         copy = self.mixed_frame.copy()
-        self.assertIsNot(copy._data, self.mixed_frame._data)
+        assert copy._data is not self.mixed_frame._data
 
     def test_pickle(self):
         unpickled = tm.round_trip_pickle(self.mixed_frame)

--- a/pandas/tests/frame/test_indexing.py
+++ b/pandas/tests/frame/test_indexing.py
@@ -672,19 +672,19 @@ class TestDataFrameIndexing(tm.TestCase, TestData):
         self.assertEqual(dm[2].dtype, np.object_)
 
     def test_setitem_clear_caches(self):
-        # GH #304
+        # see gh-304
         df = DataFrame({'x': [1.1, 2.1, 3.1, 4.1], 'y': [5.1, 6.1, 7.1, 8.1]},
                        index=[0, 1, 2, 3])
         df.insert(2, 'z', np.nan)
 
         # cache it
         foo = df['z']
-
         df.loc[df.index[2:], 'z'] = 42
 
         expected = Series([np.nan, np.nan, 42, 42], index=df.index, name='z')
-        self.assertIsNot(df['z'], foo)
-        assert_series_equal(df['z'], expected)
+
+        assert df['z'] is not foo
+        tm.assert_series_equal(df['z'], expected)
 
     def test_setitem_None(self):
         # GH #766

--- a/pandas/tests/frame/test_missing.py
+++ b/pandas/tests/frame/test_missing.py
@@ -403,18 +403,18 @@ class TestDataFrameMissingData(tm.TestCase, TestData):
         df[3][-4:] = np.nan
 
         expected = df.fillna(value=0)
-        self.assertIsNot(expected, df)
+        assert expected is not df
 
         df.fillna(value=0, inplace=True)
-        assert_frame_equal(df, expected)
+        tm.assert_frame_equal(df, expected)
 
         df[1][:4] = np.nan
         df[3][-4:] = np.nan
         expected = df.fillna(method='ffill')
-        self.assertIsNot(expected, df)
+        assert expected is not df
 
         df.fillna(method='ffill', inplace=True)
-        assert_frame_equal(df, expected)
+        tm.assert_frame_equal(df, expected)
 
     def test_fillna_dict_series(self):
         df = DataFrame({'a': [nan, 1, 2, nan, nan],

--- a/pandas/tests/frame/test_timeseries.py
+++ b/pandas/tests/frame/test_timeseries.py
@@ -14,8 +14,7 @@ from pandas import (DataFrame, Series, Index,
 import pandas as pd
 import pandas.tseries.offsets as offsets
 
-from pandas.util.testing import (assert_almost_equal,
-                                 assert_series_equal,
+from pandas.util.testing import (assert_series_equal,
                                  assert_frame_equal,
                                  assertRaisesRegexp)
 
@@ -355,7 +354,7 @@ class TestDataFrameTimeSeriesMethods(tm.TestCase, TestData):
         offset_monthly = self.tsframe.asfreq(offsets.BMonthEnd())
         rule_monthly = self.tsframe.asfreq('BM')
 
-        assert_almost_equal(offset_monthly['A'], rule_monthly['A'])
+        tm.assert_almost_equal(offset_monthly['A'], rule_monthly['A'])
 
         filled = rule_monthly.asfreq('B', method='pad')  # noqa
         # TODO: actually check that this worked.
@@ -366,7 +365,7 @@ class TestDataFrameTimeSeriesMethods(tm.TestCase, TestData):
         # test does not blow up on length-0 DataFrame
         zero_length = self.tsframe.reindex([])
         result = zero_length.asfreq('BM')
-        self.assertIsNot(result, zero_length)
+        assert result is not zero_length
 
     def test_asfreq_datetimeindex(self):
         df = DataFrame({'A': [1, 2, 3]},

--- a/pandas/tests/indexes/common.py
+++ b/pandas/tests/indexes/common.py
@@ -214,8 +214,9 @@ class Base(object):
                 hash(ind)
 
     def test_copy_name(self):
-        # Check that "name" argument passed at initialization is honoured
-        # GH12309
+        # gh-12309: Check that the "name" argument
+        # passed at initialization is honored.
+
         for name, index in compat.iteritems(self.indices):
             if isinstance(index, MultiIndex):
                 continue
@@ -224,18 +225,21 @@ class Base(object):
             second = first.__class__(first, copy=False)
 
             # Even though "copy=False", we want a new object.
-            self.assertIsNot(first, second)
-            # Not using tm.assert_index_equal() since names differ:
-            self.assertTrue(index.equals(first))
+            assert first is not second
 
-            self.assertEqual(first.name, 'mario')
-            self.assertEqual(second.name, 'mario')
+            # Not using tm.assert_index_equal() since names differ.
+            assert index.equals(first)
+
+            assert first.name == 'mario'
+            assert second.name == 'mario'
 
             s1 = Series(2, index=first)
             s2 = Series(3, index=second[:-1])
-            if not isinstance(index, CategoricalIndex):  # See GH13365
+
+            if not isinstance(index, CategoricalIndex):
+                # See gh-13365
                 s3 = s1 * s2
-                self.assertEqual(s3.index.name, 'mario')
+                assert s3.index.name == 'mario'
 
     def test_ensure_copied_data(self):
         # Check the "copy" argument of each Index.__new__ is honoured
@@ -283,11 +287,11 @@ class Base(object):
 
             for func in (copy, deepcopy):
                 idx_copy = func(ind)
-                self.assertIsNot(idx_copy, ind)
-                self.assertTrue(idx_copy.equals(ind))
+                assert idx_copy is not ind
+                assert idx_copy.equals(ind)
 
             new_copy = ind.copy(deep=True, name="banana")
-            self.assertEqual(new_copy.name, "banana")
+            assert new_copy.name == "banana"
 
     def test_duplicates(self):
         for ind in self.indices.values():

--- a/pandas/tests/indexes/test_base.py
+++ b/pandas/tests/indexes/test_base.py
@@ -1851,22 +1851,22 @@ class TestMixedIntIndex(Base, tm.TestCase):
         second = first.__class__(first, copy=False)
 
         # Even though "copy=False", we want a new object.
-        self.assertIsNot(first, second)
+        assert first is not second
         # Not using tm.assert_index_equal() since names differ:
-        self.assertTrue(idx.equals(first))
+        assert idx.equals(first)
 
-        self.assertEqual(first.name, 'mario')
-        self.assertEqual(second.name, 'mario')
+        assert first.name == 'mario'
+        assert second.name == 'mario'
 
         s1 = Series(2, index=first)
         s2 = Series(3, index=second[:-1])
-        if PY3:
-            with tm.assert_produces_warning(RuntimeWarning):
-                # unorderable types
-                s3 = s1 * s2
-        else:
+
+        warning_type = RuntimeWarning if PY3 else None
+        with tm.assert_produces_warning(warning_type):
+            # Python 3: Unorderable types
             s3 = s1 * s2
-        self.assertEqual(s3.index.name, 'mario')
+
+        assert s3.index.name == 'mario'
 
     def test_copy_name2(self):
         # Check that adding a "name" parameter to the copy is honored

--- a/pandas/tests/indexes/test_category.py
+++ b/pandas/tests/indexes/test_category.py
@@ -536,18 +536,20 @@ class TestCategoricalIndex(Base, tm.TestCase):
         self.assertFalse(ci1.identical(ci2))
 
     def test_ensure_copied_data(self):
-        # Check the "copy" argument of each Index.__new__ is honoured
-        # GH12309
+        # gh-12309: Check the "copy" argument of each
+        # Index.__new__ is honored.
+        #
         # Must be tested separately from other indexes because
-        # self.value is not an ndarray
+        # self.value is not an ndarray.
         _base = lambda ar: ar if ar.base is None else ar.base
+
         for index in self.indices.values():
             result = CategoricalIndex(index.values, copy=True)
             tm.assert_index_equal(index, result)
-            self.assertIsNot(_base(index.values), _base(result.values))
+            assert _base(index.values) is not _base(result.values)
 
             result = CategoricalIndex(index.values, copy=False)
-            self.assertIs(_base(index.values), _base(result.values))
+            assert _base(index.values) is _base(result.values)
 
     def test_equals_categorical(self):
         ci1 = CategoricalIndex(['a', 'b'], categories=['a', 'b'], ordered=True)

--- a/pandas/tests/indexes/test_frozen.py
+++ b/pandas/tests/indexes/test_frozen.py
@@ -42,13 +42,13 @@ class TestFrozenNDArray(CheckImmutable, CheckStringMixin, tm.TestCase):
 
     def test_shallow_copying(self):
         original = self.container.copy()
-        self.assertIsInstance(self.container.view(), FrozenNDArray)
-        self.assertFalse(isinstance(
-            self.container.view(np.ndarray), FrozenNDArray))
-        self.assertIsNot(self.container.view(), self.container)
-        self.assert_numpy_array_equal(self.container, original)
-        # shallow copy should be the same too
-        self.assertIsInstance(self.container._shallow_copy(), FrozenNDArray)
+        assert isinstance(self.container.view(), FrozenNDArray)
+        assert not isinstance(self.container.view(np.ndarray), FrozenNDArray)
+        assert self.container.view() is not self.container
+        tm.assert_numpy_array_equal(self.container, original)
+
+        # Shallow copy should be the same too
+        assert isinstance(self.container._shallow_copy(), FrozenNDArray)
 
         # setting should not be allowed
         def testit(container):
@@ -59,10 +59,13 @@ class TestFrozenNDArray(CheckImmutable, CheckStringMixin, tm.TestCase):
     def test_values(self):
         original = self.container.view(np.ndarray).copy()
         n = original[0] + 15
+
         vals = self.container.values()
-        self.assert_numpy_array_equal(original, vals)
-        self.assertIsNot(original, vals)
+        tm.assert_numpy_array_equal(original, vals)
+
+        assert original is not vals
         vals[0] = n
-        self.assertIsInstance(self.container, FrozenNDArray)
-        self.assert_numpy_array_equal(self.container.values(), original)
-        self.assertEqual(vals[0], n)
+
+        assert isinstance(self.container, FrozenNDArray)
+        tm.assert_numpy_array_equal(self.container.values(), original)
+        assert vals[0] == n

--- a/pandas/tests/indexes/test_interval.py
+++ b/pandas/tests/indexes/test_interval.py
@@ -165,11 +165,11 @@ class TestIntervalIndex(Base, tm.TestCase):
 
     def test_copy(self):
         actual = self.index.copy()
-        self.assertTrue(actual.equals(self.index))
+        assert actual.equals(self.index)
 
         actual = self.index.copy(deep=True)
-        self.assertTrue(actual.equals(self.index))
-        self.assertIsNot(actual.left, self.index.left)
+        assert actual.equals(self.index)
+        assert actual.left is not self.index.left
 
     def test_ensure_copied_data(self):
         # exercise the copy flag in the constructor

--- a/pandas/tests/indexes/test_multi.py
+++ b/pandas/tests/indexes/test_multi.py
@@ -584,21 +584,20 @@ class TestMultiIndex(Base, tm.TestCase):
                 self.index.copy().labels = [[0, 0, 0, 0], [0, 0]]
 
     def assert_multiindex_copied(self, copy, original):
-        # levels should be (at least, shallow copied)
-        assert_copy(copy.levels, original.levels)
+        # Levels should be (at least, shallow copied)
+        tm.assert_copy(copy.levels, original.levels)
+        tm.assert_almost_equal(copy.labels, original.labels)
 
-        assert_almost_equal(copy.labels, original.labels)
+        # Labels doesn't matter which way copied
+        tm.assert_almost_equal(copy.labels, original.labels)
+        assert copy.labels is not original.labels
 
-        # labels doesn't matter which way copied
-        assert_almost_equal(copy.labels, original.labels)
-        self.assertIsNot(copy.labels, original.labels)
+        # Names doesn't matter which way copied
+        assert copy.names == original.names
+        assert copy.names is not original.names
 
-        # names doesn't matter which way copied
-        self.assertEqual(copy.names, original.names)
-        self.assertIsNot(copy.names, original.names)
-
-        # sort order should be copied
-        self.assertEqual(copy.sortorder, original.sortorder)
+        # Sort order should be copied
+        assert copy.sortorder == original.sortorder
 
     def test_copy(self):
         i_copy = self.index.copy()

--- a/pandas/tests/series/test_apply.py
+++ b/pandas/tests/series/test_apply.py
@@ -18,11 +18,11 @@ class TestSeriesApply(TestData, tm.TestCase):
 
     def test_apply(self):
         with np.errstate(all='ignore'):
-            assert_series_equal(self.ts.apply(np.sqrt), np.sqrt(self.ts))
+            tm.assert_series_equal(self.ts.apply(np.sqrt), np.sqrt(self.ts))
 
-            # elementwise-apply
+            # element-wise apply
             import math
-            assert_series_equal(self.ts.apply(math.exp), np.exp(self.ts))
+            tm.assert_series_equal(self.ts.apply(math.exp), np.exp(self.ts))
 
         # empty series
         s = Series(dtype=object, name='foo', index=pd.Index([], name='bar'))
@@ -30,10 +30,10 @@ class TestSeriesApply(TestData, tm.TestCase):
         tm.assert_series_equal(s, rs)
 
         # check all metadata (GH 9322)
-        self.assertIsNot(s, rs)
-        self.assertIs(s.index, rs.index)
-        self.assertEqual(s.dtype, rs.dtype)
-        self.assertEqual(s.name, rs.name)
+        assert s is not rs
+        assert s.index is rs.index
+        assert s.dtype == rs.dtype
+        assert s.name == rs.name
 
         # index but no data
         s = Series(index=[1, 2, 3])

--- a/pandas/tests/series/test_timeseries.py
+++ b/pandas/tests/series/test_timeseries.py
@@ -240,25 +240,25 @@ class TestTimeSeries(TestData, tm.TestCase):
 
         daily_ts = ts.asfreq('B')
         monthly_ts = daily_ts.asfreq('BM')
-        assert_series_equal(monthly_ts, ts)
+        tm.assert_series_equal(monthly_ts, ts)
 
         daily_ts = ts.asfreq('B', method='pad')
         monthly_ts = daily_ts.asfreq('BM')
-        assert_series_equal(monthly_ts, ts)
+        tm.assert_series_equal(monthly_ts, ts)
 
         daily_ts = ts.asfreq(BDay())
         monthly_ts = daily_ts.asfreq(BMonthEnd())
-        assert_series_equal(monthly_ts, ts)
+        tm.assert_series_equal(monthly_ts, ts)
 
         result = ts[:0].asfreq('M')
-        self.assertEqual(len(result), 0)
-        self.assertIsNot(result, ts)
+        assert len(result) == 0
+        assert result is not ts
 
         daily_ts = ts.asfreq('D', fill_value=-1)
         result = daily_ts.value_counts().sort_index()
         expected = Series([60, 1, 1, 1],
                           index=[-1.0, 2.0, 1.0, 0.0]).sort_index()
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
     def test_asfreq_datetimeindex_empty_series(self):
         # GH 14320

--- a/pandas/tests/test_generic.py
+++ b/pandas/tests/test_generic.py
@@ -687,7 +687,7 @@ class Generic(object):
                          lambda x: x.copy(deep=False),
                          lambda x: x.copy(deep=True)]:
                 obj_copy = func(obj)
-                self.assertIsNot(obj_copy, obj)
+                assert obj_copy is not obj
                 self._compare(obj_copy, obj)
 
 

--- a/pandas/tests/test_internals.py
+++ b/pandas/tests/test_internals.py
@@ -248,7 +248,7 @@ class TestBlock(tm.TestCase):
 
     def test_copy(self):
         cop = self.fblock.copy()
-        self.assertIsNot(cop, self.fblock)
+        assert cop is not self.fblock
         assert_block_equal(self.fblock, cop)
 
     def test_reindex_index(self):

--- a/pandas/tests/test_panel.py
+++ b/pandas/tests/test_panel.py
@@ -883,20 +883,20 @@ class CheckIndexing(object):
                 for mjr in self.panel.major_axis[::2]:
                     for mnr in self.panel.minor_axis:
                         self.panel.set_value(item, mjr, mnr, 1.)
-                        assert_almost_equal(self.panel[item][mnr][mjr], 1.)
+                        tm.assert_almost_equal(self.panel[item][mnr][mjr], 1.)
 
             # resize
             res = self.panel.set_value('ItemE', 'foo', 'bar', 1.5)
-            tm.assertIsInstance(res, Panel)
-            self.assertIsNot(res, self.panel)
-            self.assertEqual(res.get_value('ItemE', 'foo', 'bar'), 1.5)
+            assert isinstance(res, Panel)
+            assert res is not self.panel
+            assert res.get_value('ItemE', 'foo', 'bar') == 1.5
 
             res3 = self.panel.set_value('ItemE', 'foobar', 'baz', 5)
-            self.assertTrue(is_float_dtype(res3['ItemE'].values))
-            with tm.assertRaisesRegexp(TypeError,
-                                       "There must be an argument "
-                                       "for each axis"
-                                       " plus the value provided"):
+            assert is_float_dtype(res3['ItemE'].values)
+
+            msg = ("There must be an argument for each "
+                   "axis plus the value provided")
+            with tm.assertRaisesRegexp(TypeError, msg):
                 self.panel.set_value('a')
 
 

--- a/pandas/tests/test_panel4d.py
+++ b/pandas/tests/test_panel4d.py
@@ -587,20 +587,20 @@ class CheckIndexing(object):
                     for mjr in self.panel4d.major_axis[::2]:
                         for mnr in self.panel4d.minor_axis:
                             self.panel4d.set_value(label, item, mjr, mnr, 1.)
-                            assert_almost_equal(
+                            tm.assert_almost_equal(
                                 self.panel4d[label][item][mnr][mjr], 1.)
 
             res3 = self.panel4d.set_value('l4', 'ItemE', 'foobar', 'baz', 5)
-            self.assertTrue(is_float_dtype(res3['l4'].values))
+            assert is_float_dtype(res3['l4'].values)
 
             # resize
             res = self.panel4d.set_value('l4', 'ItemE', 'foo', 'bar', 1.5)
-            tm.assertIsInstance(res, Panel4D)
-            self.assertIsNot(res, self.panel4d)
-            self.assertEqual(res.get_value('l4', 'ItemE', 'foo', 'bar'), 1.5)
+            assert isinstance(res, Panel4D)
+            assert res is not self.panel4d
+            assert res.get_value('l4', 'ItemE', 'foo', 'bar') == 1.5
 
             res3 = self.panel4d.set_value('l4', 'ItemE', 'foobar', 'baz', 5)
-            self.assertTrue(is_float_dtype(res3['l4'].values))
+            assert is_float_dtype(res3['l4'].values)
 
 
 class TestPanel4d(tm.TestCase, CheckIndexing, SafeForSparse,
@@ -619,21 +619,21 @@ class TestPanel4d(tm.TestCase, CheckIndexing, SafeForSparse,
 
         with catch_warnings(record=True):
             panel4d = Panel4D(self.panel4d._data)
-            self.assertIs(panel4d._data, self.panel4d._data)
+            assert panel4d._data is self.panel4d._data
 
             panel4d = Panel4D(self.panel4d._data, copy=True)
-            self.assertIsNot(panel4d._data, self.panel4d._data)
-            assert_panel4d_equal(panel4d, self.panel4d)
+            assert panel4d._data is not self.panel4d._data
+            tm.assert_panel4d_equal(panel4d, self.panel4d)
 
             vals = self.panel4d.values
 
             # no copy
             panel4d = Panel4D(vals)
-            self.assertIs(panel4d.values, vals)
+            assert panel4d.values is vals
 
             # copy
             panel4d = Panel4D(vals, copy=True)
-            self.assertIsNot(panel4d.values, vals)
+            assert panel4d.values is not vals
 
             # GH #8285, test when scalar data is used to construct a Panel4D
             # if dtype is not passed, it should be inferred
@@ -645,7 +645,7 @@ class TestPanel4d(tm.TestCase, CheckIndexing, SafeForSparse,
                 vals = np.empty((2, 3, 4, 5), dtype=dtype)
                 vals.fill(val)
                 expected = Panel4D(vals, dtype=dtype)
-                assert_panel4d_equal(panel4d, expected)
+                tm.assert_panel4d_equal(panel4d, expected)
 
             # test the case when dtype is passed
             panel4d = Panel4D(1, labels=range(2), items=range(
@@ -654,7 +654,7 @@ class TestPanel4d(tm.TestCase, CheckIndexing, SafeForSparse,
             vals.fill(1)
 
             expected = Panel4D(vals, dtype='float32')
-            assert_panel4d_equal(panel4d, expected)
+            tm.assert_panel4d_equal(panel4d, expected)
 
     def test_constructor_cast(self):
         with catch_warnings(record=True):

--- a/pandas/tests/tools/test_concat.py
+++ b/pandas/tests/tools/test_concat.py
@@ -12,8 +12,7 @@ from pandas import (DataFrame, concat,
                     DatetimeIndex)
 from pandas.util import testing as tm
 from pandas.util.testing import (assert_frame_equal,
-                                 makeCustomDataframe as mkdf,
-                                 assert_almost_equal)
+                                 makeCustomDataframe as mkdf)
 
 import pytest
 
@@ -708,25 +707,25 @@ class TestAppend(ConcatenateBase):
         end_frame = self.frame.reindex(end_index)
 
         appended = begin_frame.append(end_frame)
-        assert_almost_equal(appended['A'], self.frame['A'])
+        tm.assert_almost_equal(appended['A'], self.frame['A'])
 
         del end_frame['A']
         partial_appended = begin_frame.append(end_frame)
-        self.assertIn('A', partial_appended)
+        assert 'A' in partial_appended
 
         partial_appended = end_frame.append(begin_frame)
-        self.assertIn('A', partial_appended)
+        assert 'A' in partial_appended
 
         # mixed type handling
         appended = self.mixed_frame[:5].append(self.mixed_frame[5:])
-        assert_frame_equal(appended, self.mixed_frame)
+        tm.assert_frame_equal(appended, self.mixed_frame)
 
         # what to test here
         mixed_appended = self.mixed_frame[:5].append(self.frame[5:])
         mixed_appended2 = self.frame[:5].append(self.mixed_frame[5:])
 
         # all equal except 'foo' column
-        assert_frame_equal(
+        tm.assert_frame_equal(
             mixed_appended.reindex(columns=['A', 'B', 'C', 'D']),
             mixed_appended2.reindex(columns=['A', 'B', 'C', 'D']))
 
@@ -734,25 +733,24 @@ class TestAppend(ConcatenateBase):
         empty = DataFrame({})
 
         appended = self.frame.append(empty)
-        assert_frame_equal(self.frame, appended)
-        self.assertIsNot(appended, self.frame)
+        tm.assert_frame_equal(self.frame, appended)
+        assert appended is not self.frame
 
         appended = empty.append(self.frame)
-        assert_frame_equal(self.frame, appended)
-        self.assertIsNot(appended, self.frame)
+        tm.assert_frame_equal(self.frame, appended)
+        assert appended is not self.frame
 
-        # overlap
-        self.assertRaises(ValueError, self.frame.append, self.frame,
-                          verify_integrity=True)
+        # Overlap
+        with pytest.raises(ValueError):
+            self.frame.append(self.frame, verify_integrity=True)
 
-        # new columns
-        # GH 6129
+        # see gh-6129: new columns
         df = DataFrame({'a': {'x': 1, 'y': 2}, 'b': {'x': 3, 'y': 4}})
         row = Series([5, 6, 7], index=['a', 'b', 'c'], name='z')
         expected = DataFrame({'a': {'x': 1, 'y': 2, 'z': 5}, 'b': {
                              'x': 3, 'y': 4, 'z': 6}, 'c': {'z': 7}})
         result = df.append(row)
-        assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
     def test_append_length0_frame(self):
         df = DataFrame(columns=['A', 'B', 'C'])

--- a/pandas/util/testing.py
+++ b/pandas/util/testing.py
@@ -1043,12 +1043,6 @@ def assertIs(first, second, msg=''):
     assert a is b, "%s: %r is not %r" % (msg.format(a, b), a, b)
 
 
-def assertIsNot(first, second, msg=''):
-    """Checks that 'first' is not 'second'"""
-    a, b = first, second
-    assert a is not b, "%s: %r is %r" % (msg.format(a, b), a, b)
-
-
 def assertIn(first, second, msg=''):
     """Checks that 'first' is in 'second'"""
     a, b = first, second
@@ -1068,7 +1062,7 @@ def assertIsNone(expr, msg=''):
 
 def assertIsNotNone(expr, msg=''):
     """Checks that 'expr' is not None"""
-    return assertIsNot(expr, None, msg)
+    assert expr is not None, msg
 
 
 def assertIsInstance(obj, cls, msg=''):
@@ -1178,10 +1172,17 @@ def assert_numpy_array_equal(left, right, strict_nan=False,
     def _get_base(obj):
         return obj.base if getattr(obj, 'base', None) is not None else obj
 
+    left_base = _get_base(left)
+    right_base = _get_base(right)
+
     if check_same == 'same':
-        assertIs(_get_base(left), _get_base(right))
+        if left_base is not right_base:
+            msg = "%r is not %r" % (left_base, right_base)
+            raise AssertionError(msg)
     elif check_same == 'copy':
-        assertIsNot(_get_base(left), _get_base(right))
+        if left_base is right_base:
+            msg = "%r is %r" % (left_base, right_base)
+            raise AssertionError(msg)
 
     def _raise(left, right, err_msg):
         if err_msg is None:


### PR DESCRIPTION
Title is self-explanatory.  Also clean up other non-`pytest` idioms where I was removing `assertIsNot`.

Partially addresses #15990.
