### PR TITLE
TST: Remove __init__ statements in testing

### DIFF
--- a/pandas/tests/indexes/test_multi.py
+++ b/pandas/tests/indexes/test_multi.py
@@ -486,7 +486,7 @@ class TestMultiIndex(Base):
 
     def test_names(self):
 
-        # names are assigned in __init__
+        # names are assigned in setup
         names = self.index_names
         level_names = [level.name for level in self.index.levels]
         assert names == level_names

--- a/pandas/tests/test_config.py
+++ b/pandas/tests/test_config.py
@@ -8,21 +8,27 @@ import warnings
 
 class TestConfig(object):
 
-    def __init__(self, *args):
-        super(TestConfig, self).__init__(*args)
-
+    @classmethod
+    def setup_class(cls):
         from copy import deepcopy
-        self.cf = pd.core.config
-        self.gc = deepcopy(getattr(self.cf, '_global_config'))
-        self.do = deepcopy(getattr(self.cf, '_deprecated_options'))
-        self.ro = deepcopy(getattr(self.cf, '_registered_options'))
+
+        cls.cf = pd.core.config
+        cls.gc = deepcopy(getattr(cls.cf, '_global_config'))
+        cls.do = deepcopy(getattr(cls.cf, '_deprecated_options'))
+        cls.ro = deepcopy(getattr(cls.cf, '_registered_options'))
 
     def setup_method(self, method):
         setattr(self.cf, '_global_config', {})
-        setattr(
-            self.cf, 'options', self.cf.DictWrapper(self.cf._global_config))
+        setattr(self.cf, 'options', self.cf.DictWrapper(
+            self.cf._global_config))
         setattr(self.cf, '_deprecated_options', {})
         setattr(self.cf, '_registered_options', {})
+
+        # Our test fixture in conftest.py sets "chained_assignment"
+        # to "raise" only after all test methods have been setup.
+        # However, after this setup, there is no longer any
+        # "chained_assignment" option, so re-register it.
+        self.cf.register_option('chained_assignment', 'raise')
 
     def teardown_method(self, method):
         setattr(self.cf, '_global_config', self.gc)


### PR DESCRIPTION
We should never have had `__init__` in a test case (even with the old `nose` paradigm).

Closes #16235.
