### PR TITLE
REF/INT: preserve block type in joining when only having a single block

### DIFF
--- a/pandas/core/internals.py
+++ b/pandas/core/internals.py
@@ -5182,7 +5182,15 @@ def concatenate_block_managers(mgrs_indexers, axes, concat_axis, copy):
 
     for placement, join_units in concat_plan:
 
-        if is_uniform_join_units(join_units):
+        if len(join_units) == 1 and not join_units[0].indexers:
+            b = join_units[0].block
+            values = b.values
+            if copy and values.base is not None:
+                values = values.copy()
+            elif not copy:
+                values = values.view()
+            b = b.make_block_same_class(values, placement=placement)
+        elif is_uniform_join_units(join_units):
             b = join_units[0].block.concat_same_type(
                 [ju.block for ju in join_units], placement=placement)
         else:

--- a/pandas/core/internals.py
+++ b/pandas/core/internals.py
@@ -5185,7 +5185,7 @@ def concatenate_block_managers(mgrs_indexers, axes, concat_axis, copy):
         if len(join_units) == 1 and not join_units[0].indexers:
             b = join_units[0].block
             values = b.values
-            if copy and values.base is not None:
+            if copy:  # and values.base is not None:
                 values = values.copy()
             elif not copy:
                 values = values.view()

--- a/pandas/core/internals.py
+++ b/pandas/core/internals.py
@@ -5185,7 +5185,7 @@ def concatenate_block_managers(mgrs_indexers, axes, concat_axis, copy):
         if len(join_units) == 1 and not join_units[0].indexers:
             b = join_units[0].block
             values = b.values
-            if copy:  # and values.base is not None:
+            if copy:
                 values = values.copy()
             elif not copy:
                 values = values.view()


### PR DESCRIPTION
xref https://github.com/pandas-dev/pandas/issues/17283