### PR TITLE
DOC: escaping code examples properly in read_csv docstring

### DIFF
--- a/pandas/io/parsers.py
+++ b/pandas/io/parsers.py
@@ -245,9 +245,9 @@ comment : str, default None
     Indicates remainder of line should not be parsed. If found at the beginning
     of a line, the line will be ignored altogether. This parameter must be a
     single character. Like empty lines (as long as ``skip_blank_lines=True``),
-    fully commented lines are ignored by the parameter `header` but not by
-    `skiprows`. For example, if comment='#', parsing '#empty\\na,b,c\\n1,2,3'
-    with `header=0` will result in 'a,b,c' being
+    fully commented lines are ignored by the parameter ``header`` but not by
+    ``skiprows``. For example, if ``comment='#'``, parsing
+    ``#empty\\na,b,c\\n1,2,3`` with ``header=0`` will result in 'a,b,c' being
     treated as the header.
 encoding : str, default None
     Encoding to use for UTF when reading/writing (ex. 'utf-8'). `List of Python

--- a/pandas/io/parsers.py
+++ b/pandas/io/parsers.py
@@ -245,8 +245,8 @@ comment : str, default None
     Indicates remainder of line should not be parsed. If found at the beginning
     of a line, the line will be ignored altogether. This parameter must be a
     single character. Like empty lines (as long as ``skip_blank_lines=True``),
-    fully commented lines are ignored by the parameter ``header`` but not by
-    ``skiprows``. For example, if ``comment='#'``, parsing
+    fully commented lines are ignored by the parameter `header` but not by
+    `skiprows`. For example, if ``comment='#'``, parsing
     ``#empty\\na,b,c\\n1,2,3`` with ``header=0`` will result in 'a,b,c' being
     treated as the header.
 encoding : str, default None


### PR DESCRIPTION
- [x] closes #18411
~~- [ ] tests added / passed~~
~~- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`~~
~~- [ ] whatsnew entry~~
