### PR TITLE
Update pandas.read_gbq docs to point to pandas-gbq

### DIFF
--- a/doc/source/install.rst
+++ b/doc/source/install.rst
@@ -259,7 +259,8 @@ Optional Dependencies
   `xsel <http://www.vergenet.net/~conrad/software/xsel/>`__, or
   `xclip <https://github.com/astrand/xclip/>`__: necessary to use
   :func:`~pandas.read_clipboard`. Most package managers on Linux distributions will have ``xclip`` and/or ``xsel`` immediately available for installation.
-* For Google BigQuery I/O - see `here <https://pandas-gbq.readthedocs.io/en/latest/install.html#dependencies>`__
+* `pandas-gbq <https://pandas-gbq.readthedocs.io/en/latest/install.html#dependencies>`__: for Google BigQuery I/O.
+
 
 * `Backports.lzma <https://pypi.python.org/pypi/backports.lzma/>`__: Only for Python 2, for writing to and/or reading from an xz compressed DataFrame in CSV; Python 3 support is built into the standard library.
 * One of the following combinations of libraries is needed to use the

--- a/pandas/io/gbq.py
+++ b/pandas/io/gbq.py
@@ -29,9 +29,11 @@ def read_gbq(query, project_id=None, index_col=None, col_order=None,
     The main method a user calls to execute a Query in Google BigQuery
     and read results into a pandas DataFrame.
 
-    Google BigQuery API Client Library v2 for Python is used.
-    Documentation is available `here
-    <https://developers.google.com/api-client-library/python/apis/bigquery/v2>`__
+    This function requires the `pandas-gbq package
+    <https://pandas-gbq.readthedocs.io>`__ which uses the `Google Cloud
+    BigQuery Client Library for Python
+    <https://googlecloudplatform.github.io/google-cloud-python/latest/bigquery/usage.html>`__
+    as of version 0.3.0 of the ``pandas-gbq`` library.
 
     Authentication to the Google BigQuery service is via OAuth 2.0.
 
@@ -70,7 +72,7 @@ def read_gbq(query, project_id=None, index_col=None, col_order=None,
 
     dialect : {'legacy', 'standard'}, default 'legacy'
         'legacy' : Use BigQuery's legacy SQL dialect.
-        'standard' : Use BigQuery's standard SQL (beta), which is
+        'standard' : Use BigQuery's standard SQL, which is
         compliant with the SQL 2011 standard. For more information
         see `BigQuery SQL Reference
         <https://cloud.google.com/bigquery/sql-reference/>`__

--- a/pandas/io/gbq.py
+++ b/pandas/io/gbq.py
@@ -30,10 +30,7 @@ def read_gbq(query, project_id=None, index_col=None, col_order=None,
     and read results into a pandas DataFrame.
 
     This function requires the `pandas-gbq package
-    <https://pandas-gbq.readthedocs.io>`__ which uses the `Google Cloud
-    BigQuery Client Library for Python
-    <https://googlecloudplatform.github.io/google-cloud-python/latest/bigquery/usage.html>`__
-    as of version 0.3.0 of the ``pandas-gbq`` library.
+    <https://pandas-gbq.readthedocs.io>`__.
 
     Authentication to the Google BigQuery service is via OAuth 2.0.
 


### PR DESCRIPTION
The `pandas-gbq` package must be installed to use `pandas.read_gbq`.
Also, with soon-to-be-release version 0.3.0 of `pandas-gbq` the Google
Cloud client library is used instead of the Google API library.

Also, standard SQL is no longer beta. In fact it is highly recommended
over using legacy SQL.

- `N/A` - closes #xxxx
- `N/A` (docs change only) - tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- `N/A` (docs change only) - whatsnew entry
