### PR TITLE
BUG: fillna returns frame when inplace=True if value is a dict (#16156)

### DIFF
--- a/doc/source/whatsnew/v0.21.0.txt
+++ b/doc/source/whatsnew/v0.21.0.txt
@@ -314,7 +314,7 @@ Conversion
 - Fix :func:`DataFrame.memory_usage` to support PyPy. Objects on PyPy do not have a fixed size, so an approximation is used instead (:issue:`17228`)
 - Fixed the return type of ``IntervalIndex.is_non_overlapping_monotonic`` to be a Python ``bool`` for consistency with similar attributes/methods.  Previously returned a ``numpy.bool_``. (:issue:`17237`)
 - Bug in ``IntervalIndex.is_non_overlapping_monotonic`` when intervals are closed on both sides and overlap at a point (:issue:`16560`)
-
+- Bug in :func:`Series.fillna` returns frame when ``inplace=True`` and ``value`` is dict (:issue:`16156`)
 
 Indexing
 ^^^^^^^^

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -4054,7 +4054,8 @@ class NDFrame(PandasObject, SelectionMixin):
                         continue
                     obj = result[k]
                     obj.fillna(v, limit=limit, inplace=True, downcast=downcast)
-                return result
+                return result if not inplace else None
+
             elif not is_list_like(value):
                 new_data = self._data.fillna(value=value, limit=limit,
                                              inplace=inplace,

--- a/pandas/tests/frame/test_missing.py
+++ b/pandas/tests/frame/test_missing.py
@@ -407,6 +407,9 @@ class TestDataFrameMissingData(TestData):
         df.fillna(value=0, inplace=True)
         tm.assert_frame_equal(df, expected)
 
+        expected = df.fillna(value={0: 0}, inplace=True)
+        assert expected is None
+
         df[1][:4] = np.nan
         df[3][-4:] = np.nan
         expected = df.fillna(method='ffill')


### PR DESCRIPTION
- [x] closes #16156
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry
