### PR TITLE
Removed unused funcs from _libs

### DIFF
--- a/pandas/_libs/algos.pyx
+++ b/pandas/_libs/algos.pyx
@@ -212,51 +212,6 @@ cpdef numeric median(numeric[:] arr):
                 kth_smallest(arr, n // 2 - 1)) / 2
 
 
-# -------------- Min, Max subsequence
-
-@cython.boundscheck(False)
-@cython.wraparound(False)
-def max_subseq(ndarray[double_t] arr):
-    cdef:
-        Py_ssize_t i=0, s=0, e=0, T, n
-        double m, S
-
-    n = len(arr)
-
-    if len(arr) == 0:
-        return (-1, -1, None)
-
-    m = arr[0]
-    S = m
-    T = 0
-
-    with nogil:
-        for i in range(1, n):
-            # S = max { S + A[i], A[i] )
-            if (S > 0):
-                S = S + arr[i]
-            else:
-                S = arr[i]
-                T = i
-            if S > m:
-                s = T
-                e = i
-                m = S
-
-    return (s, e, m)
-
-
-@cython.boundscheck(False)
-@cython.wraparound(False)
-def min_subseq(ndarray[double_t] arr):
-    cdef:
-        Py_ssize_t s, e
-        double m
-
-    (s, e, m) = max_subseq(-arr)
-
-    return (s, e, -m)
-
 # ----------------------------------------------------------------------
 # Pairwise correlation/covariance
 

--- a/pandas/_libs/groupby.pyx
+++ b/pandas/_libs/groupby.pyx
@@ -77,57 +77,6 @@ def group_nth_object(ndarray[object, ndim=2] out,
 
 @cython.boundscheck(False)
 @cython.wraparound(False)
-def group_nth_bin_object(ndarray[object, ndim=2] out,
-                         ndarray[int64_t] counts,
-                         ndarray[object, ndim=2] values,
-                         ndarray[int64_t] bins, int64_t rank):
-    """
-    Only aggregates on axis=0
-    """
-    cdef:
-        Py_ssize_t i, j, N, K, ngroups, b
-        object val
-        float64_t count
-        ndarray[object, ndim=2] resx
-        ndarray[float64_t, ndim=2] nobs
-
-    nobs = np.zeros((<object> out).shape, dtype=np.float64)
-    resx = np.empty((<object> out).shape, dtype=object)
-
-    if len(bins) == 0:
-        return
-    if bins[len(bins) - 1] == len(values):
-        ngroups = len(bins)
-    else:
-        ngroups = len(bins) + 1
-
-    N, K = (<object> values).shape
-
-    b = 0
-    for i in range(N):
-        while b < ngroups - 1 and i >= bins[b]:
-            b += 1
-
-        counts[b] += 1
-        for j in range(K):
-            val = values[i, j]
-
-            # not nan
-            if val == val:
-                nobs[b, j] += 1
-                if nobs[b, j] == rank:
-                    resx[b, j] = val
-
-    for i in range(ngroups):
-        for j in range(K):
-            if nobs[i, j] == 0:
-                out[i, j] = nan
-            else:
-                out[i, j] = resx[i, j]
-
-
-@cython.boundscheck(False)
-@cython.wraparound(False)
 def group_last_object(ndarray[object, ndim=2] out,
                       ndarray[int64_t] counts,
                       ndarray[object, ndim=2] values,
@@ -162,56 +111,6 @@ def group_last_object(ndarray[object, ndim=2] out,
                 resx[lab, j] = val
 
     for i in range(len(counts)):
-        for j in range(K):
-            if nobs[i, j] == 0:
-                out[i, j] = nan
-            else:
-                out[i, j] = resx[i, j]
-
-
-@cython.boundscheck(False)
-@cython.wraparound(False)
-def group_last_bin_object(ndarray[object, ndim=2] out,
-                          ndarray[int64_t] counts,
-                          ndarray[object, ndim=2] values,
-                          ndarray[int64_t] bins):
-    """
-    Only aggregates on axis=0
-    """
-    cdef:
-        Py_ssize_t i, j, N, K, ngroups, b
-        object val
-        float64_t count
-        ndarray[object, ndim=2] resx
-        ndarray[float64_t, ndim=2] nobs
-
-    nobs = np.zeros((<object> out).shape, dtype=np.float64)
-    resx = np.empty((<object> out).shape, dtype=object)
-
-    if len(bins) == 0:
-        return
-    if bins[len(bins) - 1] == len(values):
-        ngroups = len(bins)
-    else:
-        ngroups = len(bins) + 1
-
-    N, K = (<object> values).shape
-
-    b = 0
-    for i in range(N):
-        while b < ngroups - 1 and i >= bins[b]:
-            b += 1
-
-        counts[b] += 1
-        for j in range(K):
-            val = values[i, j]
-
-            # not nan
-            if val == val:
-                nobs[b, j] += 1
-                resx[b, j] = val
-
-    for i in range(ngroups):
         for j in range(K):
             if nobs[i, j] == 0:
                 out[i, j] = nan

--- a/pandas/_libs/hashing.pyx
+++ b/pandas/_libs/hashing.pyx
@@ -105,11 +105,6 @@ cdef inline void u32to8_le(uint8_t* p, uint32_t v) nogil:
     p[3] = <uint8_t>(v >> 24)
 
 
-cdef inline void u64to8_le(uint8_t* p, uint64_t v) nogil:
-    u32to8_le(p, <uint32_t>v)
-    u32to8_le(p + 4, <uint32_t>(v >> 32))
-
-
 cdef inline uint64_t u8to64_le(uint8_t* p) nogil:
     return (<uint64_t>p[0] |
             <uint64_t>p[1] << 8 |

--- a/pandas/_libs/join.pyx
+++ b/pandas/_libs/join.pyx
@@ -240,28 +240,4 @@ def ffill_indexer(ndarray[int64_t] indexer):
     return result
 
 
-def ffill_by_group(ndarray[int64_t] indexer, ndarray[int64_t] group_ids,
-                   int64_t max_group):
-    cdef:
-        Py_ssize_t i, n = len(indexer)
-        ndarray[int64_t] result, last_obs
-        int64_t gid, val
-
-    result = np.empty(n, dtype=np.int64)
-
-    last_obs = np.empty(max_group, dtype=np.int64)
-    last_obs.fill(-1)
-
-    for i in range(n):
-        gid = group_ids[i]
-        val = indexer[i]
-        if val == -1:
-            result[i] = last_obs[gid]
-        else:
-            result[i] = val
-            last_obs[gid] = val
-
-    return result
-
-
 include "join_helper.pxi"

--- a/pandas/_libs/src/datetime/np_datetime.c
+++ b/pandas/_libs/src/datetime/np_datetime.c
@@ -24,20 +24,7 @@ This file is derived from NumPy 1.7. See NUMPY_LICENSE.txt
 #include "np_datetime.h"
 
 #if PY_MAJOR_VERSION >= 3
-#define PyIntObject PyLongObject
-#define PyInt_Type PyLong_Type
-#define PyInt_Check(op) PyLong_Check(op)
-#define PyInt_CheckExact(op) PyLong_CheckExact(op)
-#define PyInt_FromString PyLong_FromString
-#define PyInt_FromUnicode PyLong_FromUnicode
-#define PyInt_FromLong PyLong_FromLong
-#define PyInt_FromSize_t PyLong_FromSize_t
-#define PyInt_FromSsize_t PyLong_FromSsize_t
 #define PyInt_AsLong PyLong_AsLong
-#define PyInt_AS_LONG PyLong_AS_LONG
-#define PyInt_AsSsize_t PyLong_AsSsize_t
-#define PyInt_AsUnsignedLongMask PyLong_AsUnsignedLongMask
-#define PyInt_AsUnsignedLongLongMask PyLong_AsUnsignedLongLongMask
 #endif
 
 const pandas_datetimestruct _NS_MIN_DTS = {
@@ -690,44 +677,6 @@ int convert_datetimestruct_to_datetime(pandas_datetime_metadata *meta,
     *out = ret;
 
     return 0;
-}
-
-/*
- * This provides the casting rules for the TIMEDELTA data type units.
- *
- * Notably, there is a barrier between the nonlinear years and
- * months units, and all the other units.
- */
-npy_bool can_cast_timedelta64_units(PANDAS_DATETIMEUNIT src_unit,
-                                    PANDAS_DATETIMEUNIT dst_unit,
-                                    NPY_CASTING casting) {
-    switch (casting) {
-        /* Allow anything with unsafe casting */
-        case NPY_UNSAFE_CASTING:
-            return 1;
-
-        /*
-         * Only enforce the 'date units' vs 'time units' barrier with
-         * 'same_kind' casting.
-         */
-        case NPY_SAME_KIND_CASTING:
-            return (src_unit <= PANDAS_FR_M && dst_unit <= PANDAS_FR_M) ||
-                   (src_unit > PANDAS_FR_M && dst_unit > PANDAS_FR_M);
-
-        /*
-         * Enforce the 'date units' vs 'time units' barrier and that
-         * casting is only allowed towards more precise units with
-         * 'safe' casting.
-         */
-        case NPY_SAFE_CASTING:
-            return (src_unit <= dst_unit) &&
-                   ((src_unit <= PANDAS_FR_M && dst_unit <= PANDAS_FR_M) ||
-                    (src_unit > PANDAS_FR_M && dst_unit > PANDAS_FR_M));
-
-        /* Enforce equality with 'no' or 'equiv' casting */
-        default:
-            return src_unit == dst_unit;
-    }
 }
 
 /*


### PR DESCRIPTION
See coverage report: https://github.com/pandas-dev/pandas/pull/18512#issuecomment-347281660

This just removes a handful of unused functions.  LMK if some should be kept around just-in-case.

Not included in the never-used group but worth mentioning: lib.fast_unique, lib.convert_timestamps, and lib.string_array_replace_from_nan_rep are each called exactly once in io.pytables, not covered in tests (io.pytables looks poorly covered, might have had a bunch of skipTests locally)

- [ ] closes #xxxx
- [ ] tests added / passed
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
