### PR TITLE
bugfix for plot for string x values

### DIFF
--- a/pandas/plotting/_core.py
+++ b/pandas/plotting/_core.py
@@ -573,6 +573,8 @@ class MPLPlot(object):
                 self.data = self.data[notna(self.data.index)]
                 self.data = self.data.sort_index()
                 x = self.data.index._mpl_repr()
+            elif all(isinstance(val, str) for val in index):
+                x = index._mpl_repr()
             else:
                 self._need_to_set_index = True
                 x = lrange(len(index))

--- a/pandas/plotting/_core.py
+++ b/pandas/plotting/_core.py
@@ -573,7 +573,7 @@ class MPLPlot(object):
                 self.data = self.data[notna(self.data.index)]
                 self.data = self.data.sort_index()
                 x = self.data.index._mpl_repr()
-            elif all(isinstance(val, str) for val in index):
+            elif all(isinstance(val, string_types) for val in index):
                 x = index._mpl_repr()
             else:
                 self._need_to_set_index = True

--- a/pandas/plotting/_core.py
+++ b/pandas/plotting/_core.py
@@ -562,14 +562,12 @@ class MPLPlot(object):
                 self.data = self.data.reindex(index=index.sort_values())
                 x = self.data.index.to_timestamp()._mpl_repr()
             elif (index.is_numeric() or
-                  index.inferred_type in ['string', 'unicode']
-            ):
+                  index.inferred_type in ['string', 'unicode']):
                 """
                 Matplotlib supports numeric values or datetime objects as
                 xaxis values. Taking LBYL approach here, by the time
                 matplotlib raises exception when using non numeric/datetime
                 values for xaxis, several actions are already taken by plt.
-                
                 Matplotlib also supports strings as xaxis values.
                 """
                 x = index._mpl_repr()

--- a/pandas/plotting/_core.py
+++ b/pandas/plotting/_core.py
@@ -561,20 +561,22 @@ class MPLPlot(object):
             if convert_period and isinstance(index, PeriodIndex):
                 self.data = self.data.reindex(index=index.sort_values())
                 x = self.data.index.to_timestamp()._mpl_repr()
-            elif index.is_numeric():
+            elif (index.is_numeric() or
+                  index.inferred_type in ['string', 'unicode']
+            ):
                 """
                 Matplotlib supports numeric values or datetime objects as
                 xaxis values. Taking LBYL approach here, by the time
                 matplotlib raises exception when using non numeric/datetime
                 values for xaxis, several actions are already taken by plt.
+                
+                Matplotlib also supports strings as xaxis values.
                 """
                 x = index._mpl_repr()
             elif is_datetype:
                 self.data = self.data[notna(self.data.index)]
                 self.data = self.data.sort_index()
                 x = self.data.index._mpl_repr()
-            elif all(isinstance(val, string_types) for val in index):
-                x = index._mpl_repr()
             else:
                 self._need_to_set_index = True
                 x = lrange(len(index))

--- a/pandas/tests/plotting/test_frame.py
+++ b/pandas/tests/plotting/test_frame.py
@@ -150,11 +150,16 @@ class TestDataFramePlots(TestPlotBase):
         ax = df2.plot(ax=ax)
 
         line1, line2 = ax.lines
+
         # xdata should not be touched (Earlier it was [0, 1])
-        np.testing.assert_equal(line1.get_xdata(), x1)
-        np.testing.assert_equal(line1.get_ydata(), y1)
-        np.testing.assert_equal(line2.get_xdata(), x2)
-        np.testing.assert_equal(line2.get_ydata(), y2)
+        tm.assert_numpy_array_equal(line1.get_xdata(), np.array(x1),
+                                    check_dtype=False)
+        tm.assert_numpy_array_equal(line1.get_ydata(), np.array(y1),
+                                    check_dtype=False)
+        tm.assert_numpy_array_equal(line2.get_xdata(), np.array(x2),
+                                    check_dtype=False)
+        tm.assert_numpy_array_equal(line2.get_ydata(), np.array(y2),
+                                    check_dtype=False)
 
     # GH 15516
     def test_mpl2_color_cycle_str(self):

--- a/pandas/tests/plotting/test_frame.py
+++ b/pandas/tests/plotting/test_frame.py
@@ -139,6 +139,23 @@ class TestDataFramePlots(TestPlotBase):
             result = ax.get_axes()  # deprecated
         assert result is axes[0]
 
+    # GH 18726
+    def test_two_plots_with_x_str(self):
+        x1, y1 = ['a', 'b'], [1, 2]
+        x2, y2 = ['b', 'a'], [4, 3]
+        df1 = pd.DataFrame(y1, index=x1)
+        df2 = pd.DataFrame(y2, index=x2)
+        ax = None
+        ax = df1.plot(ax=ax)
+        ax = df2.plot(ax=ax)
+
+        line1, line2 = ax.lines
+        # xdata should not be touched (Earlier it was [0, 1])
+        np.testing.assert_equal(line1.get_xdata(), x1)
+        np.testing.assert_equal(line1.get_ydata(), y1)
+        np.testing.assert_equal(line2.get_xdata(), x2)
+        np.testing.assert_equal(line2.get_ydata(), y2)
+
     # GH 15516
     def test_mpl2_color_cycle_str(self):
         # test CN mpl 2.0 color cycle


### PR DESCRIPTION
- [ ] closes #18687
- [ ] tests added / passed
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

Matplotlib can handle string data, so `_get_xticks` does not need to convert strings to int