### PR TITLE
cleaned up imports

### DIFF
--- a/pandas/core/api.py
+++ b/pandas/core/api.py
@@ -23,9 +23,6 @@ from pandas.core.series import Series
 from pandas.core.frame import DataFrame
 from pandas.core.panel import Panel, WidePanel
 from pandas.core.panel4d import Panel4D
-from pandas.core.reshape.reshape import (
-    pivot_simple as pivot, get_dummies)
-from pandas.core.reshape.melt import lreshape, wide_to_long
 
 from pandas.core.indexing import IndexSlice
 from pandas.core.tools.numeric import to_numeric

--- a/pandas/core/api.py
+++ b/pandas/core/api.py
@@ -24,6 +24,9 @@ from pandas.core.frame import DataFrame
 from pandas.core.panel import Panel, WidePanel
 from pandas.core.panel4d import Panel4D
 
+# TODO: Remove import when statsmodels updates #18264
+from pandas.core.reshape.reshape import get_dummies
+
 from pandas.core.indexing import IndexSlice
 from pandas.core.tools.numeric import to_numeric
 from pandas.tseries.offsets import DateOffset

--- a/pandas/core/reshape/api.py
+++ b/pandas/core/reshape/api.py
@@ -1,7 +1,8 @@
 # flake8: noqa
 
 from pandas.core.reshape.concat import concat
-from pandas.core.reshape.melt import melt
+from pandas.core.reshape.melt import melt, lreshape, wide_to_long
+from pandas.core.reshape.reshape import pivot_simple as pivot, get_dummies
 from pandas.core.reshape.merge import (
     merge, ordered_merge, merge_ordered, merge_asof)
 from pandas.core.reshape.pivot import pivot_table, crosstab

--- a/pandas/core/reshape/melt.py
+++ b/pandas/core/reshape/melt.py
@@ -6,14 +6,12 @@ from pandas.core.dtypes.common import is_list_like
 from pandas import compat
 from pandas.core.categorical import Categorical
 
-from pandas.core.frame import DataFrame
-from pandas.core.index import MultiIndex
+from pandas.core.dtypes.generic import ABCMultiIndex
 
 from pandas.core.frame import _shared_docs
 from pandas.util._decorators import Appender
 
 import re
-import pandas.core.dtypes.concat as _concat
 from pandas.core.dtypes.missing import notna
 
 
@@ -27,7 +25,7 @@ def melt(frame, id_vars=None, value_vars=None, var_name=None,
     if id_vars is not None:
         if not is_list_like(id_vars):
             id_vars = [id_vars]
-        elif (isinstance(frame.columns, MultiIndex) and
+        elif (isinstance(frame.columns, ABCMultiIndex) and
               not isinstance(id_vars, list)):
             raise ValueError('id_vars must be a list of tuples when columns'
                              ' are a MultiIndex')
@@ -39,7 +37,7 @@ def melt(frame, id_vars=None, value_vars=None, var_name=None,
     if value_vars is not None:
         if not is_list_like(value_vars):
             value_vars = [value_vars]
-        elif (isinstance(frame.columns, MultiIndex) and
+        elif (isinstance(frame.columns, ABCMultiIndex) and
               not isinstance(value_vars, list)):
             raise ValueError('value_vars must be a list of tuples when'
                              ' columns are a MultiIndex')
@@ -54,7 +52,7 @@ def melt(frame, id_vars=None, value_vars=None, var_name=None,
         frame.columns = frame.columns.get_level_values(col_level)
 
     if var_name is None:
-        if isinstance(frame.columns, MultiIndex):
+        if isinstance(frame.columns, ABCMultiIndex):
             if len(frame.columns.names) == len(set(frame.columns.names)):
                 var_name = frame.columns.names
             else:
@@ -81,6 +79,7 @@ def melt(frame, id_vars=None, value_vars=None, var_name=None,
         mdata[col] = np.asanyarray(frame.columns
                                    ._get_level_values(i)).repeat(N)
 
+    from pandas import DataFrame
     return DataFrame(mdata, columns=mcolumns)
 
 
@@ -137,6 +136,8 @@ def lreshape(data, groups, dropna=True, label=None):
 
     for target, names in zip(keys, values):
         to_concat = [data[col].values for col in names]
+
+        import pandas.core.dtypes.concat as _concat
         mdata[target] = _concat._concat_compat(to_concat)
         pivot_cols.append(target)
 
@@ -150,6 +151,7 @@ def lreshape(data, groups, dropna=True, label=None):
         if not mask.all():
             mdata = dict((k, v[mask]) for k, v in compat.iteritems(mdata))
 
+    from pandas import DataFrame
     return DataFrame(mdata, columns=id_cols + pivot_cols)
 
 

--- a/pandas/tests/reshape/test_reshape.py
+++ b/pandas/tests/reshape/test_reshape.py
@@ -11,8 +11,7 @@ import numpy as np
 
 from pandas.util.testing import assert_frame_equal
 
-from pandas.core.reshape.reshape import get_dummies
-from pandas.core.reshape.melt import melt, lreshape, wide_to_long
+from pandas import melt, lreshape, wide_to_long, get_dummies
 import pandas.util.testing as tm
 from pandas.compat import range, u
 


### PR DESCRIPTION
This is a continuation of #18148 and does the following

-  puts the `reshape` imports from `pandas.core.api` to `pandas.core.reshape.api`
- uses `pandas.core.dtypes.generic.ABCMultiIndex` inplace of `MultiIndex` in `melt.py`
- uses `from pandas import DataFrame` in `melt.py` inside functions
- imports directly from pandas in reshape tests

There is one test failing. Statsmodels imports `get_dummies` from `pandas.core.api` which is no longer possible. It should import directly from pandas.
