### PR TITLE
CLN: ASV attrs_caching benchmark

### DIFF
--- a/asv_bench/benchmarks/attrs_caching.py
+++ b/asv_bench/benchmarks/attrs_caching.py
@@ -1,4 +1,5 @@
-from .pandas_vb_common import *
+import numpy as np
+from pandas import DataFrame
 
 try:
     from pandas.util import cache_readonly
@@ -7,9 +8,11 @@ except ImportError:
 
 
 class DataFrameAttributes(object):
+
     goal_time = 0.2
 
     def setup(self):
+        np.random.seed(1234)
         self.df = DataFrame(np.random.randn(10, 6))
         self.cur_index = self.df.index
 
@@ -21,6 +24,7 @@ class DataFrameAttributes(object):
 
 
 class CacheReadonly(object):
+
     goal_time = 0.2
 
     def setup(self):


### PR DESCRIPTION
- Added `np.random.seed(1234)` in setup classes where random data is created xref #8144

- Ran flake 8 and replaced star imports (with pep8 in mind, I think we should avoid `from .pandas_vb_common import *`) 

```
$asv run -q -b ^attrs_caching
[ 33.33%] ··· Running attrs_caching.CacheReadonly.time_cache_readonly                                                                   9.12μs
[ 66.67%] ··· Running attrs_caching.DataFrameAttributes.time_get_index                                                                  14.5μs
[100.00%] ··· Running attrs_caching.DataFrameAttributes.time_set_index                                                                  27.3μs
```
