### PR TITLE
CLN: ASV  frame_ctor benchmark

### DIFF
--- a/asv_bench/benchmarks/frame_ctor.py
+++ b/asv_bench/benchmarks/frame_ctor.py
@@ -1,4 +1,7 @@
-from .pandas_vb_common import *
+import numpy as np
+import pandas.util.testing as tm
+from pandas import DataFrame, Series, MultiIndex
+from pandas import *
 try:
     from pandas.tseries.offsets import *
 except:
@@ -9,23 +12,22 @@ except:
 # Creation from nested dict
 
 class FromDicts(object):
+
     goal_time = 0.2
 
     def setup(self):
-        (N, K) = (5000, 50)
+        np.random.seed(1234)
+        N, K = 5000, 50
         self.index = tm.makeStringIndex(N)
         self.columns = tm.makeStringIndex(K)
-        self.frame = DataFrame(np.random.randn(N, K), index=self.index, columns=self.columns)
-        try:
-            self.data = self.frame.to_dict()
-        except:
-            self.data = self.frame.toDict()
+        self.frame = DataFrame(np.random.randn(N, K),
+                               index=self.index,
+                               columns=self.columns)
+        self.data = self.frame.to_dict()
         self.some_dict = list(self.data.values())[0]
-        self.dict_list = [dict(zip(self.columns, row)) for row in self.frame.values]
-
+        self.dict_list = self.frame.to_dict(orient='records')
         self.data2 = {i: {j: float(j) for j in range(100)}
                       for i in range(2000)}
-
 
     def time_frame_ctor_list_of_dict(self):
         DataFrame(self.dict_list)
@@ -38,37 +40,20 @@ class FromDicts(object):
 
     def time_frame_ctor_nested_dict_int64(self):
         # nested dict, integer indexes, regression described in #621
-        DataFrame(self.data)
+        DataFrame(self.data2)
 
 
 # from a mi-series
 
-class frame_from_series(object):
+class FromSeries(object):
     goal_time = 0.2
 
     def setup(self):
-        self.mi = MultiIndex.from_tuples([(x, y) for x in range(100) for y in range(100)])
-        self.s = Series(randn(10000), index=self.mi)
+        self.mi = MultiIndex.from_product([range(100), range(100)])
+        self.s = Series(np.random.randn(10000), index=self.mi)
 
     def time_frame_from_mi_series(self):
         DataFrame(self.s)
-
-
-#----------------------------------------------------------------------
-# get_numeric_data
-
-class frame_get_numeric_data(object):
-    goal_time = 0.2
-
-    def setup(self):
-        self.df = DataFrame(randn(10000, 25))
-        self.df['foo'] = 'bar'
-        self.df['bar'] = 'baz'
-        self.df = self.df.consolidate()
-
-    def time_frame_get_numeric_data(self):
-        self.df._get_numeric_data()
-
 
 # ----------------------------------------------------------------------
 # From dict with DatetimeIndex with all offsets
@@ -84,13 +69,15 @@ def get_period_count(start_date, off):
     if (ten_offsets_in_days == 0):
         return 1000
     else:
-        return min((9 * ((Timestamp.max - start_date).days // ten_offsets_in_days)), 1000)
+        periods = 9 * (Timestamp.max - start_date).days // ten_offsets_in_days
+        return min(periods, 1000)
 
 
 def get_index_for_offset(off):
     start_date = Timestamp('1/1/1900')
-    return date_range(start_date, periods=min(1000, get_period_count(
-        start_date, off)), freq=off)
+    return date_range(start_date,
+                      periods=get_period_count(start_date, off),
+                      freq=off)
 
 
 all_offsets = offsets.__all__
@@ -100,7 +87,7 @@ for off in ['FY5253', 'FY5253Quarter']:
     all_offsets.extend([off + '_1', off + '_2'])
 
 
-class FrameConstructorDTIndexFromOffsets(object):
+class FromDictwithTimestampOffsets(object):
 
     params = [all_offsets, [1, 2]]
     param_names = ['offset', 'n_steps']
@@ -108,13 +95,15 @@ class FrameConstructorDTIndexFromOffsets(object):
     offset_kwargs = {'WeekOfMonth': {'weekday': 1, 'week': 1},
                      'LastWeekOfMonth': {'weekday': 1, 'week': 1},
                      'FY5253': {'startingMonth': 1, 'weekday': 1},
-                     'FY5253Quarter': {'qtr_with_extra_week': 1, 'startingMonth': 1, 'weekday': 1}}
+                     'FY5253Quarter': {'qtr_with_extra_week': 1,
+                                       'startingMonth': 1,
+                                       'weekday': 1}}
 
     offset_extra_cases = {'FY5253': {'variation': ['nearest', 'last']},
                           'FY5253Quarter': {'variation': ['nearest', 'last']}}
 
     def setup(self, offset, n_steps):
-
+        np.random.seed(1234)
         extra = False
         if offset.endswith("_", None, -1):
             extra = int(offset[-1])
@@ -132,7 +121,7 @@ class FrameConstructorDTIndexFromOffsets(object):
         offset = getattr(offsets, offset)
         self.idx = get_index_for_offset(offset(n_steps, **kwargs))
         self.df = DataFrame(np.random.randn(len(self.idx), 10), index=self.idx)
-        self.d = dict(self.df.items())
+        self.d = self.df.to_dict()
 
     def time_frame_ctor(self, offset, n_steps):
         DataFrame(self.d)

--- a/asv_bench/benchmarks/frame_ctor.py
+++ b/asv_bench/benchmarks/frame_ctor.py
@@ -1,9 +1,8 @@
 import numpy as np
 import pandas.util.testing as tm
-from pandas import DataFrame, Series, MultiIndex
-from pandas import *
+from pandas import DataFrame, Series, MultiIndex, Timestamp, date_range
 try:
-    from pandas.tseries.offsets import *
+    from pandas.tseries import offsets
 except:
     from pandas.core.datetools import *
 

--- a/asv_bench/benchmarks/frame_ctor.py
+++ b/asv_bench/benchmarks/frame_ctor.py
@@ -7,7 +7,7 @@ except:
     from pandas.core.datetools import *
 
 
-#----------------------------------------------------------------------
+# ----------------------------------------------------------------------
 # Creation from nested dict
 
 class FromDicts(object):
@@ -115,7 +115,7 @@ class FromDictwithTimestampOffsets(object):
         if extra:
             extras = self.offset_extra_cases[offset]
             for extra_arg in extras:
-                kwargs[extra_arg] = extras[extra_arg][extra -1]
+                kwargs[extra_arg] = extras[extra_arg][extra - 1]
 
         offset = getattr(offsets, offset)
         self.idx = get_index_for_offset(offset(n_steps, **kwargs))

--- a/asv_bench/benchmarks/frame_methods.py
+++ b/asv_bench/benchmarks/frame_methods.py
@@ -1,6 +1,20 @@
 from .pandas_vb_common import *
 import string
 
+#----------------------------------------------------------------------
+# get_numeric_data
+
+class frame_get_numeric_data(object):
+    goal_time = 0.2
+
+    def setup(self):
+        self.df = DataFrame(np.random.randn(10000, 25))
+        self.df['foo'] = 'bar'
+        self.df['bar'] = 'baz'
+        self.df = self.df.consolidate()
+
+    def time_frame_get_numeric_data(self):
+        self.df._get_numeric_data()
 
 #----------------------------------------------------------------------
 # lookup


### PR DESCRIPTION
- Added `np.random.seed(1234)` in setup classes where random data is created xref #8144

- Ran flake8 and replaced star imports (but `from pandas.core.datetools import *` might need to be kept for compat?)

- `time_frame_ctor_nested_dict_int64` was using `self.data` instead of `self.data2`

- Moved the class `frame_get_numeric_data` to `frame_methods.py` 

```
asv run -b ^frame_ctor
[  0.00%] ·· Benchmarking conda-py3.6-Cython-matplotlib-numexpr-numpy-openpyxl-pytables-pytest-scipy-sqlalchemy-xlrd-xlsxwriter-xlwt
[ 16.67%] ··· Running frame_ctor.FromDicts.time_frame_ctor_list_of_dict                                                        113±0.3ms
[ 33.33%] ··· Running frame_ctor.FromDicts.time_frame_ctor_nested_dict                                                        92.7±0.3ms
[ 50.00%] ··· Running frame_ctor.FromDicts.time_frame_ctor_nested_dict_int64                                                   243±0.5ms
[ 66.67%] ··· Running frame_ctor.FromDicts.time_series_ctor_from_dict                                                        6.17±0.01ms
[ 83.33%] ··· Running frame_ctor.FromDictwithTimestampOffsets.time_frame_ctor                                                2/76 failed
[100.00%] ··· Running frame_ctor.FromSeries.time_frame_from_mi_series                                                          243±0.7μs
```

The supposed offsets benchmark failures do not show up when running asv dev?
```
asv dev -b ^frame_ctor
· Discovering benchmarks
· Running 6 total benchmarks (1 commits * 1 environments * 6 benchmarks)
[  0.00%] ·· Building for existing-py_home_matt_anaconda_envs_pandas_dev_bin_python
[  0.00%] ·· Benchmarking existing-py_home_matt_anaconda_envs_pandas_dev_bin_python
[ 16.67%] ··· Running frame_ctor.FromDicts.time_frame_ctor_list_of_dict                                                            153ms
[ 33.33%] ··· Running frame_ctor.FromDicts.time_frame_ctor_nested_dict                                                             147ms
[ 50.00%] ··· Running frame_ctor.FromDicts.time_frame_ctor_nested_dict_int64                                                       217ms
[ 66.67%] ··· Running frame_ctor.FromDicts.time_series_ctor_from_dict                                                             6.09ms
[ 83.33%] ··· Running frame_ctor.FromDictwithTimestampOffsets.time_frame_ctor                                                         ok
[ 83.33%] ···· 
               ==================== ======== ========
               --                        n_steps     
               -------------------- -----------------
                      offset           1        2    
               ==================== ======== ========
                       Day           96.5ms   96.7ms 
                   BusinessDay       96.7ms   96.5ms 
                       BDay          99.8ms   96.8ms 
                CustomBusinessDay    98.8ms   97.5ms 
                       CDay          96.7ms   95.8ms 
                    CBMonthEnd       96.8ms   97.7ms 
                   CBMonthBegin      97.0ms   98.0ms 
                    MonthBegin       96.4ms   97.6ms 
                   BMonthBegin       98.1ms   96.4ms 
                     MonthEnd        95.8ms   96.6ms 
                    BMonthEnd        96.7ms   96.9ms 
                   SemiMonthEnd      96.2ms   97.3ms 
                  SemiMonthBegin     96.3ms   98.1ms 
                   BusinessHour      96.5ms   97.1ms 
                CustomBusinessHour   97.2ms   97.0ms 
                    YearBegin        33.4ms   17.5ms 
                    BYearBegin       32.3ms   17.6ms 
                     YearEnd         32.2ms   17.3ms 
                     BYearEnd        36.2ms   17.9ms 
                   QuarterBegin      98.0ms   64.9ms 
                  BQuarterBegin      99.5ms   70.6ms 
                    QuarterEnd       101ms    67.9ms 
                   BQuarterEnd       98.3ms   69.0ms 
                 LastWeekOfMonth     97.1ms   102ms  
                       Week          97.5ms   102ms  
                   WeekOfMonth       104ms    102ms  
                      Easter         35.4ms   18.0ms 
                       Hour          102ms    96.3ms 
                      Minute         95.8ms   100ms  
                      Second         95.8ms   97.2ms 
                      Milli          98.7ms   101ms  
                      Micro          94.7ms   93.5ms 
                       Nano          71.8ms   72.3ms 
                    DateOffset       95.9ms   96.1ms 
                     FY5253_1        36.9ms   18.1ms 
                     FY5253_2        35.8ms   18.2ms 
                 FY5253Quarter_1     98.7ms   66.2ms 
                 FY5253Quarter_2     96.3ms   65.4ms 
               ==================== ======== ========

[100.00%] ··· Running frame_ctor.FromSeries.time_frame_from_mi_series                                                              282μs
```
