### PR TITLE
Fix in date conversion param handling

### DIFF
--- a/pandas/io/stata.py
+++ b/pandas/io/stata.py
@@ -2059,7 +2059,7 @@ class StataWriter(StataParser):
         # Check date conversion, and fix key if needed
         if self._convert_dates:
             for c, o in zip(columns, original_columns):
-                if c != o:
+                if o in self._convert_dates and c != o:
                     self._convert_dates[c] = self._convert_dates[o]
                     del self._convert_dates[o]
 


### PR DESCRIPTION
Previously this was trying to update any column name that had changed in `self._convert_dates`. If you had a column name that was non-date that was being changed, it would throw an error.

 - [ ] closes #xxxx
 - [ ] tests added / passed
 - [ ] passes ``git diff upstream/master --name-only -- '*.py' | flake8 --diff``
 - [ ] whatsnew entry
