### PR TITLE
API/BUG: .apply will correctly infer output shape when axis=1

### DIFF
--- a/doc/source/basics.rst
+++ b/doc/source/basics.rst
@@ -797,8 +797,10 @@ The return type of the function passed to :meth:`~DataFrame.apply` affects the
 type of the ultimate output from DataFrame.apply
 
 * If the applied function returns a ``Series``, the ultimate output is a ``DataFrame``.
-  The columns match the index ``Series`` returned by the applied function.
+  The columns match the index of the ``Series`` returned by the applied function.
 * If the applied function returns any other type, the ultimate output is a ``Series``.
+* A ``result_type`` kwarg is accepted with the options: ``reduce``, ``broadcast``, and ``expand``.
+  These will determine how list-likes return results expand (or not) to a ``DataFrame``.
 
 :meth:`~DataFrame.apply` combined with some cleverness can be used to answer many questions
 about a data set. For example, suppose we wanted to extract the date where the

--- a/doc/source/basics.rst
+++ b/doc/source/basics.rst
@@ -793,8 +793,12 @@ The :meth:`~DataFrame.apply` method will also dispatch on a string method name.
    df.apply('mean')
    df.apply('mean', axis=1)
 
-Depending on the return type of the function passed to :meth:`~DataFrame.apply`,
-the result will either be of lower dimension or the same dimension.
+The return type of the function passed to :meth:`~DataFrame.apply` affects the
+type of the ultimate output from DataFrame.apply
+
+* If the applied function returns a ``Series``, the ultimate output is a ``DataFrame``.
+  The columns match the index ``Series`` returned by the applied function.
+* If the applied function returns any other type, the ultimate output is a ``Series``.
 
 :meth:`~DataFrame.apply` combined with some cleverness can be used to answer many questions
 about a data set. For example, suppose we wanted to extract the date where the

--- a/doc/source/whatsnew/v0.23.0.txt
+++ b/doc/source/whatsnew/v0.23.0.txt
@@ -524,6 +524,7 @@ Deprecations
 - ``IntervalIndex.from_intervals`` is deprecated in favor of the :class:`IntervalIndex` constructor (:issue:`19263`)
 - :func:``DataFrame.from_items`` is deprecated. Use :func:``DataFrame.from_dict()`` instead, or :func:``DataFrame.from_dict(OrderedDict())`` if you wish to preserve the key order (:issue:`17320`)
 - The ``broadcast`` parameter of ``.apply()`` is removed in favor of ``result_type='broadcast'`` (:issue:`18577`)
+- The ``reduce`` parameter of ``.apply()`` is removed in favor of ``result_type='reduce'`` (:issue:`18577`)
 
 .. _whatsnew_0230.prior_deprecations:
 

--- a/doc/source/whatsnew/v0.23.0.txt
+++ b/doc/source/whatsnew/v0.23.0.txt
@@ -380,11 +380,11 @@ New Behavior. The behavior is consistent. These will *always* return a ``Series`
     df.apply(lambda x: [1, 2, 3], axis=1)
     df.apply(lambda x: [1, 2], axis=1)
 
-To have expanded columns, you can use ``result_type='infer'``
+To have expanded columns, you can use ``result_type='expand'``
 
 .. ipython:: python
 
-    df.apply(lambda x: [1, 2, 3], axis=1, result_type='infer')
+    df.apply(lambda x: [1, 2, 3], axis=1, result_type='expand')
 
 To have broadcast the result across, you can use ``result_type='broadcast'``. The shape
 must match the original columns.

--- a/doc/source/whatsnew/v0.23.0.txt
+++ b/doc/source/whatsnew/v0.23.0.txt
@@ -142,7 +142,7 @@ Previous Behavior:
     4    NaN
     dtype: float64
 
-Current Behavior
+Current Behavior:
 
 .. ipython:: python
 
@@ -167,7 +167,7 @@ Previous Behavior:
     3    2.5
     dtype: float64
 
-Current Behavior
+Current Behavior:
 
 .. ipython:: python
 
@@ -332,6 +332,59 @@ Convert to an xarray DataArray
 
    p.to_xarray()
 
+.. _whatsnew_0230.api_breaking.apply:
+
+Apply Changes
+~~~~~~~~~~~~~
+
+:func:`DataFrame.apply` was inconsistent when applying an arbitrary user-defined-function that returned a list-like with ``axis=1``. Several bugs and inconsistencies
+are resolved. If the applied function returns a Series, then pandas will return a DataFrame; otherwise a Series will be returned, this includes the case
+where a list-like (e.g. ``tuple`` or ``list`` is returned), (:issue:`16353`, :issue:`17437`, :issue:`17970`, :issue:`17348`, :issue:`17892`, :issue:`18573`,
+:issue:`17602`, :issue:`18775`, :issue:`18901`, :issue:`18919`)
+
+.. ipython:: python
+
+    df = pd.DataFrame(np.tile(np.arange(3), 6).reshape(6, -1) + 1, columns=['A', 'B', 'C'])
+    df
+
+Previous Behavior. If the returned shape happened to match the index, this would return a list-like.
+
+.. code-block:: python
+
+   In [3]: df.apply(lambda x: [1, 2, 3], axis=1)
+   Out[3]:
+      A  B  C
+   0  1  2  3
+   1  1  2  3
+   2  1  2  3
+   3  1  2  3
+   4  1  2  3
+   5  1  2  3
+
+   In [4]: df.apply(lambda x: [1, 2], axis=1)
+   Out[4]:
+   0    [1, 2]
+   1    [1, 2]
+   2    [1, 2]
+   3    [1, 2]
+   4    [1, 2]
+   5    [1, 2]
+   dtype: object
+
+
+New Behavior. The behavior is consistent. These will *always* return a ``Series``.
+
+.. ipython:: python
+
+    df.apply(lambda x: [1, 2, 3], axis=1)
+    df.apply(lambda x: [1, 2], axis=1)
+
+To have automatic inference, you can use ``result_type='infer'``
+
+.. ipython:: python
+
+    df.apply(lambda x: [1, 2, 3], axis=1, result_type='infer')
+
 
 .. _whatsnew_0230.api_breaking.build_changes:
 
@@ -456,6 +509,7 @@ Deprecations
 - The ``is_copy`` attribute is deprecated and will be removed in a future version (:issue:`18801`).
 - ``IntervalIndex.from_intervals`` is deprecated in favor of the :class:`IntervalIndex` constructor (:issue:`19263`)
 - :func:``DataFrame.from_items`` is deprecated. Use :func:``DataFrame.from_dict()`` instead, or :func:``DataFrame.from_dict(OrderedDict())`` if you wish to preserve the key order (:issue:`17320`)
+- The ``broadcast`` parameter of ``.apply()`` is removed in favor of ``result_type='broadcast'`` (:issue:`18577`)
 
 .. _whatsnew_0230.prior_deprecations:
 

--- a/doc/source/whatsnew/v0.23.0.txt
+++ b/doc/source/whatsnew/v0.23.0.txt
@@ -347,7 +347,8 @@ where a list-like (e.g. ``tuple`` or ``list`` is returned), (:issue:`16353`, :is
     df = pd.DataFrame(np.tile(np.arange(3), 6).reshape(6, -1) + 1, columns=['A', 'B', 'C'])
     df
 
-Previous Behavior. If the returned shape happened to match the index, this would return a list-like.
+Previous Behavior. If the returned shape happened to match the original columns, this would return a ``DataFrame``.
+If the return shape did not match, a ``Series`` with lists was returned.
 
 .. code-block:: python
 
@@ -379,11 +380,24 @@ New Behavior. The behavior is consistent. These will *always* return a ``Series`
     df.apply(lambda x: [1, 2, 3], axis=1)
     df.apply(lambda x: [1, 2], axis=1)
 
-To have automatic inference, you can use ``result_type='infer'``
+To have expanded columns, you can use ``result_type='infer'``
 
 .. ipython:: python
 
     df.apply(lambda x: [1, 2, 3], axis=1, result_type='infer')
+
+To have broadcast the result across, you can use ``result_type='broadcast'``. The shape
+must match the original columns.
+
+.. ipython:: python
+
+    df.apply(lambda x: [1, 2, 3], axis=1, result_type='broadcast')
+
+Returning a ``Series`` allows one to control the exact return structure and column names:
+
+.. ipython:: python
+
+    df.apply(lambda x: Series([1, 2, 3], index=x.index), axis=1)
 
 
 .. _whatsnew_0230.api_breaking.build_changes:

--- a/pandas/core/apply.py
+++ b/pandas/core/apply.py
@@ -39,6 +39,10 @@ class FrameApply(object):
         self.args = args or ()
         self.kwds = kwds or {}
 
+        if result_type not in [None, 'reduce', 'broadcast', 'expand']:
+            raise ValueError("invalid value for result_type, must be one "
+                             "of {None, 'reduce', 'broadcast', 'expand'}")
+
         if broadcast is not None:
             warnings.warn("The broadcast argument is deprecated and will "
                           "be removed in a future version. You can specify "

--- a/pandas/core/apply.py
+++ b/pandas/core/apply.py
@@ -187,7 +187,6 @@ class FrameApply(object):
         # axis which we want to compare compliance
         result_compare = target.shape[0]
 
-        index = None
         for i, col in enumerate(target.columns):
             res = self.f(target[col])
             ares = np. asarray(res).ndim
@@ -201,19 +200,11 @@ class FrameApply(object):
                 if result_compare != len(res):
                     raise ValueError("cannot broadcast result")
 
-                # if we have a Series result, then then index
-                # is our result
-                if isinstance(res, ABCSeries):
-                    index = res.index
-
             result_values[:, i] = res
 
-        # if we are returning a list-like
-        # then preserve the original index
-        if index is None:
-            index = target.index
-
-        result = self.obj._constructor(result_values, index=index,
+        # we *always* preserve the original index / columns
+        result = self.obj._constructor(result_values,
+                                       index=target.index,
                                        columns=target.columns)
         return result
 

--- a/pandas/core/apply.py
+++ b/pandas/core/apply.py
@@ -358,8 +358,8 @@ class FrameColumnApply(FrameApply):
         """ return the results for the columns """
         results = self.results
 
-        # we have requested inference
-        if self.result_type == 'infer':
+        # we have requested to expand
+        if self.result_type == 'expand':
             result = self.infer_to_same_shape()
 
         # we have a non-series and don't want inference

--- a/pandas/core/apply.py
+++ b/pandas/core/apply.py
@@ -187,7 +187,7 @@ class FrameApply(object):
         # axis which we want to compare compliance
         result_compare = target.shape[0]
 
-        index = target.index
+        index = None
         for i, col in enumerate(target.columns):
             res = self.f(target[col])
             ares = np. asarray(res).ndim
@@ -207,6 +207,11 @@ class FrameApply(object):
                     index = res.index
 
             result_values[:, i] = res
+
+        # if we are returning a list-like
+        # then preserve the original index
+        if index is None:
+            index = target.index
 
         result = self.obj._constructor(result_values, index=index,
                                        columns=target.columns)

--- a/pandas/core/apply.py
+++ b/pandas/core/apply.py
@@ -1,15 +1,20 @@
+import warnings
 import numpy as np
 from pandas import compat
 from pandas._libs import reduction
+from pandas.core.dtypes.generic import ABCSeries
 from pandas.core.dtypes.common import (
     is_extension_type,
     is_sequence)
+from pandas.util._decorators import cache_readonly
 
 from pandas.io.formats.printing import pprint_thing
 
 
-def frame_apply(obj, func, axis=0, broadcast=False,
-                raw=False, reduce=None, args=(), **kwds):
+def frame_apply(obj, func, axis=0, broadcast=None,
+                raw=False, reduce=None, result_type=None,
+                ignore_failures=False,
+                args=None, kwds=None):
     """ construct and return a row or column based frame apply object """
 
     axis = obj._get_axis_number(axis)
@@ -19,20 +24,31 @@ def frame_apply(obj, func, axis=0, broadcast=False,
         klass = FrameColumnApply
 
     return klass(obj, func, broadcast=broadcast,
-                 raw=raw, reduce=reduce, args=args, kwds=kwds)
+                 raw=raw, reduce=reduce, result_type=result_type,
+                 ignore_failures=ignore_failures,
+                 args=args, kwds=kwds)
 
 
 class FrameApply(object):
 
-    def __init__(self, obj, func, broadcast, raw, reduce, args, kwds):
+    def __init__(self, obj, func, broadcast, raw, reduce, result_type,
+                 ignore_failures, args, kwds):
         self.obj = obj
-        self.broadcast = broadcast
         self.raw = raw
         self.reduce = reduce
-        self.args = args
+        self.ignore_failures = ignore_failures
+        self.args = args or ()
+        self.kwds = kwds or {}
 
-        self.ignore_failures = kwds.pop('ignore_failures', False)
-        self.kwds = kwds
+        if broadcast is not None:
+            warnings.warn("The broadcast argument is deprecated and will "
+                          "be removed in a future version. You can specify "
+                          "result_type='broadcast' broadcast a scalar result",
+                          FutureWarning, stacklevel=4)
+            if broadcast:
+                result_type = 'broadcast'
+
+        self.result_type = result_type
 
         # curry if needed
         if kwds or args and not isinstance(func, np.ufunc):
@@ -43,6 +59,11 @@ class FrameApply(object):
 
         self.f = f
 
+        # results
+        self.result = None
+        self.res_index = None
+        self.res_columns = None
+
     @property
     def columns(self):
         return self.obj.columns
@@ -51,9 +72,13 @@ class FrameApply(object):
     def index(self):
         return self.obj.index
 
-    @property
+    @cache_readonly
     def values(self):
         return self.obj.values
+
+    @cache_readonly
+    def dtypes(self):
+        return self.obj.dtypes
 
     @property
     def agg_axis(self):
@@ -68,8 +93,7 @@ class FrameApply(object):
 
         # string dispatch
         if isinstance(self.f, compat.string_types):
-            if self.axis:
-                self.kwds['axis'] = self.axis
+            self.kwds['axis'] = self.axis
             return getattr(self.obj, self.f)(*self.args, **self.kwds)
 
         # ufunc
@@ -80,20 +104,27 @@ class FrameApply(object):
                                          columns=self.columns, copy=False)
 
         # broadcasting
-        if self.broadcast:
+        if self.result_type == 'broadcast':
             return self.apply_broadcast()
 
         # one axis empty
-        if not all(self.obj.shape):
+        elif not all(self.obj.shape):
             return self.apply_empty_result()
 
         # raw
-        if self.raw and not self.obj._is_mixed_type:
+        elif self.raw and not self.obj._is_mixed_type:
             return self.apply_raw()
 
         return self.apply_standard()
 
     def apply_empty_result(self):
+        """
+        we have an empty result; at least 1 axis is 0
+
+        we will try to apply the function to an empty
+        series in order to see if this is a reduction function
+        """
+
         from pandas import Series
         reduce = self.reduce
 
@@ -113,6 +144,8 @@ class FrameApply(object):
             return self.obj.copy()
 
     def apply_raw(self):
+        """ apply to the values as a numpy array """
+
         try:
             result = reduction.reduce(self.values, self.f, axis=self.axis)
         except Exception:
@@ -125,9 +158,17 @@ class FrameApply(object):
         else:
             return Series(result, index=self.agg_axis)
 
-    def apply_standard(self):
-        from pandas import Series
+    def apply_broadcast(self, target):
+        result_values = np.empty_like(target.values)
+        columns = target.columns
+        for i, col in enumerate(columns):
+            result_values[:, i] = self.f(target[col])
 
+        result = self.obj._constructor(result_values, index=target.index,
+                                       columns=target.columns)
+        return result
+
+    def apply_standard(self):
         reduce = self.reduce
         if reduce is None:
             reduce = True
@@ -135,39 +176,39 @@ class FrameApply(object):
         # try to reduce first (by default)
         # this only matters if the reduction in values is of different dtype
         # e.g. if we want to apply to a SparseFrame, then can't directly reduce
-        if reduce:
+
+        # we cannot reduce using non-numpy dtypes,
+        # as demonstrated in gh-12244
+        if (reduce and
+                self.result_type is None and
+                not self.dtypes.apply(is_extension_type).any()):
+
+            # Create a dummy Series from an empty array
+            from pandas import Series
             values = self.values
+            index = self.obj._get_axis(self.axis)
+            labels = self.agg_axis
+            empty_arr = np.empty(len(index), dtype=values.dtype)
+            dummy = Series(empty_arr, index=index, dtype=values.dtype)
 
-            # we cannot reduce using non-numpy dtypes,
-            # as demonstrated in gh-12244
-            if not is_extension_type(values):
-
-                # Create a dummy Series from an empty array
-                index = self.obj._get_axis(self.axis)
-                empty_arr = np.empty(len(index), dtype=values.dtype)
-
-                dummy = Series(empty_arr, index=index, dtype=values.dtype)
-
-                try:
-                    labels = self.agg_axis
-                    result = reduction.reduce(values, self.f,
-                                              axis=self.axis,
-                                              dummy=dummy,
-                                              labels=labels)
-                    return Series(result, index=labels)
-                except Exception:
-                    pass
+            try:
+                result = reduction.reduce(values, self.f,
+                                          axis=self.axis,
+                                          dummy=dummy,
+                                          labels=labels)
+                return Series(result, index=labels)
+            except Exception:
+                pass
 
         # compute the result using the series generator
-        results, res_index, res_columns = self._apply_series_generator()
+        self.apply_series_generator()
 
         # wrap results
-        return self.wrap_results(results, res_index, res_columns)
+        return self.wrap_results()
 
-    def _apply_series_generator(self):
+    def apply_series_generator(self):
         series_gen = self.series_generator
         res_index = self.result_index
-        res_columns = self.result_columns
 
         i = None
         keys = []
@@ -201,40 +242,23 @@ class FrameApply(object):
                                            pprint_thing(k), )
                 raise
 
-        return results, res_index, res_columns
+        self.results = results
+        self.res_index = res_index
+        self.res_columns = self.result_columns
 
-    def wrap_results(self, results, res_index, res_columns):
-        from pandas import Series
+    def wrap_results(self):
+        results = self.results
 
+        # see if we can infer the results
         if len(results) > 0 and is_sequence(results[0]):
-            if not isinstance(results[0], Series):
-                index = res_columns
-            else:
-                index = None
 
-            result = self.obj._constructor(data=results, index=index)
-            result.columns = res_index
+            return self.wrap_results_for_axis()
 
-            if self.axis == 1:
-                result = result.T
-            result = result._convert(
-                datetime=True, timedelta=True, copy=False)
+        # dict of scalars
+        from pandas import Series
+        result = Series(results)
+        result.index = self.res_index
 
-        else:
-
-            result = Series(results)
-            result.index = res_index
-
-        return result
-
-    def _apply_broadcast(self, target):
-        result_values = np.empty_like(target.values)
-        columns = target.columns
-        for i, col in enumerate(columns):
-            result_values[:, i] = self.f(target[col])
-
-        result = self.obj._constructor(result_values, index=target.index,
-                                       columns=target.columns)
         return result
 
 
@@ -251,7 +275,7 @@ class FrameRowApply(FrameApply):
         return super(FrameRowApply, self).get_result()
 
     def apply_broadcast(self):
-        return self._apply_broadcast(self.obj)
+        return super(FrameRowApply, self).apply_broadcast(self.obj)
 
     @property
     def series_generator(self):
@@ -266,29 +290,37 @@ class FrameRowApply(FrameApply):
     def result_columns(self):
         return self.index
 
+    def wrap_results_for_axis(self):
+        """ return the results for the rows """
+
+        results = self.results
+        result = self.obj._constructor(data=results)
+
+        if not isinstance(results[0], ABCSeries):
+            try:
+                result.index = self.res_columns
+            except ValueError:
+                pass
+
+        try:
+            result.columns = self.res_index
+        except ValueError:
+            pass
+
+        return result
+
 
 class FrameColumnApply(FrameApply):
     axis = 1
 
-    def __init__(self, obj, func, broadcast, raw, reduce, args, kwds):
-        super(FrameColumnApply, self).__init__(obj, func, broadcast,
-                                               raw, reduce, args, kwds)
-
-        # skip if we are mixed datelike and trying reduce across axes
-        # GH6125
-        if self.reduce:
-            if self.obj._is_mixed_type and self.obj._is_datelike_mixed_type:
-                self.reduce = False
-
     def apply_broadcast(self):
-        return self._apply_broadcast(self.obj.T).T
+        result = super(FrameColumnApply, self).apply_broadcast(self.obj.T)
+        return result.T
 
     @property
     def series_generator(self):
-        from pandas import Series
-        dtype = object if self.obj._is_mixed_type else None
-        return (Series._from_array(arr, index=self.columns, name=name,
-                                   dtype=dtype)
+        constructor = self.obj._constructor_sliced
+        return (constructor(arr, index=self.columns, name=name)
                 for i, (arr, name) in enumerate(zip(self.values,
                                                     self.index)))
 
@@ -299,3 +331,39 @@ class FrameColumnApply(FrameApply):
     @property
     def result_columns(self):
         return self.columns
+
+    def wrap_results_for_axis(self):
+        """ return the results for the columns """
+        results = self.results
+
+        # we have requested inference
+        if self.result_type == 'infer':
+            result = self.infer_to_same_shape()
+
+        # we have a non-series and don't want inference
+        elif not isinstance(results[0], ABCSeries):
+            from pandas import Series
+
+            result = Series(results)
+            result.index = self.res_index
+
+        # we may want to infer results
+        else:
+            result = self.infer_to_same_shape()
+
+        return result
+
+    def infer_to_same_shape(self):
+        """ infer the results to the same shape as the input object """
+        results = self.results
+
+        result = self.obj._constructor(data=results)
+        result = result.T
+
+        # set the index
+        result.index = self.res_index
+
+        # infer dtypes
+        result = result.infer_objects()
+
+        return result

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -4870,10 +4870,11 @@ class DataFrame(NDFrame):
             while guessing, exceptions raised by func will be ignored). If
             reduce is True a Series will always be returned, and if False a
             DataFrame will always be returned.
+
         result_type : {'infer', 'broadcast, None}
             These only act when axis=1 {columns}
-            * infer : list-like results will be turned into columns
-            * broadcast : scalar results will be broadcast to all rows
+            * 'infer' : list-like results will be turned into columns
+            * 'broadcast' : scalar results will be broadcast to all columns
             * None : list-like results will be returned as a list
               in a single column. However if the apply function
               returns a Series these are expanded to columns.

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -4871,9 +4871,9 @@ class DataFrame(NDFrame):
             reduce is True a Series will always be returned, and if False a
             DataFrame will always be returned.
 
-        result_type : {'infer', 'broadcast, None}
+        result_type : {'expand', 'broadcast, None}
             These only act when axis=1 {columns}
-            * 'infer' : list-like results will be turned into columns
+            * 'expand' : list-like results will be turned into columns
             * 'broadcast' : scalar results will be broadcast to all columns
             * None : list-like results will be returned as a list
               in a single column. However if the apply function
@@ -4948,10 +4948,10 @@ class DataFrame(NDFrame):
         4    [1, 2]
         5    [1, 2]
 
-        Passing result_type='infer' will expand list-like results
+        Passing result_type='expand' will expand list-like results
         to columns of a Dataframe
 
-        >>> df.apply(lambda x: [1, 2], axis=1, result_type='infer')
+        >>> df.apply(lambda x: [1, 2], axis=1, result_type='expand')
            0  1
         0  1  2
         1  1  2

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -4871,9 +4871,15 @@ class DataFrame(NDFrame):
             reduce is True a Series will always be returned, and if False a
             DataFrame will always be returned.
 
-        result_type : {'expand', 'broadcast, None}
+            .. deprecated:: 0.23.0
+               This argument will be removed in a future version, replaced
+               by result_type='reduce'.
+
+        result_type : {'expand', 'reduce', 'broadcast, None}
             These only act when axis=1 {columns}
             * 'expand' : list-like results will be turned into columns
+            * 'reduce' : return a Series if possible rather than expanding
+              list-like results. This is the opposite to 'expand'
             * 'broadcast' : scalar results will be broadcast to all columns
             * None : list-like results will be returned as a list
               in a single column. However if the apply function
@@ -5686,7 +5692,7 @@ class DataFrame(NDFrame):
                         from pandas.core.apply import frame_apply
                         opa = frame_apply(self,
                                           func=f,
-                                          reduce=False,
+                                          result_type='expand',
                                           ignore_failures=True)
                         result = opa.get_result()
                         if result.ndim == self.ndim:

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -4877,10 +4877,11 @@ class DataFrame(NDFrame):
 
         result_type : {'expand', 'reduce', 'broadcast, None}
             These only act when axis=1 {columns}
-            * 'expand' : list-like results will be turned into columns
+            * 'expand' : list-like results will be turned into columns.
             * 'reduce' : return a Series if possible rather than expanding
-              list-like results. This is the opposite to 'expand'
-            * 'broadcast' : scalar results will be broadcast to all columns
+              list-like results. This is the opposite to 'expand'.
+            * 'broadcast' : results will be broadcast to the original shape
+              of the frame, the original index & columns will be retained.
             * None : list-like results will be returned as a list
               in a single column. However if the apply function
               returns a Series these are expanded to columns.

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -4966,6 +4966,33 @@ class DataFrame(NDFrame):
         4  1  2
         5  1  2
 
+        Return a Series inside the function is similar to passing
+        Passing result_type='expand'. The resulting column names
+        will be the Series index.
+
+        >>> df.apply(lambda x: Series([1, 2], index=['foo', 'bar']), axis=1)
+           foo  bar
+        0    1    2
+        1    1    2
+        2    1    2
+        3    1    2
+        4    1    2
+        5    1    2
+
+
+        Passing result_type='broadcast' will take a same shape
+        result, whether list-like or scalar and broadcast it
+        along the axis. The resulting column names will be the originals.
+
+        >>> df.apply(lambda x: [1, 2, 3], axis=1, result_type='broadcast')
+           A  B  C
+        0  1  2  3
+        1  1  2  3
+        2  1  2  3
+        3  1  2  3
+        4  1  2  3
+        5  1  2  3
+
         See also
         --------
         DataFrame.applymap: For elementwise operations

--- a/pandas/core/sparse/frame.py
+++ b/pandas/core/sparse/frame.py
@@ -853,9 +853,9 @@ class SparseDataFrame(DataFrame):
                This argument will be removed in a future version, replaced
                by result_type='broadcast'.
 
-        result_type : {'infer', 'broadcast, None}
+        result_type : {'expand', 'broadcast, None}
             These only act when axis=1 {columns}
-            * 'infer' : list-like results will be turned into columns
+            * 'expand' : list-like results will be turned into columns
             * 'broadcast' : scalar results will be broadcast to all columns
             * None : list-like results will be returned as a list
               in a single column. However if the apply function

--- a/pandas/core/sparse/frame.py
+++ b/pandas/core/sparse/frame.py
@@ -835,7 +835,8 @@ class SparseDataFrame(DataFrame):
         return self._apply_columns(lambda x: x.notna())
     notnull = notna
 
-    def apply(self, func, axis=0, broadcast=False, reduce=False):
+    def apply(self, func, axis=0, broadcast=None, reduce=False,
+              result_type=None):
         """
         Analogous to DataFrame.apply, for SparseDataFrame
 
@@ -847,6 +848,20 @@ class SparseDataFrame(DataFrame):
         broadcast : bool, default False
             For aggregation functions, return object of same size with values
             propagated
+
+            .. deprecated:: 0.23.0
+               This argument will be removed in a future version, replaced
+               by result_type='broadcast'.
+
+        result_type : {'infer', 'broadcast, None}
+            These only act when axis=1 {columns}
+            * infer : list-like results will be turned into columns
+            * broadcast : scalar results will be broadcast to all rows
+            * None : list-like results will be returned as a list
+              in a single column. However if the apply function
+              returns a Series these are expanded to columns.
+
+            .. versionadded:: 0.23.0
 
         Returns
         -------
@@ -871,12 +886,10 @@ class SparseDataFrame(DataFrame):
         op = frame_apply(self,
                          func=func,
                          axis=axis,
-                         reduce=reduce)
-
-        if broadcast:
-            return op.apply_broadcast()
-
-        return op.apply_standard()
+                         reduce=reduce,
+                         broadcast=broadcast,
+                         result_type=result_type)
+        return op.get_result()
 
     def applymap(self, func):
         """

--- a/pandas/core/sparse/frame.py
+++ b/pandas/core/sparse/frame.py
@@ -855,8 +855,8 @@ class SparseDataFrame(DataFrame):
 
         result_type : {'infer', 'broadcast, None}
             These only act when axis=1 {columns}
-            * infer : list-like results will be turned into columns
-            * broadcast : scalar results will be broadcast to all rows
+            * 'infer' : list-like results will be turned into columns
+            * 'broadcast' : scalar results will be broadcast to all columns
             * None : list-like results will be returned as a list
               in a single column. However if the apply function
               returns a Series these are expanded to columns.

--- a/pandas/core/sparse/frame.py
+++ b/pandas/core/sparse/frame.py
@@ -835,7 +835,7 @@ class SparseDataFrame(DataFrame):
         return self._apply_columns(lambda x: x.notna())
     notnull = notna
 
-    def apply(self, func, axis=0, broadcast=None, reduce=False,
+    def apply(self, func, axis=0, broadcast=None, reduce=None,
               result_type=None):
         """
         Analogous to DataFrame.apply, for SparseDataFrame
@@ -853,9 +853,24 @@ class SparseDataFrame(DataFrame):
                This argument will be removed in a future version, replaced
                by result_type='broadcast'.
 
-        result_type : {'expand', 'broadcast, None}
+        reduce : boolean or None, default None
+            Try to apply reduction procedures. If the DataFrame is empty,
+            apply will use reduce to determine whether the result should be a
+            Series or a DataFrame. If reduce is None (the default), apply's
+            return value will be guessed by calling func an empty Series (note:
+            while guessing, exceptions raised by func will be ignored). If
+            reduce is True a Series will always be returned, and if False a
+            DataFrame will always be returned.
+
+            .. deprecated:: 0.23.0
+               This argument will be removed in a future version, replaced
+               by result_type='reduce'.
+
+        result_type : {'expand', 'reduce', 'broadcast, None}
             These only act when axis=1 {columns}
             * 'expand' : list-like results will be turned into columns
+            * 'reduce' : return a Series if possible rather than expanding
+              list-like results. This is the opposite to 'expand'
             * 'broadcast' : scalar results will be broadcast to all columns
             * None : list-like results will be returned as a list
               in a single column. However if the apply function

--- a/pandas/io/formats/style.py
+++ b/pandas/io/formats/style.py
@@ -510,7 +510,7 @@ class Styler(object):
         data = self.data.loc[subset]
         if axis is not None:
             result = data.apply(func, axis=axis,
-                                result_type='infer', **kwargs)
+                                result_type='expand', **kwargs)
             result.columns = data.columns
         else:
             result = func(data, **kwargs)

--- a/pandas/io/formats/style.py
+++ b/pandas/io/formats/style.py
@@ -509,7 +509,9 @@ class Styler(object):
         subset = _non_reducing_slice(subset)
         data = self.data.loc[subset]
         if axis is not None:
-            result = data.apply(func, axis=axis, **kwargs)
+            result = data.apply(func, axis=axis,
+                                result_type='infer', **kwargs)
+            result.columns = data.columns
         else:
             result = func(data, **kwargs)
             if not isinstance(result, pd.DataFrame):

--- a/pandas/tests/frame/test_apply.py
+++ b/pandas/tests/frame/test_apply.py
@@ -750,6 +750,18 @@ class TestInferOutputShape(object):
         expected.columns = columns
         assert_frame_equal(result, expected)
 
+    @pytest.mark.parametrize("result_type", ['foo', 1])
+    def test_result_type_error(self, result_type):
+        # allowed result_type
+        df = DataFrame(
+            np.tile(np.arange(3, dtype='int64'), 6).reshape(6, -1) + 1,
+            columns=['A', 'B', 'C'])
+
+        with pytest.raises(ValueError):
+            df.apply(lambda x: [1, 2, 3],
+                     axis=1,
+                     result_type=result_type)
+
     @pytest.mark.parametrize(
         "box",
         [lambda x: list(x),

--- a/pandas/tests/frame/test_apply.py
+++ b/pandas/tests/frame/test_apply.py
@@ -171,14 +171,12 @@ class TestDataFrameApply(TestData):
                           result_type='broadcast')
         tm.assert_frame_equal(result, df)
 
-        # columms come from the returned Series
         df = DataFrame(np.tile(np.arange(3), 6).reshape(6, -1) + 1,
                        columns=list('ABC'))
         result = df.apply(lambda x: Series([1, 2, 3], index=list('abc')),
                           axis=1,
                           result_type='broadcast')
         expected = df.copy()
-        expected.columns = list('abc')
         tm.assert_frame_equal(result, expected)
 
     def test_apply_broadcast_error(self):
@@ -756,7 +754,6 @@ class TestInferOutputShape(object):
             axis=1,
             result_type='broadcast')
         expected = df.copy()
-        expected.columns = columns
         assert_frame_equal(result, expected)
 
         # series result

--- a/pandas/tests/frame/test_apply.py
+++ b/pandas/tests/frame/test_apply.py
@@ -82,23 +82,29 @@ class TestDataFrameApply(TestData):
         rs = xp.apply(lambda x: x['a'], axis=1)
         assert_frame_equal(xp, rs)
 
+    def test_apply_with_reduce_empty(self):
         # reduce with an empty DataFrame
         x = []
-        result = self.empty.apply(x.append, axis=1, reduce=False)
+        result = self.empty.apply(x.append, axis=1, result_type='expand')
         assert_frame_equal(result, self.empty)
-        result = self.empty.apply(x.append, axis=1, reduce=True)
+        result = self.empty.apply(x.append, axis=1, result_type='reduce')
         assert_series_equal(result, Series(
             [], index=pd.Index([], dtype=object)))
 
         empty_with_cols = DataFrame(columns=['a', 'b', 'c'])
-        result = empty_with_cols.apply(x.append, axis=1, reduce=False)
+        result = empty_with_cols.apply(x.append, axis=1, result_type='expand')
         assert_frame_equal(result, empty_with_cols)
-        result = empty_with_cols.apply(x.append, axis=1, reduce=True)
+        result = empty_with_cols.apply(x.append, axis=1, result_type='reduce')
         assert_series_equal(result, Series(
             [], index=pd.Index([], dtype=object)))
 
         # Ensure that x.append hasn't been called
         assert x == []
+
+    def test_apply_deprecate_reduce(self):
+        with warnings.catch_warnings(record=True):
+            x = []
+            self.empty.apply(x.append, axis=1, result_type='reduce')
 
     def test_apply_standard_nonunique(self):
         df = DataFrame(
@@ -419,9 +425,9 @@ class TestDataFrameApply(TestData):
         fn = lambda x: x.to_dict()
 
         for df, dicts in [(A, A_dicts), (B, B_dicts)]:
-            reduce_true = df.apply(fn, reduce=True)
-            reduce_false = df.apply(fn, reduce=False)
-            reduce_none = df.apply(fn, reduce=None)
+            reduce_true = df.apply(fn, result_type='reduce')
+            reduce_false = df.apply(fn, result_type='expand')
+            reduce_none = df.apply(fn)
 
             assert_series_equal(reduce_true, dicts)
             assert_frame_equal(reduce_false, df)

--- a/pandas/tests/frame/test_apply.py
+++ b/pandas/tests/frame/test_apply.py
@@ -509,14 +509,16 @@ class TestInferOutputShape(object):
 
     def test_with_dictlike_columns(self):
         # gh 17602
-
         df = DataFrame([[1, 2], [1, 2]], columns=['a', 'b'])
-        result = df.apply(lambda x: {'s': x['a'] + x['b']}, 1)
+        result = df.apply(lambda x: {'s': x['a'] + x['b']},
+                          axis=1)
         expected = Series([{'s': 3} for t in df.itertuples()])
         assert_series_equal(result, expected)
 
         df['tm'] = [pd.Timestamp('2017-05-01 00:00:00'),
                     pd.Timestamp('2017-05-02 00:00:00')]
+        result = df.apply(lambda x: {'s': x['a'] + x['b']},
+                          axis=1)
         assert_series_equal(result, expected)
 
         # compose a series
@@ -534,6 +536,20 @@ class TestInferOutputShape(object):
         result = df.apply(lambda x: {}, axis=1)
         expected = Series([{}, {}, {}])
         assert_series_equal(result, expected)
+
+    def test_with_dictlike_columns_with_infer(self):
+        # gh 17602
+        df = DataFrame([[1, 2], [1, 2]], columns=['a', 'b'])
+        result = df.apply(lambda x: {'s': x['a'] + x['b']},
+                          axis=1, result_type='infer')
+        expected = DataFrame({'s': [3, 3]})
+        assert_frame_equal(result, expected)
+
+        df['tm'] = [pd.Timestamp('2017-05-01 00:00:00'),
+                    pd.Timestamp('2017-05-02 00:00:00')]
+        result = df.apply(lambda x: {'s': x['a'] + x['b']},
+                          axis=1, result_type='infer')
+        assert_frame_equal(result, expected)
 
     def test_with_listlike_columns(self):
         # gh-17348

--- a/pandas/tests/frame/test_apply.py
+++ b/pandas/tests/frame/test_apply.py
@@ -198,6 +198,11 @@ class TestDataFrameApply(TestData):
                      axis=1,
                      result_type='broadcast')
 
+        with pytest.raises(ValueError):
+            df.apply(lambda x: Series([1, 2]),
+                     axis=1,
+                     result_type='broadcast')
+
     def test_apply_raw(self):
         result0 = self.frame.apply(np.mean, raw=True)
         result1 = self.frame.apply(np.mean, axis=1, raw=True)

--- a/pandas/tests/frame/test_apply.py
+++ b/pandas/tests/frame/test_apply.py
@@ -576,14 +576,14 @@ class TestInferOutputShape(object):
         # gh 17602
         df = DataFrame([[1, 2], [1, 2]], columns=['a', 'b'])
         result = df.apply(lambda x: {'s': x['a'] + x['b']},
-                          axis=1, result_type='infer')
+                          axis=1, result_type='expand')
         expected = DataFrame({'s': [3, 3]})
         assert_frame_equal(result, expected)
 
         df['tm'] = [pd.Timestamp('2017-05-01 00:00:00'),
                     pd.Timestamp('2017-05-02 00:00:00')]
         result = df.apply(lambda x: {'s': x['a'] + x['b']},
-                          axis=1, result_type='infer')
+                          axis=1, result_type='expand')
         assert_frame_equal(result, expected)
 
     def test_with_listlike_columns(self):
@@ -705,12 +705,12 @@ class TestInferOutputShape(object):
             np.tile(np.arange(3, dtype='int64'), 6).reshape(6, -1) + 1,
             columns=['A', 'B', 'C'])
 
-        result = df.apply(lambda x: [1, 2, 3], axis=1, result_type='infer')
+        result = df.apply(lambda x: [1, 2, 3], axis=1, result_type='expand')
         expected = df.copy()
         expected.columns = [0, 1, 2]
         assert_frame_equal(result, expected)
 
-        result = df.apply(lambda x: [1, 2], axis=1, result_type='infer')
+        result = df.apply(lambda x: [1, 2], axis=1, result_type='expand')
         expected = df[['A', 'B']].copy()
         expected.columns = [0, 1]
         assert_frame_equal(result, expected)
@@ -760,7 +760,7 @@ class TestInferOutputShape(object):
         expected = Series([box([1, 2]) for t in df.itertuples()])
         assert_series_equal(result, expected)
 
-        result = df.apply(lambda x: box([1, 2]), axis=1, result_type='infer')
+        result = df.apply(lambda x: box([1, 2]), axis=1, result_type='expand')
         expected = DataFrame(
             np.tile(np.arange(2, dtype='int64'), 6).reshape(6, -1) + 1)
         assert_frame_equal(result, expected)

--- a/pandas/tests/frame/test_apply.py
+++ b/pandas/tests/frame/test_apply.py
@@ -163,6 +163,24 @@ class TestDataFrameApply(TestData):
                              index=self.frame.index)
         tm.assert_frame_equal(result, expected)
 
+        # preserve columns
+        df = DataFrame(np.tile(np.arange(3), 6).reshape(6, -1) + 1,
+                       columns=list('ABC'))
+        result = df.apply(lambda x: [1, 2, 3],
+                          axis=1,
+                          result_type='broadcast')
+        tm.assert_frame_equal(result, df)
+
+        # columms come from the returned Series
+        df = DataFrame(np.tile(np.arange(3), 6).reshape(6, -1) + 1,
+                       columns=list('ABC'))
+        result = df.apply(lambda x: Series([1, 2, 3], index=list('abc')),
+                          axis=1,
+                          result_type='broadcast')
+        expected = df.copy()
+        expected.columns = list('abc')
+        tm.assert_frame_equal(result, expected)
+
     def test_apply_broadcast_error(self):
         df = DataFrame(
             np.tile(np.arange(3, dtype='int64'), 6).reshape(6, -1) + 1,

--- a/pandas/tests/sparse/frame/test_apply.py
+++ b/pandas/tests/sparse/frame/test_apply.py
@@ -1,0 +1,92 @@
+import pytest
+import numpy as np
+from pandas import SparseDataFrame, DataFrame, Series, bdate_range
+from pandas.core import nanops
+from pandas.util import testing as tm
+
+
+@pytest.fixture
+def dates():
+    return bdate_range('1/1/2011', periods=10)
+
+
+@pytest.fixture
+def empty():
+    return SparseDataFrame()
+
+
+@pytest.fixture
+def frame(dates):
+    data = {'A': [np.nan, np.nan, np.nan, 0, 1, 2, 3, 4, 5, 6],
+            'B': [0, 1, 2, np.nan, np.nan, np.nan, 3, 4, 5, 6],
+            'C': np.arange(10, dtype=np.float64),
+            'D': [0, 1, 2, 3, 4, 5, np.nan, np.nan, np.nan, np.nan]}
+
+    return SparseDataFrame(data, index=dates)
+
+
+@pytest.fixture
+def fill_frame(frame):
+    values = frame.values.copy()
+    values[np.isnan(values)] = 2
+
+    return SparseDataFrame(values, columns=['A', 'B', 'C', 'D'],
+                           default_fill_value=2,
+                           index=frame.index)
+
+
+def test_apply(frame):
+    applied = frame.apply(np.sqrt)
+    assert isinstance(applied, SparseDataFrame)
+    tm.assert_almost_equal(applied.values, np.sqrt(frame.values))
+
+    # agg / broadcast
+    with tm.assert_produces_warning(FutureWarning):
+        broadcasted = frame.apply(np.sum, broadcast=True)
+    assert isinstance(broadcasted, SparseDataFrame)
+
+    with tm.assert_produces_warning(FutureWarning):
+        exp = frame.to_dense().apply(np.sum, broadcast=True)
+    tm.assert_frame_equal(broadcasted.to_dense(), exp)
+
+    applied = frame.apply(np.sum)
+    tm.assert_series_equal(applied,
+                           frame.to_dense().apply(nanops.nansum))
+
+
+def test_apply_fill(fill_frame):
+    applied = fill_frame.apply(np.sqrt)
+    assert applied['A'].fill_value == np.sqrt(2)
+
+
+def test_apply_empty(empty):
+    assert empty.apply(np.sqrt) is empty
+
+
+def test_apply_nonuq():
+    orig = DataFrame([[1, 2, 3], [4, 5, 6], [7, 8, 9]],
+                     index=['a', 'a', 'c'])
+    sparse = orig.to_sparse()
+    res = sparse.apply(lambda s: s[0], axis=1)
+    exp = orig.apply(lambda s: s[0], axis=1)
+
+    # dtype must be kept
+    assert res.dtype == np.int64
+
+    # ToDo: apply must return subclassed dtype
+    assert isinstance(res, Series)
+    tm.assert_series_equal(res.to_dense(), exp)
+
+    # df.T breaks
+    sparse = orig.T.to_sparse()
+    res = sparse.apply(lambda s: s[0], axis=0)  # noqa
+    exp = orig.T.apply(lambda s: s[0], axis=0)
+
+    # TODO: no non-unique columns supported in sparse yet
+    # tm.assert_series_equal(res.to_dense(), exp)
+
+
+def test_applymap(frame):
+    # just test that it works
+    result = frame.applymap(lambda x: x * 2)
+    assert isinstance(result, SparseDataFrame)

--- a/pandas/tests/sparse/frame/test_frame.py
+++ b/pandas/tests/sparse/frame/test_frame.py
@@ -621,52 +621,6 @@ class TestSparseDataFrame(SharedWithSparse):
         tm.assert_sp_frame_equal(appended.iloc[:, :3], self.frame.iloc[:, :3],
                                  exact_indices=False)
 
-    def test_apply(self):
-        applied = self.frame.apply(np.sqrt)
-        assert isinstance(applied, SparseDataFrame)
-        tm.assert_almost_equal(applied.values, np.sqrt(self.frame.values))
-
-        applied = self.fill_frame.apply(np.sqrt)
-        assert applied['A'].fill_value == np.sqrt(2)
-
-        # agg / broadcast
-        broadcasted = self.frame.apply(np.sum, broadcast=True)
-        assert isinstance(broadcasted, SparseDataFrame)
-
-        exp = self.frame.to_dense().apply(np.sum, broadcast=True)
-        tm.assert_frame_equal(broadcasted.to_dense(), exp)
-
-        assert self.empty.apply(np.sqrt) is self.empty
-
-        from pandas.core import nanops
-        applied = self.frame.apply(np.sum)
-        tm.assert_series_equal(applied,
-                               self.frame.to_dense().apply(nanops.nansum))
-
-    def test_apply_nonuq(self):
-        orig = DataFrame([[1, 2, 3], [4, 5, 6], [7, 8, 9]],
-                         index=['a', 'a', 'c'])
-        sparse = orig.to_sparse()
-        res = sparse.apply(lambda s: s[0], axis=1)
-        exp = orig.apply(lambda s: s[0], axis=1)
-        # dtype must be kept
-        assert res.dtype == np.int64
-        # ToDo: apply must return subclassed dtype
-        assert isinstance(res, pd.Series)
-        tm.assert_series_equal(res.to_dense(), exp)
-
-        # df.T breaks
-        sparse = orig.T.to_sparse()
-        res = sparse.apply(lambda s: s[0], axis=0)  # noqa
-        exp = orig.T.apply(lambda s: s[0], axis=0)
-        # TODO: no non-unique columns supported in sparse yet
-        # tm.assert_series_equal(res.to_dense(), exp)
-
-    def test_applymap(self):
-        # just test that it works
-        result = self.frame.applymap(lambda x: x * 2)
-        assert isinstance(result, SparseDataFrame)
-
     def test_astype(self):
         sparse = pd.SparseDataFrame({'A': SparseArray([1, 2, 3, 4],
                                                       dtype=np.int64),


### PR DESCRIPTION
closes #16353
closes #17348
closes #17437
closes #18573
closes #17970
closes #17892
closes #17602 
closes #15628 
closes #18775 
closes #18901
closes #18919 

This fixes apply to work correctly when the returned shape mismatches the original. It will try to set the indices if it possible. Setting to a list-like with ``axis=1`` is now disallowed (but still possible if you operate *row-wise*). We were applying this inconsitently. This is of course a discouraged practice anyhow.

Prob should add some examples / update the doc-string a bit.
