### PR TITLE
MAINT: Complete Conversion to Pytest Idiom

### DIFF
--- a/doc/source/contributing.rst
+++ b/doc/source/contributing.rst
@@ -632,14 +632,6 @@ framework that will facilitate testing and developing. Thus, instead of writing 
     def test_really_cool_feature():
         ....
 
-Sometimes, it does make sense to bundle test functions together into a single class, either because the test file is testing multiple functions from a single module, and
-using test classes allows for better organization. However, instead of inheriting from ``tm.TestCase``, we should just inherit from ``object``:
-
-.. code-block:: python
-
-    class TestReallyCoolFeature(object):
-        ....
-
 Using ``pytest``
 ~~~~~~~~~~~~~~~~
 

--- a/pandas/tests/computation/test_eval.py
+++ b/pandas/tests/computation/test_eval.py
@@ -98,8 +98,8 @@ _good_arith_ops = com.difference(_arith_ops_syms, _special_case_arith_ops_syms)
 class TestEvalNumexprPandas(tm.TestCase):
 
     @classmethod
-    def setUpClass(cls):
-        super(TestEvalNumexprPandas, cls).setUpClass()
+    def setup_class(cls):
+        super(TestEvalNumexprPandas, cls).setup_class()
         tm.skip_if_no_ne()
         import numexpr as ne
         cls.ne = ne
@@ -107,8 +107,8 @@ class TestEvalNumexprPandas(tm.TestCase):
         cls.parser = 'pandas'
 
     @classmethod
-    def tearDownClass(cls):
-        super(TestEvalNumexprPandas, cls).tearDownClass()
+    def teardown_class(cls):
+        super(TestEvalNumexprPandas, cls).teardown_class()
         del cls.engine, cls.parser
         if hasattr(cls, 'ne'):
             del cls.ne
@@ -137,12 +137,12 @@ class TestEvalNumexprPandas(tm.TestCase):
         self.arith_ops = _good_arith_ops
         self.unary_ops = '-', '~', 'not '
 
-    def setUp(self):
+    def setup_method(self, method):
         self.setup_ops()
         self.setup_data()
         self.current_engines = filter(lambda x: x != self.engine, _engines)
 
-    def tearDown(self):
+    def teardown_method(self, method):
         del self.lhses, self.rhses, self.scalar_rhses, self.scalar_lhses
         del self.pandas_rhses, self.pandas_lhses, self.current_engines
 
@@ -723,8 +723,8 @@ class TestEvalNumexprPandas(tm.TestCase):
 class TestEvalNumexprPython(TestEvalNumexprPandas):
 
     @classmethod
-    def setUpClass(cls):
-        super(TestEvalNumexprPython, cls).setUpClass()
+    def setup_class(cls):
+        super(TestEvalNumexprPython, cls).setup_class()
         tm.skip_if_no_ne()
         import numexpr as ne
         cls.ne = ne
@@ -750,8 +750,8 @@ class TestEvalNumexprPython(TestEvalNumexprPandas):
 class TestEvalPythonPython(TestEvalNumexprPython):
 
     @classmethod
-    def setUpClass(cls):
-        super(TestEvalPythonPython, cls).setUpClass()
+    def setup_class(cls):
+        super(TestEvalPythonPython, cls).setup_class()
         cls.engine = 'python'
         cls.parser = 'python'
 
@@ -780,8 +780,8 @@ class TestEvalPythonPython(TestEvalNumexprPython):
 class TestEvalPythonPandas(TestEvalPythonPython):
 
     @classmethod
-    def setUpClass(cls):
-        super(TestEvalPythonPandas, cls).setUpClass()
+    def setup_class(cls):
+        super(TestEvalPythonPandas, cls).setup_class()
         cls.engine = 'python'
         cls.parser = 'pandas'
 
@@ -1070,16 +1070,16 @@ class TestAlignment(object):
 class TestOperationsNumExprPandas(tm.TestCase):
 
     @classmethod
-    def setUpClass(cls):
-        super(TestOperationsNumExprPandas, cls).setUpClass()
+    def setup_class(cls):
+        super(TestOperationsNumExprPandas, cls).setup_class()
         tm.skip_if_no_ne()
         cls.engine = 'numexpr'
         cls.parser = 'pandas'
         cls.arith_ops = expr._arith_ops_syms + expr._cmp_ops_syms
 
     @classmethod
-    def tearDownClass(cls):
-        super(TestOperationsNumExprPandas, cls).tearDownClass()
+    def teardown_class(cls):
+        super(TestOperationsNumExprPandas, cls).teardown_class()
         del cls.engine, cls.parser
 
     def eval(self, *args, **kwargs):
@@ -1492,8 +1492,8 @@ class TestOperationsNumExprPandas(tm.TestCase):
 class TestOperationsNumExprPython(TestOperationsNumExprPandas):
 
     @classmethod
-    def setUpClass(cls):
-        super(TestOperationsNumExprPython, cls).setUpClass()
+    def setup_class(cls):
+        super(TestOperationsNumExprPython, cls).setup_class()
         cls.engine = 'numexpr'
         cls.parser = 'python'
         tm.skip_if_no_ne(cls.engine)
@@ -1566,8 +1566,8 @@ class TestOperationsNumExprPython(TestOperationsNumExprPandas):
 class TestOperationsPythonPython(TestOperationsNumExprPython):
 
     @classmethod
-    def setUpClass(cls):
-        super(TestOperationsPythonPython, cls).setUpClass()
+    def setup_class(cls):
+        super(TestOperationsPythonPython, cls).setup_class()
         cls.engine = cls.parser = 'python'
         cls.arith_ops = expr._arith_ops_syms + expr._cmp_ops_syms
         cls.arith_ops = filter(lambda x: x not in ('in', 'not in'),
@@ -1577,8 +1577,8 @@ class TestOperationsPythonPython(TestOperationsNumExprPython):
 class TestOperationsPythonPandas(TestOperationsNumExprPandas):
 
     @classmethod
-    def setUpClass(cls):
-        super(TestOperationsPythonPandas, cls).setUpClass()
+    def setup_class(cls):
+        super(TestOperationsPythonPandas, cls).setup_class()
         cls.engine = 'python'
         cls.parser = 'pandas'
         cls.arith_ops = expr._arith_ops_syms + expr._cmp_ops_syms
@@ -1587,8 +1587,8 @@ class TestOperationsPythonPandas(TestOperationsNumExprPandas):
 class TestMathPythonPython(tm.TestCase):
 
     @classmethod
-    def setUpClass(cls):
-        super(TestMathPythonPython, cls).setUpClass()
+    def setup_class(cls):
+        super(TestMathPythonPython, cls).setup_class()
         tm.skip_if_no_ne()
         cls.engine = 'python'
         cls.parser = 'pandas'
@@ -1596,7 +1596,7 @@ class TestMathPythonPython(tm.TestCase):
         cls.binary_fns = _binary_math_ops
 
     @classmethod
-    def tearDownClass(cls):
+    def teardown_class(cls):
         del cls.engine, cls.parser
 
     def eval(self, *args, **kwargs):
@@ -1694,8 +1694,8 @@ class TestMathPythonPython(tm.TestCase):
 class TestMathPythonPandas(TestMathPythonPython):
 
     @classmethod
-    def setUpClass(cls):
-        super(TestMathPythonPandas, cls).setUpClass()
+    def setup_class(cls):
+        super(TestMathPythonPandas, cls).setup_class()
         cls.engine = 'python'
         cls.parser = 'pandas'
 
@@ -1703,8 +1703,8 @@ class TestMathPythonPandas(TestMathPythonPython):
 class TestMathNumExprPandas(TestMathPythonPython):
 
     @classmethod
-    def setUpClass(cls):
-        super(TestMathNumExprPandas, cls).setUpClass()
+    def setup_class(cls):
+        super(TestMathNumExprPandas, cls).setup_class()
         cls.engine = 'numexpr'
         cls.parser = 'pandas'
 
@@ -1712,8 +1712,8 @@ class TestMathNumExprPandas(TestMathPythonPython):
 class TestMathNumExprPython(TestMathPythonPython):
 
     @classmethod
-    def setUpClass(cls):
-        super(TestMathNumExprPython, cls).setUpClass()
+    def setup_class(cls):
+        super(TestMathNumExprPython, cls).setup_class()
         cls.engine = 'numexpr'
         cls.parser = 'python'
 

--- a/pandas/tests/frame/test_asof.py
+++ b/pandas/tests/frame/test_asof.py
@@ -10,7 +10,7 @@ from .common import TestData
 
 
 class TestFrameAsof(TestData, tm.TestCase):
-    def setUp(self):
+    def setup_method(self, method):
         self.N = N = 50
         self.rng = date_range('1/1/1990', periods=N, freq='53s')
         self.df = DataFrame({'A': np.arange(N), 'B': np.arange(N)},

--- a/pandas/tests/frame/test_indexing.py
+++ b/pandas/tests/frame/test_indexing.py
@@ -2914,7 +2914,7 @@ class TestDataFrameIndexing(tm.TestCase, TestData):
 
 class TestDataFrameIndexingDatetimeWithTZ(tm.TestCase, TestData):
 
-    def setUp(self):
+    def setup_method(self, method):
         self.idx = Index(date_range('20130101', periods=3, tz='US/Eastern'),
                          name='foo')
         self.dr = date_range('20130110', periods=3)
@@ -2972,7 +2972,7 @@ class TestDataFrameIndexingDatetimeWithTZ(tm.TestCase, TestData):
 
 class TestDataFrameIndexingUInt64(tm.TestCase, TestData):
 
-    def setUp(self):
+    def setup_method(self, method):
         self.ir = Index(np.arange(3), dtype=np.uint64)
         self.idx = Index([2**63, 2**63 + 5, 2**63 + 10], name='foo')
 

--- a/pandas/tests/frame/test_period.py
+++ b/pandas/tests/frame/test_period.py
@@ -14,7 +14,7 @@ def _permute(obj):
 
 class TestPeriodIndex(tm.TestCase):
 
-    def setUp(self):
+    def setup_method(self, method):
         pass
 
     def test_as_frame_columns(self):

--- a/pandas/tests/frame/test_query_eval.py
+++ b/pandas/tests/frame/test_query_eval.py
@@ -41,7 +41,7 @@ def skip_if_no_ne(engine='numexpr'):
 
 class TestCompat(tm.TestCase):
 
-    def setUp(self):
+    def setup_method(self, method):
         self.df = DataFrame({'A': [1, 2, 3]})
         self.expected1 = self.df[self.df.A > 0]
         self.expected2 = self.df.A + 1
@@ -401,15 +401,15 @@ class TestDataFrameQueryWithMultiIndex(tm.TestCase):
 class TestDataFrameQueryNumExprPandas(tm.TestCase):
 
     @classmethod
-    def setUpClass(cls):
-        super(TestDataFrameQueryNumExprPandas, cls).setUpClass()
+    def setup_class(cls):
+        super(TestDataFrameQueryNumExprPandas, cls).setup_class()
         cls.engine = 'numexpr'
         cls.parser = 'pandas'
         tm.skip_if_no_ne(cls.engine)
 
     @classmethod
-    def tearDownClass(cls):
-        super(TestDataFrameQueryNumExprPandas, cls).tearDownClass()
+    def teardown_class(cls):
+        super(TestDataFrameQueryNumExprPandas, cls).teardown_class()
         del cls.engine, cls.parser
 
     def test_date_query_with_attribute_access(self):
@@ -733,8 +733,8 @@ class TestDataFrameQueryNumExprPandas(tm.TestCase):
 class TestDataFrameQueryNumExprPython(TestDataFrameQueryNumExprPandas):
 
     @classmethod
-    def setUpClass(cls):
-        super(TestDataFrameQueryNumExprPython, cls).setUpClass()
+    def setup_class(cls):
+        super(TestDataFrameQueryNumExprPython, cls).setup_class()
         cls.engine = 'numexpr'
         cls.parser = 'python'
         tm.skip_if_no_ne(cls.engine)
@@ -834,8 +834,8 @@ class TestDataFrameQueryNumExprPython(TestDataFrameQueryNumExprPandas):
 class TestDataFrameQueryPythonPandas(TestDataFrameQueryNumExprPandas):
 
     @classmethod
-    def setUpClass(cls):
-        super(TestDataFrameQueryPythonPandas, cls).setUpClass()
+    def setup_class(cls):
+        super(TestDataFrameQueryPythonPandas, cls).setup_class()
         cls.engine = 'python'
         cls.parser = 'pandas'
         cls.frame = TestData().frame
@@ -855,8 +855,8 @@ class TestDataFrameQueryPythonPandas(TestDataFrameQueryNumExprPandas):
 class TestDataFrameQueryPythonPython(TestDataFrameQueryNumExprPython):
 
     @classmethod
-    def setUpClass(cls):
-        super(TestDataFrameQueryPythonPython, cls).setUpClass()
+    def setup_class(cls):
+        super(TestDataFrameQueryPythonPython, cls).setup_class()
         cls.engine = cls.parser = 'python'
         cls.frame = TestData().frame
 
@@ -1092,16 +1092,16 @@ class TestDataFrameQueryStrings(tm.TestCase):
 class TestDataFrameEvalNumExprPandas(tm.TestCase):
 
     @classmethod
-    def setUpClass(cls):
-        super(TestDataFrameEvalNumExprPandas, cls).setUpClass()
+    def setup_class(cls):
+        super(TestDataFrameEvalNumExprPandas, cls).setup_class()
         cls.engine = 'numexpr'
         cls.parser = 'pandas'
         tm.skip_if_no_ne()
 
-    def setUp(self):
+    def setup_method(self, method):
         self.frame = DataFrame(randn(10, 3), columns=list('abc'))
 
-    def tearDown(self):
+    def teardown_method(self, method):
         del self.frame
 
     def test_simple_expr(self):
@@ -1129,8 +1129,8 @@ class TestDataFrameEvalNumExprPandas(tm.TestCase):
 class TestDataFrameEvalNumExprPython(TestDataFrameEvalNumExprPandas):
 
     @classmethod
-    def setUpClass(cls):
-        super(TestDataFrameEvalNumExprPython, cls).setUpClass()
+    def setup_class(cls):
+        super(TestDataFrameEvalNumExprPython, cls).setup_class()
         cls.engine = 'numexpr'
         cls.parser = 'python'
         tm.skip_if_no_ne(cls.engine)
@@ -1139,8 +1139,8 @@ class TestDataFrameEvalNumExprPython(TestDataFrameEvalNumExprPandas):
 class TestDataFrameEvalPythonPandas(TestDataFrameEvalNumExprPandas):
 
     @classmethod
-    def setUpClass(cls):
-        super(TestDataFrameEvalPythonPandas, cls).setUpClass()
+    def setup_class(cls):
+        super(TestDataFrameEvalPythonPandas, cls).setup_class()
         cls.engine = 'python'
         cls.parser = 'pandas'
 
@@ -1148,6 +1148,6 @@ class TestDataFrameEvalPythonPandas(TestDataFrameEvalNumExprPandas):
 class TestDataFrameEvalPythonPython(TestDataFrameEvalNumExprPython):
 
     @classmethod
-    def setUpClass(cls):
-        super(TestDataFrameEvalPythonPython, cls).tearDownClass()
+    def setup_class(cls):
+        super(TestDataFrameEvalPythonPython, cls).teardown_class()
         cls.engine = cls.parser = 'python'

--- a/pandas/tests/frame/test_validate.py
+++ b/pandas/tests/frame/test_validate.py
@@ -1,10 +1,10 @@
-from unittest import TestCase
 from pandas.core.frame import DataFrame
 
+import pandas.util.testing as tm
 import pytest
 
 
-class TestDataFrameValidate(TestCase):
+class TestDataFrameValidate(tm.TestCase):
     """Tests for error handling related to data types of method arguments."""
     df = DataFrame({'a': [1, 2], 'b': [3, 4]})
 

--- a/pandas/tests/groupby/common.py
+++ b/pandas/tests/groupby/common.py
@@ -28,7 +28,7 @@ def df():
 
 class MixIn(object):
 
-    def setUp(self):
+    def setup_method(self, method):
         self.ts = tm.makeTimeSeries()
 
         self.seriesd = tm.getSeriesData()

--- a/pandas/tests/groupby/test_aggregate.py
+++ b/pandas/tests/groupby/test_aggregate.py
@@ -27,7 +27,7 @@ import pandas.util.testing as tm
 
 class TestGroupByAggregate(tm.TestCase):
 
-    def setUp(self):
+    def setup_method(self, method):
         self.ts = tm.makeTimeSeries()
 
         self.seriesd = tm.getSeriesData()

--- a/pandas/tests/groupby/test_bin_groupby.py
+++ b/pandas/tests/groupby/test_bin_groupby.py
@@ -48,7 +48,7 @@ def test_series_bin_grouper():
 
 class TestBinGroupers(tm.TestCase):
 
-    def setUp(self):
+    def setup_method(self, method):
         self.obj = np.random.randn(10, 1)
         self.labels = np.array([0, 0, 0, 1, 1, 1, 2, 2, 2, 2], dtype=np.int64)
         self.bins = np.array([3, 6], dtype=np.int64)

--- a/pandas/tests/groupby/test_filters.py
+++ b/pandas/tests/groupby/test_filters.py
@@ -25,7 +25,7 @@ import pandas as pd
 
 class TestGroupByFilter(tm.TestCase):
 
-    def setUp(self):
+    def setup_method(self, method):
         self.ts = tm.makeTimeSeries()
 
         self.seriesd = tm.getSeriesData()

--- a/pandas/tests/indexes/datetimes/test_astype.py
+++ b/pandas/tests/indexes/datetimes/test_astype.py
@@ -187,7 +187,7 @@ class TestDatetimeIndex(tm.TestCase):
 
 class TestToPeriod(tm.TestCase):
 
-    def setUp(self):
+    def setup_method(self, method):
         data = [Timestamp('2007-01-01 10:11:12.123456Z'),
                 Timestamp('2007-01-01 10:11:13.789123Z')]
         self.index = DatetimeIndex(data)

--- a/pandas/tests/indexes/datetimes/test_date_range.py
+++ b/pandas/tests/indexes/datetimes/test_date_range.py
@@ -198,7 +198,7 @@ class TestGenRangeGeneration(tm.TestCase):
 
 class TestBusinessDateRange(tm.TestCase):
 
-    def setUp(self):
+    def setup_method(self, method):
         self.rng = bdate_range(START, END)
 
     def test_constructor(self):
@@ -483,7 +483,7 @@ class TestBusinessDateRange(tm.TestCase):
 
 
 class TestCustomDateRange(tm.TestCase):
-    def setUp(self):
+    def setup_method(self, method):
         self.rng = cdate_range(START, END)
 
     def test_constructor(self):

--- a/pandas/tests/indexes/datetimes/test_datetimelike.py
+++ b/pandas/tests/indexes/datetimes/test_datetimelike.py
@@ -11,7 +11,7 @@ from ..datetimelike import DatetimeLike
 class TestDatetimeIndex(DatetimeLike, tm.TestCase):
     _holder = DatetimeIndex
 
-    def setUp(self):
+    def setup_method(self, method):
         self.indices = dict(index=tm.makeDateIndex(10))
         self.setup_indices()
 

--- a/pandas/tests/indexes/datetimes/test_ops.py
+++ b/pandas/tests/indexes/datetimes/test_ops.py
@@ -23,8 +23,8 @@ class TestDatetimeIndexOps(Ops):
     tz = [None, 'UTC', 'Asia/Tokyo', 'US/Eastern', 'dateutil/Asia/Singapore',
           'dateutil/US/Pacific']
 
-    def setUp(self):
-        super(TestDatetimeIndexOps, self).setUp()
+    def setup_method(self, method):
+        super(TestDatetimeIndexOps, self).setup_method(method)
         mask = lambda x: (isinstance(x, DatetimeIndex) or
                           isinstance(x, PeriodIndex))
         self.is_valid_objs = [o for o in self.objs if mask(o)]
@@ -1109,7 +1109,7 @@ def test_shift_months(years, months):
 
 class TestBusinessDatetimeIndex(tm.TestCase):
 
-    def setUp(self):
+    def setup_method(self, method):
         self.rng = bdate_range(START, END)
 
     def test_comparison(self):
@@ -1209,7 +1209,7 @@ class TestBusinessDatetimeIndex(tm.TestCase):
 
 class TestCustomDatetimeIndex(tm.TestCase):
 
-    def setUp(self):
+    def setup_method(self, method):
         self.rng = cdate_range(START, END)
 
     def test_comparison(self):

--- a/pandas/tests/indexes/datetimes/test_setops.py
+++ b/pandas/tests/indexes/datetimes/test_setops.py
@@ -201,7 +201,7 @@ class TestDatetimeIndex(tm.TestCase):
 
 class TestBusinessDatetimeIndex(tm.TestCase):
 
-    def setUp(self):
+    def setup_method(self, method):
         self.rng = bdate_range(START, END)
 
     def test_union(self):
@@ -345,7 +345,7 @@ class TestBusinessDatetimeIndex(tm.TestCase):
 
 class TestCustomDatetimeIndex(tm.TestCase):
 
-    def setUp(self):
+    def setup_method(self, method):
         self.rng = cdate_range(START, END)
 
     def test_union(self):

--- a/pandas/tests/indexes/period/test_asfreq.py
+++ b/pandas/tests/indexes/period/test_asfreq.py
@@ -8,7 +8,7 @@ from pandas import PeriodIndex, Series, DataFrame
 
 class TestPeriodIndex(tm.TestCase):
 
-    def setUp(self):
+    def setup_method(self, method):
         pass
 
     def test_asfreq(self):

--- a/pandas/tests/indexes/period/test_construction.py
+++ b/pandas/tests/indexes/period/test_construction.py
@@ -11,7 +11,7 @@ from pandas import (Period, PeriodIndex, period_range, offsets, date_range,
 
 class TestPeriodIndex(tm.TestCase):
 
-    def setUp(self):
+    def setup_method(self, method):
         pass
 
     def test_construction_base_constructor(self):
@@ -475,7 +475,7 @@ class TestPeriodIndex(tm.TestCase):
 
 class TestSeriesPeriod(tm.TestCase):
 
-    def setUp(self):
+    def setup_method(self, method):
         self.series = Series(period_range('2000-01-01', periods=10, freq='D'))
 
     def test_constructor_cant_cast_period(self):

--- a/pandas/tests/indexes/period/test_indexing.py
+++ b/pandas/tests/indexes/period/test_indexing.py
@@ -13,7 +13,7 @@ from pandas import (PeriodIndex, Series, DatetimeIndex,
 
 class TestGetItem(tm.TestCase):
 
-    def setUp(self):
+    def setup_method(self, method):
         pass
 
     def test_getitem(self):

--- a/pandas/tests/indexes/period/test_ops.py
+++ b/pandas/tests/indexes/period/test_ops.py
@@ -15,8 +15,8 @@ from pandas.tests.test_base import Ops
 
 class TestPeriodIndexOps(Ops):
 
-    def setUp(self):
-        super(TestPeriodIndexOps, self).setUp()
+    def setup_method(self, method):
+        super(TestPeriodIndexOps, self).setup_method(method)
         mask = lambda x: (isinstance(x, DatetimeIndex) or
                           isinstance(x, PeriodIndex))
         self.is_valid_objs = [o for o in self.objs if mask(o)]
@@ -1137,7 +1137,7 @@ class TestPeriodIndexSeriesMethods(tm.TestCase):
 
 class TestSeriesPeriod(tm.TestCase):
 
-    def setUp(self):
+    def setup_method(self, method):
         self.series = Series(period_range('2000-01-01', periods=10, freq='D'))
 
     def test_ops_series_timedelta(self):

--- a/pandas/tests/indexes/period/test_partial_slicing.py
+++ b/pandas/tests/indexes/period/test_partial_slicing.py
@@ -10,7 +10,7 @@ from pandas import (Series, period_range, DatetimeIndex, PeriodIndex,
 
 class TestPeriodIndex(tm.TestCase):
 
-    def setUp(self):
+    def setup_method(self, method):
         pass
 
     def test_slice_with_negative_step(self):

--- a/pandas/tests/indexes/period/test_period.py
+++ b/pandas/tests/indexes/period/test_period.py
@@ -17,7 +17,7 @@ class TestPeriodIndex(DatetimeLike, tm.TestCase):
     _holder = PeriodIndex
     _multiprocess_can_split_ = True
 
-    def setUp(self):
+    def setup_method(self, method):
         self.indices = dict(index=tm.makePeriodIndex(10))
         self.setup_indices()
 

--- a/pandas/tests/indexes/period/test_setops.py
+++ b/pandas/tests/indexes/period/test_setops.py
@@ -14,7 +14,7 @@ def _permute(obj):
 
 class TestPeriodIndex(tm.TestCase):
 
-    def setUp(self):
+    def setup_method(self, method):
         pass
 
     def test_joins(self):

--- a/pandas/tests/indexes/period/test_tools.py
+++ b/pandas/tests/indexes/period/test_tools.py
@@ -152,7 +152,7 @@ class TestTslib(tm.TestCase):
 
 class TestPeriodIndex(tm.TestCase):
 
-    def setUp(self):
+    def setup_method(self, method):
         pass
 
     def test_tolist(self):

--- a/pandas/tests/indexes/test_base.py
+++ b/pandas/tests/indexes/test_base.py
@@ -32,7 +32,7 @@ from pandas._libs.lib import Timestamp
 class TestIndex(Base, tm.TestCase):
     _holder = Index
 
-    def setUp(self):
+    def setup_method(self, method):
         self.indices = dict(unicodeIndex=tm.makeUnicodeIndex(100),
                             strIndex=tm.makeStringIndex(100),
                             dateIndex=tm.makeDateIndex(100),
@@ -1808,7 +1808,7 @@ class TestMixedIntIndex(Base, tm.TestCase):
 
     _holder = Index
 
-    def setUp(self):
+    def setup_method(self, method):
         self.indices = dict(mixedIndex=Index([0, 'a', 1, 'b', 2, 'c']))
         self.setup_indices()
 

--- a/pandas/tests/indexes/test_category.py
+++ b/pandas/tests/indexes/test_category.py
@@ -22,7 +22,7 @@ if PY3:
 class TestCategoricalIndex(Base, tm.TestCase):
     _holder = CategoricalIndex
 
-    def setUp(self):
+    def setup_method(self, method):
         self.indices = dict(catIndex=tm.makeCategoricalIndex(100))
         self.setup_indices()
 

--- a/pandas/tests/indexes/test_frozen.py
+++ b/pandas/tests/indexes/test_frozen.py
@@ -9,7 +9,7 @@ class TestFrozenList(CheckImmutable, CheckStringMixin, tm.TestCase):
     mutable_methods = ('extend', 'pop', 'remove', 'insert')
     unicode_container = FrozenList([u("\u05d0"), u("\u05d1"), "c"])
 
-    def setUp(self):
+    def setup_method(self, method):
         self.lst = [1, 2, 3, 4, 5]
         self.container = FrozenList(self.lst)
         self.klass = FrozenList
@@ -35,7 +35,7 @@ class TestFrozenNDArray(CheckImmutable, CheckStringMixin, tm.TestCase):
     mutable_methods = ('put', 'itemset', 'fill')
     unicode_container = FrozenNDArray([u("\u05d0"), u("\u05d1"), "c"])
 
-    def setUp(self):
+    def setup_method(self, method):
         self.lst = [3, 5, 7, -2]
         self.container = FrozenNDArray(self.lst)
         self.klass = FrozenNDArray

--- a/pandas/tests/indexes/test_interval.py
+++ b/pandas/tests/indexes/test_interval.py
@@ -15,7 +15,7 @@ import pandas as pd
 class TestIntervalIndex(Base, tm.TestCase):
     _holder = IntervalIndex
 
-    def setUp(self):
+    def setup_method(self, method):
         self.index = IntervalIndex.from_arrays([0, 1], [1, 2])
         self.index_with_nan = IntervalIndex.from_tuples(
             [(0, 1), np.nan, (1, 2)])
@@ -721,7 +721,7 @@ class TestIntervalRange(tm.TestCase):
 
 
 class TestIntervalTree(tm.TestCase):
-    def setUp(self):
+    def setup_method(self, method):
         gentree = lambda dtype: IntervalTree(np.arange(5, dtype=dtype),
                                              np.arange(5, dtype=dtype) + 2)
         self.tree = gentree('int64')

--- a/pandas/tests/indexes/test_multi.py
+++ b/pandas/tests/indexes/test_multi.py
@@ -31,7 +31,7 @@ class TestMultiIndex(Base, tm.TestCase):
     _holder = MultiIndex
     _compat_props = ['shape', 'ndim', 'size', 'itemsize']
 
-    def setUp(self):
+    def setup_method(self, method):
         major_axis = Index(['foo', 'bar', 'baz', 'qux'])
         minor_axis = Index(['one', 'two'])
 

--- a/pandas/tests/indexes/test_numeric.py
+++ b/pandas/tests/indexes/test_numeric.py
@@ -179,7 +179,7 @@ class Numeric(Base):
 class TestFloat64Index(Numeric, tm.TestCase):
     _holder = Float64Index
 
-    def setUp(self):
+    def setup_method(self, method):
         self.indices = dict(mixed=Float64Index([1.5, 2, 3, 4, 5]),
                             float=Float64Index(np.arange(5) * 2.5))
         self.setup_indices()
@@ -625,7 +625,7 @@ class TestInt64Index(NumericInt, tm.TestCase):
     _dtype = 'int64'
     _holder = Int64Index
 
-    def setUp(self):
+    def setup_method(self, method):
         self.indices = dict(index=Int64Index(np.arange(0, 20, 2)))
         self.setup_indices()
 
@@ -920,7 +920,7 @@ class TestUInt64Index(NumericInt, tm.TestCase):
     _dtype = 'uint64'
     _holder = UInt64Index
 
-    def setUp(self):
+    def setup_method(self, method):
         self.indices = dict(index=UInt64Index([2**63, 2**63 + 10, 2**63 + 15,
                                                2**63 + 20, 2**63 + 25]))
         self.setup_indices()

--- a/pandas/tests/indexes/test_range.py
+++ b/pandas/tests/indexes/test_range.py
@@ -24,7 +24,7 @@ class TestRangeIndex(Numeric, tm.TestCase):
     _holder = RangeIndex
     _compat_props = ['shape', 'ndim', 'size', 'itemsize']
 
-    def setUp(self):
+    def setup_method(self, method):
         self.indices = dict(index=RangeIndex(0, 20, 2, name='foo'))
         self.setup_indices()
 

--- a/pandas/tests/indexes/timedeltas/test_astype.py
+++ b/pandas/tests/indexes/timedeltas/test_astype.py
@@ -14,7 +14,7 @@ class TestTimedeltaIndex(DatetimeLike, tm.TestCase):
     _holder = TimedeltaIndex
     _multiprocess_can_split_ = True
 
-    def setUp(self):
+    def setup_method(self, method):
         self.indices = dict(index=tm.makeTimedeltaIndex(10))
         self.setup_indices()
 

--- a/pandas/tests/indexes/timedeltas/test_ops.py
+++ b/pandas/tests/indexes/timedeltas/test_ops.py
@@ -16,8 +16,8 @@ from pandas.tests.test_base import Ops
 
 
 class TestTimedeltaIndexOps(Ops):
-    def setUp(self):
-        super(TestTimedeltaIndexOps, self).setUp()
+    def setup_method(self, method):
+        super(TestTimedeltaIndexOps, self).setup_method(method)
         mask = lambda x: isinstance(x, TimedeltaIndex)
         self.is_valid_objs = [o for o in self.objs if mask(o)]
         self.not_valid_objs = []

--- a/pandas/tests/indexes/timedeltas/test_timedelta.py
+++ b/pandas/tests/indexes/timedeltas/test_timedelta.py
@@ -20,7 +20,7 @@ class TestTimedeltaIndex(DatetimeLike, tm.TestCase):
     _holder = TimedeltaIndex
     _multiprocess_can_split_ = True
 
-    def setUp(self):
+    def setup_method(self, method):
         self.indices = dict(index=tm.makeTimedeltaIndex(10))
         self.setup_indices()
 

--- a/pandas/tests/indexing/common.py
+++ b/pandas/tests/indexing/common.py
@@ -31,7 +31,7 @@ class Base(object):
     _typs = set(['ints', 'uints', 'labels', 'mixed',
                  'ts', 'floats', 'empty', 'ts_rev'])
 
-    def setUp(self):
+    def setup_method(self, method):
 
         self.series_ints = Series(np.random.rand(4), index=lrange(0, 8, 2))
         self.frame_ints = DataFrame(np.random.randn(4, 4),

--- a/pandas/tests/indexing/test_categorical.py
+++ b/pandas/tests/indexing/test_categorical.py
@@ -12,7 +12,7 @@ from pandas.util import testing as tm
 
 class TestCategoricalIndex(tm.TestCase):
 
-    def setUp(self):
+    def setup_method(self, method):
 
         self.df = DataFrame({'A': np.arange(6, dtype='int64'),
                              'B': Series(list('aabbca')).astype(

--- a/pandas/tests/indexing/test_coercion.py
+++ b/pandas/tests/indexing/test_coercion.py
@@ -1146,7 +1146,7 @@ class TestReplaceSeriesCoercion(CoercionBase, tm.TestCase):
     klasses = ['series']
     method = 'replace'
 
-    def setUp(self):
+    def setup_method(self, method):
         self.rep = {}
         self.rep['object'] = ['a', 'b']
         self.rep['int64'] = [4, 5]

--- a/pandas/tests/indexing/test_interval.py
+++ b/pandas/tests/indexing/test_interval.py
@@ -8,7 +8,7 @@ import pandas.util.testing as tm
 
 class TestIntervalIndex(tm.TestCase):
 
-    def setUp(self):
+    def setup_method(self, method):
         self.s = Series(np.arange(5), IntervalIndex.from_breaks(np.arange(6)))
 
     def test_loc_with_scalar(self):

--- a/pandas/tests/io/formats/test_format.py
+++ b/pandas/tests/io/formats/test_format.py
@@ -107,14 +107,14 @@ def has_expanded_repr(df):
 
 class TestDataFrameFormatting(tm.TestCase):
 
-    def setUp(self):
+    def setup_method(self, method):
         self.warn_filters = warnings.filters
         warnings.filterwarnings('ignore', category=FutureWarning,
                                 module=".*format")
 
         self.frame = _frame.copy()
 
-    def tearDown(self):
+    def teardown_method(self, method):
         warnings.filters = self.warn_filters
 
     def test_repr_embedded_ndarray(self):
@@ -1606,7 +1606,7 @@ def gen_series_formatting():
 
 class TestSeriesFormatting(tm.TestCase):
 
-    def setUp(self):
+    def setup_method(self, method):
         self.ts = tm.makeTimeSeries()
 
     def test_repr_unicode(self):

--- a/pandas/tests/io/formats/test_printing.py
+++ b/pandas/tests/io/formats/test_printing.py
@@ -126,7 +126,7 @@ c        ff         いいい"""
 class TestTableSchemaRepr(tm.TestCase):
 
     @classmethod
-    def setUpClass(cls):
+    def setup_class(cls):
         pytest.importorskip('IPython')
         try:
             import mock

--- a/pandas/tests/io/formats/test_style.py
+++ b/pandas/tests/io/formats/test_style.py
@@ -14,7 +14,7 @@ from pandas.io.formats.style import Styler, _get_level_lengths  # noqa
 
 class TestStyler(TestCase):
 
-    def setUp(self):
+    def setup_method(self, method):
         np.random.seed(24)
         self.s = DataFrame({'A': np.random.permutation(range(6))})
         self.df = DataFrame({'A': [0, 1], 'B': np.random.randn(2)})

--- a/pandas/tests/io/formats/test_style.py
+++ b/pandas/tests/io/formats/test_style.py
@@ -5,14 +5,13 @@ import pytest
 import numpy as np
 import pandas as pd
 from pandas import DataFrame
-from pandas.util.testing import TestCase
 import pandas.util.testing as tm
 
 jinja2 = pytest.importorskip('jinja2')
 from pandas.io.formats.style import Styler, _get_level_lengths  # noqa
 
 
-class TestStyler(TestCase):
+class TestStyler(tm.TestCase):
 
     def setup_method(self, method):
         np.random.seed(24)
@@ -813,10 +812,10 @@ class TestStyler(TestCase):
         assert head == expected
 
 
-@tm.mplskip
-class TestStylerMatplotlibDep(TestCase):
+class TestStylerMatplotlibDep(tm.TestCase):
 
     def test_background_gradient(self):
+        tm._skip_if_no_mpl()
         df = pd.DataFrame([[1, 2], [2, 4]], columns=['A', 'B'])
 
         for c_map in [None, 'YlOrRd']:

--- a/pandas/tests/io/json/test_json_table_schema.py
+++ b/pandas/tests/io/json/test_json_table_schema.py
@@ -19,7 +19,7 @@ from pandas.io.json.table_schema import (
 
 class TestBuildSchema(tm.TestCase):
 
-    def setUp(self):
+    def setup_method(self, method):
         self.df = DataFrame(
             {'A': [1, 2, 3, 4],
              'B': ['a', 'b', 'c', 'c'],
@@ -171,7 +171,7 @@ class TestTableSchemaType(tm.TestCase):
 
 class TestTableOrient(tm.TestCase):
 
-    def setUp(self):
+    def setup_method(self, method):
         self.df = DataFrame(
             {'A': [1, 2, 3, 4],
              'B': ['a', 'b', 'c', 'c'],

--- a/pandas/tests/io/json/test_pandas.py
+++ b/pandas/tests/io/json/test_pandas.py
@@ -37,7 +37,7 @@ _mixed_frame = _frame.copy()
 
 class TestPandasContainer(tm.TestCase):
 
-    def setUp(self):
+    def setup_method(self, method):
         self.dirpath = tm.get_data_path()
 
         self.ts = tm.makeTimeSeries()
@@ -59,7 +59,7 @@ class TestPandasContainer(tm.TestCase):
         self.mixed_frame = _mixed_frame.copy()
         self.categorical = _cat_frame.copy()
 
-    def tearDown(self):
+    def teardown_method(self, method):
         del self.dirpath
 
         del self.ts

--- a/pandas/tests/io/json/test_ujson.py
+++ b/pandas/tests/io/json/test_ujson.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from unittest import TestCase
-
 try:
     import json
 except ImportError:
@@ -27,7 +25,7 @@ json_unicode = (json.dumps if compat.PY3
                 else partial(json.dumps, encoding="utf-8"))
 
 
-class UltraJSONTests(TestCase):
+class UltraJSONTests(tm.TestCase):
 
     @pytest.mark.skipif(compat.is_platform_32bit(),
                         reason="not compliant on 32-bit, xref #15865")
@@ -948,7 +946,7 @@ class UltraJSONTests(TestCase):
                 ujson.decode(ujson.encode(l, default_handler=str)))
 
 
-class NumpyJSONTests(TestCase):
+class NumpyJSONTests(tm.TestCase):
 
     def testBool(self):
         b = np.bool(True)
@@ -1224,7 +1222,7 @@ class NumpyJSONTests(TestCase):
         assert (np.array(['a', 'b']) == output[2]).all()
 
 
-class PandasJSONTests(TestCase):
+class PandasJSONTests(tm.TestCase):
 
     def testDataFrame(self):
         df = DataFrame([[1, 2, 3], [4, 5, 6]], index=[

--- a/pandas/tests/io/parser/test_network.py
+++ b/pandas/tests/io/parser/test_network.py
@@ -49,7 +49,7 @@ def check_compressed_urls(salaries_table, compression, extension, mode,
 
 class TestS3(tm.TestCase):
 
-    def setUp(self):
+    def setup_method(self, method):
         try:
             import s3fs  # noqa
         except ImportError:

--- a/pandas/tests/io/parser/test_parsers.py
+++ b/pandas/tests/io/parser/test_parsers.py
@@ -42,7 +42,7 @@ class BaseParser(CommentTests, CompressionTests,
     def float_precision_choices(self):
         raise AbstractMethodError(self)
 
-    def setUp(self):
+    def setup_method(self, method):
         self.dirpath = tm.get_data_path()
         self.csv1 = os.path.join(self.dirpath, 'test1.csv')
         self.csv2 = os.path.join(self.dirpath, 'test2.csv')

--- a/pandas/tests/io/parser/test_textreader.py
+++ b/pandas/tests/io/parser/test_textreader.py
@@ -28,7 +28,7 @@ import pandas.io.libparsers as parser
 
 class TestTextReader(tm.TestCase):
 
-    def setUp(self):
+    def setup_method(self, method):
         self.dirpath = tm.get_data_path()
         self.csv1 = os.path.join(self.dirpath, 'test1.csv')
         self.csv2 = os.path.join(self.dirpath, 'test2.csv')

--- a/pandas/tests/io/sas/test_sas7bdat.py
+++ b/pandas/tests/io/sas/test_sas7bdat.py
@@ -8,7 +8,7 @@ import numpy as np
 
 class TestSAS7BDAT(tm.TestCase):
 
-    def setUp(self):
+    def setup_method(self, method):
         self.dirpath = tm.get_data_path()
         self.data = []
         self.test_ix = [list(range(1, 16)), [16]]

--- a/pandas/tests/io/sas/test_xport.py
+++ b/pandas/tests/io/sas/test_xport.py
@@ -18,7 +18,7 @@ def numeric_as_float(data):
 
 class TestXport(tm.TestCase):
 
-    def setUp(self):
+    def setup_method(self, method):
         self.dirpath = tm.get_data_path()
         self.file01 = os.path.join(self.dirpath, "DEMO_G.xpt")
         self.file02 = os.path.join(self.dirpath, "SSHSV1_A.xpt")

--- a/pandas/tests/io/test_clipboard.py
+++ b/pandas/tests/io/test_clipboard.py
@@ -26,8 +26,8 @@ except PyperclipException:
 class TestClipboard(tm.TestCase):
 
     @classmethod
-    def setUpClass(cls):
-        super(TestClipboard, cls).setUpClass()
+    def setup_class(cls):
+        super(TestClipboard, cls).setup_class()
         cls.data = {}
         cls.data['string'] = mkdf(5, 3, c_idx_type='s', r_idx_type='i',
                                   c_idx_names=[None], r_idx_names=[None])
@@ -62,8 +62,8 @@ class TestClipboard(tm.TestCase):
         cls.data_types = list(cls.data.keys())
 
     @classmethod
-    def tearDownClass(cls):
-        super(TestClipboard, cls).tearDownClass()
+    def teardown_class(cls):
+        super(TestClipboard, cls).teardown_class()
         del cls.data_types, cls.data
 
     def check_round_trip_frame(self, data_type, excel=None, sep=None,

--- a/pandas/tests/io/test_common.py
+++ b/pandas/tests/io/test_common.py
@@ -92,7 +92,7 @@ bar2,12,13,14,15
 
 class TestMMapWrapper(tm.TestCase):
 
-    def setUp(self):
+    def setup_method(self, method):
         self.mmap_file = os.path.join(tm.get_data_path(),
                                       'test_mmap.csv')
 

--- a/pandas/tests/io/test_excel.py
+++ b/pandas/tests/io/test_excel.py
@@ -84,7 +84,7 @@ _mixed_frame['foo'] = 'bar'
 
 class SharedItems(object):
 
-    def setUp(self):
+    def setup_method(self, method):
         self.dirpath = tm.get_data_path()
         self.frame = _frame.copy()
         self.frame2 = _frame2.copy()
@@ -161,9 +161,9 @@ class ReadingTestsBase(SharedItems):
     # 3. Add a property engine_name, which is the name of the reader class.
     #    For the reader this is not used for anything at the moment.
 
-    def setUp(self):
+    def setup_method(self, method):
         self.check_skip()
-        super(ReadingTestsBase, self).setUp()
+        super(ReadingTestsBase, self).setup_method(method)
 
     def test_parse_cols_int(self):
 
@@ -1019,14 +1019,14 @@ class ExcelWriterBase(SharedItems):
     # Test with MultiIndex and Hierarchical Rows as merged cells.
     merge_cells = True
 
-    def setUp(self):
+    def setup_method(self, method):
         self.check_skip()
-        super(ExcelWriterBase, self).setUp()
+        super(ExcelWriterBase, self).setup_method(method)
         self.option_name = 'io.excel.%s.writer' % self.ext.strip('.')
         self.prev_engine = get_option(self.option_name)
         set_option(self.option_name, self.engine_name)
 
-    def tearDown(self):
+    def teardown_method(self, method):
         set_option(self.option_name, self.prev_engine)
 
     def test_excel_sheet_by_name_raise(self):
@@ -1926,7 +1926,7 @@ def skip_openpyxl_gt21(cls):
     """Skip a TestCase instance if openpyxl >= 2.2"""
 
     @classmethod
-    def setUpClass(cls):
+    def setup_class(cls):
         _skip_if_no_openpyxl()
         import openpyxl
         ver = openpyxl.__version__
@@ -1934,7 +1934,7 @@ def skip_openpyxl_gt21(cls):
                  LooseVersion(ver) < LooseVersion('2.2.0'))):
             pytest.skip("openpyxl %s >= 2.2" % str(ver))
 
-    cls.setUpClass = setUpClass
+    cls.setup_class = setup_class
     return cls
 
 
@@ -2043,14 +2043,14 @@ def skip_openpyxl_lt22(cls):
     """Skip a TestCase instance if openpyxl < 2.2"""
 
     @classmethod
-    def setUpClass(cls):
+    def setup_class(cls):
         _skip_if_no_openpyxl()
         import openpyxl
         ver = openpyxl.__version__
         if LooseVersion(ver) < LooseVersion('2.2.0'):
             pytest.skip("openpyxl %s < 2.2" % str(ver))
 
-    cls.setUpClass = setUpClass
+    cls.setup_class = setup_class
     return cls
 
 

--- a/pandas/tests/io/test_gbq.py
+++ b/pandas/tests/io/test_gbq.py
@@ -97,7 +97,7 @@ def make_mixed_dataframe_v2(test_size):
 class TestToGBQIntegrationWithServiceAccountKeyPath(tm.TestCase):
 
     @classmethod
-    def setUpClass(cls):
+    def setup_class(cls):
         # - GLOBAL CLASS FIXTURES -
         # put here any instruction you want to execute only *ONCE* *BEFORE*
         # executing *ALL* tests described below.
@@ -111,7 +111,7 @@ class TestToGBQIntegrationWithServiceAccountKeyPath(tm.TestCase):
                                 ).create(DATASET_ID + "1")
 
     @classmethod
-    def tearDownClass(cls):
+    def teardown_class(cls):
         # - GLOBAL CLASS FIXTURES -
         # put here any instruction you want to execute only *ONCE* *AFTER*
         # executing all tests.

--- a/pandas/tests/io/test_html.py
+++ b/pandas/tests/io/test_html.py
@@ -99,8 +99,8 @@ class TestReadHtml(tm.TestCase, ReadHtmlMixin):
     banklist_data = os.path.join(DATA_PATH, 'banklist.html')
 
     @classmethod
-    def setUpClass(cls):
-        super(TestReadHtml, cls).setUpClass()
+    def setup_class(cls):
+        super(TestReadHtml, cls).setup_class()
         _skip_if_none_of(('bs4', 'html5lib'))
 
     def test_to_html_compat(self):
@@ -783,8 +783,8 @@ class TestReadHtmlEncoding(tm.TestCase):
     flavor = 'bs4'
 
     @classmethod
-    def setUpClass(cls):
-        super(TestReadHtmlEncoding, cls).setUpClass()
+    def setup_class(cls):
+        super(TestReadHtmlEncoding, cls).setup_class()
         _skip_if_none_of((cls.flavor, 'html5lib'))
 
     def read_html(self, *args, **kwargs):
@@ -825,8 +825,8 @@ class TestReadHtmlEncodingLxml(TestReadHtmlEncoding):
     flavor = 'lxml'
 
     @classmethod
-    def setUpClass(cls):
-        super(TestReadHtmlEncodingLxml, cls).setUpClass()
+    def setup_class(cls):
+        super(TestReadHtmlEncodingLxml, cls).setup_class()
         _skip_if_no(cls.flavor)
 
 
@@ -834,8 +834,8 @@ class TestReadHtmlLxml(tm.TestCase, ReadHtmlMixin):
     flavor = 'lxml'
 
     @classmethod
-    def setUpClass(cls):
-        super(TestReadHtmlLxml, cls).setUpClass()
+    def setup_class(cls):
+        super(TestReadHtmlLxml, cls).setup_class()
         _skip_if_no('lxml')
 
     def test_data_fail(self):

--- a/pandas/tests/io/test_packers.py
+++ b/pandas/tests/io/test_packers.py
@@ -92,10 +92,10 @@ def check_arbitrary(a, b):
 
 class TestPackers(tm.TestCase):
 
-    def setUp(self):
+    def setup_method(self, method):
         self.path = '__%s__.msg' % tm.rands(10)
 
-    def tearDown(self):
+    def teardown_method(self, method):
         pass
 
     def encode_decode(self, x, compress=None, **kwargs):
@@ -301,8 +301,8 @@ class TestBasic(TestPackers):
 
 class TestIndex(TestPackers):
 
-    def setUp(self):
-        super(TestIndex, self).setUp()
+    def setup_method(self, method):
+        super(TestIndex, self).setup_method(method)
 
         self.d = {
             'string': tm.makeStringIndex(100),
@@ -364,8 +364,8 @@ class TestIndex(TestPackers):
 
 class TestSeries(TestPackers):
 
-    def setUp(self):
-        super(TestSeries, self).setUp()
+    def setup_method(self, method):
+        super(TestSeries, self).setup_method(method)
 
         self.d = {}
 
@@ -412,8 +412,8 @@ class TestSeries(TestPackers):
 
 class TestCategorical(TestPackers):
 
-    def setUp(self):
-        super(TestCategorical, self).setUp()
+    def setup_method(self, method):
+        super(TestCategorical, self).setup_method(method)
 
         self.d = {}
 
@@ -435,8 +435,8 @@ class TestCategorical(TestPackers):
 
 class TestNDFrame(TestPackers):
 
-    def setUp(self):
-        super(TestNDFrame, self).setUp()
+    def setup_method(self, method):
+        super(TestNDFrame, self).setup_method(method)
 
         data = {
             'A': [0., 1., 2., 3., np.nan],
@@ -579,7 +579,7 @@ class TestCompression(TestPackers):
     """See https://github.com/pandas-dev/pandas/pull/9783
     """
 
-    def setUp(self):
+    def setup_method(self, method):
         try:
             from sqlalchemy import create_engine
             self._create_sql_engine = create_engine
@@ -588,7 +588,7 @@ class TestCompression(TestPackers):
         else:
             self._SQLALCHEMY_INSTALLED = True
 
-        super(TestCompression, self).setUp()
+        super(TestCompression, self).setup_method(method)
         data = {
             'A': np.arange(1000, dtype=np.float64),
             'B': np.arange(1000, dtype=np.int32),
@@ -773,8 +773,8 @@ class TestCompression(TestPackers):
 
 class TestEncoding(TestPackers):
 
-    def setUp(self):
-        super(TestEncoding, self).setUp()
+    def setup_method(self, method):
+        super(TestEncoding, self).setup_method(method)
         data = {
             'A': [compat.u('\u2019')] * 1000,
             'B': np.arange(1000, dtype=np.int32),

--- a/pandas/tests/io/test_pytables.py
+++ b/pandas/tests/io/test_pytables.py
@@ -124,23 +124,23 @@ def _maybe_remove(store, key):
 class Base(tm.TestCase):
 
     @classmethod
-    def setUpClass(cls):
-        super(Base, cls).setUpClass()
+    def setup_class(cls):
+        super(Base, cls).setup_class()
 
         # Pytables 3.0.0 deprecates lots of things
         tm.reset_testing_mode()
 
     @classmethod
-    def tearDownClass(cls):
-        super(Base, cls).tearDownClass()
+    def teardown_class(cls):
+        super(Base, cls).teardown_class()
 
         # Pytables 3.0.0 deprecates lots of things
         tm.set_testing_mode()
 
-    def setUp(self):
+    def setup_method(self, method):
         self.path = 'tmp.__%s__.h5' % tm.rands(10)
 
-    def tearDown(self):
+    def teardown_method(self, method):
         pass
 
 

--- a/pandas/tests/io/test_sql.py
+++ b/pandas/tests/io/test_sql.py
@@ -179,7 +179,7 @@ SQL_STRINGS = {
 
 class MixInBase(object):
 
-    def tearDown(self):
+    def teardown_method(self, method):
         for tbl in self._get_all_tables():
             self.drop_table(tbl)
         self._close_conn()
@@ -498,7 +498,7 @@ class _TestSQLApi(PandasSQLTest):
     flavor = 'sqlite'
     mode = None
 
-    def setUp(self):
+    def setup_method(self, method):
         self.conn = self.connect()
         self._load_iris_data()
         self._load_iris_view()
@@ -981,8 +981,8 @@ class _EngineToConnMixin(object):
     A mixin that causes setup_connect to create a conn rather than an engine.
     """
 
-    def setUp(self):
-        super(_EngineToConnMixin, self).setUp()
+    def setup_method(self, method):
+        super(_EngineToConnMixin, self).setup_method(method)
         engine = self.conn
         conn = engine.connect()
         self.__tx = conn.begin()
@@ -990,12 +990,12 @@ class _EngineToConnMixin(object):
         self.__engine = engine
         self.conn = conn
 
-    def tearDown(self):
+    def teardown_method(self, method):
         self.__tx.rollback()
         self.conn.close()
         self.conn = self.__engine
         self.pandasSQL = sql.SQLDatabase(self.__engine)
-        super(_EngineToConnMixin, self).tearDown()
+        super(_EngineToConnMixin, self).teardown_method(method)
 
 
 @pytest.mark.single
@@ -1093,7 +1093,7 @@ class _TestSQLAlchemy(SQLAlchemyMixIn, PandasSQLTest):
     flavor = None
 
     @classmethod
-    def setUpClass(cls):
+    def setup_class(cls):
         cls.setup_import()
         cls.setup_driver()
 
@@ -1105,7 +1105,7 @@ class _TestSQLAlchemy(SQLAlchemyMixIn, PandasSQLTest):
             msg = "{0} - can't connect to {1} server".format(cls, cls.flavor)
             pytest.skip(msg)
 
-    def setUp(self):
+    def setup_method(self, method):
         self.setup_connect()
 
         self._load_iris_data()
@@ -1871,7 +1871,7 @@ class TestSQLiteFallback(SQLiteMixIn, PandasSQLTest, unittest.TestCase):
     def connect(cls):
         return sqlite3.connect(':memory:')
 
-    def setUp(self):
+    def setup_method(self, method):
         self.conn = self.connect()
         self.pandasSQL = sql.SQLiteDatabase(self.conn)
 
@@ -2086,7 +2086,8 @@ def _skip_if_no_pymysql():
 @pytest.mark.single
 class TestXSQLite(SQLiteMixIn, tm.TestCase):
 
-    def setUp(self):
+    def setup_method(self, method):
+        self.method = method
         self.conn = sqlite3.connect(':memory:')
 
     def test_basic(self):
@@ -2186,7 +2187,7 @@ class TestXSQLite(SQLiteMixIn, tm.TestCase):
             tquery("select * from test", con=self.conn)
 
         # Initialize connection again (needed for tearDown)
-        self.setUp()
+        self.setup_method(self.method)
 
     def test_na_roundtrip(self):
         pass
@@ -2317,7 +2318,7 @@ class TestSQLFlavorDeprecation(tm.TestCase):
 class TestXMySQL(MySQLMixIn, tm.TestCase):
 
     @classmethod
-    def setUpClass(cls):
+    def setup_class(cls):
         _skip_if_no_pymysql()
 
         # test connection
@@ -2345,7 +2346,7 @@ class TestXMySQL(MySQLMixIn, tm.TestCase):
                 "[pandas] in your system's mysql default file, "
                 "typically located at ~/.my.cnf or /etc/.my.cnf. ")
 
-    def setUp(self):
+    def setup_method(self, method):
         _skip_if_no_pymysql()
         import pymysql
         try:
@@ -2370,6 +2371,8 @@ class TestXMySQL(MySQLMixIn, tm.TestCase):
                 "Create a group of connection parameters under the heading "
                 "[pandas] in your system's mysql default file, "
                 "typically located at ~/.my.cnf or /etc/.my.cnf. ")
+
+        self.method = method
 
     def test_basic(self):
         _skip_if_no_pymysql()
@@ -2498,7 +2501,7 @@ class TestXMySQL(MySQLMixIn, tm.TestCase):
             tquery("select * from test", con=self.conn)
 
         # Initialize connection again (needed for tearDown)
-        self.setUp()
+        self.setup_method(self.method)
 
     def test_na_roundtrip(self):
         _skip_if_no_pymysql()

--- a/pandas/tests/io/test_sql.py
+++ b/pandas/tests/io/test_sql.py
@@ -20,7 +20,6 @@ The SQL tests are broken down in different classes:
 from __future__ import print_function
 from warnings import catch_warnings
 import pytest
-import unittest
 import sqlite3
 import csv
 import os
@@ -819,7 +818,7 @@ class _TestSQLApi(PandasSQLTest):
 
 
 @pytest.mark.single
-class TestSQLApi(SQLAlchemyMixIn, _TestSQLApi, unittest.TestCase):
+class TestSQLApi(SQLAlchemyMixIn, _TestSQLApi, tm.TestCase):
     """
     Test the public API as it would be used directly
 
@@ -999,12 +998,12 @@ class _EngineToConnMixin(object):
 
 
 @pytest.mark.single
-class TestSQLApiConn(_EngineToConnMixin, TestSQLApi, unittest.TestCase):
+class TestSQLApiConn(_EngineToConnMixin, TestSQLApi, tm.TestCase):
     pass
 
 
 @pytest.mark.single
-class TestSQLiteFallbackApi(SQLiteMixIn, _TestSQLApi, unittest.TestCase):
+class TestSQLiteFallbackApi(SQLiteMixIn, _TestSQLApi, tm.TestCase):
     """
     Test the public sqlite connection fallback API
 
@@ -1822,37 +1821,37 @@ class _TestPostgreSQLAlchemy(object):
 
 
 @pytest.mark.single
-class TestMySQLAlchemy(_TestMySQLAlchemy, _TestSQLAlchemy, unittest.TestCase):
+class TestMySQLAlchemy(_TestMySQLAlchemy, _TestSQLAlchemy, tm.TestCase):
     pass
 
 
 @pytest.mark.single
 class TestMySQLAlchemyConn(_TestMySQLAlchemy, _TestSQLAlchemyConn,
-                           unittest.TestCase):
+                           tm.TestCase):
     pass
 
 
 @pytest.mark.single
 class TestPostgreSQLAlchemy(_TestPostgreSQLAlchemy, _TestSQLAlchemy,
-                            unittest.TestCase):
+                            tm.TestCase):
     pass
 
 
 @pytest.mark.single
 class TestPostgreSQLAlchemyConn(_TestPostgreSQLAlchemy, _TestSQLAlchemyConn,
-                                unittest.TestCase):
+                                tm.TestCase):
     pass
 
 
 @pytest.mark.single
 class TestSQLiteAlchemy(_TestSQLiteAlchemy, _TestSQLAlchemy,
-                        unittest.TestCase):
+                        tm.TestCase):
     pass
 
 
 @pytest.mark.single
 class TestSQLiteAlchemyConn(_TestSQLiteAlchemy, _TestSQLAlchemyConn,
-                            unittest.TestCase):
+                            tm.TestCase):
     pass
 
 
@@ -1860,7 +1859,7 @@ class TestSQLiteAlchemyConn(_TestSQLiteAlchemy, _TestSQLAlchemyConn,
 # -- Test Sqlite / MySQL fallback
 
 @pytest.mark.single
-class TestSQLiteFallback(SQLiteMixIn, PandasSQLTest, unittest.TestCase):
+class TestSQLiteFallback(SQLiteMixIn, PandasSQLTest, tm.TestCase):
     """
     Test the fallback mode against an in-memory sqlite database.
 

--- a/pandas/tests/io/test_stata.py
+++ b/pandas/tests/io/test_stata.py
@@ -25,7 +25,7 @@ from pandas.core.dtypes.common import is_categorical_dtype
 
 class TestStata(tm.TestCase):
 
-    def setUp(self):
+    def setup_method(self, method):
         self.dirpath = tm.get_data_path()
         self.dta1_114 = os.path.join(self.dirpath, 'stata1_114.dta')
         self.dta1_117 = os.path.join(self.dirpath, 'stata1_117.dta')

--- a/pandas/tests/plotting/common.py
+++ b/pandas/tests/plotting/common.py
@@ -19,10 +19,11 @@ from numpy import random
 import pandas.plotting as plotting
 from pandas.plotting._tools import _flatten
 
-
 """
 This is a common base class used for various plotting tests
 """
+
+tm._skip_module_if_no_mpl()
 
 
 def _skip_if_no_scipy_gaussian_kde():
@@ -41,7 +42,6 @@ def _ok_for_gaussian_kde(kind):
     return True
 
 
-@tm.mplskip
 class TestPlotBase(tm.TestCase):
 
     def setup_method(self, method):

--- a/pandas/tests/plotting/common.py
+++ b/pandas/tests/plotting/common.py
@@ -44,7 +44,7 @@ def _ok_for_gaussian_kde(kind):
 @tm.mplskip
 class TestPlotBase(tm.TestCase):
 
-    def setUp(self):
+    def setup_method(self, method):
 
         import matplotlib as mpl
         mpl.rcdefaults()
@@ -95,7 +95,7 @@ class TestPlotBase(tm.TestCase):
                                     "C": np.arange(20) + np.random.uniform(
                                         size=20)})
 
-    def tearDown(self):
+    def teardown_method(self, method):
         tm.close()
 
     @cache_readonly

--- a/pandas/tests/plotting/test_boxplot_method.py
+++ b/pandas/tests/plotting/test_boxplot_method.py
@@ -21,6 +21,8 @@ from pandas.tests.plotting.common import (TestPlotBase, _check_plot_works)
 
 """ Test cases for .boxplot method """
 
+tm._skip_module_if_no_mpl()
+
 
 def _skip_if_mpl_14_or_dev_boxplot():
     # GH 8382
@@ -31,7 +33,6 @@ def _skip_if_mpl_14_or_dev_boxplot():
         pytest.skip("Matplotlib Regression in 1.4 and current dev.")
 
 
-@tm.mplskip
 class TestDataFramePlots(TestPlotBase):
 
     @slow
@@ -165,7 +166,6 @@ class TestDataFramePlots(TestPlotBase):
                                 xlabelsize=16, ylabelsize=16)
 
 
-@tm.mplskip
 class TestDataFrameGroupByPlots(TestPlotBase):
 
     @slow

--- a/pandas/tests/plotting/test_converter.py
+++ b/pandas/tests/plotting/test_converter.py
@@ -17,7 +17,7 @@ def test_timtetonum_accepts_unicode():
 
 class TestDateTimeConverter(tm.TestCase):
 
-    def setUp(self):
+    def setup_method(self, method):
         self.dtc = converter.DatetimeConverter()
         self.tc = converter.TimeFormatter(None)
 
@@ -148,7 +148,7 @@ class TestDateTimeConverter(tm.TestCase):
 
 class TestPeriodConverter(tm.TestCase):
 
-    def setUp(self):
+    def setup_method(self, method):
         self.pc = converter.PeriodConverter()
 
         class Axis(object):

--- a/pandas/tests/plotting/test_datetimelike.py
+++ b/pandas/tests/plotting/test_datetimelike.py
@@ -20,8 +20,9 @@ import pandas.util.testing as tm
 from pandas.tests.plotting.common import (TestPlotBase,
                                           _skip_if_no_scipy_gaussian_kde)
 
+tm._skip_module_if_no_mpl()
 
-@tm.mplskip
+
 class TestTSPlot(TestPlotBase):
 
     def setup_method(self, method):

--- a/pandas/tests/plotting/test_datetimelike.py
+++ b/pandas/tests/plotting/test_datetimelike.py
@@ -24,8 +24,8 @@ from pandas.tests.plotting.common import (TestPlotBase,
 @tm.mplskip
 class TestTSPlot(TestPlotBase):
 
-    def setUp(self):
-        TestPlotBase.setUp(self)
+    def setup_method(self, method):
+        TestPlotBase.setup_method(self, method)
 
         freq = ['S', 'T', 'H', 'D', 'W', 'M', 'Q', 'A']
         idx = [period_range('12/31/1999', freq=x, periods=100) for x in freq]
@@ -41,7 +41,7 @@ class TestTSPlot(TestPlotBase):
                                       columns=['A', 'B', 'C'])
                             for x in idx]
 
-    def tearDown(self):
+    def teardown_method(self, method):
         tm.close()
 
     @slow

--- a/pandas/tests/plotting/test_deprecated.py
+++ b/pandas/tests/plotting/test_deprecated.py
@@ -18,8 +18,9 @@ Test cases for plot functions imported from deprecated
 pandas.tools.plotting
 """
 
+tm._skip_module_if_no_mpl()
 
-@tm.mplskip
+
 class TestDeprecatedNameSpace(TestPlotBase):
 
     @slow

--- a/pandas/tests/plotting/test_frame.py
+++ b/pandas/tests/plotting/test_frame.py
@@ -31,8 +31,8 @@ from pandas.tests.plotting.common import (TestPlotBase, _check_plot_works,
 @tm.mplskip
 class TestDataFramePlots(TestPlotBase):
 
-    def setUp(self):
-        TestPlotBase.setUp(self)
+    def setup_method(self, method):
+        TestPlotBase.setup_method(self, method)
         import matplotlib as mpl
         mpl.rcdefaults()
 

--- a/pandas/tests/plotting/test_frame.py
+++ b/pandas/tests/plotting/test_frame.py
@@ -27,8 +27,9 @@ from pandas.tests.plotting.common import (TestPlotBase, _check_plot_works,
                                           _skip_if_no_scipy_gaussian_kde,
                                           _ok_for_gaussian_kde)
 
+tm._skip_module_if_no_mpl()
 
-@tm.mplskip
+
 class TestDataFramePlots(TestPlotBase):
 
     def setup_method(self, method):

--- a/pandas/tests/plotting/test_groupby.py
+++ b/pandas/tests/plotting/test_groupby.py
@@ -10,8 +10,9 @@ import numpy as np
 
 from pandas.tests.plotting.common import TestPlotBase
 
+tm._skip_module_if_no_mpl()
 
-@tm.mplskip
+
 class TestDataFrameGroupByPlots(TestPlotBase):
 
     def test_series_groupby_plotting_nominally_works(self):

--- a/pandas/tests/plotting/test_hist_method.py
+++ b/pandas/tests/plotting/test_hist_method.py
@@ -15,7 +15,9 @@ from pandas.plotting._core import grouped_hist
 from pandas.tests.plotting.common import (TestPlotBase, _check_plot_works)
 
 
-@tm.mplskip
+tm._skip_module_if_no_mpl()
+
+
 class TestSeriesPlots(TestPlotBase):
 
     def setup_method(self, method):
@@ -140,7 +142,6 @@ class TestSeriesPlots(TestPlotBase):
             self.ts.hist(ax=ax1, figure=fig2)
 
 
-@tm.mplskip
 class TestDataFramePlots(TestPlotBase):
 
     @slow
@@ -251,7 +252,6 @@ class TestDataFramePlots(TestPlotBase):
             tm.close()
 
 
-@tm.mplskip
 class TestDataFrameGroupByPlots(TestPlotBase):
 
     @slow

--- a/pandas/tests/plotting/test_hist_method.py
+++ b/pandas/tests/plotting/test_hist_method.py
@@ -18,8 +18,8 @@ from pandas.tests.plotting.common import (TestPlotBase, _check_plot_works)
 @tm.mplskip
 class TestSeriesPlots(TestPlotBase):
 
-    def setUp(self):
-        TestPlotBase.setUp(self)
+    def setup_method(self, method):
+        TestPlotBase.setup_method(self, method)
         import matplotlib as mpl
         mpl.rcdefaults()
 

--- a/pandas/tests/plotting/test_misc.py
+++ b/pandas/tests/plotting/test_misc.py
@@ -21,8 +21,8 @@ from pandas.tests.plotting.common import (TestPlotBase, _check_plot_works,
 @tm.mplskip
 class TestSeriesPlots(TestPlotBase):
 
-    def setUp(self):
-        TestPlotBase.setUp(self)
+    def setup_method(self, method):
+        TestPlotBase.setup_method(self, method)
         import matplotlib as mpl
         mpl.rcdefaults()
 

--- a/pandas/tests/plotting/test_misc.py
+++ b/pandas/tests/plotting/test_misc.py
@@ -17,8 +17,9 @@ import pandas.plotting as plotting
 from pandas.tests.plotting.common import (TestPlotBase, _check_plot_works,
                                           _ok_for_gaussian_kde)
 
+tm._skip_module_if_no_mpl()
 
-@tm.mplskip
+
 class TestSeriesPlots(TestPlotBase):
 
     def setup_method(self, method):
@@ -50,7 +51,6 @@ class TestSeriesPlots(TestPlotBase):
         _check_plot_works(bootstrap_plot, series=self.ts, size=10)
 
 
-@tm.mplskip
 class TestDataFramePlots(TestPlotBase):
 
     @slow

--- a/pandas/tests/plotting/test_series.py
+++ b/pandas/tests/plotting/test_series.py
@@ -22,8 +22,9 @@ from pandas.tests.plotting.common import (TestPlotBase, _check_plot_works,
                                           _skip_if_no_scipy_gaussian_kde,
                                           _ok_for_gaussian_kde)
 
+tm._skip_module_if_no_mpl()
 
-@tm.mplskip
+
 class TestSeriesPlots(TestPlotBase):
 
     def setup_method(self, method):

--- a/pandas/tests/plotting/test_series.py
+++ b/pandas/tests/plotting/test_series.py
@@ -26,8 +26,8 @@ from pandas.tests.plotting.common import (TestPlotBase, _check_plot_works,
 @tm.mplskip
 class TestSeriesPlots(TestPlotBase):
 
-    def setUp(self):
-        TestPlotBase.setUp(self)
+    def setup_method(self, method):
+        TestPlotBase.setup_method(self, method)
         import matplotlib as mpl
         mpl.rcdefaults()
 

--- a/pandas/tests/reshape/test_concat.py
+++ b/pandas/tests/reshape/test_concat.py
@@ -19,7 +19,7 @@ import pytest
 
 class ConcatenateBase(tm.TestCase):
 
-    def setUp(self):
+    def setup_method(self, method):
         self.frame = DataFrame(tm.getSeriesData())
         self.mixed_frame = self.frame.copy()
         self.mixed_frame['foo'] = 'bar'
@@ -31,7 +31,7 @@ class TestConcatAppendCommon(ConcatenateBase):
     Test common dtype coercion rules between concat and append.
     """
 
-    def setUp(self):
+    def setup_method(self, method):
 
         dt_data = [pd.Timestamp('2011-01-01'),
                    pd.Timestamp('2011-01-02'),

--- a/pandas/tests/reshape/test_hashing.py
+++ b/pandas/tests/reshape/test_hashing.py
@@ -11,7 +11,7 @@ import pandas.util.testing as tm
 
 class TestHashing(tm.TestCase):
 
-    def setUp(self):
+    def setup_method(self, method):
         self.df = DataFrame(
             {'i32': np.array([1, 2, 3] * 3, dtype='int32'),
              'f32': np.array([None, 2.5, 3.5] * 3, dtype='float32'),

--- a/pandas/tests/reshape/test_join.py
+++ b/pandas/tests/reshape/test_join.py
@@ -21,7 +21,7 @@ a_ = np.array
 
 class TestJoin(tm.TestCase):
 
-    def setUp(self):
+    def setup_method(self, method):
         # aggregate multiple columns
         self.df = DataFrame({'key1': get_test_data(),
                              'key2': get_test_data(),

--- a/pandas/tests/reshape/test_merge.py
+++ b/pandas/tests/reshape/test_merge.py
@@ -35,7 +35,7 @@ def get_test_data(ngroups=NGROUPS, n=N):
 
 class TestMerge(tm.TestCase):
 
-    def setUp(self):
+    def setup_method(self, method):
         # aggregate multiple columns
         self.df = DataFrame({'key1': get_test_data(),
                              'key2': get_test_data(),
@@ -739,7 +739,7 @@ def _check_merge(x, y):
 
 class TestMergeMulti(tm.TestCase):
 
-    def setUp(self):
+    def setup_method(self, method):
         self.index = MultiIndex(levels=[['foo', 'bar', 'baz', 'qux'],
                                         ['one', 'two', 'three']],
                                 labels=[[0, 0, 0, 1, 1, 2, 2, 3, 3, 3],

--- a/pandas/tests/reshape/test_merge_asof.py
+++ b/pandas/tests/reshape/test_merge_asof.py
@@ -23,7 +23,7 @@ class TestAsOfMerge(tm.TestCase):
         x.time = to_datetime(x.time)
         return x
 
-    def setUp(self):
+    def setup_method(self, method):
 
         self.trades = self.read_data('trades.csv')
         self.quotes = self.read_data('quotes.csv', dedupe=True)

--- a/pandas/tests/reshape/test_merge_ordered.py
+++ b/pandas/tests/reshape/test_merge_ordered.py
@@ -8,7 +8,7 @@ from numpy import nan
 
 class TestOrderedMerge(tm.TestCase):
 
-    def setUp(self):
+    def setup_method(self, method):
         self.left = DataFrame({'key': ['a', 'c', 'e'],
                                'lvalue': [1, 2., 3]})
 

--- a/pandas/tests/reshape/test_pivot.py
+++ b/pandas/tests/reshape/test_pivot.py
@@ -17,7 +17,7 @@ from pandas.tseries.util import pivot_annual, isleapyear
 
 class TestPivotTable(tm.TestCase):
 
-    def setUp(self):
+    def setup_method(self, method):
         self.data = DataFrame({'A': ['foo', 'foo', 'foo', 'foo',
                                      'bar', 'bar', 'bar', 'bar',
                                      'foo', 'foo', 'foo'],
@@ -984,7 +984,7 @@ class TestPivotTable(tm.TestCase):
 
 class TestCrosstab(tm.TestCase):
 
-    def setUp(self):
+    def setup_method(self, method):
         df = DataFrame({'A': ['foo', 'foo', 'foo', 'foo',
                               'bar', 'bar', 'bar', 'bar',
                               'foo', 'foo', 'foo'],

--- a/pandas/tests/reshape/test_reshape.py
+++ b/pandas/tests/reshape/test_reshape.py
@@ -19,7 +19,7 @@ from pandas.compat import range, u
 
 class TestMelt(tm.TestCase):
 
-    def setUp(self):
+    def setup_method(self, method):
         self.df = tm.makeTimeDataFrame()[:10]
         self.df['id1'] = (self.df['A'] > 0).astype(np.int64)
         self.df['id2'] = (self.df['B'] > 0).astype(np.int64)
@@ -220,7 +220,7 @@ class TestGetDummies(tm.TestCase):
 
     sparse = False
 
-    def setUp(self):
+    def setup_method(self, method):
         self.df = DataFrame({'A': ['a', 'b', 'a'],
                              'B': ['b', 'b', 'c'],
                              'C': [1, 2, 3]})

--- a/pandas/tests/scalar/test_interval.py
+++ b/pandas/tests/scalar/test_interval.py
@@ -6,7 +6,7 @@ import pandas.util.testing as tm
 
 
 class TestInterval(tm.TestCase):
-    def setUp(self):
+    def setup_method(self, method):
         self.interval = Interval(0, 1)
 
     def test_properties(self):

--- a/pandas/tests/scalar/test_period.py
+++ b/pandas/tests/scalar/test_period.py
@@ -923,7 +923,7 @@ class TestPeriodField(tm.TestCase):
 
 class TestComparisons(tm.TestCase):
 
-    def setUp(self):
+    def setup_method(self, method):
         self.january1 = Period('2000-01', 'M')
         self.january2 = Period('2000-01', 'M')
         self.february = Period('2000-02', 'M')

--- a/pandas/tests/scalar/test_timedelta.py
+++ b/pandas/tests/scalar/test_timedelta.py
@@ -15,7 +15,7 @@ from pandas._libs.tslib import iNaT, NaTType
 class TestTimedeltas(tm.TestCase):
     _multiprocess_can_split_ = True
 
-    def setUp(self):
+    def setup_method(self, method):
         pass
 
     def test_construction(self):

--- a/pandas/tests/scalar/test_timestamp.py
+++ b/pandas/tests/scalar/test_timestamp.py
@@ -1096,7 +1096,7 @@ class TestTimestamp(tm.TestCase):
 
 class TestTimestampNsOperations(tm.TestCase):
 
-    def setUp(self):
+    def setup_method(self, method):
         self.timestamp = Timestamp(datetime.utcnow())
 
     def assert_ns_timedelta(self, modified_timestamp, expected_value):

--- a/pandas/tests/series/test_indexing.py
+++ b/pandas/tests/series/test_indexing.py
@@ -2254,7 +2254,7 @@ class TestSeriesIndexing(TestData, tm.TestCase):
 
 class TestTimeSeriesDuplicates(tm.TestCase):
 
-    def setUp(self):
+    def setup_method(self, method):
         dates = [datetime(2000, 1, 2), datetime(2000, 1, 2),
                  datetime(2000, 1, 2), datetime(2000, 1, 3),
                  datetime(2000, 1, 3), datetime(2000, 1, 3),
@@ -2499,7 +2499,7 @@ class TestDatetimeIndexing(tm.TestCase):
     Also test support for datetime64[ns] in Series / DataFrame
     """
 
-    def setUp(self):
+    def setup_method(self, method):
         dti = DatetimeIndex(start=datetime(2005, 1, 1),
                             end=datetime(2005, 1, 10), freq='Min')
         self.series = Series(np.random.rand(len(dti)), dti)
@@ -2640,7 +2640,7 @@ class TestDatetimeIndexing(tm.TestCase):
 
 class TestNatIndexing(tm.TestCase):
 
-    def setUp(self):
+    def setup_method(self, method):
         self.series = Series(date_range('1/1/2000', periods=10))
 
     # ---------------------------------------------------------------------

--- a/pandas/tests/series/test_period.py
+++ b/pandas/tests/series/test_period.py
@@ -12,7 +12,7 @@ def _permute(obj):
 
 class TestSeriesPeriod(tm.TestCase):
 
-    def setUp(self):
+    def setup_method(self, method):
         self.series = Series(period_range('2000-01-01', periods=10, freq='D'))
 
     def test_auto_conversion(self):

--- a/pandas/tests/sparse/test_array.py
+++ b/pandas/tests/sparse/test_array.py
@@ -17,7 +17,7 @@ import pandas.util.testing as tm
 
 class TestSparseArray(tm.TestCase):
 
-    def setUp(self):
+    def setup_method(self, method):
         self.arr_data = np.array([nan, nan, 1, 2, 3, nan, 4, 5, nan, 6])
         self.arr = SparseArray(self.arr_data)
         self.zarr = SparseArray([0, 0, 1, 2, 3, 0, 4, 5, 0, 6], fill_value=0)

--- a/pandas/tests/sparse/test_combine_concat.py
+++ b/pandas/tests/sparse/test_combine_concat.py
@@ -124,7 +124,7 @@ class TestSparseSeriesConcat(tm.TestCase):
 
 class TestSparseDataFrameConcat(tm.TestCase):
 
-    def setUp(self):
+    def setup_method(self, method):
 
         self.dense1 = pd.DataFrame({'A': [0., 1., 2., np.nan],
                                     'B': [0., 0., 0., 0.],

--- a/pandas/tests/sparse/test_frame.py
+++ b/pandas/tests/sparse/test_frame.py
@@ -29,7 +29,7 @@ from pandas.tests.frame.test_api import SharedWithSparse
 class TestSparseDataFrame(tm.TestCase, SharedWithSparse):
     klass = SparseDataFrame
 
-    def setUp(self):
+    def setup_method(self, method):
         self.data = {'A': [nan, nan, nan, 0, 1, 2, 3, 4, 5, 6],
                      'B': [0, 1, 2, nan, nan, nan, 3, 4, 5, 6],
                      'C': np.arange(10, dtype=np.float64),
@@ -1275,7 +1275,7 @@ class TestSparseDataFrameArithmetic(tm.TestCase):
 
 
 class TestSparseDataFrameAnalytics(tm.TestCase):
-    def setUp(self):
+    def setup_method(self, method):
         self.data = {'A': [nan, nan, nan, 0, 1, 2, 3, 4, 5, 6],
                      'B': [0, 1, 2, nan, nan, nan, 3, 4, 5, 6],
                      'C': np.arange(10, dtype=float),

--- a/pandas/tests/sparse/test_groupby.py
+++ b/pandas/tests/sparse/test_groupby.py
@@ -6,7 +6,7 @@ import pandas.util.testing as tm
 
 class TestSparseGroupBy(tm.TestCase):
 
-    def setUp(self):
+    def setup_method(self, method):
         self.dense = pd.DataFrame({'A': ['foo', 'bar', 'foo', 'bar',
                                          'foo', 'bar', 'foo', 'foo'],
                                    'B': ['one', 'one', 'two', 'three',

--- a/pandas/tests/sparse/test_indexing.py
+++ b/pandas/tests/sparse/test_indexing.py
@@ -8,7 +8,7 @@ import pandas.util.testing as tm
 
 class TestSparseSeriesIndexing(tm.TestCase):
 
-    def setUp(self):
+    def setup_method(self, method):
         self.orig = pd.Series([1, np.nan, np.nan, 3, np.nan])
         self.sparse = self.orig.to_sparse()
 
@@ -446,7 +446,7 @@ class TestSparseSeriesIndexing(tm.TestCase):
 
 class TestSparseSeriesMultiIndexing(TestSparseSeriesIndexing):
 
-    def setUp(self):
+    def setup_method(self, method):
         # Mi with duplicated values
         idx = pd.MultiIndex.from_tuples([('A', 0), ('A', 1), ('B', 0),
                                          ('C', 0), ('C', 1)])
@@ -954,7 +954,7 @@ class TestSparseDataFrameIndexing(tm.TestCase):
 
 class TestMultitype(tm.TestCase):
 
-    def setUp(self):
+    def setup_method(self, method):
         self.cols = ['string', 'int', 'float', 'object']
 
         self.string_series = pd.SparseSeries(['a', 'b', 'c'])

--- a/pandas/tests/sparse/test_list.py
+++ b/pandas/tests/sparse/test_list.py
@@ -1,5 +1,4 @@
 from pandas.compat import range
-import unittest
 
 from numpy import nan
 import numpy as np
@@ -8,7 +7,7 @@ from pandas.core.sparse.api import SparseList, SparseArray
 import pandas.util.testing as tm
 
 
-class TestSparseList(unittest.TestCase):
+class TestSparseList(tm.TestCase):
 
     def setup_method(self, method):
         self.na_data = np.array([nan, nan, 1, 2, 3, nan, 4, 5, nan, 6])

--- a/pandas/tests/sparse/test_list.py
+++ b/pandas/tests/sparse/test_list.py
@@ -10,7 +10,7 @@ import pandas.util.testing as tm
 
 class TestSparseList(unittest.TestCase):
 
-    def setUp(self):
+    def setup_method(self, method):
         self.na_data = np.array([nan, nan, 1, 2, 3, nan, 4, 5, nan, 6])
         self.zero_data = np.array([0, 0, 1, 2, 3, 0, 4, 5, 0, 6])
 

--- a/pandas/tests/sparse/test_pivot.py
+++ b/pandas/tests/sparse/test_pivot.py
@@ -5,7 +5,7 @@ import pandas.util.testing as tm
 
 class TestPivotTable(tm.TestCase):
 
-    def setUp(self):
+    def setup_method(self, method):
         self.dense = pd.DataFrame({'A': ['foo', 'bar', 'foo', 'bar',
                                          'foo', 'bar', 'foo', 'foo'],
                                    'B': ['one', 'one', 'two', 'three',

--- a/pandas/tests/sparse/test_series.py
+++ b/pandas/tests/sparse/test_series.py
@@ -58,7 +58,7 @@ def _test_data2_zero():
 
 class TestSparseSeries(tm.TestCase, SharedWithSparse):
 
-    def setUp(self):
+    def setup_method(self, method):
         arr, index = _test_data1()
 
         date_index = bdate_range('1/1/2011', periods=len(index))
@@ -936,7 +936,7 @@ class TestSparseSeries(tm.TestCase, SharedWithSparse):
 
 class TestSparseHandlingMultiIndexes(tm.TestCase):
 
-    def setUp(self):
+    def setup_method(self, method):
         miindex = pd.MultiIndex.from_product(
             [["x", "y"], ["10", "20"]], names=['row-foo', 'row-bar'])
         micol = pd.MultiIndex.from_product(
@@ -963,7 +963,7 @@ class TestSparseHandlingMultiIndexes(tm.TestCase):
 class TestSparseSeriesScipyInteraction(tm.TestCase):
     # Issue 8048: add SparseSeries coo methods
 
-    def setUp(self):
+    def setup_method(self, method):
         tm._skip_if_no_scipy()
         import scipy.sparse
         # SparseSeries inputs used in tests, the tests rely on the order
@@ -1312,7 +1312,7 @@ def _dense_series_compare(s, f):
 
 class TestSparseSeriesAnalytics(tm.TestCase):
 
-    def setUp(self):
+    def setup_method(self, method):
         arr, index = _test_data1()
         self.bseries = SparseSeries(arr, index=index, kind='block',
                                     name='bseries')

--- a/pandas/tests/test_algos.py
+++ b/pandas/tests/test_algos.py
@@ -282,7 +282,7 @@ class TestFactorize(tm.TestCase):
         # gh 12666 - check no segfault
         # Test not valid numpy versions older than 1.11
         if pd._np_version_under1p11:
-            self.skipTest("Test valid only for numpy 1.11+")
+            pytest.skip("Test valid only for numpy 1.11+")
 
         x17 = np.array([complex(i) for i in range(17)], dtype=object)
 

--- a/pandas/tests/test_base.py
+++ b/pandas/tests/test_base.py
@@ -109,7 +109,7 @@ class TestPandasDelegate(tm.TestCase):
         def __init__(self, obj):
             self.obj = obj
 
-    def setUp(self):
+    def setup_method(self, method):
         pass
 
     def test_invalida_delgation(self):
@@ -162,7 +162,7 @@ class Ops(tm.TestCase):
             return False
         return True
 
-    def setUp(self):
+    def setup_method(self, method):
         self.bool_index = tm.makeBoolIndex(10, name='a')
         self.int_index = tm.makeIntIndex(10, name='a')
         self.float_index = tm.makeFloatIndex(10, name='a')
@@ -259,8 +259,8 @@ class Ops(tm.TestCase):
 
 class TestIndexOps(Ops):
 
-    def setUp(self):
-        super(TestIndexOps, self).setUp()
+    def setup_method(self, method):
+        super(TestIndexOps, self).setup_method(method)
         self.is_valid_objs = [o for o in self.objs if o._allow_index_ops]
         self.not_valid_objs = [o for o in self.objs if not o._allow_index_ops]
 

--- a/pandas/tests/test_categorical.py
+++ b/pandas/tests/test_categorical.py
@@ -30,7 +30,7 @@ from pandas.core.config import option_context
 
 class TestCategorical(tm.TestCase):
 
-    def setUp(self):
+    def setup_method(self, method):
         self.factor = Categorical(['a', 'b', 'b', 'a', 'a', 'c', 'c', 'c'],
                                   ordered=True)
 
@@ -1602,7 +1602,7 @@ Categories (3, object): [ああああ, いいいいい, ううううううう]""
 
 class TestCategoricalAsBlock(tm.TestCase):
 
-    def setUp(self):
+    def setup_method(self, method):
         self.factor = Categorical(['a', 'b', 'b', 'a', 'a', 'c', 'c', 'c'])
 
         df = DataFrame({'value': np.random.randint(0, 10000, 100)})

--- a/pandas/tests/test_config.py
+++ b/pandas/tests/test_config.py
@@ -1,12 +1,13 @@
 # -*- coding: utf-8 -*-
 import pytest
 
+import pandas.util.testing as tm
 import pandas as pd
-import unittest
+
 import warnings
 
 
-class TestConfig(unittest.TestCase):
+class TestConfig(tm.TestCase):
 
     def __init__(self, *args):
         super(TestConfig, self).__init__(*args)

--- a/pandas/tests/test_config.py
+++ b/pandas/tests/test_config.py
@@ -17,14 +17,14 @@ class TestConfig(unittest.TestCase):
         self.do = deepcopy(getattr(self.cf, '_deprecated_options'))
         self.ro = deepcopy(getattr(self.cf, '_registered_options'))
 
-    def setUp(self):
+    def setup_method(self, method):
         setattr(self.cf, '_global_config', {})
         setattr(
             self.cf, 'options', self.cf.DictWrapper(self.cf._global_config))
         setattr(self.cf, '_deprecated_options', {})
         setattr(self.cf, '_registered_options', {})
 
-    def tearDown(self):
+    def teardown_method(self, method):
         setattr(self.cf, '_global_config', self.gc)
         setattr(self.cf, '_deprecated_options', self.do)
         setattr(self.cf, '_registered_options', self.ro)

--- a/pandas/tests/test_expressions.py
+++ b/pandas/tests/test_expressions.py
@@ -58,7 +58,7 @@ with catch_warnings(record=True):
 @pytest.mark.skipif(not expr._USE_NUMEXPR, reason='not using numexpr')
 class TestExpressions(tm.TestCase):
 
-    def setUp(self):
+    def setup_method(self, method):
 
         self.frame = _frame.copy()
         self.frame2 = _frame2.copy()
@@ -67,7 +67,7 @@ class TestExpressions(tm.TestCase):
         self.integer = _integer.copy()
         self._MIN_ELEMENTS = expr._MIN_ELEMENTS
 
-    def tearDown(self):
+    def teardown_method(self, method):
         expr._MIN_ELEMENTS = self._MIN_ELEMENTS
 
     def run_arithmetic(self, df, other, assert_func, check_dtype=False,

--- a/pandas/tests/test_internals.py
+++ b/pandas/tests/test_internals.py
@@ -194,7 +194,7 @@ def create_mgr(descr, item_shape=None):
 
 class TestBlock(tm.TestCase):
 
-    def setUp(self):
+    def setup_method(self, method):
         # self.fblock = get_float_ex()  # a,c,e
         # self.cblock = get_complex_ex() #
         # self.oblock = get_obj_ex()

--- a/pandas/tests/test_multilevel.py
+++ b/pandas/tests/test_multilevel.py
@@ -22,7 +22,7 @@ import pandas._libs.index as _index
 
 class Base(object):
 
-    def setUp(self):
+    def setup_method(self, method):
 
         index = MultiIndex(levels=[['foo', 'bar', 'baz', 'qux'], ['one', 'two',
                                                                   'three']],

--- a/pandas/tests/test_nanops.py
+++ b/pandas/tests/test_nanops.py
@@ -18,7 +18,7 @@ use_bn = nanops._USE_BOTTLENECK
 
 class TestnanopsDataFrame(tm.TestCase):
 
-    def setUp(self):
+    def setup_method(self, method):
         np.random.seed(11235)
         nanops._USE_BOTTLENECK = False
 
@@ -118,7 +118,7 @@ class TestnanopsDataFrame(tm.TestCase):
         self.arr_float_nan_inf_1d = self.arr_float_nan_inf[:, 0, 0]
         self.arr_nan_nan_inf_1d = self.arr_nan_nan_inf[:, 0, 0]
 
-    def tearDown(self):
+    def teardown_method(self, method):
         nanops._USE_BOTTLENECK = use_bn
 
     def check_results(self, targ, res, axis, check_dtype=True):
@@ -786,7 +786,7 @@ class TestNanvarFixedValues(tm.TestCase):
 
     # xref GH10242
 
-    def setUp(self):
+    def setup_method(self, method):
         # Samples from a normal distribution.
         self.variance = variance = 3.0
         self.samples = self.prng.normal(scale=variance ** 0.5, size=100000)
@@ -899,7 +899,7 @@ class TestNanskewFixedValues(tm.TestCase):
 
     # xref GH 11974
 
-    def setUp(self):
+    def setup_method(self, method):
         # Test data + skewness value (computed with scipy.stats.skew)
         self.samples = np.sin(np.linspace(0, 1, 200))
         self.actual_skew = -0.1875895205961754
@@ -949,7 +949,7 @@ class TestNankurtFixedValues(tm.TestCase):
 
     # xref GH 11974
 
-    def setUp(self):
+    def setup_method(self, method):
         # Test data + kurtosis value (computed with scipy.stats.kurtosis)
         self.samples = np.sin(np.linspace(0, 1, 200))
         self.actual_kurt = -1.2058303433799713

--- a/pandas/tests/test_panel.py
+++ b/pandas/tests/test_panel.py
@@ -908,7 +908,7 @@ class TestPanel(tm.TestCase, PanelTests, CheckIndexing, SafeForLongAndSparse,
     def assert_panel_equal(cls, x, y):
         assert_panel_equal(x, y)
 
-    def setUp(self):
+    def setup_method(self, method):
         self.panel = make_test_panel()
         self.panel.major_axis.name = None
         self.panel.minor_axis.name = None
@@ -2435,7 +2435,7 @@ class TestLongPanel(tm.TestCase):
     LongPanel no longer exists, but...
     """
 
-    def setUp(self):
+    def setup_method(self, method):
         panel = make_test_panel()
         self.panel = panel.to_frame()
         self.unfiltered_panel = panel.to_frame(filter_observations=False)

--- a/pandas/tests/test_panel4d.py
+++ b/pandas/tests/test_panel4d.py
@@ -596,7 +596,7 @@ class CheckIndexing(object):
 class TestPanel4d(tm.TestCase, CheckIndexing, SafeForSparse,
                   SafeForLongAndSparse):
 
-    def setUp(self):
+    def setup_method(self, method):
         with catch_warnings(record=True):
             self.panel4d = tm.makePanel4D(nper=8)
             add_nans(self.panel4d)
@@ -685,7 +685,7 @@ class TestPanel4d(tm.TestCase, CheckIndexing, SafeForSparse,
             tm.assert_panel_equal(panel4d['A'], self.panel4d['l1'])
             tm.assert_frame_equal(panel4d.loc['B', 'ItemB', :, :],
                                   self.panel4d.loc['l2', ['ItemB'],
-                                  :, :]['ItemB'])
+                                                   :, :]['ItemB'])
 
     def test_constructor_dict_mixed(self):
         with catch_warnings(record=True):
@@ -798,7 +798,7 @@ class TestPanel4d(tm.TestCase, CheckIndexing, SafeForSparse,
                                      method='pad')
 
             tm.assert_panel_equal(larger.loc[:, :,
-                                  self.panel4d.major_axis[1], :],
+                                             self.panel4d.major_axis[1], :],
                                   smaller.loc[:, :, smaller_major[0], :])
 
             # don't necessarily copy

--- a/pandas/tests/test_panelnd.py
+++ b/pandas/tests/test_panelnd.py
@@ -11,7 +11,7 @@ import pandas.util.testing as tm
 
 class TestPanelnd(tm.TestCase):
 
-    def setUp(self):
+    def setup_method(self, method):
         pass
 
     def test_4d_construction(self):

--- a/pandas/tests/test_resample.py
+++ b/pandas/tests/test_resample.py
@@ -52,7 +52,7 @@ def _simple_pts(start, end, freq='D'):
 
 class TestResampleAPI(tm.TestCase):
 
-    def setUp(self):
+    def setup_method(self, method):
         dti = DatetimeIndex(start=datetime(2005, 1, 1),
                             end=datetime(2005, 1, 10), freq='Min')
 
@@ -850,7 +850,7 @@ class Base(object):
 class TestDatetimeIndex(Base, tm.TestCase):
     _index_factory = lambda x: date_range
 
-    def setUp(self):
+    def setup_method(self, method):
         dti = DatetimeIndex(start=datetime(2005, 1, 1),
                             end=datetime(2005, 1, 10), freq='Min')
 
@@ -2796,7 +2796,7 @@ class TestTimedeltaIndex(Base, tm.TestCase):
 
 class TestResamplerGrouper(tm.TestCase):
 
-    def setUp(self):
+    def setup_method(self, method):
         self.frame = DataFrame({'A': [1] * 20 + [2] * 12 + [3] * 8,
                                 'B': np.arange(40)},
                                index=date_range('1/1/2000',
@@ -2991,7 +2991,7 @@ class TestResamplerGrouper(tm.TestCase):
 
 class TestTimeGrouper(tm.TestCase):
 
-    def setUp(self):
+    def setup_method(self, method):
         self.ts = Series(np.random.randn(1000),
                          index=date_range('1/1/2000', periods=1000))
 

--- a/pandas/tests/test_testing.py
+++ b/pandas/tests/test_testing.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 import pandas as pd
-import unittest
 import pytest
 import numpy as np
 import sys
@@ -340,7 +339,7 @@ Iterable values are different \\(50\\.0 %\\)
             assert_almost_equal([1, 2], [1, 3])
 
 
-class TestAssertIndexEqual(unittest.TestCase):
+class TestAssertIndexEqual(tm.TestCase):
 
     def test_index_equal_message(self):
 
@@ -680,7 +679,7 @@ DataFrame\\.iloc\\[:, 1\\] values are different \\(33\\.33333 %\\)
                                by_blocks=True)
 
 
-class TestAssertCategoricalEqual(unittest.TestCase):
+class TestAssertCategoricalEqual(tm.TestCase):
 
     def test_categorical_equal_message(self):
 
@@ -718,7 +717,7 @@ Attribute "ordered" are different
             tm.assert_categorical_equal(a, b)
 
 
-class TestRNGContext(unittest.TestCase):
+class TestRNGContext(tm.TestCase):
 
     def test_RNGContext(self):
         expected0 = 1.764052345967664

--- a/pandas/tests/test_util.py
+++ b/pandas/tests/test_util.py
@@ -22,7 +22,7 @@ LOCALE_OVERRIDE = os.environ.get('LOCALE_OVERRIDE', None)
 
 class TestDecorators(tm.TestCase):
 
-    def setUp(self):
+    def setup_method(self, method):
         @deprecate_kwarg('old', 'new')
         def _f1(new=False):
             return new
@@ -410,8 +410,8 @@ def test_numpy_errstate_is_default():
 class TestLocaleUtils(tm.TestCase):
 
     @classmethod
-    def setUpClass(cls):
-        super(TestLocaleUtils, cls).setUpClass()
+    def setup_class(cls):
+        super(TestLocaleUtils, cls).setup_class()
         cls.locales = tm.get_locales()
 
         if not cls.locales:
@@ -420,8 +420,8 @@ class TestLocaleUtils(tm.TestCase):
         tm._skip_if_windows()
 
     @classmethod
-    def tearDownClass(cls):
-        super(TestLocaleUtils, cls).tearDownClass()
+    def teardown_class(cls):
+        super(TestLocaleUtils, cls).teardown_class()
         del cls.locales
 
     def test_get_locales(self):

--- a/pandas/tests/test_window.py
+++ b/pandas/tests/test_window.py
@@ -48,7 +48,7 @@ class Base(tm.TestCase):
 
 class TestApi(Base):
 
-    def setUp(self):
+    def setup_method(self, method):
         self._create_data()
 
     def test_getitem(self):
@@ -315,7 +315,7 @@ class TestApi(Base):
 
 class TestWindow(Base):
 
-    def setUp(self):
+    def setup_method(self, method):
         self._create_data()
 
     def test_constructor(self):
@@ -360,7 +360,7 @@ class TestWindow(Base):
 
 class TestRolling(Base):
 
-    def setUp(self):
+    def setup_method(self, method):
         self._create_data()
 
     def test_doc_string(self):
@@ -444,7 +444,7 @@ class TestRolling(Base):
 
 class TestExpanding(Base):
 
-    def setUp(self):
+    def setup_method(self, method):
         self._create_data()
 
     def test_doc_string(self):
@@ -486,7 +486,7 @@ class TestExpanding(Base):
 
 class TestEWM(Base):
 
-    def setUp(self):
+    def setup_method(self, method):
         self._create_data()
 
     def test_doc_string(self):
@@ -549,7 +549,7 @@ class TestEWM(Base):
 class TestDeprecations(Base):
     """ test that we are catching deprecation warnings """
 
-    def setUp(self):
+    def setup_method(self, method):
         self._create_data()
 
     def test_deprecations(self):
@@ -775,7 +775,7 @@ class TestDtype_datetime64UTC(DatetimeLike):
 
 class TestMoments(Base):
 
-    def setUp(self):
+    def setup_method(self, method):
         self._create_data()
 
     def test_centered_axis_validation(self):
@@ -1958,7 +1958,7 @@ class TestMomentsConsistency(Base):
         super(TestMomentsConsistency, self)._create_data()
         self.data = _consistency_data
 
-    def setUp(self):
+    def setup_method(self, method):
         self._create_data()
 
     def _test_moments_consistency(self, min_periods, count, mean, mock_mean,
@@ -3039,7 +3039,7 @@ class TestMomentsConsistency(Base):
 
 class TestGrouperGrouping(tm.TestCase):
 
-    def setUp(self):
+    def setup_method(self, method):
         self.series = Series(np.arange(10))
         self.frame = DataFrame({'A': [1] * 20 + [2] * 12 + [3] * 8,
                                 'B': np.arange(40)})
@@ -3187,7 +3187,7 @@ class TestRollingTS(tm.TestCase):
     # rolling time-series friendly
     # xref GH13327
 
-    def setUp(self):
+    def setup_method(self, method):
 
         self.regular = DataFrame({'A': pd.date_range('20130101',
                                                      periods=5,

--- a/pandas/tests/test_window.py
+++ b/pandas/tests/test_window.py
@@ -559,11 +559,11 @@ class TestDeprecations(Base):
             mom.rolling_mean(Series(np.ones(10)), 3, center=True, axis=0)
 
 
-# GH #12373 : rolling functions error on float32 data
+# gh-12373 : rolling functions error on float32 data
 # make sure rolling functions works for different dtypes
 #
 # NOTE that these are yielded tests and so _create_data is
-# explicity called, nor do these inherit from unittest.TestCase
+# explicity called, nor do these inherit from tm.TestCase
 #
 # further note that we are only checking rolling for fully dtype
 # compliance (though both expanding and ewm inherit)

--- a/pandas/tests/tseries/test_holiday.py
+++ b/pandas/tests/tseries/test_holiday.py
@@ -21,7 +21,7 @@ from pytz import utc
 
 class TestCalendar(tm.TestCase):
 
-    def setUp(self):
+    def setup_method(self, method):
         self.holiday_list = [
             datetime(2012, 1, 2),
             datetime(2012, 1, 16),
@@ -87,7 +87,7 @@ class TestCalendar(tm.TestCase):
 
 class TestHoliday(tm.TestCase):
 
-    def setUp(self):
+    def setup_method(self, method):
         self.start_date = datetime(2011, 1, 1)
         self.end_date = datetime(2020, 12, 31)
 
@@ -286,7 +286,7 @@ class TestHoliday(tm.TestCase):
 
 class TestObservanceRules(tm.TestCase):
 
-    def setUp(self):
+    def setup_method(self, method):
         self.we = datetime(2014, 4, 9)
         self.th = datetime(2014, 4, 10)
         self.fr = datetime(2014, 4, 11)

--- a/pandas/tests/tseries/test_offsets.py
+++ b/pandas/tests/tseries/test_offsets.py
@@ -167,7 +167,7 @@ class Base(tm.TestCase):
 
 class TestCommon(Base):
 
-    def setUp(self):
+    def setup_method(self, method):
         # exected value created by Base._get_offset
         # are applied to 2011/01/01 09:00 (Saturday)
         # used for .apply and .rollforward
@@ -507,7 +507,7 @@ class TestCommon(Base):
 
 class TestDateOffset(Base):
 
-    def setUp(self):
+    def setup_method(self, method):
         self.d = Timestamp(datetime(2008, 1, 2))
         _offset_map.clear()
 
@@ -547,7 +547,7 @@ class TestDateOffset(Base):
 class TestBusinessDay(Base):
     _offset = BDay
 
-    def setUp(self):
+    def setup_method(self, method):
         self.d = datetime(2008, 1, 1)
 
         self.offset = BDay()
@@ -724,7 +724,7 @@ class TestBusinessDay(Base):
 class TestBusinessHour(Base):
     _offset = BusinessHour
 
-    def setUp(self):
+    def setup_method(self, method):
         self.d = datetime(2014, 7, 1, 10, 00)
 
         self.offset1 = BusinessHour()
@@ -1418,7 +1418,7 @@ class TestBusinessHour(Base):
 class TestCustomBusinessHour(Base):
     _offset = CustomBusinessHour
 
-    def setUp(self):
+    def setup_method(self, method):
         # 2014 Calendar to check custom holidays
         #   Sun Mon Tue Wed Thu Fri Sat
         #  6/22  23  24  25  26  27  28
@@ -1674,7 +1674,7 @@ class TestCustomBusinessHour(Base):
 class TestCustomBusinessDay(Base):
     _offset = CDay
 
-    def setUp(self):
+    def setup_method(self, method):
         self.d = datetime(2008, 1, 1)
         self.nd = np_datetime64_compat('2008-01-01 00:00:00Z')
 
@@ -1910,7 +1910,7 @@ class TestCustomBusinessDay(Base):
 
 class CustomBusinessMonthBase(object):
 
-    def setUp(self):
+    def setup_method(self, method):
         self.d = datetime(2008, 1, 1)
 
         self.offset = self._object()
@@ -4612,7 +4612,7 @@ def test_quarterly_dont_normalize():
 
 class TestOffsetAliases(tm.TestCase):
 
-    def setUp(self):
+    def setup_method(self, method):
         _offset_map.clear()
 
     def test_alias_equality(self):
@@ -4696,7 +4696,7 @@ class TestCaching(tm.TestCase):
     # as of GH 6479 (in 0.14.0), offset caching is turned off
     # as of v0.12.0 only BusinessMonth/Quarter were actually caching
 
-    def setUp(self):
+    def setup_method(self, method):
         _daterange_cache.clear()
         _offset_map.clear()
 

--- a/pandas/tests/tseries/test_timezones.py
+++ b/pandas/tests/tseries/test_timezones.py
@@ -52,7 +52,7 @@ fixed_off_no_name = FixedOffset(-330, None)
 
 class TestTimeZoneSupportPytz(tm.TestCase):
 
-    def setUp(self):
+    def setup_method(self, method):
         tm._skip_if_no_pytz()
 
     def tz(self, tz):
@@ -944,7 +944,7 @@ class TestTimeZoneSupportPytz(tm.TestCase):
 
 class TestTimeZoneSupportDateutil(TestTimeZoneSupportPytz):
 
-    def setUp(self):
+    def setup_method(self, method):
         tm._skip_if_no_dateutil()
 
     def tz(self, tz):
@@ -1197,7 +1197,7 @@ class TestTimeZoneCacheKey(tm.TestCase):
 class TestTimeZones(tm.TestCase):
     timezones = ['UTC', 'Asia/Tokyo', 'US/Eastern', 'dateutil/US/Pacific']
 
-    def setUp(self):
+    def setup_method(self, method):
         tm._skip_if_no_pytz()
 
     def test_replace(self):

--- a/pandas/util/testing.py
+++ b/pandas/util/testing.py
@@ -10,7 +10,6 @@ import inspect
 import os
 import subprocess
 import locale
-import unittest
 import traceback
 
 from datetime import datetime
@@ -86,22 +85,17 @@ def reset_testing_mode():
 set_testing_mode()
 
 
-class TestCase(unittest.TestCase):
+class TestCase(object):
     """
-    The test case class that we originally used when using the
-    nosetests framework. Under the new pytest framework, we are
-    moving away from this class.
-
-    Do not create new test classes derived from this one. Rather,
-    they should inherit from object directly.
+    Base class for all test case classes.
     """
 
     @classmethod
-    def setUpClass(cls):
+    def setup_class(cls):
         pd.set_option('chained_assignment', 'raise')
 
     @classmethod
-    def tearDownClass(cls):
+    def teardown_class(cls):
         pass
 
 
@@ -299,7 +293,7 @@ def mplskip(cls):
     """Skip a TestCase instance if matplotlib isn't installed"""
 
     @classmethod
-    def setUpClass(cls):
+    def setup_class(cls):
         try:
             import matplotlib as mpl
             mpl.use("Agg", warn=False)
@@ -307,7 +301,7 @@ def mplskip(cls):
             import pytest
             pytest.skip("matplotlib not installed")
 
-    cls.setUpClass = setUpClass
+    cls.setup_class = setup_class
     return cls
 
 

--- a/pandas/util/testing.py
+++ b/pandas/util/testing.py
@@ -289,36 +289,31 @@ def _skip_if_32bit():
         pytest.skip("skipping for 32 bit")
 
 
-def mplskip(cls):
-    """Skip a TestCase instance if matplotlib isn't installed"""
+def _skip_module_if_no_mpl():
+    import pytest
 
-    @classmethod
-    def setup_class(cls):
-        try:
-            import matplotlib as mpl
-            mpl.use("Agg", warn=False)
-        except ImportError:
-            import pytest
-            pytest.skip("matplotlib not installed")
-
-    cls.setup_class = setup_class
-    return cls
+    mpl = pytest.importorskip("matplotlib")
+    mpl.use("Agg", warn=False)
 
 
 def _skip_if_no_mpl():
     try:
-        import matplotlib  # noqa
+        import matplotlib as mpl
+        mpl.use("Agg", warn=False)
     except ImportError:
         import pytest
         pytest.skip("matplotlib not installed")
 
 
 def _skip_if_mpl_1_5():
-    import matplotlib
-    v = matplotlib.__version__
+    import matplotlib as mpl
+
+    v = mpl.__version__
     if v > LooseVersion('1.4.3') or v[0] == '0':
         import pytest
         pytest.skip("matplotlib 1.5")
+    else:
+        mpl.use("Agg", warn=False)
 
 
 def _skip_if_no_scipy():


### PR DESCRIPTION
* Convert all test setup/teardown to `pytest` idiom
* Remove any classes that inherit from `unittest.TestCase`
* Update documentation that we are still using `tm.TestCase`

Closes #15990.

`pytest` idiom for test setup/teardown can be found <a href="https://docs.pytest.org/en/2.7.3/xunit_setup.html">here</a>.