### PR TITLE
remove get_value_box since it is redundant with libindex.get_value_at

### DIFF
--- a/pandas/_libs/index.pyx
+++ b/pandas/_libs/index.pyx
@@ -47,6 +47,31 @@ def get_value_at(ndarray arr, object loc):
     return util.get_value_at(arr, loc)
 
 
+cpdef object get_value_box(ndarray arr, object loc):
+    cdef:
+        Py_ssize_t i, sz
+
+    if util.is_float_object(loc):
+        casted = int(loc)
+        if casted == loc:
+            loc = casted
+    i = <Py_ssize_t> loc
+    sz = cnp.PyArray_SIZE(arr)
+
+    if i < 0 and sz > 0:
+        i += sz
+
+    if i >= sz or sz == 0 or i < 0:
+        raise IndexError('index out of bounds')
+
+    if arr.descr.type_num == NPY_DATETIME:
+        return Timestamp(util.get_value_1d(arr, i))
+    elif arr.descr.type_num == NPY_TIMEDELTA:
+        return Timedelta(util.get_value_1d(arr, i))
+    else:
+        return util.get_value_1d(arr, i)
+
+
 def set_value_at(ndarray arr, object loc, object val):
     return util.set_value_at(arr, loc, val)
 

--- a/pandas/_libs/src/util.pxd
+++ b/pandas/_libs/src/util.pxd
@@ -53,7 +53,8 @@ cdef extern from "headers/stdint.h":
 cdef inline object get_value_at(ndarray arr, object loc):
     cdef:
         Py_ssize_t i, sz
-        void* data_ptr
+        int casted
+
     if is_float_object(loc):
         casted = int(loc)
         if casted == loc:

--- a/pandas/_libs/tslib.pyx
+++ b/pandas/_libs/tslib.pyx
@@ -6,7 +6,7 @@
 
 cimport numpy as np
 from numpy cimport (int32_t, int64_t, import_array, ndarray,
-                    float64_t, NPY_DATETIME, NPY_TIMEDELTA)
+                    float64_t)
 import numpy as np
 
 import sys
@@ -846,31 +846,6 @@ cdef inline bint _check_all_nulls(object val):
     else:
         res = 0
     return res
-
-
-cpdef object get_value_box(ndarray arr, object loc):
-    cdef:
-        Py_ssize_t i, sz
-
-    if is_float_object(loc):
-        casted = int(loc)
-        if casted == loc:
-            loc = casted
-    i = <Py_ssize_t> loc
-    sz = np.PyArray_SIZE(arr)
-
-    if i < 0 and sz > 0:
-        i += sz
-
-    if i >= sz or sz == 0 or i < 0:
-        raise IndexError('index out of bounds')
-
-    if arr.descr.type_num == NPY_DATETIME:
-        return Timestamp(util.get_value_1d(arr, i))
-    elif arr.descr.type_num == NPY_TIMEDELTA:
-        return Timedelta(util.get_value_1d(arr, i))
-    else:
-        return util.get_value_1d(arr, i)
 
 
 # Add the min and max fields at the class level

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -2559,7 +2559,7 @@ class Index(IndexOpsMixin, PandasObject):
                 raise
 
             try:
-                return libts.get_value_box(s, key)
+                return libindex.get_value_at(s, key)
             except IndexError:
                 raise
             except TypeError:

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -2559,7 +2559,7 @@ class Index(IndexOpsMixin, PandasObject):
                 raise
 
             try:
-                return libindex.get_value_at(s, key)
+                return libindex.get_value_box(s, key)
             except IndexError:
                 raise
             except TypeError:


### PR DESCRIPTION
`tslib.get_value_box` is effectively identical to `index.get_value_at` (figuring this out requires looking at `util.get_value_at`).  Since the only use of `get_value_box` is in `core.index.base`, just get rid of it and use `libindex.get_value_at` there instead.

Fixup type declarations in `util.get_value_at`.

- [x] closes #18299
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
