### PR TITLE
DOCS: Updated NDFrame.astype docs

### DIFF
--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -3677,6 +3677,10 @@ class NDFrame(PandasObject, SelectionMixin):
         1    2
         dtype: category
         Categories (2, int64): [1, 2]
+
+        See also
+        --------
+        numpy.ndarray.astype : Cast a numpy array to a specified type.
         """
         if is_dict_like(dtype):
             if self.ndim == 1:  # i.e. Series

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -3665,6 +3665,18 @@ class NDFrame(PandasObject, SelectionMixin):
         1    2
         dtype: category
         Categories (2, int64): [2 < 1]
+
+        Note that using ``copy=False`` and changing data on a new
+        pandas object may propagate changes upwards:
+
+        >>> cat1 = pd.Series([1,2], dtype='category')
+        >>> cat2 = cat1.astype('category', copy=False)
+        >>> cat2[0] = 2
+        >>> cat1  # note that cat1[0] is changed too
+        0    2
+        1    2
+        dtype: category
+        Categories (2, int64): [1, 2]
         """
         if is_dict_like(dtype):
             if self.ndim == 1:  # i.e. Series

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -3610,7 +3610,7 @@ class NDFrame(PandasObject, SelectionMixin):
                      mapping={True: 'raise', False: 'ignore'})
     def astype(self, dtype, copy=True, errors='raise', **kwargs):
         """
-        Cast a pandas object to new dtype ``dtype``.
+        Cast a pandas object to a specified dtype ``dtype``.
 
         Parameters
         ----------
@@ -3620,7 +3620,9 @@ class NDFrame(PandasObject, SelectionMixin):
             column label and dtype is a numpy.dtype or Python type to cast one
             or more of the DataFrame's columns to column-specific types.
         copy : bool, default True.
-            Return a copy when ``copy=True`` (be really careful with this!).
+            Return a copy when ``copy=True`` (be very careful setting
+            ``copy=False`` as changes to values then may propagate to other
+            pandas objects).
         errors : {'raise', 'ignore'}, default 'raise'.
             Control raising of exceptions on invalid data for provided dtype.
 
@@ -3650,7 +3652,7 @@ class NDFrame(PandasObject, SelectionMixin):
         1    2
         dtype: int64
 
-        Convert to pd.Categorial:
+        Convert to categorical type:
 
         >>> ser.astype('category')
         0    1
@@ -3658,7 +3660,7 @@ class NDFrame(PandasObject, SelectionMixin):
         dtype: category
         Categories (2, int64): [1, 2]
 
-        Convert to ordered pd.Categorial with custom ordering:
+        Convert to ordered categorical type with custom ordering:
 
         >>> ser.astype('category', ordered=True, categories=[2, 1])
         0    1
@@ -3667,16 +3669,15 @@ class NDFrame(PandasObject, SelectionMixin):
         Categories (2, int64): [2 < 1]
 
         Note that using ``copy=False`` and changing data on a new
-        pandas object may propagate changes upwards:
+        pandas object may propagate changes:
 
-        >>> cat1 = pd.Series([1,2], dtype='category')
-        >>> cat2 = cat1.astype('category', copy=False)
-        >>> cat2[0] = 2
-        >>> cat1  # note that cat1[0] is changed too
-        0    2
-        1    2
-        dtype: category
-        Categories (2, int64): [1, 2]
+        >>> s1 = pd.Series([1,2])
+        >>> s2 = s1.astype('int', copy=False)
+        >>> s2[0] = 10
+        >>> s1  # note that s1[0] has changed too
+        0    10
+        1     2
+        dtype: int64
 
         See also
         --------

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -3610,8 +3610,9 @@ class NDFrame(PandasObject, SelectionMixin):
                      mapping={True: 'raise', False: 'ignore'})
     def astype(self, dtype, copy=True, errors='raise', **kwargs):
         """
-        Cast object to input numpy.dtype
-        Return a copy when copy = True (be really careful with this!)
+        Cast object to input numpy.dtype.
+
+        Return a copy when ``copy=True`` (be really careful with this!).
 
         Parameters
         ----------
@@ -3636,6 +3637,34 @@ class NDFrame(PandasObject, SelectionMixin):
         Returns
         -------
         casted : type of caller
+
+        Examples
+        --------
+        >>> ser = pd.Series([1, 2], dtype='int32')
+        >>> ser
+        0    1
+        1    2
+        dtype: int32
+        >>> ser.astype('int64')
+        0    1
+        1    2
+        dtype: int64
+
+        Convert to pd.Categorial:
+
+        >>> ser.astype('category')
+        0    1
+        1    2
+        dtype: category
+        Categories (2, int64): [1, 2]
+
+        Convert to ordered pd.Categorial with custom ordering:
+
+        >>> ser.astype('category', ordered=True, categories=[2, 1])
+        0    1
+        1    2
+        dtype: category
+        Categories (2, int64): [2 < 1]
         """
         if is_dict_like(dtype):
             if self.ndim == 1:  # i.e. Series

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -3610,9 +3610,7 @@ class NDFrame(PandasObject, SelectionMixin):
                      mapping={True: 'raise', False: 'ignore'})
     def astype(self, dtype, copy=True, errors='raise', **kwargs):
         """
-        Cast object to input numpy.dtype.
-
-        Return a copy when ``copy=True`` (be really careful with this!).
+        Cast a pandas object to new dtype ``dtype``.
 
         Parameters
         ----------
@@ -3621,6 +3619,8 @@ class NDFrame(PandasObject, SelectionMixin):
             the same type. Alternatively, use {col: dtype, ...}, where col is a
             column label and dtype is a numpy.dtype or Python type to cast one
             or more of the DataFrame's columns to column-specific types.
+        copy : bool, default True.
+            Return a copy when ``copy=True`` (be really careful with this!).
         errors : {'raise', 'ignore'}, default 'raise'.
             Control raising of exceptions on invalid data for provided dtype.
 


### PR DESCRIPTION
I've had a couple situations where I've doubted if it's ``ser.astype('category')`` or ``ser.astype('categorical')`` and the doc string doesn't say. 

I think a few examples could help here + illustrate usage of the method. Also some cleanup of the doc string.