### PR TITLE
ENH Adding categorical parallel_coordinates implementation

### DIFF
--- a/pandas/plotting/__init__.py
+++ b/pandas/plotting/__init__.py
@@ -12,8 +12,8 @@ except ImportError:
 
 from pandas.plotting._misc import (scatter_matrix, radviz,
                                    andrews_curves, bootstrap_plot,
-                                   parallel_coordinates, lag_plot,
-                                   autocorrelation_plot)
+                                   parallel_coordinates, parallel_sets,
+                                   lag_plot, autocorrelation_plot)
 from pandas.plotting._core import boxplot
 from pandas.plotting._style import plot_params
 from pandas.plotting._tools import table

--- a/pandas/plotting/_misc.py
+++ b/pandas/plotting/_misc.py
@@ -648,7 +648,7 @@ class _ParSets(object):
         from matplotlib.ticker import MaxNLocator
         for n, ax in enumerate(axes):
             ax.set_xticks([0])
-            ax.set_xticklabels(df_to_use.columns[n])
+            ax.set_xticklabels([df_to_use.columns[n]])
             ax.yaxis.set_major_locator(MaxNLocator(integer=True))
 
         for cat_index in range(len(column_cats_list)):

--- a/pandas/plotting/_misc.py
+++ b/pandas/plotting/_misc.py
@@ -499,6 +499,160 @@ def parallel_coordinates(frame, class_column, cols=None, ax=None, color=None,
     ax.grid()
     return ax
 
+def parallel_sets(frame, class_column, color=None, colormap=None, **kwds):
+    """Parallel sets plotting.
+
+    Parameters
+    ----------
+    frame: DataFrame
+    class_column: str
+        Column name containing class names
+    color: list or tuple, optional
+        Colors to use for the different classes
+    colormap: str or matplotlib colormap, default None
+        Colormap to use for line colors.
+    kwds: keywords
+        Options to pass to matplotlib plotting method
+
+    Returns
+    -------
+    ax: matplotlib axis object
+
+    Examples
+    --------
+    >>> from pandas import read_csv
+    >>> from pandas.tools.plotting import parallel_sets
+    >>> from matplotlib import pyplot as plt
+    >>> df = read_csv('https://raw.github.com/pandas-dev/pandas/master'
+                      '/pandas/tests/data/iris.csv')
+    >>> parallel_sets(df, 'Name', color=('#556270',
+                             '#4ECDC4', '#C7F464'))
+    >>> plt.show()
+    """
+    import matplotlib.pyplot as plt
+
+    classes = frame[class_column].drop_duplicates()
+
+    parsets = _ParSets(color, colormap)
+    return parsets.par_sets(frame, class_column)
+
+class _ParSets():
+  def __init__(self, color=None, colormap=None):
+    """
+    Objects needed for test
+    """
+    self._reverse_column_cats_map = {}
+    self._color = color
+    self._colormap = colormap
+
+  def par_sets(self, df, class_column):
+    import matplotlib.pyplot as plt
+    data = df.values
+
+    classes = df[class_column].drop_duplicates()
+    colour_map = self._get_colours_for_par_sets(classes)
+
+    df_to_use = df.drop(class_column, axis=1)
+    class_column_values = df[class_column]
+    data = df_to_use.values
+
+    value_to_string_maps, column_cats_list = \
+        self._map_data_points_to_strs_for_par_sets(df_to_use)
+
+    fig, axes = plt.subplots(ncols=len(df_to_use.columns), figsize=(10,5))
+
+    self._set_axes_limits_with_column_cardinality(axes, column_cats_list)
+
+    self._connect_axes_pairs_with_polyline_segments(axes, data, value_to_string_maps,
+                                                    class_column_values, colour_map)
+
+    self._set_appropriate_label_values_to_axes(axes, df_to_use, column_cats_list)
+
+    fig.subplots_adjust(wspace=0)
+
+    self._remove_spines_for_last_axis_to_match_parallel_sets_plot(axes[-1])
+
+    return axes
+
+  def _connect_polyline(self, left_ax_index, left_ax, right_ax_index, right_ax,
+                        left_data_y, right_data_y, **line_kwds):
+    """ Adapted from https://gist.github.com/phobson/9de120cabde660ec734c
+    The params left_ax_index and right_ax_index are not directly used in
+    this method but are need for testing via a proxy class
+    """
+    import mpl_toolkits.axes_grid1.inset_locator as inset
+    import matplotlib.transforms as mtrans
+
+    to_left_ax_transformer = left_ax.transScale + left_ax.transLimits
+    left_ax_y = to_left_ax_transformer.transform((0, left_data_y))[1]
+
+    to_right_ax_transformer = right_ax.transScale + right_ax.transLimits
+    right_ax_y = to_right_ax_transformer.transform((0, right_data_y))[1]
+
+    left_data_to_ax_transformer = \
+        mtrans.blended_transform_factory(left_ax.transData, left_ax.transAxes)
+    right_data_to_ax_transformer = \
+        mtrans.blended_transform_factory(right_ax.transData, right_ax.transAxes)
+
+    bbox = mtrans.Bbox.from_extents(0, left_ax_y, 0, right_ax_y)
+    left_bbox = mtrans.TransformedBbox(bbox, left_data_to_ax_transformer)
+    right_bbox = mtrans.TransformedBbox(bbox, right_data_to_ax_transformer)
+
+    left_bbox_corner, right_bbox_corner = 3, 2
+    bbox_connecter_line = inset.BboxConnector(left_bbox, right_bbox, loc1=left_bbox_corner,
+        loc2=right_bbox_corner, **line_kwds)
+    bbox_connecter_line.set_clip_on(False)
+
+    return bbox_connecter_line
+
+  def _set_axes_limits_with_column_cardinality(self, axes, column_cats_list):
+    for ind, column_cats in enumerate(column_cats_list):
+      axes[ind].set_ylim(0, len(column_cats)-1)
+
+  def _connect_axes_pairs_with_polyline_segments(self, axes, data, value_to_string_maps,
+                                                 class_column_values, colour_map):
+    for n, (ax1, ax2) in enumerate(zip(axes[:-1], axes[1:])):
+        for ind, row in enumerate(data):
+            polyline_segment = self._connect_polyline(n, ax1, n+1, ax2,
+                value_to_string_maps[(n, row[n])], value_to_string_maps[(n+1, row[n+1])],
+                color=colour_map[class_column_values[ind]])
+            ax1.add_line(polyline_segment)
+
+  def _set_appropriate_label_values_to_axes(self, axes, df_to_use, column_cats_list):
+    from matplotlib.ticker import MaxNLocator
+    for n, ax in enumerate(axes):
+        ax.set_xticks([0])
+        ax.set_xticklabels(df_to_use.columns[n])
+        ax.yaxis.set_major_locator(MaxNLocator(integer=True))
+
+    for cat_index in range(len(column_cats_list)):
+      axes[cat_index].set_yticklabels(column_cats_list[cat_index])
+
+  def _remove_spines_for_last_axis_to_match_parallel_sets_plot(self, last_axes):
+    spine_keys = ['right', 'bottom', 'top']
+    for spine_key in spine_keys:
+      last_axes.spines[spine_key].set_visible(False)
+
+  def _get_colours_for_par_sets(self, classes):
+    colours = sorted(_get_standard_colors(num_colors=len(classes), color=self._color,
+                                          colormap=self._colormap))
+    return dict(zip(classes, colours))
+
+  def _map_data_points_to_strs_for_par_sets(self, df):
+    maps = {}
+    column_cats_list = []
+    reverse_column_cats_map = {}
+
+    for column_index, column in enumerate(df.columns):
+      column_cats = df[column].unique()
+      column_cats_list.append(column_cats)
+      for value_map, cat in enumerate(column_cats):
+        maps[(column_index, cat)] = value_map
+        reverse_column_cats_map[(column_index, value_map)] = cat
+
+    self._reverse_column_cats_map = reverse_column_cats_map
+
+    return maps, column_cats_list
 
 def lag_plot(series, lag=1, ax=None, **kwds):
     """Lag plot for time series.

--- a/pandas/plotting/_misc.py
+++ b/pandas/plotting/_misc.py
@@ -564,7 +564,12 @@ class _ParSets(object):
         classes = df[class_column].drop_duplicates()
         colour_map = self._get_colours_for_par_sets(classes)
 
+        class_column_ref = df[class_column]
+
         df_to_use = df.drop(class_column, axis=1)
+        df_to_use.insert(len(df_to_use.columns), class_column,
+                         class_column_ref)
+
         class_column_values = df[class_column]
         data = df_to_use.values
 

--- a/pandas/plotting/_misc.py
+++ b/pandas/plotting/_misc.py
@@ -536,7 +536,7 @@ def parallel_sets(frame, class_column, color=None, colormap=None, **kwds):
     parsets = _ParSets(color, colormap)
     return parsets.par_sets(frame, class_column)
 
-class _ParSets():
+class _ParSets(object):
   def __init__(self, color=None, colormap=None):
     """
     Objects needed for test

--- a/pandas/plotting/_misc.py
+++ b/pandas/plotting/_misc.py
@@ -499,6 +499,7 @@ def parallel_coordinates(frame, class_column, cols=None, ax=None, color=None,
     ax.grid()
     return ax
 
+
 def parallel_sets(frame, class_column, color=None, colormap=None, **kwds):
     """Parallel sets plotting.
 
@@ -529,130 +530,144 @@ def parallel_sets(frame, class_column, color=None, colormap=None, **kwds):
                              '#4ECDC4', '#C7F464'))
     >>> plt.show()
     """
-    import matplotlib.pyplot as plt
-
-    classes = frame[class_column].drop_duplicates()
-
     parsets = _ParSets(color, colormap)
     return parsets.par_sets(frame, class_column)
 
+
 class _ParSets(object):
-  def __init__(self, color=None, colormap=None):
-    """
-    Objects needed for test
-    """
-    self._reverse_column_cats_map = {}
-    self._color = color
-    self._colormap = colormap
+    def __init__(self, color=None, colormap=None):
+        """
 
-  def par_sets(self, df, class_column):
-    import matplotlib.pyplot as plt
-    data = df.values
+        Objects needed for test
+        """
+        self._reverse_column_cats_map = {}
+        self._color = color
+        self._colormap = colormap
 
-    classes = df[class_column].drop_duplicates()
-    colour_map = self._get_colours_for_par_sets(classes)
+    def par_sets(self, df, class_column):
+        import matplotlib.pyplot as plt
+        data = df.values
 
-    df_to_use = df.drop(class_column, axis=1)
-    class_column_values = df[class_column]
-    data = df_to_use.values
+        classes = df[class_column].drop_duplicates()
+        colour_map = self._get_colours_for_par_sets(classes)
 
-    value_to_string_maps, column_cats_list = \
-        self._map_data_points_to_strs_for_par_sets(df_to_use)
+        df_to_use = df.drop(class_column, axis=1)
+        class_column_values = df[class_column]
+        data = df_to_use.values
 
-    fig, axes = plt.subplots(ncols=len(df_to_use.columns), figsize=(10,5))
+        value_to_string_maps, column_cats_list = \
+            self._map_data_points_to_strs_for_par_sets(df_to_use)
 
-    self._set_axes_limits_with_column_cardinality(axes, column_cats_list)
+        fig, axes = plt.subplots(ncols=len(df_to_use.columns), figsize=(10, 5))
 
-    self._connect_axes_pairs_with_polyline_segments(axes, data, value_to_string_maps,
-                                                    class_column_values, colour_map)
+        self._set_axes_limits_with_column_cardinality(axes, column_cats_list)
 
-    self._set_appropriate_label_values_to_axes(axes, df_to_use, column_cats_list)
+        self._connect_axes_pairs_with_polyline_segments(axes, data,
+                                                        value_to_string_maps,
+                                                        class_column_values,
+                                                        colour_map)
 
-    fig.subplots_adjust(wspace=0)
+        self._set_appropriate_label_values_to_axes(axes, df_to_use,
+                                                   column_cats_list)
 
-    self._remove_spines_for_last_axis_to_match_parallel_sets_plot(axes[-1])
+        fig.subplots_adjust(wspace=0)
 
-    return axes
+        self._remove_spines_to_match_parallel_sets_plot(axes[-1])
 
-  def _connect_polyline(self, left_ax_index, left_ax, right_ax_index, right_ax,
-                        left_data_y, right_data_y, **line_kwds):
-    """ Adapted from https://gist.github.com/phobson/9de120cabde660ec734c
-    The params left_ax_index and right_ax_index are not directly used in
-    this method but are need for testing via a proxy class
-    """
-    import mpl_toolkits.axes_grid1.inset_locator as inset
-    import matplotlib.transforms as mtrans
+        return axes
 
-    to_left_ax_transformer = left_ax.transScale + left_ax.transLimits
-    left_ax_y = to_left_ax_transformer.transform((0, left_data_y))[1]
+    def _connect_polyline(self, left_ax_index, left_ax, right_ax_index,
+                          right_ax, left_data_y, right_data_y, **line_kwds):
+        """ Adapted from https://gist.github.com/phobson/9de120cabde660ec734c
+        The params left_ax_index and right_ax_index are not directly used in
+        this method but are need for testing via a proxy class
+        """
+        import mpl_toolkits.axes_grid1.inset_locator as inset
+        import matplotlib.transforms as mtrans
 
-    to_right_ax_transformer = right_ax.transScale + right_ax.transLimits
-    right_ax_y = to_right_ax_transformer.transform((0, right_data_y))[1]
+        to_left_ax_transformer = left_ax.transScale + left_ax.transLimits
+        left_ax_y = to_left_ax_transformer.transform((0, left_data_y))[1]
 
-    left_data_to_ax_transformer = \
-        mtrans.blended_transform_factory(left_ax.transData, left_ax.transAxes)
-    right_data_to_ax_transformer = \
-        mtrans.blended_transform_factory(right_ax.transData, right_ax.transAxes)
+        to_right_ax_transformer = right_ax.transScale + right_ax.transLimits
+        right_ax_y = to_right_ax_transformer.transform((0, right_data_y))[1]
 
-    bbox = mtrans.Bbox.from_extents(0, left_ax_y, 0, right_ax_y)
-    left_bbox = mtrans.TransformedBbox(bbox, left_data_to_ax_transformer)
-    right_bbox = mtrans.TransformedBbox(bbox, right_data_to_ax_transformer)
+        left_data_to_ax_transformer = \
+            mtrans.blended_transform_factory(left_ax.transData,
+                                             left_ax.transAxes)
+        right_data_to_ax_transformer = \
+            mtrans.blended_transform_factory(right_ax.transData,
+                                             right_ax.transAxes)
 
-    left_bbox_corner, right_bbox_corner = 3, 2
-    bbox_connecter_line = inset.BboxConnector(left_bbox, right_bbox, loc1=left_bbox_corner,
-        loc2=right_bbox_corner, **line_kwds)
-    bbox_connecter_line.set_clip_on(False)
+        bbox = mtrans.Bbox.from_extents(0, left_ax_y, 0, right_ax_y)
+        left_bbox = mtrans.TransformedBbox(bbox, left_data_to_ax_transformer)
+        right_bbox = mtrans.TransformedBbox(bbox, right_data_to_ax_transformer)
 
-    return bbox_connecter_line
+        left_bbox_corner, right_bbox_corner = 3, 2
+        bbox_connecter_line = inset.BboxConnector(left_bbox, right_bbox,
+                                                  loc1=left_bbox_corner,
+                                                  loc2=right_bbox_corner,
+                                                  **line_kwds)
+        bbox_connecter_line.set_clip_on(False)
 
-  def _set_axes_limits_with_column_cardinality(self, axes, column_cats_list):
-    for ind, column_cats in enumerate(column_cats_list):
-      axes[ind].set_ylim(0, len(column_cats)-1)
+        return bbox_connecter_line
 
-  def _connect_axes_pairs_with_polyline_segments(self, axes, data, value_to_string_maps,
-                                                 class_column_values, colour_map):
-    for n, (ax1, ax2) in enumerate(zip(axes[:-1], axes[1:])):
-        for ind, row in enumerate(data):
-            polyline_segment = self._connect_polyline(n, ax1, n+1, ax2,
-                value_to_string_maps[(n, row[n])], value_to_string_maps[(n+1, row[n+1])],
-                color=colour_map[class_column_values[ind]])
-            ax1.add_line(polyline_segment)
+    def _set_axes_limits_with_column_cardinality(self, axes, column_cats_list):
+        for ind, column_cats in enumerate(column_cats_list):
+            axes[ind].set_ylim(0, len(column_cats) - 1)
 
-  def _set_appropriate_label_values_to_axes(self, axes, df_to_use, column_cats_list):
-    from matplotlib.ticker import MaxNLocator
-    for n, ax in enumerate(axes):
-        ax.set_xticks([0])
-        ax.set_xticklabels(df_to_use.columns[n])
-        ax.yaxis.set_major_locator(MaxNLocator(integer=True))
+    def _connect_axes_pairs_with_polyline_segments(self, axes, data,
+                                                   value_to_string_maps,
+                                                   class_column_values,
+                                                   colour_map):
+        for n, (ax1, ax2) in enumerate(zip(axes[:-1], axes[1:])):
+            for ind, row in enumerate(data):
+                polyline_segment = \
+                    self._connect_polyline(n, ax1, n + 1, ax2,
+                                           value_to_string_maps[(n, row[n])],
+                                           value_to_string_maps[(n + 1,
+                                                                row[n + 1])],
+                                           color=colour_map[
+                                               class_column_values[ind]])
+                ax1.add_line(polyline_segment)
 
-    for cat_index in range(len(column_cats_list)):
-      axes[cat_index].set_yticklabels(column_cats_list[cat_index])
+    def _set_appropriate_label_values_to_axes(self, axes, df_to_use,
+                                              column_cats_list):
+        from matplotlib.ticker import MaxNLocator
+        for n, ax in enumerate(axes):
+            ax.set_xticks([0])
+            ax.set_xticklabels(df_to_use.columns[n])
+            ax.yaxis.set_major_locator(MaxNLocator(integer=True))
 
-  def _remove_spines_for_last_axis_to_match_parallel_sets_plot(self, last_axes):
-    spine_keys = ['right', 'bottom', 'top']
-    for spine_key in spine_keys:
-      last_axes.spines[spine_key].set_visible(False)
+        for cat_index in range(len(column_cats_list)):
+            axes[cat_index].set_yticklabels(column_cats_list[cat_index])
 
-  def _get_colours_for_par_sets(self, classes):
-    colours = sorted(_get_standard_colors(num_colors=len(classes), color=self._color,
-                                          colormap=self._colormap))
-    return dict(zip(classes, colours))
+    def _remove_spines_to_match_parallel_sets_plot(self, last_axes):
+        spine_keys = ['right', 'bottom', 'top']
+        for spine_key in spine_keys:
+            last_axes.spines[spine_key].set_visible(False)
 
-  def _map_data_points_to_strs_for_par_sets(self, df):
-    maps = {}
-    column_cats_list = []
-    reverse_column_cats_map = {}
+    def _get_colours_for_par_sets(self, classes):
+        colours = sorted(_get_standard_colors(num_colors=len(classes),
+                                              color=self._color,
+                                              colormap=self._colormap))
+        return dict(zip(classes, colours))
 
-    for column_index, column in enumerate(df.columns):
-      column_cats = df[column].unique()
-      column_cats_list.append(column_cats)
-      for value_map, cat in enumerate(column_cats):
-        maps[(column_index, cat)] = value_map
-        reverse_column_cats_map[(column_index, value_map)] = cat
+    def _map_data_points_to_strs_for_par_sets(self, df):
+        maps = {}
+        column_cats_list = []
+        reverse_column_cats_map = {}
 
-    self._reverse_column_cats_map = reverse_column_cats_map
+        for column_index, column in enumerate(df.columns):
+            column_cats = df[column].unique()
+            column_cats_list.append(column_cats)
+            for value_map, cat in enumerate(column_cats):
+                maps[(column_index, cat)] = value_map
+                reverse_column_cats_map[(column_index, value_map)] = cat
 
-    return maps, column_cats_list
+        self._reverse_column_cats_map = reverse_column_cats_map
+
+        return maps, column_cats_list
+
 
 def lag_plot(series, lag=1, ax=None, **kwds):
     """Lag plot for time series.

--- a/pandas/plotting/_misc.py
+++ b/pandas/plotting/_misc.py
@@ -503,6 +503,13 @@ def parallel_coordinates(frame, class_column, cols=None, ax=None, color=None,
 def parallel_sets(frame, class_column, color=None, colormap=None, **kwds):
     """Parallel sets plotting.
 
+    Parallel sets is a visualization technique for categorical data
+    that is useful for identifying discriminating structure within
+    a dataset in most class classification problems. Each sample from
+    the dataset is viewed as a polyline whose segment endpoints
+    are the values of the respective columns in the frame and the line
+    is assigned a colour per the class_column value.
+
     Parameters
     ----------
     frame: DataFrame
@@ -535,6 +542,12 @@ def parallel_sets(frame, class_column, color=None, colormap=None, **kwds):
 
 
 class _ParSets(object):
+    """ Utility class for parallel_sets.
+
+    Used to construct a parallel sets plot. It organizes the helper
+    functions and is useful for testing.
+    """
+
     def __init__(self, color=None, colormap=None):
         """
 

--- a/pandas/tests/plotting/test_misc.py
+++ b/pandas/tests/plotting/test_misc.py
@@ -271,9 +271,9 @@ class TestDataFramePlots(TestPlotBase):
         df = pd.DataFrame({'1': ['a', 'b', 'c', 'b'],
                            '2': ['d', 'f', 'g', 'd'],
                            '3': ['h', 'e', 'j', 'h'],
-                           '4': ['x', 'y', 'x', 'y']})
+                           'four': ['x', 'y', 'x', 'y']})
         expected_pairs = [list(zip(df[i].values, df[j].values))
-                          for i, j in [('1', '2'), ('2', '4')]]
+                          for i, j in [('1', '2'), ('2', 'four')]]
         expected_data_pairs = reduce(list.__add__, expected_pairs)
 
         class _ParSetsProxy(_ParSets):
@@ -296,7 +296,7 @@ class TestDataFramePlots(TestPlotBase):
         par_sets = _ParSetsProxy()
         axes = par_sets.par_sets(df, class_column='3')
 
-        expected_x_ticks = ['1', '2', '4']
+        expected_x_ticks = ['1', '2', 'four']
         actual_x_ticks = [ax.get_xticklabels()[0].get_text() for ax in axes]
         assert expected_x_ticks == actual_x_ticks
 
@@ -304,6 +304,27 @@ class TestDataFramePlots(TestPlotBase):
         actual_y_ticks = [list(map(lambda i: i.get_text(),
                                    ax.get_yticklabels())) for ax in axes]
         assert expected_y_ticks == actual_y_ticks
+
+        last_axes = axes[-1]
+        spine_keys = ['right', 'bottom', 'top']
+        for spine_key in spine_keys:
+            assert last_axes.spines[spine_key].get_visible() is False
+        assert last_axes.spines['left'].get_visible() is True
+
+        par_sets = _ParSets()
+        actual_colour_map = par_sets._get_colours_for_par_sets([1, 2, 3])
+        expected_colour_map = {1: '#17becf', 2: '#1f77b4', 3: '#1f77b4'}
+        assert actual_colour_map == expected_colour_map
+
+        colours = ['b', 'g', 'r']
+        df = DataFrame({"A": [1, 2, 3],
+                        "B": [1, 2, 3],
+                        "C": [1, 2, 3],
+                        "Name": colours})
+        par_sets = _ParSets(color=colours)
+        actual_colour_map = par_sets._get_colours_for_par_sets([1, 2, 3])
+        expected_colour_map = {1: 'b', 2: 'g', 3: 'r'}
+        assert actual_colour_map == expected_colour_map
 
     @slow
     def test_radviz(self):

--- a/pandas/tests/plotting/test_misc.py
+++ b/pandas/tests/plotting/test_misc.py
@@ -3,6 +3,7 @@
 """ Test cases for misc plot functions """
 
 import pytest
+from functools import reduce
 
 from pandas import Series, DataFrame
 from pandas.compat import lmap
@@ -263,8 +264,8 @@ class TestDataFramePlots(TestPlotBase):
             # lables and colors are ordered strictly increasing
             assert prev[1] < nxt[1] and prev[0] < nxt[0]
 
+    @slow
     def test_parallel_sets(self):
-        from functools import reduce
         import pandas as pd
         from pandas.plotting._misc import _ParSets
         df = pd.DataFrame({'1': ['a', 'b', 'c', 'b'],

--- a/pandas/tests/plotting/test_misc.py
+++ b/pandas/tests/plotting/test_misc.py
@@ -263,6 +263,36 @@ class TestDataFramePlots(TestPlotBase):
             # lables and colors are ordered strictly increasing
             assert prev[1] < nxt[1] and prev[0] < nxt[0]
 
+    def test_parallel_sets(self):
+      from functools import reduce
+      import pandas as pd
+      from pandas.plotting import parallel_sets
+      from pandas.plotting._misc import _ParSets
+      df = pd.DataFrame({'1':['a', 'b', 'c', 'b'], '2':['d', 'f', 'g', 'd'], \
+            '3':['h', 'e', 'j', 'h'], '4': ['x', 'y', 'x', 'y']})
+      expected_data_pairs = reduce(list.__add__,
+            [list(zip(df[i].values, df[j].values)) for i, j in [('1', '2'), ('2', '4')]])
+
+      class _ParSetsProxy(_ParSets):
+        def _connect_polyline(self, left_ax_index, left_ax, right_ax_index,
+                              right_ax, left_data_y, right_data_y, **line_kwds):
+          data_tuple = self._reverse_column_cats_map[(left_ax_index, left_data_y)], \
+                self._reverse_column_cats_map[(right_ax_index, right_data_y)]
+          assert data_tuple in expected_data_pairs
+          return super(_ParSetsProxy, self)._connect_polyline(left_ax_index, left_ax,
+                right_ax_index, right_ax, left_data_y, right_data_y, **line_kwds)
+
+      par_sets = _ParSetsProxy()
+      axes = par_sets.par_sets(df, class_column='3')
+
+      expected_x_ticks = ['1', '2', '4']
+      actual_x_ticks = [ax.get_xticklabels()[0].get_text() for ax in axes]
+      assert expected_x_ticks == actual_x_ticks
+
+      expected_y_ticks = [['a', 'b', 'c'], ['d', 'f', 'g'], ['x', 'y']]
+      actual_y_ticks = [list(map(lambda i: i.get_text(), ax.get_yticklabels())) for ax in axes]
+      assert expected_y_ticks == actual_y_ticks
+
     @slow
     def test_radviz(self):
         from pandas.plotting import radviz

--- a/pandas/tests/plotting/test_misc.py
+++ b/pandas/tests/plotting/test_misc.py
@@ -313,16 +313,7 @@ class TestDataFramePlots(TestPlotBase):
             assert last_axes.spines[hidden_spine_key].get_visible() is False
         assert last_axes.spines['left'].get_visible() is True
 
-        par_sets = _ParSets()
-        actual_colour_map = par_sets._get_colours_for_par_sets([1, 2, 3])
-        expected_colour_map = {1: '#17becf', 2: '#1f77b4', 3: '#1f77b4'}
-        assert actual_colour_map == expected_colour_map
-
         colours = ['b', 'g', 'r']
-        df = DataFrame({"A": [1, 2, 3],
-                        "B": [1, 2, 3],
-                        "C": [1, 2, 3],
-                        "Name": colours})
         par_sets = _ParSets(color=colours)
         actual_colour_map = par_sets._get_colours_for_par_sets([1, 2, 3])
         expected_colour_map = {1: 'b', 2: 'g', 3: 'r'}

--- a/pandas/tests/plotting/test_misc.py
+++ b/pandas/tests/plotting/test_misc.py
@@ -273,7 +273,8 @@ class TestDataFramePlots(TestPlotBase):
                            '3': ['h', 'e', 'j', 'h'],
                            'four': ['x', 'y', 'x', 'y']})
         expected_pairs = [list(zip(df[i].values, df[j].values))
-                          for i, j in [('1', '2'), ('2', 'four')]]
+                          for i, j in [('1', '2'), ('2', 'four'),
+                                       ('four', '3')]]
         expected_data_pairs = reduce(list.__add__, expected_pairs)
 
         class _ParSetsProxy(_ParSets):
@@ -296,19 +297,20 @@ class TestDataFramePlots(TestPlotBase):
         par_sets = _ParSetsProxy()
         axes = par_sets.par_sets(df, class_column='3')
 
-        expected_x_ticks = ['1', '2', 'four']
+        expected_x_ticks = ['1', '2', 'four', '3']
         actual_x_ticks = [ax.get_xticklabels()[0].get_text() for ax in axes]
         assert expected_x_ticks == actual_x_ticks
 
-        expected_y_ticks = [['a', 'b', 'c'], ['d', 'f', 'g'], ['x', 'y']]
+        expected_y_ticks = [['a', 'b', 'c'], ['d', 'f', 'g'], ['x', 'y'],
+                            ['h', 'e', 'j']]
         actual_y_ticks = [list(map(lambda i: i.get_text(),
                                    ax.get_yticklabels())) for ax in axes]
         assert expected_y_ticks == actual_y_ticks
 
         last_axes = axes[-1]
-        spine_keys = ['right', 'bottom', 'top']
-        for spine_key in spine_keys:
-            assert last_axes.spines[spine_key].get_visible() is False
+        hidden_spine_keys = ['right', 'bottom', 'top']
+        for hidden_spine_key in hidden_spine_keys:
+            assert last_axes.spines[hidden_spine_key].get_visible() is False
         assert last_axes.spines['left'].get_visible() is True
 
         par_sets = _ParSets()

--- a/pandas/tests/plotting/test_misc.py
+++ b/pandas/tests/plotting/test_misc.py
@@ -264,34 +264,45 @@ class TestDataFramePlots(TestPlotBase):
             assert prev[1] < nxt[1] and prev[0] < nxt[0]
 
     def test_parallel_sets(self):
-      from functools import reduce
-      import pandas as pd
-      from pandas.plotting import parallel_sets
-      from pandas.plotting._misc import _ParSets
-      df = pd.DataFrame({'1':['a', 'b', 'c', 'b'], '2':['d', 'f', 'g', 'd'], \
-            '3':['h', 'e', 'j', 'h'], '4': ['x', 'y', 'x', 'y']})
-      expected_data_pairs = reduce(list.__add__,
-            [list(zip(df[i].values, df[j].values)) for i, j in [('1', '2'), ('2', '4')]])
+        from functools import reduce
+        import pandas as pd
+        from pandas.plotting._misc import _ParSets
+        df = pd.DataFrame({'1': ['a', 'b', 'c', 'b'],
+                           '2': ['d', 'f', 'g', 'd'],
+                           '3': ['h', 'e', 'j', 'h'],
+                           '4': ['x', 'y', 'x', 'y']})
+        expected_pairs = [list(zip(df[i].values, df[j].values))
+                          for i, j in [('1', '2'), ('2', '4')]]
+        expected_data_pairs = reduce(list.__add__, expected_pairs)
 
-      class _ParSetsProxy(_ParSets):
-        def _connect_polyline(self, left_ax_index, left_ax, right_ax_index,
-                              right_ax, left_data_y, right_data_y, **line_kwds):
-          data_tuple = self._reverse_column_cats_map[(left_ax_index, left_data_y)], \
-                self._reverse_column_cats_map[(right_ax_index, right_data_y)]
-          assert data_tuple in expected_data_pairs
-          return super(_ParSetsProxy, self)._connect_polyline(left_ax_index, left_ax,
-                right_ax_index, right_ax, left_data_y, right_data_y, **line_kwds)
+        class _ParSetsProxy(_ParSets):
+            def _connect_polyline(self, left_ax_index, left_ax, right_ax_index,
+                                  right_ax, left_data_y, right_data_y,
+                                  **line_kwds):
+                data_tuple_left = \
+                    self._reverse_column_cats_map[(left_ax_index,
+                                                  left_data_y)]
+                data_tuple_right = \
+                    self._reverse_column_cats_map[(right_ax_index,
+                                                  right_data_y)]
+                data_tuple = data_tuple_left, data_tuple_right
+                assert data_tuple in expected_data_pairs
+                return super(_ParSetsProxy, self)\
+                    ._connect_polyline(left_ax_index, left_ax, right_ax_index,
+                                       right_ax, left_data_y, right_data_y,
+                                       **line_kwds)
 
-      par_sets = _ParSetsProxy()
-      axes = par_sets.par_sets(df, class_column='3')
+        par_sets = _ParSetsProxy()
+        axes = par_sets.par_sets(df, class_column='3')
 
-      expected_x_ticks = ['1', '2', '4']
-      actual_x_ticks = [ax.get_xticklabels()[0].get_text() for ax in axes]
-      assert expected_x_ticks == actual_x_ticks
+        expected_x_ticks = ['1', '2', '4']
+        actual_x_ticks = [ax.get_xticklabels()[0].get_text() for ax in axes]
+        assert expected_x_ticks == actual_x_ticks
 
-      expected_y_ticks = [['a', 'b', 'c'], ['d', 'f', 'g'], ['x', 'y']]
-      actual_y_ticks = [list(map(lambda i: i.get_text(), ax.get_yticklabels())) for ax in axes]
-      assert expected_y_ticks == actual_y_ticks
+        expected_y_ticks = [['a', 'b', 'c'], ['d', 'f', 'g'], ['x', 'y']]
+        actual_y_ticks = [list(map(lambda i: i.get_text(),
+                                   ax.get_yticklabels())) for ax in axes]
+        assert expected_y_ticks == actual_y_ticks
 
     @slow
     def test_radviz(self):


### PR DESCRIPTION
 - [x] closes #12341
 - [x] tests added / passed
 - [x] passes ``git diff upstream/master --name-only -- '*.py' | flake8 --diff``
 - [ ] whatsnew entry

Initial PR for #12341 

I have a couple of questions, the signature is different from the parallel_coordinates method and I was not sure if we need all of them (for example axvlines)?

I've added some tests but need suggestions on how to test _connect_polyline(). I was thinking of simply using a mock object for the axes objects and verifying their attributes were being accessed.

Some context, I have a new method called parallel_sets() which converts all of its inputs to a string expecting categorical data always, via a string_to_integer dictionary, and plots those integers.