### PR TITLE
EHN: Add index parameter to to_json

### DIFF
--- a/doc/source/whatsnew/v0.22.0.txt
+++ b/doc/source/whatsnew/v0.22.0.txt
@@ -136,6 +136,7 @@ Other Enhancements
 - :func:`DataFrame.corrwith` now silently drops non-numeric columns when passed a Series. Before, an exception was raised (:issue:`18570`).
 - :class:`IntervalIndex` now supports time zone aware ``Interval`` objects (:issue:`18537`, :issue:`18538`)
 - :func:`read_excel()` has gained the ``nrows`` parameter (:issue:`16645`)
+- :func:``DataFrame.to_json`` and ``Series.to_json`` now accept an ``index`` argument which allows the user to exclude the index from the JSON output (:issue:`17394`)
 
 .. _whatsnew_0220.api_breaking:
 

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -1673,9 +1673,9 @@ class NDFrame(PandasObject, SelectionMixin):
             .. versionadded:: 0.21.0
 
         index : boolean, default True
-            Whether to include the index values in the JSON string. A
-            ValueError will be thrown if index is False when orient is not
-            'split' or 'table'.
+            Whether to include the index values in the JSON string. Not
+            including the index (``index=False``) is only supported when
+            orient is 'split' or 'table'.
 
             .. versionadded:: 0.22.0
 

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -1603,7 +1603,8 @@ class NDFrame(PandasObject, SelectionMixin):
 
     def to_json(self, path_or_buf=None, orient=None, date_format=None,
                 double_precision=10, force_ascii=True, date_unit='ms',
-                default_handler=None, lines=False, compression=None):
+                default_handler=None, lines=False, compression=None,
+                index=True):
         """
         Convert the object to a JSON string.
 
@@ -1671,6 +1672,13 @@ class NDFrame(PandasObject, SelectionMixin):
 
             .. versionadded:: 0.21.0
 
+        index : boolean, default True
+            Whether to include the index values in the JSON string. A
+            ValueError will be thrown if index is False when orient is not
+            'split' or 'table'.
+
+            .. versionadded:: 0.22.0
+
         Returns
         -------
         same type as input object with filtered info axis
@@ -1723,7 +1731,8 @@ class NDFrame(PandasObject, SelectionMixin):
                             double_precision=double_precision,
                             force_ascii=force_ascii, date_unit=date_unit,
                             default_handler=default_handler,
-                            lines=lines, compression=compression)
+                            lines=lines, compression=compression,
+                            index=index)
 
     def to_hdf(self, path_or_buf, key, **kwargs):
         """Write the contained data to an HDF5 file using HDFStore.

--- a/pandas/io/json/json.py
+++ b/pandas/io/json/json.py
@@ -200,15 +200,17 @@ class JSONTableWriter(FrameWriter):
         if is_period_dtype(obj.index):
             obj.index = obj.index.to_timestamp()
 
-        self.obj = obj.reset_index()
+        # exclude index from obj if index=False
+        if not self.index:
+            self.obj = obj.reset_index(drop=True)
+        else:
+            self.obj = obj.reset_index(drop=False)
         self.date_format = 'iso'
         self.orient = 'records'
         self.index = index
 
     def _write(self, obj, orient, double_precision, ensure_ascii,
                date_unit, iso_dates, default_handler):
-        if not self.index:
-            obj = obj.drop('index', axis=1)
         data = super(JSONTableWriter, self)._write(obj, orient,
                                                    double_precision,
                                                    ensure_ascii, date_unit,

--- a/pandas/io/json/json.py
+++ b/pandas/io/json/json.py
@@ -28,7 +28,12 @@ TABLE_SCHEMA_VERSION = '0.20.0'
 # interface to/from
 def to_json(path_or_buf, obj, orient=None, date_format='epoch',
             double_precision=10, force_ascii=True, date_unit='ms',
-            default_handler=None, lines=False, compression=None):
+            default_handler=None, lines=False, compression=None,
+            index=True):
+
+    if not index and orient not in ['split', 'table']:
+        raise ValueError("'index=False' is only valid when 'orient' is "
+                         "'split' or 'table'")
 
     path_or_buf = _stringify_path(path_or_buf)
     if lines and orient != 'records':
@@ -49,7 +54,8 @@ def to_json(path_or_buf, obj, orient=None, date_format='epoch',
     s = writer(
         obj, orient=orient, date_format=date_format,
         double_precision=double_precision, ensure_ascii=force_ascii,
-        date_unit=date_unit, default_handler=default_handler).write()
+        date_unit=date_unit, default_handler=default_handler,
+        index=index).write()
 
     if lines:
         s = _convert_to_line_delimits(s)
@@ -69,7 +75,7 @@ def to_json(path_or_buf, obj, orient=None, date_format='epoch',
 class Writer(object):
 
     def __init__(self, obj, orient, date_format, double_precision,
-                 ensure_ascii, date_unit, default_handler=None):
+                 ensure_ascii, date_unit, index, default_handler=None):
         self.obj = obj
 
         if orient is None:
@@ -81,6 +87,7 @@ class Writer(object):
         self.ensure_ascii = ensure_ascii
         self.date_unit = date_unit
         self.default_handler = default_handler
+        self.index = index
 
         self.is_copy = None
         self._format_axes()
@@ -108,6 +115,19 @@ class SeriesWriter(Writer):
             raise ValueError("Series index must be unique for orient="
                              "'{orient}'".format(orient=self.orient))
 
+    def write(self):
+        if not self.index and self.orient == 'split':
+            self.obj = {"name": self.obj.name, "data": self.obj.values}
+        return dumps(
+            self.obj,
+            orient=self.orient,
+            double_precision=self.double_precision,
+            ensure_ascii=self.ensure_ascii,
+            date_unit=self.date_unit,
+            iso_dates=self.date_format == 'iso',
+            default_handler=self.default_handler
+        )
+
 
 class FrameWriter(Writer):
     _default_orient = 'columns'
@@ -123,12 +143,26 @@ class FrameWriter(Writer):
             raise ValueError("DataFrame columns must be unique for orient="
                              "'{orient}'.".format(orient=self.orient))
 
+    def write(self):
+        if not self.index and self.orient == 'split':
+            self.obj = self.obj.to_dict(orient='split')
+            del self.obj["index"]
+        return dumps(
+            self.obj,
+            orient=self.orient,
+            double_precision=self.double_precision,
+            ensure_ascii=self.ensure_ascii,
+            date_unit=self.date_unit,
+            iso_dates=self.date_format == 'iso',
+            default_handler=self.default_handler
+        )
+
 
 class JSONTableWriter(FrameWriter):
     _default_orient = 'records'
 
     def __init__(self, obj, orient, date_format, double_precision,
-                 ensure_ascii, date_unit, default_handler=None):
+                 ensure_ascii, date_unit, index, default_handler=None):
         """
         Adds a `schema` attribut with the Table Schema, resets
         the index (can't do in caller, because the schema inference needs
@@ -137,7 +171,7 @@ class JSONTableWriter(FrameWriter):
         """
         super(JSONTableWriter, self).__init__(
             obj, orient, date_format, double_precision, ensure_ascii,
-            date_unit, default_handler=default_handler)
+            date_unit, index, default_handler=default_handler)
 
         if date_format != 'iso':
             msg = ("Trying to write with `orient='table'` and "
@@ -146,7 +180,7 @@ class JSONTableWriter(FrameWriter):
                    .format(fmt=date_format))
             raise ValueError(msg)
 
-        self.schema = build_table_schema(obj)
+        self.schema = build_table_schema(obj, index=self.index)
 
         # NotImplementd on a column MultiIndex
         if obj.ndim == 2 and isinstance(obj.columns, MultiIndex):
@@ -173,7 +207,17 @@ class JSONTableWriter(FrameWriter):
         self.orient = 'records'
 
     def write(self):
-        data = super(JSONTableWriter, self).write()
+        if not self.index:
+            self.obj = self.obj.drop('index', axis=1)
+        data = dumps(
+            self.obj,
+            orient=self.orient,
+            double_precision=self.double_precision,
+            ensure_ascii=self.ensure_ascii,
+            date_unit=self.date_unit,
+            iso_dates=self.date_format == 'iso',
+            default_handler=self.default_handler
+        )
         serialized = '{{"schema": {schema}, "data": {data}}}'.format(
             schema=dumps(self.schema), data=data)
         return serialized

--- a/pandas/tests/io/json/test_pandas.py
+++ b/pandas/tests/io/json/test_pandas.py
@@ -9,6 +9,7 @@ from pandas import (Series, DataFrame, DatetimeIndex, Timestamp,
                     read_json, compat)
 from datetime import timedelta
 import pandas as pd
+import json
 
 from pandas.util.testing import (assert_almost_equal, assert_frame_equal,
                                  assert_series_equal, network,
@@ -1151,7 +1152,8 @@ DataFrame\\.index values are different \\(100\\.0 %\\)
     def test_index_false_to_json(self):
         # GH 17394
         # Testing index parameter in to_json
-        import json
+
+        # Testing DataFrame.to_json(orient='split', index=False)
         df = pd.DataFrame([[1, 2], [4, 5]], columns=['a', 'b'])
 
         result = df.to_json(orient='split', index=False)
@@ -1164,6 +1166,7 @@ DataFrame\\.index values are different \\(100\\.0 %\\)
 
         assert result == expected
 
+        # Testing DataFrame.to_json(orient='table', index=False)
         result = df.to_json(orient='table', index=False)
         result = json.loads(result)
 
@@ -1180,6 +1183,7 @@ DataFrame\\.index values are different \\(100\\.0 %\\)
 
         assert result == expected
 
+        # Testing Series.to_json(orient='split', index=False)
         s = pd.Series([1, 2, 3], name='A')
 
         result = s.to_json(orient='split', index=False)
@@ -1192,6 +1196,7 @@ DataFrame\\.index values are different \\(100\\.0 %\\)
 
         assert result == expected
 
+        # Testing Series.to_json(orient='table', index=False)
         result = s.to_json(orient='table', index=False)
         result = json.loads(result)
 


### PR DESCRIPTION
- [ ] closes #17394
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry

Examples:
```
In [1]: df = pd.DataFrame([[1, 2, 3], [4, 5, 6]], columns=['a', 'b', 'c'])

In [2]: df.to_json(orient='split', index=True)
Out[2]: 
{"columns":["a","b","c"],"index":[0,1],"data":[[1,2,3],[4,5,6]]}

In [3]: df.to_json(orient='split', index=False)
Out[3]:
{"columns":["a","b","c"],"data":[[1,2,3],[4,5,6]]}

In [4]: df.to_json(orient='table', index=True)
Out[4]:
{"schema": {"fields":[{"name":"index","type":"integer"},{"name":"a","type":"integer"},{"name":"b","type":"integer"},{"name":"c","type":"integer"}],"primaryKey":["index"],"pandas_version":"0.20.0"}, "data": [{"index":0,"a":1,"b":2,"c":3},{"index":1,"a":4,"b":5,"c":6}]}

In [5]: df.to_json(orient='table', index=False)
Out[5]:
{"schema": {"fields":[{"name":"a","type":"integer"},{"name":"b","type":"integer"},{"name":"c","type":"integer"}],"pandas_version":"0.20.0"}, "data": [{"a":1,"b":2,"c":3},{"a":4,"b":5,"c":6}]}
```