### PR TITLE
CLN: Move test_intersect_str_dates from tests/indexes/test_range.py to test_base.py

### DIFF
--- a/pandas/tests/indexes/test_base.py
+++ b/pandas/tests/indexes/test_base.py
@@ -663,6 +663,15 @@ class TestIndex(Base):
         intersect = first.intersection(second)
         assert intersect.name is None
 
+    def test_intersect_str_dates(self):
+        dt_dates = [datetime(2012, 2, 9), datetime(2012, 2, 22)]
+
+        i1 = Index(dt_dates, dtype=object)
+        i2 = Index(['aa'], dtype=object)
+        res = i2.intersection(i1)
+
+        assert len(res) == 0
+
     def test_union(self):
         first = self.strIndex[5:20]
         second = self.strIndex[:10]

--- a/pandas/tests/indexes/test_range.py
+++ b/pandas/tests/indexes/test_range.py
@@ -639,15 +639,6 @@ class TestRangeIndex(Numeric):
         expected = RangeIndex(0, 0, 1)
         tm.assert_index_equal(result, expected)
 
-    def test_intersect_str_dates(self):
-        dt_dates = [datetime(2012, 2, 9), datetime(2012, 2, 22)]
-
-        i1 = Index(dt_dates, dtype=object)
-        i2 = Index(['aa'], dtype=object)
-        res = i2.intersection(i1)
-
-        assert len(res) == 0
-
     def test_union_noncomparable(self):
         from datetime import datetime, timedelta
         # corner case, non-Int64Index


### PR DESCRIPTION
- [X] closes #17362
- [X] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`

It doesn't seem like `test_intersect_str_dates` has anything to do with `RangeIndex`, so I've moved it from `test_range.py` to `test_base.py`.