### PR TITLE
sets data index if it's not None

### DIFF
--- a/pandas/io/stata.py
+++ b/pandas/io/stata.py
@@ -178,6 +178,8 @@ def read_stata(filepath_or_buffer, convert_dates=True,
             data = reader.read()
         finally:
             reader.close()
+    if index is not None:
+        data.set_index(index)
     return data
 
 

--- a/pandas/tests/io/test_stata.py
+++ b/pandas/tests/io/test_stata.py
@@ -1297,3 +1297,11 @@ class TestStata(object):
         reader = lambda x: read_stata(x).set_index('index')
         result = tm.round_trip_localpath(df.to_stata, reader)
         tm.assert_frame_equal(df, result)
+
+    def test_read_index(self):
+        df = tm.makeDataFrame()
+        df.index.name = "my_index"
+        with tm.ensure_clean() as path:
+            df.to_stata(path)
+            result = pd.read_stata(path, index_col="my_index")
+        tm.assert_frame_equal(df, result)


### PR DESCRIPTION
Fixed Bug #16342 read_stata ignores `index` parameter