### PR TITLE
Allow accessing AxisProperties on classes

### DIFF
--- a/pandas/_libs/properties.pyx
+++ b/pandas/_libs/properties.pyx
@@ -63,7 +63,14 @@ cdef class AxisProperty(object):
         self.axis = axis
 
     def __get__(self, obj, type):
-        cdef list axes = obj._data.axes
+        cdef:
+            list axes
+
+        if obj is None:
+            # Only instances have _data, not classes
+            return None
+        else:
+            axes = obj._data.axes
         return axes[self.axis]
 
     def __set__(self, obj, value):

--- a/pandas/tests/frame/test_api.py
+++ b/pandas/tests/frame/test_api.py
@@ -306,6 +306,11 @@ class SharedWithSparse(object):
         result = f.sum(axis='columns')
         assert_series_equal(result, expected)
 
+    def test_class_axis(self):
+        # https://github.com/pandas-dev/pandas/issues/18147
+        DataFrame.index  # no exception!
+        DataFrame.columns  # no exception!
+
     def test_more_asMatrix(self):
         values = self.mixed_frame.as_matrix()
         assert values.shape[1] == len(self.mixed_frame.columns)

--- a/pandas/tests/series/test_api.py
+++ b/pandas/tests/series/test_api.py
@@ -334,6 +334,10 @@ class TestSeriesMisc(TestData, SharedWithSparse):
         assert s._get_axis_number('rows') == 0
         assert s._get_axis_name('rows') == 'index'
 
+    def test_class_axis(self):
+        # https://github.com/pandas-dev/pandas/issues/18147
+        Series.index  # no exception!
+
     def test_numpy_unique(self):
         # it works!
         np.unique(self.ts)


### PR DESCRIPTION
xref https://github.com/pandas-dev/pandas/issues/18147

This will remove the doc warnings about DataFrame.index, Series.index, ...

Basically, before if you did `pd.DataFrame.index` you got an exception, about `None._data`, since there was no instance.

cc @jreback if you have any concerns.