### PR TITLE
Prevent RecursionError on Timestamp comparison against object array

### DIFF
--- a/doc/source/whatsnew/v0.22.0.txt
+++ b/doc/source/whatsnew/v0.22.0.txt
@@ -346,3 +346,4 @@ Other
 ^^^^^
 
 - Improved error message when attempting to use a Python keyword as an identifier in a ``numexpr`` backed query (:issue:`18221`)
+- Bug in :class:`Timestamp` where comparison with an array of ``Timestamp`` objects would result in a ``RecursionError`` (:issue:`15183`)

--- a/pandas/_libs/tslibs/timestamps.pyx
+++ b/pandas/_libs/tslibs/timestamps.pyx
@@ -17,7 +17,7 @@ from cpython.datetime cimport (datetime,
 PyDateTime_IMPORT
 
 from util cimport (is_datetime64_object, is_timedelta64_object,
-                   is_integer_object, is_string_object,
+                   is_integer_object, is_string_object, is_array,
                    INT64_MAX)
 
 cimport ccalendar
@@ -108,6 +108,9 @@ cdef class _Timestamp(datetime):
                         raise TypeError('Cannot compare type %r with type %r' %
                                         (type(self).__name__,
                                          type(other).__name__))
+                elif is_array(other):
+                    # avoid recursion error GH#15183
+                    return PyObject_RichCompare(np.array([self]), other, op)
                 return PyObject_RichCompare(other, self, reverse_ops[op])
             else:
                 if op == Py_EQ:

--- a/pandas/tests/scalar/test_timedelta.py
+++ b/pandas/tests/scalar/test_timedelta.py
@@ -163,6 +163,27 @@ class TestTimedeltaArithmetic(object):
         pytest.raises(TypeError, lambda: td * td)
 
 
+class TestTimedeltaComparison(object):
+    def test_comparison_object_array(self):
+        # analogous to GH#15183
+        td = Timedelta('2 days')
+        other = Timedelta('3 hours')
+
+        arr = np.array([other, td], dtype=object)
+        res = arr == td
+        expected = np.array([False, True], dtype=bool)
+        assert (res == expected).all()
+
+        # 2D case
+        arr = np.array([[other, td],
+                        [td, other]],
+                        dtype=object)
+        res = arr != td
+        expected = np.array([[True, False], [False, True]], dtype=bool)
+        assert res.shape == expected.shape
+        assert (res == expected).all()
+
+
 class TestTimedeltas(object):
     _multiprocess_can_split_ = True
 

--- a/pandas/tests/scalar/test_timedelta.py
+++ b/pandas/tests/scalar/test_timedelta.py
@@ -177,7 +177,7 @@ class TestTimedeltaComparison(object):
         # 2D case
         arr = np.array([[other, td],
                         [td, other]],
-                        dtype=object)
+                       dtype=object)
         res = arr != td
         expected = np.array([[True, False], [False, True]], dtype=bool)
         assert res.shape == expected.shape

--- a/pandas/tests/scalar/test_timestamp.py
+++ b/pandas/tests/scalar/test_timestamp.py
@@ -969,6 +969,31 @@ class TestTimestamp(object):
 
 
 class TestTimestampComparison(object):
+    def test_comparison_object_array(self):
+        # GH#15183
+        ts = Timestamp('2011-01-03 00:00:00-0500', tz='US/Eastern')
+        other = Timestamp('2011-01-01 00:00:00-0500', tz='US/Eastern')
+        naive = Timestamp('2011-01-01 00:00:00')
+
+        arr = np.array([other, ts], dtype=object)
+        res = arr == ts
+        expected = np.array([False, True], dtype=bool)
+        assert (res == expected).all()
+
+        # 2D case
+        arr = np.array([[other, ts],
+                        [ts, other]],
+                        dtype=object)
+        res = arr != ts
+        expected = np.array([[True, False], [False, True]], dtype=bool)
+        assert res.shape == expected.shape
+        assert (res == expected).all()
+
+        # tzaware mismatch
+        arr = np.array([naive], dtype=object)
+        with pytest.raises(TypeError):
+            arr < ts
+
     def test_comparison(self):
         # 5-18-2012 00:00:00.000
         stamp = long(1337299200000000000)

--- a/pandas/tests/scalar/test_timestamp.py
+++ b/pandas/tests/scalar/test_timestamp.py
@@ -983,7 +983,7 @@ class TestTimestampComparison(object):
         # 2D case
         arr = np.array([[other, ts],
                         [ts, other]],
-                        dtype=object)
+                       dtype=object)
         res = arr != ts
         expected = np.array([[True, False], [False, True]], dtype=bool)
         assert res.shape == expected.shape


### PR DESCRIPTION
Timedelta comparison already handled this correctly but I didn't see a test for it, so added one.

- [x] closes #15183
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry
