### PR TITLE
remove period_helper from non-period reqs

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -461,7 +461,6 @@ lib_depends = lib_depends + ['pandas/_libs/src/numpy_helper.h',
 
 tseries_depends = ['pandas/_libs/src/datetime/np_datetime.h',
                    'pandas/_libs/src/datetime/np_datetime_strings.h',
-                   'pandas/_libs/src/period_helper.h',
                    'pandas/_libs/src/datetime.pxd']
 
 
@@ -478,11 +477,11 @@ ext_data = {
                     'pxdfiles': ['_libs/src/util'],
                     'depends': tseries_depends,
                     'sources': ['pandas/_libs/src/datetime/np_datetime.c',
-                                'pandas/_libs/src/datetime/np_datetime_strings.c',
-                                'pandas/_libs/src/period_helper.c']},
+                                'pandas/_libs/src/datetime/np_datetime_strings.c']},
     '_libs.tslibs.timezones': {'pyxfile': '_libs/tslibs/timezones'},
     '_libs.period': {'pyxfile': '_libs/period',
-                     'depends': tseries_depends,
+                     'depends': (tseries_depends +
+                                 ['pandas/_libs/src/period_helper.h']),
                      'sources': ['pandas/_libs/src/datetime/np_datetime.c',
                                  'pandas/_libs/src/datetime/np_datetime_strings.c',
                                  'pandas/_libs/src/period_helper.c']},


### PR DESCRIPTION
There are a bunch of other reqs that _could_ be removed (e.g. every direct reference to src/util, all of `lib_depends`), but at least `period_helper` it's obvious _why_ it belongs where it does.

- [ ] closes #xxxx
- [ ] tests added / passed
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
