### PR TITLE
CLN/DEPR: remove pd.ordered_merge

### DIFF
--- a/asv_bench/benchmarks/join_merge.py
+++ b/asv_bench/benchmarks/join_merge.py
@@ -1,10 +1,6 @@
 from .pandas_vb_common import *
 
-try:
-    from pandas import merge_ordered
-except ImportError:
-    from pandas import ordered_merge as merge_ordered
-
+from pandas import merge_ordered
 
 # ----------------------------------------------------------------------
 # Append

--- a/asv_bench/benchmarks/join_merge.py
+++ b/asv_bench/benchmarks/join_merge.py
@@ -1,6 +1,10 @@
 from .pandas_vb_common import *
 
-from pandas import merge_ordered
+try:
+    from pandas import merge_ordered
+except ImportError:
+    from pandas import ordered_merge as merge_ordered
+
 
 # ----------------------------------------------------------------------
 # Append

--- a/doc/source/whatsnew/v0.22.0.txt
+++ b/doc/source/whatsnew/v0.22.0.txt
@@ -95,6 +95,7 @@ Removal of prior version deprecations/changes
 - The ``levels`` and ``labels`` attributes of a ``MultiIndex`` can no longer be set directly (:issue:`4039`).
 - ``pd.tseries.util.pivot_annual`` has been  removed (deprecated since v0.19). Use ``pivot_table`` instead (:issue:`18370`)
 - ``pd.tseries.util.isleapyear`` has been removed (deprecated since v0.19). Use ``.is_leap_year`` property in Datetime-likes instead (:issue:`18370`)
+- ``pd.ordered_merge`` has been removed (deprecated since v0.19). Use ``pd..merge_ordered`` instead (:issue:`18459`)
 
 .. _whatsnew_0220.performance:
 

--- a/pandas/core/reshape/api.py
+++ b/pandas/core/reshape/api.py
@@ -3,7 +3,6 @@
 from pandas.core.reshape.concat import concat
 from pandas.core.reshape.melt import melt, lreshape, wide_to_long
 from pandas.core.reshape.reshape import pivot_simple as pivot, get_dummies
-from pandas.core.reshape.merge import (
-    merge, ordered_merge, merge_ordered, merge_asof)
+from pandas.core.reshape.merge import merge, merge_ordered, merge_asof
 from pandas.core.reshape.pivot import pivot_table, crosstab
 from pandas.core.reshape.tile import cut, qcut

--- a/pandas/core/reshape/merge.py
+++ b/pandas/core/reshape/merge.py
@@ -1067,7 +1067,7 @@ def _get_join_indexers(left_keys, right_keys, sort=False, how='inner',
 
 
 class _OrderedMerge(_MergeOperation):
-    _merge_type = 'merge_ordered'
+    _merge_type = 'ordered_merge'
 
     def __init__(self, left, right, on=None, left_on=None, right_on=None,
                  left_index=False, right_index=False, axis=1,

--- a/pandas/core/reshape/merge.py
+++ b/pandas/core/reshape/merge.py
@@ -139,19 +139,6 @@ def _groupby_and_merge(by, on, left, right, _merge_pieces,
     return result, lby
 
 
-def ordered_merge(left, right, on=None,
-                  left_on=None, right_on=None,
-                  left_by=None, right_by=None,
-                  fill_method=None, suffixes=('_x', '_y')):
-
-    warnings.warn("ordered_merge is deprecated and replaced by merge_ordered",
-                  FutureWarning, stacklevel=2)
-    return merge_ordered(left, right, on=on,
-                         left_on=left_on, right_on=right_on,
-                         left_by=left_by, right_by=right_by,
-                         fill_method=fill_method, suffixes=suffixes)
-
-
 def merge_ordered(left, right, on=None,
                   left_on=None, right_on=None,
                   left_by=None, right_by=None,
@@ -204,7 +191,7 @@ def merge_ordered(left, right, on=None,
     4   c       2     b
     5   e       3     b
 
-    >>> ordered_merge(A, B, fill_method='ffill', left_by='group')
+    >>> merge_ordered(A, B, fill_method='ffill', left_by='group')
        key  lvalue group  rvalue
     0    a       1     a     NaN
     1    b       1     a       1
@@ -251,9 +238,6 @@ def merge_ordered(left, right, on=None,
     else:
         result = _merger(left, right)
     return result
-
-
-ordered_merge.__doc__ = merge_ordered.__doc__
 
 
 def merge_asof(left, right, on=None,
@@ -1083,7 +1067,7 @@ def _get_join_indexers(left_keys, right_keys, sort=False, how='inner',
 
 
 class _OrderedMerge(_MergeOperation):
-    _merge_type = 'ordered_merge'
+    _merge_type = 'merge_ordered'
 
     def __init__(self, left, right, on=None, left_on=None, right_on=None,
                  left_index=False, right_index=False, axis=1,

--- a/pandas/tests/api/test_api.py
+++ b/pandas/tests/api/test_api.py
@@ -103,7 +103,7 @@ class TestPDApi(Base):
                         'rolling_kurt', 'rolling_max', 'rolling_mean',
                         'rolling_median', 'rolling_min', 'rolling_quantile',
                         'rolling_skew', 'rolling_std', 'rolling_sum',
-                        'rolling_var', 'rolling_window', 'ordered_merge',
+                        'rolling_var', 'rolling_window',
                         'pnow', 'match', 'groupby', 'get_store',
                         'plot_params', 'scatter_matrix']
 

--- a/pandas/tests/reshape/test_merge_ordered.py
+++ b/pandas/tests/reshape/test_merge_ordered.py
@@ -6,7 +6,7 @@ from pandas.util.testing import assert_frame_equal
 from numpy import nan
 
 
-class TestOrderedMerge(object):
+class TestMergeOrdered(object):
 
     def setup_method(self, method):
         self.left = DataFrame({'key': ['a', 'c', 'e'],
@@ -14,13 +14,6 @@ class TestOrderedMerge(object):
 
         self.right = DataFrame({'key': ['b', 'c', 'd', 'f'],
                                 'rvalue': [1, 2, 3., 4]})
-
-    def test_deprecation(self):
-
-        with tm.assert_produces_warning(FutureWarning):
-            pd.ordered_merge(self.left, self.right, on='key')
-
-    # GH #813
 
     def test_basic(self):
         result = merge_ordered(self.left, self.right, on='key')


### PR DESCRIPTION
- [ x] xref #13358
- [x ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ x] whatsnew entry

``pd.ordered_merge`` was deprecated in #13358 (pandas v.0.19). This PR removes it from the code base.