### PR TITLE
Implement _make_accessor classmethod for PandasDelegate

### DIFF
--- a/pandas/core/base.py
+++ b/pandas/core/base.py
@@ -167,8 +167,8 @@ class PandasDelegate(PandasObject):
 
     @classmethod
     def _make_accessor(cls, data):
-        raise NotImplementedError("_make_accessor should be implemented"
-                                  "by subclass.  It should return an instance"
+        raise AbstractMethodError("_make_accessor should be implemented"
+                                  "by subclass and return an instance"
                                   "of `cls`.")
 
     def _delegate_property_get(self, name, *args, **kwargs):
@@ -239,10 +239,8 @@ class AccessorProperty(object):
 
     def __init__(self, accessor_cls, construct_accessor=None):
         self.accessor_cls = accessor_cls
-        if construct_accessor is None:
-            # We are assuming that `_make_accessor` classmethod exists.
-            construct_accessor = accessor_cls._make_accessor
-        self.construct_accessor = construct_accessor
+        self.construct_accessor = (construct_accessor or
+                                   accessor_cls._make_accessor)
         self.__doc__ = accessor_cls.__doc__
 
     def __get__(self, instance, owner=None):

--- a/pandas/core/base.py
+++ b/pandas/core/base.py
@@ -165,6 +165,12 @@ class NoNewAttributesMixin(object):
 class PandasDelegate(PandasObject):
     """ an abstract base class for delegating methods/properties """
 
+    @classmethod
+    def _make_accessor(cls, data):
+        raise NotImplementedError("_make_accessor should be implemented"
+                                  "by subclass.  It should return an instance"
+                                  "of `cls`.")
+
     def _delegate_property_get(self, name, *args, **kwargs):
         raise TypeError("You cannot access the "
                         "property {name}".format(name=name))
@@ -231,8 +237,11 @@ class AccessorProperty(object):
     """Descriptor for implementing accessor properties like Series.str
     """
 
-    def __init__(self, accessor_cls, construct_accessor):
+    def __init__(self, accessor_cls, construct_accessor=None):
         self.accessor_cls = accessor_cls
+        if construct_accessor is None:
+            # We are assuming that `_make_accessor` classmethod exists.
+            construct_accessor = accessor_cls._make_accessor
         self.construct_accessor = construct_accessor
         self.__doc__ = accessor_cls.__doc__
 

--- a/pandas/core/categorical.py
+++ b/pandas/core/categorical.py
@@ -2061,6 +2061,13 @@ class CategoricalAccessor(PandasDelegate, NoNewAttributesMixin):
         if res is not None:
             return Series(res, index=self.index)
 
+    @classmethod
+    def _make_accessor(cls, data):
+        if not is_categorical_dtype(data.dtype):
+            raise AttributeError("Can only use .cat accessor with a "
+                                 "'category' dtype")
+        return CategoricalAccessor(data.values, data.index)
+
 
 CategoricalAccessor._add_delegate_accessors(delegate=Categorical,
                                             accessors=["categories",

--- a/pandas/core/indexes/accessors.py
+++ b/pandas/core/indexes/accessors.py
@@ -243,3 +243,11 @@ class CombinedDatetimelikeProperties(DatetimeProperties, TimedeltaProperties):
     # the Series.dt class property. For Series objects, .dt will always be one
     # of the more specific classes above.
     __doc__ = DatetimeProperties.__doc__
+
+    @classmethod
+    def _make_accessor(cls, data):
+        try:
+            return maybe_to_datetimelike(data)
+        except Exception:
+            raise AttributeError("Can only use .dt accessor with datetimelike "
+                                 "values")

--- a/pandas/core/indexes/accessors.py
+++ b/pandas/core/indexes/accessors.py
@@ -249,5 +249,5 @@ class CombinedDatetimelikeProperties(DatetimeProperties, TimedeltaProperties):
         try:
             return maybe_to_datetimelike(data)
         except Exception:
-            raise AttributeError("Can only use .dt accessor with datetimelike "
-                                 "values")
+            raise AttributeError("Can only use .dt accessor with "
+                                 "datetimelike values")

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -55,8 +55,7 @@ from pandas.core import generic, base
 from pandas.core.internals import SingleBlockManager
 from pandas.core.categorical import Categorical, CategoricalAccessor
 import pandas.core.strings as strings
-from pandas.core.indexes.accessors import (
-    maybe_to_datetimelike, CombinedDatetimelikeProperties)
+from pandas.core.indexes.accessors import CombinedDatetimelikeProperties
 from pandas.core.indexes.datetimes import DatetimeIndex
 from pandas.core.indexes.timedeltas import TimedeltaIndex
 from pandas.core.indexes.period import PeriodIndex
@@ -2912,27 +2911,11 @@ class Series(base.IndexOpsMixin, strings.StringAccessorMixin,
 
     # -------------------------------------------------------------------------
     # Datetimelike delegation methods
-
-    def _make_dt_accessor(self):
-        try:
-            return maybe_to_datetimelike(self)
-        except Exception:
-            raise AttributeError("Can only use .dt accessor with datetimelike "
-                                 "values")
-
-    dt = base.AccessorProperty(CombinedDatetimelikeProperties,
-                               _make_dt_accessor)
+    dt = base.AccessorProperty(CombinedDatetimelikeProperties)
 
     # -------------------------------------------------------------------------
     # Categorical methods
-
-    def _make_cat_accessor(self):
-        if not is_categorical_dtype(self.dtype):
-            raise AttributeError("Can only use .cat accessor with a "
-                                 "'category' dtype")
-        return CategoricalAccessor(self.values, self.index)
-
-    cat = base.AccessorProperty(CategoricalAccessor, _make_cat_accessor)
+    cat = base.AccessorProperty(CategoricalAccessor)
 
     def _dir_deletions(self):
         return self._accessors

--- a/pandas/core/strings.py
+++ b/pandas/core/strings.py
@@ -1890,18 +1890,14 @@ class StringMethods(NoNewAttributesMixin):
                                docstring=_shared_docs['ismethods'] %
                                _shared_docs['isdecimal'])
 
-
-class StringAccessorMixin(object):
-    """ Mixin to add a `.str` acessor to the class."""
-
-    # string methods
-    def _make_str_accessor(self):
+    @classmethod
+    def _make_accessor(cls, data):
         from pandas.core.index import Index
 
-        if (isinstance(self, ABCSeries) and
-                not ((is_categorical_dtype(self.dtype) and
-                      is_object_dtype(self.values.categories)) or
-                     (is_object_dtype(self.dtype)))):
+        if (isinstance(data, ABCSeries) and
+                not ((is_categorical_dtype(data.dtype) and
+                      is_object_dtype(data.values.categories)) or
+                     (is_object_dtype(data.dtype)))):
             # it's neither a string series not a categorical series with
             # strings inside the categories.
             # this really should exclude all series with any non-string values
@@ -1910,23 +1906,27 @@ class StringAccessorMixin(object):
             raise AttributeError("Can only use .str accessor with string "
                                  "values, which use np.object_ dtype in "
                                  "pandas")
-        elif isinstance(self, Index):
+        elif isinstance(data, Index):
             # can't use ABCIndex to exclude non-str
 
             # see scc/inferrence.pyx which can contain string values
             allowed_types = ('string', 'unicode', 'mixed', 'mixed-integer')
-            if self.inferred_type not in allowed_types:
+            if data.inferred_type not in allowed_types:
                 message = ("Can only use .str accessor with string values "
                            "(i.e. inferred_type is 'string', 'unicode' or "
                            "'mixed')")
                 raise AttributeError(message)
-            if self.nlevels > 1:
+            if data.nlevels > 1:
                 message = ("Can only use .str accessor with Index, not "
                            "MultiIndex")
                 raise AttributeError(message)
-        return StringMethods(self)
+        return StringMethods(data)
 
-    str = AccessorProperty(StringMethods, _make_str_accessor)
+
+class StringAccessorMixin(object):
+    """ Mixin to add a `.str` acessor to the class."""
+
+    str = AccessorProperty(StringMethods)
 
     def _dir_additions(self):
         return set()


### PR DESCRIPTION
This is an absolutely minimal subset of the refactor in #17042.  It should be obvious and uncontroversial.

- Define `_make_accessor` as a classmethod of `PandasDelegate`.

 - Make `AccessorProperty.__init__` argument `construct_accessor` default to `accessor_cls._make_accessor`.

- Remove methods `_make_cat_accessor` and `_make_dt_accessor` from `Series`, as they do not belong in the namespace.  Remove `_make_str_accessor` from both `Series` and `Index` namespace.

 - [ ] closes #xxxx
 - [ ] tests added / passed
 - [x] passes ``git diff upstream/master -u -- "*.py" | flake8 --diff``
 - [ ] whatsnew entry
