### PR TITLE
DEPR: deprecate publicfacing .asobject

### DIFF
--- a/asv_bench/benchmarks/index_object.py
+++ b/asv_bench/benchmarks/index_object.py
@@ -12,7 +12,7 @@ class SetOperations(object):
         if (self.rng.dtype == object):
             self.idx_rng = self.rng.view(Index)
         else:
-            self.idx_rng = self.rng.asobject
+            self.idx_rng = self.rng._asobject
         self.idx_rng2 = self.idx_rng[:(-1)]
 
         # other datetime

--- a/doc/source/whatsnew/v0.22.0.txt
+++ b/doc/source/whatsnew/v0.22.0.txt
@@ -84,7 +84,7 @@ Deprecations
 ~~~~~~~~~~~~
 
 - ``Series.from_array`` and ``SparseSeries.from_array`` are deprecated. Use the normal constructor ``Series(..)`` and ``SparseSeries(..)`` instead (:issue:`18213`).
--
+- ``Series.asobject``, ``DatetimeIndex.asobject`` and ``PeriodIndex.asobject``have been deprecated. Use '.astype(object).values' instead (:issue:`18477`)
 -
 
 .. _whatsnew_0220.prior_deprecations:

--- a/pandas/core/algorithms.py
+++ b/pandas/core/algorithms.py
@@ -369,7 +369,7 @@ def unique(values):
         # to return an object array of tz-aware Timestamps
 
         # TODO: it must return DatetimeArray with tz in pandas 2.0
-        uniques = uniques.asobject.values
+        uniques = uniques._asobject.values
 
     return uniques
 

--- a/pandas/core/dtypes/concat.py
+++ b/pandas/core/dtypes/concat.py
@@ -401,7 +401,7 @@ def _concat_datetime(to_concat, axis=0, typs=None):
         # if dtype is of datetimetz or timezone
         if x.dtype.kind == _NS_DTYPE.kind:
             if getattr(x, 'tz', None) is not None:
-                x = x.asobject.values
+                x = x._asobject.values
             else:
                 shape = x.shape
                 x = tslib.ints_to_pydatetime(x.view(np.int64).ravel(),
@@ -479,7 +479,7 @@ def _concat_index_asobject(to_concat, name=None):
     """
 
     klasses = ABCDatetimeIndex, ABCTimedeltaIndex, ABCPeriodIndex
-    to_concat = [x.asobject if isinstance(x, klasses) else x
+    to_concat = [x._asobject if isinstance(x, klasses) else x
                  for x in to_concat]
 
     from pandas import Index

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -3305,7 +3305,7 @@ class DataFrame(NDFrame):
 
         def _maybe_casted_values(index, labels=None):
             if isinstance(index, PeriodIndex):
-                values = index.asobject.values
+                values = index._asobject.values
             elif isinstance(index, DatetimeIndex) and index.tz is not None:
                 values = index
             else:
@@ -5052,7 +5052,7 @@ class DataFrame(NDFrame):
         def infer(x):
             if x.empty:
                 return lib.map_infer(x, func)
-            return lib.map_infer(x.asobject, func)
+            return lib.map_infer(x._asobject, func)
 
         return self.apply(infer)
 

--- a/pandas/core/indexes/datetimelike.py
+++ b/pandas/core/indexes/datetimelike.py
@@ -358,7 +358,7 @@ class DatetimeIndexOpsMixin(object):
                 raise TypeError('The map function must return an Index object')
             return result
         except Exception:
-            return self.asobject.map(f)
+            return self._asobject.map(f)
 
     def sort_values(self, return_indexer=False, ascending=True):
         """
@@ -421,14 +421,22 @@ class DatetimeIndexOpsMixin(object):
         return (self.asi8 == iNaT)
 
     @property
-    def asobject(self):
+    def _asobject(self):
         """
-        return object Index which contains boxed values
-
-        *this is an internal non-public method*
+        Return object Index which contains boxed values
         """
         from pandas.core.index import Index
         return Index(self._box_values(self.asi8), name=self.name, dtype=object)
+
+    @property
+    def asobject(self):
+        """DEPRECATED: Use 'astype(object).values' instead.
+
+        Return object Index which contains boxed values
+        """
+        warnings.warn("'.asobject' is deprecated. Use 'astype(object).values'"
+                      " instead", FutureWarning, stacklevel=2)
+        return self._asobject
 
     def _convert_tolerance(self, tolerance, target):
         tolerance = np.asarray(to_timedelta(tolerance, box=False))
@@ -466,7 +474,7 @@ class DatetimeIndexOpsMixin(object):
         """
         return a list of the underlying data
         """
-        return list(self.asobject)
+        return list(self._asobject)
 
     def min(self, axis=None, *args, **kwargs):
         """
@@ -744,7 +752,7 @@ class DatetimeIndexOpsMixin(object):
             try:
                 values = type(self)(values)
             except ValueError:
-                return self.asobject.isin(values)
+                return self._asobject.isin(values)
 
         return algorithms.isin(self.asi8, values.asi8)
 

--- a/pandas/core/indexes/datetimes.py
+++ b/pandas/core/indexes/datetimes.py
@@ -906,7 +906,7 @@ class DatetimeIndex(DatelikeOps, TimelikeOps, DatetimeIndexOpsMixin,
     def astype(self, dtype, copy=True):
         dtype = pandas_dtype(dtype)
         if is_object_dtype(dtype):
-            return self.asobject
+            return self._asobject
         elif is_integer_dtype(dtype):
             return Index(self.values.astype('i8', copy=copy), name=self.name,
                          dtype='i8')
@@ -1678,7 +1678,7 @@ class DatetimeIndex(DatelikeOps, TimelikeOps, DatetimeIndexOpsMixin,
         Returns numpy array of datetime.time. The time part of the Timestamps.
         """
         return self._maybe_mask_results(libalgos.arrmap_object(
-            self.asobject.values,
+            self._asobject.values,
             lambda x: np.nan if x is libts.NaT else x.time()))
 
     @property
@@ -1785,7 +1785,7 @@ class DatetimeIndex(DatelikeOps, TimelikeOps, DatetimeIndexOpsMixin,
 
             # fall back to object index
             if isinstance(item, compat.string_types):
-                return self.asobject.insert(loc, item)
+                return self._asobject.insert(loc, item)
             raise TypeError(
                 "cannot insert DatetimeIndex with incompatible label")
 

--- a/pandas/core/indexes/period.py
+++ b/pandas/core/indexes/period.py
@@ -418,7 +418,7 @@ class PeriodIndex(DatelikeOps, DatetimeIndexOpsMixin, Int64Index):
 
     @property
     def values(self):
-        return self.asobject.values
+        return self._asobject.values
 
     @property
     def _values(self):
@@ -428,7 +428,7 @@ class PeriodIndex(DatelikeOps, DatetimeIndexOpsMixin, Int64Index):
         if is_integer_dtype(dtype):
             return self.asi8
         else:
-            return self.asobject.values
+            return self._asobject.values
 
     def __array_wrap__(self, result, context=None):
         """
@@ -476,7 +476,7 @@ class PeriodIndex(DatelikeOps, DatetimeIndexOpsMixin, Int64Index):
         if dtype is not None:
             return self.astype(dtype)._to_embed(keep_tz=keep_tz)
 
-        return self.asobject.values
+        return self._asobject.values
 
     @property
     def _formatter_func(self):
@@ -506,7 +506,7 @@ class PeriodIndex(DatelikeOps, DatetimeIndexOpsMixin, Int64Index):
     def astype(self, dtype, copy=True, how='start'):
         dtype = pandas_dtype(dtype)
         if is_object_dtype(dtype):
-            return self.asobject
+            return self._asobject
         elif is_integer_dtype(dtype):
             if copy:
                 return self._int64index.copy()
@@ -656,7 +656,7 @@ class PeriodIndex(DatelikeOps, DatetimeIndexOpsMixin, Int64Index):
 
     def _mpl_repr(self):
         # how to represent ourselves to matplotlib
-        return self.asobject.values
+        return self._asobject.values
 
     def to_timestamp(self, freq=None, how='start'):
         """
@@ -971,7 +971,7 @@ class PeriodIndex(DatelikeOps, DatetimeIndexOpsMixin, Int64Index):
 
     def insert(self, loc, item):
         if not isinstance(item, Period) or self.freq != item.freq:
-            return self.asobject.insert(loc, item)
+            return self._asobject.insert(loc, item)
 
         idx = np.concatenate((self[:loc].asi8, np.array([item.ordinal]),
                               self[loc:].asi8))
@@ -1018,7 +1018,7 @@ class PeriodIndex(DatelikeOps, DatetimeIndexOpsMixin, Int64Index):
     def _format_native_types(self, na_rep=u('NaT'), date_format=None,
                              **kwargs):
 
-        values = self.asobject.values
+        values = self._asobject.values
 
         if date_format:
             formatter = lambda dt: dt.strftime(date_format)

--- a/pandas/core/indexes/timedeltas.py
+++ b/pandas/core/indexes/timedeltas.py
@@ -482,7 +482,7 @@ class TimedeltaIndex(DatetimeIndexOpsMixin, TimelikeOps, Int64Index):
         dtype = np.dtype(dtype)
 
         if is_object_dtype(dtype):
-            return self.asobject
+            return self._asobject
         elif is_timedelta64_ns_dtype(dtype):
             if copy is True:
                 return self.copy()
@@ -881,7 +881,7 @@ class TimedeltaIndex(DatetimeIndexOpsMixin, TimelikeOps, Int64Index):
 
             # fall back to object index
             if isinstance(item, compat.string_types):
-                return self.asobject.insert(loc, item)
+                return self._asobject.insert(loc, item)
             raise TypeError(
                 "cannot insert TimedeltaIndex with incompatible label")
 

--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -405,7 +405,7 @@ class _NDFrameIndexer(_NDFrameIndexerBase):
                             new_values = np.concatenate([self.obj._values,
                                                          new_values])
                         except TypeError:
-                            new_values = np.concatenate([self.obj.asobject,
+                            new_values = np.concatenate([self.obj._asobject,
                                                          new_values])
                     self.obj._data = self.obj._constructor(
                         new_values, index=new_index, name=self.obj.name)._data

--- a/pandas/core/internals.py
+++ b/pandas/core/internals.py
@@ -2190,7 +2190,7 @@ class ObjectBlock(Block):
 
         if isinstance(other, ABCDatetimeIndex):
             # to store DatetimeTZBlock as object
-            other = other.asobject.values
+            other = other._asobject.values
 
         return values, False, other, False
 

--- a/pandas/core/ops.py
+++ b/pandas/core/ops.py
@@ -850,7 +850,7 @@ def _comp_method_SERIES(op, name, str_rep, masker=False):
                 # tested in test_nat_comparisons
                 # (pandas.tests.series.test_operators.TestSeriesOperators)
                 return self._constructor(na_op(self.values,
-                                               other.asobject.values),
+                                               other._asobject.values),
                                          index=self.index)
 
             return self._constructor(na_op(self.values, np.asarray(other)),

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -209,7 +209,7 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
                             # coerce back to datetime objects for lookup
                             data = _dict_compat(data)
                             data = lib.fast_multiget(data,
-                                                     index.asobject.values,
+                                                     index._asobject.values,
                                                      default=np.nan)
                         else:
                             data = np.nan
@@ -433,13 +433,22 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
         return self._data.get_values()
 
     @property
-    def asobject(self):
+    def _asobject(self):
         """
-        return object Series which contains boxed values
-
-        *this is an internal non-public method*
+        Return object Series which contains boxed values
         """
         return self._data.asobject
+
+    @property
+    def asobject(self):
+        """DEPRECATED: '.asobject' is deprecated. Use 'astype(object).values'
+        instead.
+
+        Return object Series which contains boxed values
+        """
+        warnings.warn("asobject is deprecated. Use 'astype(object).values'"
+                      " instead", FutureWarning, stacklevel=2)
+        return self._asobject
 
     # ops
     def ravel(self, order='C'):
@@ -1307,7 +1316,7 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
             # to return an object array of tz-aware Timestamps
 
             # TODO: it must return DatetimeArray with tz in pandas 2.0
-            result = result.asobject.values
+            result = result._asobject.values
 
         return result
 
@@ -2345,7 +2354,7 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
                 raise NotImplementedError
             map_f = lambda values, f: values.map(f)
         else:
-            values = self.asobject
+            values = self._asobject
 
             if na_action == 'ignore':
                 def map_f(values, f):
@@ -2567,7 +2576,7 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
             if is_extension_type(self.dtype):
                 mapped = self._values.map(f)
             else:
-                values = self.asobject
+                values = self._asobject
                 mapped = lib.map_infer(values, f, convert=convert_dtype)
 
         if len(mapped) and isinstance(mapped[0], Series):
@@ -3143,7 +3152,7 @@ def _sanitize_index(data, index, copy=False):
     if isinstance(data, ABCIndexClass) and not copy:
         pass
     elif isinstance(data, PeriodIndex):
-        data = data.asobject
+        data = data._asobject
     elif isinstance(data, DatetimeIndex):
         data = data._to_embed(keep_tz=True)
     elif isinstance(data, np.ndarray):

--- a/pandas/io/formats/format.py
+++ b/pandas/io/formats/format.py
@@ -2231,7 +2231,7 @@ class Datetime64TZFormatter(Datetime64Formatter):
     def _format_strings(self):
         """ we by definition have a TZ """
 
-        values = self.values.asobject
+        values = self.values._asobject
         is_dates_only = _is_dates_only(values)
         formatter = (self.formatter or
                      _get_format_datetime64(is_dates_only,

--- a/pandas/plotting/_converter.py
+++ b/pandas/plotting/_converter.py
@@ -363,7 +363,7 @@ class MilliSecondLocator(dates.DateLocator):
         tz = self.tz.tzname(None)
         st = _from_ordinal(dates.date2num(dmin))  # strip tz
         ed = _from_ordinal(dates.date2num(dmax))
-        all_dates = date_range(start=st, end=ed, freq=freq, tz=tz).asobject
+        all_dates = date_range(start=st, end=ed, freq=freq, tz=tz)._asobject
 
         try:
             if len(all_dates) > 0:

--- a/pandas/tests/frame/test_constructors.py
+++ b/pandas/tests/frame/test_constructors.py
@@ -500,8 +500,8 @@ class TestDataFrameConstructors(TestData):
         assert df['b'].dtype == 'object'
 
         # list of periods
-        df = pd.DataFrame({'a': a.asobject.tolist(),
-                           'b': b.asobject.tolist()})
+        df = pd.DataFrame({'a': a._asobject.tolist(),
+                           'b': b._asobject.tolist()})
         assert df['a'].dtype == 'object'
         assert df['b'].dtype == 'object'
 

--- a/pandas/tests/indexes/datetimes/test_ops.py
+++ b/pandas/tests/indexes/datetimes/test_ops.py
@@ -59,7 +59,7 @@ class TestDatetimeIndexOps(Ops):
                          Timestamp('2013-03-31'),
                          Timestamp('2013-04-30')]
         expected = pd.Index(expected_list, dtype=object, name='idx')
-        result = idx.asobject
+        result = idx._asobject
         assert isinstance(result, Index)
 
         assert result.dtype == object
@@ -74,7 +74,7 @@ class TestDatetimeIndexOps(Ops):
                          Timestamp('2013-03-31', tz='Asia/Tokyo'),
                          Timestamp('2013-04-30', tz='Asia/Tokyo')]
         expected = pd.Index(expected_list, dtype=object, name='idx')
-        result = idx.asobject
+        result = idx._asobject
         assert isinstance(result, Index)
         assert result.dtype == object
         tm.assert_index_equal(result, expected)
@@ -87,7 +87,7 @@ class TestDatetimeIndexOps(Ops):
                          Timestamp('2013-01-02'), pd.NaT,
                          Timestamp('2013-01-04')]
         expected = pd.Index(expected_list, dtype=object, name='idx')
-        result = idx.asobject
+        result = idx._asobject
         assert isinstance(result, Index)
         assert result.dtype == object
         tm.assert_index_equal(result, expected)
@@ -389,7 +389,7 @@ class TestDatetimeIndexOps(Ops):
                                  pd.Timestamp('2011-01-03')])
         right = pd.DatetimeIndex([pd.NaT, pd.NaT, pd.Timestamp('2011-01-03')])
 
-        for l, r in [(left, right), (left.asobject, right.asobject)]:
+        for l, r in [(left, right), (left._asobject, right._asobject)]:
             result = l == r
             expected = np.array([False, False, True])
             tm.assert_numpy_array_equal(result, expected)
@@ -636,9 +636,9 @@ class TestDatetimeIndexOps(Ops):
             idx = pd.DatetimeIndex(['2011-01-01', '2011-01-02', 'NaT'])
             assert idx.equals(idx)
             assert idx.equals(idx.copy())
-            assert idx.equals(idx.asobject)
-            assert idx.asobject.equals(idx)
-            assert idx.asobject.equals(idx.asobject)
+            assert idx.equals(idx._asobject)
+            assert idx._asobject.equals(idx)
+            assert idx._asobject.equals(idx._asobject)
             assert not idx.equals(list(idx))
             assert not idx.equals(pd.Series(idx))
 
@@ -646,8 +646,8 @@ class TestDatetimeIndexOps(Ops):
                                     tz='US/Pacific')
             assert not idx.equals(idx2)
             assert not idx.equals(idx2.copy())
-            assert not idx.equals(idx2.asobject)
-            assert not idx.asobject.equals(idx2)
+            assert not idx.equals(idx2._asobject)
+            assert not idx._asobject.equals(idx2)
             assert not idx.equals(list(idx2))
             assert not idx.equals(pd.Series(idx2))
 
@@ -656,8 +656,8 @@ class TestDatetimeIndexOps(Ops):
             tm.assert_numpy_array_equal(idx.asi8, idx3.asi8)
             assert not idx.equals(idx3)
             assert not idx.equals(idx3.copy())
-            assert not idx.equals(idx3.asobject)
-            assert not idx.asobject.equals(idx3)
+            assert not idx.equals(idx3._asobject)
+            assert not idx._asobject.equals(idx3)
             assert not idx.equals(list(idx3))
             assert not idx.equals(pd.Series(idx3))
 

--- a/pandas/tests/indexes/period/test_ops.py
+++ b/pandas/tests/indexes/period/test_ops.py
@@ -35,7 +35,7 @@ class TestPeriodIndexOps(Ops):
                          pd.Period('2013-03-31', freq='M'),
                          pd.Period('2013-04-30', freq='M')]
         expected = pd.Index(expected_list, dtype=object, name='idx')
-        result = idx.asobject
+        result = idx._asobject
         assert isinstance(result, Index)
         assert result.dtype == object
         tm.assert_index_equal(result, expected)
@@ -49,7 +49,7 @@ class TestPeriodIndexOps(Ops):
                          pd.Period('NaT', freq='D'),
                          pd.Period('2013-01-04', freq='D')]
         expected = pd.Index(expected_list, dtype=object, name='idx')
-        result = idx.asobject
+        result = idx._asobject
         assert isinstance(result, Index)
         assert result.dtype == object
         tm.assert_index_equal(result, expected)
@@ -290,7 +290,7 @@ Freq: Q-DEC"""
                                pd.Period('2011-01-03')])
         right = pd.PeriodIndex([pd.NaT, pd.NaT, pd.Period('2011-01-03')])
 
-        for l, r in [(left, right), (left.asobject, right.asobject)]:
+        for l, r in [(left, right), (left._asobject, right._asobject)]:
             result = l == r
             expected = np.array([False, False, True])
             tm.assert_numpy_array_equal(result, expected)
@@ -614,9 +614,9 @@ Freq: Q-DEC"""
                                  freq=freq)
             assert idx.equals(idx)
             assert idx.equals(idx.copy())
-            assert idx.equals(idx.asobject)
-            assert idx.asobject.equals(idx)
-            assert idx.asobject.equals(idx.asobject)
+            assert idx.equals(idx._asobject)
+            assert idx._asobject.equals(idx)
+            assert idx._asobject.equals(idx._asobject)
             assert not idx.equals(list(idx))
             assert not idx.equals(pd.Series(idx))
 
@@ -624,8 +624,8 @@ Freq: Q-DEC"""
                                   freq='H')
             assert not idx.equals(idx2)
             assert not idx.equals(idx2.copy())
-            assert not idx.equals(idx2.asobject)
-            assert not idx.asobject.equals(idx2)
+            assert not idx.equals(idx2._asobject)
+            assert not idx._asobject.equals(idx2)
             assert not idx.equals(list(idx2))
             assert not idx.equals(pd.Series(idx2))
 
@@ -634,8 +634,8 @@ Freq: Q-DEC"""
             tm.assert_numpy_array_equal(idx.asi8, idx3.asi8)
             assert not idx.equals(idx3)
             assert not idx.equals(idx3.copy())
-            assert not idx.equals(idx3.asobject)
-            assert not idx.asobject.equals(idx3)
+            assert not idx.equals(idx3._asobject)
+            assert not idx._asobject.equals(idx3)
             assert not idx.equals(list(idx3))
             assert not idx.equals(pd.Series(idx3))
 

--- a/pandas/tests/indexes/period/test_period.py
+++ b/pandas/tests/indexes/period/test_period.py
@@ -384,19 +384,19 @@ class TestPeriodIndex(DatetimeLike):
         idx = pd.PeriodIndex([], freq='M')
 
         exp = np.array([], dtype=object)
-        tm.assert_numpy_array_equal(idx.asobject.values, exp)
+        tm.assert_numpy_array_equal(idx._asobject.values, exp)
         tm.assert_numpy_array_equal(idx._mpl_repr(), exp)
 
         idx = pd.PeriodIndex(['2011-01', pd.NaT], freq='M')
 
         exp = np.array([pd.Period('2011-01', freq='M'), pd.NaT], dtype=object)
-        tm.assert_numpy_array_equal(idx.asobject.values, exp)
+        tm.assert_numpy_array_equal(idx._asobject.values, exp)
         tm.assert_numpy_array_equal(idx._mpl_repr(), exp)
 
         exp = np.array([pd.Period('2011-01-01', freq='D'), pd.NaT],
                        dtype=object)
         idx = pd.PeriodIndex(['2011-01-01', pd.NaT], freq='D')
-        tm.assert_numpy_array_equal(idx.asobject.values, exp)
+        tm.assert_numpy_array_equal(idx._asobject.values, exp)
         tm.assert_numpy_array_equal(idx._mpl_repr(), exp)
 
     def test_is_(self):

--- a/pandas/tests/indexes/test_base.py
+++ b/pandas/tests/indexes/test_base.py
@@ -111,7 +111,7 @@ class TestIndex(Base):
         tm.assert_index_equal(result, idx)
         assert result.tz == idx.tz
 
-        result = pd.Index(idx.asobject)
+        result = pd.Index(idx._asobject)
         tm.assert_index_equal(result, idx)
         assert result.tz == idx.tz
 
@@ -120,7 +120,7 @@ class TestIndex(Base):
         result = pd.Index(idx)
         tm.assert_index_equal(result, idx)
 
-        result = pd.Index(idx.asobject)
+        result = pd.Index(idx._asobject)
         tm.assert_index_equal(result, idx)
 
     def test_constructor_from_index_period(self):
@@ -128,7 +128,7 @@ class TestIndex(Base):
         result = pd.Index(idx)
         tm.assert_index_equal(result, idx)
 
-        result = pd.Index(idx.asobject)
+        result = pd.Index(idx._asobject)
         tm.assert_index_equal(result, idx)
 
     def test_constructor_from_series_datetimetz(self):

--- a/pandas/tests/indexes/timedeltas/test_ops.py
+++ b/pandas/tests/indexes/timedeltas/test_ops.py
@@ -30,7 +30,7 @@ class TestTimedeltaIndexOps(Ops):
         expected_list = [Timedelta('1 days'), Timedelta('2 days'),
                          Timedelta('3 days'), Timedelta('4 days')]
         expected = pd.Index(expected_list, dtype=object, name='idx')
-        result = idx.asobject
+        result = idx._asobject
         assert isinstance(result, Index)
 
         assert result.dtype == object
@@ -43,7 +43,7 @@ class TestTimedeltaIndexOps(Ops):
         expected_list = [Timedelta('1 days'), Timedelta('2 days'), pd.NaT,
                          Timedelta('4 days')]
         expected = pd.Index(expected_list, dtype=object, name='idx')
-        result = idx.asobject
+        result = idx._asobject
         assert isinstance(result, Index)
         assert result.dtype == object
         tm.assert_index_equal(result, expected)
@@ -217,7 +217,7 @@ dtype: timedelta64[ns]"""
                                   pd.Timedelta('3 days')])
         right = pd.TimedeltaIndex([pd.NaT, pd.NaT, pd.Timedelta('3 days')])
 
-        for l, r in [(left, right), (left.asobject, right.asobject)]:
+        for l, r in [(left, right), (left._asobject, right._asobject)]:
             result = l == r
             expected = np.array([False, False, True])
             tm.assert_numpy_array_equal(result, expected)
@@ -473,18 +473,18 @@ dtype: timedelta64[ns]"""
         idx = pd.TimedeltaIndex(['1 days', '2 days', 'NaT'])
         assert idx.equals(idx)
         assert idx.equals(idx.copy())
-        assert idx.equals(idx.asobject)
-        assert idx.asobject.equals(idx)
-        assert idx.asobject.equals(idx.asobject)
+        assert idx.equals(idx._asobject)
+        assert idx._asobject.equals(idx)
+        assert idx._asobject.equals(idx._asobject)
         assert not idx.equals(list(idx))
         assert not idx.equals(pd.Series(idx))
 
         idx2 = pd.TimedeltaIndex(['2 days', '1 days', 'NaT'])
         assert not idx.equals(idx2)
         assert not idx.equals(idx2.copy())
-        assert not idx.equals(idx2.asobject)
-        assert not idx.asobject.equals(idx2)
-        assert not idx.asobject.equals(idx2.asobject)
+        assert not idx.equals(idx2._asobject)
+        assert not idx._asobject.equals(idx2)
+        assert not idx._asobject.equals(idx2._asobject)
         assert not idx.equals(list(idx2))
         assert not idx.equals(pd.Series(idx2))
 

--- a/pandas/tests/plotting/test_datetimelike.py
+++ b/pandas/tests/plotting/test_datetimelike.py
@@ -272,7 +272,7 @@ class TestTSPlot(TestPlotBase):
 
         _, ax = self.plt.subplots()
         df2 = df.copy()
-        df2.index = df.index.asobject
+        df2.index = df.index._asobject
         df2.plot(ax=ax)
         diffs = Series(ax.get_lines()[0].get_xydata()[:, 0]).diff()
         assert (np.fabs(diffs[1:] - sec) < 1e-8).all()
@@ -712,9 +712,9 @@ class TestTSPlot(TestPlotBase):
         assert not hasattr(ax, 'freq')
         lines = ax.get_lines()
         x1 = lines[0].get_xdata()
-        tm.assert_numpy_array_equal(x1, s2.index.asobject.values)
+        tm.assert_numpy_array_equal(x1, s2.index._asobject.values)
         x2 = lines[1].get_xdata()
-        tm.assert_numpy_array_equal(x2, s1.index.asobject.values)
+        tm.assert_numpy_array_equal(x2, s1.index._asobject.values)
 
     def test_mixed_freq_regular_first_df(self):
         # GH 9852
@@ -744,9 +744,9 @@ class TestTSPlot(TestPlotBase):
         assert not hasattr(ax, 'freq')
         lines = ax.get_lines()
         x1 = lines[0].get_xdata()
-        tm.assert_numpy_array_equal(x1, s2.index.asobject.values)
+        tm.assert_numpy_array_equal(x1, s2.index._asobject.values)
         x2 = lines[1].get_xdata()
-        tm.assert_numpy_array_equal(x2, s1.index.asobject.values)
+        tm.assert_numpy_array_equal(x2, s1.index._asobject.values)
 
     def test_mixed_freq_hf_first(self):
         idxh = date_range('1/1/1999', periods=365, freq='D')
@@ -1019,7 +1019,7 @@ class TestTSPlot(TestPlotBase):
 
         # np.datetime64
         idx = date_range('1/1/2000', periods=10)
-        idx = idx[[0, 2, 5, 9]].asobject
+        idx = idx[[0, 2, 5, 9]]._asobject
         df = DataFrame(np.random.randn(len(idx), 3), idx)
         _, ax = self.plt.subplots()
         _check_plot_works(df.plot, ax=ax)

--- a/pandas/tests/series/test_api.py
+++ b/pandas/tests/series/test_api.py
@@ -200,6 +200,11 @@ class SharedWithSparse(object):
         with tm.assert_produces_warning(FutureWarning):
             self.series_klass.from_array([1, 2, 3])
 
+    def test_asobject_deprecated(self):
+        # GH18477
+        with tm.assert_produces_warning(FutureWarning):
+            pd.Series().asobject
+
 
 class TestSeriesMisc(TestData, SharedWithSparse):
 

--- a/pandas/tests/series/test_constructors.py
+++ b/pandas/tests/series/test_constructors.py
@@ -606,7 +606,7 @@ class TestSeriesConstructors(TestData):
 
         pi = period_range('20130101', periods=5, freq='D')
         s = Series(pi)
-        expected = Series(pi.asobject)
+        expected = Series(pi._asobject)
         assert_series_equal(s, expected)
 
         assert s.dtype == 'object'

--- a/pandas/tests/series/test_datetime_values.py
+++ b/pandas/tests/series/test_datetime_values.py
@@ -228,7 +228,7 @@ class TestSeriesDatetimeValues(TestData):
             results, list(sorted(set(ok_for_dt + ok_for_dt_methods))))
 
         s = Series(period_range('20130101', periods=5,
-                                freq='D', name='xxx').asobject)
+                                freq='D', name='xxx')._asobject)
         results = get_dir(s)
         tm.assert_almost_equal(
             results, list(sorted(set(ok_for_period + ok_for_period_methods))))
@@ -387,7 +387,7 @@ class TestSeriesDatetimeValues(TestData):
         assert result.dtype == 'timedelta64[ns]'
 
     def test_between(self):
-        s = Series(bdate_range('1/1/2000', periods=20).asobject)
+        s = Series(bdate_range('1/1/2000', periods=20)._asobject)
         s[::2] = np.nan
 
         result = s[s.between(s[3], s[17])]

--- a/pandas/tests/series/test_timeseries.py
+++ b/pandas/tests/series/test_timeseries.py
@@ -134,13 +134,13 @@ class TestTimeSeries(TestData):
         assert res.dtype == 'datetime64[ns, US/Eastern]'
 
         res = s.shift(1)
-        exp_vals = [NaT] + dates.asobject.values.tolist()[:9]
+        exp_vals = [NaT] + dates._asobject.values.tolist()[:9]
         exp = Series(exp_vals)
         tm.assert_series_equal(res, exp)
         assert res.dtype == 'datetime64[ns, US/Eastern]'
 
         res = s.shift(-2)
-        exp_vals = dates.asobject.values.tolist()[2:] + [NaT, NaT]
+        exp_vals = dates._asobject.values.tolist()[2:] + [NaT, NaT]
         exp = Series(exp_vals)
         tm.assert_series_equal(res, exp)
         assert res.dtype == 'datetime64[ns, US/Eastern]'

--- a/pandas/tests/test_base.py
+++ b/pandas/tests/test_base.py
@@ -437,7 +437,7 @@ class TestIndexOps(Ops):
                 for r in result:
                     assert isinstance(r, Timestamp)
                 tm.assert_numpy_array_equal(result,
-                                            orig._values.asobject.values)
+                                            orig._values._asobject.values)
             else:
                 tm.assert_numpy_array_equal(result, orig.values)
 
@@ -526,7 +526,7 @@ class TestIndexOps(Ops):
                 elif is_datetimetz(o):
                     # unable to compare NaT / nan
                     tm.assert_numpy_array_equal(result[1:],
-                                                values[2:].asobject.values)
+                                                values[2:]._asobject.values)
                     assert result[0] is pd.NaT
                 else:
                     tm.assert_numpy_array_equal(result[1:], values[2:])

--- a/pandas/tests/tseries/test_frequencies.py
+++ b/pandas/tests/tseries/test_frequencies.py
@@ -720,15 +720,15 @@ class TestFrequencyInference(object):
 
     def test_infer_freq(self):
         rng = period_range('1959Q2', '2009Q3', freq='Q')
-        rng = Index(rng.to_timestamp('D', how='e').asobject)
+        rng = Index(rng.to_timestamp('D', how='e')._asobject)
         assert rng.inferred_freq == 'Q-DEC'
 
         rng = period_range('1959Q2', '2009Q3', freq='Q-NOV')
-        rng = Index(rng.to_timestamp('D', how='e').asobject)
+        rng = Index(rng.to_timestamp('D', how='e')._asobject)
         assert rng.inferred_freq == 'Q-NOV'
 
         rng = period_range('1959Q2', '2009Q3', freq='Q-OCT')
-        rng = Index(rng.to_timestamp('D', how='e').asobject)
+        rng = Index(rng.to_timestamp('D', how='e')._asobject)
         assert rng.inferred_freq == 'Q-OCT'
 
     def test_infer_freq_tz(self):

--- a/pandas/tests/tseries/test_timezones.py
+++ b/pandas/tests/tseries/test_timezones.py
@@ -688,7 +688,7 @@ class TestTimeZoneSupportPytz(object):
         # dates around a dst transition
         rng = date_range('2/13/2010', '5/6/2010', tz=self.tzstr('US/Eastern'))
 
-        objs = rng.asobject
+        objs = rng._asobject
         for i, x in enumerate(objs):
             exval = rng[i]
             assert x == exval
@@ -1552,8 +1552,8 @@ class TestTimeZones(object):
         ts2 = Series(np.random.randn(len(rng2)), index=rng2)
         ts_result = ts1.append(ts2)
 
-        assert ts_result.index.equals(ts1.index.asobject.append(
-            ts2.index.asobject))
+        assert ts_result.index.equals(ts1.index._asobject.append(
+            ts2.index._asobject))
 
         # mixed
         rng1 = date_range('1/1/2011 01:00', periods=1, freq='H')
@@ -1561,7 +1561,7 @@ class TestTimeZones(object):
         ts1 = Series(np.random.randn(len(rng1)), index=rng1)
         ts2 = Series(np.random.randn(len(rng2)), index=rng2)
         ts_result = ts1.append(ts2)
-        assert ts_result.index.equals(ts1.index.asobject.append(
+        assert ts_result.index.equals(ts1.index._asobject.append(
             ts2.index))
 
     def test_equal_join_ensure_utc(self):


### PR DESCRIPTION
- [ x] xref #18262
- [x ] tests added / passedPR
- [ x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ x] whatsnew entry

Deprecate ``Series.asobject`` and ``DateTimeIndex.asobject`` as public-facing attributes and make them private as per discussion in #18262.

@ManrajGrover please note that I've made a PR on ``.asobject``.