### PR TITLE
DOC/TST: Add examples to MultiIndex.get_level_values + related changes

### DIFF
--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -2533,11 +2533,15 @@ class Index(IndexOpsMixin, PandasObject):
 
         Parameters
         ----------
-        level : int or level name
+        level : int or str
+            ``level`` is either the integer position of the level in the 
+            MultiIndex, or the name of the level.
 
         Returns
         -------
-        self : Index
+        values : Index
+            Because there is only one level when the index has one level,
+            the return value is always self in this case. 
 
         See also
         ---------

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -2534,14 +2534,13 @@ class Index(IndexOpsMixin, PandasObject):
         Parameters
         ----------
         level : int or str
-            ``level`` is either the integer position of the level in the 
+            ``level`` is either the integer position of the level in the
             MultiIndex, or the name of the level.
 
         Returns
         -------
         values : Index
-            Because there is only one level when the index has one level,
-            the return value is always self in this case. 
+            ``self``, as there is only one level in the Index.
 
         See also
         ---------

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -2529,15 +2529,20 @@ class Index(IndexOpsMixin, PandasObject):
     def _get_level_values(self, level):
         """
         Return an Index of values for requested level, equal to the length
-        of the index
+        of the index.
 
         Parameters
         ----------
-        level : int
+        level : int or level name
 
         Returns
         -------
-        values : Index
+        self : Index
+
+        See also
+        ---------
+        pandas.MultiIndex.get_level_values : get values for a level of a
+                                             MultiIndex
         """
 
         self._validate_index_level(level)

--- a/pandas/core/indexes/multi.py
+++ b/pandas/core/indexes/multi.py
@@ -893,6 +893,8 @@ class MultiIndex(Index):
         Returns
         -------
         values : Index
+            ``values`` is a level of this MultiIndex converted to
+            a single :class:`Index` (or subclass thereof).
 
         Examples
         ---------

--- a/pandas/core/indexes/multi.py
+++ b/pandas/core/indexes/multi.py
@@ -882,7 +882,7 @@ class MultiIndex(Index):
     def get_level_values(self, level):
         """
         Return vector of label values for requested level,
-        equal to the length of the index
+        equal to the length of the index.
 
         Parameters
         ----------
@@ -891,6 +891,24 @@ class MultiIndex(Index):
         Returns
         -------
         values : Index
+
+        Examples
+        ---------
+
+        Create a MultiIndex:
+
+        >>> i1 = pd.Index(list('abc'), name='level_1')
+        >>> i2 = pd.CategoricalIndex(list('def'), name='level_2')
+        >>> mi = pd.MultiIndex.from_arrays((i1, i2))
+
+        Get level values by supplying level as either integer or name:
+
+        >>> mi.get_level_values(1)
+        CategoricalIndex(['d', 'e', 'f'], categories=['d', 'e', 'f'],
+                         ordered=False, name='level_2',
+                         dtype='category')
+        >>> mi.get_level_values('level_1')
+        Index(['a', 'b', 'c'], dtype='object', name='level_1')
         """
         level = self._get_level_number(level)
         values = self._get_level_values(level)

--- a/pandas/core/indexes/multi.py
+++ b/pandas/core/indexes/multi.py
@@ -886,7 +886,9 @@ class MultiIndex(Index):
 
         Parameters
         ----------
-        level : int or level name
+        level : int or str
+            ``level`` is either the integer position of the level in the
+            MultiIndex, or the name of the level.
 
         Returns
         -------
@@ -897,18 +899,15 @@ class MultiIndex(Index):
 
         Create a MultiIndex:
 
-        >>> i1 = pd.Index(list('abc'), name='level_1')
-        >>> i2 = pd.CategoricalIndex(list('def'), name='level_2')
-        >>> mi = pd.MultiIndex.from_arrays((i1, i2))
+        >>> mi = pd.MultiIndex.from_arrays((list('abc'), list('def')))
+        >>> mi.names = ['level_1', 'level_2']
 
         Get level values by supplying level as either integer or name:
 
-        >>> mi.get_level_values(1)
-        CategoricalIndex(['d', 'e', 'f'], categories=['d', 'e', 'f'],
-                         ordered=False, name='level_2',
-                         dtype='category')
-        >>> mi.get_level_values('level_1')
+        >>> mi.get_level_values(0)
         Index(['a', 'b', 'c'], dtype='object', name='level_1')
+        >>> mi.get_level_values('level_2')
+        Index(['d', 'e', 'f'], dtype='object', name='level_2')
         """
         level = self._get_level_number(level)
         values = self._get_level_values(level)

--- a/pandas/tests/indexes/test_base.py
+++ b/pandas/tests/indexes/test_base.py
@@ -1438,7 +1438,7 @@ class TestIndex(Base):
         result = self.strIndex.get_level_values(0)
         tm.assert_index_equal(result, self.strIndex)
 
-        # GH 17414
+        # test for name (GH 17414)
         index_with_name = self.strIndex.copy()
         index_with_name.name = 'a'
         result = index_with_name.get_level_values('a')

--- a/pandas/tests/indexes/test_base.py
+++ b/pandas/tests/indexes/test_base.py
@@ -1438,7 +1438,7 @@ class TestIndex(Base):
         result = self.strIndex.get_level_values(0)
         tm.assert_index_equal(result, self.strIndex)
 
-        # test with name
+        # GH 17414
         index_with_name = self.strIndex.copy()
         index_with_name.name = 'a'
         result = index_with_name.get_level_values('a')

--- a/pandas/tests/indexes/test_base.py
+++ b/pandas/tests/indexes/test_base.py
@@ -1438,6 +1438,12 @@ class TestIndex(Base):
         result = self.strIndex.get_level_values(0)
         tm.assert_index_equal(result, self.strIndex)
 
+        # test with name
+        index_with_name = self.strIndex.copy()
+        index_with_name.name = 'a'
+        result = index_with_name.get_level_values('a')
+        tm.assert_index_equal(result, index_with_name)
+
     def test_slice_keep_name(self):
         idx = Index(['a', 'b'], name='asdf')
         assert idx.name == idx[1:].name


### PR DESCRIPTION
- [ ] closes #xxxx
- [x ] tests added / passed
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

I've added examples to ``MultiIndex.get_level_values``. Also I've done some related changes:
* made return value of ``Index._get_level_values``
* Added test for when supplying name to ``Index._get_level_values``. The method could always take level name, but the doc said only integer could be supplied.