### PR TITLE
DOC: Removed references to v0.17 in docs and doc strings

### DIFF
--- a/doc/source/basics.rst
+++ b/doc/source/basics.rst
@@ -1738,11 +1738,6 @@ description.
 Sorting
 -------
 
-.. warning::
-
-   The sorting API is substantially changed in 0.17.0, see :ref:`here <whatsnew_0170.api_breaking.sorting>` for these changes.
-   In particular, all sorting methods now return a new object by default, and **DO NOT** operate in-place (except by passing ``inplace=True``).
-
 There are two obvious kinds of sorting that you may be interested in: sorting
 by label and sorting by actual values.
 
@@ -1829,8 +1824,6 @@ faster than sorting the entire Series and calling ``head(n)`` on the result.
    s.nsmallest(3)
    s.nlargest(3)
 
-.. versionadded:: 0.17.0
-
 ``DataFrame`` also has the ``nlargest`` and ``nsmallest`` methods.
 
 .. ipython:: python
@@ -1881,7 +1874,7 @@ dtypes
 ------
 
 The main types stored in pandas objects are ``float``, ``int``, ``bool``,
-``datetime64[ns]`` and ``datetime64[ns, tz]`` (in >= 0.17.0), ``timedelta[ns]``,
+``datetime64[ns]`` and ``datetime64[ns, tz]``, ``timedelta[ns]``,
 ``category`` and ``object``. In addition these dtypes have item sizes, e.g.
 ``int64`` and ``int32``. See :ref:`Series with TZ <timeseries.timezone_series>`
 for more detail on ``datetime64[ns, tz]`` dtypes.

--- a/doc/source/categorical.rst
+++ b/doc/source/categorical.rst
@@ -632,8 +632,6 @@ To get a single value `Series` of type ``category`` pass in a list with a single
 String and datetime accessors
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. versionadded:: 0.17.1
-
 The accessors  ``.dt`` and ``.str`` will work if the ``s.cat.categories`` are of an appropriate
 type:
 

--- a/doc/source/computation.rst
+++ b/doc/source/computation.rst
@@ -206,8 +206,6 @@ Window Functions
    functions and are now deprecated. These are replaced by using the :class:`~pandas.core.window.Rolling`, :class:`~pandas.core.window.Expanding` and :class:`~pandas.core.window.EWM`. objects and a corresponding method call.
 
    The deprecation warning will show the new syntax, see an example :ref:`here <whatsnew_0180.window_deprecations>`
-   You can view the previous documentation
-   `here <http://pandas.pydata.org/pandas-docs/version/0.17.1/computation.html#moving-rolling-statistics-moments>`__
 
 For working with data, a number of windows functions are provided for
 computing common *window* or *rolling* statistics. Among these are count, sum,

--- a/doc/source/contributing.rst
+++ b/doc/source/contributing.rst
@@ -877,12 +877,12 @@ directive is used. The sphinx syntax for that is:
 
 .. code-block:: rst
 
-  .. versionadded:: 0.17.0
+  .. versionadded:: 0.21.0
 
-This will put the text *New in version 0.17.0* wherever you put the sphinx
+This will put the text *New in version 0.21.0* wherever you put the sphinx
 directive. This should also be put in the docstring when adding a new function
-or method (`example <https://github.com/pandas-dev/pandas/blob/v0.16.2/pandas/core/generic.py#L1959>`__)
-or a new keyword argument (`example <https://github.com/pandas-dev/pandas/blob/v0.16.2/pandas/core/frame.py#L1171>`__).
+or method (`example <https://github.com/pandas-dev/pandas/blob/v0.20.2/pandas/core/frame.py#L1495>`__)
+or a new keyword argument (`example <https://github.com/pandas-dev/pandas/blob/v0.20.2/pandas/core/generic.py#L568>`__).
 
 Contributing your changes to *pandas*
 =====================================

--- a/doc/source/ecosystem.rst
+++ b/doc/source/ecosystem.rst
@@ -146,7 +146,10 @@ API
 
 `pandas-datareader <https://github.com/pydata/pandas-datareader>`__
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-``pandas-datareader`` is a remote data access library for pandas. ``pandas.io`` from pandas < 0.17.0 is now refactored/split-off to and importable from ``pandas_datareader`` (PyPI:``pandas-datareader``). Many/most of the supported APIs have at least a documentation paragraph in the `pandas-datareader docs <https://pandas-datareader.readthedocs.io/en/latest/>`_:
+``pandas-datareader`` is a remote data access library for pandas (PyPI:``pandas-datareader``).
+It is based on functionality that was located in ``pandas.io.data`` and ``pandas.io.wb`` but was
+split off in v0.19.
+See more in the  `pandas-datareader docs <https://pandas-datareader.readthedocs.io/en/latest/>`_:
 
 The following data feeds are available:
 

--- a/doc/source/gotchas.rst
+++ b/doc/source/gotchas.rst
@@ -47,8 +47,6 @@ The ``+`` symbol indicates that the true memory usage could be higher, because
 pandas does not count the memory used by values in columns with
 ``dtype=object``.
 
-.. versionadded:: 0.17.1
-
 Passing ``memory_usage='deep'`` will enable a more accurate memory usage report,
 that accounts for the full usage of the contained objects. This is optional
 as it can be expensive to do this deeper introspection.

--- a/doc/source/indexing.rst
+++ b/doc/source/indexing.rst
@@ -1632,8 +1632,6 @@ Missing values
 
 .. _indexing.missing:
 
-.. versionadded:: 0.17.1
-
 .. important::
 
    Even though ``Index`` can hold missing values (``NaN``), it should be avoided

--- a/doc/source/io.rst
+++ b/doc/source/io.rst
@@ -2689,11 +2689,6 @@ of sheet names can simply be passed to ``read_excel`` with no loss in performanc
     # equivalent using the read_excel function
     data = read_excel('path_to_file.xls', ['Sheet1', 'Sheet2'], index_col=None, na_values=['NA'])
 
-.. versionadded:: 0.17
-
-``read_excel`` can take an ``ExcelFile`` object as input
-
-
 .. _io.excel.specifying_sheets:
 
 Specifying Sheets
@@ -2753,8 +2748,6 @@ respectively.
 
 Reading a ``MultiIndex``
 ++++++++++++++++++++++++
-
-.. versionadded:: 0.17
 
 ``read_excel`` can read a ``MultiIndex`` index, by passing a list of columns to ``index_col``
 and a ``MultiIndex`` column by passing a list of rows to ``header``.  If either the ``index``
@@ -2928,14 +2921,8 @@ one can pass an :class:`~pandas.io.excel.ExcelWriter`.
 Writing Excel Files to Memory
 +++++++++++++++++++++++++++++
 
-.. versionadded:: 0.17
-
 Pandas supports writing Excel files to buffer-like objects such as ``StringIO`` or
-``BytesIO`` using :class:`~pandas.io.excel.ExcelWriter`.
-
-.. versionadded:: 0.17
-
-Added support for Openpyxl >= 2.2
+``BytesIO`` using :class:`~pandas.io.excel.ExcelWriter`. Pandas also supports Openpyxl >= 2.2.
 
 .. code-block:: python
 
@@ -3191,25 +3178,6 @@ both on the writing (serialization), and reading (deserialization).
    optimizations in the io of the ``msgpack`` data. Since this is marked
    as an EXPERIMENTAL LIBRARY, the storage format may not be stable until a future release.
 
-   As a result of writing format changes and other issues:
-
-   +----------------------+------------------------+
-   | Packed with          | Can be unpacked with   |
-   +======================+========================+
-   | pre-0.17 / Python 2  | any                    |
-   +----------------------+------------------------+
-   | pre-0.17 / Python 3  | any                    |
-   +----------------------+------------------------+
-   | 0.17 / Python 2      | - 0.17 / Python 2      |
-   |                      | - >=0.18 / any Python  |
-   +----------------------+------------------------+
-   | 0.17 / Python 3      | >=0.18 / any Python    |
-   +----------------------+------------------------+
-   | 0.18                 | >= 0.18                |
-   +----------------------+------------------------+
-
-   Reading (files packed by older versions) is backward-compatibile, except for files packed with 0.17 in Python 2, in which case only they can only be unpacked in Python 2.
-
 .. ipython:: python
 
    df = pd.DataFrame(np.random.rand(5,2),columns=list('AB'))
@@ -3286,10 +3254,6 @@ for some advanced strategies
    There is a indexing bug in ``PyTables`` < 3.2 which may appear when querying stores using an index.
    If you see a subset of results being returned, upgrade to ``PyTables`` >= 3.2.
    Stores created previously will need to be rewritten using the updated version.
-
-.. warning::
-
-   As of version 0.17.0, ``HDFStore`` will not drop rows that have all missing values by default. Previously, if all values (except the index) were missing, ``HDFStore`` would not write those rows to disk.
 
 .. ipython:: python
    :suppress:
@@ -3388,7 +3352,7 @@ similar to how ``read_csv`` and ``to_csv`` work.
    os.remove('store_tl.h5')
 
 
-As of version 0.17.0, HDFStore will no longer drop rows that are all missing by default. This behavior can be enabled by setting ``dropna=True``.
+HDFStore will by default not drop rows that are all missing. This behavior can be changed by setting ``dropna=True``.
 
 .. ipython:: python
    :suppress:
@@ -3631,12 +3595,6 @@ Querying
 
 Querying a Table
 ++++++++++++++++
-
-.. warning::
-
-   This query capabilities have changed substantially starting in ``0.13.0``.
-   Queries from prior version are accepted (with a ``DeprecationWarning``) printed
-   if its not string-like.
 
 ``select`` and ``delete`` operations have an optional criterion that can
 be specified to select/delete only a subset of the data. This allows one
@@ -5098,10 +5056,8 @@ whether imported ``Categorical`` variables are ordered.
 SAS Formats
 -----------
 
-.. versionadded:: 0.17.0
-
 The top-level function :func:`read_sas` can read (but not write) SAS
-`xport` (.XPT) and `SAS7BDAT` (.sas7bdat) format files were added in *v0.18.0*.
+`xport` (.XPT) and (since *v0.18.0*) `SAS7BDAT` (.sas7bdat) format files.
 
 SAS files only contain two value types: ASCII text and floating point
 values (usually 8 bytes but sometimes truncated).  For xport files,

--- a/doc/source/merging.rst
+++ b/doc/source/merging.rst
@@ -550,8 +550,6 @@ standard database join operations between DataFrame objects:
   merge key only appears in ``'right'`` DataFrame, and ``both`` if the
   observation's merge key is found in both.
 
-  .. versionadded:: 0.17.0
-
 - ``validate`` : string, default None.
   If specified, checks if merge is of specified type.
 
@@ -766,9 +764,7 @@ If the user is aware of the duplicates in the right `DataFrame` but wants to ens
 The merge indicator
 ~~~~~~~~~~~~~~~~~~~
 
-.. versionadded:: 0.17.0
-
-``merge`` now accepts the argument ``indicator``. If ``True``, a Categorical-type column called ``_merge`` will be added to the output object that takes on values:
+``merge`` accepts the argument ``indicator``. If ``True``, a Categorical-type column called ``_merge`` will be added to the output object that takes on values:
 
   ===================================   ================
   Observation Origin                    ``_merge`` value

--- a/doc/source/missing_data.rst
+++ b/doc/source/missing_data.rst
@@ -352,10 +352,6 @@ examined :ref:`in the API <api.dataframe.missing>`.
 Interpolation
 ~~~~~~~~~~~~~
 
-.. versionadded:: 0.17.0
-
-  The ``limit_direction`` keyword argument was added.
-
 Both Series and DataFrame objects have an ``interpolate`` method that, by default,
 performs linear interpolation at missing datapoints.
 

--- a/doc/source/remote_data.rst
+++ b/doc/source/remote_data.rst
@@ -11,7 +11,7 @@ Remote Data Access
 DataReader
 ----------
 
-The sub-package ``pandas.io.data`` was deprecated in v.0.17 and removed in
+The sub-package ``pandas.io.data`` was removed in
 `v.0.19 <http://pandas-docs.github.io/pandas-docs-travis/whatsnew.html#v0-19-0-october-2-2016>`__.
 Instead there has been created a separately installable
 `pandas-datareader package <https://github.com/pydata/pandas-datareader>`__.

--- a/doc/source/timeseries.rst
+++ b/doc/source/timeseries.rst
@@ -229,12 +229,7 @@ You can pass only the columns that you need to assemble.
 Invalid Data
 ~~~~~~~~~~~~
 
-.. note::
-
-   In version 0.17.0, the default for ``to_datetime`` is now ``errors='raise'``, rather than ``errors='ignore'``. This means
-   that invalid parsing will raise rather that return the original input as in previous versions.
-
-The default behavior, ``errors='raise'``, is to raise when unparseable: 
+The default behavior, ``errors='raise'``, is to raise when unparseable:
 
 .. code-block:: ipython
 
@@ -2229,8 +2224,6 @@ constructor as well as ``tz_localize``.
 
 TZ Aware Dtypes
 ~~~~~~~~~~~~~~~
-
-.. versionadded:: 0.17.0
 
 ``Series/DatetimeIndex`` with a timezone **naive** value are represented with a dtype of ``datetime64[ns]``.
 

--- a/doc/source/visualization.rst
+++ b/doc/source/visualization.rst
@@ -129,8 +129,6 @@ For example, a bar plot can be created the following way:
    @savefig bar_plot_ex.png
    df.iloc[5].plot(kind='bar');
 
-.. versionadded:: 0.17.0
-
 You can also create these other plots using the methods ``DataFrame.plot.<kind>`` instead of providing the ``kind`` keyword argument. This makes it easier to discover plot methods and the specific arguments they use:
 
 .. ipython::

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -182,8 +182,6 @@ indicator : boolean or string, default False
     "right_only" for observations whose merge key only appears in 'right'
     DataFrame, and "both" if the observation's merge key is found in both.
 
-    .. versionadded:: 0.17.0
-
 validate : string, default None
     If specified, checks if merge is of specified type.
 
@@ -915,8 +913,6 @@ class DataFrame(NDFrame):
             - records : list like
               [{column -> value}, ... , {column -> value}]
             - index : dict like {index -> {column -> value}}
-
-              .. versionadded:: 0.17.0
 
             Abbreviations are allowed. `s` indicates `series` and `sp`
             indicates `split`.
@@ -3743,8 +3739,6 @@ class DataFrame(NDFrame):
         """Get the rows of a DataFrame sorted by the `n` largest
         values of `columns`.
 
-        .. versionadded:: 0.17.0
-
         Parameters
         ----------
         n : int
@@ -3779,8 +3773,6 @@ class DataFrame(NDFrame):
     def nsmallest(self, n, columns, keep='first'):
         """Get the rows of a DataFrame sorted by the `n` smallest
         values of `columns`.
-
-        .. versionadded:: 0.17.0
 
         Parameters
         ----------
@@ -5349,8 +5341,6 @@ class DataFrame(NDFrame):
     def round(self, decimals=0, *args, **kwargs):
         """
         Round a DataFrame to a variable number of decimal places.
-
-        .. versionadded:: 0.17.0
 
         Parameters
         ----------

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -2415,7 +2415,6 @@ class NDFrame(PandasObject, SelectionMixin):
             Maximum distance between labels of the other object and this
             object for inexact matches. Can be list-like.
 
-            .. versionadded:: 0.17.0
             .. versionadded:: 0.21.0 (list-like tolerance)
 
         Notes
@@ -2622,8 +2621,6 @@ class NDFrame(PandasObject, SelectionMixin):
     _shared_docs['sort_values'] = """
         Sort by the values along either axis
 
-        .. versionadded:: 0.17.0
-
         Parameters
         ----------%(optional_by)s
         axis : %(axes_single_arg)s, default 0
@@ -2810,7 +2807,6 @@ class NDFrame(PandasObject, SelectionMixin):
             the same size as the index and its dtype must exactly match the
             index's type.
 
-            .. versionadded:: 0.17.0
             .. versionadded:: 0.21.0 (list-like tolerance)
 
         Examples
@@ -3077,7 +3073,6 @@ class NDFrame(PandasObject, SelectionMixin):
             the same size as the index and its dtype must exactly match the
             index's type.
 
-            .. versionadded:: 0.17.0
             .. versionadded:: 0.21.0 (list-like tolerance)
 
         Examples
@@ -4658,9 +4653,6 @@ class NDFrame(PandasObject, SelectionMixin):
         limit_direction : {'forward', 'backward', 'both'}, default 'forward'
             If limit is specified, consecutive NaNs will be filled in this
             direction.
-
-            .. versionadded:: 0.17.0
-
         inplace : bool, default False
             Update the NDFrame in place if possible.
         downcast : optional, 'infer' or None, defaults to None
@@ -5666,8 +5658,6 @@ class NDFrame(PandasObject, SelectionMixin):
         broadcast_axis : %(axes_single_arg)s, default None
             Broadcast values along this axis, if aligning two objects of
             different dimensions
-
-            .. versionadded:: 0.17.0
 
         Returns
         -------

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -2490,7 +2490,6 @@ class Index(IndexOpsMixin, PandasObject):
             includes list, tuple, array, Series, and must be the same size as
             the index and its dtype must exactly match the index's type.
 
-            .. versionadded:: 0.17.0
             .. versionadded:: 0.21.0 (list-like tolerance)
 
         Returns
@@ -2640,7 +2639,6 @@ class Index(IndexOpsMixin, PandasObject):
             the same size as the index and its dtype must exactly match the
             index's type.
 
-            .. versionadded:: 0.17.0
             .. versionadded:: 0.21.0 (list-like tolerance)
 
         Examples

--- a/pandas/core/indexes/datetimelike.py
+++ b/pandas/core/indexes/datetimelike.py
@@ -47,8 +47,6 @@ class DatelikeOps(object):
     supports the same string format as the python standard library. Details
     of the string format can be found in `python string format doc <{0}>`__
 
-    .. versionadded:: 0.17.0
-
     Parameters
     ----------
     date_format : str

--- a/pandas/core/indexes/datetimes.py
+++ b/pandas/core/indexes/datetimes.py
@@ -1016,11 +1016,9 @@ class DatetimeIndex(DatelikeOps, TimelikeOps, DatetimeIndexOpsMixin,
 
     def to_perioddelta(self, freq):
         """
-        Calcuates TimedeltaIndex of difference between index
+        Calculates TimedeltaIndex of difference between index
         values and index converted to PeriodIndex at specified
         freq.  Used for vectorized offsets
-
-        .. versionadded:: 0.17.0
 
         Parameters
         ----------

--- a/pandas/core/indexes/timedeltas.py
+++ b/pandas/core/indexes/timedeltas.py
@@ -454,8 +454,6 @@ class TimedeltaIndex(DatetimeIndexOpsMixin, TimelikeOps, Int64Index):
     def total_seconds(self):
         """
         Total duration of each element expressed in seconds.
-
-        .. versionadded:: 0.17.0
         """
         return Index(self._maybe_mask_results(1e-9 * self.asi8),
                      name=self.name)

--- a/pandas/io/formats/style.py
+++ b/pandas/io/formats/style.py
@@ -52,13 +52,6 @@ class Styler(object):
     Helps style a DataFrame or Series according to the
     data with HTML and CSS.
 
-    .. versionadded:: 0.17.1
-
-    .. warning::
-        This is a new feature and is under active development.
-        We'll be adding features and possibly making breaking changes in future
-        releases.
-
     Parameters
     ----------
     data: Series or DataFrame
@@ -396,8 +389,6 @@ class Styler(object):
         r"""
         Render the built up styles to HTML
 
-        .. versionadded:: 0.17.1
-
         Parameters
         ----------
         **kwargs:
@@ -541,8 +532,6 @@ class Styler(object):
         Apply a function column-wise, row-wise, or table-wase,
         updating the HTML representation with the result.
 
-        .. versionadded:: 0.17.1
-
         Parameters
         ----------
         func : function
@@ -600,8 +589,6 @@ class Styler(object):
         """
         Apply a function elementwise, updating the HTML
         representation with the result.
-
-        .. versionadded:: 0.17.1
 
         Parameters
         ----------
@@ -668,8 +655,6 @@ class Styler(object):
         """
         Set the precision used to render.
 
-        .. versionadded:: 0.17.1
-
         Parameters
         ----------
         precision: int
@@ -686,8 +671,6 @@ class Styler(object):
         Set the table attributes. These are the items
         that show up in the opening ``<table>`` tag in addition
         to to automatic (by default) id.
-
-        .. versionadded:: 0.17.1
 
         Parameters
         ----------
@@ -711,8 +694,6 @@ class Styler(object):
         Export the styles to applied to the current Styler.
         Can be applied to a second style with ``Styler.use``.
 
-        .. versionadded:: 0.17.1
-
         Returns
         -------
         styles: list
@@ -727,8 +708,6 @@ class Styler(object):
         """
         Set the styles on the current Styler, possibly using styles
         from ``Styler.export``.
-
-        .. versionadded:: 0.17.1
 
         Parameters
         ----------
@@ -750,8 +729,6 @@ class Styler(object):
         """
         Set the uuid for a Styler.
 
-        .. versionadded:: 0.17.1
-
         Parameters
         ----------
         uuid: str
@@ -766,8 +743,6 @@ class Styler(object):
     def set_caption(self, caption):
         """
         Se the caption on a Styler
-
-        .. versionadded:: 0.17.1
 
         Parameters
         ----------
@@ -784,8 +759,6 @@ class Styler(object):
         """
         Set the table styles on a Styler. These are placed in a
         ``<style>`` tag before the generated HTML table.
-
-        .. versionadded:: 0.17.1
 
         Parameters
         ----------
@@ -824,8 +797,6 @@ class Styler(object):
         """
         Shade the background ``null_color`` for missing values.
 
-        .. versionadded:: 0.17.1
-
         Parameters
         ----------
         null_color: str
@@ -843,8 +814,6 @@ class Styler(object):
         Color the background in a gradient according to
         the data in each column (optionally row).
         Requires matplotlib.
-
-        .. versionadded:: 0.17.1
 
         Parameters
         ----------
@@ -891,10 +860,8 @@ class Styler(object):
 
     def set_properties(self, subset=None, **kwargs):
         """
-        Convience method for setting one or more non-data dependent
+        Convenience method for setting one or more non-data dependent
         properties or each cell.
-
-        .. versionadded:: 0.17.1
 
         Parameters
         ----------
@@ -1033,8 +1000,6 @@ class Styler(object):
         Color the background ``color`` proptional to the values in each column.
         Excludes non-numeric data by default.
 
-        .. versionadded:: 0.17.1
-
         Parameters
         ----------
         subset: IndexSlice, default None
@@ -1095,8 +1060,6 @@ class Styler(object):
         """
         Highlight the maximum by shading the background
 
-        .. versionadded:: 0.17.1
-
         Parameters
         ----------
         subset: IndexSlice, default None
@@ -1116,8 +1079,6 @@ class Styler(object):
     def highlight_min(self, subset=None, color='yellow', axis=0):
         """
         Highlight the minimum by shading the background
-
-        .. versionadded:: 0.17.1
 
         Parameters
         ----------

--- a/pandas/io/sas/sas_xport.py
+++ b/pandas/io/sas/sas_xport.py
@@ -76,7 +76,6 @@ Read a Xport file in 10,000 line chunks:
 >>> for chunk in itr:
 >>>     do_something(chunk)
 
-.. versionadded:: 0.17.0
 """ % {"_base_params_doc": _base_params_doc,
        "_format_params_doc": _format_params_doc,
        "_params2_doc": _params2_doc,

--- a/pandas/plotting/_core.py
+++ b/pandas/plotting/_core.py
@@ -2503,8 +2503,6 @@ class SeriesPlotMethods(BasePlotMethods):
         """
         Line plot
 
-        .. versionadded:: 0.17.0
-
         Parameters
         ----------
         **kwds : optional
@@ -2519,8 +2517,6 @@ class SeriesPlotMethods(BasePlotMethods):
     def bar(self, **kwds):
         """
         Vertical bar plot
-
-        .. versionadded:: 0.17.0
 
         Parameters
         ----------
@@ -2537,8 +2533,6 @@ class SeriesPlotMethods(BasePlotMethods):
         """
         Horizontal bar plot
 
-        .. versionadded:: 0.17.0
-
         Parameters
         ----------
         **kwds : optional
@@ -2554,8 +2548,6 @@ class SeriesPlotMethods(BasePlotMethods):
         """
         Boxplot
 
-        .. versionadded:: 0.17.0
-
         Parameters
         ----------
         **kwds : optional
@@ -2570,8 +2562,6 @@ class SeriesPlotMethods(BasePlotMethods):
     def hist(self, bins=10, **kwds):
         """
         Histogram
-
-        .. versionadded:: 0.17.0
 
         Parameters
         ----------
@@ -2590,8 +2580,6 @@ class SeriesPlotMethods(BasePlotMethods):
         """
         Kernel Density Estimate plot
 
-        .. versionadded:: 0.17.0
-
         Parameters
         ----------
         **kwds : optional
@@ -2609,8 +2597,6 @@ class SeriesPlotMethods(BasePlotMethods):
         """
         Area plot
 
-        .. versionadded:: 0.17.0
-
         Parameters
         ----------
         **kwds : optional
@@ -2625,8 +2611,6 @@ class SeriesPlotMethods(BasePlotMethods):
     def pie(self, **kwds):
         """
         Pie chart
-
-        .. versionadded:: 0.17.0
 
         Parameters
         ----------
@@ -2677,8 +2661,6 @@ class FramePlotMethods(BasePlotMethods):
         """
         Line plot
 
-        .. versionadded:: 0.17.0
-
         Parameters
         ----------
         x, y : label or position, optional
@@ -2695,8 +2677,6 @@ class FramePlotMethods(BasePlotMethods):
     def bar(self, x=None, y=None, **kwds):
         """
         Vertical bar plot
-
-        .. versionadded:: 0.17.0
 
         Parameters
         ----------
@@ -2715,8 +2695,6 @@ class FramePlotMethods(BasePlotMethods):
         """
         Horizontal bar plot
 
-        .. versionadded:: 0.17.0
-
         Parameters
         ----------
         x, y : label or position, optional
@@ -2734,8 +2712,6 @@ class FramePlotMethods(BasePlotMethods):
         r"""
         Boxplot
 
-        .. versionadded:: 0.17.0
-
         Parameters
         ----------
         by : string or sequence
@@ -2752,8 +2728,6 @@ class FramePlotMethods(BasePlotMethods):
     def hist(self, by=None, bins=10, **kwds):
         """
         Histogram
-
-        .. versionadded:: 0.17.0
 
         Parameters
         ----------
@@ -2774,8 +2748,6 @@ class FramePlotMethods(BasePlotMethods):
         """
         Kernel Density Estimate plot
 
-        .. versionadded:: 0.17.0
-
         Parameters
         ----------
         **kwds : optional
@@ -2792,8 +2764,6 @@ class FramePlotMethods(BasePlotMethods):
     def area(self, x=None, y=None, **kwds):
         """
         Area plot
-
-        .. versionadded:: 0.17.0
 
         Parameters
         ----------
@@ -2812,8 +2782,6 @@ class FramePlotMethods(BasePlotMethods):
         """
         Pie chart
 
-        .. versionadded:: 0.17.0
-
         Parameters
         ----------
         y : label or position, optional
@@ -2830,8 +2798,6 @@ class FramePlotMethods(BasePlotMethods):
     def scatter(self, x, y, s=None, c=None, **kwds):
         """
         Scatter plot
-
-        .. versionadded:: 0.17.0
 
         Parameters
         ----------
@@ -2854,8 +2820,6 @@ class FramePlotMethods(BasePlotMethods):
                **kwds):
         """
         Hexbin plot
-
-        .. versionadded:: 0.17.0
 
         Parameters
         ----------

--- a/pandas/tseries/offsets.py
+++ b/pandas/tseries/offsets.py
@@ -236,8 +236,6 @@ class DateOffset(object):
         raises NotImplentedError for offsets without a
         vectorized implementation
 
-        .. versionadded:: 0.17.0
-
         Parameters
         ----------
         i : DatetimeIndex


### PR DESCRIPTION
- [ x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`

This PR removes references to changes and "versionadded" for pandas v0.17. This can be considered a continuation to #17504.

I propose pulling this in as soon as 0.21 is released.

Alternatively, these could be accepted in v0.21, as these references to v0.17 IMO are too old to be useful to the average doc reader (approx. 2 years) and upgraders could just reference the 0.20 docs or the whatsnew sections of v0.21.