### PR TITLE
Improve DatetimeIndex.time performance

### DIFF
--- a/asv_bench/benchmarks/timeseries.py
+++ b/asv_bench/benchmarks/timeseries.py
@@ -85,7 +85,7 @@ class DatetimeIndex(object):
         self.dti_tz.factorize()
 
     def time_dti_time(self):
-        self.rng.time
+        self.dst_rng.time
 
     def time_timestamp_tzinfo_cons(self):
         self.rng5[0]

--- a/doc/source/whatsnew/v0.22.0.txt
+++ b/doc/source/whatsnew/v0.22.0.txt
@@ -231,6 +231,7 @@ Performance Improvements
 - Improved performance of :func:`Series.dt.date` and :func:`DatetimeIndex.date` (:issue:`18058`)
 - Improved performance of :func:`IntervalIndex.symmetric_difference()` (:issue:`18475`)
 - Improved performance of ``DatetimeIndex`` and ``Series`` arithmetic operations with Business-Month and Business-Quarter frequencies (:issue:`18489`)
+- Improved performance of :func:`Series.dt.time` and :func:`DatetimeIndex.time`
 
 .. _whatsnew_0220.docs:
 

--- a/pandas/_libs/tslib.pyx
+++ b/pandas/_libs/tslib.pyx
@@ -100,10 +100,6 @@ def ints_to_pydatetime(ndarray[int64_t] arr, tz=None, freq=None,
     result : array of dtype specified by box
     """
 
-    assert ((box == "datetime") or (box == "date") or (box == "timestamp")
-            or (box == "time")), \
-        "box must be one of 'datetime', 'date', 'time' or 'timestamp'"
-
     cdef:
         Py_ssize_t i, n = len(arr)
         ndarray[int64_t] trans, deltas
@@ -127,6 +123,9 @@ def ints_to_pydatetime(ndarray[int64_t] arr, tz=None, freq=None,
         func_create = create_time_from_ts
     elif box == "datetime":
         func_create = create_datetime_from_ts
+    else:
+        raise ValueError("box must be one of 'datetime', 'date', 'time' or" +
+                         " 'timestamp'")
 
     if tz is not None:
         if is_utc(tz):

--- a/pandas/core/indexes/datetimes.py
+++ b/pandas/core/indexes/datetimes.py
@@ -1677,9 +1677,7 @@ class DatetimeIndex(DatelikeOps, TimelikeOps, DatetimeIndexOpsMixin,
         """
         Returns numpy array of datetime.time. The time part of the Timestamps.
         """
-        return self._maybe_mask_results(libalgos.arrmap_object(
-            self.astype(object).values,
-            lambda x: np.nan if x is libts.NaT else x.time()))
+        return libts.ints_to_pydatetime(self.asi8, self.tz, box="time")
 
     @property
     def date(self):

--- a/pandas/core/indexes/datetimes.py
+++ b/pandas/core/indexes/datetimes.py
@@ -53,8 +53,7 @@ import pandas.tseries.offsets as offsets
 import pandas.core.tools.datetimes as tools
 
 from pandas._libs import (lib, index as libindex, tslib as libts,
-                          algos as libalgos, join as libjoin,
-                          Timestamp)
+                          join as libjoin, Timestamp)
 from pandas._libs.tslibs import (timezones, conversion, fields, parsing,
                                  period as libperiod)
 


### PR DESCRIPTION
   xref #18058 
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry

  Speed up DatetimeIndex.time in a similar way to DatetimeIndex.date. Not sure whether the timezone information should be passed to `ints_to_pydatetime()` or not.