### PR TITLE
DOC: add google analytics to the documentation

### DIFF
--- a/doc/source/themes/nature_with_gtoc/layout.html
+++ b/doc/source/themes/nature_with_gtoc/layout.html
@@ -94,4 +94,15 @@ $(document).ready(function() {
     });
 });
 </script>
+<script type="text/javascript">
+  var _gaq = _gaq || [];
+  _gaq.push(['_setAccount', 'UA-27880019-2']);
+  _gaq.push(['_trackPageview']);
+
+  (function() {
+    var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
+    ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
+    var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
+  })();
+</script>
 {% endblock %}


### PR DESCRIPTION
The main pandas website (pandas.pydata.org) has google analytics tracking, but I think it would be interesting to also have this on the docs, so adding it to the theme.

