### PR TITLE
PERF: improve MultiIndex get_loc performance

### DIFF
--- a/asv_bench/benchmarks/indexing.py
+++ b/asv_bench/benchmarks/indexing.py
@@ -227,11 +227,23 @@ class MultiIndexing(object):
     def time_multiindex_large_get_loc(self):
         self.mi_large.get_loc((999, 19, 'Z'))
 
+    def time_multiindex_large_get_loc_warm(self):
+        for _ in range(1000):
+            self.mi_large.get_loc((999, 19, 'Z'))
+
     def time_multiindex_med_get_loc(self):
         self.mi_med.get_loc((999, 9, 'A'))
 
+    def time_multiindex_med_get_loc_warm(self):
+        for _ in range(1000):
+            self.mi_med.get_loc((999, 9, 'A'))
+
     def time_multiindex_string_get_loc(self):
         self.mi_small.get_loc((99, 'A', 'A'))
+
+    def time_multiindex_small_get_loc_warm(self):
+        for _ in range(1000):
+            self.mi_small.get_loc((99, 'A', 'A'))
 
     def time_is_monotonic(self):
         self.miint.is_monotonic

--- a/doc/source/whatsnew/v0.20.2.txt
+++ b/doc/source/whatsnew/v0.20.2.txt
@@ -27,8 +27,9 @@ Performance Improvements
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
 - Performance regression fix when indexing with a list-like (:issue:`16285`)
-- Performance regression fix for small MultiIndexes (:issuse:`16319`)
+- Performance regression fix for MultiIndexes (:issue:`16319`, :issue:`16346`)
 - Improved performance of ``.clip()`` with scalar arguments (:issue:`15400`)
+
 
 .. _whatsnew_0202.bug_fixes:
 

--- a/pandas/_libs/hashtable.pxd
+++ b/pandas/_libs/hashtable.pxd
@@ -38,6 +38,8 @@ cdef class MultiIndexHashTable(HashTable):
 
     cpdef get_item(self, object val)
     cpdef set_item(self, object key, Py_ssize_t val)
+    cdef inline void _check_for_collision(self, Py_ssize_t loc, object label)
+
 
 cdef class StringHashTable(HashTable):
     cdef kh_str_t *table

--- a/pandas/_libs/hashtable_class_helper.pxi.in
+++ b/pandas/_libs/hashtable_class_helper.pxi.in
@@ -4,7 +4,8 @@ Template for each `dtype` helper function for hashtable
 WARNING: DO NOT edit .pxi FILE directly, .pxi is generated from .pxi.in
 """
 
-from pandas.core.dtypes.missing import array_equivalent
+from lib cimport is_null_datetimelike
+
 
 #----------------------------------------------------------------------
 # VectorData
@@ -923,12 +924,15 @@ cdef class MultiIndexHashTable(HashTable):
                     "hash collision\nlocs:\n{}\n"
                     "result:\n{}\nmi:\n{}".format(alocs, result, mi))
 
-    def _check_for_collision(self, Py_ssize_t loc, object label):
+    cdef inline void _check_for_collision(self, Py_ssize_t loc, object label):
         # validate that the loc maps to the actual value
         # version of _check_for_collisions above for single label (tuple)
 
         result = self.mi[loc]
-        if not array_equivalent(result, label):
+
+        if not all(l == r or (is_null_datetimelike(l)
+                              and is_null_datetimelike(r))
+                   for l, r in zip(result, label)):
             raise AssertionError(
                 "hash collision\nloc:\n{}\n"
                 "result:\n{}\nmi:\n{}".format(loc, result, label))

--- a/pandas/_libs/hashtable_class_helper.pxi.in
+++ b/pandas/_libs/hashtable_class_helper.pxi.in
@@ -4,6 +4,8 @@ Template for each `dtype` helper function for hashtable
 WARNING: DO NOT edit .pxi FILE directly, .pxi is generated from .pxi.in
 """
 
+from pandas.core.dtypes.missing import array_equivalent
+
 #----------------------------------------------------------------------
 # VectorData
 #----------------------------------------------------------------------
@@ -921,6 +923,16 @@ cdef class MultiIndexHashTable(HashTable):
                     "hash collision\nlocs:\n{}\n"
                     "result:\n{}\nmi:\n{}".format(alocs, result, mi))
 
+    def _check_for_collision(self, Py_ssize_t loc, object label):
+        # validate that the loc maps to the actual value
+        # version of _check_for_collisions above for single label (tuple)
+
+        result = self.mi[loc]
+        if not array_equivalent(result, label):
+            raise AssertionError(
+                "hash collision\nloc:\n{}\n"
+                "result:\n{}\nmi:\n{}".format(loc, result, label))
+
     def __contains__(self, object key):
         try:
             self.get_item(key)
@@ -939,8 +951,7 @@ cdef class MultiIndexHashTable(HashTable):
         k = kh_get_uint64(self.table, value)
         if k != self.table.n_buckets:
             loc = self.table.vals[k]
-            locs = np.array([loc], dtype=np.int64)
-            self._check_for_collisions(locs, key)
+            self._check_for_collision(loc, key)
             return loc
         else:
             raise KeyError(key)

--- a/pandas/core/dtypes/cast.py
+++ b/pandas/core/dtypes/cast.py
@@ -333,7 +333,7 @@ def maybe_promote(dtype, fill_value=np.nan):
     return dtype, fill_value
 
 
-def infer_dtype_from_scalar(val, pandas_dtype=False, use_datetimetz=True):
+def infer_dtype_from_scalar(val, pandas_dtype=False):
     """
     interpret the dtype from a scalar
 
@@ -368,7 +368,7 @@ def infer_dtype_from_scalar(val, pandas_dtype=False, use_datetimetz=True):
 
     elif isinstance(val, (np.datetime64, datetime)):
         val = tslib.Timestamp(val)
-        if val is tslib.NaT or val.tz is None or not use_datetimetz:
+        if val is tslib.NaT or val.tz is None:
             dtype = np.dtype('M8[ns]')
         else:
             if pandas_dtype:

--- a/pandas/core/dtypes/cast.py
+++ b/pandas/core/dtypes/cast.py
@@ -333,7 +333,7 @@ def maybe_promote(dtype, fill_value=np.nan):
     return dtype, fill_value
 
 
-def infer_dtype_from_scalar(val, pandas_dtype=False):
+def infer_dtype_from_scalar(val, pandas_dtype=False, use_datetimetz=True):
     """
     interpret the dtype from a scalar
 
@@ -368,7 +368,7 @@ def infer_dtype_from_scalar(val, pandas_dtype=False):
 
     elif isinstance(val, (np.datetime64, datetime)):
         val = tslib.Timestamp(val)
-        if val is tslib.NaT or val.tz is None:
+        if val is tslib.NaT or val.tz is None or not use_datetimetz:
             dtype = np.dtype('M8[ns]')
         else:
             if pandas_dtype:

--- a/pandas/core/indexes/multi.py
+++ b/pandas/core/indexes/multi.py
@@ -748,7 +748,7 @@ class MultiIndex(Index):
         we need to stringify if we have mixed levels
 
         """
-        from pandas.core.util.hashing import hash_tuples
+        from pandas.core.util.hashing import hash_tuples, hash_tuple
 
         if not isinstance(key, tuple):
             return hash_tuples(key)
@@ -762,7 +762,7 @@ class MultiIndex(Index):
             return k
         key = tuple([f(k, stringify)
                      for k, stringify in zip(key, self._have_mixed_levels)])
-        return hash_tuples(key)
+        return hash_tuple(key)
 
     @Appender(base._shared_docs['duplicated'] % _index_doc_kwargs)
     def duplicated(self, keep='first'):

--- a/pandas/core/util/hashing.py
+++ b/pandas/core/util/hashing.py
@@ -5,6 +5,7 @@ import itertools
 
 import numpy as np
 from pandas._libs import hashing
+from pandas.compat import string_and_binary_types, text_type
 from pandas.core.dtypes.generic import (
     ABCMultiIndex,
     ABCIndexClass,
@@ -12,6 +13,8 @@ from pandas.core.dtypes.generic import (
     ABCDataFrame)
 from pandas.core.dtypes.common import (
     is_categorical_dtype, is_list_like)
+from pandas.core.dtypes.missing import isnull
+
 
 # 16 byte long hashing key
 _default_hash_key = '0123456789123456'
@@ -179,9 +182,17 @@ def hash_tuple(val, encoding='utf8', hash_key=None):
     hash
 
     """
-    hashes = (hash_array(np.array([v]), encoding=encoding, hash_key=hash_key,
-                         categorize=False)
+    #def to_array(v):
+    #    dtype, arr = infer_dtype_from_array([v])
+    #    return np.asarray(arr, dtype=dtype)
+
+    #hashes = (hash_array(to_array(v), encoding=encoding, hash_key=hash_key,
+    #                     categorize=False)
+    #          for v in val)
+
+    hashes = (_hash_scalar(v, encoding=encoding, hash_key=hash_key)
               for v in val)
+
     h = _combine_hash_arrays(hashes, len(val))[0]
 
     return h
@@ -291,6 +302,66 @@ def hash_array(vals, encoding='utf8', hash_key=None, categorize=True):
             # we have mixed types
             vals = hashing.hash_object_array(vals.astype(str).astype(object),
                                              hash_key, encoding)
+
+    # Then, redistribute these 64-bit ints within the space of 64-bit ints
+    vals ^= vals >> 30
+    vals *= np.uint64(0xbf58476d1ce4e5b9)
+    vals ^= vals >> 27
+    vals *= np.uint64(0x94d049bb133111eb)
+    vals ^= vals >> 31
+    return vals
+
+
+def _hash_scalar(val, encoding='utf8', hash_key=None):
+    """
+    Hash scalar value
+
+    Returns
+    -------
+    1d uint64 numpy array of hash value, of length 1
+    """
+
+    if hash_key is None:
+        hash_key = _default_hash_key
+
+    if isnull(val):
+        # this is to be consistent with the _hash_categorical implementation
+        return np.array([np.iinfo(np.uint64).max], dtype='u8')
+
+    if isinstance(val, string_and_binary_types + (text_type,)):
+        vals = np.array([val], dtype=object)
+        string_like = True
+    else:
+        vals = np.array([val])
+        string_like = False
+
+    dtype = vals.dtype
+
+    #dtype, vals = infer_dtype_from_array([vals])
+    #if dtype == np.object_:
+    #    vals = np.asarray(vals, dtype='object')
+    #    dtype = vals.dtype
+
+    # we'll be working with everything as 64-bit values, so handle this
+    # 128-bit value early
+    if np.issubdtype(dtype, np.complex128):
+        return hash_array(vals.real) + 23 * hash_array(vals.imag)
+
+    # First, turn whatever array this is into unsigned 64-bit ints, if we can
+    # manage it.
+    elif isinstance(dtype, np.bool):
+        vals = vals.astype('u8')
+    elif issubclass(dtype.type, (np.datetime64, np.timedelta64)):
+        vals = vals.view('i8').astype('u8', copy=False)
+    elif issubclass(dtype.type, np.number) and dtype.itemsize <= 8:
+        vals = vals.view('u{}'.format(vals.dtype.itemsize)).astype('u8')
+    else:
+        if not string_like:
+            from pandas import Index
+            vals = Index(vals).values
+            return hash_array(vals, hash_key=hash_key, encoding=encoding,
+                              categorize=False)
+        vals = hashing.hash_object_array(vals, hash_key, encoding)
 
     # Then, redistribute these 64-bit ints within the space of 64-bit ints
     vals ^= vals >> 30

--- a/pandas/core/util/hashing.py
+++ b/pandas/core/util/hashing.py
@@ -164,6 +164,29 @@ def hash_tuples(vals, encoding='utf8', hash_key=None):
     return h
 
 
+def hash_tuple(val, encoding='utf8', hash_key=None):
+    """
+    Hash a single tuple efficiently
+
+    Parameters
+    ----------
+    val : single tuple
+    encoding : string, default 'utf8'
+    hash_key : string key to encode, default to _default_hash_key
+
+    Returns
+    -------
+    hash
+
+    """
+    hashes = (hash_array(np.array([v]), encoding=encoding, hash_key=hash_key,
+                         categorize=False)
+              for v in val)
+    h = _combine_hash_arrays(hashes, len(val))[0]
+
+    return h
+
+
 def _hash_categorical(c, encoding, hash_key):
     """
     Hash a Categorical by hashing its categories, and then mapping the codes
@@ -264,7 +287,7 @@ def hash_array(vals, encoding='utf8', hash_key=None, categorize=True):
 
         try:
             vals = hashing.hash_object_array(vals, hash_key, encoding)
-        except TypeError:
+        except (TypeError, ValueError):
             # we have mixed types
             vals = hashing.hash_object_array(vals.astype(str).astype(object),
                                              hash_key, encoding)

--- a/pandas/tests/util/test_hashing.py
+++ b/pandas/tests/util/test_hashing.py
@@ -81,13 +81,13 @@ class TestHashing(object):
 
     def test_hash_tuple(self):
         # test equivalence between hash_tuples and hash_tuple
-        for tup in [(1, 'one'), (1, np.nan)]:
+        for tup in [(1, 'one'), (1, np.nan), (1.0, pd.NaT, 'A')]:
             result = hash_tuple(tup)
             expected = hash_tuples([tup])[0]
             assert result == expected
 
     def test_hash_scalar(self):
-        for val in [1, 1.4, 'A', b'A', u'A',  pd.Timestamp("2012-01-01"),
+        for val in [1, 1.4, 'A', b'A', u'A', pd.Timestamp("2012-01-01"),
                     pd.Timestamp("2012-01-01", tz='Europe/Brussels'),
                     pd.Period('2012-01-01', freq='D'), pd.Timedelta('1 days'),
                     pd.Interval(0, 1), np.nan, pd.NaT, None]:

--- a/pandas/tests/util/test_hashing.py
+++ b/pandas/tests/util/test_hashing.py
@@ -1,4 +1,5 @@
 import pytest
+import datetime
 
 from warnings import catch_warnings
 import numpy as np
@@ -81,7 +82,8 @@ class TestHashing(object):
 
     def test_hash_tuple(self):
         # test equivalence between hash_tuples and hash_tuple
-        for tup in [(1, 'one'), (1, np.nan), (1.0, pd.NaT, 'A')]:
+        for tup in [(1, 'one'), (1, np.nan), (1.0, pd.NaT, 'A'),
+                    ('A', pd.Timestamp("2012-01-01"))]:
             result = hash_tuple(tup)
             expected = hash_tuples([tup])[0]
             assert result == expected
@@ -89,8 +91,11 @@ class TestHashing(object):
     def test_hash_scalar(self):
         for val in [1, 1.4, 'A', b'A', u'A', pd.Timestamp("2012-01-01"),
                     pd.Timestamp("2012-01-01", tz='Europe/Brussels'),
-                    pd.Period('2012-01-01', freq='D'), pd.Timedelta('1 days'),
-                    pd.Interval(0, 1), np.nan, pd.NaT, None]:
+                    datetime.datetime(2012, 1, 1),
+                    pd.Timestamp("2012-01-01", tz='EST').to_pydatetime(),
+                    pd.Timedelta('1 days'), datetime.timedelta(1),
+                    pd.Period('2012-01-01', freq='D'), pd.Interval(0, 1),
+                    np.nan, pd.NaT, None]:
             result = _hash_scalar(val)
             expected = hash_array(np.array([val], dtype=object),
                                   categorize=True)

--- a/pandas/tests/util/test_hashing.py
+++ b/pandas/tests/util/test_hashing.py
@@ -6,7 +6,7 @@ import pandas as pd
 
 from pandas import DataFrame, Series, Index, MultiIndex
 from pandas.util import hash_array, hash_pandas_object
-from pandas.core.util.hashing import hash_tuples
+from pandas.core.util.hashing import hash_tuples, hash_tuple
 import pandas.util.testing as tm
 
 
@@ -78,6 +78,13 @@ class TestHashing(object):
 
         result = hash_tuples(tups[0])
         assert result == expected[0]
+
+    def test_hash_tuple(self):
+        # test equivalence between hash_tuples and hash_tuple
+        tup = (1, 'one')
+        result = hash_tuple(tup)
+        expected = hash_tuples([tup])[0]
+        assert result == expected
 
     def test_hash_tuples_err(self):
 

--- a/pandas/tests/util/test_hashing.py
+++ b/pandas/tests/util/test_hashing.py
@@ -6,7 +6,7 @@ import pandas as pd
 
 from pandas import DataFrame, Series, Index, MultiIndex
 from pandas.util import hash_array, hash_pandas_object
-from pandas.core.util.hashing import hash_tuples, hash_tuple
+from pandas.core.util.hashing import hash_tuples, hash_tuple, _hash_scalar
 import pandas.util.testing as tm
 
 
@@ -81,10 +81,20 @@ class TestHashing(object):
 
     def test_hash_tuple(self):
         # test equivalence between hash_tuples and hash_tuple
-        tup = (1, 'one')
-        result = hash_tuple(tup)
-        expected = hash_tuples([tup])[0]
-        assert result == expected
+        for tup in [(1, 'one'), (1, np.nan)]:
+            result = hash_tuple(tup)
+            expected = hash_tuples([tup])[0]
+            assert result == expected
+
+    def test_hash_scalar(self):
+        for val in [1, 1.4, 'A', b'A', u'A',  pd.Timestamp("2012-01-01"),
+                    pd.Timestamp("2012-01-01", tz='Europe/Brussels'),
+                    pd.Period('2012-01-01', freq='D'), pd.Timedelta('1 days'),
+                    pd.Interval(0, 1), np.nan, pd.NaT, None]:
+            result = _hash_scalar(val)
+            expected = hash_array(np.array([val], dtype=object),
+                                  categorize=True)
+            assert result[0] == expected[0]
 
     def test_hash_tuples_err(self):
 


### PR DESCRIPTION
While I was timing the MultiIndex get_loc in https://github.com/pandas-dev/pandas/pull/16324, I saw some 'quick wins' with some further profiling.

Rationale:

- big part of the time was spent in checking for a hash collision: `_check_for_collisions`. This function was a generic one for one or multiple labels. I added a slightly adapted version specialized for a single tuple
- another important factor was the hash creation with `hash_tuples`. Again, added specialized version for a single tuple.

@jreback I have some questions (will add them as comments), as this is not my specialty, but good opportunity to get more familiar with the inner guts :-)

Some timings using

```
import string
mi_large = pd.MultiIndex.from_product(
    [np.arange(1000),
     np.arange(20), list(string.ascii_letters)],
    names=['one', 'two', 'three'])
```

master:

```
In [2]: %time mi_large.get_loc((999, 19, 'E'))   # <--- first slower cold one
CPU times: user 140 ms, sys: 8 ms, total: 148 ms
Wall time: 145 ms
Out[2]: 1039978

In [3]: %time mi_large.get_loc((999, 19, 'E'))
CPU times: user 0 ns, sys: 4 ms, total: 4 ms
Wall time: 4.33 ms
Out[3]: 1039978

In [4]: %time mi_large.get_loc((999, 19, 'E'))
CPU times: user 4 ms, sys: 4 ms, total: 8 ms
Wall time: 4.18 ms
Out[4]: 1039978

In [5]: %timeit mi_large.get_loc((999, 19, 'E'))
100 loops, best of 3: 2.56 ms per loop

In [6]: %%timeit
   ...: for _ in range(1000):
   ...:     mi_large.get_loc((999, 19, 'E'))
   ...: 
1 loop, best of 3: 2.62 s per loop

```

PR:

```
In [3]: %time mi_large.get_loc((999, 19, 'E'))   # <--- first slower cold one
CPU times: user 128 ms, sys: 24 ms, total: 152 ms
Wall time: 152 ms
Out[3]: 1039978

In [4]: %time mi_large.get_loc((999, 19, 'E'))
CPU times: user 4 ms, sys: 0 ns, total: 4 ms
Wall time: 716 µs
Out[4]: 1039978

In [5]: %time mi_large.get_loc((999, 19, 'E'))
CPU times: user 0 ns, sys: 0 ns, total: 0 ns
Wall time: 371 µs
Out[5]: 1039978

In [6]: %timeit mi_large.get_loc((999, 19, 'E'))
1000 loops, best of 3: 189 µs per loop

In [15]: %%timeit
    ...: for _ in range(1000):
    ...:     mi_large.get_loc((999, 19, 'E'))
    ...: 
1 loop, best of 3: 188 ms per loop
```

So something between a 5x and 15x improvement (big variability between individual timings)