### PR TITLE
Add shim modules with deprecation warnings to ensure backward compat

### DIFF
--- a/pandas/__init__.py
+++ b/pandas/__init__.py
@@ -58,6 +58,7 @@ from pandas.util.print_versions import show_versions
 from pandas.io.api import *
 from pandas.util._tester import test
 import pandas.testing
+from . import computation  # TODO: Remove when deprecated shim module is removed
 
 # extension module deprecations
 from pandas.util.depr_module import _DeprecatedModule

--- a/pandas/computation/__init__.py
+++ b/pandas/computation/__init__.py
@@ -1,0 +1,14 @@
+import warnings
+
+
+warnings.warn(
+    "The pandas.computation module is deprecated and will be removed in a future "
+    "version. Please import from the pandas.core.computation module instead.",
+    FutureWarning, stacklevel=2
+)
+
+
+from . import (
+    align, api, common, engines, eval,
+    expr, expressions, ops, pytables, scope
+)

--- a/pandas/computation/align.py
+++ b/pandas/computation/align.py
@@ -1,0 +1,1 @@
+from pandas.core.computation.align import *

--- a/pandas/computation/api.py
+++ b/pandas/computation/api.py
@@ -1,0 +1,1 @@
+from pandas.core.computation.api import *

--- a/pandas/computation/common.py
+++ b/pandas/computation/common.py
@@ -1,0 +1,1 @@
+from pandas.core.computation.common import *

--- a/pandas/computation/engines.py
+++ b/pandas/computation/engines.py
@@ -1,0 +1,1 @@
+from pandas.core.computation.engines import *

--- a/pandas/computation/eval.py
+++ b/pandas/computation/eval.py
@@ -1,0 +1,1 @@
+from pandas.core.computation.eval import *

--- a/pandas/computation/expr.py
+++ b/pandas/computation/expr.py
@@ -1,0 +1,1 @@
+from pandas.core.computation.expr import *

--- a/pandas/computation/expressions.py
+++ b/pandas/computation/expressions.py
@@ -1,0 +1,1 @@
+from pandas.core.computation.expressions import *

--- a/pandas/computation/ops.py
+++ b/pandas/computation/ops.py
@@ -1,0 +1,1 @@
+from pandas.core.computation.ops import *

--- a/pandas/computation/pytables.py
+++ b/pandas/computation/pytables.py
@@ -1,0 +1,1 @@
+from pandas.core.computation.pytables import *

--- a/pandas/computation/scope.py
+++ b/pandas/computation/scope.py
@@ -1,0 +1,1 @@
+from pandas.core.computation.scope import *

--- a/pandas/tools/hashing/__init__.py
+++ b/pandas/tools/hashing/__init__.py
@@ -1,0 +1,10 @@
+import warnings
+
+
+warnings.warn(
+    "The pandas.tools.hashimg module is deprecated and will be removed in a "
+    "future version. Please import from the pandas.util.hashing module instead.",
+    FutureWarning, stacklevel=2
+)
+
+from pandas.util.hashing import *

--- a/pandas/types/__init__.py
+++ b/pandas/types/__init__.py
@@ -1,0 +1,8 @@
+import warnings
+
+
+warnings.warn(
+    "The pandas.types module is deprecated and will be removed in a future "
+    "version. Please import from the pandas.core.dtypes module instead.",
+    FutureWarning, stacklevel=2
+)

--- a/pandas/types/api.py
+++ b/pandas/types/api.py
@@ -1,0 +1,1 @@
+from pandas.core.dtypes.api import *

--- a/pandas/types/cast.py
+++ b/pandas/types/cast.py
@@ -1,0 +1,1 @@
+from pandas.core.dtypes.cast import *

--- a/pandas/types/common.py
+++ b/pandas/types/common.py
@@ -1,0 +1,1 @@
+from pandas.core.dtypes.common import *

--- a/pandas/types/concat.py
+++ b/pandas/types/concat.py
@@ -1,0 +1,1 @@
+from pandas.core.dtypes.concat import *

--- a/pandas/types/dtypes.py
+++ b/pandas/types/dtypes.py
@@ -1,0 +1,1 @@
+from pandas.core.dtypes.dtypes import *

--- a/pandas/types/generic.py
+++ b/pandas/types/generic.py
@@ -1,0 +1,1 @@
+from pandas.core.dtypes.generic import *

--- a/pandas/types/inference.py
+++ b/pandas/types/inference.py
@@ -1,0 +1,1 @@
+from pandas.core.dtypes.inference import *

--- a/pandas/types/missing.py
+++ b/pandas/types/missing.py
@@ -1,0 +1,1 @@
+from pandas.core.dtypes.missing import *


### PR DESCRIPTION
The following shim modules are included:
  - `pandas.computation`
  - `pandas.tools.hashing`
  - `pandas.types`

Fixes #16138
