### PR TITLE
Added line decoding before sniffing at PythonParser#_make_reader

### DIFF
--- a/pandas/io/parsers.py
+++ b/pandas/io/parsers.py
@@ -2125,6 +2125,8 @@ class PythonParser(ParserBase):
 
                 self.pos += 1
                 self.line_pos += 1
+                if self.encoding is not None:
+                    line = line.decode(self.encoding)
                 sniffed = csv.Sniffer().sniff(line)
                 dia.delimiter = sniffed.delimiter
                 if self.encoding is not None:


### PR DESCRIPTION
Fixes issue when reading CSV from unencoded IO stream (i.e. WSGI request body). CSV sniffer uses regexp internally and crashes with `TypeError: cannot use a string pattern on a bytes-like object`.
This change fixes the issue. Better way, however would be to add proper encoding support to `csv.Sniffer()`.

- [ ] closes #xxxx
- [ ] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
