### PR TITLE
TST: Use fixtures in indexes common tests

### DIFF
--- a/pandas/conftest.py
+++ b/pandas/conftest.py
@@ -3,8 +3,6 @@ import pytest
 import numpy
 import pandas
 import pandas.util.testing as tm
-from pandas.core.indexes.api import Index, MultiIndex
-from pandas.compat import lzip
 
 
 def pytest_addoption(parser):
@@ -68,21 +66,3 @@ def ip():
     from IPython.core.interactiveshell import InteractiveShell
     return InteractiveShell()
 
-
-@pytest.fixture(params=[tm.makeUnicodeIndex(100),
-                        tm.makeStringIndex(100),
-                        tm.makeDateIndex(100),
-                        tm.makePeriodIndex(100),
-                        tm.makeTimedeltaIndex(100),
-                        tm.makeIntIndex(100),
-                        tm.makeUIntIndex(100),
-                        tm.makeFloatIndex(100),
-                        Index([True, False]),
-                        tm.makeCategoricalIndex(100),
-                        Index([]),
-                        MultiIndex.from_tuples(lzip(
-                            ['foo', 'bar', 'baz'], [1, 2, 3])),
-                        Index([0, 0, 1, 1, 2, 2])],
-                ids=lambda x: type(x).__name__)
-def indices(request):
-    return request.param

--- a/pandas/conftest.py
+++ b/pandas/conftest.py
@@ -65,4 +65,3 @@ def ip():
     pytest.importorskip('IPython', minversion="6.0.0")
     from IPython.core.interactiveshell import InteractiveShell
     return InteractiveShell()
-

--- a/pandas/conftest.py
+++ b/pandas/conftest.py
@@ -83,6 +83,6 @@ def ip():
                         MultiIndex.from_tuples(lzip(
                             ['foo', 'bar', 'baz'], [1, 2, 3])),
                         Index([0, 0, 1, 1, 2, 2])],
-                ids=lambda(x): type(x).__name__)
+                ids=lambda x: type(x).__name__)
 def indices(request):
     return request.param

--- a/pandas/conftest.py
+++ b/pandas/conftest.py
@@ -3,6 +3,8 @@ import pytest
 import numpy
 import pandas
 import pandas.util.testing as tm
+from pandas.core.indexes.api import Index, MultiIndex
+from pandas.compat import lzip
 
 
 def pytest_addoption(parser):
@@ -65,3 +67,22 @@ def ip():
     pytest.importorskip('IPython', minversion="6.0.0")
     from IPython.core.interactiveshell import InteractiveShell
     return InteractiveShell()
+
+
+@pytest.fixture(params=[tm.makeUnicodeIndex(100),
+                        tm.makeStringIndex(100),
+                        tm.makeDateIndex(100),
+                        tm.makePeriodIndex(100),
+                        tm.makeTimedeltaIndex(100),
+                        tm.makeIntIndex(100),
+                        tm.makeUIntIndex(100),
+                        tm.makeFloatIndex(100),
+                        Index([True, False]),
+                        tm.makeCategoricalIndex(100),
+                        Index([]),
+                        MultiIndex.from_tuples(lzip(
+                            ['foo', 'bar', 'baz'], [1, 2, 3])),
+                        Index([0, 0, 1, 1, 2, 2])],
+                ids=lambda(x): type(x).__name__)
+def indices(request):
+    return request.param

--- a/pandas/tests/indexes/common.py
+++ b/pandas/tests/indexes/common.py
@@ -306,9 +306,9 @@ class Base(object):
         assert new_copy.name == "banana"
 
     def test_duplicates(self, indices):
-        if not len(indices):
+        if type(indices) is not self._holder:
             return
-        if isinstance(indices, MultiIndex):
+        if not len(indices) or isinstance(indices, MultiIndex):
             return
         idx = self._holder([indices[0]] * 5)
         assert not idx.is_unique

--- a/pandas/tests/indexes/common.py
+++ b/pandas/tests/indexes/common.py
@@ -97,7 +97,7 @@ class Base(object):
                                lambda: 1 * idx)
 
         div_err = "cannot perform __truediv__" if PY3 \
-                  else "cannot perform __div__"
+            else "cannot perform __div__"
         tm.assert_raises_regex(TypeError, div_err, lambda: idx / 1)
         tm.assert_raises_regex(TypeError, div_err, lambda: 1 / idx)
         tm.assert_raises_regex(TypeError, "cannot perform __floordiv__",
@@ -178,11 +178,10 @@ class Base(object):
         assert "'foo'" in str(idx)
         assert idx.__class__.__name__ in str(idx)
 
-    def test_dtype_str(self):
-        for idx in self.indices.values():
-            dtype = idx.dtype_str
-            assert isinstance(dtype, compat.string_types)
-            assert dtype == str(idx.dtype)
+    def test_dtype_str(self, index):
+        dtype = index.dtype_str
+        assert isinstance(dtype, compat.string_types)
+        assert dtype == str(index.dtype)
 
     def test_repr_max_seq_item_setting(self):
         # GH10182
@@ -192,48 +191,42 @@ class Base(object):
             repr(idx)
             assert '...' not in str(idx)
 
-    def test_wrong_number_names(self):
+    def test_wrong_number_names(self, index):
         def testit(ind):
             ind.names = ["apple", "banana", "carrot"]
+        tm.assert_raises_regex(ValueError, "^Length", testit, index)
 
-        for ind in self.indices.values():
-            tm.assert_raises_regex(ValueError, "^Length", testit, ind)
-
-    def test_set_name_methods(self):
+    def test_set_name_methods(self, index):
         new_name = "This is the new name for this index"
-        for ind in self.indices.values():
 
-            # don't tests a MultiIndex here (as its tested separated)
-            if isinstance(ind, MultiIndex):
-                continue
+        # don't tests a MultiIndex here (as its tested separated)
+        if isinstance(index, MultiIndex):
+            return
+        original_name = index.name
+        new_ind = index.set_names([new_name])
+        assert new_ind.name == new_name
+        assert index.name == original_name
+        res = index.rename(new_name, inplace=True)
 
-            original_name = ind.name
-            new_ind = ind.set_names([new_name])
-            assert new_ind.name == new_name
-            assert ind.name == original_name
-            res = ind.rename(new_name, inplace=True)
+        # should return None
+        assert res is None
+        assert index.name == new_name
+        assert index.names == [new_name]
+        # with tm.assert_raises_regex(TypeError, "list-like"):
+        #    # should still fail even if it would be the right length
+        #    ind.set_names("a")
+        with tm.assert_raises_regex(ValueError, "Level must be None"):
+            index.set_names("a", level=0)
 
-            # should return None
-            assert res is None
-            assert ind.name == new_name
-            assert ind.names == [new_name]
-            # with tm.assert_raises_regex(TypeError, "list-like"):
-            #    # should still fail even if it would be the right length
-            #    ind.set_names("a")
-            with tm.assert_raises_regex(ValueError, "Level must be None"):
-                ind.set_names("a", level=0)
+        # rename in place just leaves tuples and other containers alone
+        name = ('A', 'B')
+        index.rename(name, inplace=True)
+        assert index.name == name
+        assert index.names == [name]
 
-            # rename in place just leaves tuples and other containers alone
-            name = ('A', 'B')
-            ind.rename(name, inplace=True)
-            assert ind.name == name
-            assert ind.names == [name]
-
-    def test_hash_error(self):
-        for ind in self.indices.values():
-            with tm.assert_raises_regex(TypeError, "unhashable type: %r" %
-                                        type(ind).__name__):
-                hash(ind)
+    def test_hash_error(self, index):
+        tm.assert_raises_regex(TypeError, "unhashable type: %r" %
+                               type(index).__name__, hash, index)
 
     def test_copy_name(self):
         # gh-12309: Check that the "name" argument
@@ -298,106 +291,87 @@ class Base(object):
                 tm.assert_numpy_array_equal(index._values, result._values,
                                             check_same='same')
 
-    def test_copy_and_deepcopy(self):
+    def test_copy_and_deepcopy(self, index):
         from copy import copy, deepcopy
 
-        for ind in self.indices.values():
+        if isinstance(index, MultiIndex):
+            return
+        for func in (copy, deepcopy):
+            idx_copy = func(index)
+            assert idx_copy is not index
+            assert idx_copy.equals(index)
 
-            # don't tests a MultiIndex here (as its tested separated)
-            if isinstance(ind, MultiIndex):
-                continue
+        new_copy = index.copy(deep=True, name="banana")
+        assert new_copy.name == "banana"
 
-            for func in (copy, deepcopy):
-                idx_copy = func(ind)
-                assert idx_copy is not ind
-                assert idx_copy.equals(ind)
+    def test_duplicates(self, index):
+        if not len(index):
+            return
+        if isinstance(index, MultiIndex):
+            return
+        idx = self._holder([index[0]] * 5)
+        assert not idx.is_unique
+        assert idx.has_duplicates
 
-            new_copy = ind.copy(deep=True, name="banana")
-            assert new_copy.name == "banana"
+    def test_get_unique_index(self, index):
+        # MultiIndex tested separately
+        if not len(index) or isinstance(index, MultiIndex):
+            return
 
-    def test_duplicates(self):
-        for ind in self.indices.values():
+        idx = index[[0] * 5]
+        idx_unique = index[[0]]
 
-            if not len(ind):
-                continue
-            if isinstance(ind, MultiIndex):
-                continue
-            idx = self._holder([ind[0]] * 5)
-            assert not idx.is_unique
-            assert idx.has_duplicates
+        # We test against `idx_unique`, so first we make sure it's unique
+        # and doesn't contain nans.
+        assert idx_unique.is_unique
+        try:
+            assert not idx_unique.hasnans
+        except NotImplementedError:
+            pass
 
-            # GH 10115
-            # preserve names
-            idx.name = 'foo'
-            result = idx.drop_duplicates()
-            assert result.name == 'foo'
-            tm.assert_index_equal(result, Index([ind[0]], name='foo'))
+        for dropna in [False, True]:
+            result = idx._get_unique_index(dropna=dropna)
+            tm.assert_index_equal(result, idx_unique)
 
-    def test_get_unique_index(self):
-        for ind in self.indices.values():
+        # nans:
+        if not index._can_hold_na:
+            return
 
-            # MultiIndex tested separately
-            if not len(ind) or isinstance(ind, MultiIndex):
-                continue
+        if needs_i8_conversion(index):
+            vals = index.asi8[[0] * 5]
+            vals[0] = iNaT
+        else:
+            vals = index.values[[0] * 5]
+            vals[0] = np.nan
 
-            idx = ind[[0] * 5]
-            idx_unique = ind[[0]]
+        vals_unique = vals[:2]
+        idx_nan = index._shallow_copy(vals)
+        idx_unique_nan = index._shallow_copy(vals_unique)
+        assert idx_unique_nan.is_unique
 
-            # We test against `idx_unique`, so first we make sure it's unique
-            # and doesn't contain nans.
-            assert idx_unique.is_unique
-            try:
-                assert not idx_unique.hasnans
-            except NotImplementedError:
-                pass
+        assert idx_nan.dtype == index.dtype
+        assert idx_unique_nan.dtype == index.dtype
 
-            for dropna in [False, True]:
-                result = idx._get_unique_index(dropna=dropna)
-                tm.assert_index_equal(result, idx_unique)
+        for dropna, expected in zip([False, True],
+                                    [idx_unique_nan,
+                                     idx_unique]):
+            for i in [idx_nan, idx_unique_nan]:
+                result = i._get_unique_index(dropna=dropna)
+                tm.assert_index_equal(result, expected)
 
-            # nans:
-            if not ind._can_hold_na:
-                continue
+    def test_sort(self, index):
+        pytest.raises(TypeError, index.sort)
 
-            if needs_i8_conversion(ind):
-                vals = ind.asi8[[0] * 5]
-                vals[0] = iNaT
-            else:
-                vals = ind.values[[0] * 5]
-                vals[0] = np.nan
+    def test_mutability(self, index):
+        if not len(index):
+            return
+        pytest.raises(TypeError, index.__setitem__, 0, index[0])
 
-            vals_unique = vals[:2]
-            idx_nan = ind._shallow_copy(vals)
-            idx_unique_nan = ind._shallow_copy(vals_unique)
-            assert idx_unique_nan.is_unique
+    def test_view(self, index):
+        assert index.view().name == index.name
 
-            assert idx_nan.dtype == ind.dtype
-            assert idx_unique_nan.dtype == ind.dtype
-
-            for dropna, expected in zip([False, True],
-                                        [idx_unique_nan, idx_unique]):
-                for i in [idx_nan, idx_unique_nan]:
-                    result = i._get_unique_index(dropna=dropna)
-                    tm.assert_index_equal(result, expected)
-
-    def test_sort(self):
-        for ind in self.indices.values():
-            pytest.raises(TypeError, ind.sort)
-
-    def test_mutability(self):
-        for ind in self.indices.values():
-            if not len(ind):
-                continue
-            pytest.raises(TypeError, ind.__setitem__, 0, ind[0])
-
-    def test_view(self):
-        for ind in self.indices.values():
-            i_view = ind.view()
-            assert i_view.name == ind.name
-
-    def test_compat(self):
-        for ind in self.indices.values():
-            assert ind.tolist() == list(ind)
+    def test_compat(self, index):
+        assert index.tolist() == list(index)
 
     def test_memory_usage(self):
         for name, index in compat.iteritems(self.indices):
@@ -457,11 +431,11 @@ class Base(object):
                 tm.assert_raises_regex(ValueError, msg, np.argsort,
                                        ind, order=('a', 'b'))
 
-    def test_pickle(self):
-        for ind in self.indices.values():
-            self.verify_pickle(ind)
-            ind.name = 'foo'
-            self.verify_pickle(ind)
+    def test_pickle(self, index):
+        self.verify_pickle(index)
+        original_name, index.name = index.name, 'foo'
+        self.verify_pickle(index)
+        index.name = original_name
 
     def test_take(self):
         indexer = [4, 3, 0, 2]
@@ -962,46 +936,47 @@ class Base(object):
             joined = index.join(index, how=how)
             assert (index == joined).all()
 
-    def test_searchsorted_monotonic(self):
+    def test_searchsorted_monotonic(self, index):
         # GH17271
-        for index in self.indices.values():
-            # not implemented for tuple searches in MultiIndex
-            # or Intervals searches in IntervalIndex
-            if isinstance(index, (MultiIndex, IntervalIndex)):
-                continue
+        # not implemented for tuple searches in MultiIndex
+        # or Intervals searches in IntervalIndex
+        if isinstance(index, (MultiIndex, IntervalIndex)):
+            return
 
-            # nothing to test if the index is empty
-            if index.empty:
-                continue
-            value = index[0]
+        # nothing to test if the index is empty
+        if index.empty:
+            return
+        value = index[0]
 
-            # determine the expected results (handle dupes for 'right')
-            expected_left, expected_right = 0, (index == value).argmin()
-            if expected_right == 0:
-                # all values are the same, expected_right should be length
-                expected_right = len(index)
+        # determine the expected results (handle dupes for 'right')
+        expected_left, expected_right = 0, (index == value).argmin()
+        if expected_right == 0:
+            # all values are the same, expected_right should be length
+            expected_right = len(index)
 
-            # test _searchsorted_monotonic in all cases
-            # test searchsorted only for increasing
-            if index.is_monotonic_increasing:
-                ssm_left = index._searchsorted_monotonic(value, side='left')
-                assert expected_left == ssm_left
+        # test _searchsorted_monotonic in all cases
+        # test searchsorted only for increasing
+        if index.is_monotonic_increasing:
+            ssm_left = index._searchsorted_monotonic(value, side='left')
+            assert expected_left == ssm_left
 
-                ssm_right = index._searchsorted_monotonic(value, side='right')
-                assert expected_right == ssm_right
+            ssm_right = index._searchsorted_monotonic(value, side='right')
+            assert expected_right == ssm_right
 
-                ss_left = index.searchsorted(value, side='left')
-                assert expected_left == ss_left
+            ss_left = index.searchsorted(value, side='left')
+            assert expected_left == ss_left
 
-                ss_right = index.searchsorted(value, side='right')
-                assert expected_right == ss_right
-            elif index.is_monotonic_decreasing:
-                ssm_left = index._searchsorted_monotonic(value, side='left')
-                assert expected_left == ssm_left
+            ss_right = index.searchsorted(value, side='right')
+            assert expected_right == ss_right
 
-                ssm_right = index._searchsorted_monotonic(value, side='right')
-                assert expected_right == ssm_right
-            else:
-                # non-monotonic should raise.
-                with pytest.raises(ValueError):
-                    index._searchsorted_monotonic(value, side='left')
+        elif index.is_monotonic_decreasing:
+            ssm_left = index._searchsorted_monotonic(value, side='left')
+            assert expected_left == ssm_left
+
+            ssm_right = index._searchsorted_monotonic(value, side='right')
+            assert expected_right == ssm_right
+
+        else:
+            # non-monotonic should raise.
+            with pytest.raises(ValueError):
+                index._searchsorted_monotonic(value, side='left')

--- a/pandas/tests/indexes/conftest.py
+++ b/pandas/tests/indexes/conftest.py
@@ -1,0 +1,24 @@
+import pytest
+
+import pandas.util.testing as tm
+from pandas.core.indexes.api import Index, MultiIndex
+from pandas.compat import lzip
+
+
+@pytest.fixture(params=[tm.makeUnicodeIndex(100),
+                        tm.makeStringIndex(100),
+                        tm.makeDateIndex(100),
+                        tm.makePeriodIndex(100),
+                        tm.makeTimedeltaIndex(100),
+                        tm.makeIntIndex(100),
+                        tm.makeUIntIndex(100),
+                        tm.makeFloatIndex(100),
+                        Index([True, False]),
+                        tm.makeCategoricalIndex(100),
+                        Index([]),
+                        MultiIndex.from_tuples(lzip(
+                            ['foo', 'bar', 'baz'], [1, 2, 3])),
+                        Index([0, 0, 1, 1, 2, 2])],
+                ids=lambda x: type(x).__name__)
+def indices(request):
+    return request.param

--- a/pandas/tests/indexes/datetimelike.py
+++ b/pandas/tests/indexes/datetimelike.py
@@ -26,8 +26,8 @@ class DatetimeLike(Base):
         if hasattr(idx, 'freq'):
             assert "freq='%s'" % idx.freqstr in str(idx)
 
-    def test_view(self):
-        super(DatetimeLike, self).test_view()
+    def test_view(self, indices):
+        super(DatetimeLike, self).test_view(indices)
 
         i = self.create_index()
 

--- a/pandas/tests/indexes/test_base.py
+++ b/pandas/tests/indexes/test_base.py
@@ -29,6 +29,24 @@ import pandas as pd
 from pandas._libs.lib import Timestamp
 
 
+@pytest.fixture(params=[tm.makeUnicodeIndex(100),
+                        tm.makeStringIndex(100),
+                        tm.makeDateIndex(100),
+                        tm.makePeriodIndex(100),
+                        tm.makeTimedeltaIndex(100),
+                        tm.makeIntIndex(100),
+                        tm.makeUIntIndex(100),
+                        tm.makeFloatIndex(100),
+                        Index([True, False]),
+                        tm.makeCategoricalIndex(100),
+                        Index([]),
+                        MultiIndex.from_tuples(lzip(
+                            ['foo', 'bar', 'baz'], [1, 2, 3])),
+                        Index([0, 0, 1, 1, 2, 2])])
+def index(request):
+    return request.param
+
+
 class TestIndex(Base):
     _holder = Index
 
@@ -58,8 +76,8 @@ class TestIndex(Base):
         assert new_index.ndim == 2
         assert isinstance(new_index, np.ndarray)
 
-    def test_copy_and_deepcopy(self):
-        super(TestIndex, self).test_copy_and_deepcopy()
+    def test_copy_and_deepcopy(self, index):
+        super(TestIndex, self).test_copy_and_deepcopy(index)
 
         new_copy2 = self.intIndex.copy(dtype=int)
         assert new_copy2.dtype.kind == 'i'

--- a/pandas/tests/indexes/test_base.py
+++ b/pandas/tests/indexes/test_base.py
@@ -29,24 +29,6 @@ import pandas as pd
 from pandas._libs.lib import Timestamp
 
 
-@pytest.fixture(params=[tm.makeUnicodeIndex(100),
-                        tm.makeStringIndex(100),
-                        tm.makeDateIndex(100),
-                        tm.makePeriodIndex(100),
-                        tm.makeTimedeltaIndex(100),
-                        tm.makeIntIndex(100),
-                        tm.makeUIntIndex(100),
-                        tm.makeFloatIndex(100),
-                        Index([True, False]),
-                        tm.makeCategoricalIndex(100),
-                        Index([]),
-                        MultiIndex.from_tuples(lzip(
-                            ['foo', 'bar', 'baz'], [1, 2, 3])),
-                        Index([0, 0, 1, 1, 2, 2])])
-def index(request):
-    return request.param
-
-
 class TestIndex(Base):
     _holder = Index
 
@@ -76,8 +58,8 @@ class TestIndex(Base):
         assert new_index.ndim == 2
         assert isinstance(new_index, np.ndarray)
 
-    def test_copy_and_deepcopy(self, index):
-        super(TestIndex, self).test_copy_and_deepcopy(index)
+    def test_copy_and_deepcopy(self, indices):
+        super(TestIndex, self).test_copy_and_deepcopy(indices)
 
         new_copy2 = self.intIndex.copy(dtype=int)
         assert new_copy2.dtype.kind == 'i'

--- a/pandas/tests/indexes/test_numeric.py
+++ b/pandas/tests/indexes/test_numeric.py
@@ -459,8 +459,8 @@ class TestFloat64Index(Numeric):
 
 class NumericInt(Numeric):
 
-    def test_view(self):
-        super(NumericInt, self).test_view()
+    def test_view(self, indices):
+        super(NumericInt, self).test_view(indices)
 
         i = self._holder([], name='Foo')
         i_view = i.view()

--- a/pandas/tests/indexes/test_range.py
+++ b/pandas/tests/indexes/test_range.py
@@ -312,8 +312,8 @@ class TestRangeIndex(Numeric):
             # either depending on numpy version
             result = idx.delete(len(idx))
 
-    def test_view(self):
-        super(TestRangeIndex, self).test_view()
+    def test_view(self, indices):
+        super(TestRangeIndex, self).test_view(indices)
 
         i = RangeIndex(0, name='Foo')
         i_view = i.view()


### PR DESCRIPTION
- [x] closes #16835
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

Not sure if there is a better way to define fixture params since they're essentially the indexes defined in `setup_method`. Also thinking about adding an id to each param so the output doesn't look like:

```
test_base.py::TestMixedIntIndex::test_sort[index0] <- pandas/tests/indexes/common.py PASSED
test_base.py::TestMixedIntIndex::test_sort[index1] <- pandas/tests/indexes/common.py PASSED
test_base.py::TestMixedIntIndex::test_sort[index2] <- pandas/tests/indexes/common.py PASSED
test_base.py::TestMixedIntIndex::test_sort[index3] <- pandas/tests/indexes/common.py PASSED
...
```