### PR TITLE
Cleanup & De-duplication for custom offset classes

### DIFF
--- a/pandas/_libs/tslibs/offsets.pyx
+++ b/pandas/_libs/tslibs/offsets.pyx
@@ -307,27 +307,6 @@ class CacheableOffset(object):
     _cacheable = True
 
 
-class BeginMixin(object):
-    # helper for vectorized offsets
-
-    def _beg_apply_index(self, i, freq):
-        """Offsets index to beginning of Period frequency"""
-
-        off = i.to_perioddelta('D')
-
-        base, mult = get_freq_code(freq)
-        base_period = i.to_period(base)
-        if self.n <= 0:
-            # when subtracting, dates on start roll to prior
-            roll = np.where(base_period.to_timestamp() == i - off,
-                            self.n, self.n + 1)
-        else:
-            roll = self.n
-
-        base = (base_period + roll).to_timestamp()
-        return base + off
-
-
 class EndMixin(object):
     # helper for vectorized offsets
 

--- a/pandas/tseries/offsets.py
+++ b/pandas/tseries/offsets.py
@@ -594,6 +594,22 @@ class BusinessHourMixin(BusinessMixin):
         self.kwds = kwds
         self._offset = offset
 
+    @cache_readonly
+    def next_bday(self):
+        # used for moving to next businessday
+        if self.n >= 0:
+            nb_offset = 1
+        else:
+            nb_offset = -1
+        if self._prefix.startswith('C'):
+            # CustomBusinessHour
+            return return CustomBusinessDay(n=nb_offset,
+                                            weekmask=self.weekmask,
+                                            holidays=self.holidays,
+                                            calendar=self.calendar)
+        else:
+            return BusinessDay(n=nb_offset)
+
     # TODO: Cache this once offsets are immutable
     def _get_daytime_flag(self):
         if self.start == self.end:
@@ -807,15 +823,6 @@ class BusinessHour(BusinessHourMixin, SingleConstructorOffset):
         self.normalize = normalize
         super(BusinessHour, self).__init__(start=start, end=end, offset=offset)
 
-    @cache_readonly
-    def next_bday(self):
-        # used for moving to next businessday
-        if self.n >= 0:
-            nb_offset = 1
-        else:
-            nb_offset = -1
-        return BusinessDay(n=nb_offset)
-
 
 class CustomBusinessDay(_CustomMixin, BusinessDay):
     """
@@ -906,18 +913,6 @@ class CustomBusinessHour(_CustomMixin, BusinessHourMixin,
 
         # Note: `self.kwds` gets defined in BusinessHourMixin.__init__
         _CustomMixin.__init__(self, weekmask, holidays, calendar)
-
-    @cache_readonly
-    def next_bday(self):
-        # used for moving to next businessday
-        if self.n >= 0:
-            nb_offset = 1
-        else:
-            nb_offset = -1
-        return CustomBusinessDay(n=nb_offset,
-                                 weekmask=self.weekmask,
-                                 holidays=self.holidays,
-                                 calendar=self.calendar)
 
 
 # ---------------------------------------------------------------------

--- a/pandas/tseries/offsets.py
+++ b/pandas/tseries/offsets.py
@@ -1707,13 +1707,16 @@ class YearOffset(DateOffset):
         return dt.month == self.month and dt.day == self._get_offset_day(dt)
 
     def __init__(self, n=1, normalize=False, month=None):
+        self.n = self._validate_n(n)
+        self.normalize = normalize
+
         month = month if month is not None else self._default_month
         self.month = month
 
         if self.month < 1 or self.month > 12:
             raise ValueError('Month must go from 1 to 12')
 
-        DateOffset.__init__(self, n=n, normalize=normalize, month=month)
+        self.kwds = {'month': month}
 
     @classmethod
     def _from_name(cls, suffix=None):

--- a/pandas/tseries/offsets.py
+++ b/pandas/tseries/offsets.py
@@ -603,10 +603,10 @@ class BusinessHourMixin(BusinessMixin):
             nb_offset = -1
         if self._prefix.startswith('C'):
             # CustomBusinessHour
-            return return CustomBusinessDay(n=nb_offset,
-                                            weekmask=self.weekmask,
-                                            holidays=self.holidays,
-                                            calendar=self.calendar)
+            return CustomBusinessDay(n=nb_offset,
+                                     weekmask=self.weekmask,
+                                     holidays=self.holidays,
+                                     calendar=self.calendar)
         else:
             return BusinessDay(n=nb_offset)
 
@@ -908,8 +908,7 @@ class CustomBusinessHour(_CustomMixin, BusinessHourMixin,
                  start='09:00', end='17:00', offset=timedelta(0)):
         self.n = self._validate_n(n)
         self.normalize = normalize
-        super(CustomBusinessHour, self).__init__(start=start,
-                                                 end=end, offset=offset)
+        BusinessHourMixin.__init__(self, start=start, end=end, offset=offset)
 
         # Note: `self.kwds` gets defined in BusinessHourMixin.__init__
         _CustomMixin.__init__(self, weekmask, holidays, calendar)
@@ -1023,7 +1022,7 @@ class _CustomBusinessMonth(_CustomMixin, BusinessMixin, MonthOffset):
 
     @cache_readonly
     def m_offset(self):
-        if self._prefix.endwith('S'):
+        if self._prefix.endswith('S'):
             # MonthBegin:
             return MonthBegin(n=1, normalize=self.normalize)
         else:

--- a/pandas/tseries/offsets.py
+++ b/pandas/tseries/offsets.py
@@ -415,7 +415,7 @@ class SingleConstructorOffset(DateOffset):
 
 class _CustomMixin(object):
     """
-    mixin for classes that define and validate calendar, holidays,
+    Mixin for classes that define and validate calendar, holidays,
     and weekdays attributes
     """
     def __init__(self, weekmask, holidays, calendar):
@@ -433,7 +433,7 @@ class _CustomMixin(object):
 
 
 class BusinessMixin(object):
-    """ mixin to business types to provide related functions """
+    """ Mixin to business types to provide related functions """
 
     @property
     def offset(self):
@@ -596,7 +596,7 @@ class BusinessHourMixin(BusinessMixin):
 
     @cache_readonly
     def next_bday(self):
-        # used for moving to next businessday
+        """used for moving to next businessday"""
         if self.n >= 0:
             nb_offset = 1
         else:

--- a/pandas/tseries/offsets.py
+++ b/pandas/tseries/offsets.py
@@ -591,7 +591,7 @@ class BusinessHourMixin(BusinessMixin):
         kwds = {'offset': offset}
         self.start = kwds['start'] = _validate_business_time(start)
         self.end = kwds['end'] = _validate_business_time(end)
-        self.kwds = kwds
+        self.kwds.update(kwds)
         self._offset = offset
 
     @cache_readonly
@@ -821,6 +821,7 @@ class BusinessHour(BusinessHourMixin, SingleConstructorOffset):
                  end='17:00', offset=timedelta(0)):
         self.n = self._validate_n(n)
         self.normalize = normalize
+        self.kwds = {}
         super(BusinessHour, self).__init__(start=start, end=end, offset=offset)
 
 
@@ -908,10 +909,11 @@ class CustomBusinessHour(_CustomMixin, BusinessHourMixin,
                  start='09:00', end='17:00', offset=timedelta(0)):
         self.n = self._validate_n(n)
         self.normalize = normalize
-        BusinessHourMixin.__init__(self, start=start, end=end, offset=offset)
+        self._offset = offset
+        self.kwds = {'offset': offset}
 
-        # Note: `self.kwds` gets defined in BusinessHourMixin.__init__
         _CustomMixin.__init__(self, weekmask, holidays, calendar)
+        BusinessHourMixin.__init__(self, start=start, end=end, offset=offset)
 
 
 # ---------------------------------------------------------------------


### PR DESCRIPTION
The diff looks a little bit mangled.  This PR does two things.

1) Centralize frequently-repeated calendar `__init__` in a new _CustomMixin

2) Merge a bunch of shared CustomBusinessMonthEnd and CustomBusinessMonthBegin logic into a parent class.

- [ ] closes #xxxx
- [ ] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
