### PR TITLE
REGR: assure .unique of mixed strings does not stringize

### DIFF
--- a/pandas/core/algorithms.py
+++ b/pandas/core/algorithms.py
@@ -161,7 +161,11 @@ def _ensure_arraylike(values):
     """
     if not isinstance(values, (np.ndarray, ABCCategorical,
                                ABCIndexClass, ABCSeries)):
-        values = np.array(values)
+        inferred = lib.infer_dtype(values)
+        if inferred in ['mixed', 'string', 'unicode']:
+            values = np.asarray(values, dtype=object)
+        else:
+            values = np.asarray(values)
     return values
 
 

--- a/pandas/tests/indexes/common.py
+++ b/pandas/tests/indexes/common.py
@@ -323,6 +323,7 @@ class Base(object):
 
             idx = ind[[0] * 5]
             idx_unique = ind[[0]]
+
             # We test against `idx_unique`, so first we make sure it's unique
             # and doesn't contain nans.
             self.assertTrue(idx_unique.is_unique)
@@ -336,7 +337,6 @@ class Base(object):
                 tm.assert_index_equal(result, idx_unique)
 
             # nans:
-
             if not ind._can_hold_na:
                 continue
 

--- a/pandas/tests/test_algos.py
+++ b/pandas/tests/test_algos.py
@@ -387,6 +387,12 @@ class TestUnique(tm.TestCase):
         exp = np.array([1, 2, 2**63], dtype=np.uint64)
         tm.assert_numpy_array_equal(algos.unique(s), exp)
 
+    def test_nan_in_object_array(self):
+        l = ['a', np.nan, 'c', 'c']
+        result = pd.unique(l)
+        expected = np.array(['a', np.nan, 'c'], dtype=object)
+        tm.assert_numpy_array_equal(result, expected)
+
     def test_categorical(self):
 
         # we are expecting to return in the order
@@ -1378,8 +1384,8 @@ class TestMode(tm.TestCase):
         exp = Series([], dtype=np.float64)
         tm.assert_series_equal(algos.mode([]), exp)
 
-    # GH 15714
     def test_mode_single(self):
+        # GH 15714
         exp_single = [1]
         data_single = [1]
 


### PR DESCRIPTION
closes #16107

this *might* slow things down (because of the inferring), so will have to make a fix for that.