### PR TITLE
PERF: Implement RangeIndex min/max using RangeIndex properties

### DIFF
--- a/asv_bench/benchmarks/index_object.py
+++ b/asv_bench/benchmarks/index_object.py
@@ -199,3 +199,23 @@ class Multi3(object):
 
     def time_datetime_level_values_sliced(self):
         self.mi[:10].values
+
+
+class Range(object):
+    goal_time = 0.2
+
+    def setup(self):
+        self.idx_inc = RangeIndex(start=0, stop=10**7, step=3)
+        self.idx_dec = RangeIndex(start=10**7, stop=-1, step=-3)
+
+    def time_max(self):
+        self.idx_inc.max()
+
+    def time_max_trivial(self):
+        self.idx_dec.max()
+
+    def time_min(self):
+        self.idx_dec.min()
+
+    def time_min_trivial(self):
+        self.idx_inc.min()

--- a/doc/source/api.rst
+++ b/doc/source/api.rst
@@ -1416,6 +1416,50 @@ Selecting
    Index.slice_indexer
    Index.slice_locs
 
+.. _api.int64index:
+
+Int64Index
+----------
+
+.. autosummary::
+   :toctree: generated/
+   :template: autosummary/class_without_autosummary.rst
+
+   Int64Index
+
+.. _api.uint64index:
+
+UInt64Index
+-----------
+
+.. autosummary::
+   :toctree: generated/
+   :template: autosummary/class_without_autosummary.rst
+
+   UInt64Index
+
+.. _api.float64index:
+
+Float64Index
+------------
+
+.. autosummary::
+   :toctree: generated/
+   :template: autosummary/class_without_autosummary.rst
+
+   Float64Index
+
+.. _api.rangeindex:
+
+RangeIndex
+----------
+
+.. autosummary::
+   :toctree: generated/
+   :template: autosummary/class_without_autosummary.rst
+
+   RangeIndex
+
 .. _api.categoricalindex:
 
 CategoricalIndex

--- a/doc/source/api.rst
+++ b/doc/source/api.rst
@@ -1416,49 +1416,19 @@ Selecting
    Index.slice_indexer
    Index.slice_locs
 
-.. _api.int64index:
+.. _api.numericindex:
 
-Int64Index
-----------
-
-.. autosummary::
-   :toctree: generated/
-   :template: autosummary/class_without_autosummary.rst
-
-   Int64Index
-
-.. _api.uint64index:
-
-UInt64Index
------------
-
-.. autosummary::
-   :toctree: generated/
-   :template: autosummary/class_without_autosummary.rst
-
-   UInt64Index
-
-.. _api.float64index:
-
-Float64Index
-------------
-
-.. autosummary::
-   :toctree: generated/
-   :template: autosummary/class_without_autosummary.rst
-
-   Float64Index
-
-.. _api.rangeindex:
-
-RangeIndex
-----------
+Numeric Index
+-------------
 
 .. autosummary::
    :toctree: generated/
    :template: autosummary/class_without_autosummary.rst
 
    RangeIndex
+   Int64Index
+   UInt64Index
+   Float64Index
 
 .. _api.categoricalindex:
 

--- a/doc/source/whatsnew/v0.21.0.txt
+++ b/doc/source/whatsnew/v0.21.0.txt
@@ -473,6 +473,7 @@ Performance Improvements
 - Improved performance of :meth:`Categorical.set_categories` by not materializing the values (:issue:`17508`)
 - :attr:`Timestamp.microsecond` no longer re-computes on attribute access (:issue:`17331`)
 - Improved performance of the :class:`CategoricalIndex` for data that is already categorical dtype (:issue:`17513`)
+- Improved performance of ``RangeIndex.min`` and ``RangeIndex.max`` by using ``RangeIndex`` properties to perform the computations (:issue:`17607`)
 
 .. _whatsnew_0210.bug_fixes:
 

--- a/doc/source/whatsnew/v0.21.0.txt
+++ b/doc/source/whatsnew/v0.21.0.txt
@@ -473,7 +473,7 @@ Performance Improvements
 - Improved performance of :meth:`Categorical.set_categories` by not materializing the values (:issue:`17508`)
 - :attr:`Timestamp.microsecond` no longer re-computes on attribute access (:issue:`17331`)
 - Improved performance of the :class:`CategoricalIndex` for data that is already categorical dtype (:issue:`17513`)
-- Improved performance of ``RangeIndex.min`` and ``RangeIndex.max`` by using ``RangeIndex`` properties to perform the computations (:issue:`17607`)
+- Improved performance of :meth:`RangeIndex.min` and :meth:`RangeIndex.max` by using ``RangeIndex`` properties to perform the computations (:issue:`17607`)
 
 .. _whatsnew_0210.bug_fixes:
 

--- a/pandas/core/indexes/range.py
+++ b/pandas/core/indexes/range.py
@@ -269,6 +269,24 @@ class RangeIndex(Int64Index):
         return RangeIndex(name=name, fastpath=True,
                           **dict(self._get_data_as_items()))
 
+    def _minmax(self, meth):
+        no_steps = len(self) - 1
+        if no_steps == -1:
+            return np.nan
+        elif ((meth == 'min' and self._step > 0) or
+              (meth == 'max' and self._step < 0)):
+            return self._start
+
+        return self._start + self._step * no_steps
+
+    def min(self):
+        """The minimum value of the RangeIndex"""
+        return self._minmax('min')
+
+    def max(self):
+        """The maximum value of the RangeIndex"""
+        return self._minmax('max')
+
     def argsort(self, *args, **kwargs):
         """
         Returns the indices that would sort the index and its

--- a/pandas/tests/indexes/test_range.py
+++ b/pandas/tests/indexes/test_range.py
@@ -995,21 +995,21 @@ class TestRangeIndex(Numeric):
                 result2 = indices[0].append(indices[1])
                 tm.assert_index_equal(result2, expected, exact=True)
 
-    def test_max_min(self):
-        params = [(0, 400, 3), (500, 0, -6), (-10**6, 10**6, 4),
-                  (10**6, -10**6, -4), (0, 10, 20)]
-        for start, stop, step in params:
-            idx = RangeIndex(start, stop, step)
+    @pytest.mark.parametrize('start,stop,step',
+                             [(0, 400, 3), (500, 0, -6), (-10**6, 10**6, 4),
+                              (10**6, -10**6, -4), (0, 10, 20)])
+    def test_max_min(self, start, stop, step):
+        # GH17607
+        idx = RangeIndex(start, stop, step)
+        expected = idx._int64index.max()
+        result = idx.max()
+        assert result == expected
 
-            expected = idx._int64index.max()
-            result = idx.max()
-            assert result == expected
-
-            expected = idx._int64index.min()
-            result = idx.min()
-            assert result == expected
+        expected = idx._int64index.min()
+        result = idx.min()
+        assert result == expected
 
         # empty
-        idx = RangeIndex(0, 1, -1)
+        idx = RangeIndex(start, stop, -step)
         assert isna(idx.max())
         assert isna(idx.min())

--- a/pandas/tests/indexes/test_range.py
+++ b/pandas/tests/indexes/test_range.py
@@ -10,7 +10,7 @@ from pandas.compat import range, u, PY3
 
 import numpy as np
 
-from pandas import (notna, Series, Index, Float64Index,
+from pandas import (isna, notna, Series, Index, Float64Index,
                     Int64Index, RangeIndex)
 
 import pandas.util.testing as tm
@@ -994,3 +994,22 @@ class TestRangeIndex(Numeric):
                 # Append single item rather than list
                 result2 = indices[0].append(indices[1])
                 tm.assert_index_equal(result2, expected, exact=True)
+
+    def test_max_min(self):
+        params = [(0, 400, 3), (500, 0, -6), (-10**6, 10**6, 4),
+                  (10**6, -10**6, -4), (0, 10, 20)]
+        for start, stop, step in params:
+            idx = RangeIndex(start, stop, step)
+
+            expected = idx._int64index.max()
+            result = idx.max()
+            assert result == expected
+
+            expected = idx._int64index.min()
+            result = idx.min()
+            assert result == expected
+
+        # empty
+        idx = RangeIndex(0, 1, -1)
+        assert isna(idx.max())
+        assert isna(idx.min())


### PR DESCRIPTION
- [X] closes #17607
- [X] tests added / passed
- [X] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [X] whatsnew entry

Benchmarks are essentially the same as what's referenced in the issue.  Maybe a few ns slower since I combined logic into a helper function vs having identical code (other than `elif`) for both min/max, which was the case I did the benchmarks posted in the issue.  Updated benchmarks:

```
      before           after         ratio
     [fedf9228]       [4cb0de8d]
-        25.4±0ms      1.77±0.06μs     0.00  index_object.Range.time_min
-      26.0±0.9ms      1.71±0.06μs     0.00  index_object.Range.time_max
-        25.4±0ms         1.51±0μs     0.00  index_object.Range.time_max_trivial
-        25.4±0ms         1.30±0μs     0.00  index_object.Range.time_min_trivial

SOME BENCHMARKS HAVE CHANGED SIGNIFICANTLY.
```