### PR TITLE
repr string for pd.Grouper

### DIFF
--- a/pandas/core/groupby.py
+++ b/pandas/core/groupby.py
@@ -9,7 +9,7 @@ from textwrap import dedent
 
 from pandas.compat import (
     zip, range, lzip,
-    callable, map
+    callable, map, signature
 )
 
 from pandas import compat
@@ -233,10 +233,6 @@ class Grouper(object):
 
     >>> df.groupby(Grouper(level='date', freq='60s', axis=1))
     """
-    _attributes = collections.OrderedDict((('key', None), ('level', None),
-                                           ('freq', None), ('axis', 0),
-                                           ('sort', False)
-                                           ))
 
     def __new__(cls, *args, **kwargs):
         if kwargs.get('freq') is not None:
@@ -255,6 +251,11 @@ class Grouper(object):
         self.obj = None
         self.indexer = None
         self.binner = None
+
+    # _attributes is used in __repr__below
+    _attributes = collections.OrderedDict(
+        (k, v) for k, v in zip(signature(__init__).args[1:],
+                               signature(__init__).defaults))
 
     @property
     def ax(self):
@@ -338,9 +339,9 @@ class Grouper(object):
         return self.grouper.groups
 
     def __repr__(self):
-        defaults = self._attributes
         sd = self.__dict__
-        attrs = collections.OrderedDict((k, sd[k]) for k, v in defaults.items()
+        attr = self._attributes
+        attrs = collections.OrderedDict((k, sd[k]) for k, v in attr.items()
                                         if k in sd and sd[k] != v)
         attrs = ", ".join("{}={!r}".format(k, v) for k, v in attrs.items())
         cls_name = self.__class__.__name__

--- a/pandas/core/groupby.py
+++ b/pandas/core/groupby.py
@@ -233,6 +233,10 @@ class Grouper(object):
 
     >>> df.groupby(Grouper(level='date', freq='60s', axis=1))
     """
+    _attributes = collections.OrderedDict((('key', None), ('level', None),
+                                           ('freq', None), ('axis', 0),
+                                           ('sort', False)
+                                           ))
 
     def __new__(cls, *args, **kwargs):
         if kwargs.get('freq') is not None:
@@ -332,6 +336,15 @@ class Grouper(object):
     @property
     def groups(self):
         return self.grouper.groups
+
+    def __repr__(self):
+        defaults = self._attributes
+        sd = self.__dict__
+        attrs = collections.OrderedDict((k, sd[k]) for k, v in defaults.items()
+                                        if k in sd and sd[k] != v)
+        attrs = ", ".join("{}={!r}".format(k, v) for k, v in attrs.items())
+        cls_name = self.__class__.__name__
+        return "{}({})".format(cls_name, attrs)
 
 
 class GroupByPlot(PandasObject):

--- a/pandas/core/groupby.py
+++ b/pandas/core/groupby.py
@@ -234,6 +234,8 @@ class Grouper(object):
     >>> df.groupby(Grouper(level='date', freq='60s', axis=1))
     """
 
+    _attributes = ['key', 'level', 'freq', 'axis', 'sort']
+
     def __new__(cls, *args, **kwargs):
         if kwargs.get('freq') is not None:
             from pandas.core.resample import TimeGrouper
@@ -251,11 +253,6 @@ class Grouper(object):
         self.obj = None
         self.indexer = None
         self.binner = None
-
-    # _attributes is used in __repr__below
-    _attributes = collections.OrderedDict(
-        (k, v) for k, v in zip(signature(__init__).args[1:],
-                               signature(__init__).defaults))
 
     @property
     def ax(self):
@@ -339,10 +336,12 @@ class Grouper(object):
         return self.grouper.groups
 
     def __repr__(self):
+        grouper_defaults = compat.signature(self.__init__).defaults
         sd = self.__dict__
-        attr = self._attributes
-        attrs = collections.OrderedDict((k, sd[k]) for k, v in attr.items()
-                                        if k in sd and sd[k] != v)
+        attrs = collections.OrderedDict()
+        for k, v in zip(self._attributes, grouper_defaults):
+            if k in sd and sd[k] != v:
+                attrs[k] = sd[k]
         attrs = ", ".join("{}={!r}".format(k, v) for k, v in attrs.items())
         cls_name = self.__class__.__name__
         return "{}({})".format(cls_name, attrs)

--- a/pandas/core/resample.py
+++ b/pandas/core/resample.py
@@ -1026,16 +1026,6 @@ class TimeGrouper(Grouper):
     Use begin, end, nperiods to generate intervals that cannot be derived
     directly from the associated object
     """
-    # _attributes is used in __repr__below
-    _attributes = Grouper._attributes.copy()
-    _attributes.update((('freq', 'Min'), ('closed', None), ('label', None),
-                        ('how', 'mean'), ('nperiods', None), ('axis', 0),
-                        ('fill_method', None), ('limit', None),
-                        ('loffset', None), ('kind', None),
-                        ('convention', None), ('base', 0),
-                        ('convention', 'e'), ('sort', True),
-                        ))
-    _end_types = {'M', 'A', 'Q', 'BM', 'BA', 'BQ', 'W'}
 
     def __init__(self, freq='Min', closed=None, label=None, how='mean',
                  nperiods=None, axis=0,
@@ -1079,6 +1069,14 @@ class TimeGrouper(Grouper):
         kwargs['sort'] = True
 
         super(TimeGrouper, self).__init__(freq=freq, axis=axis, **kwargs)
+
+    # _attributes is used in __repr__below
+    _attributes = Grouper._attributes.copy()
+    _attributes.update(
+        (k, v) for k, v in zip(compat.signature(__init__).args[1:],
+                               compat.signature(__init__).defaults))
+    _attributes.update(sort=True, convention='e')
+    _end_types = {'M', 'A', 'Q', 'BM', 'BA', 'BQ', 'W'}
 
     def _get_resampler(self, obj, kind=None):
         """

--- a/pandas/core/resample.py
+++ b/pandas/core/resample.py
@@ -1027,6 +1027,11 @@ class TimeGrouper(Grouper):
     directly from the associated object
     """
 
+    _attributes = ['key', 'level', 'freq', 'axis', 'sort', 'closed', 'label',
+                   'how', 'nperiods', 'fill_method', 'limit',
+                   'loffset', 'kind', 'convention', 'base']
+    _end_types = {'M', 'A', 'Q', 'BM', 'BA', 'BQ', 'W'}
+
     def __init__(self, freq='Min', closed=None, label=None, how='mean',
                  nperiods=None, axis=0,
                  fill_method=None, limit=None, loffset=None, kind=None,
@@ -1069,14 +1074,6 @@ class TimeGrouper(Grouper):
         kwargs['sort'] = True
 
         super(TimeGrouper, self).__init__(freq=freq, axis=axis, **kwargs)
-
-    # _attributes is used in __repr__below
-    _attributes = Grouper._attributes.copy()
-    _attributes.update(
-        (k, v) for k, v in zip(compat.signature(__init__).args[1:],
-                               compat.signature(__init__).defaults))
-    _attributes.update(sort=True, convention='e')
-    _end_types = {'M', 'A', 'Q', 'BM', 'BA', 'BQ', 'W'}
 
     def _get_resampler(self, obj, kind=None):
         """
@@ -1299,25 +1296,6 @@ class TimeGrouper(Grouper):
             labels = labels.insert(0, tslib.NaT)
 
         return binner, bins, labels
-
-    def __repr__(self):
-        defaults = self._attributes.copy()
-        end_types = self._end_types
-        rule = self.freq.rule_code
-        if (rule in end_types or
-                ('-' in rule and rule[:rule.find('-')] in end_types)):
-            defaults.update(closed='right', label='right')
-        else:
-            defaults.update(closed='left', label='left')
-
-        sd = self.__dict__
-        attrs = collections.OrderedDict((k, sd[k]) for k, v in defaults.items()
-                                        if k in sd and sd[k] != v)
-        if 'freq' in attrs:
-            attrs['freq'] = attrs['freq'].freqstr
-        attrs = ", ".join("{}={!r}".format(k, v) for k, v in attrs.items())
-        cls_name = self.__class__.__name__
-        return "{}({})".format(cls_name, attrs)
 
 
 def _take_new_index(obj, indexer, new_index, axis=0):

--- a/pandas/tests/test_resample.py
+++ b/pandas/tests/test_resample.py
@@ -3177,6 +3177,14 @@ class TestTimeGrouper(object):
         self.ts = Series(np.random.randn(1000),
                          index=date_range('1/1/2000', periods=1000))
 
+    def test_timegrouper_repr(self):
+        # Added in GH17727
+        result = repr(TimeGrouper(key='key', freq='50Min', label='right'))
+        cls_name_result, attrib_result = result.split('(')
+        attrib_result = set(attrib_result.rstrip(')').split(', '))
+        assert cls_name_result == 'TimeGrouper'
+        assert attrib_result == {"key='key'", "freq='50T'", "label='right'"}
+
     def test_apply(self):
         with tm.assert_produces_warning(FutureWarning,
                                         check_stacklevel=False):

--- a/pandas/tests/test_resample.py
+++ b/pandas/tests/test_resample.py
@@ -3180,10 +3180,8 @@ class TestTimeGrouper(object):
     def test_timegrouper_repr(self):
         # Added in GH17727
         result = repr(TimeGrouper(key='key', freq='50Min', label='right'))
-        cls_name_result, attrib_result = result.split('(')
-        attrib_result = set(attrib_result.rstrip(')').split(', '))
-        assert cls_name_result == 'TimeGrouper'
-        assert attrib_result == {"key='key'", "freq='50T'", "label='right'"}
+        expected = "TimeGrouper(key='key', freq='50T', label='right')"
+        assert result == expected
 
     def test_apply(self):
         with tm.assert_produces_warning(FutureWarning,

--- a/pandas/tests/test_resample.py
+++ b/pandas/tests/test_resample.py
@@ -3180,7 +3180,9 @@ class TestTimeGrouper(object):
     def test_timegrouper_repr(self):
         # Added in GH17727
         result = repr(TimeGrouper(key='key', freq='50Min', label='right'))
-        expected = "TimeGrouper(key='key', freq='50T', label='right')"
+        expected = ("TimeGrouper(key='key', freq=<50 * Minutes>, axis=0,"
+                    " sort=True, closed='left', label='right', how='mean', "
+                    "loffset=None)")
         assert result == expected
 
     def test_apply(self):


### PR DESCRIPTION
- [ ] closes #xxxx
- [x ] tests added / passed
- [ x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

**Edit: I've made a full proposal (sans some  discussion points below)**

Currently the repr for ``Grouper`` and ``TimeGrouper`` is not pretty:

```python
>>> pd.Grouper(key='key')
<pandas.core.groupby.Grouper at 0x248d5ebfd30>
>>> pd.Grouper(key='key', freq='50Min')
<pandas.core.resample.TimeGrouper at 0x248d68d95c0>
```

I propose adding a ``Grouper.__repr__``, so the repr will be like:

```python
>>> pd.Grouper(key='key')
Grouper(key='key')
>>> pd.Grouper(key='key', freq='50Min')
TimeGrouper(key='key', freq='50T')
>>> pd.Grouper(key='key', freq='50Min', label='right')
TimeGrouper(label='right', key='k', freq='50T')
```

The repr shows the instantiation form, so users could copy the repr and paste it in to use it, which is always nice.

See attached PR. Tests are still missing. Comments welcome.

Two points:
* The repr calculation is a bit heavy, so I've cached it. Don't know if that is going overboard?
* Is ``TimeGrouper`` deprecated?