### PR TITLE
DOC: Recommend sphinx 1.5 for now

### DIFF
--- a/ci/requirements_all.txt
+++ b/ci/requirements_all.txt
@@ -2,7 +2,7 @@ pytest
 pytest-cov
 pytest-xdist
 flake8
-sphinx
+sphinx=1.5*
 nbsphinx
 ipython
 python-dateutil


### PR DESCRIPTION
xref https://github.com/pandas-dev/pandas/issues/16705

I've started to debug the slowdown (it's on the writing side), but haven't diagnosed the cause. For the SciPy sprints tomorrow we should recommend 1.5