### PR TITLE
TST: Enable tests that aren't currently running in indexes/datetimes/test_tools.py

### DIFF
--- a/pandas/core/tools/datetimes.py
+++ b/pandas/core/tools/datetimes.py
@@ -605,7 +605,7 @@ def _assemble_from_unit_mappings(arg, errors):
     if len(excess):
         raise ValueError("extra keys have been passed "
                          "to the datetime assemblage: "
-                         "[{excess}]".format(','.join(excess=excess)))
+                         "[{excess}]".format(excess=','.join(excess)))
 
     def coerce(values):
         # we allow coercion to if errors allows

--- a/pandas/tests/indexes/datetimes/test_tools.py
+++ b/pandas/tests/indexes/datetimes/test_tools.py
@@ -25,7 +25,7 @@ from pandas import (isna, to_datetime, Timestamp, Series, DataFrame,
                     compat)
 
 
-class TimeConversionFormats(object):
+class TestTimeConversionFormats(object):
 
     def test_to_datetime_format(self):
         values = ['1/1/2000', '1/2/2000', '1/3/2000']
@@ -334,7 +334,7 @@ class TestToDatetime(object):
             pd.to_datetime(pd.to_datetime)
 
 
-class ToDatetimeUnit(object):
+class TestToDatetimeUnit(object):
 
     def test_unit(self):
         # GH 11758
@@ -528,7 +528,10 @@ class ToDatetimeUnit(object):
         df2 = DataFrame({'year': [2015, 2016],
                          'month': [2, 20],
                          'day': [4, 5]})
-        with pytest.raises(ValueError):
+
+        msg = ("cannot assemble the datetimes: time data .+ does not "
+               "match format '%Y%m%d' \(match\)")
+        with tm.assert_raises_regex(ValueError, msg):
             to_datetime(df2)
         result = to_datetime(df2, errors='coerce')
         expected = Series([Timestamp('20150204 00:00:00'),
@@ -536,26 +539,31 @@ class ToDatetimeUnit(object):
         assert_series_equal(result, expected)
 
         # extra columns
-        with pytest.raises(ValueError):
+        msg = ("extra keys have been passed to the datetime assemblage: "
+               "\[foo\]")
+        with tm.assert_raises_regex(ValueError, msg):
             df2 = df.copy()
             df2['foo'] = 1
             to_datetime(df2)
 
         # not enough
+        msg = ('to assemble mappings requires at least that \[year, month, '
+               'day\] be specified: \[.+\] is missing')
         for c in [['year'],
                   ['year', 'month'],
                   ['year', 'month', 'second'],
                   ['month', 'day'],
                   ['year', 'day', 'second']]:
-            with pytest.raises(ValueError):
+            with tm.assert_raises_regex(ValueError, msg):
                 to_datetime(df[c])
 
         # duplicates
+        msg = 'cannot assemble with duplicate keys'
         df2 = DataFrame({'year': [2015, 2016],
                          'month': [2, 20],
                          'day': [4, 5]})
         df2.columns = ['year', 'year', 'day']
-        with pytest.raises(ValueError):
+        with tm.assert_raises_regex(ValueError, msg):
             to_datetime(df2)
 
         df2 = DataFrame({'year': [2015, 2016],
@@ -563,7 +571,7 @@ class ToDatetimeUnit(object):
                          'day': [4, 5],
                          'hour': [4, 5]})
         df2.columns = ['year', 'month', 'day', 'day']
-        with pytest.raises(ValueError):
+        with tm.assert_raises_regex(ValueError, msg):
             to_datetime(df2)
 
     def test_dataframe_dtypes(self):
@@ -594,7 +602,7 @@ class ToDatetimeUnit(object):
             to_datetime(df)
 
 
-class ToDatetimeMisc(object):
+class TestToDatetimeMisc(object):
 
     def test_index_to_datetime(self):
         idx = Index(['1/1/2000', '1/2/2000', '1/3/2000'])


### PR DESCRIPTION
- [X] closes #17403
- [X] tests added / passed
- [X] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`

Enabled tests that aren't currently running.  Made a small modification to a typo in `datetimes.py` to make sure all tests pass.  Small modifications to checks in `TestToDatetimeUnit::test_frame` to verify that the raised messages match expectations.

