### PR TITLE
Fix double ` in 'Reshaping by Melt' section

### DIFF
--- a/doc/source/reshaping.rst
+++ b/doc/source/reshaping.rst
@@ -265,7 +265,7 @@ the right thing:
 Reshaping by Melt
 -----------------
 
-The top-level :func:``melt` and :func:`~DataFrame.melt` functions are useful to
+The top-level :func:`melt` and :func:`~DataFrame.melt` functions are useful to
 massage a DataFrame into a format where one or more columns are identifier variables,
 while all other columns, considered measured variables, are "unpivoted" to the
 row axis, leaving just two non-identifier columns, "variable" and "value". The


### PR DESCRIPTION
See current stable docs for the issue: https://pandas.pydata.org/pandas-docs/stable/reshaping.html#reshaping-by-melt

The double ` is causing the entire paragraph to be fixed width until the next double `. This commit removes the extra `

 - [ ] closes #xxxx
 - [ ] tests added / passed
 - [ ] passes ``git diff upstream/master -u -- "*.py" | flake8 --diff``
 - [ ] whatsnew entry
