### PR TITLE
BUG: Convert data elements when dtype=str in Series constructor with …

### DIFF
--- a/doc/source/whatsnew/v0.22.0.txt
+++ b/doc/source/whatsnew/v0.22.0.txt
@@ -277,6 +277,7 @@ Conversion
 - Fixed a bug where ``FY5253`` date offsets could incorrectly raise an ``AssertionError`` in arithmetic operatons (:issue:`14774`)
 - Bug in :meth:`Index.astype` with a categorical dtype where the resultant index is not converted to a :class:`CategoricalIndex` for all types of index (:issue:`18630`)
 - Bug in :meth:`Series.astype` and ``Categorical.astype()`` where an existing categorical data does not get updated (:issue:`10696`, :issue:`18593`)
+- Bug in :class:`Series` constructor with an int or float list where specifying ``dtype=str``, ``dtype='str'`` or ``dtype='U'`` failed to convert the data elements to strings (:issue:`16605`)
 
 
 Indexing

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -3277,6 +3277,11 @@ def _sanitize_array(data, index, dtype=None, copy=False,
     # This is to prevent mixed-type Series getting all casted to
     # NumPy string type, e.g. NaN --> '-1#IND'.
     if issubclass(subarr.dtype.type, compat.string_types):
+        # GH 16605
+        # If not empty convert the data to dtype
+        if not isna(data).all():
+            data = np.array(data, dtype=dtype)
+
         subarr = np.array(data, dtype=object, copy=copy)
 
     return subarr

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -3280,7 +3280,7 @@ def _sanitize_array(data, index, dtype=None, copy=False,
         # GH 16605
         # If not empty convert the data to dtype
         if not isna(data).all():
-            data = np.array(data, dtype=dtype)
+            data = np.array(data, dtype=dtype, copy=False)
 
         subarr = np.array(data, dtype=object, copy=copy)
 

--- a/pandas/tests/frame/test_dtypes.py
+++ b/pandas/tests/frame/test_dtypes.py
@@ -677,6 +677,26 @@ class TestDataFrameDataTypes(TestData):
         df.astype(np.int8, errors='ignore')
 
 
+    @pytest.mark.parametrize('input_vals', [
+        ([1, 2]),
+        ([1.0, 2.0, np.nan]),
+        (['1', '2']),
+        (list(pd.date_range('1/1/2011', periods=2, freq='H'))),
+        (list(pd.date_range('1/1/2011', periods=2, freq='H',
+                            tz='US/Eastern'))),
+        ([pd.Interval(left=0, right=5)]),
+    ])
+    def test_constructor_list_str(self, input_vals):
+        # GH 16605
+        # Ensure that data elements are converted to strings when
+        # dtype is str, 'str', or 'U'
+
+        for dtype in ['str', str, 'U']:
+            result = DataFrame({'A': input_vals}, dtype=dtype)
+            expected = DataFrame({'A': input_vals}).astype({'A': dtype})
+            assert_frame_equal(result, expected)
+
+
 class TestDataFrameDatetimeWithTZ(TestData):
 
     def test_interleave(self):

--- a/pandas/tests/frame/test_dtypes.py
+++ b/pandas/tests/frame/test_dtypes.py
@@ -676,7 +676,6 @@ class TestDataFrameDataTypes(TestData):
 
         df.astype(np.int8, errors='ignore')
 
-
     @pytest.mark.parametrize('input_vals', [
         ([1, 2]),
         ([1.0, 2.0, np.nan]),

--- a/pandas/tests/series/test_constructors.py
+++ b/pandas/tests/series/test_constructors.py
@@ -142,6 +142,22 @@ class TestSeriesConstructors(TestData):
             result = Series(obj, index=[0, 1, 2])
             assert_series_equal(result, expected)
 
+    @pytest.mark.parametrize('input_vals, dtype, expected', [
+        ([1, 2, 3], 'str', ['1', '2', '3']),
+        ([1, 2, 3], str, ['1', '2', '3']),
+        ([1, 2, 3], 'U', ['1', '2', '3']),
+        ([1.0, 2.0, 3.0], 'str', ['1.0', '2.0', '3.0']),
+        ([1.0, 2.0, 3.0], str, ['1.0', '2.0', '3.0']),
+        ([1.0, 2.0, 3.0], 'U', ['1.0', '2.0', '3.0'])
+    ])
+    def test_constructor_list_str(self, input_vals, dtype, expected):
+        # GH 16605
+        # Ensure that data elements are converted to strings when
+        # dtype is str, 'str', or 'U'
+
+        result = Series(input_vals, dtype=dtype)
+        assert_series_equal(result, Series(expected))
+
     def test_constructor_generator(self):
         gen = (i for i in range(10))
 

--- a/pandas/tests/series/test_constructors.py
+++ b/pandas/tests/series/test_constructors.py
@@ -23,7 +23,7 @@ from pandas._libs import lib
 from pandas._libs.tslib import iNaT
 
 from pandas.compat import lrange, range, zip, long
-from pandas.util.testing import assert_series_equal
+from pandas.util.testing import assert_series_equal, assert_frame_equal
 import pandas.util.testing as tm
 
 from .common import TestData
@@ -146,14 +146,15 @@ class TestSeriesConstructors(TestData):
         ([1, 2]),
         ([1.0, 2.0, np.nan]),
         (['1', '2']),
-        (pd.date_range('1/1/2011', periods=2)),
-        (pd.date_range('1/1/2011', periods=2, tz='US/Eastern')),
-        (pd.Interval(left=0, right=5)),
+        (list(pd.date_range('1/1/2011', periods=2, freq='H'))),
+        (list(pd.date_range('1/1/2011', periods=2, freq='H',
+                            tz='US/Eastern'))),
+        ([pd.Interval(left=0, right=5)]),
     ])
     def test_constructor_list_str(self, input_vals):
         # GH 16605
-        # Ensure that data elements are converted to strings when
-        # dtype is str, 'str', or 'U'
+        # Ensure that data elements from a list are converted to strings
+        # when dtype is str, 'str', or 'U'
 
         for dtype in ['str', str, 'U']:
             result = Series(input_vals, dtype=dtype)

--- a/pandas/tests/series/test_constructors.py
+++ b/pandas/tests/series/test_constructors.py
@@ -142,21 +142,23 @@ class TestSeriesConstructors(TestData):
             result = Series(obj, index=[0, 1, 2])
             assert_series_equal(result, expected)
 
-    @pytest.mark.parametrize('input_vals, dtype, expected', [
-        ([1, 2, 3], 'str', ['1', '2', '3']),
-        ([1, 2, 3], str, ['1', '2', '3']),
-        ([1, 2, 3], 'U', ['1', '2', '3']),
-        ([1.0, 2.0, 3.0], 'str', ['1.0', '2.0', '3.0']),
-        ([1.0, 2.0, 3.0], str, ['1.0', '2.0', '3.0']),
-        ([1.0, 2.0, 3.0], 'U', ['1.0', '2.0', '3.0'])
+    @pytest.mark.parametrize('input_vals', [
+        ([1, 2]),
+        ([1.0, 2.0, np.nan]),
+        (['1', '2']),
+        (pd.date_range('1/1/2011', periods=2)),
+        (pd.date_range('1/1/2011', periods=2, tz='US/Eastern')),
+        (pd.Interval(left=0, right=5)),
     ])
-    def test_constructor_list_str(self, input_vals, dtype, expected):
+    def test_constructor_list_str(self, input_vals):
         # GH 16605
         # Ensure that data elements are converted to strings when
         # dtype is str, 'str', or 'U'
 
-        result = Series(input_vals, dtype=dtype)
-        assert_series_equal(result, Series(expected))
+        for dtype in ['str', str, 'U']:
+            result = Series(input_vals, dtype=dtype)
+            expected = Series(input_vals).astype(dtype)
+            assert_series_equal(result, expected)
 
     def test_constructor_generator(self):
         gen = (i for i in range(10))

--- a/pandas/tests/series/test_constructors.py
+++ b/pandas/tests/series/test_constructors.py
@@ -23,7 +23,7 @@ from pandas._libs import lib
 from pandas._libs.tslib import iNaT
 
 from pandas.compat import lrange, range, zip, long
-from pandas.util.testing import assert_series_equal, assert_frame_equal
+from pandas.util.testing import assert_series_equal
 import pandas.util.testing as tm
 
 from .common import TestData


### PR DESCRIPTION
…int/float list

- [ ] closes #16605
- [ ] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry

Not sure if my solution is correct but it seems to resolve the issue and pass the tests.