### PR TITLE
BLD: since we already use setuptools, let's remove the optional logic…

### DIFF
--- a/doc/source/whatsnew/v0.22.0.txt
+++ b/doc/source/whatsnew/v0.22.0.txt
@@ -245,5 +245,5 @@ Other
 - Fixed a bug where creating a Series from an array that contains both tz-naive and tz-aware values will result in a Series whose dtype is tz-aware instead of object (:issue:`16406`)
 - Fixed construction of a :class:`Series` from a ``dict`` containing ``NaN`` as key (:issue:`18480`)
 - Adding a ``Period`` object to a ``datetime`` or ``Timestamp`` object will now correctly raise a ``TypeError`` (:issue:`17983`)
-- BLD: since we already use setuptools, let's remove the optional logic in setup.py (:issue:`18113`)
-- 
+- Simplified setup due to explicit dependence on setuptools (:issue:`18113`)
+-

--- a/doc/source/whatsnew/v0.22.0.txt
+++ b/doc/source/whatsnew/v0.22.0.txt
@@ -245,4 +245,5 @@ Other
 - Fixed a bug where creating a Series from an array that contains both tz-naive and tz-aware values will result in a Series whose dtype is tz-aware instead of object (:issue:`16406`)
 - Fixed construction of a :class:`Series` from a ``dict`` containing ``NaN`` as key (:issue:`18480`)
 - Adding a ``Period`` object to a ``datetime`` or ``Timestamp`` object will now correctly raise a ``TypeError`` (:issue:`17983`)
--
+- BLD: since we already use setuptools, let's remove the optional logic in setup.py (:issue:`18113`)
+- 

--- a/setup.py
+++ b/setup.py
@@ -41,23 +41,17 @@ except ImportError:
     _CYTHON_INSTALLED = False
 
 
-setuptools_kwargs = {}
 min_numpy_ver = '1.9.0'
-if sys.version_info[0] >= 3:
+setuptools_kwargs = {
+    'install_requires': [
+        'python-dateutil >= 2' if sys.version_info[0] >= 3 else 'python-dateutil',
+        'pytz >= 2011k',
+        'numpy >= %s' % min_numpy_ver,
+    ],
+    'setup_requires': ['numpy >= %s' % min_numpy_ver],
+    'zip_safe': False,
+}
 
-    setuptools_kwargs = {'zip_safe': False,
-                         'install_requires': ['python-dateutil >= 2',
-                                              'pytz >= 2011k',
-                                              'numpy >= %s' % min_numpy_ver],
-                         'setup_requires': ['numpy >= %s' % min_numpy_ver]}
-else:
-    setuptools_kwargs = {
-        'install_requires': ['python-dateutil',
-                             'pytz >= 2011k',
-                             'numpy >= %s' % min_numpy_ver],
-        'setup_requires': ['numpy >= %s' % min_numpy_ver],
-        'zip_safe': False,
-    }
 
 from distutils.extension import Extension  # noqa:E402
 from distutils.command.build import build  # noqa:E402
@@ -708,8 +702,6 @@ _move_ext = Extension('pandas.util._move',
                       depends=[],
                       sources=['pandas/util/move.c'])
 extensions.append(_move_ext)
-
-setuptools_kwargs["test_suite"] = "nose.collector"
 
 # The build cache system does string matching below this point.
 # if you change something, be careful.

--- a/setup.py
+++ b/setup.py
@@ -9,9 +9,11 @@ BSD license. Parts are from lxml (https://github.com/lxml/lxml)
 import os
 from os.path import join as pjoin
 
+import pkg_resources
 import sys
 import shutil
 from distutils.version import LooseVersion
+from setuptools import setup, Command
 
 # versioning
 import versioneer
@@ -38,14 +40,6 @@ try:
 except ImportError:
     _CYTHON_INSTALLED = False
 
-try:
-    import pkg_resources
-    from setuptools import setup, Command
-    _have_setuptools = True
-except ImportError:
-    # no setuptools installed
-    from distutils.core import setup, Command
-    _have_setuptools = False
 
 setuptools_kwargs = {}
 min_numpy_ver = '1.9.0'
@@ -56,10 +50,6 @@ if sys.version_info[0] >= 3:
                                               'pytz >= 2011k',
                                               'numpy >= %s' % min_numpy_ver],
                          'setup_requires': ['numpy >= %s' % min_numpy_ver]}
-    if not _have_setuptools:
-        sys.exit("need setuptools/distribute for Py3k"
-                 "\n$ pip install distribute")
-
 else:
     setuptools_kwargs = {
         'install_requires': ['python-dateutil',
@@ -68,16 +58,6 @@ else:
         'setup_requires': ['numpy >= %s' % min_numpy_ver],
         'zip_safe': False,
     }
-
-    if not _have_setuptools:
-        try:
-            import numpy  # noqa:F401
-            import dateutil  # noqa:F401
-            setuptools_kwargs = {}
-        except ImportError:
-            sys.exit("install requires: 'python-dateutil < 2','numpy'."
-                     "  use pip or easy_install."
-                     "\n   $ pip install 'python-dateutil < 2' 'numpy'")
 
 from distutils.extension import Extension  # noqa:E402
 from distutils.command.build import build  # noqa:E402
@@ -695,7 +675,7 @@ extensions.append(unpacker_ext)
 # ----------------------------------------------------------------------
 # ujson
 
-if suffix == '.pyx' and 'setuptools' in sys.modules:
+if suffix == '.pyx':
     # undo dumb setuptools bug clobbering .pyx sources back to .c
     for ext in extensions:
         if ext.sources[0].endswith(('.c', '.cpp')):
@@ -729,9 +709,7 @@ _move_ext = Extension('pandas.util._move',
                       sources=['pandas/util/move.c'])
 extensions.append(_move_ext)
 
-
-if _have_setuptools:
-    setuptools_kwargs["test_suite"] = "nose.collector"
+setuptools_kwargs["test_suite"] = "nose.collector"
 
 # The build cache system does string matching below this point.
 # if you change something, be careful.


### PR DESCRIPTION
… in setup.py (GH18113).

- [x] closes #18113 
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry
