### PR TITLE
DOC: (de)type the return value of concat (#17079)

### DIFF
--- a/pandas/core/reshape/concat.py
+++ b/pandas/core/reshape/concat.py
@@ -65,7 +65,7 @@ def concat(objs, axis=0, join='outer', join_axes=None, ignore_index=False,
 
     Returns
     -------
-    concatenated : type of objects
+    concatenated : object, type of objs
 
     Notes
     -----


### PR DESCRIPTION
Was being parsed by Pycharm as being type "type".

 - [ ] closes #17079
 - [ ] tests added / passed
 - [ ] passes ``git diff upstream/master -u -- "*.py" | flake8 --diff``
 - [ ] whatsnew entry
