### PR TITLE
Remove property that re-computed microsecond

### DIFF
--- a/asv_bench/benchmarks/timestamp.py
+++ b/asv_bench/benchmarks/timestamp.py
@@ -1,0 +1,61 @@
+from .pandas_vb_common import *
+from pandas import to_timedelta, Timestamp
+
+
+class TimestampProperties(object):
+    goal_time = 0.2
+
+    def setup(self):
+        self.ts = Timestamp('2017-08-25 08:16:14')
+
+    def time_tz(self):
+        self.ts.tz
+    
+    def time_offset(self):
+        self.ts.offset
+
+    def time_dayofweek(self):
+        self.ts.dayofweek
+
+    def time_weekday_name(self):
+        self.ts.weekday_name
+
+    def time_dayofyear(self):
+        self.ts.dayofyear
+
+    def time_week(self):
+        self.ts.week
+
+    def time_quarter(self):
+        self.ts.quarter
+
+    def time_days_in_month(self):
+        self.ts.days_in_month
+
+    def time_freqstr(self):
+        self.ts.freqstr
+
+    def time_is_month_start(self):
+        self.ts.is_month_start
+
+    def time_is_month_end(self):
+        self.ts.is_month_end
+
+    def time_is_quarter_start(self):
+        self.ts.is_quarter_start
+
+    def time_is_quarter_end(self):
+        self.ts.is_quarter_end
+
+    def time_is_year_start(self):
+        self.ts.is_quarter_end
+
+    def time_is_year_end(self):
+        self.ts.is_quarter_end
+
+    def time_is_leap_year(self):
+        self.ts.is_quarter_end
+
+    def time_microsecond(self):
+        self.ts.microsecond
+

--- a/asv_bench/benchmarks/timestamp.py
+++ b/asv_bench/benchmarks/timestamp.py
@@ -10,7 +10,7 @@ class TimestampProperties(object):
 
     def time_tz(self):
         self.ts.tz
-    
+
     def time_offset(self):
         self.ts.offset
 
@@ -58,4 +58,3 @@ class TimestampProperties(object):
 
     def time_microsecond(self):
         self.ts.microsecond
-

--- a/doc/source/whatsnew/v0.21.0.txt
+++ b/doc/source/whatsnew/v0.21.0.txt
@@ -325,7 +325,7 @@ Performance Improvements
 
 - Improved performance of instantiating :class:`SparseDataFrame` (:issue:`16773`)
 - :attr:`Series.dt` no longer performs frequency inference, yielding a large speedup when accessing the attribute (:issue:`17210`)
-- `Timestamp.microsecond` no longer re-computes on attribute access.
+- :attr:`Timestamp.microsecond` no longer re-computes on attribute access (:issue:`17331`)
 
 .. _whatsnew_0210.bug_fixes:
 

--- a/doc/source/whatsnew/v0.21.0.txt
+++ b/doc/source/whatsnew/v0.21.0.txt
@@ -325,7 +325,7 @@ Performance Improvements
 
 - Improved performance of instantiating :class:`SparseDataFrame` (:issue:`16773`)
 - :attr:`Series.dt` no longer performs frequency inference, yielding a large speedup when accessing the attribute (:issue:`17210`)
-
+- `Timestamp.microsecond` no longer re-computes on attribute access.
 
 .. _whatsnew_0210.bug_fixes:
 

--- a/pandas/_libs/period.pyx
+++ b/pandas/_libs/period.pyx
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 from datetime import datetime, date, timedelta
 import operator
 

--- a/pandas/_libs/tslib.pyx
+++ b/pandas/_libs/tslib.pyx
@@ -549,10 +549,6 @@ class Timestamp(_Timestamp):
     weekofyear = week
 
     @property
-    def microsecond(self):
-        return self._get_field('us')
-
-    @property
     def quarter(self):
         return self._get_field('q')
 


### PR DESCRIPTION
Just accessing the already-existing attribute is about 50-130x faster than re-computing it.  These results are from a 2011-era MBP.

Before:
```
In [1]: import pandas as pd
In [2]: ts = pd.Timestamp.now()
In [3]: %timeit ts.microsecond
The slowest run took 4.69 times longer than the fastest. This could mean that an intermediate result is being cached.
10000 loops, best of 3: 29.7 µs per loop
```

After:
```
In [1]: import pandas as pd
In [2]: ts = pd.Timestamp.now()
In [3]: %timeit ts.microsecond
The slowest run took 8.08 times longer than the fastest. This could mean that an intermediate result is being cached.
1000000 loops, best of 3: 620 ns per loop
```

This accounts for the discrepancy discussed in #17234 (https://github.com/pandas-dev/pandas/pull/17297#pullrequestreview-57686247)

Per requests from @jreback, I'm refraining from moving forward with any other optimizations that this makes possible (e.g. removing the roundabout call to `convert_to_tsobject` from `Timestamp.to_pydatetime`).

- [ ] closes #xxxx
- [ ] tests added / passed
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
