### PR TITLE
Fixed problem parsing float and int columns with bool_ and NaN values

### DIFF
--- a/pandas/_libs/parsers.pyx
+++ b/pandas/_libs/parsers.pyx
@@ -1192,7 +1192,12 @@ cdef class TextReader:
         # only allow safe casts, eg. with a nan you cannot safely cast to int
         if col_res is not None and col_dtype is not None:
             try:
+                mask = None
+                if col_res.dtype == np.bool_ and na_count > 0:
+                    mask = col_res.view(np.uint8) == na_values[np.uint8]
                 col_res = col_res.astype(col_dtype, casting='safe')
+                if mask is not None:
+                    np.putmask(col_res, mask, na_values[col_dtype])
             except TypeError:
 
                 # float -> int conversions can fail the above
@@ -2255,6 +2260,8 @@ def _compute_na_values():
     uint16info = np.iinfo(np.uint16)
     uint8info = np.iinfo(np.uint8)
     na_values = {
+        np.float16: np.nan,
+        np.float32: np.nan,
         np.float64: np.nan,
         np.int64: int64info.min,
         np.int32: int32info.min,

--- a/pandas/tests/io/parser/c_parser_only.py
+++ b/pandas/tests/io/parser/c_parser_only.py
@@ -497,8 +497,8 @@ No,No,No"""
         df = self.read_csv(csv, low_memory=False)
         assert not df.empty
 
-    # Test for issue #16698
     def test_casting_boolean_nas(self):
+        # Test for issue #16698
         data = "c1,c2\nfalse,1\n,1"
         expected = DataFrame({'c1': [0.0, np.nan],
                               'c2': [1, 1]})

--- a/pandas/tests/io/parser/c_parser_only.py
+++ b/pandas/tests/io/parser/c_parser_only.py
@@ -497,6 +497,7 @@ No,No,No"""
         df = self.read_csv(csv, low_memory=False)
         assert not df.empty
 
+    # Test for issue #16698
     def test_casting_boolean_nas(self):
         data = "c1,c2\nfalse,1\n,1"
         expected = DataFrame({'c1': [0.0, np.nan],

--- a/pandas/tests/io/parser/c_parser_only.py
+++ b/pandas/tests/io/parser/c_parser_only.py
@@ -496,3 +496,13 @@ No,No,No"""
             ['x' * (1 << 20) for _ in range(2100)]))
         df = self.read_csv(csv, low_memory=False)
         assert not df.empty
+
+    def test_casting_boolean_nas(self):
+        data = "c1,c2\nfalse,1\n,1"
+        expected = DataFrame({'c1': [0.0, np.nan],
+                              'c2': [1, 1]})
+
+        expected['c1'] = expected['c1'].astype('float32')
+        result = self.read_csv(StringIO(data), dtype={'c1': 'float32'})
+
+        tm.assert_frame_equal(result, expected)


### PR DESCRIPTION
- [x] closes #16698
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry

Fixed problem parsing a column to float* or int* or uint* when it contains (boolean) true_values or false_values and NAs.