### PR TITLE
COMPAT: Catch warnings on tab-complete in IPy 6

### DIFF
--- a/doc/source/whatsnew/v0.20.2.txt
+++ b/doc/source/whatsnew/v0.20.2.txt
@@ -40,6 +40,10 @@ Bug Fixes
 - Bug in ``DataFrame.update()`` with ``overwrite=False`` and ``NaN values`` (:issue:`15593`)
 
 
+
+- Fixed a compatibility issue with IPython 6.0's tab completion showing deprecation warnings on Categoricals (:issue:`16409`)
+
+
 Conversion
 ^^^^^^^^^^
 

--- a/pandas/conftest.py
+++ b/pandas/conftest.py
@@ -45,3 +45,13 @@ def spmatrix(request):
     tm._skip_if_no_scipy()
     from scipy import sparse
     return getattr(sparse, request.param + '_matrix')
+
+
+@pytest.fixture
+def ip():
+    """An instance of IPython.InteractiveShell.
+    Will raise a skip if IPython is not installed.
+    """
+    pytest.importorskip('IPython', minversion="6.0.0")
+    from IPython.core.interactiveshell import InteractiveShell
+    return InteractiveShell()

--- a/pandas/core/categorical.py
+++ b/pandas/core/categorical.py
@@ -342,6 +342,13 @@ class Categorical(PandasObject):
         self._categories = categories
         self._codes = coerce_indexer_dtype(codes, categories)
 
+    def __dir__(self):
+        # Avoid IPython warnings for deprecated properties
+        # https://github.com/pandas-dev/pandas/issues/16409
+        rv = set(dir(type(self)))
+        rv.discard("labels")
+        return sorted(rv)
+
     @property
     def _constructor(self):
         return Categorical

--- a/pandas/core/resample.py
+++ b/pandas/core/resample.py
@@ -184,6 +184,12 @@ class Resampler(_GroupBy):
         matches_pattern = any(attr.startswith(x) for x
                               in self._deprecated_valid_patterns)
         if not matches_pattern and attr not in self._deprecated_valids:
+            # avoid the warning, if it's just going to be an exception
+            # anyway.
+            if not hasattr(self.obj, attr):
+                raise AttributeError("'{}' has no attribute '{}'".format(
+                    type(self.obj).__name__, attr
+                ))
             self = self._deprecated(attr)
 
         return object.__getattribute__(self, attr)

--- a/pandas/tests/test_categorical.py
+++ b/pandas/tests/test_categorical.py
@@ -736,6 +736,17 @@ Categories (3, object): [ああああ, いいいいい, ううううううう]""
 
             assert _rep(c) == expected
 
+    def test_tab_complete_warning(self, ip):
+        # https://github.com/pandas-dev/pandas/issues/16409
+        pytest.importorskip('IPython', minversion="6.0.0")
+        from IPython.core.completer import provisionalcompleter
+
+        code = "import pandas as pd; c = pd.Categorical([])"
+        ip.run_code(code)
+        with tm.assert_produces_warning(None):
+            with provisionalcompleter('ignore'):
+                list(ip.Completer.completions('c.', 1))
+
     def test_periodindex(self):
         idx1 = PeriodIndex(['2014-01', '2014-01', '2014-02', '2014-02',
                             '2014-03', '2014-03'], freq='M')

--- a/pandas/tests/test_resample.py
+++ b/pandas/tests/test_resample.py
@@ -3,6 +3,7 @@
 from warnings import catch_warnings
 from datetime import datetime, timedelta
 from functools import partial
+from textwrap import dedent
 
 import pytz
 import pytest
@@ -284,8 +285,7 @@ class TestResampleAPI(object):
         tm.assert_series_equal(r.A.sum(), r['A'].sum())
 
         # getting
-        with tm.assert_produces_warning(FutureWarning, check_stacklevel=False):
-            pytest.raises(AttributeError, lambda: r.F)
+        pytest.raises(AttributeError, lambda: r.F)
 
         # setting
         def f():
@@ -2815,6 +2815,19 @@ class TestResamplerGrouper(object):
                                               fill_method='ffill')
             expected = df.groupby('A').resample('4s').mean().ffill()
             assert_frame_equal(result, expected)
+
+    def test_tab_complete_ipython6_warning(self, ip):
+        from IPython.core.completer import provisionalcompleter
+        code = dedent("""\
+        import pandas.util.testing as tm
+        s = tm.makeTimeSeries()
+        rs = s.resample("D")
+        """)
+        ip.run_code(code)
+
+        with tm.assert_produces_warning(None):
+            with provisionalcompleter('ignore'):
+                list(ip.Completer.completions('rs.', 1))
 
     def test_deferred_with_groupby(self):
 


### PR DESCRIPTION
Properties may run code with Jedi completion in IPython 6

Closes https://github.com/pandas-dev/pandas/issues/16409

I want to leave this open for a couple days to see if I can find other places that trigger this warning. I'm pretty sure I've seen other instances, but they may have been from other libraries.