### PR TITLE
Accept range for list-requiring kwargs in pd.read_csv

### DIFF
--- a/pandas/io/parsers.py
+++ b/pandas/io/parsers.py
@@ -1193,8 +1193,11 @@ class ParserBase(object):
 
         # validate header options for mi
         self.header = kwds.get('header')
-        if PY3 and isinstance(self.header, range):
-            self.header = list(self.header)
+        if PY3:
+            if isinstance(self.header, range):
+                self.header = list(self.header)
+            if isinstance(self.index_col, range):
+                self.index_col = list(self.index_col)
         if isinstance(self.header, (list, tuple, np.ndarray)):
             if not all(map(is_integer, self.header)):
                 raise ValueError("header must be integer or list of integers")

--- a/pandas/io/parsers.py
+++ b/pandas/io/parsers.py
@@ -943,6 +943,8 @@ class TextFileReader(BaseIterator):
         if _is_index_col(index_col):
             if not isinstance(index_col, (list, tuple, np.ndarray)):
                 index_col = [index_col]
+        if PY3 and isinstance(index_col, range):
+            index_col = list(index_col)
         result['index_col'] = index_col
 
         names = list(names) if names is not None else names
@@ -1191,6 +1193,8 @@ class ParserBase(object):
 
         # validate header options for mi
         self.header = kwds.get('header')
+        if PY3 and isinstance(self.header, range):
+            self.header = list(self.header)
         if isinstance(self.header, (list, tuple, np.ndarray)):
             if not all(map(is_integer, self.header)):
                 raise ValueError("header must be integer or list of integers")
@@ -1213,7 +1217,6 @@ class ParserBase(object):
                         is_integer(self.index_col)):
                     raise ValueError("index_col must only contain row numbers "
                                      "when specifying a multi-index header")
-
         # GH 16338
         elif self.header is not None and not is_integer(self.header):
             raise ValueError("header must be integer or list of integers")

--- a/pandas/tests/io/parser/index_col.py
+++ b/pandas/tests/io/parser/index_col.py
@@ -10,7 +10,7 @@ import pytest
 
 import pandas.util.testing as tm
 
-from pandas import DataFrame, Index, MultiIndex
+from pandas import DataFrame, Index, MultiIndex, date_range
 from pandas.compat import StringIO
 
 
@@ -141,3 +141,20 @@ baz,7,8,9
         result = self.read_csv(StringIO(data), index_col=False)
         expected = DataFrame([], columns=['x', 'y'])
         tm.assert_frame_equal(result, expected)
+
+    def test_range_index_col(self):
+        cols = MultiIndex.from_arrays([['A', 'B', 'C'], ['foo', 'bar', 'baz']])
+        index = date_range('2016-01-02', periods=3, freq='D')
+        data = [[1, 2, 3], [4, 5, 6], [7, 8, 9]]
+        df = DataFrame(data, index=index, columns=cols)
+
+        data = (",A,B,C\n"
+                ",foo,bar,baz\n"
+                "2016-01-02,1,2,3\n"
+                "2016-01-03,4,5,6\n"
+                "2016-01-04,7,8,9"
+                )
+        res = self.read_csv(StringIO(df.to_csv()),
+                            index_col=range(1),
+                            header=range(2))
+        tm.assert_frame_equal(df, res)


### PR DESCRIPTION
`pd.read_csv(path, index_col=range(1))` currently breaks in py3.  This PR fixes that.

There are likely other functions and kwargs for which the same fix would be useful.  I haven't tracked them all down.

Edits to `series` and `frame` are unrelated, but not big enough to merit their own PR.  This is just removing import of `nan, ndarray` that are used in a small number of places and instead using `np.nan, np.ndarray`.

 - [ ] closes #xxxx
 - [x] tests added / passed
 - [x] passes ``git diff upstream/master -u -- "*.py" | flake8 --diff``
 - [ ] whatsnew entry
