### PR TITLE
Correctly redirect to SetupTools documentations

### DIFF
--- a/doc/source/install.rst
+++ b/doc/source/install.rst
@@ -202,7 +202,7 @@ installed), make sure you have `pytest
 Dependencies
 ------------
 
-* `setuptools <http://pythonhosted.org/setuptools>`__
+* `setuptools <https://setuptools.readthedocs.io/en/latest/>`__
 * `NumPy <http://www.numpy.org>`__: 1.7.1 or higher
 * `python-dateutil <http://labix.org/python-dateutil>`__: 1.5 or higher
 * `pytz <http://pytz.sourceforge.net/>`__: Needed for time zone support


### PR DESCRIPTION
 - [x] closes #16332
 - [x] tests added / passed
 - [ ] passes ``git diff upstream/master --name-only -- '*.py' | flake8 --diff``
 - [x] Correct doc string from http://pythonhosted.org/setuptools to https://setuptools.readthedocs.io/en/latest
