### PR TITLE
DEPR: deprecate is_any_int_dtype and is_floating_dtype from pandas.api.types

### DIFF
--- a/doc/source/api.rst
+++ b/doc/source/api.rst
@@ -1939,3 +1939,29 @@ Data types related functionality
    api.types.union_categoricals
    api.types.infer_dtype
    api.types.pandas_dtype
+
+Dtype introspection
+
+.. autosummary::
+   :toctree: generated/
+
+    api.types.is_bool_dtype
+    api.types.is_categorical_dtype
+    api.types.is_complex_dtype
+    api.types.is_datetime64_any_dtype
+    api.types.is_datetime64_dtype
+    api.types.is_datetime64_ns_dtype
+    api.types.is_datetime64tz_dtype
+    api.types.is_extension_type
+    api.types.is_float_dtype
+    api.types.is_int64_dtype
+    api.types.is_integer_dtype
+    api.types.is_interval_dtype
+    api.types.is_numeric_dtype
+    api.types.is_object_dtype
+    api.types.is_period_dtype
+    api.types.is_signed_integer_dtype
+    api.types.is_string_dtype
+    api.types.is_timedelta64_dtype
+    api.types.is_timedelta64_ns_dtype
+    api.types.is_unsigned_integer_dtype

--- a/doc/source/api.rst
+++ b/doc/source/api.rst
@@ -1965,3 +1965,35 @@ Dtype introspection
     api.types.is_timedelta64_dtype
     api.types.is_timedelta64_ns_dtype
     api.types.is_unsigned_integer_dtype
+    api.types.is_sparse
+
+Iterable introspection
+
+    api.types.is_dict_like
+    api.types.is_file_like
+    api.types.is_list_like
+    api.types.is_named_tuple
+    api.types.is_iterator
+    api.types.is_sequence
+
+.. autosummary::
+   :toctree: generated/
+
+Scalar introspection
+
+.. autosummary::
+   :toctree: generated/
+
+    api.types.is_bool
+    api.types.is_categorical
+    api.types.is_complex
+    api.types.is_datetimetz
+    api.types.is_float
+    api.types.is_hashable
+    api.types.is_integer
+    api.types.is_interval
+    api.types.is_number
+    api.types.is_period
+    api.types.is_re
+    api.types.is_re_compilable
+    api.types.is_scalar

--- a/doc/source/whatsnew/v0.20.0.txt
+++ b/doc/source/whatsnew/v0.20.0.txt
@@ -1520,6 +1520,7 @@ Other Deprecations
   * ``pd.match()``, is removed.
   * ``pd.groupby()``, replaced by using the ``.groupby()`` method directly on a ``Series/DataFrame``
   * ``pd.get_store()``, replaced by a direct call to ``pd.HDFStore(...)``
+- ``is_any_int_dtype`` and ``is_floating_dtype`` are deprecated from ``pandas.api.types`` (:issue:`16042`)
 
 .. _whatsnew_0200.prior_deprecations:
 

--- a/pandas/api/types/__init__.py
+++ b/pandas/api/types/__init__.py
@@ -7,4 +7,3 @@ from pandas.core.dtypes.dtypes import (CategoricalDtype,  # noqa
                                        IntervalDtype)
 from pandas.core.dtypes.concat import union_categoricals  # noqa
 from pandas._libs.lib import infer_dtype  # noqa
-del np  # noqa

--- a/pandas/core/dtypes/api.py
+++ b/pandas/core/dtypes/api.py
@@ -1,6 +1,6 @@
 # flake8: noqa
 
-import numpy as np
+import sys
 
 from .common import (pandas_dtype,
                      is_dtype_equal,
@@ -40,12 +40,10 @@ from .common import (pandas_dtype,
                      is_float,
                      is_complex,
                      is_number,
-                     is_any_int_dtype,
                      is_integer_dtype,
                      is_int64_dtype,
                      is_numeric_dtype,
                      is_float_dtype,
-                     is_floating_dtype,
                      is_bool_dtype,
                      is_complex_dtype,
                      is_signed_integer_dtype,
@@ -61,3 +59,24 @@ from .common import (pandas_dtype,
                      is_hashable,
                      is_named_tuple,
                      is_sequence)
+
+
+# deprecated
+m = sys.modules['pandas.core.dtypes.api']
+
+for t in ['is_any_int_dtype', 'is_floating_dtype']:
+
+    def outer(t=t):
+
+        def wrapper(arr_or_dtype):
+            import warnings
+            import pandas
+            warnings.warn("{t} is deprecated and will be "
+                          "removed in a future version".format(t=t),
+                          FutureWarning, stacklevel=3)
+            return getattr(pandas.core.dtypes.common, t)(arr_or_dtype)
+        return wrapper
+
+    setattr(m, t, outer(t))
+
+del sys, m, t, outer

--- a/pandas/tests/api/test_types.py
+++ b/pandas/tests/api/test_types.py
@@ -15,13 +15,13 @@ from .test_api import Base
 
 class TestTypes(Base, tm.TestCase):
 
-    allowed = ['is_any_int_dtype', 'is_bool', 'is_bool_dtype',
+    allowed = ['is_bool', 'is_bool_dtype',
                'is_categorical', 'is_categorical_dtype', 'is_complex',
                'is_complex_dtype', 'is_datetime64_any_dtype',
                'is_datetime64_dtype', 'is_datetime64_ns_dtype',
                'is_datetime64tz_dtype', 'is_datetimetz', 'is_dtype_equal',
                'is_extension_type', 'is_float', 'is_float_dtype',
-               'is_floating_dtype', 'is_int64_dtype', 'is_integer',
+               'is_int64_dtype', 'is_integer',
                'is_integer_dtype', 'is_number', 'is_numeric_dtype',
                'is_object_dtype', 'is_scalar', 'is_sparse',
                'is_string_dtype', 'is_signed_integer_dtype',
@@ -33,12 +33,13 @@ class TestTypes(Base, tm.TestCase):
                'is_list_like', 'is_hashable',
                'is_named_tuple', 'is_sequence',
                'pandas_dtype', 'union_categoricals', 'infer_dtype']
+    deprecated = ['is_any_int_dtype', 'is_floating_dtype']
     dtypes = ['CategoricalDtype', 'DatetimeTZDtype',
               'PeriodDtype', 'IntervalDtype']
 
     def test_types(self):
 
-        self.check(types, self.allowed + self.dtypes)
+        self.check(types, self.allowed + self.dtypes + self.deprecated)
 
     def check_deprecation(self, fold, fnew):
         with tm.assert_produces_warning(DeprecationWarning):
@@ -86,6 +87,13 @@ class TestTypes(Base, tm.TestCase):
         for t in ['is_null_datelike_scalar',
                   'ensure_float']:
             pytest.raises(AttributeError, lambda: getattr(com, t))
+
+    def test_deprecated_from_api_types(self):
+
+        for t in ['is_any_int_dtype', 'is_floating_dtype']:
+            with tm.assert_produces_warning(FutureWarning,
+                                            check_stacklevel=False):
+                getattr(types, t)(1)
 
 
 def test_moved_infer_dtype():


### PR DESCRIPTION
closes #16042 

