### PR TITLE
TST: not correctly using OrderedDict in test_series_apply

### DIFF
--- a/pandas/tests/series/test_apply.py
+++ b/pandas/tests/series/test_apply.py
@@ -317,9 +317,9 @@ class TestSeriesAggregate(TestData):
 
         # test when mixed w/ callable reducers
         result = s.agg(['size', 'count', 'mean'])
-        expected = Series(OrderedDict({'size': 3.0,
-                                       'count': 2.0,
-                                       'mean': 1.5}))
+        expected = Series(OrderedDict([('size', 3.0),
+                                       ('count', 2.0),
+                                       ('mean', 1.5)]))
         assert_series_equal(result[expected.index], expected)
 
 


### PR DESCRIPTION
in Python versions <3.6 this syntax will result in an unordered dict

- [ ] closes #xxxx
- [ ] tests added / passed
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
