### PR TITLE
BLD: Bump Cython version from 0.23 to 0.24

### DIFF
--- a/ci/requirements-2.7.build
+++ b/ci/requirements-2.7.build
@@ -3,4 +3,4 @@ python-dateutil=2.5.0
 pytz=2013b
 nomkl
 numpy
-cython=0.23
+cython=0.24

--- a/ci/requirements-2.7_COMPAT.build
+++ b/ci/requirements-2.7_COMPAT.build
@@ -1,5 +1,5 @@
 python=2.7*
 numpy=1.9.2
-cython=0.23
+cython=0.24
 python-dateutil=2.5.0
 pytz=2013b

--- a/ci/requirements-2.7_LOCALE.build
+++ b/ci/requirements-2.7_LOCALE.build
@@ -2,4 +2,4 @@ python=2.7*
 python-dateutil
 pytz=2013b
 numpy=1.9.2
-cython=0.23
+cython=0.24

--- a/doc/source/enhancingperf.rst
+++ b/doc/source/enhancingperf.rst
@@ -94,8 +94,7 @@ hence we'll concentrate our efforts cythonizing these two functions.
 Plain cython
 ~~~~~~~~~~~~
 
-First we're going to need to import the cython magic function to ipython (for
-cython versions  < 0.21 you can use ``%load_ext cythonmagic``):
+First we're going to need to import the cython magic function to ipython:
 
 .. ipython:: python
    :okwarning:

--- a/doc/source/install.rst
+++ b/doc/source/install.rst
@@ -228,7 +228,7 @@ Optional Dependencies
 ~~~~~~~~~~~~~~~~~~~~~
 
 * `Cython <http://www.cython.org>`__: Only necessary to build development
-  version. Version 0.23 or higher.
+  version. Version 0.24 or higher.
 * `SciPy <http://www.scipy.org>`__: miscellaneous statistical functions, Version 0.14.0 or higher
 * `xarray <http://xarray.pydata.org>`__: pandas like handling for > 2 dims, needed for converting Panels to xarray objects. Version 0.7.0 or higher is recommended.
 * `PyTables <http://www.pytables.org>`__: necessary for HDF5-based storage. Version 3.0.0 or higher required, Version 3.2.1 or higher highly recommended.

--- a/doc/source/whatsnew/v0.22.0.txt
+++ b/doc/source/whatsnew/v0.22.0.txt
@@ -83,16 +83,12 @@ Other Enhancements
 Backwards incompatible API changes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-- :func:`Series.fillna` now raises a ``TypeError`` instead of a ``ValueError`` when passed a list, tuple or DataFrame as a ``value`` (:issue:`18293`)
-- :func:`pandas.DataFrame.merge` no longer casts a ``float`` column to ``object`` when merging on ``int`` and ``float`` columns (:issue:`16572`)
-- The default NA value for :class:`UInt64Index` has changed from 0 to ``NaN``, which impacts methods that mask with NA, such as ``UInt64Index.where()`` (:issue:`18398`)
-
 .. _whatsnew_0220.api_breaking.deps:
 
 Dependencies have increased minimum versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-We have updated our minimum supported versions of dependencies (:issue:`15184`).
+We have updated our minimum supported versions of dependencies (:issue:`15184`, :issue:`18613`).
 If installed, we now require:
 
    +-----------------+-----------------+----------+
@@ -102,8 +98,8 @@ If installed, we now require:
    +-----------------+-----------------+----------+
    | openpyxl        | 2.4.0           |          |
    +-----------------+-----------------+----------+
-
-
+   | Cython          | 0.24            |          |
+   +-----------------+-----------------+----------+
 
 
 .. _whatsnew_0220.api:
@@ -129,6 +125,9 @@ Other API Changes
 - :func:`DataFrame.from_items` provides a more informative error message when passed scalar values (:issue:`17312`)
 - When created with duplicate labels, ``MultiIndex`` now raises a ``ValueError``. (:issue:`17464`)
 - Building from source now explicity requires ``setuptools`` in ``setup.py`` (:issue:`18113`)
+- :func:`Series.fillna` now raises a ``TypeError`` instead of a ``ValueError`` when passed a list, tuple or DataFrame as a ``value`` (:issue:`18293`)
+- :func:`pandas.DataFrame.merge` no longer casts a ``float`` column to ``object`` when merging on ``int`` and ``float`` columns (:issue:`16572`)
+- The default NA value for :class:`UInt64Index` has changed from 0 to ``NaN``, which impacts methods that mask with NA, such as ``UInt64Index.where()`` (:issue:`18398`)
 
 .. _whatsnew_0220.deprecations:
 

--- a/doc/source/whatsnew/v0.22.0.txt
+++ b/doc/source/whatsnew/v0.22.0.txt
@@ -88,7 +88,7 @@ Backwards incompatible API changes
 Dependencies have increased minimum versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-We have updated our minimum supported versions of dependencies (:issue:`15184`, :issue:`18613`).
+We have updated our minimum supported versions of dependencies (:issue:`15184`).
 If installed, we now require:
 
    +-----------------+-----------------+----------+
@@ -97,8 +97,6 @@ If installed, we now require:
    | python-dateutil | 2.5.0           |    X     |
    +-----------------+-----------------+----------+
    | openpyxl        | 2.4.0           |          |
-   +-----------------+-----------------+----------+
-   | Cython          | 0.24            |          |
    +-----------------+-----------------+----------+
 
 
@@ -128,6 +126,7 @@ Other API Changes
 - :func:`Series.fillna` now raises a ``TypeError`` instead of a ``ValueError`` when passed a list, tuple or DataFrame as a ``value`` (:issue:`18293`)
 - :func:`pandas.DataFrame.merge` no longer casts a ``float`` column to ``object`` when merging on ``int`` and ``float`` columns (:issue:`16572`)
 - The default NA value for :class:`UInt64Index` has changed from 0 to ``NaN``, which impacts methods that mask with NA, such as ``UInt64Index.where()`` (:issue:`18398`)
+- Building pandas for development now requires ``cython >= 0.24`` (:issue:`18613`)
 
 .. _whatsnew_0220.deprecations:
 

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ def is_platform_mac():
     return sys.platform == 'darwin'
 
 
-min_cython_ver = '0.23'
+min_cython_ver = '0.24'
 try:
     import Cython
     ver = Cython.__version__


### PR DESCRIPTION
- [X] closes #18613 
- [X] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [X] whatsnew entry

For the whatsnew:

- Used the same whatsnew message as was used during the last cython version bump in 0.20
- Moved some previous entries that were under the main "Backwards incompatible API changes" section to the "Other API Changes" subsection.