### PR TITLE
move pivot_table doc-string to DataFrame

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -4226,10 +4226,11 @@ class DataFrame(NDFrame):
     def pivot_table(self, values=None, index=None, columns=None,
                     aggfunc='mean', fill_value=None, margins=False,
                     dropna=True, margins_name='All'):
-        return pivot.pivot_table(self, values=values, index=index,
-                                 columns=columns, aggfunc=aggfunc,
-                                 fill_value=fill_value, margins=margins,
-                                 dropna=dropna, margins_name=margins_name)
+        from pandas.core.reshape.pivot import pivot_table
+        return pivot_table(self, values=values, index=index, columns=columns,
+                           aggfunc=aggfunc, fill_value=fill_value,
+                           margins=margins, dropna=dropna,
+                           margins_name=margins_name)
 
     def stack(self, level=-1, dropna=True):
         """

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -101,7 +101,6 @@ import pandas.plotting._core as gfx
 from pandas._libs import lib, algos as libalgos
 
 from pandas.core.config import get_option
-from pandas.core.reshape import pivot
 
 # ---------------------------------------------------------------------
 # Docstring templates
@@ -4146,6 +4145,81 @@ class DataFrame(NDFrame):
         """
         from pandas.core.reshape.reshape import pivot
         return pivot(self, index=index, columns=columns, values=values)
+
+    _shared_docs['pivot_table'] = """
+        Create a spreadsheet-style pivot table as a DataFrame. The levels in
+        the pivot table will be stored in MultiIndex objects (hierarchical
+        indexes) on the index and columns of the result DataFrame
+
+        Parameters
+        ----------%s
+        values : column to aggregate, optional
+        index : column, Grouper, array, or list of the previous
+            If an array is passed, it must be the same length as the data. The
+            list can contain any of the other types (except list).
+            Keys to group by on the pivot table index.  If an array is passed,
+            it is being used as the same manner as column values.
+        columns : column, Grouper, array, or list of the previous
+            If an array is passed, it must be the same length as the data. The
+            list can contain any of the other types (except list).
+            Keys to group by on the pivot table column.  If an array is passed,
+            it is being used as the same manner as column values.
+        aggfunc : function or list of functions, default numpy.mean
+            If list of functions passed, the resulting pivot table will have
+            hierarchical columns whose top level are the function names
+            (inferred from the function objects themselves)
+        fill_value : scalar, default None
+            Value to replace missing values with
+        margins : boolean, default False
+            Add all row / columns (e.g. for subtotal / grand totals)
+        dropna : boolean, default True
+            Do not include columns whose entries are all NaN
+        margins_name : string, default 'All'
+            Name of the row / column that will contain the totals
+            when margins is True.
+
+        Examples
+        --------
+        >>> df = pd.DataFrame({"A": ["foo", "foo", "foo", "foo", "foo",
+        ...                          "bar", "bar", "bar", "bar"],
+        ...                    "B": ["one", "one", "one", "two", "two",
+        ...                          "one", "one", "two", "two"],
+        ...                    "C": ["small", "large", "large", "small",
+        ...                          "small", "large", "small", "small",
+        ...                          "large"],
+        ...                    "D": [1, 2, 2, 3, 3, 4, 5, 6, 7]})
+        >>> df
+             A    B      C  D
+        0  foo  one  small  1
+        1  foo  one  large  2
+        2  foo  one  large  2
+        3  foo  two  small  3
+        4  foo  two  small  3
+        5  bar  one  large  4
+        6  bar  one  small  5
+        7  bar  two  small  6
+        8  bar  two  large  7
+
+        >>> table = pivot_table(df, values='D', index=['A', 'B'],
+        ...                     columns=['C'], aggfunc=np.sum)
+        >>> table
+        ... # doctest: +NORMALIZE_WHITESPACE
+        C        large  small
+        A   B
+        bar one    4.0    5.0
+            two    7.0    6.0
+        foo one    4.0    1.0
+            two    NaN    6.0
+
+        Returns
+        -------
+        table : DataFrame
+
+        See also
+        --------
+        DataFrame.pivot : pivot without aggregation that can handle
+            non-numeric data
+        """
 
     @Substitution('')
     @Appender(_shared_docs['pivot_table'])

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -101,6 +101,7 @@ import pandas.plotting._core as gfx
 from pandas._libs import lib, algos as libalgos
 
 from pandas.core.config import get_option
+from pandas.core.reshape import pivot
 
 # ---------------------------------------------------------------------
 # Docstring templates
@@ -4146,89 +4147,15 @@ class DataFrame(NDFrame):
         from pandas.core.reshape.reshape import pivot
         return pivot(self, index=index, columns=columns, values=values)
 
+    @Substitution('')
+    @Appender(_shared_docs['pivot_table'])
     def pivot_table(self, values=None, index=None, columns=None,
                     aggfunc='mean', fill_value=None, margins=False,
                     dropna=True, margins_name='All'):
-        """
-        Create a spreadsheet-style pivot table as a DataFrame. The levels in
-        the pivot table will be stored in MultiIndex objects (hierarchical
-        indexes) on the index and columns of the result DataFrame
-
-        Parameters
-        ----------
-        data : DataFrame
-        values : column to aggregate, optional
-        index : column, Grouper, array, or list of the previous
-            If an array is passed, it must be the same length as the data. The
-            list can contain any of the other types (except list).
-            Keys to group by on the pivot table index.  If an array is passed,
-            it is being used as the same manner as column values.
-        columns : column, Grouper, array, or list of the previous
-            If an array is passed, it must be the same length as the data. The
-            list can contain any of the other types (except list).
-            Keys to group by on the pivot table column.  If an array is passed,
-            it is being used as the same manner as column values.
-        aggfunc : function or list of functions, default numpy.mean
-            If list of functions passed, the resulting pivot table will have
-            hierarchical columns whose top level are the function names
-            (inferred from the function objects themselves)
-        fill_value : scalar, default None
-            Value to replace missing values with
-        margins : boolean, default False
-            Add all row / columns (e.g. for subtotal / grand totals)
-        dropna : boolean, default True
-            Do not include columns whose entries are all NaN
-        margins_name : string, default 'All'
-            Name of the row / column that will contain the totals
-            when margins is True.
-
-        Examples
-        --------
-        >>> df = pd.DataFrame({"A": ["foo", "foo", "foo", "foo", "foo",
-        ...                          "bar", "bar", "bar", "bar"],
-        ...                    "B": ["one", "one", "one", "two", "two",
-        ...                          "one", "one", "two", "two"],
-        ...                    "C": ["small", "large", "large", "small",
-        ...                          "small", "large", "small", "small",
-        ...                          "large"],
-        ...                    "D": [1, 2, 2, 3, 3, 4, 5, 6, 7]})
-        >>> df
-             A    B      C  D
-        0  foo  one  small  1
-        1  foo  one  large  2
-        2  foo  one  large  2
-        3  foo  two  small  3
-        4  foo  two  small  3
-        5  bar  one  large  4
-        6  bar  one  small  5
-        7  bar  two  small  6
-        8  bar  two  large  7
-
-        >>> table = pivot_table(df, values='D', index=['A', 'B'],
-        ...                     columns=['C'], aggfunc=np.sum)
-        >>> table
-        ... # doctest: +NORMALIZE_WHITESPACE
-        C        large  small
-        A   B
-        bar one    4.0    5.0
-            two    7.0    6.0
-        foo one    4.0    1.0
-            two    NaN    6.0
-
-        Returns
-        -------
-        table : DataFrame
-
-        See also
-        --------
-        DataFrame.pivot : pivot without aggregation that can handle
-            non-numeric data
-        """
-        from pandas.core.reshape.pivot import pivot_table
-        return pivot_table(self, values=values, index=index, columns=columns,
-                           aggfunc=aggfunc, fill_value=fill_value,
-                           margins=margins, dropna=dropna,
-                           margins_name=margins_name)
+        return pivot.pivot_table(self, values=values, index=index,
+                                 columns=columns, aggfunc=aggfunc,
+                                 fill_value=fill_value, margins=margins,
+                                 dropna=dropna, margins_name=margins_name)
 
     def stack(self, level=-1, dropna=True):
         """

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -4146,6 +4146,90 @@ class DataFrame(NDFrame):
         from pandas.core.reshape.reshape import pivot
         return pivot(self, index=index, columns=columns, values=values)
 
+    def pivot_table(self, values=None, index=None, columns=None,
+                    aggfunc='mean', fill_value=None, margins=False,
+                    dropna=True, margins_name='All'):
+        """
+        Create a spreadsheet-style pivot table as a DataFrame. The levels in
+        the pivot table will be stored in MultiIndex objects (hierarchical
+        indexes) on the index and columns of the result DataFrame
+
+        Parameters
+        ----------
+        data : DataFrame
+        values : column to aggregate, optional
+        index : column, Grouper, array, or list of the previous
+            If an array is passed, it must be the same length as the data. The
+            list can contain any of the other types (except list).
+            Keys to group by on the pivot table index.  If an array is passed,
+            it is being used as the same manner as column values.
+        columns : column, Grouper, array, or list of the previous
+            If an array is passed, it must be the same length as the data. The
+            list can contain any of the other types (except list).
+            Keys to group by on the pivot table column.  If an array is passed,
+            it is being used as the same manner as column values.
+        aggfunc : function or list of functions, default numpy.mean
+            If list of functions passed, the resulting pivot table will have
+            hierarchical columns whose top level are the function names
+            (inferred from the function objects themselves)
+        fill_value : scalar, default None
+            Value to replace missing values with
+        margins : boolean, default False
+            Add all row / columns (e.g. for subtotal / grand totals)
+        dropna : boolean, default True
+            Do not include columns whose entries are all NaN
+        margins_name : string, default 'All'
+            Name of the row / column that will contain the totals
+            when margins is True.
+
+        Examples
+        --------
+        >>> df = pd.DataFrame({"A": ["foo", "foo", "foo", "foo", "foo",
+        ...                          "bar", "bar", "bar", "bar"],
+        ...                    "B": ["one", "one", "one", "two", "two",
+        ...                          "one", "one", "two", "two"],
+        ...                    "C": ["small", "large", "large", "small",
+        ...                          "small", "large", "small", "small",
+        ...                          "large"],
+        ...                    "D": [1, 2, 2, 3, 3, 4, 5, 6, 7]})
+        >>> df
+             A    B      C  D
+        0  foo  one  small  1
+        1  foo  one  large  2
+        2  foo  one  large  2
+        3  foo  two  small  3
+        4  foo  two  small  3
+        5  bar  one  large  4
+        6  bar  one  small  5
+        7  bar  two  small  6
+        8  bar  two  large  7
+
+        >>> table = pivot_table(df, values='D', index=['A', 'B'],
+        ...                     columns=['C'], aggfunc=np.sum)
+        >>> table
+        ... # doctest: +NORMALIZE_WHITESPACE
+        C        large  small
+        A   B
+        bar one    4.0    5.0
+            two    7.0    6.0
+        foo one    4.0    1.0
+            two    NaN    6.0
+
+        Returns
+        -------
+        table : DataFrame
+
+        See also
+        --------
+        DataFrame.pivot : pivot without aggregation that can handle
+            non-numeric data
+        """
+        from pandas.core.reshape.reshape import pivot_table
+        return pivot_table(self, values=values, index=index, columns=columns,
+                           aggfunc=aggfunc, fill_value=fill_value,
+                           margins=margins, dropna=dropna,
+                           margins_name=margins_name)
+
     def stack(self, level=-1, dropna=True):
         """
         Pivot a level of the (possibly hierarchical) column labels, returning a

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -4224,7 +4224,7 @@ class DataFrame(NDFrame):
         DataFrame.pivot : pivot without aggregation that can handle
             non-numeric data
         """
-        from pandas.core.reshape.reshape import pivot_table
+        from pandas.core.reshape.pivot import pivot_table
         return pivot_table(self, values=values, index=index, columns=columns,
                            aggfunc=aggfunc, fill_value=fill_value,
                            margins=margins, dropna=dropna,

--- a/pandas/core/reshape/pivot.py
+++ b/pandas/core/reshape/pivot.py
@@ -16,81 +16,6 @@ import numpy as np
 def pivot_table(data, values=None, index=None, columns=None, aggfunc='mean',
                 fill_value=None, margins=False, dropna=True,
                 margins_name='All'):
-    """
-    Create a spreadsheet-style pivot table as a DataFrame. The levels in the
-    pivot table will be stored in MultiIndex objects (hierarchical indexes) on
-    the index and columns of the result DataFrame
-
-    Parameters
-    ----------
-    data : DataFrame
-    values : column to aggregate, optional
-    index : column, Grouper, array, or list of the previous
-        If an array is passed, it must be the same length as the data. The list
-        can contain any of the other types (except list).
-        Keys to group by on the pivot table index.  If an array is passed, it
-        is being used as the same manner as column values.
-    columns : column, Grouper, array, or list of the previous
-        If an array is passed, it must be the same length as the data. The list
-        can contain any of the other types (except list).
-        Keys to group by on the pivot table column.  If an array is passed, it
-        is being used as the same manner as column values.
-    aggfunc : function or list of functions, default numpy.mean
-        If list of functions passed, the resulting pivot table will have
-        hierarchical columns whose top level are the function names (inferred
-        from the function objects themselves)
-    fill_value : scalar, default None
-        Value to replace missing values with
-    margins : boolean, default False
-        Add all row / columns (e.g. for subtotal / grand totals)
-    dropna : boolean, default True
-        Do not include columns whose entries are all NaN
-    margins_name : string, default 'All'
-        Name of the row / column that will contain the totals
-        when margins is True.
-
-    Examples
-    --------
-    >>> df = pd.DataFrame({"A": ["foo", "foo", "foo", "foo", "foo",
-    ...                          "bar", "bar", "bar", "bar"],
-    ...                    "B": ["one", "one", "one", "two", "two",
-    ...                          "one", "one", "two", "two"],
-    ...                    "C": ["small", "large", "large", "small",
-    ...                          "small", "large", "small", "small",
-    ...                          "large"],
-    ...                    "D": [1, 2, 2, 3, 3, 4, 5, 6, 7]})
-    >>> df
-         A    B      C  D
-    0  foo  one  small  1
-    1  foo  one  large  2
-    2  foo  one  large  2
-    3  foo  two  small  3
-    4  foo  two  small  3
-    5  bar  one  large  4
-    6  bar  one  small  5
-    7  bar  two  small  6
-    8  bar  two  large  7
-
-    >>> table = pivot_table(df, values='D', index=['A', 'B'],
-    ...                     columns=['C'], aggfunc=np.sum)
-    >>> table
-    ... # doctest: +NORMALIZE_WHITESPACE
-    C        large  small
-    A   B
-    bar one    4.0    5.0
-        two    7.0    6.0
-    foo one    4.0    1.0
-        two    NaN    6.0
-
-    Returns
-    -------
-    table : DataFrame
-
-    See also
-    --------
-    DataFrame.pivot : pivot without aggregation that can handle
-        non-numeric data
-    """
     index = _convert_by(index)
     columns = _convert_by(columns)
 
@@ -202,9 +127,7 @@ def pivot_table(data, values=None, index=None, columns=None, aggfunc='mean',
         table = table.dropna(how='all', axis=1)
 
     return table
-
-
-DataFrame.pivot_table = pivot_table
+pivot_table.__doc__ = DataFrame.pivot_table.__doc__
 
 
 def _add_margins(table, data, values, rows, cols, aggfunc,

--- a/pandas/core/reshape/pivot.py
+++ b/pandas/core/reshape/pivot.py
@@ -5,9 +5,6 @@ from pandas.core.dtypes.common import is_list_like, is_scalar
 from pandas.core.dtypes.generic import ABCDataFrame, ABCSeries
 
 from pandas.core.reshape.concat import concat
-from pandas.core.frame import _shared_docs
-# Note: We need to make sure `frame` is imported before `pivot`, otherwise
-# _shared_docs['pivot_table'] will not yet exist.
 from pandas.core.series import Series
 from pandas.core.groupby import Grouper
 from pandas.core.reshape.util import cartesian_product
@@ -16,6 +13,11 @@ from pandas.compat import range, lrange, zip
 from pandas import compat
 import pandas.core.common as com
 from pandas.util._decorators import Appender, Substitution
+
+from pandas.core.frame import _shared_docs
+# Note: We need to make sure `frame` is imported before `pivot`, otherwise
+# _shared_docs['pivot_table'] will not yet exist.  TODO: Fix this dependency
+
 import numpy as np
 
 

--- a/pandas/core/reshape/pivot.py
+++ b/pandas/core/reshape/pivot.py
@@ -5,6 +5,7 @@ from pandas.core.dtypes.common import is_list_like, is_scalar
 from pandas.core.dtypes.generic import ABCDataFrame, ABCSeries
 
 from pandas.core.reshape.concat import concat
+from pandas.core.generic import _shared_docs
 from pandas.core.series import Series
 from pandas.core.groupby import Grouper
 from pandas.core.reshape.util import cartesian_product
@@ -12,13 +13,91 @@ from pandas.core.index import Index, _get_combined_index
 from pandas.compat import range, lrange, zip
 from pandas import compat
 import pandas.core.common as com
+from pandas.util._decorators import Appender, Substitution
 import numpy as np
 
 
+_shared_docs['pivot_table'] = """
+    Create a spreadsheet-style pivot table as a DataFrame. The levels in
+    the pivot table will be stored in MultiIndex objects (hierarchical
+    indexes) on the index and columns of the result DataFrame
+
+    Parameters
+    ----------%s
+    values : column to aggregate, optional
+    index : column, Grouper, array, or list of the previous
+        If an array is passed, it must be the same length as the data. The
+        list can contain any of the other types (except list).
+        Keys to group by on the pivot table index.  If an array is passed,
+        it is being used as the same manner as column values.
+    columns : column, Grouper, array, or list of the previous
+        If an array is passed, it must be the same length as the data. The
+        list can contain any of the other types (except list).
+        Keys to group by on the pivot table column.  If an array is passed,
+        it is being used as the same manner as column values.
+    aggfunc : function or list of functions, default numpy.mean
+        If list of functions passed, the resulting pivot table will have
+        hierarchical columns whose top level are the function names
+        (inferred from the function objects themselves)
+    fill_value : scalar, default None
+        Value to replace missing values with
+    margins : boolean, default False
+        Add all row / columns (e.g. for subtotal / grand totals)
+    dropna : boolean, default True
+        Do not include columns whose entries are all NaN
+    margins_name : string, default 'All'
+        Name of the row / column that will contain the totals
+        when margins is True.
+
+    Examples
+    --------
+    >>> df = pd.DataFrame({"A": ["foo", "foo", "foo", "foo", "foo",
+    ...                          "bar", "bar", "bar", "bar"],
+    ...                    "B": ["one", "one", "one", "two", "two",
+    ...                          "one", "one", "two", "two"],
+    ...                    "C": ["small", "large", "large", "small",
+    ...                          "small", "large", "small", "small",
+    ...                          "large"],
+    ...                    "D": [1, 2, 2, 3, 3, 4, 5, 6, 7]})
+    >>> df
+         A    B      C  D
+    0  foo  one  small  1
+    1  foo  one  large  2
+    2  foo  one  large  2
+    3  foo  two  small  3
+    4  foo  two  small  3
+    5  bar  one  large  4
+    6  bar  one  small  5
+    7  bar  two  small  6
+    8  bar  two  large  7
+
+    >>> table = pivot_table(df, values='D', index=['A', 'B'],
+    ...                     columns=['C'], aggfunc=np.sum)
+    >>> table
+    ... # doctest: +NORMALIZE_WHITESPACE
+    C        large  small
+    A   B
+    bar one    4.0    5.0
+        two    7.0    6.0
+    foo one    4.0    1.0
+        two    NaN    6.0
+
+    Returns
+    -------
+    table : DataFrame
+
+    See also
+    --------
+    DataFrame.pivot : pivot without aggregation that can handle
+        non-numeric data
+    """
+
+
+@Substitution('\ndata : DataFrame')
+@Appender(_shared_docs['pivot_table'], indents=1)
 def pivot_table(data, values=None, index=None, columns=None, aggfunc='mean',
                 fill_value=None, margins=False, dropna=True,
                 margins_name='All'):
-    """ See DataFrame.pivot_table.__doc__ """
     index = _convert_by(index)
     columns = _convert_by(columns)
 

--- a/pandas/core/reshape/pivot.py
+++ b/pandas/core/reshape/pivot.py
@@ -5,7 +5,9 @@ from pandas.core.dtypes.common import is_list_like, is_scalar
 from pandas.core.dtypes.generic import ABCDataFrame, ABCSeries
 
 from pandas.core.reshape.concat import concat
-from pandas.core.generic import _shared_docs
+from pandas.core.frame import _shared_docs
+# Note: We need to make sure `frame` is imported before `pivot`, otherwise
+# _shared_docs['pivot_table'] will not yet exist.
 from pandas.core.series import Series
 from pandas.core.groupby import Grouper
 from pandas.core.reshape.util import cartesian_product
@@ -15,82 +17,6 @@ from pandas import compat
 import pandas.core.common as com
 from pandas.util._decorators import Appender, Substitution
 import numpy as np
-
-
-_shared_docs['pivot_table'] = """
-    Create a spreadsheet-style pivot table as a DataFrame. The levels in
-    the pivot table will be stored in MultiIndex objects (hierarchical
-    indexes) on the index and columns of the result DataFrame
-
-    Parameters
-    ----------%s
-    values : column to aggregate, optional
-    index : column, Grouper, array, or list of the previous
-        If an array is passed, it must be the same length as the data. The
-        list can contain any of the other types (except list).
-        Keys to group by on the pivot table index.  If an array is passed,
-        it is being used as the same manner as column values.
-    columns : column, Grouper, array, or list of the previous
-        If an array is passed, it must be the same length as the data. The
-        list can contain any of the other types (except list).
-        Keys to group by on the pivot table column.  If an array is passed,
-        it is being used as the same manner as column values.
-    aggfunc : function or list of functions, default numpy.mean
-        If list of functions passed, the resulting pivot table will have
-        hierarchical columns whose top level are the function names
-        (inferred from the function objects themselves)
-    fill_value : scalar, default None
-        Value to replace missing values with
-    margins : boolean, default False
-        Add all row / columns (e.g. for subtotal / grand totals)
-    dropna : boolean, default True
-        Do not include columns whose entries are all NaN
-    margins_name : string, default 'All'
-        Name of the row / column that will contain the totals
-        when margins is True.
-
-    Examples
-    --------
-    >>> df = pd.DataFrame({"A": ["foo", "foo", "foo", "foo", "foo",
-    ...                          "bar", "bar", "bar", "bar"],
-    ...                    "B": ["one", "one", "one", "two", "two",
-    ...                          "one", "one", "two", "two"],
-    ...                    "C": ["small", "large", "large", "small",
-    ...                          "small", "large", "small", "small",
-    ...                          "large"],
-    ...                    "D": [1, 2, 2, 3, 3, 4, 5, 6, 7]})
-    >>> df
-         A    B      C  D
-    0  foo  one  small  1
-    1  foo  one  large  2
-    2  foo  one  large  2
-    3  foo  two  small  3
-    4  foo  two  small  3
-    5  bar  one  large  4
-    6  bar  one  small  5
-    7  bar  two  small  6
-    8  bar  two  large  7
-
-    >>> table = pivot_table(df, values='D', index=['A', 'B'],
-    ...                     columns=['C'], aggfunc=np.sum)
-    >>> table
-    ... # doctest: +NORMALIZE_WHITESPACE
-    C        large  small
-    A   B
-    bar one    4.0    5.0
-        two    7.0    6.0
-    foo one    4.0    1.0
-        two    NaN    6.0
-
-    Returns
-    -------
-    table : DataFrame
-
-    See also
-    --------
-    DataFrame.pivot : pivot without aggregation that can handle
-        non-numeric data
-    """
 
 
 @Substitution('\ndata : DataFrame')

--- a/pandas/core/reshape/pivot.py
+++ b/pandas/core/reshape/pivot.py
@@ -2,13 +2,13 @@
 
 
 from pandas.core.dtypes.common import is_list_like, is_scalar
-from pandas.core.dtypes.generic import ABCDataFrame, ABCIndex, ABCSeries
+from pandas.core.dtypes.generic import ABCDataFrame, ABCSeries
 
 from pandas.core.reshape.concat import concat
 from pandas.core.series import Series
 from pandas.core.groupby import Grouper
 from pandas.core.reshape.util import cartesian_product
-from pandas.core.index import _get_combined_index
+from pandas.core.index import Index, _get_combined_index
 from pandas.compat import range, lrange, zip
 from pandas import compat
 import pandas.core.common as com
@@ -126,7 +126,7 @@ def pivot_table(data, values=None, index=None, columns=None, aggfunc='mean',
     if len(index) == 0 and len(columns) > 0:
         table = table.T
 
-    # GH 15193 Makse sure empty columns are removed if dropna=True
+    # GH 15193 Make sure empty columns are removed if dropna=True
     if isinstance(table, ABCDataFrame) and dropna:
         table = table.dropna(how='all', axis=1)
 
@@ -329,7 +329,7 @@ def _convert_by(by):
     if by is None:
         by = []
     elif (is_scalar(by) or
-          isinstance(by, (np.ndarray, ABCIndex, ABCSeries, Grouper)) or
+          isinstance(by, (np.ndarray, Index, ABCSeries, Grouper)) or
           hasattr(by, '__call__')):
         by = [by]
     else:


### PR DESCRIPTION
instead of pinning it on over pin `core.reshape.pivot`

At the moment `core.reshape.pivot.pivot_table` is pinned to `DataFrame` by writing `DataFrame.pivot_table = pivot_table`.  This PR defines `pivot_table` directly in `DataFrame` and then calls to the function.  It's the same pattern already used by `DataFrame.pivot`.

I think this is the last `DataFrame` method pinned on to `DataFrame` this way.  Two more left in `Series`

 - [ ] closes #xxxx
 - [ ] tests added / passed
 - [x] passes ``git diff upstream/master -u -- "*.py" | flake8 --diff``
 - [ ] whatsnew entry
