### PR TITLE
BLD: 3.6.1 ABI compat

### DIFF
--- a/pandas/_libs/src/compat_helper.h
+++ b/pandas/_libs/src/compat_helper.h
@@ -17,7 +17,18 @@ The full license is in the LICENSE file, distributed with this software.
 PySlice_GetIndicesEx changes signature in PY3
 but 3.6.1 in particular changes the behavior of this function slightly
 https://bugs.python.org/issue27867
+
+
+In 3.6.1 PySlice_GetIndicesEx was changed to a macro
+inadvertently breaking ABI compat.  For now, undefing
+the macro, which restores compat.
+https://github.com/pandas-dev/pandas/issues/15961
+https://bugs.python.org/issue29943
 */
+
+#if PY_VERSION_HEX < 0x03070000 && defined(PySlice_GetIndicesEx)
+  #undef PySlice_GetIndicesEx
+#endif
 
 PANDAS_INLINE int slice_get_indices(PyObject *s,
                                     Py_ssize_t length,


### PR DESCRIPTION
 - [x] closes #15961
 - [ ] tests added / passed
 - [ ] passes ``git diff upstream/master --name-only -- '*.py' | flake8 --diff``
 - [ ] whatsnew entry

So I _think_ this works - locally was able to build a wheel with `3.6.1` and import it into a `3.6.0` environment, which was failing before this patch.