### PR TITLE
CategoricalDtype construction: actually use fastpath

### DIFF
--- a/pandas/core/dtypes/dtypes.py
+++ b/pandas/core/dtypes/dtypes.py
@@ -178,7 +178,7 @@ class CategoricalDtype(ExtensionDtype):
         if categories is not None:
             categories = Index(categories, tupleize_cols=False)
             # validation
-            self._validate_categories(categories)
+            self._validate_categories(categories, fastpath=fastpath)
             self._validate_ordered(ordered)
         self._categories = categories
         self._ordered = ordered


### PR DESCRIPTION
cc @TomAugspurger the current `CategoricalDtype._from_fastpath(..)` was not any different from `CategoricalDtype(..)` as far as I could see, as the `fastpath` argument in `_finalize` was not used. This seems the logical fix.