### PR TITLE
Raise ValueError when using levels with non-unique values in MultiIndex constructor

### DIFF
--- a/doc/source/whatsnew/v0.21.0.txt
+++ b/doc/source/whatsnew/v0.21.0.txt
@@ -432,7 +432,7 @@ Other API Changes
 - :class:`Period` is now immutable, and will now raise an ``AttributeError`` when a user tries to assign a new value to the ``ordinal`` or ``freq`` attributes (:issue:`17116`).
 - :func:`to_datetime` when passed a tz-aware ``origin=`` kwarg will now raise a more informative ``ValueError`` rather than a ``TypeError`` (:issue:`16842`)
 - Renamed non-functional ``index`` to ``index_col`` in :func:`read_stata` to improve API consistency (:issue:`16342`)
-
+- :class:`MultiIndex` constructor now checks if the values of each level are unique when ``verify_integrity=True`` (:issue:`17464`)
 
 .. _whatsnew_0210.deprecations:
 

--- a/pandas/core/indexes/multi.py
+++ b/pandas/core/indexes/multi.py
@@ -147,6 +147,11 @@ class MultiIndex(Index):
                                  " level  (%d). NOTE: this index is in an"
                                  " inconsistent state" % (i, label.max(),
                                                           len(level)))
+        for i, level in enumerate(levels):
+            if len(level) != len(set(level)):
+                raise ValueError("Level values must be unique: %s "
+                                 "on level %d" % ([value for value
+                                                   in level], i))
 
     def _get_levels(self):
         return self._levels

--- a/pandas/core/indexes/multi.py
+++ b/pandas/core/indexes/multi.py
@@ -148,8 +148,8 @@ class MultiIndex(Index):
                                  " inconsistent state" % (i, label.max(),
                                                           len(level)))
         for i, level in enumerate(levels):
-            if len(level) != len(set(level)):
-                raise ValueError("Level values must be unique: {0}"
+            if not level.is_unique:
+                raise ValueError("Level values must be unique: {0!r}"
                                  " on level {1}".format([value for value
                                                          in level], i))
 

--- a/pandas/core/indexes/multi.py
+++ b/pandas/core/indexes/multi.py
@@ -149,9 +149,9 @@ class MultiIndex(Index):
                                                           len(level)))
         for i, level in enumerate(levels):
             if len(level) != len(set(level)):
-                raise ValueError("Level values must be unique: %s "
-                                 "on level %d" % ([value for value
-                                                   in level], i))
+                raise ValueError("Level values must be unique: {0}"
+                                 " on level {1}".format([value for value
+                                                         in level], i))
 
     def _get_levels(self):
         return self._levels

--- a/pandas/tests/indexes/test_multi.py
+++ b/pandas/tests/indexes/test_multi.py
@@ -588,6 +588,14 @@ class TestMultiIndex(Base):
             with tm.assert_raises_regex(ValueError, label_error):
                 self.index.copy().labels = [[0, 0, 0, 0], [0, 0]]
 
+    def test_constructor_non_unique_level_values(self):
+        # GH #17464
+        with tm.assert_raises_regex(ValueError, '^Level values'):
+            MultiIndex(levels=[[0, 1], [0, 0, 1, 1]],
+                       labels=[[0, 0, 0, 0, 1, 1, 1, 1],
+                               [0, 0, 1, 1, 0, 0, 1, 1]],
+                       names=[u'idx0', u'idx1'])
+
     def assert_multiindex_copied(self, copy, original):
         # Levels should be (at least, shallow copied)
         tm.assert_copy(copy.levels, original.levels)


### PR DESCRIPTION
- [x] closes #17464
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

`verify_integrity` now also checks if any level has non-unique values and raises `ValueError` if one does.

However, some tests were broken due to this new behaviour.
I'd like to know what should I do in this case, should I add `verify_integrity=False` to those tests, change them, or do something else?

Also, how should I state this in the whatsnew file and where?

Thank you for your time! 🐼 🐍 