### PR TITLE
DEPR: Deprecate the convert parameter completely

### DIFF
--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -2172,6 +2172,7 @@ class NDFrame(PandasObject, SelectionMixin):
             selecting rows, "1" means that we are selecting columns, etc.
         convert : bool, default True
             .. deprecated:: 0.21.0
+               In the future, negative indices will always be converted.
 
             Whether to convert negative indices into positive ones.
             For example, ``-1`` would map to the ``len(axis) - 1``.
@@ -2234,14 +2235,15 @@ class NDFrame(PandasObject, SelectionMixin):
         """
 
     @Appender(_shared_docs['take'])
-    def take(self, indices, axis=0, convert=True, is_copy=True, **kwargs):
-        nv.validate_take(tuple(), kwargs)
-
-        if not convert:
+    def take(self, indices, axis=0, convert=None, is_copy=True, **kwargs):
+        if convert is not None:
             msg = ("The 'convert' parameter is deprecated "
                    "and will be removed in a future version.")
             warnings.warn(msg, FutureWarning, stacklevel=2)
+        else:
+            convert = True
 
+        convert = nv.validate_take(tuple(), kwargs)
         return self._take(indices, axis=axis, convert=convert, is_copy=is_copy)
 
     def xs(self, key, axis=0, level=None, drop_level=True):

--- a/pandas/core/sparse/series.py
+++ b/pandas/core/sparse/series.py
@@ -387,7 +387,7 @@ class SparseSeries(Series):
         """
         label = self.index[i]
         if isinstance(label, Index):
-            return self.take(i, axis=axis, convert=True)
+            return self.take(i, axis=axis)
         else:
             return self._get_val_at(i)
 
@@ -629,14 +629,15 @@ class SparseSeries(Series):
                                  fill_value=self.fill_value).__finalize__(self)
 
     @Appender(generic._shared_docs['take'])
-    def take(self, indices, axis=0, convert=True, *args, **kwargs):
-        convert = nv.validate_take_with_convert(convert, args, kwargs)
-
-        if not convert:
+    def take(self, indices, axis=0, convert=None, *args, **kwargs):
+        if convert is not None:
             msg = ("The 'convert' parameter is deprecated "
                    "and will be removed in a future version.")
             warnings.warn(msg, FutureWarning, stacklevel=2)
+        else:
+            convert = True
 
+        nv.validate_take_with_convert(convert, args, kwargs)
         new_values = SparseArray.take(self.values, indices)
         new_index = self.index.take(indices)
         return self._constructor(new_values,

--- a/pandas/tests/frame/test_axis_select_reindex.py
+++ b/pandas/tests/frame/test_axis_select_reindex.py
@@ -945,6 +945,10 @@ class TestDataFrameSelectReindex(TestData):
             assert_frame_equal(result, expected)
 
             with tm.assert_produces_warning(FutureWarning):
+                result = df.take(order, convert=True, axis=0)
+                assert_frame_equal(result, expected)
+
+            with tm.assert_produces_warning(FutureWarning):
                 result = df.take(order, convert=False, axis=0)
                 assert_frame_equal(result, expected)
 

--- a/pandas/tests/sparse/test_series.py
+++ b/pandas/tests/sparse/test_series.py
@@ -529,27 +529,26 @@ class TestSparseSeries(SharedWithSparse):
         tm.assert_series_equal(sp.take([0, 1, 2, 3, 4]), exp)
 
         with tm.assert_produces_warning(FutureWarning):
+            sp.take([1, 5], convert=True)
+
+        with tm.assert_produces_warning(FutureWarning):
             sp.take([1, 5], convert=False)
 
     def test_numpy_take(self):
         sp = SparseSeries([1.0, 2.0, 3.0])
         indices = [1, 2]
 
-        # gh-17352: older versions of numpy don't properly
-        # pass in arguments to downstream .take() implementations.
-        warning = FutureWarning if _np_version_under1p12 else None
-
-        with tm.assert_produces_warning(warning, check_stacklevel=False):
+        if not _np_version_under1p12:
             tm.assert_series_equal(np.take(sp, indices, axis=0).to_dense(),
                                    np.take(sp.to_dense(), indices, axis=0))
 
-        msg = "the 'out' parameter is not supported"
-        tm.assert_raises_regex(ValueError, msg, np.take,
-                               sp, indices, out=np.empty(sp.shape))
+            msg = "the 'out' parameter is not supported"
+            tm.assert_raises_regex(ValueError, msg, np.take,
+                                   sp, indices, out=np.empty(sp.shape))
 
-        msg = "the 'mode' parameter is not supported"
-        tm.assert_raises_regex(ValueError, msg, np.take,
-                               sp, indices, mode='clip')
+            msg = "the 'mode' parameter is not supported"
+            tm.assert_raises_regex(ValueError, msg, np.take,
+                                   sp, indices, out=None, mode='clip')
 
     def test_setitem(self):
         self.bseries[5] = 7.


### PR DESCRIPTION
Previously, we weren't issuing a warning if the user happened to pass in the original default of `True`,
which would cause downstream code to break.

Closes #17828