### PR TITLE
REF: _get_objs_combined_axis

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -6126,12 +6126,10 @@ def _list_to_arrays(data, columns, coerce_float=False, dtype=None):
 
 
 def _list_of_series_to_arrays(data, columns, coerce_float=False, dtype=None):
-    from pandas.core.index import _get_combined_index
+    from pandas.core.index import _get_objs_combined_axis
 
     if columns is None:
-        columns = _get_combined_index([
-            s.index for s in data if getattr(s, 'index', None) is not None
-        ])
+        columns = _get_objs_combined_axis(data)
 
     indexer_cache = {}
 

--- a/pandas/core/indexes/api.py
+++ b/pandas/core/indexes/api.py
@@ -23,9 +23,20 @@ __all__ = ['Index', 'MultiIndex', 'NumericIndex', 'Float64Index', 'Int64Index',
            'PeriodIndex', 'DatetimeIndex',
            '_new_Index', 'NaT',
            '_ensure_index', '_get_na_value', '_get_combined_index',
+           '_get_objs_combined_axis',
            '_get_distinct_indexes', '_union_indexes',
            '_get_consensus_names',
            '_all_indexes_same']
+
+
+def _get_objs_combined_axis(objs, intersect=False, axis=0):
+    # Extract combined index: return intersection or union (depending on the
+    # value of "intersect") of indexes on given axis, or None if all objects
+    # lack indexes (e.g. they are numpy arrays)
+    obs_idxes = [obj._get_axis(axis) for obj in objs
+                 if hasattr(obj, '_get_axis')]
+    if obs_idxes:
+        return _get_combined_index(obs_idxes, intersect=intersect)
 
 
 def _get_combined_index(indexes, intersect=False):

--- a/pandas/core/panel.py
+++ b/pandas/core/panel.py
@@ -26,7 +26,7 @@ from pandas.core.common import _try_sort, _default_index
 from pandas.core.frame import DataFrame
 from pandas.core.generic import NDFrame, _shared_docs
 from pandas.core.index import (Index, MultiIndex, _ensure_index,
-                               _get_combined_index)
+                               _get_objs_combined_axis)
 from pandas.io.formats.printing import pprint_thing
 from pandas.core.indexing import maybe_droplevels
 from pandas.core.internals import (BlockManager,
@@ -1448,7 +1448,6 @@ class Panel(NDFrame):
             index = Index([])
         elif len(data) > 0:
             raw_lengths = []
-            indexes = []
 
         have_raw_arrays = False
         have_frames = False
@@ -1456,13 +1455,13 @@ class Panel(NDFrame):
         for v in data.values():
             if isinstance(v, self._constructor_sliced):
                 have_frames = True
-                indexes.append(v._get_axis(axis))
             elif v is not None:
                 have_raw_arrays = True
                 raw_lengths.append(v.shape[axis])
 
         if have_frames:
-            index = _get_combined_index(indexes, intersect=intersect)
+            index = _get_objs_combined_axis(data.values(), axis=axis,
+                                            intersect=intersect)
 
         if have_raw_arrays:
             lengths = list(set(raw_lengths))

--- a/pandas/core/reshape/concat.py
+++ b/pandas/core/reshape/concat.py
@@ -4,7 +4,7 @@ concat routines
 
 import numpy as np
 from pandas import compat, DataFrame, Series, Index, MultiIndex
-from pandas.core.index import (_get_combined_index,
+from pandas.core.index import (_get_objs_combined_axis,
                                _ensure_index, _get_consensus_names,
                                _all_indexes_same)
 from pandas.core.categorical import (_factorize_from_iterable,
@@ -445,16 +445,13 @@ class _Concatenator(object):
         return new_axes
 
     def _get_comb_axis(self, i):
-        if self._is_series:
-            all_indexes = [x.index for x in self.objs]
-        else:
-            try:
-                all_indexes = [x._data.axes[i] for x in self.objs]
-            except IndexError:
-                types = [type(x).__name__ for x in self.objs]
-                raise TypeError("Cannot concatenate list of %s" % types)
-
-        return _get_combined_index(all_indexes, intersect=self.intersect)
+        data_axis = self.objs[0]._get_block_manager_axis(i)
+        try:
+            return _get_objs_combined_axis(self.objs, axis=data_axis,
+                                           intersect=self.intersect)
+        except IndexError:
+            types = [type(x).__name__ for x in self.objs]
+            raise TypeError("Cannot concatenate list of %s" % types)
 
     def _get_concat_axis(self):
         """

--- a/pandas/core/reshape/pivot.py
+++ b/pandas/core/reshape/pivot.py
@@ -8,7 +8,7 @@ from pandas.core.reshape.concat import concat
 from pandas.core.series import Series
 from pandas.core.groupby import Grouper
 from pandas.core.reshape.util import cartesian_product
-from pandas.core.index import Index, _get_combined_index
+from pandas.core.index import Index, _get_objs_combined_axis
 from pandas.compat import range, lrange, zip
 from pandas import compat
 import pandas.core.common as com
@@ -440,12 +440,7 @@ def crosstab(index, columns, values=None, rownames=None, colnames=None,
     rownames = _get_names(index, rownames, prefix='row')
     colnames = _get_names(columns, colnames, prefix='col')
 
-    obs_idxes = [obj.index for objs in (index, columns) for obj in objs
-                 if hasattr(obj, 'index')]
-    if obs_idxes:
-        common_idx = _get_combined_index(obs_idxes, intersect=True)
-    else:
-        common_idx = None
+    common_idx = _get_objs_combined_axis(index + columns, intersect=True)
 
     data = {}
     data.update(zip(rownames, index))


### PR DESCRIPTION
- [x] tests passed
- [x] passes `git diff master -u -- "*.py" | flake8 --diff`

As proposed [here](https://github.com/pandas-dev/pandas/pull/17011#discussion_r128045375), with the addition of the ``axis`` argument.