### PR TITLE
CLN: replace %s syntax with .format in core.tools, algorithms.py, base.py

### DIFF
--- a/pandas/core/algorithms.py
+++ b/pandas/core/algorithms.py
@@ -394,12 +394,12 @@ def isin(comps, values):
 
     if not is_list_like(comps):
         raise TypeError("only list-like objects are allowed to be passed"
-                        " to isin(), you passed a "
-                        "[{0}]".format(type(comps).__name__))
+                        " to isin(), you passed a [{comps_type}]"
+                        .format(comps_type=type(comps).__name__))
     if not is_list_like(values):
         raise TypeError("only list-like objects are allowed to be passed"
-                        " to isin(), you passed a "
-                        "[{0}]".format(type(values).__name__))
+                        " to isin(), you passed a [{values_type}]"
+                        .format(values_type=type(values).__name__))
 
     if not isinstance(values, (ABCIndex, ABCSeries, np.ndarray)):
         values = lib.list_to_object_array(list(values))
@@ -674,7 +674,7 @@ def mode(values):
     try:
         result = np.sort(result)
     except TypeError as e:
-        warn("Unable to sort modes: %s" % e)
+        warn("Unable to sort modes: {error}".format(error=e))
 
     result = _reconstruct_data(result, original.dtype, original)
     return Series(result)

--- a/pandas/core/base.py
+++ b/pandas/core/base.py
@@ -342,24 +342,25 @@ class SelectionMixin(object):
 
     def __getitem__(self, key):
         if self._selection is not None:
-            raise Exception('Column(s) %s already selected' % self._selection)
+            raise Exception('Column(s) {selection} already selected'
+                            .format(selection=self._selection))
 
         if isinstance(key, (list, tuple, ABCSeries, ABCIndexClass,
                             np.ndarray)):
             if len(self.obj.columns.intersection(key)) != len(key):
                 bad_keys = list(set(key).difference(self.obj.columns))
-                raise KeyError("Columns not found: %s"
-                               % str(bad_keys)[1:-1])
+                raise KeyError("Columns not found: {missing}"
+                               .format(missing=str(bad_keys)[1:-1]))
             return self._gotitem(list(key), ndim=2)
 
         elif not getattr(self, 'as_index', False):
             if key not in self.obj.columns:
-                raise KeyError("Column not found: %s" % key)
+                raise KeyError("Column not found: {key}".format(key=key))
             return self._gotitem(key, ndim=2)
 
         else:
             if key not in self.obj:
-                raise KeyError("Column not found: %s" % key)
+                raise KeyError("Column not found: {key}".format(key=key))
             return self._gotitem(key, ndim=1)
 
     def _gotitem(self, key, ndim, subset=None):
@@ -409,7 +410,7 @@ class SelectionMixin(object):
         if f is not None:
             return f(self, *args, **kwargs)
 
-        raise ValueError("{} is an unknown string function".format(arg))
+        raise ValueError("{arg} is an unknown string function".format(arg=arg))
 
     def _aggregate(self, arg, *args, **kwargs):
         """
@@ -484,9 +485,9 @@ class SelectionMixin(object):
                         is_nested_renamer = True
 
                         if k not in obj.columns:
-                            raise SpecificationError('cannot perform renaming '
-                                                     'for {0} with a nested '
-                                                     'dictionary'.format(k))
+                            msg = ('cannot perform renaming for {key} with a '
+                                   'nested dictionary').format(key=k)
+                            raise SpecificationError(msg)
                         nested_renaming_depr(4 + (_level or 0))
 
                     elif isinstance(obj, ABCSeries):

--- a/pandas/core/tools/datetimes.py
+++ b/pandas/core/tools/datetimes.py
@@ -46,7 +46,8 @@ def _infer_tzinfo(start, end):
         if b and b.tzinfo:
             if not (tslib.get_timezone(tz) == tslib.get_timezone(b.tzinfo)):
                 raise AssertionError('Inputs must both have the same timezone,'
-                                     ' {0} != {1}'.format(tz, b.tzinfo))
+                                     ' {timezone1} != {timezone2}'
+                                     .format(timezone1=tz, timezone2=b.tzinfo))
         return tz
 
     tz = None
@@ -491,10 +492,10 @@ def to_datetime(arg, errors='raise', dayfirst=False, yearfirst=False,
             offset = tslib.Timestamp(origin) - tslib.Timestamp(0)
         except tslib.OutOfBoundsDatetime:
             raise tslib.OutOfBoundsDatetime(
-                "origin {} is Out of Bounds".format(origin))
+                "origin {origin} is Out of Bounds".format(origin=origin))
         except ValueError:
-            raise ValueError("origin {} cannot be converted "
-                             "to a Timestamp".format(origin))
+            raise ValueError("origin {origin} cannot be converted "
+                             "to a Timestamp".format(origin=origin))
 
         # convert the offset to the unit of the arg
         # this should be lossless in terms of precision
@@ -590,16 +591,16 @@ def _assemble_from_unit_mappings(arg, errors):
     required = ['year', 'month', 'day']
     req = sorted(list(set(required) - set(unit_rev.keys())))
     if len(req):
-        raise ValueError("to assemble mappings requires at "
-                         "least that [year, month, day] be specified: "
-                         "[{0}] is missing".format(','.join(req)))
+        raise ValueError("to assemble mappings requires at least that "
+                         "[year, month, day] be specified: [{required}] "
+                         "is missing".format(required=','.join(req)))
 
     # keys we don't recognize
     excess = sorted(list(set(unit_rev.keys()) - set(_unit_map.values())))
     if len(excess):
         raise ValueError("extra keys have been passed "
                          "to the datetime assemblage: "
-                         "[{0}]".format(','.join(excess)))
+                         "[{excess}]".format(','.join(excess=excess)))
 
     def coerce(values):
         # we allow coercion to if errors allows
@@ -617,7 +618,7 @@ def _assemble_from_unit_mappings(arg, errors):
         values = to_datetime(values, format='%Y%m%d', errors=errors)
     except (TypeError, ValueError) as e:
         raise ValueError("cannot assemble the "
-                         "datetimes: {0}".format(e))
+                         "datetimes: {error}".format(error=e))
 
     for u in ['h', 'm', 's', 'ms', 'us', 'ns']:
         value = unit_rev.get(u)
@@ -627,8 +628,8 @@ def _assemble_from_unit_mappings(arg, errors):
                                        unit=u,
                                        errors=errors)
             except (TypeError, ValueError) as e:
-                raise ValueError("cannot assemble the datetimes "
-                                 "[{0}]: {1}".format(value, e))
+                raise ValueError("cannot assemble the datetimes [{value}]: "
+                                 "{error}".format(value=value, error=e))
 
     return values
 
@@ -810,8 +811,10 @@ def to_time(arg, format=None, infer_time_format=False, errors='raise'):
                     times.append(datetime.strptime(element, format).time())
                 except (ValueError, TypeError):
                     if errors == 'raise':
-                        raise ValueError("Cannot convert %s to a time with "
-                                         "given format %s" % (element, format))
+                        msg = ("Cannot convert {element} to a time with given "
+                               "format {format}").format(element=element,
+                                                         format=format)
+                        raise ValueError(msg)
                     elif errors == 'ignore':
                         return arg
                     else:
@@ -876,6 +879,7 @@ def ole2datetime(oledt):
     # Excel has a bug where it thinks the date 2/29/1900 exists
     # we just reject any date before 3/1/1900.
     if val < 61:
-        raise ValueError("Value is outside of acceptable range: %s " % val)
+        msg = "Value is outside of acceptable range: {value}".format(value=val)
+        raise ValueError(msg)
 
     return OLE_TIME_ZERO + timedelta(days=val)

--- a/pandas/core/tools/timedeltas.py
+++ b/pandas/core/tools/timedeltas.py
@@ -129,7 +129,8 @@ def _validate_timedelta_unit(arg):
     except:
         if arg is None:
             return 'ns'
-        raise ValueError("invalid timedelta unit {0} provided".format(arg))
+        raise ValueError("invalid timedelta unit {arg} provided"
+                         .format(arg=arg))
 
 
 def _coerce_scalar_to_timedelta_type(r, unit='ns', box=True, errors='raise'):
@@ -161,8 +162,8 @@ def _convert_listlike(arg, unit='ns', box=True, errors='raise', name=None):
     if is_timedelta64_dtype(arg):
         value = arg.astype('timedelta64[ns]')
     elif is_integer_dtype(arg):
-        value = arg.astype('timedelta64[{0}]'.format(
-            unit)).astype('timedelta64[ns]', copy=False)
+        value = arg.astype('timedelta64[{unit}]'.format(unit=unit)).astype(
+            'timedelta64[ns]', copy=False)
     else:
         try:
             value = tslib.array_to_timedelta64(_ensure_object(arg),


### PR DESCRIPTION
Progress towards #16130

- [X] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`

Replaced `%s` syntax with `.format` in core.tools, algorithms.py, base.py. Additionally, made some of the existing positional `.format` code more explicit.