### PR TITLE
CI: remove no-longer-available conda versions

### DIFF
--- a/ci/install_travis.sh
+++ b/ci/install_travis.sh
@@ -52,9 +52,6 @@ conda update -q conda
 
 echo
 echo "[add channels]"
-# add the pandas channel to take priority
-# to add extra packages
-conda config --add channels pandas || exit 1
 conda config --remove channels defaults || exit 1
 conda config --add channels defaults || exit 1
 

--- a/ci/requirements-2.7.pip
+++ b/ci/requirements-2.7.pip
@@ -1,5 +1,7 @@
 blosc
 pandas-gbq
+html5lib
+beautifulsoup4
 pathlib
 backports.lzma
 py

--- a/ci/requirements-2.7.run
+++ b/ci/requirements-2.7.run
@@ -10,13 +10,11 @@ xlrd=0.9.2
 sqlalchemy=0.9.6
 lxml=3.2.1
 scipy
-xlsxwriter=0.4.6
+xlsxwriter=0.5.2
 s3fs
 bottleneck
-psycopg2=2.5.2
+psycopg2
 patsy
 pymysql=0.6.3
-html5lib=1.0b2
-beautiful-soup=4.2.1
 jinja2=2.8
 xarray=0.8.0

--- a/ci/requirements-2.7_COMPAT.pip
+++ b/ci/requirements-2.7_COMPAT.pip
@@ -1,2 +1,4 @@
+html5lib==1.0b2
+beautifulsoup4==4.2.0
 openpyxl
 argparse

--- a/ci/requirements-2.7_COMPAT.run
+++ b/ci/requirements-2.7_COMPAT.run
@@ -4,13 +4,10 @@ pytz=2013b
 scipy=0.11.0
 xlwt=0.7.5
 xlrd=0.9.2
-bottleneck=0.8.0
 numexpr=2.2.2
 pytables=3.0.0
-html5lib=1.0b2
-beautiful-soup=4.2.0
-psycopg2=2.5.1
+psycopg2
 pymysql=0.6.0
 sqlalchemy=0.7.8
-xlsxwriter=0.4.6
+xlsxwriter=0.5.2
 jinja2=2.8

--- a/ci/requirements-2.7_LOCALE.pip
+++ b/ci/requirements-2.7_LOCALE.pip
@@ -1,1 +1,3 @@
+html5lib==1.0b2
+beautifulsoup4==4.2.1
 blosc

--- a/ci/requirements-2.7_LOCALE.run
+++ b/ci/requirements-2.7_LOCALE.run
@@ -3,12 +3,9 @@ pytz=2013b
 numpy=1.8.2
 xlwt=0.7.5
 openpyxl=1.6.2
-xlsxwriter=0.4.6
+xlsxwriter=0.5.2
 xlrd=0.9.2
-bottleneck=0.8.0
 matplotlib=1.3.1
 sqlalchemy=0.8.1
-html5lib=1.0b2
 lxml=3.2.1
 scipy
-beautiful-soup=4.2.1

--- a/ci/requirements-2.7_SLOW.run
+++ b/ci/requirements-2.7_SLOW.run
@@ -13,7 +13,6 @@ pytables
 sqlalchemy
 lxml
 s3fs
-bottleneck
 psycopg2
 pymysql
 html5lib

--- a/ci/requirements-3.6.run
+++ b/ci/requirements-3.6.run
@@ -16,7 +16,7 @@ sqlalchemy
 pymysql
 feather-format
 pyarrow
-# psycopg2 (not avail on defaults ATM)
+psycopg2
 beautifulsoup4
 s3fs
 xarray

--- a/ci/requirements-3.6_LOCALE.run
+++ b/ci/requirements-3.6_LOCALE.run
@@ -15,7 +15,7 @@ jinja2
 sqlalchemy
 pymysql
 # feather-format (not available on defaults ATM)
-# psycopg2 (not avail on defaults ATM)
+psycopg2
 beautifulsoup4
 s3fs
 xarray

--- a/ci/requirements-3.6_LOCALE_SLOW.run
+++ b/ci/requirements-3.6_LOCALE_SLOW.run
@@ -15,7 +15,7 @@ jinja2
 sqlalchemy
 pymysql
 # feather-format (not available on defaults ATM)
-# psycopg2 (not available on defaults ATM)
+psycopg2
 beautifulsoup4
 s3fs
 xarray

--- a/doc/source/install.rst
+++ b/doc/source/install.rst
@@ -217,7 +217,8 @@ Recommended Dependencies
   If installed, must be Version 2.4.6 or higher.
 
 * `bottleneck <http://berkeleyanalytics.com/bottleneck>`__: for accelerating certain types of ``nan``
-  evaluations. ``bottleneck`` uses specialized cython routines to achieve large speedups.
+  evaluations. ``bottleneck`` uses specialized cython routines to achieve large speedups. If installed,
+  must be Version 1.0.0 or higher.
 
 .. note::
 

--- a/doc/source/whatsnew/v0.21.0.txt
+++ b/doc/source/whatsnew/v0.21.0.txt
@@ -205,6 +205,7 @@ Other API Changes
 ^^^^^^^^^^^^^^^^^
 
 - Support has been dropped for Python 3.4 (:issue:`15251`)
+- Support has been dropped for bottleneck < 1.0.0 (:issue:`15214`)
 - The Categorical constructor no longer accepts a scalar for the ``categories`` keyword. (:issue:`16022`)
 - Accessing a non-existent attribute on a closed :class:`~pandas.HDFStore` will now
   raise an ``AttributeError`` rather than a ``ClosedFileError`` (:issue:`16301`)

--- a/pandas/core/nanops.py
+++ b/pandas/core/nanops.py
@@ -1,6 +1,8 @@
 import itertools
 import functools
 import operator
+import warnings
+from distutils.version import LooseVersion
 
 import numpy as np
 from pandas import compat
@@ -20,11 +22,24 @@ from pandas.core.dtypes.missing import isna, notna
 from pandas.core.config import get_option
 from pandas.core.common import _values_from_object
 
+_BOTTLENECK_INSTALLED = False
+_MIN_BOTTLENECK_VERSION = '1.0.0'
+
 try:
     import bottleneck as bn
-    _BOTTLENECK_INSTALLED = True
+    ver = bn.__version__
+    _BOTTLENCK_INSTALLED = ver >= LooseVersion(_MIN_BOTTLENECK_VERSION)
+
+    if not _BOTTLENECK_INSTALLED:
+        warnings.warn(
+            "The installed version of bottleneck {ver} is not supported "
+            "in pandas and will be not be used\nThe minimum supported "
+            "version is {min_ver}\n".format(
+                ver=ver, min_ver=_MIN_BOTTLENECK_VERSION), UserWarning)
+
 except ImportError:  # pragma: no cover
-    _BOTTLENECK_INSTALLED = False
+    pass
+
 
 _USE_BOTTLENECK = False
 


### PR DESCRIPTION
closes #15214, remove bottleneck < 1.0.0
changes CI min of xlsxwriter to 0.5.2

removing our ``pandas`` channel as well (which held some really old versions of things).