### PR TITLE
BUG: Plotting Timedelta on y-axis #16953

### DIFF
--- a/doc/source/whatsnew/v0.21.0.txt
+++ b/doc/source/whatsnew/v0.21.0.txt
@@ -400,7 +400,7 @@ I/O
 Plotting
 ^^^^^^^^
 - Bug in plotting methods using ``secondary_y`` and ``fontsize`` not setting secondary axis font size (:issue:`12565`)
-
+- Bug when plotting Timedelta and Datetime on y-axis (:issue:`16953`)
 
 Groupby/Resample/Rolling
 ^^^^^^^^^^^^^^^^^^^^^^^^

--- a/doc/source/whatsnew/v0.21.0.txt
+++ b/doc/source/whatsnew/v0.21.0.txt
@@ -400,7 +400,7 @@ I/O
 Plotting
 ^^^^^^^^
 - Bug in plotting methods using ``secondary_y`` and ``fontsize`` not setting secondary axis font size (:issue:`12565`)
-- Bug when plotting Timedelta and Datetime on y-axis (:issue:`16953`)
+- Bug when plotting ``timedelta`` and ``datetime`` dtypes on y-axis (:issue:`16953`)
 
 Groupby/Resample/Rolling
 ^^^^^^^^^^^^^^^^^^^^^^^^

--- a/pandas/plotting/_core.py
+++ b/pandas/plotting/_core.py
@@ -344,7 +344,9 @@ class MPLPlot(object):
 
         # GH16953
         data = data._convert(datetime=True, timedelta=True)
-        numeric_data = data.select_dtypes(include=[np.number, "datetime", "timedelta"])
+        numeric_data = data.select_dtypes(include=[np.number,
+                                                   "datetime",
+                                                   "timedelta"])
 
         try:
             is_empty = numeric_data.empty

--- a/pandas/plotting/_core.py
+++ b/pandas/plotting/_core.py
@@ -342,7 +342,9 @@ class MPLPlot(object):
                 label = 'None'
             data = data.to_frame(name=label)
 
-        numeric_data = data._convert(datetime=True)._get_numeric_data()
+        # fix of issue #16953
+        data = data.select_dtypes(include=[np.number, "datetime", "timedelta"])
+        numeric_data = data._convert(datetime=True)
 
         try:
             is_empty = numeric_data.empty

--- a/pandas/plotting/_core.py
+++ b/pandas/plotting/_core.py
@@ -342,10 +342,12 @@ class MPLPlot(object):
                 label = 'None'
             data = data.to_frame(name=label)
 
-        # GH16953
+        # GH16953, _convert is needed as fallback, for ``Series``
+        # with ``dtype == object``
         data = data._convert(datetime=True, timedelta=True)
         numeric_data = data.select_dtypes(include=[np.number,
                                                    "datetime",
+                                                   "datetimetz",
                                                    "timedelta"])
 
         try:

--- a/pandas/plotting/_core.py
+++ b/pandas/plotting/_core.py
@@ -342,7 +342,7 @@ class MPLPlot(object):
                 label = 'None'
             data = data.to_frame(name=label)
 
-        # fix of issue #16953
+        # GH16953
         data = data.select_dtypes(include=[np.number, "datetime", "timedelta"])
         numeric_data = data._convert(datetime=True)
 

--- a/pandas/plotting/_core.py
+++ b/pandas/plotting/_core.py
@@ -343,8 +343,8 @@ class MPLPlot(object):
             data = data.to_frame(name=label)
 
         # GH16953
-        data = data.select_dtypes(include=[np.number, "datetime", "timedelta"])
-        numeric_data = data._convert(datetime=True)
+        data = data._convert(datetime=True, timedelta=True)
+        numeric_data = data.select_dtypes(include=[np.number, "datetime", "timedelta"])
 
         try:
             is_empty = numeric_data.empty

--- a/pandas/tests/plotting/test_frame.py
+++ b/pandas/tests/plotting/test_frame.py
@@ -413,7 +413,8 @@ class TestDataFramePlots(TestPlotBase):
         with pytest.raises(TypeError):
             testdata.plot(y="text")
 
-    @pytest.mark.xfail
+    @pytest.mark.xfail(reason='not support for period, categorical, '
+                       'datetime_mixed_tz')
     def test_subplots_timeseries_y_axis_not_supported(self):
         """
         This test will fail for:

--- a/pandas/tests/plotting/test_frame.py
+++ b/pandas/tests/plotting/test_frame.py
@@ -382,20 +382,24 @@ class TestDataFramePlots(TestPlotBase):
 
     def test_subplots_timeseries_y_axis(self):
         # GH16953
-        testdata = DataFrame({"numeric": np.array([1, 2, 5]),
-                              "timedelta": [pd.Timedelta(10, unit="s"),
-                                            pd.Timedelta(10, unit="m"),
-                                            pd.Timedelta(10, unit="h")],
-                              "datetime": [pd.to_datetime("2017-08-01 00:00:00"),
-                                           pd.to_datetime("2017-08-01 02:00:00"),
-                                           pd.to_datetime("2017-08-02 00:00:00")],
-                              "text": ["This", "should", "fail"]})
+        data = {"numeric": np.array([1, 2, 5]),
+                "timedelta": [pd.Timedelta(10, unit="s"),
+                              pd.Timedelta(10, unit="m"),
+                              pd.Timedelta(10, unit="h")],
+                "datetime": [pd.to_datetime("2017-08-01 00:00:00"),
+                             pd.to_datetime("2017-08-01 02:00:00"),
+                             pd.to_datetime("2017-08-02 00:00:00")],
+                "text": ["This", "should", "fail"]}
+        testdata = DataFrame(data)
         ax_numeric = testdata.plot(y="numeric")
-        assert (ax_numeric.get_lines()[0].get_data()[1] == testdata["numeric"].values).all()
+        assert (ax_numeric.get_lines()[0].get_data()[1] ==
+                testdata["numeric"].values).all()
         ax_timedelta = testdata.plot(y="timedelta")
-        assert (ax_timedelta.get_lines()[0].get_data()[1] == testdata["timedelta"].values).all()
+        assert (ax_timedelta.get_lines()[0].get_data()[1] ==
+                testdata["timedelta"].values).all()
         ax_datetime = testdata.plot(y="datetime")
-        assert (ax_datetime.get_lines()[0].get_data()[1] == testdata["datetime"].values).all()
+        assert (ax_datetime.get_lines()[0].get_data()[1] ==
+                testdata["datetime"].values).all()
         with pytest.raises(TypeError):
             testdata.plot(y="text")
 

--- a/pandas/tests/plotting/test_frame.py
+++ b/pandas/tests/plotting/test_frame.py
@@ -380,6 +380,25 @@ class TestDataFramePlots(TestPlotBase):
                 self._check_ticks_props(ax, xlabelsize=7, xrot=45,
                                         ylabelsize=7)
 
+    def test_subplots_timeseries_y_axis(self):
+        # tests for fix of issue #16953
+        testdata = DataFrame({"numeric": np.array([1, 2, 5]),
+                              "timedelta": [pd.Timedelta(10, unit="s"),
+                                            pd.Timedelta(10, unit="m"),
+                                            pd.Timedelta(10, unit="h")],
+                              "datetime": [pd.to_datetime("2017-08-01 00:00:00"),
+                                           pd.to_datetime("2017-08-01 02:00:00"),
+                                           pd.to_datetime("2017-08-02 00:00:00")],
+                              "text": ["This", "should", "fail"]})
+        ax_numeric = testdata.plot(y="numeric")
+        assert (ax_numeric.get_lines()[0].get_data()[1] == testdata["numeric"].values).all()
+        ax_timedelta = testdata.plot(y="timedelta")
+        assert (ax_timedelta.get_lines()[0].get_data()[1] == testdata["timedelta"].values).all()
+        ax_datetime = testdata.plot(y="datetime")
+        assert (ax_datetime.get_lines()[0].get_data()[1] == testdata["datetime"].values).all()
+        with pytest.raises(TypeError):
+            testdata.plot(y="text")
+
     @pytest.mark.slow
     def test_subplots_layout(self):
         # GH 6667

--- a/pandas/tests/plotting/test_frame.py
+++ b/pandas/tests/plotting/test_frame.py
@@ -381,7 +381,7 @@ class TestDataFramePlots(TestPlotBase):
                                         ylabelsize=7)
 
     def test_subplots_timeseries_y_axis(self):
-        # tests for fix of issue #16953
+        # GH16953
         testdata = DataFrame({"numeric": np.array([1, 2, 5]),
                               "timedelta": [pd.Timedelta(10, unit="s"),
                                             pd.Timedelta(10, unit="m"),

--- a/pandas/tests/plotting/test_frame.py
+++ b/pandas/tests/plotting/test_frame.py
@@ -383,25 +383,77 @@ class TestDataFramePlots(TestPlotBase):
     def test_subplots_timeseries_y_axis(self):
         # GH16953
         data = {"numeric": np.array([1, 2, 5]),
-                "timedelta": [pd.Timedelta(10, unit="s"),
+                "timedelta": [pd.Timedelta(-10, unit="s"),
                               pd.Timedelta(10, unit="m"),
                               pd.Timedelta(10, unit="h")],
-                "datetime": [pd.to_datetime("2017-08-01 00:00:00"),
-                             pd.to_datetime("2017-08-01 02:00:00"),
-                             pd.to_datetime("2017-08-02 00:00:00")],
+                "datetime_no_tz": [pd.to_datetime("2017-08-01 00:00:00"),
+                                   pd.to_datetime("2017-08-01 02:00:00"),
+                                   pd.to_datetime("2017-08-02 00:00:00")],
+                "datetime_all_tz": [pd.to_datetime("2017-08-01 00:00:00",
+                                                   utc=True),
+                                    pd.to_datetime("2017-08-01 02:00:00",
+                                                   utc=True),
+                                    pd.to_datetime("2017-08-02 00:00:00",
+                                                   utc=True)],
                 "text": ["This", "should", "fail"]}
         testdata = DataFrame(data)
+
         ax_numeric = testdata.plot(y="numeric")
         assert (ax_numeric.get_lines()[0].get_data()[1] ==
                 testdata["numeric"].values).all()
         ax_timedelta = testdata.plot(y="timedelta")
         assert (ax_timedelta.get_lines()[0].get_data()[1] ==
                 testdata["timedelta"].values).all()
-        ax_datetime = testdata.plot(y="datetime")
-        assert (ax_datetime.get_lines()[0].get_data()[1] ==
-                testdata["datetime"].values).all()
+        ax_datetime_no_tz = testdata.plot(y="datetime_no_tz")
+        assert (ax_datetime_no_tz.get_lines()[0].get_data()[1] ==
+                testdata["datetime_no_tz"].values).all()
+        ax_datetime_all_tz = testdata.plot(y="datetime_all_tz")
+        assert (ax_datetime_all_tz.get_lines()[0].get_data()[1] ==
+                testdata["datetime_all_tz"].values).all()
         with pytest.raises(TypeError):
             testdata.plot(y="text")
+
+    @pytest.mark.xfail
+    def test_subplots_timeseries_y_axis_not_supported(self):
+        """
+        This test will fail for:
+            period:
+                since period isn't yet implemented in ``select_dtypes``
+                and because it will need a custom value converter +
+                tick formater (as was done for x-axis plots)
+
+            categorical:
+                 because it will need a custom value converter +
+                 tick formater (also doesn't work for x-axis, as of now)
+
+            datetime_mixed_tz:
+                because of the way how pandas handels ``Series`` of
+                ``datetime`` objects with different timezone,
+                generally converting ``datetime`` objects in a tz-aware
+                form could help with this problem
+        """
+        data = {"numeric": np.array([1, 2, 5]),
+                "period": [pd.Period('2017-08-01 00:00:00', freq='H'),
+                           pd.Period('2017-08-01 02:00', freq='H'),
+                           pd.Period('2017-08-02 00:00:00', freq='H')],
+                "categorical": pd.Categorical(["c", "b", "a"],
+                                              categories=["a", "b", "c"],
+                                              ordered=False),
+                "datetime_mixed_tz": [pd.to_datetime("2017-08-01 00:00:00",
+                                                     utc=True),
+                                      pd.to_datetime("2017-08-01 02:00:00"),
+                                      pd.to_datetime("2017-08-02 00:00:00")]}
+        testdata = pd.DataFrame(data)
+        ax_period = testdata.plot(x="numeric", y="period")
+        assert (ax_period.get_lines()[0].get_data()[1] ==
+                testdata["period"].values).all()
+        ax_categorical = testdata.plot(x="numeric", y="categorical")
+        assert (ax_categorical.get_lines()[0].get_data()[1] ==
+                testdata["categorical"].values).all()
+        ax_datetime_mixed_tz = testdata.plot(x="numeric",
+                                             y="datetime_mixed_tz")
+        assert (ax_datetime_mixed_tz.get_lines()[0].get_data()[1] ==
+                testdata["datetime_mixed_tz"].values).all()
 
     @pytest.mark.slow
     def test_subplots_layout(self):


### PR DESCRIPTION
- [x] closes #16953 
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`

This fixes the issue with a TypeError being raised if the y-data were of type Timedelta or Datetime.
The plot of Timedelta doesn't look pretty since it is converted to ns representation, but matplotlib has already an open issue for that.

PS: Greetings to the people from the EuroSciPy 2017 sprints ^^
