### PR TITLE
MAINT: Remove self.assertAlmostEqual from testing

### DIFF
--- a/pandas/tests/indexing/test_chaining_and_caching.py
+++ b/pandas/tests/indexing/test_chaining_and_caching.py
@@ -32,7 +32,7 @@ class TestCaching(tm.TestCase):
             # Assignment to wrong series
             df['bb'].iloc[0] = 0.17
             df._clear_item_cache()
-            self.assertAlmostEqual(df['bb'][0], 0.17)
+            tm.assert_almost_equal(df['bb'][0], 0.17)
 
     def test_setitem_cache_updating(self):
         # GH 5424

--- a/pandas/tests/io/json/test_ujson.py
+++ b/pandas/tests/io/json/test_ujson.py
@@ -738,37 +738,37 @@ class UltraJSONTests(TestCase):
     def test_numericIntFrcExp(self):
         input = "1.337E40"
         output = ujson.decode(input)
-        self.assertAlmostEqual(output, json.loads(input))
+        tm.assert_almost_equal(output, json.loads(input))
 
     def test_decodeNumericIntExpEPLUS(self):
         input = "1337E+9"
         output = ujson.decode(input)
-        self.assertAlmostEqual(output, json.loads(input))
+        tm.assert_almost_equal(output, json.loads(input))
 
     def test_decodeNumericIntExpePLUS(self):
         input = "1.337e+40"
         output = ujson.decode(input)
-        self.assertAlmostEqual(output, json.loads(input))
+        tm.assert_almost_equal(output, json.loads(input))
 
     def test_decodeNumericIntExpE(self):
         input = "1337E40"
         output = ujson.decode(input)
-        self.assertAlmostEqual(output, json.loads(input))
+        tm.assert_almost_equal(output, json.loads(input))
 
     def test_decodeNumericIntExpe(self):
         input = "1337e40"
         output = ujson.decode(input)
-        self.assertAlmostEqual(output, json.loads(input))
+        tm.assert_almost_equal(output, json.loads(input))
 
     def test_decodeNumericIntExpEMinus(self):
         input = "1.337E-4"
         output = ujson.decode(input)
-        self.assertAlmostEqual(output, json.loads(input))
+        tm.assert_almost_equal(output, json.loads(input))
 
     def test_decodeNumericIntExpeMinus(self):
         input = "1.337e-4"
         output = ujson.decode(input)
-        self.assertAlmostEqual(output, json.loads(input))
+        tm.assert_almost_equal(output, json.loads(input))
 
     def test_dumpToFile(self):
         f = StringIO()
@@ -1583,36 +1583,49 @@ class PandasJSONTests(TestCase):
     def test_decodeFloatingPointAdditionalTests(self):
         places = 15
 
-        self.assertAlmostEqual(-1.1234567893,
-                               ujson.loads("-1.1234567893"), places=places)
-        self.assertAlmostEqual(-1.234567893,
-                               ujson.loads("-1.234567893"), places=places)
-        self.assertAlmostEqual(-1.34567893,
-                               ujson.loads("-1.34567893"), places=places)
-        self.assertAlmostEqual(-1.4567893,
-                               ujson.loads("-1.4567893"), places=places)
-        self.assertAlmostEqual(-1.567893,
-                               ujson.loads("-1.567893"), places=places)
-        self.assertAlmostEqual(-1.67893,
-                               ujson.loads("-1.67893"), places=places)
-        self.assertAlmostEqual(-1.7893, ujson.loads("-1.7893"), places=places)
-        self.assertAlmostEqual(-1.893, ujson.loads("-1.893"), places=places)
-        self.assertAlmostEqual(-1.3, ujson.loads("-1.3"), places=places)
+        tm.assert_almost_equal(-1.1234567893,
+                               ujson.loads("-1.1234567893"),
+                               check_less_precise=places)
+        tm.assert_almost_equal(-1.234567893,
+                               ujson.loads("-1.234567893"),
+                               check_less_precise=places)
+        tm.assert_almost_equal(-1.34567893,
+                               ujson.loads("-1.34567893"),
+                               check_less_precise=places)
+        tm.assert_almost_equal(-1.4567893,
+                               ujson.loads("-1.4567893"),
+                               check_less_precise=places)
+        tm.assert_almost_equal(-1.567893,
+                               ujson.loads("-1.567893"),
+                               check_less_precise=places)
+        tm.assert_almost_equal(-1.67893,
+                               ujson.loads("-1.67893"),
+                               check_less_precise=places)
+        tm.assert_almost_equal(-1.7893, ujson.loads("-1.7893"),
+                               check_less_precise=places)
+        tm.assert_almost_equal(-1.893, ujson.loads("-1.893"),
+                               check_less_precise=places)
+        tm.assert_almost_equal(-1.3, ujson.loads("-1.3"),
+                               check_less_precise=places)
 
-        self.assertAlmostEqual(1.1234567893, ujson.loads(
-            "1.1234567893"), places=places)
-        self.assertAlmostEqual(1.234567893, ujson.loads(
-            "1.234567893"), places=places)
-        self.assertAlmostEqual(
-            1.34567893, ujson.loads("1.34567893"), places=places)
-        self.assertAlmostEqual(
-            1.4567893, ujson.loads("1.4567893"), places=places)
-        self.assertAlmostEqual(
-            1.567893, ujson.loads("1.567893"), places=places)
-        self.assertAlmostEqual(1.67893, ujson.loads("1.67893"), places=places)
-        self.assertAlmostEqual(1.7893, ujson.loads("1.7893"), places=places)
-        self.assertAlmostEqual(1.893, ujson.loads("1.893"), places=places)
-        self.assertAlmostEqual(1.3, ujson.loads("1.3"), places=places)
+        tm.assert_almost_equal(1.1234567893, ujson.loads(
+            "1.1234567893"), check_less_precise=places)
+        tm.assert_almost_equal(1.234567893, ujson.loads(
+            "1.234567893"), check_less_precise=places)
+        tm.assert_almost_equal(
+            1.34567893, ujson.loads("1.34567893"), check_less_precise=places)
+        tm.assert_almost_equal(
+            1.4567893, ujson.loads("1.4567893"), check_less_precise=places)
+        tm.assert_almost_equal(
+            1.567893, ujson.loads("1.567893"), check_less_precise=places)
+        tm.assert_almost_equal(1.67893, ujson.loads("1.67893"),
+                               check_less_precise=places)
+        tm.assert_almost_equal(1.7893, ujson.loads("1.7893"),
+                               check_less_precise=places)
+        tm.assert_almost_equal(1.893, ujson.loads("1.893"),
+                               check_less_precise=places)
+        tm.assert_almost_equal(1.3, ujson.loads("1.3"),
+                               check_less_precise=places)
 
     def test_encodeBigSet(self):
         s = set()

--- a/pandas/tests/plotting/common.py
+++ b/pandas/tests/plotting/common.py
@@ -292,10 +292,10 @@ class TestPlotBase(tm.TestCase):
 
                 for label in labels:
                     if xlabelsize is not None:
-                        self.assertAlmostEqual(label.get_fontsize(),
+                        tm.assert_almost_equal(label.get_fontsize(),
                                                xlabelsize)
                     if xrot is not None:
-                        self.assertAlmostEqual(label.get_rotation(), xrot)
+                        tm.assert_almost_equal(label.get_rotation(), xrot)
 
             if ylabelsize or yrot:
                 if isinstance(ax.yaxis.get_minor_formatter(), NullFormatter):
@@ -306,10 +306,10 @@ class TestPlotBase(tm.TestCase):
 
                 for label in labels:
                     if ylabelsize is not None:
-                        self.assertAlmostEqual(label.get_fontsize(),
+                        tm.assert_almost_equal(label.get_fontsize(),
                                                ylabelsize)
                     if yrot is not None:
-                        self.assertAlmostEqual(label.get_rotation(), yrot)
+                        tm.assert_almost_equal(label.get_rotation(), yrot)
 
     def _check_ax_scales(self, axes, xaxis='linear', yaxis='linear'):
         """

--- a/pandas/tests/plotting/test_frame.py
+++ b/pandas/tests/plotting/test_frame.py
@@ -1036,8 +1036,8 @@ class TestDataFramePlots(TestPlotBase):
 
             # GH 7498
             # compare margins between lim and bar edges
-            self.assertAlmostEqual(ax_min, min_edge - 0.25)
-            self.assertAlmostEqual(ax_max, max_edge + 0.25)
+            tm.assert_almost_equal(ax_min, min_edge - 0.25)
+            tm.assert_almost_equal(ax_max, max_edge + 0.25)
 
             p = ax.patches[0]
             if kind == 'bar' and (stacked is True or subplots is True):
@@ -1061,10 +1061,10 @@ class TestDataFramePlots(TestPlotBase):
 
             if align == 'center':
                 # Check whether the bar locates on center
-                self.assertAlmostEqual(axis.get_ticklocs()[0], center)
+                tm.assert_almost_equal(axis.get_ticklocs()[0], center)
             elif align == 'edge':
                 # Check whether the bar's edge starts from the tick
-                self.assertAlmostEqual(axis.get_ticklocs()[0], edge)
+                tm.assert_almost_equal(axis.get_ticklocs()[0], edge)
             else:
                 raise ValueError
 
@@ -1314,13 +1314,13 @@ class TestDataFramePlots(TestPlotBase):
         ax = series.plot.hist(normed=True, cumulative=True, bins=4)
         # height of last bin (index 5) must be 1.0
         rects = [x for x in ax.get_children() if isinstance(x, Rectangle)]
-        self.assertAlmostEqual(rects[-1].get_height(), 1.0)
+        tm.assert_almost_equal(rects[-1].get_height(), 1.0)
         tm.close()
 
         ax = series.plot.hist(cumulative=True, bins=4)
         rects = [x for x in ax.get_children() if isinstance(x, Rectangle)]
 
-        self.assertAlmostEqual(rects[-2].get_height(), 100.0)
+        tm.assert_almost_equal(rects[-2].get_height(), 100.0)
         tm.close()
 
         # if horizontal, yticklabels are rotated

--- a/pandas/tests/plotting/test_hist_method.py
+++ b/pandas/tests/plotting/test_hist_method.py
@@ -196,7 +196,7 @@ class TestDataFramePlots(TestPlotBase):
         ax = ser.hist(normed=True, cumulative=True, bins=4)
         # height of last bin (index 5) must be 1.0
         rects = [x for x in ax.get_children() if isinstance(x, Rectangle)]
-        self.assertAlmostEqual(rects[-1].get_height(), 1.0)
+        tm.assert_almost_equal(rects[-1].get_height(), 1.0)
 
         tm.close()
         ax = ser.hist(log=True)
@@ -286,7 +286,7 @@ class TestDataFrameGroupByPlots(TestPlotBase):
         for ax in axes.ravel():
             rects = [x for x in ax.get_children() if isinstance(x, Rectangle)]
             height = rects[-1].get_height()
-            self.assertAlmostEqual(height, 1.0)
+            tm.assert_almost_equal(height, 1.0)
         self._check_ticks_props(axes, xlabelsize=xf, xrot=xrot,
                                 ylabelsize=yf, yrot=yrot)
 

--- a/pandas/tests/plotting/test_series.py
+++ b/pandas/tests/plotting/test_series.py
@@ -222,15 +222,15 @@ class TestSeriesPlots(TestPlotBase):
         ymin = 0.0007943282347242822 if self.mpl_ge_2_0_0 else 0.001
         ymax = 0.12589254117941673 if self.mpl_ge_2_0_0 else .10000000000000001
         res = ax.get_ylim()
-        self.assertAlmostEqual(res[0], ymin)
-        self.assertAlmostEqual(res[1], ymax)
+        tm.assert_almost_equal(res[0], ymin)
+        tm.assert_almost_equal(res[1], ymax)
         tm.assert_numpy_array_equal(ax.yaxis.get_ticklocs(), expected)
         tm.close()
 
         ax = Series([0.1, 0.01, 0.001]).plot(log=True, kind='barh')
         res = ax.get_xlim()
-        self.assertAlmostEqual(res[0], ymin)
-        self.assertAlmostEqual(res[1], ymax)
+        tm.assert_almost_equal(res[0], ymin)
+        tm.assert_almost_equal(res[1], ymax)
         tm.assert_numpy_array_equal(ax.xaxis.get_ticklocs(), expected)
 
     @slow

--- a/pandas/tests/series/test_analytics.py
+++ b/pandas/tests/series/test_analytics.py
@@ -123,7 +123,7 @@ class TestSeriesAnalytics(TestData, tm.TestCase):
 
         # test with integers, test failure
         int_ts = Series(np.ones(10, dtype=int), index=lrange(10))
-        self.assertAlmostEqual(np.median(int_ts), int_ts.median())
+        tm.assert_almost_equal(np.median(int_ts), int_ts.median())
 
     def test_mode(self):
         # No mode should be found.
@@ -298,7 +298,7 @@ class TestSeriesAnalytics(TestData, tm.TestCase):
                            labels=[[0, 0, 0, 0, 0, 0], [0, 1, 2, 0, 1, 2],
                                    [0, 1, 0, 1, 0, 1]])
         s = Series(np.random.randn(6), index=index)
-        self.assertAlmostEqual(s.kurt(), s.kurt(level=0)['bar'])
+        tm.assert_almost_equal(s.kurt(), s.kurt(level=0)['bar'])
 
         # test corner cases, kurt() returns NaN unless there's at least 4
         # values
@@ -743,10 +743,10 @@ class TestSeriesAnalytics(TestData, tm.TestCase):
         import scipy.stats as stats
 
         # full overlap
-        self.assertAlmostEqual(self.ts.corr(self.ts), 1)
+        tm.assert_almost_equal(self.ts.corr(self.ts), 1)
 
         # partial overlap
-        self.assertAlmostEqual(self.ts[:15].corr(self.ts[5:]), 1)
+        tm.assert_almost_equal(self.ts[:15].corr(self.ts[5:]), 1)
 
         assert isnull(self.ts[:15].corr(self.ts[5:], min_periods=12))
 
@@ -766,7 +766,7 @@ class TestSeriesAnalytics(TestData, tm.TestCase):
         B = tm.makeTimeSeries()
         result = A.corr(B)
         expected, _ = stats.pearsonr(A, B)
-        self.assertAlmostEqual(result, expected)
+        tm.assert_almost_equal(result, expected)
 
     def test_corr_rank(self):
         tm._skip_if_no_scipy()
@@ -780,11 +780,11 @@ class TestSeriesAnalytics(TestData, tm.TestCase):
         A[-5:] = A[:5]
         result = A.corr(B, method='kendall')
         expected = stats.kendalltau(A, B)[0]
-        self.assertAlmostEqual(result, expected)
+        tm.assert_almost_equal(result, expected)
 
         result = A.corr(B, method='spearman')
         expected = stats.spearmanr(A, B)[0]
-        self.assertAlmostEqual(result, expected)
+        tm.assert_almost_equal(result, expected)
 
         # these methods got rewritten in 0.8
         if scipy.__version__ < LooseVersion('0.9'):
@@ -800,15 +800,15 @@ class TestSeriesAnalytics(TestData, tm.TestCase):
              1.17258718, -1.06009347, -0.10222060, -0.89076239, 0.89372375])
         kexp = 0.4319297
         sexp = 0.5853767
-        self.assertAlmostEqual(A.corr(B, method='kendall'), kexp)
-        self.assertAlmostEqual(A.corr(B, method='spearman'), sexp)
+        tm.assert_almost_equal(A.corr(B, method='kendall'), kexp)
+        tm.assert_almost_equal(A.corr(B, method='spearman'), sexp)
 
     def test_cov(self):
         # full overlap
-        self.assertAlmostEqual(self.ts.cov(self.ts), self.ts.std() ** 2)
+        tm.assert_almost_equal(self.ts.cov(self.ts), self.ts.std() ** 2)
 
         # partial overlap
-        self.assertAlmostEqual(self.ts[:15].cov(self.ts[5:]),
+        tm.assert_almost_equal(self.ts[:15].cov(self.ts[5:]),
                                self.ts[5:15].std() ** 2)
 
         # No overlap

--- a/pandas/tests/series/test_indexing.py
+++ b/pandas/tests/series/test_indexing.py
@@ -558,7 +558,7 @@ class TestSeriesIndexing(TestData, tm.TestCase):
 
         assert s.iloc[0] == s['a']
         s.iloc[0] = 5
-        self.assertAlmostEqual(s['a'], 5)
+        tm.assert_almost_equal(s['a'], 5)
 
     def test_getitem_box_float64(self):
         value = self.ts[5]

--- a/pandas/tests/test_nanops.py
+++ b/pandas/tests/test_nanops.py
@@ -922,7 +922,7 @@ class TestNanskewFixedValues(tm.TestCase):
 
     def test_ground_truth(self):
         skew = nanops.nanskew(self.samples)
-        self.assertAlmostEqual(skew, self.actual_skew)
+        tm.assert_almost_equal(skew, self.actual_skew)
 
     def test_axis(self):
         samples = np.vstack([self.samples,
@@ -972,7 +972,7 @@ class TestNankurtFixedValues(tm.TestCase):
 
     def test_ground_truth(self):
         kurt = nanops.nankurt(self.samples)
-        self.assertAlmostEqual(kurt, self.actual_kurt)
+        tm.assert_almost_equal(kurt, self.actual_kurt)
 
     def test_axis(self):
         samples = np.vstack([self.samples,

--- a/pandas/tests/test_window.py
+++ b/pandas/tests/test_window.py
@@ -1406,7 +1406,7 @@ class TestMoments(Base):
             trunc_series = self.series[::2].truncate(prev_date, last_date)
             trunc_frame = self.frame[::2].truncate(prev_date, last_date)
 
-            self.assertAlmostEqual(series_result[-1],
+            tm.assert_almost_equal(series_result[-1],
                                    static_comp(trunc_series))
 
             tm.assert_series_equal(frame_result.xs(last_date),

--- a/pandas/tests/tseries/test_timezones.py
+++ b/pandas/tests/tseries/test_timezones.py
@@ -729,7 +729,7 @@ class TestTimeZoneSupportPytz(tm.TestCase):
         ts = Series(np.random.randn(len(rng)), index=rng)
 
         result = ts['1/3/2000']
-        self.assertAlmostEqual(result, ts[2])
+        tm.assert_almost_equal(result, ts[2])
 
     def test_fixed_offset(self):
         dates = [datetime(2000, 1, 1, tzinfo=fixed_off),

--- a/pandas/util/testing.py
+++ b/pandas/util/testing.py
@@ -140,7 +140,8 @@ def round_trip_pickle(obj, path=None):
 def assert_almost_equal(left, right, check_exact=False,
                         check_dtype='equiv', check_less_precise=False,
                         **kwargs):
-    """Check that left and right Index are equal.
+    """
+    Check that the left and right objects are approximately equal.
 
     Parameters
     ----------


### PR DESCRIPTION
Title is self-explanatory.

Partially addresses #15990.
