### PR TITLE
Fix 18068: Updates merge_asof error, now outputs datatypes

### DIFF
--- a/doc/source/whatsnew/v0.21.1.txt
+++ b/doc/source/whatsnew/v0.21.1.txt
@@ -102,7 +102,7 @@ Sparse
 Reshaping
 ^^^^^^^^^
 
--
+- Error message in ``pd.merge_asof()`` for key datatype mismatch now includes datatype of left and right key (:issue:`18068`)
 -
 -
 

--- a/pandas/core/reshape/merge.py
+++ b/pandas/core/reshape/merge.py
@@ -1255,8 +1255,9 @@ class _AsOfMerge(_OrderedMerge):
         # validate index types are the same
         for lk, rk in zip(left_join_keys, right_join_keys):
             if not is_dtype_equal(lk.dtype, rk.dtype):
-                raise MergeError("incompatible merge keys, "
-                                 "must be the same type")
+                raise MergeError("incompatible merge keys {lkdtype} and "
+                                 "{rkdtype}, must be the same type"
+                                 .format(lkdtype=lk.dtype, rkdtype=rk.dtype))
 
         # validate tolerance; must be a Timedelta if we have a DTI
         if self.tolerance is not None:

--- a/pandas/core/reshape/merge.py
+++ b/pandas/core/reshape/merge.py
@@ -1255,8 +1255,8 @@ class _AsOfMerge(_OrderedMerge):
         # validate index types are the same
         for i, (lk, rk) in enumerate(zip(left_join_keys, right_join_keys)):
             if not is_dtype_equal(lk.dtype, rk.dtype):
-                raise MergeError("incompatible merge keys [{i} {lkdtype} and "
-                                 "{rkdtype}], must be the same type"
+                raise MergeError("incompatible merge keys [{i}] {lkdtype} and "
+                                 "{rkdtype}, must be the same type"
                                  .format(i=i, lkdtype=lk.dtype,
                                          rkdtype=rk.dtype))
 

--- a/pandas/core/reshape/merge.py
+++ b/pandas/core/reshape/merge.py
@@ -1253,11 +1253,12 @@ class _AsOfMerge(_OrderedMerge):
          join_names) = super(_AsOfMerge, self)._get_merge_keys()
 
         # validate index types are the same
-        for lk, rk in zip(left_join_keys, right_join_keys):
+        for i, (lk, rk) in enumerate(zip(left_join_keys, right_join_keys)):
             if not is_dtype_equal(lk.dtype, rk.dtype):
-                raise MergeError("incompatible merge keys {lkdtype} and "
-                                 "{rkdtype}, must be the same type"
-                                 .format(lkdtype=lk.dtype, rkdtype=rk.dtype))
+                raise MergeError("incompatible merge keys [{i} {lkdtype} and "
+                                 "{rkdtype}], must be the same type"
+                                 .format(i=i, lkdtype=lk.dtype,
+                                         rkdtype=rk.dtype))
 
         # validate tolerance; must be a Timedelta if we have a DTI
         if self.tolerance is not None:

--- a/pandas/tests/reshape/test_merge_asof.py
+++ b/pandas/tests/reshape/test_merge_asof.py
@@ -973,3 +973,15 @@ class TestAsOfMerge(object):
             columns=['symbol', 'exch', 'price', 'mpv'])
 
         assert_frame_equal(result, expected)
+
+    def test_merge_datatype_error(self):
+        """ Tests merge datatype mismatch error """
+        msg = 'merge keys \[0\] object and int64, must be the same type'
+
+        left = pd.DataFrame({'left_val': [1, 5, 10],
+                             'a': ['a', 'b', 'c']})
+        right = pd.DataFrame({'right_val': [1, 2, 3, 6, 7],
+                              'a': [1, 2, 3, 6, 7]})
+
+        with tm.assert_raises_regex(MergeError, msg):
+            merge_asof(left, right, on='a')


### PR DESCRIPTION
- [ ] closes #18068
- [ ] tests added / passed
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
