### PR TITLE
FIX: define `DataFrame.items` for all versions of python

### DIFF
--- a/doc/source/whatsnew/v0.21.0.txt
+++ b/doc/source/whatsnew/v0.21.0.txt
@@ -128,6 +128,8 @@ Other Enhancements
 - :func:`DataFrame.add_prefix` and :func:`DataFrame.add_suffix` now accept strings containing the '%' character. (:issue:`17151`)
 - `read_*` methods can now infer compression from non-string paths, such as ``pathlib.Path`` objects (:issue:`17206`).
 - :func:`pd.read_sas()` now recognizes much more of the most frequently used date (datetime) formats in SAS7BDAT files (:issue:`15871`).
+- :func:`DataFrame.items` is present in both Python 2 and 3 and is lazy in all cases (:issue:`13918`, :issue:`17213`)
+
 
 .. _whatsnew_0210.api_breaking:
 

--- a/doc/source/whatsnew/v0.21.0.txt
+++ b/doc/source/whatsnew/v0.21.0.txt
@@ -128,7 +128,8 @@ Other Enhancements
 - :func:`DataFrame.add_prefix` and :func:`DataFrame.add_suffix` now accept strings containing the '%' character. (:issue:`17151`)
 - `read_*` methods can now infer compression from non-string paths, such as ``pathlib.Path`` objects (:issue:`17206`).
 - :func:`pd.read_sas()` now recognizes much more of the most frequently used date (datetime) formats in SAS7BDAT files (:issue:`15871`).
-- :func:`DataFrame.items` is present in both Python 2 and 3 and is lazy in all cases (:issue:`13918`, :issue:`17213`)
+- :func:`DataFrame.items` is now present in both Python 2 and 3 and is lazy in all cases (:issue:`13918`, :issue:`17213`)
+
 
 
 .. _whatsnew_0210.api_breaking:

--- a/doc/source/whatsnew/v0.21.0.txt
+++ b/doc/source/whatsnew/v0.21.0.txt
@@ -128,7 +128,8 @@ Other Enhancements
 - :func:`DataFrame.add_prefix` and :func:`DataFrame.add_suffix` now accept strings containing the '%' character. (:issue:`17151`)
 - `read_*` methods can now infer compression from non-string paths, such as ``pathlib.Path`` objects (:issue:`17206`).
 - :func:`pd.read_sas()` now recognizes much more of the most frequently used date (datetime) formats in SAS7BDAT files (:issue:`15871`).
-- :func:`DataFrame.items` is now present in both Python 2 and 3 and is lazy in all cases (:issue:`13918`, :issue:`17213`)
+- :func:`DataFrame.items` and :func:`Series.items` is now present in both Python 2 and 3 and is lazy in all cases (:issue:`13918`, :issue:`17213`)
+
 
 
 

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -802,8 +802,7 @@ class DataFrame(NDFrame):
         # fallback to regular tuples
         return zip(*arrays)
 
-    if compat.PY3:  # pragma: no cover
-        items = iteritems
+    items = iteritems
 
     def __len__(self):
         """Returns length of info axis, but here we use the index """

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -1110,8 +1110,7 @@ class Series(base.IndexOpsMixin, strings.StringAccessorMixin,
         """
         return zip(iter(self.index), iter(self))
 
-    if compat.PY3:  # pragma: no cover
-        items = iteritems
+    items = iteritems
 
     # ----------------------------------------------------------------------
     # Misc public methods

--- a/pandas/tests/frame/test_api.py
+++ b/pandas/tests/frame/test_api.py
@@ -171,7 +171,7 @@ class SharedWithSparse(object):
     def test_iteritems(self):
         df = self.klass([[1, 2, 3], [4, 5, 6]], columns=['a', 'a', 'b'])
         for k, v in compat.iteritems(df):
-            assert type(v) == self.klass._constructor_sliced
+            assert isinstance(v, self.klass._constructor_sliced)
 
     def test_items(self):
         # issue #17213, #13918
@@ -179,7 +179,7 @@ class SharedWithSparse(object):
         df = DataFrame([[1, 2, 3], [4, 5, 6]], columns=cols)
         for c, (k, v) in zip(cols, df.items()):
             assert c == k
-            assert type(v) == Series
+            assert isinstance(v, Series)
             assert (df[k] == v).all()
 
     def test_iter(self):

--- a/pandas/tests/frame/test_api.py
+++ b/pandas/tests/frame/test_api.py
@@ -173,6 +173,11 @@ class SharedWithSparse(object):
         for k, v in compat.iteritems(df):
             assert type(v) == self.klass._constructor_sliced
 
+    def test_items(self):
+        df = DataFrame([[1, 2, 3], [4, 5, 6]], columns=['a', 'a', 'b'])
+        for k, v in df.items():
+            assert type(v) == Series
+
     def test_iter(self):
         assert tm.equalContents(list(self.frame), self.frame.columns)
 

--- a/pandas/tests/frame/test_api.py
+++ b/pandas/tests/frame/test_api.py
@@ -174,9 +174,13 @@ class SharedWithSparse(object):
             assert type(v) == self.klass._constructor_sliced
 
     def test_items(self):
-        df = DataFrame([[1, 2, 3], [4, 5, 6]], columns=['a', 'a', 'b'])
-        for k, v in df.items():
+        # issue #17213, #13918
+        cols = ['a', 'b', 'c']
+        df = DataFrame([[1, 2, 3], [4, 5, 6]], columns=cols)
+        for c, (k, v) in zip(cols, df.items()):
+            assert c == k
             assert type(v) == Series
+            assert (df[k] == v).all()
 
     def test_iter(self):
         assert tm.equalContents(list(self.frame), self.frame.columns)

--- a/pandas/tests/series/test_api.py
+++ b/pandas/tests/series/test_api.py
@@ -301,6 +301,16 @@ class TestSeriesMisc(TestData, SharedWithSparse):
         # assert is lazy (genrators don't define reverse, lists do)
         assert not hasattr(self.series.iteritems(), 'reverse')
 
+    def test_items(self):
+        for idx, val in self.series.items():
+            assert val == self.series[idx]
+
+        for idx, val in self.ts.items():
+            assert val == self.ts[idx]
+
+        # assert is lazy (genrators don't define reverse, lists do)
+        assert not hasattr(self.series.items(), 'reverse')
+
     def test_raise_on_info(self):
         s = Series(np.random.randn(10))
         with pytest.raises(AttributeError):


### PR DESCRIPTION
Closes #13918, #17213

This leaves a slight semantic difference between `dict.items` and
`DateFrame.items` in python2, however there is no code currently
expecting `DataFrame.items` to return a list and in python3 there is
no `dict.iteritems`.

This eases writing 'native' python3 code that also runs under python2.

Do you want a whatsnew for this?

- [x] closes #xxxx
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
