### PR TITLE
ENH: SparseDataFrame/SparseSeries value assignment

### DIFF
--- a/doc/source/whatsnew/v0.24.0.txt
+++ b/doc/source/whatsnew/v0.24.0.txt
@@ -175,6 +175,7 @@ Other Enhancements
   (:issue:`21627`)
 - New method :meth:`HDFStore.walk` will recursively walk the group hierarchy of an HDF5 file (:issue:`10932`)
 - :func:`read_html` copies cell data across ``colspan`` and ``rowspan``, and it treats all-``th`` table rows as headers if ``header`` kwarg is not given and there is no ``thead`` (:issue:`17054`)
+- :class:`SparseDataFrame` and :class:`SparseSeries` support value assignment (:issue:`21818`)
 - :meth:`Series.nlargest`, :meth:`Series.nsmallest`, :meth:`DataFrame.nlargest`, and :meth:`DataFrame.nsmallest` now accept the value ``"all"`` for the ``keep`` argument. This keeps all ties for the nth largest/smallest value (:issue:`16818`)
 - :class:`IntervalIndex` has gained the :meth:`~IntervalIndex.set_closed` method to change the existing ``closed`` value (:issue:`21670`)
 - :func:`~DataFrame.to_csv`, :func:`~Series.to_csv`, :func:`~DataFrame.to_json`, and :func:`~Series.to_json` now support ``compression='infer'`` to infer compression based on filename extension (:issue:`15008`).

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -785,11 +785,9 @@ class DataFrame(NDFrame):
         iteritems : Iterate over (column name, Series) pairs.
 
         """
-        columns = self.columns
-        klass = self._constructor_sliced
-        for k, v in zip(self.index, self.values):
-            s = klass(v, index=columns, name=k)
-            yield k, s
+        iloc = self.iloc
+        for i, k in enumerate(self.index):
+            yield k, iloc[i]
 
     def itertuples(self, index=True, name="Pandas"):
         """
@@ -2765,7 +2763,7 @@ class DataFrame(NDFrame):
             return self._get_item_cache(key)
 
     def _getitem_frame(self, key):
-        if key.values.size and not is_bool_dtype(key.values):
+        if key.size and not key.dtypes.map(is_bool_dtype).all():
             raise ValueError('Must pass DataFrame with boolean values only')
         return self.where(key)
 
@@ -3153,7 +3151,7 @@ class DataFrame(NDFrame):
                 )
             key = self._constructor(key, **self._construct_axes_dict())
 
-        if key.values.size and not is_bool_dtype(key.values):
+        if key.size and not key.dtypes.map(is_bool_dtype).all():
             raise TypeError(
                 'Must pass DataFrame or 2-d ndarray with boolean values only'
             )

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -2548,9 +2548,7 @@ class DataFrame(NDFrame):
 
         Returns
         -------
-        frame : DataFrame
-            If label pair is contained, will be reference to calling DataFrame,
-            otherwise a new object
+        self : DataFrame
         """
         warnings.warn("set_value is deprecated and will be removed "
                       "in a future release. Please use "

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -1071,9 +1071,7 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
 
         Returns
         -------
-        series : Series
-            If label is contained, will be reference to calling Series,
-            otherwise a new object
+        self : Series
         """
         warnings.warn("set_value is deprecated and will be removed "
                       "in a future release. Please use "

--- a/pandas/core/sparse/frame.py
+++ b/pandas/core/sparse/frame.py
@@ -330,7 +330,8 @@ class SparseDataFrame(DataFrame):
 
         return self._constructor(
             data=new_data, index=self.index, columns=self.columns,
-            default_fill_value=self.default_fill_value).__finalize__(self)
+            default_fill_value=self.default_fill_value,
+            default_kind=self.default_kind).__finalize__(self)
 
     def astype(self, dtype):
         return self._apply_columns(lambda x: x.astype(dtype))
@@ -576,7 +577,8 @@ class SparseDataFrame(DataFrame):
 
         return self._constructor(data=new_data, index=new_index,
                                  columns=new_columns,
-                                 default_fill_value=new_fill_value
+                                 default_fill_value=new_fill_value,
+                                 default_kind=self.default_kind,
                                  ).__finalize__(self)
 
     def _combine_match_index(self, other, func, level=None):
@@ -605,7 +607,8 @@ class SparseDataFrame(DataFrame):
 
         return self._constructor(
             new_data, index=new_index, columns=self.columns,
-            default_fill_value=fill_value).__finalize__(self)
+            default_fill_value=fill_value,
+            default_kind=self.default_kind).__finalize__(self)
 
     def _combine_match_columns(self, other, func, level=None, try_cast=True):
         # patched version of DataFrame._combine_match_columns to account for
@@ -629,7 +632,8 @@ class SparseDataFrame(DataFrame):
 
         return self._constructor(
             new_data, index=self.index, columns=union,
-            default_fill_value=self.default_fill_value).__finalize__(self)
+            default_fill_value=self.default_fill_value,
+            default_kind=self.default_kind).__finalize__(self)
 
     def _combine_const(self, other, func, errors='raise', try_cast=True):
         return self._apply_columns(lambda x: func(x, other))
@@ -673,7 +677,8 @@ class SparseDataFrame(DataFrame):
 
         return self._constructor(
             new_series, index=index, columns=self.columns,
-            default_fill_value=self._default_fill_value).__finalize__(self)
+            default_fill_value=self._default_fill_value,
+            default_kind=self.default_kind).__finalize__(self)
 
     def _reindex_columns(self, columns, method, copy, level, fill_value=None,
                          limit=None, takeable=False):
@@ -693,7 +698,8 @@ class SparseDataFrame(DataFrame):
         sdict = {k: v for k, v in compat.iteritems(self) if k in columns}
         return self._constructor(
             sdict, index=self.index, columns=columns,
-            default_fill_value=self._default_fill_value).__finalize__(self)
+            default_fill_value=self._default_fill_value,
+            default_kind=self.default_kind).__finalize__(self)
 
     def _reindex_with_indexers(self, reindexers, method=None, fill_value=None,
                                limit=None, copy=False, allow_dups=False):
@@ -725,8 +731,10 @@ class SparseDataFrame(DataFrame):
             else:
                 new_arrays[col] = self[col]
 
-        return self._constructor(new_arrays, index=index,
-                                 columns=columns).__finalize__(self)
+        return self._constructor(
+            new_arrays, index=index, columns=columns,
+            default_fill_value=self.default_fill_value,
+            default_kind=self.default_kind).__finalize__(self)
 
     def _join_compat(self, other, on=None, how='left', lsuffix='', rsuffix='',
                      sort=False):

--- a/pandas/core/sparse/frame.py
+++ b/pandas/core/sparse/frame.py
@@ -333,8 +333,8 @@ class SparseDataFrame(DataFrame):
             default_fill_value=self.default_fill_value,
             default_kind=self.default_kind).__finalize__(self)
 
-    def astype(self, dtype):
-        return self._apply_columns(lambda x: x.astype(dtype))
+    def astype(self, dtype, **kwargs):
+        return self._apply_columns(lambda x: x.astype(dtype, **kwargs))
 
     def copy(self, deep=True):
         """
@@ -464,44 +464,6 @@ class SparseDataFrame(DataFrame):
 
         return series._get_value(index, takeable=takeable)
     _get_value.__doc__ = get_value.__doc__
-
-    def set_value(self, index, col, value, takeable=False):
-        """
-        Put single value at passed column and index
-
-        .. deprecated:: 0.21.0
-
-        Please use .at[] or .iat[] accessors.
-
-        Parameters
-        ----------
-        index : row label
-        col : column label
-        value : scalar value
-        takeable : interpret the index/col as indexers, default False
-
-        Notes
-        -----
-        This method *always* returns a new object. It is currently not
-        particularly efficient (and potentially very expensive) but is provided
-        for API compatibility with DataFrame
-
-        Returns
-        -------
-        frame : DataFrame
-        """
-        warnings.warn("set_value is deprecated and will be removed "
-                      "in a future release. Please use "
-                      ".at[] or .iat[] accessors instead", FutureWarning,
-                      stacklevel=2)
-        return self._set_value(index, col, value, takeable=takeable)
-
-    def _set_value(self, index, col, value, takeable=False):
-        dense = self.to_dense()._set_value(
-            index, col, value, takeable=takeable)
-        return dense.to_sparse(kind=self._default_kind,
-                               fill_value=self._default_fill_value)
-    _set_value.__doc__ = set_value.__doc__
 
     def _slice(self, slobj, axis=0, kind=None):
         if axis == 0:

--- a/pandas/core/sparse/series.py
+++ b/pandas/core/sparse/series.py
@@ -277,11 +277,13 @@ class SparseSeries(Series):
         else:
             fill_value = self.fill_value
 
-        # Assume: If result size matches, old sparse index is valid (ok???)
+        # Only reuse old sparse index if result size matches
+        # (fails e.g. for ~sparseseries)
         if np.size(result) == self.sp_index.npoints:
             sp_index = self.sp_index
         else:
             sp_index = None
+
         return self._constructor(result, index=self.index,
                                  sparse_index=sp_index,
                                  fill_value=fill_value,
@@ -490,10 +492,10 @@ class SparseSeries(Series):
                       "in a future release. Please use "
                       ".at[] or .iat[] accessors instead", FutureWarning,
                       stacklevel=2)
+        self._data = self._data.copy()
         return self._set_value(label, value, takeable=takeable)
 
     def _set_value(self, label, value, takeable=False):
-        self._data = self._data.copy()
         try:
             idx = self.index.get_loc(label)
         except KeyError:

--- a/pandas/tests/sparse/frame/test_frame.py
+++ b/pandas/tests/sparse/frame/test_frame.py
@@ -10,7 +10,6 @@ import pandas as pd
 
 from pandas import Series, DataFrame, bdate_range, Panel
 from pandas.core.indexes.datetimes import DatetimeIndex
-from pandas.errors import PerformanceWarning
 from pandas.tseries.offsets import BDay
 from pandas.util import testing as tm
 from pandas.compat import lrange
@@ -461,8 +460,7 @@ class TestSparseDataFrame(SharedWithSparse):
         # ok, as the index gets converted to object
         frame = self.frame.copy()
         with tm.assert_produces_warning(FutureWarning,
-                                        check_stacklevel=False,
-                                        ignore_extra=True):
+                                        check_stacklevel=False):
             res = frame.set_value('foobar', 'B', 1.5)
         assert res.index.dtype == 'object'
 
@@ -470,24 +468,20 @@ class TestSparseDataFrame(SharedWithSparse):
         res.index = res.index.astype(object)
 
         with tm.assert_produces_warning(FutureWarning,
-                                        check_stacklevel=False,
-                                        ignore_extra=True):
+                                        check_stacklevel=False):
             res = self.frame.set_value('foobar', 'B', 1.5)
         assert res.index[-1] == 'foobar'
         with tm.assert_produces_warning(FutureWarning,
-                                        check_stacklevel=False,
-                                        ignore_extra=True):
+                                        check_stacklevel=False):
             assert res.get_value('foobar', 'B') == 1.5
 
         with tm.assert_produces_warning(FutureWarning,
-                                        check_stacklevel=False,
-                                        ignore_extra=True):
+                                        check_stacklevel=False):
             res2 = res.set_value('foobar', 'qux', 1.5)
         tm.assert_index_equal(res2.columns,
                               pd.Index(list(self.frame.columns)))
         with tm.assert_produces_warning(FutureWarning,
-                                        check_stacklevel=False,
-                                        ignore_extra=True):
+                                        check_stacklevel=False):
             assert res2.get_value('foobar', 'qux') == 1.5
 
     def test_fancy_index_misc(self):
@@ -594,9 +588,8 @@ class TestSparseDataFrame(SharedWithSparse):
         # issuecomment-361696418
         # chained setitem used to cause consolidation
         sdf = pd.SparseDataFrame([[np.nan, 1], [2, np.nan]])
-        with tm.assert_produces_warning(PerformanceWarning):
-            with pd.option_context('mode.chained_assignment', None):
-                sdf[0][1] = 2
+        with pd.option_context('mode.chained_assignment', None):
+            sdf[0][1] = 2
         assert len(sdf._data.blocks) == 2
 
     def test_delitem(self):

--- a/pandas/tests/sparse/series/test_series.py
+++ b/pandas/tests/sparse/series/test_series.py
@@ -486,14 +486,12 @@ class TestSparseSeries(SharedWithSparse):
     def test_set_value(self):
         idx = self.btseries.index[7]
         with tm.assert_produces_warning(FutureWarning,
-                                        check_stacklevel=False,
-                                        ignore_extra=True):
+                                        check_stacklevel=False):
             self.btseries.set_value(idx, 0)
         assert self.btseries[idx] == 0
 
         with tm.assert_produces_warning(FutureWarning,
-                                        check_stacklevel=False,
-                                        ignore_extra=True):
+                                        check_stacklevel=False):
             self.iseries.set_value('foobar', 0)
         assert self.iseries.index[-1] == 'foobar'
         assert self.iseries['foobar'] == 0

--- a/pandas/tests/sparse/test_array.py
+++ b/pandas/tests/sparse/test_array.py
@@ -928,3 +928,9 @@ class TestSparseArrayAnalytics(object):
         sparse = SparseArray([1, -1, 0, -2], fill_value=0)
         result = SparseArray([2, 0, 1, -1], fill_value=1)
         tm.assert_sp_array_equal(np.add(sparse, 1), result)
+
+    def test_tolist(self):
+        sparse = SparseArray([1, np.nan, 2, np.nan, -2])
+        assert isinstance(sparse.tolist(), list)
+        tm.assert_numpy_array_equal(np.array(sparse.tolist()),
+                                    np.array([1, np.nan, 2, np.nan, -2]))

--- a/pandas/tests/sparse/test_format.py
+++ b/pandas/tests/sparse/test_format.py
@@ -8,7 +8,6 @@ import pandas.util.testing as tm
 from pandas.compat import (is_platform_windows,
                            is_platform_32bit)
 from pandas.core.config import option_context
-from pandas.errors import PerformanceWarning
 
 use_32bit_repr = is_platform_windows() or is_platform_32bit()
 
@@ -124,10 +123,9 @@ class TestSparseDataFrameFormatting(object):
         sdf = pd.SparseDataFrame([[np.nan, 1], [2, np.nan]])
         res = sdf.copy()
 
-        with tm.assert_produces_warning(PerformanceWarning):
-            # Ignore the warning
-            with pd.option_context('mode.chained_assignment', None):
-                sdf[0][1] = 2  # This line triggers the bug
+        # Ignore the warning
+        with pd.option_context('mode.chained_assignment', None):
+            sdf[0][1] = 2  # This line triggers the bug
 
         repr(sdf)
         tm.assert_sp_frame_equal(sdf, res)

--- a/pandas/tests/sparse/test_format.py
+++ b/pandas/tests/sparse/test_format.py
@@ -8,7 +8,7 @@ import pandas.util.testing as tm
 from pandas.compat import (is_platform_windows,
                            is_platform_32bit)
 from pandas.core.config import option_context
-
+from pandas.errors import PerformanceWarning
 
 use_32bit_repr = is_platform_windows() or is_platform_32bit()
 
@@ -124,9 +124,10 @@ class TestSparseDataFrameFormatting(object):
         sdf = pd.SparseDataFrame([[np.nan, 1], [2, np.nan]])
         res = sdf.copy()
 
-        # Ignore the warning
-        with pd.option_context('mode.chained_assignment', None):
-            sdf[0][1] = 2  # This line triggers the bug
+        with tm.assert_produces_warning(PerformanceWarning):
+            # Ignore the warning
+            with pd.option_context('mode.chained_assignment', None):
+                sdf[0][1] = 2  # This line triggers the bug
 
         repr(sdf)
         tm.assert_sp_frame_equal(sdf, res)

--- a/pandas/util/testing.py
+++ b/pandas/util/testing.py
@@ -2493,7 +2493,8 @@ class _AssertRaisesContextmanager(object):
 
 @contextmanager
 def assert_produces_warning(expected_warning=Warning, filter_level="always",
-                            clear=None, check_stacklevel=True):
+                            clear=None, check_stacklevel=True,
+                            ignore_extra=False):
     """
     Context manager for running code expected to either raise a specific
     warning, or not raise any warnings. Verifies that the code raises the
@@ -2530,6 +2531,8 @@ def assert_produces_warning(expected_warning=Warning, filter_level="always",
         If True, displays the line that called the function containing
         the warning to show were the function is called. Otherwise, the
         line that implements the function is displayed.
+    ignore_extra : bool, default False
+        If False, any extra, unexpected warnings are raised as errors.
 
     Examples
     --------
@@ -2596,6 +2599,7 @@ def assert_produces_warning(expected_warning=Warning, filter_level="always",
             msg = "Did not see expected warning of class {name!r}.".format(
                 name=expected_warning.__name__)
             assert saw_warning, msg
+    if not ignore_extra:
         assert not extra_warnings, ("Caused unexpected warning(s): {extra!r}."
                                     ).format(extra=extra_warnings)
 

--- a/pandas/util/testing.py
+++ b/pandas/util/testing.py
@@ -2493,8 +2493,7 @@ class _AssertRaisesContextmanager(object):
 
 @contextmanager
 def assert_produces_warning(expected_warning=Warning, filter_level="always",
-                            clear=None, check_stacklevel=True,
-                            ignore_extra=False):
+                            clear=None, check_stacklevel=True):
     """
     Context manager for running code expected to either raise a specific
     warning, or not raise any warnings. Verifies that the code raises the
@@ -2531,8 +2530,6 @@ def assert_produces_warning(expected_warning=Warning, filter_level="always",
         If True, displays the line that called the function containing
         the warning to show were the function is called. Otherwise, the
         line that implements the function is displayed.
-    ignore_extra : bool, default False
-        If False, any extra, unexpected warnings are raised as errors.
 
     Examples
     --------
@@ -2599,7 +2596,6 @@ def assert_produces_warning(expected_warning=Warning, filter_level="always",
             msg = "Did not see expected warning of class {name!r}.".format(
                 name=expected_warning.__name__)
             assert saw_warning, msg
-    if not ignore_extra:
         assert not extra_warnings, ("Caused unexpected warning(s): {extra!r}."
                                     ).format(extra=extra_warnings)
 


### PR DESCRIPTION
- [x] closes https://github.com/pandas-dev/pandas/issues/21818
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry

Works by as much as possible using `SparseBlock.setitem()` which calls into `SparseArray.set_values()`, which returns a new (replacement) `SparseArray` object.