### PR TITLE
Update parsers.py usecols description

### DIFF
--- a/pandas/io/parsers.py
+++ b/pandas/io/parsers.py
@@ -108,6 +108,8 @@ usecols : array-like or callable, default None
     example of a valid callable argument would be ``lambda x: x.upper() in
     ['AAA', 'BBB', 'DDD']``. Using this parameter results in much faster
     parsing time and lower memory usage.
+    Note that indexes in usecols is automatically sorted in ascending order. (ie. [1,0]
+    will return same dataframe as [0,1] using indexes)
 as_recarray : boolean, default False
     .. deprecated:: 0.19.0
        Please call `pd.read_csv(...).to_records()` instead.


### PR DESCRIPTION
Added note on the description of usecols in parsers.py file to clarify that order of parsers.py doesn't matter in the read_csv() method. Regardless of what order usecols is inputted in, read_csv() will return a DataFrame of the columns in ascending order.