### PR TITLE
CLN: replace %s syntax with .format in pandas.util

### DIFF
--- a/pandas/util/_decorators.py
+++ b/pandas/util/_decorators.py
@@ -27,8 +27,9 @@ def deprecate(name, alternative, alt_name=None, klass=None,
     klass = klass or FutureWarning
 
     def wrapper(*args, **kwargs):
-        warnings.warn("%s is deprecated. Use %s instead" % (name, alt_name),
-                      klass, stacklevel=stacklevel)
+        msg = "{name} is deprecated. Use {alt_name} instead".format(
+            name=name, alt_name=alt_name)
+        warnings.warn(msg, klass, stacklevel=stacklevel)
         return alternative(*args, **kwargs)
     return wrapper
 
@@ -90,19 +91,24 @@ def deprecate_kwarg(old_arg_name, new_arg_name, mapping=None, stacklevel=2):
                                                     old_arg_value)
                     else:
                         new_arg_value = mapping(old_arg_value)
-                    msg = "the %s=%r keyword is deprecated, " \
-                          "use %s=%r instead" % \
-                          (old_arg_name, old_arg_value,
-                           new_arg_name, new_arg_value)
+                    msg = ("the {old_name}={old_val!r} keyword is deprecated, "
+                           "use {new_name}={new_val!r} instead"
+                           ).format(old_name=old_arg_name,
+                                    old_val=old_arg_value,
+                                    new_name=new_arg_name,
+                                    new_val=new_arg_value)
                 else:
                     new_arg_value = old_arg_value
-                    msg = "the '%s' keyword is deprecated, " \
-                          "use '%s' instead" % (old_arg_name, new_arg_name)
+                    msg = ("the '{old_name}' keyword is deprecated, "
+                           "use '{new_name}' instead"
+                           ).format(old_name=old_arg_name,
+                                    new_name=new_arg_name)
 
                 warnings.warn(msg, FutureWarning, stacklevel=stacklevel)
                 if kwargs.get(new_arg_name, None) is not None:
-                    msg = ("Can only specify '%s' or '%s', not both" %
-                           (old_arg_name, new_arg_name))
+                    msg = ("Can only specify '{old_name}' or '{new_name}', "
+                           "not both").format(old_name=old_arg_name,
+                                              new_name=new_arg_name)
                     raise TypeError(msg)
                 else:
                     kwargs[new_arg_name] = new_arg_value

--- a/pandas/util/_print_versions.py
+++ b/pandas/util/_print_versions.py
@@ -38,18 +38,17 @@ def get_sys_info():
         (sysname, nodename, release,
          version, machine, processor) = platform.uname()
         blob.extend([
-            ("python", "%d.%d.%d.%s.%s" % sys.version_info[:]),
+            ("python", '.'.join(map(str, sys.version_info))),
             ("python-bits", struct.calcsize("P") * 8),
-            ("OS", "%s" % (sysname)),
-            ("OS-release", "%s" % (release)),
-            # ("Version", "%s" % (version)),
-            ("machine", "%s" % (machine)),
-            ("processor", "%s" % (processor)),
-            ("byteorder", "%s" % sys.byteorder),
-            ("LC_ALL", "%s" % os.environ.get('LC_ALL', "None")),
-            ("LANG", "%s" % os.environ.get('LANG', "None")),
-            ("LOCALE", "%s.%s" % locale.getlocale()),
-
+            ("OS", "{sysname}".format(sysname=sysname)),
+            ("OS-release", "{release}".format(release=release)),
+            # ("Version", "{version}".format(version=version)),
+            ("machine", "{machine}".format(machine=machine)),
+            ("processor", "{processor}".format(processor=processor)),
+            ("byteorder", "{byteorder}".format(byteorder=sys.byteorder)),
+            ("LC_ALL", "{lc}".format(lc=os.environ.get('LC_ALL', "None"))),
+            ("LANG", "{lang}".format(lang=os.environ.get('LANG', "None"))),
+            ("LOCALE", '.'.join(map(str, locale.getlocale()))),
         ])
     except:
         pass
@@ -131,11 +130,11 @@ def show_versions(as_json=False):
         print("------------------")
 
         for k, stat in sys_info:
-            print("%s: %s" % (k, stat))
+            print("{k}: {stat}".format(k=k, stat=stat))
 
         print("")
         for k, stat in deps_blob:
-            print("%s: %s" % (k, stat))
+            print("{k}: {stat}".format(k=k, stat=stat))
 
 
 def main():

--- a/pandas/util/_validators.py
+++ b/pandas/util/_validators.py
@@ -220,7 +220,7 @@ def validate_args_and_kwargs(fname, args, kwargs,
 def validate_bool_kwarg(value, arg_name):
     """ Ensures that argument passed in arg_name is of type bool. """
     if not (is_bool(value) or value is None):
-        raise ValueError('For argument "%s" expected type bool, '
-                         'received type %s.' %
-                         (arg_name, type(value).__name__))
+        raise ValueError('For argument "{arg}" expected type bool, received '
+                         'type {typ}.'.format(arg=arg_name,
+                                              typ=type(value).__name__))
     return value


### PR DESCRIPTION
Progress towards #16130

- [X] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`

Replaced `%s` syntax with `.format` in pandas.util.  Additionally, made some of the existing positional `.format` code more explicit.  Left the `Substitution` class in _decorators.py as-is, since it appears to impact docstrings across the entire codebase.

