### PR TITLE
Infer compression from non-string paths

### DIFF
--- a/doc/source/whatsnew/v0.21.0.txt
+++ b/doc/source/whatsnew/v0.21.0.txt
@@ -126,7 +126,7 @@ Other Enhancements
 - :func:`date_range` now accepts 'Y' in addition to 'A' as an alias for end of year (:issue:`9313`)
 - Integration with `Apache Parquet <https://parquet.apache.org/>`__, including a new top-level :func:`read_parquet` and :func:`DataFrame.to_parquet` method, see :ref:`here <io.parquet>`.
 - :func:`DataFrame.add_prefix` and :func:`DataFrame.add_suffix` now accept strings containing the '%' character. (:issue:`17151`)
-- :func:`read_csv` can now infer compression from non-string paths, such as a ``pathlib.Path`` objects (:issue:`17206`).
+- `read_*` methods can now infer compression from non-string paths, such as a ``pathlib.Path`` objects (:issue:`17206`).
 
 .. _whatsnew_0210.api_breaking:
 

--- a/doc/source/whatsnew/v0.21.0.txt
+++ b/doc/source/whatsnew/v0.21.0.txt
@@ -126,7 +126,7 @@ Other Enhancements
 - :func:`date_range` now accepts 'Y' in addition to 'A' as an alias for end of year (:issue:`9313`)
 - Integration with `Apache Parquet <https://parquet.apache.org/>`__, including a new top-level :func:`read_parquet` and :func:`DataFrame.to_parquet` method, see :ref:`here <io.parquet>`.
 - :func:`DataFrame.add_prefix` and :func:`DataFrame.add_suffix` now accept strings containing the '%' character. (:issue:`17151`)
-- `read_*` methods can now infer compression from non-string paths, such as a ``pathlib.Path`` objects (:issue:`17206`).
+- `read_*` methods can now infer compression from non-string paths, such as ``pathlib.Path`` objects (:issue:`17206`).
 
 .. _whatsnew_0210.api_breaking:
 

--- a/doc/source/whatsnew/v0.21.0.txt
+++ b/doc/source/whatsnew/v0.21.0.txt
@@ -126,7 +126,7 @@ Other Enhancements
 - :func:`date_range` now accepts 'Y' in addition to 'A' as an alias for end of year (:issue:`9313`)
 - Integration with `Apache Parquet <https://parquet.apache.org/>`__, including a new top-level :func:`read_parquet` and :func:`DataFrame.to_parquet` method, see :ref:`here <io.parquet>`.
 - :func:`DataFrame.add_prefix` and :func:`DataFrame.add_suffix` now accept strings containing the '%' character. (:issue:`17151`)
-- :func:`read_csv` can now infer compression from non-string paths, such as a ``pathlab.Path`` objects (:issue:`17206`).
+- :func:`read_csv` can now infer compression from non-string paths, such as a ``pathlib.Path`` objects (:issue:`17206`).
 
 .. _whatsnew_0210.api_breaking:
 

--- a/doc/source/whatsnew/v0.21.0.txt
+++ b/doc/source/whatsnew/v0.21.0.txt
@@ -126,6 +126,7 @@ Other Enhancements
 - :func:`date_range` now accepts 'Y' in addition to 'A' as an alias for end of year (:issue:`9313`)
 - Integration with `Apache Parquet <https://parquet.apache.org/>`__, including a new top-level :func:`read_parquet` and :func:`DataFrame.to_parquet` method, see :ref:`here <io.parquet>`.
 - :func:`DataFrame.add_prefix` and :func:`DataFrame.add_suffix` now accept strings containing the '%' character. (:issue:`17151`)
+- :func:`read_csv` can now infer compression from non-string paths, such as a ``pathlab.Path`` objects (:issue:`17206`).
 
 .. _whatsnew_0210.api_breaking:
 

--- a/pandas/io/common.py
+++ b/pandas/io/common.py
@@ -272,13 +272,15 @@ def _infer_compression(filepath_or_buffer, compression):
     if compression is None:
         return None
 
-    # Cannot infer compression of a buffer. Hence assume no compression.
-    is_path = isinstance(filepath_or_buffer, compat.string_types)
-    if compression == 'infer' and not is_path:
-        return None
-
-    # Infer compression from the filename/URL extension
+    # Infer compression
     if compression == 'infer':
+        # Convert all path types (e.g. pathlib.Path) to strings
+        filepath_or_buffer = _stringify_path(filepath_or_buffer)
+        if not isinstance(filepath_or_buffer, compat.string_types):
+            # Cannot infer compression of a buffer, assume no compression
+            return None
+
+        # Infer compression from the filename/URL extension
         for compression, extension in _compression_to_extension.items():
             if filepath_or_buffer.endswith(extension):
                 return compression

--- a/pandas/io/parsers.py
+++ b/pandas/io/parsers.py
@@ -208,11 +208,11 @@ chunksize : int, default None
     <http://pandas.pydata.org/pandas-docs/stable/io.html#io-chunking>`_
     for more information on ``iterator`` and ``chunksize``.
 compression : {'infer', 'gzip', 'bz2', 'zip', 'xz', None}, default 'infer'
-    For on-the-fly decompression of on-disk data. If 'infer', then use gzip,
-    bz2, zip or xz if filepath_or_buffer is a string ending in '.gz', '.bz2',
-    '.zip', or 'xz', respectively, and no decompression otherwise. If using
-    'zip', the ZIP file must contain only one data file to be read in.
-    Set to None for no decompression.
+    For on-the-fly decompression of on-disk data. If 'infer' and
+    `filepath_or_buffer` is path-like, then detect compression from the
+    following extensions: '.gz', '.bz2', '.zip', or '.xz' (otherwise no
+    decompression). If using 'zip', the ZIP file must contain only one data
+    file to be read in. Set to None for no decompression.
 
     .. versionadded:: 0.18.1 support for 'zip' and 'xz' compression.
 

--- a/pandas/io/pickle.py
+++ b/pandas/io/pickle.py
@@ -62,8 +62,8 @@ def read_pickle(path, compression='infer'):
         File path
     compression : {'infer', 'gzip', 'bz2', 'xz', 'zip', None}, default 'infer'
         For on-the-fly decompression of on-disk data. If 'infer', then use
-        gzip, bz2, xz or zip if path is a string ending in '.gz', '.bz2', 'xz',
-        or 'zip' respectively, and no decompression otherwise.
+        gzip, bz2, xz or zip if path ends in '.gz', '.bz2', '.xz',
+        or '.zip' respectively, and no decompression otherwise.
         Set to None for no decompression.
 
         .. versionadded:: 0.20.0

--- a/pandas/tests/io/parser/compression.py
+++ b/pandas/tests/io/parser/compression.py
@@ -157,20 +157,17 @@ class CompressionTests(object):
 
         inputs[3].close()
 
-    def test_read_csv_infer_compression_pathlib(self):
+    @pytest.mark.parametrize('extension', ['', '.gz', '.bz2'])
+    def test_read_csv_infer_compression_pathlib(self, extension):
         """
         Test that compression is inferred from pathlib.Path paths.
         """
-        try:
-            import pathlib
-        except ImportError:
-            pytest.skip('need pathlib to run')
-        expected = self.read_csv(self.csv1, index_col=0, parse_dates=True)
-        for extension in '', '.gz', '.bz2':
-            path = pathlib.Path(self.csv1 + extension)
-            df = self.read_csv(
-                path, index_col=0, parse_dates=True, compression='infer')
-            tm.assert_frame_equal(expected, df)
+        pathlib = pytest.importorskip('pathlib')
+        read_csv_kwargs = {'index_col': 0, 'parse_dates': True}
+        expected = self.read_csv(self.csv1, **read_csv_kwargs)
+        path = pathlib.Path(self.csv1 + extension)
+        df = self.read_csv(path, compression='infer', **read_csv_kwargs)
+        tm.assert_frame_equal(expected, df)
 
     def test_invalid_compression(self):
         msg = 'Unrecognized compression type: sfark'

--- a/pandas/tests/io/parser/compression.py
+++ b/pandas/tests/io/parser/compression.py
@@ -157,6 +157,21 @@ class CompressionTests(object):
 
         inputs[3].close()
 
+    def test_read_csv_infer_compression_pathlib(self):
+        """
+        Test that compression is inferred from pathlib.Path paths.
+        """
+        try:
+            import pathlib
+        except ImportError:
+            pytest.skip('need pathlib to run')
+        expected = self.read_csv(self.csv1, index_col=0, parse_dates=True)
+        for extension in '', '.gz', '.bz2':
+            path = pathlib.Path(self.csv1 + extension)
+            df = self.read_csv(
+                path, index_col=0, parse_dates=True, compression='infer')
+            tm.assert_frame_equal(expected, df)
+
     def test_invalid_compression(self):
         msg = 'Unrecognized compression type: sfark'
         with tm.assert_raises_regex(ValueError, msg):

--- a/pandas/tests/io/parser/compression.py
+++ b/pandas/tests/io/parser/compression.py
@@ -157,18 +157,6 @@ class CompressionTests(object):
 
         inputs[3].close()
 
-    @pytest.mark.parametrize('extension', ['', '.gz', '.bz2'])
-    def test_read_csv_infer_compression_pathlib(self, extension):
-        """
-        Test that compression is inferred from pathlib.Path paths.
-        """
-        pathlib = pytest.importorskip('pathlib')
-        read_csv_kwargs = {'index_col': 0, 'parse_dates': True}
-        expected = self.read_csv(self.csv1, **read_csv_kwargs)
-        path = pathlib.Path(self.csv1 + extension)
-        df = self.read_csv(path, compression='infer', **read_csv_kwargs)
-        tm.assert_frame_equal(expected, df)
-
     def test_invalid_compression(self):
         msg = 'Unrecognized compression type: sfark'
         with tm.assert_raises_regex(ValueError, msg):

--- a/pandas/tests/io/test_common.py
+++ b/pandas/tests/io/test_common.py
@@ -14,16 +14,6 @@ from pandas.compat import is_platform_windows, StringIO
 
 from pandas import read_csv, concat
 
-try:
-    from pathlib import Path
-except ImportError:
-    pass
-
-try:
-    from py.path import local as LocalPath
-except ImportError:
-    pass
-
 
 class CustomFSPath(object):
     """For testing fspath on unknown objects"""
@@ -33,6 +23,21 @@ class CustomFSPath(object):
     def __fspath__(self):
         return self.path
 
+
+# Functions that consume a string path and return a string or path-like object
+path_types = [str, CustomFSPath]
+
+try:
+    from pathlib import Path
+    path_types.append(Path)
+except ImportError:
+    pass
+
+try:
+    from py.path import local as LocalPath
+    path_types.append(LocalPath)
+except ImportError:
+    pass
 
 HERE = os.path.dirname(__file__)
 
@@ -82,6 +87,19 @@ bar2,12,13,14,15
         p = CustomFSPath('foo/bar.csv')
         result = common._stringify_path(p)
         assert result == 'foo/bar.csv'
+
+    @pytest.mark.parametrize('extension,expected', [
+        ('', None),
+        ('.gz', 'gzip'),
+        ('.bz2', 'bz2'),
+        ('.zip', 'zip'),
+        ('.xz', 'xz'),
+    ])
+    @pytest.mark.parametrize('path_type', path_types)
+    def test_infer_compression_from_path(self, extension, expected, path_type):
+        path = path_type('foo/bar.csv' + extension)
+        compression = common._infer_compression(path, compression='infer')
+        assert compression == expected
 
     def test_get_filepath_or_buffer_with_path(self):
         filename = '~/sometest'


### PR DESCRIPTION
Currently, `compression='infer'` only works on paths that are strings. However, pandas supports non-string paths, such as `pathlib.Path` objects. This PR adds support for inferring compression for all path types (for io interfaces that use `io.common._infer_compression`).

## Checklist

- [x] passes ``git diff upstream/master -u -- "*.py" | flake8 --diff``
- [x] No issue opened
- [x] tests added / passed
- [x] whatsnew entry
