### PR TITLE
Fixes truncated error message "C extension: umpy.core.multiarray failed to import"

### DIFF
--- a/pandas/__init__.py
+++ b/pandas/__init__.py
@@ -28,7 +28,7 @@ try:
                              tslib as _tslib)
 except ImportError as e:  # pragma: no cover
     # hack but overkill to use re
-    module = str(e).lstrip('cannot import name ')
+    module = str(e).replace('cannot import name ', '')
     raise ImportError("C extension: {0} not built. If you want to import "
                       "pandas from the source directory, you may need to run "
                       "'python setup.py build_ext --inplace --force' to build "


### PR DESCRIPTION
This occurred because lstrip is the wrong tool here:
```
>>> e = 'cannot import name numpy.core.multiarray'
>>> str(e).lstrip('cannot import name ')
'umpy.core.multiarray'
```
Better:
```
>>> str(e).replace('cannot import name ', '')
'numpy.core.multiarray'
```
--

 - [ ] closes #xxxx
 - [ ] tests added / passed
 - [ ] passes ``git diff upstream/master --name-only -- '*.py' | flake8 --diff``
 - [ ] whatsnew entry
