### PR TITLE
add benchmarks for timestamp parsing

### DIFF
--- a/asv_bench/benchmarks/timedelta.py
+++ b/asv_bench/benchmarks/timedelta.py
@@ -1,5 +1,7 @@
-from .pandas_vb_common import *
-from pandas import to_timedelta, Timestamp
+import numpy as np
+import pandas as pd
+
+from pandas import to_timedelta, Timestamp, Timedelta
 
 
 class ToTimedelta(object):
@@ -67,8 +69,8 @@ class DatetimeAccessor(object):
     def setup(self):
         self.N = 100000
         self.series = pd.Series(
-            pd.timedelta_range('1 days', periods=self.N, freq='h')
-        )
+            pd.timedelta_range('1 days', periods=self.N, freq='h'))
+
     def time_dt_accessor(self):
         self.series.dt
 

--- a/asv_bench/benchmarks/timestamp.py
+++ b/asv_bench/benchmarks/timestamp.py
@@ -2,6 +2,24 @@ from pandas import to_timedelta, Timestamp
 import pytz
 import datetime
 
+class TimestampConstruction(object):
+    # TODO: classmethod constructors: fromordinal, fromtimestamp...
+
+    def time_parse_iso8601_no_tz(self):
+        Timestamp('2017-08-25 08:16:14')
+
+    def time_parse_iso8601_tz(self):
+        Timestamp('2017-08-25 08:16:14-0500')
+
+    def time_parse_dateutil(self):
+        Timestamp('2017/08/25 08:16:14 AM')
+
+    def time_parse_today(self):
+        Timestamp('today')
+
+    def time_parse_now(self):
+        Timestamp('now')
+
 
 class TimestampProperties(object):
     goal_time = 0.2

--- a/asv_bench/benchmarks/timestamp.py
+++ b/asv_bench/benchmarks/timestamp.py
@@ -1,6 +1,7 @@
-from pandas import to_timedelta, Timestamp
+from pandas import Timestamp
 import pytz
 import datetime
+
 
 class TimestampConstruction(object):
     # TODO: classmethod constructors: fromordinal, fromtimestamp...

--- a/ci/lint.sh
+++ b/ci/lint.sh
@@ -24,7 +24,7 @@ if [ "$LINT" ]; then
     echo "Linting setup.py DONE"
 
     echo "Linting asv_bench/benchmarks/"
-    flake8 asv_bench/benchmarks/  --exclude=asv_bench/benchmarks/[ghijoprst]*.py --ignore=F811
+    flake8 asv_bench/benchmarks/  --exclude=asv_bench/benchmarks/[ghijoprs]*.py --ignore=F811
     if [ $? -ne "0" ]; then
         RET=1
     fi


### PR DESCRIPTION
There's a reasonable case to be made that these and timeseries.ToDatetime benchmarks belong in the same place.  LMK if there's a preference.

Small flake8 fixups got timedelta.py passing, enabled linting for modules starting with "t".