### PR TITLE
import from np_datetime instead of src/datetime

### DIFF
--- a/pandas/_libs/period.pyx
+++ b/pandas/_libs/period.pyx
@@ -19,31 +19,29 @@ from pandas.compat import PY2
 cimport cython
 
 from tslibs.np_datetime cimport (pandas_datetimestruct,
-                                 dtstruct_to_dt64, dt64_to_dtstruct)
-from datetime cimport is_leapyear
+                                 dtstruct_to_dt64, dt64_to_dtstruct,
+                                 is_leapyear)
 
 
 cimport util
 from util cimport is_period_object, is_string_object, INT32_MIN
 
 from lib cimport is_null_datetimelike
-from pandas._libs import tslib
-from pandas._libs.tslib import Timestamp, iNaT
+from pandas._libs.tslib import Timestamp
 from tslibs.timezones cimport (
-    is_utc, is_tzlocal, get_utcoffset, get_dst_info, maybe_get_tz)
+    is_utc, is_tzlocal, get_utcoffset, get_dst_info)
 from tslibs.timedeltas cimport delta_to_nanoseconds
 
 from tslibs.parsing import (parse_time_string, NAT_SENTINEL,
                             _get_rule_month, _MONTH_NUMBERS)
 from tslibs.frequencies cimport get_freq_code
 from tslibs.resolution import resolution, Resolution
-from tslibs.nattype import nat_strings, NaT
-from tslibs.nattype cimport _nat_scalar_rules
+from tslibs.nattype import nat_strings, NaT, iNaT
+from tslibs.nattype cimport _nat_scalar_rules, NPY_NAT
 
 from pandas.tseries import offsets
 from pandas.tseries import frequencies
 
-cdef int64_t NPY_NAT = util.get_nat()
 
 cdef extern from "period_helper.h":
     ctypedef struct date_info:

--- a/pandas/_libs/tslib.pyx
+++ b/pandas/_libs/tslib.pyx
@@ -38,14 +38,7 @@ from cpython.datetime cimport (PyDelta_Check, PyTZInfo_Check,
 # import datetime C API
 PyDateTime_IMPORT
 # this is our datetime.pxd
-from datetime cimport (
-    pandas_datetime_to_datetimestruct,
-    days_per_month_table,
-    PANDAS_DATETIMEUNIT,
-    _string_to_dts,
-    is_leapyear,
-    dayofweek,
-    PANDAS_FR_ns)
+from datetime cimport pandas_datetime_to_datetimestruct, _string_to_dts
 
 # stdlib datetime imports
 from datetime import time as datetime_time
@@ -55,11 +48,14 @@ from tslibs.np_datetime cimport (check_dts_bounds,
                                  reverse_ops,
                                  cmp_scalar,
                                  pandas_datetimestruct,
+                                 PANDAS_DATETIMEUNIT, PANDAS_FR_ns,
                                  dt64_to_dtstruct, dtstruct_to_dt64,
                                  pydatetime_to_dt64, pydate_to_dt64,
                                  npy_datetime,
                                  get_datetime64_unit, get_datetime64_value,
-                                 get_timedelta64_value)
+                                 get_timedelta64_value,
+                                 days_per_month_table,
+                                 dayofweek, is_leapyear)
 from tslibs.np_datetime import OutOfBoundsDatetime
 
 from .tslibs.parsing import parse_datetime_string
@@ -74,9 +70,6 @@ UTC = pytz.utc
 # initialize numpy
 import_array()
 
-
-cdef int64_t NPY_NAT = util.get_nat()
-iNaT = NPY_NAT
 
 from tslibs.timedeltas cimport cast_from_unit, delta_to_nanoseconds
 from tslibs.timedeltas import Timedelta
@@ -95,8 +88,8 @@ from tslibs.conversion cimport (tz_convert_single, _TSObject,
 from tslibs.conversion import (tz_localize_to_utc,
                                tz_convert_single, date_normalize)
 
-from tslibs.nattype import NaT, nat_strings
-from tslibs.nattype cimport _checknull_with_nat
+from tslibs.nattype import NaT, nat_strings, iNaT
+from tslibs.nattype cimport _checknull_with_nat, NPY_NAT
 
 
 cdef inline object create_timestamp_from_ts(

--- a/pandas/_libs/tslibs/conversion.pyx
+++ b/pandas/_libs/tslibs/conversion.pyx
@@ -20,15 +20,14 @@ PyDateTime_IMPORT
 
 from np_datetime cimport (check_dts_bounds,
                           pandas_datetimestruct,
+                          PANDAS_DATETIMEUNIT, PANDAS_FR_ns,
+                          npy_datetime,
                           dt64_to_dtstruct, dtstruct_to_dt64,
+                          get_datetime64_unit, get_datetime64_value,
                           pydatetime_to_dt64)
 
-from datetime cimport (pandas_datetime_to_datetimestruct,
-                       PANDAS_DATETIMEUNIT, PANDAS_FR_ns, npy_datetime,
-                       _string_to_dts,
-                       get_datetime64_unit, get_datetime64_value)
+from datetime cimport pandas_datetime_to_datetimestruct, _string_to_dts
 
-cimport util
 from util cimport (is_string_object,
                    is_datetime64_object,
                    is_integer_object, is_float_object)
@@ -41,10 +40,10 @@ from timezones cimport (
 from parsing import parse_datetime_string
 
 from nattype import nat_strings, NaT
+from nattype cimport NPY_NAT
 
 # ----------------------------------------------------------------------
 # Constants
-cdef int64_t NPY_NAT = util.get_nat()
 
 cdef int64_t DAY_NS = 86400000000000LL
 

--- a/pandas/_libs/tslibs/fields.pyx
+++ b/pandas/_libs/tslibs/fields.pyx
@@ -18,16 +18,9 @@ np.import_array()
 
 
 from np_datetime cimport (pandas_datetimestruct, pandas_timedeltastruct,
-                          dt64_to_dtstruct, td64_to_tdstruct)
-
-from datetime cimport (
-    days_per_month_table,
-    is_leapyear,
-    dayofweek)
-
-cimport util
-
-cdef int64_t NPY_NAT = util.get_nat()
+                          dt64_to_dtstruct, td64_to_tdstruct,
+                          days_per_month_table, is_leapyear, dayofweek)
+from nattype cimport NPY_NAT
 
 
 def build_field_sarray(ndarray[int64_t] dtindex):

--- a/pandas/_libs/tslibs/nattype.pxd
+++ b/pandas/_libs/tslibs/nattype.pxd
@@ -1,6 +1,9 @@
 # -*- coding: utf-8 -*-
 # cython: profile=False
 
+from numpy cimport int64_t
+cdef int64_t NPY_NAT
+
 cdef bint _nat_scalar_rules[6]
 
 cdef bint _checknull_with_nat(object val)

--- a/pandas/_libs/tslibs/nattype.pyx
+++ b/pandas/_libs/tslibs/nattype.pyx
@@ -26,6 +26,7 @@ from util cimport (get_nat,
 nat_strings = set(['NaT', 'nat', 'NAT', 'nan', 'NaN', 'NAN'])
 
 cdef int64_t NPY_NAT = get_nat()
+iNaT = NPY_NAT  # python-visible constant
 
 cdef bint _nat_scalar_rules[6]
 _nat_scalar_rules[Py_EQ] = False

--- a/pandas/_libs/tslibs/np_datetime.pxd
+++ b/pandas/_libs/tslibs/np_datetime.pxd
@@ -50,6 +50,11 @@ cdef extern from "../src/datetime/np_datetime.h":
         PANDAS_FR_fs
         PANDAS_FR_as
 
+    int days_per_month_table[2][12]
+    int dayofweek(int y, int m, int d) nogil
+    int is_leapyear(int64_t year) nogil
+
+
 cdef int reverse_ops[6]
 
 cdef bint cmp_scalar(int64_t lhs, int64_t rhs, int op) except -1

--- a/pandas/_libs/tslibs/strptime.pyx
+++ b/pandas/_libs/tslibs/strptime.pyx
@@ -36,11 +36,9 @@ from cpython.datetime cimport datetime
 from np_datetime cimport (check_dts_bounds,
                           dtstruct_to_dt64, pandas_datetimestruct)
 
-from util cimport is_string_object, get_nat
+from util cimport is_string_object
 
-cdef int64_t NPY_NAT = get_nat()
-
-from nattype cimport _checknull_with_nat
+from nattype cimport _checknull_with_nat, NPY_NAT
 from nattype import nat_strings
 
 

--- a/pandas/_libs/tslibs/timedeltas.pyx
+++ b/pandas/_libs/tslibs/timedeltas.pyx
@@ -30,12 +30,10 @@ from np_datetime cimport (cmp_scalar, reverse_ops, td64_to_tdstruct,
                           pandas_timedeltastruct)
 
 from nattype import nat_strings, NaT
-from nattype cimport _checknull_with_nat
+from nattype cimport _checknull_with_nat, NPY_NAT
 
 # ----------------------------------------------------------------------
 # Constants
-
-cdef int64_t NPY_NAT = util.get_nat()
 
 cdef int64_t DAY_NS = 86400000000000LL
 
@@ -872,7 +870,7 @@ class Timedelta(_Timedelta):
 
         if isinstance(value, Timedelta):
             value = value.value
-        elif util.is_string_object(value):
+        elif is_string_object(value):
             value = np.timedelta64(parse_timedelta_string(value))
         elif PyDelta_Check(value):
             value = convert_to_timedelta64(value, 'ns')
@@ -882,7 +880,7 @@ class Timedelta(_Timedelta):
             value = value.astype('timedelta64[ns]')
         elif hasattr(value, 'delta'):
             value = np.timedelta64(delta_to_nanoseconds(value.delta), 'ns')
-        elif is_integer_object(value) or util.is_float_object(value):
+        elif is_integer_object(value) or is_float_object(value):
             # unit=None is de-facto 'ns'
             value = convert_to_timedelta64(value, unit)
         elif _checknull_with_nat(value):

--- a/setup.py
+++ b/setup.py
@@ -553,13 +553,14 @@ ext_data = {
     '_libs.tslibs.conversion': {
         'pyxfile': '_libs/tslibs/conversion',
         'pxdfiles': ['_libs/src/util',
+                     '_libs/tslibs/nattype',
                      '_libs/tslibs/timezones',
                      '_libs/tslibs/timedeltas'],
         'depends': tseries_depends,
         'sources': np_datetime_sources},
     '_libs.tslibs.fields': {
         'pyxfile': '_libs/tslibs/fields',
-        'pxdfiles': ['_libs/src/util'],
+        'pxdfiles': ['_libs/tslibs/nattype'],
         'depends': tseries_depends,
         'sources': np_datetime_sources},
     '_libs.tslibs.frequencies': {


### PR DESCRIPTION
There are a handful of things where there is an option to cimport from either tslibs.np_datetime or src/datetime.pxd.  This PR updates imports use tslibs.np_datetime where possible.

Exposes NPY_NAT in nattype.pxd so other modules can cimport it from there instead of using util.get_nat().  Thematically `nattype` is the appropriate place for this to come from.

I don't think this has any overlaps with #18298.

- [ ] closes #xxxx
- [ ] tests added / passed
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
