### PR TITLE
ENH: Support strings containing '%' in add_prefix/add_suffix (#17151)

### DIFF
--- a/doc/source/whatsnew/v0.21.0.txt
+++ b/doc/source/whatsnew/v0.21.0.txt
@@ -81,6 +81,7 @@ Other Enhancements
 - :func:`date_range` now accepts 'YS' in addition to 'AS' as an alias for start of year (:issue:`9313`)
 - :func:`date_range` now accepts 'Y' in addition to 'A' as an alias for end of year (:issue:`9313`)
 - Integration with `Apache Parquet <https://parquet.apache.org/>`__, including a new top-level :func:`read_parquet` and :func:`DataFrame.to_parquet` method, see :ref:`here <io.parquet>`.
+- :func:`DataFrame.add_prefix` and :func:`DataFrame.add_suffix` now accept strings containing the '%' character. (:issue:`17151`)
 
 .. _whatsnew_0210.api_breaking:
 

--- a/pandas/core/internals.py
+++ b/pandas/core/internals.py
@@ -5,6 +5,7 @@ import re
 import operator
 from datetime import datetime, timedelta, date
 from collections import defaultdict
+from functools import partial
 
 import numpy as np
 
@@ -2959,11 +2960,11 @@ class BlockManager(PandasObject):
         return obj
 
     def add_prefix(self, prefix):
-        f = (str(prefix) + '%s').__mod__
+        f = partial('{prefix}{}'.format, prefix=prefix)
         return self.rename_axis(f, axis=0)
 
     def add_suffix(self, suffix):
-        f = ('%s' + str(suffix)).__mod__
+        f = partial('{}{suffix}'.format, suffix=suffix)
         return self.rename_axis(f, axis=0)
 
     @property

--- a/pandas/tests/frame/test_api.py
+++ b/pandas/tests/frame/test_api.py
@@ -68,6 +68,14 @@ class SharedWithSparse(object):
         expected = pd.Index(['%s#foo' % c for c in self.frame.columns])
         tm.assert_index_equal(with_suffix.columns, expected)
 
+        with_pct_prefix = self.frame.add_prefix('%')
+        expected = pd.Index(['%{}'.format(c) for c in self.frame.columns])
+        tm.assert_index_equal(with_pct_prefix.columns, expected)
+
+        with_pct_suffix = self.frame.add_suffix('%')
+        expected = pd.Index(['{}%'.format(c) for c in self.frame.columns])
+        tm.assert_index_equal(with_pct_suffix.columns, expected)
+
 
 class TestDataFrameMisc(SharedWithSparse, TestData):
 


### PR DESCRIPTION
 - [X] closes #17151
 - [X] tests added / passed
 - [X] passes ``git diff upstream/master -u -- "*.py" | flake8 --diff``
 - [X] whatsnew entry

Updated the `DataFrame.add_prefix` and `DataFrame.add_suffix` methods to use the new style `.format` syntax to perform the string formatting.  These previously used the old style string formatting, which raises when the prefix/suffix to add contains the '%' character.