### PR TITLE
demonstrate similarity for discussion purposes

### DIFF
--- a/pandas/core/internals.py
+++ b/pandas/core/internals.py
@@ -4699,17 +4699,7 @@ def get_block_type(values, dtype=None):
 def form_blocks(arrays, names, axes):
     # put "leftover" items in float bucket, where else?
     # generalize?
-    items_dict = {
-        'float': [],
-        'complex': [],
-        'int': [],
-        'bool': [],
-        'object': [],
-        'sparse': [],
-        'datetime': [],
-        'datetime_tz': [],
-        'timedelta': [],
-        'cat': []}
+    items_dict = {key: [] for key in _block_type_klasses}
     extra_locs = []
 
     names_idx = Index(names)

--- a/pandas/core/internals.py
+++ b/pandas/core/internals.py
@@ -2913,7 +2913,7 @@ class SparseBlock(NonConsolidatableMixIn, Block):
                                           placement=self.mgr_locs)
 
 
-_block_types_klasses =  {
+_block_types_klasses = {
     'sparse': SparseBlock,
     'float': FloatBlock,
     'complex': ComplexBlock,
@@ -2964,7 +2964,7 @@ def _get_block_klass(dtype):
 def make_block(values, placement, klass=None, ndim=None, dtype=None,
                fastpath=False):
     if klass is None:
-        klass  = _get_block_klass(dtype)
+        klass = _get_block_klass(dtype)
 
     elif klass is DatetimeTZBlock and not is_datetimetz(values):
         return klass(values, ndim=ndim, fastpath=fastpath,
@@ -4670,7 +4670,7 @@ def get_block_type(values, dtype=None):
         block_type = 'float'
     elif issubclass(vtype, np.complexfloating):
         block_type = 'complex'
-    
+
     elif issubclass(vtype, np.datetime64):
         if dtype != _NS_DTYPE:
             values = tslib.cast_to_nanoseconds(values)
@@ -4679,13 +4679,13 @@ def get_block_type(values, dtype=None):
             block_type = 'datetime_tz'
         else:
             block_type = 'datetime'
-        
+
     elif is_datetimetz(values):
         block_type = 'datetime_tz'
-    
+
     elif issubclass(vtype, np.integer):
         block_type = 'int'
-    
+
     elif dtype == np.bool_:
         block_type = 'bool'
     elif is_categorical(values):


### PR DESCRIPTION
This is a demonstration rather than an actual PR.

There is some very similar logic in `internals.make_block` and `internals.form_blocks`.  For demonstration this PR separates the relevant bits out into `_get_block_klass` and `get_block_type`, respectively.

Suppose that the small differences in these two new functions were reconciled.  Then adding a custom block type would be a matter of adding it to `_block_type_klasses` along with registering some kind of hook in `_get_block_klass`.

There would need to be some cleanup at the end of `form_blocks` to map block types to `_foo_blockify` functions.

ref #17144
noci
