### PR TITLE
Add dt accessor to Index

### DIFF
--- a/pandas/core/indexes/accessors.py
+++ b/pandas/core/indexes/accessors.py
@@ -11,6 +11,7 @@ from pandas.core.dtypes.common import (
     is_timedelta64_dtype, is_categorical_dtype,
     is_list_like)
 
+
 from pandas.core.base import PandasDelegate, NoNewAttributesMixin
 from pandas.core.indexes.datetimes import DatetimeIndex
 from pandas._libs.period import IncompatibleFrequency  # noqa
@@ -48,8 +49,10 @@ def maybe_to_datetimelike(data, copy=False):
     DelegatedClass
 
     """
-    from pandas import Series
+    from pandas import Series, Index
 
+    if isinstance(data, Index):
+        data = data.to_series()
     if not isinstance(data, Series):
         raise TypeError("cannot convert an object of type {0} to a "
                         "datetimelike index".format(type(data)))

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -1592,6 +1592,13 @@ class Index(IndexOpsMixin, StringAccessorMixin, PandasObject):
             return False
         return is_datetime_array(_ensure_object(self.values))
 
+    @property
+    def dt(self):
+        # Non-raising versions of the `.dt` attribute are available in
+        # DatetimeIndex, PeriodIndex, and TimedeltaIndex.
+        raise AttributeError("Can only use .dt accessor with datetimelike "
+                             "values")
+
     def __iter__(self):
         return iter(self.values)
 

--- a/pandas/core/indexes/datetimelike.py
+++ b/pandas/core/indexes/datetimelike.py
@@ -125,6 +125,21 @@ class TimelikeOps(object):
 class DatetimeIndexOpsMixin(object):
     """ common ops mixin to support a unified inteface datetimelike Index """
 
+    @cache_readonly
+    def dt(self):
+        """
+        For a datetime-like Index object, `self.dt` returns `self` so that
+        datetime-like attributes can be accessed symmetrically for Index
+        and Series objects.
+
+        For Index objects that are not datetime-like, `self.dt` will raise
+        and AttributeError.
+        """
+        # Note: we use a `cache_readonly` instead of AccessorProperty
+        # to avoid circular imports.
+        from pandas.core.indexes import accessors
+        return accessors.CombinedDatetimelikeProperties._make_accessor(self)
+
     def equals(self, other):
         """
         Determines if two Index objects contain the same elements.


### PR DESCRIPTION
Following discussion in #17134, this adds a `dt` property/accessor to `pd.Index`.  This property should quack like `pd.Series.dt`.  If `index` is not datetime-like, `index.dt` will raise an `AttributeError`.  Otherwise it will return an object that is effectively `index.to_series().dt`

Subsumes parts of #17117 

 - [ ] closes #17134
 - [x] tests added / passed
 - [x] passes ``git diff upstream/master -u -- "*.py" | flake8 --diff``
 - [ ] whatsnew entry
