### PR TITLE
DOC: fixes after #17503 and #17491

### DIFF
--- a/doc/source/whatsnew/v0.21.0.txt
+++ b/doc/source/whatsnew/v0.21.0.txt
@@ -215,7 +215,7 @@ New Behaviour:
 
 Furthermore this will now correctly box the results of iteration for :func:`DataFrame.to_dict` as well.
 
-.. ipython:: ipython
+.. ipython:: python
 
    d = {'a':[1], 'b':['b']}
    df = pd.DataFrame(d)

--- a/pandas/core/base.py
+++ b/pandas/core/base.py
@@ -900,7 +900,7 @@ class IndexOpsMixin(object):
 
         See Also
         --------
-        numpy.tolist
+        numpy.ndarray.tolist
         """
 
         if is_datetimelike(self):


### PR DESCRIPTION
There was still a doc build error (`df` was not defined due to a missing 'i' in 'ipython')