### PR TITLE
BUG: raise error for groupby() with invalid tuple key

### DIFF
--- a/doc/source/whatsnew/v0.22.0.txt
+++ b/doc/source/whatsnew/v0.22.0.txt
@@ -310,6 +310,7 @@ Groupby/Resample/Rolling
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
 - Bug when grouping by a single column and aggregating with a class like ``list`` or ``tuple`` (:issue:`18079`)
+- Fixed regression in :func:`DataFrame.groupby` which would not emit an error when called with a tuple key not in the index (:issue:`18798`)
 -
 -
 

--- a/pandas/core/groupby.py
+++ b/pandas/core/groupby.py
@@ -2977,7 +2977,7 @@ def _get_grouper(obj, key=None, axis=0, level=None, sort=True,
 
 
 def _is_label_like(val):
-    return (isinstance(val, compat.string_types) or
+    return (isinstance(val, (compat.string_types, tuple)) or
             (val is not None and is_scalar(val)))
 
 

--- a/pandas/tests/groupby/test_groupby.py
+++ b/pandas/tests/groupby/test_groupby.py
@@ -2750,7 +2750,6 @@ class TestGroupBy(MixIn):
 
         assert "Interpreting tuple 'by' as a list" in str(w[0].message)
 
-    @pytest.mark.xfail(reason="GH-18798")
     def test_tuple_correct_keyerror(self):
         # https://github.com/pandas-dev/pandas/issues/18798
         df = pd.DataFrame(1, index=range(3),


### PR DESCRIPTION
- [x] closes #18798
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry
