### PR TITLE
Define plot methods in class definitions

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -5591,9 +5591,8 @@ it is assumed to be aliases for the column names')
         2   True   True
         """
         if isinstance(values, dict):
-            from collections import defaultdict
             from pandas.core.reshape.concat import concat
-            values = defaultdict(list, values)
+            values = collections.defaultdict(list, values)
             return concat((self.iloc[:, [i]].isin(values[col])
                            for i, col in enumerate(self.columns)), axis=1)
         elif isinstance(values, Series):
@@ -5616,6 +5615,24 @@ it is assumed to be aliases for the column names')
                 algorithms.isin(self.values.ravel(),
                                 values).reshape(self.shape), self.index,
                 self.columns)
+
+    # ----------------------------------------------------------------------
+    # Add plotting methods to DataFrame
+    plot = base.AccessorProperty(gfx.FramePlotMethods, gfx.FramePlotMethods)
+    hist = gfx.hist_frame
+
+    @Appender(_shared_docs['boxplot'] % _shared_doc_kwargs)
+    def boxplot(self, column=None, by=None, ax=None, fontsize=None, rot=0,
+                grid=True, figsize=None, layout=None, return_type=None, **kwds):
+        from pandas.plotting._core import boxplot
+        import matplotlib.pyplot as plt
+        ax = boxplot(self, column=column, by=by, ax=ax, fontsize=fontsize,
+                     grid=grid, rot=rot, figsize=figsize, layout=layout,
+                     return_type=return_type, **kwds)
+        plt.draw_if_interactive()
+        return ax
+
+
 
 
 DataFrame._setup_axes(['index', 'columns'], info_axis=1, stat_axis=0,
@@ -5970,26 +5987,6 @@ def _put_str(s, space):
     return ('%s' % s)[:space].ljust(space)
 
 
-# ----------------------------------------------------------------------
-# Add plotting methods to DataFrame
-DataFrame.plot = base.AccessorProperty(gfx.FramePlotMethods,
-                                       gfx.FramePlotMethods)
-DataFrame.hist = gfx.hist_frame
-
-
-@Appender(_shared_docs['boxplot'] % _shared_doc_kwargs)
-def boxplot(self, column=None, by=None, ax=None, fontsize=None, rot=0,
-            grid=True, figsize=None, layout=None, return_type=None, **kwds):
-    from pandas.plotting._core import boxplot
-    import matplotlib.pyplot as plt
-    ax = boxplot(self, column=column, by=by, ax=ax, fontsize=fontsize,
-                 grid=grid, rot=rot, figsize=figsize, layout=layout,
-                 return_type=return_type, **kwds)
-    plt.draw_if_interactive()
-    return ax
-
-
-DataFrame.boxplot = boxplot
 
 ops.add_flex_arithmetic_methods(DataFrame, **ops.frame_flex_funcs)
 ops.add_special_arithmetic_methods(DataFrame, **ops.frame_special_funcs)

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -77,6 +77,8 @@ from pandas.util._validators import validate_bool_kwarg
 from pandas._libs import index as libindex, tslib as libts, lib, iNaT
 from pandas.core.config import get_option
 
+import pandas.plotting._core as gfx  # noqa
+
 __all__ = ['Series']
 
 _shared_doc_kwargs = dict(
@@ -2877,6 +2879,12 @@ class Series(base.IndexOpsMixin, strings.StringAccessorMixin,
                 pass
         return rv
 
+    # ----------------------------------------------------------------------
+    # Add plotting methods to Series
+
+    plot = base.AccessorProperty(gfx.SeriesPlotMethods, gfx.SeriesPlotMethods)
+    hist = gfx.hist_series
+
 
 Series._setup_axes(['index'], info_axis=0, stat_axis=0, aliases={'rows': 0})
 Series._add_numeric_operations()
@@ -3064,14 +3072,6 @@ def _sanitize_array(data, index, dtype=None, copy=False,
     return subarr
 
 
-# ----------------------------------------------------------------------
-# Add plotting methods to Series
-
-import pandas.plotting._core as _gfx  # noqa
-
-Series.plot = base.AccessorProperty(_gfx.SeriesPlotMethods,
-                                    _gfx.SeriesPlotMethods)
-Series.hist = _gfx.hist_series
 
 # Add arithmetic!
 ops.add_flex_arithmetic_methods(Series, **ops.series_flex_funcs)

--- a/pandas/plotting/_core.py
+++ b/pandas/plotting/_core.py
@@ -12,7 +12,7 @@ import numpy as np
 from pandas.util._decorators import cache_readonly
 from pandas.core.base import PandasObject
 
-from pandas.core.dtypes.generic import (ABCSeries, ABCDataFrame,
+from pandas.core.dtypes.generic import (ABCSeries, ABCDataFrame, ABCIndex,
                                         ABCMultiIndex, ABCPeriodIndex)
 from pandas.core.dtypes.missing import notnull
 from pandas.core.dtypes.common import (

--- a/pandas/plotting/_core.py
+++ b/pandas/plotting/_core.py
@@ -21,7 +21,7 @@ from pandas.core.dtypes.common import (
 from pandas.core.common import AbstractMethodError, isnull, _try_sort
 from pandas.core.generic import _shared_docs, _shared_doc_kwargs
 from pandas.core.index import Index, MultiIndex
-from pandas.core.series import Series, remove_na
+
 from pandas.core.indexes.period import PeriodIndex
 from pandas.compat import range, lrange, map, zip, string_types
 import pandas.compat as compat
@@ -334,6 +334,7 @@ class MPLPlot(object):
     def _compute_plot_data(self):
         data = self.data
 
+        from pandas.core.series import Series
         if isinstance(data, Series):
             label = self.label
             if label is None and data.name is None:
@@ -1376,6 +1377,7 @@ class KdePlot(HistPlot):
         from scipy.stats import gaussian_kde
         from scipy import __version__ as spv
 
+        from pandas.core.series import remove_na
         y = remove_na(y)
 
         if LooseVersion(spv) >= '0.11.0':
@@ -1494,6 +1496,7 @@ class BoxPlot(LinePlot):
 
     @classmethod
     def _plot(cls, ax, y, column_num=None, return_type='axes', **kwds):
+        from pandas.core.series import remove_na
         if y.ndim == 2:
             y = [remove_na(v) for v in y]
             # Boxplot fails with empty arrays, so need to add a NaN
@@ -1566,6 +1569,7 @@ class BoxPlot(LinePlot):
 
     def _make_plot(self):
         if self.subplots:
+            from pandas.core.series import Series
             self._return_obj = Series()
 
             for i, (label, y) in enumerate(self._iter_data()):
@@ -1968,6 +1972,7 @@ def boxplot(data, column=None, by=None, ax=None, fontsize=None,
             setp(bp['medians'], color=colors[2], alpha=1)
 
     def plot_group(keys, values, ax):
+        from pandas.core.series import remove_na
         keys = [pprint_thing(x) for x in keys]
         values = [remove_na(v) for v in values]
         bp = ax.boxplot(values, **kwds)
@@ -2317,6 +2322,7 @@ def boxplot_frame_groupby(grouped, subplots=True, column=None, fontsize=None,
                               figsize=figsize, layout=layout)
         axes = _flatten(axes)
 
+        from pandas.core.series import Series
         ret = Series()
         for (key, group), ax in zip(grouped, axes):
             d = group.boxplot(ax=ax, column=column, fontsize=fontsize,
@@ -2388,7 +2394,6 @@ def _grouped_plot_by_column(plotf, data, columns=None, by=None,
 
     _axes = _flatten(axes)
 
-    result = Series()
     ax_values = []
 
     for i, col in enumerate(columns):
@@ -2401,6 +2406,7 @@ def _grouped_plot_by_column(plotf, data, columns=None, by=None,
         ax_values.append(re_plotf)
         ax.grid(grid)
 
+    from pandas.core.series import Series
     result = Series(ax_values, index=columns)
 
     # Return axes in multiplot case, maybe revisit later # 985

--- a/pandas/plotting/_tools.py
+++ b/pandas/plotting/_tools.py
@@ -7,8 +7,9 @@ from math import ceil
 
 import numpy as np
 
+from pandas.core.dtypes.generic import ABCSeries, ABCDataFrame, ABCIndex
+
 from pandas.core.dtypes.common import is_list_like
-from pandas.core.index import Index
 from pandas.compat import range
 
 
@@ -43,10 +44,9 @@ def table(ax, data, rowLabels=None, colLabels=None,
     -------
     matplotlib table object
     """
-    from pandas import Series, DataFrame
-    if isinstance(data, Series):
-        data = DataFrame(data, columns=[data.name])
-    elif isinstance(data, DataFrame):
+    if isinstance(data, ABCSeries):
+        data = data.to_frame()
+    elif isinstance(data, ABCDataFrame):
         pass
     else:
         raise ValueError('Input data must be DataFrame or Series')
@@ -340,7 +340,7 @@ def _handle_shared_axes(axarr, nplots, naxes, nrows, ncols, sharex, sharey):
 def _flatten(axes):
     if not is_list_like(axes):
         return np.array([axes])
-    elif isinstance(axes, (np.ndarray, Index)):
+    elif isinstance(axes, (np.ndarray, ABCIndex)):
         return axes.ravel()
     return np.array(axes)
 

--- a/pandas/plotting/_tools.py
+++ b/pandas/plotting/_tools.py
@@ -9,7 +9,6 @@ import numpy as np
 
 from pandas.core.dtypes.common import is_list_like
 from pandas.core.index import Index
-from pandas.core.series import Series
 from pandas.compat import range
 
 
@@ -44,7 +43,7 @@ def table(ax, data, rowLabels=None, colLabels=None,
     -------
     matplotlib table object
     """
-    from pandas import DataFrame
+    from pandas import Series, DataFrame
     if isinstance(data, Series):
         data = DataFrame(data, columns=[data.name])
     elif isinstance(data, DataFrame):


### PR DESCRIPTION
instead of pinning them to Series/DataFrame at the bottom of the files.

(For reasons I dont quite get) Importing `pandas.plotting._core` at the top of core.series
instead of near the bottom causes a circular-import problem.  Avoided this by delaying
import from core.series inside plotting._tools and plotting._core.

Follows-up on conversation in #11053 