### PR TITLE
Refactor _TimeOp._validate to separate datetime vs timedelta vs dateoffset

### DIFF
--- a/pandas/core/ops.py
+++ b/pandas/core/ops.py
@@ -419,11 +419,7 @@ class _TimeOp(_Op):
 
         if self.is_integer_rhs or self.is_floating_rhs:
             # timedelta and integer mul/div
-            if name not in ('__div__', '__truediv__', '__mul__', '__rmul__'):
-                raise TypeError("can only operate on a timedelta and an "
-                                "integer or a float for division and "
-                                "multiplication, but the operator [{name}] "
-                                "was passed".format(name=name))
+            self._check_timedelta_with_numeric(name)
         elif self.is_timedelta_rhs or self.is_offset_rhs:
             # 2 timedeltas
             if name not in ('__div__', '__rdiv__', '__truediv__',
@@ -476,16 +472,18 @@ class _TimeOp(_Op):
 
         if ((self.is_integer_lhs or self.is_floating_lhs) and
                 self.is_timedelta_rhs):
-
-            if name not in ('__div__', '__truediv__', '__mul__', '__rmul__'):
-                raise TypeError("can only operate on a timedelta and an "
-                                "integer or a float for division and "
-                                "multiplication, but the operator [{name}] "
-                                "was passed".format(name=name))
+            self._check_timedelta_with_numeric(name)
         else:
             raise TypeError('cannot operate on a series without a rhs '
                             'of a series/ndarray of type datetime64[ns] '
                             'or a timedelta')
+
+    def _check_timedelta_with_numeric(self, name):
+        if name not in ('__div__', '__truediv__', '__mul__', '__rmul__'):
+            raise TypeError("can only operate on a timedelta and an "
+                            "integer or a float for division and "
+                            "multiplication, but the operator [{name}] "
+                            "was passed".format(name=name))
 
     def _convert_to_array(self, values, name=None, other=None):
         """converts values to ndarray"""

--- a/pandas/core/ops.py
+++ b/pandas/core/ops.py
@@ -487,70 +487,47 @@ class _TimeOp(_Op):
                             'of a series/ndarray of type datetime64[ns] '
                             'or a timedelta')
 
-    def _convert_datetimelike_to_array(self, raw_values, values, other):
-        """
-        By the time we get here, we know that:
-            * inferred_type in ('datetime64', 'datetime', 'date', 'time') or
-                is_datetimetz(inferred_type)
-            * is_list_like(values)
-        """
-        supplied_dtype = None
-        if raw_values is not values:
-            # skip unnecessary isinstance call because we know values is an
-            # ndarray
-            pass
-        elif (isinstance(values, pd.Series) and
-              (is_timedelta64_dtype(values) or is_datetime64_dtype(values))):
-            # if this is a Series that contains relevant dtype info, then use
-            # this instead of the inferred type; this avoids coercing
-            # Series([NaT], dtype='datetime64[ns]') to
-            # Series([NaT], dtype='timedelta64[ns]')
-            supplied_dtype = values.dtype
-
-        inferred_type = lib.infer_dtype(values)
-
-        if (supplied_dtype is None and other is not None and
-            (other.dtype in ('timedelta64[ns]', 'datetime64[ns]')) and
-                isna(values).all()):
-            # if we have a other of timedelta, but use pd.NaT here we
-            # we are in the wrong path
-            values = np.empty(values.shape, dtype='timedelta64[ns]')
-            values[:] = iNaT
-
-        elif isinstance(values, pd.DatetimeIndex):
-            # a datelike
-            values = values.to_series()
-
-        elif (isinstance(raw_values, datetime.datetime) and
-              hasattr(raw_values, 'tzinfo')):
-            # datetime with tz
-            values = pd.DatetimeIndex(values)
-
-        elif is_datetimetz(values):
-            # datetime array with tz
-            if isinstance(values, ABCSeries):
-                values = values._values
-
-        elif not (isinstance(values, (np.ndarray, ABCSeries)) and
-                  is_datetime64_dtype(values)):
-            values = libts.array_to_datetime(values)
-
-        return values
-
     def _convert_to_array(self, values, name=None, other=None):
         """converts values to ndarray"""
         from pandas.core.tools.timedeltas import to_timedelta
 
         ovalues = values
+        supplied_dtype = None
         if not is_list_like(values):
             values = np.array([values])
 
-        inferred_type = lib.infer_dtype(values)
+        # if this is a Series that contains relevant dtype info, then use this
+        # instead of the inferred type; this avoids coercing Series([NaT],
+        # dtype='datetime64[ns]') to Series([NaT], dtype='timedelta64[ns]')
+        elif (isinstance(values, pd.Series) and
+              (is_timedelta64_dtype(values) or is_datetime64_dtype(values))):
+            supplied_dtype = values.dtype
 
+        inferred_type = lib.infer_dtype(values)
         if (inferred_type in ('datetime64', 'datetime', 'date', 'time') or
                 is_datetimetz(inferred_type)):
-            return self._convert_datetimelike_to_array(ovalues, values, other)
+            # if we have a other of timedelta, but use pd.NaT here we
+            # we are in the wrong path
+            if (supplied_dtype is None and other is not None and
+                (other.dtype in ('timedelta64[ns]', 'datetime64[ns]')) and
+                    isna(values).all()):
+                values = np.empty(values.shape, dtype='timedelta64[ns]')
+                values[:] = iNaT
 
+            # a datelike
+            elif isinstance(values, pd.DatetimeIndex):
+                values = values.to_series()
+            # datetime with tz
+            elif (isinstance(ovalues, datetime.datetime) and
+                  hasattr(ovalues, 'tzinfo')):
+                values = pd.DatetimeIndex(values)
+            # datetime array with tz
+            elif is_datetimetz(values):
+                if isinstance(values, ABCSeries):
+                    values = values._values
+            elif not (isinstance(values, (np.ndarray, ABCSeries)) and
+                      is_datetime64_dtype(values)):
+                values = libts.array_to_datetime(values)
         elif inferred_type in ('timedelta', 'timedelta64'):
             # have a timedelta, convert to to ns here
             values = to_timedelta(values, errors='coerce', box=False)

--- a/pandas/tests/series/test_operators.py
+++ b/pandas/tests/series/test_operators.py
@@ -972,10 +972,7 @@ class TestTimedeltaSeriesArithmetic(object):
         td1 / td2
         td2 / td1
 
-    @pytest.mark.parametrize('op_str', ['__mul__', '__rmul__',
-                                        '__floordiv__', '__rfloordiv__',
-                                        '__pow__', '__rpow__'])
-    def test_operators_timedelta64_invalid(self, op_str):
+    def test_operators_timedelta64_invalid(self):
         td1 = Series([timedelta(minutes=5, seconds=3)] * 3)
         td1.iloc[2] = np.nan
         td2 = timedelta(minutes=5, seconds=4)
@@ -983,10 +980,19 @@ class TestTimedeltaSeriesArithmetic(object):
         # check that we are getting a TypeError
         # with 'operate' (from core/ops.py) for the ops that are not
         # defined
-        op = getattr(td1, op_str, None)
         pattern = 'operate|unsupported|cannot'
         with tm.assert_raises_regex(TypeError, pattern):
-            op(td2)
+            td1 * td2
+        with tm.assert_raises_regex(TypeError, pattern):
+            td2 * td1
+        with tm.assert_raises_regex(TypeError, pattern):
+            td1 // td2
+        with tm.assert_raises_regex(TypeError, pattern):
+            td2 // td1
+        with tm.assert_raises_regex(TypeError, pattern):
+            td2 ** td1
+        with tm.assert_raises_regex(TypeError, pattern):
+            td1 ** td2
 
 
 class TestDatetimeSeriesArithmetic(object):

--- a/pandas/tests/series/test_operators.py
+++ b/pandas/tests/series/test_operators.py
@@ -960,8 +960,37 @@ class TestTimedeltaSeriesArithmetic(object):
         assert_series_equal(timedelta_series / nan,
                             nat_series_dtype_timedelta)
 
+    def test_operators_timedelta64(self):
+        td1 = Series([timedelta(minutes=5, seconds=3)] * 3)
+        td1.iloc[2] = np.nan
+        td2 = timedelta(minutes=5, seconds=4)
+
+        td1 + td2
+        td2 + td1
+        td1 - td2
+        td2 - td1
+        td1 / td2
+        td2 / td1
+
+    @pytest.mark.parametrize('op_str', ['__mul__', '__rmul__',
+                                        '__floordiv__', '__rfloordiv__',
+                                        '__pow__', '__rpow__'])
+    def test_operators_timedelta64_invalid(self, op_str):
+        td1 = Series([timedelta(minutes=5, seconds=3)] * 3)
+        td1.iloc[2] = np.nan
+        td2 = timedelta(minutes=5, seconds=4)
+
+        # check that we are getting a TypeError
+        # with 'operate' (from core/ops.py) for the ops that are not
+        # defined
+        op = getattr(td1, op_str, None)
+        pattern = 'operate|unsupported|cannot'
+        with tm.assert_raises_regex(TypeError, pattern):
+            op(td2)
+
 
 class TestDatetimeSeriesArithmetic(object):
+
     def test_operators_datetimelike(self):
         def run_ops(ops, get_ser, test_ser):
 
@@ -976,16 +1005,6 @@ class TestDatetimeSeriesArithmetic(object):
         # ## timedelta64 ###
         td1 = Series([timedelta(minutes=5, seconds=3)] * 3)
         td1.iloc[2] = np.nan
-        td2 = timedelta(minutes=5, seconds=4)
-        ops = ['__mul__', '__floordiv__', '__pow__', '__rmul__',
-               '__rfloordiv__', '__rpow__']
-        run_ops(ops, td1, td2)
-        td1 + td2
-        td2 + td1
-        td1 - td2
-        td2 - td1
-        td1 / td2
-        td2 / td1
 
         # ## datetime64 ###
         dt1 = Series([Timestamp('20111230'), Timestamp('20120101'),

--- a/pandas/tests/series/test_operators.py
+++ b/pandas/tests/series/test_operators.py
@@ -960,7 +960,8 @@ class TestTimedeltaSeriesArithmetic(object):
         assert_series_equal(timedelta_series / nan,
                             nat_series_dtype_timedelta)
 
-    def test_operators_timedelta64(self):
+    def test_operators_timedelta64_with_timedelta(self):
+        # smoke tests
         td1 = Series([timedelta(minutes=5, seconds=3)] * 3)
         td1.iloc[2] = np.nan
         td2 = timedelta(minutes=5, seconds=4)
@@ -972,7 +973,7 @@ class TestTimedeltaSeriesArithmetic(object):
         td1 / td2
         td2 / td1
 
-    def test_operators_timedelta64_invalid(self):
+    def test_operators_timedelta64_with_timedelta_invalid(self):
         td1 = Series([timedelta(minutes=5, seconds=3)] * 3)
         td1.iloc[2] = np.nan
         td2 = timedelta(minutes=5, seconds=4)

--- a/pandas/tests/series/test_operators.py
+++ b/pandas/tests/series/test_operators.py
@@ -960,40 +960,47 @@ class TestTimedeltaSeriesArithmetic(object):
         assert_series_equal(timedelta_series / nan,
                             nat_series_dtype_timedelta)
 
-    def test_operators_timedelta64_with_timedelta(self):
+    @pytest.mark.parametrize('scalar_td', [timedelta(minutes=5, seconds=4),
+                                           Timedelta(minutes=5, seconds=4),
+                                           Timedelta('5m4s').to_timedelta64()])
+    def test_operators_timedelta64_with_timedelta(self, scalar_td):
         # smoke tests
         td1 = Series([timedelta(minutes=5, seconds=3)] * 3)
         td1.iloc[2] = np.nan
-        td2 = timedelta(minutes=5, seconds=4)
 
-        td1 + td2
-        td2 + td1
-        td1 - td2
-        td2 - td1
-        td1 / td2
-        td2 / td1
+        td1 + scalar_td
+        scalar_td + td1
+        td1 - scalar_td
+        scalar_td - td1
+        td1 / scalar_td
+        scalar_td / td1
 
-    def test_operators_timedelta64_with_timedelta_invalid(self):
+    @pytest.mark.parametrize('scalar_td', [
+        timedelta(minutes=5, seconds=4),
+        pytest.param(Timedelta('5m4s'),
+                     marks=pytest.mark.xfail(reason="Timedelta.__floordiv__ "
+                                                    "bug GH#18846")),
+        Timedelta('5m4s').to_timedelta64()])
+    def test_operators_timedelta64_with_timedelta_invalid(self, scalar_td):
         td1 = Series([timedelta(minutes=5, seconds=3)] * 3)
         td1.iloc[2] = np.nan
-        td2 = timedelta(minutes=5, seconds=4)
 
         # check that we are getting a TypeError
         # with 'operate' (from core/ops.py) for the ops that are not
         # defined
         pattern = 'operate|unsupported|cannot'
         with tm.assert_raises_regex(TypeError, pattern):
-            td1 * td2
+            td1 * scalar_td
         with tm.assert_raises_regex(TypeError, pattern):
-            td2 * td1
+            scalar_td * td1
         with tm.assert_raises_regex(TypeError, pattern):
-            td1 // td2
+            td1 // scalar_td
         with tm.assert_raises_regex(TypeError, pattern):
-            td2 // td1
+            scalar_td // td1
         with tm.assert_raises_regex(TypeError, pattern):
-            td2 ** td1
+            scalar_td ** td1
         with tm.assert_raises_regex(TypeError, pattern):
-            td1 ** td2
+            td1 ** scalar_td
 
 
 class TestDatetimeSeriesArithmetic(object):


### PR DESCRIPTION
Trying to mirror the logic in the datetimelike index classes.

Separate some of the tests in the same vein.  

No logic should be changed in this PR, it should be pure refactor.

This _will_ have a merge conflict with #18831.
