### PR TITLE
TST: Add test for clip-na

### DIFF
--- a/pandas/tests/frame/test_analytics.py
+++ b/pandas/tests/frame/test_analytics.py
@@ -1863,6 +1863,23 @@ class TestDataFrameAnalytics(TestData):
         tm.assert_frame_equal(clipped_df[ub_mask], ub[ub_mask])
         tm.assert_frame_equal(clipped_df[mask], df[mask])
 
+    def test_clip_na(self):
+        msg = "Cannot use an NA"
+        with tm.assert_raises_regex(ValueError, msg):
+            self.frame.clip(lower=np.nan)
+
+        with tm.assert_raises_regex(ValueError, msg):
+            self.frame.clip(lower=[np.nan])
+
+        with tm.assert_raises_regex(ValueError, msg):
+            self.frame.clip(upper=np.nan)
+
+        with tm.assert_raises_regex(ValueError, msg):
+            self.frame.clip(upper=[np.nan])
+
+        with tm.assert_raises_regex(ValueError, msg):
+            self.frame.clip(lower=np.nan, upper=np.nan)
+
     # Matrix-like
 
     def test_dot(self):


### PR DESCRIPTION
Additional test cases for https://github.com/pandas-dev/pandas/pull/16364
when upper and / or lower is nan.

cc @jreback [this line](https://github.com/pandas-dev/pandas/pull/16364/files#diff-03b380f521c43cf003207b0711bac67fR4112) was missing tests I think.