### PR TITLE
BUG:Time Grouper bug fix when applied for list groupers

### DIFF
--- a/doc/source/whatsnew/v0.21.0.txt
+++ b/doc/source/whatsnew/v0.21.0.txt
@@ -704,6 +704,7 @@ Groupby/Resample/Rolling
 - Bug in ``DataFrame.groupby`` where index and column keys were not recognized correctly when the number of keys equaled the number of elements on the groupby axis (:issue:`16859`)
 - Bug in ``groupby.nunique()`` with ``TimeGrouper`` which cannot handle ``NaT`` correctly (:issue:`17575`)
 - Bug in ``DataFrame.groupby`` where a single level selection from a ``MultiIndex`` unexpectedly sorts (:issue:`17537`)
+- Bug in ``TimeGrouper`` differs when passes as a list and as a scalar (:issue:`17530`)
 
 Sparse
 ^^^^^^

--- a/pandas/core/groupby.py
+++ b/pandas/core/groupby.py
@@ -1897,6 +1897,15 @@ class BaseGrouper(object):
         comp_ids = _ensure_int64(comp_ids)
         return comp_ids, obs_group_ids, ngroups
 
+    # 17530
+    @cache_readonly
+    def label_info(self):
+        labels, _, _ = self.group_info
+        if self.indexer is not None:
+            sorter = np.lexsort((labels, self.indexer))
+            labels = labels[sorter]
+        return labels
+
     def _get_compressed_labels(self):
         all_labels = [ping.labels for ping in self.groupings]
         if len(all_labels) > 1:
@@ -2596,11 +2605,8 @@ class Grouping(object):
         if self._labels is None or self._group_index is None:
             # for the situation of groupby list of groupers
             if isinstance(self.grouper, BaseGrouper):
-                labels, _, _ = self.grouper.group_info
+                labels = self.grouper.label_info
                 uniques = self.grouper.result_index
-                if self.grouper.indexer is not None:
-                    sorter = np.lexsort((labels, self.grouper.indexer))
-                    labels = labels[sorter]
             else:
                 labels, uniques = algorithms.factorize(
                     self.grouper, sort=self.sort)

--- a/pandas/core/groupby.py
+++ b/pandas/core/groupby.py
@@ -1730,8 +1730,10 @@ class BaseGrouper(object):
 
     Parameters
     ----------
-    axis : the axis to group
-    groupings : all the grouping instances to handle in this grouper
+    axis : int
+        the axis to group
+    groupings : array of grouping
+        all the grouping instances to handle in this grouper
         for example for grouper list to groupby, need to pass the list
     sort : boolean, default True
         whether this grouper will give sorted result or not
@@ -1897,9 +1899,9 @@ class BaseGrouper(object):
         comp_ids = _ensure_int64(comp_ids)
         return comp_ids, obs_group_ids, ngroups
 
-    # 17530
     @cache_readonly
     def label_info(self):
+        # return the labels of items in original grouped axis
         labels, _, _ = self.group_info
         if self.indexer is not None:
             sorter = np.lexsort((labels, self.indexer))
@@ -2319,16 +2321,19 @@ class BinGrouper(BaseGrouper):
 
     Examples
     --------
-    bins is [2, 4, 6, 8, 10]
-    binlabels is DatetimeIndex(['2005-01-01', '2005-01-03',
+    bins: [2, 4, 6, 8, 10]
+    binlabels: DatetimeIndex(['2005-01-01', '2005-01-03',
         '2005-01-05', '2005-01-07', '2005-01-09'],
         dtype='datetime64[ns]', freq='2D')
 
-    then the group_info is
+    the group_info, which contains the label of each item in grouped
+    axis, the index of label in label list, group number, is
+
     (array([0, 0, 1, 1, 2, 2, 3, 3, 4, 4]), array([0, 1, 2, 3, 4]), 5)
 
-    means the label of each item in axis, the index of label in label
-    list, group number
+    means that, the grouped axis has 10 items, can be grouped into 5
+    labels, the first and second items belong to the first label, the
+    third and forth items belong to the second label, and so on
 
     """
 

--- a/pandas/core/groupby.py
+++ b/pandas/core/groupby.py
@@ -1733,9 +1733,11 @@ class BaseGrouper(object):
     axis : the axis to group
     groupings : all the grouping instances to handle in this grouper
         for example for grouper list to groupby, need to pass the list
-    sort : True/False
+    sort : boolean, default True
         whether this grouper will give sorted result or not
-    indexer: the indexer created by Grouper
+    group_keys : boolean, default True
+    mutated : boolean, default False
+    indexer : the indexer created by Grouper
         some grouper (TimeGrouper eg) will sort its axis and its
         group_info is also sorted, so need the indexer to reorder
 
@@ -2296,18 +2298,15 @@ def generate_bins_generic(values, binner, closed):
 class BinGrouper(BaseGrouper):
 
     """
-    This is an internal Grouper class, which actually holds
-    the generated groups. In contrast with BaseGrouper,
-    BinGrouper get the sorted bins and binlabels to compute group_info
+    This is an internal Grouper class
 
     Parameters
     ----------
     bins : the split index of binlabels to group the item of axis
     binlabels : the label list
-    indexer: the indexer created by Grouper
-        some grouper (TimeGrouper eg) will sort its axis and the
-        group_info of BinGrouper is also sorted
-        can use the indexer to reorder as the unsorted axis
+    filter_empty : boolean, default False
+    mutated : boolean, default False
+    indexer : a intp array
 
     Examples
     --------

--- a/pandas/core/groupby.py
+++ b/pandas/core/groupby.py
@@ -2283,7 +2283,8 @@ def generate_bins_generic(values, binner, closed):
 
 class BinGrouper(BaseGrouper):
 
-    def __init__(self, bins, binlabels, filter_empty=False, mutated=False, indexer=None):
+    def __init__(self, bins, binlabels, filter_empty=False, mutated=False,
+                 indexer=None):
         self.bins = _ensure_int64(bins)
         self.binlabels = _ensure_index(binlabels)
         self._filter_empty_groups = filter_empty
@@ -2486,7 +2487,6 @@ class Grouping(object):
                     Categorical.from_codes(np.arange(len(c)),
                                            categories=c,
                                            ordered=self.grouper.ordered))
-
 
             # we are done
             if isinstance(self.grouper, Grouping):

--- a/pandas/core/resample.py
+++ b/pandas/core/resample.py
@@ -879,14 +879,7 @@ class PeriodIndexResampler(DatetimeIndexResampler):
 
         if is_subperiod(ax.freq, self.freq):
             # Downsampling
-            if len(new_index) == 0:
-                bins = []
-            else:
-                i8 = memb.asi8
-                rng = np.arange(i8[0], i8[-1] + 1)
-                bins = memb.searchsorted(rng, side='right')
-            grouper = BinGrouper(bins, new_index, indexer=self.groupby.indexer)
-            return self._groupby_and_aggregate(how, grouper=grouper)
+            return self._groupby_and_aggregate(how, grouper=self.grouper)
         elif is_superperiod(ax.freq, self.freq):
             if how == 'ohlc':
                 # GH #13083
@@ -1112,7 +1105,7 @@ class TimeGrouper(Grouper):
                         "TimedeltaIndex or PeriodIndex, "
                         "but got an instance of %r" % type(ax).__name__)
 
-    def _get_grouper(self, obj):
+    def _get_grouper(self, obj, validate=True):
         # create the resampler and return our binner
         r = self._get_resampler(obj)
         r._set_binner()

--- a/pandas/core/resample.py
+++ b/pandas/core/resample.py
@@ -1111,29 +1111,6 @@ class TimeGrouper(Grouper):
         r._set_binner()
         return r.binner, r.grouper, r.obj
 
-    def _get_binner_for_grouping(self, obj):
-        # return an ordering of the transformed group labels,
-        # suitable for multi-grouping, e.g the labels for
-        # the resampled intervals
-        binner, grouper, obj = self._get_grouper(obj)
-
-        l = []
-        for key, group in grouper.get_iterator(self.ax):
-            l.extend([key] * len(group))
-
-        if isinstance(self.ax, PeriodIndex):
-            grouper = binner.__class__(l, freq=binner.freq, name=binner.name)
-        else:
-            # resampling causes duplicated values, specifying freq is invalid
-            grouper = binner.__class__(l, name=binner.name)
-
-        # since we may have had to sort
-        # may need to reorder groups here
-        if self.indexer is not None:
-            indexer = self.indexer.argsort(kind='quicksort')
-            grouper = grouper.take(indexer)
-        return grouper
-
     def _get_time_bins(self, ax):
         if not isinstance(ax, DatetimeIndex):
             raise TypeError('axis must be a DatetimeIndex, but got '

--- a/pandas/tests/groupby/test_timegrouper.py
+++ b/pandas/tests/groupby/test_timegrouper.py
@@ -634,9 +634,11 @@ class TestGroupBy(object):
             'value': [1, 2, 3]
         }
         data_frame = pd.DataFrame(data_frame).set_index('time')
-        grouper = pd.TimeGrouper('D')
+        grouper = pd.Grouper(freq='D')
+
         grouped = data_frame.groupby(grouper)
-        data1 = grouped.count()
+        result = grouped.count()
         grouped = data_frame.groupby([grouper])
-        data2 = grouped.count()
-        assert_frame_equal(data1, data2)
+        expected = grouped.count()
+
+        assert_frame_equal(result, expected)

--- a/pandas/tests/groupby/test_timegrouper.py
+++ b/pandas/tests/groupby/test_timegrouper.py
@@ -623,3 +623,20 @@ class TestGroupBy(object):
         result = test.groupby(grouper)['data'].nunique()
         expected = test[test.time.notnull()].groupby(grouper)['data'].nunique()
         tm.assert_series_equal(result, expected)
+
+    def test_scalar_call_versus_list_call(self):
+        # Issue: 17530
+        data_frame = {
+            'location': ['shanghai', 'beijing', 'shanghai'],
+            'time': pd.Series(['2017-08-09 13:32:23', '2017-08-11 23:23:15',
+                               '2017-08-11 22:23:15'],
+                              dtype='datetime64[ns]'),
+            'value': [1, 2, 3]
+        }
+        data_frame = pd.DataFrame(data_frame).set_index('time')
+        grouper = pd.TimeGrouper('D')
+        grouped = data_frame.groupby(grouper)
+        data1 = grouped.count()
+        grouped = data_frame.groupby([grouper])
+        data2 = grouped.count()
+        assert_frame_equal(data1, data2)

--- a/pandas/tests/test_resample.py
+++ b/pandas/tests/test_resample.py
@@ -3381,13 +3381,16 @@ class TestTimeGrouper(object):
             # if NaT is included, 'var', 'std', 'mean', 'first','last'
             # and 'nth' doesn't work yet
 
+    # Issue: 17530
     def test_scalar_call_versus_list_call(self):
-        data_frame = pd.DataFrame({
-                                      'location': ['shanghai', 'beijing', 'shanghai'],
-                                      'time': pd.Series(['2017-08-09 13:32:23', '2017-08-11 23:23:15', '2017-08-11 22:23:15'],
-                                                  dtype='datetime64[ns]'),
-                                      'value': [1, 2, 3]
-        }).set_index('time')
+        data_frame = {
+            'location': ['shanghai', 'beijing', 'shanghai'],
+            'time': pd.Series(['2017-08-09 13:32:23', '2017-08-11 23:23:15',
+                               '2017-08-11 22:23:15'],
+                              dtype='datetime64[ns]'),
+            'value': [1, 2, 3]
+        }
+        data_frame = pd.DataFrame(data_frame).set_index('time')
         grouper = TimeGrouper('D')
         grouped = data_frame.groupby(grouper)
         data1 = grouped.count()

--- a/pandas/tests/test_resample.py
+++ b/pandas/tests/test_resample.py
@@ -3380,20 +3380,3 @@ class TestTimeGrouper(object):
 
             # if NaT is included, 'var', 'std', 'mean', 'first','last'
             # and 'nth' doesn't work yet
-
-    # Issue: 17530
-    def test_scalar_call_versus_list_call(self):
-        data_frame = {
-            'location': ['shanghai', 'beijing', 'shanghai'],
-            'time': pd.Series(['2017-08-09 13:32:23', '2017-08-11 23:23:15',
-                               '2017-08-11 22:23:15'],
-                              dtype='datetime64[ns]'),
-            'value': [1, 2, 3]
-        }
-        data_frame = pd.DataFrame(data_frame).set_index('time')
-        grouper = TimeGrouper('D')
-        grouped = data_frame.groupby(grouper)
-        data1 = grouped.count()
-        grouped = data_frame.groupby([grouper])
-        data2 = grouped.count()
-        assert_frame_equal(data1, data2)

--- a/pandas/tests/test_resample.py
+++ b/pandas/tests/test_resample.py
@@ -3380,3 +3380,17 @@ class TestTimeGrouper(object):
 
             # if NaT is included, 'var', 'std', 'mean', 'first','last'
             # and 'nth' doesn't work yet
+
+    def test_scalar_call_versus_list_call(self):
+        data_frame = pd.DataFrame({
+                                      'location': ['shanghai', 'beijing', 'shanghai'],
+                                      'time': pd.Series(['2017-08-09 13:32:23', '2017-08-11 23:23:15', '2017-08-11 22:23:15'],
+                                                  dtype='datetime64[ns]'),
+                                      'value': [1, 2, 3]
+        }).set_index('time')
+        grouper = TimeGrouper('D')
+        grouped = data_frame.groupby(grouper)
+        data1 = grouped.count()
+        grouped = data_frame.groupby([grouper])
+        data2 = grouped.count()
+        assert_frame_equal(data1, data2)


### PR DESCRIPTION
- [x] closes #17530
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry 
* save the axis indexer for Base/BinGrouper. As BinGrouper has get the sorted labels, need to use indexer to reorder them into right place for unsorted axis values
* add label_info property to get unsorted labels
* enable Grouping to use Base/BinGrouper instance generated by _get_grouper. Get label_info and group_info to get right labels and label indexes from Base/BinGrouper instance
* add test for #17530
* add comment