### PR TITLE
DOC: Fix table styling in main docs

### DIFF
--- a/doc/source/themes/nature_with_gtoc/static/nature.css_t
+++ b/doc/source/themes/nature_with_gtoc/static/nature.css_t
@@ -315,7 +315,6 @@ thead {
     vertical-align: bottom;
 }
 tr, th, td {
-    text-align: right;
     vertical-align: middle;
     padding: 0.5em 0.5em;
     line-height: normal;
@@ -325,6 +324,9 @@ tr, th, td {
 }
 th {
     font-weight: bold;
+}
+th.col_heading {
+    text-align: right;
 }
 tbody tr:nth-child(odd) {
     background: #f5f5f5;


### PR DESCRIPTION
When switching to nbsphinx, I modified the site's CSS so
that the converted notebook looks decent. This had some
unfortunate changes on tables elsewhere in the notebook.

This change fixes the headers to be left-aligned in the main site,
and right-aligned for the tables generated by `df.style` in the
nbsphinx-converted notebook.

xref https://github.com/pandas-dev/pandas/pull/15581/

Before:
<img width="801" alt="screen shot 2017-04-26 at 7 11 19 am" src="https://cloud.githubusercontent.com/assets/1312546/25437376/c568c4b2-2a5b-11e7-9bb0-f524d87d3813.png">


After:

![screen shot 2017-04-26 at 8 23 43 am](https://cloud.githubusercontent.com/assets/1312546/25437380/cba5a07a-2a5b-11e7-9669-e9e469e3a7e7.png)
