### PR TITLE
API: Deprecate renamae_axis and reindex_axis

### DIFF
--- a/doc/source/basics.rst
+++ b/doc/source/basics.rst
@@ -1201,8 +1201,11 @@ With a DataFrame, you can simultaneously reindex the index and columns:
    df
    df.reindex(index=['c', 'f', 'b'], columns=['three', 'two', 'one'])
 
-For convenience, you may utilize the :meth:`~Series.reindex_axis` method, which
-takes the labels and a keyword ``axis`` parameter.
+You may also use ``reindex`` with an ``axis`` keyword:
+
+.. ipython:: python
+
+   df.reindex(index=['c', 'f', 'b'], axis='index')
 
 Note that the ``Index`` objects containing the actual axis labels can be
 **shared** between objects. So if we have a Series and a DataFrame, the

--- a/doc/source/whatsnew/v0.21.0.txt
+++ b/doc/source/whatsnew/v0.21.0.txt
@@ -810,6 +810,8 @@ Deprecations
 - ``.get_value`` and ``.set_value`` on ``Series``, ``DataFrame``, ``Panel``, ``SparseSeries``, and ``SparseDataFrame`` are deprecated in favor of using ``.iat[]`` or ``.at[]`` accessors (:issue:`15269`)
 - Passing a non-existent column in ``.to_excel(..., columns=)`` is deprecated and will raise a ``KeyError`` in the future (:issue:`17295`)
 - ``raise_on_error`` parameter to :func:`Series.where`, :func:`Series.mask`, :func:`DataFrame.where`, :func:`DataFrame.mask` is deprecated, in favor of ``errors=`` (:issue:`14968`)
+- Using :meth:`DataFrame.rename_axis` and :meth:`Series.rename_axis` to alter index or column *labels* is now deprecated in favor of using ``.rename``. ``rename_axis`` may still be used to alter the name of the index or columns (:issue:`17833`).
+- :meth:`~NDFrame.reindex_axis` has been deprecated in favor of :meth:`~NDFrame.reindex`. See :ref`here` <whatsnew_0210.enhancements.rename_reindex_axis> for more (:issue:`17833`).
 
 .. _whatsnew_0210.deprecations.select:
 

--- a/doc/source/whatsnew/v0.21.0.txt
+++ b/doc/source/whatsnew/v0.21.0.txt
@@ -1000,6 +1000,7 @@ Reshaping
 - Bug in :func:`unique` where checking a tuple of strings raised a ``TypeError`` (:issue:`17108`)
 - Bug in :func:`concat` where order of result index was unpredictable if it contained non-comparable elements (:issue:`17344`)
 - Fixes regression when sorting by multiple columns on a ``datetime64`` dtype ``Series`` with ``NaT`` values (:issue:`16836`)
+- Bug in :fun:`pivot_table` where the result's columns did not preserve the categorical dtype of ``columns`` when ``dropna`` was ``False`` (:issue:`17842`)
 
 Numeric
 ^^^^^^^

--- a/doc/source/whatsnew/v0.21.0.txt
+++ b/doc/source/whatsnew/v0.21.0.txt
@@ -811,7 +811,7 @@ Deprecations
 - Passing a non-existent column in ``.to_excel(..., columns=)`` is deprecated and will raise a ``KeyError`` in the future (:issue:`17295`)
 - ``raise_on_error`` parameter to :func:`Series.where`, :func:`Series.mask`, :func:`DataFrame.where`, :func:`DataFrame.mask` is deprecated, in favor of ``errors=`` (:issue:`14968`)
 - Using :meth:`DataFrame.rename_axis` and :meth:`Series.rename_axis` to alter index or column *labels* is now deprecated in favor of using ``.rename``. ``rename_axis`` may still be used to alter the name of the index or columns (:issue:`17833`).
-- :meth:`~NDFrame.reindex_axis` has been deprecated in favor of :meth:`~NDFrame.reindex`. See :ref`here` <whatsnew_0210.enhancements.rename_reindex_axis> for more (:issue:`17833`).
+- :meth:`~DataFrame.reindex_axis` has been deprecated in favor of :meth:`~DataFrame.reindex`. See :ref`here` <whatsnew_0210.enhancements.rename_reindex_axis> for more (:issue:`17833`).
 
 .. _whatsnew_0210.deprecations.select:
 

--- a/pandas/core/computation/align.py
+++ b/pandas/core/computation/align.py
@@ -89,6 +89,7 @@ def _align_core(terms):
         for axis, items in zip(range(ndim), axes):
             ti = terms[i].value
 
+            # TODO: handle this for when reindex_axis is removed...
             if hasattr(ti, 'reindex_axis'):
                 transpose = isinstance(ti, pd.Series) and naxes > 1
                 reindexer = axes[naxes - 1] if transpose else items
@@ -104,11 +105,7 @@ def _align_core(terms):
                          ).format(axis=axis, term=terms[i].name, ordm=ordm)
                     warnings.warn(w, category=PerformanceWarning, stacklevel=6)
 
-                if transpose:
-                    f = partial(ti.reindex, index=reindexer, copy=False)
-                else:
-                    f = partial(ti.reindex_axis, reindexer, axis=axis,
-                                copy=False)
+                f = partial(ti.reindex, reindexer, axis=axis, copy=False)
 
                 terms[i].update(f())
 

--- a/pandas/core/computation/align.py
+++ b/pandas/core/computation/align.py
@@ -89,8 +89,7 @@ def _align_core(terms):
         for axis, items in zip(range(ndim), axes):
             ti = terms[i].value
 
-            # TODO: handle this for when reindex_axis is removed...
-            if hasattr(ti, 'reindex_axis'):
+            if hasattr(ti, 'reindex'):
                 transpose = isinstance(ti, pd.Series) and naxes > 1
                 reindexer = axes[naxes - 1] if transpose else items
 

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -2736,7 +2736,7 @@ class DataFrame(NDFrame):
                 if isinstance(loc, (slice, Series, np.ndarray, Index)):
                     cols = maybe_droplevels(self.columns[loc], key)
                     if len(cols) and not cols.equals(value.columns):
-                        value = value.reindex_axis(cols, axis=1)
+                        value = value.reindex(cols, axis=1)
             # now align rows
             value = reindexer(value).T
 

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -2913,7 +2913,8 @@ class DataFrame(NDFrame):
         axes = self._validate_axis_style_args(labels, 'labels',
                                               axes=[index, columns],
                                               axis=axis, method_name='reindex')
-        return super(DataFrame, self).reindex(**axes, **kwargs)
+        kwargs.update(axes)
+        return super(DataFrame, self).reindex(**kwargs)
 
     @Appender(_shared_docs['reindex_axis'] % _shared_doc_kwargs)
     def reindex_axis(self, labels, axis=0, method=None, level=None, copy=True,
@@ -3001,7 +3002,8 @@ class DataFrame(NDFrame):
         axes = self._validate_axis_style_args(mapper, 'mapper',
                                               axes=[index, columns],
                                               axis=axis, method_name='rename')
-        return super(DataFrame, self).rename(**axes, **kwargs)
+        kwargs.update(axes)
+        return super(DataFrame, self).rename(**kwargs)
 
     @Appender(_shared_docs['fillna'] % _shared_doc_kwargs)
     def fillna(self, value=None, method=None, axis=None, inplace=False,

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -65,7 +65,6 @@ from pandas.core.common import (_try_sort,
                                 _values_from_object,
                                 _maybe_box_datetimelike,
                                 _dict_compat,
-                                _all_not_none,
                                 standardize_mapping)
 from pandas.core.generic import NDFrame, _shared_docs
 from pandas.core.index import (Index, MultiIndex, _ensure_index,
@@ -2783,47 +2782,6 @@ class DataFrame(NDFrame):
 
         return np.atleast_2d(np.asarray(value))
 
-    def _validate_axis_style_args(self, arg, arg_name, index, columns,
-                                  axis, method_name):
-        if axis is not None:
-            # Using "axis" style, along with a positional arg
-            # Both index and columns should be None then
-            axis = self._get_axis_name(axis)
-            if index is not None or columns is not None:
-                msg = (
-                    "Can't specify both 'axis' and 'index' or 'columns'. "
-                    "Specify either\n"
-                    "\t.{method_name}.rename({arg_name}, axis=axis), or\n"
-                    "\t.{method_name}.rename(index=index, columns=columns)"
-                ).format(arg_name=arg_name, method_name=method_name)
-                raise TypeError(msg)
-            if axis == 'index':
-                index = arg
-            elif axis == 'columns':
-                columns = arg
-
-        elif _all_not_none(arg, index, columns):
-            msg = (
-                "Cannot specify all of '{arg_name}', 'index', and 'columns'. "
-                "Specify either {arg_name} and 'axis', or 'index' and "
-                "'columns'."
-            ).format(arg_name=arg_name)
-            raise TypeError(msg)
-
-        elif _all_not_none(arg, index):
-            # This is the "ambiguous" case, so emit a warning
-            msg = (
-                "Interpreting call to '.{method_name}(a, b)' as "
-                "'.{method_name}(index=a, columns=b)'. "
-                "Use keyword arguments to remove any ambiguity."
-            ).format(method_name=method_name)
-            warnings.warn(msg, stacklevel=3)
-            index, columns = arg, index
-        elif index is None:
-            # This is for the default axis, like reindex([0, 1])
-            index = arg
-        return index, columns
-
     @property
     def _series(self):
         result = {}
@@ -2952,11 +2910,10 @@ class DataFrame(NDFrame):
     @Appender(_shared_docs['reindex'] % _shared_doc_kwargs)
     def reindex(self, labels=None, index=None, columns=None, axis=None,
                 **kwargs):
-        index, columns = self._validate_axis_style_args(labels, 'labels',
-                                                        index, columns,
-                                                        axis, 'reindex')
-        return super(DataFrame, self).reindex(index=index, columns=columns,
-                                              **kwargs)
+        axes = self._validate_axis_style_args(labels, 'labels',
+                                              axes=[index, columns],
+                                              axis=axis, method_name='reindex')
+        return super(DataFrame, self).reindex(**axes, **kwargs)
 
     @Appender(_shared_docs['reindex_axis'] % _shared_doc_kwargs)
     def reindex_axis(self, labels, axis=0, method=None, level=None, copy=True,
@@ -3041,11 +2998,10 @@ class DataFrame(NDFrame):
         2  2  5
         4  3  6
         """
-        index, columns = self._validate_axis_style_args(mapper, 'mapper',
-                                                        index, columns,
-                                                        axis, 'rename')
-        return super(DataFrame, self).rename(index=index, columns=columns,
-                                             **kwargs)
+        axes = self._validate_axis_style_args(mapper, 'mapper',
+                                              axes=[index, columns],
+                                              axis=axis, method_name='rename')
+        return super(DataFrame, self).rename(**axes, **kwargs)
 
     @Appender(_shared_docs['fillna'] % _shared_doc_kwargs)
     def fillna(self, value=None, method=None, axis=None, inplace=False,

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -744,10 +744,10 @@ class NDFrame(PandasObject, SelectionMixin):
             axis = self._get_axis_name(axis)
             if any(x is not None for x in axes):
                 msg = (
-                    "Can't specify both 'axis' and {aliases}"
+                    "Can't specify both 'axis' and {aliases}. "
                     "Specify either\n"
                     "\t.{method_name}({arg_name}, axis=axis), or\n"
-                    "\t.{method_name}(index=index, columns=columns)"  # TODO
+                    "\t.{method_name}(index=index, columns=columns)"
                 ).format(arg_name=arg_name, method_name=method_name,
                          aliases=aliases)
                 raise TypeError(msg)
@@ -755,7 +755,7 @@ class NDFrame(PandasObject, SelectionMixin):
 
         elif _all_not_none(arg, *axes):
             msg = (
-                "Cannot specify all of '{arg_name}', {aliases}"
+                "Cannot specify all of '{arg_name}', {aliases}. "
                 "Specify either {arg_name} and 'axis', or {aliases}."
             ).format(arg_name=arg_name, aliases=aliases)
             raise TypeError(msg)

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -130,7 +130,7 @@ class NDFrame(PandasObject, SelectionMixin):
 
             if axes is not None:
                 for i, ax in enumerate(axes):
-                    data = data.reindex(ax, axis=i)
+                    data = data.reindex_axis(ax, axis=i)
 
         object.__setattr__(self, 'is_copy', None)
         object.__setattr__(self, '_data', data)
@@ -963,7 +963,7 @@ class NDFrame(PandasObject, SelectionMixin):
 
         See Also
         --------
-        pandas.NDFrame.rename
+        pandas.Series.rename, pandas.DataFrame.rename
         pandas.Index.rename
 
         Examples

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -29,7 +29,8 @@ from pandas.core.dtypes.cast import maybe_promote, maybe_upcast_putmask
 from pandas.core.dtypes.missing import isna, notna
 from pandas.core.dtypes.generic import ABCSeries, ABCPanel, ABCDataFrame
 
-from pandas.core.common import (_values_from_object,
+from pandas.core.common import (_all_not_none,
+                                _values_from_object,
                                 _maybe_box_datetimelike,
                                 SettingWithCopyError, SettingWithCopyWarning,
                                 AbstractMethodError)
@@ -728,6 +729,51 @@ class NDFrame(PandasObject, SelectionMixin):
         labels = result._data.axes[axis]
         result._data.set_axis(axis, labels.swaplevel(i, j))
         return result
+
+    def _validate_axis_style_args(self, arg, arg_name, axes,
+                                  axis, method_name):
+        out = {}
+        for i, value in enumerate(axes):
+            if value is not None:
+                out[self._AXIS_NAMES[i]] = value
+
+        aliases = ', '.join(self._AXIS_NAMES.values())
+        if axis is not None:
+            # Using "axis" style, along with a positional arg
+            # Both index and columns should be None then
+            axis = self._get_axis_name(axis)
+            if any(x is not None for x in axes):
+                msg = (
+                    "Can't specify both 'axis' and {aliases}"
+                    "Specify either\n"
+                    "\t.{method_name}({arg_name}, axis=axis), or\n"
+                    "\t.{method_name}(index=index, columns=columns)"  # TODO
+                ).format(arg_name=arg_name, method_name=method_name,
+                         aliases=aliases)
+                raise TypeError(msg)
+            out[axis] = arg
+
+        elif _all_not_none(arg, *axes):
+            msg = (
+                "Cannot specify all of '{arg_name}', {aliases}"
+                "Specify either {arg_name} and 'axis', or {aliases}."
+            ).format(arg_name=arg_name, aliases=aliases)
+            raise TypeError(msg)
+
+        elif _all_not_none(arg, axes[0]):
+            # This is the "ambiguous" case, so emit a warning
+            msg = (
+                "Interpreting call to '.{method_name}(a, b)' as "
+                "'.{method_name}(index=a, columns=b)'. "  # TODO
+                "Use keyword arguments to remove any ambiguity."
+            ).format(method_name=method_name)
+            warnings.warn(msg, stacklevel=3)
+            out[self._AXIS_ORDERS[0]] = arg
+            out[self._AXIS_ORDERS[1]] = axes[0]
+        elif axes[0] is None:
+            # This is for the default axis, like reindex([0, 1])
+            out[self._AXIS_ORDERS[0]] = arg
+        return out
 
     # ----------------------------------------------------------------------
     # Rename

--- a/pandas/core/groupby.py
+++ b/pandas/core/groupby.py
@@ -901,7 +901,7 @@ class _GroupBy(PandasObject, SelectionMixin):
                         result.index.get_indexer_for(ax.values))
                     result = result.take(indexer, axis=self.axis)
                 else:
-                    result = result.reindex_axis(ax, axis=self.axis)
+                    result = result.reindex(ax, axis=self.axis)
 
         elif self.group_keys:
 
@@ -4580,7 +4580,7 @@ class NDFrameSplitter(DataSplitter):
 
         # this is sort of wasteful but...
         sorted_axis = data.axes[self.axis].take(self.sort_idx)
-        sorted_data = data.reindex_axis(sorted_axis, axis=self.axis)
+        sorted_data = data.reindex(sorted_axis, axis=self.axis)
 
         return sorted_data
 

--- a/pandas/core/groupby.py
+++ b/pandas/core/groupby.py
@@ -4580,7 +4580,7 @@ class NDFrameSplitter(DataSplitter):
 
         # this is sort of wasteful but...
         sorted_axis = data.axes[self.axis].take(self.sort_idx)
-        sorted_data = data.reindex(sorted_axis, axis=self.axis)
+        sorted_data = data.reindex_axis(sorted_axis, axis=self.axis)
 
         return sorted_data
 

--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -368,7 +368,7 @@ class _NDFrameIndexer(object):
                     # so the object is the same
                     index = self.obj._get_axis(i)
                     labels = index.insert(len(index), key)
-                    self.obj._data = self.obj.reindex_axis(labels, i)._data
+                    self.obj._data = self.obj.reindex(labels, axis=i)._data
                     self.obj._maybe_update_cacher(clear=True)
                     self.obj.is_copy = None
 
@@ -1132,7 +1132,7 @@ class _NDFrameIndexer(object):
             if labels.is_unique and Index(keyarr).is_unique:
 
                 try:
-                    return self.obj.reindex_axis(keyarr, axis=axis)
+                    return self.obj.reindex(keyarr, axis=axis)
                 except AttributeError:
 
                     # Series

--- a/pandas/core/internals.py
+++ b/pandas/core/internals.py
@@ -3283,8 +3283,8 @@ class BlockManager(PandasObject):
 
                 for k, obj in aligned_args.items():
                     axis = getattr(obj, '_info_axis_number', 0)
-                    kwargs[k] = obj.reindex_axis(b_items, axis=axis,
-                                                 copy=align_copy)
+                    kwargs[k] = obj.reindex(b_items, axis=axis,
+                                            copy=align_copy)
 
             kwargs['mgr'] = self
             applied = getattr(b, f)(**kwargs)

--- a/pandas/core/panel.py
+++ b/pandas/core/panel.py
@@ -722,7 +722,7 @@ class Panel(NDFrame):
             cond = mask == per_slice
 
         new_ax = self._get_axis(axis)[cond]
-        result = self.reindex_axis(new_ax, axis=axis)
+        result = self.reindex(new_ax, axis=axis)
         if inplace:
             self._update_inplace(result)
         else:

--- a/pandas/core/panel.py
+++ b/pandas/core/panel.py
@@ -1207,6 +1207,9 @@ class Panel(NDFrame):
         axes = self._validate_axis_style_args(
             labels, 'labels', axes=[items, major_axis, minor_axis],
             axis=axis, method_name='reindex')
+        if self.ndim >= 4:
+            # Hack for PanelND
+            axes = {}
         return super(Panel, self).reindex(**axes, **kwargs)
 
     @Appender(_shared_docs['rename'] % _shared_doc_kwargs)

--- a/pandas/core/panel.py
+++ b/pandas/core/panel.py
@@ -722,7 +722,7 @@ class Panel(NDFrame):
             cond = mask == per_slice
 
         new_ax = self._get_axis(axis)[cond]
-        result = self.reindex(new_ax, axis=axis)
+        result = self.reindex_axis(new_ax, axis=axis)
         if inplace:
             self._update_inplace(result)
         else:
@@ -1197,13 +1197,17 @@ class Panel(NDFrame):
         return self._construct_return_type(result, axes)
 
     @Appender(_shared_docs['reindex'] % _shared_doc_kwargs)
-    def reindex(self, items=None, major_axis=None, minor_axis=None, **kwargs):
+    def reindex(self, labels=None,
+                items=None, major_axis=None, minor_axis=None,
+                axis=None, **kwargs):
         major_axis = (major_axis if major_axis is not None else
                       kwargs.pop('major', None))
         minor_axis = (minor_axis if minor_axis is not None else
                       kwargs.pop('minor', None))
-        return super(Panel, self).reindex(items=items, major_axis=major_axis,
-                                          minor_axis=minor_axis, **kwargs)
+        axes = self._validate_axis_style_args(
+            labels, 'labels', axes=[items, major_axis, minor_axis],
+            axis=axis, method_name='reindex')
+        return super(Panel, self).reindex(**axes, **kwargs)
 
     @Appender(_shared_docs['rename'] % _shared_doc_kwargs)
     def rename(self, items=None, major_axis=None, minor_axis=None, **kwargs):

--- a/pandas/core/panel.py
+++ b/pandas/core/panel.py
@@ -1210,7 +1210,8 @@ class Panel(NDFrame):
         if self.ndim >= 4:
             # Hack for PanelND
             axes = {}
-        return super(Panel, self).reindex(**axes, **kwargs)
+        kwargs.update(axes)
+        return super(Panel, self).reindex(**kwargs)
 
     @Appender(_shared_docs['rename'] % _shared_doc_kwargs)
     def rename(self, items=None, major_axis=None, minor_axis=None, **kwargs):

--- a/pandas/core/panel4d.py
+++ b/pandas/core/panel4d.py
@@ -57,4 +57,17 @@ def panel4d_init(self, data=None, labels=None, items=None, major_axis=None,
                     dtype=dtype)
 
 
+def panel4d_reindex(self, labs=None, labels=None, items=None, major_axis=None,
+                    minor_axis=None, axis=None, **kwargs):
+    # Hack for reindex_axis deprecation
+    # Ha, we used labels for two different things
+    # I think this will work still.
+    axes = self._validate_axis_style_args(
+        labs, 'labels',
+        axes=[labels, items, major_axis, minor_axis],
+        axis=axis, method_name='reindex')
+    return super(Panel, self).reindex(**axes, **kwargs)
+
+
 Panel4D.__init__ = panel4d_init
+Panel4D.reindex = panel4d_reindex

--- a/pandas/core/panel4d.py
+++ b/pandas/core/panel4d.py
@@ -66,7 +66,8 @@ def panel4d_reindex(self, labs=None, labels=None, items=None, major_axis=None,
         labs, 'labels',
         axes=[labels, items, major_axis, minor_axis],
         axis=axis, method_name='reindex')
-    return super(Panel, self).reindex(**axes, **kwargs)
+    kwargs.update(axes)
+    return super(Panel, self).reindex(**kwargs)
 
 
 Panel4D.__init__ = panel4d_init

--- a/pandas/core/reshape/pivot.py
+++ b/pandas/core/reshape/pivot.py
@@ -101,14 +101,14 @@ def pivot_table(data, values=None, index=None, columns=None, aggfunc='mean',
         try:
             m = MultiIndex.from_arrays(cartesian_product(table.index.levels),
                                        names=table.index.names)
-            table = table.reindex_axis(m, axis=0)
+            table = table.reindex(m, axis=0)
         except AttributeError:
             pass  # it's a single level
 
         try:
             m = MultiIndex.from_arrays(cartesian_product(table.columns.levels),
                                        names=table.columns.names)
-            table = table.reindex_axis(m, axis=1)
+            table = table.reindex(m, axis=1)
         except AttributeError:
             pass  # it's a single level or a series
 

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -2615,6 +2615,10 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
         """ for compatibility with higher dims """
         if axis != 0:
             raise ValueError("cannot reindex series on non-zero axis!")
+        msg = ("'.reindex_axis' is deprecated and will be removed in a future "
+               "version. Use '.reindex' instead.")
+        warnings.warn(msg, FutureWarning, stacklevel=2)
+
         return self.reindex(index=labels, **kwargs)
 
     def memory_usage(self, index=True, deep=False):

--- a/pandas/core/sparse/scipy_sparse.py
+++ b/pandas/core/sparse/scipy_sparse.py
@@ -134,5 +134,5 @@ def _coo_to_sparse_series(A, dense_index=False):
         i = range(A.shape[0])
         j = range(A.shape[1])
         ind = MultiIndex.from_product([i, j])
-        s = s.reindex_axis(ind)
+        s = s.reindex(ind)
     return s

--- a/pandas/io/pytables.py
+++ b/pandas/io/pytables.py
@@ -1040,7 +1040,7 @@ class HDFStore(StringMixin):
             dc = data_columns if k == selector else None
 
             # compute the val
-            val = value.reindex_axis(v, axis=axis)
+            val = value.reindex(v, axis=axis)
 
             self.append(k, val, data_columns=dc, **kwargs)
 

--- a/pandas/io/pytables.py
+++ b/pandas/io/pytables.py
@@ -3493,7 +3493,7 @@ class Table(Fixed):
             data_columns = self.validate_data_columns(
                 data_columns, min_itemsize)
             if len(data_columns):
-                mgr = block_obj.reindex_axis(
+                mgr = block_obj.reindex(
                     Index(axis_labels).difference(Index(data_columns)),
                     axis=axis
                 )._data
@@ -3501,7 +3501,7 @@ class Table(Fixed):
                 blocks = list(mgr.blocks)
                 blk_items = get_blk_items(mgr, blocks)
                 for c in data_columns:
-                    mgr = block_obj.reindex_axis([c], axis=axis)._data
+                    mgr = block_obj.reindex([c], axis=axis)._data
                     blocks.extend(mgr.blocks)
                     blk_items.extend(get_blk_items(mgr, mgr.blocks))
 

--- a/pandas/plotting/_core.py
+++ b/pandas/plotting/_core.py
@@ -697,7 +697,7 @@ class MPLPlot(object):
         from pandas import DataFrame, Series
 
         def match_labels(data, e):
-            e = e.reindex_axis(data.index)
+            e = e.reindex(data.index)
             return e
 
         # key-matched DataFrame

--- a/pandas/tests/frame/test_alter_axes.py
+++ b/pandas/tests/frame/test_alter_axes.py
@@ -436,6 +436,25 @@ class TestDataFrameAlterAxes(TestData):
         assert no_return is None
         assert_frame_equal(result, expected)
 
+    def test_rename_axis_warns(self):
+        # https://github.com/pandas-dev/pandas/issues/17833
+        df = pd.DataFrame({"A": [1, 2], "B": [1, 2]})
+        with tm.assert_produces_warning(FutureWarning) as w:
+            df.rename_axis(id, axis=0)
+            assert 'rename' in str(w[0].message)
+
+        with tm.assert_produces_warning(FutureWarning) as w:
+            df.rename_axis({0: 10, 1: 20}, axis=0)
+            assert 'rename' in str(w[0].message)
+
+        with tm.assert_produces_warning(FutureWarning) as w:
+            df.rename_axis(id, axis=1)
+            assert 'rename' in str(w[0].message)
+
+        with tm.assert_produces_warning(FutureWarning) as w:
+            df['A'].rename_axis(id)
+            assert 'rename' in str(w[0].message)
+
     def test_rename_multiindex(self):
 
         tuples_index = [('foo1', 'bar1'), ('foo2', 'bar2')]

--- a/pandas/tests/frame/test_axis_select_reindex.py
+++ b/pandas/tests/frame/test_axis_select_reindex.py
@@ -418,11 +418,13 @@ class TestDataFrameSelectReindex(TestData):
         assert_frame_equal(result, expected)
 
         # reindex_axis
-        result = df.reindex_axis(lrange(15), fill_value=0., axis=0)
+        with tm.assert_produces_warning(FutureWarning):
+            result = df.reindex_axis(lrange(15), fill_value=0., axis=0)
         expected = df.reindex(lrange(15)).fillna(0)
         assert_frame_equal(result, expected)
 
-        result = df.reindex_axis(lrange(5), fill_value=0., axis=1)
+        with tm.assert_produces_warning(FutureWarning):
+            result = df.reindex_axis(lrange(5), fill_value=0., axis=1)
         expected = df.reindex(columns=lrange(5)).fillna(0)
         assert_frame_equal(result, expected)
 
@@ -1030,12 +1032,16 @@ class TestDataFrameSelectReindex(TestData):
 
     def test_reindex_axis(self):
         cols = ['A', 'B', 'E']
-        reindexed1 = self.intframe.reindex_axis(cols, axis=1)
+        with tm.assert_produces_warning(FutureWarning) as m:
+            reindexed1 = self.intframe.reindex_axis(cols, axis=1)
+            assert 'reindex' in str(m[0].message)
         reindexed2 = self.intframe.reindex(columns=cols)
         assert_frame_equal(reindexed1, reindexed2)
 
         rows = self.intframe.index[0:5]
-        reindexed1 = self.intframe.reindex_axis(rows, axis=0)
+        with tm.assert_produces_warning(FutureWarning) as m:
+            reindexed1 = self.intframe.reindex_axis(rows, axis=0)
+            assert 'reindex' in str(m[0].message)
         reindexed2 = self.intframe.reindex(index=rows)
         assert_frame_equal(reindexed1, reindexed2)
 
@@ -1043,7 +1049,9 @@ class TestDataFrameSelectReindex(TestData):
 
         # no-op case
         cols = self.frame.columns.copy()
-        newFrame = self.frame.reindex_axis(cols, axis=1)
+        with tm.assert_produces_warning(FutureWarning) as m:
+            newFrame = self.frame.reindex_axis(cols, axis=1)
+            assert 'reindex' in str(m[0].message)
         assert_frame_equal(newFrame, self.frame)
 
     def test_reindex_with_nans(self):

--- a/pandas/tests/reshape/test_pivot.py
+++ b/pandas/tests/reshape/test_pivot.py
@@ -116,7 +116,9 @@ class TestPivotTable(object):
 
         result_false = df.pivot_table(index='B', columns='A', values='C',
                                       dropna=False)
-        expected_columns = Series(['a', 'b', 'c', 'd'], name='A')
+        expected_columns = (
+            Series(['a', 'b', 'c', 'd'], name='A').astype('category')
+        )
         expected_false = DataFrame([[0.0, 3.0, 6.0, np.NaN],
                                     [1.0, 4.0, 7.0, np.NaN],
                                     [2.0, 5.0, 8.0, np.NaN]],

--- a/pandas/tests/reshape/test_reshape.py
+++ b/pandas/tests/reshape/test_reshape.py
@@ -311,7 +311,7 @@ class TestGetDummies(object):
                             'a': {0: 1, 1: 0, 2: 0},
                             'b': {0: 0, 1: 1, 2: 0}},
                            dtype=np.uint8)
-        exp_na = exp_na.reindex_axis(['a', 'b', nan], 1)
+        exp_na = exp_na.reindex(['a', 'b', nan], axis=1)
         # hack (NaN handling in assert_index_equal)
         exp_na.columns = res_na.columns
         assert_frame_equal(res_na, exp_na)
@@ -542,8 +542,8 @@ class TestGetDummies(object):
                                   2: 0},
                             nan: {0: 0,
                                   1: 0,
-                                  2: 1}}, dtype=np.uint8).reindex_axis(
-                                      ['b', nan], 1)
+                                  2: 1}}, dtype=np.uint8).reindex(
+                                      ['b', nan], axis=1)
         assert_frame_equal(res_na, exp_na)
 
         res_just_na = get_dummies([nan], dummy_na=True, sparse=self.sparse,

--- a/pandas/tests/sparse/test_series.py
+++ b/pandas/tests/sparse/test_series.py
@@ -1414,6 +1414,12 @@ class TestSparseSeriesAnalytics(object):
                                                 check_stacklevel=False):
                     getattr(getattr(self, series), func)()
 
+    def test_deprecated_reindex_axis(self):
+        # https://github.com/pandas-dev/pandas/issues/17833
+        with tm.assert_produces_warning(FutureWarning) as m:
+            self.bseries.reindex_axis([0, 1, 2])
+        assert 'reindex' in str(m[0].message)
+
 
 @pytest.mark.parametrize(
     'datetime_type', (np.datetime64,

--- a/pandas/tests/test_multilevel.py
+++ b/pandas/tests/test_multilevel.py
@@ -1805,7 +1805,7 @@ Thur,Lunch,Yes,51.51,17"""
         expected = self.frame.iloc[[0, 1, 2, 7, 8, 9]]
         tm.assert_frame_equal(result, expected)
 
-        result = self.frame.T.reindex_axis(['foo', 'qux'], axis=1, level=0)
+        result = self.frame.T.reindex(['foo', 'qux'], axis=1, level=0)
         tm.assert_frame_equal(result, expected.T)
 
         result = self.frame.loc[['foo', 'qux']]

--- a/pandas/tests/test_panel.py
+++ b/pandas/tests/test_panel.py
@@ -1444,6 +1444,22 @@ class TestPanel(PanelTests, CheckIndexing, SafeForLongAndSparse,
             assert_panel_equal(result, self.panel)
             assert result is self.panel
 
+    def test_reindex_axis_style(self):
+        with catch_warnings(record=True):
+            panel = Panel(np.random.rand(5, 5, 5))
+            expected0 = Panel(panel.values).iloc[[0, 1]]
+            expected1 = Panel(panel.values).iloc[:, [0, 1]]
+            expected2 = Panel(panel.values).iloc[:, :, [0, 1]]
+
+        result = panel.reindex([0, 1], axis=0)
+        assert_panel_equal(result, expected0)
+
+        result = panel.reindex([0, 1], axis=1)
+        assert_panel_equal(result, expected1)
+
+        result = panel.reindex([0, 1], axis=2)
+        assert_panel_equal(result, expected2)
+
     def test_reindex_multi(self):
         with catch_warnings(record=True):
 

--- a/pandas/tests/test_resample.py
+++ b/pandas/tests/test_resample.py
@@ -1422,7 +1422,7 @@ class TestDatetimeIndex(Base):
                     Timestamp('2011-01-06 10:59:05', tz=None): 1500000000,
                     Timestamp('2011-01-06 12:43:33', tz=None): 5000000000,
                     Timestamp('2011-01-06 12:54:09', tz=None): 100000000}})
-        ).reindex_axis(['VOLUME', 'PRICE'], axis=1)
+        ).reindex(['VOLUME', 'PRICE'], axis=1)
         res = df.resample('H').ohlc()
         exp = pd.concat([df['VOLUME'].resample('H').ohlc(),
                          df['PRICE'].resample('H').ohlc()],
@@ -1652,7 +1652,7 @@ class TestDatetimeIndex(Base):
         expected = DataFrame({'Group_obj': ['A', 'A'],
                               'Group': ['A', 'A']},
                              index=pd.to_timedelta([0, 10], unit='s'))
-        expected = expected.reindex_axis(['Group_obj', 'Group'], 1)
+        expected = expected.reindex(['Group_obj', 'Group'], axis=1)
         tm.assert_frame_equal(result, expected)
 
     def test_resample_daily_anchored(self):


### PR DESCRIPTION
Closes https://github.com/pandas-dev/pandas/issues/17833

Some notes:

- the positional argument for `rename_axis` is `mapper`, which isn't really descriptive of what it does now. Oh well
- Added a TODO in https://github.com/pandas-dev/pandas/compare/master...TomAugspurger:depr-rename_axis?expand=1#diff-492dc2a862db88ec1f1d80589ce8a7d6R92. That will (presumably) break in the future when we remove reindex_axis. I haven't attempted to understand what's going on there yet. Maybe it'll be easy
