### PR TITLE
WIP: keep column levels when using apply after grouping (#16231)

### DIFF
--- a/doc/source/whatsnew/v0.20.3.txt
+++ b/doc/source/whatsnew/v0.20.3.txt
@@ -65,6 +65,7 @@ Plotting
 Groupby/Resample/Rolling
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
+- Bug in groupby logic causing MultiIndex column levels to be lost (:issue:`16231`)
 
 
 Sparse

--- a/pandas/core/base.py
+++ b/pandas/core/base.py
@@ -658,6 +658,7 @@ class SelectionMixin(object):
 
         # degenerate case
         if obj.ndim == 1:
+            names = obj.index.names
             for a in arg:
                 try:
                     colg = self._gotitem(obj.name, ndim=1, subset=obj)
@@ -673,6 +674,7 @@ class SelectionMixin(object):
 
         # multiples
         else:
+            names = obj.columns.names
             for col in obj:
                 try:
                     colg = self._gotitem(col, ndim=1, subset=obj[col])
@@ -691,7 +693,7 @@ class SelectionMixin(object):
             raise ValueError("no results")
 
         try:
-            return concat(results, keys=keys, axis=1)
+            return concat(results, keys=keys, axis=1, names=names)
         except TypeError:
 
             # we are concatting non-NDFrame objects,

--- a/pandas/core/groupby.py
+++ b/pandas/core/groupby.py
@@ -3481,9 +3481,9 @@ class NDFrameGroupBy(GroupBy):
                     assert not args and not kwargs
                     result = self._aggregate_multiple_funcs(
                         [arg], _level=_level, _axis=self.axis)
-                    result.columns = Index(
-                        result.columns.levels[0],
-                        name=self._selected_obj.columns.name)
+                    result.columns = result.columns.droplevel(-1)
+                    if result.columns.nlevels == 1:
+                        result.columns.name = self._selected_obj.columns.name
                 except:
                     result = self._aggregate_generic(arg, *args, **kwargs)
 

--- a/pandas/tests/test_resample.py
+++ b/pandas/tests/test_resample.py
@@ -2972,6 +2972,37 @@ class TestResamplerGrouper(object):
         result = g.apply(f)
         assert_frame_equal(result, expected)
 
+    def test_apply_preserves_multiindex_columns(self):
+        # GH 16231
+        # the original failing case
+        cols = pd.MultiIndex.from_tuples([('A', 'a', '', 'one'),
+                                          ('B', 'b', 'i', 'two')])
+        ind = pd.DatetimeIndex(start='2017-01-01', freq='15Min', periods=8)
+        df = pd.DataFrame(np.random.randn(8, 2), index=ind, columns=cols)
+
+        agg_dict = {col: (np.sum if col[3] == 'one' else np.mean)
+                    for col in df.columns}
+        resampled = df.resample('H').apply(lambda x: agg_dict[x.name](x))
+        assert isinstance(resampled.columns, pd.MultiIndex)
+
+    @pytest.mark.parametrize('nlevel', range(1, 6))
+    @pytest.mark.parametrize('ncol', [1, 2])
+    @pytest.mark.parametrize('freq', ['D', '360Min'])
+    def test_apply_preserves_multiindex_columns_grid(self, nlevel, ncol, freq):
+        # GH 16231
+        cols = pd.MultiIndex.from_tuples([[i] * nlevel for i in range(ncol)],
+                                         names=['lev_{}'.format(lev)
+                                                for lev in range(nlevel)])
+        idx = pd.date_range('2000-01-01', freq="H", periods=50)
+        df = pd.DataFrame(np.random.randn(len(idx), len(cols)),
+                          columns=cols, index=idx)
+
+        resampled = df.resample(freq)
+
+        via_direct = resampled.sum()
+        via_apply = resampled.apply(lambda x: x.sum())
+        tm.assert_frame_equal(via_direct, via_apply)
+
     def test_resample_groupby_with_label(self):
         # GH 13235
         index = date_range('2000-01-01', freq='2D', periods=5)


### PR DESCRIPTION
 - [X] closes #16231
 - [X] 3 tests added / passed
 - [X] passes ``git diff upstream/master --name-only -- '*.py' | flake8 --diff``
 - [X] whatsnew entry

This is still experimental-- the groupby logic is awfully complicated at this point, and there are lots of edge cases.