### PR TITLE
Add inplace support for rename_axis

### DIFF
--- a/doc/source/whatsnew/v0.21.0.txt
+++ b/doc/source/whatsnew/v0.21.0.txt
@@ -33,6 +33,7 @@ Other Enhancements
 - The ``validate`` argument for :func:`merge` function now checks whether a merge is one-to-one, one-to-many, many-to-one, or many-to-many. If a merge is found to not be an example of specified merge type, an exception of type ``MergeError`` will be raised. For more, see :ref:`here <merging.validation>` (:issue:`16270`)
 - ``Series.to_dict()`` and ``DataFrame.to_dict()`` now support an ``into`` keyword which allows you to specify the ``collections.Mapping`` subclass that you would like returned.  The default is ``dict``, which is backwards compatible. (:issue:`16122`)
 - ``RangeIndex.append`` now returns a ``RangeIndex`` object when possible (:issue:`16212`)
+- ``Series.rename_axis()`` and ``DataFrame.rename_axis()`` with ``inplace=True`` now return None while renaming the axis inplace. (:issue:`15704`)
 - :func:`to_pickle` has gained a protocol parameter (:issue:`16252`). By default, this parameter is set to `HIGHEST_PROTOCOL <https://docs.python.org/3/library/pickle.html#data-stream-format>`__
 - :func:`api.types.infer_dtype` now infers decimals. (:issue: `15690`)
 - :func:`read_feather` has gained the ``nthreads`` parameter for multi-threaded operations (:issue:`16359`)

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -753,7 +753,7 @@ class NDFrame(PandasObject, SelectionMixin):
 
         Returns
         -------
-        renamed : type of caller
+        renamed : type of caller or None if inplace=True
 
         See Also
         --------
@@ -784,16 +784,16 @@ class NDFrame(PandasObject, SelectionMixin):
         non_mapper = is_scalar(mapper) or (is_list_like(mapper) and not
                                            is_dict_like(mapper))
         if non_mapper:
-            return self._set_axis_name(mapper, axis=axis)
+            return self._set_axis_name(mapper, axis=axis, inplace=inplace)
         else:
             axis = self._get_axis_name(axis)
             d = {'copy': copy, 'inplace': inplace}
             d[axis] = mapper
             return self.rename(**d)
 
-    def _set_axis_name(self, name, axis=0):
+    def _set_axis_name(self, name, axis=0, inplace=False):
         """
-        Alter the name or names of the axis, returning self.
+        Alter the name or names of the axis.
 
         Parameters
         ----------
@@ -801,10 +801,14 @@ class NDFrame(PandasObject, SelectionMixin):
             Name for the Index, or list of names for the MultiIndex
         axis : int or str
            0 or 'index' for the index; 1 or 'columns' for the columns
+        inplace : bool
+            whether to modify `self` directly or return a copy
+
+            .. versionadded: 0.21.0
 
         Returns
         -------
-        renamed : type of caller
+        renamed : type of caller or None if inplace=True
 
         See Also
         --------
@@ -831,9 +835,11 @@ class NDFrame(PandasObject, SelectionMixin):
         axis = self._get_axis_number(axis)
         idx = self._get_axis(axis).set_names(name)
 
-        renamed = self.copy(deep=True)
+        inplace = validate_bool_kwarg(inplace, 'inplace')
+        renamed = self if inplace else self.copy()
         renamed.set_axis(axis, idx)
-        return renamed
+        if not inplace:
+            return renamed
 
     # ----------------------------------------------------------------------
     # Comparisons

--- a/pandas/tests/frame/test_alter_axes.py
+++ b/pandas/tests/frame/test_alter_axes.py
@@ -420,10 +420,19 @@ class TestDataFrameAlterAxes(TestData):
 
     def test_rename_axis_inplace(self):
         # GH 15704
-        expected = self.frame.rename_axis('foo')
-        no_return = self.frame.rename_axis('foo', inplace=True)
+        frame = self.frame.copy()
+        expected = frame.rename_axis('foo')
+        result = frame.copy()
+        no_return = result.rename_axis('foo', inplace=True)
+
         assert no_return is None
-        result = self.frame
+        assert_frame_equal(result, expected)
+
+        expected = frame.rename_axis('bar', axis=1)
+        result = frame.copy()
+        no_return = result.rename_axis('bar', axis=1, inplace=True)
+
+        assert no_return is None
         assert_frame_equal(result, expected)
 
     def test_rename_multiindex(self):

--- a/pandas/tests/frame/test_alter_axes.py
+++ b/pandas/tests/frame/test_alter_axes.py
@@ -418,6 +418,14 @@ class TestDataFrameAlterAxes(TestData):
                               pd.Index(['bar', 'foo'], name='name'))
         assert renamed.index.name == renamer.index.name
 
+    def test_rename_axis_inplace(self):
+        # GH 15704
+        expected = self.frame.rename_axis('foo')
+        no_return = self.frame.rename_axis('foo', inplace=True)
+        assert no_return is None
+        result = self.frame
+        assert_frame_equal(result, expected)
+
     def test_rename_multiindex(self):
 
         tuples_index = [('foo1', 'bar1'), ('foo2', 'bar2')]

--- a/pandas/tests/series/test_alter_axes.py
+++ b/pandas/tests/series/test_alter_axes.py
@@ -224,3 +224,13 @@ class TestSeriesAlterAxes(TestData):
 
         result = s.reorder_levels(['L0', 'L0', 'L0'])
         assert_series_equal(result, expected)
+
+    def test_rename_axis_inplace(self):
+        # GH 15704
+        series = self.ts.copy()
+        expected = series.rename_axis('foo')
+        result = series.copy()
+        no_return = result.rename_axis('foo', inplace=True)
+
+        assert no_return is None
+        assert_series_equal(result, expected)


### PR DESCRIPTION
 - [x] closes #15704 
 - [x] tests added / passed
 - [x] passes ``git diff upstream/master --name-only -- '*.py' | flake8 --diff``