### PR TITLE
STYLE/CI: implement incremental linting for asv benchmarks

### DIFF
--- a/asv_bench/vbench_to_asv.py
+++ b/asv_bench/vbench_to_asv.py
@@ -15,7 +15,8 @@ def vbench_to_asv_source(bench, kinds=None):
     output += tab + 'goal_time = 0.2\n\n'
 
     if bench.setup:
-        indented_setup = [tab * 2 + '{}\n'.format(x) for x in bench.setup.splitlines()]
+        indented_setup = [tab * 2 + '{}\n'.format(x)
+                          for x in bench.setup.splitlines()]
         output += tab + 'def setup(self):\n' + ''.join(indented_setup) + '\n'
 
     for kind in kinds:
@@ -77,7 +78,9 @@ class AssignToSelf(ast.NodeTransformer):
 
     def visit_Assign(self, node):
         for target in node.targets:
-            if isinstance(target, ast.Name) and not isinstance(target.ctx, ast.Param) and not self.in_class_define:
+            if (isinstance(target, ast.Name) and
+                    not isinstance(target.ctx, ast.Param) and
+                    not self.in_class_define):
                 self.transforms[target.id] = 'self.' + target.id
         self.generic_visit(node)
 
@@ -87,7 +90,9 @@ class AssignToSelf(ast.NodeTransformer):
         new_node = node
         if node.id in self.transforms:
             if not isinstance(node.ctx, ast.Param):
-                new_node = ast.Attribute(value=ast.Name(id='self', ctx=node.ctx), attr=node.id, ctx=node.ctx)
+                new_node = ast.Attribute(value=ast.Name(id='self',
+                                                        ctx=node.ctx),
+                                         attr=node.id, ctx=node.ctx)
 
         self.generic_visit(node)
 
@@ -111,7 +116,6 @@ class AssignToSelf(ast.NodeTransformer):
 
 def translate_module(target_module):
     g_vars = {}
-    l_vars = {}
     exec('import ' + target_module) in g_vars
 
     print(target_module)
@@ -138,9 +142,11 @@ def translate_module(target_module):
     transformer = AssignToSelf()
     transformed_module = transformer.visit(ast_module)
 
-    unique_imports = {astor.to_source(node): node for node in transformer.imports}
+    unique_imports = {astor.to_source(node): node
+                      for node in transformer.imports}
 
-    transformed_module.body = unique_imports.values() + transformed_module.body
+    transformed_module.body = (unique_imports.values() +
+                               transformed_module.body)
 
     transformed_source = astor.to_source(transformed_module)
 
@@ -155,7 +161,9 @@ if __name__ == '__main__':
 
     for module in glob.glob(os.path.join(new_dir, '*.py')):
         mod = os.path.basename(module)
-        if mod in ['make.py', 'measure_memory_consumption.py', 'perf_HEAD.py', 'run_suite.py', 'test_perf.py', 'generate_rst_files.py', 'test.py', 'suite.py']:
+        if mod in ['make.py', 'measure_memory_consumption.py', 'perf_HEAD.py',
+                   'run_suite.py', 'test_perf.py', 'generate_rst_files.py',
+                   'test.py', 'suite.py']:
             continue
         print('')
         print(mod)

--- a/asv_bench/vbench_to_asv.py
+++ b/asv_bench/vbench_to_asv.py
@@ -15,8 +15,7 @@ def vbench_to_asv_source(bench, kinds=None):
     output += tab + 'goal_time = 0.2\n\n'
 
     if bench.setup:
-        indented_setup = [tab * 2 + '{}\n'.format(x)
-                          for x in bench.setup.splitlines()]
+        indented_setup = [tab * 2 + '{}\n'.format(x) for x in bench.setup.splitlines()]
         output += tab + 'def setup(self):\n' + ''.join(indented_setup) + '\n'
 
     for kind in kinds:
@@ -78,9 +77,7 @@ class AssignToSelf(ast.NodeTransformer):
 
     def visit_Assign(self, node):
         for target in node.targets:
-            if (isinstance(target, ast.Name) and
-                    not isinstance(target.ctx, ast.Param) and
-                    not self.in_class_define):
+            if isinstance(target, ast.Name) and not isinstance(target.ctx, ast.Param) and not self.in_class_define:
                 self.transforms[target.id] = 'self.' + target.id
         self.generic_visit(node)
 
@@ -90,9 +87,7 @@ class AssignToSelf(ast.NodeTransformer):
         new_node = node
         if node.id in self.transforms:
             if not isinstance(node.ctx, ast.Param):
-                new_node = ast.Attribute(value=ast.Name(id='self',
-                                                        ctx=node.ctx),
-                                         attr=node.id, ctx=node.ctx)
+                new_node = ast.Attribute(value=ast.Name(id='self', ctx=node.ctx), attr=node.id, ctx=node.ctx)
 
         self.generic_visit(node)
 
@@ -116,6 +111,7 @@ class AssignToSelf(ast.NodeTransformer):
 
 def translate_module(target_module):
     g_vars = {}
+    l_vars = {}
     exec('import ' + target_module) in g_vars
 
     print(target_module)
@@ -142,11 +138,9 @@ def translate_module(target_module):
     transformer = AssignToSelf()
     transformed_module = transformer.visit(ast_module)
 
-    unique_imports = {astor.to_source(node): node
-                      for node in transformer.imports}
+    unique_imports = {astor.to_source(node): node for node in transformer.imports}
 
-    transformed_module.body = (unique_imports.values() +
-                               transformed_module.body)
+    transformed_module.body = unique_imports.values() + transformed_module.body
 
     transformed_source = astor.to_source(transformed_module)
 
@@ -161,9 +155,7 @@ if __name__ == '__main__':
 
     for module in glob.glob(os.path.join(new_dir, '*.py')):
         mod = os.path.basename(module)
-        if mod in ['make.py', 'measure_memory_consumption.py', 'perf_HEAD.py',
-                   'run_suite.py', 'test_perf.py', 'generate_rst_files.py',
-                   'test.py', 'suite.py']:
+        if mod in ['make.py', 'measure_memory_consumption.py', 'perf_HEAD.py', 'run_suite.py', 'test_perf.py', 'generate_rst_files.py', 'test.py', 'suite.py']:
             continue
         print('')
         print(mod)

--- a/ci/lint.sh
+++ b/ci/lint.sh
@@ -23,6 +23,13 @@ if [ "$LINT" ]; then
     fi
     echo "Linting setup.py DONE"
 
+    echo "Linting asv_bench/"
+    flake8 asv_bench/  --exclude=asv_bench/benchmarks/[bcdefghijklmnopqrstuvwxyz]*.py --ignore=F811
+    if [ $? -ne "0" ]; then
+        RET=1
+    fi
+    echo "Linting asv_bench/*.py DONE"
+
     echo "Linting *.pyx"
     flake8 pandas --filename=*.pyx --select=E501,E302,E203,E111,E114,E221,E303,E128,E231,E126,E265,E305,E301,E127,E261,E271,E129,W291,E222,E241,E123,F403
     if [ $? -ne "0" ]; then

--- a/ci/lint.sh
+++ b/ci/lint.sh
@@ -24,7 +24,7 @@ if [ "$LINT" ]; then
     echo "Linting setup.py DONE"
 
     echo "Linting asv_bench/"
-    flake8 asv_bench/  --exclude=asv_bench/benchmarks/[bcdefghijklmnopqrstuvwxyz]*.py --ignore=F811
+    flake8 asv_bench/  --exclude=asv_bench/benchmarks/[ghijoprst]*.py --ignore=F811
     if [ $? -ne "0" ]; then
         RET=1
     fi

--- a/ci/lint.sh
+++ b/ci/lint.sh
@@ -23,12 +23,12 @@ if [ "$LINT" ]; then
     fi
     echo "Linting setup.py DONE"
 
-    echo "Linting asv_bench/"
-    flake8 asv_bench/  --exclude=asv_bench/benchmarks/[ghijoprst]*.py --ignore=F811
+    echo "Linting asv_bench/benchmarks/"
+    flake8 asv_bench/benchmarks/  --exclude=asv_bench/benchmarks/[ghijoprst]*.py --ignore=F811
     if [ $? -ne "0" ]; then
         RET=1
     fi
-    echo "Linting asv_bench/*.py DONE"
+    echo "Linting asv_bench/benchmarks/*.py DONE"
 
     echo "Linting *.pyx"
     flake8 pandas --filename=*.pyx --select=E501,E302,E203,E111,E114,E221,E303,E128,E231,E126,E265,E305,E301,E127,E261,E271,E129,W291,E222,E241,E123,F403


### PR DESCRIPTION
Another try at #18620 

@mroeschke since it looks like you are going through the asv files one-by-one, the idea here is that when file X gets cleaned up, it can be un-excluded in the lint.sh command.

- [ ] closes #xxxx
- [ ] tests added / passed
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
