### PR TITLE
BUG: If Series is called with no arguments, let it have a RangeIndex (#16737)

### DIFF
--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -173,6 +173,8 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
 
             if data is None:
                 data = {}
+                if index is None:
+                    index = _default_index(0)
             if dtype is not None:
                 dtype = self._validate_dtype(dtype)
 


### PR DESCRIPTION
 - [x] closes #16737
 - [ ] tests added / passed
 - [x] passes ``git diff upstream/master -u -- "*.py" | flake8 --diff``
 - [x] whatsnew entry

Before:
```python
In [4]: Series().index
Out[4]: Index([], dtype='object')
```

Now:
```python
In [3]: Series().index
Out[3]: RangeIndex(start=0, stop=0, step=1)
```