### PR TITLE
ENH: to_datetime support iso week year (16607)

### DIFF
--- a/doc/source/whatsnew/v0.21.0.txt
+++ b/doc/source/whatsnew/v0.21.0.txt
@@ -24,6 +24,9 @@ New features
   <https://www.python.org/dev/peps/pep-0519/>`_ on most readers and writers (:issue:`13823`)
 - Added `__fspath__` method to :class`:pandas.HDFStore`, :class:`pandas.ExcelFile`,
   and :class:`pandas.ExcelWriter` to work properly with the file system path protocol (:issue:`13823`)
+- Added 'iso week year support to to_datetime', added method '_calc_julian_from_V'
+  and amended method 'array_strptime' to support the feature. 
+  (:issue: '16607') 
 
 .. _whatsnew_0210.enhancements.other:
 

--- a/pandas/_libs/tslib.pyx
+++ b/pandas/_libs/tslib.pyx
@@ -3827,7 +3827,7 @@ def array_strptime(ndarray[object] values, object fmt,
             if iso_week == -1 or weekday == -1:
                 raise ValueError("ISO year directive '%G' must be used with "
                                  "the ISO week directive '%V' and a weekday "
-                                 "directive ('%A', '%a', '%w', or '%u').")
+                                 "directive '%A', '%a', '%w', or '%u'.")
             if julian != -1:
                 raise ValueError("Day of the year directive '%j' is not "
                                  "compatible with ISO year directive '%G'. "
@@ -3836,9 +3836,9 @@ def array_strptime(ndarray[object] values, object fmt,
             if weekday == -1:
                 raise ValueError("ISO week directive '%V' must be used with "
                                  "the ISO year directive '%G' and a weekday "
-                                 "directive ('%A', '%a', '%w', or '%u').")
+                                 "directive '%A', '%a', '%w', or '%u'.")
             else:
-                raise ValueError("ISO week directive '%V' is incompatible with "
+                raise ValueError("ISO week directive '%V' is incompatible with"
                                  " the year directive '%Y'. Use the ISO year "
                                  "'%G' instead.")
 

--- a/pandas/_libs/tslib.pyx
+++ b/pandas/_libs/tslib.pyx
@@ -3827,25 +3827,30 @@ def array_strptime(ndarray[object] values, object fmt,
             if iso_week == -1 or weekday == -1:
                 raise ValueError("ISO year directive '%G' must be used with "
                                  "the ISO week directive '%V' and a weekday "
-                                 "directive ('%w', or '%u').")
+                                 "directive ('%A', '%a', '%w', or '%u').")
             if julian != -1:
                 raise ValueError("Day of the year directive '%j' is not "
                                  "compatible with ISO year directive '%G'. "
                                  "Use '%Y' instead.")
-        elif week_of_year == -1 and iso_week != -1:
+        elif year != -1 and week_of_year == -1 and iso_week != -1:
             if weekday == -1:
                 raise ValueError("ISO week directive '%V' must be used with "
                                  "the ISO year directive '%G' and a weekday "
-                                 "directive ('%w', or '%u').")
+                                 "directive ('%A', '%a', '%w', or '%u').")
+            else:
+                raise ValueError("ISO week directive '%V' is incompatible with "
+                                 " the year directive '%Y'. Use the ISO year "
+                                 "'%G' instead.")
 
         # If we know the wk of the year and what day of that wk, we can figure
         # out the Julian day of the year.
-        if julian == -1 and week_of_year != -1 and weekday != -1:
-            week_starts_Mon = True if week_of_year_start == 0 else False
-            julian = _calc_julian_from_U_or_W(year, week_of_year, weekday,
-                                                week_starts_Mon)
-        elif iso_year != -1 and iso_week != -1 and weekday != -1:
-            year, julian = _calc_julian_from_V(iso_year, iso_week, weekday + 1)
+        if julian == -1 and weekday != -1:
+            if week_of_year != -1:
+                week_starts_Mon = True if week_of_year_start == 0 else False
+                julian = _calc_julian_from_U_or_W(year, week_of_year, weekday,
+                                                    week_starts_Mon)
+            elif iso_year != -1 and iso_week != -1:
+                year, julian = _calc_julian_from_V(iso_year, iso_week, weekday + 1)
 
         # Cannot pre-calculate datetime_date() since can change in Julian
         # calculation and thus could have different value for the day of the wk

--- a/pandas/_libs/tslib.pyx
+++ b/pandas/_libs/tslib.pyx
@@ -3658,7 +3658,10 @@ def array_strptime(ndarray[object] values, object fmt,
         'U': 15,
         'W': 16,
         'Z': 17,
-        'p': 18   # just an additional key, works only with I
+        'p': 18,  # just an additional key, works only with I
+        'G': 19,
+        'V': 20,
+        'u': 21
     }
     cdef int parse_code
 
@@ -3701,13 +3704,14 @@ def array_strptime(ndarray[object] values, object fmt,
                 raise ValueError("time data %r does not match format "
                                  "%r (search)" % (values[i], fmt))
 
+        iso_year = -1
         year = 1900
         month = day = 1
         hour = minute = second = ns = us = 0
         tz = -1
         # Default to -1 to signify that values not known; not critical to have,
         # though
-        week_of_year = -1
+        iso_week = week_of_year = -1
         week_of_year_start = -1
         # weekday and julian defaulted to -1 so as to signal need to calculate
         # values
@@ -3809,12 +3813,40 @@ def array_strptime(ndarray[object] values, object fmt,
                         else:
                             tz = value
                             break
+            elif parse_code == 19:
+                iso_year = int(found_dict['G'])
+            elif parse_code == 20:
+                iso_week = int(found_dict['V'])
+            elif parse_code == 21:
+                weekday = int(found_dict['u'])
+                weekday -= 1
+
+
+        # don't assume default values for ISO week/year
+        if iso_year != -1:
+            if iso_week == -1 or weekday == -1:
+                raise ValueError("ISO year directive '%G' must be used with "
+                                 "the ISO week directive '%V' and a weekday "
+                                 "directive ('%w', or '%u').")
+            if julian != -1:
+                raise ValueError("Day of the year directive '%j' is not "
+                                 "compatible with ISO year directive '%G'. "
+                                 "Use '%Y' instead.")
+        elif week_of_year == -1 and iso_week != -1:
+            if weekday == -1:
+                raise ValueError("ISO week directive '%V' must be used with "
+                                 "the ISO year directive '%G' and a weekday "
+                                 "directive ('%w', or '%u').")
+
         # If we know the wk of the year and what day of that wk, we can figure
         # out the Julian day of the year.
         if julian == -1 and week_of_year != -1 and weekday != -1:
             week_starts_Mon = True if week_of_year_start == 0 else False
             julian = _calc_julian_from_U_or_W(year, week_of_year, weekday,
                                                 week_starts_Mon)
+        elif iso_year != -1 and iso_week != -1 and weekday != -1:
+            year, julian = _calc_julian_from_V(iso_year, iso_week, weekday + 1)
+
         # Cannot pre-calculate datetime_date() since can change in Julian
         # calculation and thus could have different value for the day of the wk
         # calculation.
@@ -5630,6 +5662,7 @@ class TimeRE(dict):
             'f': r"(?P<f>[0-9]{1,9})",
             'H': r"(?P<H>2[0-3]|[0-1]\d|\d)",
             'I': r"(?P<I>1[0-2]|0[1-9]|[1-9])",
+            'G': r"(?P<G>\d\d\d\d)",
             'j': (r"(?P<j>36[0-6]|3[0-5]\d|[1-2]\d\d|0[1-9]\d|00[1-9]|"
                   r"[1-9]\d|0[1-9]|[1-9])"),
             'm': r"(?P<m>1[0-2]|0[1-9]|[1-9])",
@@ -5637,6 +5670,8 @@ class TimeRE(dict):
             'S': r"(?P<S>6[0-1]|[0-5]\d|\d)",
             'U': r"(?P<U>5[0-3]|[0-4]\d|\d)",
             'w': r"(?P<w>[0-6])",
+            'u': r"(?P<u>[1-7])",
+            'V': r"(?P<V>5[0-3]|0[1-9]|[1-4]\d|\d)",
             # W is set below by using 'U'
             'y': r"(?P<y>\d\d)",
             #XXX: Does 'Y' need to worry about having less or more than
@@ -5736,3 +5771,22 @@ cdef _calc_julian_from_U_or_W(int year, int week_of_year,
 
 # def _strptime_time(data_string, format="%a %b %d %H:%M:%S %Y"):
 #     return _strptime(data_string, format)[0]
+
+cdef _calc_julian_from_V(int iso_year, int iso_week, int iso_weekday):
+    """Calculate the Julian day based on the ISO 8601 year, week, and weekday.
+    ISO weeks start on Mondays, with week 01 being the week containing 4 Jan.
+    ISO week days range from 1 (Monday) to 7 (Sunday)."""
+
+    cdef:
+        int correction, ordinal
+
+    correction = datetime_date(iso_year, 1, 4).isoweekday() + 3
+    ordinal = (iso_week * 7) + iso_weekday - correction
+    # ordinal may be negative or 0 now, which means the date is in the previous
+    # calendar year
+    if ordinal < 1:
+        ordinal += datetime_date(iso_year, 1, 1).toordinal()
+        iso_year -= 1
+        ordinal -= datetime_date(iso_year, 1, 1).toordinal()
+    return iso_year, ordinal
+

--- a/pandas/_libs/tslib.pyx
+++ b/pandas/_libs/tslib.pyx
@@ -3598,7 +3598,7 @@ def array_strptime(ndarray[object] values, object fmt,
         pandas_datetimestruct dts
         ndarray[int64_t] iresult
         int year, month, day, minute, hour, second, weekday, julian, tz
-        int week_of_year, week_of_year_start
+        int week_of_year, week_of_year_start, iso_week, iso_year
         int64_t us, ns
         object val, group_key, ampm, found
         dict found_key

--- a/pandas/_libs/tslib.pyx
+++ b/pandas/_libs/tslib.pyx
@@ -3681,7 +3681,6 @@ def array_strptime(ndarray[object] values, object fmt,
         # exact matching
         if exact:
             found = format_regex.match(val)
-            print found
             if not found:
                 if is_coerce:
                     iresult[i] = NPY_NAT

--- a/pandas/tests/indexes/datetimes/test_tools.py
+++ b/pandas/tests/indexes/datetimes/test_tools.py
@@ -186,7 +186,7 @@ class TestToDatetime(object):
     @pytest.mark.parametrize("msg, s, _format", [
         ["ISO week directive '%V' must be used with the ISO year directive "
          "'%G' and a weekday directive '%A', '%a', '%w', or '%u'.", "1999 50",
-         "%V"],
+         "%Y %V"],
         ["ISO year directive '%G' must be used with the ISO week directive "
          "'%V' and a weekday directive '%A', '%a', '%w', or '%u'.", "1999 51",
          "%G %V"],

--- a/pandas/tests/indexes/datetimes/test_tools.py
+++ b/pandas/tests/indexes/datetimes/test_tools.py
@@ -177,11 +177,39 @@ class TestToDatetime(object):
 
     def test_to_datetime_iso_week_year_format(self):
         data = [
-            ['2015-53-1', '%G-%V-%u',
-            datetime(2015, 12, 28, 0, 0)]
+            ['2015-1-1', '%G-%V-%u',
+            datetime(2014, 12, 29, 0, 0)], #negative ordinal (date in previous year)
+            ['2015-1-4', '%G-%V-%u',
+            datetime(2015, 1, 1, 0, 0)],
+            ['2015-1-7', '%G-%V-%u',
+            datetime(2015, 1, 4, 0, 0)] 
             ]
         for s, format, dt in data:
             assert to_datetime(s, format=format) == dt
+
+    def test_ValueError_iso_week_year(self):
+        # 1. ISO week (%V) is specified, but the year is specified with %Y
+        # instead of %G
+        with pytest.raises(ValueError):
+           to_datetime("1999 50", format="%Y %V")
+        # 2. ISO year (%G) and ISO week (%V) are specified, but weekday is not
+        with pytest.raises(ValueError):
+            to_datetime("1999 51", format="%G %V")
+        # 3. ISO year (%G) and weekday are specified, but ISO week (%V) is not
+        for w in ('A', 'a', 'w', 'u'):
+            with pytest.raises(ValueError):
+                to_datetime("1999 51", format="%G %{}".format(w))
+        # 4. ISO year is specified alone 
+        with pytest.raises(ValueError):
+            to_datetime("2015", format="%G")
+        # 5. Julian/ordinal day (%j) is specified with %G, but not %Y
+        with pytest.raises(ValueError):
+            to_datetime("1999 256", format="%G %j")
+        #6. ISO week (%V) and weekday are specified, but ISO year (%G) is not 
+        for w in ('A', 'a', 'w', 'u'):
+            with pytest.raises(ValueError):
+                to_datetime("51 11", format="%V %{}".format(w))
+
 
     def test_to_datetime_dt64s(self):
         in_bound_dts = [

--- a/pandas/tests/indexes/datetimes/test_tools.py
+++ b/pandas/tests/indexes/datetimes/test_tools.py
@@ -175,6 +175,14 @@ class TimeConversionFormats(object):
 
 class TestToDatetime(object):
 
+    def test_to_datetime_iso_week_year_format(self):
+        data = [
+            ['2015-53-1', '%G-%V-%u',
+            datetime(2015, 12, 28, 0, 0)]
+            ]
+        for s, format, dt in data:
+            assert to_datetime(s, format=format) == dt
+
     def test_to_datetime_dt64s(self):
         in_bound_dts = [
             np.datetime64('2000-01-01'),

--- a/pandas/tests/indexes/datetimes/test_tools.py
+++ b/pandas/tests/indexes/datetimes/test_tools.py
@@ -1003,13 +1003,9 @@ class TestToDatetimeInferFormat(object):
         tm.assert_series_equal(pd.to_datetime(s, infer_datetime_format=False),
                                pd.to_datetime(s, infer_datetime_format=True))
 
-    def test_to_datetime_infer_datetime_format_series_starting_with_nans(
-            self):
-        s = pd.Series(np.array([np.nan,
-                                np.nan,
-                                '01/01/2011 00:00:00',
-                                '01/02/2011 00:00:00',
-                                '01/03/2011 00:00:00']))
+    def test_to_datetime_infer_datetime_format_series_starting_with_nans(self):
+        s = pd.Series(np.array([np.nan, np.nan, '01/01/2011 00:00:00',
+                                '01/02/2011 00:00:00', '01/03/2011 00:00:00']))
 
         tm.assert_series_equal(pd.to_datetime(s, infer_datetime_format=False),
                                pd.to_datetime(s, infer_datetime_format=True))

--- a/pandas/tests/indexes/datetimes/test_tools.py
+++ b/pandas/tests/indexes/datetimes/test_tools.py
@@ -296,23 +296,11 @@ class TestToDatetime(object):
     def test_to_datetime_tz_pytz(self):
         # see gh-8260
         us_eastern = pytz.timezone('US/Eastern')
-        arr = np.array(
-            [
-                us_eastern.localize(
-                    datetime(
-                        year=2000,
-                        month=1,
-                        day=1,
-                        hour=3,
-                        minute=0)),
-                us_eastern.localize(
-                    datetime(
-                        year=2000,
-                        month=6,
-                        day=1,
-                        hour=3,
-                        minute=0))],
-            dtype=object)
+        arr = np.array([us_eastern.localize(datetime(year=2000, month=1, day=1,
+                                                    hour=3, minute=0)),
+                        us_eastern.localize(datetime(year=2000, month=6, day=1,
+                                                    hour=3, minute=0))],
+                        dtype=object)
         result = pd.to_datetime(arr, utc=True)
         expected = DatetimeIndex(['2000-01-01 08:00:00+00:00',
                                   '2000-06-01 07:00:00+00:00'],

--- a/pandas/tests/indexes/datetimes/test_tools.py
+++ b/pandas/tests/indexes/datetimes/test_tools.py
@@ -99,8 +99,8 @@ class TimeConversionFormats(object):
         assert_series_equal(result, expected)
 
         s = Series([200001, 200105, 200206])
-        expected = Series([Timestamp(x[:4] + '-' + x[4:]) for x in s.apply(str)
-                           ])
+        expected = Series([Timestamp(x[:4] + '-' + x[4:])
+                           for x in s.apply(str)])
 
         result = to_datetime(s, format='%Y%m')
         assert_series_equal(result, expected)
@@ -176,44 +176,51 @@ class TimeConversionFormats(object):
 class TestToDatetime(object):
 
     @pytest.mark.parametrize("s, _format, dt", [
-            ['2015-1-1', '%G-%V-%u', datetime(2014, 12, 29, 0, 0)],
-            ['2015-1-4', '%G-%V-%u', datetime(2015, 1, 1, 0, 0)],
-            ['2015-1-7', '%G-%V-%u', datetime(2015, 1, 4, 0, 0)]
-            ])
+        ['2015-1-1', '%G-%V-%u', datetime(2014, 12, 29, 0, 0)],
+        ['2015-1-4', '%G-%V-%u', datetime(2015, 1, 1, 0, 0)],
+        ['2015-1-7', '%G-%V-%u', datetime(2015, 1, 4, 0, 0)]
+    ])
     def test_to_datetime_iso_week_year_format(self, s, _format, dt):
-            assert to_datetime(s, format = _format) == dt
+        assert to_datetime(s, format=_format) == dt
 
     @pytest.mark.parametrize("msg, s, _format", [
-            ["ISO week directive '%V' must be used with the ISO year directive '%G' "
-             "and a weekday directive '%A', '%a', '%w', or '%u'.", "1999 50", "%Y %V"],
-            ["ISO year directive '%G' must be used with the ISO week directive '%V' "
-             "and a weekday directive '%A', '%a', '%w', or '%u'.", "1999 51", "%G %V"],
-            ["ISO year directive '%G' must be used with the ISO week directive '%V' "
-             "and a weekday directive '%A', '%a', '%w', or '%u'.", "1999 Monday", "%G %A"],
-            ["ISO year directive '%G' must be used with the ISO week directive '%V' "
-             "and a weekday directive '%A', '%a', '%w', or '%u'.", "1999 Mon", "%G %a"],
-            ["ISO year directive '%G' must be used with the ISO week directive '%V' "
-             "and a weekday directive '%A', '%a', '%w', or '%u'.", "1999 6", "%G %w"],
-            ["ISO year directive '%G' must be used with the ISO week directive '%V' "
-             "and a weekday directive '%A', '%a', '%w', or '%u'.", "1999 6", "%G %u"],
-            ["ISO year directive '%G' must be used with the ISO week directive '%V' "
-             "and a weekday directive '%A', '%a', '%w', or '%u'.", "2051", "%G"],
-            ["Day of the year directive '%j' is not compatible with ISO year directive "
-             "'%G'. Use '%Y' instead.", "1999 51 6 256", "%G %V %u %j"],
-            ["ISO week directive '%V' is incompatible with the year directive '%Y'. "
-             "Use the ISO year '%G' instead.", "1999 51 Sunday", "%Y %V %A"],
-            ["ISO week directive '%V' is incompatible with the year directive '%Y'. "
-             "Use the ISO year '%G' instead.", "1999 51 Sun", "%Y %V %a"],
-            ["ISO week directive '%V' is incompatible with the year directive '%Y'. "
-             "Use the ISO year '%G' instead.", "1999 51 1", "%Y %V %w"],
-            ["ISO week directive '%V' is incompatible with the year directive '%Y'. "
-             "Use the ISO year '%G' instead.", "1999 51 1", "%Y %V %u"],
-            ["ISO week directive '%V' must be used with the ISO year directive '%G' "
-             "and a weekday directive '%A', '%a', '%w', or '%u'.", "20", "%V"]
-             ])
+        ["ISO week directive '%V' must be used with the ISO year directive "
+         "'%G' and a weekday directive '%A', '%a', '%w', or '%u'.", "1999 50",
+         "%V"],
+        ["ISO year directive '%G' must be used with the ISO week directive "
+         "'%V' and a weekday directive '%A', '%a', '%w', or '%u'.", "1999 51",
+         "%G %V"],
+        ["ISO year directive '%G' must be used with the ISO week directive "
+         "'%V' and a weekday directive '%A', '%a', '%w', or '%u'.", "1999 "
+         "Monday", "%G %A"],
+        ["ISO year directive '%G' must be used with the ISO week directive "
+         "'%V' and a weekday directive '%A', '%a', '%w', or '%u'.", "1999 Mon",
+         "%G %a"],
+        ["ISO year directive '%G' must be used with the ISO week directive "
+         "'%V' and a weekday directive '%A', '%a', '%w', or '%u'.", "1999 6",
+         "%G %w"],
+        ["ISO year directive '%G' must be used with the ISO week directive "
+         "'%V' and a weekday directive '%A', '%a', '%w', or '%u'.", "1999 6",
+         "%G %u"],
+        ["ISO year directive '%G' must be used with the ISO week directive "
+         "'%V' and a weekday directive '%A', '%a', '%w', or '%u'.", "2051",
+         "%G"],
+        ["Day of the year directive '%j' is not compatible with ISO year "
+         "directive '%G'. Use '%Y' instead.", "1999 51 6 256", "%G %V %u %j"],
+        ["ISO week directive '%V' is incompatible with the year directive "
+         "'%Y'. Use the ISO year '%G' instead.", "1999 51 Sunday", "%Y %V %A"],
+        ["ISO week directive '%V' is incompatible with the year directive "
+         "'%Y'. Use the ISO year '%G' instead.", "1999 51 Sun", "%Y %V %a"],
+        ["ISO week directive '%V' is incompatible with the year directive "
+         "'%Y'. Use the ISO year '%G' instead.", "1999 51 1", "%Y %V %w"],
+        ["ISO week directive '%V' is incompatible with the year directive "
+         "'%Y'. Use the ISO year '%G' instead.", "1999 51 1", "%Y %V %u"],
+        ["ISO week directive '%V' must be used with the ISO year directive "
+         "'%G' and a weekday directive '%A', '%a', '%w', or '%u'.", "20", "%V"]
+    ])
     def test_ValueError_iso_week_year(self, msg, s, _format):
         with tm.assert_raises_regex(ValueError, msg):
-            to_datetime(s, format = _format)
+            to_datetime(s, format=_format)
 
     def test_to_datetime_dt64s(self):
         in_bound_dts = [
@@ -289,11 +296,23 @@ class TestToDatetime(object):
     def test_to_datetime_tz_pytz(self):
         # see gh-8260
         us_eastern = pytz.timezone('US/Eastern')
-        arr = np.array([us_eastern.localize(datetime(year=2000, month=1, day=1,
-                                                     hour=3, minute=0)),
-                        us_eastern.localize(datetime(year=2000, month=6, day=1,
-                                                     hour=3, minute=0))],
-                       dtype=object)
+        arr = np.array(
+            [
+                us_eastern.localize(
+                    datetime(
+                        year=2000,
+                        month=1,
+                        day=1,
+                        hour=3,
+                        minute=0)),
+                us_eastern.localize(
+                    datetime(
+                        year=2000,
+                        month=6,
+                        day=1,
+                        hour=3,
+                        minute=0))],
+            dtype=object)
         result = pd.to_datetime(arr, utc=True)
         expected = DatetimeIndex(['2000-01-01 08:00:00+00:00',
                                   '2000-06-01 07:00:00+00:00'],
@@ -996,9 +1015,13 @@ class TestToDatetimeInferFormat(object):
         tm.assert_series_equal(pd.to_datetime(s, infer_datetime_format=False),
                                pd.to_datetime(s, infer_datetime_format=True))
 
-    def test_to_datetime_infer_datetime_format_series_starting_with_nans(self):
-        s = pd.Series(np.array([np.nan, np.nan, '01/01/2011 00:00:00',
-                                '01/02/2011 00:00:00', '01/03/2011 00:00:00']))
+    def test_to_datetime_infer_datetime_format_series_starting_with_nans(
+            self):
+        s = pd.Series(np.array([np.nan,
+                                np.nan,
+                                '01/01/2011 00:00:00',
+                                '01/02/2011 00:00:00',
+                                '01/03/2011 00:00:00']))
 
         tm.assert_series_equal(pd.to_datetime(s, infer_datetime_format=False),
                                pd.to_datetime(s, infer_datetime_format=True))

--- a/pandas/tests/indexes/datetimes/test_tools.py
+++ b/pandas/tests/indexes/datetimes/test_tools.py
@@ -100,7 +100,7 @@ class TimeConversionFormats(object):
 
         s = Series([200001, 200105, 200206])
         expected = Series([Timestamp(x[:4] + '-' + x[4:]) for x in s.apply(str)
-                            ])
+                           ])
 
         result = to_datetime(s, format='%Y%m')
         assert_series_equal(result, expected)

--- a/pandas/tests/indexes/datetimes/test_tools.py
+++ b/pandas/tests/indexes/datetimes/test_tools.py
@@ -297,10 +297,10 @@ class TestToDatetime(object):
         # see gh-8260
         us_eastern = pytz.timezone('US/Eastern')
         arr = np.array([us_eastern.localize(datetime(year=2000, month=1, day=1,
-                                                    hour=3, minute=0)),
+                                                     hour=3, minute=0)),
                         us_eastern.localize(datetime(year=2000, month=6, day=1,
-                                                    hour=3, minute=0))],
-                        dtype=object)
+                                                     hour=3, minute=0))],
+                         dtype=object)
         result = pd.to_datetime(arr, utc=True)
         expected = DatetimeIndex(['2000-01-01 08:00:00+00:00',
                                   '2000-06-01 07:00:00+00:00'],

--- a/pandas/tests/indexes/datetimes/test_tools.py
+++ b/pandas/tests/indexes/datetimes/test_tools.py
@@ -99,8 +99,8 @@ class TimeConversionFormats(object):
         assert_series_equal(result, expected)
 
         s = Series([200001, 200105, 200206])
-        expected = Series([Timestamp(x[:4] + '-' + x[4:])
-                           for x in s.apply(str)])
+        expected = Series([Timestamp(x[:4] + '-' + x[4:]) for x in s.apply(str)
+                            ])
 
         result = to_datetime(s, format='%Y%m')
         assert_series_equal(result, expected)
@@ -300,7 +300,7 @@ class TestToDatetime(object):
                                                      hour=3, minute=0)),
                         us_eastern.localize(datetime(year=2000, month=6, day=1,
                                                      hour=3, minute=0))],
-                         dtype=object)
+                       dtype=object)
         result = pd.to_datetime(arr, utc=True)
         expected = DatetimeIndex(['2000-01-01 08:00:00+00:00',
                                   '2000-06-01 07:00:00+00:00'],


### PR DESCRIPTION
ENH: to_datetime support iso week year

 - [x] closes #16607 
 - [x] test added / passed
 - [x] passes ``git diff upstream/master --name-only -- '*.py' | flake8 --diff``
 - [x] whatsnew entry
