### PR TITLE
Confirm that `select` was *not* clearer in 0.12

### DIFF
--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -2098,7 +2098,6 @@ it is assumed to be aliases for the column names.')
 
     _xs = xs
 
-    # TODO: Check if this was clearer in 0.12
     def select(self, crit, axis=0):
         """
         Return data corresponding to axis labels matching criteria


### PR DESCRIPTION
This just deletes a comment `# TODO: Check if this was clearer in 0.12`.

Checking, the answer is "no".  It was nearly identical.  The docstring was exactly identical.  The only change in the code from 0.12.0 is using `_get_axis_number` in the newer version.

This is based on comparison against 0.12.0 found at https://pypi.python.org/pypi/pandas/0.12.0/#downloads

