### PR TITLE
CLN: Drop the buffer_lines parameter in read_csv

### DIFF
--- a/doc/source/io.rst
+++ b/doc/source/io.rst
@@ -199,11 +199,6 @@ low_memory : boolean, default ``True``
   Note that the entire file is read into a single DataFrame regardless,
   use the ``chunksize`` or ``iterator`` parameter to return the data in chunks.
   (Only valid with C parser)
-buffer_lines : int, default None
-  .. deprecated:: 0.19.0
-
-     Argument removed because its value is not respected by the parser
-
 compact_ints : boolean, default False
   .. deprecated:: 0.19.0
 

--- a/doc/source/whatsnew/v0.22.0.txt
+++ b/doc/source/whatsnew/v0.22.0.txt
@@ -227,6 +227,7 @@ Removal of prior version deprecations/changes
 - ``DatetimeIndex.to_datetime``, ``Timestamp.to_datetime``, ``PeriodIndex.to_datetime``, and ``Index.to_datetime`` have been removed (:issue:`8254`, :issue:`14096`, :issue:`14113`)
 - :func:`read_csv` has dropped the ``skip_footer`` parameter (:issue:`13386`)
 - :func:`read_csv` has dropped the ``as_recarray`` parameter (:issue:`13373`)
+- :func:`read_csv` has dropped the ``buffer_lines`` parameter (:issue:`13360`)
 
 .. _whatsnew_0220.performance:
 

--- a/pandas/_libs/parsers.pyx
+++ b/pandas/_libs/parsers.pyx
@@ -360,7 +360,6 @@ cdef class TextReader:
                   allow_leading_cols=True,
                   use_unsigned=False,
                   low_memory=False,
-                  buffer_lines=None,
                   skiprows=None,
                   skipfooter=0,
                   verbose=False,
@@ -557,7 +556,7 @@ cdef class TextReader:
         if not self.table_width:
             raise EmptyDataError("No columns to parse from file")
 
-        # compute buffer_lines as function of table width
+        # Compute buffer_lines as function of table width.
         heuristic = 2**20 // self.table_width
         self.buffer_lines = 1
         while self.buffer_lines * 2 < heuristic:

--- a/pandas/io/parsers.py
+++ b/pandas/io/parsers.py
@@ -273,9 +273,6 @@ low_memory : boolean, default True
     Note that the entire file is read into a single DataFrame regardless,
     use the `chunksize` or `iterator` parameter to return the data in chunks.
     (Only valid with C parser)
-buffer_lines : int, default None
-    .. deprecated:: 0.19.0
-       This argument is not respected by the parser
 compact_ints : boolean, default False
     .. deprecated:: 0.19.0
        Argument moved to ``pd.to_numeric``
@@ -503,7 +500,6 @@ _c_parser_defaults = {
     'use_unsigned': False,
     'low_memory': True,
     'memory_map': False,
-    'buffer_lines': None,
     'error_bad_lines': True,
     'warn_bad_lines': True,
     'tupleize_cols': False,
@@ -518,18 +514,15 @@ _fwf_defaults = {
 _c_unsupported = {'skipfooter'}
 _python_unsupported = {
     'low_memory',
-    'buffer_lines',
     'float_precision',
 }
 
 _deprecated_defaults = {
-    'buffer_lines': None,
     'compact_ints': None,
     'use_unsigned': None,
     'tupleize_cols': None
 }
 _deprecated_args = {
-    'buffer_lines',
     'compact_ints',
     'use_unsigned',
     'tupleize_cols',
@@ -606,7 +599,6 @@ def _make_parser_function(name, sep=','):
                  compact_ints=None,
                  use_unsigned=None,
                  low_memory=_c_parser_defaults['low_memory'],
-                 buffer_lines=None,
                  memory_map=False,
                  float_precision=None):
 
@@ -676,7 +668,6 @@ def _make_parser_function(name, sep=','):
                     warn_bad_lines=warn_bad_lines,
                     error_bad_lines=error_bad_lines,
                     low_memory=low_memory,
-                    buffer_lines=buffer_lines,
                     mangle_dupe_cols=mangle_dupe_cols,
                     tupleize_cols=tupleize_cols,
                     infer_datetime_format=infer_datetime_format,

--- a/pandas/tests/io/parser/test_unsupported.py
+++ b/pandas/tests/io/parser/test_unsupported.py
@@ -128,9 +128,7 @@ x   q   30      3    -0.6662 -0.5243 -0.3580  0.89145  2.5838"""
 class TestDeprecatedFeatures(object):
 
     @pytest.mark.parametrize("engine", ["c", "python"])
-    @pytest.mark.parametrize("kwargs", [{"buffer_lines": True},
-                                        {"buffer_lines": False},
-                                        {"compact_ints": True},
+    @pytest.mark.parametrize("kwargs", [{"compact_ints": True},
                                         {"compact_ints": False},
                                         {"use_unsigned": True},
                                         {"use_unsigned": False},


### PR DESCRIPTION
Deprecated back in 0.19.0

xref #13360.