### PR TITLE
TST: Verify columns entirely below chop_threshold still print (#6839)

### DIFF
--- a/pandas/tests/io/formats/test_format.py
+++ b/pandas/tests/io/formats/test_format.py
@@ -209,6 +209,33 @@ class TestDataFrameFormatting(object):
         with option_context("display.chop_threshold", None):
             assert repr(df) == '     0    1\n0  0.1  0.5\n1  0.5 -0.1'
 
+    def test_repr_chop_threshold_column_below(self):
+        # GH 6839: validation case
+
+        df = pd.DataFrame([[10, 20, 30, 40],
+                           [8e-10, -1e-11, 2e-9, -2e-11]]).T
+
+        with option_context("display.chop_threshold", 0):
+            assert repr(df) == ('      0             1\n'
+                                '0  10.0  8.000000e-10\n'
+                                '1  20.0 -1.000000e-11\n'
+                                '2  30.0  2.000000e-09\n'
+                                '3  40.0 -2.000000e-11')
+
+        with option_context("display.chop_threshold", 1e-8):
+            assert repr(df) == ('      0             1\n'
+                                '0  10.0  0.000000e+00\n'
+                                '1  20.0  0.000000e+00\n'
+                                '2  30.0  0.000000e+00\n'
+                                '3  40.0  0.000000e+00')
+
+        with option_context("display.chop_threshold", 5e-11):
+            assert repr(df) == ('      0             1\n'
+                                '0  10.0  8.000000e-10\n'
+                                '1  20.0  0.000000e+00\n'
+                                '2  30.0  2.000000e-09\n'
+                                '3  40.0  0.000000e+00')
+
     def test_repr_obeys_max_seq_limit(self):
         with option_context("display.max_seq_items", 2000):
             assert len(printing.pprint_thing(lrange(1000))) > 1000


### PR DESCRIPTION
Just adds a confirming test for closes #6839.  No need for whatsnew update.