### PR TITLE
BUG: Fix length 1 .loc slicing with datetime string GH16071

### DIFF
--- a/doc/source/whatsnew/v0.20.0.txt
+++ b/doc/source/whatsnew/v0.20.0.txt
@@ -1575,6 +1575,7 @@ Conversion
 - Bug in ``is_string_dtype``, ``is_timedelta64_ns_dtype``, and ``is_string_like_dtype`` in which an error was raised when ``None`` was passed in (:issue:`15941`)
 - Bug in the return type of ``pd.unique`` on a ``Categorical``, which was returning an ndarray and not a ``Categorical`` (:issue:`15903`)
 - Bug in ``Index.to_series()`` where the index was not copied (and so mutating later would change the original), (:issue:`15949`)
+- Bug in indexing with partial string indexing with a len-1 DataFrame (:issue:`16071`)
 
 Indexing
 ^^^^^^^^

--- a/pandas/core/indexes/datetimes.py
+++ b/pandas/core/indexes/datetimes.py
@@ -1470,8 +1470,9 @@ class DatetimeIndex(DatelikeOps, TimelikeOps, DatetimeIndexOpsMixin,
             #   [parsed, parsed + 1 freq)
             # because label may be passed to searchsorted
             # the bounds need swapped if index is reverse sorted and has a
-            # length (is_monotonic_decreasing gives True for empty index)
-            if self.is_monotonic_decreasing and len(self):
+            # length > 1 (is_monotonic_decreasing gives True for empty
+            # and length 1 index)
+            if self.is_monotonic_decreasing and len(self) > 1:
                 return upper if side == 'left' else lower
             return lower if side == 'left' else upper
         else:

--- a/pandas/tests/indexes/datetimes/test_partial_slcing.py
+++ b/pandas/tests/indexes/datetimes/test_partial_slcing.py
@@ -254,3 +254,16 @@ class TestSlicing(tm.TestCase):
         self.assertRaisesRegexp(KeyError,
                                 r"Timestamp\('2014-01-10 00:00:00'\)",
                                 lambda: nonmonotonic.loc[timestamp:])
+
+    def test_loc_datetime_length_one(self):
+        """
+        GH16071
+        """
+        df = pd.DataFrame(columns=['1'],
+                          index=pd.date_range('2016-10-01T00:00:00',
+                                              '2016-10-01T23:59:59'))
+        result = df.loc[datetime(2016, 10, 1):]
+        tm.assert_frame_equal(result, df)
+
+        result = df.loc['2016-10-01T00:00:00':]
+        tm.assert_frame_equal(result, df)


### PR DESCRIPTION
I've written the test in pytest style since I read that you are moving to this style. If I misunderstood I can add the test to the class. 

- [x] closes #16071 
 - [x] tests added / passed
 - [x] passes ``git diff upstream/master --name-only -- '*.py' | flake8 --diff``
 - [x] whatsnew entry
