### PR TITLE
PERF: improve plotting performance by not stringifying all x data

### DIFF
--- a/asv_bench/benchmarks/plotting.py
+++ b/asv_bench/benchmarks/plotting.py
@@ -10,21 +10,46 @@ except ImportError:
     from pandas.tools.plotting import andrews_curves
 
 
+class Plotting(object):
+    goal_time = 0.2
+
+    def setup(self):
+        import matplotlib
+        matplotlib.use('Agg')
+        self.s = Series(np.random.randn(1000000))
+        self.df = DataFrame({'col': self.s})
+
+    def time_series_plot(self):
+        self.s.plot()
+
+    def time_frame_plot(self):
+        self.df.plot()
+
+
 class TimeseriesPlotting(object):
     goal_time = 0.2
 
     def setup(self):
         import matplotlib
         matplotlib.use('Agg')
-        self.N = 2000
-        self.M = 5
-        self.df = DataFrame(np.random.randn(self.N, self.M), index=date_range('1/1/1975', periods=self.N))
+        N = 2000
+        M = 5
+        idx = date_range('1/1/1975', periods=N)
+        self.df = DataFrame(np.random.randn(N, M), index=idx)
+
+        idx_irregular = pd.DatetimeIndex(np.concatenate((idx.values[0:10],
+                                                         idx.values[12:])))
+        self.df2 = DataFrame(np.random.randn(len(idx_irregular), M),
+                             index=idx_irregular)
 
     def time_plot_regular(self):
         self.df.plot()
 
     def time_plot_regular_compat(self):
         self.df.plot(x_compat=True)
+
+    def time_plot_irregular(self):
+        self.df2.plot()
 
 
 class Misc(object):

--- a/doc/source/whatsnew/v0.21.1.txt
+++ b/doc/source/whatsnew/v0.21.1.txt
@@ -39,7 +39,7 @@ Deprecations
 Performance Improvements
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
--
+- Improved performance of plotting large series/dataframes (:issue:`18236`).
 -
 -
 

--- a/pandas/plotting/_core.py
+++ b/pandas/plotting/_core.py
@@ -383,12 +383,16 @@ class MPLPlot(object):
 
     def _post_plot_logic_common(self, ax, data):
         """Common post process for each axes"""
-        labels = [pprint_thing(key) for key in data.index]
-        labels = dict(zip(range(len(data.index)), labels))
+
+        def get_label(i):
+            try:
+                return pprint_thing(data.index[i])
+            except Exception:
+                return ''
 
         if self.orientation == 'vertical' or self.orientation is None:
             if self._need_to_set_index:
-                xticklabels = [labels.get(x, '') for x in ax.get_xticks()]
+                xticklabels = [get_label(x) for x in ax.get_xticks()]
                 ax.set_xticklabels(xticklabels)
             self._apply_axis_properties(ax.xaxis, rot=self.rot,
                                         fontsize=self.fontsize)
@@ -400,7 +404,7 @@ class MPLPlot(object):
 
         elif self.orientation == 'horizontal':
             if self._need_to_set_index:
-                yticklabels = [labels.get(y, '') for y in ax.get_yticks()]
+                yticklabels = [get_label(y) for y in ax.get_yticks()]
                 ax.set_yticklabels(yticklabels)
             self._apply_axis_properties(ax.yaxis, rot=self.rot,
                                         fontsize=self.fontsize)


### PR DESCRIPTION
Closes #18236

Currently when plotting all x / index data are converted to strings, while you typically only need a few tick labels. So when you have a lot of data, this cause the pandas plotter to be hugely slower than needed (and than a pure matplotlib one)

On master:

```
[ 33.33%] ··· Running plotting.Plotting.time_frame_plot                        4.43s
[ 50.00%] ··· Running plotting.Plotting.time_series_plot                       4.19s
[ 66.67%] ··· Running plotting.TimeseriesPlotting.time_plot_irregular          72.2±0.2ms
[ 83.33%] ··· Running plotting.TimeseriesPlotting.time_plot_regular            108±0.5ms
[100.00%] ··· Running plotting.TimeseriesPlotting.time_plot_regular_compat     71.5±0.8ms
```

with this branch:

```
[ 33.33%] ··· Running plotting.Plotting.time_frame_plot                        132±20ms
[ 50.00%] ··· Running plotting.Plotting.time_series_plot                       71.4±30ms
[ 66.67%] ··· Running plotting.TimeseriesPlotting.time_plot_irregular          58.7±0.5ms
[ 83.33%] ··· Running plotting.TimeseriesPlotting.time_plot_regular            96.9±2ms
[100.00%] ··· Running plotting.TimeseriesPlotting.time_plot_regular_compat     57.4±0.8ms
```

So for very simple plot when from 4s to ca 100ms (which is much closer to the pure matplotlib performance)