### PR TITLE
BUG: kind parameter on categorical argsort

### DIFF
--- a/doc/source/whatsnew/v0.20.2.txt
+++ b/doc/source/whatsnew/v0.20.2.txt
@@ -120,7 +120,6 @@ Categorical
 ^^^^^^^^^^^
 
 - Fixed comparison operations considering the order of the categories when both categoricals are unordered (:issue:`16014`)
-- Bug in ``DataFrame.sort_values`` not respecting the ``kind`` with categorical data (:issue:`16793`)
 
 Other
 ^^^^^

--- a/doc/source/whatsnew/v0.20.2.txt
+++ b/doc/source/whatsnew/v0.20.2.txt
@@ -120,6 +120,7 @@ Categorical
 ^^^^^^^^^^^
 
 - Fixed comparison operations considering the order of the categories when both categoricals are unordered (:issue:`16014`)
+- Bug in ``DataFrame.sort_values`` not respecting the ``kind`` with categorical data (:issue:`16793`)
 
 Other
 ^^^^^

--- a/doc/source/whatsnew/v0.20.3.txt
+++ b/doc/source/whatsnew/v0.20.3.txt
@@ -92,6 +92,7 @@ Numeric
 Categorical
 ^^^^^^^^^^^
 
+- Bug in ``DataFrame.sort_values`` not respecting the ``kind`` with categorical data (:issue:`16793`)
 
 Other
 ^^^^^

--- a/pandas/compat/numpy/function.py
+++ b/pandas/compat/numpy/function.py
@@ -102,10 +102,9 @@ def validate_argmax_with_skipna(skipna, args, kwargs):
 
 ARGSORT_DEFAULTS = OrderedDict()
 ARGSORT_DEFAULTS['axis'] = -1
-ARGSORT_DEFAULTS['kind'] = 'quicksort'
 ARGSORT_DEFAULTS['order'] = None
 validate_argsort = CompatValidator(ARGSORT_DEFAULTS, fname='argsort',
-                                   max_fname_arg_count=0, method='both')
+                                   max_fname_arg_count=3, method='both')
 
 
 def validate_argsort_with_ascending(ascending, args, kwargs):
@@ -121,7 +120,7 @@ def validate_argsort_with_ascending(ascending, args, kwargs):
         args = (ascending,) + args
         ascending = True
 
-    validate_argsort(args, kwargs, max_fname_arg_count=1)
+    validate_argsort(args, kwargs, max_fname_arg_count=3)
     return ascending
 
 

--- a/pandas/compat/numpy/function.py
+++ b/pandas/compat/numpy/function.py
@@ -102,9 +102,18 @@ def validate_argmax_with_skipna(skipna, args, kwargs):
 
 ARGSORT_DEFAULTS = OrderedDict()
 ARGSORT_DEFAULTS['axis'] = -1
+ARGSORT_DEFAULTS['kind'] = 'quicksort'
 ARGSORT_DEFAULTS['order'] = None
 validate_argsort = CompatValidator(ARGSORT_DEFAULTS, fname='argsort',
-                                   max_fname_arg_count=3, method='both')
+                                   max_fname_arg_count=0, method='both')
+
+# two different signatures of argsort, this second validation
+# for when the `kind` param is supported
+ARGSORT_DEFAULTS_KIND = OrderedDict()
+ARGSORT_DEFAULTS_KIND['axis'] = -1
+ARGSORT_DEFAULTS_KIND['order'] = None
+validate_argsort_kind = CompatValidator(ARGSORT_DEFAULTS_KIND, fname='argsort',
+                                        max_fname_arg_count=0, method='both')
 
 
 def validate_argsort_with_ascending(ascending, args, kwargs):
@@ -120,7 +129,7 @@ def validate_argsort_with_ascending(ascending, args, kwargs):
         args = (ascending,) + args
         ascending = True
 
-    validate_argsort(args, kwargs, max_fname_arg_count=3)
+    validate_argsort_kind(args, kwargs, max_fname_arg_count=3)
     return ascending
 
 

--- a/pandas/core/categorical.py
+++ b/pandas/core/categorical.py
@@ -1288,7 +1288,7 @@ class Categorical(PandasObject):
                             "you can use .as_ordered() to change the "
                             "Categorical to an ordered one\n".format(op=op))
 
-    def argsort(self, ascending=True, *args, **kwargs):
+    def argsort(self, ascending=True, kind='quicksort', *args, **kwargs):
         """
         Returns the indices that would sort the Categorical instance if
         'sort_values' was called. This function is implemented to provide
@@ -1309,7 +1309,7 @@ class Categorical(PandasObject):
         numpy.ndarray.argsort
         """
         ascending = nv.validate_argsort_with_ascending(ascending, args, kwargs)
-        result = np.argsort(self._codes.copy(), **kwargs)
+        result = np.argsort(self._codes.copy(), kind=kind, **kwargs)
         if not ascending:
             result = result[::-1]
         return result

--- a/pandas/core/sorting.py
+++ b/pandas/core/sorting.py
@@ -233,7 +233,7 @@ def nargsort(items, kind='quicksort', ascending=True, na_position='last'):
 
     # specially handle Categorical
     if is_categorical_dtype(items):
-        return items.argsort(ascending=ascending)
+        return items.argsort(ascending=ascending, kind=kind)
 
     items = np.asanyarray(items)
     idx = np.arange(len(items))

--- a/pandas/tests/frame/test_sorting.py
+++ b/pandas/tests/frame/test_sorting.py
@@ -238,6 +238,15 @@ class TestDataFrameSorting(TestData):
                                    kind='mergesort')
         assert_frame_equal(sorted_df, expected)
 
+    def test_stable_categorial(self):
+        # GH 16793
+        df = DataFrame({
+            'x': pd.Categorical(np.repeat([1, 2, 3, 4], 5), ordered=True)
+        })
+        expected = df.copy()
+        sorted_df = df.sort_values('x', kind='mergesort')
+        assert_frame_equal(sorted_df, expected)
+
     def test_sort_datetimes(self):
 
         # GH 3461, argsort / lexsort differences for a datetime column

--- a/pandas/tests/test_categorical.py
+++ b/pandas/tests/test_categorical.py
@@ -585,9 +585,8 @@ class TestCategorical(object):
         tm.assert_numpy_array_equal(np.argsort(c), expected,
                                     check_dtype=False)
 
-        msg = "the 'kind' parameter is not supported"
-        tm.assert_raises_regex(ValueError, msg, np.argsort,
-                               c, kind='mergesort')
+        tm.assert_numpy_array_equal(np.argsort(c, kind='mergesort'), expected,
+                                    check_dtype=False)
 
         msg = "the 'axis' parameter is not supported"
         tm.assert_raises_regex(ValueError, msg, np.argsort,


### PR DESCRIPTION
 - [x] closes #16793
 - [ ] tests added / passed
 - [x] passes ``git diff upstream/master --name-only -- '*.py' | flake8 --diff`` (On Windows, ``git diff upstream/master -u -- "*.py" | flake8 --diff`` might work as an alternative.)
 - [x] whatsnew entry
