### PR TITLE
BUG: fix to_latex bold_rows option

### DIFF
--- a/doc/source/whatsnew/v0.20.3.txt
+++ b/doc/source/whatsnew/v0.20.3.txt
@@ -41,7 +41,6 @@ Bug Fixes
 - Fixed compat with loading a ``DataFrame`` with a ``PeriodIndex``, from a ``format='fixed'`` HDFStore, in Python 3, that was written in Python 2 (:issue:`16781`)
 
 
-
 Conversion
 ^^^^^^^^^^
 
@@ -59,6 +58,7 @@ I/O
 
 - Bug in :func:`read_csv` in which files weren't opened as binary files by the C engine on Windows, causing EOF characters mid-field, which would fail (:issue:`16039`, :issue:`16559`, :issue:`16675`)
 - Bug in :func:`read_hdf` in which reading a ``Series`` saved to an HDF file in 'fixed' format fails when an explicit ``mode='r'`` argument is supplied (:issue:`16583`)
+- Bug in :func:`DataFrame.to_latex` where ``bold_rows`` was wrongly specified to be ``True`` by default, whereas in reality row labels remained non-bold whatever parameter provided. (:issue:`16707`)
 
 Plotting
 ^^^^^^^^

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -1538,7 +1538,7 @@ class NDFrame(PandasObject, SelectionMixin):
 
         `to_latex`-specific options:
 
-        bold_rows : boolean, default True
+        bold_rows : boolean, default False
             Make the row labels bold in the output
         column_format : str, default None
             The columns format as specified in `LaTeX table format
@@ -1587,7 +1587,7 @@ it is assumed to be aliases for the column names.')
     @Appender(_shared_docs['to_latex'] % _shared_doc_kwargs)
     def to_latex(self, buf=None, columns=None, col_space=None, header=True,
                  index=True, na_rep='NaN', formatters=None, float_format=None,
-                 sparsify=None, index_names=True, bold_rows=True,
+                 sparsify=None, index_names=True, bold_rows=False,
                  column_format=None, longtable=None, escape=None,
                  encoding=None, decimal='.', multicolumn=None,
                  multicolumn_format=None, multirow=None):

--- a/pandas/io/formats/format.py
+++ b/pandas/io/formats/format.py
@@ -845,6 +845,7 @@ class LatexFormatter(TableFormatter):
                  multicolumn=False, multicolumn_format=None, multirow=False):
         self.fmt = formatter
         self.frame = self.fmt.frame
+        self.bold_rows = self.fmt.kwds.get('bold_rows', False)
         self.column_format = column_format
         self.longtable = longtable
         self.multicolumn = multicolumn
@@ -943,6 +944,11 @@ class LatexFormatter(TableFormatter):
                          if x else '{}') for x in row]
             else:
                 crow = [x if x else '{}' for x in row]
+            if self.bold_rows and self.fmt.index:
+                # bold row labels
+                crow = ['\\textbf{%s}' % x
+                        if j < ilevels and x.strip() not in ['', '{}'] else x
+                        for j, x in enumerate(crow)]
             if i < clevels and self.fmt.header and self.multicolumn:
                 # sum up columns to multicolumns
                 crow = self._format_multicolumn(crow, ilevels)

--- a/pandas/tests/io/formats/test_to_latex.py
+++ b/pandas/tests/io/formats/test_to_latex.py
@@ -506,3 +506,33 @@ AA &  BB \\
 \end{tabular}
 """
         assert withindex_result == withindex_expected
+
+    def test_to_latex_bold_rows(self):
+        # GH 16707
+        df = pd.DataFrame({'a': [1, 2], 'b': ['b1', 'b2']})
+        observed = df.to_latex(bold_rows=True)
+        expected = r"""\begin{tabular}{lrl}
+\toprule
+{} &  a &   b \\
+\midrule
+\textbf{0} &  1 &  b1 \\
+\textbf{1} &  2 &  b2 \\
+\bottomrule
+\end{tabular}
+"""
+        assert observed == expected
+
+    def test_to_latex_no_bold_rows(self):
+        # GH 16707
+        df = pd.DataFrame({'a': [1, 2], 'b': ['b1', 'b2']})
+        observed = df.to_latex(bold_rows=False)
+        expected = r"""\begin{tabular}{lrl}
+\toprule
+{} &  a &   b \\
+\midrule
+0 &  1 &  b1 \\
+1 &  2 &  b2 \\
+\bottomrule
+\end{tabular}
+"""
+        assert observed == expected


### PR DESCRIPTION
 - [x] closes #16707
 - [x] tests added / passed
 - [ ] passes ``git diff upstream/master --name-only -- '*.py' | flake8 --diff``
 - [x] whatsnew entry
