### PR TITLE
move src/datetime.pxd funcs to np_datetime and fix misleading names

### DIFF
--- a/pandas/_libs/src/datetime.pxd
+++ b/pandas/_libs/src/datetime.pxd
@@ -136,28 +136,6 @@ cdef inline int _cstring_to_dts(char *val, int length,
     return result
 
 
-cdef inline int64_t _pydatetime_to_dts(object val, pandas_datetimestruct *dts):
-    dts.year = PyDateTime_GET_YEAR(val)
-    dts.month = PyDateTime_GET_MONTH(val)
-    dts.day = PyDateTime_GET_DAY(val)
-    dts.hour = PyDateTime_DATE_GET_HOUR(val)
-    dts.min = PyDateTime_DATE_GET_MINUTE(val)
-    dts.sec = PyDateTime_DATE_GET_SECOND(val)
-    dts.us = PyDateTime_DATE_GET_MICROSECOND(val)
-    dts.ps = dts.as = 0
-    return pandas_datetimestruct_to_datetime(PANDAS_FR_ns, dts)
-
-
-cdef inline int64_t _date_to_datetime64(object val,
-                                        pandas_datetimestruct *dts):
-    dts.year = PyDateTime_GET_YEAR(val)
-    dts.month = PyDateTime_GET_MONTH(val)
-    dts.day = PyDateTime_GET_DAY(val)
-    dts.hour = dts.min = dts.sec = dts.us = 0
-    dts.ps = dts.as = 0
-    return pandas_datetimestruct_to_datetime(PANDAS_FR_ns, dts)
-
-
 cdef inline bint check_dts_bounds(pandas_datetimestruct *dts):
     """Returns True if an error needs to be raised"""
     cdef:

--- a/pandas/_libs/tslib.pyx
+++ b/pandas/_libs/tslib.pyx
@@ -41,8 +41,6 @@ from datetime cimport (
     get_datetime64_unit,
     PANDAS_DATETIMEUNIT,
     _string_to_dts,
-    _pydatetime_to_dt64,
-    _pydate_to_dt64,
     npy_datetime,
     is_leapyear,
     dayofweek,
@@ -57,7 +55,8 @@ from datetime import time as datetime_time
 
 from tslibs.np_datetime cimport (check_dts_bounds,
                                  pandas_datetimestruct,
-                                 dt64_to_dtstruct, dtstruct_to_dt64)
+                                 dt64_to_dtstruct, dtstruct_to_dt64,
+                                 _pydatetime_to_dt64, _pydate_to_dt64)
 from tslibs.np_datetime import OutOfBoundsDatetime
 
 from khash cimport (

--- a/pandas/_libs/tslib.pyx
+++ b/pandas/_libs/tslib.pyx
@@ -56,7 +56,7 @@ from datetime import time as datetime_time
 from tslibs.np_datetime cimport (check_dts_bounds,
                                  pandas_datetimestruct,
                                  dt64_to_dtstruct, dtstruct_to_dt64,
-                                 _pydatetime_to_dt64, _pydate_to_dt64)
+                                 pydatetime_to_dt64, pydate_to_dt64)
 from tslibs.np_datetime import OutOfBoundsDatetime
 
 from khash cimport (
@@ -1679,7 +1679,7 @@ cdef _TSObject convert_datetime_to_tsobject(datetime ts, object tz,
             if (hasattr(tz, 'normalize') and
                 hasattr(ts.tzinfo, '_utcoffset')):
                 ts = tz.normalize(ts)
-                obj.value = _pydatetime_to_dt64(ts, &obj.dts)
+                obj.value = pydatetime_to_dt64(ts, &obj.dts)
                 obj.tzinfo = ts.tzinfo
             else:
                 # tzoffset
@@ -1687,7 +1687,7 @@ cdef _TSObject convert_datetime_to_tsobject(datetime ts, object tz,
                     tz = ts.astimezone(tz).tzinfo
                 except:
                     pass
-                obj.value = _pydatetime_to_dt64(ts, &obj.dts)
+                obj.value = pydatetime_to_dt64(ts, &obj.dts)
                 ts_offset = get_utcoffset(ts.tzinfo, ts)
                 obj.value -= int(ts_offset.total_seconds() * 1e9)
                 tz_offset = get_utcoffset(tz, ts)
@@ -1697,14 +1697,14 @@ cdef _TSObject convert_datetime_to_tsobject(datetime ts, object tz,
                 obj.tzinfo = tz
         elif not is_utc(tz):
             ts = _localize_pydatetime(ts, tz)
-            obj.value = _pydatetime_to_dt64(ts, &obj.dts)
+            obj.value = pydatetime_to_dt64(ts, &obj.dts)
             obj.tzinfo = ts.tzinfo
         else:
             # UTC
-            obj.value = _pydatetime_to_dt64(ts, &obj.dts)
+            obj.value = pydatetime_to_dt64(ts, &obj.dts)
             obj.tzinfo = pytz.utc
     else:
-        obj.value = _pydatetime_to_dt64(ts, &obj.dts)
+        obj.value = pydatetime_to_dt64(ts, &obj.dts)
         obj.tzinfo = ts.tzinfo
 
     if obj.tzinfo is not None and not is_utc(obj.tzinfo):
@@ -1858,7 +1858,7 @@ def datetime_to_datetime64(ndarray[object] values):
                 if inferred_tz is not None:
                     raise ValueError('Cannot mix tz-aware with '
                                      'tz-naive values')
-                iresult[i] = _pydatetime_to_dt64(val, &dts)
+                iresult[i] = pydatetime_to_dt64(val, &dts)
                 check_dts_bounds(&dts)
         else:
             raise TypeError('Unrecognized value type: %s' % type(val))
@@ -2183,7 +2183,7 @@ cpdef array_to_datetime(ndarray[object] values, errors='raise',
                                          'be converted to datetime64 unless '
                                          'utc=True')
                 else:
-                    iresult[i] = _pydatetime_to_dt64(val, &dts)
+                    iresult[i] = pydatetime_to_dt64(val, &dts)
                     if is_timestamp(val):
                         iresult[i] += val.nanosecond
                     try:
@@ -2195,7 +2195,7 @@ cpdef array_to_datetime(ndarray[object] values, errors='raise',
                         raise
 
             elif PyDate_Check(val):
-                iresult[i] = _pydate_to_dt64(val, &dts)
+                iresult[i] = pydate_to_dt64(val, &dts)
                 try:
                     check_dts_bounds(&dts)
                     seen_datetime = 1
@@ -2352,7 +2352,7 @@ cpdef array_to_datetime(ndarray[object] values, errors='raise',
                 try:
                     oresult[i] = parse_datetime_string(val, dayfirst=dayfirst,
                                                        yearfirst=yearfirst)
-                    _pydatetime_to_dt64(oresult[i], &dts)
+                    pydatetime_to_dt64(oresult[i], &dts)
                     check_dts_bounds(&dts)
                 except Exception:
                     if is_raise:

--- a/pandas/_libs/tslibs/np_datetime.pxd
+++ b/pandas/_libs/tslibs/np_datetime.pxd
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 # cython: profile=False
 
+from cpython.datetime cimport date, datetime
+
 from numpy cimport int64_t, int32_t
 
 
@@ -14,3 +16,6 @@ cdef check_dts_bounds(pandas_datetimestruct *dts)
 
 cdef int64_t dtstruct_to_dt64(pandas_datetimestruct* dts) nogil
 cdef void dt64_to_dtstruct(int64_t dt64, pandas_datetimestruct* out) nogil
+
+cdef int64_t _pydatetime_to_dt64(datetime val, pandas_datetimestruct *dts)
+cdef int64_t _pydate_to_dt64(date val, pandas_datetimestruct *dts)

--- a/pandas/_libs/tslibs/np_datetime.pxd
+++ b/pandas/_libs/tslibs/np_datetime.pxd
@@ -17,5 +17,5 @@ cdef check_dts_bounds(pandas_datetimestruct *dts)
 cdef int64_t dtstruct_to_dt64(pandas_datetimestruct* dts) nogil
 cdef void dt64_to_dtstruct(int64_t dt64, pandas_datetimestruct* out) nogil
 
-cdef int64_t _pydatetime_to_dt64(datetime val, pandas_datetimestruct *dts)
-cdef int64_t _pydate_to_dt64(date val, pandas_datetimestruct *dts)
+cdef int64_t pydatetime_to_dt64(datetime val, pandas_datetimestruct *dts)
+cdef int64_t pydate_to_dt64(date val, pandas_datetimestruct *dts)

--- a/pandas/_libs/tslibs/np_datetime.pyx
+++ b/pandas/_libs/tslibs/np_datetime.pyx
@@ -91,8 +91,8 @@ cdef inline void dt64_to_dtstruct(int64_t dt64,
     return
 
 
-cdef inline int64_t _pydatetime_to_dt64(datetime val,
-                                        pandas_datetimestruct *dts):
+cdef inline int64_t pydatetime_to_dt64(datetime val,
+                                       pandas_datetimestruct *dts):
     dts.year = PyDateTime_GET_YEAR(val)
     dts.month = PyDateTime_GET_MONTH(val)
     dts.day = PyDateTime_GET_DAY(val)
@@ -104,8 +104,8 @@ cdef inline int64_t _pydatetime_to_dt64(datetime val,
     return dtstruct_to_dt64(dts)
 
 
-cdef inline int64_t _pydate_to_dt64(date val,
-                                    pandas_datetimestruct *dts):
+cdef inline int64_t pydate_to_dt64(date val,
+                                   pandas_datetimestruct *dts):
     dts.year = PyDateTime_GET_YEAR(val)
     dts.month = PyDateTime_GET_MONTH(val)
     dts.day = PyDateTime_GET_DAY(val)

--- a/pandas/_libs/tslibs/np_datetime.pyx
+++ b/pandas/_libs/tslibs/np_datetime.pyx
@@ -1,6 +1,15 @@
 # -*- coding: utf-8 -*-
 # cython: profile=False
 
+from cpython.datetime cimport (datetime, date,
+                               PyDateTime_IMPORT,
+                               PyDateTime_GET_YEAR, PyDateTime_GET_MONTH,
+                               PyDateTime_GET_DAY, PyDateTime_DATE_GET_HOUR,
+                               PyDateTime_DATE_GET_MINUTE,
+                               PyDateTime_DATE_GET_SECOND,
+                               PyDateTime_DATE_GET_MICROSECOND)
+PyDateTime_IMPORT
+
 from numpy cimport int64_t
 
 cdef extern from "numpy/ndarrayobject.h":
@@ -80,3 +89,26 @@ cdef inline void dt64_to_dtstruct(int64_t dt64,
     with the by-far-most-common frequency PANDAS_FR_ns"""
     pandas_datetime_to_datetimestruct(dt64, PANDAS_FR_ns, out)
     return
+
+
+cdef inline int64_t _pydatetime_to_dt64(datetime val,
+                                        pandas_datetimestruct *dts):
+    dts.year = PyDateTime_GET_YEAR(val)
+    dts.month = PyDateTime_GET_MONTH(val)
+    dts.day = PyDateTime_GET_DAY(val)
+    dts.hour = PyDateTime_DATE_GET_HOUR(val)
+    dts.min = PyDateTime_DATE_GET_MINUTE(val)
+    dts.sec = PyDateTime_DATE_GET_SECOND(val)
+    dts.us = PyDateTime_DATE_GET_MICROSECOND(val)
+    dts.ps = dts.as = 0
+    return dtstruct_to_dt64(dts)
+
+
+cdef inline int64_t _pydate_to_dt64(date val,
+                                    pandas_datetimestruct *dts):
+    dts.year = PyDateTime_GET_YEAR(val)
+    dts.month = PyDateTime_GET_MONTH(val)
+    dts.day = PyDateTime_GET_DAY(val)
+    dts.hour = dts.min = dts.sec = dts.us = 0
+    dts.ps = dts.as = 0
+    return dtstruct_to_dt64(dts)

--- a/pandas/_libs/tslibs/offsets.pyx
+++ b/pandas/_libs/tslibs/offsets.pyx
@@ -13,8 +13,8 @@ np.import_array()
 
 from util cimport is_string_object
 
-
-from pandas._libs.tslib import pydt_to_i8, tz_convert_single
+from conversion cimport tz_convert_single
+from pandas._libs.tslib import pydt_to_i8
 
 # ---------------------------------------------------------------------
 # Constants


### PR DESCRIPTION
The name `_pydatetime_to_dts` is misleading, since `dts` is the variable names used for `pandas_datetimestruct` objects, while the func actually returns an int64.  This renames it to `_pydatetime_to_dt64`.

The analogous function for `datetime.date` has the non-misleading name `_date_to_datetime64`.  For consistency this is renamed to `_pydate_to_dt64`.

Both are moved to `np_datetime`, and have their inputs typed as `datetime` and `date` instead of `object`.
