### PR TITLE
DOC: tm.assert_almost_equal() check_exact param defaults to False in code & docstring

### DIFF
--- a/pandas/util/testing.py
+++ b/pandas/util/testing.py
@@ -127,7 +127,7 @@ def assert_almost_equal(left, right, check_exact=False,
     ----------
     left : object
     right : object
-    check_exact : bool, default True
+    check_exact : bool, default False
         Whether to compare number exactly.
     check_dtype: bool, default True
         check dtype if both a and b are the same type


### PR DESCRIPTION
 - [x] passes ``git diff upstream/master --name-only -- '*.py' | flake8 --diff``

Parameter ```check_exact``` defaults to ```False``` whereas the docstring indicated ```True```. 
