### PR TITLE
Add NaTType to tslib public api

### DIFF
--- a/pandas/tslib.py
+++ b/pandas/tslib.py
@@ -4,4 +4,4 @@ import warnings
 warnings.warn("The pandas.tslib module is deprecated and will be "
               "removed in a future version.", FutureWarning, stacklevel=2)
 from pandas._libs.tslib import (Timestamp, Timedelta,
-                               NaT, OutOfBoundsDatetime)
+                               NaT, NaTType, OutOfBoundsDatetime)


### PR DESCRIPTION
When testing the new `0.20.0` release candidate I found that the removal of `NaTType`  from the `tslib` public api breaks `odo`.

If this api breakage is actually intentional/desired I'm ok with this being closed however it should probably get a mention in the backwards incompatible API changes section of the whatsnew.

Whilst a deprecation warning is raised in https://github.com/pandas-dev/pandas/commit/648ae4f03622d8eafe1ca3b833bd6a99f56bece4#diff-d6b2c5dbe1e7fbda4ed4b87e0c49399f the removal of NaTType breaks the previous public api rendering the warning ineffective and not giving any 3rd party libraries a chance to make the necessary changes and cut a release