### PR TITLE
TST: test reset_index with tuple index name and col_level!=0

### DIFF
--- a/pandas/tests/test_multilevel.py
+++ b/pandas/tests/test_multilevel.py
@@ -2286,6 +2286,11 @@ Thur,Lunch,Yes,51.51,17"""
                                      "incomplete column name \('C', 'c'\)")):
             df2.rename_axis([('C', 'c')]).reset_index(col_fill=None)
 
+        # with col_level != 0
+        result = df2.rename_axis([('c', 'ii')]).reset_index(col_level=1,
+                                                            col_fill='C')
+        tm.assert_frame_equal(result, expected)
+
     def test_set_index_period(self):
         # GH 6631
         df = DataFrame(np.random.random(6))


### PR DESCRIPTION
 - [x] tests added / passed
 - [x] passes ``git diff master --name-only -- '*.py' | flake8 --diff``

This just completes #16165 as [asked](https://github.com/pandas-dev/pandas/pull/16165#issuecomment-298427315) by @jorisvandenbossche 