### PR TITLE
MAINT: Remove unused mock import

### DIFF
--- a/pandas/tests/io/formats/test_printing.py
+++ b/pandas/tests/io/formats/test_printing.py
@@ -127,14 +127,7 @@ class TestTableSchemaRepr(object):
     @classmethod
     def setup_class(cls):
         pytest.importorskip('IPython')
-        try:
-            import mock
-        except ImportError:
-            try:
-                from unittest import mock
-            except ImportError:
-                pytest.skip("Mock is not installed")
-        cls.mock = mock
+
         from IPython.core.interactiveshell import InteractiveShell
         cls.display_formatter = InteractiveShell.instance().display_formatter
 


### PR DESCRIPTION
We import it, set it as an attribute, and then don't use it.

xref <a href="https://github.com/pandas-dev/pandas/issues/16716#issuecomment-315127204">#16716 (comment)</a>

cc @TomAugspurger 