### PR TITLE
Follow up to #17422

### DIFF
--- a/pandas/_libs/period.pyx
+++ b/pandas/_libs/period.pyx
@@ -10,6 +10,7 @@ from cpython cimport (
 from numpy cimport (int8_t, int32_t, int64_t, import_array, ndarray,
                     NPY_INT64, NPY_DATETIME, NPY_TIMEDELTA)
 import numpy as np
+import_array()
 
 from libc.stdlib cimport free
 

--- a/pandas/_libs/period.pyx
+++ b/pandas/_libs/period.pyx
@@ -13,14 +13,12 @@ import numpy as np
 
 from libc.stdlib cimport free
 
-from pandas import compat
 from pandas.compat import PY2
 
 cimport cython
 
 from datetime cimport (
     is_leapyear,
-    PyDateTime_IMPORT,
     pandas_datetimestruct,
     pandas_datetimestruct_to_datetime,
     pandas_datetime_to_datetimestruct,
@@ -29,6 +27,7 @@ from datetime cimport (
 
 
 cimport util, lib
+from util cimport is_period_object, is_string_object
 
 from lib cimport is_null_datetimelike, is_period
 from pandas._libs import tslib, lib
@@ -40,6 +39,8 @@ from tslib cimport (
     _is_tzlocal,
     _get_dst_info,
     _nat_scalar_rules)
+
+from tslibs.frequencies cimport get_freq_code
 
 from pandas.tseries import offsets
 from pandas.core.tools.datetimes import parse_time_string
@@ -329,8 +330,6 @@ cdef list str_extra_fmts = ["^`AB`^", "^`CD`^", "^`EF`^",
                             "^`GH`^", "^`IJ`^", "^`KL`^"]
 
 cdef object _period_strftime(int64_t value, int freq, object fmt):
-    import sys
-
     cdef:
         Py_ssize_t i
         date_info dinfo
@@ -683,7 +682,7 @@ cdef class _Period(object):
     def _maybe_convert_freq(cls, object freq):
 
         if isinstance(freq, (int, tuple)):
-            code, stride = frequencies.get_freq_code(freq)
+            code, stride = get_freq_code(freq)
             freq = frequencies._get_freq_str(code, stride)
 
         freq = frequencies.to_offset(freq)
@@ -707,7 +706,7 @@ cdef class _Period(object):
             return self
 
     def __richcmp__(self, other, op):
-        if isinstance(other, Period):
+        if is_period_object(other):
             if other.freq != self.freq:
                 msg = _DIFFERENT_FREQ.format(self.freqstr, other.freqstr)
                 raise IncompatibleFrequency(msg)
@@ -753,7 +752,7 @@ cdef class _Period(object):
             return NotImplemented
 
     def __add__(self, other):
-        if isinstance(self, Period):
+        if is_period_object(self):
             if isinstance(other, (timedelta, np.timedelta64,
                                   offsets.DateOffset,
                                   Timedelta)):
@@ -765,13 +764,13 @@ cdef class _Period(object):
                 return Period(ordinal=ordinal, freq=self.freq)
             else:  # pragma: no cover
                 return NotImplemented
-        elif isinstance(other, Period):
+        elif is_period_object(other):
             return other + self
         else:
             return NotImplemented
 
     def __sub__(self, other):
-        if isinstance(self, Period):
+        if is_period_object(self):
             if isinstance(other, (timedelta, np.timedelta64,
                                   offsets.DateOffset,
                                   Timedelta)):
@@ -780,7 +779,7 @@ cdef class _Period(object):
             elif lib.is_integer(other):
                 ordinal = self.ordinal - other * self.freq.n
                 return Period(ordinal=ordinal, freq=self.freq)
-            elif isinstance(other, Period):
+            elif is_period_object(other):
                 if other.freq != self.freq:
                     msg = _DIFFERENT_FREQ.format(self.freqstr, other.freqstr)
                     raise IncompatibleFrequency(msg)
@@ -789,7 +788,7 @@ cdef class _Period(object):
                 return -other.__sub__(self)
             else:  # pragma: no cover
                 return NotImplemented
-        elif isinstance(other, Period):
+        elif is_period_object(other):
             if self is NaT:
                 return NaT
             return NotImplemented
@@ -813,8 +812,8 @@ cdef class _Period(object):
         """
         freq = self._maybe_convert_freq(freq)
         how = _validate_end_alias(how)
-        base1, mult1 = frequencies.get_freq_code(self.freq)
-        base2, mult2 = frequencies.get_freq_code(freq)
+        base1, mult1 = get_freq_code(self.freq)
+        base2, mult2 = get_freq_code(freq)
 
         # mult1 can't be negative or 0
         end = how == 'E'
@@ -860,17 +859,17 @@ cdef class _Period(object):
         how = _validate_end_alias(how)
 
         if freq is None:
-            base, mult = frequencies.get_freq_code(self.freq)
+            base, mult = get_freq_code(self.freq)
             freq = frequencies.get_to_timestamp_base(base)
 
-        base, mult = frequencies.get_freq_code(freq)
+        base, mult = get_freq_code(freq)
         val = self.asfreq(freq, how)
 
         dt64 = period_ordinal_to_dt64(val.ordinal, base)
         return Timestamp(dt64, tz=tz)
 
     cdef _field(self, alias):
-        base, mult = frequencies.get_freq_code(self.freq)
+        base, mult = get_freq_code(self.freq)
         return get_period_field(alias, self.ordinal, base)
 
     property year:
@@ -935,7 +934,7 @@ cdef class _Period(object):
         return self.freq.freqstr
 
     def __repr__(self):
-        base, mult = frequencies.get_freq_code(self.freq)
+        base, mult = get_freq_code(self.freq)
         formatted = period_format(self.ordinal, base)
         return "Period('%s', '%s')" % (formatted, self.freqstr)
 
@@ -946,7 +945,7 @@ cdef class _Period(object):
         Invoked by unicode(df) in py2 only. Yields a Unicode String in both
         py2/py3.
         """
-        base, mult = frequencies.get_freq_code(self.freq)
+        base, mult = get_freq_code(self.freq)
         formatted = period_format(self.ordinal, base)
         value = ("%s" % formatted)
         return value
@@ -1096,7 +1095,7 @@ cdef class _Period(object):
             >>> a.strftime('%b. %d, %Y was a %A')
             'Jan. 01, 2001 was a Monday'
         """
-        base, mult = frequencies.get_freq_code(self.freq)
+        base, mult = get_freq_code(self.freq)
         return period_format(self.ordinal, base, fmt)
 
 
@@ -1161,10 +1160,10 @@ class Period(_Period):
                 ordinal = _ordinal_from_fields(year, month, quarter, day,
                                                hour, minute, second, freq)
 
-        elif isinstance(value, Period):
+        elif is_period_object(value):
             other = value
-            if freq is None or frequencies.get_freq_code(
-                    freq) == frequencies.get_freq_code(other.freq):
+            if freq is None or get_freq_code(
+                    freq) == get_freq_code(other.freq):
                 ordinal = other.ordinal
                 freq = other.freq
             else:
@@ -1174,7 +1173,7 @@ class Period(_Period):
         elif is_null_datetimelike(value) or value in tslib._nat_strings:
             ordinal = iNaT
 
-        elif isinstance(value, compat.string_types) or lib.is_integer(value):
+        elif is_string_object(value) or lib.is_integer(value):
             if lib.is_integer(value):
                 value = str(value)
             value = value.upper()
@@ -1191,7 +1190,7 @@ class Period(_Period):
             dt = value
             if freq is None:
                 raise ValueError('Must supply freq for datetime value')
-        elif isinstance(value, np.datetime64):
+        elif util.is_datetime64_object(value):
             dt = Timestamp(value)
             if freq is None:
                 raise ValueError('Must supply freq for datetime value')
@@ -1204,7 +1203,7 @@ class Period(_Period):
             raise ValueError(msg)
 
         if ordinal is None:
-            base, mult = frequencies.get_freq_code(freq)
+            base, mult = get_freq_code(freq)
             ordinal = get_period_ordinal(dt.year, dt.month, dt.day,
                                          dt.hour, dt.minute, dt.second,
                                          dt.microsecond, 0, base)
@@ -1214,7 +1213,7 @@ class Period(_Period):
 
 def _ordinal_from_fields(year, month, quarter, day,
                          hour, minute, second, freq):
-    base, mult = frequencies.get_freq_code(freq)
+    base, mult = get_freq_code(freq)
     if quarter is not None:
         year, month = _quarter_to_myear(year, quarter, freq)
 
@@ -1227,8 +1226,7 @@ def _quarter_to_myear(year, quarter, freq):
         if quarter <= 0 or quarter > 4:
             raise ValueError('Quarter must be 1 <= q <= 4')
 
-        mnum = frequencies._month_numbers[
-            frequencies._get_rule_month(freq)] + 1
+        mnum = tslib._MONTH_NUMBERS[tslib._get_rule_month(freq)] + 1
         month = (mnum + (quarter - 1) * 3) % 12 + 1
         if month > mnum:
             year -= 1

--- a/pandas/_libs/tslibs/frequencies.pxd
+++ b/pandas/_libs/tslibs/frequencies.pxd
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+# cython: profile=False
+
+cpdef get_freq_code(freqstr)

--- a/pandas/_libs/tslibs/frequencies.pyx
+++ b/pandas/_libs/tslibs/frequencies.pyx
@@ -150,6 +150,9 @@ _period_code_map = {
     "N": 12000,       # Nanosecondly
 }
 
+_reverse_period_code_map = {
+    _period_code_map[key]: key for key in _period_code_map}
+
 # Yearly aliases; careful not to put these in _reverse_period_code_map
 _period_code_map.update({'Y' + key[1:]: _period_code_map[key]
                          for key in _period_code_map


### PR DESCRIPTION
As a follow-up, this performs small touchups in a handful of places.

Implement .pxd file for tslibs.frequencies

cimport get_freq_code in period.pyx

Replace isinstance checks in period.pyx with C-equivalents form util

Remove unused imports from period.pyx

Remove code in tseries.frequencies that can now be imported from tslibs.frequencies

- [ ] closes #xxxx
- [ ] tests added / passed
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
