### PR TITLE
DOC: Remove duplicate 'in' from contributing.rst (#18040)

### DIFF
--- a/doc/source/contributing.rst
+++ b/doc/source/contributing.rst
@@ -330,7 +330,7 @@ The utility script ``scripts/api_rst_coverage.py`` can be used to compare
 the list of methods documented in ``doc/source/api.rst`` (which is used to generate
 the `API Reference <http://pandas.pydata.org/pandas-docs/stable/api.html>`_ page)
 and the actual public methods.
-This will identify methods documented in in ``doc/source/api.rst`` that are not actually
+This will identify methods documented in ``doc/source/api.rst`` that are not actually
 class methods, and existing methods that are not documented in ``doc/source/api.rst``.
 
 


### PR DESCRIPTION
- [x] closes #18040 (already closed)
- [ ] Tests added / passed (N/A)
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry (N/A)


Removes a duplicate "in" from the second sentence of the last paragraph of the "About the _pandas_ documentation" section of the "Contributing to Pandas" docs.