### PR TITLE
BUG: wide_to_long should check for unique id vars (#16382)

### DIFF
--- a/doc/source/whatsnew/v0.20.2.txt
+++ b/doc/source/whatsnew/v0.20.2.txt
@@ -79,6 +79,7 @@ Reshaping
 ^^^^^^^^^
 
 - Bug in ``DataFrame.stack`` with unsorted levels in MultiIndex columns (:issue:`16323`)
+- Bug in ``pd.wide_to_long()`` where no error was raised when ``i`` was not a unique identifier (:issue:`16382`)
 
 
 Numeric

--- a/pandas/core/reshape/reshape.py
+++ b/pandas/core/reshape/reshape.py
@@ -1046,6 +1046,9 @@ def wide_to_long(df, stubnames, i, j, sep="", suffix='\d+'):
     else:
         i = list(i)
 
+    if df[i].duplicated().any():
+        raise ValueError("the id variables need to uniquely identify each row")
+
     value_vars = list(map(lambda stub:
                           get_var_names(df, stub, sep, suffix), stubnames))
 

--- a/pandas/tests/reshape/test_reshape.py
+++ b/pandas/tests/reshape/test_reshape.py
@@ -976,3 +976,14 @@ class TestWideToLong(object):
         exp_frame = exp_frame.set_index(['famid', 'birth', 'age'])[['ht']]
         long_frame = wide_to_long(df, 'ht', i=['famid', 'birth'], j='age')
         tm.assert_frame_equal(long_frame, exp_frame)
+
+    def test_non_unique_idvars(self):
+        # GH16382
+        # Raise an error message if non unique id vars (i) are passed
+        df = pd.DataFrame({
+            'A_A1' : [1, 2, 3, 4, 5],
+            'B_B1' : [1, 2, 3, 4, 5],
+            'x' : [1, 1, 1, 1, 1]
+        })
+        with pytest.raises(ValueError):
+            wide_to_long(df, ['A_A', 'B_B'], i='x', j='colname')

--- a/pandas/tests/reshape/test_reshape.py
+++ b/pandas/tests/reshape/test_reshape.py
@@ -981,9 +981,9 @@ class TestWideToLong(object):
         # GH16382
         # Raise an error message if non unique id vars (i) are passed
         df = pd.DataFrame({
-            'A_A1' : [1, 2, 3, 4, 5],
-            'B_B1' : [1, 2, 3, 4, 5],
-            'x' : [1, 1, 1, 1, 1]
+            'A_A1': [1, 2, 3, 4, 5],
+            'B_B1': [1, 2, 3, 4, 5],
+            'x': [1, 1, 1, 1, 1]
         })
         with pytest.raises(ValueError):
             wide_to_long(df, ['A_A', 'B_B'], i='x', j='colname')


### PR DESCRIPTION
 - [x] closes #16382 
 - [x] tests added / passed
 - [x] passes ``git diff upstream/master --name-only -- '*.py' | flake8 --diff``

Input validation: raise a ValueError in case `i` does not uniquely identify each row.
