### PR TITLE
MAINT: Drop the get_offset_name method

### DIFF
--- a/doc/source/whatsnew/v0.21.0.txt
+++ b/doc/source/whatsnew/v0.21.0.txt
@@ -126,6 +126,7 @@ Removal of prior version deprecations/changes
 - ``Index`` has dropped the ``.sym_diff()`` method in favor of ``.symmetric_difference()`` (:issue:`12591`)
 - ``Categorical`` has dropped the ``.order()`` and ``.sort()`` methods in favor of ``.sort_values()`` (:issue:`12882`)
 - :func:`eval` and :method:`DataFrame.eval` have changed the default of ``inplace`` from ``None`` to ``False`` (:issue:`11149`)
+- The function ``get_offset_name`` has been dropped in favor of the ``.freqstr`` attribute for an offset (:issue:`11834`)
 
 
 .. _whatsnew_0210.performance:

--- a/pandas/tseries/frequencies.py
+++ b/pandas/tseries/frequencies.py
@@ -637,20 +637,6 @@ def get_offset(name):
 getOffset = get_offset
 
 
-def get_offset_name(offset):
-    """
-    Return rule name associated with a DateOffset object
-
-    Examples
-    --------
-    get_offset_name(BMonthEnd(1)) --> 'EOM'
-    """
-
-    msg = "get_offset_name(offset) is deprecated. Use offset.freqstr instead"
-    warnings.warn(msg, FutureWarning, stacklevel=2)
-    return offset.freqstr
-
-
 def get_standard_freq(freq):
     """
     Return the standardized frequency string


### PR DESCRIPTION
Deprecated since 0.18.0

xref #11834 ( :-1: for no test being added for its deprecation back then! :smile:)
