### PR TITLE
BUG: writing invalid table names to sqlite

### DIFF
--- a/pandas/tests/io/test_sql.py
+++ b/pandas/tests/io/test_sql.py
@@ -816,6 +816,11 @@ class _TestSQLApi(PandasSQLTest):
         df = DataFrame([[1, 2], [3, 4]], columns=[u'\xe9', u'b'])
         df.to_sql('test_unicode', self.conn, index=False)
 
+    def test_escaped_table_name(self):
+        # GH 13206
+        df = DataFrame({'A': [0, 1, 2], 'B': [0.2, np.nan, 5.6]})
+        df.to_sql('d1187b08-4943-4c8d-a7f6-6c06b7cb9509', self.conn, index=False)
+
 
 @pytest.mark.single
 class TestSQLApi(SQLAlchemyMixIn, _TestSQLApi):

--- a/pandas/tests/io/test_sql.py
+++ b/pandas/tests/io/test_sql.py
@@ -819,7 +819,12 @@ class _TestSQLApi(PandasSQLTest):
     def test_escaped_table_name(self):
         # GH 13206
         df = DataFrame({'A': [0, 1, 2], 'B': [0.2, np.nan, 5.6]})
-        df.to_sql('d1187b08-4943-4c8d-a7f6-6c06b7cb9509', self.conn, index=False)
+        df.to_sql('d1187b08-4943-4c8d-a7f6', self.conn, index=False)
+
+        res = sql.read_sql_query('SELECT * FROM `d1187b08-4943-4c8d-a7f6`',
+                                 self.conn)
+
+        tm.assert_frame_equal(res, df)
 
 
 @pytest.mark.single


### PR DESCRIPTION
I verified that the test exposes the bug prior to the fix for bug #13206.

Pandas from master
```
>>> import sqlite3
>>> import pandas as pd
>>> import numpy as np
>>> conn = sqlite3.connect(':memory:')
>>> df = pd.DataFrame({'A': [0, 1, 2], 'B': [0.2, np.nan, 5.6]})
>>> df.to_sql('d1187b08-4943-4c8d-a7f6-6c06b7cb9509', conn, index=False)
>>> 
```

Pandas 0.13.1
```
>>> import sqlite3
>>> import pandas as pd
>>> import numpy as np
>>> conn = sqlite3.connect(':memory:')
>>> df = pd.DataFrame({'A': [0, 1, 2], 'B': [0.2, np.nan, 5.6]})
>>> df.to_sql('d1187b08-4943-4c8d-a7f6-6c06b7cb9509', conn, index=False)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "C:\Projects\Sprints\PandasVirtualEnvLatest\PandasVirtualEnvLatest\oldpy27\lib\site-packages\pandas\core\frame.py", line 1261, in to_sql
    self, name, con, flavor=flavor, if_exists=if_exists, **kwargs)
  File "C:\Projects\Sprints\PandasVirtualEnvLatest\PandasVirtualEnvLatest\oldpy27\lib\site-packages\pandas\io\sql.py", line 226, in write_frame
    cur.execute(create)
OperationalError: near "-": syntax error
>>> 
```
