### PR TITLE
Added repr string for Grouper and TimeGrouper

### DIFF
--- a/doc/source/whatsnew/v0.21.1.txt
+++ b/doc/source/whatsnew/v0.21.1.txt
@@ -22,7 +22,7 @@ Other Enhancements
 ^^^^^^^^^^^^^^^^^^
 
 - :meth:`Timestamp.timestamp` is now available in Python 2.7. (:issue:`17329`)
--
+- :class:`Grouper` and :class:`TimeGrouper` now have a friendly repr output (:issue:`18203`).
 -
 
 .. _whatsnew_0211.deprecations:

--- a/doc/source/whatsnew/v0.22.0.txt
+++ b/doc/source/whatsnew/v0.22.0.txt
@@ -100,7 +100,7 @@ Removal of prior version deprecations/changes
 - The ``levels`` and ``labels`` attributes of a ``MultiIndex`` can no longer be set directly (:issue:`4039`).
 - ``pd.tseries.util.pivot_annual`` has been  removed (deprecated since v0.19). Use ``pivot_table`` instead (:issue:`18370`)
 - ``pd.tseries.util.isleapyear`` has been removed (deprecated since v0.19). Use ``.is_leap_year`` property in Datetime-likes instead (:issue:`18370`)
-- ``pd.ordered_merge`` has been removed (deprecated since v0.19). Use ``pd..merge_ordered`` instead (:issue:`18459`)
+- ``pd.ordered_merge`` has been removed (deprecated since v0.19). Use ``pd.merge_ordered`` instead (:issue:`18459`)
 
 .. _whatsnew_0220.performance:
 

--- a/pandas/core/groupby.py
+++ b/pandas/core/groupby.py
@@ -206,12 +206,13 @@ class Grouper(object):
     sort : boolean, default to False
         whether to sort the resulting labels
 
-    additional kwargs to control time-like groupers (when freq is passed)
+    additional kwargs to control time-like groupers (when ``freq`` is passed)
 
-    closed : closed end of interval; left or right
-    label : interval boundary to use for labeling; left or right
+    closed : closed end of interval; 'left' or 'right'
+    label : interval boundary to use for labeling; 'left' or 'right'
     convention : {'start', 'end', 'e', 's'}
         If grouper is PeriodIndex
+    base, loffset
 
     Returns
     -------
@@ -233,6 +234,7 @@ class Grouper(object):
 
     >>> df.groupby(Grouper(level='date', freq='60s', axis=1))
     """
+    _attributes = ('key', 'level', 'freq', 'axis', 'sort')
 
     def __new__(cls, *args, **kwargs):
         if kwargs.get('freq') is not None:
@@ -332,6 +334,14 @@ class Grouper(object):
     @property
     def groups(self):
         return self.grouper.groups
+
+    def __repr__(self):
+        attrs_list = ["{}={!r}".format(attr_name, getattr(self, attr_name))
+                      for attr_name in self._attributes
+                      if getattr(self, attr_name) is not None]
+        attrs = ", ".join(attrs_list)
+        cls_name = self.__class__.__name__
+        return "{}({})".format(cls_name, attrs)
 
 
 class GroupByPlot(PandasObject):

--- a/pandas/core/resample.py
+++ b/pandas/core/resample.py
@@ -1014,22 +1014,18 @@ class TimeGrouper(Grouper):
     Parameters
     ----------
     freq : pandas date offset or offset alias for identifying bin edges
-    closed : closed end of interval; left or right
-    label : interval boundary to use for labeling; left or right
-    nperiods : optional, integer
+    closed : closed end of interval; 'left' or 'right'
+    label : interval boundary to use for labeling; 'left' or 'right'
     convention : {'start', 'end', 'e', 's'}
         If axis is PeriodIndex
-
-    Notes
-    -----
-    Use begin, end, nperiods to generate intervals that cannot be derived
-    directly from the associated object
     """
+    _attributes = Grouper._attributes + ('closed', 'label', 'how',
+                                         'loffset', 'kind', 'convention',
+                                         'base')
 
     def __init__(self, freq='Min', closed=None, label=None, how='mean',
-                 nperiods=None, axis=0,
-                 fill_method=None, limit=None, loffset=None, kind=None,
-                 convention=None, base=0, **kwargs):
+                 axis=0, fill_method=None, limit=None, loffset=None,
+                 kind=None, convention=None, base=0, **kwargs):
         freq = to_offset(freq)
 
         end_types = set(['M', 'A', 'Q', 'BM', 'BA', 'BQ', 'W'])
@@ -1048,7 +1044,6 @@ class TimeGrouper(Grouper):
 
         self.closed = closed
         self.label = label
-        self.nperiods = nperiods
         self.kind = kind
 
         self.convention = convention or 'E'

--- a/pandas/tests/groupby/test_groupby.py
+++ b/pandas/tests/groupby/test_groupby.py
@@ -25,6 +25,15 @@ import pandas as pd
 from .common import MixIn
 
 
+class TestGrouper(object):
+
+    def test_repr(self):
+        # GH18203
+        result = repr(pd.Grouper(key='A', level='B'))
+        expected = "Grouper(key='A', level='B', axis=0, sort=False)"
+        assert result == expected
+
+
 class TestGroupBy(MixIn):
 
     def test_basic(self):

--- a/pandas/tests/test_resample.py
+++ b/pandas/tests/test_resample.py
@@ -3416,3 +3416,11 @@ class TestTimeGrouper(object):
 
             # if NaT is included, 'var', 'std', 'mean', 'first','last'
             # and 'nth' doesn't work yet
+
+    def test_repr(self):
+        # GH18203
+        result = repr(TimeGrouper(key='A', freq='H'))
+        expected = ("TimeGrouper(key='A', freq=<Hour>, axis=0, sort=True, "
+                    "closed='left', label='left', how='mean', "
+                    "convention='e', base=0)")
+        assert result == expected


### PR DESCRIPTION
- [ ] closes #xxxx
- [ ] tests added / passed
- [x ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

This is a new implementation of #17727. This is much simpler than the previous attempts. The outputs are now:

```python
>>> pd.Grouper(key='A')
Grouper(key='A')
>>> pd.Grouper(key='A', freq='2T')
TimeGrouper(key='A', freq=<2 * Minutes>, sort=True, closed='left', label='left', convention='e')
```

Tests still need to be written. I can do them when/if this is ok.