### PR TITLE
Add file-like object to docs for Feather

### DIFF
--- a/pandas/io/feather_format.py
+++ b/pandas/io/feather_format.py
@@ -41,8 +41,7 @@ def to_feather(df, path):
     Parameters
     ----------
     df : DataFrame
-    path : string
-        File path
+    path : string file path, or file-like object
 
     """
     path = _stringify_path(path)
@@ -92,8 +91,7 @@ def read_feather(path, nthreads=1):
 
     Parameters
     ----------
-    path : string
-        File path
+    path : string file path, or file-like object
     nthreads : int, default 1
         Number of CPU threads to use when reading to pandas.DataFrame
 


### PR DESCRIPTION
`read_feather` and `to_feather` accept file-like object. For example, something like this works:
```
# python -uc "import pandas, sys; print(pandas.read_feather(sys.stdin))" < a.feather 
    id
0  1.0
1  2.0
2  3.0
3  NaN
4  5.0
5  6.0
6  7.0
7  8.0
# python -uc "import pandas, sys; pandas.to_feather(pandas.read_feather(sys.stdin), sys.stdout)" < a.feather > b.feather
```

- [ ] closes #xxxx
- [ ] tests added / passed
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
