### PR TITLE
BUG: Use float64 for row counter in rank()

### DIFF
--- a/doc/source/whatsnew/v0.21.1.txt
+++ b/doc/source/whatsnew/v0.21.1.txt
@@ -117,7 +117,7 @@ Reshaping
 Numeric
 ^^^^^^^
 
--
+- Fixed incorrect maximum :func:`Series.rank` percentile for large arrays (:issue:`18271`)
 -
 -
 

--- a/pandas/_libs/algos_rank_helper.pxi.in
+++ b/pandas/_libs/algos_rank_helper.pxi.in
@@ -60,7 +60,7 @@ def rank_1d_{{dtype}}(object in_arr, ties_method='average', ascending=True,
         float64_t sum_ranks = 0
         int tiebreak = 0
         bint keep_na = 0
-        float count = 0.0
+        float64_t count = 0.0
     tiebreak = tiebreakers[ties_method]
 
     {{if dtype == 'float64'}}
@@ -234,7 +234,7 @@ def rank_2d_{{dtype}}(object in_arr, axis=0, ties_method='average',
         float64_t sum_ranks = 0
         int tiebreak = 0
         bint keep_na = 0
-        float count = 0.0
+        float64_t count = 0.0
 
     tiebreak = tiebreakers[ties_method]
 


### PR DESCRIPTION
- [X] closes #18271
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry

As reported in #18271, for a large `Series` `s` of `float`s, `Series.rank(pct=True).max()` may not be `<=1` as expected.

This is due to the use of a `float` for the row counter. This updates the counter to use a `float64`.
