### PR TITLE
DOC: Link to Python 3 versions of official Python docs

### DIFF
--- a/doc/source/basics.rst
+++ b/doc/source/basics.rst
@@ -1728,7 +1728,7 @@ built-in string methods. For example:
 
 Powerful pattern-matching methods are provided as well, but note that
 pattern-matching generally uses `regular expressions
-<https://docs.python.org/2/library/re.html>`__ by default (and in some cases
+<https://docs.python.org/3/library/re.html>`__ by default (and in some cases
 always uses them).
 
 Please see :ref:`Vectorized String Methods <text.string_methods>` for a complete

--- a/doc/source/enhancingperf.rst
+++ b/doc/source/enhancingperf.rst
@@ -468,8 +468,8 @@ This Python syntax is **not** allowed:
 
 * Statements
 
-  - Neither `simple <http://docs.python.org/2/reference/simple_stmts.html>`__
-    nor `compound <http://docs.python.org/2/reference/compound_stmts.html>`__
+  - Neither `simple <https://docs.python.org/3/reference/simple_stmts.html>`__
+    nor `compound <https://docs.python.org/3/reference/compound_stmts.html>`__
     statements are allowed. This includes things like ``for``, ``while``, and
     ``if``.
 

--- a/doc/source/indexing.rst
+++ b/doc/source/indexing.rst
@@ -232,7 +232,7 @@ as an attribute:
 
    - You can use this access only if the index element is a valid python identifier, e.g. ``s.1`` is not allowed.
      See `here for an explanation of valid identifiers
-     <http://docs.python.org/2.7/reference/lexical_analysis.html#identifiers>`__.
+     <https://docs.python.org/3/reference/lexical_analysis.html#identifiers>`__.
 
    - The attribute will not be available if it conflicts with an existing method name, e.g. ``s.min`` is not allowed.
 

--- a/doc/source/install.rst
+++ b/doc/source/install.rst
@@ -234,7 +234,7 @@ Optional Dependencies
 
   * `psycopg2 <http://initd.org/psycopg/>`__: for PostgreSQL
   * `pymysql <https://github.com/PyMySQL/PyMySQL>`__: for MySQL.
-  * `SQLite <https://docs.python.org/3.5/library/sqlite3.html>`__: for SQLite, this is included in Python's standard library by default.
+  * `SQLite <https://docs.python.org/3/library/sqlite3.html>`__: for SQLite, this is included in Python's standard library by default.
 
 * `matplotlib <http://matplotlib.org/>`__: for plotting, Version 1.4.3 or higher.
 * For Excel I/O:

--- a/doc/source/io.rst
+++ b/doc/source/io.rst
@@ -3065,7 +3065,7 @@ any pickled pandas object (or any other pickled object) from file:
 
    Loading pickled data received from untrusted sources can be unsafe.
 
-   See: https://docs.python.org/3.6/library/pickle.html
+   See: https://docs.python.org/3/library/pickle.html
 
 .. warning::
 
@@ -4545,7 +4545,7 @@ facilitate data retrieval and to reduce dependency on DB-specific API. Database 
 is provided by SQLAlchemy if installed. In addition you will need a driver library for
 your database. Examples of such drivers are `psycopg2 <http://initd.org/psycopg/>`__
 for PostgreSQL or `pymysql <https://github.com/PyMySQL/PyMySQL>`__ for MySQL.
-For `SQLite <https://docs.python.org/3.5/library/sqlite3.html>`__ this is
+For `SQLite <https://docs.python.org/3/library/sqlite3.html>`__ this is
 included in Python's standard library by default.
 You can find an overview of supported drivers for each SQL dialect in the
 `SQLAlchemy docs <http://docs.sqlalchemy.org/en/latest/dialects/index.html>`__.

--- a/doc/source/missing_data.rst
+++ b/doc/source/missing_data.rst
@@ -559,7 +559,7 @@ String/Regular Expression Replacement
    backslashes than strings without this prefix. Backslashes in raw strings
    will be interpreted as an escaped backslash, e.g., ``r'\' == '\\'``. You
    should `read about them
-   <http://docs.python.org/2/reference/lexical_analysis.html#string-literals>`__
+   <https://docs.python.org/3/reference/lexical_analysis.html#string-literals>`__
    if this is unclear.
 
 Replace the '.' with ``NaN`` (str -> str)

--- a/doc/source/text.rst
+++ b/doc/source/text.rst
@@ -119,7 +119,7 @@ i.e., from the end of the string to the beginning of the string:
    s2.str.rsplit('_', expand=True, n=1)
 
 Methods like ``replace`` and ``findall`` take `regular expressions
-<https://docs.python.org/2/library/re.html>`__, too:
+<https://docs.python.org/3/library/re.html>`__, too:
 
 .. ipython:: python
 
@@ -221,7 +221,7 @@ Extract first match in each subject (extract)
    confusing from the perspective of a user.
 
 The ``extract`` method accepts a `regular expression
-<https://docs.python.org/2/library/re.html>`__ with at least one
+<https://docs.python.org/3/library/re.html>`__ with at least one
 capture group.
 
 Extracting a regular expression with more than one group returns a

--- a/pandas/_libs/tslibs/ccalendar.pyx
+++ b/pandas/_libs/tslibs/ccalendar.pyx
@@ -94,7 +94,7 @@ cdef int dayofweek(int y, int m, int d) nogil:
 
     See Also
     --------
-    [1] https://docs.python.org/3.6/library/calendar.html#calendar.weekday
+    [1] https://docs.python.org/3/library/calendar.html#calendar.weekday
 
     [2] https://en.wikipedia.org/wiki/\
     Determination_of_the_day_of_the_week#Sakamoto.27s_methods

--- a/pandas/core/computation/eval.py
+++ b/pandas/core/computation/eval.py
@@ -169,9 +169,9 @@ def eval(expr, parser='pandas', engine=None, truediv=True,
     expr : str or unicode
         The expression to evaluate. This string cannot contain any Python
         `statements
-        <http://docs.python.org/2/reference/simple_stmts.html#simple-statements>`__,
+        <https://docs.python.org/3/reference/simple_stmts.html#simple-statements>`__,
         only Python `expressions
-        <http://docs.python.org/2/reference/simple_stmts.html#expression-statements>`__.
+        <https://docs.python.org/3/reference/simple_stmts.html#expression-statements>`__.
     parser : string, default 'pandas', {'pandas', 'python'}
         The parser to use to construct the syntax tree from the expression. The
         default of ``'pandas'`` parses code slightly different than standard

--- a/pandas/core/indexes/datetimelike.py
+++ b/pandas/core/indexes/datetimelike.py
@@ -65,7 +65,7 @@ class DatelikeOps(object):
     Returns
     -------
     ndarray of formatted strings
-    """.format("https://docs.python.org/2/library/datetime.html"
+    """.format("https://docs.python.org/3/library/datetime.html"
                "#strftime-and-strptime-behavior")
 
 

--- a/pandas/io/pickle.py
+++ b/pandas/io/pickle.py
@@ -54,7 +54,7 @@ def read_pickle(path, compression='infer'):
     file path
 
     Warning: Loading pickled data received from untrusted sources can be
-    unsafe. See: http://docs.python.org/2.7/library/pickle.html
+    unsafe. See: https://docs.python.org/3/library/pickle.html
 
     Parameters
     ----------

--- a/pandas/tests/io/formats/test_format.py
+++ b/pandas/tests/io/formats/test_format.py
@@ -254,8 +254,7 @@ class TestDataFrameFormatting(object):
         tm.assert_series_equal(Series(res), Series(idx))
 
     def test_repr_should_return_str(self):
-        # http://docs.python.org/py3k/reference/datamodel.html#object.__repr__
-        # http://docs.python.org/reference/datamodel.html#object.__repr__
+        # https://docs.python.org/3/reference/datamodel.html#object.__repr__
         # "...The return value must be a string object."
 
         # (str on py2.x, str (unicode) on py3)

--- a/pandas/tests/series/test_repr.py
+++ b/pandas/tests/series/test_repr.py
@@ -140,8 +140,7 @@ class TestSeriesRepr(TestData):
         repr(s)
 
     def test_repr_should_return_str(self):
-        # http://docs.python.org/py3k/reference/datamodel.html#object.__repr__
-        # http://docs.python.org/reference/datamodel.html#object.__repr__
+        # https://docs.python.org/3/reference/datamodel.html#object.__repr__
         # ...The return value must be a string object.
 
         # (str on py2.x, str (unicode) on py3)


### PR DESCRIPTION
- [X] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`

Went through and made sure that all links to the official Python docs start with `https://docs.python.org/3/` to ensure that the links go to the most recent stable version of Python 3.