### PR TITLE
PERF: don't materialize arrays on checking in groupby

### DIFF
--- a/asv_bench/benchmarks/groupby.py
+++ b/asv_bench/benchmarks/groupby.py
@@ -368,6 +368,11 @@ class groupby_size(object):
         self.dates = (np.datetime64('now') + self.offsets)
         self.df = DataFrame({'key1': np.random.randint(0, 500, size=self.n), 'key2': np.random.randint(0, 100, size=self.n), 'value1': np.random.randn(self.n), 'value2': np.random.randn(self.n), 'value3': np.random.randn(self.n), 'dates': self.dates, })
 
+        N = 1000000
+        self.draws = pd.Series(np.random.randn(N))
+        labels = pd.Series(['foo', 'bar', 'baz', 'qux'] * (N // 4))
+        self.cats = labels.astype('category')
+
     def time_groupby_multi_size(self):
         self.df.groupby(['key1', 'key2']).size()
 
@@ -376,6 +381,10 @@ class groupby_size(object):
 
     def time_groupby_dt_timegrouper_size(self):
         self.df.groupby(TimeGrouper(key='dates', freq='M')).size()
+
+    def time_groupby_size(self):
+        self.draws.groupby(self.cats).size()
+
 
 
 #----------------------------------------------------------------------

--- a/doc/source/whatsnew/v0.20.2.txt
+++ b/doc/source/whatsnew/v0.20.2.txt
@@ -29,7 +29,7 @@ Performance Improvements
 - Performance regression fix when indexing with a list-like (:issue:`16285`)
 - Performance regression fix for MultiIndexes (:issue:`16319`, :issue:`16346`)
 - Improved performance of ``.clip()`` with scalar arguments (:issue:`15400`)
-
+- Improved performance of groupby with categorical groupers (:issue:`16413`)
 
 .. _whatsnew_0202.bug_fixes:
 

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -2388,7 +2388,6 @@ class Index(IndexOpsMixin, StringAccessorMixin, PandasObject):
             if tolerance is not None:
                 raise ValueError('tolerance argument only valid if using pad, '
                                  'backfill or nearest lookups')
-            key = _values_from_object(key)
             try:
                 return self._engine.get_loc(key)
             except KeyError:


### PR DESCRIPTION
```
    before     after       ratio
  [a6fcec6c] [6edcdc0d]
-   15.41ms     9.48ms      0.62  groupby.groupby_size.time_groupby_size

```

this is more dramatic as the size increases as this should be pretty much a constant time operation (the actual size computation itself).