### PR TITLE
CLN: replace %s syntax with .format in pandas.core.reshape

### DIFF
--- a/pandas/core/reshape/concat.py
+++ b/pandas/core/reshape/concat.py
@@ -220,7 +220,7 @@ class _Concatenator(object):
         if isinstance(objs, (NDFrame, compat.string_types)):
             raise TypeError('first argument must be an iterable of pandas '
                             'objects, you passed an object of type '
-                            '"{0}"'.format(type(objs).__name__))
+                            '"{name}"'.format(name=type(objs).__name__))
 
         if join == 'outer':
             self.intersect = False
@@ -309,8 +309,8 @@ class _Concatenator(object):
 
         self._is_series = isinstance(sample, Series)
         if not 0 <= axis <= sample.ndim:
-            raise AssertionError("axis must be between 0 and {0}, "
-                                 "input was {1}".format(sample.ndim, axis))
+            raise AssertionError("axis must be between 0 and {ndim}, input was"
+                                 " {axis}".format(ndim=sample.ndim, axis=axis))
 
         # if we have mixed ndims, then convert to highest ndim
         # creating column numbers as needed
@@ -431,8 +431,8 @@ class _Concatenator(object):
                 new_axes[i] = self._get_comb_axis(i)
         else:
             if len(self.join_axes) != ndim - 1:
-                raise AssertionError("length of join_axes must not be "
-                                     "equal to {0}".format(ndim - 1))
+                raise AssertionError("length of join_axes must not be equal "
+                                     "to {length}".format(length=ndim - 1))
 
             # ufff...
             indices = compat.lrange(ndim)
@@ -451,7 +451,8 @@ class _Concatenator(object):
                                            intersect=self.intersect)
         except IndexError:
             types = [type(x).__name__ for x in self.objs]
-            raise TypeError("Cannot concatenate list of %s" % types)
+            raise TypeError("Cannot concatenate list of {types}"
+                            .format(types=types))
 
     def _get_concat_axis(self):
         """
@@ -470,8 +471,8 @@ class _Concatenator(object):
                 for i, x in enumerate(self.objs):
                     if not isinstance(x, Series):
                         raise TypeError("Cannot concatenate type 'Series' "
-                                        "with object of type "
-                                        "%r" % type(x).__name__)
+                                        "with object of type {type!r}"
+                                        .format(type=type(x).__name__))
                     if x.name is not None:
                         names[i] = x.name
                         has_names = True
@@ -505,8 +506,8 @@ class _Concatenator(object):
         if self.verify_integrity:
             if not concat_index.is_unique:
                 overlap = concat_index.get_duplicates()
-                raise ValueError('Indexes have overlapping values: %s'
-                                 % str(overlap))
+                raise ValueError('Indexes have overlapping values: '
+                                 '{overlap!s}'.format(overlap=overlap))
 
 
 def _concat_indexes(indexes):
@@ -547,8 +548,8 @@ def _make_concat_multiindex(indexes, keys, levels=None, names=None):
                 try:
                     i = level.get_loc(key)
                 except KeyError:
-                    raise ValueError('Key %s not in level %s'
-                                     % (str(key), str(level)))
+                    raise ValueError('Key {key!s} not in level {level!s}'
+                                     .format(key=key, level=level))
 
                 to_concat.append(np.repeat(i, len(index)))
             label_list.append(np.concatenate(to_concat))
@@ -597,8 +598,8 @@ def _make_concat_multiindex(indexes, keys, levels=None, names=None):
 
         mask = mapped == -1
         if mask.any():
-            raise ValueError('Values not found in passed level: %s'
-                             % str(hlevel[mask]))
+            raise ValueError('Values not found in passed level: {hlevel!s}'
+                             .format(hlevel=hlevel[mask]))
 
         new_labels.append(np.repeat(mapped, n))
 

--- a/pandas/core/reshape/pivot.py
+++ b/pandas/core/reshape/pivot.py
@@ -145,10 +145,10 @@ def _add_margins(table, data, values, rows, cols, aggfunc,
     if not isinstance(margins_name, compat.string_types):
         raise ValueError('margins_name argument must be a string')
 
-    exception_msg = 'Conflicting name "{0}" in margins'.format(margins_name)
+    msg = 'Conflicting name "{name}" in margins'.format(name=margins_name)
     for level in table.index.names:
         if margins_name in table.index.get_level_values(level):
-            raise ValueError(exception_msg)
+            raise ValueError(msg)
 
     grand_margin = _compute_grand_margin(data, values, aggfunc, margins_name)
 
@@ -156,7 +156,7 @@ def _add_margins(table, data, values, rows, cols, aggfunc,
     if hasattr(table, 'columns'):
         for level in table.columns.names[1:]:
             if margins_name in table.columns.get_level_values(level):
-                raise ValueError(exception_msg)
+                raise ValueError(msg)
 
     if len(rows) > 1:
         key = (margins_name,) + ('',) * (len(rows) - 1)
@@ -553,7 +553,7 @@ def _get_names(arrs, names, prefix='row'):
             if isinstance(arr, ABCSeries) and arr.name is not None:
                 names.append(arr.name)
             else:
-                names.append('%s_%d' % (prefix, i))
+                names.append('{prefix}_{i}'.format(prefix=prefix, i=i))
     else:
         if len(names) != len(arrs):
             raise AssertionError('arrays and names must have the same length')

--- a/pandas/core/reshape/reshape.py
+++ b/pandas/core/reshape/reshape.py
@@ -1,6 +1,6 @@
 # pylint: disable=E1101,E1103
 # pylint: disable=W0703,W0622,W0613,W0201
-from pandas.compat import range, zip
+from pandas.compat import range, text_type, zip
 from pandas import compat
 import itertools
 import re
@@ -91,8 +91,8 @@ class _Unstacker(object):
 
         if isinstance(self.index, MultiIndex):
             if index._reference_duplicate_name(level):
-                msg = ("Ambiguous reference to {0}. The index "
-                       "names are not unique.".format(level))
+                msg = ("Ambiguous reference to {level}. The index "
+                       "names are not unique.".format(level=level))
                 raise ValueError(msg)
 
         self.level = self.index._get_level_number(level)
@@ -229,7 +229,7 @@ class _Unstacker(object):
             sorted_values = sorted_values.astype(name, copy=False)
 
         # fill in our values & mask
-        f = getattr(_reshape, "unstack_{}".format(name))
+        f = getattr(_reshape, "unstack_{name}".format(name=name))
         f(sorted_values,
           mask.view('u1'),
           stride,
@@ -516,8 +516,8 @@ def stack(frame, level=-1, dropna=True):
     N, K = frame.shape
     if isinstance(frame.columns, MultiIndex):
         if frame.columns._reference_duplicate_name(level):
-            msg = ("Ambiguous reference to {0}. The column "
-                   "names are not unique.".format(level))
+            msg = ("Ambiguous reference to {level}. The column "
+                   "names are not unique.".format(level=level))
             raise ValueError(msg)
 
     # Will also convert negative level numbers and check if out of bounds.
@@ -747,7 +747,7 @@ def melt(frame, id_vars=None, value_vars=None, var_name=None,
             if len(frame.columns.names) == len(set(frame.columns.names)):
                 var_name = frame.columns.names
             else:
-                var_name = ['variable_%s' % i
+                var_name = ['variable_{i}'.format(i=i)
                             for i in range(len(frame.columns.names))]
         else:
             var_name = [frame.columns.name if frame.columns.name is not None
@@ -1027,7 +1027,8 @@ def wide_to_long(df, stubnames, i, j, sep="", suffix='\d+'):
     in a typicaly case.
     """
     def get_var_names(df, stub, sep, suffix):
-        regex = "^{0}{1}{2}".format(re.escape(stub), re.escape(sep), suffix)
+        regex = "^{stub}{sep}{suffix}".format(
+            stub=re.escape(stub), sep=re.escape(sep), suffix=suffix)
         return df.filter(regex=regex).columns.tolist()
 
     def melt_stub(df, stub, i, j, value_vars, sep):
@@ -1180,13 +1181,14 @@ def get_dummies(data, prefix=None, prefix_sep='_', dummy_na=False,
 
         # validate prefixes and separator to avoid silently dropping cols
         def check_len(item, name):
-            length_msg = ("Length of '{0}' ({1}) did not match the length of "
-                          "the columns being encoded ({2}).")
+            len_msg = ("Length of '{name}' ({len_item}) did not match the "
+                       "length of the columns being encoded ({len_enc}).")
 
             if is_list_like(item):
                 if not len(item) == len(columns_to_encode):
-                    raise ValueError(length_msg.format(name, len(item),
-                                                       len(columns_to_encode)))
+                    len_msg = len_msg.format(name=name, len_item=len(item),
+                                             len_enc=len(columns_to_encode))
+                    raise ValueError(len_msg)
 
         check_len(prefix, 'prefix')
         check_len(prefix_sep, 'prefix_sep')
@@ -1253,7 +1255,10 @@ def _get_dummies_1d(data, prefix, prefix_sep='_', dummy_na=False,
     number_of_cols = len(levels)
 
     if prefix is not None:
-        dummy_cols = ['%s%s%s' % (prefix, prefix_sep, v) for v in levels]
+        dummy_strs = [u'{prefix}{sep}{level}' if isinstance(v, text_type)
+                      else '{prefix}{sep}{level}' for v in levels]
+        dummy_cols = [dummy_str.format(prefix=prefix, sep=prefix_sep, level=v)
+                      for dummy_str, v in zip(dummy_strs, levels)]
     else:
         dummy_cols = levels
 

--- a/pandas/core/reshape/tile.py
+++ b/pandas/core/reshape/tile.py
@@ -229,9 +229,9 @@ def _bins_to_cuts(x, bins, right=True, labels=None,
     unique_bins = algos.unique(bins)
     if len(unique_bins) < len(bins) and len(bins) != 2:
         if duplicates == 'raise':
-            raise ValueError("Bin edges must be unique: {}.\nYou "
+            raise ValueError("Bin edges must be unique: {bins!r}.\nYou "
                              "can drop duplicate edges by setting "
-                             "the 'duplicates' kwarg".format(repr(bins)))
+                             "the 'duplicates' kwarg".format(bins=bins))
         else:
             bins = unique_bins
 


### PR DESCRIPTION
Progress towards #16130

- [X] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`

Replaced `%s` syntax with `.format` in pandas.core.reshape.  Additionally, made some of the existing positional `.format` code more explicit.
