### PR TITLE
PERF: refactor Series().str.get_dummies

### DIFF
--- a/doc/source/whatsnew/v0.22.0.txt
+++ b/doc/source/whatsnew/v0.22.0.txt
@@ -107,6 +107,7 @@ Performance Improvements
 - The overriden ``Timedelta`` properties of days, seconds and microseconds have been removed, leveraging their built-in Python versions instead (:issue:`18242`)
 - ``Series`` construction will reduce the number of copies made of the input data in certain cases (:issue:`17449`)
 - Improved performance of :func:`Series.dt.date` and :func:`DatetimeIndex.date` (:issue:`18058`)
+- Improved performance of :func:`Series.str.get_dummies` (:issue:`18454`)
 -
 
 .. _whatsnew_0220.docs:

--- a/pandas/core/strings.py
+++ b/pandas/core/strings.py
@@ -19,6 +19,7 @@ import pandas.compat as compat
 from pandas.core.base import NoNewAttributesMixin
 from pandas.util._decorators import Appender
 import re
+import itertools
 import pandas._libs.lib as lib
 import warnings
 import textwrap
@@ -837,23 +838,11 @@ def str_get_dummies(arr, sep='|'):
     --------
     pandas.get_dummies
     """
-    arr = arr.fillna('')
-    try:
-        arr = sep + arr + sep
-    except TypeError:
-        arr = sep + arr.astype(str) + sep
 
-    tags = set()
-    for ts in arr.str.split(sep):
-        tags.update(ts)
-    tags = sorted(tags - set([""]))
-
-    dummies = np.empty((len(arr), len(tags)), dtype=np.int64)
-
-    for i, t in enumerate(tags):
-        pat = sep + t + sep
-        dummies[:, i] = lib.map_infer(arr.values, lambda x: pat in x)
-    return dummies, tags
+    arr = [list() if el is np.nan else str(el).split(sep) for el in arr]
+    tags = sorted(set(itertools.chain.from_iterable(arr)))
+    result = np.array([[t in x for t in tags] for x in arr], dtype=np.int64)
+    return result, tags
 
 
 def str_join(arr, sep):


### PR DESCRIPTION
- [x] tests passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry

No issue to link. No new tests.

Since `str_get_dummies` always receives just `Series` of strings, it's safe to transform it to python-native data structures and cut back some performance overhead. Works up to 2x faster and does not require Cython magic.

Script I used to test performance:
```python
import pandas as pd
import string
from itertools import cycle, islice
from timeit import timeit

letters_cycle = cycle(string.ascii_lowercase)
def letters(n):
    return list(islice(letters_cycle, n))

s1 = pd.Series(letters(3))
def f1():
    return s1.str.get_dummies('|')

s2 = pd.Series(letters(100))
def f2():
    return s2.str.get_dummies('|')


s3 = pd.Series(['{}|{}'.format(a, b) for a, b in list(zip(letters(10), letters(10)))])
def f3():
    return s3.str.get_dummies('|')

print('3 items:         ', timeit(f1, number=1000))
print('100 items:       ', timeit(f2, number=1000))
print('10 complex items:', timeit(f3, number=1000))
```

Current master:
```
3 items:          1.226549802115187
100 items:        4.812093775952235
10 complex items: 2.868986740009859
```

This PR:
```
3 items:          0.5505142270121723
100 items:        3.0751350841019303
10 complex items: 1.5680736750364304
```