### PR TITLE
DEPR #16747: deprecate pd.TimeGrouper 

### DIFF
--- a/pandas/core/resample.py
+++ b/pandas/core/resample.py
@@ -1020,6 +1020,10 @@ class TimeGrouper(Grouper):
                  nperiods=None, axis=0,
                  fill_method=None, limit=None, loffset=None, kind=None,
                  convention=None, base=0, **kwargs):
+        # deprecation TimeGrouper, #16747
+        warnings.warn("TimeGrouper is deprecated. Please use "
+                      "Grouper", FutureWarning, stacklevel=2)
+
         freq = to_offset(freq)
 
         end_types = set(['M', 'A', 'Q', 'BM', 'BA', 'BQ', 'W'])

--- a/pandas/tests/api/test_api.py
+++ b/pandas/tests/api/test_api.py
@@ -47,7 +47,7 @@ class TestPDApi(Base):
                'Grouper', 'HDFStore', 'Index', 'Int64Index', 'MultiIndex',
                'Period', 'PeriodIndex', 'RangeIndex', 'UInt64Index',
                'Series', 'SparseArray', 'SparseDataFrame',
-               'SparseSeries', 'TimeGrouper', 'Timedelta',
+               'SparseSeries', 'Timedelta',
                'TimedeltaIndex', 'Timestamp', 'Interval', 'IntervalIndex']
 
     # these are already deprecated; awaiting removal
@@ -55,7 +55,7 @@ class TestPDApi(Base):
                           'SparseList', 'Expr', 'Term']
 
     # these should be deprecated in the future
-    deprecated_classes_in_future = ['Panel']
+    deprecated_classes_in_future = ['Panel', 'TimeGrouper']
 
     # external modules exposed in pandas namespace
     modules = ['np', 'datetime']

--- a/pandas/tests/api/test_api.py
+++ b/pandas/tests/api/test_api.py
@@ -52,10 +52,11 @@ class TestPDApi(Base):
 
     # these are already deprecated; awaiting removal
     deprecated_classes = ['WidePanel', 'Panel4D',
-                          'SparseList', 'Expr', 'Term']
+                          'SparseList', 'Expr', 'Term',
+                          'TimeGrouper']
 
     # these should be deprecated in the future
-    deprecated_classes_in_future = ['Panel', 'TimeGrouper']
+    deprecated_classes_in_future = ['Panel']
 
     # external modules exposed in pandas namespace
     modules = ['np', 'datetime']

--- a/pandas/tests/test_resample.py
+++ b/pandas/tests/test_resample.py
@@ -3031,7 +3031,7 @@ class TestTimeGrouper(object):
                          index=date_range('1/1/2000', periods=1000))
 
     def test_TimeGrouper_deprecation(self):
-        # deprecation TimeGrouper, #16747
+        # GH 16747
         with tm.assert_produces_warning(FutureWarning):
             TimeGrouper('A', label='right', closed='right')
 

--- a/pandas/tests/test_resample.py
+++ b/pandas/tests/test_resample.py
@@ -3030,6 +3030,11 @@ class TestTimeGrouper(object):
         self.ts = Series(np.random.randn(1000),
                          index=date_range('1/1/2000', periods=1000))
 
+    def test_TimeGrouper_deprecation(self):
+        # deprecation TimeGrouper, #16747
+        with tm.assert_produces_warning(FutureWarning):
+            TimeGrouper('A', label='right', closed='right')
+
     def test_apply(self):
         grouper = TimeGrouper('A', label='right', closed='right')
 


### PR DESCRIPTION
 - [x] closes #16747
 - [x] tests added / passed
 - [x] passes ``git diff upstream/master -u -- "*.py" | flake8 --diff``
 - [ ] whatsnew entry -> Should I do this for a future   
