### PR TITLE
Fixed 'add_methods' when the 'select' argument is specified.

### DIFF
--- a/pandas/core/ops.py
+++ b/pandas/core/ops.py
@@ -149,13 +149,15 @@ def _create_methods(arith_method, comp_method, bool_method,
 def add_methods(cls, new_methods, force, select, exclude):
     if select and exclude:
         raise TypeError("May only pass either select or exclude")
-    methods = new_methods
+
     if select:
         select = set(select)
         methods = {}
         for key, method in new_methods.items():
             if key in select:
                 methods[key] = method
+        new_methods = methods
+
     if exclude:
         for k in exclude:
             new_methods.pop(k, None)


### PR DESCRIPTION
The 'add_methods' function was not behaving correctly when the 'select' argument was specified. This case was not covered by tests - https://codecov.io/gh/pandas-dev/pandas/src/master/pandas/core/ops.py#L149 .
The function is not fully tested and it is unclear how to write a proper test for it. The function is currently not used with the 'select' argument in any place within pandas. The intent of the code was clear and the bug was obvious by plain reading.