### PR TITLE
MAINT: Remove tm.assertNotIsInstance from testing

### DIFF
--- a/pandas/tests/indexes/common.py
+++ b/pandas/tests/indexes/common.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 
+import pytest
+
 from pandas import compat
 from pandas.compat import PY3
 
@@ -793,7 +795,7 @@ class Base(object):
                 if isinstance(idx, DatetimeIndexOpsMixin):
                     # raise TypeError or ValueError (PeriodIndex)
                     # PeriodIndex behavior should be changed in future version
-                    with tm.assertRaises(Exception):
+                    with pytest.raises(Exception):
                         with np.errstate(all='ignore'):
                             func(idx)
                 elif isinstance(idx, (Float64Index, Int64Index, UInt64Index)):
@@ -801,33 +803,33 @@ class Base(object):
                     with np.errstate(all='ignore'):
                         result = func(idx)
                         exp = Index(func(idx.values), name=idx.name)
-                    self.assert_index_equal(result, exp)
-                    self.assertIsInstance(result, pd.Float64Index)
+
+                    tm.assert_index_equal(result, exp)
+                    assert isinstance(result, pd.Float64Index)
                 else:
                     # raise AttributeError or TypeError
                     if len(idx) == 0:
                         continue
                     else:
-                        with tm.assertRaises(Exception):
+                        with pytest.raises(Exception):
                             with np.errstate(all='ignore'):
                                 func(idx)
 
             for func in [np.isfinite, np.isinf, np.isnan, np.signbit]:
                 if isinstance(idx, DatetimeIndexOpsMixin):
                     # raise TypeError or ValueError (PeriodIndex)
-                    with tm.assertRaises(Exception):
+                    with pytest.raises(Exception):
                         func(idx)
                 elif isinstance(idx, (Float64Index, Int64Index, UInt64Index)):
-                    # results in bool array
+                    # Results in bool array
                     result = func(idx)
-                    exp = func(idx.values)
-                    self.assertIsInstance(result, np.ndarray)
-                    tm.assertNotIsInstance(result, Index)
+                    assert isinstance(result, np.ndarray)
+                    assert not isinstance(result, Index)
                 else:
                     if len(idx) == 0:
                         continue
                     else:
-                        with tm.assertRaises(Exception):
+                        with pytest.raises(Exception):
                             func(idx)
 
     def test_hasnans_isnans(self):

--- a/pandas/tests/indexes/datetimes/test_indexing.py
+++ b/pandas/tests/indexes/datetimes/test_indexing.py
@@ -1,5 +1,6 @@
-import numpy as np
+import pytest
 
+import numpy as np
 import pandas as pd
 import pandas.util.testing as tm
 import pandas.compat as compat
@@ -54,9 +55,9 @@ class TestDatetimeIndex(tm.TestCase):
         expected = Index([datetime(2000, 1, 4), 'inserted',
                           datetime(2000, 1, 1),
                           datetime(2000, 1, 2)], name='idx')
-        self.assertNotIsInstance(result, DatetimeIndex)
+        assert not isinstance(result, DatetimeIndex)
         tm.assert_index_equal(result, expected)
-        self.assertEqual(result.name, expected.name)
+        assert result.name == expected.name
 
         idx = date_range('1/1/2000', periods=3, freq='M', name='idx')
 
@@ -85,16 +86,16 @@ class TestDatetimeIndex(tm.TestCase):
         for n, d, expected in cases:
             result = idx.insert(n, d)
             tm.assert_index_equal(result, expected)
-            self.assertEqual(result.name, expected.name)
-            self.assertEqual(result.freq, expected.freq)
+            assert result.name == expected.name
+            assert result.freq == expected.freq
 
         # reset freq to None
         result = idx.insert(3, datetime(2000, 1, 2))
         expected = DatetimeIndex(['2000-01-31', '2000-02-29', '2000-03-31',
                                   '2000-01-02'], name='idx', freq=None)
         tm.assert_index_equal(result, expected)
-        self.assertEqual(result.name, expected.name)
-        self.assertTrue(result.freq is None)
+        assert result.name == expected.name
+        assert result.freq is None
 
         # GH 7299
         tm._skip_if_no_pytz()
@@ -102,16 +103,15 @@ class TestDatetimeIndex(tm.TestCase):
 
         idx = date_range('1/1/2000', periods=3, freq='D', tz='Asia/Tokyo',
                          name='idx')
-        with tm.assertRaises(ValueError):
-            result = idx.insert(3, pd.Timestamp('2000-01-04'))
-        with tm.assertRaises(ValueError):
-            result = idx.insert(3, datetime(2000, 1, 4))
-        with tm.assertRaises(ValueError):
-            result = idx.insert(3, pd.Timestamp('2000-01-04', tz='US/Eastern'))
-        with tm.assertRaises(ValueError):
-            result = idx.insert(3,
-                                datetime(2000, 1, 4,
-                                         tzinfo=pytz.timezone('US/Eastern')))
+        with pytest.raises(ValueError):
+            idx.insert(3, pd.Timestamp('2000-01-04'))
+        with pytest.raises(ValueError):
+            idx.insert(3, datetime(2000, 1, 4))
+        with pytest.raises(ValueError):
+            idx.insert(3, pd.Timestamp('2000-01-04', tz='US/Eastern'))
+        with pytest.raises(ValueError):
+            idx.insert(3, datetime(2000, 1, 4,
+                                   tzinfo=pytz.timezone('US/Eastern')))
 
         for tz in ['US/Pacific', 'Asia/Singapore']:
             idx = date_range('1/1/2000 09:00', periods=6, freq='H', tz=tz,
@@ -124,9 +124,9 @@ class TestDatetimeIndex(tm.TestCase):
 
                 result = idx.insert(6, d)
                 tm.assert_index_equal(result, expected)
-                self.assertEqual(result.name, expected.name)
-                self.assertEqual(result.freq, expected.freq)
-                self.assertEqual(result.tz, expected.tz)
+                assert result.name == expected.name
+                assert result.freq == expected.freq
+                assert result.tz == expected.tz
 
             expected = DatetimeIndex(['2000-01-01 09:00', '2000-01-01 10:00',
                                       '2000-01-01 11:00',
@@ -139,9 +139,9 @@ class TestDatetimeIndex(tm.TestCase):
                       pytz.timezone(tz).localize(datetime(2000, 1, 1, 10))]:
                 result = idx.insert(6, d)
                 tm.assert_index_equal(result, expected)
-                self.assertEqual(result.name, expected.name)
-                self.assertTrue(result.freq is None)
-                self.assertEqual(result.tz, expected.tz)
+                assert result.name == expected.name
+                assert result.tz == expected.tz
+                assert result.freq is None
 
     def test_delete(self):
         idx = date_range(start='2000-01-01', periods=5, freq='M', name='idx')

--- a/pandas/tests/indexes/test_base.py
+++ b/pandas/tests/indexes/test_base.py
@@ -283,27 +283,27 @@ class TestIndex(Base, tm.TestCase):
         for idx in [Index(np.array([1, 2, 3], dtype=int)),
                     Index(np.array([1, 2, 3], dtype=int), dtype=int),
                     Index([1, 2, 3], dtype=int)]:
-            self.assertIsInstance(idx, Int64Index)
+            assert isinstance(idx, Int64Index)
 
-        # these should coerce
+        # These should coerce
         for idx in [Index(np.array([1., 2., 3.], dtype=float), dtype=int),
                     Index([1., 2., 3.], dtype=int)]:
-            self.assertIsInstance(idx, Int64Index)
+            assert isinstance(idx, Int64Index)
 
         for idx in [Index(np.array([1., 2., 3.], dtype=float)),
                     Index(np.array([1, 2, 3], dtype=int), dtype=float),
                     Index(np.array([1., 2., 3.], dtype=float), dtype=float),
                     Index([1, 2, 3], dtype=float),
                     Index([1., 2., 3.], dtype=float)]:
-            self.assertIsInstance(idx, Float64Index)
+            assert isinstance(idx, Float64Index)
 
         for idx in [Index(np.array([True, False, True], dtype=bool)),
                     Index([True, False, True]),
                     Index(np.array([True, False, True], dtype=bool),
                           dtype=bool),
                     Index([True, False, True], dtype=bool)]:
-            self.assertIsInstance(idx, Index)
-            self.assertEqual(idx.dtype, object)
+            assert isinstance(idx, Index)
+            assert idx.dtype == object
 
         for idx in [Index(np.array([1, 2, 3], dtype=int), dtype='category'),
                     Index([1, 2, 3], dtype='category'),
@@ -312,32 +312,32 @@ class TestIndex(Base, tm.TestCase):
                           dtype='category'),
                     Index([datetime(2011, 1, 1), datetime(2011, 1, 2)],
                           dtype='category')]:
-            self.assertIsInstance(idx, CategoricalIndex)
+            assert isinstance(idx, CategoricalIndex)
 
         for idx in [Index(np.array([np_datetime64_compat('2011-01-01'),
                                     np_datetime64_compat('2011-01-02')])),
                     Index([datetime(2011, 1, 1), datetime(2011, 1, 2)])]:
-            self.assertIsInstance(idx, DatetimeIndex)
+            assert isinstance(idx, DatetimeIndex)
 
         for idx in [Index(np.array([np_datetime64_compat('2011-01-01'),
                                     np_datetime64_compat('2011-01-02')]),
                           dtype=object),
                     Index([datetime(2011, 1, 1),
                            datetime(2011, 1, 2)], dtype=object)]:
-            self.assertNotIsInstance(idx, DatetimeIndex)
-            self.assertIsInstance(idx, Index)
-            self.assertEqual(idx.dtype, object)
+            assert not isinstance(idx, DatetimeIndex)
+            assert isinstance(idx, Index)
+            assert idx.dtype == object
 
         for idx in [Index(np.array([np.timedelta64(1, 'D'), np.timedelta64(
                 1, 'D')])), Index([timedelta(1), timedelta(1)])]:
-            self.assertIsInstance(idx, TimedeltaIndex)
+            assert isinstance(idx, TimedeltaIndex)
 
         for idx in [Index(np.array([np.timedelta64(1, 'D'),
                                     np.timedelta64(1, 'D')]), dtype=object),
                     Index([timedelta(1), timedelta(1)], dtype=object)]:
-            self.assertNotIsInstance(idx, TimedeltaIndex)
-            self.assertIsInstance(idx, Index)
-            self.assertEqual(idx.dtype, object)
+            assert not isinstance(idx, TimedeltaIndex)
+            assert isinstance(idx, Index)
+            assert idx.dtype == object
 
     def test_constructor_dtypes_datetime(self):
 

--- a/pandas/tests/indexes/test_category.py
+++ b/pandas/tests/indexes/test_category.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 
+import pytest
+
 import pandas.util.testing as tm
 from pandas.core.indexes.api import Index, CategoricalIndex
 from .common import Base
@@ -37,62 +39,66 @@ class TestCategoricalIndex(Base, tm.TestCase):
 
         result = Index(ci)
         tm.assert_index_equal(result, ci, exact=True)
-        self.assertFalse(result.ordered)
+        assert not result.ordered
 
         result = Index(ci.values)
         tm.assert_index_equal(result, ci, exact=True)
-        self.assertFalse(result.ordered)
+        assert not result.ordered
 
         # empty
         result = CategoricalIndex(categories=categories)
-        self.assert_index_equal(result.categories, Index(categories))
+        tm.assert_index_equal(result.categories, Index(categories))
         tm.assert_numpy_array_equal(result.codes, np.array([], dtype='int8'))
-        self.assertFalse(result.ordered)
+        assert not result.ordered
 
         # passing categories
         result = CategoricalIndex(list('aabbca'), categories=categories)
-        self.assert_index_equal(result.categories, Index(categories))
+        tm.assert_index_equal(result.categories, Index(categories))
         tm.assert_numpy_array_equal(result.codes,
-                                    np.array([0, 0, 1, 1, 2, 0], dtype='int8'))
+                                    np.array([0, 0, 1,
+                                              1, 2, 0], dtype='int8'))
 
         c = pd.Categorical(list('aabbca'))
         result = CategoricalIndex(c)
-        self.assert_index_equal(result.categories, Index(list('abc')))
+        tm.assert_index_equal(result.categories, Index(list('abc')))
         tm.assert_numpy_array_equal(result.codes,
-                                    np.array([0, 0, 1, 1, 2, 0], dtype='int8'))
-        self.assertFalse(result.ordered)
+                                    np.array([0, 0, 1,
+                                              1, 2, 0], dtype='int8'))
+        assert not result.ordered
 
         result = CategoricalIndex(c, categories=categories)
-        self.assert_index_equal(result.categories, Index(categories))
+        tm.assert_index_equal(result.categories, Index(categories))
         tm.assert_numpy_array_equal(result.codes,
-                                    np.array([0, 0, 1, 1, 2, 0], dtype='int8'))
-        self.assertFalse(result.ordered)
+                                    np.array([0, 0, 1,
+                                              1, 2, 0], dtype='int8'))
+        assert not result.ordered
 
         ci = CategoricalIndex(c, categories=list('abcd'))
         result = CategoricalIndex(ci)
-        self.assert_index_equal(result.categories, Index(categories))
+        tm.assert_index_equal(result.categories, Index(categories))
         tm.assert_numpy_array_equal(result.codes,
-                                    np.array([0, 0, 1, 1, 2, 0], dtype='int8'))
-        self.assertFalse(result.ordered)
+                                    np.array([0, 0, 1,
+                                              1, 2, 0], dtype='int8'))
+        assert not result.ordered
 
         result = CategoricalIndex(ci, categories=list('ab'))
-        self.assert_index_equal(result.categories, Index(list('ab')))
+        tm.assert_index_equal(result.categories, Index(list('ab')))
         tm.assert_numpy_array_equal(result.codes,
-                                    np.array([0, 0, 1, 1, -1, 0],
-                                             dtype='int8'))
-        self.assertFalse(result.ordered)
+                                    np.array([0, 0, 1,
+                                              1, -1, 0], dtype='int8'))
+        assert not result.ordered
 
         result = CategoricalIndex(ci, categories=list('ab'), ordered=True)
-        self.assert_index_equal(result.categories, Index(list('ab')))
+        tm.assert_index_equal(result.categories, Index(list('ab')))
         tm.assert_numpy_array_equal(result.codes,
-                                    np.array([0, 0, 1, 1, -1, 0],
-                                             dtype='int8'))
-        self.assertTrue(result.ordered)
+                                    np.array([0, 0, 1,
+                                              1, -1, 0], dtype='int8'))
+        assert result.ordered
 
         # turn me to an Index
         result = Index(np.array(ci))
-        self.assertIsInstance(result, Index)
-        self.assertNotIsInstance(result, CategoricalIndex)
+        assert isinstance(result, Index)
+        assert not isinstance(result, CategoricalIndex)
 
     def test_construction_with_dtype(self):
 
@@ -325,9 +331,9 @@ class TestCategoricalIndex(Base, tm.TestCase):
         expected = CategoricalIndex(list('aabbc'), categories=categories)
         tm.assert_index_equal(result, expected, exact=True)
 
-        with tm.assertRaises((IndexError, ValueError)):
-            # either depeidnig on numpy version
-            result = ci.delete(10)
+        with pytest.raises((IndexError, ValueError)):
+            # Either depending on NumPy version
+            ci.delete(10)
 
     def test_astype(self):
 
@@ -336,12 +342,12 @@ class TestCategoricalIndex(Base, tm.TestCase):
         tm.assert_index_equal(result, ci, exact=True)
 
         result = ci.astype(object)
-        self.assert_index_equal(result, Index(np.array(ci)))
+        tm.assert_index_equal(result, Index(np.array(ci)))
 
         # this IS equal, but not the same class
-        self.assertTrue(result.equals(ci))
-        self.assertIsInstance(result, Index)
-        self.assertNotIsInstance(result, CategoricalIndex)
+        assert result.equals(ci)
+        assert isinstance(result, Index)
+        assert not isinstance(result, CategoricalIndex)
 
         # interval
         ii = IntervalIndex.from_arrays(left=[-0.001, 2.0],

--- a/pandas/tests/indexes/test_multi.py
+++ b/pandas/tests/indexes/test_multi.py
@@ -539,17 +539,17 @@ class TestMultiIndex(Base, tm.TestCase):
     def test_constructor_single_level(self):
         single_level = MultiIndex(levels=[['foo', 'bar', 'baz', 'qux']],
                                   labels=[[0, 1, 2, 3]], names=['first'])
-        tm.assertIsInstance(single_level, Index)
-        self.assertNotIsInstance(single_level, MultiIndex)
-        self.assertEqual(single_level.name, 'first')
+        assert isinstance(single_level, Index)
+        assert not isinstance(single_level, MultiIndex)
+        assert single_level.name == 'first'
 
         single_level = MultiIndex(levels=[['foo', 'bar', 'baz', 'qux']],
                                   labels=[[0, 1, 2, 3]])
-        self.assertIsNone(single_level.name)
+        assert single_level.name is None
 
     def test_constructor_no_levels(self):
-        assertRaisesRegexp(ValueError, "non-zero number of levels/labels",
-                           MultiIndex, levels=[], labels=[])
+        tm.assertRaisesRegexp(ValueError, "non-zero number of levels/labels",
+                              MultiIndex, levels=[], labels=[])
         both_re = re.compile('Must pass both levels and labels')
         with tm.assertRaisesRegexp(TypeError, both_re):
             MultiIndex(levels=[])

--- a/pandas/tests/indexes/test_numeric.py
+++ b/pandas/tests/indexes/test_numeric.py
@@ -171,7 +171,7 @@ class Numeric(Base):
         # GH 9244
         index = self.create_index()
         expected = Index(index.values % 2)
-        self.assert_index_equal(index % 2, expected)
+        tm.assert_index_equal(index % 2, expected)
 
 
 class TestFloat64Index(Numeric, tm.TestCase):
@@ -190,14 +190,14 @@ class TestFloat64Index(Numeric, tm.TestCase):
             tm.assert_index_equal(eval(repr(ind)), ind)
 
     def check_is_index(self, i):
-        self.assertIsInstance(i, Index)
-        self.assertNotIsInstance(i, Float64Index)
+        assert isinstance(i, Index)
+        assert not isinstance(i, Float64Index)
 
     def check_coerce(self, a, b, is_float_index=True):
-        self.assertTrue(a.equals(b))
-        self.assert_index_equal(a, b, exact=False)
+        assert a.equals(b)
+        tm.assert_index_equal(a, b, exact=False)
         if is_float_index:
-            self.assertIsInstance(b, Float64Index)
+            assert isinstance(b, Float64Index)
         else:
             self.check_is_index(b)
 

--- a/pandas/tests/indexes/timedeltas/test_indexing.py
+++ b/pandas/tests/indexes/timedeltas/test_indexing.py
@@ -13,15 +13,15 @@ class TestTimedeltaIndex(tm.TestCase):
 
         result = idx.insert(2, timedelta(days=5))
         exp = TimedeltaIndex(['4day', '1day', '5day', '2day'], name='idx')
-        self.assert_index_equal(result, exp)
+        tm.assert_index_equal(result, exp)
 
         # insertion of non-datetime should coerce to object index
         result = idx.insert(1, 'inserted')
         expected = Index([Timedelta('4day'), 'inserted', Timedelta('1day'),
                           Timedelta('2day')], name='idx')
-        self.assertNotIsInstance(result, TimedeltaIndex)
+        assert not isinstance(result, TimedeltaIndex)
         tm.assert_index_equal(result, expected)
-        self.assertEqual(result.name, expected.name)
+        assert result.name == expected.name
 
         idx = timedelta_range('1day 00:00:01', periods=3, freq='s', name='idx')
 
@@ -49,9 +49,9 @@ class TestTimedeltaIndex(tm.TestCase):
 
         for n, d, expected in cases:
             result = idx.insert(n, d)
-            self.assert_index_equal(result, expected)
-            self.assertEqual(result.name, expected.name)
-            self.assertEqual(result.freq, expected.freq)
+            tm.assert_index_equal(result, expected)
+            assert result.name == expected.name
+            assert result.freq == expected.freq
 
     def test_delete(self):
         idx = timedelta_range(start='1 Days', periods=5, freq='D', name='idx')

--- a/pandas/tests/io/parser/parse_dates.py
+++ b/pandas/tests/io/parser/parse_dates.py
@@ -144,7 +144,7 @@ KORD,19990127 22:00:00, 21:56:00, -0.5900, 1.7100, 5.1000, 0.0000, 290.0000
                                parse_dates=[[0, 1]], date_parser=Timestamp)
 
         ex_val = Timestamp('05/31/2012 15:30:00.029')
-        self.assertEqual(result['0_1'][0], ex_val)
+        assert result['0_1'][0] == ex_val
 
     def test_multiple_date_cols_with_header(self):
         data = """\
@@ -157,7 +157,7 @@ KORD,19990127, 22:00:00, 21:56:00, -0.5900, 1.7100, 5.1000, 0.0000, 290.0000
 KORD,19990127, 23:00:00, 22:56:00, -0.5900, 1.7100, 4.6000, 0.0000, 280.0000"""
 
         df = self.read_csv(StringIO(data), parse_dates={'nominal': [1, 2]})
-        self.assertNotIsInstance(df.nominal[0], compat.string_types)
+        assert not isinstance(df.nominal[0], compat.string_types)
 
     ts_data = """\
 ID,date,nominalTime,actualTime,A,B,C,D,E
@@ -170,8 +170,8 @@ KORD,19990127, 23:00:00, 22:56:00, -0.5900, 1.7100, 4.6000, 0.0000, 280.0000
 """
 
     def test_multiple_date_col_name_collision(self):
-        self.assertRaises(ValueError, self.read_csv, StringIO(self.ts_data),
-                          parse_dates={'ID': [1, 2]})
+        with pytest.raises(ValueError):
+            self.read_csv(StringIO(self.ts_data), parse_dates={'ID': [1, 2]})
 
         data = """\
 date_NominalTime,date,NominalTime,ActualTime,TDew,TAir,Windspeed,Precip,WindDir
@@ -182,8 +182,8 @@ KORD4,19990127, 21:00:00, 21:18:00, -0.9900, 2.0100, 3.6000, 0.0000, 270.0000
 KORD5,19990127, 22:00:00, 21:56:00, -0.5900, 1.7100, 5.1000, 0.0000, 290.0000
 KORD6,19990127, 23:00:00, 22:56:00, -0.5900, 1.7100, 4.6000, 0.0000, 280.0000"""  # noqa
 
-        self.assertRaises(ValueError, self.read_csv, StringIO(data),
-                          parse_dates=[[1, 2]])
+        with pytest.raises(ValueError):
+            self.read_csv(StringIO(data), parse_dates=[[1, 2]])
 
     def test_date_parser_int_bug(self):
         # See gh-3071

--- a/pandas/tests/plotting/test_frame.py
+++ b/pandas/tests/plotting/test_frame.py
@@ -237,33 +237,34 @@ class TestDataFramePlots(TestPlotBase):
         df = self.tdf
         ax = df.plot(x_compat=True)
         lines = ax.get_lines()
-        self.assertNotIsInstance(lines[0].get_xdata(), PeriodIndex)
+        assert not isinstance(lines[0].get_xdata(), PeriodIndex)
 
         tm.close()
         pd.plotting.plot_params['xaxis.compat'] = True
         ax = df.plot()
         lines = ax.get_lines()
-        self.assertNotIsInstance(lines[0].get_xdata(), PeriodIndex)
+        assert not isinstance(lines[0].get_xdata(), PeriodIndex)
 
         tm.close()
         pd.plotting.plot_params['x_compat'] = False
+
         ax = df.plot()
         lines = ax.get_lines()
-        self.assertNotIsInstance(lines[0].get_xdata(), PeriodIndex)
-        self.assertIsInstance(PeriodIndex(lines[0].get_xdata()), PeriodIndex)
+        assert not isinstance(lines[0].get_xdata(), PeriodIndex)
+        assert isinstance(PeriodIndex(lines[0].get_xdata()), PeriodIndex)
 
         tm.close()
         # useful if you're plotting a bunch together
         with pd.plotting.plot_params.use('x_compat', True):
             ax = df.plot()
             lines = ax.get_lines()
-            self.assertNotIsInstance(lines[0].get_xdata(), PeriodIndex)
+            assert not isinstance(lines[0].get_xdata(), PeriodIndex)
 
         tm.close()
         ax = df.plot()
         lines = ax.get_lines()
-        self.assertNotIsInstance(lines[0].get_xdata(), PeriodIndex)
-        self.assertIsInstance(PeriodIndex(lines[0].get_xdata()), PeriodIndex)
+        assert not isinstance(lines[0].get_xdata(), PeriodIndex)
+        assert isinstance(PeriodIndex(lines[0].get_xdata()), PeriodIndex)
 
     def test_period_compat(self):
         # GH 9012

--- a/pandas/tests/series/test_analytics.py
+++ b/pandas/tests/series/test_analytics.py
@@ -639,7 +639,8 @@ class TestSeriesAnalytics(TestData, tm.TestCase):
     def test_prod_numpy16_bug(self):
         s = Series([1., 1., 1.], index=lrange(3))
         result = s.prod()
-        self.assertNotIsInstance(result, Series)
+
+        assert not isinstance(result, Series)
 
     def test_all_any(self):
         ts = tm.makeTimeSeries()
@@ -1465,16 +1466,16 @@ class TestSeriesAnalytics(TestData, tm.TestCase):
 
         with tm.assert_produces_warning(FutureWarning):
             result = x.reshape((-1, 1))
-            self.assertNotIsInstance(result, Series)
+            assert not isinstance(result, Series)
 
         with tm.assert_produces_warning(FutureWarning, check_stacklevel=False):
             result2 = np.reshape(x, (-1, 1))
-            self.assertNotIsInstance(result2, Series)
+            assert not isinstance(result2, Series)
 
         with tm.assert_produces_warning(FutureWarning):
             result = x[:, None]
             expected = x.reshape((-1, 1))
-            assert_almost_equal(result, expected)
+            tm.assert_almost_equal(result, expected)
 
     def test_reshape_bad_kwarg(self):
         a = Series([1, 2, 3, 4])

--- a/pandas/tests/series/test_constructors.py
+++ b/pandas/tests/series/test_constructors.py
@@ -32,12 +32,12 @@ class TestSeriesConstructors(TestData, tm.TestCase):
 
         # Pass in scalar is disabled
         scalar = Series(0.5)
-        self.assertNotIsInstance(scalar, float)
+        assert not isinstance(scalar, float)
 
-        # coercion
-        self.assertEqual(float(Series([1.])), 1.0)
-        self.assertEqual(int(Series([1.])), 1)
-        self.assertEqual(long(Series([1.])), 1)
+        # Coercion
+        assert float(Series([1.])) == 1.0
+        assert int(Series([1.])) == 1
+        assert long(Series([1.])) == 1
 
     def test_constructor(self):
         self.assertTrue(self.ts.index.is_all_dates)

--- a/pandas/tests/sparse/test_series.py
+++ b/pandas/tests/sparse/test_series.py
@@ -764,12 +764,12 @@ class TestSparseSeries(tm.TestCase, SharedWithSparse):
         expected = expected[expected != 0]
         exp_arr = pd.SparseArray(expected.values, fill_value=0, kind='block')
         tm.assert_sp_array_equal(sp_valid.values, exp_arr)
-        self.assert_index_equal(sp_valid.index, expected.index)
-        self.assertEqual(len(sp_valid.sp_values), 2)
+        tm.assert_index_equal(sp_valid.index, expected.index)
+        assert len(sp_valid.sp_values) == 2
 
         result = self.bseries.dropna()
         expected = self.bseries.to_dense().dropna()
-        self.assertNotIsInstance(result, SparseSeries)
+        assert not isinstance(result, SparseSeries)
         tm.assert_series_equal(result, expected)
 
     def test_homogenize(self):

--- a/pandas/tests/test_compat.py
+++ b/pandas/tests/test_compat.py
@@ -11,16 +11,19 @@ import pandas.util.testing as tm
 
 class TestBuiltinIterators(tm.TestCase):
 
-    def check_result(self, actual, expected, lengths):
+    @classmethod
+    def check_result(cls, actual, expected, lengths):
         for (iter_res, list_res), exp, length in zip(actual, expected,
                                                      lengths):
-            self.assertNotIsInstance(iter_res, list)
-            tm.assertIsInstance(list_res, list)
+            assert not isinstance(iter_res, list)
+            assert isinstance(list_res, list)
+
             iter_res = list(iter_res)
-            self.assertEqual(len(list_res), length)
-            self.assertEqual(len(iter_res), length)
-            self.assertEqual(iter_res, exp)
-            self.assertEqual(list_res, exp)
+
+            assert len(list_res) == length
+            assert len(iter_res) == length
+            assert iter_res == exp
+            assert list_res == exp
 
     def test_range(self):
         actual1 = range(10)
@@ -64,6 +67,6 @@ class TestBuiltinIterators(tm.TestCase):
         self.check_result(actual, expected, lengths)
 
     def test_dict_iterators(self):
-        self.assertEqual(next(itervalues({1: 2})), 2)
-        self.assertEqual(next(iterkeys({1: 2})), 1)
-        self.assertEqual(next(iteritems({1: 2})), (1, 2))
+        assert next(itervalues({1: 2})) == 2
+        assert next(iterkeys({1: 2})) == 1
+        assert next(iteritems({1: 2})) == (1, 2)

--- a/pandas/tests/test_multilevel.py
+++ b/pandas/tests/test_multilevel.py
@@ -115,24 +115,24 @@ class TestMultiLevel(Base, tm.TestCase):
                           index=[np.array(['a', 'a', 'b', 'b']),
                                  np.array(['x', 'y', 'x', 'y'])])
         tm.assertIsInstance(multi.index, MultiIndex)
-        self.assertNotIsInstance(multi.columns, MultiIndex)
+        assert not isinstance(multi.columns, MultiIndex)
 
         multi = DataFrame(np.random.randn(4, 4),
                           columns=[['a', 'a', 'b', 'b'],
                                    ['x', 'y', 'x', 'y']])
-        tm.assertIsInstance(multi.columns, MultiIndex)
+        assert isinstance(multi.columns, MultiIndex)
 
     def test_series_constructor(self):
         multi = Series(1., index=[np.array(['a', 'a', 'b', 'b']), np.array(
             ['x', 'y', 'x', 'y'])])
-        tm.assertIsInstance(multi.index, MultiIndex)
+        assert isinstance(multi.index, MultiIndex)
 
         multi = Series(1., index=[['a', 'a', 'b', 'b'], ['x', 'y', 'x', 'y']])
-        tm.assertIsInstance(multi.index, MultiIndex)
+        assert isinstance(multi.index, MultiIndex)
 
         multi = Series(lrange(4), index=[['a', 'a', 'b', 'b'],
                                          ['x', 'y', 'x', 'y']])
-        tm.assertIsInstance(multi.index, MultiIndex)
+        assert isinstance(multi.index, MultiIndex)
 
     def test_reindex_level(self):
         # axis=0

--- a/pandas/tests/test_testing.py
+++ b/pandas/tests/test_testing.py
@@ -689,12 +689,6 @@ class TestIsInstance(tm.TestCase):
         with assertRaisesRegexp(AssertionError, expected):
             tm.assertIsInstance(1, pd.Series)
 
-    def test_notisinstance(self):
-
-        expected = "Input must not be type "
-        with assertRaisesRegexp(AssertionError, expected):
-            tm.assertNotIsInstance(pd.Series([1]), pd.Series)
-
 
 class TestAssertCategoricalEqual(unittest.TestCase):
 

--- a/pandas/util/testing.py
+++ b/pandas/util/testing.py
@@ -1069,15 +1069,6 @@ def assertIsInstance(obj, cls, msg=''):
         raise AssertionError(err_msg.format(msg, cls, type(obj)))
 
 
-def assertNotIsInstance(obj, cls, msg=''):
-    """Test that obj is not an instance of cls
-    (which can be a class or a tuple of classes,
-    as supported by isinstance())."""
-    if isinstance(obj, cls):
-        err_msg = "{0}Input must not be type {1}"
-        raise AssertionError(err_msg.format(msg, cls))
-
-
 def assert_categorical_equal(left, right, check_dtype=True,
                              obj='Categorical', check_category_order=True):
     """Test that categoricals are eqivalent


### PR DESCRIPTION
Title is self-explanatory.

Partially addresses #15990.