### PR TITLE
Removed old xarr and ipython decorators

### DIFF
--- a/pandas/tests/generic/test_frame.py
+++ b/pandas/tests/generic/test_frame.py
@@ -17,6 +17,7 @@ from pandas.util.testing import (assert_series_equal,
                                  assert_almost_equal)
 
 import pandas.util.testing as tm
+import pandas.util._test_decorators as td
 from .test_generic import Generic
 
 try:
@@ -218,8 +219,8 @@ class TestDataFrame(Generic):
         assert_frame_equal(result.to_dataframe(), expected,
                            check_index_type=False, check_categorical=False)
 
+    @td.skip_if_no('xarray', min_version='0.7.0')
     def test_to_xarray(self):
-        tm._skip_if_no_xarray()
         from xarray import Dataset
 
         df = DataFrame({'a': list('abc'),

--- a/pandas/tests/generic/test_panel.py
+++ b/pandas/tests/generic/test_panel.py
@@ -11,6 +11,7 @@ from pandas.util.testing import (assert_panel_equal,
                                  assert_almost_equal)
 
 import pandas.util.testing as tm
+import pandas.util._test_decorators as td
 from .test_generic import Generic
 
 
@@ -18,9 +19,8 @@ class TestPanel(Generic):
     _typ = Panel
     _comparator = lambda self, x, y: assert_panel_equal(x, y, by_blocks=True)
 
+    @td.skip_if_no('xarray', min_version='0.7.0')
     def test_to_xarray(self):
-
-        tm._skip_if_no_xarray()
         from xarray import DataArray
 
         with catch_warnings(record=True):
@@ -44,9 +44,8 @@ class TestPanel4D(Generic):
     def test_sample(self):
         pytest.skip("sample on Panel4D")
 
+    @td.skip_if_no('xarray', min_version='0.7.0')
     def test_to_xarray(self):
-
-        tm._skip_if_no_xarray()
         from xarray import DataArray
 
         with catch_warnings(record=True):

--- a/pandas/tests/generic/test_series.py
+++ b/pandas/tests/generic/test_series.py
@@ -15,6 +15,7 @@ from pandas.util.testing import (assert_series_equal,
                                  assert_almost_equal)
 
 import pandas.util.testing as tm
+import pandas.util._test_decorators as td
 from .test_generic import Generic
 
 try:
@@ -200,9 +201,8 @@ class TestSeries(Generic):
                             check_index_type=False,
                             check_categorical=True)
 
+    @td.skip_if_no('xarray', min_version='0.7.0')
     def test_to_xarray(self):
-
-        tm._skip_if_no_xarray()
         from xarray import DataArray
 
         s = Series([])

--- a/pandas/util/testing.py
+++ b/pandas/util/testing.py
@@ -348,17 +348,6 @@ def _skip_if_no_lzma():
     return _check_if_lzma() or pytest.skip('need backports.lzma to run')
 
 
-def _skip_if_no_xarray():
-    import pytest
-
-    xarray = pytest.importorskip("xarray")
-    v = xarray.__version__
-
-    if LooseVersion(v) < LooseVersion('0.7.0'):
-        import pytest
-        pytest.skip("xarray version is too low: {version}".format(version=v))
-
-
 def skip_if_no_ne(engine='numexpr'):
     from pandas.core.computation.expressions import (
         _USE_NUMEXPR,
@@ -382,11 +371,6 @@ def _skip_if_no_mock():
         except ImportError:
             import pytest
             raise pytest.skip("mock is not installed")
-
-
-def _skip_if_no_ipython():
-    import pytest
-    pytest.importorskip("IPython")
 
 # -----------------------------------------------------------------------------
 # locale utilities


### PR DESCRIPTION
- [ ] progress towards #18190
- [X] tests added / passed
- [X] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

Didn't think either of these were used enough to justify as their own decorator, so I removed them from the old ``testing`` module and just used the generic ``skip_if_no`` decorator where applicable