### PR TITLE
Feature/get dotted columns by prefix

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -77,7 +77,8 @@ import pandas.core.computation.expressions as expressions
 import pandas.core.algorithms as algorithms
 from pandas.core.computation.eval import eval as _eval
 from pandas.compat import (range, map, zip, lrange, lmap, lzip, StringIO, u,
-                           OrderedDict, raise_with_traceback)
+                           string_types, OrderedDict, raise_with_traceback,
+                           isidentifier)
 from pandas import compat
 from pandas.compat.numpy import function as nv
 from pandas.util._decorators import Appender, Substitution
@@ -629,6 +630,12 @@ class DataFrame(NDFrame):
             return self.to_latex()
         else:
             return None
+
+    def _dir_additions(self):
+        """ add the string-like attributes from the info_axis """
+        return set([c.split('.')[0] for c in self._info_axis
+                    if isinstance(c, string_types) and
+                    isidentifier(c.split('.')[0])])
 
     @property
     def style(self):
@@ -1891,6 +1898,20 @@ it is assumed to be aliases for the column names.')
             dm = dm.join(objects)
 
         self._data = dm._data
+
+    # ----------------------------------------------------------------------
+    # Attribute access
+
+    def __getattr__(self, key):
+        try:
+            return super(DataFrame, self).__getattr__(key)
+        except AttributeError:
+            cols = [x for x in self.columns if x.startswith(key + '.')]
+            if len(cols):
+                return self[cols].rename_axis(
+                    lambda x: x[len(key + '.'):], axis=1)
+            else:
+                raise
 
     # ----------------------------------------------------------------------
     # Getting and setting elements

--- a/pandas/tests/frame/test_api.py
+++ b/pandas/tests/frame/test_api.py
@@ -99,6 +99,30 @@ class TestDataFrameMisc(SharedWithSparse, TestData):
         tm.assert_raises_regex(ValueError, 'No axis named',
                                f._get_axis_number, None)
 
+    def test_attribute_indexing(self):
+        df = pd.DataFrame(np.ones((4,3)),
+                          columns=['foo.bar', 'bar.foo.foo', 'bar.foo.bar'])
+
+        # Test access to df.foo -> DataFrame
+        df_foo = pd.DataFrame(np.ones((4,1)), columns=['bar'])
+        pd.util.testing.assert_frame_equal(df_foo, df.foo)
+
+        # Test access to df.bar -> Series
+        df_foo_bar = pd.Series(np.ones((4,)), name='bar')
+        pd.util.testing.assert_series_equal(df_foo_bar, df.foo.bar)
+
+        # Test access to df.bar -> DataFrame
+        df_bar = pd.DataFrame(np.ones((4,2)), columns=['foo.foo', 'foo.bar'])
+        pd.util.testing.assert_frame_equal(df_bar, df.bar)
+
+        # Test access to df.bar.foo -> DataFrame
+        df_bar_foo = pd.DataFrame(np.ones((4,2)), columns=['foo', 'bar'])
+        pd.util.testing.assert_frame_equal(df_bar_foo, df.bar.foo)
+
+        # Test access to df.bar.foo.foo -> Series
+        df_bar_foo_foo = pd.Series(np.ones((4,)), name='foo')
+        pd.util.testing.assert_series_equal(df_bar_foo_foo, df.bar.foo.foo)
+
     def test_keys(self):
         getkeys = self.frame.keys
         assert getkeys() is self.frame.columns


### PR DESCRIPTION
 - [ ] closes #xxxx
 - [x] tests added / passed
 - [x] passes ``git diff upstream/master --name-only -- '*.py' | flake8 --diff``
 - [ ] whatsnew entry

Assuming a DataFrame like this:
```
>> df
    foo  bar.foo  bar.bar
0  0.32     0.15     0.45
1  0.62     0.73     0.36
2  0.21     0.68     0.10
3  0.05     0.36     0.90
```

one can access to `df['foo']` with the shortcut `df.foo`.

This PR extends this idea to column names containing dots, so that `df.bar` yields:

```
>> df.bar
    foo   bar
0  0.15  0.45
1  0.73  0.36
2  0.68  0.10
3  0.36  0.90
```

I'm new to contributing in pandas: so I need a few help:

* Do I need to create an issue to *host* the PR ?
* Where in the docs should I host explainations about this ?

Thanks in advance (and pandas is awesome btw !)