### PR TITLE
BUG: csv parsing with EOF byte on windows, Revert gh-16039

### DIFF
--- a/doc/source/whatsnew/v0.20.3.txt
+++ b/doc/source/whatsnew/v0.20.3.txt
@@ -54,6 +54,7 @@ Indexing
 I/O
 ^^^
 
+- Bug in ``pd.read_csv()`` in which files containing EOF characters mid-field could fail with the C engine on Windows (:issue:`16039`, :issue:`16559`)
 
 
 Plotting

--- a/pandas/_libs/src/parser/io.h
+++ b/pandas/_libs/src/parser/io.h
@@ -15,10 +15,19 @@ The full license is in the LICENSE file, distributed with this software.
 
 typedef struct _file_source {
     /* The file being read. */
-    int fd;
+    FILE *fp;
 
     char *buffer;
-    size_t size;
+
+    /* file position when the file_buffer was created. */
+    off_t initial_file_pos;
+
+    /* Offset in the file of the data currently in the buffer. */
+    off_t buffer_file_pos;
+
+    /* Actual number of bytes in the current buffer. (Can be less than
+     * buffer_size.) */
+    off_t last_pos;
 } file_source;
 
 #define FS(source) ((file_source *)source)
@@ -28,13 +37,20 @@ typedef struct _file_source {
 #endif
 
 typedef struct _memory_map {
-    int fd;
+    FILE *fp;
 
     /* Size of the file, in bytes. */
-    char *memmap;
-    size_t size;
+    off_t size;
 
-    size_t position;
+    /* file position when the file_buffer was created. */
+    off_t initial_file_pos;
+
+    int line_number;
+
+    int fileno;
+    off_t position;
+    off_t last_pos;
+    char *memmap;
 } memory_map;
 
 #define MM(src) ((memory_map *)src)

--- a/pandas/io/parsers.py
+++ b/pandas/io/parsers.py
@@ -1985,7 +1985,8 @@ class PythonParser(ParserBase):
         self.comment = kwds['comment']
         self._comment_lines = []
 
-        f, handles = _get_handle(f, 'r', encoding=self.encoding,
+        mode = 'r' if PY3 else 'rb'
+        f, handles = _get_handle(f, mode, encoding=self.encoding,
                                  compression=self.compression,
                                  memory_map=self.memory_map)
         self.handles.extend(handles)

--- a/pandas/tests/io/parser/common.py
+++ b/pandas/tests/io/parser/common.py
@@ -1662,6 +1662,21 @@ j,-inF"""
         result = self.read_csv(StringIO(data))
         tm.assert_frame_equal(result, expected)
 
+    def test_internal_eof_byte_to_file(self):
+        # see gh-16559
+        data = b'c1,c2\r\n"test \x1a    test", test\r\n'
+        expected = pd.DataFrame([["test \x1a    test", " test"]],
+                                columns=["c1", "c2"])
+
+        path = '__%s__.csv' % tm.rands(10)
+
+        with tm.ensure_clean(path) as path:
+            with open(path, "wb") as f:
+                f.write(data)
+
+            result = self.read_csv(path)
+            tm.assert_frame_equal(result, expected)
+
     def test_file_handles(self):
         # GH 14418 - don't close user provided file handles
 


### PR DESCRIPTION
#16039 created a bug in which files containing byte-like data could break on Windows, as EOF characters mid-field (despite being quoted) would cause premature line breaks.  Given that this PR was a performance patch, this commit can be safely reverted.

Closes #16559 (confirmed with unit test).

cc @dgwynne 