### PR TITLE
BUG: IntervalIndex is_non_overlapping_monotonic is incorrect when endpoints are closed on both sides

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@
 .ipynb_checkpoints
 .tags
 .cache/
+.vscode
 
 # Compiled source #
 ###################

--- a/doc/source/whatsnew/v0.21.0.txt
+++ b/doc/source/whatsnew/v0.21.0.txt
@@ -90,6 +90,7 @@ Bug Fixes
 Conversion
 ^^^^^^^^^^
 
+- Bug in ``IntervalIndex`` where ``is_non_overlapping_monotonic`` returned incorrect value for intervals closed on both sides (:issue:`16560`)
 
 
 Indexing

--- a/pandas/core/indexes/interval.py
+++ b/pandas/core/indexes/interval.py
@@ -556,8 +556,12 @@ class IntervalIndex(IntervalMixin, Index):
         # must be increasing  (e.g., [0, 1), [1, 2), [2, 3), ... )
         # or decreasing (e.g., [-1, 0), [-2, -1), [-3, -2), ...)
         # we already require left <= right
-        return ((self.right[:-1] <= self.left[1:]).all() or
-                (self.left[:-1] >= self.right[1:]).all())
+        if self.closed == 'both':
+            return ((self.right[:-1] < self.left[1:]).all() or
+                    (self.left[:-1] > self.right[1:]).all())
+        else:
+            return ((self.right[:-1] <= self.left[1:]).all() or
+                    (self.left[:-1] >= self.right[1:]).all())
 
     @Appender(_index_shared_docs['_convert_scalar_indexer'])
     def _convert_scalar_indexer(self, key, kind=None):

--- a/pandas/core/indexes/interval.py
+++ b/pandas/core/indexes/interval.py
@@ -559,9 +559,10 @@ class IntervalIndex(IntervalMixin, Index):
         if self.closed == 'both':
             return ((self.right[:-1] < self.left[1:]).all() or
                     (self.left[:-1] > self.right[1:]).all())
-        else:
-            return ((self.right[:-1] <= self.left[1:]).all() or
-                    (self.left[:-1] >= self.right[1:]).all())
+        
+        # self.closed == 'left' or 'right' or 'neither'
+        return ((self.right[:-1] <= self.left[1:]).all() or
+                (self.left[:-1] >= self.right[1:]).all())
 
     @Appender(_index_shared_docs['_convert_scalar_indexer'])
     def _convert_scalar_indexer(self, key, kind=None):

--- a/pandas/tests/indexes/test_interval.py
+++ b/pandas/tests/indexes/test_interval.py
@@ -371,9 +371,18 @@ class TestIntervalIndex(Base):
         assert index.slice_locs(1, 1) == (1, 1)
         assert index.slice_locs(1, 2) == (1, 2)
 
-        index = IntervalIndex.from_breaks([0, 1, 2], closed='both')
-        assert index.slice_locs(1, 1) == (0, 2)
+        index = IntervalIndex.from_tuples(
+            [(0, 1), (2, 3), (4, 5)], closed='both')
+        assert index.slice_locs(1, 1) == (0, 1)
         assert index.slice_locs(1, 2) == (0, 2)
+
+    def test_is_non_overlapping_monotonic(self):
+        index = IntervalIndex.from_tuples(
+            [(0, 1), (2, 3), (4, 5)], closed='both')
+        assert index.is_non_overlapping_monotonic == True
+
+        index = IntervalIndex.from_breaks(range(4), closed='both')
+        assert index.is_non_overlapping_monotonic == False
 
     def test_slice_locs_int64(self):
         self.slice_locs_cases([0, 1, 2])

--- a/pandas/tests/indexes/test_interval.py
+++ b/pandas/tests/indexes/test_interval.py
@@ -380,8 +380,25 @@ class TestIntervalIndex(Base):
         index = IntervalIndex.from_tuples(
             [(0, 1), (2, 3), (4, 5)], closed='both')
         assert index.is_non_overlapping_monotonic == True
-
         index = IntervalIndex.from_breaks(range(4), closed='both')
+        assert index.is_non_overlapping_monotonic == False
+
+        index = IntervalIndex.from_breaks([0, 1, 2], closed='neither')
+        assert index.is_non_overlapping_monotonic == True
+        index = IntervalIndex.from_tuples(
+            [(0, 2), (1, 3), (3, 4)], closed='neither')
+        assert index.is_non_overlapping_monotonic == False
+
+        index = IntervalIndex.from_breaks(range(4), closed='left')
+        assert index.is_non_overlapping_monotonic == True
+        index = IntervalIndex.from_tuples(
+            [(0, 1), (1, 2), (1.5, 3)], closed='left')
+        assert index.is_non_overlapping_monotonic == False
+
+        index = IntervalIndex.from_breaks(range(4), closed='right')
+        assert index.is_non_overlapping_monotonic == True
+        index = IntervalIndex.from_tuples(
+            [(0, 1), (1, 2), (1.5, 3)], closed='right')
         assert index.is_non_overlapping_monotonic == False
 
     def test_slice_locs_int64(self):


### PR DESCRIPTION
 - [x] closes #16560
 - [x] tests added / passed
 - [x] passes ``git diff upstream/master --name-only -- '*.py' | flake8 --diff``
 - [x] whatsnew entry
