### PR TITLE
TST: Fix test assertions

### DIFF
--- a/pandas/tests/groupby/test_nth.py
+++ b/pandas/tests/groupby/test_nth.py
@@ -153,8 +153,8 @@ class TestNth(MixIn):
         expected = s.groupby(g).first()
         expected2 = s.groupby(g).apply(lambda x: x.iloc[0])
         assert_series_equal(expected2, expected, check_names=False)
-        assert expected.name, 0
         assert expected.name == 1
+        assert expected2.name == 1
 
         # validate first
         v = s[g == 1].iloc[0]

--- a/pandas/tests/indexes/datetimes/test_tools.py
+++ b/pandas/tests/indexes/datetimes/test_tools.py
@@ -625,7 +625,7 @@ class ToDatetimeMisc(object):
     def test_to_datetime_default(self):
         rs = to_datetime('2001')
         xp = datetime(2001, 1, 1)
-        assert rs, xp
+        assert rs == xp
 
         # dayfirst is essentially broken
 

--- a/pandas/tests/indexes/period/test_construction.py
+++ b/pandas/tests/indexes/period/test_construction.py
@@ -135,15 +135,15 @@ class TestPeriodIndex(object):
 
         result = PeriodIndex(idx, freq=offsets.MonthEnd())
         tm.assert_index_equal(result, idx)
-        assert result.freq, 'M'
+        assert result.freq == 'M'
 
         result = PeriodIndex(idx, freq='2M')
         tm.assert_index_equal(result, idx.asfreq('2M'))
-        assert result.freq, '2M'
+        assert result.freq == '2M'
 
         result = PeriodIndex(idx, freq=offsets.MonthEnd(2))
         tm.assert_index_equal(result, idx.asfreq('2M'))
-        assert result.freq, '2M'
+        assert result.freq == '2M'
 
         result = PeriodIndex(idx, freq='D')
         exp = idx.asfreq('D', 'e')

--- a/pandas/tests/indexes/test_range.py
+++ b/pandas/tests/indexes/test_range.py
@@ -172,16 +172,16 @@ class TestRangeIndex(Numeric):
         copy = RangeIndex(orig)
         copy.name = 'copy'
 
-        assert orig.name, 'original'
-        assert copy.name, 'copy'
+        assert orig.name == 'original'
+        assert copy.name == 'copy'
 
         new = Index(copy)
-        assert new.name, 'copy'
+        assert new.name == 'copy'
 
         new.name = 'new'
-        assert orig.name, 'original'
-        assert new.name, 'copy'
-        assert new.name, 'new'
+        assert orig.name == 'original'
+        assert copy.name == 'copy'
+        assert new.name == 'new'
 
     def test_numeric_compat2(self):
         # validate that we are handling the RangeIndex overrides to numeric ops
@@ -273,7 +273,7 @@ class TestRangeIndex(Numeric):
             expected = "RangeIndex(start=0, stop=5, step=1, name='Foo')"
         else:
             expected = "RangeIndex(start=0, stop=5, step=1, name=u'Foo')"
-        assert result, expected
+        assert result == expected
 
         result = eval(result)
         tm.assert_index_equal(result, i, exact=True)

--- a/pandas/tests/plotting/test_datetimelike.py
+++ b/pandas/tests/plotting/test_datetimelike.py
@@ -843,7 +843,7 @@ class TestTSPlot(TestPlotBase):
         tsplot(high, plt.Axes.plot)
         lines = tsplot(low, plt.Axes.plot)
         for l in lines:
-            assert PeriodIndex(data=l.get_xdata()).freq, idxh.freq
+            assert PeriodIndex(data=l.get_xdata()).freq == idxh.freq
 
     @slow
     def test_from_weekly_resampling(self):
@@ -858,7 +858,7 @@ class TestTSPlot(TestPlotBase):
         expected_l = np.array([1514, 1519, 1523, 1527, 1531, 1536, 1540, 1544,
                                1549, 1553, 1558, 1562], dtype=np.float64)
         for l in ax.get_lines():
-            assert PeriodIndex(data=l.get_xdata()).freq, idxh.freq
+            assert PeriodIndex(data=l.get_xdata()).freq == idxh.freq
             xdata = l.get_xdata(orig=False)
             if len(xdata) == 12:  # idxl lines
                 tm.assert_numpy_array_equal(xdata, expected_l)
@@ -873,7 +873,7 @@ class TestTSPlot(TestPlotBase):
         tsplot(low, plt.Axes.plot)
         lines = tsplot(high, plt.Axes.plot)
         for l in lines:
-            assert PeriodIndex(data=l.get_xdata()).freq, idxh.freq
+            assert PeriodIndex(data=l.get_xdata()).freq == idxh.freq
             xdata = l.get_xdata(orig=False)
             if len(xdata) == 12:  # idxl lines
                 tm.assert_numpy_array_equal(xdata, expected_l)

--- a/pandas/tests/series/test_timeseries.py
+++ b/pandas/tests/series/test_timeseries.py
@@ -916,7 +916,7 @@ class TestTimeSeries(TestData):
         assert df['Forecasting'][0] == dates[0][1]
 
         s = Series(arr['Date'])
-        assert s[0], Timestamp
+        assert isinstance(s[0], Timestamp)
         assert s[0] == dates[0][0]
 
         s = Series.from_array(arr['Date'], Index([0]))

--- a/pandas/tests/test_lib.py
+++ b/pandas/tests/test_lib.py
@@ -13,15 +13,15 @@ class TestMisc(object):
     def test_max_len_string_array(self):
 
         arr = a = np.array(['foo', 'b', np.nan], dtype='object')
-        assert lib.max_len_string_array(arr), 3
+        assert lib.max_len_string_array(arr) == 3
 
         # unicode
         arr = a.astype('U').astype(object)
-        assert lib.max_len_string_array(arr), 3
+        assert lib.max_len_string_array(arr) == 3
 
         # bytes for python3
         arr = a.astype('S').astype(object)
-        assert lib.max_len_string_array(arr), 3
+        assert lib.max_len_string_array(arr) == 3
 
         # raises
         pytest.raises(TypeError,

--- a/pandas/tests/test_strings.py
+++ b/pandas/tests/test_strings.py
@@ -2102,12 +2102,12 @@ class TestStringMethods(object):
         idx = Index(['a,b', 'c,d'], name='xxx')
         res = idx.str.split(',')
         exp = Index([['a', 'b'], ['c', 'd']], name='xxx')
-        assert res.nlevels, 1
+        assert res.nlevels == 1
         tm.assert_index_equal(res, exp)
 
         res = idx.str.split(',', expand=True)
         exp = MultiIndex.from_tuples([('a', 'b'), ('c', 'd')])
-        assert res.nlevels, 2
+        assert res.nlevels == 2
         tm.assert_index_equal(res, exp)
 
     def test_partition_series(self):
@@ -2247,13 +2247,13 @@ class TestStringMethods(object):
         idx = Index(['a,b', 'c,d'], name='xxx')
         res = idx.str.partition(',')
         exp = MultiIndex.from_tuples([('a', ',', 'b'), ('c', ',', 'd')])
-        assert res.nlevels, 3
+        assert res.nlevels == 3
         tm.assert_index_equal(res, exp)
 
         # should preserve name
         res = idx.str.partition(',', expand=False)
         exp = Index(np.array([('a', ',', 'b'), ('c', ',', 'd')]), name='xxx')
-        assert res.nlevels, 1
+        assert res.nlevels == 1
         tm.assert_index_equal(res, exp)
 
     def test_pipe_failures(self):


### PR DESCRIPTION
 - [ ] closes #xxxx
 - [ ] tests added / passed
 - [x] passes ``git diff upstream/master --name-only -- '*.py' | flake8 --diff``
 - [ ] whatsnew entry

This fixes some test assertions that were only checking the truthiness of a value when they should have been comparing two values. Initially, through typos, tests were written using assertTrue when they should have been using assertEqual. The second argument to assertTrue was being treated as a message instead of as the expected value. More recently, these assertions with typos were transformed to use `assert`, with the same problems persisting.

I have fixed each of the problems I found on a case-by-case basis. Some lines required more complicated fixes, like adding instanceof() or fixing an expected value. I believe I have found all such instances of this error, because I reviewed all the locations where assertTrue was called with two arguments.