### PR TITLE
CLN: replace %s syntax with .format in missing.py, nanops.py, ops.py

### DIFF
--- a/pandas/core/missing.py
+++ b/pandas/core/missing.py
@@ -88,8 +88,8 @@ def clean_fill_method(method, allow_nearest=False):
         valid_methods.append('nearest')
         expecting = 'pad (ffill), backfill (bfill) or nearest'
     if method not in valid_methods:
-        msg = ('Invalid fill method. Expecting %s. Got %s' %
-               (expecting, method))
+        msg = ('Invalid fill method. Expecting {expecting}. Got {method}'
+               .format(expecting=expecting, method=method))
         raise ValueError(msg)
     return method
 
@@ -104,8 +104,8 @@ def clean_interp_method(method, **kwargs):
         raise ValueError("You must specify the order of the spline or "
                          "polynomial.")
     if method not in valid:
-        raise ValueError("method must be one of {0}."
-                         "Got '{1}' instead.".format(valid, method))
+        raise ValueError("method must be one of {valid}. Got '{method}' "
+                         "instead.".format(valid=valid, method=method))
 
     return method
 
@@ -146,8 +146,10 @@ def interpolate_1d(xvalues, yvalues, method='linear', limit=None,
     valid_limit_directions = ['forward', 'backward', 'both']
     limit_direction = limit_direction.lower()
     if limit_direction not in valid_limit_directions:
-        raise ValueError('Invalid limit_direction: expecting one of %r, got '
-                         '%r.' % (valid_limit_directions, limit_direction))
+        msg = ('Invalid limit_direction: expecting one of {valid!r}, '
+               'got {invalid!r}.')
+        raise ValueError(msg.format(valid=valid_limit_directions,
+                                    invalid=limit_direction))
 
     from pandas import Series
     ys = Series(yvalues)
@@ -248,7 +250,8 @@ def _interpolate_scipy_wrapper(x, y, new_x, method, fill_value=None,
         # TODO: Why is DatetimeIndex being imported here?
         from pandas import DatetimeIndex  # noqa
     except ImportError:
-        raise ImportError('{0} interpolation requires Scipy'.format(method))
+        raise ImportError('{method} interpolation requires SciPy'
+                          .format(method=method))
 
     new_x = np.asarray(new_x)
 
@@ -466,7 +469,8 @@ def pad_1d(values, limit=None, mask=None, dtype=None):
         dtype = values.dtype
     _method = None
     if is_float_dtype(values):
-        _method = getattr(algos, 'pad_inplace_%s' % dtype.name, None)
+        name = 'pad_inplace_{name}'.format(name=dtype.name)
+        _method = getattr(algos, name, None)
     elif is_datetime64_dtype(dtype) or is_datetime64tz_dtype(dtype):
         _method = _pad_1d_datetime
     elif is_integer_dtype(values):
@@ -476,7 +480,8 @@ def pad_1d(values, limit=None, mask=None, dtype=None):
         _method = algos.pad_inplace_object
 
     if _method is None:
-        raise ValueError('Invalid dtype for pad_1d [%s]' % dtype.name)
+        raise ValueError('Invalid dtype for pad_1d [{name}]'
+                         .format(name=dtype.name))
 
     if mask is None:
         mask = isna(values)
@@ -490,7 +495,8 @@ def backfill_1d(values, limit=None, mask=None, dtype=None):
         dtype = values.dtype
     _method = None
     if is_float_dtype(values):
-        _method = getattr(algos, 'backfill_inplace_%s' % dtype.name, None)
+        name = 'backfill_inplace_{name}'.format(name=dtype.name)
+        _method = getattr(algos, name, None)
     elif is_datetime64_dtype(dtype) or is_datetime64tz_dtype(dtype):
         _method = _backfill_1d_datetime
     elif is_integer_dtype(values):
@@ -500,7 +506,8 @@ def backfill_1d(values, limit=None, mask=None, dtype=None):
         _method = algos.backfill_inplace_object
 
     if _method is None:
-        raise ValueError('Invalid dtype for backfill_1d [%s]' % dtype.name)
+        raise ValueError('Invalid dtype for backfill_1d [{name}]'
+                         .format(name=dtype.name))
 
     if mask is None:
         mask = isna(values)
@@ -515,7 +522,8 @@ def pad_2d(values, limit=None, mask=None, dtype=None):
         dtype = values.dtype
     _method = None
     if is_float_dtype(values):
-        _method = getattr(algos, 'pad_2d_inplace_%s' % dtype.name, None)
+        name = 'pad_2d_inplace_{name}'.format(name=dtype.name)
+        _method = getattr(algos, name, None)
     elif is_datetime64_dtype(dtype) or is_datetime64tz_dtype(dtype):
         _method = _pad_2d_datetime
     elif is_integer_dtype(values):
@@ -525,7 +533,8 @@ def pad_2d(values, limit=None, mask=None, dtype=None):
         _method = algos.pad_2d_inplace_object
 
     if _method is None:
-        raise ValueError('Invalid dtype for pad_2d [%s]' % dtype.name)
+        raise ValueError('Invalid dtype for pad_2d [{name}]'
+                         .format(name=dtype.name))
 
     if mask is None:
         mask = isna(values)
@@ -544,7 +553,8 @@ def backfill_2d(values, limit=None, mask=None, dtype=None):
         dtype = values.dtype
     _method = None
     if is_float_dtype(values):
-        _method = getattr(algos, 'backfill_2d_inplace_%s' % dtype.name, None)
+        name = 'backfill_2d_inplace_{name}'.format(name=dtype.name)
+        _method = getattr(algos, name, None)
     elif is_datetime64_dtype(dtype) or is_datetime64tz_dtype(dtype):
         _method = _backfill_2d_datetime
     elif is_integer_dtype(values):
@@ -554,7 +564,8 @@ def backfill_2d(values, limit=None, mask=None, dtype=None):
         _method = algos.backfill_2d_inplace_object
 
     if _method is None:
-        raise ValueError('Invalid dtype for backfill_2d [%s]' % dtype.name)
+        raise ValueError('Invalid dtype for backfill_2d [{name}]'
+                         .format(name=dtype.name))
 
     if mask is None:
         mask = isna(values)

--- a/pandas/core/nanops.py
+++ b/pandas/core/nanops.py
@@ -70,9 +70,8 @@ class disallow(object):
         def _f(*args, **kwargs):
             obj_iter = itertools.chain(args, compat.itervalues(kwargs))
             if any(self.check(obj) for obj in obj_iter):
-                raise TypeError('reduction operation {0!r} not allowed for '
-                                'this dtype'.format(
-                                    f.__name__.replace('nan', '')))
+                msg = 'reduction operation {name!r} not allowed for this dtype'
+                raise TypeError(msg.format(name=f.__name__.replace('nan', '')))
             try:
                 with np.errstate(invalid='ignore'):
                     return f(*args, **kwargs)
@@ -786,7 +785,8 @@ def _ensure_numeric(x):
             try:
                 x = complex(x)
             except Exception:
-                raise TypeError('Could not convert %s to numeric' % str(x))
+                raise TypeError('Could not convert {value!s} to numeric'
+                                .format(value=x))
     return x
 
 # NA-friendly array comparisons


### PR DESCRIPTION
Progress towards #16130
- [X] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`

Replaced `%s` syntax with `.format` in `missing.py`, `nanops.py`, `ops.py`. Additionally, made some of the existing positional `.format` code more explicit.