### PR TITLE
fix 4 lgtm alerts

### DIFF
--- a/asv_bench/benchmarks/rolling.py
+++ b/asv_bench/benchmarks/rolling.py
@@ -26,7 +26,7 @@ class DataframeRolling(object):
     def time_rolling_median(self):
         (self.df.rolling(self.wins).median())
 
-    def time_rolling_median(self):
+    def time_rolling_mean(self):
         (self.df.rolling(self.wins).mean())
 
     def time_rolling_max(self):
@@ -68,7 +68,7 @@ class DataframeRolling(object):
     def time_rolling_median_l(self):
         (self.df.rolling(self.winl).median())
 
-    def time_rolling_median_l(self):
+    def time_rolling_mean_l(self):
         (self.df.rolling(self.winl).mean())
 
     def time_rolling_max_l(self):
@@ -118,7 +118,7 @@ class SeriesRolling(object):
     def time_rolling_median(self):
         (self.sr.rolling(self.wins).median())
 
-    def time_rolling_median(self):
+    def time_rolling_mean(self):
         (self.sr.rolling(self.wins).mean())
 
     def time_rolling_max(self):
@@ -160,7 +160,7 @@ class SeriesRolling(object):
     def time_rolling_median_l(self):
         (self.sr.rolling(self.winl).median())
 
-    def time_rolling_median_l(self):
+    def time_rolling_mean_l(self):
         (self.sr.rolling(self.winl).mean())
 
     def time_rolling_max_l(self):


### PR DESCRIPTION
Fix name of methods as `rolling_mean` instead of `rolling_median` following a43c1576ce3d94bc82f7cdd63531280ced5a9fa0.

I'm a dev on lgtm.com so I'm very biased but these were flagged [here](https://lgtm.com/projects/g/pydata/pandas/rev/a43c1576ce3d94bc82f7cdd63531280ced5a9fa0) and you can catch such issues (and more subtle ones) before they find their way into master by giving a go at [PR integration](https://lgtm.com/docs/lgtm/config/pr-integration) :)

Hope that helps! 
