### PR TITLE
BUG: np.inf now causes Index to upcast from int to float

### DIFF
--- a/doc/source/whatsnew/v0.21.0.txt
+++ b/doc/source/whatsnew/v0.21.0.txt
@@ -145,7 +145,7 @@ Bug Fixes
 ~~~~~~~~~
 
 - Fixes regression in 0.20, :func:`Series.aggregate` and :func:`DataFrame.aggregate` allow dictionaries as return values again (:issue:`16741`)
-- Fixes bug where indexing with `np.inf` caused an `OverflowError` to be raised (:issue:`16957`)
+- Fixes bug where indexing with ``np.inf`` caused an ``OverflowError`` to be raised (:issue:`16957`)
 
 Conversion
 ^^^^^^^^^^

--- a/doc/source/whatsnew/v0.21.0.txt
+++ b/doc/source/whatsnew/v0.21.0.txt
@@ -145,6 +145,7 @@ Bug Fixes
 ~~~~~~~~~
 
 - Fixes regression in 0.20, :func:`Series.aggregate` and :func:`DataFrame.aggregate` allow dictionaries as return values again (:issue:`16741`)
+- Fixes inf upcast from integer indices in 0.20, previously :func:`Int64Index.__contains__` and `DataFrame.loc.__setitem__` raised an `OverflowError` when given `np.inf` (:issue:`16957`)
 
 Conversion
 ^^^^^^^^^^

--- a/doc/source/whatsnew/v0.21.0.txt
+++ b/doc/source/whatsnew/v0.21.0.txt
@@ -145,7 +145,7 @@ Bug Fixes
 ~~~~~~~~~
 
 - Fixes regression in 0.20, :func:`Series.aggregate` and :func:`DataFrame.aggregate` allow dictionaries as return values again (:issue:`16741`)
-- Fixes inf upcast from integer indices in 0.20, previously :func:`Int64Index.__contains__` and `DataFrame.loc.__setitem__` raised an `OverflowError` when given `np.inf` (:issue:`16957`)
+- Fixes bug where indexing with `np.inf` caused an `OverflowError` to be raised (:issue:`16957`)
 
 Conversion
 ^^^^^^^^^^

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -666,7 +666,7 @@ class Index(IndexOpsMixin, StringAccessorMixin, PandasObject):
             res = data.astype('u8', copy=False)
             if (res == data).all():
                 return UInt64Index(res, copy=copy, name=name)
-        except (TypeError, ValueError):
+        except (OverflowError, TypeError, ValueError):
             pass
 
         raise ValueError
@@ -1640,7 +1640,7 @@ class Index(IndexOpsMixin, StringAccessorMixin, PandasObject):
         hash(key)
         try:
             return key in self._engine
-        except (TypeError, ValueError):
+        except (OverflowError, TypeError, ValueError):
             return False
 
     _index_shared_docs['contains'] = """
@@ -3365,7 +3365,7 @@ class Index(IndexOpsMixin, StringAccessorMixin, PandasObject):
                 ckey = int(key)
                 if ckey == key:
                     key = ckey
-            except (ValueError, TypeError):
+            except (OverflowError, ValueError, TypeError):
                 pass
         return key
 

--- a/pandas/tests/indexing/test_indexing.py
+++ b/pandas/tests/indexing/test_indexing.py
@@ -571,20 +571,19 @@ class TestFancy(Base):
         # expected = Series({'float64': 2, 'object': 1}).sort_index()
 
     @pytest.mark.parametrize("val,expected", [
-        (np.inf, False),
-        (np.nan, False),
-        (3.0, True),
-        (3.5, False),
-        (0.0, True),
+        # Checking if np.inf in Int64Index should not cause an OverflowError
+        (pd.Int64Index([0, 1, 2]), np.inf, False),
+        (pd.Int64Index([0, 1, 2]), np.nan, False),
+        (pd.UInt64Index([0, 1, 2]), np.inf, False),
+        (pd.UInt64Index([0, 1, 2]), np.nan, False),
+        # Check contains correctly checks for np.inf
+        (pd.Index([0, 1, 2, np.inf]), np.inf, True),
+        (pd.Index([0, 1, 2, np.nan]), np.nan, True),
+        (pd.Index([0, 1, 2, np.inf]), np.nan, False),
+        (pd.Index([0, 1, 2, np.nan]), np.inf, False),
     ])
-    def test_coercion_with_contains(self, val, expected):
+    def test_coercion_with_contains(self, index, val, expected):
         # Related to GH 16957
-        # Checking if Int64Index contains np.inf should catch the OverflowError
-        index = pd.Int64Index([1, 2, 3])
-        result = val in index
-        assert result is expected
-
-        index = pd.UInt64Index([1, 2, 3])
         result = val in index
         assert result is expected
 

--- a/pandas/tests/indexing/test_indexing.py
+++ b/pandas/tests/indexing/test_indexing.py
@@ -573,6 +573,17 @@ class TestFancy(Base):
     @pytest.mark.parametrize("index,val", [
         (pd.Index([0, 1, 2]), 2),
         (pd.Index([0, 1, '2']), '2'),
+        (pd.Index([0, 1, 2, np.inf, 4]), 4),
+        (pd.Index([0, 1, 2, np.nan, 4]), 4),
+        (pd.Index([0, 1, 2, np.inf]), np.inf),
+        (pd.Index([0, 1, 2, np.nan]), np.nan),
+    ])
+    def test_index_contains(self, index, val):
+        assert val in index
+
+    @pytest.mark.parametrize("index,val", [
+        (pd.Index([0, 1, 2]), '2'),
+        (pd.Index([0, 1, '2']), 2),
         (pd.Index([0, 1, 2, np.inf]), 4),
         (pd.Index([0, 1, 2, np.nan]), 4),
         (pd.Index([0, 1, 2, np.inf]), np.nan),
@@ -583,17 +594,6 @@ class TestFancy(Base):
         (pd.Int64Index([0, 1, 2]), np.nan),
         (pd.UInt64Index([0, 1, 2]), np.inf),
         (pd.UInt64Index([0, 1, 2]), np.nan),
-    ])
-    def test_index_contains(self, index, val):
-        assert val in index
-
-    @pytest.mark.parametrize("index,val", [
-        (pd.Index([0, 1, 2]), '2'),
-        (pd.Index([0, 1, '2']), 2),
-        (pd.Index([0, 1, 2, np.inf, 4]), 4),
-        (pd.Index([0, 1, 2, np.nan, 4]), 4),
-        (pd.Index([0, 1, 2, np.inf]), np.inf),
-        (pd.Index([0, 1, 2, np.nan]), np.nan),
     ])
     def test_index_not_contains(self, index, val):
         assert val not in index

--- a/pandas/tests/indexing/test_indexing.py
+++ b/pandas/tests/indexing/test_indexing.py
@@ -75,8 +75,7 @@ class TestFancy(Base):
         df.loc[np.inf] = 3
 
         # make sure we can look up the value
-        result = df.loc[np.inf, 0]
-        tm.assert_almost_equal(result, 3)
+        assert df.loc[np.inf, 0] == 3
 
         result = df.index
         expected = pd.Float64Index([1, 2, np.inf])
@@ -571,17 +570,23 @@ class TestFancy(Base):
         # result = df.get_dtype_counts().sort_index()
         # expected = Series({'float64': 2, 'object': 1}).sort_index()
 
-    def test_coercion_with_contains(self):
+    @pytest.mark.parametrize("val,expected", [
+        (np.inf, False),
+        (np.nan, False),
+        (3.0, True),
+        (3.5, False),
+        (0.0, True),
+    ])
+    def test_coercion_with_contains(self, val, expected):
         # Related to GH 16957
         # Checking if Int64Index contains np.inf should catch the OverflowError
-        for val in [np.inf, np.nan]:
-            index = pd.Int64Index([1, 2, 3])
-            result = val in index
-            tm.assert_almost_equal(result, False)
+        index = pd.Int64Index([1, 2, 3])
+        result = val in index
+        assert result is expected
 
-            index = pd.UInt64Index([1, 2, 3])
-            result = np.inf in index
-            tm.assert_almost_equal(result, False)
+        index = pd.UInt64Index([1, 2, 3])
+        result = val in index
+        assert result is expected
 
     def test_index_type_coercion(self):
 

--- a/pandas/tests/indexing/test_indexing.py
+++ b/pandas/tests/indexing/test_indexing.py
@@ -570,7 +570,7 @@ class TestFancy(Base):
         # result = df.get_dtype_counts().sort_index()
         # expected = Series({'float64': 2, 'object': 1}).sort_index()
 
-    @pytest.mark.parametrize("val,expected", [
+    @pytest.mark.parametrize("index,val,expected", [
         # Checking if np.inf in Int64Index should not cause an OverflowError
         (pd.Int64Index([0, 1, 2]), np.inf, False),
         (pd.Int64Index([0, 1, 2]), np.nan, False),

--- a/pandas/tests/indexing/test_indexing.py
+++ b/pandas/tests/indexing/test_indexing.py
@@ -570,22 +570,33 @@ class TestFancy(Base):
         # result = df.get_dtype_counts().sort_index()
         # expected = Series({'float64': 2, 'object': 1}).sort_index()
 
-    @pytest.mark.parametrize("index,val,expected", [
+    @pytest.mark.parametrize("index,val", [
+        (pd.Index([0, 1, 2]), 2),
+        (pd.Index([0, 1, '2']), '2'),
+        (pd.Index([0, 1, 2, np.inf]), 4),
+        (pd.Index([0, 1, 2, np.nan]), 4),
+        (pd.Index([0, 1, 2, np.inf]), np.nan),
+        (pd.Index([0, 1, 2, np.nan]), np.inf),
         # Checking if np.inf in Int64Index should not cause an OverflowError
-        (pd.Int64Index([0, 1, 2]), np.inf, False),
-        (pd.Int64Index([0, 1, 2]), np.nan, False),
-        (pd.UInt64Index([0, 1, 2]), np.inf, False),
-        (pd.UInt64Index([0, 1, 2]), np.nan, False),
-        # Check contains correctly checks for np.inf
-        (pd.Index([0, 1, 2, np.inf]), np.inf, True),
-        (pd.Index([0, 1, 2, np.nan]), np.nan, True),
-        (pd.Index([0, 1, 2, np.inf]), np.nan, False),
-        (pd.Index([0, 1, 2, np.nan]), np.inf, False),
-    ])
-    def test_coercion_with_contains(self, index, val, expected):
         # Related to GH 16957
-        result = val in index
-        assert result is expected
+        (pd.Int64Index([0, 1, 2]), np.inf),
+        (pd.Int64Index([0, 1, 2]), np.nan),
+        (pd.UInt64Index([0, 1, 2]), np.inf),
+        (pd.UInt64Index([0, 1, 2]), np.nan),
+    ])
+    def test_index_contains(self, index, val):
+        assert val in index
+
+    @pytest.mark.parametrize("index,val", [
+        (pd.Index([0, 1, 2]), '2'),
+        (pd.Index([0, 1, '2']), 2),
+        (pd.Index([0, 1, 2, np.inf, 4]), 4),
+        (pd.Index([0, 1, 2, np.nan, 4]), 4),
+        (pd.Index([0, 1, 2, np.inf]), np.inf),
+        (pd.Index([0, 1, 2, np.nan]), np.nan),
+    ])
+    def test_index_not_contains(self, index, val):
+        assert val not in index
 
     def test_index_type_coercion(self):
 


### PR DESCRIPTION
 - [x] closes #16957
 - [x] tests added / passed
 - [x] passes ``git diff upstream/master -u -- "*.py" | flake8 --diff``
 - [x] whatsnew entry

Previously the following code would cause an OverflowError

```python
df = pd.DataFrame(columns=[0])
df.loc[0] = 0
df.loc[np.inf] = 1
```

This patch catches the exception and allows the `pd.Int64Index` / `pd.UInt64Index` to upcast itself into a `pd.Float64Index`. 

Additionally, when I was writing tests for this patch I noticed 

```python 
np.inf in pd.Int64Index([1, 2, 3])
```

would also cause an OverflowError. I also patched this as well, and now it correctly returns False. 

------- 

I had trouble running tests on my local machine, so I'll wait for the travis checks. 

I'm also unsure the whatsnew entry is in the correct format. Let me know if that needs to be changed. 