### PR TITLE
DOC: slice_indexer correction + examples

### DIFF
--- a/doc/source/advanced.rst
+++ b/doc/source/advanced.rst
@@ -833,14 +833,14 @@ Of course if you need integer based selection, then use ``iloc``
 IntervalIndex
 ~~~~~~~~~~~~~
 
+.. versionadded:: 0.20.0
+
 :class:`IntervalIndex` together with its own dtype, ``interval`` as well as the
 :class:`Interval` scalar type,  allow first-class support in pandas for interval
 notation.
 
 The ``IntervalIndex`` allows some unique indexing and is also used as a
 return type for the categories in :func:`cut` and :func:`qcut`.
-
-.. versionadded:: 0.20.0
 
 .. warning::
 
@@ -862,7 +862,7 @@ selecting that particular interval.
    df.loc[2]
    df.loc[[2, 3]]
 
-If you select a lable *contained* within an interval, this will also select the interval.
+If you select a label *contained* within an interval, this will also select the interval.
 
 .. ipython:: python
 

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -3430,7 +3430,7 @@ class Index(IndexOpsMixin, PandasObject):
 
     def slice_indexer(self, start=None, end=None, step=None, kind=None):
         """
-        For an ordered Index, compute the slice indexer for input labels and
+        For an ordered index, compute the slice indexer for input labels and
         step
 
         Parameters
@@ -3444,11 +3444,23 @@ class Index(IndexOpsMixin, PandasObject):
 
         Returns
         -------
-        indexer : ndarray or slice
+        indexer : slice
 
         Notes
         -----
         This function assumes that the data is sorted, so use at your own peril
+
+        Examples
+        ---------
+        This is a method on all index types. For example you can do:
+
+        >>> idx = pd.Index(list('abcd'))
+        >>> idx.slice_indexer(start='b', end='c')
+        slice(1, 3)
+
+        >>> idx = pd.MultiIndex.from_arrays([list('abcd'), list('efgh')])
+        >>> idx.slice_indexer(start='b', end=('c', 'g'))
+        slice(1, 3)
         """
         start_slice, end_slice = self.slice_locs(start, end, step=step,
                                                  kind=kind)

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -3430,8 +3430,8 @@ class Index(IndexOpsMixin, PandasObject):
 
     def slice_indexer(self, start=None, end=None, step=None, kind=None):
         """
-        For an ordered index, compute the slice indexer for input labels and
-        step
+        For an ordered or unique index, compute the slice indexer for input
+        labels and step.
 
         Parameters
         ----------
@@ -3445,6 +3445,11 @@ class Index(IndexOpsMixin, PandasObject):
         Returns
         -------
         indexer : slice
+
+        Raises
+        ------
+        KeyError : If key does not exist, or key is not unique and index is
+            not ordered.
 
         Notes
         -----


### PR DESCRIPTION
The stated return value of ``Index.slice_indexer`` in the doc string is wrong, the method can only return slices. Also added some examples.

In addition, some very minor corrections on the user guide text on ``IntervalIndex`` (moved the versionadded to the chapter top +  a spelling correction).  EDIT: These are not related to the ``.slice_indexer`` changes, but are attached to this PR as the changes are very small.