### PR TITLE
MAINT: Drop pd.options.display.mpl_style

### DIFF
--- a/doc/source/whatsnew/v0.21.0.txt
+++ b/doc/source/whatsnew/v0.21.0.txt
@@ -75,6 +75,7 @@ Removal of prior version deprecations/changes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 - :func:`read_excel()` has dropped the ``has_index_names`` parameter (:issue:`10967`)
+- The ``pd.options.display.mpl_style`` configuration has been dropped (:issue:`12190`)
 - ``Categorical`` has dropped the ``.order()`` and ``.sort()`` methods in favor of ``.sort_values()`` (:issue:`12882`)
 
 

--- a/pandas/core/config_init.py
+++ b/pandas/core/config_init.py
@@ -9,8 +9,6 @@ If you need to make sure options are available even before a certain
 module is imported, register them here rather then in the module.
 
 """
-import warnings
-
 import pandas.core.config as cf
 from pandas.core.config import (is_int, is_bool, is_text, is_instance_factory,
                                 is_one_of_factory, get_default_val,
@@ -313,33 +311,6 @@ pc_latex_multirow = """
 style_backup = dict()
 
 
-def mpl_style_cb(key):
-    warnings.warn(pc_mpl_style_deprecation_warning, FutureWarning,
-                  stacklevel=5)
-
-    import sys
-    from pandas.plotting._style import mpl_stylesheet
-    global style_backup
-
-    val = cf.get_option(key)
-
-    if 'matplotlib' not in sys.modules.keys():
-        if not val:  # starting up, we get reset to None
-            return val
-        raise Exception("matplotlib has not been imported. aborting")
-
-    import matplotlib.pyplot as plt
-
-    if val == 'default':
-        style_backup = dict([(k, plt.rcParams[k]) for k in mpl_stylesheet])
-        plt.rcParams.update(mpl_stylesheet)
-    elif not val:
-        if style_backup:
-            plt.rcParams.update(style_backup)
-
-    return val
-
-
 def table_schema_cb(key):
     from pandas.io.formats.printing import _enable_data_resource_formatter
     _enable_data_resource_formatter(cf.get_option(key))
@@ -382,9 +353,6 @@ with cf.config_prefix('display'):
                        validator=is_one_of_factory([True, False, 'truncate']))
     cf.register_option('chop_threshold', None, pc_chop_threshold_doc)
     cf.register_option('max_seq_items', 100, pc_max_seq_items)
-    cf.register_option('mpl_style', None, pc_mpl_style_doc,
-                       validator=is_one_of_factory([None, False, 'default']),
-                       cb=mpl_style_cb)
     cf.register_option('height', 60, pc_height_doc,
                        validator=is_instance_factory([type(None), int]))
     cf.register_option('width', 80, pc_width_doc,

--- a/pandas/tests/plotting/test_frame.py
+++ b/pandas/tests/plotting/test_frame.py
@@ -17,8 +17,6 @@ from pandas.io.formats.printing import pprint_thing
 import pandas.util.testing as tm
 from pandas.util.testing import slow
 
-from pandas.core.config import set_option
-
 import numpy as np
 from numpy.random import rand, randn
 
@@ -2681,20 +2679,6 @@ class TestDataFramePlots(TestPlotBase):
         self._check_grid_settings(
             DataFrame({'a': [1, 2, 3], 'b': [2, 3, 4]}),
             plotting._core._dataframe_kinds, kws={'x': 'a', 'y': 'b'})
-
-    def test_option_mpl_style(self):
-        with tm.assert_produces_warning(FutureWarning,
-                                        check_stacklevel=False):
-            set_option('display.mpl_style', 'default')
-        with tm.assert_produces_warning(FutureWarning,
-                                        check_stacklevel=False):
-            set_option('display.mpl_style', None)
-        with tm.assert_produces_warning(FutureWarning,
-                                        check_stacklevel=False):
-            set_option('display.mpl_style', False)
-
-        with pytest.raises(ValueError):
-            set_option('display.mpl_style', 'default2')
 
     def test_invalid_colormap(self):
         df = DataFrame(randn(3, 2), columns=['A', 'B'])


### PR DESCRIPTION
Deprecated in 0.18.0

xref #12190

(another nice short deprecation! 😄 )
