### PR TITLE
Update link in the deprecation message for .ix

### DIFF
--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -1288,7 +1288,7 @@ class _IXIndexer(_NDFrameIndexer):
 .iloc for positional indexing
 
 See the documentation here:
-http://pandas.pydata.org/pandas-docs/stable/indexing.html#deprecate_ix"""
+http://pandas.pydata.org/pandas-docs/stable/indexing.html#ix-indexer-is-deprecated"""
 
         warnings.warn(_ix_deprecation_warning,
                       DeprecationWarning, stacklevel=3)


### PR DESCRIPTION
The anchor on the indexing.html page has changed, this updates the link in the warning message

