### PR TITLE
FIX: Allow aggregate to return dictionaries again #16741

### DIFF
--- a/doc/source/whatsnew/v0.21.0.txt
+++ b/doc/source/whatsnew/v0.21.0.txt
@@ -90,7 +90,7 @@ Performance Improvements
 Bug Fixes
 ~~~~~~~~~
 
-- Fixes regression in 0.20, `aggregate` allows dictionaries as return values again (:issue:`16741`)
+- Fixes regression in 0.20, :func:`Series.aggregate` and :func:`DataFrame.aggregate` allow dictionaries as return values again (:issue:`16741`)
 
 Conversion
 ^^^^^^^^^^

--- a/doc/source/whatsnew/v0.21.0.txt
+++ b/doc/source/whatsnew/v0.21.0.txt
@@ -90,6 +90,8 @@ Performance Improvements
 Bug Fixes
 ~~~~~~~~~
 
+- Fixes regression in 0.20, `aggregate` allows dictionaries as return values again (:issue:`16741`)
+
 Conversion
 ^^^^^^^^^^
 

--- a/pandas/_libs/src/reduce.pyx
+++ b/pandas/_libs/src/reduce.pyx
@@ -395,7 +395,6 @@ cdef class SeriesGrouper:
                         result = _get_result_array(res,
                                                    self.ngroups,
                                                    len(self.dummy_arr))
-
                     util.assign_value_1d(result, lab, res)
                     counts[lab] = group_size
                     islider.advance(group_size)
@@ -419,7 +418,7 @@ cdef class SeriesGrouper:
 cdef inline _extract_result(object res):
     """ extract the result object, it might be a 0-dim ndarray
         or a len-1 0-dim, or a scalar """
-    if hasattr(res, 'values'):
+    if hasattr(res, 'values') and isinstance(res.values, np.ndarray):
         res = res.values
     if not np.isscalar(res):
         if isinstance(res, np.ndarray):

--- a/pandas/_libs/src/reduce.pyx
+++ b/pandas/_libs/src/reduce.pyx
@@ -395,6 +395,7 @@ cdef class SeriesGrouper:
                         result = _get_result_array(res,
                                                    self.ngroups,
                                                    len(self.dummy_arr))
+
                     util.assign_value_1d(result, lab, res)
                     counts[lab] = group_size
                     islider.advance(group_size)

--- a/pandas/tests/groupby/test_aggregate.py
+++ b/pandas/tests/groupby/test_aggregate.py
@@ -612,9 +612,14 @@ class TestGroupByAggregate(object):
         df.groupby(level=0, axis='columns').mean()
 
     def test_cython_agg_return_dict(self):
+        # GH 16741
         ts = self.df.groupby('A')['B'].agg(
             lambda x: x.value_counts().to_dict())
-        assert isinstance(ts.loc['foo'], dict)
+        expected = Series([{'two': 1, 'one': 1, 'three': 1},
+                           {'two': 2, 'one': 2, 'three': 1}],
+                          index=Index(['bar', 'foo'], name='A'),
+                          name='B')
+        assert_series_equal(ts, expected)
 
     def test_cython_fail_agg(self):
         dr = bdate_range('1/1/2000', periods=50)

--- a/pandas/tests/groupby/test_aggregate.py
+++ b/pandas/tests/groupby/test_aggregate.py
@@ -882,3 +882,7 @@ class TestGroupByAggregate(object):
         expected.index.name = 0
         result = df.groupby(0).sum()
         tm.assert_frame_equal(result, expected)
+
+    def test_agg_ret_dict(self):
+        ts = self.df.groupby('A')['B'].agg(lambda x: x.value_counts().to_dict())
+        assert isinstance(ts.loc['foo'], dict)

--- a/pandas/tests/groupby/test_aggregate.py
+++ b/pandas/tests/groupby/test_aggregate.py
@@ -612,9 +612,9 @@ class TestGroupByAggregate(object):
         df.groupby(level=0, axis='columns').mean()
 
     def test_cython_agg_return_dict(self):
-        ts = self.df.groupby('A')['B'].agg(lambda x: x.value_counts().to_dict())
+        ts = self.df.groupby('A')['B'].agg(
+            lambda x: x.value_counts().to_dict())
         assert isinstance(ts.loc['foo'], dict)
-
 
     def test_cython_fail_agg(self):
         dr = bdate_range('1/1/2000', periods=50)

--- a/pandas/tests/groupby/test_aggregate.py
+++ b/pandas/tests/groupby/test_aggregate.py
@@ -611,6 +611,11 @@ class TestGroupByAggregate(object):
         df.groupby(level=0, axis='columns').mean()
         df.groupby(level=0, axis='columns').mean()
 
+    def test_cython_agg_return_dict(self):
+        ts = self.df.groupby('A')['B'].agg(lambda x: x.value_counts().to_dict())
+        assert isinstance(ts.loc['foo'], dict)
+
+
     def test_cython_fail_agg(self):
         dr = bdate_range('1/1/2000', periods=50)
         ts = Series(['A', 'B', 'C', 'D', 'E'] * 10, index=dr)
@@ -882,7 +887,3 @@ class TestGroupByAggregate(object):
         expected.index.name = 0
         result = df.groupby(0).sum()
         tm.assert_frame_equal(result, expected)
-
-    def test_agg_ret_dict(self):
-        ts = self.df.groupby('A')['B'].agg(lambda x: x.value_counts().to_dict())
-        assert isinstance(ts.loc['foo'], dict)


### PR DESCRIPTION
Fixes a regression from 0.19 to 0.20. The function passed to `aggregate` is allowed again to return dictionaries.
 
- [X] closes #16741
- [X] tests added / passed, added `test_cython_agg_return_dict`
- [X] passes ``git diff upstream/master --name-only -- '*.py' | flake8 --diff``
- [X] whatsnew entry
