### PR TITLE
TST: Remove pow test in expressions

### DIFF
--- a/ci/install_travis.sh
+++ b/ci/install_travis.sh
@@ -56,11 +56,6 @@ if [ "$CONDA_BUILD_TEST" ]; then
     conda install conda-build
 fi
 
-# TODO(jreback)
-echo
-echo "[fix conda version]"
-conda install conda=4.3.30
-
 echo
 echo "[add channels]"
 conda config --remove channels defaults || exit 1

--- a/pandas/tests/test_expressions.py
+++ b/pandas/tests/test_expressions.py
@@ -73,16 +73,10 @@ class TestExpressions(object):
     def run_arithmetic(self, df, other, assert_func, check_dtype=False,
                        test_flex=True):
         expr._MIN_ELEMENTS = 0
-        operations = ['add', 'sub', 'mul', 'mod', 'truediv', 'floordiv', 'pow']
+        operations = ['add', 'sub', 'mul', 'mod', 'truediv', 'floordiv']
         if not compat.PY3:
             operations.append('div')
         for arith in operations:
-
-            # numpy >= 1.11 doesn't handle integers
-            # raised to integer powers
-            # https://github.com/pandas-dev/pandas/issues/15363
-            if arith == 'pow' and not _np_version_under1p11:
-                continue
 
             operator_name = arith
             if arith == 'div':


### PR DESCRIPTION
These are already skipped for NumPy>=1.12, and buggy for NumPy
1.10.4

cc @jreback 

This will be backported.

closes #18992 