### PR TITLE
BUG: Fix regression for RGB(A) color arguments

### DIFF
--- a/doc/source/whatsnew/v0.20.3.txt
+++ b/doc/source/whatsnew/v0.20.3.txt
@@ -59,7 +59,7 @@ I/O
 
 Plotting
 ^^^^^^^^
-
+- Allow series plots to accept RGB and RGBA tuples as color arguments (:issue:`16233`)
 
 
 

--- a/doc/source/whatsnew/v0.20.3.txt
+++ b/doc/source/whatsnew/v0.20.3.txt
@@ -59,7 +59,7 @@ I/O
 
 Plotting
 ^^^^^^^^
-- Allow series plots to accept RGB and RGBA tuples as color arguments (:issue:`16233`)
+- Fix regression in series plotting that prevented RGB and RGBA tuples from being used as color arguments (:issue:`16233`)
 
 
 

--- a/pandas/plotting/_core.py
+++ b/pandas/plotting/_core.py
@@ -187,6 +187,11 @@ class MPLPlot(object):
             # support series.plot(color='green')
             self.kwds['color'] = [self.kwds['color']]
 
+        if ('color' in self.kwds and isinstance(self.kwds['color'], tuple) and
+                self.nseries == 1 and len(self.kwds['color']) in (3, 4)):
+            # support RGB and RGBA tuples in series plot
+            self.kwds['color'] = [self.kwds['color']]
+
         if ('color' in self.kwds or 'colors' in self.kwds) and \
                 self.colormap is not None:
             warnings.warn("'color' and 'colormap' cannot be used "

--- a/pandas/tests/plotting/test_frame.py
+++ b/pandas/tests/plotting/test_frame.py
@@ -162,6 +162,7 @@ class TestDataFramePlots(TestPlotBase):
         # GH 16695
         df = DataFrame({'x': [1, 2], 'y': [3, 4]})
         _check_plot_works(df.plot, x='x', y='y', color=(1, 0, 0))
+        _check_plot_works(df.plot, x='x', y='y', color=(1, 0, 0, 0.5))
 
     def test_color_empty_string(self):
         df = DataFrame(randn(10, 2))

--- a/pandas/tests/plotting/test_frame.py
+++ b/pandas/tests/plotting/test_frame.py
@@ -158,6 +158,11 @@ class TestDataFramePlots(TestPlotBase):
         df = DataFrame({"A": [1, 2, 3]})
         _check_plot_works(df.plot, color=['red'])
 
+    def test_rgb_tuple_color(self):
+        # GH 16695
+        df = DataFrame({'x': [1, 2], 'y': [3, 4]})
+        _check_plot_works(df.plot, x='x', y='y', color=(1, 0, 0))
+
     def test_color_empty_string(self):
         df = DataFrame(randn(10, 2))
         with pytest.raises(ValueError):


### PR DESCRIPTION
 - [ ] closes #16695
 - [x] test added / passed
 - [x] passes ``git diff upstream/master --name-only -- '*.py' | flake8 --diff``
 - [x] whatsnew entry

Fixes a regression in the plot API in which RGB and RGBA tuples in the `color` kwarg caused an error when passed to matplotlib.  The root cause of this error is the fact that anything list-like passed with the `color` kwarg is treated as a set of colors to be mapped to the series being plotted.

This PR specifically fixes issues where a series is being plotted using an RGB(A) tuple to specify color.

This fixes only the regression between previous versions and 0.20.2.  There are still API inconsistencies with color specification using RGB(A) tuples versus other methods, e.g.  
```python
df = pandas.DataFrame({'a': [1, 2], 'b': [3, 4]})
df.plot(color=(1, 0, 0))  # will still fail since there are 2 columns to plot
df.plot(color='r')  # works
```

