### PR TITLE
BUG: Copy categorical codes if empty (fixes #18051)

### DIFF
--- a/doc/source/whatsnew/v0.21.1.txt
+++ b/doc/source/whatsnew/v0.21.1.txt
@@ -135,6 +135,7 @@ Categorical
 - Bug in :meth:`DataFrame.astype` where casting to 'category' on an empty ``DataFrame`` causes a segmentation fault (:issue:`18004`)
 - Error messages in the testing module have been improved when items have different ``CategoricalDtype`` (:issue:`18069`)
 - ``CategoricalIndex`` can now correctly take a ``pd.api.types.CategoricalDtype`` as its dtype (:issue:`18116`)
+- Bug in ``Categorical.unique()`` returning read-only ``codes``  array when all categories were ``NaN`` (:issue:`18051`)
 
 Other
 ^^^^^

--- a/pandas/core/categorical.py
+++ b/pandas/core/categorical.py
@@ -2276,7 +2276,7 @@ def _recode_for_categories(codes, old_categories, new_categories):
 
     if len(old_categories) == 0:
         # All null anyway, so just retain the nulls
-        return codes
+        return codes.copy()
     indexer = coerce_indexer_dtype(new_categories.get_indexer(old_categories),
                                    new_categories)
     new_codes = take_1d(indexer, codes.copy(), fill_value=-1)

--- a/pandas/tests/series/test_analytics.py
+++ b/pandas/tests/series/test_analytics.py
@@ -848,6 +848,12 @@ class TestSeriesAnalytics(TestData):
         result = series.nunique()
         assert result == 11
 
+        # GH 18051
+        s = pd.Series(pd.Categorical([]))
+        assert s.nunique() == 0
+        s = pd.Series(pd.Categorical([np.nan]))
+        assert s.nunique() == 0
+
     def test_unique(self):
 
         # 714 also, dtype=float
@@ -872,6 +878,14 @@ class TestSeriesAnalytics(TestData):
         result = s.unique()
         expected = np.array([1, 2, 3, None], dtype=object)
         tm.assert_numpy_array_equal(result, expected)
+
+        # GH 18051
+        s = pd.Series(pd.Categorical([]))
+        tm.assert_categorical_equal(s.unique(), pd.Categorical([]),
+                                    check_dtype=False)
+        s = pd.Series(pd.Categorical([np.nan]))
+        tm.assert_categorical_equal(s.unique(), pd.Categorical([np.nan]),
+                                    check_dtype=False)
 
     @pytest.mark.parametrize(
         "tc1, tc2",


### PR DESCRIPTION
In [agreement with @ghasemnaddaf](https://github.com/pandas-dev/pandas/pull/18279#issuecomment-346488176) , I've finished up his PR #18279 (added correct tests). Is it time still to get this into v0.21.1?

- [ x] closes #18051 
- [ x] tests added / passed
- [x ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ x] whatsnew entry
