### PR TITLE
CLN: Drop the skip_footer parameter in read_csv

### DIFF
--- a/doc/source/io.rst
+++ b/doc/source/io.rst
@@ -198,10 +198,6 @@ skiprows : list-like or integer, default ``None``
 
 skipfooter : int, default ``0``
   Number of lines at bottom of file to skip (unsupported with engine='c').
-skip_footer : int, default ``0``
-  .. deprecated:: 0.19.0
-
-     Use the ``skipfooter`` parameter instead, as they are identical
 
 nrows : int, default ``None``
   Number of rows of file to read. Useful for reading pieces of large files.

--- a/doc/source/whatsnew/v0.22.0.txt
+++ b/doc/source/whatsnew/v0.22.0.txt
@@ -219,6 +219,7 @@ Removal of prior version deprecations/changes
 - The ``freq`` and ``how`` parameters have been removed from the ``rolling``/``expanding``/``ewm`` methods of DataFrame
   and Series (deprecated since v0.18). Instead, resample before calling the methods. (:issue:18601 & :issue:18668)
 - ``DatetimeIndex.to_datetime``, ``Timestamp.to_datetime``, ``PeriodIndex.to_datetime``, and ``Index.to_datetime`` have been removed (:issue:`8254`, :issue:`14096`, :issue:`14113`)
+- :func:`read_csv` has dropped the ``skip_footer`` parameter (:issue:`13386`)
 
 .. _whatsnew_0220.performance:
 

--- a/pandas/io/parsers.py
+++ b/pandas/io/parsers.py
@@ -148,9 +148,6 @@ skiprows : list-like or integer or callable, default None
     An example of a valid callable argument would be ``lambda x: x in [0, 2]``.
 skipfooter : int, default 0
     Number of lines at bottom of file to skip (Unsupported with engine='c')
-skip_footer : int, default 0
-    .. deprecated:: 0.19.0
-       Use the `skipfooter` parameter instead, as they are identical
 nrows : int, default None
     Number of rows of file to read. Useful for reading pieces of large files
 na_values : scalar, str, list-like, or dict, default None
@@ -613,7 +610,6 @@ def _make_parser_function(name, sep=','):
                  warn_bad_lines=True,
 
                  skipfooter=0,
-                 skip_footer=0,  # deprecated
 
                  # Internal
                  doublequote=True,
@@ -640,13 +636,6 @@ def _make_parser_function(name, sep=','):
         else:
             engine = 'c'
             engine_specified = False
-
-        if skip_footer != 0:
-            warnings.warn("The 'skip_footer' argument has "
-                          "been deprecated and will be removed "
-                          "in a future version. Please use the "
-                          "'skipfooter' argument instead.",
-                          FutureWarning, stacklevel=2)
 
         kwds = dict(delimiter=delimiter,
                     engine=engine,
@@ -682,7 +671,7 @@ def _make_parser_function(name, sep=','):
                     nrows=nrows,
                     iterator=iterator,
                     chunksize=chunksize,
-                    skipfooter=skipfooter or skip_footer,
+                    skipfooter=skipfooter,
                     converters=converters,
                     dtype=dtype,
                     usecols=usecols,

--- a/pandas/tests/io/parser/test_unsupported.py
+++ b/pandas/tests/io/parser/test_unsupported.py
@@ -137,15 +137,10 @@ class TestDeprecatedFeatures(object):
                                         {"use_unsigned": True},
                                         {"use_unsigned": False},
                                         {"tupleize_cols": True},
-                                        {"tupleize_cols": False},
-                                        {"skip_footer": 1}])
+                                        {"tupleize_cols": False}])
     def test_deprecated_args(self, engine, kwargs):
         data = "1,2,3"
         arg, _ = list(kwargs.items())[0]
-
-        if engine == "c" and arg == "skip_footer":
-            # unsupported --> exception is raised
-            return
 
         if engine == "python" and arg == "buffer_lines":
             # unsupported --> exception is raised


### PR DESCRIPTION
Deprecated back in 0.19.0.

xref #13386.