### PR TITLE
Remove old warnings (plus some useless code)

### DIFF
--- a/doc/source/whatsnew/v0.22.0.txt
+++ b/doc/source/whatsnew/v0.22.0.txt
@@ -60,7 +60,7 @@ Deprecations
 Removal of prior version deprecations/changes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
--
+- Warnings against the obsolete usage ``Categorical(codes, categories)``, which were emitted for instance when the first two arguments to ``Categorical()`` had different dtypes, and recommended the use of ``Categorical.from_codes``, have now been removed (:issue:`8074`)
 -
 -
 

--- a/pandas/core/categorical.py
+++ b/pandas/core/categorical.py
@@ -25,7 +25,6 @@ from pandas.core.dtypes.common import (
     is_timedelta64_dtype,
     is_categorical,
     is_categorical_dtype,
-    is_integer_dtype,
     is_list_like, is_sequence,
     is_scalar,
     is_dict_like)
@@ -352,28 +351,7 @@ class Categorical(PandasObject):
                 dtype = CategoricalDtype(categories, ordered)
 
         else:
-            # there were two ways if categories are present
-            # - the old one, where each value is a int pointer to the levels
-            #   array -> not anymore possible, but code outside of pandas could
-            #   call us like that, so make some checks
-            # - the new one, where each value is also in the categories array
-            #   (or np.nan)
-
             codes = _get_codes_for_values(values, dtype.categories)
-
-            # TODO: check for old style usage. These warnings should be removes
-            # after 0.18/ in 2016
-            if (is_integer_dtype(values) and
-                    not is_integer_dtype(dtype.categories)):
-                warn("Values and categories have different dtypes. Did you "
-                     "mean to use\n'Categorical.from_codes(codes, "
-                     "categories)'?", RuntimeWarning, stacklevel=2)
-
-            if (len(values) and is_integer_dtype(values) and
-                    (codes == -1).all()):
-                warn("None of the categories were found in values. Did you "
-                     "mean to use\n'Categorical.from_codes(codes, "
-                     "categories)'?", RuntimeWarning, stacklevel=2)
 
         if null_mask.any():
             # Reinsert -1 placeholders for previously removed missing values

--- a/pandas/core/categorical.py
+++ b/pandas/core/categorical.py
@@ -260,6 +260,7 @@ class Categorical(PandasObject):
         #    c.) infer from values
 
         if dtype is not None:
+            # The dtype argument takes precedence over values.dtype (if any)
             if isinstance(dtype, compat.string_types):
                 if dtype == 'category':
                     dtype = CategoricalDtype(categories, ordered)
@@ -274,9 +275,12 @@ class Categorical(PandasObject):
             ordered = dtype.ordered
 
         elif is_categorical(values):
+            # If no "dtype" was passed, use the one from "values", but honor
+            # the "ordered" and "categories" arguments
             dtype = values.dtype._from_categorical_dtype(values.dtype,
                                                          categories, ordered)
         else:
+            # If dtype=None and values is not categorical, create a new dtype
             dtype = CategoricalDtype(categories, ordered)
 
         # At this point, dtype is always a CategoricalDtype

--- a/pandas/tests/test_categorical.py
+++ b/pandas/tests/test_categorical.py
@@ -306,20 +306,18 @@ class TestCategorical(object):
         assert len(cat.codes) == 1
         assert cat.codes[0] == 0
 
-        # Catch old style constructor useage: two arrays, codes + categories
-        # We can only catch two cases:
+        # two arrays
         #  - when the first is an integer dtype and the second is not
         #  - when the resulting codes are all -1/NaN
-        with tm.assert_produces_warning(RuntimeWarning):
+        with tm.assert_produces_warning(None):
             c_old = Categorical([0, 1, 2, 0, 1, 2],
                                 categories=["a", "b", "c"])  # noqa
 
-        with tm.assert_produces_warning(RuntimeWarning):
+        with tm.assert_produces_warning(None):
             c_old = Categorical([0, 1, 2, 0, 1, 2],  # noqa
                                 categories=[3, 4, 5])
 
-        # the next one are from the old docs, but unfortunately these don't
-        # trigger :-(
+        # the next one are from the old docs
         with tm.assert_produces_warning(None):
             c_old2 = Categorical([0, 1, 2, 0, 1, 2], [1, 2, 3])  # noqa
             cat = Categorical([1, 2], categories=[1, 2, 3])


### PR DESCRIPTION
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`

This removes some warnings which @jreback [suggested](https://github.com/pandas-dev/pandas/pull/17934#discussion_r146225334) to split from #17934 , plus some other useless, probably obsolete, lines of code.