### PR TITLE
CLN: Remove Timestamp.offset

### DIFF
--- a/doc/source/whatsnew/v0.23.0.txt
+++ b/doc/source/whatsnew/v0.23.0.txt
@@ -238,6 +238,7 @@ Removal of prior version deprecations/changes
 - :func:`read_csv` has dropped the ``as_recarray`` parameter (:issue:`13373`)
 - :func:`read_csv` has dropped the ``buffer_lines`` parameter (:issue:`13360`)
 - :func:`read_csv` has dropped the ``compact_ints`` and ``use_unsigned`` parameters (:issue:`13323`)
+- The ``Timestamp`` class has dropped the ``offset`` attribute in favor of ``freq`` (:issue:`13593`)
 
 .. _whatsnew_0230.performance:
 

--- a/pandas/_libs/tslibs/nattype.pyx
+++ b/pandas/_libs/tslibs/nattype.pyx
@@ -396,7 +396,7 @@ class NaTType(_NaT):
         """)
     fromordinal = _make_error_func('fromordinal',  # noqa:E128
         """
-        Timestamp.fromordinal(ordinal, freq=None, tz=None, offset=None)
+        Timestamp.fromordinal(ordinal, freq=None, tz=None)
 
         passed an ordinal, translate and convert to a ts
         note: by definition there cannot be any tz info on the ordinal itself
@@ -409,8 +409,6 @@ class NaTType(_NaT):
             Offset which Timestamp will have
         tz : str, pytz.timezone, dateutil.tz.tzfile or None
             Time zone for time which Timestamp will have.
-        offset : str, DateOffset
-            Deprecated, use freq
         """)
 
     # _nat_methods

--- a/pandas/_libs/tslibs/timestamps.pyx
+++ b/pandas/_libs/tslibs/timestamps.pyx
@@ -435,9 +435,9 @@ class Timestamp(_Timestamp):
     """
 
     @classmethod
-    def fromordinal(cls, ordinal, freq=None, tz=None, offset=None):
+    def fromordinal(cls, ordinal, freq=None, tz=None):
         """
-        Timestamp.fromordinal(ordinal, freq=None, tz=None, offset=None)
+        Timestamp.fromordinal(ordinal, freq=None, tz=None)
 
         passed an ordinal, translate and convert to a ts
         note: by definition there cannot be any tz info on the ordinal itself
@@ -450,11 +450,9 @@ class Timestamp(_Timestamp):
             Offset which Timestamp will have
         tz : str, pytz.timezone, dateutil.tz.tzfile or None
             Time zone for time which Timestamp will have.
-        offset : str, DateOffset
-            Deprecated, use freq
         """
         return cls(datetime.fromordinal(ordinal),
-                   freq=freq, tz=tz, offset=offset)
+                   freq=freq, tz=tz)
 
     @classmethod
     def now(cls, tz=None):
@@ -529,8 +527,7 @@ class Timestamp(_Timestamp):
                 object freq=None, tz=None, unit=None,
                 year=None, month=None, day=None,
                 hour=None, minute=None, second=None, microsecond=None,
-                tzinfo=None,
-                object offset=None):
+                tzinfo=None):
         # The parameter list folds together legacy parameter names (the first
         # four) and positional and keyword parameter names from pydatetime.
         #
@@ -553,15 +550,6 @@ class Timestamp(_Timestamp):
         # Mixing pydatetime positional and keyword arguments is forbidden!
 
         cdef _TSObject ts
-
-        if offset is not None:
-            # deprecate offset kwd in 0.19.0, GH13593
-            if freq is not None:
-                msg = "Can only specify freq or offset, not both"
-                raise TypeError(msg)
-            warnings.warn("offset is deprecated. Use freq instead",
-                          FutureWarning)
-            freq = offset
 
         if tzinfo is not None:
             if not PyTZInfo_Check(tzinfo):
@@ -675,12 +663,6 @@ class Timestamp(_Timestamp):
         Alias for tzinfo
         """
         return self.tzinfo
-
-    @property
-    def offset(self):
-        warnings.warn(".offset is deprecated. Use .freq instead",
-                      FutureWarning)
-        return self.freq
 
     def __setstate__(self, state):
         self.value = state[0]

--- a/pandas/tests/scalar/test_nat.py
+++ b/pandas/tests/scalar/test_nat.py
@@ -170,8 +170,9 @@ def test_NaT_docstrings():
     ts_missing = [x for x in ts_names if x not in nat_names and
                   not x.startswith('_')]
     ts_missing.sort()
-    ts_expected = ['freqstr', 'normalize', 'offset',
-                   'to_julian_date', 'to_period', 'tz']
+    ts_expected = ['freqstr', 'normalize',
+                   'to_julian_date',
+                   'to_period', 'tz']
     assert ts_missing == ts_expected
 
     ts_overlap = [x for x in nat_names if x in ts_names and

--- a/pandas/tests/scalar/test_timestamp.py
+++ b/pandas/tests/scalar/test_timestamp.py
@@ -307,36 +307,6 @@ class TestTimestampConstructors(object):
         ts = Timestamp.fromordinal(dt_tz.toordinal(), tz='US/Eastern')
         assert ts.to_pydatetime() == dt_tz
 
-    def test_constructor_offset_depr(self):
-        # see gh-12160
-        with tm.assert_produces_warning(FutureWarning,
-                                        check_stacklevel=False):
-            ts = Timestamp('2011-01-01', offset='D')
-        assert ts.freq == 'D'
-
-        with tm.assert_produces_warning(FutureWarning,
-                                        check_stacklevel=False):
-            assert ts.offset == 'D'
-
-        msg = "Can only specify freq or offset, not both"
-        with tm.assert_raises_regex(TypeError, msg):
-            Timestamp('2011-01-01', offset='D', freq='D')
-
-    def test_constructor_offset_depr_fromordinal(self):
-        # GH 12160
-        base = datetime(2000, 1, 1)
-
-        with tm.assert_produces_warning(FutureWarning,
-                                        check_stacklevel=False):
-            ts = Timestamp.fromordinal(base.toordinal(), offset='D')
-        assert Timestamp('2000-01-01') == ts
-        assert ts.freq == 'D'
-        assert base.toordinal() == ts.toordinal()
-
-        msg = "Can only specify freq or offset, not both"
-        with tm.assert_raises_regex(TypeError, msg):
-            Timestamp.fromordinal(base.toordinal(), offset='D', freq='D')
-
 
 class TestTimestamp(object):
 


### PR DESCRIPTION
Deprecated in v0.19.0

xref #13593
