### PR TITLE
TST: Make HDF5 fspath write test robust

### DIFF
--- a/pandas/tests/io/test_common.py
+++ b/pandas/tests/io/test_common.py
@@ -143,7 +143,6 @@ bar2,12,13,14,15
         ('to_csv', {}, 'os'),
         ('to_excel', {'engine': 'xlwt'}, 'xlwt'),
         ('to_feather', {}, 'feather'),
-        ('to_hdf', {'key': 'bar', 'mode': 'w'}, 'tables'),
         ('to_html', {}, 'os'),
         ('to_json', {}, 'os'),
         ('to_latex', {}, 'os'),
@@ -170,6 +169,26 @@ bar2,12,13,14,15
                 result = f.read()
 
             assert result == expected
+
+    def test_write_fspath_hdf5(self):
+        # Same test as write_fspath_all, except HDF5 files aren't
+        # necessarily byte-for-byte identical for a given dataframe, so we'll
+        # have to read and compare equality
+        pytest.importorskip('tables')
+
+        df = pd.DataFrame({"A": [1, 2]})
+        p1 = tm.ensure_clean('string')
+        p2 = tm.ensure_clean('fspath')
+
+        with p1 as string, p2 as fspath:
+            mypath = CustomFSPath(fspath)
+            df.to_hdf(mypath, key='bar')
+            df.to_hdf(string, key='bar')
+
+            result = pd.read_hdf(fspath, key='bar')
+            expected = pd.read_hdf(string, key='bar')
+
+        tm.assert_frame_equal(result, expected)
 
 
 class TestMMapWrapper(object):


### PR DESCRIPTION
The test_write_fspath_all test would fail on the HDF5 example
occasionally (about 1/100 in my experience). Apparently you don't get an
identical HDF5 every single time. This refactors that test out to its own where
we write and read both versions, and compare equality that way.

See https://github.com/pandas-dev/pandas/pull/14026#issuecomment-305554714 and https://circleci.com/gh/pandas-dev/pandas/2507?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link for an example