### PR TITLE
Fix bugs in IntervalIndex.is_non_overlapping_monotonic

### DIFF
--- a/doc/source/whatsnew/v0.21.0.txt
+++ b/doc/source/whatsnew/v0.21.0.txt
@@ -310,7 +310,8 @@ Conversion
 
 - Bug in assignment against datetime-like data with ``int`` may incorrectly converte to datetime-like (:issue:`14145`)
 - Bug in assignment against ``int64`` data with ``np.ndarray`` with ``float64`` dtype may keep ``int64`` dtype (:issue:`14001`)
-- Bug in the return type of ``IntervalIndex.is_non_overlapping_monotonic``, which returned ``numpy.bool_`` instead of Python ``bool`` (:issue:`17237`)
+- Fixed the return type of ``IntervalIndex.is_non_overlapping_monotonic`` to be a Python ``bool`` for consistency with similar attributes/methods.  Previously returned a ``numpy.bool_``. (:issue:`17237`)
+- Bug in ``IntervalIndex.is_non_overlapping_monotonic`` when intervals are closed on both sides and overlap at a point (:issue:`16560`)
 
 Indexing
 ^^^^^^^^
@@ -386,4 +387,3 @@ Other
 - Bug in :func:`eval` where the ``inplace`` parameter was being incorrectly handled (:issue:`16732`)
 - Bug in ``.isin()`` in which checking membership in empty ``Series`` objects raised an error (:issue:`16991`)
 - Bug in :func:`unique` where checking a tuple of strings raised a ``TypeError`` (:issue:`17108`)
-- Bug in ``IntervalIndex.is_non_overlapping_monotonic`` when intervals are closed on both sides and overlap at a point (:issue:`16560`)

--- a/doc/source/whatsnew/v0.21.0.txt
+++ b/doc/source/whatsnew/v0.21.0.txt
@@ -310,7 +310,7 @@ Conversion
 
 - Bug in assignment against datetime-like data with ``int`` may incorrectly converte to datetime-like (:issue:`14145`)
 - Bug in assignment against ``int64`` data with ``np.ndarray`` with ``float64`` dtype may keep ``int64`` dtype (:issue:`14001`)
-
+- Bug in the return type of ``IntervalIndex.is_non_overlapping_monotonic``, which returned ``numpy.bool_`` instead of Python ``bool`` (:issue:`17237`)
 
 Indexing
 ^^^^^^^^
@@ -386,3 +386,4 @@ Other
 - Bug in :func:`eval` where the ``inplace`` parameter was being incorrectly handled (:issue:`16732`)
 - Bug in ``.isin()`` in which checking membership in empty ``Series`` objects raised an error (:issue:`16991`)
 - Bug in :func:`unique` where checking a tuple of strings raised a ``TypeError`` (:issue:`17108`)
+- Bug in ``IntervalIndex.is_non_overlapping_monotonic`` when intervals are closed on both sides and overlap at a point (:issue:`16560`)

--- a/pandas/core/indexes/interval.py
+++ b/pandas/core/indexes/interval.py
@@ -556,8 +556,17 @@ class IntervalIndex(IntervalMixin, Index):
         # must be increasing  (e.g., [0, 1), [1, 2), [2, 3), ... )
         # or decreasing (e.g., [-1, 0), [-2, -1), [-3, -2), ...)
         # we already require left <= right
-        return ((self.right[:-1] <= self.left[1:]).all() or
-                (self.left[:-1] >= self.right[1:]).all())
+
+        # strict inequality for closed == 'both'; equality implies overlapping
+        # at a point when both sides of intervals are included
+        if self.closed == 'both':
+            return bool((self.right[:-1] < self.left[1:]).all() or
+                        (self.left[:-1] > self.right[1:]).all())
+
+        # non-strict inequality when closed != 'both'; at least one side is
+        # not included in the intervals, so equality does not imply overlapping
+        return bool((self.right[:-1] <= self.left[1:]).all() or
+                    (self.left[:-1] >= self.right[1:]).all())
 
     @Appender(_index_shared_docs['_convert_scalar_indexer'])
     def _convert_scalar_indexer(self, key, kind=None):

--- a/pandas/tests/indexes/test_interval.py
+++ b/pandas/tests/indexes/test_interval.py
@@ -371,8 +371,9 @@ class TestIntervalIndex(Base):
         assert index.slice_locs(1, 1) == (1, 1)
         assert index.slice_locs(1, 2) == (1, 2)
 
-        index = IntervalIndex.from_breaks([0, 1, 2], closed='both')
-        assert index.slice_locs(1, 1) == (0, 2)
+        index = IntervalIndex.from_tuples([(0, 1), (2, 3), (4, 5)],
+                                          closed='both')
+        assert index.slice_locs(1, 1) == (0, 1)
         assert index.slice_locs(1, 2) == (0, 2)
 
     def test_slice_locs_int64(self):
@@ -680,6 +681,47 @@ class TestIntervalIndex(Base):
                                                     closed='both'))
 
         pytest.raises(ValueError, f)
+
+    def test_is_non_overlapping_monotonic(self):
+        # Verify that a Python Boolean is returned (GH17237)
+        for closed in ('left', 'right', 'neither', 'both'):
+            idx = IntervalIndex.from_breaks(range(4), closed=closed)
+            assert type(idx.is_non_overlapping_monotonic) is bool
+
+        # Should be True in all cases
+        tpls = [(0, 1), (2, 3), (4, 5), (6, 7)]
+        for closed in ('left', 'right', 'neither', 'both'):
+            idx = IntervalIndex.from_tuples(tpls, closed=closed)
+            assert idx.is_non_overlapping_monotonic is True
+
+            idx = IntervalIndex.from_tuples(reversed(tpls), closed=closed)
+            assert idx.is_non_overlapping_monotonic is True
+
+        # Should be False in all cases (overlapping)
+        tpls = [(0, 2), (1, 3), (4, 5), (6, 7)]
+        for closed in ('left', 'right', 'neither', 'both'):
+            idx = IntervalIndex.from_tuples(tpls, closed=closed)
+            assert idx.is_non_overlapping_monotonic is False
+
+            idx = IntervalIndex.from_tuples(reversed(tpls), closed=closed)
+            assert idx.is_non_overlapping_monotonic is False
+
+        # Should be False in all cases (non-monotonic)
+        tpls = [(0, 1), (2, 3), (6, 7), (4, 5)]
+        for closed in ('left', 'right', 'neither', 'both'):
+            idx = IntervalIndex.from_tuples(tpls, closed=closed)
+            assert idx.is_non_overlapping_monotonic is False
+
+            idx = IntervalIndex.from_tuples(reversed(tpls), closed=closed)
+            assert idx.is_non_overlapping_monotonic is False
+
+        # Should be False for closed='both', overwise True (GH16560)
+        idx = IntervalIndex.from_breaks(range(4), closed='both')
+        assert idx.is_non_overlapping_monotonic is False
+
+        for closed in ('left', 'right', 'neither'):
+            idx = IntervalIndex.from_breaks(range(4), closed=closed)
+            assert idx.is_non_overlapping_monotonic is True
 
 
 class TestIntervalRange(object):

--- a/pandas/tests/indexes/test_interval.py
+++ b/pandas/tests/indexes/test_interval.py
@@ -683,11 +683,6 @@ class TestIntervalIndex(Base):
         pytest.raises(ValueError, f)
 
     def test_is_non_overlapping_monotonic(self):
-        # Verify that a Python Boolean is returned (GH17237)
-        for closed in ('left', 'right', 'neither', 'both'):
-            idx = IntervalIndex.from_breaks(range(4), closed=closed)
-            assert type(idx.is_non_overlapping_monotonic) is bool
-
         # Should be True in all cases
         tpls = [(0, 1), (2, 3), (4, 5), (6, 7)]
         for closed in ('left', 'right', 'neither', 'both'):


### PR DESCRIPTION
- [X] closes #17237
- [X] closes #16560
- [X] tests added / passed
- [X] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [X] whatsnew entry

I had to modify one of the existing tests, which used an `IntervalIndex` that was overlapping at endpoints but was assumed to be non-overlapping.  The test failed due to an intermediate check against `is_non_overlapping_monotonic`, which is now fixed and properly returns that the index in question is in fact overlapping.  The test was modified to use an index which is similar with `closed='both'` but non-overlapping.

Note that #16588 also fixes #16560, but the PR appears to have gone stale, as there hasn't been an update in over two months.  Both #17237 and #16560 involve making changes to the same block of code, so it seemed easiest to fix both simultaneously.  