### PR TITLE
BUG: Copy categorical codes if empty (fixes #18051)

### DIFF
--- a/doc/source/whatsnew/v0.21.1.txt
+++ b/doc/source/whatsnew/v0.21.1.txt
@@ -130,6 +130,7 @@ Categorical
 - Error messages in the testing module have been improved when items have
   different ``CategoricalDtype`` (:issue:`18069`)
 - ``CategoricalIndex`` can now correctly take a ``pd.api.types.CategoricalDtype`` as its dtype (:issue:`18116`)
+- Bug in ``Categorical.unique()`` returning read-only ``codes``  array when all categories were ``NaN`` (:issue:`18051`)
 
 Other
 ^^^^^

--- a/pandas/core/categorical.py
+++ b/pandas/core/categorical.py
@@ -2250,7 +2250,7 @@ def _recode_for_categories(codes, old_categories, new_categories):
 
     if len(old_categories) == 0:
         # All null anyway, so just retain the nulls
-        return codes
+        return codes.copy()
     indexer = coerce_indexer_dtype(new_categories.get_indexer(old_categories),
                                    new_categories)
     new_codes = take_1d(indexer, codes.copy(), fill_value=-1)

--- a/pandas/tests/test_categorical.py
+++ b/pandas/tests/test_categorical.py
@@ -1673,9 +1673,11 @@ Categories (3, object): [ああああ, いいいいい, ううううううう]""
         exp_cat = Categorical(["b", np.nan, "a"], categories=["b", "a"])
         tm.assert_categorical_equal(res, exp_cat)
 
-        # GH 18051 unique()._codes should be writeable
-        cat_nan = Categorical([np.nan])
-        assert cat_nan.unique()._codes.flags.writeable
+        # GH 18051
+        cat = Categorical([np.nan])
+        res = cat.unique()
+        exp_cat = Categorical([np.nan], categories=[])
+        tm.assert_categorical_equal(res, exp_cat)
 
     def test_unique_ordered(self):
         # keep categories order when ordered=True
@@ -2177,6 +2179,10 @@ class TestCategoricalAsBlock(object):
 
         result = x.person_name.loc[0]
         assert result == expected
+
+        # GH 18051
+        s = pd.Series(pd.Categorical([np.nan]))
+        assert s.nunique() == 0
 
     def test_creation_astype(self):
         l = ["a", "b", "c", "a"]

--- a/pandas/tests/test_categorical.py
+++ b/pandas/tests/test_categorical.py
@@ -1673,6 +1673,10 @@ Categories (3, object): [ああああ, いいいいい, ううううううう]""
         exp_cat = Categorical(["b", np.nan, "a"], categories=["b", "a"])
         tm.assert_categorical_equal(res, exp_cat)
 
+        # GH 18051 unique()._codes should be writeable
+        cat_nan = Categorical([np.nan])
+        assert cat_nan.unique()._codes.flags.writeable
+
     def test_unique_ordered(self):
         # keep categories order when ordered=True
         cat = Categorical(['b', 'a', 'b'], categories=['a', 'b'], ordered=True)


### PR DESCRIPTION
If `old_categories` is empty (all nan categories) then `_recode_for_categories`
should return `codes.copy()` so that the writable flag is True.

- [x] closes #18051 
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry
