### PR TITLE
BUG: in Python3 MultiIndex.from_tuples cannot take "zipped" tuples

### DIFF
--- a/doc/source/whatsnew/v0.22.0.txt
+++ b/doc/source/whatsnew/v0.22.0.txt
@@ -140,6 +140,7 @@ Indexing
 - Bug in :func:`Series.truncate` which raises ``TypeError`` with a monotonic ``PeriodIndex`` (:issue:`17717`)
 - Bug in :func:`DataFrame.groupby` where tuples were interpreted as lists of keys rather than as keys (:issue:`17979`, :issue:`18249`)
 - Bug in :func:`MultiIndex.remove_unused_levels`` which would fill nan values (:issue:`18417`)
+- Bug in :func:`MultiIndex.from_tuples`` which would fail to take zipped tuples in python3 (:issue:`18434`)
 - Bug in :class:`IntervalIndex` where empty and purely NA data was constructed inconsistently depending on the construction method (:issue:`18421`)
 -
 

--- a/pandas/core/indexes/multi.py
+++ b/pandas/core/indexes/multi.py
@@ -1162,6 +1162,11 @@ class MultiIndex(Index):
         MultiIndex.from_product : Make a MultiIndex from cartesian product
                                   of iterables
         """
+        if not is_list_like(arrays):
+            raise TypeError("Input must be a list / sequence of array-likes.")
+        elif is_iterator(arrays):
+            arrays = list(arrays)
+
         # Check if lengths of all arrays are equal or not,
         # raise ValueError, if not
         for i in range(1, len(arrays)):
@@ -1206,6 +1211,11 @@ class MultiIndex(Index):
         MultiIndex.from_product : Make a MultiIndex from cartesian product
                                   of iterables
         """
+        if not is_list_like(tuples):
+            raise TypeError('Input must be a list / sequence of tuple-likes.')
+        elif is_iterator(tuples):
+            tuples = list(tuples)
+
         if len(tuples) == 0:
             if names is None:
                 msg = 'Cannot infer number of levels from empty list'
@@ -1259,6 +1269,11 @@ class MultiIndex(Index):
         """
         from pandas.core.categorical import _factorize_from_iterables
         from pandas.core.reshape.util import cartesian_product
+
+        if not is_list_like(iterables):
+            raise TypeError("Input must be a list / sequence of iterables.")
+        elif is_iterator(iterables):
+            iterables = list(iterables)
 
         labels, levels = _factorize_from_iterables(iterables)
         labels = cartesian_product(labels)

--- a/pandas/tests/indexes/test_multi.py
+++ b/pandas/tests/indexes/test_multi.py
@@ -673,8 +673,8 @@ class TestMultiIndex(Base):
             arrays.append(np.asarray(lev).take(lab))
 
         # list of arrays as input
-        result = MultiIndex.from_arrays(arrays)
-        assert list(result) == list(self.index)
+        result = MultiIndex.from_arrays(arrays, names=self.index.names)
+        tm.assert_index_equal(result, self.index)
 
         # infer correctly
         result = MultiIndex.from_arrays([[pd.NaT, Timestamp('20130101')],
@@ -689,8 +689,8 @@ class TestMultiIndex(Base):
             arrays.append(np.asarray(lev).take(lab))
 
         # iterator as input
-        result = MultiIndex.from_arrays(iter(arrays))
-        assert list(result) == list(self.index)
+        result = MultiIndex.from_arrays(iter(arrays), names=self.index.names)
+        tm.assert_index_equal(result, self.index)
 
         # invalid iterator input
         with tm.assert_raises_regex(
@@ -841,7 +841,6 @@ class TestMultiIndex(Base):
         expected = MultiIndex.from_tuples(tuples, names=names)
 
         tm.assert_index_equal(result, expected)
-        assert result.names == names
 
     def test_from_product_iterator(self):
         # GH 18434
@@ -855,8 +854,7 @@ class TestMultiIndex(Base):
 
         # iterator as input
         result = MultiIndex.from_product(iter([first, second]), names=names)
-        assert result.equals(expected)
-        assert result.names == names
+        tm.assert_index_equal(result, expected)
 
         # Invalid non-iterable input
         with tm.assert_raises_regex(
@@ -1767,8 +1765,7 @@ class TestMultiIndex(Base):
 
         # input tuples
         result = MultiIndex.from_tuples(((1, 2), (3, 4)), names=['a', 'b'])
-        assert expected.names == result.names
-        assert result.equals(expected)
+        tm.assert_index_equal(result, expected)
 
     def test_from_tuples_iterator(self):
         # GH 18434
@@ -1778,8 +1775,7 @@ class TestMultiIndex(Base):
                               names=['a', 'b'])
 
         result = MultiIndex.from_tuples(zip([1, 3], [2, 4]), names=['a', 'b'])
-        assert expected.names == result.names
-        assert result.equals(expected)
+        tm.assert_index_equal(result, expected)
 
         # input non-iterables
         with tm.assert_raises_regex(


### PR DESCRIPTION
MultiIndex.from_tuples accept zipped tuples in python 3. Ensures compatibility
between 2 and 3.

- [x] closes #18434 
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry
