### PR TITLE
Support resetting index with tuple name

### DIFF
--- a/doc/source/whatsnew/v0.20.0.txt
+++ b/doc/source/whatsnew/v0.20.0.txt
@@ -490,6 +490,7 @@ Other Enhancements
 - ``Series.interpolate()`` now supports timedelta as an index type with ``method='time'`` (:issue:`6424`)
 - Addition of a ``level`` keyword to ``DataFrame/Series.rename`` to rename
   labels in the specified level of a MultiIndex (:issue:`4160`).
+- ``DataFrame.reset_index()`` will now interpret a tuple ``index.name`` as a key spanning across levels of ``columns``, if this is a ``MultiIndex`` (:issues:`16164`)
 - ``Timedelta.isoformat`` method added for formatting Timedeltas as an `ISO 8601 duration`_. See the :ref:`Timedelta docs <timedeltas.isoformat>` (:issue:`15136`)
 - ``.select_dtypes()`` now allows the string ``datetimetz`` to generically select datetimes with tz (:issue:`14910`)
 - The ``.to_latex()`` method will now accept ``multicolumn`` and ``multirow`` arguments to use the accompanying LaTeX enhancements

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -3034,7 +3034,7 @@ it is assumed to be aliases for the column names.')
             for i, (lev, lab) in reversed(list(enumerate(to_insert))):
                 col_name = names[i]
 
-                if multi_col:
+                if multi_col and not isinstance(col_name, tuple):
                     if col_fill is None:
                         col_name = tuple([col_name] * self.columns.nlevels)
                     else:

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -3019,17 +3019,17 @@ it is assumed to be aliases for the column names.')
                 if len(level) < len(self.index.levels):
                     new_index = self.index.droplevel(level)
 
-            if not drop:
+        if not drop:
+            if isinstance(self.index, MultiIndex):
                 names = [n if n is not None else ('level_%d' % i)
                          for (i, n) in enumerate(self.index.names)]
                 to_insert = lzip(self.index.levels, self.index.labels)
+            else:
+                default = 'index' if 'index' not in self else 'level_0'
+                names = ([default] if self.index.name is None
+                         else [self.index.name])
+                to_insert = ((self.index, None),)
 
-        elif not drop:
-            default = 'index' if 'index' not in self else 'level_0'
-            names = [default] if self.index.name is None else [self.index.name]
-            to_insert = ((self.index, None),)
-
-        if not drop:
             multi_col = isinstance(self.columns, MultiIndex)
             for i, (lev, lab) in reversed(list(enumerate(to_insert))):
                 name = names[i]

--- a/pandas/tests/test_multilevel.py
+++ b/pandas/tests/test_multilevel.py
@@ -2255,6 +2255,14 @@ Thur,Lunch,Yes,51.51,17"""
         result = df.set_index([('A', '')]).reset_index()
         tm.assert_frame_equal(result, df)
 
+        # with additional (unnamed) index level
+        idx_col = pd.DataFrame([[0], [1]],
+                               columns=pd.MultiIndex.from_tuples([('level_0',
+                                                                   '')]))
+        expected = pd.concat([idx_col, df[[('B', 'b'), ('A', '')]]], axis=1)
+        result = df.set_index([('B', 'b')], append=True).reset_index()
+        tm.assert_frame_equal(result, expected)
+
     def test_set_index_period(self):
         # GH 6631
         df = DataFrame(np.random.random(6))

--- a/pandas/tests/test_multilevel.py
+++ b/pandas/tests/test_multilevel.py
@@ -2242,16 +2242,18 @@ Thur,Lunch,Yes,51.51,17"""
         levels = [['A', ''], ['B', 'b']]
         df = pd.DataFrame([[0, 2], [1, 3]],
                           columns=pd.MultiIndex.from_tuples(levels))
-        expected = df.copy()
-        df.index.name = 'A'
-        result = df[['B']].reset_index()
-        tm.assert_frame_equal(result, expected)
+        result = df[['B']].rename_axis('A').reset_index()
+        tm.assert_frame_equal(result, df)
 
         # gh-16120: already existing column
         with tm.assert_raises_regex(ValueError,
                                     ("cannot insert \('A', ''\), "
                                      "already exists")):
-            df.reset_index()
+            df.rename_axis('A').reset_index()
+
+        # gh-16164: multiindex (tuple) full key
+        result = df.set_index([('A', '')]).reset_index()
+        tm.assert_frame_equal(result, df)
 
     def test_set_index_period(self):
         # GH 6631

--- a/pandas/tests/test_multilevel.py
+++ b/pandas/tests/test_multilevel.py
@@ -2263,6 +2263,29 @@ Thur,Lunch,Yes,51.51,17"""
         result = df.set_index([('B', 'b')], append=True).reset_index()
         tm.assert_frame_equal(result, expected)
 
+        # with index name which is a too long tuple...
+        with tm.assert_raises_regex(ValueError,
+                                    ("Item must have length equal to number "
+                                     "of levels.")):
+            df.rename_axis([('C', 'c', 'i')]).reset_index()
+        # or too short...
+        levels = [['A', 'a', ''], ['B', 'b', 'i']]
+        df2 = pd.DataFrame([[0, 2], [1, 3]],
+                           columns=pd.MultiIndex.from_tuples(levels))
+        idx_col = pd.DataFrame([[0], [1]],
+                               columns=pd.MultiIndex.from_tuples([('C',
+                                                                   'c',
+                                                                   'ii')]))
+        expected = pd.concat([idx_col, df2], axis=1)
+        result = df2.rename_axis([('C', 'c')]).reset_index(col_fill='ii')
+        tm.assert_frame_equal(result, expected)
+
+        # ... which is incompatible with col_fill=None
+        with tm.assert_raises_regex(ValueError,
+                                    ("col_fill=None is incompatible with "
+                                     "incomplete column name \('C', 'c'\)")):
+            df2.rename_axis([('C', 'c')]).reset_index(col_fill=None)
+
     def test_set_index_period(self):
         # GH 6631
         df = DataFrame(np.random.random(6))


### PR DESCRIPTION
 - [x] closes #16164
 - [x] tests added / passed
 - [x] passes ``git diff master --name-only -- '*.py' | flake8 --diff``
 - [x] whatsnew entry

Notice the first commit is pure refactoring, and the bug is actually fixed by the [one-liner](https://github.com/pandas-dev/pandas/pull/16165/commits/e12bca109658435a709dda0858869323a7af6783#diff-1e79abbbdd150d4771b91ea60a4e1cc7R3036) second commit.