### PR TITLE
CLN: ASV panel ctor

### DIFF
--- a/asv_bench/benchmarks/panel_ctor.py
+++ b/asv_bench/benchmarks/panel_ctor.py
@@ -1,65 +1,56 @@
-from .pandas_vb_common import *
-from datetime import timedelta
+from datetime import datetime, timedelta
+
+from pandas import DataFrame, DatetimeIndex, date_range
+
+from .pandas_vb_common import Panel, setup  # noqa
 
 
-class Constructors1(object):
+class DifferentIndexes(object):
     goal_time = 0.2
 
     def setup(self):
         self.data_frames = {}
-        self.start = datetime(1990, 1, 1)
-        self.end = datetime(2012, 1, 1)
+        start = datetime(1990, 1, 1)
+        end = datetime(2012, 1, 1)
         for x in range(100):
-            self.end += timedelta(days=1)
-            self.dr = np.asarray(date_range(self.start, self.end))
-            self.df = DataFrame({'a': ([0] * len(self.dr)), 'b': ([1] * len(self.dr)), 'c': ([2] * len(self.dr)), }, index=self.dr)
-            self.data_frames[x] = self.df
+            end += timedelta(days=1)
+            idx = date_range(start, end)
+            df = DataFrame({'a': 0, 'b': 1, 'c': 2}, index=idx)
+            self.data_frames[x] = df
 
-    def time_panel_from_dict_all_different_indexes(self):
+    def time_from_dict(self):
         Panel.from_dict(self.data_frames)
 
 
-class Constructors2(object):
+class SameIndexes(object):
+
     goal_time = 0.2
 
     def setup(self):
-        self.data_frames = {}
-        for x in range(100):
-            self.dr = np.asarray(DatetimeIndex(start=datetime(1990, 1, 1), end=datetime(2012, 1, 1), freq='D'))
-            self.df = DataFrame({'a': ([0] * len(self.dr)), 'b': ([1] * len(self.dr)), 'c': ([2] * len(self.dr)), }, index=self.dr)
-            self.data_frames[x] = self.df
+        idx = DatetimeIndex(start=datetime(1990, 1, 1),
+                            end=datetime(2012, 1, 1),
+                            freq='D')
+        df = DataFrame({'a': 0, 'b': 1, 'c': 2}, index=idx)
+        self.data_frames = dict(enumerate([df] * 100))
 
-    def time_panel_from_dict_equiv_indexes(self):
+    def time_from_dict(self):
         Panel.from_dict(self.data_frames)
 
 
-class Constructors3(object):
+class TwoIndexes(object):
+
     goal_time = 0.2
 
     def setup(self):
-        self.dr = np.asarray(DatetimeIndex(start=datetime(1990, 1, 1), end=datetime(2012, 1, 1), freq='D'))
-        self.data_frames = {}
-        for x in range(100):
-            self.df = DataFrame({'a': ([0] * len(self.dr)), 'b': ([1] * len(self.dr)), 'c': ([2] * len(self.dr)), }, index=self.dr)
-            self.data_frames[x] = self.df
+        start = datetime(1990, 1, 1)
+        end = datetime(2012, 1, 1)
+        df1 = DataFrame({'a': 0, 'b': 1, 'c': 2},
+                        index=DatetimeIndex(start=start, end=end, freq='D'))
+        end += timedelta(days=1)
+        df2 = DataFrame({'a': 0, 'b': 1, 'c': 2},
+                        index=DatetimeIndex(start=start, end=end, freq='D'))
+        dfs = [df1] * 50 + [df2] * 50
+        self.data_frames = dict(enumerate(dfs))
 
-    def time_panel_from_dict_same_index(self):
-        Panel.from_dict(self.data_frames)
-
-
-class Constructors4(object):
-    goal_time = 0.2
-
-    def setup(self):
-        self.data_frames = {}
-        self.start = datetime(1990, 1, 1)
-        self.end = datetime(2012, 1, 1)
-        for x in range(100):
-            if (x == 50):
-                self.end += timedelta(days=1)
-            self.dr = np.asarray(date_range(self.start, self.end))
-            self.df = DataFrame({'a': ([0] * len(self.dr)), 'b': ([1] * len(self.dr)), 'c': ([2] * len(self.dr)), }, index=self.dr)
-            self.data_frames[x] = self.df
-
-    def time_panel_from_dict_two_different_indexes(self):
+    def time_from_dict(self):
         Panel.from_dict(self.data_frames)


### PR DESCRIPTION
There were two benchmarks that were essentially the same (dictionary of dataframes with the same index benchmark), so I removed one along with the usual flake8.
```
$ asv dev -b ^panel_ctor
· Discovering benchmarks
· Running 3 total benchmarks (1 commits * 1 environments * 3 benchmarks)
[  0.00%] ·· Building for existing-py_home_matt_anaconda_envs_pandas_dev_bin_python
[  0.00%] ·· Benchmarking existing-py_home_matt_anaconda_envs_pandas_dev_bin_python
[ 33.33%] ··· Running panel_ctor.DifferentIndexes.time_from_dict          387ms
[ 66.67%] ··· Running panel_ctor.SameIndexes.time_from_dict              32.0ms
[100.00%] ··· Running panel_ctor.TwoIndexes.time_from_dict                105ms
```
