### PR TITLE
BUG: fix tz-aware DatetimeIndex + TimedeltaIndex (#17558)

### DIFF
--- a/doc/source/whatsnew/v0.21.0.txt
+++ b/doc/source/whatsnew/v0.21.0.txt
@@ -506,6 +506,7 @@ Indexing
 - Bug in ``CategoricalIndex`` reindexing in which specified indices containing duplicates were not being respected (:issue:`17323`)
 - Bug in intersection of ``RangeIndex`` with negative step (:issue:`17296`)
 - Bug in ``IntervalIndex`` where performing a scalar lookup fails for included right endpoints of non-overlapping monotonic decreasing indexes (:issue:`16417`, :issue:`17271`)
+- Bug in adding ``DatetimeIndex`` with a ``TimedeltaIndex`` or a numpy array with ``dtype="timedelta64"`` (:issue:`17558`)
 
 I/O
 ^^^

--- a/doc/source/whatsnew/v0.21.0.txt
+++ b/doc/source/whatsnew/v0.21.0.txt
@@ -506,7 +506,7 @@ Indexing
 - Bug in ``CategoricalIndex`` reindexing in which specified indices containing duplicates were not being respected (:issue:`17323`)
 - Bug in intersection of ``RangeIndex`` with negative step (:issue:`17296`)
 - Bug in ``IntervalIndex`` where performing a scalar lookup fails for included right endpoints of non-overlapping monotonic decreasing indexes (:issue:`16417`, :issue:`17271`)
-- Bug in adding ``DatetimeIndex`` with a ``TimedeltaIndex`` or a numpy array with ``dtype="timedelta64"`` (:issue:`17558`)
+- Bug in adding tz-aware ``DatetimeIndex`` with a numpy array of ``timedelta64``s, and a bug in adding tz-aware ``DatetimeIndex`` with ``TimedeltaIndex`` (:issue:`17558`)
 
 I/O
 ^^^

--- a/pandas/core/indexes/datetimelike.py
+++ b/pandas/core/indexes/datetimelike.py
@@ -13,6 +13,7 @@ from pandas.core.dtypes.common import (
     is_integer, is_float,
     is_bool_dtype, _ensure_int64,
     is_scalar, is_dtype_equal,
+    is_timedelta64_dtype, is_integer_dtype,
     is_list_like)
 from pandas.core.dtypes.generic import (
     ABCIndex, ABCSeries,
@@ -651,6 +652,15 @@ class DatetimeIndexOpsMixin(object):
                 raise TypeError("cannot add {typ1} and {typ2}"
                                 .format(typ1=type(self).__name__,
                                         typ2=type(other).__name__))
+            elif isinstance(other, np.ndarray):
+                if is_timedelta64_dtype(other):
+                    return self._add_delta(TimedeltaIndex(other))
+                elif is_integer_dtype(other):
+                    return NotImplemented
+                else:
+                    raise TypeError("cannot add {typ1} and np.ndarray[{typ2}]"
+                                    .format(typ1=type(self).__name__,
+                                            typ2=other.dtype))
             elif isinstance(other, (DateOffset, timedelta, np.timedelta64,
                                     Timedelta)):
                 return self._add_delta(other)
@@ -731,7 +741,7 @@ class DatetimeIndexOpsMixin(object):
         if self.hasnans or other.hasnans:
             mask = (self._isnan) | (other._isnan)
             new_values[mask] = iNaT
-        return new_values.view(self.dtype)
+        return new_values.view('i8')
 
     def isin(self, values):
         """

--- a/pandas/core/indexes/datetimes.py
+++ b/pandas/core/indexes/datetimes.py
@@ -14,6 +14,7 @@ from pandas.core.dtypes.common import (
     is_integer, is_float,
     is_integer_dtype,
     is_datetime64_ns_dtype,
+    is_timedelta64_dtype,
     is_period_dtype,
     is_bool_dtype,
     is_string_dtype,
@@ -800,6 +801,8 @@ class DatetimeIndex(DatelikeOps, TimelikeOps, DatetimeIndexOpsMixin,
         name = self.name
 
         if isinstance(delta, (Tick, timedelta, np.timedelta64)):
+            new_values = self._add_delta_td(delta)
+        elif isinstance(delta, np.ndarray) and is_timedelta64_dtype(delta):
             new_values = self._add_delta_td(delta)
         elif isinstance(delta, TimedeltaIndex):
             new_values = self._add_delta_tdi(delta)

--- a/pandas/core/indexes/period.py
+++ b/pandas/core/indexes/period.py
@@ -647,7 +647,7 @@ class PeriodIndex(DatelikeOps, DatetimeIndexOpsMixin, Int64Index):
                 return other.n
             msg = _DIFFERENT_FREQ_INDEX.format(self.freqstr, other.freqstr)
             raise IncompatibleFrequency(msg)
-        elif isinstance(other, np.ndarray):
+        elif isinstance(other, (np.ndarray, TimedeltaIndex)):
             if is_integer_dtype(other):
                 return other
             elif is_timedelta64_dtype(other):

--- a/pandas/core/indexes/timedeltas.py
+++ b/pandas/core/indexes/timedeltas.py
@@ -312,9 +312,11 @@ class TimedeltaIndex(DatetimeIndexOpsMixin, TimelikeOps, Int64Index):
         return attrs
 
     def _add_delta(self, delta):
+        name = self.name
         if isinstance(delta, (Tick, timedelta, np.timedelta64)):
             new_values = self._add_delta_td(delta)
-            name = self.name
+        elif isinstance(delta, np.ndarray) and is_timedelta64_dtype(delta):
+            new_values = self._add_delta_td(delta)
         elif isinstance(delta, TimedeltaIndex):
             new_values = self._add_delta_tdi(delta)
             # update name when delta is index

--- a/pandas/tests/indexes/datetimes/test_ops.py
+++ b/pandas/tests/indexes/datetimes/test_ops.py
@@ -460,20 +460,6 @@ Freq: D"""
         with pytest.raises(TypeError):
             dti + dti_tz
 
-    def test_add_dti_ndarray(self):
-        # GH 17558
-        # Check that tz-aware DatetimeIndex + np.array(dtype="timedelta64")
-        # and DatetimeIndex + TimedeltaIndex work as expected
-        dti = pd.DatetimeIndex([pd.Timestamp("2017/01/01")])
-        dti = dti.tz_localize('US/Eastern')
-        expected = pd.DatetimeIndex([pd.Timestamp("2017/01/01 01:00")])
-        expected = expected.tz_localize('US/Eastern')
-
-        td_np = np.array([np.timedelta64(1, 'h')], dtype="timedelta64[ns]")
-        tm.assert_index_equal(dti + td_np, expected)
-        tm.assert_index_equal(dti + td_np[0], expected)
-        tm.assert_index_equal(dti + TimedeltaIndex(td_np), expected)
-
     def test_difference(self):
         for tz in self.tz:
             # diff

--- a/pandas/tests/indexes/datetimes/test_ops.py
+++ b/pandas/tests/indexes/datetimes/test_ops.py
@@ -460,6 +460,20 @@ Freq: D"""
         with pytest.raises(TypeError):
             dti + dti_tz
 
+    def test_add_dti_ndarray(self):
+        # GH 17558
+        # Check that tz-aware DatetimeIndex + np.array(dtype="timedelta64")
+        # and DatetimeIndex + TimedeltaIndex work as expected
+        dti = pd.DatetimeIndex([pd.Timestamp("2017/01/01")])
+        dti = dti.tz_localize('US/Eastern')
+        expected = pd.DatetimeIndex([pd.Timestamp("2017/01/01 01:00")])
+        expected = expected.tz_localize('US/Eastern')
+
+        td_np = np.array([np.timedelta64(1, 'h')], dtype="timedelta64[ns]")
+        tm.assert_index_equal(dti + td_np, expected)
+        tm.assert_index_equal(dti + td_np[0], expected)
+        tm.assert_index_equal(dti + TimedeltaIndex(td_np), expected)
+
     def test_difference(self):
         for tz in self.tz:
             # diff


### PR DESCRIPTION
Fix a bug that was causing a tz-aware DatetimeIndex + TimedeltaIndex to raise an error. (An internal function was documented to return an integer view, but instead was trying to use the DatetimeIndex's dtype.) Fix another bug causing the sum of a tz-aware DatetimeIndex and a numpy array of timedeltas to incorrectly have timezone applied twice, by adding another case in `DatetimeIndex.__add__`.

- [x] closes #17558 
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry
