### PR TITLE
DOC: added a reference to DataFrame assign in concatenate section of merging

### DIFF
--- a/doc/source/merging.rst
+++ b/doc/source/merging.rst
@@ -323,6 +323,13 @@ the name of the ``Series``.
           labels=['df1', 's1'], vertical=False);
    plt.close('all');
 
+.. note::
+
+   Since we're concatenating a ``Series`` to a ``DataFrame``, we could have
+   achieved the same result with :meth:`DataFrame.assign`. To concatenate an
+   arbitrary number of pandas objects (``DataFrame`` or ``Series``), use
+   ``concat``.
+
 If unnamed ``Series`` are passed they will be numbered consecutively.
 
 .. ipython:: python

--- a/doc/source/whatsnew/v0.23.0.txt
+++ b/doc/source/whatsnew/v0.23.0.txt
@@ -677,7 +677,7 @@ Documentation Changes
   Rewrote some sentences for greater clarity, added more dynamic references
   to functions, methods and classes.
   (:issue:`18941`, :issue:`18948`, :issue:`18973`, :issue:`19017`)
-
+- Added a reference to :func:`DataFrame.assign` in the concatenate section of the merging documentation (:issue:`18665`)
 
 .. _whatsnew_0230.bug_fixes:
 


### PR DESCRIPTION
Because of various stack overflow answers we are directed to the merging
page where a link to DataFrame.assign would be better. Adding the
reference here will make people's code better. At least it would have
for me.

- [ ] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry

For tests, we'll see with CI.