### PR TITLE
BUG: Index._searchsorted_monotonic(..., side='right') returns the left side position for monotonic decreasing indexes

### DIFF
--- a/doc/source/whatsnew/v0.21.0.txt
+++ b/doc/source/whatsnew/v0.21.0.txt
@@ -418,6 +418,7 @@ Indexing
 - Bug in ``.isin()`` in which checking membership in empty ``Series`` objects raised an error (:issue:`16991`)
 - Bug in ``CategoricalIndex`` reindexing in which specified indices containing duplicates were not being respected (:issue:`17323`)
 - Bug in intersection of ``RangeIndex`` with negative step (:issue:`17296`)
+- Bug in ``IntervalIndex`` where performing a scalar lookup fails for included right endpoints of non-overlapping monotonic decreasing indexes (:issue:`16417`, :issue:`17271`)
 
 I/O
 ^^^

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -3465,7 +3465,7 @@ class Index(IndexOpsMixin, PandasObject):
             # everything for it to work (element ordering, search side and
             # resulting value).
             pos = self[::-1].searchsorted(label, side='right' if side == 'left'
-                                          else 'right')
+                                          else 'left')
             return len(self) - pos
 
         raise ValueError('index must be monotonic increasing or decreasing')

--- a/pandas/tests/indexes/common.py
+++ b/pandas/tests/indexes/common.py
@@ -565,9 +565,6 @@ class Base(object):
 
             if isinstance(idx, CategoricalIndex):
                 pass
-            elif isinstance(idx, RangeIndex):
-                pytest.xfail(reason='intersection fails for decreasing '
-                                    'RangeIndex (GH 17296)')
             else:
                 assert tm.equalContents(intersect, second)
 

--- a/pandas/tests/indexes/common.py
+++ b/pandas/tests/indexes/common.py
@@ -11,6 +11,7 @@ from pandas import (Series, Index, Float64Index, Int64Index, UInt64Index,
                     RangeIndex, MultiIndex, CategoricalIndex, DatetimeIndex,
                     TimedeltaIndex, PeriodIndex, IntervalIndex,
                     notna, isna)
+from pandas.core.indexes.base import InvalidIndexError
 from pandas.core.indexes.datetimelike import DatetimeIndexOpsMixin
 from pandas.core.dtypes.common import needs_i8_conversion
 from pandas._libs.tslib import iNaT
@@ -138,10 +139,14 @@ class Base(object):
             if isinstance(index, IntervalIndex):
                 continue
 
-            if index.is_unique:
+            if index.is_unique or isinstance(index, CategoricalIndex):
                 indexer = index.get_indexer(index[0:2])
                 assert isinstance(indexer, np.ndarray)
                 assert indexer.dtype == np.intp
+            else:
+                e = "Reindexing only valid with uniquely valued Index objects"
+                with tm.assert_raises_regex(InvalidIndexError, e):
+                    indexer = index.get_indexer(index[0:2])
 
             indexer, _ = index.get_indexer_non_unique(index[0:2])
             assert isinstance(indexer, np.ndarray)

--- a/pandas/tests/indexes/common.py
+++ b/pandas/tests/indexes/common.py
@@ -551,6 +551,8 @@ class Base(object):
                                            "or array-like",
                                            method, case)
 
+    @pytest.mark.xfail(reason='intersection fails for monotonic decreasing '
+                              'RangeIndex (GH 17296)')
     def test_intersection_base(self):
         for name, idx in compat.iteritems(self.indices):
             first = idx[:5]
@@ -632,7 +634,8 @@ class Base(object):
                     pass
                 elif isinstance(idx, (DatetimeIndex, TimedeltaIndex)):
                     assert result.__class__ == answer.__class__
-                    assert tm.equalContents(result.asi8, answer.asi8)
+                    tm.assert_numpy_array_equal(result.sort_values().asi8,
+                                                answer.sort_values().asi8)
                 else:
                     result = first.difference(case)
                     assert tm.equalContents(result, answer)

--- a/pandas/tests/indexes/datetimes/test_datetimelike.py
+++ b/pandas/tests/indexes/datetimes/test_datetimelike.py
@@ -12,7 +12,9 @@ class TestDatetimeIndex(DatetimeLike):
     _holder = DatetimeIndex
 
     def setup_method(self, method):
-        self.indices = dict(index=tm.makeDateIndex(10))
+        self.indices = dict(index=tm.makeDateIndex(10),
+                            index_dec=date_range('20130110', periods=10,
+                                                 freq='-1D'))
         self.setup_indices()
 
     def create_index(self):

--- a/pandas/tests/indexes/period/test_period.py
+++ b/pandas/tests/indexes/period/test_period.py
@@ -18,7 +18,9 @@ class TestPeriodIndex(DatetimeLike):
     _multiprocess_can_split_ = True
 
     def setup_method(self, method):
-        self.indices = dict(index=tm.makePeriodIndex(10))
+        self.indices = dict(index=tm.makePeriodIndex(10),
+                            index_dec=period_range('20130101', periods=10,
+                                                   freq='D')[::-1])
         self.setup_indices()
 
     def create_index(self):

--- a/pandas/tests/indexes/test_base.py
+++ b/pandas/tests/indexes/test_base.py
@@ -46,7 +46,8 @@ class TestIndex(Base):
                             catIndex=tm.makeCategoricalIndex(100),
                             empty=Index([]),
                             tuples=MultiIndex.from_tuples(lzip(
-                                ['foo', 'bar', 'baz'], [1, 2, 3])))
+                                ['foo', 'bar', 'baz'], [1, 2, 3])),
+                            repeats=Index([0, 0, 1, 1, 2, 2]))
         self.setup_indices()
 
     def create_index(self):

--- a/pandas/tests/indexes/test_base.py
+++ b/pandas/tests/indexes/test_base.py
@@ -2119,6 +2119,27 @@ class TestMixedIntIndex(Base):
 
         assert len(res) == 0
 
+    def test_searchsorted_monotonic(self):
+        # GH17271
+        idx_inc = Index([0, 2, 4])
+        idx_dec = Index([4, 2, 0])
+
+        # test included value.
+        assert idx_inc._searchsorted_monotonic(0, side='left') == 0
+        assert idx_inc._searchsorted_monotonic(0, side='right') == 1
+        assert idx_dec._searchsorted_monotonic(0, side='left') == 2
+        assert idx_dec._searchsorted_monotonic(0, side='right') == 3
+
+        # test non-included value.
+        for side in ('left', 'right'):
+            assert idx_inc._searchsorted_monotonic(1, side=side) == 1
+            assert idx_dec._searchsorted_monotonic(1, side=side) == 2
+
+        # non-monotonic should raise.
+        idx_bad = Index([0, 4, 2])
+        with pytest.raises(ValueError):
+            idx_bad._searchsorted_monotonic(3)
+
 
 class TestIndexUtils(object):
 

--- a/pandas/tests/indexes/test_base.py
+++ b/pandas/tests/indexes/test_base.py
@@ -2119,27 +2119,6 @@ class TestMixedIntIndex(Base):
 
         assert len(res) == 0
 
-    def test_searchsorted_monotonic(self):
-        # GH17271
-        idx_inc = Index([0, 2, 4])
-        idx_dec = Index([4, 2, 0])
-
-        # test included value.
-        assert idx_inc._searchsorted_monotonic(0, side='left') == 0
-        assert idx_inc._searchsorted_monotonic(0, side='right') == 1
-        assert idx_dec._searchsorted_monotonic(0, side='left') == 2
-        assert idx_dec._searchsorted_monotonic(0, side='right') == 3
-
-        # test non-included value.
-        for side in ('left', 'right'):
-            assert idx_inc._searchsorted_monotonic(1, side=side) == 1
-            assert idx_dec._searchsorted_monotonic(1, side=side) == 2
-
-        # non-monotonic should raise.
-        idx_bad = Index([0, 4, 2])
-        with pytest.raises(ValueError):
-            idx_bad._searchsorted_monotonic(3)
-
 
 class TestIndexUtils(object):
 

--- a/pandas/tests/indexes/test_numeric.py
+++ b/pandas/tests/indexes/test_numeric.py
@@ -181,7 +181,9 @@ class TestFloat64Index(Numeric):
 
     def setup_method(self, method):
         self.indices = dict(mixed=Float64Index([1.5, 2, 3, 4, 5]),
-                            float=Float64Index(np.arange(5) * 2.5))
+                            float=Float64Index(np.arange(5) * 2.5),
+                            mixed_dec=Float64Index([5, 4, 3, 2, 1.5]),
+                            float_dec=Float64Index(np.arange(4, -1, -1) * 2.5))
         self.setup_indices()
 
     def create_index(self):
@@ -654,7 +656,8 @@ class TestInt64Index(NumericInt):
     _holder = Int64Index
 
     def setup_method(self, method):
-        self.indices = dict(index=Int64Index(np.arange(0, 20, 2)))
+        self.indices = dict(index=Int64Index(np.arange(0, 20, 2)),
+                            index_dec=Int64Index(np.arange(19, -1, -1)))
         self.setup_indices()
 
     def create_index(self):
@@ -949,8 +952,9 @@ class TestUInt64Index(NumericInt):
     _holder = UInt64Index
 
     def setup_method(self, method):
-        self.indices = dict(index=UInt64Index([2**63, 2**63 + 10, 2**63 + 15,
-                                               2**63 + 20, 2**63 + 25]))
+        vals = [2**63, 2**63 + 10, 2**63 + 15, 2**63 + 20, 2**63 + 25]
+        self.indices = dict(index=UInt64Index(vals),
+                            index_dec=UInt64Index(reversed(vals)))
         self.setup_indices()
 
     def create_index(self):

--- a/pandas/tests/indexes/test_range.py
+++ b/pandas/tests/indexes/test_range.py
@@ -25,7 +25,8 @@ class TestRangeIndex(Numeric):
     _compat_props = ['shape', 'ndim', 'size', 'itemsize']
 
     def setup_method(self, method):
-        self.indices = dict(index=RangeIndex(0, 20, 2, name='foo'))
+        self.indices = dict(index=RangeIndex(0, 20, 2, name='foo'),
+                            index_dec=RangeIndex(18, -1, -2, name='bar'))
         self.setup_indices()
 
     def create_index(self):

--- a/pandas/tests/indexing/test_interval.py
+++ b/pandas/tests/indexing/test_interval.py
@@ -3,6 +3,7 @@ import numpy as np
 import pandas as pd
 
 from pandas import Series, DataFrame, IntervalIndex, Interval
+from pandas.compat import product
 import pandas.util.testing as tm
 
 
@@ -11,22 +12,9 @@ class TestIntervalIndex(object):
     def setup_method(self, method):
         self.s = Series(np.arange(5), IntervalIndex.from_breaks(np.arange(6)))
 
-        idx_dec = IntervalIndex.from_tuples([(2, 3), (1, 2), (0, 1)])
-        self.s_dec = Series(list('abc'), idx_dec)
-
     def test_loc_with_scalar(self):
 
         s = self.s
-        expected = 0
-
-        result = s.loc[0.5]
-        assert result == expected
-
-        result = s.loc[1]
-        assert result == expected
-
-        with pytest.raises(KeyError):
-            s.loc[0]
 
         expected = s.iloc[:3]
         tm.assert_series_equal(expected, s.loc[:3])
@@ -42,22 +30,9 @@ class TestIntervalIndex(object):
         expected = s.iloc[2:5]
         tm.assert_series_equal(expected, s.loc[s >= 2])
 
-        # test endpoint of non-overlapping monotonic decreasing (GH16417)
-        assert self.s_dec.loc[3] == 'a'
-
     def test_getitem_with_scalar(self):
 
         s = self.s
-        expected = 0
-
-        result = s[0.5]
-        assert result == expected
-
-        result = s[1]
-        assert result == expected
-
-        with pytest.raises(KeyError):
-            s[0]
 
         expected = s.iloc[:3]
         tm.assert_series_equal(expected, s[:3])
@@ -73,8 +48,40 @@ class TestIntervalIndex(object):
         expected = s.iloc[2:5]
         tm.assert_series_equal(expected, s[s >= 2])
 
-        # test endpoint of non-overlapping monotonic decreasing (GH16417)
-        assert self.s_dec[3] == 'a'
+    @pytest.mark.parametrize('direction, closed',
+                             product(('increasing', 'decreasing'),
+                                     ('left', 'right', 'neither', 'both')))
+    def test_nonoverlapping_monotonic(self, direction, closed):
+        tpls = [(0, 1), (2, 3), (4, 5)]
+        if direction == 'decreasing':
+            tpls = reversed(tpls)
+
+        idx = IntervalIndex.from_tuples(tpls, closed=closed)
+        s = Series(list('abc'), idx)
+
+        for key, expected in zip(idx.left, s):
+            if idx.closed_left:
+                assert s[key] == expected
+                assert s.loc[key] == expected
+            else:
+                with pytest.raises(KeyError):
+                    s[key]
+                with pytest.raises(KeyError):
+                    s.loc[key]
+
+        for key, expected in zip(idx.right, s):
+            if idx.closed_right:
+                assert s[key] == expected
+                assert s.loc[key] == expected
+            else:
+                with pytest.raises(KeyError):
+                    s[key]
+                with pytest.raises(KeyError):
+                    s.loc[key]
+
+        for key, expected in zip(idx.mid, s):
+            assert s[key] == expected
+            assert s.loc[key] == expected
 
     def test_with_interval(self):
 

--- a/pandas/tests/indexing/test_interval.py
+++ b/pandas/tests/indexing/test_interval.py
@@ -11,6 +11,9 @@ class TestIntervalIndex(object):
     def setup_method(self, method):
         self.s = Series(np.arange(5), IntervalIndex.from_breaks(np.arange(6)))
 
+        idx_dec = IntervalIndex.from_tuples([(2, 3), (1, 2), (0, 1)])
+        self.s_dec = Series(list('abc'), idx_dec)
+
     def test_loc_with_scalar(self):
 
         s = self.s
@@ -39,6 +42,9 @@ class TestIntervalIndex(object):
         expected = s.iloc[2:5]
         tm.assert_series_equal(expected, s.loc[s >= 2])
 
+        # test endpoint of non-overlapping monotonic decreasing (GH16417)
+        assert self.s_dec.loc[3] == 'a'
+
     def test_getitem_with_scalar(self):
 
         s = self.s
@@ -66,6 +72,9 @@ class TestIntervalIndex(object):
 
         expected = s.iloc[2:5]
         tm.assert_series_equal(expected, s[s >= 2])
+
+        # test endpoint of non-overlapping monotonic decreasing (GH16417)
+        assert self.s_dec[3] == 'a'
 
     def test_with_interval(self):
 


### PR DESCRIPTION
- [X] closes #17271
- [X] closes #16417
- [X] tests added / passed
- [X] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [X] whatsnew entry

I didn't add a whatsnew entry for the `Index._searchsorted_monotonic` fix, since it looks like past convention has been to not add whatsnew entries for private methods.  Happy to add a whatsnew entry if I'm mistaken though.  I did add a whatsnew entry for the downstream effect on IntervalIndex.