### PR TITLE
BUG: Fix TypeError caused by GH13374

### DIFF
--- a/doc/source/whatsnew/v0.21.0.txt
+++ b/doc/source/whatsnew/v0.21.0.txt
@@ -411,7 +411,7 @@ I/O
 - Bug in :func:`read_csv` when called with a single-element list ``header`` would return a ``DataFrame`` of all NaN values (:issue:`7757`)
 - Bug in :func:`read_stata` where value labels could not be read when using an iterator (:issue:`16923`)
 - Bug in :func:`read_html` where import check fails when run in multiple threads (:issue:`16928`)
-- Bug in :func:`read_csv` where automatic delimiter detection caused a `TypeError` to be thrown when a bad line was encountered (:issue:`13374`)
+- Bug in :func:`read_csv` where automatic delimiter detection caused a ``TypeError`` to be thrown when a bad line was encountered rather than the correct error message (:issue:`13374`)
 
 Plotting
 ^^^^^^^^

--- a/doc/source/whatsnew/v0.21.0.txt
+++ b/doc/source/whatsnew/v0.21.0.txt
@@ -411,6 +411,7 @@ I/O
 - Bug in :func:`read_csv` when called with a single-element list ``header`` would return a ``DataFrame`` of all NaN values (:issue:`7757`)
 - Bug in :func:`read_stata` where value labels could not be read when using an iterator (:issue:`16923`)
 - Bug in :func:`read_html` where import check fails when run in multiple threads (:issue:`16928`)
+- Bug in :func:`read_csv` where automatic delimiter detection caused a `TypeError` to be thrown when a bad line was encountered (:issue:`13374`)
 
 Plotting
 ^^^^^^^^

--- a/pandas/io/parsers.py
+++ b/pandas/io/parsers.py
@@ -2836,7 +2836,8 @@ class PythonParser(ParserBase):
             for row_num, actual_len in bad_lines:
                 msg = ('Expected %d fields in line %d, saw %d' %
                        (col_len, row_num + 1, actual_len))
-                if self.delimiter and len(self.delimiter) > 1 and self.quoting != csv.QUOTE_NONE:
+                if self.delimiter and \
+                   len(self.delimiter) > 1 and self.quoting != csv.QUOTE_NONE:
                     # see gh-13374
                     reason = ('Error could possibly be due to quotes being '
                               'ignored when a multi-char delimiter is used.')

--- a/pandas/io/parsers.py
+++ b/pandas/io/parsers.py
@@ -2836,7 +2836,7 @@ class PythonParser(ParserBase):
             for row_num, actual_len in bad_lines:
                 msg = ('Expected %d fields in line %d, saw %d' %
                        (col_len, row_num + 1, actual_len))
-                if len(self.delimiter) > 1 and self.quoting != csv.QUOTE_NONE:
+                if self.delimiter and len(self.delimiter) > 1 and self.quoting != csv.QUOTE_NONE:
                     # see gh-13374
                     reason = ('Error could possibly be due to quotes being '
                               'ignored when a multi-char delimiter is used.')

--- a/pandas/io/parsers.py
+++ b/pandas/io/parsers.py
@@ -2836,9 +2836,9 @@ class PythonParser(ParserBase):
             for row_num, actual_len in bad_lines:
                 msg = ('Expected %d fields in line %d, saw %d' %
                        (col_len, row_num + 1, actual_len))
-                if (self.delimiter and 
-                    len(self.delimiter) > 1 and 
-                    self.quoting != csv.QUOTE_NONE):
+                if (self.delimiter and
+                        len(self.delimiter) > 1 and
+                        self.quoting != csv.QUOTE_NONE):
                     # see gh-13374
                     reason = ('Error could possibly be due to quotes being '
                               'ignored when a multi-char delimiter is used.')

--- a/pandas/io/parsers.py
+++ b/pandas/io/parsers.py
@@ -2836,8 +2836,9 @@ class PythonParser(ParserBase):
             for row_num, actual_len in bad_lines:
                 msg = ('Expected %d fields in line %d, saw %d' %
                        (col_len, row_num + 1, actual_len))
-                if self.delimiter and \
-                   len(self.delimiter) > 1 and self.quoting != csv.QUOTE_NONE:
+                if (self.delimiter and 
+                    len(self.delimiter) > 1 and 
+                    self.quoting != csv.QUOTE_NONE):
                     # see gh-13374
                     reason = ('Error could possibly be due to quotes being '
                               'ignored when a multi-char delimiter is used.')

--- a/pandas/tests/io/parser/python_parser_only.py
+++ b/pandas/tests/io/parser/python_parser_only.py
@@ -227,8 +227,8 @@ x   q   30      3    -0.6662 -0.5243 -0.3580  0.89145  2.5838"""
                               'c': [2, 9]})
 
         # We expect the third line in the data to be
-        # skipped because it is malformed
-        # but we do not expect any errors to occur
+        # skipped because it is malformed,
+        # but we do not expect any errors to occur.
         result = self.read_csv(StringIO(data), header=0,
                                sep=None,
                                error_bad_lines=False,

--- a/pandas/tests/io/parser/python_parser_only.py
+++ b/pandas/tests/io/parser/python_parser_only.py
@@ -218,6 +218,24 @@ x   q   30      3    -0.6662 -0.5243 -0.3580  0.89145  2.5838"""
                 self.read_csv(StringIO(data), sep=',,',
                               quoting=csv.QUOTE_NONE)
 
+    def test_none_delimiter(self):
+        # see gh-13374 and gh-17465
+
+        data = "a,b,c\n0,1,2\n3,4,5,6\n7,8,9"
+        expected = DataFrame({'a': [0, 7],
+                              'b': [1, 8],
+                              'c': [2, 9]})
+
+        # We expect no error to be thrown, and the
+        result = self.read_csv(StringIO(data), header=0,
+                               sep=None,
+                               error_bad_lines=False,
+                               warn_bad_lines=True,
+                               engine='python',
+                               iterator=True,
+                               tupleize_cols=True)
+        tm.assert_frame_equal(result, expected)
+
     def test_skipfooter_bad_row(self):
         # see gh-13879
         # see gh-15910

--- a/pandas/tests/io/parser/python_parser_only.py
+++ b/pandas/tests/io/parser/python_parser_only.py
@@ -226,7 +226,9 @@ x   q   30      3    -0.6662 -0.5243 -0.3580  0.89145  2.5838"""
                               'b': [1, 8],
                               'c': [2, 9]})
 
-        # We expect no error to be thrown, and the
+        # We expect the third line in the data to be
+        # skipped because it is malformed
+        # but we do not expect any errors to occur
         result = self.read_csv(StringIO(data), header=0,
                                sep=None,
                                error_bad_lines=False,

--- a/pandas/tests/io/parser/python_parser_only.py
+++ b/pandas/tests/io/parser/python_parser_only.py
@@ -232,7 +232,6 @@ x   q   30      3    -0.6662 -0.5243 -0.3580  0.89145  2.5838"""
                                error_bad_lines=False,
                                warn_bad_lines=True,
                                engine='python',
-                               iterator=True,
                                tupleize_cols=True)
         tm.assert_frame_equal(result, expected)
 


### PR DESCRIPTION
- [x] closes #13374
- [x] `0 failed, 9873 passed, 1955 skipped, 11 xfailed, 4 warnings in 1475.44 seconds`
   > added ``test_none_delimiter`` in ``pandas/tests/io/parser/python_parser_only.py``
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry
   > Bug in :func:`read_csv` where automatic delimiter detection caused a ``TypeError`` to be thrown when a bad line was encountered rather than the correct error message (:issue:`13374`)

@gfyoung 