### PR TITLE
Make *_range functions consistent

### DIFF
--- a/doc/source/api.rst
+++ b/doc/source/api.rst
@@ -218,9 +218,18 @@ Top-level dealing with datetimelike
    to_timedelta
    date_range
    bdate_range
+   cdate_range
    period_range
    timedelta_range
    infer_freq
+
+Top-level dealing with intervals
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. autosummary::
+   :toctree: generated/
+
+   interval_range
 
 Top-level evaluation
 ~~~~~~~~~~~~~~~~~~~~

--- a/doc/source/timeseries.rst
+++ b/doc/source/timeseries.rst
@@ -1705,6 +1705,15 @@ has multiplied span.
 
    pd.PeriodIndex(start='2014-01', freq='3M', periods=4)
 
+If ``start`` or ``end`` are ``Period`` objects, they will be used as anchor
+endpoints for a ``PeriodIndex`` with frequency matching that of the
+``PeriodIndex`` constructor.
+
+.. ipython:: python
+
+   pd.PeriodIndex(start=pd.Period('2017Q1', freq='Q'),
+                  end=pd.Period('2017Q2', freq='Q'), freq='M')
+
 Just like ``DatetimeIndex``, a ``PeriodIndex`` can also be used to index pandas
 objects:
 

--- a/doc/source/whatsnew/v0.21.0.txt
+++ b/doc/source/whatsnew/v0.21.0.txt
@@ -358,6 +358,59 @@ Previously, :func:`to_datetime` did not localize datetime ``Series`` data when `
 
 Additionally, DataFrames with datetime columns that were parsed by :func:`read_sql_table` and :func:`read_sql_query` will also be localized to UTC only if the original SQL columns were timezone aware datetime columns.
 
+.. _whatsnew_0200.api.consistency_of_range_functions:
+
+Consistency of Range Functions
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+In previous versions, there were some inconsistencies between the various range functions: ``date_range``, ``bdate_range``, ``cdate_range``, ``interval_range``, ``period_range``, and ``timedelta_range``.   (:issue:`17471`).
+
+One of the inconsistent behaviors occurred when the ``start``, ``end`` and ``period`` parameters were all specified, potentially leading to ambiguous ranges.  When all three parameters were passed, ``interval_range`` ignored the ``period`` parameter, ``period_range`` ignored the ``end`` parameter, and the other range functions raised.  To promote consistency among the range functions, and avoid potentially ambiguous ranges, ``interval_range`` and ``period_range`` will now raise when all three parameters are passed.
+
+Previous Behavior:
+
+.. code-block:: ipython
+
+  In [2]: pd.interval_range(start=0, end=4, periods=6)
+  Out[2]:
+  IntervalIndex([(0, 1], (1, 2], (2, 3]]
+                closed='right',
+                dtype='interval[int64]')
+
+  In [3]: pd.period_range(start='2017Q1', end='2017Q4', periods=6, freq='Q')
+  Out[3]: PeriodIndex(['2017Q1', '2017Q2', '2017Q3', '2017Q4', '2018Q1', '2018Q2'], dtype='period[Q-DEC]', freq='Q-DEC')
+
+New Behavior:
+
+.. code-block:: ipython
+
+  In [2]: pd.interval_range(start=0, end=4, periods=6)
+  ---------------------------------------------------------------------------
+  ValueError: Must specify exactly two of start, end, or periods
+
+  In [3]: pd.period_range(start='2017Q1', end='2017Q4', periods=6, freq='Q')  
+  ---------------------------------------------------------------------------
+  ValueError: Must specify exactly two of start, end, or periods
+
+Additionally, the endpoint parameter ``end`` was not included in the intervals produced by ``interval_range``.  However, all other range functions include ``end`` in their output.  To promote consistency among the range functions, ``interval_range`` will now include ``end`` as the right endpoint of the final interval, except if ``freq`` is specified in a way which skips ``end``.
+
+Previous Behavior:
+
+.. code-block:: ipython
+
+  In [4]: pd.interval_range(start=0, end=4)
+  Out[4]:
+  IntervalIndex([(0, 1], (1, 2], (2, 3]]
+                closed='right',
+                dtype='interval[int64]')
+
+
+New Behavior:
+
+  .. ipython:: python
+
+     pd.interval_range(start=0, end=4)
+
 .. _whatsnew_0210.api:
 
 Other API Changes

--- a/doc/source/whatsnew/v0.21.0.txt
+++ b/doc/source/whatsnew/v0.21.0.txt
@@ -218,7 +218,7 @@ Furthermore this will now correctly box the results of iteration for :func:`Data
 .. ipython:: ipython
 
    d = {'a':[1], 'b':['b']}
-   df = pd,DataFrame(d)
+   df = pd.DataFrame(d)
 
 Previously:
 
@@ -363,7 +363,7 @@ Additionally, DataFrames with datetime columns that were parsed by :func:`read_s
 Consistency of Range Functions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-In previous versions, there were some inconsistencies between the various range functions: ``date_range``, ``bdate_range``, ``cdate_range``, ``interval_range``, ``period_range``, and ``timedelta_range``.   (:issue:`17471`).
+In previous versions, there were some inconsistencies between the various range functions: func:`date_range`, func:`bdate_range`, func:`cdate_range`, func:`period_range`, func:`timedelta_range`, and func:`interval_range`. (:issue:`17471`).
 
 One of the inconsistent behaviors occurred when the ``start``, ``end`` and ``period`` parameters were all specified, potentially leading to ambiguous ranges.  When all three parameters were passed, ``interval_range`` ignored the ``period`` parameter, ``period_range`` ignored the ``end`` parameter, and the other range functions raised.  To promote consistency among the range functions, and avoid potentially ambiguous ranges, ``interval_range`` and ``period_range`` will now raise when all three parameters are passed.
 

--- a/doc/source/whatsnew/v0.21.0.txt
+++ b/doc/source/whatsnew/v0.21.0.txt
@@ -358,7 +358,7 @@ Previously, :func:`to_datetime` did not localize datetime ``Series`` data when `
 
 Additionally, DataFrames with datetime columns that were parsed by :func:`read_sql_table` and :func:`read_sql_query` will also be localized to UTC only if the original SQL columns were timezone aware datetime columns.
 
-.. _whatsnew_0200.api.consistency_of_range_functions:
+.. _whatsnew_0210.api.consistency_of_range_functions:
 
 Consistency of Range Functions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -386,11 +386,11 @@ New Behavior:
 
   In [2]: pd.interval_range(start=0, end=4, periods=6)
   ---------------------------------------------------------------------------
-  ValueError: Must specify exactly two of start, end, or periods
+  ValueError: Of the three parameters, start, end, and periods, exactly two must be specified
 
   In [3]: pd.period_range(start='2017Q1', end='2017Q4', periods=6, freq='Q')  
   ---------------------------------------------------------------------------
-  ValueError: Must specify exactly two of start, end, or periods
+  ValueError: Of the three parameters, start, end, and periods, exactly two must be specified
 
 Additionally, the endpoint parameter ``end`` was not included in the intervals produced by ``interval_range``.  However, all other range functions include ``end`` in their output.  To promote consistency among the range functions, ``interval_range`` will now include ``end`` as the right endpoint of the final interval, except if ``freq`` is specified in a way which skips ``end``.
 

--- a/doc/source/whatsnew/v0.21.0.txt
+++ b/doc/source/whatsnew/v0.21.0.txt
@@ -386,11 +386,11 @@ New Behavior:
 
   In [2]: pd.interval_range(start=0, end=4, periods=6)
   ---------------------------------------------------------------------------
-  ValueError: Of the three parameters, start, end, and periods, exactly two must be specified
+  ValueError: Of the three parameters: start, end, and periods, exactly two must be specified
 
   In [3]: pd.period_range(start='2017Q1', end='2017Q4', periods=6, freq='Q')  
   ---------------------------------------------------------------------------
-  ValueError: Of the three parameters, start, end, and periods, exactly two must be specified
+  ValueError: Of the three parameters: start, end, and periods, exactly two must be specified
 
 Additionally, the endpoint parameter ``end`` was not included in the intervals produced by ``interval_range``.  However, all other range functions include ``end`` in their output.  To promote consistency among the range functions, ``interval_range`` will now include ``end`` as the right endpoint of the final interval, except if ``freq`` is specified in a way which skips ``end``.
 

--- a/pandas/core/indexes/datetimes.py
+++ b/pandas/core/indexes/datetimes.py
@@ -412,7 +412,8 @@ class DatetimeIndex(DatelikeOps, TimelikeOps, DatetimeIndexOpsMixin,
     def _generate(cls, start, end, periods, name, offset,
                   tz=None, normalize=False, ambiguous='raise', closed=None):
         if com._count_not_none(start, end, periods) != 2:
-            raise ValueError('Must specify two of start, end, or periods')
+            msg = 'Must specify exactly two of start, end, or periods'
+            raise ValueError(msg)
 
         _normalized = True
 
@@ -2030,7 +2031,7 @@ def date_range(start=None, end=None, periods=None, freq='D', tz=None,
 
     Notes
     -----
-    2 of start, end, or periods must be specified
+    Exactly two of start, end, or periods must be specified
 
     To learn more about the frequency strings, please see `this link
     <http://pandas.pydata.org/pandas-docs/stable/timeseries.html#offset-aliases>`__.
@@ -2073,7 +2074,7 @@ def bdate_range(start=None, end=None, periods=None, freq='B', tz=None,
 
     Notes
     -----
-    2 of start, end, or periods must be specified
+    Exactly two of start, end, or periods must be specified
 
     To learn more about the frequency strings, please see `this link
     <http://pandas.pydata.org/pandas-docs/stable/timeseries.html#offset-aliases>`__.
@@ -2127,7 +2128,7 @@ def cdate_range(start=None, end=None, periods=None, freq='C', tz=None,
 
     Notes
     -----
-    2 of start, end, or periods must be specified
+    Exactly two of start, end, or periods must be specified
 
     To learn more about the frequency strings, please see `this link
     <http://pandas.pydata.org/pandas-docs/stable/timeseries.html#offset-aliases>`__.

--- a/pandas/core/indexes/datetimes.py
+++ b/pandas/core/indexes/datetimes.py
@@ -412,8 +412,8 @@ class DatetimeIndex(DatelikeOps, TimelikeOps, DatetimeIndexOpsMixin,
     def _generate(cls, start, end, periods, name, offset,
                   tz=None, normalize=False, ambiguous='raise', closed=None):
         if com._count_not_none(start, end, periods) != 2:
-            msg = 'Must specify exactly two of start, end, or periods'
-            raise ValueError(msg)
+            raise ValueError('Of the three parameters, start, end, and '
+                             'periods, exactly two must be specified')
 
         _normalized = True
 
@@ -2031,7 +2031,8 @@ def date_range(start=None, end=None, periods=None, freq='D', tz=None,
 
     Notes
     -----
-    Exactly two of start, end, or periods must be specified
+    Of the three parameters, ``start``, ``end``, and ``periods``, exactly two
+    must be specified.
 
     To learn more about the frequency strings, please see `this link
     <http://pandas.pydata.org/pandas-docs/stable/timeseries.html#offset-aliases>`__.
@@ -2074,7 +2075,8 @@ def bdate_range(start=None, end=None, periods=None, freq='B', tz=None,
 
     Notes
     -----
-    Exactly two of start, end, or periods must be specified
+    Of the three parameters, ``start``, ``end``, and ``periods``, exactly two
+    must be specified.
 
     To learn more about the frequency strings, please see `this link
     <http://pandas.pydata.org/pandas-docs/stable/timeseries.html#offset-aliases>`__.
@@ -2128,7 +2130,8 @@ def cdate_range(start=None, end=None, periods=None, freq='C', tz=None,
 
     Notes
     -----
-    Exactly two of start, end, or periods must be specified
+    Of the three parameters, ``start``, ``end``, and ``periods``, exactly two
+    must be specified.
 
     To learn more about the frequency strings, please see `this link
     <http://pandas.pydata.org/pandas-docs/stable/timeseries.html#offset-aliases>`__.

--- a/pandas/core/indexes/datetimes.py
+++ b/pandas/core/indexes/datetimes.py
@@ -292,8 +292,8 @@ class DatetimeIndex(DatelikeOps, TimelikeOps, DatetimeIndexOpsMixin,
             if is_float(periods):
                 periods = int(periods)
             elif not is_integer(periods):
-                raise ValueError('Periods must be a number, got %s' %
-                                 str(periods))
+                msg = 'periods must be a number, got {periods}'
+                raise ValueError(msg.format(periods=periods))
 
         if data is None and freq is None:
             raise ValueError("Must provide freq argument if no data is "
@@ -412,7 +412,7 @@ class DatetimeIndex(DatelikeOps, TimelikeOps, DatetimeIndexOpsMixin,
     def _generate(cls, start, end, periods, name, offset,
                   tz=None, normalize=False, ambiguous='raise', closed=None):
         if com._count_not_none(start, end, periods) != 2:
-            raise ValueError('Of the three parameters, start, end, and '
+            raise ValueError('Of the three parameters: start, end, and '
                              'periods, exactly two must be specified')
 
         _normalized = True
@@ -2005,7 +2005,7 @@ def _generate_regular_range(start, end, periods, offset):
 def date_range(start=None, end=None, periods=None, freq='D', tz=None,
                normalize=False, name=None, closed=None, **kwargs):
     """
-    Return a fixed frequency datetime index, with day (calendar) as the default
+    Return a fixed frequency DatetimeIndex, with day (calendar) as the default
     frequency
 
     Parameters
@@ -2014,24 +2014,24 @@ def date_range(start=None, end=None, periods=None, freq='D', tz=None,
         Left bound for generating dates
     end : string or datetime-like, default None
         Right bound for generating dates
-    periods : integer or None, default None
-        If None, must specify start and end
+    periods : integer, default None
+        Number of dates to generate
     freq : string or DateOffset, default 'D' (calendar daily)
         Frequency strings can have multiples, e.g. '5H'
-    tz : string or None
+    tz : string, default None
         Time zone name for returning localized DatetimeIndex, for example
         Asia/Hong_Kong
     normalize : bool, default False
         Normalize start/end dates to midnight before generating date range
-    name : str, default None
-        Name of the resulting index
-    closed : string or None, default None
+    name : string, default None
+        Name of the resulting DatetimeIndex
+    closed : string, default None
         Make the interval closed with respect to the given frequency to
         the 'left', 'right', or both sides (None)
 
     Notes
     -----
-    Of the three parameters, ``start``, ``end``, and ``periods``, exactly two
+    Of the three parameters: ``start``, ``end``, and ``periods``, exactly two
     must be specified.
 
     To learn more about the frequency strings, please see `this link
@@ -2049,7 +2049,7 @@ def date_range(start=None, end=None, periods=None, freq='D', tz=None,
 def bdate_range(start=None, end=None, periods=None, freq='B', tz=None,
                 normalize=True, name=None, closed=None, **kwargs):
     """
-    Return a fixed frequency datetime index, with business day as the default
+    Return a fixed frequency DatetimeIndex, with business day as the default
     frequency
 
     Parameters
@@ -2058,24 +2058,24 @@ def bdate_range(start=None, end=None, periods=None, freq='B', tz=None,
         Left bound for generating dates
     end : string or datetime-like, default None
         Right bound for generating dates
-    periods : integer or None, default None
-        If None, must specify start and end
+    periods : integer, default None
+        Number of dates to generate
     freq : string or DateOffset, default 'B' (business daily)
-        Frequency strings can have multiples, e.g. '5H'
+        Frequency strings can have multiples, e.g. '5, default
     tz : string or None
         Time zone name for returning localized DatetimeIndex, for example
         Asia/Beijing
     normalize : bool, default False
         Normalize start/end dates to midnight before generating date range
-    name : str, default None
-        Name for the resulting index
-    closed : string or None, default None
+    name : string, default None
+        Name of the resulting DatetimeIndex
+    closed : string, default None
         Make the interval closed with respect to the given frequency to
         the 'left', 'right', or both sides (None)
 
     Notes
     -----
-    Of the three parameters, ``start``, ``end``, and ``periods``, exactly two
+    Of the three parameters: ``start``, ``end``, and ``periods``, exactly two
     must be specified.
 
     To learn more about the frequency strings, please see `this link
@@ -2094,7 +2094,7 @@ def bdate_range(start=None, end=None, periods=None, freq='B', tz=None,
 def cdate_range(start=None, end=None, periods=None, freq='C', tz=None,
                 normalize=True, name=None, closed=None, **kwargs):
     """
-    **EXPERIMENTAL** Return a fixed frequency datetime index, with
+    **EXPERIMENTAL** Return a fixed frequency DatetimeIndex, with
     CustomBusinessDay as the default frequency
 
     .. warning:: EXPERIMENTAL
@@ -2108,29 +2108,29 @@ def cdate_range(start=None, end=None, periods=None, freq='C', tz=None,
         Left bound for generating dates
     end : string or datetime-like, default None
         Right bound for generating dates
-    periods : integer or None, default None
-        If None, must specify start and end
+    periods : integer, default None
+        Number of dates to generate
     freq : string or DateOffset, default 'C' (CustomBusinessDay)
         Frequency strings can have multiples, e.g. '5H'
-    tz : string or None
+    tz : string, default None
         Time zone name for returning localized DatetimeIndex, for example
         Asia/Beijing
     normalize : bool, default False
         Normalize start/end dates to midnight before generating date range
-    name : str, default None
-        Name for the resulting index
-    weekmask : str, Default 'Mon Tue Wed Thu Fri'
+    name : string, default None
+        Name of the resulting DatetimeIndex
+    weekmask : string, Default 'Mon Tue Wed Thu Fri'
         weekmask of valid business days, passed to ``numpy.busdaycalendar``
     holidays : list
         list/array of dates to exclude from the set of valid business days,
         passed to ``numpy.busdaycalendar``
-    closed : string or None, default None
+    closed : string, default None
         Make the interval closed with respect to the given frequency to
         the 'left', 'right', or both sides (None)
 
     Notes
     -----
-    Of the three parameters, ``start``, ``end``, and ``periods``, exactly two
+    Of the three parameters: ``start``, ``end``, and ``periods``, exactly two
     must be specified.
 
     To learn more about the frequency strings, please see `this link

--- a/pandas/core/indexes/datetimes.py
+++ b/pandas/core/indexes/datetimes.py
@@ -293,7 +293,7 @@ class DatetimeIndex(DatelikeOps, TimelikeOps, DatetimeIndexOpsMixin,
                 periods = int(periods)
             elif not is_integer(periods):
                 msg = 'periods must be a number, got {periods}'
-                raise ValueError(msg.format(periods=periods))
+                raise TypeError(msg.format(periods=periods))
 
         if data is None and freq is None:
             raise ValueError("Must provide freq argument if no data is "
@@ -2015,7 +2015,7 @@ def date_range(start=None, end=None, periods=None, freq='D', tz=None,
     end : string or datetime-like, default None
         Right bound for generating dates
     periods : integer, default None
-        Number of dates to generate
+        Number of periods to generate
     freq : string or DateOffset, default 'D' (calendar daily)
         Frequency strings can have multiples, e.g. '5H'
     tz : string, default None
@@ -2059,9 +2059,9 @@ def bdate_range(start=None, end=None, periods=None, freq='B', tz=None,
     end : string or datetime-like, default None
         Right bound for generating dates
     periods : integer, default None
-        Number of dates to generate
+        Number of periods to generate
     freq : string or DateOffset, default 'B' (business daily)
-        Frequency strings can have multiples, e.g. '5, default
+        Frequency strings can have multiples, e.g. '5H'
     tz : string or None
         Time zone name for returning localized DatetimeIndex, for example
         Asia/Beijing
@@ -2109,7 +2109,7 @@ def cdate_range(start=None, end=None, periods=None, freq='C', tz=None,
     end : string or datetime-like, default None
         Right bound for generating dates
     periods : integer, default None
-        Number of dates to generate
+        Number of periods to generate
     freq : string or DateOffset, default 'C' (CustomBusinessDay)
         Frequency strings can have multiples, e.g. '5H'
     tz : string, default None

--- a/pandas/core/indexes/interval.py
+++ b/pandas/core/indexes/interval.py
@@ -1039,8 +1039,8 @@ def interval_range(start=None, end=None, freq=None, periods=None,
         Left bound for generating data
     end : string or datetime-like, default None
         Right bound for generating data
-    freq : interger, string or DateOffset, default 1
-    periods : interger, default None
+    freq : integer, string or DateOffset, default 1
+    periods : integer, default None
     name : str, default None
         Name of the resulting index
     closed : string, default 'right'
@@ -1048,34 +1048,26 @@ def interval_range(start=None, end=None, freq=None, periods=None,
 
     Notes
     -----
-    2 of start, end, or periods must be specified
+    Exactly two of start, end, or periods must be specified
 
     Returns
     -------
     rng : IntervalIndex
     """
+    if com._count_not_none(start, end, periods) != 2:
+        raise ValueError('Must specify exactly two of start, end, or periods')
 
     if freq is None:
         freq = 1
-
     if start is None:
-        if periods is None or end is None:
-            raise ValueError("must specify 2 of start, end, periods")
         start = end - periods * freq
     if end is None:
-        if periods is None or start is None:
-            raise ValueError("must specify 2 of start, end, periods")
         end = start + periods * freq
-    if periods is None:
-        if start is None or end is None:
-            raise ValueError("must specify 2 of start, end, periods")
-        pass
 
     # must all be same units or None
     arr = np.array([start, end, freq])
     if is_object_dtype(arr):
         raise ValueError("start, end, freq need to be the same type")
 
-    return IntervalIndex.from_breaks(np.arange(start, end, freq),
-                                     name=name,
-                                     closed=closed)
+    return IntervalIndex.from_breaks(np.arange(start, end + 1, freq),
+                                     name=name, closed=closed, **kwargs)

--- a/pandas/core/indexes/interval.py
+++ b/pandas/core/indexes/interval.py
@@ -1048,14 +1048,16 @@ def interval_range(start=None, end=None, freq=None, periods=None,
 
     Notes
     -----
-    Exactly two of start, end, or periods must be specified
+    Of the three parameters, ``start``, ``end``, and ``periods``, exactly two
+    must be specified.
 
     Returns
     -------
     rng : IntervalIndex
     """
     if com._count_not_none(start, end, periods) != 2:
-        raise ValueError('Must specify exactly two of start, end, or periods')
+        raise ValueError('Of the three parameters, start, end, and periods, '
+                         'exactly two must be specified')
 
     if freq is None:
         freq = 1

--- a/pandas/core/indexes/period.py
+++ b/pandas/core/indexes/period.py
@@ -1051,8 +1051,8 @@ PeriodIndex._add_datetimelike_methods()
 
 
 def _get_ordinal_range(start, end, periods, freq, mult=1):
-    if com._count_not_none(start, end, periods) < 2:
-        raise ValueError('Must specify 2 of start, end, periods')
+    if com._count_not_none(start, end, periods) != 2:
+        raise ValueError('Must specify exactly two of start, end, or periods')
 
     if freq is not None:
         _, mult = _gfc(freq)
@@ -1160,7 +1160,6 @@ def period_range(start=None, end=None, periods=None, freq='D', name=None):
     Return a fixed frequency datetime index, with day (calendar) as the default
     frequency
 
-
     Parameters
     ----------
     start : starting value, period-like, optional
@@ -1171,6 +1170,13 @@ def period_range(start=None, end=None, periods=None, freq='D', name=None):
         Frequency alias
     name : str, default None
         Name for the resulting PeriodIndex
+
+    Notes
+    -----
+    Exactly two of start, end, or periods must be specified
+
+    To learn more about the frequency strings, please see `this link
+    <http://pandas.pydata.org/pandas-docs/stable/timeseries.html#offset-aliases>`__.
 
     Returns
     -------

--- a/pandas/core/indexes/period.py
+++ b/pandas/core/indexes/period.py
@@ -199,8 +199,8 @@ class PeriodIndex(DatelikeOps, DatetimeIndexOpsMixin, Int64Index):
             if is_float(periods):
                 periods = int(periods)
             elif not is_integer(periods):
-                raise ValueError('Periods must be a number, got %s' %
-                                 str(periods))
+                msg = 'periods must be a number, got {periods}'
+                raise ValueError(msg.format(periods=periods))
 
         if name is None and hasattr(data, 'name'):
             name = data.name
@@ -1052,7 +1052,7 @@ PeriodIndex._add_datetimelike_methods()
 
 def _get_ordinal_range(start, end, periods, freq, mult=1):
     if com._count_not_none(start, end, periods) != 2:
-        raise ValueError('Of the three parameters, start, end, and periods, '
+        raise ValueError('Of the three parameters: start, end, and periods, '
                          'exactly two must be specified')
 
     if freq is not None:
@@ -1067,9 +1067,9 @@ def _get_ordinal_range(start, end, periods, freq, mult=1):
     is_end_per = isinstance(end, Period)
 
     if is_start_per and is_end_per and start.freq != end.freq:
-        raise ValueError('Start and end must have same freq')
+        raise ValueError('start and end must have same freq')
     if (start is tslib.NaT or end is tslib.NaT):
-        raise ValueError('Start and end must not be NaT')
+        raise ValueError('start and end must not be NaT')
 
     if freq is None:
         if is_start_per:
@@ -1158,23 +1158,25 @@ def pnow(freq=None):
 
 def period_range(start=None, end=None, periods=None, freq='D', name=None):
     """
-    Return a fixed frequency datetime index, with day (calendar) as the default
+    Return a fixed frequency PeriodIndex, with day (calendar) as the default
     frequency
 
     Parameters
     ----------
-    start : starting value, period-like, optional
-    end : ending value, period-like, optional
-    periods : int, default None
-        Number of periods in the index
-    freq : str/DateOffset, default 'D'
+    start : string or period-like, default None
+        Left bound for generating periods
+    end : string or period-like, default None
+        Right bound for generating periods
+    periods : integer, default None
+        Number of periods to generate
+    freq : string or DateOffset, default 'D' (calendar daily)
         Frequency alias
-    name : str, default None
-        Name for the resulting PeriodIndex
+    name : string, default None
+        Name of the resulting PeriodIndex
 
     Notes
     -----
-    Of the three parameters, ``start``, ``end``, and ``periods``, exactly two
+    Of the three parameters: ``start``, ``end``, and ``periods``, exactly two
     must be specified.
 
     To learn more about the frequency strings, please see `this link
@@ -1183,9 +1185,27 @@ def period_range(start=None, end=None, periods=None, freq='D', name=None):
     Returns
     -------
     prng : PeriodIndex
+
+    Examples
+    --------
+
+    >>> pd.period_range(start='2017-01-01', end='2018-01-01', freq='M')
+    PeriodIndex(['2017-01', '2017-02', '2017-03', '2017-04', '2017-05',
+                 '2017-06', '2017-06', '2017-07', '2017-08', '2017-09',
+                 '2017-10', '2017-11', '2017-12', '2018-01'],
+                dtype='period[M]', freq='M')
+
+    If ``start`` or ``end`` are ``Period`` objects, they will be used as anchor
+    endpoints for a ``PeriodIndex`` with frequency matching that of the
+    ``period_range`` constructor.
+
+    >>> pd.period_range(start=pd.Period('2017Q1', freq='Q'),
+    ...                 end=pd.Period('2017Q2', freq='Q'), freq='M')
+    PeriodIndex(['2017-03', '2017-04', '2017-05', '2017-06'],
+                dtype='period[M]', freq='M')
     """
     if com._count_not_none(start, end, periods) != 2:
-        raise ValueError('Of the three parameters, start, end, and periods, '
+        raise ValueError('Of the three parameters: start, end, and periods, '
                          'exactly two must be specified')
 
     return PeriodIndex(start=start, end=end, periods=periods,

--- a/pandas/core/indexes/period.py
+++ b/pandas/core/indexes/period.py
@@ -200,7 +200,7 @@ class PeriodIndex(DatelikeOps, DatetimeIndexOpsMixin, Int64Index):
                 periods = int(periods)
             elif not is_integer(periods):
                 msg = 'periods must be a number, got {periods}'
-                raise ValueError(msg.format(periods=periods))
+                raise TypeError(msg.format(periods=periods))
 
         if name is None and hasattr(data, 'name'):
             name = data.name

--- a/pandas/core/indexes/period.py
+++ b/pandas/core/indexes/period.py
@@ -1052,7 +1052,8 @@ PeriodIndex._add_datetimelike_methods()
 
 def _get_ordinal_range(start, end, periods, freq, mult=1):
     if com._count_not_none(start, end, periods) != 2:
-        raise ValueError('Must specify exactly two of start, end, or periods')
+        raise ValueError('Of the three parameters, start, end, and periods, '
+                         'exactly two must be specified')
 
     if freq is not None:
         _, mult = _gfc(freq)
@@ -1173,7 +1174,8 @@ def period_range(start=None, end=None, periods=None, freq='D', name=None):
 
     Notes
     -----
-    Exactly two of start, end, or periods must be specified
+    Of the three parameters, ``start``, ``end``, and ``periods``, exactly two
+    must be specified.
 
     To learn more about the frequency strings, please see `this link
     <http://pandas.pydata.org/pandas-docs/stable/timeseries.html#offset-aliases>`__.
@@ -1182,5 +1184,9 @@ def period_range(start=None, end=None, periods=None, freq='D', name=None):
     -------
     prng : PeriodIndex
     """
+    if com._count_not_none(start, end, periods) != 2:
+        raise ValueError('Of the three parameters, start, end, and periods, '
+                         'exactly two must be specified')
+
     return PeriodIndex(start=start, end=end, periods=periods,
                        freq=freq, name=name)

--- a/pandas/core/indexes/timedeltas.py
+++ b/pandas/core/indexes/timedeltas.py
@@ -234,8 +234,8 @@ class TimedeltaIndex(DatetimeIndexOpsMixin, TimelikeOps, Int64Index):
     @classmethod
     def _generate(cls, start, end, periods, name, offset, closed=None):
         if com._count_not_none(start, end, periods) != 2:
-            msg = 'Must specify exactly two of start, end, or periods'
-            raise ValueError(msg)
+            raise ValueError('Of the three parameters, start, end, and '
+                             'periods, exactly two must be specified')
 
         if start is not None:
             start = Timedelta(start)
@@ -986,7 +986,8 @@ def timedelta_range(start=None, end=None, periods=None, freq='D',
 
     Notes
     -----
-    Exactly two of start, end, or periods must be specified.
+    Of the three parameters, ``start``, ``end``, and ``periods``, exactly two
+    must be specified.
 
     To learn more about the frequency strings, please see `this link
     <http://pandas.pydata.org/pandas-docs/stable/timeseries.html#offset-aliases>`__.

--- a/pandas/core/indexes/timedeltas.py
+++ b/pandas/core/indexes/timedeltas.py
@@ -180,8 +180,8 @@ class TimedeltaIndex(DatetimeIndexOpsMixin, TimelikeOps, Int64Index):
             if is_float(periods):
                 periods = int(periods)
             elif not is_integer(periods):
-                raise ValueError('Periods must be a number, got %s' %
-                                 str(periods))
+                msg = 'periods must be a number, got {periods}'
+                raise ValueError(msg.format(periods=periods))
 
         if data is None and freq is None:
             raise ValueError("Must provide freq argument if no data is "
@@ -234,7 +234,7 @@ class TimedeltaIndex(DatetimeIndexOpsMixin, TimelikeOps, Int64Index):
     @classmethod
     def _generate(cls, start, end, periods, name, offset, closed=None):
         if com._count_not_none(start, end, periods) != 2:
-            raise ValueError('Of the three parameters, start, end, and '
+            raise ValueError('Of the three parameters: start, end, and '
                              'periods, exactly two must be specified')
 
         if start is not None:
@@ -961,22 +961,22 @@ def _generate_regular_range(start, end, periods, offset):
 def timedelta_range(start=None, end=None, periods=None, freq='D',
                     name=None, closed=None):
     """
-    Return a fixed frequency timedelta index, with day as the default
+    Return a fixed frequency TimedeltaIndex, with day as the default
     frequency
 
     Parameters
     ----------
     start : string or timedelta-like, default None
-        Left bound for generating dates
-    end : string or datetime-like, default None
-        Right bound for generating dates
-    periods : integer or None, default None
-        If None, must specify start and end
+        Left bound for generating timedeltas
+    end : string or timedelta-like, default None
+        Right bound for generating timedeltas
+    periods : integer, default None
+        Number of timedeltas to generate
     freq : string or DateOffset, default 'D' (calendar daily)
         Frequency strings can have multiples, e.g. '5H'
-    name : str, default None
-        Name of the resulting index
-    closed : string or None, default None
+    name : string, default None
+        Name of the resulting TimedeltaIndex
+    closed : string, default None
         Make the interval closed with respect to the given frequency to
         the 'left', 'right', or both sides (None)
 
@@ -986,12 +986,11 @@ def timedelta_range(start=None, end=None, periods=None, freq='D',
 
     Notes
     -----
-    Of the three parameters, ``start``, ``end``, and ``periods``, exactly two
+    Of the three parameters: ``start``, ``end``, and ``periods``, exactly two
     must be specified.
 
     To learn more about the frequency strings, please see `this link
     <http://pandas.pydata.org/pandas-docs/stable/timeseries.html#offset-aliases>`__.
     """
     return TimedeltaIndex(start=start, end=end, periods=periods,
-                          freq=freq, name=name,
-                          closed=closed)
+                          freq=freq, name=name, closed=closed)

--- a/pandas/core/indexes/timedeltas.py
+++ b/pandas/core/indexes/timedeltas.py
@@ -234,7 +234,8 @@ class TimedeltaIndex(DatetimeIndexOpsMixin, TimelikeOps, Int64Index):
     @classmethod
     def _generate(cls, start, end, periods, name, offset, closed=None):
         if com._count_not_none(start, end, periods) != 2:
-            raise ValueError('Must specify two of start, end, or periods')
+            msg = 'Must specify exactly two of start, end, or periods'
+            raise ValueError(msg)
 
         if start is not None:
             start = Timedelta(start)
@@ -985,7 +986,7 @@ def timedelta_range(start=None, end=None, periods=None, freq='D',
 
     Notes
     -----
-    2 of start, end, or periods must be specified.
+    Exactly two of start, end, or periods must be specified.
 
     To learn more about the frequency strings, please see `this link
     <http://pandas.pydata.org/pandas-docs/stable/timeseries.html#offset-aliases>`__.

--- a/pandas/core/indexes/timedeltas.py
+++ b/pandas/core/indexes/timedeltas.py
@@ -181,7 +181,7 @@ class TimedeltaIndex(DatetimeIndexOpsMixin, TimelikeOps, Int64Index):
                 periods = int(periods)
             elif not is_integer(periods):
                 msg = 'periods must be a number, got {periods}'
-                raise ValueError(msg.format(periods=periods))
+                raise TypeError(msg.format(periods=periods))
 
         if data is None and freq is None:
             raise ValueError("Must provide freq argument if no data is "
@@ -971,7 +971,7 @@ def timedelta_range(start=None, end=None, periods=None, freq='D',
     end : string or timedelta-like, default None
         Right bound for generating timedeltas
     periods : integer, default None
-        Number of timedeltas to generate
+        Number of periods to generate
     freq : string or DateOffset, default 'D' (calendar daily)
         Frequency strings can have multiples, e.g. '5H'
     name : string, default None
@@ -991,6 +991,29 @@ def timedelta_range(start=None, end=None, periods=None, freq='D',
 
     To learn more about the frequency strings, please see `this link
     <http://pandas.pydata.org/pandas-docs/stable/timeseries.html#offset-aliases>`__.
+
+    Examples
+    --------
+
+    >>> pd.timedelta_range(start='1 day', periods=4)
+    TimedeltaIndex(['1 days', '2 days', '3 days', '4 days'],
+                   dtype='timedelta64[ns]', freq='D')
+
+    The ``closed`` parameter specifies which endpoint is included.  The default
+    behavior is to include both endpoints.
+
+    >>> pd.timedelta_range(start='1 day', periods=4, closed='right')
+    TimedeltaIndex(['2 days', '3 days', '4 days'],
+                   dtype='timedelta64[ns]', freq='D')
+
+    The ``freq`` parameter specifies the frequency of the TimedeltaIndex.
+    Only fixed frequencies can be passed, non-fixed frequencies such as
+    'M' (month end) will raise.
+
+    >>> pd.timedelta_range(start='1 day', end='2 days', freq='6H')
+    TimedeltaIndex(['1 days 00:00:00', '1 days 06:00:00', '1 days 12:00:00',
+                    '1 days 18:00:00', '2 days 00:00:00'],
+                   dtype='timedelta64[ns]', freq='6H')
     """
     return TimedeltaIndex(start=start, end=end, periods=periods,
                           freq=freq, name=name, closed=closed)

--- a/pandas/tests/indexes/datetimes/test_construction.py
+++ b/pandas/tests/indexes/datetimes/test_construction.py
@@ -307,8 +307,9 @@ class TestDatetimeIndex(object):
         exp = date_range('1/1/2000', periods=10)
         tm.assert_index_equal(rng, exp)
 
-        pytest.raises(ValueError, DatetimeIndex, start='1/1/2000',
-                      periods='foo', freq='D')
+        msg = 'periods must be a number, got foo'
+        with tm.assert_raises_regex(TypeError, msg):
+            DatetimeIndex(start='1/1/2000', periods='foo', freq='D')
 
         pytest.raises(ValueError, DatetimeIndex, start='1/1/2000',
                       end='1/10/2000')

--- a/pandas/tests/indexes/datetimes/test_date_range.py
+++ b/pandas/tests/indexes/datetimes/test_date_range.py
@@ -107,7 +107,7 @@ class TestDateRanges(TestData):
         start = datetime(2011, 1, 1, 5, 3, 40)
         end = datetime(2011, 1, 1, 8, 9, 40)
 
-        msg = ('Of the three parameters, start, end, and periods, '
+        msg = ('Of the three parameters: start, end, and periods, '
                'exactly two must be specified')
         with tm.assert_raises_regex(ValueError, msg):
             date_range(start, end, periods=10, freq='s')
@@ -148,7 +148,7 @@ class TestDateRanges(TestData):
 
     def test_range_misspecified(self):
         # GH #1095
-        msg = ('Of the three parameters, start, end, and periods, '
+        msg = ('Of the three parameters: start, end, and periods, '
                'exactly two must be specified')
 
         with tm.assert_raises_regex(ValueError, msg):

--- a/pandas/tests/indexes/datetimes/test_date_range.py
+++ b/pandas/tests/indexes/datetimes/test_date_range.py
@@ -107,8 +107,8 @@ class TestDateRanges(TestData):
         start = datetime(2011, 1, 1, 5, 3, 40)
         end = datetime(2011, 1, 1, 8, 9, 40)
 
-        pytest.raises(ValueError, date_range, start, end, freq='s',
-                      periods=10)
+        with pytest.raises(ValueError):
+            date_range(start, end, periods=10, freq='s')
 
     def test_date_range_businesshour(self):
         idx = DatetimeIndex(['2014-07-04 09:00', '2014-07-04 10:00',
@@ -146,14 +146,26 @@ class TestDateRanges(TestData):
 
     def test_range_misspecified(self):
         # GH #1095
+        with pytest.raises(ValueError):
+            date_range(start='1/1/2000')
 
-        pytest.raises(ValueError, date_range, '1/1/2000')
-        pytest.raises(ValueError, date_range, end='1/1/2000')
-        pytest.raises(ValueError, date_range, periods=10)
+        with pytest.raises(ValueError):
+            date_range(end='1/1/2000')
 
-        pytest.raises(ValueError, date_range, '1/1/2000', freq='H')
-        pytest.raises(ValueError, date_range, end='1/1/2000', freq='H')
-        pytest.raises(ValueError, date_range, periods=10, freq='H')
+        with pytest.raises(ValueError):
+            date_range(periods=10)
+
+        with pytest.raises(ValueError):
+            date_range(start='1/1/2000', freq='H')
+
+        with pytest.raises(ValueError):
+            date_range(end='1/1/2000', freq='H')
+
+        with pytest.raises(ValueError):
+            date_range(periods=10, freq='H')
+
+        with pytest.raises(ValueError):
+            date_range()
 
     def test_compat_replace(self):
         # https://github.com/statsmodels/statsmodels/issues/3349

--- a/pandas/tests/indexes/datetimes/test_date_range.py
+++ b/pandas/tests/indexes/datetimes/test_date_range.py
@@ -248,8 +248,13 @@ class TestBusinessDateRange(object):
         bdate_range(START, END, freq=BDay())
         bdate_range(START, periods=20, freq=BDay())
         bdate_range(end=START, periods=20, freq=BDay())
-        pytest.raises(ValueError, date_range, '2011-1-1', '2012-1-1', 'B')
-        pytest.raises(ValueError, bdate_range, '2011-1-1', '2012-1-1', 'B')
+
+        msg = 'periods must be a number, got B'
+        with tm.assert_raises_regex(TypeError, msg):
+            date_range('2011-1-1', '2012-1-1', 'B')
+
+        with tm.assert_raises_regex(TypeError, msg):
+            bdate_range('2011-1-1', '2012-1-1', 'B')
 
     def test_naive_aware_conflicts(self):
         naive = bdate_range(START, END, freq=BDay(), tz=None)
@@ -527,8 +532,13 @@ class TestCustomDateRange(object):
         cdate_range(START, END, freq=CDay())
         cdate_range(START, periods=20, freq=CDay())
         cdate_range(end=START, periods=20, freq=CDay())
-        pytest.raises(ValueError, date_range, '2011-1-1', '2012-1-1', 'C')
-        pytest.raises(ValueError, cdate_range, '2011-1-1', '2012-1-1', 'C')
+
+        msg = 'periods must be a number, got C'
+        with tm.assert_raises_regex(TypeError, msg):
+            date_range('2011-1-1', '2012-1-1', 'C')
+
+        with tm.assert_raises_regex(TypeError, msg):
+            cdate_range('2011-1-1', '2012-1-1', 'C')
 
     def test_cached_range(self):
         DatetimeIndex._cached_range(START, END, offset=CDay())

--- a/pandas/tests/indexes/datetimes/test_date_range.py
+++ b/pandas/tests/indexes/datetimes/test_date_range.py
@@ -107,7 +107,9 @@ class TestDateRanges(TestData):
         start = datetime(2011, 1, 1, 5, 3, 40)
         end = datetime(2011, 1, 1, 8, 9, 40)
 
-        with pytest.raises(ValueError):
+        msg = ('Of the three parameters, start, end, and periods, '
+               'exactly two must be specified')
+        with tm.assert_raises_regex(ValueError, msg):
             date_range(start, end, periods=10, freq='s')
 
     def test_date_range_businesshour(self):
@@ -146,25 +148,28 @@ class TestDateRanges(TestData):
 
     def test_range_misspecified(self):
         # GH #1095
-        with pytest.raises(ValueError):
+        msg = ('Of the three parameters, start, end, and periods, '
+               'exactly two must be specified')
+
+        with tm.assert_raises_regex(ValueError, msg):
             date_range(start='1/1/2000')
 
-        with pytest.raises(ValueError):
+        with tm.assert_raises_regex(ValueError, msg):
             date_range(end='1/1/2000')
 
-        with pytest.raises(ValueError):
+        with tm.assert_raises_regex(ValueError, msg):
             date_range(periods=10)
 
-        with pytest.raises(ValueError):
+        with tm.assert_raises_regex(ValueError, msg):
             date_range(start='1/1/2000', freq='H')
 
-        with pytest.raises(ValueError):
+        with tm.assert_raises_regex(ValueError, msg):
             date_range(end='1/1/2000', freq='H')
 
-        with pytest.raises(ValueError):
+        with tm.assert_raises_regex(ValueError, msg):
             date_range(periods=10, freq='H')
 
-        with pytest.raises(ValueError):
+        with tm.assert_raises_regex(ValueError, msg):
             date_range()
 
     def test_compat_replace(self):

--- a/pandas/tests/indexes/period/test_construction.py
+++ b/pandas/tests/indexes/period/test_construction.py
@@ -436,11 +436,11 @@ class TestPeriodIndex(object):
         start = Period('02-Apr-2005', 'B')
         end_intv = Period('2006-12-31', ('w', 1))
 
-        msg = 'Start and end must have same freq'
+        msg = 'start and end must have same freq'
         with tm.assert_raises_regex(ValueError, msg):
             PeriodIndex(start=start, end=end_intv)
 
-        msg = ('Of the three parameters, start, end, and periods, '
+        msg = ('Of the three parameters: start, end, and periods, '
                'exactly two must be specified')
         with tm.assert_raises_regex(ValueError, msg):
             PeriodIndex(start=start)

--- a/pandas/tests/indexes/period/test_construction.py
+++ b/pandas/tests/indexes/period/test_construction.py
@@ -440,7 +440,8 @@ class TestPeriodIndex(object):
         with tm.assert_raises_regex(ValueError, msg):
             PeriodIndex(start=start, end=end_intv)
 
-        msg = 'Must specify exactly two of start, end, or periods'
+        msg = ('Of the three parameters, start, end, and periods, '
+               'exactly two must be specified')
         with tm.assert_raises_regex(ValueError, msg):
             PeriodIndex(start=start)
 

--- a/pandas/tests/indexes/period/test_construction.py
+++ b/pandas/tests/indexes/period/test_construction.py
@@ -440,7 +440,7 @@ class TestPeriodIndex(object):
         with tm.assert_raises_regex(ValueError, msg):
             PeriodIndex(start=start, end=end_intv)
 
-        msg = 'Must specify 2 of start, end, periods'
+        msg = 'Must specify exactly two of start, end, or periods'
         with tm.assert_raises_regex(ValueError, msg):
             PeriodIndex(start=start)
 

--- a/pandas/tests/indexes/period/test_period_range.py
+++ b/pandas/tests/indexes/period/test_period_range.py
@@ -1,12 +1,12 @@
 import pytest
 import pandas.util.testing as tm
-from pandas import date_range, period_range, PeriodIndex
+from pandas import date_range, NaT, period_range, Period, PeriodIndex
 
 
 class TestPeriodRange(object):
 
     @pytest.mark.parametrize('freq', ['D', 'W', 'M', 'Q', 'A'])
-    def test_construction(self, freq):
+    def test_construction_from_string(self, freq):
         # non-empty
         expected = date_range(start='2017-01-01', periods=5,
                               freq=freq, name='foo').to_period()
@@ -33,9 +33,36 @@ class TestPeriodRange(object):
         result = period_range(start=end, end=start, freq=freq, name='foo')
         tm.assert_index_equal(result, expected)
 
+    def test_construction_from_period(self):
+        # upsampling
+        start, end = Period('2017Q1', freq='Q'), Period('2018Q1', freq='Q')
+        expected = date_range(start='2017-03-31', end='2018-03-31', freq='M',
+                              name='foo').to_period()
+        result = period_range(start=start, end=end, freq='M', name='foo')
+        tm.assert_index_equal(result, expected)
+
+        # downsampling
+        start, end = Period('2017-1', freq='M'), Period('2019-12', freq='M')
+        expected = date_range(start='2017-01-31', end='2019-12-31', freq='Q',
+                              name='foo').to_period()
+        result = period_range(start=start, end=end, freq='Q', name='foo')
+        tm.assert_index_equal(result, expected)
+
+        # empty
+        expected = PeriodIndex([], freq='W', name='foo')
+
+        result = period_range(start=start, periods=0, freq='W', name='foo')
+        tm.assert_index_equal(result, expected)
+
+        result = period_range(end=end, periods=0, freq='W', name='foo')
+        tm.assert_index_equal(result, expected)
+
+        result = period_range(start=end, end=start, freq='W', name='foo')
+        tm.assert_index_equal(result, expected)
+
     def test_errors(self):
         # not enough params
-        msg = ('Of the three parameters, start, end, and periods, '
+        msg = ('Of the three parameters: start, end, and periods, '
                'exactly two must be specified')
         with tm.assert_raises_regex(ValueError, msg):
             period_range(start='2017Q1')
@@ -52,3 +79,11 @@ class TestPeriodRange(object):
         # too many params
         with tm.assert_raises_regex(ValueError, msg):
             period_range(start='2017Q1', end='2018Q1', periods=8, freq='Q')
+
+        # start/end NaT
+        msg = 'start and end must not be NaT'
+        with tm.assert_raises_regex(ValueError, msg):
+            period_range(start=NaT, end='2018Q1')
+
+        with tm.assert_raises_regex(ValueError, msg):
+            period_range(start='2017Q1', end=NaT)

--- a/pandas/tests/indexes/period/test_period_range.py
+++ b/pandas/tests/indexes/period/test_period_range.py
@@ -87,3 +87,8 @@ class TestPeriodRange(object):
 
         with tm.assert_raises_regex(ValueError, msg):
             period_range(start='2017Q1', end=NaT)
+
+        # invalid periods param
+        msg = 'periods must be a number, got foo'
+        with tm.assert_raises_regex(TypeError, msg):
+            period_range(start='2017Q1', periods='foo')

--- a/pandas/tests/indexes/period/test_period_range.py
+++ b/pandas/tests/indexes/period/test_period_range.py
@@ -35,18 +35,20 @@ class TestPeriodRange(object):
 
     def test_errors(self):
         # not enough params
-        with pytest.raises(ValueError):
+        msg = ('Of the three parameters, start, end, and periods, '
+               'exactly two must be specified')
+        with tm.assert_raises_regex(ValueError, msg):
             period_range(start='2017Q1')
 
-        with pytest.raises(ValueError):
+        with tm.assert_raises_regex(ValueError, msg):
             period_range(end='2017Q1')
 
-        with pytest.raises(ValueError):
+        with tm.assert_raises_regex(ValueError, msg):
             period_range(periods=5)
 
-        with pytest.raises(ValueError):
+        with tm.assert_raises_regex(ValueError, msg):
             period_range()
 
         # too many params
-        with pytest.raises(ValueError):
+        with tm.assert_raises_regex(ValueError, msg):
             period_range(start='2017Q1', end='2018Q1', periods=8, freq='Q')

--- a/pandas/tests/indexes/period/test_period_range.py
+++ b/pandas/tests/indexes/period/test_period_range.py
@@ -1,0 +1,52 @@
+import pytest
+import pandas.util.testing as tm
+from pandas import date_range, period_range, PeriodIndex
+
+
+class TestPeriodRange(object):
+
+    @pytest.mark.parametrize('freq', ['D', 'W', 'M', 'Q', 'A'])
+    def test_construction(self, freq):
+        # non-empty
+        expected = date_range(start='2017-01-01', periods=5,
+                              freq=freq, name='foo').to_period()
+        start, end = str(expected[0]), str(expected[-1])
+
+        result = period_range(start=start, end=end, freq=freq, name='foo')
+        tm.assert_index_equal(result, expected)
+
+        result = period_range(start=start, periods=5, freq=freq, name='foo')
+        tm.assert_index_equal(result, expected)
+
+        result = period_range(end=end, periods=5, freq=freq, name='foo')
+        tm.assert_index_equal(result, expected)
+
+        # empty
+        expected = PeriodIndex([], freq=freq, name='foo')
+
+        result = period_range(start=start, periods=0, freq=freq, name='foo')
+        tm.assert_index_equal(result, expected)
+
+        result = period_range(end=end, periods=0, freq=freq, name='foo')
+        tm.assert_index_equal(result, expected)
+
+        result = period_range(start=end, end=start, freq=freq, name='foo')
+        tm.assert_index_equal(result, expected)
+
+    def test_errors(self):
+        # not enough params
+        with pytest.raises(ValueError):
+            period_range(start='2017Q1')
+
+        with pytest.raises(ValueError):
+            period_range(end='2017Q1')
+
+        with pytest.raises(ValueError):
+            period_range(periods=5)
+
+        with pytest.raises(ValueError):
+            period_range()
+
+        # too many params
+        with pytest.raises(ValueError):
+            period_range(start='2017Q1', end='2018Q1', periods=8, freq='Q')

--- a/pandas/tests/indexes/test_interval.py
+++ b/pandas/tests/indexes/test_interval.py
@@ -753,13 +753,21 @@ class TestIntervalRange(object):
         tm.assert_index_equal(result, expected)
 
         # output truncates early if freq causes end to be skipped.
-        result = interval_range(start=0, end=7, freq=2, name='foo',
+        expected = IntervalIndex.from_tuples([(0.0, 1.5), (1.5, 3.0)],
+                                             name='foo', closed=closed)
+        result = interval_range(start=0, end=4, freq=1.5, name='foo',
                                 closed=closed)
+        tm.assert_index_equal(result, expected)
+
+    def test_constructor_coverage(self):
+        # float value for periods
+        expected = pd.interval_range(start=0, periods=10)
+        result = pd.interval_range(start=0, periods=10.5)
         tm.assert_index_equal(result, expected)
 
     def test_errors(self):
         # not enough params
-        msg = ('Of the three parameters, start, end, and periods, '
+        msg = ('Of the three parameters: start, end, and periods, '
                'exactly two must be specified')
 
         with tm.assert_raises_regex(ValueError, msg):
@@ -778,8 +786,16 @@ class TestIntervalRange(object):
         with tm.assert_raises_regex(ValueError, msg):
             interval_range(start=0, end=5, periods=6)
 
+        # invalid periods
+        msg = 'periods must be a number, got foo'
+        with tm.assert_raises_regex(ValueError, msg):
+            interval_range(start=0, periods='foo')
+
         # mixed units
         msg = 'start, end, freq need to be the same type'
+        with tm.assert_raises_regex(ValueError, msg):
+            interval_range(start=Timestamp('20130101'), end=10, freq=2)
+
         with tm.assert_raises_regex(ValueError, msg):
             interval_range(start=0, end=Timestamp('20130101'), freq=2)
 

--- a/pandas/tests/indexes/test_interval.py
+++ b/pandas/tests/indexes/test_interval.py
@@ -759,27 +759,31 @@ class TestIntervalRange(object):
 
     def test_errors(self):
         # not enough params
-        with pytest.raises(ValueError):
+        msg = ('Of the three parameters, start, end, and periods, '
+               'exactly two must be specified')
+
+        with tm.assert_raises_regex(ValueError, msg):
             interval_range(start=0)
 
-        with pytest.raises(ValueError):
+        with tm.assert_raises_regex(ValueError, msg):
             interval_range(end=5)
 
-        with pytest.raises(ValueError):
+        with tm.assert_raises_regex(ValueError, msg):
             interval_range(periods=2)
 
-        with pytest.raises(ValueError):
+        with tm.assert_raises_regex(ValueError, msg):
             interval_range()
 
         # too many params
-        with pytest.raises(ValueError):
+        with tm.assert_raises_regex(ValueError, msg):
             interval_range(start=0, end=5, periods=6)
 
         # mixed units
-        with pytest.raises(ValueError):
+        msg = 'start, end, freq need to be the same type'
+        with tm.assert_raises_regex(ValueError, msg):
             interval_range(start=0, end=Timestamp('20130101'), freq=2)
 
-        with pytest.raises(ValueError):
+        with tm.assert_raises_regex(ValueError, msg):
             interval_range(start=0, end=10, freq=Timedelta('1day'))
 
 

--- a/pandas/tests/indexes/timedeltas/test_construction.py
+++ b/pandas/tests/indexes/timedeltas/test_construction.py
@@ -50,8 +50,9 @@ class TestTimedeltaIndex(object):
         exp = timedelta_range('1 days', periods=10)
         tm.assert_index_equal(rng, exp)
 
-        pytest.raises(ValueError, TimedeltaIndex, start='1 days',
-                      periods='foo', freq='D')
+        msg = 'periods must be a number, got foo'
+        with tm.assert_raises_regex(TypeError, msg):
+            TimedeltaIndex(start='1 days', periods='foo', freq='D')
 
         pytest.raises(ValueError, TimedeltaIndex, start='1 days',
                       end='10 days')

--- a/pandas/tests/indexes/timedeltas/test_timedelta_range.py
+++ b/pandas/tests/indexes/timedeltas/test_timedelta_range.py
@@ -51,7 +51,7 @@ class TestTimedeltas(object):
 
     def test_errors(self):
         # not enough params
-        msg = ('Of the three parameters, start, end, and periods, '
+        msg = ('Of the three parameters: start, end, and periods, '
                'exactly two must be specified')
         with tm.assert_raises_regex(ValueError, msg):
             timedelta_range(start='0 days')

--- a/pandas/tests/indexes/timedeltas/test_timedelta_range.py
+++ b/pandas/tests/indexes/timedeltas/test_timedelta_range.py
@@ -1,5 +1,5 @@
 import numpy as np
-
+import pytest
 import pandas as pd
 import pandas.util.testing as tm
 from pandas.tseries.offsets import Day, Second
@@ -49,3 +49,21 @@ class TestTimedeltas(object):
         expected = df.loc[pd.Timedelta('0s'):, :]
         result = df.loc['0s':, :]
         assert_frame_equal(expected, result)
+
+    def test_errors(self):
+        # not enough params
+        with pytest.raises(ValueError):
+            timedelta_range(start='0 days')
+
+        with pytest.raises(ValueError):
+            timedelta_range(end='5 days')
+
+        with pytest.raises(ValueError):
+            timedelta_range(periods=2)
+
+        with pytest.raises(ValueError):
+            timedelta_range()
+
+        # too many params
+        with pytest.raises(ValueError):
+            timedelta_range(start='0 days', end='5 days', periods=10)

--- a/pandas/tests/indexes/timedeltas/test_timedelta_range.py
+++ b/pandas/tests/indexes/timedeltas/test_timedelta_range.py
@@ -1,5 +1,4 @@
 import numpy as np
-import pytest
 import pandas as pd
 import pandas.util.testing as tm
 from pandas.tseries.offsets import Day, Second
@@ -52,18 +51,20 @@ class TestTimedeltas(object):
 
     def test_errors(self):
         # not enough params
-        with pytest.raises(ValueError):
+        msg = ('Of the three parameters, start, end, and periods, '
+               'exactly two must be specified')
+        with tm.assert_raises_regex(ValueError, msg):
             timedelta_range(start='0 days')
 
-        with pytest.raises(ValueError):
+        with tm.assert_raises_regex(ValueError, msg):
             timedelta_range(end='5 days')
 
-        with pytest.raises(ValueError):
+        with tm.assert_raises_regex(ValueError, msg):
             timedelta_range(periods=2)
 
-        with pytest.raises(ValueError):
+        with tm.assert_raises_regex(ValueError, msg):
             timedelta_range()
 
         # too many params
-        with pytest.raises(ValueError):
+        with tm.assert_raises_regex(ValueError, msg):
             timedelta_range(start='0 days', end='5 days', periods=10)


### PR DESCRIPTION
- [X] closes #17471
- [X] tests added / passed
- [X] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [X] whatsnew entry

Comments:

- I couldn't find any existing tests of `period_range`, so I created a new file `test_period_range.py` in a similar fashion to the existing files `test_date_range.py` and `test_timedelta_range.py`.
- Cleaned up a few existing tests relevant to this issue (used `with` context where appropriate, etc.).