### PR TITLE
Don't ignore figsize in df.boxplot

### DIFF
--- a/doc/source/whatsnew/v0.20.2.txt
+++ b/doc/source/whatsnew/v0.20.2.txt
@@ -61,6 +61,7 @@ Plotting
 
 - Bug in ``DataFrame.plot`` with a single column and a list-like ``color`` (:issue:`3486`)
 - Bug in ``plot`` where ``NaT`` in ``DatetimeIndex`` results in ``Timestamp.min`` (:issue: `12405`)
+- Bug in ``DataFrame.boxplot`` where ``figsize`` keyword was not respected for non-grouped boxplots (:issue:`11959`)
 
 
 

--- a/doc/source/whatsnew/v0.21.0.txt
+++ b/doc/source/whatsnew/v0.21.0.txt
@@ -34,6 +34,7 @@ Other Enhancements
 - ``Series.to_dict()`` and ``DataFrame.to_dict()`` now support an ``into`` keyword which allows you to specify the ``collections.Mapping`` subclass that you would like returned.  The default is ``dict``, which is backwards compatible. (:issue:`16122`)
 - ``RangeIndex.append`` now returns a ``RangeIndex`` object when possible (:issue:`16212`)
 - :func:`to_pickle` has gained a protocol parameter (:issue:`16252`). By default, this parameter is set to `HIGHEST_PROTOCOL <https://docs.python.org/3/library/pickle.html#data-stream-format>`__
+- ``DataFrame.boxplot`` now respects the ``figsize`` keyword for non-grouped boxplots (:issue:`11959`)
 
 .. _whatsnew_0210.api_breaking:
 

--- a/doc/source/whatsnew/v0.21.0.txt
+++ b/doc/source/whatsnew/v0.21.0.txt
@@ -35,7 +35,6 @@ Other Enhancements
 - ``RangeIndex.append`` now returns a ``RangeIndex`` object when possible (:issue:`16212`)
 - :func:`to_pickle` has gained a protocol parameter (:issue:`16252`). By default, this parameter is set to `HIGHEST_PROTOCOL <https://docs.python.org/3/library/pickle.html#data-stream-format>`__
 - :func:`api.types.infer_dtype` now infers decimals. (:issue: `15690`)
-- ``DataFrame.boxplot`` now respects the ``figsize`` keyword for non-grouped boxplots (:issue:`11959`)
 
 .. _whatsnew_0210.api_breaking:
 

--- a/pandas/plotting/_core.py
+++ b/pandas/plotting/_core.py
@@ -49,9 +49,18 @@ def _get_standard_kind(kind):
     return {'density': 'kde'}.get(kind, kind)
 
 
-def _gca():
+def _gca(figsize=None):
     import matplotlib.pyplot as plt
-    return plt.gca()
+    if figsize is not None:
+        # No way of passing in figsize via gca() call so temporarily change the
+        # defaults so that when it calls figure() it uses our figsize.
+        old_figsize = plt.rcParams.get('figure.figsize')
+        plt.rcParams['figure.figsize'] = figsize
+    try:
+        return plt.gca()
+    finally:
+        if figsize is not None:
+            plt.rcParams['figure.figsize'] = old_figsize
 
 
 def _gcf():
@@ -1871,14 +1880,8 @@ def plot_series(data, kind='line', ax=None,                    # Series unique
                 **kwds):
 
     import matplotlib.pyplot as plt
-    """
-    If no axes is specified, check whether there are existing figures
-    If there is no existing figures, _gca() will
-    create a figure with the default figsize, causing the figsize=parameter to
-    be ignored.
-    """
     if ax is None and len(plt.get_fignums()) > 0:
-        ax = _gca()
+        ax = _gca(figsize)
         ax = MPLPlot._get_ax_layer(ax)
     return _plot(data, kind=kind, ax=ax,
                  figsize=figsize, use_index=use_index, title=title,
@@ -2006,7 +2009,7 @@ def boxplot(data, column=None, by=None, ax=None, fontsize=None,
                              "'by' is None")
 
         if ax is None:
-            ax = _gca()
+            ax = _gca(figsize)
         data = data._get_numeric_data()
         if columns is None:
             columns = data.columns

--- a/pandas/plotting/_core.py
+++ b/pandas/plotting/_core.py
@@ -51,16 +51,11 @@ def _get_standard_kind(kind):
 
 def _gca(figsize=None):
     import matplotlib.pyplot as plt
-    if figsize is not None:
-        # No way of passing in figsize via gca() call so temporarily change the
-        # defaults so that when it calls figure() it uses our figsize.
-        old_figsize = plt.rcParams.get('figure.figsize')
-        plt.rcParams['figure.figsize'] = figsize
-    try:
+    # No way of passing in figsize via gca() call so temporarily change the
+    # defaults so that when it calls figure() it uses our figsize.
+    rc = {'figure.figsize': figsize} if figsize is not None else {}
+    with plt.rc_context(rc):
         return plt.gca()
-    finally:
-        if figsize is not None:
-            plt.rcParams['figure.figsize'] = old_figsize
 
 
 def _gcf():
@@ -1881,7 +1876,7 @@ def plot_series(data, kind='line', ax=None,                    # Series unique
 
     import matplotlib.pyplot as plt
     if ax is None and len(plt.get_fignums()) > 0:
-        ax = _gca(figsize)
+        ax = _gca()
         ax = MPLPlot._get_ax_layer(ax)
     return _plot(data, kind=kind, ax=ax,
                  figsize=figsize, use_index=use_index, title=title,

--- a/pandas/plotting/_core.py
+++ b/pandas/plotting/_core.py
@@ -49,11 +49,8 @@ def _get_standard_kind(kind):
     return {'density': 'kde'}.get(kind, kind)
 
 
-def _gca(figsize=None):
+def _gca(rc=None):
     import matplotlib.pyplot as plt
-    # No way of passing in figsize via gca() call so temporarily change the
-    # defaults so that when it calls figure() it uses our figsize.
-    rc = {'figure.figsize': figsize} if figsize is not None else {}
     with plt.rc_context(rc):
         return plt.gca()
 
@@ -2004,7 +2001,8 @@ def boxplot(data, column=None, by=None, ax=None, fontsize=None,
                              "'by' is None")
 
         if ax is None:
-            ax = _gca(figsize)
+            rc = {'figure.figsize': figsize} if figsize is not None else {}
+            ax = _gca(rc)
         data = data._get_numeric_data()
         if columns is None:
             columns = data.columns

--- a/pandas/tests/plotting/test_boxplot_method.py
+++ b/pandas/tests/plotting/test_boxplot_method.py
@@ -162,8 +162,9 @@ class TestDataFramePlots(TestPlotBase):
 
     @slow
     def test_figsize(self):
-        df = DataFrame(np.random.rand(10, 5), columns=['A', 'B', 'C', 'D', 'E'])
-        result = df.boxplot(return_type='axes', figsize=(12,8))
+        df = DataFrame(np.random.rand(10, 5),
+                       columns=['A', 'B', 'C', 'D', 'E'])
+        result = df.boxplot(return_type='axes', figsize=(12, 8))
         assert result.figure.bbox_inches.width == 12
         assert result.figure.bbox_inches.height == 8
 

--- a/pandas/tests/plotting/test_boxplot_method.py
+++ b/pandas/tests/plotting/test_boxplot_method.py
@@ -160,6 +160,13 @@ class TestDataFramePlots(TestPlotBase):
         df.loc[:, 0] = np.nan
         _check_plot_works(df.boxplot, return_type='axes')
 
+    @slow
+    def test_figsize(self):
+        df = DataFrame(np.random.rand(10, 5), columns=['A', 'B', 'C', 'D', 'E'])
+        result = df.boxplot(return_type='axes', figsize=(12,8))
+        assert result.figure.bbox_inches.width == 12
+        assert result.figure.bbox_inches.height == 8
+
     def test_fontsize(self):
         df = DataFrame({"a": [1, 2, 3, 4, 5, 6]})
         self._check_ticks_props(df.boxplot("a", fontsize=16),


### PR DESCRIPTION
Work in progress from PyCon sprints

Fix for https://github.com/pandas-dev/pandas/issues/11959

It really doesn't feel like a proper fix, but I'm not sure what a proper fix would be (without changing matplotlib).  The matplotlib `gca()` ends up calling `figure()`, but doesn't let us pass in a `figsize` to `gca()`.

Any advice? FYI this works, ie it fixes the behavior for the code snippet in the bug report. It would obviously break in multithreaded scenarios, but I'm not sure if that's a consideration or not.