### PR TITLE
modernize syntax in Timestamp

### DIFF
--- a/pandas/_libs/tslib.pyx
+++ b/pandas/_libs/tslib.pyx
@@ -92,7 +92,6 @@ from tslibs.nattype import NaT, nat_strings, iNaT
 from tslibs.nattype cimport _checknull_with_nat, NPY_NAT
 
 
-# TODO: Can this become a classmethod?
 cdef inline object create_timestamp_from_ts(
         int64_t value, pandas_datetimestruct dts,
         object tz, object freq):
@@ -1162,7 +1161,8 @@ cdef class _Timestamp(datetime):
 
     @property
     def _repr_base(self):
-        return '%s %s' % (self._date_repr, self._time_repr)
+        return '{date} {time}'.format(date=self._date_repr,
+                                      time=self._time_repr)
 
     @property
     def _date_repr(self):

--- a/pandas/_libs/tslib.pyx
+++ b/pandas/_libs/tslib.pyx
@@ -92,6 +92,7 @@ from tslibs.nattype import NaT, nat_strings, iNaT
 from tslibs.nattype cimport _checknull_with_nat, NPY_NAT
 
 
+# TODO: Can this become a classmethod?
 cdef inline object create_timestamp_from_ts(
         int64_t value, pandas_datetimestruct dts,
         object tz, object freq):
@@ -981,11 +982,10 @@ cdef class _Timestamp(datetime):
             pass
 
         tz = ", tz='{0}'".format(zone) if zone is not None else ""
-        freq = ", freq='{0}'".format(
-            self.freq.freqstr) if self.freq is not None else ""
+        freq = "" if self.freq is None else ", freq='{0}'".format(self.freqstr)
 
-        return "Timestamp('{stamp}'{tz}{freq})".format(
-            stamp=stamp, tz=tz, freq=freq)
+        return "Timestamp('{stamp}'{tz}{freq})".format(stamp=stamp,
+                                                       tz=tz, freq=freq)
 
     cdef bint _compare_outside_nanorange(_Timestamp self, datetime other,
                                          int op) except -1:
@@ -1064,11 +1064,13 @@ cdef class _Timestamp(datetime):
             return Timestamp((self.freq * other).apply(self), freq=self.freq)
 
         elif PyDelta_Check(other) or hasattr(other, 'delta'):
+            # delta --> offsets.Tick
             nanos = delta_to_nanoseconds(other)
             result = Timestamp(self.value + nanos,
                                tz=self.tzinfo, freq=self.freq)
             if getattr(other, 'normalize', False):
-                result = Timestamp(normalize_date(result))
+                # DateOffset
+                result = result.normalize()
             return result
 
         # index/series like
@@ -1158,42 +1160,42 @@ cdef class _Timestamp(datetime):
                                   field, freqstr, month_kw)
         return out[0]
 
-    property _repr_base:
-        def __get__(self):
-            return '%s %s' % (self._date_repr, self._time_repr)
+    @property
+    def _repr_base(self):
+        return '%s %s' % (self._date_repr, self._time_repr)
 
-    property _date_repr:
-        def __get__(self):
-            # Ideal here would be self.strftime("%Y-%m-%d"), but
-            # the datetime strftime() methods require year >= 1900
-            return '%d-%.2d-%.2d' % (self.year, self.month, self.day)
+    @property
+    def _date_repr(self):
+        # Ideal here would be self.strftime("%Y-%m-%d"), but
+        # the datetime strftime() methods require year >= 1900
+        return '%d-%.2d-%.2d' % (self.year, self.month, self.day)
 
-    property _time_repr:
-        def __get__(self):
-            result = '%.2d:%.2d:%.2d' % (self.hour, self.minute, self.second)
+    @property
+    def _time_repr(self):
+        result = '%.2d:%.2d:%.2d' % (self.hour, self.minute, self.second)
 
-            if self.nanosecond != 0:
-                result += '.%.9d' % (self.nanosecond + 1000 * self.microsecond)
-            elif self.microsecond != 0:
-                result += '.%.6d' % self.microsecond
+        if self.nanosecond != 0:
+            result += '.%.9d' % (self.nanosecond + 1000 * self.microsecond)
+        elif self.microsecond != 0:
+            result += '.%.6d' % self.microsecond
 
-            return result
+        return result
 
-    property _short_repr:
-        def __get__(self):
-            # format a Timestamp with only _date_repr if possible
-            # otherwise _repr_base
-            if (self.hour == 0 and
-                    self.minute == 0 and
-                    self.second == 0 and
-                    self.microsecond == 0 and
-                    self.nanosecond == 0):
-                return self._date_repr
-            return self._repr_base
+    @property
+    def _short_repr(self):
+        # format a Timestamp with only _date_repr if possible
+        # otherwise _repr_base
+        if (self.hour == 0 and
+                self.minute == 0 and
+                self.second == 0 and
+                self.microsecond == 0 and
+                self.nanosecond == 0):
+            return self._date_repr
+        return self._repr_base
 
-    property asm8:
-        def __get__(self):
-            return np.datetime64(self.value, 'ns')
+    @property
+    def asm8(self):
+        return np.datetime64(self.value, 'ns')
 
     def timestamp(self):
         """Return POSIX timestamp as float."""


### PR DESCRIPTION
Small cleanups to `Timestamp`+`_Timestamp`, use `@property` instead of older syntax.

The only substantive change is in `__add__`, where `result = Timestamp(normalize_date(result))` is changed to `result = result.normalize()`.  The latter has the benefits
1) is robust for tzaware timestamps,

2) does not require `normalize_date` in the namespace, so after this `Timestamp`+`_Timestamp` can be cut/paste into a new `tslibs.timestamps` and

3) is robust to subclassing of `Timestamp`.