### PR TITLE
CLN: ASV period

### DIFF
--- a/asv_bench/benchmarks/period.py
+++ b/asv_bench/benchmarks/period.py
@@ -1,61 +1,24 @@
-import pandas as pd
-from pandas import Series, Period, PeriodIndex, date_range
+from pandas import (DataFrame, Series, Period, PeriodIndex, date_range,
+                    period_range)
 
 
 class PeriodProperties(object):
-    params = ['M', 'min']
-    param_names = ['freq']
 
-    def setup(self, freq):
+    params = (['M', 'min'],
+              ['year', 'month', 'day', 'hour', 'minute', 'second',
+               'is_leap_year', 'quarter', 'qyear', 'week', 'daysinmonth',
+               'dayofweek', 'dayofyear', 'start_time', 'end_time'])
+    param_names = ['freq', 'attr']
+
+    def setup(self, freq, attr):
         self.per = Period('2012-06-01', freq=freq)
 
-    def time_year(self, freq):
-        self.per.year
-
-    def time_month(self, freq):
-        self.per.month
-
-    def time_day(self, freq):
-        self.per.day
-
-    def time_hour(self, freq):
-        self.per.hour
-
-    def time_minute(self, freq):
-        self.per.minute
-
-    def time_second(self, freq):
-        self.per.second
-
-    def time_is_leap_year(self, freq):
-        self.per.is_leap_year
-
-    def time_quarter(self, freq):
-        self.per.quarter
-
-    def time_qyear(self, freq):
-        self.per.qyear
-
-    def time_week(self, freq):
-        self.per.week
-
-    def time_daysinmonth(self, freq):
-        self.per.daysinmonth
-
-    def time_dayofweek(self, freq):
-        self.per.dayofweek
-
-    def time_dayofyear(self, freq):
-        self.per.dayofyear
-
-    def time_start_time(self, freq):
-        self.per.start_time
-
-    def time_end_time(self, freq):
-        self.per.end_time
+    def time_property(self, freq, attr):
+        getattr(self.per, attr)
 
 
 class PeriodUnaryMethods(object):
+
     params = ['M', 'min']
     param_names = ['freq']
 
@@ -73,6 +36,7 @@ class PeriodUnaryMethods(object):
 
 
 class PeriodIndexConstructor(object):
+
     goal_time = 0.2
 
     params = ['D']
@@ -90,19 +54,19 @@ class PeriodIndexConstructor(object):
 
 
 class DataFramePeriodColumn(object):
+
     goal_time = 0.2
 
-    def setup_cache(self):
-        rng = pd.period_range(start='1/1/1990', freq='S', periods=20000)
-        df = pd.DataFrame(index=range(len(rng)))
-        return rng, df
+    def setup(self):
+        self.rng = period_range(start='1/1/1990', freq='S', periods=20000)
+        self.df = DataFrame(index=range(len(self.rng)))
 
-    def time_setitem_period_column(self, tup):
-        rng, df = tup
-        df['col'] = rng
+    def time_setitem_period_column(self):
+        self.df['col'] = self.rng
 
 
 class Algorithms(object):
+
     goal_time = 0.2
 
     params = ['index', 'series']
@@ -125,6 +89,7 @@ class Algorithms(object):
 
 
 class Indexing(object):
+
     goal_time = 0.2
 
     def setup(self):
@@ -145,7 +110,7 @@ class Indexing(object):
         self.series.loc[self.period]
 
     def time_align(self):
-        pd.DataFrame({'a': self.series, 'b': self.series[:500]})
+        DataFrame({'a': self.series, 'b': self.series[:500]})
 
     def time_intersection(self):
         self.index[:750].intersection(self.index[250:])


### PR DESCRIPTION
- Utilized `param` for the  `PeriodProperties` benchmark

- Replaced `setup_cache` for just `setup` since only one benchmark was being run for that class. 
```
$ asv dev -b ^period
· Discovering benchmarks
· Running 15 total benchmarks (1 commits * 1 environments * 15 benchmarks)
[  0.00%] ·· Building for existing-py_home_matt_anaconda_envs_pandas_dev_bin_python
[  0.00%] ·· Benchmarking existing-py_home_matt_anaconda_envs_pandas_dev_bin_python
[  6.67%] ··· Running period.Algorithms.time_drop_duplicates                 ok
[  6.67%] ···· 
               ======== ========
                 typ            
               -------- --------
                index    777μs  
                series   7.47ms 
               ======== ========

[ 13.33%] ··· Running period.Algorithms.time_value_counts                    ok
[ 13.33%] ···· 
               ======== ========
                 typ            
               -------- --------
                index    1.33ms 
                series   7.94ms 
               ======== ========

[ 20.00%] ··· Running ...ramePeriodColumn.time_setitem_period_column     80.8ms
[ 26.67%] ··· Running period.Indexing.time_align                         2.57ms
[ 33.33%] ··· Running period.Indexing.time_get_loc                        211μs
[ 40.00%] ··· Running period.Indexing.time_intersection                   516μs
[ 46.67%] ··· Running period.Indexing.time_series_loc                     417μs
[ 53.33%] ··· Running period.Indexing.time_shallow_copy                  53.4μs
[ 60.00%] ··· Running period.Indexing.time_shape                         13.5μs
[ 66.67%] ··· Running ...PeriodIndexConstructor.time_from_date_range         ok
[ 66.67%] ···· 
               ====== =======
                freq         
               ------ -------
                 D     408μs 
               ====== =======

[ 73.33%] ··· Running ...PeriodIndexConstructor.time_from_pydatetime         ok
[ 73.33%] ···· 
               ====== ========
                freq          
               ------ --------
                 D     15.3ms 
               ====== ========

[ 80.00%] ··· Running period.PeriodProperties.time_property                  ok
[ 80.00%] ···· 
               ====== ============== ========
                freq       attr              
               ------ -------------- --------
                 M         year       17.5μs 
                 M        month       17.2μs 
                 M         day        17.4μs 
                 M         hour       17.4μs 
                 M        minute      17.6μs 
                 M        second      16.8μs 
                 M     is_leap_year   17.6μs 
                 M       quarter      17.1μs 
                 M        qyear       17.1μs 
                 M         week       17.8μs 
                 M     daysinmonth    17.7μs 
                 M      dayofweek     16.9μs 
                 M      dayofyear     17.4μs 
                 M      start_time    243μs  
                 M       end_time     263μs  
                min        year       17.4μs 
                min       month       18.5μs 
                min        day        18.1μs 
                min        hour       18.1μs 
                min       minute      18.2μs 
                min       second      18.1μs 
                min    is_leap_year   19.4μs 
                min      quarter      16.7μs 
                min       qyear       17.7μs 
                min        week       18.2μs 
                min    daysinmonth    18.4μs 
                min     dayofweek     18.2μs 
                min     dayofyear     18.2μs 
                min     start_time    242μs  
                min      end_time     260μs  
               ====== ============== ========

[ 86.67%] ··· Running period.PeriodUnaryMethods.time_asfreq                  ok
[ 86.67%] ···· 
               ====== =======
                freq         
               ------ -------
                 M     161μs 
                min    166μs 
               ====== =======

[ 93.33%] ··· Running period.PeriodUnaryMethods.time_now                     ok
[ 93.33%] ···· 
               ====== =======
                freq         
               ------ -------
                 M     128μs 
                min    224μs 
               ====== =======

[100.00%] ··· Running period.PeriodUnaryMethods.time_to_timestamp            ok
[100.00%] ···· 
               ====== =======
                freq         
               ------ -------
                 M     245μs 
                min    242μs 
               ====== =======
```
