### PR TITLE
TST/DOC: test pyarrow tz data + doc / enable cross compat tests for pyarrow/fastparquet

### DIFF
--- a/doc/source/io.rst
+++ b/doc/source/io.rst
@@ -4522,6 +4522,7 @@ See the documentation for `pyarrow <http://arrow.apache.org/docs/python/>`__ and
 .. note::
 
    These engines are very similar and should read/write nearly identical parquet format files.
+   Currently ``pyarrow`` does not support timedelta data, and ``fastparquet`` does not support timezone aware datetimes (they are coerced to UTC).
    These libraries differ by having different underlying dependencies (``fastparquet`` by using ``numba``, while ``pyarrow`` uses a c-library).
 
 .. ipython:: python
@@ -4548,8 +4549,8 @@ Read from a parquet file.
 
 .. ipython:: python
 
-   result = pd.read_parquet('example_pa.parquet', engine='pyarrow')
    result = pd.read_parquet('example_fp.parquet', engine='fastparquet')
+   result = pd.read_parquet('example_pa.parquet', engine='pyarrow')
 
    result.dtypes
 

--- a/pandas/tests/io/test_parquet.py
+++ b/pandas/tests/io/test_parquet.py
@@ -323,8 +323,10 @@ class TestParquetPyArrow(Base):
         df = df_full
 
         # additional supported types for pyarrow
-        df['datetime_tz'] = pd.date_range('20130101', periods=3,
-                                          tz='Europe/Brussels')
+        import pyarrow
+        if LooseVersion(pyarrow.__version__) >= LooseVersion('0.7.0'):
+            df['datetime_tz'] = pd.date_range('20130101', periods=3,
+                                              tz='Europe/Brussels')
         df['bool_with_none'] = [True, None, True]
 
         self.check_round_trip(df, pa)

--- a/pandas/tests/io/test_parquet.py
+++ b/pandas/tests/io/test_parquet.py
@@ -186,6 +186,9 @@ def test_cross_engine_pa_fp(df_cross_compat, pa, fp):
         result = read_parquet(path, engine=fp)
         tm.assert_frame_equal(result, df)
 
+        result = read_parquet(path, engine=fp, columns=['a', 'd'])
+        tm.assert_frame_equal(result, df[['a', 'd']])
+
 
 def test_cross_engine_fp_pa(df_cross_compat, pa, fp):
     # cross-compat with differing reading/writing engines
@@ -196,6 +199,9 @@ def test_cross_engine_fp_pa(df_cross_compat, pa, fp):
 
         result = read_parquet(path, engine=pa)
         tm.assert_frame_equal(result, df)
+
+        result = read_parquet(path, engine=pa, columns=['a', 'd'])
+        tm.assert_frame_equal(result, df[['a', 'd']])
 
 
 class Base(object):

--- a/pandas/tests/io/test_parquet.py
+++ b/pandas/tests/io/test_parquet.py
@@ -80,13 +80,14 @@ def df_compat():
 def df_cross_compat():
     df = pd.DataFrame({'a': list('abc'),
                        'b': list(range(1, 4)),
-                       'c': np.arange(3, 6).astype('u1'),
+                       # 'c': np.arange(3, 6).astype('u1'),
                        'd': np.arange(4.0, 7.0, dtype='float64'),
                        'e': [True, False, True],
                        'f': pd.date_range('20130101', periods=3),
-                       'g': pd.date_range('20130101', periods=3,
-                                          tz='US/Eastern'),
-                       'h': pd.date_range('20130101', periods=3, freq='ns')})
+                       # 'g': pd.date_range('20130101', periods=3,
+                       #                    tz='US/Eastern'),
+                       # 'h': pd.date_range('20130101', periods=3, freq='ns')
+                       })
     return df
 
 
@@ -173,7 +174,6 @@ def test_options_get_engine(fp, pa):
         assert isinstance(get_engine('fastparquet'), FastParquetImpl)
 
 
-@pytest.mark.xfail(reason="fp does not ignore pa index __index_level_0__")
 def test_cross_engine_pa_fp(df_cross_compat, pa, fp):
     # cross-compat with differing reading/writing engines
 
@@ -185,7 +185,6 @@ def test_cross_engine_pa_fp(df_cross_compat, pa, fp):
         tm.assert_frame_equal(result, df)
 
 
-@pytest.mark.xfail(reason="pyarrow reading fp in some cases")
 def test_cross_engine_fp_pa(df_cross_compat, pa, fp):
     # cross-compat with differing reading/writing engines
 

--- a/pandas/tests/io/test_parquet.py
+++ b/pandas/tests/io/test_parquet.py
@@ -7,7 +7,7 @@ from warnings import catch_warnings
 
 import numpy as np
 import pandas as pd
-from pandas.compat import PY3
+from pandas.compat import PY3, is_platform_windows
 from pandas.io.parquet import (to_parquet, read_parquet, get_engine,
                                PyArrowImpl, FastParquetImpl)
 from pandas.util import testing as tm
@@ -174,6 +174,8 @@ def test_options_get_engine(fp, pa):
         assert isinstance(get_engine('fastparquet'), FastParquetImpl)
 
 
+@pytest.mark.xfail(is_platform_windows(),
+                   reason="reading pa metadata failing on Windows")
 def test_cross_engine_pa_fp(df_cross_compat, pa, fp):
     # cross-compat with differing reading/writing engines
 


### PR DESCRIPTION
Commits:

TST: add parquet test with tz datetime data for pyarrow
    
+ clean-up basic data types tests: make common dataframe with types
supported by both pyarrow and fastparquet

DOC: document differences between pyarrow and fastparquet in supported data types

TST: enable pyarrow/fastparquet cross compatibility tests on smaller subset of dataframe

Closes https://github.com/pandas-dev/pandas/issues/17448 
Also adds a test for https://github.com/pandas-dev/pandas/issues/18628
