### PR TITLE
Untangle reshape imports --> Define pivot_table in DataFrame

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -98,6 +98,8 @@ import pandas.io.formats.console as console
 from pandas.io.formats.printing import pprint_thing
 import pandas.plotting._core as gfx
 
+from pandas.core.reshape import pivot as _pivot
+
 from pandas._libs import lib, algos as libalgos
 
 from pandas.core.config import get_option
@@ -4145,6 +4147,16 @@ class DataFrame(NDFrame):
         """
         from pandas.core.reshape.reshape import pivot
         return pivot(self, index=index, columns=columns, values=values)
+
+    @Substitution('')
+    @Appender(_shared_docs['pivot_table'])
+    def pivot_table(self, values=None, index=None, columns=None,
+                    aggfunc='mean', fill_value=None, margins=False,
+                    dropna=True, margins_name='All'):
+        return _pivot.pivot_table(self, values=values, index=index,
+                                  columns=columns, aggfunc=aggfunc,
+                                  fill_value=fill_value, margins=margins,
+                                  dropna=dropna, margins_name=margins_name)
 
     def stack(self, level=-1, dropna=True):
         """


### PR DESCRIPTION
This is an _alternative_ to #17174.  This is ultimately a better solution to the issue there, but involves a more invasive refactoring.

To recap:

- Right now `DataFrame.pivot_table` is defined in `core.reshape.pivot` with `DataFrame.pivot_table = pivot_table`.  The original and main goal of this (and #17174) is to avoid that, and instead define `DataFrame.pivot_table` within the `DataFrame` class definition.

- Doing this makes the docstrings tricky, since we want `pivot_table.__doc__` to be shared by `reshape.pivot.pivot_table` and `DataFrame.pivot_table`.  To resolve this cleanly, we need to import `reshape.pivot` at the top of `core.frame`.  Doing this requires getting the import of `DataFrame` out of `reshape.pivot` (and anything else it imports, namely `reshape.concat`).


Bonus: If/when this is approved, all of the mid-module imports of `reshape.concat` can be moved to the top of `core.frame`, and a handful of other docstrings can be put into `_shared_docs` in more convenient locations.

Bonus 2: If/when this is approved, doing the same thing in `reshape.merge` and `reshape.tile` is very easy.  `reshape.reshape` is doable but take a bit more work.

- [ ] closes #xxxx
- [ ] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
