### PR TITLE
Fixed to_html ignoring index_names parameter

### DIFF
--- a/doc/source/whatsnew/v0.20.2.txt
+++ b/doc/source/whatsnew/v0.20.2.txt
@@ -59,6 +59,7 @@ I/O
 - Bug in pd.read_csv() when comment is passed in space deliminted text files (:issue:`16472`)
 - Bug that would force importing of the clipboard routines unnecessarily, potentially causing an import error on startup (:issue:`16288`)
 - Bug that raised IndexError HTML-rendering an empty DataFrame (:issue:`15953`)
+- Bug where to_html ignored the index_names parameter (:issue:`16493`)
 
 
 Plotting

--- a/doc/source/whatsnew/v0.20.2.txt
+++ b/doc/source/whatsnew/v0.20.2.txt
@@ -59,7 +59,7 @@ I/O
 - Bug in pd.read_csv() when comment is passed in space deliminted text files (:issue:`16472`)
 - Bug that would force importing of the clipboard routines unnecessarily, potentially causing an import error on startup (:issue:`16288`)
 - Bug that raised IndexError HTML-rendering an empty DataFrame (:issue:`15953`)
-- Bug where ``DataFrame.to_html`` ignored the ``index_names`` parameter (:issue:`16493`)
+- Bug where ``DataFrame.to_html()`` ignored the ``index_names`` parameter (:issue:`16493`)
 
 
 Plotting

--- a/doc/source/whatsnew/v0.20.2.txt
+++ b/doc/source/whatsnew/v0.20.2.txt
@@ -59,7 +59,7 @@ I/O
 - Bug in pd.read_csv() when comment is passed in space deliminted text files (:issue:`16472`)
 - Bug that would force importing of the clipboard routines unnecessarily, potentially causing an import error on startup (:issue:`16288`)
 - Bug that raised IndexError HTML-rendering an empty DataFrame (:issue:`15953`)
-- Bug where to_html ignored the index_names parameter (:issue:`16493`)
+- Bug where ``DataFrame.to_html`` ignored the ``index_names`` parameter (:issue:`16493`)
 
 
 Plotting

--- a/pandas/io/formats/format.py
+++ b/pandas/io/formats/format.py
@@ -1292,7 +1292,7 @@ class HTMLFormatter(TableFormatter):
             self.write_tr(col_row, indent, self.indent_delta, header=True,
                           align=align)
 
-        if self.fmt.has_index_names and self.fmt.index:
+        if self.fmt.has_index_names and self.fmt.index and self.show_index_names:
             row = ([x if x is not None else ''
                     for x in self.frame.index.names] +
                    [''] * min(len(self.columns), self.max_cols))

--- a/pandas/io/formats/format.py
+++ b/pandas/io/formats/format.py
@@ -1292,7 +1292,7 @@ class HTMLFormatter(TableFormatter):
             self.write_tr(col_row, indent, self.indent_delta, header=True,
                           align=align)
 
-        if self.fmt.has_index_names and self.fmt.index and self.show_index_names:
+        if self.fmt.has_index_names and self.fmt.index and self.fmt.show_index_names:
             row = ([x if x is not None else ''
                     for x in self.frame.index.names] +
                    [''] * min(len(self.columns), self.max_cols))

--- a/pandas/io/formats/format.py
+++ b/pandas/io/formats/format.py
@@ -1292,7 +1292,9 @@ class HTMLFormatter(TableFormatter):
             self.write_tr(col_row, indent, self.indent_delta, header=True,
                           align=align)
 
-        if self.fmt.has_index_names and self.fmt.index and self.fmt.show_index_names:
+        if all(self.fmt.has_index_names,
+                self.fmt.index,
+                self.fmt.show_index_names):
             row = ([x if x is not None else ''
                     for x in self.frame.index.names] +
                    [''] * min(len(self.columns), self.max_cols))

--- a/pandas/io/formats/format.py
+++ b/pandas/io/formats/format.py
@@ -1292,9 +1292,9 @@ class HTMLFormatter(TableFormatter):
             self.write_tr(col_row, indent, self.indent_delta, header=True,
                           align=align)
 
-        if all(self.fmt.has_index_names,
+        if all((self.fmt.has_index_names,
                 self.fmt.index,
-                self.fmt.show_index_names):
+                self.fmt.show_index_names)):
             row = ([x if x is not None else ''
                     for x in self.frame.index.names] +
                    [''] * min(len(self.columns), self.max_cols))

--- a/pandas/tests/io/formats/test_to_html.py
+++ b/pandas/tests/io/formats/test_to_html.py
@@ -1869,3 +1869,8 @@ class TestToHTML(object):
         df = pd.DataFrame({"A": [1, 2, 3]})
         result = df.to_html()
         assert "thead tr:only-child" not in result
+
+    def test_to_html_with_index_names_false(self):
+        df = pd.DataFrame({"A": [1, 2], index=pd.Index(['a', 'b'], name='myindexname'})
+        result = df.to_html(index_names=False)
+        assert 'myindexname' not in result

--- a/pandas/tests/io/formats/test_to_html.py
+++ b/pandas/tests/io/formats/test_to_html.py
@@ -1871,6 +1871,7 @@ class TestToHTML(object):
         assert "thead tr:only-child" not in result
 
     def test_to_html_with_index_names_false(self):
+        # gh-16493
         df = pd.DataFrame({"A": [1, 2]}, index=pd.Index(['a', 'b'],
                                                         name='myindexname'))
         result = df.to_html(index_names=False)

--- a/pandas/tests/io/formats/test_to_html.py
+++ b/pandas/tests/io/formats/test_to_html.py
@@ -1871,6 +1871,6 @@ class TestToHTML(object):
         assert "thead tr:only-child" not in result
 
     def test_to_html_with_index_names_false(self):
-        df = pd.DataFrame({"A": [1, 2], index=pd.Index(['a', 'b'], name='myindexname'})
+        df = pd.DataFrame({"A": [1, 2]}, index=pd.Index(['a', 'b'], name='myindexname'))
         result = df.to_html(index_names=False)
         assert 'myindexname' not in result

--- a/pandas/tests/io/formats/test_to_html.py
+++ b/pandas/tests/io/formats/test_to_html.py
@@ -1871,6 +1871,7 @@ class TestToHTML(object):
         assert "thead tr:only-child" not in result
 
     def test_to_html_with_index_names_false(self):
-        df = pd.DataFrame({"A": [1, 2]}, index=pd.Index(['a', 'b'], name='myindexname'))
+        df = pd.DataFrame({"A": [1, 2]}, index=pd.Index(['a', 'b'],
+                                                        name='myindexname'))
         result = df.to_html(index_names=False)
         assert 'myindexname' not in result


### PR DESCRIPTION
 - [x ] closes #16493
 - [ ] tests added / passed
 - [ ] passes ``git diff upstream/master --name-only -- '*.py' | flake8 --diff``
 - [ ] whatsnew entry
