### PR TITLE
Remove clutter from ext_data

### DIFF
--- a/pandas/_libs/src/util.pxd
+++ b/pandas/_libs/src/util.pxd
@@ -2,6 +2,8 @@ from numpy cimport ndarray
 cimport numpy as cnp
 cimport cpython
 
+from cpython cimport PyString_Check, PyUnicode_Check
+
 cdef extern from "numpy_helper.h":
     inline void set_array_owndata(ndarray ao)
     inline void set_array_not_contiguous(ndarray ao)
@@ -10,7 +12,6 @@ cdef extern from "numpy_helper.h":
     inline int is_float_object(object)
     inline int is_complex_object(object)
     inline int is_bool_object(object)
-    inline int is_string_object(object)
     inline int is_datetime64_object(object)
     inline int is_timedelta64_object(object)
     inline int assign_value_1d(ndarray, Py_ssize_t, object) except -1
@@ -126,3 +127,6 @@ cdef inline bint _checknan(object val):
 
 cdef inline bint is_period_object(object val):
     return getattr(val, '_typ', '_typ') == 'period'
+
+cdef inline bint is_string_object(object obj):
+    return PyString_Check(obj) or PyUnicode_Check(obj)

--- a/setup.py
+++ b/setup.py
@@ -429,7 +429,7 @@ else:
     cmdclass['build_src'] = DummyBuildSrc
     cmdclass['build_ext'] = CheckingBuildExt
 
-lib_depends = ['reduce', 'inference', 'properties']
+lib_depends = []#['reduce', 'inference', 'properties']
 
 
 def srcpath(name=None, suffix='.pyx', subdir='src'):
@@ -454,9 +454,9 @@ if is_platform_windows():
 else:
     extra_compile_args=['-Wno-unused-function']
 
-lib_depends = lib_depends + ['pandas/_libs/src/numpy_helper.h',
-                             'pandas/_libs/src/parse_helper.h',
-                             'pandas/_libs/src/compat_helper.h']
+#lib_depends = lib_depends + ['pandas/_libs/src/numpy_helper.h',
+#                             'pandas/_libs/src/parse_helper.h',
+#                             'pandas/_libs/src/compat_helper.h']
 
 
 tseries_depends = ['pandas/_libs/src/datetime/np_datetime.h',
@@ -471,10 +471,8 @@ ext_data = {
     '_libs.lib': {'pyxfile': '_libs/lib',
                   'depends': lib_depends + tseries_depends},
     '_libs.hashtable': {'pyxfile': '_libs/hashtable',
-                        'depends': (['pandas/_libs/src/klib/khash_python.h']
-                                    + _pxi_dep['hashtable'])},
+                        'depends': _pxi_dep['hashtable']},
     '_libs.tslib': {'pyxfile': '_libs/tslib',
-                    'pxdfiles': ['_libs/src/util'],
                     'depends': tseries_depends,
                     'sources': ['pandas/_libs/src/datetime/np_datetime.c',
                                 'pandas/_libs/src/datetime/np_datetime_strings.c']},
@@ -485,28 +483,22 @@ ext_data = {
                      'sources': ['pandas/_libs/src/datetime/np_datetime.c',
                                  'pandas/_libs/src/datetime/np_datetime_strings.c',
                                  'pandas/_libs/src/period_helper.c']},
-    '_libs.tslibs.frequencies': {'pyxfile': '_libs/tslibs/frequencies',
-                                 'pxdfiles': ['_libs/src/util']},
+    '_libs.tslibs.frequencies': {'pyxfile': '_libs/tslibs/frequencies'},
     '_libs.index': {'pyxfile': '_libs/index',
                     'sources': ['pandas/_libs/src/datetime/np_datetime.c',
                                 'pandas/_libs/src/datetime/np_datetime_strings.c'],
-                    'pxdfiles': ['_libs/src/util'],
                     'depends': _pxi_dep['index']},
     '_libs.algos': {'pyxfile': '_libs/algos',
-                    'pxdfiles': ['_libs/src/util'],
                     'depends': _pxi_dep['algos']},
     '_libs.groupby': {'pyxfile': '_libs/groupby',
-                      'pxdfiles': ['_libs/src/util'],
                       'depends': _pxi_dep['groupby']},
     '_libs.join': {'pyxfile': '_libs/join',
-                   'pxdfiles': ['_libs/src/util'],
                    'depends': _pxi_dep['join']},
     '_libs.reshape': {'pyxfile': '_libs/reshape',
                       'depends': _pxi_dep['reshape']},
     '_libs.interval': {'pyxfile': '_libs/interval',
                        'depends': _pxi_dep['interval']},
     '_libs.window': {'pyxfile': '_libs/window',
-                     'pxdfiles': ['_libs/src/skiplist', '_libs/src/util'],
                      'depends': ['pandas/_libs/src/skiplist.pyx',
                                  'pandas/_libs/src/skiplist.h']},
     '_libs.parsers': {'pyxfile': '_libs/parsers',

--- a/setup.py
+++ b/setup.py
@@ -429,7 +429,7 @@ else:
     cmdclass['build_src'] = DummyBuildSrc
     cmdclass['build_ext'] = CheckingBuildExt
 
-lib_depends = []#['reduce', 'inference', 'properties']
+lib_depends = []
 
 
 def srcpath(name=None, suffix='.pyx', subdir='src'):
@@ -454,32 +454,22 @@ if is_platform_windows():
 else:
     extra_compile_args=['-Wno-unused-function']
 
-#lib_depends = lib_depends + ['pandas/_libs/src/numpy_helper.h',
-#                             'pandas/_libs/src/parse_helper.h',
-#                             'pandas/_libs/src/compat_helper.h']
-
-
-tseries_depends = ['pandas/_libs/src/datetime/np_datetime.h',
-                   'pandas/_libs/src/datetime/np_datetime_strings.h',
-                   'pandas/_libs/src/datetime.pxd']
+tseries_depends = []
 
 
 # some linux distros require it
 libraries = ['m'] if not is_platform_windows() else []
 
 ext_data = {
-    '_libs.lib': {'pyxfile': '_libs/lib',
-                  'depends': lib_depends + tseries_depends},
+    '_libs.lib': {'pyxfile': '_libs/lib'},
     '_libs.hashtable': {'pyxfile': '_libs/hashtable',
                         'depends': _pxi_dep['hashtable']},
     '_libs.tslib': {'pyxfile': '_libs/tslib',
-                    'depends': tseries_depends,
                     'sources': ['pandas/_libs/src/datetime/np_datetime.c',
                                 'pandas/_libs/src/datetime/np_datetime_strings.c']},
     '_libs.tslibs.timezones': {'pyxfile': '_libs/tslibs/timezones'},
     '_libs.period': {'pyxfile': '_libs/period',
-                     'depends': (tseries_depends +
-                                 ['pandas/_libs/src/period_helper.h']),
+                     'depends': ['pandas/_libs/src/period_helper.h'],
                      'sources': ['pandas/_libs/src/datetime/np_datetime.c',
                                  'pandas/_libs/src/datetime/np_datetime_strings.c',
                                  'pandas/_libs/src/period_helper.c']},


### PR DESCRIPTION
I'm quite bothered by the lack of clarity in setup.py as to what is and is not required for the build.  To demonstrate the issue, this PR removes a bunch of gee-I-thought-that-was-necessary clutter from the `Extension` kwargs.