### PR TITLE
BUG: rolling.quantile does not return an interpolated result

### DIFF
--- a/asv_bench/benchmarks/rolling.py
+++ b/asv_bench/benchmarks/rolling.py
@@ -1,0 +1,185 @@
+from .pandas_vb_common import *
+import pandas as pd
+import numpy as np
+
+
+class DataframeRolling(object):
+    goal_time = 0.2
+
+    def setup(self):
+        self.N = 100000
+        self.Ns = 10000
+        self.df = pd.DataFrame({'a': np.random.random(self.N)})
+        self.dfs = pd.DataFrame({'a': np.random.random(self.Ns)})
+        self.wins = 10
+        self.winl = 1000
+
+    def time_rolling_quantile_0(self):
+        (self.df.rolling(self.wins).quantile(0.0))
+
+    def time_rolling_quantile_1(self):
+        (self.df.rolling(self.wins).quantile(1.0))
+
+    def time_rolling_quantile_median(self):
+        (self.df.rolling(self.wins).quantile(0.5))
+
+    def time_rolling_median(self):
+        (self.df.rolling(self.wins).median())
+
+    def time_rolling_median(self):
+        (self.df.rolling(self.wins).mean())
+
+    def time_rolling_max(self):
+        (self.df.rolling(self.wins).max())
+
+    def time_rolling_min(self):
+        (self.df.rolling(self.wins).min())
+
+    def time_rolling_std(self):
+        (self.df.rolling(self.wins).std())
+
+    def time_rolling_count(self):
+        (self.df.rolling(self.wins).count())
+
+    def time_rolling_skew(self):
+        (self.df.rolling(self.wins).skew())
+
+    def time_rolling_kurt(self):
+        (self.df.rolling(self.wins).kurt())
+
+    def time_rolling_sum(self):
+        (self.df.rolling(self.wins).sum())
+
+    def time_rolling_corr(self):
+        (self.dfs.rolling(self.wins).corr())
+
+    def time_rolling_cov(self):
+        (self.dfs.rolling(self.wins).cov())
+        
+    def time_rolling_quantile_0_l(self):
+        (self.df.rolling(self.winl).quantile(0.0))
+
+    def time_rolling_quantile_1_l(self):
+        (self.df.rolling(self.winl).quantile(1.0))
+
+    def time_rolling_quantile_median_l(self):
+        (self.df.rolling(self.winl).quantile(0.5))
+
+    def time_rolling_median_l(self):
+        (self.df.rolling(self.winl).median())
+
+    def time_rolling_median_l(self):
+        (self.df.rolling(self.winl).mean())
+
+    def time_rolling_max_l(self):
+        (self.df.rolling(self.winl).max())
+
+    def time_rolling_min_l(self):
+        (self.df.rolling(self.winl).min())
+
+    def time_rolling_std_l(self):
+        (self.df.rolling(self.wins).std())
+
+    def time_rolling_count_l(self):
+        (self.df.rolling(self.wins).count())
+
+    def time_rolling_skew_l(self):
+        (self.df.rolling(self.wins).skew())
+
+    def time_rolling_kurt_l(self):
+        (self.df.rolling(self.wins).kurt())
+
+    def time_rolling_sum_l(self):
+        (self.df.rolling(self.wins).sum())
+
+
+class SeriesRolling(object):
+    goal_time = 0.2
+
+    def setup(self):
+        self.N = 100000
+        self.Ns = 10000
+        self.df = pd.DataFrame({'a': np.random.random(self.N)})
+        self.dfs = pd.DataFrame({'a': np.random.random(self.Ns)})
+        self.sr = self.df.a
+        self.srs = self.dfs.a
+        self.wins = 10
+        self.winl = 1000
+
+    def time_rolling_quantile_0(self):
+        (self.sr.rolling(self.wins).quantile(0.0))
+
+    def time_rolling_quantile_1(self):
+        (self.sr.rolling(self.wins).quantile(1.0))
+
+    def time_rolling_quantile_median(self):
+        (self.sr.rolling(self.wins).quantile(0.5))
+
+    def time_rolling_median(self):
+        (self.sr.rolling(self.wins).median())
+
+    def time_rolling_median(self):
+        (self.sr.rolling(self.wins).mean())
+
+    def time_rolling_max(self):
+        (self.sr.rolling(self.wins).max())
+
+    def time_rolling_min(self):
+        (self.sr.rolling(self.wins).min())
+
+    def time_rolling_std(self):
+        (self.sr.rolling(self.wins).std())
+
+    def time_rolling_count(self):
+        (self.sr.rolling(self.wins).count())
+
+    def time_rolling_skew(self):
+        (self.sr.rolling(self.wins).skew())
+
+    def time_rolling_kurt(self):
+        (self.sr.rolling(self.wins).kurt())
+
+    def time_rolling_sum(self):
+        (self.sr.rolling(self.wins).sum())
+
+    def time_rolling_corr(self):
+        (self.srs.rolling(self.wins).corr())
+
+    def time_rolling_cov(self):
+        (self.srs.rolling(self.wins).cov())
+        
+    def time_rolling_quantile_0_l(self):
+        (self.sr.rolling(self.winl).quantile(0.0))
+
+    def time_rolling_quantile_1_l(self):
+        (self.sr.rolling(self.winl).quantile(1.0))
+
+    def time_rolling_quantile_median_l(self):
+        (self.sr.rolling(self.winl).quantile(0.5))
+
+    def time_rolling_median_l(self):
+        (self.sr.rolling(self.winl).median())
+
+    def time_rolling_median_l(self):
+        (self.sr.rolling(self.winl).mean())
+
+    def time_rolling_max_l(self):
+        (self.sr.rolling(self.winl).max())
+
+    def time_rolling_min_l(self):
+        (self.sr.rolling(self.winl).min())
+
+    def time_rolling_std_l(self):
+        (self.sr.rolling(self.wins).std())
+
+    def time_rolling_count_l(self):
+        (self.sr.rolling(self.wins).count())
+
+    def time_rolling_skew_l(self):
+        (self.sr.rolling(self.wins).skew())
+
+    def time_rolling_kurt_l(self):
+        (self.sr.rolling(self.wins).kurt())
+
+    def time_rolling_sum_l(self):
+        (self.sr.rolling(self.wins).sum())

--- a/doc/source/whatsnew/v0.21.0.txt
+++ b/doc/source/whatsnew/v0.21.0.txt
@@ -189,6 +189,8 @@ Numeric
 Categorical
 ^^^^^^^^^^^
 
+- Bug in ``.rolling.quantile()`` which incorrectly used different defaults than Series.quantile() and DataFrame.quantile()
+
 
 Other
 ^^^^^

--- a/doc/source/whatsnew/v0.21.0.txt
+++ b/doc/source/whatsnew/v0.21.0.txt
@@ -167,9 +167,11 @@ Plotting
 
 Groupby/Resample/Rolling
 ^^^^^^^^^^^^^^^^^^^^^^^^
-- Bug in ``DataFrame.resample().size()`` where an empty ``DataFrame`` did not return a ``Series`` (:issue:`14962`)
 
+- Bug in ``DataFrame.resample().size()`` where an empty ``DataFrame`` did not return a ``Series`` (:issue:`14962`)
 - Bug in ``infer_freq`` causing indices with 2-day gaps during the working week to be wrongly inferred as business daily (:issue:`16624`)
+- Bug in ``.rolling.quantile()`` which incorrectly used different defaults than Series.quantile() and DataFrame.quantile()
+
 
 Sparse
 ^^^^^^
@@ -189,7 +191,6 @@ Numeric
 Categorical
 ^^^^^^^^^^^
 
-- Bug in ``.rolling.quantile()`` which incorrectly used different defaults than Series.quantile() and DataFrame.quantile()
 
 
 Other

--- a/doc/source/whatsnew/v0.21.0.txt
+++ b/doc/source/whatsnew/v0.21.0.txt
@@ -191,6 +191,7 @@ Numeric
 Categorical
 ^^^^^^^^^^^
 
+- Bug in ``.rolling.quantile()`` which incorrectly used different defaults than Series.quantile() and DataFrame.quantile()
 
 
 Other

--- a/doc/source/whatsnew/v0.21.0.txt
+++ b/doc/source/whatsnew/v0.21.0.txt
@@ -191,7 +191,6 @@ Numeric
 Categorical
 ^^^^^^^^^^^
 
-- Bug in ``.rolling.quantile()`` which incorrectly used different defaults than Series.quantile() and DataFrame.quantile()
 
 
 Other

--- a/doc/source/whatsnew/v0.21.0.txt
+++ b/doc/source/whatsnew/v0.21.0.txt
@@ -170,7 +170,7 @@ Groupby/Resample/Rolling
 
 - Bug in ``DataFrame.resample().size()`` where an empty ``DataFrame`` did not return a ``Series`` (:issue:`14962`)
 - Bug in ``infer_freq`` causing indices with 2-day gaps during the working week to be wrongly inferred as business daily (:issue:`16624`)
-- Bug in ``.rolling.quantile()`` which incorrectly used different defaults than Series.quantile() and DataFrame.quantile()
+- Bug in ``.rolling.quantile()`` which incorrectly used different defaults than :func:`Series.quantile()` and :func:`DataFrame.quantile()` (:issue:`9413`, :issue:`16211`)
 
 
 Sparse

--- a/pandas/_libs/window.pyx
+++ b/pandas/_libs/window.pyx
@@ -1350,7 +1350,7 @@ def roll_quantile(ndarray[float64_t, cast=True] input, int64_t win,
         ndarray[double_t] output
         double vlow, vhigh
 
-    if quantile < 0.0 or quantile > 1.0:
+    if quantile <= 0.0 or quantile >= 1.0:
         raise ValueError("quantile value {0} not in [0, 1]".format(quantile))
 
     # we use the Fixed/Variable Indexer here as the
@@ -1401,8 +1401,8 @@ def roll_quantile(ndarray[float64_t, cast=True] input, int64_t win,
             else:
                 vlow = skiplist.get(idx)
                 vhigh = skiplist.get(idx + 1)
-                output[i] = vlow + (vhigh - vlow) * \
-                            (quantile * (nobs - 1) - idx)
+                output[i] = (vlow + (vhigh - vlow) *
+                                 (quantile * (nobs - 1) - idx))
         else:
             output[i] = NaN
 

--- a/pandas/_libs/window.pyx
+++ b/pandas/_libs/window.pyx
@@ -1348,7 +1348,7 @@ def roll_quantile(ndarray[float64_t, cast=True] input, int64_t win,
         bint is_variable
         ndarray[int64_t] start, end
         ndarray[double_t] output
-        double qlow, qhigh, vlow, vhigh
+        double vlow, vhigh
 
     if quantile < 0.0 or quantile > 1.0:
         raise ValueError("quantile value {0} not in [0, 1]".format(quantile))
@@ -1393,18 +1393,16 @@ def roll_quantile(ndarray[float64_t, cast=True] input, int64_t win,
         if nobs >= minp:
             idx = int(quantile * <double>(nobs - 1))
 
-            # Exactly last point
-            if idx == nobs - 1:
-                output[i] = skiplist.get(idx)
+            # Single value in skip list
+            if nobs == 1:
+                output[i] = skiplist.get(0)
 
             # Interpolated quantile
             else:
-                qlow = (<double> idx) / (<double>(nobs - 1))
-                qhigh = (<double> (idx + 1)) / (<double>(nobs - 1))
                 vlow = skiplist.get(idx)
                 vhigh = skiplist.get(idx + 1)
                 output[i] = vlow + (vhigh - vlow) * \
-                    (quantile - qlow) / (qhigh - qlow)
+                            (quantile * (nobs - 1) - idx)
         else:
             output[i] = NaN
 

--- a/pandas/_libs/window.pyx
+++ b/pandas/_libs/window.pyx
@@ -1348,6 +1348,7 @@ def roll_quantile(ndarray[float64_t, cast=True] input, int64_t win,
         bint is_variable
         ndarray[int64_t] start, end
         ndarray[double_t] output
+        double qlow, qhigh, vlow, vhigh
 
     if quantile < 0.0 or quantile > 1.0:
         raise ValueError("quantile value {0} not in [0, 1]".format(quantile))
@@ -1391,7 +1392,19 @@ def roll_quantile(ndarray[float64_t, cast=True] input, int64_t win,
 
         if nobs >= minp:
             idx = int(quantile * <double>(nobs - 1))
-            output[i] = skiplist.get(idx)
+
+            # Exactly last point
+            if idx == nobs - 1:
+                output[i] = skiplist.get(idx)
+
+            # Interpolated quantile
+            else:
+                qlow = (<double> idx) / (<double>(nobs - 1))
+                qhigh = (<double> (idx + 1)) / (<double>(nobs - 1))
+                vlow = skiplist.get(idx)
+                vhigh = skiplist.get(idx + 1)
+                output[i] = vlow + (vhigh - vlow) * \
+                    (quantile - qlow) / (qhigh - qlow)
         else:
             output[i] = NaN
 

--- a/pandas/core/window.py
+++ b/pandas/core/window.py
@@ -975,8 +975,15 @@ class _Rolling_and_Expanding(_Rolling):
 
         def f(arg, *args, **kwargs):
             minp = _use_window(self.min_periods, window)
-            return _window.roll_quantile(arg, window, minp, indexi,
-                                         self.closed, quantile)
+            if quantile == 1.0:
+                return _window.roll_max(arg, window, minp, indexi,
+                                        self.closed)
+            elif quantile == 0.0:
+                return _window.roll_min(arg, window, minp, indexi,
+                                        self.closed)
+            else:
+                return _window.roll_quantile(arg, window, minp, indexi,
+                                             self.closed, quantile)
 
         return self._apply(f, 'quantile', quantile=quantile,
                            **kwargs)

--- a/pandas/tests/test_window.py
+++ b/pandas/tests/test_window.py
@@ -1151,7 +1151,7 @@ class TestMoments(Base):
 
     def test_rolling_quantile_np_percentile(self):
         # #9413: Tests that rolling window's quantile default behavior
-        # is analogus to Numpy's percentile 
+        # is analogus to Numpy's percentile
         row = 10
         col = 5
         idx = pd.date_range(20100101, periods=row, freq='B')

--- a/pandas/tests/test_window.py
+++ b/pandas/tests/test_window.py
@@ -1150,7 +1150,8 @@ class TestMoments(Base):
             self._check_moment_func(f, alt, name='quantile', quantile=q)
 
     def test_rolling_quantile_np_percentile(self):
-        # #9413
+        # #9413: Tests that rolling window's quantile default behavior
+        # is analogus to Numpy's percentile 
         row = 10
         col = 5
         idx = pd.date_range(20100101, periods=row, freq='B')
@@ -1163,7 +1164,8 @@ class TestMoments(Base):
         tm.assert_almost_equal(df_quantile.values, np.array(np_percentile))
 
     def test_rolling_quantile_series(self):
-        # #16211
+        # #16211: Tests that rolling window's quantile default behavior
+        # is analogus to pd.Series' quantile
         arr = np.arange(100)
         s = pd.Series(arr)
         q1 = s.quantile(0.1)


### PR DESCRIPTION
Now computing the quantile of a rolling window matches the default of the rolling method in Series, DataFrame and np.percentile.

Fixes bugs #9413 and #16211

 - [x] closes #9413
 - [x] tests added / passed
 - [x] passes ``git diff upstream/master --name-only -- '*.py' | flake8 --diff``
 - [x] whatsnew entry
