### PR TITLE
ENH: Let Resampler objects have a pipe method

### DIFF
--- a/doc/source/api.rst
+++ b/doc/source/api.rst
@@ -2274,6 +2274,7 @@ Function application
    Resampler.apply
    Resampler.aggregate
    Resampler.transform
+   Resampler.pipe
 
 Upsampling
 ~~~~~~~~~~

--- a/doc/source/whatsnew/v0.23.0.txt
+++ b/doc/source/whatsnew/v0.23.0.txt
@@ -142,6 +142,8 @@ Other Enhancements
 - ``Categorical.rename_categories``, ``CategoricalIndex.rename_categories`` and :attr:`Series.cat.rename_categories`
   can now take a callable as their argument (:issue:`18862`)
 - :class:`Interval` and :class:`IntervalIndex` have gained a ``length`` attribute (:issue:`18789`)
+- ``Resampler`` objects now have a functioning :attr:`~pandas.core.resample.Resampler.pipe` method.
+  Previously, calls to ``pipe`` were diverted to  the ``mean`` method (:issue:`17905`).
 
 .. _whatsnew_0230.api_breaking:
 

--- a/pandas/core/resample.py
+++ b/pandas/core/resample.py
@@ -8,7 +8,8 @@ import pandas as pd
 from pandas.core.base import AbstractMethodError, GroupByMixin
 
 from pandas.core.groupby import (BinGrouper, Grouper, _GroupBy, GroupBy,
-                                 SeriesGroupBy, groupby, PanelGroupBy)
+                                 SeriesGroupBy, groupby, PanelGroupBy,
+                                 _pipe_template)
 
 from pandas.tseries.frequencies import to_offset, is_subperiod, is_superperiod
 from pandas.core.indexes.datetimes import DatetimeIndex, date_range
@@ -26,7 +27,7 @@ from pandas._libs import lib, tslib
 from pandas._libs.lib import Timestamp
 from pandas._libs.tslibs.period import IncompatibleFrequency
 
-from pandas.util._decorators import Appender
+from pandas.util._decorators import Appender, Substitution
 from pandas.core.generic import _shared_docs
 _shared_docs_kwargs = dict()
 
@@ -256,6 +257,29 @@ class Resampler(_GroupBy):
     def _assure_grouper(self):
         """ make sure that we are creating our binner & grouper """
         self._set_binner()
+
+    @Substitution(klass='Resampler',
+                  versionadded='.. versionadded:: 0.23.0',
+                  examples="""
+>>> df = pd.DataFrame({'A': [1, 2, 3, 4]},
+...                   index=pd.date_range('2012-08-02', periods=4))
+>>> df
+            A
+2012-08-02  1
+2012-08-03  2
+2012-08-04  3
+2012-08-05  4
+
+To get the difference between each 2-day period's maximum and minimum value in
+one pass, you can do
+
+>>> df.resample('2D').pipe(lambda x: x.max() - x.min())
+            A
+2012-08-02  1
+2012-08-04  1""")
+    @Appender(_pipe_template)
+    def pipe(self, func, *args, **kwargs):
+        return super(Resampler, self).pipe(func, *args, **kwargs)
 
     def plot(self, *args, **kwargs):
         # for compat with prior versions, we want to

--- a/pandas/tests/test_resample.py
+++ b/pandas/tests/test_resample.py
@@ -235,6 +235,21 @@ class TestResampleAPI(object):
         result = df.groupby('key').resample('D', on='dates').mean()
         assert_frame_equal(result, expected)
 
+    def test_pipe(self):
+        # GH17905
+
+        # series
+        r = self.series.resample('H')
+        expected = r.max() - r.mean()
+        result = r.pipe(lambda x: x.max() - x.mean())
+        tm.assert_series_equal(result, expected)
+
+        # dataframe
+        r = self.frame.resample('H')
+        expected = r.max() - r.mean()
+        result = r.pipe(lambda x: x.max() - x.mean())
+        tm.assert_frame_equal(result, expected)
+
     @td.skip_if_no_mpl
     def test_plot_api(self):
         # .resample(....).plot(...)


### PR DESCRIPTION
- [x] closes #17905
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry

Currently, calls to ``df.resample(....).pipe(...)`` are converted to ``df.resample(....).mean().pipe(...)`` and a warning is emitted (see #17905).

This PR solves this by moving the ``pipe`` method from the ``GroupBy`` class to the ``_GroupBy`` class. As ``_GroupBy`` is a common parent class of both ``GroupBy`` and ``Resampler``, the ``pipe`` method is now available for ``Resampler`` too.

See also #17871.