### PR TITLE
Handle unsortable Periods correctly in set_index, MultiIndex

### DIFF
--- a/pandas/core/sorting.py
+++ b/pandas/core/sorting.py
@@ -431,21 +431,32 @@ def safe_sort(values, labels=None, na_sentinel=-1, assume_unique=False):
 
     def sort_mixed(values):
         # order ints before strings, safe in py3
+        from pandas import Period
+        per_pos = np.array([isinstance(x, Period) for x in values],
+                           dtype=bool)
         str_pos = np.array([isinstance(x, string_types) for x in values],
                            dtype=bool)
-        nums = np.sort(values[~str_pos])
+        nums = np.sort(values[~(str_pos | per_pos)])
         strs = np.sort(values[str_pos])
-        return np.concatenate([nums, np.asarray(strs, dtype=object)])
+        try:
+            pers = np.sort(values[per_pos])
+        except (TypeError, ValueError):
+            # period.IncompatibleFrequency subclasses ValueError, leads
+            # to inconsistent behavior in py2/py3
+            pers = sorted(values[per_pos], key=lambda x: x.start_time)
+            pers = np.array(pers, dtype=object)
+        return np.concatenate([nums, np.asarray(strs, dtype=object), pers])
 
     sorter = None
     if PY3 and lib.infer_dtype(values) == 'mixed-integer':
         # unorderable in py3 if mixed str/int
         ordered = sort_mixed(values)
     else:
+        from pandas._libs.period import IncompatibleFrequency
         try:
             sorter = values.argsort()
             ordered = values.take(sorter)
-        except TypeError:
+        except (TypeError, IncompatibleFrequency):
             # try this anyway
             ordered = sort_mixed(values)
 

--- a/pandas/tests/indexes/period/test_period.py
+++ b/pandas/tests/indexes/period/test_period.py
@@ -40,21 +40,6 @@ class TestPeriodLevelMultiIndex(object):
         assert mi.names == ['Variable', 'Period']
         assert mi.get_level_values('Variable').equals(index)
 
-    def test_from_arrays_dataframe_level_invalid(self):
-        # GH#17112
-        index = pd.Index(['CPROF', 'HOUSING', 'INDPROD', 'NGDP', 'PGDP'],
-                         name='Variable')
-        data = [pd.Period('1968Q4')] * 5
-        df = pd.DataFrame(data, index=index, columns=['Period'])
-        with pytest.raises(TypeError):
-            # user should not pass a DataFrame as an index level.
-            # In this single-column case the user needs to specifically pass
-            # df['Period'].
-            # Check that this raises at construction time instead of later
-            # when accessing `mi.shape`, which used to raise
-            # "ValueError: all arrays must be the same length",
-            pd.MultiIndex.from_arrays([df.index, df])
-
 
 class TestPeriodIndex(DatetimeLike):
     _holder = PeriodIndex


### PR DESCRIPTION
3rd of 3 to address bugs in #17112

`set_index` goes through MultiIndex.from_arrays, which calls `factorize_from_iterables`... which tries to sort the inputs.  In cases like `Period`, sometimes the inputs can't be sorted.  But for the purposes of `set_index`, we don't actually _care_ about the order.  So we impose a reasonable fallback.

New tests are likely not in the correct place.  Pls advise.