### PR TITLE
BUG: fix pivot_table with multiple aggregations per column and margins=True #12210

### DIFF
--- a/pandas/core/reshape/pivot.py
+++ b/pandas/core/reshape/pivot.py
@@ -12,6 +12,7 @@ import pandas.core.common as com
 import numpy as np
 import types
 
+
 def pivot_table(data, values=None, index=None, columns=None, aggfunc='mean',
                 fill_value=None, margins=False, dropna=True,
                 margins_name='All'):
@@ -211,7 +212,7 @@ def _add_margins(table, data, values, rows, cols, aggfunc,
 
     # could be passed a Series object with no 'columns'
     if hasattr(table, 'columns'):
-        for i,level in enumerate(table.columns.names[1:]):
+        for i, level in enumerate(table.columns.names[1:]):
             if level is None:
                 level = i
             if margins_name in table.columns.get_level_values(level):
@@ -245,7 +246,6 @@ def _add_margins(table, data, values, rows, cols, aggfunc,
     row_margin = row_margin.reindex(result.columns)
     # populate grand margin
     for k in margin_keys:
-        #import pdb;pdb.set_trace()
         if isinstance(k, compat.string_types):
             row_margin[k] = grand_margin[k]
         elif is_scalar(grand_margin.get(k[0])):
@@ -275,11 +275,12 @@ def _compute_grand_margin(data, values, aggfunc,
         grand_margin = {}
         for k, v in data[values].iteritems():
             try:
-                #import pdb; pdb.set_trace()
-                if isinstance(aggfunc, (types.FunctionType,types.BuiltinFunctionType)):
+                if isinstance(aggfunc, (types.FunctionType,
+                                        types.BuiltinFunctionType)):
                     grand_margin[k] = aggfunc(v)
                 elif isinstance(aggfunc, dict):
-                    if isinstance(aggfunc[k], (types.FunctionType,types.BuiltinFunctionType)):
+                    if isinstance(aggfunc[k], (types.FunctionType,
+                                               types.BuiltinFunctionType)):
                         grand_margin[k] = aggfunc[k](v)
                     else:
                         grand_margin[k] = v.apply(aggfunc[k])

--- a/pandas/tests/reshape/test_pivot.py
+++ b/pandas/tests/reshape/test_pivot.py
@@ -374,31 +374,47 @@ class TestPivotTable(object):
         for value_col in table.columns.levels[0]:
             _check_output(table[value_col], value_col)
 
-        commonargs = dict(values=['D','E'], index=['A', 'B'], margins=True, )
-        expectedmean = self.data.pivot_table(columns='C', aggfunc=np.mean, **commonargs).fillna(99999)
-        expectedsum = self.data.pivot_table(columns='C', aggfunc=np.sum, **commonargs).fillna(99999)
+        commonargs = dict(values=['D', 'E'], index=['A', 'B'], margins=True, )
+        expectedmean = self.data.pivot_table(columns='C',
+                                             aggfunc=np.mean,
+                                             **commonargs).fillna(99999)
+        expectedsum = self.data.pivot_table(columns='C',
+                                            aggfunc=np.sum,
+                                            **commonargs).fillna(99999)
 
-        result = self.data.pivot_table(columns='C', aggfunc=[np.mean,np.sum], **commonargs ).fillna(99999)
+        result = self.data.pivot_table(columns='C',
+                                       aggfunc=[np.mean, np.sum],
+                                       **commonargs).fillna(99999)
         assert all(result['mean'] == expectedmean)
         assert all(result['sum'] == expectedsum)
 
-        result = self.data.pivot_table(aggfunc={'D':np.mean,'E':np.sum}, **commonargs )
-        assert all(result['E'] == expectedsum[('E','All')])
-        assert all(result['D'] == expectedmean[('D','All')])
+        result = self.data.pivot_table(aggfunc={'D': np.mean, 'E': np.sum},
+                                       **commonargs)
+        assert all(result['E'] == expectedsum[('E', 'All')])
+        assert all(result['D'] == expectedmean[('D', 'All')])
 
-        result = self.data.pivot_table(columns='C', aggfunc={'D':np.mean,'E':np.sum}, **commonargs )
+        result = self.data.pivot_table(columns='C',
+                                       aggfunc={'D': np.mean, 'E': np.sum},
+                                       **commonargs)
         assert all(result['E'] == expectedsum['E'])
         assert all(result['D'] == expectedmean['D'])
 
-        result = self.data.pivot_table(aggfunc={'D':[np.mean,np.sum],'E':np.mean}, **commonargs )
-        assert ( expectedmean[[('D','All'),('E','All')]].values == result[ [('D','mean'),('E','mean')] ].values ).all()
+        result = self.data.pivot_table(aggfunc={'D': [np.mean, np.sum],
+                                                'E': np.mean},
+                                       **commonargs)
+        assert (expectedmean[[('D', 'All'), ('E', 'All')]].values ==
+                result[[('D', 'mean'), ('E', 'mean')]].values).all()
 
-        result2 = self.data.pivot_table(aggfunc={'D':[np.mean,np.sum],'E':np.mean}, **commonargs )
-        assert all( result == result2 )
+        result2 = self.data.pivot_table(aggfunc={'D': [np.mean, np.sum],
+                                                 'E': np.mean},
+                                        **commonargs)
+        assert all(result == result2)
 
         # this fails - can't mix columns + dict aggfunc with list of funcs
-        #result = self.data.pivot_table(columns='C', aggfunc={'D':[np.mean,np.sum],'E':[np.mean]}, **commonargs )
-
+        # result = self.data.pivot_table(columns='C',
+        #                                aggfunc={'D':[np.mean, np.sum],
+        #                                         'E':[np.mean]},
+        #                                **commonargs )
 
         # no col
 
@@ -420,7 +436,7 @@ class TestPivotTable(object):
         for item in ['DD', 'EE', 'FF']:
             totals = table.loc[('All', ''), item]
             assert totals == self.data[item].mean()
- 
+
         # issue number #8349: pivot_table with margins and dictionary aggfunc
         data = [
             {'JOB': 'Worker', 'NAME': 'Bob', 'YEAR': 2013,

--- a/pandas/tests/reshape/test_pivot.py
+++ b/pandas/tests/reshape/test_pivot.py
@@ -374,6 +374,32 @@ class TestPivotTable(object):
         for value_col in table.columns.levels[0]:
             _check_output(table[value_col], value_col)
 
+        commonargs = dict(values=['D','E'], index=['A', 'B'], margins=True, )
+        expectedmean = self.data.pivot_table(columns='C', aggfunc=np.mean, **commonargs).fillna(99999)
+        expectedsum = self.data.pivot_table(columns='C', aggfunc=np.sum, **commonargs).fillna(99999)
+
+        result = self.data.pivot_table(columns='C', aggfunc=[np.mean,np.sum], **commonargs ).fillna(99999)
+        assert all(result['mean'] == expectedmean)
+        assert all(result['sum'] == expectedsum)
+
+        result = self.data.pivot_table(aggfunc={'D':np.mean,'E':np.sum}, **commonargs )
+        assert all(result['E'] == expectedsum[('E','All')])
+        assert all(result['D'] == expectedmean[('D','All')])
+
+        result = self.data.pivot_table(columns='C', aggfunc={'D':np.mean,'E':np.sum}, **commonargs )
+        assert all(result['E'] == expectedsum['E'])
+        assert all(result['D'] == expectedmean['D'])
+
+        result = self.data.pivot_table(aggfunc={'D':[np.mean,np.sum],'E':np.mean}, **commonargs )
+        assert ( expectedmean[[('D','All'),('E','All')]].values == result[ [('D','mean'),('E','mean')] ].values ).all()
+
+        result2 = self.data.pivot_table(aggfunc={'D':[np.mean,np.sum],'E':np.mean}, **commonargs )
+        assert all( result == result2 )
+
+        # this fails - can't mix columns + dict aggfunc with list of funcs
+        #result = self.data.pivot_table(columns='C', aggfunc={'D':[np.mean,np.sum],'E':[np.mean]}, **commonargs )
+
+
         # no col
 
         # to help with a buglet
@@ -394,7 +420,7 @@ class TestPivotTable(object):
         for item in ['DD', 'EE', 'FF']:
             totals = table.loc[('All', ''), item]
             assert totals == self.data[item].mean()
-
+ 
         # issue number #8349: pivot_table with margins and dictionary aggfunc
         data = [
             {'JOB': 'Worker', 'NAME': 'Bob', 'YEAR': 2013,


### PR DESCRIPTION
Fix handling of list of functions per column:
    - in pivot_table (checking) column name conflict
    - in _compute_grand_margin

This case is still failing: if also specify columns='C', then there's another exception in
_generate_marginal_results.

 - [X] closes #12210
 - [X] tests added / passed
 - [ ] passes ``git diff upstream/master --name-only -- '*.py' | flake8 --diff``
 - [ ] whatsnew entry
