### PR TITLE
MAINT: Remove np.array_equal calls in tests

### DIFF
--- a/pandas/tests/dtypes/test_cast.py
+++ b/pandas/tests/dtypes/test_cast.py
@@ -38,17 +38,17 @@ class TestMaybeDowncast(object):
 
         arr = np.array([8.5, 8.6, 8.7, 8.8, 8.9999999999995])
         result = maybe_downcast_to_dtype(arr, 'infer')
-        assert (np.array_equal(result, arr))
+        tm.assert_numpy_array_equal(result, arr)
 
         arr = np.array([8., 8., 8., 8., 8.9999999999995])
         result = maybe_downcast_to_dtype(arr, 'infer')
-        expected = np.array([8, 8, 8, 8, 9])
-        assert (np.array_equal(result, expected))
+        expected = np.array([8, 8, 8, 8, 9], dtype=np.int64)
+        tm.assert_numpy_array_equal(result, expected)
 
         arr = np.array([8., 8., 8., 8., 9.0000000000005])
         result = maybe_downcast_to_dtype(arr, 'infer')
-        expected = np.array([8, 8, 8, 8, 9])
-        assert (np.array_equal(result, expected))
+        expected = np.array([8, 8, 8, 8, 9], dtype=np.int64)
+        tm.assert_numpy_array_equal(result, expected)
 
         # GH16875 coercing of bools
         ser = Series([True, True, False])

--- a/pandas/tests/frame/test_constructors.py
+++ b/pandas/tests/frame/test_constructors.py
@@ -1913,10 +1913,11 @@ class TestDataFrameConstructors(TestData):
         # #2633
         result = DataFrame.from_records([], index='foo',
                                         columns=['foo', 'bar'])
+        expected = Index(['bar'])
 
-        assert np.array_equal(result.columns, ['bar'])
         assert len(result) == 0
         assert result.index.name == 'foo'
+        tm.assert_index_equal(result.columns, expected)
 
     def test_to_frame_with_falsey_names(self):
         # GH 16114

--- a/pandas/tests/frame/test_nonunique_indexes.py
+++ b/pandas/tests/frame/test_nonunique_indexes.py
@@ -448,7 +448,7 @@ class TestDataFrameNonuniqueIndexes(TestData):
         expected = np.array([[1, 2, 'a', 'b'], [1, 2, 'a', 'b']],
                             dtype=object)
 
-        assert np.array_equal(result, expected)
+        tm.assert_numpy_array_equal(result, expected)
 
     def test_set_value_by_index(self):
         # See gh-12344

--- a/pandas/tests/indexes/datetimes/test_date_range.py
+++ b/pandas/tests/indexes/datetimes/test_date_range.py
@@ -20,14 +20,6 @@ from pandas.tests.series.common import TestData
 START, END = datetime(2009, 1, 1), datetime(2010, 1, 1)
 
 
-def eq_gen_range(kwargs, expected):
-    rng = generate_range(**kwargs)
-    result = np.asarray(list(rng))
-    expected = np.asarray(expected)
-
-    tm.assert_numpy_array_equal(result, expected)
-
-
 class TestDateRanges(TestData):
 
     def test_date_range_gen_error(self):
@@ -204,20 +196,23 @@ class TestGenRangeGeneration(object):
         assert rng1 == rng2
 
     def test_1(self):
-        eq_gen_range(dict(start=datetime(2009, 3, 25), periods=2),
-                     [datetime(2009, 3, 25), datetime(2009, 3, 26)])
+        rng = list(generate_range(start=datetime(2009, 3, 25), periods=2))
+        expected = [datetime(2009, 3, 25), datetime(2009, 3, 26)]
+        assert rng == expected
 
     def test_2(self):
-        eq_gen_range(dict(start=datetime(2008, 1, 1),
-                          end=datetime(2008, 1, 3)),
-                     [datetime(2008, 1, 1),
-                      datetime(2008, 1, 2),
-                      datetime(2008, 1, 3)])
+        rng = list(generate_range(start=datetime(2008, 1, 1),
+                                  end=datetime(2008, 1, 3)))
+        expected = [datetime(2008, 1, 1),
+                    datetime(2008, 1, 2),
+                    datetime(2008, 1, 3)]
+        assert rng == expected
 
     def test_3(self):
-        eq_gen_range(dict(start=datetime(2008, 1, 5),
-                          end=datetime(2008, 1, 6)),
-                     [])
+        rng = list(generate_range(start=datetime(2008, 1, 5),
+                                  end=datetime(2008, 1, 6)))
+        expected = []
+        assert rng == expected
 
     def test_precision_finer_than_offset(self):
         # GH 9907

--- a/pandas/tests/indexes/datetimes/test_date_range.py
+++ b/pandas/tests/indexes/datetimes/test_date_range.py
@@ -22,7 +22,10 @@ START, END = datetime(2009, 1, 1), datetime(2010, 1, 1)
 
 def eq_gen_range(kwargs, expected):
     rng = generate_range(**kwargs)
-    assert (np.array_equal(list(rng), expected))
+    result = np.asarray(list(rng))
+    expected = np.asarray(expected)
+
+    tm.assert_numpy_array_equal(result, expected)
 
 
 class TestDateRanges(TestData):

--- a/pandas/tests/io/parser/common.py
+++ b/pandas/tests/io/parser/common.py
@@ -823,7 +823,7 @@ A,B,C
                                           17007000002000192,
                                           17007000002000194]})
 
-        assert np.array_equal(result['Numbers'], expected['Numbers'])
+        tm.assert_series_equal(result['Numbers'], expected['Numbers'])
 
     def test_chunks_have_consistent_numerical_type(self):
         integers = [str(i) for i in range(499999)]

--- a/pandas/tests/io/parser/test_textreader.py
+++ b/pandas/tests/io/parser/test_textreader.py
@@ -161,9 +161,9 @@ class TestTextReader(object):
                             error_bad_lines=False,
                             warn_bad_lines=False)
         result = reader.read()
-        expected = {0: ['a', 'd', 'g', 'l'],
-                    1: ['b', 'e', 'h', 'm'],
-                    2: ['c', 'f', 'i', 'n']}
+        expected = {0: np.array(['a', 'd', 'g', 'l'], dtype=object),
+                    1: np.array(['b', 'e', 'h', 'm'], dtype=object),
+                    2: np.array(['c', 'f', 'i', 'n'], dtype=object)}
         assert_array_dicts_equal(result, expected)
 
         reader = TextReader(StringIO(data), delimiter=':',
@@ -189,8 +189,10 @@ class TestTextReader(object):
         assert header == expected
 
         recs = reader.read()
-        expected = {0: [1, 4], 1: [2, 5], 2: [3, 6]}
-        assert_array_dicts_equal(expected, recs)
+        expected = {0: np.array([1, 4], dtype=np.int64),
+                    1: np.array([2, 5], dtype=np.int64),
+                    2: np.array([3, 6], dtype=np.int64)}
+        assert_array_dicts_equal(recs, expected)
 
         # not enough rows
         pytest.raises(parser.ParserError, TextReader, StringIO(data),
@@ -203,14 +205,16 @@ class TestTextReader(object):
                 '1,2,3\n'
                 '4,5,6')
 
-        reader = TextReader(StringIO(data), delimiter=',', header=2,
-                            as_recarray=True)
+        reader = TextReader(StringIO(data), delimiter=',',
+                            header=2, as_recarray=True)
         header = reader.header
         expected = [['a', 'b', 'c']]
         assert header == expected
 
         recs = reader.read()
-        expected = {'a': [1, 4], 'b': [2, 5], 'c': [3, 6]}
+        expected = {'a': np.array([1, 4], dtype=np.int64),
+                    'b': np.array([2, 5], dtype=np.int64),
+                    'c': np.array([3, 6], dtype=np.int64)}
         assert_array_dicts_equal(expected, recs)
 
         # not enough rows
@@ -225,7 +229,7 @@ class TestTextReader(object):
         reader = TextReader(StringIO(data), delimiter=',', header=None,
                             escapechar='\\')
         result = reader.read()
-        expected = {0: ['"hello world"'] * 3}
+        expected = {0: np.array(['"hello world"'] * 3, dtype=object)}
         assert_array_dicts_equal(result, expected)
 
     def test_eof_has_eol(self):
@@ -360,7 +364,7 @@ a,b,c
 
         result = TextReader(StringIO(data), delimiter=',').read()
 
-        expected = {0: np.array([1, 4]),
+        expected = {0: np.array([1, 4], dtype=np.int64),
                     1: np.array(['2', ''], dtype=object),
                     2: np.array(['3', ''], dtype=object)}
         assert_array_dicts_equal(result, expected)
@@ -397,4 +401,5 @@ a,b,c
 
 def assert_array_dicts_equal(left, right):
     for k, v in compat.iteritems(left):
-        assert(np.array_equal(v, right[k]))
+        assert tm.assert_numpy_array_equal(np.asarray(v),
+                                           np.asarray(right[k]))

--- a/pandas/tests/reshape/test_concat.py
+++ b/pandas/tests/reshape/test_concat.py
@@ -1594,7 +1594,9 @@ class TestConcatenate(ConcatenateBase):
         s2 = Series(randn(len(dates)), index=dates, name='value')
 
         result = concat([s1, s2], axis=1, ignore_index=True)
-        assert np.array_equal(result.columns, [0, 1])
+        expected = Index([0, 1])
+
+        tm.assert_index_equal(result.columns, expected)
 
     def test_concat_iterables(self):
         from collections import deque, Iterable

--- a/pandas/tests/series/test_missing.py
+++ b/pandas/tests/series/test_missing.py
@@ -636,17 +636,21 @@ class TestSeriesMissingData(TestData):
 
     def test_isna(self):
         ser = Series([0, 5.4, 3, nan, -0.001])
-        np.array_equal(ser.isna(),
-                       Series([False, False, False, True, False]).values)
+        expected = Series([False, False, False, True, False])
+        tm.assert_series_equal(ser.isna(), expected)
+
         ser = Series(["hi", "", nan])
-        np.array_equal(ser.isna(), Series([False, False, True]).values)
+        expected = Series([False, False, True])
+        tm.assert_series_equal(ser.isna(), expected)
 
     def test_notna(self):
         ser = Series([0, 5.4, 3, nan, -0.001])
-        np.array_equal(ser.notna(),
-                       Series([True, True, True, False, True]).values)
+        expected = Series([True, True, True, False, True])
+        tm.assert_series_equal(ser.notna(), expected)
+
         ser = Series(["hi", "", nan])
-        np.array_equal(ser.notna(), Series([True, True, False]).values)
+        expected = Series([True, True, False])
+        tm.assert_series_equal(ser.notna(), expected)
 
     def test_pad_nan(self):
         x = Series([np.nan, 1., np.nan, 3., np.nan], ['z', 'a', 'b', 'c', 'd'],

--- a/pandas/tests/test_algos.py
+++ b/pandas/tests/test_algos.py
@@ -1132,19 +1132,19 @@ def test_pad_backfill_object_segfault():
 
     result = libalgos.pad_object(old, new)
     expected = np.array([-1], dtype=np.int64)
-    assert (np.array_equal(result, expected))
+    tm.assert_numpy_array_equal(result, expected)
 
     result = libalgos.pad_object(new, old)
     expected = np.array([], dtype=np.int64)
-    assert (np.array_equal(result, expected))
+    tm.assert_numpy_array_equal(result, expected)
 
     result = libalgos.backfill_object(old, new)
     expected = np.array([-1], dtype=np.int64)
-    assert (np.array_equal(result, expected))
+    tm.assert_numpy_array_equal(result, expected)
 
     result = libalgos.backfill_object(new, old)
     expected = np.array([], dtype=np.int64)
-    assert (np.array_equal(result, expected))
+    tm.assert_numpy_array_equal(result, expected)
 
 
 def test_arrmap():
@@ -1235,15 +1235,6 @@ def test_is_lexsorted():
 
     assert (not libalgos.is_lexsorted(failure))
 
-# def test_get_group_index():
-#     a = np.array([0, 1, 2, 0, 2, 1, 0, 0], dtype=np.int64)
-#     b = np.array([1, 0, 3, 2, 0, 2, 3, 0], dtype=np.int64)
-#     expected = np.array([1, 4, 11, 2, 8, 6, 3, 0], dtype=np.int64)
-
-#     result = lib.get_group_index([a, b], (3, 4))
-
-#     assert(np.array_equal(result, expected))
-
 
 def test_groupsort_indexer():
     a = np.random.randint(0, 1000, 100).astype(np.int64)
@@ -1253,13 +1244,13 @@ def test_groupsort_indexer():
 
     # need to use a stable sort
     expected = np.argsort(a, kind='mergesort')
-    assert (np.array_equal(result, expected))
+    tm.assert_numpy_array_equal(result, expected)
 
     # compare with lexsort
     key = a * 1000 + b
     result = libalgos.groupsort_indexer(key, 1000000)[0]
     expected = np.lexsort((b, a))
-    assert (np.array_equal(result, expected))
+    tm.assert_numpy_array_equal(result, expected)
 
 
 def test_infinity_sort():

--- a/pandas/tests/test_join.py
+++ b/pandas/tests/test_join.py
@@ -53,7 +53,7 @@ def test_left_join_indexer_unique():
 
     result = _join.left_join_indexer_unique_int64(b, a)
     expected = np.array([1, 1, 2, 3, 3], dtype=np.int64)
-    assert (np.array_equal(result, expected))
+    tm.assert_numpy_array_equal(result, expected)
 
 
 def test_left_outer_join_bug():
@@ -69,13 +69,14 @@ def test_left_outer_join_bug():
 
     lidx, ridx = _join.left_outer_join(left, right, max_groups, sort=False)
 
-    exp_lidx = np.arange(len(left))
-    exp_ridx = -np.ones(len(left))
+    exp_lidx = np.arange(len(left), dtype=np.int64)
+    exp_ridx = -np.ones(len(left), dtype=np.int64)
+
     exp_ridx[left == 1] = 1
     exp_ridx[left == 3] = 0
 
-    assert (np.array_equal(lidx, exp_lidx))
-    assert (np.array_equal(ridx, exp_ridx))
+    tm.assert_numpy_array_equal(lidx, exp_lidx)
+    tm.assert_numpy_array_equal(ridx, exp_ridx)
 
 
 def test_inner_join_indexer():

--- a/pandas/tests/test_lib.py
+++ b/pandas/tests/test_lib.py
@@ -198,7 +198,7 @@ class TestIndexing(object):
         indexer = np.array([-1, -1, 1, 2, 0, -1, 3, 4], dtype=np.int64)
         result = lib.get_reverse_indexer(indexer, 5)
         expected = np.array([4, 2, 3, 6, 7], dtype=np.int64)
-        assert np.array_equal(result, expected)
+        tm.assert_numpy_array_equal(result, expected)
 
 
 class TestNAObj(object):

--- a/pandas/tests/test_sorting.py
+++ b/pandas/tests/test_sorting.py
@@ -332,16 +332,17 @@ def test_decons():
         label_list2 = decons_group_index(group_index, shape)
 
         for a, b in zip(label_list, label_list2):
-            assert (np.array_equal(a, b))
+            tm.assert_numpy_array_equal(a, b)
 
     shape = (4, 5, 6)
-    label_list = [np.tile([0, 1, 2, 3, 0, 1, 2, 3], 100), np.tile(
-        [0, 2, 4, 3, 0, 1, 2, 3], 100), np.tile(
-            [5, 1, 0, 2, 3, 0, 5, 4], 100)]
+    label_list = [np.tile([0, 1, 2, 3, 0, 1, 2, 3], 100).astype(np.int64),
+                  np.tile([0, 2, 4, 3, 0, 1, 2, 3], 100).astype(np.int64),
+                  np.tile([5, 1, 0, 2, 3, 0, 5, 4], 100).astype(np.int64)]
     testit(label_list, shape)
 
     shape = (10000, 10000)
-    label_list = [np.tile(np.arange(10000), 5), np.tile(np.arange(10000), 5)]
+    label_list = [np.tile(np.arange(10000, dtype=np.int64), 5),
+                  np.tile(np.arange(10000, dtype=np.int64), 5)]
     testit(label_list, shape)
 
 

--- a/pandas/tests/tseries/test_timezones.py
+++ b/pandas/tests/tseries/test_timezones.py
@@ -70,7 +70,7 @@ class TestTimeZoneSupportPytz(object):
         rng_eastern = rng.tz_convert(self.tzstr('US/Eastern'))
 
         # Values are unmodified
-        assert np.array_equal(rng.asi8, rng_eastern.asi8)
+        tm.assert_numpy_array_equal(rng.asi8, rng_eastern.asi8)
 
         assert self.cmptz(rng_eastern.tz, self.tz('US/Eastern'))
 
@@ -108,7 +108,7 @@ class TestTimeZoneSupportPytz(object):
         rng = date_range('3/10/2012', '3/11/2012', freq='30T')
         converted = rng.tz_localize(self.tz('US/Eastern'))
         expected_naive = rng + offsets.Hour(5)
-        assert np.array_equal(converted.asi8, expected_naive.asi8)
+        tm.assert_numpy_array_equal(converted.asi8, expected_naive.asi8)
 
         # DST ambiguity, this should fail
         rng = date_range('3/11/2012', '3/12/2012', freq='30T')


### PR DESCRIPTION
Preferable to use `tm.assert_numpy_array_equal` instead.