### PR TITLE
remove unused time conversion funcs

### DIFF
--- a/pandas/_libs/index.pyx
+++ b/pandas/_libs/index.pyx
@@ -14,6 +14,7 @@ cimport util
 import numpy as np
 
 cimport tslib
+from tslib cimport _to_i8
 
 from hashtable cimport HashTable
 
@@ -406,12 +407,12 @@ cdef class DatetimeEngine(Int64Engine):
             if not self.is_unique:
                 return self._get_loc_duplicates(val)
             values = self._get_index_values()
-            conv = tslib.pydt_to_i8(val)
+            conv = _to_i8(val)
             loc = values.searchsorted(conv, side='left')
             return util.get_value_at(values, loc) == conv
 
         self._ensure_mapping_populated()
-        return tslib.pydt_to_i8(val) in self.mapping
+        return _to_i8(val) in self.mapping
 
     cdef _get_index_values(self):
         return self.vgetter().view('i8')
@@ -426,12 +427,12 @@ cdef class DatetimeEngine(Int64Engine):
         # Welcome to the spaghetti factory
         if self.over_size_threshold and self.is_monotonic_increasing:
             if not self.is_unique:
-                val = tslib.pydt_to_i8(val)
+                val = _to_i8(val)
                 return self._get_loc_duplicates(val)
             values = self._get_index_values()
 
             try:
-                conv = tslib.pydt_to_i8(val)
+                conv = _to_i8(val)
                 loc = values.searchsorted(conv, side='left')
             except TypeError:
                 self._date_check_type(val)
@@ -443,7 +444,7 @@ cdef class DatetimeEngine(Int64Engine):
 
         self._ensure_mapping_populated()
         if not self.unique:
-            val = tslib.pydt_to_i8(val)
+            val = _to_i8(val)
             return self._get_loc_duplicates(val)
 
         try:
@@ -454,7 +455,7 @@ cdef class DatetimeEngine(Int64Engine):
             pass
 
         try:
-            val = tslib.pydt_to_i8(val)
+            val = _to_i8(val)
             return self.mapping.get_item(val)
         except (TypeError, ValueError):
             self._date_check_type(val)

--- a/pandas/_libs/index.pyx
+++ b/pandas/_libs/index.pyx
@@ -13,13 +13,11 @@ cimport util
 
 import numpy as np
 
-cimport tslib
 from tslib cimport _to_i8
 
 from hashtable cimport HashTable
 
-from tslibs.timezones cimport is_utc, get_utcoffset
-from pandas._libs import tslib, algos, hashtable as _hash
+from pandas._libs import algos, hashtable as _hash
 from pandas._libs.tslib import Timestamp, Timedelta
 from datetime import datetime, timedelta
 

--- a/pandas/_libs/lib.pyx
+++ b/pandas/_libs/lib.pyx
@@ -50,12 +50,6 @@ from datetime cimport (
     get_timedelta64_value, get_datetime64_value,
     npy_timedelta, npy_datetime,
     PyDateTime_Check, PyDate_Check, PyTime_Check, PyDelta_Check,
-    PyDateTime_GET_YEAR,
-    PyDateTime_GET_MONTH,
-    PyDateTime_GET_DAY,
-    PyDateTime_DATE_GET_HOUR,
-    PyDateTime_DATE_GET_MINUTE,
-    PyDateTime_DATE_GET_SECOND,
     PyDateTime_IMPORT)
 
 

--- a/pandas/_libs/lib.pyx
+++ b/pandas/_libs/lib.pyx
@@ -45,8 +45,6 @@ cdef double NaN = <double> np.NaN
 cdef double nan = NaN
 cdef double NAN = nan
 
-from datetime import datetime as pydatetime
-
 # this is our tseries.pxd
 from datetime cimport (
     get_timedelta64_value, get_datetime64_value,
@@ -131,61 +129,6 @@ def memory_usage_of_objects(ndarray[object, ndim=1] arr):
     for i from 0 <= i < n:
         s += arr[i].__sizeof__()
     return s
-
-#----------------------------------------------------------------------
-# datetime / io related
-
-cdef int _EPOCH_ORD = 719163
-
-from datetime import date as pydate
-
-cdef inline int64_t gmtime(object date):
-    cdef int y, m, d, h, mn, s, days
-
-    y = PyDateTime_GET_YEAR(date)
-    m = PyDateTime_GET_MONTH(date)
-    d = PyDateTime_GET_DAY(date)
-    h = PyDateTime_DATE_GET_HOUR(date)
-    mn = PyDateTime_DATE_GET_MINUTE(date)
-    s = PyDateTime_DATE_GET_SECOND(date)
-
-    days = pydate(y, m, 1).toordinal() - _EPOCH_ORD + d - 1
-    return ((<int64_t> (((days * 24 + h) * 60 + mn))) * 60 + s) * 1000
-
-
-cpdef object to_datetime(int64_t timestamp):
-    return pydatetime.utcfromtimestamp(timestamp / 1000.0)
-
-
-cpdef object to_timestamp(object dt):
-    return gmtime(dt)
-
-
-def array_to_timestamp(ndarray[object, ndim=1] arr):
-    cdef int i, n
-    cdef ndarray[int64_t, ndim=1] result
-
-    n = len(arr)
-    result = np.empty(n, dtype=np.int64)
-
-    for i from 0 <= i < n:
-        result[i] = gmtime(arr[i])
-
-    return result
-
-
-def time64_to_datetime(ndarray[int64_t, ndim=1] arr):
-    cdef int i, n
-    cdef ndarray[object, ndim=1] result
-
-    n = len(arr)
-    result = np.empty(n, dtype=object)
-
-    for i from 0 <= i < n:
-        result[i] = to_datetime(arr[i])
-
-    return result
-
 
 #----------------------------------------------------------------------
 # isnull / notnull related

--- a/pandas/_libs/tslib.pxd
+++ b/pandas/_libs/tslib.pxd
@@ -4,3 +4,5 @@ cdef convert_to_tsobject(object, object, object, bint, bint)
 cpdef convert_to_timedelta64(object, object)
 cdef bint _nat_scalar_rules[6]
 cdef bint _check_all_nulls(obj)
+
+cdef _to_i8(object val)

--- a/pandas/_libs/tslib.pyx
+++ b/pandas/_libs/tslib.pyx
@@ -3436,7 +3436,7 @@ def cast_to_nanoseconds(ndarray arr):
     return result
 
 
-def pydt_to_i8(object pydt):
+cpdef pydt_to_i8(object pydt):
     """
     Convert to int64 representation compatible with numpy datetime64; converts
     to UTC

--- a/pandas/_libs/tslib.pyx
+++ b/pandas/_libs/tslib.pyx
@@ -3444,13 +3444,7 @@ cdef inline _to_i8(object val):
         if is_datetime64_object(val):
             return get_datetime64_value(val)
         elif PyDateTime_Check(val):
-            tzinfo = getattr(val, 'tzinfo', None)
-            # Save the original date value so we can get the utcoffset from it.
-            ival = _pydatetime_to_dts(val, &dts)
-            if tzinfo is not None and not is_utc(tzinfo):
-                offset = get_utcoffset(tzinfo, val)
-                ival -= _delta_to_nanoseconds(offset)
-            return ival
+            return Timestamp(val).value
         return val
 
 cpdef pydt_to_i8(object pydt):

--- a/pandas/io/pytables.py
+++ b/pandas/io/pytables.py
@@ -25,7 +25,7 @@ from pandas.core.dtypes.missing import array_equivalent
 
 import numpy as np
 from pandas import (Series, DataFrame, Panel, Panel4D, Index,
-                    MultiIndex, Int64Index, isna, concat,
+                    MultiIndex, Int64Index, isna, concat, to_datetime,
                     SparseSeries, SparseDataFrame, PeriodIndex,
                     DatetimeIndex, TimedeltaIndex)
 from pandas.core import config
@@ -4529,7 +4529,7 @@ def _unconvert_index(data, kind, encoding=None):
 def _unconvert_index_legacy(data, kind, legacy=False, encoding=None):
     kind = _ensure_decoded(kind)
     if kind == u('datetime'):
-        index = lib.time64_to_datetime(data)
+        index = to_datetime(data)
     elif kind in (u('integer')):
         index = np.asarray(data, dtype=object)
     elif kind in (u('string')):


### PR DESCRIPTION
Takes the place of #17708, removing funcs instead of moving them.

Had to cpdef `pydt_to_i8` because the func it is replacing in `_libs.index` was cdef'd.

- [ ] closes #xxxx
- [ ] tests added / passed
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
