### PR TITLE
BUG: Categorical(Index) passed as categories

### DIFF
--- a/doc/source/whatsnew/v0.21.0.txt
+++ b/doc/source/whatsnew/v0.21.0.txt
@@ -1023,6 +1023,7 @@ Categorical
 - Bug in the categorical constructor with empty values and categories causing the ``.categories`` to be an empty ``Float64Index`` rather than an empty ``Index`` with object dtype (:issue:`17248`)
 - Bug in categorical operations with :ref:`Series.cat <categorical.cat>` not preserving the original Series' name (:issue:`17509`)
 - Bug in :func:`DataFrame.merge` failing for categorical columns with boolean/int data types (:issue:`17187`)
+- Bug in constructing a ``Categorical``/``CategoricalDtype`` when the specified ``categories`` where of categorical type (:issue:`17884`).
 
 .. _whatsnew_0210.pypy:
 

--- a/doc/source/whatsnew/v0.21.0.txt
+++ b/doc/source/whatsnew/v0.21.0.txt
@@ -1023,7 +1023,7 @@ Categorical
 - Bug in the categorical constructor with empty values and categories causing the ``.categories`` to be an empty ``Float64Index`` rather than an empty ``Index`` with object dtype (:issue:`17248`)
 - Bug in categorical operations with :ref:`Series.cat <categorical.cat>` not preserving the original Series' name (:issue:`17509`)
 - Bug in :func:`DataFrame.merge` failing for categorical columns with boolean/int data types (:issue:`17187`)
-- Bug in constructing a ``Categorical``/``CategoricalDtype`` when the specified ``categories`` where of categorical type (:issue:`17884`).
+- Bug in constructing a ``Categorical``/``CategoricalDtype`` when the specified ``categories`` are of categorical type (:issue:`17884`).
 
 .. _whatsnew_0210.pypy:
 

--- a/pandas/core/dtypes/dtypes.py
+++ b/pandas/core/dtypes/dtypes.py
@@ -174,12 +174,12 @@ class CategoricalDtype(ExtensionDtype):
 
         if ordered is None:
             ordered = False
+        else:
+            self._validate_ordered(ordered)
 
         if categories is not None:
-            categories = Index(categories, tupleize_cols=False)
-            # validation
-            self._validate_categories(categories)
-            self._validate_ordered(ordered)
+            categories = self._validate_categories(categories)
+
         self._categories = categories
         self._ordered = ordered
 
@@ -316,7 +316,11 @@ class CategoricalDtype(ExtensionDtype):
         from pandas import Index
 
         if not isinstance(categories, ABCIndexClass):
-            categories = Index(categories)
+            categories = Index(categories, tupleize_cols=False)
+
+        if hasattr(categories, 'categories'):
+            # I am a CategoricalIndex
+            categories = categories.categories
 
         if not fastpath:
 

--- a/pandas/core/dtypes/dtypes.py
+++ b/pandas/core/dtypes/dtypes.py
@@ -3,8 +3,7 @@
 import re
 import numpy as np
 from pandas import compat
-from pandas.core.dtypes.generic import (
-    ABCIndexClass, ABCCategoricalIndex, ABCCategorical)
+from pandas.core.dtypes.generic import ABCIndexClass, ABCCategoricalIndex
 
 
 class ExtensionDtype(object):
@@ -316,9 +315,7 @@ class CategoricalDtype(ExtensionDtype):
         """
         from pandas import Index
 
-        if isinstance(categories, (ABCCategorical, ABCCategoricalIndex)):
-            categories = categories.categories
-        elif not isinstance(categories, ABCIndexClass):
+        if not isinstance(categories, ABCIndexClass):
             categories = Index(categories, tupleize_cols=False)
 
         if not fastpath:
@@ -328,6 +325,9 @@ class CategoricalDtype(ExtensionDtype):
 
             if not categories.is_unique:
                 raise ValueError('Categorical categories must be unique')
+
+        if isinstance(categories, ABCCategoricalIndex):
+            categories = categories.categories
 
         return categories
 

--- a/pandas/core/dtypes/dtypes.py
+++ b/pandas/core/dtypes/dtypes.py
@@ -3,7 +3,7 @@
 import re
 import numpy as np
 from pandas import compat
-from pandas.core.dtypes.generic import ABCIndexClass
+from pandas.core.dtypes.generic import ABCIndexClass, ABCCategoricalIndex
 
 
 class ExtensionDtype(object):
@@ -318,8 +318,7 @@ class CategoricalDtype(ExtensionDtype):
         if not isinstance(categories, ABCIndexClass):
             categories = Index(categories, tupleize_cols=False)
 
-        if hasattr(categories, 'categories'):
-            # I am a CategoricalIndex
+        if isinstance(categories, ABCCategoricalIndex):
             categories = categories.categories
 
         if not fastpath:

--- a/pandas/core/dtypes/dtypes.py
+++ b/pandas/core/dtypes/dtypes.py
@@ -170,7 +170,6 @@ class CategoricalDtype(ExtensionDtype):
         return cls(categories, ordered)
 
     def _finalize(self, categories, ordered, fastpath=False):
-        from pandas.core.indexes.base import Index
 
         if ordered is None:
             ordered = False

--- a/pandas/core/dtypes/dtypes.py
+++ b/pandas/core/dtypes/dtypes.py
@@ -3,7 +3,8 @@
 import re
 import numpy as np
 from pandas import compat
-from pandas.core.dtypes.generic import ABCIndexClass, ABCCategoricalIndex
+from pandas.core.dtypes.generic import (
+    ABCIndexClass, ABCCategoricalIndex, ABCCategorical)
 
 
 class ExtensionDtype(object):
@@ -315,11 +316,10 @@ class CategoricalDtype(ExtensionDtype):
         """
         from pandas import Index
 
-        if not isinstance(categories, ABCIndexClass):
-            categories = Index(categories, tupleize_cols=False)
-
-        if isinstance(categories, ABCCategoricalIndex):
+        if isinstance(categories, (ABCCategorical, ABCCategoricalIndex)):
             categories = categories.categories
+        elif not isinstance(categories, ABCIndexClass):
+            categories = Index(categories, tupleize_cols=False)
 
         if not fastpath:
 

--- a/pandas/tests/dtypes/test_dtypes.py
+++ b/pandas/tests/dtypes/test_dtypes.py
@@ -657,3 +657,10 @@ class TestCategoricalDtypeParametrized(object):
         # Py2 will have unicode prefixes
         pat = r"CategoricalDtype\(categories=\[.*\], ordered=False\)"
         assert re.match(pat, repr(c1))
+
+    def test_categorical_categories(self):
+        # GH17884
+        c1 = CategoricalDtype(pd.Categorical(['a', 'b']))
+        tm.assert_index_equal(c1.categories, pd.Index(['a', 'b']))
+        c1 = CategoricalDtype(pd.CategoricalIndex(['a', 'b']))
+        tm.assert_index_equal(c1.categories, pd.Index(['a', 'b']))

--- a/pandas/tests/dtypes/test_dtypes.py
+++ b/pandas/tests/dtypes/test_dtypes.py
@@ -6,7 +6,8 @@ from itertools import product
 
 import numpy as np
 import pandas as pd
-from pandas import Series, Categorical, IntervalIndex, date_range
+from pandas import (
+    Series, Categorical, CategoricalIndex, IntervalIndex, date_range)
 
 from pandas.core.dtypes.dtypes import (
     DatetimeTZDtype, PeriodDtype,
@@ -660,7 +661,7 @@ class TestCategoricalDtypeParametrized(object):
 
     def test_categorical_categories(self):
         # GH17884
-        c1 = CategoricalDtype(pd.Categorical(['a', 'b']))
+        c1 = CategoricalDtype(Categorical(['a', 'b']))
         tm.assert_index_equal(c1.categories, pd.Index(['a', 'b']))
-        c1 = CategoricalDtype(pd.CategoricalIndex(['a', 'b']))
+        c1 = CategoricalDtype(CategoricalIndex(['a', 'b']))
         tm.assert_index_equal(c1.categories, pd.Index(['a', 'b']))

--- a/pandas/tests/test_categorical.py
+++ b/pandas/tests/test_categorical.py
@@ -521,14 +521,14 @@ class TestCategorical(object):
 
     def test_constructor_with_categorical_categories(self):
         # GH17884
-        expected = pd.Categorical(['a', 'b'], categories=['a', 'b', 'c'])
+        expected = Categorical(['a', 'b'], categories=['a', 'b', 'c'])
 
-        result = pd.Categorical(
-            ['a', 'b'], categories=pd.Categorical(['a', 'b', 'c']))
+        result = Categorical(
+            ['a', 'b'], categories=Categorical(['a', 'b', 'c']))
         tm.assert_categorical_equal(result, expected)
 
-        result = pd.Categorical(
-            ['a', 'b'], categories=pd.CategoricalIndex(['a', 'b', 'c']))
+        result = Categorical(
+            ['a', 'b'], categories=CategoricalIndex(['a', 'b', 'c']))
         tm.assert_categorical_equal(result, expected)
 
     def test_from_codes(self):
@@ -574,14 +574,14 @@ class TestCategorical(object):
 
     def test_from_codes_with_categorical_categories(self):
         # GH17884
-        expected = pd.Categorical(['a', 'b'], categories=['a', 'b', 'c'])
+        expected = Categorical(['a', 'b'], categories=['a', 'b', 'c'])
 
-        result = pd.Categorical.from_codes(
-            [0, 1], categories=pd.Categorical(['a', 'b', 'c']))
+        result = Categorical.from_codes(
+            [0, 1], categories=Categorical(['a', 'b', 'c']))
         tm.assert_categorical_equal(result, expected)
 
-        result = pd.Categorical.from_codes(
-            [0, 1], categories=pd.CategoricalIndex(['a', 'b', 'c']))
+        result = Categorical.from_codes(
+            [0, 1], categories=CategoricalIndex(['a', 'b', 'c']))
         tm.assert_categorical_equal(result, expected)
 
     @pytest.mark.parametrize('dtype', [None, 'category'])

--- a/pandas/tests/test_categorical.py
+++ b/pandas/tests/test_categorical.py
@@ -519,6 +519,18 @@ class TestCategorical(object):
         result = Categorical(values, categories=['a', 'b', 'c'], ordered=True)
         tm.assert_categorical_equal(result, expected)
 
+    def test_constructor_with_categorical_categories(self):
+        # GH17884
+        expected = pd.Categorical(['a', 'b'], categories=['a', 'b', 'c'])
+
+        result = pd.Categorical(
+            ['a', 'b'], categories=pd.Categorical(['a', 'b', 'c']))
+        tm.assert_categorical_equal(result, expected)
+
+        result = pd.Categorical(
+            ['a', 'b'], categories=pd.CategoricalIndex(['a', 'b', 'c']))
+        tm.assert_categorical_equal(result, expected)
+
     def test_from_codes(self):
 
         # too few categories
@@ -559,6 +571,18 @@ class TestCategorical(object):
         if hasattr(np.random, "choice"):
             codes = np.random.choice([0, 1], 5, p=[0.9, 0.1])
             pd.Categorical.from_codes(codes, categories=["train", "test"])
+
+    def test_from_codes_with_categorical_categories(self):
+        # GH17884
+        expected = pd.Categorical(['a', 'b'], categories=['a', 'b', 'c'])
+
+        result = pd.Categorical.from_codes(
+            [0, 1], categories=pd.Categorical(['a', 'b', 'c']))
+        tm.assert_categorical_equal(result, expected)
+
+        result = pd.Categorical.from_codes(
+            [0, 1], categories=pd.CategoricalIndex(['a', 'b', 'c']))
+        tm.assert_categorical_equal(result, expected)
 
     @pytest.mark.parametrize('dtype', [None, 'category'])
     def test_from_inferred_categories(self, dtype):

--- a/pandas/tests/test_categorical.py
+++ b/pandas/tests/test_categorical.py
@@ -584,6 +584,10 @@ class TestCategorical(object):
             [0, 1], categories=CategoricalIndex(['a', 'b', 'c']))
         tm.assert_categorical_equal(result, expected)
 
+        # non-unique Categorical still raises
+        with pytest.raises(ValueError):
+            Categorical.from_codes([0, 1], Categorical(['a', 'b', 'a']))
+
     @pytest.mark.parametrize('dtype', [None, 'category'])
     def test_from_inferred_categories(self, dtype):
         cats = ['a', 'b']


### PR DESCRIPTION
- [x] closes #17884
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry

@TomAugspurger I am not sure we had a discussion about that before, but to me it does not make many sense to have a CategoricalIndex as the categories of a Categorical/CategoricalIndex, so I think we should convert passed categories (which is what this PR is doing). 
Alternative to fix #17884 is to fix the repr code to deal with Categorical categories.