### PR TITLE
BUG: Let CategoricalIndex take CategoricalDtype as dtype argument

### DIFF
--- a/doc/source/whatsnew/v0.21.1.txt
+++ b/doc/source/whatsnew/v0.21.1.txt
@@ -119,7 +119,7 @@ Categorical
 - Bug in :meth:`DataFrame.astype` where casting to 'category' on an empty ``DataFrame`` causes a segmentation fault (:issue:`18004`)
 - Error messages in the testing module have been improved when items have
   different ``CategoricalDtype`` (:issue:`18069`)
--
+- ``CategoricalIndex`` can now correctly take a ``pd.api.types.CategoricalDtype`` as its dtype (:issue:`18116`)
 
 Other
 ^^^^^

--- a/pandas/core/indexes/category.py
+++ b/pandas/core/indexes/category.py
@@ -79,7 +79,8 @@ class CategoricalIndex(Index, accessor.PandasDelegate):
                 if data is not None or categories is None:
                     cls._scalar_data_error(data)
                 data = []
-            data = cls._create_categorical(cls, data, categories, ordered)
+            data = cls._create_categorical(cls, data, categories, ordered,
+                                           dtype)
 
         if copy:
             data = data.copy()


### PR DESCRIPTION
- [x ] closes #18109 
- [x ] tests added / passed
- [ x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ x] whatsnew entry

This PR allows CategoricalIndex to take CategoricalDtype as its dtype argument, see #18109 for details.