### PR TITLE
Fix IntervalDtype Bugs and Inconsistencies

### DIFF
--- a/doc/source/whatsnew/v0.23.0.txt
+++ b/doc/source/whatsnew/v0.23.0.txt
@@ -270,6 +270,7 @@ Other API Changes
 - Subtraction of :class:`Series` with timezone-aware ``dtype='datetime64[ns]'`` with mis-matched timezones will raise ``TypeError`` instead of ``ValueError`` (issue:`18817`)
 - :class:`IntervalIndex` and ``IntervalDtype`` no longer support categorical, object, and string subtypes (:issue:`19016`)
 - The default ``Timedelta`` constructor now accepts an ``ISO 8601 Duration`` string as an argument (:issue:`19040`)
+- ``IntervalDtype`` now returns ``True`` when compared against ``'interval'`` regardless of subtype, and ``IntervalDtype.name`` now returns ``'interval'`` regardless of subtype (:issue:`18980`)
 
 .. _whatsnew_0230.deprecations:
 
@@ -377,7 +378,7 @@ Conversion
 - Fixed bug where comparing :class:`DatetimeIndex` failed to raise ``TypeError`` when attempting to compare timezone-aware and timezone-naive datetimelike objects (:issue:`18162`)
 - Bug in :class:`DatetimeIndex` where the repr was not showing high-precision time values at the end of a day (e.g., 23:59:59.999999999) (:issue:`19030`)
 - Bug where dividing a scalar timedelta-like object with :class:`TimedeltaIndex` performed the reciprocal operation (:issue:`19125`)
--
+- Bug in ``IntervalDtype`` when constructing two instances with subtype ``CategoricalDtype`` where the second instance used cached attributes from the first (:issue:`18980`)
 
 Indexing
 ^^^^^^^^

--- a/doc/source/whatsnew/v0.23.0.txt
+++ b/doc/source/whatsnew/v0.23.0.txt
@@ -378,7 +378,7 @@ Conversion
 - Fixed bug where comparing :class:`DatetimeIndex` failed to raise ``TypeError`` when attempting to compare timezone-aware and timezone-naive datetimelike objects (:issue:`18162`)
 - Bug in :class:`DatetimeIndex` where the repr was not showing high-precision time values at the end of a day (e.g., 23:59:59.999999999) (:issue:`19030`)
 - Bug where dividing a scalar timedelta-like object with :class:`TimedeltaIndex` performed the reciprocal operation (:issue:`19125`)
-- Bug in ``IntervalDtype`` when constructing two instances with subtype ``CategoricalDtype`` where the second instance used cached attributes from the first (:issue:`18980`)
+-
 
 Indexing
 ^^^^^^^^

--- a/pandas/tests/dtypes/test_dtypes.py
+++ b/pandas/tests/dtypes/test_dtypes.py
@@ -458,7 +458,7 @@ class TestIntervalDtype(Base):
         assert i.subtype == np.dtype('int64')
         assert is_interval_dtype(i)
 
-    @pytest.mark.parametrize('subtype', [None, 'interval', 'interval[]'])
+    @pytest.mark.parametrize('subtype', [None, 'interval', 'Interval'])
     def test_construction_generic(self, subtype):
         # generic
         i = IntervalDtype(subtype)
@@ -535,8 +535,8 @@ class TestIntervalDtype(Base):
                                   IntervalDtype('float64'))
 
     @pytest.mark.parametrize('subtype', [
-        None, 'interval', 'interval[]', 'int64', 'uint64', 'float64', object,
-        CategoricalDtype(), 'datetime64', 'timedelta64', PeriodDtype('Q')])
+        None, 'interval', 'Interval', 'int64', 'uint64', 'float64',
+        'complex128', 'datetime64', 'timedelta64', PeriodDtype('Q')])
     def test_equality_generic(self, subtype):
         # GH 18980
         dtype = IntervalDtype(subtype)
@@ -544,8 +544,8 @@ class TestIntervalDtype(Base):
         assert is_dtype_equal(dtype, IntervalDtype())
 
     @pytest.mark.parametrize('subtype', [
-        'int64', 'uint64', 'float64', 'complex128', np.dtype('O'),
-        CategoricalDtype(), 'datetime64', 'timedelta64', PeriodDtype('Q')])
+        'int64', 'uint64', 'float64', 'complex128', 'datetime64',
+        'timedelta64', PeriodDtype('Q')])
     def test_name_repr(self, subtype):
         # GH 18980
         dtype = IntervalDtype(subtype)
@@ -553,7 +553,7 @@ class TestIntervalDtype(Base):
         assert str(dtype) == expected
         assert dtype.name == 'interval'
 
-    @pytest.mark.parametrize('subtype', [None, 'interval', 'interval[]'])
+    @pytest.mark.parametrize('subtype', [None, 'interval', 'Interval'])
     def test_name_repr_generic(self, subtype):
         # GH 18980
         dtype = IntervalDtype(subtype)
@@ -599,15 +599,6 @@ class TestIntervalDtype(Base):
         IntervalDtype.reset_cache()
         tm.round_trip_pickle(dtype)
         assert len(IntervalDtype._cache) == 0
-
-    def test_caching_categoricaldtype(self):
-        # GH 18980
-        cdt1 = CategoricalDtype(list('abc'), True)
-        cdt2 = CategoricalDtype(list('wxyz'), False)
-        idt1 = IntervalDtype(cdt1)
-        idt2 = IntervalDtype(cdt2)
-        assert idt1.subtype is cdt1
-        assert idt2.subtype is cdt2
 
 
 class TestCategoricalDtypeParametrized(object):

--- a/pandas/tests/dtypes/test_dtypes.py
+++ b/pandas/tests/dtypes/test_dtypes.py
@@ -433,7 +433,7 @@ class TestIntervalDtype(Base):
         assert dtype2 == dtype
         assert dtype3 == dtype
         assert dtype is dtype2
-        assert dtype2 is dtype
+        assert dtype2 is dtype3
         assert dtype3 is dtype
         assert hash(dtype) == hash(dtype2)
         assert hash(dtype) == hash(dtype3)
@@ -451,14 +451,19 @@ class TestIntervalDtype(Base):
         assert hash(dtype2) == hash(dtype2)
         assert hash(dtype2) == hash(dtype3)
 
-    def test_construction(self):
-        with pytest.raises(ValueError):
-            IntervalDtype('xx')
+    @pytest.mark.parametrize('subtype', [
+        'interval[int64]', 'Interval[int64]', 'int64', np.dtype('int64')])
+    def test_construction(self, subtype):
+        i = IntervalDtype(subtype)
+        assert i.subtype == np.dtype('int64')
+        assert is_interval_dtype(i)
 
-        for s in ['interval[int64]', 'Interval[int64]', 'int64']:
-            i = IntervalDtype(s)
-            assert i.subtype == np.dtype('int64')
-            assert is_interval_dtype(i)
+    @pytest.mark.parametrize('subtype', [None, 'interval', 'interval[]'])
+    def test_construction_generic(self, subtype):
+        # generic
+        i = IntervalDtype(subtype)
+        assert i.subtype is None
+        assert is_interval_dtype(i)
 
     @pytest.mark.parametrize('subtype', [
         CategoricalDtype(list('abc'), False),
@@ -471,17 +476,27 @@ class TestIntervalDtype(Base):
         with tm.assert_raises_regex(TypeError, msg):
             IntervalDtype(subtype)
 
-    def test_construction_generic(self):
-        # generic
-        i = IntervalDtype('interval')
-        assert i.subtype == ''
-        assert is_interval_dtype(i)
-        assert str(i) == 'interval[]'
+    def test_construction_errors(self):
+        msg = 'could not construct IntervalDtype'
+        with tm.assert_raises_regex(ValueError, msg):
+            IntervalDtype('xx')
 
-        i = IntervalDtype()
-        assert i.subtype is None
-        assert is_interval_dtype(i)
-        assert str(i) == 'interval'
+    def test_construction_from_string(self):
+        result = IntervalDtype('interval[int64]')
+        assert is_dtype_equal(self.dtype, result)
+        result = IntervalDtype.construct_from_string('interval[int64]')
+        assert is_dtype_equal(self.dtype, result)
+
+    @pytest.mark.parametrize('string', [
+        'foo', 'interval[foo]', 'foo[int64]', 0, 3.14, ('a', 'b'), None])
+    def test_construction_from_string_errors(self, string):
+        if isinstance(string, string_types):
+            error, msg = ValueError, 'could not construct IntervalDtype'
+        else:
+            error, msg = TypeError, 'a string needs to be passed, got type'
+
+        with tm.assert_raises_regex(error, msg):
+            IntervalDtype.construct_from_string(string)
 
     def test_subclass(self):
         a = IntervalDtype('interval[int64]')
@@ -506,35 +521,44 @@ class TestIntervalDtype(Base):
         assert not IntervalDtype.is_dtype(np.int64)
         assert not IntervalDtype.is_dtype(np.float64)
 
-    def test_identity(self):
-        assert (IntervalDtype('interval[int64]') ==
-                IntervalDtype('interval[int64]'))
-
     def test_coerce_to_dtype(self):
         assert (_coerce_to_dtype('interval[int64]') ==
                 IntervalDtype('interval[int64]'))
 
-    def test_construction_from_string(self):
-        result = IntervalDtype('interval[int64]')
-        assert is_dtype_equal(self.dtype, result)
-        result = IntervalDtype.construct_from_string('interval[int64]')
-        assert is_dtype_equal(self.dtype, result)
-        with pytest.raises(TypeError):
-            IntervalDtype.construct_from_string('foo')
-        with pytest.raises(TypeError):
-            IntervalDtype.construct_from_string('interval[foo]')
-        with pytest.raises(TypeError):
-            IntervalDtype.construct_from_string('foo[int64]')
-
     def test_equality(self):
         assert is_dtype_equal(self.dtype, 'interval[int64]')
-        assert is_dtype_equal(self.dtype, IntervalDtype('int64'))
         assert is_dtype_equal(self.dtype, IntervalDtype('int64'))
         assert is_dtype_equal(IntervalDtype('int64'), IntervalDtype('int64'))
 
         assert not is_dtype_equal(self.dtype, 'int64')
         assert not is_dtype_equal(IntervalDtype('int64'),
                                   IntervalDtype('float64'))
+
+    @pytest.mark.parametrize('subtype', [
+        None, 'interval', 'interval[]', 'int64', 'uint64', 'float64', object,
+        CategoricalDtype(), 'datetime64', 'timedelta64', PeriodDtype('Q')])
+    def test_equality_generic(self, subtype):
+        # GH 18980
+        dtype = IntervalDtype(subtype)
+        assert is_dtype_equal(dtype, 'interval')
+        assert is_dtype_equal(dtype, IntervalDtype())
+
+    @pytest.mark.parametrize('subtype', [
+        'int64', 'uint64', 'float64', 'complex128', np.dtype('O'),
+        CategoricalDtype(), 'datetime64', 'timedelta64', PeriodDtype('Q')])
+    def test_name_repr(self, subtype):
+        # GH 18980
+        dtype = IntervalDtype(subtype)
+        expected = 'interval[{subtype}]'.format(subtype=subtype)
+        assert str(dtype) == expected
+        assert dtype.name == 'interval'
+
+    @pytest.mark.parametrize('subtype', [None, 'interval', 'interval[]'])
+    def test_name_repr_generic(self, subtype):
+        # GH 18980
+        dtype = IntervalDtype(subtype)
+        assert str(dtype) == 'interval'
+        assert dtype.name == 'interval'
 
     def test_basic(self):
         assert is_interval_dtype(self.dtype)
@@ -575,6 +599,15 @@ class TestIntervalDtype(Base):
         IntervalDtype.reset_cache()
         tm.round_trip_pickle(dtype)
         assert len(IntervalDtype._cache) == 0
+
+    def test_caching_categoricaldtype(self):
+        # GH 18980
+        cdt1 = CategoricalDtype(list('abc'), True)
+        cdt2 = CategoricalDtype(list('wxyz'), False)
+        idt1 = IntervalDtype(cdt1)
+        idt2 = IntervalDtype(cdt2)
+        assert idt1.subtype is cdt1
+        assert idt2.subtype is cdt2
 
 
 class TestCategoricalDtypeParametrized(object):


### PR DESCRIPTION
- [X] closes #18980
- [X] tests added / passed
- [X] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [X] whatsnew entry

Summary:
- `IntervalDtype(*)` now returns `True` when compared against `'interval'` and `IntervalDtype()` regardless of subtype
- `IntervalDtype(*)` now returns `'interval'` regardless of subtype
   - `str(IntervalDtype(*))` still displays subtype information, e.g. `'interval[int64]'`
- Cleaned up miscellaneous tests related to `IntervalDtype`
  