### PR TITLE
MAINT: asv with py3 on windows

### DIFF
--- a/asv_bench/asv.conf.json
+++ b/asv_bench/asv.conf.json
@@ -46,7 +46,6 @@
         "numexpr": [],
         "pytables": [null, ""],  // platform dependent, see excludes below
         "tables": [null, ""],
-        "libpython": [null, ""],
         "openpyxl": [],
         "xlsxwriter": [],
         "xlrd": [],
@@ -80,10 +79,6 @@
         {"environment_type": "conda", "pytables": null},
         {"environment_type": "(?!conda).*", "tables": null},
         {"environment_type": "(?!conda).*", "pytables": ""},
-        // On conda&win32, install libpython
-        {"sys_platform": "(?!win32).*", "libpython": ""},
-        {"environment_type": "conda", "sys_platform": "win32", "libpython": null},
-        {"environment_type": "(?!conda).*", "libpython": ""}
     ],
     "include": [],
 

--- a/asv_bench/asv.conf.json
+++ b/asv_bench/asv.conf.json
@@ -51,6 +51,9 @@
         "xlrd": [],
         "xlwt": [],
         "pytest": [],
+        // If using Windows with python 2.7 and want to build using the
+        // mingw toolchain (rather than MSVC), uncomment the following line.
+        // "libpython": [],
     },
 
     // Combinations of libraries/python versions can be excluded/included


### PR DESCRIPTION
 Since benchmarking on python 3, no longer want to install `libpython`
