### PR TITLE
BUG: MultiIndex sort with ascending as list

### DIFF
--- a/doc/source/whatsnew/v0.21.0.txt
+++ b/doc/source/whatsnew/v0.21.0.txt
@@ -156,6 +156,7 @@ Indexing
 - When called on an unsorted ``MultiIndex``, the ``loc`` indexer now will raise ``UnsortedIndexError`` only if proper slicing is used on non-sorted levels (:issue:`16734`).
 - Fixes regression in 0.20.3 when indexing with a string on a ``TimedeltaIndex`` (:issue:`16896`).
 - Fixed ``TimedeltaIndex.get_loc`` handling of ``np.timedelta64`` inputs (:issue:`16909`).
+- Fix MultiIndex ``sort_index`` ordering when ``ascending`` argument is a list but not all levels are specified, or are in a different order (:issue:`16934`).
 
 I/O
 ^^^

--- a/doc/source/whatsnew/v0.21.0.txt
+++ b/doc/source/whatsnew/v0.21.0.txt
@@ -156,7 +156,7 @@ Indexing
 - When called on an unsorted ``MultiIndex``, the ``loc`` indexer now will raise ``UnsortedIndexError`` only if proper slicing is used on non-sorted levels (:issue:`16734`).
 - Fixes regression in 0.20.3 when indexing with a string on a ``TimedeltaIndex`` (:issue:`16896`).
 - Fixed ``TimedeltaIndex.get_loc`` handling of ``np.timedelta64`` inputs (:issue:`16909`).
-- Fix MultiIndex ``sort_index`` ordering when ``ascending`` argument is a list but not all levels are specified, or are in a different order (:issue:`16934`).
+- Fix :meth:`MultiIndex.sort_index` ordering when ``ascending`` argument is a list, but not all levels are specified, or are in a different order (:issue:`16934`).
 
 I/O
 ^^^

--- a/pandas/core/indexes/multi.py
+++ b/pandas/core/indexes/multi.py
@@ -1697,7 +1697,8 @@ class MultiIndex(Index):
                 raise ValueError("level must have same length as ascending")
 
             from pandas.core.sorting import lexsort_indexer
-            indexer = lexsort_indexer(self.labels, orders=ascending)
+            indexer = lexsort_indexer([self.labels[lev] for lev in level],
+                                      orders=ascending)
 
         # level ordering
         else:

--- a/pandas/tests/test_multilevel.py
+++ b/pandas/tests/test_multilevel.py
@@ -2781,3 +2781,20 @@ class TestSorted(Base):
         result = s.sort_index(na_position='first')
         expected = s.iloc[[1, 2, 3, 0]]
         tm.assert_series_equal(result, expected)
+
+    def test_sort_ascending_list(self):
+        # GH: 16934
+
+        # Set up a Series with a three level MultiIndex
+        arrays = [['bar', 'bar', 'baz', 'baz', 'foo', 'foo', 'qux', 'qux'],
+                  ['one', 'two', 'one', 'two', 'one', 'two', 'one', 'two'],
+                  [4, 3, 2, 1, 4, 3, 2, 1]]
+        tuples = list(zip(*arrays))
+        index = pd.MultiIndex.from_tuples(tuples,
+                                          names=['first', 'second', 'third'])
+        s = pd.Series(range(8), index=index)
+
+        result = s.sort_index(level=['third', 'first'],
+                              ascending=[False, True])
+
+        assert np.array_equal(result, [0, 4, 1, 5, 2, 6, 3, 7])

--- a/pandas/tests/test_multilevel.py
+++ b/pandas/tests/test_multilevel.py
@@ -2794,7 +2794,13 @@ class TestSorted(Base):
                                           names=['first', 'second', 'third'])
         s = pd.Series(range(8), index=index)
 
+        # Sort with boolean ascending
+        result = s.sort_index(level=['third', 'first'], ascending=False)
+        expected = s.iloc[[4, 0, 5, 1, 6, 2, 7, 3]]
+        tm.assert_series_equal(result, expected)
+
+        # Sort with list of boolean ascending
         result = s.sort_index(level=['third', 'first'],
                               ascending=[False, True])
-
-        assert np.array_equal(result, [0, 4, 1, 5, 2, 6, 3, 7])
+        expected = s.iloc[[0, 4, 1, 5, 2, 6, 3, 7]]
+        tm.assert_series_equal(result, expected)


### PR DESCRIPTION
MultiIndex sorting with `sort_index` would fail when the `ascending`
argument was specified as a list but not all levels of the index were
specified in the `level` argument, or the levels were specified in
a different order to the MultiIndex.

 - [X] closes #16934
 - [X] tests added / passed
 - [X] passes ``git diff upstream/master -u -- "*.py" | flake8 --diff``
 - [X] whatsnew entry