### PR TITLE
ERR: add stacklevel to to_dict() UserWarning (#16927)

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -972,7 +972,8 @@ class DataFrame(NDFrame):
         """
         if not self.columns.is_unique:
             warnings.warn("DataFrame columns are not unique, some "
-                          "columns will be omitted.", UserWarning)
+                          "columns will be omitted.", UserWarning,
+                          stacklevel=2)
         # GH16122
         into_c = standardize_mapping(into)
         if orient.lower().startswith('d'):

--- a/pandas/tests/frame/test_convert_to.py
+++ b/pandas/tests/frame/test_convert_to.py
@@ -217,8 +217,8 @@ class TestDataFrameConvertTo(TestData):
             df.to_dict(into=mapping)
 
     def test_to_dict_not_unique_warning(self):
-        # When converting to a dict, if a column has a non-unique name it will
-        # be dropped, throwing a warning.
+        # GH16927: When converting to a dict, if a column has a non-unique name
+        # it will be dropped, throwing a warning.
         df = DataFrame([[1, 2, 3]], columns=['a', 'a', 'b'])
         with tm.assert_produces_warning(UserWarning):
             df.to_dict()

--- a/pandas/tests/frame/test_convert_to.py
+++ b/pandas/tests/frame/test_convert_to.py
@@ -220,7 +220,8 @@ class TestDataFrameConvertTo(TestData):
         # When converting to a dict, if a column has a non-unique name it will
         # be dropped, throwing a warning.
         df = DataFrame([[1, 2, 3]], columns=['a', 'a', 'b'])
-        tm.assert_produces_warning(df.to_dict())
+        with tm.assert_produces_warning(UserWarning):
+            df.to_dict()
 
     @pytest.mark.parametrize('tz', ['UTC', 'GMT', 'US/Eastern'])
     def test_to_records_datetimeindex_with_tz(self, tz):

--- a/pandas/tests/frame/test_convert_to.py
+++ b/pandas/tests/frame/test_convert_to.py
@@ -216,6 +216,12 @@ class TestDataFrameConvertTo(TestData):
         with pytest.raises(TypeError):
             df.to_dict(into=mapping)
 
+    def test_to_dict_not_unique_warning(self):
+        # When converting to a dict, if a column has a non-unique name it will
+        # be dropped, throwing a warning.
+        df = DataFrame([[1, 2, 3]], columns=['a', 'a', 'b'])
+        tm.assert_produces_warning(df.to_dict())
+
     @pytest.mark.parametrize('tz', ['UTC', 'GMT', 'US/Eastern'])
     def test_to_records_datetimeindex_with_tz(self, tz):
         # GH13937


### PR DESCRIPTION
 - [x] closes #16927 
 - [ ] tests added / passed
 - [x] passes ``git diff upstream/master --name-only -- '*.py' | flake8 --diff`` (On Windows, ``git diff upstream/master -u -- "*.py" | flake8 --diff`` might work as an alternative.)
 - [x] The warning now correctly points to the calling site.

I would like some guidance on how to implement testing for this quick fix. I was thinking on using pytest's [warning assertion](https://docs.pytest.org/en/latest/warnings.html#warns), but couldn't figure out how to make it elegantly.

Cheers! :beers:
