### PR TITLE
BLD Added --strict and -r sxX to test scripts

### DIFF
--- a/test.bat
+++ b/test.bat
@@ -1,3 +1,3 @@
 :: test on windows
 
-pytest --strict --skip-slow --skip-network pandas -n 2 %*
+pytest --skip-slow --skip-network pandas -n 2 -r sxX --strict %*

--- a/test.sh
+++ b/test.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 command -v coverage >/dev/null && coverage erase
 command -v python-coverage >/dev/null && python-coverage erase
-pytest pandas --cov=pandas
+pytest pandas --cov=pandas -r sxX --strict

--- a/test_fast.bat
+++ b/test_fast.bat
@@ -1,3 +1,3 @@
 :: test on windows
 set PYTHONHASHSEED=314159265
-pytest --skip-slow --skip-network -m "not single" -n 4 pandas
+pytest --skip-slow --skip-network -m "not single" -n 4 -r sXX --strict pandas

--- a/test_fast.sh
+++ b/test_fast.sh
@@ -5,4 +5,4 @@
 # https://github.com/pytest-dev/pytest/issues/1075
 export PYTHONHASHSEED=$(python -c 'import random; print(random.randint(1, 4294967295))')
 
-pytest pandas --skip-slow --skip-network -m "not single" -n 4 "$@"
+pytest pandas --skip-slow --skip-network -m "not single" -n 4 -r sxX --strict "$@"


### PR DESCRIPTION
- no related issue in issue tracker
- no tests added because it was a minor build script change)
- modified shell script, no python syntax check required
- [] whatsnew entry
Altered pytest output to show summaries for xFailed, xPassed and skipped
Added --strict to align these convenience scripts with ci

it will now output summaries below like this

```
...
.........................s........s..s...............s........................................... [ 99%]
....................s...............sssssssssssssssssssssssssssssssssssssssssssssssssssssssssssss [ 99%]
sssssssssssssssssssssssssssssssssssssssssssssssss..                                               [100%]
======================================== short test summary info ========================================
SKIP [1] /Users/206673/open/pandas-nicku33/pandas/tests/io/test_packers.py:649: no blosc
SKIP [3] /Users/206673/open/pandas-nicku33/pandas/tests/io/parser/usecols.py:381: TODO: see gh-13253
SKIP [1] pandas/tests/plotting/test_series.py:667: Missing matplotlib dependency
SKIP [1] /Users/206673/open/pandas-nicku33/pandas/tests/tseries/offsets/test_offsets.py:164: cannot create out_of_range offset: TestBYearBegin object at 0x1259dbd50> year is out of range
...
```
