### PR TITLE
BUG: Fix series rename called with str altering name rather index (GH17407)

### DIFF
--- a/doc/source/whatsnew/v0.21.0.txt
+++ b/doc/source/whatsnew/v0.21.0.txt
@@ -588,9 +588,10 @@ Indexing
 - Bug in ``CategoricalIndex`` reindexing in which specified indices containing duplicates were not being respected (:issue:`17323`)
 - Bug in intersection of ``RangeIndex`` with negative step (:issue:`17296`)
 - Bug in ``IntervalIndex`` where performing a scalar lookup fails for included right endpoints of non-overlapping monotonic decreasing indexes (:issue:`16417`, :issue:`17271`)
+<<<<<<< 4996e764fb0adbd5c77574eb3cb60f19c0fafba3
 <<<<<<< 99300ddcc636c859a02b3010ee379d1adbd1678e
 - Bug in :meth:`DataFrame.first_valid_index` and :meth:`DataFrame.last_valid_index` when no valid entry (:issue:`17400`)
-- Bug in ``Series.rename`` when called with `str` alters name of series rather than index of series. (:issue:`17407`)
+- Bug in ``Series.rename`` when called with a `callable` alters name of series rather than index of series. (:issue:`17407`)
 
 I/O
 ^^^

--- a/doc/source/whatsnew/v0.21.0.txt
+++ b/doc/source/whatsnew/v0.21.0.txt
@@ -588,9 +588,6 @@ Indexing
 - Bug in ``CategoricalIndex`` reindexing in which specified indices containing duplicates were not being respected (:issue:`17323`)
 - Bug in intersection of ``RangeIndex`` with negative step (:issue:`17296`)
 - Bug in ``IntervalIndex`` where performing a scalar lookup fails for included right endpoints of non-overlapping monotonic decreasing indexes (:issue:`16417`, :issue:`17271`)
-<<<<<<< f97c9bc2d44f7aa58314fe67f1fa074af3032473
-<<<<<<< 4996e764fb0adbd5c77574eb3cb60f19c0fafba3
-<<<<<<< 99300ddcc636c859a02b3010ee379d1adbd1678e
 - Bug in :meth:`DataFrame.first_valid_index` and :meth:`DataFrame.last_valid_index` when no valid entry (:issue:`17400`)
 - Bug in :func:`Series.rename` when called with a `callable`, incorrectly alters the name of the `Series`, rather than the name of the `Index`. (:issue:`17407`)
 

--- a/doc/source/whatsnew/v0.21.0.txt
+++ b/doc/source/whatsnew/v0.21.0.txt
@@ -588,10 +588,11 @@ Indexing
 - Bug in ``CategoricalIndex`` reindexing in which specified indices containing duplicates were not being respected (:issue:`17323`)
 - Bug in intersection of ``RangeIndex`` with negative step (:issue:`17296`)
 - Bug in ``IntervalIndex`` where performing a scalar lookup fails for included right endpoints of non-overlapping monotonic decreasing indexes (:issue:`16417`, :issue:`17271`)
+<<<<<<< f97c9bc2d44f7aa58314fe67f1fa074af3032473
 <<<<<<< 4996e764fb0adbd5c77574eb3cb60f19c0fafba3
 <<<<<<< 99300ddcc636c859a02b3010ee379d1adbd1678e
 - Bug in :meth:`DataFrame.first_valid_index` and :meth:`DataFrame.last_valid_index` when no valid entry (:issue:`17400`)
-- Bug in ``Series.rename`` when called with a `callable` alters name of series rather than index of series. (:issue:`17407`)
+- Bug in :func:`Series.rename` when called with a `callable`, incorrectly alters the name of the `Series`, rather than the name of the `Index`. (:issue:`17407`)
 
 I/O
 ^^^

--- a/doc/source/whatsnew/v0.21.0.txt
+++ b/doc/source/whatsnew/v0.21.0.txt
@@ -588,8 +588,9 @@ Indexing
 - Bug in ``CategoricalIndex`` reindexing in which specified indices containing duplicates were not being respected (:issue:`17323`)
 - Bug in intersection of ``RangeIndex`` with negative step (:issue:`17296`)
 - Bug in ``IntervalIndex`` where performing a scalar lookup fails for included right endpoints of non-overlapping monotonic decreasing indexes (:issue:`16417`, :issue:`17271`)
+<<<<<<< 99300ddcc636c859a02b3010ee379d1adbd1678e
 - Bug in :meth:`DataFrame.first_valid_index` and :meth:`DataFrame.last_valid_index` when no valid entry (:issue:`17400`)
-- Bug in ``Series.rename`` when called with `str` will alter name of series rather than index of series. (:issue:`17407`)
+- Bug in ``Series.rename`` when called with `str` alters name of series rather than index of series. (:issue:`17407`)
 
 I/O
 ^^^

--- a/doc/source/whatsnew/v0.21.0.txt
+++ b/doc/source/whatsnew/v0.21.0.txt
@@ -589,6 +589,7 @@ Indexing
 - Bug in intersection of ``RangeIndex`` with negative step (:issue:`17296`)
 - Bug in ``IntervalIndex`` where performing a scalar lookup fails for included right endpoints of non-overlapping monotonic decreasing indexes (:issue:`16417`, :issue:`17271`)
 - Bug in :meth:`DataFrame.first_valid_index` and :meth:`DataFrame.last_valid_index` when no valid entry (:issue:`17400`)
+- Bug in ``Series.rename`` when called with `str` will alter name of series rather than index of series. (:issue:`17407`)
 
 I/O
 ^^^

--- a/pandas/core/dtypes/inference.py
+++ b/pandas/core/dtypes/inference.py
@@ -263,7 +263,8 @@ def is_list_like(obj):
     """
 
     return (hasattr(obj, '__iter__') and
-            not isinstance(obj, string_and_binary_types))
+            not isinstance(obj, string_and_binary_types) and
+            isinstance(obj, collections.Iterable))
 
 
 def is_nested_list_like(obj):

--- a/pandas/core/dtypes/inference.py
+++ b/pandas/core/dtypes/inference.py
@@ -3,6 +3,7 @@
 import collections
 import re
 import numpy as np
+from collections import Iterable
 from numbers import Number
 from pandas.compat import (PY2, string_types, text_type,
                            string_and_binary_types)
@@ -262,10 +263,8 @@ def is_list_like(obj):
     False
     """
 
-    return (hasattr(obj, '__iter__') and
-            not isinstance(obj, string_and_binary_types) and
-            isinstance(obj, collections.Iterable))
-
+    return ((hasattr(obj, '__iter__') or isinstance(obj, Iterable)) and
+            not isinstance(obj, string_and_binary_types))
 
 def is_nested_list_like(obj):
     """

--- a/pandas/core/dtypes/inference.py
+++ b/pandas/core/dtypes/inference.py
@@ -263,7 +263,7 @@ def is_list_like(obj):
     False
     """
 
-    return (hasattr(obj, '__iter__') and isinstance(obj, Iterable) and
+    return (isinstance(obj, Iterable) and
             not isinstance(obj, string_and_binary_types))
 
 

--- a/pandas/core/dtypes/inference.py
+++ b/pandas/core/dtypes/inference.py
@@ -263,8 +263,9 @@ def is_list_like(obj):
     False
     """
 
-    return ((hasattr(obj, '__iter__') or isinstance(obj, Iterable)) and
+    return (hasattr(obj, '__iter__') and isinstance(obj, Iterable) and
             not isinstance(obj, string_and_binary_types))
+
 
 def is_nested_list_like(obj):
     """

--- a/pandas/tests/dtypes/test_inference.py
+++ b/pandas/tests/dtypes/test_inference.py
@@ -58,7 +58,7 @@ def test_is_sequence():
 def test_is_list_like():
     passes = ([], [1], (1, ), (1, 2), {'a': 1}, set([1, 'a']), Series([1]),
               Series([]), Series(['a']).str)
-    fails = (1, '2', object())
+    fails = (1, '2', object(), str)
 
     for p in passes:
         assert inference.is_list_like(p)

--- a/pandas/tests/series/test_indexing.py
+++ b/pandas/tests/series/test_indexing.py
@@ -2188,6 +2188,16 @@ class TestSeriesIndexing(TestData):
         expected = Series([False, True, False], index=[1, 2, 3])
         assert_series_equal(result, expected)
 
+    def test_rename(self):
+        
+        # GH 17407
+        s = Series(range(1, 6), index=pd.Index(range(2, 7), name='IntIndex'))
+        result = s.rename(str)
+        expected = s.rename(lambda i: str(i))
+        assert_series_equal(result, expected)
+
+        assert result.name == expected.name
+
     def test_select(self):
         n = len(self.ts)
         result = self.ts.select(lambda x: x >= self.ts.index[n // 2])

--- a/pandas/tests/series/test_indexing.py
+++ b/pandas/tests/series/test_indexing.py
@@ -2189,7 +2189,7 @@ class TestSeriesIndexing(TestData):
         assert_series_equal(result, expected)
 
     def test_rename(self):
-        
+
         # GH 17407
         s = Series(range(1, 6), index=pd.Index(range(2, 7), name='IntIndex'))
         result = s.rename(str)


### PR DESCRIPTION
- [x] closes #17407
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry
