### PR TITLE
TYPO: IntervalIndex.symmetric_differnce -> IntervalIndex.symmetric_difference

### DIFF
--- a/doc/source/whatsnew/v0.21.1.txt
+++ b/doc/source/whatsnew/v0.21.1.txt
@@ -40,7 +40,7 @@ Performance Improvements
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
 - Improved performance of plotting large series/dataframes (:issue:`18236`).
--
+- Improved performance of ``IntervalIndex.symmetric_difference()`` (:issue:`18475`)
 -
 
 .. _whatsnew_0211.docs:
@@ -74,7 +74,7 @@ Indexing
 - Bug where a ``MultiIndex`` with more than a million records was not raising ``AttributeError`` when trying to access a missing attribute (:issue:`18165`)
 - Bug in :class:`IntervalIndex` constructor when a list of intervals is passed with non-default ``closed`` (:issue:`18334`)
 - Bug in ``Index.putmask`` when an invalid mask passed (:issue:`18368`)
--
+- Bug in ``IntervalIndex.symmetric_difference()`` where the symmetric difference with a non-``IntervalIndex`` did not raise (:issue:`18475`)
 
 I/O
 ^^^

--- a/doc/source/whatsnew/v0.21.1.txt
+++ b/doc/source/whatsnew/v0.21.1.txt
@@ -40,7 +40,7 @@ Performance Improvements
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
 - Improved performance of plotting large series/dataframes (:issue:`18236`).
-- Improved performance of ``IntervalIndex.symmetric_difference()`` (:issue:`18475`)
+-
 -
 
 .. _whatsnew_0211.docs:
@@ -74,7 +74,7 @@ Indexing
 - Bug where a ``MultiIndex`` with more than a million records was not raising ``AttributeError`` when trying to access a missing attribute (:issue:`18165`)
 - Bug in :class:`IntervalIndex` constructor when a list of intervals is passed with non-default ``closed`` (:issue:`18334`)
 - Bug in ``Index.putmask`` when an invalid mask passed (:issue:`18368`)
-- Bug in ``IntervalIndex.symmetric_difference()`` where the symmetric difference with a non-``IntervalIndex`` did not raise (:issue:`18475`)
+-
 
 I/O
 ^^^

--- a/doc/source/whatsnew/v0.22.0.txt
+++ b/doc/source/whatsnew/v0.22.0.txt
@@ -114,7 +114,7 @@ Performance Improvements
 - The overriden ``Timedelta`` properties of days, seconds and microseconds have been removed, leveraging their built-in Python versions instead (:issue:`18242`)
 - ``Series`` construction will reduce the number of copies made of the input data in certain cases (:issue:`17449`)
 - Improved performance of :func:`Series.dt.date` and :func:`DatetimeIndex.date` (:issue:`18058`)
--
+- Improved performance of ``IntervalIndex.symmetric_difference()`` (:issue:`18475`)
 
 .. _whatsnew_0220.docs:
 
@@ -146,7 +146,7 @@ Indexing
 - Bug in :func:`MultiIndex.remove_unused_levels`` which would fill nan values (:issue:`18417`)
 - Bug in :func:`MultiIndex.from_tuples`` which would fail to take zipped tuples in python3 (:issue:`18434`)
 - Bug in :class:`IntervalIndex` where empty and purely NA data was constructed inconsistently depending on the construction method (:issue:`18421`)
--
+- Bug in ``IntervalIndex.symmetric_difference()`` where the symmetric difference with a non-``IntervalIndex`` did not raise (:issue:`18475`)
 
 I/O
 ^^^

--- a/pandas/core/indexes/interval.py
+++ b/pandas/core/indexes/interval.py
@@ -1171,7 +1171,7 @@ class IntervalIndex(IntervalMixin, Index):
     union = _setop('union')
     intersection = _setop('intersection')
     difference = _setop('difference')
-    symmetric_differnce = _setop('symmetric_difference')
+    symmetric_difference = _setop('symmetric_difference')
 
     # TODO: arithmetic operations
 


### PR DESCRIPTION
- [X] closes #18475
- [X] tests added / passed
- [X] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [X] whatsnew entry

Before this, `IntervalIndex.symmetric_difference` hit the base class implementation, and appeared to generally be working, albeit without full error handling and with worse performance than the intended implementation.

Also went through and did some more work on the tests:

- expanded the `test_set_operation_errors`, since this didn't have full coverage of all set ops prior.
- `self.create_index` previous only created an index with two elements, which seemed kind of small; increased this to 10 elements, and updated impacted tests accordingly.
- added a fixture for parameterizing over `name`, and updated a few tests to use this.