### PR TITLE
Remove inline declarations in pxd files

### DIFF
--- a/pandas/_libs/hashtable.pxd
+++ b/pandas/_libs/hashtable.pxd
@@ -38,7 +38,7 @@ cdef class MultiIndexHashTable(HashTable):
 
     cpdef get_item(self, object val)
     cpdef set_item(self, object key, Py_ssize_t val)
-    cdef inline void _check_for_collision(self, Py_ssize_t loc, object label)
+    cdef void _check_for_collision(self, Py_ssize_t loc, object label)
 
 
 cdef class StringHashTable(HashTable):
@@ -58,5 +58,5 @@ cdef class Int64Vector:
 
     cdef resize(self)
     cpdef to_array(self)
-    cdef inline void append(self, int64_t x)
+    cdef void append(self, int64_t x)
     cdef extend(self, int64_t[:] x)

--- a/pandas/_libs/src/khash.pxd
+++ b/pandas/_libs/src/khash.pxd
@@ -11,13 +11,13 @@ cdef extern from "khash_python.h":
         PyObject **keys
         size_t *vals
 
-    inline kh_pymap_t* kh_init_pymap()
-    inline void kh_destroy_pymap(kh_pymap_t*)
-    inline void kh_clear_pymap(kh_pymap_t*)
-    inline khint_t kh_get_pymap(kh_pymap_t*, PyObject*)
-    inline void kh_resize_pymap(kh_pymap_t*, khint_t)
-    inline khint_t kh_put_pymap(kh_pymap_t*, PyObject*, int*)
-    inline void kh_del_pymap(kh_pymap_t*, khint_t)
+    kh_pymap_t* kh_init_pymap()
+    void kh_destroy_pymap(kh_pymap_t*)
+    void kh_clear_pymap(kh_pymap_t*)
+    khint_t kh_get_pymap(kh_pymap_t*, PyObject*)
+    void kh_resize_pymap(kh_pymap_t*, khint_t)
+    khint_t kh_put_pymap(kh_pymap_t*, PyObject*, int*)
+    void kh_del_pymap(kh_pymap_t*, khint_t)
 
     bint kh_exist_pymap(kh_pymap_t*, khiter_t)
 
@@ -27,13 +27,13 @@ cdef extern from "khash_python.h":
         PyObject **keys
         size_t *vals
 
-    inline kh_pyset_t* kh_init_pyset()
-    inline void kh_destroy_pyset(kh_pyset_t*)
-    inline void kh_clear_pyset(kh_pyset_t*)
-    inline khint_t kh_get_pyset(kh_pyset_t*, PyObject*)
-    inline void kh_resize_pyset(kh_pyset_t*, khint_t)
-    inline khint_t kh_put_pyset(kh_pyset_t*, PyObject*, int*)
-    inline void kh_del_pyset(kh_pyset_t*, khint_t)
+    kh_pyset_t* kh_init_pyset()
+    void kh_destroy_pyset(kh_pyset_t*)
+    void kh_clear_pyset(kh_pyset_t*)
+    khint_t kh_get_pyset(kh_pyset_t*, PyObject*)
+    void kh_resize_pyset(kh_pyset_t*, khint_t)
+    khint_t kh_put_pyset(kh_pyset_t*, PyObject*, int*)
+    void kh_del_pyset(kh_pyset_t*, khint_t)
 
     bint kh_exist_pyset(kh_pyset_t*, khiter_t)
 
@@ -45,13 +45,13 @@ cdef extern from "khash_python.h":
         kh_cstr_t *keys
         size_t *vals
 
-    inline kh_str_t* kh_init_str() nogil
-    inline void kh_destroy_str(kh_str_t*) nogil
-    inline void kh_clear_str(kh_str_t*) nogil
-    inline khint_t kh_get_str(kh_str_t*, kh_cstr_t) nogil
-    inline void kh_resize_str(kh_str_t*, khint_t) nogil
-    inline khint_t kh_put_str(kh_str_t*, kh_cstr_t, int*) nogil
-    inline void kh_del_str(kh_str_t*, khint_t) nogil
+    kh_str_t* kh_init_str() nogil
+    void kh_destroy_str(kh_str_t*) nogil
+    void kh_clear_str(kh_str_t*) nogil
+    khint_t kh_get_str(kh_str_t*, kh_cstr_t) nogil
+    void kh_resize_str(kh_str_t*, khint_t) nogil
+    khint_t kh_put_str(kh_str_t*, kh_cstr_t, int*) nogil
+    void kh_del_str(kh_str_t*, khint_t) nogil
 
     bint kh_exist_str(kh_str_t*, khiter_t) nogil
 
@@ -61,13 +61,13 @@ cdef extern from "khash_python.h":
         int64_t *keys
         size_t *vals
 
-    inline kh_int64_t* kh_init_int64() nogil
-    inline void kh_destroy_int64(kh_int64_t*) nogil
-    inline void kh_clear_int64(kh_int64_t*) nogil
-    inline khint_t kh_get_int64(kh_int64_t*, int64_t) nogil
-    inline void kh_resize_int64(kh_int64_t*, khint_t) nogil
-    inline khint_t kh_put_int64(kh_int64_t*, int64_t, int*) nogil
-    inline void kh_del_int64(kh_int64_t*, khint_t) nogil
+    kh_int64_t* kh_init_int64() nogil
+    void kh_destroy_int64(kh_int64_t*) nogil
+    void kh_clear_int64(kh_int64_t*) nogil
+    khint_t kh_get_int64(kh_int64_t*, int64_t) nogil
+    void kh_resize_int64(kh_int64_t*, khint_t) nogil
+    khint_t kh_put_int64(kh_int64_t*, int64_t, int*) nogil
+    void kh_del_int64(kh_int64_t*, khint_t) nogil
 
     bint kh_exist_int64(kh_int64_t*, khiter_t) nogil
 
@@ -79,13 +79,13 @@ cdef extern from "khash_python.h":
         khuint64_t *keys
         size_t *vals
 
-    inline kh_uint64_t* kh_init_uint64() nogil
-    inline void kh_destroy_uint64(kh_uint64_t*) nogil
-    inline void kh_clear_uint64(kh_uint64_t*) nogil
-    inline khint_t kh_get_uint64(kh_uint64_t*, int64_t) nogil
-    inline void kh_resize_uint64(kh_uint64_t*, khint_t) nogil
-    inline khint_t kh_put_uint64(kh_uint64_t*, int64_t, int*) nogil
-    inline void kh_del_uint64(kh_uint64_t*, khint_t) nogil
+    kh_uint64_t* kh_init_uint64() nogil
+    void kh_destroy_uint64(kh_uint64_t*) nogil
+    void kh_clear_uint64(kh_uint64_t*) nogil
+    khint_t kh_get_uint64(kh_uint64_t*, int64_t) nogil
+    void kh_resize_uint64(kh_uint64_t*, khint_t) nogil
+    khint_t kh_put_uint64(kh_uint64_t*, int64_t, int*) nogil
+    void kh_del_uint64(kh_uint64_t*, khint_t) nogil
 
     bint kh_exist_uint64(kh_uint64_t*, khiter_t) nogil
 
@@ -95,13 +95,13 @@ cdef extern from "khash_python.h":
         float64_t *keys
         size_t *vals
 
-    inline kh_float64_t* kh_init_float64() nogil
-    inline void kh_destroy_float64(kh_float64_t*) nogil
-    inline void kh_clear_float64(kh_float64_t*) nogil
-    inline khint_t kh_get_float64(kh_float64_t*, float64_t) nogil
-    inline void kh_resize_float64(kh_float64_t*, khint_t) nogil
-    inline khint_t kh_put_float64(kh_float64_t*, float64_t, int*) nogil
-    inline void kh_del_float64(kh_float64_t*, khint_t) nogil
+    kh_float64_t* kh_init_float64() nogil
+    void kh_destroy_float64(kh_float64_t*) nogil
+    void kh_clear_float64(kh_float64_t*) nogil
+    khint_t kh_get_float64(kh_float64_t*, float64_t) nogil
+    void kh_resize_float64(kh_float64_t*, khint_t) nogil
+    khint_t kh_put_float64(kh_float64_t*, float64_t, int*) nogil
+    void kh_del_float64(kh_float64_t*, khint_t) nogil
 
     bint kh_exist_float64(kh_float64_t*, khiter_t) nogil
 
@@ -111,13 +111,13 @@ cdef extern from "khash_python.h":
         int32_t *keys
         size_t *vals
 
-    inline kh_int32_t* kh_init_int32() nogil
-    inline void kh_destroy_int32(kh_int32_t*) nogil
-    inline void kh_clear_int32(kh_int32_t*) nogil
-    inline khint_t kh_get_int32(kh_int32_t*, int32_t) nogil
-    inline void kh_resize_int32(kh_int32_t*, khint_t) nogil
-    inline khint_t kh_put_int32(kh_int32_t*, int32_t, int*) nogil
-    inline void kh_del_int32(kh_int32_t*, khint_t) nogil
+    kh_int32_t* kh_init_int32() nogil
+    void kh_destroy_int32(kh_int32_t*) nogil
+    void kh_clear_int32(kh_int32_t*) nogil
+    khint_t kh_get_int32(kh_int32_t*, int32_t) nogil
+    void kh_resize_int32(kh_int32_t*, khint_t) nogil
+    khint_t kh_put_int32(kh_int32_t*, int32_t, int*) nogil
+    void kh_del_int32(kh_int32_t*, khint_t) nogil
 
     bint kh_exist_int32(kh_int32_t*, khiter_t) nogil
 
@@ -129,12 +129,12 @@ cdef extern from "khash_python.h":
         kh_cstr_t *keys
         PyObject **vals
 
-    inline kh_strbox_t* kh_init_strbox() nogil
-    inline void kh_destroy_strbox(kh_strbox_t*) nogil
-    inline void kh_clear_strbox(kh_strbox_t*) nogil
-    inline khint_t kh_get_strbox(kh_strbox_t*, kh_cstr_t) nogil
-    inline void kh_resize_strbox(kh_strbox_t*, khint_t) nogil
-    inline khint_t kh_put_strbox(kh_strbox_t*, kh_cstr_t, int*) nogil
-    inline void kh_del_strbox(kh_strbox_t*, khint_t) nogil
+    kh_strbox_t* kh_init_strbox() nogil
+    void kh_destroy_strbox(kh_strbox_t*) nogil
+    void kh_clear_strbox(kh_strbox_t*) nogil
+    khint_t kh_get_strbox(kh_strbox_t*, kh_cstr_t) nogil
+    void kh_resize_strbox(kh_strbox_t*, khint_t) nogil
+    khint_t kh_put_strbox(kh_strbox_t*, kh_cstr_t, int*) nogil
+    void kh_del_strbox(kh_strbox_t*, khint_t) nogil
 
     bint kh_exist_strbox(kh_strbox_t*, khiter_t) nogil

--- a/pandas/_libs/src/skiplist.pxd
+++ b/pandas/_libs/src/skiplist.pxd
@@ -14,9 +14,9 @@ cdef extern from "skiplist.h":
         int size
         int maxlevels
 
-    inline skiplist_t* skiplist_init(int) nogil
-    inline void skiplist_destroy(skiplist_t*) nogil
-    inline double skiplist_get(skiplist_t*, int, int*) nogil
-    inline int skiplist_insert(skiplist_t*, double) nogil
-    inline int skiplist_remove(skiplist_t*, double) nogil
+    skiplist_t* skiplist_init(int) nogil
+    void skiplist_destroy(skiplist_t*) nogil
+    double skiplist_get(skiplist_t*, int, int*) nogil
+    int skiplist_insert(skiplist_t*, double) nogil
+    int skiplist_remove(skiplist_t*, double) nogil
 

--- a/pandas/_libs/src/util.pxd
+++ b/pandas/_libs/src/util.pxd
@@ -3,26 +3,26 @@ cimport numpy as cnp
 cimport cpython
 
 cdef extern from "numpy_helper.h":
-    inline void set_array_owndata(ndarray ao)
-    inline void set_array_not_contiguous(ndarray ao)
+    void set_array_owndata(ndarray ao)
+    void set_array_not_contiguous(ndarray ao)
 
-    inline int is_integer_object(object)
-    inline int is_float_object(object)
-    inline int is_complex_object(object)
-    inline int is_bool_object(object)
-    inline int is_string_object(object)
-    inline int is_datetime64_object(object)
-    inline int is_timedelta64_object(object)
-    inline int assign_value_1d(ndarray, Py_ssize_t, object) except -1
-    inline cnp.int64_t get_nat()
-    inline object get_value_1d(ndarray, Py_ssize_t)
-    inline int floatify(object, double*) except -1
-    inline char *get_c_string(object) except NULL
-    inline object char_to_string(char*)
-    inline void transfer_object_column(char *dst, char *src, size_t stride,
+    int is_integer_object(object)
+    int is_float_object(object)
+    int is_complex_object(object)
+    int is_bool_object(object)
+    int is_string_object(object)
+    int is_datetime64_object(object)
+    int is_timedelta64_object(object)
+    int assign_value_1d(ndarray, Py_ssize_t, object) except -1
+    cnp.int64_t get_nat()
+    object get_value_1d(ndarray, Py_ssize_t)
+    int floatify(object, double*) except -1
+    char *get_c_string(object) except NULL
+    object char_to_string(char*)
+    void transfer_object_column(char *dst, char *src, size_t stride,
                                        size_t length)
     object sarr_from_data(cnp.dtype, int length, void* data)
-    inline object unbox_if_zerodim(object arr)
+    object unbox_if_zerodim(object arr)
 
 ctypedef fused numeric:
     cnp.int8_t


### PR DESCRIPTION
At the moment (I think since .26, not sure) they don't do anything but cause lots of warnings during cythonizing.  Eventually they will raise errors.

https://github.com/cython/cython/issues/1706#issuecomment-302347613

- [ ] closes #xxxx
- [ ] tests added / passed
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
