### PR TITLE
ERR: raise if values passed to Categorical is a DataFrame

### DIFF
--- a/pandas/core/categorical.py
+++ b/pandas/core/categorical.py
@@ -309,8 +309,8 @@ class Categorical(PandasObject):
             # we'll do inference later
             pass
         elif getattr(values, 'ndim', 0) > 1:
-            raise TypeError("> 1 ndim Categorical are not "
-                            "supported at this time")
+            raise NotImplementedError("> 1 ndim Categorical are not "
+                                      "supported at this time")
 
         else:
 
@@ -2335,7 +2335,7 @@ def _factorize_from_iterable(values):
                                       ordered=values.ordered)
         codes = values.codes
     elif getattr(values, 'ndim', 0) > 1:
-        raise TypeError('Factorizing DataFrame is not supported.')
+        raise NotImplementedError('Factorizing DataFrame is not supported.')
     else:
         cat = Categorical(values, ordered=True)
         categories = cat.categories

--- a/pandas/core/categorical.py
+++ b/pandas/core/categorical.py
@@ -9,7 +9,7 @@ from pandas.compat import u, lzip
 from pandas._libs import lib, algos as libalgos
 
 from pandas.core.dtypes.generic import (
-    ABCSeries, ABCIndexClass, ABCCategoricalIndex)
+    ABCDataFrame, ABCSeries, ABCIndexClass, ABCCategoricalIndex)
 from pandas.core.dtypes.missing import isna, notna
 from pandas.core.dtypes.cast import (
     maybe_infer_to_datetimelike,
@@ -308,6 +308,9 @@ class Categorical(PandasObject):
         elif isinstance(values, (ABCIndexClass, ABCSeries)):
             # we'll do inference later
             pass
+        elif isinstance(values, ABCDataFrame):
+            raise TypeError("> 1 ndim Categorical are not "
+                            "supported at this time")
 
         else:
 
@@ -2331,6 +2334,8 @@ def _factorize_from_iterable(values):
                                       categories=values.categories,
                                       ordered=values.ordered)
         codes = values.codes
+    elif isinstance(values, ABCDataFrame):
+        raise TypeError('Factorizing DataFrame is not supported.')
     else:
         cat = Categorical(values, ordered=True)
         categories = cat.categories

--- a/pandas/core/categorical.py
+++ b/pandas/core/categorical.py
@@ -9,7 +9,7 @@ from pandas.compat import u, lzip
 from pandas._libs import lib, algos as libalgos
 
 from pandas.core.dtypes.generic import (
-    ABCDataFrame, ABCSeries, ABCIndexClass, ABCCategoricalIndex)
+    ABCSeries, ABCIndexClass, ABCCategoricalIndex)
 from pandas.core.dtypes.missing import isna, notna
 from pandas.core.dtypes.cast import (
     maybe_infer_to_datetimelike,
@@ -308,7 +308,7 @@ class Categorical(PandasObject):
         elif isinstance(values, (ABCIndexClass, ABCSeries)):
             # we'll do inference later
             pass
-        elif isinstance(values, ABCDataFrame):
+        elif getattr(values, 'ndim', 0) > 1:
             raise TypeError("> 1 ndim Categorical are not "
                             "supported at this time")
 
@@ -2334,7 +2334,7 @@ def _factorize_from_iterable(values):
                                       categories=values.categories,
                                       ordered=values.ordered)
         codes = values.codes
-    elif isinstance(values, ABCDataFrame):
+    elif getattr(values, 'ndim', 0) > 1:
         raise TypeError('Factorizing DataFrame is not supported.')
     else:
         cat = Categorical(values, ordered=True)

--- a/pandas/tests/test_categorical.py
+++ b/pandas/tests/test_categorical.py
@@ -173,6 +173,12 @@ class TestCategorical(object):
         pytest.raises(
             TypeError, lambda: Categorical(arr, ordered=True))
 
+    def test_constructor_dataframe_error(self):
+        # GH#17112
+        df = pd.DataFrame(np.random.randn(3, 2), columns=['A', 'B'])
+        with pytest.raises(TypeError):
+            Categorical(df)
+
     def test_constructor_interval(self):
         result = Categorical([Interval(1, 2), Interval(2, 3), Interval(3, 6)],
                              ordered=True)

--- a/pandas/tests/test_categorical.py
+++ b/pandas/tests/test_categorical.py
@@ -176,7 +176,7 @@ class TestCategorical(object):
     def test_constructor_dataframe_error(self):
         # GH#17112
         df = pd.DataFrame(np.random.randn(3, 2), columns=['A', 'B'])
-        with pytest.raises(TypeError):
+        with pytest.raises(NotImplementedError):
             Categorical(df)
 
     def test_constructor_interval(self):


### PR DESCRIPTION
2nd of 3 to address #17112.   This raises instead of making the following mistake:

```
>>> df = pd.DataFrame(np.random.randn(3,2), columns=['A', 'B'])
>>> pd.Categorical(df)
[A, B]
Categories (2, object): [A, B]
```