### PR TITLE
STYLE: Use decorator syntax instead of legacy syntax for defining properties in Cython

### DIFF
--- a/pandas/_libs/index.pyx
+++ b/pandas/_libs/index.pyx
@@ -220,34 +220,31 @@ cdef class IndexEngine:
     def __sizeof__(self):
         return self.sizeof()
 
-    property is_unique:
+    @property
+    def is_unique(self):
+        if self.need_unique_check:
+            self._do_unique_check()
 
-        def __get__(self):
-            if self.need_unique_check:
-                self._do_unique_check()
-
-            return self.unique == 1
+        return self.unique == 1
 
     cdef inline _do_unique_check(self):
 
         # this de-facto the same
         self._ensure_mapping_populated()
 
-    property is_monotonic_increasing:
+    @property
+    def is_monotonic_increasing(self):
+        if self.need_monotonic_check:
+            self._do_monotonic_check()
 
-        def __get__(self):
-            if self.need_monotonic_check:
-                self._do_monotonic_check()
+        return self.monotonic_inc == 1
 
-            return self.monotonic_inc == 1
+    @property
+    def is_monotonic_decreasing(self):
+        if self.need_monotonic_check:
+            self._do_monotonic_check()
 
-    property is_monotonic_decreasing:
-
-        def __get__(self):
-            if self.need_monotonic_check:
-                self._do_monotonic_check()
-
-            return self.monotonic_dec == 1
+        return self.monotonic_dec == 1
 
     cdef inline _do_monotonic_check(self):
         cdef object is_unique
@@ -279,10 +276,9 @@ cdef class IndexEngine:
     cdef _check_type(self, object val):
         hash(val)
 
-    property is_mapping_populated:
-
-        def __get__(self):
-            return self.mapping is not None
+    @property
+    def is_mapping_populated(self):
+        return self.mapping is not None
 
     cdef inline _ensure_mapping_populated(self):
         # this populates the mapping

--- a/pandas/_libs/tslibs/conversion.pyx
+++ b/pandas/_libs/tslibs/conversion.pyx
@@ -203,9 +203,9 @@ cdef class _TSObject:
     #    int64_t value               # numpy dt64
     #    object tzinfo
 
-    property value:
-        def __get__(self):
-            return self.value
+    @property
+    def value(self):
+        return self.value
 
 
 cpdef int64_t pydt_to_i8(object pydt) except? -1:


### PR DESCRIPTION
- [X] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`

See the [Cython docs](http://cython.readthedocs.io/en/latest/src/userguide/extension_types.html#properties) for a comparison of the decorator syntax and legacy syntax.  I only found a few instances of the legacy syntax; looks like most of the Cython code is already using decorator syntax.