### PR TITLE
BUG: Categorical constructor scalar categories

### DIFF
--- a/doc/source/whatsnew/v0.21.0.txt
+++ b/doc/source/whatsnew/v0.21.0.txt
@@ -36,6 +36,8 @@ Backwards incompatible API changes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 - Support has been dropped for Python 3.4 (:issue:`15251`)
+- The Categorical constructor no longer accepts a scalar for the ``categories`` keyword. (:issue:`16022`)
+
 
 .. _whatsnew_0210.api:
 
@@ -112,7 +114,6 @@ Numeric
 Categorical
 ^^^^^^^^^^^
 
-- The Categorical constructor no longer accepts a scalar for the ``categories`` keyword (:issue:`16022`)
 
 Other
 ^^^^^

--- a/doc/source/whatsnew/v0.21.0.txt
+++ b/doc/source/whatsnew/v0.21.0.txt
@@ -109,6 +109,10 @@ Numeric
 ^^^^^^^
 
 
+Categorical
+^^^^^^^^^^^
+
+- The Categorical constructor no longer accepts a scalar for the ``categories`` keyword (:issue:`16022`)
 
 Other
 ^^^^^

--- a/pandas/core/categorical.py
+++ b/pandas/core/categorical.py
@@ -533,6 +533,9 @@ class Categorical(PandasObject):
         if not isinstance(categories, ABCIndexClass):
             dtype = None
             if not hasattr(categories, "dtype"):
+                if not is_list_like(categories):
+                    raise TypeError("`categories` must be list-like. "
+                                    "Got {} instead".format(repr(categories)))
                 categories = _convert_to_list_like(categories)
                 # On categories with NaNs, int values would be converted to
                 # float. Use "object" dtype to prevent this.

--- a/pandas/tests/test_categorical.py
+++ b/pandas/tests/test_categorical.py
@@ -256,12 +256,6 @@ class TestCategorical(object):
         assert len(cat.codes) == 1
         assert cat.codes[0] == 0
 
-        cat = pd.Categorical([1], categories=1)
-        assert len(cat.categories) == 1
-        assert cat.categories[0] == 1
-        assert len(cat.codes) == 1
-        assert cat.codes[0] == 0
-
         # Catch old style constructor useage: two arrays, codes + categories
         # We can only catch two cases:
         #  - when the first is an integer dtype and the second is not
@@ -284,6 +278,11 @@ class TestCategorical(object):
         with tm.assert_produces_warning(None):
             c = Categorical(np.array([], dtype='int64'),  # noqa
                             categories=[3, 2, 1], ordered=True)
+
+    def test_constructor_not_sequence(self):
+        # https://github.com/pandas-dev/pandas/issues/16022
+        with pytest.raises(TypeError):
+            Categorical(['a', 'b'], categories='a')
 
     def test_constructor_with_null(self):
 


### PR DESCRIPTION
Categorical constructor no longer accepts scalars for categories.

Closes #16022