### PR TITLE
follow-up to #17943, closes #5168

### DIFF
--- a/doc/source/whatsnew/v0.22.0.txt
+++ b/doc/source/whatsnew/v0.22.0.txt
@@ -42,9 +42,9 @@ Other API Changes
 
 - ``NaT`` division with :class:`datetime.timedelta` will now return ``NaN`` instead of raising (:issue:`17876`)
 - All-NaN levels in ``MultiIndex`` are now assigned float rather than object dtype, coherently with flat indexes (:issue:`17929`).
-- :class:`Timestamp` will no longer silently ignore unused or invalid `tz` or `tzinfo` arguments (:issue:`17690`)
+- :class:`Timestamp` will no longer silently ignore unused or invalid `tz` or `tzinfo` keyword arguments (:issue:`17690`)
+- :class:`Timestamp` will no longer silently ignore invalid `freq` arguments (:issue:`5168`)
 - :class:`CacheableOffset` and :class:`WeekDay` are no longer available in the `tseries.offsets` module (:issue:`17830`)
--
 
 .. _whatsnew_0220.deprecations:
 

--- a/pandas/tests/scalar/test_timestamp.py
+++ b/pandas/tests/scalar/test_timestamp.py
@@ -183,7 +183,7 @@ class TestTimestamp(object):
         with tm.assert_raises_regex(ValueError, 'at most one of'):
             Timestamp('2017-10-22', tzinfo=utc, tz='UTC')
 
-        with tm.assert_raises_regex(ValueError: "Invalid frequency:"):
+        with tm.assert_raises_regex(ValueError, "Invalid frequency:"):
             # GH#5168
             # case where user tries to pass tz as an arg, not kwarg, gets
             # interpreted as a `freq`

--- a/pandas/tests/scalar/test_timestamp.py
+++ b/pandas/tests/scalar/test_timestamp.py
@@ -176,12 +176,18 @@ class TestTimestamp(object):
             Timestamp(Period('1000-01-01'))
 
     def test_constructor_invalid_tz(self):
-        # GH#17690, GH#5168
+        # GH#17690
         with tm.assert_raises_regex(TypeError, 'must be a datetime.tzinfo'):
             Timestamp('2017-10-22', tzinfo='US/Eastern')
 
         with tm.assert_raises_regex(ValueError, 'at most one of'):
             Timestamp('2017-10-22', tzinfo=utc, tz='UTC')
+
+        with tm.assert_raises_regex(ValueError: "Invalid frequency:"):
+            # GH#5168
+            # case where user tries to pass tz as an arg, not kwarg, gets
+            # interpreted as a `freq`
+            Timestamp('2012-01-01', 'US/Pacific')
 
     def test_constructor_tz_or_tzinfo(self):
         # GH#17943, GH#17690, GH#5168


### PR DESCRIPTION
- [x] closes #5168
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
