### PR TITLE
MAINT: Drop Index.sym_diff

### DIFF
--- a/doc/source/whatsnew/v0.21.0.txt
+++ b/doc/source/whatsnew/v0.21.0.txt
@@ -75,6 +75,7 @@ Removal of prior version deprecations/changes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 - :func:`read_excel()` has dropped the ``has_index_names`` parameter (:issue:`10967`)
+- ``Index`` has dropped the ``.sym_diff()`` method in favor of ``.symmetric_difference()`` (:issue:`12591`)
 - ``Categorical`` has dropped the ``.order()`` and ``.sort()`` methods in favor of ``.sort_values()`` (:issue:`12882`)
 
 

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -41,8 +41,8 @@ from pandas.core.common import (is_bool_indexer,
 
 from pandas.core.base import PandasObject, IndexOpsMixin
 import pandas.core.base as base
-from pandas.util._decorators import (Appender, Substitution, cache_readonly,
-                                     deprecate, deprecate_kwarg)
+from pandas.util._decorators import (Appender, Substitution,
+                                     cache_readonly, deprecate_kwarg)
 from pandas.core.indexes.frozen import FrozenList
 import pandas.core.common as com
 import pandas.core.dtypes.concat as _concat
@@ -2375,8 +2375,6 @@ class Index(IndexOpsMixin, StringAccessorMixin, PandasObject):
         if 'freq' in attribs:
             attribs['freq'] = None
         return self._shallow_copy_with_infer(the_diff, **attribs)
-
-    sym_diff = deprecate('sym_diff', symmetric_difference)
 
     def _get_unique_index(self, dropna=False):
         """

--- a/pandas/tests/indexes/common.py
+++ b/pandas/tests/indexes/common.py
@@ -656,11 +656,7 @@ class Base(object):
             if isinstance(idx, MultiIndex):
                 msg = "other must be a MultiIndex or a list of tuples"
                 with tm.assert_raises_regex(TypeError, msg):
-                    result = first.symmetric_difference([1, 2, 3])
-
-        # 12591 deprecated
-        with tm.assert_produces_warning(FutureWarning):
-            first.sym_diff(second)
+                    first.symmetric_difference([1, 2, 3])
 
     def test_insert_base(self):
 


### PR DESCRIPTION
Deprecated in 0.18.1

xref #12591, #12594

(a nice deprecation removal unlike `pd.eval` :smile:)
