### PR TITLE
DEPR/CLN: Remove freq parameters from df.rolling/expanding/ewm

### DIFF
--- a/doc/source/whatsnew/v0.22.0.txt
+++ b/doc/source/whatsnew/v0.22.0.txt
@@ -150,6 +150,8 @@ Removal of prior version deprecations/changes
 - The ``SparseList`` class has been removed (:issue:`14007`)
 - The ``pandas.io.wb`` and ``pandas.io.data`` stub modules have been removed (:issue:`13735`)
 - ``Categorical.from_array`` has been removed (:issue:`13854`)
+- The ``freq`` parameter has been removed from the ``rolling``/``expanding``/``ewm`` methods of DataFrame
+  and Series (deprecated since v0.18). Instead, resample before calling the methods. (:issue:18601)
 
 .. _whatsnew_0220.performance:
 

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -7357,31 +7357,31 @@ class NDFrame(PandasObject, SelectionMixin):
         from pandas.core import window as rwindow
 
         @Appender(rwindow.rolling.__doc__)
-        def rolling(self, window, min_periods=None, freq=None, center=False,
+        def rolling(self, window, min_periods=None, center=False,
                     win_type=None, on=None, axis=0, closed=None):
             axis = self._get_axis_number(axis)
             return rwindow.rolling(self, window=window,
-                                   min_periods=min_periods, freq=freq,
+                                   min_periods=min_periods,
                                    center=center, win_type=win_type,
                                    on=on, axis=axis, closed=closed)
 
         cls.rolling = rolling
 
         @Appender(rwindow.expanding.__doc__)
-        def expanding(self, min_periods=1, freq=None, center=False, axis=0):
+        def expanding(self, min_periods=1, center=False, axis=0):
             axis = self._get_axis_number(axis)
-            return rwindow.expanding(self, min_periods=min_periods, freq=freq,
+            return rwindow.expanding(self, min_periods=min_periods,
                                      center=center, axis=axis)
 
         cls.expanding = expanding
 
         @Appender(rwindow.ewm.__doc__)
         def ewm(self, com=None, span=None, halflife=None, alpha=None,
-                min_periods=0, freq=None, adjust=True, ignore_na=False,
+                min_periods=0, adjust=True, ignore_na=False,
                 axis=0):
             axis = self._get_axis_number(axis)
             return rwindow.ewm(self, com=com, span=span, halflife=halflife,
-                               alpha=alpha, min_periods=min_periods, freq=freq,
+                               alpha=alpha, min_periods=min_periods,
                                adjust=adjust, ignore_na=ignore_na, axis=axis)
 
         cls.ewm = ewm

--- a/pandas/stats/moments.py
+++ b/pandas/stats/moments.py
@@ -208,6 +208,8 @@ def ensure_compat(dispatch, name, arg, func_kw=None, *args, **kwargs):
         if value is not None:
             kwds[k] = value
 
+    # TODO: the below is only in place temporary until this module is removed.
+    kwargs.pop('freq', None)  # freq removed in 0.22
     # how is a keyword that if not-None should be in kwds
     how = kwargs.pop('how', None)
     if how is not None:
@@ -680,7 +682,6 @@ def _expanding_func(name, desc, func_kw=None, additional_kw=''):
                              name,
                              arg,
                              min_periods=min_periods,
-                             freq=freq,
                              func_kw=func_kw,
                              **kwargs)
     return f


### PR DESCRIPTION
-- [x ] tests added / passed
- [x ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x ] whatsnew entry

The ``freq`` parameter of df.rolling/expanding/ewm was deprecated in 0.18 (#11603). This PR removes the parameter from the code base.

After this PR, I will remove the ``how`` parameter and lastly the ``pd.rolling_*``, ``pd.expanding_*`` and ``pd.ewm_*`` will be removed (AKA ``pd.stats.*``). By removing ``freq`` and ``how``before ``pd.stats`` I think it will be easier to clean up `` pandas/tests/test_window.py``, as ATM these three issues are not very cleanly separated in that test module.

In some test in ``test_window.py::TestMoments`` there is a bit of resampling going on, as I've moved ``freq`` stuff from ``rolling`` into a prior ``df.resample`` step. These are tests for ``how`` and will be removed once ``how`` is removed (unless the tests good for testing the windows functions, I'm not completely sure ATM, but will look into it when I reach that point).

Additionally (and unrelated), in `` pandas/tests/test_window.py`` there are checks for numpy>=1.8 and >=1.9. These checks are no longer necessary, as numpy 1.9 is the current minium version, so they're removed,.