### PR TITLE
BUG: Categorical comparison with unordered

### DIFF
--- a/doc/source/categorical.rst
+++ b/doc/source/categorical.rst
@@ -453,6 +453,14 @@ the original values:
 
     np.asarray(cat) > base
 
+When you compare two unordered categoricals with the same categories, the order is not considered:
+
+.. ipython:: python
+
+   c1 = pd.Categorical(['a', 'b'], categories=['a', 'b'], ordered=False)
+   c2 = pd.Categorical(['a', 'b'], categories=['b', 'a'], ordered=False)
+   c1 == c2
+
 Operations
 ----------
 

--- a/doc/source/whatsnew/v0.20.2.txt
+++ b/doc/source/whatsnew/v0.20.2.txt
@@ -85,7 +85,10 @@ Numeric
 ^^^^^^^
 
 
+Categorical
+^^^^^^^^^^^
 
+- Fixed comparison operations considering the order of the categories when both categoricals are unordered (:issue:`16014`)
 
 Other
 ^^^^^

--- a/pandas/core/categorical.py
+++ b/pandas/core/categorical.py
@@ -55,17 +55,31 @@ def _cat_compare_op(op):
                                 "equality or not")
         if isinstance(other, Categorical):
             # Two Categoricals can only be be compared if the categories are
-            # the same
-            if ((len(self.categories) != len(other.categories)) or
-                    not ((self.categories == other.categories).all())):
-                raise TypeError("Categoricals can only be compared if "
-                                "'categories' are the same")
+            # the same (maybe up to ordering, depending on ordered)
+
+            msg = ("Categoricals can only be compared if "
+                   "'categories' are the same.")
+            if len(self.categories) != len(other.categories):
+                raise TypeError(msg + " Categories are different lengths")
+            elif (self.ordered and not (self.categories ==
+                                        other.categories).all()):
+                raise TypeError(msg)
+            elif not set(self.categories) == set(other.categories):
+                raise TypeError(msg)
+
             if not (self.ordered == other.ordered):
                 raise TypeError("Categoricals can only be compared if "
                                 "'ordered' is the same")
-            na_mask = (self._codes == -1) | (other._codes == -1)
+            if not self.ordered and not self.categories.equals(
+                    other.categories):
+                # both unordered and different order
+                other_codes = _get_codes_for_values(other, self.categories)
+            else:
+                other_codes = other._codes
+
+            na_mask = (self._codes == -1) | (other_codes == -1)
             f = getattr(self._codes, op)
-            ret = f(other._codes)
+            ret = f(other_codes)
             if na_mask.any():
                 # In other series, the leads to False, so do that here too
                 ret[na_mask] = False


### PR DESCRIPTION
Fixes categorical comparison operations improperly considering
ordering when two unordered categoricals are compared.

Closes #16014