### PR TITLE
DEPR: deprecate html.border option

### DIFF
--- a/doc/source/options.rst
+++ b/doc/source/options.rst
@@ -400,7 +400,7 @@ display.width                       80           Width of the display in charact
 display.html.table_schema           False        Whether to publish a Table Schema
                                                  representation for frontends that
                                                  support it.
-html.border                         1            A ``border=value`` attribute is
+display.html.border                 1            A ``border=value`` attribute is
                                                  inserted in the ``<table>`` tag
                                                  for the DataFrame HTML repr.
 io.excel.xls.writer                 xlwt         The default Excel writer engine for

--- a/doc/source/whatsnew/v0.21.0.txt
+++ b/doc/source/whatsnew/v0.21.0.txt
@@ -116,6 +116,7 @@ Deprecations
 ~~~~~~~~~~~~
 - :func:`read_excel()` has deprecated ``sheetname`` in favor of ``sheet_name`` for consistency with ``.to_excel()`` (:issue:`10559`).
 
+- ``pd.options.html.border`` has been deprecated in favor of ``pd.options.display.html.border`` (:issue:`15793`).
 
 .. _whatsnew_0210.prior_deprecations:
 

--- a/pandas/core/config_init.py
+++ b/pandas/core/config_init.py
@@ -202,6 +202,17 @@ pc_table_schema_doc = """
     (default: False)
 """
 
+pc_html_border_doc = """
+: int
+    A ``border=value`` attribute is inserted in the ``<table>`` tag
+    for the DataFrame HTML repr.
+"""
+
+pc_html_border_deprecation_warning = """\
+html.border has been deprecated, use display.html.border instead
+(currently both are identical)
+"""
+
 pc_line_width_deprecation_warning = """\
 line_width has been deprecated, use display.width instead (currently both are
 identical)
@@ -381,6 +392,8 @@ with cf.config_prefix('display'):
                        validator=is_bool)
     cf.register_option('html.table_schema', False, pc_table_schema_doc,
                        validator=is_bool, cb=table_schema_cb)
+    cf.register_option('html.border', 1, pc_html_border_doc,
+                       validator=is_int)
 
 
 cf.deprecate_option('display.line_width',
@@ -390,15 +403,12 @@ cf.deprecate_option('display.line_width',
 cf.deprecate_option('display.height', msg=pc_height_deprecation_warning,
                     rkey='display.max_rows')
 
-pc_html_border_doc = """
-: int
-    A ``border=value`` attribute is inserted in the ``<table>`` tag
-    for the DataFrame HTML repr.
-"""
-
 with cf.config_prefix('html'):
     cf.register_option('border', 1, pc_html_border_doc,
                        validator=is_int)
+
+cf.deprecate_option('html.border', msg=pc_html_border_deprecation_warning,
+                    rkey='display.html.border')
 
 
 tc_sim_interactive_doc = """

--- a/pandas/io/formats/format.py
+++ b/pandas/io/formats/format.py
@@ -1064,7 +1064,7 @@ class HTMLFormatter(TableFormatter):
                              self.max_cols < len(self.fmt.columns))
         self.notebook = notebook
         if border is None:
-            border = get_option('html.border')
+            border = get_option('display.html.border')
         self.border = border
 
     def write(self, s, indent=0):

--- a/pandas/tests/io/formats/test_to_html.py
+++ b/pandas/tests/io/formats/test_to_html.py
@@ -1401,7 +1401,7 @@ class TestToHTML(object):
 
     def test_to_html_border_option(self):
         df = DataFrame({'A': [1, 2]})
-        with pd.option_context('html.border', 0):
+        with pd.option_context('display.html.border', 0):
             result = df.to_html()
             assert 'border="0"' in result
             assert 'border="0"' in df._repr_html_()
@@ -1410,6 +1410,11 @@ class TestToHTML(object):
         df = DataFrame({'A': [1, 2]})
         result = df.to_html(border=0)
         assert 'border="0"' in result
+
+    def test_display_option_warning(self):
+        with tm.assert_produces_warning(DeprecationWarning,
+                                        check_stacklevel=False):
+            pd.options.html.border
 
     def test_to_html(self):
         # big mixed


### PR DESCRIPTION
Use display.html.border instead

 - [x] closes #15793 
 - [x] tests added / passed
 - [x] passes ``git diff upstream/master -u -- "*.py" | flake8 --diff``
 - [x] whatsnew entry
