### PR TITLE
CLN: Remove .to_datetime methods

### DIFF
--- a/doc/source/api.rst
+++ b/doc/source/api.rst
@@ -1489,7 +1489,6 @@ Conversion
    Index.map
    Index.ravel
    Index.tolist
-   Index.to_datetime
    Index.to_native_types
    Index.to_series
    Index.to_frame
@@ -1757,7 +1756,6 @@ Conversion
 .. autosummary::
    :toctree: generated/
 
-   DatetimeIndex.to_datetime
    DatetimeIndex.to_period
    DatetimeIndex.to_perioddelta
    DatetimeIndex.to_pydatetime

--- a/doc/source/whatsnew/v0.22.0.txt
+++ b/doc/source/whatsnew/v0.22.0.txt
@@ -152,6 +152,7 @@ Removal of prior version deprecations/changes
 - ``Categorical.from_array`` has been removed (:issue:`13854`)
 - The ``freq`` parameter has been removed from the ``rolling``/``expanding``/``ewm`` methods of DataFrame
   and Series (deprecated since v0.18). Instead, resample before calling the methods. (:issue:18601)
+- ``DatetimeIndex.to_datetime``, ``Timestamp.to_datetime``, ``PeriodIndex.to_datetime``, and ``Index.to_datetime`` have been removed (:issue:`8254`, :issue:`14096`, :issue:`14113`)
 
 .. _whatsnew_0220.performance:
 

--- a/pandas/_libs/tslibs/nattype.pyx
+++ b/pandas/_libs/tslibs/nattype.pyx
@@ -556,16 +556,6 @@ class NaTType(_NaT):
         Timestamp with fields replaced
         """)
 
-    def to_datetime(self):
-        """
-        DEPRECATED: use :meth:`to_pydatetime` instead.
-
-        Convert a Timestamp object to a native Python datetime object.
-        """
-        warnings.warn("to_datetime is deprecated. Use self.to_pydatetime()",
-                      FutureWarning, stacklevel=2)
-        return self.to_pydatetime(warn=False)
-
 
 NaT = NaTType()
 

--- a/pandas/_libs/tslibs/timestamps.pyx
+++ b/pandas/_libs/tslibs/timestamps.pyx
@@ -181,16 +181,6 @@ cdef class _Timestamp(datetime):
         elif other.tzinfo is None:
             raise TypeError('Cannot compare tz-naive and tz-aware timestamps')
 
-    cpdef datetime to_datetime(_Timestamp self):
-        """
-        DEPRECATED: use :meth:`to_pydatetime` instead.
-
-        Convert a Timestamp object to a native Python datetime object.
-        """
-        warnings.warn("to_datetime is deprecated. Use self.to_pydatetime()",
-                      FutureWarning, stacklevel=2)
-        return self.to_pydatetime(warn=False)
-
     cpdef datetime to_pydatetime(_Timestamp self, warn=True):
         """
         Convert a Timestamp object to a native Python datetime object.

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -7,7 +7,6 @@ from pandas._libs import (lib, index as libindex, tslib as libts,
                           algos as libalgos, join as libjoin,
                           Timestamp, Timedelta, )
 from pandas._libs.lib import is_datetime_array
-from pandas._libs.tslibs import parsing
 
 from pandas.compat import range, u, set_function_name
 from pandas.compat.numpy import function as nv
@@ -1060,25 +1059,6 @@ class Index(IndexOpsMixin, PandasObject):
     def _to_safe_for_reshape(self):
         """ convert to object if we are a categorical """
         return self
-
-    def to_datetime(self, dayfirst=False):
-        """
-        DEPRECATED: use :meth:`pandas.to_datetime` instead.
-
-        For an Index containing strings or datetime.datetime objects, attempt
-        conversion to DatetimeIndex
-        """
-        warnings.warn("to_datetime is deprecated. Use pd.to_datetime(...)",
-                      FutureWarning, stacklevel=2)
-
-        from pandas.core.indexes.datetimes import DatetimeIndex
-        if self.inferred_type == 'string':
-            from dateutil.parser import parse
-            parser = lambda x: parse(x, dayfirst=dayfirst)
-            parsed = parsing.try_parse_dates(self.values, parser=parser)
-            return DatetimeIndex(parsed)
-        else:
-            return DatetimeIndex(self.values)
 
     def _assert_can_do_setop(self, other):
         if not is_list_like(other):

--- a/pandas/core/indexes/datetimes.py
+++ b/pandas/core/indexes/datetimes.py
@@ -244,7 +244,6 @@ class DatetimeIndex(DatelikeOps, TimelikeOps, DatetimeIndexOpsMixin,
     round
     floor
     ceil
-    to_datetime
     to_period
     to_perioddelta
     to_pydatetime
@@ -898,9 +897,6 @@ class DatetimeIndex(DatelikeOps, TimelikeOps, DatetimeIndexOpsMixin,
                                                 tz=self.tz,
                                                 format=format,
                                                 na_rep=na_rep)
-
-    def to_datetime(self, dayfirst=False):
-        return self.copy()
 
     @Appender(_index_shared_docs['astype'])
     def astype(self, dtype, copy=True):

--- a/pandas/core/indexes/period.py
+++ b/pandas/core/indexes/period.py
@@ -3,7 +3,6 @@ from datetime import datetime, timedelta
 import numpy as np
 import warnings
 
-
 from pandas.core import common as com
 from pandas.core.dtypes.common import (
     is_integer,
@@ -611,17 +610,6 @@ class PeriodIndex(DatelikeOps, DatetimeIndexOpsMixin, Int64Index):
 
         return self._simple_new(new_data, self.name, freq=freq)
 
-    def to_datetime(self, dayfirst=False):
-        """
-        .. deprecated:: 0.19.0
-           Use :meth:`to_timestamp` instead.
-
-        Cast to DatetimeIndex.
-        """
-        warnings.warn("to_datetime is deprecated. Use self.to_timestamp(...)",
-                      FutureWarning, stacklevel=2)
-        return self.to_timestamp()
-
     year = _field_accessor('year', 0, "The year of the period")
     month = _field_accessor('month', 3, "The month as January=1, December=12")
     day = _field_accessor('day', 4, "The days of the period")
@@ -1214,8 +1202,6 @@ def _make_field_arrays(*fields):
 
 def pnow(freq=None):
     # deprecation, xref #13790
-    import warnings
-
     warnings.warn("pd.pnow() and pandas.core.indexes.period.pnow() "
                   "are deprecated. Please use Period.now()",
                   FutureWarning, stacklevel=2)

--- a/pandas/tests/indexes/datetimes/test_tools.py
+++ b/pandas/tests/indexes/datetimes/test_tools.py
@@ -23,8 +23,7 @@ from pandas.core.dtypes.common import is_datetime64_ns_dtype
 from pandas.util import testing as tm
 from pandas.util.testing import assert_series_equal, _skip_if_has_locale
 from pandas import (isna, to_datetime, Timestamp, Series, DataFrame,
-                    Index, DatetimeIndex, NaT, date_range, bdate_range,
-                    compat)
+                    Index, DatetimeIndex, NaT, date_range, compat)
 
 
 class TestTimeConversionFormats(object):
@@ -736,24 +735,6 @@ class TestToDatetimeUnit(object):
 class TestToDatetimeMisc(object):
 
     @pytest.mark.parametrize('cache', [True, False])
-    def test_index_to_datetime(self, cache):
-        idx = Index(['1/1/2000', '1/2/2000', '1/3/2000'])
-
-        with tm.assert_produces_warning(FutureWarning,
-                                        check_stacklevel=False):
-            result = idx.to_datetime()
-            expected = DatetimeIndex(pd.to_datetime(idx.values, cache=cache))
-            tm.assert_index_equal(result, expected)
-
-        with tm.assert_produces_warning(FutureWarning,
-                                        check_stacklevel=False):
-            today = datetime.today()
-            idx = Index([today], dtype=object)
-            result = idx.to_datetime()
-            expected = DatetimeIndex([today])
-            tm.assert_index_equal(result, expected)
-
-    @pytest.mark.parametrize('cache', [True, False])
     def test_to_datetime_iso8601(self, cache):
         result = to_datetime(["2012-01-01 00:00:00"], cache=cache)
         exp = Timestamp("2012-01-01 00:00:00")
@@ -887,12 +868,6 @@ class TestToDatetimeMisc(object):
         result = DatetimeIndex(ints)
 
         tm.assert_index_equal(rng, result)
-
-    def test_to_datetime_freq(self):
-        xp = bdate_range('2000-1-1', periods=10, tz='UTC')
-        rs = xp.to_datetime()
-        assert xp.freq == rs.freq
-        assert xp.tzinfo == rs.tzinfo
 
     def test_to_datetime_overflow(self):
         # gh-17637

--- a/pandas/tests/indexes/period/test_tools.py
+++ b/pandas/tests/indexes/period/test_tools.py
@@ -386,14 +386,6 @@ class TestPeriodIndex(object):
         result = index.to_timestamp()
         assert result[0] == Timestamp('1/1/2012')
 
-    def test_to_datetime_depr(self):
-        index = period_range('1/1/2012', periods=4, freq='D')
-
-        with tm.assert_produces_warning(FutureWarning,
-                                        check_stacklevel=False):
-            result = index.to_datetime()
-            assert result[0] == Timestamp('1/1/2012')
-
     def test_combine_first(self):
         # GH 3367
         didx = pd.DatetimeIndex(start='1950-01-31', end='1950-07-31', freq='M')

--- a/pandas/tests/scalar/test_timestamp.py
+++ b/pandas/tests/scalar/test_timestamp.py
@@ -672,16 +672,6 @@ class TestTimestamp(object):
  'foo': 1}"""
         assert result == expected
 
-    def test_to_datetime_depr(self):
-        # see gh-8254
-        ts = Timestamp('2011-01-01')
-
-        with tm.assert_produces_warning(FutureWarning,
-                                        check_stacklevel=False):
-            expected = datetime(2011, 1, 1)
-            result = ts.to_datetime()
-            assert result == expected
-
     def test_to_pydatetime_nonzero_nano(self):
         ts = Timestamp('2011-01-01 9:00:00.123456789')
 


### PR DESCRIPTION
Removes the following .to_datetime methods

* `Index.to_datetime`
* `Timestamp.to_datetime`
* `PeriodIndex.to_datetime`
* `DatetimeIndex.to_datetime`

All were deprecated in 0.19.0

xref #8254, #14096, #14113