### PR TITLE
DOC: Clean-up references to v12 to v14 (both included)

### DIFF
--- a/doc/source/advanced.rst
+++ b/doc/source/advanced.rst
@@ -270,9 +270,6 @@ Passing a list of labels or tuples works similar to reindexing:
 Using slicers
 ~~~~~~~~~~~~~
 
-.. versionadded:: 0.14.0
-
-In 0.14.0 we added a new way to slice multi-indexed objects.
 You can slice a multi-index by providing multiple indexers.
 
 You can provide any of the selectors as if you are indexing by label, see :ref:`Selection by Label <indexing.label>`,
@@ -384,7 +381,7 @@ selecting data at a particular level of a MultiIndex easier.
 
 .. ipython:: python
 
-   # using the slicers (new in 0.14.0)
+   # using the slicers
    df.loc[(slice(None),'one'),:]
 
 You can also select on the columns with :meth:`~pandas.MultiIndex.xs`, by
@@ -397,7 +394,7 @@ providing the axis argument
 
 .. ipython:: python
 
-   # using the slicers (new in 0.14.0)
+   # using the slicers
    df.loc[:,(slice(None),'one')]
 
 :meth:`~pandas.MultiIndex.xs` also allows selection with multiple keys
@@ -408,10 +405,8 @@ providing the axis argument
 
 .. ipython:: python
 
-   # using the slicers (new in 0.14.0)
+   # using the slicers
    df.loc[:,('bar','one')]
-
-.. versionadded:: 0.13.0
 
 You can pass ``drop_level=False`` to :meth:`~pandas.MultiIndex.xs` to retain
 the level that was selected
@@ -742,16 +737,6 @@ Prior to 0.18.0, the ``Int64Index`` would provide the default index for all ``ND
 
 Float64Index
 ~~~~~~~~~~~~
-
-.. note::
-
-   As of 0.14.0, ``Float64Index`` is backed by a native ``float64`` dtype
-   array. Prior to 0.14.0, ``Float64Index`` was backed by an ``object`` dtype
-   array. Using a ``float64`` dtype in the backend speeds up arithmetic
-   operations by about 30x and boolean indexing operations on the
-   ``Float64Index`` itself are about 2x as fast.
-
-.. versionadded:: 0.13.0
 
 By default a ``Float64Index`` will be automatically created when passing floating, or mixed-integer-floating values in index creation.
 This enables a pure label-based slicing paradigm that makes ``[],ix,loc`` for scalar indexing and slicing work exactly the

--- a/doc/source/basics.rst
+++ b/doc/source/basics.rst
@@ -347,7 +347,7 @@ That is because NaNs do not compare as equals:
 
    np.nan == np.nan
 
-So, as of v0.13.1, NDFrames (such as Series, DataFrames, and Panels)
+So, NDFrames (such as Series, DataFrames, and Panels)
 have an :meth:`~DataFrame.equals` method for testing equality, with NaNs in
 corresponding locations treated as equal.
 
@@ -1104,10 +1104,6 @@ Applying with a ``Panel`` will pass a ``Series`` to the applied function. If the
 function returns a ``Series``, the result of the application will be a ``Panel``. If the applied function
 reduces to a scalar, the result of the application will be a ``DataFrame``.
 
-.. note::
-
-   Prior to 0.13.1 ``apply`` on a ``Panel`` would only work on ``ufuncs`` (e.g. ``np.sum/np.max``).
-
 .. ipython:: python
 
    import pandas.util.testing as tm
@@ -1800,8 +1796,6 @@ Series has the :meth:`~Series.searchsorted` method, which works similar to
 smallest / largest values
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. versionadded:: 0.14.0
-
 ``Series`` has the :meth:`~Series.nsmallest` and :meth:`~Series.nlargest` methods which return the
 smallest or largest :math:`n` values. For a large ``Series`` this can be much
 faster than sorting the entire Series and calling ``head(n)`` on the result.
@@ -2167,8 +2161,6 @@ Selecting columns based on ``dtype``
 ------------------------------------
 
 .. _basics.selectdtypes:
-
-.. versionadded:: 0.14.1
 
 The :meth:`~DataFrame.select_dtypes` method implements subsetting of columns
 based on their ``dtype``.

--- a/doc/source/comparison_with_r.rst
+++ b/doc/source/comparison_with_r.rst
@@ -247,8 +247,6 @@ For more details and examples see :ref:`the reshaping documentation
 |subset|_
 ~~~~~~~~~~
 
-.. versionadded:: 0.13
-
 The :meth:`~pandas.DataFrame.query` method is similar to the base R ``subset``
 function. In R you might want to get the rows of a ``data.frame`` where one
 column's values are less than another column's values:
@@ -276,8 +274,6 @@ For more details and examples see :ref:`the query documentation
 
 |with|_
 ~~~~~~~~
-
-.. versionadded:: 0.13
 
 An expression using a data.frame called ``df`` in R with the columns ``a`` and
 ``b`` would be evaluated using ``with`` like so:

--- a/doc/source/cookbook.rst
+++ b/doc/source/cookbook.rst
@@ -818,7 +818,7 @@ The :ref:`Concat <merging.concatenation>` docs. The :ref:`Join <merging.join>` d
    df1 = pd.DataFrame(np.random.randn(6, 3), index=rng, columns=['A', 'B', 'C'])
    df2 = df1.copy()
 
-ignore_index is needed in pandas < v0.13, and depending on df construction
+Depending on df construction, ``ignore_index`` may be needed
 
 .. ipython:: python
 

--- a/doc/source/enhancingperf.rst
+++ b/doc/source/enhancingperf.rst
@@ -214,7 +214,9 @@ the rows, applying our ``integrate_f_typed``, and putting this in the zeros arra
 .. warning::
 
    You can **not pass** a ``Series`` directly as a ``ndarray`` typed parameter
-   to a cython function. Instead pass the actual ``ndarray`` using the ``.values`` attribute of the Series.
+   to a cython function. Instead pass the actual ``ndarray`` using the
+   ``.values`` attribute of the Series. The reason is that the cython
+   definition is specific to an ndarray and not the passed Series.
 
    So, do not do this:
 
@@ -398,10 +400,8 @@ Read more in the `numba docs <http://numba.pydata.org/>`__.
 
 .. _enhancingperf.eval:
 
-Expression Evaluation via :func:`~pandas.eval` (Experimental)
--------------------------------------------------------------
-
-.. versionadded:: 0.13
+Expression Evaluation via :func:`~pandas.eval`
+-----------------------------------------------
 
 The top-level function :func:`pandas.eval` implements expression evaluation of
 :class:`~pandas.Series` and :class:`~pandas.DataFrame` objects.
@@ -538,10 +538,8 @@ Now let's do the same thing but with comparisons:
    of type ``bool`` or ``np.bool_``. Again, you should perform these kinds of
    operations in plain Python.
 
-The ``DataFrame.eval`` method (Experimental)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-.. versionadded:: 0.13
+The ``DataFrame.eval`` method
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 In addition to the top level :func:`pandas.eval` function you can also
 evaluate an expression in the "context" of a :class:`~pandas.DataFrame`.

--- a/doc/source/enhancingperf.rst
+++ b/doc/source/enhancingperf.rst
@@ -213,17 +213,16 @@ the rows, applying our ``integrate_f_typed``, and putting this in the zeros arra
 
 .. warning::
 
-   In 0.13.0 since ``Series`` has internaly been refactored to no longer sub-class ``ndarray``
-   but instead subclass ``NDFrame``, you can **not pass** a ``Series`` directly as a ``ndarray`` typed parameter
+   You can **not pass** a ``Series`` directly as a ``ndarray`` typed parameter
    to a cython function. Instead pass the actual ``ndarray`` using the ``.values`` attribute of the Series.
 
-   Prior to 0.13.0
+   So, do not do this:
 
    .. code-block:: python
 
         apply_integrate_f(df['a'], df['b'], df['N'])
 
-   Use ``.values`` to get the underlying ``ndarray``
+   But rather, use ``.values`` to get the underlying ``ndarray``
 
    .. code-block:: python
 
@@ -646,19 +645,6 @@ whether the query modifies the original frame.
 Local Variables
 ~~~~~~~~~~~~~~~
 
-In pandas version 0.14 the local variable API has changed. In pandas 0.13.x,
-you could refer to local variables the same way you would in standard Python.
-For example,
-
-.. code-block:: python
-
-   df = pd.DataFrame(np.random.randn(5, 2), columns=['a', 'b'])
-   newcol = np.random.randn(len(df))
-   df.eval('b + newcol')
-
-   UndefinedVariableError: name 'newcol' is not defined
-
-As you can see from the exception generated, this syntax is no longer allowed.
 You must *explicitly reference* any local variable that you want to use in an
 expression by placing the ``@`` character in front of the name. For example,
 

--- a/doc/source/groupby.rst
+++ b/doc/source/groupby.rst
@@ -766,8 +766,6 @@ missing values with the ``ffill()`` method.
 Filtration
 ----------
 
-.. versionadded:: 0.12
-
 The ``filter`` method returns a subset of the original object. Suppose we
 want to take only elements that belong to groups with a group sum greater
 than 2.
@@ -857,8 +855,6 @@ next). This enables some operations to be carried out rather succinctly:
 In this example, we chopped the collection of time series into yearly chunks
 then independently called :ref:`fillna <missing_data.fillna>` on the
 groups.
-
-.. versionadded:: 0.14.1
 
 The ``nlargest`` and ``nsmallest`` methods work on ``Series`` style groupbys:
 
@@ -1048,19 +1044,6 @@ Just like for a DataFrame or Series you can call head and tail on a groupby:
 
 This shows the first or last n rows from each group.
 
-.. warning::
-
-   Before 0.14.0 this was implemented with a fall-through apply,
-   so the result would incorrectly respect the as_index flag:
-
-   .. code-block:: python
-
-       >>> g.head(1):  # was equivalent to g.apply(lambda x: x.head(1))
-             A  B
-        A
-        1 0  1  2
-        5 2  5  6
-
 .. _groupby.nth:
 
 Taking the nth row of each group
@@ -1112,8 +1095,6 @@ You can also select multiple rows from each group by specifying multiple nth val
 
 Enumerate group items
 ~~~~~~~~~~~~~~~~~~~~~
-
-.. versionadded:: 0.13.0
 
 To see the order in which each row appears within its group, use the
 ``cumcount`` method:

--- a/doc/source/indexing.rst
+++ b/doc/source/indexing.rst
@@ -1773,7 +1773,7 @@ Evaluation order matters
 
 Furthermore, in chained expressions, the order may determine whether a copy is returned or not.
 If an expression will set values on a copy of a slice, then a ``SettingWithCopy``
-exception will be raised.
+warning will be issued.
 
 You can control the action of a chained assignment via the option ``mode.chained_assignment``,
 which can take the values ``['raise','warn',None]``, where showing a warning is the default.

--- a/doc/source/indexing.rst
+++ b/doc/source/indexing.rst
@@ -248,8 +248,6 @@ as an attribute:
    - In any of these cases, standard indexing will still work, e.g. ``s['1']``, ``s['min']``, and ``s['index']`` will
      access the corresponding element or column.
 
-   - The ``Series/Panel`` accesses are available starting in 0.13.0.
-
 If you are using the IPython environment, you may also use tab-completion to
 see these accessible attributes.
 
@@ -529,7 +527,6 @@ Out of range slice indexes are handled gracefully just as in Python/Numpy.
 .. ipython:: python
 
     # these are allowed in python/numpy.
-    # Only works in Pandas starting from v0.14.0.
     x = list('abcdef')
     x
     x[4:10]
@@ -539,14 +536,8 @@ Out of range slice indexes are handled gracefully just as in Python/Numpy.
     s.iloc[4:10]
     s.iloc[8:10]
 
-.. note::
-
-    Prior to v0.14.0, ``iloc`` would not accept out of bounds indexers for
-    slices, e.g. a value that exceeds the length of the object being indexed.
-
-
-Note that this could result in an empty axis (e.g. an empty DataFrame being
-returned)
+Note that using slices that go out of bounds can result in
+an empty axis (e.g. an empty DataFrame being returned)
 
 .. ipython:: python
 
@@ -744,8 +735,6 @@ Finally, one can also set a seed for ``sample``'s random number generator using 
 
 Setting With Enlargement
 ------------------------
-
-.. versionadded:: 0.13
 
 The ``.loc/[]`` operations can perform enlargement when setting a non-existant key for that axis.
 
@@ -1020,8 +1009,6 @@ partial setting via ``.loc`` (but on the contents rather than the axis labels)
    df2[ df2[1:4] > 0 ] = 3
    df2
 
-.. versionadded:: 0.13
-
 Where can also accept ``axis`` and ``level`` parameters to align the input when
 performing the ``where``.
 
@@ -1063,8 +1050,6 @@ as condition and ``other`` argument.
 
 The :meth:`~pandas.DataFrame.query` Method (Experimental)
 ---------------------------------------------------------
-
-.. versionadded:: 0.13
 
 :class:`~pandas.DataFrame` objects have a :meth:`~pandas.DataFrame.query`
 method that allows selection using an expression.
@@ -1506,8 +1491,6 @@ The name, if set, will be shown in the console display:
 Setting metadata
 ~~~~~~~~~~~~~~~~
 
-.. versionadded:: 0.13.0
-
 Indexes are "mostly immutable", but it is possible to set and change their
 metadata, like the index ``name`` (or, for ``MultiIndex``, ``levels`` and
 ``labels``).
@@ -1790,7 +1773,7 @@ Evaluation order matters
 
 Furthermore, in chained expressions, the order may determine whether a copy is returned or not.
 If an expression will set values on a copy of a slice, then a ``SettingWithCopy``
-exception will be raised (this raise/warn behavior is new starting in 0.13.0)
+exception will be raised.
 
 You can control the action of a chained assignment via the option ``mode.chained_assignment``,
 which can take the values ``['raise','warn',None]``, where showing a warning is the default.

--- a/doc/source/install.rst
+++ b/doc/source/install.rst
@@ -107,7 +107,7 @@ following command::
 
 To install a specific pandas version::
 
-    conda install pandas=0.13.1
+    conda install pandas=0.20.3
 
 To install other packages, IPython for example::
 

--- a/doc/source/io.rst
+++ b/doc/source/io.rst
@@ -3058,13 +3058,17 @@ any pickled pandas object (or any other pickled object) from file:
 
    Loading pickled data received from untrusted sources can be unsafe.
 
-   See: http://docs.python.org/2.7/library/pickle.html
+   See: https://docs.python.org/3.6/library/pickle.html
 
 .. warning::
 
-   Pickled data must
-   be read with ``pd.read_pickle``, rather than the default python ``pickle.load``.
-   See `this question <http://stackoverflow.com/questions/20444593/pandas-compiled-from-source-default-pickle-behavior-changed>`__
+   Several internal refactorings over time have done to pandas while preserving
+   compatibility with pickles created with prior versions. However, in such
+   cases, where there are changes to the data structures between pandas
+   versions, pickled data must be read with ``pd.read_pickle`` to be read
+   correctly, rather than the default python ``pickle.load``. It is therefore
+   recommended to read pickled dataframes, series etc. using
+   ``pd.read_pickle``. See `this question <http://stackoverflow.com/questions/20444593/pandas-compiled-from-source-default-pickle-behavior-changed>`__
    for a detailed explanation.
 
 .. _io.pickle.compression:
@@ -3851,11 +3855,7 @@ create a new table!)
 Iterator
 ++++++++
 
-<<<<<<< HEAD
 You can pass ``iterator=True`` or ``chunksize=number_in_a_chunk``
-=======
-Note that you can pass ``iterator=True`` or ``chunksize=number_in_a_chunk``
->>>>>>> Cleaned references to versions <0.12 in docs
 to ``select`` and ``select_as_multiple`` to return an iterator on the results.
 The default is 50,000 rows returned in a chunk.
 

--- a/doc/source/io.rst
+++ b/doc/source/io.rst
@@ -3878,7 +3878,11 @@ create a new table!)
 Iterator
 ++++++++
 
+<<<<<<< HEAD
 You can pass ``iterator=True`` or ``chunksize=number_in_a_chunk``
+=======
+Note that you can pass ``iterator=True`` or ``chunksize=number_in_a_chunk``
+>>>>>>> Cleaned references to versions <0.12 in docs
 to ``select`` and ``select_as_multiple`` to return an iterator on the results.
 The default is 50,000 rows returned in a chunk.
 

--- a/doc/source/io.rst
+++ b/doc/source/io.rst
@@ -3062,13 +3062,15 @@ any pickled pandas object (or any other pickled object) from file:
 
 .. warning::
 
-   Several internal refactorings over time have done to pandas while preserving
-   compatibility with pickles created with prior versions. However, in such
-   cases, where there are changes to the data structures between pandas
-   versions, pickled data must be read with ``pd.read_pickle`` to be read
-   correctly, rather than the default python ``pickle.load``. It is therefore
-   recommended to read pickled dataframes, series etc. using
-   ``pd.read_pickle``. See `this question <http://stackoverflow.com/questions/20444593/pandas-compiled-from-source-default-pickle-behavior-changed>`__
+   Several internal refactorings have been done while still preserving
+   compatibility with pickles created with older versions of pandas. However,
+   for such cases, pickled dataframes, series etc, must be read with
+   ``pd.read_pickle``, rather than ``pickle.load``.
+
+   See `here <http://pandas.pydata.org/pandas-docs/stable/whatsnew.html#whatsnew-0130-refactoring>`__
+   and `here <http://pandas.pydata.org/pandas-docs/stable/whatsnew.html#whatsnew-0150-refactoring>`__
+   for some examples of compatibility-breaking changes. See
+   `this question <http://stackoverflow.com/questions/20444593/pandas-compiled-from-source-default-pickle-behavior-changed>`__
    for a detailed explanation.
 
 .. _io.pickle.compression:

--- a/doc/source/io.rst
+++ b/doc/source/io.rst
@@ -1310,8 +1310,6 @@ column widths for contiguous columns:
 The parser will take care of extra white spaces around the columns
 so it's ok to have extra separation between the columns in the file.
 
-.. versionadded:: 0.13.0
-
 By default, ``read_fwf`` will try to infer the file's ``colspecs`` by using the
 first 100 rows of the file. It can do it only in cases when the columns are
 aligned and correctly separated by the provided ``delimiter`` (default delimiter
@@ -1407,8 +1405,7 @@ Reading columns with a ``MultiIndex``
 
 By specifying list of row locations for the ``header`` argument, you
 can read in a ``MultiIndex`` for the columns. Specifying non-consecutive
-rows will skip the intervening rows. In order to have the pre-0.13 behavior
-of tupleizing columns, specify ``tupleize_cols=True``.
+rows will skip the intervening rows.
 
 .. ipython:: python
 
@@ -1418,7 +1415,7 @@ of tupleizing columns, specify ``tupleize_cols=True``.
    print(open('mi.csv').read())
    pd.read_csv('mi.csv',header=[0,1,2,3],index_col=[0,1])
 
-Starting in 0.13.0, ``read_csv`` will be able to interpret a more common format
+``read_csv`` is also able to interpret a more common format
 of multi-columns indices.
 
 .. ipython:: python
@@ -2012,8 +2009,6 @@ The speedup is less noticeable for smaller datasets:
 Normalization
 '''''''''''''
 
-.. versionadded:: 0.13.0
-
 pandas provides a utility function to take a dict or list of dicts and *normalize* this semi-structured data
 into a flat table.
 
@@ -2197,8 +2192,6 @@ Reading HTML Content
 
    We **highly encourage** you to read the :ref:`HTML Table Parsing gotchas <io.html.gotchas>`
    below regarding the issues surrounding the BeautifulSoup4/html5lib/lxml parsers.
-
-.. versionadded:: 0.12.0
 
 The top-level :func:`~pandas.io.html.read_html` function can accept an HTML
 string/file/URL and will parse HTML tables into list of pandas DataFrames.
@@ -2653,10 +2646,6 @@ of sheet names can simply be passed to ``read_excel`` with no loss in performanc
     # equivalent using the read_excel function
     data = read_excel('path_to_file.xls', ['Sheet1', 'Sheet2'], index_col=None, na_values=['NA'])
 
-.. versionadded:: 0.12
-
-``ExcelFile`` has been moved to the top level namespace.
-
 .. versionadded:: 0.17
 
 ``read_excel`` can take an ``ExcelFile`` object as input
@@ -2716,9 +2705,6 @@ Using a list to get multiple sheets:
 
 ``read_excel`` can read more than one sheet, by setting ``sheet_name`` to either
 a list of sheet names, a list of sheet positions, or ``None`` to read all sheets.
-
-.. versionadded:: 0.13
-
 Sheets can be specified by sheet index or sheet name, using an integer or string,
 respectively.
 
@@ -2866,9 +2852,9 @@ Files with a ``.xls`` extension will be written using ``xlwt`` and those with a
 ``.xlsx`` extension will be written using ``xlsxwriter`` (if available) or
 ``openpyxl``.
 
-The DataFrame will be written in a way that tries to mimic the REPL output. One
-difference from 0.12.0 is that the ``index_label`` will be placed in the second
-row instead of the first. You can get the previous behaviour by setting the
+The DataFrame will be written in a way that tries to mimic the REPL output.
+The ``index_label`` will be placed in the second
+row instead of the first. You can place it in the first row by setting the
 ``merge_cells`` option in ``to_excel()`` to ``False``:
 
 .. code-block:: python
@@ -2944,8 +2930,6 @@ Added support for Openpyxl >= 2.2
 
 Excel writer engines
 ''''''''''''''''''''
-
-.. versionadded:: 0.13
 
 ``pandas`` chooses an Excel writer via two methods:
 
@@ -3078,8 +3062,7 @@ any pickled pandas object (or any other pickled object) from file:
 
 .. warning::
 
-   Several internal refactorings, 0.13 (:ref:`Series Refactoring <whatsnew_0130.refactoring>`), and 0.15 (:ref:`Index Refactoring <whatsnew_0150.refactoring>`),
-   preserve compatibility with pickles created prior to these versions. However, these must
+   Pickled data must
    be read with ``pd.read_pickle``, rather than the default python ``pickle.load``.
    See `this question <http://stackoverflow.com/questions/20444593/pandas-compiled-from-source-default-pickle-behavior-changed>`__
    for a detailed explanation.
@@ -3150,9 +3133,7 @@ The default is to 'infer
 msgpack
 -------
 
-.. versionadded:: 0.13.0
-
-Starting in 0.13.0, pandas is supporting the ``msgpack`` format for
+pandas supports the ``msgpack`` format for
 object serialization. This is a lightweight portable binary format, similar
 to binary JSON, that is highly space efficient, and provides good performance
 both on the writing (serialization), and reading (deserialization).
@@ -3424,10 +3405,6 @@ This is also true for the major axis of a ``Panel``:
 Fixed Format
 ''''''''''''
 
-.. note::
-
-   This was prior to 0.13.0 the ``Storer`` format.
-
 The examples above show storing using ``put``, which write the HDF5 to ``PyTables`` in a fixed array format, called
 the ``fixed`` format. These types of stores are **not** appendable once written (though you can simply
 remove them and rewrite). Nor are they **queryable**; they must be
@@ -3459,8 +3436,6 @@ with rows and columns. A ``table`` may be appended to in the same or
 other sessions.  In addition, delete & query type operations are
 supported. This format is specified by ``format='table'`` or ``format='t'``
 to ``append`` or ``put`` or ``to_hdf``
-
-.. versionadded:: 0.13
 
 This format can be set as an option as well ``pd.set_option('io.hdf.default_format','table')`` to
 enable ``put/append/to_hdf`` to by default store in the ``table`` format.
@@ -3765,9 +3740,7 @@ space. These are in terms of the total number of rows in a table.
 Using timedelta64[ns]
 +++++++++++++++++++++
 
-.. versionadded:: 0.13
-
-Beginning in 0.13.0, you can store and query using the ``timedelta64[ns]`` type. Terms can be
+You can store and query using the ``timedelta64[ns]`` type. Terms can be
 specified in the format: ``<float>(<unit>)``, where float may be signed (and fractional), and unit can be
 ``D,s,ms,us,ns`` for the timedelta. Here's an example:
 
@@ -3892,8 +3865,6 @@ The default is 50,000 rows returned in a chunk.
       print(df)
 
 .. note::
-
-   .. versionadded:: 0.12.0
 
    You can also use the iterator with ``read_hdf`` which will open, then
    automatically close the store when finished iterating.
@@ -4607,8 +4578,6 @@ included in Python's standard library by default.
 You can find an overview of supported drivers for each SQL dialect in the
 `SQLAlchemy docs <http://docs.sqlalchemy.org/en/latest/dialects/index.html>`__.
 
-.. versionadded:: 0.14.0
-
 If SQLAlchemy is not installed, a fallback is only provided for sqlite (and
 for mysql for backwards compatibility, but this is deprecated and will be
 removed in a future version).
@@ -4940,8 +4909,6 @@ Full documentation can be found `here <https://pandas-gbq.readthedocs.io/>`__
 
 Stata Format
 ------------
-
-.. versionadded:: 0.12.0
 
 .. _io.stata_writer:
 

--- a/doc/source/merging.rst
+++ b/doc/source/merging.rst
@@ -1053,8 +1053,6 @@ As you can see, this drops any rows where there was no match.
 Joining a single Index to a Multi-index
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. versionadded:: 0.14.0
-
 You can join a singly-indexed ``DataFrame`` with a level of a multi-indexed ``DataFrame``.
 The level will match on the name of the index of the singly-indexed frame against
 a level name of the multi-indexed frame.

--- a/doc/source/missing_data.rst
+++ b/doc/source/missing_data.rst
@@ -263,8 +263,6 @@ and ``bfill()`` is equivalent to ``fillna(method='bfill')``
 Filling with a PandasObject
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. versionadded:: 0.12
-
 You can also fillna using a dict or Series that is alignable. The labels of the dict or index of the Series
 must match the columns of the frame you wish to fill. The
 use case of this is to fill a DataFrame with the mean of that column.
@@ -279,8 +277,6 @@ use case of this is to fill a DataFrame with the mean of that column.
 
         dff.fillna(dff.mean())
         dff.fillna(dff.mean()['B':'C'])
-
-.. versionadded:: 0.13
 
 Same result as above, but is aligning the 'fill' value which is
 a Series in this case.
@@ -319,11 +315,6 @@ examined :ref:`in the API <api.dataframe.missing>`.
 
 Interpolation
 ~~~~~~~~~~~~~
-
-.. versionadded:: 0.13.0
-
-  :meth:`~pandas.DataFrame.interpolate`, and :meth:`~pandas.Series.interpolate` have
-  revamped interpolation methods and functionality.
 
 .. versionadded:: 0.17.0
 

--- a/doc/source/options.rst
+++ b/doc/source/options.rst
@@ -306,7 +306,7 @@ display.float_format                None         The callable should accept a fl
                                                  See core.format.EngFormatter for an example.
 display.large_repr                  truncate     For DataFrames exceeding max_rows/max_cols,
                                                  the repr (and HTML repr) can show
-                                                 a truncated table (the default from 0.13),
+                                                 a truncated table (the default),
                                                  or switch to the view from df.info()
                                                  (the behaviour in earlier versions of pandas).
                                                  allowable settings, ['truncate', 'info']

--- a/doc/source/text.rst
+++ b/doc/source/text.rst
@@ -211,8 +211,6 @@ Extracting Substrings
 Extract first match in each subject (extract)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-.. versionadded:: 0.13.0
-
 .. warning::
 
    In version 0.18.0, ``extract`` gained the ``expand`` argument. When

--- a/doc/source/timedeltas.rst
+++ b/doc/source/timedeltas.rst
@@ -242,8 +242,6 @@ Numeric reduction operation for ``timedelta64[ns]`` will return ``Timedelta`` ob
 Frequency Conversion
 --------------------
 
-.. versionadded:: 0.13
-
 Timedelta Series, ``TimedeltaIndex``, and ``Timedelta`` scalars can be converted to other 'frequencies' by dividing by another timedelta,
 or by astyping to a specific timedelta type. These operations yield Series and propagate ``NaT`` -> ``nan``.
 Note that division by the numpy scalar is true division, while astyping is equivalent of floor division.

--- a/doc/source/timeseries.rst
+++ b/doc/source/timeseries.rst
@@ -177,7 +177,7 @@ you can pass the ``dayfirst`` flag:
 
 .. note::
    Specifying a ``format`` argument will potentially speed up the conversion
-   considerably and on versions later then 0.13.0 explicitly specifying
+   considerably and explicitly specifying
    a format string of '%Y%m%d' takes a faster path still.
 
 If you pass a single string to ``to_datetime``, it returns single ``Timestamp``.
@@ -1946,9 +1946,11 @@ These can easily be converted to a ``PeriodIndex``
 Time Zone Handling
 ------------------
 
-Pandas provides rich support for working with timestamps in different time zones using ``pytz`` and ``dateutil`` libraries.
-``dateutil`` support is new in 0.14.1 and currently only supported for fixed offset and tzfile zones. The default library is ``pytz``.
-Support for ``dateutil`` is provided for compatibility with other applications e.g. if you use ``dateutil`` in other python packages.
+Pandas provides rich support for working with timestamps in different time
+zones using ``pytz`` and ``dateutil`` libraries. ``dateutil`` currently is only
+supported for fixed offset and tzfile zones. The default library is ``pytz``.
+Support for ``dateutil`` is provided for compatibility with other
+applications e.g. if you use ``dateutil`` in other python packages.
 
 Working with Time Zones
 ~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/source/visualization.rst
+++ b/doc/source/visualization.rst
@@ -512,8 +512,6 @@ Compare to:
 Area Plot
 ~~~~~~~~~
 
-.. versionadded:: 0.14
-
 You can create area plots with :meth:`Series.plot.area` and :meth:`DataFrame.plot.area`.
 Area plots are stacked by default. To produce stacked area plot, each column must be either all positive or all negative values.
 
@@ -549,8 +547,6 @@ To produce an unstacked plot, pass ``stacked=False``. Alpha value is set to 0.5 
 
 Scatter Plot
 ~~~~~~~~~~~~
-
-.. versionadded:: 0.13
 
 Scatter plot can be drawn by using the :meth:`DataFrame.plot.scatter` method.
 Scatter plot requires numeric columns for x and y axis.
@@ -619,8 +615,6 @@ See the :meth:`scatter <matplotlib.axes.Axes.scatter>` method and the
 Hexagonal Bin Plot
 ~~~~~~~~~~~~~~~~~~
 
-.. versionadded:: 0.14
-
 You can create hexagonal bin plots with :meth:`DataFrame.plot.hexbin`.
 Hexbin plots can be a useful alternative to scatter plots if your data are
 too dense to plot each point individually.
@@ -681,8 +675,6 @@ See the :meth:`hexbin <matplotlib.axes.Axes.hexbin>` method and the
 
 Pie plot
 ~~~~~~~~
-
-.. versionadded:: 0.14
 
 You can create a pie plot with :meth:`DataFrame.plot.pie` or :meth:`Series.plot.pie`.
 If your data includes any ``NaN``, they will be automatically filled with 0.
@@ -1365,8 +1357,6 @@ Another option is passing an ``ax`` argument to :meth:`Series.plot` to plot on a
 Plotting With Error Bars
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. versionadded:: 0.14
-
 Plotting with error bars is now supported in the :meth:`DataFrame.plot` and :meth:`Series.plot`
 
 Horizontal and vertical errorbars can be supplied to the ``xerr`` and ``yerr`` keyword arguments to :meth:`~DataFrame.plot()`. The error values can be specified using a variety of formats.
@@ -1406,8 +1396,6 @@ Here is an example of one way to easily plot group means with standard deviation
 
 Plotting Tables
 ~~~~~~~~~~~~~~~
-
-.. versionadded:: 0.14
 
 Plotting with matplotlib table is now supported in  :meth:`DataFrame.plot` and :meth:`Series.plot` with a ``table`` keyword. The ``table`` keyword can accept ``bool``, :class:`DataFrame` or :class:`Series`. The simple way to draw a table is to specify ``table=True``. Data will be transposed to meet matplotlib's default layout.
 
@@ -1584,10 +1572,6 @@ indices, thereby extending date and time support to practically all plot types
 available in matplotlib. Although this formatting does not provide the same
 level of refinement you would get when plotting via pandas, it can be faster
 when plotting a large number of points.
-
-.. note::
-
-    The speed up for large data sets only applies to pandas 0.14.0 and later.
 
 .. ipython:: python
    :suppress:


### PR DESCRIPTION
- [ ] closes #xxxx
- [ ] tests added / passed
- [x ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

This is a continution of #17375 and cleans up references to old versions of pandas in the documentation.

Somme issues, I'd appreciate input on:
* In ``enhancingperf.rst`` there is under "Expression Evaluation via :func:`~pandas.eval` (Experimental)" and "The ``DataFrame.eval`` method (Experimental)" a line ``..versionadded:: 0.13``.
  In general I think it's a bit weird that something introduced back in 0.13 still is marked as experimental. I've let the versionadded stay for now, to somehow mark that ``eval`` is quite old even though it is experimental. Are there thoughts whether ``eval`` should still be marked experimental?