### PR TITLE
DOC: Add redirect for moved classes

### DIFF
--- a/doc/_templates/api_redirect.html
+++ b/doc/_templates/api_redirect.html
@@ -1,15 +1,10 @@
-{% set pgn = pagename.split('.') -%}
-{% if pgn[-2][0].isupper() -%}
-    {% set redirect = ["pandas", pgn[-2], pgn[-1], 'html']|join('.') -%}
-{% else -%}
-    {% set redirect = ["pandas", pgn[-1], 'html']|join('.') -%}
-{% endif -%}
+{% set redirect = redirects[pagename.split("/")[-1]] %}
 <html>
     <head>
-        <meta http-equiv="Refresh" content="0; url={{ redirect }}" />
+        <meta http-equiv="Refresh" content="0; url={{ redirect }}.html" />
         <title>This API page has moved</title>
     </head>
     <body>
-        <p>This API page has moved <a href="{{ redirect }}">here</a>.</p>
+        <p>This API page has moved <a href="{{ redirect }}.html">here</a>.</p>
     </body>
 </html>

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -273,7 +273,7 @@ for old, new in moved_classes:
     mod, classname = new.rsplit('.', 1)
     klass = getattr(importlib.import_module(mod), classname)
     methods = [x for x in dir(klass)
-               if not x.startswith('_') or x.startswith('__')]
+               if not x.startswith('_') or x in ('__iter__', '__array__')]
 
     for method in methods:
         # ... and each of its public methods


### PR DESCRIPTION
The new redirects in this commit are for Resampler and Styler

Refactor how we do redirects. Moved all the logic into the
config file, where you state the methods / classes to be redirected.
Removed all the logic from the template, and just look up in the
new html_context variable.

Closes https://github.com/pandas-dev/pandas/issues/16186

Running a test locally ATM.