### PR TITLE
BUG: GH17525 Function _get_standard_colors resets random seed

### DIFF
--- a/doc/source/whatsnew/v0.21.0.txt
+++ b/doc/source/whatsnew/v0.21.0.txt
@@ -614,6 +614,7 @@ Plotting
 - Line plots no longer assume monotonic x data when calculating xlims, they show the entire lines now even for unsorted x data. (:issue:`11310`, :issue:`11471`)
 - With matplotlib 2.0.0 and above, calculation of x limits for line plots is left to matplotlib, so that its new default settings are applied. (:issue:`15495`)
 - Bug in ``Series.plot.bar`` or ``DataFramee.plot.bar`` with ``y`` not respecting user-passed ``color`` (:issue:`16822`)
+- Bug in ``plotting._style._get_standard_colors`` resetting the random seed when generating random colors (:issue:`17525`)
 
 
 Groupby/Resample/Rolling

--- a/pandas/plotting/_style.py
+++ b/pandas/plotting/_style.py
@@ -114,7 +114,6 @@ def _get_standard_colors(num_colors=None, colormap=None, color_type='default',
             import random
 
             def random_color(column):
-                random.seed(column)
                 return [random.random() for _ in range(3)]
 
             colors = lmap(random_color, lrange(num_colors))


### PR DESCRIPTION
- [X] closes #17525  
- [X] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [X] whatsnew entry
