### PR TITLE
Remove experimental warning from custom offsets

### DIFF
--- a/pandas/tseries/offsets.py
+++ b/pandas/tseries/offsets.py
@@ -951,13 +951,8 @@ class BusinessHour(BusinessHourMixin, SingleConstructorOffset):
 
 class CustomBusinessDay(BusinessDay):
     """
-    **EXPERIMENTAL** DateOffset subclass representing possibly n business days
+    DateOffset subclass representing possibly n custom business days,
     excluding holidays
-
-    .. warning:: EXPERIMENTAL
-
-        This class is not officially supported and the API is likely to change
-        in future versions. Use this at your own risk.
 
     Parameters
     ----------
@@ -1405,12 +1400,8 @@ class BusinessMonthBegin(MonthOffset):
 
 class CustomBusinessMonthEnd(BusinessMixin, MonthOffset):
     """
-    **EXPERIMENTAL** DateOffset of one custom business month
-
-    .. warning:: EXPERIMENTAL
-
-        This class is not officially supported and the API is likely to change
-        in future versions. Use this at your own risk.
+    DateOffset subclass representing one custom business month, incrementing
+    between end of month dates
 
     Parameters
     ----------
@@ -1479,12 +1470,8 @@ class CustomBusinessMonthEnd(BusinessMixin, MonthOffset):
 
 class CustomBusinessMonthBegin(BusinessMixin, MonthOffset):
     """
-    **EXPERIMENTAL** DateOffset of one custom business month
-
-    .. warning:: EXPERIMENTAL
-
-        This class is not officially supported and the API is likely to change
-        in future versions. Use this at your own risk.
+    DateOffset subclass representing one custom business month, incrementing
+    between beginning of month dates
 
     Parameters
     ----------


### PR DESCRIPTION
Per discussion here: https://github.com/pandas-dev/pandas/pull/17554#pullrequestreview-63229522

- [X] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`

I edited the docstring descriptions slightly.  Feel free to suggest cleaner descriptions, if my edits don't suffice.  Should there be a whatsnew entry related to removing the experimental status?

