### PR TITLE
ENH: simple patch for read_json compression

### DIFF
--- a/doc/source/whatsnew/v0.21.0.txt
+++ b/doc/source/whatsnew/v0.21.0.txt
@@ -24,6 +24,7 @@ New features
   <https://www.python.org/dev/peps/pep-0519/>`_ on most readers and writers (:issue:`13823`)
 - Added ``__fspath__`` method to :class:`~pandas.HDFStore`, :class:`~pandas.ExcelFile`,
   and :class:`~pandas.ExcelWriter` to work properly with the file system path protocol (:issue:`13823`)
+- The ``read_json`` method now supports a ``compression`` keyword, which allows you to read compressed json directly. The behavior of this is identical to the ``read_csv`` keyword and defaults to ``infer``. (:issue:`15644`)
 
 .. _whatsnew_0210.enhancements.other:
 


### PR DESCRIPTION
Addresses GH15644

 - [x] closes #15644
 - [x] tests added / passed
 - [x] passes ``git diff upstream/master --name-only -- '*.py' | flake8 --diff``
 - [x] whatsnew entry

The latest comment on https://github.com/pandas-dev/pandas/issues/15644 from March suggest just adding compression to read_json. This does that.

Not sure what kind of tests should be added since its using pre-existing code. It works when I tested it manually, and test_fast.sh returned with:
>9880 passed, 1280 skipped, 6 xfailed in 145.52 seconds

This is my first contribution, and I'm a bit confused about the whatsnew entry. I'm not sure which version the changes should be recorded in.

In that vein,``git diff upstream/master --name-only -- '*.py' | flake8 --diff`` fails with:
>fatal: bad revision 'upstream/master'