### PR TITLE
DOC: header='infer' is not working when there is no header, closes #17473

### DIFF
--- a/doc/source/io.rst
+++ b/doc/source/io.rst
@@ -108,14 +108,15 @@ header : int or list of ints, default ``'infer'``
   passed the behavior is identical to ``header=0`` and column names
   are inferred from the first line of the file, if column names are
   passed explicitly then the behavior is identical to
-  ``header=None``. Explicitly pass ``header=0`` to be able to replace
-  existing names. The header can be a list of ints that specify row
-  locations for a multi-index on the columns
-  e.g. ``[0,1,3]``. Intervening rows that are not specified will be
-  skipped (e.g. 2 in this example is skipped). Note that this
-  parameter ignores commented lines and empty lines if
-  ``skip_blank_lines=True``, so header=0 denotes the first line of
-  data rather than the first line of the file.
+  ``header=None``.
+
+  Explicitly pass ``header=0`` to be able to replace existing
+  names. The header can be a list of ints that specify row locations
+  for a multi-index on the columns e.g. ``[0,1,3]``. Intervening rows
+  that are not specified will be skipped (e.g. 2 in this example is
+  skipped). Note that this parameter ignores commented lines and empty
+  lines if ``skip_blank_lines=True``, so header=0 denotes the first
+  line of data rather than the first line of the file.
 names : array-like, default ``None``
   List of column names to use. If file contains no header row, then you should
   explicitly pass ``header=None``. Duplicates in this list will cause

--- a/doc/source/io.rst
+++ b/doc/source/io.rst
@@ -103,15 +103,19 @@ Column and Index Locations and Names
 ++++++++++++++++++++++++++++++++++++
 
 header : int or list of ints, default ``'infer'``
-  Row number(s) to use as the column names, and the start of the data. Default
-  behavior is as if ``header=0`` if no ``names`` passed, otherwise as if
-  ``header=None``. Explicitly pass ``header=0`` to be able to replace existing
-  names. The header can be a list of ints that specify row locations for a
-  multi-index on the columns e.g. ``[0,1,3]``. Intervening rows that are not
-  specified will be skipped (e.g. 2 in this example is skipped). Note that
-  this parameter ignores commented lines and empty lines if
-  ``skip_blank_lines=True``, so header=0 denotes the first line of data
-  rather than the first line of the file.
+  Row number(s) to use as the column names, and the start of the
+  data. Default behavior is to infer the column names: if no names are
+  passed the behavior is identical to ``header=0`` and column names
+  are inferred from the first line of the file, if column names are
+  passed explicitly then the behavior is identical to
+  ``header=None``. Explicitly pass ``header=0`` to be able to replace
+  existing names. The header can be a list of ints that specify row
+  locations for a multi-index on the columns
+  e.g. ``[0,1,3]``. Intervening rows that are not specified will be
+  skipped (e.g. 2 in this example is skipped). Note that this
+  parameter ignores commented lines and empty lines if
+  ``skip_blank_lines=True``, so header=0 denotes the first line of
+  data rather than the first line of the file.
 names : array-like, default ``None``
   List of column names to use. If file contains no header row, then you should
   explicitly pass ``header=None``. Duplicates in this list will cause

--- a/doc/source/io.rst
+++ b/doc/source/io.rst
@@ -558,6 +558,11 @@ If the header is in a row other than the first, pass the row number to
     data = 'skip this skip it\na,b,c\n1,2,3\n4,5,6\n7,8,9'
     pd.read_csv(StringIO(data), header=1)
 
+.. note::
+
+   The default behavior of ``read_csv`` is to use ``header='infer'``,
+   which will use the first nonblank row of the file as a header row.
+
 .. _io.dupe_names:
 
 Duplicate names parsing

--- a/doc/source/io.rst
+++ b/doc/source/io.rst
@@ -560,8 +560,11 @@ If the header is in a row other than the first, pass the row number to
 
 .. note::
 
-   The default behavior of ``read_csv`` is to use ``header='infer'``,
-   which will use the first nonblank row of the file as a header row.
+  Default behavior is to infer the column names: if no names are
+  passed the behavior is identical to ``header=0`` and column names
+  are inferred from the first line of the file, if column names are
+  passed explicitly then the behavior is identical to
+  ``header=None``.
 
 .. _io.dupe_names:
 

--- a/doc/source/io.rst
+++ b/doc/source/io.rst
@@ -108,10 +108,10 @@ header : int or list of ints, default ``'infer'``
   passed the behavior is identical to ``header=0`` and column names
   are inferred from the first line of the file, if column names are
   passed explicitly then the behavior is identical to
-  ``header=None``.
+  ``header=None``. Explicitly pass ``header=0`` to be able to replace
+  existing names.
 
-  Explicitly pass ``header=0`` to be able to replace existing
-  names. The header can be a list of ints that specify row locations
+  The header can be a list of ints that specify row locations
   for a multi-index on the columns e.g. ``[0,1,3]``. Intervening rows
   that are not specified will be skipped (e.g. 2 in this example is
   skipped). Note that this parameter ignores commented lines and empty
@@ -562,11 +562,9 @@ If the header is in a row other than the first, pass the row number to
 
   Default behavior is to infer the column names: if no names are
   passed the behavior is identical to ``header=0`` and column names
-  are inferred from the first line of the file, if column names are
-  passed explicitly then the behavior is identical to
+  are inferred from the first nonblank line of the file, if column
+  names are passed explicitly then the behavior is identical to
   ``header=None``.
-   The default behavior of ``read_csv`` is to use ``header='infer'``,
-   which will use the first nonblank row of the file as a header row.
 
 .. _io.dupe_names:
 

--- a/doc/source/io.rst
+++ b/doc/source/io.rst
@@ -565,6 +565,8 @@ If the header is in a row other than the first, pass the row number to
   are inferred from the first line of the file, if column names are
   passed explicitly then the behavior is identical to
   ``header=None``.
+   The default behavior of ``read_csv`` is to use ``header='infer'``,
+   which will use the first nonblank row of the file as a header row.
 
 .. _io.dupe_names:
 

--- a/pandas/io/parsers.py
+++ b/pandas/io/parsers.py
@@ -74,15 +74,19 @@ delim_whitespace : boolean, default False
     .. versionadded:: 0.18.1 support for the Python parser.
 
 header : int or list of ints, default 'infer'
-    Row number(s) to use as the column names, and the start of the data.
-    Default behavior is as if set to 0 if no ``names`` passed, otherwise
-    ``None``. Explicitly pass ``header=0`` to be able to replace existing
-    names. The header can be a list of integers that specify row locations for
-    a multi-index on the columns e.g. [0,1,3]. Intervening rows that are not
-    specified will be skipped (e.g. 2 in this example is skipped). Note that
-    this parameter ignores commented lines and empty lines if
-    ``skip_blank_lines=True``, so header=0 denotes the first line of data
-    rather than the first line of the file.
+    Row number(s) to use as the column names, and the start of the
+    data.  Default behavior is to infer the column names: if no names
+    are passed the behavior is identical to ``header=0`` and column
+    names are inferred from the first line of the file, if column
+    names are passed explicitly then the behavior is identical to
+    ``header=None``. Explicitly pass ``header=0`` to be able to
+    replace existing names. The header can be a list of integers that
+    specify row locations for a multi-index on the columns
+    e.g. [0,1,3]. Intervening rows that are not specified will be
+    skipped (e.g. 2 in this example is skipped). Note that this
+    parameter ignores commented lines and empty lines if
+    ``skip_blank_lines=True``, so header=0 denotes the first line of
+    data rather than the first line of the file.
 names : array-like, default None
     List of column names to use. If file contains no header row, then you
     should explicitly pass header=None. Duplicates in this list will cause


### PR DESCRIPTION
- [X] closes #17483
