### PR TITLE
Fix first_valid_index/last_valid_index on DataFrame of all None/NaN values

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -4070,7 +4070,15 @@ class DataFrame(NDFrame):
         if len(self) == 0:
             return None
 
-        return self.index[self.count(1) > 0][0]
+        try:
+            return self.index[self.count(1) > 0][0]
+        except IndexError:
+            # Ensures same behavior as a Series of all Null values.
+            mask = isna(self._values)
+            if all(mask):
+                return None
+
+            raise
 
     def last_valid_index(self):
         """
@@ -4079,8 +4087,15 @@ class DataFrame(NDFrame):
         if len(self) == 0:
             return None
 
-        return self.index[self.count(1) > 0][-1]
+        try:
+            return self.index[self.count(1) > 0][-1]
+        except IndexError:
+            # Ensures same behavior as a Series of all Null values.
+            mask = isna(self._values)
+            if all(mask):
+                return None
 
+            raise
     # ----------------------------------------------------------------------
     # Data reshaping
 

--- a/pandas/tests/frame/test_timeseries.py
+++ b/pandas/tests/frame/test_timeseries.py
@@ -440,6 +440,11 @@ class TestDataFrameTimeSeriesMethods(TestData):
         assert empty.last_valid_index() is None
         assert empty.first_valid_index() is None
 
+        # GH17400
+        allnulls = DataFrame({'a': [np.nan, np.nan]})
+        assert allnulls.first_valid_index() is None
+        assert allnulls.last_valid_index() is None
+
     def test_at_time_frame(self):
         rng = date_range('1/1/2000', '1/5/2000', freq='5min')
         ts = DataFrame(np.random.randn(len(rng), 2), index=rng)


### PR DESCRIPTION
Ensures DataFrame behaves consistent to Series when calling first_valid_index or last_valid_index when all values in df are None/NaN.

- [x] closes #17400
- [x] added two test cases in pandas/tests/frame/test_timeseries.py (all other tests of first/last_valid_index() were located there) and verified that they failed prior to/passed after the change.
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
