### PR TITLE
CLN: ASV ctors benchmark

### DIFF
--- a/asv_bench/benchmarks/ctors.py
+++ b/asv_bench/benchmarks/ctors.py
@@ -1,6 +1,7 @@
 import numpy as np
 from pandas import DataFrame, Series, Index, DatetimeIndex, Timestamp
 
+
 class Constructors(object):
 
     goal_time = 0.2

--- a/asv_bench/benchmarks/ctors.py
+++ b/asv_bench/benchmarks/ctors.py
@@ -1,24 +1,27 @@
-from .pandas_vb_common import *
-
+import numpy as np
+from pandas import DataFrame, Series, Index, DatetimeIndex, Timestamp
 
 class Constructors(object):
+
     goal_time = 0.2
 
     def setup(self):
-        self.arr = np.random.randn(100, 100)
+        N = 10**2
+        np.random.seed(1234)
+        self.arr = np.random.randn(N, N)
         self.arr_str = np.array(['foo', 'bar', 'baz'], dtype=object)
 
-        self.data = np.random.randn(100)
-        self.index = Index(np.arange(100))
+        self.data = np.random.randn(N)
+        self.index = Index(np.arange(N))
 
-        self.s = Series(([Timestamp('20110101'), Timestamp('20120101'),
-                          Timestamp('20130101')] * 1000))
+        self.s = Series([Timestamp('20110101'), Timestamp('20120101'),
+                         Timestamp('20130101')] * N * 10)
 
     def time_frame_from_ndarray(self):
         DataFrame(self.arr)
 
     def time_series_from_ndarray(self):
-        pd.Series(self.data, index=self.index)
+        Series(self.data, index=self.index)
 
     def time_index_from_array_string(self):
         Index(self.arr_str)
@@ -26,5 +29,5 @@ class Constructors(object):
     def time_dtindex_from_series(self):
         DatetimeIndex(self.s)
 
-    def time_dtindex_from_series2(self):
+    def time_dtindex_from_index_with_series(self):
         Index(self.s)


### PR DESCRIPTION
I think this these asvs should be enhanced or reorganized to other files in the future, but in the meantime:

- Added `np.random.seed(1234)` in setup classes where random data is created xref #8144

- Ran flake8 and replaced star imports

```
$ asv run -q -b ^ctors
[  0.00%] ·· Benchmarking conda-py3.6-Cython-matplotlib-numexpr-numpy-openpyxl-pytables-pytest-scipy-sqlalchemy-xlrd-xlsxwriter-xlwt
[ 20.00%] ··· Running ctors.Constructors.time_dtindex_from_index_with_series                                         99.0μs
[ 40.00%] ··· Running ctors.Constructors.time_dtindex_from_series                                                    59.5μs
[ 60.00%] ··· Running ctors.Constructors.time_frame_from_ndarray                                                      237μs
[ 80.00%] ··· Running ctors.Constructors.time_index_from_array_string                                                 101μs
[100.00%] ··· Running ctors.Constructors.time_series_from_ndarray                                                    61.2μs
```
