### PR TITLE
BUG: Correctly localize naive datetime strings with Series and datetimetztype (#17415)

### DIFF
--- a/doc/source/whatsnew/v0.23.0.txt
+++ b/doc/source/whatsnew/v0.23.0.txt
@@ -380,7 +380,7 @@ Conversion
 - Fixed bug where comparing :class:`DatetimeIndex` failed to raise ``TypeError`` when attempting to compare timezone-aware and timezone-naive datetimelike objects (:issue:`18162`)
 - Bug in :class:`DatetimeIndex` where the repr was not showing high-precision time values at the end of a day (e.g., 23:59:59.999999999) (:issue:`19030`)
 - Bug where dividing a scalar timedelta-like object with :class:`TimedeltaIndex` performed the reciprocal operation (:issue:`19125`)
--
+- Bug in localization of a naive, datetime string in a ``Series`` constructor with a ``datetime[ns, timezone]`` dtype (:issue:`174151`)
 
 Indexing
 ^^^^^^^^

--- a/doc/source/whatsnew/v0.23.0.txt
+++ b/doc/source/whatsnew/v0.23.0.txt
@@ -380,7 +380,7 @@ Conversion
 - Fixed bug where comparing :class:`DatetimeIndex` failed to raise ``TypeError`` when attempting to compare timezone-aware and timezone-naive datetimelike objects (:issue:`18162`)
 - Bug in :class:`DatetimeIndex` where the repr was not showing high-precision time values at the end of a day (e.g., 23:59:59.999999999) (:issue:`19030`)
 - Bug where dividing a scalar timedelta-like object with :class:`TimedeltaIndex` performed the reciprocal operation (:issue:`19125`)
-- Bug in localization of a naive, datetime string in a ``Series`` constructor with a ``datetime[ns, timezone]`` dtype (:issue:`174151`)
+- Bug in localization of a naive, datetime string in a ``Series`` constructor with a ``datetime64[ns, tz]`` dtype (:issue:`174151`)
 
 Indexing
 ^^^^^^^^

--- a/pandas/core/dtypes/cast.py
+++ b/pandas/core/dtypes/cast.py
@@ -1003,7 +1003,7 @@ def maybe_cast_to_datetime(value, dtype, errors='raise'):
                         if is_datetime64:
                             value = to_datetime(value, errors=errors)._values
                         elif is_datetime64tz:
-                            # This block can be simplified once PR #17413 is 
+                            # This block can be simplified once PR #17413 is
                             # complete
                             is_dt_string = is_string_dtype(value)
                             value = to_datetime(value, errors=errors)

--- a/pandas/core/dtypes/cast.py
+++ b/pandas/core/dtypes/cast.py
@@ -20,7 +20,7 @@ from .common import (_ensure_object, is_bool, is_integer, is_float,
                      is_integer_dtype,
                      is_datetime_or_timedelta_dtype,
                      is_bool_dtype, is_scalar,
-                     _string_dtypes,
+                     is_string_dtype, _string_dtypes,
                      pandas_dtype,
                      _ensure_int8, _ensure_int16,
                      _ensure_int32, _ensure_int64,
@@ -1003,12 +1003,18 @@ def maybe_cast_to_datetime(value, dtype, errors='raise'):
                         if is_datetime64:
                             value = to_datetime(value, errors=errors)._values
                         elif is_datetime64tz:
-                            # input has to be UTC at this point, so just
-                            # localize
-                            value = (to_datetime(value, errors=errors)
-                                     .tz_localize('UTC')
-                                     .tz_convert(dtype.tz)
-                                     )
+                            # This block can be simplified once PR #17413 is 
+                            # complete
+                            is_dt_string = is_string_dtype(value)
+                            value = to_datetime(value, errors=errors)
+                            if is_dt_string:
+                                # Strings here are naive, so directly localize
+                                value = value.tz_localize(dtype.tz)
+                            else:
+                                # Numeric values are UTC at this point,
+                                # so localize and convert
+                                value = (value.tz_localize('UTC')
+                                         .tz_convert(dtype.tz))
                         elif is_timedelta64:
                             value = to_timedelta(value, errors=errors)._values
                     except (AttributeError, ValueError, TypeError):

--- a/pandas/core/dtypes/cast.py
+++ b/pandas/core/dtypes/cast.py
@@ -1003,8 +1003,10 @@ def maybe_cast_to_datetime(value, dtype, errors='raise'):
                         if is_datetime64:
                             value = to_datetime(value, errors=errors)._values
                         elif is_datetime64tz:
-                            # This block can be simplified once PR #17413 is
-                            # complete
+                            # The string check can be removed once issue #13712
+                            # is solved. String data that is passed with a
+                            # datetime64tz is assumed to be naive which should
+                            # be localized to the timezone.
                             is_dt_string = is_string_dtype(value)
                             value = to_datetime(value, errors=errors)
                             if is_dt_string:

--- a/pandas/tests/series/test_constructors.py
+++ b/pandas/tests/series/test_constructors.py
@@ -707,6 +707,14 @@ class TestSeriesConstructors(TestData):
         expected = Series(pd.DatetimeIndex(['NaT', 'NaT'], tz='US/Eastern'))
         assert_series_equal(s, expected)
 
+    @pytest.mark.parametrize('arg, dtype',
+                             ['2013-01-01 00:00:00', pd.NaT, np.nan, None])
+    def test_constructor_with_naive_string_and_datetimetz_dtype(self, arg):
+        # GH 17415: With naive string
+        result = Series([arg], dtype='datetime64[ns, CET]')
+        expected = Series([pd.Timestamp(arg, tz='CET')])
+        assert_series_equal(result, expected)
+
     def test_construction_interval(self):
         # construction from interval & array of intervals
         index = IntervalIndex.from_breaks(np.arange(3), closed='right')

--- a/pandas/tests/series/test_constructors.py
+++ b/pandas/tests/series/test_constructors.py
@@ -709,7 +709,8 @@ class TestSeriesConstructors(TestData):
 
     @pytest.mark.parametrize('arg, dtype',
                              ['2013-01-01 00:00:00', pd.NaT, np.nan, None])
-    def test_constructor_with_naive_string_and_datetimetz_dtype(self, arg):
+    def test_constructor_with_naive_string_and_datetimetz_dtype(self, arg,
+                                                                dtype):
         # GH 17415: With naive string
         result = Series([arg], dtype='datetime64[ns, CET]')
         expected = Series([pd.Timestamp(arg, tz='CET')])

--- a/pandas/tests/series/test_constructors.py
+++ b/pandas/tests/series/test_constructors.py
@@ -712,7 +712,7 @@ class TestSeriesConstructors(TestData):
     def test_constructor_with_naive_string_and_datetimetz_dtype(self, arg):
         # GH 17415: With naive string
         result = Series([arg], dtype='datetime64[ns, CET]')
-        expected = Series([pd.Timestamp(arg, tz='CET')])
+        expected = Series(pd.Timestamp(arg)).dt.tz_localize('CET')
         assert_series_equal(result, expected)
 
     def test_construction_interval(self):

--- a/pandas/tests/series/test_constructors.py
+++ b/pandas/tests/series/test_constructors.py
@@ -707,10 +707,9 @@ class TestSeriesConstructors(TestData):
         expected = Series(pd.DatetimeIndex(['NaT', 'NaT'], tz='US/Eastern'))
         assert_series_equal(s, expected)
 
-    @pytest.mark.parametrize('arg, dtype',
+    @pytest.mark.parametrize('arg',
                              ['2013-01-01 00:00:00', pd.NaT, np.nan, None])
-    def test_constructor_with_naive_string_and_datetimetz_dtype(self, arg,
-                                                                dtype):
+    def test_constructor_with_naive_string_and_datetimetz_dtype(self, arg):
         # GH 17415: With naive string
         result = Series([arg], dtype='datetime64[ns, CET]')
         expected = Series([pd.Timestamp(arg, tz='CET')])


### PR DESCRIPTION
- [x] closes #17415
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry
