### PR TITLE
MAINT: Give nice error message if xarray import fails

### DIFF
--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -1501,7 +1501,17 @@ class NDFrame(PandasObject, SelectionMixin):
         -----
         See the `xarray docs <http://xarray.pydata.org/en/stable/>`__
         """
-        import xarray
+
+        try:
+            import xarray
+        except ImportError:
+            # Give a nice error message
+            raise ImportError("the xarray library is not installed\n"
+                              "you can install via conda\n"
+                              "conda install xarray\n"
+                              "or via pip\n"
+                              "pip install xarray\n")
+
         if self.ndim == 1:
             return xarray.DataArray.from_series(self)
         elif self.ndim == 2:


### PR DESCRIPTION
Title is self-explanatory.  Shouldn't `xarray` get the same nice error message as `feather-format`?