### PR TITLE
isolate scalar Timestamp tests from date_range tests

### DIFF
--- a/pandas/tests/scalar/test_timestamp.py
+++ b/pandas/tests/scalar/test_timestamp.py
@@ -1497,7 +1497,6 @@ class TestTimestampEquivDateRange(object):
         assert ts == stamp
 
     def test_date_range_timestamp_equiv_from_datetime_instance(self):
-        # This test refers to TestTimestampOps.test_addition_subtraction_types
         datetime_instance = datetime(2014, 3, 4)
         # build a timestamp with a frequency, since then it supports
         # addition/subtraction of integers
@@ -1508,8 +1507,6 @@ class TestTimestampEquivDateRange(object):
         assert ts == timestamp_instance
 
     def test_date_range_timestamp_equiv_preserve_frequency(self):
-        # This test refers to
-        # TestTimestampOps.test_addition_subtraction_preserve_frequency
         timestamp_instance = date_range('2014-03-05', periods=1, freq='D')[0]
         ts = Timestamp('2014-03-05', freq='D')
 

--- a/pandas/tests/scalar/test_timestamp.py
+++ b/pandas/tests/scalar/test_timestamp.py
@@ -582,8 +582,9 @@ class TestTimestamp(object):
  'foo': 1}"""
         assert result == expected
 
-    def to_datetime_depr(self):
+    def test_to_datetime_depr(self):
         # see gh-8254
+        assert False
         ts = Timestamp('2011-01-01')
 
         with tm.assert_produces_warning(FutureWarning,
@@ -592,7 +593,8 @@ class TestTimestamp(object):
             result = ts.to_datetime()
             assert result == expected
 
-    def to_pydatetime_nonzero_nano(self):
+    def test_to_pydatetime_nonzero_nano(self):
+        assert False
         ts = Timestamp('2011-01-01 9:00:00.123456789')
 
         # Warn the user of data loss (nanoseconds).

--- a/pandas/tests/scalar/test_timestamp.py
+++ b/pandas/tests/scalar/test_timestamp.py
@@ -1518,7 +1518,7 @@ class TestTimestampEquivDateRange(object):
     def test_date_range_timestamp_equiv_explicit_dateutil(self):
         tm._skip_if_windows_python_3()
         from pandas._libs.tslibs.timezones import dateutil_gettz as gettz
-        
+
         rng = date_range('20090415', '20090519', tz=gettz('US/Eastern'))
         stamp = rng[0]
 

--- a/pandas/tests/scalar/test_timestamp.py
+++ b/pandas/tests/scalar/test_timestamp.py
@@ -1268,26 +1268,19 @@ class TestTimestampToJulianDate(object):
 class TestTimeSeries(object):
 
     def test_timestamp_to_datetime(self):
-        rng = date_range('20090415', '20090519', tz='US/Eastern')
-
-        stamp = rng[0]
+        stamp = Timestamp('20090415', tz='US/Eastern', freq='D')
         dtval = stamp.to_pydatetime()
         assert stamp == dtval
         assert stamp.tzinfo == dtval.tzinfo
 
     def test_timestamp_to_datetime_dateutil(self):
-        rng = date_range('20090415', '20090519', tz='dateutil/US/Eastern')
-
-        stamp = rng[0]
+        stamp = Timestamp('20090415', tz='dateutil/US/Eastern', freq='D')
         dtval = stamp.to_pydatetime()
         assert stamp == dtval
         assert stamp.tzinfo == dtval.tzinfo
 
     def test_timestamp_to_datetime_explicit_pytz(self):
-        rng = date_range('20090415', '20090519',
-                         tz=pytz.timezone('US/Eastern'))
-
-        stamp = rng[0]
+        stamp = Timestamp('20090415', tz=pytz.timezone('US/Eastern'), freq='D')
         dtval = stamp.to_pydatetime()
         assert stamp == dtval
         assert stamp.tzinfo == dtval.tzinfo
@@ -1296,9 +1289,7 @@ class TestTimeSeries(object):
         tm._skip_if_windows_python_3()
 
         from pandas._libs.tslibs.timezones import dateutil_gettz as gettz
-        rng = date_range('20090415', '20090519', tz=gettz('US/Eastern'))
-
-        stamp = rng[0]
+        stamp = Timestamp('20090415', tz=gettz('US/Eastern'), freq='D')
         dtval = stamp.to_pydatetime()
         assert stamp == dtval
         assert stamp.tzinfo == dtval.tzinfo
@@ -1494,3 +1485,61 @@ class TestTsUtil(object):
         with tm.assert_produces_warning(exp_warning, check_stacklevel=False):
             assert (Timestamp(Timestamp.min.to_pydatetime()).value / 1000 ==
                     Timestamp.min.value / 1000)
+
+
+class TestTimestampEquivDateRange(object):
+    # Older tests in TestTimeSeries constructed their `stamp` objects
+    # using `date_range` instead of the `Timestamp` constructor.
+    # TestTimestampEquivDateRange checks that these are equivalent in the
+    # pertinent cases.
+
+    def test_date_range_timestamp_equiv(self):
+        rng = date_range('20090415', '20090519', tz='US/Eastern')
+        stamp = rng[0]
+
+        ts = Timestamp('20090415', tz='US/Eastern', freq='D')
+        assert ts == stamp
+
+    def test_date_range_timestamp_equiv_dateutil(self):
+        rng = date_range('20090415', '20090519', tz='dateutil/US/Eastern')
+        stamp = rng[0]
+
+        ts = Timestamp('20090415', tz='dateutil/US/Eastern', freq='D')
+        assert ts == stamp
+
+    def test_date_range_timestamp_equiv_explicit_pytz(self):
+        rng = date_range('20090415', '20090519',
+                         tz=pytz.timezone('US/Eastern'))
+        stamp = rng[0]
+
+        ts = Timestamp('20090415', tz=pytz.timezone('US/Eastern'), freq='D')
+        assert ts == stamp
+
+    def test_date_range_timestamp_equiv_explicit_dateutil(self):
+        tm._skip_if_windows_python_3()
+        from pandas._libs.tslibs.timezones import dateutil_gettz as gettz
+        
+        rng = date_range('20090415', '20090519', tz=gettz('US/Eastern'))
+        stamp = rng[0]
+
+        ts = Timestamp('20090415', tz=gettz('US/Eastern'), freq='D')
+        assert ts == stamp
+
+    def test_date_range_timestamp_equiv_from_datetime_instance(self):
+        # This test refers to TestTimestampOps.test_addition_subtraction_types
+        datetime_instance = datetime(2014, 3, 4)
+        # build a timestamp with a frequency, since then it supports
+        # addition/subtraction of integers
+        timestamp_instance = date_range(datetime_instance, periods=1,
+                                        freq='D')[0]
+
+        ts = Timestamp(datetime_instance, freq='D')
+        assert ts == timestamp_instance
+
+    def test_date_range_timestamp_equiv_preserve_frequency(self):
+        # This test refers to
+        # TestTimestampOps.test_addition_subtraction_preserve_frequency
+        timestamp_instance = date_range('2014-03-05', periods=1, freq='D')[0]
+        ts = Timestamp('2014-03-05', freq='D')
+
+        assert timestamp_instance == ts

--- a/pandas/tests/scalar/test_timestamp.py
+++ b/pandas/tests/scalar/test_timestamp.py
@@ -584,7 +584,6 @@ class TestTimestamp(object):
 
     def test_to_datetime_depr(self):
         # see gh-8254
-        assert False
         ts = Timestamp('2011-01-01')
 
         with tm.assert_produces_warning(FutureWarning,
@@ -594,7 +593,6 @@ class TestTimestamp(object):
             assert result == expected
 
     def test_to_pydatetime_nonzero_nano(self):
-        assert False
         ts = Timestamp('2011-01-01 9:00:00.123456789')
 
         # Warn the user of data loss (nanoseconds).

--- a/pandas/tests/scalar/test_timestamp.py
+++ b/pandas/tests/scalar/test_timestamp.py
@@ -969,35 +969,6 @@ class TestTimestamp(object):
         result = val + timedelta(1)
         assert result.nanosecond == val.nanosecond
 
-    def test_frequency_misc(self):
-        assert (frequencies.get_freq_group('T') ==
-                frequencies.FreqGroup.FR_MIN)
-
-        code, stride = frequencies.get_freq_code(offsets.Hour())
-        assert code == frequencies.FreqGroup.FR_HR
-
-        code, stride = frequencies.get_freq_code((5, 'T'))
-        assert code == frequencies.FreqGroup.FR_MIN
-        assert stride == 5
-
-        offset = offsets.Hour()
-        result = frequencies.to_offset(offset)
-        assert result == offset
-
-        result = frequencies.to_offset((5, 'T'))
-        expected = offsets.Minute(5)
-        assert result == expected
-
-        pytest.raises(ValueError, frequencies.get_freq_code, (5, 'baz'))
-
-        pytest.raises(ValueError, frequencies.to_offset, '100foo')
-
-        pytest.raises(ValueError, frequencies.to_offset, ('', ''))
-
-        with tm.assert_produces_warning(FutureWarning, check_stacklevel=False):
-            result = frequencies.get_standard_freq(offsets.Hour())
-        assert result == 'H'
-
     def test_hash_equivalent(self):
         d = {datetime(2011, 1, 1): 5}
         stamp = Timestamp(datetime(2011, 1, 1))

--- a/pandas/tests/tseries/test_frequencies.py
+++ b/pandas/tests/tseries/test_frequencies.py
@@ -509,6 +509,35 @@ class TestFrequencyCode(object):
         assert (frequencies.get_freq_code(offsets.Week(-2, weekday=4)) ==
                 (frequencies.get_freq('W-FRI'), -2))
 
+    def test_frequency_misc(self):
+        assert (frequencies.get_freq_group('T') ==
+                frequencies.FreqGroup.FR_MIN)
+
+        code, stride = frequencies.get_freq_code(offsets.Hour())
+        assert code == frequencies.FreqGroup.FR_HR
+
+        code, stride = frequencies.get_freq_code((5, 'T'))
+        assert code == frequencies.FreqGroup.FR_MIN
+        assert stride == 5
+
+        offset = offsets.Hour()
+        result = frequencies.to_offset(offset)
+        assert result == offset
+
+        result = frequencies.to_offset((5, 'T'))
+        expected = offsets.Minute(5)
+        assert result == expected
+
+        pytest.raises(ValueError, frequencies.get_freq_code, (5, 'baz'))
+
+        pytest.raises(ValueError, frequencies.to_offset, '100foo')
+
+        pytest.raises(ValueError, frequencies.to_offset, ('', ''))
+
+        with tm.assert_produces_warning(FutureWarning, check_stacklevel=False):
+            result = frequencies.get_standard_freq(offsets.Hour())
+        assert result == 'H'
+
 
 _dti = DatetimeIndex
 

--- a/pandas/tests/tseries/test_frequencies.py
+++ b/pandas/tests/tseries/test_frequencies.py
@@ -528,11 +528,14 @@ class TestFrequencyCode(object):
         expected = offsets.Minute(5)
         assert result == expected
 
-        pytest.raises(ValueError, frequencies.get_freq_code, (5, 'baz'))
+        with tm.assert_raises_regex(ValueError, 'Invalid frequency'):
+            frequencies.get_freq_code((5, 'baz'))
 
-        pytest.raises(ValueError, frequencies.to_offset, '100foo')
+        with tm.assert_raises_regex(ValueError, 'Invalid frequency'):
+            frequencies.to_offset('100foo')
 
-        pytest.raises(ValueError, frequencies.to_offset, ('', ''))
+        with tm.assert_raises_regex(ValueError, 'Could not evaluate'):
+            frequencies.to_offset(('', ''))
 
         with tm.assert_produces_warning(FutureWarning, check_stacklevel=False):
             result = frequencies.get_standard_freq(offsets.Hour())


### PR DESCRIPTION
Discussed in #17697 

- [ ] closes #xxxx
- [x] tests added / passed
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
