### PR TITLE
Add chunksize param to read_json when lines=True

### DIFF
--- a/asv_bench/benchmarks/io_bench.py
+++ b/asv_bench/benchmarks/io_bench.py
@@ -193,6 +193,7 @@ class read_csv_from_s3(object):
         pd.read_csv(self.big_fname + ext, nrows=10,
                     compression=compression, engine=engine)
 
+
 class read_json_lines(object):
     goal_time = 0.2
 
@@ -206,4 +207,10 @@ class read_json_lines(object):
         pd.read_json("__test__.json", lines=True)
 
     def time_read_json_lines_chunk(self):
-        pd.read_json("__test__.json", lines=True, chunksize=self.N/4)
+        pd.concat(pd.read_json("__test__.json", lines=True, chunksize=self.N/4))
+
+    def peakmem_read_json_lines(self):
+        pd.read_json("__test__.json", lines=True)
+
+    def peakmem_read_json_lines_chunk(self):
+        pd.concat(pd.read_json("__test__.json", lines=True, chunksize=self.N/4))

--- a/asv_bench/benchmarks/io_bench.py
+++ b/asv_bench/benchmarks/io_bench.py
@@ -207,10 +207,10 @@ class read_json_lines(object):
         pd.read_json("__test__.json", lines=True)
 
     def time_read_json_lines_chunk(self):
-        pd.concat(pd.read_json("__test__.json", lines=True, chunksize=self.N/4))
+        pd.concat(pd.read_json("__test__.json", lines=True, chunksize=self.N//4))
 
     def peakmem_read_json_lines(self):
         pd.read_json("__test__.json", lines=True)
 
     def peakmem_read_json_lines_chunk(self):
-        pd.concat(pd.read_json("__test__.json", lines=True, chunksize=self.N/4))
+        pd.concat(pd.read_json("__test__.json", lines=True, chunksize=self.N//4))

--- a/asv_bench/benchmarks/io_bench.py
+++ b/asv_bench/benchmarks/io_bench.py
@@ -192,3 +192,18 @@ class read_csv_from_s3(object):
             ext = ".bz2"
         pd.read_csv(self.big_fname + ext, nrows=10,
                     compression=compression, engine=engine)
+
+class read_json_lines(object):
+    goal_time = 0.2
+
+    def setup(self):
+        self.N = 1000000
+        self.C = 5
+        self.df = DataFrame(dict([('float{0}'.format(i), randn(self.N)) for i in range(self.C)]))
+        self.df.to_json("__test__.json",orient="records",lines=True)
+
+    def time_read_json_lines(self):
+        pd.read_json("__test__.json", lines=True)
+
+    def time_read_json_lines_chunk(self):
+        pd.read_json("__test__.json", lines=True, chunksize=self.N/4)

--- a/asv_bench/benchmarks/io_bench.py
+++ b/asv_bench/benchmarks/io_bench.py
@@ -198,7 +198,7 @@ class read_json_lines(object):
     goal_time = 0.2
 
     def setup(self):
-        self.N = 1000000
+        self.N = 100000
         self.C = 5
         self.df = DataFrame(dict([('float{0}'.format(i), randn(self.N)) for i in range(self.C)]))
         self.df.to_json("__test__.json",orient="records",lines=True)

--- a/asv_bench/benchmarks/io_bench.py
+++ b/asv_bench/benchmarks/io_bench.py
@@ -1,3 +1,4 @@
+import os
 from .pandas_vb_common import *
 from pandas import concat, Timestamp, compat
 try:
@@ -196,21 +197,28 @@ class read_csv_from_s3(object):
 
 class read_json_lines(object):
     goal_time = 0.2
+    fname = "__test__.json"
 
     def setup(self):
         self.N = 100000
         self.C = 5
         self.df = DataFrame(dict([('float{0}'.format(i), randn(self.N)) for i in range(self.C)]))
-        self.df.to_json("__test__.json",orient="records",lines=True)
+        self.df.to_json(self.fname,orient="records",lines=True)
+
+    def teardown(self):
+        try:
+            os.remove(self.fname)
+        except:
+            pass
 
     def time_read_json_lines(self):
-        pd.read_json("__test__.json", lines=True)
+        pd.read_json(self.fname, lines=True)
 
     def time_read_json_lines_chunk(self):
-        pd.concat(pd.read_json("__test__.json", lines=True, chunksize=self.N//4))
+        pd.concat(pd.read_json(self.fname, lines=True, chunksize=self.N//4))
 
     def peakmem_read_json_lines(self):
-        pd.read_json("__test__.json", lines=True)
+        pd.read_json(self.fname, lines=True)
 
     def peakmem_read_json_lines_chunk(self):
-        pd.concat(pd.read_json("__test__.json", lines=True, chunksize=self.N//4))
+        pd.concat(pd.read_json(self.fname, lines=True, chunksize=self.N//4))

--- a/asv_bench/benchmarks/packers.py
+++ b/asv_bench/benchmarks/packers.py
@@ -85,6 +85,25 @@ class packers_read_json(_Packers):
         pd.read_json(self.f, orient='split')
 
 
+class packers_read_json_lines(_Packers):
+
+    def setup(self):
+        self._setup()
+        self.df.to_json(self.f, orient="records", lines=True)
+
+    def time_packers_read_json_lines(self):
+        pd.read_json(self.f, lines=True)
+
+class packers_read_json_lines_chunks(_Packers):
+    def setup(self):
+        self._setup()
+        self.df.to_json('abc.json', orient="records", lines=True)
+        self.df.index = np.arange(self.N)
+
+    def time_packers_read_json_lines_chunks(self):
+        chunksize = int(self.C / 5.0)
+        pd.read_json('abc.json', lines=True, chunksize=chunksize)
+
 class packers_read_json_date_index(_Packers):
 
     def setup(self):

--- a/asv_bench/benchmarks/packers.py
+++ b/asv_bench/benchmarks/packers.py
@@ -85,24 +85,6 @@ class packers_read_json(_Packers):
         pd.read_json(self.f, orient='split')
 
 
-class packers_read_json_lines(_Packers):
-
-    def setup(self):
-        self._setup()
-        self.df.to_json(self.f, orient="records", lines=True)
-
-    def time_packers_read_json_lines(self):
-        pd.read_json(self.f, lines=True)
-
-class packers_read_json_lines_chunks(_Packers):
-    def setup(self):
-        self._setup()
-        self.df.to_json(self.f, orient="records", lines=True)
-
-    def time_packers_read_json_lines_chunks(self):
-        chunksize = int(self.C / 5.0)
-        next([c for c in pd.read_json(self.f, lines=True, chunksize=chunksize)])
-
 class packers_read_json_date_index(_Packers):
 
     def setup(self):

--- a/asv_bench/benchmarks/packers.py
+++ b/asv_bench/benchmarks/packers.py
@@ -97,12 +97,11 @@ class packers_read_json_lines(_Packers):
 class packers_read_json_lines_chunks(_Packers):
     def setup(self):
         self._setup()
-        self.df.to_json('abc.json', orient="records", lines=True)
-        self.df.index = np.arange(self.N)
+        self.df.to_json(self.f, orient="records", lines=True)
 
     def time_packers_read_json_lines_chunks(self):
         chunksize = int(self.C / 5.0)
-        pd.read_json('abc.json', lines=True, chunksize=chunksize)
+        next([c for c in pd.read_json(self.f, lines=True, chunksize=chunksize)])
 
 class packers_read_json_date_index(_Packers):
 

--- a/doc/source/io.rst
+++ b/doc/source/io.rst
@@ -1845,7 +1845,7 @@ is ``None``. To explicitly force ``Series`` parsing, pass ``typ=series``
   seconds, milliseconds, microseconds or nanoseconds respectively.
 - ``lines`` : reads file as one json object per line.
 - ``encoding`` : The encoding to use to decode py3 bytes.
-- ``chunksize`` : when used in combination with ``lines=True``, return a JsonLineReader which reads in ``chunksize`` lines per iteration.
+- ``chunksize`` : when used in combination with ``lines=True``, return a JsonReader which reads in ``chunksize`` lines per iteration.
 
 The parser will raise one of ``ValueError/TypeError/AssertionError`` if the JSON is not parseable.
 

--- a/doc/source/io.rst
+++ b/doc/source/io.rst
@@ -2064,6 +2064,7 @@ For line-delimited json files, pandas can also return an iterator which reads in
   df
   df.to_json(orient='records', lines=True)
 
+  # reader is an iterator that returns `chunksize` lines each iteration
   reader = pd.read_json(StringIO(jsonl), lines=True, chunksize=1)
   reader
   for chunk in reader:

--- a/doc/source/io.rst
+++ b/doc/source/io.rst
@@ -2065,8 +2065,7 @@ For line-delimited json files, pandas can also return an iterator which reads in
   df.to_json(orient='records', lines=True)
 
   # chunksize has no effect when reading a string.
-  import io
-  reader = pd.read_json(io.StringIO(jsonl), lines=True, chunksize=1)
+  reader = pd.read_json(StringIO(jsonl), lines=True, chunksize=1)
   reader
   for chunk in reader:
       print(chunk)

--- a/doc/source/io.rst
+++ b/doc/source/io.rst
@@ -2064,7 +2064,6 @@ For line-delimited json files, pandas can also return an iterator which reads in
   df
   df.to_json(orient='records', lines=True)
 
-  # chunksize has no effect when reading a string.
   reader = pd.read_json(StringIO(jsonl), lines=True, chunksize=1)
   reader
   for chunk in reader:

--- a/doc/source/io.rst
+++ b/doc/source/io.rst
@@ -1845,6 +1845,7 @@ is ``None``. To explicitly force ``Series`` parsing, pass ``typ=series``
   seconds, milliseconds, microseconds or nanoseconds respectively.
 - ``lines`` : reads file as one json object per line.
 - ``encoding`` : The encoding to use to decode py3 bytes.
+- ``chunksize`` : when used in combination with ``lines=True``, return a JsonLineReader which reads in ``chunksize`` lines per iteration.
 
 The parser will raise one of ``ValueError/TypeError/AssertionError`` if the JSON is not parseable.
 
@@ -2049,6 +2050,10 @@ Line delimited json
 pandas is able to read and write line-delimited json files that are common in data processing pipelines
 using Hadoop or Spark.
 
+.. versionadded:: 0.21.0
+
+For line-delimited json files, pandas can also return an iterator which reads in ``chunksize`` lines at a time. This can be useful for large files or to read from a stream.
+
 .. ipython:: python
 
   jsonl = '''
@@ -2059,6 +2064,12 @@ using Hadoop or Spark.
   df
   df.to_json(orient='records', lines=True)
 
+  # chunksize has no effect when reading a string.
+  import io
+  reader = pd.read_json(io.StringIO(jsonl), lines=True, chunksize=1)
+  reader
+  for chunk in reader:
+      print(chunk)
 
 .. _io.table_schema:
 

--- a/doc/source/whatsnew/v0.21.0.txt
+++ b/doc/source/whatsnew/v0.21.0.txt
@@ -471,7 +471,7 @@ Other API Changes
 - :func:`read_csv` now issues a ``UserWarning`` if the ``names`` parameter contains duplicates (:issue:`17095`)
 - :func:`read_csv` now treats ``'null'`` strings as missing values by default (:issue:`16471`)
 - :func:`read_csv` now treats ``'n/a'`` strings as missing values by default (:issue:`16078`)
-- :func:`read_json` now accepts a ``chunksize`` parameter that can reduce memory usage when ``lines=True``. (:issue:`17048`)
+- :func:`read_json` now accepts a ``chunksize`` parameter that can be used when ``lines=True``. If ``chunksize`` is passed, read_json now returns an iterator which reads in ``chunksize`` lines with each iteration. (:issue:`17048`)
 - :class:`pandas.HDFStore`'s string representation is now faster and less detailed. For the previous behavior, use ``pandas.HDFStore.info()``. (:issue:`16503`).
 - Compression defaults in HDF stores now follow pytable standards. Default is no compression and if ``complib`` is missing and ``complevel`` > 0 ``zlib`` is used (:issue:`15943`)
 - ``Index.get_indexer_non_unique()`` now returns a ndarray indexer rather than an ``Index``; this is consistent with ``Index.get_indexer()`` (:issue:`16819`)

--- a/doc/source/whatsnew/v0.21.0.txt
+++ b/doc/source/whatsnew/v0.21.0.txt
@@ -162,6 +162,7 @@ Other Enhancements
 - :func:`MultiIndex.is_monotonic_decreasing` has been implemented.  Previously returned ``False`` in all cases. (:issue:`16554`)
 - :func:`Categorical.rename_categories` now accepts a dict-like argument as `new_categories` and only updates the categories found in that dict. (:issue:`17336`)
 - :func:`read_excel` raises ``ImportError`` with a better message if ``xlrd`` is not installed. (:issue:`17613`)
+- :func:`read_json` now accepts a ``chunksize`` parameter that can be used when ``lines=True``. If ``chunksize`` is passed, read_json now returns an iterator which reads in ``chunksize`` lines with each iteration. (:issue:`17048`)
 - :meth:`DataFrame.assign` will preserve the original order of ``**kwargs`` for Python 3.6+ users instead of sorting the column names
 
 
@@ -471,7 +472,6 @@ Other API Changes
 - :func:`read_csv` now issues a ``UserWarning`` if the ``names`` parameter contains duplicates (:issue:`17095`)
 - :func:`read_csv` now treats ``'null'`` strings as missing values by default (:issue:`16471`)
 - :func:`read_csv` now treats ``'n/a'`` strings as missing values by default (:issue:`16078`)
-- :func:`read_json` now accepts a ``chunksize`` parameter that can be used when ``lines=True``. If ``chunksize`` is passed, read_json now returns an iterator which reads in ``chunksize`` lines with each iteration. (:issue:`17048`)
 - :class:`pandas.HDFStore`'s string representation is now faster and less detailed. For the previous behavior, use ``pandas.HDFStore.info()``. (:issue:`16503`).
 - Compression defaults in HDF stores now follow pytable standards. Default is no compression and if ``complib`` is missing and ``complevel`` > 0 ``zlib`` is used (:issue:`15943`)
 - ``Index.get_indexer_non_unique()`` now returns a ndarray indexer rather than an ``Index``; this is consistent with ``Index.get_indexer()`` (:issue:`16819`)

--- a/doc/source/whatsnew/v0.21.0.txt
+++ b/doc/source/whatsnew/v0.21.0.txt
@@ -471,6 +471,7 @@ Other API Changes
 - :func:`read_csv` now issues a ``UserWarning`` if the ``names`` parameter contains duplicates (:issue:`17095`)
 - :func:`read_csv` now treats ``'null'`` strings as missing values by default (:issue:`16471`)
 - :func:`read_csv` now treats ``'n/a'`` strings as missing values by default (:issue:`16078`)
+- :func:`read_json` now accepts a ``chunksize`` parameter that can reduce memory usage when ``lines=True``. (:issue:`17048`)
 - :class:`pandas.HDFStore`'s string representation is now faster and less detailed. For the previous behavior, use ``pandas.HDFStore.info()``. (:issue:`16503`).
 - Compression defaults in HDF stores now follow pytable standards. Default is no compression and if ``complib`` is missing and ``complevel`` > 0 ``zlib`` is used (:issue:`15943`)
 - ``Index.get_indexer_non_unique()`` now returns a ndarray indexer rather than an ``Index``; this is consistent with ``Index.get_indexer()`` (:issue:`16819`)

--- a/pandas/io/json/json.py
+++ b/pandas/io/json/json.py
@@ -349,8 +349,7 @@ def read_json(path_or_buf=None, orient=None, typ='frame', dtype=True,
     if chunksize:
         return json_reader
 
-    else:
-        return json_reader.read()
+    return json_reader.read()
 
 
 class JsonReader(BaseIterator):

--- a/pandas/io/json/json.py
+++ b/pandas/io/json/json.py
@@ -392,6 +392,9 @@ class JsonReader(BaseIterator):
         """
         At this point, the data either has a `read` attribute (e.g. a file
         object or a StringIO) or is a string that is a JSON document.
+
+        If self.chunksize, we want to prepare the data for the `__next__`
+        method. Otherwise, we want to read it into memory for the `read` method.
         """
         if hasattr(data, 'read'):
             if self.chunksize:
@@ -441,7 +444,6 @@ class JsonReader(BaseIterator):
         """Combines a list of JSON objects into one JSON object"""
         lines = filter(None, map(lambda x: x.strip(), lines))
         return '[' + ','.join(lines) + ']'
-
 
     def read(self):
         """Read the whole JSON input into a pandas object"""

--- a/pandas/io/json/json.py
+++ b/pandas/io/json/json.py
@@ -337,6 +337,15 @@ def read_json(path_or_buf=None, orient=None, typ='frame', dtype=True,
                                                       encoding=encoding)
 
     def _read_json_as_lines(fh, chunksize):
+        """
+        Read json lines from fh in chunks, then concatenate the resulting
+        pandas objects.
+
+        Parameters
+        ----------
+        fh : a file-like object
+        chunksize : integer
+        """
         return_val = None
         while True:
             lines = list(islice(fh, chunksize))

--- a/pandas/io/json/json.py
+++ b/pandas/io/json/json.py
@@ -441,7 +441,8 @@ class JsonReader(BaseIterator):
         """Combines a multi-line JSON document into a single document"""
         # If given a json lines file, we break the string into lines, add
         # commas and put it in a json list to make a valid json object.
-        lines = StringIO(data.strip())
+
+        lines = filter(None, data.strip().split('\n'))
         return '[' + ','.join(lines) + ']'
 
     def read(self):
@@ -496,11 +497,7 @@ class JsonReader(BaseIterator):
         lines = list(islice(self.data, self.chunksize))
         if lines:
 
-            # _get_object_parser can't handle multiple empty lines, so we just
-            # pass it one and it will correctly return an empty object
-            if all(line=="\n" for line in lines):
-                lines = lines[0]
-
+            lines = filter(None, map(lambda x: x.strip(), lines))
             lines_json = '[' + ','.join(lines) + ']'
             obj = self._get_object_parser(lines_json)
 

--- a/pandas/io/json/json.py
+++ b/pandas/io/json/json.py
@@ -11,6 +11,7 @@ from pandas import compat, isna
 from pandas import Series, DataFrame, to_datetime, MultiIndex
 from pandas.io.common import (get_filepath_or_buffer, _get_handle,
                               _stringify_path)
+from pandas.io.parsers import _validate_integer
 from pandas.core.common import AbstractMethodError
 from pandas.io.formats.printing import pprint_thing
 from .normalize import _convert_to_line_delimits
@@ -335,6 +336,9 @@ def read_json(path_or_buf=None, orient=None, typ='frame', dtype=True,
 
     filepath_or_buffer, _, _ = get_filepath_or_buffer(path_or_buf,
                                                       encoding=encoding)
+
+    if chunksize is not None:
+        _validate_integer("chunksize", chunksize, 1)
 
     def _read_json_as_lines(fh, chunksize):
         """

--- a/pandas/io/json/json.py
+++ b/pandas/io/json/json.py
@@ -403,7 +403,7 @@ class JsonReader(BaseIterator):
                 self.raw_json = True
                 self.data = filepath_or_buffer
         elif hasattr(filepath_or_buffer, 'read'):
-                self.data = filepath_or_buffer
+            self.data = filepath_or_buffer
         else:
             self.raw_json = True
             self.data = filepath_or_buffer
@@ -422,15 +422,15 @@ class JsonReader(BaseIterator):
                 return self._get_obj(self.combine_lines(self.data))
             else:
                 return self._get_obj(self.data)
-        elif self.lines and self.chunksize:
+        if self.lines and self.chunksize:
             return concat(self)
+
+        if self.lines:
+            to_return = self._get_obj(self.combine_lines(self.data.read()))
         else:
-            if self.lines:
-                to_return = self._get_obj(self.combine_lines(self.data.read()))
-            else:
-                to_return = self._get_obj(self.data.read())
-            self.__close__()
-            return to_return
+            to_return = self._get_obj(self.data.read())
+        self.__close__()
+        return to_return
 
     def _get_obj(self, json):
         typ = self.typ

--- a/pandas/io/json/json.py
+++ b/pandas/io/json/json.py
@@ -274,6 +274,8 @@ def read_json(path_or_buf=None, orient=None, typ='frame', dtype=True,
             `read_csv`, which returns a FileTextReader.
         If the JSON input is a string, this argument has no effect.
 
+        .. versionadded:: 0.21.0
+
     Returns
     -------
     result : Series or DataFrame, depending on the value of `typ`.

--- a/pandas/io/json/json.py
+++ b/pandas/io/json/json.py
@@ -360,11 +360,9 @@ class JsonReader(BaseIterator):
     ``chunksize`` lines at a time. Otherwise, calling ``read`` reads in the
     whole document.
     """
-    def __init__(
-        self, filepath_or_buffer, orient, typ, dtype, convert_axes,
-        convert_dates, keep_default_dates, numpy, precise_float, date_unit,
-        encoding, lines, chunksize, raw_json=False
-    ):
+    def __init__(self, filepath_or_buffer, orient, typ, dtype, convert_axes,
+                 convert_dates, keep_default_dates, numpy, precise_float,
+                 date_unit, encoding, lines, chunksize, raw_json=False):
 
         self.path_or_buf = filepath_or_buffer
         self.orient = orient
@@ -391,8 +389,7 @@ class JsonReader(BaseIterator):
             try:
                 exists = os.path.exists(filepath_or_buffer)
 
-            # if the filepath is too long will raise here
-            # 5874
+            # gh-5874: if the filepath is too long will raise here
             except (TypeError, ValueError):
                 exists = False
 
@@ -469,7 +466,7 @@ class JsonReader(BaseIterator):
             lines_json = '[' + ','.join(lines) + ']'
             obj = self._get_object_parser(lines_json)
 
-            # Make sure that the returned objects have the right index
+            # Make sure that the returned objects have the right index.
             obj.index = range(self.nrows_seen, self.nrows_seen + len(obj))
             self.nrows_seen += len(obj)
 

--- a/pandas/io/json/json.py
+++ b/pandas/io/json/json.py
@@ -333,6 +333,11 @@ def read_json(path_or_buf=None, orient=None, typ='frame', dtype=True,
                 {"index": "row 2", "col 1": "c", "col 2": "d"}]}'
     """
 
+    if chunksize is not None:
+        chunksize = _validate_integer("chunksize", chunksize, 1)
+        if not lines:
+            raise ValueError("chunksize should only be passed if lines=True")
+
     filepath_or_buffer, _, _ = get_filepath_or_buffer(path_or_buf,
                                                       encoding=encoding)
 
@@ -342,11 +347,6 @@ def read_json(path_or_buf=None, orient=None, typ='frame', dtype=True,
               "convert_axes": convert_axes, "convert_dates": convert_dates,
               "keep_default_dates": keep_default_dates, "numpy": numpy,
               "precise_float": precise_float, "date_unit": date_unit}
-
-    if chunksize is not None:
-        chunksize = _validate_integer("chunksize", chunksize, 1)
-        if not lines:
-            raise ValueError("chunksize should only be passed if lines=True")
 
     if isinstance(filepath_or_buffer, compat.string_types):
         try:

--- a/pandas/io/json/json.py
+++ b/pandas/io/json/json.py
@@ -413,22 +413,20 @@ class JsonReader(BaseIterator):
         It returns input types (2) and (3) unchanged.
         """
 
-        data = None
+        data = filepath_or_buffer
 
-        if isinstance(filepath_or_buffer, compat.string_types):
+        if isinstance(data, compat.string_types):
             try:
                 exists = os.path.exists(filepath_or_buffer)
 
             # gh-5874: if the filepath is too long will raise here
             except (TypeError, ValueError):
-                exists = False
+                pass
 
-            if exists:
-                data, _ = _get_handle(filepath_or_buffer, 'r',
-                                      encoding=self.encoding)
-
-        if not data:
-            data = filepath_or_buffer
+            else:
+                if exists:
+                    data, _ = _get_handle(filepath_or_buffer, 'r',
+                                          encoding=self.encoding)
 
         return data
 

--- a/pandas/io/json/json.py
+++ b/pandas/io/json/json.py
@@ -335,11 +335,6 @@ def read_json(path_or_buf=None, orient=None, typ='frame', dtype=True,
                 {"index": "row 2", "col 1": "c", "col 2": "d"}]}'
     """
 
-    if chunksize is not None:
-        chunksize = _validate_integer("chunksize", chunksize, 1)
-        if not lines:
-            raise ValueError("chunksize should only be passed if lines=True")
-
     filepath_or_buffer, _, _ = get_filepath_or_buffer(path_or_buf,
                                                       encoding=encoding)
 
@@ -387,6 +382,11 @@ class JsonReader(BaseIterator):
         self.chunksize = chunksize
         self.nrows_seen = 0
         self.raw_json = False
+
+        if self.chunksize is not None:
+            self.chunksize = _validate_integer("chunksize", self.chunksize, 1)
+            if not self.lines:
+                raise ValueError("chunksize should only be passed if lines=True")
 
         if isinstance(filepath_or_buffer, compat.string_types):
             try:

--- a/pandas/io/json/json.py
+++ b/pandas/io/json/json.py
@@ -437,6 +437,7 @@ class JsonLineReader(BaseIterator):
                 pass
             raise StopIteration
 
+
 class Parser(object):
 
     _STAMP_UNITS = ('s', 'ms', 'us', 'ns')

--- a/pandas/io/json/json.py
+++ b/pandas/io/json/json.py
@@ -432,7 +432,7 @@ class JsonReader(BaseIterator):
 
         return data
 
-    def combine_lines(self, lines):
+    def _combine_lines(self, lines):
         """Combines a list of JSON objects into one JSON object"""
         lines = filter(None, map(lambda x: x.strip(), lines))
         return '[' + ','.join(lines) + ']'
@@ -443,7 +443,7 @@ class JsonReader(BaseIterator):
             obj = concat(self)
         elif self.lines:
             obj = self._get_object_parser(
-                self.combine_lines(self.data.split('\n'))
+                self._combine_lines(self.data.split('\n'))
             )
         else:
             obj = self._get_object_parser(self.data)
@@ -486,7 +486,7 @@ class JsonReader(BaseIterator):
     def __next__(self):
         lines = list(islice(self.data, self.chunksize))
         if lines:
-            lines_json = self.combine_lines(lines)
+            lines_json = self._combine_lines(lines)
             obj = self._get_object_parser(lines_json)
 
             # Make sure that the returned objects have the right index.

--- a/pandas/io/json/json.py
+++ b/pandas/io/json/json.py
@@ -395,17 +395,10 @@ class JsonReader(BaseIterator):
         If self.chunksize, we prepare the data for the `__next__` method.
         Otherwise, we read it into memory for the `read` method.
         """
-        if hasattr(data, 'read'):
-            if self.chunksize:
-                data = data
-            else:
-                data = data.read()
-
-        else:
-            if self.chunksize:
-                data = StringIO(data)
-            else:
-                data = data
+        if hasattr(data, 'read') and not self.chunksize:
+            data = data.read()
+        if not hasattr(data, 'read') and self.chunksize:
+            data = StringIO(data)
 
         return data
 

--- a/pandas/io/json/json.py
+++ b/pandas/io/json/json.py
@@ -472,9 +472,8 @@ class JsonReader(BaseIterator):
 
             return obj
 
-        else:
-            self.close()
-            raise StopIteration
+        self.close()
+        raise StopIteration
 
 
 class Parser(object):

--- a/pandas/io/json/json.py
+++ b/pandas/io/json/json.py
@@ -1,6 +1,5 @@
 # pylint: disable-msg=E1101,W0613,W0603
 from itertools import islice
-from pandas import concat
 import os
 import numpy as np
 
@@ -423,7 +422,7 @@ class JsonLineReader(BaseIterator):
                 self.fh.close()
             except:
                 pass
-            return StopIteration
+            raise StopIteration
 
 class Parser(object):
 

--- a/pandas/io/json/json.py
+++ b/pandas/io/json/json.py
@@ -267,11 +267,12 @@ def read_json(path_or_buf=None, orient=None, typ='frame', dtype=True,
         .. versionadded:: 0.19.0
 
     chunksize: integer, default None
-        If `lines=True`, how many lines to read into memory at a time.
+        Return JsonLineReader object for iteration.
+        See the `line-delimted json docs
+        <http://pandas.pydata.org/pandas-docs/stable/io.html#io-jsonl>`_
+        for more information on ``chunksize``.
+        This can only be passed if `lines=True`.
         If this is None, the file will be read into memory all at once.
-        Passing a chunksize helps with memory usage, but is slower.
-        Also note this is different from the `chunksize` parameter in
-            `read_csv`, which returns a FileTextReader.
         If the JSON input is a string, this argument has no effect.
 
         .. versionadded:: 0.21.0

--- a/pandas/io/json/json.py
+++ b/pandas/io/json/json.py
@@ -346,6 +346,8 @@ def read_json(path_or_buf=None, orient=None, typ='frame', dtype=True,
 
     if chunksize is not None:
         _validate_integer("chunksize", chunksize, 1)
+        if not lines:
+            raise ValueError("chunksize should only be passed if lines=True")
 
     if isinstance(filepath_or_buffer, compat.string_types):
         try:

--- a/pandas/io/json/json.py
+++ b/pandas/io/json/json.py
@@ -362,7 +362,7 @@ class JsonReader(BaseIterator):
     """
     def __init__(self, filepath_or_buffer, orient, typ, dtype, convert_axes,
                  convert_dates, keep_default_dates, numpy, precise_float,
-                 date_unit, encoding, lines, chunksize, raw_json=False):
+                 date_unit, encoding, lines, chunksize):
 
         self.path_or_buf = filepath_or_buffer
         self.orient = orient

--- a/pandas/io/json/json.py
+++ b/pandas/io/json/json.py
@@ -408,9 +408,6 @@ class JsonReader(BaseIterator):
             self.raw_json = True
             self.data = filepath_or_buffer
 
-        if self.raw_json and lines:
-            self.data = self.combine_lines(self.data)
-
     def combine_lines(self, data):
         """Combines a multi-line JSON document into a single document"""
         # If given a json lines file, we break the string into lines, add
@@ -421,7 +418,10 @@ class JsonReader(BaseIterator):
     def read(self):
         """Read the whole JSON input into a pandas object"""
         if self.raw_json:
-            return self._get_obj(self.data)
+            if self.lines:
+                return self._get_obj(self.combine_lines(self.data))
+            else:
+                return self._get_obj(self.data)
         elif self.lines and self.chunksize:
             return concat(self)
         else:

--- a/pandas/io/json/json.py
+++ b/pandas/io/json/json.py
@@ -420,7 +420,7 @@ class JsonLineReader(BaseIterator):
         else:
             try:
                 self.fh.close()
-            except:
+            except IOError:
                 pass
             raise StopIteration
 

--- a/pandas/io/json/json.py
+++ b/pandas/io/json/json.py
@@ -370,7 +370,8 @@ def read_json(path_or_buf=None, orient=None, typ='frame', dtype=True,
             json = filepath_or_buffer
     elif hasattr(filepath_or_buffer, 'read'):
         if lines and chunksize:
-            return JsonLineReader(filepath_or_buffer, chunksize, encoding, **kwargs)
+            return JsonLineReader(filepath_or_buffer, chunksize, encoding,
+                                  **kwargs)
         else:
             json = filepath_or_buffer.read()
     else:

--- a/pandas/io/json/json.py
+++ b/pandas/io/json/json.py
@@ -393,8 +393,8 @@ class JsonReader(BaseIterator):
         At this point, the data either has a `read` attribute (e.g. a file
         object or a StringIO) or is a string that is a JSON document.
 
-        If self.chunksize, we want to prepare the data for the `__next__`
-        method. Otherwise, we want to read it into memory for the `read` method.
+        If self.chunksize, we prepare the data for the `__next__` method.
+        Otherwise, we read it into memory for the `read` method.
         """
         if hasattr(data, 'read'):
             if self.chunksize:
@@ -417,7 +417,7 @@ class JsonReader(BaseIterator):
             2. file-like object (e.g. open file object, StringIO)
             3. JSON string
 
-        This function turns (1) into (2) to simplify the rest of the processing.
+        This method turns (1) into (2) to simplify the rest of the processing.
         It returns input types (2) and (3) unchanged.
         """
 

--- a/pandas/io/json/json.py
+++ b/pandas/io/json/json.py
@@ -274,7 +274,6 @@ def read_json(path_or_buf=None, orient=None, typ='frame', dtype=True,
         for more information on ``chunksize``.
         This can only be passed if `lines=True`.
         If this is None, the file will be read into memory all at once.
-        If the JSON input is a string, this argument has no effect.
 
         .. versionadded:: 0.21.0
 
@@ -354,7 +353,7 @@ def read_json(path_or_buf=None, orient=None, typ='frame', dtype=True,
 
 class JsonReader(BaseIterator):
     """
-    Reads a JSON document to a pandas object.
+    JsonReader provides an interface for reading in a JSON file.
 
     If initialized with ``lines=True`` and ``chunksize``, can be iterated over
     ``chunksize`` lines at a time. Otherwise, calling ``read`` reads in the

--- a/pandas/io/json/json.py
+++ b/pandas/io/json/json.py
@@ -415,7 +415,7 @@ class JsonReader(BaseIterator):
         """Combines a multi-line JSON document into a single document"""
         # If given a json lines file, we break the string into lines, add
         # commas and put it in a json list to make a valid json object.
-        lines = list(StringIO(data.strip()))
+        lines = StringIO(data.strip())
         return '[' + ','.join(lines) + ']'
 
     def read(self):

--- a/pandas/tests/io/json/test_pandas.py
+++ b/pandas/tests/io/json/test_pandas.py
@@ -1082,6 +1082,16 @@ DataFrame\\.index values are different \\(100\\.0 %\\)
 
         assert_series_equal(chunked, unchunked)
 
+        chunks = list(pd.read_json(get_strio(), lines=True, chunksize=2))
+        assert chunks[0].shape == (2, 2)
+        assert chunks[1].shape == (1, 2)
+
+        with ensure_clean('test.json') as path:
+            df.to_json(path, lines=True, orient="records")
+            unchunked = pd.concat(pd.read_json(path, lines=True, chunksize=1))
+            chunked = pd.read_json(path, lines=True)
+            assert_frame_equal(unchunked, chunked)
+
     def test_latin_encoding(self):
         if compat.PY2:
             tm.assert_raises_regex(

--- a/pandas/tests/io/json/test_pandas.py
+++ b/pandas/tests/io/json/test_pandas.py
@@ -1040,7 +1040,8 @@ DataFrame\\.index values are different \\(100\\.0 %\\)
             return StringIO(df.to_json(lines=True, orient="records"))
 
         def test_with_chunksize(c):
-            return pd.concat(pd.read_json(get_strio(), lines=True, chunksize=c))
+            iterator = pd.read_json(get_strio(), lines=True, chunksize=c)
+            return pd.concat(iterator)
 
         unchunked = pd.read_json(get_strio(), lines=True)
 

--- a/pandas/tests/io/json/test_pandas.py
+++ b/pandas/tests/io/json/test_pandas.py
@@ -1043,17 +1043,14 @@ DataFrame\\.index values are different \\(100\\.0 %\\)
         read_json(chunks=False)"""
         # GH17048: memory usage when lines=True
 
-        unchunked = pd.read_json(StringIO(lines_json_df), lines=True)
-        chunked = pd.concat(
-            pd.read_json(StringIO(lines_json_df), lines=True, chunksize=1)
-        )
+        for cs in [1, 1.0]:
 
-        assert_frame_equal(chunked, unchunked)
+            unchunked = pd.read_json(StringIO(lines_json_df), lines=True)
+            chunked = pd.concat(
+                pd.read_json(StringIO(lines_json_df), lines=True, chunksize=cs)
+            )
 
-        chunked_float = pd.concat(
-            pd.read_json(StringIO(lines_json_df), lines=True, chunksize=1.0)
-        )
-        assert_frame_equal(chunked_float, unchunked)
+            assert_frame_equal(chunked, unchunked)
 
     def test_readjson_chunksize_requires_lines(self, lines_json_df):
         msg = "chunksize should only be passed if lines=True"
@@ -1096,17 +1093,9 @@ DataFrame\\.index values are different \\(100\\.0 %\\)
     def test_readjson_invalid_chunksize(self, lines_json_df):
         msg = r"'chunksize' must be an integer >=1"
 
-        with tm.assert_raises_regex(ValueError, msg):
-            pd.read_json(StringIO(lines_json_df), lines=True, chunksize=0)
-
-        with tm.assert_raises_regex(ValueError, msg):
-            pd.read_json(StringIO(lines_json_df), lines=True, chunksize=-1)
-
-        with tm.assert_raises_regex(ValueError, msg):
-            pd.read_json(StringIO(lines_json_df), lines=True, chunksize=-2.2)
-
-        with tm.assert_raises_regex(ValueError, msg):
-            pd.read_json(StringIO(lines_json_df), lines=True, chunksize='foo')
+        for cs in [0, -1, 2.2, 'foo']:
+            with tm.assert_raises_regex(ValueError, msg):
+                pd.read_json(StringIO(lines_json_df), lines=True, chunksize=cs)
 
     def test_latin_encoding(self):
         if compat.PY2:

--- a/pandas/tests/io/json/test_pandas.py
+++ b/pandas/tests/io/json/test_pandas.py
@@ -1033,6 +1033,7 @@ DataFrame\\.index values are different \\(100\\.0 %\\)
         assert_frame_equal(pd.read_json(result, lines=True), df)
 
     def test_read_jsonchunks(self):
+        # GH17048: memory usage when lines=True
         df = pd.DataFrame({'A': [1, 2, 3], 'B': [4, 5, 6]})
         strio = df.to_json(lines=True, orient="records")
 
@@ -1057,6 +1058,11 @@ DataFrame\\.index values are different \\(100\\.0 %\\)
 
         with tm.assert_raises_regex(ValueError, msg):
             pd.read_json(strio, lines=True, chunksize='foo')
+
+
+        msg = "chunksize should only be passed if lines=True"
+        with tm.assert_raises_regex(ValueError, msg):
+            pd.read_json(strio, lines=False, chunksize=2)
 
     def test_latin_encoding(self):
         if compat.PY2:

--- a/pandas/tests/io/json/test_pandas.py
+++ b/pandas/tests/io/json/test_pandas.py
@@ -10,6 +10,7 @@ from pandas import (Series, DataFrame, DatetimeIndex, Timestamp,
                     read_json, compat)
 from datetime import timedelta
 import pandas as pd
+from pandas.io.json.json import JsonReader
 
 from pandas.util.testing import (assert_almost_equal, assert_frame_equal,
                                  assert_series_equal, network,
@@ -1148,13 +1149,14 @@ class TestPandasJsonLines(object):
         with ensure_clean('test.json') as path:
             df = pd.DataFrame({'A': [1, 2, 3], 'B': [4, 5, 6]})
             df.to_json(path, lines=True, orient="records")
-            f = open(path, 'r')
-            if chunksize is not None:
-                pd.concat(pd.read_json(f, lines=True, chunksize=chunksize))
-            else:
-                pd.read_json(f, lines=True)
-            assert f.closed, \
-                "didn't close file with chunksize = %s" % chunksize
+            reader = JsonReader(
+                path, orient=None, typ="frame", dtype=True, convert_axes=True,
+                convert_dates=True, keep_default_dates=True, numpy=False,
+                precise_float=False, date_unit=None, encoding=None,
+                lines=True, chunksize=chunksize)
+            reader.read()
+            assert reader.open_stream.closed, "didn't close stream with \
+                chunksize = %s" % chunksize
 
     @pytest.mark.parametrize("chunksize", [0, -1, 2.2, "foo"])
     def test_readjson_invalid_chunksize(self, lines_json_df, chunksize):

--- a/pandas/tests/io/json/test_pandas.py
+++ b/pandas/tests/io/json/test_pandas.py
@@ -1074,10 +1074,13 @@ DataFrame\\.index values are different \\(100\\.0 %\\)
         assert_series_equal(chunked, unchunked)
 
     def test_readjson_each_chunk(self):
-        """Other tests check that the final result of read_json(chunksize=True)
-        is correct. This checks that the intermediate chunks read in are correct.
         """
-        chunks = list(pd.read_json(strio_lines_json_df(), lines=True, chunksize=2))
+        Other tests check that the final result of read_json(chunksize=True) is
+        correct. This checks that the intermediate chunks read in are correct.
+        """
+        chunks = list(
+            pd.read_json(strio_lines_json_df(), lines=True, chunksize=2)
+        )
         assert chunks[0].shape == (2, 2)
         assert chunks[1].shape == (1, 2)
 
@@ -1103,7 +1106,6 @@ DataFrame\\.index values are different \\(100\\.0 %\\)
 
         with tm.assert_raises_regex(ValueError, msg):
             json_lines_to_df_chunked(strio_lines_json_df(), 'foo')
-
 
     def test_latin_encoding(self):
         if compat.PY2:

--- a/pandas/tests/io/json/test_pandas.py
+++ b/pandas/tests/io/json/test_pandas.py
@@ -1037,5 +1037,3 @@ DataFrame\\.index values are different \\(100\\.0 %\\)
         size_after = df.memory_usage(index=True, deep=True).sum()
 
         assert size_before == size_after
-
-

--- a/pandas/tests/io/json/test_pandas.py
+++ b/pandas/tests/io/json/test_pandas.py
@@ -1059,7 +1059,6 @@ DataFrame\\.index values are different \\(100\\.0 %\\)
         with tm.assert_raises_regex(ValueError, msg):
             pd.read_json(strio, lines=True, chunksize='foo')
 
-
         msg = "chunksize should only be passed if lines=True"
         with tm.assert_raises_regex(ValueError, msg):
             pd.read_json(strio, lines=False, chunksize=2)

--- a/pandas/tests/io/json/test_pandas.py
+++ b/pandas/tests/io/json/test_pandas.py
@@ -1044,11 +1044,15 @@ DataFrame\\.index values are different \\(100\\.0 %\\)
         # GH17048: memory usage when lines=True
 
         unchunked = pd.read_json(StringIO(lines_json_df), lines=True)
-        chunked = pd.concat(pd.read_json(StringIO(lines_json_df), lines=True, chunksize=1))
+        chunked = pd.concat(
+            pd.read_json(StringIO(lines_json_df), lines=True, chunksize=1)
+        )
 
         assert_frame_equal(chunked, unchunked)
 
-        chunked_float = pd.concat(pd.read_json(StringIO(lines_json_df), lines=True, chunksize=1.0))
+        chunked_float = pd.concat(
+            pd.read_json(StringIO(lines_json_df), lines=True, chunksize=1.0)
+        )
         assert_frame_equal(chunked_float, unchunked)
 
     def test_readjson_chunksize_requires_lines(self, lines_json_df):
@@ -1093,16 +1097,16 @@ DataFrame\\.index values are different \\(100\\.0 %\\)
         msg = r"'chunksize' must be an integer >=1"
 
         with tm.assert_raises_regex(ValueError, msg):
-            pd.concat(pd.read_json(StringIO(lines_json_df), lines=True, chunksize=0))
+            pd.read_json(StringIO(lines_json_df), lines=True, chunksize=0)
 
         with tm.assert_raises_regex(ValueError, msg):
-            pd.concat(pd.read_json(StringIO(lines_json_df), lines=True, chunksize=-1))
+            pd.read_json(StringIO(lines_json_df), lines=True, chunksize=-1)
 
         with tm.assert_raises_regex(ValueError, msg):
-            pd.concat(pd.read_json(StringIO(lines_json_df), lines=True, chunksize=-2.2))
+            pd.read_json(StringIO(lines_json_df), lines=True, chunksize=-2.2)
 
         with tm.assert_raises_regex(ValueError, msg):
-            pd.concat(pd.read_json(StringIO(lines_json_df), lines=True, chunksize='foo'))
+            pd.read_json(StringIO(lines_json_df), lines=True, chunksize='foo')
 
     def test_latin_encoding(self):
         if compat.PY2:

--- a/pandas/tests/io/json/test_pandas.py
+++ b/pandas/tests/io/json/test_pandas.py
@@ -10,7 +10,6 @@ from pandas import (Series, DataFrame, DatetimeIndex, Timestamp,
                     read_json, compat)
 from datetime import timedelta
 import pandas as pd
-from pandas.io.json.json import JsonReader
 
 from pandas.util.testing import (assert_almost_equal, assert_frame_equal,
                                  assert_series_equal, network,
@@ -34,12 +33,6 @@ _cat_frame['E'] = list(reversed(cat))
 _cat_frame['sort'] = np.arange(len(_cat_frame), dtype='int64')
 
 _mixed_frame = _frame.copy()
-
-
-@pytest.fixture
-def lines_json_df():
-    df = pd.DataFrame({'A': [1, 2, 3], 'B': [4, 5, 6]})
-    return df.to_json(lines=True, orient="records")
 
 
 class TestPandasContainer(object):
@@ -1046,146 +1039,3 @@ DataFrame\\.index values are different \\(100\\.0 %\\)
         assert size_before == size_after
 
 
-class TestPandasJsonLines(object):
-
-    def test_read_jsonl(self):
-        # GH9180
-        result = read_json('{"a": 1, "b": 2}\n{"b":2, "a" :1}\n', lines=True)
-        expected = DataFrame([[1, 2], [1, 2]], columns=['a', 'b'])
-        assert_frame_equal(result, expected)
-
-    def test_read_jsonl_unicode_chars(self):
-        # GH15132: non-ascii unicode characters
-        # \u201d == RIGHT DOUBLE QUOTATION MARK
-
-        # simulate file handle
-        json = '{"a": "foo”", "b": "bar"}\n{"a": "foo", "b": "bar"}\n'
-        json = StringIO(json)
-        result = read_json(json, lines=True)
-        expected = DataFrame([[u"foo\u201d", "bar"], ["foo", "bar"]],
-                             columns=['a', 'b'])
-        assert_frame_equal(result, expected)
-
-        # simulate string
-        json = '{"a": "foo”", "b": "bar"}\n{"a": "foo", "b": "bar"}\n'
-        result = read_json(json, lines=True)
-        expected = DataFrame([[u"foo\u201d", "bar"], ["foo", "bar"]],
-                             columns=['a', 'b'])
-        assert_frame_equal(result, expected)
-
-    def test_to_jsonl(self):
-        # GH9180
-        df = DataFrame([[1, 2], [1, 2]], columns=['a', 'b'])
-        result = df.to_json(orient="records", lines=True)
-        expected = '{"a":1,"b":2}\n{"a":1,"b":2}'
-        assert result == expected
-
-        df = DataFrame([["foo}", "bar"], ['foo"', "bar"]], columns=['a', 'b'])
-        result = df.to_json(orient="records", lines=True)
-        expected = '{"a":"foo}","b":"bar"}\n{"a":"foo\\"","b":"bar"}'
-        assert result == expected
-        assert_frame_equal(pd.read_json(result, lines=True), df)
-
-        # GH15096: escaped characters in columns and data
-        df = DataFrame([["foo\\", "bar"], ['foo"', "bar"]],
-                       columns=["a\\", 'b'])
-        result = df.to_json(orient="records", lines=True)
-        expected = ('{"a\\\\":"foo\\\\","b":"bar"}\n'
-                    '{"a\\\\":"foo\\"","b":"bar"}')
-        assert result == expected
-        assert_frame_equal(pd.read_json(result, lines=True), df)
-
-    @pytest.mark.parametrize("chunksize", [1, 1.0])
-    def test_readjson_chunks(self, lines_json_df, chunksize):
-        # Basic test that read_json(chunks=True) gives the same result as
-        # read_json(chunks=False)
-        # GH17048: memory usage when lines=True
-
-        unchunked = pd.read_json(StringIO(lines_json_df), lines=True)
-        reader = pd.read_json(StringIO(lines_json_df), lines=True,
-                              chunksize=chunksize)
-        chunked = pd.concat(reader)
-
-        assert_frame_equal(chunked, unchunked)
-
-    def test_readjson_chunksize_requires_lines(self, lines_json_df):
-        msg = "chunksize can only be passed if lines=True"
-        with tm.assert_raises_regex(ValueError, msg):
-            pd.read_json(StringIO(lines_json_df), lines=False, chunksize=2)
-
-    def test_readjson_chunks_series(self):
-        # Test reading line-format JSON to Series with chunksize param
-        s = pd.Series({'A': 1, 'B': 2})
-
-        strio = StringIO(s.to_json(lines=True, orient="records"))
-        unchunked = pd.read_json(strio, lines=True, typ='Series')
-
-        strio = StringIO(s.to_json(lines=True, orient="records"))
-        chunked = pd.concat(pd.read_json(
-            strio, lines=True, typ='Series', chunksize=1
-        ))
-
-        assert_series_equal(chunked, unchunked)
-
-    def test_readjson_each_chunk(self, lines_json_df):
-        # Other tests check that the final result of read_json(chunksize=True)
-        # is correct. This checks the intermediate chunks.
-        chunks = list(
-            pd.read_json(StringIO(lines_json_df), lines=True, chunksize=2)
-        )
-        assert chunks[0].shape == (2, 2)
-        assert chunks[1].shape == (1, 2)
-
-    def test_readjson_chunks_from_file(self):
-        with ensure_clean('test.json') as path:
-            df = pd.DataFrame({'A': [1, 2, 3], 'B': [4, 5, 6]})
-            df.to_json(path, lines=True, orient="records")
-            chunked = pd.concat(pd.read_json(path, lines=True, chunksize=1))
-            unchunked = pd.read_json(path, lines=True)
-            assert_frame_equal(unchunked, chunked)
-
-    @pytest.mark.parametrize("chunksize", [None, 1])
-    def test_readjson_chunks_closes(self, chunksize):
-        with ensure_clean('test.json') as path:
-            df = pd.DataFrame({'A': [1, 2, 3], 'B': [4, 5, 6]})
-            df.to_json(path, lines=True, orient="records")
-            reader = JsonReader(
-                path, orient=None, typ="frame", dtype=True, convert_axes=True,
-                convert_dates=True, keep_default_dates=True, numpy=False,
-                precise_float=False, date_unit=None, encoding=None,
-                lines=True, chunksize=chunksize)
-            reader.read()
-            assert reader.open_stream.closed, "didn't close stream with \
-                chunksize = %s" % chunksize
-
-    @pytest.mark.parametrize("chunksize", [0, -1, 2.2, "foo"])
-    def test_readjson_invalid_chunksize(self, lines_json_df, chunksize):
-        msg = r"'chunksize' must be an integer >=1"
-
-        with tm.assert_raises_regex(ValueError, msg):
-            pd.read_json(StringIO(lines_json_df), lines=True,
-                         chunksize=chunksize)
-
-    @pytest.mark.parametrize("chunksize", [None, 1, 2])
-    def test_readjson_chunks_multiple_empty_lines(self, chunksize):
-        j = """
-
-        {"A":1,"B":4}
-
-
-
-        {"A":2,"B":5}
-
-
-
-
-
-
-
-        {"A":3,"B":6}
-        """
-        orig = pd.DataFrame({'A': [1, 2, 3], 'B': [4, 5, 6]})
-        test = pd.read_json(j, lines=True, chunksize=chunksize)
-        if chunksize is not None:
-            test = pd.concat(test)
-        tm.assert_frame_equal(orig, test, obj="chunksize: %s" % chunksize)

--- a/pandas/tests/io/json/test_pandas.py
+++ b/pandas/tests/io/json/test_pandas.py
@@ -1041,6 +1041,23 @@ DataFrame\\.index values are different \\(100\\.0 %\\)
 
         assert_frame_equal(chunked, unchunked)
 
+        chunked_float = pd.read_json(strio, lines=True, chunksize=1.0)
+        assert_frame_equal(chunked_float, unchunked)
+
+        msg = r"'chunksize' must be an integer >=1"
+
+        with tm.assert_raises_regex(ValueError, msg):
+            pd.read_json(strio, lines=True, chunksize=0)
+
+        with tm.assert_raises_regex(ValueError, msg):
+            pd.read_json(strio, lines=True, chunksize=-1)
+
+        with tm.assert_raises_regex(ValueError, msg):
+            pd.read_json(strio, lines=True, chunksize=2.2)
+
+        with tm.assert_raises_regex(ValueError, msg):
+            pd.read_json(strio, lines=True, chunksize='foo')
+
     def test_latin_encoding(self):
         if compat.PY2:
             tm.assert_raises_regex(

--- a/pandas/tests/io/json/test_pandas.py
+++ b/pandas/tests/io/json/test_pandas.py
@@ -1110,6 +1110,28 @@ DataFrame\\.index values are different \\(100\\.0 %\\)
             with tm.assert_raises_regex(ValueError, msg):
                 pd.read_json(StringIO(lines_json_df), lines=True, chunksize=cs)
 
+    def test_readjson_chunks_multiple_empty_lines(self):
+        j = """
+
+        {"A":1,"B":4}
+
+
+
+        {"A":2,"B":5}
+
+
+
+
+
+
+
+        {"A":3,"B":6}
+        """
+        for chunksize in [None, 1, 2]:
+            orig = pd.DataFrame({'A': [1, 2, 3], 'B': [4, 5, 6]})
+            test = pd.concat(pd.read_json(j, lines=True, chunksize=chunksize))
+            tm.assert_frame_equal(orig, test, obj="chunksize: %s" % chunksize)
+
     def test_latin_encoding(self):
         if compat.PY2:
             tm.assert_raises_regex(

--- a/pandas/tests/io/json/test_pandas.py
+++ b/pandas/tests/io/json/test_pandas.py
@@ -1090,6 +1090,19 @@ DataFrame\\.index values are different \\(100\\.0 %\\)
             unchunked = pd.read_json(path, lines=True)
             assert_frame_equal(unchunked, chunked)
 
+    def test_readjson_chunks_closes(self):
+        for chunksize in [None, 1]:
+            with ensure_clean('test.json') as path:
+                df = pd.DataFrame({'A': [1, 2, 3], 'B': [4, 5, 6]})
+                df.to_json(path, lines=True, orient="records")
+                f = open(path, 'r')
+                if chunksize is not None:
+                    pd.concat(pd.read_json(f, lines=True, chunksize=chunksize))
+                else:
+                    pd.read_json(f, lines=True)
+                assert f.closed, \
+                    "didn't close file with chunksize = %s" % chunksize
+
     def test_readjson_invalid_chunksize(self, lines_json_df):
         msg = r"'chunksize' must be an integer >=1"
 

--- a/pandas/tests/io/json/test_pandas.py
+++ b/pandas/tests/io/json/test_pandas.py
@@ -1089,8 +1089,8 @@ DataFrame\\.index values are different \\(100\\.0 %\\)
 
         with ensure_clean('test.json') as path:
             df.to_json(path, lines=True, orient="records")
-            unchunked = pd.concat(pd.read_json(path, lines=True, chunksize=1))
-            chunked = pd.read_json(path, lines=True)
+            chunked = pd.concat(pd.read_json(path, lines=True, chunksize=1))
+            unchunked = pd.read_json(path, lines=True)
             assert_frame_equal(unchunked, chunked)
 
     def test_latin_encoding(self):

--- a/pandas/tests/io/json/test_pandas.py
+++ b/pandas/tests/io/json/test_pandas.py
@@ -35,7 +35,6 @@ _cat_frame['sort'] = np.arange(len(_cat_frame), dtype='int64')
 _mixed_frame = _frame.copy()
 
 
-@pytest.fixture
 def strio_lines_json_df():
     df = pd.DataFrame({'A': [1, 2, 3], 'B': [4, 5, 6]})
     return StringIO(df.to_json(lines=True, orient="records"))
@@ -43,6 +42,7 @@ def strio_lines_json_df():
 
 def json_lines_to_df_chunked(jlines, chunksize):
     return pd.concat(pd.read_json(jlines, lines=True, chunksize=chunksize))
+
 
 class TestPandasContainer(object):
 
@@ -1054,7 +1054,7 @@ DataFrame\\.index values are different \\(100\\.0 %\\)
         chunked_float = json_lines_to_df_chunked(strio_lines_json_df(), 1.0)
         assert_frame_equal(chunked_float, unchunked)
 
-    def test_readjson_chunksize_requires_lines():
+    def test_readjson_chunksize_requires_lines(self):
         msg = "chunksize should only be passed if lines=True"
         with tm.assert_raises_regex(ValueError, msg):
             pd.read_json(strio_lines_json_df(), lines=False, chunksize=2)

--- a/pandas/tests/io/json/test_pandas.py
+++ b/pandas/tests/io/json/test_pandas.py
@@ -1129,7 +1129,9 @@ DataFrame\\.index values are different \\(100\\.0 %\\)
         """
         for chunksize in [None, 1, 2]:
             orig = pd.DataFrame({'A': [1, 2, 3], 'B': [4, 5, 6]})
-            test = pd.concat(pd.read_json(j, lines=True, chunksize=chunksize))
+            test = pd.read_json(j, lines=True, chunksize=chunksize)
+            if chunksize is not None:
+                test = pd.concat(test)
             tm.assert_frame_equal(orig, test, obj="chunksize: %s" % chunksize)
 
     def test_latin_encoding(self):

--- a/pandas/tests/io/json/test_pandas.py
+++ b/pandas/tests/io/json/test_pandas.py
@@ -1032,6 +1032,15 @@ DataFrame\\.index values are different \\(100\\.0 %\\)
         assert result == expected
         assert_frame_equal(pd.read_json(result, lines=True), df)
 
+    def test_read_jsonchunks(self):
+        df = pd.DataFrame({'A': [1, 2, 3], 'B': [4, 5, 6]})
+        strio = df.to_json(lines=True, orient="records")
+
+        unchunked = pd.read_json(strio, lines=True)
+        chunked = pd.read_json(strio, lines=True, chunksize=1)
+
+        assert_frame_equal(chunked, unchunked)
+
     def test_latin_encoding(self):
         if compat.PY2:
             tm.assert_raises_regex(

--- a/pandas/tests/io/json/test_pandas.py
+++ b/pandas/tests/io/json/test_pandas.py
@@ -1053,7 +1053,7 @@ DataFrame\\.index values are different \\(100\\.0 %\\)
             assert_frame_equal(chunked, unchunked)
 
     def test_readjson_chunksize_requires_lines(self, lines_json_df):
-        msg = "chunksize should only be passed if lines=True"
+        msg = "chunksize can only be passed if lines=True"
         with tm.assert_raises_regex(ValueError, msg):
             pd.read_json(StringIO(lines_json_df), lines=False, chunksize=2)
 

--- a/pandas/tests/io/json/test_readlines.py
+++ b/pandas/tests/io/json/test_readlines.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 import pytest
 import pandas as pd
 from pandas import DataFrame, read_json

--- a/pandas/tests/io/json/test_readlines.py
+++ b/pandas/tests/io/json/test_readlines.py
@@ -1,0 +1,167 @@
+import pytest
+import pandas as pd
+from pandas import DataFrame, read_json
+from pandas.compat import StringIO
+from pandas.io.json.json import JsonReader
+import pandas.util.testing as tm
+from pandas.util.testing import (assert_frame_equal, assert_series_equal,
+                                 ensure_clean)
+
+
+@pytest.fixture
+def lines_json_df():
+    df = pd.DataFrame({'A': [1, 2, 3], 'B': [4, 5, 6]})
+    return df.to_json(lines=True, orient="records")
+
+
+def test_read_jsonl():
+    # GH9180
+    result = read_json('{"a": 1, "b": 2}\n{"b":2, "a" :1}\n', lines=True)
+    expected = DataFrame([[1, 2], [1, 2]], columns=['a', 'b'])
+    assert_frame_equal(result, expected)
+
+
+def test_read_jsonl_unicode_chars():
+    # GH15132: non-ascii unicode characters
+    # \u201d == RIGHT DOUBLE QUOTATION MARK
+
+    # simulate file handle
+    json = '{"a": "foo”", "b": "bar"}\n{"a": "foo", "b": "bar"}\n'
+    json = StringIO(json)
+    result = read_json(json, lines=True)
+    expected = DataFrame([[u"foo\u201d", "bar"], ["foo", "bar"]],
+                         columns=['a', 'b'])
+    assert_frame_equal(result, expected)
+
+    # simulate string
+    json = '{"a": "foo”", "b": "bar"}\n{"a": "foo", "b": "bar"}\n'
+    result = read_json(json, lines=True)
+    expected = DataFrame([[u"foo\u201d", "bar"], ["foo", "bar"]],
+                         columns=['a', 'b'])
+    assert_frame_equal(result, expected)
+
+
+def test_to_jsonl():
+    # GH9180
+    df = DataFrame([[1, 2], [1, 2]], columns=['a', 'b'])
+    result = df.to_json(orient="records", lines=True)
+    expected = '{"a":1,"b":2}\n{"a":1,"b":2}'
+    assert result == expected
+
+    df = DataFrame([["foo}", "bar"], ['foo"', "bar"]], columns=['a', 'b'])
+    result = df.to_json(orient="records", lines=True)
+    expected = '{"a":"foo}","b":"bar"}\n{"a":"foo\\"","b":"bar"}'
+    assert result == expected
+    assert_frame_equal(read_json(result, lines=True), df)
+
+    # GH15096: escaped characters in columns and data
+    df = DataFrame([["foo\\", "bar"], ['foo"', "bar"]],
+                   columns=["a\\", 'b'])
+    result = df.to_json(orient="records", lines=True)
+    expected = ('{"a\\\\":"foo\\\\","b":"bar"}\n'
+                '{"a\\\\":"foo\\"","b":"bar"}')
+    assert result == expected
+    assert_frame_equal(read_json(result, lines=True), df)
+
+
+@pytest.mark.parametrize("chunksize", [1, 1.0])
+def test_readjson_chunks(lines_json_df, chunksize):
+    # Basic test that read_json(chunks=True) gives the same result as
+    # read_json(chunks=False)
+    # GH17048: memory usage when lines=True
+
+    unchunked = read_json(StringIO(lines_json_df), lines=True)
+    reader = read_json(StringIO(lines_json_df), lines=True,
+                       chunksize=chunksize)
+    chunked = pd.concat(reader)
+
+    assert_frame_equal(chunked, unchunked)
+
+
+def test_readjson_chunksize_requires_lines(lines_json_df):
+    msg = "chunksize can only be passed if lines=True"
+    with tm.assert_raises_regex(ValueError, msg):
+        pd.read_json(StringIO(lines_json_df), lines=False, chunksize=2)
+
+
+def test_readjson_chunks_series():
+    # Test reading line-format JSON to Series with chunksize param
+    s = pd.Series({'A': 1, 'B': 2})
+
+    strio = StringIO(s.to_json(lines=True, orient="records"))
+    unchunked = pd.read_json(strio, lines=True, typ='Series')
+
+    strio = StringIO(s.to_json(lines=True, orient="records"))
+    chunked = pd.concat(pd.read_json(
+        strio, lines=True, typ='Series', chunksize=1
+    ))
+
+    assert_series_equal(chunked, unchunked)
+
+
+def test_readjson_each_chunk(lines_json_df):
+    # Other tests check that the final result of read_json(chunksize=True)
+    # is correct. This checks the intermediate chunks.
+    chunks = list(
+        pd.read_json(StringIO(lines_json_df), lines=True, chunksize=2)
+    )
+    assert chunks[0].shape == (2, 2)
+    assert chunks[1].shape == (1, 2)
+
+
+def test_readjson_chunks_from_file():
+    with ensure_clean('test.json') as path:
+        df = pd.DataFrame({'A': [1, 2, 3], 'B': [4, 5, 6]})
+        df.to_json(path, lines=True, orient="records")
+        chunked = pd.concat(pd.read_json(path, lines=True, chunksize=1))
+        unchunked = pd.read_json(path, lines=True)
+        assert_frame_equal(unchunked, chunked)
+
+
+@pytest.mark.parametrize("chunksize", [None, 1])
+def test_readjson_chunks_closes(chunksize):
+    with ensure_clean('test.json') as path:
+        df = pd.DataFrame({'A': [1, 2, 3], 'B': [4, 5, 6]})
+        df.to_json(path, lines=True, orient="records")
+        reader = JsonReader(
+            path, orient=None, typ="frame", dtype=True, convert_axes=True,
+            convert_dates=True, keep_default_dates=True, numpy=False,
+            precise_float=False, date_unit=None, encoding=None,
+            lines=True, chunksize=chunksize)
+        reader.read()
+        assert reader.open_stream.closed, "didn't close stream with \
+            chunksize = %s" % chunksize
+
+
+@pytest.mark.parametrize("chunksize", [0, -1, 2.2, "foo"])
+def test_readjson_invalid_chunksize(lines_json_df, chunksize):
+    msg = r"'chunksize' must be an integer >=1"
+
+    with tm.assert_raises_regex(ValueError, msg):
+        pd.read_json(StringIO(lines_json_df), lines=True,
+                     chunksize=chunksize)
+
+
+@pytest.mark.parametrize("chunksize", [None, 1, 2])
+def test_readjson_chunks_multiple_empty_lines(chunksize):
+    j = """
+
+    {"A":1,"B":4}
+
+
+
+    {"A":2,"B":5}
+
+
+
+
+
+
+
+    {"A":3,"B":6}
+    """
+    orig = pd.DataFrame({'A': [1, 2, 3], 'B': [4, 5, 6]})
+    test = pd.read_json(j, lines=True, chunksize=chunksize)
+    if chunksize is not None:
+        test = pd.concat(test)
+    tm.assert_frame_equal(orig, test, obj="chunksize: %s" % chunksize)


### PR DESCRIPTION
Previous behavior: reading the whole file to memory and then split into lines.
New behavior: if `lines=True` and `chunksize` is passed: read in `chunksize` lines at a time, and concat.

This only covers some kinds of input to `read_json`.  When `chunksize` is passed, `read_json` becomes slower but more memory-efficient.

Closes #17048.

Tests and style-check pass, no new tests added.