### PR TITLE
CLN: Fix Spelling Errors

### DIFF
--- a/doc/source/advanced.rst
+++ b/doc/source/advanced.rst
@@ -625,7 +625,7 @@ Index Types
 We have discussed ``MultiIndex`` in the previous sections pretty extensively. ``DatetimeIndex`` and ``PeriodIndex``
 are shown :ref:`here <timeseries.overview>`. ``TimedeltaIndex`` are :ref:`here <timedeltas.timedeltas>`.
 
-In the following sub-sections we will highlite some other index types.
+In the following sub-sections we will highlight some other index types.
 
 .. _indexing.categoricalindex:
 
@@ -645,7 +645,7 @@ and allows efficient indexing and storage of an index with a large number of dup
    df.dtypes
    df.B.cat.categories
 
-Setting the index, will create create a ``CategoricalIndex``
+Setting the index, will create a ``CategoricalIndex``
 
 .. ipython:: python
 
@@ -681,7 +681,7 @@ Groupby operations on the index will preserve the index nature as well
 Reindexing operations, will return a resulting index based on the type of the passed
 indexer, meaning that passing a list will return a plain-old-``Index``; indexing with
 a ``Categorical`` will return a ``CategoricalIndex``, indexed according to the categories
-of the PASSED ``Categorical`` dtype. This allows one to arbitrarly index these even with
+of the PASSED ``Categorical`` dtype. This allows one to arbitrarily index these even with
 values NOT in the categories, similarly to how you can reindex ANY pandas index.
 
 .. ipython :: python
@@ -722,7 +722,7 @@ Int64Index and RangeIndex
 Prior to 0.18.0, the ``Int64Index`` would provide the default index for all ``NDFrame`` objects.
 
 ``RangeIndex`` is a sub-class of ``Int64Index`` added in version 0.18.0, now providing the default index for all ``NDFrame`` objects.
-``RangeIndex`` is an optimized version of ``Int64Index`` that can represent a monotonic ordered set. These are analagous to python `range types <https://docs.python.org/3/library/stdtypes.html#typesseq-range>`__.
+``RangeIndex`` is an optimized version of ``Int64Index`` that can represent a monotonic ordered set. These are analogous to python `range types <https://docs.python.org/3/library/stdtypes.html#typesseq-range>`__.
 
 .. _indexing.float64index:
 
@@ -963,7 +963,7 @@ index can be somewhat complicated. For example, the following does not work:
     s.loc['c':'e'+1]
 
 A very common use case is to limit a time series to start and end at two
-specific dates. To enable this, we made the design design to make label-based
+specific dates. To enable this, we made the design to make label-based
 slicing include both endpoints:
 
 .. ipython:: python

--- a/doc/source/api.rst
+++ b/doc/source/api.rst
@@ -1291,7 +1291,7 @@ Index
 -----
 
 **Many of these methods or variants thereof are available on the objects
-that contain an index (Series/Dataframe) and those should most likely be
+that contain an index (Series/DataFrame) and those should most likely be
 used before calling these methods directly.**
 
 .. autosummary::

--- a/doc/source/basics.rst
+++ b/doc/source/basics.rst
@@ -923,7 +923,7 @@ Passing a named function will yield that name for the row:
 Aggregating with a dict
 +++++++++++++++++++++++
 
-Passing a dictionary of column names to a scalar or a list of scalars, to ``DataFame.agg``
+Passing a dictionary of column names to a scalar or a list of scalars, to ``DataFrame.agg``
 allows you to customize which functions are applied to which columns. Note that the results
 are not in any particular order, you can use an ``OrderedDict`` instead to guarantee ordering.
 

--- a/doc/source/computation.rst
+++ b/doc/source/computation.rst
@@ -654,7 +654,7 @@ aggregation with, outputting a DataFrame:
 
    r['A'].agg([np.sum, np.mean, np.std])
 
-On a widowed DataFrame, you can pass a list of functions to apply to each
+On a windowed DataFrame, you can pass a list of functions to apply to each
 column, which produces an aggregated result with a hierarchical index:
 
 .. ipython:: python

--- a/doc/source/groupby.rst
+++ b/doc/source/groupby.rst
@@ -561,7 +561,7 @@ must be either implemented on GroupBy or available via :ref:`dispatching
 
 .. note::
 
-    If you pass a dict to ``aggregate``, the ordering of the output colums is
+    If you pass a dict to ``aggregate``, the ordering of the output columns is
     non-deterministic. If you want to be sure the output columns will be in a specific
     order, you can use an ``OrderedDict``.  Compare the output of the following two commands:
 
@@ -1211,7 +1211,7 @@ Groupby by Indexer to 'resample' data
 
 Resampling produces new hypothetical samples (resamples) from already existing observed data or from a model that generates data. These new samples are similar to the pre-existing samples.
 
-In order to resample to work on indices that are non-datetimelike , the following procedure can be utilized.
+In order to resample to work on indices that are non-datetimelike, the following procedure can be utilized.
 
 In the following examples, **df.index // 5** returns a binary array which is used to determine what gets selected for the groupby operation.
 

--- a/doc/source/indexing.rst
+++ b/doc/source/indexing.rst
@@ -714,7 +714,7 @@ Finally, one can also set a seed for ``sample``'s random number generator using 
 Setting With Enlargement
 ------------------------
 
-The ``.loc/[]`` operations can perform enlargement when setting a non-existant key for that axis.
+The ``.loc/[]`` operations can perform enlargement when setting a non-existent key for that axis.
 
 In the ``Series`` case this is effectively an appending operation
 

--- a/doc/source/io.rst
+++ b/doc/source/io.rst
@@ -3077,7 +3077,7 @@ Compressed pickle files
 
 .. versionadded:: 0.20.0
 
-:func:`read_pickle`, :meth:`DataFame.to_pickle` and :meth:`Series.to_pickle` can read
+:func:`read_pickle`, :meth:`DataFrame.to_pickle` and :meth:`Series.to_pickle` can read
 and write compressed pickle files. The compression types of ``gzip``, ``bz2``, ``xz`` are supported for reading and writing.
 `zip`` file supports read only and must contain only one data file
 to be read in.

--- a/doc/source/merging.rst
+++ b/doc/source/merging.rst
@@ -1329,7 +1329,7 @@ By default we are taking the asof of the quotes.
                  on='time',
                  by='ticker')
 
-We only asof within ``2ms`` betwen the quote time and the trade time.
+We only asof within ``2ms`` between the quote time and the trade time.
 
 .. ipython:: python
 
@@ -1338,8 +1338,8 @@ We only asof within ``2ms`` betwen the quote time and the trade time.
                  by='ticker',
                  tolerance=pd.Timedelta('2ms'))
 
-We only asof within ``10ms`` betwen the quote time and the trade time and we exclude exact matches on time.
-Note that though we exclude the exact matches (of the quotes), prior quotes DO propogate to that point
+We only asof within ``10ms`` between the quote time and the trade time and we exclude exact matches on time.
+Note that though we exclude the exact matches (of the quotes), prior quotes DO propagate to that point
 in time.
 
 .. ipython:: python

--- a/doc/source/missing_data.rst
+++ b/doc/source/missing_data.rst
@@ -320,7 +320,7 @@ Interpolation
 
   The ``limit_direction`` keyword argument was added.
 
-Both Series and Dataframe objects have an ``interpolate`` method that, by default,
+Both Series and DataFrame objects have an ``interpolate`` method that, by default,
 performs linear interpolation at missing datapoints.
 
 .. ipython:: python

--- a/doc/source/options.rst
+++ b/doc/source/options.rst
@@ -313,9 +313,9 @@ display.large_repr                  truncate     For DataFrames exceeding max_ro
 display.latex.repr                  False        Whether to produce a latex DataFrame
                                                  representation for jupyter frontends
                                                  that support it.
-display.latex.escape                True         Escapes special caracters in Dataframes, when
+display.latex.escape                True         Escapes special characters in DataFrames, when
                                                  using the to_latex method.
-display.latex.longtable             False        Specifies if the to_latex method of a Dataframe
+display.latex.longtable             False        Specifies if the to_latex method of a DataFrame
                                                  uses the longtable format.
 display.latex.multicolumn           True         Combines columns when using a MultiIndex
 display.latex.multicolumn_format    'l'          Alignment of multicolumn labels

--- a/doc/source/reshaping.rst
+++ b/doc/source/reshaping.rst
@@ -156,7 +156,7 @@ the level numbers:
    stacked.unstack('second')
 
 Notice that the ``stack`` and ``unstack`` methods implicitly sort the index
-levels involved. Hence a call to ``stack`` and then ``unstack``, or viceversa,
+levels involved. Hence a call to ``stack`` and then ``unstack``, or vice versa,
 will result in a **sorted** copy of the original DataFrame or Series:
 
 .. ipython:: python

--- a/doc/source/sparse.rst
+++ b/doc/source/sparse.rst
@@ -132,7 +132,7 @@ dtype, ``fill_value`` default changes:
    s.to_sparse()
 
 You can change the dtype using ``.astype()``, the result is also sparse. Note that
-``.astype()`` also affects to the ``fill_value`` to keep its dense represantation.
+``.astype()`` also affects to the ``fill_value`` to keep its dense representation.
 
 
 .. ipython:: python

--- a/doc/source/style.ipynb
+++ b/doc/source/style.ipynb
@@ -169,7 +169,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Notice the similarity with the standard `df.applymap`, which operates on DataFrames elementwise. We want you to be able to resuse your existing knowledge of how to interact with DataFrames.\n",
+    "Notice the similarity with the standard `df.applymap`, which operates on DataFrames elementwise. We want you to be able to reuse your existing knowledge of how to interact with DataFrames.\n",
     "\n",
     "Notice also that our function returned a string containing the CSS attribute and value, separated by a colon just like in a `<style>` tag. This will be a common theme.\n",
     "\n",

--- a/doc/source/timeseries.rst
+++ b/doc/source/timeseries.rst
@@ -1054,7 +1054,7 @@ as ``BusinessHour`` except that it skips specified custom holidays.
     # Tuesday after MLK Day (Monday is skipped because it's a holiday)
     dt + bhour_us * 2
 
-You can use keyword arguments suported by either ``BusinessHour`` and ``CustomBusinessDay``.
+You can use keyword arguments supported by either ``BusinessHour`` and ``CustomBusinessDay``.
 
 .. ipython:: python
 
@@ -1088,7 +1088,7 @@ frequencies. We will refer to these aliases as *offset aliases*.
     "BMS", "business month start frequency"
     "CBMS", "custom business month start frequency"
     "Q", "quarter end frequency"
-    "BQ", "business quarter endfrequency"
+    "BQ", "business quarter end frequency"
     "QS", "quarter start frequency"
     "BQS", "business quarter start frequency"
     "A, Y", "year end frequency"
@@ -1132,13 +1132,13 @@ For some frequencies you can specify an anchoring suffix:
     :header: "Alias", "Description"
     :widths: 15, 100
 
-    "W\-SUN", "weekly frequency (sundays). Same as 'W'"
-    "W\-MON", "weekly frequency (mondays)"
-    "W\-TUE", "weekly frequency (tuesdays)"
-    "W\-WED", "weekly frequency (wednesdays)"
-    "W\-THU", "weekly frequency (thursdays)"
-    "W\-FRI", "weekly frequency (fridays)"
-    "W\-SAT", "weekly frequency (saturdays)"
+    "W\-SUN", "weekly frequency (Sundays). Same as 'W'"
+    "W\-MON", "weekly frequency (Mondays)"
+    "W\-TUE", "weekly frequency (Tuesdays)"
+    "W\-WED", "weekly frequency (Wednesdays)"
+    "W\-THU", "weekly frequency (Thursdays)"
+    "W\-FRI", "weekly frequency (Fridays)"
+    "W\-SAT", "weekly frequency (Saturdays)"
     "(B)Q(S)\-DEC", "quarterly frequency, year ends in December. Same as 'Q'"
     "(B)Q(S)\-JAN", "quarterly frequency, year ends in January"
     "(B)Q(S)\-FEB", "quarterly frequency, year ends in February"

--- a/doc/source/visualization.rst
+++ b/doc/source/visualization.rst
@@ -261,7 +261,7 @@ Histogram can be stacked by ``stacked=True``. Bin size can be changed by ``bins`
 
    plt.close('all')
 
-You can pass other keywords supported by matplotlib ``hist``. For example, horizontal and cumulative histgram can be drawn by ``orientation='horizontal'`` and ``cumulative='True'``.
+You can pass other keywords supported by matplotlib ``hist``. For example, horizontal and cumulative histogram can be drawn by ``orientation='horizontal'`` and ``cumulative=True``.
 
 .. ipython:: python
 

--- a/pandas/core/algorithms.py
+++ b/pandas/core/algorithms.py
@@ -1475,7 +1475,7 @@ _diff_special = {
 def diff(arr, n, axis=0):
     """
     difference of n between self,
-    analagoust to s-s.shift(n)
+    analogous to s-s.shift(n)
 
     Parameters
     ----------

--- a/pandas/core/indexes/interval.py
+++ b/pandas/core/indexes/interval.py
@@ -918,7 +918,7 @@ class IntervalIndex(IntervalMixin, Index):
         except ValueError:
 
             # we need to coerce; migth have NA's in an
-            # interger dtype
+            # integer dtype
             new_left = taker(left.astype(float))
             new_right = taker(right.astype(float))
 

--- a/pandas/core/reshape/concat.py
+++ b/pandas/core/reshape/concat.py
@@ -72,7 +72,7 @@ def concat(objs, axis=0, join='outer', join_axes=None, ignore_index=False,
     The keys, levels, and names arguments are all optional.
 
     A walkthrough of how this method fits in with other tools for combining
-    panda objects can be found `here
+    pandas objects can be found `here
     <http://pandas.pydata.org/pandas-docs/stable/merging.html>`__.
 
     See Also

--- a/pandas/core/reshape/merge.py
+++ b/pandas/core/reshape/merge.py
@@ -447,7 +447,7 @@ def merge_asof(left, right, on=None,
     3 2016-05-25 13:30:00.048   GOOG  720.92       100  720.50  720.93
     4 2016-05-25 13:30:00.048   AAPL   98.00       100     NaN     NaN
 
-    We only asof within 2ms betwen the quote time and the trade time
+    We only asof within 2ms between the quote time and the trade time
 
     >>> pd.merge_asof(trades, quotes,
     ...                       on='time',
@@ -460,9 +460,9 @@ def merge_asof(left, right, on=None,
     3 2016-05-25 13:30:00.048   GOOG  720.92       100  720.50  720.93
     4 2016-05-25 13:30:00.048   AAPL   98.00       100     NaN     NaN
 
-    We only asof within 10ms betwen the quote time and the trade time
+    We only asof within 10ms between the quote time and the trade time
     and we exclude exact matches on time. However *prior* data will
-    propogate forward
+    propagate forward
 
     >>> pd.merge_asof(trades, quotes,
     ...                       on='time',

--- a/pandas/core/reshape/tile.py
+++ b/pandas/core/reshape/tile.py
@@ -359,7 +359,7 @@ def _preprocess_for_cut(x):
     """
     handles preprocessing for cut where we convert passed
     input to array, strip the index information and store it
-    seperately
+    separately
     """
     x_is_series = isinstance(x, Series)
     series_index = None

--- a/pandas/io/formats/excel.py
+++ b/pandas/io/formats/excel.py
@@ -263,7 +263,7 @@ class CSSToExcelConverter(object):
                           else None),
             'strike': ('line-through' in decoration) or None,
             'color': self.color_to_excel(props.get('color')),
-            # shadow if nonzero digit before shadow colour
+            # shadow if nonzero digit before shadow color
             'shadow': (bool(re.search('^[^#(]*[1-9]',
                                       props['text-shadow']))
                        if 'text-shadow' in props else None),
@@ -304,7 +304,7 @@ class CSSToExcelConverter(object):
         try:
             return self.NAMED_COLORS[val]
         except KeyError:
-            warnings.warn('Unhandled colour format: {val!r}'.format(val=val),
+            warnings.warn('Unhandled color format: {val!r}'.format(val=val),
                           CSSWarning)
 
 

--- a/pandas/io/pytables.py
+++ b/pandas/io/pytables.py
@@ -605,7 +605,7 @@ class HDFStore(StringMixin):
 
         except (Exception) as e:
 
-            # trying to read from a non-existant file causes an error which
+            # trying to read from a non-existent file causes an error which
             # is not part of IOError, make it one
             if self._mode == 'r' and 'Unable to open/create file' in str(e):
                 raise IOError(str(e))
@@ -1621,7 +1621,7 @@ class IndexCol(StringMixin):
 
     def maybe_set_size(self, min_itemsize=None, **kwargs):
         """ maybe set a string col itemsize:
-               min_itemsize can be an interger or a dict with this columns name
+               min_itemsize can be an integer or a dict with this columns name
                with an integer size """
         if _ensure_decoded(self.kind) == u('string'):
 
@@ -1712,11 +1712,11 @@ class IndexCol(StringMixin):
             self.__dict__.update(idx)
 
     def get_attr(self):
-        """ set the kind for this colummn """
+        """ set the kind for this column """
         self.kind = getattr(self.attrs, self.kind_attr, None)
 
     def set_attr(self):
-        """ set the kind for this colummn """
+        """ set the kind for this column """
         setattr(self.attrs, self.kind_attr, self.kind)
 
     def read_metadata(self, handler):
@@ -2160,14 +2160,14 @@ class DataCol(IndexCol):
         return self
 
     def get_attr(self):
-        """ get the data for this colummn """
+        """ get the data for this column """
         self.values = getattr(self.attrs, self.kind_attr, None)
         self.dtype = getattr(self.attrs, self.dtype_attr, None)
         self.meta = getattr(self.attrs, self.meta_attr, None)
         self.set_kind()
 
     def set_attr(self):
-        """ set the data for this colummn """
+        """ set the data for this column """
         setattr(self.attrs, self.kind_attr, self.values)
         setattr(self.attrs, self.meta_attr, self.meta)
         if self.dtype is not None:

--- a/pandas/io/stata.py
+++ b/pandas/io/stata.py
@@ -511,8 +511,8 @@ def _cast_to_stata_types(data):
     this range.  If the int64 values are outside of the range of those
     perfectly representable as float64 values, a warning is raised.
 
-    bool columns are cast to int8.  uint colums are converted to int of the
-    same size if there is no loss in precision, other wise are upcast to a
+    bool columns are cast to int8.  uint columns are converted to int of the
+    same size if there is no loss in precision, otherwise are upcast to a
     larger type.  uint64 is currently not supported since it is concerted to
     object in a DataFrame.
     """

--- a/pandas/plotting/_misc.py
+++ b/pandas/plotting/_misc.py
@@ -413,7 +413,7 @@ def parallel_coordinates(frame, class_column, cols=None, ax=None, color=None,
     axvlines_kwds: keywords, optional
         Options to be passed to axvline method for vertical lines
     sort_labels: bool, False
-        Sort class_column labels, useful when assigning colours
+        Sort class_column labels, useful when assigning colors
 
         .. versionadded:: 0.20.0
 

--- a/pandas/plotting/_tools.py
+++ b/pandas/plotting/_tools.py
@@ -329,7 +329,7 @@ def _handle_shared_axes(axarr, nplots, naxes, nrows, ncols, sharex, sharey):
         if ncols > 1:
             for ax in axarr:
                 # only the first column should get y labels -> set all other to
-                # off as we only have labels in teh first column and we always
+                # off as we only have labels in the first column and we always
                 # have a subplot there, we can skip the layout test
                 if ax.is_first_col():
                     continue

--- a/pandas/tests/frame/test_convert_to.py
+++ b/pandas/tests/frame/test_convert_to.py
@@ -136,11 +136,11 @@ class TestDataFrameConvertTo(TestData):
     def test_to_records_with_unicode_column_names(self):
         # xref issue: https://github.com/numpy/numpy/issues/2407
         # Issue #11879. to_records used to raise an exception when used
-        # with column names containing non ascii caracters in Python 2
+        # with column names containing non-ascii characters in Python 2
         result = DataFrame(data={u"accented_name_é": [1.0]}).to_records()
 
         # Note that numpy allows for unicode field names but dtypes need
-        # to be specified using dictionnary intsead of list of tuples.
+        # to be specified using dictionary instead of list of tuples.
         expected = np.rec.array(
             [(0, 1.0)],
             dtype={"names": ["index", u"accented_name_é"],

--- a/pandas/tests/groupby/test_transform.py
+++ b/pandas/tests/groupby/test_transform.py
@@ -533,7 +533,7 @@ class TestGroupBy(MixIn):
                 for (op, args), targop in ops:
                     if op != 'shift' and 'int' not in gb_target:
                         # numeric apply fastpath promotes dtype so have
-                        # to apply seperately and concat
+                        # to apply separately and concat
                         i = gb[['int']].apply(targop)
                         f = gb[['float', 'float_missing']].apply(targop)
                         expected = pd.concat([f, i], axis=1)

--- a/pandas/tests/indexes/datetimes/test_tools.py
+++ b/pandas/tests/indexes/datetimes/test_tools.py
@@ -1144,7 +1144,7 @@ class TestDatetimeParsingWrappers(object):
                 exp = DatetimeIndex([pd.Timestamp(expected)])
                 tm.assert_index_equal(res, exp)
 
-            # these really need to have yearfist, but we don't support
+            # these really need to have yearfirst, but we don't support
             if not yearfirst:
                 result5 = Timestamp(date_str)
                 assert result5 == expected

--- a/pandas/tests/io/json/test_json_table_schema.py
+++ b/pandas/tests/io/json/test_json_table_schema.py
@@ -52,7 +52,7 @@ class TestBuildSchema(object):
         result = build_table_schema(s)
         assert 'pandas_version' in result
 
-    def tets_series_unnamed(self):
+    def test_series_unnamed(self):
         result = build_table_schema(pd.Series([1, 2, 3]), version=False)
         expected = {'fields': [{'name': 'index', 'type': 'integer'},
                                {'name': 'values', 'type': 'integer'}],

--- a/pandas/tests/io/parser/test_read_fwf.py
+++ b/pandas/tests/io/parser/test_read_fwf.py
@@ -291,7 +291,7 @@ Account                 Name  Balance     CreditLimit   AccountCreated
         tm.assert_frame_equal(expected, read_fwf(StringIO(test)))
 
     def test_full_file_with_spaces_and_missing(self):
-        # File with spaces and missing values in columsn
+        # File with spaces and missing values in columns
         test = """
 Account               Name    Balance     CreditLimit   AccountCreated
 101                           10000.00                       1/17/1998

--- a/pandas/tests/io/test_pytables.py
+++ b/pandas/tests/io/test_pytables.py
@@ -1370,7 +1370,7 @@ class TestHDFStore(Base):
                     labels=['l1'], items=['ItemA'], minor_axis=['B'])
                 assert_panel4d_equal(result, expected)
 
-                # non-existant partial selection
+                # non-existent partial selection
                 result = store.select(
                     'p4d', "labels='l1' and items='Item1' and minor_axis='B'")
                 expected = p4d.reindex(labels=['l1'], items=[],
@@ -1980,11 +1980,11 @@ class TestHDFStore(Base):
 
             with catch_warnings(record=True):
 
-                # unsuported data types for non-tables
+                # unsupported data types for non-tables
                 p4d = tm.makePanel4D()
                 pytest.raises(TypeError, store.put, 'p4d', p4d)
 
-                # unsuported data types
+                # unsupported data types
                 pytest.raises(TypeError, store.put, 'abc', None)
                 pytest.raises(TypeError, store.put, 'abc', '123')
                 pytest.raises(TypeError, store.put, 'abc', 123)
@@ -4965,7 +4965,7 @@ class TestHDFStore(Base):
             store['df'] = df
             assert_frame_equal(store['df'], df)
 
-    def test_colums_multiindex_modified(self):
+    def test_columns_multiindex_modified(self):
         # BUG: 7212
         # read_hdf store.select modified the passed columns parameters
         # when multi-indexed.

--- a/pandas/tests/plotting/test_datetimelike.py
+++ b/pandas/tests/plotting/test_datetimelike.py
@@ -347,7 +347,7 @@ class TestTSPlot(TestPlotBase):
             assert int(result[0]) == expected[0].ordinal
             assert int(result[1]) == expected[1].ordinal
 
-            # datetim
+            # datetime
             expected = (Period('1/1/2000', ax.freq),
                         Period('4/1/2000', ax.freq))
             ax.set_xlim(datetime(2000, 1, 1), datetime(2000, 4, 1))

--- a/pandas/tests/series/test_dtypes.py
+++ b/pandas/tests/series/test_dtypes.py
@@ -279,7 +279,7 @@ class TestSeriesDtypes(TestData):
         expected = Series([1., 2., 3., np.nan])
         tm.assert_series_equal(actual, expected)
 
-        # only soft conversions, uncovertable pass thru unchanged
+        # only soft conversions, unconvertable pass thru unchanged
         actual = (Series(np.array([1, 2, 3, None, 'a'], dtype='O'))
                   .infer_objects())
         expected = Series([1, 2, 3, None, 'a'])

--- a/pandas/tests/test_categorical.py
+++ b/pandas/tests/test_categorical.py
@@ -4064,7 +4064,7 @@ Categories (10, timedelta64[ns]): [0 days 01:00:00 < 1 days 01:00:00 < 2 days 01
         expected = df.copy()
 
         # object-cat
-        # note that we propogate the category
+        # note that we propagate the category
         # because we don't have any matching rows
         cright = right.copy()
         cright['d'] = cright['d'].astype('category')

--- a/pandas/tests/test_sorting.py
+++ b/pandas/tests/test_sorting.py
@@ -408,7 +408,7 @@ class TestSafeSort(object):
         tm.assert_numpy_array_equal(result, expected)
         tm.assert_numpy_array_equal(result_labels, expected_labels)
 
-    def test_mixed_interger_from_list(self):
+    def test_mixed_integer_from_list(self):
         values = ['b', 1, 0, 'a', 0, 'b']
         result = safe_sort(values)
         expected = np.array([0, 0, 1, 'a', 'b', 'b'], dtype=object)

--- a/pandas/tseries/util.py
+++ b/pandas/tseries/util.py
@@ -16,7 +16,7 @@ def pivot_annual(series, freq=None):
     The output has as many rows as distinct years in the original series,
     and as many columns as the length of a leap year in the units corresponding
     to the original frequency (366 for daily frequency, 366*24 for hourly...).
-    The fist column of the output corresponds to Jan. 1st, 00:00:00,
+    The first column of the output corresponds to Jan. 1st, 00:00:00,
     while the last column corresponds to Dec, 31st, 23:59:59.
     Entries corresponding to Feb. 29th are masked for non-leap years.
 


### PR DESCRIPTION
- [X] tests added / passed
- [X] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`

Fixed some miscellaneous spelling errors.  One test has been re-enabled after not running due to the prefix `tets_` being misspelled.  Not technically a spelling error, but I changed colour -> color in a few places; seems reasonable since the 'u' is omitted in most cases when color is a parameter.  Some changes were just to code comments, so not terribly useful, but makes reading comments a bit nicer.
