### PR TITLE
BUG: Fix groupby over a CategoricalIndex in axis=1

### DIFF
--- a/doc/source/whatsnew/v0.21.1.txt
+++ b/doc/source/whatsnew/v0.21.1.txt
@@ -137,6 +137,7 @@ Categorical
 - Error messages in the testing module have been improved when items have different ``CategoricalDtype`` (:issue:`18069`)
 - ``CategoricalIndex`` can now correctly take a ``pd.api.types.CategoricalDtype`` as its dtype (:issue:`18116`)
 - Bug in ``Categorical.unique()`` returning read-only ``codes``  array when all categories were ``NaN`` (:issue:`18051`)
+- Bug in ``DataFrame.groupby(axis=1)`` with a ``CategoricalIndex`` (:issue:`18432`)
 
 String
 ^^^^^^

--- a/pandas/core/groupby.py
+++ b/pandas/core/groupby.py
@@ -2859,9 +2859,11 @@ def _get_grouper(obj, key=None, axis=0, level=None, sort=True,
         else:
             in_axis, name = False, None
 
-        if is_categorical_dtype(gpr) and len(gpr) != len(obj):
-            raise ValueError("Categorical dtype grouper must "
-                             "have len(grouper) == len(data)")
+        if is_categorical_dtype(gpr) and len(gpr) != obj.shape[axis]:
+            raise ValueError(
+                ("Length of grouper ({len_gpr}) and axis ({len_axis})"
+                 " must be same length"
+                 .format(len_gpr=len(gpr), len_axis=obj.shape[axis])))
 
         # create the Grouping
         # allow us to passing the actual Grouping as the gpr

--- a/pandas/tests/groupby/test_grouping.py
+++ b/pandas/tests/groupby/test_grouping.py
@@ -6,7 +6,7 @@ import pytest
 
 from warnings import catch_warnings
 from pandas import (date_range, Timestamp,
-                    Index, MultiIndex, DataFrame, Series)
+                    Index, MultiIndex, DataFrame, Series, CategoricalIndex)
 from pandas.util.testing import (assert_panel_equal, assert_frame_equal,
                                  assert_series_equal, assert_almost_equal)
 from pandas.compat import lrange, long
@@ -250,6 +250,29 @@ class TestGrouping(MixIn):
 
         by_columns.columns = pd.Index(by_columns.columns, dtype=np.int64)
         tm.assert_frame_equal(by_levels, by_columns)
+
+    def test_groupby_categorical_index_and_columns(self):
+        # GH18432
+        columns = ['A', 'B', 'A', 'B']
+        categories = ['B', 'A']
+        data = np.ones((5, 4), int)
+        cat_columns = CategoricalIndex(columns,
+                                       categories=categories,
+                                       ordered=True)
+        df = DataFrame(data=data, columns=cat_columns)
+        result = df.groupby(axis=1, level=0).sum()
+        expected_data = 2 * np.ones((5, 2), int)
+        expected_columns = CategoricalIndex(categories,
+                                            categories=categories,
+                                            ordered=True)
+        expected = DataFrame(data=expected_data, columns=expected_columns)
+        assert_frame_equal(result, expected)
+
+        # test transposed version
+        df = DataFrame(data.T, index=cat_columns)
+        result = df.groupby(axis=0, level=0).sum()
+        expected = DataFrame(data=expected_data.T, index=expected_columns)
+        assert_frame_equal(result, expected)
 
     def test_grouper_getting_correct_binner(self):
 


### PR DESCRIPTION
- [x] closes #18432
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] add whatsnew entry