### PR TITLE
Dec cleanup

### DIFF
--- a/pandas/conftest.py
+++ b/pandas/conftest.py
@@ -3,7 +3,6 @@ import pytest
 from distutils.version import LooseVersion
 import numpy
 import pandas
-import pandas.util.testing as tm
 import dateutil
 
 
@@ -51,7 +50,6 @@ def add_imports(doctest_namespace):
 
 @pytest.fixture(params=['bsr', 'coo', 'csc', 'csr', 'dia', 'dok', 'lil'])
 def spmatrix(request):
-    tm._skip_if_no_scipy()
     from scipy import sparse
     return getattr(sparse, request.param + '_matrix')
 

--- a/pandas/tests/io/test_pytables.py
+++ b/pandas/tests/io/test_pytables.py
@@ -716,7 +716,6 @@ class TestHDFStore(Base):
             pytest.raises(ValueError, store.put, 'b', df,
                           format='fixed', complib='zlib')
 
-    @td.skip_if_no('tables', min_version='2.2')
     @td.skip_if_windows_python_3
     def test_put_compression_blosc(self):
         df = tm.makeTimeDataFrame()

--- a/pandas/tests/io/test_pytables.py
+++ b/pandas/tests/io/test_pytables.py
@@ -716,10 +716,9 @@ class TestHDFStore(Base):
             pytest.raises(ValueError, store.put, 'b', df,
                           format='fixed', complib='zlib')
 
+    @td.skip_if_no('tables', min_version='2.2')
     @td.skip_if_windows_python_3
     def test_put_compression_blosc(self):
-        tm.skip_if_no_package('tables', min_version='2.2',
-                              app='blosc support')
         df = tm.makeTimeDataFrame()
 
         with ensure_clean_store(self.path) as store:

--- a/pandas/tests/sparse/test_frame.py
+++ b/pandas/tests/sparse/test_frame.py
@@ -7,6 +7,7 @@ from warnings import catch_warnings
 from numpy import nan
 import numpy as np
 import pandas as pd
+from distutils.version import LooseVersion
 
 from pandas import Series, DataFrame, bdate_range, Panel
 from pandas.core.dtypes.common import (
@@ -20,6 +21,7 @@ from pandas.util import testing as tm
 from pandas.compat import lrange
 from pandas import compat
 from pandas.core.sparse import frame as spf
+import pandas.util._test_decorators as td
 
 from pandas._libs.sparse import BlockIndex, IntIndex
 from pandas.core.sparse.api import SparseSeries, SparseDataFrame, SparseArray
@@ -1169,14 +1171,13 @@ class TestSparseDataFrame(SharedWithSparse):
         tm.assert_frame_equal(res.to_dense(), exp)
 
 
+@td.skip_if_no_scipy
 @pytest.mark.parametrize('index', [None, list('abc')])  # noqa: F811
 @pytest.mark.parametrize('columns', [None, list('def')])
 @pytest.mark.parametrize('fill_value', [None, 0, np.nan])
 @pytest.mark.parametrize('dtype', [bool, int, float, np.uint16])
 def test_from_to_scipy(spmatrix, index, columns, fill_value, dtype):
     # GH 4343
-    tm.skip_if_no_package('scipy')
-
     # Make one ndarray and from it one sparse matrix, both to be used for
     # constructing frames and comparing results
     arr = np.eye(3, dtype=dtype)
@@ -1231,7 +1232,10 @@ def test_from_to_scipy_object(spmatrix, fill_value):
     dtype = object
     columns = list('cd')
     index = list('ab')
-    tm.skip_if_no_package('scipy', max_version='0.19.0')
+    import scipy
+    if (spmatrix is scipy.sparse.dok_matrix and LooseVersion(
+            scipy.__version__) >= LooseVersion('0.19.0')):
+        pytest.skip("dok_matrix from object does not work in SciPy >= 0.19")
 
     # Make one ndarray and from it one sparse matrix, both to be used for
     # constructing frames and comparing results
@@ -1270,10 +1274,9 @@ def test_from_to_scipy_object(spmatrix, fill_value):
     assert sdf.to_coo().dtype == res_dtype
 
 
+@td.skip_if_no_scipy
 def test_from_scipy_correct_ordering(spmatrix):
     # GH 16179
-    tm.skip_if_no_package('scipy')
-
     arr = np.arange(1, 5).reshape(2, 2)
     try:
         spm = spmatrix(arr)
@@ -1290,10 +1293,9 @@ def test_from_scipy_correct_ordering(spmatrix):
     tm.assert_frame_equal(sdf.to_dense(), expected.to_dense())
 
 
+@td.skip_if_no_scipy
 def test_from_scipy_fillna(spmatrix):
     # GH 16112
-    tm.skip_if_no_package('scipy')
-
     arr = np.eye(3)
     arr[1:, 0] = np.nan
 

--- a/pandas/tests/sparse/test_frame.py
+++ b/pandas/tests/sparse/test_frame.py
@@ -1226,6 +1226,7 @@ def test_from_to_scipy(spmatrix, index, columns, fill_value, dtype):
     assert sdf.to_coo().dtype == np.object_
 
 
+@td.skip_if_no_scipy
 @pytest.mark.parametrize('fill_value', [None, 0, np.nan])  # noqa: F811
 def test_from_to_scipy_object(spmatrix, fill_value):
     # GH 4343

--- a/pandas/tests/test_nanops.py
+++ b/pandas/tests/test_nanops.py
@@ -12,6 +12,7 @@ from pandas import Series, isna
 from pandas.core.dtypes.common import is_integer_dtype
 import pandas.core.nanops as nanops
 import pandas.util.testing as tm
+import pandas.util._test_decorators as td
 
 use_bn = nanops._USE_BOTTLENECK
 
@@ -381,8 +382,8 @@ class TestnanopsDataFrame(object):
                              allow_str=False, allow_date=False,
                              allow_tdelta=True, allow_obj='convert')
 
+    @td.skip_if_no('scipy', min_version='0.17.0')
     def test_nansem(self):
-        tm.skip_if_no_package('scipy', min_version='0.17.0')
         from scipy.stats import sem
         with np.errstate(invalid='ignore'):
             self.check_funs_ddof(nanops.nansem, sem, allow_complex=False,
@@ -441,8 +442,8 @@ class TestnanopsDataFrame(object):
             return 0.
         return result
 
+    @td.skip_if_no('scipy', min_version='0.17.0')
     def test_nanskew(self):
-        tm.skip_if_no_package('scipy', min_version='0.17.0')
         from scipy.stats import skew
         func = partial(self._skew_kurt_wrap, func=skew)
         with np.errstate(invalid='ignore'):
@@ -450,8 +451,8 @@ class TestnanopsDataFrame(object):
                             allow_str=False, allow_date=False,
                             allow_tdelta=False)
 
+    @td.skip_if_no('scipy', min_version='0.17.0')
     def test_nankurt(self):
-        tm.skip_if_no_package('scipy', min_version='0.17.0')
         from scipy.stats import kurtosis
         func1 = partial(kurtosis, fisher=True)
         func = partial(self._skew_kurt_wrap, func=func1)
@@ -549,8 +550,8 @@ class TestnanopsDataFrame(object):
         self.check_nancorr_nancov_1d(nanops.nancorr, targ0, targ1,
                                      method='pearson')
 
+    @td.skip_if_no_scipy
     def test_nancorr_kendall(self):
-        tm.skip_if_no_package('scipy.stats')
         from scipy.stats import kendalltau
         targ0 = kendalltau(self.arr_float_2d, self.arr_float1_2d)[0]
         targ1 = kendalltau(self.arr_float_2d.flat, self.arr_float1_2d.flat)[0]
@@ -561,8 +562,8 @@ class TestnanopsDataFrame(object):
         self.check_nancorr_nancov_1d(nanops.nancorr, targ0, targ1,
                                      method='kendall')
 
+    @td.skip_if_no_scipy
     def test_nancorr_spearman(self):
-        tm.skip_if_no_package('scipy.stats')
         from scipy.stats import spearmanr
         targ0 = spearmanr(self.arr_float_2d, self.arr_float1_2d)[0]
         targ1 = spearmanr(self.arr_float_2d.flat, self.arr_float1_2d.flat)[0]

--- a/pandas/util/testing.py
+++ b/pandas/util/testing.py
@@ -1979,62 +1979,6 @@ class TestSubDict(dict):
         dict.__init__(self, *args, **kwargs)
 
 
-# Dependency checker when running tests.
-#
-# Copied this from nipy/nipype
-# Copyright of respective developers, License: BSD-3
-def skip_if_no_package(pkg_name, min_version=None, max_version=None,
-                       app='pandas', checker=LooseVersion):
-    """Check that the min/max version of the required package is installed.
-
-    If the package check fails, the test is automatically skipped.
-
-    Parameters
-    ----------
-    pkg_name : string
-        Name of the required package.
-    min_version : string, optional
-        Minimal version number for required package.
-    max_version : string, optional
-        Max version number for required package.
-    app : string, optional
-        Application that is performing the check. For instance, the
-        name of the tutorial being executed that depends on specific
-        packages.
-    checker : object, optional
-        The class that will perform the version checking. Default is
-        distutils.version.LooseVersion.
-
-    Examples
-    --------
-    package_check('numpy', '1.3')
-
-    """
-
-    import pytest
-    if app:
-        msg = '{app} requires {pkg_name}'.format(app=app, pkg_name=pkg_name)
-    else:
-        msg = 'module requires {pkg_name}'.format(pkg_name=pkg_name)
-    if min_version:
-        msg += ' with version >= {min_version}'.format(min_version=min_version)
-    if max_version:
-        msg += ' with version < {max_version}'.format(max_version=max_version)
-    try:
-        mod = __import__(pkg_name)
-    except ImportError:
-        mod = None
-    try:
-        have_version = mod.__version__
-    except AttributeError:
-        pytest.skip('Cannot find version for {pkg_name}'
-                    .format(pkg_name=pkg_name))
-    if min_version and checker(have_version) < checker(min_version):
-        pytest.skip(msg)
-    if max_version and checker(have_version) >= checker(max_version):
-        pytest.skip(msg)
-
-
 def optional_args(decorator):
     """allows a decorator to take optional positional and keyword arguments.
     Assumes that taking a single, callable, positional argument means that

--- a/pandas/util/testing.py
+++ b/pandas/util/testing.py
@@ -15,7 +15,6 @@ import traceback
 from datetime import datetime
 from functools import wraps, partial
 from contextlib import contextmanager
-from distutils.version import LooseVersion
 
 from numpy.random import randn, rand
 import numpy as np
@@ -316,35 +315,6 @@ def close(fignum=None):
     else:
         _close(fignum)
 
-
-def _skip_if_mpl_1_5():
-    import matplotlib as mpl
-
-    v = mpl.__version__
-    if LooseVersion(v) > LooseVersion('1.4.3') or str(v)[0] == '0':
-        import pytest
-        pytest.skip("matplotlib 1.5")
-    else:
-        mpl.use("Agg", warn=False)
-
-
-def _skip_if_no_scipy():
-    import pytest
-
-    pytest.importorskip("scipy.stats")
-    pytest.importorskip("scipy.sparse")
-    pytest.importorskip("scipy.interpolate")
-
-
-def _skip_if_no_mock():
-    try:
-        import mock  # noqa
-    except ImportError:
-        try:
-            from unittest import mock  # noqa
-        except ImportError:
-            import pytest
-            raise pytest.skip("mock is not installed")
 
 # -----------------------------------------------------------------------------
 # locale utilities


### PR DESCRIPTION
- [X] closes #18190 
- [X] tests added / passed
- [X] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

This should be the last commit to close out the issue referenced above. I think there's further opportunity to convert some of the imperative ``pytest.skip`` calls over to the new decorator methodology (especially Ibn ``pandas/tests/io``) but to keep the scope clean I would rather open a new issue for those rather than continually update #18190