### PR TITLE
ENH: Add optional argument keep_index to dataframe melt method

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -4367,6 +4367,10 @@ class DataFrame(NDFrame):
         Name to use for the 'value' column.
     col_level : int or string, optional
         If columns are a MultiIndex then use this level to melt.
+    keep_index : boolean, optional, default False
+        If True, the original index is reused.
+        In the resulting MulitIndex the names of the unpivoted columns
+        are added as an additional level to ensure uniqueness.
 
     See also
     --------
@@ -4439,11 +4443,11 @@ class DataFrame(NDFrame):
                    versionadded='.. versionadded:: 0.20.0\n',
                    other='melt'))
     def melt(self, id_vars=None, value_vars=None, var_name=None,
-             value_name='value', col_level=None):
+             value_name='value', col_level=None, keep_index=False):
         from pandas.core.reshape.reshape import melt
         return melt(self, id_vars=id_vars, value_vars=value_vars,
                     var_name=var_name, value_name=value_name,
-                    col_level=col_level)
+                    col_level=col_level, keep_index=keep_index)
 
     # ----------------------------------------------------------------------
     # Time series-related


### PR DESCRIPTION
Setting keep_index to True will reuse the original DataFrame index +
names of melted columns as additional level. closes issue #17440

- [ ] closes #17440
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`

I appreciate any corrections, comments and/or help very much, as this is my first pull request on such a big project. Thank you.

