### PR TITLE
Propogating NaN values when using str.split (#18450)

### DIFF
--- a/doc/source/whatsnew/v0.21.1.txt
+++ b/doc/source/whatsnew/v0.21.1.txt
@@ -138,9 +138,13 @@ Categorical
 - ``CategoricalIndex`` can now correctly take a ``pd.api.types.CategoricalDtype`` as its dtype (:issue:`18116`)
 - Bug in ``Categorical.unique()`` returning read-only ``codes``  array when all categories were ``NaN`` (:issue:`18051`)
 
+String
+^^^^^^
+
+- :meth:`Series.str.split()` will now propogate ``NaN`` values across all expanded columns instead of ``None`` (:issue:`18450`)
+
 Other
 ^^^^^
 
-- :meth:`Series.str.split()` will now propogate ``NaN`` values across all expanded columns instead of ``None`` (:issue:`18450`)
 -
 -

--- a/doc/source/whatsnew/v0.21.1.txt
+++ b/doc/source/whatsnew/v0.21.1.txt
@@ -141,6 +141,6 @@ Categorical
 Other
 ^^^^^
 
--
+- :meth:`Series.str.split()` will now propogate ``NaN`` values across all expanded columns instead of ``None`` (:issue:`18450`)
 -
 -

--- a/pandas/core/strings.py
+++ b/pandas/core/strings.py
@@ -1423,6 +1423,10 @@ class StringMethods(NoNewAttributesMixin):
                     return [x]
 
             result = [cons_row(x) for x in result]
+            if result:
+                # propogate nan values to match longest sequence (GH 18450)
+                max_len = max(len(x) for x in result)
+                result = [x * max_len if x[0] is np.nan else x for x in result]
 
         if not isinstance(expand, bool):
             raise ValueError("expand must be True or False")

--- a/pandas/tests/test_strings.py
+++ b/pandas/tests/test_strings.py
@@ -2086,6 +2086,15 @@ class TestStringMethods(object):
         tm.assert_index_equal(result, exp)
         assert result.nlevels == 2
 
+    def test_split_nan_expand(self):
+        s = Series(["foo,bar,baz", NA])
+        result = s.str.split(",", expand=True)
+        exp = DataFrame([["foo", "bar", "baz"], [NA, NA, NA]])
+        tm.assert_frame_equal(result, exp)
+
+        # extra nan check - see GH 18463
+        assert all(np.isnan(x) for x in result.iloc[1])
+
     def test_split_with_name(self):
         # GH 12617
 

--- a/pandas/tests/test_strings.py
+++ b/pandas/tests/test_strings.py
@@ -2087,12 +2087,15 @@ class TestStringMethods(object):
         assert result.nlevels == 2
 
     def test_split_nan_expand(self):
+        # gh-18450
         s = Series(["foo,bar,baz", NA])
         result = s.str.split(",", expand=True)
         exp = DataFrame([["foo", "bar", "baz"], [NA, NA, NA]])
         tm.assert_frame_equal(result, exp)
 
-        # extra nan check - see GH 18463
+        # check that these are actually np.nan and not None
+        # TODO see GH 18463
+        # tm.assert_frame_equal does not differentiate
         assert all(np.isnan(x) for x in result.iloc[1])
 
     def test_split_with_name(self):


### PR DESCRIPTION
- [X] closes #18450
- [X] tests added / passed
- [X] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry