### PR TITLE
Revert "explicitly set 'include' to numpy_incls (#18112)"

### DIFF
--- a/pandas/_libs/reshape.pyx
+++ b/pandas/_libs/reshape.pyx
@@ -10,7 +10,7 @@ np.import_array()
 
 from numpy cimport (ndarray,
                     int8_t, int16_t, int32_t, int64_t, uint8_t, uint16_t,
-                    uint32_t, uint64_t, float32_t, float64_t)
+                    uint32_t, uint64_t, float16_t, float32_t, float64_t)
 
 cdef double NaN = <double> np.NaN
 cdef double nan = NaN

--- a/pandas/_libs/sparse.pyx
+++ b/pandas/_libs/sparse.pyx
@@ -1,5 +1,5 @@
 from numpy cimport (ndarray, uint8_t, int64_t, int32_t, int16_t, int8_t,
-                    float64_t, float32_t)
+                    float64_t, float32_t, float16_t)
 cimport numpy as np
 
 cimport cython

--- a/setup.py
+++ b/setup.py
@@ -461,13 +461,6 @@ def pxd(name):
     return os.path.abspath(pjoin('pandas', name + '.pxd'))
 
 
-if _have_setuptools:
-    # Note: this is a list, whereas `numpy_incl` in build_ext.build_extensions
-    # is a string
-    numpy_incls = [pkg_resources.resource_filename('numpy', 'core/include')]
-else:
-    numpy_incls = []
-
 # args to ignore warnings
 if is_platform_windows():
     extra_compile_args = []
@@ -510,8 +503,7 @@ ext_data = {
         'depends': _pxi_dep['index'],
         'sources': np_datetime_sources},
     '_libs.indexing': {
-        'pyxfile': '_libs/indexing',
-        'include': []},
+        'pyxfile': '_libs/indexing'},
     '_libs.interval': {
         'pyxfile': '_libs/interval',
         'pxdfiles': ['_libs/hashtable'],
@@ -544,12 +536,10 @@ ext_data = {
         'include': []},
     '_libs.reshape': {
         'pyxfile': '_libs/reshape',
-        'depends': _pxi_dep['reshape'],
-        'include': numpy_incls},
+        'depends': _pxi_dep['reshape']},
     '_libs.sparse': {
         'pyxfile': '_libs/sparse',
-        'depends': _pxi_dep['sparse'],
-        'include': numpy_incls},
+        'depends': _pxi_dep['sparse']},
     '_libs.tslib': {
         'pyxfile': '_libs/tslib',
         'pxdfiles': ['_libs/src/util',
@@ -590,7 +580,8 @@ ext_data = {
                      '_libs/tslibs/frequencies']},
     '_libs.tslibs.parsing': {
         'pyxfile': '_libs/tslibs/parsing',
-        'include': numpy_incls},
+        'pxdfiles': ['_libs/src/util',
+                     '_libs/src/khash']},
     '_libs.tslibs.resolution': {
         'pyxfile': '_libs/tslibs/resolution',
         'pxdfiles': ['_libs/src/util',
@@ -614,16 +605,14 @@ ext_data = {
         'pyxfile': '_libs/tslibs/timezones',
         'pxdfiles': ['_libs/src/util']},
     '_libs.testing': {
-        'pyxfile': '_libs/testing',
-        'include': []},
+        'pyxfile': '_libs/testing'},
     '_libs.window': {
         'pyxfile': '_libs/window',
         'pxdfiles': ['_libs/src/skiplist', '_libs/src/util'],
         'depends': ['pandas/_libs/src/skiplist.pyx',
                     'pandas/_libs/src/skiplist.h']},
     'io.sas._sas': {
-        'pyxfile': 'io/sas/sas',
-        'include': numpy_incls}}
+        'pyxfile': 'io/sas/sas'}}
 
 extensions = []
 


### PR DESCRIPTION
This reverts commit 54f2a5e91e90e35f7cbd15214297169831d6a6a6.

xref #18112

our 2.7 wheels started breaking with this: https://travis-ci.org/MacPython/pandas-wheels/builds/302788535
