### PR TITLE
Adding Series._repr_html_

### DIFF
--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -6,6 +6,7 @@ from __future__ import division
 # pylint: disable=E1101,E1103
 # pylint: disable=W0703,W0622,W0613,W0201
 
+import re
 import types
 import warnings
 from textwrap import dedent
@@ -1047,6 +1048,16 @@ class Series(base.IndexOpsMixin, strings.StringAccessorMixin,
             except AttributeError:
                 with open(buf, 'w') as f:
                     f.write(result)
+
+    def _repr_html_(self):
+        """
+        Return a html representation for a particular Series.
+        Mainly for IPython notebook.
+        """
+        df = self.to_frame()
+        s = df._repr_html_()
+        s2 = re.sub(r'<thead>(.*)</thead>', '', s, flags=re.DOTALL)
+        return s2
 
     def __iter__(self):
         """ provide iteration over the values of the Series

--- a/series_html_demo.ipynb
+++ b/series_html_demo.ipynb
@@ -1,0 +1,228 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "series = pd.Series([])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "series[0] = 'zero'\n",
+    "series[1] = 'one'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style>\n",
+       "    .dataframe thead tr:only-child th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: left;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  \n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>zero</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>one</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "0    zero\n",
+       "1     one\n",
+       "dtype: object"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "series"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "<div>\n",
+      "<style>\n",
+      "    .dataframe thead tr:only-child th {\n",
+      "        text-align: right;\n",
+      "    }\n",
+      "\n",
+      "    .dataframe thead th {\n",
+      "        text-align: left;\n",
+      "    }\n",
+      "\n",
+      "    .dataframe tbody tr th {\n",
+      "        vertical-align: top;\n",
+      "    }\n",
+      "</style>\n",
+      "<table border=\"1\" class=\"dataframe\">\n",
+      "  \n",
+      "  <tbody>\n",
+      "    <tr>\n",
+      "      <th>0</th>\n",
+      "      <td>zero</td>\n",
+      "    </tr>\n",
+      "    <tr>\n",
+      "      <th>1</th>\n",
+      "      <td>one</td>\n",
+      "    </tr>\n",
+      "  </tbody>\n",
+      "</table>\n",
+      "</div>\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(series._repr_html_())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df = series.to_frame()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style>\n",
+       "    .dataframe thead tr:only-child th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: left;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>0</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>zero</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>one</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "      0\n",
+       "0  zero\n",
+       "1   one"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.1"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
This is intended to close #5563 by adding `Series._repr_html_`
As suggested by previous discussion, the HTML representation of a Series looks different from the representation of a DataFrame, specifically by omitting the `<thead>` row, which (for a DataFrame) contains the column names.
I've tested it in a Jupyter notebook; I can provide a screenshot if someone suggests the best way to do that.


- [ ] closes #5563
 - [ ] tests added / passed
 - [ ] passes ``git diff upstream/master --name-only -- '*.py' | flake8 --diff`` (On Windows, ``git diff upstream/master -u -- "*.py" | flake8 --diff`` might work as an alternative.)
 - [ ] whatsnew entry
