### PR TITLE
DOC: Added example to MultiIndex doc string

### DIFF
--- a/pandas/core/indexes/multi.py
+++ b/pandas/core/indexes/multi.py
@@ -76,7 +76,7 @@ class MultiIndex(Index):
     and :meth:`MultiIndex.from_tuples``. For example (using ``.from_arrays``):
 
     >>> arrays = [[1, 1, 2, 2], ['red', 'blue', 'red', 'blue']]
-    >>> MultiIndex.from_arrays(arrays, names=('number', 'color'))
+    >>> pd.MultiIndex.from_arrays(arrays, names=('number', 'color'))
     MultiIndex(levels=[[1, 2], ['blue', 'red']],
            labels=[[0, 0, 1, 1], [1, 0, 1, 0]],
            names=['number', 'color'])

--- a/pandas/core/indexes/multi.py
+++ b/pandas/core/indexes/multi.py
@@ -68,6 +68,33 @@ class MultiIndex(Index):
         Copy the meta-data
     verify_integrity : boolean, default True
         Check that the levels/labels are consistent and valid
+
+    Examples
+    ---------
+    A new ``MultiIndex`` is typically constructed using one of the helper
+    methods :meth:`MultiIndex.from_arrays``, :meth:`MultiIndex.from_product``
+    and :meth:`MultiIndex.from_tuples``. For example (using ``.from_arrays``):
+
+    >>> arrays = [[1, 1, 2, 2], ['red', 'blue', 'red', 'blue']]
+    >>> MultiIndex.from_arrays(arrays, names=('number', 'color'))
+    MultiIndex(levels=[[1, 2], ['blue', 'red']],
+           labels=[[0, 0, 1, 1], [1, 0, 1, 0]],
+           names=['number', 'color'])
+
+    See further examples for how to construct a MultiIndex in the doc strings
+    of the mentioned helper methods.
+
+    Notes
+    -----
+    See the `user guide
+    <http://pandas.pydata.org/pandas-docs/stable/advanced.html>`_ for more.
+
+    See Also
+    --------
+    MultiIndex.from_arrays  : Convert list of arrays to MultiIndex
+    MultiIndex.from_product : Create a MultiIndex from the cartesian product
+                              of iterables
+    MultiIndex.from_tuples  : Convert list of tuples to a MultiIndex
     """
 
     # initialize to zero-length tuples to make everything work


### PR DESCRIPTION
- [ ] closes #xxxx
- [ ] tests added / passed
- [x ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

I think ``MultiIndex`` doc string should have a quick note on how ``MultiIndex`` is typically instantiated, as you normally wouldn't instantiate it directly.

I've added an example to the doc string, as in my experience  ``MultiIndex`` is one of the more complex areas of Pandas, so a quick example is justified. This may be debatable, so if others disagree on having an example here, I can remove the example and just retain the links to the ``.from_*`` methods.