### PR TITLE
Error with .drop([]) on non-unique index

### DIFF
--- a/doc/source/whatsnew/v0.20.2.txt
+++ b/doc/source/whatsnew/v0.20.2.txt
@@ -94,4 +94,4 @@ Categorical
 Other
 ^^^^^
 
-- Fix ``pd.drop([])`` for dataframes with non-unique indices (:issue:`16270`)
+- Bug in ``pd.drop([])`` for DataFrame with non-unique indices (:issue:`16270`)

--- a/doc/source/whatsnew/v0.20.2.txt
+++ b/doc/source/whatsnew/v0.20.2.txt
@@ -93,3 +93,5 @@ Categorical
 
 Other
 ^^^^^
+
+- Fix ``pd.drop([])`` for dataframes with non-unique indices (:issue:`16270`)

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -12,6 +12,7 @@ import pandas as pd
 from pandas._libs import tslib, lib
 from pandas.core.dtypes.common import (
     _ensure_int64,
+    _ensure_object,
     needs_i8_conversion,
     is_scalar,
     is_number,
@@ -2076,7 +2077,7 @@ class NDFrame(PandasObject, SelectionMixin):
             result = dropped
 
         else:
-            labels = com._index_labels_to_array(labels)
+            labels = _ensure_object(com._index_labels_to_array(labels))
             if level is not None:
                 if not isinstance(axis, MultiIndex):
                     raise AssertionError('axis must be a MultiIndex')

--- a/pandas/tests/frame/test_axis_select_reindex.py
+++ b/pandas/tests/frame/test_axis_select_reindex.py
@@ -61,6 +61,11 @@ class TestDataFrameSelectReindex(TestData):
         expected = Index(['e', 'f'], name='second')
         tm.assert_index_equal(dropped.columns, expected)
 
+        # GH 16398
+        dropped = df.drop([], errors='ignore')
+        expected = Index(['a', 'b', 'c'], name='first')
+        tm.assert_index_equal(dropped.index, expected)
+
     def test_drop_col_still_multiindex(self):
         arrays = [['a', 'b', 'c', 'top'],
                   ['', '', '', 'OD'],
@@ -100,6 +105,7 @@ class TestDataFrameSelectReindex(TestData):
                           columns=['a', 'a', 'b'])
         assert_frame_equal(nu_df.drop('a', axis=1), nu_df[['b']])
         assert_frame_equal(nu_df.drop('b', axis='columns'), nu_df['a'])
+        assert_frame_equal(nu_df.drop([]), nu_df)  # GH 16398
 
         nu_df = nu_df.set_index(pd.Index(['X', 'Y', 'X']))
         nu_df.columns = list('abc')


### PR DESCRIPTION
Wraps the labels array in `_ensure_object`. The labels array is being cast to a float by default, causing the error raised in #16398.

 - [X] closes #16398 
 - [X] tests added / passed
 - [X] passes ``git diff upstream/master --name-only -- '*.py' | flake8 --diff``
 - [x] whatsnew entry
