### PR TITLE
BUG: Series.argmax() fails with np.inf

### DIFF
--- a/doc/source/whatsnew/v0.21.0.txt
+++ b/doc/source/whatsnew/v0.21.0.txt
@@ -265,7 +265,7 @@ Other API Changes
 - Removed the ``@slow`` decorator from ``pandas.util.testing``, which caused issues for some downstream packages' test suites. Use ``@pytest.mark.slow`` instead, which achieves the same thing (:issue:`16850`)
 - Moved definition of ``MergeError`` to the ``pandas.errors`` module.
 - The signature of :func:`Series.set_axis` and :func:`DataFrame.set_axis` has been changed from ``set_axis(axis, labels)`` to ``set_axis(labels, axis=0)``, for consistency with the rest of the API. The old signature is deprecated and will show a ``FutureWarning`` (:issue:`14636`)
-
+- :func:`Series.argmin` and :func:`Series.argmax` will now raise a ``TypeError`` when used with ``object`` dtypes, instead of a ``ValueError`` (:issue:`13595`)
 
 .. _whatsnew_0210.deprecations:
 
@@ -369,6 +369,7 @@ Reshaping
 - Fixes regression from 0.20, :func:`Series.aggregate` and :func:`DataFrame.aggregate` allow dictionaries as return values again (:issue:`16741`)
 - Fixes dtype of result with integer dtype input, from :func:`pivot_table` when called with ``margins=True`` (:issue:`17013`)
 - Bug in :func:`crosstab` where passing two ``Series`` with the same name raised a ``KeyError`` (:issue:`13279`)
+- :func:`Series.argmin`, :func:`Series.argmax`, and their counterparts on ``DataFrame`` and groupby objects work correctly with floating point data that contains infinite values (:issue:`13595`).
 
 Numeric
 ^^^^^^^

--- a/pandas/core/nanops.py
+++ b/pandas/core/nanops.py
@@ -486,23 +486,23 @@ nanmin = _nanminmax('min', fill_value_typ='+inf')
 nanmax = _nanminmax('max', fill_value_typ='-inf')
 
 
+@disallow('O')
 def nanargmax(values, axis=None, skipna=True):
     """
     Returns -1 in the NA case
     """
-    values, mask, dtype, _ = _get_values(values, skipna, fill_value_typ='-inf',
-                                         isfinite=True)
+    values, mask, dtype, _ = _get_values(values, skipna, fill_value_typ='-inf')
     result = values.argmax(axis)
     result = _maybe_arg_null_out(result, axis, mask, skipna)
     return result
 
 
+@disallow('O')
 def nanargmin(values, axis=None, skipna=True):
     """
     Returns -1 in the NA case
     """
-    values, mask, dtype, _ = _get_values(values, skipna, fill_value_typ='+inf',
-                                         isfinite=True)
+    values, mask, dtype, _ = _get_values(values, skipna, fill_value_typ='+inf')
     result = values.argmin(axis)
     result = _maybe_arg_null_out(result, axis, mask, skipna)
     return result

--- a/pandas/tests/groupby/test_groupby.py
+++ b/pandas/tests/groupby/test_groupby.py
@@ -2339,7 +2339,7 @@ class TestGroupBy(MixIn):
         assert_frame_equal(result, expected)
 
         # idxmax
-        expected = DataFrame([[0], [nan]], columns=['B'], index=[1, 3])
+        expected = DataFrame([[0.0], [nan]], columns=['B'], index=[1, 3])
         expected.index.name = 'A'
         result = g.idxmax()
         assert_frame_equal(result, expected)


### PR DESCRIPTION
closes #13595

This PR changes the behavior of two functions in the `nanops` module to address #13595, `nanargmax` and `nanargmin`. Previously, these two functions used a flag on the `_get_values` helper that caused it to 1) always mask out and ignore infinite values in the input, and 2) attempt to coerce the input to float.

It's worth noting that because of 2), this changes the way `nanargmax` and `nanargmin`, and consequently `Series.idxmax` etc, behave with string data. Previously,

```python
data = ['foo', 'bar', 'baz']

pd.Series(data).idxmax() # --> ValueError

pd.DataFrame({'A': data}).idxmax() # --> ValueError

pd.DataFrame({'grp': [1, 1, 2], 'A': data}).groupby('grp').idxmax() # --> an empty data frame
```

After the PR,

```python
In [1]: import pandas as pd

In [2]: data = ['foo', 'bar', 'baz']

In [3]: pd.Series(data).idxmax()
Out[3]: 0

In [4]: pd.DataFrame({'A': data}).idxmax()
Out[4]:
A    0
dtype: int64

In [5]: pd.DataFrame({'grp': [1, 1, 2], 'A': data}).groupby('grp').idxmax()
Out[5]:
     A
grp
1    0
2    2
```

This is consistent with the behavior of `numpy.argmax` etc with string data, and might be more consistent with user expectations. It did mean that I needed to update one of the `DataFrame.groupby` test cases, but otherwise appears to cause no breakage.

Since this might be a bigger change that was expected for fixing the issue, I'm posting it as WIP.

 - [x] closes #13595
 - [x] tests added / passed
 - [x] passes ``git diff upstream/master --name-only -- '*.py' | flake8 --diff``
 - [x] whatsnew entry
