### PR TITLE
use == to test String equality

### DIFF
--- a/pandas/io/parquet.py
+++ b/pandas/io/parquet.py
@@ -10,10 +10,10 @@ from pandas.io.common import get_filepath_or_buffer
 def get_engine(engine):
     """ return our implementation """
 
-    if engine is 'auto':
+    if engine == 'auto':
         engine = get_option('io.parquet.engine')
 
-    if engine is 'auto':
+    if engine == 'auto':
         # try engines in this order
         try:
             return PyArrowImpl()


### PR DESCRIPTION
@jreback quick fix following f4330611ff5ac1cbb4a89c4a7dab3d0900f9e64a (see [lgtm report](https://lgtm.com/projects/g/pydata/pandas/rev/f4330611ff5ac1cbb4a89c4a7dab3d0900f9e64a))

Using `is` instead of `==` might work in simple cases such as this one due to the Python implementation being "efficient" but it checks for identity rather than value and will  produce likely un-intended results pretty quickly:

```
>>> a = "f"
>>> b = "f"
>>> a == b
True
>>> a is b
True
```
but:

```
>>> a = "f "
>>> b = "f "
>>> a == b
True
>>> a is b
False
```
