### PR TITLE
make get_firstbday, get_lastbday nogil

### DIFF
--- a/pandas/tests/tseries/offsets/test_liboffsets.py
+++ b/pandas/tests/tseries/offsets/test_liboffsets.py
@@ -6,7 +6,6 @@ from datetime import datetime
 
 import pytest
 
-from pandas._libs import tslib
 from pandas import Timestamp
 
 import pandas._libs.tslibs.offsets as liboffsets
@@ -15,25 +14,21 @@ import pandas._libs.tslibs.offsets as liboffsets
 def test_get_lastbday():
     dt = datetime(2017, 11, 30)
     assert dt.weekday() == 3  # i.e. this is a business day
-    wkday, days_in_month = tslib.monthrange(dt.year, dt.month)
-    assert liboffsets.get_lastbday(wkday, days_in_month) == 30
+    assert liboffsets.get_lastbday(dt.year, dt.month) == 30
 
     dt = datetime(1993, 10, 31)
     assert dt.weekday() == 6  # i.e. this is not a business day
-    wkday, days_in_month = tslib.monthrange(dt.year, dt.month)
-    assert liboffsets.get_lastbday(wkday, days_in_month) == 29
+    assert liboffsets.get_lastbday(dt.year, dt.month) == 29
 
 
 def test_get_firstbday():
     dt = datetime(2017, 4, 1)
     assert dt.weekday() == 5  # i.e. not a weekday
-    wkday, days_in_month = tslib.monthrange(dt.year, dt.month)
-    assert liboffsets.get_firstbday(wkday, days_in_month) == 3
+    assert liboffsets.get_firstbday(dt.year, dt.month) == 3
 
     dt = datetime(1993, 10, 1)
     assert dt.weekday() == 4  # i.e. a business day
-    wkday, days_in_month = tslib.monthrange(dt.year, dt.month)
-    assert liboffsets.get_firstbday(wkday, days_in_month) == 1
+    assert liboffsets.get_firstbday(dt.year, dt.month) == 1
 
 
 def test_shift_month():


### PR DESCRIPTION
These are only used in `tslibs.offsets` and in tests, _and_ every use is preceeded by a call to `monthrange`.  But because `monthrange` returns a tuple, it cannot be declared `nogil`.  This PR removes the call to `monthrange` in favor of the two separate calls that go into `monthrange` (actually only one is needed for `get_first_bday`).  On the side we get rid of a few unnecessary calls and get to nogil two more cases worth of the apply_index loops.

There are more cases coming up for `shift_months` (i.e. more subclasses getting implementations of `apply_index`) and these will benefit from these changes too.

- [ ] closes #xxxx
- [ ] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
