### PR TITLE
Cleanup Series arithmetic tests

### DIFF
--- a/pandas/tests/indexes/timedeltas/test_arithmetic.py
+++ b/pandas/tests/indexes/timedeltas/test_arithmetic.py
@@ -60,7 +60,7 @@ class TestTimedeltaIndexArithmetic(object):
         expected = TimedeltaIndex(np.arange(5, dtype='int64') ** 2)
         tm.assert_index_equal(result, expected)
 
-    # FIXME: These ops should return Series, NOT indexes
+    # TODO: These ops should return Series, NOT indexes
     def test_tdi_mul_intSeries(self):
         idx = TimedeltaIndex(np.arange(5, dtype='int64'))
         expected = TimedeltaIndex(np.arange(5, dtype='int64') ** 2)


### PR DESCRIPTION
Also a few for TimedeltaIndex.  One of the TimedeltaIndex tests specifically tests a behavior I think is wrong, #18963.  Actually _fixing_ that bug is separate.

Actual content of tests is unchanged.