### PR TITLE
BUG: Render empty DataFrame as empty HTML table w/o raising IndexError.

### DIFF
--- a/doc/source/whatsnew/v0.20.2.txt
+++ b/doc/source/whatsnew/v0.20.2.txt
@@ -54,6 +54,7 @@ I/O
 ^^^
 
 - Bug that would force importing of the clipboard routines unnecessarily, potentially causing an import error on startup (:issue:`16288`)
+- Bug that raised IndexError HTML-rendering an empty DataFrame (:issue:`15953`)
 
 
 Plotting

--- a/pandas/io/formats/style.py
+++ b/pandas/io/formats/style.py
@@ -238,24 +238,25 @@ class Styler(object):
                            "class": " ".join(cs),
                            "is_visible": True})
 
-            for c, value in enumerate(clabels[r]):
-                cs = [COL_HEADING_CLASS, "level%s" % r, "col%s" % c]
-                cs.extend(cell_context.get(
-                    "col_headings", {}).get(r, {}).get(c, []))
-                es = {
-                    "type": "th",
-                    "value": value,
-                    "display_value": value,
-                    "class": " ".join(cs),
-                    "is_visible": _is_visible(c, r, col_lengths),
-                }
-                colspan = col_lengths.get((r, c), 0)
-                if colspan > 1:
-                    es["attributes"] = [
-                        format_attr({"key": "colspan", "value": colspan})
-                    ]
-                row_es.append(es)
-            head.append(row_es)
+            if clabels:
+                for c, value in enumerate(clabels[r]):
+                    cs = [COL_HEADING_CLASS, "level%s" % r, "col%s" % c]
+                    cs.extend(cell_context.get(
+                        "col_headings", {}).get(r, {}).get(c, []))
+                    es = {
+                        "type": "th",
+                        "value": value,
+                        "display_value": value,
+                        "class": " ".join(cs),
+                        "is_visible": _is_visible(c, r, col_lengths),
+                    }
+                    colspan = col_lengths.get((r, c), 0)
+                    if colspan > 1:
+                        es["attributes"] = [
+                            format_attr({"key": "colspan", "value": colspan})
+                        ]
+                    row_es.append(es)
+                head.append(row_es)
 
         if self.data.index.names and not all(x is None
                                              for x in self.data.index.names):

--- a/pandas/tests/io/formats/test_style.py
+++ b/pandas/tests/io/formats/test_style.py
@@ -103,6 +103,12 @@ class TestStyler(object):
         s.render()
         # it worked?
 
+    def test_render_empty_df(self):
+        empty_df = DataFrame()
+        es = Styler(empty_df)
+        es.render()
+        # It didn't raise IndexError?
+
     def test_render_double(self):
         df = pd.DataFrame({"A": [0, 1]})
         style = lambda x: pd.Series(["color: red; border: 1px",

--- a/pandas/tests/io/formats/test_style.py
+++ b/pandas/tests/io/formats/test_style.py
@@ -103,11 +103,15 @@ class TestStyler(object):
         s.render()
         # it worked?
 
-    def test_render_empty_df(self):
+    def test_render_empty_dfs(self):
         empty_df = DataFrame()
         es = Styler(empty_df)
         es.render()
-        # It didn't raise IndexError?
+        # An index but no columns
+        DataFrame(columns=['a']).style.render()
+        # A column but no index
+        DataFrame(index=['a']).style.render()
+        # No IndexError raised?
 
     def test_render_double(self):
         df = pd.DataFrame({"A": [0, 1]})


### PR DESCRIPTION
 - [X] closes #15953 
 - [X] 1 test added / passed
 - [X] passes ``git diff upstream/master --name-only -- '*.py' | flake8 --diff``
 - [ ] whatsnew entry

A one line change to add an ``if clabels`` guard to clabels enumeration.

Returns HTML string consisting of empty table.

Help requested with format and placement of whatsnew entry.
