### PR TITLE
CLN: remove unused TimeGrouper._get_binner_for_resample() method

### DIFF
--- a/pandas/core/resample.py
+++ b/pandas/core/resample.py
@@ -1099,23 +1099,6 @@ class TimeGrouper(Grouper):
         r._set_binner()
         return r.binner, r.grouper, r.obj
 
-    def _get_binner_for_resample(self, kind=None):
-        # create the BinGrouper
-        # assume that self.set_grouper(obj) has already been called
-
-        ax = self.ax
-        if kind is None:
-            kind = self.kind
-        if kind is None or kind == 'timestamp':
-            self.binner, bins, binlabels = self._get_time_bins(ax)
-        elif kind == 'timedelta':
-            self.binner, bins, binlabels = self._get_time_delta_bins(ax)
-        else:
-            self.binner, bins, binlabels = self._get_time_period_bins(ax)
-
-        self.grouper = BinGrouper(bins, binlabels)
-        return self.binner, self.grouper, self.obj
-
     def _get_binner_for_grouping(self, obj):
         # return an ordering of the transformed group labels,
         # suitable for multi-grouping, e.g the labels for


### PR DESCRIPTION
 - [x] tests passed
 - [x] passes ``git diff upstream/master --name-only -- '*.py' | flake8 --diff``
 - [ ] whatsnew entry

method seems unused and is not covered by tests -> remove it?
