### PR TITLE
Add requirement for a 1-dimensional ndarray in the `pd.qcut` docstring

### DIFF
--- a/doc/source/whatsnew/v0.22.0.txt
+++ b/doc/source/whatsnew/v0.22.0.txt
@@ -78,7 +78,7 @@ Performance Improvements
 Documentation Changes
 ~~~~~~~~~~~~~~~~~~~~~
 
-- Add requirement for 1-dimensional ndarrays in ``pd.qcut`` docstring (:issue:`18173`)
+-
 -
 -
 

--- a/doc/source/whatsnew/v0.22.0.txt
+++ b/doc/source/whatsnew/v0.22.0.txt
@@ -78,7 +78,7 @@ Performance Improvements
 Documentation Changes
 ~~~~~~~~~~~~~~~~~~~~~
 
--
+- Add requirement for 1-dimensional ndarrays in ``pd.qcut`` docstring (:issue:`18173`)
 -
 -
 

--- a/pandas/core/reshape/tile.py
+++ b/pandas/core/reshape/tile.py
@@ -148,7 +148,7 @@ def qcut(x, q, labels=None, retbins=False, precision=3, duplicates='raise'):
 
     Parameters
     ----------
-    x : ndarray (1-dimensional) or Series
+    x : 1d ndarray or Series
     q : integer or array of quantiles
         Number of quantiles. 10 for deciles, 4 for quartiles, etc. Alternately
         array of quantiles, e.g. [0, .25, .5, .75, 1.] for quartiles

--- a/pandas/core/reshape/tile.py
+++ b/pandas/core/reshape/tile.py
@@ -148,7 +148,7 @@ def qcut(x, q, labels=None, retbins=False, precision=3, duplicates='raise'):
 
     Parameters
     ----------
-    x : ndarray or Series
+    x : ndarray (1-dimensional) or Series
     q : integer or array of quantiles
         Number of quantiles. 10 for deciles, 4 for quartiles, etc. Alternately
         array of quantiles, e.g. [0, .25, .5, .75, 1.] for quartiles


### PR DESCRIPTION
- [x] closes #18173 

`pd.qcut` only accepts 1-dimensional numpy arrays, which is not mentioned in the docstring. This PR  updates the docstring accordingly.