### PR TITLE
tslib flake8 cleanup, missing declarations

### DIFF
--- a/pandas/_libs/tslib.pyx
+++ b/pandas/_libs/tslib.pyx
@@ -3719,7 +3719,7 @@ def tz_localize_to_utc(ndarray[int64_t] vals, object tz, object ambiguous=None,
         ndarray ambiguous_array
         Py_ssize_t i, idx, pos, ntrans, n = len(vals)
         int64_t *tdata
-        int64_t v, left, right, delta
+        int64_t v, left, right
         ndarray[int64_t] result, result_a, result_b, dst_hours
         pandas_datetimestruct dts
         bint infer_dst = False, is_dst = False, fill = False

--- a/pandas/_libs/tslib.pyx
+++ b/pandas/_libs/tslib.pyx
@@ -1466,7 +1466,7 @@ cdef class _NaT(_Timestamp):
         return NaT
 
     def __sub__(self, other):
-        if isinstance(other, (datetime, timedelta)):
+        if PyDateTime_Check(other) or PyDelta_Check(other):
             return NaT
         try:
             result = _Timestamp.__sub__(self, other)
@@ -2877,8 +2877,7 @@ class Timedelta(_Timedelta):
         # return True if we are compat with operating
         if _checknull_with_nat(other):
             return True
-        elif (isinstance(other, (Timedelta, timedelta)) or
-              is_timedelta64_object(other)):
+        elif PyDelta_Check(other) or is_timedelta64_object(other):
             return True
         elif util.is_string_object(other):
             return True

--- a/pandas/_libs/tslib.pyx
+++ b/pandas/_libs/tslib.pyx
@@ -1754,7 +1754,7 @@ cdef inline void _localize_tso(_TSObject obj, object tz):
     """
     cdef:
         ndarray[int64_t] trans, deltas
-        Py_ssize_t delta, pos
+        Py_ssize_t pos
         datetime dt
         int64_t delta
 
@@ -1785,8 +1785,8 @@ cdef inline void _localize_tso(_TSObject obj, object tz):
                 pandas_datetime_to_datetimestruct(obj.value + deltas[0],
                                                   PANDAS_FR_ns, &obj.dts)
             else:
-                pandas_datetime_to_datetimestruct(
-                    obj.value, PANDAS_FR_ns, &obj.dts)
+                pandas_datetime_to_datetimestruct(obj.value,
+                                                  PANDAS_FR_ns, &obj.dts)
             obj.tzinfo = tz
         elif treat_tz_as_pytz(tz):
             inf = tz._transition_info[pos]

--- a/pandas/_libs/tslib.pyx
+++ b/pandas/_libs/tslib.pyx
@@ -501,7 +501,7 @@ class Timestamp(_Timestamp):
         return self.weekday()
 
     @property
-    def str weekday_name(self):
+    def weekday_name(self):
         cdef dict wdays = {0: 'Monday', 1: 'Tuesday', 2: 'Wednesday',
                            3: 'Thursday', 4: 'Friday', 5: 'Saturday',
                            6: 'Sunday'}
@@ -2192,9 +2192,10 @@ cpdef array_to_datetime(ndarray[object] values, errors='raise',
                                          'be converted to datetime64 unless '
                                          'utc=True')
                 else:
-                    iresult[i] = _pydatetime_to_dts(val, &dts)
                     if is_timestamp(val):
-                        iresult[i] += (<_Timestamp>val).nanosecond
+                        iresult[i] = val.value
+                    else:
+                        iresult[i] = _pydatetime_to_dts(val, &dts)
                     try:
                         _check_dts_bounds(&dts)
                     except ValueError:

--- a/pandas/_libs/tslib.pyx
+++ b/pandas/_libs/tslib.pyx
@@ -1342,7 +1342,7 @@ cdef class _Timestamp(datetime):
             val = tz_convert_single(self.value, 'UTC', self.tz)
         return val
 
-    cpdef _get_field(self, field):
+    cdef _get_field(self, field):
         cdef:
             int64_t val
             ndarray[int32_t] out
@@ -1350,7 +1350,7 @@ cdef class _Timestamp(datetime):
         out = get_date_field(np.array([val], dtype=np.int64), field)
         return int(out[0])
 
-    cpdef _get_named_field(self, field):
+    cdef _get_named_field(self, field):
         cdef:
             int64_t val
             ndarray[object] out
@@ -1358,7 +1358,7 @@ cdef class _Timestamp(datetime):
         out = get_date_name_field(np.array([val], dtype=np.int64), field)
         return out[0]
 
-    cpdef _get_start_end_field(self, field):
+    cdef _get_start_end_field(self, field):
         month_kw = self.freq.kwds.get(
             'startingMonth', self.freq.kwds.get(
                 'month', 12)) if self.freq else 12

--- a/pandas/_libs/tslib.pyx
+++ b/pandas/_libs/tslib.pyx
@@ -1666,7 +1666,7 @@ cpdef convert_str_to_tsobject(object ts, object tz, object unit,
     cdef:
         _TSObject obj
         int out_local = 0, out_tzoffset = 0
-        datetime dtime
+        datetime dt
 
     if tz is not None:
         tz = maybe_get_tz(tz)
@@ -1702,10 +1702,10 @@ cpdef convert_str_to_tsobject(object ts, object tz, object unit,
                     # Keep the converter same as PyDateTime's
                     obj = convert_to_tsobject(obj.value, obj.tzinfo,
                                               None, 0, 0)
-                    dtime = datetime(obj.dts.year, obj.dts.month, obj.dts.day,
+                    dt = datetime(obj.dts.year, obj.dts.month, obj.dts.day,
                                      obj.dts.hour, obj.dts.min, obj.dts.sec,
                                      obj.dts.us, obj.tzinfo)
-                    obj = convert_datetime_to_tsobject(dtime, tz,
+                    obj = convert_datetime_to_tsobject(dt, tz,
                                                        nanos=obj.dts.ps / 1000)
                     return obj
 

--- a/pandas/_libs/tslib.pyx
+++ b/pandas/_libs/tslib.pyx
@@ -500,8 +500,11 @@ class Timestamp(_Timestamp):
         return self.weekday()
 
     @property
-    def weekday_name(self):
-        return self._get_named_field('weekday_name')
+    def str weekday_name(self):
+        cdef dict  wdays = {0: 'Monday', 1: 'Tuesday', 2: 'Wednesday',
+                            3: 'Thursday', 4: 'Friday', 5: 'Saturday',
+                            6: 'Sunday'}
+        return wdays[self.weekday()]
 
     @property
     def dayofyear(self):
@@ -1349,14 +1352,6 @@ cdef class _Timestamp(datetime):
         val = self._maybe_convert_value_to_local()
         out = get_date_field(np.array([val], dtype=np.int64), field)
         return int(out[0])
-
-    cdef _get_named_field(self, field):
-        cdef:
-            int64_t val
-            ndarray[object] out
-        val = self._maybe_convert_value_to_local()
-        out = get_date_name_field(np.array([val], dtype=np.int64), field)
-        return out[0]
 
     cdef _get_start_end_field(self, field):
         month_kw = self.freq.kwds.get(


### PR DESCRIPTION
replace `isinstance` checks with the faster C versions
change cpdef-->cdef for internal field-getter methods
remove get_named_field in favor of faster dict lookup (yah yah I'll show asv results in a bit)

- [ ] closes #xxxx
- [ ] tests added / passed
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
