### PR TITLE
Fixed typo in test_eval arguments

### DIFF
--- a/pandas/tests/computation/test_eval.py
+++ b/pandas/tests/computation/test_eval.py
@@ -1798,7 +1798,7 @@ _parsers = {'python': PythonExprVisitor, 'pytables': pytables.ExprVisitor,
             'pandas': PandasExprVisitor}
 
 
-@pytest.mark.parametrize('engine', _parsers)
+@pytest.mark.parametrize('engine', _engines)
 @pytest.mark.parametrize('parser', _parsers)
 def test_disallowed_nodes(engine, parser):
     VisitorClass = _parsers[parser]


### PR DESCRIPTION
- [X] closes #18821
- [X] tests added / passed
- [X] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry