### PR TITLE
DEPR: Deprecate Series.valid

### DIFF
--- a/doc/source/whatsnew/v0.22.0.txt
+++ b/doc/source/whatsnew/v0.22.0.txt
@@ -203,6 +203,7 @@ Deprecations
 - ``Series.from_array`` and ``SparseSeries.from_array`` are deprecated. Use the normal constructor ``Series(..)`` and ``SparseSeries(..)`` instead (:issue:`18213`).
 - ``DataFrame.as_matrix`` is deprecated. Use ``DataFrame.values`` instead (:issue:`18458`).
 - ``Series.asobject``, ``DatetimeIndex.asobject``, ``PeriodIndex.asobject`` and ``TimeDeltaIndex.asobject`` have been deprecated. Use ``.astype(object)`` instead (:issue:`18572`)
+- ``Series.valid`` is deprecated. Use :meth:`Series.dropna` instead (:issue:`18800`).
 
 .. _whatsnew_0220.prior_deprecations:
 

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -150,7 +150,7 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
     _accessors = frozenset(['dt', 'cat', 'str'])
     _deprecations = generic.NDFrame._deprecations | frozenset(
         ['asobject', 'sortlevel', 'reshape', 'get_value', 'set_value',
-         'from_csv'])
+         'from_csv', 'valid'])
     _allow_index_ops = True
 
     def __init__(self, data=None, index=None, dtype=None, name=None,
@@ -3006,8 +3006,13 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
             else:
                 return self.copy()
 
-    valid = lambda self, inplace=False, **kwargs: self.dropna(inplace=inplace,
-                                                              **kwargs)
+    def valid(self, inplace=False, **kwargs):
+        """DEPRECATED. Series.valid will be removed in a future version.
+        Use :meth:`Series.dropna` instead.
+        """
+        warnings.warn("Method .valid will be removed in a future version. "
+                      "Use .dropna instead.", FutureWarning, stacklevel=2)
+        return self.dropna(inplace=inplace, **kwargs)
 
     @Appender(generic._shared_docs['valid_index'] % {
         'position': 'first', 'klass': 'Series'})

--- a/pandas/core/sparse/series.py
+++ b/pandas/core/sparse/series.py
@@ -701,7 +701,7 @@ class SparseSeries(Series):
         """
         # TODO: make more efficient
         axis = self._get_axis_number(axis or 0)
-        dense_valid = self.to_dense().valid()
+        dense_valid = self.to_dense().dropna()
         if inplace:
             raise NotImplementedError("Cannot perform inplace dropna"
                                       " operations on a SparseSeries")

--- a/pandas/tests/frame/test_operators.py
+++ b/pandas/tests/frame/test_operators.py
@@ -766,10 +766,10 @@ class TestDataFrameOperators(TestData):
 
         added = self.frame + frame_copy
 
-        indexer = added['A'].valid().index
+        indexer = added['A'].dropna().index
         exp = (self.frame['A'] * 2).copy()
 
-        tm.assert_series_equal(added['A'].valid(), exp.loc[indexer])
+        tm.assert_series_equal(added['A'].dropna(), exp.loc[indexer])
 
         exp.loc[~exp.index.isin(indexer)] = np.nan
         tm.assert_series_equal(added['A'], exp.loc[added['A'].index])

--- a/pandas/tests/frame/test_timeseries.py
+++ b/pandas/tests/frame/test_timeseries.py
@@ -213,7 +213,7 @@ class TestDataFrameTimeSeriesMethods(TestData):
         unshifted = shifted.shift(-1)
         tm.assert_index_equal(shifted.index, ps.index)
         tm.assert_index_equal(unshifted.index, ps.index)
-        tm.assert_numpy_array_equal(unshifted.iloc[:, 0].valid().values,
+        tm.assert_numpy_array_equal(unshifted.iloc[:, 0].dropna().values,
                                     ps.iloc[:-1, 0].values)
 
         shifted2 = ps.shift(1, 'B')

--- a/pandas/tests/generic/test_series.py
+++ b/pandas/tests/generic/test_series.py
@@ -222,3 +222,8 @@ class TestSeries(Generic):
         assert_almost_equal(list(result.coords.keys()), ['one', 'two'])
         assert isinstance(result, DataArray)
         assert_series_equal(result.to_series(), s)
+
+    def test_valid_deprecated(self):
+        # GH18800
+        with tm.assert_produces_warning(FutureWarning):
+            pd.Series([]).valid()

--- a/pandas/tests/series/test_analytics.py
+++ b/pandas/tests/series/test_analytics.py
@@ -396,7 +396,7 @@ class TestSeriesAnalytics(TestData):
         ts = self.ts.copy()
         ts[::2] = np.NaN
         result = ts.cummin()[1::2]
-        expected = np.minimum.accumulate(ts.valid())
+        expected = np.minimum.accumulate(ts.dropna())
 
         tm.assert_series_equal(result, expected)
 
@@ -406,7 +406,7 @@ class TestSeriesAnalytics(TestData):
         ts = self.ts.copy()
         ts[::2] = np.NaN
         result = ts.cummax()[1::2]
-        expected = np.maximum.accumulate(ts.valid())
+        expected = np.maximum.accumulate(ts.dropna())
 
         tm.assert_series_equal(result, expected)
 
@@ -570,7 +570,7 @@ class TestSeriesAnalytics(TestData):
         ts[::2] = np.NaN
 
         result = func(ts)[1::2]
-        expected = func(np.array(ts.valid()))
+        expected = func(np.array(ts.dropna()))
 
         tm.assert_numpy_array_equal(result.values, expected,
                                     check_dtype=False)
@@ -1530,7 +1530,7 @@ class TestSeriesAnalytics(TestData):
         # GH 9416
         s = pd.Series(['a', 'b', 'c', 'd'], dtype='category')
 
-        assert_series_equal(s.iloc[:-1], s.shift(1).shift(-1).valid())
+        assert_series_equal(s.iloc[:-1], s.shift(1).shift(-1).dropna())
 
         sp1 = s.shift(1)
         assert_index_equal(s.index, sp1.index)

--- a/pandas/tests/series/test_missing.py
+++ b/pandas/tests/series/test_missing.py
@@ -694,7 +694,7 @@ class TestSeriesMissingData(TestData):
         ts = self.ts.copy()
         ts[::2] = np.NaN
 
-        result = ts.valid()
+        result = ts.dropna()
         assert len(result) == ts.count()
         tm.assert_series_equal(result, ts[1::2])
         tm.assert_series_equal(result, ts[pd.notna(ts)])

--- a/pandas/tests/series/test_quantile.py
+++ b/pandas/tests/series/test_quantile.py
@@ -17,14 +17,14 @@ class TestSeriesQuantile(TestData):
     def test_quantile(self):
 
         q = self.ts.quantile(0.1)
-        assert q == np.percentile(self.ts.valid(), 10)
+        assert q == np.percentile(self.ts.dropna(), 10)
 
         q = self.ts.quantile(0.9)
-        assert q == np.percentile(self.ts.valid(), 90)
+        assert q == np.percentile(self.ts.dropna(), 90)
 
         # object dtype
         q = Series(self.ts, dtype=object).quantile(0.9)
-        assert q == np.percentile(self.ts.valid(), 90)
+        assert q == np.percentile(self.ts.dropna(), 90)
 
         # datetime64[ns] dtype
         dts = self.ts.index.to_series()
@@ -49,8 +49,8 @@ class TestSeriesQuantile(TestData):
 
         qs = [.1, .9]
         result = self.ts.quantile(qs)
-        expected = pd.Series([np.percentile(self.ts.valid(), 10),
-                              np.percentile(self.ts.valid(), 90)],
+        expected = pd.Series([np.percentile(self.ts.dropna(), 10),
+                              np.percentile(self.ts.dropna(), 90)],
                              index=qs, name=self.ts.name)
         tm.assert_series_equal(result, expected)
 
@@ -72,9 +72,9 @@ class TestSeriesQuantile(TestData):
 
         # interpolation = linear (default case)
         q = self.ts.quantile(0.1, interpolation='linear')
-        assert q == np.percentile(self.ts.valid(), 10)
+        assert q == np.percentile(self.ts.dropna(), 10)
         q1 = self.ts.quantile(0.1)
-        assert q1 == np.percentile(self.ts.valid(), 10)
+        assert q1 == np.percentile(self.ts.dropna(), 10)
 
         # test with and without interpolation keyword
         assert q == q1

--- a/pandas/tests/series/test_sorting.py
+++ b/pandas/tests/series/test_sorting.py
@@ -50,10 +50,10 @@ class TestSeriesSorting(TestData):
 
         # ascending=False
         ordered = ts.sort_values(ascending=False)
-        expected = np.sort(ts.valid().values)[::-1]
-        assert_almost_equal(expected, ordered.valid().values)
+        expected = np.sort(ts.dropna().values)[::-1]
+        assert_almost_equal(expected, ordered.dropna().values)
         ordered = ts.sort_values(ascending=False, na_position='first')
-        assert_almost_equal(expected, ordered.valid().values)
+        assert_almost_equal(expected, ordered.dropna().values)
 
         # ascending=[False] should behave the same as ascending=False
         ordered = ts.sort_values(ascending=[False])

--- a/pandas/tests/series/test_timeseries.py
+++ b/pandas/tests/series/test_timeseries.py
@@ -42,7 +42,7 @@ class TestTimeSeries(TestData):
 
         tm.assert_index_equal(shifted.index, self.ts.index)
         tm.assert_index_equal(unshifted.index, self.ts.index)
-        tm.assert_numpy_array_equal(unshifted.valid().values,
+        tm.assert_numpy_array_equal(unshifted.dropna().values,
                                     self.ts.values[:-1])
 
         offset = BDay()
@@ -69,7 +69,7 @@ class TestTimeSeries(TestData):
         unshifted = shifted.shift(-1)
         tm.assert_index_equal(shifted.index, ps.index)
         tm.assert_index_equal(unshifted.index, ps.index)
-        tm.assert_numpy_array_equal(unshifted.valid().values, ps.values[:-1])
+        tm.assert_numpy_array_equal(unshifted.dropna().values, ps.values[:-1])
 
         shifted2 = ps.shift(1, 'B')
         shifted3 = ps.shift(1, BDay())

--- a/pandas/tests/sparse/test_series.py
+++ b/pandas/tests/sparse/test_series.py
@@ -796,9 +796,9 @@ class TestSparseSeries(SharedWithSparse):
     def test_dropna(self):
         sp = SparseSeries([0, 0, 0, nan, nan, 5, 6], fill_value=0)
 
-        sp_valid = sp.valid()
+        sp_valid = sp.dropna()
 
-        expected = sp.to_dense().valid()
+        expected = sp.to_dense().dropna()
         expected = expected[expected != 0]
         exp_arr = pd.SparseArray(expected.values, fill_value=0, kind='block')
         tm.assert_sp_array_equal(sp_valid.values, exp_arr)


### PR DESCRIPTION
- [x] xref #18262
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry

This PR deprecates the ``valid`` method on ``pd.Series``. This method duplicates ``dropna`` and should be deprecated according to #18262.