### PR TITLE
MAINT: Remove vestigial assertRaisesRegexp

### DIFF
--- a/pandas/tests/dtypes/test_common.py
+++ b/pandas/tests/dtypes/test_common.py
@@ -20,7 +20,7 @@ class TestPandasDtype(tm.TestCase):
         msg = 'not understood'
         invalid_list = [pd.Timestamp, 'pd.Timestamp', list]
         for dtype in invalid_list:
-            with tm.assertRaisesRegexp(TypeError, msg):
+            with tm.assert_raises_regex(TypeError, msg):
                 pandas_dtype(dtype)
 
         valid_list = [object, 'float64', np.object_, np.dtype('object'), 'O',

--- a/pandas/tests/series/test_constructors.py
+++ b/pandas/tests/series/test_constructors.py
@@ -35,7 +35,7 @@ class TestSeriesConstructors(TestData, tm.TestCase):
         msg = 'not understood'
         invalid_list = [pd.Timestamp, 'pd.Timestamp', list]
         for dtype in invalid_list:
-            with tm.assertRaisesRegexp(TypeError, msg):
+            with tm.assert_raises_regex(TypeError, msg):
                 Series([], name='time', dtype=dtype)
 
     def test_scalar_conversion(self):

--- a/pandas/tests/test_base.py
+++ b/pandas/tests/test_base.py
@@ -45,7 +45,7 @@ class CheckImmutable(object):
     mutable_regex = re.compile('does not support mutable operations')
 
     def check_mutable_error(self, *args, **kwargs):
-        # Pass whatever function you normally would to assertRaisesRegexp
+        # Pass whatever function you normally would to assert_raises_regex
         # (after the Exception kind).
         tm.assert_raises_regex(
             TypeError, self.mutable_regex, *args, **kwargs)


### PR DESCRIPTION
Removes remaining `assertRaisesRegexp` before #16119 got merged.

This must be merged in ASAP because `master` will fail otherwise.

@jreback 
@jorisvandenbossche 