### PR TITLE
ERR: Fix segfault with .astype('category') on empty DataFrame

### DIFF
--- a/doc/source/whatsnew/v0.21.1.txt
+++ b/doc/source/whatsnew/v0.21.1.txt
@@ -113,7 +113,7 @@ Numeric
 Categorical
 ^^^^^^^^^^^
 
--
+- Bug in :meth:`DataFrame.astype` where casting to 'category' on an empty ``DataFrame`` causes a segmentation fault (:issue:`18004`)
 -
 -
 

--- a/pandas/_libs/src/inference.pyx
+++ b/pandas/_libs/src/inference.pyx
@@ -349,12 +349,12 @@ def infer_dtype(object value, bint skipna=False):
     if values.dtype != np.object_:
         values = values.astype('O')
 
+    # make contiguous
+    values = values.ravel()
+
     n = len(values)
     if n == 0:
         return 'empty'
-
-    # make contiguous
-    values = values.ravel()
 
     # try to use a valid value
     for i in range(n):

--- a/pandas/tests/dtypes/test_inference.py
+++ b/pandas/tests/dtypes/test_inference.py
@@ -416,6 +416,12 @@ class TestTypeInference(object):
         result = lib.infer_dtype([])
         assert result == 'empty'
 
+        # GH 18004
+        arr = np.array([np.array([], dtype=object),
+                        np.array([], dtype=object)])
+        result = lib.infer_dtype(arr)
+        assert result == 'empty'
+
     def test_integers(self):
         arr = np.array([1, 2, 3, np.int64(4), np.int32(5)], dtype='O')
         result = lib.infer_dtype(arr)

--- a/pandas/tests/test_categorical.py
+++ b/pandas/tests/test_categorical.py
@@ -2124,6 +2124,13 @@ class TestCategoricalAsBlock(object):
         res = s.astype(CategoricalDtype(list('abcdef'), ordered=True))
         tm.assert_series_equal(res, exp)
 
+    @pytest.mark.parametrize('columns', [['x'], ['x', 'y'], ['x', 'y', 'z']])
+    def test_empty_astype(self, columns):
+        # GH 18004
+        msg = '> 1 ndim Categorical are not supported at this time'
+        with tm.assert_raises_regex(NotImplementedError, msg):
+            DataFrame(columns=columns).astype('category')
+
     def test_construction_series(self):
 
         l = [1, 2, 3, 1]


### PR DESCRIPTION
- [X] closes #18004
- [X] tests added / passed
- [X] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [X] whatsnew entry

Credit to @cgohlke for determining the fix.