### PR TITLE
Fix typo in setup.py introduced by #17422

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -341,7 +341,7 @@ class CheckSDist(sdist_class):
                  'pandas/_libs/window.pyx',
                  'pandas/_libs/sparse.pyx',
                  'pandas/_libs/parsers.pyx',
-                 'panads/_libs/tslibs/frequencies.pyx',
+                 'pandas/_libs/tslibs/frequencies.pyx',
                  'pandas/io/sas/sas.pyx']
 
     def initialize_options(self):


### PR DESCRIPTION
- [ ] closes #xxxx
- [ ] tests added / passed
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
