### PR TITLE
Fix df.to_csv() for string arrays when encoded in utf-8

### DIFF
--- a/pandas/tests/io/formats/test_to_csv.py
+++ b/pandas/tests/io/formats/test_to_csv.py
@@ -197,7 +197,7 @@ $1$,$2$
                 expected_ymd_sec)
 
     def test_to_csv_multi_index(self):
-        # see gh-6618
+        # GH 6618
         df = DataFrame([1], columns=pd.MultiIndex.from_arrays([[1], [2]]))
 
         exp = ",1\n,2\n0,1\n"
@@ -223,3 +223,11 @@ $1$,$2$
 
         exp = "foo\nbar\n1\n"
         assert df.to_csv(index=False) == exp
+
+    def test_to_csv_string_array(self):
+        # GH 10813
+        str_array = [{'names': ['foo', 'bar']}, {'names': ['baz', 'qux']}]
+        df = pd.DataFrame(str_array)
+        expected = ",names\n0,\"['foo', 'bar']\"\n1,\"['baz', 'qux']\"\n"
+        assert df.to_csv(encoding='ascii') == expected
+        assert df.to_csv(path_or_buf='temp.csv', encoding='utf-8') == expected

--- a/pandas/tests/io/formats/test_to_csv.py
+++ b/pandas/tests/io/formats/test_to_csv.py
@@ -228,6 +228,22 @@ $1$,$2$
         # GH 10813
         str_array = [{'names': ['foo', 'bar']}, {'names': ['baz', 'qux']}]
         df = pd.DataFrame(str_array)
-        expected = ",names\n0,\"['foo', 'bar']\"\n1,\"['baz', 'qux']\"\n"
-        assert df.to_csv(encoding='ascii') == expected
-        assert df.to_csv(path_or_buf='temp.csv', encoding='utf-8') == expected
+        expected_ascii = '''\
+,names
+0,"['foo', 'bar']"
+1,"['baz', 'qux']"
+'''
+        with tm.ensure_clean('str_test.csv') as path:
+            df.to_csv(path, encoding='ascii')
+            with open(path, 'r') as f:
+                assert f.read() == expected_ascii
+
+        expected_utf8 = '''\
+,names
+0,"[u'foo', u'bar']"
+1,"[u'baz', u'qux']"
+'''
+        with tm.ensure_clean('unicode_test.csv') as path:
+            df.to_csv(path, encoding='utf-8')
+            with open(path, 'r') as f:
+                assert f.read() == expected_utf8

--- a/pandas/tests/io/formats/test_to_csv.py
+++ b/pandas/tests/io/formats/test_to_csv.py
@@ -1,8 +1,9 @@
 # -*- coding: utf-8 -*-
 
-from pandas import DataFrame
 import numpy as np
 import pandas as pd
+import pytest
+from pandas import DataFrame
 from pandas.util import testing as tm
 
 
@@ -224,7 +225,7 @@ $1$,$2$
         exp = "foo\nbar\n1\n"
         assert df.to_csv(index=False) == exp
 
-    def test_to_csv_string_array(self):
+    def test_to_csv_string_array_ascii(self):
         # GH 10813
         str_array = [{'names': ['foo', 'bar']}, {'names': ['baz', 'qux']}]
         df = pd.DataFrame(str_array)
@@ -238,6 +239,11 @@ $1$,$2$
             with open(path, 'r') as f:
                 assert f.read() == expected_ascii
 
+    @pytest.mark.xfail
+    def test_to_csv_string_array_utf8(self):
+        # GH 10813
+        str_array = [{'names': ['foo', 'bar']}, {'names': ['baz', 'qux']}]
+        df = pd.DataFrame(str_array)
         expected_utf8 = '''\
 ,names
 0,"[u'foo', u'bar']"


### PR DESCRIPTION
So it looks like `df.to_csv()` is now working correctly for string arrays when using the `ascii` encoding but it is still broken when using `utf-8`.
