### PR TITLE
MAINT: Drop line_width and height from options

### DIFF
--- a/doc/source/options.rst
+++ b/doc/source/options.rst
@@ -304,7 +304,6 @@ display.float_format                None         The callable should accept a fl
                                                  This is used in some places like
                                                  SeriesFormatter.
                                                  See core.format.EngFormatter for an example.
-display.height                      60           Deprecated. Use `display.max_rows` instead.
 display.large_repr                  truncate     For DataFrames exceeding max_rows/max_cols,
                                                  the repr (and HTML repr) can show
                                                  a truncated table (the default from 0.13),
@@ -323,7 +322,6 @@ display.latex.multicolumn_format    'l'          Alignment of multicolumn labels
 display.latex.multirow              False        Combines rows when using a MultiIndex.
                                                  Centered instead of top-aligned,
                                                  separated by clines.
-display.line_width                  80           Deprecated. Use `display.width` instead.
 display.max_columns                 20           max_rows and max_columns are used
                                                  in __repr__() methods to decide if
                                                  to_string() or info() is used to

--- a/doc/source/whatsnew/v0.21.0.txt
+++ b/doc/source/whatsnew/v0.21.0.txt
@@ -124,6 +124,8 @@ Removal of prior version deprecations/changes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 - :func:`read_excel()` has dropped the ``has_index_names`` parameter (:issue:`10967`)
+- The ``pd.options.display.height`` configuration has been dropped (:issue:`3663`)
+- The ``pd.options.display.line_width`` configuration has been dropped (:issue:`2881`)
 - The ``pd.options.display.mpl_style`` configuration has been dropped (:issue:`12190`)
 - ``Index`` has dropped the ``.sym_diff()`` method in favor of ``.symmetric_difference()`` (:issue:`12591`)
 - ``Categorical`` has dropped the ``.order()`` and ``.sort()`` methods in favor of ``.sort_values()`` (:issue:`12882`)

--- a/pandas/core/config_init.py
+++ b/pandas/core/config_init.py
@@ -213,14 +213,6 @@ html.border has been deprecated, use display.html.border instead
 (currently both are identical)
 """
 
-pc_line_width_deprecation_warning = """\
-line_width has been deprecated, use display.width instead (currently both are
-identical)
-"""
-
-pc_height_deprecation_warning = """\
-height has been deprecated.
-"""
 
 pc_width_doc = """
 : int
@@ -382,14 +374,6 @@ with cf.config_prefix('display'):
                        validator=is_bool, cb=table_schema_cb)
     cf.register_option('html.border', 1, pc_html_border_doc,
                        validator=is_int)
-
-
-cf.deprecate_option('display.line_width',
-                    msg=pc_line_width_deprecation_warning,
-                    rkey='display.width')
-
-cf.deprecate_option('display.height', msg=pc_height_deprecation_warning,
-                    rkey='display.max_rows')
 
 with cf.config_prefix('html'):
     cf.register_option('border', 1, pc_html_border_doc,

--- a/pandas/io/formats/console.py
+++ b/pandas/io/formats/console.py
@@ -53,7 +53,7 @@ def get_console_size():
 
     display_width = get_option('display.width')
     # deprecated.
-    display_height = get_option('display.height', silent=True)
+    display_height = get_option('display.max_rows')
 
     # Consider
     # interactive shell terminal, can detect term size
@@ -71,7 +71,7 @@ def get_console_size():
             # match default for width,height in config_init
             from pandas.core.config import get_default_val
             terminal_width = get_default_val('display.width')
-            terminal_height = get_default_val('display.height')
+            terminal_height = get_default_val('display.max_rows')
         else:
             # pure terminal
             terminal_width, terminal_height = get_terminal_size()

--- a/pandas/tests/io/formats/test_format.py
+++ b/pandas/tests/io/formats/test_format.py
@@ -302,7 +302,7 @@ class TestDataFrameFormatting(object):
         df = DataFrame('hello', lrange(1000), lrange(5))
 
         with option_context('mode.sim_interactive', False, 'display.width', 0,
-                            'display.height', 0, 'display.max_rows', 5000):
+                            'display.max_rows', 5000):
             assert not has_truncated_repr(df)
             assert not has_expanded_repr(df)
 


### PR DESCRIPTION
Deprecated since 0.11 and 0.12 respectively.

xref #2881
xref #3663


