### PR TITLE
CLN: Drop the .reshape method from classes

### DIFF
--- a/doc/source/whatsnew/v0.23.0.txt
+++ b/doc/source/whatsnew/v0.23.0.txt
@@ -241,6 +241,7 @@ Removal of prior version deprecations/changes
 - :func:`read_csv` has dropped the ``buffer_lines`` parameter (:issue:`13360`)
 - :func:`read_csv` has dropped the ``compact_ints`` and ``use_unsigned`` parameters (:issue:`13323`)
 - The ``Timestamp`` class has dropped the ``offset`` attribute in favor of ``freq`` (:issue:`13593`)
+- The ``Series``, ``Categorical``, and ``Index`` classes have dropped the ``reshape`` method (:issue:`13012`)
 
 .. _whatsnew_0230.performance:
 

--- a/pandas/core/categorical.py
+++ b/pandas/core/categorical.py
@@ -471,32 +471,6 @@ class Categorical(PandasObject):
             return [_maybe_box_datetimelike(x) for x in self]
         return np.array(self).tolist()
 
-    def reshape(self, new_shape, *args, **kwargs):
-        """
-        .. deprecated:: 0.19.0
-           Calling this method will raise an error in a future release.
-
-        An ndarray-compatible method that returns `self` because
-        `Categorical` instances cannot actually be reshaped.
-
-        Parameters
-        ----------
-        new_shape : int or tuple of ints
-            A 1-D array of integers that correspond to the new
-            shape of the `Categorical`. For more information on
-            the parameter, please refer to `np.reshape`.
-        """
-        warn("reshape is deprecated and will raise "
-             "in a subsequent release", FutureWarning, stacklevel=2)
-
-        nv.validate_reshape(args, kwargs)
-
-        # while the 'new_shape' parameter has no effect,
-        # we should still enforce valid shape parameters
-        np.reshape(self.codes, new_shape)
-
-        return self
-
     @property
     def base(self):
         """ compat, we are always our own object """

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -1190,16 +1190,6 @@ class Index(IndexOpsMixin, PandasObject):
         """
         return self.set_names([name], inplace=inplace)
 
-    def reshape(self, *args, **kwargs):
-        """
-        NOT IMPLEMENTED: do not call this method, as reshaping is not
-        supported for Index objects and will raise an error.
-
-        Reshape an Index.
-        """
-        raise NotImplementedError("reshaping is not supported "
-                                  "for Index objects")
-
     @property
     def _has_complex_internals(self):
         # to disable groupby tricks in MultiIndex

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -910,37 +910,6 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
         return self._constructor(new_values,
                                  index=new_index).__finalize__(self)
 
-    def reshape(self, *args, **kwargs):
-        """
-        .. deprecated:: 0.19.0
-           Calling this method will raise an error. Please call
-           ``.values.reshape(...)`` instead.
-
-        return an ndarray with the values shape
-        if the specified shape matches exactly the current shape, then
-        return self (for compat)
-
-        See also
-        --------
-        numpy.ndarray.reshape
-        """
-        warnings.warn("reshape is deprecated and will raise "
-                      "in a subsequent release. Please use "
-                      ".values.reshape(...) instead", FutureWarning,
-                      stacklevel=2)
-
-        if len(args) == 1 and hasattr(args[0], '__iter__'):
-            shape = args[0]
-        else:
-            shape = args
-
-        if tuple(shape) == self.shape:
-            # XXX ignoring the "order" keyword.
-            nv.validate_reshape(tuple(), kwargs)
-            return self
-
-        return self._values.reshape(shape, **kwargs)
-
     def get_value(self, label, takeable=False):
         """
         Quickly retrieve single value at passed index label

--- a/pandas/tests/indexes/test_base.py
+++ b/pandas/tests/indexes/test_base.py
@@ -1684,12 +1684,6 @@ class TestIndex(Base):
         with pytest.raises(IndexError):
             idx.take(np.array([1, -5]))
 
-    def test_reshape_raise(self):
-        msg = "reshaping is not supported"
-        idx = pd.Index([0, 1, 2])
-        tm.assert_raises_regex(NotImplementedError, msg,
-                               idx.reshape, idx.shape)
-
     def test_reindex_preserves_name_if_target_is_list_or_ndarray(self):
         # GH6552
         idx = pd.Index([0, 1, 2])

--- a/pandas/tests/reshape/test_reshape.py
+++ b/pandas/tests/reshape/test_reshape.py
@@ -476,41 +476,6 @@ class TestCategoricalReshape(object):
                              index=p.major_axis.set_names('major'))
         tm.assert_frame_equal(result, expected)
 
-    def test_reshape_categorical(self):
-        cat = Categorical([], categories=["a", "b"])
-        tm.assert_produces_warning(FutureWarning, cat.reshape, 0)
-
-        with tm.assert_produces_warning(FutureWarning):
-            cat = Categorical([], categories=["a", "b"])
-            tm.assert_categorical_equal(cat.reshape(0), cat)
-
-        with tm.assert_produces_warning(FutureWarning):
-            cat = Categorical([], categories=["a", "b"])
-            tm.assert_categorical_equal(cat.reshape((5, -1)), cat)
-
-        with tm.assert_produces_warning(FutureWarning):
-            cat = Categorical(["a", "b"], categories=["a", "b"])
-            tm.assert_categorical_equal(cat.reshape(cat.shape), cat)
-
-        with tm.assert_produces_warning(FutureWarning):
-            cat = Categorical(["a", "b"], categories=["a", "b"])
-            tm.assert_categorical_equal(cat.reshape(cat.size), cat)
-
-        with tm.assert_produces_warning(FutureWarning, check_stacklevel=False):
-            msg = "can only specify one unknown dimension"
-            cat = Categorical(["a", "b"], categories=["a", "b"])
-            tm.assert_raises_regex(ValueError, msg, cat.reshape, (-2, -1))
-
-    def test_reshape_categorical_numpy(self):
-        with tm.assert_produces_warning(FutureWarning, check_stacklevel=False):
-            cat = Categorical(["a", "b"], categories=["a", "b"])
-            tm.assert_categorical_equal(np.reshape(cat, cat.shape), cat)
-
-        with tm.assert_produces_warning(FutureWarning, check_stacklevel=False):
-            msg = "the 'order' parameter is not supported"
-            tm.assert_raises_regex(ValueError, msg, np.reshape,
-                                   cat, cat.shape, order='F')
-
 
 class TestMakeAxisDummies(object):
 

--- a/pandas/tests/series/test_analytics.py
+++ b/pandas/tests/series/test_analytics.py
@@ -1542,66 +1542,6 @@ class TestSeriesAnalytics(TestData):
         assert_index_equal(s.values.categories, sp1.values.categories)
         assert_index_equal(s.values.categories, sn2.values.categories)
 
-    def test_reshape_deprecate(self):
-        x = Series(np.random.random(10), name='x')
-        tm.assert_produces_warning(FutureWarning, x.reshape, x.shape)
-
-    def test_reshape_non_2d(self):
-        # see gh-4554
-        with tm.assert_produces_warning(FutureWarning):
-            x = Series(np.random.random(201), name='x')
-            assert x.reshape(x.shape, ) is x
-
-        # see gh-2719
-        with tm.assert_produces_warning(FutureWarning):
-            a = Series([1, 2, 3, 4])
-            result = a.reshape(2, 2)
-            expected = a.values.reshape(2, 2)
-            tm.assert_numpy_array_equal(result, expected)
-            assert isinstance(result, type(expected))
-
-    def test_reshape_2d_return_array(self):
-        x = Series(np.random.random(201), name='x')
-
-        with tm.assert_produces_warning(FutureWarning):
-            result = x.reshape((-1, 1))
-            assert not isinstance(result, Series)
-
-        with tm.assert_produces_warning(FutureWarning, check_stacklevel=False):
-            result2 = np.reshape(x, (-1, 1))
-            assert not isinstance(result2, Series)
-
-        with tm.assert_produces_warning(FutureWarning):
-            result = x[:, None]
-            expected = x.reshape((-1, 1))
-            tm.assert_almost_equal(result, expected)
-
-    def test_reshape_bad_kwarg(self):
-        a = Series([1, 2, 3, 4])
-
-        with tm.assert_produces_warning(FutureWarning, check_stacklevel=False):
-            msg = "'foo' is an invalid keyword argument for this function"
-            tm.assert_raises_regex(
-                TypeError, msg, a.reshape, (2, 2), foo=2)
-
-        with tm.assert_produces_warning(FutureWarning, check_stacklevel=False):
-            msg = r"reshape\(\) got an unexpected keyword argument 'foo'"
-            tm.assert_raises_regex(
-                TypeError, msg, a.reshape, a.shape, foo=2)
-
-    def test_numpy_reshape(self):
-        a = Series([1, 2, 3, 4])
-
-        with tm.assert_produces_warning(FutureWarning, check_stacklevel=False):
-            result = np.reshape(a, (2, 2))
-            expected = a.values.reshape(2, 2)
-            tm.assert_numpy_array_equal(result, expected)
-            assert isinstance(result, type(expected))
-
-        with tm.assert_produces_warning(FutureWarning, check_stacklevel=False):
-            result = np.reshape(a, a.shape)
-            tm.assert_series_equal(result, a)
-
     def test_unstack(self):
         from numpy import nan
 


### PR DESCRIPTION
Remove the method for Series, Categorical, and Index. Deprecated or errored in v0.19.0

xref #13012