### PR TITLE
use npy_datetimestruct and NPY_DATETIMEUNIT instead of pandas versions

### DIFF
--- a/pandas/_libs/period.pyx
+++ b/pandas/_libs/period.pyx
@@ -17,7 +17,7 @@ from pandas.compat import PY2
 
 cimport cython
 
-from tslibs.np_datetime cimport (pandas_datetimestruct,
+from tslibs.np_datetime cimport (npy_datetimestruct,
                                  dtstruct_to_dt64, dt64_to_dtstruct,
                                  is_leapyear)
 
@@ -117,7 +117,7 @@ def dt64arr_to_periodarr(ndarray[int64_t] dtarr, int freq, tz=None):
     cdef:
         ndarray[int64_t] out
         Py_ssize_t i, l
-        pandas_datetimestruct dts
+        npy_datetimestruct dts
 
     l = len(dtarr)
 
@@ -240,7 +240,7 @@ def period_ordinal(int y, int m, int d, int h, int min,
 
 cpdef int64_t period_ordinal_to_dt64(int64_t ordinal, int freq) nogil:
     cdef:
-        pandas_datetimestruct dts
+        npy_datetimestruct dts
         date_info dinfo
         float subsecond_fraction
 
@@ -487,7 +487,7 @@ cdef ndarray[int64_t] localize_dt64arr_to_period(ndarray[int64_t] stamps,
         Py_ssize_t n = len(stamps)
         ndarray[int64_t] result = np.empty(n, dtype=np.int64)
         ndarray[int64_t] trans, deltas, pos
-        pandas_datetimestruct dts
+        npy_datetimestruct dts
 
     if is_utc(tz):
         for i in range(n):

--- a/pandas/_libs/src/datetime.pxd
+++ b/pandas/_libs/src/datetime.pxd
@@ -1,5 +1,5 @@
 # cython: profile=False
-from numpy cimport int64_t, npy_int64, npy_int32
+from numpy cimport int64_t, int32_t, npy_int64, npy_int32
 
 from cpython cimport PyUnicode_Check, PyUnicode_AsASCIIString
 
@@ -22,50 +22,50 @@ cdef extern from "numpy_helper.h":
 cdef extern from "numpy/npy_common.h":
     ctypedef unsigned char npy_bool
 
+cdef extern from "numpy/ndarraytypes.h":
+    ctypedef enum NPY_DATETIMEUNIT:
+        NPY_FR_Y
+        NPY_FR_M
+        NPY_FR_W
+        NPY_FR_D
+        NPY_FR_B
+        NPY_FR_h
+        NPY_FR_m
+        NPY_FR_s
+        NPY_FR_ms
+        NPY_FR_us
+        NPY_FR_ns
+        NPY_FR_ps
+        NPY_FR_fs
+        NPY_FR_as
+
+    ctypedef struct npy_datetimestruct:
+        int64_t year
+        int32_t month, day, hour, min, sec, us, ps, as
+
 cdef extern from "datetime/np_datetime.h":
-
-    ctypedef enum PANDAS_DATETIMEUNIT:
-        PANDAS_FR_Y
-        PANDAS_FR_M
-        PANDAS_FR_W
-        PANDAS_FR_D
-        PANDAS_FR_B
-        PANDAS_FR_h
-        PANDAS_FR_m
-        PANDAS_FR_s
-        PANDAS_FR_ms
-        PANDAS_FR_us
-        PANDAS_FR_ns
-        PANDAS_FR_ps
-        PANDAS_FR_fs
-        PANDAS_FR_as
-
-    ctypedef struct pandas_datetimestruct:
-        npy_int64 year
-        npy_int32 month, day, hour, min, sec, us, ps, as
-
     npy_datetime pandas_datetimestruct_to_datetime(
-        PANDAS_DATETIMEUNIT fr, pandas_datetimestruct *d) nogil
+        NPY_DATETIMEUNIT fr, npy_datetimestruct *d) nogil
 
     void pandas_datetime_to_datetimestruct(npy_datetime val,
-                                           PANDAS_DATETIMEUNIT fr,
-                                           pandas_datetimestruct *result) nogil
+                                           NPY_DATETIMEUNIT fr,
+                                           npy_datetimestruct *result) nogil
     int days_per_month_table[2][12]
 
     int dayofweek(int y, int m, int d) nogil
     int is_leapyear(int64_t year) nogil
-    PANDAS_DATETIMEUNIT get_datetime64_unit(object o)
+    NPY_DATETIMEUNIT get_datetime64_unit(object o)
 
 cdef extern from "datetime/np_datetime_strings.h":
 
-    int parse_iso_8601_datetime(char *str, int len, PANDAS_DATETIMEUNIT unit,
+    int parse_iso_8601_datetime(char *str, int len, NPY_DATETIMEUNIT unit,
                                 NPY_CASTING casting,
-                                pandas_datetimestruct *out,
+                                npy_datetimestruct *out,
                                 int *out_local, int *out_tzoffset,
-                                PANDAS_DATETIMEUNIT *out_bestunit,
+                                NPY_DATETIMEUNIT *out_bestunit,
                                 npy_bool *out_special)
 
-cdef inline int _string_to_dts(object val, pandas_datetimestruct* dts,
+cdef inline int _string_to_dts(object val, npy_datetimestruct* dts,
                            int* out_local, int* out_tzoffset) except? -1:
     cdef int result
     cdef char *tmp
@@ -81,14 +81,14 @@ cdef inline int _string_to_dts(object val, pandas_datetimestruct* dts,
     return result
 
 cdef inline int _cstring_to_dts(char *val, int length,
-                                pandas_datetimestruct* dts,
+                                npy_datetimestruct* dts,
                                 int* out_local, int* out_tzoffset) except? -1:
     cdef:
         npy_bool special
-        PANDAS_DATETIMEUNIT out_bestunit
+        NPY_DATETIMEUNIT out_bestunit
         int result
 
-    result = parse_iso_8601_datetime(val, length, PANDAS_FR_ns,
+    result = parse_iso_8601_datetime(val, length, NPY_FR_ns,
                                      NPY_UNSAFE_CASTING,
                                      dts, out_local, out_tzoffset,
                                      &out_bestunit, &special)

--- a/pandas/_libs/src/datetime/np_datetime.c
+++ b/pandas/_libs/src/datetime/np_datetime.c
@@ -40,9 +40,9 @@ This file is derived from NumPy 1.7. See NUMPY_LICENSE.txt
 #define PyInt_AsUnsignedLongLongMask PyLong_AsUnsignedLongLongMask
 #endif
 
-const pandas_datetimestruct _NS_MIN_DTS = {
+const npy_datetimestruct _NS_MIN_DTS = {
     1677, 9, 21, 0, 12, 43, 145225, 0, 0};
-const pandas_datetimestruct _NS_MAX_DTS = {
+const npy_datetimestruct _NS_MAX_DTS = {
     2262, 4, 11, 23, 47, 16, 854775, 807000, 0};
 
 
@@ -74,7 +74,7 @@ int dayofweek(int y, int m, int d) {
  * Adjusts a datetimestruct based on a minutes offset. Assumes
  * the current values are valid.g
  */
-void add_minutes_to_datetimestruct(pandas_datetimestruct *dts, int minutes) {
+void add_minutes_to_datetimestruct(npy_datetimestruct *dts, int minutes) {
     int isleap;
 
     /* MINUTES */
@@ -123,7 +123,7 @@ void add_minutes_to_datetimestruct(pandas_datetimestruct *dts, int minutes) {
 /*
  * Calculates the days offset from the 1970 epoch.
  */
-npy_int64 get_datetimestruct_days(const pandas_datetimestruct *dts) {
+npy_int64 get_datetimestruct_days(const npy_datetimestruct *dts) {
     int i, month;
     npy_int64 year, days = 0;
     const int *month_lengths;
@@ -223,7 +223,7 @@ static npy_int64 days_to_yearsdays(npy_int64 *days_) {
  * Adjusts a datetimestruct based on a seconds offset. Assumes
  * the current values are valid.
  */
-NPY_NO_EXPORT void add_seconds_to_datetimestruct(pandas_datetimestruct *dts,
+NPY_NO_EXPORT void add_seconds_to_datetimestruct(npy_datetimestruct *dts,
                                                  int seconds) {
     int minutes;
 
@@ -248,7 +248,7 @@ NPY_NO_EXPORT void add_seconds_to_datetimestruct(pandas_datetimestruct *dts,
  * offset from 1970.
  */
 static void set_datetimestruct_days(npy_int64 days,
-                                    pandas_datetimestruct *dts) {
+                                    npy_datetimestruct *dts) {
     const int *month_lengths;
     int i;
 
@@ -267,10 +267,10 @@ static void set_datetimestruct_days(npy_int64 days,
 }
 
 /*
- * Compares two pandas_datetimestruct objects chronologically
+ * Compares two npy_datetimestruct objects chronologically
  */
-int cmp_pandas_datetimestruct(const pandas_datetimestruct *a,
-                              const pandas_datetimestruct *b) {
+int cmp_pandas_datetimestruct(const npy_datetimestruct *a,
+                              const npy_datetimestruct *b) {
     if (a->year > b->year) {
         return 1;
     } else if (a->year < b->year) {
@@ -331,7 +331,7 @@ int cmp_pandas_datetimestruct(const pandas_datetimestruct *a,
 /*
  *
  * Tests for and converts a Python datetime.datetime or datetime.date
- * object into a NumPy pandas_datetimestruct.
+ * object into a NumPy npy_datetimestruct.
  *
  * While the C API has PyDate_* and PyDateTime_* functions, the following
  * implementation just asks for attributes, and thus supports
@@ -348,14 +348,14 @@ int cmp_pandas_datetimestruct(const pandas_datetimestruct *a,
  * if obj doesn't have the neeeded date or datetime attributes.
  */
 int convert_pydatetime_to_datetimestruct(PyObject *obj,
-                                         pandas_datetimestruct *out,
-                                         PANDAS_DATETIMEUNIT *out_bestunit,
+                                         npy_datetimestruct *out,
+                                         NPY_DATETIMEUNIT *out_bestunit,
                                          int apply_tzinfo) {
     PyObject *tmp;
     int isleap;
 
     /* Initialize the output to all zeros */
-    memset(out, 0, sizeof(pandas_datetimestruct));
+    memset(out, 0, sizeof(npy_datetimestruct));
     out->month = 1;
     out->day = 1;
 
@@ -419,7 +419,7 @@ int convert_pydatetime_to_datetimestruct(PyObject *obj,
         !PyObject_HasAttrString(obj, "microsecond")) {
         /* The best unit for date is 'D' */
         if (out_bestunit != NULL) {
-            *out_bestunit = PANDAS_FR_D;
+            *out_bestunit = NPY_FR_D;
         }
         return 0;
     }
@@ -521,7 +521,7 @@ int convert_pydatetime_to_datetimestruct(PyObject *obj,
 
     /* The resolution of Python's datetime is 'us' */
     if (out_bestunit != NULL) {
-        *out_bestunit = PANDAS_FR_us;
+        *out_bestunit = NPY_FR_us;
     }
 
     return 0;
@@ -540,8 +540,8 @@ invalid_time:
     return -1;
 }
 
-npy_datetime pandas_datetimestruct_to_datetime(PANDAS_DATETIMEUNIT fr,
-                                               pandas_datetimestruct *d) {
+npy_datetime pandas_datetimestruct_to_datetime(NPY_DATETIMEUNIT fr,
+                                               npy_datetimestruct *d) {
     pandas_datetime_metadata meta;
     npy_datetime result = PANDAS_DATETIME_NAT;
 
@@ -552,8 +552,8 @@ npy_datetime pandas_datetimestruct_to_datetime(PANDAS_DATETIMEUNIT fr,
     return result;
 }
 
-void pandas_datetime_to_datetimestruct(npy_datetime val, PANDAS_DATETIMEUNIT fr,
-                                       pandas_datetimestruct *result) {
+void pandas_datetime_to_datetimestruct(npy_datetime val, NPY_DATETIMEUNIT fr,
+                                       npy_datetimestruct *result) {
     pandas_datetime_metadata meta;
 
     meta.base = fr;
@@ -563,7 +563,7 @@ void pandas_datetime_to_datetimestruct(npy_datetime val, PANDAS_DATETIMEUNIT fr,
 }
 
 void pandas_timedelta_to_timedeltastruct(npy_timedelta val,
-                                         PANDAS_DATETIMEUNIT fr,
+                                         NPY_DATETIMEUNIT fr,
                                           pandas_timedeltastruct *result) {
   pandas_datetime_metadata meta;
 
@@ -573,8 +573,8 @@ void pandas_timedelta_to_timedeltastruct(npy_timedelta val,
   convert_timedelta_to_timedeltastruct(&meta, val, result);
 }
 
-PANDAS_DATETIMEUNIT get_datetime64_unit(PyObject *obj) {
-    return (PANDAS_DATETIMEUNIT)((PyDatetimeScalarObject *)obj)->obmeta.base;
+NPY_DATETIMEUNIT get_datetime64_unit(PyObject *obj) {
+    return (NPY_DATETIMEUNIT)((PyDatetimeScalarObject *)obj)->obmeta.base;
 }
 
 /*
@@ -586,15 +586,15 @@ PANDAS_DATETIMEUNIT get_datetime64_unit(PyObject *obj) {
  * Returns 0 on success, -1 on failure.
  */
 int convert_datetimestruct_to_datetime(pandas_datetime_metadata *meta,
-                                       const pandas_datetimestruct *dts,
+                                       const npy_datetimestruct *dts,
                                        npy_datetime *out) {
     npy_datetime ret;
-    PANDAS_DATETIMEUNIT base = meta->base;
+    NPY_DATETIMEUNIT base = meta->base;
 
-    if (base == PANDAS_FR_Y) {
+    if (base == NPY_FR_Y) {
         /* Truncate to the year */
         ret = dts->year - 1970;
-    } else if (base == PANDAS_FR_M) {
+    } else if (base == NPY_FR_M) {
         /* Truncate to the month */
         ret = 12 * (dts->year - 1970) + (dts->month - 1);
     } else {
@@ -602,7 +602,7 @@ int convert_datetimestruct_to_datetime(pandas_datetime_metadata *meta,
         npy_int64 days = get_datetimestruct_days(dts);
 
         switch (base) {
-            case PANDAS_FR_W:
+            case NPY_FR_W:
                 /* Truncate to weeks */
                 if (days >= 0) {
                     ret = days / 7;
@@ -610,31 +610,31 @@ int convert_datetimestruct_to_datetime(pandas_datetime_metadata *meta,
                     ret = (days - 6) / 7;
                 }
                 break;
-            case PANDAS_FR_D:
+            case NPY_FR_D:
                 ret = days;
                 break;
-            case PANDAS_FR_h:
+            case NPY_FR_h:
                 ret = days * 24 + dts->hour;
                 break;
-            case PANDAS_FR_m:
+            case NPY_FR_m:
                 ret = (days * 24 + dts->hour) * 60 + dts->min;
                 break;
-            case PANDAS_FR_s:
+            case NPY_FR_s:
                 ret = ((days * 24 + dts->hour) * 60 + dts->min) * 60 + dts->sec;
                 break;
-            case PANDAS_FR_ms:
+            case NPY_FR_ms:
                 ret = (((days * 24 + dts->hour) * 60 + dts->min) * 60 +
                        dts->sec) *
                           1000 +
                       dts->us / 1000;
                 break;
-            case PANDAS_FR_us:
+            case NPY_FR_us:
                 ret = (((days * 24 + dts->hour) * 60 + dts->min) * 60 +
                        dts->sec) *
                           1000000 +
                       dts->us;
                 break;
-            case PANDAS_FR_ns:
+            case NPY_FR_ns:
                 ret = ((((days * 24 + dts->hour) * 60 + dts->min) * 60 +
                         dts->sec) *
                            1000000 +
@@ -642,7 +642,7 @@ int convert_datetimestruct_to_datetime(pandas_datetime_metadata *meta,
                           1000 +
                       dts->ps / 1000;
                 break;
-            case PANDAS_FR_ps:
+            case NPY_FR_ps:
                 ret = ((((days * 24 + dts->hour) * 60 + dts->min) * 60 +
                         dts->sec) *
                            1000000 +
@@ -650,7 +650,7 @@ int convert_datetimestruct_to_datetime(pandas_datetime_metadata *meta,
                           1000000 +
                       dts->ps;
                 break;
-            case PANDAS_FR_fs:
+            case NPY_FR_fs:
                 /* only 2.6 hours */
                 ret = (((((days * 24 + dts->hour) * 60 + dts->min) * 60 +
                          dts->sec) *
@@ -661,7 +661,7 @@ int convert_datetimestruct_to_datetime(pandas_datetime_metadata *meta,
                           1000 +
                       dts->as / 1000;
                 break;
-            case PANDAS_FR_as:
+            case NPY_FR_as:
                 /* only 9.2 secs */
                 ret = (((((days * 24 + dts->hour) * 60 + dts->min) * 60 +
                          dts->sec) *
@@ -701,8 +701,8 @@ int convert_datetimestruct_to_datetime(pandas_datetime_metadata *meta,
  * Notably, there is a barrier between the nonlinear years and
  * months units, and all the other units.
  */
-npy_bool can_cast_timedelta64_units(PANDAS_DATETIMEUNIT src_unit,
-                                    PANDAS_DATETIMEUNIT dst_unit,
+npy_bool can_cast_timedelta64_units(NPY_DATETIMEUNIT src_unit,
+                                    NPY_DATETIMEUNIT dst_unit,
                                     NPY_CASTING casting) {
     switch (casting) {
         /* Allow anything with unsafe casting */
@@ -714,8 +714,8 @@ npy_bool can_cast_timedelta64_units(PANDAS_DATETIMEUNIT src_unit,
          * 'same_kind' casting.
          */
         case NPY_SAME_KIND_CASTING:
-            return (src_unit <= PANDAS_FR_M && dst_unit <= PANDAS_FR_M) ||
-                   (src_unit > PANDAS_FR_M && dst_unit > PANDAS_FR_M);
+            return (src_unit <= NPY_FR_M && dst_unit <= NPY_FR_M) ||
+                   (src_unit > NPY_FR_M && dst_unit > NPY_FR_M);
 
         /*
          * Enforce the 'date units' vs 'time units' barrier and that
@@ -724,8 +724,8 @@ npy_bool can_cast_timedelta64_units(PANDAS_DATETIMEUNIT src_unit,
          */
         case NPY_SAFE_CASTING:
             return (src_unit <= dst_unit) &&
-                   ((src_unit <= PANDAS_FR_M && dst_unit <= PANDAS_FR_M) ||
-                    (src_unit > PANDAS_FR_M && dst_unit > PANDAS_FR_M));
+                   ((src_unit <= NPY_FR_M && dst_unit <= NPY_FR_M) ||
+                    (src_unit > NPY_FR_M && dst_unit > NPY_FR_M));
 
         /* Enforce equality with 'no' or 'equiv' casting */
         default:
@@ -739,8 +739,8 @@ npy_bool can_cast_timedelta64_units(PANDAS_DATETIMEUNIT src_unit,
  * Notably, there is a barrier between 'date units' and 'time units'
  * for all but 'unsafe' casting.
  */
-npy_bool can_cast_datetime64_units(PANDAS_DATETIMEUNIT src_unit,
-                                   PANDAS_DATETIMEUNIT dst_unit,
+npy_bool can_cast_datetime64_units(NPY_DATETIMEUNIT src_unit,
+                                   NPY_DATETIMEUNIT dst_unit,
                                    NPY_CASTING casting) {
     switch (casting) {
         /* Allow anything with unsafe casting */
@@ -752,8 +752,8 @@ npy_bool can_cast_datetime64_units(PANDAS_DATETIMEUNIT src_unit,
          * 'same_kind' casting.
          */
         case NPY_SAME_KIND_CASTING:
-            return (src_unit <= PANDAS_FR_D && dst_unit <= PANDAS_FR_D) ||
-                   (src_unit > PANDAS_FR_D && dst_unit > PANDAS_FR_D);
+            return (src_unit <= NPY_FR_D && dst_unit <= NPY_FR_D) ||
+                   (src_unit > NPY_FR_D && dst_unit > NPY_FR_D);
 
         /*
          * Enforce the 'date units' vs 'time units' barrier and that
@@ -762,8 +762,8 @@ npy_bool can_cast_datetime64_units(PANDAS_DATETIMEUNIT src_unit,
          */
         case NPY_SAFE_CASTING:
             return (src_unit <= dst_unit) &&
-                   ((src_unit <= PANDAS_FR_D && dst_unit <= PANDAS_FR_D) ||
-                    (src_unit > PANDAS_FR_D && dst_unit > PANDAS_FR_D));
+                   ((src_unit <= NPY_FR_D && dst_unit <= NPY_FR_D) ||
+                    (src_unit > NPY_FR_D && dst_unit > NPY_FR_D));
 
         /* Enforce equality with 'no' or 'equiv' casting */
         default:
@@ -776,11 +776,11 @@ npy_bool can_cast_datetime64_units(PANDAS_DATETIMEUNIT src_unit,
  */
 int convert_datetime_to_datetimestruct(pandas_datetime_metadata *meta,
                                        npy_datetime dt,
-                                       pandas_datetimestruct *out) {
+                                       npy_datetimestruct *out) {
     npy_int64 perday;
 
     /* Initialize the output to all zeros */
-    memset(out, 0, sizeof(pandas_datetimestruct));
+    memset(out, 0, sizeof(npy_datetimestruct));
     out->year = 1970;
     out->month = 1;
     out->day = 1;
@@ -793,11 +793,11 @@ int convert_datetime_to_datetimestruct(pandas_datetime_metadata *meta,
      * for negative values.
      */
     switch (meta->base) {
-        case PANDAS_FR_Y:
+        case NPY_FR_Y:
             out->year = 1970 + dt;
             break;
 
-        case PANDAS_FR_M:
+        case NPY_FR_M:
             if (dt >= 0) {
                 out->year = 1970 + dt / 12;
                 out->month = dt % 12 + 1;
@@ -807,16 +807,16 @@ int convert_datetime_to_datetimestruct(pandas_datetime_metadata *meta,
             }
             break;
 
-        case PANDAS_FR_W:
+        case NPY_FR_W:
             /* A week is 7 days */
             set_datetimestruct_days(dt * 7, out);
             break;
 
-        case PANDAS_FR_D:
+        case NPY_FR_D:
             set_datetimestruct_days(dt, out);
             break;
 
-        case PANDAS_FR_h:
+        case NPY_FR_h:
             perday = 24LL;
 
             if (dt >= 0) {
@@ -830,7 +830,7 @@ int convert_datetime_to_datetimestruct(pandas_datetime_metadata *meta,
             out->hour = dt;
             break;
 
-        case PANDAS_FR_m:
+        case NPY_FR_m:
             perday = 24LL * 60;
 
             if (dt >= 0) {
@@ -845,7 +845,7 @@ int convert_datetime_to_datetimestruct(pandas_datetime_metadata *meta,
             out->min = dt % 60;
             break;
 
-        case PANDAS_FR_s:
+        case NPY_FR_s:
             perday = 24LL * 60 * 60;
 
             if (dt >= 0) {
@@ -861,7 +861,7 @@ int convert_datetime_to_datetimestruct(pandas_datetime_metadata *meta,
             out->sec = dt % 60;
             break;
 
-        case PANDAS_FR_ms:
+        case NPY_FR_ms:
             perday = 24LL * 60 * 60 * 1000;
 
             if (dt >= 0) {
@@ -878,7 +878,7 @@ int convert_datetime_to_datetimestruct(pandas_datetime_metadata *meta,
             out->us = (dt % 1000LL) * 1000;
             break;
 
-        case PANDAS_FR_us:
+        case NPY_FR_us:
             perday = 24LL * 60LL * 60LL * 1000LL * 1000LL;
 
             if (dt >= 0) {
@@ -895,7 +895,7 @@ int convert_datetime_to_datetimestruct(pandas_datetime_metadata *meta,
             out->us = dt % 1000000LL;
             break;
 
-        case PANDAS_FR_ns:
+        case NPY_FR_ns:
             perday = 24LL * 60LL * 60LL * 1000LL * 1000LL * 1000LL;
 
             if (dt >= 0) {
@@ -913,7 +913,7 @@ int convert_datetime_to_datetimestruct(pandas_datetime_metadata *meta,
             out->ps = (dt % 1000LL) * 1000;
             break;
 
-        case PANDAS_FR_ps:
+        case NPY_FR_ps:
             perday = 24LL * 60 * 60 * 1000 * 1000 * 1000 * 1000;
 
             if (dt >= 0) {
@@ -931,7 +931,7 @@ int convert_datetime_to_datetimestruct(pandas_datetime_metadata *meta,
             out->ps = dt % 1000000LL;
             break;
 
-        case PANDAS_FR_fs:
+        case NPY_FR_fs:
             /* entire range is only +- 2.6 hours */
             if (dt >= 0) {
                 out->hour = dt / (60 * 60 * 1000000000000000LL);
@@ -958,7 +958,7 @@ int convert_datetime_to_datetimestruct(pandas_datetime_metadata *meta,
             }
             break;
 
-        case PANDAS_FR_as:
+        case NPY_FR_as:
             /* entire range is only +- 9.2 seconds */
             if (dt >= 0) {
                 out->sec = (dt / 1000000000000000000LL) % 60;
@@ -1012,7 +1012,7 @@ int convert_timedelta_to_timedeltastruct(pandas_timedelta_metadata *meta,
     memset(out, 0, sizeof(pandas_timedeltastruct));
 
     switch (meta->base) {
-        case PANDAS_FR_ns:
+        case NPY_FR_ns:
 
         // put frac in seconds
         if (td < 0 && td % (1000LL * 1000LL * 1000LL) != 0)

--- a/pandas/_libs/src/datetime/np_datetime.h
+++ b/pandas/_libs/src/datetime/np_datetime.h
@@ -19,24 +19,6 @@ This file is derived from NumPy 1.7. See NUMPY_LICENSE.txt
 
 #include <numpy/ndarraytypes.h>
 
-typedef enum {
-        PANDAS_FR_Y = 0,  // Years
-        PANDAS_FR_M = 1,  // Months
-        PANDAS_FR_W = 2,  // Weeks
-        // Gap where NPY_FR_B was
-        PANDAS_FR_D = 4,  // Days
-        PANDAS_FR_h = 5,  // hours
-        PANDAS_FR_m = 6,  // minutes
-        PANDAS_FR_s = 7,  // seconds
-        PANDAS_FR_ms = 8,  // milliseconds
-        PANDAS_FR_us = 9,  // microseconds
-        PANDAS_FR_ns = 10,  // nanoseconds
-        PANDAS_FR_ps = 11,  // picoseconds
-        PANDAS_FR_fs = 12,  // femtoseconds
-        PANDAS_FR_as = 13,  // attoseconds
-        PANDAS_FR_GENERIC = 14  // Generic, unbound units, can
-                                // convert to anything
-} PANDAS_DATETIMEUNIT;
 
 #define PANDAS_DATETIME_NUMUNITS 13
 
@@ -44,10 +26,6 @@ typedef enum {
 
 #define PANDAS_DATETIME_NAT NPY_MIN_INT64
 
-typedef struct {
-        npy_int64 year;
-        npy_int32 month, day, hour, min, sec, us, ps, as;
-} pandas_datetimestruct;
 
 typedef struct {
         npy_int64 days;
@@ -55,31 +33,31 @@ typedef struct {
 } pandas_timedeltastruct;
 
 typedef struct {
-    PANDAS_DATETIMEUNIT base;
+    NPY_DATETIMEUNIT base;
     int num;
 } pandas_datetime_metadata;
 
 typedef pandas_datetime_metadata pandas_timedelta_metadata;
 
-extern const pandas_datetimestruct _NS_MIN_DTS;
-extern const pandas_datetimestruct _NS_MAX_DTS;
+extern const npy_datetimestruct _NS_MIN_DTS;
+extern const npy_datetimestruct _NS_MAX_DTS;
 
 // stuff pandas needs
 // ----------------------------------------------------------------------------
 
 int convert_pydatetime_to_datetimestruct(PyObject *obj,
-                                         pandas_datetimestruct *out,
-                                         PANDAS_DATETIMEUNIT *out_bestunit,
+                                         npy_datetimestruct *out,
+                                         NPY_DATETIMEUNIT *out_bestunit,
                                          int apply_tzinfo);
 
-npy_datetime pandas_datetimestruct_to_datetime(PANDAS_DATETIMEUNIT fr,
-                                               pandas_datetimestruct *d);
+npy_datetime pandas_datetimestruct_to_datetime(NPY_DATETIMEUNIT fr,
+                                               npy_datetimestruct *d);
 
-void pandas_datetime_to_datetimestruct(npy_datetime val, PANDAS_DATETIMEUNIT fr,
-                                       pandas_datetimestruct *result);
+void pandas_datetime_to_datetimestruct(npy_datetime val, NPY_DATETIMEUNIT fr,
+                                       npy_datetimestruct *result);
 
 void pandas_timedelta_to_timedeltastruct(npy_timedelta val,
-                                         PANDAS_DATETIMEUNIT fr,
+                                         NPY_DATETIMEUNIT fr,
                                          pandas_timedeltastruct *result);
 
 int dayofweek(int y, int m, int d);
@@ -101,21 +79,21 @@ int is_leapyear(npy_int64 year);
  */
 int
 convert_datetimestruct_to_datetime(pandas_datetime_metadata *meta,
-                                   const pandas_datetimestruct *dts,
+                                   const npy_datetimestruct *dts,
                                    npy_datetime *out);
 
 /*
  * Calculates the days offset from the 1970 epoch.
  */
 npy_int64
-get_datetimestruct_days(const pandas_datetimestruct *dts);
+get_datetimestruct_days(const npy_datetimestruct *dts);
 
 
 /*
- * Compares two pandas_datetimestruct objects chronologically
+ * Compares two npy_datetimestruct objects chronologically
  */
-int cmp_pandas_datetimestruct(const pandas_datetimestruct *a,
-                              const pandas_datetimestruct *b);
+int cmp_pandas_datetimestruct(const npy_datetimestruct *a,
+                              const npy_datetimestruct *b);
 
 
 /*
@@ -123,7 +101,7 @@ int cmp_pandas_datetimestruct(const pandas_datetimestruct *a,
  * the current values are valid.
  */
 void
-add_minutes_to_datetimestruct(pandas_datetimestruct *dts, int minutes);
+add_minutes_to_datetimestruct(npy_datetimestruct *dts, int minutes);
 
 /*
  * This provides the casting rules for the TIMEDELTA data type units.
@@ -132,15 +110,15 @@ add_minutes_to_datetimestruct(pandas_datetimestruct *dts, int minutes);
  * months units, and all the other units.
  */
 npy_bool
-can_cast_datetime64_units(PANDAS_DATETIMEUNIT src_unit,
-                          PANDAS_DATETIMEUNIT dst_unit,
+can_cast_datetime64_units(NPY_DATETIMEUNIT src_unit,
+                          NPY_DATETIMEUNIT dst_unit,
                           NPY_CASTING casting);
 
 
 int
 convert_datetime_to_datetimestruct(pandas_datetime_metadata *meta,
                                    npy_datetime dt,
-                                   pandas_datetimestruct *out);
+                                   npy_datetimestruct *out);
 
 int
 convert_timedelta_to_timedeltastruct(pandas_timedelta_metadata *meta,
@@ -148,7 +126,7 @@ convert_timedelta_to_timedeltastruct(pandas_timedelta_metadata *meta,
                                      pandas_timedeltastruct *out);
 
 
-PANDAS_DATETIMEUNIT get_datetime64_unit(PyObject *obj);
+NPY_DATETIMEUNIT get_datetime64_unit(PyObject *obj);
 
 
 #endif  // PANDAS__LIBS_SRC_DATETIME_NP_DATETIME_H_

--- a/pandas/_libs/src/datetime/np_datetime_strings.c
+++ b/pandas/_libs/src/datetime/np_datetime_strings.c
@@ -168,7 +168,7 @@ fail:
  * Returns 0 on success, -1 on failure.
  */
 static int convert_datetimestruct_utc_to_local(
-    pandas_datetimestruct *out_dts_local, const pandas_datetimestruct *dts_utc,
+    npy_datetimestruct *out_dts_local, const npy_datetimestruct *dts_utc,
     int *out_timezone_offset) {
     NPY_TIME_T rawtime = 0, localrawtime;
     struct tm tm_;
@@ -193,7 +193,7 @@ static int convert_datetimestruct_utc_to_local(
     /*
      * Convert everything in 'dts' to a time_t, to minutes precision.
      * This is POSIX time, which skips leap-seconds, but because
-     * we drop the seconds value from the pandas_datetimestruct, everything
+     * we drop the seconds value from the npy_datetimestruct, everything
      * is ok for this operation.
      */
     rawtime = (time_t)get_datetimestruct_days(out_dts_local) * 24 * 60 * 60;
@@ -233,8 +233,8 @@ static int convert_datetimestruct_utc_to_local(
  * Returns 0 on success, -1 on failure.
  */
 static int
-convert_datetimestruct_local_to_utc(pandas_datetimestruct *out_dts_utc,
-                const pandas_datetimestruct *dts_local) {
+convert_datetimestruct_local_to_utc(npy_datetimestruct *out_dts_utc,
+                const npy_datetimestruct *dts_local) {
     npy_int64 year_correction = 0;
 
     /* Make a copy of the input 'dts' to modify */
@@ -302,11 +302,11 @@ convert_datetimestruct_local_to_utc(pandas_datetimestruct *out_dts_utc,
 #endif
 
 /* int */
-/* parse_python_string(PyObject* obj, pandas_datetimestruct *dts) { */
+/* parse_python_string(PyObject* obj, npy_datetimestruct *dts) { */
 /*     PyObject *bytes = NULL; */
 /*     char *str = NULL; */
 /*     Py_ssize_t len = 0; */
-/*     PANDAS_DATETIMEUNIT bestunit = -1; */
+/*     NPY_DATETIMEUNIT bestunit = -1; */
 
 /*     /\* Convert to an ASCII string for the date parser *\/ */
 /*     if (PyUnicode_Check(obj)) { */
@@ -325,7 +325,7 @@ convert_datetimestruct_local_to_utc(pandas_datetimestruct *out_dts_utc,
 /*     } */
 
 /*     /\* Parse the ISO date *\/ */
-/*     if (parse_iso_8601_datetime(str, len, PANDAS_FR_us, NPY_UNSAFE_CASTING,
+/*     if (parse_iso_8601_datetime(str, len, NPY_FR_us, NPY_UNSAFE_CASTING,
  */
 /*                             dts, NULL, &bestunit, NULL) < 0) { */
 /*         Py_DECREF(bytes); */
@@ -374,15 +374,15 @@ convert_datetimestruct_local_to_utc(pandas_datetimestruct *out_dts_utc,
  *
  * Returns 0 on success, -1 on failure.
  */
-int parse_iso_8601_datetime(char *str, int len, PANDAS_DATETIMEUNIT unit,
-                            NPY_CASTING casting, pandas_datetimestruct *out,
+int parse_iso_8601_datetime(char *str, int len, NPY_DATETIMEUNIT unit,
+                            NPY_CASTING casting, npy_datetimestruct *out,
                             int *out_local, int *out_tzoffset,
-                            PANDAS_DATETIMEUNIT *out_bestunit,
+                            NPY_DATETIMEUNIT *out_bestunit,
                             npy_bool *out_special) {
     int year_leap = 0;
     int i, numdigits;
     char *substr, sublen;
-    PANDAS_DATETIMEUNIT bestunit;
+    NPY_DATETIMEUNIT bestunit;
 
     /* If year-month-day are separated by a valid separator,
      * months/days without leading zeroes will be parsed
@@ -401,7 +401,7 @@ int parse_iso_8601_datetime(char *str, int len, PANDAS_DATETIMEUNIT unit,
     int hour_was_2_digits = 0;
 
     /* Initialize the output to all zeros */
-    memset(out, 0, sizeof(pandas_datetimestruct));
+    memset(out, 0, sizeof(npy_datetimestruct));
     out->month = 1;
     out->day = 1;
 
@@ -428,7 +428,7 @@ int parse_iso_8601_datetime(char *str, int len, PANDAS_DATETIMEUNIT unit,
         out->month = tm_.tm_mon + 1;
         out->day = tm_.tm_mday;
 
-        bestunit = PANDAS_FR_D;
+        bestunit = NPY_FR_D;
 
         /*
          * Indicate that this was a special value, and
@@ -466,10 +466,10 @@ int parse_iso_8601_datetime(char *str, int len, PANDAS_DATETIMEUNIT unit,
         time(&rawtime);
 
         /* Set up a dummy metadata for the conversion */
-        meta.base = PANDAS_FR_s;
+        meta.base = NPY_FR_s;
         meta.num = 1;
 
-        bestunit = PANDAS_FR_s;
+        bestunit = NPY_FR_s;
 
         /*
          * Indicate that this was a special value, and
@@ -546,7 +546,7 @@ int parse_iso_8601_datetime(char *str, int len, PANDAS_DATETIMEUNIT unit,
         if (out_local != NULL) {
             *out_local = 0;
         }
-        bestunit = PANDAS_FR_Y;
+        bestunit = NPY_FR_Y;
         goto finish;
     }
 
@@ -597,7 +597,7 @@ int parse_iso_8601_datetime(char *str, int len, PANDAS_DATETIMEUNIT unit,
         if (out_local != NULL) {
             *out_local = 0;
         }
-        bestunit = PANDAS_FR_M;
+        bestunit = NPY_FR_M;
         goto finish;
     }
 
@@ -638,7 +638,7 @@ int parse_iso_8601_datetime(char *str, int len, PANDAS_DATETIMEUNIT unit,
         if (out_local != NULL) {
             *out_local = 0;
         }
-        bestunit = PANDAS_FR_D;
+        bestunit = NPY_FR_D;
         goto finish;
     }
 
@@ -674,7 +674,7 @@ int parse_iso_8601_datetime(char *str, int len, PANDAS_DATETIMEUNIT unit,
         if (!hour_was_2_digits) {
             goto parse_error;
         }
-        bestunit = PANDAS_FR_h;
+        bestunit = NPY_FR_h;
         goto finish;
     }
 
@@ -690,7 +690,7 @@ int parse_iso_8601_datetime(char *str, int len, PANDAS_DATETIMEUNIT unit,
         if (!hour_was_2_digits) {
             goto parse_error;
         }
-        bestunit = PANDAS_FR_h;
+        bestunit = NPY_FR_h;
         goto parse_timezone;
     }
 
@@ -714,7 +714,7 @@ int parse_iso_8601_datetime(char *str, int len, PANDAS_DATETIMEUNIT unit,
     }
 
     if (sublen == 0) {
-        bestunit = PANDAS_FR_m;
+        bestunit = NPY_FR_m;
         goto finish;
     }
 
@@ -729,7 +729,7 @@ int parse_iso_8601_datetime(char *str, int len, PANDAS_DATETIMEUNIT unit,
         }
     } else if (!has_hms_sep && isdigit(*substr)) {
     } else {
-        bestunit = PANDAS_FR_m;
+        bestunit = NPY_FR_m;
         goto parse_timezone;
     }
 
@@ -757,7 +757,7 @@ int parse_iso_8601_datetime(char *str, int len, PANDAS_DATETIMEUNIT unit,
         ++substr;
         --sublen;
     } else {
-        bestunit = PANDAS_FR_s;
+        bestunit = NPY_FR_s;
         goto parse_timezone;
     }
 
@@ -775,9 +775,9 @@ int parse_iso_8601_datetime(char *str, int len, PANDAS_DATETIMEUNIT unit,
 
     if (sublen == 0 || !isdigit(*substr)) {
         if (numdigits > 3) {
-            bestunit = PANDAS_FR_us;
+            bestunit = NPY_FR_us;
         } else {
-            bestunit = PANDAS_FR_ms;
+            bestunit = NPY_FR_ms;
         }
         goto parse_timezone;
     }
@@ -796,9 +796,9 @@ int parse_iso_8601_datetime(char *str, int len, PANDAS_DATETIMEUNIT unit,
 
     if (sublen == 0 || !isdigit(*substr)) {
         if (numdigits > 3) {
-            bestunit = PANDAS_FR_ps;
+            bestunit = NPY_FR_ps;
         } else {
-            bestunit = PANDAS_FR_ns;
+            bestunit = NPY_FR_ns;
         }
         goto parse_timezone;
     }
@@ -816,9 +816,9 @@ int parse_iso_8601_datetime(char *str, int len, PANDAS_DATETIMEUNIT unit,
     }
 
     if (numdigits > 3) {
-        bestunit = PANDAS_FR_as;
+        bestunit = NPY_FR_as;
     } else {
-        bestunit = PANDAS_FR_fs;
+        bestunit = NPY_FR_fs;
     }
 
 parse_timezone:
@@ -967,37 +967,37 @@ error:
  * Provides a string length to use for converting datetime
  * objects with the given local and unit settings.
  */
-int get_datetime_iso_8601_strlen(int local, PANDAS_DATETIMEUNIT base) {
+int get_datetime_iso_8601_strlen(int local, NPY_DATETIMEUNIT base) {
     int len = 0;
 
     switch (base) {
         /* Generic units can only be used to represent NaT */
-        /*case PANDAS_FR_GENERIC:*/
+        /*case NPY_FR_GENERIC:*/
         /*    return 4;*/
-        case PANDAS_FR_as:
+        case NPY_FR_as:
             len += 3; /* "###" */
-        case PANDAS_FR_fs:
+        case NPY_FR_fs:
             len += 3; /* "###" */
-        case PANDAS_FR_ps:
+        case NPY_FR_ps:
             len += 3; /* "###" */
-        case PANDAS_FR_ns:
+        case NPY_FR_ns:
             len += 3; /* "###" */
-        case PANDAS_FR_us:
+        case NPY_FR_us:
             len += 3; /* "###" */
-        case PANDAS_FR_ms:
+        case NPY_FR_ms:
             len += 4; /* ".###" */
-        case PANDAS_FR_s:
+        case NPY_FR_s:
             len += 3; /* ":##" */
-        case PANDAS_FR_m:
+        case NPY_FR_m:
             len += 3; /* ":##" */
-        case PANDAS_FR_h:
+        case NPY_FR_h:
             len += 3; /* "T##" */
-        case PANDAS_FR_D:
-        case PANDAS_FR_W:
+        case NPY_FR_D:
+        case NPY_FR_W:
             len += 3; /* "-##" */
-        case PANDAS_FR_M:
+        case NPY_FR_M:
             len += 3; /* "-##" */
-        case PANDAS_FR_Y:
+        case NPY_FR_Y:
             len += 21; /* 64-bit year */
             break;
         default:
@@ -1005,7 +1005,7 @@ int get_datetime_iso_8601_strlen(int local, PANDAS_DATETIMEUNIT base) {
             break;
     }
 
-    if (base >= PANDAS_FR_h) {
+    if (base >= NPY_FR_h) {
         if (local) {
             len += 5; /* "+####" or "-####" */
         } else {
@@ -1022,37 +1022,37 @@ int get_datetime_iso_8601_strlen(int local, PANDAS_DATETIMEUNIT base) {
  * Finds the largest unit whose value is nonzero, and for which
  * the remainder for the rest of the units is zero.
  */
-static PANDAS_DATETIMEUNIT lossless_unit_from_datetimestruct(
-    pandas_datetimestruct *dts) {
+static NPY_DATETIMEUNIT lossless_unit_from_datetimestruct(
+    npy_datetimestruct *dts) {
     if (dts->as % 1000 != 0) {
-        return PANDAS_FR_as;
+        return NPY_FR_as;
     } else if (dts->as != 0) {
-        return PANDAS_FR_fs;
+        return NPY_FR_fs;
     } else if (dts->ps % 1000 != 0) {
-        return PANDAS_FR_ps;
+        return NPY_FR_ps;
     } else if (dts->ps != 0) {
-        return PANDAS_FR_ns;
+        return NPY_FR_ns;
     } else if (dts->us % 1000 != 0) {
-        return PANDAS_FR_us;
+        return NPY_FR_us;
     } else if (dts->us != 0) {
-        return PANDAS_FR_ms;
+        return NPY_FR_ms;
     } else if (dts->sec != 0) {
-        return PANDAS_FR_s;
+        return NPY_FR_s;
     } else if (dts->min != 0) {
-        return PANDAS_FR_m;
+        return NPY_FR_m;
     } else if (dts->hour != 0) {
-        return PANDAS_FR_h;
+        return NPY_FR_h;
     } else if (dts->day != 1) {
-        return PANDAS_FR_D;
+        return NPY_FR_D;
     } else if (dts->month != 1) {
-        return PANDAS_FR_M;
+        return NPY_FR_M;
     } else {
-        return PANDAS_FR_Y;
+        return NPY_FR_Y;
     }
 }
 
 /*
- * Converts an pandas_datetimestruct to an (almost) ISO 8601
+ * Converts an npy_datetimestruct to an (almost) ISO 8601
  * NULL-terminated string. If the string fits in the space exactly,
  * it leaves out the NULL terminator and returns success.
  *
@@ -1077,10 +1077,10 @@ static PANDAS_DATETIMEUNIT lossless_unit_from_datetimestruct(
  *  Returns 0 on success, -1 on failure (for example if the output
  *  string was too short).
  */
-int make_iso_8601_datetime(pandas_datetimestruct *dts, char *outstr, int outlen,
-                           int local, PANDAS_DATETIMEUNIT base, int tzoffset,
+int make_iso_8601_datetime(npy_datetimestruct *dts, char *outstr, int outlen,
+                           int local, NPY_DATETIMEUNIT base, int tzoffset,
                            NPY_CASTING casting) {
-    pandas_datetimestruct dts_local;
+    npy_datetimestruct dts_local;
     int timezone_offset = 0;
 
     char *substr = outstr, sublen = outlen;
@@ -1097,8 +1097,8 @@ int make_iso_8601_datetime(pandas_datetimestruct *dts, char *outstr, int outlen,
      * TODO: Could print weeks with YYYY-Www format if the week
      *       epoch is a Monday.
      */
-    if (base == PANDAS_FR_W) {
-        base = PANDAS_FR_D;
+    if (base == NPY_FR_W) {
+        base = NPY_FR_D;
     }
 
     /* Use the C API to convert from UTC to local time */
@@ -1112,7 +1112,7 @@ int make_iso_8601_datetime(pandas_datetimestruct *dts, char *outstr, int outlen,
         dts = &dts_local;
     } else if (local) {
         // Use the manually provided tzoffset.
-        // Make a copy of the pandas_datetimestruct we can modify.
+        // Make a copy of the npy_datetimestruct we can modify.
         dts_local = *dts;
         dts = &dts_local;
 
@@ -1128,7 +1128,7 @@ int make_iso_8601_datetime(pandas_datetimestruct *dts, char *outstr, int outlen,
      */
     if (casting != NPY_UNSAFE_CASTING) {
         /* Producing a date as a local time is always 'unsafe' */
-        if (base <= PANDAS_FR_D && local) {
+        if (base <= NPY_FR_D && local) {
             PyErr_SetString(PyExc_TypeError,
                             "Cannot create a local "
                             "timezone-based date string from a NumPy "
@@ -1136,7 +1136,7 @@ int make_iso_8601_datetime(pandas_datetimestruct *dts, char *outstr, int outlen,
             return -1;
         } else {
             /* Only 'unsafe' and 'same_kind' allow data loss */
-            PANDAS_DATETIMEUNIT unitprec;
+            NPY_DATETIMEUNIT unitprec;
 
             unitprec = lossless_unit_from_datetimestruct(dts);
             if (casting != NPY_SAME_KIND_CASTING && unitprec > base) {
@@ -1172,7 +1172,7 @@ int make_iso_8601_datetime(pandas_datetimestruct *dts, char *outstr, int outlen,
     sublen -= tmplen;
 
     /* Stop if the unit is years */
-    if (base == PANDAS_FR_Y) {
+    if (base == NPY_FR_Y) {
         if (sublen > 0) {
             *substr = '\0';
         }
@@ -1196,7 +1196,7 @@ int make_iso_8601_datetime(pandas_datetimestruct *dts, char *outstr, int outlen,
     sublen -= 3;
 
     /* Stop if the unit is months */
-    if (base == PANDAS_FR_M) {
+    if (base == NPY_FR_M) {
         if (sublen > 0) {
             *substr = '\0';
         }
@@ -1220,7 +1220,7 @@ int make_iso_8601_datetime(pandas_datetimestruct *dts, char *outstr, int outlen,
     sublen -= 3;
 
     /* Stop if the unit is days */
-    if (base == PANDAS_FR_D) {
+    if (base == NPY_FR_D) {
         if (sublen > 0) {
             *substr = '\0';
         }
@@ -1244,7 +1244,7 @@ int make_iso_8601_datetime(pandas_datetimestruct *dts, char *outstr, int outlen,
     sublen -= 3;
 
     /* Stop if the unit is hours */
-    if (base == PANDAS_FR_h) {
+    if (base == NPY_FR_h) {
         goto add_time_zone;
     }
 
@@ -1265,7 +1265,7 @@ int make_iso_8601_datetime(pandas_datetimestruct *dts, char *outstr, int outlen,
     sublen -= 3;
 
     /* Stop if the unit is minutes */
-    if (base == PANDAS_FR_m) {
+    if (base == NPY_FR_m) {
         goto add_time_zone;
     }
 
@@ -1286,7 +1286,7 @@ int make_iso_8601_datetime(pandas_datetimestruct *dts, char *outstr, int outlen,
     sublen -= 3;
 
     /* Stop if the unit is seconds */
-    if (base == PANDAS_FR_s) {
+    if (base == NPY_FR_s) {
         goto add_time_zone;
     }
 
@@ -1311,7 +1311,7 @@ int make_iso_8601_datetime(pandas_datetimestruct *dts, char *outstr, int outlen,
     sublen -= 4;
 
     /* Stop if the unit is milliseconds */
-    if (base == PANDAS_FR_ms) {
+    if (base == NPY_FR_ms) {
         goto add_time_zone;
     }
 
@@ -1332,7 +1332,7 @@ int make_iso_8601_datetime(pandas_datetimestruct *dts, char *outstr, int outlen,
     sublen -= 3;
 
     /* Stop if the unit is microseconds */
-    if (base == PANDAS_FR_us) {
+    if (base == NPY_FR_us) {
         goto add_time_zone;
     }
 
@@ -1353,7 +1353,7 @@ int make_iso_8601_datetime(pandas_datetimestruct *dts, char *outstr, int outlen,
     sublen -= 3;
 
     /* Stop if the unit is nanoseconds */
-    if (base == PANDAS_FR_ns) {
+    if (base == NPY_FR_ns) {
         goto add_time_zone;
     }
 
@@ -1374,7 +1374,7 @@ int make_iso_8601_datetime(pandas_datetimestruct *dts, char *outstr, int outlen,
     sublen -= 3;
 
     /* Stop if the unit is picoseconds */
-    if (base == PANDAS_FR_ps) {
+    if (base == NPY_FR_ps) {
         goto add_time_zone;
     }
 
@@ -1395,7 +1395,7 @@ int make_iso_8601_datetime(pandas_datetimestruct *dts, char *outstr, int outlen,
     sublen -= 3;
 
     /* Stop if the unit is femtoseconds */
-    if (base == PANDAS_FR_fs) {
+    if (base == NPY_FR_fs) {
         goto add_time_zone;
     }
 

--- a/pandas/_libs/src/datetime/np_datetime_strings.h
+++ b/pandas/_libs/src/datetime/np_datetime_strings.h
@@ -61,12 +61,12 @@ This file implements string parsing and creation for NumPy datetime.
  */
 int
 parse_iso_8601_datetime(char *str, int len,
-                    PANDAS_DATETIMEUNIT unit,
+                    NPY_DATETIMEUNIT unit,
                     NPY_CASTING casting,
-                    pandas_datetimestruct *out,
+                    npy_datetimestruct *out,
                     int *out_local,
                     int *out_tzoffset,
-                    PANDAS_DATETIMEUNIT *out_bestunit,
+                    NPY_DATETIMEUNIT *out_bestunit,
                     npy_bool *out_special);
 
 /*
@@ -74,10 +74,10 @@ parse_iso_8601_datetime(char *str, int len,
  * objects with the given local and unit settings.
  */
 int
-get_datetime_iso_8601_strlen(int local, PANDAS_DATETIMEUNIT base);
+get_datetime_iso_8601_strlen(int local, NPY_DATETIMEUNIT base);
 
 /*
- * Converts an pandas_datetimestruct to an (almost) ISO 8601
+ * Converts an npy_datetimestruct to an (almost) ISO 8601
  * NULL-terminated string.
  *
  * If 'local' is non-zero, it produces a string in local time with
@@ -99,8 +99,8 @@ get_datetime_iso_8601_strlen(int local, PANDAS_DATETIMEUNIT base);
  *  string was too short).
  */
 int
-make_iso_8601_datetime(pandas_datetimestruct *dts, char *outstr, int outlen,
-                    int local, PANDAS_DATETIMEUNIT base, int tzoffset,
+make_iso_8601_datetime(npy_datetimestruct *dts, char *outstr, int outlen,
+                    int local, NPY_DATETIMEUNIT base, int tzoffset,
                     NPY_CASTING casting);
 
 #endif  // PANDAS__LIBS_SRC_DATETIME_NP_DATETIME_STRINGS_H_

--- a/pandas/_libs/src/ujson/python/objToJSON.c
+++ b/pandas/_libs/src/ujson/python/objToJSON.c
@@ -137,7 +137,7 @@ typedef struct __PyObjectEncoder {
     TypeContext basicTypeContext;
 
     int datetimeIso;
-    PANDAS_DATETIMEUNIT datetimeUnit;
+    NPY_DATETIMEUNIT datetimeUnit;
 
     // output format style for pandas data types
     int outputFormat;
@@ -440,10 +440,10 @@ static void *PyUnicodeToUTF8(JSOBJ _obj, JSONTypeContext *tc, void *outValue,
     return PyString_AS_STRING(newObj);
 }
 
-static void *PandasDateTimeStructToJSON(pandas_datetimestruct *dts,
+static void *PandasDateTimeStructToJSON(npy_datetimestruct *dts,
                                         JSONTypeContext *tc, void *outValue,
                                         size_t *_outLen) {
-    PANDAS_DATETIMEUNIT base = ((PyObjectEncoder *)tc->encoder)->datetimeUnit;
+    NPY_DATETIMEUNIT base = ((PyObjectEncoder *)tc->encoder)->datetimeUnit;
 
     if (((PyObjectEncoder *)tc->encoder)->datetimeIso) {
         PRINTMARK();
@@ -477,18 +477,18 @@ static void *PandasDateTimeStructToJSON(pandas_datetimestruct *dts,
 
 static void *NpyDateTimeScalarToJSON(JSOBJ _obj, JSONTypeContext *tc,
                                      void *outValue, size_t *_outLen) {
-    pandas_datetimestruct dts;
+    npy_datetimestruct dts;
     PyDatetimeScalarObject *obj = (PyDatetimeScalarObject *)_obj;
     PRINTMARK();
 
     pandas_datetime_to_datetimestruct(
-        obj->obval, (PANDAS_DATETIMEUNIT)obj->obmeta.base, &dts);
+        obj->obval, (NPY_DATETIMEUNIT)obj->obmeta.base, &dts);
     return PandasDateTimeStructToJSON(&dts, tc, outValue, _outLen);
 }
 
 static void *PyDateTimeToJSON(JSOBJ _obj, JSONTypeContext *tc, void *outValue,
                               size_t *_outLen) {
-    pandas_datetimestruct dts;
+    npy_datetimestruct dts;
     PyObject *obj = (PyObject *)_obj;
 
     PRINTMARK();
@@ -508,11 +508,11 @@ static void *PyDateTimeToJSON(JSOBJ _obj, JSONTypeContext *tc, void *outValue,
 
 static void *NpyDatetime64ToJSON(JSOBJ _obj, JSONTypeContext *tc,
                                  void *outValue, size_t *_outLen) {
-    pandas_datetimestruct dts;
+    npy_datetimestruct dts;
     PRINTMARK();
 
     pandas_datetime_to_datetimestruct((npy_datetime)GET_TC(tc)->longValue,
-                                      PANDAS_FR_ns, &dts);
+                                      NPY_FR_ns, &dts);
     return PandasDateTimeStructToJSON(&dts, tc, outValue, _outLen);
 }
 
@@ -1864,15 +1864,15 @@ void Object_beginTypeContext(JSOBJ _obj, JSONTypeContext *tc) {
 
         base = ((PyObjectEncoder *)tc->encoder)->datetimeUnit;
         switch (base) {
-            case PANDAS_FR_ns:
+            case NPY_FR_ns:
                 break;
-            case PANDAS_FR_us:
+            case NPY_FR_us:
                 value /= 1000LL;
                 break;
-            case PANDAS_FR_ms:
+            case NPY_FR_ms:
                 value /= 1000000LL;
                 break;
-            case PANDAS_FR_s:
+            case NPY_FR_s:
                 value /= 1000000000LL;
                 break;
         }
@@ -2358,7 +2358,7 @@ PyObject *objToJSON(PyObject *self, PyObject *args, PyObject *kwargs) {
     pyEncoder.npyType = -1;
     pyEncoder.npyValue = NULL;
     pyEncoder.datetimeIso = 0;
-    pyEncoder.datetimeUnit = PANDAS_FR_ms;
+    pyEncoder.datetimeUnit = NPY_FR_ms;
     pyEncoder.outputFormat = COLUMNS;
     pyEncoder.defaultHandler = 0;
     pyEncoder.basicTypeContext.newObj = NULL;
@@ -2416,13 +2416,13 @@ PyObject *objToJSON(PyObject *self, PyObject *args, PyObject *kwargs) {
 
     if (sdateFormat != NULL) {
         if (strcmp(sdateFormat, "s") == 0) {
-            pyEncoder.datetimeUnit = PANDAS_FR_s;
+            pyEncoder.datetimeUnit = NPY_FR_s;
         } else if (strcmp(sdateFormat, "ms") == 0) {
-            pyEncoder.datetimeUnit = PANDAS_FR_ms;
+            pyEncoder.datetimeUnit = NPY_FR_ms;
         } else if (strcmp(sdateFormat, "us") == 0) {
-            pyEncoder.datetimeUnit = PANDAS_FR_us;
+            pyEncoder.datetimeUnit = NPY_FR_us;
         } else if (strcmp(sdateFormat, "ns") == 0) {
-            pyEncoder.datetimeUnit = PANDAS_FR_ns;
+            pyEncoder.datetimeUnit = NPY_FR_ns;
         } else {
             PyErr_Format(PyExc_ValueError,
                          "Invalid value '%s' for option 'date_unit'",

--- a/pandas/_libs/tslib.pyx
+++ b/pandas/_libs/tslib.pyx
@@ -45,7 +45,7 @@ from datetime import time as datetime_time
 from tslibs.np_datetime cimport (check_dts_bounds,
                                  reverse_ops,
                                  cmp_scalar,
-                                 pandas_datetimestruct,
+                                 npy_datetimestruct,
                                  dt64_to_dtstruct, dtstruct_to_dt64,
                                  pydatetime_to_dt64, pydate_to_dt64,
                                  get_datetime64_value,
@@ -87,7 +87,7 @@ from tslibs.nattype cimport _checknull_with_nat, NPY_NAT
 
 
 cdef inline object create_timestamp_from_ts(
-        int64_t value, pandas_datetimestruct dts,
+        int64_t value, npy_datetimestruct dts,
         object tz, object freq):
     """ convenience routine to construct a Timestamp from its parts """
     cdef _Timestamp ts_base
@@ -102,7 +102,7 @@ cdef inline object create_timestamp_from_ts(
 
 
 cdef inline object create_datetime_from_ts(
-        int64_t value, pandas_datetimestruct dts,
+        int64_t value, npy_datetimestruct dts,
         object tz, object freq):
     """ convenience routine to construct a datetime.datetime from its parts """
     return datetime(dts.year, dts.month, dts.day, dts.hour,
@@ -116,11 +116,11 @@ def ints_to_pydatetime(ndarray[int64_t] arr, tz=None, freq=None, box=False):
     cdef:
         Py_ssize_t i, n = len(arr)
         ndarray[int64_t] trans, deltas
-        pandas_datetimestruct dts
+        npy_datetimestruct dts
         object dt
         int64_t value
         ndarray[object] result = np.empty(n, dtype=object)
-        object (*func_create)(int64_t, pandas_datetimestruct, object, object)
+        object (*func_create)(int64_t, npy_datetimestruct, object, object)
 
     if box and is_string_object(freq):
         from pandas.tseries.frequencies import to_offset
@@ -707,7 +707,7 @@ class Timestamp(_Timestamp):
         """
 
         cdef:
-            pandas_datetimestruct dts
+            npy_datetimestruct dts
             int64_t value, value_tz, offset
             object _tzinfo, result, k, v
             datetime ts_input
@@ -1239,7 +1239,7 @@ def format_array_from_datetime(ndarray[int64_t] values, object tz=None,
         bint show_ms = 0, show_us = 0, show_ns = 0, basic_format = 0
         ndarray[object] result = np.empty(N, dtype=object)
         object ts, res
-        pandas_datetimestruct dts
+        npy_datetimestruct dts
 
     if na_rep is None:
         na_rep = 'NaT'
@@ -1471,7 +1471,7 @@ cpdef array_to_datetime(ndarray[object] values, errors='raise',
         object val, py_dt
         ndarray[int64_t] iresult
         ndarray[object] oresult
-        pandas_datetimestruct dts
+        npy_datetimestruct dts
         bint utc_convert = bool(utc)
         bint seen_integer = 0
         bint seen_string = 0
@@ -1705,7 +1705,7 @@ def get_time_micros(ndarray[int64_t] dtindex):
     """
     cdef:
         Py_ssize_t i, n = len(dtindex)
-        pandas_datetimestruct dts
+        npy_datetimestruct dts
         ndarray[int64_t] micros
 
     micros = np.empty(n, dtype=np.int64)

--- a/pandas/_libs/tslibs/conversion.pxd
+++ b/pandas/_libs/tslibs/conversion.pxd
@@ -5,12 +5,12 @@ from cpython.datetime cimport datetime
 
 from numpy cimport int64_t, int32_t
 
-from np_datetime cimport pandas_datetimestruct
+from np_datetime cimport npy_datetimestruct
 
 
 cdef class _TSObject:
     cdef:
-        pandas_datetimestruct dts      # pandas_datetimestruct
+        npy_datetimestruct dts      # npy_datetimestruct
         int64_t value               # numpy dt64
         object tzinfo
 

--- a/pandas/_libs/tslibs/conversion.pyx
+++ b/pandas/_libs/tslibs/conversion.pyx
@@ -19,8 +19,8 @@ from cpython.datetime cimport (datetime, tzinfo,
 PyDateTime_IMPORT
 
 from np_datetime cimport (check_dts_bounds,
-                          pandas_datetimestruct,
-                          PANDAS_DATETIMEUNIT, PANDAS_FR_ns,
+                          npy_datetimestruct,
+                          NPY_DATETIMEUNIT, NPY_FR_ns,
                           npy_datetime,
                           dt64_to_dtstruct, dtstruct_to_dt64,
                           get_datetime64_unit, get_datetime64_value,
@@ -59,14 +59,14 @@ cdef inline int64_t get_datetime64_nanos(object val) except? -1:
     value to nanoseconds if necessary.
     """
     cdef:
-        pandas_datetimestruct dts
-        PANDAS_DATETIMEUNIT unit
+        npy_datetimestruct dts
+        NPY_DATETIMEUNIT unit
         npy_datetime ival
 
     unit = get_datetime64_unit(val)
     ival = get_datetime64_value(val)
 
-    if unit != PANDAS_FR_ns:
+    if unit != NPY_FR_ns:
         pandas_datetime_to_datetimestruct(ival, unit, &dts)
         check_dts_bounds(&dts)
         ival = dtstruct_to_dt64(&dts)
@@ -90,8 +90,8 @@ def ensure_datetime64ns(ndarray arr):
     cdef:
         Py_ssize_t i, n = arr.size
         ndarray[int64_t] ivalues, iresult
-        PANDAS_DATETIMEUNIT unit
-        pandas_datetimestruct dts
+        NPY_DATETIMEUNIT unit
+        npy_datetimestruct dts
 
     shape = (<object> arr).shape
 
@@ -133,7 +133,7 @@ def datetime_to_datetime64(ndarray[object] values):
         Py_ssize_t i, n = len(values)
         object val, inferred_tz = None
         ndarray[int64_t] iresult
-        pandas_datetimestruct dts
+        npy_datetimestruct dts
         _TSObject _ts
 
     result = np.empty(n, dtype='M8[ns]')
@@ -179,7 +179,7 @@ cdef inline maybe_datetimelike_to_i8(object val):
     val : int64 timestamp or original input
     """
     cdef:
-        pandas_datetimestruct dts
+        npy_datetimestruct dts
     try:
         return val.value
     except AttributeError:
@@ -196,7 +196,7 @@ cdef inline maybe_datetimelike_to_i8(object val):
 # lightweight C object to hold datetime & int64 pair
 cdef class _TSObject:
     # cdef:
-    #    pandas_datetimestruct dts      # pandas_datetimestruct
+    #    npy_datetimestruct dts      # npy_datetimestruct
     #    int64_t value               # numpy dt64
     #    object tzinfo
 
@@ -546,7 +546,7 @@ cpdef int64_t tz_convert_single(int64_t val, object tz1, object tz2):
         ndarray[int64_t] trans, deltas
         Py_ssize_t pos
         int64_t v, offset, utc_date
-        pandas_datetimestruct dts
+        npy_datetimestruct dts
         datetime dt
 
     # See GH#17734 We should always be converting either from UTC or to UTC
@@ -614,7 +614,7 @@ def tz_convert(ndarray[int64_t] vals, object tz1, object tz2):
         Py_ssize_t i, j, pos, n = len(vals)
         ndarray[Py_ssize_t] posn
         int64_t v, offset, delta
-        pandas_datetimestruct dts
+        npy_datetimestruct dts
         datetime dt
 
     if len(vals) == 0:
@@ -727,7 +727,7 @@ def tz_localize_to_utc(ndarray[int64_t] vals, object tz, object ambiguous=None,
         int64_t *tdata
         int64_t v, left, right
         ndarray[int64_t] result, result_a, result_b, dst_hours
-        pandas_datetimestruct dts
+        npy_datetimestruct dts
         bint infer_dst = False, is_dst = False, fill = False
         bint is_coerce = errors == 'coerce', is_raise = errors == 'raise'
         datetime dt
@@ -936,7 +936,7 @@ def date_normalize(ndarray[int64_t] stamps, tz=None):
     """
     cdef:
         Py_ssize_t i, n = len(stamps)
-        pandas_datetimestruct dts
+        npy_datetimestruct dts
         ndarray[int64_t] result = np.empty(n, dtype=np.int64)
 
     if tz is not None:
@@ -975,7 +975,7 @@ cdef ndarray[int64_t] _normalize_local(ndarray[int64_t] stamps, object tz):
         Py_ssize_t n = len(stamps)
         ndarray[int64_t] result = np.empty(n, dtype=np.int64)
         ndarray[int64_t] trans, deltas, pos
-        pandas_datetimestruct dts
+        npy_datetimestruct dts
         datetime dt
 
     if is_utc(tz):
@@ -1025,13 +1025,13 @@ cdef ndarray[int64_t] _normalize_local(ndarray[int64_t] stamps, object tz):
     return result
 
 
-cdef inline int64_t _normalized_stamp(pandas_datetimestruct *dts) nogil:
+cdef inline int64_t _normalized_stamp(npy_datetimestruct *dts) nogil:
     """
     Normalize the given datetimestruct to midnight, then convert to int64_t.
 
     Parameters
     ----------
-    *dts : pointer to pandas_datetimestruct
+    *dts : pointer to npy_datetimestruct
 
     Returns
     -------
@@ -1063,7 +1063,7 @@ def is_date_array_normalized(ndarray[int64_t] stamps, tz=None):
     cdef:
         Py_ssize_t i, n = len(stamps)
         ndarray[int64_t] trans, deltas
-        pandas_datetimestruct dts
+        npy_datetimestruct dts
         datetime dt
 
     if tz is None or is_utc(tz):

--- a/pandas/_libs/tslibs/fields.pyx
+++ b/pandas/_libs/tslibs/fields.pyx
@@ -17,7 +17,7 @@ from numpy cimport ndarray, int64_t, int32_t, int8_t
 np.import_array()
 
 
-from np_datetime cimport (pandas_datetimestruct, pandas_timedeltastruct,
+from np_datetime cimport (npy_datetimestruct, pandas_timedeltastruct,
                           dt64_to_dtstruct, td64_to_tdstruct,
                           days_per_month_table, is_leapyear, dayofweek)
 from nattype cimport NPY_NAT
@@ -29,7 +29,7 @@ def build_field_sarray(ndarray[int64_t] dtindex):
     """
     cdef:
         Py_ssize_t i, count = 0
-        pandas_datetimestruct dts
+        npy_datetimestruct dts
         ndarray[int32_t] years, months, days, hours, minutes, seconds, mus
 
     count = len(dtindex)
@@ -75,7 +75,7 @@ def get_date_name_field(ndarray[int64_t] dtindex, object field):
     cdef:
         Py_ssize_t i, count = 0
         ndarray[object] out
-        pandas_datetimestruct dts
+        npy_datetimestruct dts
         int dow
 
     _dayname = np.array(
@@ -117,7 +117,7 @@ def get_start_end_field(ndarray[int64_t] dtindex, object field,
         ndarray[int8_t] out
         ndarray[int32_t, ndim=2] _month_offset
         bint isleap
-        pandas_datetimestruct dts
+        npy_datetimestruct dts
         int mo_off, dom, doy, dow, ldom
 
     _month_offset = np.array(
@@ -358,7 +358,7 @@ def get_date_field(ndarray[int64_t] dtindex, object field):
         ndarray[int32_t] out
         ndarray[int32_t, ndim=2] _month_offset
         int isleap, isleap_prev
-        pandas_datetimestruct dts
+        npy_datetimestruct dts
         int mo_off, doy, dow, woy
 
     _month_offset = np.array(
@@ -656,7 +656,7 @@ def get_timedelta_field(ndarray[int64_t] tdindex, object field):
     raise ValueError("Field %s not supported" % field)
 
 
-cdef inline int days_in_month(pandas_datetimestruct dts) nogil:
+cdef inline int days_in_month(npy_datetimestruct dts) nogil:
     return days_per_month_table[is_leapyear(dts.year)][dts.month - 1]
 
 

--- a/pandas/_libs/tslibs/np_datetime.pxd
+++ b/pandas/_libs/tslibs/np_datetime.pxd
@@ -11,8 +11,28 @@ cdef extern from "numpy/ndarrayobject.h":
 
 cdef extern from "numpy/ndarraytypes.h":
     ctypedef struct PyArray_DatetimeMetaData:
-        PANDAS_DATETIMEUNIT base
+        NPY_DATETIMEUNIT base
         int64_t num
+
+    ctypedef enum NPY_DATETIMEUNIT:
+        NPY_FR_Y
+        NPY_FR_M
+        NPY_FR_W
+        NPY_FR_D
+        NPY_FR_B
+        NPY_FR_h
+        NPY_FR_m
+        NPY_FR_s
+        NPY_FR_ms
+        NPY_FR_us
+        NPY_FR_ns
+        NPY_FR_ps
+        NPY_FR_fs
+        NPY_FR_as
+
+    ctypedef struct npy_datetimestruct:
+        int64_t year
+        int32_t month, day, hour, min, sec, us, ps, as
 
 cdef extern from "numpy/arrayscalars.h":
     ctypedef struct PyDatetimeScalarObject:
@@ -26,29 +46,9 @@ cdef extern from "numpy/arrayscalars.h":
         PyArray_DatetimeMetaData obmeta
 
 cdef extern from "../src/datetime/np_datetime.h":
-    ctypedef struct pandas_datetimestruct:
-        int64_t year
-        int32_t month, day, hour, min, sec, us, ps, as
-
     ctypedef struct pandas_timedeltastruct:
         int64_t days
         int32_t hrs, min, sec, ms, us, ns, seconds, microseconds, nanoseconds
-
-    ctypedef enum PANDAS_DATETIMEUNIT:
-        PANDAS_FR_Y
-        PANDAS_FR_M
-        PANDAS_FR_W
-        PANDAS_FR_D
-        PANDAS_FR_B
-        PANDAS_FR_h
-        PANDAS_FR_m
-        PANDAS_FR_s
-        PANDAS_FR_ms
-        PANDAS_FR_us
-        PANDAS_FR_ns
-        PANDAS_FR_ps
-        PANDAS_FR_fs
-        PANDAS_FR_as
 
     int days_per_month_table[2][12]
     int dayofweek(int y, int m, int d) nogil
@@ -59,15 +59,15 @@ cdef int reverse_ops[6]
 
 cdef bint cmp_scalar(int64_t lhs, int64_t rhs, int op) except -1
 
-cdef check_dts_bounds(pandas_datetimestruct *dts)
+cdef check_dts_bounds(npy_datetimestruct *dts)
 
-cdef int64_t dtstruct_to_dt64(pandas_datetimestruct* dts) nogil
-cdef void dt64_to_dtstruct(int64_t dt64, pandas_datetimestruct* out) nogil
+cdef int64_t dtstruct_to_dt64(npy_datetimestruct* dts) nogil
+cdef void dt64_to_dtstruct(int64_t dt64, npy_datetimestruct* out) nogil
 cdef void td64_to_tdstruct(int64_t td64, pandas_timedeltastruct* out) nogil
 
-cdef int64_t pydatetime_to_dt64(datetime val, pandas_datetimestruct *dts)
-cdef int64_t pydate_to_dt64(date val, pandas_datetimestruct *dts)
+cdef int64_t pydatetime_to_dt64(datetime val, npy_datetimestruct *dts)
+cdef int64_t pydate_to_dt64(date val, npy_datetimestruct *dts)
 
 cdef npy_datetime get_datetime64_value(object obj) nogil
 cdef npy_timedelta get_timedelta64_value(object obj) nogil
-cdef PANDAS_DATETIMEUNIT get_datetime64_unit(object obj) nogil
+cdef NPY_DATETIMEUNIT get_datetime64_unit(object obj) nogil

--- a/pandas/_libs/tslibs/np_datetime.pyx
+++ b/pandas/_libs/tslibs/np_datetime.pyx
@@ -15,23 +15,23 @@ PyDateTime_IMPORT
 from numpy cimport int64_t
 
 cdef extern from "../src/datetime/np_datetime.h":
-    int cmp_pandas_datetimestruct(pandas_datetimestruct *a,
-                                  pandas_datetimestruct *b)
+    int cmp_pandas_datetimestruct(npy_datetimestruct *a,
+                                  npy_datetimestruct *b)
 
-    npy_datetime pandas_datetimestruct_to_datetime(PANDAS_DATETIMEUNIT fr,
-                                                   pandas_datetimestruct *d
+    npy_datetime pandas_datetimestruct_to_datetime(NPY_DATETIMEUNIT fr,
+                                                   npy_datetimestruct *d
                                                    ) nogil
 
     void pandas_datetime_to_datetimestruct(npy_datetime val,
-                                           PANDAS_DATETIMEUNIT fr,
-                                           pandas_datetimestruct *result) nogil
+                                           NPY_DATETIMEUNIT fr,
+                                           npy_datetimestruct *result) nogil
 
     void pandas_timedelta_to_timedeltastruct(npy_timedelta val,
-                                             PANDAS_DATETIMEUNIT fr,
+                                             NPY_DATETIMEUNIT fr,
                                              pandas_timedeltastruct *result
                                             ) nogil
 
-    pandas_datetimestruct _NS_MIN_DTS, _NS_MAX_DTS
+    npy_datetimestruct _NS_MIN_DTS, _NS_MAX_DTS
 
 # ----------------------------------------------------------------------
 # numpy object inspection
@@ -53,11 +53,11 @@ cdef inline npy_timedelta get_timedelta64_value(object obj) nogil:
     return (<PyTimedeltaScalarObject*>obj).obval
 
 
-cdef inline PANDAS_DATETIMEUNIT get_datetime64_unit(object obj) nogil:
+cdef inline NPY_DATETIMEUNIT get_datetime64_unit(object obj) nogil:
     """
     returns the unit part of the dtype for a numpy datetime64 object.
     """
-    return <PANDAS_DATETIMEUNIT>(<PyDatetimeScalarObject*>obj).obmeta.base
+    return <NPY_DATETIMEUNIT>(<PyDatetimeScalarObject*>obj).obmeta.base
 
 # ----------------------------------------------------------------------
 # Comparison
@@ -95,7 +95,7 @@ class OutOfBoundsDatetime(ValueError):
     pass
 
 
-cdef inline check_dts_bounds(pandas_datetimestruct *dts):
+cdef inline check_dts_bounds(npy_datetimestruct *dts):
     """Raises OutOfBoundsDatetime if the given date is outside the range that
     can be represented by nanosecond-resolution 64-bit integers."""
     cdef:
@@ -119,29 +119,29 @@ cdef inline check_dts_bounds(pandas_datetimestruct *dts):
 # ----------------------------------------------------------------------
 # Conversion
 
-cdef inline int64_t dtstruct_to_dt64(pandas_datetimestruct* dts) nogil:
+cdef inline int64_t dtstruct_to_dt64(npy_datetimestruct* dts) nogil:
     """Convenience function to call pandas_datetimestruct_to_datetime
-    with the by-far-most-common frequency PANDAS_FR_ns"""
-    return pandas_datetimestruct_to_datetime(PANDAS_FR_ns, dts)
+    with the by-far-most-common frequency NPY_FR_ns"""
+    return pandas_datetimestruct_to_datetime(NPY_FR_ns, dts)
 
 
 cdef inline void dt64_to_dtstruct(int64_t dt64,
-                                  pandas_datetimestruct* out) nogil:
+                                  npy_datetimestruct* out) nogil:
     """Convenience function to call pandas_datetime_to_datetimestruct
-    with the by-far-most-common frequency PANDAS_FR_ns"""
-    pandas_datetime_to_datetimestruct(dt64, PANDAS_FR_ns, out)
+    with the by-far-most-common frequency NPY_FR_ns"""
+    pandas_datetime_to_datetimestruct(dt64, NPY_FR_ns, out)
     return
 
 cdef inline void td64_to_tdstruct(int64_t td64,
                                   pandas_timedeltastruct* out) nogil:
     """Convenience function to call pandas_timedelta_to_timedeltastruct
-    with the by-far-most-common frequency PANDAS_FR_ns"""
-    pandas_timedelta_to_timedeltastruct(td64, PANDAS_FR_ns, out)
+    with the by-far-most-common frequency NPY_FR_ns"""
+    pandas_timedelta_to_timedeltastruct(td64, NPY_FR_ns, out)
     return
 
 
 cdef inline int64_t pydatetime_to_dt64(datetime val,
-                                       pandas_datetimestruct *dts):
+                                       npy_datetimestruct *dts):
     dts.year = PyDateTime_GET_YEAR(val)
     dts.month = PyDateTime_GET_MONTH(val)
     dts.day = PyDateTime_GET_DAY(val)
@@ -154,7 +154,7 @@ cdef inline int64_t pydatetime_to_dt64(datetime val,
 
 
 cdef inline int64_t pydate_to_dt64(date val,
-                                   pandas_datetimestruct *dts):
+                                   npy_datetimestruct *dts):
     dts.year = PyDateTime_GET_YEAR(val)
     dts.month = PyDateTime_GET_MONTH(val)
     dts.day = PyDateTime_GET_DAY(val)

--- a/pandas/_libs/tslibs/offsets.pyx
+++ b/pandas/_libs/tslibs/offsets.pyx
@@ -22,7 +22,7 @@ from pandas._libs.tslib import monthrange
 from conversion cimport tz_convert_single, pydt_to_i8
 from frequencies cimport get_freq_code
 from nattype cimport NPY_NAT
-from np_datetime cimport (pandas_datetimestruct,
+from np_datetime cimport (npy_datetimestruct,
                           dtstruct_to_dt64, dt64_to_dtstruct,
                           is_leapyear, days_per_month_table)
 
@@ -431,14 +431,14 @@ cdef inline int get_days_in_month(int year, int month) nogil:
     return days_per_month_table[is_leapyear(year)][month - 1]
 
 
-cdef inline int year_add_months(pandas_datetimestruct dts, int months) nogil:
-    """new year number after shifting pandas_datetimestruct number of months"""
+cdef inline int year_add_months(npy_datetimestruct dts, int months) nogil:
+    """new year number after shifting npy_datetimestruct number of months"""
     return dts.year + (dts.month + months - 1) / 12
 
 
-cdef inline int month_add_months(pandas_datetimestruct dts, int months) nogil:
+cdef inline int month_add_months(npy_datetimestruct dts, int months) nogil:
     """
-    New month number after shifting pandas_datetimestruct
+    New month number after shifting npy_datetimestruct
     number of months.
     """
     cdef int new_month = (dts.month + months) % 12
@@ -459,7 +459,7 @@ def shift_months(int64_t[:] dtindex, int months, object day=None):
     """
     cdef:
         Py_ssize_t i
-        pandas_datetimestruct dts
+        npy_datetimestruct dts
         int count = len(dtindex)
         int months_to_roll
         bint roll_check

--- a/pandas/_libs/tslibs/resolution.pyx
+++ b/pandas/_libs/tslibs/resolution.pyx
@@ -18,7 +18,7 @@ from khash cimport (
 
 from cpython.datetime cimport datetime
 
-from np_datetime cimport (pandas_datetimestruct,
+from np_datetime cimport (npy_datetimestruct,
                           dtstruct_to_dt64, dt64_to_dtstruct)
 from frequencies cimport get_freq_code
 from timezones cimport (
@@ -64,7 +64,7 @@ _MONTH_ALIASES = {(k + 1): v for k, v in enumerate(_MONTHS)}
 cpdef resolution(ndarray[int64_t] stamps, tz=None):
     cdef:
         Py_ssize_t i, n = len(stamps)
-        pandas_datetimestruct dts
+        npy_datetimestruct dts
         int reso = RESO_DAY, curr_reso
 
     if tz is not None:
@@ -86,7 +86,7 @@ cdef _reso_local(ndarray[int64_t] stamps, object tz):
         Py_ssize_t n = len(stamps)
         int reso = RESO_DAY, curr_reso
         ndarray[int64_t] trans, deltas, pos
-        pandas_datetimestruct dts
+        npy_datetimestruct dts
 
     if is_utc(tz):
         for i in range(n):
@@ -138,7 +138,7 @@ cdef _reso_local(ndarray[int64_t] stamps, object tz):
     return reso
 
 
-cdef inline int _reso_stamp(pandas_datetimestruct *dts):
+cdef inline int _reso_stamp(npy_datetimestruct *dts):
     if dts.us != 0:
         if dts.us % 1000 == 0:
             return RESO_MS

--- a/pandas/_libs/tslibs/strptime.pyx
+++ b/pandas/_libs/tslibs/strptime.pyx
@@ -34,7 +34,7 @@ from datetime import date as datetime_date
 from cpython.datetime cimport datetime
 
 from np_datetime cimport (check_dts_bounds,
-                          dtstruct_to_dt64, pandas_datetimestruct)
+                          dtstruct_to_dt64, npy_datetimestruct)
 
 from util cimport is_string_object
 
@@ -57,7 +57,7 @@ def array_strptime(ndarray[object] values, object fmt,
 
     cdef:
         Py_ssize_t i, n = len(values)
-        pandas_datetimestruct dts
+        npy_datetimestruct dts
         ndarray[int64_t] iresult
         int year, month, day, minute, hour, second, weekday, julian, tz
         int week_of_year, week_of_year_start


### PR DESCRIPTION
pandas implements `pandas_datetimestruct` and `PANDAS_DATETIMEUNIT`, AFAICT because at the time they were implemented, pandas was supporting versions of numpy that did not yet have `npy_datetimestruct` and `NPY_DATETIMEUNIT`.  The implementations are identical.

The upshot of using the numpy versions is dependency simplification.  There are a handful of functions/modules in `tslibs` (also `tslib`, `_libs.period`) that depend on `tslibs.np_datetime` and as a result need to have `tseries_depends` and `np_datetime_sources` in their extension specification.  In many cases, this is including much more than is necessary (and while I haven't timed it, I assume this impacts the build speed).

By using the numpy versions, we can import just datetimestruct and DATETIMEUNIT in the relevant places, avoiding dependencies on src/datetime/, lightening the build, and simplifying setup.py.

Note this PR doesn't actually _do_ any of those simplifications, is just the preliminary search+replace.

- [ ] closes #xxxx
- [ ] tests added / passed
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
