### PR TITLE
DEPR: Deprecate skip_footer in read_excel

### DIFF
--- a/doc/source/whatsnew/v0.22.0.txt
+++ b/doc/source/whatsnew/v0.22.0.txt
@@ -208,6 +208,7 @@ Deprecations
   that is the actual tuple, instead of treating the tuple as multiple keys. To
   retain the previous behavior, use a list instead of a tuple (:issue:`18314`)
 - ``Series.valid`` is deprecated. Use :meth:`Series.dropna` instead (:issue:`18800`).
+- :func:`read_excel` has deprecated the ``skip_footer`` parameter. Use ``skipfooter`` instead (:issue:`18836`)
 
 .. _whatsnew_0220.prior_deprecations:
 

--- a/pandas/io/excel.py
+++ b/pandas/io/excel.py
@@ -149,6 +149,10 @@ thousands : str, default None
     any numeric columns will automatically be parsed, regardless of display
     format.
 skip_footer : int, default 0
+
+    .. deprecated:: 0.22.0
+       Pass in `skipfooter` instead.
+skipfooter : int, default 0
     Rows at the end to skip (0-indexed)
 convert_float : boolean, default True
     convert integral floats to int (i.e., 1.0 --> 1). If False, all numeric
@@ -200,6 +204,7 @@ def get_writer(engine_name):
 
 @Appender(_read_excel_doc)
 @deprecate_kwarg("parse_cols", "usecols")
+@deprecate_kwarg("skip_footer", "skipfooter")
 def read_excel(io,
                sheet_name=0,
                header=0,
@@ -218,7 +223,7 @@ def read_excel(io,
                parse_dates=False,
                date_parser=None,
                thousands=None,
-               skip_footer=0,
+               skipfooter=0,
                convert_float=True,
                **kwds):
 
@@ -251,7 +256,7 @@ def read_excel(io,
         parse_dates=parse_dates,
         date_parser=date_parser,
         thousands=thousands,
-        skip_footer=skip_footer,
+        skipfooter=skipfooter,
         convert_float=convert_float,
         **kwds)
 
@@ -333,7 +338,7 @@ class ExcelFile(object):
               parse_dates=False,
               date_parser=None,
               thousands=None,
-              skip_footer=0,
+              skipfooter=0,
               convert_float=True,
               **kwds):
         """
@@ -358,7 +363,7 @@ class ExcelFile(object):
                                  parse_dates=parse_dates,
                                  date_parser=date_parser,
                                  thousands=thousands,
-                                 skip_footer=skip_footer,
+                                 skipfooter=skipfooter,
                                  convert_float=convert_float,
                                  **kwds)
 
@@ -412,13 +417,9 @@ class ExcelFile(object):
                      parse_dates=False,
                      date_parser=None,
                      thousands=None,
-                     skip_footer=0,
+                     skipfooter=0,
                      convert_float=True,
                      **kwds):
-
-        skipfooter = kwds.pop('skipfooter', None)
-        if skipfooter is not None:
-            skip_footer = skipfooter
 
         _validate_header_arg(header)
 
@@ -590,7 +591,7 @@ class ExcelFile(object):
                                     parse_dates=parse_dates,
                                     date_parser=date_parser,
                                     thousands=thousands,
-                                    skipfooter=skip_footer,
+                                    skipfooter=skipfooter,
                                     **kwds)
 
                 output[asheetname] = parser.read(nrows=nrows)

--- a/pandas/tests/io/test_excel.py
+++ b/pandas/tests/io/test_excel.py
@@ -286,14 +286,14 @@ class ReadingTestsBase(SharedItems):
         tm.assert_frame_equal(df2, dfref, check_names=False)
 
         df3 = read_excel(excel, 0, index_col=0, skipfooter=1)
-        df4 = read_excel(excel, 0, index_col=0, skip_footer=1)
         tm.assert_frame_equal(df3, df1.iloc[:-1])
-        tm.assert_frame_equal(df3, df4)
+
+        with tm.assert_produces_warning(FutureWarning, check_stacklevel=False):
+            df4 = read_excel(excel, 0, index_col=0, skip_footer=1)
+            tm.assert_frame_equal(df3, df4)
 
         df3 = excel.parse(0, index_col=0, skipfooter=1)
-        df4 = excel.parse(0, index_col=0, skip_footer=1)
         tm.assert_frame_equal(df3, df1.iloc[:-1])
-        tm.assert_frame_equal(df3, df4)
 
         import xlrd
         with pytest.raises(xlrd.XLRDError):
@@ -311,10 +311,7 @@ class ReadingTestsBase(SharedItems):
 
         df3 = self.get_exceldf('test1', 'Sheet1', index_col=0,
                                skipfooter=1)
-        df4 = self.get_exceldf('test1', 'Sheet1', index_col=0,
-                               skip_footer=1)
         tm.assert_frame_equal(df3, df1.iloc[:-1])
-        tm.assert_frame_equal(df3, df4)
 
     def test_reader_special_dtypes(self):
 


### PR DESCRIPTION
For consistency with `read_csv`, which uses `skipfooter`.