### PR TITLE
DEPR: deprecate .asobject property

### DIFF
--- a/asv_bench/benchmarks/index_object.py
+++ b/asv_bench/benchmarks/index_object.py
@@ -12,7 +12,7 @@ class SetOperations(object):
         if (self.rng.dtype == object):
             self.idx_rng = self.rng.view(Index)
         else:
-            self.idx_rng = self.rng.asobject
+            self.idx_rng = self.rng.astype(object)
         self.idx_rng2 = self.idx_rng[:(-1)]
 
         # other datetime

--- a/doc/source/whatsnew/v0.22.0.txt
+++ b/doc/source/whatsnew/v0.22.0.txt
@@ -124,8 +124,7 @@ Deprecations
 
 - ``Series.from_array`` and ``SparseSeries.from_array`` are deprecated. Use the normal constructor ``Series(..)`` and ``SparseSeries(..)`` instead (:issue:`18213`).
 - ``DataFrame.as_matrix`` is deprecated. Use ``DataFrame.values`` instead (:issue:`18458`).
-- ``DatetimeIndex.asobject``, ``PeriodIndex.asobject`` and ``TimeDeltaIndex.asobject`` have been deprecated. Use '.astype(object)' instead (:issue:`18572`)
-- ``Series.asobject`` has been deprecated. Use '.astype(object).values' instead (:issue:`18572`)
+- ``Series.asobject``, ``DatetimeIndex.asobject``, ``PeriodIndex.asobject`` and ``TimeDeltaIndex.asobject`` have been deprecated. Use '.astype(object)' instead (:issue:`18572`)
 
 .. _whatsnew_0220.prior_deprecations:
 

--- a/doc/source/whatsnew/v0.22.0.txt
+++ b/doc/source/whatsnew/v0.22.0.txt
@@ -124,7 +124,8 @@ Deprecations
 
 - ``Series.from_array`` and ``SparseSeries.from_array`` are deprecated. Use the normal constructor ``Series(..)`` and ``SparseSeries(..)`` instead (:issue:`18213`).
 - ``DataFrame.as_matrix`` is deprecated. Use ``DataFrame.values`` instead (:issue:`18458`).
--
+- ``DatetimeIndex.asobject``, ``PeriodIndex.asobject`` and ``TimeDeltaIndex.asobject`` have been deprecated. Use '.astype(object)' instead (:issue:`18572`)
+- ``Series.asobject`` has been deprecated. Use '.astype(object).values' instead (:issue:`18572`)
 
 .. _whatsnew_0220.prior_deprecations:
 

--- a/pandas/_libs/algos_common_helper.pxi.in
+++ b/pandas/_libs/algos_common_helper.pxi.in
@@ -552,8 +552,8 @@ cpdef ensure_object(object arr):
             return arr
         else:
             return arr.astype(np.object_)
-    elif hasattr(arr, 'asobject'):
-        return arr.asobject
+    elif hasattr(arr, '_asobject'):
+        return arr._asobject
     else:
         return np.array(arr, dtype=np.object_)
 

--- a/pandas/_libs/algos_common_helper.pxi.in
+++ b/pandas/_libs/algos_common_helper.pxi.in
@@ -552,8 +552,8 @@ cpdef ensure_object(object arr):
             return arr
         else:
             return arr.astype(np.object_)
-    elif hasattr(arr, '_asobject'):
-        return arr._asobject
+    elif hasattr(arr, '_box_values_as_index'):
+        return arr._box_values_as_index()
     else:
         return np.array(arr, dtype=np.object_)
 

--- a/pandas/core/accessor.py
+++ b/pandas/core/accessor.py
@@ -10,7 +10,7 @@ from pandas.core.common import AbstractMethodError
 
 class DirNamesMixin(object):
     _accessors = frozenset([])
-    _deprecations = frozenset([])
+    _deprecations = frozenset(['asobject'])
 
     def _dir_deletions(self):
         """ delete unwanted __dir__ for this object """

--- a/pandas/core/algorithms.py
+++ b/pandas/core/algorithms.py
@@ -369,7 +369,7 @@ def unique(values):
         # to return an object array of tz-aware Timestamps
 
         # TODO: it must return DatetimeArray with tz in pandas 2.0
-        uniques = uniques.asobject.values
+        uniques = uniques.astype(object).values
 
     return uniques
 

--- a/pandas/core/dtypes/concat.py
+++ b/pandas/core/dtypes/concat.py
@@ -401,7 +401,7 @@ def _concat_datetime(to_concat, axis=0, typs=None):
         # if dtype is of datetimetz or timezone
         if x.dtype.kind == _NS_DTYPE.kind:
             if getattr(x, 'tz', None) is not None:
-                x = x.asobject.values
+                x = x.astype(object).values
             else:
                 shape = x.shape
                 x = tslib.ints_to_pydatetime(x.view(np.int64).ravel(),
@@ -479,7 +479,7 @@ def _concat_index_asobject(to_concat, name=None):
     """
 
     klasses = ABCDatetimeIndex, ABCTimedeltaIndex, ABCPeriodIndex
-    to_concat = [x.asobject if isinstance(x, klasses) else x
+    to_concat = [x.astype(object) if isinstance(x, klasses) else x
                  for x in to_concat]
 
     from pandas import Index

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -3330,7 +3330,7 @@ class DataFrame(NDFrame):
 
         def _maybe_casted_values(index, labels=None):
             if isinstance(index, PeriodIndex):
-                values = index.asobject.values
+                values = index.astype(object).values
             elif isinstance(index, DatetimeIndex) and index.tz is not None:
                 values = index
             else:
@@ -5077,7 +5077,7 @@ class DataFrame(NDFrame):
         def infer(x):
             if x.empty:
                 return lib.map_infer(x, func)
-            return lib.map_infer(x.asobject, func)
+            return lib.map_infer(x.astype(object).values, func)
 
         return self.apply(infer)
 

--- a/pandas/core/indexes/datetimelike.py
+++ b/pandas/core/indexes/datetimelike.py
@@ -360,7 +360,7 @@ class DatetimeIndexOpsMixin(object):
                 raise TypeError('The map function must return an Index object')
             return result
         except Exception:
-            return self.asobject.map(f)
+            return self.astype(object).map(f)
 
     def sort_values(self, return_indexer=False, ascending=True):
         """
@@ -423,14 +423,24 @@ class DatetimeIndexOpsMixin(object):
         return (self.asi8 == iNaT)
 
     @property
-    def asobject(self):
+    def _asobject(self):
         """
+        return object Index which contains boxed values
+        """
+        from pandas.core.index import Index
+        return Index(self._box_values(self.asi8), name=self.name, dtype=object)
+
+    @property
+    def asobject(self):
+        """DEPRECATED: Use ``astype(object)`` instead.
+
         return object Index which contains boxed values
 
         *this is an internal non-public method*
         """
-        from pandas.core.index import Index
-        return Index(self._box_values(self.asi8), name=self.name, dtype=object)
+        warnings.warn("'asobject' is deprecated. Use 'astype(object)'"
+                      " instead", FutureWarning, stacklevel=2)
+        return self.astype(object)
 
     def _convert_tolerance(self, tolerance, target):
         tolerance = np.asarray(to_timedelta(tolerance, box=False))
@@ -468,7 +478,7 @@ class DatetimeIndexOpsMixin(object):
         """
         return a list of the underlying data
         """
-        return list(self.asobject)
+        return list(self.astype(object))
 
     def min(self, axis=None, *args, **kwargs):
         """
@@ -746,7 +756,7 @@ class DatetimeIndexOpsMixin(object):
             try:
                 values = type(self)(values)
             except ValueError:
-                return self.asobject.isin(values)
+                return self.astype(object).isin(values)
 
         return algorithms.isin(self.asi8, values.asi8)
 

--- a/pandas/core/indexes/datetimelike.py
+++ b/pandas/core/indexes/datetimelike.py
@@ -242,6 +242,13 @@ class DatetimeIndexOpsMixin(object):
         """
         return lib.map_infer(values, self._box_func)
 
+    def _box_values_as_index(self):
+        """
+        return object Index which contains boxed values
+        """
+        from pandas.core.index import Index
+        return Index(self._box_values(self.asi8), name=self.name, dtype=object)
+
     def _format_with_header(self, header, **kwargs):
         return header + list(self._format_native_types(**kwargs))
 
@@ -421,14 +428,6 @@ class DatetimeIndexOpsMixin(object):
     def _isnan(self):
         """ return if each value is nan"""
         return (self.asi8 == iNaT)
-
-    @property
-    def _asobject(self):
-        """
-        return object Index which contains boxed values
-        """
-        from pandas.core.index import Index
-        return Index(self._box_values(self.asi8), name=self.name, dtype=object)
 
     @property
     def asobject(self):

--- a/pandas/core/indexes/datetimes.py
+++ b/pandas/core/indexes/datetimes.py
@@ -907,7 +907,7 @@ class DatetimeIndex(DatelikeOps, TimelikeOps, DatetimeIndexOpsMixin,
     def astype(self, dtype, copy=True):
         dtype = pandas_dtype(dtype)
         if is_object_dtype(dtype):
-            return self.asobject
+            return self._asobject
         elif is_integer_dtype(dtype):
             return Index(self.values.astype('i8', copy=copy), name=self.name,
                          dtype='i8')
@@ -1679,7 +1679,7 @@ class DatetimeIndex(DatelikeOps, TimelikeOps, DatetimeIndexOpsMixin,
         Returns numpy array of datetime.time. The time part of the Timestamps.
         """
         return self._maybe_mask_results(libalgos.arrmap_object(
-            self.asobject.values,
+            self.astype(object).values,
             lambda x: np.nan if x is libts.NaT else x.time()))
 
     @property
@@ -1789,7 +1789,7 @@ class DatetimeIndex(DatelikeOps, TimelikeOps, DatetimeIndexOpsMixin,
 
             # fall back to object index
             if isinstance(item, compat.string_types):
-                return self.asobject.insert(loc, item)
+                return self.astype(object).insert(loc, item)
             raise TypeError(
                 "cannot insert DatetimeIndex with incompatible label")
 

--- a/pandas/core/indexes/datetimes.py
+++ b/pandas/core/indexes/datetimes.py
@@ -907,7 +907,7 @@ class DatetimeIndex(DatelikeOps, TimelikeOps, DatetimeIndexOpsMixin,
     def astype(self, dtype, copy=True):
         dtype = pandas_dtype(dtype)
         if is_object_dtype(dtype):
-            return self._asobject
+            return self._box_values_as_index()
         elif is_integer_dtype(dtype):
             return Index(self.values.astype('i8', copy=copy), name=self.name,
                          dtype='i8')

--- a/pandas/core/indexes/period.py
+++ b/pandas/core/indexes/period.py
@@ -418,7 +418,7 @@ class PeriodIndex(DatelikeOps, DatetimeIndexOpsMixin, Int64Index):
 
     @property
     def values(self):
-        return self.asobject.values
+        return self.astype(object).values
 
     @property
     def _values(self):
@@ -428,7 +428,7 @@ class PeriodIndex(DatelikeOps, DatetimeIndexOpsMixin, Int64Index):
         if is_integer_dtype(dtype):
             return self.asi8
         else:
-            return self.asobject.values
+            return self.astype(object).values
 
     def __array_wrap__(self, result, context=None):
         """
@@ -476,7 +476,7 @@ class PeriodIndex(DatelikeOps, DatetimeIndexOpsMixin, Int64Index):
         if dtype is not None:
             return self.astype(dtype)._to_embed(keep_tz=keep_tz)
 
-        return self.asobject.values
+        return self.astype(object).values
 
     @property
     def _formatter_func(self):
@@ -506,7 +506,7 @@ class PeriodIndex(DatelikeOps, DatetimeIndexOpsMixin, Int64Index):
     def astype(self, dtype, copy=True, how='start'):
         dtype = pandas_dtype(dtype)
         if is_object_dtype(dtype):
-            return self.asobject
+            return self._asobject
         elif is_integer_dtype(dtype):
             if copy:
                 return self._int64index.copy()
@@ -656,7 +656,7 @@ class PeriodIndex(DatelikeOps, DatetimeIndexOpsMixin, Int64Index):
 
     def _mpl_repr(self):
         # how to represent ourselves to matplotlib
-        return self.asobject.values
+        return self.astype(object).values
 
     def to_timestamp(self, freq=None, how='start'):
         """
@@ -971,7 +971,7 @@ class PeriodIndex(DatelikeOps, DatetimeIndexOpsMixin, Int64Index):
 
     def insert(self, loc, item):
         if not isinstance(item, Period) or self.freq != item.freq:
-            return self.asobject.insert(loc, item)
+            return self.astype(object).insert(loc, item)
 
         idx = np.concatenate((self[:loc].asi8, np.array([item.ordinal]),
                               self[loc:].asi8))
@@ -1018,7 +1018,7 @@ class PeriodIndex(DatelikeOps, DatetimeIndexOpsMixin, Int64Index):
     def _format_native_types(self, na_rep=u('NaT'), date_format=None,
                              **kwargs):
 
-        values = self.asobject.values
+        values = self.astype(object).values
 
         if date_format:
             formatter = lambda dt: dt.strftime(date_format)

--- a/pandas/core/indexes/period.py
+++ b/pandas/core/indexes/period.py
@@ -506,7 +506,7 @@ class PeriodIndex(DatelikeOps, DatetimeIndexOpsMixin, Int64Index):
     def astype(self, dtype, copy=True, how='start'):
         dtype = pandas_dtype(dtype)
         if is_object_dtype(dtype):
-            return self._asobject
+            return self._box_values_as_index()
         elif is_integer_dtype(dtype):
             if copy:
                 return self._int64index.copy()

--- a/pandas/core/indexes/timedeltas.py
+++ b/pandas/core/indexes/timedeltas.py
@@ -482,7 +482,7 @@ class TimedeltaIndex(DatetimeIndexOpsMixin, TimelikeOps, Int64Index):
         dtype = np.dtype(dtype)
 
         if is_object_dtype(dtype):
-            return self.asobject
+            return self._asobject
         elif is_timedelta64_ns_dtype(dtype):
             if copy is True:
                 return self.copy()
@@ -883,7 +883,7 @@ class TimedeltaIndex(DatetimeIndexOpsMixin, TimelikeOps, Int64Index):
 
             # fall back to object index
             if isinstance(item, compat.string_types):
-                return self.asobject.insert(loc, item)
+                return self.astype(object).insert(loc, item)
             raise TypeError(
                 "cannot insert TimedeltaIndex with incompatible label")
 

--- a/pandas/core/indexes/timedeltas.py
+++ b/pandas/core/indexes/timedeltas.py
@@ -482,7 +482,7 @@ class TimedeltaIndex(DatetimeIndexOpsMixin, TimelikeOps, Int64Index):
         dtype = np.dtype(dtype)
 
         if is_object_dtype(dtype):
-            return self._asobject
+            return self._box_values_as_index()
         elif is_timedelta64_ns_dtype(dtype):
             if copy is True:
                 return self.copy()

--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -405,7 +405,8 @@ class _NDFrameIndexer(_NDFrameIndexerBase):
                             new_values = np.concatenate([self.obj._values,
                                                          new_values])
                         except TypeError:
-                            new_values = np.concatenate([self.obj.asobject,
+                            as_obj = self.obj.astype(object)
+                            new_values = np.concatenate([as_obj,
                                                          new_values])
                     self.obj._data = self.obj._constructor(
                         new_values, index=new_index, name=self.obj.name)._data

--- a/pandas/core/internals.py
+++ b/pandas/core/internals.py
@@ -2191,7 +2191,7 @@ class ObjectBlock(Block):
 
         if isinstance(other, ABCDatetimeIndex):
             # to store DatetimeTZBlock as object
-            other = other.asobject.values
+            other = other.astype(object).values
 
         return values, False, other, False
 

--- a/pandas/core/ops.py
+++ b/pandas/core/ops.py
@@ -850,7 +850,7 @@ def _comp_method_SERIES(op, name, str_rep, masker=False):
                 # tested in test_nat_comparisons
                 # (pandas.tests.series.test_operators.TestSeriesOperators)
                 return self._constructor(na_op(self.values,
-                                               other.asobject.values),
+                                               other.astype(object).values),
                                          index=self.index)
 
             return self._constructor(na_op(self.values, np.asarray(other)),

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -449,12 +449,15 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
 
     @property
     def asobject(self):
-        """
+        """DEPRECATED: Use ``astype(object).values`` instead.
+
         return object Series which contains boxed values
 
         *this is an internal non-public method*
         """
-        return self._data.asobject
+        warnings.warn("'asobject' is deprecated. Use 'astype(object).values'"
+                      " instead", FutureWarning, stacklevel=2)
+        return self.astype(object).values
 
     # ops
     def ravel(self, order='C'):
@@ -1322,7 +1325,7 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
             # to return an object array of tz-aware Timestamps
 
             # TODO: it must return DatetimeArray with tz in pandas 2.0
-            result = result.asobject.values
+            result = result.astype(object).values
 
         return result
 
@@ -2549,7 +2552,7 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
             if is_extension_type(self.dtype):
                 mapped = self._values.map(f)
             else:
-                values = self.asobject
+                values = self.astype(object).values
                 mapped = lib.map_infer(values, f, convert=convert_dtype)
 
         if len(mapped) and isinstance(mapped[0], Series):
@@ -3125,7 +3128,7 @@ def _sanitize_index(data, index, copy=False):
     if isinstance(data, ABCIndexClass) and not copy:
         pass
     elif isinstance(data, PeriodIndex):
-        data = data.asobject
+        data = data.astype(object).values
     elif isinstance(data, DatetimeIndex):
         data = data._to_embed(keep_tz=True)
     elif isinstance(data, np.ndarray):

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -149,7 +149,8 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
     _metadata = ['name']
     _accessors = frozenset(['dt', 'cat', 'str'])
     _deprecations = generic.NDFrame._deprecations | frozenset(
-        ['sortlevel', 'reshape', 'get_value', 'set_value', 'from_csv'])
+        ['asobject', 'sortlevel', 'reshape', 'get_value', 'set_value',
+         'from_csv'])
     _allow_index_ops = True
 
     def __init__(self, data=None, index=None, dtype=None, name=None,
@@ -449,13 +450,13 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
 
     @property
     def asobject(self):
-        """DEPRECATED: Use ``astype(object).values`` instead.
+        """DEPRECATED: Use ``astype(object)`` instead.
 
         return object Series which contains boxed values
 
         *this is an internal non-public method*
         """
-        warnings.warn("'asobject' is deprecated. Use 'astype(object).values'"
+        warnings.warn("'asobject' is deprecated. Use 'astype(object)'"
                       " instead", FutureWarning, stacklevel=2)
         return self.astype(object).values
 

--- a/pandas/io/formats/format.py
+++ b/pandas/io/formats/format.py
@@ -2231,7 +2231,7 @@ class Datetime64TZFormatter(Datetime64Formatter):
     def _format_strings(self):
         """ we by definition have a TZ """
 
-        values = self.values.asobject
+        values = self.values.astype(object)
         is_dates_only = _is_dates_only(values)
         formatter = (self.formatter or
                      _get_format_datetime64(is_dates_only,

--- a/pandas/plotting/_converter.py
+++ b/pandas/plotting/_converter.py
@@ -363,7 +363,8 @@ class MilliSecondLocator(dates.DateLocator):
         tz = self.tz.tzname(None)
         st = _from_ordinal(dates.date2num(dmin))  # strip tz
         ed = _from_ordinal(dates.date2num(dmax))
-        all_dates = date_range(start=st, end=ed, freq=freq, tz=tz).asobject
+        all_dates = date_range(start=st, end=ed,
+                               freq=freq, tz=tz).astype(object)
 
         try:
             if len(all_dates) > 0:

--- a/pandas/tests/frame/test_constructors.py
+++ b/pandas/tests/frame/test_constructors.py
@@ -501,8 +501,8 @@ class TestDataFrameConstructors(TestData):
         assert df['b'].dtype == 'object'
 
         # list of periods
-        df = pd.DataFrame({'a': a.asobject.tolist(),
-                           'b': b.asobject.tolist()})
+        df = pd.DataFrame({'a': a.astype(object).tolist(),
+                           'b': b.astype(object).tolist()})
         assert df['a'].dtype == 'object'
         assert df['b'].dtype == 'object'
 

--- a/pandas/tests/indexes/datetimelike.py
+++ b/pandas/tests/indexes/datetimelike.py
@@ -78,15 +78,8 @@ class DatetimeLike(Base):
         tm.assert_index_equal(result, expected)
 
     def test_asobject_deprecated(self):
-        d = pd.date_range('2010-01-1', periods=3)
+        # GH18572
+        d = self.create_index()
         with tm.assert_produces_warning(FutureWarning):
             i = d.asobject
-        assert isinstance(i, pd.Index)
-        p = pd.period_range('2010-01-1', periods=3)
-        with tm.assert_produces_warning(FutureWarning):
-            i = p.asobject
-        assert isinstance(i, pd.Index)
-        t = pd.timedelta_range('1 day', periods=3)
-        with tm.assert_produces_warning(FutureWarning):
-            i = t.asobject
         assert isinstance(i, pd.Index)

--- a/pandas/tests/indexes/datetimelike.py
+++ b/pandas/tests/indexes/datetimelike.py
@@ -76,3 +76,17 @@ class DatetimeLike(Base):
         expected = pd.Index([np.nan] * len(self.index))
         result = self.index.map(mapper([], []))
         tm.assert_index_equal(result, expected)
+
+    def test_asobject_deprecated(self):
+        d = pd.date_range('2010-01-1', periods=3)
+        with tm.assert_produces_warning(FutureWarning):
+            i = d.asobject
+        assert isinstance(i, pd.Index)
+        p = pd.period_range('2010-01-1', periods=3)
+        with tm.assert_produces_warning(FutureWarning):
+            i = p.asobject
+        assert isinstance(i, pd.Index)
+        t = pd.timedelta_range('1 day', periods=3)
+        with tm.assert_produces_warning(FutureWarning):
+            i = t.asobject
+        assert isinstance(i, pd.Index)

--- a/pandas/tests/indexes/datetimes/test_ops.py
+++ b/pandas/tests/indexes/datetimes/test_ops.py
@@ -51,7 +51,7 @@ class TestDatetimeIndexOps(Ops):
         assert s.day == 10
         pytest.raises(AttributeError, lambda: s.weekday)
 
-    def test_asobject_tolist(self):
+    def test_astype(self):
         idx = pd.date_range(start='2013-01-01', periods=4, freq='M',
                             name='idx')
         expected_list = [Timestamp('2013-01-31'),
@@ -59,7 +59,7 @@ class TestDatetimeIndexOps(Ops):
                          Timestamp('2013-03-31'),
                          Timestamp('2013-04-30')]
         expected = pd.Index(expected_list, dtype=object, name='idx')
-        result = idx.asobject
+        result = idx.astype(object)
         assert isinstance(result, Index)
 
         assert result.dtype == object
@@ -74,7 +74,7 @@ class TestDatetimeIndexOps(Ops):
                          Timestamp('2013-03-31', tz='Asia/Tokyo'),
                          Timestamp('2013-04-30', tz='Asia/Tokyo')]
         expected = pd.Index(expected_list, dtype=object, name='idx')
-        result = idx.asobject
+        result = idx.astype(object)
         assert isinstance(result, Index)
         assert result.dtype == object
         tm.assert_index_equal(result, expected)
@@ -87,7 +87,7 @@ class TestDatetimeIndexOps(Ops):
                          Timestamp('2013-01-02'), pd.NaT,
                          Timestamp('2013-01-04')]
         expected = pd.Index(expected_list, dtype=object, name='idx')
-        result = idx.asobject
+        result = idx.astype(object)
         assert isinstance(result, Index)
         assert result.dtype == object
         tm.assert_index_equal(result, expected)
@@ -389,8 +389,9 @@ class TestDatetimeIndexOps(Ops):
                                  pd.Timestamp('2011-01-03')])
         right = pd.DatetimeIndex([pd.NaT, pd.NaT, pd.Timestamp('2011-01-03')])
 
-        for l, r in [(left, right), (left.asobject, right.asobject)]:
-            result = l == r
+        for l, r in [(left, right),
+                     (left.astype(object), right.astype(object))]:
+            result = r == l
             expected = np.array([False, False, True])
             tm.assert_numpy_array_equal(result, expected)
 
@@ -636,9 +637,9 @@ class TestDatetimeIndexOps(Ops):
             idx = pd.DatetimeIndex(['2011-01-01', '2011-01-02', 'NaT'])
             assert idx.equals(idx)
             assert idx.equals(idx.copy())
-            assert idx.equals(idx.asobject)
-            assert idx.asobject.equals(idx)
-            assert idx.asobject.equals(idx.asobject)
+            assert idx.equals(idx.astype(object))
+            assert idx.astype(object).equals(idx)
+            assert idx.astype(object).equals(idx.astype(object))
             assert not idx.equals(list(idx))
             assert not idx.equals(pd.Series(idx))
 
@@ -646,8 +647,8 @@ class TestDatetimeIndexOps(Ops):
                                     tz='US/Pacific')
             assert not idx.equals(idx2)
             assert not idx.equals(idx2.copy())
-            assert not idx.equals(idx2.asobject)
-            assert not idx.asobject.equals(idx2)
+            assert not idx.equals(idx2.astype(object))
+            assert not idx.astype(object).equals(idx2)
             assert not idx.equals(list(idx2))
             assert not idx.equals(pd.Series(idx2))
 
@@ -656,8 +657,8 @@ class TestDatetimeIndexOps(Ops):
             tm.assert_numpy_array_equal(idx.asi8, idx3.asi8)
             assert not idx.equals(idx3)
             assert not idx.equals(idx3.copy())
-            assert not idx.equals(idx3.asobject)
-            assert not idx.asobject.equals(idx3)
+            assert not idx.equals(idx3.astype(object))
+            assert not idx.astype(object).equals(idx3)
             assert not idx.equals(list(idx3))
             assert not idx.equals(pd.Series(idx3))
 

--- a/pandas/tests/indexes/datetimes/test_ops.py
+++ b/pandas/tests/indexes/datetimes/test_ops.py
@@ -389,27 +389,27 @@ class TestDatetimeIndexOps(Ops):
                                  pd.Timestamp('2011-01-03')])
         right = pd.DatetimeIndex([pd.NaT, pd.NaT, pd.Timestamp('2011-01-03')])
 
-        for l, r in [(left, right),
-                     (left.astype(object), right.astype(object))]:
-            result = r == l
+        for lhs, rhs in [(left, right),
+                         (left.astype(object), right.astype(object))]:
+            result = rhs == lhs
             expected = np.array([False, False, True])
             tm.assert_numpy_array_equal(result, expected)
 
-            result = l != r
+            result = lhs != rhs
             expected = np.array([True, True, False])
             tm.assert_numpy_array_equal(result, expected)
 
             expected = np.array([False, False, False])
-            tm.assert_numpy_array_equal(l == pd.NaT, expected)
-            tm.assert_numpy_array_equal(pd.NaT == r, expected)
+            tm.assert_numpy_array_equal(lhs == pd.NaT, expected)
+            tm.assert_numpy_array_equal(pd.NaT == rhs, expected)
 
             expected = np.array([True, True, True])
-            tm.assert_numpy_array_equal(l != pd.NaT, expected)
-            tm.assert_numpy_array_equal(pd.NaT != l, expected)
+            tm.assert_numpy_array_equal(lhs != pd.NaT, expected)
+            tm.assert_numpy_array_equal(pd.NaT != lhs, expected)
 
             expected = np.array([False, False, False])
-            tm.assert_numpy_array_equal(l < pd.NaT, expected)
-            tm.assert_numpy_array_equal(pd.NaT > l, expected)
+            tm.assert_numpy_array_equal(lhs < pd.NaT, expected)
+            tm.assert_numpy_array_equal(pd.NaT > lhs, expected)
 
     def test_value_counts_unique(self):
         # GH 7735

--- a/pandas/tests/indexes/datetimes/test_ops.py
+++ b/pandas/tests/indexes/datetimes/test_ops.py
@@ -51,7 +51,7 @@ class TestDatetimeIndexOps(Ops):
         assert s.day == 10
         pytest.raises(AttributeError, lambda: s.weekday)
 
-    def test_astype(self):
+    def test_astype_object(self):
         idx = pd.date_range(start='2013-01-01', periods=4, freq='M',
                             name='idx')
         expected_list = [Timestamp('2013-01-31'),

--- a/pandas/tests/indexes/period/test_ops.py
+++ b/pandas/tests/indexes/period/test_ops.py
@@ -27,7 +27,7 @@ class TestPeriodIndexOps(Ops):
         self.check_ops_properties(PeriodIndex._object_ops, f)
         self.check_ops_properties(PeriodIndex._bool_ops, f)
 
-    def test_asobject_tolist(self):
+    def test_astype(self):
         idx = pd.period_range(start='2013-01-01', periods=4, freq='M',
                               name='idx')
         expected_list = [pd.Period('2013-01-31', freq='M'),
@@ -35,7 +35,7 @@ class TestPeriodIndexOps(Ops):
                          pd.Period('2013-03-31', freq='M'),
                          pd.Period('2013-04-30', freq='M')]
         expected = pd.Index(expected_list, dtype=object, name='idx')
-        result = idx.asobject
+        result = idx.astype(object)
         assert isinstance(result, Index)
         assert result.dtype == object
         tm.assert_index_equal(result, expected)
@@ -49,7 +49,7 @@ class TestPeriodIndexOps(Ops):
                          pd.Period('NaT', freq='D'),
                          pd.Period('2013-01-04', freq='D')]
         expected = pd.Index(expected_list, dtype=object, name='idx')
-        result = idx.asobject
+        result = idx.astype(object)
         assert isinstance(result, Index)
         assert result.dtype == object
         tm.assert_index_equal(result, expected)
@@ -290,8 +290,9 @@ Freq: Q-DEC"""
                                pd.Period('2011-01-03')])
         right = pd.PeriodIndex([pd.NaT, pd.NaT, pd.Period('2011-01-03')])
 
-        for l, r in [(left, right), (left.asobject, right.asobject)]:
-            result = l == r
+        for l, r in [(left, right),
+                     (left.astype(object), right.astype(object))]:
+            result = r == l
             expected = np.array([False, False, True])
             tm.assert_numpy_array_equal(result, expected)
 
@@ -614,9 +615,9 @@ Freq: Q-DEC"""
                                  freq=freq)
             assert idx.equals(idx)
             assert idx.equals(idx.copy())
-            assert idx.equals(idx.asobject)
-            assert idx.asobject.equals(idx)
-            assert idx.asobject.equals(idx.asobject)
+            assert idx.equals(idx.astype(object))
+            assert idx.astype(object).equals(idx)
+            assert idx.astype(object).equals(idx.astype(object))
             assert not idx.equals(list(idx))
             assert not idx.equals(pd.Series(idx))
 
@@ -624,8 +625,8 @@ Freq: Q-DEC"""
                                   freq='H')
             assert not idx.equals(idx2)
             assert not idx.equals(idx2.copy())
-            assert not idx.equals(idx2.asobject)
-            assert not idx.asobject.equals(idx2)
+            assert not idx.equals(idx2.astype(object))
+            assert not idx.astype(object).equals(idx2)
             assert not idx.equals(list(idx2))
             assert not idx.equals(pd.Series(idx2))
 
@@ -634,8 +635,8 @@ Freq: Q-DEC"""
             tm.assert_numpy_array_equal(idx.asi8, idx3.asi8)
             assert not idx.equals(idx3)
             assert not idx.equals(idx3.copy())
-            assert not idx.equals(idx3.asobject)
-            assert not idx.asobject.equals(idx3)
+            assert not idx.equals(idx3.astype(object))
+            assert not idx.astype(object).equals(idx3)
             assert not idx.equals(list(idx3))
             assert not idx.equals(pd.Series(idx3))
 

--- a/pandas/tests/indexes/period/test_ops.py
+++ b/pandas/tests/indexes/period/test_ops.py
@@ -27,7 +27,7 @@ class TestPeriodIndexOps(Ops):
         self.check_ops_properties(PeriodIndex._object_ops, f)
         self.check_ops_properties(PeriodIndex._bool_ops, f)
 
-    def test_astype(self):
+    def test_astype_object(self):
         idx = pd.period_range(start='2013-01-01', periods=4, freq='M',
                               name='idx')
         expected_list = [pd.Period('2013-01-31', freq='M'),
@@ -291,7 +291,7 @@ Freq: Q-DEC"""
         right = pd.PeriodIndex([pd.NaT, pd.NaT, pd.Period('2011-01-03')])
 
         for lhs, rhs in [(left, right),
-                     (left.astype(object), right.astype(object))]:
+                         (left.astype(object), right.astype(object))]:
             result = lhs == rhs
             expected = np.array([False, False, True])
             tm.assert_numpy_array_equal(result, expected)

--- a/pandas/tests/indexes/period/test_ops.py
+++ b/pandas/tests/indexes/period/test_ops.py
@@ -290,27 +290,27 @@ Freq: Q-DEC"""
                                pd.Period('2011-01-03')])
         right = pd.PeriodIndex([pd.NaT, pd.NaT, pd.Period('2011-01-03')])
 
-        for l, r in [(left, right),
+        for lhs, rhs in [(left, right),
                      (left.astype(object), right.astype(object))]:
-            result = r == l
+            result = lhs == rhs
             expected = np.array([False, False, True])
             tm.assert_numpy_array_equal(result, expected)
 
-            result = l != r
+            result = lhs != rhs
             expected = np.array([True, True, False])
             tm.assert_numpy_array_equal(result, expected)
 
             expected = np.array([False, False, False])
-            tm.assert_numpy_array_equal(l == pd.NaT, expected)
-            tm.assert_numpy_array_equal(pd.NaT == r, expected)
+            tm.assert_numpy_array_equal(lhs == pd.NaT, expected)
+            tm.assert_numpy_array_equal(pd.NaT == rhs, expected)
 
             expected = np.array([True, True, True])
-            tm.assert_numpy_array_equal(l != pd.NaT, expected)
-            tm.assert_numpy_array_equal(pd.NaT != l, expected)
+            tm.assert_numpy_array_equal(lhs != pd.NaT, expected)
+            tm.assert_numpy_array_equal(pd.NaT != lhs, expected)
 
             expected = np.array([False, False, False])
-            tm.assert_numpy_array_equal(l < pd.NaT, expected)
-            tm.assert_numpy_array_equal(pd.NaT > l, expected)
+            tm.assert_numpy_array_equal(lhs < pd.NaT, expected)
+            tm.assert_numpy_array_equal(pd.NaT > lhs, expected)
 
     def test_value_counts_unique(self):
         # GH 7735

--- a/pandas/tests/indexes/period/test_period.py
+++ b/pandas/tests/indexes/period/test_period.py
@@ -24,7 +24,7 @@ class TestPeriodIndex(DatetimeLike):
     def create_index(self):
         return period_range('20130101', periods=5, freq='D')
 
-    def test_astype(self):
+    def test_astype_conversion(self):
         # GH 13149, GH 13209
         idx = PeriodIndex(['2016-05-16', 'NaT', NaT, np.NaN], freq='D')
 
@@ -380,23 +380,23 @@ class TestPeriodIndex(DatetimeLike):
         tm.assert_numpy_array_equal(arr, exp_arr)
         tm.assert_index_equal(idx, exp_idx)
 
-    def test_asobject_like(self):
+    def test_astype(self):
         idx = pd.PeriodIndex([], freq='M')
 
         exp = np.array([], dtype=object)
-        tm.assert_numpy_array_equal(idx.asobject.values, exp)
+        tm.assert_numpy_array_equal(idx.astype(object).values, exp)
         tm.assert_numpy_array_equal(idx._mpl_repr(), exp)
 
         idx = pd.PeriodIndex(['2011-01', pd.NaT], freq='M')
 
         exp = np.array([pd.Period('2011-01', freq='M'), pd.NaT], dtype=object)
-        tm.assert_numpy_array_equal(idx.asobject.values, exp)
+        tm.assert_numpy_array_equal(idx.astype(object).values, exp)
         tm.assert_numpy_array_equal(idx._mpl_repr(), exp)
 
         exp = np.array([pd.Period('2011-01-01', freq='D'), pd.NaT],
                        dtype=object)
         idx = pd.PeriodIndex(['2011-01-01', pd.NaT], freq='D')
-        tm.assert_numpy_array_equal(idx.asobject.values, exp)
+        tm.assert_numpy_array_equal(idx.astype(object).values, exp)
         tm.assert_numpy_array_equal(idx._mpl_repr(), exp)
 
     def test_is_(self):

--- a/pandas/tests/indexes/period/test_period.py
+++ b/pandas/tests/indexes/period/test_period.py
@@ -380,7 +380,7 @@ class TestPeriodIndex(DatetimeLike):
         tm.assert_numpy_array_equal(arr, exp_arr)
         tm.assert_index_equal(idx, exp_idx)
 
-    def test_astype(self):
+    def test_astype_object(self):
         idx = pd.PeriodIndex([], freq='M')
 
         exp = np.array([], dtype=object)

--- a/pandas/tests/indexes/test_base.py
+++ b/pandas/tests/indexes/test_base.py
@@ -122,7 +122,7 @@ class TestIndex(Base):
         tm.assert_index_equal(result, idx)
         assert result.tz == idx.tz
 
-        result = pd.Index(idx.asobject)
+        result = pd.Index(idx.astype(object))
         tm.assert_index_equal(result, idx)
         assert result.tz == idx.tz
 
@@ -131,7 +131,7 @@ class TestIndex(Base):
         result = pd.Index(idx)
         tm.assert_index_equal(result, idx)
 
-        result = pd.Index(idx.asobject)
+        result = pd.Index(idx.astype(object))
         tm.assert_index_equal(result, idx)
 
     def test_constructor_from_index_period(self):
@@ -139,7 +139,7 @@ class TestIndex(Base):
         result = pd.Index(idx)
         tm.assert_index_equal(result, idx)
 
-        result = pd.Index(idx.asobject)
+        result = pd.Index(idx.astype(object))
         tm.assert_index_equal(result, idx)
 
     def test_constructor_from_series_datetimetz(self):

--- a/pandas/tests/indexes/timedeltas/test_ops.py
+++ b/pandas/tests/indexes/timedeltas/test_ops.py
@@ -25,12 +25,12 @@ class TestTimedeltaIndexOps(Ops):
         self.check_ops_properties(TimedeltaIndex._field_ops, f)
         self.check_ops_properties(TimedeltaIndex._object_ops, f)
 
-    def test_asobject_tolist(self):
+    def test_astype(self):
         idx = timedelta_range(start='1 days', periods=4, freq='D', name='idx')
         expected_list = [Timedelta('1 days'), Timedelta('2 days'),
                          Timedelta('3 days'), Timedelta('4 days')]
         expected = pd.Index(expected_list, dtype=object, name='idx')
-        result = idx.asobject
+        result = idx.astype(object)
         assert isinstance(result, Index)
 
         assert result.dtype == object
@@ -43,7 +43,7 @@ class TestTimedeltaIndexOps(Ops):
         expected_list = [Timedelta('1 days'), Timedelta('2 days'), pd.NaT,
                          Timedelta('4 days')]
         expected = pd.Index(expected_list, dtype=object, name='idx')
-        result = idx.asobject
+        result = idx.astype(object)
         assert isinstance(result, Index)
         assert result.dtype == object
         tm.assert_index_equal(result, expected)
@@ -217,12 +217,13 @@ dtype: timedelta64[ns]"""
                                   pd.Timedelta('3 days')])
         right = pd.TimedeltaIndex([pd.NaT, pd.NaT, pd.Timedelta('3 days')])
 
-        for l, r in [(left, right), (left.asobject, right.asobject)]:
-            result = l == r
+        for l, r in [(left, right),
+                     (left.astype(object), right.astype(object))]:
+            result = r == l
             expected = np.array([False, False, True])
             tm.assert_numpy_array_equal(result, expected)
 
-            result = l != r
+            result = r != l
             expected = np.array([True, True, False])
             tm.assert_numpy_array_equal(result, expected)
 
@@ -473,18 +474,18 @@ dtype: timedelta64[ns]"""
         idx = pd.TimedeltaIndex(['1 days', '2 days', 'NaT'])
         assert idx.equals(idx)
         assert idx.equals(idx.copy())
-        assert idx.equals(idx.asobject)
-        assert idx.asobject.equals(idx)
-        assert idx.asobject.equals(idx.asobject)
+        assert idx.equals(idx.astype(object))
+        assert idx.astype(object).equals(idx)
+        assert idx.astype(object).equals(idx.astype(object))
         assert not idx.equals(list(idx))
         assert not idx.equals(pd.Series(idx))
 
         idx2 = pd.TimedeltaIndex(['2 days', '1 days', 'NaT'])
         assert not idx.equals(idx2)
         assert not idx.equals(idx2.copy())
-        assert not idx.equals(idx2.asobject)
-        assert not idx.asobject.equals(idx2)
-        assert not idx.asobject.equals(idx2.asobject)
+        assert not idx.equals(idx2.astype(object))
+        assert not idx.astype(object).equals(idx2)
+        assert not idx.astype(object).equals(idx2.astype(object))
         assert not idx.equals(list(idx2))
         assert not idx.equals(pd.Series(idx2))
 

--- a/pandas/tests/indexes/timedeltas/test_ops.py
+++ b/pandas/tests/indexes/timedeltas/test_ops.py
@@ -25,7 +25,7 @@ class TestTimedeltaIndexOps(Ops):
         self.check_ops_properties(TimedeltaIndex._field_ops, f)
         self.check_ops_properties(TimedeltaIndex._object_ops, f)
 
-    def test_astype(self):
+    def test_astype_object(self):
         idx = timedelta_range(start='1 days', periods=4, freq='D', name='idx')
         expected_list = [Timedelta('1 days'), Timedelta('2 days'),
                          Timedelta('3 days'), Timedelta('4 days')]
@@ -217,27 +217,27 @@ dtype: timedelta64[ns]"""
                                   pd.Timedelta('3 days')])
         right = pd.TimedeltaIndex([pd.NaT, pd.NaT, pd.Timedelta('3 days')])
 
-        for l, r in [(left, right),
-                     (left.astype(object), right.astype(object))]:
-            result = r == l
+        for lhs, rhs in [(left, right),
+                         (left.astype(object), right.astype(object))]:
+            result = rhs == lhs
             expected = np.array([False, False, True])
             tm.assert_numpy_array_equal(result, expected)
 
-            result = r != l
+            result = rhs != lhs
             expected = np.array([True, True, False])
             tm.assert_numpy_array_equal(result, expected)
 
             expected = np.array([False, False, False])
-            tm.assert_numpy_array_equal(l == pd.NaT, expected)
-            tm.assert_numpy_array_equal(pd.NaT == r, expected)
+            tm.assert_numpy_array_equal(lhs == pd.NaT, expected)
+            tm.assert_numpy_array_equal(pd.NaT == rhs, expected)
 
             expected = np.array([True, True, True])
-            tm.assert_numpy_array_equal(l != pd.NaT, expected)
-            tm.assert_numpy_array_equal(pd.NaT != l, expected)
+            tm.assert_numpy_array_equal(lhs != pd.NaT, expected)
+            tm.assert_numpy_array_equal(pd.NaT != lhs, expected)
 
             expected = np.array([False, False, False])
-            tm.assert_numpy_array_equal(l < pd.NaT, expected)
-            tm.assert_numpy_array_equal(pd.NaT > l, expected)
+            tm.assert_numpy_array_equal(lhs < pd.NaT, expected)
+            tm.assert_numpy_array_equal(pd.NaT > lhs, expected)
 
     def test_value_counts_unique(self):
         # GH 7735

--- a/pandas/tests/plotting/test_datetimelike.py
+++ b/pandas/tests/plotting/test_datetimelike.py
@@ -272,7 +272,7 @@ class TestTSPlot(TestPlotBase):
 
         _, ax = self.plt.subplots()
         df2 = df.copy()
-        df2.index = df.index.asobject
+        df2.index = df.index.astype(object)
         df2.plot(ax=ax)
         diffs = Series(ax.get_lines()[0].get_xydata()[:, 0]).diff()
         assert (np.fabs(diffs[1:] - sec) < 1e-8).all()
@@ -712,9 +712,9 @@ class TestTSPlot(TestPlotBase):
         assert not hasattr(ax, 'freq')
         lines = ax.get_lines()
         x1 = lines[0].get_xdata()
-        tm.assert_numpy_array_equal(x1, s2.index.asobject.values)
+        tm.assert_numpy_array_equal(x1, s2.index.astype(object).values)
         x2 = lines[1].get_xdata()
-        tm.assert_numpy_array_equal(x2, s1.index.asobject.values)
+        tm.assert_numpy_array_equal(x2, s1.index.astype(object).values)
 
     def test_mixed_freq_regular_first_df(self):
         # GH 9852
@@ -744,9 +744,9 @@ class TestTSPlot(TestPlotBase):
         assert not hasattr(ax, 'freq')
         lines = ax.get_lines()
         x1 = lines[0].get_xdata()
-        tm.assert_numpy_array_equal(x1, s2.index.asobject.values)
+        tm.assert_numpy_array_equal(x1, s2.index.astype(object).values)
         x2 = lines[1].get_xdata()
-        tm.assert_numpy_array_equal(x2, s1.index.asobject.values)
+        tm.assert_numpy_array_equal(x2, s1.index.astype(object).values)
 
     def test_mixed_freq_hf_first(self):
         idxh = date_range('1/1/1999', periods=365, freq='D')
@@ -1019,7 +1019,7 @@ class TestTSPlot(TestPlotBase):
 
         # np.datetime64
         idx = date_range('1/1/2000', periods=10)
-        idx = idx[[0, 2, 5, 9]].asobject
+        idx = idx[[0, 2, 5, 9]].astype(object)
         df = DataFrame(np.random.randn(len(idx), 3), idx)
         _, ax = self.plt.subplots()
         _check_plot_works(df.plot, ax=ax)

--- a/pandas/tests/series/test_constructors.py
+++ b/pandas/tests/series/test_constructors.py
@@ -632,7 +632,7 @@ class TestSeriesConstructors(TestData):
 
         pi = period_range('20130101', periods=5, freq='D')
         s = Series(pi)
-        expected = Series(pi.asobject)
+        expected = Series(pi.astype(object))
         assert_series_equal(s, expected)
 
         assert s.dtype == 'object'

--- a/pandas/tests/series/test_datetime_values.py
+++ b/pandas/tests/series/test_datetime_values.py
@@ -228,7 +228,7 @@ class TestSeriesDatetimeValues(TestData):
             results, list(sorted(set(ok_for_dt + ok_for_dt_methods))))
 
         s = Series(period_range('20130101', periods=5,
-                                freq='D', name='xxx').asobject)
+                                freq='D', name='xxx').astype(object))
         results = get_dir(s)
         tm.assert_almost_equal(
             results, list(sorted(set(ok_for_period + ok_for_period_methods))))
@@ -387,7 +387,7 @@ class TestSeriesDatetimeValues(TestData):
         assert result.dtype == 'timedelta64[ns]'
 
     def test_between(self):
-        s = Series(bdate_range('1/1/2000', periods=20).asobject)
+        s = Series(bdate_range('1/1/2000', periods=20).astype(object))
         s[::2] = np.nan
 
         result = s[s.between(s[3], s[17])]

--- a/pandas/tests/series/test_dtypes.py
+++ b/pandas/tests/series/test_dtypes.py
@@ -37,6 +37,12 @@ class TestSeriesDtypes(TestData):
         assert as_typed.dtype == dtype
         assert as_typed.name == s.name
 
+    def test_asobject_deprecated(self):
+        s = Series(np.random.randn(5), name='foo')
+        with tm.assert_produces_warning(FutureWarning):
+            o = s.asobject
+        assert isinstance(o, np.ndarray)
+
     def test_dtype(self):
 
         assert self.ts.dtype == np.dtype('float64')

--- a/pandas/tests/series/test_timeseries.py
+++ b/pandas/tests/series/test_timeseries.py
@@ -134,13 +134,13 @@ class TestTimeSeries(TestData):
         assert res.dtype == 'datetime64[ns, US/Eastern]'
 
         res = s.shift(1)
-        exp_vals = [NaT] + dates.asobject.values.tolist()[:9]
+        exp_vals = [NaT] + dates.astype(object).values.tolist()[:9]
         exp = Series(exp_vals)
         tm.assert_series_equal(res, exp)
         assert res.dtype == 'datetime64[ns, US/Eastern]'
 
         res = s.shift(-2)
-        exp_vals = dates.asobject.values.tolist()[2:] + [NaT, NaT]
+        exp_vals = dates.astype(object).values.tolist()[2:] + [NaT, NaT]
         exp = Series(exp_vals)
         tm.assert_series_equal(res, exp)
         assert res.dtype == 'datetime64[ns, US/Eastern]'

--- a/pandas/tests/test_base.py
+++ b/pandas/tests/test_base.py
@@ -437,7 +437,7 @@ class TestIndexOps(Ops):
                 for r in result:
                     assert isinstance(r, Timestamp)
                 tm.assert_numpy_array_equal(result,
-                                            orig._values.asobject.values)
+                                            orig._values.astype(object).values)
             else:
                 tm.assert_numpy_array_equal(result, orig.values)
 
@@ -525,8 +525,8 @@ class TestIndexOps(Ops):
                                           Index(values[1:], name='a'))
                 elif is_datetimetz(o):
                     # unable to compare NaT / nan
-                    tm.assert_numpy_array_equal(result[1:],
-                                                values[2:].asobject.values)
+                    vals = values[2:].astype(object).values
+                    tm.assert_numpy_array_equal(result[1:], vals)
                     assert result[0] is pd.NaT
                 else:
                     tm.assert_numpy_array_equal(result[1:], values[2:])

--- a/pandas/tests/tseries/test_frequencies.py
+++ b/pandas/tests/tseries/test_frequencies.py
@@ -720,15 +720,15 @@ class TestFrequencyInference(object):
 
     def test_infer_freq(self):
         rng = period_range('1959Q2', '2009Q3', freq='Q')
-        rng = Index(rng.to_timestamp('D', how='e').asobject)
+        rng = Index(rng.to_timestamp('D', how='e').astype(object))
         assert rng.inferred_freq == 'Q-DEC'
 
         rng = period_range('1959Q2', '2009Q3', freq='Q-NOV')
-        rng = Index(rng.to_timestamp('D', how='e').asobject)
+        rng = Index(rng.to_timestamp('D', how='e').astype(object))
         assert rng.inferred_freq == 'Q-NOV'
 
         rng = period_range('1959Q2', '2009Q3', freq='Q-OCT')
-        rng = Index(rng.to_timestamp('D', how='e').asobject)
+        rng = Index(rng.to_timestamp('D', how='e').astype(object))
         assert rng.inferred_freq == 'Q-OCT'
 
     def test_infer_freq_tz(self):

--- a/pandas/tests/tseries/test_timezones.py
+++ b/pandas/tests/tseries/test_timezones.py
@@ -688,7 +688,7 @@ class TestTimeZoneSupportPytz(object):
         # dates around a dst transition
         rng = date_range('2/13/2010', '5/6/2010', tz=self.tzstr('US/Eastern'))
 
-        objs = rng.asobject
+        objs = rng.astype(object)
         for i, x in enumerate(objs):
             exval = rng[i]
             assert x == exval
@@ -1552,8 +1552,8 @@ class TestTimeZones(object):
         ts2 = Series(np.random.randn(len(rng2)), index=rng2)
         ts_result = ts1.append(ts2)
 
-        assert ts_result.index.equals(ts1.index.asobject.append(
-            ts2.index.asobject))
+        assert ts_result.index.equals(ts1.index.astype(object).append(
+            ts2.index.astype(object)))
 
         # mixed
         rng1 = date_range('1/1/2011 01:00', periods=1, freq='H')
@@ -1561,7 +1561,7 @@ class TestTimeZones(object):
         ts1 = Series(np.random.randn(len(rng1)), index=rng1)
         ts2 = Series(np.random.randn(len(rng2)), index=rng2)
         ts_result = ts1.append(ts2)
-        assert ts_result.index.equals(ts1.index.asobject.append(
+        assert ts_result.index.equals(ts1.index.astype(object).append(
             ts2.index))
 
     def test_equal_join_ensure_utc(self):


### PR DESCRIPTION
This PR supersedes #18477. 
closes #18237
 
- [ x] xref #18262
- [x ] tests added / passed
- [ x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ x] whatsnew entry

Deprecate ``Series.asobject`` and ``DatetimeIndexOpsMixin.asobject`` as per discussion in #18262. ``DatetimeIndexOpsMixin`` is a mixin for ``DatetimeIndex``, ``PeriodIndex`` and ``TimeDeltaIndex``, so all the ``.asobject`` property will be deprecated all those classes.

Internal references to ``asobject`` have been cleaned up, so a eventual removal will be easy when that time comes.