### PR TITLE
Add column index to be removed in get_dummies

### DIFF
--- a/pandas/core/reshape/reshape.py
+++ b/pandas/core/reshape/reshape.py
@@ -1242,7 +1242,7 @@ def _get_dummies_1d(data, prefix, prefix_sep='_', dummy_na=False,
         levels = np.append(levels, np.nan)
 
     # if dummy_na, we just fake a nan level. drop_first will drop it again
-    if drop_colidx is not False and len(levels) == 1:
+    if drop_idx is not False and len(levels) == 1:
         return get_empty_Frame(data, sparse)
 
     number_of_cols = len(levels)

--- a/pandas/core/reshape/reshape.py
+++ b/pandas/core/reshape/reshape.py
@@ -1293,7 +1293,7 @@ def _get_dummies_1d(data, prefix, prefix_sep='_', dummy_na=False,
             # reset NaN GH4446
             dummy_mat[codes == -1] = 0
 
-                if (drop_idx==True) & (type(drop_idx)!=int) :
+        if (drop_idx==True) & (type(drop_idx)!=int) :
             # remove first categorical level to avoid perfect collinearity
             # GH12042
             dummy_mat = dummy_mat[:, 1:]


### PR DESCRIPTION
While create dummies with get_dummies, we sometime want to remove an other column than the first one.
Add this possibility by :
- changing drop_first to drop_idx,
- drop_idx accept both bool (as drop_first) and int

 - [ ] closes #xxxx
 - [ ] tests added / passed
 - [ ] passes ``git diff upstream/master --name-only -- '*.py' | flake8 --diff``
 - [ ] whatsnew entry
