### PR TITLE
CLN: Standardize indentation and alphabetize deps

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -480,78 +480,104 @@ tseries_depends = np_datetime_headers + ['pandas/_libs/src/datetime.pxd']
 libraries = ['m'] if not is_platform_windows() else []
 
 ext_data = {
-    '_libs.lib': {'pyxfile': '_libs/lib',
-                  'depends': lib_depends + tseries_depends},
-    '_libs.properties': {'pyxfile': '_libs/properties', 'include': []},
-    '_libs.hashtable': {'pyxfile': '_libs/hashtable',
-                        'pxdfiles': ['_libs/hashtable'],
-                        'depends': (['pandas/_libs/src/klib/khash_python.h'] +
-                                    _pxi_dep['hashtable'])},
-    '_libs.tslibs.strptime': {'pyxfile': '_libs/tslibs/strptime',
-                              'depends': tseries_depends,
-                              'sources': np_datetime_sources},
-    '_libs.tslibs.offsets': {'pyxfile': '_libs/tslibs/offsets'},
-    '_libs.tslib': {'pyxfile': '_libs/tslib',
-                    'pxdfiles': ['_libs/src/util'],
-                    'depends': tseries_depends,
-                    'sources': np_datetime_sources},
-    '_libs.tslibs.conversion': {'pyxfile': '_libs/tslibs/conversion',
-                                'depends': tseries_depends,
-                                'sources': np_datetime_sources},
-    '_libs.tslibs.np_datetime': {'pyxfile': '_libs/tslibs/np_datetime',
-                                 'depends': np_datetime_headers,
-                                 'sources': np_datetime_sources},
-    '_libs.tslibs.timedeltas': {'pyxfile': '_libs/tslibs/timedeltas'},
-    '_libs.tslibs.timezones': {'pyxfile': '_libs/tslibs/timezones'},
-    '_libs.tslibs.fields': {'pyxfile': '_libs/tslibs/fields',
-                            'depends': tseries_depends,
-                            'sources': np_datetime_sources},
-    '_libs.period': {'pyxfile': '_libs/period',
-                     'depends': (tseries_depends +
-                                 ['pandas/_libs/src/period_helper.h']),
-                     'sources': np_datetime_sources + [
-                                'pandas/_libs/src/period_helper.c']},
-    '_libs.tslibs.parsing': {'pyxfile': '_libs/tslibs/parsing',
-                             'pxdfiles': ['_libs/src/util']},
-    '_libs.tslibs.frequencies': {'pyxfile': '_libs/tslibs/frequencies',
-                                 'pxdfiles': ['_libs/src/util']},
-    '_libs.tslibs.nattype': {'pyxfile': '_libs/tslibs/nattype',
-                             'pxdfiles': ['_libs/src/util']},
-    '_libs.index': {'pyxfile': '_libs/index',
-                    'sources': np_datetime_sources,
-                    'pxdfiles': ['_libs/src/util', '_libs/hashtable'],
-                    'depends': _pxi_dep['index']},
-    '_libs.algos': {'pyxfile': '_libs/algos',
-                    'pxdfiles': ['_libs/src/util',
-                                 '_libs/algos', '_libs/hashtable'],
-                    'depends': _pxi_dep['algos']},
-    '_libs.groupby': {'pyxfile': '_libs/groupby',
-                      'pxdfiles': ['_libs/src/util', '_libs/algos'],
-                      'depends': _pxi_dep['groupby']},
-    '_libs.join': {'pyxfile': '_libs/join',
-                   'pxdfiles': ['_libs/src/util', '_libs/hashtable'],
-                   'depends': _pxi_dep['join']},
-    '_libs.reshape': {'pyxfile': '_libs/reshape',
-                      'depends': _pxi_dep['reshape']},
-    '_libs.indexing': {'pyxfile': '_libs/indexing'},
-    '_libs.interval': {'pyxfile': '_libs/interval',
-                       'pxdfiles': ['_libs/hashtable'],
-                       'depends': _pxi_dep['interval']},
-    '_libs.window': {'pyxfile': '_libs/window',
-                     'pxdfiles': ['_libs/src/skiplist', '_libs/src/util'],
-                     'depends': ['pandas/_libs/src/skiplist.pyx',
-                                 'pandas/_libs/src/skiplist.h']},
-    '_libs.parsers': {'pyxfile': '_libs/parsers',
-                      'depends': ['pandas/_libs/src/parser/tokenizer.h',
-                                  'pandas/_libs/src/parser/io.h',
-                                  'pandas/_libs/src/numpy_helper.h'],
-                      'sources': ['pandas/_libs/src/parser/tokenizer.c',
-                                  'pandas/_libs/src/parser/io.c']},
-    '_libs.sparse': {'pyxfile': '_libs/sparse',
-                     'depends': _pxi_dep['sparse']},
-    '_libs.testing': {'pyxfile': '_libs/testing'},
-    '_libs.hashing': {'pyxfile': '_libs/hashing'},
-    'io.sas._sas': {'pyxfile': 'io/sas/sas'}}
+    '_libs.algos': {
+        'pyxfile': '_libs/algos',
+        'pxdfiles': ['_libs/src/util', '_libs/algos', '_libs/hashtable'],
+        'depends': _pxi_dep['algos']},
+    '_libs.groupby': {
+        'pyxfile': '_libs/groupby',
+        'pxdfiles': ['_libs/src/util', '_libs/algos'],
+        'depends': _pxi_dep['groupby']},
+    '_libs.hashing': {
+        'pyxfile': '_libs/hashing'},
+    '_libs.hashtable': {
+        'pyxfile': '_libs/hashtable',
+        'pxdfiles': ['_libs/hashtable'],
+        'depends': (['pandas/_libs/src/klib/khash_python.h'] +
+                    _pxi_dep['hashtable'])},
+    '_libs.index': {
+        'pyxfile': '_libs/index',
+        'pxdfiles': ['_libs/src/util', '_libs/hashtable'],
+        'depends': _pxi_dep['index'],
+        'sources': np_datetime_sources},
+    '_libs.indexing': {
+        'pyxfile': '_libs/indexing'},
+    '_libs.interval': {
+        'pyxfile': '_libs/interval',
+        'pxdfiles': ['_libs/hashtable'],
+        'depends': _pxi_dep['interval']},
+    '_libs.join': {
+        'pyxfile': '_libs/join',
+        'pxdfiles': ['_libs/src/util', '_libs/hashtable'],
+        'depends': _pxi_dep['join']},
+    '_libs.lib': {
+        'pyxfile': '_libs/lib',
+        'depends': lib_depends + tseries_depends},
+    '_libs.parsers': {
+        'pyxfile': '_libs/parsers',
+        'depends': ['pandas/_libs/src/parser/tokenizer.h',
+                    'pandas/_libs/src/parser/io.h',
+                    'pandas/_libs/src/numpy_helper.h'],
+        'sources': ['pandas/_libs/src/parser/tokenizer.c',
+                    'pandas/_libs/src/parser/io.c']},
+    '_libs.period': {
+        'pyxfile': '_libs/period',
+        'depends': tseries_depends + ['pandas/_libs/src/period_helper.h'],
+        'sources': np_datetime_sources + ['pandas/_libs/src/period_helper.c']},
+    '_libs.properties': {
+        'pyxfile': '_libs/properties',
+        'include': []},
+    '_libs.reshape': {
+        'pyxfile': '_libs/reshape',
+        'depends': _pxi_dep['reshape']},
+    '_libs.sparse': {
+        'pyxfile': '_libs/sparse',
+        'depends': _pxi_dep['sparse']},
+    '_libs.tslib': {
+        'pyxfile': '_libs/tslib',
+        'pxdfiles': ['_libs/src/util'],
+        'depends': tseries_depends,
+        'sources': np_datetime_sources},
+    '_libs.tslibs.conversion': {
+        'pyxfile': '_libs/tslibs/conversion',
+        'depends': tseries_depends,
+        'sources': np_datetime_sources},
+    '_libs.tslibs.fields': {
+        'pyxfile': '_libs/tslibs/fields',
+        'depends': tseries_depends,
+        'sources': np_datetime_sources},
+    '_libs.tslibs.frequencies': {
+        'pyxfile': '_libs/tslibs/frequencies',
+        'pxdfiles': ['_libs/src/util']},
+    '_libs.tslibs.nattype': {
+        'pyxfile': '_libs/tslibs/nattype',
+        'pxdfiles': ['_libs/src/util']},
+    '_libs.tslibs.np_datetime': {
+        'pyxfile': '_libs/tslibs/np_datetime',
+        'depends': np_datetime_headers,
+        'sources': np_datetime_sources},
+    '_libs.tslibs.offsets': {
+        'pyxfile': '_libs/tslibs/offsets'},
+    '_libs.tslibs.parsing': {
+        'pyxfile': '_libs/tslibs/parsing',
+        'pxdfiles': ['_libs/src/util']},
+    '_libs.tslibs.strptime': {
+        'pyxfile': '_libs/tslibs/strptime',
+        'depends': tseries_depends,
+        'sources': np_datetime_sources},
+    '_libs.tslibs.timedeltas': {
+        'pyxfile': '_libs/tslibs/timedeltas'},
+    '_libs.tslibs.timezones': {
+        'pyxfile': '_libs/tslibs/timezones'},
+    '_libs.testing': {
+        'pyxfile': '_libs/testing'},
+    '_libs.window': {
+        'pyxfile': '_libs/window',
+        'pxdfiles': ['_libs/src/skiplist', '_libs/src/util'],
+        'depends': ['pandas/_libs/src/skiplist.pyx',
+                    'pandas/_libs/src/skiplist.h']},
+    'io.sas._sas': {
+        'pyxfile': 'io/sas/sas'}}
 
 extensions = []
 


### PR DESCRIPTION
I can't fix a problem that makes zero sense to me (#18089), but in the interests of being a team player, I can try to contribute around the periphery.

This just takes the `ext_data` dict and a) standardizes the indentation, b) arranges the entries in alphabetical order.  It is straightforward to check that the version of the dict here `==` the version in master.  The main reason to do this is so that the diff in the next step is easy to review.  

The next step is to go through and identify pyx files that don't cimport _anything_  e.g. `_libs.testing` and fill out their `ext_data` entries with the appropriate `[]`s (note that the processing of `ext_data` inserts default values for missing keys, so adding `[]` entries _is_ part of the specification).

There are a few modules that meet that description, then a handful of others that only have cimports from numpy (e.g. io.sas._sas).  Those entries can be fully filled out independently of any other outstanding issues.