### PR TITLE
Define DataFrame plot methods in DataFrame

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -5651,11 +5651,31 @@ it is assumed to be aliases for the column names')
                                 values).reshape(self.shape), self.index,
                 self.columns)
 
+    # ----------------------------------------------------------------------
+    # Add plotting methods to DataFrame
+    plot = base.AccessorProperty(gfx.FramePlotMethods, gfx.FramePlotMethods)
+    hist = gfx.hist_frame
+
+    @Appender(_shared_docs['boxplot'] % _shared_doc_kwargs)
+    def boxplot(self, column=None, by=None, ax=None, fontsize=None, rot=0,
+                grid=True, figsize=None, layout=None,
+                return_type=None, **kwds):
+        from pandas.plotting._core import boxplot
+        import matplotlib.pyplot as plt
+        ax = boxplot(self, column=column, by=by, ax=ax, fontsize=fontsize,
+                     grid=grid, rot=rot, figsize=figsize, layout=layout,
+                     return_type=return_type, **kwds)
+        plt.draw_if_interactive()
+        return ax
+
 
 DataFrame._setup_axes(['index', 'columns'], info_axis=1, stat_axis=0,
                       axes_are_reversed=True, aliases={'rows': 0})
 DataFrame._add_numeric_operations()
 DataFrame._add_series_or_dataframe_operations()
+
+ops.add_flex_arithmetic_methods(DataFrame, **ops.frame_flex_funcs)
+ops.add_special_arithmetic_methods(DataFrame, **ops.frame_special_funcs)
 
 _EMPTY_SERIES = Series([])
 
@@ -6002,28 +6022,3 @@ def _from_nested_dict(data):
 
 def _put_str(s, space):
     return ('%s' % s)[:space].ljust(space)
-
-
-# ----------------------------------------------------------------------
-# Add plotting methods to DataFrame
-DataFrame.plot = base.AccessorProperty(gfx.FramePlotMethods,
-                                       gfx.FramePlotMethods)
-DataFrame.hist = gfx.hist_frame
-
-
-@Appender(_shared_docs['boxplot'] % _shared_doc_kwargs)
-def boxplot(self, column=None, by=None, ax=None, fontsize=None, rot=0,
-            grid=True, figsize=None, layout=None, return_type=None, **kwds):
-    from pandas.plotting._core import boxplot
-    import matplotlib.pyplot as plt
-    ax = boxplot(self, column=column, by=by, ax=ax, fontsize=fontsize,
-                 grid=grid, rot=rot, figsize=figsize, layout=layout,
-                 return_type=return_type, **kwds)
-    plt.draw_if_interactive()
-    return ax
-
-
-DataFrame.boxplot = boxplot
-
-ops.add_flex_arithmetic_methods(DataFrame, **ops.frame_flex_funcs)
-ops.add_special_arithmetic_methods(DataFrame, **ops.frame_special_funcs)

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -5655,18 +5655,7 @@ it is assumed to be aliases for the column names')
     # Add plotting methods to DataFrame
     plot = base.AccessorProperty(gfx.FramePlotMethods, gfx.FramePlotMethods)
     hist = gfx.hist_frame
-
-    @Appender(_shared_docs['boxplot'] % _shared_doc_kwargs)
-    def boxplot(self, column=None, by=None, ax=None, fontsize=None, rot=0,
-                grid=True, figsize=None, layout=None,
-                return_type=None, **kwds):
-        from pandas.plotting._core import boxplot
-        import matplotlib.pyplot as plt
-        ax = boxplot(self, column=column, by=by, ax=ax, fontsize=fontsize,
-                     grid=grid, rot=rot, figsize=figsize, layout=layout,
-                     return_type=return_type, **kwds)
-        plt.draw_if_interactive()
-        return ax
+    boxplot = gfx.boxplot_frame
 
 
 DataFrame._setup_axes(['index', 'columns'], info_axis=1, stat_axis=0,

--- a/pandas/plotting/_core.py
+++ b/pandas/plotting/_core.py
@@ -2034,6 +2034,18 @@ def boxplot(data, column=None, by=None, ax=None, fontsize=None,
     return result
 
 
+@Appender(_shared_docs['boxplot'] % _shared_doc_kwargs)
+def boxplot_frame(self, column=None, by=None, ax=None, fontsize=None, rot=0,
+                  grid=True, figsize=None, layout=None,
+                  return_type=None, **kwds):
+    import matplotlib.pyplot as plt
+    ax = boxplot(self, column=column, by=by, ax=ax, fontsize=fontsize,
+                 grid=grid, rot=rot, figsize=figsize, layout=layout,
+                 return_type=return_type, **kwds)
+    plt.draw_if_interactive()
+    return ax
+
+
 def scatter_plot(data, x, y, by=None, ax=None, figsize=None, grid=False,
                  **kwargs):
     """


### PR DESCRIPTION
instead of pinning them on at the bottom of the module.

This is a follow-up to <s>#16391</s>#16931 with a smaller scope, avoiding the as-yet-unresolved circular import problem.

 - [x] passes ``git diff upstream/master -u -- "*.py" | flake8 --diff``

