### PR TITLE
DOC: Add column name metadata to spec

### DIFF
--- a/doc/source/developer.rst
+++ b/doc/source/developer.rst
@@ -45,6 +45,7 @@ So that a ``pandas.DataFrame`` can be faithfully reconstructed, we store a
 .. code-block:: text
 
    {'index_columns': ['__index_level_0__', '__index_level_1__', ...],
+    'column_index_names': [<column index level name 0>, <column index level name 1>, ...],
     'columns': [<c0>, <c1>, ...],
     'pandas_version': $VERSION}
 
@@ -106,6 +107,7 @@ As an example of fully-formed metadata:
 .. code-block:: text
 
    {'index_columns': ['__index_level_0__'],
+    'column_index_names': [None],
     'columns': [
         {'name': 'c0',
          'pandas_type': 'int8',

--- a/doc/source/developer.rst
+++ b/doc/source/developer.rst
@@ -46,6 +46,7 @@ So that a ``pandas.DataFrame`` can be faithfully reconstructed, we store a
 
    {'index_columns': ['__index_level_0__', '__index_level_1__', ...],
     'column_index_names': [<column index level name 0>, <column index level name 1>, ...],
+    'column_index_dtypes': [<dtype 0>, <dtype 1>, ..., <dtype N>]
     'columns': [<c0>, <c1>, ...],
     'pandas_version': $VERSION}
 
@@ -108,6 +109,7 @@ As an example of fully-formed metadata:
 
    {'index_columns': ['__index_level_0__'],
     'column_index_names': [None],
+    'column_index_dtypes': ['object'],
     'columns': [
         {'name': 'c0',
          'pandas_type': 'int8',


### PR DESCRIPTION
This adds an additional metadata field to the spec to allow faithful
reproduction of names of column indexes.

cc @wesm @martindurant @jreback