### PR TITLE
BUG: Handle numpy strings in index names in HDF #13492

### DIFF
--- a/doc/source/whatsnew/v0.20.2.txt
+++ b/doc/source/whatsnew/v0.20.2.txt
@@ -70,6 +70,7 @@ I/O
 - Bug that raised IndexError HTML-rendering an empty DataFrame (:issue:`15953`)
 - Bug in ``pd.read_csv()`` in which tarfile object inputs were raising an error in Python 2.x for the C engine (:issue:`16530`)
 - Bug where ``DataFrame.to_html()`` ignored the ``index_names`` parameter (:issue:`16493`)
+- Bug where ``pd.read_hdf()`` returns numpy strings for index names (:issue:`13492`)
 
 - Bug in ``HDFStore.select_as_multiple()`` where start/stop arguments were not respected (:issue:`16209`)
 

--- a/pandas/io/pytables.py
+++ b/pandas/io/pytables.py
@@ -2568,6 +2568,8 @@ class GenericFixed(Fixed):
 
         if 'name' in node._v_attrs:
             name = node._v_attrs.name
+            if isinstance(name, compat.string_types):
+                name = compat.text_type(name)
 
         index_class = self._alias_to_class(getattr(node._v_attrs,
                                                    'index_class', ''))

--- a/pandas/io/pytables.py
+++ b/pandas/io/pytables.py
@@ -73,6 +73,18 @@ def _ensure_encoding(encoding):
     return encoding
 
 
+def _ensure_str(name):
+    """Ensure that an index / column name is a str (python 3) or
+    unicode (python 2); otherwise they may be np.string dtype.
+    Non-string dtypes are passed through unchanged.
+
+    https://github.com/pandas-dev/pandas/issues/13492
+    """
+    if isinstance(name, compat.string_types):
+        name = compat.text_type(name)
+    return name
+
+
 Term = Expr
 
 
@@ -2567,9 +2579,7 @@ class GenericFixed(Fixed):
         name = None
 
         if 'name' in node._v_attrs:
-            name = node._v_attrs.name
-            if isinstance(name, compat.string_types):
-                name = compat.text_type(name)
+            name = _ensure_str(node._v_attrs.name)
 
         index_class = self._alias_to_class(getattr(node._v_attrs,
                                                    'index_class', ''))


### PR DESCRIPTION
Work in progress!
 - [ ] closes #13492
 - [ ] tests added / passed
 - [x] passes ``git diff upstream/master --name-only -- '*.py' | flake8 --diff``
 - [x] whatsnew entry
