### PR TITLE
ENH: improve output for testing.assert_*_equal with Categoricals

### DIFF
--- a/doc/source/whatsnew/v0.21.1.txt
+++ b/doc/source/whatsnew/v0.21.1.txt
@@ -117,7 +117,8 @@ Categorical
 ^^^^^^^^^^^
 
 - Bug in :meth:`DataFrame.astype` where casting to 'category' on an empty ``DataFrame`` causes a segmentation fault (:issue:`18004`)
--
+- Error messages in the testing module have been improved when items have
+  different ``CategoricalDtype`` (:issue:`18069`)
 -
 
 Other

--- a/pandas/util/testing.py
+++ b/pandas/util/testing.py
@@ -1074,8 +1074,12 @@ def assert_categorical_equal(left, right, check_dtype=True,
 def raise_assert_detail(obj, message, left, right, diff=None):
     if isinstance(left, np.ndarray):
         left = pprint_thing(left)
+    elif is_categorical_dtype(left):
+        left = repr(left)
     if isinstance(right, np.ndarray):
         right = pprint_thing(right)
+    elif is_categorical_dtype(right):
+        right = repr(right)
 
     msg = """{obj} are different
 


### PR DESCRIPTION
- [x ] closes #18056
- [ ] tests added / passed
- [ x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x ] whatsnew entry

The new CategoricalDtype made the output from failing tests uninformative, see #18056. 

The error message is now:

```python
>>> c1 = pd.CategoricalIndex(['a', 'b'])
>>> c2 = pd.CategoricalIndex(['c', 'd'])
>>> s1 = pd.Series([1,2], index=c1)
>>> s2 = pd.Series([1,2], index=c2)
>>> pd.testing.assert_series_equal(s1, s2)
AssertionError: Series.index are different

Attribute "dtype" are different
[left]:  CategoricalDtype(categories=['a', 'b'], ordered=False)
[right]: CategoricalDtype(categories=['c', 'd'], ordered=False)
```
Which is much better.