### PR TITLE
BUG: Restore return value in notebook reprs

### DIFF
--- a/pandas/core/config_init.py
+++ b/pandas/core/config_init.py
@@ -309,39 +309,12 @@ def mpl_style_cb(key):
 
 def table_schema_cb(key):
     # Having _ipython_display_ defined messes with the return value
-    # from cells, so the Out[x] dicitonary breaks.
+    # from cells, so the Out[x] dictionary breaks.
     # Currently table schema is the only thing using it, so we'll
-    # monkey patch `_ipython_displa_` onto NDFrame when config option
+    # monkey patch `_ipython_display_` onto NDFrame when config option
     # is set
     # see https://github.com/pandas-dev/pandas/issues/16168
-    from pandas.core.generic import NDFrame
-
-    def _ipython_display_(self):
-        from pandas.errors import UnserializableWarning
-
-        try:
-            from IPython.display import display
-        except ImportError:
-            return None
-
-        # Series doesn't define _repr_html_ or _repr_latex_
-        latex = self._repr_latex_() if hasattr(self, '_repr_latex_') else None
-        html = self._repr_html_() if hasattr(self, '_repr_html_') else None
-        try:
-            table_schema = self._repr_table_schema_()
-        except Exception as e:
-            warnings.warn("Cannot create table schema representation. "
-                          "{}".format(e), UnserializableWarning)
-            table_schema = None
-        # We need the inital newline since we aren't going through the
-        # usual __repr__. See
-        # https://github.com/pandas-dev/pandas/pull/14904#issuecomment-277829277
-        text = "\n" + repr(self)
-
-        reprs = {"text/plain": text, "text/html": html, "text/latex": latex,
-                 "application/vnd.dataresource+json": table_schema}
-        reprs = {k: v for k, v in reprs.items() if v}
-        display(reprs, raw=True)
+    from pandas.core.generic import NDFrame, _ipython_display_
 
     if cf.get_option(key):
         NDFrame._ipython_display_ = _ipython_display_

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -130,13 +130,6 @@ class NDFrame(PandasObject, SelectionMixin):
         object.__setattr__(self, '_data', data)
         object.__setattr__(self, '_item_cache', {})
 
-    # def _repr_ipython_(self):
-    #     This is defined in config_init.py and monkey patched
-    #     onto NDFrame, depending on the display.html.table_schema
-    #     setting. Defining a _repr_iptyhon_ means notebook cells to not
-    #     have a return value.
-    #     See https://github.com/ipython/ipython/issues/10491
-
     def _repr_table_schema_(self):
         """
         Not a real Jupyter special repr method, but we use the same
@@ -6263,6 +6256,38 @@ def _make_logical_function(cls, name, name1, name2, axis_descr, desc, f):
                             name=name)
 
     return set_function_name(logical_func, name, cls)
+
+
+def _ipython_display_(self):
+    # Having _ipython_display_ defined messes with the return value
+    # from cells, so the Out[x] dictionary breaks.
+    # Currently table schema is the only thing using it, so we'll
+    # monkey patch `_ipython_display_` onto NDFrame when config option
+    # is set
+    # see https://github.com/pandas-dev/pandas/issues/16168
+    try:
+        from IPython.display import display
+    except ImportError:
+        return None
+
+    # Series doesn't define _repr_html_ or _repr_latex_
+    latex = self._repr_latex_() if hasattr(self, '_repr_latex_') else None
+    html = self._repr_html_() if hasattr(self, '_repr_html_') else None
+    try:
+        table_schema = self._repr_table_schema_()
+    except Exception as e:
+        warnings.warn("Cannot create table schema representation. "
+                      "{}".format(e), UnserializableWarning)
+        table_schema = None
+    # We need the inital newline since we aren't going through the
+    # usual __repr__. See
+    # https://github.com/pandas-dev/pandas/pull/14904#issuecomment-277829277
+    text = "\n" + repr(self)
+
+    reprs = {"text/plain": text, "text/html": html, "text/latex": latex,
+             "application/vnd.dataresource+json": table_schema}
+    reprs = {k: v for k, v in reprs.items() if v}
+    display(reprs, raw=True)
 
 
 # install the indexes

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -130,30 +130,12 @@ class NDFrame(PandasObject, SelectionMixin):
         object.__setattr__(self, '_data', data)
         object.__setattr__(self, '_item_cache', {})
 
-    def _ipython_display_(self):
-        try:
-            from IPython.display import display
-        except ImportError:
-            return None
-
-        # Series doesn't define _repr_html_ or _repr_latex_
-        latex = self._repr_latex_() if hasattr(self, '_repr_latex_') else None
-        html = self._repr_html_() if hasattr(self, '_repr_html_') else None
-        try:
-            table_schema = self._repr_table_schema_()
-        except Exception as e:
-            warnings.warn("Cannot create table schema representation. "
-                          "{}".format(e), UnserializableWarning)
-            table_schema = None
-        # We need the inital newline since we aren't going through the
-        # usual __repr__. See
-        # https://github.com/pandas-dev/pandas/pull/14904#issuecomment-277829277
-        text = "\n" + repr(self)
-
-        reprs = {"text/plain": text, "text/html": html, "text/latex": latex,
-                 "application/vnd.dataresource+json": table_schema}
-        reprs = {k: v for k, v in reprs.items() if v}
-        display(reprs, raw=True)
+    # def _repr_ipython_(self):
+    #     This is defined in config_init.py and monkey patched
+    #     onto NDFrame, depending on the display.html.table_schema
+    #     setting. Defining a _repr_iptyhon_ means notebook cells to not
+    #     have a return value.
+    #     See https://github.com/ipython/ipython/issues/10491
 
     def _repr_table_schema_(self):
         """

--- a/pandas/tests/io/formats/test_printing.py
+++ b/pandas/tests/io/formats/test_printing.py
@@ -218,6 +218,19 @@ class TestTableSchemaRepr(tm.TestCase):
 
         assert not hasattr(df, '_ipython_display_')
         assert not hasattr(df['A'], '_ipython_display_')
+        # re-unsetting is OK
+        assert not hasattr(df, '_ipython_display_')
+        assert not hasattr(df['A'], '_ipython_display_')
+
+        # able to re-set
+        with pd.option_context('display.html.table_schema', True):
+            assert hasattr(df, '_ipython_display_')
+            # smoke test that it works
+            df._ipython_display_()
+            assert hasattr(df['A'], '_ipython_display_')
+            df['A']._ipython_display_()
+
+
 
 
 # TODO: fix this broken test

--- a/pandas/tests/io/formats/test_printing.py
+++ b/pandas/tests/io/formats/test_printing.py
@@ -203,6 +203,22 @@ class TestTableSchemaRepr(tm.TestCase):
 
         assert result is None
 
+    def test_config_monkeypatches(self):
+        # GH 10491
+        df = pd.DataFrame({"A": [1, 2]})
+        assert not hasattr(df, '_ipython_display_')
+        assert not hasattr(df['A'], '_ipython_display_')
+
+        with pd.option_context('display.html.table_schema', True):
+            assert hasattr(df, '_ipython_display_')
+            # smoke test that it works
+            df._ipython_display_()
+            assert hasattr(df['A'], '_ipython_display_')
+            df['A']._ipython_display_()
+
+        assert not hasattr(df, '_ipython_display_')
+        assert not hasattr(df['A'], '_ipython_display_')
+
 
 # TODO: fix this broken test
 

--- a/pandas/tests/io/formats/test_printing.py
+++ b/pandas/tests/io/formats/test_printing.py
@@ -231,8 +231,6 @@ class TestTableSchemaRepr(tm.TestCase):
             df['A']._ipython_display_()
 
 
-
-
 # TODO: fix this broken test
 
 # def test_console_encode():


### PR DESCRIPTION
Monkey patches the _ipython_display_ method onto NDFrame, so that
notebook cells have a real return value. Setting the
display.html.table_schema will monkey patch the method on,
and remove it when unset.

closes https://github.com/ipython/ipython/issues/10491