### PR TITLE
index._is_multi

### DIFF
--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -2029,7 +2029,7 @@ it is assumed to be aliases for the column names.')
         deleted = False
 
         maybe_shortcut = False
-        if hasattr(self, 'columns') and isinstance(self.columns, MultiIndex):
+        if hasattr(self, 'columns') and self.columns._is_multi:
             try:
                 maybe_shortcut = key not in self.columns._engine
             except TypeError:
@@ -2175,7 +2175,7 @@ it is assumed to be aliases for the column names.')
         self._consolidate_inplace()
 
         index = self.index
-        if isinstance(index, MultiIndex):
+        if index._is_multi:
             loc, new_index = self.index.get_loc_level(key,
                                                       drop_level=drop_level)
         else:
@@ -2334,7 +2334,7 @@ it is assumed to be aliases for the column names.')
 
         if axis.is_unique:
             if level is not None:
-                if not isinstance(axis, MultiIndex):
+                if not axis._is_multi:
                     raise AssertionError('axis must be a MultiIndex')
                 new_axis = axis.drop(labels, level=level, errors=errors)
             else:
@@ -2349,7 +2349,7 @@ it is assumed to be aliases for the column names.')
         else:
             labels = _ensure_object(com._index_labels_to_array(labels))
             if level is not None:
-                if not isinstance(axis, MultiIndex):
+                if not axis._is_multi:
                     raise AssertionError('axis must be a MultiIndex')
                 indexer = ~axis.get_level_values(level).isin(labels)
             else:
@@ -4382,7 +4382,7 @@ it is assumed to be aliases for the column names.')
         else:
             alt_ax = ax
 
-        if (isinstance(_maybe_transposed_self.index, MultiIndex) and
+        if (_maybe_transposed_self.index._is_multi and
                 method != 'linear'):
             raise ValueError("Only `method=linear` interpolation is supported "
                              "on MultiIndexes.")
@@ -5917,7 +5917,7 @@ it is assumed to be aliases for the column names.')
         slicer[axis] = slice(before, after)
         result = self.loc[tuple(slicer)]
 
-        if isinstance(ax, MultiIndex):
+        if ax._is_multi:
             setattr(result, self._get_axis_name(axis),
                     ax.truncate(before, after))
 
@@ -5965,7 +5965,7 @@ it is assumed to be aliases for the column names.')
 
         # if a level is given it must be a MultiIndex level or
         # equivalent to the axis name
-        if isinstance(ax, MultiIndex):
+        if ax._is_multi:
             level = ax._get_level_number(level)
             new_level = _tz_convert(ax.levels[level], tz)
             ax = ax.set_levels(new_level, level=level)
@@ -6033,7 +6033,7 @@ it is assumed to be aliases for the column names.')
 
         # if a level is given it must be a MultiIndex level or
         # equivalent to the axis name
-        if isinstance(ax, MultiIndex):
+        if ax._is_multi:
             level = ax._get_level_number(level)
             new_level = _tz_localize(ax.levels[level], tz, ambiguous)
             ax = ax.set_levels(new_level, level=level)

--- a/pandas/core/groupby.py
+++ b/pandas/core/groupby.py
@@ -301,7 +301,7 @@ class Grouper(object):
 
                 # if a level is given it must be a mi level or
                 # equivalent to the axis name
-                if isinstance(ax, MultiIndex):
+                if ax._is_multi:
                     level = ax._get_level_number(level)
                     ax = Index(ax._get_level_values(level),
                                name=ax.names[level])
@@ -896,7 +896,7 @@ class _GroupBy(PandasObject, SelectionMixin):
                 # and we have a result which is duplicated
                 # we can't reindex, so we resort to this
                 # GH 14776
-                if isinstance(ax, MultiIndex) and not ax.is_unique:
+                if ax._is_multi and not ax.is_unique:
                     indexer = algorithms.unique1d(
                         result.index.get_indexer_for(ax.values))
                     result = result.take(indexer, axis=self.axis)
@@ -2577,7 +2577,7 @@ def _get_grouper(obj, key=None, axis=0, level=None, sort=True,
     # validate that the passed level is compatible with the passed
     # axis of the object
     if level is not None:
-        if not isinstance(group_axis, MultiIndex):
+        if not group_axis._is_multi:
             # allow level to be a length-one list-like object
             # (e.g., level=[0])
             # GH 13901

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -13,7 +13,7 @@ from pandas.compat.numpy import function as nv
 from pandas import compat
 
 
-from pandas.core.dtypes.generic import ABCSeries, ABCMultiIndex, ABCPeriodIndex
+from pandas.core.dtypes.generic import ABCSeries, ABCPeriodIndex
 from pandas.core.dtypes.missing import isna, array_equivalent
 from pandas.core.dtypes.common import (
     _ensure_int64,

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -1319,7 +1319,7 @@ class Index(IndexOpsMixin, StringAccessorMixin, PandasObject):
         if kind == 'iloc':
             return self._validate_indexer('positional', key, kind)
 
-        if len(self) and not isinstance(self, ABCMultiIndex,):
+        if len(self) and not self._is_multi:
 
             # we can raise here if we are definitive that this
             # is positional indexing (eg. .ix on with a float)
@@ -2994,7 +2994,7 @@ class Index(IndexOpsMixin, StringAccessorMixin, PandasObject):
     def join(self, other, how='left', level=None, return_indexers=False,
              sort=False):
         from .multi import MultiIndex
-        self_is_mi = isinstance(self, MultiIndex)
+        self_is_mi = self._is_multi
         other_is_mi = isinstance(other, MultiIndex)
 
         # try to figure out the join level
@@ -3091,7 +3091,7 @@ class Index(IndexOpsMixin, StringAccessorMixin, PandasObject):
 
     def _join_multi(self, other, how, return_indexers=True):
         from .multi import MultiIndex
-        self_is_mi = isinstance(self, MultiIndex)
+        self_is_mi = self._is_multi
         other_is_mi = isinstance(other, MultiIndex)
 
         # figure out join names
@@ -3187,13 +3187,13 @@ class Index(IndexOpsMixin, StringAccessorMixin, PandasObject):
             lab = _ensure_int64(labels[-1])
             return lib.get_level_sorter(lab, _ensure_int64(starts))
 
-        if isinstance(self, MultiIndex) and isinstance(other, MultiIndex):
+        if self._is_multi and isinstance(other, MultiIndex):
             raise TypeError('Join on level between two MultiIndex objects '
                             'is ambiguous')
 
         left, right = self, other
 
-        flip_order = not isinstance(self, MultiIndex)
+        flip_order = not self._is_multi
         if flip_order:
             left, right = right, left
             how = {'right': 'left', 'left': 'right'}.get(how, how)

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -141,6 +141,7 @@ class Index(IndexOpsMixin, StringAccessorMixin, PandasObject):
     _allow_period_index_ops = False
     _is_numeric_dtype = False
     _can_hold_na = True
+    _is_multi = False
 
     # would we like our indexing holder to defer to us
     _defer_to_indexing = False

--- a/pandas/core/indexes/multi.py
+++ b/pandas/core/indexes/multi.py
@@ -1774,7 +1774,7 @@ class MultiIndex(Index):
         if is_list_like(target) and not len(target):
             return _ensure_platform_int(np.array([]))
 
-        if not isinstance(target, MultiIndex):
+        if not target._is_multi:
             try:
                 target = MultiIndex.from_tuples(target)
             except (TypeError, ValueError):
@@ -1859,7 +1859,7 @@ class MultiIndex(Index):
                 else:
                     raise Exception("cannot handle a non-unique multi-index!")
 
-        if not isinstance(target, MultiIndex):
+        if not target._is_multi:
             if indexer is None:
                 target = self
             elif (indexer >= 0).all():
@@ -2393,7 +2393,7 @@ class MultiIndex(Index):
         if not isinstance(other, Index):
             return False
 
-        if not isinstance(other, MultiIndex):
+        if not other._is_multi:
             return array_equivalent(self._values,
                                     _values_from_object(_ensure_index(other)))
 

--- a/pandas/core/indexes/multi.py
+++ b/pandas/core/indexes/multi.py
@@ -77,6 +77,7 @@ class MultiIndex(Index):
     _labels = FrozenList()
     _comparables = ['names']
     rename = Index.set_names
+    _is_multi = True
 
     def __new__(cls, levels=None, labels=None, sortorder=None, names=None,
                 copy=False, verify_integrity=True, _set_identity=True,

--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -539,7 +539,7 @@ class _NDFrameIndexer(object):
                 # we have an equal len Frame
                 if isinstance(value, ABCDataFrame) and value.ndim > 1:
                     sub_indexer = list(indexer)
-                    multiindex_indexer = isinstance(labels, MultiIndex)
+                    multiindex_indexer = labels._is_multi
 
                     for item in labels:
                         if item in value:
@@ -1411,7 +1411,7 @@ class _LocIndexer(_LocationIndexer):
         elif is_list_like_indexer(key):
 
             # mi is just a passthru
-            if isinstance(key, tuple) and isinstance(ax, MultiIndex):
+            if isinstance(key, tuple) and ax._is_multi:
                 return True
 
             # TODO: don't check the entire key unless necessary

--- a/pandas/core/panel.py
+++ b/pandas/core/panel.py
@@ -281,7 +281,7 @@ class Panel(NDFrame):
     def __getitem__(self, key):
         key = com._apply_if_callable(key, self)
 
-        if isinstance(self._info_axis, MultiIndex):
+        if self._info_axis._is_multi:
             return self._getitem_multilevel(key)
         if not (is_list_like(key) or isinstance(key, slice)):
             return super(Panel, self).__getitem__(key)
@@ -854,7 +854,7 @@ class Panel(NDFrame):
         # xs cannot handle a non-scalar key, so just reindex here
         # if we have a multi-index and a single tuple, then its a reduction
         # (GH 7516)
-        if not (isinstance(ax, MultiIndex) and isinstance(key, tuple)):
+        if not (ax._is_multi and isinstance(key, tuple)):
             if is_list_like(key):
                 indexer = {self._get_axis_name(axis): key}
                 return self.reindex(**indexer)
@@ -937,14 +937,14 @@ class Panel(NDFrame):
             names = [names]
             return labels, levels, names
 
-        if isinstance(self.major_axis, MultiIndex):
+        if self.major_axis._is_multi:
             major_labels, major_levels, major_names = construct_multi_parts(
                 self.major_axis, n_repeat=K)
         else:
             major_labels, major_levels, major_names = construct_index_parts(
                 self.major_axis)
 
-        if isinstance(self.minor_axis, MultiIndex):
+        if self.minor_axis._is_multi:
             minor_labels, minor_levels, minor_names = construct_multi_parts(
                 self.minor_axis, n_repeat=N, n_shuffle=K)
         else:

--- a/pandas/core/reshape/merge.py
+++ b/pandas/core/reshape/merge.py
@@ -848,7 +848,7 @@ class _MergeOperation(object):
                 else:
                     left_keys.append(left[k]._values)
                     join_names.append(k)
-            if isinstance(self.right.index, MultiIndex):
+            if self.right.index._is_multi:
                 right_keys = [lev._values.take(lab)
                               for lev, lab in zip(self.right.index.levels,
                                                   self.right.index.labels)]
@@ -862,7 +862,7 @@ class _MergeOperation(object):
                 else:
                     right_keys.append(right[k]._values)
                     join_names.append(k)
-            if isinstance(self.left.index, MultiIndex):
+            if self.left.index._is_multi:
                 left_keys = [lev._values.take(lab)
                              for lev, lab in zip(self.left.index.levels,
                                                  self.left.index.labels)]
@@ -1202,10 +1202,10 @@ class _AsOfMerge(_OrderedMerge):
         if len(self.right_on) != 1 and not self.right_index:
             raise MergeError("can only asof on a key for right")
 
-        if self.left_index and isinstance(self.left.index, MultiIndex):
+        if self.left_index and self.left.index._is_multi:
             raise MergeError("left can only have one index")
 
-        if self.right_index and isinstance(self.right.index, MultiIndex):
+        if self.right_index and self.right.index._is_multi:
             raise MergeError("right can only have one index")
 
         # set 'by' columns

--- a/pandas/core/reshape/reshape.py
+++ b/pandas/core/reshape/reshape.py
@@ -89,7 +89,7 @@ class _Unstacker(object):
 
         self.index = index
 
-        if isinstance(self.index, MultiIndex):
+        if self.index._is_multi:
             if index._reference_duplicate_name(level):
                 msg = ("Ambiguous reference to {0}. The index "
                        "names are not unique.".format(level))
@@ -324,7 +324,7 @@ def _unstack_multiple(data, clocs):
         new_names = cnames
         new_labels = recons_labels
     else:
-        if isinstance(data.columns, MultiIndex):
+        if data.columns._is_multi:
             result = data
             for i in range(len(clocs)):
                 val = clocs[i]
@@ -449,7 +449,7 @@ def unstack(obj, level, fill_value=None):
         return _unstack_multiple(obj, level)
 
     if isinstance(obj, DataFrame):
-        if isinstance(obj.index, MultiIndex):
+        if obj.index._is_multi:
             return _unstack_frame(obj, level, fill_value=fill_value)
         else:
             return obj.T.stack(dropna=False)
@@ -514,7 +514,7 @@ def stack(frame, level=-1, dropna=True):
         return categories, codes
 
     N, K = frame.shape
-    if isinstance(frame.columns, MultiIndex):
+    if frame.columns._is_multi:
         if frame.columns._reference_duplicate_name(level):
             msg = ("Ambiguous reference to {0}. The column "
                    "names are not unique.".format(level))
@@ -523,9 +523,9 @@ def stack(frame, level=-1, dropna=True):
     # Will also convert negative level numbers and check if out of bounds.
     level_num = frame.columns._get_level_number(level)
 
-    if isinstance(frame.columns, MultiIndex):
+    if frame.columns._is_multi:
         return _stack_multi_columns(frame, level_num=level_num, dropna=dropna)
-    elif isinstance(frame.index, MultiIndex):
+    elif frame.index._is_multi:
         new_levels = list(frame.index.levels)
         new_labels = [lab.repeat(K) for lab in frame.index.labels]
 
@@ -680,7 +680,7 @@ def _stack_multi_columns(frame, level_num=-1, dropna=True):
 
     N = len(this)
 
-    if isinstance(this.index, MultiIndex):
+    if this.index._is_multi:
         new_levels = list(this.index.levels)
         new_names = list(this.index.names)
         new_labels = [lab.repeat(levsize) for lab in this.index.labels]
@@ -716,7 +716,7 @@ def melt(frame, id_vars=None, value_vars=None, var_name=None,
     if id_vars is not None:
         if not is_list_like(id_vars):
             id_vars = [id_vars]
-        elif (isinstance(frame.columns, MultiIndex) and
+        elif (frame.columns._is_multi and
               not isinstance(id_vars, list)):
             raise ValueError('id_vars must be a list of tuples when columns'
                              ' are a MultiIndex')
@@ -728,7 +728,7 @@ def melt(frame, id_vars=None, value_vars=None, var_name=None,
     if value_vars is not None:
         if not is_list_like(value_vars):
             value_vars = [value_vars]
-        elif (isinstance(frame.columns, MultiIndex) and
+        elif (frame.columns._is_multi and
               not isinstance(value_vars, list)):
             raise ValueError('value_vars must be a list of tuples when'
                              ' columns are a MultiIndex')
@@ -743,7 +743,7 @@ def melt(frame, id_vars=None, value_vars=None, var_name=None,
         frame.columns = frame.columns.get_level_values(col_level)
 
     if var_name is None:
-        if isinstance(frame.columns, MultiIndex):
+        if frame.columns._is_multi:
             if len(frame.columns.names) == len(set(frame.columns.names)):
                 var_name = frame.columns.names
             else:

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -626,7 +626,7 @@ class Series(base.IndexOpsMixin, strings.StringAccessorMixin,
         except InvalidIndexError:
             pass
         except (KeyError, ValueError):
-            if isinstance(key, tuple) and isinstance(self.index, MultiIndex):
+            if isinstance(key, tuple) and self.index._is_multi:
                 # kludge
                 pass
             elif key is Ellipsis:
@@ -708,7 +708,7 @@ class Series(base.IndexOpsMixin, strings.StringAccessorMixin,
         if any(k is None for k in key):
             return self._get_values(key)
 
-        if not isinstance(self.index, MultiIndex):
+        if not self.index._is_multi:
             raise ValueError('Can only tuple-index with a MultiIndex')
 
         # If key is contained, would have returned by now
@@ -760,8 +760,7 @@ class Series(base.IndexOpsMixin, strings.StringAccessorMixin,
                 return
 
             except TypeError as e:
-                if (isinstance(key, tuple) and
-                        not isinstance(self.index, MultiIndex)):
+                if isinstance(key, tuple) and not self.index._is_multi:
                     raise ValueError("Can only tuple-index with a MultiIndex")
 
                 # python 3 type errors should be raised
@@ -994,7 +993,7 @@ class Series(base.IndexOpsMixin, strings.StringAccessorMixin,
         inplace = validate_bool_kwarg(inplace, 'inplace')
         if drop:
             new_index = _default_index(len(self))
-            if level is not None and isinstance(self.index, MultiIndex):
+            if level is not None and self.index._is_multi:
                 if not isinstance(level, (tuple, list)):
                     level = [level]
                 level = [self.index._get_level_number(lev) for lev in level]
@@ -1832,7 +1831,7 @@ class Series(base.IndexOpsMixin, strings.StringAccessorMixin,
         if level:
             new_index, indexer = index.sortlevel(level, ascending=ascending,
                                                  sort_remaining=sort_remaining)
-        elif isinstance(index, MultiIndex):
+        elif index._is_multi:
             from pandas.core.sorting import lexsort_indexer
             labels = index._sort_levels_monotonic()
             indexer = lexsort_indexer(labels._get_labels_for_sorting(),
@@ -2060,7 +2059,7 @@ class Series(base.IndexOpsMixin, strings.StringAccessorMixin,
         -------
         type of caller (new object)
         """
-        if not isinstance(self.index, MultiIndex):  # pragma: no cover
+        if not self.index._is_multi:  # pragma: no cover
             raise Exception('Can only reorder levels on a hierarchical axis.')
 
         result = self.copy()

--- a/pandas/plotting/_core.py
+++ b/pandas/plotting/_core.py
@@ -20,7 +20,7 @@ from pandas.core.dtypes.common import (
     is_iterator)
 from pandas.core.common import AbstractMethodError, _try_sort
 from pandas.core.generic import _shared_docs, _shared_doc_kwargs
-from pandas.core.index import Index, MultiIndex
+from pandas.core.index import Index
 from pandas.core.series import Series
 from pandas.core.indexes.period import PeriodIndex
 from pandas.compat import range, lrange, map, zip, string_types

--- a/pandas/plotting/_core.py
+++ b/pandas/plotting/_core.py
@@ -460,7 +460,7 @@ class MPLPlot(object):
 
     @property
     def legend_title(self):
-        if not isinstance(self.data.columns, MultiIndex):
+        if not self.data.columns._is_multi:
             name = self.data.columns.name
             if name is not None:
                 name = pprint_thing(name)
@@ -591,7 +591,7 @@ class MPLPlot(object):
             return ax.plot(*args, **kwds)
 
     def _get_index_name(self):
-        if isinstance(self.data.index, MultiIndex):
+        if self.data.index._is_multi:
             name = self.data.index.names
             if any(x is not None for x in name):
                 name = ','.join([pprint_thing(x) for x in name])


### PR DESCRIPTION
See timeit stats in #16981.  In cases where we know `index` is some flavor of `pd.Index` object, replacing `isinstance(index, MultiIndex)` with `index._is_multi` cuts the runtime by 40-60%.  And `isinstance(index, ABCMultiIndex)` is about twice as expensive as `isinstance(index, MultiIndex)`.

These checks add up.  Among other things, every call to `DataFrame.__getitem__`  includes a check for `isinstance(self.columns, pd.MultiIndex)`.

 - [ ] closes #xxxx
 - [ ] tests added / passed
 - [ ] passes ``git diff upstream/master -u -- "*.py" | flake8 --diff``
 - [ ] whatsnew entry
