### PR TITLE
Added tests for _get_dtype

### DIFF
--- a/pandas/tests/dtypes/test_common.py
+++ b/pandas/tests/dtypes/test_common.py
@@ -551,15 +551,15 @@ def test_is_complex_dtype():
     (PeriodDtype(freq='D'), PeriodDtype(freq='D')),
     ('period[D]', PeriodDtype(freq='D')),
     (IntervalDtype(), IntervalDtype()),
-    ])
+])
 def test__get_dtype(input_param, result):
     assert com._get_dtype(input_param) == result
 
 
 @pytest.mark.parametrize('input_param', [None,
-                                   1, 1.2,
-                                   'random string',
-                                   pd.DataFrame([1, 2])])
+                                         1, 1.2,
+                                         'random string',
+                                         pd.DataFrame([1, 2])])
 def test__get_dtype_fails(input_param):
     # python objects
     pytest.raises(TypeError, com._get_dtype, input_param)

--- a/pandas/tests/dtypes/test_common.py
+++ b/pandas/tests/dtypes/test_common.py
@@ -532,7 +532,7 @@ def test_is_complex_dtype():
     (float, np.dtype(float)),
     ('float64', np.dtype('float64')),
     (np.dtype('float64'), np.dtype('float64')),
-    (str, np.dtype('<U')),
+    pytest.mark.xfail(str, np.dtype('<U')),
     (pd.Series([1, 2], dtype=np.dtype('int16')), np.dtype('int16')),
     (pd.Series(['a', 'b']), np.dtype(object)),
     (pd.Index([1, 2]), np.dtype('int64')),

--- a/pandas/tests/dtypes/test_common.py
+++ b/pandas/tests/dtypes/test_common.py
@@ -524,3 +524,42 @@ def test_is_complex_dtype():
 
     assert com.is_complex_dtype(np.complex)
     assert com.is_complex_dtype(np.array([1 + 1j, 5]))
+
+
+@pytest.mark.parametrize('input_param,result', [
+    (int, np.dtype(int)),
+    ('int32', np.dtype('int32')),
+    (float, np.dtype(float)),
+    ('float64', np.dtype('float64')),
+    (np.dtype('float64'), np.dtype('float64')),
+    (str, np.dtype('<U')),
+    (pd.Series([1, 2], dtype=np.dtype('int16')), np.dtype('int16')),
+    (pd.Series(['a', 'b']), np.dtype(object)),
+    (pd.Index([1, 2]), np.dtype('int64')),
+    (pd.Index(['a', 'b']), np.dtype(object)),
+    ('category', 'category'),
+    (pd.Categorical(['a', 'b']).dtype, CategoricalDtype()),
+    pytest.mark.xfail((pd.Categorical(['a', 'b']), CategoricalDtype()),),
+    (pd.CategoricalIndex(['a', 'b']).dtype, CategoricalDtype()),
+    pytest.mark.xfail((pd.CategoricalIndex(['a', 'b']), CategoricalDtype()),),
+    (pd.DatetimeIndex([1, 2]), np.dtype('<M8[ns]')),
+    (pd.DatetimeIndex([1, 2]).dtype, np.dtype('<M8[ns]')),
+    ('<M8[ns]', np.dtype('<M8[ns]')),
+    ('datetime64[ns, Europe/London]', DatetimeTZDtype('ns', 'Europe/London')),
+    (pd.SparseSeries([1, 2], dtype='int32'), np.dtype('int32')),
+    (pd.SparseSeries([1, 2], dtype='int32').dtype, np.dtype('int32')),
+    (PeriodDtype(freq='D'), PeriodDtype(freq='D')),
+    ('period[D]', PeriodDtype(freq='D')),
+    (IntervalDtype(), IntervalDtype()),
+    ])
+def test__get_dtype(input_param, result):
+    assert com._get_dtype(input_param) == result
+
+
+@pytest.mark.parametrize('input_param', [None,
+                                   1, 1.2,
+                                   'random string',
+                                   pd.DataFrame([1, 2])])
+def test__get_dtype_fails(input_param):
+    # python objects
+    pytest.raises(TypeError, com._get_dtype, input_param)

--- a/pandas/tests/dtypes/test_common.py
+++ b/pandas/tests/dtypes/test_common.py
@@ -532,7 +532,7 @@ def test_is_complex_dtype():
     (float, np.dtype(float)),
     ('float64', np.dtype('float64')),
     (np.dtype('float64'), np.dtype('float64')),
-    pytest.mark.xfail(str, np.dtype('<U')),
+    pytest.mark.xfail((str, np.dtype('<U')), ),
     (pd.Series([1, 2], dtype=np.dtype('int16')), np.dtype('int16')),
     (pd.Series(['a', 'b']), np.dtype(object)),
     (pd.Index([1, 2]), np.dtype('int64')),


### PR DESCRIPTION
 - [ ] closes #xxxx
 - [ x] tests added / passed
 - [ ] passes ``git diff upstream/master --name-only -- '*.py' | flake8 --diff`` (On Windows, ``git diff upstream/master -u -- "*.py" | flake8 --diff`` might work as an alternative.)
 - [ ] whatsnew entry

See #16817 for a discussion on this.

Added tests for `` pd.core.dtypes.common._get_dtype``. Some things to note:
* Tests for Categoricals fail, I've marked them xfail. This is because I propose allowing categoricals to pass in a later commit.
* ``Interval``s don't have a dtype, so they'd fail with an AttributeError. I therefore haven't added tests for Intervals, but it could be considered if it's a bug/inconsistency, that ``Interval``s don't have a dtype.

This is my first serious pull request, and I may have made errors. If anything is wrong, against the style guide,etc. please let me know.

I will make a pull request of tests for ``_get_dtype_type``, when this one has been accepted.
