### PR TITLE
Remove from numpy cimport *

### DIFF
--- a/pandas/_libs/algos.pyx
+++ b/pandas/_libs/algos.pyx
@@ -1,10 +1,10 @@
 # cython: profile=False
 
-from numpy cimport *
 cimport numpy as np
 import numpy as np
 
 cimport cython
+from cython cimport Py_ssize_t
 
 import_array()
 
@@ -15,31 +15,19 @@ cimport util
 from libc.stdlib cimport malloc, free
 from libc.string cimport memmove
 
-from numpy cimport NPY_INT8 as NPY_int8
-from numpy cimport NPY_INT16 as NPY_int16
-from numpy cimport NPY_INT32 as NPY_int32
-from numpy cimport NPY_INT64 as NPY_int64
-from numpy cimport NPY_FLOAT16 as NPY_float16
-from numpy cimport NPY_FLOAT32 as NPY_float32
-from numpy cimport NPY_FLOAT64 as NPY_float64
+from numpy cimport (ndarray,
+                    NPY_INT64, NPY_UINT64, NPY_INT32, NPY_INT16, NPY_INT8,
+                    NPY_FLOAT32, NPY_FLOAT64,
+                    NPY_OBJECT,
+                    int8_t, int16_t, int32_t, int64_t, uint8_t, uint16_t,
+                    uint32_t, uint64_t, float16_t, float32_t, float64_t,
+                    double_t)
 
-from numpy cimport (int8_t, int16_t, int32_t, int64_t, uint8_t, uint16_t,
-                    uint32_t, uint64_t, float16_t, float32_t, float64_t)
-
-int8 = np.dtype(np.int8)
-int16 = np.dtype(np.int16)
-int32 = np.dtype(np.int32)
-int64 = np.dtype(np.int64)
-float16 = np.dtype(np.float16)
-float32 = np.dtype(np.float32)
-float64 = np.dtype(np.float64)
 
 cdef double NaN = <double> np.NaN
 cdef double nan = NaN
 
-cdef extern from "../src/headers/math.h":
-    double sqrt(double x) nogil
-    double fabs(double) nogil
+from cpython.math cimport sqrt, fabs
 
 # this is our util.pxd
 from util cimport numeric, get_nat

--- a/pandas/_libs/algos.pyx
+++ b/pandas/_libs/algos.pyx
@@ -6,7 +6,7 @@ import numpy as np
 cimport cython
 from cython cimport Py_ssize_t
 
-import_array()
+np.import_array()
 
 cdef float64_t FP_ERR = 1e-13
 

--- a/pandas/_libs/algos.pyx
+++ b/pandas/_libs/algos.pyx
@@ -27,7 +27,7 @@ from numpy cimport (ndarray,
 cdef double NaN = <double> np.NaN
 cdef double nan = NaN
 
-from cpython.math cimport sqrt, fabs
+from libc.math cimport sqrt, fabs
 
 # this is our util.pxd
 from util cimport numeric, get_nat

--- a/pandas/_libs/groupby.pyx
+++ b/pandas/_libs/groupby.pyx
@@ -1,16 +1,17 @@
 # cython: profile=False
 
-from numpy cimport *
 cimport numpy as np
 import numpy as np
 
 cimport cython
 
-import_array()
+np.import_array()
 
 cimport util
 
-from numpy cimport (int8_t, int16_t, int32_t, int64_t, uint8_t, uint16_t,
+from numpy cimport (ndarray,
+                    double_t,
+                    int8_t, int16_t, int32_t, int64_t, uint8_t, uint16_t,
                     uint32_t, uint64_t, float16_t, float32_t, float64_t)
 
 from libc.stdlib cimport malloc, free

--- a/pandas/_libs/groupby.pyx
+++ b/pandas/_libs/groupby.pyx
@@ -1,11 +1,11 @@
 # cython: profile=False
 
-cimport numpy as np
+cimport numpy as cnp
 import numpy as np
 
 cimport cython
 
-np.import_array()
+cnp.import_array()
 
 cimport util
 

--- a/pandas/_libs/hashtable.pyx
+++ b/pandas/_libs/hashtable.pyx
@@ -23,7 +23,7 @@ from khash cimport (
     kh_put_pymap, kh_resize_pymap)
 
 
-from numpy cimport *
+from numpy cimport ndarray, uint8_t, uint32_t
 
 from libc.stdlib cimport malloc, free
 from cpython cimport (PyMem_Malloc, PyMem_Realloc, PyMem_Free,
@@ -56,8 +56,6 @@ cdef extern from "datetime.h":
 
 PyDateTime_IMPORT
 
-cdef extern from "Python.h":
-    int PySlice_Check(object)
 
 cdef size_t _INIT_VEC_CAP = 128
 

--- a/pandas/_libs/interval.pyx
+++ b/pandas/_libs/interval.pyx
@@ -1,11 +1,10 @@
 cimport numpy as np
 import numpy as np
-import pandas as pd
 
 cimport util
 cimport cython
 import cython
-from numpy cimport *
+from numpy cimport ndarray
 from tslib import Timestamp
 
 from cpython.object cimport (Py_EQ, Py_NE, Py_GT, Py_LT, Py_GE, Py_LE,

--- a/pandas/_libs/intervaltree.pxi.in
+++ b/pandas/_libs/intervaltree.pxi.in
@@ -4,11 +4,15 @@ Template for intervaltree
 WARNING: DO NOT edit .pxi FILE directly, .pxi is generated from .pxi.in
 """
 
-from numpy cimport int64_t, float64_t
-from numpy cimport ndarray, PyArray_ArgSort, NPY_QUICKSORT, PyArray_Take
+from numpy cimport (
+    int64_t, int32_t, float64_t, float32_t,
+    ndarray,
+    PyArray_ArgSort, NPY_QUICKSORT, PyArray_Take)
 import numpy as np
 
 cimport cython
+from cython cimport Py_ssize_t
+
 cimport numpy as cnp
 cnp.import_array()
 

--- a/pandas/_libs/join.pyx
+++ b/pandas/_libs/join.pyx
@@ -1,33 +1,18 @@
 # cython: profile=False
 
-from numpy cimport *
 cimport numpy as np
 import numpy as np
 
 cimport cython
+from cython cimport Py_ssize_t
 
 import_array()
 
 cimport util
 
-from numpy cimport NPY_INT8 as NPY_int8
-from numpy cimport NPY_INT16 as NPY_int16
-from numpy cimport NPY_INT32 as NPY_int32
-from numpy cimport NPY_INT64 as NPY_int64
-from numpy cimport NPY_FLOAT16 as NPY_float16
-from numpy cimport NPY_FLOAT32 as NPY_float32
-from numpy cimport NPY_FLOAT64 as NPY_float64
-
-from numpy cimport (int8_t, int16_t, int32_t, int64_t, uint8_t, uint16_t,
+from numpy cimport (ndarray,
+                    int8_t, int16_t, int32_t, int64_t, uint8_t, uint16_t,
                     uint32_t, uint64_t, float16_t, float32_t, float64_t)
-
-int8 = np.dtype(np.int8)
-int16 = np.dtype(np.int16)
-int32 = np.dtype(np.int32)
-int64 = np.dtype(np.int64)
-float16 = np.dtype(np.float16)
-float32 = np.dtype(np.float32)
-float64 = np.dtype(np.float64)
 
 cdef double NaN = <double> np.NaN
 cdef double nan = NaN

--- a/pandas/_libs/join.pyx
+++ b/pandas/_libs/join.pyx
@@ -6,7 +6,7 @@ import numpy as np
 cimport cython
 from cython cimport Py_ssize_t
 
-import_array()
+np.import_array()
 
 cimport util
 

--- a/pandas/_libs/reshape.pyx
+++ b/pandas/_libs/reshape.pyx
@@ -1,33 +1,18 @@
 # cython: profile=False
 
-from numpy cimport *
 cimport numpy as np
 import numpy as np
 
 cimport cython
+from cython cimport Py_ssize_t
 
-import_array()
+np.import_array()
 
 cimport util
 
-from numpy cimport NPY_INT8 as NPY_int8
-from numpy cimport NPY_INT16 as NPY_int16
-from numpy cimport NPY_INT32 as NPY_int32
-from numpy cimport NPY_INT64 as NPY_int64
-from numpy cimport NPY_FLOAT16 as NPY_float16
-from numpy cimport NPY_FLOAT32 as NPY_float32
-from numpy cimport NPY_FLOAT64 as NPY_float64
-
-from numpy cimport (int8_t, int16_t, int32_t, int64_t, uint8_t, uint16_t,
+from numpy cimport (ndarray,
+					int8_t, int16_t, int32_t, int64_t, uint8_t, uint16_t,
                     uint32_t, uint64_t, float16_t, float32_t, float64_t)
-
-int8 = np.dtype(np.int8)
-int16 = np.dtype(np.int16)
-int32 = np.dtype(np.int32)
-int64 = np.dtype(np.int64)
-float16 = np.dtype(np.float16)
-float32 = np.dtype(np.float32)
-float64 = np.dtype(np.float64)
 
 cdef double NaN = <double> np.NaN
 cdef double nan = NaN

--- a/pandas/_libs/reshape.pyx
+++ b/pandas/_libs/reshape.pyx
@@ -11,7 +11,7 @@ np.import_array()
 cimport util
 
 from numpy cimport (ndarray,
-					int8_t, int16_t, int32_t, int64_t, uint8_t, uint16_t,
+                    int8_t, int16_t, int32_t, int64_t, uint8_t, uint16_t,
                     uint32_t, uint64_t, float16_t, float32_t, float64_t)
 
 cdef double NaN = <double> np.NaN

--- a/pandas/_libs/src/reduce.pyx
+++ b/pandas/_libs/src/reduce.pyx
@@ -1,5 +1,4 @@
 #cython=False
-from numpy cimport *
 import numpy as np
 
 from distutils.version import LooseVersion


### PR DESCRIPTION
Replace these imports with explicit imports.

There are a couple of other similar things coming up, splitting them apart for easier review.

There are a couple of places with `cdef extern from "../src/headers/math.h":` but I don't think the path here makes sense.  The fact that it works anyway bothers me.  This PR changes one such occurrence as a demonstration, leaves the others for the next PR.

- [ ] closes #xxxx
- [ ] tests added / passed
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
