### PR TITLE
cleanup; use timedelta instead of relativedelta where possible

### DIFF
--- a/pandas/tseries/offsets.py
+++ b/pandas/tseries/offsets.py
@@ -237,7 +237,7 @@ class DateOffset(BaseOffset):
             weeks = (self.kwds.get('weeks', 0)) * self.n
             if weeks:
                 i = ((i.to_period('W') + weeks).to_timestamp() +
-                      i.to_perioddelta('W'))
+                     i.to_perioddelta('W'))
 
             timedelta_kwds = dict((k, v) for k, v in self.kwds.items()
                                   if k in ['days', 'hours', 'minutes',


### PR DESCRIPTION
- Cleanup, flake8, modernize imports
- Replace usage of `other + relativedelta(...)` with `other + timedelta(...)` or `other.replace(...)` where possible.  Clearer and more performant.
- Use _get_firstbday in one place that had previously duplicated its logic.

```
asv continuous -f 1.1 -E virtualenv master HEAD -b timeseries
[...]
       before           after         ratio
     [8dac6331]       [c6145385]
-      31.4±0.2μs       26.7±0.3μs     0.85  timeseries.Offsets.time_custom_bday_decr
-      14.4±0.1ms       12.0±0.2ms     0.84  timeseries.DatetimeIndex.time_infer_freq_none
-           1.76s            1.45s     0.82  timeseries.Iteration.time_iter_periodindex
-      53.8±0.2μs       42.2±0.2μs     0.78  timeseries.SemiMonthOffset.time_end_decr_n
-        53.1±4μs       41.1±0.3μs     0.78  timeseries.SemiMonthOffset.time_begin_incr_n
-      54.6±0.2μs       41.5±0.2μs     0.76  timeseries.SemiMonthOffset.time_begin_decr_n
-      3.55±0.5ms      2.70±0.01ms     0.76  timeseries.ToDatetime.time_iso8601_nosep
-      51.8±0.2μs       38.6±0.2μs     0.75  timeseries.SemiMonthOffset.time_begin_decr
-        53.0±3μs       38.1±0.3μs     0.72  timeseries.SemiMonthOffset.time_end_incr_n
-      47.5±0.3μs       34.0±0.3μs     0.72  timeseries.SemiMonthOffset.time_end_incr
-      49.2±0.2μs       34.9±0.8μs     0.71  timeseries.SemiMonthOffset.time_begin_incr
-      55.8±0.1μs         39.3±1μs     0.70  timeseries.SemiMonthOffset.time_end_decr
-      43.6±0.5μs       30.7±0.2μs     0.70  timeseries.SemiMonthOffset.time_begin_apply
-      43.6±0.4μs       30.6±0.1μs     0.70  timeseries.SemiMonthOffset.time_end_apply
```