### PR TITLE
Simplify to_pydatetime()

### DIFF
--- a/asv_bench/benchmarks/timestamp.py
+++ b/asv_bench/benchmarks/timestamp.py
@@ -87,4 +87,3 @@ class TimestampOps(object):
 
     def time_to_pydatetime_tz(self):
         self.ts_tz.to_pydatetime()
-

--- a/asv_bench/benchmarks/timestamp.py
+++ b/asv_bench/benchmarks/timestamp.py
@@ -58,3 +58,15 @@ class TimestampProperties(object):
 
     def time_microsecond(self):
         self.ts.microsecond
+
+
+class TimestampMethods(object):
+    def setup(self):
+        self.ts = Timestamp('2017-08-25 08:16:14')
+        self.ts_tz = Timestamp('2017-08-25 08:16:14', tz='Europe/Brussels')
+
+    def time_to_pydatetime(self):
+        self.ts.to_pydatetime()
+
+    def time_to_pydatetime_tz(self):
+        self.ts_tz.to_pydatetime()

--- a/pandas/_libs/tslib.pyx
+++ b/pandas/_libs/tslib.pyx
@@ -1157,18 +1157,13 @@ cdef class _Timestamp(datetime):
 
         If warn=True, issue a warning if nanoseconds is nonzero.
         """
-        cdef:
-            pandas_datetimestruct dts
-            _TSObject ts
-
         if self.nanosecond != 0 and warn:
             warnings.warn("Discarding nonzero nanoseconds in conversion",
                           UserWarning, stacklevel=2)
-        ts = convert_to_tsobject(self, self.tzinfo, None, 0, 0)
-        dts = ts.dts
-        return datetime(dts.year, dts.month, dts.day,
-                        dts.hour, dts.min, dts.sec,
-                        dts.us, ts.tzinfo)
+
+        return datetime(self.year, self.month, self.day,
+                         self.hour, self.minute, self.second,
+                         self.microsecond, self.tzinfo)
 
     cpdef to_datetime64(self):
         """ Returns a numpy.datetime64 object with 'ns' precision """

--- a/pandas/_libs/tslib.pyx
+++ b/pandas/_libs/tslib.pyx
@@ -1162,8 +1162,8 @@ cdef class _Timestamp(datetime):
                           UserWarning, stacklevel=2)
 
         return datetime(self.year, self.month, self.day,
-                         self.hour, self.minute, self.second,
-                         self.microsecond, self.tzinfo)
+                        self.hour, self.minute, self.second,
+                        self.microsecond, self.tzinfo)
 
     cpdef to_datetime64(self):
         """ Returns a numpy.datetime64 object with 'ns' precision """


### PR DESCRIPTION
Up until #17331, `Timestamp.microsecond` was very slow.  So previously it was faster to go through `convert_to_tsobject` to get a new `datetime` instance than it was to just return 
 `datetime(self.year, self.month, self.day, self.hour, self.minute, self.second, self.microsecond, self.tzinfo)`

Now it is slightly faster (and much simpler) to do it this way.

Before:

```
In [2]: ts = pd.Timestamp.now()
In [3]: %timeit ts.to_pydatetime()
The slowest run took 13.88 times longer than the fastest. This could mean that an intermediate result is being cached.
1000000 loops, best of 3: 1.44 µs per loop
```

After:
```
In [2]: ts = pd.Timestamp.now()
In [3]: %timeit ts.to_pydatetime()
The slowest run took 8.51 times longer than the fastest. This could mean that an intermediate result is being cached.
1000000 loops, best of 3: 1.29 µs per loop
```

With a tz-aware Timestamp the speedup is much bigger:

Before:
```
In [4]: import pytz
In [5]: ts2 = ts.replace(tzinfo=pytz.timezone('US/Pacific'))
In [6]: %timeit ts2.to_pydatetime()
The slowest run took 39.71 times longer than the fastest. This could mean that an intermediate result is being cached.
10000 loops, best of 3: 68.9 µs per loop
```

After:
```
In [7]: import pytz
In [8]: ts2 = ts.replace(tzinfo=pytz.timezone('US/Pacific'))
In [9]: %timeit ts2.to_pydatetime()
The slowest run took 8.29 times longer than the fastest. This could mean that an intermediate result is being cached.
1000000 loops, best of 3: 1.47 µs per loop
```
