### PR TITLE
ENH: Add Styler.where

### DIFF
--- a/doc/source/api.rst
+++ b/doc/source/api.rst
@@ -2062,6 +2062,7 @@ Style Application
 
    Styler.apply
    Styler.applymap
+   Styler.where
    Styler.format
    Styler.set_precision
    Styler.set_table_styles

--- a/doc/source/whatsnew/v0.21.0.txt
+++ b/doc/source/whatsnew/v0.21.0.txt
@@ -112,6 +112,7 @@ Other Enhancements
 - `read_*` methods can now infer compression from non-string paths, such as ``pathlib.Path`` objects (:issue:`17206`).
 - :func:`pd.read_sas()` now recognizes much more of the most frequently used date (datetime) formats in SAS7BDAT files (:issue:`15871`).
 - :func:`DataFrame.items` and :func:`Series.items` is now present in both Python 2 and 3 and is lazy in all cases (:issue:`13918`, :issue:`17213`)
+- :func:`Styler.where` has been implemented. It is as a convenience for :func:`Styler.applymap` and enables simple DataFrame styling on the Jupyter notebook (:issue:`17474`).
 
 
 

--- a/pandas/io/formats/style.py
+++ b/pandas/io/formats/style.py
@@ -623,6 +623,44 @@ class Styler(object):
                            (func, subset), kwargs))
         return self
 
+    def where(self, cond, value, other=None, subset=None, **kwargs):
+        """
+        Apply a function elementwise, updating the HTML
+        representation with a style which is selected in
+        accordance with the return value of a function.
+
+        .. versionadded:: 0.21.0
+
+        Parameters
+        ----------
+        cond : callable
+            ``cond`` should take a scalar and return a boolean
+        value : str
+            applied when ``cond`` returns true
+        other : str
+            applied when ``cond`` returns false
+        subset : IndexSlice
+            a valid indexer to limit ``data`` to *before* applying the
+            function. Consider using a pandas.IndexSlice
+        kwargs : dict
+            pass along to ``cond``
+
+        Returns
+        -------
+        self : Styler
+
+        See Also
+        --------
+        Styler.applymap
+
+        """
+
+        if other is None:
+            other = ''
+
+        return self.applymap(lambda val: value if cond(val) else other,
+                             subset=subset, **kwargs)
+
     def set_precision(self, precision):
         """
         Set the precision used to render.

--- a/pandas/io/formats/style.py
+++ b/pandas/io/formats/style.py
@@ -618,6 +618,10 @@ class Styler(object):
         -------
         self : Styler
 
+        See Also
+        --------
+        Styler.where
+
         """
         self._todo.append((lambda instance: getattr(instance, '_applymap'),
                            (func, subset), kwargs))


### PR DESCRIPTION
- [x] closes #16255
- [x] tests added / passed
Added `test_where_subset` in `pandas/tests/io/formats/test_style.py`.
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry
It makes the redundant style condition simple.
```python
df.style.applymap(lambda val: 'color: %s' % 'red' if val < 0 else 'black')
df.style.where(lambda val: val < 0, 'color: red', 'color: black')
```