### PR TITLE
BUG #15150  normalization of crosstable with multiindex and margins

### DIFF
--- a/doc/source/whatsnew/v0.21.0.txt
+++ b/doc/source/whatsnew/v0.21.0.txt
@@ -311,6 +311,9 @@ Reshaping
 - Bug in merging with categorical dtypes with datetimelikes incorrectly raised a ``TypeError`` (:issue:`16900`)
 - Bug when using :func:`isin` on a large object series and large comparison array (:issue:`16012`)
 - Fixes regression from 0.20, :func:`Series.aggregate` and :func:`DataFrame.aggregate` allow dictionaries as return values again (:issue:`16741`)
+- Bug in ``pd.crosstab(normalize=True, margins=True)`` when at least one axis has a multi-index (:issue:`15150`)
+
+>>>>>>> added whatsnew and reformatted tests to be more readable
 
 Numeric
 ^^^^^^^

--- a/pandas/core/reshape/pivot.py
+++ b/pandas/core/reshape/pivot.py
@@ -554,57 +554,27 @@ def _normalize(table, normalize, margins, margins_name='All'):
             'columns': lambda x: x / x.sum(),
             'index': lambda x: x.div(x.sum(axis=1), axis=0)
         }
-
-        normalizers[True] = normalizers['all']
-
-        try:
-            f = normalizers[normalize]
-        except KeyError:
-            raise ValueError("Not a valid normalize argument")
-
-        table = f(table)
-        table = table.fillna(0)
-
+    
     elif margins is True:
 
-        column_margin = table.loc[:, margins_name].drop(margins_name)
-        index_margin = table.loc[margins_name, :].drop(margins_name)
-        table = table.drop(margins_name, axis=1).drop(margins_name)
-        # to keep index and columns names
-        table_index_names = table.index.names
-        table_columns_names = table.columns.names
-
-        # Normalize core
-        table = _normalize(table, normalize=normalize, margins=False)
-
-        # Fix Margins
-        if normalize == 'columns':
-            column_margin = column_margin / column_margin.sum()
-            table = concat([table, column_margin], axis=1)
-            table = table.fillna(0)
-
-        elif normalize == 'index':
-            index_margin = index_margin / index_margin.sum()
-            table = table.append(index_margin)
-            table = table.fillna(0)
-
-        elif normalize == "all" or normalize is True:
-            column_margin = column_margin / column_margin.sum()
-            index_margin = index_margin / index_margin.sum()
-            index_margin.loc[margins_name] = 1
-            table = concat([table, column_margin], axis=1)
-            table = table.append(index_margin)
-
-            table = table.fillna(0)
-
-        else:
-            raise ValueError("Not a valid normalize argument")
-
-        table.index.names = table_index_names
-        table.columns.names = table_columns_names
+        normalizers = {
+            'all': lambda x: x / x.iloc[:-1,:-1].sum(axis=1).sum(axis=0),
+            'columns': lambda x: x.div(x.iloc[:-1,:].sum()).iloc[:-1,:],
+            'index': lambda x: (x.div(x.iloc[:,:-1].sum(axis=1), axis=0)).iloc[:,:-1]
+        }
 
     else:
-        raise ValueError("Not a valid margins argument")
+        raise ValueError("Not a valid margins argument")    
+
+    normalizers[True] = normalizers['all']
+
+    try:
+        f = normalizers[normalize]
+    except KeyError:
+        raise ValueError("Not a valid normalize argument")
+      
+    table=f(table)
+    table = table.fillna(0)       
 
     return table
 

--- a/pandas/core/reshape/pivot.py
+++ b/pandas/core/reshape/pivot.py
@@ -556,7 +556,7 @@ def _normalize(table, normalize, margins, margins_name='All'):
         }
     
     elif margins is True:
-
+        #skip margin rows and/or cols for normalization
         normalizers = {
             'all': lambda x: x / x.iloc[:-1,:-1].sum(axis=1).sum(axis=0),
             'columns': lambda x: x.div(x.iloc[:-1,:].sum()).iloc[:-1,:],
@@ -573,7 +573,7 @@ def _normalize(table, normalize, margins, margins_name='All'):
     except KeyError:
         raise ValueError("Not a valid normalize argument")
       
-    table=f(table)
+    table = f(table)
     table = table.fillna(0)       
 
     return table

--- a/pandas/core/reshape/pivot.py
+++ b/pandas/core/reshape/pivot.py
@@ -574,8 +574,8 @@ def _normalize(table, normalize, margins, margins_name='All'):
         raise ValueError("Not a valid normalize argument")
       
     table = f(table)
-    table = table.fillna(0)       
-
+    table = table.fillna(0)
+    
     return table
 
 

--- a/pandas/core/reshape/pivot.py
+++ b/pandas/core/reshape/pivot.py
@@ -547,24 +547,24 @@ def _normalize(table, normalize, margins, margins_name='All'):
             raise ValueError("Not a valid normalize argument")
 
     if margins is False:
-
         # Actual Normalizations
         normalizers = {
             'all': lambda x: x / x.sum(axis=1).sum(axis=0),
             'columns': lambda x: x / x.sum(),
             'index': lambda x: x.div(x.sum(axis=1), axis=0)
         }
-    
+
     elif margins is True:
-        #skip margin rows and/or cols for normalization
+        # skip margin rows and/or cols for normalization
         normalizers = {
-            'all': lambda x: x / x.iloc[:-1,:-1].sum(axis=1).sum(axis=0),
-            'columns': lambda x: x.div(x.iloc[:-1,:].sum()).iloc[:-1,:],
-            'index': lambda x: (x.div(x.iloc[:,:-1].sum(axis=1), axis=0)).iloc[:,:-1]
+            'all': lambda x: x / x.iloc[:-1, :-1].sum(axis=1).sum(axis=0),
+            'columns': lambda x: x.div(x.iloc[:-1, :].sum()).iloc[:-1, :],
+            'index': lambda x: (x.div(x.iloc[:, :-1].sum(axis=1),
+                                axis=0)).iloc[:, :-1]
         }
 
     else:
-        raise ValueError("Not a valid margins argument")    
+        raise ValueError("Not a valid margins argument")
 
     normalizers[True] = normalizers['all']
 
@@ -572,10 +572,21 @@ def _normalize(table, normalize, margins, margins_name='All'):
         f = normalizers[normalize]
     except KeyError:
         raise ValueError("Not a valid normalize argument")
-      
+
     table = f(table)
     table = table.fillna(0)
-    
+
+    if margins is True:
+        # reset index to ensure default index dtype
+        if normalize == 'index':
+            colnames = table.columns.names
+            table.columns = Index(table.columns.tolist())
+            table.columns.names = colnames
+        if normalize == 'columns':
+            rownames = table.index.names
+            table.index = Index(table.index.tolist())
+            table.index.names = rownames
+
     return table
 
 

--- a/pandas/core/reshape/pivot.py
+++ b/pandas/core/reshape/pivot.py
@@ -532,7 +532,6 @@ def crosstab(index, columns, values=None, rownames=None, colnames=None,
     if values is None and margins:
         table = table.fillna(0).astype(np.int64)
 
-
     if margins:
         _check_margins_name(margins_name, table)
 

--- a/pandas/tests/reshape/test_pivot.py
+++ b/pandas/tests/reshape/test_pivot.py
@@ -1218,7 +1218,7 @@ class TestCrosstab(object):
         df = pd.DataFrame({'a': [1, 2, 2, 2, 2, np.nan],
                            'b': [3, 3, 4, 4, 4, 4]})
         actual = pd.crosstab(df.a, df.b, margins=True, dropna=False)
-        expected = pd.DataFrame([[1, 0, 1], [1, 3, 4], [2, 4, 6]])
+        expected = pd.DataFrame([[1, 0, 1], [1, 3, 4], [2, 3, 5]])
         expected.index = Index([1.0, 2.0, 'All'], name='a')
         expected.columns = Index([3, 4, 'All'], name='b')
         tm.assert_frame_equal(actual, expected)
@@ -1226,7 +1226,7 @@ class TestCrosstab(object):
         df = DataFrame({'a': [1, np.nan, np.nan, np.nan, 2, np.nan],
                         'b': [3, np.nan, 4, 4, 4, 4]})
         actual = pd.crosstab(df.a, df.b, margins=True, dropna=False)
-        expected = pd.DataFrame([[1, 0, 1], [0, 1, 1], [1, 4, 6]])
+        expected = pd.DataFrame([[1, 0, 1], [0, 1, 1], [1, 1, 2]])
         expected.index = Index([1.0, 2.0, 'All'], name='a')
         expected.columns = Index([3.0, 4.0, 'All'], name='b')
         tm.assert_frame_equal(actual, expected)
@@ -1243,8 +1243,8 @@ class TestCrosstab(object):
         m = MultiIndex.from_arrays([['one', 'one', 'two', 'two', 'All'],
                                     ['dull', 'shiny', 'dull', 'shiny', '']],
                                    names=['b', 'c'])
-        expected = DataFrame([[1, 0, 1, 0, 2], [2, 0, 1, 1, 5],
-                              [3, 0, 2, 1, 7]], columns=m)
+        expected = DataFrame([[1, 0, 1, 0, 2], [2, 0, 1, 1, 4],
+                              [3, 0, 2, 1, 6]], columns=m)
         expected.index = Index(['bar', 'foo', 'All'], name='a')
         tm.assert_frame_equal(actual, expected)
 
@@ -1254,7 +1254,7 @@ class TestCrosstab(object):
                                     ['one', 'two', 'one', 'two', '']],
                                    names=['a', 'b'])
         expected = DataFrame([[1, 0, 1], [1, 0, 1], [2, 0, 2], [1, 1, 2],
-                              [5, 2, 7]], index=m)
+                              [5, 1, 6]], index=m)
         expected.columns = Index(['dull', 'shiny', 'All'], name='c')
         tm.assert_frame_equal(actual, expected)
 
@@ -1455,22 +1455,23 @@ class TestCrosstab(object):
         df = pd.DataFrame({'a': [1, 2, 2, 2, 2], 'b': [3, 3, 4, 4, 4],
                            'c': [1, 1, np.nan, 1, 1]})
 
-        error = 'values cannot be used without an aggfunc.'
+        error = "values cannot be used without an aggfunc."
         with tm.assert_raises_regex(ValueError, error):
             pd.crosstab(df.a, df.b, values=df.c)
 
-        error = 'aggfunc cannot be used without values'
+        error = "aggfunc cannot be used without values"
         with tm.assert_raises_regex(ValueError, error):
             pd.crosstab(df.a, df.b, aggfunc=np.mean)
 
-        error = 'Not a valid normalize argument'
+        error = "Not a valid normalize argument: '42'"
         with tm.assert_raises_regex(ValueError, error):
             pd.crosstab(df.a, df.b, normalize='42')
 
+        error = "Not a valid normalize argument: 42"
         with tm.assert_raises_regex(ValueError, error):
             pd.crosstab(df.a, df.b, normalize=42)
 
-        error = 'Not a valid margins argument'
+        error = "Not a valid margins argument: 42"
         with tm.assert_raises_regex(ValueError, error):
             pd.crosstab(df.a, df.b, normalize='all', margins=42)
 
@@ -1529,6 +1530,7 @@ class TestCrosstab(object):
         expected = pd.DataFrame(expected_data,
                                 index=expected_index,
                                 columns=expected_column)
+
         tm.assert_frame_equal(result, expected)
 
 

--- a/pandas/tests/reshape/test_pivot.py
+++ b/pandas/tests/reshape/test_pivot.py
@@ -1362,66 +1362,80 @@ class TestCrosstab(object):
         b = np.array(['one', 'one', 'two', 'one', 'two', 'two'])
         c = np.array(['dull', 'shiny', 'dull', 'dull', 'dull', 'shiny'])
         d = np.array(['a', 'a', 'b', 'a', 'b', 'b'])
-        expected_col_colnorm = MultiIndex(levels=[['All', 'dull', 'shiny'],
-                                                  ['', 'a', 'b']],
-                                          labels=[[1, 1, 2, 2, 0],
-                                                  [1, 2, 1, 2, 0]],
-                                          names=['col_0', 'col_1'])
-        expected_index_colnorm = MultiIndex(levels=[['All', 'bar', 'foo'],
-                                                    ['', 'one', 'two']],
-                                            labels=[[1, 1, 2, 2],
-                                                    [1, 2, 1, 2]],
-                                            names=['row_0', 'row_1'])
-        expected_data_colnorm = np.array([[.5, 0., 1., 0., .333333],
-                                          [0., .5, 0., 0., .166667],
-                                          [.5, 0., 0., 0., .166667],
-                                          [0., .5, 0., 1., .333333]])
-        expected_colnorm = pd.DataFrame(expected_data_colnorm,
-                                        index=expected_index_colnorm,
-                                        columns=expected_col_colnorm)
-        expected_col_indexnorm = MultiIndex(levels=[['All', 'dull', 'shiny'],
-                                                    ['', 'a', 'b']],
-                                            labels=[[1, 1, 2, 2],
-                                                    [1, 2, 1, 2]],
-                                            names=['col_0', 'col_1'])
-        expected_index_indexnorm = MultiIndex(levels=[['All', 'bar', 'foo'],
-                                                      ['', 'one', 'two']],
-                                              labels=[[1, 1, 2, 2, 0],
-                                                      [1, 2, 1, 2, 0]],
-                                              names=['row_0', 'row_1'])
-        expected_data_indexnorm = np.array([[.5, 0., .5, 0.],
-                                            [0., 1., 0., 0.],
-                                            [1., 0., 0., 0.],
-                                            [0., .5, 0., .5],
-                                            [.33333333, .33333333,
-                                             .16666667, .16666667]])
-        expected_indexnorm = pd.DataFrame(expected_data_indexnorm,
-                                          index=expected_index_indexnorm,
-                                          columns=expected_col_indexnorm)
-        expected_data_allnorm = np.array([[0.16666667, 0., .16666667,
-                                           0., .33333333],
-                                          [0., .16666667, 0.,
-                                           0., .16666667],
-                                          [.16666667, 0., 0.,
-                                           0., .16666667],
-                                          [0., .16666667, 0.,
-                                           .16666667, .33333333],
-                                          [0.33333333, .33333333, .16666667,
-                                           .16666667, 1.]])
-        expected_allnorm = pd.DataFrame(expected_data_allnorm,
-                                        index=expected_index_indexnorm,
-                                        columns=expected_col_colnorm)
 
-        result_colnorm = pd.crosstab([a, b], [c, d], normalize='columns',
-                                     margins=True)
-        result_indexnorm = pd.crosstab([a, b], [c, d], normalize='index',
-                                       margins=True)
-        result_allnorm = pd.crosstab([a, b], [c, d], normalize='all',
-                                     margins=True)
+        # test for normalize == 'columns'
+        expected_columns = MultiIndex(levels=[['All', 'dull', 'shiny'],
+                                              ['', 'a', 'b']],
+                                      labels=[[1, 1, 2, 2, 0],
+                                              [1, 2, 1, 2, 0]],
+                                      names=['col_0', 'col_1'])
+        expected_index = MultiIndex(levels=[['All', 'bar', 'foo'],
+                                            ['', 'one', 'two']],
+                                    labels=[[1, 1, 2, 2],
+                                            [1, 2, 1, 2]],
+                                    names=['row_0', 'row_1'])
+        expected_data = np.array([[.5, 0., 1., 0., .333333],
+                                  [0., .5, 0., 0., .166667],
+                                  [.5, 0., 0., 0., .166667],
+                                  [0., .5, 0., 1., .333333]])
+        expected = pd.DataFrame(expected_data,
+                                index=expected_index,
+                                columns=expected_columns)
+        result = pd.crosstab([a, b], [c, d], normalize='columns',
+                             margins=True)
+        tm.assert_frame_equal(result, expected)
 
-        tm.assert_frame_equal(result_colnorm, expected_colnorm)
-        tm.assert_frame_equal(result_indexnorm, expected_indexnorm)
-        tm.assert_frame_equal(result_allnorm, expected_allnorm)
+        # test for normalize == 'index'
+        expected_columns = MultiIndex(levels=[['All', 'dull', 'shiny'],
+                                              ['', 'a', 'b']],
+                                      labels=[[1, 1, 2, 2],
+                                              [1, 2, 1, 2]],
+                                      names=['col_0', 'col_1'])
+        expected_index = MultiIndex(levels=[['All', 'bar', 'foo'],
+                                            ['', 'one', 'two']],
+                                    labels=[[1, 1, 2, 2, 0],
+                                            [1, 2, 1, 2, 0]],
+                                    names=['row_0', 'row_1'])
+        expected_data = np.array([[.5, 0., .5, 0.],
+                                  [0., 1., 0., 0.],
+                                  [1., 0., 0., 0.],
+                                  [0., .5, 0., .5],
+                                  [.33333333, .33333333,
+                                   .16666667, .16666667]])
+        expected = pd.DataFrame(expected_data,
+                                index=expected_index,
+                                columns=expected_columns)
+        result = pd.crosstab([a, b], [c, d], normalize='index',
+                             margins=True)
+        tm.assert_frame_equal(result, expected)
+
+        # test for normalize == 'all'
+        expected_columns = MultiIndex(levels=[['All', 'dull', 'shiny'],
+                                              ['', 'a', 'b']],
+                                      labels=[[1, 1, 2, 2, 0],
+                                              [1, 2, 1, 2, 0]],
+                                      names=['col_0', 'col_1'])
+        expected_index = MultiIndex(levels=[['All', 'bar', 'foo'],
+                                            ['', 'one', 'two']],
+                                    labels=[[1, 1, 2, 2, 0],
+                                            [1, 2, 1, 2, 0]],
+                                    names=['row_0', 'row_1'])
+        expected_data = np.array([[0.16666667, 0., .16666667,
+                                   0., .33333333],
+                                  [0., .16666667, 0.,
+                                   0., .16666667],
+                                  [.16666667, 0., 0.,
+                                   0., .16666667],
+                                  [0., .16666667, 0.,
+                                   .16666667, .33333333],
+                                  [0.33333333, .33333333, .16666667,
+                                   .16666667, 1.]])
+        expected = pd.DataFrame(expected_data,
+                                index=expected_index,
+                                columns=expected_columns)
+        result = pd.crosstab([a, b], [c, d], normalize='all',
+                             margins=True)
+        tm.assert_frame_equal(result, expected)
 
     def test_crosstab_with_empties(self):
         # Check handling of empties

--- a/pandas/tests/reshape/test_pivot.py
+++ b/pandas/tests/reshape/test_pivot.py
@@ -1477,8 +1477,8 @@ class TestCrosstab(object):
         with tm.assert_raises_regex(ValueError, error):
             pd.crosstab(df.a, df.b, aggfunc=np.mean)
 
-        error = "Not a valid normalize argument: '42'"
-        with tm.assert_raises_regex(ValueError, error):
+        error = "'42'"
+        with tm.assert_raises_regex(KeyError, error):
             pd.crosstab(df.a, df.b, normalize='42')
 
         error = "Not a valid normalize argument: 42"

--- a/pandas/tests/reshape/test_pivot.py
+++ b/pandas/tests/reshape/test_pivot.py
@@ -1300,12 +1300,10 @@ class TestCrosstab(object):
                                            [0.25, 0.75],
                                            [0.4, 0.6]],
                                           index=pd.Index([1, 2, 'All'],
-                                                         name='a',
-                                                         dtype='object'),
+                                                         name='a'),
                                           columns=pd.Index([3, 4], name='b'))
         col_normal_margins = pd.DataFrame([[0.5, 0, 0.2], [0.5, 1.0, 0.8]],
-                                          index=pd.Index([1, 2], name='a',
-                                                         dtype='object'),
+                                          index=pd.Index([1, 2], name='a'),
                                           columns=pd.Index([3, 4, 'All'],
                                                            name='b'))
 
@@ -1313,8 +1311,7 @@ class TestCrosstab(object):
                                            [0.2, 0.6, 0.8],
                                            [0.4, 0.6, 1]],
                                           index=pd.Index([1, 2, 'All'],
-                                                         name='a',
-                                                         dtype='object'),
+                                                         name='a'),
                                           columns=pd.Index([3, 4, 'All'],
                                                            name='b'))
         tm.assert_frame_equal(pd.crosstab(df.a, df.b, normalize='index',
@@ -1361,10 +1358,10 @@ class TestCrosstab(object):
 
     def test_crosstab_norm_margins_with_multiindex(self):
         # GH 15150
-        a = np.array(['foo', 'bar', 'foo', 'bar','bar', 'foo'])
-        b = np.array(['one', 'one', 'two', 'one','two', 'two'])
-        c = np.array(['dull', 'shiny', 'dull', 'dull','dull', 'shiny'])
-        d = np.array(['a', 'a', 'b', 'a','b', 'b'])
+        a = np.array(['foo', 'bar', 'foo', 'bar', 'bar', 'foo'])
+        b = np.array(['one', 'one', 'two', 'one', 'two', 'two'])
+        c = np.array(['dull', 'shiny', 'dull', 'dull', 'dull', 'shiny'])
+        d = np.array(['a', 'a', 'b', 'a', 'b', 'b'])
         expected_col_colnorm = MultiIndex(levels=[['All', 'dull', 'shiny'],
                                                   ['', 'a', 'b']],
                                           labels=[[1, 1, 2, 2, 0],
@@ -1399,11 +1396,11 @@ class TestCrosstab(object):
                                             [.33333333, .33333333,
                                              .16666667, .16666667]])
         expected_indexnorm = pd.DataFrame(expected_data_indexnorm,
-                                 index=expected_index_indexnorm,
-                                 columns=expected_col_indexnorm)
+                                          index=expected_index_indexnorm,
+                                          columns=expected_col_indexnorm)
         expected_data_allnorm = np.array([[0.16666667, 0., .16666667,
                                            0., .33333333],
-                                          [0. ,.16666667, 0.,
+                                          [0., .16666667, 0.,
                                            0., .16666667],
                                           [.16666667, 0., 0.,
                                            0., .16666667],
@@ -1412,15 +1409,15 @@ class TestCrosstab(object):
                                           [0.33333333, .33333333, .16666667,
                                            .16666667, 1.]])
         expected_allnorm = pd.DataFrame(expected_data_allnorm,
-                                 index=expected_index_indexnorm,
-                                 columns=expected_col_colnorm)
+                                        index=expected_index_indexnorm,
+                                        columns=expected_col_colnorm)
 
-        result_colnorm = pd.crosstab([a, b], [c,d], normalize='columns',
+        result_colnorm = pd.crosstab([a, b], [c, d], normalize='columns',
                                      margins=True)
-        result_indexnorm = pd.crosstab([a, b], [c,d], normalize='index',
+        result_indexnorm = pd.crosstab([a, b], [c, d], normalize='index',
                                        margins=True)
-        result_allnorm = pd.crosstab([a, b], [c,d], normalize='all',
-                                       margins=True)
+        result_allnorm = pd.crosstab([a, b], [c, d], normalize='all',
+                                     margins=True)
 
         tm.assert_frame_equal(result_colnorm, expected_colnorm)
         tm.assert_frame_equal(result_indexnorm, expected_indexnorm)


### PR DESCRIPTION
 - [x] closes #15150
 - [x] tests added / passed
 - [x] passes ``git diff upstream/master --name-only -- '*.py' | flake8 --diff``
 - [x] whatsnew entry

When debugging this issue I came across some unexpected results for margins 
when normalization 'index' or 'column' is performed. Here a cross table with 'column' normalization (example from line 1271 in test_pivot.py):

    b    3    4  All
    a               
    1  0.5  0.0  0.2
    2  0.5  1.0  0.8

I would expect, that margin values should always be the sums of rows/cols, regardless if values were normalized or not, so I would expect the following:

    b    3    4  All
    a               
    1  0.5  0.0  0.5
    2  0.5  1.0  1.5

This is not the case for 'index' and 'column' normalization. In fact, margin values are calculated as sums of raw values and then normalized. This is fine for normalization 'all'. But for normalization 'columns' and 'index', this leads to -- at least for me -- unexpected results.

I left the calculation as it is, because this kind of behavior is validated in test_crosstab_normalize
(test_pivot.py), so maybe the calculation is wanted like that. Is it?
 