### PR TITLE
Set defaults to empty dicts since that's how they are set internally

### DIFF
--- a/pandas/plotting/_misc.py
+++ b/pandas/plotting/_misc.py
@@ -15,8 +15,8 @@ from pandas.plotting._tools import _subplots, _set_ticks_props
 
 
 def scatter_matrix(frame, alpha=0.5, figsize=None, ax=None, grid=False,
-                   diagonal='hist', marker='.', density_kwds=None,
-                   hist_kwds=None, range_padding=0.05, **kwds):
+                   diagonal='hist', marker='.', density_kwds={},
+                   hist_kwds={}, range_padding=0.05, **kwds):
     """
     Draw a matrix of scatter plots.
 
@@ -65,9 +65,6 @@ def scatter_matrix(frame, alpha=0.5, figsize=None, ax=None, grid=False,
     mask = notnull(df)
 
     marker = _get_marker_compat(marker)
-
-    hist_kwds = hist_kwds or {}
-    density_kwds = density_kwds or {}
 
     # GH 14855
     kwds.setdefault('edgecolors', 'none')


### PR DESCRIPTION
`scatter_matrix()` takes arguments `density_kwds` and `hist_kwds` which defaults to None. These are later set to empty dicts if they are not None. This tiny PR changes the defaults to empty dicts to improve code clarity.

 - [ ] closes #xxxx
 - [X] tests added / passed
 - [X] passes ``git diff upstream/master --name-only -- '*.py' | flake8 --diff``
 - [ ] whatsnew entry
