### PR TITLE
BUG: rolling.cov with multi-index columns should preseve the MI

### DIFF
--- a/doc/source/whatsnew/v0.20.3.txt
+++ b/doc/source/whatsnew/v0.20.3.txt
@@ -40,7 +40,7 @@ Bug Fixes
 - Fixed issue with :meth:`DataFrame.style` where element id's were not unique (:issue:`16780`)
 - Fixed a pytest marker failing downstream packages' tests suites (:issue:`16680`)
 - Fixed compat with loading a ``DataFrame`` with a ``PeriodIndex``, from a ``format='fixed'`` HDFStore, in Python 3, that was written in Python 2 (:issue:`16781`)
-- Fixed bug where computing the rolling covariance of a MultiIndexed ``DataFrame`` improperly raised a ``ValueError`` (:issue:`16789`)
+- Fixed a bug in failing to compute rolling computations of a column-MultiIndexed ``DataFrame`` (:issue:`16789`, :issue:`16825`)
 
 Conversion
 ^^^^^^^^^^

--- a/pandas/core/indexes/multi.py
+++ b/pandas/core/indexes/multi.py
@@ -1383,6 +1383,9 @@ class MultiIndex(Index):
                 # cannot be sure whether the result will be sorted
                 sortorder = None
 
+                if isinstance(key, Index):
+                    key = np.asarray(key)
+
             new_labels = [lab[key] for lab in self.labels]
 
             return MultiIndex(levels=self.levels, labels=new_labels,

--- a/pandas/core/window.py
+++ b/pandas/core/window.py
@@ -836,7 +836,7 @@ class _Rolling_and_Expanding(_Rolling):
 
         return self._wrap_results(results, blocks, obj)
 
-    _shared_docs['apply'] = dedent("""
+    _shared_docs['apply'] = dedent(r"""
     %(name)s function apply
 
     Parameters
@@ -1922,7 +1922,8 @@ def _flex_binary_moment(arg1, arg2, f, pairwise=False):
 
                 # TODO: not the most efficient (perf-wise)
                 # though not bad code-wise
-                from pandas import Panel, MultiIndex, Index
+                from pandas import Panel, MultiIndex
+
                 with warnings.catch_warnings(record=True):
                     p = Panel.from_dict(results).swapaxes('items', 'major')
                     if len(p.major_axis) > 0:
@@ -1945,8 +1946,8 @@ def _flex_binary_moment(arg1, arg2, f, pairwise=False):
                 # reset our index names to arg1 names
                 # reset our column names to arg2 names
                 # careful not to mutate the original names
-                result.columns = Index(result.columns).set_names(
-                    arg2.columns.name)
+                result.columns = result.columns.set_names(
+                    arg2.columns.names)
                 result.index = result.index.set_names(
                     arg1.index.names + arg1.columns.names)
 

--- a/pandas/tests/indexes/test_multi.py
+++ b/pandas/tests/indexes/test_multi.py
@@ -61,15 +61,6 @@ class TestMultiIndex(Base):
 
         tm.assert_raises_regex(ValueError, 'The truth value of a', f)
 
-    def test_multi_index_names(self):
-
-        # GH 16789
-        cols = pd.MultiIndex.from_product([['A', 'B'], ['C', 'D', 'E']],
-                                          names=['1', '2'])
-        df = pd.DataFrame(np.ones((10, 6)), columns=cols)
-        rolling_result = df.rolling(3).cov()
-        assert rolling_result.index.names == [None, '1', '2']
-
     def test_labels_dtypes(self):
 
         # GH 8456

--- a/pandas/tests/test_window.py
+++ b/pandas/tests/test_window.py
@@ -455,6 +455,17 @@ class TestRolling(Base):
         result = DataFrame(index=pd.DatetimeIndex([])).rolling(roller).sum()
         tm.assert_frame_equal(result, expected)
 
+    def test_multi_index_names(self):
+
+        # GH 16789, 16825
+        cols = pd.MultiIndex.from_product([['A', 'B'], ['C', 'D', 'E']],
+                                          names=['1', '2'])
+        df = pd.DataFrame(np.ones((10, 6)), columns=cols)
+        result = df.rolling(3).cov()
+
+        tm.assert_index_equal(result.columns, df.columns)
+        assert result.index.names == [None, '1', '2']
+
 
 class TestExpanding(Base):
 
@@ -501,9 +512,10 @@ class TestExpanding(Base):
         'expander',
         [1, pytest.mark.xfail(
             reason='GH 16425 expanding with offset not supported')('1s')])
-    def tests_empty_df_expanding(self, expander):
+    def test_empty_df_expanding(self, expander):
         # GH 15819 Verifies that datetime and integer expanding windows can be
         # applied to empty DataFrames
+
         expected = DataFrame()
         result = DataFrame().expanding(expander).sum()
         tm.assert_frame_equal(result, expected)


### PR DESCRIPTION
xref #16814
