### PR TITLE
ENH: Support TZ Aware IntervalIndex

### DIFF
--- a/doc/source/whatsnew/v0.22.0.txt
+++ b/doc/source/whatsnew/v0.22.0.txt
@@ -132,6 +132,7 @@ Other Enhancements
 - :func:`pandas.read_clipboard` updated to use qtpy, falling back to PyQt5 and then PyQt4, adding compatibility with Python3 and multiple python-qt bindings (:issue:`17722`)
 - Improved wording of ``ValueError`` raised in :func:`read_csv` when the ``usecols`` argument cannot match all columns. (:issue:`17301`)
 - :func:`DataFrame.corrwith` now silently drops non-numeric columns when passed a Series. Before, an exception was raised (:issue:`18570`).
+- :class:`IntervalIndex` now supports time zone aware ``Interval`` objects (:issue:`18537`, :issue:`18538`)
 
 
 .. _whatsnew_0220.api_breaking:

--- a/pandas/_libs/interval.pyx
+++ b/pandas/_libs/interval.pyx
@@ -6,6 +6,7 @@ cimport cython
 import cython
 from numpy cimport ndarray
 from tslib import Timestamp
+from tslibs.timezones cimport get_timezone
 
 from cpython.object cimport (Py_EQ, Py_NE, Py_GT, Py_LT, Py_GE, Py_LE,
                              PyObject_RichCompare)
@@ -119,6 +120,13 @@ cdef class Interval(IntervalMixin):
             raise ValueError(msg)
         if not left <= right:
             raise ValueError('left side of interval must be <= right side')
+        if (isinstance(left, Timestamp) and
+                get_timezone(left.tzinfo) != get_timezone(right.tzinfo)):
+            # GH 18538
+            msg = ("left and right must have the same time zone, got "
+                   "'{left_tz}' and '{right_tz}'")
+            raise ValueError(msg.format(left_tz=left.tzinfo,
+                                        right_tz=right.tzinfo))
         self.left = left
         self.right = right
         self.closed = closed

--- a/pandas/core/indexes/interval.py
+++ b/pandas/core/indexes/interval.py
@@ -29,7 +29,7 @@ from pandas._libs.interval import (
     Interval, IntervalMixin, IntervalTree,
     intervals_to_interval_bounds)
 
-from pandas.core.indexes.datetimes import DatetimeIndex, date_range
+from pandas.core.indexes.datetimes import date_range
 from pandas.core.indexes.timedeltas import timedelta_range
 from pandas.core.indexes.multi import MultiIndex
 from pandas.compat.numpy import function as nv
@@ -239,7 +239,8 @@ class IntervalIndex(IntervalMixin, Index):
         elif isinstance(left, ABCPeriodIndex):
             msg = 'Period dtypes are not supported, use a PeriodIndex instead'
             raise ValueError(msg)
-        elif isinstance(left, ABCDatetimeIndex) and left.tz != right.tz:
+        elif (isinstance(left, ABCDatetimeIndex) and
+                str(left.tz) != str(right.tz)):
             msg = ("left and right must have the same time zone, got "
                    "'{left_tz}' and '{right_tz}'")
             raise ValueError(msg.format(left_tz=left.tz, right_tz=right.tz))
@@ -663,7 +664,6 @@ class IntervalIndex(IntervalMixin, Index):
         except TypeError:
             # datetime safe version
             tz = self.right.tz
-            freq = self.right.freq
             delta = self.right.values - self.left.values
 
             # handle tz aware
@@ -673,7 +673,7 @@ class IntervalIndex(IntervalMixin, Index):
             else:
                 data = self.left + 0.5 * delta
 
-            return DatetimeIndex(data, freq=freq, tz=tz)
+            return data
 
     @cache_readonly
     def is_monotonic(self):

--- a/pandas/core/indexes/interval.py
+++ b/pandas/core/indexes/interval.py
@@ -3,13 +3,14 @@
 import numpy as np
 
 from pandas.core.dtypes.missing import notna, isna
-from pandas.core.dtypes.generic import ABCPeriodIndex
+from pandas.core.dtypes.generic import ABCDatetimeIndex, ABCPeriodIndex
 from pandas.core.dtypes.dtypes import IntervalDtype
 from pandas.core.dtypes.cast import maybe_convert_platform
 from pandas.core.dtypes.common import (
     _ensure_platform_int,
     is_list_like,
     is_datetime_or_timedelta_dtype,
+    is_datetime64tz_dtype,
     is_integer_dtype,
     is_object_dtype,
     is_categorical_dtype,
@@ -28,7 +29,7 @@ from pandas._libs.interval import (
     Interval, IntervalMixin, IntervalTree,
     intervals_to_interval_bounds)
 
-from pandas.core.indexes.datetimes import date_range
+from pandas.core.indexes.datetimes import DatetimeIndex, date_range
 from pandas.core.indexes.timedeltas import timedelta_range
 from pandas.core.indexes.multi import MultiIndex
 from pandas.compat.numpy import function as nv
@@ -54,7 +55,7 @@ def _get_next_label(label):
     dtype = getattr(label, 'dtype', type(label))
     if isinstance(label, (Timestamp, Timedelta)):
         dtype = 'datetime64'
-    if is_datetime_or_timedelta_dtype(dtype):
+    if is_datetime_or_timedelta_dtype(dtype) or is_datetime64tz_dtype(dtype):
         return label + np.timedelta64(1, 'ns')
     elif is_integer_dtype(dtype):
         return label + 1
@@ -69,7 +70,7 @@ def _get_prev_label(label):
     dtype = getattr(label, 'dtype', type(label))
     if isinstance(label, (Timestamp, Timedelta)):
         dtype = 'datetime64'
-    if is_datetime_or_timedelta_dtype(dtype):
+    if is_datetime_or_timedelta_dtype(dtype) or is_datetime64tz_dtype(dtype):
         return label - np.timedelta64(1, 'ns')
     elif is_integer_dtype(dtype):
         return label - 1
@@ -227,17 +228,21 @@ class IntervalIndex(IntervalMixin, Index):
         # coerce dtypes to match if needed
         if is_float_dtype(left) and is_integer_dtype(right):
             right = right.astype(left.dtype)
-        if is_float_dtype(right) and is_integer_dtype(left):
+        elif is_float_dtype(right) and is_integer_dtype(left):
             left = left.astype(right.dtype)
 
         if type(left) != type(right):
-            raise ValueError("must not have differing left [{left}] "
-                             "and right [{right}] types"
-                             .format(left=type(left), right=type(right)))
-
-        if isinstance(left, ABCPeriodIndex):
-            raise ValueError("Period dtypes are not supported, "
-                             "use a PeriodIndex instead")
+            msg = ('must not have differing left [{ltype}] and right '
+                   '[{rtype}] types')
+            raise ValueError(msg.format(ltype=type(left).__name__,
+                                        rtype=type(right).__name__))
+        elif isinstance(left, ABCPeriodIndex):
+            msg = 'Period dtypes are not supported, use a PeriodIndex instead'
+            raise ValueError(msg)
+        elif isinstance(left, ABCDatetimeIndex) and left.tz != right.tz:
+            msg = ("left and right must have the same time zone, got "
+                   "'{left_tz}' and '{right_tz}'")
+            raise ValueError(msg.format(left_tz=left.tz, right_tz=right.tz))
 
         result._left = left
         result._right = right
@@ -657,8 +662,18 @@ class IntervalIndex(IntervalMixin, Index):
             return Index(0.5 * (self.left.values + self.right.values))
         except TypeError:
             # datetime safe version
+            tz = self.right.tz
+            freq = self.right.freq
             delta = self.right.values - self.left.values
-            return Index(self.left.values + 0.5 * delta)
+
+            # handle tz aware
+            if tz:
+                data = self.left.tz_localize(None) + 0.5 * delta
+                data = data.tz_localize(tz)
+            else:
+                data = self.left + 0.5 * delta
+
+            return DatetimeIndex(data, freq=freq, tz=tz)
 
     @cache_readonly
     def is_monotonic(self):

--- a/pandas/core/indexes/interval.py
+++ b/pandas/core/indexes/interval.py
@@ -663,17 +663,8 @@ class IntervalIndex(IntervalMixin, Index):
             return Index(0.5 * (self.left.values + self.right.values))
         except TypeError:
             # datetime safe version
-            tz = self.right.tz
-            delta = self.right.values - self.left.values
-
-            # handle tz aware
-            if tz:
-                data = self.left.tz_localize(None) + 0.5 * delta
-                data = data.tz_localize(tz)
-            else:
-                data = self.left + 0.5 * delta
-
-            return data
+            delta = self.right - self.left
+            return self.left + 0.5 * delta
 
     @cache_readonly
     def is_monotonic(self):


### PR DESCRIPTION
- [X] closes #18537
- [X] closes #18538
- [X] tests added / passed
- [X] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [X] whatsnew entry

Updates to `Interval`:
- Disallowed `Interval` objects with mixed time zones
- Minor docstring updates

Updates to `IntervalIndex`:
- Disallowed `IntervalIndex` with mixed time zones
- Fixed `IntervalIndex.mid` for tz aware
- Fixed `_get_next_label` and `_get_previous_label` for tz aware
   - cascades to other methods
- Cleaned up error message for mixed `left`/`right` types
