### PR TITLE
Parquet: Add error message for no engine found

### DIFF
--- a/pandas/io/parquet.py
+++ b/pandas/io/parquet.py
@@ -25,9 +25,10 @@ def get_engine(engine):
         except ImportError:
             pass
 
-        raise ImportError("unable to find a usable engine\n"
-                          "tried using: pyarrow, fastparquet\n\n"
-                          + PyArrowImpl.PYARROW_INSTALL_INSTRUCTIONS)
+        raise ImportError("Unable to find a usable engine; "
+                          "tried using: 'pyarrow', 'fastparquet'.\n"
+                          "pyarrow or fastparquet is required for parquet "
+                          "support")
 
     if engine not in ['pyarrow', 'fastparquet']:
         raise ValueError("engine must be one of 'pyarrow', 'fastparquet'")
@@ -39,10 +40,6 @@ def get_engine(engine):
 
 
 class PyArrowImpl(object):
-    PYARROW_INSTALL_INSTRUCTIONS = ("you can install pyarrow via conda\n"
-                                    "conda install pyarrow -c conda-forge\n"
-                                    "\nor via pip\n"
-                                    "pip install -U pyarrow\n")
 
     def __init__(self):
         # since pandas is a dependency of pyarrow
@@ -53,11 +50,18 @@ class PyArrowImpl(object):
             import pyarrow.parquet
         except ImportError:
             raise ImportError("pyarrow is required for parquet support\n\n"
-                              + PYARROW_INSTALL_INSTRUCTIONS)
+                              "you can install via conda\n"
+                              "conda install pyarrow -c conda-forge\n"
+                              "\nor via pip\n"
+                              "pip install -U pyarrow\n")
 
         if LooseVersion(pyarrow.__version__) < LooseVersion('0.4.1'):
             raise ImportError("pyarrow >= 0.4.1 is required for parquet"
-                              "support\n\n" + PYARROW_INSTALL_INSTRUCTIONS)
+                              "support\n\n"
+                              "you can install via conda\n"
+                              "conda install pyarrow -c conda-forge\n"
+                              "\nor via pip\n"
+                              "pip install -U pyarrow\n")
 
         self._pyarrow_lt_050 = (LooseVersion(pyarrow.__version__) <
                                 LooseVersion('0.5.0'))

--- a/pandas/io/parquet.py
+++ b/pandas/io/parquet.py
@@ -25,6 +25,10 @@ def get_engine(engine):
         except ImportError:
             pass
 
+        raise ImportError("unable to find a usable engine\n"
+                          "tried using: pyarrow, fastparquet\n\n"
+                          + PyArrowImpl.PYARROW_INSTALL_INSTRUCTIONS)
+
     if engine not in ['pyarrow', 'fastparquet']:
         raise ValueError("engine must be one of 'pyarrow', 'fastparquet'")
 
@@ -35,6 +39,10 @@ def get_engine(engine):
 
 
 class PyArrowImpl(object):
+    PYARROW_INSTALL_INSTRUCTIONS = ("you can install pyarrow via conda\n"
+                                    "conda install pyarrow -c conda-forge\n"
+                                    "\nor via pip\n"
+                                    "pip install -U pyarrow\n")
 
     def __init__(self):
         # since pandas is a dependency of pyarrow
@@ -45,18 +53,11 @@ class PyArrowImpl(object):
             import pyarrow.parquet
         except ImportError:
             raise ImportError("pyarrow is required for parquet support\n\n"
-                              "you can install via conda\n"
-                              "conda install pyarrow -c conda-forge\n"
-                              "\nor via pip\n"
-                              "pip install -U pyarrow\n")
+                              + PYARROW_INSTALL_INSTRUCTIONS)
 
         if LooseVersion(pyarrow.__version__) < LooseVersion('0.4.1'):
             raise ImportError("pyarrow >= 0.4.1 is required for parquet"
-                              "support\n\n"
-                              "you can install via conda\n"
-                              "conda install pyarrow -c conda-forge\n"
-                              "\nor via pip\n"
-                              "pip install -U pyarrow\n")
+                              "support\n\n" + PYARROW_INSTALL_INSTRUCTIONS)
 
         self._pyarrow_lt_050 = (LooseVersion(pyarrow.__version__) <
                                 LooseVersion('0.5.0'))


### PR DESCRIPTION
Give a better error message for engine="auto" case when none of the
engines were found installed.

closes #18156

Cherry-picking the doc part of PR https://github.com/pandas-dev/pandas/pull/18568