### PR TITLE
Use argument dtype to inform coercion

### DIFF
--- a/pandas/core/dtypes/cast.py
+++ b/pandas/core/dtypes/cast.py
@@ -483,6 +483,39 @@ def infer_dtype_from_array(arr, pandas_dtype=False):
     return arr.dtype, arr
 
 
+def maybe_infer_dtype_type(element):
+    """Try to infer an object's dtype, for use in arithmetic ops
+
+    Uses `element.dtype` if that's available.
+    Objects implementing the iterator protocol are cast to a NumPy array,
+    and from there the array's type is used.
+
+    Parameters
+    ----------
+    element : object
+        Possibly has a `.dtype` attribute, and possibly the iterator
+        protocol.
+
+    Returns
+    -------
+    tipo : type
+
+    Examples
+    --------
+    >>> from collections import namedtuple
+    >>> Foo = namedtuple("Foo", "dtype")
+    >>> maybe_infer_dtype_type(Foo(np.dtype("i8")))
+    numpy.int64
+    """
+    tipo = None
+    if hasattr(element, 'dtype'):
+        tipo = element.dtype
+    elif is_list_like(element):
+        element = np.asarray(element)
+        tipo = element.dtype
+    return tipo
+
+
 def maybe_upcast(values, fill_value=np.nan, dtype=None, copy=False):
     """ provide explict type promotion and coercion
 

--- a/pandas/core/internals.py
+++ b/pandas/core/internals.py
@@ -44,7 +44,8 @@ from pandas.core.dtypes.cast import (
     soft_convert_objects,
     maybe_convert_objects,
     astype_nansafe,
-    find_common_type)
+    find_common_type,
+    maybe_infer_dtype_type)
 from pandas.core.dtypes.missing import (
     isna, notna, array_equivalent,
     _isna_compat,
@@ -629,10 +630,9 @@ class Block(PandasObject):
     def _can_hold_element(self, element):
         """ require the same dtype as ourselves """
         dtype = self.values.dtype.type
-        if is_list_like(element):
-            element = np.asarray(element)
-            tipo = element.dtype.type
-            return issubclass(tipo, dtype)
+        tipo = maybe_infer_dtype_type(element)
+        if tipo:
+            return issubclass(tipo.type, dtype)
         return isinstance(element, dtype)
 
     def _try_cast_result(self, result, dtype=None):
@@ -1806,11 +1806,10 @@ class FloatBlock(FloatOrComplexBlock):
     _downcast_dtype = 'int64'
 
     def _can_hold_element(self, element):
-        if is_list_like(element):
-            element = np.asarray(element)
-            tipo = element.dtype.type
-            return (issubclass(tipo, (np.floating, np.integer)) and
-                    not issubclass(tipo, (np.datetime64, np.timedelta64)))
+        tipo = maybe_infer_dtype_type(element)
+        if tipo:
+            return (issubclass(tipo.type, (np.floating, np.integer)) and
+                    not issubclass(tipo.type, (np.datetime64, np.timedelta64)))
         return (isinstance(element, (float, int, np.floating, np.int_)) and
                 not isinstance(element, (bool, np.bool_, datetime, timedelta,
                                          np.datetime64, np.timedelta64)))
@@ -1856,9 +1855,9 @@ class ComplexBlock(FloatOrComplexBlock):
     is_complex = True
 
     def _can_hold_element(self, element):
-        if is_list_like(element):
-            element = np.array(element)
-            return issubclass(element.dtype.type,
+        tipo = maybe_infer_dtype_type(element)
+        if tipo:
+            return issubclass(tipo.type,
                               (np.floating, np.integer, np.complexfloating))
         return (isinstance(element,
                            (float, int, complex, np.float_, np.int_)) and
@@ -1874,12 +1873,12 @@ class IntBlock(NumericBlock):
     _can_hold_na = False
 
     def _can_hold_element(self, element):
-        if is_list_like(element):
-            element = np.array(element)
-            tipo = element.dtype.type
-            return (issubclass(tipo, np.integer) and
-                    not issubclass(tipo, (np.datetime64, np.timedelta64)) and
-                    self.dtype.itemsize >= element.dtype.itemsize)
+        tipo = maybe_infer_dtype_type(element)
+        if tipo:
+            return (issubclass(tipo.type, np.integer) and
+                    not issubclass(tipo.type, (np.datetime64,
+                                               np.timedelta64)) and
+                    self.dtype.itemsize >= tipo.itemsize)
         return is_integer(element)
 
     def should_store(self, value):
@@ -1917,10 +1916,9 @@ class TimeDeltaBlock(DatetimeLikeBlockMixin, IntBlock):
         return lambda x: tslib.Timedelta(x, unit='ns')
 
     def _can_hold_element(self, element):
-        if is_list_like(element):
-            element = np.array(element)
-            tipo = element.dtype.type
-            return issubclass(tipo, np.timedelta64)
+        tipo = maybe_infer_dtype_type(element)
+        if tipo:
+            return issubclass(tipo.type, np.timedelta64)
         return isinstance(element, (timedelta, np.timedelta64))
 
     def fillna(self, value, **kwargs):
@@ -2018,9 +2016,9 @@ class BoolBlock(NumericBlock):
     _can_hold_na = False
 
     def _can_hold_element(self, element):
-        if is_list_like(element):
-            element = np.asarray(element)
-            return issubclass(element.dtype.type, np.bool_)
+        tipo = maybe_infer_dtype_type(element)
+        if tipo:
+            return issubclass(tipo.type, np.bool_)
         return isinstance(element, (bool, np.bool_))
 
     def should_store(self, value):
@@ -2450,7 +2448,9 @@ class DatetimeBlock(DatetimeLikeBlockMixin, Block):
         return super(DatetimeBlock, self)._astype(dtype=dtype, **kwargs)
 
     def _can_hold_element(self, element):
-        if is_list_like(element):
+        tipo = maybe_infer_dtype_type(element)
+        if tipo:
+            # TODO: this still uses asarray, instead of dtype.type
             element = np.array(element)
             return element.dtype == _NS_DTYPE or element.dtype == np.int64
         return (is_integer(element) or isinstance(element, datetime) or

--- a/pandas/core/internals.py
+++ b/pandas/core/internals.py
@@ -631,7 +631,7 @@ class Block(PandasObject):
         """ require the same dtype as ourselves """
         dtype = self.values.dtype.type
         tipo = maybe_infer_dtype_type(element)
-        if tipo:
+        if tipo is not None:
             return issubclass(tipo.type, dtype)
         return isinstance(element, dtype)
 
@@ -1807,7 +1807,7 @@ class FloatBlock(FloatOrComplexBlock):
 
     def _can_hold_element(self, element):
         tipo = maybe_infer_dtype_type(element)
-        if tipo:
+        if tipo is not None:
             return (issubclass(tipo.type, (np.floating, np.integer)) and
                     not issubclass(tipo.type, (np.datetime64, np.timedelta64)))
         return (isinstance(element, (float, int, np.floating, np.int_)) and
@@ -1856,7 +1856,7 @@ class ComplexBlock(FloatOrComplexBlock):
 
     def _can_hold_element(self, element):
         tipo = maybe_infer_dtype_type(element)
-        if tipo:
+        if tipo is not None:
             return issubclass(tipo.type,
                               (np.floating, np.integer, np.complexfloating))
         return (isinstance(element,
@@ -1874,7 +1874,7 @@ class IntBlock(NumericBlock):
 
     def _can_hold_element(self, element):
         tipo = maybe_infer_dtype_type(element)
-        if tipo:
+        if tipo is not None:
             return (issubclass(tipo.type, np.integer) and
                     not issubclass(tipo.type, (np.datetime64,
                                                np.timedelta64)) and
@@ -1917,7 +1917,7 @@ class TimeDeltaBlock(DatetimeLikeBlockMixin, IntBlock):
 
     def _can_hold_element(self, element):
         tipo = maybe_infer_dtype_type(element)
-        if tipo:
+        if tipo is not None:
             return issubclass(tipo.type, np.timedelta64)
         return isinstance(element, (timedelta, np.timedelta64))
 
@@ -2017,7 +2017,7 @@ class BoolBlock(NumericBlock):
 
     def _can_hold_element(self, element):
         tipo = maybe_infer_dtype_type(element)
-        if tipo:
+        if tipo is not None:
             return issubclass(tipo.type, np.bool_)
         return isinstance(element, (bool, np.bool_))
 
@@ -2449,7 +2449,7 @@ class DatetimeBlock(DatetimeLikeBlockMixin, Block):
 
     def _can_hold_element(self, element):
         tipo = maybe_infer_dtype_type(element)
-        if tipo:
+        if tipo is not None:
             # TODO: this still uses asarray, instead of dtype.type
             element = np.array(element)
             return element.dtype == _NS_DTYPE or element.dtype == np.int64

--- a/pandas/tests/internals/test_internals.py
+++ b/pandas/tests/internals/test_internals.py
@@ -1247,7 +1247,7 @@ class TestCanHoldElement(object):
         (1.0, 'f8'),
         (1j, 'complex128'),
         (True, 'bool'),
-        # (np.timedelta64(20, 'ns'), '<m8[ns]'),
+        (np.timedelta64(20, 'ns'), '<m8[ns]'),
         (np.datetime64(20, 'ns'), '<M8[ns]'),
     ])
     @pytest.mark.parametrize('op', [
@@ -1266,6 +1266,7 @@ class TestCanHoldElement(object):
                 (operator.mod, 'i8'),
                 (operator.mod, 'complex128'),
                 (operator.mod, '<M8[ns]'),
+                (operator.mod, '<m8[ns]'),
                 (operator.pow, 'bool')}
         if (op, dtype) in skip:
             pytest.skip("Invalid combination {},{}".format(op, dtype))

--- a/pandas/tests/internals/test_internals.py
+++ b/pandas/tests/internals/test_internals.py
@@ -2,6 +2,7 @@
 # pylint: disable=W0102
 
 from datetime import datetime, date
+import operator
 import sys
 import pytest
 import numpy as np
@@ -1213,3 +1214,63 @@ class TestBlockPlacement(object):
 
             with pytest.raises(ValueError):
                 BlockPlacement(slice(2, None, -1)).add(-1)
+
+
+class DummyElement(object):
+    def __init__(self, value, dtype):
+        self.value = value
+        self.dtype = np.dtype(dtype)
+
+    def __array__(self):
+        return np.array(self.value, dtype=self.dtype)
+
+    def __str__(self):
+        return "DummyElement({}, {})".format(self.value, self.dtype)
+
+    def __repr__(self):
+        return str(self)
+
+    def astype(self, dtype, copy=False):
+        self.dtype = dtype
+        return self
+
+    def view(self, dtype):
+        return type(self)(self.value.view(dtype), dtype)
+
+    def any(self, axis=None):
+        return bool(self.value)
+
+
+class TestCanHoldElement(object):
+    @pytest.mark.parametrize('value, dtype', [
+        (1, 'i8'),
+        (1.0, 'f8'),
+        (1j, 'complex128'),
+        (True, 'bool'),
+        # (np.timedelta64(20, 'ns'), '<m8[ns]'),
+        (np.datetime64(20, 'ns'), '<M8[ns]'),
+    ])
+    @pytest.mark.parametrize('op', [
+        operator.add,
+        operator.sub,
+        operator.mul,
+        operator.truediv,
+        operator.mod,
+        operator.pow,
+    ], ids=lambda x: x.__name__)
+    def test_binop_other(self, op, value, dtype):
+        skip = {(operator.add, 'bool'),
+                (operator.sub, 'bool'),
+                (operator.mul, 'bool'),
+                (operator.truediv, 'bool'),
+                (operator.mod, 'i8'),
+                (operator.mod, 'complex128'),
+                (operator.mod, '<M8[ns]'),
+                (operator.pow, 'bool')}
+        if (op, dtype) in skip:
+            pytest.skip("Invalid combination {},{}".format(op, dtype))
+        e = DummyElement(value, dtype)
+        s = pd.DataFrame({"A": [e.value, e.value]}, dtype=e.dtype)
+        result = op(s, e).dtypes
+        expected = op(s, value).dtypes
+        assert_series_equal(result, expected)


### PR DESCRIPTION
Master:

```python
>>> import dask.dataframe as dd

>>> s = dd.core.Scalar({('s', 0): 10}, 's', 'i8')
>>> pdf = pd.DataFrame({'a': [1, 2, 3, 4, 5, 6, 7],
...                     'b': [7, 6, 5, 4, 3, 2, 1]})
>>> (pdf + s).dtypes
a    object
b    object
dtype: object
```

Head:

```
>>> (pdf + s).dtypes
a    int64
b    int64
dtype: object
```

This is more consistent with 0.20.3, while keeping the benefits from https://github.com/pandas-dev/pandas/pull/16821

Closes https://github.com/pandas-dev/pandas/issues/17767

---

I may play around with this a bit more. I feel like this is a bit too numpy specific, for example, adding a `DataFrame` and a `pa.Scalar` still fails:


```python
In [39]: x = pa.array([1])[0]

In [40]: df = pd.DataFrame({"A": [1, 2]})

In [41]: df + x
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
~/Envs/pandas-dev/lib/python3.6/site-packages/pandas/pandas/core/internals.py in eval(self, func, other, raise_on_error, try_cast, mgr)
   1292         try:
-> 1293             values, values_mask, other, other_mask = self._try_coerce_args(
   1294                 transf(values), other)

~/Envs/pandas-dev/lib/python3.6/site-packages/pandas/pandas/core/internals.py in _try_coerce_args(self, values, other)
    677             raise TypeError("cannot convert {} to an {}".format(
--> 678                 type(other).__name__,
    679                 type(self).__name__.lower().replace('Block', '')))

TypeError: cannot convert Int64Value to an intblock

During handling of the above exception, another exception occurred:

TypeError                                 Traceback (most recent call last)
~/Envs/pandas-dev/lib/python3.6/site-packages/pandas/pandas/core/ops.py in na_op(x, y)
   1199             result = expressions.evaluate(op, str_rep, x, y,
-> 1200                                           raise_on_error=True, **eval_kwargs)
   1201         except TypeError:

~/Envs/pandas-dev/lib/python3.6/site-packages/pandas/pandas/core/computation/expressions.py in evaluate(op, op_str, a, b, raise_on_error, use_numexpr, **eval_kwargs)
    210         return _evaluate(op, op_str, a, b, raise_on_error=raise_on_error,
--> 211                          **eval_kwargs)
    212     return _evaluate_standard(op, op_str, a, b, raise_on_error=raise_on_error)

~/Envs/pandas-dev/lib/python3.6/site-packages/pandas/pandas/core/computation/expressions.py in _evaluate_standard(op, op_str, a, b, raise_on_error, **eval_kwargs)
     63     with np.errstate(all='ignore'):
---> 64         return op(a, b)
     65

TypeError: unsupported operand type(s) for +: 'int' and 'pyarrow.lib.Int64Value'

During handling of the above exception, another exception occurred:

TypeError                                 Traceback (most recent call last)
~/Envs/pandas-dev/lib/python3.6/site-packages/pandas/pandas/core/internals.py in eval(self, func, other, raise_on_error, try_cast, mgr)
   1351         try:
-> 1352             with np.errstate(all='ignore'):
   1353                 result = get_result(other)

~/Envs/pandas-dev/lib/python3.6/site-packages/pandas/pandas/core/internals.py in get_result(other)
   1320                 result = func(values, other)
-> 1321             else:
   1322                 result = func(values, other)

~/Envs/pandas-dev/lib/python3.6/site-packages/pandas/pandas/core/ops.py in na_op(x, y)
   1225                     with np.errstate(all='ignore'):
-> 1226                         result[mask] = op(xrav, y)
   1227             else:

TypeError: unsupported operand type(s) for +: 'int' and 'pyarrow.lib.Int64Value'

During handling of the above exception, another exception occurred:

TypeError                                 Traceback (most recent call last)
<ipython-input-41-a01bb1dd67a6> in <module>()
----> 1 df + x

~/Envs/pandas-dev/lib/python3.6/site-packages/pandas/pandas/core/ops.py in f(self, other, axis, level, fill_value)
   1263                 self = self.fillna(fill_value)
   1264
-> 1265             return self._combine_const(other, na_op)
   1266
   1267     f.__name__ = name

~/Envs/pandas-dev/lib/python3.6/site-packages/pandas/pandas/core/frame.py in _combine_const(self, other, func, raise_on_error, try_cast)
   3836         new_data = self._data.eval(func=func, other=other,
   3837                                    raise_on_error=raise_on_error,
-> 3838                                    try_cast=try_cast)
   3839         return self._constructor(new_data)
   3840

~/Envs/pandas-dev/lib/python3.6/site-packages/pandas/pandas/core/internals.py in eval(self, **kwargs)
   3375         return self.apply('where', **kwargs)
   3376
-> 3377     def eval(self, **kwargs):
   3378         return self.apply('eval', **kwargs)
   3379

~/Envs/pandas-dev/lib/python3.6/site-packages/pandas/pandas/core/internals.py in apply(self, f, axes, filter, do_integrity_check, consolidate, **kwargs)
   3269                                                  copy=align_copy)
   3270
-> 3271             kwargs['mgr'] = self
   3272             applied = getattr(b, f)(**kwargs)
   3273             result_blocks = _extend_blocks(applied, result_blocks)

~/Envs/pandas-dev/lib/python3.6/site-packages/pandas/pandas/core/internals.py in eval(self, func, other, raise_on_error, try_cast, mgr)
   1296             block = self.coerce_to_target_dtype(orig_other)
   1297             return block.eval(func, orig_other,
-> 1298                               raise_on_error=raise_on_error,
   1299                               try_cast=try_cast, mgr=mgr)
   1300

~/Envs/pandas-dev/lib/python3.6/site-packages/pandas/pandas/core/internals.py in eval(self, func, other, raise_on_error, try_cast, mgr)
   1357         except ValueError as detail:
   1358             raise
-> 1359         except Exception as detail:
   1360             result = handle_error()
   1361

~/Envs/pandas-dev/lib/python3.6/site-packages/pandas/pandas/core/internals.py in handle_error()
   1340             if raise_on_error:
   1341                 # The 'detail' variable is defined in outer scope.
-> 1342                 raise TypeError('Could not operate %s with block values %s' %
   1343                                 (repr(other), str(detail)))  # noqa
   1344             else:

TypeError: Could not operate 1 with block values unsupported operand type(s) for +: 'int' and 'pyarrow.lib.Int64Value'
```

Do we want that to work?