### PR TITLE
DOC: cleaned references to pandas v0.15 and v0.16 in docs

### DIFF
--- a/doc/source/10min.rst
+++ b/doc/source/10min.rst
@@ -655,7 +655,7 @@ the quarter end:
 Categoricals
 ------------
 
-Since version 0.15, pandas can include categorical data in a ``DataFrame``. For full docs, see the
+pandas can include categorical data in a ``DataFrame``. For full docs, see the
 :ref:`categorical introduction <categorical>` and the :ref:`API documentation <api.categorical>`.
 
 .. ipython:: python

--- a/doc/source/advanced.rst
+++ b/doc/source/advanced.rst
@@ -26,12 +26,6 @@ See the :ref:`Indexing and Selecting Data <indexing>` for general indexing docum
    should be avoided.  See :ref:`Returning a View versus Copy
    <indexing.view_versus_copy>`
 
-.. warning::
-
-   In 0.15.0 ``Index`` has internally been refactored to no longer sub-class ``ndarray``
-   but instead subclass ``PandasObject``, similarly to the rest of the pandas objects. This should be
-   a transparent change with only very limited API implications (See the :ref:`Internal Refactoring <whatsnew_0150.refactoring>`)
-
 See the :ref:`cookbook<cookbook.selection>` for some advanced strategies
 
 .. _advanced.hierarchical:
@@ -638,12 +632,9 @@ In the following sub-sections we will highlite some other index types.
 CategoricalIndex
 ~~~~~~~~~~~~~~~~
 
-.. versionadded:: 0.16.1
-
-We introduce a ``CategoricalIndex``, a new type of index object that is useful for supporting
-indexing with duplicates. This is a container around a ``Categorical`` (introduced in v0.15.0)
-and allows efficient indexing and storage of an index with a large number of duplicated elements. Prior to 0.16.1,
-setting the index of a ``DataFrame/Series`` with a ``category`` dtype would convert this to regular object-based ``Index``.
+``CategoricalIndex`` is a type of index that is useful for supporting
+indexing with duplicates. This is a container around a ``Categorical``
+and allows efficient indexing and storage of an index with a large number of duplicated elements.
 
 .. ipython:: python
 

--- a/doc/source/basics.rst
+++ b/doc/source/basics.rst
@@ -719,8 +719,6 @@ on an entire ``DataFrame`` or ``Series``, row- or column-wise, or elementwise.
 Tablewise Function Application
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. versionadded:: 0.16.2
-
 ``DataFrames`` and ``Series`` can of course just be passed into functions.
 However, if the function needs to be called in a chain, consider using the :meth:`~DataFrame.pipe` method.
 Compare the following
@@ -1860,8 +1858,10 @@ dtypes
 ------
 
 The main types stored in pandas objects are ``float``, ``int``, ``bool``,
-``datetime64[ns]`` and ``datetime64[ns, tz]`` (in >= 0.17.0), ``timedelta[ns]``, ``category`` (in >= 0.15.0), and ``object``. In addition these dtypes
-have item sizes, e.g. ``int64`` and ``int32``. See :ref:`Series with TZ <timeseries.timezone_series>` for more detail on ``datetime64[ns, tz]`` dtypes.
+``datetime64[ns]`` and ``datetime64[ns, tz]`` (in >= 0.17.0), ``timedelta[ns]``,
+``category`` and ``object``. In addition these dtypes have item sizes, e.g.
+``int64`` and ``int32``. See :ref:`Series with TZ <timeseries.timezone_series>`
+for more detail on ``datetime64[ns, tz]`` dtypes.
 
 A convenient :attr:`~DataFrame.dtypes` attribute for DataFrames returns a Series with the data type of each column.
 

--- a/doc/source/categorical.rst
+++ b/doc/source/categorical.rst
@@ -16,13 +16,6 @@
 Categorical Data
 ****************
 
-.. versionadded:: 0.15
-
-.. note::
-    While there was `pandas.Categorical` in earlier versions, the ability to use
-    categorical data in `Series` and `DataFrame` is new.
-
-
 This is an introduction to pandas categorical data type, including a short comparison
 with R's ``factor``.
 
@@ -294,10 +287,6 @@ Sorting and Order
 -----------------
 
 .. _categorical.sort:
-
-.. warning::
-
-   The default for construction has changed in v0.16.0 to ``ordered=False``, from the prior implicit ``ordered=True``
 
 If categorical data is ordered (``s.cat.ordered == True``), then the order of the categories has a
 meaning and certain operations are possible. If the categorical is unordered, ``.min()/.max()`` will raise a `TypeError`.
@@ -803,13 +792,11 @@ Following table summarizes the results of ``Categoricals`` related concatenation
 Getting Data In/Out
 -------------------
 
-.. versionadded:: 0.15.2
+You can write data that contains ``category`` dtypes to a ``HDFStore``.
+See :ref:`here <io.hdf5-categorical>` for an example and caveats.
 
-Writing data (`Series`, `Frames`) to a HDF store that contains a ``category`` dtype was implemented
-in 0.15.2. See :ref:`here <io.hdf5-categorical>` for an example and caveats.
-
-Writing data to and reading data from *Stata* format files was implemented in
-0.15.2. See :ref:`here <io.stata-categorical>` for an example and caveats.
+It is also possible to write data to and reading data from *Stata* format files.
+See :ref:`here <io.stata-categorical>` for an example and caveats.
 
 Writing to a CSV file will convert the data, effectively removing any information about the
 categorical (categories and ordering). So if you read back the CSV file you have to convert the
@@ -928,32 +915,6 @@ an ``object`` dtype is a constant times the length of the data.
       s.astype('category').nbytes
 
 
-Old style constructor usage
-~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-In earlier versions than pandas 0.15, a `Categorical` could be constructed by passing in precomputed
-`codes` (called then `labels`) instead of values with categories. The `codes` were interpreted as
-pointers to the categories with `-1` as `NaN`. This type of constructor usage is replaced by
-the special constructor :func:`Categorical.from_codes`.
-
-Unfortunately, in some special cases, using code which assumes the old style constructor usage
-will work with the current pandas version, resulting in subtle bugs:
-
-.. code-block:: python
-
-    >>> cat = pd.Categorical([1,2], [1,2,3])
-    >>> # old version
-    >>> cat.get_values()
-    array([2, 3], dtype=int64)
-    >>> # new version
-    >>> cat.get_values()
-    array([1, 2], dtype=int64)
-
-.. warning::
-    If you used `Categoricals` with older versions of pandas, please audit your code before
-    upgrading and change your code to use the :func:`~pandas.Categorical.from_codes`
-    constructor.
-
 `Categorical` is not a `numpy` array
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -982,8 +943,7 @@ Dtype comparisons work:
     dtype == np.str_
     np.str_ == dtype
 
-To check if a Series contains Categorical data, with pandas 0.16 or later, use
-``hasattr(s, 'cat')``:
+To check if a Series contains Categorical data, use ``hasattr(s, 'cat')``:
 
 .. ipython:: python
 
@@ -1023,13 +983,13 @@ basic type) and applying along columns will also convert to object.
 Categorical Index
 ~~~~~~~~~~~~~~~~~
 
-.. versionadded:: 0.16.1
-
-A new ``CategoricalIndex`` index type is introduced in version 0.16.1. See the
-:ref:`advanced indexing docs <indexing.categoricalindex>` for a more detailed
+``CategoricalIndex`` is a type of index that is useful for supporting
+indexing with duplicates. This is a container around a ``Categorical``
+and allows efficient indexing and storage of an index with a large number of duplicated elements.
+See the :ref:`advanced indexing docs <indexing.categoricalindex>` for a more detailed
 explanation.
 
-Setting the index, will create create a ``CategoricalIndex``
+Setting the index will create a ``CategoricalIndex``
 
 .. ipython:: python
 
@@ -1040,10 +1000,6 @@ Setting the index, will create create a ``CategoricalIndex``
     df.index
     # This now sorts by the categories order
     df.sort_index()
-
-In previous versions (<0.16.1) there is no index of type ``category``, so
-setting the index to categorical column will convert the categorical data to a
-"normal" dtype first and therefore remove any custom ordering of the categories.
 
 Side Effects
 ~~~~~~~~~~~~

--- a/doc/source/comparison_with_r.rst
+++ b/doc/source/comparison_with_r.rst
@@ -505,8 +505,6 @@ For more details and examples see :ref:`the reshaping documentation
 |factor|_
 ~~~~~~~~~
 
-.. versionadded:: 0.15
-
 pandas has a data type for categorical data.
 
 .. code-block:: r

--- a/doc/source/computation.rst
+++ b/doc/source/computation.rst
@@ -924,15 +924,12 @@ EWM has a ``min_periods`` argument, which has the same
 meaning it does for all the ``.expanding`` and ``.rolling`` methods:
 no output values will be set until at least ``min_periods`` non-null values
 are encountered in the (expanding) window.
-(This is a change from versions prior to 0.15.0, in which the ``min_periods``
-argument affected only the ``min_periods`` consecutive entries starting at the
-first non-null value.)
 
-EWM also has an ``ignore_na`` argument, which deterines how
+EWM also has an ``ignore_na`` argument, which determines how
 intermediate null values affect the calculation of the weights.
 When ``ignore_na=False`` (the default), weights are calculated based on absolute
 positions, so that intermediate null values affect the result.
-When ``ignore_na=True`` (which reproduces the behavior in versions prior to 0.15.0),
+When ``ignore_na=True``,
 weights are calculated by ignoring intermediate null values.
 For example, assuming ``adjust=True``, if ``ignore_na=False``, the weighted
 average of ``3, NaN, 5`` would be calculated as

--- a/doc/source/cookbook.rst
+++ b/doc/source/cookbook.rst
@@ -256,12 +256,6 @@ Panels
 
    pf = pd.Panel({'df1':df1,'df2':df2,'df3':df3});pf
 
-   #Assignment using Transpose  (pandas < 0.15)
-   pf = pf.transpose(2,0,1)
-   pf['E'] = pd.DataFrame(data, rng, cols)
-   pf = pf.transpose(1,2,0);pf
-
-   #Direct assignment (pandas > 0.15)
    pf.loc[:,:,'F'] = pd.DataFrame(data, rng, cols);pf
 
 `Mask a panel by using np.where and then reconstructing the panel with the new masked values

--- a/doc/source/dsintro.rst
+++ b/doc/source/dsintro.rst
@@ -453,8 +453,6 @@ available to insert at a particular location in the columns:
 Assigning New Columns in Method Chains
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. versionadded:: 0.16.0
-
 Inspired by `dplyr's
 <http://cran.rstudio.com/web/packages/dplyr/vignettes/introduction.html#mutate>`__
 ``mutate`` verb, DataFrame has an :meth:`~pandas.DataFrame.assign`

--- a/doc/source/gotchas.rst
+++ b/doc/source/gotchas.rst
@@ -22,8 +22,8 @@ Frequently Asked Questions (FAQ)
 
 DataFrame memory usage
 ----------------------
-As of pandas version 0.15.0, the memory usage of a dataframe (including
-the index) is shown when accessing the ``info`` method of a dataframe. A
+The memory usage of a dataframe (including the index)
+is shown when accessing the ``info`` method of a dataframe. A
 configuration option, ``display.memory_usage`` (see :ref:`options`),
 specifies if the dataframe's memory usage will be displayed when
 invoking the ``df.info()`` method.

--- a/doc/source/indexing.rst
+++ b/doc/source/indexing.rst
@@ -49,12 +49,6 @@ advanced indexing.
 
 .. warning::
 
-   In 0.15.0 ``Index`` has internally been refactored to no longer subclass ``ndarray``
-   but instead subclass ``PandasObject``, similarly to the rest of the pandas objects. This should be
-   a transparent change with only very limited API implications (See the :ref:`Internal Refactoring <whatsnew_0150.refactoring>`)
-
-.. warning::
-
    Indexing on an integer-based Index with floats has been clarified in 0.18.0, for a summary of the changes, see :ref:`here <whatsnew_0180.float_indexers>`.
 
 See the :ref:`MultiIndex / Advanced Indexing <advanced>` for ``MultiIndex`` and more advanced indexing documentation.
@@ -660,7 +654,6 @@ For getting *multiple* indexers, using ``.get_indexer``
 
 Selecting Random Samples
 ------------------------
-.. versionadded::0.16.1
 
 A random selection of rows or columns from a Series, DataFrame, or Panel with the :meth:`~DataFrame.sample` method. The method will sample rows by default, and accepts a specific number of rows/columns to return, or a fraction of rows.
 
@@ -1510,8 +1503,6 @@ See :ref:`Advanced Indexing <advanced>` for usage of MultiIndexes.
   ind.name = "bob"
   ind
 
-.. versionadded:: 0.15.0
-
 ``set_names``, ``set_levels``, and ``set_labels`` also take an optional
 `level`` argument
 
@@ -1526,11 +1517,6 @@ Set operations on Index objects
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. _indexing.set_ops:
-
-.. warning::
-
-   In 0.15.0. the set operations ``+`` and ``-`` were deprecated in order to provide these for numeric type operations on certain
-   index types. ``+`` can be replace by ``.union()`` or ``|``, and ``-`` by ``.difference()``.
 
 The two main operations are ``union (|)``, ``intersection (&)``
 These can be directly called as instance methods or used via overloaded

--- a/doc/source/install.rst
+++ b/doc/source/install.rst
@@ -18,7 +18,7 @@ Instructions for installing from source,
 Python version support
 ----------------------
 
-Officially Python 2.7, 3.4, 3.5, and 3.6
+Officially Python 2.7, 3.5, and 3.6.
 
 Installing pandas
 -----------------
@@ -183,21 +183,17 @@ installed), make sure you have `pytest
 
     >>> import pandas as pd
     >>> pd.test()
-    Running unit tests for pandas
-    pandas version 0.18.0
-    numpy version 1.10.2
-    pandas is installed in pandas
-    Python version 2.7.11 |Continuum Analytics, Inc.|
-       (default, Dec  6 2015, 18:57:58) [GCC 4.2.1 (Apple Inc. build 5577)]
-    nose version 1.3.7
+    running: pytest --skip-slow --skip-network C:\Users\TP\Anaconda3\envs\py36\lib\site-packages\pandas
+    ============================= test session starts =============================
+    platform win32 -- Python 3.6.2, pytest-3.2.1, py-1.4.34, pluggy-0.4.0
+    rootdir: C:\Users\TP\Documents\Python\pandasdev\pandas, inifile: setup.cfg
+    collected 12145 items / 3 skipped
+
     ..................................................................S......
     ........S................................................................
     .........................................................................
 
-    ----------------------------------------------------------------------
-    Ran 9252 tests in 368.339s
-
-    OK (SKIP=117)
+    ==================== 12130 passed, 12 skipped in 368.339 seconds =====================
 
 Dependencies
 ------------

--- a/doc/source/io.rst
+++ b/doc/source/io.rst
@@ -592,8 +592,7 @@ Ignoring line comments and empty lines
 ++++++++++++++++++++++++++++++++++++++
 
 If the ``comment`` parameter is specified, then completely commented lines will
-be ignored. By default, completely blank lines will be ignored as well. Both of
-these are API changes introduced in version 0.15.
+be ignored. By default, completely blank lines will be ignored as well.
 
 .. ipython:: python
 
@@ -2701,8 +2700,6 @@ Using a list to get multiple sheets:
    # Returns the 1st and 4th sheet, as a dictionary of DataFrames.
    read_excel('path_to_file.xls',sheet_name=['Sheet1',3])
 
-.. versionadded:: 0.16
-
 ``read_excel`` can read more than one sheet, by setting ``sheet_name`` to either
 a list of sheet names, a list of sheet positions, or ``None`` to read all sheets.
 Sheets can be specified by sheet index or sheet name, using an integer or string,
@@ -3241,11 +3238,10 @@ for some advanced strategies
 
 .. warning::
 
-   As of version 0.15.0, pandas requires ``PyTables`` >= 3.0.0. Stores written with prior versions of pandas / ``PyTables`` >= 2.3 are fully compatible (this was the previous minimum ``PyTables`` required version).
-
-.. warning::
-
-   There is a ``PyTables`` indexing bug which may appear when querying stores using an index.  If you see a subset of results being returned, upgrade to ``PyTables`` >= 3.2.  Stores created previously will need to be rewritten using the updated version.
+   pandas requires ``PyTables`` >= 3.0.0.
+   There is a indexing bug in ``PyTables`` < 3.2 which may appear when querying stores using an index.
+   If you see a subset of results being returned, upgrade to ``PyTables`` >= 3.2.
+   Stores created previously will need to be rewritten using the updated version.
 
 .. warning::
 
@@ -4210,10 +4206,8 @@ object : ``strings``                                    ``np.nan``
 Categorical Data
 ++++++++++++++++
 
-.. versionadded:: 0.15.2
-
-Writing data to a ``HDFStore`` that contains a ``category`` dtype was implemented
-in 0.15.2. Queries work the same as if it was an object array. However, the ``category`` dtyped data is
+You can write data that contains ``category`` dtypes to a ``HDFStore``.
+Queries work the same as if it was an object array. However, the ``category`` dtyped data is
 stored in a more efficient manner.
 
 .. ipython:: python
@@ -4227,21 +4221,6 @@ stored in a more efficient manner.
    result = cstore.select('dfcat', where="A in ['b','c']")
    result
    result.dtypes
-
-.. warning::
-
-   The format of the ``Categorical`` is readable by prior versions of pandas (< 0.15.2), but will retrieve
-   the data as an integer based column (e.g. the ``codes``). However, the ``categories`` *can* be retrieved
-   but require the user to select them manually using the explicit meta path.
-
-   The data is stored like so:
-
-   .. ipython:: python
-
-      cstore
-
-      # to get the categories
-      cstore.select('dfcat/meta/A/meta')
 
 .. ipython:: python
    :suppress:
@@ -4746,8 +4725,6 @@ You can check if a table exists using :func:`~pandas.io.sql.has_table`
 Schema support
 ''''''''''''''
 
-.. versionadded:: 0.15.0
-
 Reading from and writing to different schema's is supported through the ``schema``
 keyword in the :func:`~pandas.read_sql_table` and :func:`~pandas.DataFrame.to_sql`
 functions. Note however that this depends on the database flavor (sqlite does not
@@ -4975,8 +4952,6 @@ be used to read the file incrementally.
 
    pd.read_stata('stata.dta')
 
-.. versionadded:: 0.16.0
-
 Specifying a ``chunksize`` yields a
 :class:`~pandas.io.stata.StataReader` instance that can be used to
 read ``chunksize`` lines from the file at a time.  The ``StataReader``
@@ -5033,8 +5008,6 @@ values will have ``object`` data type.
 
 Categorical Data
 ++++++++++++++++
-
-.. versionadded:: 0.15.2
 
 ``Categorical`` data can be exported to *Stata* data files as value labeled data.
 The exported data consists of the underlying category codes as integer data values

--- a/doc/source/remote_data.rst
+++ b/doc/source/remote_data.rst
@@ -11,14 +11,13 @@ Remote Data Access
 DataReader
 ----------
 
-The sub-package ``pandas.io.data`` is removed in favor of a separately
-installable `pandas-datareader package
+The sub-package ``pandas.io.data`` was deprecated in v.0.17 and removed in
+`v.0.19 <http://pandas-docs.github.io/pandas-docs-travis/whatsnew.html#v0-19-0-october-2-2016>`__.
+ Instead there has been created a separately installable `pandas-datareader package
 <https://github.com/pydata/pandas-datareader>`_. This will allow the data
-modules to be independently updated to your pandas installation. The API for
-``pandas-datareader v0.1.1`` is the same as in ``pandas v0.16.1``.
-(:issue:`8961`)
+modules to be independently updated on your pandas installation.
 
-   You should replace the imports of the following:
+   For code older than < 0.19 you should replace the imports of the following:
 
    .. code-block:: python
 

--- a/doc/source/reshaping.rst
+++ b/doc/source/reshaping.rst
@@ -569,8 +569,6 @@ This function is often used along with discretization functions like ``cut``:
 
 See also :func:`Series.str.get_dummies <pandas.Series.str.get_dummies>`.
 
-.. versionadded:: 0.15.0
-
 :func:`get_dummies` also accepts a DataFrame. By default all categorical
 variables (categorical in the statistical sense,
 those with `object` or `categorical` dtype) are encoded as dummy variables.
@@ -675,4 +673,4 @@ handling of NaN:
     you can use  ``df["cat_col"] = pd.Categorical(df["col"])`` or
     ``df["cat_col"] = df["col"].astype("category")``. For full docs on :class:`~pandas.Categorical`,
     see the :ref:`Categorical introduction <categorical>` and the
-    :ref:`API documentation <api.categorical>`. This feature was introduced in version 0.15.
+    :ref:`API documentation <api.categorical>`.

--- a/doc/source/sparse.rst
+++ b/doc/source/sparse.rst
@@ -216,8 +216,6 @@ To convert a ``SparseDataFrame`` back to sparse SciPy matrix in COO format, you 
 SparseSeries
 ~~~~~~~~~~~~
 
-.. versionadded:: 0.16.0
-
 A :meth:`SparseSeries.to_coo` method is implemented for transforming a ``SparseSeries`` indexed by a ``MultiIndex`` to a ``scipy.sparse.coo_matrix``.
 
 The method requires a ``MultiIndex`` with two or more levels.

--- a/doc/source/timedeltas.rst
+++ b/doc/source/timedeltas.rst
@@ -23,13 +23,12 @@
 Time Deltas
 ***********
 
-.. note::
+Timedeltas are differences in times, expressed in difference units, e.g. days, hours, minutes,
+seconds. They can be both positive and negative.
 
-   Starting in v0.15.0, we introduce a new scalar type ``Timedelta``, which is a subclass of ``datetime.timedelta``, and behaves in a similar manner,
-   but allows compatibility with ``np.timedelta64`` types as well as a host of custom representation, parsing, and attributes.
-
-Timedeltas are differences in times, expressed in difference units, e.g. days, hours, minutes, seconds.
-They can be both positive and negative.
+``Timedelta`` is a subclass of ``datetime.timedelta``, and behaves in a similar manner,
+but allows compatibility with ``np.timedelta64`` types as well as a host of custom representation,
+parsing, and attributes.
 
 Parsing
 -------
@@ -78,15 +77,10 @@ Further, operations among the scalars yield another scalar ``Timedelta``.
 to_timedelta
 ~~~~~~~~~~~~
 
-.. warning::
-
-       Prior to 0.15.0 ``pd.to_timedelta`` would return a ``Series`` for list-like/Series input, and a ``np.timedelta64`` for scalar input.
-       It will now return a ``TimedeltaIndex`` for list-like input, ``Series`` for Series input, and ``Timedelta`` for scalar input.
-
-       The arguments to ``pd.to_timedelta`` are now ``(arg, unit='ns', box=True)``, previously were ``(arg, box=True, unit='ns')`` as these are more logical.
-
-Using the top-level ``pd.to_timedelta``, you can convert a scalar, array, list, or Series from a recognized timedelta format / value into a ``Timedelta`` type.
-It will construct Series if the input is a Series, a scalar if the input is scalar-like, otherwise will output a ``TimedeltaIndex``.
+Using the top-level ``pd.to_timedelta``, you can convert a scalar, array, list,
+or Series from a recognized timedelta format / value into a ``Timedelta`` type.
+It will construct Series if the input is a Series, a scalar if the input is
+scalar-like, otherwise it will output a ``TimedeltaIndex``.
 
 You can parse a single string to a Timedelta:
 
@@ -327,8 +321,6 @@ You can convert a ``Timedelta`` to an `ISO 8601 Duration`_ string with the
 
 TimedeltaIndex
 --------------
-
-.. versionadded:: 0.15.0
 
 To generate an index with time delta, you can use either the ``TimedeltaIndex`` or
 the ``timedelta_range`` constructor.

--- a/doc/source/visualization.rst
+++ b/doc/source/visualization.rst
@@ -229,8 +229,6 @@ To get horizontal bar plots, use the ``barh`` method:
 Histograms
 ~~~~~~~~~~
 
-.. versionadded:: 0.15.0
-
 Histogram can be drawn by using the :meth:`DataFrame.plot.hist` and :meth:`Series.plot.hist` methods.
 
 .. ipython:: python
@@ -327,8 +325,6 @@ The ``by`` keyword can be specified to plot grouped histograms:
 
 Box Plots
 ~~~~~~~~~
-
-.. versionadded:: 0.15.0
 
 Boxplot can be drawn calling :meth:`Series.plot.box` and :meth:`DataFrame.plot.box`,
 or :meth:`DataFrame.boxplot` to visualize the distribution of values within each column.

--- a/doc/source/whatsnew/v0.21.0.txt
+++ b/doc/source/whatsnew/v0.21.0.txt
@@ -483,3 +483,4 @@ Other
 ^^^^^
 - Bug in :func:`eval` where the ``inplace`` parameter was being incorrectly handled (:issue:`16732`)
 - Several ``NaT`` method docstrings (e.g. :func:`NaT.ctime`) were incorrect (:issue:`17327`)
+- The documentation has had references to versions < v0.16 removed and cleaned up (:issue:`17442`, :issue:`17442` & :issue:`#17404`)


### PR DESCRIPTION
Last round of cleanup of references to older pandas versions (here v0.15 and v0.16).

I'm not intending to go further up:  v0.16.2 was released in june 2015, and allowing up to 2 years old references to be seen in the docs themselves is reasonable IMO. (but other may have a different view, so if there's a "demand" I could change the cut-off point, its not so much work).

See also #17420 and #17404.

I also removed a reference to python 3.4  in the ``install.rst``. In  the same document, I also "updated" the test section to show python3.6 (just a (very) minor signal that pandas is python 3 positive).