### PR TITLE
Documentation fix for method last_valid_index

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -4320,7 +4320,7 @@ class DataFrame(NDFrame):
         return valid_indices[0] if len(valid_indices) else None
 
     @Appender(_shared_docs['valid_index'] % {
-        'position': 'first', 'klass': 'DataFrame'})
+        'position': 'last', 'klass': 'DataFrame'})
     def last_valid_index(self):
         if len(self) == 0:
             return None


### PR DESCRIPTION
Documentation was showing "Return index for first non-NA/null value" for both first_valid_index and last_valid_index methods. Fixed by switching "first" to "last"

- [ X ] closes #18564
- [ ] tests added / passed
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
