### PR TITLE
implement is_offsetlike

### DIFF
--- a/pandas/core/dtypes/common.py
+++ b/pandas/core/dtypes/common.py
@@ -277,6 +277,17 @@ def is_offsetlike(arr_or_obj):
     Returns
     -------
     boolean : Whether the object is a DateOffset or listlike of DatetOffsets
+
+    Examples
+    --------
+    >>> is_offsetlike(pd.DateOffset(days=1))
+    True
+    >>> is_offsetlike('offset')
+    False
+    >>> is_offsetlike([pd.offsets.Minute(4), pd.offsets.MonthEnd()])
+    True
+    >>> is_offsetlike(np.array([pd.DateOffset(months=3), pd.Timestamp.now()]))
+    False
     """
     if isinstance(arr_or_obj, ABCDateOffset):
         return True

--- a/pandas/core/dtypes/common.py
+++ b/pandas/core/dtypes/common.py
@@ -12,8 +12,8 @@ from .dtypes import (CategoricalDtype, CategoricalDtypeType,
 from .generic import (ABCCategorical, ABCPeriodIndex,
                       ABCDatetimeIndex, ABCSeries,
                       ABCSparseArray, ABCSparseSeries, ABCCategoricalIndex,
-                      ABCIndexClass)
-from .inference import is_string_like
+                      ABCIndexClass, ABCDateOffset)
+from .inference import is_string_like, is_list_like
 from .inference import *  # noqa
 
 
@@ -264,6 +264,26 @@ def is_datetimetz(arr):
     return ((isinstance(arr, ABCDatetimeIndex) and
              getattr(arr, 'tz', None) is not None) or
             is_datetime64tz_dtype(arr))
+
+
+def is_offsetlike(arr_or_obj):
+    """
+    Check if obj or all elements of list-like is DateOffset
+
+    Parameters
+    ----------
+    arr_or_obj : object
+
+    Returns
+    -------
+    boolean : Whether the object is a DateOffset or listlike of DatetOffsets
+    """
+    if isinstance(arr_or_obj, ABCDateOffset):
+        return True
+    elif (is_list_like(arr_or_obj) and len(arr_or_obj) and
+          is_object_dtype(arr_or_obj)):
+        return all(isinstance(x, ABCDateOffset) for x in arr_or_obj)
+    return False
 
 
 def is_period(arr):

--- a/pandas/tests/dtypes/test_common.py
+++ b/pandas/tests/dtypes/test_common.py
@@ -544,10 +544,10 @@ def test_is_offsetlike():
     assert com.is_offsetlike(pd.Index([pd.DateOffset(second=1)]))
 
     assert not com.is_offsetlike(pd.Timedelta(1))
-    assert not com.isoffsetlike(np.array([1 + 1j, 5]))
+    assert not com.is_offsetlike(np.array([1 + 1j, 5]))
 
     # mixed case
-    assert not com.isoffsetlike(np.array([pd.DateOffset(), pd.Timestamp(0)]))
+    assert not com.is_offsetlike(np.array([pd.DateOffset(), pd.Timestamp(0)]))
 
 
 @pytest.mark.parametrize('input_param,result', [

--- a/pandas/tests/dtypes/test_common.py
+++ b/pandas/tests/dtypes/test_common.py
@@ -541,14 +541,13 @@ def test_is_offsetlike():
     assert com.is_offsetlike(np.array([pd.DateOffset(month=3),
                                        pd.offsets.Nano()]))
     assert com.is_offsetlike(pd.offsets.MonthEnd())
-    assert com.is_offsetlike([pd.offsets.MonthBegin(),
-                              pd.offsets.YearBegin()])
+    assert com.is_offsetlike(pd.Index([pd.DateOffset(second=1)]))
 
     assert not com.is_offsetlike(pd.Timedelta(1))
     assert not com.isoffsetlike(np.array([1 + 1j, 5]))
 
     # mixed case
-    assert not com.isoffsetlike([pd.DateOffset(), pd.Timestamp(0)])
+    assert not com.isoffsetlike(np.array([pd.DateOffset(), pd.Timestamp(0)]))
 
 
 @pytest.mark.parametrize('input_param,result', [

--- a/pandas/tests/dtypes/test_common.py
+++ b/pandas/tests/dtypes/test_common.py
@@ -537,6 +537,20 @@ def test_is_complex_dtype():
     assert com.is_complex_dtype(np.array([1 + 1j, 5]))
 
 
+def test_is_offsetlike():
+    assert com.is_offsetlike(np.array([pd.DateOffset(month=3),
+                                       pd.offsets.Nano()]))
+    assert com.is_offsetlike(pd.offsets.MonthEnd())
+    assert com.is_offsetlike([pd.offsets.MonthBegin(),
+                              pd.offsets.YearBegin()])
+
+    assert not com.is_offsetlike(pd.Timedelta(1))
+    assert not com.isoffsetlike(np.array([1 + 1j, 5]))
+
+    # mixed case
+    assert not com.isoffsetlike([pd.DateOffset(), pd.Timestamp(0)])
+
+
 @pytest.mark.parametrize('input_param,result', [
     (int, np.dtype(int)),
     ('int32', np.dtype('int32')),


### PR DESCRIPTION
This is a subset of #18817 that just implements `is_offsetlike` in `dtypes.common` (plus a nicer docstring).  This needs to be implemented before some fixes can be made in indexes.datetimelike, so is worth separating from the more difficult bits of 18817.

- [ ] closes #xxxx
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
