### PR TITLE
BUG: fillna ignoring axis=1 parameter. #17399

### DIFF
--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -4758,8 +4758,8 @@ class NDFrame(PandasObject, SelectionMixin):
                 return result if not inplace else None
 
             elif not is_list_like(value):
-                new_data = self._data.fillna(value=value, limit=limit,
-                                             inplace=inplace,
+                new_data = self._data.fillna(value=value, axis=axis,
+                                             limit=limit, inplace=inplace,
                                              downcast=downcast)
             elif isinstance(value, DataFrame) and self.ndim == 2:
                 new_data = self.where(self.notna(), value)

--- a/pandas/core/internals.py
+++ b/pandas/core/internals.py
@@ -375,17 +375,14 @@ class Block(PandasObject):
         return result
 
     def fillna(self, value, limit=None, inplace=False, downcast=None,
-               mgr=None):
+               axis=0, mgr=None):
         """ fillna on the block with the value. If we fail, then convert to
         ObjectBlock and try again
         """
         inplace = validate_bool_kwarg(inplace, 'inplace')
 
         if not self._can_hold_na:
-            if inplace:
-                return self
-            else:
-                return self.copy()
+            return self if inplace else self.copy()
 
         mask = isna(self.values)
         if limit is not None:
@@ -396,8 +393,7 @@ class Block(PandasObject):
             if self.ndim > 2:
                 raise NotImplementedError("number of dimensions for 'fillna' "
                                           "is currently limited to 2")
-            mask[mask.cumsum(self.ndim - 1) > limit] = False
-
+            mask[mask.cumsum(int(axis == 0 and self.ndim > 1)) > limit] = False
         # fillna, but if we cannot coerce, then try again as an ObjectBlock
         try:
             values, _, _, _ = self._try_coerce_args(self.values, value)
@@ -2381,8 +2377,8 @@ class CategoricalBlock(NonConsolidatableMixIn, ObjectBlock):
 
         return result
 
-    def fillna(self, value, limit=None, inplace=False, downcast=None,
-               mgr=None):
+    def fillna(self, value, axis=0, limit=None, inplace=False,
+               downcast=None, mgr=None):
         # we may need to upcast our fill to match our dtype
         if limit is not None:
             raise NotImplementedError("specifying a limit for 'fillna' has "
@@ -2859,7 +2855,7 @@ class SparseBlock(NonConsolidatableMixIn, Block):
                                           placement=self.mgr_locs)
 
     def fillna(self, value, limit=None, inplace=False, downcast=None,
-               mgr=None):
+               axis=0, mgr=None):
         # we may need to upcast our fill to match our dtype
         if limit is not None:
             raise NotImplementedError("specifying a limit for 'fillna' has "

--- a/pandas/tests/frame/test_missing.py
+++ b/pandas/tests/frame/test_missing.py
@@ -465,6 +465,36 @@ class TestDataFrameMissingData(TestData):
         expected.values[:3] = np.nan
         tm.assert_frame_equal(result, expected)
 
+    def test_frame_fillna_axis(self):
+        # GH 17399
+        # with limit
+        df = DataFrame(np.random.randn(10, 4))
+        df.iloc[1:4, 1:4] = nan
+        expected = df.copy()
+        expected.iloc[1:4, 1:3] = 0
+        result = df.fillna(value=0, limit=2, axis=1)
+        tm.assert_frame_equal(result, expected)
+
+        # with no limit
+        expected = df.copy()
+        expected.iloc[1:4, 1:4] = 0
+        result = df.fillna(value=0, axis=1)
+        tm.assert_frame_equal(result, expected)
+
+        # with method, limit
+        expected = df.copy()
+        for c in lrange(1, 3):
+            expected.iloc[1:4, c] = expected.iloc[1:4, 0]
+        result = df.fillna(method='ffill', limit=2, axis=1)
+        tm.assert_frame_equal(result, expected)
+        tm.assert_frame_equal(result, df.ffill(limit=2, axis=1))
+
+        # with inplace
+        expected = df.copy()
+        expected.fillna(value=0, limit=2, axis=1, inplace=True)
+        result = df.fillna(value=0, limit=2, axis=1)
+        tm.assert_frame_equal(result, expected)
+
     def test_fillna_skip_certain_blocks(self):
         # don't try to fill boolean, int blocks
 


### PR DESCRIPTION
- [x] closes #17399
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry
