### PR TITLE
Add shebangs to pyx/pxd/pyx.in files

### DIFF
--- a/pandas/_libs/algos.pxd
+++ b/pandas/_libs/algos.pxd
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
 from util cimport numeric
 from numpy cimport float64_t, double_t
 

--- a/pandas/_libs/algos.pyx
+++ b/pandas/_libs/algos.pyx
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
 # cython: profile=False
 
 from numpy cimport *

--- a/pandas/_libs/algos_common_helper.pxi.in
+++ b/pandas/_libs/algos_common_helper.pxi.in
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
 """
 Template for each `dtype` helper function using 1-d template
 

--- a/pandas/_libs/algos_rank_helper.pxi.in
+++ b/pandas/_libs/algos_rank_helper.pxi.in
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
 """
 Template for each `dtype` helper function for rank
 

--- a/pandas/_libs/algos_take_helper.pxi.in
+++ b/pandas/_libs/algos_take_helper.pxi.in
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
 """
 Template for each `dtype` helper function for take
 

--- a/pandas/_libs/groupby.pyx
+++ b/pandas/_libs/groupby.pyx
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
 # cython: profile=False
 
 from numpy cimport *

--- a/pandas/_libs/groupby_helper.pxi.in
+++ b/pandas/_libs/groupby_helper.pxi.in
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
 """
 Template for each `dtype` helper function using groupby
 

--- a/pandas/_libs/hashing.pyx
+++ b/pandas/_libs/hashing.pyx
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
 # cython: profile=False
 # Translated from the reference implementation
 # at https://github.com/veorq/SipHash

--- a/pandas/_libs/hashtable.pxd
+++ b/pandas/_libs/hashtable.pxd
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
 from khash cimport (kh_int64_t, kh_uint64_t, kh_float64_t, kh_pymap_t,
                     kh_str_t, uint64_t, int64_t, float64_t)
 from numpy cimport ndarray

--- a/pandas/_libs/hashtable.pyx
+++ b/pandas/_libs/hashtable.pyx
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
 # cython: profile=False
 
 from cpython cimport PyObject, Py_INCREF, PyList_Check, PyTuple_Check

--- a/pandas/_libs/hashtable_class_helper.pxi.in
+++ b/pandas/_libs/hashtable_class_helper.pxi.in
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
 """
 Template for each `dtype` helper function for hashtable
 

--- a/pandas/_libs/hashtable_func_helper.pxi.in
+++ b/pandas/_libs/hashtable_func_helper.pxi.in
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
 """
 Template for each `dtype` helper function for hashtable
 

--- a/pandas/_libs/index.pyx
+++ b/pandas/_libs/index.pyx
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
 # cython: profile=False
 
 from numpy cimport ndarray

--- a/pandas/_libs/index_class_helper.pxi.in
+++ b/pandas/_libs/index_class_helper.pxi.in
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
 """
 Template for functions of IndexEngine subclasses.
 

--- a/pandas/_libs/interval.pyx
+++ b/pandas/_libs/interval.pyx
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
 cimport numpy as np
 import numpy as np
 import pandas as pd

--- a/pandas/_libs/intervaltree.pxi.in
+++ b/pandas/_libs/intervaltree.pxi.in
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
 """
 Template for intervaltree
 

--- a/pandas/_libs/join.pyx
+++ b/pandas/_libs/join.pyx
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
 # cython: profile=False
 
 from numpy cimport *

--- a/pandas/_libs/join_func_helper.pxi.in
+++ b/pandas/_libs/join_func_helper.pxi.in
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
 # cython: boundscheck=False, wraparound=False
 """
 Template for each `dtype` helper function for hashtable

--- a/pandas/_libs/join_helper.pxi.in
+++ b/pandas/_libs/join_helper.pxi.in
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
 """
 Template for each `dtype` helper function for join
 

--- a/pandas/_libs/lib.pxd
+++ b/pandas/_libs/lib.pxd
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
 # prototypes for sharing
 
 cdef bint is_null_datetimelike(v)

--- a/pandas/_libs/lib.pyx
+++ b/pandas/_libs/lib.pyx
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
 # cython: profile=False
 cimport numpy as np
 cimport cython

--- a/pandas/_libs/parsers.pyx
+++ b/pandas/_libs/parsers.pyx
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
 # Copyright (c) 2012, Lambda Foundry, Inc.
 # See LICENSE for the license
 

--- a/pandas/_libs/period.pyx
+++ b/pandas/_libs/period.pyx
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
 from datetime import datetime, date, timedelta
 import operator
 

--- a/pandas/_libs/reshape.pyx
+++ b/pandas/_libs/reshape.pyx
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
 # cython: profile=False
 
 from numpy cimport *

--- a/pandas/_libs/reshape_helper.pxi.in
+++ b/pandas/_libs/reshape_helper.pxi.in
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
 """
 Template for each `dtype` helper function for take
 

--- a/pandas/_libs/sparse.pyx
+++ b/pandas/_libs/sparse.pyx
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
 from numpy cimport (ndarray, uint8_t, int64_t, int32_t, int16_t, int8_t,
                     float64_t, float32_t, float16_t)
 cimport numpy as np

--- a/pandas/_libs/sparse_op_helper.pxi.in
+++ b/pandas/_libs/sparse_op_helper.pxi.in
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
 """
 Template for each `dtype` helper function for sparse ops
 

--- a/pandas/_libs/src/datetime.pxd
+++ b/pandas/_libs/src/datetime.pxd
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
 # cython: profile=False
 from numpy cimport int64_t, int32_t, npy_int64, npy_int32, ndarray
 from cpython cimport PyObject

--- a/pandas/_libs/src/inference.pyx
+++ b/pandas/_libs/src/inference.pyx
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
 import sys
 from decimal import Decimal
 cimport util

--- a/pandas/_libs/src/khash.pxd
+++ b/pandas/_libs/src/khash.pxd
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
 from cpython cimport PyObject
 from numpy cimport int64_t, uint64_t, int32_t, uint32_t, float64_t
 

--- a/pandas/_libs/src/numpy.pxd
+++ b/pandas/_libs/src/numpy.pxd
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
 # NumPy static imports for Cython
 #
 # If any of the PyArray_* functions are called, import_array must be

--- a/pandas/_libs/src/offsets.pyx
+++ b/pandas/_libs/src/offsets.pyx
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
 
 ctypedef enum time_res:
     r_min = 0

--- a/pandas/_libs/src/properties.pyx
+++ b/pandas/_libs/src/properties.pyx
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
 from cpython cimport PyDict_Contains, PyDict_GetItem, PyDict_GetItem
 
 

--- a/pandas/_libs/src/reduce.pyx
+++ b/pandas/_libs/src/reduce.pyx
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
 #cython=False
 from numpy cimport *
 import numpy as np

--- a/pandas/_libs/src/skiplist.pxd
+++ b/pandas/_libs/src/skiplist.pxd
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
 cdef extern from "skiplist.h":
     ctypedef struct node_t:
         node_t **next

--- a/pandas/_libs/src/skiplist.pyx
+++ b/pandas/_libs/src/skiplist.pyx
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
 # Cython version of IndexableSkiplist, for implementing moving median
 # with O(log n) updates
 # Original author: Raymond Hettinger

--- a/pandas/_libs/src/util.pxd
+++ b/pandas/_libs/src/util.pxd
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
 from numpy cimport ndarray
 cimport numpy as cnp
 cimport cpython

--- a/pandas/_libs/testing.pyx
+++ b/pandas/_libs/testing.pyx
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
 import numpy as np
 
 from pandas import compat

--- a/pandas/_libs/tslib.pxd
+++ b/pandas/_libs/tslib.pxd
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
 from numpy cimport ndarray, int64_t
 
 cdef convert_to_tsobject(object, object, object, bint, bint)

--- a/pandas/_libs/tslib.pyx
+++ b/pandas/_libs/tslib.pyx
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
 # cython: profile=False
 
 import warnings

--- a/pandas/_libs/window.pyx
+++ b/pandas/_libs/window.pyx
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
 # cython: profile=False
 # cython: boundscheck=False, wraparound=False, cdivision=True
 

--- a/pandas/io/msgpack/_packer.pyx
+++ b/pandas/io/msgpack/_packer.pyx
@@ -1,4 +1,5 @@
-# coding: utf-8
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
 #cython: embedsignature=True
 
 from cpython cimport *

--- a/pandas/io/msgpack/_unpacker.pyx
+++ b/pandas/io/msgpack/_unpacker.pyx
@@ -1,4 +1,5 @@
-# coding: utf-8
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
 #cython: embedsignature=True
 
 from cpython cimport *

--- a/pandas/io/sas/sas.pyx
+++ b/pandas/io/sas/sas.pyx
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
 # cython: profile=False
 # cython: boundscheck=False, initializedcheck=False
 


### PR DESCRIPTION
This enables automatic syntax highlighting in SublimeText (and presumably other editors).  This is effectively 100% cosmetic.

`msgpack` had shebangs `# coding: utf-8` which is changed to `# -*- coding: utf-8 -*-`.  If there is a reason to use the former, let me know and I'll amend the PR. 

Related: #15131, #15134

 - [ ] closes #xxxx
 - [ ] tests added / passed
 - [X] passes ``git diff upstream/master --name-only -- '*.py' | flake8 --diff`` (On Windows, ``git diff upstream/master -u -- "*.py" | flake8 --diff`` might work as an alternative.)
 - [ ] whatsnew entry
