### PR TITLE
More tslibs TODOS: small optimizations, trim namespaces

### DIFF
--- a/pandas/_libs/tslibs/timedeltas.pyx
+++ b/pandas/_libs/tslibs/timedeltas.pyx
@@ -775,55 +775,6 @@ cdef class _Timedelta(timedelta):
             td=components, seconds=seconds)
         return tpl
 
-    cdef _Timedelta _round(_Timedelta self, freq, rounder):
-        # Note: _round is not visible in the python namespace, so methods that
-        # call it must be defined in _Timedelta, not Timedelta
-        cdef:
-            int64_t result, unit
-
-        from pandas.tseries.frequencies import to_offset
-        unit = to_offset(freq).nanos
-        result = unit * rounder(self.value / float(unit))
-        return Timedelta(result, unit='ns')
-
-    def round(self, freq):
-        """
-        Round the Timedelta to the specified resolution
-
-        Returns
-        -------
-        a new Timedelta rounded to the given resolution of `freq`
-
-        Parameters
-        ----------
-        freq : a freq string indicating the rounding resolution
-
-        Raises
-        ------
-        ValueError if the freq cannot be converted
-        """
-        return self._round(freq, np.round)
-
-    def floor(self, freq):
-        """
-        return a new Timedelta floored to this resolution
-
-        Parameters
-        ----------
-        freq : a freq string indicating the flooring resolution
-        """
-        return self._round(freq, np.floor)
-
-    def ceil(self, freq):
-        """
-        return a new Timedelta ceiled to this resolution
-
-        Parameters
-        ----------
-        freq : a freq string indicating the ceiling resolution
-        """
-        return self._round(freq, np.ceil)
-
 
 # Python front end to C extension type _Timedelta
 # This serves as the box for timedelta64
@@ -913,6 +864,53 @@ class Timedelta(_Timedelta):
     def __reduce__(self):
         object_state = self.value,
         return (Timedelta, object_state)
+
+    def _round(self, freq, rounder):
+        cdef:
+            int64_t result, unit
+
+        from pandas.tseries.frequencies import to_offset
+        unit = to_offset(freq).nanos
+        result = unit * rounder(self.value / float(unit))
+        return Timedelta(result, unit='ns')
+
+    def round(self, freq):
+        """
+        Round the Timedelta to the specified resolution
+
+        Returns
+        -------
+        a new Timedelta rounded to the given resolution of `freq`
+
+        Parameters
+        ----------
+        freq : a freq string indicating the rounding resolution
+
+        Raises
+        ------
+        ValueError if the freq cannot be converted
+        """
+        return self._round(freq, np.round)
+
+    def floor(self, freq):
+        """
+        return a new Timedelta floored to this resolution
+
+        Parameters
+        ----------
+        freq : a freq string indicating the flooring resolution
+        """
+        return self._round(freq, np.floor)
+
+    def ceil(self, freq):
+        """
+        return a new Timedelta ceiled to this resolution
+
+        Parameters
+        ----------
+        freq : a freq string indicating the ceiling resolution
+        """
+        return self._round(freq, np.ceil)
 
     # ----------------------------------------------------------------
     # Arithmetic Methods

--- a/pandas/_libs/tslibs/timestamps.pyx
+++ b/pandas/_libs/tslibs/timestamps.pyx
@@ -5,6 +5,8 @@ import warnings
 from cpython cimport (PyObject_RichCompareBool, PyObject_RichCompare,
                       Py_GT, Py_GE, Py_EQ, Py_NE, Py_LT, Py_LE)
 
+cimport cython
+
 import numpy as np
 cimport numpy as np
 from numpy cimport int64_t, int32_t, int8_t, ndarray

--- a/pandas/_libs/tslibs/timestamps.pyx
+++ b/pandas/_libs/tslibs/timestamps.pyx
@@ -174,8 +174,8 @@ cdef class _Timestamp(datetime):
             elif op == Py_GE:
                 return dtval >= other
 
-    cdef void _assert_tzawareness_compat(_Timestamp self,
-                                         object other) except -1:
+    cdef int _assert_tzawareness_compat(_Timestamp self,
+                                        object other) except -1:
         if self.tzinfo is None:
             if other.tzinfo is not None:
                 raise TypeError('Cannot compare tz-naive and tz-aware '

--- a/pandas/_libs/tslibs/timestamps.pyx
+++ b/pandas/_libs/tslibs/timestamps.pyx
@@ -643,7 +643,7 @@ class Timestamp(_Timestamp):
     def _round(self, freq, rounder):
 
         cdef:
-            int64_t unit, rounded, value, buff = 1000000
+            int64_t unit, r, value, buff = 1000000
             object result
 
         from pandas.tseries.frequencies import to_offset
@@ -655,15 +655,15 @@ class Timestamp(_Timestamp):
         if unit < 1000 and unit % 1000 != 0:
             # for nano rounding, work with the last 6 digits separately
             # due to float precision
-            rounded = (buff * (value // buff) + unit *
-                       (rounder((value % buff) / float(unit))).astype('i8'))
+            r = (buff * (value // buff) + unit *
+                 (rounder((value % buff) / float(unit))).astype('i8'))
         elif unit >= 1000 and unit % 1000 != 0:
             msg = 'Precision will be lost using frequency: {}'
             warnings.warn(msg.format(freq))
-            rounded = (unit * rounder(value / float(unit)).astype('i8'))
+            r = (unit * rounder(value / float(unit)).astype('i8'))
         else:
-            rounded = (unit * rounder(value / float(unit)).astype('i8'))
-        result = Timestamp(rounded, unit='ns')
+            r = (unit * rounder(value / float(unit)).astype('i8'))
+        result = Timestamp(r, unit='ns')
         if self.tz is not None:
             result = result.tz_localize(self.tz)
         return result


### PR DESCRIPTION
A few methods of `Timedelta` and `Timestamp` that don't need to be user-facing are changed from `cpdef` to `cdef`.  To make the wheels turn, `Timestamp` methods that _call_ those methods are moved from `Timestamp` to `_Timestamp`.

Stronger typing for `_Timestamp. _get_start_end_field` and a couple others.

`@cython.final` supposedly allows for a small optimization because cython does not need to check at runtime whether a method has been overridden.  Applied to `Timestamp.__add__`, `Timestamp.__sub__`

