### PR TITLE
BUG: fixed wrong order of ordered labels in pd.cut()

### DIFF
--- a/doc/source/whatsnew/v0.20.2.txt
+++ b/doc/source/whatsnew/v0.20.2.txt
@@ -44,7 +44,7 @@ Bug Fixes
 - Bug in ``DataFrame.update()`` with ``overwrite=False`` and ``NaN values`` (:issue:`15593`)
 - Passing an invalid engine to :func:`read_csv` now raises an informative
   ``ValueError`` rather than ``UnboundLocalError``. (:issue:`16511`)
-- Bug in ``pd.cut`` when ``labels`` are set (:issue:`16459`)
+- Bug in ``pd.cut`` when ``labels`` are set, resulting in incorrect label ordering (:issue:`16459`)
 - Fixed a compatibility issue with IPython 6.0's tab completion showing deprecation warnings on Categoricals (:issue:`16409`)
 
 Conversion

--- a/doc/source/whatsnew/v0.20.2.txt
+++ b/doc/source/whatsnew/v0.20.2.txt
@@ -44,12 +44,8 @@ Bug Fixes
 - Bug in ``DataFrame.update()`` with ``overwrite=False`` and ``NaN values`` (:issue:`15593`)
 - Passing an invalid engine to :func:`read_csv` now raises an informative
   ``ValueError`` rather than ``UnboundLocalError``. (:issue:`16511`)
-
-
-
-
+- Bug in ``pd.cut`` when ``labels`` are set (:issue:`16459`)
 - Fixed a compatibility issue with IPython 6.0's tab completion showing deprecation warnings on Categoricals (:issue:`16409`)
-
 
 Conversion
 ^^^^^^^^^^

--- a/pandas/core/reshape/tile.py
+++ b/pandas/core/reshape/tile.py
@@ -254,7 +254,7 @@ def _bins_to_cuts(x, bins, right=True, labels=None,
                 raise ValueError('Bin labels must be one fewer than '
                                  'the number of bin edges')
         if not is_categorical_dtype(labels):
-            labels = Categorical(labels, ordered=True)
+            labels = Categorical(labels, categories=labels, ordered=True)
 
         np.putmask(ids, na_mask, 0)
         result = algos.take_nd(labels, ids - 1)

--- a/pandas/tests/reshape/test_tile.py
+++ b/pandas/tests/reshape/test_tile.py
@@ -220,6 +220,7 @@ class TestCut(object):
         exp = Categorical.from_codes([1] + 4 * [0] + [1, 2], labels)
         tm.assert_categorical_equal(result, exp)
 
+	# issue 16459
         labels = ['Good', 'Medium', 'Bad']
         result = cut(arr, 3, labels=labels)
         exp = cut(arr, 3, labels=Categorical(labels, categories=labels,

--- a/pandas/tests/reshape/test_tile.py
+++ b/pandas/tests/reshape/test_tile.py
@@ -211,12 +211,19 @@ class TestCut(object):
 
         result = cut(arr, bins, labels=labels)
         exp = Categorical(['Medium'] + 4 * ['Small'] + ['Medium', 'Large'],
+                          categories=labels,
                           ordered=True)
         tm.assert_categorical_equal(result, exp)
 
         result = cut(arr, bins, labels=Categorical.from_codes([0, 1, 2],
                                                               labels))
         exp = Categorical.from_codes([1] + 4 * [0] + [1, 2], labels)
+        tm.assert_categorical_equal(result, exp)
+
+        labels = ['Good', 'Medium', 'Bad']
+        result = cut(arr, 3, labels=labels)
+        exp = cut(arr, 3, labels=Categorical(labels, categories=labels,
+                                             ordered=True))
         tm.assert_categorical_equal(result, exp)
 
     def test_qcut_include_lowest(self):


### PR DESCRIPTION
 - [x] closes #16459 
 - [x] tests added / passed
 - [x] passes ``git diff upstream/master --name-only -- '*.py' | flake8 --diff``
 - [ ] whatsnew entry

Changes to how `cut` instantiates `Categorical` when a list of labels are passed to it, and the `test_cut_pass_labels` test for it. If labels are passed in as a `Categorical` already, behavior isn't altered at all, but if the user specifies a list of labels, the rank ordering of those labels is preserved in `cut`.
