### PR TITLE
TST: add datetimelike tests for tz-aware DatetimeIndex

### DIFF
--- a/pandas/tests/indexes/datetimelike.py
+++ b/pandas/tests/indexes/datetimelike.py
@@ -22,7 +22,7 @@ class DatetimeLike(Base):
 
         if hasattr(idx, 'tz'):
             if idx.tz is not None:
-                assert idx.tz in str(idx)
+                assert str(idx.tz) in str(idx)
         if hasattr(idx, 'freq'):
             assert "freq='%s'" % idx.freqstr in str(idx)
 


### PR DESCRIPTION
This commit just makes quick patches to get tests working for subclassing common index tests for tz-aware DatetimeIndex, by either ignoring tests entirely or explicitly converting to the DatetimeIndex's TZ. This is split off from PR #17583 where we were trying to add another common test. Advice is requested for whether to try to also make fixes upstream or just to keep these fixes localized to the test suite.

- [ ] closes #xxxx
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
