### PR TITLE
ENH: is_scalar returns True for DateOffset objects

### DIFF
--- a/doc/source/whatsnew/v0.23.0.txt
+++ b/doc/source/whatsnew/v0.23.0.txt
@@ -144,6 +144,7 @@ Other Enhancements
 - :class:`Interval` and :class:`IntervalIndex` have gained a ``length`` attribute (:issue:`18789`)
 - ``Resampler`` objects now have a functioning :attr:`~pandas.core.resample.Resampler.pipe` method.
   Previously, calls to ``pipe`` were diverted to  the ``mean`` method (:issue:`17905`).
+- :func:`~pandas.api.types.is_scalar` now returns ``True`` for ``DateOffset`` objects (:issue:`18943`).
 
 .. _whatsnew_0230.api_breaking:
 

--- a/pandas/_libs/lib.pyx
+++ b/pandas/_libs/lib.pyx
@@ -112,6 +112,7 @@ cpdef bint isscalar(object val):
     - Period
     - instances of decimal.Decimal
     - Interval
+    - DateOffset
 
     """
 
@@ -126,7 +127,8 @@ cpdef bint isscalar(object val):
             or PyTime_Check(val)
             or util.is_period_object(val)
             or is_decimal(val)
-            or is_interval(val))
+            or is_interval(val)
+            or is_offset(val))
 
 
 def item_from_zerodim(object val):

--- a/pandas/_libs/src/inference.pyx
+++ b/pandas/_libs/src/inference.pyx
@@ -45,6 +45,8 @@ cpdef bint is_period(object val):
     """ Return a boolean if this is a Period object """
     return util.is_period_object(val)
 
+cdef inline bint is_offset(object val):
+    return getattr(val, '_typ', '_typ') == 'dateoffset'
 
 _TYPE_MAP = {
     'categorical': 'categorical',

--- a/pandas/tests/dtypes/test_inference.py
+++ b/pandas/tests/dtypes/test_inference.py
@@ -18,7 +18,8 @@ import pandas as pd
 from pandas._libs import tslib, lib, missing as libmissing
 from pandas import (Series, Index, DataFrame, Timedelta,
                     DatetimeIndex, TimedeltaIndex, Timestamp,
-                    Panel, Period, Categorical, isna)
+                    Panel, Period, Categorical, isna, Interval,
+                    DateOffset)
 from pandas.compat import u, PY2, PY3, StringIO, lrange
 from pandas.core.dtypes import inference
 from pandas.core.dtypes.common import (
@@ -1151,6 +1152,8 @@ class Testisscalar(object):
         assert is_scalar(Timestamp('2014-01-01'))
         assert is_scalar(Timedelta(hours=1))
         assert is_scalar(Period('2014-01-01'))
+        assert is_scalar(Interval(left=0, right=1))
+        assert is_scalar(DateOffset(days=1))
 
     def test_lisscalar_pandas_containers(self):
         assert not is_scalar(Series())


### PR DESCRIPTION
- [x] closes #18943
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry

I've implemented `is_offset` identically to `is_period_object` and added it to `isscalar` and `is_scalar` is now returning true for DateOffsets. 

But not sure how to go about this exactly:
> `is_offset` should also be imported / tested in `pandas/core/dtypes/common.py`

The other "is" functions that are explicitly imported from inference `is_string_like` and `is_list_like` are used for testing but don't look like they themselves are being tested so I'm not sure what kind of test is needed. The rest of the "is" functions are imported with a wildcard but pylint is telling me they are not used (should I go through and make the required imports explicit?).




