### PR TITLE
Minor touch-ups to GitHub PULL_REQUEST_TEMPLATE

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,4 @@
 - [ ] closes #xxxx
 - [ ] tests added / passed
-- [ ] passes ``git diff upstream/master -- "*.py" | flake8 --diff``
+- [ ] passes `git diff upstream/master -- "*.py" | flake8 --diff`
 - [ ] whatsnew entry

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,4 @@
- - [ ] closes #xxxx
- - [ ] tests added / passed
- - [ ] passes ``git diff upstream/master -u -- "*.py" | flake8 --diff``
- - [ ] whatsnew entry
+- [ ] closes #xxxx
+- [ ] tests added / passed
+- [ ] passes ``git diff upstream/master -u -- "*.py" | flake8 --diff``
+- [ ] whatsnew entry

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,4 @@
 - [ ] closes #xxxx
 - [ ] tests added / passed
-- [ ] passes `git diff upstream/master -- "*.py" | flake8 --diff`
+- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
 - [ ] whatsnew entry

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,4 @@
 - [ ] closes #xxxx
 - [ ] tests added / passed
-- [ ] passes ``git diff upstream/master -u -- "*.py" | flake8 --diff``
+- [ ] passes ``git diff upstream/master -- "*.py" | flake8 --diff``
 - [ ] whatsnew entry

--- a/doc/source/contributing.rst
+++ b/doc/source/contributing.rst
@@ -509,7 +509,7 @@ the `flake8 <http://pypi.python.org/pypi/flake8>`_ tool
 and report any stylistic errors in your code. Therefore, it is helpful before
 submitting code to run the check yourself on the diff::
 
-   git diff master -u -- "*.py" | flake8 --diff
+   git diff master --patch -- "*.py" | flake8 --diff
 
 This command will catch any stylistic errors in your changes specifically, but
 be beware it may not catch all of them. For example, if you delete the only

--- a/doc/source/contributing.rst
+++ b/doc/source/contributing.rst
@@ -509,7 +509,7 @@ the `flake8 <http://pypi.python.org/pypi/flake8>`_ tool
 and report any stylistic errors in your code. Therefore, it is helpful before
 submitting code to run the check yourself on the diff::
 
-   git diff master --patch -- "*.py" | flake8 --diff
+   git diff master -u -- "*.py" | flake8 --diff
 
 This command will catch any stylistic errors in your changes specifically, but
 be beware it may not catch all of them. For example, if you delete the only


### PR DESCRIPTION
Previously, `PULL_REQUEST_TEMPLATE.md` included spaces before each item in the [GitHub task list](https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments), which caused the tasks to become nested upon GUI reordering.

I made minor changes to other aspects of `PULL_REQUEST_TEMPLATE.md`. I removed the `-u` arg from the `git diff` command since its default. In `contributing.rst`, I switched `-u` to the long form of `--patch`, since it's later juxtaposed to `--name-only`.