### PR TITLE
test for #17517 category name None after set_category() change

### DIFF
--- a/pandas/tests/test_categorical.py
+++ b/pandas/tests/test_categorical.py
@@ -56,6 +56,13 @@ class TestCategorical(object):
         expected = c[np.array([100000]).astype(np.int64)].codes
         tm.assert_numpy_array_equal(result, expected)
 
+    def test_getname_category(self):
+        result = 'A'
+        s = pd.Series([1,2,3], name='A').astype('category')
+        s = s.cat.set_categories([1,2,3])
+        expected = s.astype('category').name
+        tm.assert_almost_equal(result, expected)
+    
     def test_getitem_category_type(self):
         # GH 14580
         # test iloc() on Series with Categorical data

--- a/pandas/tests/test_categorical.py
+++ b/pandas/tests/test_categorical.py
@@ -58,11 +58,11 @@ class TestCategorical(object):
 
     def test_getname_category(self):
         result = 'A'
-        s = pd.Series([1,2,3], name='A').astype('category')
-        s = s.cat.set_categories([1,2,3])
+        s = pd.Series([1, 2, 3], name='A').astype('category')
+        s = s.cat.set_categories([1, 2, 3])
         expected = s.astype('category').name
         tm.assert_almost_equal(result, expected)
-    
+
     def test_getitem_category_type(self):
         # GH 14580
         # test iloc() on Series with Categorical data


### PR DESCRIPTION
This test is for #17517 
- [ ] closes #xxxx
- [ ] tests added / passed
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
