### PR TITLE
BUG: Allow non-callable attributes in aggregate function. Fixes GH16405

### DIFF
--- a/doc/source/whatsnew/v0.20.2.txt
+++ b/doc/source/whatsnew/v0.20.2.txt
@@ -89,7 +89,7 @@ Reshaping
 - Bug in ``pd.wide_to_long()`` where no error was raised when ``i`` was not a unique identifier (:issue:`16382`)
 - Bug in ``Series.isin(..)`` with a list of tuples (:issue:`16394`)
 - Bug in construction of a ``DataFrame`` with mixed dtypes including an all-NaT column. (:issue:`16395`)
-- Bug in ``DataFrame.agg`` and ``Series.agg`` with aggregating on non-callable attributes (:issue:`16405`)
+- Bug in ``DataFrame.agg()`` and ``Series.agg()`` with aggregating on non-callable attributes (:issue:`16405`)
 
 
 Numeric

--- a/doc/source/whatsnew/v0.20.2.txt
+++ b/doc/source/whatsnew/v0.20.2.txt
@@ -89,6 +89,7 @@ Reshaping
 - Bug in ``pd.wide_to_long()`` where no error was raised when ``i`` was not a unique identifier (:issue:`16382`)
 - Bug in ``Series.isin(..)`` with a list of tuples (:issue:`16394`)
 - Bug in construction of a ``DataFrame`` with mixed dtypes including an all-NaT column. (:issue:`16395`)
+- Bug in ``DataFrame.agg`` and ``Series.agg`` with aggregating on non-callable attributes (:issue:`16404`)
 
 
 Numeric

--- a/doc/source/whatsnew/v0.20.2.txt
+++ b/doc/source/whatsnew/v0.20.2.txt
@@ -89,7 +89,7 @@ Reshaping
 - Bug in ``pd.wide_to_long()`` where no error was raised when ``i`` was not a unique identifier (:issue:`16382`)
 - Bug in ``Series.isin(..)`` with a list of tuples (:issue:`16394`)
 - Bug in construction of a ``DataFrame`` with mixed dtypes including an all-NaT column. (:issue:`16395`)
-- Bug in ``DataFrame.agg`` and ``Series.agg`` with aggregating on non-callable attributes (:issue:`16404`)
+- Bug in ``DataFrame.agg`` and ``Series.agg`` with aggregating on non-callable attributes (:issue:`16405`)
 
 
 Numeric

--- a/pandas/core/base.py
+++ b/pandas/core/base.py
@@ -378,7 +378,7 @@ class SelectionMixin(object):
     def _try_aggregate_string_function(self, arg, *args, **kwargs):
         """
         if arg is a string, then try to operate on it:
-        - try to find an attribute on ourselves
+        - try to find a function (or attribute) on ourselves
         - try to find a numpy function
         - raise
 
@@ -389,9 +389,12 @@ class SelectionMixin(object):
         if f is not None:
             if callable(f):
                 return f(*args, **kwargs)
+
             # people may try to aggregate on a non-callable attribute
             # but don't let them think they can pass args to it
-            assert len(args) == 0 and len(kwargs) == 0
+            assert len(args) == 0
+            assert len([kwarg for kwarg in kwargs
+                        if kwarg not in ['axis', '_level']]) == 0
             return f
 
         f = getattr(np, arg, None)

--- a/pandas/core/base.py
+++ b/pandas/core/base.py
@@ -378,7 +378,7 @@ class SelectionMixin(object):
     def _try_aggregate_string_function(self, arg, *args, **kwargs):
         """
         if arg is a string, then try to operate on it:
-        - try to find a function on ourselves
+        - try to find an attribute on ourselves
         - try to find a numpy function
         - raise
 
@@ -387,7 +387,12 @@ class SelectionMixin(object):
 
         f = getattr(self, arg, None)
         if f is not None:
-            return f(*args, **kwargs)
+            if callable(f):
+                return f(*args, **kwargs)
+            # people may try to aggregate on a non-callable attribute
+            # but don't let them think they can pass args to it
+            assert len(args) == 0 and len(kwargs) == 0
+            return f
 
         f = getattr(np, arg, None)
         if f is not None:

--- a/pandas/tests/frame/test_apply.py
+++ b/pandas/tests/frame/test_apply.py
@@ -639,6 +639,8 @@ class TestDataFrameAggregate(TestData):
     def test_non_callable_aggregates(self):
 
         # GH 16405
+        # 'size' is a property of frame/series
+        # validate that this is working
         df = DataFrame({'A': [None, 2, 3],
                         'B': [1.0, np.nan, 3.0],
                         'C': ['foo', None, 'bar']})

--- a/pandas/tests/frame/test_apply.py
+++ b/pandas/tests/frame/test_apply.py
@@ -664,9 +664,8 @@ class TestDataFrameAggregate(TestData):
                                  'B': {'count': 2, 'size': 3},
                                  'C': {'count': 2, 'size': 3}})
 
-        assert_frame_equal(result1.reindex_like(expected),
-                           result2.reindex_like(expected))
-        assert_frame_equal(result2.reindex_like(expected), expected)
+        assert_frame_equal(result1, result2, check_like=True)
+        assert_frame_equal(result2, expected, check_like=True)
 
         # Just functional string arg is same as calling df.arg()
         result = df.agg('count')
@@ -674,7 +673,8 @@ class TestDataFrameAggregate(TestData):
 
         assert_series_equal(result, expected)
 
-        # Trying to to the same w/ non-function tries to pass args
-        # which we explicitly forbid
-        with pytest.raises(AssertionError):
-            result = df.agg('size')
+        # Just a string attribute arg same as calling df.arg
+        result = df.agg('size')
+        expected = df.size
+
+        assert result == expected

--- a/pandas/tests/series/test_apply.py
+++ b/pandas/tests/series/test_apply.py
@@ -306,6 +306,22 @@ class TestSeriesAggregate(TestData):
                           name=self.series.name)
         assert_series_equal(result, expected)
 
+    def test_non_callable_aggregates(self):
+        # test agg using non-callable series attributes
+        s = Series([1, 2, None])
+
+        # Calling agg w/ just a string arg same as calling s.arg
+        result = s.agg('size')
+        expected = s.size
+        assert result == expected
+
+        # test when mixed w/ callable reducers
+        result = s.agg(['size', 'count', 'mean'])
+        expected = Series(OrderedDict({'size': 3.0,
+                                       'count': 2.0,
+                                       'mean': 1.5}))
+        assert_series_equal(result[expected.index], expected)
+
 
 class TestSeriesMap(TestData):
 


### PR DESCRIPTION
 - [x] closes #16405
 - [x] tests added / passed
 - [x] passes ``git diff upstream/master --name-only -- '*.py' | flake8 --diff``
 - [x] whatsnew entry
