### PR TITLE
register custom DisplayFormatter for table schema

### DIFF
--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -6278,8 +6278,6 @@ def _make_logical_function(cls, name, name1, name2, axis_descr, desc, f):
     return set_function_name(logical_func, name, cls)
 
 
-
-
 # install the indexes
 for _name, _indexer in indexing.get_indexers_list():
     NDFrame._create_indexer(_name, _indexer)

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -6279,36 +6279,6 @@ def _make_logical_function(cls, name, name1, name2, axis_descr, desc, f):
     return set_function_name(logical_func, name, cls)
 
 
-def _ipython_display_(self):
-    # Having _ipython_display_ defined messes with the return value
-    # from cells, so the Out[x] dictionary breaks.
-    # Currently table schema is the only thing using it, so we'll
-    # monkey patch `_ipython_display_` onto NDFrame when config option
-    # is set
-    # see https://github.com/pandas-dev/pandas/issues/16168
-    try:
-        from IPython.display import display
-    except ImportError:
-        return None
-
-    # Series doesn't define _repr_html_ or _repr_latex_
-    latex = self._repr_latex_() if hasattr(self, '_repr_latex_') else None
-    html = self._repr_html_() if hasattr(self, '_repr_html_') else None
-    try:
-        table_schema = self._repr_table_schema_()
-    except Exception as e:
-        warnings.warn("Cannot create table schema representation. "
-                      "{}".format(e), UnserializableWarning)
-        table_schema = None
-    # We need the inital newline since we aren't going through the
-    # usual __repr__. See
-    # https://github.com/pandas-dev/pandas/pull/14904#issuecomment-277829277
-    text = "\n" + repr(self)
-
-    reprs = {"text/plain": text, "text/html": html, "text/latex": latex,
-             "application/vnd.dataresource+json": table_schema}
-    reprs = {k: v for k, v in reprs.items() if v}
-    display(reprs, raw=True)
 
 
 # install the indexes

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -43,7 +43,6 @@ from pandas.core.internals import BlockManager
 import pandas.core.algorithms as algos
 import pandas.core.common as com
 import pandas.core.missing as missing
-from pandas.errors import UnserializableWarning
 from pandas.io.formats.printing import pprint_thing
 from pandas.io.formats.format import format_percentiles
 from pandas.tseries.frequencies import to_offset

--- a/pandas/errors/__init__.py
+++ b/pandas/errors/__init__.py
@@ -57,9 +57,3 @@ class ParserWarning(Warning):
     """
 
 
-class UnserializableWarning(Warning):
-    """
-    Warning that is raised when a DataFrame cannot be serialized.
-
-    .. versionadded:: 0.20.0
-    """

--- a/pandas/tests/io/formats/test_printing.py
+++ b/pandas/tests/io/formats/test_printing.py
@@ -176,8 +176,6 @@ class TestTableSchemaRepr(tm.TestCase):
 
         expected = {'text/plain', 'text/html'}
         assert set(formatted[0].keys()) == expected
-        assert "orient='table' is not supported for MultiIndex" in (
-            record[-1].message.args[0])
 
     def test_config_on(self):
         df = pd.DataFrame({"A": [1, 2]})
@@ -205,7 +203,7 @@ class TestTableSchemaRepr(tm.TestCase):
         with pd.option_context('display.html.table_schema', True):
             assert 'application/vnd.dataresource+json' in formatters
             assert formatters[mimetype].enabled
-        
+
         # still there, just disabled
         assert 'application/vnd.dataresource+json' in formatters
         assert not formatters[mimetype].enabled

--- a/pandas/tests/io/formats/test_printing.py
+++ b/pandas/tests/io/formats/test_printing.py
@@ -5,7 +5,6 @@ import numpy as np
 import pandas as pd
 
 from pandas import compat
-from pandas.errors import UnserializableWarning
 import pandas.io.formats.printing as printing
 import pandas.io.formats.format as fmt
 import pandas.util.testing as tm
@@ -173,9 +172,7 @@ class TestTableSchemaRepr(tm.TestCase):
         opt = pd.option_context('display.html.table_schema', True)
 
         with opt:
-            # FIXME: no warning for now
-            with pytest.warns(UnserializableWarning) as record:
-                formatted = self.display_formatter.format(df)
+            formatted = self.display_formatter.format(df)
 
         expected = {'text/plain', 'text/html'}
         assert set(formatted[0].keys()) == expected

--- a/pandas/tests/io/formats/test_printing.py
+++ b/pandas/tests/io/formats/test_printing.py
@@ -137,8 +137,11 @@ class TestTableSchemaRepr(tm.TestCase):
             except ImportError:
                 pytest.skip("Mock is not installed")
         cls.mock = mock
+        from IPython.core.interactiveshell import InteractiveShell
+        cls.display_formatter = InteractiveShell.instance().display_formatter
 
     def test_publishes(self):
+
         df = pd.DataFrame({"A": [1, 2]})
         objects = [df['A'], df, df]  # dataframe / series
         expected_keys = [
@@ -146,29 +149,20 @@ class TestTableSchemaRepr(tm.TestCase):
             {'text/plain', 'text/html', 'application/vnd.dataresource+json'},
         ]
 
-        make_patch = self.mock.patch('IPython.display.display')
         opt = pd.option_context('display.html.table_schema', True)
         for obj, expected in zip(objects, expected_keys):
-            with opt, make_patch as mock_display:
-                handle = obj._ipython_display_()
-                assert mock_display.call_count == 1
-                assert handle is None
-                args, kwargs = mock_display.call_args
-                arg, = args  # just one argument
-
-            assert kwargs == {"raw": True}
-            assert set(arg.keys()) == expected
+            with opt:
+                formatted = self.display_formatter.format(obj)
+            assert set(formatted[0].keys()) == expected
 
         with_latex = pd.option_context('display.latex.repr', True)
 
-        with opt, with_latex, make_patch as mock_display:
-            handle = obj._ipython_display_()
-            args, kwargs = mock_display.call_args
-            arg, = args
+        with opt, with_latex:
+            formatted = self.display_formatter.format(obj)
 
         expected = {'text/plain', 'text/html', 'text/latex',
                     'application/vnd.dataresource+json'}
-        assert set(arg.keys()) == expected
+        assert set(formatted[0].keys()) == expected
 
     def test_publishes_not_implemented(self):
         # column MultiIndex
@@ -176,16 +170,15 @@ class TestTableSchemaRepr(tm.TestCase):
         midx = pd.MultiIndex.from_product([['A', 'B'], ['a', 'b', 'c']])
         df = pd.DataFrame(np.random.randn(5, len(midx)), columns=midx)
 
-        make_patch = self.mock.patch('IPython.display.display')
         opt = pd.option_context('display.html.table_schema', True)
-        with opt, make_patch as mock_display:
+
+        with opt:
+            # FIXME: no warning for now
             with pytest.warns(UnserializableWarning) as record:
-                df._ipython_display_()
-                args, _ = mock_display.call_args
-                arg, = args  # just one argument
+                formatted = self.display_formatter.format(df)
 
         expected = {'text/plain', 'text/html'}
-        assert set(arg.keys()) == expected
+        assert set(formatted[0].keys()) == expected
         assert "orient='table' is not supported for MultiIndex" in (
             record[-1].message.args[0])
 
@@ -209,26 +202,23 @@ class TestTableSchemaRepr(tm.TestCase):
         assert not hasattr(df, '_ipython_display_')
         assert not hasattr(df['A'], '_ipython_display_')
 
-        with pd.option_context('display.html.table_schema', True):
-            assert hasattr(df, '_ipython_display_')
-            # smoke test that it works
-            df._ipython_display_()
-            assert hasattr(df['A'], '_ipython_display_')
-            df['A']._ipython_display_()
+        formatters = self.display_formatter.formatters
+        mimetype = 'application/vnd.dataresource+json'
 
-        assert not hasattr(df, '_ipython_display_')
-        assert not hasattr(df['A'], '_ipython_display_')
-        # re-unsetting is OK
-        assert not hasattr(df, '_ipython_display_')
-        assert not hasattr(df['A'], '_ipython_display_')
+        with pd.option_context('display.html.table_schema', True):
+            assert 'application/vnd.dataresource+json' in formatters
+            assert formatters[mimetype].enabled
+        
+        # still there, just disabled
+        assert 'application/vnd.dataresource+json' in formatters
+        assert not formatters[mimetype].enabled
 
         # able to re-set
         with pd.option_context('display.html.table_schema', True):
-            assert hasattr(df, '_ipython_display_')
+            assert 'application/vnd.dataresource+json' in formatters
+            assert formatters[mimetype].enabled
             # smoke test that it works
-            df._ipython_display_()
-            assert hasattr(df['A'], '_ipython_display_')
-            df['A']._ipython_display_()
+            self.display_formatter.format(cf)
 
 
 # TODO: fix this broken test


### PR DESCRIPTION
instead of using `_ipython_display_` for custom mime-types

This should solve the issues in #16171, without needing to register/unregister `_ipython_display_`.

In the long run, https://github.com/ipython/ipython/pull/10496 should remove the need for any custom registration, in favor of a simple `_repr_mimebundle_` method.

I think the only thing missing is the UnserializableWarning because IPython does its own catching and displaying of tracebacks when formatters fail. I can copy and modify a little more code out of the base Formatter to preserve that warning, though.