### PR TITLE
ENH: Make RangeIndex.append() return RangeIndex when possible

### DIFF
--- a/doc/source/whatsnew/v0.21.0.txt
+++ b/doc/source/whatsnew/v0.21.0.txt
@@ -26,6 +26,7 @@ New features
 
 Other Enhancements
 ^^^^^^^^^^^^^^^^^^
+- ``RangeIndex.append`` now returns a ``RangeIndex`` object when possible (:issue:`16212`)
 
 
 

--- a/pandas/tests/indexes/test_range.py
+++ b/pandas/tests/indexes/test_range.py
@@ -941,3 +941,39 @@ class TestRangeIndex(Numeric, tm.TestCase):
         for klass in klasses:
             result = i.where(klass(cond))
             tm.assert_index_equal(result, expected)
+
+    def test_append(self):
+        # GH16212
+        RI = RangeIndex
+        I64 = Int64Index
+        F64 = Float64Index
+        OI = Index
+        cases = [([RI(1, 12, 5)], RI(1, 12, 5)),
+                 ([RI(0, 6, 4)], RI(0, 6, 4)),
+                 ([RI(1, 3), RI(3, 7)], RI(1, 7)),
+                 ([RI(1, 5, 2), RI(5, 6)], RI(1, 6, 2)),
+                 ([RI(1, 3, 2), RI(4, 7, 3)], RI(1, 7, 3)),
+                 ([RI(-4, 3, 2), RI(4, 7, 2)], RI(-4, 7, 2)),
+                 ([RI(-4, -8), RI(-8, -12)], RI(-8, -12)),
+                 ([RI(-4, -8), RI(3, -4)], RI(3, -8)),
+                 ([RI(-4, -8), RI(3, 5)], RI(3, 5)),
+                 ([RI(-4, -2), RI(3, 5)], I64([-4, -3, 3, 4])),
+                 ([RI(-2,), RI(3, 5)], RI(3, 5)),
+                 ([RI(2,), RI(2)], I64([0, 1, 0, 1])),
+                 ([RI(2,), RI(2, 5), RI(5, 8, 4)], RI(0, 6)),
+                 ([RI(2,), RI(3, 5), RI(5, 8, 4)], I64([0, 1, 3, 4, 5])),
+                 ([RI(-2, 2), RI(2, 5), RI(5, 8, 4)], RI(-2, 6)),
+                 ([RI(3,), I64([-1, 3, 15])], I64([0, 1, 2, -1, 3, 15])),
+                 ([RI(3,), F64([-1, 3.1, 15.])], F64([0, 1, 2, -1, 3.1, 15.])),
+                 ([RI(3,), OI(['a', None, 14])], OI([0, 1, 2, 'a', None, 14])),
+                 ([RI(3, 1), OI(['a', None, 14])], OI(['a', None, 14]))
+                 ]
+
+        for indices, expected in cases:
+            result = indices[0].append(indices[1:])
+            tm.assert_index_equal(result, expected, exact=True)
+
+            if len(indices) == 2:
+                # Append single item rather than list
+                result2 = indices[0].append(indices[1])
+                tm.assert_index_equal(result2, expected, exact=True)


### PR DESCRIPTION
 - [x] closes #16212
 - [x] tests added / passed
 - [x] passes ``git diff master --name-only -- '*.py' | flake8 --diff``
 - [x] whatsnew entry

This is analogous to what is already done for ``RangeIndex.union()``, but there doesn't seem to be much scope for code reuse (what could be, in principle, reused in ``.append`` of all ``Index`` subclasses is the initial casting to list/name handling, I could do in a separate PR).