### PR TITLE
MAINT: Remove vestigial self.assert*

### DIFF
--- a/pandas/tests/frame/test_repr_info.py
+++ b/pandas/tests/frame/test_repr_info.py
@@ -331,13 +331,13 @@ class TestDataFrameReprInfoEtc(tm.TestCase, TestData):
         res = buf.getvalue().splitlines()
         assert re.match(r"memory usage: [^+]+$", res[-1])
 
-        self.assertGreater(df_with_object_index.memory_usage(index=True,
-                                                             deep=True).sum(),
-                           df_with_object_index.memory_usage(index=True).sum())
+        assert (df_with_object_index.memory_usage(
+            index=True, deep=True).sum() > df_with_object_index.memory_usage(
+            index=True).sum())
 
         df_object = pd.DataFrame({'a': ['a']})
-        self.assertGreater(df_object.memory_usage(deep=True).sum(),
-                           df_object.memory_usage().sum())
+        assert (df_object.memory_usage(deep=True).sum() >
+                df_object.memory_usage().sum())
 
         # Test a DataFrame with duplicate columns
         dtypes = ['int64', 'int64', 'int64', 'float64']

--- a/pandas/tests/io/formats/test_style.py
+++ b/pandas/tests/io/formats/test_style.py
@@ -374,7 +374,7 @@ class TestStyler(TestCase):
                              '#5fba7d 10.0%, #5fba7d 100.0%, '
                              'transparent 100.0%)']}
 
-        self.assertEqual(result, expected)
+        assert result == expected
 
     def test_bar_align_mid_all_pos(self):
         df = pd.DataFrame({'A': [10, 20, 50, 100]})
@@ -399,7 +399,7 @@ class TestStyler(TestCase):
                              'transparent 0%, transparent 0.0%, #5fba7d 0.0%, '
                              '#5fba7d 100.0%, transparent 100.0%)']}
 
-        self.assertEqual(result, expected)
+        assert result == expected
 
     def test_bar_align_mid_all_neg(self):
         df = pd.DataFrame({'A': [-100, -60, -30, -20]})

--- a/pandas/tests/test_nanops.py
+++ b/pandas/tests/test_nanops.py
@@ -914,11 +914,11 @@ class TestNanskewFixedValues(tm.TestCase):
     def test_all_finite(self):
         alpha, beta = 0.3, 0.1
         left_tailed = self.prng.beta(alpha, beta, size=100)
-        self.assertLess(nanops.nanskew(left_tailed), 0)
+        assert nanops.nanskew(left_tailed) < 0
 
         alpha, beta = 0.1, 0.3
         right_tailed = self.prng.beta(alpha, beta, size=100)
-        self.assertGreater(nanops.nanskew(right_tailed), 0)
+        assert nanops.nanskew(right_tailed) > 0
 
     def test_ground_truth(self):
         skew = nanops.nanskew(self.samples)
@@ -964,11 +964,11 @@ class TestNankurtFixedValues(tm.TestCase):
     def test_all_finite(self):
         alpha, beta = 0.3, 0.1
         left_tailed = self.prng.beta(alpha, beta, size=100)
-        self.assertLess(nanops.nankurt(left_tailed), 0)
+        assert nanops.nankurt(left_tailed) < 0
 
         alpha, beta = 0.1, 0.3
         right_tailed = self.prng.beta(alpha, beta, size=100)
-        self.assertGreater(nanops.nankurt(right_tailed), 0)
+        assert nanops.nankurt(right_tailed) > 0
 
     def test_ground_truth(self):
         kurt = nanops.nankurt(self.samples)

--- a/pandas/tests/test_panel4d.py
+++ b/pandas/tests/test_panel4d.py
@@ -13,10 +13,7 @@ from pandas.core.panel4d import Panel4D
 from pandas.core.series import remove_na
 from pandas.tseries.offsets import BDay
 
-from pandas.util.testing import (assert_panel_equal,
-                                 assert_panel4d_equal,
-                                 assert_frame_equal,
-                                 assert_series_equal,
+from pandas.util.testing import (assert_frame_equal, assert_series_equal,
                                  assert_almost_equal)
 import pandas.util.testing as tm
 
@@ -133,7 +130,7 @@ class SafeForLongAndSparse(object):
                 for i in range(obj.ndim):
                     result = f(axis=i, skipna=False)
                     expected = obj.apply(wrapper, axis=i)
-                    assert_panel_equal(result, expected)
+                    tm.assert_panel_equal(result, expected)
         else:
             skipna_wrapper = alternative
             wrapper = alternative
@@ -143,26 +140,18 @@ class SafeForLongAndSparse(object):
                 result = f(axis=i)
                 if not tm._incompat_bottleneck_version(name):
                     expected = obj.apply(skipna_wrapper, axis=i)
-                    assert_panel_equal(result, expected)
+                    tm.assert_panel_equal(result, expected)
 
         pytest.raises(Exception, f, axis=obj.ndim)
 
 
 class SafeForSparse(object):
 
-    @classmethod
-    def assert_panel_equal(cls, x, y):
-        assert_panel_equal(x, y)
-
-    @classmethod
-    def assert_panel4d_equal(cls, x, y):
-        assert_panel4d_equal(x, y)
-
     def test_get_axis(self):
-        assert(self.panel4d._get_axis(0) is self.panel4d.labels)
-        assert(self.panel4d._get_axis(1) is self.panel4d.items)
-        assert(self.panel4d._get_axis(2) is self.panel4d.major_axis)
-        assert(self.panel4d._get_axis(3) is self.panel4d.minor_axis)
+        assert self.panel4d._get_axis(0) is self.panel4d.labels
+        assert self.panel4d._get_axis(1) is self.panel4d.items
+        assert self.panel4d._get_axis(2) is self.panel4d.major_axis
+        assert self.panel4d._get_axis(3) is self.panel4d.minor_axis
 
     def test_set_axis(self):
         with catch_warnings(record=True):
@@ -226,7 +215,7 @@ class SafeForSparse(object):
     @staticmethod
     def _test_op(panel4d, op):
         result = op(panel4d, 1)
-        assert_panel_equal(result['l1'], op(panel4d['l1'], 1))
+        tm.assert_panel_equal(result['l1'], op(panel4d['l1'], 1))
 
     def test_keys(self):
         tm.equalContents(list(self.panel4d.keys()), self.panel4d.labels)
@@ -240,11 +229,11 @@ class SafeForSparse(object):
     def test_combinePanel4d(self):
         with catch_warnings(record=True):
             result = self.panel4d.add(self.panel4d)
-            self.assert_panel4d_equal(result, self.panel4d * 2)
+            tm.assert_panel4d_equal(result, self.panel4d * 2)
 
     def test_neg(self):
         with catch_warnings(record=True):
-            self.assert_panel4d_equal(-self.panel4d, self.panel4d * -1)
+            tm.assert_panel4d_equal(-self.panel4d, self.panel4d * -1)
 
     def test_select(self):
         with catch_warnings(record=True):
@@ -254,28 +243,28 @@ class SafeForSparse(object):
             # select labels
             result = p.select(lambda x: x in ('l1', 'l3'), axis='labels')
             expected = p.reindex(labels=['l1', 'l3'])
-            self.assert_panel4d_equal(result, expected)
+            tm.assert_panel4d_equal(result, expected)
 
             # select items
             result = p.select(lambda x: x in ('ItemA', 'ItemC'), axis='items')
             expected = p.reindex(items=['ItemA', 'ItemC'])
-            self.assert_panel4d_equal(result, expected)
+            tm.assert_panel4d_equal(result, expected)
 
             # select major_axis
             result = p.select(lambda x: x >= datetime(2000, 1, 15),
                               axis='major')
             new_major = p.major_axis[p.major_axis >= datetime(2000, 1, 15)]
             expected = p.reindex(major=new_major)
-            self.assert_panel4d_equal(result, expected)
+            tm.assert_panel4d_equal(result, expected)
 
             # select minor_axis
             result = p.select(lambda x: x in ('D', 'A'), axis=3)
             expected = p.reindex(minor=['A', 'D'])
-            self.assert_panel4d_equal(result, expected)
+            tm.assert_panel4d_equal(result, expected)
 
             # corner case, empty thing
             result = p.select(lambda x: x in ('foo',), axis='items')
-            self.assert_panel4d_equal(result, p.reindex(items=[]))
+            tm.assert_panel4d_equal(result, p.reindex(items=[]))
 
     def test_get_value(self):
 
@@ -291,12 +280,12 @@ class SafeForSparse(object):
         with catch_warnings(record=True):
             result = self.panel4d.abs()
             expected = np.abs(self.panel4d)
-            self.assert_panel4d_equal(result, expected)
+            tm.assert_panel4d_equal(result, expected)
 
             p = self.panel4d['l1']
             result = p.abs()
             expected = np.abs(p)
-            assert_panel_equal(result, expected)
+            tm.assert_panel_equal(result, expected)
 
             df = p['ItemA']
             result = df.abs()
@@ -314,7 +303,7 @@ class CheckIndexing(object):
         with catch_warnings(record=True):
             expected = self.panel4d['l2']
             result = self.panel4d.pop('l2')
-            assert_panel_equal(expected, result)
+            tm.assert_panel_equal(expected, result)
             assert 'l2' not in self.panel4d.labels
 
             del self.panel4d['l3']
@@ -367,9 +356,9 @@ class CheckIndexing(object):
 
             p2 = self.panel4d['l4']
 
-            assert_panel_equal(p, p2.reindex(items=p.items,
-                                             major_axis=p.major_axis,
-                                             minor_axis=p.minor_axis))
+            tm.assert_panel_equal(p, p2.reindex(items=p.items,
+                                                major_axis=p.major_axis,
+                                                minor_axis=p.minor_axis))
 
             # scalar
             self.panel4d['lG'] = 1
@@ -534,34 +523,34 @@ class CheckIndexing(object):
             cols = ['D', 'C', 'F']
 
             # all 4 specified
-            assert_panel4d_equal(panel4d.loc[labels, items, dates, cols],
-                                 panel4d.reindex(labels=labels, items=items,
-                                                 major=dates, minor=cols))
+            tm.assert_panel4d_equal(panel4d.loc[labels, items, dates, cols],
+                                    panel4d.reindex(labels=labels, items=items,
+                                                    major=dates, minor=cols))
 
             # 3 specified
-            assert_panel4d_equal(panel4d.loc[:, items, dates, cols],
-                                 panel4d.reindex(items=items, major=dates,
-                                                 minor=cols))
+            tm.assert_panel4d_equal(panel4d.loc[:, items, dates, cols],
+                                    panel4d.reindex(items=items, major=dates,
+                                                    minor=cols))
 
             # 2 specified
-            assert_panel4d_equal(panel4d.loc[:, :, dates, cols],
-                                 panel4d.reindex(major=dates, minor=cols))
+            tm.assert_panel4d_equal(panel4d.loc[:, :, dates, cols],
+                                    panel4d.reindex(major=dates, minor=cols))
 
-            assert_panel4d_equal(panel4d.loc[:, items, :, cols],
-                                 panel4d.reindex(items=items, minor=cols))
+            tm.assert_panel4d_equal(panel4d.loc[:, items, :, cols],
+                                    panel4d.reindex(items=items, minor=cols))
 
-            assert_panel4d_equal(panel4d.loc[:, items, dates, :],
-                                 panel4d.reindex(items=items, major=dates))
+            tm.assert_panel4d_equal(panel4d.loc[:, items, dates, :],
+                                    panel4d.reindex(items=items, major=dates))
 
             # only 1
-            assert_panel4d_equal(panel4d.loc[:, items, :, :],
-                                 panel4d.reindex(items=items))
+            tm.assert_panel4d_equal(panel4d.loc[:, items, :, :],
+                                    panel4d.reindex(items=items))
 
-            assert_panel4d_equal(panel4d.loc[:, :, dates, :],
-                                 panel4d.reindex(major=dates))
+            tm.assert_panel4d_equal(panel4d.loc[:, :, dates, :],
+                                    panel4d.reindex(major=dates))
 
-            assert_panel4d_equal(panel4d.loc[:, :, :, cols],
-                                 panel4d.reindex(minor=cols))
+            tm.assert_panel4d_equal(panel4d.loc[:, :, :, cols],
+                                    panel4d.reindex(minor=cols))
 
     def test_getitem_fancy_slice(self):
         pass
@@ -606,10 +595,6 @@ class CheckIndexing(object):
 
 class TestPanel4d(tm.TestCase, CheckIndexing, SafeForSparse,
                   SafeForLongAndSparse):
-
-    @classmethod
-    def assert_panel4d_equal(cls, x, y):
-        assert_panel4d_equal(x, y)
 
     def setUp(self):
         with catch_warnings(record=True):
@@ -697,10 +682,10 @@ class TestPanel4d(tm.TestCase, CheckIndexing, SafeForSparse,
             d = {'A': l1, 'B': l2.loc[['ItemB'], :, :]}
             panel4d = Panel4D(d)
 
-            assert_panel_equal(panel4d['A'], self.panel4d['l1'])
-            assert_frame_equal(panel4d.loc['B', 'ItemB', :, :],
-                               self.panel4d.loc['l2', ['ItemB'],
-                                                :, :]['ItemB'])
+            tm.assert_panel_equal(panel4d['A'], self.panel4d['l1'])
+            tm.assert_frame_equal(panel4d.loc['B', 'ItemB', :, :],
+                                  self.panel4d.loc['l2', ['ItemB'],
+                                  :, :]['ItemB'])
 
     def test_constructor_dict_mixed(self):
         with catch_warnings(record=True):
@@ -715,12 +700,12 @@ class TestPanel4d(tm.TestCase, CheckIndexing, SafeForSparse,
                              items=self.panel4d.items,
                              major_axis=self.panel4d.major_axis,
                              minor_axis=self.panel4d.minor_axis)
-            assert_panel4d_equal(result, self.panel4d)
+            tm.assert_panel4d_equal(result, self.panel4d)
 
             data['l2'] = self.panel4d['l2']
 
             result = Panel4D(data)
-            assert_panel4d_equal(result, self.panel4d)
+            tm.assert_panel4d_equal(result, self.panel4d)
 
             # corner, blow up
             data['l2'] = data['l2']['ItemB']
@@ -741,19 +726,19 @@ class TestPanel4d(tm.TestCase, CheckIndexing, SafeForSparse,
                              major_axis=major, minor_axis=minor)
             expected = self.panel4d.reindex(
                 labels=labels, items=items, major=major, minor=minor)
-            assert_panel4d_equal(result, expected)
+            tm.assert_panel4d_equal(result, expected)
 
             result = Panel4D(data, items=items, major_axis=major)
             expected = self.panel4d.reindex(items=items, major=major)
-            assert_panel4d_equal(result, expected)
+            tm.assert_panel4d_equal(result, expected)
 
             result = Panel4D(data, items=items)
             expected = self.panel4d.reindex(items=items)
-            assert_panel4d_equal(result, expected)
+            tm.assert_panel4d_equal(result, expected)
 
             result = Panel4D(data, minor_axis=minor)
             expected = self.panel4d.reindex(minor=minor)
-            assert_panel4d_equal(result, expected)
+            tm.assert_panel4d_equal(result, expected)
 
     def test_conform(self):
         with catch_warnings(record=True):
@@ -773,7 +758,7 @@ class TestPanel4d(tm.TestCase, CheckIndexing, SafeForSparse,
 
             # labels
             result = self.panel4d.reindex(labels=['l1', 'l2'])
-            assert_panel_equal(result['l2'], ref)
+            tm.assert_panel_equal(result['l2'], ref)
 
             # items
             result = self.panel4d.reindex(items=['ItemA', 'ItemB'])
@@ -802,7 +787,7 @@ class TestPanel4d(tm.TestCase, CheckIndexing, SafeForSparse,
 
             # don't necessarily copy
             result = self.panel4d.reindex()
-            assert_panel4d_equal(result, self.panel4d)
+            tm.assert_panel4d_equal(result, self.panel4d)
             assert result is not self.panel4d
 
             # with filling
@@ -812,13 +797,14 @@ class TestPanel4d(tm.TestCase, CheckIndexing, SafeForSparse,
             larger = smaller.reindex(major=self.panel4d.major_axis,
                                      method='pad')
 
-            assert_panel_equal(larger.loc[:, :, self.panel4d.major_axis[1], :],
-                               smaller.loc[:, :, smaller_major[0], :])
+            tm.assert_panel_equal(larger.loc[:, :,
+                                  self.panel4d.major_axis[1], :],
+                                  smaller.loc[:, :, smaller_major[0], :])
 
             # don't necessarily copy
             result = self.panel4d.reindex(
                 major=self.panel4d.major_axis, copy=False)
-            assert_panel4d_equal(result, self.panel4d)
+            tm.assert_panel4d_equal(result, self.panel4d)
             assert result is self.panel4d
 
     def test_not_hashable(self):
@@ -835,7 +821,7 @@ class TestPanel4d(tm.TestCase, CheckIndexing, SafeForSparse,
                                            major=self.panel4d.major_axis[:-1],
                                            minor=self.panel4d.minor_axis[:-1])
             smaller_like = self.panel4d.reindex_like(smaller)
-            assert_panel4d_equal(smaller, smaller_like)
+            tm.assert_panel4d_equal(smaller, smaller_like)
 
     def test_sort_index(self):
         with catch_warnings(record=True):
@@ -852,7 +838,7 @@ class TestPanel4d(tm.TestCase, CheckIndexing, SafeForSparse,
 
             random_order = self.panel4d.reindex(labels=rlabels)
             sorted_panel4d = random_order.sort_index(axis=0)
-            assert_panel4d_equal(sorted_panel4d, self.panel4d)
+            tm.assert_panel4d_equal(sorted_panel4d, self.panel4d)
 
     def test_fillna(self):
 
@@ -887,7 +873,7 @@ class TestPanel4d(tm.TestCase, CheckIndexing, SafeForSparse,
 
             # this works, but return a copy
             result = self.panel4d.swapaxes('items', 'items')
-            assert_panel4d_equal(self.panel4d, result)
+            tm.assert_panel4d_equal(self.panel4d, result)
             assert id(self.panel4d) != id(result)
 
     def test_update(self):
@@ -916,7 +902,7 @@ class TestPanel4d(tm.TestCase, CheckIndexing, SafeForSparse,
                                   [1.5, np.nan, 3.],
                                   [1.5, np.nan, 3.]]]])
 
-            assert_panel4d_equal(p4d, expected)
+            tm.assert_panel4d_equal(p4d, expected)
 
     def test_dtypes(self):
 
@@ -952,4 +938,4 @@ class TestPanel4d(tm.TestCase, CheckIndexing, SafeForSparse,
             assert (self.panel4d['l1'].values == 3).all()
 
     def test_get_attr(self):
-        assert_panel_equal(self.panel4d['l1'], self.panel4d.l1)
+        tm.assert_panel_equal(self.panel4d['l1'], self.panel4d.l1)


### PR DESCRIPTION
Remove all remaining `self.assert*` method calls originating from `unittest`.  Any that are left are calls to methods directly defined in the test class or a higher derived `pandas` test class.

Partially addresses #15990.

Once this PR is merged, it is important that we remain vigilant about requiring PR's to adhere to the `pytest` idiom until we remove our dependency on `unittest.TestCase` (after which the builds will do the work when tests fail).