### PR TITLE
resample().apply not returning multiple columns like groupby(pd.Timegrouper()).apply

### DIFF
--- a/doc/source/whatsnew/v0.21.1.txt
+++ b/doc/source/whatsnew/v0.21.1.txt
@@ -56,6 +56,7 @@ Documentation Changes
 
 Bug Fixes
 ~~~~~~~~~
+- Bug in ``DataFrame.resample(...).apply(...)`` when there is a callable that returns different columns (:issue:`15169`)
 
 Conversion
 ^^^^^^^^^^

--- a/pandas/core/resample.py
+++ b/pandas/core/resample.py
@@ -395,7 +395,11 @@ class Resampler(_GroupBy):
             grouped = PanelGroupBy(obj, grouper=grouper, axis=self.axis)
 
         try:
-            result = grouped.aggregate(how, *args, **kwargs)
+            if isinstance(obj, ABCDataFrame) and compat.callable(how):
+                # Check if the function is reducing or not.
+                result = grouped._aggregate_item_by_item(how, *args, **kwargs)
+            else:
+                result = grouped.aggregate(how, *args, **kwargs)
         except Exception:
 
             # we have a non-reducing function

--- a/pandas/tests/test_resample.py
+++ b/pandas/tests/test_resample.py
@@ -3103,6 +3103,26 @@ class TestResamplerGrouper(object):
         result = g.apply(f)
         assert_frame_equal(result, expected)
 
+    def test_apply_with_mutated_index(self):
+        # GH 15169
+        index = pd.date_range('1-1-2015', '12-31-15', freq='D')
+        df = pd.DataFrame(data={'col1': np.random.rand(len(index))},
+                          index=index)
+
+        def f(x):
+            s = pd.Series([1, 2], index=['a', 'b'])
+            return s
+
+        expected = df.groupby(pd.Grouper(freq='M')).apply(f)
+
+        result = df.resample('M').apply(f)
+        assert_frame_equal(result, expected)
+
+        # A case for series
+        expected = df['col1'].groupby(pd.Grouper(freq='M')).apply(f)
+        result = df['col1'].resample('M').apply(f)
+        assert_series_equal(result, expected)
+
     def test_resample_groupby_with_label(self):
         # GH 13235
         index = date_range('2000-01-01', freq='2D', periods=5)


### PR DESCRIPTION
- [x] closes #15169
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry
