### PR TITLE
Fix tzaware dates mismatch but no exception raised

### DIFF
--- a/doc/source/whatsnew/v0.21.1.txt
+++ b/doc/source/whatsnew/v0.21.1.txt
@@ -64,7 +64,7 @@ Conversion
 - Bug in :class:`DatetimeIndex` subtracting datetimelike from DatetimeIndex could fail to overflow (:issue:`18020`)
 - Bug in :meth:`IntervalIndex.copy` when copying and ``IntervalIndex`` with non-default ``closed`` (:issue:`18339`)
 - Bug in :func:`DataFrame.to_dict` where columns of datetime that are tz-aware were not converted to required arrays when used with ``orient='records'``, raising``TypeError` (:issue:`18372`)
--
+- Bug in :class:`DateTimeIndex` and :meth:`date_range` where mismatching tz-aware ``start`` and ``end`` timezones would not raise an err if ``end.tzinfo`` is None (:issue:`18431`)
 -
 
 Indexing

--- a/pandas/_libs/tslibs/timezones.pyx
+++ b/pandas/_libs/tslibs/timezones.pyx
@@ -284,10 +284,9 @@ cdef object get_dst_info(object tz):
 def infer_tzinfo(start, end):
     if start is not None and end is not None:
         tz = start.tzinfo
-        if end.tzinfo:
-            if not (get_timezone(tz) == get_timezone(end.tzinfo)):
-                msg = 'Inputs must both have the same timezone, {tz1} != {tz2}'
-                raise AssertionError(msg.format(tz1=tz, tz2=end.tzinfo))
+        if not (get_timezone(tz) == get_timezone(end.tzinfo)):
+            msg = 'Inputs must both have the same timezone, {tz1} != {tz2}'
+            raise AssertionError(msg.format(tz1=tz, tz2=end.tzinfo))
     elif start is not None:
         tz = start.tzinfo
     elif end is not None:

--- a/pandas/tests/indexes/datetimes/test_date_range.py
+++ b/pandas/tests/indexes/datetimes/test_date_range.py
@@ -290,6 +290,24 @@ class TestGenRangeGeneration(object):
         tm.assert_index_equal(result1, expected1)
         tm.assert_index_equal(result2, expected2)
 
+    def test_mismatching_tz_raises_err(self):
+        dt1_tz = pd.Timestamp('2017-01-01', tz='US/Eastern')
+        dt1_no_tz = pd.Timestamp('2017-01-01')
+        dt2_tz = pd.Timestamp('2017-01-04', tz='US/Eastern')
+        dt2_no_tz = pd.Timestamp('2017-01-04')
+
+        with pytest.raises(TypeError):
+            pd.date_range(start=dt1_no_tz, end=dt2_tz)
+
+        with pytest.raises(TypeError):
+            pd.date_range(start=dt1_tz, end=dt2_no_tz)
+
+        with pytest.raises(TypeError):
+            pd.DatetimeIndex(start=dt1_no_tz, end=dt2_tz, freq='D')
+
+        with pytest.raises(TypeError):
+            pd.DatetimeIndex(start=dt1_tz, end=dt2_no_tz, freq='D')
+
 
 class TestBusinessDateRange(object):
 

--- a/pandas/tests/indexes/datetimes/test_date_range.py
+++ b/pandas/tests/indexes/datetimes/test_date_range.py
@@ -290,25 +290,20 @@ class TestGenRangeGeneration(object):
         tm.assert_index_equal(result1, expected1)
         tm.assert_index_equal(result2, expected2)
 
-    def test_mismatching_tz_raises_err(self):
+    dt1, dt2, tz1, tz2 = '2017-01-01', '2017-01-01', 'US/Eastern', 'Europe/London'
+    @pytest.mark.parametrize("start,end", [
+        (pd.Timestamp(dt1, tz=tz1), pd.Timestamp(dt2)),
+        (pd.Timestamp(dt1),  pd.Timestamp(dt2, tz=tz2)),
+        (pd.Timestamp(dt1, tz=tz1), pd.Timestamp(dt2, tz=tz2)),
+        (pd.Timestamp(dt1, tz=tz2), pd.Timestamp(dt2, tz=tz1))
+    ])
+    def test_mismatching_tz_raises_err(self, start, end):
         #issue 18488
-        dt1_tz = pd.Timestamp('2017-01-01', tz='US/Eastern')
-        dt1_no_tz = pd.Timestamp('2017-01-01')
-        dt2_tz = pd.Timestamp('2017-01-04', tz='US/Eastern')
-        dt2_no_tz = pd.Timestamp('2017-01-04')
-        dt1_diff_tz = pd.Timestamp('2017-01-01', tz='Europe/London')
-        dt2_diff_tz = pd.Timestamp('2017-01-04', tz='Europe/London')
+        with pytest.raises(TypeError):
+            pd.date_range(start, end)
+        with pytest.raises(TypeError):
+            pd.DatetimeIndex(start, end, freq=BDay())
 
-        def assert_tz_raises_exception(start, end):
-            with pytest.raises(TypeError):
-                pd.date_range(start, end)
-            with pytest.raises(TypeError):
-                pd.DatetimeIndexstart(start, end)
-
-        assert_tz_raises_exception(dt1_no_tz, dt2_tz)
-        assert_tz_raises_exception(dt1_tz, dt2_no_tz)
-        assert_tz_raises_exception(dt1_tz, dt2_diff_tz)
-        assert_tz_raises_exception(dt1_diff_tz, dt2_tz)
 
 class TestBusinessDateRange(object):
 

--- a/pandas/tests/indexes/datetimes/test_date_range.py
+++ b/pandas/tests/indexes/datetimes/test_date_range.py
@@ -291,23 +291,24 @@ class TestGenRangeGeneration(object):
         tm.assert_index_equal(result2, expected2)
 
     def test_mismatching_tz_raises_err(self):
+        #issue 18488
         dt1_tz = pd.Timestamp('2017-01-01', tz='US/Eastern')
         dt1_no_tz = pd.Timestamp('2017-01-01')
         dt2_tz = pd.Timestamp('2017-01-04', tz='US/Eastern')
         dt2_no_tz = pd.Timestamp('2017-01-04')
+        dt1_diff_tz = pd.Timestamp('2017-01-01', tz='Europe/London')
+        dt2_diff_tz = pd.Timestamp('2017-01-04', tz='Europe/London')
 
-        with pytest.raises(TypeError):
-            pd.date_range(start=dt1_no_tz, end=dt2_tz)
+        def assert_tz_raises_exception(start, end):
+            with pytest.raises(TypeError):
+                pd.date_range(start, end)
+            with pytest.raises(TypeError):
+                pd.DatetimeIndexstart(start, end)
 
-        with pytest.raises(TypeError):
-            pd.date_range(start=dt1_tz, end=dt2_no_tz)
-
-        with pytest.raises(TypeError):
-            pd.DatetimeIndex(start=dt1_no_tz, end=dt2_tz, freq='D')
-
-        with pytest.raises(TypeError):
-            pd.DatetimeIndex(start=dt1_tz, end=dt2_no_tz, freq='D')
-
+        assert_tz_raises_exception(dt1_no_tz, dt2_tz)
+        assert_tz_raises_exception(dt1_tz, dt2_no_tz)
+        assert_tz_raises_exception(dt1_tz, dt2_diff_tz)
+        assert_tz_raises_exception(dt1_diff_tz, dt2_tz)
 
 class TestBusinessDateRange(object):
 

--- a/pandas/tests/indexes/datetimes/test_date_range.py
+++ b/pandas/tests/indexes/datetimes/test_date_range.py
@@ -292,9 +292,10 @@ class TestGenRangeGeneration(object):
 
     dt1, dt2 = '2017-01-01', '2017-01-01'
     tz1, tz2 = 'US/Eastern', 'Europe/London'
+
     @pytest.mark.parametrize("start,end", [
         (pd.Timestamp(dt1, tz=tz1), pd.Timestamp(dt2)),
-        (pd.Timestamp(dt1),  pd.Timestamp(dt2, tz=tz2)),
+        (pd.Timestamp(dt1), pd.Timestamp(dt2, tz=tz2)),
         (pd.Timestamp(dt1, tz=tz1), pd.Timestamp(dt2, tz=tz2)),
         (pd.Timestamp(dt1, tz=tz2), pd.Timestamp(dt2, tz=tz1))
     ])

--- a/pandas/tests/indexes/datetimes/test_date_range.py
+++ b/pandas/tests/indexes/datetimes/test_date_range.py
@@ -290,7 +290,8 @@ class TestGenRangeGeneration(object):
         tm.assert_index_equal(result1, expected1)
         tm.assert_index_equal(result2, expected2)
 
-    dt1, dt2, tz1, tz2 = '2017-01-01', '2017-01-01', 'US/Eastern', 'Europe/London'
+    dt1, dt2 = '2017-01-01', '2017-01-01'
+    tz1, tz2 = 'US/Eastern', 'Europe/London'
     @pytest.mark.parametrize("start,end", [
         (pd.Timestamp(dt1, tz=tz1), pd.Timestamp(dt2)),
         (pd.Timestamp(dt1),  pd.Timestamp(dt2, tz=tz2)),
@@ -298,7 +299,7 @@ class TestGenRangeGeneration(object):
         (pd.Timestamp(dt1, tz=tz2), pd.Timestamp(dt2, tz=tz1))
     ])
     def test_mismatching_tz_raises_err(self, start, end):
-        #issue 18488
+        # issue 18488
         with pytest.raises(TypeError):
             pd.date_range(start, end)
         with pytest.raises(TypeError):

--- a/pandas/tests/tseries/test_timezones.py
+++ b/pandas/tests/tseries/test_timezones.py
@@ -424,7 +424,7 @@ class TestTimeZoneSupportPytz(object):
 
         # datetimes with tzinfo set
         dr = bdate_range(datetime(2005, 1, 1, tzinfo=pytz.utc),
-                         '1/1/2009', tz=pytz.utc)
+                         datetime(2009, 1, 1, tzinfo=pytz.utc))
 
         pytest.raises(Exception, bdate_range,
                       datetime(2005, 1, 1, tzinfo=pytz.utc), '1/1/2009',


### PR DESCRIPTION
- [x] closes #18431
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry
