### PR TITLE
hexbin: Fixed incorrect "optional" attribute. Defined default behavior.

### DIFF
--- a/pandas/plotting/_core.py
+++ b/pandas/plotting/_core.py
@@ -2852,10 +2852,12 @@ class FramePlotMethods(BasePlotMethods):
 
         Parameters
         ----------
-        x, y : label or position, optional
+        x, y : label or position
             Coordinates for each point.
         C : label or position, optional
             The value at each `(x, y)` point.
+            If `None` (default), the plot displays histogram counts
+            (number of `(x, y)` that fall in each bin).
         reduce_C_function : callable, optional
             Function of one argument that reduces all the values in a bin to
             a single number (e.g. `mean`, `max`, `sum`, `std`).

--- a/pandas/plotting/_core.py
+++ b/pandas/plotting/_core.py
@@ -2861,6 +2861,7 @@ class FramePlotMethods(BasePlotMethods):
         reduce_C_function : callable, optional
             Function of one argument that reduces all the values in a bin to
             a single number (e.g. `mean`, `max`, `sum`, `std`).
+            Only used if `C` is not `None`. Defaults to `mean`.
         gridsize : int, optional
             Number of bins.
         **kwds : optional


### PR DESCRIPTION
`x` and `y` have no default values and are thus not optional.

The semantics of hexbin() with default arguments (i.e. when only `x` and `y` are given) is now defined.

It would be nice to describe what kind of argument `reduce_C_function()` expects (A sequence? A Series?), but this is not immediately obvious from the code.

- [ ] closes #xxxx
- [ ] tests added / passed
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
