### PR TITLE
CLN: replace %s syntax with .format in io

### DIFF
--- a/pandas/io/clipboard/exceptions.py
+++ b/pandas/io/clipboard/exceptions.py
@@ -8,5 +8,5 @@ class PyperclipException(RuntimeError):
 class PyperclipWindowsException(PyperclipException):
 
     def __init__(self, message):
-        message += " (%s)" % ctypes.WinError()
+        message += " ({err})".format(err=ctypes.WinError())
         super(PyperclipWindowsException, self).__init__(message)

--- a/pandas/io/html.py
+++ b/pandas/io/html.py
@@ -439,14 +439,15 @@ class _BeautifulSoupHtml5LibFrameParser(_HtmlFrameParser):
             unique_tables.add(table)
 
         if not result:
-            raise ValueError("No tables found matching pattern %r" %
-                             match.pattern)
+            raise ValueError("No tables found matching pattern {patt!r}"
+                             .format(patt=match.pattern))
         return result
 
     def _setup_build_doc(self):
         raw_text = _read(self.io)
         if not raw_text:
-            raise ValueError('No text parsed from document: %s' % self.io)
+            raise ValueError('No text parsed from document: {doc}'
+                             .format(doc=self.io))
         return raw_text
 
     def _build_doc(self):
@@ -473,8 +474,8 @@ def _build_xpath_expr(attrs):
     if 'class_' in attrs:
         attrs['class'] = attrs.pop('class_')
 
-    s = [u("@%s=%r") % (k, v) for k, v in iteritems(attrs)]
-    return u('[%s]') % ' and '.join(s)
+    s = [u("@{key}={val!r}").format(key=k, val=v) for k, v in iteritems(attrs)]
+    return u('[{expr}]').format(expr=' and '.join(s))
 
 
 _re_namespace = {'re': 'http://exslt.org/regular-expressions'}
@@ -517,8 +518,8 @@ class _LxmlFrameParser(_HtmlFrameParser):
 
         # 1. check all descendants for the given pattern and only search tables
         # 2. go up the tree until we find a table
-        query = '//table//*[re:test(text(), %r)]/ancestor::table'
-        xpath_expr = u(query) % pattern
+        query = '//table//*[re:test(text(), {patt!r})]/ancestor::table'
+        xpath_expr = u(query).format(patt=pattern)
 
         # if any table attributes were given build an xpath expression to
         # search for them
@@ -528,7 +529,8 @@ class _LxmlFrameParser(_HtmlFrameParser):
         tables = doc.xpath(xpath_expr, namespaces=_re_namespace)
 
         if not tables:
-            raise ValueError("No tables found matching regex %r" % pattern)
+            raise ValueError("No tables found matching regex {patt!r}"
+                             .format(patt=pattern))
         return tables
 
     def _build_doc(self):
@@ -574,8 +576,9 @@ class _LxmlFrameParser(_HtmlFrameParser):
                 scheme = parse_url(self.io).scheme
                 if scheme not in _valid_schemes:
                     # lxml can't parse it
-                    msg = ('%r is not a valid url scheme, valid schemes are '
-                           '%s') % (scheme, _valid_schemes)
+                    msg = (('{invalid!r} is not a valid url scheme, valid '
+                            'schemes are {valid}')
+                           .format(invalid=scheme, valid=_valid_schemes))
                     raise ValueError(msg)
                 else:
                     # something else happened: maybe a faulty connection
@@ -670,8 +673,9 @@ def _parser_dispatch(flavor):
     """
     valid_parsers = list(_valid_parsers.keys())
     if flavor not in valid_parsers:
-        raise ValueError('%r is not a valid flavor, valid flavors are %s' %
-                         (flavor, valid_parsers))
+        raise ValueError('{invalid!r} is not a valid flavor, valid flavors '
+                         'are {valid}'
+                         .format(invalid=flavor, valid=valid_parsers))
 
     if flavor in ('bs4', 'html5lib'):
         if not _HAS_HTML5LIB:
@@ -695,7 +699,7 @@ def _parser_dispatch(flavor):
 
 
 def _print_as_set(s):
-    return '{%s}' % ', '.join([pprint_thing(el) for el in s])
+    return '{{arg}}'.format(arg=', '.join([pprint_thing(el) for el in s]))
 
 
 def _validate_flavor(flavor):
@@ -705,21 +709,23 @@ def _validate_flavor(flavor):
         flavor = flavor,
     elif isinstance(flavor, collections.Iterable):
         if not all(isinstance(flav, string_types) for flav in flavor):
-            raise TypeError('Object of type %r is not an iterable of strings' %
-                            type(flavor).__name__)
+            raise TypeError('Object of type {typ!r} is not an iterable of '
+                            'strings'
+                            .format(typ=type(flavor).__name__))
     else:
-        fmt = '{0!r}' if isinstance(flavor, string_types) else '{0}'
+        fmt = '{flavor!r}' if isinstance(flavor, string_types) else '{flavor}'
         fmt += ' is not a valid flavor'
-        raise ValueError(fmt.format(flavor))
+        raise ValueError(fmt.format(flavor=flavor))
 
     flavor = tuple(flavor)
     valid_flavors = set(_valid_parsers)
     flavor_set = set(flavor)
 
     if not flavor_set & valid_flavors:
-        raise ValueError('%s is not a valid set of flavors, valid flavors are '
-                         '%s' % (_print_as_set(flavor_set),
-                                 _print_as_set(valid_flavors)))
+        raise ValueError('{invalid} is not a valid set of flavors, valid '
+                         'flavors are {valid}'
+                         .format(invalid=_print_as_set(flavor_set),
+                                 valid=_print_as_set(valid_flavors)))
     return flavor
 
 

--- a/pandas/io/json/json.py
+++ b/pandas/io/json/json.py
@@ -99,7 +99,7 @@ class SeriesWriter(Writer):
     def _format_axes(self):
         if not self.obj.index.is_unique and self.orient == 'index':
             raise ValueError("Series index must be unique for orient="
-                             "'%s'" % self.orient)
+                             "'{orient}'".format(orient=self.orient))
 
 
 class FrameWriter(Writer):
@@ -110,11 +110,11 @@ class FrameWriter(Writer):
         if not self.obj.index.is_unique and self.orient in (
                 'index', 'columns'):
             raise ValueError("DataFrame index must be unique for orient="
-                             "'%s'." % self.orient)
+                             "'{orient}'.".format(orient=self.orient))
         if not self.obj.columns.is_unique and self.orient in (
                 'index', 'columns', 'records'):
             raise ValueError("DataFrame columns must be unique for orient="
-                             "'%s'." % self.orient)
+                             "'{orient}'.".format(orient=self.orient))
 
 
 class JSONTableWriter(FrameWriter):
@@ -134,8 +134,9 @@ class JSONTableWriter(FrameWriter):
 
         if date_format != 'iso':
             msg = ("Trying to write with `orient='table'` and "
-                   "`date_format='%s'`. Table Schema requires dates "
-                   "to be formatted with `date_format='iso'`" % date_format)
+                   "`date_format='{fmt}'`. Table Schema requires dates "
+                   "to be formatted with `date_format='iso'`"
+                   .format(fmt=date_format))
             raise ValueError(msg)
 
         self.schema = build_table_schema(obj)
@@ -166,8 +167,8 @@ class JSONTableWriter(FrameWriter):
 
     def write(self):
         data = super(JSONTableWriter, self).write()
-        serialized = '{{"schema": {}, "data": {}}}'.format(
-            dumps(self.schema), data)
+        serialized = '{{"schema": {schema}, "data": {data}}}'.format(
+            schema=dumps(self.schema), data=data)
         return serialized
 
 
@@ -391,8 +392,8 @@ class Parser(object):
         if date_unit is not None:
             date_unit = date_unit.lower()
             if date_unit not in self._STAMP_UNITS:
-                raise ValueError('date_unit must be one of %s' %
-                                 (self._STAMP_UNITS,))
+                raise ValueError('date_unit must be one of {units}'
+                                 .format(units=self._STAMP_UNITS))
             self.min_stamp = self._MIN_STAMPS[date_unit]
         else:
             self.min_stamp = self._MIN_STAMPS['s']
@@ -410,8 +411,8 @@ class Parser(object):
         bad_keys = set(decoded.keys()).difference(set(self._split_keys))
         if bad_keys:
             bad_keys = ", ".join(bad_keys)
-            raise ValueError(u("JSON data had unexpected key(s): %s") %
-                             pprint_thing(bad_keys))
+            raise ValueError(u("JSON data had unexpected key(s): {bad_keys}")
+                             .format(bad_keys=pprint_thing(bad_keys)))
 
     def parse(self):
 

--- a/pandas/io/json/normalize.py
+++ b/pandas/io/json/normalize.py
@@ -249,7 +249,8 @@ def json_normalize(data, record_path=None, meta=None,
                                 raise \
                                     KeyError("Try running with "
                                              "errors='ignore' as key "
-                                             "%s is not always present", e)
+                                             "{err} is not always present"
+                                             .format(err=e))
                     meta_vals[key].append(meta_val)
 
                 records.extend(recs)
@@ -267,8 +268,8 @@ def json_normalize(data, record_path=None, meta=None,
             k = meta_prefix + k
 
         if k in result:
-            raise ValueError('Conflicting metadata name %s, '
-                             'need distinguishing prefix ' % k)
+            raise ValueError('Conflicting metadata name {name}, '
+                             'need distinguishing prefix '.format(name=k))
 
         result[k] = np.array(v).repeat(lengths)
 

--- a/pandas/io/msgpack/_packer.pyx
+++ b/pandas/io/msgpack/_packer.pyx
@@ -224,7 +224,7 @@ cdef class Packer(object):
                 default_used = 1
                 continue
             else:
-                raise TypeError("can't serialize %r" % (o,))
+                raise TypeError("can't serialize {thing!r}".format(thing=o))
             return ret
 
     cpdef pack(self, object obj):

--- a/pandas/io/msgpack/_unpacker.pyx
+++ b/pandas/io/msgpack/_unpacker.pyx
@@ -94,7 +94,7 @@ cdef inline init_ctx(unpack_context *ctx,
 
 def default_read_extended_type(typecode, data):
     raise NotImplementedError("Cannot decode extended type "
-                              "with typecode=%d" % typecode)
+                              "with typecode={code}".format(code=typecode))
 
 
 def unpackb(object packed, object object_hook=None, object list_hook=None,
@@ -144,7 +144,7 @@ def unpackb(object packed, object object_hook=None, object list_hook=None,
                 buf + off, buf_len - off))
         return obj
     else:
-        raise UnpackValueError("Unpack failed: error = %d" % (ret,))
+        raise UnpackValueError("Unpack failed: error = {ret}".format(ret=ret))
 
 
 def unpack(object stream, object object_hook=None, object list_hook=None,
@@ -411,7 +411,8 @@ cdef class Unpacker(object):
                 else:
                     raise OutOfData("No more data to unpack.")
             else:
-                raise ValueError("Unpack failed: error = %d" % (ret,))
+                raise ValueError("Unpack failed: error = {ret}"
+                                 .format(ret=ret))
 
     def read_bytes(self, Py_ssize_t nbytes):
         """Read a specified number of raw bytes from the stream"""

--- a/pandas/io/sas/sas.pyx
+++ b/pandas/io/sas/sas.pyx
@@ -101,10 +101,12 @@ cdef np.ndarray[uint8_t, ndim=1] rle_decompress(
                 result[rpos] = 0x00
                 rpos += 1
         else:
-            raise ValueError("unknown control byte: %v", control_byte)
+            raise ValueError("unknown control byte: {byte}"
+                             .format(byte=control_byte))
 
     if len(result) != result_length:
-        raise ValueError("RLE: %v != %v", (len(result), result_length))
+        raise ValueError("RLE: {got} != {expect}".format(got=len(result),
+                                                         expect=result_length))
 
     return np.asarray(result)
 
@@ -185,7 +187,8 @@ cdef np.ndarray[uint8_t, ndim=1] rdc_decompress(
             raise ValueError("unknown RDC command")
 
     if len(outbuff) != result_length:
-        raise ValueError("RDC: %v != %v\n", len(outbuff), result_length)
+        raise ValueError("RDC: {got} != {expect}\n"
+                         .format(got=len(outbuff), expect=result_length))
 
     return np.asarray(outbuff)
 
@@ -258,7 +261,8 @@ cdef class Parser(object):
                 self.column_types[j] = column_type_string
             else:
                 raise ValueError("unknown column type: "
-                                 "%s" % self.parser.columns[j].ctype)
+                                 "{typ}"
+                                 .format(typ=self.parser.columns[j].ctype))
 
         # compression
         if parser.compression == const.rle_compression:
@@ -378,8 +382,8 @@ cdef class Parser(object):
                         return True
                 return False
             else:
-                raise ValueError("unknown page type: %s",
-                                 self.current_page_type)
+                raise ValueError("unknown page type: {typ}"
+                                 .format(typ=self.current_page_type))
 
     cdef void process_byte_array_with_data(self, int offset, int length):
 


### PR DESCRIPTION
Progress toward issue #16130. Converted old string formatting to new string formatting in io/html.py, io/excel.py, msgpack/_packer.pyx, msgpack/_unpacker.pyx, clipboard/exceptions.py, json/json.py, json/normalize.py, sas/sas.pyx

