### PR TITLE
BUG: LatexFormatter.write_result multi-index

### DIFF
--- a/doc/source/whatsnew/v0.21.0.txt
+++ b/doc/source/whatsnew/v0.21.0.txt
@@ -415,6 +415,7 @@ I/O
 - Bug in :func:`read_stata` where value labels could not be read when using an iterator (:issue:`16923`)
 - Bug in :func:`read_html` where import check fails when run in multiple threads (:issue:`16928`)
 - Bug in :func:`read_csv` where automatic delimiter detection caused a ``TypeError`` to be thrown when a bad line was encountered rather than the correct error message (:issue:`13374`)
+- Bug in :func:`to_latex` where repeated multi-index values were not printed even though a higher level index differed from the previous row (:issue:`14484`)
 
 Plotting
 ^^^^^^^^

--- a/pandas/io/formats/format.py
+++ b/pandas/io/formats/format.py
@@ -45,7 +45,6 @@ from pandas.core.indexes.period import PeriodIndex
 import pandas as pd
 import numpy as np
 
-import itertools
 import csv
 from functools import partial
 
@@ -887,6 +886,7 @@ class LatexFormatter(TableFormatter):
             name = any(self.frame.index.names)
             cname = any(self.frame.columns.names)
             lastcol = self.frame.index.nlevels - 1
+            previous_lev3 = None
             for i, lev in enumerate(self.frame.index.levels):
                 lev2 = lev.format()
                 blank = ' ' * len(lev2[0])
@@ -897,11 +897,19 @@ class LatexFormatter(TableFormatter):
                     lev3 = [blank] * clevels
                 if name:
                     lev3.append(lev.name)
-                for level_idx, group in itertools.groupby(
-                        self.frame.index.labels[i]):
-                    count = len(list(group))
-                    lev3.extend([lev2[level_idx]] + [blank] * (count - 1))
+                current_idx_val = None
+                for level_idx in self.frame.index.labels[i]:
+                    if ((previous_lev3 is None or
+                        previous_lev3[len(lev3)].isspace()) and
+                            lev2[level_idx] == current_idx_val):
+                        # same index as above row and left index was the same
+                        lev3.append(blank)
+                    else:
+                        # different value than above or left index different
+                        lev3.append(lev2[level_idx])
+                        current_idx_val = lev2[level_idx]
                 strcols.insert(i, lev3)
+                previous_lev3 = lev3
 
         column_format = self.column_format
         if column_format is None:

--- a/pandas/tests/io/formats/test_to_latex.py
+++ b/pandas/tests/io/formats/test_to_latex.py
@@ -221,6 +221,28 @@ a &       &      &           &      &       &      &       &      \\
 
         assert result == expected
 
+        # GH 14484
+        # If an index is repeated in subsequent rows, it should be
+        # replaced with a blank in the created table.
+        # This should ONLY happen if all higher order indicies
+        # (to the left) are equal, too.
+        # In this test, 'c' has to be printed both times, because
+        # the higher order index 'A' != 'B'
+        df = pd.DataFrame(index=pd.MultiIndex.from_tuples(
+            [('A', 'c'), ('B', 'c')]), columns=['col'])
+        result = df.to_latex()
+        expected = r"""\begin{tabular}{lll}
+\toprule
+  &   &  col \\
+\midrule
+A & c &  NaN \\
+B & c &  NaN \\
+\bottomrule
+\end{tabular}
+"""
+
+        assert result == expected
+
     def test_to_latex_multicolumnrow(self):
         df = pd.DataFrame({
             ('c1', 0): dict((x, x) for x in range(5)),


### PR DESCRIPTION
Fixed GH issue 14484:

`LatexFormatter.write_result(...)` now does not print blanks if a
higher-order index differs from the previous row.
Also added testcase for this.

- [X] closes #14484
- [X] tests added / passed
- [X] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [X] whatsnew entry
