### PR TITLE
BUG: resample with non-existant columns

### DIFF
--- a/pandas/core/resample.py
+++ b/pandas/core/resample.py
@@ -366,6 +366,8 @@ class Resampler(_GroupBy):
         subset : object, default None
             subset to act on
         """
+        if key not in self.obj.keys():
+            raise KeyError('{}'.format(key))
         self._set_binner()
         grouper = self.grouper
         if subset is None:


### PR DESCRIPTION
 - [ ] closes #16766 
 - [ ] tests added / passed
 - [ ] passes ``git diff upstream/master -u -- "*.py" | flake8 --diff``
 - [ ] whatsnew entry

I have added a check for keys in ``Resampler._gotitem``. I am not sure if it's the best place to put this check. ``df.groupby('x').agg({'z': ['sum'] })`` works as pointed out by @chris-b1 but I suspect there is no explicit check if the key exists or not. From what I found the code errors inside ``DataFrameGroupBy._gotitem``, due to the ``self.obj[key]`` call which is not in ``Resampler._gotitem``. If this is a suitable fix, I can add similar check in ``DataFrameGroupBy._gotitem`` (current traceback is very messy).