### PR TITLE
Fixing 3.6 Escape Sequence Deprecations in tests/io/parser/usecols.py

### DIFF
--- a/pandas/tests/io/parser/usecols.py
+++ b/pandas/tests/io/parser/usecols.py
@@ -492,11 +492,13 @@ a,b,c
         tm.assert_frame_equal(df, expected)
 
         usecols = ['a', 'b', 'c', 'f']
-        with tm.assert_raises_regex(ValueError, msg.format(missing=r"\['f'\]")):
+        with tm.assert_raises_regex(
+                ValueError, msg.format(missing=r"\['f'\]")):
             self.read_csv(StringIO(data), usecols=usecols)
 
         usecols = ['a', 'b', 'f']
-        with tm.assert_raises_regex(ValueError, msg.format(missing=r"\['f'\]")):
+        with tm.assert_raises_regex(
+                ValueError, msg.format(missing=r"\['f'\]")):
             self.read_csv(StringIO(data), usecols=usecols)
 
         usecols = ['a', 'b', 'f', 'g']
@@ -525,9 +527,11 @@ a,b,c
         # tm.assert_frame_equal(df, expected)
 
         usecols = ['A', 'B', 'C', 'f']
-        with tm.assert_raises_regex(ValueError, msg.format(missing=r"\['f'\]")):
+        with tm.assert_raises_regex(
+                ValueError, msg.format(missing=r"\['f'\]")):
             self.read_csv(StringIO(data), header=0, names=names,
                           usecols=usecols)
         usecols = ['A', 'B', 'f']
-        with tm.assert_raises_regex(ValueError, msg.format(missing=r"\['f'\]")):
+        with tm.assert_raises_regex(
+                ValueError, msg.format(missing=r"\['f'\]")):
             self.read_csv(StringIO(data), names=names, usecols=usecols)

--- a/pandas/tests/io/parser/usecols.py
+++ b/pandas/tests/io/parser/usecols.py
@@ -492,16 +492,16 @@ a,b,c
         tm.assert_frame_equal(df, expected)
 
         usecols = ['a', 'b', 'c', 'f']
-        with tm.assert_raises_regex(ValueError, msg.format(missing="\['f'\]")):
+        with tm.assert_raises_regex(ValueError, msg.format(missing=r"\['f'\]")):
             self.read_csv(StringIO(data), usecols=usecols)
 
         usecols = ['a', 'b', 'f']
-        with tm.assert_raises_regex(ValueError, msg.format(missing="\['f'\]")):
+        with tm.assert_raises_regex(ValueError, msg.format(missing=r"\['f'\]")):
             self.read_csv(StringIO(data), usecols=usecols)
 
         usecols = ['a', 'b', 'f', 'g']
         with tm.assert_raises_regex(
-                ValueError, msg.format(missing="\[('f', 'g'|'g', 'f')\]")):
+                ValueError, msg.format(missing=r"\[('f', 'g'|'g', 'f')\]")):
             self.read_csv(StringIO(data), usecols=usecols)
 
         names = ['A', 'B', 'C', 'D']
@@ -525,9 +525,9 @@ a,b,c
         # tm.assert_frame_equal(df, expected)
 
         usecols = ['A', 'B', 'C', 'f']
-        with tm.assert_raises_regex(ValueError, msg.format(missing="\['f'\]")):
+        with tm.assert_raises_regex(ValueError, msg.format(missing=r"\['f'\]")):
             self.read_csv(StringIO(data), header=0, names=names,
                           usecols=usecols)
         usecols = ['A', 'B', 'f']
-        with tm.assert_raises_regex(ValueError, msg.format(missing="\['f'\]")):
+        with tm.assert_raises_regex(ValueError, msg.format(missing=r"\['f'\]")):
             self.read_csv(StringIO(data), names=names, usecols=usecols)


### PR DESCRIPTION
@jreback [brought up some warnings](https://github.com/pandas-dev/pandas/pull/17310#issuecomment-353402586) on 3.6 that should be fixed by making the regex an r'string'.

Tests pass, happy to fix all the other occurrences, would need to know how to generate these warnings on my local machine though, as running the same pytest command as CI doesn't seem to bring them up for me.