### PR TITLE
BUG: Return local Timestamp.weekday_name attribute (#17354)

### DIFF
--- a/doc/source/whatsnew/v0.21.0.txt
+++ b/doc/source/whatsnew/v0.21.0.txt
@@ -399,6 +399,7 @@ Conversion
 - Fixed the return type of ``IntervalIndex.is_non_overlapping_monotonic`` to be a Python ``bool`` for consistency with similar attributes/methods.  Previously returned a ``numpy.bool_``. (:issue:`17237`)
 - Bug in ``IntervalIndex.is_non_overlapping_monotonic`` when intervals are closed on both sides and overlap at a point (:issue:`16560`)
 - Bug in :func:`Series.fillna` returns frame when ``inplace=True`` and ``value`` is dict (:issue:`16156`)
+- Bug in ``Timestamp.weekday_name`` returning a UTC-based weekday name when localized to a timezone (:issue:`17354`)
 
 Indexing
 ^^^^^^^^

--- a/doc/source/whatsnew/v0.21.0.txt
+++ b/doc/source/whatsnew/v0.21.0.txt
@@ -399,7 +399,7 @@ Conversion
 - Fixed the return type of ``IntervalIndex.is_non_overlapping_monotonic`` to be a Python ``bool`` for consistency with similar attributes/methods.  Previously returned a ``numpy.bool_``. (:issue:`17237`)
 - Bug in ``IntervalIndex.is_non_overlapping_monotonic`` when intervals are closed on both sides and overlap at a point (:issue:`16560`)
 - Bug in :func:`Series.fillna` returns frame when ``inplace=True`` and ``value`` is dict (:issue:`16156`)
-- Bug in ``Timestamp.weekday_name`` returning a UTC-based weekday name when localized to a timezone (:issue:`17354`)
+- Bug in :attr:`Timestamp.weekday_name` returning a UTC-based weekday name when localized to a timezone (:issue:`17354`)
 
 Indexing
 ^^^^^^^^

--- a/pandas/_libs/tslib.pyx
+++ b/pandas/_libs/tslib.pyx
@@ -1266,7 +1266,7 @@ cdef class _Timestamp(datetime):
         # same timezone if specified)
         return datetime.__sub__(self, other)
 
-    cpdef _maybe_convert_value_to_local(self):
+    cdef int64_t _maybe_convert_value_to_local(self):
         """Convert UTC i8 value to local i8 value if tz exists"
         val = self.value
         if self.tz is not None and not _is_utc(self.tz):
@@ -1274,11 +1274,15 @@ cdef class _Timestamp(datetime):
         return val
 
     cpdef _get_field(self, field):
+        cdef:
+            int64_t val
         val = self._maybe_convert_value_to_local()
         out = get_date_field(np.array([val], dtype=np.int64), field)
         return int(out[0])
 
     cpdef _get_named_field(self, field):
+        cdef:
+            int64_t val
         val = self._maybe_convert_value_to_local()
         out = get_date_name_field(np.array([val], dtype=np.int64), field)
         return out[0]

--- a/pandas/_libs/tslib.pyx
+++ b/pandas/_libs/tslib.pyx
@@ -1268,6 +1268,8 @@ cdef class _Timestamp(datetime):
 
     cdef int64_t _maybe_convert_value_to_local(self):
         """Convert UTC i8 value to local i8 value if tz exists"""
+        cdef:
+            int64_t val
         val = self.value
         if self.tz is not None and not _is_utc(self.tz):
             val = tz_convert_single(self.value, 'UTC', self.tz)
@@ -1276,15 +1278,19 @@ cdef class _Timestamp(datetime):
     cpdef _get_field(self, field):
         cdef:
             int64_t val
+            ndarray[int64_t] date_array = np.empty(1, dtype=np.int64)
         val = self._maybe_convert_value_to_local()
-        out = get_date_field(np.array([val], dtype=np.int64), field)
+        date_array[0] = val
+        out = get_date_field(date_array, field)
         return int(out[0])
 
     cpdef _get_named_field(self, field):
         cdef:
             int64_t val
+            ndarray[int64_t] date_array = np.empty(1, dtype=np.int64)
         val = self._maybe_convert_value_to_local()
-        out = get_date_name_field(np.array([val], dtype=np.int64), field)
+        date_array[0] = val
+        out = get_date_name_field(date_array, field)
         return out[0]
 
     cpdef _get_start_end_field(self, field):

--- a/pandas/_libs/tslib.pyx
+++ b/pandas/_libs/tslib.pyx
@@ -1278,19 +1278,15 @@ cdef class _Timestamp(datetime):
     cpdef _get_field(self, field):
         cdef:
             int64_t val
-            ndarray[int64_t] date_array = np.empty(1, dtype=np.int64)
         val = self._maybe_convert_value_to_local()
-        date_array[0] = val
-        out = get_date_field(date_array, field)
+        out = get_date_field(np.array([val], dtype=np.int64), field)
         return int(out[0])
 
     cpdef _get_named_field(self, field):
         cdef:
             int64_t val
-            ndarray[int64_t] date_array = np.empty(1, dtype=np.int64)
         val = self._maybe_convert_value_to_local()
-        date_array[0] = val
-        out = get_date_name_field(date_array, field)
+        out = get_date_name_field(np.array([val], dtype=np.int64), field)
         return out[0]
 
     cpdef _get_start_end_field(self, field):

--- a/pandas/_libs/tslib.pyx
+++ b/pandas/_libs/tslib.pyx
@@ -1267,7 +1267,7 @@ cdef class _Timestamp(datetime):
         return datetime.__sub__(self, other)
 
     cdef int64_t _maybe_convert_value_to_local(self):
-        """Convert UTC i8 value to local i8 value if tz exists"
+        """Convert UTC i8 value to local i8 value if tz exists"""
         val = self.value
         if self.tz is not None and not _is_utc(self.tz):
             val = tz_convert_single(self.value, 'UTC', self.tz)

--- a/pandas/tests/scalar/test_timestamp.py
+++ b/pandas/tests/scalar/test_timestamp.py
@@ -555,6 +555,14 @@ class TestTimestamp(object):
         for end in ends:
             assert getattr(ts, end)
 
+    @pytest.mark.parametrize('data, expected',
+                             [(Timestamp('2017-08-28 23:00:00'), 'Monday'),
+                              (Timestamp('2017-08-28 23:00:00', tz='EST'),
+                               'Monday')])
+    def test_weekday_name(self, data, expected):
+        # GH 17354
+        assert data.weekday_name == expected
+
     def test_pprint(self):
         # GH12622
         import pprint


### PR DESCRIPTION
- [x] closes #17354
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry

@jreback created a new method `_get_named_field` based on your [comment](https://github.com/pandas-dev/pandas/issues/17354#issuecomment-325319229) in the issue thread.