### PR TITLE
BUG: fix infer frequency for business daily

### DIFF
--- a/asv_bench/benchmarks/timeseries.py
+++ b/asv_bench/benchmarks/timeseries.py
@@ -55,6 +55,9 @@ class DatetimeIndex(object):
         self.rng7 = date_range(start='1/1/1700', freq='D', periods=100000)
         self.a = self.rng7[:50000].append(self.rng7[50002:])
 
+        self.rng8 = date_range(start='1/1/1700', freq='B', periods=100000)
+        self.b = self.rng8[:50000].append(self.rng8[50000:])
+
     def time_add_timedelta(self):
         (self.rng + dt.timedelta(minutes=2))
 
@@ -94,8 +97,11 @@ class DatetimeIndex(object):
     def time_timeseries_is_month_start(self):
         self.rng6.is_month_start
 
-    def time_infer_freq(self):
+    def time_infer_freq_daily(self):
         infer_freq(self.a)
+
+    def time_infer_freq_business(self):
+        infer_freq(self.b)
 
 
 class TimeDatetimeConverter(object):

--- a/asv_bench/benchmarks/timeseries.py
+++ b/asv_bench/benchmarks/timeseries.py
@@ -53,10 +53,11 @@ class DatetimeIndex(object):
         self.rng6 = date_range(start='1/1/1', periods=self.N, freq='B')
 
         self.rng7 = date_range(start='1/1/1700', freq='D', periods=100000)
-        self.a = self.rng7[:50000].append(self.rng7[50002:])
+        self.no_freq = self.rng7[:50000].append(self.rng7[50002:])
+        self.d_freq = self.rng7[:50000].append(self.rng7[50000:])
 
         self.rng8 = date_range(start='1/1/1700', freq='B', periods=100000)
-        self.b = self.rng8[:50000].append(self.rng8[50000:])
+        self.b_freq = self.rng8[:50000].append(self.rng8[50000:])
 
     def time_add_timedelta(self):
         (self.rng + dt.timedelta(minutes=2))
@@ -97,11 +98,14 @@ class DatetimeIndex(object):
     def time_timeseries_is_month_start(self):
         self.rng6.is_month_start
 
+    def time_infer_freq_none(self):
+        infer_freq(self.no_freq)
+
     def time_infer_freq_daily(self):
-        infer_freq(self.a)
+        infer_freq(self.d_freq)
 
     def time_infer_freq_business(self):
-        infer_freq(self.b)
+        infer_freq(self.b_freq)
 
 
 class TimeDatetimeConverter(object):

--- a/doc/source/whatsnew/v0.20.3.txt
+++ b/doc/source/whatsnew/v0.20.3.txt
@@ -66,7 +66,7 @@ Plotting
 Groupby/Resample/Rolling
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
-
+- Bug in ``infer_freq`` causing indices with 2-day gaps during the working week to be wrongly inferred as business daily (:issue:`16624`)
 
 Sparse
 ^^^^^^

--- a/doc/source/whatsnew/v0.20.3.txt
+++ b/doc/source/whatsnew/v0.20.3.txt
@@ -66,7 +66,6 @@ Plotting
 Groupby/Resample/Rolling
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
-- Bug in ``infer_freq`` causing indices with 2-day gaps during the working week to be wrongly inferred as business daily (:issue:`16624`)
 
 Sparse
 ^^^^^^

--- a/doc/source/whatsnew/v0.21.0.txt
+++ b/doc/source/whatsnew/v0.21.0.txt
@@ -113,7 +113,7 @@ Plotting
 Groupby/Resample/Rolling
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
-
+- Bug in ``infer_freq`` causing indices with 2-day gaps during the working week to be wrongly inferred as business daily (:issue:`16624`)
 
 Sparse
 ^^^^^^

--- a/pandas/tests/indexes/timedeltas/test_timedelta.py
+++ b/pandas/tests/indexes/timedeltas/test_timedelta.py
@@ -567,7 +567,7 @@ class TestSlicing(object):
 
     def test_timedelta(self):
         # this is valid too
-        index = date_range('1/1/2000', periods=50, freq='B')
+        index = date_range('1/1/2000', periods=50, freq='D')
         shifted = index + timedelta(1)
         back = shifted + timedelta(-1)
         assert tm.equalContents(index, back)

--- a/pandas/tests/indexes/timedeltas/test_timedelta.py
+++ b/pandas/tests/indexes/timedeltas/test_timedelta.py
@@ -579,7 +579,7 @@ class TestSlicing(object):
             assert back.freq == expected
         else:  # freq == 'B'
             assert index.freq == pd.tseries.offsets.BusinessDay(1)
-            assert shifted.freq == None
+            assert shifted.freq is None
             assert back.freq == pd.tseries.offsets.BusinessDay(1)
 
         result = index - timedelta(1)

--- a/pandas/tests/indexes/timedeltas/test_timedelta.py
+++ b/pandas/tests/indexes/timedeltas/test_timedelta.py
@@ -567,26 +567,34 @@ class TestSlicing(object):
 
     def test_timedelta(self):
         # this is valid too
-        index = date_range('1/1/2000', periods=50, freq='D')
-        shifted = index + timedelta(1)
-        back = shifted + timedelta(-1)
-        assert tm.equalContents(index, back)
-        assert shifted.freq == index.freq
-        assert shifted.freq == back.freq
+        for freq in ['D', 'B']:
+            index = date_range('1/1/2000', periods=50, freq=freq)
+            shifted = index + timedelta(1)
+            back = shifted + timedelta(-1)
+            assert tm.equalContents(index, back)
+            if freq == 'D':
+                expected = pd.tseries.offsets.Day(1)
+                assert index.freq == expected
+                assert shifted.freq == expected
+                assert back.freq == expected
+            else:  # freq == 'B'
+                assert index.freq == pd.tseries.offsets.BusinessDay(1)
+                assert shifted.freq == None
+                assert back.freq == pd.tseries.offsets.BusinessDay(1)
 
-        result = index - timedelta(1)
-        expected = index + timedelta(-1)
-        tm.assert_index_equal(result, expected)
+            result = index - timedelta(1)
+            expected = index + timedelta(-1)
+            tm.assert_index_equal(result, expected)
 
-        # GH4134, buggy with timedeltas
-        rng = date_range('2013', '2014')
-        s = Series(rng)
-        result1 = rng - pd.offsets.Hour(1)
-        result2 = DatetimeIndex(s - np.timedelta64(100000000))
-        result3 = rng - np.timedelta64(100000000)
-        result4 = DatetimeIndex(s - pd.offsets.Hour(1))
-        tm.assert_index_equal(result1, result4)
-        tm.assert_index_equal(result2, result3)
+            # GH4134, buggy with timedeltas
+            rng = date_range('2013', '2014')
+            s = Series(rng)
+            result1 = rng - pd.offsets.Hour(1)
+            result2 = DatetimeIndex(s - np.timedelta64(100000000))
+            result3 = rng - np.timedelta64(100000000)
+            result4 = DatetimeIndex(s - pd.offsets.Hour(1))
+            tm.assert_index_equal(result1, result4)
+            tm.assert_index_equal(result2, result3)
 
 
 class TestTimeSeries(object):

--- a/pandas/tests/indexes/timedeltas/test_timedelta.py
+++ b/pandas/tests/indexes/timedeltas/test_timedelta.py
@@ -564,37 +564,37 @@ class TestTimedeltaIndex(DatetimeLike):
 
 
 class TestSlicing(object):
+    @pytest.mark.parametrize('freq', ['B', 'D'])
+    def test_timedelta(self, freq):
+        index = date_range('1/1/2000', periods=50, freq=freq)
 
-    def test_timedelta(self):
-        # this is valid too
-        for freq in ['D', 'B']:
-            index = date_range('1/1/2000', periods=50, freq=freq)
-            shifted = index + timedelta(1)
-            back = shifted + timedelta(-1)
-            assert tm.equalContents(index, back)
-            if freq == 'D':
-                expected = pd.tseries.offsets.Day(1)
-                assert index.freq == expected
-                assert shifted.freq == expected
-                assert back.freq == expected
-            else:  # freq == 'B'
-                assert index.freq == pd.tseries.offsets.BusinessDay(1)
-                assert shifted.freq == None
-                assert back.freq == pd.tseries.offsets.BusinessDay(1)
+        shifted = index + timedelta(1)
+        back = shifted + timedelta(-1)
+        tm.assert_index_equal(index, back)
 
-            result = index - timedelta(1)
-            expected = index + timedelta(-1)
-            tm.assert_index_equal(result, expected)
+        if freq == 'D':
+            expected = pd.tseries.offsets.Day(1)
+            assert index.freq == expected
+            assert shifted.freq == expected
+            assert back.freq == expected
+        else:  # freq == 'B'
+            assert index.freq == pd.tseries.offsets.BusinessDay(1)
+            assert shifted.freq == None
+            assert back.freq == pd.tseries.offsets.BusinessDay(1)
 
-            # GH4134, buggy with timedeltas
-            rng = date_range('2013', '2014')
-            s = Series(rng)
-            result1 = rng - pd.offsets.Hour(1)
-            result2 = DatetimeIndex(s - np.timedelta64(100000000))
-            result3 = rng - np.timedelta64(100000000)
-            result4 = DatetimeIndex(s - pd.offsets.Hour(1))
-            tm.assert_index_equal(result1, result4)
-            tm.assert_index_equal(result2, result3)
+        result = index - timedelta(1)
+        expected = index + timedelta(-1)
+        tm.assert_index_equal(result, expected)
+
+        # GH4134, buggy with timedeltas
+        rng = date_range('2013', '2014')
+        s = Series(rng)
+        result1 = rng - pd.offsets.Hour(1)
+        result2 = DatetimeIndex(s - np.timedelta64(100000000))
+        result3 = rng - np.timedelta64(100000000)
+        result4 = DatetimeIndex(s - pd.offsets.Hour(1))
+        tm.assert_index_equal(result1, result4)
+        tm.assert_index_equal(result2, result3)
 
 
 class TestTimeSeries(object):

--- a/pandas/tests/tseries/test_frequencies.py
+++ b/pandas/tests/tseries/test_frequencies.py
@@ -504,8 +504,13 @@ class TestFrequencyInference(object):
         pytest.raises(ValueError, frequencies.infer_freq, index)
 
     def test_business_daily(self):
-        index = _dti(['12/31/1998', '1/3/1999', '1/4/1999'])
+        index = _dti(['01/01/1999', '1/4/1999', '1/5/1999'])
         assert frequencies.infer_freq(index) == 'B'
+
+    def test_business_daily_look_alike(self):
+        # 'weekend' (2-day gap) in wrong place
+        index = _dti(['12/31/1998', '1/3/1999', '1/4/1999'])
+        assert frequencies.infer_freq(index) is None
 
     def test_day(self):
         self._check_tick(timedelta(1), 'D')

--- a/pandas/tests/tseries/test_frequencies.py
+++ b/pandas/tests/tseries/test_frequencies.py
@@ -508,7 +508,7 @@ class TestFrequencyInference(object):
         assert frequencies.infer_freq(index) == 'B'
 
     def test_business_daily_look_alike(self):
-        # 'weekend' (2-day gap) in wrong place
+        # GH 16624, do not infer 'B' when 'weekend' (2-day gap) in wrong place
         index = _dti(['12/31/1998', '1/3/1999', '1/4/1999'])
         assert frequencies.infer_freq(index) is None
 

--- a/pandas/tseries/frequencies.py
+++ b/pandas/tseries/frequencies.py
@@ -1012,11 +1012,13 @@ class _FrequencyInferer(object):
                 'ce': 'M', 'be': 'BM'}.get(pos_check)
 
     def _is_business_daily(self):
-        if self.day_deltas != [1, 3]:  # quick check: cannot be business daily
+        # quick check: cannot be business daily
+        if self.day_deltas != [1, 3]:
             return False
+
         # probably business daily, but need to confirm
         first_weekday = self.index[0].weekday()
-        shifts = np.diff(np.asarray(self.index).view('i8'))
+        shifts = np.diff(self.index.asi8)
         shifts = np.floor_divide(shifts, _ONE_DAY)
         weekdays = np.mod(first_weekday + np.cumsum(shifts), 7)
         return np.all(((weekdays == 0) & (shifts == 3)) |

--- a/pandas/tseries/frequencies.py
+++ b/pandas/tseries/frequencies.py
@@ -1011,8 +1011,6 @@ class _FrequencyInferer(object):
         return {'cs': 'MS', 'bs': 'BMS',
                 'ce': 'M', 'be': 'BM'}.get(pos_check)
 
-    WORKING_DAY_SHIFTS = set([(0, 1), (1, 2), (2, 3), (3, 4), (4, 0)])
-
     def _is_business_daily(self):
         if self.day_deltas != [1, 3]:  # quick check: cannot be business daily
             return False


### PR DESCRIPTION
Closes #16624 

Had to update a couple of tests, test_timedelta and test_business_daily, which appear to rely on the old incorrect behaviour. Added a new regression test, test_business_daily_look_alike, for the bug.

Modest performance impact: for 50,000-long business daily index, infer_freq goes from 2.54 ms to 3.91 ms. There should be no performance impact in most cases for non-business daily index, as the initial day_deltas check will throw out most of these cases.