### PR TITLE
DEPR/CLN: Remove how keyword from df.rolling() etc.

### DIFF
--- a/doc/source/computation.rst
+++ b/doc/source/computation.rst
@@ -253,12 +253,6 @@ accept the following arguments:
   result is NA)
 - ``center``: boolean, whether to set the labels at the center (default is False)
 
-.. warning::
-
-   The ``freq`` and ``how`` arguments were in the API prior to 0.18.0 changes. These are deprecated in the new API. You can simply resample the input prior to creating a window function.
-
-   For example, instead of ``s.rolling(window=5,freq='D').max()`` to get the max value on a rolling 5 Day window, one could use ``s.resample('D').max().rolling(window=5).max()``, which first resamples the data to daily data, then provides a rolling 5 day window.
-
 We can then call methods on these ``rolling`` objects. These return like-indexed objects:
 
 .. ipython:: python

--- a/doc/source/whatsnew/v0.22.0.txt
+++ b/doc/source/whatsnew/v0.22.0.txt
@@ -237,8 +237,8 @@ Removal of prior version deprecations/changes
 - The ``SparseList`` class has been removed (:issue:`14007`)
 - The ``pandas.io.wb`` and ``pandas.io.data`` stub modules have been removed (:issue:`13735`)
 - ``Categorical.from_array`` has been removed (:issue:`13854`)
-- The ``freq`` parameter has been removed from the ``rolling``/``expanding``/``ewm`` methods of DataFrame
-  and Series (deprecated since v0.18). Instead, resample before calling the methods. (:issue:18601)
+- The ``freq`` and ``how`` parameters have been removed from the ``rolling``/``expanding``/``ewm`` methods of DataFrame
+  and Series (deprecated since v0.18). Instead, resample before calling the methods. (:issue:18601 & :issue:18668)
 - ``DatetimeIndex.to_datetime``, ``Timestamp.to_datetime``, ``PeriodIndex.to_datetime``, and ``Index.to_datetime`` have been removed (:issue:`8254`, :issue:`14096`, :issue:`14113`)
 
 .. _whatsnew_0220.performance:

--- a/pandas/tests/test_window.py
+++ b/pandas/tests/test_window.py
@@ -3019,7 +3019,7 @@ class TestMomentsConsistency(Base):
         x = series.resample('D').max().rolling(window=1).max()
         tm.assert_series_equal(expected, x)
 
-    def test_rolling_max_how_resample(self):
+    def test_rolling_max_resample(self):
 
         indices = [datetime(1975, 1, i) for i in range(1, 6)]
         # So that we can have 3 datapoints on last day (4, 10, and 20)
@@ -3040,17 +3040,17 @@ class TestMomentsConsistency(Base):
         # Now specify median (10.0)
         expected = Series([0.0, 1.0, 2.0, 3.0, 10.0],
                           index=[datetime(1975, 1, i, 0) for i in range(1, 6)])
-        x = series.resample('D').median().rolling(window=1).max(how='median')
+        x = series.resample('D').median().rolling(window=1).max()
         tm.assert_series_equal(expected, x)
 
         # Now specify mean (4+10+20)/3
         v = (4.0 + 10.0 + 20.0) / 3.0
         expected = Series([0.0, 1.0, 2.0, 3.0, v],
                           index=[datetime(1975, 1, i, 0) for i in range(1, 6)])
-        x = series.resample('D').mean().rolling(window=1).max(how='mean')
+        x = series.resample('D').mean().rolling(window=1).max()
         tm.assert_series_equal(expected, x)
 
-    def test_rolling_min_how_resample(self):
+    def test_rolling_min_resample(self):
 
         indices = [datetime(1975, 1, i) for i in range(1, 6)]
         # So that we can have 3 datapoints on last day (4, 10, and 20)
@@ -3068,7 +3068,7 @@ class TestMomentsConsistency(Base):
         r = series.resample('D').min().rolling(window=1)
         tm.assert_series_equal(expected, r.min())
 
-    def test_rolling_median_how_resample(self):
+    def test_rolling_median_resample(self):
 
         indices = [datetime(1975, 1, i) for i in range(1, 6)]
         # So that we can have 3 datapoints on last day (4, 10, and 20)


### PR DESCRIPTION
- [x] xref #18601 and #11603
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry

The ``how`` parameter of df.rolling/expanding/ewm related methods was deprecated in 0.18 (#11603). This PR removes the parameter from the code base.

This PR is a continuation of #18601 (removed the ``freq`` parameter). Next up will be to remove ``pd.stats.*``).