### PR TITLE
ENH: Return locale based month_name and weekday_name values (#12805, #12806)

### DIFF
--- a/doc/source/api.rst
+++ b/doc/source/api.rst
@@ -551,7 +551,6 @@ These can be accessed like ``Series.dt.<property>``.
    Series.dt.weekofyear
    Series.dt.dayofweek
    Series.dt.weekday
-   Series.dt.weekday_name
    Series.dt.dayofyear
    Series.dt.quarter
    Series.dt.is_month_start
@@ -581,6 +580,8 @@ These can be accessed like ``Series.dt.<property>``.
    Series.dt.round
    Series.dt.floor
    Series.dt.ceil
+   Series.dt.month_name
+   Series.dt.day_name
 
 **Timedelta Properties**
 
@@ -1723,7 +1724,6 @@ Time/Date Components
    DatetimeIndex.week
    DatetimeIndex.dayofweek
    DatetimeIndex.weekday
-   DatetimeIndex.weekday_name
    DatetimeIndex.quarter
    DatetimeIndex.tz
    DatetimeIndex.freq
@@ -1759,6 +1759,8 @@ Time-specific operations
    DatetimeIndex.round
    DatetimeIndex.floor
    DatetimeIndex.ceil
+   DatetimeIndex.month_name
+   DatetimeIndex.day_name
 
 Conversion
 ~~~~~~~~~~
@@ -1940,7 +1942,6 @@ Properties
     Timestamp.tzinfo
     Timestamp.value
     Timestamp.week
-    Timestamp.weekday_name
     Timestamp.weekofyear
     Timestamp.year
 
@@ -1954,6 +1955,7 @@ Methods
     Timestamp.combine
     Timestamp.ctime
     Timestamp.date
+    Timestamp.day_name
     Timestamp.dst
     Timestamp.floor
     Timestamp.freq
@@ -1963,6 +1965,7 @@ Methods
     Timestamp.isocalendar
     Timestamp.isoformat
     Timestamp.isoweekday
+    Timestamp.month_name
     Timestamp.normalize
     Timestamp.now
     Timestamp.replace

--- a/doc/source/whatsnew/v0.23.0.txt
+++ b/doc/source/whatsnew/v0.23.0.txt
@@ -338,7 +338,8 @@ Other Enhancements
 - For subclassed ``DataFrames``, :func:`DataFrame.apply` will now preserve the ``Series`` subclass (if defined) when passing the data to the applied function (:issue:`19822`)
 - :func:`DataFrame.from_dict` now accepts a ``columns`` argument that can be used to specify the column names when ``orient='index'`` is used (:issue:`18529`)
 - Added option ``display.html.use_mathjax`` so `MathJax <https://www.mathjax.org/>`_ can be disabled when rendering tables in ``Jupyter`` notebooks (:issue:`19856`, :issue:`19824`)
-
+- :meth:`Timestamp.month_name`, :meth:`DatetimeIndex.month_name`, and :meth:`Series.dt.month_name` are now available (:issue:`12805`)
+- :meth:`Timestamp.day_name` and :meth:`DatetimeIndex.day_name` are now available to return day names with a specified locale (:issue:`12806`)
 
 .. _whatsnew_0230.api_breaking:
 
@@ -677,6 +678,7 @@ Deprecations
 - The ``broadcast`` parameter of ``.apply()`` is deprecated in favor of ``result_type='broadcast'`` (:issue:`18577`)
 - The ``reduce`` parameter of ``.apply()`` is deprecated in favor of ``result_type='reduce'`` (:issue:`18577`)
 - The ``order`` parameter of :func:`factorize` is deprecated and will be removed in a future release (:issue:`19727`)
+- :attr:`Timestamp.weekday_name`, :attr:`DatetimeIndex.weekday_name`, and :attr:`Series.dt.weekday_name` are deprecated in favor of :meth:`Timestamp.day_name`, :meth:`DatetimeIndex.day_name`, and :meth:`Series.dt.day_name` (:issue:`12806`)
 
 .. _whatsnew_0230.prior_deprecations:
 

--- a/pandas/_libs/tslibs/ccalendar.pyx
+++ b/pandas/_libs/tslibs/ccalendar.pyx
@@ -12,6 +12,8 @@ cimport numpy as cnp
 from numpy cimport int64_t, int32_t
 cnp.import_array()
 
+from locale import LC_TIME
+from strptime import LocaleTime
 
 # ----------------------------------------------------------------------
 # Constants
@@ -35,11 +37,18 @@ cdef int32_t* _month_offset = [
 # Canonical location for other modules to find name constants
 MONTHS = ['JAN', 'FEB', 'MAR', 'APR', 'MAY', 'JUN', 'JUL',
           'AUG', 'SEP', 'OCT', 'NOV', 'DEC']
+# The first blank line is consistent with calendar.month_name in the calendar
+# standard library
+MONTHS_FULL = ['', 'January', 'February', 'March', 'April', 'May', 'June',
+               'July', 'August', 'September', 'October', 'November',
+               'December']
 MONTH_NUMBERS = {name: num for num, name in enumerate(MONTHS)}
 MONTH_ALIASES = {(num + 1): name for num, name in enumerate(MONTHS)}
 MONTH_TO_CAL_NUM = {name: num + 1 for num, name in enumerate(MONTHS)}
 
 DAYS = ['MON', 'TUE', 'WED', 'THU', 'FRI', 'SAT', 'SUN']
+DAYS_FULL = ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday',
+             'Saturday', 'Sunday']
 int_to_weekday = {num: name for num, name in enumerate(DAYS)}
 weekday_to_int = {int_to_weekday[key]: key for key in int_to_weekday}
 
@@ -199,3 +208,23 @@ cpdef int32_t get_day_of_year(int year, int month, int day) nogil:
 
     day_of_year = mo_off + day
     return day_of_year
+
+
+cpdef get_locale_names(object name_type, object locale=None):
+    """Returns an array of localized day or month names
+
+    Parameters
+    ----------
+    name_type : string, attribute of LocaleTime() in which to return localized
+        names
+    locale : string
+
+    Returns
+    -------
+    list of locale names
+
+    """
+    from pandas.util.testing import set_locale
+
+    with set_locale(locale, LC_TIME):
+        return getattr(LocaleTime(), name_type)

--- a/pandas/_libs/tslibs/nattype.pyx
+++ b/pandas/_libs/tslibs/nattype.pyx
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 # cython: profile=False
-import warnings
 
 from cpython cimport (
     PyFloat_Check, PyComplex_Check,
@@ -39,24 +38,19 @@ _nat_scalar_rules[Py_GE] = False
 # ----------------------------------------------------------------------
 
 
-def _make_nan_func(func_name, cls):
+def _make_nan_func(func_name, doc):
     def f(*args, **kwargs):
         return np.nan
     f.__name__ = func_name
-    f.__doc__ = getattr(cls, func_name).__doc__
+    f.__doc__ = doc
     return f
 
 
-def _make_nat_func(func_name, cls):
+def _make_nat_func(func_name, doc):
     def f(*args, **kwargs):
         return NaT
-
     f.__name__ = func_name
-    if isinstance(cls, str):
-        # passed the literal docstring directly
-        f.__doc__ = cls
-    else:
-        f.__doc__ = getattr(cls, func_name).__doc__
+    f.__doc__ = doc
     return f
 
 
@@ -318,11 +312,40 @@ class NaTType(_NaT):
     # These are the ones that can get their docstrings from datetime.
 
     # nan methods
-    weekday = _make_nan_func('weekday', datetime)
-    isoweekday = _make_nan_func('isoweekday', datetime)
+    weekday = _make_nan_func('weekday', datetime.weekday.__doc__)
+    isoweekday = _make_nan_func('isoweekday', datetime.isoweekday.__doc__)
+    month_name = _make_nan_func('month_name',  # noqa:E128
+        """
+        Return the month name of the Timestamp with specified locale.
 
+        Parameters
+        ----------
+        locale : string, default None (English locale)
+            locale determining the language in which to return the month name
+
+        Returns
+        -------
+        month_name : string
+
+        .. versionadded:: 0.23.0
+        """)
+    day_name = _make_nan_func('day_name', # noqa:E128
+        """
+        Return the day name of the Timestamp with specified locale.
+
+        Parameters
+        ----------
+        locale : string, default None (English locale)
+            locale determining the language in which to return the day name
+
+        Returns
+        -------
+        day_name : string
+
+        .. versionadded:: 0.23.0
+        """)
     # _nat_methods
-    date = _make_nat_func('date', datetime)
+    date = _make_nat_func('date', datetime.date.__doc__)
 
     utctimetuple = _make_error_func('utctimetuple', datetime)
     timetz = _make_error_func('timetz', datetime)

--- a/pandas/_libs/tslibs/timestamps.pyx
+++ b/pandas/_libs/tslibs/timestamps.pyx
@@ -24,7 +24,7 @@ cimport ccalendar
 from conversion import tz_localize_to_utc, date_normalize
 from conversion cimport (tz_convert_single, _TSObject,
                          convert_to_tsobject, convert_datetime_to_tsobject)
-from fields import get_date_field, get_start_end_field
+from fields import get_start_end_field, get_date_name_field
 from nattype import NaT
 from nattype cimport NPY_NAT
 from np_datetime import OutOfBoundsDatetime
@@ -350,6 +350,16 @@ cdef class _Timestamp(datetime):
         val = self._maybe_convert_value_to_local()
         out = get_start_end_field(np.array([val], dtype=np.int64),
                                   field, freqstr, month_kw)
+        return out[0]
+
+    cpdef _get_date_name_field(self, object field, object locale):
+        cdef:
+            int64_t val
+            ndarray out
+
+        val = self._maybe_convert_value_to_local()
+        out = get_date_name_field(np.array([val], dtype=np.int64),
+                                  field, locale=locale)
         return out[0]
 
     @property
@@ -714,12 +724,50 @@ class Timestamp(_Timestamp):
     def dayofweek(self):
         return self.weekday()
 
+    def day_name(self, locale=None):
+        """
+        Return the day name of the Timestamp with specified locale.
+
+        Parameters
+        ----------
+        locale : string, default None (English locale)
+            locale determining the language in which to return the day name
+
+        Returns
+        -------
+        day_name : string
+
+        .. versionadded:: 0.23.0
+        """
+        return self._get_date_name_field('day_name', locale)
+
+    def month_name(self, locale=None):
+        """
+        Return the month name of the Timestamp with specified locale.
+
+        Parameters
+        ----------
+        locale : string, default None (English locale)
+            locale determining the language in which to return the month name
+
+        Returns
+        -------
+        month_name : string
+
+        .. versionadded:: 0.23.0
+        """
+        return self._get_date_name_field('month_name', locale)
+
     @property
     def weekday_name(self):
-        cdef dict wdays = {0: 'Monday', 1: 'Tuesday', 2: 'Wednesday',
-                           3: 'Thursday', 4: 'Friday', 5: 'Saturday',
-                           6: 'Sunday'}
-        return wdays[self.weekday()]
+        """
+        .. deprecated:: 0.23.0
+            Use ``Timestamp.day_name()`` instead
+        """
+        warnings.warn("`weekday_name` is deprecated and will be removed in a "
+                      "future version. Use `day_name` instead",
+                      DeprecationWarning)
+        return self.day_name()
 
     @property
     def dayofyear(self):

--- a/pandas/core/indexes/datetimes.py
+++ b/pandas/core/indexes/datetimes.py
@@ -231,7 +231,6 @@ class DatetimeIndex(DatelikeOps, TimelikeOps, DatetimeIndexOpsMixin,
     week
     dayofweek
     weekday
-    weekday_name
     quarter
     tz
     freq
@@ -260,6 +259,8 @@ class DatetimeIndex(DatelikeOps, TimelikeOps, DatetimeIndexOpsMixin,
     to_pydatetime
     to_series
     to_frame
+    month_name
+    day_name
 
     Notes
     -----
@@ -318,7 +319,7 @@ class DatetimeIndex(DatelikeOps, TimelikeOps, DatetimeIndexOpsMixin,
     _datetimelike_methods = ['to_period', 'tz_localize',
                              'tz_convert',
                              'normalize', 'strftime', 'round', 'floor',
-                             'ceil']
+                             'ceil', 'month_name', 'day_name']
 
     _is_numeric_dtype = False
     _infer_as_myclass = True
@@ -1713,7 +1714,7 @@ class DatetimeIndex(DatelikeOps, TimelikeOps, DatetimeIndexOpsMixin,
     weekday_name = _field_accessor(
         'weekday_name',
         'weekday_name',
-        "The name of day in a week (ex: Friday)\n\n.. versionadded:: 0.18.1")
+        "The name of day in a week (ex: Friday)\n\n.. deprecated:: 0.23.0")
 
     dayofyear = _field_accessor('dayofyear', 'doy',
                                 "The ordinal day of the year")
@@ -2096,6 +2097,58 @@ class DatetimeIndex(DatelikeOps, TimelikeOps, DatetimeIndexOpsMixin,
                              self.microsecond / 3600.0 / 1e+6 +
                              self.nanosecond / 3600.0 / 1e+9
                              ) / 24.0)
+
+    def month_name(self, locale=None):
+        """
+        Return the month names of the DateTimeIndex with specified locale.
+
+        Parameters
+        ----------
+        locale : string, default None (English locale)
+            locale determining the language in which to return the month name
+
+        Returns
+        -------
+        month_names : Index
+            Index of month names
+
+        .. versionadded:: 0.23.0
+        """
+        values = self.asi8
+        if self.tz is not None:
+            if self.tz is not utc:
+                values = self._local_timestamps()
+
+        result = fields.get_date_name_field(values, 'month_name',
+                                            locale=locale)
+        result = self._maybe_mask_results(result)
+        return Index(result, name=self.name)
+
+    def day_name(self, locale=None):
+        """
+        Return the day names of the DateTimeIndex with specified locale.
+
+        Parameters
+        ----------
+        locale : string, default None (English locale)
+            locale determining the language in which to return the day name
+
+        Returns
+        -------
+        month_names : Index
+            Index of day names
+
+        .. versionadded:: 0.23.0
+        """
+        values = self.asi8
+        if self.tz is not None:
+            if self.tz is not utc:
+                values = self._local_timestamps()
+
+        result = fields.get_date_name_field(values, 'day_name',
+                                            locale=locale)
+        result = self._maybe_mask_results(result)
+        return Index(result, name=self.name)
 
 
 DatetimeIndex._add_comparison_methods()

--- a/pandas/tests/indexes/datetimes/test_misc.py
+++ b/pandas/tests/indexes/datetimes/test_misc.py
@@ -1,3 +1,6 @@
+import locale
+import calendar
+
 import pytest
 
 import numpy as np
@@ -87,7 +90,6 @@ class TestTimeSeries(object):
 class TestDatetime64(object):
 
     def test_datetimeindex_accessors(self):
-
         dti_naive = DatetimeIndex(freq='D', start=datetime(1998, 1, 1),
                                   periods=365)
         # GH 13303
@@ -133,23 +135,6 @@ class TestDatetime64(object):
             assert dti.is_quarter_end[364]
             assert not dti.is_year_end[0]
             assert dti.is_year_end[364]
-
-            # GH 11128
-            assert dti.weekday_name[4] == u'Monday'
-            assert dti.weekday_name[5] == u'Tuesday'
-            assert dti.weekday_name[6] == u'Wednesday'
-            assert dti.weekday_name[7] == u'Thursday'
-            assert dti.weekday_name[8] == u'Friday'
-            assert dti.weekday_name[9] == u'Saturday'
-            assert dti.weekday_name[10] == u'Sunday'
-
-            assert Timestamp('2016-04-04').weekday_name == u'Monday'
-            assert Timestamp('2016-04-05').weekday_name == u'Tuesday'
-            assert Timestamp('2016-04-06').weekday_name == u'Wednesday'
-            assert Timestamp('2016-04-07').weekday_name == u'Thursday'
-            assert Timestamp('2016-04-08').weekday_name == u'Friday'
-            assert Timestamp('2016-04-09').weekday_name == u'Saturday'
-            assert Timestamp('2016-04-10').weekday_name == u'Sunday'
 
             assert len(dti.year) == 365
             assert len(dti.month) == 365
@@ -255,6 +240,54 @@ class TestDatetime64(object):
         expected = [52, 1, 1]
         assert dates.weekofyear.tolist() == expected
         assert [d.weekofyear for d in dates] == expected
+
+    # GH 12806
+    @pytest.mark.parametrize('time_locale', [
+        None] if tm.get_locales() is None else [None] + tm.get_locales())
+    def test_datetime_name_accessors(self, time_locale):
+        # Test Monday -> Sunday and January -> December, in that sequence
+        if time_locale is None:
+            # If the time_locale is None, day-name and month_name should
+            # return the english attributes
+            expected_days = ['Monday', 'Tuesday', 'Wednesday', 'Thursday',
+                             'Friday', 'Saturday', 'Sunday']
+            expected_months = ['January', 'February', 'March', 'April', 'May',
+                               'June', 'July', 'August', 'September',
+                               'October', 'November', 'December']
+        else:
+            with tm.set_locale(time_locale, locale.LC_TIME):
+                expected_days = calendar.day_name[:]
+                expected_months = calendar.month_name[1:]
+
+        # GH 11128
+        dti = DatetimeIndex(freq='D', start=datetime(1998, 1, 1),
+                            periods=365)
+        english_days = ['Monday', 'Tuesday', 'Wednesday', 'Thursday',
+                        'Friday', 'Saturday', 'Sunday']
+        for day, name, eng_name in zip(range(4, 11),
+                                       expected_days,
+                                       english_days):
+            name = name.capitalize()
+            assert dti.weekday_name[day] == eng_name
+            assert dti.day_name(locale=time_locale)[day] == name
+            ts = Timestamp(datetime(2016, 4, day))
+            assert ts.weekday_name == eng_name
+            assert ts.day_name(locale=time_locale) == name
+        dti = dti.append(DatetimeIndex([pd.NaT]))
+        assert np.isnan(dti.day_name(locale=time_locale)[-1])
+        ts = Timestamp(pd.NaT)
+        assert np.isnan(ts.day_name(locale=time_locale))
+
+        # GH 12805
+        dti = DatetimeIndex(freq='M', start='2012', end='2013')
+        result = dti.month_name(locale=time_locale)
+        expected = Index([month.capitalize() for month in expected_months])
+        tm.assert_index_equal(result, expected)
+        for date, expected in zip(dti, expected_months):
+            result = date.month_name(locale=time_locale)
+            assert result == expected.capitalize()
+        dti = dti.append(DatetimeIndex([pd.NaT]))
+        assert np.isnan(dti.month_name(locale=time_locale)[-1])
 
     def test_nanosecond_field(self):
         dti = DatetimeIndex(np.arange(10))

--- a/pandas/tests/scalar/timestamp/test_timestamp.py
+++ b/pandas/tests/scalar/timestamp/test_timestamp.py
@@ -4,6 +4,7 @@ import pytz
 import pytest
 import dateutil
 import calendar
+import locale
 import numpy as np
 
 from dateutil.tz import tzutc
@@ -21,7 +22,7 @@ from pandas._libs.tslibs.timezones import get_timezone, dateutil_gettz as gettz
 from pandas.errors import OutOfBoundsDatetime
 from pandas.compat import long, PY3
 from pandas.compat.numpy import np_datetime64_compat
-from pandas import Timestamp, Period, Timedelta
+from pandas import Timestamp, Period, Timedelta, NaT
 
 
 class TestTimestampProperties(object):
@@ -95,13 +96,33 @@ class TestTimestampProperties(object):
         for end in ends:
             assert getattr(ts, end)
 
-    @pytest.mark.parametrize('data, expected',
-                             [(Timestamp('2017-08-28 23:00:00'), 'Monday'),
-                              (Timestamp('2017-08-28 23:00:00', tz='EST'),
-                               'Monday')])
-    def test_weekday_name(self, data, expected):
+    # GH 12806
+    @pytest.mark.parametrize('data',
+                             [Timestamp('2017-08-28 23:00:00'),
+                              Timestamp('2017-08-28 23:00:00', tz='EST')])
+    @pytest.mark.parametrize('time_locale', [
+        None] if tm.get_locales() is None else [None] + tm.get_locales())
+    def test_names(self, data, time_locale):
         # GH 17354
-        assert data.weekday_name == expected
+        # Test .weekday_name, .day_name(), .month_name
+        with tm.assert_produces_warning(DeprecationWarning,
+                                        check_stacklevel=False):
+            assert data.weekday_name == 'Monday'
+        if time_locale is None:
+            expected_day = 'Monday'
+            expected_month = 'August'
+        else:
+            with tm.set_locale(time_locale, locale.LC_TIME):
+                expected_day = calendar.day_name[0].capitalize()
+                expected_month = calendar.month_name[8].capitalize()
+
+        assert data.day_name(time_locale) == expected_day
+        assert data.month_name(time_locale) == expected_month
+
+        # Test NaT
+        nan_ts = Timestamp(NaT)
+        assert np.isnan(nan_ts.day_name(time_locale))
+        assert np.isnan(nan_ts.month_name(time_locale))
 
     @pytest.mark.parametrize('tz', [None, 'UTC', 'US/Eastern', 'Asia/Tokyo'])
     def test_is_leap_year(self, tz):

--- a/pandas/tests/series/test_datetime_values.py
+++ b/pandas/tests/series/test_datetime_values.py
@@ -1,6 +1,8 @@
 # coding=utf-8
 # pylint: disable-msg=E1101,W0612
 
+import locale
+import calendar
 import pytest
 
 from datetime import datetime, date
@@ -32,7 +34,7 @@ class TestSeriesDatetimeValues(TestData):
         ok_for_dt = DatetimeIndex._datetimelike_ops
         ok_for_dt_methods = ['to_period', 'to_pydatetime', 'tz_localize',
                              'tz_convert', 'normalize', 'strftime', 'round',
-                             'floor', 'ceil', 'weekday_name']
+                             'floor', 'ceil', 'day_name', 'month_name']
         ok_for_td = TimedeltaIndex._datetimelike_ops
         ok_for_td_methods = ['components', 'to_pytimedelta', 'total_seconds',
                              'round', 'floor', 'ceil']
@@ -273,6 +275,46 @@ class TestSeriesDatetimeValues(TestData):
         with tm.assert_raises_regex(AttributeError,
                                     "You cannot add any new attribute"):
             s.dt.xlabel = "a"
+
+    @pytest.mark.parametrize('time_locale', [
+        None] if tm.get_locales() is None else [None] + tm.get_locales())
+    def test_dt_accessor_datetime_name_accessors(self, time_locale):
+        # Test Monday -> Sunday and January -> December, in that sequence
+        if time_locale is None:
+            # If the time_locale is None, day-name and month_name should
+            # return the english attributes
+            expected_days = ['Monday', 'Tuesday', 'Wednesday', 'Thursday',
+                             'Friday', 'Saturday', 'Sunday']
+            expected_months = ['January', 'February', 'March', 'April', 'May',
+                               'June', 'July', 'August', 'September',
+                               'October', 'November', 'December']
+        else:
+            with tm.set_locale(time_locale, locale.LC_TIME):
+                expected_days = calendar.day_name[:]
+                expected_months = calendar.month_name[1:]
+
+        s = Series(DatetimeIndex(freq='D', start=datetime(1998, 1, 1),
+                                 periods=365))
+        english_days = ['Monday', 'Tuesday', 'Wednesday', 'Thursday',
+                        'Friday', 'Saturday', 'Sunday']
+        for day, name, eng_name in zip(range(4, 11),
+                                       expected_days,
+                                       english_days):
+            name = name.capitalize()
+            assert s.dt.weekday_name[day] == eng_name
+            assert s.dt.day_name(locale=time_locale)[day] == name
+        s = s.append(Series([pd.NaT]))
+        assert np.isnan(s.dt.day_name(locale=time_locale).iloc[-1])
+
+        s = Series(DatetimeIndex(freq='M', start='2012', end='2013'))
+        result = s.dt.month_name(locale=time_locale)
+        expected = Series([month.capitalize() for month in expected_months])
+        tm.assert_series_equal(result, expected)
+        for s_date, expected in zip(s, expected_months):
+            result = s_date.month_name(locale=time_locale)
+            assert result == expected.capitalize()
+        s = s.append(Series([pd.NaT]))
+        assert np.isnan(s.dt.month_name(locale=time_locale).iloc[-1])
 
     def test_strftime(self):
         # GH 10086


### PR DESCRIPTION
closes #12805
closes #12806
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry

I am not sure what locales are available on the CI machines, but the test will run all available locales. 