### PR TITLE
Define Series.plot and Series.hist in class definition

### DIFF
--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -76,6 +76,8 @@ from pandas.util._validators import validate_bool_kwarg
 from pandas._libs import index as libindex, tslib as libts, lib, iNaT
 from pandas.core.config import get_option
 
+import pandas.plotting._core as gfx
+
 __all__ = ['Series']
 
 _shared_doc_kwargs = dict(
@@ -2952,11 +2954,22 @@ class Series(base.IndexOpsMixin, strings.StringAccessorMixin,
                 pass
         return rv
 
+    # ----------------------------------------------------------------------
+    # Add plotting methods to Series
+    plot = base.AccessorProperty(gfx.SeriesPlotMethods,
+                                 gfx.SeriesPlotMethods)
+    hist = gfx.hist_series
+
 
 Series._setup_axes(['index'], info_axis=0, stat_axis=0, aliases={'rows': 0})
 Series._add_numeric_operations()
 Series._add_series_only_operations()
 Series._add_series_or_dataframe_operations()
+
+# Add arithmetic!
+ops.add_flex_arithmetic_methods(Series, **ops.series_flex_funcs)
+ops.add_special_arithmetic_methods(Series, **ops.series_special_funcs)
+
 
 # -----------------------------------------------------------------------------
 # Supplementary functions
@@ -3129,17 +3142,3 @@ def _sanitize_array(data, index, dtype=None, copy=False,
         subarr = np.array(data, dtype=object, copy=copy)
 
     return subarr
-
-
-# ----------------------------------------------------------------------
-# Add plotting methods to Series
-
-import pandas.plotting._core as _gfx  # noqa
-
-Series.plot = base.AccessorProperty(_gfx.SeriesPlotMethods,
-                                    _gfx.SeriesPlotMethods)
-Series.hist = _gfx.hist_series
-
-# Add arithmetic!
-ops.add_flex_arithmetic_methods(Series, **ops.series_flex_funcs)
-ops.add_special_arithmetic_methods(Series, **ops.series_special_funcs)

--- a/pandas/plotting/_converter.py
+++ b/pandas/plotting/_converter.py
@@ -18,6 +18,7 @@ from pandas.core.dtypes.common import (
     is_period_arraylike,
     is_nested_list_like
 )
+from pandas.core.dtypes.generic import ABCSeries
 
 from pandas.compat import lrange
 import pandas.compat as compat
@@ -25,7 +26,6 @@ import pandas._libs.lib as lib
 import pandas.core.common as com
 from pandas.core.index import Index
 
-from pandas.core.series import Series
 from pandas.core.indexes.datetimes import date_range
 import pandas.core.tools.datetimes as tools
 import pandas.tseries.frequencies as frequencies
@@ -175,7 +175,7 @@ def _dt_to_float_ordinal(dt):
     preserving hours, minutes, seconds and microseconds.  Return value
     is a :func:`float`.
     """
-    if (isinstance(dt, (np.ndarray, Index, Series)
+    if (isinstance(dt, (np.ndarray, Index, ABCSeries)
                    ) and is_datetime64_ns_dtype(dt)):
         base = dates.epoch2num(dt.asi8 / 1.0E9)
     else:

--- a/pandas/plotting/_core.py
+++ b/pandas/plotting/_core.py
@@ -18,10 +18,12 @@ from pandas.core.dtypes.common import (
     is_number,
     is_hashable,
     is_iterator)
+from pandas.core.dtypes.generic import ABCSeries
+
 from pandas.core.common import AbstractMethodError, _try_sort
 from pandas.core.generic import _shared_docs, _shared_doc_kwargs
 from pandas.core.index import Index, MultiIndex
-from pandas.core.series import Series
+
 from pandas.core.indexes.period import PeriodIndex
 from pandas.compat import range, lrange, map, zip, string_types
 import pandas.compat as compat
@@ -334,7 +336,7 @@ class MPLPlot(object):
     def _compute_plot_data(self):
         data = self.data
 
-        if isinstance(data, Series):
+        if isinstance(data, ABCSeries):
             label = self.label
             if label is None and data.name is None:
                 label = 'None'
@@ -1575,6 +1577,7 @@ class BoxPlot(LinePlot):
 
     def _make_plot(self):
         if self.subplots:
+            from pandas.core.series import Series
             self._return_obj = Series()
 
             for i, (label, y) in enumerate(self._iter_data()):
@@ -2338,6 +2341,7 @@ def boxplot_frame_groupby(grouped, subplots=True, column=None, fontsize=None,
                               figsize=figsize, layout=layout)
         axes = _flatten(axes)
 
+        from pandas.core.series import Series
         ret = Series()
         for (key, group), ax in zip(grouped, axes):
             d = group.boxplot(ax=ax, column=column, fontsize=fontsize,
@@ -2409,7 +2413,6 @@ def _grouped_plot_by_column(plotf, data, columns=None, by=None,
 
     _axes = _flatten(axes)
 
-    result = Series()
     ax_values = []
 
     for i, col in enumerate(columns):
@@ -2422,6 +2425,7 @@ def _grouped_plot_by_column(plotf, data, columns=None, by=None,
         ax_values.append(re_plotf)
         ax.grid(grid)
 
+    from pandas.core.series import Series
     result = Series(ax_values, index=columns)
 
     # Return axes in multiplot case, maybe revisit later # 985

--- a/pandas/plotting/_tools.py
+++ b/pandas/plotting/_tools.py
@@ -8,8 +8,8 @@ from math import ceil
 import numpy as np
 
 from pandas.core.dtypes.common import is_list_like
+from pandas.core.dtypes.generic import ABCSeries
 from pandas.core.index import Index
-from pandas.core.series import Series
 from pandas.compat import range
 
 
@@ -25,8 +25,7 @@ def format_date_labels(ax, rot):
         pass
 
 
-def table(ax, data, rowLabels=None, colLabels=None,
-          **kwargs):
+def table(ax, data, rowLabels=None, colLabels=None, **kwargs):
     """
     Helper function to convert DataFrame and Series to matplotlib.table
 
@@ -45,7 +44,7 @@ def table(ax, data, rowLabels=None, colLabels=None,
     matplotlib table object
     """
     from pandas import DataFrame
-    if isinstance(data, Series):
+    if isinstance(data, ABCSeries):
         data = DataFrame(data, columns=[data.name])
     elif isinstance(data, DataFrame):
         pass


### PR DESCRIPTION
Avoid fragile circular import between core.series and `plotting._core`, `plotting._tools`, `plotting._converter`

Ends the saga of #16913, #16931.

In the status quo, the tail end of `core.series` does:

```
import pandas.plotting._core as _gfx  # noqa
Series.plot = base.AccessorProperty(_gfx.SeriesPlotMethods,
                                                              _gfx.SeriesPlotMethods)
Series.hist = _gfx.hist_series
```

This PR moves the import of `plotting._core` to the top of the module and defines `plot` and `hist` inside the `class Series` block.

Initially this caused a bunch of test failures  because `plotting._core` itself imports `Series` (and `plotting._tools`, which also imports `Series`).  #16913 and #16931 removed these circular imports, but mysteriously that didn't solve the problem.

The one that I missed last time around was `pandas.plotting.__init__`, which imports `pandas.plotting._converter`, which imports `Series`.  Changing that to `ABSeries` in addition to the earlier ones finally fixes the problem.

 - [ ] closes #xxxx
 - [ ] tests added / passed
 - [x] passes ``git diff upstream/master -u -- "*.py" | flake8 --diff``
 - [ ] whatsnew entry
