### PR TITLE
CLN: Drop the as_recarray parameter in read_csv

### DIFF
--- a/doc/source/io.rst
+++ b/doc/source/io.rst
@@ -143,15 +143,6 @@ usecols : array-like or callable, default ``None``
      pd.read_csv(StringIO(data), usecols=lambda x: x.upper() in ['COL1', 'COL3'])
 
   Using this parameter results in much faster parsing time and lower memory usage.
-as_recarray : boolean, default ``False``
-  .. deprecated:: 0.18.2
-
-     Please call ``pd.read_csv(...).to_records()`` instead.
-
-  Return a NumPy recarray instead of a DataFrame after parsing the data. If
-  set to ``True``, this option takes precedence over the ``squeeze`` parameter.
-  In addition, as row indices are not available in such a format, the ``index_col``
-  parameter will be ignored.
 squeeze : boolean, default ``False``
   If the parsed data only contains one column then return a Series.
 prefix : str, default ``None``

--- a/doc/source/whatsnew/v0.22.0.txt
+++ b/doc/source/whatsnew/v0.22.0.txt
@@ -221,6 +221,7 @@ Removal of prior version deprecations/changes
   and Series (deprecated since v0.18). Instead, resample before calling the methods. (:issue:18601 & :issue:18668)
 - ``DatetimeIndex.to_datetime``, ``Timestamp.to_datetime``, ``PeriodIndex.to_datetime``, and ``Index.to_datetime`` have been removed (:issue:`8254`, :issue:`14096`, :issue:`14113`)
 - :func:`read_csv` has dropped the ``skip_footer`` parameter (:issue:`13386`)
+- :func:`read_csv` has dropped the ``as_recarray`` parameter (:issue:`13373`)
 
 .. _whatsnew_0220.performance:
 

--- a/pandas/_libs/parsers.pyx
+++ b/pandas/_libs/parsers.pyx
@@ -302,7 +302,6 @@ cdef class TextReader:
         object delimiter, converters, delim_whitespace
         object na_values
         object memory_map
-        object as_recarray
         object header, orig_header, names, header_start, header_end
         object index_col
         object low_memory
@@ -333,8 +332,6 @@ cdef class TextReader:
                   compression=None,
 
                   converters=None,
-
-                  as_recarray=False,
 
                   skipinitialspace=False,
                   escapechar=None,
@@ -489,8 +486,6 @@ cdef class TextReader:
         self.converters = converters
 
         self.na_filter = na_filter
-        self.as_recarray = as_recarray
-
         self.compact_ints = compact_ints
         self.use_unsigned = use_unsigned
 
@@ -903,14 +898,7 @@ cdef class TextReader:
             # Don't care about memory usage
             columns = self._read_rows(rows, 1)
 
-        if self.as_recarray:
-            self._start_clock()
-            result = _to_structured_array(columns, self.header, self.usecols)
-            self._end_clock('Conversion to structured array')
-
-            return result
-        else:
-            return columns
+        return columns
 
     cdef _read_low_memory(self, rows):
         cdef:
@@ -999,7 +987,7 @@ cdef class TextReader:
         self._start_clock()
         columns = self._convert_column_data(rows=rows,
                                             footer=footer,
-                                            upcast_na=not self.as_recarray)
+                                            upcast_na=True)
         self._end_clock('Type conversion')
 
         self._start_clock()
@@ -2319,63 +2307,6 @@ cdef _apply_converter(object f, parser_t *parser, int64_t col,
             result[i] = f(val)
 
     return lib.maybe_convert_objects(result)
-
-
-def _to_structured_array(dict columns, object names, object usecols):
-    cdef:
-        ndarray recs, column
-        cnp.dtype dt
-        dict fields
-
-        object name, fnames, field_type
-        Py_ssize_t i, offset, nfields, length
-        int64_t stride, elsize
-        char *buf
-
-    if names is None:
-        names = ['%d' % i for i in range(len(columns))]
-    else:
-        # single line header
-        names = names[0]
-
-    if usecols is not None:
-        names = [n for i, n in enumerate(names)
-                 if i in usecols or n in usecols]
-
-    dt = np.dtype([(str(name), columns[i].dtype)
-                   for i, name in enumerate(names)])
-    fnames = dt.names
-    fields = dt.fields
-
-    nfields = len(fields)
-
-    if PY3:
-        length = len(list(columns.values())[0])
-    else:
-        length = len(columns.values()[0])
-
-    stride = dt.itemsize
-
-    # We own the data.
-    buf = <char*> malloc(length * stride)
-
-    recs = sarr_from_data(dt, length, buf)
-    assert(recs.flags.owndata)
-
-    for i in range(nfields):
-        # XXX
-        field_type = fields[fnames[i]]
-
-        # (dtype, stride) tuple
-        offset = field_type[1]
-        elsize = field_type[0].itemsize
-        column = columns[i]
-
-        _fill_structured_column(buf + offset, <char*> column.data,
-                                elsize, stride, length,
-                                field_type[0] == np.object_)
-
-    return recs
 
 
 cdef _fill_structured_column(char *dst, char* src, int64_t elsize,

--- a/pandas/_libs/parsers.pyx
+++ b/pandas/_libs/parsers.pyx
@@ -91,7 +91,6 @@ except NameError:
     basestring = str
 
 cdef extern from "src/numpy_helper.h":
-    object sarr_from_data(cnp.dtype, int length, void* data)
     void transfer_object_column(char *dst, char *src, size_t stride,
                                 size_t length)
 

--- a/pandas/_libs/parsers.pyx
+++ b/pandas/_libs/parsers.pyx
@@ -2309,20 +2309,6 @@ cdef _apply_converter(object f, parser_t *parser, int64_t col,
     return lib.maybe_convert_objects(result)
 
 
-cdef _fill_structured_column(char *dst, char* src, int64_t elsize,
-                             int64_t stride, int64_t length, bint incref):
-    cdef:
-        int64_t i
-
-    if incref:
-        transfer_object_column(dst, src, stride, length)
-    else:
-        for i in range(length):
-            memcpy(dst, src, elsize)
-            dst += stride
-            src += elsize
-
-
 def _maybe_encode(values):
     if values is None:
         return []

--- a/pandas/_libs/src/numpy_helper.h
+++ b/pandas/_libs/src/numpy_helper.h
@@ -75,19 +75,6 @@ PANDAS_INLINE PyObject* char_to_string(char* data) {
 #endif
 }
 
-PyObject* sarr_from_data(PyArray_Descr* descr, int length, void* data) {
-    PyArrayObject* result;
-    npy_intp dims[1] = {length};
-    Py_INCREF(descr);  // newfromdescr steals a reference to descr
-    result = (PyArrayObject*)PyArray_NewFromDescr(&PyArray_Type, descr, 1, dims,
-                                                  NULL, data, 0, NULL);
-
-    // Returned array doesn't own data by default
-    result->flags |= NPY_OWNDATA;
-
-    return (PyObject*)result;
-}
-
 void transfer_object_column(char* dst, char* src, size_t stride,
                             size_t length) {
     size_t i;
@@ -104,7 +91,6 @@ void transfer_object_column(char* dst, char* src, size_t stride,
         dst += stride;
     }
 }
-
 
 void set_array_not_contiguous(PyArrayObject* ao) {
     ao->flags &= ~(NPY_C_CONTIGUOUS | NPY_F_CONTIGUOUS);

--- a/pandas/tests/io/parser/c_parser_only.py
+++ b/pandas/tests/io/parser/c_parser_only.py
@@ -18,7 +18,6 @@ import pandas as pd
 import pandas.util.testing as tm
 import pandas.util._test_decorators as td
 from pandas import DataFrame
-from pandas import compat
 from pandas.compat import StringIO, range, lrange
 
 

--- a/pandas/tests/io/parser/c_parser_only.py
+++ b/pandas/tests/io/parser/c_parser_only.py
@@ -161,25 +161,6 @@ nan 2
         assert sum(precise_errors) <= sum(normal_errors)
         assert max(precise_errors) <= max(normal_errors)
 
-    def test_pass_dtype_as_recarray(self):
-        if compat.is_platform_windows() and self.low_memory:
-            pytest.skip(
-                "segfaults on win-64, only when all tests are run")
-
-        data = """\
-one,two
-1,2.5
-2,3.5
-3,4.5
-4,5.5"""
-
-        with tm.assert_produces_warning(
-                FutureWarning, check_stacklevel=False):
-            result = self.read_csv(StringIO(data), dtype={
-                'one': 'u1', 1: 'S1'}, as_recarray=True)
-            assert result['one'].dtype == 'u1'
-            assert result['two'].dtype == 'S1'
-
     def test_usecols_dtypes(self):
         data = """\
 1,2,3

--- a/pandas/tests/io/parser/common.py
+++ b/pandas/tests/io/parser/common.py
@@ -997,23 +997,6 @@ A,B,C
             StringIO('foo,bar\n'), chunksize=10)))
         tm.assert_frame_equal(result, expected)
 
-        with tm.assert_produces_warning(
-                FutureWarning, check_stacklevel=False):
-            result = self.read_csv(StringIO('foo,bar\n'),
-                                   nrows=10, as_recarray=True)
-            result = DataFrame(result[2], columns=result[1],
-                               index=result[0])
-            tm.assert_frame_equal(DataFrame.from_records(
-                result), expected, check_index_type=False)
-
-        with tm.assert_produces_warning(
-                FutureWarning, check_stacklevel=False):
-            result = next(iter(self.read_csv(StringIO('foo,bar\n'),
-                                             chunksize=10, as_recarray=True)))
-            result = DataFrame(result[2], columns=result[1], index=result[0])
-            tm.assert_frame_equal(DataFrame.from_records(result), expected,
-                                  check_index_type=False)
-
     def test_eof_states(self):
         # see gh-10728, gh-10548
 
@@ -1430,93 +1413,6 @@ j,-inF"""
             out = self.read_csv(StringIO(data), compact_ints=True,
                                 use_unsigned=True)
             tm.assert_frame_equal(out, expected)
-
-    def test_compact_ints_as_recarray(self):
-        data = ('0,1,0,0\n'
-                '1,1,0,0\n'
-                '0,1,0,1')
-
-        with tm.assert_produces_warning(
-                FutureWarning, check_stacklevel=False):
-            result = self.read_csv(StringIO(data), delimiter=',', header=None,
-                                   compact_ints=True, as_recarray=True)
-            ex_dtype = np.dtype([(str(i), 'i1') for i in range(4)])
-            assert result.dtype == ex_dtype
-
-        with tm.assert_produces_warning(
-                FutureWarning, check_stacklevel=False):
-            result = self.read_csv(StringIO(data), delimiter=',', header=None,
-                                   as_recarray=True, compact_ints=True,
-                                   use_unsigned=True)
-            ex_dtype = np.dtype([(str(i), 'u1') for i in range(4)])
-            assert result.dtype == ex_dtype
-
-    def test_as_recarray(self):
-        # basic test
-        with tm.assert_produces_warning(
-                FutureWarning, check_stacklevel=False):
-            data = 'a,b\n1,a\n2,b'
-            expected = np.array([(1, 'a'), (2, 'b')],
-                                dtype=[('a', '=i8'), ('b', 'O')])
-            out = self.read_csv(StringIO(data), as_recarray=True)
-            tm.assert_numpy_array_equal(out, expected)
-
-        # index_col ignored
-        with tm.assert_produces_warning(
-                FutureWarning, check_stacklevel=False):
-            data = 'a,b\n1,a\n2,b'
-            expected = np.array([(1, 'a'), (2, 'b')],
-                                dtype=[('a', '=i8'), ('b', 'O')])
-            out = self.read_csv(StringIO(data), as_recarray=True, index_col=0)
-            tm.assert_numpy_array_equal(out, expected)
-
-        # respects names
-        with tm.assert_produces_warning(
-                FutureWarning, check_stacklevel=False):
-            data = '1,a\n2,b'
-            expected = np.array([(1, 'a'), (2, 'b')],
-                                dtype=[('a', '=i8'), ('b', 'O')])
-            out = self.read_csv(StringIO(data), names=['a', 'b'],
-                                header=None, as_recarray=True)
-            tm.assert_numpy_array_equal(out, expected)
-
-        # header order is respected even though it conflicts
-        # with the natural ordering of the column names
-        with tm.assert_produces_warning(
-                FutureWarning, check_stacklevel=False):
-            data = 'b,a\n1,a\n2,b'
-            expected = np.array([(1, 'a'), (2, 'b')],
-                                dtype=[('b', '=i8'), ('a', 'O')])
-            out = self.read_csv(StringIO(data), as_recarray=True)
-            tm.assert_numpy_array_equal(out, expected)
-
-        # overrides the squeeze parameter
-        with tm.assert_produces_warning(
-                FutureWarning, check_stacklevel=False):
-            data = 'a\n1'
-            expected = np.array([(1,)], dtype=[('a', '=i8')])
-            out = self.read_csv(StringIO(data), as_recarray=True, squeeze=True)
-            tm.assert_numpy_array_equal(out, expected)
-
-        # does data conversions before doing recarray conversion
-        with tm.assert_produces_warning(
-                FutureWarning, check_stacklevel=False):
-            data = 'a,b\n1,a\n2,b'
-            conv = lambda x: int(x) + 1
-            expected = np.array([(2, 'a'), (3, 'b')],
-                                dtype=[('a', '=i8'), ('b', 'O')])
-            out = self.read_csv(StringIO(data), as_recarray=True,
-                                converters={'a': conv})
-            tm.assert_numpy_array_equal(out, expected)
-
-        # filters by usecols before doing recarray conversion
-        with tm.assert_produces_warning(
-                FutureWarning, check_stacklevel=False):
-            data = 'a,b\n1,a\n2,b'
-            expected = np.array([(1,), (2,)], dtype=[('a', '=i8')])
-            out = self.read_csv(StringIO(data), as_recarray=True,
-                                usecols=['a'])
-            tm.assert_numpy_array_equal(out, expected)
 
     def test_memory_map(self):
         mmap_file = os.path.join(self.dirpath, 'test_mmap.csv')

--- a/pandas/tests/io/parser/header.py
+++ b/pandas/tests/io/parser/header.py
@@ -116,13 +116,6 @@ R_l0_g4,R_l1_g4,R4C0,R4C1,R4C2
 
         # INVALID OPTIONS
 
-        # no as_recarray
-        with tm.assert_produces_warning(
-                FutureWarning, check_stacklevel=False):
-            pytest.raises(ValueError, self.read_csv,
-                          StringIO(data), header=[0, 1, 2, 3],
-                          index_col=[0, 1], as_recarray=True)
-
         # names
         pytest.raises(ValueError, self.read_csv,
                       StringIO(data), header=[0, 1, 2, 3],

--- a/pandas/tests/io/parser/test_textreader.py
+++ b/pandas/tests/io/parser/test_textreader.py
@@ -194,33 +194,6 @@ class TestTextReader(object):
                     2: np.array([3, 6], dtype=np.int64)}
         assert_array_dicts_equal(recs, expected)
 
-        # not enough rows
-        pytest.raises(parser.ParserError, TextReader, StringIO(data),
-                      delimiter=',', header=5, as_recarray=True)
-
-    def test_header_not_enough_lines_as_recarray(self):
-        data = ('skip this\n'
-                'skip this\n'
-                'a,b,c\n'
-                '1,2,3\n'
-                '4,5,6')
-
-        reader = TextReader(StringIO(data), delimiter=',',
-                            header=2, as_recarray=True)
-        header = reader.header
-        expected = [['a', 'b', 'c']]
-        assert header == expected
-
-        recs = reader.read()
-        expected = {'a': np.array([1, 4], dtype=np.int64),
-                    'b': np.array([2, 5], dtype=np.int64),
-                    'c': np.array([3, 6], dtype=np.int64)}
-        assert_array_dicts_equal(expected, recs)
-
-        # not enough rows
-        pytest.raises(parser.ParserError, TextReader, StringIO(data),
-                      delimiter=',', header=5, as_recarray=True)
-
     def test_escapechar(self):
         data = ('\\"hello world\"\n'
                 '\\"hello world\"\n'
@@ -266,25 +239,6 @@ aaaaa,5"""
         ex_values = np.array(['a', 'aa', 'aaa', 'aaaa', 'aaaa'], dtype='S4')
         assert (result[0] == ex_values).all()
         assert result[1].dtype == 'S4'
-
-    def test_numpy_string_dtype_as_recarray(self):
-        data = """\
-a,1
-aa,2
-aaa,3
-aaaa,4
-aaaaa,5"""
-
-        def _make_reader(**kwds):
-            return TextReader(StringIO(data), delimiter=',', header=None,
-                              **kwds)
-
-        reader = _make_reader(dtype='S4', as_recarray=True)
-        result = reader.read()
-        assert result['0'].dtype == 'S4'
-        ex_values = np.array(['a', 'aa', 'aaa', 'aaaa', 'aaaa'], dtype='S4')
-        assert (result['0'] == ex_values).all()
-        assert result['1'].dtype == 'S4'
 
     def test_pass_dtype(self):
         data = """\

--- a/pandas/tests/io/parser/test_unsupported.py
+++ b/pandas/tests/io/parser/test_unsupported.py
@@ -128,9 +128,7 @@ x   q   30      3    -0.6662 -0.5243 -0.3580  0.89145  2.5838"""
 class TestDeprecatedFeatures(object):
 
     @pytest.mark.parametrize("engine", ["c", "python"])
-    @pytest.mark.parametrize("kwargs", [{"as_recarray": True},
-                                        {"as_recarray": False},
-                                        {"buffer_lines": True},
+    @pytest.mark.parametrize("kwargs", [{"buffer_lines": True},
                                         {"buffer_lines": False},
                                         {"compact_ints": True},
                                         {"compact_ints": False},


### PR DESCRIPTION
Deprecated back in 0.19.0

xref #13373.
