### PR TITLE
BUG: coercing of bools in groupby transform

### DIFF
--- a/doc/source/whatsnew/v0.21.0.txt
+++ b/doc/source/whatsnew/v0.21.0.txt
@@ -175,7 +175,7 @@ Groupby/Resample/Rolling
 - Bug in ``DataFrame.resample(...).size()`` where an empty ``DataFrame`` did not return a ``Series`` (:issue:`14962`)
 - Bug in :func:`infer_freq` causing indices with 2-day gaps during the working week to be wrongly inferred as business daily (:issue:`16624`)
 - Bug in ``.rolling(...).quantile()`` which incorrectly used different defaults than :func:`Series.quantile()` and :func:`DataFrame.quantile()` (:issue:`9413`, :issue:`16211`)
-
+- Bug in ``groupby.transform()`` that would coerce boolean dtypes back to float (:issue:`16875`)
 
 Sparse
 ^^^^^^

--- a/pandas/core/dtypes/cast.py
+++ b/pandas/core/dtypes/cast.py
@@ -110,11 +110,7 @@ def maybe_downcast_to_dtype(result, dtype):
                     np.prod(result.shape)):
                 return result
 
-        # don't convert bool to float GH16875
-        if (issubclass(dtype.type, np.floating) and
-                not is_bool_dtype(result.dtype)):
-            return result.astype(dtype)
-        elif is_bool_dtype(dtype) or is_integer_dtype(dtype):
+        if is_bool_dtype(dtype) or is_integer_dtype(dtype):
 
             # if we don't have any elements, just astype it
             if not np.prod(result.shape):
@@ -146,6 +142,9 @@ def maybe_downcast_to_dtype(result, dtype):
                     # hit here
                     if (new_result == result).all():
                         return new_result
+        elif (issubclass(dtype.type, np.floating) and
+                not is_bool_dtype(result.dtype)):
+            return result.astype(dtype)
 
         # a datetimelike
         # GH12821, iNaT is casted to float

--- a/pandas/core/dtypes/cast.py
+++ b/pandas/core/dtypes/cast.py
@@ -111,8 +111,8 @@ def maybe_downcast_to_dtype(result, dtype):
                 return result
 
         # don't convert bool to float GH16875
-        if issubclass(dtype.type, np.floating) and\
-                not is_bool_dtype(result.dtype):
+        if (issubclass(dtype.type, np.floating) and
+                not is_bool_dtype(result.dtype)):
             return result.astype(dtype)
         elif is_bool_dtype(dtype) or is_integer_dtype(dtype):
 

--- a/pandas/core/dtypes/cast.py
+++ b/pandas/core/dtypes/cast.py
@@ -110,7 +110,9 @@ def maybe_downcast_to_dtype(result, dtype):
                     np.prod(result.shape)):
                 return result
 
-        if issubclass(dtype.type, np.floating):
+        # don't convert bool to float GH16875
+        if issubclass(dtype.type, np.floating) and\
+                not is_bool_dtype(result.dtype):
             return result.astype(dtype)
         elif is_bool_dtype(dtype) or is_integer_dtype(dtype):
 

--- a/pandas/core/groupby.py
+++ b/pandas/core/groupby.py
@@ -3055,7 +3055,7 @@ class SeriesGroupBy(GroupBy):
         # we have a numeric dtype, as these are *always* udfs
         # the cython take a different path (and casting)
         dtype = self._selected_obj.dtype
-        if is_numeric_dtype(dtype) and not is_bool_dtype(result.dtype):
+        if is_numeric_dtype(dtype):
             result = maybe_downcast_to_dtype(result, dtype)
 
         result.name = self._selected_obj.name

--- a/pandas/core/groupby.py
+++ b/pandas/core/groupby.py
@@ -3055,7 +3055,7 @@ class SeriesGroupBy(GroupBy):
         # we have a numeric dtype, as these are *always* udfs
         # the cython take a different path (and casting)
         dtype = self._selected_obj.dtype
-        if is_numeric_dtype(dtype):
+        if is_numeric_dtype(dtype) and not is_bool_dtype(result.dtype):
             result = maybe_downcast_to_dtype(result, dtype)
 
         result.name = self._selected_obj.name

--- a/pandas/tests/dtypes/test_cast.py
+++ b/pandas/tests/dtypes/test_cast.py
@@ -9,7 +9,7 @@ import pytest
 from datetime import datetime, timedelta, date
 import numpy as np
 
-from pandas import Timedelta, Timestamp, DatetimeIndex, DataFrame, NaT
+from pandas import Timedelta, Timestamp, DatetimeIndex, DataFrame, NaT, Series
 
 from pandas.core.dtypes.cast import (
     maybe_downcast_to_dtype,
@@ -44,6 +44,12 @@ class TestMaybeDowncast(object):
         result = maybe_downcast_to_dtype(arr, 'infer')
         expected = np.array([8, 8, 8, 8, 9])
         assert (np.array_equal(result, expected))
+
+        # GH16875 coercing of bools
+        ser = Series([True, True, False])
+        result = maybe_downcast_to_dtype(ser, np.dtype(np.float64))
+        expected = ser
+        tm.assert_series_equal(result, expected)
 
         # conversions
 

--- a/pandas/tests/groupby/test_transform.py
+++ b/pandas/tests/groupby/test_transform.py
@@ -195,6 +195,19 @@ class TestGroupBy(MixIn):
         expected = Series(np.arange(5, 0, step=-1), name='B')
         assert_series_equal(result, expected)
 
+    def test_transform_numeric_to_boolean(self):
+        # GH 16875
+        # inconsistency in transforming boolean values
+        expected = pd.Series([True, True], name='A')
+
+        df = pd.DataFrame({'A': [1.1, 2.2], 'B': [1, 2]})
+        result = df.groupby('B').A.transform(lambda x: True)
+        assert_series_equal(result, expected)
+
+        df = pd.DataFrame({'A': [1, 2], 'B': [1, 2]})
+        result = df.groupby('B').A.transform(lambda x: True)
+        assert_series_equal(result, expected)
+
     def test_transform_datetime_to_timedelta(self):
         # GH 15429
         # transforming a datetime to timedelta


### PR DESCRIPTION
This bug is  happening because of the following lines of code(3054-3059 in groupby.py)
```      
       # we will only try to coerce the result type if
       # we have a numeric dtype, as these are *always* udfs
       # the cython take a different path (and casting)
       dtype = self._selected_obj.dtype
       if is_numeric_dtype(dtype):
           result = maybe_downcast_to_dtype(result, dtype)
```
the call to `maybe_downcast_to_dtype` successfully downcasts bool to float thus the result is 1.0.
I've put a guard in place to check if the result is boolean. This seems like an optimal solution, to me, since the behaviour of `maybe_downcast_to_dtype` seems consistent.

Fix inconsistency in groupby tranformations

 - [ ] closes #16875 
 - [ ] tests added / passed
 - [ ] passes ``git diff upstream/master --name-only -- '*.py' | flake8 --diff`` (On Windows, ``git diff upstream/master -u -- "*.py" | flake8 --diff`` might work as an alternative.)
 - [ ] whatsnew entry
