### PR TITLE
BUG: resample by BusinessHour raises ValueError

### DIFF
--- a/doc/source/whatsnew/v0.21.0.txt
+++ b/doc/source/whatsnew/v0.21.0.txt
@@ -102,6 +102,7 @@ Plotting
 Groupby/Resample/Rolling
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
+- Bug in ``.resample(..)`` with a ``BusinessHour`` raises ``ValueError`` (:issue:`12351`)
 
 
 Sparse

--- a/pandas/tests/test_resample.py
+++ b/pandas/tests/test_resample.py
@@ -2564,6 +2564,22 @@ class TestPeriodIndex(Base):
         expected = ts.asfreq('H', how='s').reindex(exp_rng)
         assert_series_equal(result, expected)
 
+
+    # GH12351
+    def test_resample_business_hourly(self):
+        rng = pd.date_range(start='2017-05-18 00:00:00',
+                            end='2017-05-19 23:00:00',
+                            freq='H')
+        expected_rng = pd.date_range(start='2017-05-18 00:00:00',
+                                    end='2017-05-19 23:00:00',
+                                    freq='BH')
+        ts = Series(1, index=rng)
+        result = ts.asfreq('BH')
+        expected_ts = Series(1, index=expected_rng)
+
+        assert_series_equal(result, expected_ts)
+
+
     def test_resample_irregular_sparse(self):
         dr = date_range(start='1/1/2012', freq='5min', periods=1000)
         s = Series(np.array(100), index=dr)

--- a/pandas/tests/test_resample.py
+++ b/pandas/tests/test_resample.py
@@ -2564,21 +2564,36 @@ class TestPeriodIndex(Base):
         expected = ts.asfreq('H', how='s').reindex(exp_rng)
         assert_series_equal(result, expected)
 
-
-    # GH12351
     def test_resample_business_hourly(self):
+        # GH12351
         rng = pd.date_range(start='2017-05-18 00:00:00',
                             end='2017-05-19 23:00:00',
                             freq='H')
         expected_rng = pd.date_range(start='2017-05-18 00:00:00',
-                                    end='2017-05-19 23:00:00',
-                                    freq='BH')
+                                     end='2017-05-19 23:00:00',
+                                     freq='BH')
         ts = Series(1, index=rng)
         result = ts.asfreq('BH')
         expected_ts = Series(1, index=expected_rng)
 
         assert_series_equal(result, expected_ts)
 
+    def test_resample_custom_business_hourly(self):
+        # GH12351
+        rng = pd.date_range(start='2017-05-18 00:00:00',
+                            end='2017-05-19 23:00:00',
+                            freq='H')
+
+        hours = offsets.CustomBusinessHour(start='10:00')
+        expected_rng = pd.date_range(start='2017-05-18 00:00:00',
+                                     end='2017-05-19 23:00:00',
+                                     freq=hours)
+
+        ts = Series(1, index=rng)
+        result = ts.asfreq(hours)
+        expected_ts = Series(1, index=expected_rng)
+
+        assert_series_equal(result, expected_ts)
 
     def test_resample_irregular_sparse(self):
         dr = date_range(start='1/1/2012', freq='5min', periods=1000)


### PR DESCRIPTION
 - [x] closes #12351
 - [x] tests added / passed
 - [x] passes ``git diff upstream/master --name-only -- '*.py' | flake8 --diff``
 - [x] whatsnew entry

I've been away from this issue for a long time. Just made this PR again at PyCon 2017. Sorry for a long absence.