### PR TITLE
BUG: Made SparseDataFrame.fillna() fill all NaNs

### DIFF
--- a/doc/source/whatsnew/v0.21.0.txt
+++ b/doc/source/whatsnew/v0.21.0.txt
@@ -178,6 +178,7 @@ Groupby/Resample/Rolling
 Sparse
 ^^^^^^
 
+- Bug in :func:`SparseDataFrame.fillna` not filling all NaNs when frame was instantiated from SciPy sparse matrix (:issue:`16112`)
 
 
 Reshaping

--- a/pandas/core/sparse/array.py
+++ b/pandas/core/sparse/array.py
@@ -595,9 +595,8 @@ class SparseArray(PandasObject, np.ndarray):
         if issubclass(self.dtype.type, np.floating):
             value = float(value)
 
-        new_values = self.sp_values.copy()
-        new_values[isnull(new_values)] = value
-        fill_value = value if isnull(self.fill_value) else self.fill_value
+        new_values = np.where(isnull(self.sp_values), value, self.sp_values)
+        fill_value = value if self._null_fill_value else self.fill_value
 
         return self._simple_new(new_values, self.sp_index,
                                 fill_value=fill_value)

--- a/pandas/core/sparse/array.py
+++ b/pandas/core/sparse/array.py
@@ -595,14 +595,12 @@ class SparseArray(PandasObject, np.ndarray):
         if issubclass(self.dtype.type, np.floating):
             value = float(value)
 
-        if self._null_fill_value:
-            return self._simple_new(self.sp_values, self.sp_index,
-                                    fill_value=value)
-        else:
-            new_values = self.sp_values.copy()
-            new_values[isnull(new_values)] = value
-            return self._simple_new(new_values, self.sp_index,
-                                    fill_value=self.fill_value)
+        new_values = self.sp_values.copy()
+        new_values[isnull(new_values)] = value
+        fill_value = value if isnull(self.fill_value) else self.fill_value
+
+        return self._simple_new(new_values, self.sp_index,
+                                fill_value=fill_value)
 
     def sum(self, axis=0, *args, **kwargs):
         """

--- a/pandas/tests/sparse/test_frame.py
+++ b/pandas/tests/sparse/test_frame.py
@@ -1252,7 +1252,6 @@ def test_from_scipy_correct_ordering(spmatrix):
     tm.skip_if_no_package('scipy')
 
     arr = np.arange(1, 5).reshape(2, 2)
-
     try:
         spm = spmatrix(arr)
         assert spm.dtype == arr.dtype
@@ -1268,9 +1267,9 @@ def test_from_scipy_correct_ordering(spmatrix):
     tm.assert_frame_equal(sdf.to_dense(), expected.to_dense())
 
 
-def test_from_scipy_object_fillna(spmatrix):
+def test_from_scipy_fillna(spmatrix):
     # GH 16112
-    tm.skip_if_no_package('scipy', max_version='0.19.0')
+    tm.skip_if_no_package('scipy')
 
     arr = np.eye(3)
     arr[1:, 0] = np.nan
@@ -1287,12 +1286,11 @@ def test_from_scipy_object_fillna(spmatrix):
     sdf = pd.SparseDataFrame(spm).fillna(-1.0)
 
     # Returning frame should fill all nan values with -1.0
-    expected = pd.SparseDataFrame({0: {0: 1.0, 1: np.nan, 2: np.nan},
-                                   1: {0: np.nan, 1: 1.0, 2: np.nan},
-                                   2: {0: np.nan, 1: np.nan, 2: 1.0}}
-                                  ).fillna(-1.0)
+    expected = pd.SparseDataFrame([[1, -1, -1],
+                                   [-1, 1, -1],
+                                   [-1, -1, 1.]])
 
-    tm.assert_frame_equal(sdf.to_dense(), expected.to_dense())
+    tm.assert_numpy_array_equal(sdf.values, expected.values)
 
 
 class TestSparseDataFrameArithmetic(object):

--- a/pandas/tests/sparse/test_frame.py
+++ b/pandas/tests/sparse/test_frame.py
@@ -1286,11 +1286,20 @@ def test_from_scipy_fillna(spmatrix):
     sdf = pd.SparseDataFrame(spm).fillna(-1.0)
 
     # Returning frame should fill all nan values with -1.0
-    expected = pd.SparseDataFrame([[1, -1, -1],
-                                   [-1, 1, -1],
-                                   [-1, -1, 1.]])
+    expected = pd.SparseDataFrame({
+        0: pd.SparseSeries([1., -1, -1]),
+        1: pd.SparseSeries([np.nan, 1, np.nan]),
+        2: pd.SparseSeries([np.nan, np.nan, 1]),
+    }, default_fill_value=-1)
 
-    tm.assert_numpy_array_equal(sdf.values, expected.values)
+    # fill_value is expected to be what .fillna() above was called with
+    # We don't use -1 as initial fill_value in expected SparseSeries
+    # construction because this way we obtain "compressed" SparseArrays,
+    # avoiding having to construct them ourselves
+    for col in expected:
+        expected[col].fill_value = -1
+
+    tm.assert_sp_frame_equal(sdf, expected)
 
 
 class TestSparseDataFrameArithmetic(object):


### PR DESCRIPTION
A continuation of https://github.com/pandas-dev/pandas/pull/16178

 - [x] fixes https://github.com/pandas-dev/pandas/issues/16112, closes https://github.com/pandas-dev/pandas/pull/16178
 - [x] tests added / passed
 - [x] passes ``git diff upstream/master --name-only -- '*.py' | flake8 --diff`` (On Windows, ``git diff upstream/master -u -- "*.py" | flake8 --diff`` might work as an alternative.)
 - [x] whatsnew entry