### PR TITLE
TST: Skip if no openpyxl in test_excel

### DIFF
--- a/pandas/tests/io/test_excel.py
+++ b/pandas/tests/io/test_excel.py
@@ -975,6 +975,7 @@ class XlrdTests(ReadingTestsBase):
 
     def test_read_excel_parse_dates(self):
         # GH 11544, 12051
+        _skip_if_no_openpyxl()
 
         df = DataFrame(
             {'col': [1, 2, 3],


### PR DESCRIPTION
`test_read_excel_parse_dates` was calling `to_excel` without checking if `openpyxl` was installed.  Should skip the test if not installed.

Will merge on green.
