### PR TITLE
BUG fixed broken link re GH16279

### DIFF
--- a/doc/source/style.ipynb
+++ b/doc/source/style.ipynb
@@ -12,7 +12,7 @@
     "\n",
     "<span style=\"color: red\">*Provisional: This is a new feature and still under development. We'll be adding features and possibly making breaking changes in future releases. We'd love to hear your feedback.*</span>\n",
     "\n",
-    "This document is written as a Jupyter Notebook, and can be viewed or downloaded [here](http://nbviewer.ipython.org/github/pandas-dev/pandas/blob/master/doc/source/html-styling.ipynb).\n",
+    "This document is written as a Jupyter Notebook, and can be viewed or downloaded [here](http://nbviewer.ipython.org/github/pandas-dev/pandas/blob/master/doc/source/style.ipynb).\n",
     "\n",
     "You can apply **conditional formatting**, the visual styling of a DataFrame\n",
     "depending on the data within, by using the ``DataFrame.style`` property.\n",


### PR DESCRIPTION
GH16279

http://nbviewer.jupyter.org/github/pandas-dev/pandas/blob/master/doc/source/html-styling.ipynb gives 404, changed to
http://nbviewer.ipython.org/github/pandas-dev/pandas/blob/master/doc/source/style.ipynb

 - [ ] closes #16279
 - [ ] tests added / passed
 - [ ] passes ``git diff upstream/master --name-only -- '*.py' | flake8 --diff``
 - [ ] whatsnew entry
