### PR TITLE
CLN: ASV inference benchmark

### DIFF
--- a/asv_bench/benchmarks/inference.py
+++ b/asv_bench/benchmarks/inference.py
@@ -1,77 +1,81 @@
-from .pandas_vb_common import *
-import pandas as pd
+import numpy as np
+import pandas.util.testing as tm
+import pandas._libs.lib as lib
+from pandas import DataFrame, Series, to_numeric
+
+from .pandas_vb_common import setup  # noqa
 
 
-class DtypeInfer(object):
-    goal_time = 0.2
-
+class NumericInferOps(object):
     # from GH 7332
+    goal_time = 0.2
+    params = ['int64', 'int32', 'uint32', 'float32', 'float64']
+    param_names = ['dtype']
 
-    def setup(self):
-        self.N = 500000
-        self.df_int64 = DataFrame(dict(A=np.arange(self.N, dtype='int64'),
-                                       B=np.arange(self.N, dtype='int64')))
-        self.df_int32 = DataFrame(dict(A=np.arange(self.N, dtype='int32'),
-                                       B=np.arange(self.N, dtype='int32')))
-        self.df_uint32 = DataFrame(dict(A=np.arange(self.N, dtype='uint32'),
-                                        B=np.arange(self.N, dtype='uint32')))
-        self.df_float64 = DataFrame(dict(A=np.arange(self.N, dtype='float64'),
-                                         B=np.arange(self.N, dtype='float64')))
-        self.df_float32 = DataFrame(dict(A=np.arange(self.N, dtype='float32'),
-                                         B=np.arange(self.N, dtype='float32')))
-        self.df_datetime64 = DataFrame(dict(A=pd.to_datetime(np.arange(self.N, dtype='int64'), unit='ms'),
-                                            B=pd.to_datetime(np.arange(self.N, dtype='int64'), unit='ms')))
-        self.df_timedelta64 = DataFrame(dict(A=(self.df_datetime64['A'] - self.df_datetime64['B']),
-                                             B=self.df_datetime64['B']))
+    def setup(self, dtype):
+        N = 5 * 10**5
+        self.df = DataFrame({'A': np.arange(N).astype(dtype),
+                             'B': np.arange(N).astype(dtype)})
 
-    def time_int64(self):
-        (self.df_int64['A'] + self.df_int64['B'])
+    def time_add(self, dtype):
+        self.df['A'] + self.df['B']
 
-    def time_int32(self):
-        (self.df_int32['A'] + self.df_int32['B'])
+    def time_subtract(self, dtype):
+        self.df['A'] - self.df['B']
 
-    def time_uint32(self):
-        (self.df_uint32['A'] + self.df_uint32['B'])
+    def time_multiply(self, dtype):
+        self.df['A'] * self.df['B']
 
-    def time_float64(self):
-        (self.df_float64['A'] + self.df_float64['B'])
+    def time_divide(self, dtype):
+        self.df['A'] / self.df['B']
 
-    def time_float32(self):
-        (self.df_float32['A'] + self.df_float32['B'])
-
-    def time_datetime64(self):
-        (self.df_datetime64['A'] - self.df_datetime64['B'])
-
-    def time_timedelta64_1(self):
-        (self.df_timedelta64['A'] + self.df_timedelta64['B'])
-
-    def time_timedelta64_2(self):
-        (self.df_timedelta64['A'] + self.df_timedelta64['A'])
+    def time_modulo(self, dtype):
+        self.df['A'] % self.df['B']
 
 
-class to_numeric(object):
+class DateInferOps(object):
+    # from GH 7332
     goal_time = 0.2
 
-    def setup(self):
-        self.n = 10000
-        self.float = Series(np.random.randn(self.n * 100))
+    def setup_cache(self):
+        N = 5 * 10**5
+        df = DataFrame({'datetime64': np.arange(N).astype('datetime64[ms]')})
+        df['timedelta'] = df['datetime64'] - df['datetime64']
+        return df
+
+    def time_subtract_datetimes(self, df):
+        df['datetime64'] - df['datetime64']
+
+    def time_timedelta_plus_datetime(self, df):
+        df['timedelta'] + df['datetime64']
+
+    def time_add_timedeltas(self, df):
+        df['timedelta'] + df['timedelta']
+
+
+class ToNumeric(object):
+
+    goal_time = 0.2
+    params = ['ignore', 'coerce']
+    param_names = ['errors']
+
+    def setup(self, errors):
+        N = 10000
+        self.float = Series(np.random.randn(N))
         self.numstr = self.float.astype('str')
-        self.str = Series(tm.makeStringIndex(self.n))
+        self.str = Series(tm.makeStringIndex(N))
 
-    def time_from_float(self):
-        pd.to_numeric(self.float)
+    def time_from_float(self, errors):
+        to_numeric(self.float, errors=errors)
 
-    def time_from_numeric_str(self):
-        pd.to_numeric(self.numstr)
+    def time_from_numeric_str(self, errors):
+        to_numeric(self.numstr, errors=errors)
 
-    def time_from_str_ignore(self):
-        pd.to_numeric(self.str, errors='ignore')
-
-    def time_from_str_coerce(self):
-        pd.to_numeric(self.str, errors='coerce')
+    def time_from_str(self, errors):
+        to_numeric(self.str, errors=errors)
 
 
-class to_numeric_downcast(object):
+class ToNumericDowncast(object):
 
     param_names = ['dtype', 'downcast']
     params = [['string-float', 'string-int', 'string-nint', 'datetime64',
@@ -79,39 +83,32 @@ class to_numeric_downcast(object):
               [None, 'integer', 'signed', 'unsigned', 'float']]
 
     N = 500000
-    N2 = int(N / 2)
+    N2 = N / 2
 
-    data_dict = {
-        'string-int': (['1'] * N2) + ([2] * N2),
-        'string-nint': (['-1'] * N2) + ([2] * N2),
-        'datetime64': np.repeat(np.array(['1970-01-01', '1970-01-02'],
-                                         dtype='datetime64[D]'), N),
-        'string-float': (['1.1'] * N2) + ([2] * N2),
-        'int-list': ([1] * N2) + ([2] * N2),
-        'int32': np.repeat(np.int32(1), N)
-        }
+    data_dict = {'string-int': ['1'] * N2 + [2] * N2,
+                 'string-nint': ['-1'] * N2 + [2] * N2,
+                 'datetime64': np.repeat(np.array(['1970-01-01', '1970-01-02'],
+                                                  dtype='datetime64[D]'), N),
+                 'string-float': ['1.1'] * N2 + [2] * N2,
+                 'int-list': [1] * N2 + [2] * N2,
+                 'int32': np.repeat(np.int32(1), N)}
 
     def setup(self, dtype, downcast):
         self.data = self.data_dict[dtype]
 
     def time_downcast(self, dtype, downcast):
-        pd.to_numeric(self.data, downcast=downcast)
+        to_numeric(self.data, downcast=downcast)
 
 
 class MaybeConvertNumeric(object):
 
-    def setup(self):
-        n = 1000000
-        arr = np.repeat([2**63], n)
-        arr = arr + np.arange(n).astype('uint64')
-        arr = np.array([arr[i] if i%2 == 0 else
-                        str(arr[i]) for i in range(n)],
-                       dtype=object)
+    def setup_cache(self):
+        N = 10**6
+        arr = np.repeat([2**63], N) + np.arange(N).astype('uint64')
+        data = arr.astype(object)
+        data[1::2] = arr[1::2].astype(str)
+        data[-1] = -1
+        return data
 
-        arr[-1] = -1
-        self.data = arr
-        self.na_values = set()
-
-    def time_convert(self):
-        lib.maybe_convert_numeric(self.data, self.na_values,
-                                  coerce_numeric=False)
+    def time_convert(self, data):
+        lib.maybe_convert_numeric(data, set(), coerce_numeric=False)

--- a/asv_bench/benchmarks/inference.py
+++ b/asv_bench/benchmarks/inference.py
@@ -1,15 +1,18 @@
 import numpy as np
 import pandas.util.testing as tm
-import pandas._libs.lib as lib
+try:
+    import pandas._libs.lib as lib
+except ImportError:
+    import pandas.lib as lib
 from pandas import DataFrame, Series, to_numeric
 
-from .pandas_vb_common import setup  # noqa
+from .pandas_vb_common import numeric_dtypes, setup  # noqa
 
 
 class NumericInferOps(object):
     # from GH 7332
     goal_time = 0.2
-    params = ['int64', 'int32', 'uint32', 'float32', 'float64']
+    params = numeric_dtypes
     param_names = ['dtype']
 
     def setup(self, dtype):
@@ -83,7 +86,7 @@ class ToNumericDowncast(object):
               [None, 'integer', 'signed', 'unsigned', 'float']]
 
     N = 500000
-    N2 = N / 2
+    N2 = int(N / 2)
 
     data_dict = {'string-int': ['1'] * N2 + [2] * N2,
                  'string-nint': ['-1'] * N2 + [2] * N2,

--- a/asv_bench/benchmarks/inference.py
+++ b/asv_bench/benchmarks/inference.py
@@ -1,12 +1,8 @@
 import numpy as np
 import pandas.util.testing as tm
-try:
-    import pandas._libs.lib as lib
-except ImportError:
-    import pandas.lib as lib
 from pandas import DataFrame, Series, to_numeric
 
-from .pandas_vb_common import numeric_dtypes, setup  # noqa
+from .pandas_vb_common import numeric_dtypes, lib, setup  # noqa
 
 
 class NumericInferOps(object):

--- a/asv_bench/benchmarks/pandas_vb_common.py
+++ b/asv_bench/benchmarks/pandas_vb_common.py
@@ -43,7 +43,7 @@ class BaseIO(object):
     def teardown(self, *args, **kwargs):
         self.remove(self.fname)
 
-# try em until it works!
+# Compatability import for lib
 for imp in ['pandas._libs.lib', 'pandas.lib', 'pandas_tseries']:
     try:
         lib = import_module(imp)

--- a/asv_bench/benchmarks/pandas_vb_common.py
+++ b/asv_bench/benchmarks/pandas_vb_common.py
@@ -14,6 +14,10 @@ try:
 except ImportError:
     pass
 
+numeric_dtypes = [np.int64, np.int32, np.uint32, np.uint64, np.float32,
+                  np.float64, np.int16, np.int8, np.uint16, np.uint8]
+datetime_dtypes = [np.datetime64, np.timedelta64]
+
 # This function just needs to be imported into each benchmark file in order to 
 # sets up the random seed before each function. 
 # http://asv.readthedocs.io/en/latest/writing_benchmarks.html


### PR DESCRIPTION
- Flake8 and removed star imports

- Used `params` and `setup_cache` where possible

```
asv dev -b ^inference
· Discovering benchmarks
· Running 13 total benchmarks (1 commits * 1 environments * 13 benchmarks)
[  0.00%] ·· Building for existing-py_home_matt_anaconda_envs_pandas_dev_bin_python
[  0.00%] ·· Benchmarking existing-py_home_matt_anaconda_envs_pandas_dev_bin_python
[  0.00%] ··· Setting up /home/matt/Projects/pandas-mroeschke/asv_bench/benchmarks/inference.py:105
[  7.69%] ··· Running inference.MaybeConvertNumeric.time_convert                                                                    2.55s
[ 15.38%] ··· Running inference.NumericInferOps.time_add                                                                               ok
[ 15.38%] ···· 
               ========= ========
                 dtype           
               --------- --------
                 int64    7.27ms 
                 int32    4.09ms 
                 uint32   2.33ms 
                float32   3.98ms 
                float64   7.20ms 
               ========= ========

[ 23.08%] ··· Running inference.NumericInferOps.time_divide                                                                            ok
[ 23.08%] ···· 
               ========= ========
                 dtype           
               --------- --------
                 int64    9.22ms 
                 int32    7.77ms 
                 uint32   6.34ms 
                float32   4.00ms 
                float64   7.25ms 
               ========= ========

[ 30.77%] ··· Running inference.NumericInferOps.time_modulo                                                                            ok
[ 30.77%] ···· 
               ========= ========
                 dtype           
               --------- --------
                 int64    17.3ms 
                 int32    9.96ms 
                 uint32   10.3ms 
                float32   8.27ms 
                float64   8.37ms 
               ========= ========

[ 38.46%] ··· Running inference.NumericInferOps.time_multiply                                                                          ok
[ 38.46%] ···· 
               ========= ========
                 dtype           
               --------- --------
                 int64    7.18ms 
                 int32    4.12ms 
                 uint32   2.42ms 
                float32   4.08ms 
                float64   7.15ms 
               ========= ========

[ 46.15%] ··· Running inference.NumericInferOps.time_subtract                                                                          ok
[ 46.15%] ···· 
               ========= ========
                 dtype           
               --------- --------
                 int64    7.23ms 
                 int32    3.96ms 
                 uint32   2.36ms 
                float32   3.96ms 
                float64   7.12ms 
               ========= ========

[ 53.85%] ··· Running inference.ToNumeric.time_from_float                                                                              ok
[ 53.85%] ···· 
               ======== =======
                errors         
               -------- -------
                ignore   157μs 
                coerce   158μs 
               ======== =======

[ 61.54%] ··· Running inference.ToNumeric.time_from_numeric_str                                                                        ok
[ 61.54%] ···· 
               ======== ========
                errors          
               -------- --------
                ignore   8.08ms 
                coerce   8.05ms 
               ======== ========

[ 69.23%] ··· Running inference.ToNumeric.time_from_str                                                                                ok
[ 69.23%] ···· 
               ======== ========
                errors          
               -------- --------
                ignore   365μs  
                coerce   24.7ms 
               ======== ========

[ 76.92%] ··· Running inference.ToNumericDowncast.time_downcast                                                                        ok
[ 76.92%] ···· 
               ============== ======== ========= ======== ========== ========
               --                                 downcast                   
               -------------- -----------------------------------------------
                   dtype        None    integer   signed   unsigned   float  
               ============== ======== ========= ======== ========== ========
                string-float   264ms     270ms    272ms     267ms     268ms  
                 string-int    597ms     621ms    640ms     612ms     605ms  
                string-nint    613ms     622ms    631ms     597ms     610ms  
                 datetime64    5.17ms    72.0ms   72.3ms    74.3ms    8.87ms 
                  int-list     65.0ms    92.7ms   92.5ms    94.5ms    66.8ms 
                   int32       26.2μs    27.2ms   26.9ms    27.9ms    1.35ms 
               ============== ======== ========= ======== ========== ========

[ 76.92%] ··· Setting up /home/matt/Projects/pandas-mroeschke/asv_bench/benchmarks/inference.py:40
[ 84.62%] ··· Running inference.DateInferOps.time_add_timedeltas                                                                   29.1ms
[ 92.31%] ··· Running inference.DateInferOps.time_subtract_datetimes                                                               23.6ms
[100.00%] ··· Running inference.DateInferOps.time_timedelta_plus_datetime                                                           157ms
```
