### PR TITLE
BUG: support pandas objects in iloc with old numpy versions

### DIFF
--- a/doc/source/whatsnew/v0.21.0.txt
+++ b/doc/source/whatsnew/v0.21.0.txt
@@ -278,6 +278,7 @@ Indexing
 - Fixes bug where indexing with ``np.inf`` caused an ``OverflowError`` to be raised (:issue:`16957`)
 - Bug in reindexing on an empty ``CategoricalIndex`` (:issue:`16770`)
 - Fixes ``DataFrame.loc`` for setting with alignment and tz-aware ``DatetimeIndex`` (:issue:`16889`)
+- Avoids ``IndexError`` when passing an Index or Series to ``.iloc`` with older numpy (:issue:`17193`)
 
 I/O
 ^^^

--- a/pandas/core/internals.py
+++ b/pandas/core/internals.py
@@ -861,6 +861,9 @@ class Block(PandasObject):
 
         # set
         else:
+            if _np_version_under1p9:
+                # Work around GH 6168 to support old numpy
+                indexer = getattr(indexer, 'values', indexer)
             values[indexer] = value
 
         # coerce and try to infer the dtypes of the result

--- a/pandas/tests/indexing/test_iloc.py
+++ b/pandas/tests/indexing/test_iloc.py
@@ -282,6 +282,19 @@ class TestiLoc(Base):
             index=["A", "B", "C"], columns=["A", "B", "C"])
         tm.assert_frame_equal(df, expected)
 
+    def test_iloc_setitem_pandas_object(self):
+        # GH 17193, affecting old numpy (1.7 and 1.8)
+        s_orig = Series([0, 1, 2, 3])
+        expected = Series([0, -1, -2, 3])
+
+        s = s_orig.copy()
+        s.iloc[Series([1, 2])] = [-1, -2]
+        tm.assert_series_equal(s, expected)
+
+        s = s_orig.copy()
+        s.iloc[pd.Index([1, 2])] = [-1, -2]
+        tm.assert_series_equal(s, expected)
+
     def test_iloc_setitem_dups(self):
 
         # GH 6766


### PR DESCRIPTION
 - [x] closes #17193
 - [x] tests added / passed
 - [x] passes ``git diff master -u -- "*.py" | flake8 --diff``
 - [x] whatsnew entry
