### PR TITLE
BUG: strange timeseries plot behavior

### DIFF
--- a/pandas/tests/plotting/test_datetimelike.py
+++ b/pandas/tests/plotting/test_datetimelike.py
@@ -1349,6 +1349,22 @@ class TestTSPlot(TestPlotBase):
         w2 = np.arange(0, 1, .1)[::-1]
         self.plt.hist([x, x], weights=[w1, w2])
 
+    @slow
+    def test_overlapping_datetime(self):
+        # GB 6608
+        s1 = Series([1, 2, 3], index=[datetime(1995, 12, 31),
+                                      datetime(2000, 12, 31),
+                                      datetime(2005, 12, 31)])
+        s2 = Series([1, 2, 3], index=[datetime(1997, 12, 31),
+                                      datetime(2003, 12, 31),
+                                      datetime(2008, 12, 31)])
+
+        # plot first series, then add the second series to those axes,
+        # then try adding the first series again
+        ax = s1.plot()
+        s2.plot(ax=ax)
+        s1.plot(ax=ax)
+
 
 def _check_plot_works(f, freq=None, series=None, *args, **kwargs):
     import matplotlib.pyplot as plt

--- a/pandas/tests/plotting/test_series.py
+++ b/pandas/tests/plotting/test_series.py
@@ -434,22 +434,6 @@ class TestSeriesPlots(TestPlotBase):
         assert len(axes) == 2
 
     @slow
-    def test_overlapping_datetime(self):
-        # GB 6608
-        s1 = pd.Series([1, 2, 3], index=[datetime(1995, 12, 31),
-                                         datetime(2000, 12, 31),
-                                         datetime(2005, 12, 31)])
-        s2 = pd.Series([1, 2, 3], index=[datetime(1997, 12, 31),
-                                         datetime(2003, 12, 31),
-                                         datetime(2008, 12, 31)])
-
-        # plot first series, then add the second series to those axes,
-        # then try adding the first series again
-        ax = s1.plot()
-        s2.plot(ax=ax)
-        s1.plot(ax=ax)
-
-    @slow
     def test_hist_secondary_legend(self):
         # GH 9610
         df = DataFrame(np.random.randn(30, 4), columns=list('abcd'))

--- a/pandas/tests/plotting/test_series.py
+++ b/pandas/tests/plotting/test_series.py
@@ -434,6 +434,22 @@ class TestSeriesPlots(TestPlotBase):
         assert len(axes) == 2
 
     @slow
+    def test_overlapping_datetime(self):
+        # GB 6608
+        s1 = pd.Series([1, 2, 3], index=[datetime(1995, 12, 31),
+                                         datetime(2000, 12, 31),
+                                         datetime(2005, 12, 31)])
+        s2 = pd.Series([1, 2, 3], index=[datetime(1997, 12, 31),
+                                         datetime(2003, 12, 31),
+                                         datetime(2008, 12, 31)])
+
+        # plot first series, then add the second series to those axes,
+        # then try adding the first series again
+        ax = s1.plot()
+        s2.plot(ax=ax)
+        s1.plot(ax=ax)
+
+    @slow
     def test_hist_secondary_legend(self):
         # GH 9610
         df = DataFrame(np.random.randn(30, 4), columns=list('abcd'))


### PR DESCRIPTION
I added a test with the simple repro at the top of bug #6608, which appears to be the missing piece for the bug to be closed.

I went back in time to a previous version of pandas, and I confirmed the issue.
```
Python 2.7.13 (v2.7.13:a06454b1afa1, Dec 17 2016, 20:42:59) [MSC v.1500 32 bit (Intel)] on win32
Type "help", "copyright", "credits" or "license" for more information.
>>> import pandas as pd
>>> import datetime
>>>
>>> s1 = pd.Series([1, 2, 3], index=[datetime.datetime(1995, 12, 31), datetime.datetime(2000, 12, 31), datetime.datetime(2005, 12, 31)])
>>> s2 = pd.Series([1, 2, 3], index=[datetime.datetime(1997, 12, 31), datetime.datetime(2003, 12, 31), datetime.datetime(2008, 12, 31)])
>>>
>>> ax = s1.plot()
>>> s2.plot(ax=ax)
<matplotlib.axes._subplots.AxesSubplot object at 0x04ECED10>
>>> s1.plot(ax=ax)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "C:\Projects\Sprints\PandasVirtualEnvLatest\PandasVirtualEnvLatest\oldpy27\lib\site-packages\pandas\tools\plotting.py", line 1829, in plot_series
    plot_obj.generate()
  File "C:\Projects\Sprints\PandasVirtualEnvLatest\PandasVirtualEnvLatest\oldpy27\lib\site-packages\pandas\tools\plotting.py", line 905, in generate
    self._make_plot()
  File "C:\Projects\Sprints\PandasVirtualEnvLatest\PandasVirtualEnvLatest\oldpy27\lib\site-packages\pandas\tools\plotting.py", line 1317, in _make_plot
    self._make_ts_plot(data, **self.kwds)
  File "C:\Projects\Sprints\PandasVirtualEnvLatest\PandasVirtualEnvLatest\oldpy27\lib\site-packages\pandas\tools\plotting.py", line 1388, in _make_ts_plot
    _plot(data, 0, ax, label, self.style, **kwds)
  File "C:\Projects\Sprints\PandasVirtualEnvLatest\PandasVirtualEnvLatest\oldpy27\lib\site-packages\pandas\tools\plotting.py", line 1372, in _plot
    style=style, **kwds)
  File "C:\Projects\Sprints\PandasVirtualEnvLatest\PandasVirtualEnvLatest\oldpy27\lib\site-packages\pandas\tseries\plotting.py", line 82, in tsplot
    left, right = _get_xlim(ax.get_lines())
  File "C:\Projects\Sprints\PandasVirtualEnvLatest\PandasVirtualEnvLatest\oldpy27\lib\site-packages\pandas\tseries\plotting.py", line 226, in _get_xlim
    left = min(x[0].ordinal, left)
AttributeError: 'datetime.datetime' object has no attribute 'ordinal'
>>> print(pd.__version__)
0.13.1
>>>
```
