### PR TITLE
Converted windows / 32bit skips into decorators

### DIFF
--- a/pandas/tests/computation/test_eval.py
+++ b/pandas/tests/computation/test_eval.py
@@ -28,6 +28,7 @@ from pandas.core.computation.ops import (
 
 import pandas.core.computation.expr as expr
 import pandas.util.testing as tm
+import pandas.util._test_decorators as td
 from pandas.util.testing import (assert_frame_equal, randbool,
                                  assert_numpy_array_equal, assert_series_equal,
                                  assert_produces_warning)
@@ -175,9 +176,8 @@ class TestEvalNumexprPandas(object):
         for lhs, rhs in product(self.lhses, self.rhses):
             self.check_floor_division(lhs, '//', rhs)
 
+    @td.skip_if_windows
     def test_pow(self):
-        tm._skip_if_windows()
-
         # odd failure on win32 platform, so skip
         for lhs, rhs in product(self.lhses, self.rhses):
             self.check_pow(lhs, '**', rhs)

--- a/pandas/tests/indexes/datetimes/test_date_range.py
+++ b/pandas/tests/indexes/datetimes/test_date_range.py
@@ -11,6 +11,7 @@ from datetime import datetime, timedelta, time
 
 import pandas as pd
 import pandas.util.testing as tm
+import pandas.util._test_decorators as td
 from pandas import compat
 from pandas import date_range, bdate_range, offsets, DatetimeIndex, Timestamp
 from pandas.tseries.offsets import (generate_range, CDay, BDay, DateOffset,
@@ -49,8 +50,8 @@ class TestTimestampEquivDateRange(object):
         ts = Timestamp('20090415', tz=pytz.timezone('US/Eastern'), freq='D')
         assert ts == stamp
 
+    @td.skip_if_windows_python_3
     def test_date_range_timestamp_equiv_explicit_dateutil(self):
-        tm._skip_if_windows_python_3()
         from pandas._libs.tslibs.timezones import dateutil_gettz as gettz
 
         rng = date_range('20090415', '20090519', tz=gettz('US/Eastern'))

--- a/pandas/tests/indexes/datetimes/test_setops.py
+++ b/pandas/tests/indexes/datetimes/test_setops.py
@@ -5,6 +5,7 @@ import numpy as np
 
 import pandas as pd
 import pandas.util.testing as tm
+import pandas.util._test_decorators as td
 from pandas import (DatetimeIndex, date_range, Series, bdate_range, DataFrame,
                     Int64Index, Index, to_datetime)
 from pandas.tseries.offsets import Minute, BMonthEnd, MonthEnd
@@ -358,9 +359,8 @@ class TestBusinessDatetimeIndex(object):
 
         early_dr.union(late_dr)
 
+    @td.skip_if_windows_python_3
     def test_month_range_union_tz_dateutil(self):
-        tm._skip_if_windows_python_3()
-
         from pandas._libs.tslibs.timezones import dateutil_gettz
         tz = dateutil_gettz('US/Eastern')
 

--- a/pandas/tests/indexes/period/test_period.py
+++ b/pandas/tests/indexes/period/test_period.py
@@ -3,10 +3,11 @@ import pytest
 import numpy as np
 
 import pandas as pd
+import pandas.util._test_decorators as td
 from pandas.util import testing as tm
 from pandas import (PeriodIndex, period_range, notna, DatetimeIndex, NaT,
                     Index, Period, Int64Index, Series, DataFrame, date_range,
-                    offsets, compat)
+                    offsets)
 
 from ..datetimelike import DatetimeLike
 
@@ -544,9 +545,8 @@ class TestPeriodIndex(DatetimeLike):
         tm.assert_index_equal(result, expected)
         assert result.name == expected.name
 
+    @td.skip_if_32bit
     def test_ndarray_compat_properties(self):
-        if compat.is_platform_32bit():
-            pytest.skip("skipping on 32bit")
         super(TestPeriodIndex, self).test_ndarray_compat_properties()
 
     def test_shift_ndarray(self):

--- a/pandas/tests/indexing/test_coercion.py
+++ b/pandas/tests/indexing/test_coercion.py
@@ -1195,6 +1195,8 @@ class TestFillnaSeriesCoercion(CoercionBase):
         pass
 
 
+@td.skip_if_windows
+@td.skip_if_32bit
 class TestReplaceSeriesCoercion(CoercionBase):
 
     # not indexing, but place here for consisntency
@@ -1221,8 +1223,6 @@ class TestReplaceSeriesCoercion(CoercionBase):
         self.rep['timedelta64[ns]'] = [pd.Timedelta('1 day'),
                                        pd.Timedelta('2 day')]
 
-    @td.skip_if_windows
-    @td.skip_if_32bit
     def _assert_replace_conversion(self, from_key, to_key, how):
         index = pd.Index([3, 4], name='xxx')
         obj = pd.Series(self.rep[from_key], index=index, name='yyy')

--- a/pandas/tests/indexing/test_coercion.py
+++ b/pandas/tests/indexing/test_coercion.py
@@ -5,7 +5,6 @@ import numpy as np
 
 import pandas as pd
 import pandas.util.testing as tm
-import pandas.util._test_decorators as td
 import pandas.compat as compat
 
 
@@ -1195,38 +1194,33 @@ class TestFillnaSeriesCoercion(CoercionBase):
         pass
 
 
-@pytest.mark.parametrize('how', ['dict', 'series'])
-@pytest.mark.parametrize('to_key', [
-    'object', 'int64', 'float64', 'complex128', 'bool', 'datetime64[ns]',
-    'datetime64[ns, UTC]', 'datetime64[ns, US/Eastern]', 'timedelta64[ns]'])
-@pytest.mark.parametrize('from_key', [
-    'object', 'int64', 'float64', 'complex128', 'bool', 'datetime64[ns]',
-    'datetime64[ns, UTC]', 'datetime64[ns, US/Eastern]', 'timedelta64[ns]'])
-class TestReplaceSeriesCoercion(object):
+class TestReplaceSeriesCoercion(CoercionBase):
 
-    rep = {}
-    rep['object'] = ['a', 'b']
-    rep['int64'] = [4, 5]
-    rep['float64'] = [1.1, 2.2]
-    rep['complex128'] = [1 + 1j, 2 + 2j]
-    rep['bool'] = [True, False]
-    rep['datetime64[ns]'] = [pd.Timestamp('2011-01-01'),
-                             pd.Timestamp('2011-01-03')]
+    # not indexing, but place here for consisntency
 
-    for tz in ['UTC', 'US/Eastern']:
-        # to test tz => different tz replacement
-        key = 'datetime64[ns, {0}]'.format(tz)
-        rep[key] = [pd.Timestamp('2011-01-01', tz=tz),
-                    pd.Timestamp('2011-01-03', tz=tz)]
+    klasses = ['series']
+    method = 'replace'
 
-    rep['timedelta64[ns]'] = [pd.Timedelta('1 day'),
-                              pd.Timedelta('2 day')]
+    def setup_method(self, method):
+        self.rep = {}
+        self.rep['object'] = ['a', 'b']
+        self.rep['int64'] = [4, 5]
+        self.rep['float64'] = [1.1, 2.2]
+        self.rep['complex128'] = [1 + 1j, 2 + 2j]
+        self.rep['bool'] = [True, False]
+        self.rep['datetime64[ns]'] = [pd.Timestamp('2011-01-01'),
+                                      pd.Timestamp('2011-01-03')]
 
-    def test_replace_series(self, how, to_key, from_key):
-        if from_key == 'bool' and how == 'series' and compat.PY3:
-            # doesn't work in PY3, though ...dict_from_bool works fine
-            pytest.skip("doesn't work as in PY3")
+        for tz in ['UTC', 'US/Eastern']:
+            # to test tz => different tz replacement
+            key = 'datetime64[ns, {0}]'.format(tz)
+            self.rep[key] = [pd.Timestamp('2011-01-01', tz=tz),
+                             pd.Timestamp('2011-01-03', tz=tz)]
 
+        self.rep['timedelta64[ns]'] = [pd.Timedelta('1 day'),
+                                       pd.Timedelta('2 day')]
+
+    def _assert_replace_conversion(self, from_key, to_key, how):
         index = pd.Index([3, 4], name='xxx')
         obj = pd.Series(self.rep[from_key], index=index, name='yyy')
         assert obj.dtype == from_key
@@ -1248,8 +1242,10 @@ class TestReplaceSeriesCoercion(object):
             (from_key == 'complex128' and
              to_key in ('int64', 'float64'))):
 
-            td.skip_if_32bit()
-            td.skip_if_windows()
+            # buggy on 32-bit / window
+            if compat.is_platform_32bit() or compat.is_platform_windows():
+                pytest.skip("32-bit platform buggy: {0} -> {1}".format
+                            (from_key, to_key))
 
             # Expected: do not downcast by replacement
             exp = pd.Series(self.rep[to_key], index=index,
@@ -1260,3 +1256,78 @@ class TestReplaceSeriesCoercion(object):
             assert exp.dtype == to_key
 
         tm.assert_series_equal(result, exp)
+
+    def test_replace_series_object(self):
+        from_key = 'object'
+        for to_key in self.rep:
+            self._assert_replace_conversion(from_key, to_key, how='dict')
+
+        for to_key in self.rep:
+            self._assert_replace_conversion(from_key, to_key, how='series')
+
+    def test_replace_series_int64(self):
+        from_key = 'int64'
+        for to_key in self.rep:
+            self._assert_replace_conversion(from_key, to_key, how='dict')
+
+        for to_key in self.rep:
+            self._assert_replace_conversion(from_key, to_key, how='series')
+
+    def test_replace_series_float64(self):
+        from_key = 'float64'
+        for to_key in self.rep:
+            self._assert_replace_conversion(from_key, to_key, how='dict')
+
+        for to_key in self.rep:
+            self._assert_replace_conversion(from_key, to_key, how='series')
+
+    def test_replace_series_complex128(self):
+        from_key = 'complex128'
+        for to_key in self.rep:
+            self._assert_replace_conversion(from_key, to_key, how='dict')
+
+        for to_key in self.rep:
+            self._assert_replace_conversion(from_key, to_key, how='series')
+
+    def test_replace_series_bool(self):
+        from_key = 'bool'
+        for to_key in self.rep:
+            self._assert_replace_conversion(from_key, to_key, how='dict')
+
+        for to_key in self.rep:
+
+            if compat.PY3:
+                # doesn't work in PY3, though ...dict_from_bool works fine
+                pytest.skip("doesn't work as in PY3")
+
+            self._assert_replace_conversion(from_key, to_key, how='series')
+
+    def test_replace_series_datetime64(self):
+        from_key = 'datetime64[ns]'
+        for to_key in self.rep:
+            self._assert_replace_conversion(from_key, to_key, how='dict')
+
+        from_key = 'datetime64[ns]'
+        for to_key in self.rep:
+            self._assert_replace_conversion(from_key, to_key, how='series')
+
+    def test_replace_series_datetime64tz(self):
+        from_key = 'datetime64[ns, US/Eastern]'
+        for to_key in self.rep:
+            self._assert_replace_conversion(from_key, to_key, how='dict')
+
+        from_key = 'datetime64[ns, US/Eastern]'
+        for to_key in self.rep:
+            self._assert_replace_conversion(from_key, to_key, how='series')
+
+    def test_replace_series_timedelta64(self):
+        from_key = 'timedelta64[ns]'
+        for to_key in self.rep:
+            self._assert_replace_conversion(from_key, to_key, how='dict')
+
+        from_key = 'timedelta64[ns]'
+        for to_key in self.rep:
+            self._assert_replace_conversion(from_key, to_key, how='series')
+
+    def test_replace_series_period(self):
+        pass

--- a/pandas/tests/indexing/test_coercion.py
+++ b/pandas/tests/indexing/test_coercion.py
@@ -5,6 +5,7 @@ import numpy as np
 
 import pandas as pd
 import pandas.util.testing as tm
+import pandas.util._test_decorators as td
 import pandas.compat as compat
 
 
@@ -1220,6 +1221,8 @@ class TestReplaceSeriesCoercion(CoercionBase):
         self.rep['timedelta64[ns]'] = [pd.Timedelta('1 day'),
                                        pd.Timedelta('2 day')]
 
+    @td.skip_if_windows
+    @td.skip_if_32bit
     def _assert_replace_conversion(self, from_key, to_key, how):
         index = pd.Index([3, 4], name='xxx')
         obj = pd.Series(self.rep[from_key], index=index, name='yyy')
@@ -1241,11 +1244,6 @@ class TestReplaceSeriesCoercion(CoercionBase):
         if ((from_key == 'float64' and to_key in ('int64')) or
             (from_key == 'complex128' and
              to_key in ('int64', 'float64'))):
-
-            # buggy on 32-bit / window
-            if compat.is_platform_32bit() or compat.is_platform_windows():
-                pytest.skip("32-bit platform buggy: {0} -> {1}".format
-                            (from_key, to_key))
 
             # Expected: do not downcast by replacement
             exp = pd.Series(self.rep[to_key], index=index,

--- a/pandas/tests/io/parser/c_parser_only.py
+++ b/pandas/tests/io/parser/c_parser_only.py
@@ -16,6 +16,7 @@ import numpy as np
 
 import pandas as pd
 import pandas.util.testing as tm
+import pandas.util._test_decorators as td
 from pandas import DataFrame
 from pandas import compat
 from pandas.compat import StringIO, range, lrange
@@ -129,9 +130,8 @@ nan 2
                           dtype={'A': 'U8'},
                           index_col=0)
 
+    @td.skip_if_32bit
     def test_precise_conversion(self):
-        # see gh-8002
-        tm._skip_if_32bit()
         from decimal import Decimal
 
         normal_errors = []

--- a/pandas/tests/io/test_pytables.py
+++ b/pandas/tests/io/test_pytables.py
@@ -2888,8 +2888,7 @@ class TestHDFStore(Base):
             pytest.skip('known failer on some windows platforms')
 
     @pytest.mark.parametrize("compression", [
-        (False,),
-        td.skip_if_windows_python_3()(True,)
+        False, pytest.param(True, marks=td.skip_if_windows_python_3)
     ])
     def test_frame(self, compression):
 
@@ -3014,8 +3013,7 @@ class TestHDFStore(Base):
             tm.assert_series_equal(recons, series)
 
     @pytest.mark.parametrize("compression", [
-        (False,),
-        td.skip_if_windows_python_3()(True,)
+        False, pytest.param(True, marks=td.skip_if_windows_python_3)
     ])
     def test_store_mixed(self, compression):
 

--- a/pandas/tests/io/test_pytables.py
+++ b/pandas/tests/io/test_pytables.py
@@ -17,6 +17,7 @@ from pandas import (Series, DataFrame, Panel, Panel4D, MultiIndex, Int64Index,
                     isna, compat, concat, Timestamp)
 
 import pandas.util.testing as tm
+import pandas.util._test_decorators as td
 from pandas.util.testing import (assert_panel4d_equal,
                                  assert_panel_equal,
                                  assert_frame_equal,
@@ -39,10 +40,6 @@ from pandas.io.pytables import (TableIterator,  # noqa:E402
 _default_compressor = ('blosc' if LooseVersion(tables.__version__) >=
                        LooseVersion('2.2') else 'zlib')
 
-
-# testing on windows/py3 seems to fault
-# for using compression
-skip_compression = PY3 and is_platform_windows()
 
 # contextmanager to ensure the file cleanup
 
@@ -719,12 +716,10 @@ class TestHDFStore(Base):
             pytest.raises(ValueError, store.put, 'b', df,
                           format='fixed', complib='zlib')
 
+    @td.skip_if_windows_python_3
     def test_put_compression_blosc(self):
         tm.skip_if_no_package('tables', min_version='2.2',
                               app='blosc support')
-        if skip_compression:
-            pytest.skip("skipping on windows/PY3")
-
         df = tm.makeTimeDataFrame()
 
         with ensure_clean_store(self.path) as store:
@@ -2892,7 +2887,11 @@ class TestHDFStore(Base):
         except OverflowError:
             pytest.skip('known failer on some windows platforms')
 
-    def test_frame(self):
+    @pytest.mark.parametrize("compression", [
+        (False,),
+        td.skip_if_windows_python_3()(True,)
+    ])
+    def test_frame(self, compression):
 
         df = tm.makeDataFrame()
 
@@ -2900,21 +2899,14 @@ class TestHDFStore(Base):
         df.values[0, 0] = np.nan
         df.values[5, 3] = np.nan
 
-        self._check_roundtrip_table(df, tm.assert_frame_equal)
-        self._check_roundtrip(df, tm.assert_frame_equal)
-
-        if not skip_compression:
-            self._check_roundtrip_table(df, tm.assert_frame_equal,
-                                        compression=True)
-            self._check_roundtrip(df, tm.assert_frame_equal,
-                                  compression=True)
+        self._check_roundtrip_table(df, tm.assert_frame_equal,
+                                    compression=compression)
+        self._check_roundtrip(df, tm.assert_frame_equal,
+                              compression=compression)
 
         tdf = tm.makeTimeDataFrame()
-        self._check_roundtrip(tdf, tm.assert_frame_equal)
-
-        if not skip_compression:
-            self._check_roundtrip(tdf, tm.assert_frame_equal,
-                                  compression=True)
+        self._check_roundtrip(tdf, tm.assert_frame_equal,
+                              compression=compression)
 
         with ensure_clean_store(self.path) as store:
             # not consolidated
@@ -3021,7 +3013,11 @@ class TestHDFStore(Base):
             recons = store['series']
             tm.assert_series_equal(recons, series)
 
-    def test_store_mixed(self):
+    @pytest.mark.parametrize("compression", [
+        (False,),
+        td.skip_if_windows_python_3()(True,)
+    ])
+    def test_store_mixed(self, compression):
 
         def _make_one():
             df = tm.makeDataFrame()
@@ -3046,19 +3042,12 @@ class TestHDFStore(Base):
             tm.assert_frame_equal(store['obj'], df2)
 
         # check that can store Series of all of these types
-        self._check_roundtrip(df1['obj1'], tm.assert_series_equal)
-        self._check_roundtrip(df1['bool1'], tm.assert_series_equal)
-        self._check_roundtrip(df1['int1'], tm.assert_series_equal)
-
-        if not skip_compression:
-            self._check_roundtrip(df1['obj1'], tm.assert_series_equal,
-                                  compression=True)
-            self._check_roundtrip(df1['bool1'], tm.assert_series_equal,
-                                  compression=True)
-            self._check_roundtrip(df1['int1'], tm.assert_series_equal,
-                                  compression=True)
-            self._check_roundtrip(df1, tm.assert_frame_equal,
-                                  compression=True)
+        self._check_roundtrip(df1['obj1'], tm.assert_series_equal,
+                              compression=compression)
+        self._check_roundtrip(df1['bool1'], tm.assert_series_equal,
+                              compression=compression)
+        self._check_roundtrip(df1['int1'], tm.assert_series_equal,
+                              compression=compression)
 
     def test_wide(self):
 
@@ -5639,6 +5628,7 @@ class TestTimezones(Base):
             tm.assert_index_equal(recons.index, rng)
             assert rng.tz == recons.index.tz
 
+    @td.skip_if_windows
     def test_store_timezone(self):
         # GH2852
         # issue storing datetime.date with a timezone as it resets when read

--- a/pandas/tests/io/test_pytables.py
+++ b/pandas/tests/io/test_pytables.py
@@ -25,7 +25,7 @@ from pandas.util.testing import (assert_panel4d_equal,
                                  set_timezone)
 
 from pandas.compat import (is_platform_windows, is_platform_little_endian,
-                           PY3, PY35, PY36, BytesIO, text_type,
+                           PY35, PY36, BytesIO, text_type,
                            range, lrange, u)
 from pandas.io.formats.printing import pprint_thing
 from pandas.core.dtypes.common import is_categorical_dtype

--- a/pandas/tests/scalar/test_timestamp.py
+++ b/pandas/tests/scalar/test_timestamp.py
@@ -15,6 +15,7 @@ from distutils.version import LooseVersion
 from pytz.exceptions import AmbiguousTimeError, NonExistentTimeError
 
 import pandas.util.testing as tm
+import pandas.util._test_decorators as td
 from pandas.tseries import offsets, frequencies
 from pandas._libs.tslibs.timezones import get_timezone, dateutil_gettz as gettz
 from pandas._libs.tslibs import conversion, period
@@ -943,6 +944,7 @@ class TestTimestamp(object):
         dt = Timestamp('2100-01-01 00:00:00', tz=tz)
         assert not dt.is_leap_year
 
+    @td.skip_if_windows
     def test_timestamp(self):
         # GH#17329
         # tz-naive --> treat it as if it were UTC for purposes of timestamp()
@@ -1366,9 +1368,8 @@ class TestTimestampConversion(object):
         assert stamp == dtval
         assert stamp.tzinfo == dtval.tzinfo
 
+    @td.skip_if_windows_python_3
     def test_timestamp_to_datetime_explicit_dateutil(self):
-        tm._skip_if_windows_python_3()
-
         stamp = Timestamp('20090415', tz=gettz('US/Eastern'), freq='D')
         dtval = stamp.to_pydatetime()
         assert stamp == dtval

--- a/pandas/tests/sparse/test_libsparse.py
+++ b/pandas/tests/sparse/test_libsparse.py
@@ -4,8 +4,7 @@ import pytest
 import numpy as np
 import operator
 import pandas.util.testing as tm
-
-from pandas import compat
+import pandas.util._test_decorators as td
 
 from pandas.core.sparse.array import IntIndex, BlockIndex, _make_index
 import pandas._libs.sparse as splib
@@ -190,6 +189,7 @@ class TestSparseIndexUnion(object):
 
 class TestSparseIndexIntersect(object):
 
+    @td.skip_if_windows
     def test_intersect(self):
         def _check_correct(a, b, expected):
             result = a.intersect(b)
@@ -212,8 +212,6 @@ class TestSparseIndexIntersect(object):
             _check_length_exc(xindex.to_int_index(),
                               longer_index.to_int_index())
 
-        if compat.is_platform_windows():
-            pytest.skip("segfaults on win-64 when all tests are run")
         check_cases(_check_case)
 
     def test_intersect_empty(self):

--- a/pandas/tests/tseries/test_timezones.py
+++ b/pandas/tests/tseries/test_timezones.py
@@ -12,6 +12,7 @@ from dateutil.tz import tzlocal, tzoffset
 from datetime import datetime, timedelta, tzinfo, date
 
 import pandas.util.testing as tm
+import pandas.util._test_decorators as td
 import pandas.tseries.offsets as offsets
 from pandas.compat import lrange, zip, PY3
 from pandas.core.indexes.datetimes import bdate_range, date_range
@@ -958,10 +959,8 @@ class TestTimeZoneSupportDateutil(TestTimeZoneSupportPytz):
     def localize(self, tz, x):
         return x.replace(tzinfo=tz)
 
+    @td.skip_if_windows
     def test_utc_with_system_utc(self):
-        # Skipped on win32 due to dateutil bug
-        tm._skip_if_windows()
-
         from pandas._libs.tslibs.timezones import maybe_get_tz
 
         # from system utc to real utc
@@ -1270,6 +1269,7 @@ class TestTimeZones(object):
             assert (result_pytz.to_pydatetime().tzname() ==
                     result_dateutil.to_pydatetime().tzname())
 
+    @td.skip_if_windows
     def test_replace_tzinfo(self):
         # GH 15683
         dt = datetime(2016, 3, 27, 1)
@@ -1663,6 +1663,7 @@ class TestTimeZones(object):
         assert result.is_normalized
         assert not rng.is_normalized
 
+    @td.skip_if_windows
     def test_normalize_tz_local(self):
         # see gh-13459
         timezones = ['US/Pacific', 'US/Eastern', 'UTC', 'Asia/Kolkata',

--- a/pandas/tests/util/test_testing.py
+++ b/pandas/tests/util/test_testing.py
@@ -10,7 +10,6 @@ from pandas.util.testing import (assert_almost_equal, raise_with_traceback,
                                  assert_index_equal, assert_series_equal,
                                  assert_frame_equal, assert_numpy_array_equal,
                                  RNGContext)
-from pandas.compat import is_platform_windows
 
 
 class TestAssertAlmostEqual(object):

--- a/pandas/tests/util/test_testing.py
+++ b/pandas/tests/util/test_testing.py
@@ -5,6 +5,7 @@ import numpy as np
 import sys
 from pandas import Series, DataFrame
 import pandas.util.testing as tm
+import pandas.util._test_decorators as td
 from pandas.util.testing import (assert_almost_equal, raise_with_traceback,
                                  assert_index_equal, assert_series_equal,
                                  assert_frame_equal, assert_numpy_array_equal,
@@ -159,11 +160,8 @@ class TestUtilTesting(object):
 
 class TestAssertNumpyArrayEqual(object):
 
+    @td.skip_if_windows
     def test_numpy_array_equal_message(self):
-
-        if is_platform_windows():
-            pytest.skip("windows has incomparable line-endings "
-                        "and uses L on the shape")
 
         expected = """numpy array are different
 
@@ -287,11 +285,8 @@ Index shapes are different
             assert_almost_equal(np.array([1, 2]), np.array([3, 4, 5]),
                                 obj='Index')
 
+    @td.skip_if_windows
     def test_numpy_array_equal_object_message(self):
-
-        if is_platform_windows():
-            pytest.skip("windows has incomparable line-endings "
-                        "and uses L on the shape")
 
         a = np.array([pd.Timestamp('2011-01-01'), pd.Timestamp('2011-01-01')])
         b = np.array([pd.Timestamp('2011-01-01'), pd.Timestamp('2011-01-02')])

--- a/pandas/tests/util/test_util.py
+++ b/pandas/tests/util/test_util.py
@@ -16,7 +16,7 @@ from pandas.util._validators import (validate_args, validate_kwargs,
                                      validate_bool_kwarg)
 
 import pandas.util.testing as tm
-from pandas.util._test_decorators import safe_import
+import pandas.util._test_decorators as td
 
 
 class TestDecorators(object):
@@ -406,6 +406,7 @@ def test_numpy_errstate_is_default():
     assert np.geterr() == expected
 
 
+@td.skip_if_windows
 class TestLocaleUtils(object):
 
     @classmethod
@@ -415,8 +416,6 @@ class TestLocaleUtils(object):
 
         if not cls.locales:
             pytest.skip("No locales found")
-
-        tm._skip_if_windows()
 
     @classmethod
     def teardown_class(cls):
@@ -486,8 +485,8 @@ def test_make_signature():
 
 
 def test_safe_import(monkeypatch):
-    assert not safe_import("foo")
-    assert not safe_import("pandas", min_version="99.99.99")
+    assert not td.safe_import("foo")
+    assert not td.safe_import("pandas", min_version="99.99.99")
 
     # Create dummy module to be imported
     import types
@@ -496,7 +495,7 @@ def test_safe_import(monkeypatch):
     mod = types.ModuleType(mod_name)
     mod.__version__ = "1.5"
 
-    assert not safe_import(mod_name)
+    assert not td.safe_import(mod_name)
     monkeypatch.setitem(sys.modules, mod_name, mod)
-    assert not safe_import(mod_name, min_version="2.0")
-    assert safe_import(mod_name, min_version="1.0")
+    assert not td.safe_import(mod_name, min_version="2.0")
+    assert td.safe_import(mod_name, min_version="1.0")

--- a/pandas/util/_test_decorators.py
+++ b/pandas/util/_test_decorators.py
@@ -27,6 +27,8 @@ For more information, refer to the ``pytest`` documentation on ``skipif``.
 import pytest
 from distutils.version import LooseVersion
 
+from pandas.compat import is_platform_windows, is_platform_32bit, PY3
+
 
 def safe_import(mod_name, min_version=None):
     """
@@ -83,3 +85,10 @@ skip_if_no_mpl = pytest.mark.skipif(_skip_if_no_mpl(),
                                     reason="Missing matplotlib dependency")
 skip_if_mpl_1_5 = pytest.mark.skipif(_skip_if_mpl_1_5(),
                                      reason="matplotlib 1.5")
+skip_if_32bit = pytest.mark.skipif(is_platform_32bit(),
+                                   reason="skipping for 32 bit")
+skip_if_windows = pytest.mark.skipif(is_platform_windows(),
+                                     reason="Running on Windows")
+skip_if_windows_python_3 = pytest.mark.skipif(is_platform_windows() and PY3,
+                                              reason=("not used on python3/"
+                                                      "win32"))

--- a/pandas/util/testing.py
+++ b/pandas/util/testing.py
@@ -38,9 +38,7 @@ from pandas.core.common import _all_not_none
 import pandas.compat as compat
 from pandas.compat import (
     filter, map, zip, range, unichr, lrange, lmap, lzip, u, callable, Counter,
-    raise_with_traceback, httplib, is_platform_windows, is_platform_32bit,
-    StringIO, PY3
-)
+    raise_with_traceback, httplib, StringIO, PY3)
 
 from pandas import (bdate_range, CategoricalIndex, Categorical, IntervalIndex,
                     DatetimeIndex, TimedeltaIndex, PeriodIndex, RangeIndex,
@@ -319,12 +317,6 @@ def close(fignum=None):
         _close(fignum)
 
 
-def _skip_if_32bit():
-    if is_platform_32bit():
-        import pytest
-        pytest.skip("skipping for 32 bit")
-
-
 def _skip_if_mpl_1_5():
     import matplotlib as mpl
 
@@ -365,18 +357,6 @@ def _skip_if_no_xarray():
     if LooseVersion(v) < LooseVersion('0.7.0'):
         import pytest
         pytest.skip("xarray version is too low: {version}".format(version=v))
-
-
-def _skip_if_windows_python_3():
-    if PY3 and is_platform_windows():
-        import pytest
-        pytest.skip("not used on python 3/win32")
-
-
-def _skip_if_windows():
-    if is_platform_windows():
-        import pytest
-        pytest.skip("Running on Windows")
 
 
 def _skip_if_no_pathlib():
@@ -2825,9 +2805,6 @@ def set_timezone(tz):
     ...
     'EDT'
     """
-    if is_platform_windows():
-        import pytest
-        pytest.skip("timezone setting not supported on windows")
 
     import os
     import time


### PR DESCRIPTION
- [X] xref #18190 
- [ ] tests added / passed
- [X] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

Don't have a 32bit or Windows platform at my disposal so plan to leverage AppVeyor and compare before / after of skips to ensure consistency. If you have other ideas on how to tackle let me know.

FWIW the functions that were previously defined in ``pandas.util.testing`` were scarcely used, but I noticed that a lot of tests manually checked for 32 bit or windows and skipped directly. For consistency, I've updated those to use the decorators as well (will need to go back and do the same thing for matplotlib)