### PR TITLE
Explicitly define cmp_pandas_datetimestruct

### DIFF
--- a/pandas/_libs/src/datetime/np_datetime.c
+++ b/pandas/_libs/src/datetime/np_datetime.c
@@ -269,8 +269,8 @@ static void set_datetimestruct_days(npy_int64 days,
 /*
  * Compares two pandas_datetimestruct objects chronologically
  */
-int cmp_pandas_datetimestruct(pandas_datetimestruct *a,
-                              pandas_datetimestruct *b) {
+int cmp_pandas_datetimestruct(const pandas_datetimestruct *a,
+                              const pandas_datetimestruct *b) {
     if (a->year > b->year) {
         return 1;
     } else if (a->year < b->year) {

--- a/pandas/_libs/src/datetime/np_datetime.h
+++ b/pandas/_libs/src/datetime/np_datetime.h
@@ -99,6 +99,14 @@ convert_datetimestruct_to_datetime(pandas_datetime_metadata *meta,
 npy_int64
 get_datetimestruct_days(const pandas_datetimestruct *dts);
 
+
+/*
+ * Compares two pandas_datetimestruct objects chronologically
+ */
+int cmp_pandas_datetimestruct(pandas_datetimestruct *a,
+                              pandas_datetimestruct *b);
+
+
 /*
  * Adjusts a datetimestruct based on a minutes offset. Assumes
  * the current values are valid.

--- a/pandas/_libs/src/datetime/np_datetime.h
+++ b/pandas/_libs/src/datetime/np_datetime.h
@@ -103,8 +103,8 @@ get_datetimestruct_days(const pandas_datetimestruct *dts);
 /*
  * Compares two pandas_datetimestruct objects chronologically
  */
-int cmp_pandas_datetimestruct(pandas_datetimestruct *a,
-                              pandas_datetimestruct *b);
+int cmp_pandas_datetimestruct(const pandas_datetimestruct *a,
+                              const pandas_datetimestruct *b);
 
 
 /*

--- a/setup.py
+++ b/setup.py
@@ -511,7 +511,7 @@ ext_data = {
                    'pxdfiles': ['_libs/src/util', '_libs/hashtable'],
                    'depends': _pxi_dep['join']},
     '_libs.reshape': {'pyxfile': '_libs/reshape',
-                      'depends': _pxi_dep['reshape'], 'include': []},
+                      'depends': _pxi_dep['reshape']},
     '_libs.interval': {'pyxfile': '_libs/interval',
                        'pxdfiles': ['_libs/hashtable'],
                        'depends': _pxi_dep['interval']},
@@ -527,7 +527,7 @@ ext_data = {
                                   'pandas/_libs/src/parser/io.c']},
     '_libs.sparse': {'pyxfile': '_libs/sparse',
                      'depends': (['pandas/_libs/sparse.pyx'] +
-                                 _pxi_dep['sparse']), 'include': []},
+                                 _pxi_dep['sparse'])},
     '_libs.testing': {'pyxfile': '_libs/testing',
                       'depends': ['pandas/_libs/testing.pyx']},
     '_libs.hashing': {'pyxfile': '_libs/hashing',


### PR DESCRIPTION
Fixes build warning
```
pandas/_libs/tslib.c:78967:17: warning: implicit declaration of function 'cmp_pandas_datetimestruct' is invalid in C99 [-Wimplicit-function-declaration]
```
