### PR TITLE
PERF: maybe_convert_numeric speedup

### DIFF
--- a/pandas/_libs/src/inference.pyx
+++ b/pandas/_libs/src/inference.pyx
@@ -954,7 +954,7 @@ def maybe_convert_numeric(ndarray[object] values, set na_values,
             maybe_ints = values.astype('i8')
             if (maybe_ints == values).all():
                 return maybe_ints
-        except ValueError:
+        except (ValueError, OverflowError, TypeError):
             pass
     elif util.is_float_object(val):
         try:
@@ -964,7 +964,7 @@ def maybe_convert_numeric(ndarray[object] values, set na_values,
             if ((lmask == rmask).all()
                 and (maybe_floats[lmask] == values[lmask]).all()):
                 return maybe_floats
-        except ValueError:
+        except (ValueError, OverflowError, TypeError):
             pass
     # otherwise, iterate and do full infererence
     cdef:
@@ -993,6 +993,7 @@ def maybe_convert_numeric(ndarray[object] values, set na_values,
         elif util.is_integer_object(val):
             floats[i] = complexes[i] = val
 
+            val = int(val)
             seen.saw_int(val)
 
             if val >= 0:

--- a/pandas/_libs/src/inference.pyx
+++ b/pandas/_libs/src/inference.pyx
@@ -947,7 +947,7 @@ def maybe_convert_numeric(ndarray[object] values, set na_values,
     -------
     numeric_array : array of converted object values to numerical ones
     """
-    # fastpath for ints/floats - try to convert in one shot based on first value
+    # fastpath for ints - try to convert all based on first value
     cdef object val = values[0]
     if util.is_integer_object(val):
         try:
@@ -956,16 +956,7 @@ def maybe_convert_numeric(ndarray[object] values, set na_values,
                 return maybe_ints
         except (ValueError, OverflowError, TypeError):
             pass
-    elif util.is_float_object(val):
-        try:
-            maybe_floats = values.astype('f8')
-            lmask = np.isnan(maybe_floats)
-            rmask = np.isnan(values)
-            if ((lmask == rmask).all()
-                and (maybe_floats[lmask] == values[lmask]).all()):
-                return maybe_floats
-        except (ValueError, OverflowError, TypeError):
-            pass
+
     # otherwise, iterate and do full infererence
     cdef:
         int status, maybe_int
@@ -985,10 +976,11 @@ def maybe_convert_numeric(ndarray[object] values, set na_values,
             seen.saw_null()
             floats[i] = complexes[i] = nan
         elif util.is_float_object(val):
-            if val != val:
+            fval = val
+            if fval != fval:
                 seen.null_ = True
 
-            floats[i] = complexes[i] = val
+            floats[i] = complexes[i] = fval
             seen.float_ = True
         elif util.is_integer_object(val):
             floats[i] = complexes[i] = val

--- a/pandas/_libs/src/inference.pyx
+++ b/pandas/_libs/src/inference.pyx
@@ -948,7 +948,7 @@ def maybe_convert_numeric(ndarray[object] values, set na_values,
     numeric_array : array of converted object values to numerical ones
     """
     # fastpath for ints/floats - try to convert in one shot based on first value
-    cdef object val = values[1]
+    cdef object val = values[0]
     if util.is_integer_object(val):
         try:
             maybe_ints = values.astype('i8')

--- a/pandas/_libs/src/inference.pyx
+++ b/pandas/_libs/src/inference.pyx
@@ -96,7 +96,7 @@ cdef class Seen(object):
     encountered when trying to perform type conversions.
     """
 
-    cdef public:
+    cdef:
         bint int_             # seen_int
         bint bool_            # seen_bool
         bint null_            # seen_null
@@ -185,7 +185,7 @@ cdef class Seen(object):
         self.null_ = 1
         self.float_ = 1
 
-    def saw_int(self, val):
+    cdef saw_int(self, object val):
         """
         Set flags indicating that an integer value was encountered.
 
@@ -196,7 +196,7 @@ cdef class Seen(object):
         """
         self.int_ = 1
         self.sint_ = self.sint_ or (val < 0)
-        self.uint_ = self.uint_ or (val > iINT64_MAX)
+        self.uint_ = self.uint_ or (val > oINT64_MAX)
 
     @property
     def numeric_(self):
@@ -908,11 +908,15 @@ cpdef bint is_interval_array(ndarray[object] values):
 cdef extern from "parse_helper.h":
     inline int floatify(object, double *result, int *maybe_int) except -1
 
-cdef int64_t iINT64_MAX = <int64_t> INT64_MAX
-cdef int64_t iINT64_MIN = <int64_t> INT64_MIN
-cdef uint64_t iUINT64_MAX = <uint64_t> UINT64_MAX
+# constants that will be compared to potentially arbitrarily large
+# python int
+cdef object oINT64_MAX = <object> INT64_MAX
+cdef object oINT64_MIN = <object> INT64_MIN
+cdef object oUINT64_MAX = <object> UINT64_MAX
 
 
+@cython.boundscheck(False)
+@cython.wraparound(False)
 def maybe_convert_numeric(ndarray[object] values, set na_values,
                           bint convert_empty=True, bint coerce_numeric=False):
     """
@@ -970,13 +974,12 @@ def maybe_convert_numeric(ndarray[object] values, set na_values,
         elif util.is_integer_object(val):
             floats[i] = complexes[i] = val
 
-            as_int = int(val)
-            seen.saw_int(as_int)
+            seen.saw_int(val)
 
-            if as_int >= 0:
-                uints[i] = as_int
-            if as_int <= iINT64_MAX:
-                ints[i] = as_int
+            if val >= 0:
+                uints[i] = val
+            if val <= oINT64_MAX:
+                ints[i] = val
         elif util.is_bool_object(val):
             floats[i] = uints[i] = ints[i] = bools[i] = val
             seen.bool_ = True
@@ -1017,12 +1020,12 @@ def maybe_convert_numeric(ndarray[object] values, set na_values,
                         seen.saw_int(as_int)
 
                     if not (seen.float_ or as_int in na_values):
-                        if as_int < iINT64_MIN or as_int > iUINT64_MAX:
+                        if as_int < oINT64_MIN or as_int > oUINT64_MAX:
                             raise ValueError('Integer out of range.')
 
                         if as_int >= 0:
                             uints[i] = as_int
-                        if as_int <= iINT64_MAX:
+                        if as_int <= oINT64_MAX:
                             ints[i] = as_int
                 else:
                     seen.float_ = True
@@ -1053,6 +1056,8 @@ def maybe_convert_numeric(ndarray[object] values, set na_values,
     return ints
 
 
+@cython.boundscheck(False)
+@cython.wraparound(False)
 def maybe_convert_objects(ndarray[object] objects, bint try_float=0,
                           bint safe=0, bint convert_datetime=0,
                           bint convert_timedelta=0):

--- a/pandas/_libs/src/inference.pyx
+++ b/pandas/_libs/src/inference.pyx
@@ -959,7 +959,10 @@ def maybe_convert_numeric(ndarray[object] values, set na_values,
     elif util.is_float_object(val):
         try:
             maybe_floats = values.astype('f8')
-            if (maybe_floats == values).all():
+            lmask = np.isnan(maybe_floats)
+            rmask = np.isnan(values)
+            if ((lmask == rmask).all()
+                and (maybe_floats[lmask] == values[lmask]).all()):
                 return maybe_floats
         except ValueError:
             pass


### PR DESCRIPTION
 xref #16043
 
Probably more to be done, but picks up some easy performance on the int path.  For some reason I'm having trouble running asv, here are some timings.

### setup
```
ints = np.array(list(range(1000000)), dtype=object)
floats = np.array([float(x) for x in range(1000000)], dtype=object)
ints_with_float = ints.copy()
ints_with_float[-1] = 1.2
```
### Master
```
In [2]: %timeit pd.to_numeric(floats)
10 loops, best of 3: 132 ms per loop

In [3]: %timeit pd.to_numeric(ints)
1 loop, best of 3: 437 ms per loop

In [4]: %timeit pd.to_numeric(ints_with_float)
1 loop, best of 3: 444 ms per loop
```

### PR
```
In [5]: %timeit pd.to_numeric(floats)
10 loops, best of 3: 88.9 ms per loop

In [6]: %timeit pd.to_numeric(ints)
10 loops, best of 3: 57.6 ms per loop

In [7]: %timeit pd.to_numeric(ints_with_float)
1 loop, best of 3: 392 ms per loop
```
