### PR TITLE
DOC: Modify astype copy=False example to work across platforms

### DIFF
--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -4343,7 +4343,7 @@ class NDFrame(PandasObject, SelectionMixin):
         pandas object may propagate changes:
 
         >>> s1 = pd.Series([1,2])
-        >>> s2 = s1.astype('int', copy=False)
+        >>> s2 = s1.astype('int64', copy=False)
         >>> s2[0] = 10
         >>> s1  # note that s1[0] has changed too
         0    10


### PR DESCRIPTION
- [X] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`

Very minor, just changed `'int'` -> `'int64'`.

The example as previously written does not work on Windows, since `astype('int')` converts to `int32` instead of `int64`.  The `Series` constructor defaults to `int64`, so on Windows the `astype` ends up making a copy since the dtype changes, and thus the propagation to `s1` doesn't occur.

This shouldn't impact Linux or Mac, since `astype('int')` converts to `int64` on those platforms, so `astype('int64')` should be equivalent.  I suppose this might not work for people using 32 bit distributions (?), but this should have wider coverage of potential readers of the docs, and is less confusing than using something like `'intp'`.