### PR TITLE
CLN: ASV categoricals benchmark

### DIFF
--- a/asv_bench/benchmarks/categoricals.py
+++ b/asv_bench/benchmarks/categoricals.py
@@ -1,7 +1,13 @@
 import numpy as np
 import pandas as pd
 import pandas.util.testing as tm
-from pandas.core.dtypes.concat import union_categoricals
+try:
+    from pandas.api.types import union_categoricals
+except ImportError:
+    try:
+        from pandas.types.concat import union_categoricals
+    except ImportError:
+        pass
 
 
 class Concat(object):
@@ -42,22 +48,22 @@ class Constructor(object):
         self.values_some_nan = list(np.tile(self.categories + [np.nan], N))
         self.values_all_nan = [np.nan] * len(self.values)
 
-    def time_constructor_regular(self):
+    def time_regular(self):
         pd.Categorical(self.values, self.categories)
 
-    def time_constructor_fastpath(self):
+    def time_fastpath(self):
         pd.Categorical(self.codes, self.cat_idx, fastpath=True)
 
-    def time_constructor_datetimes(self):
+    def time_datetimes(self):
         pd.Categorical(self.datetimes)
 
-    def time_constructor_datetimes_with_nat(self):
+    def time_datetimes_with_nat(self):
         pd.Categorical(self.datetimes_with_nat)
 
-    def time_constructor_with_nan(self):
+    def time_with_nan(self):
         pd.Categorical(self.values_some_nan)
 
-    def time_constructor_all_nan(self):
+    def time_all_nan(self):
         pd.Categorical(self.values_all_nan)
 
 
@@ -73,10 +79,9 @@ class ValueCounts(object):
         np.random.seed(2718281)
         arr = ['s%04d' % i for i in np.random.randint(0, n // 10, size=n)]
         self.ts = pd.Series(arr).astype('category')
-        self.dropna = dropna
 
     def time_value_counts(self, dropna):
-        self.ts.value_counts(dropna=self.dropna)
+        self.ts.value_counts(dropna=dropna)
 
 
 class Repr(object):

--- a/asv_bench/benchmarks/categoricals.py
+++ b/asv_bench/benchmarks/categoricals.py
@@ -1,114 +1,140 @@
-from .pandas_vb_common import *
-try:
-    from pandas.api.types import union_categoricals
-except ImportError:
-    try:
-        from pandas.types.concat import union_categoricals
-    except ImportError:
-        pass
+import numpy as np
+import pandas as pd
+import pandas.util.testing as tm
+from pandas.core.dtypes.concat import union_categoricals
 
 
-class Categoricals(object):
+class Concat(object):
+
     goal_time = 0.2
 
     def setup(self):
-        N = 100000
-        self.s = pd.Series((list('aabbcd') * N)).astype('category')
+        N = 10**5
+        self.s = pd.Series(list('aabbcd') * N).astype('category')
 
-        self.a = pd.Categorical((list('aabbcd') * N))
-        self.b = pd.Categorical((list('bbcdjk') * N))
-
-        self.categories = list('abcde')
-        self.cat_idx = Index(self.categories)
-        self.values = np.tile(self.categories, N)
-        self.codes = np.tile(range(len(self.categories)), N)
-
-        self.datetimes = pd.Series(pd.date_range(
-            '1995-01-01 00:00:00', periods=10000, freq='s'))
-
-        self.values_some_nan = list(np.tile(self.categories + [np.nan], N))
-        self.values_all_nan = [np.nan] * len(self.values)
+        self.a = pd.Categorical(list('aabbcd') * N)
+        self.b = pd.Categorical(list('bbcdjk') * N)
 
     def time_concat(self):
-        concat([self.s, self.s])
+        pd.concat([self.s, self.s])
 
     def time_union(self):
         union_categoricals([self.a, self.b])
 
-    def time_constructor_regular(self):
-        Categorical(self.values, self.categories)
 
-    def time_constructor_fastpath(self):
-        Categorical(self.codes, self.cat_idx, fastpath=True)
+class Constructor(object):
 
-    def time_constructor_datetimes(self):
-        Categorical(self.datetimes)
-
-    def time_constructor_datetimes_with_nat(self):
-        t = self.datetimes
-        t.iloc[-1] = pd.NaT
-        Categorical(t)
-
-    def time_constructor_with_nan(self):
-        Categorical(self.values_some_nan)
-
-    def time_constructor_all_nan(self):
-        Categorical(self.values_all_nan)
-
-
-class Categoricals2(object):
     goal_time = 0.2
 
     def setup(self):
-        n = 500000
+        N = 10**5
+        self.categories = list('abcde')
+        self.cat_idx = pd.Index(self.categories)
+        self.values = np.tile(self.categories, N)
+        self.codes = np.tile(range(len(self.categories)), N)
+
+        self.datetimes = pd.Series(pd.date_range('1995-01-01 00:00:00',
+                                                 periods=N / 10,
+                                                 freq='s'))
+        self.datetimes_with_nat = self.datetimes.copy()
+        self.datetimes_with_nat.iloc[-1] = pd.NaT
+
+        self.values_some_nan = list(np.tile(self.categories + [np.nan], N))
+        self.values_all_nan = [np.nan] * len(self.values)
+
+    def time_constructor_regular(self):
+        pd.Categorical(self.values, self.categories)
+
+    def time_constructor_fastpath(self):
+        pd.Categorical(self.codes, self.cat_idx, fastpath=True)
+
+    def time_constructor_datetimes(self):
+        pd.Categorical(self.datetimes)
+
+    def time_constructor_datetimes_with_nat(self):
+        pd.Categorical(self.datetimes_with_nat)
+
+    def time_constructor_with_nan(self):
+        pd.Categorical(self.values_some_nan)
+
+    def time_constructor_all_nan(self):
+        pd.Categorical(self.values_all_nan)
+
+
+class ValueCounts(object):
+
+    goal_time = 0.2
+
+    params = [True, False]
+    param_names = ['dropna']
+
+    def setup(self, dropna):
+        n = 5 * 10**5
         np.random.seed(2718281)
         arr = ['s%04d' % i for i in np.random.randint(0, n // 10, size=n)]
-        self.ts = Series(arr).astype('category')
+        self.ts = pd.Series(arr).astype('category')
+        self.dropna = dropna
 
-        self.sel = self.ts.loc[[0]]
+    def time_value_counts(self, dropna):
+        self.ts.value_counts(dropna=self.dropna)
 
-    def time_value_counts(self):
-        self.ts.value_counts(dropna=False)
 
-    def time_value_counts_dropna(self):
-        self.ts.value_counts(dropna=True)
+class Repr(object):
+
+    goal_time = 0.2
+
+    def setup(self):
+        self.sel = pd.Series(['s1234']).astype('category')
 
     def time_rendering(self):
         str(self.sel)
+
+
+class SetCategories(object):
+
+    goal_time = 0.2
+
+    def setup(self):
+        n = 5 * 10**5
+        np.random.seed(2718281)
+        arr = ['s%04d' % i for i in np.random.randint(0, n // 10, size=n)]
+        self.ts = pd.Series(arr).astype('category')
 
     def time_set_categories(self):
         self.ts.cat.set_categories(self.ts.cat.categories[::2])
 
 
-class Categoricals3(object):
+class Rank(object):
+
     goal_time = 0.2
 
     def setup(self):
-        N = 100000
+        N = 10**5
         ncats = 100
+        np.random.seed(1234)
 
-        self.s1 = Series(np.array(tm.makeCategoricalIndex(N, ncats)))
-        self.s1_cat = self.s1.astype('category')
-        self.s1_cat_ordered = self.s1.astype('category', ordered=True)
+        self.s_str = pd.Series(tm.makeCategoricalIndex(N, ncats)).astype(str)
+        self.s_str_cat = self.s_str.astype('category')
+        self.s_str_cat_ordered = self.s_str.astype('category', ordered=True)
 
-        self.s2 = Series(np.random.randint(0, ncats, size=N))
-        self.s2_cat = self.s2.astype('category')
-        self.s2_cat_ordered = self.s2.astype('category', ordered=True)
+        self.s_int = pd.Series(np.random.randint(0, ncats, size=N))
+        self.s_int_cat = self.s_int.astype('category')
+        self.s_int_cat_ordered = self.s_int.astype('category', ordered=True)
 
     def time_rank_string(self):
-        self.s1.rank()
+        self.s_str.rank()
 
     def time_rank_string_cat(self):
-        self.s1_cat.rank()
+        self.s_str_cat.rank()
 
     def time_rank_string_cat_ordered(self):
-        self.s1_cat_ordered.rank()
+        self.s_str_cat_ordered.rank()
 
     def time_rank_int(self):
-        self.s2.rank()
+        self.s_int.rank()
 
     def time_rank_int_cat(self):
-        self.s2_cat.rank()
+        self.s_int_cat.rank()
 
     def time_rank_int_cat_ordered(self):
-        self.s2_cat_ordered.rank()
+        self.s_int_cat_ordered.rank()


### PR DESCRIPTION
- Split classes from `Categoricals/2/3` --> `Concat`, `ValueCounts`, `Rank`, `Repr`, `SetCategories`, and `Constructor`

- Utilized `params` and `param_names` for `ValueCounts`

- Added `np.random.seed(1234)` in setup classes where random data is created xref #8144

- Ran flake8 and replaced star imports

```
$ asv run -q -b ^categoricals
[  0.00%] ·· Benchmarking conda-py3.6-Cython-matplotlib-numexpr-numpy-openpyxl-pytables-pytest-scipy-sqlalchemy-xlrd-xlsxwriter-xlwt
[  5.88%] ··· Running categoricals.Concat.time_concat                                                                               14.2ms
[ 11.76%] ··· Running categoricals.Concat.time_union                                                                                12.2ms
[ 17.65%] ··· Running categoricals.Constructor.time_constructor_all_nan                                                             54.7ms
[ 23.53%] ··· Running categoricals.Constructor.time_constructor_datetimes                                                           2.22ms
[ 29.41%] ··· Running categoricals.Constructor.time_constructor_datetimes_with_nat                                                  2.32ms
[ 35.29%] ··· Running categoricals.Constructor.time_constructor_fastpath                                                            1.59ms
[ 41.18%] ··· Running categoricals.Constructor.time_constructor_regular                                                             48.8ms
[ 47.06%] ··· Running categoricals.Constructor.time_constructor_with_nan                                                             510ms
[ 52.94%] ··· Running categoricals.Rank.time_rank_int                                                                               11.7ms
[ 58.82%] ··· Running categoricals.Rank.time_rank_int_cat                                                                           12.9ms
[ 64.71%] ··· Running categoricals.Rank.time_rank_int_cat_ordered                                                                   12.2ms
[ 70.59%] ··· Running categoricals.Rank.time_rank_string                                                                             520ms
[ 76.47%] ··· Running categoricals.Rank.time_rank_string_cat                                                                        18.3ms
[ 82.35%] ··· Running categoricals.Rank.time_rank_string_cat_ordered                                                                10.2ms
[ 88.24%] ··· Running categoricals.Repr.time_rendering                                                                              1.58ms
[ 94.12%] ··· Running categoricals.SetCategories.time_set_categories                                                                70.7ms
[100.00%] ··· Running categoricals.ValueCounts.time_value_counts                                                                81.2ms;...
```