### PR TITLE
PERF: vectorize _interp_limit

### DIFF
--- a/pandas/core/missing.py
+++ b/pandas/core/missing.py
@@ -143,12 +143,6 @@ def interpolate_1d(xvalues, yvalues, method='linear', limit=None,
                              'DatetimeIndex')
         method = 'values'
 
-    def _interp_limit(invalid, fw_limit, bw_limit):
-        "Get idx of values that won't be filled b/c they exceed the limits."
-        for x in np.where(invalid)[0]:
-            if invalid[max(0, x - fw_limit):x + bw_limit + 1].all():
-                yield x
-
     valid_limit_directions = ['forward', 'backward', 'both']
     limit_direction = limit_direction.lower()
     if limit_direction not in valid_limit_directions:
@@ -180,21 +174,29 @@ def interpolate_1d(xvalues, yvalues, method='linear', limit=None,
 
     # default limit is unlimited GH #16282
     if limit is None:
-        limit = len(xvalues)
+        # limit = len(xvalues)
+        pass
     elif not is_integer(limit):
         raise ValueError('Limit must be an integer')
     elif limit < 1:
         raise ValueError('Limit must be greater than 0')
 
     # each possible limit_direction
-    if limit_direction == 'forward':
+    # TODO: do we need sorted?
+    if limit_direction == 'forward' and limit is not None:
         violate_limit = sorted(start_nans |
                                set(_interp_limit(invalid, limit, 0)))
-    elif limit_direction == 'backward':
+    elif limit_direction == 'forward':
+        violate_limit = sorted(start_nans)
+    elif limit_direction == 'backward' and limit is not None:
         violate_limit = sorted(end_nans |
                                set(_interp_limit(invalid, 0, limit)))
-    elif limit_direction == 'both':
+    elif limit_direction == 'backward':
+        violate_limit = sorted(end_nans)
+    elif limit_direction == 'both' and limit is not None:
         violate_limit = sorted(_interp_limit(invalid, limit, limit))
+    else:
+        violate_limit = []
 
     xvalues = getattr(xvalues, 'values', xvalues)
     yvalues = getattr(yvalues, 'values', yvalues)
@@ -630,3 +632,65 @@ def fill_zeros(result, x, y, name, fill):
             result = result.reshape(shape)
 
     return result
+
+
+def _interp_limit0(invalid, fw_limit, bw_limit):
+    "Get idx of values that won't be filled b/c they exceed the limits."
+    for x in np.where(invalid)[0]:
+        if invalid[max(0, x - fw_limit):x + bw_limit + 1].all():
+            yield x
+
+
+def _interp_limit(invalid, fw_limit, bw_limit):
+    """Get idx of values that won't be filled b/c they exceed the limits.
+
+    This is equivalent to the more readable, but slower
+
+    .. code-block:: python
+
+       for x in np.where(invalid)[0]:
+           if invalid[max(0, x - fw_limit):x + bw_limit + 1].all():
+               yield x
+    """
+    # handle forward first; the backward direction is the same except
+    # 1. operate on the reversed array
+    # 2. subtract the returned indicies from N - 1
+    N = len(invalid)
+
+    def inner(invalid, limit):
+        limit = min(limit, N)
+        windowed = rolling_window(invalid, limit + 1).all(1)
+        idx = (set(np.where(windowed)[0] + limit) |
+               set(np.where((~invalid[:limit + 1]).cumsum() == 0)[0]))
+        return idx
+
+    if fw_limit == 0:
+        f_idx = set(np.where(invalid)[0])
+    else:
+        f_idx = inner(invalid, fw_limit)
+
+    if bw_limit == 0:
+        # then we don't even need to care about backwards, just use forwards
+        return f_idx
+    else:
+        b_idx = set(N - 1 - np.asarray(list(inner(invalid[::-1], bw_limit))))
+        if fw_limit == 0:
+            return b_idx
+    return f_idx & b_idx
+
+
+def rolling_window(a, window):
+    """
+    [True, True, False, True, False], 2 ->
+
+    [
+        [True,  True],
+        [True, False],
+        [False, True],
+        [True, False],
+    ]
+    """
+    # https://stackoverflow.com/a/6811241
+    shape = a.shape[:-1] + (a.shape[-1] - window + 1, window)
+    strides = a.strides + (a.strides[-1],)
+    return np.lib.stride_tricks.as_strided(a, shape=shape, strides=strides)

--- a/pandas/core/missing.py
+++ b/pandas/core/missing.py
@@ -634,13 +634,6 @@ def fill_zeros(result, x, y, name, fill):
     return result
 
 
-def _interp_limit0(invalid, fw_limit, bw_limit):
-    "Get idx of values that won't be filled b/c they exceed the limits."
-    for x in np.where(invalid)[0]:
-        if invalid[max(0, x - fw_limit):x + bw_limit + 1].all():
-            yield x
-
-
 def _interp_limit(invalid, fw_limit, bw_limit):
     """Get idx of values that won't be filled b/c they exceed the limits.
 

--- a/pandas/core/missing.py
+++ b/pandas/core/missing.py
@@ -652,7 +652,7 @@ def _interp_limit(invalid, fw_limit, bw_limit):
 
     def inner(invalid, limit):
         limit = min(limit, N)
-        windowed = rolling_window(invalid, limit + 1).all(1)
+        windowed = _rolling_window(invalid, limit + 1).all(1)
         idx = (set(np.where(windowed)[0] + limit) |
                set(np.where((~invalid[:limit + 1]).cumsum() == 0)[0]))
         return idx
@@ -672,7 +672,7 @@ def _interp_limit(invalid, fw_limit, bw_limit):
     return f_idx & b_idx
 
 
-def rolling_window(a, window):
+def _rolling_window(a, window):
     """
     [True, True, False, True, False], 2 ->
 


### PR DESCRIPTION
xref https://github.com/pandas-dev/pandas/issues/16584

Here are the timings vs. master

```
       before           after         ratio
     [ff0d1f4d]       [6b1552f1]
-      12.3±0.3ms      2.28±0.04ms     0.18  frame_methods.Interpolate.time_interpolate_some_good_infer
-      12.6±0.7ms      1.15±0.01ms     0.09  frame_methods.Interpolate.time_interpolate_some_good
-           1.30s         53.8±1ms     0.04  frame_methods.Interpolate.time_interpolate

```

I still need to time vs 0.20.1 (will post those timings later, have to run for a bit now). I may have one more spot to optimize.