### PR TITLE
ENH: allow get_dummies to accept dtype argument

### DIFF
--- a/doc/source/reshaping.rst
+++ b/doc/source/reshaping.rst
@@ -240,7 +240,7 @@ values will be set to ``NaN``.
    df3
    df3.unstack()
 
-.. versionadded: 0.18.0
+.. versionadded:: 0.18.0
 
 Alternatively, unstack takes an optional ``fill_value`` argument, for specifying
 the value of missing data.
@@ -633,6 +633,17 @@ When a column contains only one level, it will be omitted in the result.
     pd.get_dummies(df)
 
     pd.get_dummies(df, drop_first=True)
+
+By default new columns will have ``np.uint8`` dtype. To choose another dtype use ``dtype`` argument:
+
+.. ipython:: python
+
+    df = pd.DataFrame({'A': list('abc'), 'B': [1.1, 2.2, 3.3]})
+
+    pd.get_dummies(df, dtype=bool).dtypes
+
+.. versionadded:: 0.22.0
+
 
 .. _reshaping.factorize:
 

--- a/doc/source/whatsnew/v0.22.0.txt
+++ b/doc/source/whatsnew/v0.22.0.txt
@@ -29,9 +29,12 @@ Other Enhancements
 - :class:`pandas.io.formats.style.Styler` now has method ``hide_columns()`` to determine whether columns will be hidden in output (:issue:`14194`)
 - Improved wording of ``ValueError`` raised in :func:`to_datetime` when ``unit=`` is passed with a non-convertible value (:issue:`14350`)
 - :func:`Series.fillna` now accepts a Series or a dict as a ``value`` for a categorical dtype (:issue:`17033`)
+- :func:`get_dummies` now supports ``dtype`` argument, see :ref:`here <whatsnew_0220.enhancements.get_dummies_dtype>` for more  (:issue: `18330`)
 
-``get_dummies`` now supports ``dtype`` argument (:issue:`18330`)
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+.. _whatsnew_0220.enhancements.get_dummies_dtype
+
+``get_dummies`` now supports ``dtype`` argument
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 The :func:`get_dummies` now accepts a ``dtype`` argument, which specifies a specific dtype for the new columns. When ``dtype`` is not specified or ``None``, the dtype will be ``uint8`` as before. (:issue:`18330`)
 

--- a/doc/source/whatsnew/v0.22.0.txt
+++ b/doc/source/whatsnew/v0.22.0.txt
@@ -156,7 +156,7 @@ Sparse
 Reshaping
 ^^^^^^^^^
 
-- :func:`get_dummies` now supports ``dtype`` argument
+-
 -
 -
 

--- a/doc/source/whatsnew/v0.22.0.txt
+++ b/doc/source/whatsnew/v0.22.0.txt
@@ -30,6 +30,27 @@ Other Enhancements
 - Improved wording of ``ValueError`` raised in :func:`to_datetime` when ``unit=`` is passed with a non-convertible value (:issue:`14350`)
 - :func:`Series.fillna` now accepts a Series or a dict as a ``value`` for a categorical dtype (:issue:`17033`)
 
+``get_dummies`` now supports ``dtype`` argument
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+:func:`get_dummies` function now accepts ``dtype`` argument, which forces specific dtype for new columns. When ``dtype`` is not specified or equals to ``None``, new columns will have dtype ``uint8`` (as before), so this change is backwards compatible. (:issue:`18330`)
+
+**Previous behavior**:
+
+.. ipython:: python
+
+   df = pd.DataFrame({'a': [1, 2], 'b': [3, 4], 'c': [5, 6]})
+   pd.get_dummies(df, columns=['c'])
+
+**New behavior**:
+
+.. ipython:: python
+
+   df = pd.DataFrame({'a': [1, 2], 'b': [3, 4], 'c': [5, 6]})
+   pd.get_dummies(df, columns=['c'])
+   pd.get_dummies(df, columns=['c'], dtype=bool)
+   pd.get_dummies(df, columns=['c'], dtype=np.float64)
+
 .. _whatsnew_0220.api_breaking:
 
 Backwards incompatible API changes

--- a/doc/source/whatsnew/v0.22.0.txt
+++ b/doc/source/whatsnew/v0.22.0.txt
@@ -23,7 +23,7 @@ New features
 ``get_dummies`` now supports ``dtype`` argument
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The :func:`get_dummies` now accepts a ``dtype`` argument, which specifies a specific dtype for the new columns. When ``dtype`` is not specified or ``None``, the dtype will be ``uint8`` as before. (:issue:`18330`)
+The :func:`get_dummies` now accepts a ``dtype`` argument, which specifies a dtype for the new columns. The default remains uint8. (:issue:`18330`)
 
 .. ipython:: python
 

--- a/doc/source/whatsnew/v0.22.0.txt
+++ b/doc/source/whatsnew/v0.22.0.txt
@@ -17,6 +17,21 @@ New features
 -
 -
 
+
+.. _whatsnew_0210.enhancements.get_dummies_dtype:
+
+``get_dummies`` now supports ``dtype`` argument
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The :func:`get_dummies` now accepts a ``dtype`` argument, which specifies a specific dtype for the new columns. When ``dtype`` is not specified or ``None``, the dtype will be ``uint8`` as before. (:issue:`18330`)
+
+.. ipython:: python
+
+   df = pd.DataFrame({'a': [1, 2], 'b': [3, 4], 'c': [5, 6]})
+   pd.get_dummies(df, columns=['c']).dtypes
+   pd.get_dummies(df, columns=['c'], dtype=bool).dtypes
+
+
 .. _whatsnew_0220.enhancements.other:
 
 Other Enhancements
@@ -29,20 +44,6 @@ Other Enhancements
 - :class:`pandas.io.formats.style.Styler` now has method ``hide_columns()`` to determine whether columns will be hidden in output (:issue:`14194`)
 - Improved wording of ``ValueError`` raised in :func:`to_datetime` when ``unit=`` is passed with a non-convertible value (:issue:`14350`)
 - :func:`Series.fillna` now accepts a Series or a dict as a ``value`` for a categorical dtype (:issue:`17033`)
-- :func:`get_dummies` now supports ``dtype`` argument, see :ref:`here <whatsnew_0220.enhancements.get_dummies_dtype>` for more (:issue:`18330`)
-
-.. _whatsnew_0220.enhancements.get_dummies_dtype
-
-``get_dummies`` now supports ``dtype`` argument
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-The :func:`get_dummies` now accepts a ``dtype`` argument, which specifies a specific dtype for the new columns. When ``dtype`` is not specified or ``None``, the dtype will be ``uint8`` as before. (:issue:`18330`)
-
-.. ipython:: python
-
-   df = pd.DataFrame({'a': [1, 2], 'b': [3, 4], 'c': [5, 6]})
-   pd.get_dummies(df, columns=['c']).dtypes
-   pd.get_dummies(df, columns=['c'], dtype=bool).dtypes
 
 .. _whatsnew_0220.api_breaking:
 

--- a/doc/source/whatsnew/v0.22.0.txt
+++ b/doc/source/whatsnew/v0.22.0.txt
@@ -30,26 +30,16 @@ Other Enhancements
 - Improved wording of ``ValueError`` raised in :func:`to_datetime` when ``unit=`` is passed with a non-convertible value (:issue:`14350`)
 - :func:`Series.fillna` now accepts a Series or a dict as a ``value`` for a categorical dtype (:issue:`17033`)
 
-``get_dummies`` now supports ``dtype`` argument
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+``get_dummies`` now supports ``dtype`` argument (:issue:`18330`)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-:func:`get_dummies` function now accepts ``dtype`` argument, which forces specific dtype for new columns. When ``dtype`` is not specified or equals to ``None``, new columns will have dtype ``uint8`` (as before), so this change is backwards compatible. (:issue:`18330`)
-
-**Previous behavior**:
+The :func:`get_dummies` now accepts a ``dtype`` argument, which specifies a specific dtype for the new columns. When ``dtype`` is not specified or ``None``, the dtype will be ``uint8`` as before. (:issue:`18330`)
 
 .. ipython:: python
 
    df = pd.DataFrame({'a': [1, 2], 'b': [3, 4], 'c': [5, 6]})
-   pd.get_dummies(df, columns=['c'])
-
-**New behavior**:
-
-.. ipython:: python
-
-   df = pd.DataFrame({'a': [1, 2], 'b': [3, 4], 'c': [5, 6]})
-   pd.get_dummies(df, columns=['c'])
-   pd.get_dummies(df, columns=['c'], dtype=bool)
-   pd.get_dummies(df, columns=['c'], dtype=np.float64)
+   pd.get_dummies(df, columns=['c']).dtypes
+   pd.get_dummies(df, columns=['c'], dtype=bool).dtypes
 
 .. _whatsnew_0220.api_breaking:
 

--- a/doc/source/whatsnew/v0.22.0.txt
+++ b/doc/source/whatsnew/v0.22.0.txt
@@ -156,7 +156,7 @@ Sparse
 Reshaping
 ^^^^^^^^^
 
--
+- :func:`get_dummies` now supports ``dtype`` argument
 -
 -
 

--- a/doc/source/whatsnew/v0.22.0.txt
+++ b/doc/source/whatsnew/v0.22.0.txt
@@ -29,7 +29,7 @@ Other Enhancements
 - :class:`pandas.io.formats.style.Styler` now has method ``hide_columns()`` to determine whether columns will be hidden in output (:issue:`14194`)
 - Improved wording of ``ValueError`` raised in :func:`to_datetime` when ``unit=`` is passed with a non-convertible value (:issue:`14350`)
 - :func:`Series.fillna` now accepts a Series or a dict as a ``value`` for a categorical dtype (:issue:`17033`)
-- :func:`get_dummies` now supports ``dtype`` argument, see :ref:`here <whatsnew_0220.enhancements.get_dummies_dtype>` for more  (:issue: `18330`)
+- :func:`get_dummies` now supports ``dtype`` argument, see :ref:`here <whatsnew_0220.enhancements.get_dummies_dtype>` for more (:issue:`18330`)
 
 .. _whatsnew_0220.enhancements.get_dummies_dtype
 

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -965,7 +965,7 @@ class NDFrame(PandasObject, SelectionMixin):
         inplace : bool
             whether to modify `self` directly or return a copy
 
-            .. versionadded: 0.21.0
+            .. versionadded:: 0.21.0
 
         Returns
         -------

--- a/pandas/core/reshape/reshape.py
+++ b/pandas/core/reshape/reshape.py
@@ -801,12 +801,6 @@ def get_dummies(data, prefix=None, prefix_sep='_', dummy_na=False,
     from pandas.core.reshape.concat import concat
     from itertools import cycle
 
-    if dtype is None:
-        dtype = np.uint8
-
-    if is_object_dtype(dtype):
-        raise ValueError("dtype=object is not a valid dtype for get_dummies")
-
     if isinstance(data, DataFrame):
         # determine columns being encoded
 
@@ -864,9 +858,17 @@ def get_dummies(data, prefix=None, prefix_sep='_', dummy_na=False,
 
 
 def _get_dummies_1d(data, prefix, prefix_sep='_', dummy_na=False,
-                    sparse=False, drop_first=False, dtype=np.uint8):
+                    sparse=False, drop_first=False, dtype=None):
     # Series avoids inconsistent NaN handling
     codes, levels = _factorize_from_iterable(Series(data))
+
+    if dtype is None:
+        dtype = np.uint8
+    else:
+        dtype = np.dtype(dtype)
+
+    if is_object_dtype(dtype):
+        raise ValueError("dtype=object is not a valid dtype for get_dummies")
 
     def get_empty_Frame(data, sparse):
         if isinstance(data, Series):

--- a/pandas/core/reshape/reshape.py
+++ b/pandas/core/reshape/reshape.py
@@ -725,10 +725,13 @@ def get_dummies(data, prefix=None, prefix_sep='_', dummy_na=False,
     drop_first : bool, default False
         Whether to get k-1 dummies out of k categorical levels by removing the
         first level.
+
+        .. versionadded:: 0.18.0
+
     dtype : dtype, default np.uint8
         Data type to force on a new columns. Only a single dtype is allowed.
 
-        .. versionadded:: 0.18.0
+        .. versionadded:: 0.22.0
 
     Returns
     -------

--- a/pandas/core/reshape/reshape.py
+++ b/pandas/core/reshape/reshape.py
@@ -10,7 +10,7 @@ import numpy as np
 from pandas.core.dtypes.common import (
     _ensure_platform_int,
     is_list_like, is_bool_dtype,
-    needs_i8_conversion, is_sparse)
+    needs_i8_conversion, is_sparse, is_object_dtype)
 from pandas.core.dtypes.cast import maybe_promote
 from pandas.core.dtypes.missing import notna
 
@@ -804,8 +804,8 @@ def get_dummies(data, prefix=None, prefix_sep='_', dummy_na=False,
     if dtype is None:
         dtype = np.uint8
 
-    if np.dtype(dtype) is np.dtype('O'):
-        raise TypeError("'object' is not a valid type for get_dummies")
+    if is_object_dtype(dtype):
+        raise ValueError("dtype=object is not a valid dtype for get_dummies")
 
     if isinstance(data, DataFrame):
         # determine columns being encoded

--- a/pandas/core/reshape/reshape.py
+++ b/pandas/core/reshape/reshape.py
@@ -851,7 +851,9 @@ def get_dummies(data, prefix=None, prefix_sep='_', dummy_na=False,
         result = concat(with_dummies, axis=1)
     else:
         result = _get_dummies_1d(data, prefix, prefix_sep, dummy_na,
-                                 sparse=sparse, drop_first=drop_first, dtype=dtype)
+                                 sparse=sparse,
+                                 drop_first=drop_first,
+                                 dtype=dtype)
     return result
 
 

--- a/pandas/core/reshape/reshape.py
+++ b/pandas/core/reshape/reshape.py
@@ -729,7 +729,7 @@ def get_dummies(data, prefix=None, prefix_sep='_', dummy_na=False,
         .. versionadded:: 0.18.0
 
     dtype : dtype, default np.uint8
-        Data type to force on a new columns. Only a single dtype is allowed.
+        Data type for new columns. Only a single dtype is allowed.
 
         .. versionadded:: 0.22.0
 

--- a/pandas/core/reshape/reshape.py
+++ b/pandas/core/reshape/reshape.py
@@ -804,6 +804,9 @@ def get_dummies(data, prefix=None, prefix_sep='_', dummy_na=False,
     if dtype is None:
         dtype = np.uint8
 
+    if np.dtype(dtype) is np.dtype('O'):
+        raise TypeError("'object' is not a valid type for get_dummies")
+
     if isinstance(data, DataFrame):
         # determine columns being encoded
 

--- a/pandas/core/reshape/reshape.py
+++ b/pandas/core/reshape/reshape.py
@@ -864,8 +864,7 @@ def _get_dummies_1d(data, prefix, prefix_sep='_', dummy_na=False,
 
     if dtype is None:
         dtype = np.uint8
-    else:
-        dtype = np.dtype(dtype)
+    dtype = np.dtype(dtype)
 
     if is_object_dtype(dtype):
         raise ValueError("dtype=object is not a valid dtype for get_dummies")

--- a/pandas/tests/reshape/test_reshape.py
+++ b/pandas/tests/reshape/test_reshape.py
@@ -221,8 +221,8 @@ class TestGetDummies(object):
     @pytest.fixture
     def df(self):
         return DataFrame({'A': ['a', 'b', 'a'],
-                        'B': ['b', 'b', 'c'],
-                        'C': [1, 2, 3]})
+                          'B': ['b', 'b', 'c'],
+                          'C': [1, 2, 3]})
 
     @pytest.fixture(params=['uint8', 'int64', np.float64, bool, None])
     def dtype(self, request):
@@ -295,7 +295,7 @@ class TestGetDummies(object):
         result = get_dummies(s_df, columns=['a'], sparse=sparse, dtype=dtype)
         dtype_name = self.effective_dtype(dtype).name
 
-        expected_counts = { 'int64': 1, 'object': 1 }
+        expected_counts = {'int64': 1, 'object': 1}
         expected_counts[dtype_name] = 3 + expected_counts.get(dtype_name, 0)
 
         expected = Series(expected_counts).sort_values()
@@ -404,7 +404,7 @@ class TestGetDummies(object):
                               [3, 1, 0, 0, 1]],
                              columns=['C'] + bad_columns,
                              dtype=self.effective_dtype(dtype))
-        expected['C'] = [1,2,3]
+        expected['C'] = [1, 2, 3]
         assert_frame_equal(result, expected)
 
     def test_dataframe_dummies_subset(self, df, sparse, dtype):
@@ -414,9 +414,8 @@ class TestGetDummies(object):
                               'from_A_b': [0, 1, 0],
                               'B': ['b', 'b', 'c'],
                               'C': [1, 2, 3]})
-        expected[['from_A_a', 'from_A_b']] = expected[['from_A_a', 'from_A_b']].astype(dtype)
-        cols = ['from_A_a', 'from_A_b']
-        expected[cols] = expected[cols].astype(dtype)
+        columns = ['from_A_a', 'from_A_b']
+        expected[columns] = expected[columns].astype(dtype)
         assert_frame_equal(result, expected)
 
     def test_dataframe_dummies_prefix_sep(self, df, sparse, dtype):
@@ -460,8 +459,10 @@ class TestGetDummies(object):
                               'from_B_b': [1, 1, 0],
                               'from_B_c': [0, 0, 1],
                               'C': [1, 2, 3]})
+
         columns = ['from_A_a', 'from_A_b', 'from_B_b', 'from_B_c']
-        expected[columns] = expected[columns].astype(self.effective_dtype(dtype))
+        effective_dtype = self.effective_dtype(dtype)
+        expected[columns] = expected[columns].astype(effective_dtype)
         assert_frame_equal(result, expected)
 
     def test_dataframe_dummies_with_na(self, df, sparse, dtype):
@@ -495,8 +496,10 @@ class TestGetDummies(object):
                               'B_c': [0, 0, 1],
                               'cat_x': [1, 0, 0],
                               'cat_y': [0, 1, 1]}).sort_index(axis=1)
+
         columns = ['A_a', 'A_b', 'B_b', 'B_c', 'cat_x', 'cat_y']
-        expected[columns] = expected[columns].astype(self.effective_dtype(dtype))
+        effective_dtype = self.effective_dtype(dtype)
+        expected[columns] = expected[columns].astype(effective_dtype)
         expected.sort_index(axis=1)
         assert_frame_equal(result, expected)
 
@@ -508,7 +511,8 @@ class TestGetDummies(object):
         s_series_index = Series(s_list, list('ABC'))
 
         expected = DataFrame({'b': [0, 1, 0],
-                              'c': [0, 0, 1]}, dtype=self.effective_dtype(dtype))
+                              'c': [0, 0, 1]},
+                             dtype=self.effective_dtype(dtype))
 
         result = get_dummies(s_list, drop_first=True,
                              sparse=sparse, dtype=dtype)

--- a/pandas/tests/reshape/test_reshape.py
+++ b/pandas/tests/reshape/test_reshape.py
@@ -407,15 +407,14 @@ class TestGetDummies(object):
         expected[['C']] = df[['C']]
         assert_frame_equal(result, expected)
 
-    def test_dataframe_dummies_subset(self, df, sparse, dtype):
+    def test_dataframe_dummies_subset(self, df, sparse):
         result = get_dummies(df, prefix=['from_A'], columns=['A'],
-                             sparse=sparse, dtype=dtype)
+                             sparse=sparse)
         expected = DataFrame({'from_A_a': [1, 0, 1],
                               'from_A_b': [0, 1, 0],
                               'B': ['b', 'b', 'c'],
-                              'C': [1, 2, 3]})
-        columns = ['from_A_a', 'from_A_b']
-        expected[columns] = expected[columns].astype(dtype)
+                              'C': [1, 2, 3]}, dtype=np.uint8)
+        expected[['C']] = df[['C']]
         assert_frame_equal(result, expected)
 
     def test_dataframe_dummies_prefix_sep(self, df, sparse):

--- a/pandas/tests/reshape/test_reshape.py
+++ b/pandas/tests/reshape/test_reshape.py
@@ -397,6 +397,7 @@ class TestGetDummies(object):
 
     def test_dataframe_dummies_prefix_str(self, df, sparse):
         # not that you should do this...
+        df[['C']] = df[['C']].astype(np.uint8)
         result = get_dummies(df, prefix='bad', sparse=sparse)
         bad_columns = ['bad_a', 'bad_b', 'bad_b', 'bad_c']
         expected = DataFrame([[1, 1, 0, 1, 0],
@@ -404,7 +405,6 @@ class TestGetDummies(object):
                               [3, 1, 0, 0, 1]],
                              columns=['C'] + bad_columns,
                              dtype=np.uint8)
-        expected[['C']] = df[['C']]
         assert_frame_equal(result, expected)
 
     def test_dataframe_dummies_subset(self, df, sparse):

--- a/pandas/tests/reshape/test_reshape.py
+++ b/pandas/tests/reshape/test_reshape.py
@@ -236,12 +236,17 @@ class TestGetDummies(object):
         expected = DataFrame({'a': [1, 0, 0],
                               'b': [0, 1, 0],
                               'c': [0, 0, 1]}, dtype=self.dtype)
-        assert_frame_equal(get_dummies(s_list, sparse=self.sparse, dtype=self.dtype), expected)
-        assert_frame_equal(get_dummies(s_series, sparse=self.sparse, dtype=self.dtype), expected)
+        result = get_dummies(s_list, sparse=self.sparse, dtype=self.dtype)
+        assert_frame_equal(result, expected)
+
+        result = get_dummies(s_series, sparse=self.sparse, dtype=self.dtype)
+        assert_frame_equal(result, expected)
 
         expected.index = list('ABC')
-        assert_frame_equal(
-            get_dummies(s_series_index, sparse=self.sparse, dtype=self.dtype), expected)
+        result = get_dummies(s_series_index,
+                             sparse=self.sparse,
+                             dtype=self.dtype)
+        assert_frame_equal(result, expected)
 
     def test_basic_types(self):
         # GH 10531
@@ -268,13 +273,22 @@ class TestGetDummies(object):
         result = get_dummies(s_series, sparse=self.sparse, dtype=self.dtype)
         compare(result, expected)
 
-        result = get_dummies(s_df, sparse=self.sparse, columns=s_df.columns, dtype=self.dtype)
+        result = get_dummies(s_df,
+                             sparse=self.sparse,
+                             columns=s_df.columns,
+                             dtype=self.dtype)
         tm.assert_series_equal(result.get_dtype_counts(),
                                Series({self.dtype_str: 8}))
 
-        result = get_dummies(s_df, sparse=self.sparse, columns=['a'], dtype=self.dtype)
-        expected = Series({self.dtype_str: 3, 'int64': 1, 'object': 1}).sort_values()
-        tm.assert_series_equal(result.get_dtype_counts().sort_values(), expected)
+        result = get_dummies(s_df,
+                             sparse=self.sparse,
+                             columns=['a'],
+                             dtype=self.dtype)
+        expected = Series({self.dtype_str: 3,
+                           'int64': 1,
+                           'object': 1}).sort_values()
+        tm.assert_series_equal(result.get_dtype_counts().sort_values(),
+                               expected)
 
     def test_just_na(self):
         just_na_list = [np.nan]
@@ -302,7 +316,10 @@ class TestGetDummies(object):
         assert_frame_equal(res, exp)
 
         # Sparse dataframes do not allow nan labelled columns, see #GH8822
-        res_na = get_dummies(s, dummy_na=True, sparse=self.sparse, dtype=self.dtype)
+        res_na = get_dummies(s,
+                             dummy_na=True,
+                             sparse=self.sparse,
+                             dtype=self.dtype)
         exp_na = DataFrame({nan: {0: 0, 1: 0, 2: 1},
                             'a': {0: 1, 1: 0, 2: 0},
                             'b': {0: 0, 1: 1, 2: 0}},
@@ -312,7 +329,10 @@ class TestGetDummies(object):
         exp_na.columns = res_na.columns
         assert_frame_equal(res_na, exp_na)
 
-        res_just_na = get_dummies([nan], dummy_na=True, sparse=self.sparse, dtype=self.dtype)
+        res_just_na = get_dummies([nan],
+                                  dummy_na=True,
+                                  sparse=self.sparse,
+                                  dtype=self.dtype)
         exp_just_na = DataFrame(Series(1, index=[0]), columns=[nan],
                                 dtype=self.dtype)
         tm.assert_numpy_array_equal(res_just_na.values, exp_just_na.values)
@@ -323,7 +343,10 @@ class TestGetDummies(object):
         e = 'e'
         eacute = unicodedata.lookup('LATIN SMALL LETTER E WITH ACUTE')
         s = [e, eacute, eacute]
-        res = get_dummies(s, prefix='letter', sparse=self.sparse, dtype=self.dtype)
+        res = get_dummies(s,
+                          prefix='letter',
+                          sparse=self.sparse,
+                          dtype=self.dtype)
         exp = DataFrame({'letter_e': {0: 1,
                                       1: 0,
                                       2: 0},
@@ -360,7 +383,10 @@ class TestGetDummies(object):
         df = DataFrame({'A': ['a', 'b', 'a'],
                         'B': ['b', 'b', 'c'],
                         'C': [1, 2, 3]}, dtype=self.dtype)
-        result = get_dummies(df, prefix=prefixes, sparse=self.sparse, dtype=self.dtype)
+        result = get_dummies(df,
+                             prefix=prefixes,
+                             sparse=self.sparse,
+                             dtype=self.dtype)
         expected = DataFrame({'C': [1, 2, 3],
                               'from_A_a': [1, 0, 1],
                               'from_A_b': [0, 1, 0],
@@ -368,13 +394,15 @@ class TestGetDummies(object):
                               'from_B_c': [0, 0, 1]}, dtype=self.dtype)
         cols = expected.columns[1:]
         expected[cols] = expected[cols].astype(self.dtype)
-        expected = expected[['C', 'from_A_a', 'from_A_b', 'from_B_b', 'from_B_c']]
+        expected = expected[['C', 'from_A_a', 'from_A_b',
+                             'from_B_b', 'from_B_c']]
         assert_frame_equal(result, expected)
 
     def test_dataframe_dummies_prefix_str(self):
         # not that you should do this...
         df = self.df
-        result = get_dummies(df, prefix='bad', sparse=self.sparse, dtype=self.dtype)
+        result = get_dummies(df, prefix='bad', sparse=self.sparse,
+                             dtype=self.dtype)
         expected = DataFrame([[1, 1, 0, 1, 0],
                               [2, 0, 1, 1, 0],
                               [3, 1, 0, 0, 1]],
@@ -397,7 +425,8 @@ class TestGetDummies(object):
 
     def test_dataframe_dummies_prefix_sep(self):
         df = self.df
-        result = get_dummies(df, prefix_sep='..', sparse=self.sparse, dtype=self.dtype)
+        result = get_dummies(df, prefix_sep='..', sparse=self.sparse,
+                             dtype=self.dtype)
         expected = DataFrame({'C': [1, 2, 3],
                               'A..a': [1, 0, 1],
                               'A..b': [0, 1, 0],
@@ -408,12 +437,17 @@ class TestGetDummies(object):
         expected[cols] = expected[cols].astype(self.dtype)
         assert_frame_equal(result, expected)
 
-        result = get_dummies(df, prefix_sep=['..', '__'], sparse=self.sparse, dtype=self.dtype)
+        result = get_dummies(df,
+                             prefix_sep=['..', '__'],
+                             sparse=self.sparse,
+                             dtype=self.dtype)
         expected = expected.rename(columns={'B..b': 'B__b', 'B..c': 'B__c'})
         assert_frame_equal(result, expected)
 
         result = get_dummies(df, prefix_sep={'A': '..',
-                                             'B': '__'}, sparse=self.sparse, dtype=self.dtype)
+                                             'B': '__'},
+                             sparse=self.sparse,
+                             dtype=self.dtype)
         assert_frame_equal(result, expected)
 
     def test_dataframe_dummies_prefix_bad_length(self):
@@ -429,7 +463,8 @@ class TestGetDummies(object):
         df = DataFrame({'A': ['a', 'b', 'a'],
                         'B': ['b', 'b', 'c'],
                         'C': [1, 2, 3]}, dtype=self.dtype)
-        result = get_dummies(df, prefix=prefixes, sparse=self.sparse, dtype=self.dtype)
+        result = get_dummies(df, prefix=prefixes, sparse=self.sparse,
+                             dtype=self.dtype)
         expected = DataFrame({'from_A_a': [1, 0, 1],
                               'from_A_b': [0, 1, 0],
                               'from_B_b': [1, 1, 0],
@@ -440,7 +475,8 @@ class TestGetDummies(object):
     def test_dataframe_dummies_with_na(self):
         df = self.df
         df.loc[3, :] = [np.nan, np.nan, np.nan]
-        result = get_dummies(df, dummy_na=True, sparse=self.sparse, dtype=self.dtype)
+        result = get_dummies(df, dummy_na=True, sparse=self.sparse,
+                             dtype=self.dtype)
         expected = DataFrame({'C': [1, 2, 3, np.nan],
                               'A_a': [1, 0, 1, 0],
                               'A_b': [0, 1, 0, 0],
@@ -449,10 +485,12 @@ class TestGetDummies(object):
                               'B_c': [0, 0, 1, 0],
                               'B_nan': [0, 0, 0, 1]}, dtype=self.dtype)
         expected[['C']] = expected[['C']].astype(np.float64)
-        expected = expected[['C', 'A_a', 'A_b', 'A_nan', 'B_b', 'B_c', 'B_nan']]
+        expected = expected[['C', 'A_a', 'A_b', 'A_nan',
+                             'B_b', 'B_c', 'B_nan']]
         assert_frame_equal(result, expected)
 
-        result = get_dummies(df, dummy_na=False, sparse=self.sparse, dtype=self.dtype)
+        result = get_dummies(df, dummy_na=False, sparse=self.sparse,
+                             dtype=self.dtype)
         expected = expected[['C', 'A_a', 'A_b', 'B_b', 'B_c']]
         assert_frame_equal(result, expected)
 
@@ -467,7 +505,6 @@ class TestGetDummies(object):
                               'B_c': [0, 0, 1],
                               'cat_x': [1, 0, 0],
                               'cat_y': [0, 1, 1]}, dtype=self.dtype)
-        cols = ['A_a', 'A_b', 'B_b', 'B_c', 'cat_x', 'cat_y']
         expected = expected[['C', 'A_a', 'A_b', 'B_b', 'B_c',
                              'cat_x', 'cat_y']]
         assert_frame_equal(result, expected)
@@ -482,10 +519,16 @@ class TestGetDummies(object):
         expected = DataFrame({'b': [0, 1, 0],
                               'c': [0, 0, 1]}, dtype=self.dtype)
 
-        result = get_dummies(s_list, sparse=self.sparse, drop_first=True, dtype=self.dtype)
+        result = get_dummies(s_list,
+                             sparse=self.sparse,
+                             drop_first=True,
+                             dtype=self.dtype)
         assert_frame_equal(result, expected)
 
-        result = get_dummies(s_series, sparse=self.sparse, drop_first=True, dtype=self.dtype)
+        result = get_dummies(s_series,
+                             sparse=self.sparse,
+                             drop_first=True,
+                             dtype=self.dtype)
         assert_frame_equal(result, expected)
 
         expected.index = list('ABC')
@@ -515,7 +558,10 @@ class TestGetDummies(object):
     def test_basic_drop_first_NA(self):
         # Test NA hadling together with drop_first
         s_NA = ['a', 'b', np.nan]
-        res = get_dummies(s_NA, sparse=self.sparse, drop_first=True, dtype=self.dtype)
+        res = get_dummies(s_NA,
+                          sparse=self.sparse,
+                          drop_first=True,
+                          dtype=self.dtype)
         exp = DataFrame({'b': [0, 1, 0]}, dtype=self.dtype)
         assert_frame_equal(res, exp)
 
@@ -533,7 +579,10 @@ class TestGetDummies(object):
 
     def test_dataframe_dummies_drop_first(self):
         df = self.df[['A', 'B']]
-        result = get_dummies(df, sparse=self.sparse, drop_first=True, dtype=self.dtype)
+        result = get_dummies(df,
+                             sparse=self.sparse,
+                             drop_first=True,
+                             dtype=self.dtype)
         expected = DataFrame({'A_b': [0, 1, 0],
                               'B_c': [0, 0, 1]}, dtype=self.dtype)
         assert_frame_equal(result, expected)
@@ -541,7 +590,10 @@ class TestGetDummies(object):
     def test_dataframe_dummies_drop_first_with_categorical(self):
         df = self.df
         df['cat'] = pd.Categorical(['x', 'y', 'y'])
-        result = get_dummies(df, sparse=self.sparse, drop_first=True, dtype=self.dtype)
+        result = get_dummies(df,
+                             sparse=self.sparse,
+                             drop_first=True,
+                             dtype=self.dtype)
         expected = DataFrame({'C': [1, 2, 3],
                               'A_b': [0, 1, 0],
                               'B_c': [0, 0, 1],
@@ -633,6 +685,7 @@ class TestGetDummiesSparse(TestGetDummies):
     def test_include_na(self):
         super(TestGetDummiesSparse, self).test_include_na()
 
+
 class TestGetDummiesDtypeMixin(object):
     dtype_str = 'float64'
 
@@ -652,11 +705,15 @@ class TestGetDummiesDtypeMixin(object):
     def test_basic_drop_first_one_level(self):
         pass
 
+
 class TestGetDummiesDtypeFloat(TestGetDummiesDtypeMixin, TestGetDummies):
     pass
 
-class TestGetDummiesSparseDtypeFloat(TestGetDummiesDtypeMixin, TestGetDummiesSparse):
+
+class TestGetDummiesSparseDtypeFloat(TestGetDummiesDtypeMixin,
+                                     TestGetDummiesSparse):
     pass
+
 
 class TestMakeAxisDummies(object):
 

--- a/pandas/tests/reshape/test_reshape.py
+++ b/pandas/tests/reshape/test_reshape.py
@@ -500,7 +500,7 @@ class TestGetDummies(object):
         expected.sort_index(axis=1)
         assert_frame_equal(result, expected)
 
-    def test_basic_drop_first(self, sparse, dtype):
+    def test_basic_drop_first(self, sparse):
         # GH12402 Add a new parameter `drop_first` to avoid collinearity
         # Basic case
         s_list = list('abc')
@@ -509,22 +509,19 @@ class TestGetDummies(object):
 
         expected = DataFrame({'b': [0, 1, 0],
                               'c': [0, 0, 1]},
-                             dtype=self.effective_dtype(dtype))
+                             dtype=np.uint8)
 
-        result = get_dummies(s_list, drop_first=True,
-                             sparse=sparse, dtype=dtype)
+        result = get_dummies(s_list, drop_first=True, sparse=sparse)
         assert_frame_equal(result, expected)
 
-        result = get_dummies(s_series, drop_first=True,
-                             sparse=sparse, dtype=dtype)
+        result = get_dummies(s_series, drop_first=True, sparse=sparse)
         assert_frame_equal(result, expected)
 
         expected.index = list('ABC')
-        result = get_dummies(s_series_index, drop_first=True,
-                             sparse=sparse, dtype=dtype)
+        result = get_dummies(s_series_index, drop_first=True, sparse=sparse)
         assert_frame_equal(result, expected)
 
-    def test_basic_drop_first_one_level(self, sparse, dtype):
+    def test_basic_drop_first_one_level(self, sparse):
         # Test the case that categorical variable only has one level.
         s_list = list('aaa')
         s_series = Series(s_list)
@@ -532,78 +529,73 @@ class TestGetDummies(object):
 
         expected = DataFrame(index=np.arange(3))
 
-        result = get_dummies(s_list, drop_first=True,
-                             sparse=sparse, dtype=dtype)
+        result = get_dummies(s_list, drop_first=True, sparse=sparse)
         assert_frame_equal(result, expected)
 
-        result = get_dummies(s_series, drop_first=True,
-                             sparse=sparse, dtype=dtype)
+        result = get_dummies(s_series, drop_first=True, sparse=sparse)
         assert_frame_equal(result, expected)
 
         expected = DataFrame(index=list('ABC'))
-        result = get_dummies(s_series_index, drop_first=True,
-                             sparse=sparse, dtype=dtype)
+        result = get_dummies(s_series_index, drop_first=True, sparse=sparse)
         assert_frame_equal(result, expected)
 
-    def test_basic_drop_first_NA(self, sparse, dtype):
+    def test_basic_drop_first_NA(self, sparse):
         # Test NA hadling together with drop_first
         s_NA = ['a', 'b', np.nan]
-        res = get_dummies(s_NA, drop_first=True, sparse=sparse, dtype=dtype)
-        exp = DataFrame({'b': [0, 1, 0]}, dtype=self.effective_dtype(dtype))
+        res = get_dummies(s_NA, drop_first=True, sparse=sparse)
+        exp = DataFrame({'b': [0, 1, 0]}, dtype=np.uint8)
         assert_frame_equal(res, exp)
 
         res_na = get_dummies(s_NA, dummy_na=True, drop_first=True,
-                             sparse=sparse, dtype=dtype)
+                             sparse=sparse)
         exp_na = DataFrame(
             {'b': [0, 1, 0],
              nan: [0, 0, 1]},
-            dtype=self.effective_dtype(dtype)).reindex(['b', nan], axis=1)
+            dtype=np.uint8).reindex(['b', nan], axis=1)
         assert_frame_equal(res_na, exp_na)
 
-        res_just_na = get_dummies([nan],
-                                  dummy_na=True,
-                                  drop_first=True,
-                                  sparse=sparse, dtype=dtype)
+        res_just_na = get_dummies([nan], dummy_na=True, drop_first=True,
+                                  sparse=sparse)
         exp_just_na = DataFrame(index=np.arange(1))
         assert_frame_equal(res_just_na, exp_just_na)
 
-    def test_dataframe_dummies_drop_first(self, df, sparse, dtype):
+    def test_dataframe_dummies_drop_first(self, df, sparse):
         df = df[['A', 'B']]
-        result = get_dummies(df, drop_first=True, sparse=sparse, dtype=dtype)
+        result = get_dummies(df, drop_first=True, sparse=sparse)
         expected = DataFrame({'A_b': [0, 1, 0],
                               'B_c': [0, 0, 1]},
-                             dtype=self.effective_dtype(dtype))
+                             dtype=np.uint8)
         assert_frame_equal(result, expected)
 
     def test_dataframe_dummies_drop_first_with_categorical(
             self, df, sparse, dtype):
         df['cat'] = pd.Categorical(['x', 'y', 'y'])
-        result = get_dummies(df, drop_first=True, sparse=sparse, dtype=dtype)
+        result = get_dummies(df, drop_first=True, sparse=sparse)
         expected = DataFrame({'C': [1, 2, 3],
                               'A_b': [0, 1, 0],
                               'B_c': [0, 0, 1],
                               'cat_y': [0, 1, 1]})
         cols = ['A_b', 'B_c', 'cat_y']
-        expected[cols] = expected[cols].astype(self.effective_dtype(dtype))
+        expected[cols] = expected[cols].astype(np.uint8)
         expected = expected[['C', 'A_b', 'B_c', 'cat_y']]
         assert_frame_equal(result, expected)
 
-    def test_dataframe_dummies_drop_first_with_na(self, df, sparse, dtype):
+    def test_dataframe_dummies_drop_first_with_na(self, df, sparse):
         df.loc[3, :] = [np.nan, np.nan, np.nan]
         result = get_dummies(df, dummy_na=True, drop_first=True,
-                             sparse=sparse, dtype=dtype).sort_index(axis=1)
+                             sparse=sparse).sort_index(axis=1)
         expected = DataFrame({'C': [1, 2, 3, np.nan],
                               'A_b': [0, 1, 0, 0],
                               'A_nan': [0, 0, 0, 1],
                               'B_c': [0, 0, 1, 0],
                               'B_nan': [0, 0, 0, 1]})
         cols = ['A_b', 'A_nan', 'B_c', 'B_nan']
-        expected[cols] = expected[cols].astype(self.effective_dtype(dtype))
+        expected[cols] = expected[cols].astype(np.uint8)
         expected = expected.sort_index(axis=1)
         assert_frame_equal(result, expected)
 
         result = get_dummies(df, dummy_na=False, drop_first=True,
-                             sparse=sparse, dtype=dtype)
+                             sparse=sparse)
         expected = expected[['C', 'A_b', 'B_c']]
         assert_frame_equal(result, expected)
 

--- a/pandas/tests/reshape/test_reshape.py
+++ b/pandas/tests/reshape/test_reshape.py
@@ -217,39 +217,47 @@ class TestMelt(object):
 
 
 class TestGetDummies(object):
-    dtype_str = 'uint8'
-    sparse = False
 
-    def setup_class(cls):
-        cls.dtype = np.dtype(cls.dtype_str)
+    @pytest.fixture
+    def df(self, dtype):
+        return DataFrame({'A': ['a', 'b', 'a'],
+                          'B': ['b', 'b', 'c'],
+                          'C': [1, 2, 3]}, dtype=dtype)
 
-    def setup_method(self, method):
-        self.df = DataFrame({'A': ['a', 'b', 'a'],
-                             'B': ['b', 'b', 'c'],
-                             'C': [1, 2, 3]}, dtype=self.dtype)
+    @pytest.fixture(params=['uint8', 'float64'])
+    def dtype(self, request):
+        return np.dtype(request.param)
 
-    def test_basic(self):
+    @pytest.fixture(params=['dense', 'sparse'])
+    def sparse(self, request):
+        # params are strings to simplify reading test results,
+        # e.g. TestGetDummies::test_basic[uint8-sparse] instead of [uint8-True]
+        return request.param == 'sparse'
+
+    def test_basic(self, sparse, dtype):
+        kwargs = {'sparse': sparse, 'dtype': dtype}
+
         s_list = list('abc')
         s_series = Series(s_list)
         s_series_index = Series(s_list, list('ABC'))
 
         expected = DataFrame({'a': [1, 0, 0],
                               'b': [0, 1, 0],
-                              'c': [0, 0, 1]}, dtype=self.dtype)
-        result = get_dummies(s_list, sparse=self.sparse, dtype=self.dtype)
+                              'c': [0, 0, 1]}, dtype=dtype)
+        result = get_dummies(s_list, **kwargs)
         assert_frame_equal(result, expected)
 
-        result = get_dummies(s_series, sparse=self.sparse, dtype=self.dtype)
+        result = get_dummies(s_series, **kwargs)
         assert_frame_equal(result, expected)
 
         expected.index = list('ABC')
-        result = get_dummies(s_series_index,
-                             sparse=self.sparse,
-                             dtype=self.dtype)
+        result = get_dummies(s_series_index, **kwargs)
         assert_frame_equal(result, expected)
 
-    def test_basic_types(self):
+    def test_basic_types(self, sparse, dtype):
         # GH 10531
+        kwargs = {'sparse': sparse, 'dtype': dtype}
+
         s_list = list('abc')
         s_series = Series(s_list)
         s_df = DataFrame({'a': [0, 1, 0, 1, 2],
@@ -259,46 +267,54 @@ class TestGetDummies(object):
         expected = DataFrame({'a': [1, 0, 0],
                               'b': [0, 1, 0],
                               'c': [0, 0, 1]},
-                             dtype=self.dtype_str,
+                             dtype=dtype,
                              columns=list('abc'))
-        if not self.sparse:
+        if not sparse:
             compare = tm.assert_frame_equal
         else:
             expected = expected.to_sparse(fill_value=0, kind='integer')
             compare = tm.assert_sp_frame_equal
 
-        result = get_dummies(s_list, sparse=self.sparse, dtype=self.dtype)
+        result = get_dummies(s_list, **kwargs)
         compare(result, expected)
 
-        result = get_dummies(s_series, sparse=self.sparse, dtype=self.dtype)
+        result = get_dummies(s_series, **kwargs)
         compare(result, expected)
 
-        result = get_dummies(s_df,
-                             sparse=self.sparse,
-                             columns=s_df.columns,
-                             dtype=self.dtype)
+        result = get_dummies(s_df, columns=s_df.columns, **kwargs)
         tm.assert_series_equal(result.get_dtype_counts(),
-                               Series({self.dtype_str: 8}))
+                               Series({dtype.name: 8}))
 
-        result = get_dummies(s_df,
-                             sparse=self.sparse,
-                             columns=['a'],
-                             dtype=self.dtype)
-        expected = Series({self.dtype_str: 3,
+        result = get_dummies(s_df, columns=['a'], **kwargs)
+        expected = Series({dtype.name: 3,
                            'int64': 1,
                            'object': 1}).sort_values()
         tm.assert_series_equal(result.get_dtype_counts().sort_values(),
                                expected)
 
-    def test_just_na(self):
+    def test_dtype_none(self, df, sparse, dtype):
+        expected = DataFrame({'A_a': [1, 0, 1],
+                              'A_b': [0, 1, 0],
+                              'B_b': [1, 1, 0],
+                              'B_c': [0, 0, 1],
+                              'C': [1, 2, 3]},
+                             # dummy dimension have type uint8 by default
+                             dtype=np.uint8).sort_index(axis=1)
+
+        # column C must retain it's type
+        expected[['C']] = expected[['C']].astype(dtype)
+
+        result = get_dummies(df, sparse=sparse, dtype=None).sort_index(axis=1)
+        assert_frame_equal(result, expected)
+
+    def test_just_na(self, sparse):
         just_na_list = [np.nan]
         just_na_series = Series(just_na_list)
         just_na_series_index = Series(just_na_list, index=['A'])
 
-        res_list = get_dummies(just_na_list, sparse=self.sparse)
-        res_series = get_dummies(just_na_series, sparse=self.sparse)
-        res_series_index = get_dummies(just_na_series_index,
-                                       sparse=self.sparse)
+        res_list = get_dummies(just_na_list, sparse=sparse)
+        res_series = get_dummies(just_na_series, sparse=sparse)
+        res_series_index = get_dummies(just_na_series_index, sparse=sparse)
 
         assert res_list.empty
         assert res_series.empty
@@ -308,343 +324,314 @@ class TestGetDummies(object):
         assert res_series.index.tolist() == [0]
         assert res_series_index.index.tolist() == ['A']
 
-    def test_include_na(self):
+    def test_include_na(self, sparse, dtype):
+        if sparse:
+            pytest.xfail(reason='nan in index is problematic (GH 16894)')
+
+        kwargs = {'sparse': sparse, 'dtype': dtype}
         s = ['a', 'b', np.nan]
-        res = get_dummies(s, sparse=self.sparse, dtype=self.dtype)
+        res = get_dummies(s, **kwargs)
         exp = DataFrame({'a': {0: 1, 1: 0, 2: 0},
-                         'b': {0: 0, 1: 1, 2: 0}}, dtype=self.dtype)
+                         'b': {0: 0, 1: 1, 2: 0}}, dtype=dtype)
         assert_frame_equal(res, exp)
 
         # Sparse dataframes do not allow nan labelled columns, see #GH8822
-        res_na = get_dummies(s,
-                             dummy_na=True,
-                             sparse=self.sparse,
-                             dtype=self.dtype)
+        res_na = get_dummies(s, dummy_na=True, **kwargs)
         exp_na = DataFrame({nan: {0: 0, 1: 0, 2: 1},
                             'a': {0: 1, 1: 0, 2: 0},
                             'b': {0: 0, 1: 1, 2: 0}},
-                           dtype=self.dtype)
+                           dtype=dtype)
         exp_na = exp_na.reindex(['a', 'b', nan], axis=1)
         # hack (NaN handling in assert_index_equal)
         exp_na.columns = res_na.columns
         assert_frame_equal(res_na, exp_na)
 
-        res_just_na = get_dummies([nan],
-                                  dummy_na=True,
-                                  sparse=self.sparse,
-                                  dtype=self.dtype)
+        res_just_na = get_dummies([nan], dummy_na=True, **kwargs)
         exp_just_na = DataFrame(Series(1, index=[0]), columns=[nan],
-                                dtype=self.dtype)
+                                dtype=dtype)
         tm.assert_numpy_array_equal(res_just_na.values, exp_just_na.values)
 
-    def test_unicode(self
-                     ):  # See GH 6885 - get_dummies chokes on unicode values
+    def test_unicode(self, sparse, dtype):
+        kwargs = {'sparse': sparse, 'dtype': dtype}
+        # See GH 6885 - get_dummies chokes on unicode values
         import unicodedata
         e = 'e'
         eacute = unicodedata.lookup('LATIN SMALL LETTER E WITH ACUTE')
         s = [e, eacute, eacute]
-        res = get_dummies(s,
-                          prefix='letter',
-                          sparse=self.sparse,
-                          dtype=self.dtype)
+        res = get_dummies(s, prefix='letter', **kwargs)
         exp = DataFrame({'letter_e': {0: 1,
                                       1: 0,
                                       2: 0},
                          u('letter_%s') % eacute: {0: 0,
                                                    1: 1,
                                                    2: 1}},
-                        dtype=self.dtype)
+                        dtype=dtype)
         assert_frame_equal(res, exp)
 
-    def test_dataframe_dummies_all_obj(self):
-        df = self.df[['A', 'B']]
-        result = get_dummies(df, sparse=self.sparse, dtype=self.dtype)
+    def test_dataframe_dummies_all_obj(self, df, sparse, dtype):
+        kwargs = {'sparse': sparse, 'dtype': dtype}
+        df = df[['A', 'B']]
+        result = get_dummies(df, **kwargs)
         expected = DataFrame({'A_a': [1, 0, 1],
                               'A_b': [0, 1, 0],
                               'B_b': [1, 1, 0],
-                              'B_c': [0, 0, 1]}, dtype=self.dtype)
+                              'B_c': [0, 0, 1]}, dtype=dtype)
         assert_frame_equal(result, expected)
 
-    def test_dataframe_dummies_mix_default(self):
-        df = self.df
-        result = get_dummies(df, sparse=self.sparse, dtype=self.dtype)
+    def test_dataframe_dummies_mix_default(self, df, sparse, dtype):
+        kwargs = {'sparse': sparse, 'dtype': dtype}
+        result = get_dummies(df, **kwargs)
         expected = DataFrame({'C': [1, 2, 3],
                               'A_a': [1, 0, 1],
                               'A_b': [0, 1, 0],
                               'B_b': [1, 1, 0],
-                              'B_c': [0, 0, 1]}, dtype=self.dtype)
+                              'B_c': [0, 0, 1]}, dtype=dtype)
         cols = ['A_a', 'A_b', 'B_b', 'B_c']
-        expected[cols] = expected[cols].astype(self.dtype)
+        expected[cols] = expected[cols].astype(dtype)
         expected = expected[['C', 'A_a', 'A_b', 'B_b', 'B_c']]
         assert_frame_equal(result, expected)
 
-    def test_dataframe_dummies_prefix_list(self):
+    def test_dataframe_dummies_prefix_list(self, df, sparse, dtype):
+        kwargs = {'sparse': sparse, 'dtype': dtype}
         prefixes = ['from_A', 'from_B']
         df = DataFrame({'A': ['a', 'b', 'a'],
                         'B': ['b', 'b', 'c'],
-                        'C': [1, 2, 3]}, dtype=self.dtype)
-        result = get_dummies(df,
-                             prefix=prefixes,
-                             sparse=self.sparse,
-                             dtype=self.dtype)
+                        'C': [1, 2, 3]}, dtype=dtype)
+        result = get_dummies(df, prefix=prefixes, **kwargs)
         expected = DataFrame({'C': [1, 2, 3],
                               'from_A_a': [1, 0, 1],
                               'from_A_b': [0, 1, 0],
                               'from_B_b': [1, 1, 0],
-                              'from_B_c': [0, 0, 1]}, dtype=self.dtype)
+                              'from_B_c': [0, 0, 1]}, dtype=dtype)
         cols = expected.columns[1:]
-        expected[cols] = expected[cols].astype(self.dtype)
+        expected[cols] = expected[cols].astype(dtype)
         expected = expected[['C', 'from_A_a', 'from_A_b',
                              'from_B_b', 'from_B_c']]
         assert_frame_equal(result, expected)
 
-    def test_dataframe_dummies_prefix_str(self):
+    def test_dataframe_dummies_prefix_str(self, df, sparse, dtype):
         # not that you should do this...
-        df = self.df
-        result = get_dummies(df, prefix='bad', sparse=self.sparse,
-                             dtype=self.dtype)
+        kwargs = {'sparse': sparse, 'dtype': dtype}
+        result = get_dummies(df, prefix='bad', **kwargs)
         expected = DataFrame([[1, 1, 0, 1, 0],
                               [2, 0, 1, 1, 0],
                               [3, 1, 0, 0, 1]],
                              columns=['C', 'bad_a', 'bad_b', 'bad_b', 'bad_c'],
-                             dtype=self.dtype)
-        expected = expected.astype({"C": self.dtype})
+                             dtype=dtype)
+        expected = expected.astype({"C": dtype})
         assert_frame_equal(result, expected)
 
-    def test_dataframe_dummies_subset(self):
-        df = self.df
-        result = get_dummies(df, prefix=['from_A'], columns=['A'],
-                             sparse=self.sparse, dtype=self.dtype)
+    def test_dataframe_dummies_subset(self, df, sparse, dtype):
+        kwargs = {'sparse': sparse, 'dtype': dtype}
+        result = get_dummies(df, prefix=['from_A'], columns=['A'], **kwargs)
         expected = DataFrame({'from_A_a': [1, 0, 1],
                               'from_A_b': [0, 1, 0],
                               'B': ['b', 'b', 'c'],
-                              'C': [1, 2, 3]}, dtype=self.dtype)
+                              'C': [1, 2, 3]}, dtype=dtype)
         cols = ['from_A_a', 'from_A_b']
-        expected[cols] = expected[cols].astype(self.dtype)
+        expected[cols] = expected[cols].astype(dtype)
         assert_frame_equal(result, expected)
 
-    def test_dataframe_dummies_prefix_sep(self):
-        df = self.df
-        result = get_dummies(df, prefix_sep='..', sparse=self.sparse,
-                             dtype=self.dtype)
+    def test_dataframe_dummies_prefix_sep(self, df, sparse, dtype):
+        kwargs = {'sparse': sparse, 'dtype': dtype}
+        result = get_dummies(df, prefix_sep='..', **kwargs)
         expected = DataFrame({'C': [1, 2, 3],
                               'A..a': [1, 0, 1],
                               'A..b': [0, 1, 0],
                               'B..b': [1, 1, 0],
-                              'B..c': [0, 0, 1]}, dtype=self.dtype)
+                              'B..c': [0, 0, 1]}, dtype=dtype)
         expected = expected[['C', 'A..a', 'A..b', 'B..b', 'B..c']]
         cols = expected.columns[1:]
-        expected[cols] = expected[cols].astype(self.dtype)
+        expected[cols] = expected[cols].astype(dtype)
         assert_frame_equal(result, expected)
 
-        result = get_dummies(df,
-                             prefix_sep=['..', '__'],
-                             sparse=self.sparse,
-                             dtype=self.dtype)
+        result = get_dummies(df, prefix_sep=['..', '__'], **kwargs)
         expected = expected.rename(columns={'B..b': 'B__b', 'B..c': 'B__c'})
         assert_frame_equal(result, expected)
 
-        result = get_dummies(df, prefix_sep={'A': '..',
-                                             'B': '__'},
-                             sparse=self.sparse,
-                             dtype=self.dtype)
+        result = get_dummies(df, prefix_sep={'A': '..', 'B': '__'}, **kwargs)
         assert_frame_equal(result, expected)
 
-    def test_dataframe_dummies_prefix_bad_length(self):
+    def test_dataframe_dummies_prefix_bad_length(self, df, sparse):
         with pytest.raises(ValueError):
-            get_dummies(self.df, prefix=['too few'], sparse=self.sparse)
+            get_dummies(df, prefix=['too few'], sparse=sparse)
 
-    def test_dataframe_dummies_prefix_sep_bad_length(self):
+    def test_dataframe_dummies_prefix_sep_bad_length(self, df, sparse):
         with pytest.raises(ValueError):
-            get_dummies(self.df, prefix_sep=['bad'], sparse=self.sparse)
+            get_dummies(df, prefix_sep=['bad'], sparse=sparse)
 
-    def test_dataframe_dummies_prefix_dict(self):
+    def test_dataframe_dummies_prefix_dict(self, sparse, dtype):
+        kwargs = {'sparse': sparse, 'dtype': dtype}
         prefixes = {'A': 'from_A', 'B': 'from_B'}
         df = DataFrame({'A': ['a', 'b', 'a'],
                         'B': ['b', 'b', 'c'],
-                        'C': [1, 2, 3]}, dtype=self.dtype)
-        result = get_dummies(df, prefix=prefixes, sparse=self.sparse,
-                             dtype=self.dtype)
+                        'C': [1, 2, 3]}, dtype=dtype)
+        result = get_dummies(df, prefix=prefixes, **kwargs)
         expected = DataFrame({'from_A_a': [1, 0, 1],
                               'from_A_b': [0, 1, 0],
                               'from_B_b': [1, 1, 0],
                               'from_B_c': [0, 0, 1],
-                              'C': [1, 2, 3]}, dtype=self.dtype)
+                              'C': [1, 2, 3]}, dtype=dtype)
         assert_frame_equal(result, expected)
 
-    def test_dataframe_dummies_with_na(self):
-        df = self.df
+    def test_dataframe_dummies_with_na(self, df, sparse, dtype):
+        kwargs = {'sparse': sparse, 'dtype': dtype}
         df.loc[3, :] = [np.nan, np.nan, np.nan]
-        result = get_dummies(df, dummy_na=True, sparse=self.sparse,
-                             dtype=self.dtype)
+        result = get_dummies(df, dummy_na=True, **kwargs)
         expected = DataFrame({'C': [1, 2, 3, np.nan],
                               'A_a': [1, 0, 1, 0],
                               'A_b': [0, 1, 0, 0],
                               'A_nan': [0, 0, 0, 1],
                               'B_b': [1, 1, 0, 0],
                               'B_c': [0, 0, 1, 0],
-                              'B_nan': [0, 0, 0, 1]}, dtype=self.dtype)
+                              'B_nan': [0, 0, 0, 1]}, dtype=dtype)
         expected[['C']] = expected[['C']].astype(np.float64)
         expected = expected[['C', 'A_a', 'A_b', 'A_nan',
                              'B_b', 'B_c', 'B_nan']]
         assert_frame_equal(result, expected)
 
-        result = get_dummies(df, dummy_na=False, sparse=self.sparse,
-                             dtype=self.dtype)
+        result = get_dummies(df, dummy_na=False, **kwargs)
         expected = expected[['C', 'A_a', 'A_b', 'B_b', 'B_c']]
         assert_frame_equal(result, expected)
 
-    def test_dataframe_dummies_with_categorical(self):
-        df = self.df
+    def test_dataframe_dummies_with_categorical(self, df, sparse, dtype):
+        kwargs = {'sparse': sparse, 'dtype': dtype}
         df['cat'] = pd.Categorical(['x', 'y', 'y'])
-        result = get_dummies(df, sparse=self.sparse, dtype=self.dtype)
+        result = get_dummies(df, **kwargs)
         expected = DataFrame({'C': [1, 2, 3],
                               'A_a': [1, 0, 1],
                               'A_b': [0, 1, 0],
                               'B_b': [1, 1, 0],
                               'B_c': [0, 0, 1],
                               'cat_x': [1, 0, 0],
-                              'cat_y': [0, 1, 1]}, dtype=self.dtype)
+                              'cat_y': [0, 1, 1]}, dtype=dtype)
         expected = expected[['C', 'A_a', 'A_b', 'B_b', 'B_c',
                              'cat_x', 'cat_y']]
         assert_frame_equal(result, expected)
 
-    def test_basic_drop_first(self):
+    def test_basic_drop_first(self, sparse, dtype):
         # GH12402 Add a new parameter `drop_first` to avoid collinearity
         # Basic case
+        kwargs = {'sparse': sparse, 'dtype': dtype}
         s_list = list('abc')
         s_series = Series(s_list)
         s_series_index = Series(s_list, list('ABC'))
 
         expected = DataFrame({'b': [0, 1, 0],
-                              'c': [0, 0, 1]}, dtype=self.dtype)
+                              'c': [0, 0, 1]}, dtype=dtype)
 
-        result = get_dummies(s_list,
-                             sparse=self.sparse,
-                             drop_first=True,
-                             dtype=self.dtype)
+        result = get_dummies(s_list, drop_first=True, **kwargs)
         assert_frame_equal(result, expected)
 
-        result = get_dummies(s_series,
-                             sparse=self.sparse,
-                             drop_first=True,
-                             dtype=self.dtype)
+        result = get_dummies(s_series, drop_first=True, **kwargs)
         assert_frame_equal(result, expected)
 
         expected.index = list('ABC')
-        result = get_dummies(s_series_index, sparse=self.sparse,
-                             drop_first=True, dtype=self.dtype)
+        result = get_dummies(s_series_index, drop_first=True, **kwargs)
         assert_frame_equal(result, expected)
 
-    def test_basic_drop_first_one_level(self):
+    def test_basic_drop_first_one_level(self, sparse, dtype):
         # Test the case that categorical variable only has one level.
+        kwargs = {'sparse': sparse, 'dtype': dtype}
         s_list = list('aaa')
         s_series = Series(s_list)
         s_series_index = Series(s_list, list('ABC'))
 
         expected = DataFrame(index=np.arange(3))
 
-        result = get_dummies(s_list, sparse=self.sparse, drop_first=True)
+        result = get_dummies(s_list, drop_first=True, **kwargs)
         assert_frame_equal(result, expected)
 
-        result = get_dummies(s_series, sparse=self.sparse, drop_first=True)
+        result = get_dummies(s_series, drop_first=True, **kwargs)
         assert_frame_equal(result, expected)
 
         expected = DataFrame(index=list('ABC'))
-        result = get_dummies(s_series_index, sparse=self.sparse,
-                             drop_first=True)
+        result = get_dummies(s_series_index, drop_first=True, **kwargs)
         assert_frame_equal(result, expected)
 
-    def test_basic_drop_first_NA(self):
+    def test_basic_drop_first_NA(self, sparse, dtype):
         # Test NA hadling together with drop_first
+        kwargs = {'sparse': sparse, 'dtype': dtype}
         s_NA = ['a', 'b', np.nan]
-        res = get_dummies(s_NA,
-                          sparse=self.sparse,
-                          drop_first=True,
-                          dtype=self.dtype)
-        exp = DataFrame({'b': [0, 1, 0]}, dtype=self.dtype)
+        res = get_dummies(s_NA, drop_first=True, **kwargs)
+        exp = DataFrame({'b': [0, 1, 0]}, dtype=dtype)
         assert_frame_equal(res, exp)
 
-        res_na = get_dummies(s_NA, dummy_na=True, sparse=self.sparse,
-                             drop_first=True, dtype=self.dtype)
+        res_na = get_dummies(s_NA, dummy_na=True, drop_first=True, **kwargs)
         exp_na = DataFrame({'b': [0, 1, 0],
                             nan: [0, 0, 1]},
-                           dtype=self.dtype).reindex(['b', nan], axis=1)
+                           dtype=dtype).reindex(['b', nan], axis=1)
         assert_frame_equal(res_na, exp_na)
 
-        res_just_na = get_dummies([nan], dummy_na=True, sparse=self.sparse,
-                                  drop_first=True, dtype=self.dtype)
+        res_just_na = get_dummies([nan],
+                                  dummy_na=True,
+                                  drop_first=True,
+                                  **kwargs)
         exp_just_na = DataFrame(index=np.arange(1))
         assert_frame_equal(res_just_na, exp_just_na)
 
-    def test_dataframe_dummies_drop_first(self):
-        df = self.df[['A', 'B']]
-        result = get_dummies(df,
-                             sparse=self.sparse,
-                             drop_first=True,
-                             dtype=self.dtype)
+    def test_dataframe_dummies_drop_first(self, df, sparse, dtype):
+        kwargs = {'sparse': sparse, 'dtype': dtype}
+        df = df[['A', 'B']]
+        result = get_dummies(df, drop_first=True, **kwargs)
         expected = DataFrame({'A_b': [0, 1, 0],
-                              'B_c': [0, 0, 1]}, dtype=self.dtype)
+                              'B_c': [0, 0, 1]}, dtype=dtype)
         assert_frame_equal(result, expected)
 
-    def test_dataframe_dummies_drop_first_with_categorical(self):
-        df = self.df
+    def test_dataframe_dummies_drop_first_with_categorical(
+            self, df, sparse, dtype):
+        kwargs = {'sparse': sparse, 'dtype': dtype}
         df['cat'] = pd.Categorical(['x', 'y', 'y'])
-        result = get_dummies(df,
-                             sparse=self.sparse,
-                             drop_first=True,
-                             dtype=self.dtype)
+        result = get_dummies(df, drop_first=True, **kwargs)
         expected = DataFrame({'C': [1, 2, 3],
                               'A_b': [0, 1, 0],
                               'B_c': [0, 0, 1],
-                              'cat_y': [0, 1, 1]}, dtype=self.dtype)
+                              'cat_y': [0, 1, 1]}, dtype=dtype)
         cols = ['A_b', 'B_c', 'cat_y']
-        expected[cols] = expected[cols].astype(self.dtype)
+        expected[cols] = expected[cols].astype(dtype)
         expected = expected[['C', 'A_b', 'B_c', 'cat_y']]
         assert_frame_equal(result, expected)
 
-    def test_dataframe_dummies_drop_first_with_na(self):
-        df = self.df
+    def test_dataframe_dummies_drop_first_with_na(self, df, sparse, dtype):
+        kwargs = {'sparse': sparse, 'dtype': dtype}
         df.loc[3, :] = [np.nan, np.nan, np.nan]
-        result = get_dummies(df, dummy_na=True, sparse=self.sparse,
-                             drop_first=True, dtype=self.dtype)
+        result = get_dummies(df, dummy_na=True, drop_first=True, **kwargs)
         expected = DataFrame({'C': [1, 2, 3, np.nan],
                               'A_b': [0, 1, 0, 0],
                               'A_nan': [0, 0, 0, 1],
                               'B_c': [0, 0, 1, 0],
-                              'B_nan': [0, 0, 0, 1]}, dtype=self.dtype)
+                              'B_nan': [0, 0, 0, 1]}, dtype=dtype)
         expected[['C']] = expected[['C']].astype(np.float64)
         cols = ['A_b', 'A_nan', 'B_c', 'B_nan']
-        expected[cols] = expected[cols].astype(self.dtype)
+        expected[cols] = expected[cols].astype(dtype)
 
         expected = expected[['C', 'A_b', 'A_nan', 'B_c', 'B_nan']]
         assert_frame_equal(result, expected)
 
-        result = get_dummies(df, dummy_na=False, sparse=self.sparse,
-                             drop_first=True, dtype=self.dtype)
+        result = get_dummies(df, dummy_na=False, drop_first=True, **kwargs)
         expected = expected[['C', 'A_b', 'B_c']]
         assert_frame_equal(result, expected)
 
-    def test_int_int(self):
+    def test_int_int(self, dtype):
         data = Series([1, 2, 1])
-        result = pd.get_dummies(data, dtype=self.dtype)
+        result = pd.get_dummies(data, dtype=dtype)
         expected = DataFrame([[1, 0],
                               [0, 1],
                               [1, 0]],
                              columns=[1, 2],
-                             dtype=self.dtype)
+                             dtype=dtype)
         tm.assert_frame_equal(result, expected)
 
         data = Series(pd.Categorical(['a', 'b', 'a']))
-        result = pd.get_dummies(data, dtype=self.dtype)
+        result = pd.get_dummies(data, dtype=dtype)
         expected = DataFrame([[1, 0],
                               [0, 1],
                               [1, 0]],
                              columns=pd.Categorical(['a', 'b']),
-                             dtype=self.dtype)
+                             dtype=dtype)
         tm.assert_frame_equal(result, expected)
 
-    def test_int_df(self):
+    def test_int_df(self, dtype):
         data = DataFrame(
             {'A': [1, 2, 1],
              'B': pd.Categorical(['a', 'b', 'a']),
@@ -658,61 +645,24 @@ class TestGetDummies(object):
             [2, 2., 0, 1, 0, 1],
             [1, 1., 1, 0, 1, 0]
         ], columns=columns)
-        expected[columns[2:]] = expected[columns[2:]].astype(self.dtype)
-        result = pd.get_dummies(data, columns=['A', 'B'], dtype=self.dtype)
+        expected[columns[2:]] = expected[columns[2:]].astype(dtype)
+        result = pd.get_dummies(data, columns=['A', 'B'], dtype=dtype)
         tm.assert_frame_equal(result, expected)
 
-    def test_dataframe_dummies_preserve_categorical_dtype(self):
+    def test_dataframe_dummies_preserve_categorical_dtype(self, dtype):
         # GH13854
         for ordered in [False, True]:
             cat = pd.Categorical(list("xy"), categories=list("xyz"),
                                  ordered=ordered)
-            result = get_dummies(cat, dtype=self.dtype)
+            result = get_dummies(cat, dtype=dtype)
 
-            data = np.array([[1, 0, 0], [0, 1, 0]], dtype=self.dtype)
+            data = np.array([[1, 0, 0], [0, 1, 0]], dtype=dtype)
             cols = pd.CategoricalIndex(cat.categories,
                                        categories=cat.categories,
                                        ordered=ordered)
-            expected = DataFrame(data, columns=cols, dtype=self.dtype)
+            expected = DataFrame(data, columns=cols, dtype=dtype)
 
             tm.assert_frame_equal(result, expected)
-
-
-class TestGetDummiesSparse(TestGetDummies):
-    sparse = True
-
-    @pytest.mark.xfail(reason='nan in index is problematic (GH 16894)')
-    def test_include_na(self):
-        super(TestGetDummiesSparse, self).test_include_na()
-
-
-class TestGetDummiesDtypeMixin(object):
-    dtype_str = 'float64'
-
-    @pytest.mark.skip(reason='no element types to test')
-    def test_just_na(self):
-        pass
-
-    @pytest.mark.skip(reason='no internal elements to assert type')
-    def test_dataframe_dummies_prefix_bad_length(self):
-        pass
-
-    @pytest.mark.skip(reason='no internal elements to assert type')
-    def test_dataframe_dummies_prefix_sep_bad_length(self):
-        pass
-
-    @pytest.mark.skip(reason='no internal elements to assert type')
-    def test_basic_drop_first_one_level(self):
-        pass
-
-
-class TestGetDummiesDtypeFloat(TestGetDummiesDtypeMixin, TestGetDummies):
-    pass
-
-
-class TestGetDummiesSparseDtypeFloat(TestGetDummiesDtypeMixin,
-                                     TestGetDummiesSparse):
-    pass
 
 
 class TestMakeAxisDummies(object):

--- a/pandas/tests/reshape/test_reshape.py
+++ b/pandas/tests/reshape/test_reshape.py
@@ -239,7 +239,7 @@ class TestGetDummies(object):
             return np.uint8
         return dtype
 
-    def test_throws_on_dtype_object(self, df):
+    def test_raises_on_dtype_object(self, df):
         with pytest.raises(ValueError):
             get_dummies(df, dtype='object')
 

--- a/pandas/tests/reshape/test_reshape.py
+++ b/pandas/tests/reshape/test_reshape.py
@@ -397,7 +397,6 @@ class TestGetDummies(object):
 
     def test_dataframe_dummies_prefix_str(self, df, sparse):
         # not that you should do this...
-        df[['C']] = df[['C']].astype(np.uint8)
         result = get_dummies(df, prefix='bad', sparse=sparse)
         bad_columns = ['bad_a', 'bad_b', 'bad_b', 'bad_c']
         expected = DataFrame([[1, 1, 0, 1, 0],
@@ -405,6 +404,7 @@ class TestGetDummies(object):
                               [3, 1, 0, 0, 1]],
                              columns=['C'] + bad_columns,
                              dtype=np.uint8)
+        expected = expected.astype({"C": np.int64})
         assert_frame_equal(result, expected)
 
     def test_dataframe_dummies_subset(self, df, sparse):


### PR DESCRIPTION
- [x] closes #18330 (there's no issue for this one)
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry

Update in version 0.19.0 made `get_dummies` return uint8 values instead of floats (#8725). While I agree with the argument that `get_dummies` should output integers __by default__ (to save some memory), in many cases it would be beneficial for user to choose other dtype.

In my case there was serious performance degradation between versions 0.18 and 0.19. After investigation, reason behind it turned out to be the change to `get_dummies` output type. DataFrame with dummy values was used as an argument to np.dot in an optimization function (second argument was matrix of floats). Since there were lots of iterations involved, and on each iteration np.dot was converting all uint8 values to float64, conversion overhead took unreasonably long time. It is possible to work around this issue by converting dummy columns "manually" afterwards, but it adds unnecessary complexity to the code and is clearly less convenient than calling `get_dummies` with `dtype=float`.

Apart from performance considerations, I can imagine `dtype=bool` to be a common use case.

`get_dummies(data, dtype=None)` is allowed and will return uint8 values to match the [DataFrame](https://pandas.pydata.org/pandas-docs/stable/generated/pandas.DataFrame.html) interface (where None allows inferring datatype, which is default behavior).

I've extended the test suite to run all the `get_dummies` tests (except for those that don't deal with internal dtypes, like `test_just_na`) twice, once with `uint8` and once with `float64`.