### PR TITLE
DOC: Updated cookbook to show usage of Grouper instead of TimeGrouper…

### DIFF
--- a/doc/source/cookbook.rst
+++ b/doc/source/cookbook.rst
@@ -776,16 +776,16 @@ Resampling
 
 The :ref:`Resample <timeseries.resampling>` docs.
 
-`Using Grouper instead of TimeGrouper
+`Using Grouper instead of TimeGrouper for time grouping of values
 <https://stackoverflow.com/questions/15297053/how-can-i-divide-single-values-of-a-dataframe-by-monthly-averages>`__
 
-`Grouper#2
+`Time grouping with some missing values
 <https://stackoverflow.com/questions/33637312/pandas-grouper-by-frequency-with-completeness-requirement>`__
 
 `Valid frequency arguments to Grouper
 <http://pandas.pydata.org/pandas-docs/stable/timeseries.html#offset-aliases>`__
 
-`Grouping using multiindex
+`Grouping using a MultiIndex
 <https://stackoverflow.com/questions/41483763/pandas-timegrouper-on-multiindex>`__
 
 `Using TimeGrouper and another grouping to create subgroups, then apply a custom function

--- a/doc/source/cookbook.rst
+++ b/doc/source/cookbook.rst
@@ -776,8 +776,11 @@ Resampling
 
 The :ref:`Resample <timeseries.resampling>` docs.
 
-`Using Grouper to group values across time
-<https://pandas.pydata.org/pandas-docs/stable/generated/pandas.Grouper.html>`__
+`Using Grouper instead of TimeGrouper
+<https://stackoverflow.com/questions/15297053/how-can-i-divide-single-values-of-a-dataframe-by-monthly-averages>`__
+
+`Grouper#2
+<https://stackoverflow.com/questions/33637312/pandas-grouper-by-frequency-with-completeness-requirement>`__
 
 `Valid frequency arguments to Grouper
 <http://pandas.pydata.org/pandas-docs/stable/timeseries.html#offset-aliases>`__

--- a/doc/source/cookbook.rst
+++ b/doc/source/cookbook.rst
@@ -776,11 +776,14 @@ Resampling
 
 The :ref:`Resample <timeseries.resampling>` docs.
 
-`TimeGrouping of values grouped across time
-<http://stackoverflow.com/questions/15297053/how-can-i-divide-single-values-of-a-dataframe-by-monthly-averages>`__
+`Using Grouper to group values across time
+<https://pandas.pydata.org/pandas-docs/stable/generated/pandas.Grouper.html>`__
 
-`TimeGrouping #2
-<http://stackoverflow.com/questions/14569223/timegrouper-pandas>`__
+`Valid frequency arguments to Grouper
+<http://pandas.pydata.org/pandas-docs/stable/timeseries.html#offset-aliases>`__
+
+`Grouping using multiindex
+<https://stackoverflow.com/questions/41483763/pandas-timegrouper-on-multiindex>`__
 
 `Using TimeGrouper and another grouping to create subgroups, then apply a custom function
 <https://github.com/pandas-dev/pandas/issues/3791>`__


### PR DESCRIPTION
Added links to show usage of Grouper and removed SO links to TimeGrouper- #16747

 - [ ] closes #xxxx
 - [ ] tests added / passed
 - [ ] passes ``git diff upstream/master --name-only -- '*.py' | flake8 --diff``
 - [ ] whatsnew entry
