### PR TITLE
Numpy bool msgpack bugfix

### DIFF
--- a/doc/source/whatsnew/v0.21.1.txt
+++ b/doc/source/whatsnew/v0.21.1.txt
@@ -87,6 +87,7 @@ I/O
 - :func:`read_parquet` now allows to specify the columns to read from a parquet file (:issue:`18154`)
 - :func:`read_parquet` now allows to specify kwargs which are passed to the respective engine (:issue:`18216`)
 - Bug in parsing integer datetime-like columns with specified format in ``read_sql`` (:issue:`17855`).
+- Bug in :meth:`DataFrame.to_msgpack` when serializing data of the numpy.bool_ datatype (:issue:`18390`)
 
 
 Plotting

--- a/pandas/io/msgpack/_packer.pyx
+++ b/pandas/io/msgpack/_packer.pyx
@@ -8,6 +8,7 @@ from libc.limits cimport *
 
 from pandas.io.msgpack.exceptions import PackValueError
 from pandas.io.msgpack import ExtType
+from numpy import bool_
 
 
 cdef extern from "../../src/msgpack/pack.h":
@@ -133,7 +134,7 @@ cdef class Packer(object):
         while True:
             if o is None:
                 ret = msgpack_pack_nil(&self.pk)
-            elif isinstance(o, bool):
+            elif isinstance(o, (bool, bool_)):
                 if o:
                     ret = msgpack_pack_true(&self.pk)
                 else:

--- a/pandas/io/msgpack/_packer.pyx
+++ b/pandas/io/msgpack/_packer.pyx
@@ -8,7 +8,7 @@ from libc.limits cimport *
 
 from pandas.io.msgpack.exceptions import PackValueError
 from pandas.io.msgpack import ExtType
-from numpy import bool_
+import numpy as np
 
 
 cdef extern from "../../src/msgpack/pack.h":
@@ -134,7 +134,7 @@ cdef class Packer(object):
         while True:
             if o is None:
                 ret = msgpack_pack_nil(&self.pk)
-            elif isinstance(o, (bool, bool_)):
+            elif isinstance(o, (bool, np.bool_)):
                 if o:
                     ret = msgpack_pack_true(&self.pk)
                 else:

--- a/pandas/tests/io/msgpack/test_pack.py
+++ b/pandas/tests/io/msgpack/test_pack.py
@@ -7,7 +7,6 @@ import struct
 from pandas import compat
 from pandas.compat import u, OrderedDict
 from pandas.io.msgpack import packb, unpackb, Unpacker, Packer
-from numpy import bool_
 
 
 class TestPack(object):
@@ -26,7 +25,6 @@ class TestPack(object):
             (), ((),), ((), None,),
             {None: 0},
             (1 << 23),
-            bool_(1), bool_(0),
         ]
         for td in test_data:
             self.check(td)

--- a/pandas/tests/io/msgpack/test_pack.py
+++ b/pandas/tests/io/msgpack/test_pack.py
@@ -7,6 +7,7 @@ import struct
 from pandas import compat
 from pandas.compat import u, OrderedDict
 from pandas.io.msgpack import packb, unpackb, Unpacker, Packer
+from numpy import bool_
 
 
 class TestPack(object):
@@ -25,6 +26,7 @@ class TestPack(object):
             (), ((),), ((), None,),
             {None: 0},
             (1 << 23),
+            bool_(1), bool_(0),
         ]
         for td in test_data:
             self.check(td)

--- a/pandas/tests/io/test_packers.py
+++ b/pandas/tests/io/test_packers.py
@@ -180,6 +180,15 @@ class TestNumpy(TestPackers):
         x_rec = self.encode_decode(x)
         tm.assert_almost_equal(x, x_rec)
 
+    def test_scalar_bool(self):
+        x = np.bool_(1)
+        x_rec = self.encode_decode(x)
+        tm.assert_almost_equal(x, x_rec)
+
+        x = np.bool_(0)
+        x_rec = self.encode_decode(x)
+        tm.assert_almost_equal(x, x_rec)
+
     def test_scalar_complex(self):
         x = np.random.rand() + 1j * np.random.rand()
         x_rec = self.encode_decode(x)
@@ -263,7 +272,7 @@ class TestNumpy(TestPackers):
                 x.dtype == x_rec.dtype)
 
     def test_list_mixed(self):
-        x = [1.0, np.float32(3.5), np.complex128(4.25), u('foo')]
+        x = [1.0, np.float32(3.5), np.complex128(4.25), u('foo'), np.bool_(1)]
         x_rec = self.encode_decode(x)
         # current msgpack cannot distinguish list/tuple
         tm.assert_almost_equal(tuple(x), x_rec)

--- a/pandas/tests/io/test_packers.py
+++ b/pandas/tests/io/test_packers.py
@@ -410,6 +410,7 @@ class TestSeries(TestPackers):
             'G': [Timestamp('20130102', tz='US/Eastern')] * 5,
             'H': Categorical([1, 2, 3, 4, 5]),
             'I': Categorical([1, 2, 3, 4, 5], ordered=True),
+            'J': (np.bool_(1), 2, 3, 4, 5),
         }
 
         self.d['float'] = Series(data['A'])
@@ -419,6 +420,7 @@ class TestSeries(TestPackers):
         self.d['dt_tz'] = Series(data['G'])
         self.d['cat_ordered'] = Series(data['H'])
         self.d['cat_unordered'] = Series(data['I'])
+        self.d['numpy_bool_mixed'] = Series(data['J'])
 
     def test_basic(self):
 


### PR DESCRIPTION
This fixes issue #18390.
It allows for running DataFrame.to_msgpack() with dataframes containing fields of the numpy.bool_ datatype. 

- [x] closes #18390
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry