### PR TITLE
CLN: Remove Categorical.from_array

### DIFF
--- a/doc/source/whatsnew/v0.22.0.txt
+++ b/doc/source/whatsnew/v0.22.0.txt
@@ -149,6 +149,7 @@ Removal of prior version deprecations/changes
 - ``pd.ordered_merge`` has been removed (deprecated since v0.19). Use ``pd.merge_ordered`` instead (:issue:`18459`)
 - The ``SparseList`` class has been removed (:issue:`14007`)
 - The ``pandas.io.wb`` and ``pandas.io.data`` stub modules have been removed (:issue:`13735`)
+- ``Categorical.from_array`` has been removed (:issue:`13854`)
 
 .. _whatsnew_0220.performance:
 

--- a/pandas/core/categorical.py
+++ b/pandas/core/categorical.py
@@ -553,26 +553,6 @@ class Categorical(PandasObject):
         return cls(codes, dtype=dtype, fastpath=True)
 
     @classmethod
-    def from_array(cls, data, **kwargs):
-        """
-        .. deprecated:: 0.19.0
-           Use ``Categorical`` instead.
-
-        Make a Categorical type from a single array-like object.
-
-        For internal compatibility with numpy arrays.
-
-        Parameters
-        ----------
-        data : array-like
-            Can be an Index or array-like. The categories are assumed to be
-            the unique values of `data`.
-        """
-        warn("Categorical.from_array is deprecated, use Categorical instead",
-             FutureWarning, stacklevel=2)
-        return cls(data, **kwargs)
-
-    @classmethod
     def from_codes(cls, codes, categories, ordered=False):
         """
         Make a Categorical type from codes and categories arrays.

--- a/pandas/tests/test_categorical.py
+++ b/pandas/tests/test_categorical.py
@@ -1955,11 +1955,6 @@ Categories (3, object): [ああああ, いいいいい, ううううううう]""
             res = cat.labels
         tm.assert_numpy_array_equal(res, exp)
 
-    def test_deprecated_from_array(self):
-        # GH13854, `.from_array` is deprecated
-        with tm.assert_produces_warning(FutureWarning):
-            Categorical.from_array([0, 1])
-
     def test_datetime_categorical_comparison(self):
         dt_cat = Categorical(date_range('2014-01-01', periods=3), ordered=True)
         tm.assert_numpy_array_equal(dt_cat > dt_cat[0],
@@ -4817,7 +4812,7 @@ class TestCategoricalSubclassing(object):
         assert isinstance(sc, tm.SubclassedCategorical)
         tm.assert_categorical_equal(sc, Categorical(['a', 'b', 'c']))
 
-    def test_from_array(self):
+    def test_from_codes(self):
         sc = tm.SubclassedCategorical.from_codes([1, 0, 2], ['a', 'b', 'c'])
         assert isinstance(sc, tm.SubclassedCategorical)
         exp = Categorical.from_codes([1, 0, 2], ['a', 'b', 'c'])


### PR DESCRIPTION
Deprecated in 0.19.0

xref #13854.