### PR TITLE
API: Allow ordered=None in CategoricalDtype

### DIFF
--- a/doc/source/whatsnew/v0.23.0.txt
+++ b/doc/source/whatsnew/v0.23.0.txt
@@ -460,6 +460,29 @@ To restore previous behavior, simply set ``expand`` to ``False``:
     extracted
     type(extracted)
 
+.. _whatsnew_0230.api_breaking.cdt_ordered:
+
+Default value for the ``ordered`` parameter of ``CategoricalDtype``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The default value of the ``ordered`` parameter for :class:`~pandas.api.types.CategoricalDtype` has changed from ``False`` to ``None`` to allow updating of ``categories`` without impacting ``ordered``.  Behavior should remain consistent for downstream objects, such as :class:`Categorical` (:issue:`18790`)
+
+In previous versions, the default value for the ``ordered`` parameter was ``False``.  This could potentially lead to the ``ordered`` parameter unintentionally being changed from ``True`` to ``False`` when users attempt to update ``categories`` if ``ordered`` is not explicitly specified, as it would silently default to ``False``.  The new behavior for ``ordered=None`` is to retain the existing value of ``ordered``.
+
+New Behavior:
+
+.. ipython:: python
+
+    from pandas.api.types import CategoricalDtype
+    cat = pd.Categorical(list('abcaba'), ordered=True, categories=list('cba'))
+    cat
+    cdt = CategoricalDtype(categories=list('cbad'))
+    cat.astype(cdt)
+
+Notice in the example above that the converted ``Categorical`` has retained ``ordered=True``.  Had the default value for ``ordered`` remained as ``False``, the converted ``Categorical`` would have become unordered, despite ``ordered=False`` never being explicitly specified.  To change the value of ``ordered``, explicitly pass it to the new dtype, e.g. ``CategoricalDtype(categories=list('cbad'), ordered=False)``.
+
+Note that the unintenional conversion of ``ordered`` discussed above did not arise in previous versions due to separate bugs that prevented ``astype`` from doing any type of category to category conversion (:issue:`10696`, :issue:`18593`).  These bugs have been fixed in this release, and motivated changing the default value of ``ordered``.
+
 .. _whatsnew_0230.api:
 
 Other API Changes
@@ -507,7 +530,6 @@ Other API Changes
 - Set operations (union, difference...) on :class:`IntervalIndex` with incompatible index types will now raise a ``TypeError`` rather than a ``ValueError`` (:issue:`19329`)
 - :class:`DateOffset` objects render more simply, e.g. "<DateOffset: days=1>" instead of "<DateOffset: kwds={'days': 1}>" (:issue:`19403`)
 - :func:`pandas.merge` provides a more informative error message when trying to merge on timezone-aware and timezone-naive columns (:issue:`15800`)
-- The default value of the ``ordered`` parameter for :class:`~pandas.api.types.CategoricalDtype` has changed from ``False`` to ``None`` to allow updating of ``categories`` without impacting ``ordered``.  Behavior should remain consistent for downstream objects, such as :class:`Categorical` (:issue:`18790`)
 
 .. _whatsnew_0230.deprecations:
 

--- a/doc/source/whatsnew/v0.23.0.txt
+++ b/doc/source/whatsnew/v0.23.0.txt
@@ -507,6 +507,7 @@ Other API Changes
 - Set operations (union, difference...) on :class:`IntervalIndex` with incompatible index types will now raise a ``TypeError`` rather than a ``ValueError`` (:issue:`19329`)
 - :class:`DateOffset` objects render more simply, e.g. "<DateOffset: days=1>" instead of "<DateOffset: kwds={'days': 1}>" (:issue:`19403`)
 - :func:`pandas.merge` provides a more informative error message when trying to merge on timezone-aware and timezone-naive columns (:issue:`15800`)
+- The default value of the ``ordered`` parameter for :class:`~pandas.api.types.CategoricalDtype` has changed from ``False`` to ``None``.  Behavior should remain consistent for downstream objects, such as :class:`Categorical` (:issue:`18790`)
 
 .. _whatsnew_0230.deprecations:
 

--- a/doc/source/whatsnew/v0.23.0.txt
+++ b/doc/source/whatsnew/v0.23.0.txt
@@ -507,7 +507,7 @@ Other API Changes
 - Set operations (union, difference...) on :class:`IntervalIndex` with incompatible index types will now raise a ``TypeError`` rather than a ``ValueError`` (:issue:`19329`)
 - :class:`DateOffset` objects render more simply, e.g. "<DateOffset: days=1>" instead of "<DateOffset: kwds={'days': 1}>" (:issue:`19403`)
 - :func:`pandas.merge` provides a more informative error message when trying to merge on timezone-aware and timezone-naive columns (:issue:`15800`)
-- The default value of the ``ordered`` parameter for :class:`~pandas.api.types.CategoricalDtype` has changed from ``False`` to ``None``.  Behavior should remain consistent for downstream objects, such as :class:`Categorical` (:issue:`18790`)
+- The default value of the ``ordered`` parameter for :class:`~pandas.api.types.CategoricalDtype` has changed from ``False`` to ``None`` to allow updating of ``categories`` without impacting ``ordered``.  Behavior should remain consistent for downstream objects, such as :class:`Categorical` (:issue:`18790`)
 
 .. _whatsnew_0230.deprecations:
 

--- a/pandas/core/arrays/categorical.py
+++ b/pandas/core/arrays/categorical.py
@@ -294,7 +294,7 @@ class Categorical(ExtensionArray, PandasObject):
 
         if fastpath:
             self._codes = coerce_indexer_dtype(values, categories)
-            self._dtype = self._dtype._update_dtype(dtype)
+            self._dtype = self._dtype.update_dtype(dtype)
             return
 
         # null_mask indicates missing values we want to exclude from inference.
@@ -358,7 +358,7 @@ class Categorical(ExtensionArray, PandasObject):
             full_codes[~null_mask] = codes
             codes = full_codes
 
-        self._dtype = self._dtype._update_dtype(dtype)
+        self._dtype = self._dtype.update_dtype(dtype)
         self._codes = coerce_indexer_dtype(codes, dtype.categories)
 
     @property
@@ -438,7 +438,7 @@ class Categorical(ExtensionArray, PandasObject):
         """
         if is_categorical_dtype(dtype):
             # GH 10696/18593
-            dtype = self.dtype._update_dtype(dtype)
+            dtype = self.dtype.update_dtype(dtype)
             self = self.copy() if copy else self
             if dtype == self.dtype:
                 return self
@@ -560,7 +560,7 @@ class Categorical(ExtensionArray, PandasObject):
             raise ValueError(
                 "codes need to be convertible to an arrays of integers")
 
-        categories = CategoricalDtype._validate_categories(categories)
+        categories = CategoricalDtype.validate_categories(categories)
 
         if len(codes) and (codes.max() >= len(categories) or codes.min() < -1):
             raise ValueError("codes need to be between -1 and "
@@ -1165,7 +1165,7 @@ class Categorical(ExtensionArray, PandasObject):
 
         # Provide compatibility with pre-0.15.0 Categoricals.
         if '_categories' not in state and '_levels' in state:
-            state['_categories'] = self.dtype._validate_categories(state.pop(
+            state['_categories'] = self.dtype.validate_categories(state.pop(
                 '_levels'))
         if '_codes' not in state and 'labels' in state:
             state['_codes'] = coerce_indexer_dtype(

--- a/pandas/core/arrays/categorical.py
+++ b/pandas/core/arrays/categorical.py
@@ -243,7 +243,7 @@ class Categorical(ExtensionArray, PandasObject):
     # For comparisons, so that numpy uses our implementation if the compare
     # ops, which raise
     __array_priority__ = 1000
-    _dtype = CategoricalDtype()
+    _dtype = CategoricalDtype(ordered=False)
     _deprecations = frozenset(['labels'])
     _typ = 'categorical'
 
@@ -294,7 +294,7 @@ class Categorical(ExtensionArray, PandasObject):
 
         if fastpath:
             self._codes = coerce_indexer_dtype(values, categories)
-            self._dtype = dtype
+            self._dtype = self._dtype._update_dtype(dtype)
             return
 
         # null_mask indicates missing values we want to exclude from inference.
@@ -358,7 +358,7 @@ class Categorical(ExtensionArray, PandasObject):
             full_codes[~null_mask] = codes
             codes = full_codes
 
-        self._dtype = dtype
+        self._dtype = self._dtype._update_dtype(dtype)
         self._codes = coerce_indexer_dtype(codes, dtype.categories)
 
     @property

--- a/pandas/core/dtypes/dtypes.py
+++ b/pandas/core/dtypes/dtypes.py
@@ -181,11 +181,11 @@ class CategoricalDtype(PandasExtensionDtype):
     def _finalize(self, categories, ordered, fastpath=False):
 
         if ordered is not None:
-            self._validate_ordered(ordered)
+            self.validate_ordered(ordered)
 
         if categories is not None:
-            categories = self._validate_categories(categories,
-                                                   fastpath=fastpath)
+            categories = self.validate_categories(categories,
+                                                  fastpath=fastpath)
 
         self._categories = categories
         self._ordered = ordered
@@ -286,7 +286,7 @@ class CategoricalDtype(PandasExtensionDtype):
         raise TypeError("cannot construct a CategoricalDtype")
 
     @staticmethod
-    def _validate_ordered(ordered):
+    def validate_ordered(ordered):
         """
         Validates that we have a valid ordered parameter. If
         it is not a boolean, a TypeError will be raised.
@@ -306,7 +306,7 @@ class CategoricalDtype(PandasExtensionDtype):
             raise TypeError("'ordered' must either be 'True' or 'False'")
 
     @staticmethod
-    def _validate_categories(categories, fastpath=False):
+    def validate_categories(categories, fastpath=False):
         """
         Validates that we have good categories
 
@@ -338,7 +338,7 @@ class CategoricalDtype(PandasExtensionDtype):
 
         return categories
 
-    def _update_dtype(self, dtype):
+    def update_dtype(self, dtype):
         """
         Returns a CategoricalDtype with categories and ordered taken from dtype
         if specified, otherwise falling back to self if unspecified

--- a/pandas/core/indexes/category.py
+++ b/pandas/core/indexes/category.py
@@ -344,7 +344,7 @@ class CategoricalIndex(Index, accessor.PandasDelegate):
             return IntervalIndex(np.array(self))
         elif is_categorical_dtype(dtype):
             # GH 18630
-            dtype = self.dtype._update_dtype(dtype)
+            dtype = self.dtype.update_dtype(dtype)
             if dtype == self.dtype:
                 return self.copy() if copy else self
 

--- a/pandas/tests/dtypes/test_dtypes.py
+++ b/pandas/tests/dtypes/test_dtypes.py
@@ -24,6 +24,11 @@ from pandas.core.dtypes.common import (
 import pandas.util.testing as tm
 
 
+@pytest.fixture(params=[True, False, None])
+def ordered(request):
+    return request.param
+
+
 class Base(object):
 
     def setup_method(self, method):
@@ -123,41 +128,6 @@ class TestCategoricalDtype(Base):
         categories = [(1, 'a'), (2, 'b'), (3, 'c')]
         result = CategoricalDtype(categories)
         assert all(result.categories == categories)
-
-    @pytest.mark.parametrize('dtype', [
-        CategoricalDtype(list('abc'), False),
-        CategoricalDtype(list('abc'), True)])
-    @pytest.mark.parametrize('new_dtype', [
-        'category',
-        CategoricalDtype(None, False),
-        CategoricalDtype(None, True),
-        CategoricalDtype(list('abc'), False),
-        CategoricalDtype(list('abc'), True),
-        CategoricalDtype(list('cba'), False),
-        CategoricalDtype(list('cba'), True),
-        CategoricalDtype(list('wxyz'), False),
-        CategoricalDtype(list('wxyz'), True)])
-    def test_update_dtype(self, dtype, new_dtype):
-        if isinstance(new_dtype, string_types) and new_dtype == 'category':
-            expected_categories = dtype.categories
-            expected_ordered = dtype.ordered
-        else:
-            expected_categories = new_dtype.categories
-            if expected_categories is None:
-                expected_categories = dtype.categories
-            expected_ordered = new_dtype.ordered
-
-        result = dtype._update_dtype(new_dtype)
-        tm.assert_index_equal(result.categories, expected_categories)
-        assert result.ordered is expected_ordered
-
-    @pytest.mark.parametrize('bad_dtype', [
-        'foo', object, np.int64, PeriodDtype('Q')])
-    def test_update_dtype_errors(self, bad_dtype):
-        dtype = CategoricalDtype(list('abc'), False)
-        msg = 'a CategoricalDtype must be passed to perform an update, '
-        with tm.assert_raises_regex(ValueError, msg):
-            dtype._update_dtype(bad_dtype)
 
 
 class TestDatetimeTZDtype(Base):
@@ -609,17 +579,12 @@ class TestIntervalDtype(Base):
 
 class TestCategoricalDtypeParametrized(object):
 
-    @pytest.mark.parametrize('categories, ordered', [
-        (['a', 'b', 'c', 'd'], False),
-        (['a', 'b', 'c', 'd'], True),
-        (np.arange(1000), False),
-        (np.arange(1000), True),
-        (['a', 'b', 10, 2, 1.3, True], False),
-        ([True, False], True),
-        ([True, False], False),
-        (pd.date_range('2017', periods=4), True),
-        (pd.date_range('2017', periods=4), False),
-    ])
+    @pytest.mark.parametrize('categories', [
+        list('abcd'),
+        np.arange(1000),
+        ['a', 'b', 10, 2, 1.3, True],
+        [True, False],
+        pd.date_range('2017', periods=4)])
     def test_basic(self, categories, ordered):
         c1 = CategoricalDtype(categories, ordered=ordered)
         tm.assert_index_equal(c1.categories, pd.Index(categories))
@@ -627,21 +592,24 @@ class TestCategoricalDtypeParametrized(object):
 
     def test_order_matters(self):
         categories = ['a', 'b']
-        c1 = CategoricalDtype(categories, ordered=False)
-        c2 = CategoricalDtype(categories, ordered=True)
+        c1 = CategoricalDtype(categories, ordered=True)
+        c2 = CategoricalDtype(categories, ordered=False)
+        c3 = CategoricalDtype(categories, ordered=None)
         assert c1 is not c2
+        assert c1 is not c3
 
-    def test_unordered_same(self):
-        c1 = CategoricalDtype(['a', 'b'])
-        c2 = CategoricalDtype(['b', 'a'])
+    @pytest.mark.parametrize('ordered', [False, None])
+    def test_unordered_same(self, ordered):
+        c1 = CategoricalDtype(['a', 'b'], ordered=ordered)
+        c2 = CategoricalDtype(['b', 'a'], ordered=ordered)
         assert hash(c1) == hash(c2)
 
     def test_categories(self):
         result = CategoricalDtype(['a', 'b', 'c'])
         tm.assert_index_equal(result.categories, pd.Index(['a', 'b', 'c']))
-        assert result.ordered is False
+        assert result.ordered is None
 
-    def test_equal_but_different(self):
+    def test_equal_but_different(self, ordered):
         c1 = CategoricalDtype([1, 2, 3])
         c2 = CategoricalDtype([1., 2., 3.])
         assert c1 is not c2
@@ -652,9 +620,11 @@ class TestCategoricalDtypeParametrized(object):
         ([1, 2, 3], [3, 2, 1]),
     ])
     def test_order_hashes_different(self, v1, v2):
-        c1 = CategoricalDtype(v1)
+        c1 = CategoricalDtype(v1, ordered=False)
         c2 = CategoricalDtype(v2, ordered=True)
+        c3 = CategoricalDtype(v1, ordered=None)
         assert c1 is not c2
+        assert c1 is not c3
 
     def test_nan_invalid(self):
         with pytest.raises(ValueError):
@@ -669,26 +639,35 @@ class TestCategoricalDtypeParametrized(object):
         c2 = CategoricalDtype(['b', 'a'], ordered=True)
         assert c1 is not c2
 
-    @pytest.mark.parametrize('ordered, other, expected', [
-        (True, CategoricalDtype(['a', 'b'], True), True),
-        (False, CategoricalDtype(['a', 'b'], False), True),
-        (True, CategoricalDtype(['a', 'b'], False), False),
-        (False, CategoricalDtype(['a', 'b'], True), False),
-        (True, CategoricalDtype([1, 2], False), False),
-        (False, CategoricalDtype([1, 2], True), False),
-        (False, CategoricalDtype(None, True), True),
-        (True, CategoricalDtype(None, True), True),
-        (False, CategoricalDtype(None, False), True),
-        (True, CategoricalDtype(None, False), True),
-        (True, 'category', True),
-        (False, 'category', True),
-        (True, 'not a category', False),
-        (False, 'not a category', False),
-    ])
-    def test_categorical_equality(self, ordered, other, expected):
-        c1 = CategoricalDtype(['a', 'b'], ordered)
+    @pytest.mark.parametrize('ordered1', [True, False, None])
+    @pytest.mark.parametrize('ordered2', [True, False, None])
+    def test_categorical_equality(self, ordered1, ordered2):
+        # same categories
+        c1 = CategoricalDtype(list('abc'), ordered1)
+        c2 = CategoricalDtype(list('abc'), ordered2)
+        result = c1 == c2
+        expected = (ordered1 is ordered2) or not any([ordered1, ordered2])
+        assert result is expected
+
+        # different categories
+        c2 = CategoricalDtype([1, 2, 3], ordered2)
+        assert c1 != c2
+
+        # none categories
+        c1 = CategoricalDtype(list('abc'), ordered1)
+        c2 = CategoricalDtype(None, ordered2)
+        c3 = CategoricalDtype(None, ordered1)
+        assert c1 == c2
+        assert c2 == c1
+        assert c2 == c3
+
+    @pytest.mark.parametrize('categories', [list('abc'), None])
+    @pytest.mark.parametrize('other', ['category', 'not a category'])
+    def test_categorical_equality_strings(self, categories, ordered, other):
+        c1 = CategoricalDtype(categories, ordered)
         result = c1 == other
-        assert result == expected
+        expected = other == 'category'
+        assert result is expected
 
     def test_invalid_raises(self):
         with tm.assert_raises_regex(TypeError, 'ordered'):
@@ -729,12 +708,12 @@ class TestCategoricalDtypeParametrized(object):
             c1, categories=[1, 2], ordered=False)
         assert result == CategoricalDtype([1, 2], ordered=False)
 
-    def test_str_vs_repr(self):
-        c1 = CategoricalDtype(['a', 'b'])
+    def test_str_vs_repr(self, ordered):
+        c1 = CategoricalDtype(['a', 'b'], ordered=ordered)
         assert str(c1) == 'category'
         # Py2 will have unicode prefixes
-        pat = r"CategoricalDtype\(categories=\[.*\], ordered=False\)"
-        assert re.match(pat, repr(c1))
+        pat = r"CategoricalDtype\(categories=\[.*\], ordered={ordered}\)"
+        assert re.match(pat.format(ordered=ordered), repr(c1))
 
     def test_categorical_categories(self):
         # GH17884
@@ -742,3 +721,38 @@ class TestCategoricalDtypeParametrized(object):
         tm.assert_index_equal(c1.categories, pd.Index(['a', 'b']))
         c1 = CategoricalDtype(CategoricalIndex(['a', 'b']))
         tm.assert_index_equal(c1.categories, pd.Index(['a', 'b']))
+
+    @pytest.mark.parametrize('new_categories', [
+        list('abc'), list('cba'), list('wxyz'), None])
+    @pytest.mark.parametrize('new_ordered', [True, False, None])
+    def test_update_dtype(self, ordered, new_categories, new_ordered):
+        dtype = CategoricalDtype(list('abc'), ordered)
+        new_dtype = CategoricalDtype(new_categories, new_ordered)
+
+        expected_categories = new_dtype.categories
+        if expected_categories is None:
+            expected_categories = dtype.categories
+
+        expected_ordered = new_dtype.ordered
+        if expected_ordered is None:
+            expected_ordered = dtype.ordered
+
+        result = dtype._update_dtype(new_dtype)
+        tm.assert_index_equal(result.categories, expected_categories)
+        assert result.ordered is expected_ordered
+
+    def test_update_dtype_string(self, ordered):
+        dtype = CategoricalDtype(list('abc'), ordered)
+        expected_categories = dtype.categories
+        expected_ordered = dtype.ordered
+        result = dtype._update_dtype('category')
+        tm.assert_index_equal(result.categories, expected_categories)
+        assert result.ordered is expected_ordered
+
+    @pytest.mark.parametrize('bad_dtype', [
+        'foo', object, np.int64, PeriodDtype('Q')])
+    def test_update_dtype_errors(self, bad_dtype):
+        dtype = CategoricalDtype(list('abc'), False)
+        msg = 'a CategoricalDtype must be passed to perform an update, '
+        with tm.assert_raises_regex(ValueError, msg):
+            dtype._update_dtype(bad_dtype)

--- a/pandas/tests/dtypes/test_dtypes.py
+++ b/pandas/tests/dtypes/test_dtypes.py
@@ -737,7 +737,7 @@ class TestCategoricalDtypeParametrized(object):
         if expected_ordered is None:
             expected_ordered = dtype.ordered
 
-        result = dtype._update_dtype(new_dtype)
+        result = dtype.update_dtype(new_dtype)
         tm.assert_index_equal(result.categories, expected_categories)
         assert result.ordered is expected_ordered
 
@@ -745,7 +745,7 @@ class TestCategoricalDtypeParametrized(object):
         dtype = CategoricalDtype(list('abc'), ordered)
         expected_categories = dtype.categories
         expected_ordered = dtype.ordered
-        result = dtype._update_dtype('category')
+        result = dtype.update_dtype('category')
         tm.assert_index_equal(result.categories, expected_categories)
         assert result.ordered is expected_ordered
 
@@ -755,4 +755,4 @@ class TestCategoricalDtypeParametrized(object):
         dtype = CategoricalDtype(list('abc'), False)
         msg = 'a CategoricalDtype must be passed to perform an update, '
         with tm.assert_raises_regex(ValueError, msg):
-            dtype._update_dtype(bad_dtype)
+            dtype.update_dtype(bad_dtype)

--- a/pandas/tests/dtypes/test_dtypes.py
+++ b/pandas/tests/dtypes/test_dtypes.py
@@ -642,11 +642,22 @@ class TestCategoricalDtypeParametrized(object):
     @pytest.mark.parametrize('ordered1', [True, False, None])
     @pytest.mark.parametrize('ordered2', [True, False, None])
     def test_categorical_equality(self, ordered1, ordered2):
-        # same categories
+        # same categories, same order
+        # any combination of None/False are equal
+        # True/True is the only combination with True that are equal
         c1 = CategoricalDtype(list('abc'), ordered1)
         c2 = CategoricalDtype(list('abc'), ordered2)
         result = c1 == c2
-        expected = (ordered1 is ordered2) or not any([ordered1, ordered2])
+        expected = bool(ordered1) is bool(ordered2)
+        assert result is expected
+
+        # same categories, different order
+        # any combination of None/False are equal (order doesn't matter)
+        # any combination with True are not equal (different order of cats)
+        c1 = CategoricalDtype(list('abc'), ordered1)
+        c2 = CategoricalDtype(list('cab'), ordered2)
+        result = c1 == c2
+        expected = (bool(ordered1) is False) and (bool(ordered2) is False)
         assert result is expected
 
         # different categories


### PR DESCRIPTION
- [X] closes #18790
- [X] tests added / passed
- [X] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [X] whatsnew entry

For equality comparisons with `ordered=None`, I essentially treated it as if it where `ordered=False`:

  - `CDT(['a', 'b'], None) == CDT(['a', 'b'], False)` --> `True`
  - `CDT(['a', 'b'], None) == CDT(['b', 'a'], False)` --> `True`
  - `CDT(['a', 'b'], None) == CDT(['a', 'b'], True)` --> `False`

This maintains existing comparison behavior when ordered is not specified:
  - `CDT(['a', 'b'], False) == CDT(['a', 'b'])`  --> `True`
  - `CDT(['a', 'b'], True) == CDT(['a', 'b'])`  --> `False`
<br />

I didn't make any code modifications in regards to hashing, so `CDT(*, None)` will have the same hash as `CDT(*, False)`.  This seems to be consistent with how equality is treated.  Makes the logic implementing equality nicer too, since the case when both dtypes are unordered relies on hashes.