### PR TITLE
CLN: amended TypeError from pd.concat() to be more informative (GH15796)

### DIFF
--- a/pandas/core/reshape/concat.py
+++ b/pandas/core/reshape/concat.py
@@ -262,7 +262,10 @@ class _Concatenator(object):
         ndims = set()
         for obj in objs:
             if not isinstance(obj, NDFrame):
-                raise TypeError("cannot concatenate a non-NDFrame object")
+                msg = ('cannot concatenate object of type "{0}";'
+                       ' only pd.Series, pd.DataFrame, and pd.Panel'
+                       ' (deprecated) objs are valid'.format(type(obj)))
+                raise TypeError(msg)
 
             # consolidate
             obj._consolidate(inplace=True)

--- a/pandas/tests/reshape/test_concat.py
+++ b/pandas/tests/reshape/test_concat.py
@@ -177,7 +177,9 @@ class TestConcatAppendCommon(ConcatenateBase):
             tm.assert_series_equal(res, exp, check_index_type=True)
 
             # cannot append non-index
-            msg = "cannot concatenate a non-NDFrame object"
+            msg = ('cannot concatenate object of type \"(.+?)\";'
+                   ' only pd.Series, pd.DataFrame, and pd.Panel'
+                   ' \(deprecated\) objs are valid')
             with tm.assert_raises_regex(TypeError, msg):
                 pd.Series(vals1).append(vals2)
 


### PR DESCRIPTION
CLN/TST: Added regex matching for exception message

- [X] closes #15796 
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`

