### PR TITLE
[WIP] Prod/Sum of all-NA / all-empty

### DIFF
--- a/doc/source/whatsnew/v0.22.0.txt
+++ b/doc/source/whatsnew/v0.22.0.txt
@@ -8,6 +8,103 @@ deprecations, new features, enhancements, and performance improvements along
 with a large number of bug fixes. We recommend that all users upgrade to this
 version.
 
+.. _whatsnew_0220.na_sum:
+
+Pandas 0.22.0 changes the handling of empty and all-NA sums and products. The
+summary is that
+
+* The sum of an all-NA or empty series is now 0
+* The product of an all-NA or empty series is now 1
+* We've added an ``empty_is_na`` keyword to the ``sum`` and ``prod`` methods
+  to control whether the sum or product of an empty series should be NA. The
+  default is ``False``. To restore the 0.21 behavior, use
+  ``empty_is_na=True``.
+
+Some background: In pandas 0.21.1, we fixed a long-standing inconsistency
+in the return value of all-NA series depending on whether or not bottleneck
+was installed. See :ref:`whatsnew_0210.api_breaking.bottleneck`_. At the same
+time, we changed the sum and prod of an empty Series to also be ``NaN``.
+
+Based on feedback, we've partially reverted those changes. The defualt sum
+for all-NA and empty series is now 0 (1 for ``prod``). You can achieve the
+pandas 0.21.0 behavior, returning ``NaN``, with the ``empty_is_na`` keyword.
+
+*pandas 0.21*
+
+.. code-block:: ipython
+
+   In [1]: import pandas as pd
+
+   In [2]: import numpy as np
+
+   In [3]: pd.Series([]).sum()
+   Out[3]: nan
+
+   In [4]: pd.Series([np.nan]).sum()
+   Out[4]: nan
+
+*pandas 0.22.0*
+
+.. ipython:: python
+
+   pd.Series([]).sum()
+   pd.Series([np.nan]).sum()
+
+To have the sum of an empty series return ``NaN``, use the ``empty_is_na``
+keyword. Thanks to the ``skipna`` parameter, the ``.sum`` on an all-NA
+series is conceptually the same as on an empty. The ``empty_is_na`` parameter
+controls the return value after removing NAs.
+
+.. ipython:: python
+
+   pd.Series([]).sum(empty_is_na=True)
+   pd.Series([np.nan]).sum(empty_is_na=True)
+
+Note that this affects some other places in the library:
+
+1. Grouping by a Categorical with some unobserved categories
+
+*pandas 0.21*
+
+.. code-block:: ipython
+
+   In [3]: grouper = pd.Categorical(['a', 'a'], categories=['a', 'b'])
+
+   In [4]: pd.Series([1, 2]).groupby(grouper).sum()
+   Out[4]:
+   a    3.0
+   b    NaN
+   dtype: float64
+
+*pandas 0.22*
+
+.. ipython:: python
+
+   grouper = pd.Categorical(['a', 'a'], categories=['a', 'b'])
+   pd.Series([1, 2]).groupby(grouepr).sum()
+
+2. Upsampling
+
+*pandas 0.21.0*
+
+.. code-block:: ipython
+
+   In [5]: idx = pd.DatetimeIndex(['2017-01-01', '2017-01-02'])
+
+   In [6]: pd.Series([1, 2], index=idx).resample('12H').sum()
+   Out[6]:
+   2017-01-01 00:00:00    1.0
+   2017-01-01 12:00:00    NaN
+   2017-01-02 00:00:00    2.0
+   Freq: 12H, dtype: float64
+
+*pandas 0.22.0*
+
+.. ipython:: python
+
+   idx = pd.DatetimeIndex(['2017-01-01', '2017-01-02'])
+   pd.Series([1, 2], index=idx).resample("12H").sum()
+
 .. _whatsnew_0220.enhancements:
 
 New features

--- a/pandas/_libs/groupby_helper.pxi.in
+++ b/pandas/_libs/groupby_helper.pxi.in
@@ -89,7 +89,7 @@ def group_add_{{name}}(ndarray[{{dest_type2}}, ndim=2] out,
         for i in range(ncounts):
             for j in range(K):
                 if nobs[i, j] == 0:
-                    out[i, j] = NAN
+                    out[i, j] = 0
                 else:
                     out[i, j] = sumx[i, j]
 
@@ -148,7 +148,7 @@ def group_prod_{{name}}(ndarray[{{dest_type2}}, ndim=2] out,
         for i in range(ncounts):
             for j in range(K):
                 if nobs[i, j] == 0:
-                    out[i, j] = NAN
+                    out[i, j] = 1
                 else:
                     out[i, j] = prodx[i, j]
 

--- a/pandas/tests/groupby/test_categorical.py
+++ b/pandas/tests/groupby/test_categorical.py
@@ -37,7 +37,7 @@ class TestGroupByCategorical(MixIn):
         # single grouper
         gb = df.groupby("A")
         exp_idx = CategoricalIndex(['a', 'b', 'z'], name='A', ordered=True)
-        expected = DataFrame({'values': Series([3, 7, np.nan], index=exp_idx)})
+        expected = DataFrame({'values': Series([3, 7, 0], index=exp_idx)})
         result = gb.sum()
         tm.assert_frame_equal(result, expected)
 
@@ -662,3 +662,25 @@ class TestGroupByCategorical(MixIn):
                          "C3": [nan, nan, nan, nan, 10, 100,
                                 nan, nan, nan, nan, 200, 34]}, index=idx)
         tm.assert_frame_equal(res, exp)
+
+    def test_sum_zero(self):
+        df = pd.DataFrame({"A": pd.Categorical(['a', 'b', 'a'],
+                                               categories=['a', 'b', 'c']),
+                           'B': [1, 2, 1]})
+        result = df.groupby("A").B.sum()
+        expected = pd.Series([2, 2, 0],
+                             index=pd.CategoricalIndex(['a', 'b', 'c'],
+                                                       name='A'),
+                             name='B')
+        tm.assert_series_equal(result, expected)
+
+    def test_prod_one(self):
+        df = pd.DataFrame({"A": pd.Categorical(['a', 'b', 'a'],
+                                               categories=['a', 'b', 'c']),
+                           'B': [1, 2, 1]})
+        result = df.groupby("A").B.prod()
+        expected = pd.Series([1, 2, 1],
+                             index=pd.CategoricalIndex(['a', 'b', 'c'],
+                                                       name='A'),
+                             name='B')
+        tm.assert_series_equal(result, expected)

--- a/pandas/tests/groupby/test_groupby.py
+++ b/pandas/tests/groupby/test_groupby.py
@@ -2704,7 +2704,7 @@ class TestGroupBy(MixIn):
 
         # Assert the results here
         index = pd.Index(['A', 'B', 'C'], name='group')
-        expected = pd.Series([-79.5160891089, -78.4839108911, None],
+        expected = pd.Series([-79.5160891089, -78.4839108911, -80],
                              index=index)
 
         assert_series_equal(expected, result)

--- a/pandas/tests/groupby/test_timegrouper.py
+++ b/pandas/tests/groupby/test_timegrouper.py
@@ -41,12 +41,12 @@ class TestGroupBy(object):
             df = df.set_index(['Date'])
 
             expected = DataFrame(
-                {'Quantity': np.nan},
+                {'Quantity': 0},
                 index=date_range('20130901 13:00:00',
                                  '20131205 13:00:00', freq='5D',
                                  name='Date', closed='left'))
             expected.iloc[[0, 6, 18], 0] = np.array(
-                [24., 6., 9.], dtype='float64')
+                [24, 6, 9], dtype='int64')
 
             result1 = df.resample('5D') .sum()
             assert_frame_equal(result1, expected)
@@ -261,9 +261,10 @@ class TestGroupBy(object):
         for freq in ['D', 'M', 'A', 'Q-APR']:
             expected = df.groupby('user_id')[
                 'whole_cost'].resample(
-                    freq).sum().dropna().reorder_levels(
+                    freq).sum().reorder_levels(
                         ['date', 'user_id']).sort_index().astype('int64')
             expected.name = 'whole_cost'
+            expected = expected[expected > 0]
 
             result1 = df.sort_index().groupby([pd.Grouper(freq=freq),
                                                'user_id'])['whole_cost'].sum()

--- a/pandas/tests/series/test_quantile.py
+++ b/pandas/tests/series/test_quantile.py
@@ -38,7 +38,7 @@ class TestSeriesQuantile(TestData):
 
         # GH7661
         result = Series([np.timedelta64('NaT')]).sum()
-        assert result is pd.NaT
+        assert result == pd.Timedelta(0)
 
         msg = 'percentiles should all be in the interval \\[0, 1\\]'
         for invalid in [-1, 2, [0.5, -1], [0.5, 2]]:

--- a/pandas/tests/test_resample.py
+++ b/pandas/tests/test_resample.py
@@ -3385,7 +3385,13 @@ class TestTimeGrouper(object):
         for func in ['min', 'max', 'sum', 'prod']:
             normal_result = getattr(normal_grouped, func)()
             dt_result = getattr(dt_grouped, func)()
-            pad = DataFrame([[np.nan, np.nan, np.nan, np.nan]], index=[3],
+            if func == 'sum':
+                fill_value = 0
+            elif func == 'prod':
+                fill_value = 1
+            else:
+                fill_value = np.nan
+            pad = DataFrame([[fill_value] * 4], index=[3],
                             columns=['A', 'B', 'C', 'D'])
             expected = normal_result.append(pad)
             expected = expected.sort_index()


### PR DESCRIPTION
To make review a bit easier, I've opened this before it's complete.

Of course we still need to decide

1. Do we want
    a. `sum([]) = 0`; `prod([]) = 1`
    b. `sum([NaN]) = 0`; `prod([NaN])` = 1 
2. Do we like the keyword approach (requiring people who want empty to be NA to always specify it) or do we want a new method?
3. Do we like the `empty_is_na` keyword? Alternatives are `fill_value`, ...
4. Does this apply to groupby (unobserved categoricals)
5. Does this apply to resample?

There are still some failing tests. I've tried to keep the commits separate:

- groupby: https://github.com/pandas-dev/pandas/commit/e96e38649b9e6784fda2eae3de6c72c44f6ca813
- resample: https://github.com/pandas-dev/pandas/commit/20f2ccc4fa2bcb559732e1b37a8671f29d7ef54b

closes #18678 