### PR TITLE
BUG: allow empty multiindex (fixes .isin regression, GH16777)

### DIFF
--- a/doc/source/whatsnew/v0.20.3.txt
+++ b/doc/source/whatsnew/v0.20.3.txt
@@ -55,6 +55,7 @@ Indexing
 ^^^^^^^^
 
 - Bug in ``Float64Index`` causing an empty array instead of ``None`` to be returned from ``.get(np.nan)`` on a Series whose index did not contain any ``NaN`` s (:issue:`8569`)
+- Bug in ``MultiIndex`` causing an error when passing an empty iterable to `.isin`. (:issue:`16777`)
 
 I/O
 ^^^

--- a/doc/source/whatsnew/v0.20.3.txt
+++ b/doc/source/whatsnew/v0.20.3.txt
@@ -55,7 +55,7 @@ Indexing
 ^^^^^^^^
 
 - Bug in ``Float64Index`` causing an empty array instead of ``None`` to be returned from ``.get(np.nan)`` on a Series whose index did not contain any ``NaN`` s (:issue:`8569`)
-- Bug in ``MultiIndex`` causing an error when passing an empty iterable to `.isin`. (:issue:`16777`)
+- Bug in ``MultiIndex.isin`` causing an error when passing an empty iterable (:issue:`16777`)
 
 I/O
 ^^^

--- a/pandas/core/indexes/multi.py
+++ b/pandas/core/indexes/multi.py
@@ -2624,7 +2624,7 @@ class MultiIndex(Index):
     def isin(self, values, level=None):
         if level is None:
             values = MultiIndex.from_tuples(values,
-                                            names=self._names).values
+                                            names=self.names).values
             return algos.isin(self.values, values)
         else:
             num = self._get_level_number(level)

--- a/pandas/core/indexes/multi.py
+++ b/pandas/core/indexes/multi.py
@@ -1083,7 +1083,9 @@ class MultiIndex(Index):
         MultiIndex.from_product : Make a MultiIndex from cartesian product
                                   of iterables
         """
-        if len(arrays) == 1:
+        if len(arrays) == 0:
+            raise ValueError('Must pass non-zero number of levels/labels')
+        elif len(arrays) == 1:
             name = None if names is None else names[0]
             return Index(arrays[0], name=name)
 
@@ -1131,10 +1133,12 @@ class MultiIndex(Index):
         MultiIndex.from_product : Make a MultiIndex from cartesian product
                                   of iterables
         """
-        if len(tuples) == 0 and names is None:
-            raise TypeError('Cannot infer number of levels from empty list')
-
-        if isinstance(tuples, (np.ndarray, Index)):
+        if len(tuples) == 0:
+            if names is None:
+                msg = 'Cannot infer number of levels from empty list'
+                raise TypeError(msg)
+            arrays = [[]]*len(names)
+        elif isinstance(tuples, (np.ndarray, Index)):
             if isinstance(tuples, Index):
                 tuples = tuples._values
 

--- a/pandas/core/indexes/multi.py
+++ b/pandas/core/indexes/multi.py
@@ -1080,9 +1080,7 @@ class MultiIndex(Index):
         MultiIndex.from_product : Make a MultiIndex from cartesian product
                                   of iterables
         """
-        if len(arrays) == 0:
-            raise ValueError('Must pass non-zero number of levels/labels')
-        elif len(arrays) == 1:
+        if len(arrays) == 1:
             name = None if names is None else names[0]
             return Index(arrays[0], name=name)
 

--- a/pandas/core/indexes/multi.py
+++ b/pandas/core/indexes/multi.py
@@ -89,9 +89,6 @@ class MultiIndex(Index):
             raise TypeError("Must pass both levels and labels")
         if len(levels) != len(labels):
             raise ValueError('Length of levels and labels must be the same.')
-        if names is not None and len(names) > 0 and len(levels) == 0:
-            levels = [[] for _ in names]
-            labels = [[] for _ in names]
         if len(levels) == 0:
             raise ValueError('Must pass non-zero number of levels/labels')
         if len(levels) == 1:

--- a/pandas/core/indexes/multi.py
+++ b/pandas/core/indexes/multi.py
@@ -2624,7 +2624,7 @@ class MultiIndex(Index):
     def isin(self, values, level=None):
         if level is None:
             values = MultiIndex.from_tuples(values,
-                                            names=self._levels).values
+                                            names=self._names).values
             return algos.isin(self.values, values)
         else:
             num = self._get_level_number(level)

--- a/pandas/core/indexes/multi.py
+++ b/pandas/core/indexes/multi.py
@@ -89,6 +89,9 @@ class MultiIndex(Index):
             raise TypeError("Must pass both levels and labels")
         if len(levels) != len(labels):
             raise ValueError('Length of levels and labels must be the same.')
+        if names is not None and len(names) > 0 and len(levels) == 0:
+            levels = [[] for _ in names]
+            labels = [[] for _ in names]
         if len(levels) == 0:
             raise ValueError('Must pass non-zero number of levels/labels')
         if len(levels) == 1:
@@ -1128,8 +1131,7 @@ class MultiIndex(Index):
         MultiIndex.from_product : Make a MultiIndex from cartesian product
                                   of iterables
         """
-        if len(tuples) == 0:
-            # I think this is right? Not quite sure...
+        if len(tuples) == 0 and names is None:
             raise TypeError('Cannot infer number of levels from empty list')
 
         if isinstance(tuples, (np.ndarray, Index)):
@@ -2621,8 +2623,9 @@ class MultiIndex(Index):
     @Appender(Index.isin.__doc__)
     def isin(self, values, level=None):
         if level is None:
-            return algos.isin(self.values,
-                              MultiIndex.from_tuples(values).values)
+            values = MultiIndex.from_tuples(values,
+                                            names=self._levels).values
+            return algos.isin(self.values, values)
         else:
             num = self._get_level_number(level)
             levs = self.levels[num]

--- a/pandas/core/indexes/multi.py
+++ b/pandas/core/indexes/multi.py
@@ -1132,7 +1132,7 @@ class MultiIndex(Index):
             if names is None:
                 msg = 'Cannot infer number of levels from empty list'
                 raise TypeError(msg)
-            arrays = [[]]*len(names)
+            arrays = [[]] * len(names)
         elif isinstance(tuples, (np.ndarray, Index)):
             if isinstance(tuples, Index):
                 tuples = tuples._values

--- a/pandas/tests/indexes/test_multi.py
+++ b/pandas/tests/indexes/test_multi.py
@@ -1717,13 +1717,14 @@ class TestMultiIndex(Base):
                                'from empty list',
                                MultiIndex.from_tuples, [])
 
+        idx = MultiIndex.from_tuples(((1, 2), (3, 4)), names=['a', 'b'])
+        assert len(idx) == 2
+
+    def test_from_tuples_empty(self):
         result = MultiIndex.from_tuples([], names=['a', 'b'])
         expected = MultiIndex.from_arrays(arrays=[[], []],
                                           names=['a', 'b'])
         tm.assert_index_equal(result, expected)
-
-        idx = MultiIndex.from_tuples(((1, 2), (3, 4)), names=['a', 'b'])
-        assert len(idx) == 2
 
     def test_argsort(self):
         result = self.index.argsort()

--- a/pandas/tests/indexes/test_multi.py
+++ b/pandas/tests/indexes/test_multi.py
@@ -1721,6 +1721,7 @@ class TestMultiIndex(Base):
         assert len(idx) == 2
 
     def test_from_tuples_empty(self):
+        # GH 16777
         result = MultiIndex.from_tuples([], names=['a', 'b'])
         expected = MultiIndex.from_arrays(arrays=[[], []],
                                           names=['a', 'b'])

--- a/pandas/tests/indexes/test_multi.py
+++ b/pandas/tests/indexes/test_multi.py
@@ -766,6 +766,14 @@ class TestMultiIndex(Base):
                 ValueError, "Must pass non-zero number of levels/labels"):
             MultiIndex.from_arrays(arrays=[])
 
+        # 0 levels, names defined
+        result = MultiIndex.from_arrays(arrays=[],
+                                        names=['A', 'B'])
+        expected = MultiIndex(levels=[[], []],
+                              labels=[[], []],
+                              names=['A', 'B'])
+        tm.assert_index_equal(result, expected)
+
         # 1 level
         result = MultiIndex.from_arrays(arrays=[[]], names=['A'])
         expected = Index([], name='A')
@@ -1716,6 +1724,12 @@ class TestMultiIndex(Base):
         tm.assert_raises_regex(TypeError, 'Cannot infer number of levels '
                                'from empty list',
                                MultiIndex.from_tuples, [])
+
+        result = MultiIndex.from_tuples([], names=['a', 'b'])
+        expected = MultiIndex(levels=[[], []],
+                              labels=[[], []],
+                              names=['a', 'b'])
+        tm.assert_index_equal(result, expected)
 
         idx = MultiIndex.from_tuples(((1, 2), (3, 4)), names=['a', 'b'])
         assert len(idx) == 2

--- a/pandas/tests/indexes/test_multi.py
+++ b/pandas/tests/indexes/test_multi.py
@@ -766,14 +766,6 @@ class TestMultiIndex(Base):
                 ValueError, "Must pass non-zero number of levels/labels"):
             MultiIndex.from_arrays(arrays=[])
 
-        # 0 levels, names defined
-        result = MultiIndex.from_arrays(arrays=[],
-                                        names=['A', 'B'])
-        expected = MultiIndex(levels=[[], []],
-                              labels=[[], []],
-                              names=['A', 'B'])
-        tm.assert_index_equal(result, expected)
-
         # 1 level
         result = MultiIndex.from_arrays(arrays=[[]], names=['A'])
         expected = Index([], name='A')
@@ -1726,9 +1718,8 @@ class TestMultiIndex(Base):
                                MultiIndex.from_tuples, [])
 
         result = MultiIndex.from_tuples([], names=['a', 'b'])
-        expected = MultiIndex(levels=[[], []],
-                              labels=[[], []],
-                              names=['a', 'b'])
+        expected = MultiIndex.from_arrays(arrays=[[], []],
+                                          names=['a', 'b'])
         tm.assert_index_equal(result, expected)
 
         idx = MultiIndex.from_tuples(((1, 2), (3, 4)), names=['a', 'b'])


### PR DESCRIPTION
 - [X] closes issue #16777
 - [X] tests added / passed
 - [X] passes ``git diff upstream/master --name-only -- '*.py' | flake8 --diff``
 - [X] whatsnew entry
