### PR TITLE
API Change repr name for table schema

### DIFF
--- a/pandas/core/config_init.py
+++ b/pandas/core/config_init.py
@@ -9,7 +9,6 @@ If you need to make sure options are available even before a certain
 module is imported, register them here rather then in the module.
 
 """
-import sys
 import warnings
 
 import pandas.core.config as cf

--- a/pandas/core/config_init.py
+++ b/pandas/core/config_init.py
@@ -362,7 +362,7 @@ def table_schema_cb(key):
             from IPython.core.formatters import BaseFormatter
 
             class TableSchemaFormatter(BaseFormatter):
-                print_method = '_repr_table_schema_'
+                print_method = '_repr_data_resource_'
                 _return_type = (dict,)
             # register it:
             formatters[mimetype] = TableSchemaFormatter()

--- a/pandas/core/config_init.py
+++ b/pandas/core/config_init.py
@@ -342,36 +342,8 @@ def mpl_style_cb(key):
 
 
 def table_schema_cb(key):
-    # first, check if we are in IPython
-    if 'IPython' not in sys.modules:
-        # definitely not in IPython
-        return
-    from IPython import get_ipython
-    ip = get_ipython()
-    if ip is None:
-        # still not in IPython
-        return
-
-    formatters = ip.display_formatter.formatters
-
-    mimetype = "application/vnd.dataresource+json"
-
-    if cf.get_option(key):
-        if mimetype not in formatters:
-            # define tableschema formatter
-            from IPython.core.formatters import BaseFormatter
-
-            class TableSchemaFormatter(BaseFormatter):
-                print_method = '_repr_data_resource_'
-                _return_type = (dict,)
-            # register it:
-            formatters[mimetype] = TableSchemaFormatter()
-        # enable it if it's been disabled:
-        formatters[mimetype].enabled = True
-    else:
-        # unregister tableschema mime-type
-        if mimetype in formatters:
-            formatters[mimetype].enabled = False
+    from pandas.io.formats.printing import _enable_data_resource_formatter
+    _enable_data_resource_formatter(cf.get_option(key))
 
 
 with cf.config_prefix('display'):

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -129,7 +129,7 @@ class NDFrame(PandasObject, SelectionMixin):
         object.__setattr__(self, '_data', data)
         object.__setattr__(self, '_item_cache', {})
 
-    def _repr_table_schema_(self):
+    def _repr_data_resource_(self):
         """
         Not a real Jupyter special repr method, but we use the same
         naming convention.

--- a/pandas/tests/io/formats/test_printing.py
+++ b/pandas/tests/io/formats/test_printing.py
@@ -180,14 +180,14 @@ class TestTableSchemaRepr(tm.TestCase):
     def test_config_on(self):
         df = pd.DataFrame({"A": [1, 2]})
         with pd.option_context("display.html.table_schema", True):
-            result = df._repr_table_schema_()
+            result = df._repr_data_resource_()
 
         assert result is not None
 
     def test_config_default_off(self):
         df = pd.DataFrame({"A": [1, 2]})
         with pd.option_context("display.html.table_schema", False):
-            result = df._repr_table_schema_()
+            result = df._repr_data_resource_()
 
         assert result is None
 

--- a/pandas/tests/io/formats/test_printing.py
+++ b/pandas/tests/io/formats/test_printing.py
@@ -191,12 +191,8 @@ class TestTableSchemaRepr(tm.TestCase):
 
         assert result is None
 
-    def test_config_monkeypatches(self):
+    def test_enable_data_resource_formatter(self):
         # GH 10491
-        df = pd.DataFrame({"A": [1, 2]})
-        assert not hasattr(df, '_ipython_display_')
-        assert not hasattr(df['A'], '_ipython_display_')
-
         formatters = self.display_formatter.formatters
         mimetype = 'application/vnd.dataresource+json'
 


### PR DESCRIPTION
Not API breaking, since pandas 0.20.0 hasn't been released yet.
`_repr_table_schema_` isn't the right name, since we include both the schema and the data.

xref https://github.com/pandas-dev/pandas/pull/16198#discussion_r114342141

@rgbkrk do you need any kind of backwards compatibility with `_repr_table_schema_`?