### PR TITLE
DOC: fix no autosummary for numerical index api pages

### DIFF
--- a/doc/source/api.rst
+++ b/doc/source/api.rst
@@ -1426,8 +1426,23 @@ Numeric Index
    :template: autosummary/class_without_autosummary.rst
 
    RangeIndex
+
+.. autosummary::
+   :toctree: generated/
+   :template: autosummary/class_without_autosummary.rst
+
    Int64Index
+
+.. autosummary::
+   :toctree: generated/
+   :template: autosummary/class_without_autosummary.rst
+
    UInt64Index
+
+.. autosummary::
+   :toctree: generated/
+   :template: autosummary/class_without_autosummary.rst
+
    Float64Index
 
 .. _api.categoricalindex:

--- a/doc/source/api.rst
+++ b/doc/source/api.rst
@@ -1426,23 +1426,8 @@ Numeric Index
    :template: autosummary/class_without_autosummary.rst
 
    RangeIndex
-
-.. autosummary::
-   :toctree: generated/
-   :template: autosummary/class_without_autosummary.rst
-
    Int64Index
-
-.. autosummary::
-   :toctree: generated/
-   :template: autosummary/class_without_autosummary.rst
-
    UInt64Index
-
-.. autosummary::
-   :toctree: generated/
-   :template: autosummary/class_without_autosummary.rst
-
    Float64Index
 
 .. _api.categoricalindex:

--- a/doc/sphinxext/numpydoc/numpydoc.py
+++ b/doc/sphinxext/numpydoc/numpydoc.py
@@ -43,9 +43,10 @@ def mangle_docstrings(app, what, name, obj, options, lines,
               )
 
     # PANDAS HACK (to remove the list of methods/attributes for Categorical)
-    if what == "class" and (name.endswith(".Categorical") or
-                            name.endswith("CategoricalIndex") or
-                            name.endswith("IntervalIndex")):
+    no_autosummary = [".Categorical", "CategoricalIndex", "IntervalIndex",
+                      "RangeIndex", "Int64Index", "UInt64Index",
+                      "Float64Index"]
+    if what == "class" and any(name.endswith(n) for n in no_autosummary):
         cfg['class_members_list'] = False
 
     if what == 'module':


### PR DESCRIPTION
For some reason the 'class_without_autosummary' template is not working for the newly added numeric index classes.

I asked in the PR https://github.com/pandas-dev/pandas/pull/17611 to combine them, but now as a test splitting them again (all other cases where it does work is only one class, but if this works seems a bug in sphinx)

Don't merge yet.