### PR TITLE
EHN: Improved thread safety for read_html() GH16928

### DIFF
--- a/doc/source/whatsnew/v0.21.0.txt
+++ b/doc/source/whatsnew/v0.21.0.txt
@@ -164,6 +164,8 @@ I/O
 
 - Bug in :func:`read_stata` where value labels could not be read when using an iterator (:issue:`16923`)
 
+- Bug in :func:`read_html` where import check fails when run in multiple threads (:issue:`16928`)
+
 Plotting
 ^^^^^^^^
 - Bug in plotting methods using ``secondary_y`` and ``fontsize`` not setting secondary axis font size (:issue:`12565`)

--- a/pandas/io/html.py
+++ b/pandas/io/html.py
@@ -37,8 +37,6 @@ def _importers():
     if _IMPORTS:
         return
 
-    _IMPORTS = True
-
     global _HAS_BS4, _HAS_LXML, _HAS_HTML5LIB
 
     try:
@@ -58,6 +56,8 @@ def _importers():
         _HAS_HTML5LIB = True
     except ImportError:
         pass
+
+    _IMPORTS = True
 
 
 #############


### PR DESCRIPTION
 - [X] closes #16928
 - [x] tests added / passed
 - [X] passes ``git diff upstream/master --name-only -- '*.py' | flake8 --diff`` (On Windows, ``git diff upstream/master -u -- "*.py" | flake8 --diff`` might work as an alternative.)
 - [X] whatsnew entry

It failed a total of 6 tests when running `test_fast.sh` but failed none when running `pytest pandas/tests/io/test_html.py`.
It seems that these 6 failed tests are unrelated to my changes since they also occur on the master branch.