### PR TITLE
Separate tests specific to tslibs modules

### DIFF
--- a/pandas/tests/indexes/datetimes/test_ops.py
+++ b/pandas/tests/indexes/datetimes/test_ops.py
@@ -952,52 +952,6 @@ Freq: D"""
             assert not idx.equals(pd.Series(idx3))
 
 
-class TestDateTimeIndexToJulianDate(object):
-
-    def test_1700(self):
-        r1 = Float64Index([2345897.5, 2345898.5, 2345899.5, 2345900.5,
-                           2345901.5])
-        r2 = date_range(start=Timestamp('1710-10-01'), periods=5,
-                        freq='D').to_julian_date()
-        assert isinstance(r2, Float64Index)
-        tm.assert_index_equal(r1, r2)
-
-    def test_2000(self):
-        r1 = Float64Index([2451601.5, 2451602.5, 2451603.5, 2451604.5,
-                           2451605.5])
-        r2 = date_range(start=Timestamp('2000-02-27'), periods=5,
-                        freq='D').to_julian_date()
-        assert isinstance(r2, Float64Index)
-        tm.assert_index_equal(r1, r2)
-
-    def test_hour(self):
-        r1 = Float64Index(
-            [2451601.5, 2451601.5416666666666666, 2451601.5833333333333333,
-             2451601.625, 2451601.6666666666666666])
-        r2 = date_range(start=Timestamp('2000-02-27'), periods=5,
-                        freq='H').to_julian_date()
-        assert isinstance(r2, Float64Index)
-        tm.assert_index_equal(r1, r2)
-
-    def test_minute(self):
-        r1 = Float64Index(
-            [2451601.5, 2451601.5006944444444444, 2451601.5013888888888888,
-             2451601.5020833333333333, 2451601.5027777777777777])
-        r2 = date_range(start=Timestamp('2000-02-27'), periods=5,
-                        freq='T').to_julian_date()
-        assert isinstance(r2, Float64Index)
-        tm.assert_index_equal(r1, r2)
-
-    def test_second(self):
-        r1 = Float64Index(
-            [2451601.5, 2451601.500011574074074, 2451601.5000231481481481,
-             2451601.5000347222222222, 2451601.5000462962962962])
-        r2 = date_range(start=Timestamp('2000-02-27'), periods=5,
-                        freq='S').to_julian_date()
-        assert isinstance(r2, Float64Index)
-        tm.assert_index_equal(r1, r2)
-
-
 # GH 10699
 @pytest.mark.parametrize('klass,assert_func', zip([Series, DatetimeIndex],
                                                   [tm.assert_series_equal,

--- a/pandas/tests/indexes/datetimes/test_ops.py
+++ b/pandas/tests/indexes/datetimes/test_ops.py
@@ -3,7 +3,7 @@ import pytest
 import dateutil
 import warnings
 import numpy as np
-from datetime import timedelta
+from datetime import timedelta, datetime
 
 from itertools import product
 import pandas as pd
@@ -12,7 +12,7 @@ import pandas.util.testing as tm
 from pandas.errors import PerformanceWarning
 from pandas import (DatetimeIndex, PeriodIndex, Series, Timestamp, Timedelta,
                     date_range, TimedeltaIndex, _np_version_under1p10, Index,
-                    datetime, Float64Index, offsets, bdate_range)
+                    bdate_range)
 from pandas.tseries.offsets import BMonthEnd, CDay, BDay
 from pandas.tests.test_base import Ops
 
@@ -1077,7 +1077,7 @@ def test_shift_months(years, months):
                        Timestamp('2000-12-31')])
     actual = DatetimeIndex(tslib.shift_months(s.asi8, years * 12 +
                                               months))
-    expected = DatetimeIndex([x + offsets.DateOffset(
+    expected = DatetimeIndex([x + pd.offsets.DateOffset(
         years=years, months=months) for x in s])
     tm.assert_index_equal(actual, expected)
 

--- a/pandas/tests/scalar/test_parsing.py
+++ b/pandas/tests/scalar/test_parsing.py
@@ -1,0 +1,137 @@
+# -*- coding: utf-8 -*-
+"""
+Tests for Timestamp parsing, aimed at pandas/_libs/tslibs/parsing.pyx
+"""
+from datetime import datetime
+
+import numpy as np
+
+from pandas import compat
+from pandas.util import testing as tm
+
+from pandas._libs.tslibs import parsing
+
+
+class TestDatetimeParsingWrappers(object):
+    def test_does_not_convert_mixed_integer(self):
+        bad_date_strings = ('-50000', '999', '123.1234', 'm', 'T')
+
+        for bad_date_string in bad_date_strings:
+            assert not parsing._does_string_look_like_datetime(bad_date_string)
+
+        good_date_strings = ('2012-01-01',
+                             '01/01/2012',
+                             'Mon Sep 16, 2013',
+                             '01012012',
+                             '0101',
+                             '1-1', )
+
+        for good_date_string in good_date_strings:
+            assert parsing._does_string_look_like_datetime(good_date_string)
+
+    def test_parsers_quarterly_with_freq(self):
+        msg = ('Incorrect quarterly string is given, quarter '
+               'must be between 1 and 4: 2013Q5')
+        with tm.assert_raises_regex(parsing.DateParseError, msg):
+            parsing.parse_time_string('2013Q5')
+
+        # GH 5418
+        msg = ('Unable to retrieve month information from given freq: '
+               'INVLD-L-DEC-SAT')
+        with tm.assert_raises_regex(parsing.DateParseError, msg):
+            parsing.parse_time_string('2013Q1', freq='INVLD-L-DEC-SAT')
+
+        cases = {('2013Q2', None): datetime(2013, 4, 1),
+                 ('2013Q2', 'A-APR'): datetime(2012, 8, 1),
+                 ('2013-Q2', 'A-DEC'): datetime(2013, 4, 1)}
+
+        for (date_str, freq), exp in compat.iteritems(cases):
+            result, _, _ = parsing.parse_time_string(date_str, freq=freq)
+            assert result == exp
+
+    def test_parsers_quarter_invalid(self):
+
+        cases = ['2Q 2005', '2Q-200A', '2Q-200', '22Q2005', '6Q-20', '2Q200.']
+        for case in cases:
+            pytest.raises(ValueError, parsing.parse_time_string, case)
+
+    def test_parsers_monthfreq(self):
+        cases = {'201101': datetime(2011, 1, 1, 0, 0),
+                 '200005': datetime(2000, 5, 1, 0, 0)}
+
+        for date_str, expected in compat.iteritems(cases):
+            result1, _, _ = parsing.parse_time_string(date_str, freq='M')
+            assert result1 == expected
+
+
+class TestGuessDatetimeFormat(object):
+    def test_guess_datetime_format_with_parseable_formats(self):
+        tm._skip_if_not_us_locale()
+        dt_string_to_format = (('20111230', '%Y%m%d'),
+                               ('2011-12-30', '%Y-%m-%d'),
+                               ('30-12-2011', '%d-%m-%Y'),
+                               ('2011-12-30 00:00:00', '%Y-%m-%d %H:%M:%S'),
+                               ('2011-12-30T00:00:00', '%Y-%m-%dT%H:%M:%S'),
+                               ('2011-12-30 00:00:00.000000',
+                                '%Y-%m-%d %H:%M:%S.%f'), )
+
+        for dt_string, dt_format in dt_string_to_format:
+            assert parsing._guess_datetime_format(dt_string) == dt_format
+
+    def test_guess_datetime_format_with_dayfirst(self):
+        ambiguous_string = '01/01/2011'
+        assert parsing._guess_datetime_format(
+            ambiguous_string, dayfirst=True) == '%d/%m/%Y'
+        assert parsing._guess_datetime_format(
+            ambiguous_string, dayfirst=False) == '%m/%d/%Y'
+
+    def test_guess_datetime_format_with_locale_specific_formats(self):
+        # The month names will vary depending on the locale, in which
+        # case these wont be parsed properly (dateutil can't parse them)
+        tm._skip_if_has_locale()
+
+        dt_string_to_format = (('30/Dec/2011', '%d/%b/%Y'),
+                               ('30/December/2011', '%d/%B/%Y'),
+                               ('30/Dec/2011 00:00:00', '%d/%b/%Y %H:%M:%S'), )
+
+        for dt_string, dt_format in dt_string_to_format:
+            assert parsing._guess_datetime_format(dt_string) == dt_format
+
+    def test_guess_datetime_format_invalid_inputs(self):
+        # A datetime string must include a year, month and a day for it
+        # to be guessable, in addition to being a string that looks like
+        # a datetime
+        invalid_dts = [
+            '2013',
+            '01/2013',
+            '12:00:00',
+            '1/1/1/1',
+            'this_is_not_a_datetime',
+            '51a',
+            9,
+            datetime(2011, 1, 1),
+        ]
+
+        for invalid_dt in invalid_dts:
+            assert parsing._guess_datetime_format(invalid_dt) is None
+
+    def test_guess_datetime_format_nopadding(self):
+        # GH 11142
+        dt_string_to_format = (('2011-1-1', '%Y-%m-%d'),
+                               ('30-1-2011', '%d-%m-%Y'),
+                               ('1/1/2011', '%m/%d/%Y'),
+                               ('2011-1-1 00:00:00', '%Y-%m-%d %H:%M:%S'),
+                               ('2011-1-1 0:0:0', '%Y-%m-%d %H:%M:%S'),
+                               ('2011-1-3T00:00:0', '%Y-%m-%dT%H:%M:%S'))
+
+        for dt_string, dt_format in dt_string_to_format:
+            assert parsing._guess_datetime_format(dt_string) == dt_format
+
+class TestArrayToDatetime(object):
+
+    def test_try_parse_dates(self):
+        arr = np.array(['5/1/2000', '6/1/2000', '7/1/2000'], dtype=object)
+
+        result = parsing.try_parse_dates(arr, dayfirst=True)
+        expected = [parse(d, dayfirst=True) for d in arr]
+        assert np.array_equal(result, expected)

--- a/pandas/tests/scalar/test_parsing.py
+++ b/pandas/tests/scalar/test_parsing.py
@@ -136,4 +136,4 @@ class TestArrayToDatetime(object):
 
         result = parsing.try_parse_dates(arr, dayfirst=True)
         expected = [parse(d, dayfirst=True) for d in arr]
-        assert np.array_equal(result, expected)
+        assert tm.assert_numpy_array_equal(result, expected)

--- a/pandas/tests/scalar/test_parsing.py
+++ b/pandas/tests/scalar/test_parsing.py
@@ -5,6 +5,8 @@ Tests for Timestamp parsing, aimed at pandas/_libs/tslibs/parsing.pyx
 from datetime import datetime
 
 import numpy as np
+import pytest
+from dateutil.parser import parse
 
 from pandas import compat
 from pandas.util import testing as tm
@@ -24,7 +26,7 @@ class TestDatetimeParsingWrappers(object):
                              'Mon Sep 16, 2013',
                              '01012012',
                              '0101',
-                             '1-1', )
+                             '1-1')
 
         for good_date_string in good_date_strings:
             assert parsing._does_string_look_like_datetime(good_date_string)
@@ -127,8 +129,8 @@ class TestGuessDatetimeFormat(object):
         for dt_string, dt_format in dt_string_to_format:
             assert parsing._guess_datetime_format(dt_string) == dt_format
 
-class TestArrayToDatetime(object):
 
+class TestArrayToDatetime(object):
     def test_try_parse_dates(self):
         arr = np.array(['5/1/2000', '6/1/2000', '7/1/2000'], dtype=object)
 

--- a/pandas/tests/scalar/test_parsing.py
+++ b/pandas/tests/scalar/test_parsing.py
@@ -135,5 +135,5 @@ class TestArrayToDatetime(object):
         arr = np.array(['5/1/2000', '6/1/2000', '7/1/2000'], dtype=object)
 
         result = parsing.try_parse_dates(arr, dayfirst=True)
-        expected = [parse(d, dayfirst=True) for d in arr]
+        expected = np.array([parse(d, dayfirst=True) for d in arr])
         tm.assert_numpy_array_equal(result, expected)

--- a/pandas/tests/scalar/test_parsing.py
+++ b/pandas/tests/scalar/test_parsing.py
@@ -136,4 +136,4 @@ class TestArrayToDatetime(object):
 
         result = parsing.try_parse_dates(arr, dayfirst=True)
         expected = [parse(d, dayfirst=True) for d in arr]
-        assert tm.assert_numpy_array_equal(result, expected)
+        tm.assert_numpy_array_equal(result, expected)


### PR DESCRIPTION
Going through the tests in tests/scalars, tests/indexes/datetimes, tests/indexes/timedeltas, tests/indexes/period, there is a lot of duplication and a lot of thematically inappropriate placement.  This is a natural result of tests being added over the years.

One result of this, though, is that its easy to miss certain corner cases (#17991, #7996).

There are two things I'd like to do here.  First is gather tests specific to `tslibs` modules so they can be self-contained.  This PR starts that for `tslibs.parsing`.

Second is to go through tests.indexes centralize arithmetic tests, deduplicate where needed (#18026).  This is a big task without an immediate payoff, so I want to get the go-ahead before jumping in.

- [ ] closes #xxxx
- [ ] tests added / passed
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
