### PR TITLE
Revert "fix pytest-xidst version as 1.17 appears buggy (#16652)"

### DIFF
--- a/ci/install_travis.sh
+++ b/ci/install_travis.sh
@@ -107,7 +107,7 @@ if [ -e ${REQ} ]; then
 fi
 
 time conda install -n pandas pytest
-time pip install pytest-xdist==1.16.0
+time pip install pytest-xdist
 
 if [ "$LINT" ]; then
    conda install flake8


### PR DESCRIPTION
This reverts commit ec6bf6deaf502ac05a7120df13bd9b13cb3083f6.

1.17.1 released that fixes
closes #16653 