### PR TITLE
DOC: replaced 'Good as first PR' with 'good first issue'

### DIFF
--- a/doc/README.rst
+++ b/doc/README.rst
@@ -160,7 +160,7 @@ Where to start?
 
 There are a number of issues listed under `Docs
 <https://github.com/pandas-dev/pandas/issues?labels=Docs&sort=updated&state=open>`_
-and `good first issuse
+and `good first issue
 <https://github.com/pandas-dev/pandas/issues?labels=good+first+issue&sort=updated&state=open>`_
 where you could start out.
 

--- a/doc/README.rst
+++ b/doc/README.rst
@@ -160,8 +160,8 @@ Where to start?
 
 There are a number of issues listed under `Docs
 <https://github.com/pandas-dev/pandas/issues?labels=Docs&sort=updated&state=open>`_
-and `Good as first PR
-<https://github.com/pandas-dev/pandas/issues?labels=Good+as+first+PR&sort=updated&state=open>`_
+and `good first issuse
+<https://github.com/pandas-dev/pandas/issues?labels=good+first+issue&sort=updated&state=open>`_
 where you could start out.
 
 Or maybe you have an idea of your own, by using pandas, looking for something


### PR DESCRIPTION
- [NA] closes #xxxx
- [NA] tests added / passed
- [NA] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [NA] whatsnew entry

Was browsing https://github.com/pandas-dev/pandas/tree/master/doc and it seemed the 'Good as first PR' had no open issues, whereas 'good first issue'  has quite a few open issues.
I'm guessing the 'Good as first PR' label was not well used/got renamed to 'good first issue' label?
