### PR TITLE
Support non unique period indexes on join and merge operations

### DIFF
--- a/doc/source/whatsnew/v0.21.0.txt
+++ b/doc/source/whatsnew/v0.21.0.txt
@@ -185,7 +185,7 @@ Sparse
 
 Reshaping
 ^^^^^^^^^
-
+- Joining/Merging with a non unique ``PeriodIndex`` raised a TypeError (:issue:`16871`)
 
 
 Numeric

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -3119,14 +3119,14 @@ class Index(IndexOpsMixin, StringAccessorMixin, PandasObject):
     def _join_non_unique(self, other, how='left', return_indexers=False):
         from pandas.core.reshape.merge import _get_join_indexers
 
-        left_idx, right_idx = _get_join_indexers([self.values],
+        left_idx, right_idx = _get_join_indexers([self._values],
                                                  [other._values], how=how,
                                                  sort=True)
 
         left_idx = _ensure_platform_int(left_idx)
         right_idx = _ensure_platform_int(right_idx)
 
-        join_index = np.asarray(self.values.take(left_idx))
+        join_index = np.asarray(self._values.take(left_idx))
         mask = left_idx == -1
         np.putmask(join_index, mask, other._values.take(right_idx))
 

--- a/pandas/tests/reshape/test_join.py
+++ b/pandas/tests/reshape/test_join.py
@@ -550,6 +550,13 @@ class TestJoin(object):
                              index=[1, 2, 2, 'a'])
         tm.assert_frame_equal(result, expected)
 
+    def test_join_non_unique_period_index(self):
+        per_index = pd.period_range('2016-01-01', periods=16, freq='M')
+        per_df = DataFrame([i for i in range(len(per_index))],
+                           index=per_index, columns=['pnum'])
+        df2 = concat([per_df, per_df])
+        per_df.join(df2, how='outer', rsuffix='_df2')
+
     def test_mixed_type_join_with_suffix(self):
         # GH #916
         df = DataFrame(np.random.randn(20, 6),

--- a/pandas/tests/reshape/test_join.py
+++ b/pandas/tests/reshape/test_join.py
@@ -551,11 +551,16 @@ class TestJoin(object):
         tm.assert_frame_equal(result, expected)
 
     def test_join_non_unique_period_index(self):
-        per_index = pd.period_range('2016-01-01', periods=16, freq='M')
-        per_df = DataFrame([i for i in range(len(per_index))],
-                           index=per_index, columns=['pnum'])
-        df2 = concat([per_df, per_df])
-        per_df.join(df2, how='outer', rsuffix='_df2')
+        # GH #16871
+        index = pd.period_range('2016-01-01', periods=16, freq='M')
+        df = DataFrame([i for i in range(len(index))],
+                       index=index, columns=['pnum'])
+        df2 = concat([df, df])
+        result = df.join(df2, how='inner', rsuffix='_df2')
+        expected = DataFrame(np.tile(np.arange(16).repeat(2).reshape(-1, 1), 2),
+                             columns=['pnum', 'pnum_df2'],
+                             index=df2.sort_index().index)
+        tm.assert_frame_equal(result, expected)
 
     def test_mixed_type_join_with_suffix(self):
         # GH #916

--- a/pandas/tests/reshape/test_join.py
+++ b/pandas/tests/reshape/test_join.py
@@ -557,9 +557,9 @@ class TestJoin(object):
                        index=index, columns=['pnum'])
         df2 = concat([df, df])
         result = df.join(df2, how='inner', rsuffix='_df2')
-        expected = DataFrame(np.tile(np.arange(16).repeat(2).reshape(-1, 1), 2),
-                             columns=['pnum', 'pnum_df2'],
-                             index=df2.sort_index().index)
+        expected = DataFrame(
+            np.tile(np.arange(16, dtype=np.int64).repeat(2).reshape(-1, 1), 2),
+            columns=['pnum', 'pnum_df2'], index=df2.sort_index().index)
         tm.assert_frame_equal(result, expected)
 
     def test_mixed_type_join_with_suffix(self):

--- a/pandas/tests/reshape/test_merge.py
+++ b/pandas/tests/reshape/test_merge.py
@@ -585,6 +585,13 @@ class TestMerge(object):
         assert result['value_x'].dtype == 'datetime64[ns, US/Eastern]'
         assert result['value_y'].dtype == 'datetime64[ns, US/Eastern]'
 
+    def test_merge_non_unique_period_index(self):
+        per_index = pd.period_range('2016-01-01', periods=16, freq='M')
+        per_df = DataFrame([i for i in range(len(per_index))],
+                           index=per_index, columns=['pnum'])
+        df2 = concat([per_df, per_df])
+        per_df.merge(df2, left_index=True, right_index=True, how='outer')
+
     def test_merge_on_periods(self):
         left = pd.DataFrame({'key': pd.period_range('20151010', periods=2,
                                                     freq='D'),

--- a/pandas/tests/reshape/test_merge.py
+++ b/pandas/tests/reshape/test_merge.py
@@ -592,9 +592,9 @@ class TestMerge(object):
                        index=index, columns=['pnum'])
         df2 = concat([df, df])
         result = df.merge(df2, left_index=True, right_index=True, how='inner')
-        expected = DataFrame(np.tile(np.arange(16).repeat(2).reshape(-1, 1), 2),
-                             columns=['pnum_x', 'pnum_y'],
-                             index=df2.sort_index().index)
+        expected = DataFrame(
+            np.tile(np.arange(16, dtype=np.int64).repeat(2).reshape(-1, 1), 2),
+            columns=['pnum_x', 'pnum_y'], index=df2.sort_index().index)
         tm.assert_frame_equal(result, expected)
 
     def test_merge_on_periods(self):


### PR DESCRIPTION
 - [x] closes #16871
 - [x] tests added / passed
 - [x] passes ``git diff upstream/master -u -- "*.py" | flake8 --diff``
 - [x] whatsnew entry

Now join and merge operations on dataframes with non unique period indexes are supported, test included.