### PR TITLE
CLN: ASV panel_methods

### DIFF
--- a/asv_bench/benchmarks/panel_methods.py
+++ b/asv_bench/benchmarks/panel_methods.py
@@ -1,24 +1,19 @@
-from .pandas_vb_common import *
+import numpy as np
+
+from .pandas_vb_common import Panel, setup  # noqa
 
 
 class PanelMethods(object):
+
     goal_time = 0.2
+    params = ['items', 'major', 'minor']
+    param_names = ['axis']
 
-    def setup(self):
-        self.index = date_range(start='2000', freq='D', periods=1000)
-        self.panel = Panel(np.random.randn(100, len(self.index), 1000))
+    def setup(self, axis):
+        self.panel = Panel(np.random.randn(100, 1000, 100))
 
-    def time_pct_change_items(self):
-        self.panel.pct_change(1, axis='items')
+    def time_pct_change(self, axis):
+        self.panel.pct_change(1, axis=axis)
 
-    def time_pct_change_major(self):
-        self.panel.pct_change(1, axis='major')
-
-    def time_pct_change_minor(self):
-        self.panel.pct_change(1, axis='minor')
-
-    def time_shift(self):
-        self.panel.shift(1)
-
-    def time_shift_minor(self):
-        self.panel.shift(1, axis='minor')
+    def time_shift(self, axis):
+        self.panel.shift(1, axis=axis)


### PR DESCRIPTION
Flake8'd, `param`'d, and this benchmark was timing out on my machine so I scaled down the size of the Panel but should be representative of larger Panels

```
asv dev -b ^panel_methods
· Discovering benchmarks
· Running 2 total benchmarks (1 commits * 1 environments * 2 benchmarks)
[  0.00%] ·· Building for existing-py_home_matt_anaconda_envs_pandas_dev_bin_python
[  0.00%] ·· Benchmarking existing-py_home_matt_anaconda_envs_pandas_dev_bin_python
[ 50.00%] ··· Running panel_methods.PanelMethods.time_pct_change                                                                          ok
[ 50.00%] ···· 
               ======= =======
                 axis         
               ------- -------
                items   1.54s 
                major   1.39s 
                minor   1.41s 
               ======= =======

[100.00%] ··· Running panel_methods.PanelMethods.time_shift                                                                               ok
[100.00%] ···· 
               ======= =======
                 axis         
               ------- -------
                items   397μs 
                major   385μs 
                minor   390μs 
               ======= =======
``` 