### PR TITLE
Checks for tz/tzinfo validity in Timestamp.__new__

### DIFF
--- a/doc/source/whatsnew/v0.21.0.txt
+++ b/doc/source/whatsnew/v0.21.0.txt
@@ -830,7 +830,7 @@ Other API Changes
 - Restricted DateOffset keyword arguments.  Previously, ``DateOffset`` subclasses allowed arbitrary keyword arguments which could lead to unexpected behavior.  Now, only valid arguments will be accepted. (:issue:`17176`).
 - Pandas no longer registers matplotlib converters on import. The converters
   will be registered and used when the first plot is draw (:issue:`17710`)
-- :class:`Timestamp` will no longer silently ignore unused `tz` or `tzinfo` arguments (:issue:`17690`)
+- :class:`Timestamp` will no longer silently ignore unused or invalid `tz` or `tzinfo` arguments (:issue:`17690`)
 
 .. _whatsnew_0210.deprecations:
 

--- a/doc/source/whatsnew/v0.21.0.txt
+++ b/doc/source/whatsnew/v0.21.0.txt
@@ -902,7 +902,6 @@ Other API Changes
 - Restricted DateOffset keyword arguments.  Previously, ``DateOffset`` subclasses allowed arbitrary keyword arguments which could lead to unexpected behavior.  Now, only valid arguments will be accepted. (:issue:`17176`).
 - Pandas no longer registers matplotlib converters on import. The converters
   will be registered and used when the first plot is draw (:issue:`17710`)
-- :class:`Timestamp` will no longer silently ignore unused or invalid `tz` or `tzinfo` arguments (:issue:`17690`)
 
 .. _whatsnew_0210.deprecations:
 

--- a/doc/source/whatsnew/v0.21.0.txt
+++ b/doc/source/whatsnew/v0.21.0.txt
@@ -830,6 +830,7 @@ Other API Changes
 - Restricted DateOffset keyword arguments.  Previously, ``DateOffset`` subclasses allowed arbitrary keyword arguments which could lead to unexpected behavior.  Now, only valid arguments will be accepted. (:issue:`17176`).
 - Pandas no longer registers matplotlib converters on import. The converters
   will be registered and used when the first plot is draw (:issue:`17710`)
+- :class:`Timestamp` will no longer silently ignore unused `tz` or `tzinfo` arguments (:issue:`17690`)
 
 .. _whatsnew_0210.deprecations:
 

--- a/doc/source/whatsnew/v0.22.0.txt
+++ b/doc/source/whatsnew/v0.22.0.txt
@@ -40,7 +40,7 @@ Backwards incompatible API changes
 Other API Changes
 ^^^^^^^^^^^^^^^^^
 
--
+- :class:`Timestamp` will no longer silently ignore unused or invalid `tz` or `tzinfo` arguments (:issue:`17690`)
 -
 -
 

--- a/pandas/_libs/tslib.pyx
+++ b/pandas/_libs/tslib.pyx
@@ -383,7 +383,7 @@ class Timestamp(_Timestamp):
                 raise ValueError('Can provide at most one of tz, tzinfo')
             elif ts_input is not _no_input:
                 raise ValueError('When creating a Timestamp with this type '
-                                 'of inputs, the `tzfinfo` argument is '
+                                 'of inputs, the `tzinfo` argument is '
                                  'ignored.  Use `tz` instead.')
 
         if ts_input is _no_input:

--- a/pandas/_libs/tslib.pyx
+++ b/pandas/_libs/tslib.pyx
@@ -381,16 +381,15 @@ class Timestamp(_Timestamp):
                                 'not %s' % type(tzinfo))
             elif tz is not None:
                 raise ValueError('Can provide at most one of tz, tzinfo')
+            elif not is_integer_object(freq):
+                # tz takes on a special meaning in this case; leave it alone
+                tz, tzinfo = tzinfo, None
 
         if ts_input is _no_input:
             # User passed keyword arguments.
-            if tz is None:
-                # This allows us to handle the case where the user passes
-                # `tz` and not `tzinfo`.
-                tz = tzinfo
             return Timestamp(datetime(year, month, day, hour or 0,
                                       minute or 0, second or 0,
-                                      microsecond or 0, tzinfo),
+                                      microsecond or 0, tz),
                              tz=tz)
         elif is_integer_object(freq):
             # User passed positional arguments:
@@ -399,10 +398,6 @@ class Timestamp(_Timestamp):
             return Timestamp(datetime(ts_input, freq, tz, unit or 0,
                                       year or 0, month or 0, day or 0,
                                       hour), tz=hour)
-
-        if tzinfo is not None:
-            # User passed tzinfo instead of tz; avoid silently ignoring
-            tz, tzinfo = tzinfo, None
 
         ts = convert_to_tsobject(ts_input, tz, unit, 0, 0)
 

--- a/pandas/_libs/tslib.pyx
+++ b/pandas/_libs/tslib.pyx
@@ -381,15 +381,15 @@ class Timestamp(_Timestamp):
                                 'not %s' % type(tzinfo))
             elif tz is not None:
                 raise ValueError('Can provide at most one of tz, tzinfo')
-            elif not is_integer_object(freq):
-                # tz takes on a special meaning in this case; leave it alone
-                tz, tzinfo = tzinfo, None
 
         if ts_input is _no_input:
             # User passed keyword arguments.
+            if tz is None:
+                # Handle the case where the user passes `tz` and not `tzinfo`
+                tz = tzinfo
             return Timestamp(datetime(year, month, day, hour or 0,
                                       minute or 0, second or 0,
-                                      microsecond or 0, tz),
+                                      microsecond or 0, tzinfo),
                              tz=tz)
         elif is_integer_object(freq):
             # User passed positional arguments:
@@ -398,6 +398,10 @@ class Timestamp(_Timestamp):
             return Timestamp(datetime(ts_input, freq, tz, unit or 0,
                                       year or 0, month or 0, day or 0,
                                       hour), tz=hour)
+
+        if tzinfo is not None:
+            # User passed tzinfo instead of tz; avoid silently ignoring
+            tz, tzinfo = tzinfo, None
 
         ts = convert_to_tsobject(ts_input, tz, unit, 0, 0)
 

--- a/pandas/_libs/tslib.pyx
+++ b/pandas/_libs/tslib.pyx
@@ -381,21 +381,17 @@ class Timestamp(_Timestamp):
                                 'not %s' % type(tzinfo))
             elif tz is not None:
                 raise ValueError('Can provide at most one of tz, tzinfo')
-            elif ts_input is not _no_input:
-                raise ValueError('When creating a Timestamp with this type '
-                                 'of inputs, the `tzinfo` argument is '
-                                 'ignored.  Use `tz` instead.')
 
         if ts_input is _no_input:
             # User passed keyword arguments.
-            if tz is not None:
-                raise ValueError('When creating a Timestamp from component '
-                                 'elements, the `tz` argument is ignored.  '
-                                 'Use `tzinfo` instead.')
+            if tz is None:
+                # This allows us to handle the case where the user passes
+                # `tz` and not `tzinfo`.
+                tz = tzinfo
             return Timestamp(datetime(year, month, day, hour or 0,
                                       minute or 0, second or 0,
                                       microsecond or 0, tzinfo),
-                             tz=tzinfo)
+                             tz=tz)
         elif is_integer_object(freq):
             # User passed positional arguments:
             # Timestamp(year, month, day[, hour[, minute[, second[,
@@ -403,6 +399,10 @@ class Timestamp(_Timestamp):
             return Timestamp(datetime(ts_input, freq, tz, unit or 0,
                                       year or 0, month or 0, day or 0,
                                       hour), tz=hour)
+
+        if tzinfo is not None:
+            # User passed tzinfo instead of tz; avoid silently ignoring
+            tz, tzinfo = tzinfo, None
 
         ts = convert_to_tsobject(ts_input, tz, unit, 0, 0)
 

--- a/pandas/_libs/tslib.pyx
+++ b/pandas/_libs/tslib.pyx
@@ -30,6 +30,7 @@ from util cimport (is_integer_object, is_float_object, is_datetime64_object,
                    is_timedelta64_object, INT64_MAX)
 cimport util
 
+from cpython.datetime cimport PyTZInfo_Check
 # this is our datetime.pxd
 from datetime cimport (
     pandas_datetimestruct,
@@ -68,7 +69,7 @@ from .tslibs.parsing import parse_datetime_string
 
 cimport cython
 
-from pandas.compat import iteritems, callable
+from pandas.compat import iteritems
 
 import collections
 import warnings
@@ -373,8 +374,24 @@ class Timestamp(_Timestamp):
                           FutureWarning)
             freq = offset
 
+        if tzinfo is not None:
+            if not PyTZInfo_Check(tzinfo):
+                # tzinfo must be a datetime.tzinfo object, GH#17690
+                raise TypeError('tzinfo must be a datetime.tzinfo object, '
+                                'not %s' % type(tzinfo))
+            elif tz is not None:
+                raise ValueError('Can provide at most one of tz, tzinfo')
+            elif ts_input is not _no_input:
+                raise ValueError('When creating a Timestamp with this type '
+                                 'of inputs, the `tzfinfo` argument is '
+                                 'ignored.  Use `tz` instead.')
+
         if ts_input is _no_input:
             # User passed keyword arguments.
+            if tz is not None:
+                raise ValueError('When creating a Timestamp from component '
+                                 'elements, the `tz` argument is ignored.  '
+                                 'Use `tzinfo` instead.')
             return Timestamp(datetime(year, month, day, hour or 0,
                                       minute or 0, second or 0,
                                       microsecond or 0, tzinfo),

--- a/pandas/tests/scalar/test_timestamp.py
+++ b/pandas/tests/scalar/test_timestamp.py
@@ -180,13 +180,13 @@ class TestTimestamp(object):
         with tm.assert_raises_regex(TypeError, 'must be a datetime.tzinfo'):
             Timestamp('2017-10-22', tzinfo='US/Eastern')
 
-        with tm.assert_raises_regex(TypeError, 'at most one of'):
+        with tm.assert_raises_regex(ValueError, 'at most one of'):
             Timestamp('2017-10-22', tzinfo=utc, tz='UTC')
 
-        with tm.assert_raises_regex(TypeError, 'Use `tzinfo` instead'):
+        with tm.assert_raises_regex(ValueError, 'Use `tzinfo` instead'):
             Timestamp(year=2017, month=10, day=22, tz='UTC')
 
-        with tm.assert_raises_regex(TypeError, 'Use `tz` instead'):
+        with tm.assert_raises_regex(ValueError, 'Use `tz` instead'):
             dt = datetime(2017, 10, 22)
             Timestamp(dt, tzinfo=utc)
 

--- a/pandas/tests/scalar/test_timestamp.py
+++ b/pandas/tests/scalar/test_timestamp.py
@@ -183,12 +183,15 @@ class TestTimestamp(object):
         with tm.assert_raises_regex(ValueError, 'at most one of'):
             Timestamp('2017-10-22', tzinfo=utc, tz='UTC')
 
-        with tm.assert_raises_regex(ValueError, 'Use `tzinfo` instead'):
-            Timestamp(year=2017, month=10, day=22, tz='UTC')
-
-        with tm.assert_raises_regex(ValueError, 'Use `tz` instead'):
-            dt = datetime(2017, 10, 22)
-            Timestamp(dt, tzinfo=utc)
+    def test_constructor_tz_or_tzinfo(self):
+        # GH#17943, GH#17690, GH#5168
+        stamps = [Timestamp(year=2017, month=10, day=22, tz='UTC'),
+                  Timestamp(year=2017, month=10, day=22, tzinfo=utc),
+                  Timestamp(year=2017, month=10, day=22, tz=utc),
+                  Timestamp(datetime(2017, 10, 22), tzinfo=utc),
+                  Timestamp(datetime(2017, 10, 22), tz='UTC'),
+                  Timestamp(datetime(2017, 10, 22), tz=utc)]
+        assert all(ts == stamps[0] for ts in stamps)
 
     def test_constructor_positional(self):
         # see gh-10758

--- a/pandas/tests/scalar/test_timestamp.py
+++ b/pandas/tests/scalar/test_timestamp.py
@@ -175,6 +175,21 @@ class TestTimestamp(object):
         with tm.assert_raises_regex(ValueError, 'Cannot convert Period'):
             Timestamp(Period('1000-01-01'))
 
+    def test_constructor_invalid_tz(self):
+        # GH#17690, GH#5168
+        with tm.assert_raises_regex(TypeError, 'must be a datetime.tzinfo'):
+            Timestamp('2017-10-22', tzinfo='US/Eastern')
+
+        with tm.assert_raises_regex(TypeError, 'at most one of'):
+            Timestamp('2017-10-22', tzinfo=utc, tz='UTC')
+
+        with tm.assert_raises_regex(TypeError, 'Use `tzinfo` instead'):
+            Timestamp(year=2017, month=10, day=22, tz='UTC')
+
+        with tm.assert_raises_regex(TypeError, 'Use `tz` instead'):
+            dt = datetime(2017, 10, 22)
+            Timestamp(dt, tzinfo=utc)
+
     def test_constructor_positional(self):
         # see gh-10758
         with pytest.raises(TypeError):


### PR DESCRIPTION
closes #17690
related #5168

- [x] closes #17690
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
