### PR TITLE
DOC: Fix docstring for tsplot

### DIFF
--- a/pandas/plotting/_timeseries.py
+++ b/pandas/plotting/_timeseries.py
@@ -22,16 +22,22 @@ from pandas.plotting._converter import (TimeSeries_DateLocator,
 
 def tsplot(series, plotf, ax=None, **kwargs):
     """
-    Plots a Series on the given Matplotlib axes or the current axes
+    Plots a Series on the given Matplotlib axes or the current axis.
 
     Parameters
     ----------
-    axes : Axes
     series : Series
+    plotf : function
+        Function to plot the given Series.
+    ax : matplotlib axes object, optional, default=None
+        Axis to plot upon. If none, plots on current axis.
+    kwargs
+        Additional keywords arguments passed to plotf.
 
-    Notes
-    _____
-    Supports same kwargs as Axes.plot
+    Returns
+    -------
+    lines : list of matplotlib.lines.Line2D object
+        Resultant figure.
 
     """
     # Used inferred freq is possible, need a test case for inferred

--- a/pandas/plotting/_timeseries.py
+++ b/pandas/plotting/_timeseries.py
@@ -32,7 +32,7 @@ def tsplot(series, plotf, ax=None, **kwargs):
     ax : matplotlib axes object, optional, default=None
         Axis to plot upon. If none, plots on current axis.
     kwargs
-        Additional keywords arguments passed to plotf.
+        Additional keyword arguments passed to plotf.
 
     Returns
     -------

--- a/pandas/plotting/_timeseries.py
+++ b/pandas/plotting/_timeseries.py
@@ -22,7 +22,7 @@ from pandas.plotting._converter import (TimeSeries_DateLocator,
 
 def tsplot(series, plotf, ax=None, **kwargs):
     """
-    Plots a Series on the given Matplotlib axes or the current axis.
+    Plots a Series on the given Matplotlib axes or the current axes.
 
     Parameters
     ----------
@@ -30,7 +30,7 @@ def tsplot(series, plotf, ax=None, **kwargs):
     plotf : function
         Function to plot the given Series.
     ax : matplotlib axes object, optional, default=None
-        Axis to plot upon. If none, plots on current axis.
+        Axes to plot upon. If none, plots on current axis.
     kwargs
         Additional keyword arguments passed to plotf.
 


### PR DESCRIPTION
Browsing through pandas, I noticed a small plotting function who's docs were incomplete / out of date. This is a small update to the docstring for tsplot in plotting/_timeseries. 

- [ ] closes #xxxx
- [ ] tests added / passed
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry