### PR TITLE
Avoid circular import between core.series and plotting._xyz

### DIFF
--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -77,6 +77,8 @@ from pandas.util._validators import validate_bool_kwarg
 from pandas._libs import index as libindex, tslib as libts, lib, iNaT
 from pandas.core.config import get_option
 
+import pandas.plotting._core as _gfx  # noqa
+
 __all__ = ['Series']
 
 _shared_doc_kwargs = dict(
@@ -3066,8 +3068,6 @@ def _sanitize_array(data, index, dtype=None, copy=False,
 
 # ----------------------------------------------------------------------
 # Add plotting methods to Series
-
-import pandas.plotting._core as _gfx  # noqa
 
 Series.plot = base.AccessorProperty(_gfx.SeriesPlotMethods,
                                     _gfx.SeriesPlotMethods)

--- a/pandas/plotting/_core.py
+++ b/pandas/plotting/_core.py
@@ -334,6 +334,10 @@ class MPLPlot(object):
     def _compute_plot_data(self):
         data = self.data
 
+        from pandas import Series
+        if isinstance(data, ABCSeries) != isinstance(data, Series):
+            raise Exception('WTFError', data)
+
         if isinstance(data, ABCSeries):
             label = self.label
             if label is None and data.name is None:

--- a/pandas/plotting/_core.py
+++ b/pandas/plotting/_core.py
@@ -11,6 +11,7 @@ import numpy as np
 
 from pandas.util._decorators import cache_readonly
 from pandas.core.base import PandasObject
+from pandas.core.dtypes.generic import ABCSeries
 from pandas.core.dtypes.missing import notnull
 from pandas.core.dtypes.common import (
     is_list_like,
@@ -21,7 +22,6 @@ from pandas.core.dtypes.common import (
 from pandas.core.common import AbstractMethodError, isnull, _try_sort
 from pandas.core.generic import _shared_docs, _shared_doc_kwargs
 from pandas.core.index import Index, MultiIndex
-from pandas.core.series import Series, remove_na
 from pandas.core.indexes.period import PeriodIndex
 from pandas.compat import range, lrange, map, zip, string_types
 import pandas.compat as compat
@@ -334,7 +334,7 @@ class MPLPlot(object):
     def _compute_plot_data(self):
         data = self.data
 
-        if isinstance(data, Series):
+        if isinstance(data, ABCSeries):
             label = self.label
             if label is None and data.name is None:
                 label = 'None'
@@ -1376,6 +1376,7 @@ class KdePlot(HistPlot):
         from scipy.stats import gaussian_kde
         from scipy import __version__ as spv
 
+        from pandas.core.series import remove_na
         y = remove_na(y)
 
         if LooseVersion(spv) >= '0.11.0':
@@ -1494,6 +1495,7 @@ class BoxPlot(LinePlot):
 
     @classmethod
     def _plot(cls, ax, y, column_num=None, return_type='axes', **kwds):
+        from pandas.core.series import remove_na
         if y.ndim == 2:
             y = [remove_na(v) for v in y]
             # Boxplot fails with empty arrays, so need to add a NaN
@@ -1566,6 +1568,7 @@ class BoxPlot(LinePlot):
 
     def _make_plot(self):
         if self.subplots:
+            from pandas import Series
             self._return_obj = Series()
 
             for i, (label, y) in enumerate(self._iter_data()):
@@ -1968,6 +1971,7 @@ def boxplot(data, column=None, by=None, ax=None, fontsize=None,
             setp(bp['medians'], color=colors[2], alpha=1)
 
     def plot_group(keys, values, ax):
+        from pandas.core.series import remove_na
         keys = [pprint_thing(x) for x in keys]
         values = [remove_na(v) for v in values]
         bp = ax.boxplot(values, **kwds)
@@ -2317,6 +2321,7 @@ def boxplot_frame_groupby(grouped, subplots=True, column=None, fontsize=None,
                               figsize=figsize, layout=layout)
         axes = _flatten(axes)
 
+        from pandas import Series
         ret = Series()
         for (key, group), ax in zip(grouped, axes):
             d = group.boxplot(ax=ax, column=column, fontsize=fontsize,
@@ -2388,6 +2393,7 @@ def _grouped_plot_by_column(plotf, data, columns=None, by=None,
 
     _axes = _flatten(axes)
 
+    from pandas import Series
     result = Series()
     ax_values = []
 

--- a/pandas/plotting/_tools.py
+++ b/pandas/plotting/_tools.py
@@ -9,7 +9,6 @@ import numpy as np
 
 from pandas.core.dtypes.common import is_list_like
 from pandas.core.index import Index
-from pandas.core.series import Series
 from pandas.compat import range
 
 
@@ -44,7 +43,7 @@ def table(ax, data, rowLabels=None, colLabels=None,
     -------
     matplotlib table object
     """
-    from pandas import DataFrame
+    from pandas import Series, DataFrame
     if isinstance(data, Series):
         data = DataFrame(data, columns=[data.name])
     elif isinstance(data, DataFrame):


### PR DESCRIPTION
This follows up on #16913 but cuts down on the scope of the PR.

`pandas.core.series` currently runs

`import pandas.plotting._core as _gfx  # noqa`

about 8 lines from the bottom of the file.  `pandas.plotting._core` runs

`from pandas.core.series import Series, remove_na` 

at the top of the file.  Using very small words and talking very slowly, it was explained to me that this circular import works because `Series` and `remove_na` are defined in the `series` namespace by the time `plotting._core` tries to import them.

This PR gets rid of the module-level import from `core.series` and moves the import of `plotting._core` to the top of `core.series` so as to avoid relying on hard-to-predict/debug behavior.

Other changes that I'd like to make (like deleting the extraneous `ret = Series()` at plotting/_core.py:L2325) are ignored for now.

 - [x] passes ``git diff upstream/master --name-only -- '*.py' | flake8 --diff`` (On Windows, ``git diff upstream/master -u -- "*.py" | flake8 --diff`` might work as an alternative.)
