### PR TITLE
BUG: revert collision warning

### DIFF
--- a/doc/source/indexing.rst
+++ b/doc/source/indexing.rst
@@ -269,21 +269,6 @@ new column. In 0.21.0 and later, this will raise a ``UserWarning``:
     1  2.0
     2  3.0
 
-Similarly, it is possible to create a column with a name which collides with one of Pandas's
-built-in methods or attributes, which can cause confusion later when attempting to access
-that column as an attribute. This behavior now warns:
-
-.. code-block:: ipython
-
-    In[4]: df['sum'] = [5., 7., 9.]
-    UserWarning: Column name 'sum' collides with a built-in method, which will cause unexpected attribute behavior
-    In[5]: df.sum
-    Out[5]:
-    <bound method DataFrame.sum of    one  sum
-    0  1.0  5.0
-    1  2.0  7.0
-    2  3.0  9.0>
-
 Slicing ranges
 --------------
 

--- a/doc/source/whatsnew/v0.21.0.txt
+++ b/doc/source/whatsnew/v0.21.0.txt
@@ -67,8 +67,8 @@ Improved warnings when attempting to create columns
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 New users are often flummoxed by the relationship between column operations and attribute
-access on ``DataFrame`` instances (:issue:`5904` & :issue:`7175`). Two specific instances
-of this confusion include attempting to create a new column by setting into an attribute:
+access on ``DataFrame`` instances (:issue:`7175`). One specific instance
+of this confusion is attempting to create a new column by setting into an attribute:
 
 .. code-block:: ipython
 
@@ -86,25 +86,7 @@ This does not raise any obvious exceptions, but also does not create a new colum
   1  2.0
   2  3.0
 
-The second source of confusion is creating a column whose name collides with a method or
-attribute already in the instance namespace:
-
-.. code-block:: ipython
-
-  In[4]: df['sum'] = [5., 7., 9.]
-
-This does not permit that column to be accessed as an attribute:
-
-.. code-block:: ipython
-
-  In[5]: df.sum
-  Out[5]:
-  <bound method DataFrame.sum of    one  sum
-  0  1.0  5.0
-  1  2.0  7.0
-  2  3.0  9.0>
-
-Both of these now raise a ``UserWarning`` about the potential for unexpected behavior. See :ref:`Attribute Access <indexing.attribute_access>`.
+Setting a list-like data structure into a new attribute now raise a ``UserWarning`` about the potential for unexpected behavior. See :ref:`Attribute Access <indexing.attribute_access>`.
 
 .. _whatsnew_0210.enhancements.other:
 

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -3437,8 +3437,8 @@ class NDFrame(PandasObject, SelectionMixin):
                     object.__setattr__(self, name, value)
             except (AttributeError, TypeError):
                 if isinstance(self, ABCDataFrame) and (is_list_like(value)):
-                    warnings.warn("Pandas doesn't allow Series to be assigned "
-                                  "into nonexistent columns - see "
+                    warnings.warn("Pandas doesn't allow columns to be "
+                                  "created via a new attribute name - see "
                                   "https://pandas.pydata.org/pandas-docs/"
                                   "stable/indexing.html#attribute-access",
                                   stacklevel=2)

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -1905,10 +1905,6 @@ class NDFrame(PandasObject, SelectionMixin):
         return result
 
     def _set_item(self, key, value):
-        if isinstance(key, str) and callable(getattr(self, key, None)):
-            warnings.warn("Column name '{key}' collides with a built-in "
-                          "method, which will cause unexpected attribute "
-                          "behavior".format(key=key), stacklevel=3)
         self._data.set(key, value)
         self._clear_item_cache()
 

--- a/pandas/tests/dtypes/test_generic.py
+++ b/pandas/tests/dtypes/test_generic.py
@@ -48,7 +48,6 @@ class TestABCClasses(object):
 
 
 def test_setattr_warnings():
-    # GH5904 - Suggestion: Warning for DataFrame colname-methodname clash
     # GH7175 - GOTCHA: You can't use dot notation to add a column...
     d = {'one': pd.Series([1., 2., 3.], index=['a', 'b', 'c']),
          'two': pd.Series([1., 2., 3., 4.], index=['a', 'b', 'c', 'd'])}
@@ -78,7 +77,3 @@ def test_setattr_warnings():
         #  warn when setting column to nonexistent name
         df.four = df.two + 2
         assert df.four.sum() > df.two.sum()
-
-    with tm.assert_produces_warning(UserWarning):
-        #  warn when column has same name as method
-        df['sum'] = df.two

--- a/pandas/tests/io/test_pytables.py
+++ b/pandas/tests/io/test_pytables.py
@@ -2011,7 +2011,7 @@ class TestHDFStore(Base):
         df['string'] = 'foo'
         df['float322'] = 1.
         df['float322'] = df['float322'].astype('float32')
-        df['boolean'] = df['float322'] > 0
+        df['bool'] = df['float322'] > 0
         df['time1'] = Timestamp('20130101')
         df['time2'] = Timestamp('20130102')
         check(df, tm.assert_frame_equal)
@@ -2141,7 +2141,7 @@ class TestHDFStore(Base):
             df1['string'] = 'foo'
             df1['float322'] = 1.
             df1['float322'] = df1['float322'].astype('float32')
-            df1['boolean'] = df1['float32'] > 0
+            df1['bool'] = df1['float32'] > 0
             df1['time1'] = Timestamp('20130101')
             df1['time2'] = Timestamp('20130102')
 


### PR DESCRIPTION
- [ ] closes #17268 
- [ ] tests added / passed
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

Reverts work in #16951 that warns when creating a column whose name collides with a method.