### PR TITLE
BUG: fixed check `_is_unorderable_exception`

### DIFF
--- a/pandas/core/dtypes/common.py
+++ b/pandas/core/dtypes/common.py
@@ -1158,7 +1158,9 @@ def _is_unorderable_exception(e):
     """
 
     if PY36:
-        return "'>' not supported between instances of" in str(e)
+        str_e = str(e)
+        return ("'>' not supported between instances of" in str_e or
+                "'<' not supported between instances of" in str_e)
 
     elif PY3:
         return 'unorderable' in str(e)


### PR DESCRIPTION
With upgrade to NumPy 1.13.2 the error message raised when comparing unorderable types
changes from using `"'>' not supported between instances of"` to using
`"'<' not supported between instances of"`.

This PR checks both of these.

See [GH-17046](https://github.com/pandas-dev/pandas/issues/17046) for discussion.

This caused failing `test test_basic_indexing` when running tests with NumPy 1.13.2. 

Here is the reproducer

```
import pandas
import pytest
import numpy as np
def test_basic_indexing():
    s = pandas.Series(np.random.randn(5), index=['a', 'b', 'a', 'a', 'b'])

    pytest.raises(IndexError, s.__getitem__, 5)
    pytest.raises(IndexError, s.__setitem__, 5, 0)

    pytest.raises(KeyError, s.__getitem__, 'c')

    s = s.sort_index()

    pytest.raises(IndexError, s.__getitem__, 5)
    pytest.raises(IndexError, s.__setitem__, 5, 0) # this part was failing

test_basic_indexing()
```

