### PR TITLE
Catch SystemError in py3 Period.__richcmp__

### DIFF
--- a/pandas/_libs/period.pyx
+++ b/pandas/_libs/period.pyx
@@ -693,7 +693,12 @@ cdef class _Period(object):
 
     def __richcmp__(self, other, op):
         if is_period_object(other):
-            if other.freq != self.freq:
+            try:
+                if other.freq != self.freq:
+                    msg = _DIFFERENT_FREQ.format(self.freqstr, other.freqstr)
+                    raise IncompatibleFrequency(msg)
+            except SystemError:
+                # See GH#17112 in python3
                 msg = _DIFFERENT_FREQ.format(self.freqstr, other.freqstr)
                 raise IncompatibleFrequency(msg)
             return PyObject_RichCompareBool(self.ordinal, other.ordinal, op)

--- a/pandas/tests/scalar/test_period.py
+++ b/pandas/tests/scalar/test_period.py
@@ -1419,6 +1419,7 @@ def test_period_immutable():
     with pytest.raises(AttributeError):
         per.freq = 2 * freq
 
+
 def test_comparison_catches_system_error():
     # see GH#17112 in py3 this comparison could raise SystemError instead
     # of IncompatibleFrequency

--- a/pandas/tests/scalar/test_period.py
+++ b/pandas/tests/scalar/test_period.py
@@ -1418,3 +1418,11 @@ def test_period_immutable():
     freq = per.freq
     with pytest.raises(AttributeError):
         per.freq = 2 * freq
+
+def test_comparison_catches_system_error():
+    # see GH#17112 in py3 this comparison could raise SystemError instead
+    # of IncompatibleFrequency
+    per1 = pd.Period('2014Q1')
+    per2 = pd.Period('2015', freq='A')
+    with pytest.raises(IncompatibleFrequency):
+        per1 < per2

--- a/pandas/tests/scalar/test_period.py
+++ b/pandas/tests/scalar/test_period.py
@@ -1424,5 +1424,5 @@ def test_comparison_catches_system_error():
     # of IncompatibleFrequency
     per1 = pd.Period('2014Q1')
     per2 = pd.Period('2015', freq='A')
-    with pytest.raises(IncompatibleFrequency):
+    with pytest.raises(period.IncompatibleFrequency):
         per1 < per2


### PR DESCRIPTION
First of ~3 to fix bugs reported in #17112.  This just catches a py3-specific error in `Period.__richcmp__` and raises the correct error instead.  With a test that fails under the status quo.