### PR TITLE
TST/PKG: Remove definition of pandas.util.testing.slow

### DIFF
--- a/doc/source/whatsnew/v0.21.0.txt
+++ b/doc/source/whatsnew/v0.21.0.txt
@@ -54,6 +54,7 @@ Backwards incompatible API changes
 - :class:`pandas.HDFStore`'s string representation is now faster and less detailed. For the previous behavior, use ``pandas.HDFStore.info()``. (:issue:`16503`).
 - Compression defaults in HDF stores now follow pytable standards. Default is no compression and if ``complib`` is missing and ``complevel`` > 0 ``zlib`` is used (:issue:`15943`)
 - ``Index.get_indexer_non_unique()`` now returns a ndarray indexer rather than an ``Index``; this is consistent with ``Index.get_indexer()`` (:issue:`16819`)
+- Removed the ``@slow`` decorator from ``pandas.util.testing``, which caused issues for some downstream packages' test suites. Use ``@pytest.mark.slow`` instead, which achieves the same thing (:issue:`16850`)
 
 .. _whatsnew_0210.api:
 

--- a/pandas/tests/computation/test_eval.py
+++ b/pandas/tests/computation/test_eval.py
@@ -30,7 +30,7 @@ import pandas.core.computation.expr as expr
 import pandas.util.testing as tm
 from pandas.util.testing import (assert_frame_equal, randbool,
                                  assert_numpy_array_equal, assert_series_equal,
-                                 assert_produces_warning, slow)
+                                 assert_produces_warning)
 from pandas.compat import PY3, reduce
 
 _series_frame_incompatible = _bool_ops_syms
@@ -144,7 +144,7 @@ class TestEvalNumexprPandas(object):
         del self.lhses, self.rhses, self.scalar_rhses, self.scalar_lhses
         del self.pandas_rhses, self.pandas_lhses, self.current_engines
 
-    @slow
+    @pytest.mark.slow
     def test_complex_cmp_ops(self):
         cmp_ops = ('!=', '==', '<=', '>=', '<', '>')
         cmp2_ops = ('>', '<')
@@ -161,7 +161,7 @@ class TestEvalNumexprPandas(object):
         for lhs, rhs, cmp_op in product(bool_lhses, bool_rhses, self.cmp_ops):
             self.check_simple_cmp_op(lhs, cmp_op, rhs)
 
-    @slow
+    @pytest.mark.slow
     def test_binary_arith_ops(self):
         for lhs, op, rhs in product(self.lhses, self.arith_ops, self.rhses):
             self.check_binary_arith_op(lhs, op, rhs)
@@ -181,17 +181,17 @@ class TestEvalNumexprPandas(object):
         for lhs, rhs in product(self.lhses, self.rhses):
             self.check_pow(lhs, '**', rhs)
 
-    @slow
+    @pytest.mark.slow
     def test_single_invert_op(self):
         for lhs, op, rhs in product(self.lhses, self.cmp_ops, self.rhses):
             self.check_single_invert_op(lhs, op, rhs)
 
-    @slow
+    @pytest.mark.slow
     def test_compound_invert_op(self):
         for lhs, op, rhs in product(self.lhses, self.cmp_ops, self.rhses):
             self.check_compound_invert_op(lhs, op, rhs)
 
-    @slow
+    @pytest.mark.slow
     def test_chained_cmp_op(self):
         mids = self.lhses
         cmp_ops = '<', '>'
@@ -870,7 +870,7 @@ class TestAlignment(object):
             res = pd.eval('df < df3', engine=engine, parser=parser)
             assert_frame_equal(res, df < df3)
 
-    @slow
+    @pytest.mark.slow
     def test_medium_complex_frame_alignment(self, engine, parser):
         args = product(self.lhs_index_types, self.index_types,
                        self.index_types, self.index_types)
@@ -974,7 +974,7 @@ class TestAlignment(object):
                     if engine == 'numexpr':
                         assert_frame_equal(a, b)
 
-    @slow
+    @pytest.mark.slow
     def test_complex_series_frame_alignment(self, engine, parser):
         import random
         args = product(self.lhs_index_types, self.index_types,

--- a/pandas/tests/frame/test_repr_info.py
+++ b/pandas/tests/frame/test_repr_info.py
@@ -8,6 +8,7 @@ import sys
 
 from numpy import nan
 import numpy as np
+import pytest
 
 from pandas import (DataFrame, compat, option_context)
 from pandas.compat import StringIO, lrange, u
@@ -40,7 +41,7 @@ class TestDataFrameReprInfoEtc(TestData):
         foo = repr(self.mixed_frame)  # noqa
         self.mixed_frame.info(verbose=False, buf=buf)
 
-    @tm.slow
+    @pytest.mark.slow
     def test_repr_mixed_big(self):
         # big mixed
         biggie = DataFrame({'A': np.random.randn(200),
@@ -87,7 +88,7 @@ class TestDataFrameReprInfoEtc(TestData):
         with option_context('display.show_dimensions', 'truncate'):
             assert "2 rows x 2 columns" not in repr(df)
 
-    @tm.slow
+    @pytest.mark.slow
     def test_repr_big(self):
         # big one
         biggie = DataFrame(np.zeros((200, 4)), columns=lrange(4),

--- a/pandas/tests/frame/test_to_csv.py
+++ b/pandas/tests/frame/test_to_csv.py
@@ -17,7 +17,7 @@ import pandas as pd
 from pandas.util.testing import (assert_almost_equal,
                                  assert_series_equal,
                                  assert_frame_equal,
-                                 ensure_clean, slow,
+                                 ensure_clean,
                                  makeCustomDataframe as mkdf)
 import pandas.util.testing as tm
 
@@ -205,7 +205,7 @@ class TestDataFrameToCSV(TestData):
         cols = ['b', 'a']
         _check_df(df, cols)
 
-    @slow
+    @pytest.mark.slow
     def test_to_csv_dtnat(self):
         # GH3437
         from pandas import NaT
@@ -236,7 +236,7 @@ class TestDataFrameToCSV(TestData):
             assert_frame_equal(df, recons, check_names=False,
                                check_less_precise=True)
 
-    @slow
+    @pytest.mark.slow
     def test_to_csv_moar(self):
 
         def _do_test(df, r_dtype=None, c_dtype=None,
@@ -728,7 +728,7 @@ class TestDataFrameToCSV(TestData):
                 rs = read_csv(filename, index_col=0)
                 assert_frame_equal(rs, aa)
 
-    @slow
+    @pytest.mark.slow
     def test_to_csv_wide_frame_formatting(self):
         # Issue #8621
         df = DataFrame(np.random.randn(1, 100010), columns=None, index=None)

--- a/pandas/tests/indexing/test_indexing_slow.py
+++ b/pandas/tests/indexing/test_indexing_slow.py
@@ -6,11 +6,12 @@ import numpy as np
 import pandas as pd
 from pandas.core.api import Series, DataFrame, MultiIndex
 import pandas.util.testing as tm
+import pytest
 
 
 class TestIndexingSlow(object):
 
-    @tm.slow
+    @pytest.mark.slow
     def test_multiindex_get_loc(self):  # GH7724, GH2646
 
         with warnings.catch_warnings(record=True):
@@ -80,7 +81,7 @@ class TestIndexingSlow(object):
                     assert not mi.index.lexsort_depth < i
                     loop(mi, df, keys)
 
-    @tm.slow
+    @pytest.mark.slow
     def test_large_dataframe_indexing(self):
         # GH10692
         result = DataFrame({'x': range(10 ** 6)}, dtype='int64')
@@ -88,7 +89,7 @@ class TestIndexingSlow(object):
         expected = DataFrame({'x': range(10 ** 6 + 1)}, dtype='int64')
         tm.assert_frame_equal(result, expected)
 
-    @tm.slow
+    @pytest.mark.slow
     def test_large_mi_dataframe_indexing(self):
         # GH10645
         result = MultiIndex.from_arrays([range(10 ** 6), range(10 ** 6)])

--- a/pandas/tests/io/parser/common.py
+++ b/pandas/tests/io/parser/common.py
@@ -664,7 +664,7 @@ bar"""
         tm.assert_frame_equal(url_table, local_table)
         # TODO: ftp testing
 
-    @tm.slow
+    @pytest.mark.slow
     def test_file(self):
         dirpath = tm.get_data_path()
         localtable = os.path.join(dirpath, 'salaries.csv')

--- a/pandas/tests/io/test_excel.py
+++ b/pandas/tests/io/test_excel.py
@@ -614,7 +614,7 @@ class XlrdTests(ReadingTestsBase):
         local_table = self.get_exceldf('test1')
         tm.assert_frame_equal(url_table, local_table)
 
-    @tm.slow
+    @pytest.mark.slow
     def test_read_from_file_url(self):
 
         # FILE

--- a/pandas/tests/io/test_html.py
+++ b/pandas/tests/io/test_html.py
@@ -130,7 +130,7 @@ class TestReadHtml(ReadHtmlMixin):
 
         assert_framelist_equal(df1, df2)
 
-    @tm.slow
+    @pytest.mark.slow
     def test_banklist(self):
         df1 = self.read_html(self.banklist_data, '.*Florida.*',
                              attrs={'id': 'table'})
@@ -292,7 +292,7 @@ class TestReadHtml(ReadHtmlMixin):
         except ValueError as e:
             assert str(e) == 'No tables found'
 
-    @tm.slow
+    @pytest.mark.slow
     def test_file_url(self):
         url = self.banklist_data
         dfs = self.read_html(file_path_to_url(url), 'First',
@@ -301,7 +301,7 @@ class TestReadHtml(ReadHtmlMixin):
         for df in dfs:
             assert isinstance(df, DataFrame)
 
-    @tm.slow
+    @pytest.mark.slow
     def test_invalid_table_attrs(self):
         url = self.banklist_data
         with tm.assert_raises_regex(ValueError, 'No tables found'):
@@ -312,39 +312,39 @@ class TestReadHtml(ReadHtmlMixin):
         return self.read_html(self.banklist_data, 'Metcalf',
                               attrs={'id': 'table'}, *args, **kwargs)
 
-    @tm.slow
+    @pytest.mark.slow
     def test_multiindex_header(self):
         df = self._bank_data(header=[0, 1])[0]
         assert isinstance(df.columns, MultiIndex)
 
-    @tm.slow
+    @pytest.mark.slow
     def test_multiindex_index(self):
         df = self._bank_data(index_col=[0, 1])[0]
         assert isinstance(df.index, MultiIndex)
 
-    @tm.slow
+    @pytest.mark.slow
     def test_multiindex_header_index(self):
         df = self._bank_data(header=[0, 1], index_col=[0, 1])[0]
         assert isinstance(df.columns, MultiIndex)
         assert isinstance(df.index, MultiIndex)
 
-    @tm.slow
+    @pytest.mark.slow
     def test_multiindex_header_skiprows_tuples(self):
         df = self._bank_data(header=[0, 1], skiprows=1, tupleize_cols=True)[0]
         assert isinstance(df.columns, Index)
 
-    @tm.slow
+    @pytest.mark.slow
     def test_multiindex_header_skiprows(self):
         df = self._bank_data(header=[0, 1], skiprows=1)[0]
         assert isinstance(df.columns, MultiIndex)
 
-    @tm.slow
+    @pytest.mark.slow
     def test_multiindex_header_index_skiprows(self):
         df = self._bank_data(header=[0, 1], index_col=[0, 1], skiprows=1)[0]
         assert isinstance(df.index, MultiIndex)
         assert isinstance(df.columns, MultiIndex)
 
-    @tm.slow
+    @pytest.mark.slow
     def test_regex_idempotency(self):
         url = self.banklist_data
         dfs = self.read_html(file_path_to_url(url),
@@ -372,7 +372,7 @@ class TestReadHtml(ReadHtmlMixin):
         zz = [df.iloc[0, 0][0:4] for df in dfs]
         assert sorted(zz) == sorted(['Repo', 'What'])
 
-    @tm.slow
+    @pytest.mark.slow
     def test_thousands_macau_stats(self):
         all_non_nan_table_index = -2
         macau_data = os.path.join(DATA_PATH, 'macau.html')
@@ -382,7 +382,7 @@ class TestReadHtml(ReadHtmlMixin):
 
         assert not any(s.isnull().any() for _, s in df.iteritems())
 
-    @tm.slow
+    @pytest.mark.slow
     def test_thousands_macau_index_col(self):
         all_non_nan_table_index = -2
         macau_data = os.path.join(DATA_PATH, 'macau.html')
@@ -523,7 +523,7 @@ class TestReadHtml(ReadHtmlMixin):
         assert df.shape[0] == nrows
         tm.assert_index_equal(df.columns, columns)
 
-    @tm.slow
+    @pytest.mark.slow
     def test_banklist_header(self):
         from pandas.io.html import _remove_whitespace
 
@@ -562,7 +562,7 @@ class TestReadHtml(ReadHtmlMixin):
                                                              coerce=True)
         tm.assert_frame_equal(converted, gtnew)
 
-    @tm.slow
+    @pytest.mark.slow
     def test_gold_canyon(self):
         gc = 'Gold Canyon'
         with open(self.banklist_data, 'r') as f:
@@ -855,7 +855,7 @@ class TestReadHtmlLxml(ReadHtmlMixin):
         assert isinstance(dfs, list)
         assert isinstance(dfs[0], DataFrame)
 
-    @tm.slow
+    @pytest.mark.slow
     def test_fallback_success(self):
         _skip_if_none_of(('bs4', 'html5lib'))
         banklist_data = os.path.join(DATA_PATH, 'banklist.html')
@@ -898,7 +898,7 @@ def get_elements_from_file(url, element='table'):
     return soup.find_all(element)
 
 
-@tm.slow
+@pytest.mark.slow
 def test_bs4_finds_tables():
     filepath = os.path.join(DATA_PATH, "spam.html")
     with warnings.catch_warnings():
@@ -913,13 +913,13 @@ def get_lxml_elements(url, element):
     return doc.xpath('.//{0}'.format(element))
 
 
-@tm.slow
+@pytest.mark.slow
 def test_lxml_finds_tables():
     filepath = os.path.join(DATA_PATH, "spam.html")
     assert get_lxml_elements(filepath, 'table')
 
 
-@tm.slow
+@pytest.mark.slow
 def test_lxml_finds_tbody():
     filepath = os.path.join(DATA_PATH, "spam.html")
     assert get_lxml_elements(filepath, 'tbody')

--- a/pandas/tests/plotting/test_boxplot_method.py
+++ b/pandas/tests/plotting/test_boxplot_method.py
@@ -8,7 +8,6 @@ from distutils.version import LooseVersion
 from pandas import Series, DataFrame, MultiIndex
 from pandas.compat import range, lzip
 import pandas.util.testing as tm
-from pandas.util.testing import slow
 
 import numpy as np
 from numpy import random
@@ -35,7 +34,7 @@ def _skip_if_mpl_14_or_dev_boxplot():
 
 class TestDataFramePlots(TestPlotBase):
 
-    @slow
+    @pytest.mark.slow
     def test_boxplot_legacy(self):
         df = DataFrame(randn(6, 4),
                        index=list(string.ascii_letters[:6]),
@@ -93,13 +92,13 @@ class TestDataFramePlots(TestPlotBase):
         lines = list(itertools.chain.from_iterable(d.values()))
         assert len(ax.get_lines()) == len(lines)
 
-    @slow
+    @pytest.mark.slow
     def test_boxplot_return_type_none(self):
         # GH 12216; return_type=None & by=None -> axes
         result = self.hist_df.boxplot()
         assert isinstance(result, self.plt.Axes)
 
-    @slow
+    @pytest.mark.slow
     def test_boxplot_return_type_legacy(self):
         # API change in https://github.com/pandas-dev/pandas/pull/7096
         import matplotlib as mpl  # noqa
@@ -125,7 +124,7 @@ class TestDataFramePlots(TestPlotBase):
             result = df.boxplot(return_type='both')
         self._check_box_return_type(result, 'both')
 
-    @slow
+    @pytest.mark.slow
     def test_boxplot_axis_limits(self):
 
         def _check_ax_limits(col, ax):
@@ -153,14 +152,14 @@ class TestDataFramePlots(TestPlotBase):
         assert age_ax._sharey == height_ax
         assert dummy_ax._sharey is None
 
-    @slow
+    @pytest.mark.slow
     def test_boxplot_empty_column(self):
         _skip_if_mpl_14_or_dev_boxplot()
         df = DataFrame(np.random.randn(20, 4))
         df.loc[:, 0] = np.nan
         _check_plot_works(df.boxplot, return_type='axes')
 
-    @slow
+    @pytest.mark.slow
     def test_figsize(self):
         df = DataFrame(np.random.rand(10, 5),
                        columns=['A', 'B', 'C', 'D', 'E'])
@@ -176,7 +175,7 @@ class TestDataFramePlots(TestPlotBase):
 
 class TestDataFrameGroupByPlots(TestPlotBase):
 
-    @slow
+    @pytest.mark.slow
     def test_boxplot_legacy(self):
         grouped = self.hist_df.groupby(by='gender')
         with tm.assert_produces_warning(UserWarning):
@@ -206,7 +205,7 @@ class TestDataFrameGroupByPlots(TestPlotBase):
                                  return_type='axes')
         self._check_axes_shape(axes, axes_num=1, layout=(1, 1))
 
-    @slow
+    @pytest.mark.slow
     def test_grouped_plot_fignums(self):
         n = 10
         weight = Series(np.random.normal(166, 20, size=n))
@@ -230,7 +229,7 @@ class TestDataFrameGroupByPlots(TestPlotBase):
         res = df.groupby('gender').hist()
         tm.close()
 
-    @slow
+    @pytest.mark.slow
     def test_grouped_box_return_type(self):
         df = self.hist_df
 
@@ -267,7 +266,7 @@ class TestDataFrameGroupByPlots(TestPlotBase):
             returned = df2.boxplot(by='category', return_type=t)
             self._check_box_return_type(returned, t, expected_keys=columns2)
 
-    @slow
+    @pytest.mark.slow
     def test_grouped_box_layout(self):
         df = self.hist_df
 
@@ -341,7 +340,7 @@ class TestDataFrameGroupByPlots(TestPlotBase):
             return_type='dict')
         self._check_axes_shape(self.plt.gcf().axes, axes_num=3, layout=(1, 3))
 
-    @slow
+    @pytest.mark.slow
     def test_grouped_box_multiple_axes(self):
         # GH 6970, GH 7069
         df = self.hist_df

--- a/pandas/tests/plotting/test_datetimelike.py
+++ b/pandas/tests/plotting/test_datetimelike.py
@@ -14,7 +14,7 @@ from pandas.tseries.offsets import DateOffset
 from pandas.core.indexes.period import period_range, Period, PeriodIndex
 from pandas.core.resample import DatetimeIndex
 
-from pandas.util.testing import assert_series_equal, ensure_clean, slow
+from pandas.util.testing import assert_series_equal, ensure_clean
 import pandas.util.testing as tm
 
 from pandas.tests.plotting.common import (TestPlotBase,
@@ -45,7 +45,7 @@ class TestTSPlot(TestPlotBase):
     def teardown_method(self, method):
         tm.close()
 
-    @slow
+    @pytest.mark.slow
     def test_ts_plot_with_tz(self):
         # GH2877
         index = date_range('1/1/2011', periods=2, freq='H',
@@ -61,7 +61,7 @@ class TestTSPlot(TestPlotBase):
         for label in (ax.get_xticklabels() + ax.get_yticklabels()):
             assert label.get_fontsize() == 2
 
-    @slow
+    @pytest.mark.slow
     def test_frame_inferred(self):
         # inferred freq
         idx = date_range('1/1/1987', freq='MS', periods=100)
@@ -99,7 +99,7 @@ class TestTSPlot(TestPlotBase):
 
         pytest.raises(TypeError, df['A'].plot)
 
-    @slow
+    @pytest.mark.slow
     def test_tsplot(self):
         from pandas.tseries.plotting import tsplot
 
@@ -133,7 +133,7 @@ class TestTSPlot(TestPlotBase):
         s = ts.reset_index(drop=True)
         pytest.raises(ValueError, s.plot, style='b-', color='#000099')
 
-    @slow
+    @pytest.mark.slow
     def test_high_freq(self):
         freaks = ['ms', 'us']
         for freq in freaks:
@@ -151,7 +151,7 @@ class TestTSPlot(TestPlotBase):
         assert (get_datevalue('1/1/1987', 'D') ==
                 Period('1987-1-1', 'D').ordinal)
 
-    @slow
+    @pytest.mark.slow
     def test_ts_plot_format_coord(self):
         def check_format_of_first_point(ax, expected_string):
             first_line = ax.get_lines()[0]
@@ -185,28 +185,28 @@ class TestTSPlot(TestPlotBase):
         tsplot(daily, self.plt.Axes.plot, ax=ax)
         check_format_of_first_point(ax, 't = 2014-01-01  y = 1.000000')
 
-    @slow
+    @pytest.mark.slow
     def test_line_plot_period_series(self):
         for s in self.period_ser:
             _check_plot_works(s.plot, s.index.freq)
 
-    @slow
+    @pytest.mark.slow
     def test_line_plot_datetime_series(self):
         for s in self.datetime_ser:
             _check_plot_works(s.plot, s.index.freq.rule_code)
 
-    @slow
+    @pytest.mark.slow
     def test_line_plot_period_frame(self):
         for df in self.period_df:
             _check_plot_works(df.plot, df.index.freq)
 
-    @slow
+    @pytest.mark.slow
     def test_line_plot_datetime_frame(self):
         for df in self.datetime_df:
             freq = df.index.to_period(df.index.freq.rule_code).freq
             _check_plot_works(df.plot, freq)
 
-    @slow
+    @pytest.mark.slow
     def test_line_plot_inferred_freq(self):
         for ser in self.datetime_ser:
             ser = Series(ser.values, Index(np.asarray(ser.index)))
@@ -223,7 +223,7 @@ class TestTSPlot(TestPlotBase):
         ts.plot(ax=ax)
         assert not hasattr(ax, 'freq')
 
-    @slow
+    @pytest.mark.slow
     def test_plot_offset_freq(self):
         ser = tm.makeTimeSeries()
         _check_plot_works(ser.plot)
@@ -232,14 +232,14 @@ class TestTSPlot(TestPlotBase):
         ser = Series(np.random.randn(len(dr)), dr)
         _check_plot_works(ser.plot)
 
-    @slow
+    @pytest.mark.slow
     def test_plot_multiple_inferred_freq(self):
         dr = Index([datetime(2000, 1, 1), datetime(2000, 1, 6), datetime(
             2000, 1, 11)])
         ser = Series(np.random.randn(len(dr)), dr)
         _check_plot_works(ser.plot)
 
-    @slow
+    @pytest.mark.slow
     def test_uhf(self):
         import pandas.plotting._converter as conv
         idx = date_range('2012-6-22 21:59:51.960928', freq='L', periods=500)
@@ -257,7 +257,7 @@ class TestTSPlot(TestPlotBase):
             if len(rs):
                 assert xp == rs
 
-    @slow
+    @pytest.mark.slow
     def test_irreg_hf(self):
         idx = date_range('2012-6-22 21:59:51', freq='S', periods=100)
         df = DataFrame(np.random.randn(len(idx), 2), idx)
@@ -297,7 +297,7 @@ class TestTSPlot(TestPlotBase):
         idx = ax.get_lines()[0].get_xdata()
         assert PeriodIndex(data=idx).freqstr == 'B'
 
-    @slow
+    @pytest.mark.slow
     def test_business_freq_convert(self):
         n = tm.N
         tm.N = 300
@@ -327,7 +327,7 @@ class TestTSPlot(TestPlotBase):
         idx = ax.get_lines()[0].get_xdata()
         tm.assert_index_equal(bts.index.to_period(), PeriodIndex(idx))
 
-    @slow
+    @pytest.mark.slow
     def test_axis_limits(self):
 
         def _test(ax):
@@ -384,7 +384,7 @@ class TestTSPlot(TestPlotBase):
         assert conv.get_finder('A') == conv._annual_finder
         assert conv.get_finder('W') == conv._daily_finder
 
-    @slow
+    @pytest.mark.slow
     def test_finder_daily(self):
         xp = Period('1999-1-1', freq='B').ordinal
         day_lst = [10, 40, 252, 400, 950, 2750, 10000]
@@ -402,7 +402,7 @@ class TestTSPlot(TestPlotBase):
             assert xp == rs
             self.plt.close(ax.get_figure())
 
-    @slow
+    @pytest.mark.slow
     def test_finder_quarterly(self):
         xp = Period('1988Q1').ordinal
         yrs = [3.5, 11]
@@ -420,7 +420,7 @@ class TestTSPlot(TestPlotBase):
             assert xp == rs
             self.plt.close(ax.get_figure())
 
-    @slow
+    @pytest.mark.slow
     def test_finder_monthly(self):
         xp = Period('Jan 1988').ordinal
         yrs = [1.15, 2.5, 4, 11]
@@ -448,7 +448,7 @@ class TestTSPlot(TestPlotBase):
         xp = Period('1989Q1', 'M').ordinal
         assert rs == xp
 
-    @slow
+    @pytest.mark.slow
     def test_finder_annual(self):
         xp = [1987, 1988, 1990, 1990, 1995, 2020, 2070, 2170]
         for i, nyears in enumerate([5, 10, 19, 49, 99, 199, 599, 1001]):
@@ -461,7 +461,7 @@ class TestTSPlot(TestPlotBase):
             assert rs == Period(xp[i], freq='A').ordinal
             self.plt.close(ax.get_figure())
 
-    @slow
+    @pytest.mark.slow
     def test_finder_minutely(self):
         nminutes = 50 * 24 * 60
         rng = date_range('1/1/1999', freq='Min', periods=nminutes)
@@ -484,7 +484,7 @@ class TestTSPlot(TestPlotBase):
         xp = Period('1/1/1999', freq='H').ordinal
         assert rs == xp
 
-    @slow
+    @pytest.mark.slow
     def test_gaps(self):
         ts = tm.makeTimeSeries()
         ts[5:25] = np.nan
@@ -529,7 +529,7 @@ class TestTSPlot(TestPlotBase):
         mask = data.mask
         assert mask[2:5, 1].all()
 
-    @slow
+    @pytest.mark.slow
     def test_gap_upsample(self):
         low = tm.makeTimeSeries()
         low[5:25] = np.nan
@@ -551,7 +551,7 @@ class TestTSPlot(TestPlotBase):
         mask = data.mask
         assert mask[5:25, 1].all()
 
-    @slow
+    @pytest.mark.slow
     def test_secondary_y(self):
         ser = Series(np.random.randn(10))
         ser2 = Series(np.random.randn(10))
@@ -581,7 +581,7 @@ class TestTSPlot(TestPlotBase):
         assert hasattr(ax2, 'left_ax')
         assert not hasattr(ax2, 'right_ax')
 
-    @slow
+    @pytest.mark.slow
     def test_secondary_y_ts(self):
         idx = date_range('1/1/2000', periods=10)
         ser = Series(np.random.randn(10), idx)
@@ -608,7 +608,7 @@ class TestTSPlot(TestPlotBase):
         ax2 = ser.plot(secondary_y=True)
         assert ax.get_yaxis().get_visible()
 
-    @slow
+    @pytest.mark.slow
     def test_secondary_kde(self):
         tm._skip_if_no_scipy()
         _skip_if_no_scipy_gaussian_kde()
@@ -621,7 +621,7 @@ class TestTSPlot(TestPlotBase):
         axes = fig.get_axes()
         assert axes[1].get_yaxis().get_ticks_position() == 'right'
 
-    @slow
+    @pytest.mark.slow
     def test_secondary_bar(self):
         ser = Series(np.random.randn(10))
         fig, ax = self.plt.subplots()
@@ -629,7 +629,7 @@ class TestTSPlot(TestPlotBase):
         axes = fig.get_axes()
         assert axes[1].get_yaxis().get_ticks_position() == 'right'
 
-    @slow
+    @pytest.mark.slow
     def test_secondary_frame(self):
         df = DataFrame(np.random.randn(5, 3), columns=['a', 'b', 'c'])
         axes = df.plot(secondary_y=['a', 'c'], subplots=True)
@@ -638,7 +638,7 @@ class TestTSPlot(TestPlotBase):
                 self.default_tick_position)
         assert axes[2].get_yaxis().get_ticks_position() == 'right'
 
-    @slow
+    @pytest.mark.slow
     def test_secondary_bar_frame(self):
         df = DataFrame(np.random.randn(5, 3), columns=['a', 'b', 'c'])
         axes = df.plot(kind='bar', secondary_y=['a', 'c'], subplots=True)
@@ -666,7 +666,7 @@ class TestTSPlot(TestPlotBase):
         assert left == pidx[0].ordinal
         assert right == pidx[-1].ordinal
 
-    @slow
+    @pytest.mark.slow
     def test_mixed_freq_irregular_first(self):
         s1 = tm.makeTimeSeries()
         s2 = s1[[0, 5, 10, 11, 12, 13, 14, 15]]
@@ -697,7 +697,7 @@ class TestTSPlot(TestPlotBase):
         assert left == pidx[0].ordinal
         assert right == pidx[-1].ordinal
 
-    @slow
+    @pytest.mark.slow
     def test_mixed_freq_irregular_first_df(self):
         # GH 9852
         s1 = tm.makeTimeSeries().to_frame()
@@ -723,7 +723,7 @@ class TestTSPlot(TestPlotBase):
         for l in ax.get_lines():
             assert PeriodIndex(data=l.get_xdata()).freq == 'D'
 
-    @slow
+    @pytest.mark.slow
     def test_mixed_freq_alignment(self):
         ts_ind = date_range('2012-01-01 13:00', '2012-01-02', freq='H')
         ts_data = np.random.randn(12)
@@ -737,7 +737,7 @@ class TestTSPlot(TestPlotBase):
 
         assert ax.lines[0].get_xdata()[0] == ax.lines[1].get_xdata()[0]
 
-    @slow
+    @pytest.mark.slow
     def test_mixed_freq_lf_first(self):
 
         idxh = date_range('1/1/1999', periods=365, freq='D')
@@ -819,7 +819,7 @@ class TestTSPlot(TestPlotBase):
         assert s.index.min() <= Series(xdata).min()
         assert Series(xdata).max() <= s.index.max()
 
-    @slow
+    @pytest.mark.slow
     def test_to_weekly_resampling(self):
         idxh = date_range('1/1/1999', periods=52, freq='W')
         idxl = date_range('1/1/1999', periods=12, freq='M')
@@ -840,7 +840,7 @@ class TestTSPlot(TestPlotBase):
         for l in lines:
             assert PeriodIndex(data=l.get_xdata()).freq == idxh.freq
 
-    @slow
+    @pytest.mark.slow
     def test_from_weekly_resampling(self):
         idxh = date_range('1/1/1999', periods=52, freq='W')
         idxl = date_range('1/1/1999', periods=12, freq='M')
@@ -876,7 +876,7 @@ class TestTSPlot(TestPlotBase):
             else:
                 tm.assert_numpy_array_equal(xdata, expected_h)
 
-    @slow
+    @pytest.mark.slow
     def test_from_resampling_area_line_mixed(self):
         idxh = date_range('1/1/1999', periods=52, freq='W')
         idxl = date_range('1/1/1999', periods=12, freq='M')
@@ -950,7 +950,7 @@ class TestTSPlot(TestPlotBase):
                 tm.assert_numpy_array_equal(l.get_ydata(orig=False),
                                             expected_y)
 
-    @slow
+    @pytest.mark.slow
     def test_mixed_freq_second_millisecond(self):
         # GH 7772, GH 7760
         idxh = date_range('2014-07-01 09:00', freq='S', periods=50)
@@ -974,7 +974,7 @@ class TestTSPlot(TestPlotBase):
         for l in ax.get_lines():
             assert PeriodIndex(data=l.get_xdata()).freq == 'L'
 
-    @slow
+    @pytest.mark.slow
     def test_irreg_dtypes(self):
         # date
         idx = [date(2000, 1, 1), date(2000, 1, 5), date(2000, 1, 20)]
@@ -988,7 +988,7 @@ class TestTSPlot(TestPlotBase):
         _, ax = self.plt.subplots()
         _check_plot_works(df.plot, ax=ax)
 
-    @slow
+    @pytest.mark.slow
     def test_time(self):
         t = datetime(1, 1, 1, 3, 30, 0)
         deltas = np.random.randint(1, 20, 3).cumsum()
@@ -1024,7 +1024,7 @@ class TestTSPlot(TestPlotBase):
                 rs = time(h, m, s).strftime('%H:%M:%S')
                 assert xp == rs
 
-    @slow
+    @pytest.mark.slow
     def test_time_musec(self):
         t = datetime(1, 1, 1, 3, 30, 0)
         deltas = np.random.randint(1, 20, 3).cumsum()
@@ -1051,7 +1051,7 @@ class TestTSPlot(TestPlotBase):
                 rs = time(h, m, s).strftime('%H:%M:%S.%f')
                 assert xp == rs
 
-    @slow
+    @pytest.mark.slow
     def test_secondary_upsample(self):
         idxh = date_range('1/1/1999', periods=365, freq='D')
         idxl = date_range('1/1/1999', periods=12, freq='M')
@@ -1067,7 +1067,7 @@ class TestTSPlot(TestPlotBase):
         for l in ax.left_ax.get_lines():
             assert PeriodIndex(l.get_xdata()).freq == 'D'
 
-    @slow
+    @pytest.mark.slow
     def test_secondary_legend(self):
         fig = self.plt.figure()
         ax = fig.add_subplot(211)
@@ -1169,7 +1169,7 @@ class TestTSPlot(TestPlotBase):
             if len(l.get_text()) > 0:
                 assert l.get_rotation() == 30
 
-    @slow
+    @pytest.mark.slow
     def test_ax_plot(self):
         x = DatetimeIndex(start='2012-01-02', periods=10, freq='D')
         y = lrange(len(x))
@@ -1177,7 +1177,7 @@ class TestTSPlot(TestPlotBase):
         lines = ax.plot(x, y, label='Y')
         tm.assert_index_equal(DatetimeIndex(lines[0].get_xdata()), x)
 
-    @slow
+    @pytest.mark.slow
     def test_mpl_nopandas(self):
         dates = [date(2008, 12, 31), date(2009, 1, 31)]
         values1 = np.arange(10.0, 11.0, 0.5)
@@ -1196,7 +1196,7 @@ class TestTSPlot(TestPlotBase):
         exp = np.array([x.toordinal() for x in dates], dtype=np.float64)
         tm.assert_numpy_array_equal(line2.get_xydata()[:, 0], exp)
 
-    @slow
+    @pytest.mark.slow
     def test_irregular_ts_shared_ax_xlim(self):
         # GH 2960
         ts = tm.makeTimeSeries()[:20]
@@ -1212,7 +1212,7 @@ class TestTSPlot(TestPlotBase):
         assert left == ts_irregular.index.min().toordinal()
         assert right == ts_irregular.index.max().toordinal()
 
-    @slow
+    @pytest.mark.slow
     def test_secondary_y_non_ts_xlim(self):
         # GH 3490 - non-timeseries with secondary y
         index_1 = [1, 2, 3, 4]
@@ -1229,7 +1229,7 @@ class TestTSPlot(TestPlotBase):
         assert left_before == left_after
         assert right_before < right_after
 
-    @slow
+    @pytest.mark.slow
     def test_secondary_y_regular_ts_xlim(self):
         # GH 3490 - regular-timeseries with secondary y
         index_1 = date_range(start='2000-01-01', periods=4, freq='D')
@@ -1246,7 +1246,7 @@ class TestTSPlot(TestPlotBase):
         assert left_before == left_after
         assert right_before < right_after
 
-    @slow
+    @pytest.mark.slow
     def test_secondary_y_mixed_freq_ts_xlim(self):
         # GH 3490 - mixed frequency timeseries with secondary y
         rng = date_range('2000-01-01', periods=10000, freq='min')
@@ -1262,7 +1262,7 @@ class TestTSPlot(TestPlotBase):
         assert left_before == left_after
         assert right_before == right_after
 
-    @slow
+    @pytest.mark.slow
     def test_secondary_y_irregular_ts_xlim(self):
         # GH 3490 - irregular-timeseries with secondary y
         ts = tm.makeTimeSeries()[:20]
@@ -1361,7 +1361,7 @@ class TestTSPlot(TestPlotBase):
         _, ax = self.plt.subplots()
         ax.hist([x, x], weights=[w1, w2])
 
-    @slow
+    @pytest.mark.slow
     def test_overlapping_datetime(self):
         # GB 6608
         s1 = Series([1, 2, 3], index=[datetime(1995, 12, 31),

--- a/pandas/tests/plotting/test_deprecated.py
+++ b/pandas/tests/plotting/test_deprecated.py
@@ -4,7 +4,7 @@ import string
 
 import pandas as pd
 import pandas.util.testing as tm
-from pandas.util.testing import slow
+import pytest
 
 from numpy.random import randn
 
@@ -23,7 +23,7 @@ tm._skip_if_no_mpl()
 
 class TestDeprecatedNameSpace(TestPlotBase):
 
-    @slow
+    @pytest.mark.slow
     def test_scatter_plot_legacy(self):
         tm._skip_if_no_scipy()
 
@@ -35,7 +35,7 @@ class TestDeprecatedNameSpace(TestPlotBase):
         with tm.assert_produces_warning(FutureWarning):
             pd.scatter_matrix(df)
 
-    @slow
+    @pytest.mark.slow
     def test_boxplot_deprecated(self):
         df = pd.DataFrame(randn(6, 4),
                           index=list(string.ascii_letters[:6]),
@@ -46,13 +46,13 @@ class TestDeprecatedNameSpace(TestPlotBase):
             plotting.boxplot(df, column=['one', 'two'],
                              by='indic')
 
-    @slow
+    @pytest.mark.slow
     def test_radviz_deprecated(self):
         df = self.iris
         with tm.assert_produces_warning(FutureWarning):
             plotting.radviz(frame=df, class_column='Name')
 
-    @slow
+    @pytest.mark.slow
     def test_plot_params(self):
 
         with tm.assert_produces_warning(FutureWarning):

--- a/pandas/tests/plotting/test_frame.py
+++ b/pandas/tests/plotting/test_frame.py
@@ -15,7 +15,6 @@ from pandas.core.dtypes.api import is_list_like
 from pandas.compat import range, lrange, lmap, lzip, u, zip, PY3
 from pandas.io.formats.printing import pprint_thing
 import pandas.util.testing as tm
-from pandas.util.testing import slow
 
 import numpy as np
 from numpy.random import rand, randn
@@ -41,7 +40,7 @@ class TestDataFramePlots(TestPlotBase):
                                     "C": np.arange(20) + np.random.uniform(
                                         size=20)})
 
-    @slow
+    @pytest.mark.slow
     def test_plot(self):
         df = self.tdf
         _check_plot_works(df.plot, grid=False)
@@ -188,13 +187,13 @@ class TestDataFramePlots(TestPlotBase):
         ax = df.plot()
         assert len(ax.get_lines()) == 1  # B was plotted
 
-    @slow
+    @pytest.mark.slow
     def test_implicit_label(self):
         df = DataFrame(randn(10, 3), columns=['a', 'b', 'c'])
         ax = df.plot(x='a', y='b')
         self._check_text_labels(ax.xaxis.get_label(), 'a')
 
-    @slow
+    @pytest.mark.slow
     def test_donot_overwrite_index_name(self):
         # GH 8494
         df = DataFrame(randn(2, 2), columns=['a', 'b'])
@@ -202,7 +201,7 @@ class TestDataFramePlots(TestPlotBase):
         df.plot(y='b', label='LABEL')
         assert df.index.name == 'NAME'
 
-    @slow
+    @pytest.mark.slow
     def test_plot_xy(self):
         # columns.inferred_type == 'string'
         df = self.tdf
@@ -228,7 +227,7 @@ class TestDataFramePlots(TestPlotBase):
         # columns.inferred_type == 'mixed'
         # TODO add MultiIndex test
 
-    @slow
+    @pytest.mark.slow
     def test_logscales(self):
         df = DataFrame({'a': np.arange(100)}, index=np.arange(100))
         ax = df.plot(logy=True)
@@ -240,7 +239,7 @@ class TestDataFramePlots(TestPlotBase):
         ax = df.plot(loglog=True)
         self._check_ax_scales(ax, xaxis='log', yaxis='log')
 
-    @slow
+    @pytest.mark.slow
     def test_xcompat(self):
         import pandas as pd
 
@@ -305,7 +304,7 @@ class TestDataFramePlots(TestPlotBase):
         rs = Series(rs[:, 1], rs[:, 0], dtype=np.int64, name='y')
         tm.assert_series_equal(rs, df.y)
 
-    @slow
+    @pytest.mark.slow
     def test_subplots(self):
         df = DataFrame(np.random.rand(10, 3),
                        index=list(string.ascii_letters[:10]))
@@ -345,7 +344,7 @@ class TestDataFramePlots(TestPlotBase):
             for ax in axes:
                 assert ax.get_legend() is None
 
-    @slow
+    @pytest.mark.slow
     def test_subplots_timeseries(self):
         idx = date_range(start='2014-07-01', freq='M', periods=10)
         df = DataFrame(np.random.rand(10, 3), index=idx)
@@ -381,7 +380,7 @@ class TestDataFramePlots(TestPlotBase):
                 self._check_ticks_props(ax, xlabelsize=7, xrot=45,
                                         ylabelsize=7)
 
-    @slow
+    @pytest.mark.slow
     def test_subplots_layout(self):
         # GH 6667
         df = DataFrame(np.random.rand(10, 3),
@@ -427,7 +426,7 @@ class TestDataFramePlots(TestPlotBase):
         self._check_axes_shape(axes, axes_num=1, layout=(3, 3))
         assert axes.shape == (3, 3)
 
-    @slow
+    @pytest.mark.slow
     def test_subplots_warnings(self):
         # GH 9464
         warnings.simplefilter('error')
@@ -442,7 +441,7 @@ class TestDataFramePlots(TestPlotBase):
             self.fail(w)
         warnings.simplefilter('default')
 
-    @slow
+    @pytest.mark.slow
     def test_subplots_multiple_axes(self):
         # GH 5353, 6970, GH 7069
         fig, axes = self.plt.subplots(2, 3)
@@ -543,7 +542,7 @@ class TestDataFramePlots(TestPlotBase):
         for ax in axes.ravel():
             self._check_visible(ax.get_yticklabels(), visible=True)
 
-    @slow
+    @pytest.mark.slow
     def test_subplots_dup_columns(self):
         # GH 10962
         df = DataFrame(np.random.rand(5, 5), columns=list('aaaaa'))
@@ -697,7 +696,7 @@ class TestDataFramePlots(TestPlotBase):
             ymin, ymax = ax.get_ylim()
             assert ymax == 0
 
-    @slow
+    @pytest.mark.slow
     def test_bar_colors(self):
         import matplotlib.pyplot as plt
         default_colors = self._maybe_unpack_cycler(plt.rcParams)
@@ -733,7 +732,7 @@ class TestDataFramePlots(TestPlotBase):
         self._check_colors(ax.patches[::5], facecolors=['green'] * 5)
         tm.close()
 
-    @slow
+    @pytest.mark.slow
     def test_bar_linewidth(self):
         df = DataFrame(randn(5, 5))
 
@@ -754,7 +753,7 @@ class TestDataFramePlots(TestPlotBase):
             for r in ax.patches:
                 assert r.get_linewidth() == 2
 
-    @slow
+    @pytest.mark.slow
     def test_bar_barwidth(self):
         df = DataFrame(randn(5, 5))
 
@@ -792,7 +791,7 @@ class TestDataFramePlots(TestPlotBase):
             for r in ax.patches:
                 assert r.get_height() == width
 
-    @slow
+    @pytest.mark.slow
     def test_bar_barwidth_position(self):
         df = DataFrame(randn(5, 5))
         self._check_bar_alignment(df, kind='bar', stacked=False, width=0.9,
@@ -808,7 +807,7 @@ class TestDataFramePlots(TestPlotBase):
         self._check_bar_alignment(df, kind='barh', subplots=True, width=0.9,
                                   position=0.2)
 
-    @slow
+    @pytest.mark.slow
     def test_bar_barwidth_position_int(self):
         # GH 12979
         df = DataFrame(randn(5, 5))
@@ -828,7 +827,7 @@ class TestDataFramePlots(TestPlotBase):
         self._check_bar_alignment(df, kind='bar', subplots=True, width=1)
         self._check_bar_alignment(df, kind='barh', subplots=True, width=1)
 
-    @slow
+    @pytest.mark.slow
     def test_bar_bottom_left(self):
         df = DataFrame(rand(5, 5))
         ax = df.plot.bar(stacked=False, bottom=1)
@@ -857,7 +856,7 @@ class TestDataFramePlots(TestPlotBase):
             result = [p.get_x() for p in ax.patches]
             assert result == [1] * 5
 
-    @slow
+    @pytest.mark.slow
     def test_bar_nan(self):
         df = DataFrame({'A': [10, np.nan, 20],
                         'B': [5, 10, 20],
@@ -875,7 +874,7 @@ class TestDataFramePlots(TestPlotBase):
         expected = [0.0, 0.0, 0.0, 10.0, 0.0, 20.0, 15.0, 10.0, 40.0]
         assert result == expected
 
-    @slow
+    @pytest.mark.slow
     def test_bar_categorical(self):
         # GH 13019
         df1 = pd.DataFrame(np.random.randn(6, 5),
@@ -901,7 +900,7 @@ class TestDataFramePlots(TestPlotBase):
             assert ax.patches[0].get_x() == -0.25
             assert ax.patches[-1].get_x() == 4.75
 
-    @slow
+    @pytest.mark.slow
     def test_plot_scatter(self):
         df = DataFrame(randn(6, 4),
                        index=list(string.ascii_letters[:6]),
@@ -919,7 +918,7 @@ class TestDataFramePlots(TestPlotBase):
         axes = df.plot(x='x', y='y', kind='scatter', subplots=True)
         self._check_axes_shape(axes, axes_num=1, layout=(1, 1))
 
-    @slow
+    @pytest.mark.slow
     def test_plot_scatter_with_categorical_data(self):
         # GH 16199
         df = pd.DataFrame({'x': [1, 2, 3, 4],
@@ -937,7 +936,7 @@ class TestDataFramePlots(TestPlotBase):
             df.plot(x='y', y='y', kind='scatter')
         ve.match('requires x column to be numeric')
 
-    @slow
+    @pytest.mark.slow
     def test_plot_scatter_with_c(self):
         df = DataFrame(randn(6, 4),
                        index=list(string.ascii_letters[:6]),
@@ -1007,7 +1006,7 @@ class TestDataFramePlots(TestPlotBase):
         tm.assert_numpy_array_equal(ax.collections[0].get_facecolor()[0],
                                     np.array([1, 1, 1, 1], dtype=np.float64))
 
-    @slow
+    @pytest.mark.slow
     def test_plot_bar(self):
         df = DataFrame(randn(6, 4),
                        index=list(string.ascii_letters[:6]),
@@ -1098,7 +1097,7 @@ class TestDataFramePlots(TestPlotBase):
 
         return axes
 
-    @slow
+    @pytest.mark.slow
     def test_bar_stacked_center(self):
         # GH2157
         df = DataFrame({'A': [3] * 5, 'B': lrange(5)}, index=lrange(5))
@@ -1107,7 +1106,7 @@ class TestDataFramePlots(TestPlotBase):
         self._check_bar_alignment(df, kind='barh', stacked=True)
         self._check_bar_alignment(df, kind='barh', stacked=True, width=0.9)
 
-    @slow
+    @pytest.mark.slow
     def test_bar_center(self):
         df = DataFrame({'A': [3] * 5, 'B': lrange(5)}, index=lrange(5))
         self._check_bar_alignment(df, kind='bar', stacked=False)
@@ -1115,7 +1114,7 @@ class TestDataFramePlots(TestPlotBase):
         self._check_bar_alignment(df, kind='barh', stacked=False)
         self._check_bar_alignment(df, kind='barh', stacked=False, width=0.9)
 
-    @slow
+    @pytest.mark.slow
     def test_bar_subplots_center(self):
         df = DataFrame({'A': [3] * 5, 'B': lrange(5)}, index=lrange(5))
         self._check_bar_alignment(df, kind='bar', subplots=True)
@@ -1123,7 +1122,7 @@ class TestDataFramePlots(TestPlotBase):
         self._check_bar_alignment(df, kind='barh', subplots=True)
         self._check_bar_alignment(df, kind='barh', subplots=True, width=0.9)
 
-    @slow
+    @pytest.mark.slow
     def test_bar_align_single_column(self):
         df = DataFrame(randn(5))
         self._check_bar_alignment(df, kind='bar', stacked=False)
@@ -1133,7 +1132,7 @@ class TestDataFramePlots(TestPlotBase):
         self._check_bar_alignment(df, kind='bar', subplots=True)
         self._check_bar_alignment(df, kind='barh', subplots=True)
 
-    @slow
+    @pytest.mark.slow
     def test_bar_edge(self):
         df = DataFrame({'A': [3] * 5, 'B': lrange(5)}, index=lrange(5))
 
@@ -1158,7 +1157,7 @@ class TestDataFramePlots(TestPlotBase):
         self._check_bar_alignment(df, kind='barh', subplots=True, width=0.9,
                                   align='edge')
 
-    @slow
+    @pytest.mark.slow
     def test_bar_log_no_subplots(self):
         # GH3254, GH3298 matplotlib/matplotlib#1882, #1892
         # regressions in 1.2.1
@@ -1172,7 +1171,7 @@ class TestDataFramePlots(TestPlotBase):
         ax = df.plot.bar(grid=True, log=True)
         tm.assert_numpy_array_equal(ax.yaxis.get_ticklocs(), expected)
 
-    @slow
+    @pytest.mark.slow
     def test_bar_log_subplots(self):
         expected = np.array([1., 10., 100., 1000.])
         if not self.mpl_le_1_2_1:
@@ -1184,7 +1183,7 @@ class TestDataFramePlots(TestPlotBase):
         tm.assert_numpy_array_equal(ax[0].yaxis.get_ticklocs(), expected)
         tm.assert_numpy_array_equal(ax[1].yaxis.get_ticklocs(), expected)
 
-    @slow
+    @pytest.mark.slow
     def test_boxplot(self):
         df = self.hist_df
         series = df['height']
@@ -1222,7 +1221,7 @@ class TestDataFramePlots(TestPlotBase):
         tm.assert_numpy_array_equal(ax.xaxis.get_ticklocs(), positions)
         assert len(ax.lines) == self.bp_n_objects * len(numeric_cols)
 
-    @slow
+    @pytest.mark.slow
     def test_boxplot_vertical(self):
         df = self.hist_df
         numeric_cols = df._get_numeric_data().columns
@@ -1250,7 +1249,7 @@ class TestDataFramePlots(TestPlotBase):
         tm.assert_numpy_array_equal(ax.yaxis.get_ticklocs(), positions)
         assert len(ax.lines) == self.bp_n_objects * len(numeric_cols)
 
-    @slow
+    @pytest.mark.slow
     def test_boxplot_return_type(self):
         df = DataFrame(randn(6, 4),
                        index=list(string.ascii_letters[:6]),
@@ -1270,7 +1269,7 @@ class TestDataFramePlots(TestPlotBase):
         result = df.plot.box(return_type='both')
         self._check_box_return_type(result, 'both')
 
-    @slow
+    @pytest.mark.slow
     def test_boxplot_subplots_return_type(self):
         df = self.hist_df
 
@@ -1287,7 +1286,7 @@ class TestDataFramePlots(TestPlotBase):
                 expected_keys=['height', 'weight', 'category'],
                 check_ax_title=False)
 
-    @slow
+    @pytest.mark.slow
     def test_kde_df(self):
         tm._skip_if_no_scipy()
         _skip_if_no_scipy_gaussian_kde()
@@ -1308,7 +1307,7 @@ class TestDataFramePlots(TestPlotBase):
         axes = df.plot(kind='kde', logy=True, subplots=True)
         self._check_ax_scales(axes, yaxis='log')
 
-    @slow
+    @pytest.mark.slow
     def test_kde_missing_vals(self):
         tm._skip_if_no_scipy()
         _skip_if_no_scipy_gaussian_kde()
@@ -1316,7 +1315,7 @@ class TestDataFramePlots(TestPlotBase):
         df.loc[0, 0] = np.nan
         _check_plot_works(df.plot, kind='kde')
 
-    @slow
+    @pytest.mark.slow
     def test_hist_df(self):
         from matplotlib.patches import Rectangle
         if self.mpl_le_1_2_1:
@@ -1376,7 +1375,7 @@ class TestDataFramePlots(TestPlotBase):
             tm.assert_numpy_array_equal(result_width, expected_w,
                                         check_dtype=False)
 
-    @slow
+    @pytest.mark.slow
     def test_hist_df_coord(self):
         normal_df = DataFrame({'A': np.repeat(np.array([1, 2, 3, 4, 5]),
                                               np.array([10, 9, 8, 7, 6])),
@@ -1467,12 +1466,12 @@ class TestDataFramePlots(TestPlotBase):
                                       expected_x=np.array([0, 0, 0, 0, 0]),
                                       expected_w=np.array([6, 7, 8, 9, 10]))
 
-    @slow
+    @pytest.mark.slow
     def test_plot_int_columns(self):
         df = DataFrame(randn(100, 4)).cumsum()
         _check_plot_works(df.plot, legend=True)
 
-    @slow
+    @pytest.mark.slow
     def test_df_legend_labels(self):
         kinds = ['line', 'bar', 'barh', 'kde', 'area', 'hist']
         df = DataFrame(rand(3, 3), columns=['a', 'b', 'c'])
@@ -1565,7 +1564,7 @@ class TestDataFramePlots(TestPlotBase):
         leg_title = ax.legend_.get_title()
         self._check_text_labels(leg_title, 'new')
 
-    @slow
+    @pytest.mark.slow
     def test_no_legend(self):
         kinds = ['line', 'bar', 'barh', 'kde', 'area', 'hist']
         df = DataFrame(rand(3, 3), columns=['a', 'b', 'c'])
@@ -1577,7 +1576,7 @@ class TestDataFramePlots(TestPlotBase):
             ax = df.plot(kind=kind, legend=False)
             self._check_legend_labels(ax, visible=False)
 
-    @slow
+    @pytest.mark.slow
     def test_style_by_column(self):
         import matplotlib.pyplot as plt
         fig = plt.gcf()
@@ -1593,7 +1592,7 @@ class TestDataFramePlots(TestPlotBase):
             for i, l in enumerate(ax.get_lines()[:len(markers)]):
                 assert l.get_marker() == markers[i]
 
-    @slow
+    @pytest.mark.slow
     def test_line_label_none(self):
         s = Series([1, 2])
         ax = s.plot()
@@ -1602,7 +1601,7 @@ class TestDataFramePlots(TestPlotBase):
         ax = s.plot(legend=True)
         assert ax.get_legend().get_texts()[0].get_text() == 'None'
 
-    @slow
+    @pytest.mark.slow
     @tm.capture_stdout
     def test_line_colors(self):
         from matplotlib import cm
@@ -1654,13 +1653,13 @@ class TestDataFramePlots(TestPlotBase):
             # Forced show plot
             _check_plot_works(df.plot, color=custom_colors)
 
-    @slow
+    @pytest.mark.slow
     def test_dont_modify_colors(self):
         colors = ['r', 'g', 'b']
         pd.DataFrame(np.random.rand(10, 2)).plot(color=colors)
         assert len(colors) == 3
 
-    @slow
+    @pytest.mark.slow
     def test_line_colors_and_styles_subplots(self):
         # GH 9894
         from matplotlib import cm
@@ -1738,7 +1737,7 @@ class TestDataFramePlots(TestPlotBase):
             self._check_colors(ax.get_lines(), linecolors=[c])
         tm.close()
 
-    @slow
+    @pytest.mark.slow
     def test_area_colors(self):
         from matplotlib import cm
         from matplotlib.collections import PolyCollection
@@ -1798,7 +1797,7 @@ class TestDataFramePlots(TestPlotBase):
         for h in handles:
             assert h.get_alpha() == 0.5
 
-    @slow
+    @pytest.mark.slow
     def test_hist_colors(self):
         default_colors = self._maybe_unpack_cycler(self.plt.rcParams)
 
@@ -1832,7 +1831,7 @@ class TestDataFramePlots(TestPlotBase):
         self._check_colors(ax.patches[::10], facecolors=['green'] * 5)
         tm.close()
 
-    @slow
+    @pytest.mark.slow
     def test_kde_colors(self):
         tm._skip_if_no_scipy()
         _skip_if_no_scipy_gaussian_kde()
@@ -1855,7 +1854,7 @@ class TestDataFramePlots(TestPlotBase):
         rgba_colors = lmap(cm.jet, np.linspace(0, 1, len(df)))
         self._check_colors(ax.get_lines(), linecolors=rgba_colors)
 
-    @slow
+    @pytest.mark.slow
     def test_kde_colors_and_styles_subplots(self):
         tm._skip_if_no_scipy()
         _skip_if_no_scipy_gaussian_kde()
@@ -1914,7 +1913,7 @@ class TestDataFramePlots(TestPlotBase):
             self._check_colors(ax.get_lines(), linecolors=[c])
         tm.close()
 
-    @slow
+    @pytest.mark.slow
     def test_boxplot_colors(self):
         def _check_colors(bp, box_c, whiskers_c, medians_c, caps_c='k',
                           fliers_c=None):
@@ -2025,7 +2024,7 @@ class TestDataFramePlots(TestPlotBase):
             with pytest.raises(TypeError):
                 df.plot(kind=kind)
 
-    @slow
+    @pytest.mark.slow
     def test_partially_invalid_plot_data(self):
         with tm.RNGContext(42):
             df = DataFrame(randn(10, 2), dtype=object)
@@ -2050,7 +2049,7 @@ class TestDataFramePlots(TestPlotBase):
         with pytest.raises(ValueError):
             df.plot(kind='aasdf')
 
-    @slow
+    @pytest.mark.slow
     def test_hexbin_basic(self):
         df = self.hexbin_df
 
@@ -2066,7 +2065,7 @@ class TestDataFramePlots(TestPlotBase):
         # return value is single axes
         self._check_axes_shape(axes, axes_num=1, layout=(1, 1))
 
-    @slow
+    @pytest.mark.slow
     def test_hexbin_with_c(self):
         df = self.hexbin_df
 
@@ -2076,7 +2075,7 @@ class TestDataFramePlots(TestPlotBase):
         ax = df.plot.hexbin(x='A', y='B', C='C', reduce_C_function=np.std)
         assert len(ax.collections) == 1
 
-    @slow
+    @pytest.mark.slow
     def test_hexbin_cmap(self):
         df = self.hexbin_df
 
@@ -2088,14 +2087,14 @@ class TestDataFramePlots(TestPlotBase):
         ax = df.plot.hexbin(x='A', y='B', colormap=cm)
         assert ax.collections[0].cmap.name == cm
 
-    @slow
+    @pytest.mark.slow
     def test_no_color_bar(self):
         df = self.hexbin_df
 
         ax = df.plot.hexbin(x='A', y='B', colorbar=None)
         assert ax.collections[0].colorbar is None
 
-    @slow
+    @pytest.mark.slow
     def test_allow_cmap(self):
         df = self.hexbin_df
 
@@ -2105,7 +2104,7 @@ class TestDataFramePlots(TestPlotBase):
         with pytest.raises(TypeError):
             df.plot.hexbin(x='A', y='B', cmap='YlGn', colormap='BuGn')
 
-    @slow
+    @pytest.mark.slow
     def test_pie_df(self):
         df = DataFrame(np.random.rand(5, 3), columns=['X', 'Y', 'Z'],
                        index=['a', 'b', 'c', 'd', 'e'])
@@ -2159,7 +2158,7 @@ class TestDataFramePlots(TestPlotBase):
             assert ([x.get_text() for x in ax.get_legend().get_texts()] ==
                     base_expected[:i] + base_expected[i + 1:])
 
-    @slow
+    @pytest.mark.slow
     def test_errorbar_plot(self):
         d = {'x': np.arange(12), 'y': np.arange(12, 0, -1)}
         df = DataFrame(d)
@@ -2227,7 +2226,7 @@ class TestDataFramePlots(TestPlotBase):
         with pytest.raises((ValueError, TypeError)):
             df.plot(yerr=df_err)
 
-    @slow
+    @pytest.mark.slow
     def test_errorbar_with_integer_column_names(self):
         # test with integer column names
         df = DataFrame(np.random.randn(10, 2))
@@ -2237,7 +2236,7 @@ class TestDataFramePlots(TestPlotBase):
         ax = _check_plot_works(df.plot, y=0, yerr=1)
         self._check_has_errorbars(ax, xerr=0, yerr=1)
 
-    @slow
+    @pytest.mark.slow
     def test_errorbar_with_partial_columns(self):
         df = DataFrame(np.random.randn(10, 3))
         df_err = DataFrame(np.random.randn(10, 2), columns=[0, 2])
@@ -2260,7 +2259,7 @@ class TestDataFramePlots(TestPlotBase):
             ax = _check_plot_works(df.plot, yerr=err)
             self._check_has_errorbars(ax, xerr=0, yerr=1)
 
-    @slow
+    @pytest.mark.slow
     def test_errorbar_timeseries(self):
 
         d = {'x': np.arange(12), 'y': np.arange(12, 0, -1)}
@@ -2370,7 +2369,7 @@ class TestDataFramePlots(TestPlotBase):
         self._check_has_errorbars(ax, xerr=0, yerr=1)
         _check_errorbar_color(ax.containers, 'green', has_err='has_yerr')
 
-    @slow
+    @pytest.mark.slow
     def test_sharex_and_ax(self):
         # https://github.com/pandas-dev/pandas/issues/9737 using gridspec,
         # the axis in fig.get_axis() are sorted differently than pandas
@@ -2422,7 +2421,7 @@ class TestDataFramePlots(TestPlotBase):
             self._check_visible(ax.get_xticklabels(minor=True), visible=True)
         tm.close()
 
-    @slow
+    @pytest.mark.slow
     def test_sharey_and_ax(self):
         # https://github.com/pandas-dev/pandas/issues/9737 using gridspec,
         # the axis in fig.get_axis() are sorted differently than pandas
@@ -2505,7 +2504,7 @@ class TestDataFramePlots(TestPlotBase):
                 # need to actually access something to get an error
                 results[key].lines
 
-    @slow
+    @pytest.mark.slow
     def test_df_subplots_patterns_minorticks(self):
         # GH 10657
         import matplotlib.pyplot as plt
@@ -2550,7 +2549,7 @@ class TestDataFramePlots(TestPlotBase):
             self._check_visible(ax.get_xticklabels(minor=True), visible=True)
         tm.close()
 
-    @slow
+    @pytest.mark.slow
     def test_df_gridspec_patterns(self):
         # GH 10819
         import matplotlib.pyplot as plt
@@ -2673,7 +2672,7 @@ class TestDataFramePlots(TestPlotBase):
             self._check_visible(ax.get_xticklabels(minor=True), visible=True)
         tm.close()
 
-    @slow
+    @pytest.mark.slow
     def test_df_grid_settings(self):
         # Make sure plot defaults to rcParams['axes.grid'] setting, GH 9792
         self._check_grid_settings(

--- a/pandas/tests/plotting/test_hist_method.py
+++ b/pandas/tests/plotting/test_hist_method.py
@@ -6,7 +6,6 @@ import pytest
 
 from pandas import Series, DataFrame
 import pandas.util.testing as tm
-from pandas.util.testing import slow
 
 import numpy as np
 from numpy.random import randn
@@ -28,7 +27,7 @@ class TestSeriesPlots(TestPlotBase):
         self.ts = tm.makeTimeSeries()
         self.ts.name = 'ts'
 
-    @slow
+    @pytest.mark.slow
     def test_hist_legacy(self):
         _check_plot_works(self.ts.hist)
         _check_plot_works(self.ts.hist, grid=False)
@@ -52,13 +51,13 @@ class TestSeriesPlots(TestPlotBase):
         with pytest.raises(ValueError):
             self.ts.hist(by=self.ts.index, figure=fig)
 
-    @slow
+    @pytest.mark.slow
     def test_hist_bins_legacy(self):
         df = DataFrame(np.random.randn(10, 2))
         ax = df.hist(bins=2)[0][0]
         assert len(ax.patches) == 2
 
-    @slow
+    @pytest.mark.slow
     def test_hist_layout(self):
         df = self.hist_df
         with pytest.raises(ValueError):
@@ -67,7 +66,7 @@ class TestSeriesPlots(TestPlotBase):
         with pytest.raises(ValueError):
             df.height.hist(layout=[1, 1])
 
-    @slow
+    @pytest.mark.slow
     def test_hist_layout_with_by(self):
         df = self.hist_df
 
@@ -113,7 +112,7 @@ class TestSeriesPlots(TestPlotBase):
         self._check_axes_shape(
             axes, axes_num=4, layout=(4, 2), figsize=(12, 7))
 
-    @slow
+    @pytest.mark.slow
     def test_hist_no_overlap(self):
         from matplotlib.pyplot import subplot, gcf
         x = Series(randn(2))
@@ -126,13 +125,13 @@ class TestSeriesPlots(TestPlotBase):
         axes = fig.axes if self.mpl_ge_1_5_0 else fig.get_axes()
         assert len(axes) == 2
 
-    @slow
+    @pytest.mark.slow
     def test_hist_by_no_extra_plots(self):
         df = self.hist_df
         axes = df.height.hist(by=df.gender)  # noqa
         assert len(self.plt.get_fignums()) == 1
 
-    @slow
+    @pytest.mark.slow
     def test_plot_fails_when_ax_differs_from_figure(self):
         from pylab import figure
         fig1 = figure()
@@ -144,7 +143,7 @@ class TestSeriesPlots(TestPlotBase):
 
 class TestDataFramePlots(TestPlotBase):
 
-    @slow
+    @pytest.mark.slow
     def test_hist_df_legacy(self):
         from matplotlib.patches import Rectangle
         with tm.assert_produces_warning(UserWarning):
@@ -210,7 +209,7 @@ class TestDataFramePlots(TestPlotBase):
         with pytest.raises(AttributeError):
             ser.hist(foo='bar')
 
-    @slow
+    @pytest.mark.slow
     def test_hist_layout(self):
         df = DataFrame(randn(100, 3))
 
@@ -241,7 +240,7 @@ class TestDataFramePlots(TestPlotBase):
         with pytest.raises(ValueError):
             df.hist(layout=(-1, -1))
 
-    @slow
+    @pytest.mark.slow
     # GH 9351
     def test_tight_layout(self):
         if self.mpl_ge_2_0_1:
@@ -254,7 +253,7 @@ class TestDataFramePlots(TestPlotBase):
 
 class TestDataFrameGroupByPlots(TestPlotBase):
 
-    @slow
+    @pytest.mark.slow
     def test_grouped_hist_legacy(self):
         from matplotlib.patches import Rectangle
 
@@ -303,7 +302,7 @@ class TestDataFrameGroupByPlots(TestPlotBase):
         with tm.assert_produces_warning(FutureWarning):
             df.hist(by='C', figsize='default')
 
-    @slow
+    @pytest.mark.slow
     def test_grouped_hist_legacy2(self):
         n = 10
         weight = Series(np.random.normal(166, 20, size=n))
@@ -318,7 +317,7 @@ class TestDataFrameGroupByPlots(TestPlotBase):
         assert len(self.plt.get_fignums()) == 2
         tm.close()
 
-    @slow
+    @pytest.mark.slow
     def test_grouped_hist_layout(self):
         df = self.hist_df
         pytest.raises(ValueError, df.hist, column='weight', by=df.gender,
@@ -367,7 +366,7 @@ class TestDataFrameGroupByPlots(TestPlotBase):
         axes = df.hist(column=['height', 'weight', 'category'])
         self._check_axes_shape(axes, axes_num=3, layout=(2, 2))
 
-    @slow
+    @pytest.mark.slow
     def test_grouped_hist_multiple_axes(self):
         # GH 6970, GH 7069
         df = self.hist_df
@@ -387,7 +386,7 @@ class TestDataFrameGroupByPlots(TestPlotBase):
             # pass different number of axes from required
             axes = df.hist(column='height', ax=axes)
 
-    @slow
+    @pytest.mark.slow
     def test_axis_share_x(self):
         df = self.hist_df
         # GH4089
@@ -401,7 +400,7 @@ class TestDataFrameGroupByPlots(TestPlotBase):
         assert not ax1._shared_y_axes.joined(ax1, ax2)
         assert not ax2._shared_y_axes.joined(ax1, ax2)
 
-    @slow
+    @pytest.mark.slow
     def test_axis_share_y(self):
         df = self.hist_df
         ax1, ax2 = df.hist(column='height', by=df.gender, sharey=True)
@@ -414,7 +413,7 @@ class TestDataFrameGroupByPlots(TestPlotBase):
         assert not ax1._shared_x_axes.joined(ax1, ax2)
         assert not ax2._shared_x_axes.joined(ax1, ax2)
 
-    @slow
+    @pytest.mark.slow
     def test_axis_share_xy(self):
         df = self.hist_df
         ax1, ax2 = df.hist(column='height', by=df.gender, sharex=True,

--- a/pandas/tests/plotting/test_misc.py
+++ b/pandas/tests/plotting/test_misc.py
@@ -7,7 +7,6 @@ import pytest
 from pandas import Series, DataFrame
 from pandas.compat import lmap
 import pandas.util.testing as tm
-from pandas.util.testing import slow
 
 import numpy as np
 from numpy import random
@@ -30,7 +29,7 @@ class TestSeriesPlots(TestPlotBase):
         self.ts = tm.makeTimeSeries()
         self.ts.name = 'ts'
 
-    @slow
+    @pytest.mark.slow
     def test_autocorrelation_plot(self):
         from pandas.plotting import autocorrelation_plot
         _check_plot_works(autocorrelation_plot, series=self.ts)
@@ -39,13 +38,13 @@ class TestSeriesPlots(TestPlotBase):
         ax = autocorrelation_plot(self.ts, label='Test')
         self._check_legend_labels(ax, labels=['Test'])
 
-    @slow
+    @pytest.mark.slow
     def test_lag_plot(self):
         from pandas.plotting import lag_plot
         _check_plot_works(lag_plot, series=self.ts)
         _check_plot_works(lag_plot, series=self.ts, lag=5)
 
-    @slow
+    @pytest.mark.slow
     def test_bootstrap_plot(self):
         from pandas.plotting import bootstrap_plot
         _check_plot_works(bootstrap_plot, series=self.ts, size=10)
@@ -53,7 +52,7 @@ class TestSeriesPlots(TestPlotBase):
 
 class TestDataFramePlots(TestPlotBase):
 
-    @slow
+    @pytest.mark.slow
     def test_scatter_plot_legacy(self):
         tm._skip_if_no_scipy()
 
@@ -130,7 +129,7 @@ class TestDataFramePlots(TestPlotBase):
         self._check_ticks_props(
             axes, xlabelsize=8, xrot=90, ylabelsize=8, yrot=0)
 
-    @slow
+    @pytest.mark.slow
     def test_andrews_curves(self):
         from pandas.plotting import andrews_curves
         from matplotlib import cm
@@ -195,7 +194,7 @@ class TestDataFramePlots(TestPlotBase):
         with tm.assert_produces_warning(FutureWarning):
             andrews_curves(data=df, class_column='Name')
 
-    @slow
+    @pytest.mark.slow
     def test_parallel_coordinates(self):
         from pandas.plotting import parallel_coordinates
         from matplotlib import cm
@@ -263,7 +262,7 @@ class TestDataFramePlots(TestPlotBase):
             # lables and colors are ordered strictly increasing
             assert prev[1] < nxt[1] and prev[0] < nxt[0]
 
-    @slow
+    @pytest.mark.slow
     def test_radviz(self):
         from pandas.plotting import radviz
         from matplotlib import cm
@@ -301,7 +300,7 @@ class TestDataFramePlots(TestPlotBase):
         handles, labels = ax.get_legend_handles_labels()
         self._check_colors(handles, facecolors=colors)
 
-    @slow
+    @pytest.mark.slow
     def test_subplot_titles(self):
         df = self.iris.drop('Name', axis=1).head()
         # Use the column names as the subplot titles

--- a/pandas/tests/plotting/test_series.py
+++ b/pandas/tests/plotting/test_series.py
@@ -12,7 +12,6 @@ import pandas as pd
 from pandas import Series, DataFrame, date_range
 from pandas.compat import range, lrange
 import pandas.util.testing as tm
-from pandas.util.testing import slow
 
 import numpy as np
 from numpy.random import randn
@@ -41,7 +40,7 @@ class TestSeriesPlots(TestPlotBase):
         self.iseries = tm.makePeriodSeries()
         self.iseries.name = 'iseries'
 
-    @slow
+    @pytest.mark.slow
     def test_plot(self):
         _check_plot_works(self.ts.plot, label='foo')
         _check_plot_works(self.ts.plot, use_index=False)
@@ -79,7 +78,7 @@ class TestSeriesPlots(TestPlotBase):
         ax = _check_plot_works(self.ts.plot, subplots=True, layout=(1, -1))
         self._check_axes_shape(ax, axes_num=1, layout=(1, 1))
 
-    @slow
+    @pytest.mark.slow
     def test_plot_figsize_and_title(self):
         # figsize and title
         _, ax = self.plt.subplots()
@@ -210,7 +209,7 @@ class TestSeriesPlots(TestPlotBase):
         label2 = ax2.get_xlabel()
         assert label2 == ''
 
-    @slow
+    @pytest.mark.slow
     def test_bar_log(self):
         expected = np.array([1., 10., 100., 1000.])
 
@@ -252,7 +251,7 @@ class TestSeriesPlots(TestPlotBase):
         tm.assert_almost_equal(res[1], ymax)
         tm.assert_numpy_array_equal(ax.xaxis.get_ticklocs(), expected)
 
-    @slow
+    @pytest.mark.slow
     def test_bar_ignore_index(self):
         df = Series([1, 2, 3, 4], index=['a', 'b', 'c', 'd'])
         _, ax = self.plt.subplots()
@@ -280,7 +279,7 @@ class TestSeriesPlots(TestPlotBase):
         ax.set_xlim('1/1/1999', '1/1/2001')
         assert xp == ax.get_xlim()[0]
 
-    @slow
+    @pytest.mark.slow
     def test_pie_series(self):
         # if sum of values is less than 1.0, pie handle them as rate and draw
         # semicircle.
@@ -339,14 +338,14 @@ class TestSeriesPlots(TestPlotBase):
         result = [x.get_text() for x in ax.texts]
         assert result == expected
 
-    @slow
+    @pytest.mark.slow
     def test_hist_df_kwargs(self):
         df = DataFrame(np.random.randn(10, 2))
         _, ax = self.plt.subplots()
         ax = df.plot.hist(bins=5, ax=ax)
         assert len(ax.patches) == 10
 
-    @slow
+    @pytest.mark.slow
     def test_hist_df_with_nonnumerics(self):
         # GH 9853
         with tm.RNGContext(1):
@@ -361,7 +360,7 @@ class TestSeriesPlots(TestPlotBase):
         ax = df.plot.hist(ax=ax)  # bins=10
         assert len(ax.patches) == 40
 
-    @slow
+    @pytest.mark.slow
     def test_hist_legacy(self):
         _check_plot_works(self.ts.hist)
         _check_plot_works(self.ts.hist, grid=False)
@@ -387,13 +386,13 @@ class TestSeriesPlots(TestPlotBase):
         with pytest.raises(ValueError):
             self.ts.hist(by=self.ts.index, figure=fig)
 
-    @slow
+    @pytest.mark.slow
     def test_hist_bins_legacy(self):
         df = DataFrame(np.random.randn(10, 2))
         ax = df.hist(bins=2)[0][0]
         assert len(ax.patches) == 2
 
-    @slow
+    @pytest.mark.slow
     def test_hist_layout(self):
         df = self.hist_df
         with pytest.raises(ValueError):
@@ -402,7 +401,7 @@ class TestSeriesPlots(TestPlotBase):
         with pytest.raises(ValueError):
             df.height.hist(layout=[1, 1])
 
-    @slow
+    @pytest.mark.slow
     def test_hist_layout_with_by(self):
         df = self.hist_df
 
@@ -446,7 +445,7 @@ class TestSeriesPlots(TestPlotBase):
         self._check_axes_shape(axes, axes_num=4, layout=(4, 2),
                                figsize=(12, 7))
 
-    @slow
+    @pytest.mark.slow
     def test_hist_no_overlap(self):
         from matplotlib.pyplot import subplot, gcf
         x = Series(randn(2))
@@ -459,7 +458,7 @@ class TestSeriesPlots(TestPlotBase):
         axes = fig.axes if self.mpl_ge_1_5_0 else fig.get_axes()
         assert len(axes) == 2
 
-    @slow
+    @pytest.mark.slow
     def test_hist_secondary_legend(self):
         # GH 9610
         df = DataFrame(np.random.randn(30, 4), columns=list('abcd'))
@@ -499,7 +498,7 @@ class TestSeriesPlots(TestPlotBase):
         assert ax.get_yaxis().get_visible()
         tm.close()
 
-    @slow
+    @pytest.mark.slow
     def test_df_series_secondary_legend(self):
         # GH 9779
         df = DataFrame(np.random.randn(30, 3), columns=list('abc'))
@@ -563,14 +562,14 @@ class TestSeriesPlots(TestPlotBase):
         assert ax.get_yaxis().get_visible()
         tm.close()
 
-    @slow
+    @pytest.mark.slow
     def test_plot_fails_with_dupe_color_and_style(self):
         x = Series(randn(2))
         with pytest.raises(ValueError):
             _, ax = self.plt.subplots()
             x.plot(style='k--', color='k', ax=ax)
 
-    @slow
+    @pytest.mark.slow
     def test_hist_kde(self):
         _, ax = self.plt.subplots()
         ax = self.ts.plot.hist(logy=True, ax=ax)
@@ -593,7 +592,7 @@ class TestSeriesPlots(TestPlotBase):
         ylabels = ax.get_yticklabels()
         self._check_text_labels(ylabels, [''] * len(ylabels))
 
-    @slow
+    @pytest.mark.slow
     def test_kde_kwargs(self):
         tm._skip_if_no_scipy()
         _skip_if_no_scipy_gaussian_kde()
@@ -608,7 +607,7 @@ class TestSeriesPlots(TestPlotBase):
         self._check_ax_scales(ax, yaxis='log')
         self._check_text_labels(ax.yaxis.get_label(), 'Density')
 
-    @slow
+    @pytest.mark.slow
     def test_kde_missing_vals(self):
         tm._skip_if_no_scipy()
         _skip_if_no_scipy_gaussian_kde()
@@ -619,7 +618,7 @@ class TestSeriesPlots(TestPlotBase):
         # gh-14821: check if the values have any missing values
         assert any(~np.isnan(axes.lines[0].get_xdata()))
 
-    @slow
+    @pytest.mark.slow
     def test_hist_kwargs(self):
         _, ax = self.plt.subplots()
         ax = self.ts.plot.hist(bins=5, ax=ax)
@@ -637,7 +636,7 @@ class TestSeriesPlots(TestPlotBase):
             ax = self.ts.plot.hist(align='left', stacked=True, ax=ax)
             tm.close()
 
-    @slow
+    @pytest.mark.slow
     def test_hist_kde_color(self):
         _, ax = self.plt.subplots()
         ax = self.ts.plot.hist(logy=True, bins=10, color='b', ax=ax)
@@ -654,7 +653,7 @@ class TestSeriesPlots(TestPlotBase):
         assert len(lines) == 1
         self._check_colors(lines, ['r'])
 
-    @slow
+    @pytest.mark.slow
     def test_boxplot_series(self):
         _, ax = self.plt.subplots()
         ax = self.ts.plot.box(logy=True, ax=ax)
@@ -664,7 +663,7 @@ class TestSeriesPlots(TestPlotBase):
         ylabels = ax.get_yticklabels()
         self._check_text_labels(ylabels, [''] * len(ylabels))
 
-    @slow
+    @pytest.mark.slow
     def test_kind_both_ways(self):
         s = Series(range(3))
         kinds = (plotting._core._common_kinds +
@@ -676,7 +675,7 @@ class TestSeriesPlots(TestPlotBase):
             s.plot(kind=kind, ax=ax)
             getattr(s.plot, kind)()
 
-    @slow
+    @pytest.mark.slow
     def test_invalid_plot_data(self):
         s = Series(list('abcd'))
         _, ax = self.plt.subplots()
@@ -686,7 +685,7 @@ class TestSeriesPlots(TestPlotBase):
             with pytest.raises(TypeError):
                 s.plot(kind=kind, ax=ax)
 
-    @slow
+    @pytest.mark.slow
     def test_valid_object_plot(self):
         s = Series(lrange(10), dtype=object)
         for kind in plotting._core._common_kinds:
@@ -708,7 +707,7 @@ class TestSeriesPlots(TestPlotBase):
         with pytest.raises(ValueError):
             s.plot(kind='aasdf')
 
-    @slow
+    @pytest.mark.slow
     def test_dup_datetime_index_plot(self):
         dr1 = date_range('1/1/2009', periods=4)
         dr2 = date_range('1/2/2009', periods=4)
@@ -717,7 +716,7 @@ class TestSeriesPlots(TestPlotBase):
         s = Series(values, index=index)
         _check_plot_works(s.plot)
 
-    @slow
+    @pytest.mark.slow
     def test_errorbar_plot(self):
 
         s = Series(np.arange(10), name='x')
@@ -764,14 +763,14 @@ class TestSeriesPlots(TestPlotBase):
         _check_plot_works(self.series.plot, table=True)
         _check_plot_works(self.series.plot, table=self.series)
 
-    @slow
+    @pytest.mark.slow
     def test_series_grid_settings(self):
         # Make sure plot defaults to rcParams['axes.grid'] setting, GH 9792
         self._check_grid_settings(Series([1, 2, 3]),
                                   plotting._core._series_kinds +
                                   plotting._core._common_kinds)
 
-    @slow
+    @pytest.mark.slow
     def test_standard_colors(self):
         from pandas.plotting._style import _get_standard_colors
 
@@ -788,7 +787,7 @@ class TestSeriesPlots(TestPlotBase):
             result = _get_standard_colors(3, color=[c])
             assert result == [c] * 3
 
-    @slow
+    @pytest.mark.slow
     def test_standard_colors_all(self):
         import matplotlib.colors as colors
         from pandas.plotting._style import _get_standard_colors

--- a/pandas/tests/series/test_indexing.py
+++ b/pandas/tests/series/test_indexing.py
@@ -20,8 +20,7 @@ from pandas._libs import tslib, lib
 
 from pandas.compat import lrange, range
 from pandas import compat
-from pandas.util.testing import (slow,
-                                 assert_series_equal,
+from pandas.util.testing import (assert_series_equal,
                                  assert_almost_equal,
                                  assert_frame_equal)
 import pandas.util.testing as tm
@@ -2592,7 +2591,7 @@ class TestDatetimeIndexing(object):
         # s2 = s.set_value(dates[1], index[1])
         # assert s2.values.dtype == 'M8[ns]'
 
-    @slow
+    @pytest.mark.slow
     def test_slice_locs_indexerror(self):
         times = [datetime(2000, 1, 1) + timedelta(minutes=i * 10)
                  for i in range(100000)]

--- a/pandas/tests/test_expressions.py
+++ b/pandas/tests/test_expressions.py
@@ -16,7 +16,7 @@ from pandas.core.computation import expressions as expr
 from pandas import compat, _np_version_under1p11, _np_version_under1p13
 from pandas.util.testing import (assert_almost_equal, assert_series_equal,
                                  assert_frame_equal, assert_panel_equal,
-                                 assert_panel4d_equal, slow)
+                                 assert_panel4d_equal)
 from pandas.io.formats.printing import pprint_thing
 import pandas.util.testing as tm
 
@@ -196,7 +196,7 @@ class TestExpressions(object):
     def test_integer_arithmetic_series(self):
         self.run_series(self.integer.iloc[:, 0], self.integer.iloc[:, 0])
 
-    @slow
+    @pytest.mark.slow
     def test_integer_panel(self):
         self.run_panel(_integer2_panel, np.random.randint(1, 100))
 
@@ -206,11 +206,11 @@ class TestExpressions(object):
     def test_float_arithmetic_series(self):
         self.run_series(self.frame2.iloc[:, 0], self.frame2.iloc[:, 0])
 
-    @slow
+    @pytest.mark.slow
     def test_float_panel(self):
         self.run_panel(_frame2_panel, np.random.randn() + 0.1, binary_comp=0.8)
 
-    @slow
+    @pytest.mark.slow
     def test_panel4d(self):
         with catch_warnings(record=True):
             self.run_panel(tm.makePanel4D(), np.random.randn() + 0.5,
@@ -226,7 +226,7 @@ class TestExpressions(object):
         for col in self.mixed2.columns:
             self.run_series(self.mixed2[col], self.mixed2[col], binary_comp=4)
 
-    @slow
+    @pytest.mark.slow
     def test_mixed_panel(self):
         self.run_panel(_mixed2_panel, np.random.randint(1, 100),
                        binary_comp=-2)

--- a/pandas/tests/test_window.py
+++ b/pandas/tests/test_window.py
@@ -2120,7 +2120,7 @@ class TestMomentsConsistency(Base):
                                 assert_equal(cov_x_y, mean_x_times_y -
                                              (mean_x * mean_y))
 
-    @tm.slow
+    @pytest.mark.slow
     def test_ewm_consistency(self):
         def _weights(s, com, adjust, ignore_na):
             if isinstance(s, DataFrame):
@@ -2219,7 +2219,7 @@ class TestMomentsConsistency(Base):
                     _variance_debiasing_factors(x, com=com, adjust=adjust,
                                                 ignore_na=ignore_na)))
 
-    @tm.slow
+    @pytest.mark.slow
     def test_expanding_consistency(self):
 
         # suppress warnings about empty slices, as we are deliberately testing
@@ -2293,7 +2293,7 @@ class TestMomentsConsistency(Base):
                             assert_equal(expanding_f_result,
                                          expanding_apply_f_result)
 
-    @tm.slow
+    @pytest.mark.slow
     def test_rolling_consistency(self):
 
         # suppress warnings about empty slices, as we are deliberately testing

--- a/pandas/util/testing.py
+++ b/pandas/util/testing.py
@@ -50,13 +50,6 @@ from pandas import (bdate_range, CategoricalIndex, Categorical, IntervalIndex,
 
 from pandas._libs import testing as _testing
 from pandas.io.common import urlopen
-try:
-    import pytest
-    slow = pytest.mark.slow
-except ImportError:
-    # Should be ok to just ignore. If you actually need
-    # slow then you'll hit an import error long before getting here.
-    pass
 
 
 N = 30


### PR DESCRIPTION
And just use @pytest.mark.slow instead

closes #16850