### PR TITLE
BUG: Ensure Index.astype('category') returns a CategoricalIndex

### DIFF
--- a/doc/source/whatsnew/v0.22.0.txt
+++ b/doc/source/whatsnew/v0.22.0.txt
@@ -259,6 +259,7 @@ Conversion
 - Fixed a bug where creating a Series from an array that contains both tz-naive and tz-aware values will result in a Series whose dtype is tz-aware instead of object (:issue:`16406`)
 - Adding a ``Period`` object to a ``datetime`` or ``Timestamp`` object will now correctly raise a ``TypeError`` (:issue:`17983`)
 - Fixed a bug where ``FY5253`` date offsets could incorrectly raise an ``AssertionError`` in arithmetic operatons (:issue:`14774`)
+- Bug in :meth:`Index.astype` with a categorical dtype where the resultant index would not be converted to a :class:`CategoricalIndex` for all types of index (:issue:`18630`)
 
 
 Indexing

--- a/doc/source/whatsnew/v0.22.0.txt
+++ b/doc/source/whatsnew/v0.22.0.txt
@@ -259,7 +259,7 @@ Conversion
 - Fixed a bug where creating a Series from an array that contains both tz-naive and tz-aware values will result in a Series whose dtype is tz-aware instead of object (:issue:`16406`)
 - Adding a ``Period`` object to a ``datetime`` or ``Timestamp`` object will now correctly raise a ``TypeError`` (:issue:`17983`)
 - Fixed a bug where ``FY5253`` date offsets could incorrectly raise an ``AssertionError`` in arithmetic operatons (:issue:`14774`)
-- Bug in :meth:`Index.astype` with a categorical dtype where the resultant index would not be converted to a :class:`CategoricalIndex` for all types of index (:issue:`18630`)
+- Bug in :meth:`Index.astype` with a categorical dtype where the resultant index is not converted to a :class:`CategoricalIndex` for all types of index (:issue:`18630`)
 
 
 Indexing

--- a/pandas/core/dtypes/common.py
+++ b/pandas/core/dtypes/common.py
@@ -1934,7 +1934,7 @@ def pandas_dtype(dtype):
             except TypeError:
                 pass
 
-        elif dtype.startswith('interval[') or dtype.startswith('Interval['):
+        elif dtype.startswith('interval') or dtype.startswith('Interval'):
             try:
                 return IntervalDtype.construct_from_string(dtype)
             except TypeError:

--- a/pandas/core/dtypes/dtypes.py
+++ b/pandas/core/dtypes/dtypes.py
@@ -340,6 +340,33 @@ class CategoricalDtype(ExtensionDtype):
 
         return categories
 
+    def _update_dtype(self, dtype):
+        """
+        Returns a CategoricalDtype with categories and ordered taken from dtype
+        if specified, otherwise falling back to self if unspecified
+
+        Parameters
+        ----------
+        dtype : CategoricalDtype
+
+        Returns
+        -------
+        new_dtype : CategoricalDtype
+        """
+        if isinstance(dtype, compat.string_types) and dtype == 'category':
+            # dtype='category' should not change anything
+            return self
+        elif not self.is_dtype(dtype):
+            msg = ('a CategoricalDtype must be passed to perform an update, '
+                   'got {dtype!r}').format(dtype=dtype)
+            raise ValueError(msg)
+
+        # dtype is CDT: keep current categories if None (ordered can't be None)
+        new_categories = dtype.categories
+        if new_categories is None:
+            new_categories = self.categories
+        return CategoricalDtype(new_categories, dtype.ordered)
+
     @property
     def categories(self):
         """

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -1053,6 +1053,10 @@ class Index(IndexOpsMixin, PandasObject):
 
     @Appender(_index_shared_docs['astype'])
     def astype(self, dtype, copy=True):
+        if is_categorical_dtype(dtype):
+            from pandas.core.indexes.category import CategoricalIndex
+            return CategoricalIndex(self.values, name=self.name, dtype=dtype,
+                                    copy=copy)
         return Index(self.values.astype(dtype, copy=copy), name=self.name,
                      dtype=dtype)
 

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -1054,7 +1054,7 @@ class Index(IndexOpsMixin, PandasObject):
     @Appender(_index_shared_docs['astype'])
     def astype(self, dtype, copy=True):
         if is_categorical_dtype(dtype):
-            from pandas.core.indexes.category import CategoricalIndex
+            from .category import CategoricalIndex
             return CategoricalIndex(self.values, name=self.name, dtype=dtype,
                                     copy=copy)
         return Index(self.values.astype(dtype, copy=copy), name=self.name,

--- a/pandas/core/indexes/category.py
+++ b/pandas/core/indexes/category.py
@@ -9,7 +9,8 @@ from pandas.core.dtypes.common import (
     _ensure_platform_int,
     is_list_like,
     is_interval_dtype,
-    is_scalar)
+    is_scalar,
+    pandas_dtype)
 from pandas.core.common import (_asarray_tuplesafe,
                                 _values_from_object)
 from pandas.core.dtypes.missing import array_equivalent, isna
@@ -341,9 +342,13 @@ class CategoricalIndex(Index, accessor.PandasDelegate):
 
     @Appender(_index_shared_docs['astype'])
     def astype(self, dtype, copy=True):
+        dtype = pandas_dtype(dtype)
         if is_interval_dtype(dtype):
             from pandas import IntervalIndex
             return IntervalIndex.from_intervals(np.array(self))
+        elif is_categorical_dtype(dtype) and (dtype == self.dtype):
+            # fastpath if dtype is the same current
+            return self.copy() if copy else self
         return super(CategoricalIndex, self).astype(dtype=dtype, copy=copy)
 
     @cache_readonly

--- a/pandas/core/indexes/datetimes.py
+++ b/pandas/core/indexes/datetimes.py
@@ -20,6 +20,7 @@ from pandas.core.dtypes.common import (
     is_period_dtype,
     is_bool_dtype,
     is_string_dtype,
+    is_categorical_dtype,
     is_string_like,
     is_list_like,
     is_scalar,
@@ -915,6 +916,10 @@ class DatetimeIndex(DatelikeOps, TimelikeOps, DatetimeIndexOpsMixin,
             elif copy is True:
                 return self.copy()
             return self
+        elif is_categorical_dtype(dtype):
+            from pandas.core.indexes.category import CategoricalIndex
+            return CategoricalIndex(self.values, name=self.name, dtype=dtype,
+                                    copy=copy)
         elif is_string_dtype(dtype):
             return Index(self.format(), name=self.name, dtype=object)
         elif is_period_dtype(dtype):

--- a/pandas/core/indexes/datetimes.py
+++ b/pandas/core/indexes/datetimes.py
@@ -36,6 +36,7 @@ from pandas.core.common import _values_from_object, _maybe_box
 from pandas.core.algorithms import checked_add_with_arr
 
 from pandas.core.indexes.base import Index, _index_shared_docs
+from pandas.core.indexes.category import CategoricalIndex
 from pandas.core.indexes.numeric import Int64Index, Float64Index
 import pandas.compat as compat
 from pandas.tseries.frequencies import (
@@ -917,7 +918,6 @@ class DatetimeIndex(DatelikeOps, TimelikeOps, DatetimeIndexOpsMixin,
                 return self.copy()
             return self
         elif is_categorical_dtype(dtype):
-            from pandas.core.indexes.category import CategoricalIndex
             return CategoricalIndex(self.values, name=self.name, dtype=dtype,
                                     copy=copy)
         elif is_string_dtype(dtype):

--- a/pandas/core/indexes/interval.py
+++ b/pandas/core/indexes/interval.py
@@ -632,8 +632,9 @@ class IntervalIndex(IntervalMixin, Index):
         elif is_object_dtype(dtype):
             return Index(self.values, dtype=object)
         elif is_categorical_dtype(dtype):
-            from pandas import Categorical
-            return Categorical(self, ordered=True)
+            from pandas.core.indexes.category import CategoricalIndex
+            return CategoricalIndex(self.values, name=self.name, dtype=dtype,
+                                    copy=copy)
         raise ValueError('Cannot cast IntervalIndex to dtype {dtype}'
                          .format(dtype=dtype))
 

--- a/pandas/core/indexes/interval.py
+++ b/pandas/core/indexes/interval.py
@@ -29,6 +29,7 @@ from pandas._libs.interval import (
     Interval, IntervalMixin, IntervalTree,
     intervals_to_interval_bounds)
 
+from pandas.core.indexes.category import CategoricalIndex
 from pandas.core.indexes.datetimes import date_range
 from pandas.core.indexes.timedeltas import timedelta_range
 from pandas.core.indexes.multi import MultiIndex
@@ -632,7 +633,6 @@ class IntervalIndex(IntervalMixin, Index):
         elif is_object_dtype(dtype):
             return Index(self.values, dtype=object)
         elif is_categorical_dtype(dtype):
-            from pandas.core.indexes.category import CategoricalIndex
             return CategoricalIndex(self.values, name=self.name, dtype=dtype,
                                     copy=copy)
         raise ValueError('Cannot cast IntervalIndex to dtype {dtype}'

--- a/pandas/core/indexes/multi.py
+++ b/pandas/core/indexes/multi.py
@@ -17,6 +17,7 @@ from pandas.core.dtypes.common import (
     is_object_dtype,
     is_iterator,
     is_list_like,
+    pandas_dtype,
     is_scalar)
 from pandas.core.dtypes.missing import isna, array_equivalent
 from pandas.errors import PerformanceWarning, UnsortedIndexError
@@ -2715,7 +2716,7 @@ class MultiIndex(Index):
 
     @Appender(_index_shared_docs['astype'])
     def astype(self, dtype, copy=True):
-        if not is_object_dtype(np.dtype(dtype)):
+        if not is_object_dtype(pandas_dtype(dtype)):
             raise TypeError('Setting %s dtype to anything other than object '
                             'is not supported' % self.__class__)
         elif copy is True:

--- a/pandas/core/indexes/multi.py
+++ b/pandas/core/indexes/multi.py
@@ -14,6 +14,7 @@ from pandas import compat
 from pandas.core.dtypes.common import (
     _ensure_int64,
     _ensure_platform_int,
+    is_categorical_dtype,
     is_object_dtype,
     is_iterator,
     is_list_like,
@@ -2716,9 +2717,14 @@ class MultiIndex(Index):
 
     @Appender(_index_shared_docs['astype'])
     def astype(self, dtype, copy=True):
-        if not is_object_dtype(pandas_dtype(dtype)):
-            raise TypeError('Setting %s dtype to anything other than object '
-                            'is not supported' % self.__class__)
+        dtype = pandas_dtype(dtype)
+        if is_categorical_dtype(dtype):
+            msg = '> 1 ndim Categorical are not supported at this time'
+            raise NotImplementedError(msg)
+        elif not is_object_dtype(dtype):
+            msg = ('Setting {cls} dtype to anything other than object '
+                   'is not supported').format(cls=self.__class__)
+            raise TypeError(msg)
         elif copy is True:
             return self._shallow_copy()
         return self

--- a/pandas/core/indexes/numeric.py
+++ b/pandas/core/indexes/numeric.py
@@ -7,6 +7,7 @@ from pandas.core.dtypes.common import (
     is_float_dtype,
     is_object_dtype,
     is_integer_dtype,
+    is_categorical_dtype,
     is_bool,
     is_bool_dtype,
     is_scalar)
@@ -321,10 +322,14 @@ class Float64Index(NumericIndex):
             values = self._values.astype(dtype, copy=copy)
         elif is_object_dtype(dtype):
             values = self._values.astype('object', copy=copy)
+        elif is_categorical_dtype(dtype):
+            from pandas.core.indexes.category import CategoricalIndex
+            return CategoricalIndex(self, name=self.name, dtype=dtype,
+                                    copy=copy)
         else:
-            raise TypeError('Setting %s dtype to anything other than '
-                            'float64 or object is not supported' %
-                            self.__class__)
+            raise TypeError('Setting {cls} dtype to anything other than '
+                            'float64, object, or category is not supported'
+                            .format(cls=self.__class__))
         return Index(values, name=self.name, dtype=dtype)
 
     @Appender(_index_shared_docs['_convert_scalar_indexer'])

--- a/pandas/core/indexes/numeric.py
+++ b/pandas/core/indexes/numeric.py
@@ -17,6 +17,7 @@ from pandas import compat
 from pandas.core import algorithms
 from pandas.core.indexes.base import (
     Index, InvalidIndexError, _index_shared_docs)
+from pandas.core.indexes.category import CategoricalIndex
 from pandas.util._decorators import Appender, cache_readonly
 import pandas.core.dtypes.concat as _concat
 import pandas.core.indexes.base as ibase
@@ -323,7 +324,6 @@ class Float64Index(NumericIndex):
         elif is_object_dtype(dtype):
             values = self._values.astype('object', copy=copy)
         elif is_categorical_dtype(dtype):
-            from pandas.core.indexes.category import CategoricalIndex
             return CategoricalIndex(self, name=self.name, dtype=dtype,
                                     copy=copy)
         else:

--- a/pandas/core/indexes/period.py
+++ b/pandas/core/indexes/period.py
@@ -16,6 +16,7 @@ from pandas.core.dtypes.common import (
     is_timedelta64_dtype,
     is_period_dtype,
     is_bool_dtype,
+    is_categorical_dtype,
     pandas_dtype,
     _ensure_object)
 from pandas.core.dtypes.dtypes import PeriodDtype
@@ -517,6 +518,10 @@ class PeriodIndex(DatelikeOps, DatetimeIndexOpsMixin, Int64Index):
             return self.to_timestamp(how=how).tz_localize(dtype.tz)
         elif is_period_dtype(dtype):
             return self.asfreq(freq=dtype.freq)
+        elif is_categorical_dtype(dtype):
+            from pandas.core.indexes.category import CategoricalIndex
+            return CategoricalIndex(self.values, name=self.name, dtype=dtype,
+                                    copy=copy)
         raise TypeError('Cannot cast PeriodIndex to dtype %s' % dtype)
 
     @Substitution(klass='PeriodIndex')

--- a/pandas/core/indexes/period.py
+++ b/pandas/core/indexes/period.py
@@ -24,6 +24,7 @@ from pandas.core.dtypes.generic import ABCSeries
 
 import pandas.tseries.frequencies as frequencies
 from pandas.tseries.frequencies import get_freq_code as _gfc
+from pandas.core.indexes.category import CategoricalIndex
 from pandas.core.indexes.datetimes import DatetimeIndex, Int64Index, Index
 from pandas.core.indexes.timedeltas import TimedeltaIndex
 from pandas.core.indexes.datetimelike import DatelikeOps, DatetimeIndexOpsMixin
@@ -519,7 +520,6 @@ class PeriodIndex(DatelikeOps, DatetimeIndexOpsMixin, Int64Index):
         elif is_period_dtype(dtype):
             return self.asfreq(freq=dtype.freq)
         elif is_categorical_dtype(dtype):
-            from pandas.core.indexes.category import CategoricalIndex
             return CategoricalIndex(self.values, name=self.name, dtype=dtype,
                                     copy=copy)
         raise TypeError('Cannot cast PeriodIndex to dtype %s' % dtype)

--- a/pandas/core/indexes/timedeltas.py
+++ b/pandas/core/indexes/timedeltas.py
@@ -20,6 +20,7 @@ from pandas.core.dtypes.generic import ABCSeries
 from pandas.core.common import _maybe_box, _values_from_object
 
 from pandas.core.indexes.base import Index
+from pandas.core.indexes.category import CategoricalIndex
 from pandas.core.indexes.numeric import Int64Index
 import pandas.compat as compat
 from pandas.compat import u
@@ -501,7 +502,6 @@ class TimedeltaIndex(DatetimeIndexOpsMixin, TimelikeOps, Int64Index):
             return Index(self.values.astype('i8', copy=copy), dtype='i8',
                          name=self.name)
         elif is_categorical_dtype(dtype):
-            from pandas.core.indexes.category import CategoricalIndex
             return CategoricalIndex(self.values, name=self.name, dtype=dtype,
                                     copy=copy)
         raise TypeError('Cannot cast TimedeltaIndex to dtype %s' % dtype)

--- a/pandas/core/indexes/timedeltas.py
+++ b/pandas/core/indexes/timedeltas.py
@@ -12,6 +12,8 @@ from pandas.core.dtypes.common import (
     is_object_dtype,
     is_timedelta64_dtype,
     is_timedelta64_ns_dtype,
+    is_categorical_dtype,
+    pandas_dtype,
     _ensure_int64)
 from pandas.core.dtypes.missing import isna
 from pandas.core.dtypes.generic import ABCSeries
@@ -479,7 +481,7 @@ class TimedeltaIndex(DatetimeIndexOpsMixin, TimelikeOps, Int64Index):
 
     @Appender(_index_shared_docs['astype'])
     def astype(self, dtype, copy=True):
-        dtype = np.dtype(dtype)
+        dtype = pandas_dtype(dtype)
 
         if is_object_dtype(dtype):
             return self._box_values_as_index()
@@ -498,6 +500,10 @@ class TimedeltaIndex(DatetimeIndexOpsMixin, TimelikeOps, Int64Index):
         elif is_integer_dtype(dtype):
             return Index(self.values.astype('i8', copy=copy), dtype='i8',
                          name=self.name)
+        elif is_categorical_dtype(dtype):
+            from pandas.core.indexes.category import CategoricalIndex
+            return CategoricalIndex(self.values, name=self.name, dtype=dtype,
+                                    copy=copy)
         raise TypeError('Cannot cast TimedeltaIndex to dtype %s' % dtype)
 
     def union(self, other):

--- a/pandas/tests/indexes/common.py
+++ b/pandas/tests/indexes/common.py
@@ -13,6 +13,7 @@ from pandas import (Series, Index, Float64Index, Int64Index, UInt64Index,
 from pandas.core.indexes.base import InvalidIndexError
 from pandas.core.indexes.datetimelike import DatetimeIndexOpsMixin
 from pandas.core.dtypes.common import needs_i8_conversion
+from pandas.core.dtypes.dtypes import CategoricalDtype
 from pandas._libs.tslib import iNaT
 
 import pandas.util.testing as tm
@@ -1058,3 +1059,20 @@ class Base(object):
 
         with pytest.raises(ValueError):
             index.putmask('foo', 1)
+
+    def test_astype_category(self):
+        # GH 18630
+        index = self.create_index()
+
+        expected = CategoricalIndex(index.values)
+        result = index.astype('category', copy=True)
+        tm.assert_index_equal(result, expected)
+
+        expected = CategoricalIndex(index.values, name='foo')
+        result = index.rename('foo').astype('category', copy=False)
+        tm.assert_index_equal(result, expected)
+
+        dtype = CategoricalDtype(index.unique()[:-1], ordered=True)
+        expected = CategoricalIndex(index.values, dtype=dtype)
+        result = index.astype(dtype)
+        tm.assert_index_equal(result, expected)

--- a/pandas/tests/indexes/test_category.py
+++ b/pandas/tests/indexes/test_category.py
@@ -388,9 +388,6 @@ class TestCategoricalIndex(Base):
     def test_astype(self):
 
         ci = self.create_index()
-        result = ci.astype('category')
-        tm.assert_index_equal(result, ci, exact=True)
-
         result = ci.astype(object)
         tm.assert_index_equal(result, Index(np.array(ci)))
 
@@ -413,6 +410,38 @@ class TestCategoricalIndex(Base):
 
         result = IntervalIndex.from_intervals(result.values)
         tm.assert_index_equal(result, expected)
+
+    @pytest.mark.parametrize('copy', [True, False])
+    @pytest.mark.parametrize('name', [None, 'foo'])
+    @pytest.mark.parametrize('dtype_ordered', [True, False])
+    @pytest.mark.parametrize('index_ordered', [True, False])
+    def test_astype_category(self, copy, name, dtype_ordered, index_ordered):
+        # GH 18630
+        index = self.create_index(ordered=index_ordered)
+        if name:
+            index = index.rename(name)
+
+        # standard categories
+        dtype = CategoricalDtype(ordered=dtype_ordered)
+        result = index.astype(dtype, copy=copy)
+        expected = CategoricalIndex(index.tolist(),
+                                    name=name,
+                                    categories=index.categories,
+                                    ordered=dtype_ordered)
+        tm.assert_index_equal(result, expected)
+
+        # non-standard categories
+        dtype = CategoricalDtype(index.unique().tolist()[:-1], dtype_ordered)
+        result = index.astype(dtype, copy=copy)
+        expected = CategoricalIndex(index.tolist(), name=name, dtype=dtype)
+        tm.assert_index_equal(result, expected)
+
+        if dtype_ordered is False:
+            # dtype='category' defaults to ordered=False, so only test once
+            result = index.astype('category', copy=copy)
+            expected = CategoricalIndex(
+                index.tolist(), categories=index.categories, name=name)
+            tm.assert_index_equal(result, expected)
 
     def test_reindex_base(self):
         # Determined by cat ordering.

--- a/pandas/tests/indexes/test_category.py
+++ b/pandas/tests/indexes/test_category.py
@@ -437,10 +437,9 @@ class TestCategoricalIndex(Base):
         tm.assert_index_equal(result, expected)
 
         if dtype_ordered is False:
-            # dtype='category' defaults to ordered=False, so only test once
+            # dtype='category' can't specify ordered, so only test once
             result = index.astype('category', copy=copy)
-            expected = CategoricalIndex(
-                index.tolist(), categories=index.categories, name=name)
+            expected = index
             tm.assert_index_equal(result, expected)
 
     def test_reindex_base(self):

--- a/pandas/tests/indexes/test_interval.py
+++ b/pandas/tests/indexes/test_interval.py
@@ -6,6 +6,7 @@ from datetime import timedelta
 from pandas import (
     Interval, IntervalIndex, Index, isna, notna, interval_range, Timestamp,
     Timedelta, compat, date_range, timedelta_range, DateOffset)
+from pandas.core.dtypes.dtypes import CategoricalDtype
 from pandas.compat import lzip
 from pandas.tseries.offsets import Day
 from pandas._libs.interval import IntervalTree
@@ -376,8 +377,15 @@ class TestIntervalIndex(Base):
         tm.assert_index_equal(result, idx)
         assert result.equals(idx)
 
-        result = idx.astype('category')
+    def test_astype_category(self, closed):
+        # GH 18630
+        idx = self.create_index(closed=closed)
         expected = pd.Categorical(idx, ordered=True)
+
+        result = idx.astype('category')
+        tm.assert_categorical_equal(result, expected)
+
+        result = idx.astype(CategoricalDtype())
         tm.assert_categorical_equal(result, expected)
 
     @pytest.mark.parametrize('klass', [list, tuple, np.array, pd.Series])

--- a/pandas/tests/indexes/test_interval.py
+++ b/pandas/tests/indexes/test_interval.py
@@ -6,7 +6,6 @@ from datetime import timedelta
 from pandas import (
     Interval, IntervalIndex, Index, isna, notna, interval_range, Timestamp,
     Timedelta, compat, date_range, timedelta_range, DateOffset)
-from pandas.core.dtypes.dtypes import CategoricalDtype
 from pandas.compat import lzip
 from pandas.tseries.offsets import Day
 from pandas._libs.interval import IntervalTree
@@ -376,17 +375,6 @@ class TestIntervalIndex(Base):
         result = idx.astype('interval')
         tm.assert_index_equal(result, idx)
         assert result.equals(idx)
-
-    def test_astype_category(self, closed):
-        # GH 18630
-        idx = self.create_index(closed=closed)
-        expected = pd.Categorical(idx, ordered=True)
-
-        result = idx.astype('category')
-        tm.assert_categorical_equal(result, expected)
-
-        result = idx.astype(CategoricalDtype())
-        tm.assert_categorical_equal(result, expected)
 
     @pytest.mark.parametrize('klass', [list, tuple, np.array, pd.Series])
     def test_where(self, closed, klass):

--- a/pandas/tests/indexes/test_multi.py
+++ b/pandas/tests/indexes/test_multi.py
@@ -16,6 +16,7 @@ from pandas import (CategoricalIndex, DataFrame, Index, MultiIndex,
                     compat, date_range, period_range)
 from pandas.compat import PY3, long, lrange, lzip, range, u, PYPY
 from pandas.errors import PerformanceWarning, UnsortedIndexError
+from pandas.core.dtypes.dtypes import CategoricalDtype
 from pandas.core.indexes.base import InvalidIndexError
 from pandas._libs import lib
 from pandas._libs.lib import Timestamp
@@ -553,6 +554,15 @@ class TestMultiIndex(Base):
 
         with tm.assert_raises_regex(TypeError, "^Setting.*dtype.*object"):
             self.index.astype(np.dtype(int))
+
+    def test_astype_category(self):
+        # GH 18630
+        msg = 'Setting .* dtype to anything other than object is not supported'
+        with tm.assert_raises_regex(TypeError, msg):
+            self.index.astype('category')
+
+        with tm.assert_raises_regex(TypeError, msg):
+            self.index.astype(CategoricalDtype())
 
     def test_constructor_single_level(self):
         result = MultiIndex(levels=[['foo', 'bar', 'baz', 'qux']],

--- a/pandas/tests/indexes/test_multi.py
+++ b/pandas/tests/indexes/test_multi.py
@@ -555,14 +555,17 @@ class TestMultiIndex(Base):
         with tm.assert_raises_regex(TypeError, "^Setting.*dtype.*object"):
             self.index.astype(np.dtype(int))
 
-    def test_astype_category(self):
+    @pytest.mark.parametrize('ordered', [True, False])
+    def test_astype_category(self, ordered):
         # GH 18630
-        msg = 'Setting .* dtype to anything other than object is not supported'
-        with tm.assert_raises_regex(TypeError, msg):
-            self.index.astype('category')
+        msg = '> 1 ndim Categorical are not supported at this time'
+        with tm.assert_raises_regex(NotImplementedError, msg):
+            self.index.astype(CategoricalDtype(ordered=ordered))
 
-        with tm.assert_raises_regex(TypeError, msg):
-            self.index.astype(CategoricalDtype())
+        if ordered is False:
+            # dtype='category' defaults to ordered=False, so only test once
+            with tm.assert_raises_regex(NotImplementedError, msg):
+                self.index.astype('category')
 
     def test_constructor_single_level(self):
         result = MultiIndex(levels=[['foo', 'bar', 'baz', 'qux']],

--- a/pandas/tests/reshape/test_tile.py
+++ b/pandas/tests/reshape/test_tile.py
@@ -4,9 +4,8 @@ import pytest
 import numpy as np
 from pandas.compat import zip
 
-from pandas import (Series, Index, isna,
-                    to_datetime, DatetimeIndex, Timestamp,
-                    Interval, IntervalIndex, Categorical,
+from pandas import (Series, isna, to_datetime, DatetimeIndex,
+                    Timestamp, Interval, IntervalIndex, Categorical,
                     cut, qcut, date_range)
 import pandas.util.testing as tm
 from pandas.api.types import CategoricalDtype as CDT
@@ -29,7 +28,8 @@ class TestCut(object):
         result, bins = cut(data, 3, retbins=True)
 
         intervals = IntervalIndex.from_breaks(bins.round(3))
-        expected = intervals.take([0, 0, 0, 1, 2, 0]).astype('category')
+        intervals = intervals.take([0, 0, 0, 1, 2, 0])
+        expected = Categorical(intervals, ordered=True)
         tm.assert_categorical_equal(result, expected)
         tm.assert_almost_equal(bins, np.array([0.1905, 3.36666667,
                                                6.53333333, 9.7]))
@@ -38,7 +38,8 @@ class TestCut(object):
         data = np.array([.2, 1.4, 2.5, 6.2, 9.7, 2.1, 2.575])
         result, bins = cut(data, 4, right=True, retbins=True)
         intervals = IntervalIndex.from_breaks(bins.round(3))
-        expected = intervals.astype('category').take([0, 0, 0, 2, 3, 0, 0])
+        expected = Categorical(intervals, ordered=True)
+        expected = expected.take([0, 0, 0, 2, 3, 0, 0])
         tm.assert_categorical_equal(result, expected)
         tm.assert_almost_equal(bins, np.array([0.1905, 2.575, 4.95,
                                                7.325, 9.7]))
@@ -47,7 +48,8 @@ class TestCut(object):
         data = np.array([.2, 1.4, 2.5, 6.2, 9.7, 2.1, 2.575])
         result, bins = cut(data, 4, right=False, retbins=True)
         intervals = IntervalIndex.from_breaks(bins.round(3), closed='left')
-        expected = intervals.take([0, 0, 0, 2, 3, 0, 1]).astype('category')
+        intervals = intervals.take([0, 0, 0, 2, 3, 0, 1])
+        expected = Categorical(intervals, ordered=True)
         tm.assert_categorical_equal(result, expected)
         tm.assert_almost_equal(bins, np.array([0.2, 2.575, 4.95,
                                                7.325, 9.7095]))
@@ -56,7 +58,8 @@ class TestCut(object):
         data = [.2, 1.4, 2.5, 6.2, 9.7, 2.1]
         result, bins = cut(data, 3, retbins=True)
         intervals = IntervalIndex.from_breaks(bins.round(3))
-        expected = intervals.take([0, 0, 0, 1, 2, 0]).astype('category')
+        intervals = intervals.take([0, 0, 0, 1, 2, 0])
+        expected = Categorical(intervals, ordered=True)
         tm.assert_categorical_equal(result, expected)
         tm.assert_almost_equal(bins, np.array([0.1905, 3.36666667,
                                                6.53333333, 9.7]))
@@ -249,8 +252,8 @@ class TestCut(object):
 
     def test_qcut_index(self):
         result = qcut([0, 2], 2)
-        expected = Index([Interval(-0.001, 1), Interval(1, 2)]).astype(
-            'category')
+        intervals = [Interval(-0.001, 1), Interval(1, 2)]
+        expected = Categorical(intervals, ordered=True)
         tm.assert_categorical_equal(result, expected)
 
     def test_round_frac(self):

--- a/pandas/tests/test_algos.py
+++ b/pandas/tests/test_algos.py
@@ -19,6 +19,7 @@ from pandas.compat import lrange, range
 import pandas.core.algorithms as algos
 from pandas.core.common import _asarray_tuplesafe
 import pandas.util.testing as tm
+from pandas.core.dtypes.dtypes import CategoricalDtype as CDT
 from pandas.compat.numpy import np_array_datetime64_compat
 from pandas.util.testing import assert_almost_equal
 
@@ -565,8 +566,8 @@ class TestValueCounts(object):
         # assert isinstance(factor, n)
         result = algos.value_counts(factor)
         breaks = [-1.194, -0.535, 0.121, 0.777, 1.433]
-        expected_index = IntervalIndex.from_breaks(breaks).astype('category')
-        expected = Series([1, 1, 1, 1], index=expected_index)
+        index = IntervalIndex.from_breaks(breaks).astype(CDT(ordered=True))
+        expected = Series([1, 1, 1, 1], index=index)
         tm.assert_series_equal(result.sort_index(), expected.sort_index())
 
     def test_value_counts_bins(self):


### PR DESCRIPTION
- [X] closes #18630
- [X] tests added / passed
- [X] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [X] whatsnew entry

Notes:
  - `MultiIndex.astype('category')` raises per @TomAugspurger's comment in the issue.
  - `IntervalIndex.astype('category')` return a `Categorical` with `ordered=True` instead of `CategoricalIndex`, since it looks like someone previously intentionally implemented it this way.  I don't immediately see a reason why, but left it as is.  Would be straightforward to make this consistent and return a `CategoricalIndex`.
  -  All other types of index should return a `CategoricalIndex`.