### PR TITLE
BUG: Cannot use tz-aware origin in to_datetime (#16842)

### DIFF
--- a/doc/source/whatsnew/v0.21.0.txt
+++ b/doc/source/whatsnew/v0.21.0.txt
@@ -385,3 +385,4 @@ Other
 - Bug in :func:`eval` where the ``inplace`` parameter was being incorrectly handled (:issue:`16732`)
 - Bug in ``.isin()`` in which checking membership in empty ``Series`` objects raised an error (:issue:`16991`)
 - Bug in :func:`unique` where checking a tuple of strings raised a ``TypeError`` (:issue:`17108`)
+- :func:`to_datetime` passed tz-aware timestamp origin kwarg now raises correct ValueError (:issue:`16842`)

--- a/pandas/core/tools/datetimes.py
+++ b/pandas/core/tools/datetimes.py
@@ -488,13 +488,18 @@ def to_datetime(arg, errors='raise', dayfirst=False, yearfirst=False,
 
         # we are going to offset back to unix / epoch time
         try:
-            offset = tslib.Timestamp(origin) - tslib.Timestamp(0)
+            offset = tslib.Timestamp(origin)
         except tslib.OutOfBoundsDatetime:
             raise tslib.OutOfBoundsDatetime(
                 "origin {} is Out of Bounds".format(origin))
         except ValueError:
             raise ValueError("origin {} cannot be converted "
                              "to a Timestamp".format(origin))
+
+        if offset.tz is not None:
+            raise ValueError(
+                "offset {} must have no timezone".format(offset))
+        offset -= tslib.Timestamp(0)
 
         # convert the offset to the unit of the arg
         # this should be lossless in terms of precision

--- a/pandas/tests/indexes/datetimes/test_tools.py
+++ b/pandas/tests/indexes/datetimes/test_tools.py
@@ -1589,6 +1589,12 @@ class TestOrigin(object):
             pd.to_datetime(units_from_epochs, unit=units,
                            origin=origin)
 
+    def test_invalid_origins_tzinfo(self):
+        # GH16842
+        with pytest.raises(ValueError):
+            pd.to_datetime(1, unit='D',
+                           origin=datetime(2000, 1, 1, tzinfo=pytz.utc))
+
     def test_processing_order(self):
         # make sure we handle out-of-bounds *before*
         # constructing the dates


### PR DESCRIPTION
- [x] closes #16842 
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry
