### PR TITLE
move a small set of non-scalar tests out of scalar.test_timestamp

### DIFF
--- a/pandas/tests/frame/test_indexing.py
+++ b/pandas/tests/frame/test_indexing.py
@@ -594,6 +594,15 @@ class TestDataFrameIndexing(TestData):
 
         assert_frame_equal(self.frame, expected)
 
+    def test_frame_setitem_timestamp(self):
+        # GH#2155
+        columns = DatetimeIndex(start='1/1/2012', end='2/1/2012', freq=BDay())
+        index = lrange(10)
+        data = DataFrame(columns=columns, index=index)
+        t = datetime(2012, 11, 1)
+        ts = Timestamp(t)
+        data[ts] = np.nan  # works
+
     def test_setitem_corner(self):
         # corner case
         df = DataFrame({'B': [1., 2., 3.],

--- a/pandas/tests/frame/test_indexing.py
+++ b/pandas/tests/frame/test_indexing.py
@@ -601,7 +601,8 @@ class TestDataFrameIndexing(TestData):
         data = DataFrame(columns=columns, index=index)
         t = datetime(2012, 11, 1)
         ts = Timestamp(t)
-        data[ts] = np.nan  # works
+        data[ts] = np.nan  # works, mostly a smoke-test
+        assert np.isnan(data[ts])
 
     def test_setitem_corner(self):
         # corner case

--- a/pandas/tests/frame/test_indexing.py
+++ b/pandas/tests/frame/test_indexing.py
@@ -602,7 +602,7 @@ class TestDataFrameIndexing(TestData):
         t = datetime(2012, 11, 1)
         ts = Timestamp(t)
         data[ts] = np.nan  # works, mostly a smoke-test
-        assert np.isnan(data[ts])
+        assert np.isnan(data[ts]).all()
 
     def test_setitem_corner(self):
         # corner case

--- a/pandas/tests/indexes/datetimes/test_date_range.py
+++ b/pandas/tests/indexes/datetimes/test_date_range.py
@@ -5,6 +5,7 @@ test date_range, bdate_range construction from the convenience range functions
 import pytest
 
 import numpy as np
+import pytz
 from pytz import timezone
 from datetime import datetime, timedelta, time
 
@@ -18,6 +19,61 @@ from pandas.tseries.offsets import (generate_range, CDay, BDay, DateOffset,
 from pandas.tests.series.common import TestData
 
 START, END = datetime(2009, 1, 1), datetime(2010, 1, 1)
+
+
+class TestTimestampEquivDateRange(object):
+    # Older tests in TestTimeSeries constructed their `stamp` objects
+    # using `date_range` instead of the `Timestamp` constructor.
+    # TestTimestampEquivDateRange checks that these are equivalent in the
+    # pertinent cases.
+
+    def test_date_range_timestamp_equiv(self):
+        rng = date_range('20090415', '20090519', tz='US/Eastern')
+        stamp = rng[0]
+
+        ts = Timestamp('20090415', tz='US/Eastern', freq='D')
+        assert ts == stamp
+
+    def test_date_range_timestamp_equiv_dateutil(self):
+        rng = date_range('20090415', '20090519', tz='dateutil/US/Eastern')
+        stamp = rng[0]
+
+        ts = Timestamp('20090415', tz='dateutil/US/Eastern', freq='D')
+        assert ts == stamp
+
+    def test_date_range_timestamp_equiv_explicit_pytz(self):
+        rng = date_range('20090415', '20090519',
+                         tz=pytz.timezone('US/Eastern'))
+        stamp = rng[0]
+
+        ts = Timestamp('20090415', tz=pytz.timezone('US/Eastern'), freq='D')
+        assert ts == stamp
+
+    def test_date_range_timestamp_equiv_explicit_dateutil(self):
+        tm._skip_if_windows_python_3()
+        from pandas._libs.tslibs.timezones import dateutil_gettz as gettz
+
+        rng = date_range('20090415', '20090519', tz=gettz('US/Eastern'))
+        stamp = rng[0]
+
+        ts = Timestamp('20090415', tz=gettz('US/Eastern'), freq='D')
+        assert ts == stamp
+
+    def test_date_range_timestamp_equiv_from_datetime_instance(self):
+        datetime_instance = datetime(2014, 3, 4)
+        # build a timestamp with a frequency, since then it supports
+        # addition/subtraction of integers
+        timestamp_instance = date_range(datetime_instance, periods=1,
+                                        freq='D')[0]
+
+        ts = Timestamp(datetime_instance, freq='D')
+        assert ts == timestamp_instance
+
+    def test_date_range_timestamp_equiv_preserve_frequency(self):
+        timestamp_instance = date_range('2014-03-05', periods=1, freq='D')[0]
+        ts = Timestamp('2014-03-05', freq='D')
+
+        assert timestamp_instance == ts
 
 
 class TestDateRanges(TestData):

--- a/pandas/tests/indexes/datetimes/test_datetime.py
+++ b/pandas/tests/indexes/datetimes/test_datetime.py
@@ -1,7 +1,7 @@
 import pytest
 
 import numpy as np
-from datetime import date, timedelta, time
+from datetime import date, timedelta, time, datetime
 
 import dateutil
 import pandas as pd
@@ -9,11 +9,36 @@ import pandas.util.testing as tm
 from pandas.compat import lrange
 from pandas.compat.numpy import np_datetime64_compat
 from pandas import (DatetimeIndex, Index, date_range, DataFrame,
-                    Timestamp, datetime, offsets)
+                    Timestamp, offsets)
 
 from pandas.util.testing import assert_almost_equal
 
 randn = np.random.randn
+
+
+class TestDatetimeIndexLikeTimestamp(object):
+    # Tests for DatetimeIndex behaving like a vectorized Timestamp
+
+    def test_dti_date_out_of_range(self):
+        # see gh-1475
+        pytest.raises(ValueError, DatetimeIndex, ['1400-01-01'])
+        pytest.raises(ValueError, DatetimeIndex, [datetime(1400, 1, 1)])
+
+    def test_timestamp_fields(self):
+        # extra fields from DatetimeIndex like quarter and week
+        idx = tm.makeDateIndex(100)
+
+        fields = ['dayofweek', 'dayofyear', 'week', 'weekofyear', 'quarter',
+                  'days_in_month', 'is_month_start', 'is_month_end',
+                  'is_quarter_start', 'is_quarter_end', 'is_year_start',
+                  'is_year_end', 'weekday_name']
+        for f in fields:
+            expected = getattr(idx, f)[-1]
+            result = getattr(Timestamp(idx[-1]), f)
+            assert result == expected
+
+        assert idx.freq == Timestamp(idx[-1], idx.freq).freq
+        assert idx.freqstr == Timestamp(idx[-1], idx.freq).freqstr
 
 
 class TestDatetimeIndex(object):

--- a/pandas/tests/indexes/datetimes/test_partial_slicing.py
+++ b/pandas/tests/indexes/datetimes/test_partial_slicing.py
@@ -13,6 +13,21 @@ from pandas.util import testing as tm
 
 
 class TestSlicing(object):
+    def test_dti_slicing(self):
+        dti = DatetimeIndex(start='1/1/2005', end='12/1/2005', freq='M')
+        dti2 = dti[[1, 3, 5]]
+
+        v1 = dti2[0]
+        v2 = dti2[1]
+        v3 = dti2[2]
+
+        assert v1 == Timestamp('2/28/2005')
+        assert v2 == Timestamp('4/30/2005')
+        assert v3 == Timestamp('6/30/2005')
+
+        # don't carry freq through irregular slicing
+        assert dti2.freq is None
+
     def test_slice_keeps_name(self):
         # GH4226
         st = pd.Timestamp('2013-07-01 00:00:00', tz='America/Los_Angeles')


### PR DESCRIPTION
Taking over from #18142 where scope got out of hand.

This PR is part of a series intended to separate non-scalar tests out of `tests.scalars`.