### PR TITLE
BUG: Don't error with empty Series for .isin

### DIFF
--- a/doc/source/whatsnew/v0.21.0.txt
+++ b/doc/source/whatsnew/v0.21.0.txt
@@ -204,3 +204,4 @@ Categorical
 Other
 ^^^^^
 - Bug in :func:`eval` where the ``inplace`` parameter was being incorrectly handled (:issue:`16732`)
+- Bug in ``.isin()`` in which checking membership in empty ``Series`` objects raised an error (:issue:`16991`)

--- a/pandas/core/algorithms.py
+++ b/pandas/core/algorithms.py
@@ -65,6 +65,8 @@ def _ensure_data(values, dtype=None):
 
     # we check some simple dtypes first
     try:
+        if is_object_dtype(dtype):
+            return _ensure_object(np.asarray(values)), 'object', 'object'
         if is_bool_dtype(values) or is_bool_dtype(dtype):
             # we are actually coercing to uint64
             # until our algos suppport uint8 directly (see TODO)

--- a/pandas/tests/frame/test_analytics.py
+++ b/pandas/tests/frame/test_analytics.py
@@ -1151,10 +1151,13 @@ class TestDataFrameAnalytics(TestData):
         expected = DataFrame([df.loc[s].isin(other) for s in df.index])
         tm.assert_frame_equal(result, expected)
 
-    def test_isin_empty(self):
+    @pytest.mark.parametrize("empty", [[], Series(), np.array([])])
+    def test_isin_empty(self, empty):
+        # see gh-16991
         df = DataFrame({'A': ['a', 'b', 'c'], 'B': ['a', 'e', 'f']})
-        result = df.isin([])
-        expected = pd.DataFrame(False, df.index, df.columns)
+        expected = DataFrame(False, df.index, df.columns)
+
+        result = df.isin(empty)
         tm.assert_frame_equal(result, expected)
 
     def test_isin_dict(self):

--- a/pandas/tests/indexes/test_base.py
+++ b/pandas/tests/indexes/test_base.py
@@ -1407,6 +1407,15 @@ class TestIndex(Base):
         # Float64Index overrides isin, so must be checked separately
         check_idx(Float64Index([1.0, 2.0, 3.0, 4.0]))
 
+    @pytest.mark.parametrize("empty", [[], Series(), np.array([])])
+    def test_isin_empty(self, empty):
+        # see gh-16991
+        idx = Index(["a", "b"])
+        expected = np.array([False, False])
+
+        result = idx.isin(empty)
+        tm.assert_numpy_array_equal(expected, result)
+
     def test_boolean_cmp(self):
         values = [1, 2, 3, 4]
 

--- a/pandas/tests/series/test_analytics.py
+++ b/pandas/tests/series/test_analytics.py
@@ -1135,6 +1135,15 @@ class TestSeriesAnalytics(TestData):
         result = s.isin(s[0:2])
         assert_series_equal(result, expected)
 
+    @pytest.mark.parametrize("empty", [[], Series(), np.array([])])
+    def test_isin_empty(self, empty):
+        # see gh-16991
+        s = Series(["a", "b"])
+        expected = Series([False, False])
+
+        result = s.isin(empty)
+        tm.assert_series_equal(expected, result)
+
     def test_timedelta64_analytics(self):
         from pandas import date_range
 

--- a/pandas/tests/test_algos.py
+++ b/pandas/tests/test_algos.py
@@ -597,6 +597,15 @@ class TestIsin(object):
         result = algos.isin(Sd, St)
         tm.assert_numpy_array_equal(expected, result)
 
+    @pytest.mark.parametrize("empty", [[], pd.Series(), np.array([])])
+    def test_empty(self, empty):
+        # see gh-16991
+        vals = pd.Index(["a", "b"])
+        expected = np.array([False, False])
+
+        result = algos.isin(vals, empty)
+        tm.assert_numpy_array_equal(expected, result)
+
 
 class TestValueCounts(object):
 


### PR DESCRIPTION
Empty `Series` initializes to `float64`, even when the data type is `object` for `.isin`, leading to an error with membership.

Closes #16991.