### PR TITLE
Fix #17965 datetime64 comparison

### DIFF
--- a/doc/source/whatsnew/v0.21.1.txt
+++ b/doc/source/whatsnew/v0.21.1.txt
@@ -73,6 +73,7 @@ Conversion
 Indexing
 ^^^^^^^^
 
+- Bug in a boolean comparison of a ``datetime.datetime`` and a ``datetime64[ns]`` dtype Series (:issue:`17965`)
 - Bug where a ``MultiIndex`` with more than a million records was not raising ``AttributeError`` when trying to access a missing attribute (:issue:`18165`)
 -
 -

--- a/pandas/_libs/index.pyx
+++ b/pandas/_libs/index.pyx
@@ -19,7 +19,7 @@ from hashtable cimport HashTable
 
 from pandas._libs import algos, period as periodlib, hashtable as _hash
 from pandas._libs.tslib import Timestamp, Timedelta
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, date
 
 from cpython cimport PyTuple_Check, PyList_Check
 
@@ -549,7 +549,7 @@ cpdef convert_scalar(ndarray arr, object value):
     if arr.descr.type_num == NPY_DATETIME:
         if isinstance(value, np.ndarray):
             pass
-        elif isinstance(value, datetime):
+        elif isinstance(value, (datetime, np.datetime64, date)):
             return Timestamp(value).value
         elif value is None or value != value:
             return iNaT

--- a/pandas/tests/indexes/datetimes/test_partial_slicing.py
+++ b/pandas/tests/indexes/datetimes/test_partial_slicing.py
@@ -2,9 +2,10 @@
 
 import pytest
 
-from datetime import datetime
+from datetime import datetime, date
 import numpy as np
 import pandas as pd
+import operator as op
 
 from pandas import (DatetimeIndex, Series, DataFrame,
                     date_range, Index, Timedelta, Timestamp)
@@ -330,3 +331,21 @@ class TestSlicing(object):
 
         result = df.loc['2016-10-01T00:00:00':]
         tm.assert_frame_equal(result, df)
+
+    @pytest.mark.parametrize('datetimelike', [
+        Timestamp('20130101'), datetime(2013, 1, 1),
+        date(2013, 1, 1), np.datetime64('2013-01-01T00:00', 'ns')])
+    @pytest.mark.parametrize('op,expected', [
+        (op.lt, [True, False, False, False]),
+        (op.le, [True, True, False, False]),
+        (op.eq, [False, True, False, False]),
+        (op.gt, [False, False, False, True])])
+    def test_selection_by_datetimelike(self, datetimelike, op, expected):
+        # GH issue #17965, test for ability to compare datetime64[ns] columns
+        # to datetimelike
+        df = DataFrame({'A': [pd.Timestamp('20120101'),
+                              pd.Timestamp('20130101'),
+                              np.nan, pd.Timestamp('20130103')]})
+        result = op(df.A, datetimelike)
+        expected = Series(expected, name='A')
+        tm.assert_series_equal(result, expected)


### PR DESCRIPTION
- [x] closes #17965 
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry


