### PR TITLE
DOC: add read_gbq as top-level in api.rst

### DIFF
--- a/doc/source/api.rst
+++ b/doc/source/api.rst
@@ -128,15 +128,11 @@ SQL
 
 Google BigQuery
 ~~~~~~~~~~~~~~~
-.. currentmodule:: pandas.io.gbq
 
 .. autosummary::
    :toctree: generated/
 
    read_gbq
-
-
-.. currentmodule:: pandas
 
 
 STATA

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -243,6 +243,7 @@ moved_api_pages = [
     ('pandas.io.clipboard.read_clipboard', 'pandas.read_clipboard'),
     ('pandas.io.excel.ExcelFile.parse', 'pandas.ExcelFile.parse'),
     ('pandas.io.excel.read_excel', 'pandas.read_excel'),
+    ('pandas.io.gbq.read_gbq', 'pandas.read_gbq'),
     ('pandas.io.html.read_html', 'pandas.read_html'),
     ('pandas.io.json.read_json', 'pandas.read_json'),
     ('pandas.io.parsers.read_csv', 'pandas.read_csv'),


### PR DESCRIPTION
Noticed that the link to the top-level one did not work in the whatsnew file