### PR TITLE
DEPR: Deprecate NDFrame.as_matrix

### DIFF
--- a/doc/source/whatsnew/v0.22.0.txt
+++ b/doc/source/whatsnew/v0.22.0.txt
@@ -87,7 +87,7 @@ Deprecations
 ~~~~~~~~~~~~
 
 - ``Series.from_array`` and ``SparseSeries.from_array`` are deprecated. Use the normal constructor ``Series(..)`` and ``SparseSeries(..)`` instead (:issue:`18213`).
--
+- ``NDFrame.as_matrix`` is deprecated. Use ``NDFrame.values`` instead (:issue:`18458`).
 -
 
 .. _whatsnew_0220.prior_deprecations:

--- a/doc/source/whatsnew/v0.22.0.txt
+++ b/doc/source/whatsnew/v0.22.0.txt
@@ -87,7 +87,7 @@ Deprecations
 ~~~~~~~~~~~~
 
 - ``Series.from_array`` and ``SparseSeries.from_array`` are deprecated. Use the normal constructor ``Series(..)`` and ``SparseSeries(..)`` instead (:issue:`18213`).
-- ``NDFrame.as_matrix`` is deprecated. Use ``NDFrame.values`` instead (:issue:`18458`).
+- ``DataFrame.as_matrix`` is deprecated. Use ``DataFrame.values`` instead (:issue:`18458`).
 -
 
 .. _whatsnew_0220.prior_deprecations:

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -3773,12 +3773,11 @@ class NDFrame(PandasObject, SelectionMixin):
         --------
         pandas.DataFrame.values
         """
-        warnings.warn("method ``as_matrix`` will be removed in a future version. "
-                      "Use ``values`` instead.", FutureWarning, stacklevel=2)
+        warnings.warn("Method .as_matrix will be removed in a future version. "
+                      "Use .values instead.", FutureWarning, stacklevel=2)
         self._consolidate_inplace()
-        if self._AXIS_REVERSED:
-            return self._data.as_matrix(columns).T
-        return self._data.as_matrix(columns)
+        return self._data.as_array(transpose=self._AXIS_REVERSED,
+                                   items=columns)
 
     @property
     def values(self):
@@ -3797,7 +3796,7 @@ class NDFrame(PandasObject, SelectionMixin):
         will result in a flot64 dtype.
         """
         self._consolidate_inplace()
-        return self._data.as_matrix(transpose=self._AXIS_REVERSED)
+        return self._data.as_array(transpose=self._AXIS_REVERSED)
 
     @property
     def _values(self):

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -3735,6 +3735,9 @@ class NDFrame(PandasObject, SelectionMixin):
 
     def as_matrix(self, columns=None):
         """
+        DEPRECATED: This method will be removed in a future version.
+        Use :meth:`NDFrame.values` instead.
+
         Convert the frame to its Numpy-array representation.
 
         Parameters
@@ -3770,6 +3773,8 @@ class NDFrame(PandasObject, SelectionMixin):
         --------
         pandas.DataFrame.values
         """
+        warnings.warn("This method will be removed in a future version. "
+                      "Use ``.values`` instead.")
         self._consolidate_inplace()
         if self._AXIS_REVERSED:
             return self._data.as_matrix(columns).T
@@ -3791,7 +3796,10 @@ class NDFrame(PandasObject, SelectionMixin):
         int32. By numpy.find_common_type convention, mixing int64 and uint64
         will result in a flot64 dtype.
         """
-        return self.as_matrix()
+        self._consolidate_inplace()
+        if self._AXIS_REVERSED:
+            return self._data.as_matrix().T
+        return self._data.as_matrix()
 
     @property
     def _values(self):
@@ -3801,11 +3809,11 @@ class NDFrame(PandasObject, SelectionMixin):
     @property
     def _get_values(self):
         # compat
-        return self.as_matrix()
+        return self.values
 
     def get_values(self):
         """same as values (but handles sparseness conversions)"""
-        return self.as_matrix()
+        return self.values
 
     def get_dtype_counts(self):
         """Return the counts of dtypes in this object."""

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -3735,8 +3735,8 @@ class NDFrame(PandasObject, SelectionMixin):
 
     def as_matrix(self, columns=None):
         """
-        DEPRECATED: This method will be removed in a future version.
-        Use :meth:`NDFrame.values` instead.
+        DEPRECATED: as_matrix will be removed in a future version.
+        Use :meth:`DataFrame.values` instead.
 
         Convert the frame to its Numpy-array representation.
 
@@ -3773,8 +3773,8 @@ class NDFrame(PandasObject, SelectionMixin):
         --------
         pandas.DataFrame.values
         """
-        warnings.warn("This method will be removed in a future version. "
-                      "Use ``.values`` instead.")
+        warnings.warn("method ``as_matrix`` will be removed in a future version. "
+                      "Use ``values`` instead.", FutureWarning, stacklevel=2)
         self._consolidate_inplace()
         if self._AXIS_REVERSED:
             return self._data.as_matrix(columns).T
@@ -3797,9 +3797,7 @@ class NDFrame(PandasObject, SelectionMixin):
         will result in a flot64 dtype.
         """
         self._consolidate_inplace()
-        if self._AXIS_REVERSED:
-            return self._data.as_matrix().T
-        return self._data.as_matrix()
+        return self._data.as_matrix(transpose=self._AXIS_REVERSED)
 
     @property
     def _values(self):

--- a/pandas/core/internals.py
+++ b/pandas/core/internals.py
@@ -3670,9 +3670,10 @@ class BlockManager(PandasObject):
         return self.apply('copy', axes=new_axes, deep=deep,
                           do_integrity_check=False)
 
-    def as_matrix(self, items=None):
+    def as_matrix(self, transpose=False, items=None):
         if len(self.blocks) == 0:
-            return np.empty(self.shape, dtype=float)
+            arr = np.empty(self.shape, dtype=float)
+            return arr.transpose() if transpose else arr
 
         if items is not None:
             mgr = self.reindex_axis(items, axis=0)
@@ -3680,9 +3681,11 @@ class BlockManager(PandasObject):
             mgr = self
 
         if self._is_single_block or not self.is_mixed_type:
-            return mgr.blocks[0].get_values()
+            arr = mgr.blocks[0].get_values()
         else:
-            return mgr._interleave()
+            arr = mgr._interleave()
+
+        return arr.transpose() if transpose else arr
 
     def _interleave(self):
         """

--- a/pandas/core/internals.py
+++ b/pandas/core/internals.py
@@ -3484,7 +3484,7 @@ class BlockManager(PandasObject):
             mgr = self
 
         # figure out our mask a-priori to avoid repeated replacements
-        values = self.as_matrix()
+        values = self.as_array()
 
         def comp(s):
             if isna(s):
@@ -3670,7 +3670,21 @@ class BlockManager(PandasObject):
         return self.apply('copy', axes=new_axes, deep=deep,
                           do_integrity_check=False)
 
-    def as_matrix(self, transpose=False, items=None):
+    def as_array(self, transpose=False, items=None):
+        """Convert the blockmanager data into an numpy array.
+
+        Parameters
+        ----------
+        transpose : boolean, default False
+            If True, transpose the return array
+        items : list of strings or None
+            Names of block items that will be included in the returned
+            array. ``None`` means that all block items will be used
+
+        Returns
+        -------
+        arr : ndarray
+        """
         if len(self.blocks) == 0:
             arr = np.empty(self.shape, dtype=float)
             return arr.transpose() if transpose else arr

--- a/pandas/core/panel.py
+++ b/pandas/core/panel.py
@@ -464,7 +464,7 @@ class Panel(NDFrame):
 
     def as_matrix(self):
         self._consolidate_inplace()
-        return self._data.as_matrix()
+        return self._data.as_array()
 
     # ----------------------------------------------------------------------
     # Getting and setting elements

--- a/pandas/tests/frame/test_api.py
+++ b/pandas/tests/frame/test_api.py
@@ -257,7 +257,7 @@ class SharedWithSparse(object):
                     assert value == frame[col][i]
 
         # mixed type
-        mat = self.mixed_frame.as_matrix(['foo', 'A'])
+        mat = self.mixed_frame[['foo', 'A']].values
         assert mat[0, 0] == 'bar'
 
         df = self.klass({'real': [1, 2, 3], 'complex': [1j, 2j, 3j]})
@@ -368,6 +368,13 @@ class TestDataFrameMisc(SharedWithSparse, TestData):
     def test_values(self):
         self.frame.values[:, 0] = 5.
         assert (self.frame.values[:, 0] == 5).all()
+
+    def test_as_matrix_deprecated(self):
+        # GH18458
+        with tm.assert_produces_warning(FutureWarning):
+            result = self.frame.as_matrix()
+        expected = self.frame.values
+        tm.assert_numpy_array_equal(result, expected)
 
     def test_deepcopy(self):
         cp = deepcopy(self.frame)

--- a/pandas/tests/frame/test_api.py
+++ b/pandas/tests/frame/test_api.py
@@ -243,9 +243,9 @@ class SharedWithSparse(object):
     def test_len(self):
         assert len(self.frame) == len(self.frame.index)
 
-    def test_as_matrix(self):
+    def test_values(self):
         frame = self.frame
-        mat = frame.as_matrix()
+        mat = frame.values
 
         frameCols = frame.columns
         for i, row in enumerate(mat):
@@ -261,11 +261,11 @@ class SharedWithSparse(object):
         assert mat[0, 0] == 'bar'
 
         df = self.klass({'real': [1, 2, 3], 'complex': [1j, 2j, 3j]})
-        mat = df.as_matrix()
+        mat = df.values
         assert mat[0, 0] == 1j
 
         # single block corner case
-        mat = self.frame.as_matrix(['A', 'B'])
+        mat = self.frame[['A', 'B']].values
         expected = self.frame.reindex(columns=['A', 'B']).values
         assert_almost_equal(mat, expected)
 
@@ -311,8 +311,8 @@ class SharedWithSparse(object):
         DataFrame.index  # no exception!
         DataFrame.columns  # no exception!
 
-    def test_more_asMatrix(self):
-        values = self.mixed_frame.as_matrix()
+    def test_more_values(self):
+        values = self.mixed_frame.values
         assert values.shape[1] == len(self.mixed_frame.columns)
 
     def test_repr_with_mi_nat(self):

--- a/pandas/tests/frame/test_api.py
+++ b/pandas/tests/frame/test_api.py
@@ -245,29 +245,29 @@ class SharedWithSparse(object):
 
     def test_values(self):
         frame = self.frame
-        mat = frame.values
+        arr = frame.values
 
-        frameCols = frame.columns
-        for i, row in enumerate(mat):
+        frame_cols = frame.columns
+        for i, row in enumerate(arr):
             for j, value in enumerate(row):
-                col = frameCols[j]
+                col = frame_cols[j]
                 if np.isnan(value):
                     assert np.isnan(frame[col][i])
                 else:
                     assert value == frame[col][i]
 
         # mixed type
-        mat = self.mixed_frame[['foo', 'A']].values
-        assert mat[0, 0] == 'bar'
+        arr = self.mixed_frame[['foo', 'A']].values
+        assert arr[0, 0] == 'bar'
 
         df = self.klass({'real': [1, 2, 3], 'complex': [1j, 2j, 3j]})
-        mat = df.values
-        assert mat[0, 0] == 1j
+        arr = df.values
+        assert arr[0, 0] == 1j
 
         # single block corner case
-        mat = self.frame[['A', 'B']].values
+        arr = self.frame[['A', 'B']].values
         expected = self.frame.reindex(columns=['A', 'B']).values
-        assert_almost_equal(mat, expected)
+        assert_almost_equal(arr, expected)
 
     def test_transpose(self):
         frame = self.frame
@@ -372,7 +372,7 @@ class TestDataFrameMisc(SharedWithSparse, TestData):
     def test_as_matrix_deprecated(self):
         # GH18458
         with tm.assert_produces_warning(FutureWarning):
-            result = self.frame.as_matrix()
+            result = self.frame.as_matrix(columns=self.frame.columns.tolist())
         expected = self.frame.values
         tm.assert_numpy_array_equal(result, expected)
 

--- a/pandas/tests/frame/test_block_internals.py
+++ b/pandas/tests/frame/test_block_internals.py
@@ -67,10 +67,10 @@ class TestDataFrameBlockInternals(TestData):
         for letter in range(ord('A'), ord('Z')):
             self.frame[chr(letter)] = chr(letter)
 
-    def test_as_matrix_consolidate(self):
+    def test_values_consolidate(self):
         self.frame['E'] = 7.
         assert not self.frame._data.is_consolidated()
-        _ = self.frame.as_matrix()  # noqa
+        _ = self.frame.values  # noqa
         assert self.frame._data.is_consolidated()
 
     def test_modify_values(self):
@@ -91,50 +91,50 @@ class TestDataFrameBlockInternals(TestData):
         self.frame[self.frame > 1] = 2
         assert_almost_equal(expected, self.frame.values)
 
-    def test_as_matrix_numeric_cols(self):
+    def test_values_numeric_cols(self):
         self.frame['foo'] = 'bar'
 
-        values = self.frame.as_matrix(['A', 'B', 'C', 'D'])
+        values = self.frame[['A', 'B', 'C', 'D']].values
         assert values.dtype == np.float64
 
-    def test_as_matrix_lcd(self):
+    def test_values_lcd(self):
 
         # mixed lcd
-        values = self.mixed_float.as_matrix(['A', 'B', 'C', 'D'])
+        values = self.mixed_float[['A', 'B', 'C', 'D']].values
         assert values.dtype == np.float64
 
-        values = self.mixed_float.as_matrix(['A', 'B', 'C'])
+        values = self.mixed_float[['A', 'B', 'C']].values
         assert values.dtype == np.float32
 
-        values = self.mixed_float.as_matrix(['C'])
+        values = self.mixed_float[['C']].values
         assert values.dtype == np.float16
 
         # GH 10364
         # B uint64 forces float because there are other signed int types
-        values = self.mixed_int.as_matrix(['A', 'B', 'C', 'D'])
+        values = self.mixed_int[['A', 'B', 'C', 'D']].values
         assert values.dtype == np.float64
 
-        values = self.mixed_int.as_matrix(['A', 'D'])
+        values = self.mixed_int[['A', 'D']].values
         assert values.dtype == np.int64
 
         # B uint64 forces float because there are other signed int types
-        values = self.mixed_int.as_matrix(['A', 'B', 'C'])
+        values = self.mixed_int[['A', 'B', 'C']].values
         assert values.dtype == np.float64
 
         # as B and C are both unsigned, no forcing to float is needed
-        values = self.mixed_int.as_matrix(['B', 'C'])
+        values = self.mixed_int[['B', 'C']].values
         assert values.dtype == np.uint64
 
-        values = self.mixed_int.as_matrix(['A', 'C'])
+        values = self.mixed_int[['A', 'C']].values
         assert values.dtype == np.int32
 
-        values = self.mixed_int.as_matrix(['C', 'D'])
+        values = self.mixed_int[['C', 'D']].values
         assert values.dtype == np.int64
 
-        values = self.mixed_int.as_matrix(['A'])
+        values = self.mixed_int[['A']].values
         assert values.dtype == np.int32
 
-        values = self.mixed_int.as_matrix(['C'])
+        values = self.mixed_int[['C']].values
         assert values.dtype == np.uint8
 
     def test_constructor_with_convert(self):

--- a/pandas/tests/frame/test_nonunique_indexes.py
+++ b/pandas/tests/frame/test_nonunique_indexes.py
@@ -439,7 +439,7 @@ class TestDataFrameNonuniqueIndexes(TestData):
         xp.columns = ['A', 'A', 'B']
         assert_frame_equal(rs, xp)
 
-    def test_as_matrix_duplicates(self):
+    def test_values_duplicates(self):
         df = DataFrame([[1, 2, 'a', 'b'],
                         [1, 2, 'a', 'b']],
                        columns=['one', 'one', 'two', 'two'])

--- a/pandas/tests/internals/test_internals.py
+++ b/pandas/tests/internals/test_internals.py
@@ -476,7 +476,7 @@ class TestBlockManager(object):
     def test_sparse(self):
         mgr = create_mgr('a: sparse-1; b: sparse-2')
         # what to test here?
-        assert mgr.as_matrix().dtype == np.float64
+        assert mgr.as_array().dtype == np.float64
 
     def test_sparse_mixed(self):
         mgr = create_mgr('a: sparse-1; b: sparse-2; c: f8')
@@ -485,32 +485,32 @@ class TestBlockManager(object):
 
         # what to test here?
 
-    def test_as_matrix_float(self):
+    def test_as_array_float(self):
         mgr = create_mgr('c: f4; d: f2; e: f8')
-        assert mgr.as_matrix().dtype == np.float64
+        assert mgr.as_array().dtype == np.float64
 
         mgr = create_mgr('c: f4; d: f2')
-        assert mgr.as_matrix().dtype == np.float32
+        assert mgr.as_array().dtype == np.float32
 
-    def test_as_matrix_int_bool(self):
+    def test_as_array_int_bool(self):
         mgr = create_mgr('a: bool-1; b: bool-2')
-        assert mgr.as_matrix().dtype == np.bool_
+        assert mgr.as_array().dtype == np.bool_
 
         mgr = create_mgr('a: i8-1; b: i8-2; c: i4; d: i2; e: u1')
-        assert mgr.as_matrix().dtype == np.int64
+        assert mgr.as_array().dtype == np.int64
 
         mgr = create_mgr('c: i4; d: i2; e: u1')
-        assert mgr.as_matrix().dtype == np.int32
+        assert mgr.as_array().dtype == np.int32
 
-    def test_as_matrix_datetime(self):
+    def test_as_array_datetime(self):
         mgr = create_mgr('h: datetime-1; g: datetime-2')
-        assert mgr.as_matrix().dtype == 'M8[ns]'
+        assert mgr.as_array().dtype == 'M8[ns]'
 
-    def test_as_matrix_datetime_tz(self):
+    def test_as_array_datetime_tz(self):
         mgr = create_mgr('h: M8[ns, US/Eastern]; g: M8[ns, CET]')
         assert mgr.get('h').dtype == 'datetime64[ns, US/Eastern]'
         assert mgr.get('g').dtype == 'datetime64[ns, CET]'
-        assert mgr.as_matrix().dtype == 'object'
+        assert mgr.as_array().dtype == 'object'
 
     def test_astype(self):
         # coerce all
@@ -607,49 +607,49 @@ class TestBlockManager(object):
         for dtype in ['f8', 'i8', 'object', 'bool', 'complex', 'M8[ns]',
                       'm8[ns]']:
             mgr = create_mgr('a: {0}'.format(dtype))
-            assert mgr.as_matrix().dtype == dtype
+            assert mgr.as_array().dtype == dtype
             mgr = create_mgr('a: {0}; b: {0}'.format(dtype))
-            assert mgr.as_matrix().dtype == dtype
+            assert mgr.as_array().dtype == dtype
 
         # will be converted according the actual dtype of the underlying
         mgr = create_mgr('a: category')
-        assert mgr.as_matrix().dtype == 'i8'
+        assert mgr.as_array().dtype == 'i8'
         mgr = create_mgr('a: category; b: category')
-        assert mgr.as_matrix().dtype == 'i8'
+        assert mgr.as_array().dtype == 'i8'
         mgr = create_mgr('a: category; b: category2')
-        assert mgr.as_matrix().dtype == 'object'
+        assert mgr.as_array().dtype == 'object'
         mgr = create_mgr('a: category2')
-        assert mgr.as_matrix().dtype == 'object'
+        assert mgr.as_array().dtype == 'object'
         mgr = create_mgr('a: category2; b: category2')
-        assert mgr.as_matrix().dtype == 'object'
+        assert mgr.as_array().dtype == 'object'
 
         # combinations
         mgr = create_mgr('a: f8')
-        assert mgr.as_matrix().dtype == 'f8'
+        assert mgr.as_array().dtype == 'f8'
         mgr = create_mgr('a: f8; b: i8')
-        assert mgr.as_matrix().dtype == 'f8'
+        assert mgr.as_array().dtype == 'f8'
         mgr = create_mgr('a: f4; b: i8')
-        assert mgr.as_matrix().dtype == 'f8'
+        assert mgr.as_array().dtype == 'f8'
         mgr = create_mgr('a: f4; b: i8; d: object')
-        assert mgr.as_matrix().dtype == 'object'
+        assert mgr.as_array().dtype == 'object'
         mgr = create_mgr('a: bool; b: i8')
-        assert mgr.as_matrix().dtype == 'object'
+        assert mgr.as_array().dtype == 'object'
         mgr = create_mgr('a: complex')
-        assert mgr.as_matrix().dtype == 'complex'
+        assert mgr.as_array().dtype == 'complex'
         mgr = create_mgr('a: f8; b: category')
-        assert mgr.as_matrix().dtype == 'object'
+        assert mgr.as_array().dtype == 'object'
         mgr = create_mgr('a: M8[ns]; b: category')
-        assert mgr.as_matrix().dtype == 'object'
+        assert mgr.as_array().dtype == 'object'
         mgr = create_mgr('a: M8[ns]; b: bool')
-        assert mgr.as_matrix().dtype == 'object'
+        assert mgr.as_array().dtype == 'object'
         mgr = create_mgr('a: M8[ns]; b: i8')
-        assert mgr.as_matrix().dtype == 'object'
+        assert mgr.as_array().dtype == 'object'
         mgr = create_mgr('a: m8[ns]; b: bool')
-        assert mgr.as_matrix().dtype == 'object'
+        assert mgr.as_array().dtype == 'object'
         mgr = create_mgr('a: m8[ns]; b: i8')
-        assert mgr.as_matrix().dtype == 'object'
+        assert mgr.as_array().dtype == 'object'
         mgr = create_mgr('a: M8[ns]; b: m8[ns]')
-        assert mgr.as_matrix().dtype == 'object'
+        assert mgr.as_array().dtype == 'object'
 
     def test_interleave_non_unique_cols(self):
         df = DataFrame([
@@ -831,7 +831,7 @@ class TestBlockManager(object):
 
     def test_single_mgr_ctor(self):
         mgr = create_single_mgr('f8', num_rows=5)
-        assert mgr.as_matrix().tolist() == [0., 1., 2., 3., 4.]
+        assert mgr.as_array().tolist() == [0., 1., 2., 3., 4.]
 
     def test_validate_bool_args(self):
         invalid_values = [1, "True", [1, 2, 3], 5.0]
@@ -878,7 +878,7 @@ class TestIndexing(object):
     def test_get_slice(self):
         def assert_slice_ok(mgr, axis, slobj):
             # import pudb; pudb.set_trace()
-            mat = mgr.as_matrix()
+            mat = mgr.as_array()
 
             # we maybe using an ndarray to test slicing and
             # might not be the full length of the axis
@@ -889,7 +889,7 @@ class TestIndexing(object):
                         len(ax) - len(slobj), dtype=bool)])
             sliced = mgr.get_slice(slobj, axis=axis)
             mat_slobj = (slice(None), ) * axis + (slobj, )
-            tm.assert_numpy_array_equal(mat[mat_slobj], sliced.as_matrix(),
+            tm.assert_numpy_array_equal(mat[mat_slobj], sliced.as_array(),
                                         check_dtype=False)
             tm.assert_index_equal(mgr.axes[axis][slobj], sliced.axes[axis])
 
@@ -930,10 +930,10 @@ class TestIndexing(object):
 
     def test_take(self):
         def assert_take_ok(mgr, axis, indexer):
-            mat = mgr.as_matrix()
+            mat = mgr.as_array()
             taken = mgr.take(indexer, axis)
             tm.assert_numpy_array_equal(np.take(mat, indexer, axis),
-                                        taken.as_matrix(), check_dtype=False)
+                                        taken.as_array(), check_dtype=False)
             tm.assert_index_equal(mgr.axes[axis].take(indexer),
                                   taken.axes[axis])
 
@@ -950,14 +950,14 @@ class TestIndexing(object):
 
     def test_reindex_axis(self):
         def assert_reindex_axis_is_ok(mgr, axis, new_labels, fill_value):
-            mat = mgr.as_matrix()
+            mat = mgr.as_array()
             indexer = mgr.axes[axis].get_indexer_for(new_labels)
 
             reindexed = mgr.reindex_axis(new_labels, axis,
                                          fill_value=fill_value)
             tm.assert_numpy_array_equal(algos.take_nd(mat, indexer, axis,
                                                       fill_value=fill_value),
-                                        reindexed.as_matrix(),
+                                        reindexed.as_array(),
                                         check_dtype=False)
             tm.assert_index_equal(reindexed.axes[axis], new_labels)
 
@@ -996,13 +996,13 @@ class TestIndexing(object):
 
         def assert_reindex_indexer_is_ok(mgr, axis, new_labels, indexer,
                                          fill_value):
-            mat = mgr.as_matrix()
+            mat = mgr.as_array()
             reindexed_mat = algos.take_nd(mat, indexer, axis,
                                           fill_value=fill_value)
             reindexed = mgr.reindex_indexer(new_labels, indexer, axis,
                                             fill_value=fill_value)
             tm.assert_numpy_array_equal(reindexed_mat,
-                                        reindexed.as_matrix(),
+                                        reindexed.as_array(),
                                         check_dtype=False)
             tm.assert_index_equal(reindexed.axes[axis], new_labels)
 

--- a/pandas/tests/sparse/test_frame.py
+++ b/pandas/tests/sparse/test_frame.py
@@ -78,16 +78,16 @@ class TestSparseDataFrame(SharedWithSparse):
         res = df.add(2, fill_value=0)
         tm.assert_sp_frame_equal(res, exp)
 
-    def test_as_matrix(self):
-        empty = self.empty.as_matrix()
+    def test_values(self):
+        empty = self.empty.values
         assert empty.shape == (0, 0)
 
         no_cols = SparseDataFrame(index=np.arange(10))
-        mat = no_cols.as_matrix()
+        mat = no_cols.values
         assert mat.shape == (10, 0)
 
         no_index = SparseDataFrame(columns=np.arange(10))
-        mat = no_index.as_matrix()
+        mat = no_index.values
         assert mat.shape == (0, 10)
 
     def test_copy(self):


### PR DESCRIPTION
- [x ] xref #18262
- [x ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ x] whatsnew entry

Deprecating ``NDFrame.as_matrix`` as per discussion in #18262.