### PR TITLE
BUG: select_as_multiple doesn't respect start/stop kwargs GH16209

### DIFF
--- a/doc/source/whatsnew/v0.20.2.txt
+++ b/doc/source/whatsnew/v0.20.2.txt
@@ -51,6 +51,7 @@ I/O
 
 - Bug that would force importing of the clipboard routines unnecessarily, potentially causing an import error on startup (:issue:`16288`)
 
+- Bug in ``HDFStore.select_as_multiple()`` where start/stop arguments were not respected (:issue:`16209`)
 
 Plotting
 ^^^^^^^^

--- a/doc/source/whatsnew/v0.21.0.txt
+++ b/doc/source/whatsnew/v0.21.0.txt
@@ -82,7 +82,6 @@ Indexing
 I/O
 ^^^
 
-- Bug in ``HDFStore.select_as_multiple()`` where start/stop arguments were not respected (:issue:`16209`)
 
 
 Plotting

--- a/doc/source/whatsnew/v0.21.0.txt
+++ b/doc/source/whatsnew/v0.21.0.txt
@@ -82,6 +82,7 @@ Indexing
 I/O
 ^^^
 
+- Bug in ``HDFStore.select_as_multiple()`` where start/stop arguments were not respected (:issue:`16209`)
 
 
 Plotting

--- a/pandas/io/pytables.py
+++ b/pandas/io/pytables.py
@@ -826,8 +826,8 @@ class HDFStore(StringMixin):
 
             # retrieve the objs, _where is always passed as a set of
             # coordinates here
-            objs = [t.read(where=_where, columns=columns, **kwargs)
-                    for t in tbls]
+            objs = [t.read(where=_where, columns=columns, start=_start,
+                           stop=_stop, **kwargs) for t in tbls]
 
             # concat and return
             return concat(objs, axis=axis,
@@ -1420,7 +1420,8 @@ class TableIterator(object):
 
         # if specified read via coordinates (necessary for multiple selections
         if coordinates:
-            where = self.s.read_coordinates(where=self.where)
+            where = self.s.read_coordinates(where=self.where, start=self.start,
+                                            stop=self.stop)
         else:
             where = self.where
 

--- a/pandas/tests/io/test_pytables.py
+++ b/pandas/tests/io/test_pytables.py
@@ -4186,6 +4186,20 @@ class TestHDFStore(Base):
             expected = df.loc[30:40, ['A']]
             tm.assert_frame_equal(result, expected)
 
+    def test_start_stop_multiple(self):
+
+        with ensure_clean_store(self.path) as store:
+
+            df = DataFrame({"foo": [1, 2], "bar": [1, 2]})
+
+            store.append_to_multiple({'selector': ['foo'], 'data': None}, df,
+                                     selector='selector')
+            result = store.select_as_multiple(['selector', 'data'],
+                                              selector='selector', start=0,
+                                              stop=1)
+            expected = df[['foo', 'bar']].iloc[[0]]
+            tm.assert_frame_equal(result, expected)
+
     def test_start_stop_fixed(self):
 
         with ensure_clean_store(self.path) as store:

--- a/pandas/tests/io/test_pytables.py
+++ b/pandas/tests/io/test_pytables.py
@@ -4188,6 +4188,7 @@ class TestHDFStore(Base):
 
     def test_start_stop_multiple(self):
 
+        # GH 16209
         with ensure_clean_store(self.path) as store:
 
             df = DataFrame({"foo": [1, 2], "bar": [1, 2]})
@@ -4197,7 +4198,7 @@ class TestHDFStore(Base):
             result = store.select_as_multiple(['selector', 'data'],
                                               selector='selector', start=0,
                                               stop=1)
-            expected = df[['foo', 'bar']].iloc[[0]]
+            expected = df.loc[[0], ['foo', 'bar']]
             tm.assert_frame_equal(result, expected)
 
     def test_start_stop_fixed(self):


### PR DESCRIPTION
 - [x] closes #16209
 - [x] tests added / passed
 - [x] passes ``git diff upstream/master --name-only -- '*.py' | flake8 --diff``
 - [x] whatsnew entry
