### PR TITLE
Tslibs offsets immutable

### DIFF
--- a/pandas/_libs/tslibs/offsets.pyx
+++ b/pandas/_libs/tslibs/offsets.pyx
@@ -10,6 +10,7 @@ from dateutil.relativedelta import relativedelta
 
 import numpy as np
 cimport numpy as np
+from numpy cimport int64_t
 np.import_array()
 
 
@@ -313,10 +314,59 @@ class EndMixin(object):
         return base + off
 
 
+def __unpickle():
+    return
+
+class PickleMixin(object):
+    """Handle issues with backwards compat related to making DateOffset
+    immutable.
+    """
+    '''
+    def __reduce__(self):
+        # We need to define this explicitly or else pickle tests fail
+        wlist_attrs = tuple(getattr(self, name) for name in sorted(self.kwds))
+        tup = (self.n, self.normalize,) + wlist_attrs
+        return (self.__class__, tup)
+        # FIXME: Isn't this going to screw up on DateOffset?
+
+
+    def __reduce_ex__(self, protocol):
+        # python 3.6 compat
+        # http://bugs.python.org/issue28730
+        # now __reduce_ex__ is defined and higher priority than __reduce__
+        return self.__reduce__()
+
+    '''
+
+    def __getstate__(self):
+        """Return a pickleable state"""
+        state = self.__dict__.copy()
+
+        # Add attributes from the C base class that aren't in self.__dict__
+        state['n'] = self.n
+        state['normalize'] = self.normalize
+
+        # we don't want to actually pickle the calendar object
+        # as its a np.busyday; we recreate on deserilization
+        if 'calendar' in state:
+            del state['calendar']
+        try:
+            state['kwds'].pop('calendar')
+        except KeyError:
+            pass
+
+        return state
+
+
+class BusinessMixin(object):
+    """ mixin to business types to provide related functions """
+    pass
+
+
 # ---------------------------------------------------------------------
 # Base Classes
-
-class _BaseOffset(object):
+@cython.auto_pickle(False)
+cdef class _BaseOffset(object):
     """
     Base class for DateOffset methods that are not overriden by subclasses
     and will (after pickle errors are resolved) go into a cdef class.
@@ -324,6 +374,14 @@ class _BaseOffset(object):
     _typ = "dateoffset"
     _normalize_cache = True
     _cacheable = False
+
+    cdef readonly:
+        int64_t n
+        bint normalize
+
+    def __init__(self, n, normalize):
+        self.n = n
+        self.normalize = normalize
 
     def __call__(self, other):
         return self.apply(other)
@@ -361,8 +419,37 @@ class _BaseOffset(object):
         out = '<%s' % n_str + className + plural + self._repr_attrs() + '>'
         return out
 
+    def __setstate__(self, state):
+        """Reconstruct an instance from a pickled state"""
+        # Note: __setstate__ needs to be defined in the cython class otherwise
+        # trying to set self.n and self.normalize below will
+        # raise an AttributeError.
+        if 'normalize' not in state:
+            # default for prior pickles
+            # See GH #7748, #7789
+            state['normalize'] = False
 
-class BaseOffset(_BaseOffset):
+        if 'offset' in state:
+            # Older versions have offset attribute instead of _offset
+            if '_offset' in state:  # pragma: no cover
+                raise ValueError('Unexpected key `_offset`')
+            state['_offset'] = state.pop('offset')
+            state['kwds']['offset'] = state['_offset']
+        
+        self.n = state.pop('n')
+        self.normalize = state.pop('normalize')
+        self.__dict__ = state
+
+        if 'weekmask' in state and 'holidays' in state:
+            calendar, holidays = _get_calendar(weekmask=self.weekmask,
+                                               holidays=self.holidays,
+                                               calendar=None)
+            self.kwds['calendar'] = self.calendar = calendar
+            self.kwds['holidays'] = self.holidays = holidays
+            self.kwds['weekmask'] = state['weekmask']
+
+
+class BaseOffset(_BaseOffset, PickleMixin):
     # Here we add __rfoo__ methods that don't play well with cdef classes
     def __rmul__(self, someInt):
         return self.__mul__(someInt)

--- a/pandas/_libs/tslibs/offsets.pyx
+++ b/pandas/_libs/tslibs/offsets.pyx
@@ -317,26 +317,11 @@ class EndMixin(object):
 def __unpickle():
     return
 
+
 class PickleMixin(object):
     """Handle issues with backwards compat related to making DateOffset
     immutable.
     """
-    '''
-    def __reduce__(self):
-        # We need to define this explicitly or else pickle tests fail
-        wlist_attrs = tuple(getattr(self, name) for name in sorted(self.kwds))
-        tup = (self.n, self.normalize,) + wlist_attrs
-        return (self.__class__, tup)
-        # FIXME: Isn't this going to screw up on DateOffset?
-
-
-    def __reduce_ex__(self, protocol):
-        # python 3.6 compat
-        # http://bugs.python.org/issue28730
-        # now __reduce_ex__ is defined and higher priority than __reduce__
-        return self.__reduce__()
-
-    '''
 
     def __getstate__(self):
         """Return a pickleable state"""

--- a/pandas/_libs/tslibs/offsets.pyx
+++ b/pandas/_libs/tslibs/offsets.pyx
@@ -379,7 +379,7 @@ cdef class _BaseOffset(object):
         int64_t n
         bint normalize
 
-    def __init__(self, n, normalize):
+    def __init__(self, n=1, normalize=False):
         self.n = n
         self.normalize = normalize
 
@@ -430,17 +430,19 @@ cdef class _BaseOffset(object):
             state['normalize'] = False
 
         if 'offset' in state:
-            # Older versions have offset attribute instead of _offset
+            # Older versions Business offsets have offset attribute
+            # instead of _offset
             if '_offset' in state:  # pragma: no cover
                 raise ValueError('Unexpected key `_offset`')
             state['_offset'] = state.pop('offset')
             state['kwds']['offset'] = state['_offset']
         
-        self.n = state.pop('n')
-        self.normalize = state.pop('normalize')
+        self.n = state.pop('n', 1)
+        self.normalize = state.pop('normalize', False)
         self.__dict__ = state
 
         if 'weekmask' in state and 'holidays' in state:
+            # Business subclasses
             calendar, holidays = _get_calendar(weekmask=self.weekmask,
                                                holidays=self.holidays,
                                                calendar=None)

--- a/pandas/_libs/tslibs/offsets.pyx
+++ b/pandas/_libs/tslibs/offsets.pyx
@@ -314,11 +314,6 @@ class EndMixin(object):
         return base + off
 
 
-class BusinessMixin(object):
-    """ mixin to business types to provide related functions """
-    pass
-
-
 # ---------------------------------------------------------------------
 # Base Classes
 @cython.auto_pickle(False)
@@ -384,6 +379,8 @@ cdef class _BaseOffset(object):
             # default for prior pickles
             # See GH #7748, #7789
             state['normalize'] = False
+        if '_use_relativedelta' not in state:
+            state['_use_relativedelta'] = False
 
         if 'offset' in state:
             # Older versions Business offsets have offset attribute

--- a/pandas/_libs/tslibs/offsets.pyx
+++ b/pandas/_libs/tslibs/offsets.pyx
@@ -314,10 +314,6 @@ class EndMixin(object):
         return base + off
 
 
-def __unpickle():
-    return
-
-
 class PickleMixin(object):
     """Handle issues with backwards compat related to making DateOffset
     immutable.

--- a/pandas/compat/pickle_compat.py
+++ b/pandas/compat/pickle_compat.py
@@ -62,6 +62,7 @@ def load_reduce(self):
             except:
                 pass
 
+
         # unknown exception, re-raise
         if getattr(self, 'is_verbose', None):
             print(sys.exc_info())

--- a/pandas/tests/tseries/test_offsets.py
+++ b/pandas/tests/tseries/test_offsets.py
@@ -539,8 +539,7 @@ class TestBusinessDay(Base):
     def test_different_normalize_equals(self):
         # equivalent in this special case
         offset = BDay()
-        offset2 = BDay()
-        offset2.normalize = True
+        offset2 = BDay(normalize=True)
         assert offset == offset2
 
     def test_repr(self):
@@ -734,8 +733,7 @@ class TestBusinessHour(Base):
     def test_different_normalize_equals(self):
         # equivalent in this special case
         offset = self._offset()
-        offset2 = self._offset()
-        offset2.normalize = True
+        offset2 = self._offset(normalize=True)
         assert offset == offset2
 
     def test_repr(self):
@@ -1426,8 +1424,7 @@ class TestCustomBusinessHour(Base):
     def test_different_normalize_equals(self):
         # equivalent in this special case
         offset = self._offset()
-        offset2 = self._offset()
-        offset2.normalize = True
+        offset2 = self._offset(normalize=True)
         assert offset == offset2
 
     def test_repr(self):
@@ -1667,8 +1664,7 @@ class TestCustomBusinessDay(Base):
     def test_different_normalize_equals(self):
         # equivalent in this special case
         offset = CDay()
-        offset2 = CDay()
-        offset2.normalize = True
+        offset2 = CDay(normalize=True)
         assert offset == offset2
 
     def test_repr(self):
@@ -1953,8 +1949,7 @@ class TestCustomBusinessMonthEnd(CustomBusinessMonthBase, Base):
     def test_different_normalize_equals(self):
         # equivalent in this special case
         offset = CBMonthEnd()
-        offset2 = CBMonthEnd()
-        offset2.normalize = True
+        offset2 = CBMonthEnd(normalize=True)
         assert offset == offset2
 
     def test_repr(self):
@@ -2067,8 +2062,7 @@ class TestCustomBusinessMonthBegin(CustomBusinessMonthBase, Base):
     def test_different_normalize_equals(self):
         # equivalent in this special case
         offset = CBMonthBegin()
-        offset2 = CBMonthBegin()
-        offset2.normalize = True
+        offset2 = CBMonthBegin(normalize=True)
         assert offset == offset2
 
     def test_repr(self):
@@ -4899,3 +4893,15 @@ class TestDST(object):
             first = Timestamp(test_values[0], tz='US/Eastern') + offset()
             second = Timestamp(test_values[1], tz='US/Eastern')
             assert first == second
+
+
+def test_date_offset_immutable():
+    offset = offsets.MonthBegin(n=2, normalize=True)
+    with pytest.raises(AttributeError):
+        offset.n = 1
+
+    # Check that it didn't get changed
+    assert offset.n == 2
+
+    with pytest.raises(AttributeError):
+        offset.normalize = False

--- a/pandas/tseries/offsets.py
+++ b/pandas/tseries/offsets.py
@@ -23,8 +23,7 @@ from pandas._libs.tslibs.offsets import (
     _determine_offset,
     apply_index_wraps,
     BeginMixin, EndMixin,
-    BaseOffset,
-    BusinessMixin as _BusinessMixin)
+    BaseOffset)
 
 import functools
 import operator
@@ -157,13 +156,7 @@ class DateOffset(BaseOffset):
 
     Since 0 is a bit weird, we suggest avoiding its use.
     """
-    _use_relativedelta = False
     _adjust_dst = False
-
-    # default for prior pickles
-    # normalize = False
-    # FIXME: without commenting this out, all
-    # DateOffsets get initialized with normalize=False, regardless of kwarg
 
     def __init__(self, n=1, normalize=False, **kwds):
         BaseOffset.__init__(self, n, normalize)
@@ -415,7 +408,7 @@ class SingleConstructorOffset(DateOffset):
         return cls()
 
 
-class BusinessMixin(_BusinessMixin):
+class BusinessMixin(object):
     """ mixin to business types to provide related functions """
 
     @property

--- a/pandas/tseries/offsets.py
+++ b/pandas/tseries/offsets.py
@@ -23,7 +23,8 @@ from pandas._libs.tslibs.offsets import (
     _determine_offset,
     apply_index_wraps,
     BeginMixin, EndMixin,
-    BaseOffset)
+    BaseOffset,
+    BusinessMixin as _BusinessMixin)
 
 import functools
 import operator
@@ -160,11 +161,12 @@ class DateOffset(BaseOffset):
     _adjust_dst = False
 
     # default for prior pickles
-    normalize = False
+    # normalize = False
+    # FIXME: without commenting this out, all
+    # DateOffsets get initialized with normalize=False, regardless of kwarg
 
     def __init__(self, n=1, normalize=False, **kwds):
-        self.n = int(n)
-        self.normalize = normalize
+        BaseOffset.__init__(self, n, normalize)
         self.kwds = kwds
 
         self._offset, self._use_relativedelta = _determine_offset(kwds)
@@ -256,6 +258,11 @@ class DateOffset(BaseOffset):
 
     def _params(self):
         all_paras = dict(list(vars(self).items()) + list(self.kwds.items()))
+
+        # Add in C-class attributes not present in self.__dict__
+        all_paras['n'] = self.n
+        all_paras['normalize'] = self.normalize
+
         if 'holidays' in all_paras and not all_paras['holidays']:
             all_paras.pop('holidays')
         exclude = ['kwds', 'name', 'normalize', 'calendar']
@@ -408,7 +415,7 @@ class SingleConstructorOffset(DateOffset):
         return cls()
 
 
-class BusinessMixin(object):
+class BusinessMixin(_BusinessMixin):
     """ mixin to business types to provide related functions """
 
     @property
@@ -427,38 +434,6 @@ class BusinessMixin(object):
             out += ': ' + ', '.join(attrs)
         return out
 
-    def __getstate__(self):
-        """Return a pickleable state"""
-        state = self.__dict__.copy()
-
-        # we don't want to actually pickle the calendar object
-        # as its a np.busyday; we recreate on deserilization
-        if 'calendar' in state:
-            del state['calendar']
-        try:
-            state['kwds'].pop('calendar')
-        except KeyError:
-            pass
-
-        return state
-
-    def __setstate__(self, state):
-        """Reconstruct an instance from a pickled state"""
-        if 'offset' in state:
-            # Older versions have offset attribute instead of _offset
-            if '_offset' in state:  # pragma: no cover
-                raise ValueError('Unexpected key `_offset`')
-            state['_offset'] = state.pop('offset')
-            state['kwds']['offset'] = state['_offset']
-        self.__dict__ = state
-        if 'weekmask' in state and 'holidays' in state:
-            calendar, holidays = _get_calendar(weekmask=self.weekmask,
-                                               holidays=self.holidays,
-                                               calendar=None)
-            self.kwds['calendar'] = self.calendar = calendar
-            self.kwds['holidays'] = self.holidays = holidays
-            self.kwds['weekmask'] = state['weekmask']
-
 
 class BusinessDay(BusinessMixin, SingleConstructorOffset):
     """
@@ -468,8 +443,7 @@ class BusinessDay(BusinessMixin, SingleConstructorOffset):
     _adjust_dst = True
 
     def __init__(self, n=1, normalize=False, offset=timedelta(0)):
-        self.n = int(n)
-        self.normalize = normalize
+        BaseOffset.__init__(self, n, normalize)
         self.kwds = {'offset': offset}
         self._offset = offset
 
@@ -776,8 +750,7 @@ class BusinessHour(BusinessHourMixin, SingleConstructorOffset):
 
     def __init__(self, n=1, normalize=False, start='09:00',
                  end='17:00', offset=timedelta(0)):
-        self.n = int(n)
-        self.normalize = normalize
+        BaseOffset.__init__(self, n, normalize)
         super(BusinessHour, self).__init__(start=start, end=end, offset=offset)
 
     @cache_readonly
@@ -813,8 +786,7 @@ class CustomBusinessDay(BusinessDay):
 
     def __init__(self, n=1, normalize=False, weekmask='Mon Tue Wed Thu Fri',
                  holidays=None, calendar=None, offset=timedelta(0)):
-        self.n = int(n)
-        self.normalize = normalize
+        BaseOffset.__init__(self, n, normalize)
         self._offset = offset
         self.kwds = {}
 
@@ -881,8 +853,7 @@ class CustomBusinessHour(BusinessHourMixin, SingleConstructorOffset):
     def __init__(self, n=1, normalize=False, weekmask='Mon Tue Wed Thu Fri',
                  holidays=None, calendar=None,
                  start='09:00', end='17:00', offset=timedelta(0)):
-        self.n = int(n)
-        self.normalize = normalize
+        BaseOffset.__init__(self, n, normalize)
         super(CustomBusinessHour, self).__init__(start=start,
                                                  end=end, offset=offset)
 
@@ -975,6 +946,7 @@ class SemiMonthOffset(DateOffset):
     _min_day_of_month = 2
 
     def __init__(self, n=1, normalize=False, day_of_month=None):
+        BaseOffset.__init__(self, n, normalize)
         if day_of_month is None:
             self.day_of_month = self._default_day_of_month
         else:
@@ -983,8 +955,8 @@ class SemiMonthOffset(DateOffset):
             msg = 'day_of_month must be {min}<=day_of_month<=27, got {day}'
             raise ValueError(msg.format(min=self._min_day_of_month,
                                         day=self.day_of_month))
-        self.n = int(n)
-        self.normalize = normalize
+        # self.n = int(n)
+        # self.normalize = normalize
         self.kwds = {'day_of_month': self.day_of_month}
 
     @classmethod
@@ -1259,8 +1231,7 @@ class CustomBusinessMonthEnd(BusinessMixin, MonthOffset):
 
     def __init__(self, n=1, normalize=False, weekmask='Mon Tue Wed Thu Fri',
                  holidays=None, calendar=None, offset=timedelta(0)):
-        self.n = int(n)
-        self.normalize = normalize
+        BaseOffset.__init__(self, n, normalize)
         self._offset = offset
         self.kwds = {}
 
@@ -1330,8 +1301,7 @@ class CustomBusinessMonthBegin(BusinessMixin, MonthOffset):
 
     def __init__(self, n=1, normalize=False, weekmask='Mon Tue Wed Thu Fri',
                  holidays=None, calendar=None, offset=timedelta(0)):
-        self.n = int(n)
-        self.normalize = normalize
+        BaseOffset.__init__(self, n, normalize)
         self._offset = offset
         self.kwds = {}
 
@@ -1394,8 +1364,7 @@ class Week(EndMixin, DateOffset):
     _prefix = 'W'
 
     def __init__(self, n=1, normalize=False, weekday=None):
-        self.n = n
-        self.normalize = normalize
+        BaseOffset.__init__(self, n, normalize)
         self.weekday = weekday
 
         if self.weekday is not None:
@@ -1485,8 +1454,7 @@ class WeekOfMonth(DateOffset):
     _adjust_dst = True
 
     def __init__(self, n=1, normalize=False, week=None, weekday=None):
-        self.n = n
-        self.normalize = normalize
+        BaseOffset.__init__(self, n, normalize)
         self.weekday = weekday
         self.week = week
 
@@ -1582,8 +1550,7 @@ class LastWeekOfMonth(DateOffset):
     _prefix = 'LWOM'
 
     def __init__(self, n=1, normalize=False, weekday=None):
-        self.n = n
-        self.normalize = normalize
+        BaseOffset.__init__(self, n, normalize)
         self.weekday = weekday
 
         if self.n == 0:
@@ -1656,8 +1623,7 @@ class QuarterOffset(DateOffset):
     #       point
 
     def __init__(self, n=1, normalize=False, startingMonth=None):
-        self.n = n
-        self.normalize = normalize
+        BaseOffset.__init__(self, n, normalize)
         if startingMonth is None:
             startingMonth = self._default_startingMonth
         self.startingMonth = startingMonth
@@ -2092,8 +2058,7 @@ class FY5253(DateOffset):
 
     def __init__(self, n=1, normalize=False, weekday=0, startingMonth=1,
                  variation="nearest"):
-        self.n = n
-        self.normalize = normalize
+        BaseOffset.__init__(self, n, normalize)
         self.startingMonth = startingMonth
         self.weekday = weekday
 
@@ -2342,8 +2307,7 @@ class FY5253Quarter(DateOffset):
 
     def __init__(self, n=1, normalize=False, weekday=0, startingMonth=1,
                  qtr_with_extra_week=1, variation="nearest"):
-        self.n = n
-        self.normalize = normalize
+        BaseOffset.__init__(self, n, normalize)
 
         self.weekday = weekday
         self.startingMonth = startingMonth


### PR DESCRIPTION
This is the big hurdle towards making DateOffsets immutable.

- Make tslibs.offsets._BaseOffset a cython class, define `n` and `normalize` to be readonly
- Update tests that try to alter offsets inplace
- Poke at things until pickle tests stop failing <-- the part with the kludge

I'm not wild about the hack in pickle_compat, but haven't found any other way to avoid `TestCommon.test_pickle_v0_15_2` failing with:

```
cls = <class 'pandas.tseries.offsets.YearBegin'>, base = <type 'object'>, state = None

    def _reconstructor(cls, base, state):
        if base is object:
>           obj = object.__new__(cls)
E           TypeError: object.__new__(YearBegin) is not safe, use pandas._libs.tslibs.offsets._BaseOffset.__new__()
```

After this there will then be a) a bunch of other attributes to make readonly and b) the optimizations that are available once DateOffsets are immutable.  But first we need to either OK the pickle_compat hack or find another way around.