### PR TITLE
BUG: Made SparseDataFrame.fillna() fill all NaNs

### DIFF
--- a/pandas/core/sparse/array.py
+++ b/pandas/core/sparse/array.py
@@ -595,14 +595,12 @@ class SparseArray(PandasObject, np.ndarray):
         if issubclass(self.dtype.type, np.floating):
             value = float(value)
 
-        if self._null_fill_value:
-            return self._simple_new(self.sp_values, self.sp_index,
-                                    fill_value=value)
-        else:
-            new_values = self.sp_values.copy()
-            new_values[isnull(new_values)] = value
-            return self._simple_new(new_values, self.sp_index,
-                                    fill_value=self.fill_value)
+        new_values = self.sp_values.copy()
+        new_values[isnull(new_values)] = value
+        fill_value = value if isnull(self.fill_value) else self.fill_value
+
+        return self._simple_new(new_values, self.sp_index,
+                                fill_value=fill_value)
 
     def sum(self, axis=0, *args, **kwargs):
         """


### PR DESCRIPTION
 - [x] closes #16112 
 - [x] tests added / passed
 - [x] passes ``git diff upstream/master --name-only -- '*.py' | flake8 --diff``

The dia and dok format matrices seem to have other, unrelated bugs that prevent correct initialization. Therefore, they are excluded from tests in this commit. See #16177 and #16179.
I'm new to the codebase here, so any comments are greatly welcomed!