### PR TITLE
TST: Check more error messages in tests

### DIFF
--- a/pandas/tests/frame/test_validate.py
+++ b/pandas/tests/frame/test_validate.py
@@ -1,34 +1,33 @@
 from pandas.core.frame import DataFrame
 
 import pytest
+import pandas.util.testing as tm
+
+
+@pytest.fixture
+def dataframe():
+    return DataFrame({'a': [1, 2], 'b': [3, 4]})
 
 
 class TestDataFrameValidate(object):
     """Tests for error handling related to data types of method arguments."""
-    df = DataFrame({'a': [1, 2], 'b': [3, 4]})
 
-    def test_validate_bool_args(self):
-        # Tests for error handling related to boolean arguments.
-        invalid_values = [1, "True", [1, 2, 3], 5.0]
+    @pytest.mark.parametrize("func", ["query", "eval", "set_index",
+                                      "reset_index", "dropna",
+                                      "drop_duplicates", "sort_values"])
+    @pytest.mark.parametrize("inplace", [1, "True", [1, 2, 3], 5.0])
+    def test_validate_bool_args(self, dataframe, func, inplace):
+        msg = "For argument \"inplace\" expected type bool"
+        kwargs = dict(inplace=inplace)
 
-        for value in invalid_values:
-            with pytest.raises(ValueError):
-                self.df.query('a > b', inplace=value)
+        if func == "query":
+            kwargs["expr"] = "a > b"
+        elif func == "eval":
+            kwargs["expr"] = "a + b"
+        elif func == "set_index":
+            kwargs["keys"] = ["a"]
+        elif func == "sort_values":
+            kwargs["by"] = ["a"]
 
-            with pytest.raises(ValueError):
-                self.df.eval('a + b', inplace=value)
-
-            with pytest.raises(ValueError):
-                self.df.set_index(keys=['a'], inplace=value)
-
-            with pytest.raises(ValueError):
-                self.df.reset_index(inplace=value)
-
-            with pytest.raises(ValueError):
-                self.df.dropna(inplace=value)
-
-            with pytest.raises(ValueError):
-                self.df.drop_duplicates(inplace=value)
-
-            with pytest.raises(ValueError):
-                self.df.sort_values(by=['a'], inplace=value)
+        with tm.assert_raises_regex(ValueError, msg):
+            getattr(dataframe, func)(**kwargs)

--- a/pandas/tests/indexing/test_interval.py
+++ b/pandas/tests/indexing/test_interval.py
@@ -109,10 +109,10 @@ class TestIntervalIndex(object):
 
         # slice of interval
         with pytest.raises(NotImplementedError):
-            result = s.loc[Interval(3, 6):]
+            s.loc[Interval(3, 6):]
 
         with pytest.raises(NotImplementedError):
-            result = s[Interval(3, 6):]
+            s[Interval(3, 6):]
 
         expected = s.iloc[3:5]
         result = s[[Interval(3, 6)]]

--- a/pandas/tests/io/msgpack/test_except.py
+++ b/pandas/tests/io/msgpack/test_except.py
@@ -1,8 +1,10 @@
 # coding: utf-8
 
-import pytest
-
+from datetime import datetime
 from pandas.io.msgpack import packb, unpackb
+
+import pytest
+import pandas.util.testing as tm
 
 
 class DummyException(Exception):
@@ -12,12 +14,13 @@ class DummyException(Exception):
 class TestExceptions(object):
 
     def test_raise_on_find_unsupported_value(self):
-        import datetime
-        pytest.raises(TypeError, packb, datetime.datetime.now())
+        msg = "can\'t serialize datetime"
+        with tm.assert_raises_regex(TypeError, msg):
+            packb(datetime.now())
 
     def test_raise_from_object_hook(self):
-        def hook(obj):
-            raise DummyException
+        def hook(_):
+            raise DummyException()
 
         pytest.raises(DummyException, unpackb, packb({}), object_hook=hook)
         pytest.raises(DummyException, unpackb, packb({'fizz': 'buzz'}),
@@ -30,5 +33,7 @@ class TestExceptions(object):
                       packb({'fizz': {'buzz': 'spam'}}),
                       object_pairs_hook=hook)
 
-    def test_invalidvalue(self):
-        pytest.raises(ValueError, unpackb, b'\xd9\x97#DL_')
+    def test_invalid_value(self):
+        msg = "Unpack failed: error"
+        with tm.assert_raises_regex(ValueError, msg):
+            unpackb(b"\xd9\x97#DL_")

--- a/pandas/tests/io/msgpack/test_limits.py
+++ b/pandas/tests/io/msgpack/test_limits.py
@@ -1,10 +1,10 @@
 # coding: utf-8
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
+from pandas.io.msgpack import packb, unpackb, Packer, Unpacker, ExtType
 
 import pytest
-
-from pandas.io.msgpack import packb, unpackb, Packer, Unpacker, ExtType
+import pandas.util.testing as tm
 
 
 class TestLimits(object):
@@ -39,7 +39,10 @@ class TestLimits(object):
 
         unpacker = Unpacker(max_str_len=2, encoding='utf-8')
         unpacker.feed(packed)
-        pytest.raises(ValueError, unpacker.unpack)
+
+        msg = "3 exceeds max_str_len"
+        with tm.assert_raises_regex(ValueError, msg):
+            unpacker.unpack()
 
     def test_max_bin_len(self):
         d = b'x' * 3
@@ -51,7 +54,10 @@ class TestLimits(object):
 
         unpacker = Unpacker(max_bin_len=2)
         unpacker.feed(packed)
-        pytest.raises(ValueError, unpacker.unpack)
+
+        msg = "3 exceeds max_bin_len"
+        with tm.assert_raises_regex(ValueError, msg):
+            unpacker.unpack()
 
     def test_max_array_len(self):
         d = [1, 2, 3]
@@ -63,7 +69,10 @@ class TestLimits(object):
 
         unpacker = Unpacker(max_array_len=2)
         unpacker.feed(packed)
-        pytest.raises(ValueError, unpacker.unpack)
+
+        msg = "3 exceeds max_array_len"
+        with tm.assert_raises_regex(ValueError, msg):
+            unpacker.unpack()
 
     def test_max_map_len(self):
         d = {1: 2, 3: 4, 5: 6}
@@ -75,7 +84,10 @@ class TestLimits(object):
 
         unpacker = Unpacker(max_map_len=2)
         unpacker.feed(packed)
-        pytest.raises(ValueError, unpacker.unpack)
+
+        msg = "3 exceeds max_map_len"
+        with tm.assert_raises_regex(ValueError, msg):
+            unpacker.unpack()
 
     def test_max_ext_len(self):
         d = ExtType(42, b"abc")
@@ -87,4 +99,7 @@ class TestLimits(object):
 
         unpacker = Unpacker(max_ext_len=2)
         unpacker.feed(packed)
-        pytest.raises(ValueError, unpacker.unpack)
+
+        msg = "4 exceeds max_ext_len"
+        with tm.assert_raises_regex(ValueError, msg):
+            unpacker.unpack()

--- a/pandas/tests/io/msgpack/test_sequnpack.py
+++ b/pandas/tests/io/msgpack/test_sequnpack.py
@@ -1,28 +1,26 @@
 # coding: utf-8
 
-import pytest
-
 from pandas import compat
 from pandas.io.msgpack import Unpacker, BufferFull
 from pandas.io.msgpack import OutOfData
 
+import pytest
+import pandas.util.testing as tm
+
 
 class TestPack(object):
 
-    def test_partialdata(self):
+    def test_partial_data(self):
         unpacker = Unpacker()
-        unpacker.feed(b'\xa5')
-        pytest.raises(StopIteration, next, iter(unpacker))
-        unpacker.feed(b'h')
-        pytest.raises(StopIteration, next, iter(unpacker))
-        unpacker.feed(b'a')
-        pytest.raises(StopIteration, next, iter(unpacker))
-        unpacker.feed(b'l')
-        pytest.raises(StopIteration, next, iter(unpacker))
-        unpacker.feed(b'l')
-        pytest.raises(StopIteration, next, iter(unpacker))
-        unpacker.feed(b'o')
-        assert next(iter(unpacker)) == b'hallo'
+        msg = "No more data to unpack"
+
+        for data in [b"\xa5", b"h", b"a", b"l", b"l"]:
+            unpacker.feed(data)
+            with tm.assert_raises_regex(StopIteration, msg):
+                next(iter(unpacker))
+
+        unpacker.feed(b"o")
+        assert next(iter(unpacker)) == b"hallo"
 
     def test_foobar(self):
         unpacker = Unpacker(read_size=3, use_list=1)

--- a/pandas/tests/io/sas/test_sas.py
+++ b/pandas/tests/io/sas/test_sas.py
@@ -1,14 +1,16 @@
-import pytest
-
 from pandas.compat import StringIO
 from pandas import read_sas
+
+import pandas.util.testing as tm
 
 
 class TestSas(object):
 
     def test_sas_buffer_format(self):
-
-        # GH14947
+        # see gh-14947
         b = StringIO("")
-        with pytest.raises(ValueError):
+
+        msg = ("If this is a buffer object rather than a string "
+               "name, you must specify a format string")
+        with tm.assert_raises_regex(ValueError, msg):
             read_sas(b)

--- a/pandas/tests/scalar/test_interval.py
+++ b/pandas/tests/scalar/test_interval.py
@@ -1,42 +1,49 @@
 from __future__ import division
 
-import pytest
 from pandas import Interval
+
+import pytest
 import pandas.util.testing as tm
 
 
+@pytest.fixture
+def interval():
+    return Interval(0, 1)
+
+
 class TestInterval(object):
-    def setup_method(self, method):
-        self.interval = Interval(0, 1)
 
-    def test_properties(self):
-        assert self.interval.closed == 'right'
-        assert self.interval.left == 0
-        assert self.interval.right == 1
-        assert self.interval.mid == 0.5
+    def test_properties(self, interval):
+        assert interval.closed == 'right'
+        assert interval.left == 0
+        assert interval.right == 1
+        assert interval.mid == 0.5
 
-    def test_repr(self):
-        assert repr(self.interval) == "Interval(0, 1, closed='right')"
-        assert str(self.interval) == "(0, 1]"
+    def test_repr(self, interval):
+        assert repr(interval) == "Interval(0, 1, closed='right')"
+        assert str(interval) == "(0, 1]"
 
         interval_left = Interval(0, 1, closed='left')
         assert repr(interval_left) == "Interval(0, 1, closed='left')"
         assert str(interval_left) == "[0, 1)"
 
-    def test_contains(self):
-        assert 0.5 in self.interval
-        assert 1 in self.interval
-        assert 0 not in self.interval
-        pytest.raises(TypeError, lambda: self.interval in self.interval)
-
-        interval = Interval(0, 1, closed='both')
-        assert 0 in interval
-        assert 1 in interval
-
-        interval = Interval(0, 1, closed='neither')
-        assert 0 not in interval
+    def test_contains(self, interval):
         assert 0.5 in interval
-        assert 1 not in interval
+        assert 1 in interval
+        assert 0 not in interval
+
+        msg = "__contains__ not defined for two intervals"
+        with tm.assert_raises_regex(TypeError, msg):
+            interval in interval
+
+        interval_both = Interval(0, 1, closed='both')
+        assert 0 in interval_both
+        assert 1 in interval_both
+
+        interval_neither = Interval(0, 1, closed='neither')
+        assert 0 not in interval_neither
+        assert 0.5 in interval_neither
+        assert 1 not in interval_neither
 
     def test_equal(self):
         assert Interval(0, 1) == Interval(0, 1, closed='right')
@@ -54,74 +61,79 @@ class TestInterval(object):
         assert Interval(0, 1) > Interval(-1, 2)
         assert Interval(0, 1) >= Interval(0, 1)
 
-    def test_hash(self):
+    def test_hash(self, interval):
         # should not raise
-        hash(self.interval)
+        hash(interval)
 
-    def test_math_add(self):
+    def test_math_add(self, interval):
         expected = Interval(1, 2)
-        actual = self.interval + 1
+        actual = interval + 1
         assert expected == actual
 
         expected = Interval(1, 2)
-        actual = 1 + self.interval
+        actual = 1 + interval
         assert expected == actual
 
-        actual = self.interval
+        actual = interval
         actual += 1
         assert expected == actual
 
-        with pytest.raises(TypeError):
-            self.interval + Interval(1, 2)
+        msg = "unsupported operand type\(s\) for \+"
+        with tm.assert_raises_regex(TypeError, msg):
+            interval + Interval(1, 2)
 
-        with pytest.raises(TypeError):
-            self.interval + 'foo'
+        with tm.assert_raises_regex(TypeError, msg):
+            interval + 'foo'
 
-    def test_math_sub(self):
+    def test_math_sub(self, interval):
         expected = Interval(-1, 0)
-        actual = self.interval - 1
+        actual = interval - 1
         assert expected == actual
 
-        actual = self.interval
+        actual = interval
         actual -= 1
         assert expected == actual
 
-        with pytest.raises(TypeError):
-            self.interval - Interval(1, 2)
+        msg = "unsupported operand type\(s\) for -"
+        with tm.assert_raises_regex(TypeError, msg):
+            interval - Interval(1, 2)
 
-        with pytest.raises(TypeError):
-            self.interval - 'foo'
+        with tm.assert_raises_regex(TypeError, msg):
+            interval - 'foo'
 
-    def test_math_mult(self):
+    def test_math_mult(self, interval):
         expected = Interval(0, 2)
-        actual = self.interval * 2
+        actual = interval * 2
         assert expected == actual
 
         expected = Interval(0, 2)
-        actual = 2 * self.interval
+        actual = 2 * interval
         assert expected == actual
 
-        actual = self.interval
+        actual = interval
         actual *= 2
         assert expected == actual
 
-        with pytest.raises(TypeError):
-            self.interval * Interval(1, 2)
+        msg = "unsupported operand type\(s\) for \*"
+        with tm.assert_raises_regex(TypeError, msg):
+            interval * Interval(1, 2)
 
-        with pytest.raises(TypeError):
-            self.interval * 'foo'
+        msg = "can\'t multiply sequence by non-int"
+        with tm.assert_raises_regex(TypeError, msg):
+            interval * 'foo'
 
-    def test_math_div(self):
+    def test_math_div(self, interval):
         expected = Interval(0, 0.5)
-        actual = self.interval / 2.0
+        actual = interval / 2.0
         assert expected == actual
 
-        actual = self.interval
+        actual = interval
         actual /= 2.0
         assert expected == actual
 
-        with pytest.raises(TypeError):
-            self.interval / Interval(1, 2)
+        msg = "unsupported operand type\(s\) for /"
+        with tm.assert_raises_regex(TypeError, msg):
+            interval / Interval(1, 2)
 
-        with pytest.raises(TypeError):
-            self.interval / 'foo'
+        with tm.assert_raises_regex(TypeError, msg):
+            interval / 'foo'

--- a/pandas/tests/series/test_validate.py
+++ b/pandas/tests/series/test_validate.py
@@ -1,30 +1,27 @@
-import pytest
 from pandas.core.series import Series
+
+import pytest
+import pandas.util.testing as tm
+
+
+@pytest.fixture
+def series():
+    return Series([1, 2, 3, 4, 5])
 
 
 class TestSeriesValidate(object):
     """Tests for error handling related to data types of method arguments."""
-    s = Series([1, 2, 3, 4, 5])
 
-    def test_validate_bool_args(self):
-        # Tests for error handling related to boolean arguments.
-        invalid_values = [1, "True", [1, 2, 3], 5.0]
+    @pytest.mark.parametrize("func", ["reset_index", "_set_name",
+                                      "sort_values", "sort_index",
+                                      "rename", "dropna"])
+    @pytest.mark.parametrize("inplace", [1, "True", [1, 2, 3], 5.0])
+    def test_validate_bool_args(self, series, func, inplace):
+        msg = "For argument \"inplace\" expected type bool"
+        kwargs = dict(inplace=inplace)
 
-        for value in invalid_values:
-            with pytest.raises(ValueError):
-                self.s.reset_index(inplace=value)
+        if func == "_set_name":
+            kwargs["name"] = "hello"
 
-            with pytest.raises(ValueError):
-                self.s._set_name(name='hello', inplace=value)
-
-            with pytest.raises(ValueError):
-                self.s.sort_values(inplace=value)
-
-            with pytest.raises(ValueError):
-                self.s.sort_index(inplace=value)
-
-            with pytest.raises(ValueError):
-                self.s.rename(inplace=value)
-
-            with pytest.raises(ValueError):
-                self.s.dropna(inplace=value)
+        with tm.assert_raises_regex(ValueError, msg):
+            getattr(series, func)(**kwargs)


### PR DESCRIPTION
Just replaces some `pytest.raises` with more useful (I think) `tm.assert_raises_regexp`.

xref #16521.