### PR TITLE
DOC: temporary remove pyarrow example of reading subset columns

### DIFF
--- a/doc/source/io.rst
+++ b/doc/source/io.rst
@@ -4557,7 +4557,6 @@ Read only certain columns of a parquet file.
 
 .. ipython:: python
 
-   result = pd.read_parquet('example_pa.parquet', engine='pyarrow', columns=['a', 'b'])
    result = pd.read_parquet('example_fp.parquet', engine='fastparquet', columns=['a', 'b'])
 
    result.dtypes


### PR DESCRIPTION
xref #18628.

Until pyarrow 0.8 is released, I propose to just show the example with fastparquet. Once pyarrow 0.8 is released, we can revert this change.



