### PR TITLE
DOC: Remove preference for pytest paradigm in assert_raises_regex

### DIFF
--- a/pandas/util/testing.py
+++ b/pandas/util/testing.py
@@ -2424,15 +2424,8 @@ def assert_raises_regex(_exception, _regexp, _callable=None,
     Check that the specified Exception is raised and that the error message
     matches a given regular expression pattern. This may be a regular
     expression object or a string containing a regular expression suitable
-    for use by `re.search()`.
-
-    This is a port of the `assertRaisesRegexp` function from unittest in
-    Python 2.7. However, with our migration to `pytest`, please refrain
-    from using this. Instead, use the following paradigm:
-
-    with pytest.raises(_exception) as exc_info:
-       func(*args, **kwargs)
-    exc_info.matches(reg_exp)
+    for use by `re.search()`. This is a port of the `assertRaisesRegexp`
+    function from unittest in Python 2.7.
 
     Examples
     --------


### PR DESCRIPTION
`tm.assert_raises_regex` is a more compact version of the following:

~~~python
with pytest.raises(<exc_type>) as exc_info:
   f(...)
exc_info.match(<regex>)
~~~

No reason for the docs to say that we prefer the `pytest` paradigm over our own.

xref <a href="https://github.com/pandas-dev/pandas/pull/16511#discussion_r118771331">#16511 (comment)</a>