### PR TITLE
Make DatetimeIndex iterator pickleable by dill

### DIFF
--- a/pandas/core/indexes/datetimes.py
+++ b/pandas/core/indexes/datetimes.py
@@ -1251,8 +1251,7 @@ class DatetimeIndex(DatelikeOps, TimelikeOps, DatetimeIndexOpsMixin,
             converted = libts.ints_to_pydatetime(data[start_i:end_i],
                                                  tz=self.tz, freq=self.freq,
                                                  box="timestamp")
-            for v in converted:
-                yield v
+            return iter(converted)
 
     def _wrap_union_result(self, other, result):
         name = self.name if self.name == other.name else None


### PR DESCRIPTION
Currently, dill (https://github.com/uqfoundation/dill) cannot pickle iterators over DatetimeIndex because they are generators. This simple change removes that limitation.

- [ ] closes #xxxx
- [ ] tests added / passed
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
