### PR TITLE
Revert "BLD: fix numpy on 2.7 build as 1.13 was released but no deps are built for it

### DIFF
--- a/ci/requirements-2.7.build
+++ b/ci/requirements-2.7.build
@@ -2,5 +2,5 @@ python=2.7*
 python-dateutil=2.4.1
 pytz=2013b
 nomkl
-numpy=1.12*
+numpy
 cython=0.23


### PR DESCRIPTION
xref #16650
xref #16634 

This reverts commit 789f7bbb52f279bd1ed53abf1a9580f682c2d6b9.
