### PR TITLE
TST: use network decorator on additional tests

### DIFF
--- a/pandas/tests/io/parser/test_network.py
+++ b/pandas/tests/io/parser/test_network.py
@@ -19,6 +19,7 @@ def salaries_table():
     return read_table(path)
 
 
+@pytest.mark.network
 @pytest.mark.parametrize(
     "compression,extension",
     [('gzip', '.gz'), ('bz2', '.bz2'), ('zip', '.zip'),

--- a/pandas/tests/test_downstream.py
+++ b/pandas/tests/test_downstream.py
@@ -52,6 +52,7 @@ def test_xarray(df):
     assert df.to_xarray() is not None
 
 
+@tm.network
 def test_statsmodels():
 
     statsmodels = import_module('statsmodels')  # noqa
@@ -84,6 +85,7 @@ def test_pandas_gbq(df):
     pandas_gbq = import_module('pandas_gbq')  # noqa
 
 
+@tm.network
 def test_pandas_datareader():
 
     pandas_datareader = import_module('pandas_datareader')  # noqa

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,3 +26,4 @@ testpaths = pandas
 markers =
     single: mark a test as single cpu only
     slow: mark a test as slow
+    network: mark a test as network


### PR DESCRIPTION
``--skip-network`` didn't actually skip the parser compressed url tests as ``tm.network`` is in an inner function (and its not easy to make work with parameterize). Also some additional network required tests.