### PR TITLE
 Fix for #18178 and #18187 by changing the concat of empty RangeIndex 

### DIFF
--- a/doc/source/whatsnew/v0.21.1.txt
+++ b/doc/source/whatsnew/v0.21.1.txt
@@ -61,6 +61,7 @@ Bug Fixes
 - Bug in :class:`DatetimeIndex` subtracting datetimelike from DatetimeIndex could fail to overflow (:issue:`18020`)
 - Bug in ``pd.Series.rolling.skew()`` and ``rolling.kurt()`` with all equal values has floating issue (:issue:`18044`)
 - Bug in ``pd.DataFrameGroupBy.count()`` when counting over a datetimelike column (:issue:`13393`)
+- Bug in ``pd.concat`` when empty and non-empty DataFrames or Series are concatenated (:issue:`18178` :issue:`18187`)
 
 Conversion
 ^^^^^^^^^^

--- a/pandas/tests/reshape/test_concat.py
+++ b/pandas/tests/reshape/test_concat.py
@@ -1983,3 +1983,21 @@ def test_concat_will_upcast(dt, pdt):
                pdt(np.array([5], dtype=dt, ndmin=dims))]
         x = pd.concat(dfs)
         assert x.values.dtype == 'float64'
+
+
+def test_concat_empty_and_non_empty_frame_regression():
+    # GH 18178 regression test
+    df1 = pd.DataFrame({'foo': [1]})
+    df2 = pd.DataFrame({'foo': []})
+    expected = pd.DataFrame({'foo': [1.0]})
+    result = pd.concat([df1, df2])
+    assert_frame_equal(result, expected)
+
+
+def test_concat_empty_and_non_empty_series_regression():
+    # GH 18187 regression test
+    s1 = pd.Series([1])
+    s2 = pd.Series([])
+    expected = s1
+    result = pd.concat([s1, s2])
+    tm.assert_series_equal(result, expected)


### PR DESCRIPTION
The `_concat_rangeindex_same_dtype` function now keeps track of the last non-empty `RangeIndex` to extract the new stop value.

This fixes two issues with concatenating non-empty and empty `DataFrames` and `Series`.

Two regression tests were added as well.

- closes #18178 and closes #18187 
- 2 regression tests added
- Submission passes `git diff master -u -- "*.py" | flake8 --diff`
- 1 whatsnew entry
