### PR TITLE
de-privatize timezone functions

### DIFF
--- a/pandas/_libs/period.pyx
+++ b/pandas/_libs/period.pyx
@@ -35,7 +35,7 @@ from pandas._libs import tslib, lib
 from pandas._libs.tslib import (Timedelta, Timestamp, iNaT,
                                 NaT)
 from tslibs.timezones cimport (
-    is_utc, is_tzlocal, get_utcoffset, _get_dst_info, maybe_get_tz)
+    is_utc, is_tzlocal, get_utcoffset, get_dst_info, maybe_get_tz)
 from tslib cimport _nat_scalar_rules
 
 from tslibs.frequencies cimport get_freq_code
@@ -557,7 +557,7 @@ cdef _reso_local(ndarray[int64_t] stamps, object tz):
                 reso = curr_reso
     else:
         # Adjust datetime64 timestamp, recompute datetimestruct
-        trans, deltas, typ = _get_dst_info(tz)
+        trans, deltas, typ = get_dst_info(tz)
 
         _pos = trans.searchsorted(stamps, side='right') - 1
         if _pos.dtype != np.int64:
@@ -624,7 +624,7 @@ cdef ndarray[int64_t] localize_dt64arr_to_period(ndarray[int64_t] stamps,
                                            dts.us, dts.ps, freq)
     else:
         # Adjust datetime64 timestamp, recompute datetimestruct
-        trans, deltas, typ = _get_dst_info(tz)
+        trans, deltas, typ = get_dst_info(tz)
 
         _pos = trans.searchsorted(stamps, side='right') - 1
         if _pos.dtype != np.int64:

--- a/pandas/_libs/tslib.pyx
+++ b/pandas/_libs/tslib.pyx
@@ -100,16 +100,16 @@ iNaT = NPY_NAT
 
 
 from tslibs.timezones cimport (
-    is_utc, is_tzlocal, _is_fixed_offset,
+    is_utc, is_tzlocal, is_fixed_offset,
     treat_tz_as_dateutil, treat_tz_as_pytz,
     get_timezone, get_utcoffset, maybe_get_tz,
-    _get_dst_info
+    get_dst_info
     )
 from tslibs.timezones import (  # noqa
     get_timezone, get_utcoffset, maybe_get_tz,
-    _p_tz_cache_key, dst_cache,
-    _unbox_utcoffsets,
-    _dateutil_gettz
+    p_tz_cache_key, dst_cache,
+    unbox_utcoffsets,
+    dateutil_gettz
     )
 
 
@@ -167,7 +167,7 @@ def ints_to_pydatetime(ndarray[int64_t] arr, tz=None, freq=None, box=False):
                     pandas_datetime_to_datetimestruct(
                         value, PANDAS_FR_ns, &dts)
                     result[i] = func_create(value, dts, tz, freq)
-        elif is_tzlocal(tz) or _is_fixed_offset(tz):
+        elif is_tzlocal(tz) or is_fixed_offset(tz):
             for i in range(n):
                 value = arr[i]
                 if value == NPY_NAT:
@@ -181,7 +181,7 @@ def ints_to_pydatetime(ndarray[int64_t] arr, tz=None, freq=None, box=False):
                         dt = Timestamp(dt)
                     result[i] = dt
         else:
-            trans, deltas, typ = _get_dst_info(tz)
+            trans, deltas, typ = get_dst_info(tz)
 
             for i in range(n):
 
@@ -1641,12 +1641,12 @@ cdef inline void _localize_tso(_TSObject obj, object tz):
         obj.tzinfo = tz
     else:
         # Adjust datetime64 timestamp, recompute datetimestruct
-        trans, deltas, typ = _get_dst_info(tz)
+        trans, deltas, typ = get_dst_info(tz)
 
         pos = trans.searchsorted(obj.value, side='right') - 1
 
         # static/pytz/dateutil specific code
-        if _is_fixed_offset(tz):
+        if is_fixed_offset(tz):
             # statictzinfo
             if len(deltas) > 0 and obj.value != NPY_NAT:
                 pandas_datetime_to_datetimestruct(obj.value + deltas[0],
@@ -4066,7 +4066,7 @@ def tz_convert(ndarray[int64_t] vals, object tz1, object tz2):
                              * 1000000000)
                     utc_dates[i] = v - delta
         else:
-            trans, deltas, typ = _get_dst_info(tz1)
+            trans, deltas, typ = get_dst_info(tz1)
 
             # all-NaT
             tt = vals[vals!=NPY_NAT]
@@ -4108,7 +4108,7 @@ def tz_convert(ndarray[int64_t] vals, object tz1, object tz2):
         return result
 
     # Convert UTC to other timezone
-    trans, deltas, typ = _get_dst_info(tz2)
+    trans, deltas, typ = get_dst_info(tz2)
 
     # use first non-NaT element
     # if all-NaT, return all-NaT
@@ -4172,7 +4172,7 @@ def tz_convert_single(int64_t val, object tz1, object tz2):
         delta = int(get_utcoffset(tz1, dt).total_seconds()) * 1000000000
         utc_date = val - delta
     elif get_timezone(tz1) != 'UTC':
-        trans, deltas, typ = _get_dst_info(tz1)
+        trans, deltas, typ = get_dst_info(tz1)
         pos = trans.searchsorted(val, side='right') - 1
         if pos < 0:
             raise ValueError('First time before start of DST info')
@@ -4191,7 +4191,7 @@ def tz_convert_single(int64_t val, object tz1, object tz2):
         return utc_date + delta
 
     # Convert UTC to other timezone
-    trans, deltas, typ = _get_dst_info(tz2)
+    trans, deltas, typ = get_dst_info(tz2)
 
     pos = trans.searchsorted(utc_date, side='right') - 1
     if pos < 0:
@@ -4261,7 +4261,7 @@ def tz_localize_to_utc(ndarray[int64_t] vals, object tz, object ambiguous=None,
                 "Length of ambiguous bool-array must be the same size as vals")
         ambiguous_array = np.asarray(ambiguous)
 
-    trans, deltas, typ = _get_dst_info(tz)
+    trans, deltas, typ = get_dst_info(tz)
 
     tdata = <int64_t*> trans.data
     ntrans = len(trans)
@@ -4967,7 +4967,7 @@ cdef _normalize_local(ndarray[int64_t] stamps, object tz):
             result[i] = _normalized_stamp(&dts)
     else:
         # Adjust datetime64 timestamp, recompute datetimestruct
-        trans, deltas, typ = _get_dst_info(tz)
+        trans, deltas, typ = get_dst_info(tz)
 
         _pos = trans.searchsorted(stamps, side='right') - 1
         if _pos.dtype != np.int64:
@@ -5022,7 +5022,7 @@ def dates_normalized(ndarray[int64_t] stamps, tz=None):
             if (dt.hour + dt.minute + dt.second + dt.microsecond) > 0:
                 return False
     else:
-        trans, deltas, typ = _get_dst_info(tz)
+        trans, deltas, typ = get_dst_info(tz)
 
         for i in range(n):
             # Adjust datetime64 timestamp, recompute datetimestruct

--- a/pandas/_libs/tslib.pyx
+++ b/pandas/_libs/tslib.pyx
@@ -105,12 +105,6 @@ from tslibs.timezones cimport (
     get_timezone, get_utcoffset, maybe_get_tz,
     get_dst_info
     )
-from tslibs.timezones import (  # noqa
-    get_timezone, get_utcoffset, maybe_get_tz,
-    p_tz_cache_key, dst_cache,
-    unbox_utcoffsets,
-    dateutil_gettz
-    )
 
 
 cdef inline object create_timestamp_from_ts(

--- a/pandas/_libs/tslibs/timezones.pxd
+++ b/pandas/_libs/tslibs/timezones.pxd
@@ -13,6 +13,6 @@ cpdef object get_timezone(object tz)
 cpdef object maybe_get_tz(object tz)
 
 cpdef get_utcoffset(tzinfo, obj)
-cdef bint _is_fixed_offset(object tz)
+cdef bint is_fixed_offset(object tz)
 
-cdef object _get_dst_info(object tz)
+cdef object get_dst_info(object tz)

--- a/pandas/_libs/tslibs/timezones.pyx
+++ b/pandas/_libs/tslibs/timezones.pyx
@@ -100,7 +100,7 @@ cpdef inline object maybe_get_tz(object tz):
             tz = _dateutil_tzlocal()
         elif tz.startswith('dateutil/'):
             zone = tz[9:]
-            tz = _dateutil_gettz(zone)
+            tz = dateutil_gettz(zone)
             # On Python 3 on Windows, the filename is not always set correctly.
             if isinstance(tz, _dateutil_tzfile) and '.tar.gz' in tz._filename:
                 tz._filename = zone

--- a/pandas/_libs/tslibs/timezones.pyx
+++ b/pandas/_libs/tslibs/timezones.pyx
@@ -111,16 +111,16 @@ cpdef inline object maybe_get_tz(object tz):
     return tz
 
 
-def _p_tz_cache_key(tz):
+def p_tz_cache_key(tz):
     """ Python interface for cache function to facilitate testing."""
-    return _tz_cache_key(tz)
+    return tz_cache_key(tz)
 
 
 # Timezone data caches, key is the pytz string or dateutil file name.
 dst_cache = {}
 
 
-cdef inline object _tz_cache_key(object tz):
+cdef inline object tz_cache_key(object tz):
     """
     Return the key in the cache for the timezone info object or None
     if unknown.
@@ -163,7 +163,7 @@ cpdef get_utcoffset(tzinfo, obj):
         return tzinfo.utcoffset(obj)
 
 
-cdef inline bint _is_fixed_offset(object tz):
+cdef inline bint is_fixed_offset(object tz):
     if treat_tz_as_dateutil(tz):
         if len(tz._trans_idx) == 0 and len(tz._trans_list) == 0:
             return 1
@@ -178,7 +178,7 @@ cdef inline bint _is_fixed_offset(object tz):
     return 1
 
 
-cdef object _get_utc_trans_times_from_dateutil_tz(object tz):
+cdef object get_utc_trans_times_from_dateutil_tz(object tz):
     """
     Transition times in dateutil timezones are stored in local non-dst
     time.  This code converts them to UTC. It's the reverse of the code
@@ -193,7 +193,7 @@ cdef object _get_utc_trans_times_from_dateutil_tz(object tz):
     return new_trans
 
 
-cpdef ndarray _unbox_utcoffsets(object transinfo):
+cpdef ndarray unbox_utcoffsets(object transinfo):
     cdef:
         Py_ssize_t i, sz
         ndarray[int64_t] arr
@@ -211,7 +211,7 @@ cpdef ndarray _unbox_utcoffsets(object transinfo):
 # Daylight Savings
 
 
-cdef object _get_dst_info(object tz):
+cdef object get_dst_info(object tz):
     """
     return a tuple of :
       (UTC times of DST transitions,
@@ -219,7 +219,7 @@ cdef object _get_dst_info(object tz):
        string of type of transitions)
 
     """
-    cache_key = _tz_cache_key(tz)
+    cache_key = tz_cache_key(tz)
     if cache_key is None:
         num = int(get_utcoffset(tz, None).total_seconds()) * 1000000000
         return (np.array([NPY_NAT + 1], dtype=np.int64),
@@ -235,13 +235,13 @@ cdef object _get_dst_info(object tz):
                     trans[0] = NPY_NAT + 1
             except Exception:
                 pass
-            deltas = _unbox_utcoffsets(tz._transition_info)
+            deltas = unbox_utcoffsets(tz._transition_info)
             typ = 'pytz'
 
         elif treat_tz_as_dateutil(tz):
             if len(tz._trans_list):
                 # get utc trans times
-                trans_list = _get_utc_trans_times_from_dateutil_tz(tz)
+                trans_list = get_utc_trans_times_from_dateutil_tz(tz)
                 trans = np.hstack([
                     np.array([0], dtype='M8[s]'), # place holder for first item
                     np.array(trans_list, dtype='M8[s]')]).astype(
@@ -255,7 +255,7 @@ cdef object _get_dst_info(object tz):
                 deltas *= 1000000000
                 typ = 'dateutil'
 
-            elif _is_fixed_offset(tz):
+            elif is_fixed_offset(tz):
                 trans = np.array([NPY_NAT + 1], dtype=np.int64)
                 deltas = np.array([tz._ttinfo_std.offset],
                                   dtype='i8') * 1000000000

--- a/pandas/_libs/tslibs/timezones.pyx
+++ b/pandas/_libs/tslibs/timezones.pyx
@@ -111,7 +111,7 @@ cpdef inline object maybe_get_tz(object tz):
     return tz
 
 
-def p_tz_cache_key(tz):
+def _p_tz_cache_key(tz):
     """ Python interface for cache function to facilitate testing."""
     return tz_cache_key(tz)
 

--- a/pandas/_libs/tslibs/timezones.pyx
+++ b/pandas/_libs/tslibs/timezones.pyx
@@ -13,9 +13,9 @@ from dateutil.tz import (
 import sys
 if sys.platform == 'win32' or sys.platform == 'cygwin':
     # equiv pd.compat.is_platform_windows()
-    from dateutil.zoneinfo import gettz as _dateutil_gettz
+    from dateutil.zoneinfo import gettz as dateutil_gettz
 else:
-    from dateutil.tz import gettz as _dateutil_gettz
+    from dateutil.tz import gettz as dateutil_gettz
 
 
 from pytz.tzinfo import BaseTzInfo as _pytz_BaseTzInfo

--- a/pandas/core/indexes/datetimes.py
+++ b/pandas/core/indexes/datetimes.py
@@ -50,7 +50,7 @@ import pandas.core.tools.datetimes as tools
 from pandas._libs import (lib, index as libindex, tslib as libts,
                           algos as libalgos, join as libjoin,
                           Timestamp, period as libperiod)
-
+from pandas._libs.tslibs import timezones
 
 def _utc():
     import pytz
@@ -372,7 +372,7 @@ class DatetimeIndex(DatelikeOps, TimelikeOps, DatetimeIndexOpsMixin,
                 tz = subarr.tz
         else:
             if tz is not None:
-                tz = libts.maybe_get_tz(tz)
+                tz = timezones.maybe_get_tz(tz)
 
                 if (not isinstance(data, DatetimeIndex) or
                         getattr(data, 'tz', None) is None):
@@ -447,17 +447,18 @@ class DatetimeIndex(DatelikeOps, TimelikeOps, DatetimeIndexOpsMixin,
             raise TypeError('Start and end cannot both be tz-aware with '
                             'different timezones')
 
-        inferred_tz = libts.maybe_get_tz(inferred_tz)
+        inferred_tz = timezones.maybe_get_tz(inferred_tz)
 
         # these may need to be localized
-        tz = libts.maybe_get_tz(tz)
+        tz = timezones.maybe_get_tz(tz)
         if tz is not None:
             date = start or end
             if date.tzinfo is not None and hasattr(tz, 'localize'):
                 tz = tz.localize(date.replace(tzinfo=None)).tzinfo
 
         if tz is not None and inferred_tz is not None:
-            if not libts.get_timezone(inferred_tz) == libts.get_timezone(tz):
+            if not (timezones.get_timezone(inferred_tz) ==
+                    timezones.get_timezone(tz)):
                 raise AssertionError("Inferred time zone not equal to passed "
                                      "time zone")
 
@@ -593,7 +594,7 @@ class DatetimeIndex(DatelikeOps, TimelikeOps, DatetimeIndexOpsMixin,
         result._data = values
         result.name = name
         result.offset = freq
-        result.tz = libts.maybe_get_tz(tz)
+        result.tz = timezones.maybe_get_tz(tz)
         result._reset_identity()
         return result
 
@@ -607,7 +608,7 @@ class DatetimeIndex(DatelikeOps, TimelikeOps, DatetimeIndexOpsMixin,
     @cache_readonly
     def _timezone(self):
         """ Comparable timezone both for pytz / dateutil"""
-        return libts.get_timezone(self.tzinfo)
+        return timezones.get_timezone(self.tzinfo)
 
     def _has_same_tz(self, other):
         zzone = self._timezone
@@ -616,7 +617,7 @@ class DatetimeIndex(DatelikeOps, TimelikeOps, DatetimeIndexOpsMixin,
         if isinstance(other, np.datetime64):
             # convert to Timestamp as np.datetime64 doesn't have tz attr
             other = Timestamp(other)
-        vzone = libts.get_timezone(getattr(other, 'tzinfo', '__no_tz__'))
+        vzone = timezones.get_timezone(getattr(other, 'tzinfo', '__no_tz__'))
         return zzone == vzone
 
     @classmethod
@@ -1779,7 +1780,7 @@ class DatetimeIndex(DatelikeOps, TimelikeOps, DatetimeIndexOpsMixin,
         TypeError
             If DatetimeIndex is tz-naive.
         """
-        tz = libts.maybe_get_tz(tz)
+        tz = timezones.maybe_get_tz(tz)
 
         if self.tz is None:
             # tz naive, use tz_localize
@@ -1839,7 +1840,7 @@ class DatetimeIndex(DatelikeOps, TimelikeOps, DatetimeIndexOpsMixin,
             else:
                 raise TypeError("Already tz-aware, use tz_convert to convert.")
         else:
-            tz = libts.maybe_get_tz(tz)
+            tz = timezones.maybe_get_tz(tz)
             # Convert to UTC
 
             new_dates = libts.tz_localize_to_utc(self.asi8, tz,

--- a/pandas/core/indexes/datetimes.py
+++ b/pandas/core/indexes/datetimes.py
@@ -52,6 +52,7 @@ from pandas._libs import (lib, index as libindex, tslib as libts,
                           Timestamp, period as libperiod)
 from pandas._libs.tslibs import timezones
 
+
 def _utc():
     import pytz
     return pytz.utc

--- a/pandas/core/tools/datetimes.py
+++ b/pandas/core/tools/datetimes.py
@@ -3,6 +3,7 @@ import numpy as np
 from collections import MutableMapping
 
 from pandas._libs import lib, tslib
+from pandas._libs.tslibs.timezones import get_timezone
 
 from pandas.core.dtypes.common import (
     _ensure_object,
@@ -44,7 +45,7 @@ def _infer_tzinfo(start, end):
     def _infer(a, b):
         tz = a.tzinfo
         if b and b.tzinfo:
-            if not (tslib.get_timezone(tz) == tslib.get_timezone(b.tzinfo)):
+            if not (get_timezone(tz) == get_timezone(b.tzinfo)):
                 raise AssertionError('Inputs must both have the same timezone,'
                                      ' {timezone1} != {timezone2}'
                                      .format(timezone1=tz, timezone2=b.tzinfo))

--- a/pandas/io/pytables.py
+++ b/pandas/io/pytables.py
@@ -46,7 +46,7 @@ from pandas.compat import u_safe as u, PY3, range, lrange, string_types, filter
 from pandas.core.config import get_option
 from pandas.core.computation.pytables import Expr, maybe_expression
 
-from pandas._libs import tslib, algos, lib
+from pandas._libs import algos, lib
 from pandas._libs.tslibs import timezones
 
 from distutils.version import LooseVersion

--- a/pandas/io/pytables.py
+++ b/pandas/io/pytables.py
@@ -47,6 +47,7 @@ from pandas.core.config import get_option
 from pandas.core.computation.pytables import Expr, maybe_expression
 
 from pandas._libs import tslib, algos, lib
+from pandas._libs.tslibs import timezones
 
 from distutils.version import LooseVersion
 
@@ -4379,7 +4380,7 @@ def _get_info(info, name):
 
 def _get_tz(tz):
     """ for a tz-aware type, return an encoded zone """
-    zone = tslib.get_timezone(tz)
+    zone = timezones.get_timezone(tz)
     if zone is None:
         zone = tz.utcoffset().total_seconds()
     return zone
@@ -4401,7 +4402,7 @@ def _set_tz(values, tz, preserve_UTC=False, coerce=False):
     if tz is not None:
         name = getattr(values, 'name', None)
         values = values.ravel()
-        tz = tslib.get_timezone(_ensure_decoded(tz))
+        tz = timezones.get_timezone(_ensure_decoded(tz))
         values = DatetimeIndex(values, name=name)
         if values.tz is None:
             values = values.tz_localize('UTC').tz_convert(tz)

--- a/pandas/tests/indexes/datetimes/test_date_range.py
+++ b/pandas/tests/indexes/datetimes/test_date_range.py
@@ -394,7 +394,7 @@ class TestBusinessDateRange(object):
         # see gh-2906
 
         # Use maybe_get_tz to fix filename in tz under dateutil.
-        from pandas._libs.tslib import maybe_get_tz
+        from pandas._libs.tslibs.timezones import maybe_get_tz
         tz = lambda x: maybe_get_tz('dateutil/' + x)
 
         start = datetime(2011, 1, 1, tzinfo=tz('US/Eastern'))

--- a/pandas/tests/indexes/datetimes/test_setops.py
+++ b/pandas/tests/indexes/datetimes/test_setops.py
@@ -325,7 +325,7 @@ class TestBusinessDatetimeIndex(object):
     def test_month_range_union_tz_dateutil(self):
         tm._skip_if_windows_python_3()
 
-        from pandas._libs.tslib import _dateutil_gettz as timezone
+        from pandas._libs.tslib import dateutil_gettz as timezone
         tz = timezone('US/Eastern')
 
         early_start = datetime(2011, 1, 1)

--- a/pandas/tests/indexes/datetimes/test_setops.py
+++ b/pandas/tests/indexes/datetimes/test_setops.py
@@ -325,7 +325,7 @@ class TestBusinessDatetimeIndex(object):
     def test_month_range_union_tz_dateutil(self):
         tm._skip_if_windows_python_3()
 
-        from pandas._libs.tslib import dateutil_gettz as timezone
+        from pandas._libs.tslibs.timezones import dateutil_gettz as timezone
         tz = timezone('US/Eastern')
 
         early_start = datetime(2011, 1, 1)

--- a/pandas/tests/indexes/datetimes/test_setops.py
+++ b/pandas/tests/indexes/datetimes/test_setops.py
@@ -325,8 +325,8 @@ class TestBusinessDatetimeIndex(object):
     def test_month_range_union_tz_dateutil(self):
         tm._skip_if_windows_python_3()
 
-        from pandas._libs.tslibs.timezones import dateutil_gettz as timezone
-        tz = timezone('US/Eastern')
+        from pandas._libs.tslibs.timezones import dateutil_gettz
+        tz = dateutil_gettz('US/Eastern')
 
         early_start = datetime(2011, 1, 1)
         early_end = datetime(2011, 3, 1)

--- a/pandas/tests/io/test_pytables.py
+++ b/pandas/tests/io/test_pytables.py
@@ -5421,7 +5421,7 @@ class TestTimezones(Base):
 
         # use maybe_get_tz instead of dateutil.tz.gettz to handle the windows
         # filename issues.
-        from pandas._libs.tslib import maybe_get_tz
+        from pandas._libs.tslibs.timezones import maybe_get_tz
         gettz = lambda x: maybe_get_tz('dateutil/' + x)
 
         # as columns

--- a/pandas/tests/scalar/test_period.py
+++ b/pandas/tests/scalar/test_period.py
@@ -245,8 +245,8 @@ class TestPeriodProperties(object):
             assert p.tz == exp.tz
 
     def test_timestamp_tz_arg_dateutil(self):
-        from pandas._libs.tslib import dateutil_gettz as gettz
-        from pandas._libs.tslib import maybe_get_tz
+        from pandas._libs.tslibs.timezones import dateutil_gettz as gettz
+        from pandas._libs.tslibs.timezones import maybe_get_tz
         for case in ['dateutil/Europe/Brussels', 'dateutil/Asia/Tokyo',
                      'dateutil/US/Pacific']:
             p = Period('1/1/2005', freq='M').to_timestamp(
@@ -264,7 +264,7 @@ class TestPeriodProperties(object):
             assert p.tz == exp.tz
 
     def test_timestamp_tz_arg_dateutil_from_string(self):
-        from pandas._libs.tslib import dateutil_gettz as gettz
+        from pandas._libs.tslibs.timezones import dateutil_gettz as gettz
         p = Period('1/1/2005',
                    freq='M').to_timestamp(tz='dateutil/Europe/Brussels')
         assert p.tz == gettz('Europe/Brussels')

--- a/pandas/tests/scalar/test_period.py
+++ b/pandas/tests/scalar/test_period.py
@@ -245,7 +245,7 @@ class TestPeriodProperties(object):
             assert p.tz == exp.tz
 
     def test_timestamp_tz_arg_dateutil(self):
-        from pandas._libs.tslibs.timezones import dateutil_gettz as gettz
+        from pandas._libs.tslibs.timezones import dateutil_gettz
         from pandas._libs.tslibs.timezones import maybe_get_tz
         for case in ['dateutil/Europe/Brussels', 'dateutil/Asia/Tokyo',
                      'dateutil/US/Pacific']:
@@ -253,21 +253,21 @@ class TestPeriodProperties(object):
                 tz=maybe_get_tz(case))
             exp = Timestamp('1/1/2005', tz='UTC').tz_convert(case)
             assert p == exp
-            assert p.tz == gettz(case.split('/', 1)[1])
+            assert p.tz == dateutil_gettz(case.split('/', 1)[1])
             assert p.tz == exp.tz
 
             p = Period('1/1/2005',
                        freq='M').to_timestamp(freq='3H', tz=maybe_get_tz(case))
             exp = Timestamp('1/1/2005', tz='UTC').tz_convert(case)
             assert p == exp
-            assert p.tz == gettz(case.split('/', 1)[1])
+            assert p.tz == dateutil_gettz(case.split('/', 1)[1])
             assert p.tz == exp.tz
 
     def test_timestamp_tz_arg_dateutil_from_string(self):
-        from pandas._libs.tslibs.timezones import dateutil_gettz as gettz
+        from pandas._libs.tslibs.timezones import dateutil_gettz
         p = Period('1/1/2005',
                    freq='M').to_timestamp(tz='dateutil/Europe/Brussels')
-        assert p.tz == gettz('Europe/Brussels')
+        assert p.tz == dateutil_gettz('Europe/Brussels')
 
     def test_timestamp_mult(self):
         p = pd.Period('2011-01', freq='M')

--- a/pandas/tests/scalar/test_period.py
+++ b/pandas/tests/scalar/test_period.py
@@ -245,7 +245,7 @@ class TestPeriodProperties(object):
             assert p.tz == exp.tz
 
     def test_timestamp_tz_arg_dateutil(self):
-        from pandas._libs.tslib import _dateutil_gettz as gettz
+        from pandas._libs.tslib import dateutil_gettz as gettz
         from pandas._libs.tslib import maybe_get_tz
         for case in ['dateutil/Europe/Brussels', 'dateutil/Asia/Tokyo',
                      'dateutil/US/Pacific']:
@@ -264,7 +264,7 @@ class TestPeriodProperties(object):
             assert p.tz == exp.tz
 
     def test_timestamp_tz_arg_dateutil_from_string(self):
-        from pandas._libs.tslib import _dateutil_gettz as gettz
+        from pandas._libs.tslib import dateutil_gettz as gettz
         p = Period('1/1/2005',
                    freq='M').to_timestamp(tz='dateutil/Europe/Brussels')
         assert p.tz == gettz('Europe/Brussels')

--- a/pandas/tests/scalar/test_timestamp.py
+++ b/pandas/tests/scalar/test_timestamp.py
@@ -17,7 +17,7 @@ from pytz.exceptions import AmbiguousTimeError, NonExistentTimeError
 import pandas.util.testing as tm
 from pandas.tseries import offsets, frequencies
 from pandas._libs import tslib, period
-from pandas._libs.tslib import get_timezone
+from pandas._libs.tslibs.timezones import get_timezone
 
 from pandas.compat import lrange, long
 from pandas.util.testing import assert_series_equal
@@ -1295,7 +1295,7 @@ class TestTimeSeries(object):
     def test_timestamp_to_datetime_explicit_dateutil(self):
         tm._skip_if_windows_python_3()
 
-        from pandas._libs.tslib import dateutil_gettz as gettz
+        from pandas._libs.tslibs.timezones import dateutil_gettz as gettz
         rng = date_range('20090415', '20090519', tz=gettz('US/Eastern'))
 
         stamp = rng[0]

--- a/pandas/tests/scalar/test_timestamp.py
+++ b/pandas/tests/scalar/test_timestamp.py
@@ -1295,7 +1295,7 @@ class TestTimeSeries(object):
     def test_timestamp_to_datetime_explicit_dateutil(self):
         tm._skip_if_windows_python_3()
 
-        from pandas._libs.tslib import _dateutil_gettz as gettz
+        from pandas._libs.tslib import dateutil_gettz as gettz
         rng = date_range('20090415', '20090519', tz=gettz('US/Eastern'))
 
         stamp = rng[0]

--- a/pandas/tests/series/test_indexing.py
+++ b/pandas/tests/series/test_indexing.py
@@ -387,7 +387,7 @@ class TestSeriesIndexing(TestData):
 
     def test_getitem_setitem_datetime_tz_dateutil(self):
         from dateutil.tz import tzutc
-        from pandas._libs.tslib import _dateutil_gettz as gettz
+        from pandas._libs.tslib import dateutil_gettz as gettz
 
         tz = lambda x: tzutc() if x == 'UTC' else gettz(
             x)  # handle special case for utc in dateutil

--- a/pandas/tests/series/test_indexing.py
+++ b/pandas/tests/series/test_indexing.py
@@ -387,7 +387,7 @@ class TestSeriesIndexing(TestData):
 
     def test_getitem_setitem_datetime_tz_dateutil(self):
         from dateutil.tz import tzutc
-        from pandas._libs.tslib import dateutil_gettz as gettz
+        from pandas._libs.tslibs.timezones import dateutil_gettz as gettz
 
         tz = lambda x: tzutc() if x == 'UTC' else gettz(
             x)  # handle special case for utc in dateutil

--- a/pandas/tests/tseries/test_offsets.py
+++ b/pandas/tests/tseries/test_offsets.py
@@ -33,6 +33,7 @@ from pandas.core.tools.datetimes import (
     to_datetime, DateParseError)
 import pandas.tseries.offsets as offsets
 from pandas.io.pickle import read_pickle
+from pandas._libs.tslibs import timezones
 from pandas._libs.tslib import normalize_date, NaT, Timestamp, Timedelta
 import pandas._libs.tslib as tslib
 import pandas.util.testing as tm
@@ -288,7 +289,7 @@ class TestCommon(Base):
 
         for tz in self.timezones:
             expected_localize = expected.tz_localize(tz)
-            tz_obj = tslib.maybe_get_tz(tz)
+            tz_obj = timezones.maybe_get_tz(tz)
             dt_tz = tslib._localize_pydatetime(dt, tz_obj)
 
             result = func(dt_tz)

--- a/pandas/tests/tseries/test_timezones.py
+++ b/pandas/tests/tseries/test_timezones.py
@@ -1181,7 +1181,7 @@ class TestTimeZoneCacheKey(object):
             if tz_d is None:
                 # skip timezones that dateutil doesn't know about.
                 continue
-            assert tslib._p_tz_cache_key(tz_p) != tslib._p_tz_cache_key(tz_d)
+            assert tslib.p_tz_cache_key(tz_p) != tslib.p_tz_cache_key(tz_d)
 
 
 class TestTimeZones(object):

--- a/pandas/tests/tseries/test_timezones.py
+++ b/pandas/tests/tseries/test_timezones.py
@@ -1182,8 +1182,8 @@ class TestTimeZoneCacheKey(object):
             if tz_d is None:
                 # skip timezones that dateutil doesn't know about.
                 continue
-            assert (timezones.p_tz_cache_key(tz_p) !=
-                    timezones.p_tz_cache_key(tz_d))
+            assert (timezones._p_tz_cache_key(tz_p) !=
+                    timezones._p_tz_cache_key(tz_d))
 
 
 class TestTimeZones(object):

--- a/pandas/tests/tseries/test_timezones.py
+++ b/pandas/tests/tseries/test_timezones.py
@@ -18,6 +18,7 @@ from pandas.compat import lrange, zip
 from pandas.core.indexes.datetimes import bdate_range, date_range
 from pandas.core.dtypes.dtypes import DatetimeTZDtype
 from pandas._libs import tslib
+from pandas._libs.tslibs import timezones
 from pandas import (Index, Series, DataFrame, isna, Timestamp, NaT,
                     DatetimeIndex, to_datetime)
 from pandas.util.testing import (assert_frame_equal, assert_series_equal,
@@ -943,7 +944,7 @@ class TestTimeZoneSupportDateutil(TestTimeZoneSupportPytz):
         Use tslib.maybe_get_tz so that we get the filename on the tz right
         on windows. See #7337.
         """
-        return tslib.maybe_get_tz('dateutil/' + tz)
+        return timezones.maybe_get_tz('dateutil/' + tz)
 
     def tzstr(self, tz):
         """ Construct a timezone string from a string. Overridden in subclass
@@ -962,7 +963,7 @@ class TestTimeZoneSupportDateutil(TestTimeZoneSupportPytz):
         # Skipped on win32 due to dateutil bug
         tm._skip_if_windows()
 
-        from pandas._libs.tslib import maybe_get_tz
+        from pandas._libs.tslibs.timezones import maybe_get_tz
 
         # from system utc to real utc
         ts = Timestamp('2001-01-05 11:56', tz=maybe_get_tz('dateutil/UTC'))
@@ -1133,7 +1134,7 @@ class TestTimeZoneSupportDateutil(TestTimeZoneSupportPytz):
         assert ts.tz == dateutil.tz.tzlocal()
         assert "tz='tzlocal()')" in repr(ts)
 
-        tz = tslib.maybe_get_tz('tzlocal()')
+        tz = timezones.maybe_get_tz('tzlocal()')
         assert tz == dateutil.tz.tzlocal()
 
         # get offset using normal datetime for test
@@ -1176,12 +1177,13 @@ class TestTimeZoneCacheKey(object):
             if tz_name == 'UTC':
                 # skip utc as it's a special case in dateutil
                 continue
-            tz_p = tslib.maybe_get_tz(tz_name)
-            tz_d = tslib.maybe_get_tz('dateutil/' + tz_name)
+            tz_p = timezones.maybe_get_tz(tz_name)
+            tz_d = timezones.maybe_get_tz('dateutil/' + tz_name)
             if tz_d is None:
                 # skip timezones that dateutil doesn't know about.
                 continue
-            assert tslib.p_tz_cache_key(tz_p) != tslib.p_tz_cache_key(tz_d)
+            assert (timezones.p_tz_cache_key(tz_p) !=
+                    timezones.p_tz_cache_key(tz_d))
 
 
 class TestTimeZones(object):
@@ -1743,13 +1745,13 @@ class TestTslib(object):
 
         # Check empty array
         result = tslib.tz_convert(np.array([], dtype=np.int64),
-                                  tslib.maybe_get_tz('US/Eastern'),
-                                  tslib.maybe_get_tz('Asia/Tokyo'))
+                                  timezones.maybe_get_tz('US/Eastern'),
+                                  timezones.maybe_get_tz('Asia/Tokyo'))
         tm.assert_numpy_array_equal(result, np.array([], dtype=np.int64))
 
         # Check all-NaT array
         result = tslib.tz_convert(np.array([tslib.iNaT], dtype=np.int64),
-                                  tslib.maybe_get_tz('US/Eastern'),
-                                  tslib.maybe_get_tz('Asia/Tokyo'))
+                                  timezones.maybe_get_tz('US/Eastern'),
+                                  timezones.maybe_get_tz('Asia/Tokyo'))
         tm.assert_numpy_array_equal(result, np.array(
             [tslib.iNaT], dtype=np.int64))


### PR DESCRIPTION
Follow-up to #17526 

- [ ] closes #xxxx
- [ ] tests added / passed
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
