### PR TITLE
CLN: ASV Algorithms benchmark

### DIFF
--- a/asv_bench/benchmarks/algorithms.py
+++ b/asv_bench/benchmarks/algorithms.py
@@ -3,7 +3,6 @@ from importlib import import_module
 import numpy as np
 import pandas as pd
 from pandas.util import testing as tm
-from pandas.core.algorithms import checked_add_with_arr
 
 for imp in ['pandas.util', 'pandas.tools.hashing']:
     try:
@@ -86,49 +85,6 @@ class Match(object):
 
     def time_match_string(self):
         pd.match(self.all, self.uniques)
-
-
-class AddOverflowScalar(object):
-
-    goal_time = 0.2
-
-    params = [1, -1, 0]
-    param_names = ['scalar']
-
-    def setup(self, scalar):
-        N = 10**6
-        self.arr = np.arange(N)
-
-    def time_add_overflow_scalar(self, scalar):
-        checked_add_with_arr(self.arr, scalar)
-
-
-class AddOverflowArray(object):
-
-    goal_time = 0.2
-
-    def setup(self):
-        np.random.seed(1234)
-        N = 10**6
-        self.arr = np.arange(N)
-        self.arr_rev = np.arange(-N, 0)
-        self.arr_mixed = np.array([1, -1]).repeat(N / 2)
-        self.arr_nan_1 = np.random.choice([True, False], size=N)
-        self.arr_nan_2 = np.random.choice([True, False], size=N)
-
-    def time_add_overflow_arr_rev(self):
-        checked_add_with_arr(self.arr, self.arr_rev)
-
-    def time_add_overflow_arr_mask_nan(self):
-        checked_add_with_arr(self.arr, self.arr_mixed, arr_mask=self.arr_nan_1)
-
-    def time_add_overflow_b_mask_nan(self):
-        checked_add_with_arr(self.arr, self.arr_mixed,
-                             b_mask=self.arr_nan_1)
-
-    def time_add_overflow_both_arg_nan(self):
-        checked_add_with_arr(self.arr, self.arr_mixed, arr_mask=self.arr_nan_1,
-                             b_mask=self.arr_nan_2)
 
 
 class Hashing(object):

--- a/asv_bench/benchmarks/algorithms.py
+++ b/asv_bench/benchmarks/algorithms.py
@@ -1,9 +1,9 @@
 from importlib import import_module
 
 import numpy as np
-
 import pandas as pd
 from pandas.util import testing as tm
+from pandas.core.algorithms import checked_add_with_arr
 
 for imp in ['pandas.util', 'pandas.tools.hashing']:
     try:
@@ -12,113 +12,150 @@ for imp in ['pandas.util', 'pandas.tools.hashing']:
     except:
         pass
 
-class Algorithms(object):
+
+class Factorize(object):
+
     goal_time = 0.2
 
     def setup(self):
-        N = 100000
+        N = 10**5
         np.random.seed(1234)
+        self.int_idx = pd.Int64Index(np.arange(N).repeat(5))
+        self.float_idx = pd.Float64Index(np.random.randn(N).repeat(5))
+        self.string_idx = tm.makeStringIndex(N)
 
-        self.int_unique = pd.Int64Index(np.arange(N * 5))
+    def time_factorize_int(self):
+        self.int_idx.factorize()
+
+    def time_factorize_float(self):
+        self.float_idx.factorize()
+
+    def time_factorize_string(self):
+        self.string_idx.factorize()
+
+
+class Duplicated(object):
+
+    goal_time = 0.2
+
+    def setup(self):
+        N = 10**5
+        np.random.seed(1234)
+        self.int_idx = pd.Int64Index(np.arange(N).repeat(5))
+        self.float_idx = pd.Float64Index(np.random.randn(N).repeat(5))
+
+    def time_duplicated_int(self):
+        self.int_idx.duplicated()
+
+    def time_duplicated_float(self):
+        self.float_idx.duplicated()
+
+
+class DuplicatedUniqueIndex(object):
+
+    goal_time = 0.2
+
+    def setup(self):
+        N = 10**5
+        self.idx_int_dup = pd.Int64Index(np.arange(N * 5))
         # cache is_unique
-        self.int_unique.is_unique
+        self.idx_int_dup.is_unique
 
-        self.int = pd.Int64Index(np.arange(N).repeat(5))
-        self.float = pd.Float64Index(np.random.randn(N).repeat(5))
+    def time_duplicated_unique_int(self):
+        self.idx_int_dup.duplicated()
 
-        # Convenience naming.
-        self.checked_add = pd.core.algorithms.checked_add_with_arr
 
-        self.arr = np.arange(1000000)
-        self.arrpos = np.arange(1000000)
-        self.arrneg = np.arange(-1000000, 0)
-        self.arrmixed = np.array([1, -1]).repeat(500000)
-        self.strings = tm.makeStringIndex(100000)
+class Match(object):
 
-        self.arr_nan = np.random.choice([True, False], size=1000000)
-        self.arrmixed_nan = np.random.choice([True, False], size=1000000)
+    goal_time = 0.2
 
-        # match
+    def setup(self):
+        np.random.seed(1234)
         self.uniques = tm.makeStringIndex(1000).values
         self.all = self.uniques.repeat(10)
 
-    def time_factorize_string(self):
-        self.strings.factorize()
-
-    def time_factorize_int(self):
-        self.int.factorize()
-
-    def time_factorize_float(self):
-        self.int.factorize()
-
-    def time_duplicated_int_unique(self):
-        self.int_unique.duplicated()
-
-    def time_duplicated_int(self):
-        self.int.duplicated()
-
-    def time_duplicated_float(self):
-        self.float.duplicated()
-
-    def time_match_strings(self):
+    def time_match_string(self):
         pd.match(self.all, self.uniques)
 
-    def time_add_overflow_pos_scalar(self):
-        self.checked_add(self.arr, 1)
 
-    def time_add_overflow_neg_scalar(self):
-        self.checked_add(self.arr, -1)
+class AddOverflowScalar(object):
 
-    def time_add_overflow_zero_scalar(self):
-        self.checked_add(self.arr, 0)
+    goal_time = 0.2
 
-    def time_add_overflow_pos_arr(self):
-        self.checked_add(self.arr, self.arrpos)
+    params = [1, -1, 0]
 
-    def time_add_overflow_neg_arr(self):
-        self.checked_add(self.arr, self.arrneg)
+    def setup(self, scalar):
+        N = 10**6
+        self.arr = np.arange(N)
 
-    def time_add_overflow_mixed_arr(self):
-        self.checked_add(self.arr, self.arrmixed)
-
-    def time_add_overflow_first_arg_nan(self):
-        self.checked_add(self.arr, self.arrmixed, arr_mask=self.arr_nan)
-
-    def time_add_overflow_second_arg_nan(self):
-        self.checked_add(self.arr, self.arrmixed, b_mask=self.arrmixed_nan)
-
-    def time_add_overflow_both_arg_nan(self):
-        self.checked_add(self.arr, self.arrmixed, arr_mask=self.arr_nan,
-                         b_mask=self.arrmixed_nan)
+    def time_add_overflow_scalar(self, scalar):
+        checked_add_with_arr(self.arr, scalar)
 
 
-class Hashing(object):
+class AddOverflowArray(object):
+
     goal_time = 0.2
 
     def setup(self):
-        N = 100000
+        np.random.seed(1234)
+        N = 10**6
+        self.arr = np.arange(N)
+        self.arr_rev = np.arange(-N, 0)
+        self.arr_mixed = np.array([1, -1]).repeat(N / 2)
+        self.arr_nan_1 = np.random.choice([True, False], size=N)
+        self.arr_nan_2 = np.random.choice([True, False], size=N)
 
-        self.df = pd.DataFrame(
-            {'A': pd.Series(tm.makeStringIndex(100).take(
-                np.random.randint(0, 100, size=N))),
-             'B': pd.Series(tm.makeStringIndex(10000).take(
-                 np.random.randint(0, 10000, size=N))),
-             'D': np.random.randn(N),
-             'E': np.arange(N),
-             'F': pd.date_range('20110101', freq='s', periods=N),
-             'G': pd.timedelta_range('1 day', freq='s', periods=N),
-             })
-        self.df['C'] = self.df['B'].astype('category')
-        self.df.iloc[10:20] = np.nan
+    def time_add_overflow_arr_rev(self):
+        checked_add_with_arr(self.arr, self.arr_rev)
 
-    def time_frame(self):
-        hashing.hash_pandas_object(self.df)
+    def time_add_overflow_arr_mask_nan(self):
+        checked_add_with_arr(self.arr, self.arr_mixed, arr_mask=self.arr_nan_1)
 
-    def time_series_int(self):
-        hashing.hash_pandas_object(self.df.E)
+    def time_add_overflow_b_mask_nan(self):
+        checked_add_with_arr(self.arr, self.arr_mixed,
+                             b_mask=self.arr_nan_1)
 
-    def time_series_string(self):
-        hashing.hash_pandas_object(self.df.B)
+    def time_add_overflow_both_arg_nan(self):
+        checked_add_with_arr(self.arr, self.arr_mixed, arr_mask=self.arr_nan_1,
+                             b_mask=self.arr_nan_2)
 
-    def time_series_categorical(self):
-        hashing.hash_pandas_object(self.df.C)
+
+class Hashing(object):
+
+    goal_time = 0.2
+
+    def setup_cache(self):
+        np.random.seed(1234)
+        N = 10**5
+
+        df = pd.DataFrame(
+            {'strings': pd.Series(tm.makeStringIndex(10000).take(
+                np.random.randint(0, 10000, size=N))),
+             'floats': np.random.randn(N),
+             'ints': np.arange(N),
+             'dates': pd.date_range('20110101', freq='s', periods=N),
+             'timedeltas': pd.timedelta_range('1 day', freq='s', periods=N)})
+        df['categories'] = df['strings'].astype('category')
+        df.iloc[10:20] = np.nan
+        return df
+
+    def time_frame(self, df):
+        hashing.hash_pandas_object(df)
+
+    def time_series_int(self, df):
+        hashing.hash_pandas_object(df['ints'])
+
+    def time_series_string(self, df):
+        hashing.hash_pandas_object(df['strings'])
+
+    def time_series_float(self, df):
+        hashing.hash_pandas_object(df['floats'])
+
+    def time_series_categorical(self, df):
+        hashing.hash_pandas_object(df['categories'])
+
+    def time_series_timedeltas(self, df):
+        hashing.hash_pandas_object(df['timedeltas'])
+
+    def time_series_dates(self, df):
+        hashing.hash_pandas_object(df['dates'])

--- a/asv_bench/benchmarks/algorithms.py
+++ b/asv_bench/benchmarks/algorithms.py
@@ -17,38 +17,48 @@ class Factorize(object):
 
     goal_time = 0.2
 
-    def setup(self):
+    params = [True, False]
+    param_names = ['sort']
+
+    def setup(self, sort):
         N = 10**5
         np.random.seed(1234)
         self.int_idx = pd.Int64Index(np.arange(N).repeat(5))
         self.float_idx = pd.Float64Index(np.random.randn(N).repeat(5))
         self.string_idx = tm.makeStringIndex(N)
 
-    def time_factorize_int(self):
-        self.int_idx.factorize()
+    def time_factorize_int(self, sort):
+        self.int_idx.factorize(sort=sort)
 
-    def time_factorize_float(self):
-        self.float_idx.factorize()
+    def time_factorize_float(self, sort):
+        self.float_idx.factorize(sort=sort)
 
-    def time_factorize_string(self):
-        self.string_idx.factorize()
+    def time_factorize_string(self, sort):
+        self.string_idx.factorize(sort=sort)
 
 
 class Duplicated(object):
 
     goal_time = 0.2
 
-    def setup(self):
+    params = ['first', 'last', False]
+    param_names = ['keep']
+
+    def setup(self, keep):
         N = 10**5
         np.random.seed(1234)
         self.int_idx = pd.Int64Index(np.arange(N).repeat(5))
         self.float_idx = pd.Float64Index(np.random.randn(N).repeat(5))
+        self.string_idx = tm.makeStringIndex(N)
 
-    def time_duplicated_int(self):
-        self.int_idx.duplicated()
+    def time_duplicated_int(self, keep):
+        self.int_idx.duplicated(keep=keep)
 
-    def time_duplicated_float(self):
-        self.float_idx.duplicated()
+    def time_duplicated_float(self, keep):
+        self.float_idx.duplicated(keep=keep)
+
+    def time_duplicated_string(self, keep):
+        self.string_idx.duplicated(keep=keep)
 
 
 class DuplicatedUniqueIndex(object):

--- a/asv_bench/benchmarks/algorithms.py
+++ b/asv_bench/benchmarks/algorithms.py
@@ -83,6 +83,7 @@ class AddOverflowScalar(object):
     goal_time = 0.2
 
     params = [1, -1, 0]
+    param_names = ['scalar']
 
     def setup(self, scalar):
         N = 10**6

--- a/asv_bench/benchmarks/binary_ops.py
+++ b/asv_bench/benchmarks/binary_ops.py
@@ -1,5 +1,6 @@
 import numpy as np
 from pandas import DataFrame, Series, date_range
+from pandas.core.algorithms import checked_add_with_arr
 try:
     import pandas.core.computation.expressions as expr
 except ImportError:
@@ -108,3 +109,46 @@ class Timeseries(object):
 
     def time_timestamp_ops_diff_with_shift(self, tz):
         self.s - self.s.shift()
+
+
+class AddOverflowScalar(object):
+
+    goal_time = 0.2
+
+    params = [1, -1, 0]
+    param_names = ['scalar']
+
+    def setup(self, scalar):
+        N = 10**6
+        self.arr = np.arange(N)
+
+    def time_add_overflow_scalar(self, scalar):
+        checked_add_with_arr(self.arr, scalar)
+
+
+class AddOverflowArray(object):
+
+    goal_time = 0.2
+
+    def setup(self):
+        np.random.seed(1234)
+        N = 10**6
+        self.arr = np.arange(N)
+        self.arr_rev = np.arange(-N, 0)
+        self.arr_mixed = np.array([1, -1]).repeat(N / 2)
+        self.arr_nan_1 = np.random.choice([True, False], size=N)
+        self.arr_nan_2 = np.random.choice([True, False], size=N)
+
+    def time_add_overflow_arr_rev(self):
+        checked_add_with_arr(self.arr, self.arr_rev)
+
+    def time_add_overflow_arr_mask_nan(self):
+        checked_add_with_arr(self.arr, self.arr_mixed, arr_mask=self.arr_nan_1)
+
+    def time_add_overflow_b_mask_nan(self):
+        checked_add_with_arr(self.arr, self.arr_mixed,
+                             b_mask=self.arr_nan_1)
+
+    def time_add_overflow_both_arg_nan(self):
+        checked_add_with_arr(self.arr, self.arr_mixed, arr_mask=self.arr_nan_1,
+                             b_mask=self.arr_nan_2)


### PR DESCRIPTION
High Level changes:

- The `Algorithms` class benchmark was getting large so I broke it into several smaller classes, avoiding creating data structures in each `setup` call that would only be used for 1 benchmark.

- Added `np.random.seed(1234)` in `setup` classes where random data is created xref #8144

- Utilized `params` and `setup_cache` where applicable.

- Added additional hashing benchmarks

The benchmarks should be equivalent to what existed before. If the diff is too large I can break it up into smaller PRs. You can find 3 asv runs below. 

<details>

```
$ asv run -b ^algorithms -q

[  5.26%] ··· Running algorithms.Hashing.time_frame                                                     58.8ms
[ 10.53%] ··· Running algorithms.Hashing.time_series_categorical                                        15.6ms
[ 15.79%] ··· Running algorithms.Hashing.time_series_dates                                              10.3ms
[ 21.05%] ··· Running algorithms.Hashing.time_series_float                                              13.7ms
[ 26.32%] ··· Running algorithms.Hashing.time_series_int                                                11.0ms
[ 31.58%] ··· Running algorithms.Hashing.time_series_string                                             29.7ms
[ 36.84%] ··· Running algorithms.Hashing.time_series_timedeltas                                         13.4ms
[ 42.11%] ··· Running algorithms.AddOverflowArray.time_add_overflow_arr_mask_nan                        45.8ms
[ 47.37%] ··· Running algorithms.AddOverflowArray.time_add_overflow_arr_rev                             32.5ms
[ 52.63%] ··· Running algorithms.AddOverflowArray.time_add_overflow_b_mask_nan                          43.2ms
[ 57.89%] ··· Running algorithms.AddOverflowArray.time_add_overflow_both_arg_nan                        40.2ms
[ 63.16%] ··· Running algorithms.AddOverflowScalar.time_add_overflow_scalar                         25.8ms;...
[ 68.42%] ··· Running algorithms.Duplicated.time_duplicated_float                                       40.1ms
[ 73.68%] ··· Running algorithms.Duplicated.time_duplicated_int                                         26.3ms
[ 78.95%] ··· Running algorithms.DuplicatedUniqueIndex.time_duplicated_unique_int                        374μs
[ 84.21%] ··· Running algorithms.Factorize.time_factorize_float                                         27.8ms
[ 89.47%] ··· Running algorithms.Factorize.time_factorize_int                                           18.3ms
[ 94.74%] ··· Running algorithms.Factorize.time_factorize_string                                        52.3ms
[100.00%] ··· Running algorithms.Match.time_match_string                                                 902μs

asv run -b ^algorithms -q
[  5.26%] ··· Running algorithms.Hashing.time_frame                                                     58.7ms
[ 10.53%] ··· Running algorithms.Hashing.time_series_categorical                                        12.4ms
[ 15.79%] ··· Running algorithms.Hashing.time_series_dates                                              9.24ms
[ 21.05%] ··· Running algorithms.Hashing.time_series_float                                              9.53ms
[ 26.32%] ··· Running algorithms.Hashing.time_series_int                                                9.53ms
[ 31.58%] ··· Running algorithms.Hashing.time_series_string                                             29.1ms
[ 36.84%] ··· Running algorithms.Hashing.time_series_timedeltas                                         9.57ms
[ 42.11%] ··· Running algorithms.AddOverflowArray.time_add_overflow_arr_mask_nan                        47.3ms
[ 47.37%] ··· Running algorithms.AddOverflowArray.time_add_overflow_arr_rev                             26.5ms
[ 52.63%] ··· Running algorithms.AddOverflowArray.time_add_overflow_b_mask_nan                          38.9ms
[ 57.89%] ··· Running algorithms.AddOverflowArray.time_add_overflow_both_arg_nan                        39.6ms
[ 63.16%] ··· Running algorithms.AddOverflowScalar.time_add_overflow_scalar                         24.2ms;...
[ 68.42%] ··· Running algorithms.Duplicated.time_duplicated_float                                       40.1ms
[ 73.68%] ··· Running algorithms.Duplicated.time_duplicated_int                                         28.5ms
[ 78.95%] ··· Running algorithms.DuplicatedUniqueIndex.time_duplicated_unique_int                        450μs
[ 84.21%] ··· Running algorithms.Factorize.time_factorize_float                                         31.6ms
[ 89.47%] ··· Running algorithms.Factorize.time_factorize_int                                           18.6ms
[ 94.74%] ··· Running algorithms.Factorize.time_factorize_string                                        56.0ms
[100.00%] ··· Running algorithms.Match.time_match_string                                                 788μs

asv run -b ^algorithms -q
[  5.26%] ··· Running algorithms.Hashing.time_frame                                                     57.4ms
[ 10.53%] ··· Running algorithms.Hashing.time_series_categorical                                        13.3ms
[ 15.79%] ··· Running algorithms.Hashing.time_series_dates                                              12.5ms
[ 21.05%] ··· Running algorithms.Hashing.time_series_float                                              9.70ms
[ 26.32%] ··· Running algorithms.Hashing.time_series_int                                                9.27ms
[ 31.58%] ··· Running algorithms.Hashing.time_series_string                                             30.0ms
[ 36.84%] ··· Running algorithms.Hashing.time_series_timedeltas                                         15.8ms
[ 42.11%] ··· Running algorithms.AddOverflowArray.time_add_overflow_arr_mask_nan                        40.5ms
[ 47.37%] ··· Running algorithms.AddOverflowArray.time_add_overflow_arr_rev                             25.5ms
[ 52.63%] ··· Running algorithms.AddOverflowArray.time_add_overflow_b_mask_nan                          38.7ms
[ 57.89%] ··· Running algorithms.AddOverflowArray.time_add_overflow_both_arg_nan                        44.5ms
[ 63.16%] ··· Running algorithms.AddOverflowScalar.time_add_overflow_scalar                         20.3ms;...
[ 68.42%] ··· Running algorithms.Duplicated.time_duplicated_float                                       45.3ms
[ 73.68%] ··· Running algorithms.Duplicated.time_duplicated_int                                         33.3ms
[ 78.95%] ··· Running algorithms.DuplicatedUniqueIndex.time_duplicated_unique_int                        332μs
[ 84.21%] ··· Running algorithms.Factorize.time_factorize_float                                         26.2ms
[ 89.47%] ··· Running algorithms.Factorize.time_factorize_int                                           18.5ms
[ 94.74%] ··· Running algorithms.Factorize.time_factorize_string                                        55.5ms
[100.00%] ··· Running algorithms.Match.time_match_string                                                 800μs
```

</details>


