### PR TITLE
BUG: merging with a boolean/int categorical column

### DIFF
--- a/doc/source/whatsnew/v0.21.0.txt
+++ b/doc/source/whatsnew/v0.21.0.txt
@@ -1010,6 +1010,7 @@ Categorical
 - Bug in :func:`Series.isin` when called with a categorical (:issue:`16639`)
 - Bug in the categorical constructor with empty values and categories causing the ``.categories`` to be an empty ``Float64Index`` rather than an empty ``Index`` with object dtype (:issue:`17248`)
 - Bug in categorical operations with :ref:`Series.cat <categorical.cat>` not preserving the original Series' name (:issue:`17509`)
+- Bug in :func:`DataFrame.merge` failing for categorical columns with boolean/int data types (:issue:`17187`)
 
 PyPy
 ^^^^

--- a/pandas/core/internals.py
+++ b/pandas/core/internals.py
@@ -5494,7 +5494,7 @@ class JoinUnit(object):
                     # preserve these for validation in _concat_compat
                     return self.block.values
 
-            if self.block.is_bool:
+            if self.block.is_bool and not self.block.is_categorical:
                 # External code requested filling/upcasting, bool values must
                 # be upcasted to object to avoid being upcasted to numeric.
                 values = self.block.astype(np.object_).values

--- a/pandas/tests/reshape/test_merge.py
+++ b/pandas/tests/reshape/test_merge.py
@@ -1547,6 +1547,8 @@ class TestMergeCategorical(object):
         assert_frame_equal(result_inner, expected_inner)
 
     def test_merging_with_boolean_cateorical_column(self):
+        # GH 17187
+        # merging with a boolean/int categorical column
         df1 = pd.DataFrame({'id': [1, 2, 3, 4],
                             'cat': [False, True, True, False]})
         df1['cat'] = df1['cat'].astype('category',
@@ -1561,6 +1563,8 @@ class TestMergeCategorical(object):
         assert_frame_equal(expected, result)
 
     def test_merging_with_integer_cateorical_column(self):
+        # GH 17187
+        # merging with a boolean/int categorical column
         df1 = pd.DataFrame({'id': [1, 2, 3, 4],
                             'cat': [2, 1, 1, 2]})
         df1['cat'] = df1['cat'].astype('category',
@@ -1575,6 +1579,8 @@ class TestMergeCategorical(object):
         assert_frame_equal(expected, result)
 
     def test_merging_with_string_cateorical_column(self):
+        # GH 17187
+        # merging with a boolean/int categorical column
         df1 = pd.DataFrame({'id': [1, 2, 3, 4],
                             'cat': ['False', 'True', 'True', 'False']})
         df1['cat'] = df1['cat'].astype('category',

--- a/pandas/tests/reshape/test_merge.py
+++ b/pandas/tests/reshape/test_merge.py
@@ -1546,6 +1546,49 @@ class TestMergeCategorical(object):
         result_inner = pd.merge(df, df2, how='inner', on=['date'])
         assert_frame_equal(result_inner, expected_inner)
 
+    def test_merging_with_boolean_cateorical_column(self):
+        df1 = pd.DataFrame({'id': [1, 2, 3, 4],
+                            'cat': [False, True, True, False]})
+        df1['cat'] = df1['cat'].astype('category',
+                                       categories=[True, False], ordered=True)
+        df2 = pd.DataFrame({'id': [2, 4], 'num': [1, 9]})
+        result = df1.merge(df2)
+        expected = pd.DataFrame({'id': [2, 4], 'cat': [True, False],
+                                 'num': [1, 9]})
+        expected['cat'] = expected['cat'].astype('category',
+                                                 categories=[True, False],
+                                                 ordered=True)
+        assert_frame_equal(expected, result)
+
+    def test_merging_with_integer_cateorical_column(self):
+        df1 = pd.DataFrame({'id': [1, 2, 3, 4],
+                            'cat': [2, 1, 1, 2]})
+        df1['cat'] = df1['cat'].astype('category',
+                                       categories=[1, 2], ordered=True)
+        df2 = pd.DataFrame({'id': [2, 4], 'num': [1, 9]})
+        result = df1.merge(df2)
+        expected = pd.DataFrame({'id': [2, 4], 'cat': [1, 2],
+                                 'num': [1, 9]})
+        expected['cat'] = expected['cat'].astype('category',
+                                                 categories=[1, 2],
+                                                 ordered=True)
+        assert_frame_equal(expected, result)
+
+    def test_merging_with_string_cateorical_column(self):
+        df1 = pd.DataFrame({'id': [1, 2, 3, 4],
+                            'cat': ['False', 'True', 'True', 'False']})
+        df1['cat'] = df1['cat'].astype('category',
+                                       categories=['True', 'False'],
+                                       ordered=True)
+        df2 = pd.DataFrame({'id': [2, 4], 'num': [1, 9]})
+        result = df1.merge(df2)
+        expected = pd.DataFrame({'id': [2, 4], 'cat': ['True', 'False'],
+                                 'num': [1, 9]})
+        expected['cat'] = expected['cat'].astype('category',
+                                                 categories=['True', 'False'],
+                                                 ordered=True)
+        assert_frame_equal(expected, result)
+
 
 @pytest.fixture
 def left_df():

--- a/pandas/tests/reshape/test_merge.py
+++ b/pandas/tests/reshape/test_merge.py
@@ -1546,52 +1546,27 @@ class TestMergeCategorical(object):
         result_inner = pd.merge(df, df2, how='inner', on=['date'])
         assert_frame_equal(result_inner, expected_inner)
 
-    def test_merging_with_boolean_cateorical_column(self):
+    @pytest.mark.parametrize('category_column,categories,expected_categories',
+                             [([False, True, True, False], [True, False],
+                               [True, False]),
+                              ([2, 1, 1, 2], [1, 2], [1, 2]),
+                              (['False', 'True', 'True', 'False'],
+                               ['True', 'False'], ['True', 'False'])])
+    def test_merging_with_bool_or_int_cateorical_column(self, category_column,
+                                                        categories,
+                                                        expected_categories):
         # GH 17187
         # merging with a boolean/int categorical column
         df1 = pd.DataFrame({'id': [1, 2, 3, 4],
-                            'cat': [False, True, True, False]})
+                            'cat': category_column})
         df1['cat'] = df1['cat'].astype('category',
-                                       categories=[True, False], ordered=True)
+                                       categories=categories, ordered=True)
         df2 = pd.DataFrame({'id': [2, 4], 'num': [1, 9]})
         result = df1.merge(df2)
-        expected = pd.DataFrame({'id': [2, 4], 'cat': [True, False],
+        expected = pd.DataFrame({'id': [2, 4], 'cat': expected_categories,
                                  'num': [1, 9]})
         expected['cat'] = expected['cat'].astype('category',
-                                                 categories=[True, False],
-                                                 ordered=True)
-        assert_frame_equal(expected, result)
-
-    def test_merging_with_integer_cateorical_column(self):
-        # GH 17187
-        # merging with a boolean/int categorical column
-        df1 = pd.DataFrame({'id': [1, 2, 3, 4],
-                            'cat': [2, 1, 1, 2]})
-        df1['cat'] = df1['cat'].astype('category',
-                                       categories=[1, 2], ordered=True)
-        df2 = pd.DataFrame({'id': [2, 4], 'num': [1, 9]})
-        result = df1.merge(df2)
-        expected = pd.DataFrame({'id': [2, 4], 'cat': [1, 2],
-                                 'num': [1, 9]})
-        expected['cat'] = expected['cat'].astype('category',
-                                                 categories=[1, 2],
-                                                 ordered=True)
-        assert_frame_equal(expected, result)
-
-    def test_merging_with_string_cateorical_column(self):
-        # GH 17187
-        # merging with a boolean/int categorical column
-        df1 = pd.DataFrame({'id': [1, 2, 3, 4],
-                            'cat': ['False', 'True', 'True', 'False']})
-        df1['cat'] = df1['cat'].astype('category',
-                                       categories=['True', 'False'],
-                                       ordered=True)
-        df2 = pd.DataFrame({'id': [2, 4], 'num': [1, 9]})
-        result = df1.merge(df2)
-        expected = pd.DataFrame({'id': [2, 4], 'cat': ['True', 'False'],
-                                 'num': [1, 9]})
-        expected['cat'] = expected['cat'].astype('category',
-                                                 categories=['True', 'False'],
+                                                 categories=categories,
                                                  ordered=True)
         assert_frame_equal(expected, result)
 


### PR DESCRIPTION
Additional check prevents trying to change types of categorical blocks.

- [x] closes #17187
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry
