### PR TITLE
BUG: fix isin with Series of tuples values (#16394)

### DIFF
--- a/doc/source/whatsnew/v0.20.2.txt
+++ b/doc/source/whatsnew/v0.20.2.txt
@@ -80,7 +80,7 @@ Reshaping
 ^^^^^^^^^
 
 - Bug in ``DataFrame.stack`` with unsorted levels in MultiIndex columns (:issue:`16323`)
-- Bug in ``Series.isin(..)`` in core/algorithms.py with a list of tuples (:issue:`16394`)
+- Bug in ``Series.isin(..)`` with a list of tuples (:issue:`16394`)
 
 Numeric
 ^^^^^^^

--- a/doc/source/whatsnew/v0.20.2.txt
+++ b/doc/source/whatsnew/v0.20.2.txt
@@ -80,7 +80,7 @@ Reshaping
 ^^^^^^^^^
 
 - Bug in ``DataFrame.stack`` with unsorted levels in MultiIndex columns (:issue:`16323`)
-- Bug in ``isin`` in core/algorithms.py with comparing lists of tuples
+- Bug in ``Series.isin(..)`` in core/algorithms.py with a list of tuples (:issue:`16394`)
 
 Numeric
 ^^^^^^^

--- a/doc/source/whatsnew/v0.20.2.txt
+++ b/doc/source/whatsnew/v0.20.2.txt
@@ -80,7 +80,7 @@ Reshaping
 ^^^^^^^^^
 
 - Bug in ``DataFrame.stack`` with unsorted levels in MultiIndex columns (:issue:`16323`)
-
+- Bug in ``isin`` in core/algorithms.py with comparing lists of tuples
 
 Numeric
 ^^^^^^^

--- a/pandas/core/algorithms.py
+++ b/pandas/core/algorithms.py
@@ -388,7 +388,7 @@ def isin(comps, values):
                         "[{0}]".format(type(values).__name__))
 
     if not isinstance(values, (ABCIndex, ABCSeries, np.ndarray)):
-        values = np.array(list(values), dtype='object')
+        values = lib.list_to_object_array(list(values))
 
     comps, dtype, _ = _ensure_data(comps)
     values, _, _ = _ensure_data(values, dtype=dtype)

--- a/pandas/tests/frame/test_analytics.py
+++ b/pandas/tests/frame/test_analytics.py
@@ -1207,7 +1207,7 @@ class TestDataFrameAnalytics(TestData):
         df['C'] = list(zip(df['A'], df['B']))
         result = df['C'].isin([(1, 'a')])
         tm.assert_series_equal(result,
-                               Series([True,False,False],name="C"))
+                               Series([True, False, False], name="C"))
 
     def test_isin_df_dupe_values(self):
         df1 = DataFrame({'A': [1, 2, 3, 4], 'B': [2, np.nan, 4, 4]})

--- a/pandas/tests/frame/test_analytics.py
+++ b/pandas/tests/frame/test_analytics.py
@@ -1202,11 +1202,12 @@ class TestDataFrameAnalytics(TestData):
         tm.assert_frame_equal(result, expected)
 
     def test_isin_tuples(self):
+        # GH16394
         df = pd.DataFrame({'A': [1, 2, 3], 'B': ['a', 'b', 'f']})
         df['C'] = list(zip(df['A'], df['B']))
         result = df['C'].isin([(1, 'a')])
         tm.assert_series_equal(result,
-                              Series([True,False,False],name="C"))
+                               Series([True,False,False],name="C"))
 
     def test_isin_df_dupe_values(self):
         df1 = DataFrame({'A': [1, 2, 3, 4], 'B': [2, np.nan, 4, 4]})

--- a/pandas/tests/frame/test_analytics.py
+++ b/pandas/tests/frame/test_analytics.py
@@ -1201,6 +1201,13 @@ class TestDataFrameAnalytics(TestData):
         expected['B'] = False
         tm.assert_frame_equal(result, expected)
 
+    def test_isin_tuples(self):
+        df = pd.DataFrame({'A': [1, 2, 3], 'B': ['a', 'b', 'f']})
+        df['C'] = list(zip(df['A'], df['B']))
+        result = df['C'].isin([(1, 'a')])
+        tm.assert_series_equal(result,
+                              Series([True,False,False],name="C"))
+
     def test_isin_df_dupe_values(self):
         df1 = DataFrame({'A': [1, 2, 3, 4], 'B': [2, np.nan, 4, 4]})
         # just cols duped


### PR DESCRIPTION
Switched out 
values = np.array(list(values), dtype='object')
for
values = lib.list_to_object_array(list(values))
 in the isin() method found in core/algorithms.py

Added test for comparing to a list of tuples

 - [ ] closes #16394
 - [ ] tests added / passed
 - [ ] passes ``git diff upstream/master --name-only -- '*.py' | flake8 --diff``
 - [ ] whatsnew entry
