### PR TITLE
TST: Skip if Decorators for Localpath and Pathlib

### DIFF
--- a/pandas/tests/io/sas/test_sas7bdat.py
+++ b/pandas/tests/io/sas/test_sas7bdat.py
@@ -1,6 +1,7 @@
 import pandas as pd
 from pandas.compat import PY2
 import pandas.util.testing as tm
+import pandas.util._test_decorators as td
 from pandas.errors import EmptyDataError
 import os
 import io
@@ -71,8 +72,8 @@ class TestSAS7BDAT(object):
                 tm.assert_frame_equal(df, df0.iloc[2:5, :])
                 rdr.close()
 
+    @td.skip_if_no('pathlib')
     def test_path_pathlib(self):
-        tm._skip_if_no_pathlib()
         from pathlib import Path
         for j in 0, 1:
             df0 = self.data[j]

--- a/pandas/tests/io/sas/test_sas7bdat.py
+++ b/pandas/tests/io/sas/test_sas7bdat.py
@@ -83,8 +83,8 @@ class TestSAS7BDAT(object):
                 df = pd.read_sas(fname, encoding='utf-8')
                 tm.assert_frame_equal(df, df0)
 
+    @td.skip_if_no('py.path')
     def test_path_localpath(self):
-        tm._skip_if_no_localpath()
         from py.path import local as LocalPath
         for j in 0, 1:
             df0 = self.data[j]

--- a/pandas/tests/io/test_common.py
+++ b/pandas/tests/io/test_common.py
@@ -75,9 +75,8 @@ bar2,12,13,14,15
         redundant_path = common._stringify_path(Path('foo//bar'))
         assert redundant_path == os.path.join('foo', 'bar')
 
+    @td.skip_if_no('py.path')
     def test_stringify_path_localpath(self):
-        tm._skip_if_no_localpath()
-
         path = os.path.join('foo', 'bar')
         abs_path = os.path.abspath(path)
         lpath = LocalPath(path)

--- a/pandas/tests/io/test_common.py
+++ b/pandas/tests/io/test_common.py
@@ -8,6 +8,7 @@ from os.path import isabs
 
 import pandas as pd
 import pandas.util.testing as tm
+import pandas.util._test_decorators as td
 
 from pandas.io import common
 from pandas.compat import is_platform_windows, StringIO, FileNotFoundError
@@ -67,9 +68,8 @@ bar2,12,13,14,15
         assert expanded_name == filename
         assert os.path.expanduser(filename) == expanded_name
 
+    @td.skip_if_no('pathlib')
     def test_stringify_path_pathlib(self):
-        tm._skip_if_no_pathlib()
-
         rel_path = common._stringify_path(Path('.'))
         assert rel_path == '.'
         redundant_path = common._stringify_path(Path('foo//bar'))

--- a/pandas/tests/io/test_excel.py
+++ b/pandas/tests/io/test_excel.py
@@ -665,11 +665,10 @@ class XlrdTests(ReadingTestsBase):
 
         tm.assert_frame_equal(expected, actual)
 
+    @td.skip_if_no('py.path')
     def test_read_from_py_localpath(self):
 
         # GH12655
-        tm._skip_if_no_localpath()
-
         from py.path import local as LocalPath
 
         str_path = os.path.join(self.dirpath, 'test1' + self.ext)

--- a/pandas/tests/io/test_excel.py
+++ b/pandas/tests/io/test_excel.py
@@ -13,6 +13,7 @@ from numpy import nan
 
 import pandas as pd
 import pandas.util.testing as tm
+import pandas.util._test_decorators as td
 from pandas import DataFrame, Index, MultiIndex
 from pandas.compat import u, range, map, BytesIO, iteritems
 from pandas.core.config import set_option, get_option
@@ -650,11 +651,10 @@ class XlrdTests(ReadingTestsBase):
 
         tm.assert_frame_equal(url_table, local_table)
 
+    @td.skip_if_no('pathlib')
     def test_read_from_pathlib_path(self):
 
         # GH12655
-        tm._skip_if_no_pathlib()
-
         from pathlib import Path
 
         str_path = os.path.join(self.dirpath, 'test1' + self.ext)

--- a/pandas/tests/io/test_pytables.py
+++ b/pandas/tests/io/test_pytables.py
@@ -5119,11 +5119,10 @@ class TestHDFStore(Base):
             store.close()
             pytest.raises(ValueError, read_hdf, path)
 
+    @td.skip_if_no('pathlib')
     def test_read_from_pathlib_path(self):
 
         # GH11773
-        tm._skip_if_no_pathlib()
-
         from pathlib import Path
 
         expected = DataFrame(np.random.rand(4, 5),
@@ -5137,11 +5136,10 @@ class TestHDFStore(Base):
 
         tm.assert_frame_equal(expected, actual)
 
+    @td.skip_if_no('py.path')
     def test_read_from_py_localpath(self):
 
         # GH11773
-        tm._skip_if_no_localpath()
-
         from py.path import local as LocalPath
 
         expected = DataFrame(np.random.rand(4, 5),

--- a/pandas/util/_test_decorators.py
+++ b/pandas/util/_test_decorators.py
@@ -95,6 +95,29 @@ def _skip_if_not_us_locale():
 
 
 def skip_if_no(package, min_version=None):
+    """
+    Generic function to help skip test functions when required packages are not
+    present on the testing system.
+
+    Intended for use as a decorator, this function will wrap the decorated
+    function with a pytest ``skip_if`` mark. During a pytest test suite
+    execution, that mark will attempt to import the specified ``package`` and
+    optionally ensure it meets the ``min_version``. If the import and version
+    check are unsuccessful, then the decorated function will be skipped.
+
+    Parameters
+    ----------
+    package: str
+        The name of the package required by the decorated function
+    min_version: str or None, default None
+        Optional minimum version of the package required by the decorated
+        function
+
+    Returns
+    -------
+    decorated_func: function
+        The decorated function wrapped within a pytest ``skip_if`` mark
+    """
     def decorated_func(func):
         return pytest.mark.skipif(
             not safe_import(package, min_version=min_version),

--- a/pandas/util/_test_decorators.py
+++ b/pandas/util/_test_decorators.py
@@ -96,8 +96,10 @@ def _skip_if_not_us_locale():
 
 def skip_if_no(package, min_version=None):
     def decorated_func(func):
-        return pytest.mark.skipif(not safe_import(package, min_version=min_version),
-                                  reason="Could not import '{}'".format(package))(func)
+        return pytest.mark.skipif(
+            not safe_import(package, min_version=min_version),
+            reason="Could not import '{}'".format(package)
+        )(func)
     return decorated_func
 
 

--- a/pandas/util/_test_decorators.py
+++ b/pandas/util/_test_decorators.py
@@ -94,6 +94,13 @@ def _skip_if_not_us_locale():
         return True
 
 
+def skip_if_no(package, min_version=None):
+    def decorated_func(func):
+        return pytest.mark.skipif(not safe_import(package, min_version=min_version),
+                                  reason="Could not import '{}'".format(package))(func)
+    return decorated_func
+
+
 skip_if_no_mpl = pytest.mark.skipif(_skip_if_no_mpl(),
                                     reason="Missing matplotlib dependency")
 skip_if_mpl_1_5 = pytest.mark.skipif(_skip_if_mpl_1_5(),

--- a/pandas/util/testing.py
+++ b/pandas/util/testing.py
@@ -359,14 +359,6 @@ def _skip_if_no_xarray():
         pytest.skip("xarray version is too low: {version}".format(version=v))
 
 
-def _skip_if_no_pathlib():
-    try:
-        from pathlib import Path  # noqa
-    except ImportError:
-        import pytest
-        pytest.skip("pathlib not available")
-
-
 def _skip_if_no_localpath():
     try:
         from py.path import local as LocalPath  # noqa

--- a/pandas/util/testing.py
+++ b/pandas/util/testing.py
@@ -359,14 +359,6 @@ def _skip_if_no_xarray():
         pytest.skip("xarray version is too low: {version}".format(version=v))
 
 
-def _skip_if_no_localpath():
-    try:
-        from py.path import local as LocalPath  # noqa
-    except ImportError:
-        import pytest
-        pytest.skip("py.path not installed")
-
-
 def skip_if_no_ne(engine='numexpr'):
     from pandas.core.computation.expressions import (
         _USE_NUMEXPR,


### PR DESCRIPTION
- [ ] progress towards #18190 
- [X] tests added / passed
- [X] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

This push should knock out the ``pathlib`` and ``localpath`` skip if functions. Rather than creating them as their own marks, I've created a generic decorator that accepts a package and optionally a min_version as its arguments. With that, it returns a function marked with the ``skip_if`` decorator that calls ``safe_import`` to validate whether or not the function should be skipped.

This isn't applicable to all of the skip_if decorators because some of them have post-processing they do after import (see the matplotlib decorators) but for very generic import checks this could scale better in the future