### PR TITLE
BUG: reshape fix for maybe_infer_to_datetimelike()

### DIFF
--- a/doc/source/whatsnew/v0.20.2.txt
+++ b/doc/source/whatsnew/v0.20.2.txt
@@ -84,7 +84,6 @@ Reshaping
 - Bug in ``DataFrame.stack`` with unsorted levels in MultiIndex columns (:issue:`16323`)
 - Bug in ``pd.wide_to_long()`` where no error was raised when ``i`` was not a unique identifier (:issue:`16382`)
 - Bug in ``Series.isin(..)`` with a list of tuples (:issue:`16394`)
-- Bug in ``maybe_infer_to_datetimelike()`` in ``core.dtypes.cast`` where result was not reshaped in all cases (:issue:`16395`)
 
 
 Numeric

--- a/doc/source/whatsnew/v0.20.2.txt
+++ b/doc/source/whatsnew/v0.20.2.txt
@@ -84,6 +84,7 @@ Reshaping
 - Bug in ``DataFrame.stack`` with unsorted levels in MultiIndex columns (:issue:`16323`)
 - Bug in ``pd.wide_to_long()`` where no error was raised when ``i`` was not a unique identifier (:issue:`16382`)
 - Bug in ``Series.isin(..)`` with a list of tuples (:issue:`16394`)
+- Bug in ``maybe_infer_to_datetimelike()`` in ``core.dtypes.cast`` where result was not reshaped in all cases (:issue:`16395`)
 
 
 Numeric

--- a/pandas/core/dtypes/cast.py
+++ b/pandas/core/dtypes/cast.py
@@ -837,7 +837,7 @@ def maybe_infer_to_datetimelike(value, convert_dates=False):
         try:
             return to_timedelta(v)._values.reshape(shape)
         except:
-            return v
+            return v.reshape(shape)
 
     inferred_type = lib.infer_datetimelike_array(_ensure_object(v))
 

--- a/pandas/tests/dtypes/test_cast.py
+++ b/pandas/tests/dtypes/test_cast.py
@@ -9,7 +9,7 @@ import pytest
 from datetime import datetime, timedelta, date
 import numpy as np
 
-from pandas import Timedelta, Timestamp, DatetimeIndex
+from pandas import Timedelta, Timestamp, DatetimeIndex, DataFrame, NaT
 
 from pandas.core.dtypes.cast import (
     maybe_downcast_to_dtype,
@@ -212,6 +212,17 @@ class TestMaybe(object):
         assert result == Timestamp('20130101').value
         result = maybe_convert_scalar(Timedelta('1 day 1 min'))
         assert result == Timedelta('1 day 1 min').value
+
+    def test_maybe_infer_to_datetimelike(self):
+        # GH16362
+        # pandas=0.20.1 raises IndexError: tuple index out of range
+        result = DataFrame(np.array([[NaT, 'a', 'b', 0],
+                                     [NaT, 'b', 'c', 1]]))
+        assert result.size == 8
+        # this construction was fine
+        result = DataFrame(np.array([[NaT, 'a', 0],
+                                     [NaT, 'b', 1]]))
+        assert result.size == 6
 
 
 class TestConvert(object):


### PR DESCRIPTION
 - [x] closes #16362
 - [x] tests added / passed
 - [x] passes ``git diff upstream/master --name-only -- '*.py' | flake8 --diff``
 - [ ] whatsnew entry