### PR TITLE
BUG: Fixed tput output on windows

### DIFF
--- a/doc/source/whatsnew/v0.20.2.txt
+++ b/doc/source/whatsnew/v0.20.2.txt
@@ -36,6 +36,8 @@ Performance Improvements
 Bug Fixes
 ~~~~~~~~~
 
+- Silenced a warning on some Windows environments about "tput: terminal attributes: No such device or address" when
+  detecting the terminal size. This fix only applies to python 3 (:issue:`16496`)
 - Bug in using ``pathlib.Path`` or ``py.path.local`` objects with io functions (:issue:`16291`)
 - Bug in ``DataFrame.update()`` with ``overwrite=False`` and ``NaN values`` (:issue:`15593`)
 

--- a/pandas/io/formats/terminal.py
+++ b/pandas/io/formats/terminal.py
@@ -14,6 +14,8 @@ on linux, os x, windows and cygwin (windows).
 from __future__ import print_function
 
 import os
+import sys
+import shutil
 
 __all__ = ['get_terminal_size']
 
@@ -26,6 +28,10 @@ def get_terminal_size():
     IPython zmq frontends, or IDLE do not run in a terminal,
     """
     import platform
+
+    if sys.version_info[0] >= 3:
+        return shutil.get_terminal_size()
+
     current_os = platform.system()
     tuple_xy = None
     if current_os == 'Windows':


### PR DESCRIPTION
This came up in [dask](
https://ci.appveyor.com/project/daskdev/dask/build/1.0.1397#L477). For reasons I don't understand, you can end up with a bunch of warnings like `tput: terminal attributes: No such device or address` when pandas calls `get_terminal_size`

I was able to monkey patch those calls with `shutil.get_terminal_size` and verify that the warnings were fixed. However that's python3 only. This change uses `shutil.get_terminal_size` when possible, and falls back to our prior implementation otherwise.

Not sure about unit tests, but manually, the output matches on my mac.