### PR TITLE
[Issue: #16416] Adding examples for some DataFrame methods

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -2948,13 +2948,7 @@ it is assumed to be aliases for the column names.')
 
         Only replace the first NaN element.
 
-        >>> values = {
-        ...     'A': 0,
-        ...     'B': 1,
-        ...     'C': 2,
-        ...     'D': 3,
-        ... }
-        ... df.fillna(value=values, limit=1)
+        >>> df.fillna(value=values, limit=1)
             A   B   C   D
         0   0.0 2.0 2.0 0
         1   3.0 4.0 NaN 1

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -2920,13 +2920,15 @@ it is assumed to be aliases for the column names.')
         --------
         >>> df = pd.DataFrame([[np.nan, 2, np.nan, 0],
         ...                    [3, 4, np.nan, 1],
-        ...                    [np.nan, np.nan, np.nan, 5]],
+        ...                    [np.nan, np.nan, np.nan, 5],
+        ...                    [np.nan, 3, np.nan, 4]],
         ...                    columns=list('ABCD'))
         >>> df
              A    B   C  D
         0  NaN  2.0 NaN  0
         1  3.0  4.0 NaN  1
         2  NaN  NaN NaN  5
+        3  NaN  3.0 NaN  4
 
         Replace all NaN elements with 0s.
 
@@ -2935,6 +2937,16 @@ it is assumed to be aliases for the column names.')
         0   0.0 2.0 0.0 0
         1   3.0 4.0 0.0 1
         2   0.0 0.0 0.0 5
+        3   0.0 3.0 0.0 4
+
+        We can also propagate non-null values forward or backward.
+
+        >>> df.fillna(method='ffill')
+            A   B   C   D
+        0   NaN 2.0 NaN 0
+        1   3.0 4.0 NaN 1
+        2   3.0 4.0 NaN 5
+        3   3.0 3.0 NaN 4
 
         Replace all NaN elements in column 'A', 'B', 'C', and 'D', with 0, 1, 2,
         and 3 respectively.
@@ -2945,6 +2957,7 @@ it is assumed to be aliases for the column names.')
         0   0.0 2.0 2.0 0
         1   3.0 4.0 2.0 1
         2   0.0 1.0 2.0 5
+        3   0.0 3.0 2.0 4
 
         Only replace the first NaN element.
 
@@ -2953,6 +2966,7 @@ it is assumed to be aliases for the column names.')
         0   0.0 2.0 2.0 0
         1   3.0 4.0 NaN 1
         2   NaN 1.0 NaN 5
+        3   NaN 3.0 NaN 4
         """
         return super(DataFrame,
                      self).fillna(value=value, method=method, axis=axis,

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -2915,6 +2915,54 @@ it is assumed to be aliases for the column names.')
     @Appender(_shared_docs['fillna'] % _shared_doc_kwargs)
     def fillna(self, value=None, method=None, axis=None, inplace=False,
                limit=None, downcast=None, **kwargs):
+        """
+        Examples
+        --------
+        >>> df = pd.DataFrame([[np.nan, 2, np.nan, 0], [3, 4, np.nan, 1],
+        ...                    [np.nan, np.nan, np.nan, 5]],
+        ...                   columns=list('ABCD'))
+        >>> df
+             A    B   C  D
+        0  NaN  2.0 NaN  0
+        1  3.0  4.0 NaN  1
+        2  NaN  NaN NaN  5
+
+        Replace all NaN elements with 0s.
+
+        >>> df.fillna(0)
+            A   B   C   D
+        0   0.0 2.0 0.0 0
+        1   3.0 4.0 0.0 1
+        2   0.0 0.0 0.0 5
+
+        Replace all NaN elements in column 'A', 'B', 'C', and 'D', with 0, 1, 2, and 3 respectively.
+
+        >>> values = {
+        ...     'A': 0,
+        ...     'B': 1,
+        ...     'C': 2,
+        ...     'D': 3,
+        ... }
+        ... df.fillna(value=values)
+            A   B   C   D
+        0   0.0 2.0 2.0 0
+        1   3.0 4.0 2.0 1
+        2   0.0 1.0 2.0 5
+
+        Only replace the first NaN element.
+
+        >>> values = {
+        ...     'A': 0,
+        ...     'B': 1,
+        ...     'C': 2,
+        ...     'D': 3,
+        ... }
+        ... df.fillna(value=values, limit=1)
+            A   B   C   D
+        0   0.0 2.0 2.0 0
+        1   3.0 4.0 NaN 1
+        2   NaN 1.0 NaN 5
+        """
         return super(DataFrame,
                      self).fillna(value=value, method=method, axis=axis,
                                   inplace=inplace, limit=limit,

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -2915,59 +2915,6 @@ it is assumed to be aliases for the column names.')
     @Appender(_shared_docs['fillna'] % _shared_doc_kwargs)
     def fillna(self, value=None, method=None, axis=None, inplace=False,
                limit=None, downcast=None, **kwargs):
-        """
-        Examples
-        --------
-        >>> df = pd.DataFrame([[np.nan, 2, np.nan, 0],
-        ...                    [3, 4, np.nan, 1],
-        ...                    [np.nan, np.nan, np.nan, 5],
-        ...                    [np.nan, 3, np.nan, 4]],
-        ...                    columns=list('ABCD'))
-        >>> df
-             A    B   C  D
-        0  NaN  2.0 NaN  0
-        1  3.0  4.0 NaN  1
-        2  NaN  NaN NaN  5
-        3  NaN  3.0 NaN  4
-
-        Replace all NaN elements with 0s.
-
-        >>> df.fillna(0)
-            A   B   C   D
-        0   0.0 2.0 0.0 0
-        1   3.0 4.0 0.0 1
-        2   0.0 0.0 0.0 5
-        3   0.0 3.0 0.0 4
-
-        We can also propagate non-null values forward or backward.
-
-        >>> df.fillna(method='ffill')
-            A   B   C   D
-        0   NaN 2.0 NaN 0
-        1   3.0 4.0 NaN 1
-        2   3.0 4.0 NaN 5
-        3   3.0 3.0 NaN 4
-
-        Replace all NaN elements in column 'A', 'B', 'C', and 'D', with 0, 1, 2,
-        and 3 respectively.
-
-        >>> values = {'A': 0, 'B': 1, 'C': 2, 'D': 3}
-        ... df.fillna(value=values)
-            A   B   C   D
-        0   0.0 2.0 2.0 0
-        1   3.0 4.0 2.0 1
-        2   0.0 1.0 2.0 5
-        3   0.0 3.0 2.0 4
-
-        Only replace the first NaN element.
-
-        >>> df.fillna(value=values, limit=1)
-            A   B   C   D
-        0   0.0 2.0 2.0 0
-        1   3.0 4.0 NaN 1
-        2   NaN 1.0 NaN 5
-        3   NaN 3.0 NaN 4
-        """
         return super(DataFrame,
                      self).fillna(value=value, method=method, axis=axis,
                                   inplace=inplace, limit=limit,

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -2918,9 +2918,10 @@ it is assumed to be aliases for the column names.')
         """
         Examples
         --------
-        >>> df = pd.DataFrame([[np.nan, 2, np.nan, 0], [3, 4, np.nan, 1],
+        >>> df = pd.DataFrame([[np.nan, 2, np.nan, 0],
+        ...                    [3, 4, np.nan, 1],
         ...                    [np.nan, np.nan, np.nan, 5]],
-        ...                   columns=list('ABCD'))
+        ...                    columns=list('ABCD'))
         >>> df
              A    B   C  D
         0  NaN  2.0 NaN  0
@@ -2935,14 +2936,10 @@ it is assumed to be aliases for the column names.')
         1   3.0 4.0 0.0 1
         2   0.0 0.0 0.0 5
 
-        Replace all NaN elements in column 'A', 'B', 'C', and 'D', with 0, 1, 2, and 3 respectively.
+        Replace all NaN elements in column 'A', 'B', 'C', and 'D', with 0, 1, 2,
+        and 3 respectively.
 
-        >>> values = {
-        ...     'A': 0,
-        ...     'B': 1,
-        ...     'C': 2,
-        ...     'D': 3,
-        ... }
+        >>> values = {'A': 0, 'B': 1, 'C': 2, 'D': 3}
         ... df.fillna(value=values)
             A   B   C   D
         0   0.0 2.0 2.0 0

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -2058,34 +2058,34 @@ class NDFrame(PandasObject, SelectionMixin):
 
         Examples
         --------
-        >>> df = pd.DataFrame([[np.nan, 2, np.nan, 0],
-        ...                    [3, 4, np.nan, 1],
-        ...                    [np.nan, np.nan, np.nan, 5],
-        ...                    [np.nan, 3, np.nan, 4]
+        >>> df = pd.DataFrame([[1, 2, 3, 4],
+        ...                    [5, 6, 7, 8],
+        ...                    [9, 1, 2, 3],
+        ...                    [4, 5, 6, 7]
         ...                   ],
         ...                   columns=list('ABCD'))
         >>> df
             A   B   C   D
-        0   NaN 2.0 NaN 0
-        1   3.0 4.0 NaN 1
-        2   NaN NaN NaN 5
-        3   NaN 3.0 NaN 4
+        0   1   2   3   4
+        1   5   6   7   8
+        2   9   1   2   3
+        3   4   5   6   7
 
         Drop a row by index
 
         >>> df.drop([0, 1])
             A   B   C   D
-        2   NaN NaN NaN 5
-        3   NaN 3.0 NaN 4
+        2   9   1   2   3
+        3   4   5   6   7
 
         Drop columns
 
         >>> df.drop(['A', 'B'], axis=1)
             C   D
-        0   NaN 0
-        1   NaN 1
-        2   NaN 5
-        3   NaN 4
+        0   3   4
+        1   7   8
+        2   2   3
+        3   6   7
         """
         inplace = validate_bool_kwarg(inplace, 'inplace')
         axis = self._get_axis_number(axis)
@@ -3559,6 +3559,58 @@ class NDFrame(PandasObject, SelectionMixin):
         Returns
         -------
         filled : %(klass)s
+
+        Examples
+        --------
+        >>> df = pd.DataFrame([[np.nan, 2, np.nan, 0],
+        ...                    [3, 4, np.nan, 1],
+        ...                    [np.nan, np.nan, np.nan, 5],
+        ...                    [np.nan, 3, np.nan, 4]],
+        ...                    columns=list('ABCD'))
+        >>> df
+             A    B   C  D
+        0  NaN  2.0 NaN  0
+        1  3.0  4.0 NaN  1
+        2  NaN  NaN NaN  5
+        3  NaN  3.0 NaN  4
+
+        Replace all NaN elements with 0s.
+
+        >>> df.fillna(0)
+            A   B   C   D
+        0   0.0 2.0 0.0 0
+        1   3.0 4.0 0.0 1
+        2   0.0 0.0 0.0 5
+        3   0.0 3.0 0.0 4
+
+        We can also propagate non-null values forward or backward.
+
+        >>> df.fillna(method='ffill')
+            A   B   C   D
+        0   NaN 2.0 NaN 0
+        1   3.0 4.0 NaN 1
+        2   3.0 4.0 NaN 5
+        3   3.0 3.0 NaN 4
+
+        Replace all NaN elements in column 'A', 'B', 'C', and 'D', with 0, 1,
+        2, and 3 respectively.
+
+        >>> values = {'A': 0, 'B': 1, 'C': 2, 'D': 3}
+        >>> df.fillna(value=values)
+            A   B   C   D
+        0   0.0 2.0 2.0 0
+        1   3.0 4.0 2.0 1
+        2   0.0 1.0 2.0 5
+        3   0.0 3.0 2.0 4
+
+        Only replace the first NaN element.
+
+        >>> df.fillna(value=values, limit=1)
+            A   B   C   D
+        0   0.0 2.0 2.0 0
+        1   3.0 4.0 NaN 1
+        2   NaN 1.0 NaN 5
+        3   NaN 3.0 NaN 4
         """)
 
     @Appender(_shared_docs['fillna'] % _shared_doc_kwargs)

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -2055,6 +2055,36 @@ class NDFrame(PandasObject, SelectionMixin):
         Returns
         -------
         dropped : type of caller
+
+        Examples
+        --------
+        >>> df = pd.DataFrame([[np.nan, 2, np.nan, 0],
+        ...                    [3, 4, np.nan, 1],
+        ...                    [np.nan, np.nan, np.nan, 5],
+        ...                    [np.nan, 3, np.nan, 4]
+        ...                   ],
+        ...                   columns=list('ABCD'))
+        >>> df
+            A   B   C   D
+        0   NaN 2.0 NaN 0
+        1   3.0 4.0 NaN 1
+        2   NaN NaN NaN 5
+        3   NaN 3.0 NaN 4
+
+        Drop a row by index
+
+        >>> df.drop([0, 1])
+            A   B   C   D
+        2   NaN NaN NaN 5
+        3   NaN 3.0 NaN 4
+
+        Drop columns
+        >>> df.drop(['A', 'B'], axis=1)
+            C   D
+        0   NaN 0
+        1   NaN 1
+        2   NaN 5
+        3   NaN 4
         """
         inplace = validate_bool_kwarg(inplace, 'inplace')
         axis = self._get_axis_number(axis)

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -2079,6 +2079,7 @@ class NDFrame(PandasObject, SelectionMixin):
         3   NaN 3.0 NaN 4
 
         Drop columns
+
         >>> df.drop(['A', 'B'], axis=1)
             C   D
         0   NaN 0
@@ -2198,6 +2199,66 @@ class NDFrame(PandasObject, SelectionMixin):
         Returns
         -------
         sorted_obj : %(klass)s
+
+        Examples
+        --------
+        >>> df = pd.DataFrame({
+        ...     'col1' : ['A', 'A', 'B', np.nan, 'D', 'C'],
+        ...     'col2' : [2, 1, 9, 8, 7, 4],
+        ...     'col3': [0, 1, 9, 4, 2, 3],
+        ... })
+        >>> df
+            col1 col2 col3
+        0   A    2    0
+        1   A    1    1
+        2   B    9    9
+        3   NaN  8    4
+        4   D    7    2
+        5   C    4    3
+
+        Sort by col1
+
+        >>> df.sort_values(by=['col1'])
+            col1 col2 col3
+        0   A    2    0
+        1   A    1    1
+        2   B    9    9
+        5   C    4    3
+        4   D    7    2
+        3   NaN  8    4
+
+        Sort by multiple columns
+
+        >>> df.sort_values(by=['col1', 'col2'])
+            col1 col2 col3
+        1   A    1    1
+        0   A    2    0
+        2   B    9    9
+        5   C    4    3
+        4   D    7    2
+        3   NaN  8    4
+
+        Sort Descending
+
+        >>> df.sort_values(by='col1', ascending=False)
+            col1 col2 col3
+        4   D    7    2
+        5   C    4    3
+        2   B    9    9
+        0   A    2    0
+        1   A    1    1
+        3   NaN  8    4
+
+        Putting NAs first
+
+        >>> df.sort_values(by='col1', ascending=False, na_position='first')
+            col1 col2 col3
+        3   NaN  8    4
+        4   D    7    2
+        5   C    4    3
+        2   B    9    9
+        0   A    2    0
+        1   A    1    1
         """
 
     def sort_values(self, by, axis=0, ascending=True, inplace=False,


### PR DESCRIPTION
Adding examples for [`fillna`](https://pandas.pydata.org/pandas-docs/stable/generated/pandas.DataFrame.fillna.html), [`drop`](http://pandas.pydata.org/pandas-docs/stable/generated/pandas.DataFrame.drop.html), and [`sort_values`](http://pandas.pydata.org/pandas-docs/stable/generated/pandas.DataFrame.sort_values.html).
 - [x] related to #16416 
 - [x] tests added / passed
 - [x] passes ``git diff upstream/master --name-only -- '*.py' | flake8 --diff``
 - [x] whatsnew entry
