### PR TITLE
BUG: Fixed regex in asv.conf.json

### DIFF
--- a/asv_bench/asv.conf.json
+++ b/asv_bench/asv.conf.json
@@ -118,9 +118,9 @@
     // skipped for the matching benchmark.
     //
     "regressions_first_commits": {
-        "*": "v0.20.0"
+        ".*": "v0.20.0"
     },
     "regression_thresholds": {
-        "*": 0.05
+        ".*": 0.05
     }
 }


### PR DESCRIPTION
In https://github.com/pandas-dev/pandas/pull/17293 I messed up the syntax. I
used a glob instead of a regex. According to the docs at
http://asv.readthedocs.io/en/latest/asv.conf.json.html#regressions-thresholds we
want to use a regex. I've actually manually tested this change and verified that
it works.