### PR TITLE
DOC: Improving docstring of pop method (#16416)

### DIFF
--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -547,6 +547,43 @@ class NDFrame(PandasObject, SelectionMixin):
     def pop(self, item):
         """
         Return item and drop from frame. Raise KeyError if not found.
+
+        Parameters
+        ----------
+        item : str
+            Column label to be popped
+
+        Returns
+        -------
+        popped : Series
+
+        Examples
+        --------
+        >>> df = pd.DataFrame([('falcon', 'bird',    389.0),
+        ...                    ('parrot', 'bird',     24.0),
+        ...                    ('lion',   'mammal',   80.5),
+        ...                    ('monkey', 'mammal', np.nan)],
+        ...                   columns=('name', 'class', 'max_speed'))
+        >>> df
+             name   class  max_speed
+        0  falcon    bird      389.0
+        1  parrot    bird       24.0
+        2    lion  mammal       80.5
+        3  monkey  mammal        NaN
+
+        >>> df.pop('class')
+        0      bird
+        1      bird
+        2    mammal
+        3    mammal
+        Name: class, dtype: object
+
+        >>> df
+             name  max_speed
+        0  falcon      389.0
+        1  parrot       24.0
+        2    lion       80.5
+        3  monkey        NaN
         """
         result = self[item]
         del self[item]


### PR DESCRIPTION
 - [ ] closes #xxxx
 - [ ] tests added / passed
 - [X] passes ``git diff upstream/master --name-only -- '*.py' | flake8 --diff``
 - [ ] whatsnew entry

As discussed in gitter, it'd be nice to have more and better examples in the API documentation. I think it'd be nice to have as many examples as possible with the same DataFrame, so the users who check the documentation know it without needing to read it again.

In this PR I propose a standard DataFrame that:
 - Is simple to understand
 - Contains all the main dtypes
 - Contains NaNs
 - It can be groupped

Please feel free to propose a another one if you have a better idea, and reject this PR.

Let me know if the format of this docstring, as well as the DataFrame can be used for the rest of the method docstrings, and I'll work with them.

You can see how the html documentation looks like in the next screenshot:

![pandas_pop_doc](https://cloud.githubusercontent.com/assets/10058240/26524333/883d96e6-4327-11e7-856c-31cc3446b268.png)
