### PR TITLE
Added mpl_15 decorator

### DIFF
--- a/pandas/tests/plotting/test_datetimelike.py
+++ b/pandas/tests/plotting/test_datetimelike.py
@@ -519,6 +519,7 @@ class TestTSPlot(TestPlotBase):
             xp = Period('1/1/1999', freq='H').ordinal
         assert rs == xp
 
+    @td.skip_if_mpl_1_5
     @pytest.mark.slow
     def test_gaps(self):
         ts = tm.makeTimeSeries()
@@ -526,7 +527,6 @@ class TestTSPlot(TestPlotBase):
         _, ax = self.plt.subplots()
         ts.plot(ax=ax)
         lines = ax.get_lines()
-        tm._skip_if_mpl_1_5()
         assert len(lines) == 1
         l = lines[0]
         data = l.get_xydata()
@@ -564,6 +564,7 @@ class TestTSPlot(TestPlotBase):
         mask = data.mask
         assert mask[2:5, 1].all()
 
+    @td.skip_if_mpl_1_5
     @pytest.mark.slow
     def test_gap_upsample(self):
         low = tm.makeTimeSeries()
@@ -579,8 +580,6 @@ class TestTSPlot(TestPlotBase):
         assert len(ax.right_ax.get_lines()) == 1
         l = lines[0]
         data = l.get_xydata()
-
-        tm._skip_if_mpl_1_5()
 
         assert isinstance(data, np.ma.core.MaskedArray)
         mask = data.mask

--- a/pandas/util/_test_decorators.py
+++ b/pandas/util/_test_decorators.py
@@ -25,6 +25,7 @@ For more information, refer to the ``pytest`` documentation on ``skipif``.
 """
 
 import pytest
+from distutils.version import LooseVersion
 
 
 def safe_import(mod_name, min_version=None):
@@ -67,5 +68,18 @@ def _skip_if_no_mpl():
         return True
 
 
+def _skip_if_mpl_1_5():
+    mod = safe_import("matplotlib")
+
+    if mod:
+        v = mod.__version__
+        if LooseVersion(v) > LooseVersion('1.4.3') or str(v)[0] == '0':
+            return True
+        else:
+            mod.use("Agg", warn=False)
+
+
 skip_if_no_mpl = pytest.mark.skipif(_skip_if_no_mpl(),
                                     reason="Missing matplotlib dependency")
+skip_if_mpl_1_5 = pytest.mark.skipif(_skip_if_mpl_1_5(),
+                                     reason="matplotlib 1.5")


### PR DESCRIPTION
- [X] progress towards #18190 
- [X] tests added / passed
- [X] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

FWIW the functionality here could be slightly different, because the previous skip if items occurred in the middle of the function bodies instead of wrapping the function, so the first few lines of code within those functions would run in instances that are being skipped today. 

I've ignored that nuance because I find it strange that we would only want to run part of the test without any assertions for different versions of matplotlib, but if you feel it needs to be accounted for in some other fashion (say separate test cases) let me know