### PR TITLE
Fix some lgtm alerts

### DIFF
--- a/pandas/core/dtypes/cast.py
+++ b/pandas/core/dtypes/cast.py
@@ -668,7 +668,7 @@ def maybe_convert_objects(values, convert_dates=True, convert_numeric=True,
 
         if convert_timedeltas == 'coerce':
             from pandas.core.tools.timedeltas import to_timedelta
-            new_values = to_timedelta(values, coerce=True)
+            new_values = to_timedelta(values, errors='coerce')
 
             # if we are all nans then leave me alone
             if not isnull(new_values).all():

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -5303,8 +5303,8 @@ it is assumed to be aliases for the column names.')
 
             # slice me out of the other
             else:
-                raise NotImplementedError("cannot align with a higher dimensional "
-                                     "NDFrame")
+                raise NotImplementedError("cannot align with a higher "
+                                          "dimensional NDFrame")
 
         elif is_list_like(other):
 

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -4285,7 +4285,7 @@ it is assumed to be aliases for the column names.')
                 raise ValueError("subset is not valid for Series")
         elif self.ndim > 2:
             raise NotImplementedError("asof is not implemented "
-                                      "for {type}".format(type(self)))
+                                      "for {type}".format(type=type(self)))
         else:
             if subset is None:
                 subset = self.columns
@@ -4980,7 +4980,7 @@ it is assumed to be aliases for the column names.')
 
         offset = to_offset(offset)
 
-        start_date = start = self.index[-1] - offset
+        start_date = self.index[-1] - offset
         start = self.index.searchsorted(start_date, side='right')
         return self.iloc[start:]
 
@@ -5303,7 +5303,7 @@ it is assumed to be aliases for the column names.')
 
             # slice me out of the other
             else:
-                raise NotImplemented("cannot align with a higher dimensional "
+                raise NotImplementedError("cannot align with a higher dimensional "
                                      "NDFrame")
 
         elif is_list_like(other):

--- a/pandas/core/indexes/interval.py
+++ b/pandas/core/indexes/interval.py
@@ -1053,11 +1053,11 @@ def interval_range(start=None, end=None, freq=None, periods=None,
         if periods is None or end is None:
             raise ValueError("must specify 2 of start, end, periods")
         start = end - periods * freq
-    elif end is None:
+    if end is None:
         if periods is None or start is None:
             raise ValueError("must specify 2 of start, end, periods")
         end = start + periods * freq
-    elif periods is None:
+    if periods is None:
         if start is None or end is None:
             raise ValueError("must specify 2 of start, end, periods")
         pass

--- a/pandas/core/internals.py
+++ b/pandas/core/internals.py
@@ -4645,7 +4645,6 @@ def _block2d_to_blocknd(values, placement, shape, labels, ref_items):
         pvalues = np.empty(panel_shape, dtype=dtype)
         pvalues.fill(fill_value)
 
-    values = values
     for i in range(len(placement)):
         pvalues[i].flat[mask] = values[:, i]
 

--- a/pandas/core/internals.py
+++ b/pandas/core/internals.py
@@ -5154,8 +5154,6 @@ class JoinUnit(object):
             return _get_dtype(maybe_promote(self.block.dtype,
                                             self.block.fill_value)[0])
 
-        return self._dtype
-
     @cache_readonly
     def is_null(self):
         if self.block is None:

--- a/pandas/core/sparse/array.py
+++ b/pandas/core/sparse/array.py
@@ -125,7 +125,7 @@ def _sparse_array_op(left, right, op, name, series=False):
             name = name[1:]
 
         if name in ('and', 'or') and dtype == 'bool':
-            opname = 'sparse_{name}_uint8'.format(name=name, dtype=dtype)
+            opname = 'sparse_{name}_uint8'.format(name=name)
             # to make template simple, cast here
             left_sp_values = left.sp_values.view(np.uint8)
             right_sp_values = right.sp_values.view(np.uint8)

--- a/pandas/io/parsers.py
+++ b/pandas/io/parsers.py
@@ -2211,7 +2211,7 @@ class PythonParser(ParserBase):
     def get_chunk(self, size=None):
         if size is None:
             size = self.chunksize
-        return self.read(nrows=size)
+        return self.read(rows=size)
 
     def _convert_data(self, data):
         # apply converters

--- a/pandas/tseries/offsets.py
+++ b/pandas/tseries/offsets.py
@@ -1596,7 +1596,6 @@ class Week(DateOffset):
             if otherDay != self.weekday:
                 other = other + timedelta((self.weekday - otherDay) % 7)
                 k = k - 1
-            other = other
             for i in range(k):
                 other = other + self._inc
         else:


### PR DESCRIPTION
Hi,
I just wanted to quickly fix a few alerts flagged up by lgtm.com. These are mostly simple ones but they were a few misnamed arguments in some calls. 

A total of 209 alerts have been found by lgtm.com, you can enable PR integration for automated PR reviews and flag these in the future before they find their way to the code base.
https://lgtm.com/projects/g/pydata/pandas/

I'm a big fan of pandas, I hope you'll find these useful!

 - [ ] closes #xxxx
 - [ ] tests added / passed
 - [x] passes ``git diff upstream/master --name-only -- '*.py' | flake8 --diff``
 - [ ] whatsnew entry