### PR TITLE
TST: DatetimeIndex and its Timestamp elements returning same .weekofyear with tz (#6538)

### DIFF
--- a/doc/source/whatsnew/v0.20.0.txt
+++ b/doc/source/whatsnew/v0.20.0.txt
@@ -1580,7 +1580,7 @@ Conversion
 
 - Bug in ``Timestamp.replace`` now raises ``TypeError`` when incorrect argument names are given; previously this raised ``ValueError`` (:issue:`15240`)
 - Bug in ``Timestamp.replace`` with compat for passing long integers (:issue:`15030`)
-- Bug in ``Timestamp`` returning UTC based time/date attributes when a timezone was provided (:issue:`13303`)
+- Bug in ``Timestamp`` returning UTC based time/date attributes when a timezone was provided (:issue:`13303`, :issue:`6538`)
 - Bug in ``Timestamp`` incorrectly localizing timezones during construction (:issue:`11481`, :issue:`15777`)
 - Bug in ``TimedeltaIndex`` addition where overflow was being allowed without error (:issue:`14816`)
 - Bug in ``TimedeltaIndex`` raising a ``ValueError`` when boolean indexing with ``loc`` (:issue:`14946`)

--- a/pandas/tests/indexes/datetimes/test_misc.py
+++ b/pandas/tests/indexes/datetimes/test_misc.py
@@ -334,6 +334,14 @@ class TestDatetime64(tm.TestCase):
         for ts, value in tests:
             assert ts == value
 
+        # GH 6538: Check that DatetimeIndex and its TimeStamp elements
+        # return the same weekofyear accessor close to new year w/ tz
+        dates = ["2013/12/29", "2013/12/30", "2013/12/31"]
+        dates = DatetimeIndex(dates, tz="Europe/Brussels")
+        expected = [52, 1, 1]
+        assert dates.weekofyear.tolist() == expected
+        assert [d.weekofyear for d in dates] == expected
+
     def test_nanosecond_field(self):
         dti = DatetimeIndex(np.arange(10))
 


### PR DESCRIPTION
 - [x] closes #6538
 - [x] tests added / passed
 - [x] passes ``git diff upstream/master --name-only -- '*.py' | flake8 --diff``

I think this was closed by PR #15740.
