### PR TITLE
Implement _get_lastbday

### DIFF
--- a/pandas/_libs/tslibs/offsets.pyx
+++ b/pandas/_libs/tslibs/offsets.pyx
@@ -139,11 +139,22 @@ def apply_index_wraps(func):
 # ---------------------------------------------------------------------
 # Business Helpers
 
-cpdef int _get_firstbday(int wkday):
+cpdef int _get_lastbday(int wkday, int days_in_month):
     """
-    wkday is the result of monthrange(year, month)
+    (wkday, days_in_month) is the result of monthrange(year, month)
+
+    """
+    return days_in_month - max(((wkday + days_in_month - 1) % 7) - 4, 0)
+
+
+cpdef int _get_firstbday(int wkday, int days_in_month=0):
+    """
+    (wkday, days_in_month) is the result of monthrange(year, month)
 
     If it's a saturday or sunday, increment first business day to reflect this
+
+    Note: `days_in_month` argument is only included to match the signature
+    of _get_lastbday.
     """
     first = 1
     if wkday == 5:  # on Saturday


### PR DESCRIPTION
Orthogonal to other PRs.

Implement `_get_lastbday` mirroring `_get_firstbday`.

Add a dummy argument to get_firstbday so that the signatures match.  Following this and #18218, we'll be able to define e.g.

```
class BQuarterBegin(...):
    _get_bday = _get_firstbday

class BMonthEnd(...):
    _get_bday = _get_lastbday
```

etc.  From there we can get rid of _bunch_ of duplicated logic.

