### PR TITLE
DEPR: deprecate (Sparse)Series.from_array

### DIFF
--- a/doc/source/whatsnew/v0.22.0.txt
+++ b/doc/source/whatsnew/v0.22.0.txt
@@ -51,7 +51,7 @@ Other API Changes
 Deprecations
 ~~~~~~~~~~~~
 
--
+- ``Series.from_array`` and ``SparseSeries.from_array`` are deprecated. Use the normal constructor ``Series(..)`` and ``SparseSeries(..)`` instead (:issue:`18213`).
 -
 -
 

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -2099,10 +2099,8 @@ class DataFrame(NDFrame):
 
                 if index_len and not len(values):
                     values = np.array([np.nan] * index_len, dtype=object)
-                result = self._constructor_sliced.from_array(values,
-                                                             index=self.index,
-                                                             name=label,
-                                                             fastpath=True)
+                result = self._constructor_sliced(values, index=self.index,
+                                                  name=label, fastpath=True)
 
                 # this is a cached value, mark it so
                 result._set_as_cached(label, self)
@@ -2496,8 +2494,8 @@ class DataFrame(NDFrame):
 
     def _box_col_values(self, values, items):
         """ provide boxed values for a column """
-        return self._constructor_sliced.from_array(values, index=self.index,
-                                                   name=items, fastpath=True)
+        return self._constructor_sliced(values, index=self.index,
+                                        name=items, fastpath=True)
 
     def __setitem__(self, key, value):
         key = com._apply_if_callable(key, self)
@@ -4915,8 +4913,8 @@ class DataFrame(NDFrame):
             res_index = self.index
             res_columns = self.columns
             values = self.values
-            series_gen = (Series.from_array(arr, index=res_columns, name=name,
-                                            dtype=dtype)
+            series_gen = (Series(arr, index=res_columns, name=name,
+                                 dtype=dtype)
                           for i, (arr, name) in enumerate(zip(values,
                                                               res_index)))
         else:  # pragma : no cover

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -2099,8 +2099,8 @@ class DataFrame(NDFrame):
 
                 if index_len and not len(values):
                     values = np.array([np.nan] * index_len, dtype=object)
-                result = self._constructor_sliced(values, index=self.index,
-                                                  name=label, fastpath=True)
+                result = self._constructor_sliced._from_array(
+                    values, index=self.index, name=label, fastpath=True)
 
                 # this is a cached value, mark it so
                 result._set_as_cached(label, self)
@@ -2494,8 +2494,8 @@ class DataFrame(NDFrame):
 
     def _box_col_values(self, values, items):
         """ provide boxed values for a column """
-        return self._constructor_sliced(values, index=self.index,
-                                        name=items, fastpath=True)
+        return self._constructor_sliced._from_array(values, index=self.index,
+                                                    name=items, fastpath=True)
 
     def __setitem__(self, key, value):
         key = com._apply_if_callable(key, self)
@@ -4913,8 +4913,8 @@ class DataFrame(NDFrame):
             res_index = self.index
             res_columns = self.columns
             values = self.values
-            series_gen = (Series(arr, index=res_columns, name=name,
-                                 dtype=dtype)
+            series_gen = (Series._from_array(arr, index=res_columns, name=name,
+                                             dtype=dtype)
                           for i, (arr, name) in enumerate(zip(values,
                                                               res_index)))
         else:  # pragma : no cover

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -273,6 +273,14 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
     @classmethod
     def from_array(cls, arr, index=None, name=None, dtype=None, copy=False,
                    fastpath=False):
+        """
+        DEPRECATED: use the pd.Series(..) constructor instead.
+
+        """
+        warnings.warn("'from_array' is deprecated and will be removed in a "
+                      "future version. Please use the pd.Series(..) "
+                      "constructor instead.", FutureWarning, stacklevel=2)
+
         # return a sparse series here
         if isinstance(arr, ABCSparseArray):
             from pandas.core.sparse.series import SparseSeries

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -280,8 +280,8 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
         warnings.warn("'from_array' is deprecated and will be removed in a "
                       "future version. Please use the pd.Series(..) "
                       "constructor instead.", FutureWarning, stacklevel=2)
-        return cls._from_array(arr, index=index, name=name, dtype=dtype, copy=copy,
-                               fastpath=fastpath)
+        return cls._from_array(arr, index=index, name=name, dtype=dtype,
+                               copy=copy, fastpath=fastpath)
 
     @classmethod
     def _from_array(cls, arr, index=None, name=None, dtype=None, copy=False,

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -280,7 +280,7 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
         warnings.warn("'from_array' is deprecated and will be removed in a "
                       "future version. Please use the pd.Series(..) "
                       "constructor instead.", FutureWarning, stacklevel=2)
-        cls.from_array(arr, index=index, name=name, dtype=dtype, copy=copy,
+        cls._from_array(arr, index=index, name=name, dtype=dtype, copy=copy,
                        fastpath=fastpath)
 
     @classmethod

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -280,7 +280,18 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
         warnings.warn("'from_array' is deprecated and will be removed in a "
                       "future version. Please use the pd.Series(..) "
                       "constructor instead.", FutureWarning, stacklevel=2)
+        cls.from_array(arr, index=index, name=name, dtype=dtype, copy=copy,
+                       fastpath=fastpath)
 
+    @classmethod
+    def _from_array(cls, arr, index=None, name=None, dtype=None, copy=False,
+                    fastpath=False):
+        """
+        Internal method used in DataFrame.__setitem__/__getitem__.
+        Difference with Series(..) is that this method checks if a sparse
+        array is passed.
+
+        """
         # return a sparse series here
         if isinstance(arr, ABCSparseArray):
             from pandas.core.sparse.series import SparseSeries

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -280,8 +280,8 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
         warnings.warn("'from_array' is deprecated and will be removed in a "
                       "future version. Please use the pd.Series(..) "
                       "constructor instead.", FutureWarning, stacklevel=2)
-        cls._from_array(arr, index=index, name=name, dtype=dtype, copy=copy,
-                       fastpath=fastpath)
+        return cls._from_array(arr, index=index, name=name, dtype=dtype, copy=copy,
+                               fastpath=fastpath)
 
     @classmethod
     def _from_array(cls, arr, index=None, name=None, dtype=None, copy=False,

--- a/pandas/core/sparse/series.py
+++ b/pandas/core/sparse/series.py
@@ -262,6 +262,12 @@ class SparseSeries(Series):
         warnings.warn("'from_array' is deprecated and will be removed in a "
                       "future version. Please use the pd.SparseSeries(..) "
                       "constructor instead.", FutureWarning, stacklevel=2)
+        return cls._from_array(arr, index=index, name=name, copy=copy,
+                               fill_value=fill_value, fastpath=fastpath)
+
+    @classmethod
+    def _from_array(cls, arr, index=None, name=None, copy=False,
+                    fill_value=None, fastpath=False):
         return cls(arr, index=index, name=name, copy=copy,
                    fill_value=fill_value, fastpath=fastpath)
 

--- a/pandas/core/sparse/series.py
+++ b/pandas/core/sparse/series.py
@@ -256,8 +256,12 @@ class SparseSeries(Series):
     def from_array(cls, arr, index=None, name=None, copy=False,
                    fill_value=None, fastpath=False):
         """
-        Simplified alternate constructor
+        DEPRECATED: use the pd.SparseSeries(..) constructor instead.
+
         """
+        warnings.warn("'from_array' is deprecated and will be removed in a "
+                      "future version. Please use the pd.SparseSeries(..) "
+                      "constructor instead.", FutureWarning, stacklevel=2)
         return cls(arr, index=index, name=name, copy=copy,
                    fill_value=fill_value, fastpath=fastpath)
 

--- a/pandas/tests/series/test_api.py
+++ b/pandas/tests/series/test_api.py
@@ -195,6 +195,11 @@ class SharedWithSparse(object):
         )
         self._assert_series_equal(result, expected)
 
+    def test_from_array_deprecated(self):
+
+        with tm.assert_produces_warning(FutureWarning):
+            self.series_klass.from_array([1, 2, 3])
+
 
 class TestSeriesMisc(TestData, SharedWithSparse):
 

--- a/pandas/tests/series/test_timeseries.py
+++ b/pandas/tests/series/test_timeseries.py
@@ -919,8 +919,9 @@ class TestTimeSeries(TestData):
         assert isinstance(s[0], Timestamp)
         assert s[0] == dates[0][0]
 
-        s = Series.from_array(arr['Date'], Index([0]))
-        assert s[0] == dates[0][0]
+        with pytest.warns(FutureWarning):
+            s = Series.from_array(arr['Date'], Index([0]))
+            assert s[0] == dates[0][0]
 
     def test_get_level_values_box(self):
         from pandas import MultiIndex


### PR DESCRIPTION
Closes #18213. 

It's a bit annoying that I have to keep it as internal method. On the other hand this might signal that `from_array` actually has some use case ..