### PR TITLE
DEPR: correct deprecation message for datetools

### DIFF
--- a/pandas/util/depr_module.py
+++ b/pandas/util/depr_module.py
@@ -83,8 +83,7 @@ class _DeprecatedModule(object):
                     FutureWarning, stacklevel=2)
             else:
                 if deprmodto is None:
-                    deprmodto = "{modname}.{name}".format(
-                        modname=obj.__module__, name=name)
+                    deprmodto = obj.__module__
                 # The object is actually located in another module.
                 warnings.warn(
                     "{deprmod}.{name} is deprecated. Please use "


### PR DESCRIPTION
Small error in the datetools depr message I just noticed:

Before ("Day.Day"):

```
In [33]: from pandas import datetools

In [34]: datetools.Day(1)
/home/joris/miniconda3/envs/dev/bin/ipython:1: FutureWarning: pandas.core.datetools.Day is deprecated. Please use pandas.tseries.offsets.Day.Day instead.
  #!/home/joris/miniconda3/envs/dev/bin/python
Out[34]: <Day>
```

After:

```
In [2]: datetools.Day(1)
/home/joris/miniconda3/envs/dev/bin/ipython:1: FutureWarning: pandas.core.datetools.Day is deprecated. Please use pandas.tseries.offsets.Day instead.
  #!/home/joris/miniconda3/envs/dev/bin/python
Out[2]: <Day>
```