### PR TITLE
Fix c build warnings #17634; remove several unused funcs

### DIFF
--- a/pandas/_libs/parsers.pyx
+++ b/pandas/_libs/parsers.pyx
@@ -12,7 +12,7 @@ from cpython cimport (PyObject, PyBytes_FromString,
                       PyBytes_AsString, PyBytes_Check,
                       PyUnicode_Check, PyUnicode_AsUTF8String,
                       PyErr_Occurred, PyErr_Fetch)
-from cpython.ref cimport PyObject, Py_XDECREF
+from cpython.ref cimport Py_XDECREF
 from pandas.errors import (ParserError, DtypeWarning,
                            EmptyDataError, ParserWarning)
 
@@ -43,12 +43,10 @@ from pandas.core.dtypes.common import (
     is_categorical_dtype, CategoricalDtype,
     is_integer_dtype, is_float_dtype,
     is_bool_dtype, is_object_dtype,
-    is_string_dtype, is_datetime64_dtype,
+    is_datetime64_dtype,
     pandas_dtype)
-from pandas.core.categorical import Categorical, _recode_for_categories
-from pandas.core.algorithms import take_1d
+from pandas.core.categorical import Categorical
 from pandas.core.dtypes.concat import union_categoricals
-from pandas import Index
 
 import pandas.io.common as com
 
@@ -165,7 +163,7 @@ cdef extern from "parser/tokenizer.h":
         int quoting                # style of quoting to write */
 
         # hmm =/
-#        int numeric_field
+        # int numeric_field
 
         char commentchar
         int allow_embedded_newline
@@ -253,11 +251,7 @@ cdef extern from "parser/tokenizer.h":
     double round_trip(const char *p, char **q, char decimal, char sci,
                       char tsep, int skip_trailing) nogil
 
-#    inline int to_complex(char *item, double *p_real,
-#                          double *p_imag, char sci, char decimal)
     int to_longlong(char *item, long long *p_value) nogil
-#    inline int to_longlong_thousands(char *item, long long *p_value,
-#                                     char tsep)
     int to_boolean(const char *item, uint8_t *val) nogil
 
 

--- a/pandas/_libs/src/datetime.pxd
+++ b/pandas/_libs/src/datetime.pxd
@@ -5,12 +5,6 @@ from cpython cimport PyObject
 from cpython cimport PyUnicode_Check, PyUnicode_AsASCIIString
 
 
-cdef extern from "headers/stdint.h":
-    enum: INT64_MIN
-    enum: INT32_MIN
-
-
-
 cdef extern from "datetime.h":
 
     ctypedef class datetime.date [object PyDateTime_Date]:

--- a/pandas/_libs/src/numpy_helper.h
+++ b/pandas/_libs/src/numpy_helper.h
@@ -15,28 +15,6 @@ The full license is in the LICENSE file, distributed with this software.
 #include "numpy/arrayobject.h"
 #include "numpy/arrayscalars.h"
 
-#define PANDAS_FLOAT 0
-#define PANDAS_INT 1
-#define PANDAS_BOOL 2
-#define PANDAS_STRING 3
-#define PANDAS_OBJECT 4
-#define PANDAS_DATETIME 5
-
-PANDAS_INLINE int infer_type(PyObject* obj) {
-    if (PyBool_Check(obj)) {
-        return PANDAS_BOOL;
-    } else if (PyArray_IsIntegerScalar(obj)) {
-        return PANDAS_INT;
-    } else if (PyArray_IsScalar(obj, Datetime)) {
-        return PANDAS_DATETIME;
-    } else if (PyFloat_Check(obj) || PyArray_IsScalar(obj, Floating)) {
-        return PANDAS_FLOAT;
-    } else if (PyString_Check(obj) || PyUnicode_Check(obj)) {
-        return PANDAS_STRING;
-    } else {
-        return PANDAS_OBJECT;
-    }
-}
 
 PANDAS_INLINE npy_int64 get_nat(void) { return NPY_MIN_INT64; }
 
@@ -135,7 +113,6 @@ void transfer_object_column(char* dst, char* src, size_t stride,
     }
 }
 
-void set_array_owndata(PyArrayObject* ao) { ao->flags |= NPY_OWNDATA; }
 
 void set_array_not_contiguous(PyArrayObject* ao) {
     ao->flags &= ~(NPY_C_CONTIGUOUS | NPY_F_CONTIGUOUS);

--- a/pandas/_libs/src/parser/tokenizer.c
+++ b/pandas/_libs/src/parser/tokenizer.c
@@ -262,7 +262,7 @@ static int make_stream_space(parser_t *self, size_t nbytes) {
         ("\n\nmake_stream_space: nbytes = %zu.  grow_buffer(self->stream...)\n",
          nbytes))
     self->stream = (char *)grow_buffer((void *)self->stream, self->stream_len,
-                                       &self->stream_cap, nbytes * 2,
+                                       (size_t*)&self->stream_cap, nbytes * 2,
                                        sizeof(char), &status);
     TRACE(
         ("make_stream_space: self->stream=%p, self->stream_len = %zu, "
@@ -289,7 +289,8 @@ static int make_stream_space(parser_t *self, size_t nbytes) {
     cap = self->words_cap;
     self->words =
         (char **)grow_buffer((void *)self->words, self->words_len,
-                             &self->words_cap, nbytes, sizeof(char *), &status);
+                             (size_t*)&self->words_cap, nbytes,
+                             sizeof(char *), &status);
     TRACE(
         ("make_stream_space: grow_buffer(self->self->words, %zu, %zu, %zu, "
          "%d)\n",
@@ -319,7 +320,8 @@ static int make_stream_space(parser_t *self, size_t nbytes) {
     cap = self->lines_cap;
     self->line_start =
         (int64_t *)grow_buffer((void *)self->line_start, self->lines + 1,
-                           &self->lines_cap, nbytes, sizeof(int64_t), &status);
+                           (size_t*)&self->lines_cap, nbytes,
+                           sizeof(int64_t), &status);
     TRACE((
         "make_stream_space: grow_buffer(self->line_start, %zu, %zu, %zu, %d)\n",
         self->lines + 1, self->lines_cap, nbytes, status))

--- a/pandas/_libs/src/util.pxd
+++ b/pandas/_libs/src/util.pxd
@@ -3,7 +3,6 @@ cimport numpy as cnp
 cimport cpython
 
 cdef extern from "numpy_helper.h":
-    void set_array_owndata(ndarray ao)
     void set_array_not_contiguous(ndarray ao)
 
     int is_integer_object(object)
@@ -16,7 +15,6 @@ cdef extern from "numpy_helper.h":
     int assign_value_1d(ndarray, Py_ssize_t, object) except -1
     cnp.int64_t get_nat()
     object get_value_1d(ndarray, Py_ssize_t)
-    int floatify(object, double*) except -1
     char *get_c_string(object) except NULL
     object char_to_string(char*)
     void transfer_object_column(char *dst, char *src, size_t stride,


### PR DESCRIPTION
Removes several unused functions, most importantly `floatify` which util attempts to import from numpy_helper but which does not exist there.

While putting this together I noticed in parsers.pyx a couple occurrences of`print >> sys.stderr, self.parser.warn_msg`.  I guess this is still valid cython, but should probably be updated anyway.

- [x] closes #17634
- [ ] tests added / passed
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
