### PR TITLE
offsets cleanup

### DIFF
--- a/pandas/_libs/tslibs/offsets.pyx
+++ b/pandas/_libs/tslibs/offsets.pyx
@@ -19,6 +19,7 @@ from pandas._libs.tslib import pydt_to_i8
 
 from frequencies cimport get_freq_code
 from conversion cimport tz_convert_single
+from timedeltas import Timedelta, delta_to_nanoseconds
 
 # ---------------------------------------------------------------------
 # Constants
@@ -375,3 +376,21 @@ class BaseOffset(_BaseOffset):
             # i.e. isinstance(other, (ABCDatetimeIndex, ABCSeries))
             return other - self
         return -self + other
+
+# ---------------------------------------------------------------------
+# Ticks
+
+class _Tick(object):
+    _inc = Timedelta(microseconds=1000)
+    _prefix = 'undefined'
+
+    @property
+    def delta(self):
+        return self.n * self._inc
+
+    @property
+    def nanos(self):
+        return delta_to_nanoseconds(self.delta)
+
+    def isAnchored(self):
+        return False

--- a/pandas/_libs/tslibs/offsets.pyx
+++ b/pandas/_libs/tslibs/offsets.pyx
@@ -382,7 +382,7 @@ class BaseOffset(_BaseOffset):
 
 class _Tick(object):
     _inc = Timedelta(microseconds=1000)
-    _prefix = 'undefined'
+    _prefix = None
 
     @property
     def delta(self):

--- a/pandas/tseries/offsets.py
+++ b/pandas/tseries/offsets.py
@@ -2128,9 +2128,9 @@ class FY5253(DateOffset):
             return LastWeekOfMonth(n=1, weekday=self.weekday)
 
     def isAnchored(self):
-        return (self.n == 1
-                and self.startingMonth is not None
-                and self.weekday is not None)
+        return (self.n == 1 and
+                self.startingMonth is not None and
+                self.weekday is not None)
 
     def onOffset(self, dt):
         if self.normalize and not _is_normalized(dt):
@@ -2542,8 +2542,7 @@ class Tick(_Tick, SingleConstructorOffset):
     # This is identical to DateOffset.__hash__, but has to be redefined here
     # for Python 3, because we've redefined __eq__.
     def __hash__(self):
-        tup = (str(self.__class__), ('n', self.n),)
-        return hash(tup)
+        return hash(self._params())
 
     def __ne__(self, other):
         if isinstance(other, compat.string_types):

--- a/pandas/tseries/offsets.py
+++ b/pandas/tseries/offsets.py
@@ -2204,8 +2204,8 @@ class FY5253(DateOffset):
             else:
                 assert False
 
-            result = self.get_year_end(datetime(year - n,
-                                                self.startingMonth, 1))
+            result = self.get_year_end(
+                datetime(year - n, self.startingMonth, 1))
 
             result = datetime(result.year, result.month, result.day,
                               other.hour, other.minute, other.second,
@@ -2219,8 +2219,8 @@ class FY5253(DateOffset):
             return self._get_year_end_last(dt)
 
     def get_target_month_end(self, dt):
-        target_month = datetime(
-            dt.year, self.startingMonth, 1, tzinfo=dt.tzinfo)
+        target_month = datetime(dt.year, self.startingMonth, 1,
+                                tzinfo=dt.tzinfo)
         next_month_first_of = target_month + relativedelta(months=+1)
         return next_month_first_of + relativedelta(days=-1)
 
@@ -2238,8 +2238,8 @@ class FY5253(DateOffset):
                 return backward
 
     def _get_year_end_last(self, dt):
-        current_year = datetime(
-            dt.year, self.startingMonth, 1, tzinfo=dt.tzinfo)
+        current_year = datetime(dt.year, self.startingMonth, 1,
+                                tzinfo=dt.tzinfo)
         return current_year + self._offset_lwom
 
     @property
@@ -2542,7 +2542,8 @@ class Tick(_Tick, SingleConstructorOffset):
     # This is identical to DateOffset.__hash__, but has to be redefined here
     # for Python 3, because we've redefined __eq__.
     def __hash__(self):
-        return hash(self._params())
+        tup = (str(self.__class__), ('n', self.n),)
+        return hash(tup)
 
     def __ne__(self, other):
         if isinstance(other, compat.string_types):


### PR DESCRIPTION
This is mostly a small cleanup of offsets, want to keep this fairly trivial diff from obscuring more important upcoming changes.

The two non-trivial things here are 1) implement `_Tick` class in offsets.pyx with the most basic of its methods and 2) optimization of `Tick.__hash__`.  You'd be surprised how big a difference this particular optimization makes:

Before:
```
In [2]: day = pd.offsets.Day(2)
In [3]: %timeit hash(day)
100000 loops, best of 3: 11.7 µs per loop
```

After
```
In [3]: day = pd.offsets.Day(2)
In [5]: %timeit hash(day)
The slowest run took 8.61 times longer than the fastest. This could mean that an intermediate result is being cached.
100000 loops, best of 3: 1.86 µs per loop
```