### PR TITLE
BUG: numpy.split on non-UTC changes original time (#14042)

### DIFF
--- a/doc/source/whatsnew/v0.21.0.txt
+++ b/doc/source/whatsnew/v0.21.0.txt
@@ -1041,6 +1041,8 @@ Indexing
 - Fixes ``DataFrame.loc`` for setting with alignment and tz-aware ``DatetimeIndex`` (:issue:`16889`)
 - Avoids ``IndexError`` when passing an Index or Series to ``.iloc`` with older numpy (:issue:`17193`)
 - Allow unicode empty strings as placeholders in multilevel columns in Python 2 (:issue:`17099`)
+<<<<<<< HEAD
+<<<<<<< HEAD
 - Bug in ``.iloc`` when used with inplace addition or assignment and an int indexer on a ``MultiIndex`` causing the wrong indexes to be read from and written to (:issue:`17148`)
 - Bug in ``.isin()`` in which checking membership in empty ``Series`` objects raised an error (:issue:`16991`)
 - Bug in ``CategoricalIndex`` reindexing in which specified indices containing duplicates were not being respected (:issue:`17323`)

--- a/doc/source/whatsnew/v0.21.1.txt
+++ b/doc/source/whatsnew/v0.21.1.txt
@@ -68,7 +68,7 @@ Conversion
 Indexing
 ^^^^^^^^
 
--
+- Bug in ``numpy`` ``array_wrap`` with a pandas ``Series``/``Index`` (:issue:`14042`)
 -
 -
 

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -573,7 +573,13 @@ class Index(IndexOpsMixin, PandasObject):
 
         attrs = self._get_attributes_dict()
         attrs = self._maybe_update_attributes(attrs)
-        return Index(result, **attrs)
+        from pandas.core.dtypes.generic import ABCDatetimeIndex
+        if issubclass(self, ABCDatetimeIndex) and 'tz' in attrs:
+            from pandas.core.indexes.datetimes import _new_DatetimeIndex
+            attrs['data'] = result
+            return _new_DatetimeIndex(self, attrs)
+        else:
+            return Index(result, **attrs)
 
     @cache_readonly
     def dtype(self):

--- a/pandas/tests/indexes/datetimes/test_datetime.py
+++ b/pandas/tests/indexes/datetimes/test_datetime.py
@@ -794,3 +794,19 @@ class TestDatetimeIndex(object):
         result = idx._maybe_cast_slice_bound('2017-01-01', 'left', 'loc')
         expected = Timestamp('2017-01-01')
         assert result == expected
+
+    def test_split_datetime_index_with_timezone(self):
+        # https://github.com/pandas-dev/pandas/issues/14042
+        # check if timezone is correctly handled in array_wrapper
+        tz = 'Asia/Seoul'
+        index = date_range('2000-01-01', periods=10, freq='D', tz=tz)
+        series = Series(index, np.arange(10))
+        index_split = np.split(index, indices_or_sections=5)
+        series_split = np.split(series, indices_or_sections=5)
+        for i in range(5):
+            index_expected = date_range('2000-01-{0:02d}'.format(2 * i + 1),
+                                        periods=2, freq='D', tz=tz)
+            series_expected = Series(index_expected,
+                                     np.arange(2 * i, 2 * i + 2))
+            tm.assert_index_equal(index_split[i], index_expected)
+            tm.assert_series_equal(series_split[i], series_expected)


### PR DESCRIPTION
Root cause: When a DatetimeIndex is created by __array_wrap__,
round-trip of timezone occured

Solution: Remove the timezone of the original index when creating
a DatetimeIndex via __array_wrap__ and apply the timezone later

- [x] closes #14042 
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry
