### PR TITLE
Read html with colspan rowspan

### DIFF
--- a/pandas/io/html.py
+++ b/pandas/io/html.py
@@ -19,13 +19,8 @@ from pandas.io.parsers import TextParser
 from pandas.compat import (lrange, lmap, lfilter, u, string_types, iteritems,
                            raise_with_traceback, binary_type)
 from pandas import Series
-<< << << < HEAD
-from pandas.core.common import AbstractMethodError
-from pandas.formats.printing import pprint_thing
-== == == =
 from pandas.core.common import (AbstractMethodError, flatten)
 from pandas.io.formats.printing import pprint_thing
->>>>>> > b922af71b... read_html handles rowspan and colspan in tables, infers headers if < thead > is not specified
 
 _IMPORTS = False
 _HAS_BS4 = False

--- a/pandas/io/tests/test_html.py
+++ b/pandas/io/tests/test_html.py
@@ -977,14 +977,8 @@ class TestReadHtmlLxml(tm.TestCase, ReadHtmlMixin):
 
 def test_invalid_flavor():
     url = 'google.com'
-<< << << < HEAD:
-    pandas / io / tests / test_html.py
-    with tm.assertRaises(ValueError):
-        read_html(url, 'google', flavor='not a* valid**++ flaver')
-== == == =
     with pytest.raises(ValueError):
         read_html(url, 'google', flavor='not a* valid**++ flavor')
->>>>>> > 5818f804b... added rowspan / colspan / infer - header tests. removed test_computer_sales_page, which now appears to parse correctly.:
     pandas / tests / io / test_html.py
 
 
@@ -1031,12 +1025,9 @@ def test_same_ordering():
     dfs_bs4 = read_html(filename, index_col=0, flavor=['bs4'])
     assert_framelist_equal(dfs_lxml, dfs_bs4)
 
-<< << << < HEAD:
-    pandas / io / tests / test_html.py
 if __name__ == '__main__':
     nose.runmodule(argv=[__file__, '-vvs', '-x', '--pdb', '--pdb-failure'],
                    exit=False)
-== == == =
 
 
 class ErrorThread(threading.Thread):
@@ -1067,5 +1058,3 @@ def test_importcheck_thread_safety():
     while helper_thread1.is_alive() or helper_thread2.is_alive():
         pass
     assert None is helper_thread1.err is helper_thread2.err
->>>>>> > 5818f804b... added rowspan / colspan / infer - header tests. removed test_computer_sales_page, which now appears to parse correctly.:
-    pandas / tests / io / test_html.py


### PR DESCRIPTION
 - [x] closes #17054
 - [x] tests added / passed
 - [ ] passes ``git diff upstream/master -u -- "*.py" | flake8 --diff``
 - [ ] whatsnew entry

There's a parsererror include in the test file that doesn't need to be there any more since I removed the test.

whatsnew entry:

`read_html` now:
- handles colspan/rowspan in table elements
- attempts to infer table headers in the absence of `<thead>`