### PR TITLE
BUG: Fix to_latex with longtable (#17959)

### DIFF
--- a/doc/source/whatsnew/v0.21.0.txt
+++ b/doc/source/whatsnew/v0.21.0.txt
@@ -1089,7 +1089,6 @@ I/O
 - Bug in :meth:`DataFrame.to_html` in which there was no validation of the ``justify`` parameter (:issue:`17527`)
 - Bug in :func:`HDFStore.select` when reading a contiguous mixed-data table featuring VLArray (:issue:`17021`)
 - Bug in :func:`to_json` where several conditions (including objects with unprintable symbols, objects with deep recursion, overlong labels) caused segfaults instead of raising the appropriate exception (:issue:`14256`)
-- Bug in :meth:`DataFrame.to_latex` with ``longtable=True`` where a latex multicolumn always spanned over three columns (:issue:`17959`)
 
 Plotting
 ^^^^^^^^

--- a/doc/source/whatsnew/v0.21.0.txt
+++ b/doc/source/whatsnew/v0.21.0.txt
@@ -1089,6 +1089,7 @@ I/O
 - Bug in :meth:`DataFrame.to_html` in which there was no validation of the ``justify`` parameter (:issue:`17527`)
 - Bug in :func:`HDFStore.select` when reading a contiguous mixed-data table featuring VLArray (:issue:`17021`)
 - Bug in :func:`to_json` where several conditions (including objects with unprintable symbols, objects with deep recursion, overlong labels) caused segfaults instead of raising the appropriate exception (:issue:`14256`)
+- Bug in :meth:`DataFrame.to_latex` with ``longtable=True`` where a latex multicolumn always spanned over three columns (:issue:`17959`)
 
 Plotting
 ^^^^^^^^

--- a/doc/source/whatsnew/v0.21.1.txt
+++ b/doc/source/whatsnew/v0.21.1.txt
@@ -127,6 +127,7 @@ I/O
 - Bug in :func:`pandas.io.json.json_normalize` to avoid modification of ``meta`` (:issue:`18610`)
 - Bug in :func:`to_latex` where repeated multi-index values were not printed even though a higher level index differed from the previous row (:issue:`14484`)
 - Bug when reading NaN-only categorical columns in :class:`HDFStore` (:issue:`18413`)
+- Bug in :meth:`DataFrame.to_latex` with ``longtable=True`` where a latex multicolumn always spanned over three columns (:issue:`17959`)
 
 Plotting
 ^^^^^^^^

--- a/pandas/io/formats/format.py
+++ b/pandas/io/formats/format.py
@@ -962,8 +962,8 @@ class LatexFormatter(TableFormatter):
                 if self.longtable:
                     buf.write('\\endhead\n')
                     buf.write('\\midrule\n')
-                    buf.write('\\multicolumn{3}{r}{{Continued on next '
-                              'page}} \\\\\n')
+                    buf.write('\\multicolumn{{{n}}}{{r}}{{{{Continued on next '
+                              'page}}}} \\\\\n'.format(n=len(row)))
                     buf.write('\\midrule\n')
                     buf.write('\\endfoot\n\n')
                     buf.write('\\bottomrule\n')

--- a/pandas/tests/io/formats/test_to_latex.py
+++ b/pandas/tests/io/formats/test_to_latex.py
@@ -91,6 +91,29 @@ class TestToLatex(object):
 
         assert withindex_result == withindex_expected
 
+    def test_to_latex_empty(self):
+        df = DataFrame()
+        result = df.to_latex()
+        expected = r"""\begin{tabular}{l}
+\toprule
+Empty DataFrame
+Columns: Index([], dtype='object')
+Index: Index([], dtype='object') \\
+\bottomrule
+\end{tabular}
+"""
+        assert result == expected
+
+        result = df.to_latex(longtable=True)
+        expected = r"""\begin{longtable}{l}
+\toprule
+Empty DataFrame
+Columns: Index([], dtype='object')
+Index: Index([], dtype='object') \\
+\end{longtable}
+"""
+        assert result == expected
+
     def test_to_latex_with_formatters(self):
         df = DataFrame({'int': [1, 2, 3],
                         'float': [1.0, 2.0, 3.0],
@@ -367,7 +390,7 @@ b &       b &     b \\
 \midrule
 \endhead
 \midrule
-\multicolumn{2}{r}{{Continued on next page}} \\
+\multicolumn{3}{r}{{Continued on next page}} \\
 \midrule
 \endfoot
 
@@ -377,7 +400,7 @@ b &       b &     b \\
 1 &  2 &  b2 \\
 \end{longtable}
 """
-
+        open("expected.txt", "w").write(withindex_result)
         assert withindex_result == withindex_expected
 
         withoutindex_result = df.to_latex(index=False, longtable=True)
@@ -387,7 +410,7 @@ b &       b &     b \\
 \midrule
 \endhead
 \midrule
-\multicolumn{3}{r}{{Continued on next page}} \\
+\multicolumn{2}{r}{{Continued on next page}} \\
 \midrule
 \endfoot
 

--- a/pandas/tests/io/formats/test_to_latex.py
+++ b/pandas/tests/io/formats/test_to_latex.py
@@ -400,6 +400,14 @@ b &       b &     b \\
 
         assert withoutindex_result == withoutindex_expected
 
+        df = DataFrame({'a': [1, 2]})
+        with1column_result = df.to_latex(index=False, longtable=True)
+        assert "\multicolumn{1}" in with1column_result
+
+        df = DataFrame({'a': [1, 2], 'b': [3, 4], 'c': [5, 6]})
+        with3columns_result = df.to_latex(index=False, longtable=True)
+        assert "\multicolumn{3}" in with3columns_result
+
     def test_to_latex_escape_special_chars(self):
         special_characters = ['&', '%', '$', '#', '_', '{', '}', '~', '^',
                               '\\']

--- a/pandas/tests/io/formats/test_to_latex.py
+++ b/pandas/tests/io/formats/test_to_latex.py
@@ -367,7 +367,7 @@ b &       b &     b \\
 \midrule
 \endhead
 \midrule
-\multicolumn{3}{r}{{Continued on next page}} \\
+\multicolumn{2}{r}{{Continued on next page}} \\
 \midrule
 \endfoot
 


### PR DESCRIPTION
- [x] closes #17959
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry

pandas.DataFrame.to_latex(longtable=True) always contained `\multicolumn{3}{r}{{Continued on next page}}` regardless of the number of columns in the output. This is now changed to use the actual number of columns in the output.