### PR TITLE
Modernize indexes.timedeltas, indexes.datetimeindex

### DIFF
--- a/pandas/core/indexes/datetimes.py
+++ b/pandas/core/indexes/datetimes.py
@@ -2,9 +2,11 @@
 from __future__ import division
 import operator
 import warnings
-from datetime import time, datetime
-from datetime import timedelta
+from datetime import time, datetime, timedelta
+
 import numpy as np
+from pytz import utc
+
 from pandas.core.base import _shared_docs
 
 from pandas.core.dtypes.common import (
@@ -56,10 +58,6 @@ from pandas._libs import (lib, index as libindex, tslib as libts,
 from pandas._libs.tslibs import timezones
 
 
-def _utc():
-    import pytz
-    return pytz.utc
-
 # -------- some conversion wrapper functions
 
 
@@ -67,7 +65,6 @@ def _field_accessor(name, field, docstring=None):
     def f(self):
         values = self.asi8
         if self.tz is not None:
-            utc = _utc()
             if self.tz is not utc:
                 values = self._local_timestamps()
 
@@ -563,8 +560,6 @@ class DatetimeIndex(DatelikeOps, TimelikeOps, DatetimeIndexOpsMixin,
         raise ValueError('Passed item and index have different timezone')
 
     def _local_timestamps(self):
-        utc = _utc()
-
         if self.is_monotonic:
             return libts.tz_convert(self.asi8, utc, self.tz)
         else:
@@ -825,7 +820,6 @@ class DatetimeIndex(DatelikeOps, TimelikeOps, DatetimeIndexOpsMixin,
 
         tz = 'UTC' if self.tz is not None else None
         result = DatetimeIndex(new_values, tz=tz, name=name, freq='infer')
-        utc = _utc()
         if self.tz is not None and self.tz is not utc:
             result = result.tz_convert(self.tz)
         return result
@@ -879,7 +873,6 @@ class DatetimeIndex(DatelikeOps, TimelikeOps, DatetimeIndexOpsMixin,
         raise ValueError('Cannot cast DatetimeIndex to dtype %s' % dtype)
 
     def _get_time_micros(self):
-        utc = _utc()
         values = self.asi8
         if self.tz is not None and self.tz is not utc:
             values = self._local_timestamps()

--- a/pandas/core/indexes/timedeltas.py
+++ b/pandas/core/indexes/timedeltas.py
@@ -36,6 +36,26 @@ from pandas._libs import (lib, index as libindex, tslib as libts,
                           join as libjoin, Timedelta, NaT, iNaT)
 
 
+def _field_accessor(name, alias, docstring=None):
+    def f(self):
+        if self.hasnans:
+            result = np.empty(len(self), dtype='float64')
+            mask = self._isnan
+            imask = ~mask
+            result.flat[imask] = np.array([getattr(Timedelta(val), alias)
+                                           for val in self.asi8[imask]])
+            result[mask] = np.nan
+        else:
+            result = np.array([getattr(Timedelta(val), alias)
+                               for val in self.asi8], dtype='int64')
+
+        return Index(result, name=self.name)
+
+    f.__name__ = name
+    f.__doc__ = docstring
+    return property(f)
+
+
 def _td_index_cmp(opname, nat_result=False):
     """
     Wrap comparison operations to convert timedelta-like to timedelta64
@@ -381,46 +401,17 @@ class TimedeltaIndex(DatetimeIndexOpsMixin, TimelikeOps, Int64Index):
                                     nat_rep=na_rep,
                                     justify='all').get_result()
 
-    def _get_field(self, m):
-
-        values = self.asi8
-        hasnans = self.hasnans
-        if hasnans:
-            result = np.empty(len(self), dtype='float64')
-            mask = self._isnan
-            imask = ~mask
-            result.flat[imask] = np.array(
-                [getattr(Timedelta(val), m) for val in values[imask]])
-            result[mask] = np.nan
-        else:
-            result = np.array([getattr(Timedelta(val), m)
-                               for val in values], dtype='int64')
-        return Index(result, name=self.name)
-
-    @property
-    def days(self):
-        """ Number of days for each element. """
-        return self._get_field('days')
-
-    @property
-    def seconds(self):
-        """ Number of seconds (>= 0 and less than 1 day) for each element. """
-        return self._get_field('seconds')
-
-    @property
-    def microseconds(self):
-        """
-        Number of microseconds (>= 0 and less than 1 second) for each
-        element. """
-        return self._get_field('microseconds')
-
-    @property
-    def nanoseconds(self):
-        """
-        Number of nanoseconds (>= 0 and less than 1 microsecond) for each
-        element.
-        """
-        return self._get_field('nanoseconds')
+    days = _field_accessor("days", "days",
+                           " Number of days for each element. ")
+    seconds = _field_accessor("seconds", "seconds",
+                              " Number of seconds (>= 0 and less than 1 day) "
+                              "for each element. ")
+    microseconds = _field_accessor("microseconds", "microseconds",
+                                   "\nNumber of microseconds (>= 0 and less "
+                                   "than 1 second) for each\nelement. ")
+    nanoseconds = _field_accessor("nanoseconds", "nanoseconds",
+                                  "\nNumber of nanoseconds (>= 0 and less "
+                                  "than 1 microsecond) for each\nelement.\n")
 
     @property
     def components(self):


### PR DESCRIPTION
Two things here.  They should be separate PRs, but so it goes.

indexes.datetimes and indexes.periods use a _field_accessor pattern to define several properties in their index classes.  This updates TimedeltaIndex to use the same pattern, getting rid of the `_get_field` method that was used before.

indexes.datetimes has a _utc() function that I think is designed to lazily import pytz.  That ship has sailed elsewhere, so this removes that extra call.
