### PR TITLE
CLN: move safe_sort from core.algorithms to core.sorting

### DIFF
--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -48,6 +48,7 @@ import pandas.core.common as com
 import pandas.core.dtypes.concat as _concat
 import pandas.core.missing as missing
 import pandas.core.algorithms as algos
+import pandas.core.sorting as sorting
 from pandas.io.formats.printing import pprint_thing
 from pandas.core.ops import _comp_method_OBJECT_ARRAY
 from pandas.core.strings import StringAccessorMixin
@@ -2306,7 +2307,7 @@ class Index(IndexOpsMixin, StringAccessorMixin, PandasObject):
                                   assume_unique=True)
         the_diff = this.values.take(label_diff)
         try:
-            the_diff = algos.safe_sort(the_diff)
+            the_diff = sorting.safe_sort(the_diff)
         except TypeError:
             pass
 
@@ -2366,7 +2367,7 @@ class Index(IndexOpsMixin, StringAccessorMixin, PandasObject):
 
         the_diff = _concat._concat_compat([left_diff, right_diff])
         try:
-            the_diff = algos.safe_sort(the_diff)
+            the_diff = sorting.safe_sort(the_diff)
         except TypeError:
             pass
 

--- a/pandas/core/reshape/merge.py
+++ b/pandas/core/reshape/merge.py
@@ -38,6 +38,7 @@ from pandas.util._decorators import Appender, Substitution
 
 from pandas.core.sorting import is_int64_overflow_possible
 import pandas.core.algorithms as algos
+import pandas.core.sorting as sorting
 import pandas.core.common as com
 from pandas._libs import hashtable as libhashtable, join as libjoin, lib
 from pandas.errors import MergeError
@@ -1491,7 +1492,7 @@ def _sort_labels(uniques, left, right):
     l = len(left)
     labels = np.concatenate([left, right])
 
-    _, new_labels = algos.safe_sort(uniques, labels, na_sentinel=-1)
+    _, new_labels = sorting.safe_sort(uniques, labels, na_sentinel=-1)
     new_labels = _ensure_int64(new_labels)
     new_left, new_right = new_labels[:l], new_labels[l:]
 

--- a/pandas/tests/test_algos.py
+++ b/pandas/tests/test_algos.py
@@ -2,7 +2,6 @@
 
 import numpy as np
 import pytest
-import warnings
 
 from numpy.random import RandomState
 from numpy import nan
@@ -58,93 +57,6 @@ class TestMatch(object):
         result = Series(algos.match(to_match, values, np.nan))
         expected = Series(np.array([1, 0, np.nan, 0, 1, 2, np.nan]))
         tm.assert_series_equal(result, expected)
-
-
-class TestSafeSort(object):
-
-    def test_basic_sort(self):
-        values = [3, 1, 2, 0, 4]
-        result = algos.safe_sort(values)
-        expected = np.array([0, 1, 2, 3, 4])
-        tm.assert_numpy_array_equal(result, expected)
-
-        values = list("baaacb")
-        result = algos.safe_sort(values)
-        expected = np.array(list("aaabbc"))
-        tm.assert_numpy_array_equal(result, expected)
-
-        values = []
-        result = algos.safe_sort(values)
-        expected = np.array([])
-        tm.assert_numpy_array_equal(result, expected)
-
-    def test_labels(self):
-        values = [3, 1, 2, 0, 4]
-        expected = np.array([0, 1, 2, 3, 4])
-
-        labels = [0, 1, 1, 2, 3, 0, -1, 4]
-        result, result_labels = algos.safe_sort(values, labels)
-        expected_labels = np.array([3, 1, 1, 2, 0, 3, -1, 4], dtype=np.intp)
-        tm.assert_numpy_array_equal(result, expected)
-        tm.assert_numpy_array_equal(result_labels, expected_labels)
-
-        # na_sentinel
-        labels = [0, 1, 1, 2, 3, 0, 99, 4]
-        result, result_labels = algos.safe_sort(values, labels,
-                                                na_sentinel=99)
-        expected_labels = np.array([3, 1, 1, 2, 0, 3, 99, 4], dtype=np.intp)
-        tm.assert_numpy_array_equal(result, expected)
-        tm.assert_numpy_array_equal(result_labels, expected_labels)
-
-        # out of bound indices
-        labels = [0, 101, 102, 2, 3, 0, 99, 4]
-        result, result_labels = algos.safe_sort(values, labels)
-        expected_labels = np.array([3, -1, -1, 2, 0, 3, -1, 4], dtype=np.intp)
-        tm.assert_numpy_array_equal(result, expected)
-        tm.assert_numpy_array_equal(result_labels, expected_labels)
-
-        labels = []
-        result, result_labels = algos.safe_sort(values, labels)
-        expected_labels = np.array([], dtype=np.intp)
-        tm.assert_numpy_array_equal(result, expected)
-        tm.assert_numpy_array_equal(result_labels, expected_labels)
-
-    def test_mixed_integer(self):
-        values = np.array(['b', 1, 0, 'a', 0, 'b'], dtype=object)
-        result = algos.safe_sort(values)
-        expected = np.array([0, 0, 1, 'a', 'b', 'b'], dtype=object)
-        tm.assert_numpy_array_equal(result, expected)
-
-        values = np.array(['b', 1, 0, 'a'], dtype=object)
-        labels = [0, 1, 2, 3, 0, -1, 1]
-        result, result_labels = algos.safe_sort(values, labels)
-        expected = np.array([0, 1, 'a', 'b'], dtype=object)
-        expected_labels = np.array([3, 1, 0, 2, 3, -1, 1], dtype=np.intp)
-        tm.assert_numpy_array_equal(result, expected)
-        tm.assert_numpy_array_equal(result_labels, expected_labels)
-
-    def test_unsortable(self):
-        # GH 13714
-        arr = np.array([1, 2, datetime.now(), 0, 3], dtype=object)
-        if compat.PY2 and not pd._np_version_under1p10:
-            # RuntimeWarning: tp_compare didn't return -1 or -2 for exception
-            with warnings.catch_warnings():
-                pytest.raises(TypeError, algos.safe_sort, arr)
-        else:
-            pytest.raises(TypeError, algos.safe_sort, arr)
-
-    def test_exceptions(self):
-        with tm.assert_raises_regex(TypeError,
-                                    "Only list-like objects are allowed"):
-            algos.safe_sort(values=1)
-
-        with tm.assert_raises_regex(TypeError,
-                                    "Only list-like objects or None"):
-            algos.safe_sort(values=[0, 1, 2], labels=1)
-
-        with tm.assert_raises_regex(ValueError,
-                                    "values should be unique"):
-            algos.safe_sort(values=[0, 1, 2, 1], labels=[0, 1])
 
 
 class TestFactorize(object):

--- a/pandas/tests/test_sorting.py
+++ b/pandas/tests/test_sorting.py
@@ -1,6 +1,8 @@
 import pytest
 from itertools import product
 from collections import defaultdict
+import warnings
+from datetime import datetime
 
 import numpy as np
 from numpy import nan
@@ -13,7 +15,8 @@ from pandas.core.sorting import (is_int64_overflow_possible,
                                  decons_group_index,
                                  get_group_index,
                                  nargsort,
-                                 lexsort_indexer)
+                                 lexsort_indexer,
+                                 safe_sort)
 
 
 class TestSorting(object):
@@ -340,3 +343,96 @@ def test_decons():
     shape = (10000, 10000)
     label_list = [np.tile(np.arange(10000), 5), np.tile(np.arange(10000), 5)]
     testit(label_list, shape)
+
+
+class TestSafeSort(object):
+
+    def test_basic_sort(self):
+        values = [3, 1, 2, 0, 4]
+        result = safe_sort(values)
+        expected = np.array([0, 1, 2, 3, 4])
+        tm.assert_numpy_array_equal(result, expected)
+
+        values = list("baaacb")
+        result = safe_sort(values)
+        expected = np.array(list("aaabbc"), dtype='object')
+        tm.assert_numpy_array_equal(result, expected)
+
+        values = []
+        result = safe_sort(values)
+        expected = np.array([])
+        tm.assert_numpy_array_equal(result, expected)
+
+    def test_labels(self):
+        values = [3, 1, 2, 0, 4]
+        expected = np.array([0, 1, 2, 3, 4])
+
+        labels = [0, 1, 1, 2, 3, 0, -1, 4]
+        result, result_labels = safe_sort(values, labels)
+        expected_labels = np.array([3, 1, 1, 2, 0, 3, -1, 4], dtype=np.intp)
+        tm.assert_numpy_array_equal(result, expected)
+        tm.assert_numpy_array_equal(result_labels, expected_labels)
+
+        # na_sentinel
+        labels = [0, 1, 1, 2, 3, 0, 99, 4]
+        result, result_labels = safe_sort(values, labels,
+                                          na_sentinel=99)
+        expected_labels = np.array([3, 1, 1, 2, 0, 3, 99, 4], dtype=np.intp)
+        tm.assert_numpy_array_equal(result, expected)
+        tm.assert_numpy_array_equal(result_labels, expected_labels)
+
+        # out of bound indices
+        labels = [0, 101, 102, 2, 3, 0, 99, 4]
+        result, result_labels = safe_sort(values, labels)
+        expected_labels = np.array([3, -1, -1, 2, 0, 3, -1, 4], dtype=np.intp)
+        tm.assert_numpy_array_equal(result, expected)
+        tm.assert_numpy_array_equal(result_labels, expected_labels)
+
+        labels = []
+        result, result_labels = safe_sort(values, labels)
+        expected_labels = np.array([], dtype=np.intp)
+        tm.assert_numpy_array_equal(result, expected)
+        tm.assert_numpy_array_equal(result_labels, expected_labels)
+
+    def test_mixed_integer(self):
+        values = np.array(['b', 1, 0, 'a', 0, 'b'], dtype=object)
+        result = safe_sort(values)
+        expected = np.array([0, 0, 1, 'a', 'b', 'b'], dtype=object)
+        tm.assert_numpy_array_equal(result, expected)
+
+        values = np.array(['b', 1, 0, 'a'], dtype=object)
+        labels = [0, 1, 2, 3, 0, -1, 1]
+        result, result_labels = safe_sort(values, labels)
+        expected = np.array([0, 1, 'a', 'b'], dtype=object)
+        expected_labels = np.array([3, 1, 0, 2, 3, -1, 1], dtype=np.intp)
+        tm.assert_numpy_array_equal(result, expected)
+        tm.assert_numpy_array_equal(result_labels, expected_labels)
+
+    def test_mixed_interger_from_list(self):
+        values = ['b', 1, 0, 'a', 0, 'b']
+        result = safe_sort(values)
+        expected = np.array([0, 0, 1, 'a', 'b', 'b'], dtype=object)
+        tm.assert_numpy_array_equal(result, expected)
+
+    def test_unsortable(self):
+        # GH 13714
+        arr = np.array([1, 2, datetime.now(), 0, 3], dtype=object)
+        if compat.PY2 and not pd._np_version_under1p10:
+            # RuntimeWarning: tp_compare didn't return -1 or -2 for exception
+            with warnings.catch_warnings():
+                pytest.raises(TypeError, safe_sort, arr)
+        else:
+            pytest.raises(TypeError, safe_sort, arr)
+
+    def test_exceptions(self):
+        with tm.assert_raises_regex(TypeError,
+                                    "Only list-like objects are allowed"):
+            safe_sort(values=1)
+
+        with tm.assert_raises_regex(TypeError,
+                                    "Only list-like objects or None"):
+            safe_sort(values=[0, 1, 2], labels=1)
+
+        with tm.assert_raises_regex(ValueError,
+                                    "values should be unique"):
+            safe_sort(values=[0, 1, 2, 1], labels=[0, 1])


### PR DESCRIPTION
COMPAT: safe_sort will only coerce list-likes to object, not a numpy string type

xref: https://github.com/pandas-dev/pandas/pull/17003#discussion_r128332208