### PR TITLE
TST: Don't assert that a bug exists in numpy

### DIFF
--- a/pandas/tests/test_algos.py
+++ b/pandas/tests/test_algos.py
@@ -2,6 +2,7 @@
 
 import numpy as np
 import pytest
+import warnings
 
 from numpy.random import RandomState
 from numpy import nan
@@ -127,7 +128,7 @@ class TestSafeSort(object):
         arr = np.array([1, 2, datetime.now(), 0, 3], dtype=object)
         if compat.PY2 and not pd._np_version_under1p10:
             # RuntimeWarning: tp_compare didn't return -1 or -2 for exception
-            with tm.assert_produces_warning(RuntimeWarning):
+            with warnings.catch_warnings():
                 pytest.raises(TypeError, algos.safe_sort, arr)
         else:
             pytest.raises(TypeError, algos.safe_sort, arr)


### PR DESCRIPTION
Better to ignore the warning from the bug, rather than assert the bug is still there

After this change, numpy/numpy#9412 _could_ be backported to fix the bug