### PR TITLE
DEPR: convert_datetime64 parameter in to_records()

### DIFF
--- a/doc/source/whatsnew/v0.23.0.txt
+++ b/doc/source/whatsnew/v0.23.0.txt
@@ -842,7 +842,7 @@ Deprecations
 - ``pandas.tseries.plotting.tsplot`` is deprecated. Use :func:`Series.plot` instead (:issue:`18627`)
 - ``Index.summary()`` is deprecated and will be removed in a future version (:issue:`18217`)
 - ``NDFrame.get_ftype_counts()`` is deprecated and will be removed in a future version (:issue:`18243`)
-- The ``convert_datetime64`` parameter in :func:`DataFrame.to_records` has been deprecated and will be removed in a future version. The NumPy bug motivating this parameter has been resolved (:issue:`18160`).
+- The ``convert_datetime64`` parameter in :func:`DataFrame.to_records` has been deprecated and will be removed in a future version. The NumPy bug motivating this parameter has been resolved. The default value for this parameter has also changed from ``True`` to ``None`` (:issue:`18160`).
 
 .. _whatsnew_0230.prior_deprecations:
 

--- a/doc/source/whatsnew/v0.23.0.txt
+++ b/doc/source/whatsnew/v0.23.0.txt
@@ -842,7 +842,7 @@ Deprecations
 - ``pandas.tseries.plotting.tsplot`` is deprecated. Use :func:`Series.plot` instead (:issue:`18627`)
 - ``Index.summary()`` is deprecated and will be removed in a future version (:issue:`18217`)
 - ``NDFrame.get_ftype_counts()`` is deprecated and will be removed in a future version (:issue:`18243`)
-- The ``convert_datetime64`` parameter has been deprecated and the default value is now ``False`` in :func:`to_records` as the NumPy bug motivating this parameter has been resolved (:issue:`18160`).
+- The ``convert_datetime64`` parameter in :func:`DataFrame.to_records` has been deprecated and the default value is now ``False``. The NumPy bug motivating this parameter has been resolved (:issue:`18160`).
 
 .. _whatsnew_0230.prior_deprecations:
 

--- a/doc/source/whatsnew/v0.23.0.txt
+++ b/doc/source/whatsnew/v0.23.0.txt
@@ -842,6 +842,7 @@ Deprecations
 - ``pandas.tseries.plotting.tsplot`` is deprecated. Use :func:`Series.plot` instead (:issue:`18627`)
 - ``Index.summary()`` is deprecated and will be removed in a future version (:issue:`18217`)
 - ``NDFrame.get_ftype_counts()`` is deprecated and will be removed in a future version (:issue:`18243`)
+- The ``convert_datetime64`` parameter has been deprecated and the default value is now ``False`` in :func:`to_records` as the NumPy bug motivating this parameter has been resolved (:issue:`18160`).
 
 .. _whatsnew_0230.prior_deprecations:
 

--- a/doc/source/whatsnew/v0.23.0.txt
+++ b/doc/source/whatsnew/v0.23.0.txt
@@ -842,7 +842,7 @@ Deprecations
 - ``pandas.tseries.plotting.tsplot`` is deprecated. Use :func:`Series.plot` instead (:issue:`18627`)
 - ``Index.summary()`` is deprecated and will be removed in a future version (:issue:`18217`)
 - ``NDFrame.get_ftype_counts()`` is deprecated and will be removed in a future version (:issue:`18243`)
-- The ``convert_datetime64`` parameter in :func:`DataFrame.to_records` has been deprecated and the default value is now ``False``. The NumPy bug motivating this parameter has been resolved (:issue:`18160`).
+- The ``convert_datetime64`` parameter in :func:`DataFrame.to_records` has been deprecated and will be removed in a future version. The NumPy bug motivating this parameter has been resolved (:issue:`18160`).
 
 .. _whatsnew_0230.prior_deprecations:
 

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -1311,7 +1311,7 @@ class DataFrame(NDFrame):
 
         return cls(mgr)
 
-    def to_records(self, index=True, convert_datetime64=None):
+    def to_records(self, index=True, convert_datetime64=False):
         """
         Convert DataFrame to a NumPy record array.
 
@@ -1379,13 +1379,11 @@ class DataFrame(NDFrame):
                   dtype=[('index', '<M8[ns]'), ('A', '<i8'), ('B', '<f8')])
         """
 
-        if convert_datetime64 is not None:
+        if convert_datetime64:
             warnings.warn("The 'convert_datetime64' parameter is "
                           "deprecated and will be removed in a future "
                           "version",
                           FutureWarning, stacklevel=2)
-        else:
-            convert_datetime64 = True
 
         if index:
             if is_datetime64_any_dtype(self.index) and convert_datetime64:

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -1311,7 +1311,7 @@ class DataFrame(NDFrame):
 
         return cls(mgr)
 
-    def to_records(self, index=True, convert_datetime64=True):
+    def to_records(self, index=True, convert_datetime64=False):
         """
         Convert DataFrame to a NumPy record array.
 
@@ -1322,7 +1322,9 @@ class DataFrame(NDFrame):
         ----------
         index : boolean, default True
             Include index in resulting record array, stored in 'index' field.
-        convert_datetime64 : boolean, default True
+        convert_datetime64 : boolean, default False
+            .. deprecated:: 0.23.0
+
             Whether to convert the index to datetime.datetime if it is a
             DatetimeIndex.
 
@@ -1376,6 +1378,13 @@ class DataFrame(NDFrame):
                    ('2018-01-01T09:01:00.000000000', 2, 0.75)],
                   dtype=[('index', '<M8[ns]'), ('A', '<i8'), ('B', '<f8')])
         """
+
+        if convert_datetime64:
+            warnings.warn("The 'convert_datetime64' parameter is "
+                          "deprecated and will be removed in a future "
+                          "version",
+                          FutureWarning, stacklevel=2)
+
         if index:
             if is_datetime64_any_dtype(self.index) and convert_datetime64:
                 ix_vals = [self.index.to_pydatetime()]

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -1384,6 +1384,8 @@ class DataFrame(NDFrame):
                           "deprecated and will be removed in a future "
                           "version",
                           FutureWarning, stacklevel=2)
+        else:
+            convert_datetime64 = True
 
         if index:
             if is_datetime64_any_dtype(self.index) and convert_datetime64:

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -1311,7 +1311,7 @@ class DataFrame(NDFrame):
 
         return cls(mgr)
 
-    def to_records(self, index=True, convert_datetime64=False):
+    def to_records(self, index=True, convert_datetime64=None):
         """
         Convert DataFrame to a NumPy record array.
 
@@ -1379,7 +1379,7 @@ class DataFrame(NDFrame):
                   dtype=[('index', '<M8[ns]'), ('A', '<i8'), ('B', '<f8')])
         """
 
-        if convert_datetime64:
+        if convert_datetime64 is not None:
             warnings.warn("The 'convert_datetime64' parameter is "
                           "deprecated and will be removed in a future "
                           "version",

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -1311,7 +1311,7 @@ class DataFrame(NDFrame):
 
         return cls(mgr)
 
-    def to_records(self, index=True, convert_datetime64=False):
+    def to_records(self, index=True, convert_datetime64=None):
         """
         Convert DataFrame to a NumPy record array.
 
@@ -1322,7 +1322,7 @@ class DataFrame(NDFrame):
         ----------
         index : boolean, default True
             Include index in resulting record array, stored in 'index' field.
-        convert_datetime64 : boolean, default False
+        convert_datetime64 : boolean, default None
             .. deprecated:: 0.23.0
 
             Whether to convert the index to datetime.datetime if it is a
@@ -1379,7 +1379,7 @@ class DataFrame(NDFrame):
                   dtype=[('index', '<M8[ns]'), ('A', '<i8'), ('B', '<f8')])
         """
 
-        if convert_datetime64:
+        if convert_datetime64 is not None:
             warnings.warn("The 'convert_datetime64' parameter is "
                           "deprecated and will be removed in a future "
                           "version",

--- a/pandas/tests/frame/test_convert_to.py
+++ b/pandas/tests/frame/test_convert_to.py
@@ -84,8 +84,9 @@ class TestDataFrameConvertTo(TestData):
             result = df.to_records(convert_datetime64=True)['index'][0]
             assert expected == result
 
-        rs = df.to_records(convert_datetime64=False)
-        assert rs['index'][0] == df.index.values[0]
+        with tm.assert_produces_warning(FutureWarning):
+            rs = df.to_records(convert_datetime64=False)
+            assert rs['index'][0] == df.index.values[0]
 
     def test_to_records_with_multindex(self):
         # GH3189

--- a/pandas/tests/frame/test_convert_to.py
+++ b/pandas/tests/frame/test_convert_to.py
@@ -79,7 +79,10 @@ class TestDataFrameConvertTo(TestData):
         df = DataFrame([["one", "two", "three"],
                         ["four", "five", "six"]],
                        index=date_range("2012-01-01", "2012-01-02"))
-        assert df.to_records()['index'][0] == df.index[0]
+        with tm.assert_produces_warning(FutureWarning):
+            expected = df.index[0]
+            result = df.to_records(convert_datetime64=True)['index'][0]
+            assert expected == result
 
         rs = df.to_records(convert_datetime64=False)
         assert rs['index'][0] == df.index.values[0]

--- a/pandas/tests/frame/test_convert_to.py
+++ b/pandas/tests/frame/test_convert_to.py
@@ -80,19 +80,16 @@ class TestDataFrameConvertTo(TestData):
                         ["four", "five", "six"]],
                        index=date_range("2012-01-01", "2012-01-02"))
 
+        # convert_datetime64 defaults to False if not passed
+        expected = df.index.values[0]
+        result = df.to_records()['index'][0]
+        assert expected == result
+
+        # check for FutureWarning if convert_datetime64=True is passed
         with tm.assert_produces_warning(FutureWarning):
             expected = df.index[0]
             result = df.to_records(convert_datetime64=True)['index'][0]
             assert expected == result
-
-        expected = df.index[0]
-        # convert_datetime64 defaults to True if not passed
-        result = df.to_records()['index'][0]
-        assert expected == result
-
-        with tm.assert_produces_warning(FutureWarning):
-            rs = df.to_records(convert_datetime64=False)
-            assert rs['index'][0] == df.index.values[0]
 
     def test_to_records_with_multindex(self):
         # GH3189

--- a/pandas/tests/frame/test_convert_to.py
+++ b/pandas/tests/frame/test_convert_to.py
@@ -79,10 +79,16 @@ class TestDataFrameConvertTo(TestData):
         df = DataFrame([["one", "two", "three"],
                         ["four", "five", "six"]],
                        index=date_range("2012-01-01", "2012-01-02"))
+
         with tm.assert_produces_warning(FutureWarning):
             expected = df.index[0]
             result = df.to_records(convert_datetime64=True)['index'][0]
             assert expected == result
+
+        expected = df.index[0]
+        # convert_datetime64 defaults to True if not passed
+        result = df.to_records()['index'][0]
+        assert expected == result
 
         with tm.assert_produces_warning(FutureWarning):
             rs = df.to_records(convert_datetime64=False)

--- a/pandas/tests/frame/test_convert_to.py
+++ b/pandas/tests/frame/test_convert_to.py
@@ -80,10 +80,16 @@ class TestDataFrameConvertTo(TestData):
                         ["four", "five", "six"]],
                        index=date_range("2012-01-01", "2012-01-02"))
 
-        # convert_datetime64 defaults to False if not passed
+        # convert_datetime64 defaults to None
         expected = df.index.values[0]
         result = df.to_records()['index'][0]
         assert expected == result
+
+        # check for FutureWarning if convert_datetime64=False is passed
+        with tm.assert_produces_warning(FutureWarning):
+            expected = df.index.values[0]
+            result = df.to_records(convert_datetime64=False)['index'][0]
+            assert expected == result
 
         # check for FutureWarning if convert_datetime64=True is passed
         with tm.assert_produces_warning(FutureWarning):


### PR DESCRIPTION
- [x] closes #18160
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry

As noted in the original issue, the underlying NumPy bug seems to be fixed so this parameter may no longer be needed. 

I also changed the default value for ``convert_datetime64`` from ``True`` to ``False`` and only give a ``FutureWarning`` when ``convert_datetime64=True`` is passed but I'm not sure if this is more appropriate than leaving ``True`` as the default and always giving a ``FutureWarning``.