### PR TITLE
CLN: raise correct error for Panel sort_values

### DIFF
--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -2366,9 +2366,13 @@ it is assumed to be aliases for the column names.')
         1   A    1    1
         """
 
-    def sort_values(self, by, axis=0, ascending=True, inplace=False,
-                    kind='quicksort', na_position='last'):
-        raise AbstractMethodError(self)
+    def sort_values(self):
+        """
+        NOT IMPLEMENTED: do not call this method, as sorting values is not
+        supported for Panel objects and will raise an error.
+        """
+        raise NotImplementedError("sort_values has not been implemented "
+                                  "on Panel or Panel4D objects.")
 
     _shared_docs['sort_index'] = """
         Sort object by labels (along an axis)

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -2366,7 +2366,8 @@ it is assumed to be aliases for the column names.')
         1   A    1    1
         """
 
-    def sort_values(self):
+    def sort_values(self, by=None, axis=0, ascending=True, inplace=False,
+                    kind='quicksort', na_position='last'):
         """
         NOT IMPLEMENTED: do not call this method, as sorting values is not
         supported for Panel objects and will raise an error.

--- a/pandas/tests/test_panel.py
+++ b/pandas/tests/test_panel.py
@@ -2429,6 +2429,10 @@ class TestPanel(PanelTests, CheckIndexing, SafeForLongAndSparse,
         pytest.raises(NotImplementedError, self.panel.all, bool_only=True)
         pytest.raises(NotImplementedError, self.panel.any, bool_only=True)
 
+    def test_sort_values(self):
+        pytest.raises(NotImplementedError, self.panel.sort_values)
+        pytest.raises(NotImplementedError, self.panel.sort_values, 'ItemA')
+
 
 class TestLongPanel(object):
     """

--- a/pandas/tests/test_panel.py
+++ b/pandas/tests/test_panel.py
@@ -2429,6 +2429,7 @@ class TestPanel(PanelTests, CheckIndexing, SafeForLongAndSparse,
         pytest.raises(NotImplementedError, self.panel.all, bool_only=True)
         pytest.raises(NotImplementedError, self.panel.any, bool_only=True)
 
+    # GH issue 15960
     def test_sort_values(self):
         pytest.raises(NotImplementedError, self.panel.sort_values)
         pytest.raises(NotImplementedError, self.panel.sort_values, 'ItemA')

--- a/pandas/tests/test_panel4d.py
+++ b/pandas/tests/test_panel4d.py
@@ -940,7 +940,7 @@ class TestPanel4d(CheckIndexing, SafeForSparse,
     def test_get_attr(self):
         tm.assert_panel_equal(self.panel4d['l1'], self.panel4d.l1)
 
-
+    # GH issue 15960
     def test_sort_values(self):
         pytest.raises(NotImplementedError, self.panel4d.sort_values)
         pytest.raises(NotImplementedError, self.panel4d.sort_values, 'ItemA')

--- a/pandas/tests/test_panel4d.py
+++ b/pandas/tests/test_panel4d.py
@@ -939,3 +939,8 @@ class TestPanel4d(CheckIndexing, SafeForSparse,
 
     def test_get_attr(self):
         tm.assert_panel_equal(self.panel4d['l1'], self.panel4d.l1)
+
+
+    def test_sort_values(self):
+        pytest.raises(NotImplementedError, self.panel4d.sort_values)
+        pytest.raises(NotImplementedError, self.panel4d.sort_values, 'ItemA')


### PR DESCRIPTION
 - [x] closes #15960 
 - [x] tests added / passed
 - [x] passes ``git diff upstream/master --name-only -- '*.py' | flake8 --diff``
 - [ ] whatsnew entry

I do not believe there is a need for tests or whatsnew entry.

I modified the error raised (I think NotImplementedError should reflect better the situation) and added a small docstring to explain that the method is not implemented (similar to other methods in the same class)