### PR TITLE
Doc: Further improvements for IntervalIndex and Interval

### DIFF
--- a/doc/source/advanced.rst
+++ b/doc/source/advanced.rst
@@ -833,11 +833,20 @@ Of course if you need integer based selection, then use ``iloc``
 IntervalIndex
 ~~~~~~~~~~~~~
 
+:class:`IntervalIndex` together with its own dtype, ``interval`` as well as the
+:class:`Interval` scalar type,  allow first-class support in pandas for interval
+notation.
+
+The ``IntervalIndex`` allows some unique indexing and is also used as a
+return type for the categories in :func:`cut` and :func:`qcut`.
+
 .. versionadded:: 0.20.0
 
 .. warning::
 
    These indexing behaviors are provisional and may change in a future version of pandas.
+
+An ``IntervalIndex`` can be used in ``Series`` and in ``DataFrame`` as the index.
 
 .. ipython:: python
 
@@ -860,6 +869,20 @@ If you select a lable *contained* within an interval, this will also select the 
    df.loc[2.5]
    df.loc[[2.5, 3.5]]
 
+``Interval`` and ``IntervalIndex`` are used by ``cut`` and ``qcut``:
+
+.. ipython:: python
+
+   c = pd.cut(range(4), bins=2)
+   c
+   c.categories
+
+Furthermore, ``IntervalIndex`` allows one to bin *other* data with these same
+bins, with ``NaN`` representing a missing value similar to other dtypes.
+
+.. ipython:: python
+
+   pd.cut([0, 3, 5, 1], bins=c.categories)
 
 Miscellaneous indexing FAQ
 --------------------------

--- a/pandas/_libs/interval.pyx
+++ b/pandas/_libs/interval.pyx
@@ -51,17 +51,35 @@ cdef class Interval(IntervalMixin):
 
     .. versionadded:: 0.20.0
 
-    Attributes
+    Parameters
     ----------
-    left, right : values
-        Left and right bounds for each interval.
+    left : value
+        Left bound for interval.
+    right : value
+        Right bound for interval.
     closed : {'left', 'right', 'both', 'neither'}
         Whether the interval is closed on the left-side, right-side, both or
         neither. Defaults to 'right'.
 
+    Examples
+    --------
+    >>> iv = pd.Interval(left=0, right=5)
+    >>> iv
+    Interval(0, 5, closed='right')
+    >>> 2.5 in iv
+    True
+
+    >>> year_2017 = pd.Interval(pd.Timestamp('2017-01-01'),
+    ...                         pd.Timestamp('2017-12-31'), closed='both')
+    >>> pd.Timestamp('2017-01-01 00:00') in year_2017
+    True
+
     See Also
     --------
-    IntervalIndex : an Index of intervals that are all closed on the same side.
+    IntervalIndex : an Index of ``interval`` s that are all closed on the same
+                    side.
+    cut, qcut : convert arrays of continuous data into categoricals/series of
+                ``Interval``.
     """
 
     cdef readonly object left, right

--- a/pandas/core/indexes/interval.py
+++ b/pandas/core/indexes/interval.py
@@ -105,8 +105,10 @@ class IntervalIndex(IntervalMixin, Index):
 
     .. versionadded:: 0.20.0
 
-    Warning: the indexing behaviors are provisional and may change in
-    a future version of pandas.
+    .. warning::
+
+       The indexing behaviors are provisional and may change in
+       a future version of pandas.
 
     Attributes
     ----------
@@ -147,15 +149,11 @@ class IntervalIndex(IntervalMixin, Index):
     --------
     Index
     Interval : A bounded slice-like interval
-    interval_range : Function to create a fixed frequency IntervalIndex
-    IntervalIndex.from_arrays : Construct an IntervalIndex from a left and
-                                right array
-    IntervalIndex.from_breaks : Construct an IntervalIndex from an array of
-                                splits
-    IntervalIndex.from_intervals : Construct an IntervalIndex from an array of
-                                   Interval objects
-    IntervalIndex.from_tuples : Construct an IntervalIndex from a list/array of
-                                tuples
+    interval_range : Function to create a fixed frequency
+    IntervalIndex, IntervalIndex.from_arrays, IntervalIndex.from_breaks,
+    IntervalIndex.from_intervals, IntervalIndex.from_tuples
+    cut, qcut : convert arrays of continuous data into categoricals/series of
+                ``Interval``.
     """
     _typ = 'intervalindex'
     _comparables = ['name']


### PR DESCRIPTION
- [x ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`

This follows #17706. Further changes are:

* Taken text from the whatsnew for v0.20 and use it in advanced.rst to give more explations to ``IntervalIndex`` and ``Interval``.
* in interval.pyx, the doc string "Attributes" didn't parse properly, because sphinx doesn't like having "left" and "right" on the same line. They're now on separate lines and the section renamed to 'Parameters'. See current here and compare to source: http://pandas-docs.github.io/pandas-docs-travis/generated/pandas.Interval.html#pandas.Interval.
* some examples are added to ``Interval``
* the warning text on ``IntervalIndex`` is now parsed properly.
* The "See Also" had become quite large, felt it becomes more reader-friendly to combine the ``from_*`` metods into one line.
* added ``cut`` and ``qcut`` to 'See also'

This will conclude my contributions to ``IntervalIndex``.