### PR TITLE
Fixes for #16896(TimedeltaIndex indexing regression for strings)

### DIFF
--- a/doc/source/whatsnew/v0.21.0.txt
+++ b/doc/source/whatsnew/v0.21.0.txt
@@ -155,7 +155,7 @@ Indexing
 
 - When called with a null slice (e.g. ``df.iloc[:]``), the ``.iloc`` and ``.loc`` indexers return a shallow copy of the original object. Previously they returned the original object. (:issue:`13873`).
 - When called on an unsorted ``MultiIndex``, the ``loc`` indexer now will raise ``UnsortedIndexError`` only if proper slicing is used on non-sorted levels (:issue:`16734`).
-
+- Fixes regression in 0.20.3 that raises an index error when a string is used for ``TimedeltaIndex`` (:issue:`16896`).
 
 I/O
 ^^^

--- a/doc/source/whatsnew/v0.21.0.txt
+++ b/doc/source/whatsnew/v0.21.0.txt
@@ -155,7 +155,7 @@ Indexing
 
 - When called with a null slice (e.g. ``df.iloc[:]``), the ``.iloc`` and ``.loc`` indexers return a shallow copy of the original object. Previously they returned the original object. (:issue:`13873`).
 - When called on an unsorted ``MultiIndex``, the ``loc`` indexer now will raise ``UnsortedIndexError`` only if proper slicing is used on non-sorted levels (:issue:`16734`).
-- Fixes regression in 0.20.3 that raises an index error when a string is used for ``TimedeltaIndex`` (:issue:`16896`).
+- Fixes regression in 0.20.3 when indexing with a string on a ``TimedeltaIndex`` (:issue:`16896`).
 
 I/O
 ^^^

--- a/pandas/core/dtypes/common.py
+++ b/pandas/core/dtypes/common.py
@@ -392,13 +392,15 @@ def is_timedelta64_dtype(arr_or_dtype):
     False
     >>> is_timedelta64_dtype(pd.Series([], dtype="timedelta64[ns]"))
     True
+    >>> is_timedelta64_dtype('0 days')
+    False
     """
 
     if arr_or_dtype is None:
         return False
     try:
         tipo = _get_dtype_type(arr_or_dtype)
-    except ValueError:
+    except:
         return False
     return issubclass(tipo, np.timedelta64)
 

--- a/pandas/tests/dtypes/test_common.py
+++ b/pandas/tests/dtypes/test_common.py
@@ -209,6 +209,7 @@ def test_is_timedelta64_dtype():
 
     assert com.is_timedelta64_dtype(np.timedelta64)
     assert com.is_timedelta64_dtype(pd.Series([], dtype="timedelta64[ns]"))
+    assert com.is_timedelta64_dtype(pd.to_timedelta(['0 days', '1 days']))
 
 
 def test_is_period_dtype():

--- a/pandas/tests/dtypes/test_common.py
+++ b/pandas/tests/dtypes/test_common.py
@@ -202,12 +202,13 @@ def test_is_timedelta64_dtype():
     assert not com.is_timedelta64_dtype(None)
     assert not com.is_timedelta64_dtype([1, 2, 3])
     assert not com.is_timedelta64_dtype(np.array([], dtype=np.datetime64))
-    assert com.is_timedelta64_dtype(np.timedelta64)
-    assert com.is_timedelta64_dtype(pd.Series([], dtype="timedelta64[ns]"))
     assert not com.is_timedelta64_dtype('0 days')
     assert not com.is_timedelta64_dtype("0 days 00:00:00")
     assert not com.is_timedelta64_dtype(["0 days 00:00:00"])
     assert not com.is_timedelta64_dtype("NO DATE")
+
+    assert com.is_timedelta64_dtype(np.timedelta64)
+    assert com.is_timedelta64_dtype(pd.Series([], dtype="timedelta64[ns]"))
 
 
 def test_is_period_dtype():

--- a/pandas/tests/dtypes/test_common.py
+++ b/pandas/tests/dtypes/test_common.py
@@ -199,12 +199,15 @@ def test_is_datetime64tz_dtype():
 
 def test_is_timedelta64_dtype():
     assert not com.is_timedelta64_dtype(object)
+    assert not com.is_timedelta64_dtype(None)
     assert not com.is_timedelta64_dtype([1, 2, 3])
     assert not com.is_timedelta64_dtype(np.array([], dtype=np.datetime64))
     assert com.is_timedelta64_dtype(np.timedelta64)
     assert com.is_timedelta64_dtype(pd.Series([], dtype="timedelta64[ns]"))
-
+    assert not com.is_timedelta64_dtype('0 days')
     assert not com.is_timedelta64_dtype("0 days 00:00:00")
+    assert not com.is_timedelta64_dtype(["0 days 00:00:00"])
+    assert not com.is_timedelta64_dtype("NO DATE")
 
 
 def test_is_period_dtype():

--- a/pandas/tests/indexes/timedeltas/test_timedelta.py
+++ b/pandas/tests/indexes/timedeltas/test_timedelta.py
@@ -66,6 +66,9 @@ class TestTimedeltaIndex(DatetimeLike):
         for method, loc in [('pad', 1), ('backfill', 2), ('nearest', 1)]:
             assert idx.get_loc('1 day 1 hour', method) == loc
 
+        # GH 16896
+        assert idx.get_loc('0 days') == 0
+
     def test_get_loc_nat(self):
         tidx = TimedeltaIndex(['1 days 01:00:00', 'NaT', '2 days 01:00:00'])
 

--- a/pandas/tests/indexing/test_timedelta.py
+++ b/pandas/tests/indexing/test_timedelta.py
@@ -42,6 +42,7 @@ class TestTimedeltaIndexing(object):
         tm.assert_frame_equal(expected, df)
 
     def test_string_indexing(self):
+        # GH 16896
         df = pd.DataFrame({'x': range(3)}, index=pd.to_timedelta(range(3), unit='days'))
         expected = df.iloc[0]
         sliced = df.loc['0 days']

--- a/pandas/tests/indexing/test_timedelta.py
+++ b/pandas/tests/indexing/test_timedelta.py
@@ -5,7 +5,6 @@ from pandas.util import testing as tm
 
 
 class TestTimedeltaIndexing(object):
-
     def test_boolean_indexing(self):
         # GH 14946
         df = pd.DataFrame({'x': range(10)})
@@ -48,3 +47,5 @@ class TestTimedeltaIndexing(object):
         expected = df.iloc[0]
         sliced = df.loc['0 days']
         tm.assert_series_equal(sliced, expected)
+
+        assert df.index.get_loc('0 days') == 0

--- a/pandas/tests/indexing/test_timedelta.py
+++ b/pandas/tests/indexing/test_timedelta.py
@@ -40,3 +40,9 @@ class TestTimedeltaIndexing(object):
                                 dtype="int64")
 
         tm.assert_frame_equal(expected, df)
+
+    def test_string_indexing(self):
+        df = pd.DataFrame({'x': range(3)}, index=pd.to_timedelta(range(3), unit='days'))
+        expected = df.iloc[0]
+        sliced = df.loc['0 days']
+        tm.assert_series_equal(sliced, expected)

--- a/pandas/tests/indexing/test_timedelta.py
+++ b/pandas/tests/indexing/test_timedelta.py
@@ -47,5 +47,3 @@ class TestTimedeltaIndexing(object):
         expected = df.iloc[0]
         sliced = df.loc['0 days']
         tm.assert_series_equal(sliced, expected)
-
-        assert df.index.get_loc('0 days') == 0

--- a/pandas/tests/indexing/test_timedelta.py
+++ b/pandas/tests/indexing/test_timedelta.py
@@ -43,7 +43,8 @@ class TestTimedeltaIndexing(object):
 
     def test_string_indexing(self):
         # GH 16896
-        df = pd.DataFrame({'x': range(3)}, index=pd.to_timedelta(range(3), unit='days'))
+        df = pd.DataFrame({'x': range(3)},
+                          index=pd.to_timedelta(range(3), unit='days'))
         expected = df.iloc[0]
         sliced = df.loc['0 days']
         tm.assert_series_equal(sliced, expected)


### PR DESCRIPTION
Fixed a regression for indexing with a string with a ``TimedeltaIndex`` (#16896)

I am not a fan of the catch all except, but there is no guarantee in `_get_dtype_type`. As part of this PR, we can ensure that all type checks return True/False. `_get_dtype_type` should probably return a type or a TypeError... Nothing else. Let me know if you want to do that as well.

 - [x] closes #16896
 - [x] tests added / passed
 - [x] passes ``git diff upstream/master --name-only -- '*.py' | flake8 --diff`` (On Windows, ``git diff upstream/master -u -- "*.py" | flake8 --diff`` might work as an alternative.)
 - [x] whatsnew entry
