### PR TITLE
TST: np.argsort comparision

### DIFF
--- a/doc/source/whatsnew/v0.21.0.txt
+++ b/doc/source/whatsnew/v0.21.0.txt
@@ -259,6 +259,7 @@ Indexing
 - Fixes bug where indexing with ``np.inf`` caused an ``OverflowError`` to be raised (:issue:`16957`)
 - Bug in reindexing on an empty ``CategoricalIndex`` (:issue:`16770`)
 - Fixes ``DataFrame.loc`` for setting with alignment and tz-aware ``DatetimeIndex`` (:issue:`16889`)
+- Fixes ``test_argsort``, ``test_numpy_argsort`` to cover both `>` and `<` in the error message (:issue:`17046`)
  
 I/O
 ^^^

--- a/doc/source/whatsnew/v0.21.0.txt
+++ b/doc/source/whatsnew/v0.21.0.txt
@@ -259,7 +259,6 @@ Indexing
 - Fixes bug where indexing with ``np.inf`` caused an ``OverflowError`` to be raised (:issue:`16957`)
 - Bug in reindexing on an empty ``CategoricalIndex`` (:issue:`16770`)
 - Fixes ``DataFrame.loc`` for setting with alignment and tz-aware ``DatetimeIndex`` (:issue:`16889`)
-- Fixes ``test_argsort``, ``test_numpy_argsort`` to cover both `>` and `<` in the error message (:issue:`17046`)
  
 I/O
 ^^^

--- a/pandas/tests/indexes/test_base.py
+++ b/pandas/tests/indexes/test_base.py
@@ -1846,7 +1846,7 @@ class TestMixedIntIndex(Base):
     def test_argsort(self):
         idx = self.create_index()
         if PY36:
-            with tm.assert_raises_regex(TypeError, "'>' not supported"):
+            with tm.assert_raises_regex(TypeError, "'>|<' not supported"):
                 result = idx.argsort()
         elif PY3:
             with tm.assert_raises_regex(TypeError, "unorderable types"):
@@ -1859,7 +1859,7 @@ class TestMixedIntIndex(Base):
     def test_numpy_argsort(self):
         idx = self.create_index()
         if PY36:
-            with tm.assert_raises_regex(TypeError, "'>' not supported"):
+            with tm.assert_raises_regex(TypeError, "'>|<' not supported"):
                 result = np.argsort(idx)
         elif PY3:
             with tm.assert_raises_regex(TypeError, "unorderable types"):


### PR DESCRIPTION
 - [ ] closes #17046
 - [ ] tests added / passed
 - [ ] passes ``git diff upstream/master -u -- "*.py" | flake8 --diff``
 - [ ] whatsnew entry
