### PR TITLE
MAINT: Drop Categorical.order & sort

### DIFF
--- a/doc/source/whatsnew/v0.21.0.txt
+++ b/doc/source/whatsnew/v0.21.0.txt
@@ -75,6 +75,7 @@ Removal of prior version deprecations/changes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 - ``pd.read_excel()`` has dropped the ``has_index_names`` parameter (:issue:`10967`)
+- ``Categorical`` has dropped the ``.order()`` and ``.sort()`` methods in favor of ``.sort_values()`` (:issue:`12882`)
 
 
 .. _whatsnew_0210.performance:

--- a/pandas/core/categorical.py
+++ b/pandas/core/categorical.py
@@ -1447,37 +1447,6 @@ class Categorical(PandasObject):
             )
         return values
 
-    def order(self, inplace=False, ascending=True, na_position='last'):
-        """
-        DEPRECATED: use :meth:`Categorical.sort_values`. That function
-        is entirely equivalent to this one.
-
-        See Also
-        --------
-        Categorical.sort_values
-        """
-        warn("order is deprecated, use sort_values(...)", FutureWarning,
-             stacklevel=2)
-        return self.sort_values(inplace=inplace, ascending=ascending,
-                                na_position=na_position)
-
-    def sort(self, inplace=True, ascending=True, na_position='last', **kwargs):
-        """
-        DEPRECATED: use :meth:`Categorical.sort_values`. That function
-        is just like this one, except that a new Categorical is returned
-        by default, so make sure to pass in 'inplace=True' to get
-        inplace sorting.
-
-        See Also
-        --------
-        Categorical.sort_values
-        """
-        warn("sort is deprecated, use sort_values(...)", FutureWarning,
-             stacklevel=2)
-        nv.validate_sort(tuple(), kwargs)
-        return self.sort_values(inplace=inplace, ascending=ascending,
-                                na_position=na_position)
-
     def ravel(self, order='C'):
         """ Return a flattened (numpy) array.
 

--- a/pandas/tests/test_categorical.py
+++ b/pandas/tests/test_categorical.py
@@ -3067,12 +3067,6 @@ Categories (10, timedelta64[ns]): [0 days 01:00:00 < 1 days 01:00:00 < 2 days 01
         c = Categorical(["a", "b", "b", "a"], ordered=False)
         cat = Series(c.copy())
 
-        # 'order' was deprecated in gh-10726
-        # 'sort' was deprecated in gh-12882
-        for func in ('order', 'sort'):
-            with tm.assert_produces_warning(FutureWarning):
-                getattr(c, func)()
-
         # sort in the categories order
         expected = Series(
             Categorical(["a", "a", "b", "b"],


### PR DESCRIPTION
Deprecated back in 0.18.1

xref #12882.
