### PR TITLE
ENH: add optional ddof param to DataFrame.cov()

### DIFF
--- a/doc/source/whatsnew/v0.21.0.txt
+++ b/doc/source/whatsnew/v0.21.0.txt
@@ -119,6 +119,7 @@ Other Enhancements
 - :func:`Series.to_pickle` and :func:`DataFrame.to_pickle` have gained a ``protocol`` parameter (:issue:`16252`). By default, this parameter is set to `HIGHEST_PROTOCOL <https://docs.python.org/3/library/pickle.html#data-stream-format>`__
 - :func:`api.types.infer_dtype` now infers decimals. (:issue:`15690`)
 - :func:`read_feather` has gained the ``nthreads`` parameter for multi-threaded operations (:issue:`16359`)
+- :func:`DataFrame.cov()` and :func:`Series.cov()` now accept the parameter ``ddof``, making them consistent with ``.var()`` and ``.std()``. This allows the user to change degrees of freedom from the default value (1). (:issue:`16227`)
 - :func:`DataFrame.clip()` and :func:`Series.clip()` have gained an ``inplace`` argument. (:issue:`15388`)
 - :func:`crosstab` has gained a ``margins_name`` parameter to define the name of the row / column that will contain the totals when ``margins=True``. (:issue:`15972`)
 - :func:`DataFrame.select_dtypes` now accepts scalar values for include/exclude as well as list-like. (:issue:`16855`)
@@ -129,8 +130,6 @@ Other Enhancements
 - `read_*` methods can now infer compression from non-string paths, such as ``pathlib.Path`` objects (:issue:`17206`).
 - :func:`pd.read_sas()` now recognizes much more of the most frequently used date (datetime) formats in SAS7BDAT files (:issue:`15871`).
 - :func:`DataFrame.items` and :func:`Series.items` is now present in both Python 2 and 3 and is lazy in all cases (:issue:`13918`, :issue:`17213`)
-
-
 
 
 .. _whatsnew_0210.api_breaking:

--- a/pandas/_libs/algos.pyx
+++ b/pandas/_libs/algos.pyx
@@ -345,7 +345,8 @@ def nancorr(ndarray[float64_t, ndim=2] mat, bint cov=0, minp=None, ddof=None):
                         result[xi, yi] = result[yi, xi] = NaN
 
     if warn_ddof:
-        warnings.warn("N - ddof <= 0 for input ddof, for at least 1 pair of columns.", RuntimeWarning)
+        msg = "N - ddof <= 0 for input ddof, for at least 1 pair of columns."
+        warnings.warn(msg, RuntimeWarning)
 
     return result
 

--- a/pandas/_libs/algos.pyx
+++ b/pandas/_libs/algos.pyx
@@ -276,10 +276,10 @@ def min_subseq(ndarray[double_t] arr):
 
 @cython.boundscheck(False)
 @cython.wraparound(False)
-def nancorr(ndarray[float64_t, ndim=2] mat, bint cov=0, minp=None):
+def nancorr(ndarray[float64_t, ndim=2] mat, bint cov=0, minp=None, ddof=None):
     cdef:
         Py_ssize_t i, j, xi, yi, N, K
-        bint minpv
+        bint minpv, ddofv
         ndarray[float64_t, ndim=2] result
         ndarray[uint8_t, ndim=2] mask
         int64_t nobs = 0
@@ -291,6 +291,11 @@ def nancorr(ndarray[float64_t, ndim=2] mat, bint cov=0, minp=None):
         minpv = 1
     else:
         minpv = <int>minp
+
+    if ddof is None:
+        ddofv = 1
+    else:
+        ddofv = <int>ddof
 
     result = np.empty((K, K), dtype=np.float64)
     mask = np.isfinite(mat).view(np.uint8)
@@ -325,7 +330,7 @@ def nancorr(ndarray[float64_t, ndim=2] mat, bint cov=0, minp=None):
                             sumxx += vx * vx
                             sumyy += vy * vy
 
-                    divisor = (nobs - 1.0) if cov else sqrt(sumxx * sumyy)
+                    divisor = (nobs - ddofv) if cov else sqrt(sumxx * sumyy)
 
                     if divisor != 0:
                         result[xi, yi] = result[yi, xi] = sumx / divisor

--- a/pandas/_libs/algos.pyx
+++ b/pandas/_libs/algos.pyx
@@ -287,12 +287,12 @@ def nancorr(ndarray[float64_t, ndim=2] mat, bint cov=0, minp=None, ddof=None):
 
     N, K = (<object> mat).shape
 
-    if minp is None:
+    if minp is None or minp < 1:
         minpv = 1
     else:
         minpv = <int>minp
 
-    if ddof is None:
+    if ddof is None or ddof < 0:
         ddofv = 1
     else:
         ddofv = <int>ddof
@@ -312,7 +312,7 @@ def nancorr(ndarray[float64_t, ndim=2] mat, bint cov=0, minp=None, ddof=None):
                         sumx += vx
                         sumy += vy
 
-                if nobs < minpv:
+                if nobs < minpv or (cov and nobs - ddofv <= 0):
                     result[xi, yi] = result[yi, xi] = NaN
                 else:
                     meanx = sumx / nobs

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -5300,10 +5300,10 @@ class DataFrame(NDFrame):
             Minimum number of observations required per pair of columns
             to have a valid result.
         ddof : int, default 1
-            .. versionadded:: 0.21.0
-
             Delta Degrees of Freedom.  The divisor used in calculations
             is ``N - ddof``, where ``N`` represents the number of elements.
+
+            .. versionadded:: 0.21.0
 
         Returns
         -------
@@ -5312,16 +5312,26 @@ class DataFrame(NDFrame):
         Notes
         -----
         `y` contains the covariance matrix of the DataFrame's time series.
-        The covariance is normalized by ``N-ddof`` -- for the default ``ddof``
+        The covariance is normalized by ``N-ddof``. For the default ``ddof``
         value of 1, that results in N-1 (unbiased estimator).
         """
+        if ddof < 0:
+            raise ValueError('ddof ({}) must be >= 0'.format(ddof))
+
         numeric_df = self._get_numeric_data()
         cols = numeric_df.columns
         idx = cols.copy()
         mat = numeric_df.values
 
         if notna(mat).all():
+            fill_nan = False
+            #raise on ddof < 0, warn on N - ddof <= 0
             if min_periods is not None and min_periods > len(mat):
+                fill_nan = True
+            if len(mat) - ddof <= 0:
+                fill_nan = True
+                warnings.warn("Number rows - ddof <= 0 for input ddof.", UserWarning)
+            if fill_nan:
                 baseCov = np.empty((mat.shape[1], mat.shape[1]))
                 baseCov.fill(np.nan)
             else:

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -5290,15 +5290,20 @@ class DataFrame(NDFrame):
 
         return self._constructor(correl, index=idx, columns=cols)
 
-    def cov(self, min_periods=None):
+    def cov(self, min_periods=None, ddof=1):
         """
-        Compute pairwise covariance of columns, excluding NA/null values
+        Compute pairwise covariance of columns, excluding NA/null values.
 
         Parameters
         ----------
         min_periods : int, optional
             Minimum number of observations required per pair of columns
             to have a valid result.
+        ddof : int, default 1
+            .. versionadded:: 0.21.0
+
+            Delta Degrees of Freedom.  The divisor used in calculations
+            is ``N - ddof``, where ``N`` represents the number of elements.
 
         Returns
         -------
@@ -5307,7 +5312,8 @@ class DataFrame(NDFrame):
         Notes
         -----
         `y` contains the covariance matrix of the DataFrame's time series.
-        The covariance is normalized by N-1 (unbiased estimator).
+        The covariance is normalized by ``N-ddof`` -- for the default ``ddof``
+        value of 1, that results in N-1 (unbiased estimator).
         """
         numeric_df = self._get_numeric_data()
         cols = numeric_df.columns
@@ -5319,11 +5325,11 @@ class DataFrame(NDFrame):
                 baseCov = np.empty((mat.shape[1], mat.shape[1]))
                 baseCov.fill(np.nan)
             else:
-                baseCov = np.cov(mat.T)
+                baseCov = np.cov(mat.T, ddof=ddof)
             baseCov = baseCov.reshape((len(cols), len(cols)))
         else:
             baseCov = libalgos.nancorr(_ensure_float64(mat), cov=True,
-                                       minp=min_periods)
+                                       minp=min_periods, ddof=ddof)
 
         return self._constructor(baseCov, index=idx, columns=cols)
 

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -5325,12 +5325,11 @@ class DataFrame(NDFrame):
 
         if notna(mat).all():
             fill_nan = False
-            #raise on ddof < 0, warn on N - ddof <= 0
             if min_periods is not None and min_periods > len(mat):
                 fill_nan = True
             if len(mat) - ddof <= 0:
                 fill_nan = True
-                warnings.warn("N - ddof <= 0 for input ddof.", UserWarning)
+                warnings.warn("N - ddof <= 0 for input ddof.", RuntimeWarning)
             if fill_nan:
                 baseCov = np.empty((mat.shape[1], mat.shape[1]))
                 baseCov.fill(np.nan)

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -5330,7 +5330,7 @@ class DataFrame(NDFrame):
                 fill_nan = True
             if len(mat) - ddof <= 0:
                 fill_nan = True
-                warnings.warn("Number rows - ddof <= 0 for input ddof.", UserWarning)
+                warnings.warn("N - ddof <= 0 for input ddof.", UserWarning)
             if fill_nan:
                 baseCov = np.empty((mat.shape[1], mat.shape[1]))
                 baseCov.fill(np.nan)

--- a/pandas/core/nanops.py
+++ b/pandas/core/nanops.py
@@ -766,7 +766,7 @@ def nancov(a, b, min_periods=None, ddof=1):
     if len(a) < min_periods:
         return np.nan
     if len(a) - ddof <= 0:
-        warnings.warn("Series length - ddof <= 0 for input ddof.", UserWarning)
+        warnings.warn("N - ddof <= 0 for input ddof.", UserWarning)
         return np.nan
 
     return np.cov(a, b, ddof=ddof)[0, 1]

--- a/pandas/core/nanops.py
+++ b/pandas/core/nanops.py
@@ -752,6 +752,8 @@ def get_corr_func(method):
 def nancov(a, b, min_periods=None, ddof=1):
     if len(a) != len(b):
         raise AssertionError('Operands to nancov must have same size')
+    if ddof < 0:
+        raise ValueError('ddof ({}) must be >= 0'.format(ddof))
 
     if min_periods is None:
         min_periods = 1
@@ -762,6 +764,9 @@ def nancov(a, b, min_periods=None, ddof=1):
         b = b[valid]
 
     if len(a) < min_periods:
+        return np.nan
+    if len(a) - ddof <= 0:
+        warnings.warn("Series length - ddof <= 0 for input ddof.", UserWarning)
         return np.nan
 
     return np.cov(a, b, ddof=ddof)[0, 1]

--- a/pandas/core/nanops.py
+++ b/pandas/core/nanops.py
@@ -749,7 +749,7 @@ def get_corr_func(method):
 
 
 @disallow('M8', 'm8')
-def nancov(a, b, min_periods=None):
+def nancov(a, b, min_periods=None, ddof=1):
     if len(a) != len(b):
         raise AssertionError('Operands to nancov must have same size')
 
@@ -764,7 +764,7 @@ def nancov(a, b, min_periods=None):
     if len(a) < min_periods:
         return np.nan
 
-    return np.cov(a, b)[0, 1]
+    return np.cov(a, b, ddof=ddof)[0, 1]
 
 
 def _ensure_numeric(x):

--- a/pandas/core/nanops.py
+++ b/pandas/core/nanops.py
@@ -766,7 +766,7 @@ def nancov(a, b, min_periods=None, ddof=1):
     if len(a) < min_periods:
         return np.nan
     if len(a) - ddof <= 0:
-        warnings.warn("N - ddof <= 0 for input ddof.", UserWarning)
+        warnings.warn("N - ddof <= 0 for input ddof.", RuntimeWarning)
         return np.nan
 
     return np.cov(a, b, ddof=ddof)[0, 1]

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -1447,7 +1447,7 @@ class Series(base.IndexOpsMixin, strings.StringAccessorMixin,
         return nanops.nancorr(this.values, other.values, method=method,
                               min_periods=min_periods)
 
-    def cov(self, other, min_periods=None):
+    def cov(self, other, min_periods=None, ddof=1):
         """
         Compute covariance with Series, excluding missing values
 
@@ -1456,18 +1456,26 @@ class Series(base.IndexOpsMixin, strings.StringAccessorMixin,
         other : Series
         min_periods : int, optional
             Minimum number of observations needed to have a valid result
+        ddof : int, default 1
+            .. versionadded:: 0.21.0
+
+            Delta Degrees of Freedom.  The divisor used in calculations
+            is ``N - ddof``, where ``N`` represents the number of elements.
 
         Returns
         -------
         covariance : float
 
-        Normalized by N-1 (unbiased estimator).
+        Notes
+        -----
+        The returned covariance is normalized by ``N-ddof`` -- for the default
+        ``ddof`` value of 1, that results in N-1 (unbiased estimator).
         """
         this, other = self.align(other, join='inner', copy=False)
         if len(this) == 0:
             return np.nan
         return nanops.nancov(this.values, other.values,
-                             min_periods=min_periods)
+                             min_periods=min_periods, ddof=ddof)
 
     def diff(self, periods=1):
         """

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -1457,10 +1457,10 @@ class Series(base.IndexOpsMixin, strings.StringAccessorMixin,
         min_periods : int, optional
             Minimum number of observations needed to have a valid result
         ddof : int, default 1
-            .. versionadded:: 0.21.0
-
             Delta Degrees of Freedom.  The divisor used in calculations
             is ``N - ddof``, where ``N`` represents the number of elements.
+
+            .. versionadded:: 0.21.0
 
         Returns
         -------
@@ -1468,7 +1468,7 @@ class Series(base.IndexOpsMixin, strings.StringAccessorMixin,
 
         Notes
         -----
-        The returned covariance is normalized by ``N-ddof`` -- for the default
+        The returned covariance is normalized by ``N-ddof``. For the default
         ``ddof`` value of 1, that results in N-1 (unbiased estimator).
         """
         this, other = self.align(other, join='inner', copy=False)

--- a/pandas/tests/frame/test_analytics.py
+++ b/pandas/tests/frame/test_analytics.py
@@ -134,16 +134,18 @@ class TestDataFrameAnalytics(TestData):
         num_isna = num_rows // 2
         num_notna = num_rows - num_isna
         df_na['A'][:num_isna] = nan
-        df_na['B'][num_isna:2*num_isna] = nan
+        df_na['B'][num_isna:2 * num_isna] = nan
 
-        # compare each number in DataFrame.cov() matrix to corresponding Series.cov() number
+        # compare each number in DataFrame.cov() matrix
+        # to corresponding Series.cov() number
         for ddof in [0, 1]:
             df_cov = self.frame.cov(ddof=ddof)
             df_na_cov = df_na.cov(ddof=ddof)
             for col_i in df_cov:
                 for col_j in df_cov:
                     result = df_cov.loc[col_i, col_j]
-                    expected = self.frame[col_i].cov(self.frame[col_j], ddof=ddof)
+                    expected = self.frame[col_i].cov(self.frame[col_j],
+                                                     ddof=ddof)
                     tm.assert_almost_equal(expected, result)
 
                     result = df_na_cov.loc[col_i, col_j]

--- a/pandas/tests/frame/test_analytics.py
+++ b/pandas/tests/frame/test_analytics.py
@@ -188,6 +188,19 @@ class TestDataFrameAnalytics(TestData):
                              index=df.columns, columns=df.columns)
         tm.assert_frame_equal(result, expected)
 
+        # N - ddof == 0
+        df1 = self.frame.dropna()[:1]
+        tm.assert_produces_warning(df1.cov(ddof=1))
+        result = df1.cov(ddof=1)
+        assert isnull(result.values).all()
+
+        # N - ddof == 1
+        num_cols = df1.shape[1]
+        expected = np.zeros((num_cols, num_cols))
+        result = df1.cov(ddof=0).values
+        tm.assert_numpy_array_equal(expected, result)
+
+
     def test_corrwith(self):
         a = self.tsframe
         noise = Series(randn(len(a)), index=a.index)

--- a/pandas/tests/frame/test_analytics.py
+++ b/pandas/tests/frame/test_analytics.py
@@ -129,10 +129,26 @@ class TestDataFrameAnalytics(TestData):
             assert result.index.equals(result.columns)
 
     def test_cov(self):
-        # min_periods no NAs (corner case)
-        expected = self.frame.cov()
-        result = self.frame.cov(min_periods=len(self.frame))
+        # compare cov(col_a, col_a) to var(col_a)
+        s_expected = self.frame.var(ddof=1)
+        df_cov = self.frame.cov(ddof=1)
+        for col in df_cov:
+            result = df_cov.loc[col, col]
+            tm.assert_almost_equal(s_expected[col], result)
 
+        s_expected = self.frame.var(ddof=0)
+        df_cov = self.frame.cov(ddof=0)
+        for col in df_cov:
+            result = df_cov.loc[col, col]
+            tm.assert_almost_equal(s_expected[col], result)
+
+        # min_periods no NAs (corner case)
+        expected = self.frame.cov(ddof=1)
+        result = self.frame.cov(min_periods=len(self.frame), ddof=1)
+        tm.assert_frame_equal(expected, result)
+
+        expected = self.frame.cov(ddof=0)
+        result = self.frame.cov(min_periods=len(self.frame), ddof=0)
         tm.assert_frame_equal(expected, result)
 
         result = self.frame.cov(min_periods=len(self.frame) + 1)

--- a/pandas/tests/frame/test_analytics.py
+++ b/pandas/tests/frame/test_analytics.py
@@ -200,7 +200,6 @@ class TestDataFrameAnalytics(TestData):
         result = df1.cov(ddof=0).values
         tm.assert_numpy_array_equal(expected, result)
 
-
     def test_corrwith(self):
         a = self.tsframe
         noise = Series(randn(len(a)), index=a.index)

--- a/pandas/tests/series/test_analytics.py
+++ b/pandas/tests/series/test_analytics.py
@@ -856,6 +856,14 @@ class TestSeriesAnalytics(TestData):
         assert isna(ts1.cov(ts2, min_periods=12, ddof=1))
         assert isna(ts1.cov(ts2, min_periods=12, ddof=0))
 
+        # N - ddof == 0
+        ts1 = self.ts[:1]
+        tm.assert_produces_warning(ts1.cov(ts1, ddof=1))
+        assert isna(ts1.cov(ts1, ddof=1))
+
+        # N - ddof == 1
+        assert ts1.cov(ts1, ddof=0) == 0
+
     def test_count(self):
         assert self.ts.count() == len(self.ts)
 

--- a/pandas/tests/series/test_analytics.py
+++ b/pandas/tests/series/test_analytics.py
@@ -826,26 +826,35 @@ class TestSeriesAnalytics(TestData):
 
     def test_cov(self):
         # full overlap
-        tm.assert_almost_equal(self.ts.cov(self.ts), self.ts.std() ** 2)
+        tm.assert_almost_equal(self.ts.cov(self.ts, ddof=1),
+                               self.ts.std(ddof=1) ** 2)
+        tm.assert_almost_equal(self.ts.cov(self.ts, ddof=0),
+                               self.ts.std(ddof=0) ** 2)
 
         # partial overlap
-        tm.assert_almost_equal(self.ts[:15].cov(self.ts[5:]),
-                               self.ts[5:15].std() ** 2)
+        tm.assert_almost_equal(self.ts[:15].cov(self.ts[5:], ddof=1),
+                               self.ts[5:15].std(ddof=1) ** 2)
+        tm.assert_almost_equal(self.ts[:15].cov(self.ts[5:], ddof=0),
+                               self.ts[5:15].std(ddof=0) ** 2)
 
         # No overlap
-        assert np.isnan(self.ts[::2].cov(self.ts[1::2]))
+        assert np.isnan(self.ts[::2].cov(self.ts[1::2], ddof=1))
+        assert np.isnan(self.ts[::2].cov(self.ts[1::2], ddof=0))
 
         # all NA
         cp = self.ts[:10].copy()
         cp[:] = np.nan
-        assert isna(cp.cov(cp))
+        assert isna(cp.cov(cp, ddof=1))
+        assert isna(cp.cov(cp, ddof=0))
 
         # min_periods
-        assert isna(self.ts[:15].cov(self.ts[5:], min_periods=12))
+        assert isna(self.ts[:15].cov(self.ts[5:], min_periods=12, ddof=1))
+        assert isna(self.ts[:15].cov(self.ts[5:], min_periods=12, ddof=0))
 
         ts1 = self.ts[:15].reindex(self.ts.index)
         ts2 = self.ts[5:].reindex(self.ts.index)
-        assert isna(ts1.cov(ts2, min_periods=12))
+        assert isna(ts1.cov(ts2, min_periods=12, ddof=1))
+        assert isna(ts1.cov(ts2, min_periods=12, ddof=0))
 
     def test_count(self):
         assert self.ts.count() == len(self.ts)


### PR DESCRIPTION
 - [ ] closes #xxxx (searched, didn't see any issues on this topic)
 - [x] tests added / passed
 - [x] passes ``git diff upstream/master --name-only -- '*.py' | flake8 --diff``
 - [x] whatsnew entry

Noticed that the .cov() methods on DataFrame and Series assume the user wants to calculate sample variance and normalize by N-1. In contrast, the .var() and .std() methods on DataFrame, Series, DataFrameGroupBy, and SeriesGroupBy take a ddof parameter. Its default value is 1, calculating the sample std/var, but the user can specify ddof=0 to calculate the population std/var.

Simply added a ddof param (default value 1) to the .cov() methods. The value is then passed into other method calls as required. Did have to modify 1 bit of Cython code in algos.pyx, the nancorr() function.