### PR TITLE
DOC: add hidden IntervalIndex.str to prevent doc build warnings

### DIFF
--- a/doc/source/api.rst
+++ b/doc/source/api.rst
@@ -606,6 +606,7 @@ strings and apply several methods to it. These can be accessed like
        MultiIndex.str
        DatetimeIndex.str
        TimedeltaIndex.str
+       IntervalIndex.str
 
 
 .. _api.categorical:


### PR DESCRIPTION
@TomAugspurger @jreback This (should) fixes the warning related to the IntervalIndex.str, but, I was thinking we should maybe remove the full `IntervalIndex` class from the API docs? 
I mean the class docstring, not the docstrings for the specific methods that are unique to the IntervalIndex