### PR TITLE
BUG: Allow pd.unique to accept tuple of strings

### DIFF
--- a/doc/source/whatsnew/v0.21.0.txt
+++ b/doc/source/whatsnew/v0.21.0.txt
@@ -327,3 +327,4 @@ Other
 ^^^^^
 - Bug in :func:`eval` where the ``inplace`` parameter was being incorrectly handled (:issue:`16732`)
 - Bug in ``.isin()`` in which checking membership in empty ``Series`` objects raised an error (:issue:`16991`)
+- Bug in :func:`unique` where checking a tuple of strings raised a ``TypeError``

--- a/doc/source/whatsnew/v0.21.0.txt
+++ b/doc/source/whatsnew/v0.21.0.txt
@@ -327,4 +327,4 @@ Other
 ^^^^^
 - Bug in :func:`eval` where the ``inplace`` parameter was being incorrectly handled (:issue:`16732`)
 - Bug in ``.isin()`` in which checking membership in empty ``Series`` objects raised an error (:issue:`16991`)
-- Bug in :func:`unique` where checking a tuple of strings raised a ``TypeError``
+- Bug in :func:`unique` where checking a tuple of strings raised a ``TypeError`` (:issue:`17108`)

--- a/pandas/core/algorithms.py
+++ b/pandas/core/algorithms.py
@@ -170,6 +170,8 @@ def _ensure_arraylike(values):
                                ABCIndexClass, ABCSeries)):
         inferred = lib.infer_dtype(values)
         if inferred in ['mixed', 'string', 'unicode']:
+            if isinstance(values, tuple):
+                values = list(values)
             values = lib.list_to_object_array(values)
         else:
             values = np.asarray(values)

--- a/pandas/tests/test_algos.py
+++ b/pandas/tests/test_algos.py
@@ -415,6 +415,14 @@ class TestUnique(object):
         expected = pd.Categorical(list('abc'))
         tm.assert_categorical_equal(result, expected)
 
+    @pytest.mark.parametrize("arg ,expected", [
+        (('1', '1', '2'), np.array(['1', '2'], dtype=object)),
+        (('foo',), np.array(['foo'], dtype=object))
+    ])
+    def test_tuple_with_strings(self, arg, expected):
+        result = pd.unique(arg)
+        tm.assert_numpy_array_equal(result, expected)
+
 
 class TestIsin(object):
 

--- a/pandas/tests/test_algos.py
+++ b/pandas/tests/test_algos.py
@@ -420,6 +420,7 @@ class TestUnique(object):
         (('foo',), np.array(['foo'], dtype=object))
     ])
     def test_tuple_with_strings(self, arg, expected):
+        # see GH 17108
         result = pd.unique(arg)
         tm.assert_numpy_array_equal(result, expected)
 


### PR DESCRIPTION
 - [x] tests added / passed
 - [x] passes ``git diff upstream/master -u -- "*.py" | flake8 --diff``
 - [x] whatsnew entry

xref #17077

 `pd.unique()` calls `_ensure_arraylike` which did not accept tuples that contains strings. Converts tuple to list first before dispatching to `list_to_object_array`