### PR TITLE
catch Exception currently ignored

### DIFF
--- a/pandas/_libs/src/inference.pyx
+++ b/pandas/_libs/src/inference.pyx
@@ -689,7 +689,7 @@ cdef class BoolValidator(Validator):
         return issubclass(self.dtype.type, np.bool_)
 
 
-cpdef bint is_bool_array(ndarray values, bint skipna=False):
+cpdef bint is_bool_array(ndarray values, bint skipna=False) except -1:
     cdef:
         BoolValidator validator = BoolValidator(
             len(values),


### PR DESCRIPTION
From Travis log: https://travis-ci.org/pandas-dev/pandas/jobs/295371293
```
.ValueError: Buffer dtype mismatch, expected 'Python object' but got 'long'
Exception ignored in: 'pandas._libs.lib.is_bool_array'
ValueError: Buffer dtype mismatch, expected 'Python object' but got 'long'
.................ValueError: Buffer dtype mismatch, expected 'Python object' but got 'long'
Exception ignored in: 'pandas._libs.lib.is_bool_array'
ValueError: Buffer dtype mismatch, expected 'Python object' but got 'long'
.ValueError: Buffer dtype mismatch, expected 'Python object' but got 'long'
Exception ignored in: 'pandas._libs.lib.is_bool_array'
ValueError: Buffer dtype mismatch, expected 'Python object' but got 'long'
```

This just catches that error so we can track it down.