### PR TITLE
BUG: Use total_tie_count to normalize dense ranking

### DIFF
--- a/doc/source/whatsnew/v0.21.1.txt
+++ b/doc/source/whatsnew/v0.21.1.txt
@@ -117,7 +117,7 @@ Reshaping
 Numeric
 ^^^^^^^
 
--
+- Fixed incorrect maximum :func:`Series.rank` percentile when using the `dense` method with repeated values (:issue:`18296`)
 -
 -
 

--- a/pandas/_libs/algos_rank_helper.pxi.in
+++ b/pandas/_libs/algos_rank_helper.pxi.in
@@ -198,7 +198,10 @@ def rank_1d_{{dtype}}(object in_arr, ties_method='average', ascending=True,
                 sum_ranks = dups = 0
     {{endif}}
     if pct:
-        return ranks / count
+        if tiebreak != TIEBREAK_DENSE:
+            return ranks / count
+        else:
+            return ranks / total_tie_count
     else:
         return ranks
 
@@ -370,7 +373,11 @@ def rank_2d_{{dtype}}(object in_arr, axis=0, ties_method='average',
                         ranks[i, argsorted[i, z]] = total_tie_count
                 sum_ranks = dups = 0
         if pct:
-            ranks[i, :] /= count
+            if tiebreak != TIEBREAK_DENSE:
+                ranks[i, :] /= count
+            else:
+                ranks[i, :] /= total_tie_count
+
     if axis == 0:
         return ranks.T
     else:


### PR DESCRIPTION
- [x] closes #18296
- [ ] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry

As reported in #18296, for a `Series` with repeated values, `Series.rank(pct=True, method='dense').max()` may not be `<=1` as expected.

This is due to the division of the ranks by the total number of elements in the `Series`, instead of the maximum rank assigned. Here we update the calculation.