### PR TITLE
BUG: clip dataframe column-wise #15390

### DIFF
--- a/doc/source/whatsnew/v0.21.0.txt
+++ b/doc/source/whatsnew/v0.21.0.txt
@@ -143,3 +143,5 @@ Categorical
 
 Other
 ^^^^^
+
+- Bug in ``.clip()`` now takes list or numpy-array; previously this raised ``ValueError`` (:issue:`15390`)

--- a/doc/source/whatsnew/v0.21.0.txt
+++ b/doc/source/whatsnew/v0.21.0.txt
@@ -135,7 +135,7 @@ Reshaping
 
 Numeric
 ^^^^^^^
-- Bug in ``.clip()`` When list-like is passed; previously this raised ``ValueError`` (:issue:`15390`)
+- Bug in ``.clip()`` with ``axis=1`` and a list-like for ``threshold`` is passed; previously this raised ``ValueError`` (:issue:`15390`)
 
 
 Categorical

--- a/doc/source/whatsnew/v0.21.0.txt
+++ b/doc/source/whatsnew/v0.21.0.txt
@@ -135,6 +135,7 @@ Reshaping
 
 Numeric
 ^^^^^^^
+- Bug in ``.clip()`` When list-like is passed; previously this raised ``ValueError`` (:issue:`15390`)
 
 
 Categorical
@@ -143,5 +144,3 @@ Categorical
 
 Other
 ^^^^^
-
-- Bug in ``.clip()`` now takes list or numpy-array; previously this raised ``ValueError`` (:issue:`15390`)

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -4429,20 +4429,9 @@ it is assumed to be aliases for the column names.')
         subset = method(threshold, axis=axis) | isnull(self)
 
         # GH #15390
-        if is_scalar(threshold):
-            return self.where(subset, threshold, axis=axis, inplace=inplace)
-
-        # For arry_like threshold, convet it to Series with corret index
-        # `where` takes scalar, NDFrame, or callable for argument "other"
-        try:
-            if isinstance(subset, ABCSeries):
-                threshold = pd.Series(threshold, index=subset.index)
-            elif axis == 0:
-                threshold = pd.Series(threshold, index=subset.index)
-            else:
-                threshold = pd.Series(threshold, index=subset.columns)
-        finally:
-            return self.where(subset, threshold, axis=axis, inplace=inplace)
+        if (not isinstance(threshold, ABCSeries)) and is_list_like(threshold):
+            threshold = np.asarray(threshold)
+        return self.where(subset, threshold, axis=axis, inplace=inplace)
 
     def clip(self, lower=None, upper=None, axis=None, inplace=False,
              *args, **kwargs):

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -4430,7 +4430,10 @@ it is assumed to be aliases for the column names.')
 
         # GH #15390
         if (not isinstance(threshold, ABCSeries)) and is_list_like(threshold):
-            threshold = np.asarray(threshold)
+            if isinstance(self, ABCSeries) or axis == 0:
+                threshold = pd.Series(threshold, index=self.index)
+            elif axis == 1:
+                threshold = pd.Series(threshold, index=self.columns)
         return self.where(subset, threshold, axis=axis, inplace=inplace)
 
     def clip(self, lower=None, upper=None, axis=None, inplace=False,

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -4415,6 +4415,8 @@ it is assumed to be aliases for the column names.')
 
     def _clip_with_one_bound(self, threshold, method, axis, inplace):
 
+        inplace = validate_bool_kwarg(inplace, 'inplace')
+
         if np.any(isnull(threshold)):
             raise ValueError("Cannot use an NA value as a clip threshold")
 
@@ -4422,19 +4424,16 @@ it is assumed to be aliases for the column names.')
         if is_scalar(threshold) and is_number(threshold):
             if method.__name__ == 'le':
                 return self._clip_with_scalar(None, threshold, inplace=inplace)
-            else:
-                return self._clip_with_scalar(threshold, None, inplace=inplace)
-
-        inplace = validate_bool_kwarg(inplace, 'inplace')
+            return self._clip_with_scalar(threshold, None, inplace=inplace)
 
         subset = method(threshold, axis=axis) | isnull(self)
 
         # GH #15390
-        if is_scalar(threshold) or is_number(threshold):
+        if is_scalar(threshold):
             return self.where(subset, threshold, axis=axis, inplace=inplace)
 
         # For arry_like threshold, convet it to Series with corret index
-        # `where` only takes
+        # `where` takes scalar, NDFrame, or callable for argument "other"
         try:
             if isinstance(subset, ABCSeries):
                 threshold = pd.Series(threshold, index=subset.index)

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -4420,7 +4420,7 @@ it is assumed to be aliases for the column names.')
 
         # method is self.le for upper bound and self.ge for lower bound
         if is_scalar(threshold) and is_number(threshold):
-            if  method.__name__ == 'le':
+            if method.__name__ == 'le':
                 return self._clip_with_scalar(None, threshold, inplace=inplace)
             else:
                 return self._clip_with_scalar(threshold, None, inplace=inplace)
@@ -4444,7 +4444,6 @@ it is assumed to be aliases for the column names.')
                 threshold = pd.Series(threshold, index=subset.columns)
         finally:
             return self.where(subset, threshold, axis=axis, inplace=inplace)
-
 
     def clip(self, lower=None, upper=None, axis=None, inplace=False,
              *args, **kwargs):
@@ -4549,7 +4548,7 @@ it is assumed to be aliases for the column names.')
         clipped : same type as input
         """
         return self._clip_with_one_bound(threshold, method=self.le,
-                                        axis=axis, inplace=inplace)
+                                         axis=axis, inplace=inplace)
 
     def clip_lower(self, threshold, axis=None, inplace=False):
         """
@@ -4573,7 +4572,7 @@ it is assumed to be aliases for the column names.')
         clipped : same type as input
         """
         return self._clip_with_one_bound(threshold, method=self.ge,
-                                        axis=axis, inplace=inplace)
+                                         axis=axis, inplace=inplace)
 
     def groupby(self, by=None, axis=0, level=None, as_index=True, sort=True,
                 group_keys=True, squeeze=False, **kwargs):

--- a/pandas/tests/frame/test_analytics.py
+++ b/pandas/tests/frame/test_analytics.py
@@ -1892,6 +1892,25 @@ class TestDataFrameAnalytics(TestData):
 
             tm.assert_series_equal(clipped_df.loc[mask, i], df.loc[mask, i])
 
+    @pytest.mark.parametrize("inplace", [True, False])
+    def test_clip_against_list(self, inplace):
+        # GH #15390
+        original = self.simple
+
+        result = original.clip(lower=[2, 3, 4], upper=[5, 6, 7],
+                               axis=1, inplace=inplace)
+
+        arr = np.array([[2., 3., 4.],
+                        [4., 5., 6.],
+                        [5., 6., 7.]])
+        expected = pd.DataFrame(arr,
+                                columns=original.columns,
+                                index=original.index)
+        if inplace:
+            tm.assert_frame_equal(original, expected, check_exact=True)
+        else:
+            tm.assert_frame_equal(result, expected, check_exact=True)
+
     def test_clip_against_frame(self):
         df = DataFrame(np.random.randn(1000, 2))
         lb = DataFrame(np.random.randn(1000, 2))

--- a/pandas/tests/frame/test_analytics.py
+++ b/pandas/tests/frame/test_analytics.py
@@ -1893,17 +1893,19 @@ class TestDataFrameAnalytics(TestData):
             tm.assert_series_equal(clipped_df.loc[mask, i], df.loc[mask, i])
 
     @pytest.mark.parametrize("inplace", [True, False])
-    def test_clip_against_list(self, inplace):
+    @pytest.mark.parametrize("lower", [[2, 3, 4], np.asarray([2, 3, 4])])
+    @pytest.mark.parametrize("axis,res", [
+        (0, [[2., 2., 3.], [4., 5., 6.], [7., 7., 7.]]),
+        (1, [[2., 3., 4.], [4., 5., 6.], [5., 6., 7.]])
+    ])
+    def test_clip_against_list_like(self, inplace, lower, axis, res):
         # GH #15390
         original = self.simple.copy(deep=True)
 
-        result = original.clip(lower=[2, 3, 4], upper=[5, 6, 7],
-                               axis=1, inplace=inplace)
+        result = original.clip(lower=lower, upper=[5, 6, 7],
+                               axis=axis, inplace=inplace)
 
-        arr = np.array([[2., 3., 4.],
-                        [4., 5., 6.],
-                        [5., 6., 7.]])
-        expected = pd.DataFrame(arr,
+        expected = pd.DataFrame(res,
                                 columns=original.columns,
                                 index=original.index)
         if inplace:

--- a/pandas/tests/frame/test_analytics.py
+++ b/pandas/tests/frame/test_analytics.py
@@ -1895,7 +1895,7 @@ class TestDataFrameAnalytics(TestData):
     @pytest.mark.parametrize("inplace", [True, False])
     def test_clip_against_list(self, inplace):
         # GH #15390
-        original = self.simple
+        original = self.simple.copy(deep=True)
 
         result = original.clip(lower=[2, 3, 4], upper=[5, 6, 7],
                                axis=1, inplace=inplace)
@@ -1907,9 +1907,8 @@ class TestDataFrameAnalytics(TestData):
                                 columns=original.columns,
                                 index=original.index)
         if inplace:
-            tm.assert_frame_equal(original, expected, check_exact=True)
-        else:
-            tm.assert_frame_equal(result, expected, check_exact=True)
+            result = original
+        tm.assert_frame_equal(result, expected, check_exact=True)
 
     def test_clip_against_frame(self):
         df = DataFrame(np.random.randn(1000, 2))

--- a/pandas/tests/frame/test_analytics.py
+++ b/pandas/tests/frame/test_analytics.py
@@ -1912,12 +1912,13 @@ class TestDataFrameAnalytics(TestData):
             result = original
         tm.assert_frame_equal(result, expected, check_exact=True)
 
-    def test_clip_against_frame(self):
+    @pytest.mark.parametrize("axis", [0, 1, None])
+    def test_clip_against_frame(self, axis):
         df = DataFrame(np.random.randn(1000, 2))
         lb = DataFrame(np.random.randn(1000, 2))
         ub = lb + 1
 
-        clipped_df = df.clip(lb, ub)
+        clipped_df = df.clip(lb, ub, axis=axis)
 
         lb_mask = df <= lb
         ub_mask = df >= ub

--- a/pandas/tests/series/test_analytics.py
+++ b/pandas/tests/series/test_analytics.py
@@ -1016,10 +1016,11 @@ class TestSeriesAnalytics(TestData):
         assert_series_equal(s.clip(1.5, upper), Series([1.5, 1.5, 3.5]))
 
     @pytest.mark.parametrize("inplace", [True, False])
-    def test_clip_against_list(self, inplace):
+    @pytest.mark.parametrize("upper", [[1, 2, 3], np.asarray([1, 2, 3])])
+    def test_clip_against_list_like(self, inplace, upper):
         # GH #15390
         original = pd.Series([5, 6, 7])
-        result = original.clip(upper=[1, 2, 3], inplace=inplace)
+        result = original.clip(upper=upper, inplace=inplace)
         expected = pd.Series([1, 2, 3])
 
         if inplace:

--- a/pandas/tests/series/test_analytics.py
+++ b/pandas/tests/series/test_analytics.py
@@ -1021,7 +1021,7 @@ class TestSeriesAnalytics(TestData):
         original = pd.Series([5, 6, 7])
         result = original.clip(upper=[1, 2, 3], inplace=inplace)
         expected = pd.Series([1, 2, 3])
-        
+
         if inplace:
             tm.assert_series_equal(original, expected, check_exact=True)
         else:

--- a/pandas/tests/series/test_analytics.py
+++ b/pandas/tests/series/test_analytics.py
@@ -1023,9 +1023,8 @@ class TestSeriesAnalytics(TestData):
         expected = pd.Series([1, 2, 3])
 
         if inplace:
-            tm.assert_series_equal(original, expected, check_exact=True)
-        else:
-            tm.assert_series_equal(result, expected, check_exact=True)
+            result = original
+        tm.assert_series_equal(result, expected, check_exact=True)
 
     def test_clip_with_datetimes(self):
 

--- a/pandas/tests/series/test_analytics.py
+++ b/pandas/tests/series/test_analytics.py
@@ -1015,6 +1015,18 @@ class TestSeriesAnalytics(TestData):
         assert_series_equal(s.clip(lower, upper), Series([1.0, 2.0, 3.5]))
         assert_series_equal(s.clip(1.5, upper), Series([1.5, 1.5, 3.5]))
 
+    @pytest.mark.parametrize("inplace", [True, False])
+    def test_clip_against_list(self, inplace):
+        # GH #15390
+        original = pd.Series([5, 6, 7])
+        result = original.clip(upper=[1, 2, 3], inplace=inplace)
+        expected = pd.Series([1, 2, 3])
+        
+        if inplace:
+            tm.assert_series_equal(original, expected, check_exact=True)
+        else:
+            tm.assert_series_equal(result, expected, check_exact=True)
+
     def test_clip_with_datetimes(self):
 
         # GH 11838


### PR DESCRIPTION
The  bug is due to that `where` doesn't take array-like as argument other, as documented. I just casted array like stuff to Series with appropriate index.

 - [X] closes #15390
 - [X] test_clip_against_list in frame/test_analytics and series/test_analytics
 - [X] passes ``git diff upstream/master --name-only -- '*.py' | flake8 --diff``
 - [ ] whatsnew entry
