### PR TITLE
DEPR: deprecate .add_prefix and .add_suffix

### DIFF
--- a/doc/source/10min.rst
+++ b/doc/source/10min.rst
@@ -87,15 +87,13 @@ will be completed:
    df2.A                  df2.bool
    df2.abs                df2.boxplot
    df2.add                df2.C
-   df2.add_prefix         df2.clip
-   df2.add_suffix         df2.clip_lower
-   df2.align              df2.clip_upper
-   df2.all                df2.columns
-   df2.any                df2.combine
-   df2.append             df2.combine_first
-   df2.apply              df2.compound
-   df2.applymap           df2.consolidate
-   df2.D
+   df2.align              df2.clip
+   df2.all                df2.clip_lower
+   df2.any                df2.clip_upper
+   df2.append             df2.columns
+   df2.apply              df2.combine
+   df2.applymap           df2.combine_first
+   df2.B                  df2.compound
 
 As you can see, the columns ``A``, ``B``, ``C``, and ``D`` are automatically
 tab completed. ``E`` is there as well; the rest of the attributes have been

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -114,8 +114,9 @@ class NDFrame(PandasObject, SelectionMixin):
                        '__array_interface__']
     _internal_names_set = set(_internal_names)
     _accessors = frozenset([])
-    _deprecations = frozenset(['as_blocks', 'blocks',
-                               'consolidate', 'convert_objects', 'is_copy'])
+    _deprecations = frozenset(['as_blocks', 'add_prefix', 'add_suffix',
+                               'blocks', 'consolidate', 'convert_objects',
+                               'is_copy'])
     _metadata = []
     _is_copy = None
 
@@ -801,6 +802,11 @@ class NDFrame(PandasObject, SelectionMixin):
         1    2
         4    3
         dtype: int64
+        >>> s.rename('index_{}'.format)  # function, changes labels
+        index_0    1
+        index_1    2
+        index_2    3
+        dtype: object
         >>> s.rename({1: 3, 2: 5})  # mapping, changes labels
         0    1
         3    2
@@ -824,11 +830,11 @@ class NDFrame(PandasObject, SelectionMixin):
         We *highly* recommend using keyword arguments to clarify your
         intent.
 
-        >>> df.rename(index=str, columns={"A": "a", "B": "c"})
-           a  c
-        0  1  4
-        1  2  5
-        2  3  6
+        >>> df.rename(index="index_{}".format, columns={"A": "a", "B": "c"})
+                 a  c
+        index_0  1  4
+        index_1  2  5
+        index_2  3  6
 
         >>> df.rename(index=str, columns={"A": "a", "C": "c"})
            a  B
@@ -2922,6 +2928,9 @@ class NDFrame(PandasObject, SelectionMixin):
 
     def add_prefix(self, prefix):
         """
+        DEPRECATED: Use ``obj.rename(columns=lambda x: 'prefix_'+str(x))`` or
+        similar instead.
+
         Concatenate prefix string with panel items names.
 
         Parameters
@@ -2931,13 +2940,21 @@ class NDFrame(PandasObject, SelectionMixin):
         Returns
         -------
         with_prefix : type of caller
+
+        See Also:
+        ---------
+        rename : Alter axes labels.
         """
+        warnings.warn("'.add_prefix' is deprecated and will be removed in a "
+                      "future version. Use '.rename' instead",
+                      FutureWarning, stacklevel=2)
         new_data = self._data.add_prefix(prefix)
         return self._constructor(new_data).__finalize__(self)
 
     def add_suffix(self, suffix):
         """
-        Concatenate suffix string with panel items names.
+        DEPRECATED: Use ``obj.rename(columns=lambda x: 'prefix_'+str(x))`` or
+        similar instead. Concatenate suffix string with panel items names.
 
         Parameters
         ----------
@@ -2946,7 +2963,13 @@ class NDFrame(PandasObject, SelectionMixin):
         Returns
         -------
         with_suffix : type of caller
+
+        See Also:
+        ---------
+        rename : Alter axes labels.
         """
+        warnings.warn("'add_suffix' is deprecated and will be removed in a "
+                      "future version.", FutureWarning, stacklevel=2)
         new_data = self._data.add_suffix(suffix)
         return self._constructor(new_data).__finalize__(self)
 

--- a/pandas/tests/frame/test_api.py
+++ b/pandas/tests/frame/test_api.py
@@ -76,21 +76,25 @@ class SharedWithSparse(object):
                 tm.assert_almost_equal(result, expected)
 
     def test_add_prefix_suffix(self):
-        with_prefix = self.frame.add_prefix('foo#')
-        expected = pd.Index(['foo#%s' % c for c in self.frame.columns])
-        tm.assert_index_equal(with_prefix.columns, expected)
+        with tm.assert_produces_warning(FutureWarning):
+            with_prefix = self.frame.add_prefix('foo#')
+            expected = pd.Index(['foo#%s' % c for c in self.frame.columns])
+            tm.assert_index_equal(with_prefix.columns, expected)
 
-        with_suffix = self.frame.add_suffix('#foo')
-        expected = pd.Index(['%s#foo' % c for c in self.frame.columns])
-        tm.assert_index_equal(with_suffix.columns, expected)
+        with tm.assert_produces_warning(FutureWarning):
+            with_suffix = self.frame.add_suffix('#foo')
+            expected = pd.Index(['%s#foo' % c for c in self.frame.columns])
+            tm.assert_index_equal(with_suffix.columns, expected)
 
-        with_pct_prefix = self.frame.add_prefix('%')
-        expected = pd.Index(['%{}'.format(c) for c in self.frame.columns])
-        tm.assert_index_equal(with_pct_prefix.columns, expected)
+        with tm.assert_produces_warning(FutureWarning):
+            with_pct_prefix = self.frame.add_prefix('%')
+            expected = pd.Index(['%{}'.format(c) for c in self.frame.columns])
+            tm.assert_index_equal(with_pct_prefix.columns, expected)
 
-        with_pct_suffix = self.frame.add_suffix('%')
-        expected = pd.Index(['{}%'.format(c) for c in self.frame.columns])
-        tm.assert_index_equal(with_pct_suffix.columns, expected)
+        with tm.assert_produces_warning(FutureWarning):
+            with_pct_suffix = self.frame.add_suffix('%')
+            expected = pd.Index(['{}%'.format(c) for c in self.frame.columns])
+            tm.assert_index_equal(with_pct_suffix.columns, expected)
 
     def test_get_axis(self):
         f = self.frame


### PR DESCRIPTION
- [x ] xref #18262
- [ x] tests added / passed
- [ x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ x] whatsnew entry

Deprecate ``.add_prefix`` and ``.add_suffix`` as per #18262.

An issue is that ``.add_prefix`` and ``.add_suffix`` call the like-named methods in ``internals.py::BlockManager``. Should ``BlockManager.add_prefix/add_suffix`` be changed somehow, e.g. have a warning as well?

EDIT: This is my first deprecation PR, so I'll be more than appreciative of criticism, so I understand these better in the future.

EDIT 2: With ``.add_prefix``/``add_postfix`` deprecated, I think it would be good to show in the doc strings for ``.rename`` how to do similar things, so I've changed its doc string a bit.