### PR TITLE
Remove arg that is only ever used as NPY_UNSAFE_CASTING

### DIFF
--- a/pandas/_libs/src/datetime.pxd
+++ b/pandas/_libs/src/datetime.pxd
@@ -7,13 +7,6 @@ from cpython cimport PyUnicode_Check, PyUnicode_AsASCIIString
 cdef extern from "numpy/ndarrayobject.h":
     ctypedef int64_t npy_datetime
 
-    ctypedef enum NPY_CASTING:
-        NPY_NO_CASTING
-        NPY_EQUIV_CASTING
-        NPY_SAFE_CASTING
-        NPY_SAME_KIND_CASTING
-        NPY_UNSAFE_CASTING
-
 cdef extern from "numpy/npy_common.h":
     ctypedef unsigned char npy_bool
 
@@ -45,7 +38,6 @@ cdef extern from "datetime/np_datetime.h":
 
 cdef extern from "datetime/np_datetime_strings.h":
     int parse_iso_8601_datetime(char *str, int len, PANDAS_DATETIMEUNIT unit,
-                                NPY_CASTING casting,
                                 pandas_datetimestruct *out,
                                 int *out_local, int *out_tzoffset,
                                 PANDAS_DATETIMEUNIT *out_bestunit,
@@ -75,7 +67,6 @@ cdef inline int _cstring_to_dts(char *val, int length,
         int result
 
     result = parse_iso_8601_datetime(val, length, PANDAS_FR_ns,
-                                     NPY_UNSAFE_CASTING,
                                      dts, out_local, out_tzoffset,
                                      &out_bestunit, &special)
     return result

--- a/pandas/_libs/src/datetime/np_datetime.c
+++ b/pandas/_libs/src/datetime/np_datetime.c
@@ -680,44 +680,6 @@ int convert_datetimestruct_to_datetime(pandas_datetime_metadata *meta,
 }
 
 /*
- * This provides the casting rules for the DATETIME data type units.
- *
- * Notably, there is a barrier between 'date units' and 'time units'
- * for all but 'unsafe' casting.
- */
-npy_bool can_cast_datetime64_units(PANDAS_DATETIMEUNIT src_unit,
-                                   PANDAS_DATETIMEUNIT dst_unit,
-                                   NPY_CASTING casting) {
-    switch (casting) {
-        /* Allow anything with unsafe casting */
-        case NPY_UNSAFE_CASTING:
-            return 1;
-
-        /*
-         * Only enforce the 'date units' vs 'time units' barrier with
-         * 'same_kind' casting.
-         */
-        case NPY_SAME_KIND_CASTING:
-            return (src_unit <= PANDAS_FR_D && dst_unit <= PANDAS_FR_D) ||
-                   (src_unit > PANDAS_FR_D && dst_unit > PANDAS_FR_D);
-
-        /*
-         * Enforce the 'date units' vs 'time units' barrier and that
-         * casting is only allowed towards more precise units with
-         * 'safe' casting.
-         */
-        case NPY_SAFE_CASTING:
-            return (src_unit <= dst_unit) &&
-                   ((src_unit <= PANDAS_FR_D && dst_unit <= PANDAS_FR_D) ||
-                    (src_unit > PANDAS_FR_D && dst_unit > PANDAS_FR_D));
-
-        /* Enforce equality with 'no' or 'equiv' casting */
-        default:
-            return src_unit == dst_unit;
-    }
-}
-
-/*
  * Converts a datetime based on the given metadata into a datetimestruct
  */
 int convert_datetime_to_datetimestruct(pandas_datetime_metadata *meta,

--- a/pandas/_libs/src/datetime/np_datetime.h
+++ b/pandas/_libs/src/datetime/np_datetime.h
@@ -125,17 +125,6 @@ int cmp_pandas_datetimestruct(const pandas_datetimestruct *a,
 void
 add_minutes_to_datetimestruct(pandas_datetimestruct *dts, int minutes);
 
-/*
- * This provides the casting rules for the TIMEDELTA data type units.
- *
- * Notably, there is a barrier between the nonlinear years and
- * months units, and all the other units.
- */
-npy_bool
-can_cast_datetime64_units(PANDAS_DATETIMEUNIT src_unit,
-                          PANDAS_DATETIMEUNIT dst_unit,
-                          NPY_CASTING casting);
-
 
 int
 convert_datetime_to_datetimestruct(pandas_datetime_metadata *meta,

--- a/pandas/_libs/src/datetime/np_datetime_strings.h
+++ b/pandas/_libs/src/datetime/np_datetime_strings.h
@@ -40,8 +40,6 @@ This file implements string parsing and creation for NumPy datetime.
  * 'str' must be a NULL-terminated string, and 'len' must be its length.
  * 'unit' should contain -1 if the unit is unknown, or the unit
  *      which will be used if it is.
- * 'casting' controls how the detected unit from the string is allowed
- *           to be cast to the 'unit' parameter.
  *
  * 'out' gets filled with the parsed date-time.
  * 'out_local' gets whether returned value contains timezone. 0 for UTC, 1 for local time.
@@ -62,7 +60,6 @@ This file implements string parsing and creation for NumPy datetime.
 int
 parse_iso_8601_datetime(char *str, int len,
                     PANDAS_DATETIMEUNIT unit,
-                    NPY_CASTING casting,
                     pandas_datetimestruct *out,
                     int *out_local,
                     int *out_tzoffset,
@@ -90,17 +87,11 @@ get_datetime_iso_8601_strlen(int local, PANDAS_DATETIMEUNIT base);
  *  set to a value other than -1. This is a manual override for
  *  the local time zone to use, as an offset in minutes.
  *
- *  'casting' controls whether data loss is allowed by truncating
- *  the data to a coarser unit. This interacts with 'local', slightly,
- *  in order to form a date unit string as a local time, the casting
- *  must be unsafe.
- *
  *  Returns 0 on success, -1 on failure (for example if the output
  *  string was too short).
  */
 int
 make_iso_8601_datetime(pandas_datetimestruct *dts, char *outstr, int outlen,
-                    int local, PANDAS_DATETIMEUNIT base, int tzoffset,
-                    NPY_CASTING casting);
+                    int local, PANDAS_DATETIMEUNIT base, int tzoffset);
 
 #endif  // PANDAS__LIBS_SRC_DATETIME_NP_DATETIME_STRINGS_H_

--- a/pandas/_libs/src/ujson/python/objToJSON.c
+++ b/pandas/_libs/src/ujson/python/objToJSON.c
@@ -456,7 +456,7 @@ static void *PandasDateTimeStructToJSON(pandas_datetimestruct *dts,
         }
 
         if (!make_iso_8601_datetime(dts, GET_TC(tc)->cStr, *_outLen, 0, base,
-                                    -1, NPY_UNSAFE_CASTING)) {
+                                    -1)) {
             PRINTMARK();
             *_outLen = strlen(GET_TC(tc)->cStr);
             return GET_TC(tc)->cStr;


### PR DESCRIPTION
Several functions from src/datetime are only ever called with the casting rule NPY_UNSAFE_CASTING.  By getting rid of that dummy argument, the remaining code gets simplified quite a bit.

This PR removes that argument, then removes code that this renders unreachable or unused.  It also removes several commented-out functions.

There are a couple of other never-used args; taking these one at a time.
