### PR TITLE
TST: Remove even more uses np.array_equal in tests

### DIFF
--- a/pandas/tests/frame/test_operators.py
+++ b/pandas/tests/frame/test_operators.py
@@ -237,7 +237,7 @@ class TestDataFrameOperators(TestData):
         s = p[0]
         res = s % p
         res2 = p % s
-        assert not np.array_equal(res.fillna(0), res2.fillna(0))
+        assert not res.fillna(0).equals(res2.fillna(0))
 
     def test_div(self):
 
@@ -271,7 +271,7 @@ class TestDataFrameOperators(TestData):
         s = p[0]
         res = s / p
         res2 = p / s
-        assert not np.array_equal(res.fillna(0), res2.fillna(0))
+        assert not res.fillna(0).equals(res2.fillna(0))
 
     def test_logical_operators(self):
 
@@ -1030,7 +1030,7 @@ class TestDataFrameOperators(TestData):
         assert_numpy_array_equal(result, expected.values)
 
         pytest.raises(ValueError, lambda: df == b_c)
-        assert not np.array_equal(df.values, b_c)
+        assert df.values.shape != b_c.shape
 
         # with alignment
         df = DataFrame(np.arange(6).reshape((3, 2)),

--- a/pandas/tests/series/test_analytics.py
+++ b/pandas/tests/series/test_analytics.py
@@ -694,7 +694,7 @@ class TestSeriesAnalytics(TestData):
             p = p.astype('float64')
             result = p['first'] % p['second']
             result2 = p['second'] % p['first']
-            assert not np.array_equal(result, result2)
+            assert not result.equals(result2)
 
             # GH 9144
             s = Series([0, 1])

--- a/pandas/tests/series/test_operators.py
+++ b/pandas/tests/series/test_operators.py
@@ -122,7 +122,7 @@ class TestSeriesOperators(TestData):
             assert_series_equal(result, p['first'].astype('float64'),
                                 check_names=False)
             assert result.name is None
-            assert not np.array_equal(result, p['second'] / p['first'])
+            assert not result.equals(p['second'] / p['first'])
 
             # inf signing
             s = Series([np.nan, 1., -1.])


### PR DESCRIPTION
Implement `assert_not` as a way to check that assertions should fail (for methods more sophisticated than a simple bare `assert`).  Also takes the opportunity to remove several more `np.array_equal` assertions.

Follow-up to #18047 