### PR TITLE
Lint rule to catch incorrect sphinx directives

### DIFF
--- a/ci/lint.sh
+++ b/ci/lint.sh
@@ -90,13 +90,26 @@ if [ "$LINT" ]; then
     #
     # Check the following functions:
     # any(), all(), sum(), max(), min(), list(), dict(), set(), frozenset(), tuple(), str.join()
-    grep -R --include="*.py*" -E "[^_](any|all|sum|max|min|list|dict|set|frozenset|tuple|join)\(\[.* for .* in .*\]\)"
+    grep -R --include="*.py*" -E "[^_](any|all|sum|max|min|list|dict|set|frozenset|tuple|join)\(\[.* for .* in .*\]\)" *
 
-    if [ $? = "0" ]; then
+    if [ $? -ne "0" ]; then
         RET=1
     fi
     echo "Check for use of lists instead of generators in built-in Python functions DONE"
 
+    echo "Check for incorrect sphinx directives"
+	SPHINX_DIRECTIVES=$(echo \
+	   "autosummary|contents|currentmodule|deprecated|function|image|"\
+	   "important|include|ipython|literalinclude|math|module|note|raw|"\
+	   "seealso|toctree|versionadded|versionchanged|warning" | tr -d "[:space:]")
+    for path in './pandas' './doc/source'
+    do
+        grep -R --include="*.py" --include="*.rst" -E "\.\. ($SPHINX_DIRECTIVES):[^:]" $path
+        if [ $? -ne "0" ]; then
+            RET=1
+        fi
+    done
+	echo "Check for incorrect sphinx directives DONE"
 else
     echo "NOT Linting"
 fi

--- a/ci/lint.sh
+++ b/ci/lint.sh
@@ -104,7 +104,7 @@ if [ "$LINT" ]; then
        "seealso|toctree|versionadded|versionchanged|warning" | tr -d "[:space:]")
     for path in './pandas' './doc/source'
     do
-        grep -R --include="*.py" --include="*.rst" -E "\.\. ($SPHINX_DIRECTIVES):[^:]" $path
+        grep -R --include="*.py" --include="*.pyx" --include="*.rst" -E "\.\. ($SPHINX_DIRECTIVES):[^:]" $path
         if [ $? = "0" ]; then
             RET=1
         fi

--- a/ci/lint.sh
+++ b/ci/lint.sh
@@ -92,24 +92,24 @@ if [ "$LINT" ]; then
     # any(), all(), sum(), max(), min(), list(), dict(), set(), frozenset(), tuple(), str.join()
     grep -R --include="*.py*" -E "[^_](any|all|sum|max|min|list|dict|set|frozenset|tuple|join)\(\[.* for .* in .*\]\)" *
 
-    if [ $? -ne "0" ]; then
+    if [ $? = "0" ]; then
         RET=1
     fi
     echo "Check for use of lists instead of generators in built-in Python functions DONE"
 
     echo "Check for incorrect sphinx directives"
-	SPHINX_DIRECTIVES=$(echo \
-	   "autosummary|contents|currentmodule|deprecated|function|image|"\
-	   "important|include|ipython|literalinclude|math|module|note|raw|"\
-	   "seealso|toctree|versionadded|versionchanged|warning" | tr -d "[:space:]")
+    SPHINX_DIRECTIVES=$(echo \
+       "autosummary|contents|currentmodule|deprecated|function|image|"\
+       "important|include|ipython|literalinclude|math|module|note|raw|"\
+       "seealso|toctree|versionadded|versionchanged|warning" | tr -d "[:space:]")
     for path in './pandas' './doc/source'
     do
         grep -R --include="*.py" --include="*.rst" -E "\.\. ($SPHINX_DIRECTIVES):[^:]" $path
-        if [ $? -ne "0" ]; then
+        if [ $? = "0" ]; then
             RET=1
         fi
     done
-	echo "Check for incorrect sphinx directives DONE"
+    echo "Check for incorrect sphinx directives DONE"
 else
     echo "NOT Linting"
 fi

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -4513,7 +4513,7 @@ class DataFrame(NDFrame):
         fill_value : replace NaN with this value if the unstack produces
             missing values
 
-            .. versionadded: 0.18.0
+            .. versionadded:: 0.18.0
 
         See also
         --------
@@ -4676,7 +4676,7 @@ class DataFrame(NDFrame):
         axis : {0 or 'index', 1 or 'columns'}, default 0
             Take difference over rows (0) or columns (1).
 
-            .. versionadded: 0.16.1
+            .. versionadded:: 0.16.1
 
         Returns
         -------

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -1626,7 +1626,7 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
         ignore_index : boolean, default False
             If True, do not use the index labels.
 
-            .. versionadded: 0.19.0
+            .. versionadded:: 0.19.0
 
         verify_integrity : boolean, default False
             If True, raise Exception on creating index with duplicates
@@ -2213,7 +2213,7 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
         fill_value : replace NaN with this value if the unstack produces
             missing values
 
-            .. versionadded: 0.18.0
+            .. versionadded:: 0.18.0
 
         Examples
         --------

--- a/pandas/core/tools/datetimes.py
+++ b/pandas/core/tools/datetimes.py
@@ -114,7 +114,7 @@ def to_datetime(arg, errors='raise', dayfirst=False, yearfirst=False,
     ----------
     arg : integer, float, string, datetime, list, tuple, 1-d array, Series
 
-        .. versionadded: 0.18.1
+        .. versionadded:: 0.18.1
 
            or DataFrame/dict-like
 
@@ -140,7 +140,7 @@ def to_datetime(arg, errors='raise', dayfirst=False, yearfirst=False,
         Warning: yearfirst=True is not strict, but will prefer to parse
         with year first (this is a known bug, based on dateutil beahavior).
 
-        .. versionadded: 0.16.1
+        .. versionadded:: 0.16.1
 
     utc : boolean, default None
         Return UTC DatetimeIndex if True (converting any tz-aware
@@ -178,13 +178,13 @@ def to_datetime(arg, errors='raise', dayfirst=False, yearfirst=False,
         - If Timestamp convertible, origin is set to Timestamp identified by
           origin.
 
-        .. versionadded: 0.20.0
+        .. versionadded:: 0.20.0
     cache : boolean, default False
         If True, use a cache of unique, converted dates to apply the datetime
         conversion. May produce sigificant speed-up when parsing duplicate date
         strings, especially ones with timezone offsets.
 
-        .. versionadded: 0.22.0
+        .. versionadded:: 0.22.0
 
     Returns
     -------

--- a/pandas/tseries/offsets.py
+++ b/pandas/tseries/offsets.py
@@ -774,7 +774,7 @@ class BusinessHour(BusinessHourMixin, SingleConstructorOffset):
     """
     DateOffset subclass representing possibly n business days
 
-    .. versionadded: 0.16.1
+    .. versionadded:: 0.16.1
 
     """
     _prefix = 'BH'
@@ -878,7 +878,7 @@ class CustomBusinessHour(BusinessHourMixin, SingleConstructorOffset):
     """
     DateOffset subclass representing possibly n custom business days
 
-    .. versionadded: 0.18.1
+    .. versionadded:: 0.18.1
 
     """
     _prefix = 'CBH'


### PR DESCRIPTION
- [x] closes #18425
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
