### PR TITLE
PERF: improved clip performance

### DIFF
--- a/asv_bench/benchmarks/series_methods.py
+++ b/asv_bench/benchmarks/series_methods.py
@@ -111,6 +111,7 @@ class series_dropna_int64(object):
     def time_series_dropna_int64(self):
         self.s.dropna()
 
+
 class series_dropna_datetime(object):
     goal_time = 0.2
 
@@ -120,3 +121,13 @@ class series_dropna_datetime(object):
 
     def time_series_dropna_datetime(self):
         self.s.dropna()
+
+
+class series_clip(object):
+    goal_time = 0.2
+
+    def setup(self):
+        self.s = pd.Series(np.random.randn(50))
+
+    def time_series_dropna_datetime(self):
+        self.s.clip(0, 1)

--- a/doc/source/whatsnew/v0.20.2.txt
+++ b/doc/source/whatsnew/v0.20.2.txt
@@ -19,7 +19,7 @@ Highlights include:
 Enhancements
 ~~~~~~~~~~~~
 
-- Unblocked access to additional compression types supported in pytables: 'blosc:blosclz, 'blosc:lz4', 'blosc:lz4hc', 'blosc:snappy', 'blosc:zlib', 'blosc:zstd' (:issue:`14478`) 
+- Unblocked access to additional compression types supported in pytables: 'blosc:blosclz, 'blosc:lz4', 'blosc:lz4hc', 'blosc:snappy', 'blosc:zlib', 'blosc:zstd' (:issue:`14478`)
 
 .. _whatsnew_0202.performance:
 
@@ -28,6 +28,7 @@ Performance Improvements
 
 - Performance regression fix when indexing with a list-like (:issue:`16285`)
 - Performance regression fix for small MultiIndexes (:issuse:`16319`)
+- Improved performance of ``.clip()`` with scalar arguments (:issue:`15400`)
 
 .. _whatsnew_0202.bug_fixes:
 

--- a/pandas/tests/series/test_analytics.py
+++ b/pandas/tests/series/test_analytics.py
@@ -1011,6 +1011,7 @@ class TestSeriesAnalytics(TestData):
 
         lower = Series([1.0, 2.0, 3.0])
         upper = Series([1.5, 2.5, 3.5])
+
         assert_series_equal(s.clip(lower, upper), Series([1.0, 2.0, 3.5]))
         assert_series_equal(s.clip(1.5, upper), Series([1.5, 1.5, 3.5]))
 


### PR DESCRIPTION
closes #15400
In [1]: np.random.seed(1234)

In [2]: s = pd.Series(np.random.randn(50))

master
```
In [3]: %timeit s.clip(0, 1)
1.65 ms ± 48.2 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)
```

PR
```
In [3]: %timeit s.clip(0, 1)
124 µs ± 2.79 µs per loop (mean ± std. dev. of 7 runs, 10000 loops each)
```

prob as good as can do for now as we still have 2 where ops (numpy does this in a single loop), and we have a mask check and fill (and final construction).

but about 15x better