### PR TITLE
ENH: pd.DataFrame.info() to show line numbers GH17304

### DIFF
--- a/doc/source/whatsnew/v0.24.0.txt
+++ b/doc/source/whatsnew/v0.24.0.txt
@@ -71,7 +71,7 @@ Current Behavior:
 Output Formatting Enhancements
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-- `df.info()` now shows line numbers for the columns summary (:issue:`17304`)
+- :func:`DataFrame.info` now shows line numbers for the columns summary (:issue:`17304`)
 
 .. ipython:: python
 

--- a/doc/source/whatsnew/v0.24.0.txt
+++ b/doc/source/whatsnew/v0.24.0.txt
@@ -66,6 +66,35 @@ Current Behavior:
 
     result
 
+.. _whatsnew_0240.enhancements.output_formatting:
+
+Output Formatting Enhancements
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+- `df.info()` now shows line numbers for the columns summary (:issue:`17304`)
+
+.. ipython:: python
+
+    df = pd.DataFrame({
+            'int_col': [1, 2, 3, 4, 5],
+            'text_col': ['alpha', 'beta', 'gamma', 'delta', 'epsilon'],
+            'float_col': [0.0, 0.25, 0.5, 0.75, 1.0]})
+    df.info()
+
+Previous Behavior:
+
+.. code-block:: python
+
+    In [1]: df.info()
+    <class 'pandas.core.frame.DataFrame'>
+    RangeIndex: 5 entries, 0 to 4
+    Data columns (total 3 columns):
+    int_col      5 non-null int64
+    text_col     5 non-null object
+    float_col    5 non-null float64
+    dtypes: float64(1), int64(1), object(1)
+    memory usage: 200.0+ bytes
+
 .. _whatsnew_0240.enhancements.other:
 
 Other Enhancements

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -2121,9 +2121,11 @@ class DataFrame(NDFrame):
         <class 'pandas.core.frame.DataFrame'>
         RangeIndex: 5 entries, 0 to 4
         Data columns (total 3 columns):
-        int_col      5 non-null int64
-        text_col     5 non-null object
-        float_col    5 non-null float64
+         #.  Column       Non-Null Count
+        ---  ------       --------------
+         0   int_col      5 non-null int64
+         1   text_col     5 non-null object
+         2   float_col    5 non-null float64
         dtypes: float64(1), int64(1), object(1)
         memory usage: 200.0+ bytes
 
@@ -2161,9 +2163,11 @@ class DataFrame(NDFrame):
         <class 'pandas.core.frame.DataFrame'>
         RangeIndex: 1000000 entries, 0 to 999999
         Data columns (total 3 columns):
-        column_1    1000000 non-null object
-        column_2    1000000 non-null object
-        column_3    1000000 non-null object
+         #.  Column      Non-Null Count
+        ---  ------      --------------
+         0   column_1    1000000 non-null object
+         1   column_2    1000000 non-null object
+         2   column_3    1000000 non-null object
         dtypes: object(3)
         memory usage: 22.9+ MB
 
@@ -2171,9 +2175,11 @@ class DataFrame(NDFrame):
         <class 'pandas.core.frame.DataFrame'>
         RangeIndex: 1000000 entries, 0 to 999999
         Data columns (total 3 columns):
-        column_1    1000000 non-null object
-        column_2    1000000 non-null object
-        column_3    1000000 non-null object
+         #.  Column      Non-Null Count
+        ---  ------      --------------
+         0   column_1    1000000 non-null object
+         1   column_2    1000000 non-null object
+         2   column_3    1000000 non-null object
         dtypes: object(3)
         memory usage: 188.8 MB
         """
@@ -2210,14 +2216,15 @@ class DataFrame(NDFrame):
         def _verbose_repr():
             lines.append('Data columns (total '
                          '{count} columns):'.format(count=cols_count))
-            space = max([len(pprint_thing(k)) for k in cols])
-            space = max(space, len(pprint_thing('Column'))) + 4
+            space = max(len(pprint_thing(k)) for k in cols)
+            len_column = len(pprint_thing('Column'))
+            space = max(space, len_column) + 4
             space_num = len(pprint_thing(cols_count))
-            space_num = max(space_num, len(pprint_thing('Index'))) + 2
+            len_id = len(pprint_thing(' #.'))
+            space_num = max(space_num, len_id) + 2
             counts = None
 
-            header = _put_str('Index', space_num) + _put_str('Column', space)
-            tmpl = '{count}{dtype}'
+            header = _put_str(' #.', space_num) + _put_str('Column', space)
             if show_counts:
                 counts = self.count()
                 if len(cols) != len(counts):  # pragma: no cover
@@ -2225,10 +2232,17 @@ class DataFrame(NDFrame):
                         'Columns must equal counts '
                         '({cols_count} != {count})'.format(
                             cols_count=cols_count, count=len(counts)))
-                header += 'Non-Null Count'
+                col_header = 'Non-Null Count'
                 tmpl = '{count} non-null {dtype}'
+            else:
+                col_header = 'dtype'
+                tmpl = '{count}{dtype}'
+            header += col_header
 
             lines.append(header)
+            lines.append(_put_str('-' * len_id, space_num) +
+                         _put_str('-' * len_column, space) +
+                         '-' * len(pprint_thing(col_header)))
             dtypes = self.dtypes
             for i, col in enumerate(cols):
                 dtype = dtypes.iloc[i]

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -2121,8 +2121,8 @@ class DataFrame(NDFrame):
         <class 'pandas.core.frame.DataFrame'>
         RangeIndex: 5 entries, 0 to 4
         Data columns (total 3 columns):
-         #.  Column       Non-Null Count
-        ---  ------       --------------
+         #.  Column       Non-Null Count & Dtype
+        ---  ------       ----------------------
          0   int_col      5 non-null int64
          1   text_col     5 non-null object
          2   float_col    5 non-null float64
@@ -2163,8 +2163,8 @@ class DataFrame(NDFrame):
         <class 'pandas.core.frame.DataFrame'>
         RangeIndex: 1000000 entries, 0 to 999999
         Data columns (total 3 columns):
-         #.  Column      Non-Null Count
-        ---  ------      --------------
+         #.  Column      Non-Null Count & Dtype
+        ---  ------      ----------------------
          0   column_1    1000000 non-null object
          1   column_2    1000000 non-null object
          2   column_3    1000000 non-null object
@@ -2175,8 +2175,8 @@ class DataFrame(NDFrame):
         <class 'pandas.core.frame.DataFrame'>
         RangeIndex: 1000000 entries, 0 to 999999
         Data columns (total 3 columns):
-         #.  Column      Non-Null Count
-        ---  ------      --------------
+         #.  Column      Non-Null Count & Dtype
+        ---  ------      ----------------------
          0   column_1    1000000 non-null object
          1   column_2    1000000 non-null object
          2   column_3    1000000 non-null object
@@ -2232,10 +2232,10 @@ class DataFrame(NDFrame):
                         'Columns must equal counts '
                         '({cols_count} != {count})'.format(
                             cols_count=cols_count, count=len(counts)))
-                col_header = 'Non-Null Count'
+                col_header = 'Non-Null Count & Dtype'
                 tmpl = '{count} non-null {dtype}'
             else:
-                col_header = 'dtype'
+                col_header = 'Dtype'
                 tmpl = '{count}{dtype}'
             header += col_header
 

--- a/pandas/tests/frame/test_repr_info.py
+++ b/pandas/tests/frame/test_repr_info.py
@@ -217,13 +217,31 @@ class TestDataFrameReprInfoEtc(TestData):
         <class 'pandas.core.frame.DataFrame'>
         RangeIndex: 2 entries, 0 to 1
         Data columns (total 1 columns):
-         #.  Column    Non-Null Count
-        ---  ------    --------------
+         #.  Column    Non-Null Count & Dtype
+        ---  ------    ----------------------
          0   a         2 non-null int64
         dtypes: int64(1)
         memory usage: {} bytes
         """.format(bytes))
 
+        assert result == expected
+
+    def test_info_without_null_counts(self):
+        df = pd.DataFrame({'a': [1, 2]})
+        buf = StringIO()
+        df.info(buf=buf, null_counts=False)
+        buf.seek(0)
+        lines = buf.readlines()
+        result = ''.join(lines[:-1])
+        expected = textwrap.dedent('''\
+        <class 'pandas.core.frame.DataFrame'>
+        RangeIndex: 2 entries, 0 to 1
+        Data columns (total 1 columns):
+         #.  Column    Dtype
+        ---  ------    -----
+         0   a         int64
+        dtypes: int64(1)
+        ''')
         assert result == expected
 
     def test_info_wide(self):

--- a/pandas/tests/frame/test_repr_info.py
+++ b/pandas/tests/frame/test_repr_info.py
@@ -259,8 +259,8 @@ class TestDataFrameReprInfoEtc(TestData):
         frame.info(buf=io)
         io.seek(0)
         lines = io.readlines()
-        assert 'a    1 non-null int64\n' == lines[3]
-        assert 'a    1 non-null float64\n' == lines[4]
+        assert ' 0     a         1 non-null int64\n' == lines[4]
+        assert ' 1     a         1 non-null float64\n' == lines[5]
 
     def test_info_shows_column_dtypes(self):
         dtypes = ['int64', 'float64', 'datetime64[ns]', 'timedelta64[ns]',
@@ -274,12 +274,13 @@ class TestDataFrameReprInfoEtc(TestData):
         df.info(buf=buf)
         res = buf.getvalue()
         for i, dtype in enumerate(dtypes):
-            name = '%d    %d non-null %s' % (i, n, dtype)
+            name = '%s         %d non-null %s' % (i, n, dtype)
+
             assert name in res
 
     def test_info_max_cols(self):
         df = DataFrame(np.random.randn(10, 5))
-        for len_, verbose in [(5, None), (5, False), (10, True)]:
+        for len_, verbose in [(5, None), (5, False), (11, True)]:
             # For verbose always      ^ setting  ^ summarize ^ full output
             with option_context('max_info_columns', 4):
                 buf = StringIO()
@@ -287,7 +288,7 @@ class TestDataFrameReprInfoEtc(TestData):
                 res = buf.getvalue()
                 assert len(res.strip().split('\n')) == len_
 
-        for len_, verbose in [(10, None), (5, False), (10, True)]:
+        for len_, verbose in [(11, None), (5, False), (11, True)]:
 
             # max_cols no exceeded
             with option_context('max_info_columns', 5):
@@ -296,7 +297,7 @@ class TestDataFrameReprInfoEtc(TestData):
                 res = buf.getvalue()
                 assert len(res.strip().split('\n')) == len_
 
-        for len_, max_cols in [(10, 5), (5, 4)]:
+        for len_, max_cols in [(11, 5), (5, 4)]:
             # setting truncates
             with option_context('max_info_columns', 4):
                 buf = StringIO()

--- a/pandas/tests/frame/test_repr_info.py
+++ b/pandas/tests/frame/test_repr_info.py
@@ -217,7 +217,9 @@ class TestDataFrameReprInfoEtc(TestData):
         <class 'pandas.core.frame.DataFrame'>
         RangeIndex: 2 entries, 0 to 1
         Data columns (total 1 columns):
-        a    2 non-null int64
+         #.  Column    Non-Null Count
+        ---  ------    --------------
+         0   a         2 non-null int64
         dtypes: int64(1)
         memory usage: {} bytes
         """.format(bytes))
@@ -259,8 +261,8 @@ class TestDataFrameReprInfoEtc(TestData):
         frame.info(buf=io)
         io.seek(0)
         lines = io.readlines()
-        assert ' 0     a         1 non-null int64\n' == lines[4]
-        assert ' 1     a         1 non-null float64\n' == lines[5]
+        assert ' 0   a         1 non-null int64\n' == lines[5]
+        assert ' 1   a         1 non-null float64\n' == lines[6]
 
     def test_info_shows_column_dtypes(self):
         dtypes = ['int64', 'float64', 'datetime64[ns]', 'timedelta64[ns]',
@@ -280,7 +282,7 @@ class TestDataFrameReprInfoEtc(TestData):
 
     def test_info_max_cols(self):
         df = DataFrame(np.random.randn(10, 5))
-        for len_, verbose in [(5, None), (5, False), (11, True)]:
+        for len_, verbose in [(5, None), (5, False), (12, True)]:
             # For verbose always      ^ setting  ^ summarize ^ full output
             with option_context('max_info_columns', 4):
                 buf = StringIO()
@@ -288,8 +290,7 @@ class TestDataFrameReprInfoEtc(TestData):
                 res = buf.getvalue()
                 assert len(res.strip().split('\n')) == len_
 
-        for len_, verbose in [(11, None), (5, False), (11, True)]:
-
+        for len_, verbose in [(12, None), (5, False), (12, True)]:
             # max_cols no exceeded
             with option_context('max_info_columns', 5):
                 buf = StringIO()
@@ -297,7 +298,7 @@ class TestDataFrameReprInfoEtc(TestData):
                 res = buf.getvalue()
                 assert len(res.strip().split('\n')) == len_
 
-        for len_, max_cols in [(11, 5), (5, 4)]:
+        for len_, max_cols in [(12, 5), (5, 4)]:
             # setting truncates
             with option_context('max_info_columns', 4):
                 buf = StringIO()


### PR DESCRIPTION
- [x] closes #17304
- [x] tests updated and passed
- [x] passes flake8 diff
- [x] whatsnew entry

Refactored to  `self.columns` and `len(self.columns)`

New output
```
>>> import pandas as pd
>>> df = pd.DataFrame(pd.np.random.rand(4, 10), 
                      columns=['%s%s' % (x, pd.np.random.randint(2, 10)*'a') for x in range(10)])
>>> df.info()
<class 'pandas.core.frame.DataFrame'>
RangeIndex: 4 entries, 0 to 3
Data columns (total 10 columns):
 #.  Column        Non-Null Count & Dtype
---  ------        ----------------------
 0   0aaaaaaaaa    4 non-null float64
 1   1aaaaa        4 non-null float64
 2   2aaaaaa       4 non-null float64
 3   3aaaaaa       4 non-null float64
 4   4aaaaaa       4 non-null float64
 5   5aaaaaaa      4 non-null float64
 6   6aa           4 non-null float64
 7   7aaaaaaa      4 non-null float64
 8   8aaaaaaa      4 non-null float64
 9   9aaaaaaaaa    4 non-null float64
dtypes: float64(10)
memory usage: 392.0 bytes
```