### PR TITLE
Pass kwargs from read_parquet() to the underlying engines.

### DIFF
--- a/doc/source/whatsnew/v0.21.1.txt
+++ b/doc/source/whatsnew/v0.21.1.txt
@@ -85,7 +85,7 @@ I/O
 - Bug in :func:`read_csv` for handling null values in index columns when specifying ``na_filter=False`` (:issue:`5239`)
 - Bug in :meth:`DataFrame.to_csv` when the table had ``MultiIndex`` columns, and a list of strings was passed in for ``header`` (:issue:`5539`)
 - :func:`read_parquet` now allows to specify the columns to read from a parquet file (:issue:`18154`)
-- :func:`read_parquet` now allows to specify kwargs which are passed to the respective engine (:issue:`TODO`)
+- :func:`read_parquet` now allows to specify kwargs which are passed to the respective engine (:issue:`18216`)
 
 Plotting
 ^^^^^^^^

--- a/doc/source/whatsnew/v0.21.1.txt
+++ b/doc/source/whatsnew/v0.21.1.txt
@@ -85,6 +85,7 @@ I/O
 - Bug in :func:`read_csv` for handling null values in index columns when specifying ``na_filter=False`` (:issue:`5239`)
 - Bug in :meth:`DataFrame.to_csv` when the table had ``MultiIndex`` columns, and a list of strings was passed in for ``header`` (:issue:`5539`)
 - :func:`read_parquet` now allows to specify the columns to read from a parquet file (:issue:`18154`)
+- :func:`read_parquet` now allows to specify kwargs which are passed to the respective engine (:issue:`TODO`)
 
 Plotting
 ^^^^^^^^

--- a/pandas/io/parquet.py
+++ b/pandas/io/parquet.py
@@ -76,9 +76,9 @@ class PyArrowImpl(object):
                 table, path, compression=compression,
                 coerce_timestamps=coerce_timestamps, **kwargs)
 
-    def read(self, path, columns=None):
+    def read(self, path, columns=None, **kwargs):
         path, _, _ = get_filepath_or_buffer(path)
-        return self.api.parquet.read_table(path, columns=columns).to_pandas()
+        return self.api.parquet.read_table(path, columns=columns, **kwargs).to_pandas()
 
 
 class FastParquetImpl(object):
@@ -115,9 +115,9 @@ class FastParquetImpl(object):
             self.api.write(path, df,
                            compression=compression, **kwargs)
 
-    def read(self, path, columns=None):
+    def read(self, path, columns=None, **kwargs):
         path, _, _ = get_filepath_or_buffer(path)
-        return self.api.ParquetFile(path).to_pandas(columns=columns)
+        return self.api.ParquetFile(path).to_pandas(columns=columns, **kwargs)
 
 
 def to_parquet(df, path, engine='auto', compression='snappy', **kwargs):
@@ -205,4 +205,4 @@ def read_parquet(path, engine='auto', columns=None, **kwargs):
     """
 
     impl = get_engine(engine)
-    return impl.read(path, columns=columns)
+    return impl.read(path, columns=columns, **kwargs)

--- a/pandas/io/parquet.py
+++ b/pandas/io/parquet.py
@@ -176,7 +176,7 @@ def to_parquet(df, path, engine='auto', compression='snappy', **kwargs):
     if df.columns.inferred_type not in valid_types:
         raise ValueError("parquet must have string column names")
 
-    return impl.write(df, path, compression=compression)
+    return impl.write(df, path, compression=compression, **kwargs)
 
 
 def read_parquet(path, engine='auto', columns=None, **kwargs):

--- a/pandas/io/parquet.py
+++ b/pandas/io/parquet.py
@@ -78,7 +78,8 @@ class PyArrowImpl(object):
 
     def read(self, path, columns=None, **kwargs):
         path, _, _ = get_filepath_or_buffer(path)
-        return self.api.parquet.read_table(path, columns=columns, **kwargs).to_pandas()
+        return self.api.parquet.read_table(path, columns=columns,
+                                           **kwargs).to_pandas()
 
 
 class FastParquetImpl(object):

--- a/pandas/tests/io/test_parquet.py
+++ b/pandas/tests/io/test_parquet.py
@@ -189,13 +189,14 @@ class Base(object):
                 to_parquet(df, path, engine, compression=None)
 
     def check_round_trip(self, df, engine, expected=None,
-                         extra_write_kwargs=None, **kwargs):
-        write_kwargs = kwargs.copy()
-        if extra_write_kwargs is not None:
-            write_kwargs.update(extra_write_kwargs)
+                         write_kwargs=None, read_kwargs=None):
+        if write_kwargs is None:
+            write_kwargs = {}
+        if read_kwargs is None:
+            read_kwargs = {}
         with tm.ensure_clean() as path:
             df.to_parquet(path, engine, **write_kwargs)
-            result = read_parquet(path, engine, **kwargs)
+            result = read_parquet(path, engine, **read_kwargs)
 
             if expected is None:
                 expected = df
@@ -203,7 +204,7 @@ class Base(object):
 
             # repeat
             to_parquet(df, path, engine, **write_kwargs)
-            result = pd.read_parquet(path, engine, **kwargs)
+            result = pd.read_parquet(path, engine, **read_kwargs)
 
             if expected is None:
                 expected = df
@@ -225,8 +226,7 @@ class TestBasic(Base):
 
         # unicode
         df.columns = [u'foo', u'bar']
-        self.check_round_trip(df, engine,
-                              extra_write_kwargs={'compression': None})
+        self.check_round_trip(df, engine, write_kwargs={'compression': None})
 
     def test_columns_dtypes_invalid(self, engine):
 
@@ -250,8 +250,7 @@ class TestBasic(Base):
     def test_write_with_index(self, engine):
 
         df = pd.DataFrame({'A': [1, 2, 3]})
-        self.check_round_trip(df, engine,
-                              extra_write_kwargs={'compression': None})
+        self.check_round_trip(df, engine, write_kwargs={'compression': None})
 
         # non-default index
         for index in [[2, 3, 4],
@@ -286,7 +285,7 @@ class TestBasic(Base):
 
         df = pd.DataFrame({'A': [1, 2, 3]})
         self.check_round_trip(df, engine,
-                              extra_write_kwargs={'compression': compression})
+                              write_kwargs={'compression': compression})
 
     def test_read_columns(self, engine):
         # GH18154
@@ -295,8 +294,8 @@ class TestBasic(Base):
 
         expected = pd.DataFrame({'string': list('abc')})
         self.check_round_trip(df, engine, expected=expected,
-                              extra_write_kwargs={'compression': None},
-                              columns=["string"])
+                              write_kwargs={'compression': None},
+                              read_kwargs = {'columns': ['string']})
 
 
 class TestParquetPyArrow(Base):
@@ -384,7 +383,7 @@ class TestParquetFastParquet(Base):
              'timedelta': pd.timedelta_range('1 day', periods=3),
              })
 
-        self.check_round_trip(df, fp, extra_write_kwargs={'compression': None})
+        self.check_round_trip(df, fp, write_kwargs={'compression': None})
 
     @pytest.mark.skip(reason="not supported")
     def test_duplicate_columns(self, fp):
@@ -398,7 +397,7 @@ class TestParquetFastParquet(Base):
         df = pd.DataFrame({'a': [True, None, False]})
         expected = pd.DataFrame({'a': [1.0, np.nan, 0.0]}, dtype='float16')
         self.check_round_trip(df, fp, expected=expected,
-                              extra_write_kwargs={'compression': None})
+                              write_kwargs={'compression': None})
 
     def test_unsupported(self, fp):
 
@@ -414,7 +413,7 @@ class TestParquetFastParquet(Base):
         if LooseVersion(fastparquet.__version__) < LooseVersion("0.1.3"):
             pytest.skip("CategoricalDtype not supported for older fp")
         df = pd.DataFrame({'a': pd.Categorical(list('abc'))})
-        self.check_round_trip(df, fp, extra_write_kwargs={'compression': None})
+        self.check_round_trip(df, fp, write_kwargs={'compression': None})
 
     def test_datetime_tz(self, fp):
         # doesn't preserve tz
@@ -424,7 +423,7 @@ class TestParquetFastParquet(Base):
         # warns on the coercion
         with catch_warnings(record=True):
             self.check_round_trip(df, fp, df.astype('datetime64[ns]'),
-                                  extra_write_kwargs={'compression': None})
+                                 write_kwargs={'compression': None})
 
     def test_filter_row_groups(self, fp):
         d = {'a': list(range(0, 3))}

--- a/pandas/tests/io/test_parquet.py
+++ b/pandas/tests/io/test_parquet.py
@@ -295,7 +295,7 @@ class TestBasic(Base):
         expected = pd.DataFrame({'string': list('abc')})
         self.check_round_trip(df, engine, expected=expected,
                               write_kwargs={'compression': None},
-                              read_kwargs = {'columns': ['string']})
+                              read_kwargs={'columns': ['string']})
 
 
 class TestParquetPyArrow(Base):
@@ -423,7 +423,7 @@ class TestParquetFastParquet(Base):
         # warns on the coercion
         with catch_warnings(record=True):
             self.check_round_trip(df, fp, df.astype('datetime64[ns]'),
-                                 write_kwargs={'compression': None})
+                                  write_kwargs={'compression': None})
 
     def test_filter_row_groups(self, fp):
         d = {'a': list(range(0, 3))}

--- a/pandas/tests/io/test_parquet.py
+++ b/pandas/tests/io/test_parquet.py
@@ -425,3 +425,12 @@ class TestParquetFastParquet(Base):
         with catch_warnings(record=True):
             self.check_round_trip(df, fp, df.astype('datetime64[ns]'),
                                   extra_write_kwargs={'compression': None})
+
+    def test_filter_row_groups(self, fp):
+        d = {'a': list(range(0, 3))}
+        df = pd.DataFrame(d)
+        with tm.ensure_clean() as path:
+            df.to_parquet(path, fp, compression=None,
+                          row_group_offsets=1)
+            result = read_parquet(path, fp, filters=[('a', '==', 0)])
+        assert len(result) == 1


### PR DESCRIPTION
This allows e.g. to specify filters for predicate pushdown to fastparquet.
This is a followup to #18155/#18154

- [ ] closes #xxxx
- [ ] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry
