### PR TITLE
Fastpaths for Timestamp properties

### DIFF
--- a/asv_bench/benchmarks/timestamp.py
+++ b/asv_bench/benchmarks/timestamp.py
@@ -1,4 +1,3 @@
-from .pandas_vb_common import *
 from pandas import to_timedelta, Timestamp
 import pytz
 import datetime
@@ -7,61 +6,64 @@ import datetime
 class TimestampProperties(object):
     goal_time = 0.2
 
-    params = [None, pytz.timezone('Europe/Amsterdam')]
-    param_names = ['tz']
+    params = [(None, None),
+              (pytz.timezone('Europe/Amsterdam'), None),
+              (None, 'B'),
+              (pytz.timezone('Europe/Amsterdam'), 'B')]
+    param_names = ['tz', 'freq']
 
-    def setup(self, tz):
-        self.ts = Timestamp('2017-08-25 08:16:14', tzinfo=tz)
+    def setup(self, tz, freq):
+        self.ts = Timestamp('2017-08-25 08:16:14', tzinfo=tz, freq=freq)
 
-    def time_tz(self, tz):
+    def time_tz(self, tz, freq):
         self.ts.tz
 
-    def time_offset(self, tz):
+    def time_offset(self, tz, freq):
         self.ts.offset
 
-    def time_dayofweek(self, tz):
+    def time_dayofweek(self, tz, freq):
         self.ts.dayofweek
 
-    def time_weekday_name(self, tz):
+    def time_weekday_name(self, tz, freq):
         self.ts.weekday_name
 
-    def time_dayofyear(self, tz):
+    def time_dayofyear(self, tz, freq):
         self.ts.dayofyear
 
-    def time_week(self, tz):
+    def time_week(self, tz, freq):
         self.ts.week
 
-    def time_quarter(self, tz):
+    def time_quarter(self, tz, freq):
         self.ts.quarter
 
-    def time_days_in_month(self, tz):
+    def time_days_in_month(self, tz, freq):
         self.ts.days_in_month
 
-    def time_freqstr(self, tz):
+    def time_freqstr(self, tz, freq):
         self.ts.freqstr
 
-    def time_is_month_start(self, tz):
+    def time_is_month_start(self, tz, freq):
         self.ts.is_month_start
 
-    def time_is_month_end(self, tz):
+    def time_is_month_end(self, tz, freq):
         self.ts.is_month_end
 
-    def time_is_quarter_start(self, tz):
+    def time_is_quarter_start(self, tz, freq):
         self.ts.is_quarter_start
 
-    def time_is_quarter_end(self, tz):
+    def time_is_quarter_end(self, tz, freq):
         self.ts.is_quarter_end
 
-    def time_is_year_start(self, tz):
+    def time_is_year_start(self, tz, freq):
         self.ts.is_quarter_end
 
-    def time_is_year_end(self, tz):
+    def time_is_year_end(self, tz, freq):
         self.ts.is_quarter_end
 
-    def time_is_leap_year(self, tz):
+    def time_is_leap_year(self, tz, freq):
         self.ts.is_quarter_end
 
-    def time_microsecond(self, tz):
+    def time_microsecond(self, tz, freq):
         self.ts.microsecond
 
 

--- a/pandas/_libs/tslibs/timestamps.pyx
+++ b/pandas/_libs/tslibs/timestamps.pyx
@@ -736,6 +736,9 @@ class Timestamp(_Timestamp):
 
     @property
     def is_month_end(self):
+        if self.freq is None:
+            # fast-path for non-business frequencies
+            return self.day == self.days_in_month
         return self._get_start_end_field('is_month_end')
 
     @property
@@ -747,6 +750,9 @@ class Timestamp(_Timestamp):
 
     @property
     def is_quarter_end(self):
+        if self.freq is None:
+            # fast-path for non-business frequencies
+            return (self.month % 3) == 0 and self.day == self.days_in_month
         return self._get_start_end_field('is_quarter_end')
 
     @property

--- a/pandas/_libs/tslibs/timestamps.pyx
+++ b/pandas/_libs/tslibs/timestamps.pyx
@@ -304,10 +304,12 @@ cdef class _Timestamp(datetime):
         out = get_date_field(np.array([val], dtype=np.int64), field)
         return int(out[0])
 
-    cpdef _get_start_end_field(self, field):
+    cpdef bint _get_start_end_field(self, str field):
         cdef:
             int64_t val
             dict kwds
+            ndarray out
+            int month_kw
 
         freq = self.freq
         if freq:
@@ -713,7 +715,7 @@ class Timestamp(_Timestamp):
 
     @property
     def quarter(self):
-        return self._get_field('q')
+        return ((self.month - 1) // 3) + 1
 
     @property
     def days_in_month(self):
@@ -727,6 +729,9 @@ class Timestamp(_Timestamp):
 
     @property
     def is_month_start(self):
+        if self.freq is None:
+            # fast-path for non-business frequencies
+            return self.day == 1
         return self._get_start_end_field('is_month_start')
 
     @property
@@ -735,6 +740,9 @@ class Timestamp(_Timestamp):
 
     @property
     def is_quarter_start(self):
+        if self.freq is None:
+            # fast-path for non-business frequencies
+            return self.day == 1 and self.month % 3 == 1
         return self._get_start_end_field('is_quarter_start')
 
     @property
@@ -743,10 +751,16 @@ class Timestamp(_Timestamp):
 
     @property
     def is_year_start(self):
+        if self.freq is None:
+            # fast-path for non-business frequencies
+            return self.day == self.month == 1
         return self._get_start_end_field('is_year_start')
 
     @property
     def is_year_end(self):
+        if self.freq is None:
+            # fast-path for non-business frequencies
+            return self.month == 12 and self.day == 31
         return self._get_start_end_field('is_year_end')
 
     @property

--- a/pandas/tests/scalar/test_timestamp.py
+++ b/pandas/tests/scalar/test_timestamp.py
@@ -47,6 +47,28 @@ class TestTimestampArithmetic(object):
             stamp - offset
 
 
+class TestTimestampProperties(object):
+
+    def test_properties_business(self):
+        ts = Timestamp('2017-10-01', freq='B')
+        control = Timestamp('2017-10-01')
+        assert ts.dayofweek == 6
+        assert not ts.is_month_start    # not a weekday
+        assert not ts.is_quarter_start  # not a weekday
+        # Control case: non-business is month/qtr start
+        assert control.is_month_start
+        assert control.is_quarter_start
+
+        ts = Timestamp('2017-09-30', freq='B')
+        control = Timestamp('2017-09-30')
+        assert ts.dayofweek == 5
+        assert not ts.is_month_end    # not a weekday
+        assert not ts.is_quarter_end  # not a weekday
+        # Control case: non-business is month/qtr start
+        assert control.is_month_end
+        assert control.is_quarter_end
+
+
 class TestTimestamp(object):
 
     def test_constructor(self):


### PR DESCRIPTION
Addresses a bunch of the TimestampProperties regressions in #18532 .  ASV vs 0.21.0

```
asv continuous -f 1.1 -E virtualenv 81372093 HEAD -b TimestampProperties
[...]
       before           after         ratio
     [81372093]       [5fc79fb0]
+     5.73±0.02μs      10.5±0.03μs     1.84  timestamp.TimestampProperties.time_dayofyear(<DstTzInfo 'Europe/Amsterdam' LMT+0:20:00 STD>)
+     5.96±0.04μs      10.9±0.03μs     1.82  timestamp.TimestampProperties.time_is_month_end(<DstTzInfo 'Europe/Amsterdam' LMT+0:20:00 STD>)
+     5.80±0.01μs       10.5±0.1μs     1.82  timestamp.TimestampProperties.time_days_in_month(<DstTzInfo 'Europe/Amsterdam' LMT+0:20:00 STD>)
+     6.18±0.01μs       10.6±0.6μs     1.72  timestamp.TimestampProperties.time_week(<DstTzInfo 'Europe/Amsterdam' LMT+0:20:00 STD>)
-     5.82±0.01μs          337±4ns     0.06  timestamp.TimestampProperties.time_is_leap_year(<DstTzInfo 'Europe/Amsterdam' LMT+0:20:00 STD>)
-     5.99±0.09μs         326±10ns     0.05  timestamp.TimestampProperties.time_quarter(None)
-     5.99±0.01μs        324±0.6ns     0.05  timestamp.TimestampProperties.time_is_year_end(None)
-     5.90±0.01μs        319±0.5ns     0.05  timestamp.TimestampProperties.time_is_month_start(None)
-     6.02±0.02μs          321±1ns     0.05  timestamp.TimestampProperties.time_is_leap_year(None)
-     6.08±0.05μs          321±2ns     0.05  timestamp.TimestampProperties.time_is_year_end(<DstTzInfo 'Europe/Amsterdam' LMT+0:20:00 STD>)
-     6.06±0.01μs        316±0.8ns     0.05  timestamp.TimestampProperties.time_is_month_start(<DstTzInfo 'Europe/Amsterdam' LMT+0:20:00 STD>)
-     6.19±0.09μs        319±0.7ns     0.05  timestamp.TimestampProperties.time_is_quarter_start(None)
-      6.09±0.2μs        310±0.6ns     0.05  timestamp.TimestampProperties.time_quarter(<DstTzInfo 'Europe/Amsterdam' LMT+0:20:00 STD>)
-      6.38±0.2μs        323±0.7ns     0.05  timestamp.TimestampProperties.time_is_year_start(None)
-      6.90±0.4μs          337±4ns     0.05  timestamp.TimestampProperties.time_is_quarter_end(None)
-      6.73±0.1μs          325±2ns     0.05  timestamp.TimestampProperties.time_is_year_start(<DstTzInfo 'Europe/Amsterdam' LMT+0:20:00 STD>)
-      6.75±0.2μs          321±1ns     0.05  timestamp.TimestampProperties.time_is_quarter_start(<DstTzInfo 'Europe/Amsterdam' LMT+0:20:00 STD>)
-      7.14±0.1μs        325±0.4ns     0.05  timestamp.TimestampProperties.time_is_quarter_end(<DstTzInfo 'Europe/Amsterdam' LMT+0:20:00 STD>)
```

Timestamps with freqs are still SOL, but that's a relatively rare case.