### PR TITLE
MAINT: Remove assertIsNotNone from testing

### DIFF
--- a/pandas/tests/core/computation/test_eval.py
+++ b/pandas/tests/core/computation/test_eval.py
@@ -1308,16 +1308,17 @@ class TestOperationsNumExprPandas(tm.TestCase):
         assert_series_equal(result, expected)
 
     def assignment_not_inplace(self):
-        # GH 9297
+        # see gh-9297
         df = DataFrame(np.random.randn(5, 2), columns=list('ab'))
 
         actual = df.eval('c = a + b', inplace=False)
-        self.assertIsNotNone(actual)
+        assert actual is not None
+
         expected = df.copy()
         expected['c'] = expected['a'] + expected['b']
-        assert_frame_equal(df, expected)
+        tm.assert_frame_equal(df, expected)
 
-        # default for inplace will change
+        # Default for inplace will change
         with tm.assert_produces_warnings(FutureWarning):
             df.eval('c = a + b')
 

--- a/pandas/tests/indexes/datetimes/test_construction.py
+++ b/pandas/tests/indexes/datetimes/test_construction.py
@@ -53,15 +53,14 @@ class TestDatetimeIndex(tm.TestCase):
             i.tz_localize(None).asi8, dtype=i.dtype, tz='US/Pacific'))
 
     def test_construction_index_with_mixed_timezones(self):
-        # GH 11488
-        # no tz results in DatetimeIndex
+        # gh-11488: no tz results in DatetimeIndex
         result = Index([Timestamp('2011-01-01'),
                         Timestamp('2011-01-02')], name='idx')
         exp = DatetimeIndex([Timestamp('2011-01-01'),
                              Timestamp('2011-01-02')], name='idx')
-        self.assert_index_equal(result, exp, exact=True)
-        self.assertTrue(isinstance(result, DatetimeIndex))
-        self.assertIsNone(result.tz)
+        tm.assert_index_equal(result, exp, exact=True)
+        assert isinstance(result, DatetimeIndex)
+        assert result.tz is None
 
         # same tz results in DatetimeIndex
         result = Index([Timestamp('2011-01-01 10:00', tz='Asia/Tokyo'),
@@ -70,10 +69,10 @@ class TestDatetimeIndex(tm.TestCase):
         exp = DatetimeIndex(
             [Timestamp('2011-01-01 10:00'), Timestamp('2011-01-02 10:00')
              ], tz='Asia/Tokyo', name='idx')
-        self.assert_index_equal(result, exp, exact=True)
-        self.assertTrue(isinstance(result, DatetimeIndex))
-        self.assertIsNotNone(result.tz)
-        self.assertEqual(result.tz, exp.tz)
+        tm.assert_index_equal(result, exp, exact=True)
+        assert isinstance(result, DatetimeIndex)
+        assert result.tz is not None
+        assert result.tz == exp.tz
 
         # same tz results in DatetimeIndex (DST)
         result = Index([Timestamp('2011-01-01 10:00', tz='US/Eastern'),
@@ -82,20 +81,20 @@ class TestDatetimeIndex(tm.TestCase):
         exp = DatetimeIndex([Timestamp('2011-01-01 10:00'),
                              Timestamp('2011-08-01 10:00')],
                             tz='US/Eastern', name='idx')
-        self.assert_index_equal(result, exp, exact=True)
-        self.assertTrue(isinstance(result, DatetimeIndex))
-        self.assertIsNotNone(result.tz)
-        self.assertEqual(result.tz, exp.tz)
+        tm.assert_index_equal(result, exp, exact=True)
+        assert isinstance(result, DatetimeIndex)
+        assert result.tz is not None
+        assert result.tz == exp.tz
 
-        # different tz results in Index(dtype=object)
+        # Different tz results in Index(dtype=object)
         result = Index([Timestamp('2011-01-01 10:00'),
                         Timestamp('2011-01-02 10:00', tz='US/Eastern')],
                        name='idx')
         exp = Index([Timestamp('2011-01-01 10:00'),
                      Timestamp('2011-01-02 10:00', tz='US/Eastern')],
                     dtype='object', name='idx')
-        self.assert_index_equal(result, exp, exact=True)
-        self.assertFalse(isinstance(result, DatetimeIndex))
+        tm.assert_index_equal(result, exp, exact=True)
+        assert not isinstance(result, DatetimeIndex)
 
         result = Index([Timestamp('2011-01-01 10:00', tz='Asia/Tokyo'),
                         Timestamp('2011-01-02 10:00', tz='US/Eastern')],
@@ -103,37 +102,37 @@ class TestDatetimeIndex(tm.TestCase):
         exp = Index([Timestamp('2011-01-01 10:00', tz='Asia/Tokyo'),
                      Timestamp('2011-01-02 10:00', tz='US/Eastern')],
                     dtype='object', name='idx')
-        self.assert_index_equal(result, exp, exact=True)
-        self.assertFalse(isinstance(result, DatetimeIndex))
+        tm.assert_index_equal(result, exp, exact=True)
+        assert not isinstance(result, DatetimeIndex)
 
         # length = 1
         result = Index([Timestamp('2011-01-01')], name='idx')
         exp = DatetimeIndex([Timestamp('2011-01-01')], name='idx')
-        self.assert_index_equal(result, exp, exact=True)
-        self.assertTrue(isinstance(result, DatetimeIndex))
-        self.assertIsNone(result.tz)
+        tm.assert_index_equal(result, exp, exact=True)
+        assert isinstance(result, DatetimeIndex)
+        assert result.tz is None
 
         # length = 1 with tz
         result = Index(
             [Timestamp('2011-01-01 10:00', tz='Asia/Tokyo')], name='idx')
         exp = DatetimeIndex([Timestamp('2011-01-01 10:00')], tz='Asia/Tokyo',
                             name='idx')
-        self.assert_index_equal(result, exp, exact=True)
-        self.assertTrue(isinstance(result, DatetimeIndex))
-        self.assertIsNotNone(result.tz)
-        self.assertEqual(result.tz, exp.tz)
+        tm.assert_index_equal(result, exp, exact=True)
+        assert isinstance(result, DatetimeIndex)
+        assert result.tz is not None
+        assert result.tz == exp.tz
 
     def test_construction_index_with_mixed_timezones_with_NaT(self):
-        # GH 11488
+        # see gh-11488
         result = Index([pd.NaT, Timestamp('2011-01-01'),
                         pd.NaT, Timestamp('2011-01-02')], name='idx')
         exp = DatetimeIndex([pd.NaT, Timestamp('2011-01-01'),
                              pd.NaT, Timestamp('2011-01-02')], name='idx')
-        self.assert_index_equal(result, exp, exact=True)
-        self.assertTrue(isinstance(result, DatetimeIndex))
-        self.assertIsNone(result.tz)
+        tm.assert_index_equal(result, exp, exact=True)
+        assert isinstance(result, DatetimeIndex)
+        assert result.tz is None
 
-        # same tz results in DatetimeIndex
+        # Same tz results in DatetimeIndex
         result = Index([pd.NaT, Timestamp('2011-01-01 10:00', tz='Asia/Tokyo'),
                         pd.NaT, Timestamp('2011-01-02 10:00',
                                           tz='Asia/Tokyo')],
@@ -141,10 +140,10 @@ class TestDatetimeIndex(tm.TestCase):
         exp = DatetimeIndex([pd.NaT, Timestamp('2011-01-01 10:00'),
                              pd.NaT, Timestamp('2011-01-02 10:00')],
                             tz='Asia/Tokyo', name='idx')
-        self.assert_index_equal(result, exp, exact=True)
-        self.assertTrue(isinstance(result, DatetimeIndex))
-        self.assertIsNotNone(result.tz)
-        self.assertEqual(result.tz, exp.tz)
+        tm.assert_index_equal(result, exp, exact=True)
+        assert isinstance(result, DatetimeIndex)
+        assert result.tz is not None
+        assert result.tz == exp.tz
 
         # same tz results in DatetimeIndex (DST)
         result = Index([Timestamp('2011-01-01 10:00', tz='US/Eastern'),
@@ -154,10 +153,10 @@ class TestDatetimeIndex(tm.TestCase):
         exp = DatetimeIndex([Timestamp('2011-01-01 10:00'), pd.NaT,
                              Timestamp('2011-08-01 10:00')],
                             tz='US/Eastern', name='idx')
-        self.assert_index_equal(result, exp, exact=True)
-        self.assertTrue(isinstance(result, DatetimeIndex))
-        self.assertIsNotNone(result.tz)
-        self.assertEqual(result.tz, exp.tz)
+        tm.assert_index_equal(result, exp, exact=True)
+        assert isinstance(result, DatetimeIndex)
+        assert result.tz is not None
+        assert result.tz == exp.tz
 
         # different tz results in Index(dtype=object)
         result = Index([pd.NaT, Timestamp('2011-01-01 10:00'),
@@ -167,8 +166,8 @@ class TestDatetimeIndex(tm.TestCase):
         exp = Index([pd.NaT, Timestamp('2011-01-01 10:00'),
                      pd.NaT, Timestamp('2011-01-02 10:00', tz='US/Eastern')],
                     dtype='object', name='idx')
-        self.assert_index_equal(result, exp, exact=True)
-        self.assertFalse(isinstance(result, DatetimeIndex))
+        tm.assert_index_equal(result, exp, exact=True)
+        assert not isinstance(result, DatetimeIndex)
 
         result = Index([pd.NaT, Timestamp('2011-01-01 10:00', tz='Asia/Tokyo'),
                         pd.NaT, Timestamp('2011-01-02 10:00',
@@ -176,23 +175,24 @@ class TestDatetimeIndex(tm.TestCase):
         exp = Index([pd.NaT, Timestamp('2011-01-01 10:00', tz='Asia/Tokyo'),
                      pd.NaT, Timestamp('2011-01-02 10:00', tz='US/Eastern')],
                     dtype='object', name='idx')
-        self.assert_index_equal(result, exp, exact=True)
-        self.assertFalse(isinstance(result, DatetimeIndex))
+        tm.assert_index_equal(result, exp, exact=True)
+        assert not isinstance(result, DatetimeIndex)
 
         # all NaT
         result = Index([pd.NaT, pd.NaT], name='idx')
         exp = DatetimeIndex([pd.NaT, pd.NaT], name='idx')
-        self.assert_index_equal(result, exp, exact=True)
-        self.assertTrue(isinstance(result, DatetimeIndex))
-        self.assertIsNone(result.tz)
+        tm.assert_index_equal(result, exp, exact=True)
+        assert isinstance(result, DatetimeIndex)
+        assert result.tz is None
 
         # all NaT with tz
         result = Index([pd.NaT, pd.NaT], tz='Asia/Tokyo', name='idx')
         exp = DatetimeIndex([pd.NaT, pd.NaT], tz='Asia/Tokyo', name='idx')
-        self.assert_index_equal(result, exp, exact=True)
-        self.assertTrue(isinstance(result, DatetimeIndex))
-        self.assertIsNotNone(result.tz)
-        self.assertEqual(result.tz, exp.tz)
+
+        tm.assert_index_equal(result, exp, exact=True)
+        assert isinstance(result, DatetimeIndex)
+        assert result.tz is not None
+        assert result.tz == exp.tz
 
     def test_construction_dti_with_mixed_timezones(self):
         # GH 11488 (not changed, added explicit tests)

--- a/pandas/tests/indexes/datetimes/test_ops.py
+++ b/pandas/tests/indexes/datetimes/test_ops.py
@@ -1122,7 +1122,7 @@ class TestBusinessDatetimeIndex(tm.TestCase):
 
     def test_pickle_unpickle(self):
         unpickled = tm.round_trip_pickle(self.rng)
-        self.assertIsNotNone(unpickled.offset)
+        assert unpickled.offset is not None
 
     def test_copy(self):
         cp = self.rng.copy()
@@ -1273,7 +1273,7 @@ class TestCustomDatetimeIndex(tm.TestCase):
 
     def test_pickle_unpickle(self):
         unpickled = tm.round_trip_pickle(self.rng)
-        self.assertIsNotNone(unpickled.offset)
+        assert unpickled.offset is not None
 
     def test_summary(self):
         self.rng.summary()

--- a/pandas/tests/indexes/test_multi.py
+++ b/pandas/tests/indexes/test_multi.py
@@ -393,39 +393,46 @@ class TestMultiIndex(Base, tm.TestCase):
         levels = [['a', 'b', 'c'], [4]]
         levels2 = [[1, 2, 3], ['a']]
         labels = [[0, 1, 0, 2, 2, 0], [0, 0, 0, 0, 0, 0]]
+
         mi1 = MultiIndex(levels=levels, labels=labels)
         mi2 = MultiIndex(levels=levels2, labels=labels)
         vals = mi1.values.copy()
         vals2 = mi2.values.copy()
-        self.assertIsNotNone(mi1._tuples)
 
-        # make sure level setting works
+        assert mi1._tuples is not None
+
+        # Make sure level setting works
         new_vals = mi1.set_levels(levels2).values
-        assert_almost_equal(vals2, new_vals)
-        # non-inplace doesn't kill _tuples [implementation detail]
-        assert_almost_equal(mi1._tuples, vals)
-        # and values is still same too
-        assert_almost_equal(mi1.values, vals)
+        tm.assert_almost_equal(vals2, new_vals)
 
-        # inplace should kill _tuples
+        # Non-inplace doesn't kill _tuples [implementation detail]
+        tm.assert_almost_equal(mi1._tuples, vals)
+
+        # ...and values is still same too
+        tm.assert_almost_equal(mi1.values, vals)
+
+        # Inplace should kill _tuples
         mi1.set_levels(levels2, inplace=True)
-        assert_almost_equal(mi1.values, vals2)
+        tm.assert_almost_equal(mi1.values, vals2)
 
-        # make sure label setting works too
+        # Make sure label setting works too
         labels2 = [[0, 0, 0, 0, 0, 0], [0, 0, 0, 0, 0, 0]]
         exp_values = np.empty((6, ), dtype=object)
         exp_values[:] = [(long(1), 'a')] * 6
-        # must be 1d array of tuples
-        self.assertEqual(exp_values.shape, (6, ))
-        new_values = mi2.set_labels(labels2).values
-        # not inplace shouldn't change
-        assert_almost_equal(mi2._tuples, vals2)
-        # should have correct values
-        assert_almost_equal(exp_values, new_values)
 
-        # and again setting inplace should kill _tuples, etc
+        # Must be 1d array of tuples
+        assert exp_values.shape == (6, )
+        new_values = mi2.set_labels(labels2).values
+
+        # Not inplace shouldn't change
+        tm.assert_almost_equal(mi2._tuples, vals2)
+
+        # Should have correct values
+        tm.assert_almost_equal(exp_values, new_values)
+
+        # ...and again setting inplace should kill _tuples, etc
         mi2.set_labels(labels2, inplace=True)
-        assert_almost_equal(mi2.values, new_values)
+        tm.assert_almost_equal(mi2.values, new_values)
 
     def test_copy_in_constructor(self):
         levels = np.array(["a", "b", "c"])

--- a/pandas/tests/indexing/test_chaining_and_caching.py
+++ b/pandas/tests/indexing/test_chaining_and_caching.py
@@ -1,5 +1,7 @@
 from warnings import catch_warnings
 
+import pytest
+
 import numpy as np
 import pandas as pd
 from pandas.core import common as com
@@ -134,7 +136,8 @@ class TestChaining(tm.TestCase):
         expected = DataFrame([[-5, 1], [-6, 3]], columns=list('AB'))
         df = DataFrame(np.arange(4).reshape(2, 2),
                        columns=list('AB'), dtype='int64')
-        self.assertIsNone(df.is_copy)
+        assert df.is_copy is None
+
         df['A'][0] = -5
         df['A'][1] = -6
         tm.assert_frame_equal(df, expected)
@@ -142,71 +145,56 @@ class TestChaining(tm.TestCase):
         # test with the chaining
         df = DataFrame({'A': Series(range(2), dtype='int64'),
                         'B': np.array(np.arange(2, 4), dtype=np.float64)})
-        self.assertIsNone(df.is_copy)
+        assert df.is_copy is None
 
-        def f():
+        with pytest.raises(com.SettingWithCopyError):
             df['A'][0] = -5
 
-        self.assertRaises(com.SettingWithCopyError, f)
-
-        def f():
+        with pytest.raises(com.SettingWithCopyError):
             df['A'][1] = np.nan
 
-        self.assertRaises(com.SettingWithCopyError, f)
-        self.assertIsNone(df['A'].is_copy)
+        assert df['A'].is_copy is None
 
-        # using a copy (the chain), fails
+        # Using a copy (the chain), fails
         df = DataFrame({'A': Series(range(2), dtype='int64'),
                         'B': np.array(np.arange(2, 4), dtype=np.float64)})
 
-        def f():
+        with pytest.raises(com.SettingWithCopyError):
             df.loc[0]['A'] = -5
 
-        self.assertRaises(com.SettingWithCopyError, f)
-
-        # doc example
+        # Doc example
         df = DataFrame({'a': ['one', 'one', 'two', 'three',
                               'two', 'one', 'six'],
                         'c': Series(range(7), dtype='int64')})
-        self.assertIsNone(df.is_copy)
-        expected = DataFrame({'a': ['one', 'one', 'two', 'three',
-                                    'two', 'one', 'six'],
-                              'c': [42, 42, 2, 3, 4, 42, 6]})
+        assert df.is_copy is None
 
-        def f():
+        with pytest.raises(com.SettingWithCopyError):
             indexer = df.a.str.startswith('o')
             df[indexer]['c'] = 42
-
-        self.assertRaises(com.SettingWithCopyError, f)
 
         expected = DataFrame({'A': [111, 'bbb', 'ccc'], 'B': [1, 2, 3]})
         df = DataFrame({'A': ['aaa', 'bbb', 'ccc'], 'B': [1, 2, 3]})
 
-        def f():
+        with pytest.raises(com.SettingWithCopyError):
             df['A'][0] = 111
 
-        self.assertRaises(com.SettingWithCopyError, f)
-
-        def f():
+        with pytest.raises(com.SettingWithCopyError):
             df.loc[0]['A'] = 111
-
-        self.assertRaises(com.SettingWithCopyError, f)
 
         df.loc[0, 'A'] = 111
         tm.assert_frame_equal(df, expected)
 
-        # make sure that is_copy is picked up reconstruction
-        # GH5475
+        # gh-5475: Make sure that is_copy is picked up reconstruction
         df = DataFrame({"A": [1, 2]})
-        self.assertIsNone(df.is_copy)
+        assert df.is_copy is None
+
         with tm.ensure_clean('__tmp__pickle') as path:
             df.to_pickle(path)
             df2 = pd.read_pickle(path)
             df2["B"] = df2["A"]
             df2["B"] = df2["A"]
 
-        # a suprious raise as we are setting the entire column here
-        # GH5597
+        # gh-5597: a spurious raise as we are setting the entire column here
         from string import ascii_letters as letters
 
         def random_text(nobs=100):
@@ -214,42 +202,48 @@ class TestChaining(tm.TestCase):
             for i in range(nobs):
                 idx = np.random.randint(len(letters), size=2)
                 idx.sort()
+
                 df.append([letters[idx[0]:idx[1]]])
 
             return DataFrame(df, columns=['letters'])
 
         df = random_text(100000)
 
-        # always a copy
+        # Always a copy
         x = df.iloc[[0, 1, 2]]
-        self.assertIsNotNone(x.is_copy)
-        x = df.iloc[[0, 1, 2, 4]]
-        self.assertIsNotNone(x.is_copy)
+        assert x.is_copy is not None
 
-        # explicity copy
+        x = df.iloc[[0, 1, 2, 4]]
+        assert x.is_copy is not None
+
+        # Explicitly copy
         indexer = df.letters.apply(lambda x: len(x) > 10)
         df = df.loc[indexer].copy()
-        self.assertIsNone(df.is_copy)
+
+        assert df.is_copy is None
         df['letters'] = df['letters'].apply(str.lower)
 
-        # implicity take
+        # Implicitly take
         df = random_text(100000)
         indexer = df.letters.apply(lambda x: len(x) > 10)
         df = df.loc[indexer]
-        self.assertIsNotNone(df.is_copy)
+
+        assert df.is_copy is not None
         df['letters'] = df['letters'].apply(str.lower)
 
-        # implicity take 2
+        # Implicitly take 2
         df = random_text(100000)
         indexer = df.letters.apply(lambda x: len(x) > 10)
+
         df = df.loc[indexer]
-        self.assertIsNotNone(df.is_copy)
+        assert df.is_copy is not None
         df.loc[:, 'letters'] = df['letters'].apply(str.lower)
 
-        # should be ok even though it's a copy!
-        self.assertIsNone(df.is_copy)
+        # Should be ok even though it's a copy!
+        assert df.is_copy is None
+
         df['letters'] = df['letters'].apply(str.lower)
-        self.assertIsNone(df.is_copy)
+        assert df.is_copy is None
 
         df = random_text(100000)
         indexer = df.letters.apply(lambda x: len(x) > 10)
@@ -258,11 +252,10 @@ class TestChaining(tm.TestCase):
 
         # an identical take, so no copy
         df = DataFrame({'a': [1]}).dropna()
-        self.assertIsNone(df.is_copy)
+        assert df.is_copy is None
         df['a'] += 1
 
-        # inplace ops
-        # original from:
+        # Inplace ops, originally from:
         # http://stackoverflow.com/questions/20508968/series-fillna-in-a-multiindex-dataframe-does-not-fill-is-this-a-bug
         a = [12, 23]
         b = [123, None]
@@ -277,23 +270,25 @@ class TestChaining(tm.TestCase):
         multiind = MultiIndex.from_tuples(tuples, names=['part', 'side'])
         zed = DataFrame(events, index=['a', 'b'], columns=multiind)
 
-        def f():
+        with pytest.raises(com.SettingWithCopyError):
             zed['eyes']['right'].fillna(value=555, inplace=True)
-
-        self.assertRaises(com.SettingWithCopyError, f)
 
         df = DataFrame(np.random.randn(10, 4))
         s = df.iloc[:, 0].sort_values()
+
         tm.assert_series_equal(s, df.iloc[:, 0].sort_values())
         tm.assert_series_equal(s, df[0].sort_values())
 
-        # false positives GH6025
+        # see gh-6025: false positives
         df = DataFrame({'column1': ['a', 'a', 'a'], 'column2': [4, 8, 9]})
         str(df)
+
         df['column1'] = df['column1'] + 'b'
         str(df)
+
         df = df[df['column2'] != 8]
         str(df)
+
         df['column1'] = df['column1'] + 'c'
         str(df)
 
@@ -302,32 +297,23 @@ class TestChaining(tm.TestCase):
         df = DataFrame(np.arange(0, 9), columns=['count'])
         df['group'] = 'b'
 
-        def f():
+        with pytest.raises(com.SettingWithCopyError):
             df.iloc[0:5]['group'] = 'a'
 
-        self.assertRaises(com.SettingWithCopyError, f)
-
-        # mixed type setting
-        # same dtype & changing dtype
+        # Mixed type setting but same dtype & changing dtype
         df = DataFrame(dict(A=date_range('20130101', periods=5),
                             B=np.random.randn(5),
                             C=np.arange(5, dtype='int64'),
                             D=list('abcde')))
 
-        def f():
+        with pytest.raises(com.SettingWithCopyError):
             df.loc[2]['D'] = 'foo'
 
-        self.assertRaises(com.SettingWithCopyError, f)
-
-        def f():
+        with pytest.raises(com.SettingWithCopyError):
             df.loc[2]['C'] = 'foo'
 
-        self.assertRaises(com.SettingWithCopyError, f)
-
-        def f():
+        with pytest.raises(com.SettingWithCopyError):
             df['C'][2] = 'foo'
-
-        self.assertRaises(com.SettingWithCopyError, f)
 
     def test_setting_with_copy_bug(self):
 

--- a/pandas/tests/io/formats/test_format.py
+++ b/pandas/tests/io/formats/test_format.py
@@ -1546,12 +1546,12 @@ c  10  11  12  13  14\
                                {'parent_appname': 'ipython-qtconsole'}}}
 
         repstr = self.frame._repr_html_()
-        self.assertIsNotNone(repstr)
+        assert repstr is not None
 
         fmt.set_option('display.max_rows', 5, 'display.max_columns', 2)
         repstr = self.frame._repr_html_()
-        self.assertIn('class', repstr)  # info fallback
 
+        assert 'class' in repstr  # info fallback
         tm.reset_display_options()
 
     def test_pprint_pathological_object(self):

--- a/pandas/tests/io/formats/test_printing.py
+++ b/pandas/tests/io/formats/test_printing.py
@@ -170,13 +170,15 @@ class TestTableSchemaRepr(tm.TestCase):
         df = pd.DataFrame({"A": [1, 2]})
         with pd.option_context("display.html.table_schema", True):
             result = df._repr_table_schema_()
-        self.assertIsNotNone(result)
+
+        assert result is not None
 
     def test_config_default_off(self):
         df = pd.DataFrame({"A": [1, 2]})
         with pd.option_context("display.html.table_schema", False):
             result = df._repr_table_schema_()
-        self.assertIsNone(result)
+
+        assert result is None
 
 
 # TODO: fix this broken test

--- a/pandas/tests/plotting/test_datetimelike.py
+++ b/pandas/tests/plotting/test_datetimelike.py
@@ -296,12 +296,14 @@ class TestTSPlot(TestPlotBase):
 
         fig = plt.gcf()
         plt.clf()
+
         ax = fig.add_subplot(211)
+
         ret = ser.plot()
-        self.assertIsNotNone(ret)
+        assert ret is not None
 
         for rs, xp in zip(ax.get_lines()[0].get_xdata(), ser.index):
-            self.assertEqual(rs, xp)
+            assert rs == xp
 
     def test_business_freq(self):
         import matplotlib.pyplot as plt  # noqa

--- a/pandas/tests/series/test_indexing.py
+++ b/pandas/tests/series/test_indexing.py
@@ -1873,14 +1873,14 @@ class TestSeriesIndexing(TestData, tm.TestCase):
         rb[:2] = 5
         self.assertTrue((b[:2] == 5).all())
 
-    def test_align_sameindex(self):
+    def test_align_same_index(self):
         a, b = self.ts.align(self.ts, copy=False)
-        self.assertIs(a.index, self.ts.index)
-        self.assertIs(b.index, self.ts.index)
+        assert a.index is self.ts.index
+        assert b.index is self.ts.index
 
-        # a, b = self.ts.align(self.ts, copy=True)
-        # self.assertIsNot(a.index, self.ts.index)
-        # self.assertIsNot(b.index, self.ts.index)
+        a, b = self.ts.align(self.ts, copy=True)
+        assert a.index is not self.ts.index
+        assert b.index is not self.ts.index
 
     def test_align_multiindex(self):
         # GH 10665

--- a/pandas/tests/series/test_timeseries.py
+++ b/pandas/tests/series/test_timeseries.py
@@ -411,12 +411,12 @@ class TestTimeSeries(TestData, tm.TestCase):
 
         masked = rng[mask]
         expected = rng[10:20]
-        self.assertIsNotNone(expected.freq)
+        assert expected.freq is not None
         assert_range_equal(masked, expected)
 
         mask[22] = True
         masked = rng[mask]
-        self.assertIsNone(masked.freq)
+        assert masked.freq is None
 
     def test_to_datetime_unit(self):
 

--- a/pandas/tests/test_base.py
+++ b/pandas/tests/test_base.py
@@ -304,26 +304,28 @@ class TestIndexOps(Ops):
     def test_ndarray_compat_properties(self):
 
         for o in self.objs:
+            # Check that we work.
+            for p in ['shape', 'dtype', 'flags', 'T',
+                      'strides', 'itemsize', 'nbytes']:
+                assert getattr(o, p, None) is not None
 
-            # check that we work
-            for p in ['shape', 'dtype', 'flags', 'T', 'strides', 'itemsize',
-                      'nbytes']:
-                self.assertIsNotNone(getattr(o, p, None))
-            self.assertTrue(hasattr(o, 'base'))
+            assert hasattr(o, 'base')
 
-            # if we have a datetimelike dtype then needs a view to work
+            # If we have a datetime-like dtype then needs a view to work
             # but the user is responsible for that
             try:
-                self.assertIsNotNone(o.data)
+                assert o.data is not None
             except ValueError:
                 pass
 
-            self.assertRaises(ValueError, o.item)  # len > 1
-            self.assertEqual(o.ndim, 1)
-            self.assertEqual(o.size, len(o))
+            with pytest.raises(ValueError):
+                o.item()  # len > 1
 
-        self.assertEqual(Index([1]).item(), 1)
-        self.assertEqual(Series([1]).item(), 1)
+            assert o.ndim == 1
+            assert o.size == len(o)
+
+        assert Index([1]).item() == 1
+        assert Series([1]).item() == 1
 
     def test_ops(self):
         for op in ['max', 'min']:

--- a/pandas/tests/test_panel.py
+++ b/pandas/tests/test_panel.py
@@ -917,25 +917,25 @@ class TestPanel(tm.TestCase, PanelTests, CheckIndexing, SafeForLongAndSparse,
         with catch_warnings(record=True):
             # with BlockManager
             wp = Panel(self.panel._data)
-            self.assertIs(wp._data, self.panel._data)
+            assert wp._data is self.panel._data
 
             wp = Panel(self.panel._data, copy=True)
-            self.assertIsNot(wp._data, self.panel._data)
-            assert_panel_equal(wp, self.panel)
+            assert wp._data is not self.panel._data
+            tm.assert_panel_equal(wp, self.panel)
 
             # strings handled prop
             wp = Panel([[['foo', 'foo', 'foo', ], ['foo', 'foo', 'foo']]])
-            self.assertEqual(wp.values.dtype, np.object_)
+            assert wp.values.dtype == np.object_
 
             vals = self.panel.values
 
             # no copy
             wp = Panel(vals)
-            self.assertIs(wp.values, vals)
+            assert wp.values is vals
 
             # copy
             wp = Panel(vals, copy=True)
-            self.assertIsNot(wp.values, vals)
+            assert wp.values is not vals
 
             # GH #8285, test when scalar data is used to construct a Panel
             # if dtype is not passed, it should be inferred
@@ -946,7 +946,8 @@ class TestPanel(tm.TestCase, PanelTests, CheckIndexing, SafeForLongAndSparse,
                            minor_axis=range(4))
                 vals = np.empty((2, 3, 4), dtype=dtype)
                 vals.fill(val)
-                assert_panel_equal(wp, Panel(vals, dtype=dtype))
+
+                tm.assert_panel_equal(wp, Panel(vals, dtype=dtype))
 
             # test the case when dtype is passed
             wp = Panel(1, items=range(2), major_axis=range(3),
@@ -954,7 +955,8 @@ class TestPanel(tm.TestCase, PanelTests, CheckIndexing, SafeForLongAndSparse,
                        dtype='float32')
             vals = np.empty((2, 3, 4), dtype='float32')
             vals.fill(1)
-            assert_panel_equal(wp, Panel(vals, dtype='float32'))
+
+            tm.assert_panel_equal(wp, Panel(vals, dtype='float32'))
 
     def test_constructor_cast(self):
         with catch_warnings(record=True):

--- a/pandas/tests/test_panel.py
+++ b/pandas/tests/test_panel.py
@@ -597,17 +597,18 @@ class CheckIndexing(object):
         with catch_warnings(record=True):
             itemA = self.panel.xs('ItemA', axis=0)
             expected = self.panel['ItemA']
-            assert_frame_equal(itemA, expected)
+            tm.assert_frame_equal(itemA, expected)
 
-            # get a view by default
+            # Get a view by default.
             itemA_view = self.panel.xs('ItemA', axis=0)
             itemA_view.values[:] = np.nan
-            self.assertTrue(np.isnan(self.panel['ItemA'].values).all())
 
-            # mixed-type yields a copy
+            assert np.isnan(self.panel['ItemA'].values).all()
+
+            # Mixed-type yields a copy.
             self.panel['strings'] = 'foo'
             result = self.panel.xs('D', axis=2)
-            self.assertIsNotNone(result.is_copy)
+            assert result.is_copy is not None
 
     def test_getitem_fancy_labels(self):
         with catch_warnings(record=True):

--- a/pandas/tests/test_panel4d.py
+++ b/pandas/tests/test_panel4d.py
@@ -510,18 +510,19 @@ class CheckIndexing(object):
     def test_xs(self):
         l1 = self.panel4d.xs('l1', axis=0)
         expected = self.panel4d['l1']
-        assert_panel_equal(l1, expected)
+        tm.assert_panel_equal(l1, expected)
 
-        # view if possible
+        # View if possible
         l1_view = self.panel4d.xs('l1', axis=0)
         l1_view.values[:] = np.nan
-        self.assertTrue(np.isnan(self.panel4d['l1'].values).all())
+        assert np.isnan(self.panel4d['l1'].values).all()
 
-        # mixed-type
+        # Mixed-type
         self.panel4d['strings'] = 'foo'
         with catch_warnings(record=True):
             result = self.panel4d.xs('D', axis=3)
-        self.assertIsNotNone(result.is_copy)
+
+        assert result.is_copy is not None
 
     def test_getitem_fancy_labels(self):
         with catch_warnings(record=True):

--- a/pandas/tests/tools/test_concat.py
+++ b/pandas/tests/tools/test_concat.py
@@ -854,39 +854,37 @@ class TestAppend(ConcatenateBase):
 class TestConcatenate(ConcatenateBase):
 
     def test_concat_copy(self):
-
         df = DataFrame(np.random.randn(4, 3))
         df2 = DataFrame(np.random.randint(0, 10, size=4).reshape(4, 1))
         df3 = DataFrame({5: 'foo'}, index=range(4))
 
-        # these are actual copies
+        # These are actual copies.
         result = concat([df, df2, df3], axis=1, copy=True)
-        for b in result._data.blocks:
-            self.assertIsNone(b.values.base)
 
-        # these are the same
+        for b in result._data.blocks:
+            assert b.values.base is None
+
+        # These are the same.
         result = concat([df, df2, df3], axis=1, copy=False)
+
         for b in result._data.blocks:
             if b.is_float:
-                self.assertTrue(
-                    b.values.base is df._data.blocks[0].values.base)
+                assert b.values.base is df._data.blocks[0].values.base
             elif b.is_integer:
-                self.assertTrue(
-                    b.values.base is df2._data.blocks[0].values.base)
+                assert b.values.base is df2._data.blocks[0].values.base
             elif b.is_object:
-                self.assertIsNotNone(b.values.base)
+                assert b.values.base is not None
 
-        # float block was consolidated
+        # Float block was consolidated.
         df4 = DataFrame(np.random.randn(4, 1))
         result = concat([df, df2, df3, df4], axis=1, copy=False)
         for b in result._data.blocks:
             if b.is_float:
-                self.assertIsNone(b.values.base)
+                assert b.values.base is None
             elif b.is_integer:
-                self.assertTrue(
-                    b.values.base is df2._data.blocks[0].values.base)
+                assert b.values.base is df2._data.blocks[0].values.base
             elif b.is_object:
-                self.assertIsNotNone(b.values.base)
+                assert b.values.base is not None
 
     def test_concat_with_group_keys(self):
         df = DataFrame(np.random.randn(4, 3))

--- a/pandas/util/testing.py
+++ b/pandas/util/testing.py
@@ -1060,11 +1060,6 @@ def assertIsNone(expr, msg=''):
     return assertIs(expr, None, msg)
 
 
-def assertIsNotNone(expr, msg=''):
-    """Checks that 'expr' is not None"""
-    assert expr is not None, msg
-
-
 def assertIsInstance(obj, cls, msg=''):
     """Test that obj is an instance of cls
     (which can be a class or a tuple of classes,


### PR DESCRIPTION
Title is self-explanatory.

Also removes some vestigial `assertIsNot` calls missed in #16024.

Partially addresses #15990.