### PR TITLE
BUG: TimedeltaIndex raising ValueError when slice indexing (#16637)

### DIFF
--- a/doc/source/whatsnew/v0.20.2.txt
+++ b/doc/source/whatsnew/v0.20.2.txt
@@ -51,6 +51,7 @@ Bug Fixes
 - Bug in :func:`unique` on an array of tuples (:issue:`16519`)
 - Bug in :func:`cut` when ``labels`` are set, resulting in incorrect label ordering (:issue:`16459`)
 - Fixed a compatibility issue with IPython 6.0's tab completion showing deprecation warnings on ``Categoricals`` (:issue:`16409`)
+- Bug in ``TimedeltaIndex`` raising a ``ValueError`` when slice indexing with ``loc`` (:issue:`16637`)
 
 Conversion
 ^^^^^^^^^^

--- a/doc/source/whatsnew/v0.20.2.txt
+++ b/doc/source/whatsnew/v0.20.2.txt
@@ -51,7 +51,6 @@ Bug Fixes
 - Bug in :func:`unique` on an array of tuples (:issue:`16519`)
 - Bug in :func:`cut` when ``labels`` are set, resulting in incorrect label ordering (:issue:`16459`)
 - Fixed a compatibility issue with IPython 6.0's tab completion showing deprecation warnings on ``Categoricals`` (:issue:`16409`)
-- Bug in ``TimedeltaIndex`` raising a ``ValueError`` when slice indexing with ``loc`` (:issue:`16637`)
 
 Conversion
 ^^^^^^^^^^

--- a/doc/source/whatsnew/v0.20.3.txt
+++ b/doc/source/whatsnew/v0.20.3.txt
@@ -40,7 +40,6 @@ Bug Fixes
 - Fixed issue with :meth:`DataFrame.style` where element id's were not unique (:issue:`16780`)
 - Fixed a pytest marker failing downstream packages' tests suites (:issue:`16680`)
 - Fixed compat with loading a ``DataFrame`` with a ``PeriodIndex``, from a ``format='fixed'`` HDFStore, in Python 3, that was written in Python 2 (:issue:`16781`)
-- Fixed bug where computing the rolling covariance of a MultiIndexed ``DataFrame`` improperly raised a ``ValueError`` (:issue:`16789`)
 - Fixed a bug in failing to compute rolling computations of a column-MultiIndexed ``DataFrame`` (:issue:`16789`, :issue:`16825`)
 - Bug in a DataFrame/Series with a ``TimedeltaIndex`` when slice indexing (:issue:`16637`)
 

--- a/doc/source/whatsnew/v0.20.3.txt
+++ b/doc/source/whatsnew/v0.20.3.txt
@@ -41,6 +41,7 @@ Bug Fixes
 - Fixed a pytest marker failing downstream packages' tests suites (:issue:`16680`)
 - Fixed compat with loading a ``DataFrame`` with a ``PeriodIndex``, from a ``format='fixed'`` HDFStore, in Python 3, that was written in Python 2 (:issue:`16781`)
 - Fixed bug where computing the rolling covariance of a MultiIndexed ``DataFrame`` improperly raised a ``ValueError`` (:issue:`16789`)
+- Bug in ``TimedeltaIndex`` raising a ``ValueError`` when slice indexing with ``loc`` (:issue:`16637`)
 
 Conversion
 ^^^^^^^^^^

--- a/doc/source/whatsnew/v0.20.3.txt
+++ b/doc/source/whatsnew/v0.20.3.txt
@@ -41,7 +41,7 @@ Bug Fixes
 - Fixed a pytest marker failing downstream packages' tests suites (:issue:`16680`)
 - Fixed compat with loading a ``DataFrame`` with a ``PeriodIndex``, from a ``format='fixed'`` HDFStore, in Python 3, that was written in Python 2 (:issue:`16781`)
 - Fixed bug where computing the rolling covariance of a MultiIndexed ``DataFrame`` improperly raised a ``ValueError`` (:issue:`16789`)
-- Bug in ``TimedeltaIndex`` raising a ``ValueError`` when slice indexing with ``loc`` (:issue:`16637`)
+- Bug in a DataFrame/Series with a ``TimedeltaIndex`` when slice indexing (:issue:`16637`)
 
 Conversion
 ^^^^^^^^^^

--- a/pandas/core/dtypes/common.py
+++ b/pandas/core/dtypes/common.py
@@ -396,7 +396,10 @@ def is_timedelta64_dtype(arr_or_dtype):
 
     if arr_or_dtype is None:
         return False
-    tipo = _get_dtype_type(arr_or_dtype)
+    try:
+        tipo = _get_dtype_type(arr_or_dtype)
+    except ValueError:
+        return False
     return issubclass(tipo, np.timedelta64)
 
 

--- a/pandas/core/indexes/timedeltas.py
+++ b/pandas/core/indexes/timedeltas.py
@@ -680,8 +680,7 @@ class TimedeltaIndex(DatetimeIndexOpsMixin, TimelikeOps, Int64Index):
         -------
         loc : int
         """
-
-        if is_bool_indexer(key):
+        if is_bool_indexer(key) or is_timedelta64_dtype(key):
             raise TypeError
 
         if isnull(key):

--- a/pandas/tests/dtypes/test_common.py
+++ b/pandas/tests/dtypes/test_common.py
@@ -204,6 +204,8 @@ def test_is_timedelta64_dtype():
     assert com.is_timedelta64_dtype(np.timedelta64)
     assert com.is_timedelta64_dtype(pd.Series([], dtype="timedelta64[ns]"))
 
+    assert not com.is_timedelta64_dtype("0 days 00:00:00")
+
 
 def test_is_period_dtype():
     assert not com.is_period_dtype(object)

--- a/pandas/tests/dtypes/test_common.py
+++ b/pandas/tests/dtypes/test_common.py
@@ -200,7 +200,7 @@ def test_is_datetime64tz_dtype():
 def test_is_timedelta64_dtype():
     assert not com.is_timedelta64_dtype(object)
     assert not com.is_timedelta64_dtype([1, 2, 3])
-
+    assert not com.is_timedelta64_dtype(np.array([], dtype=np.datetime64))
     assert com.is_timedelta64_dtype(np.timedelta64)
     assert com.is_timedelta64_dtype(pd.Series([], dtype="timedelta64[ns]"))
 

--- a/pandas/tests/indexing/test_timedelta.py
+++ b/pandas/tests/indexing/test_timedelta.py
@@ -13,13 +13,14 @@ class TestTimedeltaIndexing(object):
                          [0, 1, 2, 10, 4, 5, 6, 7, 8, 9],
                          [10, 10, 10, 3, 4, 5, 6, 7, 8, 9]]
         for cond, data in zip(conditions, expected_data):
-            result = df.assign(x=df.mask(cond, 10).astype(df['x'].dtype))
+            result = df.assign(x=df.mask(cond, 10).astype('int64'))
             expected = pd.DataFrame(data,
                                     index=pd.to_timedelta(range(10), unit='s'),
-                                    columns=['x'])
+                                    columns=['x'],
+                                    dtype='int64')
             tm.assert_frame_equal(expected, result)
 
-    def test_slice_indexing(self):
+    def test_list_like_indexing(self):
         # GH 16637
         df = pd.DataFrame({'x': range(10)})
         df.index = pd.to_timedelta(range(10), unit='s')

--- a/pandas/tests/indexing/test_timedelta.py
+++ b/pandas/tests/indexing/test_timedelta.py
@@ -30,10 +30,8 @@ class TestTimedeltaIndexing(object):
         # GH 16637
         df = pd.DataFrame({'x': range(10)}, dtype="int64")
         df.index = pd.to_timedelta(range(10), unit='s')
-        try:
-            df.loc[df.index[indexer], 'x'] = 20
-        except ValueError:
-            raise ValueError(indexer)
+
+        df.loc[df.index[indexer], 'x'] = 20
 
         expected = pd.DataFrame(expected,
                                 index=pd.to_timedelta(range(10), unit='s'),

--- a/pandas/tests/indexing/test_timedelta.py
+++ b/pandas/tests/indexing/test_timedelta.py
@@ -1,3 +1,5 @@
+import pytest
+
 import pandas as pd
 from pandas.util import testing as tm
 
@@ -20,20 +22,22 @@ class TestTimedeltaIndexing(object):
                                     dtype='int64')
             tm.assert_frame_equal(expected, result)
 
-    def test_list_like_indexing(self):
+    @pytest.mark.parametrize("indexer, expected",
+                             [(0, [20, 1, 2, 3, 4, 5, 6, 7, 8, 9]),
+                              (slice(4, 8), [0, 1, 2, 3, 20, 20, 20, 20, 8, 9],),
+                              ([3, 5], [0, 1, 2, 20, 4, 20, 6, 7, 8, 9])])
+    def test_list_like_indexing(self, indexer, expected):
         # GH 16637
         df = pd.DataFrame({'x': range(10)}, dtype="int64")
         df.index = pd.to_timedelta(range(10), unit='s')
+        try:
+            df.loc[df.index[indexer], 'x'] = 20
+        except ValueError:
+            raise ValueError(indexer)
 
-        conditions = [df.index[0], df.index[4:8], df.index[[3, 5]]]
-        expected_data = [[20, 1, 2, 3, 4, 5, 6, 7, 8, 9],
-                         [0, 1, 2, 3, 20, 20, 20, 20, 8, 9],
-                         [0, 1, 2, 20, 4, 20, 6, 7, 8, 9]]
-        for cond, data in zip(conditions, expected_data):
-            result = df.copy()
-            result.loc[cond, 'x'] = 20
-            expected = pd.DataFrame(data,
-                                    index=pd.to_timedelta(range(10), unit='s'),
-                                    columns=['x'],
-                                    dtype="int64")
-            tm.assert_frame_equal(expected, result)
+        expected = pd.DataFrame(expected,
+                                index=pd.to_timedelta(range(10), unit='s'),
+                                columns=['x'],
+                                dtype="int64")
+
+        tm.assert_frame_equal(expected, df)

--- a/pandas/tests/indexing/test_timedelta.py
+++ b/pandas/tests/indexing/test_timedelta.py
@@ -22,7 +22,7 @@ class TestTimedeltaIndexing(object):
 
     def test_list_like_indexing(self):
         # GH 16637
-        df = pd.DataFrame({'x': range(10)})
+        df = pd.DataFrame({'x': range(10)}, dtype="int64")
         df.index = pd.to_timedelta(range(10), unit='s')
 
         conditions = [df.index[0], df.index[4:8], df.index[[3, 5]]]
@@ -34,5 +34,6 @@ class TestTimedeltaIndexing(object):
             result.loc[cond, 'x'] = 20
             expected = pd.DataFrame(data,
                                     index=pd.to_timedelta(range(10), unit='s'),
-                                    columns=['x'])
+                                    columns=['x'],
+                                    dtype="int64")
             tm.assert_frame_equal(expected, result)

--- a/pandas/tests/indexing/test_timedelta.py
+++ b/pandas/tests/indexing/test_timedelta.py
@@ -22,10 +22,11 @@ class TestTimedeltaIndexing(object):
                                     dtype='int64')
             tm.assert_frame_equal(expected, result)
 
-    @pytest.mark.parametrize("indexer, expected",
-                             [(0, [20, 1, 2, 3, 4, 5, 6, 7, 8, 9]),
-                              (slice(4, 8), [0, 1, 2, 3, 20, 20, 20, 20, 8, 9],),
-                              ([3, 5], [0, 1, 2, 20, 4, 20, 6, 7, 8, 9])])
+    @pytest.mark.parametrize(
+        "indexer, expected",
+        [(0, [20, 1, 2, 3, 4, 5, 6, 7, 8, 9]),
+         (slice(4, 8), [0, 1, 2, 3, 20, 20, 20, 20, 8, 9]),
+         ([3, 5], [0, 1, 2, 20, 4, 20, 6, 7, 8, 9])])
     def test_list_like_indexing(self, indexer, expected):
         # GH 16637
         df = pd.DataFrame({'x': range(10)}, dtype="int64")

--- a/pandas/tests/indexing/test_timedelta.py
+++ b/pandas/tests/indexing/test_timedelta.py
@@ -13,7 +13,7 @@ class TestTimedeltaIndexing(object):
                          [0, 1, 2, 10, 4, 5, 6, 7, 8, 9],
                          [10, 10, 10, 3, 4, 5, 6, 7, 8, 9]]
         for cond, data in zip(conditions, expected_data):
-            result = df.assign(x=df.mask(cond, 10).astype('int64'))
+            result = df.assign(x=df.mask(cond, 10).astype(df['x'].dtype))
             expected = pd.DataFrame(data,
                                     index=pd.to_timedelta(range(10), unit='s'),
                                     columns=['x'])

--- a/pandas/tests/indexing/test_timedelta.py
+++ b/pandas/tests/indexing/test_timedelta.py
@@ -18,3 +18,20 @@ class TestTimedeltaIndexing(object):
                                     index=pd.to_timedelta(range(10), unit='s'),
                                     columns=['x'])
             tm.assert_frame_equal(expected, result)
+
+    def test_slice_indexing(self):
+        # GH 16637
+        df = pd.DataFrame({'x': range(10)})
+        df.index = pd.to_timedelta(range(10), unit='s')
+
+        conditions = [df.index[0], df.index[4:8], df.index[[3, 5]]]
+        expected_data = [[20, 1, 2, 3, 4, 5, 6, 7, 8, 9],
+                         [0, 1, 2, 3, 20, 20, 20, 20, 8, 9],
+                         [0, 1, 2, 20, 4, 20, 6, 7, 8, 9]]
+        for cond, data in zip(conditions, expected_data):
+            result = df.copy()
+            result.loc[cond, 'x'] = 20
+            expected = pd.DataFrame(data,
+                                    index=pd.to_timedelta(range(10), unit='s'),
+                                    columns=['x'])
+            tm.assert_frame_equal(expected, result)


### PR DESCRIPTION
Before accepting this Pull request is there any other kind of usage of loc that might fail using deltatimeindex that I am not aware of? I could take some time to fix it once and for all.

closes #16637

 - [ x ] closes #16637
 - [ x ] tests added / passed
 - [ x ] passes ``git diff upstream/master --name-only -- '*.py' | flake8 --diff``
 - [ x ] whatsnew entry
