### PR TITLE
DOC: minor enhancement of DataFrame.insert docstring

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -2559,17 +2559,17 @@ it is assumed to be aliases for the column names.')
         """
         Insert column into DataFrame at specified location.
 
-        If `allow_duplicates` is False, raises Exception if column
-        is already contained in the DataFrame.
+        Raises a ValueError if `column` is already contained in the DataFrame,
+        unless `allow_duplicates` is set to True.
 
         Parameters
         ----------
         loc : int
             Insertion index. Must verify 0 <= loc <= len(columns)
         column : string, number, or hashable object
-            label of the column
-        value : scalar, Series, or array-like
-        allow_duplicates : bool
+            label of the inserted column
+        value : int, Series, or array-like
+        allow_duplicates : bool, optional
         """
         self._ensure_valid_index(value)
         value = self._sanitize_column(column, value, broadcast=False)

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -2565,9 +2565,11 @@ it is assumed to be aliases for the column names.')
         Parameters
         ----------
         loc : int
-            Must have 0 <= loc <= len(columns)
-        column : object
+            Insertion index. Must verify 0 <= loc <= len(columns)
+        column : string, number, or hashable object
+            label of the column
         value : scalar, Series, or array-like
+        allow_duplicates : bool
         """
         self._ensure_valid_index(value)
         value = self._sanitize_column(column, value, broadcast=False)


### PR DESCRIPTION
 - [x] passes ``git diff upstream/master --name-only -- '*.py' | flake8 --diff`` (but not clear to me if I did properly, because the first of the pipe only reports the filename of the changed file, no actual diff.)

My first objective was to clarify the role of `column` vs `value` keyword.

For the reference, this is how this function is documented on http://stackoverflow.com/a/18674915/2822346. Function call is presented as `df.insert(idx, col_name, value)`. I find the `col_name` slightly more explicit than just `column`, which is ambiguous (i.e. "does column holds the Series?"). But of course this name cannot change without breaking the API. So this small PR is just an attempt to clarify things.

Since I was touching the docstring, I've also make it a bit more tidy (e.g. removed a too long line).






