### PR TITLE
BUG: SparseSeries init from dict fixes

### DIFF
--- a/doc/source/whatsnew/v0.21.0.txt
+++ b/doc/source/whatsnew/v0.21.0.txt
@@ -179,7 +179,7 @@ Sparse
 ^^^^^^
 
 
-- Bug in instantiating :class:`SparseSeries` from ``dict`` with or without ``index=`` kwarg (:issue:`16905`)
+- Bug in instantiating :class:`SparseSeries` from ``dict`` (:issue:`16905`)
 
 Reshaping
 ^^^^^^^^^

--- a/doc/source/whatsnew/v0.21.0.txt
+++ b/doc/source/whatsnew/v0.21.0.txt
@@ -179,6 +179,7 @@ Sparse
 ^^^^^^
 
 
+- Bug in instantiating :class:`SparseSeries` from ``dict`` with or without ``index`` (:issue:`16905`)
 
 Reshaping
 ^^^^^^^^^

--- a/doc/source/whatsnew/v0.21.0.txt
+++ b/doc/source/whatsnew/v0.21.0.txt
@@ -179,7 +179,7 @@ Sparse
 ^^^^^^
 
 
-- Bug in instantiating :class:`SparseSeries` from ``dict`` with or without ``index`` (:issue:`16905`)
+- Bug in instantiating :class:`SparseSeries` from ``dict`` with or without ``index=`` kwarg (:issue:`16905`)
 
 Reshaping
 ^^^^^^^^^

--- a/pandas/core/sparse/series.py
+++ b/pandas/core/sparse/series.py
@@ -146,10 +146,8 @@ class SparseSeries(Series):
                 data = data._data
 
             elif isinstance(data, (Series, dict)):
-                if index is None:
-                    index = data.index.view()
-
-                data = Series(data)
+                data = Series(data, index=index)
+                index = data.index
                 res = make_sparse(data, kind=kind, fill_value=fill_value)
                 data, sparse_index, fill_value = res
 

--- a/pandas/tests/series/test_api.py
+++ b/pandas/tests/series/test_api.py
@@ -120,18 +120,18 @@ class SharedWithSparse(object):
 
     def test_constructor_dict(self):
         d = {'a': 0., 'b': 1., 'c': 2.}
-        result = self.Series(d)
-        expected = self.Series(d, index=sorted(d.keys()))
+        result = self.series_klass(d)
+        expected = self.series_klass(d, index=sorted(d.keys()))
         tm.assert_series_equal(result, expected)
 
-        result = self.Series(d, index=['b', 'c', 'd', 'a'])
-        expected = self.Series([1, 2, np.nan, 0], index=['b', 'c', 'd', 'a'])
+        result = self.series_klass(d, index=['b', 'c', 'd', 'a'])
+        expected = self.series_klass([1, 2, np.nan, 0], index=['b', 'c', 'd', 'a'])
         tm.assert_series_equal(result, expected)
 
     def test_constructor_subclass_dict(self):
         data = tm.TestSubDict((x, 10.0 * x) for x in range(10))
-        series = self.Series(data)
-        expected = self.Series(dict(compat.iteritems(data)))
+        series = self.series_klass(data)
+        expected = self.series_klass(dict(compat.iteritems(data)))
         tm.assert_series_equal(series, expected)
 
     def test_constructor_ordereddict(self):
@@ -139,30 +139,30 @@ class SharedWithSparse(object):
         data = OrderedDict(
             ('col%s' % i, np.random.random()) for i in range(12))
 
-        series = self.Series(data)
-        expected = self.Series(list(data.values()), list(data.keys()))
+        series = self.series_klass(data)
+        expected = self.series_klass(list(data.values()), list(data.keys()))
         tm.assert_series_equal(series, expected)
 
         # Test with subclass
         class A(OrderedDict):
             pass
 
-        series = self.Series(A(data))
+        series = self.series_klass(A(data))
         tm.assert_series_equal(series, expected)
 
     def test_constructor_dict_multiindex(self):
         d = {('a', 'a'): 0., ('b', 'a'): 1., ('b', 'c'): 2.}
         _d = sorted(d.items())
-        result = self.Series(d)
-        expected = self.Series(
+        result = self.series_klass(d)
+        expected = self.series_klass(
             [x[1] for x in _d],
             index=pd.MultiIndex.from_tuples([x[0] for x in _d]))
         tm.assert_series_equal(result, expected)
 
         d['z'] = 111.
         _d.insert(0, ('z', d['z']))
-        result = self.Series(d)
-        expected = self.Series([x[1] for x in _d],
+        result = self.series_klass(d)
+        expected = self.series_klass([x[1] for x in _d],
                                index=pd.Index([x[0] for x in _d],
                                               tupleize_cols=False))
         result = result.reindex(index=expected.index)
@@ -172,12 +172,12 @@ class SharedWithSparse(object):
         # GH #12169 : Resample category data with timedelta index
         # construct Series from dict as data and TimedeltaIndex as index
         # will result NaN in result Series data
-        expected = self.Series(
+        expected = self.series_klass(
             data=['A', 'B', 'C'],
             index=pd.to_timedelta([0, 10, 20], unit='s')
         )
 
-        result = self.Series(
+        result = self.series_klass(
             data={pd.to_timedelta(0, unit='s'): 'A',
                   pd.to_timedelta(10, unit='s'): 'B',
                   pd.to_timedelta(20, unit='s'): 'C'},
@@ -188,7 +188,7 @@ class SharedWithSparse(object):
 
 class TestSeriesMisc(TestData, SharedWithSparse):
 
-    Series = Series
+    series_klass = Series
 
     def test_tab_completion(self):
         # GH 9910

--- a/pandas/tests/series/test_constructors.py
+++ b/pandas/tests/series/test_constructors.py
@@ -20,8 +20,7 @@ from pandas.core.indexes.datetimes import Timestamp, DatetimeIndex
 from pandas._libs import lib
 from pandas._libs.tslib import iNaT
 
-from pandas.compat import lrange, range, zip, OrderedDict, long
-from pandas import compat
+from pandas.compat import lrange, range, zip, long
 from pandas.util.testing import assert_series_equal
 import pandas.util.testing as tm
 

--- a/pandas/tests/series/test_constructors.py
+++ b/pandas/tests/series/test_constructors.py
@@ -605,48 +605,6 @@ class TestSeriesConstructors(TestData):
         expected.iloc[1] = 1
         assert_series_equal(result, expected)
 
-    def test_constructor_dict_multiindex(self):
-        check = lambda result, expected: tm.assert_series_equal(
-            result, expected, check_dtype=True, check_series_type=True)
-        d = {('a', 'a'): 0., ('b', 'a'): 1., ('b', 'c'): 2.}
-        _d = sorted(d.items())
-        ser = Series(d)
-        expected = Series([x[1] for x in _d],
-                          index=MultiIndex.from_tuples([x[0] for x in _d]))
-        check(ser, expected)
-
-        d['z'] = 111.
-        _d.insert(0, ('z', d['z']))
-        ser = Series(d)
-        expected = Series([x[1] for x in _d], index=Index(
-            [x[0] for x in _d], tupleize_cols=False))
-        ser = ser.reindex(index=expected.index)
-        check(ser, expected)
-
-    def test_constructor_dict_timedelta_index(self):
-        # GH #12169 : Resample category data with timedelta index
-        # construct Series from dict as data and TimedeltaIndex as index
-        # will result NaN in result Series data
-        expected = Series(
-            data=['A', 'B', 'C'],
-            index=pd.to_timedelta([0, 10, 20], unit='s')
-        )
-
-        result = Series(
-            data={pd.to_timedelta(0, unit='s'): 'A',
-                  pd.to_timedelta(10, unit='s'): 'B',
-                  pd.to_timedelta(20, unit='s'): 'C'},
-            index=pd.to_timedelta([0, 10, 20], unit='s')
-        )
-        # this should work
-        assert_series_equal(result, expected)
-
-    def test_constructor_subclass_dict(self):
-        data = tm.TestSubDict((x, 10.0 * x) for x in range(10))
-        series = Series(data)
-        refseries = Series(dict(compat.iteritems(data)))
-        assert_series_equal(refseries, series)
-
     def test_constructor_dict_datetime64_index(self):
         # GH 9456
 
@@ -669,26 +627,6 @@ class TestSeriesConstructors(TestData):
         assert_series_equal(result_datetime64, expected)
         assert_series_equal(result_datetime, expected)
         assert_series_equal(result_Timestamp, expected)
-
-    def test_orderedDict_ctor(self):
-        # GH3283
-        import pandas
-        import random
-        data = OrderedDict([('col%s' % i, random.random()) for i in range(12)])
-        s = pandas.Series(data)
-        assert all(s.values == list(data.values()))
-
-    def test_orderedDict_subclass_ctor(self):
-        # GH3283
-        import pandas
-        import random
-
-        class A(OrderedDict):
-            pass
-
-        data = A([('col%s' % i, random.random()) for i in range(12)])
-        s = pandas.Series(data)
-        assert all(s.values == list(data.values()))
 
     def test_constructor_list_of_tuples(self):
         data = [(1, 1), (2, 2), (2, 3)]

--- a/pandas/tests/sparse/test_frame.py
+++ b/pandas/tests/sparse/test_frame.py
@@ -1002,12 +1002,14 @@ class TestSparseDataFrame(SharedWithSparse):
 
             shifted = frame.shift(2, freq='B')
             exp = orig.shift(2, freq='B')
-            exp = exp.to_sparse(frame.default_fill_value)
+            exp = exp.to_sparse(frame.default_fill_value,
+                                kind=frame.default_kind)
             tm.assert_frame_equal(shifted, exp)
 
             shifted = frame.shift(2, freq=BDay())
             exp = orig.shift(2, freq=BDay())
-            exp = exp.to_sparse(frame.default_fill_value)
+            exp = exp.to_sparse(frame.default_fill_value,
+                                kind=frame.default_kind)
             tm.assert_frame_equal(shifted, exp)
 
         self._check_all(_check)

--- a/pandas/tests/sparse/test_series.py
+++ b/pandas/tests/sparse/test_series.py
@@ -60,7 +60,7 @@ def _test_data2_zero():
 
 class TestSparseSeries(SharedWithSparse):
 
-    Series = SparseSeries
+    series_klass = SparseSeries
 
     def setup_method(self, method):
         arr, index = _test_data1()

--- a/pandas/util/testing.py
+++ b/pandas/util/testing.py
@@ -46,7 +46,7 @@ from pandas.core.computation import expressions as expr
 from pandas import (bdate_range, CategoricalIndex, Categorical, IntervalIndex,
                     DatetimeIndex, TimedeltaIndex, PeriodIndex, RangeIndex,
                     Index, MultiIndex,
-                    Series, DataFrame, Panel, Panel4D)
+                    Series, DataFrame, SparseSeries, Panel, Panel4D)
 
 from pandas._libs import testing as _testing
 from pandas.io.common import urlopen
@@ -1224,6 +1224,12 @@ def assert_series_equal(left, right, check_dtype=True,
 
     # instance validation
     _check_isinstance(left, right, Series)
+
+    if isinstance(left, SparseSeries) and isinstance(right, SparseSeries):
+        return assert_sp_series_equal(left, right,
+                                      check_dtype=check_dtype,
+                                      check_series_type=check_series_type,
+                                      check_names=check_names)
 
     if check_series_type:
         # ToDo: There are some tests using rhs is sparse


### PR DESCRIPTION
 - [X] closes #16905
 - [X] tests added / passed
 - [X] passes ``git diff upstream/master --name-only -- '*.py' | flake8 --diff`` (On Windows, ``git diff upstream/master -u -- "*.py" | flake8 --diff`` might work as an alternative.)
 - [X] whatsnew entry