### PR TITLE
API: Localize Series when calling to_datetime with utc=True (#6415)

### DIFF
--- a/doc/source/whatsnew/v0.21.0.txt
+++ b/doc/source/whatsnew/v0.21.0.txt
@@ -326,7 +326,7 @@ Previously, :func:`to_datetime` did not localize datetime ``Series`` data when `
 
      pd.to_datetime(s, utc=True)
 
-Additionally, DataFrames with datetime columns returned by :func:`read_sql_table` and :func:`read_sql_query` with the `parse_dates` argument specified will also be localized to UTC only if the original SQL columns were timezone aware datetime columns.
+Additionally, DataFrames with datetime columns that were parsed by :func:`read_sql_table` and :func:`read_sql_query` will also be localized to UTC only if the original SQL columns were timezone aware datetime columns.
 
 .. _whatsnew_0210.api:
 

--- a/doc/source/whatsnew/v0.21.0.txt
+++ b/doc/source/whatsnew/v0.21.0.txt
@@ -303,6 +303,8 @@ length 2+ levels, so a :class:`MultiIndex` is always returned from all of the
 UTC Localization with Series
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+Previously, :func:`to_datetime` did not localize datetime ``Series`` data as when ``utc=True`` was passed. Now, :func:`to_datetime` will correctly localize `Series` with a `datetime64[ns, UTC]` data type. (:issue:`6415`).
+
   Previous Behavior
 
   .. ipython:: python
@@ -331,7 +333,7 @@ UTC Localization with Series
 
      pd.to_datetime(s, utc=True)
 
-This new behavior will also localize datetime columns in DataFrames returned from :func:`read_sql` which previously returned datetime columns as naive UTC.
+Additionally, DataFrames with datetime columns returned by :func:`read_sql` will also be localized to UTC only if the original SQL columns were timezone aware datetime columns.
 
 .. _whatsnew_0210.api:
 

--- a/doc/source/whatsnew/v0.21.0.txt
+++ b/doc/source/whatsnew/v0.21.0.txt
@@ -331,6 +331,8 @@ UTC Localization with Series
 
      pd.to_datetime(s, utc=True)
 
+This new behavior will also localize datetime columns in DataFrames returned from :func:`read_sql` which previously returned datetime columns as naive UTC.
+
 .. _whatsnew_0210.api:
 
 Other API Changes

--- a/doc/source/whatsnew/v0.21.0.txt
+++ b/doc/source/whatsnew/v0.21.0.txt
@@ -398,7 +398,6 @@ Conversion
 - Bug in ``IntervalIndex.is_non_overlapping_monotonic`` when intervals are closed on both sides and overlap at a point (:issue:`16560`)
 - Bug in :func:`Series.fillna` returns frame when ``inplace=True`` and ``value`` is dict (:issue:`16156`)
 
-
 Indexing
 ^^^^^^^^
 

--- a/doc/source/whatsnew/v0.21.0.txt
+++ b/doc/source/whatsnew/v0.21.0.txt
@@ -311,7 +311,7 @@ Previously, :func:`to_datetime` did not localize datetime ``Series`` data when `
 
      s = Series(['20130101 00:00:00'] * 3)
 
-  .. code-block:: python
+  .. code-block:: ipython
 
      In [12]: pd.to_datetime(s, utc=True)
      Out[12]:
@@ -326,7 +326,7 @@ Previously, :func:`to_datetime` did not localize datetime ``Series`` data when `
 
      pd.to_datetime(s, utc=True)
 
-Additionally, DataFrames with datetime columns returned by :func:`read_sql` will also be localized to UTC only if the original SQL columns were timezone aware datetime columns.
+Additionally, DataFrames with datetime columns returned by :func:`read_sql_table` and :func:`read_sql_query` with the `parse_dates` argument specified will also be localized to UTC only if the original SQL columns were timezone aware datetime columns.
 
 .. _whatsnew_0210.api:
 

--- a/doc/source/whatsnew/v0.21.0.txt
+++ b/doc/source/whatsnew/v0.21.0.txt
@@ -303,7 +303,7 @@ length 2+ levels, so a :class:`MultiIndex` is always returned from all of the
 UTC Localization with Series
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Previously, :func:`to_datetime` did not localize datetime ``Series`` data when ``utc=True`` was passed. Now, :func:`to_datetime` will correctly localize ``Series`` with a ``datetime64[ns, UTC]`` dtype to be consistent with how list-like and `Index` data are handled. (:issue:`6415`).
+Previously, :func:`to_datetime` did not localize datetime ``Series`` data when ``utc=True`` was passed. Now, :func:`to_datetime` will correctly localize ``Series`` with a ``datetime64[ns, UTC]`` dtype to be consistent with how list-like and ``Index`` data are handled. (:issue:`6415`).
 
   Previous Behavior
 

--- a/doc/source/whatsnew/v0.21.0.txt
+++ b/doc/source/whatsnew/v0.21.0.txt
@@ -303,13 +303,13 @@ length 2+ levels, so a :class:`MultiIndex` is always returned from all of the
 UTC Localization with Series
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Previously, :func:`to_datetime` did not localize datetime ``Series`` data as when ``utc=True`` was passed. Now, :func:`to_datetime` will correctly localize `Series` with a `datetime64[ns, UTC]` data type. (:issue:`6415`).
+Previously, :func:`to_datetime` did not localize datetime ``Series`` data when ``utc=True`` was passed. Now, :func:`to_datetime` will correctly localize `Series` with a `datetime64[ns, UTC]` data type to be consistent with how list-like and Index data are handled. (:issue:`6415`).
 
   Previous Behavior
 
   .. ipython:: python
 
-     s = Series(['20130101 00:00:00'] * 10)
+     s = Series(['20130101 00:00:00'] * 3)
 
   .. code-block:: python
 
@@ -318,13 +318,6 @@ Previously, :func:`to_datetime` did not localize datetime ``Series`` data as whe
      0   2013-01-01
      1   2013-01-01
      2   2013-01-01
-     3   2013-01-01
-     4   2013-01-01
-     5   2013-01-01
-     6   2013-01-01
-     7   2013-01-01
-     8   2013-01-01
-     9   2013-01-01
      dtype: datetime64[ns]
 
   New Behavior

--- a/doc/source/whatsnew/v0.21.0.txt
+++ b/doc/source/whatsnew/v0.21.0.txt
@@ -405,6 +405,7 @@ Conversion
 - Bug in ``IntervalIndex.is_non_overlapping_monotonic`` when intervals are closed on both sides and overlap at a point (:issue:`16560`)
 - Bug in :func:`Series.fillna` returns frame when ``inplace=True`` and ``value`` is dict (:issue:`16156`)
 
+
 Indexing
 ^^^^^^^^
 

--- a/doc/source/whatsnew/v0.21.0.txt
+++ b/doc/source/whatsnew/v0.21.0.txt
@@ -396,13 +396,10 @@ Conversion
 
 - Bug in assignment against datetime-like data with ``int`` may incorrectly convert to datetime-like (:issue:`14145`)
 - Bug in assignment against ``int64`` data with ``np.ndarray`` with ``float64`` dtype may keep ``int64`` dtype (:issue:`14001`)
-<<<<<<< 062f6f118fe4ea439ae255a8ff886a532e20ecdb
 - Fix :func:`DataFrame.memory_usage` to support PyPy. Objects on PyPy do not have a fixed size, so an approximation is used instead (:issue:`17228`)
 - Fixed the return type of ``IntervalIndex.is_non_overlapping_monotonic`` to be a Python ``bool`` for consistency with similar attributes/methods.  Previously returned a ``numpy.bool_``. (:issue:`17237`)
 - Bug in ``IntervalIndex.is_non_overlapping_monotonic`` when intervals are closed on both sides and overlap at a point (:issue:`16560`)
 - Bug in :func:`Series.fillna` returns frame when ``inplace=True`` and ``value`` is dict (:issue:`16156`)
-=======
->>>>>>> BUG: to_datetime not localizing Series when utc=True (#6415)
 
 Indexing
 ^^^^^^^^

--- a/doc/source/whatsnew/v0.21.0.txt
+++ b/doc/source/whatsnew/v0.21.0.txt
@@ -298,6 +298,39 @@ length 2+ levels, so a :class:`MultiIndex` is always returned from all of the
 
    pd.MultiIndex.from_tuples([('a',), ('b',)])
 
+.. _whatsnew_0210.api.utc_localization_with_series:
+
+UTC Localization with Series
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+  Previous Behavior
+
+  .. ipython:: python
+
+     s = Series(['20130101 00:00:00'] * 10)
+
+  .. code-block:: python
+
+     In [12]: pd.to_datetime(s, utc=True)
+     Out[12]:
+     0   2013-01-01
+     1   2013-01-01
+     2   2013-01-01
+     3   2013-01-01
+     4   2013-01-01
+     5   2013-01-01
+     6   2013-01-01
+     7   2013-01-01
+     8   2013-01-01
+     9   2013-01-01
+     dtype: datetime64[ns]
+
+  New Behavior
+
+  .. ipython:: python
+
+     pd.to_datetime(s, utc=True)
+
 .. _whatsnew_0210.api:
 
 Other API Changes
@@ -363,10 +396,13 @@ Conversion
 
 - Bug in assignment against datetime-like data with ``int`` may incorrectly convert to datetime-like (:issue:`14145`)
 - Bug in assignment against ``int64`` data with ``np.ndarray`` with ``float64`` dtype may keep ``int64`` dtype (:issue:`14001`)
+<<<<<<< 062f6f118fe4ea439ae255a8ff886a532e20ecdb
 - Fix :func:`DataFrame.memory_usage` to support PyPy. Objects on PyPy do not have a fixed size, so an approximation is used instead (:issue:`17228`)
 - Fixed the return type of ``IntervalIndex.is_non_overlapping_monotonic`` to be a Python ``bool`` for consistency with similar attributes/methods.  Previously returned a ``numpy.bool_``. (:issue:`17237`)
 - Bug in ``IntervalIndex.is_non_overlapping_monotonic`` when intervals are closed on both sides and overlap at a point (:issue:`16560`)
 - Bug in :func:`Series.fillna` returns frame when ``inplace=True`` and ``value`` is dict (:issue:`16156`)
+=======
+>>>>>>> BUG: to_datetime not localizing Series when utc=True (#6415)
 
 Indexing
 ^^^^^^^^

--- a/doc/source/whatsnew/v0.21.0.txt
+++ b/doc/source/whatsnew/v0.21.0.txt
@@ -303,7 +303,7 @@ length 2+ levels, so a :class:`MultiIndex` is always returned from all of the
 UTC Localization with Series
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Previously, :func:`to_datetime` did not localize datetime ``Series`` data when ``utc=True`` was passed. Now, :func:`to_datetime` will correctly localize `Series` with a `datetime64[ns, UTC]` data type to be consistent with how list-like and Index data are handled. (:issue:`6415`).
+Previously, :func:`to_datetime` did not localize datetime ``Series`` data when ``utc=True`` was passed. Now, :func:`to_datetime` will correctly localize ``Series`` with a ``datetime64[ns, UTC]`` dtype to be consistent with how list-like and `Index` data are handled. (:issue:`6415`).
 
   Previous Behavior
 

--- a/pandas/core/tools/datetimes.py
+++ b/pandas/core/tools/datetimes.py
@@ -516,7 +516,7 @@ def to_datetime(arg, errors='raise', dayfirst=False, yearfirst=False,
         result = arg
     elif isinstance(arg, ABCSeries):
         from pandas import Series
-        values = _convert_listlike(arg, True, format)
+        values = _convert_listlike(arg._values, True, format)
         result = Series(values, index=arg.index, name=arg.name)
     elif isinstance(arg, (ABCDataFrame, MutableMapping)):
         result = _assemble_from_unit_mappings(arg, errors=errors)

--- a/pandas/core/tools/datetimes.py
+++ b/pandas/core/tools/datetimes.py
@@ -457,7 +457,7 @@ def to_datetime(arg, errors='raise', dayfirst=False, yearfirst=False,
             if is_datetime64_dtype(result) and box:
                 result = DatetimeIndex(result, tz=tz, name=name)
             # GH 6415
-            elif arg_is_series:
+            elif arg_is_series and utc:
                 result = _maybe_convert_to_utc(Series(result, name=name), utc)
             return result
 

--- a/pandas/core/tools/datetimes.py
+++ b/pandas/core/tools/datetimes.py
@@ -365,7 +365,6 @@ def to_datetime(arg, errors='raise', dayfirst=False, yearfirst=False,
                 except ValueError:
                     pass
 
-
             return arg
 
         elif unit is not None:
@@ -385,13 +384,11 @@ def to_datetime(arg, errors='raise', dayfirst=False, yearfirst=False,
             raise TypeError('arg must be a string, datetime, list, tuple, '
                             '1-d array, or Series')
 
-
         arg = _ensure_object(arg)
         require_iso8601 = False
 
         if infer_datetime_format and format is None:
-            format = _guess_datetime_format_for_array(arg,
-                                                      dayfirst=dayfirst)
+            format = _guess_datetime_format_for_array(arg, dayfirst=dayfirst)
 
         if format is not None:
             # There is a special fast-path for iso8601 formatted
@@ -418,8 +415,7 @@ def to_datetime(arg, errors='raise', dayfirst=False, yearfirst=False,
                 # fallback
                 if result is None:
                     try:
-                        result = tslib.array_strptime(arg, format,
-                                                      exact=exact,
+                        result = tslib.array_strptime(arg, format, exact=exact,
                                                       errors=errors)
                     except tslib.OutOfBoundsDatetime:
                         if errors == 'raise':
@@ -443,6 +439,7 @@ def to_datetime(arg, errors='raise', dayfirst=False, yearfirst=False,
                     yearfirst=yearfirst,
                     require_iso8601=require_iso8601
                 )
+
             if is_datetime64_dtype(result) and box:
                 result = DatetimeIndex(result, tz=tz, name=name)
             return result

--- a/pandas/io/sql.py
+++ b/pandas/io/sql.py
@@ -818,6 +818,7 @@ class SQLTable(PandasObject):
                 df_col = self.frame[col_name]
                 # the type the dataframe column should have
                 col_type = self._get_dtype(sql_col.type)
+
                 if (col_type is datetime or col_type is date or
                         col_type is DatetimeTZDtype):
                     if col_type is DatetimeTZDtype:

--- a/pandas/io/sql.py
+++ b/pandas/io/sql.py
@@ -99,24 +99,24 @@ def _convert_params(sql, params):
     return args
 
 
-def _handle_date_column(col, format=None):
+def _handle_date_column(col, utc=None, format=None):
     if isinstance(format, dict):
         return to_datetime(col, errors='ignore', **format)
     else:
         if format in ['D', 's', 'ms', 'us', 'ns']:
-            return to_datetime(col, errors='coerce', unit=format, utc=True)
+            return to_datetime(col, errors='coerce', unit=format, utc=utc)
         elif (issubclass(col.dtype.type, np.floating) or
               issubclass(col.dtype.type, np.integer)):
             # parse dates as timestamp
             format = 's' if format is None else format
-            return to_datetime(col, errors='coerce', unit=format, utc=True)
+            return to_datetime(col, errors='coerce', unit=format, utc=utc)
         elif is_datetime64tz_dtype(col):
             # coerce to UTC timezone
             # GH11216
             return (to_datetime(col, errors='coerce')
                     .astype('datetime64[ns, UTC]'))
         else:
-            return to_datetime(col, errors='coerce', format=format, utc=True)
+            return to_datetime(col, errors='coerce', format=format, utc=utc)
 
 
 def _parse_date_columns(data_frame, parse_dates):
@@ -818,10 +818,14 @@ class SQLTable(PandasObject):
                 df_col = self.frame[col_name]
                 # the type the dataframe column should have
                 col_type = self._get_dtype(sql_col.type)
-
                 if (col_type is datetime or col_type is date or
                         col_type is DatetimeTZDtype):
-                    self.frame[col_name] = _handle_date_column(df_col)
+                    if col_type is DatetimeTZDtype:
+                        # Convert SQL Datetime columns with tz to UTC
+                        self.frame[col_name] = _handle_date_column(df_col, 
+                                                                   utc=True)
+                    else:
+                        self.frame[col_name] = _handle_date_column(df_col)
 
                 elif col_type is float:
                     # floats support NA, can always convert!

--- a/pandas/io/sql.py
+++ b/pandas/io/sql.py
@@ -821,13 +821,9 @@ class SQLTable(PandasObject):
 
                 if (col_type is datetime or col_type is date or
                         col_type is DatetimeTZDtype):
-                    if col_type is DatetimeTZDtype:
-                        # Convert tz-aware Datetime SQL columns to UTC
-                        self.frame[col_name] = _handle_date_column(df_col,
-                                                                   utc=True)
-                    else:
-                        self.frame[col_name] = _handle_date_column(df_col)
-
+                    # Convert tz-aware Datetime SQL columns to UTC
+                    utc = col_type is DatetimeTZDtype
+                    self.frame[col_name] = _handle_date_column(df_col, utc=utc)
                 elif col_type is float:
                     # floats support NA, can always convert!
                     self.frame[col_name] = df_col.astype(col_type, copy=False)

--- a/pandas/io/sql.py
+++ b/pandas/io/sql.py
@@ -823,7 +823,7 @@ class SQLTable(PandasObject):
                         col_type is DatetimeTZDtype):
                     if col_type is DatetimeTZDtype:
                         # Convert tz-aware Datetime SQL columns to UTC
-                        self.frame[col_name] = _handle_date_column(df_col, 
+                        self.frame[col_name] = _handle_date_column(df_col,
                                                                    utc=True)
                     else:
                         self.frame[col_name] = _handle_date_column(df_col)

--- a/pandas/io/sql.py
+++ b/pandas/io/sql.py
@@ -821,7 +821,7 @@ class SQLTable(PandasObject):
                 if (col_type is datetime or col_type is date or
                         col_type is DatetimeTZDtype):
                     if col_type is DatetimeTZDtype:
-                        # Convert SQL Datetime columns with tz to UTC
+                        # Convert tz-aware Datetime SQL columns to UTC
                         self.frame[col_name] = _handle_date_column(df_col, 
                                                                    utc=True)
                     else:

--- a/pandas/tests/indexes/datetimes/test_tools.py
+++ b/pandas/tests/indexes/datetimes/test_tools.py
@@ -293,8 +293,8 @@ class TestToDatetime(object):
         tm.assert_series_equal(result, expected)
 
     @pytest.mark.parametrize("data, dtype",
-                             [('2013-01-01 00:00:00-01:00', None), 
-                              ('2013-01-01 00:00:00-01:00','datetime64[ns]'),
+                             [('2013-01-01 00:00:00-01:00', None),
+                              ('2013-01-01 00:00:00-01:00', 'datetime64[ns]'),
                               ('2013-01-01 01:00:00', None),
                               ('2013-01-01 01:00:00', 'datetime64[ns]')])
     def test_to_datetime_utc_true_with_naive_dtype_series(self, data, dtype):

--- a/pandas/tests/indexes/datetimes/test_tools.py
+++ b/pandas/tests/indexes/datetimes/test_tools.py
@@ -269,15 +269,15 @@ class TestToDatetime(object):
         result = pd.to_datetime(date_range, utc=True)
         expected = pd.DatetimeIndex(data=date_range)
         tm.assert_index_equal(result, expected)
-    
+
     @pytest.mark.parametrize("init_constructor, end_constructor, test_method",
-        [(Index, DatetimeIndex, tm.assert_index_equal),
-         (list, DatetimeIndex, tm.assert_index_equal),
-         (np.array, DatetimeIndex, tm.assert_index_equal),
-         (Series, Series, tm.assert_series_equal)])
-    def test_to_datetime_utc_true_with_constructors(self, 
-                                                    init_constructor, 
-                                                    end_constructor, 
+                             [(Index, DatetimeIndex, tm.assert_index_equal),
+                              (list, DatetimeIndex, tm.assert_index_equal),
+                              (np.array, DatetimeIndex, tm.assert_index_equal),
+                              (Series, Series, tm.assert_series_equal)])
+    def test_to_datetime_utc_true_with_constructors(self,
+                                                    init_constructor,
+                                                    end_constructor,
                                                     test_method):
         # GH 6415: UTC=True with Series
         data = ['20100102 121314', '20100102 121315']

--- a/pandas/tests/indexes/datetimes/test_tools.py
+++ b/pandas/tests/indexes/datetimes/test_tools.py
@@ -292,17 +292,20 @@ class TestToDatetime(object):
         expected = pd.Series([pd.Timestamp(ts, tz='utc')])
         tm.assert_series_equal(result, expected)
 
-    @pytest.mark.parametrize("data, dtype",
-                             [('2013-01-01 00:00:00-01:00', None),
-                              ('2013-01-01 00:00:00-01:00', 'datetime64[ns]'),
-                              ('2013-01-01 01:00:00', None),
-                              ('2013-01-01 01:00:00', 'datetime64[ns]')])
-    def test_to_datetime_utc_true_with_naive_dtype_series(self, data, dtype):
-        test_dates = [data] * 10
-        ser = pd.Series(test_dates, dtype=dtype)
-        result = pd.to_datetime(ser, utc=True)
-        expected_data = [pd.Timestamp('20130101 01:00:00', tz='utc')] * 10
-        expected = pd.Series(expected_data)
+    def test_to_datetime_utc_true_with_series_tzaware_string(self):
+        ts = '2013-01-01 00:00:00-01:00'
+        expected_ts = '2013-01-01 01:00:00'
+        data = pd.Series([ts] * 3)
+        result = pd.to_datetime(data, utc=True)
+        expected = pd.Series([pd.Timestamp(expected_ts, tz='utc')] * 3)
+        tm.assert_series_equal(result, expected)
+
+    @pytest.mark.parametrize('date, dtype',
+                             [('2013-01-01 01:00:00', 'datetime64[ns]'),
+                              ('2013-01-01 01:00:00', 'datetime64[ns, UTC]')])
+    def test_to_datetime_utc_true_with_series_datetime_ns(self, date, dtype):
+        expected = pd.Series([pd.Timestamp('2013-01-01 01:00:00', tz='UTC')])
+        result = pd.to_datetime(pd.Series([date], dtype=dtype), utc=True)
         tm.assert_series_equal(result, expected)
 
     def test_to_datetime_tz_psycopg2(self):

--- a/pandas/tests/indexes/datetimes/test_tools.py
+++ b/pandas/tests/indexes/datetimes/test_tools.py
@@ -260,16 +260,6 @@ class TestToDatetime(object):
                                  dtype='datetime64[ns, UTC]', freq=None)
         tm.assert_index_equal(result, expected)
 
-    def test_to_datetime_utc_is_true(self):
-        # See gh-11934
-        start = pd.Timestamp('2014-01-01', tz='utc')
-        end = pd.Timestamp('2014-01-03', tz='utc')
-        date_range = pd.bdate_range(start, end)
-
-        result = pd.to_datetime(date_range, utc=True)
-        expected = pd.DatetimeIndex(data=date_range)
-        tm.assert_index_equal(result, expected)
-
     @pytest.mark.parametrize("init_constructor, end_constructor, test_method",
                              [(Index, DatetimeIndex, tm.assert_index_equal),
                               (list, DatetimeIndex, tm.assert_index_equal),
@@ -279,7 +269,7 @@ class TestToDatetime(object):
                                                     init_constructor,
                                                     end_constructor,
                                                     test_method):
-        # GH 6415: UTC=True with Series
+        # See gh-11934 & gh-6415
         data = ['20100102 121314', '20100102 121315']
         expected_data = [pd.Timestamp('2010-01-02 12:13:14', tz='utc'),
                          pd.Timestamp('2010-01-02 12:13:15', tz='utc')]
@@ -289,6 +279,11 @@ class TestToDatetime(object):
                                 utc=True)
         expected = end_constructor(expected_data)
         test_method(result, expected)
+
+        # Test scalar case as well
+        for scalar, expected in zip(data, expected_data):
+            result = pd.to_datetime(scalar, format='%Y%m%d %H%M%S', utc=True)
+            assert result == expected
 
     def test_to_datetime_utc_true_with_series_single_value(self):
         # GH 15760 UTC=True with Series

--- a/pandas/tests/indexes/datetimes/test_tools.py
+++ b/pandas/tests/indexes/datetimes/test_tools.py
@@ -270,6 +270,38 @@ class TestToDatetime(object):
         expected = pd.DatetimeIndex(data=date_range)
         tm.assert_index_equal(result, expected)
 
+    def test_to_datetime_utc_true_with_series(self):
+        # GH 6415: UTC=True with Series
+        data = ['20100102 121314', '20100102 121315']
+        expected_data = [pd.Timestamp('2010-01-02 12:13:14', tz='utc'),
+                         pd.Timestamp('2010-01-02 12:13:15', tz='utc')]
+        result = pd.to_datetime(pd.Series(data),
+                                format='%Y%m%d %H%M%S',
+                                utc=True)
+        expected = pd.Series(expected_data)
+        tm.assert_series_equal(result, expected)
+        result = pd.to_datetime(pd.Index(data),
+                                format='%Y%m%d %H%M%S',
+                                utc=True)
+        expected = pd.DatetimeIndex(expected_data)
+        tm.assert_index_equal(result, expected)
+
+        # GH 15760 UTC=True with Series
+        ts = 1.5e18
+        result = pd.to_datetime(pd.Series([ts]), utc=True)
+        expected = pd.Series([pd.Timestamp(ts, tz='utc')])
+        tm.assert_series_equal(result, expected)
+
+        test_dates = ['2013-01-01 00:00:00-01:00'] * 10
+        expected_data = [pd.Timestamp('20130101 01:00:00', tz='utc')] * 10
+        expected = pd.Series(expected_data)
+        ser = Series(test_dates)
+        result = pd.to_datetime(ser, utc=True)
+        tm.assert_series_equal(result, expected)
+        ser_naive = Series(test_dates, dtype='datetime64[ns]')
+        result = pd.to_datetime(ser_naive, utc=True)
+        tm.assert_series_equal(result, expected)
+
     def test_to_datetime_tz_psycopg2(self):
 
         # xref 8260

--- a/pandas/tests/indexes/datetimes/test_tools.py
+++ b/pandas/tests/indexes/datetimes/test_tools.py
@@ -272,11 +272,13 @@ class TestToDatetime(object):
     
     @pytest.mark.parametrize("init_constructor, end_constructor, test_method",
         [(Index, DatetimeIndex, tm.assert_index_equal),
+         (list, DatetimeIndex, tm.assert_index_equal),
+         (np.array, DatetimeIndex, tm.assert_index_equal),
          (Series, Series, tm.assert_series_equal)])
-    def test_to_datetime_utc_true_with_series(self, 
-                                              init_constructor, 
-                                              end_constructor, 
-                                              test_method):
+    def test_to_datetime_utc_true_with_constructors(self, 
+                                                    init_constructor, 
+                                                    end_constructor, 
+                                                    test_method):
         # GH 6415: UTC=True with Series
         data = ['20100102 121314', '20100102 121315']
         expected_data = [pd.Timestamp('2010-01-02 12:13:14', tz='utc'),

--- a/pandas/tests/indexes/datetimes/test_tools.py
+++ b/pandas/tests/indexes/datetimes/test_tools.py
@@ -265,10 +265,10 @@ class TestToDatetime(object):
                               (list, DatetimeIndex, tm.assert_index_equal),
                               (np.array, DatetimeIndex, tm.assert_index_equal),
                               (Series, Series, tm.assert_series_equal)])
-    def test_to_datetime_utc_true_with_constructors(self,
-                                                    init_constructor,
-                                                    end_constructor,
-                                                    test_method):
+    def test_to_datetime_utc_true(self,
+                                  init_constructor,
+                                  end_constructor,
+                                  test_method):
         # See gh-11934 & gh-6415
         data = ['20100102 121314', '20100102 121315']
         expected_data = [pd.Timestamp('2010-01-02 12:13:14', tz='utc'),
@@ -292,9 +292,13 @@ class TestToDatetime(object):
         expected = pd.Series([pd.Timestamp(ts, tz='utc')])
         tm.assert_series_equal(result, expected)
 
-    @pytest.mark.parametrize("dtype", [None, 'datetime64[ns]'])
-    def test_to_datetime_utc_true_with_naive_series(self, dtype):
-        test_dates = ['2013-01-01 00:00:00-01:00'] * 10
+    @pytest.mark.parametrize("data, dtype",
+                             [('2013-01-01 00:00:00-01:00', None), 
+                              ('2013-01-01 00:00:00-01:00','datetime64[ns]'),
+                              ('2013-01-01 01:00:00', None),
+                              ('2013-01-01 01:00:00', 'datetime64[ns]')])
+    def test_to_datetime_utc_true_with_naive_dtype_series(self, data, dtype):
+        test_dates = [data] * 10
         ser = pd.Series(test_dates, dtype=dtype)
         result = pd.to_datetime(ser, utc=True)
         expected_data = [pd.Timestamp('20130101 01:00:00', tz='utc')] * 10

--- a/pandas/tests/io/test_sql.py
+++ b/pandas/tests/io/test_sql.py
@@ -1357,7 +1357,7 @@ class _TestSQLAlchemy(SQLAlchemyMixIn, PandasSQLTest):
         # with read_table -> type information from schema used
         result = sql.read_sql_table('test_datetime', self.conn)
         result = result.drop('index', axis=1)
-        # After GH 6415, dates outbound from a db will be localized to UTC 
+        # After GH 6415, dates outbound from a db will be localized to UTC
         # xref GH 7364
         expected = df.copy()
         expected['A'] = expected['A'].dt.tz_localize('UTC')
@@ -1381,7 +1381,7 @@ class _TestSQLAlchemy(SQLAlchemyMixIn, PandasSQLTest):
 
         # with read_table -> type information from schema used
         result = sql.read_sql_table('test_datetime', self.conn)
-        # After GH 6415, dates outbound from a db will be localized to UTC 
+        # After GH 6415, dates outbound from a db will be localized to UTC
         # xref GH 7364
         expected = df.copy()
         expected['A'] = expected['A'].dt.tz_localize('UTC')

--- a/pandas/tests/io/test_sql.py
+++ b/pandas/tests/io/test_sql.py
@@ -1314,7 +1314,6 @@ class _TestSQLAlchemy(SQLAlchemyMixIn, PandasSQLTest):
         expected = sql.read_sql_table("types_test_data", self.conn)
         col = expected.DateColWithTz
         assert is_datetime64tz_dtype(col.dtype)
-        # Removed ".astype('datetime64[ns, UTC]')"after GH 6415 was fixed
         tm.assert_series_equal(df.DateColWithTz, expected.DateColWithTz)
 
         # xref #7139

--- a/pandas/tests/io/test_sql.py
+++ b/pandas/tests/io/test_sql.py
@@ -1281,7 +1281,7 @@ class _TestSQLAlchemy(SQLAlchemyMixIn, PandasSQLTest):
                 # GH 6415
                 expected_data = [Timestamp('2000-01-01 08:00:00', tz='UTC'),
                                  Timestamp('2000-06-01 07:00:00', tz='UTC')]
-                expected = Series(expected_data)
+                expected = Series(expected_data, name=col.name)
                 tm.assert_series_equal(col, expected)
 
             else:

--- a/pandas/tests/io/test_sql.py
+++ b/pandas/tests/io/test_sql.py
@@ -1277,6 +1277,13 @@ class _TestSQLAlchemy(SQLAlchemyMixIn, PandasSQLTest):
                 # "2000-06-01 07:00:00"
                 assert col[1] == Timestamp('2000-06-01 07:00:00', tz='UTC')
 
+                # Double check that the Series has been localized correctly
+                # GH 6415
+                expected_data = [Timestamp('2000-01-01 08:00:00', tz='UTC'),
+                                 Timestamp('2000-06-01 07:00:00', tz='UTC')]
+                expected = Series(expected_data)
+                tm.assert_series_equal(col, expected)
+
             else:
                 raise AssertionError("DateCol loaded with incorrect type "
                                      "-> {0}".format(col.dtype))
@@ -1388,8 +1395,8 @@ class _TestSQLAlchemy(SQLAlchemyMixIn, PandasSQLTest):
         df = DataFrame([date(2014, 1, 1), date(2014, 1, 2)], columns=["a"])
         df.to_sql('test_date', self.conn, index=False)
         res = read_sql_table('test_date', self.conn)
-        expected = res['a']
-        result = to_datetime(df['a'])
+        result = res['a']
+        expected = to_datetime(df['a'])
         # comes back as datetime64
         tm.assert_series_equal(result, expected)
 

--- a/pandas/tests/io/test_sql.py
+++ b/pandas/tests/io/test_sql.py
@@ -606,14 +606,15 @@ class _TestSQLApi(PandasSQLTest):
         # No Parsing
         df = sql.read_sql_query("SELECT * FROM types_test_data", self.conn)
         assert not issubclass(df.DateCol.dtype.type, np.datetime64)
-
+        # Now that GH 6415 is fixed, dates are automatically parsed to UTC
+        utc_dtype = pd.core.dtypes.dtypes.DatetimeTZDtypeType
         df = sql.read_sql_query("SELECT * FROM types_test_data", self.conn,
                                 parse_dates=['DateCol'])
-        assert issubclass(df.DateCol.dtype.type, np.datetime64)
+        assert issubclass(df.DateCol.dtype.type, utc_dtype)
 
         df = sql.read_sql_query("SELECT * FROM types_test_data", self.conn,
                                 parse_dates={'DateCol': '%Y-%m-%d %H:%M:%S'})
-        assert issubclass(df.DateCol.dtype.type, np.datetime64)
+        assert issubclass(df.DateCol.dtype.type, utc_dtype)
 
         df = sql.read_sql_query("SELECT * FROM types_test_data", self.conn,
                                 parse_dates=['IntDateCol'])
@@ -631,8 +632,9 @@ class _TestSQLApi(PandasSQLTest):
         df = sql.read_sql_query("SELECT * FROM types_test_data", self.conn,
                                 index_col='DateCol',
                                 parse_dates=['DateCol', 'IntDateCol'])
-
-        assert issubclass(df.index.dtype.type, np.datetime64)
+        # Now that GH 6415 is fixed, dates are automatically parsed to UTC
+        utc_dtype = pd.core.dtypes.dtypes.DatetimeTZDtypeType
+        assert issubclass(df.index.dtype.type, utc_dtype)
         assert issubclass(df.IntDateCol.dtype.type, np.datetime64)
 
     def test_timedelta(self):
@@ -1319,18 +1321,19 @@ class _TestSQLAlchemy(SQLAlchemyMixIn, PandasSQLTest):
     def test_date_parsing(self):
         # No Parsing
         df = sql.read_sql_table("types_test_data", self.conn)
-
+        # Now that GH 6415 is fixed, dates are automatically parsed to UTC
+        utc_dtype = pd.core.dtypes.dtypes.DatetimeTZDtypeType
         df = sql.read_sql_table("types_test_data", self.conn,
                                 parse_dates=['DateCol'])
-        assert issubclass(df.DateCol.dtype.type, np.datetime64)
+        assert issubclass(df.DateCol.dtype.type, utc_dtype)
 
         df = sql.read_sql_table("types_test_data", self.conn,
                                 parse_dates={'DateCol': '%Y-%m-%d %H:%M:%S'})
-        assert issubclass(df.DateCol.dtype.type, np.datetime64)
+        assert issubclass(df.DateCol.dtype.type, utc_dtype)
 
         df = sql.read_sql_table("types_test_data", self.conn, parse_dates={
             'DateCol': {'format': '%Y-%m-%d %H:%M:%S'}})
-        assert issubclass(df.DateCol.dtype.type, np.datetime64)
+        assert issubclass(df.DateCol.dtype.type, utc_dtype)
 
         df = sql.read_sql_table(
             "types_test_data", self.conn, parse_dates=['IntDateCol'])

--- a/pandas/tests/io/test_sql.py
+++ b/pandas/tests/io/test_sql.py
@@ -1312,6 +1312,8 @@ class _TestSQLAlchemy(SQLAlchemyMixIn, PandasSQLTest):
         assert is_datetime64tz_dtype(col.dtype)
         assert str(col.dt.tz) == 'UTC'
         expected = sql.read_sql_table("types_test_data", self.conn)
+        col = expected.DateColWithTz
+        assert is_datetime64tz_dtype(col.dtype)
         # Removed ".astype('datetime64[ns, UTC]')"after GH 6415 was fixed
         tm.assert_series_equal(df.DateColWithTz, expected.DateColWithTz)
 

--- a/pandas/tests/io/test_sql.py
+++ b/pandas/tests/io/test_sql.py
@@ -1246,9 +1246,7 @@ class _TestSQLAlchemy(SQLAlchemyMixIn, PandasSQLTest):
 
         # IMPORTANT - sqlite has no native date type, so shouldn't parse, but
         # MySQL SHOULD be converted.
-        # Now that GH 6415 is fixed, dates are automatically parsed to UTC
-        utc_dtype = pd.core.dtypes.dtypes.DatetimeTZDtypeType
-        assert issubclass(df.DateCol.dtype.type, utc_dtype)
+        assert issubclass(df.DateCol.dtype.type, np.datetime64)
 
     def test_datetime_with_timezone(self):
         # edge case that converts postgresql datetime with time zone types

--- a/pandas/tests/test_multilevel.py
+++ b/pandas/tests/test_multilevel.py
@@ -2137,7 +2137,6 @@ Thur,Lunch,Yes,51.51,17"""
                           '2011-07-19 08:00:00', '2011-07-19 09:00:00'],
              'value': range(6)})
         df.index = pd.to_datetime(df.pop('datetime'), utc=True)
-        # Removed 'tz_localize('utc') below after GH 6415 was fixed
         df.index = df.index.tz_convert('US/Pacific')
 
         expected = pd.DatetimeIndex(['2011-07-19 07:00:00',

--- a/pandas/tests/test_multilevel.py
+++ b/pandas/tests/test_multilevel.py
@@ -2137,7 +2137,8 @@ Thur,Lunch,Yes,51.51,17"""
                           '2011-07-19 08:00:00', '2011-07-19 09:00:00'],
              'value': range(6)})
         df.index = pd.to_datetime(df.pop('datetime'), utc=True)
-        df.index = df.index.tz_localize('UTC').tz_convert('US/Pacific')
+        # Removed 'tz_localize('utc') below after GH 6415 was fixed
+        df.index = df.index.tz_convert('US/Pacific')
 
         expected = pd.DatetimeIndex(['2011-07-19 07:00:00',
                                      '2011-07-19 08:00:00',


### PR DESCRIPTION
 - [x] closes #6415
 - [x] tests added / passed
 - [x] passes ``git diff upstream/master -u -- "*.py" | flake8 --diff``
 - [x] whatsnew entry

When `_convert_listlike` passes a `np.array` into a `Series`, the `Series` seems to initially be of naive datetime dtype. Localized `Series` if `utc=True`. 

I made one minor change to an existing test that `tz_localize` and index when it originally set the index with a `Series` with `pd.to_datetime(...utc=True)`.