### PR TITLE
BUG: render dataframe as html do not produce duplicate element id's (#16780)

### DIFF
--- a/doc/source/whatsnew/v0.20.3.txt
+++ b/doc/source/whatsnew/v0.20.3.txt
@@ -37,9 +37,7 @@ Performance Improvements
 Bug Fixes
 ~~~~~~~~~
 - Fixed issue with dataframe scatter plot for categorical data that reports incorrect column key not found when categorical data is used for plotting (:issue:`16199`)
-
-
-
+- fix issue when rendering dataframe to html where element id's were not unique (:issue:`16780`)
 
 Conversion
 ^^^^^^^^^^

--- a/doc/source/whatsnew/v0.21.0.txt
+++ b/doc/source/whatsnew/v0.21.0.txt
@@ -92,6 +92,8 @@ Performance Improvements
 Bug Fixes
 ~~~~~~~~~
 
+- fix issue when rendering dataframe to html where element id's were not unique (:issue:`16780`)
+
 Conversion
 ^^^^^^^^^^
 

--- a/doc/source/whatsnew/v0.21.0.txt
+++ b/doc/source/whatsnew/v0.21.0.txt
@@ -92,8 +92,6 @@ Performance Improvements
 Bug Fixes
 ~~~~~~~~~
 
-- fix issue when rendering dataframe to html where element id's were not unique (:issue:`16780`)
-
 Conversion
 ^^^^^^^^^^
 

--- a/pandas/io/formats/style.py
+++ b/pandas/io/formats/style.py
@@ -281,13 +281,14 @@ class Styler(object):
         for r, idx in enumerate(self.data.index):
             row_es = []
             for c, value in enumerate(rlabels[r]):
+                rid = [ROW_HEADING_CLASS, "level%s" % c, "row%s" % r]
                 es = {
                     "type": "th",
                     "is_visible": _is_visible(r, c, idx_lengths),
                     "value": value,
                     "display_value": value,
-                    "class": " ".join([ROW_HEADING_CLASS, "level%s" % c,
-                                       "row%s" % r]),
+                    "id": "_".join(rid[1:]),
+                    "class": " ".join(rid)
                 }
                 rowspan = idx_lengths.get((c, r), 0)
                 if rowspan > 1:

--- a/pandas/tests/io/formats/test_style.py
+++ b/pandas/tests/io/formats/test_style.py
@@ -505,7 +505,7 @@ class TestStyler(object):
         result = styler.set_uuid('aaa')
         assert result is styler
         assert result.uuid == 'aaa'
-        
+
     def test_unique_id(self):
         # See https://github.com/pandas-dev/pandas/issues/16780
         df = pd.DataFrame({'a': [1, 3, 5, 6], 'b': [2, 4, 12, 21]})
@@ -513,7 +513,7 @@ class TestStyler(object):
         assert 'test' in result
         ids = re.findall('id="(.*?)"', result)
         assert np.unique(ids).size == len(ids)
-        
+
     def test_table_styles(self):
         style = [{'selector': 'th', 'props': [('foo', 'bar')]}]
         styler = Styler(self.df, table_styles=style)
@@ -728,7 +728,7 @@ class TestStyler(object):
         df = pd.DataFrame({'A': [1, 2]},
                           index=pd.MultiIndex.from_arrays([['a', 'a'],
                                                            [0, 1]]))
-        
+
         result = df.style._translate()
         body_0 = result['body'][0][0]
         expected_0 = {
@@ -741,14 +741,16 @@ class TestStyler(object):
         body_1 = result['body'][0][1]
         expected_1 = {
             "value": 0, "display_value": 0, "is_visible": True,
-            "type": "th", "class": "row_heading level1 row0", "id": "level1_row0"
+            "type": "th", "class": "row_heading level1 row0",
+            "id": "level1_row0"
         }
         tm.assert_dict_equal(body_1, expected_1)
 
         body_10 = result['body'][1][0]
         expected_10 = {
             "value": 'a', "display_value": 'a', "is_visible": False,
-            "type": "th", "class": "row_heading level0 row1", "id": "level0_row1"
+            "type": "th", "class": "row_heading level0 row1",
+            "id": "level0_row1"
         }
         tm.assert_dict_equal(body_10, expected_10)
 

--- a/pandas/tests/io/formats/test_style.py
+++ b/pandas/tests/io/formats/test_style.py
@@ -1,5 +1,6 @@
 import copy
 import textwrap
+import re
 
 import pytest
 import numpy as np
@@ -504,7 +505,15 @@ class TestStyler(object):
         result = styler.set_uuid('aaa')
         assert result is styler
         assert result.uuid == 'aaa'
-
+        
+    def test_unique_id(self):
+        # See https://github.com/pandas-dev/pandas/issues/16780
+        df = pd.DataFrame({'a': [1, 3, 5, 6], 'b': [2, 4, 12, 21]})
+        result = df.style.render(uuid='test')
+        assert 'test' in result
+        ids = re.findall('id="(.*?)"', result)
+        assert np.unique(ids).size == len(ids)
+        
     def test_table_styles(self):
         style = [{'selector': 'th', 'props': [('foo', 'bar')]}]
         styler = Styler(self.df, table_styles=style)
@@ -719,26 +728,27 @@ class TestStyler(object):
         df = pd.DataFrame({'A': [1, 2]},
                           index=pd.MultiIndex.from_arrays([['a', 'a'],
                                                            [0, 1]]))
+        
         result = df.style._translate()
         body_0 = result['body'][0][0]
         expected_0 = {
             "value": "a", "display_value": "a", "is_visible": True,
             "type": "th", "attributes": ["rowspan=2"],
-            "class": "row_heading level0 row0",
+            "class": "row_heading level0 row0", "id": "level0_row0"
         }
         tm.assert_dict_equal(body_0, expected_0)
 
         body_1 = result['body'][0][1]
         expected_1 = {
             "value": 0, "display_value": 0, "is_visible": True,
-            "type": "th", "class": "row_heading level1 row0",
+            "type": "th", "class": "row_heading level1 row0", "id": "level1_row0"
         }
         tm.assert_dict_equal(body_1, expected_1)
 
         body_10 = result['body'][1][0]
         expected_10 = {
             "value": 'a', "display_value": 'a', "is_visible": False,
-            "type": "th", "class": "row_heading level0 row1",
+            "type": "th", "class": "row_heading level0 row1", "id": "level0_row1"
         }
         tm.assert_dict_equal(body_10, expected_10)
 


### PR DESCRIPTION
closes #16780 
tests added / passed
passes ``git diff upstream/master --name-only -- '*.py' | flake8 --diff``
whatsnew entry
