### PR TITLE
DOC: don't include all methods/attributes of IntervalIndex

### DIFF
--- a/doc/source/api.rst
+++ b/doc/source/api.rst
@@ -1404,6 +1404,7 @@ CategoricalIndex
 
 .. autosummary::
    :toctree: generated/
+   :template: autosummary/class_without_autosummary.rst
 
    CategoricalIndex
 
@@ -1432,6 +1433,7 @@ IntervalIndex
 
 .. autosummary::
    :toctree: generated/
+   :template: autosummary/class_without_autosummary.rst
 
    IntervalIndex
 

--- a/doc/source/api.rst
+++ b/doc/source/api.rst
@@ -618,7 +618,6 @@ strings and apply several methods to it. These can be accessed like
        Series.cat
        Series.dt
        Index.str
-       CategoricalIndex.str
        MultiIndex.str
        DatetimeIndex.str
        TimedeltaIndex.str

--- a/doc/sphinxext/numpydoc/numpydoc.py
+++ b/doc/sphinxext/numpydoc/numpydoc.py
@@ -45,7 +45,6 @@ def mangle_docstrings(app, what, name, obj, options, lines,
     # PANDAS HACK (to remove the list of methods/attributes for Categorical)
     if what == "class" and (name.endswith(".Categorical") or
                             name.endswith("CategoricalIndex") or
-                            name.endswith("Interval") or
                             name.endswith("IntervalIndex")):
         cfg['class_members_list'] = False
 

--- a/doc/sphinxext/numpydoc/numpydoc.py
+++ b/doc/sphinxext/numpydoc/numpydoc.py
@@ -43,7 +43,10 @@ def mangle_docstrings(app, what, name, obj, options, lines,
               )
 
     # PANDAS HACK (to remove the list of methods/attributes for Categorical)
-    if what == "class" and name.endswith(".Categorical"):
+    if what == "class" and (name.endswith(".Categorical") or
+                            name.endswith("CategoricalIndex") or
+                            name.endswith("Interval") or
+                            name.endswith("IntervalIndex")):
         cfg['class_members_list'] = False
 
     if what == 'module':

--- a/pandas/core/indexes/category.py
+++ b/pandas/core/indexes/category.py
@@ -47,6 +47,9 @@ class CategoricalIndex(Index, base.PandasDelegate):
     name : object
         Name to be stored in the index
 
+    See Also
+    --------
+    Categorical, Index
     """
 
     _typ = 'categoricalindex'

--- a/pandas/core/indexes/interval.py
+++ b/pandas/core/indexes/interval.py
@@ -110,6 +110,10 @@ class IntervalIndex(IntervalMixin, Index):
         Name to be stored in the index.
     copy : boolean, default False
         Copy the meta-data
+
+    See Also
+    --------
+    Index
     """
     _typ = 'intervalindex'
     _comparables = ['name']


### PR DESCRIPTION
Alternative for #16050 

I totally forgot I already had made such a "class without autosummary table" template before for Categorical, so I hope this should work for IntervalIndex as well.