### PR TITLE
Pin correct names to wrapped Index comparison methods

### DIFF
--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -9,7 +9,7 @@ from pandas._libs import (lib, index as libindex, tslib as libts,
 from pandas._libs.lib import is_datetime_array
 from pandas._libs.tslibs import parsing
 
-from pandas.compat import range, u
+from pandas.compat import range, u, set_function_name
 from pandas.compat.numpy import function as nv
 from pandas import compat
 
@@ -3890,8 +3890,8 @@ class Index(IndexOpsMixin, PandasObject):
                 except TypeError:
                     return result
 
-            _evaluate_compare.__name__ = '__{name}__'.format(name=op.__name__)
-            return _evaluate_compare
+            name = '__{name}__'.format(name=op.__name__)
+            return set_function_name(_evaluate_compare, name, cls)
 
         cls.__eq__ = _make_compare(operator.eq)
         cls.__ne__ = _make_compare(operator.ne)

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -3890,6 +3890,7 @@ class Index(IndexOpsMixin, PandasObject):
                 except TypeError:
                     return result
 
+            _evaluate_compare.__name__ = '__{name}__'.format(name=op.__name__)
             return _evaluate_compare
 
         cls.__eq__ = _make_compare(operator.eq)

--- a/pandas/core/indexes/category.py
+++ b/pandas/core/indexes/category.py
@@ -747,6 +747,7 @@ class CategoricalIndex(Index, accessor.PandasDelegate):
 
                 return getattr(self.values, op)(other)
 
+            _evaluate_compare.__name__ = op
             return _evaluate_compare
 
         cls.__eq__ = _make_compare('__eq__')

--- a/pandas/core/indexes/category.py
+++ b/pandas/core/indexes/category.py
@@ -722,7 +722,7 @@ class CategoricalIndex(Index, accessor.PandasDelegate):
     def _add_comparison_methods(cls):
         """ add in comparison methods """
 
-        def _make_compare(op):
+        def _make_compare(opname):
             def _evaluate_compare(self, other):
 
                 # if we have a Categorical type, then must have the same
@@ -745,10 +745,9 @@ class CategoricalIndex(Index, accessor.PandasDelegate):
                                         "have the same categories and ordered "
                                         "attributes")
 
-                return getattr(self.values, op)(other)
+                return getattr(self.values, opname)(other)
 
-            _evaluate_compare.__name__ = op
-            return _evaluate_compare
+            return compat.set_function_name(_evaluate_compare, opname, cls)
 
         cls.__eq__ = _make_compare('__eq__')
         cls.__ne__ = _make_compare('__ne__')

--- a/pandas/core/indexes/datetimes.py
+++ b/pandas/core/indexes/datetimes.py
@@ -98,7 +98,7 @@ def _field_accessor(name, field, docstring=None):
     return property(f)
 
 
-def _dt_index_cmp(opname, nat_result=False):
+def _dt_index_cmp(opname, cls, nat_result=False):
     """
     Wrap comparison operations to convert datetime-like to datetime64
     """
@@ -135,8 +135,7 @@ def _dt_index_cmp(opname, nat_result=False):
             return result
         return Index(result)
 
-    wrapper.__name__ = opname
-    return wrapper
+    return compat.set_function_name(wrapper, opname, cls)
 
 
 def _ensure_datetime64(other):
@@ -278,12 +277,15 @@ class DatetimeIndex(DatelikeOps, TimelikeOps, DatetimeIndexOpsMixin,
         libjoin.left_join_indexer_unique_int64, with_indexers=False)
     _arrmap = None
 
-    __eq__ = _dt_index_cmp('__eq__')
-    __ne__ = _dt_index_cmp('__ne__', nat_result=True)
-    __lt__ = _dt_index_cmp('__lt__')
-    __gt__ = _dt_index_cmp('__gt__')
-    __le__ = _dt_index_cmp('__le__')
-    __ge__ = _dt_index_cmp('__ge__')
+    @classmethod
+    def _add_comparison_methods(cls):
+        """ add in comparison methods """
+        cls.__eq__ = _dt_index_cmp('__eq__', cls)
+        cls.__ne__ = _dt_index_cmp('__ne__', cls, nat_result=True)
+        cls.__lt__ = _dt_index_cmp('__lt__', cls)
+        cls.__gt__ = _dt_index_cmp('__gt__', cls)
+        cls.__le__ = _dt_index_cmp('__le__', cls)
+        cls.__ge__ = _dt_index_cmp('__ge__', cls)
 
     _engine_type = libindex.DatetimeEngine
 
@@ -2013,6 +2015,7 @@ class DatetimeIndex(DatelikeOps, TimelikeOps, DatetimeIndexOpsMixin,
                              ) / 24.0)
 
 
+DatetimeIndex._add_comparison_methods()
 DatetimeIndex._add_numeric_methods_disabled()
 DatetimeIndex._add_logical_methods_disabled()
 DatetimeIndex._add_datetimelike_methods()

--- a/pandas/core/indexes/datetimes.py
+++ b/pandas/core/indexes/datetimes.py
@@ -135,6 +135,7 @@ def _dt_index_cmp(opname, nat_result=False):
             return result
         return Index(result)
 
+    wrapper.__name__ = opname
     return wrapper
 
 
@@ -1596,14 +1597,15 @@ class DatetimeIndex(DatelikeOps, TimelikeOps, DatetimeIndexOpsMixin,
             else:
                 raise
 
-    # alias to offset
-    def _get_freq(self):
+    @property
+    def freq(self):
+        """get/set the frequency of the Index"""
         return self.offset
 
-    def _set_freq(self, value):
+    @freq.setter
+    def freq(self, value):
+        """get/set the frequency of the Index"""
         self.offset = value
-    freq = property(fget=_get_freq, fset=_set_freq,
-                    doc="get/set the frequency of the Index")
 
     year = _field_accessor('year', 'Y', "The year of the datetime")
     month = _field_accessor('month', 'M',

--- a/pandas/core/indexes/period.py
+++ b/pandas/core/indexes/period.py
@@ -115,6 +115,8 @@ def _period_index_cmp(opname, nat_result=False):
             result[self._isnan] = nat_result
 
         return result
+
+    wrapper.__name__ = opname
     return wrapper
 
 

--- a/pandas/core/indexes/period.py
+++ b/pandas/core/indexes/period.py
@@ -77,7 +77,7 @@ def dt64arr_to_periodarr(data, freq, tz):
 _DIFFERENT_FREQ_INDEX = period._DIFFERENT_FREQ_INDEX
 
 
-def _period_index_cmp(opname, nat_result=False):
+def _period_index_cmp(opname, cls, nat_result=False):
     """
     Wrap comparison operations to convert datetime-like to datetime64
     """
@@ -116,8 +116,7 @@ def _period_index_cmp(opname, nat_result=False):
 
         return result
 
-    wrapper.__name__ = opname
-    return wrapper
+    return compat.set_function_name(wrapper, opname, cls)
 
 
 def _new_PeriodIndex(cls, **d):
@@ -229,12 +228,15 @@ class PeriodIndex(DatelikeOps, DatetimeIndexOpsMixin, Int64Index):
 
     _engine_type = libindex.PeriodEngine
 
-    __eq__ = _period_index_cmp('__eq__')
-    __ne__ = _period_index_cmp('__ne__', nat_result=True)
-    __lt__ = _period_index_cmp('__lt__')
-    __gt__ = _period_index_cmp('__gt__')
-    __le__ = _period_index_cmp('__le__')
-    __ge__ = _period_index_cmp('__ge__')
+    @classmethod
+    def _add_comparison_methods(cls):
+        """ add in comparison methods """
+        cls.__eq__ = _period_index_cmp('__eq__', cls)
+        cls.__ne__ = _period_index_cmp('__ne__', cls, nat_result=True)
+        cls.__lt__ = _period_index_cmp('__lt__', cls)
+        cls.__gt__ = _period_index_cmp('__gt__', cls)
+        cls.__le__ = _period_index_cmp('__le__', cls)
+        cls.__ge__ = _period_index_cmp('__ge__', cls)
 
     def __new__(cls, data=None, ordinal=None, freq=None, start=None, end=None,
                 periods=None, copy=False, name=None, tz=None, dtype=None,
@@ -1104,6 +1106,7 @@ class PeriodIndex(DatelikeOps, DatetimeIndexOpsMixin, Int64Index):
         raise NotImplementedError("Not yet implemented for PeriodIndex")
 
 
+PeriodIndex._add_comparison_methods()
 PeriodIndex._add_numeric_methods_disabled()
 PeriodIndex._add_logical_methods_disabled()
 PeriodIndex._add_datetimelike_methods()

--- a/pandas/core/indexes/timedeltas.py
+++ b/pandas/core/indexes/timedeltas.py
@@ -52,7 +52,7 @@ def _field_accessor(name, alias, docstring=None):
     return property(f)
 
 
-def _td_index_cmp(opname, nat_result=False):
+def _td_index_cmp(opname, cls, nat_result=False):
     """
     Wrap comparison operations to convert timedelta-like to timedelta64
     """
@@ -93,8 +93,7 @@ def _td_index_cmp(opname, nat_result=False):
             return result
         return Index(result)
 
-    wrapper.__name__ = opname
-    return wrapper
+    return compat.set_function_name(wrapper, opname, cls)
 
 
 class TimedeltaIndex(DatetimeIndexOpsMixin, TimelikeOps, Int64Index):
@@ -181,12 +180,15 @@ class TimedeltaIndex(DatetimeIndexOpsMixin, TimelikeOps, Int64Index):
     _datetimelike_methods = ["to_pytimedelta", "total_seconds",
                              "round", "floor", "ceil"]
 
-    __eq__ = _td_index_cmp('__eq__')
-    __ne__ = _td_index_cmp('__ne__', nat_result=True)
-    __lt__ = _td_index_cmp('__lt__')
-    __gt__ = _td_index_cmp('__gt__')
-    __le__ = _td_index_cmp('__le__')
-    __ge__ = _td_index_cmp('__ge__')
+    @classmethod
+    def _add_comparison_methods(cls):
+        """ add in comparison methods """
+        cls.__eq__ = _td_index_cmp('__eq__', cls)
+        cls.__ne__ = _td_index_cmp('__ne__', cls, nat_result=True)
+        cls.__lt__ = _td_index_cmp('__lt__', cls)
+        cls.__gt__ = _td_index_cmp('__gt__', cls)
+        cls.__le__ = _td_index_cmp('__le__', cls)
+        cls.__ge__ = _td_index_cmp('__ge__', cls)
 
     _engine_type = libindex.TimedeltaEngine
 
@@ -913,6 +915,7 @@ class TimedeltaIndex(DatetimeIndexOpsMixin, TimelikeOps, Int64Index):
         return TimedeltaIndex(new_tds, name=self.name, freq=freq)
 
 
+TimedeltaIndex._add_comparison_methods()
 TimedeltaIndex._add_numeric_methods()
 TimedeltaIndex._add_logical_methods_disabled()
 TimedeltaIndex._add_datetimelike_methods()

--- a/pandas/core/indexes/timedeltas.py
+++ b/pandas/core/indexes/timedeltas.py
@@ -93,6 +93,7 @@ def _td_index_cmp(opname, nat_result=False):
             return result
         return Index(result)
 
+    wrapper.__name__ = opname
     return wrapper
 
 

--- a/pandas/tests/indexes/test_base.py
+++ b/pandas/tests/indexes/test_base.py
@@ -2174,3 +2174,13 @@ class TestIndexUtils(object):
     def test_ensure_index_from_sequences(self, data, names, expected):
         result = _ensure_index_from_sequences(data, names)
         tm.assert_index_equal(result, expected)
+
+
+def test_generated_op_names(indices):
+    index = indices
+    assert index.__eq__.__name__ == '__eq__'
+    assert index.__ne__.__name__ == '__ne__'
+    assert index.__le__.__name__ == '__le__'
+    assert index.__lt__.__name__ == '__lt__'
+    assert index.__ge__.__name__ == '__ge__'
+    assert index.__gt__.__name__ == '__gt__'

--- a/pandas/tests/indexes/test_base.py
+++ b/pandas/tests/indexes/test_base.py
@@ -2176,11 +2176,9 @@ class TestIndexUtils(object):
         tm.assert_index_equal(result, expected)
 
 
-def test_generated_op_names(indices):
+@pytest.mark.parametrize('opname', ['eq', 'ne', 'le', 'lt', 'ge', 'gt'])
+def test_generated_op_names(opname, indices):
     index = indices
-    assert index.__eq__.__name__ == '__eq__'
-    assert index.__ne__.__name__ == '__ne__'
-    assert index.__le__.__name__ == '__le__'
-    assert index.__lt__.__name__ == '__lt__'
-    assert index.__ge__.__name__ == '__ge__'
-    assert index.__gt__.__name__ == '__gt__'
+    opname = '__{name}__'.format(name=opname)
+    method = getattr(index, opname)
+    assert method.__name__ == opname


### PR DESCRIPTION
Currently:
```
>>> pd.Index.__eq__.__name__
'_evaluate_compare'
```

PR:
```
>>> pd.Index.__eq__.__name__
'__eq__'
```

Same for subclasses and other comparison methods.

On the side: use property decorator for `DatetimeIndex.freq` to avoid leaving `_get_freq` and `_set_freq` in the namespace.

- [ ] closes #xxxx
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
