### PR TITLE
BUG: duplicate indexing with embedded non-orderables (#17610)

### DIFF
--- a/doc/source/whatsnew/v0.21.0.txt
+++ b/doc/source/whatsnew/v0.21.0.txt
@@ -978,6 +978,7 @@ Indexing
 - Bug in :meth:`DataFrame.first_valid_index` and :meth:`DataFrame.last_valid_index` when no valid entry (:issue:`17400`)
 - Bug in :func:`Series.rename` when called with a callable, incorrectly alters the name of the ``Series``, rather than the name of the ``Index``. (:issue:`17407`)
 - Bug in :func:`String.str_get` raises ``IndexError`` instead of inserting NaNs when using a negative index. (:issue:`17704`)
+- Bug in ``Series`` containing duplicate indexing when gets embedded non-orderables or orderables, raises error or returns unexpected result. (:issue:`17610`)
 
 I/O
 ^^^

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -622,12 +622,11 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
         try:
             result = self.index.get_value(self, key)
 
-            if not is_scalar(result):
+            if (not is_scalar(result)) and (key in self.index):
                 if is_list_like(result) and not isinstance(result, Series):
-
                     # we need to box if we have a non-unique index here
                     # otherwise have inline ndarray/lists
-                    if not self.index.is_unique:
+                    if not is_scalar(self.index.get_loc(key)):
                         result = self._constructor(
                             result, index=[key] * len(result),
                             dtype=self.dtype).__finalize__(self)

--- a/pandas/tests/series/test_indexing.py
+++ b/pandas/tests/series/test_indexing.py
@@ -546,6 +546,22 @@ class TestSeriesIndexing(TestData):
         result[4:8] = ts[4:8]
         assert_series_equal(result, ts)
 
+    def test_getitem_with_duplicates_indices(self):
+        # GH 17610
+        s = pd.Series({1: 12, 2: [1, 2, 2, 3]})
+        s = s.append(pd.Series({1: 313}))
+        s_1 = pd.Series({1: 12, },)
+        s_1 = s_1.append(pd.Series({1: 313}))
+        assert_series_equal(s[1], s_1, check_dtype=False)
+        assert s[2] == [1, 2, 2, 3]
+
+        s = pd.Series({1: [1, 2, 3], 2: [1, 2, 2, 3]})
+        s = s.append(pd.Series({1: [1, 2, 3]}))
+        s_1 = pd.Series({1: [1, 2, 3], })
+        s_1 = s_1.append(pd.Series({1: [1, 2, 3]}))
+        assert_series_equal(s[1], s_1, check_dtype=False)
+        assert s[2] == [1, 2, 2, 3]
+
     def test_getitem_median_slice_bug(self):
         index = date_range('20090415', '20090519', freq='2B')
         s = Series(np.random.randn(13), index=index)


### PR DESCRIPTION

BUG: duplicate indexing with embedded non-orderables (#17610)


- [x] closes #xxxx
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
