### PR TITLE
CLN: Replace imports of * with explicit imports

### DIFF
--- a/pandas/_libs/hashtable.pyx
+++ b/pandas/_libs/hashtable.pyx
@@ -2,7 +2,27 @@
 
 from cpython cimport PyObject, Py_INCREF, PyList_Check, PyTuple_Check
 
-from khash cimport *
+from khash cimport (
+    khiter_t,
+
+    kh_str_t, kh_init_str, kh_put_str, kh_exist_str,
+    kh_get_str, kh_destroy_str, kh_resize_str,
+
+    kh_put_strbox, kh_get_strbox, kh_init_strbox,
+
+    kh_int64_t, kh_init_int64, kh_resize_int64, kh_destroy_int64,
+    kh_get_int64, kh_exist_int64, kh_put_int64,
+
+    kh_float64_t, kh_exist_float64, kh_put_float64, kh_init_float64,
+    kh_get_float64, kh_destroy_float64, kh_resize_float64,
+
+    kh_resize_uint64, kh_exist_uint64, kh_destroy_uint64, kh_put_uint64,
+    kh_get_uint64, kh_init_uint64,
+
+    kh_destroy_pymap, kh_exist_pymap, kh_init_pymap, kh_get_pymap,
+    kh_put_pymap, kh_resize_pymap)
+
+
 from numpy cimport *
 
 from libc.stdlib cimport malloc, free

--- a/pandas/_libs/index.pyx
+++ b/pandas/_libs/index.pyx
@@ -1,8 +1,6 @@
 # cython: profile=False
 
-from numpy cimport ndarray
-
-from numpy cimport (float64_t, int32_t, int64_t, uint8_t,
+from numpy cimport (ndarray, float64_t, int32_t, int64_t, uint8_t, uint64_t,
                     NPY_DATETIME, NPY_TIMEDELTA)
 cimport cython
 
@@ -16,7 +14,9 @@ cimport util
 import numpy as np
 
 cimport tslib
-from hashtable cimport *
+
+from hashtable cimport HashTable
+
 from pandas._libs import tslib, algos, hashtable as _hash
 from pandas._libs.tslib import Timestamp, Timedelta
 from datetime import datetime, timedelta

--- a/pandas/_libs/join_func_helper.pxi.in
+++ b/pandas/_libs/join_func_helper.pxi.in
@@ -9,6 +9,8 @@ WARNING: DO NOT edit .pxi FILE directly, .pxi is generated from .pxi.in
 # asof_join_by
 #----------------------------------------------------------------------
 
+from hashtable cimport PyObjectHashTable, UInt64HashTable, Int64HashTable
+
 {{py:
 
 # table_type, by_dtype
@@ -23,7 +25,6 @@ on_dtypes = ['uint8_t', 'uint16_t', 'uint32_t', 'uint64_t',
 }}
 
 
-from hashtable cimport *
 
 {{for table_type, by_dtype in by_dtypes}}
 {{for on_dtype in on_dtypes}}

--- a/pandas/_libs/lib.pyx
+++ b/pandas/_libs/lib.pyx
@@ -10,21 +10,14 @@ from numpy cimport *
 
 np.import_array()
 
-cdef extern from "numpy/arrayobject.h":
-    cdef enum NPY_TYPES:
-        NPY_intp "NPY_INTP"
-
 from libc.stdlib cimport malloc, free
 
-from cpython cimport (PyDict_New, PyDict_GetItem, PyDict_SetItem,
-                      PyDict_Contains, PyDict_Keys,
-                      Py_INCREF, PyTuple_SET_ITEM,
+from cpython cimport (Py_INCREF, PyTuple_SET_ITEM,
                       PyList_Check, PyFloat_Check,
                       PyString_Check,
                       PyBytes_Check,
-                      PyTuple_SetItem,
+                      PyUnicode_Check,
                       PyTuple_New,
-                      PyObject_SetAttrString,
                       PyObject_RichCompareBool,
                       PyBytes_GET_SIZE,
                       PyUnicode_GET_SIZE,
@@ -55,7 +48,18 @@ cdef double NAN = nan
 from datetime import datetime as pydatetime
 
 # this is our tseries.pxd
-from datetime cimport *
+from datetime cimport (
+    get_timedelta64_value, get_datetime64_value,
+    npy_timedelta, npy_datetime,
+    PyDateTime_Check, PyDate_Check, PyTime_Check, PyDelta_Check,
+    PyDateTime_GET_YEAR,
+    PyDateTime_GET_MONTH,
+    PyDateTime_GET_DAY,
+    PyDateTime_DATE_GET_HOUR,
+    PyDateTime_DATE_GET_MINUTE,
+    PyDateTime_DATE_GET_SECOND,
+    PyDateTime_IMPORT)
+
 
 from tslib cimport (convert_to_tsobject, convert_to_timedelta64,
                     _check_all_nulls)

--- a/pandas/_libs/parsers.pyx
+++ b/pandas/_libs/parsers.pyx
@@ -32,7 +32,7 @@ cdef extern from "stdlib.h":
 cimport cython
 cimport numpy as cnp
 
-from numpy cimport ndarray, uint8_t, uint64_t
+from numpy cimport ndarray, uint8_t, uint64_t, int64_t
 
 import numpy as np
 cimport util
@@ -57,7 +57,14 @@ import os
 
 cnp.import_array()
 
-from khash cimport *
+from khash cimport (
+    khiter_t,
+    kh_str_t, kh_init_str, kh_put_str, kh_exist_str,
+    kh_get_str, kh_destroy_str,
+    kh_float64_t, kh_get_float64, kh_destroy_float64,
+    kh_put_float64, kh_init_float64,
+    kh_strbox_t, kh_put_strbox, kh_get_strbox, kh_init_strbox,
+    kh_destroy_strbox)
 
 import sys
 

--- a/pandas/_libs/period.pyx
+++ b/pandas/_libs/period.pyx
@@ -2,6 +2,7 @@ from datetime import datetime, date, timedelta
 import operator
 
 from cpython cimport (
+    PyUnicode_Check,
     PyObject_RichCompareBool,
     Py_EQ, Py_NE,
 )
@@ -19,7 +20,16 @@ from pandas import compat
 from pandas.compat import PY2
 
 cimport cython
-from datetime cimport *
+
+from datetime cimport (
+    is_leapyear,
+    PyDateTime_IMPORT,
+    pandas_datetimestruct,
+    pandas_datetimestruct_to_datetime,
+    pandas_datetime_to_datetimestruct,
+    PANDAS_FR_ns,
+    INT32_MIN)
+
 cimport util, lib
 from lib cimport is_null_datetimelike, is_period
 from pandas._libs import tslib, lib
@@ -30,8 +40,7 @@ from tslib cimport (
     _is_utc,
     _is_tzlocal,
     _get_dst_info,
-    _nat_scalar_rules,
-)
+    _nat_scalar_rules)
 
 from pandas.tseries import offsets
 from pandas.core.tools.datetimes import parse_time_string

--- a/pandas/_libs/src/properties.pyx
+++ b/pandas/_libs/src/properties.pyx
@@ -1,4 +1,5 @@
-from cpython cimport PyDict_Contains, PyDict_GetItem, PyDict_GetItem
+from cpython cimport (
+    PyDict_Contains, PyDict_GetItem, PyDict_GetItem, PyDict_SetItem)
 
 
 cdef class cache_readonly(object):

--- a/pandas/_libs/src/skiplist.pyx
+++ b/pandas/_libs/src/skiplist.pyx
@@ -6,10 +6,6 @@
 
 # Cython version: Wes McKinney
 
-cdef extern from "numpy/arrayobject.h":
-
-    void import_array()
-
 cdef extern from "math.h":
     double log(double x)
 
@@ -25,7 +21,7 @@ import numpy as np
 from random import random
 
 # initialize numpy
-import_array()
+np.import_array()
 
 # TODO: optimize this, make less messy
 

--- a/pandas/_libs/window.pyx
+++ b/pandas/_libs/window.pyx
@@ -56,7 +56,13 @@ cdef inline int int_min(int a, int b): return a if a <= b else b
 
 from util cimport numeric
 
-from skiplist cimport *
+from skiplist cimport (
+    skiplist_t,
+    skiplist_init,
+    skiplist_destroy,
+    skiplist_get,
+    skiplist_insert,
+    skiplist_remove)
 
 cdef extern from "../src/headers/math.h":
     double sqrt(double x) nogil


### PR DESCRIPTION
Remove compat_NaT which is never used after being defined

Remove other unused imports

Remove unused cdef enum NPY_TYPES

flake8 cleanup in period.pyx

Ref #17234

- [ ] closes #xxxx
- [ ] tests added / passed
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
