### PR TITLE
MAINT: Remove self.assert_* from testing

### DIFF
--- a/pandas/tests/dtypes/test_io.py
+++ b/pandas/tests/dtypes/test_io.py
@@ -13,13 +13,13 @@ class TestParseSQL(tm.TestCase):
         arr = np.array([1.5, None, 3, 4.2], dtype=object)
         result = lib.convert_sql_column(arr)
         expected = np.array([1.5, np.nan, 3, 4.2], dtype='f8')
-        self.assert_numpy_array_equal(result, expected)
+        tm.assert_numpy_array_equal(result, expected)
 
     def test_convert_sql_column_strings(self):
         arr = np.array(['1.5', None, '3', '4.2'], dtype=object)
         result = lib.convert_sql_column(arr)
         expected = np.array(['1.5', np.nan, '3', '4.2'], dtype=object)
-        self.assert_numpy_array_equal(result, expected)
+        tm.assert_numpy_array_equal(result, expected)
 
     def test_convert_sql_column_unicode(self):
         arr = np.array([u('1.5'), None, u('3'), u('4.2')],
@@ -27,7 +27,7 @@ class TestParseSQL(tm.TestCase):
         result = lib.convert_sql_column(arr)
         expected = np.array([u('1.5'), np.nan, u('3'), u('4.2')],
                             dtype=object)
-        self.assert_numpy_array_equal(result, expected)
+        tm.assert_numpy_array_equal(result, expected)
 
     def test_convert_sql_column_ints(self):
         arr = np.array([1, 2, 3, 4], dtype='O')
@@ -35,42 +35,42 @@ class TestParseSQL(tm.TestCase):
         result = lib.convert_sql_column(arr)
         result2 = lib.convert_sql_column(arr2)
         expected = np.array([1, 2, 3, 4], dtype='i8')
-        self.assert_numpy_array_equal(result, expected)
-        self.assert_numpy_array_equal(result2, expected)
+        tm.assert_numpy_array_equal(result, expected)
+        tm.assert_numpy_array_equal(result2, expected)
 
         arr = np.array([1, 2, 3, None, 4], dtype='O')
         result = lib.convert_sql_column(arr)
         expected = np.array([1, 2, 3, np.nan, 4], dtype='f8')
-        self.assert_numpy_array_equal(result, expected)
+        tm.assert_numpy_array_equal(result, expected)
 
     def test_convert_sql_column_longs(self):
         arr = np.array([long(1), long(2), long(3), long(4)], dtype='O')
         result = lib.convert_sql_column(arr)
         expected = np.array([1, 2, 3, 4], dtype='i8')
-        self.assert_numpy_array_equal(result, expected)
+        tm.assert_numpy_array_equal(result, expected)
 
         arr = np.array([long(1), long(2), long(3), None, long(4)], dtype='O')
         result = lib.convert_sql_column(arr)
         expected = np.array([1, 2, 3, np.nan, 4], dtype='f8')
-        self.assert_numpy_array_equal(result, expected)
+        tm.assert_numpy_array_equal(result, expected)
 
     def test_convert_sql_column_bools(self):
         arr = np.array([True, False, True, False], dtype='O')
         result = lib.convert_sql_column(arr)
         expected = np.array([True, False, True, False], dtype=bool)
-        self.assert_numpy_array_equal(result, expected)
+        tm.assert_numpy_array_equal(result, expected)
 
         arr = np.array([True, False, None, False], dtype='O')
         result = lib.convert_sql_column(arr)
         expected = np.array([True, False, np.nan, False], dtype=object)
-        self.assert_numpy_array_equal(result, expected)
+        tm.assert_numpy_array_equal(result, expected)
 
     def test_convert_sql_column_decimals(self):
         from decimal import Decimal
         arr = np.array([Decimal('1.5'), None, Decimal('3'), Decimal('4.2')])
         result = lib.convert_sql_column(arr)
         expected = np.array([1.5, np.nan, 3, 4.2], dtype='f8')
-        self.assert_numpy_array_equal(result, expected)
+        tm.assert_numpy_array_equal(result, expected)
 
     def test_convert_downcast_int64(self):
         from pandas.io.libparsers import na_values
@@ -80,30 +80,30 @@ class TestParseSQL(tm.TestCase):
 
         # default argument
         result = lib.downcast_int64(arr, na_values)
-        self.assert_numpy_array_equal(result, expected)
+        tm.assert_numpy_array_equal(result, expected)
 
         result = lib.downcast_int64(arr, na_values, use_unsigned=False)
-        self.assert_numpy_array_equal(result, expected)
+        tm.assert_numpy_array_equal(result, expected)
 
         expected = np.array([1, 2, 7, 8, 10], dtype=np.uint8)
         result = lib.downcast_int64(arr, na_values, use_unsigned=True)
-        self.assert_numpy_array_equal(result, expected)
+        tm.assert_numpy_array_equal(result, expected)
 
         # still cast to int8 despite use_unsigned=True
         # because of the negative number as an element
         arr = np.array([1, 2, -7, 8, 10], dtype=np.int64)
         expected = np.array([1, 2, -7, 8, 10], dtype=np.int8)
         result = lib.downcast_int64(arr, na_values, use_unsigned=True)
-        self.assert_numpy_array_equal(result, expected)
+        tm.assert_numpy_array_equal(result, expected)
 
         arr = np.array([1, 2, 7, 8, 300], dtype=np.int64)
         expected = np.array([1, 2, 7, 8, 300], dtype=np.int16)
         result = lib.downcast_int64(arr, na_values)
-        self.assert_numpy_array_equal(result, expected)
+        tm.assert_numpy_array_equal(result, expected)
 
         int8_na = na_values[np.int8]
         int64_na = na_values[np.int64]
         arr = np.array([int64_na, 2, 3, 10, 15], dtype=np.int64)
         expected = np.array([int8_na, 2, 3, 10, 15], dtype=np.int8)
         result = lib.downcast_int64(arr, na_values)
-        self.assert_numpy_array_equal(result, expected)
+        tm.assert_numpy_array_equal(result, expected)

--- a/pandas/tests/dtypes/test_missing.py
+++ b/pandas/tests/dtypes/test_missing.py
@@ -148,18 +148,18 @@ class TestIsNull(tm.TestCase):
         mask = isnull(idx)
         self.assertTrue(mask[0])
         exp = np.array([True] + [False] * (len(idx) - 1), dtype=bool)
-        self.assert_numpy_array_equal(mask, exp)
+        tm.assert_numpy_array_equal(mask, exp)
 
         # GH 9129
         pidx = idx.to_period(freq='M')
         mask = isnull(pidx)
         self.assertTrue(mask[0])
         exp = np.array([True] + [False] * (len(idx) - 1), dtype=bool)
-        self.assert_numpy_array_equal(mask, exp)
+        tm.assert_numpy_array_equal(mask, exp)
 
         mask = isnull(pidx[1:])
         exp = np.zeros(len(mask), dtype=bool)
-        self.assert_numpy_array_equal(mask, exp)
+        tm.assert_numpy_array_equal(mask, exp)
 
     def test_datetime_other_units(self):
         idx = pd.DatetimeIndex(['2011-01-01', 'NaT', '2011-01-02'])

--- a/pandas/tests/frame/test_alter_axes.py
+++ b/pandas/tests/frame/test_alter_axes.py
@@ -233,7 +233,7 @@ class TestDataFrameAlterAxes(tm.TestCase, TestData):
         result = df['C']
         comp = pd.DatetimeIndex(expected.values).copy()
         comp.tz = None
-        self.assert_numpy_array_equal(result.values, comp.values)
+        tm.assert_numpy_array_equal(result.values, comp.values)
 
         # list of datetimes with a tz
         df['D'] = i.to_pydatetime()

--- a/pandas/tests/frame/test_alter_axes.py
+++ b/pandas/tests/frame/test_alter_axes.py
@@ -436,8 +436,8 @@ class TestDataFrameAlterAxes(tm.TestCase, TestData):
         new_columns = MultiIndex.from_tuples([('fizz3', 'buzz1'),
                                               ('fizz2', 'buzz3')],
                                              names=['fizz', 'buzz'])
-        self.assert_index_equal(renamed.index, new_index)
-        self.assert_index_equal(renamed.columns, new_columns)
+        tm.assert_index_equal(renamed.index, new_index)
+        tm.assert_index_equal(renamed.columns, new_columns)
         self.assertEqual(renamed.index.names, df.index.names)
         self.assertEqual(renamed.columns.names, df.columns.names)
 
@@ -450,20 +450,20 @@ class TestDataFrameAlterAxes(tm.TestCase, TestData):
                                              names=['fizz', 'buzz'])
         renamed = df.rename(columns={'fizz1': 'fizz3', 'buzz2': 'buzz3'},
                             level=0)
-        self.assert_index_equal(renamed.columns, new_columns)
+        tm.assert_index_equal(renamed.columns, new_columns)
         renamed = df.rename(columns={'fizz1': 'fizz3', 'buzz2': 'buzz3'},
                             level='fizz')
-        self.assert_index_equal(renamed.columns, new_columns)
+        tm.assert_index_equal(renamed.columns, new_columns)
 
         new_columns = MultiIndex.from_tuples([('fizz1', 'buzz1'),
                                               ('fizz2', 'buzz3')],
                                              names=['fizz', 'buzz'])
         renamed = df.rename(columns={'fizz1': 'fizz3', 'buzz2': 'buzz3'},
                             level=1)
-        self.assert_index_equal(renamed.columns, new_columns)
+        tm.assert_index_equal(renamed.columns, new_columns)
         renamed = df.rename(columns={'fizz1': 'fizz3', 'buzz2': 'buzz3'},
                             level='buzz')
-        self.assert_index_equal(renamed.columns, new_columns)
+        tm.assert_index_equal(renamed.columns, new_columns)
 
         # function
         func = str.upper
@@ -471,17 +471,17 @@ class TestDataFrameAlterAxes(tm.TestCase, TestData):
                                               ('FIZZ2', 'buzz2')],
                                              names=['fizz', 'buzz'])
         renamed = df.rename(columns=func, level=0)
-        self.assert_index_equal(renamed.columns, new_columns)
+        tm.assert_index_equal(renamed.columns, new_columns)
         renamed = df.rename(columns=func, level='fizz')
-        self.assert_index_equal(renamed.columns, new_columns)
+        tm.assert_index_equal(renamed.columns, new_columns)
 
         new_columns = MultiIndex.from_tuples([('fizz1', 'BUZZ1'),
                                               ('fizz2', 'BUZZ2')],
                                              names=['fizz', 'buzz'])
         renamed = df.rename(columns=func, level=1)
-        self.assert_index_equal(renamed.columns, new_columns)
+        tm.assert_index_equal(renamed.columns, new_columns)
         renamed = df.rename(columns=func, level='buzz')
-        self.assert_index_equal(renamed.columns, new_columns)
+        tm.assert_index_equal(renamed.columns, new_columns)
 
         # index
         new_index = MultiIndex.from_tuples([('foo3', 'bar1'),
@@ -489,7 +489,7 @@ class TestDataFrameAlterAxes(tm.TestCase, TestData):
                                            names=['foo', 'bar'])
         renamed = df.rename(index={'foo1': 'foo3', 'bar2': 'bar3'},
                             level=0)
-        self.assert_index_equal(renamed.index, new_index)
+        tm.assert_index_equal(renamed.index, new_index)
 
     def test_rename_nocopy(self):
         renamed = self.frame.rename(columns={'C': 'foo'}, copy=False)
@@ -601,8 +601,8 @@ class TestDataFrameAlterAxes(tm.TestCase, TestData):
         deleveled = self.frame.reset_index()
         self.assert_series_equal(deleveled['index'],
                                  pd.Series(self.frame.index))
-        self.assert_index_equal(deleveled.index,
-                                pd.Index(np.arange(len(deleveled))))
+        tm.assert_index_equal(deleveled.index,
+                              pd.Index(np.arange(len(deleveled))))
 
         # preserve column names
         self.frame.columns.name = 'columns'

--- a/pandas/tests/frame/test_alter_axes.py
+++ b/pandas/tests/frame/test_alter_axes.py
@@ -587,20 +587,20 @@ class TestDataFrameAlterAxes(tm.TestCase, TestData):
         # default name assigned
         rdf = self.frame.reset_index()
         exp = pd.Series(self.frame.index.values, name='index')
-        self.assert_series_equal(rdf['index'], exp)
+        tm.assert_series_equal(rdf['index'], exp)
 
         # default name assigned, corner case
         df = self.frame.copy()
         df['index'] = 'foo'
         rdf = df.reset_index()
         exp = pd.Series(self.frame.index.values, name='level_0')
-        self.assert_series_equal(rdf['level_0'], exp)
+        tm.assert_series_equal(rdf['level_0'], exp)
 
         # but this is ok
         self.frame.index.name = 'index'
         deleveled = self.frame.reset_index()
-        self.assert_series_equal(deleveled['index'],
-                                 pd.Series(self.frame.index))
+        tm.assert_series_equal(deleveled['index'],
+                               pd.Series(self.frame.index))
         tm.assert_index_equal(deleveled.index,
                               pd.Index(np.arange(len(deleveled))))
 

--- a/pandas/tests/frame/test_analytics.py
+++ b/pandas/tests/frame/test_analytics.py
@@ -935,13 +935,13 @@ class TestDataFrameAnalytics(tm.TestCase, TestData):
         # unit test when have object data
         the_mean = self.mixed_frame.mean(axis=0)
         the_sum = self.mixed_frame.sum(axis=0, numeric_only=True)
-        self.assert_index_equal(the_sum.index, the_mean.index)
+        tm.assert_index_equal(the_sum.index, the_mean.index)
         self.assertTrue(len(the_mean.index) < len(self.mixed_frame.columns))
 
         # xs sum mixed type, just want to know it works...
         the_mean = self.mixed_frame.mean(axis=1)
         the_sum = self.mixed_frame.sum(axis=1, numeric_only=True)
-        self.assert_index_equal(the_sum.index, the_mean.index)
+        tm.assert_index_equal(the_sum.index, the_mean.index)
 
         # take mean of boolean column
         self.frame['bool'] = self.frame['A'] > 0
@@ -1758,7 +1758,7 @@ class TestDataFrameAnalytics(tm.TestCase, TestData):
 
         dfs = pd.concat((df, df), axis=1)
         rounded = dfs.round()
-        self.assert_index_equal(rounded.index, dfs.index)
+        tm.assert_index_equal(rounded.index, dfs.index)
 
         decimals = pd.Series([1, 0, 2], index=['A', 'B', 'A'])
         self.assertRaises(ValueError, df.round, decimals)

--- a/pandas/tests/frame/test_api.py
+++ b/pandas/tests/frame/test_api.py
@@ -60,11 +60,11 @@ class SharedWithSparse(object):
     def test_add_prefix_suffix(self):
         with_prefix = self.frame.add_prefix('foo#')
         expected = pd.Index(['foo#%s' % c for c in self.frame.columns])
-        self.assert_index_equal(with_prefix.columns, expected)
+        tm.assert_index_equal(with_prefix.columns, expected)
 
         with_suffix = self.frame.add_suffix('#foo')
         expected = pd.Index(['%s#foo' % c for c in self.frame.columns])
-        self.assert_index_equal(with_suffix.columns, expected)
+        tm.assert_index_equal(with_suffix.columns, expected)
 
 
 class TestDataFrameMisc(tm.TestCase, SharedWithSparse, TestData):

--- a/pandas/tests/frame/test_axis_select_reindex.py
+++ b/pandas/tests/frame/test_axis_select_reindex.py
@@ -49,19 +49,19 @@ class TestDataFrameSelectReindex(tm.TestCase, TestData):
         # errors = 'ignore'
         dropped = df.drop(['g'], errors='ignore')
         expected = Index(['a', 'b', 'c'], name='first')
-        self.assert_index_equal(dropped.index, expected)
+        tm.assert_index_equal(dropped.index, expected)
 
         dropped = df.drop(['b', 'g'], errors='ignore')
         expected = Index(['a', 'c'], name='first')
-        self.assert_index_equal(dropped.index, expected)
+        tm.assert_index_equal(dropped.index, expected)
 
         dropped = df.drop(['g'], axis=1, errors='ignore')
         expected = Index(['d', 'e', 'f'], name='second')
-        self.assert_index_equal(dropped.columns, expected)
+        tm.assert_index_equal(dropped.columns, expected)
 
         dropped = df.drop(['d', 'g'], axis=1, errors='ignore')
         expected = Index(['e', 'f'], name='second')
-        self.assert_index_equal(dropped.columns, expected)
+        tm.assert_index_equal(dropped.columns, expected)
 
     def test_drop_col_still_multiindex(self):
         arrays = [['a', 'b', 'c', 'top'],
@@ -221,7 +221,7 @@ class TestDataFrameSelectReindex(tm.TestCase, TestData):
 
         # pass non-Index
         newFrame = self.frame.reindex(list(self.ts1.index))
-        self.assert_index_equal(newFrame.index, self.ts1.index)
+        tm.assert_index_equal(newFrame.index, self.ts1.index)
 
         # copy with no axes
         result = self.frame.reindex()
@@ -866,7 +866,7 @@ class TestDataFrameSelectReindex(tm.TestCase, TestData):
         index = Index(['a', 'b', 'c'])
         dm = self.empty.reindex(index=[1, 2, 3])
         reindexed = dm.reindex(columns=index)
-        self.assert_index_equal(reindexed.columns, index)
+        tm.assert_index_equal(reindexed.columns, index)
 
         # ints are weird
         smaller = self.intframe.reindex(columns=['A', 'B', 'E'])

--- a/pandas/tests/frame/test_block_internals.py
+++ b/pandas/tests/frame/test_block_internals.py
@@ -517,8 +517,8 @@ starting,ending,measure
                         'd': [None, None, None],
                         'e': [3.14, 0.577, 2.773]})
 
-        self.assert_index_equal(df._get_numeric_data().columns,
-                                pd.Index(['a', 'b', 'e']))
+        tm.assert_index_equal(df._get_numeric_data().columns,
+                              pd.Index(['a', 'b', 'e']))
 
     def test_strange_column_corruption_issue(self):
         # (wesm) Unclear how exactly this is related to internal matters

--- a/pandas/tests/frame/test_constructors.py
+++ b/pandas/tests/frame/test_constructors.py
@@ -161,11 +161,11 @@ class TestDataFrameConstructors(tm.TestCase, TestData):
         index = self.frame.index
 
         df = DataFrame(rec)
-        self.assert_index_equal(df.columns, pd.Index(rec.dtype.names))
+        tm.assert_index_equal(df.columns, pd.Index(rec.dtype.names))
 
         df2 = DataFrame(rec, index=index)
-        self.assert_index_equal(df2.columns, pd.Index(rec.dtype.names))
-        self.assert_index_equal(df2.index, index)
+        tm.assert_index_equal(df2.columns, pd.Index(rec.dtype.names))
+        tm.assert_index_equal(df2.index, index)
 
         rng = np.arange(len(rec))[::-1]
         df3 = DataFrame(rec, index=rng, columns=['C', 'B'])
@@ -237,7 +237,7 @@ class TestDataFrameConstructors(tm.TestCase, TestData):
 
         # Length-one dict micro-optimization
         frame = DataFrame({'A': {'1': 1, '2': 2}})
-        self.assert_index_equal(frame.index, pd.Index(['1', '2']))
+        tm.assert_index_equal(frame.index, pd.Index(['1', '2']))
 
         # empty dict plus index
         idx = Index([0, 1, 2])
@@ -253,7 +253,7 @@ class TestDataFrameConstructors(tm.TestCase, TestData):
 
         # with dict of empty list and Series
         frame = DataFrame({'A': [], 'B': []}, columns=['A', 'B'])
-        self.assert_index_equal(frame.index, Index([], dtype=np.int64))
+        tm.assert_index_equal(frame.index, Index([], dtype=np.int64))
 
         # GH 14381
         # Dict with None value
@@ -555,14 +555,14 @@ class TestDataFrameConstructors(tm.TestCase, TestData):
 
         # automatic labeling
         frame = DataFrame(mat)
-        self.assert_index_equal(frame.index, pd.Index(lrange(2)))
-        self.assert_index_equal(frame.columns, pd.Index(lrange(3)))
+        tm.assert_index_equal(frame.index, pd.Index(lrange(2)))
+        tm.assert_index_equal(frame.columns, pd.Index(lrange(3)))
 
         frame = DataFrame(mat, index=[1, 2])
-        self.assert_index_equal(frame.columns, pd.Index(lrange(3)))
+        tm.assert_index_equal(frame.columns, pd.Index(lrange(3)))
 
         frame = DataFrame(mat, columns=['A', 'B', 'C'])
-        self.assert_index_equal(frame.index, pd.Index(lrange(2)))
+        tm.assert_index_equal(frame.index, pd.Index(lrange(2)))
 
         # 0-length axis
         frame = DataFrame(empty((0, 3)))
@@ -1073,7 +1073,7 @@ class TestDataFrameConstructors(tm.TestCase, TestData):
         a = Series([1, 2, 3], index=['a', 'b', 'c'], name='x')
         df = DataFrame(a)
         self.assertEqual(df.columns[0], 'x')
-        self.assert_index_equal(df.index, a.index)
+        tm.assert_index_equal(df.index, a.index)
 
         # ndarray like
         arr = np.random.randn(10)
@@ -1123,7 +1123,7 @@ class TestDataFrameConstructors(tm.TestCase, TestData):
         df2 = DataFrame(s2, index=other_index)
         exp2 = DataFrame(s2.reindex(other_index))
         self.assertEqual(df2.columns[0], 0)
-        self.assert_index_equal(df2.index, other_index)
+        tm.assert_index_equal(df2.index, other_index)
         tm.assert_frame_equal(df2, exp2)
 
     def test_constructor_manager_resize(self):
@@ -1132,8 +1132,8 @@ class TestDataFrameConstructors(tm.TestCase, TestData):
 
         result = DataFrame(self.frame._data, index=index,
                            columns=columns)
-        self.assert_index_equal(result.index, Index(index))
-        self.assert_index_equal(result.columns, Index(columns))
+        tm.assert_index_equal(result.index, Index(index))
+        tm.assert_index_equal(result.columns, Index(columns))
 
     def test_constructor_from_items(self):
         items = [(c, self.frame[c]) for c in self.frame.columns]
@@ -1518,7 +1518,7 @@ class TestDataFrameConstructors(tm.TestCase, TestData):
 
         index = pd.Index(np.arange(len(arr))[::-1])
         indexed_frame = DataFrame.from_records(arr, index=index)
-        self.assert_index_equal(indexed_frame.index, index)
+        tm.assert_index_equal(indexed_frame.index, index)
 
         # without names, it should go to last ditch
         arr2 = np.zeros((2, 3))
@@ -1799,8 +1799,8 @@ class TestDataFrameConstructors(tm.TestCase, TestData):
         # empty case
         result = DataFrame.from_records([], columns=['foo', 'bar', 'baz'])
         self.assertEqual(len(result), 0)
-        self.assert_index_equal(result.columns,
-                                pd.Index(['foo', 'bar', 'baz']))
+        tm.assert_index_equal(result.columns,
+                              pd.Index(['foo', 'bar', 'baz']))
 
         result = DataFrame.from_records([])
         self.assertEqual(len(result), 0)

--- a/pandas/tests/frame/test_dtypes.py
+++ b/pandas/tests/frame/test_dtypes.py
@@ -553,7 +553,7 @@ class TestDataFrameDatetimeWithTZ(tm.TestCase, TestData):
                               pd.NaT,
                               Timestamp('2013-01-03 00:00:00+0100', tz='CET')],
                              ['foo', 'foo', 'foo']], dtype=object).T
-        self.assert_numpy_array_equal(result, expected)
+        tm.assert_numpy_array_equal(result, expected)
 
         # interleave with only datetime64[ns]
         result = self.tzframe.values
@@ -569,7 +569,7 @@ class TestDataFrameDatetimeWithTZ(tm.TestCase, TestData):
                               pd.NaT,
                               Timestamp('2013-01-03 00:00:00+0100',
                                         tz='CET')]], dtype=object).T
-        self.assert_numpy_array_equal(result, expected)
+        tm.assert_numpy_array_equal(result, expected)
 
     def test_astype(self):
         # astype

--- a/pandas/tests/frame/test_dtypes.py
+++ b/pandas/tests/frame/test_dtypes.py
@@ -613,7 +613,7 @@ class TestDataFrameDatetimeWithTZ(tm.TestCase, TestData):
                               ['2013-01-03', '2013-01-03 00:00:00-05:00',
                                '2013-01-03 00:00:00+01:00']],
                              columns=self.tzframe.columns)
-        self.assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
         result = str(self.tzframe)
         self.assertTrue('0 2013-01-01 2013-01-01 00:00:00-05:00 '

--- a/pandas/tests/frame/test_indexing.py
+++ b/pandas/tests/frame/test_indexing.py
@@ -239,7 +239,7 @@ class TestDataFrameIndexing(tm.TestCase, TestData):
         subindex = self.tsframe.index[indexer]
         subframe = self.tsframe[indexer]
 
-        self.assert_index_equal(subindex, subframe.index)
+        tm.assert_index_equal(subindex, subframe.index)
         with assertRaisesRegexp(ValueError, 'Item wrong length'):
             self.tsframe[indexer[:-1]]
 

--- a/pandas/tests/frame/test_missing.py
+++ b/pandas/tests/frame/test_missing.py
@@ -80,8 +80,8 @@ class TestDataFrameMissingData(tm.TestCase, TestData):
         assert_series_equal(frame['foo'], original)
         self.assertTrue((frame['bar'] == 5).all())
         inp_frame2.dropna(subset=['bar'], inplace=True)
-        self.assert_index_equal(samesize_frame.index, self.frame.index)
-        self.assert_index_equal(inp_frame2.index, self.frame.index)
+        tm.assert_index_equal(samesize_frame.index, self.frame.index)
+        tm.assert_index_equal(inp_frame2.index, self.frame.index)
 
     def test_dropna(self):
         df = DataFrame(np.random.randn(6, 4))

--- a/pandas/tests/frame/test_missing.py
+++ b/pandas/tests/frame/test_missing.py
@@ -324,7 +324,7 @@ class TestDataFrameMissingData(tm.TestCase, TestData):
                                  'C': ['foo', 'bar', '?'],
                                  'D': ['foo2', 'bar2', '?']},
                                 index=date_range('20130110', periods=3))
-        self.assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
         df = pd.DataFrame({'A': [-1, -2, np.nan],
                            'B': [pd.Timestamp('2013-01-01'),
@@ -339,7 +339,7 @@ class TestDataFrameMissingData(tm.TestCase, TestData):
                                  'C': ['foo', 'bar', '?'],
                                  'D': ['foo2', 'bar2', '?']},
                                 index=pd.date_range('20130110', periods=3))
-        self.assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, expected)
 
     def test_ffill(self):
         self.tsframe['A'][:5] = nan

--- a/pandas/tests/frame/test_mutate_columns.py
+++ b/pandas/tests/frame/test_mutate_columns.py
@@ -121,12 +121,12 @@ class TestDataFrameMutateColumns(tm.TestCase, TestData):
                        columns=['c', 'b', 'a'])
 
         df.insert(0, 'foo', df['a'])
-        self.assert_index_equal(df.columns, Index(['foo', 'c', 'b', 'a']))
+        tm.assert_index_equal(df.columns, Index(['foo', 'c', 'b', 'a']))
         tm.assert_series_equal(df['a'], df['foo'], check_names=False)
 
         df.insert(2, 'bar', df['c'])
-        self.assert_index_equal(df.columns,
-                                Index(['foo', 'c', 'bar', 'b', 'a']))
+        tm.assert_index_equal(df.columns,
+                              Index(['foo', 'c', 'bar', 'b', 'a']))
         tm.assert_almost_equal(df['c'], df['bar'], check_names=False)
 
         # diff dtype

--- a/pandas/tests/frame/test_operators.py
+++ b/pandas/tests/frame/test_operators.py
@@ -775,7 +775,7 @@ class TestDataFrameOperators(tm.TestCase, TestData):
         self.assertTrue(np.isnan(added['D']).all())
 
         self_added = self.frame + self.frame
-        self.assert_index_equal(self_added.index, self.frame.index)
+        tm.assert_index_equal(self_added.index, self.frame.index)
 
         added_rev = frame_copy + self.frame
         self.assertTrue(np.isnan(added['D']).all())
@@ -872,7 +872,7 @@ class TestDataFrameOperators(tm.TestCase, TestData):
         smaller_frame = self.tsframe[:-5]
         smaller_added = smaller_frame.add(ts, axis='index')
 
-        self.assert_index_equal(smaller_added.index, self.tsframe.index)
+        tm.assert_index_equal(smaller_added.index, self.tsframe.index)
 
         smaller_ts = ts[:-5]
         smaller_added2 = self.tsframe.add(smaller_ts, axis='index')

--- a/pandas/tests/frame/test_operators.py
+++ b/pandas/tests/frame/test_operators.py
@@ -677,13 +677,13 @@ class TestDataFrameOperators(tm.TestCase, TestData):
         # not empty DataFrame
         for op in ['eq', 'ne', 'gt', 'lt', 'ge', 'le']:
             result = getattr(df, op)(const).get_dtype_counts()
-            self.assert_series_equal(result, Series([2], ['bool']))
+            tm.assert_series_equal(result, Series([2], ['bool']))
 
         # empty DataFrame
         empty = df.iloc[:0]
         for op in ['eq', 'ne', 'gt', 'lt', 'ge', 'le']:
             result = getattr(empty, op)(const).get_dtype_counts()
-            self.assert_series_equal(result, Series([2], ['bool']))
+            tm.assert_series_equal(result, Series([2], ['bool']))
 
     def test_dti_tz_convert_to_utc(self):
         base = pd.DatetimeIndex(['2011-01-01', '2011-01-02',

--- a/pandas/tests/frame/test_operators.py
+++ b/pandas/tests/frame/test_operators.py
@@ -897,12 +897,12 @@ class TestDataFrameOperators(tm.TestCase, TestData):
 
     def test_combineFunc(self):
         result = self.frame * 2
-        self.assert_numpy_array_equal(result.values, self.frame.values * 2)
+        tm.assert_numpy_array_equal(result.values, self.frame.values * 2)
 
         # vs mix
         result = self.mixed_float * 2
         for c, s in compat.iteritems(result):
-            self.assert_numpy_array_equal(
+            tm.assert_numpy_array_equal(
                 s.values, self.mixed_float[c].values * 2)
         _check_mixed_float(result, dtype=dict(C=None))
 
@@ -919,21 +919,23 @@ class TestDataFrameOperators(tm.TestCase, TestData):
 
         def test_comp(func):
             result = func(df1, df2)
-            self.assert_numpy_array_equal(result.values,
-                                          func(df1.values, df2.values))
-            with assertRaisesRegexp(ValueError, 'Wrong number of dimensions'):
+            tm.assert_numpy_array_equal(result.values,
+                                        func(df1.values, df2.values))
+            with tm.assertRaisesRegexp(ValueError,
+                                       'Wrong number of dimensions'):
                 func(df1, ndim_5)
 
             result2 = func(self.simple, row)
-            self.assert_numpy_array_equal(result2.values,
-                                          func(self.simple.values, row.values))
+            tm.assert_numpy_array_equal(result2.values,
+                                        func(self.simple.values, row.values))
 
             result3 = func(self.frame, 0)
-            self.assert_numpy_array_equal(result3.values,
-                                          func(self.frame.values, 0))
+            tm.assert_numpy_array_equal(result3.values,
+                                        func(self.frame.values, 0))
 
-            with assertRaisesRegexp(ValueError, 'Can only compare '
-                                    'identically-labeled DataFrame'):
+            with tm.assertRaisesRegexp(ValueError,
+                                       'Can only compare identically'
+                                       '-labeled DataFrame'):
                 func(self.simple, self.simple[:2])
 
         test_comp(operator.eq)
@@ -950,7 +952,7 @@ class TestDataFrameOperators(tm.TestCase, TestData):
             expected = missing_df.values < 0
         with np.errstate(invalid='raise'):
             result = (missing_df < 0).values
-        self.assert_numpy_array_equal(result, expected)
+        tm.assert_numpy_array_equal(result, expected)
 
     def test_string_comparison(self):
         df = DataFrame([{"a": 1, "b": "foo"}, {"a": 2, "b": "bar"}])

--- a/pandas/tests/frame/test_period.py
+++ b/pandas/tests/frame/test_period.py
@@ -113,8 +113,8 @@ class TestPeriodIndex(tm.TestCase):
         expected = pd.date_range('2001-01-01', '2009-01-01', freq='AS')
         self.assertTrue(isinstance(result1.columns, DatetimeIndex))
         self.assertTrue(isinstance(result2.columns, DatetimeIndex))
-        self.assert_numpy_array_equal(result1.columns.asi8, expected.asi8)
-        self.assert_numpy_array_equal(result2.columns.asi8, expected.asi8)
+        tm.assert_numpy_array_equal(result1.columns.asi8, expected.asi8)
+        tm.assert_numpy_array_equal(result2.columns.asi8, expected.asi8)
         # PeriodIndex.to_timestamp always use 'infer'
         self.assertEqual(result1.columns.freqstr, 'AS-JAN')
         self.assertEqual(result2.columns.freqstr, 'AS-JAN')

--- a/pandas/tests/frame/test_reshape.py
+++ b/pandas/tests/frame/test_reshape.py
@@ -79,7 +79,7 @@ class TestDataFrameReshape(tm.TestCase, TestData):
 
         result = df.pivot(index=1, columns=0, values=2)
         repr(result)
-        self.assert_index_equal(result.columns, Index(['A', 'B'], name=0))
+        tm.assert_index_equal(result.columns, Index(['A', 'B'], name=0))
 
     def test_pivot_index_none(self):
         # gh-3962

--- a/pandas/tests/frame/test_timeseries.py
+++ b/pandas/tests/frame/test_timeseries.py
@@ -174,13 +174,13 @@ class TestDataFrameTimeSeriesMethods(tm.TestCase, TestData):
     def test_shift(self):
         # naive shift
         shiftedFrame = self.tsframe.shift(5)
-        self.assert_index_equal(shiftedFrame.index, self.tsframe.index)
+        tm.assert_index_equal(shiftedFrame.index, self.tsframe.index)
 
         shiftedSeries = self.tsframe['A'].shift(5)
         assert_series_equal(shiftedFrame['A'], shiftedSeries)
 
         shiftedFrame = self.tsframe.shift(-5)
-        self.assert_index_equal(shiftedFrame.index, self.tsframe.index)
+        tm.assert_index_equal(shiftedFrame.index, self.tsframe.index)
 
         shiftedSeries = self.tsframe['A'].shift(-5)
         assert_series_equal(shiftedFrame['A'], shiftedSeries)
@@ -208,8 +208,8 @@ class TestDataFrameTimeSeriesMethods(tm.TestCase, TestData):
         ps = tm.makePeriodFrame()
         shifted = ps.shift(1)
         unshifted = shifted.shift(-1)
-        self.assert_index_equal(shifted.index, ps.index)
-        self.assert_index_equal(unshifted.index, ps.index)
+        tm.assert_index_equal(shifted.index, ps.index)
+        tm.assert_index_equal(unshifted.index, ps.index)
         tm.assert_numpy_array_equal(unshifted.iloc[:, 0].valid().values,
                                     ps.iloc[:-1, 0].values)
 

--- a/pandas/tests/frame/test_to_csv.py
+++ b/pandas/tests/frame/test_to_csv.py
@@ -603,7 +603,7 @@ class TestDataFrameToCSV(tm.TestCase, TestData):
             exp = tsframe[:0]
             exp.index = []
 
-            self.assert_index_equal(recons.columns, exp.columns)
+            tm.assert_index_equal(recons.columns, exp.columns)
             self.assertEqual(len(recons), 0)
 
     def test_to_csv_float32_nanrep(self):

--- a/pandas/tests/groupby/test_aggregate.py
+++ b/pandas/tests/groupby/test_aggregate.py
@@ -639,7 +639,7 @@ class TestGroupByAggregate(tm.TestCase):
         result = self.df.groupby('A')['C'].agg(funcs)
         exp_cols = Index(['mean', 'max', 'min'])
 
-        self.assert_index_equal(result.columns, exp_cols)
+        tm.assert_index_equal(result.columns, exp_cols)
 
     def test_multiple_functions_tuples_and_non_tuples(self):
         # #1359

--- a/pandas/tests/groupby/test_categorical.py
+++ b/pandas/tests/groupby/test_categorical.py
@@ -376,7 +376,7 @@ class TestGroupByCategorical(MixIn, tm.TestCase):
         result = data.groupby("b").mean()
         result = result["a"].values
         exp = np.array([1, 2, 4, np.nan])
-        self.assert_numpy_array_equal(result, exp)
+        tm.assert_numpy_array_equal(result, exp)
 
     def test_groupby_sort_categorical(self):
         # dataframe groupby sort was being ignored # GH 8868

--- a/pandas/tests/groupby/test_categorical.py
+++ b/pandas/tests/groupby/test_categorical.py
@@ -113,14 +113,12 @@ class TestGroupByCategorical(MixIn, tm.TestCase):
         expc = Categorical.from_codes(np.arange(4).repeat(8),
                                       levels, ordered=True)
         exp = CategoricalIndex(expc)
-        self.assert_index_equal((desc_result.stack()
-                                            .index
-                                            .get_level_values(0)), exp)
+        tm.assert_index_equal((desc_result.stack().index
+                               .get_level_values(0)), exp)
         exp = Index(['count', 'mean', 'std', 'min', '25%', '50%',
                      '75%', 'max'] * 4)
-        self.assert_index_equal((desc_result.stack()
-                                            .index
-                                            .get_level_values(1)), exp)
+        tm.assert_index_equal((desc_result.stack().index
+                               .get_level_values(1)), exp)
 
     def test_groupby_datetime_categorical(self):
         # GH9049: ensure backward compatibility
@@ -157,14 +155,12 @@ class TestGroupByCategorical(MixIn, tm.TestCase):
         expc = Categorical.from_codes(
             np.arange(4).repeat(8), levels, ordered=True)
         exp = CategoricalIndex(expc)
-        self.assert_index_equal((desc_result.stack()
-                                            .index
-                                            .get_level_values(0)), exp)
+        tm.assert_index_equal((desc_result.stack().index
+                               .get_level_values(0)), exp)
         exp = Index(['count', 'mean', 'std', 'min', '25%', '50%',
                      '75%', 'max'] * 4)
-        self.assert_index_equal((desc_result.stack()
-                                            .index
-                                            .get_level_values(1)), exp)
+        tm.assert_index_equal((desc_result.stack().index
+                               .get_level_values(1)), exp)
 
     def test_groupby_categorical_index(self):
 

--- a/pandas/tests/groupby/test_groupby.py
+++ b/pandas/tests/groupby/test_groupby.py
@@ -2204,7 +2204,7 @@ class TestGroupBy(MixIn, tm.TestCase):
         result = grouped.apply(len)
         expected = grouped.count()['C']
         tm.assert_index_equal(result.index, expected.index)
-        self.assert_numpy_array_equal(result.values, expected.values)
+        tm.assert_numpy_array_equal(result.values, expected.values)
 
     def test_apply_frame_concat_series(self):
         def trans(group):
@@ -2963,7 +2963,7 @@ class TestGroupBy(MixIn, tm.TestCase):
         }
 
         for k in grouped.indices:
-            self.assert_numpy_array_equal(grouped.indices[k], expected[k])
+            tm.assert_numpy_array_equal(grouped.indices[k], expected[k])
 
         tm.assert_frame_equal(
             grouped.get_group(Timestamp('2013-01-01')), df.iloc[[1, 7]])
@@ -3045,7 +3045,7 @@ class TestGroupBy(MixIn, tm.TestCase):
         tmp = d.groupby(['group']).mean()
         res_values = np.array([[0, 1], [0, 1]], dtype=np.int64)
         tm.assert_index_equal(tmp.columns, Index(['zeros', 'ones']))
-        self.assert_numpy_array_equal(tmp.values, res_values)
+        tm.assert_numpy_array_equal(tmp.values, res_values)
 
     def test_int32_overflow(self):
         B = np.concatenate((np.arange(10000), np.arange(10000), np.arange(5000)
@@ -3070,17 +3070,17 @@ class TestGroupBy(MixIn, tm.TestCase):
         tups = lmap(tuple, df[['a', 'b', 'c']].values)
         tups = com._asarray_tuplesafe(tups)
         result = df.groupby(['a', 'b', 'c'], sort=True).sum()
-        self.assert_numpy_array_equal(result.index.values, tups[[1, 2, 0]])
+        tm.assert_numpy_array_equal(result.index.values, tups[[1, 2, 0]])
 
         tups = lmap(tuple, df[['c', 'a', 'b']].values)
         tups = com._asarray_tuplesafe(tups)
         result = df.groupby(['c', 'a', 'b'], sort=True).sum()
-        self.assert_numpy_array_equal(result.index.values, tups)
+        tm.assert_numpy_array_equal(result.index.values, tups)
 
         tups = lmap(tuple, df[['b', 'c', 'a']].values)
         tups = com._asarray_tuplesafe(tups)
         result = df.groupby(['b', 'c', 'a'], sort=True).sum()
-        self.assert_numpy_array_equal(result.index.values, tups[[2, 1, 0]])
+        tm.assert_numpy_array_equal(result.index.values, tups[[2, 1, 0]])
 
         df = DataFrame({'a': [0, 1, 2, 0, 1, 2],
                         'b': [0, 0, 0, 1, 1, 1],

--- a/pandas/tests/groupby/test_groupby.py
+++ b/pandas/tests/groupby/test_groupby.py
@@ -958,8 +958,8 @@ class TestGroupBy(MixIn, tm.TestCase):
              'c': 2}, index=[1])
         dfg_conversion_expected.index.name = 'a'
 
-        self.assert_frame_equal(dfg_no_conversion, dfg_no_conversion_expected)
-        self.assert_frame_equal(dfg_conversion, dfg_conversion_expected)
+        tm.assert_frame_equal(dfg_no_conversion, dfg_no_conversion_expected)
+        tm.assert_frame_equal(dfg_conversion, dfg_conversion_expected)
 
     def test_len(self):
         df = tm.makeTimeDataFrame()

--- a/pandas/tests/groupby/test_groupby.py
+++ b/pandas/tests/groupby/test_groupby.py
@@ -1719,7 +1719,7 @@ class TestGroupBy(MixIn, tm.TestCase):
                                 lambda x: x.day], axis=1)
 
         agged = grouped.agg(lambda x: x.sum())
-        self.assert_index_equal(agged.index, df.columns)
+        tm.assert_index_equal(agged.index, df.columns)
         assert_almost_equal(df.T.values, agged.values)
 
         agged = grouped.agg(lambda x: x.sum())
@@ -2183,7 +2183,7 @@ class TestGroupBy(MixIn, tm.TestCase):
         result = grouped.apply(f)
 
         tm.assertIsInstance(result, DataFrame)
-        self.assert_index_equal(result.index, ts.index)
+        tm.assert_index_equal(result.index, ts.index)
 
     def test_apply_series_yield_constant(self):
         result = self.df.groupby(['A', 'B'])['C'].apply(len)
@@ -2203,7 +2203,7 @@ class TestGroupBy(MixIn, tm.TestCase):
         grouped = self.df.groupby(['A', 'B'])
         result = grouped.apply(len)
         expected = grouped.count()['C']
-        self.assert_index_equal(result.index, expected.index)
+        tm.assert_index_equal(result.index, expected.index)
         self.assert_numpy_array_equal(result.values, expected.values)
 
     def test_apply_frame_concat_series(self):
@@ -2317,26 +2317,26 @@ class TestGroupBy(MixIn, tm.TestCase):
         df = DataFrame(np.random.randn(8, 4), index=index, columns=columns)
 
         result = df.groupby(level=0).mean()
-        self.assert_index_equal(result.columns, columns)
+        tm.assert_index_equal(result.columns, columns)
 
         result = df.groupby(level=0, axis=1).mean()
-        self.assert_index_equal(result.index, df.index)
+        tm.assert_index_equal(result.index, df.index)
 
         result = df.groupby(level=0).agg(np.mean)
-        self.assert_index_equal(result.columns, columns)
+        tm.assert_index_equal(result.columns, columns)
 
         result = df.groupby(level=0).apply(lambda x: x.mean())
-        self.assert_index_equal(result.columns, columns)
+        tm.assert_index_equal(result.columns, columns)
 
         result = df.groupby(level=0, axis=1).agg(lambda x: x.mean(1))
-        self.assert_index_equal(result.columns, Index(['A', 'B']))
-        self.assert_index_equal(result.index, df.index)
+        tm.assert_index_equal(result.columns, Index(['A', 'B']))
+        tm.assert_index_equal(result.index, df.index)
 
         # add a nuisance column
         sorted_columns, _ = columns.sortlevel(0)
         df['A', 'foo'] = 'bar'
         result = df.groupby(level=0).mean()
-        self.assert_index_equal(result.columns, df.columns[:-1])
+        tm.assert_index_equal(result.columns, df.columns[:-1])
 
     def test_pass_args_kwargs(self):
         from numpy import percentile
@@ -3023,18 +3023,18 @@ class TestGroupBy(MixIn, tm.TestCase):
 
             tm.assert_panel_equal(agged, agged2)
 
-            self.assert_index_equal(agged.items, Index([0, 1]))
+            tm.assert_index_equal(agged.items, Index([0, 1]))
 
             grouped = self.panel.groupby(lambda x: x.month, axis='major')
             agged = grouped.mean()
 
             exp = Index(sorted(list(set(self.panel.major_axis.month))))
-            self.assert_index_equal(agged.major_axis, exp)
+            tm.assert_index_equal(agged.major_axis, exp)
 
             grouped = self.panel.groupby({'A': 0, 'B': 0, 'C': 1, 'D': 1},
                                          axis='minor')
             agged = grouped.mean()
-            self.assert_index_equal(agged.minor_axis, Index([0, 1]))
+            tm.assert_index_equal(agged.minor_axis, Index([0, 1]))
 
     def test_groupby_2d_malformed(self):
         d = DataFrame(index=lrange(2))
@@ -3044,7 +3044,7 @@ class TestGroupBy(MixIn, tm.TestCase):
         d['label'] = ['l1', 'l2']
         tmp = d.groupby(['group']).mean()
         res_values = np.array([[0, 1], [0, 1]], dtype=np.int64)
-        self.assert_index_equal(tmp.columns, Index(['zeros', 'ones']))
+        tm.assert_index_equal(tmp.columns, Index(['zeros', 'ones']))
         self.assert_numpy_array_equal(tmp.values, res_values)
 
     def test_int32_overflow(self):

--- a/pandas/tests/groupby/test_groupby.py
+++ b/pandas/tests/groupby/test_groupby.py
@@ -2132,13 +2132,13 @@ class TestGroupBy(MixIn, tm.TestCase):
                           Index(range(1, 7), name='foo'))
 
         result = s.groupby(level=0).sum()
-        self.assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
         result = s.groupby(level=[0]).sum()
-        self.assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
         result = s.groupby(level=-1).sum()
-        self.assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
         result = s.groupby(level=[-1]).sum()
-        self.assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         tm.assertRaises(ValueError, s.groupby, level=1)
         tm.assertRaises(ValueError, s.groupby, level=-2)

--- a/pandas/tests/groupby/test_transform.py
+++ b/pandas/tests/groupby/test_transform.py
@@ -111,13 +111,13 @@ class TestGroupBy(MixIn, tm.TestCase):
         grouped = self.ts.groupby(lambda x: x.month)
         result = grouped.transform(np.mean)
 
-        self.assert_index_equal(result.index, self.ts.index)
+        tm.assert_index_equal(result.index, self.ts.index)
         for _, gp in grouped:
             assert_fp_equal(result.reindex(gp.index), gp.mean())
 
         grouped = self.tsframe.groupby(lambda x: x.month)
         result = grouped.transform(np.mean)
-        self.assert_index_equal(result.index, self.tsframe.index)
+        tm.assert_index_equal(result.index, self.tsframe.index)
         for _, gp in grouped:
             agged = gp.mean()
             res = result.reindex(gp.index)
@@ -128,8 +128,8 @@ class TestGroupBy(MixIn, tm.TestCase):
         grouped = self.tsframe.groupby({'A': 0, 'B': 0, 'C': 1, 'D': 1},
                                        axis=1)
         result = grouped.transform(np.mean)
-        self.assert_index_equal(result.index, self.tsframe.index)
-        self.assert_index_equal(result.columns, self.tsframe.columns)
+        tm.assert_index_equal(result.index, self.tsframe.index)
+        tm.assert_index_equal(result.columns, self.tsframe.columns)
         for _, gp in grouped:
             agged = gp.mean(1)
             res = result.reindex(columns=gp.columns)

--- a/pandas/tests/groupby/test_transform.py
+++ b/pandas/tests/groupby/test_transform.py
@@ -429,8 +429,8 @@ class TestGroupBy(MixIn, tm.TestCase):
                 ans = np.zeros_like(data)
                 labels = np.array([0, 0, 0, 0], dtype=np.int64)
                 pd_op(ans, data, labels, is_datetimelike)
-                self.assert_numpy_array_equal(np_op(data), ans[:, 0],
-                                              check_dtype=False)
+                tm.assert_numpy_array_equal(np_op(data), ans[:, 0],
+                                            check_dtype=False)
 
         # with nans
         labels = np.array([0, 0, 0, 0, 0], dtype=np.int64)
@@ -440,13 +440,13 @@ class TestGroupBy(MixIn, tm.TestCase):
         actual.fill(np.nan)
         groupby.group_cumprod_float64(actual, data, labels, is_datetimelike)
         expected = np.array([1, 2, 6, np.nan, 24], dtype='float64')
-        self.assert_numpy_array_equal(actual[:, 0], expected)
+        tm.assert_numpy_array_equal(actual[:, 0], expected)
 
         actual = np.zeros_like(data)
         actual.fill(np.nan)
         groupby.group_cumsum(actual, data, labels, is_datetimelike)
         expected = np.array([1, 3, 6, np.nan, 10], dtype='float64')
-        self.assert_numpy_array_equal(actual[:, 0], expected)
+        tm.assert_numpy_array_equal(actual[:, 0], expected)
 
         # timedelta
         is_datetimelike = True
@@ -457,7 +457,7 @@ class TestGroupBy(MixIn, tm.TestCase):
         expected = np.array([np.timedelta64(1, 'ns'), np.timedelta64(
             2, 'ns'), np.timedelta64(3, 'ns'), np.timedelta64(4, 'ns'),
             np.timedelta64(5, 'ns')])
-        self.assert_numpy_array_equal(actual[:, 0].view('m8[ns]'), expected)
+        tm.assert_numpy_array_equal(actual[:, 0].view('m8[ns]'), expected)
 
     def test_cython_transform(self):
         # GH 4095

--- a/pandas/tests/indexes/common.py
+++ b/pandas/tests/indexes/common.py
@@ -312,7 +312,7 @@ class Base(object):
             idx.name = 'foo'
             result = idx.drop_duplicates()
             self.assertEqual(result.name, 'foo')
-            self.assert_index_equal(result, Index([ind[0]], name='foo'))
+            tm.assert_index_equal(result, Index([ind[0]], name='foo'))
 
     def test_get_unique_index(self):
         for ind in self.indices.values():
@@ -333,7 +333,7 @@ class Base(object):
 
             for dropna in [False, True]:
                 result = idx._get_unique_index(dropna=dropna)
-                self.assert_index_equal(result, idx_unique)
+                tm.assert_index_equal(result, idx_unique)
 
             # nans:
 
@@ -359,7 +359,7 @@ class Base(object):
                                         [idx_unique_nan, idx_unique]):
                 for i in [idx_nan, idx_unique_nan]:
                     result = i._get_unique_index(dropna=dropna)
-                    self.assert_index_equal(result, expected)
+                    tm.assert_index_equal(result, expected)
 
     def test_sort(self):
         for ind in self.indices.values():
@@ -880,7 +880,7 @@ class Base(object):
             else:
                 idx = index.copy()
                 result = idx.fillna(idx[0])
-                self.assert_index_equal(result, idx)
+                tm.assert_index_equal(result, idx)
                 self.assertFalse(result is idx)
 
                 msg = "'value' must be a scalar, passed: "

--- a/pandas/tests/indexes/common.py
+++ b/pandas/tests/indexes/common.py
@@ -842,7 +842,7 @@ class Base(object):
 
                 # cases in indices doesn't include NaN
                 expected = np.array([False] * len(idx), dtype=bool)
-                self.assert_numpy_array_equal(idx._isnan, expected)
+                tm.assert_numpy_array_equal(idx._isnan, expected)
                 self.assertFalse(idx.hasnans)
 
                 idx = index.copy()
@@ -864,7 +864,7 @@ class Base(object):
 
                 expected = np.array([False] * len(idx), dtype=bool)
                 expected[1] = True
-                self.assert_numpy_array_equal(idx._isnan, expected)
+                tm.assert_numpy_array_equal(idx._isnan, expected)
                 self.assertTrue(idx.hasnans)
 
     def test_fillna(self):
@@ -904,7 +904,7 @@ class Base(object):
 
                 expected = np.array([False] * len(idx), dtype=bool)
                 expected[1] = True
-                self.assert_numpy_array_equal(idx._isnan, expected)
+                tm.assert_numpy_array_equal(idx._isnan, expected)
                 self.assertTrue(idx.hasnans)
 
     def test_nulls(self):
@@ -913,7 +913,7 @@ class Base(object):
 
         for name, index in self.indices.items():
             if len(index) == 0:
-                self.assert_numpy_array_equal(
+                tm.assert_numpy_array_equal(
                     index.isnull(), np.array([], dtype=bool))
             elif isinstance(index, MultiIndex):
                 idx = index.copy()
@@ -923,14 +923,14 @@ class Base(object):
             else:
 
                 if not index.hasnans:
-                    self.assert_numpy_array_equal(
+                    tm.assert_numpy_array_equal(
                         index.isnull(), np.zeros(len(index), dtype=bool))
-                    self.assert_numpy_array_equal(
+                    tm.assert_numpy_array_equal(
                         index.notnull(), np.ones(len(index), dtype=bool))
                 else:
                     result = isnull(index)
-                    self.assert_numpy_array_equal(index.isnull(), result)
-                    self.assert_numpy_array_equal(index.notnull(), ~result)
+                    tm.assert_numpy_array_equal(index.isnull(), result)
+                    tm.assert_numpy_array_equal(index.notnull(), ~result)
 
     def test_empty(self):
         # GH 15270

--- a/pandas/tests/indexes/datetimelike.py
+++ b/pandas/tests/indexes/datetimelike.py
@@ -9,7 +9,7 @@ class DatetimeLike(Base):
     def test_shift_identity(self):
 
         idx = self.create_index()
-        self.assert_index_equal(idx, idx.shift(0))
+        tm.assert_index_equal(idx, idx.shift(0))
 
     def test_str(self):
 

--- a/pandas/tests/indexes/datetimes/test_astype.py
+++ b/pandas/tests/indexes/datetimes/test_astype.py
@@ -24,7 +24,7 @@ class TestDatetimeIndex(tm.TestCase):
 
         rng = date_range('1/1/2000', periods=10)
         result = rng.astype('i8')
-        self.assert_index_equal(result, Index(rng.asi8))
+        tm.assert_index_equal(result, Index(rng.asi8))
         self.assert_numpy_array_equal(result.values, rng.asi8)
 
     def test_astype_with_tz(self):

--- a/pandas/tests/indexes/datetimes/test_astype.py
+++ b/pandas/tests/indexes/datetimes/test_astype.py
@@ -25,7 +25,7 @@ class TestDatetimeIndex(tm.TestCase):
         rng = date_range('1/1/2000', periods=10)
         result = rng.astype('i8')
         tm.assert_index_equal(result, Index(rng.asi8))
-        self.assert_numpy_array_equal(result.values, rng.asi8)
+        tm.assert_numpy_array_equal(result.values, rng.asi8)
 
     def test_astype_with_tz(self):
 

--- a/pandas/tests/indexes/datetimes/test_construction.py
+++ b/pandas/tests/indexes/datetimes/test_construction.py
@@ -27,26 +27,26 @@ class TestDatetimeIndex(tm.TestCase):
 
         i = pd.date_range('20130101', periods=5, freq='H', tz='US/Eastern')
         i2 = DatetimeIndex(i, dtype=i.dtype)
-        self.assert_index_equal(i, i2)
+        tm.assert_index_equal(i, i2)
         assert i.tz.zone == 'US/Eastern'
 
         i2 = DatetimeIndex(i.tz_localize(None).asi8, tz=i.dtype.tz)
-        self.assert_index_equal(i, i2)
+        tm.assert_index_equal(i, i2)
         assert i.tz.zone == 'US/Eastern'
 
         i2 = DatetimeIndex(i.tz_localize(None).asi8, dtype=i.dtype)
-        self.assert_index_equal(i, i2)
+        tm.assert_index_equal(i, i2)
         assert i.tz.zone == 'US/Eastern'
 
         i2 = DatetimeIndex(
             i.tz_localize(None).asi8, dtype=i.dtype, tz=i.dtype.tz)
-        self.assert_index_equal(i, i2)
+        tm.assert_index_equal(i, i2)
         assert i.tz.zone == 'US/Eastern'
 
         # localize into the provided tz
         i2 = DatetimeIndex(i.tz_localize(None).asi8, tz='UTC')
         expected = i.tz_localize(None).tz_localize('UTC')
-        self.assert_index_equal(i2, expected)
+        tm.assert_index_equal(i2, expected)
 
         # incompat tz/dtype
         self.assertRaises(ValueError, lambda: DatetimeIndex(
@@ -202,7 +202,7 @@ class TestDatetimeIndex(tm.TestCase):
             [Timestamp('2011-01-01'), Timestamp('2011-01-02')], name='idx')
         exp = DatetimeIndex(
             [Timestamp('2011-01-01'), Timestamp('2011-01-02')], name='idx')
-        self.assert_index_equal(result, exp, exact=True)
+        tm.assert_index_equal(result, exp, exact=True)
         self.assertTrue(isinstance(result, DatetimeIndex))
 
         # same tz results in DatetimeIndex
@@ -213,7 +213,7 @@ class TestDatetimeIndex(tm.TestCase):
         exp = DatetimeIndex([Timestamp('2011-01-01 10:00'),
                              Timestamp('2011-01-02 10:00')],
                             tz='Asia/Tokyo', name='idx')
-        self.assert_index_equal(result, exp, exact=True)
+        tm.assert_index_equal(result, exp, exact=True)
         self.assertTrue(isinstance(result, DatetimeIndex))
 
         # same tz results in DatetimeIndex (DST)
@@ -224,7 +224,7 @@ class TestDatetimeIndex(tm.TestCase):
         exp = DatetimeIndex([Timestamp('2011-01-01 10:00'),
                              Timestamp('2011-08-01 10:00')],
                             tz='US/Eastern', name='idx')
-        self.assert_index_equal(result, exp, exact=True)
+        tm.assert_index_equal(result, exp, exact=True)
         self.assertTrue(isinstance(result, DatetimeIndex))
 
         # different tz coerces tz-naive to tz-awareIndex(dtype=object)
@@ -234,7 +234,7 @@ class TestDatetimeIndex(tm.TestCase):
         exp = DatetimeIndex([Timestamp('2011-01-01 05:00'),
                              Timestamp('2011-01-02 10:00')],
                             tz='US/Eastern', name='idx')
-        self.assert_index_equal(result, exp, exact=True)
+        tm.assert_index_equal(result, exp, exact=True)
         self.assertTrue(isinstance(result, DatetimeIndex))
 
         # tz mismatch affecting to tz-aware raises TypeError/ValueError

--- a/pandas/tests/indexes/datetimes/test_construction.py
+++ b/pandas/tests/indexes/datetimes/test_construction.py
@@ -360,7 +360,7 @@ class TestDatetimeIndex(tm.TestCase):
             expected_i8 = date_range('2013-01-01T00:00:00',
                                      '2016-01-01T23:59:59', freq=freq,
                                      tz='America/Lima')
-            self.assert_numpy_array_equal(idx.asi8, expected_i8.asi8)
+            tm.assert_numpy_array_equal(idx.asi8, expected_i8.asi8)
 
             idx = date_range('2013-01-01T00:00:00+09:00',
                              '2016-01-01T23:59:59+09:00', freq=freq)
@@ -370,7 +370,7 @@ class TestDatetimeIndex(tm.TestCase):
             expected_i8 = date_range('2013-01-01T00:00:00',
                                      '2016-01-01T23:59:59', freq=freq,
                                      tz='Asia/Tokyo')
-            self.assert_numpy_array_equal(idx.asi8, expected_i8.asi8)
+            tm.assert_numpy_array_equal(idx.asi8, expected_i8.asi8)
 
         tm._skip_if_no_dateutil()
 
@@ -385,7 +385,7 @@ class TestDatetimeIndex(tm.TestCase):
             expected_i8 = date_range('2013-01-01T00:00:00',
                                      '2016-01-01T23:59:59', freq=freq,
                                      tz='America/Lima')
-            self.assert_numpy_array_equal(idx.asi8, expected_i8.asi8)
+            tm.assert_numpy_array_equal(idx.asi8, expected_i8.asi8)
 
             idx = date_range('2013/1/1 0:00:00+9:00',
                              '2016/1/1 23:59:59+09:00', freq=freq)
@@ -395,7 +395,7 @@ class TestDatetimeIndex(tm.TestCase):
             expected_i8 = date_range('2013-01-01T00:00:00',
                                      '2016-01-01T23:59:59', freq=freq,
                                      tz='Asia/Tokyo')
-            self.assert_numpy_array_equal(idx.asi8, expected_i8.asi8)
+            tm.assert_numpy_array_equal(idx.asi8, expected_i8.asi8)
 
     def test_constructor_dtype(self):
 

--- a/pandas/tests/indexes/datetimes/test_date_range.py
+++ b/pandas/tests/indexes/datetimes/test_date_range.py
@@ -190,8 +190,8 @@ class TestGenRangeGeneration(tm.TestCase):
                                   freq='Q-DEC', tz=None)
         expected2 = DatetimeIndex(expected2_list, dtype='datetime64[ns]',
                                   freq='W-SUN', tz=None)
-        self.assert_index_equal(result1, expected1)
-        self.assert_index_equal(result2, expected2)
+        tm.assert_index_equal(result1, expected1)
+        tm.assert_index_equal(result2, expected2)
 
 
 class TestBusinessDateRange(tm.TestCase):
@@ -387,8 +387,8 @@ class TestBusinessDateRange(tm.TestCase):
             if begin == closed[0]:
                 expected_right = closed[1:]
 
-            self.assert_index_equal(expected_left, left)
-            self.assert_index_equal(expected_right, right)
+            tm.assert_index_equal(expected_left, left)
+            tm.assert_index_equal(expected_right, right)
 
     def test_range_closed_with_tz_aware_start_end(self):
         # GH12409, GH12684
@@ -407,8 +407,8 @@ class TestBusinessDateRange(tm.TestCase):
             if begin == closed[0]:
                 expected_right = closed[1:]
 
-            self.assert_index_equal(expected_left, left)
-            self.assert_index_equal(expected_right, right)
+            tm.assert_index_equal(expected_left, left)
+            tm.assert_index_equal(expected_right, right)
 
         begin = Timestamp('2011/1/1')
         end = Timestamp('2014/1/1')
@@ -430,8 +430,8 @@ class TestBusinessDateRange(tm.TestCase):
             if begintz == closed[0]:
                 expected_right = closed[1:]
 
-            self.assert_index_equal(expected_left, left)
-            self.assert_index_equal(expected_right, right)
+            tm.assert_index_equal(expected_left, left)
+            tm.assert_index_equal(expected_right, right)
 
     def test_range_closed_boundary(self):
         # GH 11804
@@ -452,9 +452,9 @@ class TestBusinessDateRange(tm.TestCase):
                 expected_right = both_boundary[1:]
                 expected_left = both_boundary[:-1]
 
-            self.assert_index_equal(right_boundary, expected_right)
-            self.assert_index_equal(left_boundary, expected_left)
-            self.assert_index_equal(both_boundary, expected_both)
+            tm.assert_index_equal(right_boundary, expected_right)
+            tm.assert_index_equal(left_boundary, expected_left)
+            tm.assert_index_equal(both_boundary, expected_both)
 
     def test_years_only(self):
         # GH 6961
@@ -476,8 +476,8 @@ class TestBusinessDateRange(tm.TestCase):
                                     '2005-01-13 15:45:00'],
                                    dtype='datetime64[ns]', freq='345T',
                                    tz=None)
-        self.assert_index_equal(result_1, expected_1)
-        self.assert_index_equal(result_2, expected_2)
+        tm.assert_index_equal(result_1, expected_1)
+        tm.assert_index_equal(result_2, expected_2)
 
 
 class TestCustomDateRange(tm.TestCase):
@@ -542,22 +542,22 @@ class TestCustomDateRange(tm.TestCase):
     def test_cdaterange(self):
         rng = cdate_range('2013-05-01', periods=3)
         xp = DatetimeIndex(['2013-05-01', '2013-05-02', '2013-05-03'])
-        self.assert_index_equal(xp, rng)
+        tm.assert_index_equal(xp, rng)
 
     def test_cdaterange_weekmask(self):
         rng = cdate_range('2013-05-01', periods=3,
                           weekmask='Sun Mon Tue Wed Thu')
         xp = DatetimeIndex(['2013-05-01', '2013-05-02', '2013-05-05'])
-        self.assert_index_equal(xp, rng)
+        tm.assert_index_equal(xp, rng)
 
     def test_cdaterange_holidays(self):
         rng = cdate_range('2013-05-01', periods=3, holidays=['2013-05-01'])
         xp = DatetimeIndex(['2013-05-02', '2013-05-03', '2013-05-06'])
-        self.assert_index_equal(xp, rng)
+        tm.assert_index_equal(xp, rng)
 
     def test_cdaterange_weekmask_and_holidays(self):
         rng = cdate_range('2013-05-01', periods=3,
                           weekmask='Sun Mon Tue Wed Thu',
                           holidays=['2013-05-01'])
         xp = DatetimeIndex(['2013-05-02', '2013-05-05', '2013-05-06'])
-        self.assert_index_equal(xp, rng)
+        tm.assert_index_equal(xp, rng)

--- a/pandas/tests/indexes/datetimes/test_datetime.py
+++ b/pandas/tests/indexes/datetimes/test_datetime.py
@@ -256,7 +256,7 @@ class TestDatetimeIndex(tm.TestCase):
 
         result = rng == list(rng)
         exp = rng == rng
-        self.assert_numpy_array_equal(result, exp)
+        tm.assert_numpy_array_equal(result, exp)
 
     def test_comparisons_nat(self):
 
@@ -285,72 +285,72 @@ class TestDatetimeIndex(tm.TestCase):
 
                 result = idx1 < idx2
                 expected = np.array([True, False, False, False, True, False])
-                self.assert_numpy_array_equal(result, expected)
+                tm.assert_numpy_array_equal(result, expected)
 
                 result = idx2 > idx1
                 expected = np.array([True, False, False, False, True, False])
-                self.assert_numpy_array_equal(result, expected)
+                tm.assert_numpy_array_equal(result, expected)
 
                 result = idx1 <= idx2
                 expected = np.array([True, False, False, False, True, True])
-                self.assert_numpy_array_equal(result, expected)
+                tm.assert_numpy_array_equal(result, expected)
 
                 result = idx2 >= idx1
                 expected = np.array([True, False, False, False, True, True])
-                self.assert_numpy_array_equal(result, expected)
+                tm.assert_numpy_array_equal(result, expected)
 
                 result = idx1 == idx2
                 expected = np.array([False, False, False, False, False, True])
-                self.assert_numpy_array_equal(result, expected)
+                tm.assert_numpy_array_equal(result, expected)
 
                 result = idx1 != idx2
                 expected = np.array([True, True, True, True, True, False])
-                self.assert_numpy_array_equal(result, expected)
+                tm.assert_numpy_array_equal(result, expected)
 
         with tm.assert_produces_warning(None):
             for idx1, val in [(fidx1, np.nan), (didx1, pd.NaT)]:
                 result = idx1 < val
                 expected = np.array([False, False, False, False, False, False])
-                self.assert_numpy_array_equal(result, expected)
+                tm.assert_numpy_array_equal(result, expected)
                 result = idx1 > val
-                self.assert_numpy_array_equal(result, expected)
+                tm.assert_numpy_array_equal(result, expected)
 
                 result = idx1 <= val
-                self.assert_numpy_array_equal(result, expected)
+                tm.assert_numpy_array_equal(result, expected)
                 result = idx1 >= val
-                self.assert_numpy_array_equal(result, expected)
+                tm.assert_numpy_array_equal(result, expected)
 
                 result = idx1 == val
-                self.assert_numpy_array_equal(result, expected)
+                tm.assert_numpy_array_equal(result, expected)
 
                 result = idx1 != val
                 expected = np.array([True, True, True, True, True, True])
-                self.assert_numpy_array_equal(result, expected)
+                tm.assert_numpy_array_equal(result, expected)
 
         # Check pd.NaT is handles as the same as np.nan
         with tm.assert_produces_warning(None):
             for idx1, val in [(fidx1, 3), (didx1, datetime(2014, 3, 1))]:
                 result = idx1 < val
                 expected = np.array([True, False, False, False, False, False])
-                self.assert_numpy_array_equal(result, expected)
+                tm.assert_numpy_array_equal(result, expected)
                 result = idx1 > val
                 expected = np.array([False, False, False, False, True, True])
-                self.assert_numpy_array_equal(result, expected)
+                tm.assert_numpy_array_equal(result, expected)
 
                 result = idx1 <= val
                 expected = np.array([True, False, True, False, False, False])
-                self.assert_numpy_array_equal(result, expected)
+                tm.assert_numpy_array_equal(result, expected)
                 result = idx1 >= val
                 expected = np.array([False, False, True, False, True, True])
-                self.assert_numpy_array_equal(result, expected)
+                tm.assert_numpy_array_equal(result, expected)
 
                 result = idx1 == val
                 expected = np.array([False, False, True, False, False, False])
-                self.assert_numpy_array_equal(result, expected)
+                tm.assert_numpy_array_equal(result, expected)
 
                 result = idx1 != val
                 expected = np.array([True, True, False, True, True, True])
-                self.assert_numpy_array_equal(result, expected)
+                tm.assert_numpy_array_equal(result, expected)
 
     def test_map(self):
         rng = date_range('1/1/2000', periods=10)
@@ -456,13 +456,11 @@ class TestDatetimeIndex(tm.TestCase):
 
         ordered, dexer = idx.sort_values(return_indexer=True)
         self.assertTrue(ordered.is_monotonic)
-        self.assert_numpy_array_equal(dexer,
-                                      np.array([1, 2, 0], dtype=np.intp))
+        tm.assert_numpy_array_equal(dexer, np.array([1, 2, 0], dtype=np.intp))
 
         ordered, dexer = idx.sort_values(return_indexer=True, ascending=False)
         self.assertTrue(ordered[::-1].is_monotonic)
-        self.assert_numpy_array_equal(dexer,
-                                      np.array([0, 2, 1], dtype=np.intp))
+        tm.assert_numpy_array_equal(dexer, np.array([0, 2, 1], dtype=np.intp))
 
     def test_take(self):
         dates = [datetime(2010, 1, 1, 14), datetime(2010, 1, 1, 15),
@@ -657,11 +655,11 @@ class TestDatetimeIndex(tm.TestCase):
         exp_idx = DatetimeIndex(['2014-01', '2014-02', '2014-03'])
 
         arr, idx = idx1.factorize()
-        self.assert_numpy_array_equal(arr, exp_arr)
+        tm.assert_numpy_array_equal(arr, exp_arr)
         tm.assert_index_equal(idx, exp_idx)
 
         arr, idx = idx1.factorize(sort=True)
-        self.assert_numpy_array_equal(arr, exp_arr)
+        tm.assert_numpy_array_equal(arr, exp_arr)
         tm.assert_index_equal(idx, exp_idx)
 
         # tz must be preserved
@@ -669,7 +667,7 @@ class TestDatetimeIndex(tm.TestCase):
         exp_idx = exp_idx.tz_localize('Asia/Tokyo')
 
         arr, idx = idx1.factorize()
-        self.assert_numpy_array_equal(arr, exp_arr)
+        tm.assert_numpy_array_equal(arr, exp_arr)
         tm.assert_index_equal(idx, exp_idx)
 
         idx2 = pd.DatetimeIndex(['2014-03', '2014-03', '2014-02', '2014-01',
@@ -678,20 +676,20 @@ class TestDatetimeIndex(tm.TestCase):
         exp_arr = np.array([2, 2, 1, 0, 2, 0], dtype=np.intp)
         exp_idx = DatetimeIndex(['2014-01', '2014-02', '2014-03'])
         arr, idx = idx2.factorize(sort=True)
-        self.assert_numpy_array_equal(arr, exp_arr)
+        tm.assert_numpy_array_equal(arr, exp_arr)
         tm.assert_index_equal(idx, exp_idx)
 
         exp_arr = np.array([0, 0, 1, 2, 0, 2], dtype=np.intp)
         exp_idx = DatetimeIndex(['2014-03', '2014-02', '2014-01'])
         arr, idx = idx2.factorize()
-        self.assert_numpy_array_equal(arr, exp_arr)
+        tm.assert_numpy_array_equal(arr, exp_arr)
         tm.assert_index_equal(idx, exp_idx)
 
         # freq must be preserved
         idx3 = date_range('2000-01', periods=4, freq='M', tz='Asia/Tokyo')
         exp_arr = np.array([0, 1, 2, 3], dtype=np.intp)
         arr, idx = idx3.factorize()
-        self.assert_numpy_array_equal(arr, exp_arr)
+        tm.assert_numpy_array_equal(arr, exp_arr)
         tm.assert_index_equal(idx, idx3)
 
     def test_factorize_tz(self):
@@ -704,7 +702,7 @@ class TestDatetimeIndex(tm.TestCase):
 
             for obj in [idx, pd.Series(idx)]:
                 arr, res = obj.factorize()
-                self.assert_numpy_array_equal(arr, exp_arr)
+                tm.assert_numpy_array_equal(arr, exp_arr)
                 tm.assert_index_equal(res, base)
 
     def test_factorize_dst(self):
@@ -714,7 +712,7 @@ class TestDatetimeIndex(tm.TestCase):
 
         for obj in [idx, pd.Series(idx)]:
             arr, res = obj.factorize()
-            self.assert_numpy_array_equal(arr, np.arange(12, dtype=np.intp))
+            tm.assert_numpy_array_equal(arr, np.arange(12, dtype=np.intp))
             tm.assert_index_equal(res, idx)
 
         idx = pd.date_range('2016-06-13', freq='H', periods=12,
@@ -722,7 +720,7 @@ class TestDatetimeIndex(tm.TestCase):
 
         for obj in [idx, pd.Series(idx)]:
             arr, res = obj.factorize()
-            self.assert_numpy_array_equal(arr, np.arange(12, dtype=np.intp))
+            tm.assert_numpy_array_equal(arr, np.arange(12, dtype=np.intp))
             tm.assert_index_equal(res, idx)
 
     def test_slice_with_negative_step(self):

--- a/pandas/tests/indexes/datetimes/test_datetime.py
+++ b/pandas/tests/indexes/datetimes/test_datetime.py
@@ -107,7 +107,7 @@ class TestDatetimeIndex(tm.TestCase):
         # round-trip of timezone
         index = date_range('20130101', periods=3, tz='US/Eastern', name='foo')
         unpickled = tm.round_trip_pickle(index)
-        self.assert_index_equal(index, unpickled)
+        tm.assert_index_equal(index, unpickled)
 
     def test_reindex_preserves_tz_if_target_is_empty_list_or_array(self):
         # GH7774

--- a/pandas/tests/indexes/datetimes/test_datetimelike.py
+++ b/pandas/tests/indexes/datetimes/test_datetimelike.py
@@ -28,19 +28,19 @@ class TestDatetimeIndex(DatetimeLike, tm.TestCase):
         expected = DatetimeIndex(['2013-01-02', '2013-01-03', '2013-01-04',
                                   '2013-01-05',
                                   '2013-01-06'], freq='D')
-        self.assert_index_equal(result, expected)
+        tm.assert_index_equal(result, expected)
 
         result = drange.shift(-1)
         expected = DatetimeIndex(['2012-12-31', '2013-01-01', '2013-01-02',
                                   '2013-01-03', '2013-01-04'],
                                  freq='D')
-        self.assert_index_equal(result, expected)
+        tm.assert_index_equal(result, expected)
 
         result = drange.shift(3, freq='2D')
         expected = DatetimeIndex(['2013-01-07', '2013-01-08', '2013-01-09',
                                   '2013-01-10',
                                   '2013-01-11'], freq='D')
-        self.assert_index_equal(result, expected)
+        tm.assert_index_equal(result, expected)
 
     def test_pickle_compat_construction(self):
         pass
@@ -60,7 +60,7 @@ class TestDatetimeIndex(DatetimeLike, tm.TestCase):
         third = Index(['a', 'b', 'c'])
         result = first.intersection(third)
         expected = pd.Index([], dtype=object)
-        self.assert_index_equal(result, expected)
+        tm.assert_index_equal(result, expected)
 
     def test_union(self):
         first = self.index[:5]

--- a/pandas/tests/indexes/datetimes/test_misc.py
+++ b/pandas/tests/indexes/datetimes/test_misc.py
@@ -61,7 +61,7 @@ class TestTimeSeries(tm.TestCase):
 
         expected = Index(rng.to_pydatetime(), dtype=object)
 
-        self.assert_numpy_array_equal(idx.values, expected.values)
+        tm.assert_numpy_array_equal(idx.values, expected.values)
 
     def test_range_edges(self):
         # GH 13672

--- a/pandas/tests/indexes/datetimes/test_misc.py
+++ b/pandas/tests/indexes/datetimes/test_misc.py
@@ -337,5 +337,5 @@ class TestDatetime64(tm.TestCase):
     def test_nanosecond_field(self):
         dti = DatetimeIndex(np.arange(10))
 
-        self.assert_index_equal(dti.nanosecond,
-                                pd.Index(np.arange(10, dtype=np.int64)))
+        tm.assert_index_equal(dti.nanosecond,
+                              pd.Index(np.arange(10, dtype=np.int64)))

--- a/pandas/tests/indexes/datetimes/test_missing.py
+++ b/pandas/tests/indexes/datetimes/test_missing.py
@@ -12,34 +12,34 @@ class TestDatetimeIndex(tm.TestCase):
 
             exp = pd.DatetimeIndex(['2011-01-01 09:00', '2011-01-01 10:00',
                                     '2011-01-01 11:00'])
-            self.assert_index_equal(
+            tm.assert_index_equal(
                 idx.fillna(pd.Timestamp('2011-01-01 10:00')), exp)
 
             # tz mismatch
             exp = pd.Index([pd.Timestamp('2011-01-01 09:00'),
                             pd.Timestamp('2011-01-01 10:00', tz=tz),
                             pd.Timestamp('2011-01-01 11:00')], dtype=object)
-            self.assert_index_equal(
+            tm.assert_index_equal(
                 idx.fillna(pd.Timestamp('2011-01-01 10:00', tz=tz)), exp)
 
             # object
             exp = pd.Index([pd.Timestamp('2011-01-01 09:00'), 'x',
                             pd.Timestamp('2011-01-01 11:00')], dtype=object)
-            self.assert_index_equal(idx.fillna('x'), exp)
+            tm.assert_index_equal(idx.fillna('x'), exp)
 
             idx = pd.DatetimeIndex(['2011-01-01 09:00', pd.NaT,
                                     '2011-01-01 11:00'], tz=tz)
 
             exp = pd.DatetimeIndex(['2011-01-01 09:00', '2011-01-01 10:00',
                                     '2011-01-01 11:00'], tz=tz)
-            self.assert_index_equal(
+            tm.assert_index_equal(
                 idx.fillna(pd.Timestamp('2011-01-01 10:00', tz=tz)), exp)
 
             exp = pd.Index([pd.Timestamp('2011-01-01 09:00', tz=tz),
                             pd.Timestamp('2011-01-01 10:00'),
                             pd.Timestamp('2011-01-01 11:00', tz=tz)],
                            dtype=object)
-            self.assert_index_equal(
+            tm.assert_index_equal(
                 idx.fillna(pd.Timestamp('2011-01-01 10:00')), exp)
 
             # object
@@ -47,4 +47,4 @@ class TestDatetimeIndex(tm.TestCase):
                             'x',
                             pd.Timestamp('2011-01-01 11:00', tz=tz)],
                            dtype=object)
-            self.assert_index_equal(idx.fillna('x'), exp)
+            tm.assert_index_equal(idx.fillna('x'), exp)

--- a/pandas/tests/indexes/datetimes/test_ops.py
+++ b/pandas/tests/indexes/datetimes/test_ops.py
@@ -645,30 +645,29 @@ Freq: D"""
         for idx in [idx1, idx2]:
             ordered = idx.sort_values()
             tm.assert_index_equal(ordered, idx)
-            self.assertEqual(ordered.freq, idx.freq)
+            assert ordered.freq == idx.freq
 
             ordered = idx.sort_values(ascending=False)
             expected = idx[::-1]
             tm.assert_index_equal(ordered, expected)
-            self.assertEqual(ordered.freq, expected.freq)
-            self.assertEqual(ordered.freq.n, -1)
+            assert ordered.freq == expected.freq
+            assert ordered.freq.n == -1
 
             ordered, indexer = idx.sort_values(return_indexer=True)
             tm.assert_index_equal(ordered, idx)
-            self.assert_numpy_array_equal(indexer,
-                                          np.array([0, 1, 2]),
-                                          check_dtype=False)
-            self.assertEqual(ordered.freq, idx.freq)
+            tm.assert_numpy_array_equal(indexer, np.array([0, 1, 2]),
+                                        check_dtype=False)
+            assert ordered.freq == idx.freq
 
             ordered, indexer = idx.sort_values(return_indexer=True,
                                                ascending=False)
             expected = idx[::-1]
             tm.assert_index_equal(ordered, expected)
-            self.assert_numpy_array_equal(indexer,
-                                          np.array([2, 1, 0]),
-                                          check_dtype=False)
-            self.assertEqual(ordered.freq, expected.freq)
-            self.assertEqual(ordered.freq.n, -1)
+            tm.assert_numpy_array_equal(indexer,
+                                        np.array([2, 1, 0]),
+                                        check_dtype=False)
+            assert ordered.freq == expected.freq
+            assert ordered.freq.n == -1
 
         # without freq
         for tz in self.tz:
@@ -705,7 +704,7 @@ Freq: D"""
                 tm.assert_index_equal(ordered, expected)
 
                 exp = np.array([0, 4, 3, 1, 2])
-                self.assert_numpy_array_equal(indexer, exp, check_dtype=False)
+                tm.assert_numpy_array_equal(indexer, exp, check_dtype=False)
                 self.assertIsNone(ordered.freq)
 
                 ordered, indexer = idx.sort_values(return_indexer=True,
@@ -713,7 +712,7 @@ Freq: D"""
                 tm.assert_index_equal(ordered, expected[::-1])
 
                 exp = np.array([2, 1, 3, 4, 0])
-                self.assert_numpy_array_equal(indexer, exp, check_dtype=False)
+                tm.assert_numpy_array_equal(indexer, exp, check_dtype=False)
                 self.assertIsNone(ordered.freq)
 
     def test_getitem(self):
@@ -1154,7 +1153,7 @@ class TestBusinessDatetimeIndex(tm.TestCase):
     def test_getitem_matplotlib_hackaround(self):
         values = self.rng[:, None]
         expected = self.rng.values[:, None]
-        self.assert_numpy_array_equal(values, expected)
+        tm.assert_numpy_array_equal(values, expected)
 
     def test_shift(self):
         shifted = self.rng.shift(5)
@@ -1249,7 +1248,7 @@ class TestCustomDatetimeIndex(tm.TestCase):
     def test_getitem_matplotlib_hackaround(self):
         values = self.rng[:, None]
         expected = self.rng.values[:, None]
-        self.assert_numpy_array_equal(values, expected)
+        tm.assert_numpy_array_equal(values, expected)
 
     def test_shift(self):
 

--- a/pandas/tests/indexes/datetimes/test_ops.py
+++ b/pandas/tests/indexes/datetimes/test_ops.py
@@ -62,7 +62,7 @@ class TestDatetimeIndexOps(Ops):
         self.assertTrue(isinstance(result, Index))
 
         self.assertEqual(result.dtype, object)
-        self.assert_index_equal(result, expected)
+        tm.assert_index_equal(result, expected)
         self.assertEqual(result.name, expected.name)
         self.assertEqual(idx.tolist(), expected_list)
 
@@ -76,7 +76,7 @@ class TestDatetimeIndexOps(Ops):
         result = idx.asobject
         self.assertTrue(isinstance(result, Index))
         self.assertEqual(result.dtype, object)
-        self.assert_index_equal(result, expected)
+        tm.assert_index_equal(result, expected)
         self.assertEqual(result.name, expected.name)
         self.assertEqual(idx.tolist(), expected_list)
 
@@ -89,7 +89,7 @@ class TestDatetimeIndexOps(Ops):
         result = idx.asobject
         self.assertTrue(isinstance(result, Index))
         self.assertEqual(result.dtype, object)
-        self.assert_index_equal(result, expected)
+        tm.assert_index_equal(result, expected)
         self.assertEqual(result.name, expected.name)
         self.assertEqual(idx.tolist(), expected_list)
 
@@ -644,17 +644,17 @@ Freq: D"""
 
         for idx in [idx1, idx2]:
             ordered = idx.sort_values()
-            self.assert_index_equal(ordered, idx)
+            tm.assert_index_equal(ordered, idx)
             self.assertEqual(ordered.freq, idx.freq)
 
             ordered = idx.sort_values(ascending=False)
             expected = idx[::-1]
-            self.assert_index_equal(ordered, expected)
+            tm.assert_index_equal(ordered, expected)
             self.assertEqual(ordered.freq, expected.freq)
             self.assertEqual(ordered.freq.n, -1)
 
             ordered, indexer = idx.sort_values(return_indexer=True)
-            self.assert_index_equal(ordered, idx)
+            tm.assert_index_equal(ordered, idx)
             self.assert_numpy_array_equal(indexer,
                                           np.array([0, 1, 2]),
                                           check_dtype=False)
@@ -663,7 +663,7 @@ Freq: D"""
             ordered, indexer = idx.sort_values(return_indexer=True,
                                                ascending=False)
             expected = idx[::-1]
-            self.assert_index_equal(ordered, expected)
+            tm.assert_index_equal(ordered, expected)
             self.assert_numpy_array_equal(indexer,
                                           np.array([2, 1, 0]),
                                           check_dtype=False)
@@ -694,15 +694,15 @@ Freq: D"""
 
             for idx, expected in [(idx1, exp1), (idx2, exp2), (idx3, exp3)]:
                 ordered = idx.sort_values()
-                self.assert_index_equal(ordered, expected)
+                tm.assert_index_equal(ordered, expected)
                 self.assertIsNone(ordered.freq)
 
                 ordered = idx.sort_values(ascending=False)
-                self.assert_index_equal(ordered, expected[::-1])
+                tm.assert_index_equal(ordered, expected[::-1])
                 self.assertIsNone(ordered.freq)
 
                 ordered, indexer = idx.sort_values(return_indexer=True)
-                self.assert_index_equal(ordered, expected)
+                tm.assert_index_equal(ordered, expected)
 
                 exp = np.array([0, 4, 3, 1, 2])
                 self.assert_numpy_array_equal(indexer, exp, check_dtype=False)
@@ -710,7 +710,7 @@ Freq: D"""
 
                 ordered, indexer = idx.sort_values(return_indexer=True,
                                                    ascending=False)
-                self.assert_index_equal(ordered, expected[::-1])
+                tm.assert_index_equal(ordered, expected[::-1])
 
                 exp = np.array([2, 1, 3, 4, 0])
                 self.assert_numpy_array_equal(indexer, exp, check_dtype=False)
@@ -728,39 +728,39 @@ Freq: D"""
             result = idx[0:5]
             expected = pd.date_range('2011-01-01', '2011-01-05', freq='D',
                                      tz=idx.tz, name='idx')
-            self.assert_index_equal(result, expected)
+            tm.assert_index_equal(result, expected)
             self.assertEqual(result.freq, expected.freq)
 
             result = idx[0:10:2]
             expected = pd.date_range('2011-01-01', '2011-01-09', freq='2D',
                                      tz=idx.tz, name='idx')
-            self.assert_index_equal(result, expected)
+            tm.assert_index_equal(result, expected)
             self.assertEqual(result.freq, expected.freq)
 
             result = idx[-20:-5:3]
             expected = pd.date_range('2011-01-12', '2011-01-24', freq='3D',
                                      tz=idx.tz, name='idx')
-            self.assert_index_equal(result, expected)
+            tm.assert_index_equal(result, expected)
             self.assertEqual(result.freq, expected.freq)
 
             result = idx[4::-1]
             expected = DatetimeIndex(['2011-01-05', '2011-01-04', '2011-01-03',
                                       '2011-01-02', '2011-01-01'],
                                      freq='-1D', tz=idx.tz, name='idx')
-            self.assert_index_equal(result, expected)
+            tm.assert_index_equal(result, expected)
             self.assertEqual(result.freq, expected.freq)
 
     def test_drop_duplicates_metadata(self):
         # GH 10115
         idx = pd.date_range('2011-01-01', '2011-01-31', freq='D', name='idx')
         result = idx.drop_duplicates()
-        self.assert_index_equal(idx, result)
+        tm.assert_index_equal(idx, result)
         self.assertEqual(idx.freq, result.freq)
 
         idx_dup = idx.append(idx)
         self.assertIsNone(idx_dup.freq)  # freq is reset
         result = idx_dup.drop_duplicates()
-        self.assert_index_equal(idx, result)
+        tm.assert_index_equal(idx, result)
         self.assertIsNone(result.freq)
 
     def test_drop_duplicates(self):
@@ -797,33 +797,33 @@ Freq: D"""
             result = idx.take([0, 1, 2])
             expected = pd.date_range('2011-01-01', '2011-01-03', freq='D',
                                      tz=idx.tz, name='idx')
-            self.assert_index_equal(result, expected)
+            tm.assert_index_equal(result, expected)
             self.assertEqual(result.freq, expected.freq)
 
             result = idx.take([0, 2, 4])
             expected = pd.date_range('2011-01-01', '2011-01-05', freq='2D',
                                      tz=idx.tz, name='idx')
-            self.assert_index_equal(result, expected)
+            tm.assert_index_equal(result, expected)
             self.assertEqual(result.freq, expected.freq)
 
             result = idx.take([7, 4, 1])
             expected = pd.date_range('2011-01-08', '2011-01-02', freq='-3D',
                                      tz=idx.tz, name='idx')
-            self.assert_index_equal(result, expected)
+            tm.assert_index_equal(result, expected)
             self.assertEqual(result.freq, expected.freq)
 
             result = idx.take([3, 2, 5])
             expected = DatetimeIndex(['2011-01-04', '2011-01-03',
                                       '2011-01-06'],
                                      freq=None, tz=idx.tz, name='idx')
-            self.assert_index_equal(result, expected)
+            tm.assert_index_equal(result, expected)
             self.assertIsNone(result.freq)
 
             result = idx.take([-3, 2, 5])
             expected = DatetimeIndex(['2011-01-29', '2011-01-03',
                                       '2011-01-06'],
                                      freq=None, tz=idx.tz, name='idx')
-            self.assert_index_equal(result, expected)
+            tm.assert_index_equal(result, expected)
             self.assertIsNone(result.freq)
 
     def test_take_invalid_kwargs(self):
@@ -1127,7 +1127,7 @@ class TestBusinessDatetimeIndex(tm.TestCase):
     def test_copy(self):
         cp = self.rng.copy()
         repr(cp)
-        self.assert_index_equal(cp, self.rng)
+        tm.assert_index_equal(cp, self.rng)
 
     def test_repr(self):
         # only really care that it works
@@ -1136,7 +1136,7 @@ class TestBusinessDatetimeIndex(tm.TestCase):
     def test_getitem(self):
         smaller = self.rng[:5]
         exp = DatetimeIndex(self.rng.view(np.ndarray)[:5])
-        self.assert_index_equal(smaller, exp)
+        tm.assert_index_equal(smaller, exp)
 
         self.assertEqual(smaller.offset, self.rng.offset)
 
@@ -1223,7 +1223,7 @@ class TestCustomDatetimeIndex(tm.TestCase):
     def test_copy(self):
         cp = self.rng.copy()
         repr(cp)
-        self.assert_index_equal(cp, self.rng)
+        tm.assert_index_equal(cp, self.rng)
 
     def test_repr(self):
         # only really care that it works
@@ -1232,7 +1232,7 @@ class TestCustomDatetimeIndex(tm.TestCase):
     def test_getitem(self):
         smaller = self.rng[:5]
         exp = DatetimeIndex(self.rng.view(np.ndarray)[:5])
-        self.assert_index_equal(smaller, exp)
+        tm.assert_index_equal(smaller, exp)
         self.assertEqual(smaller.offset, self.rng.offset)
 
         sliced = self.rng[::5]

--- a/pandas/tests/indexes/datetimes/test_setops.py
+++ b/pandas/tests/indexes/datetimes/test_setops.py
@@ -272,13 +272,13 @@ class TestBusinessDatetimeIndex(tm.TestCase):
         rng1 = rng[10:]
         rng2 = rng[:25]
         the_union = rng1.union(rng2)
-        self.assert_index_equal(the_union, rng)
+        tm.assert_index_equal(the_union, rng)
 
         rng1 = rng[10:]
         rng2 = rng[15:35]
         the_union = rng1.union(rng2)
         expected = rng[10:]
-        self.assert_index_equal(the_union, expected)
+        tm.assert_index_equal(the_union, expected)
 
     def test_intersection(self):
         rng = date_range('1/1/2000', periods=50, freq=Minute())
@@ -286,24 +286,24 @@ class TestBusinessDatetimeIndex(tm.TestCase):
         rng2 = rng[:25]
         the_int = rng1.intersection(rng2)
         expected = rng[10:25]
-        self.assert_index_equal(the_int, expected)
+        tm.assert_index_equal(the_int, expected)
         tm.assertIsInstance(the_int, DatetimeIndex)
         self.assertEqual(the_int.offset, rng.offset)
 
         the_int = rng1.intersection(rng2.view(DatetimeIndex))
-        self.assert_index_equal(the_int, expected)
+        tm.assert_index_equal(the_int, expected)
 
         # non-overlapping
         the_int = rng[:10].intersection(rng[10:])
         expected = DatetimeIndex([])
-        self.assert_index_equal(the_int, expected)
+        tm.assert_index_equal(the_int, expected)
 
     def test_intersection_bug(self):
         # GH #771
         a = bdate_range('11/30/2011', '12/31/2011')
         b = bdate_range('12/10/2011', '12/20/2011')
         result = a.intersection(b)
-        self.assert_index_equal(result, b)
+        tm.assert_index_equal(result, b)
 
     def test_month_range_union_tz_pytz(self):
         tm._skip_if_no_pytz()
@@ -371,7 +371,7 @@ class TestCustomDatetimeIndex(tm.TestCase):
         tm.assertIsInstance(the_union, DatetimeIndex)
 
         # order does not matter
-        self.assert_index_equal(right.union(left), the_union)
+        tm.assert_index_equal(right.union(left), the_union)
 
         # overlapping, but different offset
         rng = date_range(START, END, freq=BMonthEnd())
@@ -416,4 +416,4 @@ class TestCustomDatetimeIndex(tm.TestCase):
         a = cdate_range('11/30/2011', '12/31/2011')
         b = cdate_range('12/10/2011', '12/20/2011')
         result = a.intersection(b)
-        self.assert_index_equal(result, b)
+        tm.assert_index_equal(result, b)

--- a/pandas/tests/indexes/datetimes/test_tools.py
+++ b/pandas/tests/indexes/datetimes/test_tools.py
@@ -193,7 +193,7 @@ class TestToDatetime(tm.TestCase):
 
         # Assuming all datetimes are in bounds, to_datetime() returns
         # an array that is equal to Timestamp() parsing
-        self.assert_numpy_array_equal(
+        tm.assert_numpy_array_equal(
             pd.to_datetime(dts, box=False),
             np.array([Timestamp(x).asm8 for x in dts])
         )
@@ -204,7 +204,7 @@ class TestToDatetime(tm.TestCase):
         self.assertRaises(ValueError, pd.to_datetime, dts_with_oob,
                           errors='raise')
 
-        self.assert_numpy_array_equal(
+        tm.assert_numpy_array_equal(
             pd.to_datetime(dts_with_oob, box=False, errors='coerce'),
             np.array(
                 [
@@ -219,7 +219,7 @@ class TestToDatetime(tm.TestCase):
         # With errors='ignore', out of bounds datetime64s
         # are converted to their .item(), which depending on the version of
         # numpy is either a python datetime.datetime or datetime.date
-        self.assert_numpy_array_equal(
+        tm.assert_numpy_array_equal(
             pd.to_datetime(dts_with_oob, box=False, errors='ignore'),
             np.array(
                 [dt.item() for dt in dts_with_oob],
@@ -709,7 +709,7 @@ class ToDatetimeMisc(tm.TestCase):
 
     def test_to_datetime_unprocessable_input(self):
         # GH 4928
-        self.assert_numpy_array_equal(
+        tm.assert_numpy_array_equal(
             to_datetime([1, '1'], errors='ignore'),
             np.array([1, '1'], dtype='O')
         )
@@ -1285,7 +1285,7 @@ class TestDatetimeParsingWrappers(tm.TestCase):
                          [None, None])
 
         res = tools.to_time(arg, format="%I:%M%p", errors="ignore")
-        self.assert_numpy_array_equal(res, np.array(arg, dtype=np.object_))
+        tm.assert_numpy_array_equal(res, np.array(arg, dtype=np.object_))
 
         with tm.assertRaises(ValueError):
             tools.to_time(arg, format="%I:%M%p", errors="raise")
@@ -1393,7 +1393,7 @@ class TestArrayToDatetime(tm.TestCase):
 
     def test_parsing_valid_dates(self):
         arr = np.array(['01-01-2013', '01-02-2013'], dtype=object)
-        self.assert_numpy_array_equal(
+        tm.assert_numpy_array_equal(
             tslib.array_to_datetime(arr),
             np_array_datetime64_compat(
                 [
@@ -1405,7 +1405,7 @@ class TestArrayToDatetime(tm.TestCase):
         )
 
         arr = np.array(['Mon Sep 16 2013', 'Tue Sep 17 2013'], dtype=object)
-        self.assert_numpy_array_equal(
+        tm.assert_numpy_array_equal(
             tslib.array_to_datetime(arr),
             np_array_datetime64_compat(
                 [
@@ -1430,7 +1430,7 @@ class TestArrayToDatetime(tm.TestCase):
             ['01-01-2013 00:00:00'], dtype=object))
 
         for dt_string in dt_strings:
-            self.assert_numpy_array_equal(
+            tm.assert_numpy_array_equal(
                 tslib.array_to_datetime(
                     np.array([dt_string], dtype=object)
                 ),
@@ -1442,11 +1442,11 @@ class TestArrayToDatetime(tm.TestCase):
         # These strings don't look like datetimes so they shouldn't be
         # attempted to be converted
         arr = np.array(['-352.737091', '183.575577'], dtype=object)
-        self.assert_numpy_array_equal(
+        tm.assert_numpy_array_equal(
             tslib.array_to_datetime(arr, errors='ignore'), arr)
 
         arr = np.array(['1', '2', '3', '4', '5'], dtype=object)
-        self.assert_numpy_array_equal(
+        tm.assert_numpy_array_equal(
             tslib.array_to_datetime(arr, errors='ignore'), arr)
 
     def test_coercing_dates_outside_of_datetime64_ns_bounds(self):
@@ -1464,7 +1464,7 @@ class TestArrayToDatetime(tm.TestCase):
                               np.array(
                                   [invalid_date], dtype='object'),
                               errors='raise', )
-            self.assert_numpy_array_equal(
+            tm.assert_numpy_array_equal(
                 tslib.array_to_datetime(
                     np.array([invalid_date], dtype='object'),
                     errors='coerce'),
@@ -1472,7 +1472,7 @@ class TestArrayToDatetime(tm.TestCase):
             )
 
         arr = np.array(['1/1/1000', '1/1/2000'], dtype=object)
-        self.assert_numpy_array_equal(
+        tm.assert_numpy_array_equal(
             tslib.array_to_datetime(arr, errors='coerce'),
             np_array_datetime64_compat(
                 [
@@ -1488,11 +1488,11 @@ class TestArrayToDatetime(tm.TestCase):
 
         # Without coercing, the presence of any invalid dates prevents
         # any values from being converted
-        self.assert_numpy_array_equal(
+        tm.assert_numpy_array_equal(
             tslib.array_to_datetime(arr, errors='ignore'), arr)
 
         # With coercing, the invalid dates becomes iNaT
-        self.assert_numpy_array_equal(
+        tm.assert_numpy_array_equal(
             tslib.array_to_datetime(arr, errors='coerce'),
             np_array_datetime64_compat(
                 [

--- a/pandas/tests/indexes/datetimes/test_tools.py
+++ b/pandas/tests/indexes/datetimes/test_tools.py
@@ -81,7 +81,7 @@ class TimeConversionFormats(tm.TestCase):
         expected = Series([datetime(2012, 12, 31),
                            datetime(2014, 12, 31), datetime(9999, 12, 31)],
                           dtype=object)
-        self.assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         result = pd.to_datetime(s, format='%Y%m%d', errors='coerce')
         expected = Series(['20121231', '20141231', 'NaT'], dtype='M8[ns]')
@@ -948,8 +948,8 @@ class TestToDatetimeInferFormat(tm.TestCase):
 
             # Whether the format is explicitly passed, it is inferred, or
             # it is not inferred, the results should all be the same
-            self.assert_series_equal(with_format, no_infer)
-            self.assert_series_equal(no_infer, yes_infer)
+            tm.assert_series_equal(with_format, no_infer)
+            tm.assert_series_equal(no_infer, yes_infer)
 
     def test_to_datetime_infer_datetime_format_inconsistent_format(self):
         s = pd.Series(np.array(['01/01/2011 00:00:00',
@@ -1290,8 +1290,8 @@ class TestDatetimeParsingWrappers(tm.TestCase):
         with tm.assertRaises(ValueError):
             tools.to_time(arg, format="%I:%M%p", errors="raise")
 
-        self.assert_series_equal(tools.to_time(Series(arg, name="test")),
-                                 Series(expected_arr, name="test"))
+        tm.assert_series_equal(tools.to_time(Series(arg, name="test")),
+                               Series(expected_arr, name="test"))
 
         res = tools.to_time(np.array(arg))
         self.assertIsInstance(res, list)

--- a/pandas/tests/indexes/period/test_asfreq.py
+++ b/pandas/tests/indexes/period/test_asfreq.py
@@ -73,9 +73,9 @@ class TestPeriodIndex(tm.TestCase):
         result1 = pi1.asfreq('3M')
         result2 = pi1.asfreq('M')
         expected = PeriodIndex(freq='M', start='2001-12', end='2001-12')
-        self.assert_numpy_array_equal(result1.asi8, expected.asi8)
+        tm.assert_numpy_array_equal(result1.asi8, expected.asi8)
         self.assertEqual(result1.freqstr, '3M')
-        self.assert_numpy_array_equal(result2.asi8, expected.asi8)
+        tm.assert_numpy_array_equal(result2.asi8, expected.asi8)
         self.assertEqual(result2.freqstr, 'M')
 
     def test_asfreq_nat(self):

--- a/pandas/tests/indexes/period/test_asfreq.py
+++ b/pandas/tests/indexes/period/test_asfreq.py
@@ -91,13 +91,13 @@ class TestPeriodIndex(tm.TestCase):
             result = pi.asfreq(freq)
             exp = PeriodIndex(['2001-02-28', '2001-03-31', 'NaT',
                                '2001-04-30'], freq=freq)
-            self.assert_index_equal(result, exp)
+            tm.assert_index_equal(result, exp)
             self.assertEqual(result.freq, exp.freq)
 
             result = pi.asfreq(freq, how='S')
             exp = PeriodIndex(['2001-01-01', '2001-02-01', 'NaT',
                                '2001-03-01'], freq=freq)
-            self.assert_index_equal(result, exp)
+            tm.assert_index_equal(result, exp)
             self.assertEqual(result.freq, exp.freq)
 
     def test_asfreq_combined_pi(self):
@@ -107,7 +107,7 @@ class TestPeriodIndex(tm.TestCase):
                           freq='25H')
         for freq, how in zip(['1D1H', '1H1D'], ['S', 'E']):
             result = pi.asfreq(freq, how=how)
-            self.assert_index_equal(result, exp)
+            tm.assert_index_equal(result, exp)
             self.assertEqual(result.freq, exp.freq)
 
         for freq in ['1D1H', '1H1D']:
@@ -116,7 +116,7 @@ class TestPeriodIndex(tm.TestCase):
             result = pi.asfreq('H')
             exp = PeriodIndex(['2001-01-02 00:00', '2001-01-03 02:00', 'NaT'],
                               freq='H')
-            self.assert_index_equal(result, exp)
+            tm.assert_index_equal(result, exp)
             self.assertEqual(result.freq, exp.freq)
 
             pi = pd.PeriodIndex(['2001-01-01 00:00', '2001-01-02 02:00',
@@ -124,7 +124,7 @@ class TestPeriodIndex(tm.TestCase):
             result = pi.asfreq('H', how='S')
             exp = PeriodIndex(['2001-01-01 00:00', '2001-01-02 02:00', 'NaT'],
                               freq='H')
-            self.assert_index_equal(result, exp)
+            tm.assert_index_equal(result, exp)
             self.assertEqual(result.freq, exp.freq)
 
     def test_asfreq_ts(self):

--- a/pandas/tests/indexes/period/test_construction.py
+++ b/pandas/tests/indexes/period/test_construction.py
@@ -91,8 +91,8 @@ class TestPeriodIndex(tm.TestCase):
 
         pindex = PeriodIndex(year=years, quarter=quarters)
 
-        self.assert_index_equal(pindex.year, pd.Index(years))
-        self.assert_index_equal(pindex.quarter, pd.Index(quarters))
+        tm.assert_index_equal(pindex.year, pd.Index(years))
+        tm.assert_index_equal(pindex.quarter, pd.Index(quarters))
 
     def test_constructor_invalid_quarters(self):
         self.assertRaises(ValueError, PeriodIndex, year=lrange(2000, 2004),
@@ -272,12 +272,12 @@ class TestPeriodIndex(tm.TestCase):
         result = idx._simple_new([pd.Period('2007-01', freq='M'),
                                   pd.Period('2007-02', freq='M')],
                                  'p', freq=idx.freq)
-        self.assert_index_equal(result, idx)
+        tm.assert_index_equal(result, idx)
 
         result = idx._simple_new(np.array([pd.Period('2007-01', freq='M'),
                                            pd.Period('2007-02', freq='M')]),
                                  'p', freq=idx.freq)
-        self.assert_index_equal(result, idx)
+        tm.assert_index_equal(result, idx)
 
     def test_constructor_simple_new_empty(self):
         # GH13079

--- a/pandas/tests/indexes/period/test_indexing.py
+++ b/pandas/tests/indexes/period/test_indexing.py
@@ -28,7 +28,7 @@ class TestGetItem(tm.TestCase):
             result = idx[0:5]
             expected = pd.period_range('2011-01-01', '2011-01-05', freq='D',
                                        name='idx')
-            self.assert_index_equal(result, expected)
+            tm.assert_index_equal(result, expected)
             self.assertEqual(result.freq, expected.freq)
             self.assertEqual(result.freq, 'D')
 
@@ -37,7 +37,7 @@ class TestGetItem(tm.TestCase):
                                        '2011-01-05',
                                        '2011-01-07', '2011-01-09'],
                                       freq='D', name='idx')
-            self.assert_index_equal(result, expected)
+            tm.assert_index_equal(result, expected)
             self.assertEqual(result.freq, expected.freq)
             self.assertEqual(result.freq, 'D')
 
@@ -46,7 +46,7 @@ class TestGetItem(tm.TestCase):
                                        '2011-01-18',
                                        '2011-01-21', '2011-01-24'],
                                       freq='D', name='idx')
-            self.assert_index_equal(result, expected)
+            tm.assert_index_equal(result, expected)
             self.assertEqual(result.freq, expected.freq)
             self.assertEqual(result.freq, 'D')
 
@@ -54,7 +54,7 @@ class TestGetItem(tm.TestCase):
             expected = PeriodIndex(['2011-01-05', '2011-01-04', '2011-01-03',
                                     '2011-01-02', '2011-01-01'],
                                    freq='D', name='idx')
-            self.assert_index_equal(result, expected)
+            tm.assert_index_equal(result, expected)
             self.assertEqual(result.freq, expected.freq)
             self.assertEqual(result.freq, 'D')
 
@@ -236,14 +236,14 @@ class TestIndexing(tm.TestCase):
             result = idx.take([0, 1, 2])
             expected = pd.period_range('2011-01-01', '2011-01-03', freq='D',
                                        name='idx')
-            self.assert_index_equal(result, expected)
+            tm.assert_index_equal(result, expected)
             self.assertEqual(result.freq, 'D')
             self.assertEqual(result.freq, expected.freq)
 
             result = idx.take([0, 2, 4])
             expected = pd.PeriodIndex(['2011-01-01', '2011-01-03',
                                        '2011-01-05'], freq='D', name='idx')
-            self.assert_index_equal(result, expected)
+            tm.assert_index_equal(result, expected)
             self.assertEqual(result.freq, expected.freq)
             self.assertEqual(result.freq, 'D')
 
@@ -251,21 +251,21 @@ class TestIndexing(tm.TestCase):
             expected = pd.PeriodIndex(['2011-01-08', '2011-01-05',
                                        '2011-01-02'],
                                       freq='D', name='idx')
-            self.assert_index_equal(result, expected)
+            tm.assert_index_equal(result, expected)
             self.assertEqual(result.freq, expected.freq)
             self.assertEqual(result.freq, 'D')
 
             result = idx.take([3, 2, 5])
             expected = PeriodIndex(['2011-01-04', '2011-01-03', '2011-01-06'],
                                    freq='D', name='idx')
-            self.assert_index_equal(result, expected)
+            tm.assert_index_equal(result, expected)
             self.assertEqual(result.freq, expected.freq)
             self.assertEqual(result.freq, 'D')
 
             result = idx.take([-3, 2, 5])
             expected = PeriodIndex(['2011-01-29', '2011-01-03', '2011-01-06'],
                                    freq='D', name='idx')
-            self.assert_index_equal(result, expected)
+            tm.assert_index_equal(result, expected)
             self.assertEqual(result.freq, expected.freq)
             self.assertEqual(result.freq, 'D')
 

--- a/pandas/tests/indexes/period/test_ops.py
+++ b/pandas/tests/indexes/period/test_ops.py
@@ -603,17 +603,15 @@ Freq: Q-DEC"""
 
             ordered, indexer = idx.sort_values(return_indexer=True)
             tm.assert_index_equal(ordered, idx)
-            self.assert_numpy_array_equal(indexer,
-                                          np.array([0, 1, 2]),
-                                          check_dtype=False)
+            tm.assert_numpy_array_equal(indexer, np.array([0, 1, 2]),
+                                        check_dtype=False)
             _check_freq(ordered, idx)
 
             ordered, indexer = idx.sort_values(return_indexer=True,
                                                ascending=False)
             tm.assert_index_equal(ordered, idx[::-1])
-            self.assert_numpy_array_equal(indexer,
-                                          np.array([2, 1, 0]),
-                                          check_dtype=False)
+            tm.assert_numpy_array_equal(indexer, np.array([2, 1, 0]),
+                                        check_dtype=False)
             _check_freq(ordered, idx[::-1])
 
         pidx = PeriodIndex(['2011', '2013', '2015', '2012',
@@ -636,7 +634,7 @@ Freq: Q-DEC"""
             tm.assert_index_equal(ordered, expected)
 
             exp = np.array([0, 4, 3, 1, 2])
-            self.assert_numpy_array_equal(indexer, exp, check_dtype=False)
+            tm.assert_numpy_array_equal(indexer, exp, check_dtype=False)
             _check_freq(ordered, idx)
 
             ordered, indexer = idx.sort_values(return_indexer=True,
@@ -644,8 +642,7 @@ Freq: Q-DEC"""
             tm.assert_index_equal(ordered, expected[::-1])
 
             exp = np.array([2, 1, 3, 4, 0])
-            self.assert_numpy_array_equal(indexer, exp,
-                                          check_dtype=False)
+            tm.assert_numpy_array_equal(indexer, exp, check_dtype=False)
             _check_freq(ordered, idx)
 
         pidx = PeriodIndex(['2011', '2013', 'NaT', '2011'], name='pidx',
@@ -680,9 +677,8 @@ Freq: Q-DEC"""
 
             ordered, indexer = idx.sort_values(return_indexer=True)
             tm.assert_index_equal(ordered, idx)
-            self.assert_numpy_array_equal(indexer,
-                                          np.array([0, 1, 2]),
-                                          check_dtype=False)
+            tm.assert_numpy_array_equal(indexer, np.array([0, 1, 2]),
+                                        check_dtype=False)
             self.assertEqual(ordered.freq, idx.freq)
             self.assertEqual(ordered.freq, freq)
 
@@ -690,9 +686,8 @@ Freq: Q-DEC"""
                                                ascending=False)
             expected = idx[::-1]
             tm.assert_index_equal(ordered, expected)
-            self.assert_numpy_array_equal(indexer,
-                                          np.array([2, 1, 0]),
-                                          check_dtype=False)
+            tm.assert_numpy_array_equal(indexer, np.array([2, 1, 0]),
+                                        check_dtype=False)
             self.assertEqual(ordered.freq, expected.freq)
             self.assertEqual(ordered.freq, freq)
 
@@ -726,7 +721,7 @@ Freq: Q-DEC"""
             tm.assert_index_equal(ordered, expected)
 
             exp = np.array([0, 4, 3, 1, 2])
-            self.assert_numpy_array_equal(indexer, exp, check_dtype=False)
+            tm.assert_numpy_array_equal(indexer, exp, check_dtype=False)
             self.assertEqual(ordered.freq, 'D')
 
             ordered, indexer = idx.sort_values(return_indexer=True,
@@ -734,7 +729,7 @@ Freq: Q-DEC"""
             tm.assert_index_equal(ordered, expected[::-1])
 
             exp = np.array([2, 1, 3, 4, 0])
-            self.assert_numpy_array_equal(indexer, exp, check_dtype=False)
+            tm.assert_numpy_array_equal(indexer, exp, check_dtype=False)
             self.assertEqual(ordered.freq, 'D')
 
     def test_nat_new(self):
@@ -1204,49 +1199,49 @@ class TestPeriodIndexComparisons(tm.TestCase):
             p = Period('2011-02', freq=freq)
 
             exp = np.array([False, True, False, False])
-            self.assert_numpy_array_equal(base == p, exp)
-            self.assert_numpy_array_equal(p == base, exp)
+            tm.assert_numpy_array_equal(base == p, exp)
+            tm.assert_numpy_array_equal(p == base, exp)
 
             exp = np.array([True, False, True, True])
-            self.assert_numpy_array_equal(base != p, exp)
-            self.assert_numpy_array_equal(p != base, exp)
+            tm.assert_numpy_array_equal(base != p, exp)
+            tm.assert_numpy_array_equal(p != base, exp)
 
             exp = np.array([False, False, True, True])
-            self.assert_numpy_array_equal(base > p, exp)
-            self.assert_numpy_array_equal(p < base, exp)
+            tm.assert_numpy_array_equal(base > p, exp)
+            tm.assert_numpy_array_equal(p < base, exp)
 
             exp = np.array([True, False, False, False])
-            self.assert_numpy_array_equal(base < p, exp)
-            self.assert_numpy_array_equal(p > base, exp)
+            tm.assert_numpy_array_equal(base < p, exp)
+            tm.assert_numpy_array_equal(p > base, exp)
 
             exp = np.array([False, True, True, True])
-            self.assert_numpy_array_equal(base >= p, exp)
-            self.assert_numpy_array_equal(p <= base, exp)
+            tm.assert_numpy_array_equal(base >= p, exp)
+            tm.assert_numpy_array_equal(p <= base, exp)
 
             exp = np.array([True, True, False, False])
-            self.assert_numpy_array_equal(base <= p, exp)
-            self.assert_numpy_array_equal(p >= base, exp)
+            tm.assert_numpy_array_equal(base <= p, exp)
+            tm.assert_numpy_array_equal(p >= base, exp)
 
             idx = PeriodIndex(['2011-02', '2011-01', '2011-03',
                                '2011-05'], freq=freq)
 
             exp = np.array([False, False, True, False])
-            self.assert_numpy_array_equal(base == idx, exp)
+            tm.assert_numpy_array_equal(base == idx, exp)
 
             exp = np.array([True, True, False, True])
-            self.assert_numpy_array_equal(base != idx, exp)
+            tm.assert_numpy_array_equal(base != idx, exp)
 
             exp = np.array([False, True, False, False])
-            self.assert_numpy_array_equal(base > idx, exp)
+            tm.assert_numpy_array_equal(base > idx, exp)
 
             exp = np.array([True, False, False, True])
-            self.assert_numpy_array_equal(base < idx, exp)
+            tm.assert_numpy_array_equal(base < idx, exp)
 
             exp = np.array([False, True, True, False])
-            self.assert_numpy_array_equal(base >= idx, exp)
+            tm.assert_numpy_array_equal(base >= idx, exp)
 
             exp = np.array([True, False, True, True])
-            self.assert_numpy_array_equal(base <= idx, exp)
+            tm.assert_numpy_array_equal(base <= idx, exp)
 
             # different base freq
             msg = "Input has different freq=A-DEC from PeriodIndex"
@@ -1279,43 +1274,43 @@ class TestPeriodIndexComparisons(tm.TestCase):
 
             result = idx1 > Period('2011-02', freq=freq)
             exp = np.array([False, False, False, True])
-            self.assert_numpy_array_equal(result, exp)
+            tm.assert_numpy_array_equal(result, exp)
             result = Period('2011-02', freq=freq) < idx1
-            self.assert_numpy_array_equal(result, exp)
+            tm.assert_numpy_array_equal(result, exp)
 
             result = idx1 == Period('NaT', freq=freq)
             exp = np.array([False, False, False, False])
-            self.assert_numpy_array_equal(result, exp)
+            tm.assert_numpy_array_equal(result, exp)
             result = Period('NaT', freq=freq) == idx1
-            self.assert_numpy_array_equal(result, exp)
+            tm.assert_numpy_array_equal(result, exp)
 
             result = idx1 != Period('NaT', freq=freq)
             exp = np.array([True, True, True, True])
-            self.assert_numpy_array_equal(result, exp)
+            tm.assert_numpy_array_equal(result, exp)
             result = Period('NaT', freq=freq) != idx1
-            self.assert_numpy_array_equal(result, exp)
+            tm.assert_numpy_array_equal(result, exp)
 
             idx2 = PeriodIndex(['2011-02', '2011-01', '2011-04',
                                 'NaT'], freq=freq)
             result = idx1 < idx2
             exp = np.array([True, False, False, False])
-            self.assert_numpy_array_equal(result, exp)
+            tm.assert_numpy_array_equal(result, exp)
 
             result = idx1 == idx2
             exp = np.array([False, False, False, False])
-            self.assert_numpy_array_equal(result, exp)
+            tm.assert_numpy_array_equal(result, exp)
 
             result = idx1 != idx2
             exp = np.array([True, True, True, True])
-            self.assert_numpy_array_equal(result, exp)
+            tm.assert_numpy_array_equal(result, exp)
 
             result = idx1 == idx1
             exp = np.array([True, True, False, True])
-            self.assert_numpy_array_equal(result, exp)
+            tm.assert_numpy_array_equal(result, exp)
 
             result = idx1 != idx1
             exp = np.array([False, False, True, False])
-            self.assert_numpy_array_equal(result, exp)
+            tm.assert_numpy_array_equal(result, exp)
 
             diff = PeriodIndex(['2011-02', '2011-01', '2011-04',
                                 'NaT'], freq='4M')

--- a/pandas/tests/indexes/period/test_ops.py
+++ b/pandas/tests/indexes/period/test_ops.py
@@ -37,7 +37,7 @@ class TestPeriodIndexOps(Ops):
         result = idx.asobject
         self.assertTrue(isinstance(result, Index))
         self.assertEqual(result.dtype, object)
-        self.assert_index_equal(result, expected)
+        tm.assert_index_equal(result, expected)
         self.assertEqual(result.name, expected.name)
         self.assertEqual(idx.tolist(), expected_list)
 
@@ -554,12 +554,12 @@ Freq: Q-DEC"""
         # GH 10115
         idx = pd.period_range('2011-01-01', '2011-01-31', freq='D', name='idx')
         result = idx.drop_duplicates()
-        self.assert_index_equal(idx, result)
+        tm.assert_index_equal(idx, result)
         self.assertEqual(idx.freq, result.freq)
 
         idx_dup = idx.append(idx)  # freq will not be reset
         result = idx_dup.drop_duplicates()
-        self.assert_index_equal(idx, result)
+        tm.assert_index_equal(idx, result)
         self.assertEqual(idx.freq, result.freq)
 
     def test_drop_duplicates(self):
@@ -594,15 +594,15 @@ Freq: Q-DEC"""
         iidx = Index([2011, 2012, 2013], name='idx')
         for idx in [pidx, iidx]:
             ordered = idx.sort_values()
-            self.assert_index_equal(ordered, idx)
+            tm.assert_index_equal(ordered, idx)
             _check_freq(ordered, idx)
 
             ordered = idx.sort_values(ascending=False)
-            self.assert_index_equal(ordered, idx[::-1])
+            tm.assert_index_equal(ordered, idx[::-1])
             _check_freq(ordered, idx[::-1])
 
             ordered, indexer = idx.sort_values(return_indexer=True)
-            self.assert_index_equal(ordered, idx)
+            tm.assert_index_equal(ordered, idx)
             self.assert_numpy_array_equal(indexer,
                                           np.array([0, 1, 2]),
                                           check_dtype=False)
@@ -610,7 +610,7 @@ Freq: Q-DEC"""
 
             ordered, indexer = idx.sort_values(return_indexer=True,
                                                ascending=False)
-            self.assert_index_equal(ordered, idx[::-1])
+            tm.assert_index_equal(ordered, idx[::-1])
             self.assert_numpy_array_equal(indexer,
                                           np.array([2, 1, 0]),
                                           check_dtype=False)
@@ -625,15 +625,15 @@ Freq: Q-DEC"""
         iexpected = Index([2011, 2011, 2012, 2013, 2015], name='idx')
         for idx, expected in [(pidx, pexpected), (iidx, iexpected)]:
             ordered = idx.sort_values()
-            self.assert_index_equal(ordered, expected)
+            tm.assert_index_equal(ordered, expected)
             _check_freq(ordered, idx)
 
             ordered = idx.sort_values(ascending=False)
-            self.assert_index_equal(ordered, expected[::-1])
+            tm.assert_index_equal(ordered, expected[::-1])
             _check_freq(ordered, idx)
 
             ordered, indexer = idx.sort_values(return_indexer=True)
-            self.assert_index_equal(ordered, expected)
+            tm.assert_index_equal(ordered, expected)
 
             exp = np.array([0, 4, 3, 1, 2])
             self.assert_numpy_array_equal(indexer, exp, check_dtype=False)
@@ -641,7 +641,7 @@ Freq: Q-DEC"""
 
             ordered, indexer = idx.sort_values(return_indexer=True,
                                                ascending=False)
-            self.assert_index_equal(ordered, expected[::-1])
+            tm.assert_index_equal(ordered, expected[::-1])
 
             exp = np.array([2, 1, 3, 4, 0])
             self.assert_numpy_array_equal(indexer, exp,
@@ -654,13 +654,13 @@ Freq: Q-DEC"""
         result = pidx.sort_values()
         expected = PeriodIndex(['NaT', '2011', '2011', '2013'],
                                name='pidx', freq='D')
-        self.assert_index_equal(result, expected)
+        tm.assert_index_equal(result, expected)
         self.assertEqual(result.freq, 'D')
 
         result = pidx.sort_values(ascending=False)
         expected = PeriodIndex(
             ['2013', '2011', '2011', 'NaT'], name='pidx', freq='D')
-        self.assert_index_equal(result, expected)
+        tm.assert_index_equal(result, expected)
         self.assertEqual(result.freq, 'D')
 
     def test_order(self):
@@ -669,17 +669,17 @@ Freq: Q-DEC"""
                               freq=freq, name='idx')
 
             ordered = idx.sort_values()
-            self.assert_index_equal(ordered, idx)
+            tm.assert_index_equal(ordered, idx)
             self.assertEqual(ordered.freq, idx.freq)
 
             ordered = idx.sort_values(ascending=False)
             expected = idx[::-1]
-            self.assert_index_equal(ordered, expected)
+            tm.assert_index_equal(ordered, expected)
             self.assertEqual(ordered.freq, expected.freq)
             self.assertEqual(ordered.freq, freq)
 
             ordered, indexer = idx.sort_values(return_indexer=True)
-            self.assert_index_equal(ordered, idx)
+            tm.assert_index_equal(ordered, idx)
             self.assert_numpy_array_equal(indexer,
                                           np.array([0, 1, 2]),
                                           check_dtype=False)
@@ -689,7 +689,7 @@ Freq: Q-DEC"""
             ordered, indexer = idx.sort_values(return_indexer=True,
                                                ascending=False)
             expected = idx[::-1]
-            self.assert_index_equal(ordered, expected)
+            tm.assert_index_equal(ordered, expected)
             self.assert_numpy_array_equal(indexer,
                                           np.array([2, 1, 0]),
                                           check_dtype=False)
@@ -715,15 +715,15 @@ Freq: Q-DEC"""
 
         for idx, expected in [(idx1, exp1), (idx2, exp2), (idx3, exp3)]:
             ordered = idx.sort_values()
-            self.assert_index_equal(ordered, expected)
+            tm.assert_index_equal(ordered, expected)
             self.assertEqual(ordered.freq, 'D')
 
             ordered = idx.sort_values(ascending=False)
-            self.assert_index_equal(ordered, expected[::-1])
+            tm.assert_index_equal(ordered, expected[::-1])
             self.assertEqual(ordered.freq, 'D')
 
             ordered, indexer = idx.sort_values(return_indexer=True)
-            self.assert_index_equal(ordered, expected)
+            tm.assert_index_equal(ordered, expected)
 
             exp = np.array([0, 4, 3, 1, 2])
             self.assert_numpy_array_equal(indexer, exp, check_dtype=False)
@@ -731,7 +731,7 @@ Freq: Q-DEC"""
 
             ordered, indexer = idx.sort_values(return_indexer=True,
                                                ascending=False)
-            self.assert_index_equal(ordered, expected[::-1])
+            tm.assert_index_equal(ordered, expected[::-1])
 
             exp = np.array([2, 1, 3, 4, 0])
             self.assert_numpy_array_equal(indexer, exp, check_dtype=False)

--- a/pandas/tests/indexes/period/test_period.py
+++ b/pandas/tests/indexes/period/test_period.py
@@ -170,11 +170,11 @@ class TestPeriodIndex(DatetimeLike, tm.TestCase):
         # GH4125
         idx = pd.period_range('2002-01', '2003-12', freq='M')
         df = pd.DataFrame(pd.np.random.randn(24, 10), index=idx)
-        self.assert_frame_equal(df, df.loc[idx])
-        self.assert_frame_equal(df, df.loc[list(idx)])
-        self.assert_frame_equal(df, df.loc[list(idx)])
-        self.assert_frame_equal(df.iloc[0:5], df.loc[idx[0:5]])
-        self.assert_frame_equal(df, df.loc[list(idx)])
+        tm.assert_frame_equal(df, df.loc[idx])
+        tm.assert_frame_equal(df, df.loc[list(idx)])
+        tm.assert_frame_equal(df, df.loc[list(idx)])
+        tm.assert_frame_equal(df.iloc[0:5], df.loc[idx[0:5]])
+        tm.assert_frame_equal(df, df.loc[list(idx)])
 
     def test_fillna_period(self):
         # GH 11343

--- a/pandas/tests/indexes/period/test_period.py
+++ b/pandas/tests/indexes/period/test_period.py
@@ -41,7 +41,7 @@ class TestPeriodIndex(DatetimeLike, tm.TestCase):
         idx = period_range('1990', '2009', freq='A')
         result = idx.astype('i8')
         tm.assert_index_equal(result, Index(idx.asi8))
-        self.assert_numpy_array_equal(result.values, idx.asi8)
+        tm.assert_numpy_array_equal(result.values, idx.asi8)
 
     def test_astype_raises(self):
         # GH 13149, GH 13209
@@ -442,11 +442,11 @@ class TestPeriodIndex(DatetimeLike, tm.TestCase):
         exp_idx = PeriodIndex(['2014-01', '2014-02', '2014-03'], freq='M')
 
         arr, idx = idx1.factorize()
-        self.assert_numpy_array_equal(arr, exp_arr)
+        tm.assert_numpy_array_equal(arr, exp_arr)
         tm.assert_index_equal(idx, exp_idx)
 
         arr, idx = idx1.factorize(sort=True)
-        self.assert_numpy_array_equal(arr, exp_arr)
+        tm.assert_numpy_array_equal(arr, exp_arr)
         tm.assert_index_equal(idx, exp_idx)
 
         idx2 = pd.PeriodIndex(['2014-03', '2014-03', '2014-02', '2014-01',
@@ -454,13 +454,13 @@ class TestPeriodIndex(DatetimeLike, tm.TestCase):
 
         exp_arr = np.array([2, 2, 1, 0, 2, 0], dtype=np.intp)
         arr, idx = idx2.factorize(sort=True)
-        self.assert_numpy_array_equal(arr, exp_arr)
+        tm.assert_numpy_array_equal(arr, exp_arr)
         tm.assert_index_equal(idx, exp_idx)
 
         exp_arr = np.array([0, 0, 1, 2, 0, 2], dtype=np.intp)
         exp_idx = PeriodIndex(['2014-03', '2014-02', '2014-01'], freq='M')
         arr, idx = idx2.factorize()
-        self.assert_numpy_array_equal(arr, exp_arr)
+        tm.assert_numpy_array_equal(arr, exp_arr)
         tm.assert_index_equal(idx, exp_idx)
 
     def test_asobject_like(self):
@@ -506,7 +506,7 @@ class TestPeriodIndex(DatetimeLike, tm.TestCase):
 
         result = idx < idx[10]
         exp = idx.values < idx.values[10]
-        self.assert_numpy_array_equal(result, exp)
+        tm.assert_numpy_array_equal(result, exp)
 
     def test_contains(self):
         rng = period_range('2007-01', freq='M', periods=10)

--- a/pandas/tests/indexes/period/test_period.py
+++ b/pandas/tests/indexes/period/test_period.py
@@ -40,7 +40,7 @@ class TestPeriodIndex(DatetimeLike, tm.TestCase):
 
         idx = period_range('1990', '2009', freq='A')
         result = idx.astype('i8')
-        self.assert_index_equal(result, Index(idx.asi8))
+        tm.assert_index_equal(result, Index(idx.asi8))
         self.assert_numpy_array_equal(result.values, idx.asi8)
 
     def test_astype_raises(self):
@@ -163,7 +163,7 @@ class TestPeriodIndex(DatetimeLike, tm.TestCase):
         idx = pd.period_range('2000-01-01', periods=3, freq='D')
         res = idx.repeat(3)
         exp = PeriodIndex(idx.values.repeat(3), freq='D')
-        self.assert_index_equal(res, exp)
+        tm.assert_index_equal(res, exp)
         self.assertEqual(res.freqstr, 'D')
 
     def test_period_index_indexer(self):
@@ -183,18 +183,18 @@ class TestPeriodIndex(DatetimeLike, tm.TestCase):
 
         exp = pd.PeriodIndex(['2011-01-01 09:00', '2011-01-01 10:00',
                               '2011-01-01 11:00'], freq='H')
-        self.assert_index_equal(
+        tm.assert_index_equal(
             idx.fillna(pd.Period('2011-01-01 10:00', freq='H')), exp)
 
         exp = pd.Index([pd.Period('2011-01-01 09:00', freq='H'), 'x',
                         pd.Period('2011-01-01 11:00', freq='H')], dtype=object)
-        self.assert_index_equal(idx.fillna('x'), exp)
+        tm.assert_index_equal(idx.fillna('x'), exp)
 
         exp = pd.Index([pd.Period('2011-01-01 09:00', freq='H'),
                         pd.Period('2011-01-01', freq='D'),
                         pd.Period('2011-01-01 11:00', freq='H')], dtype=object)
-        self.assert_index_equal(idx.fillna(pd.Period('2011-01-01', freq='D')),
-                                exp)
+        tm.assert_index_equal(idx.fillna(
+            pd.Period('2011-01-01', freq='D')), exp)
 
     def test_no_millisecond_field(self):
         with self.assertRaises(AttributeError):
@@ -565,14 +565,14 @@ class TestPeriodIndex(DatetimeLike, tm.TestCase):
     def test_index_unique(self):
         idx = PeriodIndex([2000, 2007, 2007, 2009, 2009], freq='A-JUN')
         expected = PeriodIndex([2000, 2007, 2009], freq='A-JUN')
-        self.assert_index_equal(idx.unique(), expected)
+        tm.assert_index_equal(idx.unique(), expected)
         self.assertEqual(idx.nunique(), 3)
 
         idx = PeriodIndex([2000, 2007, 2007, 2009, 2007], freq='A-JUN',
                           tz='US/Eastern')
         expected = PeriodIndex([2000, 2007, 2009], freq='A-JUN',
                                tz='US/Eastern')
-        self.assert_index_equal(idx.unique(), expected)
+        tm.assert_index_equal(idx.unique(), expected)
         self.assertEqual(idx.nunique(), 3)
 
     def test_shift_gh8083(self):
@@ -583,7 +583,7 @@ class TestPeriodIndex(DatetimeLike, tm.TestCase):
         result = drange.shift(1)
         expected = PeriodIndex(['2013-01-02', '2013-01-03', '2013-01-04',
                                 '2013-01-05', '2013-01-06'], freq='D')
-        self.assert_index_equal(result, expected)
+        tm.assert_index_equal(result, expected)
 
     def test_shift(self):
         pi1 = PeriodIndex(freq='A', start='1/1/2001', end='12/1/2009')
@@ -592,32 +592,32 @@ class TestPeriodIndex(DatetimeLike, tm.TestCase):
         tm.assert_index_equal(pi1.shift(0), pi1)
 
         self.assertEqual(len(pi1), len(pi2))
-        self.assert_index_equal(pi1.shift(1), pi2)
+        tm.assert_index_equal(pi1.shift(1), pi2)
 
         pi1 = PeriodIndex(freq='A', start='1/1/2001', end='12/1/2009')
         pi2 = PeriodIndex(freq='A', start='1/1/2000', end='12/1/2008')
         self.assertEqual(len(pi1), len(pi2))
-        self.assert_index_equal(pi1.shift(-1), pi2)
+        tm.assert_index_equal(pi1.shift(-1), pi2)
 
         pi1 = PeriodIndex(freq='M', start='1/1/2001', end='12/1/2009')
         pi2 = PeriodIndex(freq='M', start='2/1/2001', end='1/1/2010')
         self.assertEqual(len(pi1), len(pi2))
-        self.assert_index_equal(pi1.shift(1), pi2)
+        tm.assert_index_equal(pi1.shift(1), pi2)
 
         pi1 = PeriodIndex(freq='M', start='1/1/2001', end='12/1/2009')
         pi2 = PeriodIndex(freq='M', start='12/1/2000', end='11/1/2009')
         self.assertEqual(len(pi1), len(pi2))
-        self.assert_index_equal(pi1.shift(-1), pi2)
+        tm.assert_index_equal(pi1.shift(-1), pi2)
 
         pi1 = PeriodIndex(freq='D', start='1/1/2001', end='12/1/2009')
         pi2 = PeriodIndex(freq='D', start='1/2/2001', end='12/2/2009')
         self.assertEqual(len(pi1), len(pi2))
-        self.assert_index_equal(pi1.shift(1), pi2)
+        tm.assert_index_equal(pi1.shift(1), pi2)
 
         pi1 = PeriodIndex(freq='D', start='1/1/2001', end='12/1/2009')
         pi2 = PeriodIndex(freq='D', start='12/31/2000', end='11/30/2009')
         self.assertEqual(len(pi1), len(pi2))
-        self.assert_index_equal(pi1.shift(-1), pi2)
+        tm.assert_index_equal(pi1.shift(-1), pi2)
 
     def test_shift_nat(self):
         idx = PeriodIndex(['2011-01', '2011-02', 'NaT',
@@ -661,9 +661,9 @@ class TestPeriodIndex(DatetimeLike, tm.TestCase):
                            '2012-03', '2012-04'], freq='D', name='name')
 
         exp = Index([2011, 2011, -1, 2012, 2012], dtype=np.int64, name='name')
-        self.assert_index_equal(idx.year, exp)
+        tm.assert_index_equal(idx.year, exp)
         exp = Index([1, 2, -1, 3, 4], dtype=np.int64, name='name')
-        self.assert_index_equal(idx.month, exp)
+        tm.assert_index_equal(idx.month, exp)
 
     def test_pindex_qaccess(self):
         pi = PeriodIndex(['2Q05', '3Q05', '4Q05', '1Q06', '2Q06'], freq='Q')

--- a/pandas/tests/indexes/period/test_setops.py
+++ b/pandas/tests/indexes/period/test_setops.py
@@ -126,7 +126,7 @@ class TestPeriodIndex(tm.TestCase):
         df = pd.DataFrame({'s1': s1, 's2': s2})
 
         exp = pd.period_range('1/1/1980', '1/1/2012', freq='M')
-        self.assert_index_equal(df.index, exp)
+        tm.assert_index_equal(df.index, exp)
 
     def test_intersection(self):
         index = period_range('1/1/2000', '1/20/2000', freq='D')

--- a/pandas/tests/indexes/period/test_tools.py
+++ b/pandas/tests/indexes/period/test_tools.py
@@ -265,7 +265,7 @@ class TestPeriodIndex(tm.TestCase):
 
         result3 = result.to_period(freq='3M')
         exp = PeriodIndex(['NaT', '2011-01', '2011-02'], freq='3M', name='idx')
-        self.assert_index_equal(result3, exp)
+        tm.assert_index_equal(result3, exp)
         self.assertEqual(result3.freqstr, '3M')
 
         msg = ('Frequency must be positive, because it'
@@ -278,26 +278,26 @@ class TestPeriodIndex(tm.TestCase):
         result = idx.to_timestamp()
         expected = DatetimeIndex(
             ['2011-01-01', 'NaT', '2011-02-01'], name='idx')
-        self.assert_index_equal(result, expected)
+        tm.assert_index_equal(result, expected)
         result = idx.to_timestamp(how='E')
         expected = DatetimeIndex(
             ['2011-02-28', 'NaT', '2011-03-31'], name='idx')
-        self.assert_index_equal(result, expected)
+        tm.assert_index_equal(result, expected)
 
     def test_to_timestamp_pi_combined(self):
         idx = PeriodIndex(start='2011', periods=2, freq='1D1H', name='idx')
         result = idx.to_timestamp()
         expected = DatetimeIndex(
             ['2011-01-01 00:00', '2011-01-02 01:00'], name='idx')
-        self.assert_index_equal(result, expected)
+        tm.assert_index_equal(result, expected)
         result = idx.to_timestamp(how='E')
         expected = DatetimeIndex(
             ['2011-01-02 00:59:59', '2011-01-03 01:59:59'], name='idx')
-        self.assert_index_equal(result, expected)
+        tm.assert_index_equal(result, expected)
         result = idx.to_timestamp(how='E', freq='H')
         expected = DatetimeIndex(
             ['2011-01-02 00:00', '2011-01-03 01:00'], name='idx')
-        self.assert_index_equal(result, expected)
+        tm.assert_index_equal(result, expected)
 
     def test_to_timestamp_to_period_astype(self):
         idx = DatetimeIndex([pd.NaT, '2011-01-01', '2011-02-01'], name='idx')
@@ -308,7 +308,7 @@ class TestPeriodIndex(tm.TestCase):
 
         res = idx.astype('period[3M]')
         exp = PeriodIndex(['NaT', '2011-01', '2011-02'], freq='3M', name='idx')
-        self.assert_index_equal(res, exp)
+        tm.assert_index_equal(res, exp)
 
     def test_dti_to_period(self):
         dti = DatetimeIndex(start='1/1/2005', end='12/1/2005', freq='M')

--- a/pandas/tests/indexes/period/test_tools.py
+++ b/pandas/tests/indexes/period/test_tools.py
@@ -19,8 +19,8 @@ class TestPeriodRepresentation(tm.TestCase):
     def _check_freq(self, freq, base_date):
         rng = PeriodIndex(start=base_date, periods=10, freq=freq)
         exp = np.arange(10, dtype=np.int64)
-        self.assert_numpy_array_equal(rng._values, exp)
-        self.assert_numpy_array_equal(rng.asi8, exp)
+        tm.assert_numpy_array_equal(rng._values, exp)
+        tm.assert_numpy_array_equal(rng.asi8, exp)
 
     def test_annual(self):
         self._check_freq('A', 1970)

--- a/pandas/tests/indexes/test_base.py
+++ b/pandas/tests/indexes/test_base.py
@@ -151,9 +151,9 @@ class TestIndex(Base, tm.TestCase):
         s = Series([Timestamp('20110101'), Timestamp('20120101'),
                     Timestamp('20130101')])
         result = Index(s)
-        self.assert_index_equal(result, expected)
+        tm.assert_index_equal(result, expected)
         result = DatetimeIndex(s)
-        self.assert_index_equal(result, expected)
+        tm.assert_index_equal(result, expected)
 
         # GH 6273
         # create from a series, passing a freq
@@ -162,14 +162,14 @@ class TestIndex(Base, tm.TestCase):
         result = DatetimeIndex(s, freq='MS')
         expected = DatetimeIndex(['1-1-1990', '2-1-1990', '3-1-1990',
                                   '4-1-1990', '5-1-1990'], freq='MS')
-        self.assert_index_equal(result, expected)
+        tm.assert_index_equal(result, expected)
 
         df = pd.DataFrame(np.random.rand(5, 3))
         df['date'] = ['1-1-1990', '2-1-1990', '3-1-1990', '4-1-1990',
                       '5-1-1990']
         result = DatetimeIndex(df['date'], freq='MS')
         expected.name = 'date'
-        self.assert_index_equal(result, expected)
+        tm.assert_index_equal(result, expected)
         self.assertEqual(df['date'].dtype, object)
 
         exp = pd.Series(['1-1-1990', '2-1-1990', '3-1-1990', '4-1-1990',
@@ -197,7 +197,7 @@ class TestIndex(Base, tm.TestCase):
                       date_range('2000-01-01', periods=3).values]:
             expected = pd.Index(array)
             result = pd.Index(ArrayLike(array))
-            self.assert_index_equal(result, expected)
+            tm.assert_index_equal(result, expected)
 
     def test_constructor_int_dtype_nan(self):
         # see gh-15187
@@ -268,15 +268,15 @@ class TestIndex(Base, tm.TestCase):
     def test_constructor_simple_new(self):
         idx = Index([1, 2, 3, 4, 5], name='int')
         result = idx._simple_new(idx, 'int')
-        self.assert_index_equal(result, idx)
+        tm.assert_index_equal(result, idx)
 
         idx = Index([1.1, np.nan, 2.2, 3.0], name='float')
         result = idx._simple_new(idx, 'float')
-        self.assert_index_equal(result, idx)
+        tm.assert_index_equal(result, idx)
 
         idx = Index(['A', 'B', 'C', np.nan], name='obj')
         result = idx._simple_new(idx, 'obj')
-        self.assert_index_equal(result, idx)
+        tm.assert_index_equal(result, idx)
 
     def test_constructor_dtypes(self):
 
@@ -427,31 +427,31 @@ class TestIndex(Base, tm.TestCase):
         result = Index(['b', 'c', 'd'])
 
         # test 0th element
-        self.assert_index_equal(Index(['a', 'b', 'c', 'd']),
-                                result.insert(0, 'a'))
+        tm.assert_index_equal(Index(['a', 'b', 'c', 'd']),
+                              result.insert(0, 'a'))
 
         # test Nth element that follows Python list behavior
-        self.assert_index_equal(Index(['b', 'c', 'e', 'd']),
-                                result.insert(-1, 'e'))
+        tm.assert_index_equal(Index(['b', 'c', 'e', 'd']),
+                              result.insert(-1, 'e'))
 
         # test loc +/- neq (0, -1)
-        self.assert_index_equal(result.insert(1, 'z'), result.insert(-2, 'z'))
+        tm.assert_index_equal(result.insert(1, 'z'), result.insert(-2, 'z'))
 
         # test empty
         null_index = Index([])
-        self.assert_index_equal(Index(['a']), null_index.insert(0, 'a'))
+        tm.assert_index_equal(Index(['a']), null_index.insert(0, 'a'))
 
     def test_delete(self):
         idx = Index(['a', 'b', 'c', 'd'], name='idx')
 
         expected = Index(['b', 'c', 'd'], name='idx')
         result = idx.delete(0)
-        self.assert_index_equal(result, expected)
+        tm.assert_index_equal(result, expected)
         self.assertEqual(result.name, expected.name)
 
         expected = Index(['a', 'b', 'c'], name='idx')
         result = idx.delete(-1)
-        self.assert_index_equal(result, expected)
+        tm.assert_index_equal(result, expected)
         self.assertEqual(result.name, expected.name)
 
         with tm.assertRaises((IndexError, ValueError)):
@@ -613,14 +613,14 @@ class TestIndex(Base, tm.TestCase):
         idx2 = Index([3, 4, 5, 6, 7], name='idx')
         expected2 = Index([3, 4, 5], name='idx')
         result2 = idx1.intersection(idx2)
-        self.assert_index_equal(result2, expected2)
+        tm.assert_index_equal(result2, expected2)
         self.assertEqual(result2.name, expected2.name)
 
         # if target name is different, it will be reset
         idx3 = Index([3, 4, 5, 6, 7], name='other')
         expected3 = Index([3, 4, 5], name=None)
         result3 = idx1.intersection(idx3)
-        self.assert_index_equal(result3, expected3)
+        tm.assert_index_equal(result3, expected3)
         self.assertEqual(result3.name, expected3.name)
 
         # non monotonic
@@ -628,24 +628,24 @@ class TestIndex(Base, tm.TestCase):
         idx2 = Index([4, 7, 6, 5, 3], name='idx')
         expected = Index([5, 3, 4], name='idx')
         result = idx1.intersection(idx2)
-        self.assert_index_equal(result, expected)
+        tm.assert_index_equal(result, expected)
 
         idx2 = Index([4, 7, 6, 5, 3], name='other')
         expected = Index([5, 3, 4], name=None)
         result = idx1.intersection(idx2)
-        self.assert_index_equal(result, expected)
+        tm.assert_index_equal(result, expected)
 
         # non-monotonic non-unique
         idx1 = Index(['A', 'B', 'A', 'C'])
         idx2 = Index(['B', 'D'])
         expected = Index(['B'], dtype='object')
         result = idx1.intersection(idx2)
-        self.assert_index_equal(result, expected)
+        tm.assert_index_equal(result, expected)
 
         idx2 = Index(['B', 'D', 'A'])
         expected = Index(['A', 'B', 'A'], dtype='object')
         result = idx1.intersection(idx2)
-        self.assert_index_equal(result, expected)
+        tm.assert_index_equal(result, expected)
 
         # preserve names
         first = self.strIndex[5:20]
@@ -760,16 +760,16 @@ class TestIndex(Base, tm.TestCase):
     def test_add(self):
         idx = self.strIndex
         expected = Index(self.strIndex.values * 2)
-        self.assert_index_equal(idx + idx, expected)
-        self.assert_index_equal(idx + idx.tolist(), expected)
-        self.assert_index_equal(idx.tolist() + idx, expected)
+        tm.assert_index_equal(idx + idx, expected)
+        tm.assert_index_equal(idx + idx.tolist(), expected)
+        tm.assert_index_equal(idx.tolist() + idx, expected)
 
         # test add and radd
         idx = Index(list('abc'))
         expected = Index(['a1', 'b1', 'c1'])
-        self.assert_index_equal(idx + '1', expected)
+        tm.assert_index_equal(idx + '1', expected)
         expected = Index(['1a', '1b', '1c'])
-        self.assert_index_equal('1' + idx, expected)
+        tm.assert_index_equal('1' + idx, expected)
 
     def test_sub(self):
         idx = self.strIndex
@@ -825,11 +825,11 @@ class TestIndex(Base, tm.TestCase):
 
         foos = [index[:2], index[2:4], index[4:]]
         result = foos[0].append(foos[1:])
-        self.assert_index_equal(result, index)
+        tm.assert_index_equal(result, index)
 
         # empty
         result = index.append([])
-        self.assert_index_equal(result, index)
+        tm.assert_index_equal(result, index)
 
     def test_append_empty_preserve_name(self):
         left = Index([], name='foo')
@@ -1244,7 +1244,7 @@ class TestIndex(Base, tm.TestCase):
                                              in_slice.step)
             result = idx[s_start:s_stop:in_slice.step]
             expected = pd.Index(list(expected))
-            self.assert_index_equal(result, expected)
+            tm.assert_index_equal(result, expected)
 
         for in_slice, expected in [
             (SLC[::-1], 'yxdcb'), (SLC['b':'y':-1], ''),
@@ -1266,7 +1266,7 @@ class TestIndex(Base, tm.TestCase):
         drop = self.strIndex[lrange(5, 10)]
         dropped = self.strIndex.drop(drop)
         expected = self.strIndex[lrange(5) + lrange(10, n)]
-        self.assert_index_equal(dropped, expected)
+        tm.assert_index_equal(dropped, expected)
 
         self.assertRaises(ValueError, self.strIndex.drop, ['foo', 'bar'])
         self.assertRaises(ValueError, self.strIndex.drop, ['1', 'bar'])
@@ -1275,31 +1275,31 @@ class TestIndex(Base, tm.TestCase):
         mixed = drop.tolist() + ['foo']
         dropped = self.strIndex.drop(mixed, errors='ignore')
         expected = self.strIndex[lrange(5) + lrange(10, n)]
-        self.assert_index_equal(dropped, expected)
+        tm.assert_index_equal(dropped, expected)
 
         dropped = self.strIndex.drop(['foo', 'bar'], errors='ignore')
         expected = self.strIndex[lrange(n)]
-        self.assert_index_equal(dropped, expected)
+        tm.assert_index_equal(dropped, expected)
 
         dropped = self.strIndex.drop(self.strIndex[0])
         expected = self.strIndex[1:]
-        self.assert_index_equal(dropped, expected)
+        tm.assert_index_equal(dropped, expected)
 
         ser = Index([1, 2, 3])
         dropped = ser.drop(1)
         expected = Index([2, 3])
-        self.assert_index_equal(dropped, expected)
+        tm.assert_index_equal(dropped, expected)
 
         # errors='ignore'
         self.assertRaises(ValueError, ser.drop, [3, 4])
 
         dropped = ser.drop(4, errors='ignore')
         expected = Index([1, 2, 3])
-        self.assert_index_equal(dropped, expected)
+        tm.assert_index_equal(dropped, expected)
 
         dropped = ser.drop([3, 4, 5], errors='ignore')
         expected = Index([1, 2])
-        self.assert_index_equal(dropped, expected)
+        tm.assert_index_equal(dropped, expected)
 
     def test_tuple_union_bug(self):
         import pandas
@@ -1319,13 +1319,13 @@ class TestIndex(Base, tm.TestCase):
         # needs to be 1d like idx1 and idx2
         expected = idx1[:4]  # pandas.Index(sorted(set(idx1) & set(idx2)))
         self.assertEqual(int_idx.ndim, 1)
-        self.assert_index_equal(int_idx, expected)
+        tm.assert_index_equal(int_idx, expected)
 
         # union broken
         union_idx = idx1.union(idx2)
         expected = idx2
         self.assertEqual(union_idx.ndim, 1)
-        self.assert_index_equal(union_idx, expected)
+        tm.assert_index_equal(union_idx, expected)
 
     def test_is_monotonic_incomparable(self):
         index = Index([5, datetime.now(), 7])
@@ -1417,7 +1417,7 @@ class TestIndex(Base, tm.TestCase):
 
     def test_get_level_values(self):
         result = self.strIndex.get_level_values(0)
-        self.assert_index_equal(result, self.strIndex)
+        tm.assert_index_equal(result, self.strIndex)
 
     def test_slice_keep_name(self):
         idx = Index(['a', 'b'], name='asdf')
@@ -1902,11 +1902,11 @@ class TestMixedIntIndex(Base, tm.TestCase):
                 # unorderable types
                 result = first.union(second)
                 expected = Index(['b', 2, 'c', 0, 'a', 1])
-                self.assert_index_equal(result, expected)
+                tm.assert_index_equal(result, expected)
         else:
             result = first.union(second)
             expected = Index(['b', 2, 'c', 0, 'a', 1])
-            self.assert_index_equal(result, expected)
+            tm.assert_index_equal(result, expected)
 
         # GH 10149
         cases = [klass(second.values)
@@ -1928,7 +1928,7 @@ class TestMixedIntIndex(Base, tm.TestCase):
         second = idx[:3]
         result = first.intersection(second)
         expected = Index([0, 'a', 1])
-        self.assert_index_equal(result, expected)
+        tm.assert_index_equal(result, expected)
 
         # GH 10149
         cases = [klass(second.values)
@@ -1945,7 +1945,7 @@ class TestMixedIntIndex(Base, tm.TestCase):
 
         result = first.difference(second)
         expected = Index([0, 1, 'a'])
-        self.assert_index_equal(result, expected)
+        tm.assert_index_equal(result, expected)
 
     def test_symmetric_difference(self):
         # (same results for py2 and py3 but sortedness not tested elsewhere)
@@ -1955,7 +1955,7 @@ class TestMixedIntIndex(Base, tm.TestCase):
 
         result = first.symmetric_difference(second)
         expected = Index([0, 1, 2, 'a', 'c'])
-        self.assert_index_equal(result, expected)
+        tm.assert_index_equal(result, expected)
 
     def test_logical_compat(self):
         idx = self.create_index()

--- a/pandas/tests/indexes/test_base.py
+++ b/pandas/tests/indexes/test_base.py
@@ -174,7 +174,7 @@ class TestIndex(Base, tm.TestCase):
 
         exp = pd.Series(['1-1-1990', '2-1-1990', '3-1-1990', '4-1-1990',
                          '5-1-1990'], name='date')
-        self.assert_series_equal(df['date'], exp)
+        tm.assert_series_equal(df['date'], exp)
 
         # GH 6274
         # infer freq of same

--- a/pandas/tests/indexes/test_category.py
+++ b/pandas/tests/indexes/test_category.py
@@ -427,8 +427,8 @@ class TestCategoricalIndex(Base, tm.TestCase):
         self.assertTrue(idx.has_duplicates)
 
         expected = CategoricalIndex([0], name='foo')
-        self.assert_index_equal(idx.drop_duplicates(), expected)
-        self.assert_index_equal(idx.unique(), expected)
+        tm.assert_index_equal(idx.drop_duplicates(), expected)
+        tm.assert_index_equal(idx.unique(), expected)
 
     def test_get_indexer(self):
 
@@ -803,7 +803,7 @@ class TestCategoricalIndex(Base, tm.TestCase):
         idx = CategoricalIndex([1.0, np.nan, 3.0, 1.0], name='x')
         # fill by value in categories
         exp = CategoricalIndex([1.0, 1.0, 3.0, 1.0], name='x')
-        self.assert_index_equal(idx.fillna(1.0), exp)
+        tm.assert_index_equal(idx.fillna(1.0), exp)
 
         # fill by value not in categories raises ValueError
         with tm.assertRaisesRegexp(ValueError,

--- a/pandas/tests/indexes/test_category.py
+++ b/pandas/tests/indexes/test_category.py
@@ -463,9 +463,9 @@ class TestCategoricalIndex(Base, tm.TestCase):
 
         # results in bool array
         res = cidx2.get_loc('d')
-        self.assert_numpy_array_equal(res, idx2.get_loc('d'))
-        self.assert_numpy_array_equal(res, np.array([False, False, False,
-                                                     True, False, True]))
+        tm.assert_numpy_array_equal(res, idx2.get_loc('d'))
+        tm.assert_numpy_array_equal(res, np.array([False, False, False,
+                                                   True, False, True]))
         # unique element results in scalar
         res = cidx2.get_loc('e')
         self.assertEqual(res, idx2.get_loc('e'))

--- a/pandas/tests/indexes/test_interval.py
+++ b/pandas/tests/indexes/test_interval.py
@@ -122,9 +122,9 @@ class TestIntervalIndex(Base, tm.TestCase):
         self.assertEqual(index.size, 2)
         self.assertEqual(index.shape, (2, ))
 
-        self.assert_index_equal(index.left, Index([0, 1]))
-        self.assert_index_equal(index.right, Index([1, 2]))
-        self.assert_index_equal(index.mid, Index([0.5, 1.5]))
+        tm.assert_index_equal(index.left, Index([0, 1]))
+        tm.assert_index_equal(index.right, Index([1, 2]))
+        tm.assert_index_equal(index.mid, Index([0.5, 1.5]))
 
         self.assertEqual(index.closed, 'right')
 
@@ -138,9 +138,9 @@ class TestIntervalIndex(Base, tm.TestCase):
         self.assertEqual(index.size, 3)
         self.assertEqual(index.shape, (3, ))
 
-        self.assert_index_equal(index.left, Index([0, np.nan, 1]))
-        self.assert_index_equal(index.right, Index([1, np.nan, 2]))
-        self.assert_index_equal(index.mid, Index([0.5, np.nan, 1.5]))
+        tm.assert_index_equal(index.left, Index([0, np.nan, 1]))
+        tm.assert_index_equal(index.right, Index([1, np.nan, 2]))
+        tm.assert_index_equal(index.mid, Index([0.5, np.nan, 1.5]))
 
         self.assertEqual(index.closed, 'right')
 

--- a/pandas/tests/indexes/test_interval.py
+++ b/pandas/tests/indexes/test_interval.py
@@ -129,8 +129,8 @@ class TestIntervalIndex(Base, tm.TestCase):
         self.assertEqual(index.closed, 'right')
 
         expected = np.array([Interval(0, 1), Interval(1, 2)], dtype=object)
-        self.assert_numpy_array_equal(np.asarray(index), expected)
-        self.assert_numpy_array_equal(index.values, expected)
+        tm.assert_numpy_array_equal(np.asarray(index), expected)
+        tm.assert_numpy_array_equal(index.values, expected)
 
         # with nans
         index = self.index_with_nan
@@ -146,23 +146,23 @@ class TestIntervalIndex(Base, tm.TestCase):
 
         expected = np.array([Interval(0, 1), np.nan,
                              Interval(1, 2)], dtype=object)
-        self.assert_numpy_array_equal(np.asarray(index), expected)
-        self.assert_numpy_array_equal(index.values, expected)
+        tm.assert_numpy_array_equal(np.asarray(index), expected)
+        tm.assert_numpy_array_equal(index.values, expected)
 
     def test_with_nans(self):
         index = self.index
         self.assertFalse(index.hasnans)
-        self.assert_numpy_array_equal(index.isnull(),
-                                      np.array([False, False]))
-        self.assert_numpy_array_equal(index.notnull(),
-                                      np.array([True, True]))
+        tm.assert_numpy_array_equal(index.isnull(),
+                                    np.array([False, False]))
+        tm.assert_numpy_array_equal(index.notnull(),
+                                    np.array([True, True]))
 
         index = self.index_with_nan
         self.assertTrue(index.hasnans)
-        self.assert_numpy_array_equal(index.notnull(),
-                                      np.array([True, False, True]))
-        self.assert_numpy_array_equal(index.isnull(),
-                                      np.array([False, True, False]))
+        tm.assert_numpy_array_equal(index.notnull(),
+                                    np.array([True, False, True]))
+        tm.assert_numpy_array_equal(index.isnull(),
+                                    np.array([False, True, False]))
 
     def test_copy(self):
         actual = self.index.copy()
@@ -339,10 +339,10 @@ class TestIntervalIndex(Base, tm.TestCase):
         idx = IntervalIndex.from_tuples([(0, 2), (1, 3)])
         self.assertEqual(idx.get_loc(0.5), 0)
         self.assertEqual(idx.get_loc(1), 0)
-        self.assert_numpy_array_equal(idx.get_loc(1.5),
-                                      np.array([0, 1], dtype='int64'))
-        self.assert_numpy_array_equal(np.sort(idx.get_loc(2)),
-                                      np.array([0, 1], dtype='int64'))
+        tm.assert_numpy_array_equal(idx.get_loc(1.5),
+                                    np.array([0, 1], dtype='int64'))
+        tm.assert_numpy_array_equal(np.sort(idx.get_loc(2)),
+                                    np.array([0, 1], dtype='int64'))
         self.assertEqual(idx.get_loc(3), 1)
         self.assertRaises(KeyError, idx.get_loc, 3.5)
 
@@ -415,24 +415,24 @@ class TestIntervalIndex(Base, tm.TestCase):
     def test_get_indexer(self):
         actual = self.index.get_indexer([-1, 0, 0.5, 1, 1.5, 2, 3])
         expected = np.array([-1, -1, 0, 0, 1, 1, -1], dtype='intp')
-        self.assert_numpy_array_equal(actual, expected)
+        tm.assert_numpy_array_equal(actual, expected)
 
         actual = self.index.get_indexer(self.index)
         expected = np.array([0, 1], dtype='intp')
-        self.assert_numpy_array_equal(actual, expected)
+        tm.assert_numpy_array_equal(actual, expected)
 
         index = IntervalIndex.from_breaks([0, 1, 2], closed='left')
         actual = index.get_indexer([-1, 0, 0.5, 1, 1.5, 2, 3])
         expected = np.array([-1, 0, 0, 1, 1, -1, -1], dtype='intp')
-        self.assert_numpy_array_equal(actual, expected)
+        tm.assert_numpy_array_equal(actual, expected)
 
         actual = self.index.get_indexer(index[:1])
         expected = np.array([0], dtype='intp')
-        self.assert_numpy_array_equal(actual, expected)
+        tm.assert_numpy_array_equal(actual, expected)
 
         actual = self.index.get_indexer(index)
         expected = np.array([-1, 1], dtype='intp')
-        self.assert_numpy_array_equal(actual, expected)
+        tm.assert_numpy_array_equal(actual, expected)
 
     def test_get_indexer_subintervals(self):
 
@@ -441,21 +441,21 @@ class TestIntervalIndex(Base, tm.TestCase):
         target = IntervalIndex.from_breaks(np.linspace(0, 2, 5))
         actual = self.index.get_indexer(target)
         expected = np.array([0, 0, 1, 1], dtype='p')
-        self.assert_numpy_array_equal(actual, expected)
+        tm.assert_numpy_array_equal(actual, expected)
 
         target = IntervalIndex.from_breaks([0, 0.67, 1.33, 2])
         actual = self.index.get_indexer(target)
         expected = np.array([0, 0, 1, 1], dtype='intp')
-        self.assert_numpy_array_equal(actual, expected)
+        tm.assert_numpy_array_equal(actual, expected)
 
         actual = self.index.get_indexer(target[[0, -1]])
         expected = np.array([0, 1], dtype='intp')
-        self.assert_numpy_array_equal(actual, expected)
+        tm.assert_numpy_array_equal(actual, expected)
 
         target = IntervalIndex.from_breaks([0, 0.33, 0.67, 1], closed='left')
         actual = self.index.get_indexer(target)
         expected = np.array([0, 0, 0], dtype='intp')
-        self.assert_numpy_array_equal(actual, expected)
+        tm.assert_numpy_array_equal(actual, expected)
 
     def test_contains(self):
         # only endpoints are valid
@@ -507,7 +507,7 @@ class TestIntervalIndex(Base, tm.TestCase):
         target = [0.5, 1.5, 2.5]
         actual = index.get_indexer(target)
         expected = np.array([0, -1, 1], dtype='intp')
-        self.assert_numpy_array_equal(actual, expected)
+        tm.assert_numpy_array_equal(actual, expected)
 
         self.assertNotIn(1.5, index)
 
@@ -550,57 +550,57 @@ class TestIntervalIndex(Base, tm.TestCase):
 
     def test_isin(self):
         actual = self.index.isin(self.index)
-        self.assert_numpy_array_equal(np.array([True, True]), actual)
+        tm.assert_numpy_array_equal(np.array([True, True]), actual)
 
         actual = self.index.isin(self.index[:1])
-        self.assert_numpy_array_equal(np.array([True, False]), actual)
+        tm.assert_numpy_array_equal(np.array([True, False]), actual)
 
     def test_comparison(self):
         actual = Interval(0, 1) < self.index
         expected = np.array([False, True])
-        self.assert_numpy_array_equal(actual, expected)
+        tm.assert_numpy_array_equal(actual, expected)
 
         actual = Interval(0.5, 1.5) < self.index
         expected = np.array([False, True])
-        self.assert_numpy_array_equal(actual, expected)
+        tm.assert_numpy_array_equal(actual, expected)
         actual = self.index > Interval(0.5, 1.5)
-        self.assert_numpy_array_equal(actual, expected)
+        tm.assert_numpy_array_equal(actual, expected)
 
         actual = self.index == self.index
         expected = np.array([True, True])
-        self.assert_numpy_array_equal(actual, expected)
+        tm.assert_numpy_array_equal(actual, expected)
         actual = self.index <= self.index
-        self.assert_numpy_array_equal(actual, expected)
+        tm.assert_numpy_array_equal(actual, expected)
         actual = self.index >= self.index
-        self.assert_numpy_array_equal(actual, expected)
+        tm.assert_numpy_array_equal(actual, expected)
 
         actual = self.index < self.index
         expected = np.array([False, False])
-        self.assert_numpy_array_equal(actual, expected)
+        tm.assert_numpy_array_equal(actual, expected)
         actual = self.index > self.index
-        self.assert_numpy_array_equal(actual, expected)
+        tm.assert_numpy_array_equal(actual, expected)
 
         actual = self.index == IntervalIndex.from_breaks([0, 1, 2], 'left')
-        self.assert_numpy_array_equal(actual, expected)
+        tm.assert_numpy_array_equal(actual, expected)
 
         actual = self.index == self.index.values
-        self.assert_numpy_array_equal(actual, np.array([True, True]))
+        tm.assert_numpy_array_equal(actual, np.array([True, True]))
         actual = self.index.values == self.index
-        self.assert_numpy_array_equal(actual, np.array([True, True]))
+        tm.assert_numpy_array_equal(actual, np.array([True, True]))
         actual = self.index <= self.index.values
-        self.assert_numpy_array_equal(actual, np.array([True, True]))
+        tm.assert_numpy_array_equal(actual, np.array([True, True]))
         actual = self.index != self.index.values
-        self.assert_numpy_array_equal(actual, np.array([False, False]))
+        tm.assert_numpy_array_equal(actual, np.array([False, False]))
         actual = self.index > self.index.values
-        self.assert_numpy_array_equal(actual, np.array([False, False]))
+        tm.assert_numpy_array_equal(actual, np.array([False, False]))
         actual = self.index.values > self.index
-        self.assert_numpy_array_equal(actual, np.array([False, False]))
+        tm.assert_numpy_array_equal(actual, np.array([False, False]))
 
         # invalid comparisons
         actual = self.index == 0
-        self.assert_numpy_array_equal(actual, np.array([False, False]))
+        tm.assert_numpy_array_equal(actual, np.array([False, False]))
         actual = self.index == self.index.left
-        self.assert_numpy_array_equal(actual, np.array([False, False]))
+        tm.assert_numpy_array_equal(actual, np.array([False, False]))
 
         with self.assertRaisesRegexp(TypeError, 'unorderable types'):
             self.index > 0
@@ -619,8 +619,8 @@ class TestIntervalIndex(Base, tm.TestCase):
         with pytest.raises(ValueError):
             IntervalIndex.from_arrays([np.nan, 0, 1], np.array([0, 1, 2]))
 
-        self.assert_numpy_array_equal(isnull(idx),
-                                      np.array([True, False, False]))
+        tm.assert_numpy_array_equal(isnull(idx),
+                                    np.array([True, False, False]))
 
     def test_sort_values(self):
         expected = IntervalIndex.from_breaks([1, 2, 3, 4])
@@ -631,15 +631,15 @@ class TestIntervalIndex(Base, tm.TestCase):
         # nan
         idx = self.index_with_nan
         mask = idx.isnull()
-        self.assert_numpy_array_equal(mask, np.array([False, True, False]))
+        tm.assert_numpy_array_equal(mask, np.array([False, True, False]))
 
         result = idx.sort_values()
         mask = result.isnull()
-        self.assert_numpy_array_equal(mask, np.array([False, False, True]))
+        tm.assert_numpy_array_equal(mask, np.array([False, False, True]))
 
         result = idx.sort_values(ascending=False)
         mask = result.isnull()
-        self.assert_numpy_array_equal(mask, np.array([True, False, False]))
+        tm.assert_numpy_array_equal(mask, np.array([True, False, False]))
 
     def test_datetime(self):
         dates = pd.date_range('2000', periods=3)
@@ -657,7 +657,7 @@ class TestIntervalIndex(Base, tm.TestCase):
         target = pd.date_range('1999-12-31T12:00', periods=7, freq='12H')
         actual = idx.get_indexer(target)
         expected = np.array([-1, -1, 0, 0, 1, 1, -1], dtype='intp')
-        self.assert_numpy_array_equal(actual, expected)
+        tm.assert_numpy_array_equal(actual, expected)
 
     def test_append(self):
 
@@ -728,16 +728,16 @@ class TestIntervalTree(tm.TestCase):
 
     def test_get_loc(self):
         for dtype, tree in self.trees.items():
-            self.assert_numpy_array_equal(tree.get_loc(1),
-                                          np.array([0], dtype='int64'))
-            self.assert_numpy_array_equal(np.sort(tree.get_loc(2)),
-                                          np.array([0, 1], dtype='int64'))
-            with self.assertRaises(KeyError):
+            tm.assert_numpy_array_equal(tree.get_loc(1),
+                                        np.array([0], dtype='int64'))
+            tm.assert_numpy_array_equal(np.sort(tree.get_loc(2)),
+                                        np.array([0, 1], dtype='int64'))
+            with pytest.raises(KeyError):
                 tree.get_loc(-1)
 
     def test_get_indexer(self):
         for dtype, tree in self.trees.items():
-            self.assert_numpy_array_equal(
+            tm.assert_numpy_array_equal(
                 tree.get_indexer(np.array([1.0, 5.5, 6.5])),
                 np.array([0, 4, -1], dtype='int64'))
             with self.assertRaises(KeyError):
@@ -746,26 +746,26 @@ class TestIntervalTree(tm.TestCase):
     def test_get_indexer_non_unique(self):
         indexer, missing = self.tree.get_indexer_non_unique(
             np.array([1.0, 2.0, 6.5]))
-        self.assert_numpy_array_equal(indexer[:1],
-                                      np.array([0], dtype='int64'))
-        self.assert_numpy_array_equal(np.sort(indexer[1:3]),
-                                      np.array([0, 1], dtype='int64'))
-        self.assert_numpy_array_equal(np.sort(indexer[3:]),
-                                      np.array([-1], dtype='int64'))
-        self.assert_numpy_array_equal(missing, np.array([2], dtype='int64'))
+        tm.assert_numpy_array_equal(indexer[:1],
+                                    np.array([0], dtype='int64'))
+        tm.assert_numpy_array_equal(np.sort(indexer[1:3]),
+                                    np.array([0, 1], dtype='int64'))
+        tm.assert_numpy_array_equal(np.sort(indexer[3:]),
+                                    np.array([-1], dtype='int64'))
+        tm.assert_numpy_array_equal(missing, np.array([2], dtype='int64'))
 
     def test_duplicates(self):
         tree = IntervalTree([0, 0, 0], [1, 1, 1])
-        self.assert_numpy_array_equal(np.sort(tree.get_loc(0.5)),
-                                      np.array([0, 1, 2], dtype='int64'))
+        tm.assert_numpy_array_equal(np.sort(tree.get_loc(0.5)),
+                                    np.array([0, 1, 2], dtype='int64'))
 
-        with self.assertRaises(KeyError):
+        with pytest.raises(KeyError):
             tree.get_indexer(np.array([0.5]))
 
         indexer, missing = tree.get_indexer_non_unique(np.array([0.5]))
-        self.assert_numpy_array_equal(np.sort(indexer),
-                                      np.array([0, 1, 2], dtype='int64'))
-        self.assert_numpy_array_equal(missing, np.array([], dtype='int64'))
+        tm.assert_numpy_array_equal(np.sort(indexer),
+                                    np.array([0, 1, 2], dtype='int64'))
+        tm.assert_numpy_array_equal(missing, np.array([], dtype='int64'))
 
     def test_get_loc_closed(self):
         for closed in ['left', 'right', 'both', 'neither']:
@@ -773,29 +773,30 @@ class TestIntervalTree(tm.TestCase):
             for p, errors in [(0, tree.open_left),
                               (1, tree.open_right)]:
                 if errors:
-                    with self.assertRaises(KeyError):
+                    with pytest.raises(KeyError):
                         tree.get_loc(p)
                 else:
-                    self.assert_numpy_array_equal(tree.get_loc(p),
-                                                  np.array([0], dtype='int64'))
+                    tm.assert_numpy_array_equal(tree.get_loc(p),
+                                                np.array([0], dtype='int64'))
 
     @pytest.mark.skipif(compat.is_platform_32bit(),
-                        reason="int type mistmach on 32bit")
+                        reason="int type mismatch on 32bit")
     def test_get_indexer_closed(self):
         x = np.arange(1000, dtype='float64')
         found = x.astype('intp')
         not_found = (-1 * np.ones(1000)).astype('intp')
+
         for leaf_size in [1, 10, 100, 10000]:
             for closed in ['left', 'right', 'both', 'neither']:
                 tree = IntervalTree(x, x + 0.5, closed=closed,
                                     leaf_size=leaf_size)
-                self.assert_numpy_array_equal(found,
-                                              tree.get_indexer(x + 0.25))
+                tm.assert_numpy_array_equal(found,
+                                            tree.get_indexer(x + 0.25))
 
                 expected = found if tree.closed_left else not_found
-                self.assert_numpy_array_equal(expected,
-                                              tree.get_indexer(x + 0.0))
+                tm.assert_numpy_array_equal(expected,
+                                            tree.get_indexer(x + 0.0))
 
                 expected = found if tree.closed_right else not_found
-                self.assert_numpy_array_equal(expected,
-                                              tree.get_indexer(x + 0.5))
+                tm.assert_numpy_array_equal(expected,
+                                            tree.get_indexer(x + 0.5))

--- a/pandas/tests/indexes/test_multi.py
+++ b/pandas/tests/indexes/test_multi.py
@@ -951,9 +951,9 @@ class TestMultiIndex(Base, tm.TestCase):
             ['A', 'B']), CategoricalIndex([1, 2, 3])], labels=[np.array(
                 [0, 0, 0, 1, 1, 1]), np.array([0, 1, 2, 0, 1, 2])])
         exp = CategoricalIndex(['A', 'A', 'A', 'B', 'B', 'B'])
-        self.assert_index_equal(index.get_level_values(0), exp)
+        tm.assert_index_equal(index.get_level_values(0), exp)
         exp = CategoricalIndex([1, 2, 3, 1, 2, 3])
-        self.assert_index_equal(index.get_level_values(1), exp)
+        tm.assert_index_equal(index.get_level_values(1), exp)
 
     def test_get_level_values_na(self):
         arrays = [['a', 'b', 'b'], [1, np.nan, 2]]
@@ -1769,16 +1769,16 @@ class TestMultiIndex(Base, tm.TestCase):
         dropped2 = self.index.drop(index)
 
         expected = self.index[[0, 2, 3, 5]]
-        self.assert_index_equal(dropped, expected)
-        self.assert_index_equal(dropped2, expected)
+        tm.assert_index_equal(dropped, expected)
+        tm.assert_index_equal(dropped2, expected)
 
         dropped = self.index.drop(['bar'])
         expected = self.index[[0, 1, 3, 4, 5]]
-        self.assert_index_equal(dropped, expected)
+        tm.assert_index_equal(dropped, expected)
 
         dropped = self.index.drop('foo')
         expected = self.index[[2, 3, 4, 5]]
-        self.assert_index_equal(dropped, expected)
+        tm.assert_index_equal(dropped, expected)
 
         index = MultiIndex.from_tuples([('bar', 'two')])
         self.assertRaises(KeyError, self.index.drop, [('bar', 'two')])
@@ -1792,27 +1792,27 @@ class TestMultiIndex(Base, tm.TestCase):
         # error='ignore'
         dropped = self.index.drop(index, errors='ignore')
         expected = self.index[[0, 1, 2, 3, 4, 5]]
-        self.assert_index_equal(dropped, expected)
+        tm.assert_index_equal(dropped, expected)
 
         dropped = self.index.drop(mixed_index, errors='ignore')
         expected = self.index[[0, 1, 2, 3, 5]]
-        self.assert_index_equal(dropped, expected)
+        tm.assert_index_equal(dropped, expected)
 
         dropped = self.index.drop(['foo', 'two'], errors='ignore')
         expected = self.index[[2, 3, 4, 5]]
-        self.assert_index_equal(dropped, expected)
+        tm.assert_index_equal(dropped, expected)
 
         # mixed partial / full drop
         dropped = self.index.drop(['foo', ('qux', 'one')])
         expected = self.index[[2, 3, 5]]
-        self.assert_index_equal(dropped, expected)
+        tm.assert_index_equal(dropped, expected)
 
         # mixed partial / full drop / error='ignore'
         mixed_index = ['foo', ('qux', 'one'), 'two']
         self.assertRaises(KeyError, self.index.drop, mixed_index)
         dropped = self.index.drop(mixed_index, errors='ignore')
         expected = self.index[[2, 3, 5]]
-        self.assert_index_equal(dropped, expected)
+        tm.assert_index_equal(dropped, expected)
 
     def test_droplevel_with_names(self):
         index = self.index[self.index.get_loc('foo')]
@@ -1857,10 +1857,10 @@ class TestMultiIndex(Base, tm.TestCase):
         self.assertFalse(not_lexsorted_mi.is_lexsorted())
 
         # compare the results
-        self.assert_index_equal(lexsorted_mi, not_lexsorted_mi)
+        tm.assert_index_equal(lexsorted_mi, not_lexsorted_mi)
         with self.assert_produces_warning(PerformanceWarning):
-            self.assert_index_equal(lexsorted_mi.drop('a'),
-                                    not_lexsorted_mi.drop('a'))
+            tm.assert_index_equal(lexsorted_mi.drop('a'),
+                                  not_lexsorted_mi.drop('a'))
 
     def test_insert(self):
         # key contained in all levels
@@ -2053,12 +2053,12 @@ class TestMultiIndex(Base, tm.TestCase):
             [np.arange(4), [1, 2]], names=['a', 'b'])
         exp_lidx = np.array([1, 2, 5, 6, 9, 10, 13, 14], dtype=np.intp)
         exp_ridx = np.array([0, 1, 0, 1, 0, 1, 0, 1], dtype=np.intp)
-        self.assert_index_equal(jidx, exp_idx)
+        tm.assert_index_equal(jidx, exp_idx)
         self.assert_numpy_array_equal(lidx, exp_lidx)
         self.assert_numpy_array_equal(ridx, exp_ridx)
         # flip
         jidx, ridx, lidx = idx.join(midx, how='inner', return_indexers=True)
-        self.assert_index_equal(jidx, exp_idx)
+        tm.assert_index_equal(jidx, exp_idx)
         self.assert_numpy_array_equal(lidx, exp_lidx)
         self.assert_numpy_array_equal(ridx, exp_ridx)
 
@@ -2066,12 +2066,12 @@ class TestMultiIndex(Base, tm.TestCase):
         jidx, lidx, ridx = midx.join(idx, how='left', return_indexers=True)
         exp_ridx = np.array([-1, 0, 1, -1, -1, 0, 1, -1, -1, 0, 1, -1, -1, 0,
                              1, -1], dtype=np.intp)
-        self.assert_index_equal(jidx, midx)
+        tm.assert_index_equal(jidx, midx)
         self.assertIsNone(lidx)
         self.assert_numpy_array_equal(ridx, exp_ridx)
         # flip
         jidx, ridx, lidx = idx.join(midx, how='right', return_indexers=True)
-        self.assert_index_equal(jidx, midx)
+        tm.assert_index_equal(jidx, midx)
         self.assertIsNone(lidx)
         self.assert_numpy_array_equal(ridx, exp_ridx)
 
@@ -2229,7 +2229,7 @@ class TestMultiIndex(Base, tm.TestCase):
         for dropna in [False, True]:
             result = idx._get_unique_index(dropna=dropna)
             self.assertTrue(result.unique)
-            self.assert_index_equal(result, expected)
+            tm.assert_index_equal(result, expected)
 
     def test_unique(self):
         mi = pd.MultiIndex.from_arrays([[1, 2, 1, 2], [1, 1, 1, 2]])

--- a/pandas/tests/indexes/test_multi.py
+++ b/pandas/tests/indexes/test_multi.py
@@ -1364,8 +1364,8 @@ class TestMultiIndex(Base, tm.TestCase):
         index = MultiIndex.from_product([np.arange(1000), np.arange(1000)],
                                         names=['one', 'two'])
         result = index.get_indexer(index.values)
-        self.assert_numpy_array_equal(result,
-                                      np.arange(len(index), dtype='intp'))
+        tm.assert_numpy_array_equal(result, np.arange(
+            len(index), dtype='intp'))
 
         for i in [0, 1, len(index) - 2, len(index) - 1]:
             result = index.get_loc(index[i])
@@ -2054,13 +2054,13 @@ class TestMultiIndex(Base, tm.TestCase):
         exp_lidx = np.array([1, 2, 5, 6, 9, 10, 13, 14], dtype=np.intp)
         exp_ridx = np.array([0, 1, 0, 1, 0, 1, 0, 1], dtype=np.intp)
         tm.assert_index_equal(jidx, exp_idx)
-        self.assert_numpy_array_equal(lidx, exp_lidx)
-        self.assert_numpy_array_equal(ridx, exp_ridx)
+        tm.assert_numpy_array_equal(lidx, exp_lidx)
+        tm.assert_numpy_array_equal(ridx, exp_ridx)
         # flip
         jidx, ridx, lidx = idx.join(midx, how='inner', return_indexers=True)
         tm.assert_index_equal(jidx, exp_idx)
-        self.assert_numpy_array_equal(lidx, exp_lidx)
-        self.assert_numpy_array_equal(ridx, exp_ridx)
+        tm.assert_numpy_array_equal(lidx, exp_lidx)
+        tm.assert_numpy_array_equal(ridx, exp_ridx)
 
         # keep MultiIndex
         jidx, lidx, ridx = midx.join(idx, how='left', return_indexers=True)
@@ -2068,12 +2068,12 @@ class TestMultiIndex(Base, tm.TestCase):
                              1, -1], dtype=np.intp)
         tm.assert_index_equal(jidx, midx)
         self.assertIsNone(lidx)
-        self.assert_numpy_array_equal(ridx, exp_ridx)
+        tm.assert_numpy_array_equal(ridx, exp_ridx)
         # flip
         jidx, ridx, lidx = idx.join(midx, how='right', return_indexers=True)
         tm.assert_index_equal(jidx, midx)
         self.assertIsNone(lidx)
-        self.assert_numpy_array_equal(ridx, exp_ridx)
+        tm.assert_numpy_array_equal(ridx, exp_ridx)
 
     def test_reindex(self):
         result, indexer = self.index.reindex(list(self.index[:4]))

--- a/pandas/tests/indexes/test_multi.py
+++ b/pandas/tests/indexes/test_multi.py
@@ -1858,7 +1858,7 @@ class TestMultiIndex(Base, tm.TestCase):
 
         # compare the results
         tm.assert_index_equal(lexsorted_mi, not_lexsorted_mi)
-        with self.assert_produces_warning(PerformanceWarning):
+        with tm.assert_produces_warning(PerformanceWarning):
             tm.assert_index_equal(lexsorted_mi.drop('a'),
                                   not_lexsorted_mi.drop('a'))
 

--- a/pandas/tests/indexes/test_numeric.py
+++ b/pandas/tests/indexes/test_numeric.py
@@ -406,15 +406,15 @@ class TestFloat64Index(Numeric, tm.TestCase):
         idx = Index([1.0, np.nan, 3.0], dtype=float, name='x')
         # can't downcast
         exp = Index([1.0, 0.1, 3.0], name='x')
-        self.assert_index_equal(idx.fillna(0.1), exp)
+        tm.assert_index_equal(idx.fillna(0.1), exp)
 
         # downcast
         exp = Float64Index([1.0, 2.0, 3.0], name='x')
-        self.assert_index_equal(idx.fillna(2), exp)
+        tm.assert_index_equal(idx.fillna(2), exp)
 
         # object
         exp = Index([1.0, 'obj', 3.0], name='x')
-        self.assert_index_equal(idx.fillna('obj'), exp)
+        tm.assert_index_equal(idx.fillna('obj'), exp)
 
     def test_take_fill_value(self):
         # GH 12631
@@ -504,7 +504,7 @@ class NumericInt(Numeric):
         joined, lidx, ridx = left.join(left, return_indexers=True)
 
         exp_joined = Index([3, 3, 3, 3, 4, 4, 4, 4])
-        self.assert_index_equal(joined, exp_joined)
+        tm.assert_index_equal(joined, exp_joined)
 
         exp_lidx = np.array([2, 2, 3, 3, 0, 0, 1, 1], dtype=np.intp)
         tm.assert_numpy_array_equal(lidx, exp_lidx)
@@ -666,7 +666,7 @@ class TestInt64Index(NumericInt, tm.TestCase):
         arr = np.array([1, 2, 3, 4], dtype=object)
         index = Int64Index(arr)
         self.assertEqual(index.values.dtype, np.int64)
-        self.assert_index_equal(index, Index(arr))
+        tm.assert_index_equal(index, Index(arr))
 
         # preventing casting
         arr = np.array([1, '2', 3, '4'], dtype=object)
@@ -758,7 +758,7 @@ class TestInt64Index(NumericInt, tm.TestCase):
         eridx = np.array([4, 1], dtype=np.intp)
 
         tm.assertIsInstance(res, Int64Index)
-        self.assert_index_equal(res, eres)
+        tm.assert_index_equal(res, eres)
         tm.assert_numpy_array_equal(lidx, elidx)
         tm.assert_numpy_array_equal(ridx, eridx)
 
@@ -767,12 +767,12 @@ class TestInt64Index(NumericInt, tm.TestCase):
                                           return_indexers=True)
 
         res2 = self.index.intersection(other_mono)
-        self.assert_index_equal(res, res2)
+        tm.assert_index_equal(res, res2)
 
         elidx = np.array([1, 6], dtype=np.intp)
         eridx = np.array([1, 4], dtype=np.intp)
         tm.assertIsInstance(res, Int64Index)
-        self.assert_index_equal(res, eres)
+        tm.assert_index_equal(res, eres)
         tm.assert_numpy_array_equal(lidx, elidx)
         tm.assert_numpy_array_equal(ridx, eridx)
 
@@ -788,7 +788,7 @@ class TestInt64Index(NumericInt, tm.TestCase):
                          dtype=np.intp)
 
         tm.assertIsInstance(res, Int64Index)
-        self.assert_index_equal(res, eres)
+        tm.assert_index_equal(res, eres)
         self.assertIsNone(lidx)
         tm.assert_numpy_array_equal(ridx, eridx)
 
@@ -798,7 +798,7 @@ class TestInt64Index(NumericInt, tm.TestCase):
         eridx = np.array([-1, 1, -1, -1, -1, -1, 4, -1, -1, -1],
                          dtype=np.intp)
         tm.assertIsInstance(res, Int64Index)
-        self.assert_index_equal(res, eres)
+        tm.assert_index_equal(res, eres)
         self.assertIsNone(lidx)
         tm.assert_numpy_array_equal(ridx, eridx)
 
@@ -809,7 +809,7 @@ class TestInt64Index(NumericInt, tm.TestCase):
         eres = Index([1, 1, 2, 5, 7, 9])  # 1 is in idx2, so it should be x2
         eridx = np.array([0, 1, 2, 3, -1, -1], dtype=np.intp)
         elidx = np.array([0, 0, 1, 2, 3, 4], dtype=np.intp)
-        self.assert_index_equal(res, eres)
+        tm.assert_index_equal(res, eres)
         tm.assert_numpy_array_equal(lidx, elidx)
         tm.assert_numpy_array_equal(ridx, eridx)
 
@@ -824,7 +824,7 @@ class TestInt64Index(NumericInt, tm.TestCase):
         elidx = np.array([-1, 6, -1, -1, 1, -1], dtype=np.intp)
 
         tm.assertIsInstance(other, Int64Index)
-        self.assert_index_equal(res, eres)
+        tm.assert_index_equal(res, eres)
         tm.assert_numpy_array_equal(lidx, elidx)
         self.assertIsNone(ridx)
 
@@ -834,7 +834,7 @@ class TestInt64Index(NumericInt, tm.TestCase):
         eres = other_mono
         elidx = np.array([-1, 1, -1, -1, 6, -1], dtype=np.intp)
         tm.assertIsInstance(other, Int64Index)
-        self.assert_index_equal(res, eres)
+        tm.assert_index_equal(res, eres)
         tm.assert_numpy_array_equal(lidx, elidx)
         self.assertIsNone(ridx)
 
@@ -845,7 +845,7 @@ class TestInt64Index(NumericInt, tm.TestCase):
         eres = Index([1, 1, 2, 5, 7, 9])  # 1 is in idx2, so it should be x2
         elidx = np.array([0, 1, 2, 3, -1, -1], dtype=np.intp)
         eridx = np.array([0, 0, 1, 2, 3, 4], dtype=np.intp)
-        self.assert_index_equal(res, eres)
+        tm.assert_index_equal(res, eres)
         tm.assert_numpy_array_equal(lidx, elidx)
         tm.assert_numpy_array_equal(ridx, eridx)
 
@@ -855,26 +855,26 @@ class TestInt64Index(NumericInt, tm.TestCase):
         outer = self.index.join(other, how='outer')
         outer2 = other.join(self.index, how='outer')
         expected = Index([0, 2, 3, 4, 6, 7, 8, 10, 12, 14, 16, 18])
-        self.assert_index_equal(outer, outer2)
-        self.assert_index_equal(outer, expected)
+        tm.assert_index_equal(outer, outer2)
+        tm.assert_index_equal(outer, expected)
 
         inner = self.index.join(other, how='inner')
         inner2 = other.join(self.index, how='inner')
         expected = Index([6, 8, 10])
-        self.assert_index_equal(inner, inner2)
-        self.assert_index_equal(inner, expected)
+        tm.assert_index_equal(inner, inner2)
+        tm.assert_index_equal(inner, expected)
 
         left = self.index.join(other, how='left')
-        self.assert_index_equal(left, self.index.astype(object))
+        tm.assert_index_equal(left, self.index.astype(object))
 
         left2 = other.join(self.index, how='left')
-        self.assert_index_equal(left2, other)
+        tm.assert_index_equal(left2, other)
 
         right = self.index.join(other, how='right')
-        self.assert_index_equal(right, other)
+        tm.assert_index_equal(right, other)
 
         right2 = other.join(self.index, how='right')
-        self.assert_index_equal(right2, self.index.astype(object))
+        tm.assert_index_equal(right2, self.index.astype(object))
 
     def test_join_outer(self):
         other = Int64Index([7, 12, 25, 1, 2, 5])
@@ -885,7 +885,7 @@ class TestInt64Index(NumericInt, tm.TestCase):
         res, lidx, ridx = self.index.join(other, how='outer',
                                           return_indexers=True)
         noidx_res = self.index.join(other, how='outer')
-        self.assert_index_equal(res, noidx_res)
+        tm.assert_index_equal(res, noidx_res)
 
         eres = Int64Index([0, 1, 2, 4, 5, 6, 7, 8, 10, 12, 14, 16, 18, 25])
         elidx = np.array([0, -1, 1, 2, -1, 3, -1, 4, 5, 6, 7, 8, 9, -1],
@@ -894,7 +894,7 @@ class TestInt64Index(NumericInt, tm.TestCase):
                          dtype=np.intp)
 
         tm.assertIsInstance(res, Int64Index)
-        self.assert_index_equal(res, eres)
+        tm.assert_index_equal(res, eres)
         tm.assert_numpy_array_equal(lidx, elidx)
         tm.assert_numpy_array_equal(ridx, eridx)
 
@@ -902,14 +902,14 @@ class TestInt64Index(NumericInt, tm.TestCase):
         res, lidx, ridx = self.index.join(other_mono, how='outer',
                                           return_indexers=True)
         noidx_res = self.index.join(other_mono, how='outer')
-        self.assert_index_equal(res, noidx_res)
+        tm.assert_index_equal(res, noidx_res)
 
         elidx = np.array([0, -1, 1, 2, -1, 3, -1, 4, 5, 6, 7, 8, 9, -1],
                          dtype=np.intp)
         eridx = np.array([-1, 0, 1, -1, 2, -1, 3, -1, -1, 4, -1, -1, -1, 5],
                          dtype=np.intp)
         tm.assertIsInstance(res, Int64Index)
-        self.assert_index_equal(res, eres)
+        tm.assert_index_equal(res, eres)
         tm.assert_numpy_array_equal(lidx, elidx)
         tm.assert_numpy_array_equal(ridx, eridx)
 
@@ -996,7 +996,7 @@ class TestUInt64Index(NumericInt, tm.TestCase):
         eridx = np.array([5, 2], dtype=np.intp)
 
         tm.assertIsInstance(res, UInt64Index)
-        self.assert_index_equal(res, eres)
+        tm.assert_index_equal(res, eres)
         tm.assert_numpy_array_equal(lidx, elidx)
         tm.assert_numpy_array_equal(ridx, eridx)
 
@@ -1005,13 +1005,13 @@ class TestUInt64Index(NumericInt, tm.TestCase):
                                           return_indexers=True)
 
         res2 = self.index.intersection(other_mono)
-        self.assert_index_equal(res, res2)
+        tm.assert_index_equal(res, res2)
 
         elidx = np.array([1, 4], dtype=np.intp)
         eridx = np.array([3, 5], dtype=np.intp)
 
         tm.assertIsInstance(res, UInt64Index)
-        self.assert_index_equal(res, eres)
+        tm.assert_index_equal(res, eres)
         tm.assert_numpy_array_equal(lidx, elidx)
         tm.assert_numpy_array_equal(ridx, eridx)
 
@@ -1028,7 +1028,7 @@ class TestUInt64Index(NumericInt, tm.TestCase):
         eridx = np.array([-1, 5, -1, -1, 2], dtype=np.intp)
 
         tm.assertIsInstance(res, UInt64Index)
-        self.assert_index_equal(res, eres)
+        tm.assert_index_equal(res, eres)
         self.assertIsNone(lidx)
         tm.assert_numpy_array_equal(ridx, eridx)
 
@@ -1038,7 +1038,7 @@ class TestUInt64Index(NumericInt, tm.TestCase):
         eridx = np.array([-1, 3, -1, -1, 5], dtype=np.intp)
 
         tm.assertIsInstance(res, UInt64Index)
-        self.assert_index_equal(res, eres)
+        tm.assert_index_equal(res, eres)
         self.assertIsNone(lidx)
         tm.assert_numpy_array_equal(ridx, eridx)
 
@@ -1053,7 +1053,7 @@ class TestUInt64Index(NumericInt, tm.TestCase):
         eridx = np.array([0, 1, 2, 3, -1, -1], dtype=np.intp)
         elidx = np.array([0, 0, 1, 2, 3, 4], dtype=np.intp)
 
-        self.assert_index_equal(res, eres)
+        tm.assert_index_equal(res, eres)
         tm.assert_numpy_array_equal(lidx, elidx)
         tm.assert_numpy_array_equal(ridx, eridx)
 
@@ -1071,7 +1071,7 @@ class TestUInt64Index(NumericInt, tm.TestCase):
 
         tm.assert_numpy_array_equal(lidx, elidx)
         tm.assertIsInstance(other, UInt64Index)
-        self.assert_index_equal(res, eres)
+        tm.assert_index_equal(res, eres)
         self.assertIsNone(ridx)
 
         # monotonic
@@ -1082,7 +1082,7 @@ class TestUInt64Index(NumericInt, tm.TestCase):
 
         tm.assertIsInstance(other, UInt64Index)
         tm.assert_numpy_array_equal(lidx, elidx)
-        self.assert_index_equal(res, eres)
+        tm.assert_index_equal(res, eres)
         self.assertIsNone(ridx)
 
         # non-unique
@@ -1096,7 +1096,7 @@ class TestUInt64Index(NumericInt, tm.TestCase):
         elidx = np.array([0, 1, 2, 3, -1, -1], dtype=np.intp)
         eridx = np.array([0, 0, 1, 2, 3, 4], dtype=np.intp)
 
-        self.assert_index_equal(res, eres)
+        tm.assert_index_equal(res, eres)
         tm.assert_numpy_array_equal(lidx, elidx)
         tm.assert_numpy_array_equal(ridx, eridx)
 
@@ -1108,26 +1108,26 @@ class TestUInt64Index(NumericInt, tm.TestCase):
         outer2 = other.join(self.index, how='outer')
         expected = Index(2**63 + np.array(
             [0, 1, 5, 7, 10, 15, 20, 25], dtype='uint64'))
-        self.assert_index_equal(outer, outer2)
-        self.assert_index_equal(outer, expected)
+        tm.assert_index_equal(outer, outer2)
+        tm.assert_index_equal(outer, expected)
 
         inner = self.index.join(other, how='inner')
         inner2 = other.join(self.index, how='inner')
         expected = Index(2**63 + np.array([10, 20], dtype='uint64'))
-        self.assert_index_equal(inner, inner2)
-        self.assert_index_equal(inner, expected)
+        tm.assert_index_equal(inner, inner2)
+        tm.assert_index_equal(inner, expected)
 
         left = self.index.join(other, how='left')
-        self.assert_index_equal(left, self.index.astype(object))
+        tm.assert_index_equal(left, self.index.astype(object))
 
         left2 = other.join(self.index, how='left')
-        self.assert_index_equal(left2, other)
+        tm.assert_index_equal(left2, other)
 
         right = self.index.join(other, how='right')
-        self.assert_index_equal(right, other)
+        tm.assert_index_equal(right, other)
 
         right2 = other.join(self.index, how='right')
-        self.assert_index_equal(right2, self.index.astype(object))
+        tm.assert_index_equal(right2, self.index.astype(object))
 
     def test_join_outer(self):
         other = UInt64Index(2**63 + np.array(
@@ -1140,7 +1140,7 @@ class TestUInt64Index(NumericInt, tm.TestCase):
         res, lidx, ridx = self.index.join(other, how='outer',
                                           return_indexers=True)
         noidx_res = self.index.join(other, how='outer')
-        self.assert_index_equal(res, noidx_res)
+        tm.assert_index_equal(res, noidx_res)
 
         eres = UInt64Index(2**63 + np.array(
             [0, 1, 2, 7, 10, 12, 15, 20, 25], dtype='uint64'))
@@ -1148,7 +1148,7 @@ class TestUInt64Index(NumericInt, tm.TestCase):
         eridx = np.array([-1, 3, 4, 0, 5, 1, -1, -1, 2], dtype=np.intp)
 
         tm.assertIsInstance(res, UInt64Index)
-        self.assert_index_equal(res, eres)
+        tm.assert_index_equal(res, eres)
         tm.assert_numpy_array_equal(lidx, elidx)
         tm.assert_numpy_array_equal(ridx, eridx)
 
@@ -1156,12 +1156,12 @@ class TestUInt64Index(NumericInt, tm.TestCase):
         res, lidx, ridx = self.index.join(other_mono, how='outer',
                                           return_indexers=True)
         noidx_res = self.index.join(other_mono, how='outer')
-        self.assert_index_equal(res, noidx_res)
+        tm.assert_index_equal(res, noidx_res)
 
         elidx = np.array([0, -1, -1, -1, 1, -1, 2, 3, 4], dtype=np.intp)
         eridx = np.array([-1, 0, 1, 2, 3, 4, -1, -1, 5], dtype=np.intp)
 
         tm.assertIsInstance(res, UInt64Index)
-        self.assert_index_equal(res, eres)
+        tm.assert_index_equal(res, eres)
         tm.assert_numpy_array_equal(lidx, elidx)
         tm.assert_numpy_array_equal(ridx, eridx)

--- a/pandas/tests/indexes/test_numeric.py
+++ b/pandas/tests/indexes/test_numeric.py
@@ -207,7 +207,7 @@ class TestFloat64Index(Numeric, tm.TestCase):
         index = Float64Index([1, 2, 3, 4, 5])
         self.assertIsInstance(index, Float64Index)
         expected = np.array([1, 2, 3, 4, 5], dtype='float64')
-        self.assert_numpy_array_equal(index.values, expected)
+        tm.assert_numpy_array_equal(index.values, expected)
         index = Float64Index(np.array([1, 2, 3, 4, 5]))
         self.assertIsInstance(index, Float64Index)
         index = Float64Index([1., 2, 3, 4, 5])

--- a/pandas/tests/indexes/test_range.py
+++ b/pandas/tests/indexes/test_range.py
@@ -127,10 +127,10 @@ class TestRangeIndex(Numeric, tm.TestCase):
         self.assertTrue(result.identical(index))
 
         result = RangeIndex(index, copy=True)
-        self.assert_index_equal(result, index, exact=True)
+        tm.assert_index_equal(result, index, exact=True)
 
         result = RangeIndex(index)
-        self.assert_index_equal(result, index, exact=True)
+        tm.assert_index_equal(result, index, exact=True)
 
         self.assertRaises(TypeError,
                           lambda: RangeIndex(index, dtype='float64'))
@@ -141,24 +141,24 @@ class TestRangeIndex(Numeric, tm.TestCase):
 
         result = RangeIndex.from_range(range(1, 5, 2))
         expected = RangeIndex(1, 5, 2)
-        self.assert_index_equal(result, expected, exact=True)
+        tm.assert_index_equal(result, expected, exact=True)
 
         result = RangeIndex.from_range(range(5, 6))
         expected = RangeIndex(5, 6, 1)
-        self.assert_index_equal(result, expected, exact=True)
+        tm.assert_index_equal(result, expected, exact=True)
 
         # an invalid range
         result = RangeIndex.from_range(range(5, 1))
         expected = RangeIndex(0, 0, 1)
-        self.assert_index_equal(result, expected, exact=True)
+        tm.assert_index_equal(result, expected, exact=True)
 
         result = RangeIndex.from_range(range(5))
         expected = RangeIndex(0, 5, 1)
-        self.assert_index_equal(result, expected, exact=True)
+        tm.assert_index_equal(result, expected, exact=True)
 
         result = Index(range(1, 5, 2))
         expected = RangeIndex(1, 5, 2)
-        self.assert_index_equal(result, expected, exact=True)
+        tm.assert_index_equal(result, expected, exact=True)
 
         self.assertRaises(TypeError,
                           lambda: Index(range(1, 5, 2), dtype='float64'))
@@ -190,15 +190,15 @@ class TestRangeIndex(Numeric, tm.TestCase):
 
         result = idx * 2
         expected = RangeIndex(0, 20, 4)
-        self.assert_index_equal(result, expected, exact=True)
+        tm.assert_index_equal(result, expected, exact=True)
 
         result = idx + 2
         expected = RangeIndex(2, 12, 2)
-        self.assert_index_equal(result, expected, exact=True)
+        tm.assert_index_equal(result, expected, exact=True)
 
         result = idx - 2
         expected = RangeIndex(-2, 8, 2)
-        self.assert_index_equal(result, expected, exact=True)
+        tm.assert_index_equal(result, expected, exact=True)
 
         # truediv under PY3
         result = idx / 2
@@ -207,11 +207,11 @@ class TestRangeIndex(Numeric, tm.TestCase):
             expected = RangeIndex(0, 5, 1).astype('float64')
         else:
             expected = RangeIndex(0, 5, 1)
-        self.assert_index_equal(result, expected, exact=True)
+        tm.assert_index_equal(result, expected, exact=True)
 
         result = idx / 4
         expected = RangeIndex(0, 10, 2) / 4
-        self.assert_index_equal(result, expected, exact=True)
+        tm.assert_index_equal(result, expected, exact=True)
 
         result = idx // 1
         expected = idx
@@ -246,7 +246,7 @@ class TestRangeIndex(Numeric, tm.TestCase):
         arr = np.array([1, 2, 3, 4], dtype=object)
         index = RangeIndex(1, 5)
         self.assertEqual(index.values.dtype, np.int64)
-        self.assert_index_equal(index, Index(arr))
+        tm.assert_index_equal(index, Index(arr))
 
         # non-int raise Exception
         self.assertRaises(TypeError, RangeIndex, '1', '10', '1')
@@ -275,7 +275,7 @@ class TestRangeIndex(Numeric, tm.TestCase):
         self.assertTrue(result, expected)
 
         result = eval(result)
-        self.assert_index_equal(result, i, exact=True)
+        tm.assert_index_equal(result, i, exact=True)
 
         i = RangeIndex(5, 0, -1)
         result = repr(i)
@@ -283,7 +283,7 @@ class TestRangeIndex(Numeric, tm.TestCase):
         self.assertEqual(result, expected)
 
         result = eval(result)
-        self.assert_index_equal(result, i, exact=True)
+        tm.assert_index_equal(result, i, exact=True)
 
     def test_insert(self):
 
@@ -291,19 +291,19 @@ class TestRangeIndex(Numeric, tm.TestCase):
         result = idx[1:4]
 
         # test 0th element
-        self.assert_index_equal(idx[0:4], result.insert(0, idx[0]))
+        tm.assert_index_equal(idx[0:4], result.insert(0, idx[0]))
 
     def test_delete(self):
 
         idx = RangeIndex(5, name='Foo')
         expected = idx[1:].astype(int)
         result = idx.delete(0)
-        self.assert_index_equal(result, expected)
+        tm.assert_index_equal(result, expected)
         self.assertEqual(result.name, expected.name)
 
         expected = idx[:-1].astype(int)
         result = idx.delete(-1)
-        self.assert_index_equal(result, expected)
+        tm.assert_index_equal(result, expected)
         self.assertEqual(result.name, expected.name)
 
         with tm.assertRaises((IndexError, ValueError)):
@@ -412,7 +412,7 @@ class TestRangeIndex(Numeric, tm.TestCase):
         res, lidx, ridx = self.index.join(other, how='outer',
                                           return_indexers=True)
         noidx_res = self.index.join(other, how='outer')
-        self.assert_index_equal(res, noidx_res)
+        tm.assert_index_equal(res, noidx_res)
 
         eres = Int64Index([0, 2, 4, 6, 8, 10, 12, 14, 15, 16, 17, 18, 19, 20,
                            21, 22, 23, 24, 25])
@@ -423,7 +423,7 @@ class TestRangeIndex(Numeric, tm.TestCase):
 
         self.assertIsInstance(res, Int64Index)
         self.assertFalse(isinstance(res, RangeIndex))
-        self.assert_index_equal(res, eres)
+        tm.assert_index_equal(res, eres)
         self.assert_numpy_array_equal(lidx, elidx)
         self.assert_numpy_array_equal(ridx, eridx)
 
@@ -433,11 +433,11 @@ class TestRangeIndex(Numeric, tm.TestCase):
         res, lidx, ridx = self.index.join(other, how='outer',
                                           return_indexers=True)
         noidx_res = self.index.join(other, how='outer')
-        self.assert_index_equal(res, noidx_res)
+        tm.assert_index_equal(res, noidx_res)
 
         self.assertIsInstance(res, Int64Index)
         self.assertFalse(isinstance(res, RangeIndex))
-        self.assert_index_equal(res, eres)
+        tm.assert_index_equal(res, eres)
         self.assert_numpy_array_equal(lidx, elidx)
         self.assert_numpy_array_equal(ridx, eridx)
 
@@ -459,7 +459,7 @@ class TestRangeIndex(Numeric, tm.TestCase):
         eridx = np.array([9, 7], dtype=np.intp)
 
         self.assertIsInstance(res, Int64Index)
-        self.assert_index_equal(res, eres)
+        tm.assert_index_equal(res, eres)
         self.assert_numpy_array_equal(lidx, elidx)
         self.assert_numpy_array_equal(ridx, eridx)
 
@@ -470,7 +470,7 @@ class TestRangeIndex(Numeric, tm.TestCase):
                                           return_indexers=True)
 
         self.assertIsInstance(res, RangeIndex)
-        self.assert_index_equal(res, eres)
+        tm.assert_index_equal(res, eres)
         self.assert_numpy_array_equal(lidx, elidx)
         self.assert_numpy_array_equal(ridx, eridx)
 
@@ -484,7 +484,7 @@ class TestRangeIndex(Numeric, tm.TestCase):
         eridx = np.array([-1, -1, -1, -1, -1, -1, -1, -1, 9, 7], dtype=np.intp)
 
         self.assertIsInstance(res, RangeIndex)
-        self.assert_index_equal(res, eres)
+        tm.assert_index_equal(res, eres)
         self.assertIsNone(lidx)
         self.assert_numpy_array_equal(ridx, eridx)
 
@@ -495,7 +495,7 @@ class TestRangeIndex(Numeric, tm.TestCase):
                                           return_indexers=True)
 
         self.assertIsInstance(res, RangeIndex)
-        self.assert_index_equal(res, eres)
+        tm.assert_index_equal(res, eres)
         self.assertIsNone(lidx)
         self.assert_numpy_array_equal(ridx, eridx)
 
@@ -510,7 +510,7 @@ class TestRangeIndex(Numeric, tm.TestCase):
                          dtype=np.intp)
 
         self.assertIsInstance(other, Int64Index)
-        self.assert_index_equal(res, eres)
+        tm.assert_index_equal(res, eres)
         self.assert_numpy_array_equal(lidx, elidx)
         self.assertIsNone(ridx)
 
@@ -522,7 +522,7 @@ class TestRangeIndex(Numeric, tm.TestCase):
         eres = other
 
         self.assertIsInstance(other, RangeIndex)
-        self.assert_index_equal(res, eres)
+        tm.assert_index_equal(res, eres)
         self.assert_numpy_array_equal(lidx, elidx)
         self.assertIsNone(ridx)
 
@@ -532,26 +532,26 @@ class TestRangeIndex(Numeric, tm.TestCase):
         outer = self.index.join(other, how='outer')
         outer2 = other.join(self.index, how='outer')
         expected = Index([0, 2, 3, 4, 6, 7, 8, 10, 12, 14, 16, 18])
-        self.assert_index_equal(outer, outer2)
-        self.assert_index_equal(outer, expected)
+        tm.assert_index_equal(outer, outer2)
+        tm.assert_index_equal(outer, expected)
 
         inner = self.index.join(other, how='inner')
         inner2 = other.join(self.index, how='inner')
         expected = Index([6, 8, 10])
-        self.assert_index_equal(inner, inner2)
-        self.assert_index_equal(inner, expected)
+        tm.assert_index_equal(inner, inner2)
+        tm.assert_index_equal(inner, expected)
 
         left = self.index.join(other, how='left')
-        self.assert_index_equal(left, self.index.astype(object))
+        tm.assert_index_equal(left, self.index.astype(object))
 
         left2 = other.join(self.index, how='left')
-        self.assert_index_equal(left2, other)
+        tm.assert_index_equal(left2, other)
 
         right = self.index.join(other, how='right')
-        self.assert_index_equal(right, other)
+        tm.assert_index_equal(right, other)
 
         right2 = other.join(self.index, how='right')
-        self.assert_index_equal(right2, self.index.astype(object))
+        tm.assert_index_equal(right2, self.index.astype(object))
 
     def test_join_non_unique(self):
         other = Index([4, 4, 3, 3])
@@ -563,7 +563,7 @@ class TestRangeIndex(Numeric, tm.TestCase):
         eridx = np.array([-1, -1, 0, 1, -1, -1, -1, -1, -1, -1, -1],
                          dtype=np.intp)
 
-        self.assert_index_equal(res, eres)
+        tm.assert_index_equal(res, eres)
         self.assert_numpy_array_equal(lidx, elidx)
         self.assert_numpy_array_equal(ridx, eridx)
 
@@ -579,26 +579,26 @@ class TestRangeIndex(Numeric, tm.TestCase):
         result = self.index.intersection(other)
         expected = Index(np.sort(np.intersect1d(self.index.values,
                                                 other.values)))
-        self.assert_index_equal(result, expected)
+        tm.assert_index_equal(result, expected)
 
         result = other.intersection(self.index)
         expected = Index(np.sort(np.asarray(np.intersect1d(self.index.values,
                                                            other.values))))
-        self.assert_index_equal(result, expected)
+        tm.assert_index_equal(result, expected)
 
         # intersect with increasing RangeIndex
         other = RangeIndex(1, 6)
         result = self.index.intersection(other)
         expected = Index(np.sort(np.intersect1d(self.index.values,
                                                 other.values)))
-        self.assert_index_equal(result, expected)
+        tm.assert_index_equal(result, expected)
 
         # intersect with decreasing RangeIndex
         other = RangeIndex(5, 0, -1)
         result = self.index.intersection(other)
         expected = Index(np.sort(np.intersect1d(self.index.values,
                                                 other.values)))
-        self.assert_index_equal(result, expected)
+        tm.assert_index_equal(result, expected)
 
         index = RangeIndex(5)
 
@@ -606,28 +606,28 @@ class TestRangeIndex(Numeric, tm.TestCase):
         other = RangeIndex(5, 10, 1)
         result = index.intersection(other)
         expected = RangeIndex(0, 0, 1)
-        self.assert_index_equal(result, expected)
+        tm.assert_index_equal(result, expected)
 
         other = RangeIndex(-1, -5, -1)
         result = index.intersection(other)
         expected = RangeIndex(0, 0, 1)
-        self.assert_index_equal(result, expected)
+        tm.assert_index_equal(result, expected)
 
         # intersection of empty indices
         other = RangeIndex(0, 0, 1)
         result = index.intersection(other)
         expected = RangeIndex(0, 0, 1)
-        self.assert_index_equal(result, expected)
+        tm.assert_index_equal(result, expected)
 
         result = other.intersection(index)
-        self.assert_index_equal(result, expected)
+        tm.assert_index_equal(result, expected)
 
         # intersection of non-overlapping values based on start value and gcd
         index = RangeIndex(1, 10, 2)
         other = RangeIndex(0, 10, 4)
         result = index.intersection(other)
         expected = RangeIndex(0, 0, 1)
-        self.assert_index_equal(result, expected)
+        tm.assert_index_equal(result, expected)
 
     def test_intersect_str_dates(self):
         dt_dates = [datetime(2012, 2, 9), datetime(2012, 2, 22)]
@@ -645,11 +645,11 @@ class TestRangeIndex(Numeric, tm.TestCase):
         other = Index([now + timedelta(i) for i in range(4)], dtype=object)
         result = self.index.union(other)
         expected = Index(np.concatenate((self.index, other)))
-        self.assert_index_equal(result, expected)
+        tm.assert_index_equal(result, expected)
 
         result = other.union(self.index)
         expected = Index(np.concatenate((other, self.index)))
-        self.assert_index_equal(result, expected)
+        tm.assert_index_equal(result, expected)
 
     def test_union(self):
         RI = RangeIndex
@@ -856,43 +856,43 @@ class TestRangeIndex(Numeric, tm.TestCase):
         # slice value completion
         index = self.index[:]
         expected = self.index
-        self.assert_index_equal(index, expected)
+        tm.assert_index_equal(index, expected)
 
         # positive slice values
         index = self.index[7:10:2]
         expected = Index(np.array([14, 18]), name='foo')
-        self.assert_index_equal(index, expected)
+        tm.assert_index_equal(index, expected)
 
         # negative slice values
         index = self.index[-1:-5:-2]
         expected = Index(np.array([18, 14]), name='foo')
-        self.assert_index_equal(index, expected)
+        tm.assert_index_equal(index, expected)
 
         # stop overshoot
         index = self.index[2:100:4]
         expected = Index(np.array([4, 12]), name='foo')
-        self.assert_index_equal(index, expected)
+        tm.assert_index_equal(index, expected)
 
         # reverse
         index = self.index[::-1]
         expected = Index(self.index.values[::-1], name='foo')
-        self.assert_index_equal(index, expected)
+        tm.assert_index_equal(index, expected)
 
         index = self.index[-8::-1]
         expected = Index(np.array([4, 2, 0]), name='foo')
-        self.assert_index_equal(index, expected)
+        tm.assert_index_equal(index, expected)
 
         index = self.index[-40::-1]
         expected = Index(np.array([], dtype=np.int64), name='foo')
-        self.assert_index_equal(index, expected)
+        tm.assert_index_equal(index, expected)
 
         index = self.index[40::-1]
         expected = Index(self.index.values[40::-1], name='foo')
-        self.assert_index_equal(index, expected)
+        tm.assert_index_equal(index, expected)
 
         index = self.index[10::-1]
         expected = Index(self.index.values[::-1], name='foo')
-        self.assert_index_equal(index, expected)
+        tm.assert_index_equal(index, expected)
 
     def test_len_specialised(self):
 

--- a/pandas/tests/indexes/test_range.py
+++ b/pandas/tests/indexes/test_range.py
@@ -391,19 +391,19 @@ class TestRangeIndex(Numeric, tm.TestCase):
         target = RangeIndex(10)
         indexer = self.index.get_indexer(target)
         expected = np.array([0, -1, 1, -1, 2, -1, 3, -1, 4, -1], dtype=np.intp)
-        self.assert_numpy_array_equal(indexer, expected)
+        tm.assert_numpy_array_equal(indexer, expected)
 
     def test_get_indexer_pad(self):
         target = RangeIndex(10)
         indexer = self.index.get_indexer(target, method='pad')
         expected = np.array([0, 0, 1, 1, 2, 2, 3, 3, 4, 4], dtype=np.intp)
-        self.assert_numpy_array_equal(indexer, expected)
+        tm.assert_numpy_array_equal(indexer, expected)
 
     def test_get_indexer_backfill(self):
         target = RangeIndex(10)
         indexer = self.index.get_indexer(target, method='backfill')
         expected = np.array([0, 1, 1, 2, 2, 3, 3, 4, 4, 5], dtype=np.intp)
-        self.assert_numpy_array_equal(indexer, expected)
+        tm.assert_numpy_array_equal(indexer, expected)
 
     def test_join_outer(self):
         # join with Int64Index
@@ -424,8 +424,8 @@ class TestRangeIndex(Numeric, tm.TestCase):
         self.assertIsInstance(res, Int64Index)
         self.assertFalse(isinstance(res, RangeIndex))
         tm.assert_index_equal(res, eres)
-        self.assert_numpy_array_equal(lidx, elidx)
-        self.assert_numpy_array_equal(ridx, eridx)
+        tm.assert_numpy_array_equal(lidx, elidx)
+        tm.assert_numpy_array_equal(ridx, eridx)
 
         # join with RangeIndex
         other = RangeIndex(25, 14, -1)
@@ -438,8 +438,8 @@ class TestRangeIndex(Numeric, tm.TestCase):
         self.assertIsInstance(res, Int64Index)
         self.assertFalse(isinstance(res, RangeIndex))
         tm.assert_index_equal(res, eres)
-        self.assert_numpy_array_equal(lidx, elidx)
-        self.assert_numpy_array_equal(ridx, eridx)
+        tm.assert_numpy_array_equal(lidx, elidx)
+        tm.assert_numpy_array_equal(ridx, eridx)
 
     def test_join_inner(self):
         # Join with non-RangeIndex
@@ -460,8 +460,8 @@ class TestRangeIndex(Numeric, tm.TestCase):
 
         self.assertIsInstance(res, Int64Index)
         tm.assert_index_equal(res, eres)
-        self.assert_numpy_array_equal(lidx, elidx)
-        self.assert_numpy_array_equal(ridx, eridx)
+        tm.assert_numpy_array_equal(lidx, elidx)
+        tm.assert_numpy_array_equal(ridx, eridx)
 
         # Join two RangeIndex
         other = RangeIndex(25, 14, -1)
@@ -471,8 +471,8 @@ class TestRangeIndex(Numeric, tm.TestCase):
 
         self.assertIsInstance(res, RangeIndex)
         tm.assert_index_equal(res, eres)
-        self.assert_numpy_array_equal(lidx, elidx)
-        self.assert_numpy_array_equal(ridx, eridx)
+        tm.assert_numpy_array_equal(lidx, elidx)
+        tm.assert_numpy_array_equal(ridx, eridx)
 
     def test_join_left(self):
         # Join with Int64Index
@@ -486,7 +486,7 @@ class TestRangeIndex(Numeric, tm.TestCase):
         self.assertIsInstance(res, RangeIndex)
         tm.assert_index_equal(res, eres)
         self.assertIsNone(lidx)
-        self.assert_numpy_array_equal(ridx, eridx)
+        tm.assert_numpy_array_equal(ridx, eridx)
 
         # Join withRangeIndex
         other = Int64Index(np.arange(25, 14, -1))
@@ -497,7 +497,7 @@ class TestRangeIndex(Numeric, tm.TestCase):
         self.assertIsInstance(res, RangeIndex)
         tm.assert_index_equal(res, eres)
         self.assertIsNone(lidx)
-        self.assert_numpy_array_equal(ridx, eridx)
+        tm.assert_numpy_array_equal(ridx, eridx)
 
     def test_join_right(self):
         # Join with Int64Index
@@ -511,7 +511,7 @@ class TestRangeIndex(Numeric, tm.TestCase):
 
         self.assertIsInstance(other, Int64Index)
         tm.assert_index_equal(res, eres)
-        self.assert_numpy_array_equal(lidx, elidx)
+        tm.assert_numpy_array_equal(lidx, elidx)
         self.assertIsNone(ridx)
 
         # Join withRangeIndex
@@ -523,7 +523,7 @@ class TestRangeIndex(Numeric, tm.TestCase):
 
         self.assertIsInstance(other, RangeIndex)
         tm.assert_index_equal(res, eres)
-        self.assert_numpy_array_equal(lidx, elidx)
+        tm.assert_numpy_array_equal(lidx, elidx)
         self.assertIsNone(ridx)
 
     def test_join_non_int_index(self):
@@ -564,8 +564,8 @@ class TestRangeIndex(Numeric, tm.TestCase):
                          dtype=np.intp)
 
         tm.assert_index_equal(res, eres)
-        self.assert_numpy_array_equal(lidx, elidx)
-        self.assert_numpy_array_equal(ridx, eridx)
+        tm.assert_numpy_array_equal(lidx, elidx)
+        tm.assert_numpy_array_equal(ridx, eridx)
 
     def test_join_self(self):
         kinds = 'outer', 'inner', 'left', 'right'

--- a/pandas/tests/indexes/timedeltas/test_astype.py
+++ b/pandas/tests/indexes/timedeltas/test_astype.py
@@ -37,7 +37,7 @@ class TestTimedeltaIndex(DatetimeLike, tm.TestCase):
 
         result = rng.astype('i8')
         tm.assert_index_equal(result, Index(rng.asi8))
-        self.assert_numpy_array_equal(rng.asi8, result.values)
+        tm.assert_numpy_array_equal(rng.asi8, result.values)
 
     def test_astype_timedelta64(self):
         # GH 13149, GH 13209

--- a/pandas/tests/indexes/timedeltas/test_astype.py
+++ b/pandas/tests/indexes/timedeltas/test_astype.py
@@ -36,7 +36,7 @@ class TestTimedeltaIndex(DatetimeLike, tm.TestCase):
         rng = timedelta_range('1 days', periods=10)
 
         result = rng.astype('i8')
-        self.assert_index_equal(result, Index(rng.asi8))
+        tm.assert_index_equal(result, Index(rng.asi8))
         self.assert_numpy_array_equal(rng.asi8, result.values)
 
     def test_astype_timedelta64(self):
@@ -77,13 +77,13 @@ class TestTimedeltaIndex(DatetimeLike, tm.TestCase):
                                    '3 days 01:00:00',
                                    '4 days 01:00:00', '5 days 01:00:00'],
                                   freq='D')
-        self.assert_index_equal(result, expected)
+        tm.assert_index_equal(result, expected)
 
         result = drange.shift(3, freq='2D 1s')
         expected = TimedeltaIndex(['6 days 01:00:03', '7 days 01:00:03',
                                    '8 days 01:00:03', '9 days 01:00:03',
                                    '10 days 01:00:03'], freq='D')
-        self.assert_index_equal(result, expected)
+        tm.assert_index_equal(result, expected)
 
     def test_numeric_compat(self):
 

--- a/pandas/tests/indexes/timedeltas/test_construction.py
+++ b/pandas/tests/indexes/timedeltas/test_construction.py
@@ -46,7 +46,7 @@ class TestTimedeltaIndex(tm.TestCase):
     def test_constructor_coverage(self):
         rng = timedelta_range('1 days', periods=10.5)
         exp = timedelta_range('1 days', periods=10)
-        self.assert_index_equal(rng, exp)
+        tm.assert_index_equal(rng, exp)
 
         self.assertRaises(ValueError, TimedeltaIndex, start='1 days',
                           periods='foo', freq='D')
@@ -60,16 +60,16 @@ class TestTimedeltaIndex(tm.TestCase):
         gen = (timedelta(i) for i in range(10))
         result = TimedeltaIndex(gen)
         expected = TimedeltaIndex([timedelta(i) for i in range(10)])
-        self.assert_index_equal(result, expected)
+        tm.assert_index_equal(result, expected)
 
         # NumPy string array
         strings = np.array(['1 days', '2 days', '3 days'])
         result = TimedeltaIndex(strings)
         expected = to_timedelta([1, 2, 3], unit='d')
-        self.assert_index_equal(result, expected)
+        tm.assert_index_equal(result, expected)
 
         from_ints = TimedeltaIndex(expected.asi8)
-        self.assert_index_equal(from_ints, expected)
+        tm.assert_index_equal(from_ints, expected)
 
         # non-conforming freq
         self.assertRaises(ValueError, TimedeltaIndex,

--- a/pandas/tests/indexes/timedeltas/test_indexing.py
+++ b/pandas/tests/indexes/timedeltas/test_indexing.py
@@ -73,7 +73,7 @@ class TestTimedeltaIndex(tm.TestCase):
                  1: expected_1}
         for n, expected in compat.iteritems(cases):
             result = idx.delete(n)
-            self.assert_index_equal(result, expected)
+            tm.assert_index_equal(result, expected)
             self.assertEqual(result.name, expected.name)
             self.assertEqual(result.freq, expected.freq)
 
@@ -100,11 +100,11 @@ class TestTimedeltaIndex(tm.TestCase):
                  (3, 4, 5): expected_3_5}
         for n, expected in compat.iteritems(cases):
             result = idx.delete(n)
-            self.assert_index_equal(result, expected)
+            tm.assert_index_equal(result, expected)
             self.assertEqual(result.name, expected.name)
             self.assertEqual(result.freq, expected.freq)
 
             result = idx.delete(slice(n[0], n[-1] + 1))
-            self.assert_index_equal(result, expected)
+            tm.assert_index_equal(result, expected)
             self.assertEqual(result.name, expected.name)
             self.assertEqual(result.freq, expected.freq)

--- a/pandas/tests/indexes/timedeltas/test_ops.py
+++ b/pandas/tests/indexes/timedeltas/test_ops.py
@@ -34,7 +34,7 @@ class TestTimedeltaIndexOps(Ops):
         self.assertTrue(isinstance(result, Index))
 
         self.assertEqual(result.dtype, object)
-        self.assert_index_equal(result, expected)
+        tm.assert_index_equal(result, expected)
         self.assertEqual(result.name, expected.name)
         self.assertEqual(idx.tolist(), expected_list)
 
@@ -46,7 +46,7 @@ class TestTimedeltaIndexOps(Ops):
         result = idx.asobject
         self.assertTrue(isinstance(result, Index))
         self.assertEqual(result.dtype, object)
-        self.assert_index_equal(result, expected)
+        tm.assert_index_equal(result, expected)
         self.assertEqual(result.name, expected.name)
         self.assertEqual(idx.tolist(), expected_list)
 
@@ -577,17 +577,17 @@ Freq: D"""
 
         for idx in [idx1, idx2]:
             ordered = idx.sort_values()
-            self.assert_index_equal(ordered, idx)
+            tm.assert_index_equal(ordered, idx)
             self.assertEqual(ordered.freq, idx.freq)
 
             ordered = idx.sort_values(ascending=False)
             expected = idx[::-1]
-            self.assert_index_equal(ordered, expected)
+            tm.assert_index_equal(ordered, expected)
             self.assertEqual(ordered.freq, expected.freq)
             self.assertEqual(ordered.freq.n, -1)
 
             ordered, indexer = idx.sort_values(return_indexer=True)
-            self.assert_index_equal(ordered, idx)
+            tm.assert_index_equal(ordered, idx)
             self.assert_numpy_array_equal(indexer,
                                           np.array([0, 1, 2]),
                                           check_dtype=False)
@@ -595,7 +595,7 @@ Freq: D"""
 
             ordered, indexer = idx.sort_values(return_indexer=True,
                                                ascending=False)
-            self.assert_index_equal(ordered, idx[::-1])
+            tm.assert_index_equal(ordered, idx[::-1])
             self.assertEqual(ordered.freq, expected.freq)
             self.assertEqual(ordered.freq.n, -1)
 
@@ -618,15 +618,15 @@ Freq: D"""
 
         for idx, expected in [(idx1, exp1), (idx1, exp1), (idx1, exp1)]:
             ordered = idx.sort_values()
-            self.assert_index_equal(ordered, expected)
+            tm.assert_index_equal(ordered, expected)
             self.assertIsNone(ordered.freq)
 
             ordered = idx.sort_values(ascending=False)
-            self.assert_index_equal(ordered, expected[::-1])
+            tm.assert_index_equal(ordered, expected[::-1])
             self.assertIsNone(ordered.freq)
 
             ordered, indexer = idx.sort_values(return_indexer=True)
-            self.assert_index_equal(ordered, expected)
+            tm.assert_index_equal(ordered, expected)
 
             exp = np.array([0, 4, 3, 1, 2])
             self.assert_numpy_array_equal(indexer, exp, check_dtype=False)
@@ -634,7 +634,7 @@ Freq: D"""
 
             ordered, indexer = idx.sort_values(return_indexer=True,
                                                ascending=False)
-            self.assert_index_equal(ordered, expected[::-1])
+            tm.assert_index_equal(ordered, expected[::-1])
 
             exp = np.array([2, 1, 3, 4, 0])
             self.assert_numpy_array_equal(indexer, exp, check_dtype=False)
@@ -650,39 +650,39 @@ Freq: D"""
             result = idx[0:5]
             expected = pd.timedelta_range('1 day', '5 day', freq='D',
                                           name='idx')
-            self.assert_index_equal(result, expected)
+            tm.assert_index_equal(result, expected)
             self.assertEqual(result.freq, expected.freq)
 
             result = idx[0:10:2]
             expected = pd.timedelta_range('1 day', '9 day', freq='2D',
                                           name='idx')
-            self.assert_index_equal(result, expected)
+            tm.assert_index_equal(result, expected)
             self.assertEqual(result.freq, expected.freq)
 
             result = idx[-20:-5:3]
             expected = pd.timedelta_range('12 day', '24 day', freq='3D',
                                           name='idx')
-            self.assert_index_equal(result, expected)
+            tm.assert_index_equal(result, expected)
             self.assertEqual(result.freq, expected.freq)
 
             result = idx[4::-1]
             expected = TimedeltaIndex(['5 day', '4 day', '3 day',
                                        '2 day', '1 day'],
                                       freq='-1D', name='idx')
-            self.assert_index_equal(result, expected)
+            tm.assert_index_equal(result, expected)
             self.assertEqual(result.freq, expected.freq)
 
     def test_drop_duplicates_metadata(self):
         # GH 10115
         idx = pd.timedelta_range('1 day', '31 day', freq='D', name='idx')
         result = idx.drop_duplicates()
-        self.assert_index_equal(idx, result)
+        tm.assert_index_equal(idx, result)
         self.assertEqual(idx.freq, result.freq)
 
         idx_dup = idx.append(idx)
         self.assertIsNone(idx_dup.freq)  # freq is reset
         result = idx_dup.drop_duplicates()
-        self.assert_index_equal(idx, result)
+        tm.assert_index_equal(idx, result)
         self.assertIsNone(result.freq)
 
     def test_drop_duplicates(self):
@@ -720,29 +720,29 @@ Freq: D"""
             result = idx.take([0, 1, 2])
             expected = pd.timedelta_range('1 day', '3 day', freq='D',
                                           name='idx')
-            self.assert_index_equal(result, expected)
+            tm.assert_index_equal(result, expected)
             self.assertEqual(result.freq, expected.freq)
 
             result = idx.take([0, 2, 4])
             expected = pd.timedelta_range('1 day', '5 day', freq='2D',
                                           name='idx')
-            self.assert_index_equal(result, expected)
+            tm.assert_index_equal(result, expected)
             self.assertEqual(result.freq, expected.freq)
 
             result = idx.take([7, 4, 1])
             expected = pd.timedelta_range('8 day', '2 day', freq='-3D',
                                           name='idx')
-            self.assert_index_equal(result, expected)
+            tm.assert_index_equal(result, expected)
             self.assertEqual(result.freq, expected.freq)
 
             result = idx.take([3, 2, 5])
             expected = TimedeltaIndex(['4 day', '3 day', '6 day'], name='idx')
-            self.assert_index_equal(result, expected)
+            tm.assert_index_equal(result, expected)
             self.assertIsNone(result.freq)
 
             result = idx.take([-3, 2, 5])
             expected = TimedeltaIndex(['29 day', '3 day', '6 day'], name='idx')
-            self.assert_index_equal(result, expected)
+            tm.assert_index_equal(result, expected)
             self.assertIsNone(result.freq)
 
     def test_take_invalid_kwargs(self):

--- a/pandas/tests/indexes/timedeltas/test_ops.py
+++ b/pandas/tests/indexes/timedeltas/test_ops.py
@@ -588,9 +588,8 @@ Freq: D"""
 
             ordered, indexer = idx.sort_values(return_indexer=True)
             tm.assert_index_equal(ordered, idx)
-            self.assert_numpy_array_equal(indexer,
-                                          np.array([0, 1, 2]),
-                                          check_dtype=False)
+            tm.assert_numpy_array_equal(indexer, np.array([0, 1, 2]),
+                                        check_dtype=False)
             self.assertEqual(ordered.freq, idx.freq)
 
             ordered, indexer = idx.sort_values(return_indexer=True,
@@ -629,7 +628,7 @@ Freq: D"""
             tm.assert_index_equal(ordered, expected)
 
             exp = np.array([0, 4, 3, 1, 2])
-            self.assert_numpy_array_equal(indexer, exp, check_dtype=False)
+            tm.assert_numpy_array_equal(indexer, exp, check_dtype=False)
             self.assertIsNone(ordered.freq)
 
             ordered, indexer = idx.sort_values(return_indexer=True,
@@ -637,7 +636,7 @@ Freq: D"""
             tm.assert_index_equal(ordered, expected[::-1])
 
             exp = np.array([2, 1, 3, 4, 0])
-            self.assert_numpy_array_equal(indexer, exp, check_dtype=False)
+            tm.assert_numpy_array_equal(indexer, exp, check_dtype=False)
             self.assertIsNone(ordered.freq)
 
     def test_getitem(self):
@@ -908,42 +907,42 @@ class TestTimedeltas(tm.TestCase):
         # timedelta, timedelta
         other = pd.to_timedelta(['1 day']).values
         expected = pd.to_timedelta(['2 days']).values
-        self.assert_numpy_array_equal(td + other, expected)
+        tm.assert_numpy_array_equal(td + other, expected)
         if LooseVersion(np.__version__) >= '1.8':
-            self.assert_numpy_array_equal(other + td, expected)
+            tm.assert_numpy_array_equal(other + td, expected)
         self.assertRaises(TypeError, lambda: td + np.array([1]))
         self.assertRaises(TypeError, lambda: np.array([1]) + td)
 
         expected = pd.to_timedelta(['0 days']).values
-        self.assert_numpy_array_equal(td - other, expected)
+        tm.assert_numpy_array_equal(td - other, expected)
         if LooseVersion(np.__version__) >= '1.8':
-            self.assert_numpy_array_equal(-other + td, expected)
+            tm.assert_numpy_array_equal(-other + td, expected)
         self.assertRaises(TypeError, lambda: td - np.array([1]))
         self.assertRaises(TypeError, lambda: np.array([1]) - td)
 
         expected = pd.to_timedelta(['2 days']).values
-        self.assert_numpy_array_equal(td * np.array([2]), expected)
-        self.assert_numpy_array_equal(np.array([2]) * td, expected)
+        tm.assert_numpy_array_equal(td * np.array([2]), expected)
+        tm.assert_numpy_array_equal(np.array([2]) * td, expected)
         self.assertRaises(TypeError, lambda: td * other)
         self.assertRaises(TypeError, lambda: other * td)
 
-        self.assert_numpy_array_equal(td / other,
-                                      np.array([1], dtype=np.float64))
+        tm.assert_numpy_array_equal(td / other,
+                                    np.array([1], dtype=np.float64))
         if LooseVersion(np.__version__) >= '1.8':
-            self.assert_numpy_array_equal(other / td,
-                                          np.array([1], dtype=np.float64))
+            tm.assert_numpy_array_equal(other / td,
+                                        np.array([1], dtype=np.float64))
 
         # timedelta, datetime
         other = pd.to_datetime(['2000-01-01']).values
         expected = pd.to_datetime(['2000-01-02']).values
-        self.assert_numpy_array_equal(td + other, expected)
+        tm.assert_numpy_array_equal(td + other, expected)
         if LooseVersion(np.__version__) >= '1.8':
-            self.assert_numpy_array_equal(other + td, expected)
+            tm.assert_numpy_array_equal(other + td, expected)
 
         expected = pd.to_datetime(['1999-12-31']).values
-        self.assert_numpy_array_equal(-td + other, expected)
+        tm.assert_numpy_array_equal(-td + other, expected)
         if LooseVersion(np.__version__) >= '1.8':
-            self.assert_numpy_array_equal(other - td, expected)
+            tm.assert_numpy_array_equal(other - td, expected)
 
     def test_ops_series(self):
         # regression test for GH8813
@@ -1203,7 +1202,7 @@ class TestTimedeltas(tm.TestCase):
         arr = np.array(periods)
         result = arr[0] > arr
         expected = np.array([False, False])
-        self.assert_numpy_array_equal(result, expected)
+        tm.assert_numpy_array_equal(result, expected)
 
 
 class TestSlicing(tm.TestCase):

--- a/pandas/tests/indexes/timedeltas/test_setops.py
+++ b/pandas/tests/indexes/timedeltas/test_setops.py
@@ -14,7 +14,7 @@ class TestTimedeltaIndex(tm.TestCase):
         i2 = timedelta_range('3day', periods=5)
         result = i1.union(i2)
         expected = timedelta_range('1day', periods=7)
-        self.assert_index_equal(result, expected)
+        tm.assert_index_equal(result, expected)
 
         i1 = Int64Index(np.arange(0, 20, 2))
         i2 = TimedeltaIndex(start='1 day', periods=10, freq='D')
@@ -26,10 +26,10 @@ class TestTimedeltaIndex(tm.TestCase):
         idx = TimedeltaIndex(['3d', '1d', '2d'])
         ordered = TimedeltaIndex(idx.sort_values(), freq='infer')
         result = ordered.union(idx)
-        self.assert_index_equal(result, ordered)
+        tm.assert_index_equal(result, ordered)
 
         result = ordered[:0].union(ordered)
-        self.assert_index_equal(result, ordered)
+        tm.assert_index_equal(result, ordered)
         self.assertEqual(result.freq, ordered.freq)
 
     def test_union_bug_1730(self):
@@ -39,7 +39,7 @@ class TestTimedeltaIndex(tm.TestCase):
 
         result = rng_a.union(rng_b)
         exp = TimedeltaIndex(sorted(set(list(rng_a)) | set(list(rng_b))))
-        self.assert_index_equal(result, exp)
+        tm.assert_index_equal(result, exp)
 
     def test_union_bug_1745(self):
 
@@ -50,7 +50,7 @@ class TestTimedeltaIndex(tm.TestCase):
 
         result = left.union(right)
         exp = TimedeltaIndex(sorted(set(list(left)) | set(list(right))))
-        self.assert_index_equal(result, exp)
+        tm.assert_index_equal(result, exp)
 
     def test_union_bug_4564(self):
 
@@ -59,7 +59,7 @@ class TestTimedeltaIndex(tm.TestCase):
 
         result = left.union(right)
         exp = TimedeltaIndex(sorted(set(list(left)) | set(list(right))))
-        self.assert_index_equal(result, exp)
+        tm.assert_index_equal(result, exp)
 
     def test_intersection_bug_1708(self):
         index_1 = timedelta_range('1 day', periods=4, freq='h')

--- a/pandas/tests/indexes/timedeltas/test_timedelta.py
+++ b/pandas/tests/indexes/timedeltas/test_timedelta.py
@@ -261,18 +261,18 @@ class TestTimedeltaIndex(DatetimeLike, tm.TestCase):
         exp_idx = TimedeltaIndex(['1 day', '2 day', '3 day'])
 
         arr, idx = idx1.factorize()
-        self.assert_numpy_array_equal(arr, exp_arr)
+        tm.assert_numpy_array_equal(arr, exp_arr)
         tm.assert_index_equal(idx, exp_idx)
 
         arr, idx = idx1.factorize(sort=True)
-        self.assert_numpy_array_equal(arr, exp_arr)
+        tm.assert_numpy_array_equal(arr, exp_arr)
         tm.assert_index_equal(idx, exp_idx)
 
         # freq must be preserved
         idx3 = timedelta_range('1 day', periods=4, freq='s')
         exp_arr = np.array([0, 1, 2, 3], dtype=np.intp)
         arr, idx = idx3.factorize()
-        self.assert_numpy_array_equal(arr, exp_arr)
+        tm.assert_numpy_array_equal(arr, exp_arr)
         tm.assert_index_equal(idx, idx3)
 
     def test_join_self(self):
@@ -306,22 +306,22 @@ class TestTimedeltaIndex(DatetimeLike, tm.TestCase):
         idx = TimedeltaIndex(['4d', '1d', '2d'])
 
         ordered = idx.sort_values()
-        self.assertTrue(ordered.is_monotonic)
+        assert ordered.is_monotonic
 
         ordered = idx.sort_values(ascending=False)
-        self.assertTrue(ordered[::-1].is_monotonic)
+        assert ordered[::-1].is_monotonic
 
         ordered, dexer = idx.sort_values(return_indexer=True)
-        self.assertTrue(ordered.is_monotonic)
-        self.assert_numpy_array_equal(dexer,
-                                      np.array([1, 2, 0]),
-                                      check_dtype=False)
+        assert ordered.is_monotonic
+
+        tm.assert_numpy_array_equal(dexer, np.array([1, 2, 0]),
+                                    check_dtype=False)
 
         ordered, dexer = idx.sort_values(return_indexer=True, ascending=False)
-        self.assertTrue(ordered[::-1].is_monotonic)
-        self.assert_numpy_array_equal(dexer,
-                                      np.array([0, 2, 1]),
-                                      check_dtype=False)
+        assert ordered[::-1].is_monotonic
+
+        tm.assert_numpy_array_equal(dexer, np.array([0, 2, 1]),
+                                    check_dtype=False)
 
     def test_get_duplicates(self):
         idx = TimedeltaIndex(['1 day', '2 day', '2 day', '3 day', '3day',
@@ -381,41 +381,41 @@ class TestTimedeltaIndex(DatetimeLike, tm.TestCase):
 
             result = idx1 < idx2
             expected = np.array([True, False, False, False, True, False])
-            self.assert_numpy_array_equal(result, expected)
+            tm.assert_numpy_array_equal(result, expected)
 
             result = idx2 > idx1
             expected = np.array([True, False, False, False, True, False])
-            self.assert_numpy_array_equal(result, expected)
+            tm.assert_numpy_array_equal(result, expected)
 
             result = idx1 <= idx2
             expected = np.array([True, False, False, False, True, True])
-            self.assert_numpy_array_equal(result, expected)
+            tm.assert_numpy_array_equal(result, expected)
 
             result = idx2 >= idx1
             expected = np.array([True, False, False, False, True, True])
-            self.assert_numpy_array_equal(result, expected)
+            tm.assert_numpy_array_equal(result, expected)
 
             result = idx1 == idx2
             expected = np.array([False, False, False, False, False, True])
-            self.assert_numpy_array_equal(result, expected)
+            tm.assert_numpy_array_equal(result, expected)
 
             result = idx1 != idx2
             expected = np.array([True, True, True, True, True, False])
-            self.assert_numpy_array_equal(result, expected)
+            tm.assert_numpy_array_equal(result, expected)
 
     def test_comparisons_coverage(self):
         rng = timedelta_range('1 days', periods=10)
 
         result = rng < rng[3]
         exp = np.array([True, True, True] + [False] * 7)
-        self.assert_numpy_array_equal(result, exp)
+        tm.assert_numpy_array_equal(result, exp)
 
         # raise TypeError for now
         self.assertRaises(TypeError, rng.__lt__, rng[3].value)
 
         result = rng == list(rng)
         exp = rng == rng
-        self.assert_numpy_array_equal(result, exp)
+        tm.assert_numpy_array_equal(result, exp)
 
     def test_total_seconds(self):
         # GH 10939
@@ -449,7 +449,7 @@ class TestTimedeltaIndex(DatetimeLike, tm.TestCase):
 
         expected = Index(rng.to_pytimedelta(), dtype=object)
 
-        self.assert_numpy_array_equal(idx.values, expected.values)
+        tm.assert_numpy_array_equal(idx.values, expected.values)
 
     def test_pickle(self):
 

--- a/pandas/tests/indexes/timedeltas/test_timedelta.py
+++ b/pandas/tests/indexes/timedeltas/test_timedelta.py
@@ -35,13 +35,13 @@ class TestTimedeltaIndex(DatetimeLike, tm.TestCase):
                                    '3 days 01:00:00',
                                    '4 days 01:00:00', '5 days 01:00:00'],
                                   freq='D')
-        self.assert_index_equal(result, expected)
+        tm.assert_index_equal(result, expected)
 
         result = drange.shift(3, freq='2D 1s')
         expected = TimedeltaIndex(['6 days 01:00:03', '7 days 01:00:03',
                                    '8 days 01:00:03', '9 days 01:00:03',
                                    '10 days 01:00:03'], freq='D')
-        self.assert_index_equal(result, expected)
+        tm.assert_index_equal(result, expected)
 
     def test_get_loc(self):
         idx = pd.to_timedelta(['0 days', '1 days', '2 days'])
@@ -168,14 +168,14 @@ class TestTimedeltaIndex(DatetimeLike, tm.TestCase):
         idx = pd.TimedeltaIndex(['1 day', pd.NaT, '3 day'])
 
         exp = pd.TimedeltaIndex(['1 day', '2 day', '3 day'])
-        self.assert_index_equal(idx.fillna(pd.Timedelta('2 day')), exp)
+        tm.assert_index_equal(idx.fillna(pd.Timedelta('2 day')), exp)
 
         exp = pd.TimedeltaIndex(['1 day', '3 hour', '3 day'])
         idx.fillna(pd.Timedelta('3 hour'))
 
         exp = pd.Index(
             [pd.Timedelta('1 day'), 'x', pd.Timedelta('3 day')], dtype=object)
-        self.assert_index_equal(idx.fillna('x'), exp)
+        tm.assert_index_equal(idx.fillna('x'), exp)
 
     def test_difference_freq(self):
         # GH14323: Difference of TimedeltaIndex should not preserve frequency
@@ -204,7 +204,7 @@ class TestTimedeltaIndex(DatetimeLike, tm.TestCase):
         taken2 = idx[[2, 4, 10]]
 
         for taken in [taken1, taken2]:
-            self.assert_index_equal(taken, expected)
+            tm.assert_index_equal(taken, expected)
             tm.assertIsInstance(taken, TimedeltaIndex)
             self.assertIsNone(taken.freq)
             self.assertEqual(taken.name, expected.name)
@@ -262,18 +262,18 @@ class TestTimedeltaIndex(DatetimeLike, tm.TestCase):
 
         arr, idx = idx1.factorize()
         self.assert_numpy_array_equal(arr, exp_arr)
-        self.assert_index_equal(idx, exp_idx)
+        tm.assert_index_equal(idx, exp_idx)
 
         arr, idx = idx1.factorize(sort=True)
         self.assert_numpy_array_equal(arr, exp_arr)
-        self.assert_index_equal(idx, exp_idx)
+        tm.assert_index_equal(idx, exp_idx)
 
         # freq must be preserved
         idx3 = timedelta_range('1 day', periods=4, freq='s')
         exp_arr = np.array([0, 1, 2, 3], dtype=np.intp)
         arr, idx = idx3.factorize()
         self.assert_numpy_array_equal(arr, exp_arr)
-        self.assert_index_equal(idx, idx3)
+        tm.assert_index_equal(idx, idx3)
 
     def test_join_self(self):
 
@@ -329,7 +329,7 @@ class TestTimedeltaIndex(DatetimeLike, tm.TestCase):
 
         result = idx.get_duplicates()
         ex = TimedeltaIndex(['2 day', '3day'])
-        self.assert_index_equal(result, ex)
+        tm.assert_index_equal(result, ex)
 
     def test_argmin_argmax(self):
         idx = TimedeltaIndex(['1 day 00:00:05', '1 day 00:00:01',
@@ -486,16 +486,16 @@ class TestTimedeltaIndex(DatetimeLike, tm.TestCase):
     def test_fields(self):
         rng = timedelta_range('1 days, 10:11:12.100123456', periods=2,
                               freq='s')
-        self.assert_index_equal(rng.days, Index([1, 1], dtype='int64'))
-        self.assert_index_equal(
+        tm.assert_index_equal(rng.days, Index([1, 1], dtype='int64'))
+        tm.assert_index_equal(
             rng.seconds,
             Index([10 * 3600 + 11 * 60 + 12, 10 * 3600 + 11 * 60 + 13],
                   dtype='int64'))
-        self.assert_index_equal(
+        tm.assert_index_equal(
             rng.microseconds,
             Index([100 * 1000 + 123, 100 * 1000 + 123], dtype='int64'))
-        self.assert_index_equal(rng.nanoseconds,
-                                Index([456, 456], dtype='int64'))
+        tm.assert_index_equal(rng.nanoseconds,
+                              Index([456, 456], dtype='int64'))
 
         self.assertRaises(AttributeError, lambda: rng.hours)
         self.assertRaises(AttributeError, lambda: rng.minutes)

--- a/pandas/tests/indexing/test_floats.py
+++ b/pandas/tests/indexing/test_floats.py
@@ -562,7 +562,7 @@ class TestFloatIndexers(tm.TestCase):
                     if isinstance(s, Series):
                         tm.assert_series_equal(result, expected)
                     else:
-                        self.assert_frame_equal(result, expected)
+                        tm.assert_frame_equal(result, expected)
                     # setitem
                     s2 = s.copy()
                     with catch_warnings(record=True):

--- a/pandas/tests/indexing/test_floats.py
+++ b/pandas/tests/indexing/test_floats.py
@@ -560,7 +560,7 @@ class TestFloatIndexers(tm.TestCase):
                     with catch_warnings(record=True):
                         result = idxr(s)[l]
                     if isinstance(s, Series):
-                        self.assert_series_equal(result, expected)
+                        tm.assert_series_equal(result, expected)
                     else:
                         self.assert_frame_equal(result, expected)
                     # setitem

--- a/pandas/tests/indexing/test_indexing.py
+++ b/pandas/tests/indexing/test_indexing.py
@@ -108,7 +108,7 @@ class TestFancy(Base, tm.TestCase):
         df.columns = ['a', 'a', 'b']
         result = df[['b', 'a']].columns
         expected = Index(['b', 'a', 'a'])
-        self.assert_index_equal(result, expected)
+        tm.assert_index_equal(result, expected)
 
         # across dtypes
         df = DataFrame([[1, 2, 1., 2., 3., 'foo', 'bar']],
@@ -534,7 +534,7 @@ class TestFancy(Base, tm.TestCase):
         index = df.index.copy()
 
         df['A'] = df['A'].astype(np.float64)
-        self.assert_index_equal(df.index, index)
+        tm.assert_index_equal(df.index, index)
 
         # TODO(wesm): unused variables
         # result = df.get_dtype_counts().sort_index()

--- a/pandas/tests/indexing/test_ix.py
+++ b/pandas/tests/indexing/test_ix.py
@@ -184,7 +184,7 @@ class TestIX(tm.TestCase):
         key = 4.0, 2012
 
         # emits a PerformanceWarning, ok
-        with self.assert_produces_warning(PerformanceWarning):
+        with tm.assert_produces_warning(PerformanceWarning):
             tm.assert_frame_equal(df.loc[key], df.iloc[2:])
 
         # this is ok

--- a/pandas/tests/io/json/test_pandas.py
+++ b/pandas/tests/io/json/test_pandas.py
@@ -102,7 +102,7 @@ class TestPandasContainer(tm.TestCase):
         assert_frame_equal(df, read_json(df.to_json(orient='split'),
                                          orient='split'))
         unser = read_json(df.to_json(orient='records'), orient='records')
-        self.assert_index_equal(df.columns, unser.columns)
+        tm.assert_index_equal(df.columns, unser.columns)
         tm.assert_almost_equal(df.values, unser.values)
         unser = read_json(df.to_json(orient='values'), orient='values')
         tm.assert_numpy_array_equal(df.values, unser.values)
@@ -184,17 +184,17 @@ class TestPandasContainer(tm.TestCase):
                     unser.index.values.astype('i8') * 1e6)
             if orient == "records":
                 # index is not captured in this orientation
-                assert_almost_equal(df.values, unser.values,
-                                    check_dtype=check_numpy_dtype)
-                self.assert_index_equal(df.columns, unser.columns,
-                                        exact=check_column_type)
+                tm.assert_almost_equal(df.values, unser.values,
+                                       check_dtype=check_numpy_dtype)
+                tm.assert_index_equal(df.columns, unser.columns,
+                                      exact=check_column_type)
             elif orient == "values":
                 # index and cols are not captured in this orientation
                 if numpy is True and df.shape == (0, 0):
                     assert unser.shape[0] == 0
                 else:
-                    assert_almost_equal(df.values, unser.values,
-                                        check_dtype=check_numpy_dtype)
+                    tm.assert_almost_equal(df.values, unser.values,
+                                           check_dtype=check_numpy_dtype)
             elif orient == "split":
                 # index and col labels might not be strings
                 unser.index = [str(i) for i in unser.index]
@@ -202,16 +202,16 @@ class TestPandasContainer(tm.TestCase):
 
                 if sort is None:
                     unser = unser.sort_index()
-                assert_almost_equal(df.values, unser.values,
-                                    check_dtype=check_numpy_dtype)
+                tm.assert_almost_equal(df.values, unser.values,
+                                       check_dtype=check_numpy_dtype)
             else:
                 if convert_axes:
-                    assert_frame_equal(df, unser, check_dtype=check_dtype,
-                                       check_index_type=check_index_type,
-                                       check_column_type=check_column_type)
+                    tm.assert_frame_equal(df, unser, check_dtype=check_dtype,
+                                          check_index_type=check_index_type,
+                                          check_column_type=check_column_type)
                 else:
-                    assert_frame_equal(df, unser, check_less_precise=False,
-                                       check_dtype=check_dtype)
+                    tm.assert_frame_equal(df, unser, check_less_precise=False,
+                                          check_dtype=check_dtype)
 
         def _check_all_orients(df, dtype=None, convert_axes=True,
                                raise_ok=None, sort=None, check_index_type=True,

--- a/pandas/tests/io/parser/common.py
+++ b/pandas/tests/io/parser/common.py
@@ -220,9 +220,9 @@ Klosterdruckerei\tKlosterdruckerei <Kempten> (1609-1805)\tHochfurstliche Buchhan
                              [11, 12, 13, 14, 15]], dtype=np.int64)
         df = self.read_table(StringIO(data), sep=',')
         tm.assert_almost_equal(df.values, expected)
-        self.assert_index_equal(df.columns,
-                                Index(['A', 'B', 'C', 'Unnamed: 3',
-                                       'Unnamed: 4']))
+        tm.assert_index_equal(df.columns,
+                              Index(['A', 'B', 'C', 'Unnamed: 3',
+                                     'Unnamed: 4']))
 
     def test_duplicate_columns(self):
         # TODO: add test for condition 'mangle_dupe_cols=False'
@@ -261,7 +261,7 @@ c,4,5
         df = self.read_csv(self.csv1, index_col=0, parse_dates=True)
         df2 = self.read_table(self.csv1, sep=',', index_col=0,
                               parse_dates=True)
-        self.assert_index_equal(df.columns, pd.Index(['A', 'B', 'C', 'D']))
+        tm.assert_index_equal(df.columns, pd.Index(['A', 'B', 'C', 'D']))
         self.assertEqual(df.index.name, 'index')
         self.assertIsInstance(
             df.index[0], (datetime, np.datetime64, Timestamp))
@@ -272,8 +272,8 @@ c,4,5
         df = self.read_csv(self.csv2, index_col=0, parse_dates=True)
         df2 = self.read_table(self.csv2, sep=',', index_col=0,
                               parse_dates=True)
-        self.assert_index_equal(df.columns,
-                                pd.Index(['A', 'B', 'C', 'D', 'E']))
+        tm.assert_index_equal(df.columns,
+                              pd.Index(['A', 'B', 'C', 'D', 'E']))
         self.assertIsInstance(df.index[0],
                               (datetime, np.datetime64, Timestamp))
         self.assertEqual(df.loc[:, ['A', 'B', 'C', 'D']].values.dtype,

--- a/pandas/tests/io/parser/header.py
+++ b/pandas/tests/io/parser/header.py
@@ -48,9 +48,9 @@ MyColumn
                              [11, 12, 13, 14, 15]], dtype=np.int64)
         tm.assert_almost_equal(df_pref.values, expected)
 
-        self.assert_index_equal(df_pref.columns,
-                                Index(['Field0', 'Field1', 'Field2',
-                                       'Field3', 'Field4']))
+        tm.assert_index_equal(df_pref.columns,
+                              Index(['Field0', 'Field1', 'Field2',
+                                     'Field3', 'Field4']))
 
     def test_header_with_index_col(self):
         data = """foo,1,2,3
@@ -270,8 +270,8 @@ q,r,s,t,u,v
         tm.assert_almost_equal(df.values, expected)
         tm.assert_almost_equal(df.values, df2.values)
 
-        self.assert_index_equal(df_pref.columns,
-                                Index(['X0', 'X1', 'X2', 'X3', 'X4']))
-        self.assert_index_equal(df.columns, Index(lrange(5)))
+        tm.assert_index_equal(df_pref.columns,
+                              Index(['X0', 'X1', 'X2', 'X3', 'X4']))
+        tm.assert_index_equal(df.columns, Index(lrange(5)))
 
-        self.assert_index_equal(df2.columns, Index(names))
+        tm.assert_index_equal(df2.columns, Index(names))

--- a/pandas/tests/io/parser/python_parser_only.py
+++ b/pandas/tests/io/parser/python_parser_only.py
@@ -44,8 +44,8 @@ bar|4|5|6
 baz|7|8|9
 """
         data = self.read_csv(StringIO(text), index_col=0, sep=None)
-        self.assert_index_equal(data.index,
-                                Index(['foo', 'bar', 'baz'], name='index'))
+        tm.assert_index_equal(data.index,
+                              Index(['foo', 'bar', 'baz'], name='index'))
 
         data2 = self.read_csv(StringIO(text), index_col=0, delimiter='|')
         tm.assert_frame_equal(data, data2)

--- a/pandas/tests/io/parser/test_textreader.py
+++ b/pandas/tests/io/parser/test_textreader.py
@@ -76,12 +76,10 @@ class TestTextReader(tm.TestCase):
                             header=None)
         result = reader.read()
 
-        self.assert_numpy_array_equal(result[0],
-                                      np.array(['a', 'a', 'a', 'a'],
-                                               dtype=np.object_))
-        self.assert_numpy_array_equal(result[1],
-                                      np.array(['b', 'b', 'b', 'b'],
-                                               dtype=np.object_))
+        tm.assert_numpy_array_equal(result[0], np.array(['a', 'a', 'a', 'a'],
+                                                        dtype=np.object_))
+        tm.assert_numpy_array_equal(result[1], np.array(['b', 'b', 'b', 'b'],
+                                                        dtype=np.object_))
 
     def test_parse_booleans(self):
         data = 'True\nFalse\nTrue\nTrue'
@@ -98,10 +96,10 @@ class TestTextReader(tm.TestCase):
                             header=None)
         result = reader.read()
 
-        self.assert_numpy_array_equal(result[0], np.array(['a', 'a', 'a'],
-                                                          dtype=np.object_))
-        self.assert_numpy_array_equal(result[1], np.array(['b', 'b', 'b'],
-                                                          dtype=np.object_))
+        tm.assert_numpy_array_equal(result[0], np.array(['a', 'a', 'a'],
+                                                        dtype=np.object_))
+        tm.assert_numpy_array_equal(result[1], np.array(['b', 'b', 'b'],
+                                                        dtype=np.object_))
 
     def test_embedded_newline(self):
         data = 'a\n"hello\nthere"\nthis'
@@ -110,7 +108,7 @@ class TestTextReader(tm.TestCase):
         result = reader.read()
 
         expected = np.array(['a', 'hello\nthere', 'this'], dtype=np.object_)
-        self.assert_numpy_array_equal(result[0], expected)
+        tm.assert_numpy_array_equal(result[0], expected)
 
     def test_euro_decimal(self):
         data = '12345,67\n345,678'

--- a/pandas/tests/io/test_html.py
+++ b/pandas/tests/io/test_html.py
@@ -519,7 +519,7 @@ class TestReadHtml(tm.TestCase, ReadHtmlMixin):
                          'Volume', 'Price', 'Chg', '% Chg'])
         nrows = 100
         self.assertEqual(df.shape[0], nrows)
-        self.assert_index_equal(df.columns, columns)
+        tm.assert_index_equal(df.columns, columns)
 
     @tm.slow
     def test_banklist_header(self):

--- a/pandas/tests/io/test_packers.py
+++ b/pandas/tests/io/test_packers.py
@@ -327,30 +327,30 @@ class TestIndex(TestPackers):
 
         for s, i in self.d.items():
             i_rec = self.encode_decode(i)
-            self.assert_index_equal(i, i_rec)
+            tm.assert_index_equal(i, i_rec)
 
         # datetime with no freq (GH5506)
         i = Index([Timestamp('20130101'), Timestamp('20130103')])
         i_rec = self.encode_decode(i)
-        self.assert_index_equal(i, i_rec)
+        tm.assert_index_equal(i, i_rec)
 
         # datetime with timezone
         i = Index([Timestamp('20130101 9:00:00'), Timestamp(
             '20130103 11:00:00')]).tz_localize('US/Eastern')
         i_rec = self.encode_decode(i)
-        self.assert_index_equal(i, i_rec)
+        tm.assert_index_equal(i, i_rec)
 
     def test_multi_index(self):
 
         for s, i in self.mi.items():
             i_rec = self.encode_decode(i)
-            self.assert_index_equal(i, i_rec)
+            tm.assert_index_equal(i, i_rec)
 
     def test_unicode(self):
         i = tm.makeUnicodeIndex(100)
 
         i_rec = self.encode_decode(i)
-        self.assert_index_equal(i, i_rec)
+        tm.assert_index_equal(i, i_rec)
 
     def categorical_index(self):
         # GH15487

--- a/pandas/tests/io/test_pytables.py
+++ b/pandas/tests/io/test_pytables.py
@@ -5442,7 +5442,7 @@ class TestTimezones(Base, tm.TestCase):
         with ensure_clean_store(self.path) as store:
             store['frame'] = frame
             recons = store['frame']
-            self.assert_index_equal(recons.index, rng)
+            tm.assert_index_equal(recons.index, rng)
             self.assertEqual(rng.tz, recons.index.tz)
 
     def test_store_timezone(self):

--- a/pandas/tests/plotting/common.py
+++ b/pandas/tests/plotting/common.py
@@ -358,7 +358,7 @@ class TestPlotBase(tm.TestCase):
             result = self._get_axes_layout(_flatten(axes))
             self.assertEqual(result, layout)
 
-        self.assert_numpy_array_equal(
+        tm.assert_numpy_array_equal(
             visible_axes[0].figure.get_size_inches(),
             np.array(figsize, dtype=np.float64))
 

--- a/pandas/tests/plotting/test_boxplot_method.py
+++ b/pandas/tests/plotting/test_boxplot_method.py
@@ -356,7 +356,7 @@ class TestDataFrameGroupByPlots(TestPlotBase):
                                   by='gender', return_type='axes', ax=axes[0])
         returned = np.array(list(returned.values))
         self._check_axes_shape(returned, axes_num=3, layout=(1, 3))
-        self.assert_numpy_array_equal(returned, axes[0])
+        tm.assert_numpy_array_equal(returned, axes[0])
         self.assertIs(returned[0].figure, fig)
 
         # draw on second row
@@ -366,7 +366,7 @@ class TestDataFrameGroupByPlots(TestPlotBase):
                 return_type='axes', ax=axes[1])
         returned = np.array(list(returned.values))
         self._check_axes_shape(returned, axes_num=3, layout=(1, 3))
-        self.assert_numpy_array_equal(returned, axes[1])
+        tm.assert_numpy_array_equal(returned, axes[1])
         self.assertIs(returned[0].figure, fig)
 
         with tm.assertRaises(ValueError):

--- a/pandas/tests/plotting/test_datetimelike.py
+++ b/pandas/tests/plotting/test_datetimelike.py
@@ -851,9 +851,9 @@ class TestTSPlot(TestPlotBase):
             self.assertTrue(PeriodIndex(data=l.get_xdata()).freq, idxh.freq)
             xdata = l.get_xdata(orig=False)
             if len(xdata) == 12:  # idxl lines
-                self.assert_numpy_array_equal(xdata, expected_l)
+                tm.assert_numpy_array_equal(xdata, expected_l)
             else:
-                self.assert_numpy_array_equal(xdata, expected_h)
+                tm.assert_numpy_array_equal(xdata, expected_h)
         tm.close()
 
         # tsplot
@@ -866,9 +866,9 @@ class TestTSPlot(TestPlotBase):
             self.assertTrue(PeriodIndex(data=l.get_xdata()).freq, idxh.freq)
             xdata = l.get_xdata(orig=False)
             if len(xdata) == 12:  # idxl lines
-                self.assert_numpy_array_equal(xdata, expected_l)
+                tm.assert_numpy_array_equal(xdata, expected_l)
             else:
-                self.assert_numpy_array_equal(xdata, expected_h)
+                tm.assert_numpy_array_equal(xdata, expected_h)
 
     @slow
     def test_from_resampling_area_line_mixed(self):
@@ -892,25 +892,24 @@ class TestTSPlot(TestPlotBase):
             for i in range(3):
                 l = ax.lines[i]
                 self.assertEqual(PeriodIndex(l.get_xdata()).freq, idxh.freq)
-                self.assert_numpy_array_equal(l.get_xdata(orig=False),
-                                              expected_x)
+                tm.assert_numpy_array_equal(l.get_xdata(orig=False),
+                                            expected_x)
                 # check stacked values are correct
                 expected_y += low[i].values
-                self.assert_numpy_array_equal(
-                    l.get_ydata(orig=False), expected_y)
+                tm.assert_numpy_array_equal(l.get_ydata(orig=False),
+                                            expected_y)
 
             # check high dataframe result
             expected_x = idxh.to_period().asi8.astype(np.float64)
             expected_y = np.zeros(len(expected_x), dtype=np.float64)
             for i in range(3):
                 l = ax.lines[3 + i]
-                self.assertEqual(PeriodIndex(data=l.get_xdata()).freq,
-                                 idxh.freq)
-                self.assert_numpy_array_equal(l.get_xdata(orig=False),
-                                              expected_x)
+                assert PeriodIndex(data=l.get_xdata()).freq == idxh.freq
+                tm.assert_numpy_array_equal(l.get_xdata(orig=False),
+                                            expected_x)
                 expected_y += high[i].values
-                self.assert_numpy_array_equal(l.get_ydata(orig=False),
-                                              expected_y)
+                tm.assert_numpy_array_equal(l.get_ydata(orig=False),
+                                            expected_y)
 
         # high to low
         for kind1, kind2 in [('line', 'area'), ('area', 'line')]:
@@ -922,13 +921,12 @@ class TestTSPlot(TestPlotBase):
             expected_y = np.zeros(len(expected_x), dtype=np.float64)
             for i in range(3):
                 l = ax.lines[i]
-                self.assertEqual(PeriodIndex(data=l.get_xdata()).freq,
-                                 idxh.freq)
-                self.assert_numpy_array_equal(
-                    l.get_xdata(orig=False), expected_x)
+                assert PeriodIndex(data=l.get_xdata()).freq == idxh.freq
+                tm.assert_numpy_array_equal(l.get_xdata(orig=False),
+                                            expected_x)
                 expected_y += high[i].values
-                self.assert_numpy_array_equal(
-                    l.get_ydata(orig=False), expected_y)
+                tm.assert_numpy_array_equal(l.get_ydata(orig=False),
+                                            expected_y)
 
             # check low dataframe result
             expected_x = np.array([1514, 1519, 1523, 1527, 1531, 1536, 1540,
@@ -937,13 +935,12 @@ class TestTSPlot(TestPlotBase):
             expected_y = np.zeros(len(expected_x), dtype=np.float64)
             for i in range(3):
                 l = ax.lines[3 + i]
-                self.assertEqual(PeriodIndex(data=l.get_xdata()).freq,
-                                 idxh.freq)
-                self.assert_numpy_array_equal(l.get_xdata(orig=False),
-                                              expected_x)
+                assert PeriodIndex(data=l.get_xdata()).freq == idxh.freq
+                tm.assert_numpy_array_equal(l.get_xdata(orig=False),
+                                            expected_x)
                 expected_y += low[i].values
-                self.assert_numpy_array_equal(l.get_ydata(orig=False),
-                                              expected_y)
+                tm.assert_numpy_array_equal(l.get_ydata(orig=False),
+                                            expected_y)
 
     @slow
     def test_mixed_freq_second_millisecond(self):

--- a/pandas/tests/plotting/test_frame.py
+++ b/pandas/tests/plotting/test_frame.py
@@ -570,7 +570,7 @@ class TestDataFramePlots(TestPlotBase):
         for nl, sl in zip(normal_lines, stacked_lines):
             base += nl.get_data()[1]  # get y coodinates
             sy = sl.get_data()[1]
-            self.assert_numpy_array_equal(base, sy)
+            tm.assert_numpy_array_equal(base, sy)
 
     def test_line_area_stacked(self):
         with tm.RNGContext(42):
@@ -620,31 +620,31 @@ class TestDataFramePlots(TestPlotBase):
             # remove nan for comparison purpose
 
             exp = np.array([1, 2, 3], dtype=np.float64)
-            self.assert_numpy_array_equal(np.delete(masked1.data, 2), exp)
+            tm.assert_numpy_array_equal(np.delete(masked1.data, 2), exp)
 
             exp = np.array([3, 2, 1], dtype=np.float64)
-            self.assert_numpy_array_equal(np.delete(masked2.data, 1), exp)
-            self.assert_numpy_array_equal(
+            tm.assert_numpy_array_equal(np.delete(masked2.data, 1), exp)
+            tm.assert_numpy_array_equal(
                 masked1.mask, np.array([False, False, True, False]))
-            self.assert_numpy_array_equal(
+            tm.assert_numpy_array_equal(
                 masked2.mask, np.array([False, True, False, False]))
 
             expected1 = np.array([1, 2, 0, 3], dtype=np.float64)
             expected2 = np.array([3, 0, 2, 1], dtype=np.float64)
 
             ax = _check_plot_works(d.plot, stacked=True)
-            self.assert_numpy_array_equal(ax.lines[0].get_ydata(), expected1)
-            self.assert_numpy_array_equal(ax.lines[1].get_ydata(),
-                                          expected1 + expected2)
+            tm.assert_numpy_array_equal(ax.lines[0].get_ydata(), expected1)
+            tm.assert_numpy_array_equal(ax.lines[1].get_ydata(),
+                                        expected1 + expected2)
 
             ax = _check_plot_works(d.plot.area)
-            self.assert_numpy_array_equal(ax.lines[0].get_ydata(), expected1)
-            self.assert_numpy_array_equal(ax.lines[1].get_ydata(),
-                                          expected1 + expected2)
+            tm.assert_numpy_array_equal(ax.lines[0].get_ydata(), expected1)
+            tm.assert_numpy_array_equal(ax.lines[1].get_ydata(),
+                                        expected1 + expected2)
 
             ax = _check_plot_works(d.plot.area, stacked=False)
-            self.assert_numpy_array_equal(ax.lines[0].get_ydata(), expected1)
-            self.assert_numpy_array_equal(ax.lines[1].get_ydata(), expected2)
+            tm.assert_numpy_array_equal(ax.lines[0].get_ydata(), expected1)
+            tm.assert_numpy_array_equal(ax.lines[1].get_ydata(), expected2)
 
     def test_line_lim(self):
         df = DataFrame(rand(6, 3), columns=['x', 'y', 'z'])
@@ -1336,17 +1336,17 @@ class TestDataFramePlots(TestPlotBase):
         # dtype is depending on above values, no need to check
 
         if expected_y is not None:
-            self.assert_numpy_array_equal(result_y, expected_y,
-                                          check_dtype=False)
+            tm.assert_numpy_array_equal(result_y, expected_y,
+                                        check_dtype=False)
         if expected_h is not None:
-            self.assert_numpy_array_equal(result_height, expected_h,
-                                          check_dtype=False)
+            tm.assert_numpy_array_equal(result_height, expected_h,
+                                        check_dtype=False)
         if expected_x is not None:
-            self.assert_numpy_array_equal(result_x, expected_x,
-                                          check_dtype=False)
+            tm.assert_numpy_array_equal(result_x, expected_x,
+                                        check_dtype=False)
         if expected_w is not None:
-            self.assert_numpy_array_equal(result_width, expected_w,
-                                          check_dtype=False)
+            tm.assert_numpy_array_equal(result_width, expected_w,
+                                        check_dtype=False)
 
     @slow
     def test_hist_df_coord(self):

--- a/pandas/tests/plotting/test_hist_method.py
+++ b/pandas/tests/plotting/test_hist_method.py
@@ -373,11 +373,11 @@ class TestDataFrameGroupByPlots(TestPlotBase):
         fig, axes = self.plt.subplots(2, 3)
         returned = df.hist(column=['height', 'weight', 'category'], ax=axes[0])
         self._check_axes_shape(returned, axes_num=3, layout=(1, 3))
-        self.assert_numpy_array_equal(returned, axes[0])
+        tm.assert_numpy_array_equal(returned, axes[0])
         self.assertIs(returned[0].figure, fig)
         returned = df.hist(by='classroom', ax=axes[1])
         self._check_axes_shape(returned, axes_num=3, layout=(1, 3))
-        self.assert_numpy_array_equal(returned, axes[1])
+        tm.assert_numpy_array_equal(returned, axes[1])
         self.assertIs(returned[0].figure, fig)
 
         with tm.assertRaises(ValueError):

--- a/pandas/tests/plotting/test_series.py
+++ b/pandas/tests/plotting/test_series.py
@@ -172,17 +172,17 @@ class TestSeriesPlots(TestPlotBase):
             masked = ax.lines[0].get_ydata()
             # remove nan for comparison purpose
             exp = np.array([1, 2, 3], dtype=np.float64)
-            self.assert_numpy_array_equal(np.delete(masked.data, 2), exp)
-            self.assert_numpy_array_equal(
+            tm.assert_numpy_array_equal(np.delete(masked.data, 2), exp)
+            tm.assert_numpy_array_equal(
                 masked.mask, np.array([False, False, True, False]))
 
             expected = np.array([1, 2, 0, 3], dtype=np.float64)
             ax = _check_plot_works(d.plot, stacked=True)
-            self.assert_numpy_array_equal(ax.lines[0].get_ydata(), expected)
+            tm.assert_numpy_array_equal(ax.lines[0].get_ydata(), expected)
             ax = _check_plot_works(d.plot.area)
-            self.assert_numpy_array_equal(ax.lines[0].get_ydata(), expected)
+            tm.assert_numpy_array_equal(ax.lines[0].get_ydata(), expected)
             ax = _check_plot_works(d.plot.area, stacked=False)
-            self.assert_numpy_array_equal(ax.lines[0].get_ydata(), expected)
+            tm.assert_numpy_array_equal(ax.lines[0].get_ydata(), expected)
 
     def test_line_use_index_false(self):
         s = Series([1, 2, 3], index=['a', 'b', 'c'])

--- a/pandas/tests/reshape/test_concat.py
+++ b/pandas/tests/reshape/test_concat.py
@@ -930,8 +930,8 @@ class TestConcatenate(ConcatenateBase):
                         levels=[level],
                         names=['group_key'])
 
-        self.assert_index_equal(result.columns.levels[0],
-                                Index(level, name='group_key'))
+        tm.assert_index_equal(result.columns.levels[0],
+                              Index(level, name='group_key'))
         self.assertEqual(result.columns.names[0], 'group_key')
 
     def test_concat_dataframe_keys_bug(self):
@@ -1102,8 +1102,8 @@ class TestConcatenate(ConcatenateBase):
                               ('baz', 'one'), ('baz', 'two')],
                         names=['first', 'second'])
         self.assertEqual(result.index.names, ('first', 'second') + (None,))
-        self.assert_index_equal(result.index.levels[0],
-                                Index(['baz', 'foo'], name='first'))
+        tm.assert_index_equal(result.index.levels[0],
+                              Index(['baz', 'foo'], name='first'))
 
     def test_concat_keys_levels_no_overlap(self):
         # GH #1406

--- a/pandas/tests/reshape/test_hashing.py
+++ b/pandas/tests/reshape/test_hashing.py
@@ -73,7 +73,7 @@ class TestHashing(tm.TestCase):
         tups = [(1, 'one'), (1, 'two'), (2, 'one')]
         result = hash_tuples(tups)
         expected = hash_pandas_object(MultiIndex.from_tuples(tups)).values
-        self.assert_numpy_array_equal(result, expected)
+        tm.assert_numpy_array_equal(result, expected)
 
         result = hash_tuples(tups[0])
         self.assertEqual(result, expected[0])
@@ -258,12 +258,12 @@ class TestHashing(tm.TestCase):
         # these should be different!
         result1 = hash_array(np.asarray(L[0:1], dtype=object), 'utf8')
         expected1 = np.array([14963968704024874985], dtype=np.uint64)
-        self.assert_numpy_array_equal(result1, expected1)
+        tm.assert_numpy_array_equal(result1, expected1)
 
         result2 = hash_array(np.asarray(L[1:2], dtype=object), 'utf8')
         expected2 = np.array([16428432627716348016], dtype=np.uint64)
-        self.assert_numpy_array_equal(result2, expected2)
+        tm.assert_numpy_array_equal(result2, expected2)
 
         result = hash_array(np.asarray(L, dtype=object), 'utf8')
-        self.assert_numpy_array_equal(
+        tm.assert_numpy_array_equal(
             result, np.concatenate([expected1, expected2], axis=0))

--- a/pandas/tests/reshape/test_join.py
+++ b/pandas/tests/reshape/test_join.py
@@ -255,7 +255,7 @@ class TestJoin(tm.TestCase):
 
         merged2 = self.target.join(self.source.reindex([]), on='C',
                                    how='inner')
-        self.assert_index_equal(merged2.columns, merged.columns)
+        tm.assert_index_equal(merged2.columns, merged.columns)
         self.assertEqual(len(merged2), 0)
 
     def test_join_on_inner(self):
@@ -270,7 +270,7 @@ class TestJoin(tm.TestCase):
                                  check_dtype=False)
         self.assert_series_equal(joined['value'], expected['value'],
                                  check_dtype=False)
-        self.assert_index_equal(joined.index, expected.index)
+        tm.assert_index_equal(joined.index, expected.index)
 
     def test_join_on_singlekey_list(self):
         df = DataFrame({'key': ['a', 'a', 'b', 'b', 'c']})
@@ -530,7 +530,7 @@ class TestJoin(tm.TestCase):
 
         # smoke test
         joined = left.join(right, on='key', sort=False)
-        self.assert_index_equal(joined.index, pd.Index(lrange(4)))
+        tm.assert_index_equal(joined.index, pd.Index(lrange(4)))
 
     def test_join_mixed_non_unique_index(self):
         # GH 12814, unorderable types in py3 with a non-unique index

--- a/pandas/tests/reshape/test_join.py
+++ b/pandas/tests/reshape/test_join.py
@@ -63,8 +63,8 @@ class TestJoin(tm.TestCase):
         exp_rs = exp_rs.take(exp_ri)
         exp_rs[exp_ri == -1] = -1
 
-        self.assert_numpy_array_equal(ls, exp_ls, check_dtype=False)
-        self.assert_numpy_array_equal(rs, exp_rs, check_dtype=False)
+        tm.assert_numpy_array_equal(ls, exp_ls, check_dtype=False)
+        tm.assert_numpy_array_equal(rs, exp_rs, check_dtype=False)
 
     def test_cython_right_outer_join(self):
         left = a_([0, 1, 2, 1, 2, 0, 0, 1, 2, 3, 3], dtype=np.int64)
@@ -89,8 +89,8 @@ class TestJoin(tm.TestCase):
         exp_rs = exp_rs.take(exp_ri)
         exp_rs[exp_ri == -1] = -1
 
-        self.assert_numpy_array_equal(ls, exp_ls, check_dtype=False)
-        self.assert_numpy_array_equal(rs, exp_rs, check_dtype=False)
+        tm.assert_numpy_array_equal(ls, exp_ls, check_dtype=False)
+        tm.assert_numpy_array_equal(rs, exp_rs, check_dtype=False)
 
     def test_cython_inner_join(self):
         left = a_([0, 1, 2, 1, 2, 0, 0, 1, 2, 3, 3], dtype=np.int64)
@@ -113,8 +113,8 @@ class TestJoin(tm.TestCase):
         exp_rs = exp_rs.take(exp_ri)
         exp_rs[exp_ri == -1] = -1
 
-        self.assert_numpy_array_equal(ls, exp_ls, check_dtype=False)
-        self.assert_numpy_array_equal(rs, exp_rs, check_dtype=False)
+        tm.assert_numpy_array_equal(ls, exp_ls, check_dtype=False)
+        tm.assert_numpy_array_equal(rs, exp_rs, check_dtype=False)
 
     def test_left_outer_join(self):
         joined_key2 = merge(self.df, self.df2, on='key2')

--- a/pandas/tests/reshape/test_join.py
+++ b/pandas/tests/reshape/test_join.py
@@ -167,10 +167,10 @@ class TestJoin(tm.TestCase):
         source = self.source
 
         merged = target.join(source, on='C')
-        self.assert_series_equal(merged['MergedA'], target['A'],
-                                 check_names=False)
-        self.assert_series_equal(merged['MergedD'], target['D'],
-                                 check_names=False)
+        tm.assert_series_equal(merged['MergedA'], target['A'],
+                               check_names=False)
+        tm.assert_series_equal(merged['MergedD'], target['D'],
+                               check_names=False)
 
         # join with duplicates (fix regression from DataFrame/Matrix merge)
         df = DataFrame({'key': ['a', 'a', 'b', 'b', 'c']})
@@ -266,10 +266,10 @@ class TestJoin(tm.TestCase):
 
         expected = df.join(df2, on='key')
         expected = expected[expected['value'].notnull()]
-        self.assert_series_equal(joined['key'], expected['key'],
-                                 check_dtype=False)
-        self.assert_series_equal(joined['value'], expected['value'],
-                                 check_dtype=False)
+        tm.assert_series_equal(joined['key'], expected['key'],
+                               check_dtype=False)
+        tm.assert_series_equal(joined['value'], expected['value'],
+                               check_dtype=False)
         tm.assert_index_equal(joined.index, expected.index)
 
     def test_join_on_singlekey_list(self):

--- a/pandas/tests/reshape/test_merge.py
+++ b/pandas/tests/reshape/test_merge.py
@@ -238,16 +238,16 @@ class TestMerge(tm.TestCase):
         rkey = np.array([1, 1, 2, 3, 4, 5])
 
         merged = merge(left, right, left_on=lkey, right_on=rkey, how='outer')
-        self.assert_series_equal(merged['key_0'],
-                                 Series([1, 1, 1, 1, 2, 2, 3, 4, 5],
-                                        name='key_0'))
+        tm.assert_series_equal(merged['key_0'], Series([1, 1, 1, 1, 2,
+                                                        2, 3, 4, 5],
+                                                       name='key_0'))
 
         left = DataFrame({'value': lrange(3)})
         right = DataFrame({'rvalue': lrange(6)})
 
         key = np.array([0, 1, 1, 2, 2, 3], dtype=np.int64)
         merged = merge(left, right, left_index=True, right_on=key, how='outer')
-        self.assert_series_equal(merged['key_0'], Series(key, name='key_0'))
+        tm.assert_series_equal(merged['key_0'], Series(key, name='key_0'))
 
     def test_no_overlap_more_informative_error(self):
         dt = datetime.now()

--- a/pandas/tests/reshape/test_tile.py
+++ b/pandas/tests/reshape/test_tile.py
@@ -211,12 +211,12 @@ class TestCut(tm.TestCase):
         result = cut(arr, bins, labels=labels)
         exp = Categorical(['Medium'] + 4 * ['Small'] + ['Medium', 'Large'],
                           ordered=True)
-        self.assert_categorical_equal(result, exp)
+        tm.assert_categorical_equal(result, exp)
 
         result = cut(arr, bins, labels=Categorical.from_codes([0, 1, 2],
                                                               labels))
         exp = Categorical.from_codes([1] + 4 * [0] + [1, 2], labels)
-        self.assert_categorical_equal(result, exp)
+        tm.assert_categorical_equal(result, exp)
 
     def test_qcut_include_lowest(self):
         values = np.arange(10)
@@ -241,7 +241,7 @@ class TestCut(tm.TestCase):
         result = qcut([0, 2], 2)
         expected = Index([Interval(-0.001, 1), Interval(1, 2)]).astype(
             'category')
-        self.assert_categorical_equal(result, expected)
+        tm.assert_categorical_equal(result, expected)
 
     def test_round_frac(self):
         # it works

--- a/pandas/tests/reshape/test_tile.py
+++ b/pandas/tests/reshape/test_tile.py
@@ -201,7 +201,7 @@ class TestCut(tm.TestCase):
 
         mask = isnull(result)
         ex_mask = (arr < -1) | (arr > 1)
-        self.assert_numpy_array_equal(mask, ex_mask)
+        tm.assert_numpy_array_equal(mask, ex_mask)
 
     def test_cut_pass_labels(self):
         arr = [50, 5, 10, 15, 20, 30, 70]
@@ -494,9 +494,9 @@ class TestCut(tm.TestCase):
         result = cut(date_range('20130102', periods=5),
                      bins=date_range('20130101', periods=2))
         mask = result.categories.isnull()
-        self.assert_numpy_array_equal(mask, np.array([False]))
+        tm.assert_numpy_array_equal(mask, np.array([False]))
         mask = result.isnull()
-        self.assert_numpy_array_equal(
+        tm.assert_numpy_array_equal(
             mask, np.array([False, True, True, True, True]))
 
 

--- a/pandas/tests/series/test_alter_axes.py
+++ b/pandas/tests/series/test_alter_axes.py
@@ -46,7 +46,7 @@ class TestSeriesAlterAxes(TestData, tm.TestCase):
         # partial dict
         s = Series(np.arange(4), index=['a', 'b', 'c', 'd'], dtype='int64')
         renamed = s.rename({'b': 'foo', 'd': 'bar'})
-        self.assert_index_equal(renamed.index, Index(['a', 'foo', 'c', 'bar']))
+        tm.assert_index_equal(renamed.index, Index(['a', 'foo', 'c', 'bar']))
 
         # index with name
         renamer = Series(np.arange(4),
@@ -136,7 +136,7 @@ class TestSeriesAlterAxes(TestData, tm.TestCase):
         self.assertEqual(len(rs.columns), 2)
 
         rs = s.reset_index(level=[0, 2], drop=True)
-        self.assert_index_equal(rs.index, Index(index.get_level_values(1)))
+        tm.assert_index_equal(rs.index, Index(index.get_level_values(1)))
         tm.assertIsInstance(rs, Series)
 
     def test_reset_index_range(self):

--- a/pandas/tests/series/test_alter_axes.py
+++ b/pandas/tests/series/test_alter_axes.py
@@ -67,7 +67,7 @@ class TestSeriesAlterAxes(TestData, tm.TestCase):
         for name in ['foo', 123, 123., datetime(2001, 11, 11), ('foo',)]:
             result = s.rename(name)
             self.assertEqual(result.name, name)
-            self.assert_numpy_array_equal(result.index.values, s.index.values)
+            tm.assert_numpy_array_equal(result.index.values, s.index.values)
             self.assertTrue(s.name is None)
 
     def test_rename_set_name_inplace(self):
@@ -77,7 +77,7 @@ class TestSeriesAlterAxes(TestData, tm.TestCase):
             self.assertEqual(s.name, name)
 
             exp = np.array(['a', 'b', 'c'], dtype=np.object_)
-            self.assert_numpy_array_equal(s.index.values, exp)
+            tm.assert_numpy_array_equal(s.index.values, exp)
 
     def test_set_name_attribute(self):
         s = Series([1, 2, 3])

--- a/pandas/tests/series/test_analytics.py
+++ b/pandas/tests/series/test_analytics.py
@@ -375,8 +375,8 @@ class TestSeriesAnalytics(TestData, tm.TestCase):
         self._check_accum_op('cumprod')
 
     def test_cummin(self):
-        self.assert_numpy_array_equal(self.ts.cummin().values,
-                                      np.minimum.accumulate(np.array(self.ts)))
+        tm.assert_numpy_array_equal(self.ts.cummin().values,
+                                    np.minimum.accumulate(np.array(self.ts)))
         ts = self.ts.copy()
         ts[::2] = np.NaN
         result = ts.cummin()[1::2]
@@ -385,8 +385,8 @@ class TestSeriesAnalytics(TestData, tm.TestCase):
         self.assert_series_equal(result, expected)
 
     def test_cummax(self):
-        self.assert_numpy_array_equal(self.ts.cummax().values,
-                                      np.maximum.accumulate(np.array(self.ts)))
+        tm.assert_numpy_array_equal(self.ts.cummax().values,
+                                    np.maximum.accumulate(np.array(self.ts)))
         ts = self.ts.copy()
         ts[::2] = np.NaN
         result = ts.cummax()[1::2]
@@ -564,9 +564,9 @@ class TestSeriesAnalytics(TestData, tm.TestCase):
 
     def _check_accum_op(self, name, check_dtype=True):
         func = getattr(np, name)
-        self.assert_numpy_array_equal(func(self.ts).values,
-                                      func(np.array(self.ts)),
-                                      check_dtype=check_dtype)
+        tm.assert_numpy_array_equal(func(self.ts).values,
+                                    func(np.array(self.ts)),
+                                    check_dtype=check_dtype)
 
         # with missing values
         ts = self.ts.copy()
@@ -575,8 +575,8 @@ class TestSeriesAnalytics(TestData, tm.TestCase):
         result = func(ts)[1::2]
         expected = func(np.array(ts.valid()))
 
-        self.assert_numpy_array_equal(result.values, expected,
-                                      check_dtype=False)
+        tm.assert_numpy_array_equal(result.values, expected,
+                                    check_dtype=False)
 
     def test_compress(self):
         cond = [True, False, True, False, False]
@@ -900,7 +900,7 @@ class TestSeriesAnalytics(TestData, tm.TestCase):
         s = Series([1, 2, 3, None, None, None], dtype=object)
         result = s.unique()
         expected = np.array([1, 2, 3, None], dtype=object)
-        self.assert_numpy_array_equal(result, expected)
+        tm.assert_numpy_array_equal(result, expected)
 
     def test_drop_duplicates(self):
         # check both int and object

--- a/pandas/tests/series/test_analytics.py
+++ b/pandas/tests/series/test_analytics.py
@@ -320,19 +320,19 @@ class TestSeriesAnalytics(TestData, tm.TestCase):
                           name='int_data',
                           index=['count', 'mean', 'std', 'min', '25%',
                                  '50%', '75%', 'max'])
-        self.assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         s = Series([True, True, False, False, False], name='bool_data')
         result = s.describe()
         expected = Series([5, 2, False, 3], name='bool_data',
                           index=['count', 'unique', 'top', 'freq'])
-        self.assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         s = Series(['a', 'a', 'b', 'c', 'd'], name='str_data')
         result = s.describe()
         expected = Series([5, 4, 'a', 2], name='str_data',
                           index=['count', 'unique', 'top', 'freq'])
-        self.assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
     def test_argsort(self):
         self._check_accum_op('argsort', check_dtype=False)
@@ -362,11 +362,12 @@ class TestSeriesAnalytics(TestData, tm.TestCase):
         mexpected = np.argsort(s.values, kind='mergesort')
         qexpected = np.argsort(s.values, kind='quicksort')
 
-        self.assert_series_equal(mindexer, Series(mexpected),
-                                 check_dtype=False)
-        self.assert_series_equal(qindexer, Series(qexpected),
-                                 check_dtype=False)
-        self.assertFalse(np.array_equal(qindexer, mindexer))
+        tm.assert_series_equal(mindexer, Series(mexpected),
+                               check_dtype=False)
+        tm.assert_series_equal(qindexer, Series(qexpected),
+                               check_dtype=False)
+        pytest.raises(AssertionError, tm.assert_numpy_array_equal,
+                      qindexer, mindexer)
 
     def test_cumsum(self):
         self._check_accum_op('cumsum')
@@ -382,7 +383,7 @@ class TestSeriesAnalytics(TestData, tm.TestCase):
         result = ts.cummin()[1::2]
         expected = np.minimum.accumulate(ts.valid())
 
-        self.assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
     def test_cummax(self):
         tm.assert_numpy_array_equal(self.ts.cummax().values,
@@ -392,7 +393,7 @@ class TestSeriesAnalytics(TestData, tm.TestCase):
         result = ts.cummax()[1::2]
         expected = np.maximum.accumulate(ts.valid())
 
-        self.assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
     def test_cummin_datetime64(self):
         s = pd.Series(pd.to_datetime(['NaT', '2000-1-2', 'NaT', '2000-1-1',
@@ -401,13 +402,13 @@ class TestSeriesAnalytics(TestData, tm.TestCase):
         expected = pd.Series(pd.to_datetime(['NaT', '2000-1-2', 'NaT',
                                              '2000-1-1', 'NaT', '2000-1-1']))
         result = s.cummin(skipna=True)
-        self.assert_series_equal(expected, result)
+        tm.assert_series_equal(expected, result)
 
         expected = pd.Series(pd.to_datetime(
             ['NaT', '2000-1-2', '2000-1-2', '2000-1-1', '2000-1-1', '2000-1-1'
              ]))
         result = s.cummin(skipna=False)
-        self.assert_series_equal(expected, result)
+        tm.assert_series_equal(expected, result)
 
     def test_cummax_datetime64(self):
         s = pd.Series(pd.to_datetime(['NaT', '2000-1-2', 'NaT', '2000-1-1',
@@ -416,13 +417,13 @@ class TestSeriesAnalytics(TestData, tm.TestCase):
         expected = pd.Series(pd.to_datetime(['NaT', '2000-1-2', 'NaT',
                                              '2000-1-2', 'NaT', '2000-1-3']))
         result = s.cummax(skipna=True)
-        self.assert_series_equal(expected, result)
+        tm.assert_series_equal(expected, result)
 
         expected = pd.Series(pd.to_datetime(
             ['NaT', '2000-1-2', '2000-1-2', '2000-1-2', '2000-1-2', '2000-1-3'
              ]))
         result = s.cummax(skipna=False)
-        self.assert_series_equal(expected, result)
+        tm.assert_series_equal(expected, result)
 
     def test_cummin_timedelta64(self):
         s = pd.Series(pd.to_timedelta(['NaT',
@@ -439,7 +440,7 @@ class TestSeriesAnalytics(TestData, tm.TestCase):
                                               'NaT',
                                               '1 min', ]))
         result = s.cummin(skipna=True)
-        self.assert_series_equal(expected, result)
+        tm.assert_series_equal(expected, result)
 
         expected = pd.Series(pd.to_timedelta(['NaT',
                                               '2 min',
@@ -448,7 +449,7 @@ class TestSeriesAnalytics(TestData, tm.TestCase):
                                               '1 min',
                                               '1 min', ]))
         result = s.cummin(skipna=False)
-        self.assert_series_equal(expected, result)
+        tm.assert_series_equal(expected, result)
 
     def test_cummax_timedelta64(self):
         s = pd.Series(pd.to_timedelta(['NaT',
@@ -465,7 +466,7 @@ class TestSeriesAnalytics(TestData, tm.TestCase):
                                               'NaT',
                                               '3 min', ]))
         result = s.cummax(skipna=True)
-        self.assert_series_equal(expected, result)
+        tm.assert_series_equal(expected, result)
 
         expected = pd.Series(pd.to_timedelta(['NaT',
                                               '2 min',
@@ -474,7 +475,7 @@ class TestSeriesAnalytics(TestData, tm.TestCase):
                                               '2 min',
                                               '3 min', ]))
         result = s.cummax(skipna=False)
-        self.assert_series_equal(expected, result)
+        tm.assert_series_equal(expected, result)
 
     def test_npdiff(self):
         pytest.skip("skipping due to Series no longer being an "
@@ -629,12 +630,12 @@ class TestSeriesAnalytics(TestData, tm.TestCase):
         s = Series([1.123, 2.123, 3.123], index=lrange(3))
         result = round(s)
         expected_rounded0 = Series([1., 2., 3.], index=lrange(3))
-        self.assert_series_equal(result, expected_rounded0)
+        tm.assert_series_equal(result, expected_rounded0)
 
         decimals = 2
         expected_rounded = Series([1.12, 2.12, 3.12], index=lrange(3))
         result = round(s, decimals)
-        self.assert_series_equal(result, expected_rounded)
+        tm.assert_series_equal(result, expected_rounded)
 
     def test_prod_numpy16_bug(self):
         s = Series([1., 1., 1.], index=lrange(3))
@@ -1257,10 +1258,10 @@ class TestSeriesAnalytics(TestData, tm.TestCase):
         s = pd.Series([1, np.nan, 7, 3, 5, np.nan], index=mi)
 
         expected = pd.Series([6, 2], index=['a', 'b'], dtype=np.float64)
-        self.assert_series_equal(s.ptp(level=0), expected)
+        tm.assert_series_equal(s.ptp(level=0), expected)
 
         expected = pd.Series([np.nan, np.nan], index=['a', 'b'])
-        self.assert_series_equal(s.ptp(level=0, skipna=False), expected)
+        tm.assert_series_equal(s.ptp(level=0, skipna=False), expected)
 
         with self.assertRaises(ValueError):
             s.ptp(axis=1)

--- a/pandas/tests/series/test_api.py
+++ b/pandas/tests/series/test_api.py
@@ -204,7 +204,7 @@ class TestSeriesMisc(TestData, SharedWithSparse, tm.TestCase):
         self.assertIs(getkeys(), self.ts.index)
 
     def test_values(self):
-        self.assert_almost_equal(self.ts.values, self.ts, check_dtype=False)
+        tm.assert_almost_equal(self.ts.values, self.ts, check_dtype=False)
 
     def test_iteritems(self):
         for idx, val in compat.iteritems(self.series):

--- a/pandas/tests/series/test_apply.py
+++ b/pandas/tests/series/test_apply.py
@@ -325,7 +325,7 @@ class TestSeriesMap(TestData, tm.TestCase):
 
         # function
         result = self.ts.map(lambda x: x * 2)
-        self.assert_series_equal(result, self.ts * 2)
+        tm.assert_series_equal(result, self.ts * 2)
 
         # GH 10324
         a = Series([1, 2, 3, 4])
@@ -333,9 +333,9 @@ class TestSeriesMap(TestData, tm.TestCase):
         c = Series(["even", "odd", "even", "odd"])
 
         exp = Series(["odd", "even", "odd", np.nan], dtype="category")
-        self.assert_series_equal(a.map(b), exp)
+        tm.assert_series_equal(a.map(b), exp)
         exp = Series(["odd", "even", "odd", np.nan])
-        self.assert_series_equal(a.map(c), exp)
+        tm.assert_series_equal(a.map(c), exp)
 
         a = Series(['a', 'b', 'c', 'd'])
         b = Series([1, 2, 3, 4],
@@ -343,9 +343,9 @@ class TestSeriesMap(TestData, tm.TestCase):
         c = Series([1, 2, 3, 4], index=Index(['b', 'c', 'd', 'e']))
 
         exp = Series([np.nan, 1, 2, 3])
-        self.assert_series_equal(a.map(b), exp)
+        tm.assert_series_equal(a.map(b), exp)
         exp = Series([np.nan, 1, 2, 3])
-        self.assert_series_equal(a.map(c), exp)
+        tm.assert_series_equal(a.map(c), exp)
 
         a = Series(['a', 'b', 'c', 'd'])
         b = Series(['B', 'C', 'D', 'E'], dtype='category',
@@ -354,9 +354,9 @@ class TestSeriesMap(TestData, tm.TestCase):
 
         exp = Series(pd.Categorical([np.nan, 'B', 'C', 'D'],
                                     categories=['B', 'C', 'D', 'E']))
-        self.assert_series_equal(a.map(b), exp)
+        tm.assert_series_equal(a.map(b), exp)
         exp = Series([np.nan, 'B', 'C', 'D'])
-        self.assert_series_equal(a.map(c), exp)
+        tm.assert_series_equal(a.map(c), exp)
 
     def test_map_compat(self):
         # related GH 8024

--- a/pandas/tests/series/test_combine_concat.py
+++ b/pandas/tests/series/test_combine_concat.py
@@ -68,14 +68,14 @@ class TestSeriesCombine(TestData, tm.TestCase):
         # nothing used from the input
         combined = series.combine_first(series_copy)
 
-        self.assert_series_equal(combined, series)
+        tm.assert_series_equal(combined, series)
 
         # Holes filled from input
         combined = series_copy.combine_first(series)
         self.assertTrue(np.isfinite(combined).all())
 
-        self.assert_series_equal(combined[::2], series[::2])
-        self.assert_series_equal(combined[1::2], series_copy[1::2])
+        tm.assert_series_equal(combined[::2], series[::2])
+        tm.assert_series_equal(combined[1::2], series_copy[1::2])
 
         # mixed types
         index = tm.makeStringIndex(20)

--- a/pandas/tests/series/test_constructors.py
+++ b/pandas/tests/series/test_constructors.py
@@ -415,7 +415,7 @@ class TestSeriesConstructors(TestData, tm.TestCase):
         dates2 = np.array([d.date() for d in dates.to_pydatetime()],
                           dtype=object)
         series1 = Series(dates2, dates)
-        self.assert_numpy_array_equal(series1.values, dates2)
+        tm.assert_numpy_array_equal(series1.values, dates2)
         self.assertEqual(series1.dtype, object)
 
         # these will correctly infer a datetime

--- a/pandas/tests/series/test_constructors.py
+++ b/pandas/tests/series/test_constructors.py
@@ -474,7 +474,7 @@ class TestSeriesConstructors(TestData, tm.TestCase):
 
         exp = pd.DatetimeIndex(result)
         exp = exp.tz_localize('UTC').tz_convert(tz=s.dt.tz)
-        self.assert_index_equal(dr, exp)
+        tm.assert_index_equal(dr, exp)
 
         # indexing
         result = s.iloc[0]

--- a/pandas/tests/series/test_datetime_values.py
+++ b/pandas/tests/series/test_datetime_values.py
@@ -309,13 +309,13 @@ class TestSeriesDatetimeValues(TestData, tm.TestCase):
         expected = np.array(['2015/03/01', '2015/03/02', '2015/03/03',
                              '2015/03/04', '2015/03/05'], dtype=np.object_)
         # dtype may be S10 or U10 depending on python version
-        self.assert_numpy_array_equal(result, expected, check_dtype=False)
+        tm.assert_numpy_array_equal(result, expected, check_dtype=False)
 
         period_index = period_range('20150301', periods=5)
         result = period_index.strftime("%Y/%m/%d")
         expected = np.array(['2015/03/01', '2015/03/02', '2015/03/03',
                              '2015/03/04', '2015/03/05'], dtype='=U10')
-        self.assert_numpy_array_equal(result, expected)
+        tm.assert_numpy_array_equal(result, expected)
 
         s = Series([datetime(2013, 1, 1, 2, 32, 59), datetime(2013, 1, 2, 14,
                                                               32, 1)])

--- a/pandas/tests/series/test_indexing.py
+++ b/pandas/tests/series/test_indexing.py
@@ -234,7 +234,7 @@ class TestSeriesIndexing(TestData, tm.TestCase):
         result = s[list(mask)]
         expected = s[mask]
         assert_series_equal(result, expected)
-        self.assert_index_equal(result.index, s.index[mask])
+        tm.assert_index_equal(result.index, s.index[mask])
 
     def test_getitem_boolean_empty(self):
         s = Series([], dtype=np.int64)

--- a/pandas/tests/series/test_io.py
+++ b/pandas/tests/series/test_io.py
@@ -127,7 +127,7 @@ class TestSeriesIO(TestData, tm.TestCase):
         assert_frame_equal(rs, xp)
 
     def test_to_dict(self):
-        self.assert_series_equal(Series(self.ts.to_dict(), name='ts'), self.ts)
+        tm.assert_series_equal(Series(self.ts.to_dict(), name='ts'), self.ts)
 
     def test_timeseries_periodindex(self):
         # GH2891

--- a/pandas/tests/series/test_missing.py
+++ b/pandas/tests/series/test_missing.py
@@ -147,24 +147,24 @@ class TestSeriesMissingData(TestData, tm.TestCase):
                                Timestamp('2011-01-02 10:00'),
                                Timestamp('2011-01-03 10:00'),
                                Timestamp('2011-01-02 10:00')])
-            self.assert_series_equal(expected, result)
+            tm.assert_series_equal(expected, result)
             # check s is not changed
-            self.assert_series_equal(pd.isnull(s), null_loc)
+            tm.assert_series_equal(pd.isnull(s), null_loc)
 
             result = s.fillna(pd.Timestamp('2011-01-02 10:00', tz=tz))
             expected = Series([Timestamp('2011-01-01 10:00'),
                                Timestamp('2011-01-02 10:00', tz=tz),
                                Timestamp('2011-01-03 10:00'),
                                Timestamp('2011-01-02 10:00', tz=tz)])
-            self.assert_series_equal(expected, result)
-            self.assert_series_equal(pd.isnull(s), null_loc)
+            tm.assert_series_equal(expected, result)
+            tm.assert_series_equal(pd.isnull(s), null_loc)
 
             result = s.fillna('AAA')
             expected = Series([Timestamp('2011-01-01 10:00'), 'AAA',
                                Timestamp('2011-01-03 10:00'), 'AAA'],
                               dtype=object)
-            self.assert_series_equal(expected, result)
-            self.assert_series_equal(pd.isnull(s), null_loc)
+            tm.assert_series_equal(expected, result)
+            tm.assert_series_equal(pd.isnull(s), null_loc)
 
             result = s.fillna({1: pd.Timestamp('2011-01-02 10:00', tz=tz),
                                3: pd.Timestamp('2011-01-04 10:00')})
@@ -172,8 +172,8 @@ class TestSeriesMissingData(TestData, tm.TestCase):
                                Timestamp('2011-01-02 10:00', tz=tz),
                                Timestamp('2011-01-03 10:00'),
                                Timestamp('2011-01-04 10:00')])
-            self.assert_series_equal(expected, result)
-            self.assert_series_equal(pd.isnull(s), null_loc)
+            tm.assert_series_equal(expected, result)
+            tm.assert_series_equal(pd.isnull(s), null_loc)
 
             result = s.fillna({1: pd.Timestamp('2011-01-02 10:00'),
                                3: pd.Timestamp('2011-01-04 10:00')})
@@ -181,31 +181,31 @@ class TestSeriesMissingData(TestData, tm.TestCase):
                                Timestamp('2011-01-02 10:00'),
                                Timestamp('2011-01-03 10:00'),
                                Timestamp('2011-01-04 10:00')])
-            self.assert_series_equal(expected, result)
-            self.assert_series_equal(pd.isnull(s), null_loc)
+            tm.assert_series_equal(expected, result)
+            tm.assert_series_equal(pd.isnull(s), null_loc)
 
             # DatetimeBlockTZ
             idx = pd.DatetimeIndex(['2011-01-01 10:00', pd.NaT,
                                     '2011-01-03 10:00', pd.NaT], tz=tz)
             s = pd.Series(idx)
             self.assertEqual(s.dtype, 'datetime64[ns, {0}]'.format(tz))
-            self.assert_series_equal(pd.isnull(s), null_loc)
+            tm.assert_series_equal(pd.isnull(s), null_loc)
 
             result = s.fillna(pd.Timestamp('2011-01-02 10:00'))
             expected = Series([Timestamp('2011-01-01 10:00', tz=tz),
                                Timestamp('2011-01-02 10:00'),
                                Timestamp('2011-01-03 10:00', tz=tz),
                                Timestamp('2011-01-02 10:00')])
-            self.assert_series_equal(expected, result)
-            self.assert_series_equal(pd.isnull(s), null_loc)
+            tm.assert_series_equal(expected, result)
+            tm.assert_series_equal(pd.isnull(s), null_loc)
 
             result = s.fillna(pd.Timestamp('2011-01-02 10:00', tz=tz))
             idx = pd.DatetimeIndex(['2011-01-01 10:00', '2011-01-02 10:00',
                                     '2011-01-03 10:00', '2011-01-02 10:00'],
                                    tz=tz)
             expected = Series(idx)
-            self.assert_series_equal(expected, result)
-            self.assert_series_equal(pd.isnull(s), null_loc)
+            tm.assert_series_equal(expected, result)
+            tm.assert_series_equal(pd.isnull(s), null_loc)
 
             result = s.fillna(pd.Timestamp('2011-01-02 10:00',
                                            tz=tz).to_pydatetime())
@@ -213,15 +213,15 @@ class TestSeriesMissingData(TestData, tm.TestCase):
                                     '2011-01-03 10:00', '2011-01-02 10:00'],
                                    tz=tz)
             expected = Series(idx)
-            self.assert_series_equal(expected, result)
-            self.assert_series_equal(pd.isnull(s), null_loc)
+            tm.assert_series_equal(expected, result)
+            tm.assert_series_equal(pd.isnull(s), null_loc)
 
             result = s.fillna('AAA')
             expected = Series([Timestamp('2011-01-01 10:00', tz=tz), 'AAA',
                                Timestamp('2011-01-03 10:00', tz=tz), 'AAA'],
                               dtype=object)
-            self.assert_series_equal(expected, result)
-            self.assert_series_equal(pd.isnull(s), null_loc)
+            tm.assert_series_equal(expected, result)
+            tm.assert_series_equal(pd.isnull(s), null_loc)
 
             result = s.fillna({1: pd.Timestamp('2011-01-02 10:00', tz=tz),
                                3: pd.Timestamp('2011-01-04 10:00')})
@@ -229,8 +229,8 @@ class TestSeriesMissingData(TestData, tm.TestCase):
                                Timestamp('2011-01-02 10:00', tz=tz),
                                Timestamp('2011-01-03 10:00', tz=tz),
                                Timestamp('2011-01-04 10:00')])
-            self.assert_series_equal(expected, result)
-            self.assert_series_equal(pd.isnull(s), null_loc)
+            tm.assert_series_equal(expected, result)
+            tm.assert_series_equal(pd.isnull(s), null_loc)
 
             result = s.fillna({1: pd.Timestamp('2011-01-02 10:00', tz=tz),
                                3: pd.Timestamp('2011-01-04 10:00', tz=tz)})
@@ -238,8 +238,8 @@ class TestSeriesMissingData(TestData, tm.TestCase):
                                Timestamp('2011-01-02 10:00', tz=tz),
                                Timestamp('2011-01-03 10:00', tz=tz),
                                Timestamp('2011-01-04 10:00', tz=tz)])
-            self.assert_series_equal(expected, result)
-            self.assert_series_equal(pd.isnull(s), null_loc)
+            tm.assert_series_equal(expected, result)
+            tm.assert_series_equal(pd.isnull(s), null_loc)
 
             # filling with a naive/other zone, coerce to object
             result = s.fillna(Timestamp('20130101'))
@@ -247,16 +247,16 @@ class TestSeriesMissingData(TestData, tm.TestCase):
                                Timestamp('2013-01-01'),
                                Timestamp('2011-01-03 10:00', tz=tz),
                                Timestamp('2013-01-01')])
-            self.assert_series_equal(expected, result)
-            self.assert_series_equal(pd.isnull(s), null_loc)
+            tm.assert_series_equal(expected, result)
+            tm.assert_series_equal(pd.isnull(s), null_loc)
 
             result = s.fillna(Timestamp('20130101', tz='US/Pacific'))
             expected = Series([Timestamp('2011-01-01 10:00', tz=tz),
                                Timestamp('2013-01-01', tz='US/Pacific'),
                                Timestamp('2011-01-03 10:00', tz=tz),
                                Timestamp('2013-01-01', tz='US/Pacific')])
-            self.assert_series_equal(expected, result)
-            self.assert_series_equal(pd.isnull(s), null_loc)
+            tm.assert_series_equal(expected, result)
+            tm.assert_series_equal(pd.isnull(s), null_loc)
 
         # with timezone
         # GH 15855
@@ -369,18 +369,18 @@ class TestSeriesMissingData(TestData, tm.TestCase):
     def test_fillna(self):
         ts = Series([0., 1., 2., 3., 4.], index=tm.makeDateIndex(5))
 
-        self.assert_series_equal(ts, ts.fillna(method='ffill'))
+        tm.assert_series_equal(ts, ts.fillna(method='ffill'))
 
         ts[2] = np.NaN
 
         exp = Series([0., 1., 1., 3., 4.], index=ts.index)
-        self.assert_series_equal(ts.fillna(method='ffill'), exp)
+        tm.assert_series_equal(ts.fillna(method='ffill'), exp)
 
         exp = Series([0., 1., 3., 3., 4.], index=ts.index)
-        self.assert_series_equal(ts.fillna(method='backfill'), exp)
+        tm.assert_series_equal(ts.fillna(method='backfill'), exp)
 
         exp = Series([0., 1., 5., 3., 4.], index=ts.index)
-        self.assert_series_equal(ts.fillna(value=5), exp)
+        tm.assert_series_equal(ts.fillna(value=5), exp)
 
         self.assertRaises(ValueError, ts.fillna)
         self.assertRaises(ValueError, self.ts.fillna, value=0, method='ffill')
@@ -529,7 +529,7 @@ class TestSeriesMissingData(TestData, tm.TestCase):
         result = s.dropna()
         expected = Series([Timestamp('2011-01-01 10:00'),
                            Timestamp('2011-01-03 10:00')], index=[0, 2])
-        self.assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         # DatetimeBlockTZ
         idx = pd.DatetimeIndex(['2011-01-01 10:00', pd.NaT,
@@ -542,19 +542,19 @@ class TestSeriesMissingData(TestData, tm.TestCase):
                            Timestamp('2011-01-03 10:00', tz='Asia/Tokyo')],
                           index=[0, 2])
         self.assertEqual(result.dtype, 'datetime64[ns, Asia/Tokyo]')
-        self.assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
     def test_dropna_no_nan(self):
         for s in [Series([1, 2, 3], name='x'), Series(
                 [False, True, False], name='x')]:
 
             result = s.dropna()
-            self.assert_series_equal(result, s)
+            tm.assert_series_equal(result, s)
             self.assertFalse(result is s)
 
             s2 = s.copy()
             s2.dropna(inplace=True)
-            self.assert_series_equal(s2, s)
+            tm.assert_series_equal(s2, s)
 
     def test_dropna_intervals(self):
         s = Series([np.nan, 1, 2, 3], IntervalIndex.from_arrays(
@@ -707,7 +707,7 @@ class TestSeriesInterpolateData(TestData, tm.TestCase):
         ts_copy[5:10] = np.NaN
 
         linear_interp = ts_copy.interpolate(method='linear')
-        self.assert_series_equal(linear_interp, ts)
+        tm.assert_series_equal(linear_interp, ts)
 
         ord_ts = Series([d.toordinal() for d in self.ts.index],
                         index=self.ts.index).astype(float)
@@ -716,7 +716,7 @@ class TestSeriesInterpolateData(TestData, tm.TestCase):
         ord_ts_copy[5:10] = np.NaN
 
         time_interp = ord_ts_copy.interpolate(method='time')
-        self.assert_series_equal(time_interp, ord_ts)
+        tm.assert_series_equal(time_interp, ord_ts)
 
         # try time interpolation on a non-TimeSeries
         # Only raises ValueError if there are NaNs.

--- a/pandas/tests/series/test_missing.py
+++ b/pandas/tests/series/test_missing.py
@@ -1139,4 +1139,4 @@ class TestSeriesInterpolateData(TestData, tm.TestCase):
         new_index = index.append(index + pd.DateOffset(hours=1)).sort_values()
         result = ts.reindex(new_index).interpolate(method='time')
 
-        self.assert_numpy_array_equal(result.values, exp.values)
+        tm.assert_numpy_array_equal(result.values, exp.values)

--- a/pandas/tests/series/test_operators.py
+++ b/pandas/tests/series/test_operators.py
@@ -34,12 +34,12 @@ class TestSeriesOperators(TestData, tm.TestCase):
         val = datetime(2000, 1, 4)
         result = series > val
         expected = Series([x > val for x in series])
-        self.assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         val = series[5]
         result = series > val
         expected = Series([x > val for x in series])
-        self.assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
     def test_comparisons(self):
         left = np.random.randn(10)
@@ -325,13 +325,13 @@ class TestSeriesOperators(TestData, tm.TestCase):
         # GH 13006
         result = np.float64(0) > pd.Series([1, 2, 3])
         expected = 0.0 > pd.Series([1, 2, 3])
-        self.assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
         result = pd.Series([1, 2, 3]) < np.float64(0)
         expected = pd.Series([1, 2, 3]) < 0.0
-        self.assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
         result = np.array([0, 1, 2])[0] > pd.Series([0, 1, 2])
         expected = 0.0 > pd.Series([1, 2, 3])
-        self.assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
     def test_timedeltas_with_DateOffset(self):
 
@@ -1311,13 +1311,13 @@ class TestSeriesOperators(TestData, tm.TestCase):
         const = 2
         for op in ['eq', 'ne', 'gt', 'lt', 'ge', 'le']:
             result = getattr(s, op)(const).get_dtype_counts()
-            self.assert_series_equal(result, Series([1], ['bool']))
+            tm.assert_series_equal(result, Series([1], ['bool']))
 
         # empty Series
         empty = s.iloc[:0]
         for op in ['eq', 'ne', 'gt', 'lt', 'ge', 'le']:
             result = getattr(empty, op)(const).get_dtype_counts()
-            self.assert_series_equal(result, Series([1], ['bool']))
+            tm.assert_series_equal(result, Series([1], ['bool']))
 
     def test_operators_bitwise(self):
         # GH 9016: support bitwise op for integer types
@@ -1480,7 +1480,7 @@ class TestSeriesOperators(TestData, tm.TestCase):
         added = self.ts + int_ts
         expected = Series(self.ts.values[:-5] + int_ts.values,
                           index=self.ts.index[:-5], name='ts')
-        self.assert_series_equal(added[:-5], expected)
+        tm.assert_series_equal(added[:-5], expected)
 
     def test_operators_reverse_object(self):
         # GH 56

--- a/pandas/tests/series/test_period.py
+++ b/pandas/tests/series/test_period.py
@@ -30,7 +30,7 @@ class TestSeriesPeriod(tm.TestCase):
         exp = pd.Series([pd.Period('2000-01-03', freq='D'),
                          pd.Period('2000-01-05', freq='D')],
                         index=[2, 4])
-        self.assert_series_equal(result, exp)
+        tm.assert_series_equal(result, exp)
         self.assertEqual(result.dtype, 'object')
 
     def test_isnull(self):

--- a/pandas/tests/series/test_sorting.py
+++ b/pandas/tests/series/test_sorting.py
@@ -34,12 +34,12 @@ class TestSeriesSorting(TestData, tm.TestCase):
 
         result = ts.sort_values()
         self.assertTrue(np.isnan(result[-5:]).all())
-        self.assert_numpy_array_equal(result[:-5].values, np.sort(vals[5:]))
+        tm.assert_numpy_array_equal(result[:-5].values, np.sort(vals[5:]))
 
         # na_position
         result = ts.sort_values(na_position='first')
         self.assertTrue(np.isnan(result[:5]).all())
-        self.assert_numpy_array_equal(result[5:].values, np.sort(vals[5:]))
+        tm.assert_numpy_array_equal(result[5:].values, np.sort(vals[5:]))
 
         # something object-type
         ser = Series(['A', 'B'], [1, 2])

--- a/pandas/tests/series/test_sorting.py
+++ b/pandas/tests/series/test_sorting.py
@@ -26,7 +26,7 @@ class TestSeriesSorting(TestData, tm.TestCase):
         ser = Series([3, 2, 4, 1], ['A', 'B', 'C', 'D'])
         expected = Series([1, 2, 3, 4], ['D', 'B', 'A', 'C'])
         result = ser.sort_values()
-        self.assert_series_equal(expected, result)
+        tm.assert_series_equal(expected, result)
 
         ts = self.ts.copy()
         ts[:5] = np.NaN
@@ -75,7 +75,7 @@ class TestSeriesSorting(TestData, tm.TestCase):
         # inplace=True
         ts = self.ts.copy()
         ts.sort_values(ascending=False, inplace=True)
-        self.assert_series_equal(ts, self.ts.sort_values(ascending=False))
+        tm.assert_series_equal(ts, self.ts.sort_values(ascending=False))
         tm.assert_index_equal(ts.index,
                               self.ts.sort_values(ascending=False).index)
 

--- a/pandas/tests/series/test_sorting.py
+++ b/pandas/tests/series/test_sorting.py
@@ -76,8 +76,8 @@ class TestSeriesSorting(TestData, tm.TestCase):
         ts = self.ts.copy()
         ts.sort_values(ascending=False, inplace=True)
         self.assert_series_equal(ts, self.ts.sort_values(ascending=False))
-        self.assert_index_equal(ts.index,
-                                self.ts.sort_values(ascending=False).index)
+        tm.assert_index_equal(ts.index,
+                              self.ts.sort_values(ascending=False).index)
 
         # GH 5856/5853
         # Series.sort_values operating on a view

--- a/pandas/tests/series/test_timeseries.py
+++ b/pandas/tests/series/test_timeseries.py
@@ -528,7 +528,7 @@ class TestTimeSeries(TestData, tm.TestCase):
 
         result = rng.get_indexer(ts2.index)
         expected = rng.get_indexer(ts_slice.index)
-        self.assert_numpy_array_equal(result, expected)
+        tm.assert_numpy_array_equal(result, expected)
 
     def test_asfreq_normalize(self):
         rng = date_range('1/1/2000 09:30', periods=20)

--- a/pandas/tests/series/test_timeseries.py
+++ b/pandas/tests/series/test_timeseries.py
@@ -266,7 +266,7 @@ class TestTimeSeries(TestData, tm.TestCase):
             ["2016-09-29 11:00"])).asfreq('H')
         result = Series(index=pd.DatetimeIndex(["2016-09-29 11:00"]),
                         data=[3]).asfreq('H')
-        self.assert_index_equal(expected.index, result.index)
+        tm.assert_index_equal(expected.index, result.index)
 
     def test_diff(self):
         # Just run the function

--- a/pandas/tests/sparse/test_array.py
+++ b/pandas/tests/sparse/test_array.py
@@ -344,7 +344,7 @@ class TestSparseArray(tm.TestCase):
 
         for dense in [arr.to_dense(), arr.values]:
             self.assertEqual(dense.dtype, np.float32)
-            self.assert_numpy_array_equal(dense, data)
+            tm.assert_numpy_array_equal(dense, data)
 
     def test_astype(self):
         res = self.arr.astype('f8')

--- a/pandas/tests/sparse/test_frame.py
+++ b/pandas/tests/sparse/test_frame.py
@@ -962,8 +962,8 @@ class TestSparseDataFrame(tm.TestCase, SharedWithSparse):
 
                 from_sparse_lp = spf.stack_sparse_frame(frame)
 
-                self.assert_numpy_array_equal(from_dense_lp.values,
-                                              from_sparse_lp.values)
+                tm.assert_numpy_array_equal(from_dense_lp.values,
+                                            from_sparse_lp.values)
 
             _check(self.frame)
             _check(self.iframe)

--- a/pandas/tests/sparse/test_frame.py
+++ b/pandas/tests/sparse/test_frame.py
@@ -464,7 +464,7 @@ class TestSparseDataFrame(tm.TestCase, SharedWithSparse):
         subindex = self.frame.index[indexer]
         subframe = self.frame[indexer]
 
-        self.assert_index_equal(subindex, subframe.index)
+        tm.assert_index_equal(subindex, subframe.index)
         self.assertRaises(Exception, self.frame.__getitem__, indexer[:-1])
 
     def test_setitem(self):

--- a/pandas/tests/sparse/test_libsparse.py
+++ b/pandas/tests/sparse/test_libsparse.py
@@ -335,11 +335,11 @@ class TestSparseIndexCommon(tm.TestCase):
 
             res = idx.lookup_array(np.array([-1, 0, 2], dtype=np.int32))
             exp = np.array([-1, -1, 0], dtype=np.int32)
-            self.assert_numpy_array_equal(res, exp)
+            tm.assert_numpy_array_equal(res, exp)
 
             res = idx.lookup_array(np.array([4, 2, 1, 3], dtype=np.int32))
             exp = np.array([-1, 0, -1, 1], dtype=np.int32)
-            self.assert_numpy_array_equal(res, exp)
+            tm.assert_numpy_array_equal(res, exp)
 
             idx = _make_index(4, np.array([], dtype=np.int32), kind=kind)
             res = idx.lookup_array(np.array([-1, 0, 2, 4], dtype=np.int32))
@@ -349,21 +349,21 @@ class TestSparseIndexCommon(tm.TestCase):
                               kind=kind)
             res = idx.lookup_array(np.array([-1, 0, 2], dtype=np.int32))
             exp = np.array([-1, 0, 2], dtype=np.int32)
-            self.assert_numpy_array_equal(res, exp)
+            tm.assert_numpy_array_equal(res, exp)
 
             res = idx.lookup_array(np.array([4, 2, 1, 3], dtype=np.int32))
             exp = np.array([-1, 2, 1, 3], dtype=np.int32)
-            self.assert_numpy_array_equal(res, exp)
+            tm.assert_numpy_array_equal(res, exp)
 
             idx = _make_index(4, np.array([0, 2, 3], dtype=np.int32),
                               kind=kind)
             res = idx.lookup_array(np.array([2, 1, 3, 0], dtype=np.int32))
             exp = np.array([1, -1, 2, 0], dtype=np.int32)
-            self.assert_numpy_array_equal(res, exp)
+            tm.assert_numpy_array_equal(res, exp)
 
             res = idx.lookup_array(np.array([1, 4, 2, 5], dtype=np.int32))
             exp = np.array([-1, -1, 1, -1], dtype=np.int32)
-            self.assert_numpy_array_equal(res, exp)
+            tm.assert_numpy_array_equal(res, exp)
 
     def test_lookup_basics(self):
         def _check(index):

--- a/pandas/tests/sparse/test_series.py
+++ b/pandas/tests/sparse/test_series.py
@@ -818,7 +818,7 @@ class TestSparseSeries(tm.TestCase, SharedWithSparse):
 
         exp = s.fillna(0).add(2)
         res = s.add(2, fill_value=0)
-        self.assert_series_equal(res, exp)
+        tm.assert_series_equal(res, exp)
 
     def test_shift(self):
         series = SparseSeries([nan, 1., 2., 3., nan, nan], index=np.arange(6))

--- a/pandas/tests/test_algos.py
+++ b/pandas/tests/test_algos.py
@@ -213,13 +213,13 @@ class TestFactorize(tm.TestCase):
         exp = np.array([0, 0, 0, 1, 1, 0], dtype=np.intp)
         self.assert_numpy_array_equal(labels, exp)
         exp = DatetimeIndex([v1, v2])
-        self.assert_index_equal(uniques, exp)
+        tm.assert_index_equal(uniques, exp)
 
         labels, uniques = algos.factorize(x, sort=True)
         exp = np.array([1, 1, 1, 0, 0, 1], dtype=np.intp)
         self.assert_numpy_array_equal(labels, exp)
         exp = DatetimeIndex([v2, v1])
-        self.assert_index_equal(uniques, exp)
+        tm.assert_index_equal(uniques, exp)
 
         # period
         v1 = pd.Period('201302', freq='M')
@@ -230,12 +230,12 @@ class TestFactorize(tm.TestCase):
         labels, uniques = algos.factorize(x)
         exp = np.array([0, 0, 0, 1, 1, 0], dtype=np.intp)
         self.assert_numpy_array_equal(labels, exp)
-        self.assert_index_equal(uniques, pd.PeriodIndex([v1, v2]))
+        tm.assert_index_equal(uniques, pd.PeriodIndex([v1, v2]))
 
         labels, uniques = algos.factorize(x, sort=True)
         exp = np.array([0, 0, 0, 1, 1, 0], dtype=np.intp)
         self.assert_numpy_array_equal(labels, exp)
-        self.assert_index_equal(uniques, pd.PeriodIndex([v1, v2]))
+        tm.assert_index_equal(uniques, pd.PeriodIndex([v1, v2]))
 
         # GH 5986
         v1 = pd.to_timedelta('1 day 1 min')
@@ -244,12 +244,12 @@ class TestFactorize(tm.TestCase):
         labels, uniques = algos.factorize(x)
         exp = np.array([0, 1, 0, 0, 1, 1, 0], dtype=np.intp)
         self.assert_numpy_array_equal(labels, exp)
-        self.assert_index_equal(uniques, pd.to_timedelta([v1, v2]))
+        tm.assert_index_equal(uniques, pd.to_timedelta([v1, v2]))
 
         labels, uniques = algos.factorize(x, sort=True)
         exp = np.array([1, 0, 1, 1, 0, 0, 1], dtype=np.intp)
         self.assert_numpy_array_equal(labels, exp)
-        self.assert_index_equal(uniques, pd.to_timedelta([v2, v1]))
+        tm.assert_index_equal(uniques, pd.to_timedelta([v2, v1]))
 
     def test_factorize_nan(self):
         # nan should map to na_sentinel, not reverse_indexer[na_sentinel]

--- a/pandas/tests/test_algos.py
+++ b/pandas/tests/test_algos.py
@@ -29,7 +29,7 @@ class TestMatch(tm.TestCase):
 
         result = algos.match(to_match, values)
         expected = np.array([0, 2, 1, 1, 0, 2, -1, 0], dtype=np.int64)
-        self.assert_numpy_array_equal(result, expected)
+        tm.assert_numpy_array_equal(result, expected)
 
         result = Series(algos.match(to_match, values, np.nan))
         expected = Series(np.array([0, 2, 1, 1, 0, 2, np.nan, 0]))
@@ -38,7 +38,7 @@ class TestMatch(tm.TestCase):
         s = Series(np.arange(5), dtype=np.float32)
         result = algos.match(s, [2, 4])
         expected = np.array([-1, -1, 0, -1, 1], dtype=np.int64)
-        self.assert_numpy_array_equal(result, expected)
+        tm.assert_numpy_array_equal(result, expected)
 
         result = Series(algos.match(s, [2, 4], np.nan))
         expected = Series(np.array([np.nan, np.nan, 0, np.nan, 1]))
@@ -50,7 +50,7 @@ class TestMatch(tm.TestCase):
 
         result = algos.match(to_match, values)
         expected = np.array([1, 0, -1, 0, 1, 2, -1], dtype=np.int64)
-        self.assert_numpy_array_equal(result, expected)
+        tm.assert_numpy_array_equal(result, expected)
 
         result = Series(algos.match(to_match, values, np.nan))
         expected = Series(np.array([1, 0, np.nan, 0, 1, 2, np.nan]))
@@ -149,41 +149,41 @@ class TestFactorize(tm.TestCase):
 
         labels, uniques = algos.factorize(['a', 'b', 'b', 'a', 'a', 'c', 'c',
                                            'c'])
-        self.assert_numpy_array_equal(
+        tm.assert_numpy_array_equal(
             uniques, np.array(['a', 'b', 'c'], dtype=object))
 
         labels, uniques = algos.factorize(['a', 'b', 'b', 'a',
                                            'a', 'c', 'c', 'c'], sort=True)
         exp = np.array([0, 1, 1, 0, 0, 2, 2, 2], dtype=np.intp)
-        self.assert_numpy_array_equal(labels, exp)
+        tm.assert_numpy_array_equal(labels, exp)
         exp = np.array(['a', 'b', 'c'], dtype=object)
-        self.assert_numpy_array_equal(uniques, exp)
+        tm.assert_numpy_array_equal(uniques, exp)
 
         labels, uniques = algos.factorize(list(reversed(range(5))))
         exp = np.array([0, 1, 2, 3, 4], dtype=np.intp)
-        self.assert_numpy_array_equal(labels, exp)
+        tm.assert_numpy_array_equal(labels, exp)
         exp = np.array([4, 3, 2, 1, 0], dtype=np.int64)
-        self.assert_numpy_array_equal(uniques, exp)
+        tm.assert_numpy_array_equal(uniques, exp)
 
         labels, uniques = algos.factorize(list(reversed(range(5))), sort=True)
 
         exp = np.array([4, 3, 2, 1, 0], dtype=np.intp)
-        self.assert_numpy_array_equal(labels, exp)
+        tm.assert_numpy_array_equal(labels, exp)
         exp = np.array([0, 1, 2, 3, 4], dtype=np.int64)
-        self.assert_numpy_array_equal(uniques, exp)
+        tm.assert_numpy_array_equal(uniques, exp)
 
         labels, uniques = algos.factorize(list(reversed(np.arange(5.))))
         exp = np.array([0, 1, 2, 3, 4], dtype=np.intp)
-        self.assert_numpy_array_equal(labels, exp)
+        tm.assert_numpy_array_equal(labels, exp)
         exp = np.array([4., 3., 2., 1., 0.], dtype=np.float64)
-        self.assert_numpy_array_equal(uniques, exp)
+        tm.assert_numpy_array_equal(uniques, exp)
 
         labels, uniques = algos.factorize(list(reversed(np.arange(5.))),
                                           sort=True)
         exp = np.array([4, 3, 2, 1, 0], dtype=np.intp)
-        self.assert_numpy_array_equal(labels, exp)
+        tm.assert_numpy_array_equal(labels, exp)
         exp = np.array([0., 1., 2., 3., 4.], dtype=np.float64)
-        self.assert_numpy_array_equal(uniques, exp)
+        tm.assert_numpy_array_equal(uniques, exp)
 
     def test_mixed(self):
 
@@ -192,13 +192,13 @@ class TestFactorize(tm.TestCase):
         labels, uniques = algos.factorize(x)
 
         exp = np.array([0, 0, -1, 1, 2, 3], dtype=np.intp)
-        self.assert_numpy_array_equal(labels, exp)
+        tm.assert_numpy_array_equal(labels, exp)
         exp = pd.Index(['A', 'B', 3.14, np.inf])
         tm.assert_index_equal(uniques, exp)
 
         labels, uniques = algos.factorize(x, sort=True)
         exp = np.array([2, 2, -1, 3, 0, 1], dtype=np.intp)
-        self.assert_numpy_array_equal(labels, exp)
+        tm.assert_numpy_array_equal(labels, exp)
         exp = pd.Index([3.14, np.inf, 'A', 'B'])
         tm.assert_index_equal(uniques, exp)
 
@@ -211,13 +211,13 @@ class TestFactorize(tm.TestCase):
         labels, uniques = algos.factorize(x)
 
         exp = np.array([0, 0, 0, 1, 1, 0], dtype=np.intp)
-        self.assert_numpy_array_equal(labels, exp)
+        tm.assert_numpy_array_equal(labels, exp)
         exp = DatetimeIndex([v1, v2])
         tm.assert_index_equal(uniques, exp)
 
         labels, uniques = algos.factorize(x, sort=True)
         exp = np.array([1, 1, 1, 0, 0, 1], dtype=np.intp)
-        self.assert_numpy_array_equal(labels, exp)
+        tm.assert_numpy_array_equal(labels, exp)
         exp = DatetimeIndex([v2, v1])
         tm.assert_index_equal(uniques, exp)
 
@@ -229,12 +229,12 @@ class TestFactorize(tm.TestCase):
         # periods are not 'sorted' as they are converted back into an index
         labels, uniques = algos.factorize(x)
         exp = np.array([0, 0, 0, 1, 1, 0], dtype=np.intp)
-        self.assert_numpy_array_equal(labels, exp)
+        tm.assert_numpy_array_equal(labels, exp)
         tm.assert_index_equal(uniques, pd.PeriodIndex([v1, v2]))
 
         labels, uniques = algos.factorize(x, sort=True)
         exp = np.array([0, 0, 0, 1, 1, 0], dtype=np.intp)
-        self.assert_numpy_array_equal(labels, exp)
+        tm.assert_numpy_array_equal(labels, exp)
         tm.assert_index_equal(uniques, pd.PeriodIndex([v1, v2]))
 
         # GH 5986
@@ -243,12 +243,12 @@ class TestFactorize(tm.TestCase):
         x = Series([v1, v2, v1, v1, v2, v2, v1])
         labels, uniques = algos.factorize(x)
         exp = np.array([0, 1, 0, 0, 1, 1, 0], dtype=np.intp)
-        self.assert_numpy_array_equal(labels, exp)
+        tm.assert_numpy_array_equal(labels, exp)
         tm.assert_index_equal(uniques, pd.to_timedelta([v1, v2]))
 
         labels, uniques = algos.factorize(x, sort=True)
         exp = np.array([1, 0, 1, 1, 0, 0, 1], dtype=np.intp)
-        self.assert_numpy_array_equal(labels, exp)
+        tm.assert_numpy_array_equal(labels, exp)
         tm.assert_index_equal(uniques, pd.to_timedelta([v2, v1]))
 
     def test_factorize_nan(self):
@@ -1043,20 +1043,20 @@ class TestHashTable(tm.TestCase):
         xs = np.array([2.718, 3.14, np.nan, -7, 5, 2, 3])
         m = hashtable.Float64HashTable()
         m.map_locations(xs)
-        self.assert_numpy_array_equal(m.lookup(xs),
-                                      np.arange(len(xs), dtype=np.int64))
+        tm.assert_numpy_array_equal(m.lookup(xs), np.arange(len(xs),
+                                                            dtype=np.int64))
 
     def test_lookup_overflow(self):
         xs = np.array([1, 2, 2**63], dtype=np.uint64)
         m = hashtable.UInt64HashTable()
         m.map_locations(xs)
-        self.assert_numpy_array_equal(m.lookup(xs),
-                                      np.arange(len(xs), dtype=np.int64))
+        tm.assert_numpy_array_equal(m.lookup(xs), np.arange(len(xs),
+                                                            dtype=np.int64))
 
     def test_get_unique(self):
         s = Series([1, 2, 2**63, 2**63], dtype=np.uint64)
         exp = np.array([1, 2, 2**63], dtype=np.uint64)
-        self.assert_numpy_array_equal(s.unique(), exp)
+        tm.assert_numpy_array_equal(s.unique(), exp)
 
     def test_vector_resize(self):
         # Test for memory errors after internal vector
@@ -1201,7 +1201,7 @@ class TestTseriesUtil(tm.TestCase):
 
         expect_filler = np.array([0, 0, 1, 1, 1, 1,
                                   2, 2, 2, 2, 2, -1], dtype=np.int64)
-        self.assert_numpy_array_equal(filler, expect_filler)
+        tm.assert_numpy_array_equal(filler, expect_filler)
 
         # corner case
         old = Index([1, 4])
@@ -1209,7 +1209,7 @@ class TestTseriesUtil(tm.TestCase):
         filler = libalgos.backfill_int64(old.values, new.values)
 
         expect_filler = np.array([-1, -1, -1, -1, -1], dtype=np.int64)
-        self.assert_numpy_array_equal(filler, expect_filler)
+        tm.assert_numpy_array_equal(filler, expect_filler)
 
     def test_pad(self):
         old = Index([1, 5, 10])
@@ -1219,14 +1219,14 @@ class TestTseriesUtil(tm.TestCase):
 
         expect_filler = np.array([-1, 0, 0, 0, 0, 1,
                                   1, 1, 1, 1, 2, 2], dtype=np.int64)
-        self.assert_numpy_array_equal(filler, expect_filler)
+        tm.assert_numpy_array_equal(filler, expect_filler)
 
         # corner case
         old = Index([5, 10])
         new = Index(lrange(5))
         filler = libalgos.pad_int64(old.values, new.values)
         expect_filler = np.array([-1, -1, -1, -1, -1], dtype=np.int64)
-        self.assert_numpy_array_equal(filler, expect_filler)
+        tm.assert_numpy_array_equal(filler, expect_filler)
 
 
 def test_is_lexsorted():

--- a/pandas/tests/test_base.py
+++ b/pandas/tests/test_base.py
@@ -215,7 +215,7 @@ class Ops(tm.TestCase):
                     tm.assert_index_equal(result, expected)
                 elif isinstance(result, np.ndarray) and isinstance(expected,
                                                                    np.ndarray):
-                    self.assert_numpy_array_equal(result, expected)
+                    tm.assert_numpy_array_equal(result, expected)
                 else:
                     self.assertEqual(result, expected)
 
@@ -495,7 +495,7 @@ class TestIndexOps(Ops):
                 nanloc = np.zeros(len(o), dtype=np.bool)
                 nanloc[:3] = True
                 if isinstance(o, Index):
-                    self.assert_numpy_array_equal(pd.isnull(o), nanloc)
+                    tm.assert_numpy_array_equal(pd.isnull(o), nanloc)
                 else:
                     exp = pd.Series(nanloc, o.index, name='a')
                     self.assert_series_equal(pd.isnull(o), exp)
@@ -573,8 +573,7 @@ class TestIndexOps(Ops):
             s = klass(s_values)
 
             # bins
-            self.assertRaises(TypeError,
-                              lambda bins: s.value_counts(bins=bins), 1)
+            pytest.raises(TypeError, lambda bins: s.value_counts(bins=bins), 1)
 
             s1 = Series([1, 1, 2, 3])
             res1 = s1.value_counts(bins=1)
@@ -590,7 +589,7 @@ class TestIndexOps(Ops):
                 exp = np.array([1, 2, 3], dtype=np.int64)
                 tm.assert_numpy_array_equal(s1.unique(), exp)
 
-            self.assertEqual(s1.nunique(), 3)
+            assert s1.nunique() == 3
 
             # these return the same
             res4 = s1.value_counts(bins=4, dropna=True)
@@ -621,7 +620,7 @@ class TestIndexOps(Ops):
             else:
                 exp = np.array(['a', 'b', np.nan, 'd'], dtype=object)
                 tm.assert_numpy_array_equal(s.unique(), exp)
-            self.assertEqual(s.nunique(), 3)
+            assert s.nunique() == 3
 
             s = klass({})
             expected = Series([], dtype=np.int64)
@@ -631,10 +630,10 @@ class TestIndexOps(Ops):
             if isinstance(s, Index):
                 tm.assert_index_equal(s.unique(), Index([]), exact=False)
             else:
-                self.assert_numpy_array_equal(s.unique(), np.array([]),
-                                              check_dtype=False)
+                tm.assert_numpy_array_equal(s.unique(), np.array([]),
+                                            check_dtype=False)
 
-            self.assertEqual(s.nunique(), 0)
+            assert s.nunique() == 0
 
     def test_value_counts_datetime64(self):
         klasses = [Index, Series]
@@ -727,7 +726,7 @@ class TestIndexOps(Ops):
                 exp_uniques = o
             labels, uniques = o.factorize()
 
-            self.assert_numpy_array_equal(labels, exp_arr)
+            tm.assert_numpy_array_equal(labels, exp_arr)
             if isinstance(o, Series):
                 tm.assert_index_equal(uniques, Index(orig),
                                       check_names=False)
@@ -757,7 +756,7 @@ class TestIndexOps(Ops):
                                dtype=np.intp)
             labels, uniques = n.factorize(sort=True)
 
-            self.assert_numpy_array_equal(labels, exp_arr)
+            tm.assert_numpy_array_equal(labels, exp_arr)
             if isinstance(o, Series):
                 tm.assert_index_equal(uniques, Index(orig).sort_values(),
                                       check_names=False)
@@ -767,7 +766,7 @@ class TestIndexOps(Ops):
             exp_arr = np.array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3, 4],
                                np.intp)
             labels, uniques = n.factorize(sort=False)
-            self.assert_numpy_array_equal(labels, exp_arr)
+            tm.assert_numpy_array_equal(labels, exp_arr)
 
             if isinstance(o, Series):
                 expected = Index(o.iloc[5:10].append(o.iloc[:5]))

--- a/pandas/tests/test_base.py
+++ b/pandas/tests/test_base.py
@@ -498,7 +498,7 @@ class TestIndexOps(Ops):
                     tm.assert_numpy_array_equal(pd.isnull(o), nanloc)
                 else:
                     exp = pd.Series(nanloc, o.index, name='a')
-                    self.assert_series_equal(pd.isnull(o), exp)
+                    tm.assert_series_equal(pd.isnull(o), exp)
 
                 expected_s_na = Series(list(range(10, 2, -1)) + [3],
                                        index=expected_index[9:0:-1],
@@ -903,7 +903,7 @@ class TestIndexOps(Ops):
             if isinstance(o, Index):
                 tm.assert_index_equal(o, result)
             else:
-                self.assert_series_equal(o, result)
+                tm.assert_series_equal(o, result)
             # check shallow_copied
             self.assertFalse(o is result)
 
@@ -937,7 +937,7 @@ class TestIndexOps(Ops):
                 if isinstance(o, Index):
                     tm.assert_index_equal(result, expected)
                 else:
-                    self.assert_series_equal(result, expected)
+                    tm.assert_series_equal(result, expected)
                 # check shallow_copied
                 self.assertFalse(o is result)
 

--- a/pandas/tests/test_base.py
+++ b/pandas/tests/test_base.py
@@ -427,7 +427,7 @@ class TestIndexOps(Ops):
             result = o.unique()
             if isinstance(o, Index):
                 self.assertTrue(isinstance(result, o.__class__))
-                self.assert_index_equal(result, orig)
+                tm.assert_index_equal(result, orig)
             elif is_datetimetz(o):
                 # datetimetz Series returns array of Timestamp
                 self.assertEqual(result[0], orig[0])
@@ -629,8 +629,7 @@ class TestIndexOps(Ops):
                                    check_index_type=False)
             # returned dtype differs depending on original
             if isinstance(s, Index):
-                self.assert_index_equal(s.unique(), Index([]),
-                                        exact=False)
+                tm.assert_index_equal(s.unique(), Index([]), exact=False)
             else:
                 self.assert_numpy_array_equal(s.unique(), np.array([]),
                                               check_dtype=False)
@@ -730,12 +729,12 @@ class TestIndexOps(Ops):
 
             self.assert_numpy_array_equal(labels, exp_arr)
             if isinstance(o, Series):
-                self.assert_index_equal(uniques, Index(orig),
-                                        check_names=False)
+                tm.assert_index_equal(uniques, Index(orig),
+                                      check_names=False)
             else:
                 # factorize explicitly resets name
-                self.assert_index_equal(uniques, exp_uniques,
-                                        check_names=False)
+                tm.assert_index_equal(uniques, exp_uniques,
+                                      check_names=False)
 
     def test_factorize_repeated(self):
         for orig in self.objs:
@@ -760,10 +759,10 @@ class TestIndexOps(Ops):
 
             self.assert_numpy_array_equal(labels, exp_arr)
             if isinstance(o, Series):
-                self.assert_index_equal(uniques, Index(orig).sort_values(),
-                                        check_names=False)
+                tm.assert_index_equal(uniques, Index(orig).sort_values(),
+                                      check_names=False)
             else:
-                self.assert_index_equal(uniques, o, check_names=False)
+                tm.assert_index_equal(uniques, o, check_names=False)
 
             exp_arr = np.array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3, 4],
                                np.intp)
@@ -772,10 +771,10 @@ class TestIndexOps(Ops):
 
             if isinstance(o, Series):
                 expected = Index(o.iloc[5:10].append(o.iloc[:5]))
-                self.assert_index_equal(uniques, expected, check_names=False)
+                tm.assert_index_equal(uniques, expected, check_names=False)
             else:
                 expected = o[5:10].append(o[:5])
-                self.assert_index_equal(uniques, expected, check_names=False)
+                tm.assert_index_equal(uniques, expected, check_names=False)
 
     def test_duplicated_drop_duplicates_index(self):
         # GH 4060
@@ -903,7 +902,7 @@ class TestIndexOps(Ops):
             # values will not be changed
             result = o.fillna(o.astype(object).values[0])
             if isinstance(o, Index):
-                self.assert_index_equal(o, result)
+                tm.assert_index_equal(o, result)
             else:
                 self.assert_series_equal(o, result)
             # check shallow_copied
@@ -937,7 +936,7 @@ class TestIndexOps(Ops):
 
                 result = o.fillna(fill_value)
                 if isinstance(o, Index):
-                    self.assert_index_equal(result, expected)
+                    tm.assert_index_equal(result, expected)
                 else:
                     self.assert_series_equal(result, expected)
                 # check shallow_copied

--- a/pandas/tests/test_categorical.py
+++ b/pandas/tests/test_categorical.py
@@ -2050,7 +2050,7 @@ class TestCategoricalAsBlock(tm.TestCase):
 
         # sorting
         s.name = 'E'
-        self.assert_series_equal(result2.sort_index(), s.sort_index())
+        tm.assert_series_equal(result2.sort_index(), s.sort_index())
 
         cat = pd.Categorical([1, 2, 3, 10], categories=[1, 2, 3, 4, 10])
         df = pd.DataFrame(pd.Series(cat))
@@ -3104,7 +3104,7 @@ Categories (10, timedelta64[ns]): [0 days 01:00:00 < 1 days 01:00:00 < 2 days 01
 
         res = df.sort_values(by=["sort"], ascending=False)
         exp = df.sort_values(by=["string"], ascending=True)
-        self.assert_series_equal(res["values"], exp["values"])
+        tm.assert_series_equal(res["values"], exp["values"])
         self.assertEqual(res["sort"].dtype, "category")
         self.assertEqual(res["unsort"].dtype, "category")
 
@@ -3762,8 +3762,8 @@ Categories (10, timedelta64[ns]): [0 days 01:00:00 < 1 days 01:00:00 < 2 days 01
         self.assertRaises(TypeError, lambda: "d" < cat)
         self.assertRaises(TypeError, lambda: "d" > cat)
 
-        self.assert_series_equal(cat == "d", Series([False, False, False]))
-        self.assert_series_equal(cat != "d", Series([True, True, True]))
+        tm.assert_series_equal(cat == "d", Series([False, False, False]))
+        tm.assert_series_equal(cat != "d", Series([True, True, True]))
 
         # And test NaN handling...
         cat = Series(Categorical(["a", "b", "c", np.nan]))

--- a/pandas/tests/test_categorical.py
+++ b/pandas/tests/test_categorical.py
@@ -95,7 +95,7 @@ class TestCategorical(tm.TestCase):
         expected = Categorical(['c', 'b', 'b', 'a', 'a', 'c', 'c', 'c'],
                                ordered=True)
 
-        self.assert_categorical_equal(c, expected)
+        tm.assert_categorical_equal(c, expected)
 
     def test_setitem_listlike(self):
 
@@ -130,7 +130,7 @@ class TestCategorical(tm.TestCase):
                                            Interval(2, 3),
                                            Interval(3, 6)])
         exp = Categorical(ii, ordered=True)
-        self.assert_categorical_equal(result, exp)
+        tm.assert_categorical_equal(result, exp)
         tm.assert_index_equal(result.categories, ii)
 
     def test_is_equal_dtype(self):
@@ -955,14 +955,14 @@ Categories (3, object): [ああああ, いいいいい, ううううううう]""
         # first inplace == False
         res = cat.reorder_categories(["c", "b", "a"])
         # cat must be the same as before
-        self.assert_categorical_equal(cat, old)
+        tm.assert_categorical_equal(cat, old)
         # only res is changed
-        self.assert_categorical_equal(res, new)
+        tm.assert_categorical_equal(res, new)
 
         # inplace == True
         res = cat.reorder_categories(["c", "b", "a"], inplace=True)
         self.assertIsNone(res)
-        self.assert_categorical_equal(cat, new)
+        tm.assert_categorical_equal(cat, new)
 
         # not all "old" included in "new"
         cat = Categorical(["a", "b", "c", "a"], ordered=True)
@@ -992,16 +992,16 @@ Categories (3, object): [ああああ, いいいいい, ううううううう]""
 
         # first inplace == False
         res = cat.add_categories("d")
-        self.assert_categorical_equal(cat, old)
-        self.assert_categorical_equal(res, new)
+        tm.assert_categorical_equal(cat, old)
+        tm.assert_categorical_equal(res, new)
 
         res = cat.add_categories(["d"])
-        self.assert_categorical_equal(cat, old)
-        self.assert_categorical_equal(res, new)
+        tm.assert_categorical_equal(cat, old)
+        tm.assert_categorical_equal(res, new)
 
         # inplace == True
         res = cat.add_categories("d", inplace=True)
-        self.assert_categorical_equal(cat, new)
+        tm.assert_categorical_equal(cat, new)
         self.assertIsNone(res)
 
         # new is in old categories
@@ -1016,13 +1016,13 @@ Categories (3, object): [ああああ, いいいいい, ううううううう]""
             list("abc"), categories=list("abcde"), ordered=True)
         # test with Series, np.array, index, list
         res = cat.add_categories(Series(["d", "e"]))
-        self.assert_categorical_equal(res, expected)
+        tm.assert_categorical_equal(res, expected)
         res = cat.add_categories(np.array(["d", "e"]))
-        self.assert_categorical_equal(res, expected)
+        tm.assert_categorical_equal(res, expected)
         res = cat.add_categories(Index(["d", "e"]))
-        self.assert_categorical_equal(res, expected)
+        tm.assert_categorical_equal(res, expected)
         res = cat.add_categories(["d", "e"])
-        self.assert_categorical_equal(res, expected)
+        tm.assert_categorical_equal(res, expected)
 
     def test_remove_categories(self):
         cat = Categorical(["a", "b", "c", "a"], ordered=True)
@@ -1032,16 +1032,16 @@ Categories (3, object): [ああああ, いいいいい, ううううううう]""
 
         # first inplace == False
         res = cat.remove_categories("c")
-        self.assert_categorical_equal(cat, old)
-        self.assert_categorical_equal(res, new)
+        tm.assert_categorical_equal(cat, old)
+        tm.assert_categorical_equal(res, new)
 
         res = cat.remove_categories(["c"])
-        self.assert_categorical_equal(cat, old)
-        self.assert_categorical_equal(res, new)
+        tm.assert_categorical_equal(cat, old)
+        tm.assert_categorical_equal(res, new)
 
         # inplace == True
         res = cat.remove_categories("c", inplace=True)
-        self.assert_categorical_equal(cat, new)
+        tm.assert_categorical_equal(cat, new)
         self.assertIsNone(res)
 
         # removal is not in categories
@@ -1196,7 +1196,7 @@ Categories (3, object): [ああああ, いいいいい, ううううううう]""
         exp = Index(["a", "b"])
         res = cat.unique()
         tm.assert_index_equal(res.categories, exp)
-        self.assert_categorical_equal(res, cat)
+        tm.assert_categorical_equal(res, cat)
 
         cat = Categorical(["a", "b", "a", "a"], categories=["a", "b", "c"])
         res = cat.unique()
@@ -1413,18 +1413,18 @@ Categories (3, object): [ああああ, いいいいい, ううううううう]""
         # shift forward
         sp1 = cat.shift(1)
         xp1 = pd.Categorical([np.nan, 'a', 'b', 'c', 'd'])
-        self.assert_categorical_equal(sp1, xp1)
-        self.assert_categorical_equal(cat[:-1], sp1[1:])
+        tm.assert_categorical_equal(sp1, xp1)
+        tm.assert_categorical_equal(cat[:-1], sp1[1:])
 
         # shift back
         sn2 = cat.shift(-2)
         xp2 = pd.Categorical(['c', 'd', 'a', np.nan, np.nan],
                              categories=['a', 'b', 'c', 'd'])
-        self.assert_categorical_equal(sn2, xp2)
-        self.assert_categorical_equal(cat[2:], sn2[:-2])
+        tm.assert_categorical_equal(sn2, xp2)
+        tm.assert_categorical_equal(cat[2:], sn2[:-2])
 
         # shift by zero
-        self.assert_categorical_equal(cat, cat.shift(0))
+        tm.assert_categorical_equal(cat, cat.shift(0))
 
     def test_nbytes(self):
         cat = pd.Categorical([1, 2, 3])
@@ -2048,7 +2048,7 @@ class TestCategoricalAsBlock(tm.TestCase):
 
         result1 = df['D']
         result2 = df['E']
-        self.assert_categorical_equal(result1._data._block.values, d)
+        tm.assert_categorical_equal(result1._data._block.values, d)
 
         # sorting
         s.name = 'E'
@@ -3981,12 +3981,12 @@ Categories (10, timedelta64[ns]): [0 days 01:00:00 < 1 days 01:00:00 < 2 days 01
         cat = pd.Categorical(["a", "b"], categories=["a", "b"])
         exp = pd.Categorical(["a", "a", "b", "b"], categories=["a", "b"])
         res = cat.repeat(2)
-        self.assert_categorical_equal(res, exp)
+        tm.assert_categorical_equal(res, exp)
 
     def test_numpy_repeat(self):
         cat = pd.Categorical(["a", "b"], categories=["a", "b"])
         exp = pd.Categorical(["a", "a", "b", "b"], categories=["a", "b"])
-        self.assert_categorical_equal(np.repeat(cat, 2), exp)
+        tm.assert_categorical_equal(np.repeat(cat, 2), exp)
 
         msg = "the 'axis' parameter is not supported"
         tm.assertRaisesRegexp(ValueError, msg, np.repeat, cat, 2, axis=1)
@@ -3997,19 +3997,19 @@ Categories (10, timedelta64[ns]): [0 days 01:00:00 < 1 days 01:00:00 < 2 days 01
 
         with tm.assert_produces_warning(FutureWarning):
             cat = pd.Categorical([], categories=["a", "b"])
-            self.assert_categorical_equal(cat.reshape(0), cat)
+            tm.assert_categorical_equal(cat.reshape(0), cat)
 
         with tm.assert_produces_warning(FutureWarning):
             cat = pd.Categorical([], categories=["a", "b"])
-            self.assert_categorical_equal(cat.reshape((5, -1)), cat)
+            tm.assert_categorical_equal(cat.reshape((5, -1)), cat)
 
         with tm.assert_produces_warning(FutureWarning):
             cat = pd.Categorical(["a", "b"], categories=["a", "b"])
-            self.assert_categorical_equal(cat.reshape(cat.shape), cat)
+            tm.assert_categorical_equal(cat.reshape(cat.shape), cat)
 
         with tm.assert_produces_warning(FutureWarning):
             cat = pd.Categorical(["a", "b"], categories=["a", "b"])
-            self.assert_categorical_equal(cat.reshape(cat.size), cat)
+            tm.assert_categorical_equal(cat.reshape(cat.size), cat)
 
         with tm.assert_produces_warning(FutureWarning, check_stacklevel=False):
             msg = "can only specify one unknown dimension"
@@ -4019,7 +4019,7 @@ Categories (10, timedelta64[ns]): [0 days 01:00:00 < 1 days 01:00:00 < 2 days 01
     def test_numpy_reshape(self):
         with tm.assert_produces_warning(FutureWarning, check_stacklevel=False):
             cat = pd.Categorical(["a", "b"], categories=["a", "b"])
-            self.assert_categorical_equal(np.reshape(cat, cat.shape), cat)
+            tm.assert_categorical_equal(np.reshape(cat, cat.shape), cat)
 
         with tm.assert_produces_warning(FutureWarning, check_stacklevel=False):
             msg = "the 'order' parameter is not supported"

--- a/pandas/tests/test_categorical.py
+++ b/pandas/tests/test_categorical.py
@@ -54,7 +54,7 @@ class TestCategorical(tm.TestCase):
         c = Categorical(np.random.randint(0, 5, size=150000).astype(np.int8))
         result = c.codes[np.array([100000]).astype(np.int64)]
         expected = c[np.array([100000]).astype(np.int64)].codes
-        self.assert_numpy_array_equal(result, expected)
+        tm.assert_numpy_array_equal(result, expected)
 
     def test_getitem_category_type(self):
         # GH 14580
@@ -156,11 +156,11 @@ class TestCategorical(tm.TestCase):
 
         exp_arr = np.array(["a", "b", "c", "a", "b", "c"], dtype=np.object_)
         c1 = Categorical(exp_arr)
-        self.assert_numpy_array_equal(c1.__array__(), exp_arr)
+        tm.assert_numpy_array_equal(c1.__array__(), exp_arr)
         c2 = Categorical(exp_arr, categories=["a", "b", "c"])
-        self.assert_numpy_array_equal(c2.__array__(), exp_arr)
+        tm.assert_numpy_array_equal(c2.__array__(), exp_arr)
         c2 = Categorical(exp_arr, categories=["c", "b", "a"])
-        self.assert_numpy_array_equal(c2.__array__(), exp_arr)
+        tm.assert_numpy_array_equal(c2.__array__(), exp_arr)
 
         # categories must be unique
         def f():
@@ -192,7 +192,7 @@ class TestCategorical(tm.TestCase):
 
         c1 = Categorical(["a", "b", "c", "a"], categories=["a", "c", "b"])
         c2 = Categorical(c1, categories=["a", "b", "c"])
-        self.assert_numpy_array_equal(c1.__array__(), c2.__array__())
+        tm.assert_numpy_array_equal(c1.__array__(), c2.__array__())
         tm.assert_index_equal(c2.categories, Index(["a", "b", "c"]))
 
         # Series of dtype category
@@ -346,7 +346,7 @@ class TestCategorical(tm.TestCase):
             expected = type(dtl)(s)
             expected.freq = None
             tm.assert_index_equal(c.categories, expected)
-            self.assert_numpy_array_equal(c.codes, np.arange(5, dtype='int8'))
+            tm.assert_numpy_array_equal(c.codes, np.arange(5, dtype='int8'))
 
             # with NaT
             s2 = s.copy()
@@ -357,7 +357,7 @@ class TestCategorical(tm.TestCase):
             tm.assert_index_equal(c.categories, expected)
 
             exp = np.array([0, 1, 2, 3, -1], dtype=np.int8)
-            self.assert_numpy_array_equal(c.codes, exp)
+            tm.assert_numpy_array_equal(c.codes, exp)
 
             result = repr(c)
             self.assertTrue('NaT' in result)
@@ -490,11 +490,11 @@ class TestCategorical(tm.TestCase):
         other = self.factor[np.random.permutation(n)]
         result = self.factor == other
         expected = np.asarray(self.factor) == np.asarray(other)
-        self.assert_numpy_array_equal(result, expected)
+        tm.assert_numpy_array_equal(result, expected)
 
         result = self.factor == 'd'
         expected = np.repeat(False, len(self.factor))
-        self.assert_numpy_array_equal(result, expected)
+        tm.assert_numpy_array_equal(result, expected)
 
         # comparisons with categoricals
         cat_rev = pd.Categorical(["a", "b", "c"], categories=["c", "b", "a"],
@@ -508,15 +508,15 @@ class TestCategorical(tm.TestCase):
         # comparisons need to take categories ordering into account
         res_rev = cat_rev > cat_rev_base
         exp_rev = np.array([True, False, False])
-        self.assert_numpy_array_equal(res_rev, exp_rev)
+        tm.assert_numpy_array_equal(res_rev, exp_rev)
 
         res_rev = cat_rev < cat_rev_base
         exp_rev = np.array([False, False, True])
-        self.assert_numpy_array_equal(res_rev, exp_rev)
+        tm.assert_numpy_array_equal(res_rev, exp_rev)
 
         res = cat > cat_base
         exp = np.array([False, False, True])
-        self.assert_numpy_array_equal(res, exp)
+        tm.assert_numpy_array_equal(res, exp)
 
         # Only categories with same categories can be compared
         def f():
@@ -566,7 +566,7 @@ class TestCategorical(tm.TestCase):
             list("abc"), categories=list("cba"), ordered=True)
         exp = np.array([True, False, False])
         res = cat_rev > "b"
-        self.assert_numpy_array_equal(res, exp)
+        tm.assert_numpy_array_equal(res, exp)
 
     def test_argsort(self):
         c = Categorical([5, 3, 1, 4, 2], ordered=True)
@@ -608,7 +608,7 @@ class TestCategorical(tm.TestCase):
         cat = Categorical(labels, categories, fastpath=True)
         repr(cat)
 
-        self.assert_numpy_array_equal(isnull(cat), labels == -1)
+        tm.assert_numpy_array_equal(isnull(cat), labels == -1)
 
     def test_categories_none(self):
         factor = Categorical(['a', 'b', 'b', 'a',
@@ -745,7 +745,7 @@ Categories (3, object): [ああああ, いいいいい, ううううううう]""
         str(cat1)
         exp_arr = np.array([0, 0, 1, 1, 2, 2], dtype=np.int8)
         exp_idx = PeriodIndex(['2014-01', '2014-02', '2014-03'], freq='M')
-        self.assert_numpy_array_equal(cat1._codes, exp_arr)
+        tm.assert_numpy_array_equal(cat1._codes, exp_arr)
         tm.assert_index_equal(cat1.categories, exp_idx)
 
         idx2 = PeriodIndex(['2014-03', '2014-03', '2014-02', '2014-01',
@@ -754,7 +754,7 @@ Categories (3, object): [ああああ, いいいいい, ううううううう]""
         str(cat2)
         exp_arr = np.array([2, 2, 1, 0, 2, 0], dtype=np.int8)
         exp_idx2 = PeriodIndex(['2014-01', '2014-02', '2014-03'], freq='M')
-        self.assert_numpy_array_equal(cat2._codes, exp_arr)
+        tm.assert_numpy_array_equal(cat2._codes, exp_arr)
         tm.assert_index_equal(cat2.categories, exp_idx2)
 
         idx3 = PeriodIndex(['2013-12', '2013-11', '2013-10', '2013-09',
@@ -763,14 +763,14 @@ Categories (3, object): [ああああ, いいいいい, ううううううう]""
         exp_arr = np.array([6, 5, 4, 3, 2, 1, 0], dtype=np.int8)
         exp_idx = PeriodIndex(['2013-05', '2013-07', '2013-08', '2013-09',
                                '2013-10', '2013-11', '2013-12'], freq='M')
-        self.assert_numpy_array_equal(cat3._codes, exp_arr)
+        tm.assert_numpy_array_equal(cat3._codes, exp_arr)
         tm.assert_index_equal(cat3.categories, exp_idx)
 
     def test_categories_assigments(self):
         s = pd.Categorical(["a", "b", "c", "a"])
         exp = np.array([1, 2, 3, 1], dtype=np.int64)
         s.categories = [1, 2, 3]
-        self.assert_numpy_array_equal(s.__array__(), exp)
+        tm.assert_numpy_array_equal(s.__array__(), exp)
         tm.assert_index_equal(s.categories, Index([1, 2, 3]))
 
         # lengthen
@@ -847,29 +847,29 @@ Categories (3, object): [ああああ, いいいいい, ううううううう]""
 
         res = cat.set_categories(["c", "b", "a"], inplace=True)
         tm.assert_index_equal(cat.categories, exp_categories)
-        self.assert_numpy_array_equal(cat.__array__(), exp_values)
-        self.assertIsNone(res)
+        tm.assert_numpy_array_equal(cat.__array__(), exp_values)
+        assert res is None
 
         res = cat.set_categories(["a", "b", "c"])
         # cat must be the same as before
         tm.assert_index_equal(cat.categories, exp_categories)
-        self.assert_numpy_array_equal(cat.__array__(), exp_values)
+        tm.assert_numpy_array_equal(cat.__array__(), exp_values)
         # only res is changed
         exp_categories_back = Index(["a", "b", "c"])
         tm.assert_index_equal(res.categories, exp_categories_back)
-        self.assert_numpy_array_equal(res.__array__(), exp_values)
+        tm.assert_numpy_array_equal(res.__array__(), exp_values)
 
         # not all "old" included in "new" -> all not included ones are now
         # np.nan
         cat = Categorical(["a", "b", "c", "a"], ordered=True)
         res = cat.set_categories(["a"])
-        self.assert_numpy_array_equal(res.codes,
-                                      np.array([0, -1, -1, 0], dtype=np.int8))
+        tm.assert_numpy_array_equal(res.codes, np.array([0, -1, -1, 0],
+                                                        dtype=np.int8))
 
         # still not all "old" in "new"
         res = cat.set_categories(["a", "b", "d"])
-        self.assert_numpy_array_equal(res.codes,
-                                      np.array([0, 1, -1, 0], dtype=np.int8))
+        tm.assert_numpy_array_equal(res.codes, np.array([0, 1, -1, 0],
+                                                        dtype=np.int8))
         tm.assert_index_equal(res.categories, Index(["a", "b", "d"]))
 
         # all "old" included in "new"
@@ -879,50 +879,52 @@ Categories (3, object): [ああああ, いいいいい, ううううううう]""
 
         # internals...
         c = Categorical([1, 2, 3, 4, 1], categories=[1, 2, 3, 4], ordered=True)
-        self.assert_numpy_array_equal(c._codes,
-                                      np.array([0, 1, 2, 3, 0], dtype=np.int8))
+        tm.assert_numpy_array_equal(c._codes, np.array([0, 1, 2, 3, 0],
+                                                       dtype=np.int8))
         tm.assert_index_equal(c.categories, Index([1, 2, 3, 4]))
 
         exp = np.array([1, 2, 3, 4, 1], dtype=np.int64)
-        self.assert_numpy_array_equal(c.get_values(), exp)
+        tm.assert_numpy_array_equal(c.get_values(), exp)
 
         # all "pointers" to '4' must be changed from 3 to 0,...
         c = c.set_categories([4, 3, 2, 1])
 
         # positions are changed
-        self.assert_numpy_array_equal(c._codes,
-                                      np.array([3, 2, 1, 0, 3], dtype=np.int8))
+        tm.assert_numpy_array_equal(c._codes, np.array([3, 2, 1, 0, 3],
+                                                       dtype=np.int8))
 
         # categories are now in new order
         tm.assert_index_equal(c.categories, Index([4, 3, 2, 1]))
 
         # output is the same
         exp = np.array([1, 2, 3, 4, 1], dtype=np.int64)
-        self.assert_numpy_array_equal(c.get_values(), exp)
-        self.assertTrue(c.min(), 4)
-        self.assertTrue(c.max(), 1)
+        tm.assert_numpy_array_equal(c.get_values(), exp)
+        assert c.min() == 4
+        assert c.max() == 1
 
         # set_categories should set the ordering if specified
         c2 = c.set_categories([4, 3, 2, 1], ordered=False)
-        self.assertFalse(c2.ordered)
-        self.assert_numpy_array_equal(c.get_values(), c2.get_values())
+        assert not c2.ordered
+
+        tm.assert_numpy_array_equal(c.get_values(), c2.get_values())
 
         # set_categories should pass thru the ordering
         c2 = c.set_ordered(False).set_categories([4, 3, 2, 1])
-        self.assertFalse(c2.ordered)
-        self.assert_numpy_array_equal(c.get_values(), c2.get_values())
+        assert not c2.ordered
+
+        tm.assert_numpy_array_equal(c.get_values(), c2.get_values())
 
     def test_rename_categories(self):
         cat = pd.Categorical(["a", "b", "c", "a"])
 
         # inplace=False: the old one must not be changed
         res = cat.rename_categories([1, 2, 3])
-        self.assert_numpy_array_equal(res.__array__(),
-                                      np.array([1, 2, 3, 1], dtype=np.int64))
+        tm.assert_numpy_array_equal(res.__array__(), np.array([1, 2, 3, 1],
+                                                              dtype=np.int64))
         tm.assert_index_equal(res.categories, Index([1, 2, 3]))
 
         exp_cat = np.array(["a", "b", "c", "a"], dtype=np.object_)
-        self.assert_numpy_array_equal(cat.__array__(), exp_cat)
+        tm.assert_numpy_array_equal(cat.__array__(), exp_cat)
 
         exp_cat = Index(["a", "b", "c"])
         tm.assert_index_equal(cat.categories, exp_cat)
@@ -930,21 +932,17 @@ Categories (3, object): [ああああ, いいいいい, ううううううう]""
 
         # and now inplace
         self.assertIsNone(res)
-        self.assert_numpy_array_equal(cat.__array__(),
-                                      np.array([1, 2, 3, 1], dtype=np.int64))
+        tm.assert_numpy_array_equal(cat.__array__(), np.array([1, 2, 3, 1],
+                                                              dtype=np.int64))
         tm.assert_index_equal(cat.categories, Index([1, 2, 3]))
 
-        # lengthen
-        def f():
+        # Lengthen
+        with pytest.raises(ValueError):
             cat.rename_categories([1, 2, 3, 4])
 
-        self.assertRaises(ValueError, f)
-
-        # shorten
-        def f():
+        # Shorten
+        with pytest.raises(ValueError):
             cat.rename_categories([1, 2])
-
-        self.assertRaises(ValueError, f)
 
     def test_reorder_categories(self):
         cat = Categorical(["a", "b", "c", "a"], ordered=True)
@@ -1073,7 +1071,7 @@ Categories (3, object): [ああああ, いいいいい, ううううううう]""
         tm.assert_index_equal(res.categories,
                               Index(np.array(["a", "b", "c"])))
         exp_codes = np.array([0, 1, 2, -1], dtype=np.int8)
-        self.assert_numpy_array_equal(res.codes, exp_codes)
+        tm.assert_numpy_array_equal(res.codes, exp_codes)
         tm.assert_index_equal(c.categories, exp_categories_all)
 
         val = ['F', np.nan, 'D', 'B', 'D', 'F', np.nan]
@@ -1081,7 +1079,7 @@ Categories (3, object): [ああああ, いいいいい, ううううううう]""
         out = cat.remove_unused_categories()
         tm.assert_index_equal(out.categories, Index(['B', 'D', 'F']))
         exp_codes = np.array([2, -1, 1, 0, 1, 2, -1], dtype=np.int8)
-        self.assert_numpy_array_equal(out.codes, exp_codes)
+        tm.assert_numpy_array_equal(out.codes, exp_codes)
         self.assertEqual(out.get_values().tolist(), val)
 
         alpha = list('abcdefghijklmnopqrstuvwxyz')
@@ -1097,33 +1095,33 @@ Categories (3, object): [ああああ, いいいいい, ううううううう]""
         # Nans are represented as -1 in codes
         c = Categorical(["a", "b", np.nan, "a"])
         tm.assert_index_equal(c.categories, Index(["a", "b"]))
-        self.assert_numpy_array_equal(c._codes,
-                                      np.array([0, 1, -1, 0], dtype=np.int8))
+        tm.assert_numpy_array_equal(c._codes, np.array([0, 1, -1, 0],
+                                                       dtype=np.int8))
         c[1] = np.nan
         tm.assert_index_equal(c.categories, Index(["a", "b"]))
-        self.assert_numpy_array_equal(c._codes,
-                                      np.array([0, -1, -1, 0], dtype=np.int8))
+        tm.assert_numpy_array_equal(c._codes, np.array([0, -1, -1, 0],
+                                                       dtype=np.int8))
 
         # Adding nan to categories should make assigned nan point to the
         # category!
         c = Categorical(["a", "b", np.nan, "a"])
         tm.assert_index_equal(c.categories, Index(["a", "b"]))
-        self.assert_numpy_array_equal(c._codes,
-                                      np.array([0, 1, -1, 0], dtype=np.int8))
+        tm.assert_numpy_array_equal(c._codes, np.array([0, 1, -1, 0],
+                                                       dtype=np.int8))
 
     def test_isnull(self):
         exp = np.array([False, False, True])
         c = Categorical(["a", "b", np.nan])
         res = c.isnull()
 
-        self.assert_numpy_array_equal(res, exp)
+        tm.assert_numpy_array_equal(res, exp)
 
     def test_codes_immutable(self):
 
         # Codes should be read only
         c = Categorical(["a", "b", "c", "a", np.nan])
         exp = np.array([0, 1, 2, 0, -1], dtype='int8')
-        self.assert_numpy_array_equal(c.codes, exp)
+        tm.assert_numpy_array_equal(c.codes, exp)
 
         # Assignments to codes should raise
         def f():
@@ -1144,10 +1142,10 @@ Categories (3, object): [ああああ, いいいいい, ううううううう]""
         # writeable!
         c[4] = "a"
         exp = np.array([0, 1, 2, 0, 0], dtype='int8')
-        self.assert_numpy_array_equal(c.codes, exp)
+        tm.assert_numpy_array_equal(c.codes, exp)
         c._codes[4] = 2
         exp = np.array([0, 1, 2, 0, 2], dtype='int8')
-        self.assert_numpy_array_equal(c.codes, exp)
+        tm.assert_numpy_array_equal(c.codes, exp)
 
     def test_min_max(self):
 
@@ -1316,26 +1314,26 @@ Categories (3, object): [ああああ, いいいいい, ううううううう]""
         # sort_values
         res = cat.sort_values()
         exp = np.array(["a", "b", "c", "d"], dtype=object)
-        self.assert_numpy_array_equal(res.__array__(), exp)
+        tm.assert_numpy_array_equal(res.__array__(), exp)
         tm.assert_index_equal(res.categories, cat.categories)
 
         cat = Categorical(["a", "c", "b", "d"],
                           categories=["a", "b", "c", "d"], ordered=True)
         res = cat.sort_values()
         exp = np.array(["a", "b", "c", "d"], dtype=object)
-        self.assert_numpy_array_equal(res.__array__(), exp)
+        tm.assert_numpy_array_equal(res.__array__(), exp)
         tm.assert_index_equal(res.categories, cat.categories)
 
         res = cat.sort_values(ascending=False)
         exp = np.array(["d", "c", "b", "a"], dtype=object)
-        self.assert_numpy_array_equal(res.__array__(), exp)
+        tm.assert_numpy_array_equal(res.__array__(), exp)
         tm.assert_index_equal(res.categories, cat.categories)
 
         # sort (inplace order)
         cat1 = cat.copy()
         cat1.sort_values(inplace=True)
         exp = np.array(["a", "b", "c", "d"], dtype=object)
-        self.assert_numpy_array_equal(cat1.__array__(), exp)
+        tm.assert_numpy_array_equal(cat1.__array__(), exp)
         tm.assert_index_equal(res.categories, cat.categories)
 
         # reverse
@@ -1343,7 +1341,7 @@ Categories (3, object): [ああああ, いいいいい, ううううううう]""
         res = cat.sort_values(ascending=False)
         exp_val = np.array(["d", "c", "c", "b", "a"], dtype=object)
         exp_categories = Index(["a", "b", "c", "d"])
-        self.assert_numpy_array_equal(res.__array__(), exp_val)
+        tm.assert_numpy_array_equal(res.__array__(), exp_val)
         tm.assert_index_equal(res.categories, exp_categories)
 
     def test_sort_values_na_position(self):
@@ -1353,41 +1351,41 @@ Categories (3, object): [ああああ, いいいいい, ううううううう]""
 
         exp = np.array([2.0, 2.0, 5.0, np.nan, np.nan])
         res = cat.sort_values()  # default arguments
-        self.assert_numpy_array_equal(res.__array__(), exp)
+        tm.assert_numpy_array_equal(res.__array__(), exp)
         tm.assert_index_equal(res.categories, exp_categories)
 
         exp = np.array([np.nan, np.nan, 2.0, 2.0, 5.0])
         res = cat.sort_values(ascending=True, na_position='first')
-        self.assert_numpy_array_equal(res.__array__(), exp)
+        tm.assert_numpy_array_equal(res.__array__(), exp)
         tm.assert_index_equal(res.categories, exp_categories)
 
         exp = np.array([np.nan, np.nan, 5.0, 2.0, 2.0])
         res = cat.sort_values(ascending=False, na_position='first')
-        self.assert_numpy_array_equal(res.__array__(), exp)
+        tm.assert_numpy_array_equal(res.__array__(), exp)
         tm.assert_index_equal(res.categories, exp_categories)
 
         exp = np.array([2.0, 2.0, 5.0, np.nan, np.nan])
         res = cat.sort_values(ascending=True, na_position='last')
-        self.assert_numpy_array_equal(res.__array__(), exp)
+        tm.assert_numpy_array_equal(res.__array__(), exp)
         tm.assert_index_equal(res.categories, exp_categories)
 
         exp = np.array([5.0, 2.0, 2.0, np.nan, np.nan])
         res = cat.sort_values(ascending=False, na_position='last')
-        self.assert_numpy_array_equal(res.__array__(), exp)
+        tm.assert_numpy_array_equal(res.__array__(), exp)
         tm.assert_index_equal(res.categories, exp_categories)
 
         cat = Categorical(["a", "c", "b", "d", np.nan], ordered=True)
         res = cat.sort_values(ascending=False, na_position='last')
         exp_val = np.array(["d", "c", "b", "a", np.nan], dtype=object)
         exp_categories = Index(["a", "b", "c", "d"])
-        self.assert_numpy_array_equal(res.__array__(), exp_val)
+        tm.assert_numpy_array_equal(res.__array__(), exp_val)
         tm.assert_index_equal(res.categories, exp_categories)
 
         cat = Categorical(["a", "c", "b", "d", np.nan], ordered=True)
         res = cat.sort_values(ascending=False, na_position='first')
         exp_val = np.array([np.nan, "d", "c", "b", "a"], dtype=object)
         exp_categories = Index(["a", "b", "c", "d"])
-        self.assert_numpy_array_equal(res.__array__(), exp_val)
+        tm.assert_numpy_array_equal(res.__array__(), exp_val)
         tm.assert_index_equal(res.categories, exp_categories)
 
     def test_slicing_directly(self):
@@ -1396,7 +1394,7 @@ Categories (3, object): [ああああ, いいいいい, ううううううう]""
         self.assertEqual(sliced, "d")
         sliced = cat[3:5]
         expected = Categorical(["d", "a"], categories=['a', 'b', 'c', 'd'])
-        self.assert_numpy_array_equal(sliced._codes, expected._codes)
+        tm.assert_numpy_array_equal(sliced._codes, expected._codes)
         tm.assert_index_equal(sliced.categories, expected.categories)
 
     def test_set_item_nan(self):
@@ -1464,22 +1462,22 @@ Categories (3, object): [ああああ, いいいいい, ううううううう]""
         res_cat = c1.searchsorted('apple')
         res_ser = s1.searchsorted('apple')
         exp = np.array([2], dtype=np.intp)
-        self.assert_numpy_array_equal(res_cat, exp)
-        self.assert_numpy_array_equal(res_ser, exp)
+        tm.assert_numpy_array_equal(res_cat, exp)
+        tm.assert_numpy_array_equal(res_ser, exp)
 
         # Searching for single item array, side='left' (default)
         res_cat = c1.searchsorted(['bread'])
         res_ser = s1.searchsorted(['bread'])
         exp = np.array([3], dtype=np.intp)
-        self.assert_numpy_array_equal(res_cat, exp)
-        self.assert_numpy_array_equal(res_ser, exp)
+        tm.assert_numpy_array_equal(res_cat, exp)
+        tm.assert_numpy_array_equal(res_ser, exp)
 
         # Searching for several items array, side='right'
         res_cat = c1.searchsorted(['apple', 'bread'], side='right')
         res_ser = s1.searchsorted(['apple', 'bread'], side='right')
         exp = np.array([3, 5], dtype=np.intp)
-        self.assert_numpy_array_equal(res_cat, exp)
-        self.assert_numpy_array_equal(res_ser, exp)
+        tm.assert_numpy_array_equal(res_cat, exp)
+        tm.assert_numpy_array_equal(res_ser, exp)
 
         # Searching for a single value that is not from the Categorical
         self.assertRaises(ValueError, lambda: c1.searchsorted('cucumber'))
@@ -1507,7 +1505,7 @@ Categories (3, object): [ああああ, いいいいい, ううううううう]""
         exp = cat.codes
         with tm.assert_produces_warning(FutureWarning):
             res = cat.labels
-        self.assert_numpy_array_equal(res, exp)
+        tm.assert_numpy_array_equal(res, exp)
 
     def test_deprecated_from_array(self):
         # GH13854, `.from_array` is deprecated
@@ -1517,18 +1515,18 @@ Categories (3, object): [ああああ, いいいいい, ううううううう]""
     def test_datetime_categorical_comparison(self):
         dt_cat = pd.Categorical(
             pd.date_range('2014-01-01', periods=3), ordered=True)
-        self.assert_numpy_array_equal(dt_cat > dt_cat[0],
-                                      np.array([False, True, True]))
-        self.assert_numpy_array_equal(dt_cat[0] < dt_cat,
-                                      np.array([False, True, True]))
+        tm.assert_numpy_array_equal(dt_cat > dt_cat[0],
+                                    np.array([False, True, True]))
+        tm.assert_numpy_array_equal(dt_cat[0] < dt_cat,
+                                    np.array([False, True, True]))
 
     def test_reflected_comparison_with_scalars(self):
         # GH8658
         cat = pd.Categorical([1, 2, 3], ordered=True)
-        self.assert_numpy_array_equal(cat > cat[0],
-                                      np.array([False, True, True]))
-        self.assert_numpy_array_equal(cat[0] < cat,
-                                      np.array([False, True, True]))
+        tm.assert_numpy_array_equal(cat > cat[0],
+                                    np.array([False, True, True]))
+        tm.assert_numpy_array_equal(cat[0] < cat,
+                                    np.array([False, True, True]))
 
     def test_comparison_with_unknown_scalars(self):
         # https://github.com/pandas-dev/pandas/issues/9836#issuecomment-92123057
@@ -1536,15 +1534,15 @@ Categories (3, object): [ああああ, いいいいい, ううううううう]""
         # for unequal comps, but not for equal/not equal
         cat = pd.Categorical([1, 2, 3], ordered=True)
 
-        self.assertRaises(TypeError, lambda: cat < 4)
-        self.assertRaises(TypeError, lambda: cat > 4)
-        self.assertRaises(TypeError, lambda: 4 < cat)
-        self.assertRaises(TypeError, lambda: 4 > cat)
+        pytest.raises(TypeError, lambda: cat < 4)
+        pytest.raises(TypeError, lambda: cat > 4)
+        pytest.raises(TypeError, lambda: 4 < cat)
+        pytest.raises(TypeError, lambda: 4 > cat)
 
-        self.assert_numpy_array_equal(cat == 4,
-                                      np.array([False, False, False]))
-        self.assert_numpy_array_equal(cat != 4,
-                                      np.array([True, True, True]))
+        tm.assert_numpy_array_equal(cat == 4,
+                                    np.array([False, False, False]))
+        tm.assert_numpy_array_equal(cat != 4,
+                                    np.array([True, True, True]))
 
     def test_map(self):
         c = pd.Categorical(list('ABABC'), categories=list('CBA'),
@@ -1882,14 +1880,14 @@ class TestCategoricalAsBlock(tm.TestCase):
         s.cat.categories = [1, 2, 3]
         exp_s = np.array([1, 2, 3, 1], dtype=np.int64)
         exp_cat = np.array(["a", "b", "c", "a"], dtype=np.object_)
-        self.assert_numpy_array_equal(s.__array__(), exp_s)
-        self.assert_numpy_array_equal(cat.__array__(), exp_cat)
+        tm.assert_numpy_array_equal(s.__array__(), exp_s)
+        tm.assert_numpy_array_equal(cat.__array__(), exp_cat)
 
         # setting
         s[0] = 2
         exp_s2 = np.array([2, 2, 3, 1], dtype=np.int64)
-        self.assert_numpy_array_equal(s.__array__(), exp_s2)
-        self.assert_numpy_array_equal(cat.__array__(), exp_cat)
+        tm.assert_numpy_array_equal(s.__array__(), exp_s2)
+        tm.assert_numpy_array_equal(cat.__array__(), exp_cat)
 
         # however, copy is False by default
         # so this WILL change values
@@ -1898,26 +1896,27 @@ class TestCategoricalAsBlock(tm.TestCase):
         self.assertTrue(s.values is cat)
         s.cat.categories = [1, 2, 3]
         exp_s = np.array([1, 2, 3, 1], dtype=np.int64)
-        self.assert_numpy_array_equal(s.__array__(), exp_s)
-        self.assert_numpy_array_equal(cat.__array__(), exp_s)
+        tm.assert_numpy_array_equal(s.__array__(), exp_s)
+        tm.assert_numpy_array_equal(cat.__array__(), exp_s)
 
         s[0] = 2
         exp_s2 = np.array([2, 2, 3, 1], dtype=np.int64)
-        self.assert_numpy_array_equal(s.__array__(), exp_s2)
-        self.assert_numpy_array_equal(cat.__array__(), exp_s2)
+        tm.assert_numpy_array_equal(s.__array__(), exp_s2)
+        tm.assert_numpy_array_equal(cat.__array__(), exp_s2)
 
     def test_nan_handling(self):
 
         # NaNs are represented as -1 in labels
         s = Series(Categorical(["a", "b", np.nan, "a"]))
         tm.assert_index_equal(s.cat.categories, Index(["a", "b"]))
-        self.assert_numpy_array_equal(s.values.codes,
-                                      np.array([0, 1, -1, 0], dtype=np.int8))
+        tm.assert_numpy_array_equal(s.values.codes,
+                                    np.array([0, 1, -1, 0], dtype=np.int8))
 
     def test_cat_accessor(self):
         s = Series(Categorical(["a", "b", np.nan, "a"]))
         tm.assert_index_equal(s.cat.categories, Index(["a", "b"]))
-        self.assertEqual(s.cat.ordered, False)
+        assert not s.cat.ordered, False
+
         exp = Categorical(["a", "b", np.nan, "a"], categories=["b", "a"])
         s.cat.set_categories(["b", "a"], inplace=True)
         tm.assert_categorical_equal(s.values, exp)
@@ -1925,7 +1924,6 @@ class TestCategoricalAsBlock(tm.TestCase):
         res = s.cat.set_categories(["b", "a"])
         tm.assert_categorical_equal(res.values, exp)
 
-        exp = Categorical(["a", "b", np.nan, "a"], categories=["b", "a"])
         s[:] = "a"
         s = s.cat.remove_unused_categories()
         tm.assert_index_equal(s.cat.categories, Index(["a"]))
@@ -1991,8 +1989,8 @@ class TestCategoricalAsBlock(tm.TestCase):
         exp_values = np.array(["a", "b", "c", "a"], dtype=np.object_)
         s = s.cat.set_categories(["c", "b", "a"])
         tm.assert_index_equal(s.cat.categories, exp_categories)
-        self.assert_numpy_array_equal(s.values.__array__(), exp_values)
-        self.assert_numpy_array_equal(s.__array__(), exp_values)
+        tm.assert_numpy_array_equal(s.values.__array__(), exp_values)
+        tm.assert_numpy_array_equal(s.__array__(), exp_values)
 
         # remove unused categories
         s = Series(Categorical(["a", "b", "b", "a"], categories=["a", "b", "c"
@@ -2001,8 +1999,8 @@ class TestCategoricalAsBlock(tm.TestCase):
         exp_values = np.array(["a", "b", "b", "a"], dtype=np.object_)
         s = s.cat.remove_unused_categories()
         tm.assert_index_equal(s.cat.categories, exp_categories)
-        self.assert_numpy_array_equal(s.values.__array__(), exp_values)
-        self.assert_numpy_array_equal(s.__array__(), exp_values)
+        tm.assert_numpy_array_equal(s.values.__array__(), exp_values)
+        tm.assert_numpy_array_equal(s.__array__(), exp_values)
 
         # This method is likely to be confused, so test that it raises an error
         # on wrong inputs:
@@ -2077,7 +2075,7 @@ class TestCategoricalAsBlock(tm.TestCase):
         cat = pd.Series(pd.Categorical(["a", "b", "c", "c"]))
         df3 = pd.DataFrame({"cat": cat, "s": ["a", "b", "c", "c"]})
         res = df3.describe()
-        self.assert_numpy_array_equal(res["cat"].values, res["s"].values)
+        tm.assert_numpy_array_equal(res["cat"].values, res["s"].values)
 
     def test_repr(self):
         a = pd.Series(pd.Categorical([1, 2, 3, 4]))
@@ -3076,17 +3074,17 @@ Categories (10, timedelta64[ns]): [0 days 01:00:00 < 1 days 01:00:00 < 2 days 01
         cat = Series(Categorical(["a", "c", "b", "d"], ordered=True))
         res = cat.sort_values()
         exp = np.array(["a", "b", "c", "d"], dtype=np.object_)
-        self.assert_numpy_array_equal(res.__array__(), exp)
+        tm.assert_numpy_array_equal(res.__array__(), exp)
 
         cat = Series(Categorical(["a", "c", "b", "d"], categories=[
                      "a", "b", "c", "d"], ordered=True))
         res = cat.sort_values()
         exp = np.array(["a", "b", "c", "d"], dtype=np.object_)
-        self.assert_numpy_array_equal(res.__array__(), exp)
+        tm.assert_numpy_array_equal(res.__array__(), exp)
 
         res = cat.sort_values(ascending=False)
         exp = np.array(["d", "c", "b", "a"], dtype=np.object_)
-        self.assert_numpy_array_equal(res.__array__(), exp)
+        tm.assert_numpy_array_equal(res.__array__(), exp)
 
         raw_cat1 = Categorical(["a", "b", "c", "d"],
                                categories=["a", "b", "c", "d"], ordered=False)
@@ -3101,7 +3099,7 @@ Categories (10, timedelta64[ns]): [0 days 01:00:00 < 1 days 01:00:00 < 2 days 01
         # Cats must be sorted in a dataframe
         res = df.sort_values(by=["string"], ascending=False)
         exp = np.array(["d", "c", "b", "a"], dtype=np.object_)
-        self.assert_numpy_array_equal(res["sort"].values.__array__(), exp)
+        tm.assert_numpy_array_equal(res["sort"].values.__array__(), exp)
         self.assertEqual(res["sort"].dtype, "category")
 
         res = df.sort_values(by=["sort"], ascending=False)
@@ -3134,7 +3132,7 @@ Categories (10, timedelta64[ns]): [0 days 01:00:00 < 1 days 01:00:00 < 2 days 01
         cat = Series(Categorical([1, 2, 3, 4]))
         reversed = cat[::-1]
         exp = np.array([4, 3, 2, 1], dtype=np.int64)
-        self.assert_numpy_array_equal(reversed.__array__(), exp)
+        tm.assert_numpy_array_equal(reversed.__array__(), exp)
 
         df = DataFrame({'value': (np.arange(100) + 1).astype('int64')})
         df['D'] = pd.cut(df.value, bins=[0, 25, 50, 75, 100])

--- a/pandas/tests/test_categorical.py
+++ b/pandas/tests/test_categorical.py
@@ -193,7 +193,7 @@ class TestCategorical(tm.TestCase):
         c1 = Categorical(["a", "b", "c", "a"], categories=["a", "c", "b"])
         c2 = Categorical(c1, categories=["a", "b", "c"])
         self.assert_numpy_array_equal(c1.__array__(), c2.__array__())
-        self.assert_index_equal(c2.categories, Index(["a", "b", "c"]))
+        tm.assert_index_equal(c2.categories, Index(["a", "b", "c"]))
 
         # Series of dtype category
         c1 = Categorical(["a", "b", "c", "a"], categories=["a", "b", "c", "d"])
@@ -746,7 +746,7 @@ Categories (3, object): [ああああ, いいいいい, ううううううう]""
         exp_arr = np.array([0, 0, 1, 1, 2, 2], dtype=np.int8)
         exp_idx = PeriodIndex(['2014-01', '2014-02', '2014-03'], freq='M')
         self.assert_numpy_array_equal(cat1._codes, exp_arr)
-        self.assert_index_equal(cat1.categories, exp_idx)
+        tm.assert_index_equal(cat1.categories, exp_idx)
 
         idx2 = PeriodIndex(['2014-03', '2014-03', '2014-02', '2014-01',
                             '2014-03', '2014-01'], freq='M')
@@ -755,7 +755,7 @@ Categories (3, object): [ああああ, いいいいい, ううううううう]""
         exp_arr = np.array([2, 2, 1, 0, 2, 0], dtype=np.int8)
         exp_idx2 = PeriodIndex(['2014-01', '2014-02', '2014-03'], freq='M')
         self.assert_numpy_array_equal(cat2._codes, exp_arr)
-        self.assert_index_equal(cat2.categories, exp_idx2)
+        tm.assert_index_equal(cat2.categories, exp_idx2)
 
         idx3 = PeriodIndex(['2013-12', '2013-11', '2013-10', '2013-09',
                             '2013-08', '2013-07', '2013-05'], freq='M')
@@ -764,14 +764,14 @@ Categories (3, object): [ああああ, いいいいい, ううううううう]""
         exp_idx = PeriodIndex(['2013-05', '2013-07', '2013-08', '2013-09',
                                '2013-10', '2013-11', '2013-12'], freq='M')
         self.assert_numpy_array_equal(cat3._codes, exp_arr)
-        self.assert_index_equal(cat3.categories, exp_idx)
+        tm.assert_index_equal(cat3.categories, exp_idx)
 
     def test_categories_assigments(self):
         s = pd.Categorical(["a", "b", "c", "a"])
         exp = np.array([1, 2, 3, 1], dtype=np.int64)
         s.categories = [1, 2, 3]
         self.assert_numpy_array_equal(s.__array__(), exp)
-        self.assert_index_equal(s.categories, Index([1, 2, 3]))
+        tm.assert_index_equal(s.categories, Index([1, 2, 3]))
 
         # lengthen
         def f():
@@ -797,21 +797,21 @@ Categories (3, object): [ああああ, いいいいい, ううううううう]""
     def test_ordered_api(self):
         # GH 9347
         cat1 = pd.Categorical(["a", "c", "b"], ordered=False)
-        self.assert_index_equal(cat1.categories, Index(['a', 'b', 'c']))
+        tm.assert_index_equal(cat1.categories, Index(['a', 'b', 'c']))
         self.assertFalse(cat1.ordered)
 
         cat2 = pd.Categorical(["a", "c", "b"], categories=['b', 'c', 'a'],
                               ordered=False)
-        self.assert_index_equal(cat2.categories, Index(['b', 'c', 'a']))
+        tm.assert_index_equal(cat2.categories, Index(['b', 'c', 'a']))
         self.assertFalse(cat2.ordered)
 
         cat3 = pd.Categorical(["a", "c", "b"], ordered=True)
-        self.assert_index_equal(cat3.categories, Index(['a', 'b', 'c']))
+        tm.assert_index_equal(cat3.categories, Index(['a', 'b', 'c']))
         self.assertTrue(cat3.ordered)
 
         cat4 = pd.Categorical(["a", "c", "b"], categories=['b', 'c', 'a'],
                               ordered=True)
-        self.assert_index_equal(cat4.categories, Index(['b', 'c', 'a']))
+        tm.assert_index_equal(cat4.categories, Index(['b', 'c', 'a']))
         self.assertTrue(cat4.ordered)
 
     def test_set_ordered(self):
@@ -846,17 +846,17 @@ Categories (3, object): [ああああ, いいいいい, ううううううう]""
         exp_values = np.array(["a", "b", "c", "a"], dtype=np.object_)
 
         res = cat.set_categories(["c", "b", "a"], inplace=True)
-        self.assert_index_equal(cat.categories, exp_categories)
+        tm.assert_index_equal(cat.categories, exp_categories)
         self.assert_numpy_array_equal(cat.__array__(), exp_values)
         self.assertIsNone(res)
 
         res = cat.set_categories(["a", "b", "c"])
         # cat must be the same as before
-        self.assert_index_equal(cat.categories, exp_categories)
+        tm.assert_index_equal(cat.categories, exp_categories)
         self.assert_numpy_array_equal(cat.__array__(), exp_values)
         # only res is changed
         exp_categories_back = Index(["a", "b", "c"])
-        self.assert_index_equal(res.categories, exp_categories_back)
+        tm.assert_index_equal(res.categories, exp_categories_back)
         self.assert_numpy_array_equal(res.__array__(), exp_values)
 
         # not all "old" included in "new" -> all not included ones are now
@@ -870,18 +870,18 @@ Categories (3, object): [ああああ, いいいいい, ううううううう]""
         res = cat.set_categories(["a", "b", "d"])
         self.assert_numpy_array_equal(res.codes,
                                       np.array([0, 1, -1, 0], dtype=np.int8))
-        self.assert_index_equal(res.categories, Index(["a", "b", "d"]))
+        tm.assert_index_equal(res.categories, Index(["a", "b", "d"]))
 
         # all "old" included in "new"
         cat = cat.set_categories(["a", "b", "c", "d"])
         exp_categories = Index(["a", "b", "c", "d"])
-        self.assert_index_equal(cat.categories, exp_categories)
+        tm.assert_index_equal(cat.categories, exp_categories)
 
         # internals...
         c = Categorical([1, 2, 3, 4, 1], categories=[1, 2, 3, 4], ordered=True)
         self.assert_numpy_array_equal(c._codes,
                                       np.array([0, 1, 2, 3, 0], dtype=np.int8))
-        self.assert_index_equal(c.categories, Index([1, 2, 3, 4]))
+        tm.assert_index_equal(c.categories, Index([1, 2, 3, 4]))
 
         exp = np.array([1, 2, 3, 4, 1], dtype=np.int64)
         self.assert_numpy_array_equal(c.get_values(), exp)
@@ -894,7 +894,7 @@ Categories (3, object): [ああああ, いいいいい, ううううううう]""
                                       np.array([3, 2, 1, 0, 3], dtype=np.int8))
 
         # categories are now in new order
-        self.assert_index_equal(c.categories, Index([4, 3, 2, 1]))
+        tm.assert_index_equal(c.categories, Index([4, 3, 2, 1]))
 
         # output is the same
         exp = np.array([1, 2, 3, 4, 1], dtype=np.int64)
@@ -919,20 +919,20 @@ Categories (3, object): [ああああ, いいいいい, ううううううう]""
         res = cat.rename_categories([1, 2, 3])
         self.assert_numpy_array_equal(res.__array__(),
                                       np.array([1, 2, 3, 1], dtype=np.int64))
-        self.assert_index_equal(res.categories, Index([1, 2, 3]))
+        tm.assert_index_equal(res.categories, Index([1, 2, 3]))
 
         exp_cat = np.array(["a", "b", "c", "a"], dtype=np.object_)
         self.assert_numpy_array_equal(cat.__array__(), exp_cat)
 
         exp_cat = Index(["a", "b", "c"])
-        self.assert_index_equal(cat.categories, exp_cat)
+        tm.assert_index_equal(cat.categories, exp_cat)
         res = cat.rename_categories([1, 2, 3], inplace=True)
 
         # and now inplace
         self.assertIsNone(res)
         self.assert_numpy_array_equal(cat.__array__(),
                                       np.array([1, 2, 3, 1], dtype=np.int64))
-        self.assert_index_equal(cat.categories, Index([1, 2, 3]))
+        tm.assert_index_equal(cat.categories, Index([1, 2, 3]))
 
         # lengthen
         def f():
@@ -1056,30 +1056,30 @@ Categories (3, object): [ああああ, いいいいい, ううううううう]""
         exp_categories_all = Index(["a", "b", "c", "d", "e"])
         exp_categories_dropped = Index(["a", "b", "c", "d"])
 
-        self.assert_index_equal(c.categories, exp_categories_all)
+        tm.assert_index_equal(c.categories, exp_categories_all)
 
         res = c.remove_unused_categories()
-        self.assert_index_equal(res.categories, exp_categories_dropped)
-        self.assert_index_equal(c.categories, exp_categories_all)
+        tm.assert_index_equal(res.categories, exp_categories_dropped)
+        tm.assert_index_equal(c.categories, exp_categories_all)
 
         res = c.remove_unused_categories(inplace=True)
-        self.assert_index_equal(c.categories, exp_categories_dropped)
+        tm.assert_index_equal(c.categories, exp_categories_dropped)
         self.assertIsNone(res)
 
         # with NaN values (GH11599)
         c = Categorical(["a", "b", "c", np.nan],
                         categories=["a", "b", "c", "d", "e"])
         res = c.remove_unused_categories()
-        self.assert_index_equal(res.categories,
-                                Index(np.array(["a", "b", "c"])))
+        tm.assert_index_equal(res.categories,
+                              Index(np.array(["a", "b", "c"])))
         exp_codes = np.array([0, 1, 2, -1], dtype=np.int8)
         self.assert_numpy_array_equal(res.codes, exp_codes)
-        self.assert_index_equal(c.categories, exp_categories_all)
+        tm.assert_index_equal(c.categories, exp_categories_all)
 
         val = ['F', np.nan, 'D', 'B', 'D', 'F', np.nan]
         cat = pd.Categorical(values=val, categories=list('ABCDEFG'))
         out = cat.remove_unused_categories()
-        self.assert_index_equal(out.categories, Index(['B', 'D', 'F']))
+        tm.assert_index_equal(out.categories, Index(['B', 'D', 'F']))
         exp_codes = np.array([2, -1, 1, 0, 1, 2, -1], dtype=np.int8)
         self.assert_numpy_array_equal(out.codes, exp_codes)
         self.assertEqual(out.get_values().tolist(), val)
@@ -1096,18 +1096,18 @@ Categories (3, object): [ああああ, いいいいい, ううううううう]""
 
         # Nans are represented as -1 in codes
         c = Categorical(["a", "b", np.nan, "a"])
-        self.assert_index_equal(c.categories, Index(["a", "b"]))
+        tm.assert_index_equal(c.categories, Index(["a", "b"]))
         self.assert_numpy_array_equal(c._codes,
                                       np.array([0, 1, -1, 0], dtype=np.int8))
         c[1] = np.nan
-        self.assert_index_equal(c.categories, Index(["a", "b"]))
+        tm.assert_index_equal(c.categories, Index(["a", "b"]))
         self.assert_numpy_array_equal(c._codes,
                                       np.array([0, -1, -1, 0], dtype=np.int8))
 
         # Adding nan to categories should make assigned nan point to the
         # category!
         c = Categorical(["a", "b", np.nan, "a"])
-        self.assert_index_equal(c.categories, Index(["a", "b"]))
+        tm.assert_index_equal(c.categories, Index(["a", "b"]))
         self.assert_numpy_array_equal(c._codes,
                                       np.array([0, 1, -1, 0], dtype=np.int8))
 
@@ -1195,19 +1195,19 @@ Categories (3, object): [ああああ, いいいいい, ううううううう]""
         cat = Categorical(["a", "b"])
         exp = Index(["a", "b"])
         res = cat.unique()
-        self.assert_index_equal(res.categories, exp)
+        tm.assert_index_equal(res.categories, exp)
         self.assert_categorical_equal(res, cat)
 
         cat = Categorical(["a", "b", "a", "a"], categories=["a", "b", "c"])
         res = cat.unique()
-        self.assert_index_equal(res.categories, exp)
+        tm.assert_index_equal(res.categories, exp)
         tm.assert_categorical_equal(res, Categorical(exp))
 
         cat = Categorical(["c", "a", "b", "a", "a"],
                           categories=["a", "b", "c"])
         exp = Index(["c", "a", "b"])
         res = cat.unique()
-        self.assert_index_equal(res.categories, exp)
+        tm.assert_index_equal(res.categories, exp)
         exp_cat = Categorical(exp, categories=['c', 'a', 'b'])
         tm.assert_categorical_equal(res, exp_cat)
 
@@ -1216,7 +1216,7 @@ Categories (3, object): [ああああ, いいいいい, ううううううう]""
                           categories=["a", "b", "c"])
         res = cat.unique()
         exp = Index(["b", "a"])
-        self.assert_index_equal(res.categories, exp)
+        tm.assert_index_equal(res.categories, exp)
         exp_cat = Categorical(["b", np.nan, "a"], categories=["b", "a"])
         tm.assert_categorical_equal(res, exp_cat)
 
@@ -1317,26 +1317,26 @@ Categories (3, object): [ああああ, いいいいい, ううううううう]""
         res = cat.sort_values()
         exp = np.array(["a", "b", "c", "d"], dtype=object)
         self.assert_numpy_array_equal(res.__array__(), exp)
-        self.assert_index_equal(res.categories, cat.categories)
+        tm.assert_index_equal(res.categories, cat.categories)
 
         cat = Categorical(["a", "c", "b", "d"],
                           categories=["a", "b", "c", "d"], ordered=True)
         res = cat.sort_values()
         exp = np.array(["a", "b", "c", "d"], dtype=object)
         self.assert_numpy_array_equal(res.__array__(), exp)
-        self.assert_index_equal(res.categories, cat.categories)
+        tm.assert_index_equal(res.categories, cat.categories)
 
         res = cat.sort_values(ascending=False)
         exp = np.array(["d", "c", "b", "a"], dtype=object)
         self.assert_numpy_array_equal(res.__array__(), exp)
-        self.assert_index_equal(res.categories, cat.categories)
+        tm.assert_index_equal(res.categories, cat.categories)
 
         # sort (inplace order)
         cat1 = cat.copy()
         cat1.sort_values(inplace=True)
         exp = np.array(["a", "b", "c", "d"], dtype=object)
         self.assert_numpy_array_equal(cat1.__array__(), exp)
-        self.assert_index_equal(res.categories, cat.categories)
+        tm.assert_index_equal(res.categories, cat.categories)
 
         # reverse
         cat = Categorical(["a", "c", "c", "b", "d"], ordered=True)
@@ -1344,7 +1344,7 @@ Categories (3, object): [ああああ, いいいいい, ううううううう]""
         exp_val = np.array(["d", "c", "c", "b", "a"], dtype=object)
         exp_categories = Index(["a", "b", "c", "d"])
         self.assert_numpy_array_equal(res.__array__(), exp_val)
-        self.assert_index_equal(res.categories, exp_categories)
+        tm.assert_index_equal(res.categories, exp_categories)
 
     def test_sort_values_na_position(self):
         # see gh-12882
@@ -1354,41 +1354,41 @@ Categories (3, object): [ああああ, いいいいい, ううううううう]""
         exp = np.array([2.0, 2.0, 5.0, np.nan, np.nan])
         res = cat.sort_values()  # default arguments
         self.assert_numpy_array_equal(res.__array__(), exp)
-        self.assert_index_equal(res.categories, exp_categories)
+        tm.assert_index_equal(res.categories, exp_categories)
 
         exp = np.array([np.nan, np.nan, 2.0, 2.0, 5.0])
         res = cat.sort_values(ascending=True, na_position='first')
         self.assert_numpy_array_equal(res.__array__(), exp)
-        self.assert_index_equal(res.categories, exp_categories)
+        tm.assert_index_equal(res.categories, exp_categories)
 
         exp = np.array([np.nan, np.nan, 5.0, 2.0, 2.0])
         res = cat.sort_values(ascending=False, na_position='first')
         self.assert_numpy_array_equal(res.__array__(), exp)
-        self.assert_index_equal(res.categories, exp_categories)
+        tm.assert_index_equal(res.categories, exp_categories)
 
         exp = np.array([2.0, 2.0, 5.0, np.nan, np.nan])
         res = cat.sort_values(ascending=True, na_position='last')
         self.assert_numpy_array_equal(res.__array__(), exp)
-        self.assert_index_equal(res.categories, exp_categories)
+        tm.assert_index_equal(res.categories, exp_categories)
 
         exp = np.array([5.0, 2.0, 2.0, np.nan, np.nan])
         res = cat.sort_values(ascending=False, na_position='last')
         self.assert_numpy_array_equal(res.__array__(), exp)
-        self.assert_index_equal(res.categories, exp_categories)
+        tm.assert_index_equal(res.categories, exp_categories)
 
         cat = Categorical(["a", "c", "b", "d", np.nan], ordered=True)
         res = cat.sort_values(ascending=False, na_position='last')
         exp_val = np.array(["d", "c", "b", "a", np.nan], dtype=object)
         exp_categories = Index(["a", "b", "c", "d"])
         self.assert_numpy_array_equal(res.__array__(), exp_val)
-        self.assert_index_equal(res.categories, exp_categories)
+        tm.assert_index_equal(res.categories, exp_categories)
 
         cat = Categorical(["a", "c", "b", "d", np.nan], ordered=True)
         res = cat.sort_values(ascending=False, na_position='first')
         exp_val = np.array([np.nan, "d", "c", "b", "a"], dtype=object)
         exp_categories = Index(["a", "b", "c", "d"])
         self.assert_numpy_array_equal(res.__array__(), exp_val)
-        self.assert_index_equal(res.categories, exp_categories)
+        tm.assert_index_equal(res.categories, exp_categories)
 
     def test_slicing_directly(self):
         cat = Categorical(["a", "b", "c", "d", "a", "b", "c"])
@@ -1910,13 +1910,13 @@ class TestCategoricalAsBlock(tm.TestCase):
 
         # NaNs are represented as -1 in labels
         s = Series(Categorical(["a", "b", np.nan, "a"]))
-        self.assert_index_equal(s.cat.categories, Index(["a", "b"]))
+        tm.assert_index_equal(s.cat.categories, Index(["a", "b"]))
         self.assert_numpy_array_equal(s.values.codes,
                                       np.array([0, 1, -1, 0], dtype=np.int8))
 
     def test_cat_accessor(self):
         s = Series(Categorical(["a", "b", np.nan, "a"]))
-        self.assert_index_equal(s.cat.categories, Index(["a", "b"]))
+        tm.assert_index_equal(s.cat.categories, Index(["a", "b"]))
         self.assertEqual(s.cat.ordered, False)
         exp = Categorical(["a", "b", np.nan, "a"], categories=["b", "a"])
         s.cat.set_categories(["b", "a"], inplace=True)
@@ -1928,7 +1928,7 @@ class TestCategoricalAsBlock(tm.TestCase):
         exp = Categorical(["a", "b", np.nan, "a"], categories=["b", "a"])
         s[:] = "a"
         s = s.cat.remove_unused_categories()
-        self.assert_index_equal(s.cat.categories, Index(["a"]))
+        tm.assert_index_equal(s.cat.categories, Index(["a"]))
 
     def test_sequence_like(self):
 
@@ -1974,7 +1974,7 @@ class TestCategoricalAsBlock(tm.TestCase):
         tm.assert_index_equal(s.cat.categories, exp_categories)
         s.cat.categories = [1, 2, 3]
         exp_categories = Index([1, 2, 3])
-        self.assert_index_equal(s.cat.categories, exp_categories)
+        tm.assert_index_equal(s.cat.categories, exp_categories)
 
         exp_codes = Series([0, 1, 2, 0], dtype='int8')
         tm.assert_series_equal(s.cat.codes, exp_codes)
@@ -2000,7 +2000,7 @@ class TestCategoricalAsBlock(tm.TestCase):
         exp_categories = Index(["a", "b"])
         exp_values = np.array(["a", "b", "b", "a"], dtype=np.object_)
         s = s.cat.remove_unused_categories()
-        self.assert_index_equal(s.cat.categories, exp_categories)
+        tm.assert_index_equal(s.cat.categories, exp_categories)
         self.assert_numpy_array_equal(s.values.__array__(), exp_values)
         self.assert_numpy_array_equal(s.__array__(), exp_values)
 
@@ -3860,18 +3860,18 @@ Categories (10, timedelta64[ns]): [0 days 01:00:00 < 1 days 01:00:00 < 2 days 01
         df1 = df[0:3]
         df2 = df[3:]
 
-        self.assert_index_equal(df['grade'].cat.categories,
-                                df1['grade'].cat.categories)
-        self.assert_index_equal(df['grade'].cat.categories,
-                                df2['grade'].cat.categories)
+        tm.assert_index_equal(df['grade'].cat.categories,
+                              df1['grade'].cat.categories)
+        tm.assert_index_equal(df['grade'].cat.categories,
+                              df2['grade'].cat.categories)
 
         dfx = pd.concat([df1, df2])
-        self.assert_index_equal(df['grade'].cat.categories,
-                                dfx['grade'].cat.categories)
+        tm.assert_index_equal(df['grade'].cat.categories,
+                              dfx['grade'].cat.categories)
 
         dfa = df1.append(df2)
-        self.assert_index_equal(df['grade'].cat.categories,
-                                dfa['grade'].cat.categories)
+        tm.assert_index_equal(df['grade'].cat.categories,
+                              dfa['grade'].cat.categories)
 
     def test_concat_preserve(self):
 

--- a/pandas/tests/test_lib.py
+++ b/pandas/tests/test_lib.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 
+import pytest
+
 import numpy as np
 import pandas as pd
 import pandas._libs.lib as lib
@@ -47,32 +49,36 @@ class TestIndexing(tm.TestCase):
         # slice
         indices = np.array([], dtype=np.int64)
         maybe_slice = lib.maybe_indices_to_slice(indices, len(target))
-        self.assertTrue(isinstance(maybe_slice, slice))
-        self.assert_numpy_array_equal(target[indices], target[maybe_slice])
+
+        assert isinstance(maybe_slice, slice)
+        tm.assert_numpy_array_equal(target[indices], target[maybe_slice])
 
         for end in [1, 2, 5, 20, 99]:
             for step in [1, 2, 4]:
                 indices = np.arange(0, end, step, dtype=np.int64)
                 maybe_slice = lib.maybe_indices_to_slice(indices, len(target))
-                self.assertTrue(isinstance(maybe_slice, slice))
-                self.assert_numpy_array_equal(target[indices],
-                                              target[maybe_slice])
+
+                assert isinstance(maybe_slice, slice)
+                tm.assert_numpy_array_equal(target[indices],
+                                            target[maybe_slice])
 
                 # reverse
                 indices = indices[::-1]
                 maybe_slice = lib.maybe_indices_to_slice(indices, len(target))
-                self.assertTrue(isinstance(maybe_slice, slice))
-                self.assert_numpy_array_equal(target[indices],
-                                              target[maybe_slice])
+
+                assert isinstance(maybe_slice, slice)
+                tm.assert_numpy_array_equal(target[indices],
+                                            target[maybe_slice])
 
         # not slice
         for case in [[2, 1, 2, 0], [2, 2, 1, 0], [0, 1, 2, 1], [-2, 0, 2],
                      [2, 0, -2]]:
             indices = np.array(case, dtype=np.int64)
             maybe_slice = lib.maybe_indices_to_slice(indices, len(target))
-            self.assertFalse(isinstance(maybe_slice, slice))
-            self.assert_numpy_array_equal(maybe_slice, indices)
-            self.assert_numpy_array_equal(target[indices], target[maybe_slice])
+
+            assert not isinstance(maybe_slice, slice)
+            tm.assert_numpy_array_equal(maybe_slice, indices)
+            tm.assert_numpy_array_equal(target[indices], target[maybe_slice])
 
     def test_maybe_indices_to_slice_right_edge(self):
         target = np.arange(100)
@@ -82,42 +88,49 @@ class TestIndexing(tm.TestCase):
             for step in [1, 2, 4]:
                 indices = np.arange(start, 99, step, dtype=np.int64)
                 maybe_slice = lib.maybe_indices_to_slice(indices, len(target))
-                self.assertTrue(isinstance(maybe_slice, slice))
-                self.assert_numpy_array_equal(target[indices],
-                                              target[maybe_slice])
+
+                assert isinstance(maybe_slice, slice)
+                tm.assert_numpy_array_equal(target[indices],
+                                            target[maybe_slice])
 
                 # reverse
                 indices = indices[::-1]
                 maybe_slice = lib.maybe_indices_to_slice(indices, len(target))
-                self.assertTrue(isinstance(maybe_slice, slice))
-                self.assert_numpy_array_equal(target[indices],
-                                              target[maybe_slice])
+
+                assert isinstance(maybe_slice, slice)
+                tm.assert_numpy_array_equal(target[indices],
+                                            target[maybe_slice])
 
         # not slice
         indices = np.array([97, 98, 99, 100], dtype=np.int64)
         maybe_slice = lib.maybe_indices_to_slice(indices, len(target))
-        self.assertFalse(isinstance(maybe_slice, slice))
-        self.assert_numpy_array_equal(maybe_slice, indices)
-        with self.assertRaises(IndexError):
+
+        assert not isinstance(maybe_slice, slice)
+        tm.assert_numpy_array_equal(maybe_slice, indices)
+
+        with pytest.raises(IndexError):
             target[indices]
-        with self.assertRaises(IndexError):
+        with pytest.raises(IndexError):
             target[maybe_slice]
 
         indices = np.array([100, 99, 98, 97], dtype=np.int64)
         maybe_slice = lib.maybe_indices_to_slice(indices, len(target))
-        self.assertFalse(isinstance(maybe_slice, slice))
-        self.assert_numpy_array_equal(maybe_slice, indices)
-        with self.assertRaises(IndexError):
+
+        assert not isinstance(maybe_slice, slice)
+        tm.assert_numpy_array_equal(maybe_slice, indices)
+
+        with pytest.raises(IndexError):
             target[indices]
-        with self.assertRaises(IndexError):
+        with pytest.raises(IndexError):
             target[maybe_slice]
 
         for case in [[99, 97, 99, 96], [99, 99, 98, 97], [98, 98, 97, 96]]:
             indices = np.array(case, dtype=np.int64)
             maybe_slice = lib.maybe_indices_to_slice(indices, len(target))
-            self.assertFalse(isinstance(maybe_slice, slice))
-            self.assert_numpy_array_equal(maybe_slice, indices)
-            self.assert_numpy_array_equal(target[indices], target[maybe_slice])
+
+            assert not isinstance(maybe_slice, slice)
+            tm.assert_numpy_array_equal(maybe_slice, indices)
+            tm.assert_numpy_array_equal(target[indices], target[maybe_slice])
 
     def test_maybe_indices_to_slice_both_edges(self):
         target = np.arange(10)
@@ -127,21 +140,21 @@ class TestIndexing(tm.TestCase):
             indices = np.arange(0, 9, step, dtype=np.int64)
             maybe_slice = lib.maybe_indices_to_slice(indices, len(target))
             self.assertTrue(isinstance(maybe_slice, slice))
-            self.assert_numpy_array_equal(target[indices], target[maybe_slice])
+            tm.assert_numpy_array_equal(target[indices], target[maybe_slice])
 
             # reverse
             indices = indices[::-1]
             maybe_slice = lib.maybe_indices_to_slice(indices, len(target))
             self.assertTrue(isinstance(maybe_slice, slice))
-            self.assert_numpy_array_equal(target[indices], target[maybe_slice])
+            tm.assert_numpy_array_equal(target[indices], target[maybe_slice])
 
         # not slice
         for case in [[4, 2, 0, -2], [2, 2, 1, 0], [0, 1, 2, 1]]:
             indices = np.array(case, dtype=np.int64)
             maybe_slice = lib.maybe_indices_to_slice(indices, len(target))
             self.assertFalse(isinstance(maybe_slice, slice))
-            self.assert_numpy_array_equal(maybe_slice, indices)
-            self.assert_numpy_array_equal(target[indices], target[maybe_slice])
+            tm.assert_numpy_array_equal(maybe_slice, indices)
+            tm.assert_numpy_array_equal(target[indices], target[maybe_slice])
 
     def test_maybe_indices_to_slice_middle(self):
         target = np.arange(100)
@@ -151,24 +164,27 @@ class TestIndexing(tm.TestCase):
             for step in [1, 2, 4, 20]:
                 indices = np.arange(start, end, step, dtype=np.int64)
                 maybe_slice = lib.maybe_indices_to_slice(indices, len(target))
-                self.assertTrue(isinstance(maybe_slice, slice))
-                self.assert_numpy_array_equal(target[indices],
-                                              target[maybe_slice])
+
+                assert isinstance(maybe_slice, slice)
+                tm.assert_numpy_array_equal(target[indices],
+                                            target[maybe_slice])
 
                 # reverse
                 indices = indices[::-1]
                 maybe_slice = lib.maybe_indices_to_slice(indices, len(target))
-                self.assertTrue(isinstance(maybe_slice, slice))
-                self.assert_numpy_array_equal(target[indices],
-                                              target[maybe_slice])
+
+                assert isinstance(maybe_slice, slice)
+                tm.assert_numpy_array_equal(target[indices],
+                                            target[maybe_slice])
 
         # not slice
         for case in [[14, 12, 10, 12], [12, 12, 11, 10], [10, 11, 12, 11]]:
             indices = np.array(case, dtype=np.int64)
             maybe_slice = lib.maybe_indices_to_slice(indices, len(target))
-            self.assertFalse(isinstance(maybe_slice, slice))
-            self.assert_numpy_array_equal(maybe_slice, indices)
-            self.assert_numpy_array_equal(target[indices], target[maybe_slice])
+
+            assert not isinstance(maybe_slice, slice)
+            tm.assert_numpy_array_equal(maybe_slice, indices)
+            tm.assert_numpy_array_equal(target[indices], target[maybe_slice])
 
     def test_maybe_booleans_to_slice(self):
         arr = np.array([0, 0, 1, 1, 1, 0, 1], dtype=np.uint8)

--- a/pandas/tests/test_panel.py
+++ b/pandas/tests/test_panel.py
@@ -845,19 +845,19 @@ class CheckIndexing(object):
 
                 # versus same index
                 result = func(p1, p2)
-                self.assert_numpy_array_equal(result.values,
-                                              func(p1.values, p2.values))
+                tm.assert_numpy_array_equal(result.values,
+                                            func(p1.values, p2.values))
 
                 # versus non-indexed same objs
-                self.assertRaises(Exception, func, p1, tp)
+                pytest.raises(Exception, func, p1, tp)
 
                 # versus different objs
-                self.assertRaises(Exception, func, p1, df)
+                pytest.raises(Exception, func, p1, df)
 
                 # versus scalar
                 result3 = func(self.panel, 0)
-                self.assert_numpy_array_equal(result3.values,
-                                              func(self.panel.values, 0))
+                tm.assert_numpy_array_equal(result3.values,
+                                            func(self.panel.values, 0))
 
             with np.errstate(invalid='ignore'):
                 test_comp(operator.eq)
@@ -2609,7 +2609,7 @@ class TestLongPanel(tm.TestCase):
         self.panel['Label'] = self.panel.index.labels[1]
         minor_dummies = make_axis_dummies(self.panel, 'minor').astype(np.uint8)
         dummies = get_dummies(self.panel['Label'])
-        self.assert_numpy_array_equal(dummies.values, minor_dummies.values)
+        tm.assert_numpy_array_equal(dummies.values, minor_dummies.values)
 
     def test_mean(self):
         with catch_warnings(record=True):

--- a/pandas/tests/test_panel.py
+++ b/pandas/tests/test_panel.py
@@ -1071,12 +1071,12 @@ class TestPanel(tm.TestCase, PanelTests, CheckIndexing, SafeForLongAndSparse,
             # TODO: unused?
             wp3 = Panel.from_dict(d3)  # noqa
 
-            self.assert_index_equal(wp.major_axis, self.panel.major_axis)
+            tm.assert_index_equal(wp.major_axis, self.panel.major_axis)
             assert_panel_equal(wp, wp2)
 
             # intersect
             wp = Panel.from_dict(d, intersect=True)
-            self.assert_index_equal(wp.major_axis, itemb.index[5:])
+            tm.assert_index_equal(wp.major_axis, itemb.index[5:])
 
             # use constructor
             assert_panel_equal(Panel(d), Panel.from_dict(d))
@@ -1109,7 +1109,7 @@ class TestPanel(tm.TestCase, PanelTests, CheckIndexing, SafeForLongAndSparse,
             data = dict((k, v.values) for k, v in self.panel.iteritems())
             result = Panel(data)
             exp_major = Index(np.arange(len(self.panel.major_axis)))
-            self.assert_index_equal(result.major_axis, exp_major)
+            tm.assert_index_equal(result.major_axis, exp_major)
 
             result = Panel(data, items=self.panel.items,
                            major_axis=self.panel.major_axis,
@@ -2152,11 +2152,11 @@ class TestPanel(tm.TestCase, PanelTests, CheckIndexing, SafeForLongAndSparse,
 
             renamed = self.panel.rename_axis(mapper, axis=0)
             exp = Index(['foo', 'bar', 'baz'])
-            self.assert_index_equal(renamed.items, exp)
+            tm.assert_index_equal(renamed.items, exp)
 
             renamed = self.panel.rename_axis(str.lower, axis=2)
             exp = Index(['a', 'b', 'c', 'd'])
-            self.assert_index_equal(renamed.minor_axis, exp)
+            tm.assert_index_equal(renamed.minor_axis, exp)
 
             # don't copy
             renamed_nocopy = self.panel.rename_axis(mapper, axis=0, copy=False)
@@ -2599,7 +2599,7 @@ class TestLongPanel(tm.TestCase):
         transformed = make_axis_dummies(self.panel, 'minor',
                                         transform=mapping.get).astype(np.uint8)
         self.assertEqual(len(transformed.columns), 2)
-        self.assert_index_equal(transformed.columns, Index(['one', 'two']))
+        tm.assert_index_equal(transformed.columns, Index(['one', 'two']))
 
         # TODO: test correctness
 

--- a/pandas/tests/test_panel4d.py
+++ b/pandas/tests/test_panel4d.py
@@ -708,7 +708,7 @@ class TestPanel4d(tm.TestCase, CheckIndexing, SafeForSparse,
             result = Panel4D(data)
 
             exp_major = Index(np.arange(len(self.panel4d.major_axis)))
-            self.assert_index_equal(result.major_axis, exp_major)
+            tm.assert_index_equal(result.major_axis, exp_major)
 
             result = Panel4D(data,
                              labels=self.panel4d.labels,
@@ -938,11 +938,11 @@ class TestPanel4d(tm.TestCase, CheckIndexing, SafeForSparse,
 
             renamed = self.panel4d.rename_axis(mapper, axis=0)
             exp = Index(['foo', 'bar', 'baz'])
-            self.assert_index_equal(renamed.labels, exp)
+            tm.assert_index_equal(renamed.labels, exp)
 
             renamed = self.panel4d.rename_axis(str.lower, axis=3)
             exp = Index(['a', 'b', 'c', 'd'])
-            self.assert_index_equal(renamed.minor_axis, exp)
+            tm.assert_index_equal(renamed.minor_axis, exp)
 
             # don't copy
             renamed_nocopy = self.panel4d.rename_axis(mapper,

--- a/pandas/tests/test_panel4d.py
+++ b/pandas/tests/test_panel4d.py
@@ -445,18 +445,18 @@ class CheckIndexing(object):
 
             def test_comp(func):
                 result = func(p1, p2)
-                self.assert_numpy_array_equal(result.values,
-                                              func(p1.values, p2.values))
+                tm.assert_numpy_array_equal(result.values,
+                                            func(p1.values, p2.values))
 
                 # versus non-indexed same objs
-                self.assertRaises(Exception, func, p1, tp)
+                pytest.raises(Exception, func, p1, tp)
 
                 # versus different objs
-                self.assertRaises(Exception, func, p1, p)
+                pytest.raises(Exception, func, p1, p)
 
                 result3 = func(self.panel4d, 0)
-                self.assert_numpy_array_equal(result3.values,
-                                              func(self.panel4d.values, 0))
+                tm.assert_numpy_array_equal(result3.values,
+                                            func(self.panel4d.values, 0))
 
             with np.errstate(invalid='ignore'):
                 test_comp(operator.eq)

--- a/pandas/tests/test_resample.py
+++ b/pandas/tests/test_resample.py
@@ -1576,7 +1576,7 @@ class TestDatetimeIndex(Base, tm.TestCase):
         resampled = ts.resample('5min', base=2).mean()
         exp_rng = date_range('12/31/1999 23:57:00', '1/1/2000 01:57',
                              freq='5min')
-        self.assert_index_equal(resampled.index, exp_rng)
+        tm.assert_index_equal(resampled.index, exp_rng)
 
     def test_resample_base_with_timedeltaindex(self):
 
@@ -1590,8 +1590,8 @@ class TestDatetimeIndex(Base, tm.TestCase):
         exp_without_base = timedelta_range(start='0s', end='25s', freq='2s')
         exp_with_base = timedelta_range(start='5s', end='29s', freq='2s')
 
-        self.assert_index_equal(without_base.index, exp_without_base)
-        self.assert_index_equal(with_base.index, exp_with_base)
+        tm.assert_index_equal(without_base.index, exp_without_base)
+        tm.assert_index_equal(with_base.index, exp_with_base)
 
     def test_resample_categorical_data_with_timedeltaindex(self):
         # GH #12169
@@ -1622,7 +1622,7 @@ class TestDatetimeIndex(Base, tm.TestCase):
 
         result = ts.resample('M', kind='period').mean()
         exp_index = period_range('Jan-2000', 'Dec-2000', freq='M')
-        self.assert_index_equal(result.index, exp_index)
+        tm.assert_index_equal(result.index, exp_index)
 
     def test_period_with_agg(self):
 
@@ -1785,7 +1785,7 @@ class TestDatetimeIndex(Base, tm.TestCase):
 
         result = ts.resample('5t', closed='right', label='left').mean()
         ex_index = date_range('1999-12-31 23:55', periods=4, freq='5t')
-        self.assert_index_equal(result.index, ex_index)
+        tm.assert_index_equal(result.index, ex_index)
 
         len0pts = _simple_pts('2007-01', '2010-05', freq='M')[:0]
         # it works
@@ -2665,7 +2665,7 @@ class TestPeriodIndex(Base, tm.TestCase):
 
         ex_index = date_range(start='1/1/2012 9:30', freq='10min', periods=3)
 
-        self.assert_index_equal(result.index, ex_index)
+        tm.assert_index_equal(result.index, ex_index)
         assert_series_equal(result, exp)
 
     def test_quarterly_resampling(self):
@@ -3049,7 +3049,7 @@ class TestTimeGrouper(tm.TestCase):
 
         # it works!
         result = grouped.apply(f)
-        self.assert_index_equal(result.index, df.index)
+        tm.assert_index_equal(result.index, df.index)
 
     def test_panel_aggregation(self):
         ind = pd.date_range('1/1/2000', periods=100)

--- a/pandas/tests/test_sorting.py
+++ b/pandas/tests/test_sorting.py
@@ -40,10 +40,10 @@ class TestSorting(tm.TestCase):
         right = rg.sum()['values']
 
         exp_index, _ = left.index.sortlevel()
-        self.assert_index_equal(left.index, exp_index)
+        tm.assert_index_equal(left.index, exp_index)
 
         exp_index, _ = right.index.sortlevel(0)
-        self.assert_index_equal(right.index, exp_index)
+        tm.assert_index_equal(right.index, exp_index)
 
         tups = list(map(tuple, df[['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H'
                                    ]].values))

--- a/pandas/tests/test_strings.py
+++ b/pandas/tests/test_strings.py
@@ -118,7 +118,7 @@ class TestStringMethods(tm.TestCase):
         result = strings.str_cat(one, [two], na_rep='NA')
         exp = np.array(['aa', 'aNA', 'bb', 'bd', 'cfoo', 'NANA'],
                        dtype=np.object_)
-        self.assert_numpy_array_equal(result, exp)
+        tm.assert_numpy_array_equal(result, exp)
 
         result = strings.str_cat(one, two)
         exp = np.array(['aa', NA, 'bb', 'bd', 'cfoo', NA], dtype=np.object_)

--- a/pandas/tests/test_take.py
+++ b/pandas/tests/test_take.py
@@ -348,7 +348,7 @@ class TestTake(tm.TestCase):
 
         result = algos.take_1d(arr, [0, 2, 2, 1])
         expected = arr.take([0, 2, 2, 1])
-        self.assert_numpy_array_equal(result, expected)
+        tm.assert_numpy_array_equal(result, expected)
 
         result = algos.take_1d(arr, [0, 2, -1])
         self.assertEqual(result.dtype, np.object_)
@@ -358,11 +358,11 @@ class TestTake(tm.TestCase):
 
         result = algos.take_nd(arr, [0, 2, 2, 1])
         expected = arr.take([0, 2, 2, 1], axis=0)
-        self.assert_numpy_array_equal(result, expected)
+        tm.assert_numpy_array_equal(result, expected)
 
         result = algos.take_nd(arr, [0, 2, 2, 1], axis=1)
         expected = arr.take([0, 2, 2, 1], axis=1)
-        self.assert_numpy_array_equal(result, expected)
+        tm.assert_numpy_array_equal(result, expected)
 
         result = algos.take_nd(arr, [0, 2, -1])
         self.assertEqual(result.dtype, np.object_)

--- a/pandas/tests/test_testing.py
+++ b/pandas/tests/test_testing.py
@@ -128,12 +128,12 @@ class TestAssertAlmostEqual(tm.TestCase):
                                                 dtype=np.object_))
 
     def test_assert_almost_equal_pandas(self):
-        self.assert_almost_equal(pd.Index([1., 1.1]),
-                                 pd.Index([1., 1.100001]))
-        self.assert_almost_equal(pd.Series([1., 1.1]),
-                                 pd.Series([1., 1.100001]))
-        self.assert_almost_equal(pd.DataFrame({'a': [1., 1.1]}),
-                                 pd.DataFrame({'a': [1., 1.100001]}))
+        tm.assert_almost_equal(pd.Index([1., 1.1]),
+                               pd.Index([1., 1.100001]))
+        tm.assert_almost_equal(pd.Series([1., 1.1]),
+                               pd.Series([1., 1.100001]))
+        tm.assert_almost_equal(pd.DataFrame({'a': [1., 1.1]}),
+                               pd.DataFrame({'a': [1., 1.100001]}))
 
     def test_assert_almost_equal_object(self):
         a = [pd.Timestamp('2011-01-01'), pd.Timestamp('2011-01-01')]

--- a/pandas/tests/test_window.py
+++ b/pandas/tests/test_window.py
@@ -1328,7 +1328,7 @@ class TestMoments(Base):
                 expected = get_result(
                     np.concatenate((arr, np.array([np.NaN] * 9))), 20)[9:]
 
-            self.assert_numpy_array_equal(result, expected)
+            tm.assert_numpy_array_equal(result, expected)
 
         if test_stable:
             result = get_result(self.arr + 1e9, window)

--- a/pandas/tests/tseries/test_holiday.py
+++ b/pandas/tests/tseries/test_holiday.py
@@ -253,8 +253,8 @@ class TestHoliday(tm.TestCase):
             Timestamp(self.start_date),
             Timestamp(self.end_date))
 
-        self.assert_index_equal(holidays, holidays_1)
-        self.assert_index_equal(holidays, holidays_2)
+        tm.assert_index_equal(holidays, holidays_1)
+        tm.assert_index_equal(holidays, holidays_2)
 
     def test_special_holidays(self):
         base_date = [datetime(2012, 5, 28)]

--- a/pandas/tests/tseries/test_offsets.py
+++ b/pandas/tests/tseries/test_offsets.py
@@ -2831,7 +2831,7 @@ class TestSemiMonthEnd(Base):
 
     def test_vectorized_offset_addition(self):
         for klass, assert_func in zip([Series, DatetimeIndex],
-                                      [self.assert_series_equal,
+                                      [tm.assert_series_equal,
                                        tm.assert_index_equal]):
             s = klass([Timestamp('2000-01-15 00:15:00', tz='US/Central'),
                        Timestamp('2000-02-15', tz='US/Central')], name='a')
@@ -3006,7 +3006,7 @@ class TestSemiMonthBegin(Base):
 
     def test_vectorized_offset_addition(self):
         for klass, assert_func in zip([Series, DatetimeIndex],
-                                      [self.assert_series_equal,
+                                      [tm.assert_series_equal,
                                        tm.assert_index_equal]):
 
             s = klass([Timestamp('2000-01-15 00:15:00', tz='US/Central'),

--- a/pandas/tests/tseries/test_timezones.py
+++ b/pandas/tests/tseries/test_timezones.py
@@ -305,7 +305,7 @@ class TestTimeZoneSupportPytz(tm.TestCase):
         self.assertEqual(off, rng.tz)
 
         rng2 = date_range(start, periods=len(rng), tz=off)
-        self.assert_index_equal(rng, rng2)
+        tm.assert_index_equal(rng, rng2)
 
         rng3 = date_range('3/11/2012 05:00:00+07:00',
                           '6/11/2012 05:00:00+07:00')
@@ -329,7 +329,7 @@ class TestTimeZoneSupportPytz(tm.TestCase):
         rng3 = date_range('3/11/2012 03:00', periods=15, freq='H')
         rng3 = rng3.tz_localize('US/Eastern')
 
-        self.assert_index_equal(rng, rng3)
+        tm.assert_index_equal(rng, rng3)
 
         # DST transition time
         val = rng[0]
@@ -338,14 +338,14 @@ class TestTimeZoneSupportPytz(tm.TestCase):
         self.assertEqual(val.hour, 3)
         self.assertEqual(exp.hour, 3)
         self.assertEqual(val, exp)  # same UTC value
-        self.assert_index_equal(rng[:2], rng2)
+        tm.assert_index_equal(rng[:2], rng2)
 
         # Right before the DST transition
         rng = date_range('3/11/2012 00:00', periods=2, freq='H',
                          tz='US/Eastern')
         rng2 = DatetimeIndex(['3/11/2012 00:00', '3/11/2012 01:00'],
                              tz='US/Eastern')
-        self.assert_index_equal(rng, rng2)
+        tm.assert_index_equal(rng, rng2)
         exp = Timestamp('3/11/2012 00:00', tz='US/Eastern')
         self.assertEqual(exp.hour, 0)
         self.assertEqual(rng[0], exp)
@@ -406,7 +406,7 @@ class TestTimeZoneSupportPytz(tm.TestCase):
                         tz=self.tzstr('America/Atikokan'))
 
         expected = Index(np.arange(10, dtype=np.int64))
-        self.assert_index_equal(dr.hour, expected)
+        tm.assert_index_equal(dr.hour, expected)
 
     def test_with_tz(self):
         tz = self.tz('US/Central')
@@ -444,7 +444,7 @@ class TestTimeZoneSupportPytz(tm.TestCase):
         dr = bdate_range('1/1/2009', '1/1/2010')
         dr_utc = bdate_range('1/1/2009', '1/1/2010', tz=pytz.utc)
         localized = dr.tz_localize(pytz.utc)
-        self.assert_index_equal(dr_utc, localized)
+        tm.assert_index_equal(dr_utc, localized)
 
     def test_with_tz_ambiguous_times(self):
         tz = self.tz('US/Eastern')
@@ -482,22 +482,22 @@ class TestTimeZoneSupportPytz(tm.TestCase):
                  '11/06/2011 02:00', '11/06/2011 03:00']
         di = DatetimeIndex(times)
         localized = di.tz_localize(tz, ambiguous='infer')
-        self.assert_index_equal(dr, localized)
+        tm.assert_index_equal(dr, localized)
         with tm.assert_produces_warning(FutureWarning):
             localized_old = di.tz_localize(tz, infer_dst=True)
-        self.assert_index_equal(dr, localized_old)
-        self.assert_index_equal(dr, DatetimeIndex(times, tz=tz,
-                                                  ambiguous='infer'))
+        tm.assert_index_equal(dr, localized_old)
+        tm.assert_index_equal(dr, DatetimeIndex(times, tz=tz,
+                                                ambiguous='infer'))
 
         # When there is no dst transition, nothing special happens
         dr = date_range(datetime(2011, 6, 1, 0), periods=10,
                         freq=offsets.Hour())
         localized = dr.tz_localize(tz)
         localized_infer = dr.tz_localize(tz, ambiguous='infer')
-        self.assert_index_equal(localized, localized_infer)
+        tm.assert_index_equal(localized, localized_infer)
         with tm.assert_produces_warning(FutureWarning):
             localized_infer_old = dr.tz_localize(tz, infer_dst=True)
-        self.assert_index_equal(localized, localized_infer_old)
+        tm.assert_index_equal(localized, localized_infer_old)
 
     def test_ambiguous_flags(self):
         # November 6, 2011, fall back, repeat 2 AM hour
@@ -513,20 +513,20 @@ class TestTimeZoneSupportPytz(tm.TestCase):
         di = DatetimeIndex(times)
         is_dst = [1, 1, 0, 0, 0]
         localized = di.tz_localize(tz, ambiguous=is_dst)
-        self.assert_index_equal(dr, localized)
-        self.assert_index_equal(dr, DatetimeIndex(times, tz=tz,
-                                                  ambiguous=is_dst))
+        tm.assert_index_equal(dr, localized)
+        tm.assert_index_equal(dr, DatetimeIndex(times, tz=tz,
+                                                ambiguous=is_dst))
 
         localized = di.tz_localize(tz, ambiguous=np.array(is_dst))
-        self.assert_index_equal(dr, localized)
+        tm.assert_index_equal(dr, localized)
 
         localized = di.tz_localize(tz,
                                    ambiguous=np.array(is_dst).astype('bool'))
-        self.assert_index_equal(dr, localized)
+        tm.assert_index_equal(dr, localized)
 
         # Test constructor
         localized = DatetimeIndex(times, tz=tz, ambiguous=is_dst)
-        self.assert_index_equal(dr, localized)
+        tm.assert_index_equal(dr, localized)
 
         # Test duplicate times where infer_dst fails
         times += times
@@ -539,7 +539,7 @@ class TestTimeZoneSupportPytz(tm.TestCase):
         is_dst = np.hstack((is_dst, is_dst))
         localized = di.tz_localize(tz, ambiguous=is_dst)
         dr = dr.append(dr)
-        self.assert_index_equal(dr, localized)
+        tm.assert_index_equal(dr, localized)
 
         # When there is no dst transition, nothing special happens
         dr = date_range(datetime(2011, 6, 1, 0), periods=10,
@@ -547,7 +547,7 @@ class TestTimeZoneSupportPytz(tm.TestCase):
         is_dst = np.array([1] * 10)
         localized = dr.tz_localize(tz)
         localized_is_dst = dr.tz_localize(tz, ambiguous=is_dst)
-        self.assert_index_equal(localized, localized_is_dst)
+        tm.assert_index_equal(localized, localized_is_dst)
 
         # construction with an ambiguous end-point
         # GH 11626
@@ -667,7 +667,7 @@ class TestTimeZoneSupportPytz(tm.TestCase):
                             tz=self.tzstr('US/Eastern'))
         expected = date_range('1/1/2000', periods=10, tz=self.tz('US/Eastern'))
 
-        self.assert_index_equal(result, expected)
+        tm.assert_index_equal(result, expected)
 
     def test_take_dont_lose_meta(self):
         tm._skip_if_no_pytz()
@@ -869,7 +869,7 @@ class TestTimeZoneSupportPytz(tm.TestCase):
         dr = date_range('2012-06-02', periods=10,
                         tz=self.tzstr('US/Eastern'), name='foo')
         dr2 = DatetimeIndex(list(dr), name='foo')
-        self.assert_index_equal(dr, dr2)
+        tm.assert_index_equal(dr, dr2)
         self.assertEqual(dr.tz, dr2.tz)
         self.assertEqual(dr2.name, 'foo')
 
@@ -932,7 +932,7 @@ class TestTimeZoneSupportPytz(tm.TestCase):
         idx4 = DatetimeIndex(np.array(arr), tz=self.tzstr('US/Eastern'))
 
         for other in [idx2, idx3, idx4]:
-            self.assert_index_equal(idx1, other)
+            tm.assert_index_equal(idx1, other)
 
     def test_datetimeindex_tz_nat(self):
         idx = to_datetime([Timestamp("2013-1-1", tz=self.tzstr('US/Eastern')),
@@ -995,7 +995,7 @@ class TestTimeZoneSupportDateutil(TestTimeZoneSupportPytz):
         tt = to_datetime(ts).tz_localize('US/Eastern')
         ut = tt.tz_convert('UTC')
         expected = Index([13, 14, 13])
-        self.assert_index_equal(ut.hour, expected)
+        tm.assert_index_equal(ut.hour, expected)
 
         # sorted case UTC -> US/Eastern
         ts = ['2008-05-12 13:50:00',
@@ -1004,7 +1004,7 @@ class TestTimeZoneSupportDateutil(TestTimeZoneSupportPytz):
         tt = to_datetime(ts).tz_localize('UTC')
         ut = tt.tz_convert('US/Eastern')
         expected = Index([9, 9, 9])
-        self.assert_index_equal(ut.hour, expected)
+        tm.assert_index_equal(ut.hour, expected)
 
         # unsorted case US/Eastern -> UTC
         ts = ['2008-05-12 09:50:00',
@@ -1013,7 +1013,7 @@ class TestTimeZoneSupportDateutil(TestTimeZoneSupportPytz):
         tt = to_datetime(ts).tz_localize('US/Eastern')
         ut = tt.tz_convert('UTC')
         expected = Index([13, 14, 13])
-        self.assert_index_equal(ut.hour, expected)
+        tm.assert_index_equal(ut.hour, expected)
 
         # unsorted case UTC -> US/Eastern
         ts = ['2008-05-12 13:50:00',
@@ -1022,7 +1022,7 @@ class TestTimeZoneSupportDateutil(TestTimeZoneSupportPytz):
         tt = to_datetime(ts).tz_localize('UTC')
         ut = tt.tz_convert('US/Eastern')
         expected = Index([9, 9, 9])
-        self.assert_index_equal(ut.hour, expected)
+        tm.assert_index_equal(ut.hour, expected)
 
     def test_tz_convert_hour_overflow_dst_timestamps(self):
         # Regression test for:
@@ -1037,7 +1037,7 @@ class TestTimeZoneSupportDateutil(TestTimeZoneSupportPytz):
         tt = to_datetime(ts)
         ut = tt.tz_convert('UTC')
         expected = Index([13, 14, 13])
-        self.assert_index_equal(ut.hour, expected)
+        tm.assert_index_equal(ut.hour, expected)
 
         # sorted case UTC -> US/Eastern
         ts = [Timestamp('2008-05-12 13:50:00', tz='UTC'),
@@ -1046,7 +1046,7 @@ class TestTimeZoneSupportDateutil(TestTimeZoneSupportPytz):
         tt = to_datetime(ts)
         ut = tt.tz_convert('US/Eastern')
         expected = Index([9, 9, 9])
-        self.assert_index_equal(ut.hour, expected)
+        tm.assert_index_equal(ut.hour, expected)
 
         # unsorted case US/Eastern -> UTC
         ts = [Timestamp('2008-05-12 09:50:00', tz=tz),
@@ -1055,7 +1055,7 @@ class TestTimeZoneSupportDateutil(TestTimeZoneSupportPytz):
         tt = to_datetime(ts)
         ut = tt.tz_convert('UTC')
         expected = Index([13, 14, 13])
-        self.assert_index_equal(ut.hour, expected)
+        tm.assert_index_equal(ut.hour, expected)
 
         # unsorted case UTC -> US/Eastern
         ts = [Timestamp('2008-05-12 13:50:00', tz='UTC'),
@@ -1064,7 +1064,7 @@ class TestTimeZoneSupportDateutil(TestTimeZoneSupportPytz):
         tt = to_datetime(ts)
         ut = tt.tz_convert('US/Eastern')
         expected = Index([9, 9, 9])
-        self.assert_index_equal(ut.hour, expected)
+        tm.assert_index_equal(ut.hour, expected)
 
     def test_tslib_tz_convert_trans_pos_plus_1__bug(self):
         # Regression test for tslib.tz_convert(vals, tz1, tz2).
@@ -1076,7 +1076,7 @@ class TestTimeZoneSupportDateutil(TestTimeZoneSupportPytz):
             idx = idx.tz_convert('Europe/Moscow')
 
             expected = np.repeat(np.array([3, 4, 5]), np.array([n, n, 1]))
-            self.assert_index_equal(idx.hour, Index(expected))
+            tm.assert_index_equal(idx.hour, Index(expected))
 
     def test_tslib_tz_convert_dst(self):
         for freq, n in [('H', 1), ('T', 60), ('S', 3600)]:
@@ -1087,14 +1087,14 @@ class TestTimeZoneSupportDateutil(TestTimeZoneSupportPytz):
             expected = np.repeat(np.array([18, 19, 20, 21, 22, 23,
                                            0, 1, 3, 4, 5]),
                                  np.array([n, n, n, n, n, n, n, n, n, n, 1]))
-            self.assert_index_equal(idx.hour, Index(expected))
+            tm.assert_index_equal(idx.hour, Index(expected))
 
             idx = date_range('2014-03-08 18:00', '2014-03-09 05:00', freq=freq,
                              tz='US/Eastern')
             idx = idx.tz_convert('UTC')
             expected = np.repeat(np.array([23, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9]),
                                  np.array([n, n, n, n, n, n, n, n, n, n, 1]))
-            self.assert_index_equal(idx.hour, Index(expected))
+            tm.assert_index_equal(idx.hour, Index(expected))
 
             # End DST
             idx = date_range('2014-11-01 23:00', '2014-11-02 09:00', freq=freq,
@@ -1103,7 +1103,7 @@ class TestTimeZoneSupportDateutil(TestTimeZoneSupportPytz):
             expected = np.repeat(np.array([19, 20, 21, 22, 23,
                                            0, 1, 1, 2, 3, 4]),
                                  np.array([n, n, n, n, n, n, n, n, n, n, 1]))
-            self.assert_index_equal(idx.hour, Index(expected))
+            tm.assert_index_equal(idx.hour, Index(expected))
 
             idx = date_range('2014-11-01 18:00', '2014-11-02 05:00', freq=freq,
                              tz='US/Eastern')
@@ -1112,30 +1112,30 @@ class TestTimeZoneSupportDateutil(TestTimeZoneSupportPytz):
                                            7, 8, 9, 10]),
                                  np.array([n, n, n, n, n, n, n, n, n,
                                            n, n, n, 1]))
-            self.assert_index_equal(idx.hour, Index(expected))
+            tm.assert_index_equal(idx.hour, Index(expected))
 
         # daily
         # Start DST
         idx = date_range('2014-03-08 00:00', '2014-03-09 00:00', freq='D',
                          tz='UTC')
         idx = idx.tz_convert('US/Eastern')
-        self.assert_index_equal(idx.hour, Index([19, 19]))
+        tm.assert_index_equal(idx.hour, Index([19, 19]))
 
         idx = date_range('2014-03-08 00:00', '2014-03-09 00:00', freq='D',
                          tz='US/Eastern')
         idx = idx.tz_convert('UTC')
-        self.assert_index_equal(idx.hour, Index([5, 5]))
+        tm.assert_index_equal(idx.hour, Index([5, 5]))
 
         # End DST
         idx = date_range('2014-11-01 00:00', '2014-11-02 00:00', freq='D',
                          tz='UTC')
         idx = idx.tz_convert('US/Eastern')
-        self.assert_index_equal(idx.hour, Index([20, 20]))
+        tm.assert_index_equal(idx.hour, Index([20, 20]))
 
         idx = date_range('2014-11-01 00:00', '2014-11-02 000:00', freq='D',
                          tz='US/Eastern')
         idx = idx.tz_convert('UTC')
-        self.assert_index_equal(idx.hour, Index([4, 4]))
+        tm.assert_index_equal(idx.hour, Index([4, 4]))
 
     def test_tzlocal(self):
         # GH 13583
@@ -1292,7 +1292,7 @@ class TestTimeZones(tm.TestCase):
         conv = rng.tz_localize('US/Pacific')
         exp = date_range('1/1/2011', periods=100, freq='H', tz='US/Pacific')
 
-        self.assert_index_equal(conv, exp)
+        tm.assert_index_equal(conv, exp)
 
     def test_tz_localize_roundtrip(self):
         for tz in self.timezones:
@@ -1424,7 +1424,7 @@ class TestTimeZones(tm.TestCase):
         result = test1.join(test2, how='outer')
         ex_index = test1.index.union(test2.index)
 
-        self.assert_index_equal(result.index, ex_index)
+        tm.assert_index_equal(result.index, ex_index)
         self.assertTrue(result.index.tz.zone == 'US/Central')
 
         # non-overlapping
@@ -1615,7 +1615,7 @@ class TestTimeZones(tm.TestCase):
         rng = date_range('03/12/2012 00:00', periods=10, freq='W-FRI',
                          tz='US/Eastern')
         rng2 = DatetimeIndex(data=rng, tz='US/Eastern')
-        self.assert_index_equal(rng, rng2)
+        tm.assert_index_equal(rng, rng2)
 
     def test_normalize_tz(self):
         rng = date_range('1/1/2000 9:30', periods=10, freq='D',
@@ -1624,7 +1624,7 @@ class TestTimeZones(tm.TestCase):
         result = rng.normalize()
         expected = date_range('1/1/2000', periods=10, freq='D',
                               tz='US/Eastern')
-        self.assert_index_equal(result, expected)
+        tm.assert_index_equal(result, expected)
 
         self.assertTrue(result.is_normalized)
         self.assertFalse(rng.is_normalized)
@@ -1633,7 +1633,7 @@ class TestTimeZones(tm.TestCase):
 
         result = rng.normalize()
         expected = date_range('1/1/2000', periods=10, freq='D', tz='UTC')
-        self.assert_index_equal(result, expected)
+        tm.assert_index_equal(result, expected)
 
         self.assertTrue(result.is_normalized)
         self.assertFalse(rng.is_normalized)
@@ -1642,7 +1642,7 @@ class TestTimeZones(tm.TestCase):
         rng = date_range('1/1/2000 9:30', periods=10, freq='D', tz=tzlocal())
         result = rng.normalize()
         expected = date_range('1/1/2000', periods=10, freq='D', tz=tzlocal())
-        self.assert_index_equal(result, expected)
+        tm.assert_index_equal(result, expected)
 
         self.assertTrue(result.is_normalized)
         self.assertFalse(rng.is_normalized)
@@ -1662,7 +1662,7 @@ class TestTimeZones(tm.TestCase):
                 result = rng.normalize()
                 expected = date_range('1/1/2000', periods=10, freq='D',
                                       tz=tzlocal())
-                self.assert_index_equal(result, expected)
+                tm.assert_index_equal(result, expected)
 
                 self.assertTrue(result.is_normalized)
                 self.assertFalse(rng.is_normalized)
@@ -1679,45 +1679,45 @@ class TestTimeZones(tm.TestCase):
                                       '2010-11-01 07:00'], freq='H', tz=tz)
 
             offset = dates + offsets.Hour(5)
-            self.assert_index_equal(offset, expected)
+            tm.assert_index_equal(offset, expected)
             offset = dates + np.timedelta64(5, 'h')
-            self.assert_index_equal(offset, expected)
+            tm.assert_index_equal(offset, expected)
             offset = dates + timedelta(hours=5)
-            self.assert_index_equal(offset, expected)
+            tm.assert_index_equal(offset, expected)
 
     def test_nat(self):
         # GH 5546
         dates = [NaT]
         idx = DatetimeIndex(dates)
         idx = idx.tz_localize('US/Pacific')
-        self.assert_index_equal(idx, DatetimeIndex(dates, tz='US/Pacific'))
+        tm.assert_index_equal(idx, DatetimeIndex(dates, tz='US/Pacific'))
         idx = idx.tz_convert('US/Eastern')
-        self.assert_index_equal(idx, DatetimeIndex(dates, tz='US/Eastern'))
+        tm.assert_index_equal(idx, DatetimeIndex(dates, tz='US/Eastern'))
         idx = idx.tz_convert('UTC')
-        self.assert_index_equal(idx, DatetimeIndex(dates, tz='UTC'))
+        tm.assert_index_equal(idx, DatetimeIndex(dates, tz='UTC'))
 
         dates = ['2010-12-01 00:00', '2010-12-02 00:00', NaT]
         idx = DatetimeIndex(dates)
         idx = idx.tz_localize('US/Pacific')
-        self.assert_index_equal(idx, DatetimeIndex(dates, tz='US/Pacific'))
+        tm.assert_index_equal(idx, DatetimeIndex(dates, tz='US/Pacific'))
         idx = idx.tz_convert('US/Eastern')
         expected = ['2010-12-01 03:00', '2010-12-02 03:00', NaT]
-        self.assert_index_equal(idx, DatetimeIndex(expected, tz='US/Eastern'))
+        tm.assert_index_equal(idx, DatetimeIndex(expected, tz='US/Eastern'))
 
         idx = idx + offsets.Hour(5)
         expected = ['2010-12-01 08:00', '2010-12-02 08:00', NaT]
-        self.assert_index_equal(idx, DatetimeIndex(expected, tz='US/Eastern'))
+        tm.assert_index_equal(idx, DatetimeIndex(expected, tz='US/Eastern'))
         idx = idx.tz_convert('US/Pacific')
         expected = ['2010-12-01 05:00', '2010-12-02 05:00', NaT]
-        self.assert_index_equal(idx, DatetimeIndex(expected, tz='US/Pacific'))
+        tm.assert_index_equal(idx, DatetimeIndex(expected, tz='US/Pacific'))
 
         idx = idx + np.timedelta64(3, 'h')
         expected = ['2010-12-01 08:00', '2010-12-02 08:00', NaT]
-        self.assert_index_equal(idx, DatetimeIndex(expected, tz='US/Pacific'))
+        tm.assert_index_equal(idx, DatetimeIndex(expected, tz='US/Pacific'))
 
         idx = idx.tz_convert('US/Eastern')
         expected = ['2010-12-01 11:00', '2010-12-02 11:00', NaT]
-        self.assert_index_equal(idx, DatetimeIndex(expected, tz='US/Eastern'))
+        tm.assert_index_equal(idx, DatetimeIndex(expected, tz='US/Eastern'))
 
 
 class TestTslib(tm.TestCase):

--- a/pandas/tests/tseries/test_timezones.py
+++ b/pandas/tests/tseries/test_timezones.py
@@ -87,7 +87,7 @@ class TestTimeZoneSupportPytz(tm.TestCase):
         rng_eastern = rng.tz_convert(self.tz('US/Eastern'))
 
         # Values are unmodified
-        self.assert_numpy_array_equal(rng.asi8, rng_eastern.asi8)
+        tm.assert_numpy_array_equal(rng.asi8, rng_eastern.asi8)
 
         self.assertEqual(rng_eastern.tz, self.tz('US/Eastern'))
 
@@ -100,7 +100,7 @@ class TestTimeZoneSupportPytz(tm.TestCase):
 
         converted = rng.tz_localize(self.tzstr('US/Eastern'))
         expected_naive = rng + offsets.Hour(5)
-        self.assert_numpy_array_equal(converted.asi8, expected_naive.asi8)
+        tm.assert_numpy_array_equal(converted.asi8, expected_naive.asi8)
 
         # DST ambiguity, this should fail
         rng = date_range('3/11/2012', '3/12/2012', freq='30T')
@@ -248,10 +248,10 @@ class TestTimeZoneSupportPytz(tm.TestCase):
         dti_utc = DatetimeIndex(start='1/1/2005 05:00',
                                 end='1/1/2005 5:00:30.256', freq='L', tz='utc')
 
-        self.assert_numpy_array_equal(dti2.values, dti_utc.values)
+        tm.assert_numpy_array_equal(dti2.values, dti_utc.values)
 
         dti3 = dti2.tz_convert(self.tzstr('US/Pacific'))
-        self.assert_numpy_array_equal(dti3.values, dti_utc.values)
+        tm.assert_numpy_array_equal(dti3.values, dti_utc.values)
 
         dti = DatetimeIndex(start='11/6/2011 1:59', end='11/6/2011 2:00',
                             freq='L')
@@ -394,7 +394,7 @@ class TestTimeZoneSupportPytz(tm.TestCase):
         fromdates = DatetimeIndex(strdates, tz=self.tzstr('US/Eastern'))
 
         self.assertEqual(conv.tz, fromdates.tz)
-        self.assert_numpy_array_equal(conv.values, fromdates.values)
+        tm.assert_numpy_array_equal(conv.values, fromdates.values)
 
     def test_field_access_localize(self):
         strdates = ['1/1/2012', '3/1/2012', '4/1/2012']
@@ -580,7 +580,7 @@ class TestTimeZoneSupportPytz(tm.TestCase):
 
         # left dtype is  datetime64[ns, US/Eastern]
         # right is datetime64[ns, tzfile('/usr/share/zoneinfo/US/Eastern')]
-        self.assert_numpy_array_equal(di_test.values, localized.values)
+        tm.assert_numpy_array_equal(di_test.values, localized.values)
 
     def test_ambiguous_bool(self):
         # make sure that we are correctly accepting bool values as ambiguous
@@ -743,9 +743,9 @@ class TestTimeZoneSupportPytz(tm.TestCase):
                           datetime(2000, 1, 2, tzinfo=fixed_off),
                           datetime(2000, 1, 3, tzinfo=fixed_off)])
         result = to_datetime(dates).to_pydatetime()
-        self.assert_numpy_array_equal(dates, result)
+        tm.assert_numpy_array_equal(dates, result)
         result = to_datetime(dates)._mpl_repr()
-        self.assert_numpy_array_equal(dates, result)
+        tm.assert_numpy_array_equal(dates, result)
 
     def test_convert_tz_aware_datetime_datetime(self):
         # #1581
@@ -761,7 +761,7 @@ class TestTimeZoneSupportPytz(tm.TestCase):
 
         converted = to_datetime(dates_aware, utc=True)
         ex_vals = np.array([Timestamp(x).value for x in dates_aware])
-        self.assert_numpy_array_equal(converted.asi8, ex_vals)
+        tm.assert_numpy_array_equal(converted.asi8, ex_vals)
         self.assertIs(converted.tz, pytz.utc)
 
     def test_to_datetime_utc(self):
@@ -1727,13 +1727,13 @@ class TestTslib(tm.TestCase):
             f = lambda x: tslib.tz_convert_single(x, 'UTC', tz_didx.tz)
             result = tslib.tz_convert(tz_didx.asi8, 'UTC', tz_didx.tz)
             result_single = np.vectorize(f)(tz_didx.asi8)
-            self.assert_numpy_array_equal(result, result_single)
+            tm.assert_numpy_array_equal(result, result_single)
 
         def compare_local_to_utc(tz_didx, utc_didx):
             f = lambda x: tslib.tz_convert_single(x, tz_didx.tz, 'UTC')
             result = tslib.tz_convert(utc_didx.asi8, tz_didx.tz, 'UTC')
             result_single = np.vectorize(f)(utc_didx.asi8)
-            self.assert_numpy_array_equal(result, result_single)
+            tm.assert_numpy_array_equal(result, result_single)
 
         for tz in ['UTC', 'Asia/Tokyo', 'US/Eastern', 'Europe/Moscow']:
             # US: 2014-03-09 - 2014-11-11
@@ -1759,11 +1759,11 @@ class TestTslib(tm.TestCase):
         result = tslib.tz_convert(np.array([], dtype=np.int64),
                                   tslib.maybe_get_tz('US/Eastern'),
                                   tslib.maybe_get_tz('Asia/Tokyo'))
-        self.assert_numpy_array_equal(result, np.array([], dtype=np.int64))
+        tm.assert_numpy_array_equal(result, np.array([], dtype=np.int64))
 
         # Check all-NaT array
         result = tslib.tz_convert(np.array([tslib.iNaT], dtype=np.int64),
                                   tslib.maybe_get_tz('US/Eastern'),
                                   tslib.maybe_get_tz('Asia/Tokyo'))
-        self.assert_numpy_array_equal(result, np.array(
+        tm.assert_numpy_array_equal(result, np.array(
             [tslib.iNaT], dtype=np.int64))


### PR DESCRIPTION
Title is self-explanatory.

We should be using `tm.assert_*` instead (they are static methods after all) and shouldn't really be invoked by the test instance.

Partially addresses #15990.