### PR TITLE
BUG: Fix Categorical comparsion with Series of dtype 'category'

### DIFF
--- a/doc/source/whatsnew/v0.21.0.txt
+++ b/doc/source/whatsnew/v0.21.0.txt
@@ -1168,6 +1168,7 @@ PyPy
 - Fix :func:`DataFrame.memory_usage` to support PyPy. Objects on PyPy do not have a fixed size,
   so an approximation is used instead (:issue:`17228`)
 
+
 Other
 ^^^^^
 - Bug where some inplace operators were not being wrapped and produced a copy when invoked (:issue:`12962`)

--- a/pandas/core/categorical.py
+++ b/pandas/core/categorical.py
@@ -2122,15 +2122,26 @@ class Categorical(PandasObject):
 
         Parameters
         ----------
-        other : Categorical
+        other : Categorical, Series
 
         Returns
         -------
         are_equal : boolean
         """
-
         try:
+<<<<<<< 965c1c89b6df471d88dc0e1188fb8cbc0d89f867
             return hash(self.dtype) == hash(other.dtype)
+=======
+            from pandas.core.series import Series
+
+            if isinstance(other, Series):
+                other_categorical = other.values
+            else:
+                other_categorical = other
+
+            return (self.categories.equals(other_categorical.categories) and
+                    self.ordered == other_categorical.ordered)
+>>>>>>> BUG: Fix Categorical comparsion with Series of dtype 'category'
         except (AttributeError, TypeError):
             return False
 

--- a/pandas/core/categorical.py
+++ b/pandas/core/categorical.py
@@ -2135,13 +2135,16 @@ class Categorical(PandasObject):
             from pandas.core.series import Series
 
             if isinstance(other, Series):
-                other_categorical = other.values
-            else:
-                other_categorical = other
+                other = Categorical(other)
 
+<<<<<<< a581a743fe6740011e4fb0a7031ee92ce57b480b
             return (self.categories.equals(other_categorical.categories) and
                     self.ordered == other_categorical.ordered)
 >>>>>>> BUG: Fix Categorical comparsion with Series of dtype 'category'
+=======
+            return (self.categories.equals(other.categories) and
+                    self.ordered == other.ordered)
+>>>>>>> simplify the fix, add issue reference number to corresponding test and tighten the wording in doc whatsnew
         except (AttributeError, TypeError):
             return False
 

--- a/pandas/tests/test_categorical.py
+++ b/pandas/tests/test_categorical.py
@@ -202,6 +202,7 @@ class TestCategorical(object):
             CategoricalIndex(c1, categories=list('cab'))))
         assert not c1.is_dtype_equal(CategoricalIndex(c1, ordered=True))
 
+        # GH 16659
         s1 = pd.Series(c1)
         assert c1.is_dtype_equal(s1)
         assert not c2.is_dtype_equal(s1)

--- a/pandas/tests/test_categorical.py
+++ b/pandas/tests/test_categorical.py
@@ -202,6 +202,11 @@ class TestCategorical(object):
             CategoricalIndex(c1, categories=list('cab'))))
         assert not c1.is_dtype_equal(CategoricalIndex(c1, ordered=True))
 
+        s1 = pd.Series(c1)
+        assert c1.is_dtype_equal(s1)
+        assert not c2.is_dtype_equal(s1)
+        assert not c3.is_dtype_equal(s1)
+
     def test_constructor(self):
 
         exp_arr = np.array(["a", "b", "c", "a", "b", "c"], dtype=np.object_)


### PR DESCRIPTION
This is a fix attempt for issue #16659.

 - [ ] closes #xxxx
 - [ ] tests added / passed
 - [ ] passes ``git diff upstream/master --name-only -- '*.py' | flake8 --diff``
 - [ ] whatsnew entry
