### PR TITLE
implement .dt accessor for Index classes

### DIFF
--- a/doc/source/whatsnew/v0.22.0.txt
+++ b/doc/source/whatsnew/v0.22.0.txt
@@ -59,7 +59,7 @@ Other API Changes
 - `tseries.frequencies.get_freq_group()` and `tseries.frequencies.DAYS` are removed from the public API (:issue:`18034`)
 - :func:`Series.truncate` and :func:`DataFrame.truncate` will raise a ``ValueError`` if the index is not sorted instead of an unhelpful ``KeyError`` (:issue:`17935`)
 - :func:`Dataframe.unstack` will now default to filling with ``np.nan`` for ``object`` columns. (:issue:`12815`)
-
+- :class:`Index` now has a `.dt` property that behaves like `Series.dt` (:issue:`17134`)
 
 .. _whatsnew_0220.deprecations:
 

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -1641,6 +1641,21 @@ class Index(IndexOpsMixin, PandasObject):
             return False
         return is_datetime_array(_ensure_object(self.values))
 
+    @property
+    def dt(self):
+        """
+        For a datetime-like Index object, `self.dt` returns `self` so that
+        datetime-like attributes can be accessed symmetrically for Index
+        and Series objects.
+
+        For Index objects that are not datetime-like, `self.dt` will raise
+        an AttributeError.
+        """
+        # Non-raising versions of the `.dt` attribute are available in
+        # DatetimeIndex, PeriodIndex, and TimedeltaIndex.
+        raise AttributeError("Can only use .dt accessor with datetimelike "
+                             "values")
+
     def __reduce__(self):
         d = dict(data=self._data)
         d.update(self._get_attributes_dict())

--- a/pandas/core/indexes/datetimelike.py
+++ b/pandas/core/indexes/datetimelike.py
@@ -124,6 +124,11 @@ class TimelikeOps(object):
 class DatetimeIndexOpsMixin(object):
     """ common ops mixin to support a unified inteface datetimelike Index """
 
+    @property
+    @Appender(Index.dt.__doc__)
+    def dt(self):
+        return self
+
     def equals(self, other):
         """
         Determines if two Index objects contain the same elements.

--- a/pandas/tests/indexes/common.py
+++ b/pandas/tests/indexes/common.py
@@ -1017,3 +1017,12 @@ class Base(object):
             # non-monotonic should raise.
             with pytest.raises(ValueError):
                 indices._searchsorted_monotonic(value, side='left')
+
+    def test_dt_accessor(self):
+        # GH#17134
+        index = self.create_index()
+        if isinstance(index, (DatetimeIndex, TimedeltaIndex, PeriodIndex)):
+            assert index.dt is index
+        else:
+            with pytest.raises(AttributeError):
+                index.dt


### PR DESCRIPTION
`index.dt` --> `self` for `DatetimeIndex`, `TimedeltaIndex`, `PeriodIndex`.  Raises `AttributeError` for others (identical error to `Series.dt`).

@jorisvandenbossche in the discussion in #17134 you had a concern about tab completion/namespacing.  Is that a sticking point for you?

- [x] closes #17134
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry
