### PR TITLE
DOC: Fixes after #17482

### DIFF
--- a/doc/source/whatsnew/v0.21.0.txt
+++ b/doc/source/whatsnew/v0.21.0.txt
@@ -363,7 +363,7 @@ Additionally, DataFrames with datetime columns that were parsed by :func:`read_s
 Consistency of Range Functions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-In previous versions, there were some inconsistencies between the various range functions: func:`date_range`, func:`bdate_range`, func:`cdate_range`, func:`period_range`, func:`timedelta_range`, and func:`interval_range`. (:issue:`17471`).
+In previous versions, there were some inconsistencies between the various range functions: :func:`date_range`, :func:`bdate_range`, :func:`cdate_range`, :func:`period_range`, :func:`timedelta_range`, and :func:`interval_range`. (:issue:`17471`).
 
 One of the inconsistent behaviors occurred when the ``start``, ``end`` and ``period`` parameters were all specified, potentially leading to ambiguous ranges.  When all three parameters were passed, ``interval_range`` ignored the ``period`` parameter, ``period_range`` ignored the ``end`` parameter, and the other range functions raised.  To promote consistency among the range functions, and avoid potentially ambiguous ranges, ``interval_range`` and ``period_range`` will now raise when all three parameters are passed.
 

--- a/pandas/core/api.py
+++ b/pandas/core/api.py
@@ -16,7 +16,8 @@ from pandas.core.index import (Index, CategoricalIndex, Int64Index,
                                PeriodIndex, NaT)
 from pandas.core.indexes.period import Period, period_range, pnow
 from pandas.core.indexes.timedeltas import Timedelta, timedelta_range
-from pandas.core.indexes.datetimes import Timestamp, date_range, bdate_range
+from pandas.core.indexes.datetimes import (Timestamp, date_range, bdate_range,
+                                           cdate_range)
 from pandas.core.indexes.interval import Interval, interval_range
 
 from pandas.core.series import Series

--- a/pandas/core/indexes/datetimes.py
+++ b/pandas/core/indexes/datetimes.py
@@ -2094,13 +2094,8 @@ def bdate_range(start=None, end=None, periods=None, freq='B', tz=None,
 def cdate_range(start=None, end=None, periods=None, freq='C', tz=None,
                 normalize=True, name=None, closed=None, **kwargs):
     """
-    **EXPERIMENTAL** Return a fixed frequency DatetimeIndex, with
-    CustomBusinessDay as the default frequency
-
-    .. warning:: EXPERIMENTAL
-
-        The CustomBusinessDay class is not officially supported and the API is
-        likely to change in future versions. Use this at your own risk.
+    Return a fixed frequency DatetimeIndex, with CustomBusinessDay as the
+    default frequency
 
     Parameters
     ----------

--- a/pandas/core/indexes/interval.py
+++ b/pandas/core/indexes/interval.py
@@ -1094,7 +1094,8 @@ def interval_range(start=None, end=None, periods=None, freq=None,
 
     Additionally, datetime-like input is also supported.
 
-    >>> pd.interval_range(start='2017-01-01', end='2017-01-04')
+    >>> pd.interval_range(start=pd.Timestamp('2017-01-01'),
+                          end=pd.Timestamp('2017-01-04'))
     IntervalIndex([(2017-01-01, 2017-01-02], (2017-01-02, 2017-01-03],
                    (2017-01-03, 2017-01-04]]
                   closed='right', dtype='interval[datetime64[ns]]')
@@ -1110,7 +1111,8 @@ def interval_range(start=None, end=None, periods=None, freq=None,
     Similarly, for datetime-like ``start`` and ``end``, the frequency must be
     convertible to a DateOffset.
 
-    >>> pd.interval_range(start='2017-01-01', periods=3, freq='MS')
+    >>> pd.interval_range(start=pd.Timestamp('2017-01-01'),
+                          periods=3, freq='MS')
     IntervalIndex([(2017-01-01, 2017-02-01], (2017-02-01, 2017-03-01],
                    (2017-03-01, 2017-04-01]]
                   closed='right', dtype='interval[datetime64[ns]]')

--- a/pandas/tests/api/test_api.py
+++ b/pandas/tests/api/test_api.py
@@ -63,7 +63,7 @@ class TestPDApi(Base):
     # top-level functions
     funcs = ['bdate_range', 'concat', 'crosstab', 'cut',
              'date_range', 'interval_range', 'eval',
-             'factorize', 'get_dummies',
+             'factorize', 'get_dummies', 'cdate_range',
              'infer_freq', 'isna', 'isnull', 'lreshape',
              'melt', 'notna', 'notnull', 'offsets',
              'merge', 'merge_ordered', 'merge_asof',


### PR DESCRIPTION
- [X] tests added / passed
- [X] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`

Some doc fixes related to #17482:
- `func:` -> `:func:` 
    - See: https://github.com/pandas-dev/pandas/pull/17482#discussion_r139148962
- Added `cdate_range` to the public api so that it works in the docs
   - Ask for it to be added to docs:  https://github.com/pandas-dev/pandas/pull/17482#discussion_r138609092 
    - Public api issue pointed out: https://github.com/pandas-dev/pandas/pull/17482#discussion_r139148705
- Added `cdate_range` to `tests\api\test_api.py` to ensure that adding it to the top-level api is tested
- Removed the "experimental" from `cdate_range` docstring
    - See: https://github.com/pandas-dev/pandas/pull/17482#discussion_r138504193
- Fixed an error in the docstring for `interval_range` (strings aren't supported).