### PR TITLE
remove unused args etal from np_datetime.c

### DIFF
--- a/pandas/_libs/src/datetime/np_datetime.c
+++ b/pandas/_libs/src/datetime/np_datetime.c
@@ -318,26 +318,19 @@ int cmp_pandas_datetimestruct(const pandas_datetimestruct *a,
 /*
  *
  * Tests for and converts a Python datetime.datetime or datetime.date
- * object into a NumPy pandas_datetimestruct.
+ * object into a NumPy pandas_datetimestruct.  Uses tzinfo (if present)
+ * to convert to UTC time.
  *
  * While the C API has PyDate_* and PyDateTime_* functions, the following
  * implementation just asks for attributes, and thus supports
  * datetime duck typing. The tzinfo time zone conversion would require
  * this style of access anyway.
  *
- * 'out_bestunit' gives a suggested unit based on whether the object
- *      was a datetime.date or datetime.datetime object.
- *
- * If 'apply_tzinfo' is 1, this function uses the tzinfo to convert
- * to UTC time, otherwise it returns the struct with the local time.
- *
  * Returns -1 on error, 0 on success, and 1 (with no error set)
  * if obj doesn't have the neeeded date or datetime attributes.
  */
 int convert_pydatetime_to_datetimestruct(PyObject *obj,
-                                         pandas_datetimestruct *out,
-                                         PANDAS_DATETIMEUNIT *out_bestunit,
-                                         int apply_tzinfo) {
+                                         pandas_datetimestruct *out) {
     PyObject *tmp;
     int isleap;
 
@@ -404,10 +397,6 @@ int convert_pydatetime_to_datetimestruct(PyObject *obj,
         !PyObject_HasAttrString(obj, "minute") ||
         !PyObject_HasAttrString(obj, "second") ||
         !PyObject_HasAttrString(obj, "microsecond")) {
-        /* The best unit for date is 'D' */
-        if (out_bestunit != NULL) {
-            *out_bestunit = PANDAS_FR_D;
-        }
         return 0;
     }
 
@@ -465,7 +454,7 @@ int convert_pydatetime_to_datetimestruct(PyObject *obj,
     }
 
     /* Apply the time zone offset if it exists */
-    if (apply_tzinfo && PyObject_HasAttrString(obj, "tzinfo")) {
+    if (PyObject_HasAttrString(obj, "tzinfo")) {
         tmp = PyObject_GetAttrString(obj, "tzinfo");
         if (tmp == NULL) {
             return -1;
@@ -506,11 +495,6 @@ int convert_pydatetime_to_datetimestruct(PyObject *obj,
         }
     }
 
-    /* The resolution of Python's datetime is 'us' */
-    if (out_bestunit != NULL) {
-        *out_bestunit = PANDAS_FR_us;
-    }
-
     return 0;
 
 invalid_date:
@@ -529,51 +513,34 @@ invalid_time:
 
 npy_datetime pandas_datetimestruct_to_datetime(PANDAS_DATETIMEUNIT fr,
                                                pandas_datetimestruct *d) {
-    pandas_datetime_metadata meta;
     npy_datetime result = PANDAS_DATETIME_NAT;
 
-    meta.base = fr;
-    meta.num = 1;
-
-    convert_datetimestruct_to_datetime(&meta, d, &result);
+    convert_datetimestruct_to_datetime(fr, d, &result);
     return result;
 }
 
 void pandas_datetime_to_datetimestruct(npy_datetime val, PANDAS_DATETIMEUNIT fr,
                                        pandas_datetimestruct *result) {
-    pandas_datetime_metadata meta;
-
-    meta.base = fr;
-    meta.num = 1;
-
-    convert_datetime_to_datetimestruct(&meta, val, result);
+    convert_datetime_to_datetimestruct(fr, val, result);
 }
 
 void pandas_timedelta_to_timedeltastruct(npy_timedelta val,
                                          PANDAS_DATETIMEUNIT fr,
                                          pandas_timedeltastruct *result) {
-  pandas_datetime_metadata meta;
-
-  meta.base = fr;
-  meta.num = 1;
-
-  convert_timedelta_to_timedeltastruct(&meta, val, result);
+  convert_timedelta_to_timedeltastruct(fr, val, result);
 }
 
 
 /*
  * Converts a datetime from a datetimestruct to a datetime based
- * on some metadata. The date is assumed to be valid.
- *
- * TODO: If meta->num is really big, there could be overflow
+ * on a metadata unit. The date is assumed to be valid.
  *
  * Returns 0 on success, -1 on failure.
  */
-int convert_datetimestruct_to_datetime(pandas_datetime_metadata *meta,
+int convert_datetimestruct_to_datetime(PANDAS_DATETIMEUNIT base,
                                        const pandas_datetimestruct *dts,
                                        npy_datetime *out) {
     npy_datetime ret;
-    PANDAS_DATETIMEUNIT base = meta->base;
 
     if (base == PANDAS_FR_Y) {
         /* Truncate to the year */
@@ -665,15 +632,6 @@ int convert_datetimestruct_to_datetime(pandas_datetime_metadata *meta,
         }
     }
 
-    /* Divide by the multiplier */
-    if (meta->num > 1) {
-        if (ret >= 0) {
-            ret /= meta->num;
-        } else {
-            ret = (ret - meta->num + 1) / meta->num;
-        }
-    }
-
     *out = ret;
 
     return 0;
@@ -682,7 +640,7 @@ int convert_datetimestruct_to_datetime(pandas_datetime_metadata *meta,
 /*
  * Converts a datetime based on the given metadata into a datetimestruct
  */
-int convert_datetime_to_datetimestruct(pandas_datetime_metadata *meta,
+int convert_datetime_to_datetimestruct(PANDAS_DATETIMEUNIT base,
                                        npy_datetime dt,
                                        pandas_datetimestruct *out) {
     npy_int64 perday;
@@ -693,14 +651,11 @@ int convert_datetime_to_datetimestruct(pandas_datetime_metadata *meta,
     out->month = 1;
     out->day = 1;
 
-    /* TODO: Change to a mechanism that avoids the potential overflow */
-    dt *= meta->num;
-
     /*
      * Note that care must be taken with the / and % operators
      * for negative values.
      */
-    switch (meta->base) {
+    switch (base) {
         case PANDAS_FR_Y:
             out->year = 1970 + dt;
             break;
@@ -902,11 +857,11 @@ int convert_datetime_to_datetimestruct(pandas_datetime_metadata *meta,
 
 /*
  * Converts a timedelta from a timedeltastruct to a timedelta based
- * on some metadata. The timedelta is assumed to be valid.
+ * on a metadata unit. The timedelta is assumed to be valid.
  *
  * Returns 0 on success, -1 on failure.
  */
-int convert_timedelta_to_timedeltastruct(pandas_timedelta_metadata *meta,
+int convert_timedelta_to_timedeltastruct(PANDAS_DATETIMEUNIT base,
                                          npy_timedelta td,
                                          pandas_timedeltastruct *out) {
     npy_int64 frac;
@@ -918,7 +873,7 @@ int convert_timedelta_to_timedeltastruct(pandas_timedelta_metadata *meta,
     /* Initialize the output to all zeros */
     memset(out, 0, sizeof(pandas_timedeltastruct));
 
-    switch (meta->base) {
+    switch (base) {
         case PANDAS_FR_ns:
 
         // put frac in seconds

--- a/pandas/_libs/src/datetime/np_datetime.h
+++ b/pandas/_libs/src/datetime/np_datetime.h
@@ -40,8 +40,6 @@ typedef enum {
 
 #define PANDAS_DATETIME_NUMUNITS 13
 
-#define PANDAS_DATETIME_MAX_ISO8601_STRLEN (21+3*5+1+3*6+6+1)
-
 #define PANDAS_DATETIME_NAT NPY_MIN_INT64
 
 typedef struct {
@@ -54,13 +52,6 @@ typedef struct {
         npy_int32 hrs, min, sec, ms, us, ns, seconds, microseconds, nanoseconds;
 } pandas_timedeltastruct;
 
-typedef struct {
-    PANDAS_DATETIMEUNIT base;
-    int num;
-} pandas_datetime_metadata;
-
-typedef pandas_datetime_metadata pandas_timedelta_metadata;
-
 extern const pandas_datetimestruct _NS_MIN_DTS;
 extern const pandas_datetimestruct _NS_MAX_DTS;
 
@@ -68,9 +59,7 @@ extern const pandas_datetimestruct _NS_MAX_DTS;
 // ----------------------------------------------------------------------------
 
 int convert_pydatetime_to_datetimestruct(PyObject *obj,
-                                         pandas_datetimestruct *out,
-                                         PANDAS_DATETIMEUNIT *out_bestunit,
-                                         int apply_tzinfo);
+                                         pandas_datetimestruct *out);
 
 npy_datetime pandas_datetimestruct_to_datetime(PANDAS_DATETIMEUNIT fr,
                                                pandas_datetimestruct *d);
@@ -90,19 +79,6 @@ extern const int days_per_month_table[2][12];
 // ----------------------------------------------------------------------------
 
 int is_leapyear(npy_int64 year);
-
-/*
- * Converts a datetime from a datetimestruct to a datetime based
- * on some metadata. The date is assumed to be valid.
- *
- * TODO: If meta->num is really big, there could be overflow
- *
- * Returns 0 on success, -1 on failure.
- */
-int
-convert_datetimestruct_to_datetime(pandas_datetime_metadata *meta,
-                                   const pandas_datetimestruct *dts,
-                                   npy_datetime *out);
 
 /*
  * Calculates the days offset from the 1970 epoch.
@@ -127,14 +103,8 @@ add_minutes_to_datetimestruct(pandas_datetimestruct *dts, int minutes);
 
 
 int
-convert_datetime_to_datetimestruct(pandas_datetime_metadata *meta,
+convert_datetime_to_datetimestruct(PANDAS_DATETIMEUNIT base,
                                    npy_datetime dt,
                                    pandas_datetimestruct *out);
-
-int
-convert_timedelta_to_timedeltastruct(pandas_timedelta_metadata *meta,
-                                     npy_timedelta td,
-                                     pandas_timedeltastruct *out);
-
 
 #endif  // PANDAS__LIBS_SRC_DATETIME_NP_DATETIME_H_

--- a/pandas/_libs/src/datetime/np_datetime_strings.c
+++ b/pandas/_libs/src/datetime/np_datetime_strings.c
@@ -279,13 +279,8 @@ int parse_iso_8601_datetime(char *str, int len, PANDAS_DATETIMEUNIT unit,
     if (len == 3 && tolower(str[0]) == 'n' && tolower(str[1]) == 'o' &&
         tolower(str[2]) == 'w') {
         NPY_TIME_T rawtime = 0;
-        pandas_datetime_metadata meta;
 
         time(&rawtime);
-
-        /* Set up a dummy metadata for the conversion */
-        meta.base = PANDAS_FR_s;
-        meta.num = 1;
 
         bestunit = PANDAS_FR_s;
 
@@ -304,7 +299,7 @@ int parse_iso_8601_datetime(char *str, int len, PANDAS_DATETIMEUNIT unit,
             *out_special = 1;
         }
 
-        return convert_datetime_to_datetimestruct(&meta, rawtime, out);
+        return convert_datetime_to_datetimestruct(PANDAS_FR_s, rawtime, out);
     }
 
     /* Anything else isn't a special value */

--- a/pandas/_libs/src/ujson/python/objToJSON.c
+++ b/pandas/_libs/src/ujson/python/objToJSON.c
@@ -493,7 +493,7 @@ static void *PyDateTimeToJSON(JSOBJ _obj, JSONTypeContext *tc, void *outValue,
 
     PRINTMARK();
 
-    if (!convert_pydatetime_to_datetimestruct(obj, &dts, NULL, 1)) {
+    if (!convert_pydatetime_to_datetimestruct(obj, &dts)) {
         PRINTMARK();
         return PandasDateTimeStructToJSON(&dts, tc, outValue, _outLen);
     } else {


### PR DESCRIPTION
What #18565 does for np_datetime_strings.c, this does for np_datetime.c

Getting rid of `meta` also gets rid of a potential problem noted in a comment that `meta->num` could potentially cause an overflow.  Since `meta->num` is 1 in all pandas usages, that pitfall doesn't apply.