### PR TITLE
BUG: .iloc[:] and .loc[:] return a copy of the original object #13873

### DIFF
--- a/doc/source/whatsnew/v0.21.0.txt
+++ b/doc/source/whatsnew/v0.21.0.txt
@@ -97,6 +97,7 @@ Conversion
 Indexing
 ^^^^^^^^
 
+- When called with a null slice (i.e. ``df.iloc[:]``), the``iloc`` and ``loc`` indexers return a shallow copy of the original object. Previously they returned the original object. (:issue:`13873`).
 
 
 I/O

--- a/doc/source/whatsnew/v0.21.0.txt
+++ b/doc/source/whatsnew/v0.21.0.txt
@@ -97,7 +97,7 @@ Conversion
 Indexing
 ^^^^^^^^
 
-- When called with a null slice (i.e. ``df.iloc[:]``), the``iloc`` and ``loc`` indexers return a shallow copy of the original object. Previously they returned the original object. (:issue:`13873`).
+- When called with a null slice (e.g. ``df.iloc[:]``), the``iloc`` and ``loc`` indexers return a shallow copy of the original object. Previously they returned the original object. (:issue:`13873`).
 
 
 I/O

--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -845,7 +845,7 @@ class _NDFrameIndexer(object):
             return self._multi_take(tup)
 
         # no shortcut needed
-        retval = self.obj
+        retval = self.obj.copy()
         for i, key in enumerate(tup):
             if i >= self.obj.ndim:
                 raise IndexingError('Too many indexers')
@@ -854,7 +854,6 @@ class _NDFrameIndexer(object):
                 continue
 
             retval = getattr(retval, self.name)._getitem_axis(key, axis=i)
-
         return retval
 
     def _multi_take_opportunity(self, tup):
@@ -1665,7 +1664,7 @@ class _iLocIndexer(_LocationIndexer):
         except:
             pass
 
-        retval = self.obj
+        retval = self.obj.copy()
         axis = 0
         for i, key in enumerate(tup):
             if i >= self.obj.ndim:

--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -1250,7 +1250,7 @@ class _NDFrameIndexer(object):
         obj = self.obj
 
         if not need_slice(slice_obj):
-            return obj.copy()
+            return obj.copy(deep=False)
         indexer = self._convert_slice_indexer(slice_obj, axis)
 
         if isinstance(indexer, slice):
@@ -1349,7 +1349,7 @@ class _LocationIndexer(_NDFrameIndexer):
         """ this is pretty simple as we just have to deal with labels """
         obj = self.obj
         if not need_slice(slice_obj):
-            return obj.copy()
+            return obj.copy(deep=False)
 
         labels = obj._get_axis(axis)
         indexer = labels.slice_indexer(slice_obj.start, slice_obj.stop,
@@ -1690,7 +1690,7 @@ class _iLocIndexer(_LocationIndexer):
         obj = self.obj
 
         if not need_slice(slice_obj):
-            return obj.copy()
+            return obj.copy(deep=False)
 
         slice_obj = self._convert_slice_indexer(slice_obj, axis)
         if isinstance(slice_obj, slice):

--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -1250,7 +1250,7 @@ class _NDFrameIndexer(object):
         obj = self.obj
 
         if not need_slice(slice_obj):
-            return obj
+            return obj.copy()
         indexer = self._convert_slice_indexer(slice_obj, axis)
 
         if isinstance(indexer, slice):
@@ -1349,7 +1349,7 @@ class _LocationIndexer(_NDFrameIndexer):
         """ this is pretty simple as we just have to deal with labels """
         obj = self.obj
         if not need_slice(slice_obj):
-            return obj
+            return obj.copy()
 
         labels = obj._get_axis(axis)
         indexer = labels.slice_indexer(slice_obj.start, slice_obj.stop,
@@ -1690,7 +1690,7 @@ class _iLocIndexer(_LocationIndexer):
         obj = self.obj
 
         if not need_slice(slice_obj):
-            return obj
+            return obj.copy()
 
         slice_obj = self._convert_slice_indexer(slice_obj, axis)
         if isinstance(slice_obj, slice):

--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -988,6 +988,10 @@ class _NDFrameIndexer(object):
                     if len(new_key) == 1:
                         new_key, = new_key
 
+                # Slices should return views, but calling iloc/loc with a null
+                # slice returns a new object.
+                if is_null_slice(new_key):
+                    return section
                 # This is an elided recursive call to iloc/loc/etc'
                 return getattr(section, self.name)[new_key]
 

--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -845,7 +845,7 @@ class _NDFrameIndexer(object):
             return self._multi_take(tup)
 
         # no shortcut needed
-        retval = self.obj.copy()
+        retval = self.obj
         for i, key in enumerate(tup):
             if i >= self.obj.ndim:
                 raise IndexingError('Too many indexers')
@@ -854,6 +854,7 @@ class _NDFrameIndexer(object):
                 continue
 
             retval = getattr(retval, self.name)._getitem_axis(key, axis=i)
+
         return retval
 
     def _multi_take_opportunity(self, tup):
@@ -1664,7 +1665,7 @@ class _iLocIndexer(_LocationIndexer):
         except:
             pass
 
-        retval = self.obj.copy()
+        retval = self.obj
         axis = 0
         for i, key in enumerate(tup):
             if i >= self.obj.ndim:

--- a/pandas/tests/indexing/test_iloc.py
+++ b/pandas/tests/indexing/test_iloc.py
@@ -591,3 +591,8 @@ class TestiLoc(Base):
         tm.assert_frame_equal(df.iloc[[]], df.iloc[:0, :],
                               check_index_type=True,
                               check_column_type=True)
+
+    def test_loc_identity_slice_returns_new_object(self):
+        # GH13873
+        df = DataFrame({'a': [1, 3, 5], 'b': [2, 4, 6]})
+        assert not df.iloc[:] is df

--- a/pandas/tests/indexing/test_iloc.py
+++ b/pandas/tests/indexing/test_iloc.py
@@ -594,5 +594,9 @@ class TestiLoc(Base):
 
     def test_loc_identity_slice_returns_new_object(self):
         # GH13873
-        df = DataFrame({'a': [1, 3, 5], 'b': [2, 4, 6]})
-        assert not df.iloc[:] is df
+        df = DataFrame({'a': [1, 2, 3]})
+        result = df.iloc[:]
+        assert not result is df
+        # should be a shallow copy
+        df['a'] = [4, 4, 4]
+        assert (result['a'] == 4).all()

--- a/pandas/tests/indexing/test_iloc.py
+++ b/pandas/tests/indexing/test_iloc.py
@@ -596,5 +596,3 @@ class TestiLoc(Base):
         # GH13873
         df = DataFrame({'a': [1, 3, 5], 'b': [2, 4, 6]})
         assert not df.iloc[:] is df
-        assert not df.iloc[:,:] is df
-        assert not df.iloc[pd.IndexSlice[:, :]] is df

--- a/pandas/tests/indexing/test_iloc.py
+++ b/pandas/tests/indexing/test_iloc.py
@@ -594,10 +594,18 @@ class TestiLoc(Base):
 
     def test_identity_slice_returns_new_object(self):
         # GH13873
-        df = DataFrame({'a': [1, 2, 3]})
-        result = df.iloc[:]
-        assert result is not df
+        original_df = DataFrame({'a': [1, 2, 3]})
+        sliced_df = original_df.iloc[:]
+        assert sliced_df is not original_df
 
         # should be a shallow copy
-        df['a'] = [4, 4, 4]
-        assert (result['a'] == 4).all()
+        original_df['a'] = [4, 4, 4]
+        assert (sliced_df['a'] == 4).all()
+
+        original_series = Series([1, 2, 3, 4, 5, 6])
+        sliced_series = original_series.iloc[:]
+        assert sliced_series is not original_series
+
+        # should also be a shallow copy
+        original_series[:3] = [7, 8, 9]
+        assert all(sliced_series[:3] == [7, 8, 9])

--- a/pandas/tests/indexing/test_iloc.py
+++ b/pandas/tests/indexing/test_iloc.py
@@ -596,7 +596,8 @@ class TestiLoc(Base):
         # GH13873
         df = DataFrame({'a': [1, 2, 3]})
         result = df.iloc[:]
-        assert not result is df
+        assert result is not df
+
         # should be a shallow copy
         df['a'] = [4, 4, 4]
         assert (result['a'] == 4).all()

--- a/pandas/tests/indexing/test_iloc.py
+++ b/pandas/tests/indexing/test_iloc.py
@@ -596,3 +596,5 @@ class TestiLoc(Base):
         # GH13873
         df = DataFrame({'a': [1, 3, 5], 'b': [2, 4, 6]})
         assert not df.iloc[:] is df
+        assert not df.iloc[:,:] is df
+        assert not df.iloc[pd.IndexSlice[:, :]] is df

--- a/pandas/tests/indexing/test_iloc.py
+++ b/pandas/tests/indexing/test_iloc.py
@@ -592,7 +592,7 @@ class TestiLoc(Base):
                               check_index_type=True,
                               check_column_type=True)
 
-    def test_loc_identity_slice_returns_new_object(self):
+    def test_identity_slice_returns_new_object(self):
         # GH13873
         df = DataFrame({'a': [1, 2, 3]})
         result = df.iloc[:]

--- a/pandas/tests/indexing/test_loc.py
+++ b/pandas/tests/indexing/test_loc.py
@@ -633,10 +633,18 @@ Region_1,Site_2,3977723089,A,5/20/2015 8:33,5/20/2015 9:09,Yes,No"""
 
     def test_identity_slice_returns_new_object(self):
         # GH13873
-        df = DataFrame({'a': [1, 2, 3]})
-        result = df.loc[:]
-        assert result is not df
+        original_df = DataFrame({'a': [1, 2, 3]})
+        sliced_df = original_df.loc[:]
+        assert sliced_df is not original_df
 
         # should be a shallow copy
-        df['a'] = [4, 4, 4]
-        assert (result['a'] == 4).all()
+        original_df['a'] = [4, 4, 4]
+        assert (sliced_df['a'] == 4).all()
+
+        original_series = Series([1, 2, 3, 4, 5, 6])
+        sliced_series = original_series.loc[:]
+        assert sliced_series is not original_series
+
+        # should also be a shallow copy
+        original_series[:3] = [7, 8, 9]
+        assert all(sliced_series[:3] == [7, 8, 9])

--- a/pandas/tests/indexing/test_loc.py
+++ b/pandas/tests/indexing/test_loc.py
@@ -635,5 +635,3 @@ Region_1,Site_2,3977723089,A,5/20/2015 8:33,5/20/2015 9:09,Yes,No"""
         # GH13873
         df = DataFrame({'a': [1, 3, 5], 'b': [2, 4, 6]})
         assert not df.loc[:] is df
-        assert not df.loc[:,:] is df
-        assert not df.loc[pd.IndexSlice[:, :]] is df

--- a/pandas/tests/indexing/test_loc.py
+++ b/pandas/tests/indexing/test_loc.py
@@ -631,7 +631,7 @@ Region_1,Site_2,3977723089,A,5/20/2015 8:33,5/20/2015 9:09,Yes,No"""
                               check_index_type=True,
                               check_column_type=True)
 
-    def test_loc_identity_slice_returns_new_object(self):
+    def test_identity_slice_returns_new_object(self):
         # GH13873
         df = DataFrame({'a': [1, 2, 3]})
         result = df.loc[:]

--- a/pandas/tests/indexing/test_loc.py
+++ b/pandas/tests/indexing/test_loc.py
@@ -641,10 +641,15 @@ Region_1,Site_2,3977723089,A,5/20/2015 8:33,5/20/2015 9:09,Yes,No"""
         original_df['a'] = [4, 4, 4]
         assert (sliced_df['a'] == 4).all()
 
+        # These should not return copies
+        assert original_df is original_df.loc[:, :]
+        df = DataFrame(np.random.randn(10, 4))
+        assert df[0] is df.loc[:,0]
+
+        # Same tests for Series
         original_series = Series([1, 2, 3, 4, 5, 6])
         sliced_series = original_series.loc[:]
         assert sliced_series is not original_series
 
-        # should also be a shallow copy
         original_series[:3] = [7, 8, 9]
         assert all(sliced_series[:3] == [7, 8, 9])

--- a/pandas/tests/indexing/test_loc.py
+++ b/pandas/tests/indexing/test_loc.py
@@ -644,7 +644,7 @@ Region_1,Site_2,3977723089,A,5/20/2015 8:33,5/20/2015 9:09,Yes,No"""
         # These should not return copies
         assert original_df is original_df.loc[:, :]
         df = DataFrame(np.random.randn(10, 4))
-        assert df[0] is df.loc[:,0]
+        assert df[0] is df.loc[:, 0]
 
         # Same tests for Series
         original_series = Series([1, 2, 3, 4, 5, 6])

--- a/pandas/tests/indexing/test_loc.py
+++ b/pandas/tests/indexing/test_loc.py
@@ -630,3 +630,8 @@ Region_1,Site_2,3977723089,A,5/20/2015 8:33,5/20/2015 9:09,Yes,No"""
         tm.assert_frame_equal(df.loc[[]], df.iloc[:0, :],
                               check_index_type=True,
                               check_column_type=True)
+
+    def test_loc_identity_slice_returns_new_object(self):
+        # GH13873
+        df = DataFrame({'a': [1, 3, 5], 'b': [2, 4, 6]})
+        assert not df.loc[:] is df

--- a/pandas/tests/indexing/test_loc.py
+++ b/pandas/tests/indexing/test_loc.py
@@ -635,3 +635,5 @@ Region_1,Site_2,3977723089,A,5/20/2015 8:33,5/20/2015 9:09,Yes,No"""
         # GH13873
         df = DataFrame({'a': [1, 3, 5], 'b': [2, 4, 6]})
         assert not df.loc[:] is df
+        assert not df.loc[:,:] is df
+        assert not df.loc[pd.IndexSlice[:, :]] is df

--- a/pandas/tests/indexing/test_loc.py
+++ b/pandas/tests/indexing/test_loc.py
@@ -633,5 +633,9 @@ Region_1,Site_2,3977723089,A,5/20/2015 8:33,5/20/2015 9:09,Yes,No"""
 
     def test_loc_identity_slice_returns_new_object(self):
         # GH13873
-        df = DataFrame({'a': [1, 3, 5], 'b': [2, 4, 6]})
-        assert not df.loc[:] is df
+        df = DataFrame({'a': [1, 2, 3]})
+        result = df.loc[:]
+        assert not result is df
+        # should be a shallow copy
+        df['a'] = [4, 4, 4]
+        assert (result['a'] == 4).all()

--- a/pandas/tests/indexing/test_loc.py
+++ b/pandas/tests/indexing/test_loc.py
@@ -636,6 +636,7 @@ Region_1,Site_2,3977723089,A,5/20/2015 8:33,5/20/2015 9:09,Yes,No"""
         original_df = DataFrame({'a': [1, 2, 3]})
         sliced_df = original_df.loc[:]
         assert sliced_df is not original_df
+        assert original_df[:] is not original_df
 
         # should be a shallow copy
         original_df['a'] = [4, 4, 4]
@@ -650,6 +651,7 @@ Region_1,Site_2,3977723089,A,5/20/2015 8:33,5/20/2015 9:09,Yes,No"""
         original_series = Series([1, 2, 3, 4, 5, 6])
         sliced_series = original_series.loc[:]
         assert sliced_series is not original_series
+        assert original_series[:] is not original_series
 
         original_series[:3] = [7, 8, 9]
         assert all(sliced_series[:3] == [7, 8, 9])

--- a/pandas/tests/indexing/test_loc.py
+++ b/pandas/tests/indexing/test_loc.py
@@ -635,7 +635,8 @@ Region_1,Site_2,3977723089,A,5/20/2015 8:33,5/20/2015 9:09,Yes,No"""
         # GH13873
         df = DataFrame({'a': [1, 2, 3]})
         result = df.loc[:]
-        assert not result is df
+        assert result is not df
+
         # should be a shallow copy
         df['a'] = [4, 4, 4]
         assert (result['a'] == 4).all()


### PR DESCRIPTION
Previously they returned the original. This PR should make it consistent with numpy and list.

 - [x] closes #13873
 - [x] tests added / passed
 - [x] passes ``git diff upstream/master --name-only -- '*.py' | flake8 --diff``
 - [x] whatsnew entry