### PR TITLE
CLN: rename lib.isscalar to lib.is_scalar

### DIFF
--- a/pandas/_libs/lib.pyx
+++ b/pandas/_libs/lib.pyx
@@ -98,7 +98,7 @@ def memory_usage_of_objects(ndarray[object, ndim=1] arr):
 # ----------------------------------------------------------------------
 
 
-cpdef bint isscalar(object val):
+cpdef bint is_scalar(object val):
     """
     Return True if given value is scalar.
 

--- a/pandas/core/algorithms.py
+++ b/pandas/core/algorithms.py
@@ -750,7 +750,7 @@ def checked_add_with_arr(arr, b, arr_mask=None, b_mask=None):
         Helper function to broadcast arrays / scalars to the desired shape.
         """
         if _np_version_under1p10:
-            if lib.isscalar(arr_or_scalar):
+            if is_scalar(arr_or_scalar):
                 out = np.empty(shape)
                 out.fill(arr_or_scalar)
             else:

--- a/pandas/core/computation/align.py
+++ b/pandas/core/computation/align.py
@@ -126,7 +126,7 @@ def _align(terms):
         return np.result_type(terms.type), None
 
     # if all resolved variables are numeric scalars
-    if all(term.isscalar for term in terms):
+    if all(term.is_scalar for term in terms):
         return _result_type_many(*(term.value for term in terms)).type, None
 
     # perform the main alignment

--- a/pandas/core/computation/expr.py
+++ b/pandas/core/computation/expr.py
@@ -368,11 +368,11 @@ class BaseExprVisitor(ast.NodeVisitor):
 
     def _maybe_downcast_constants(self, left, right):
         f32 = np.dtype(np.float32)
-        if left.isscalar and not right.isscalar and right.return_type == f32:
+        if left.is_scalar and not right.is_scalar and right.return_type == f32:
             # right is a float32 array, left is a scalar
             name = self.env.add_tmp(np.float32(left.value))
             left = self.term_type(name, self.env)
-        if right.isscalar and not left.isscalar and left.return_type == f32:
+        if right.is_scalar and not left.is_scalar and left.return_type == f32:
             # left is a float32 array, right is a scalar
             name = self.env.add_tmp(np.float32(right.value))
             right = self.term_type(name, self.env)

--- a/pandas/core/computation/ops.py
+++ b/pandas/core/computation/ops.py
@@ -99,7 +99,7 @@ class Term(StringMixin):
         self.value = value
 
     @property
-    def isscalar(self):
+    def is_scalar(self):
         return is_scalar(self._value)
 
     @property
@@ -214,8 +214,8 @@ class Op(StringMixin):
         return frozenset(term.type for term in com.flatten(self))
 
     @property
-    def isscalar(self):
-        return all(operand.isscalar for operand in self.operands)
+    def is_scalar(self):
+        return all(operand.is_scalar for operand in self.operands)
 
     @property
     def is_datetime(self):
@@ -412,7 +412,7 @@ class BinOp(Op):
 
         lhs, rhs = self.lhs, self.rhs
 
-        if is_term(lhs) and lhs.is_datetime and is_term(rhs) and rhs.isscalar:
+        if is_term(lhs) and lhs.is_datetime and is_term(rhs) and rhs.is_scalar:
             v = rhs.value
             if isinstance(v, (int, float)):
                 v = stringify(v)
@@ -421,7 +421,7 @@ class BinOp(Op):
                 v = v.tz_convert('UTC')
             self.rhs.update(v)
 
-        if is_term(rhs) and rhs.is_datetime and is_term(lhs) and lhs.isscalar:
+        if is_term(rhs) and rhs.is_datetime and is_term(lhs) and lhs.is_scalar:
             v = lhs.value
             if isinstance(v, (int, float)):
                 v = stringify(v)
@@ -431,7 +431,7 @@ class BinOp(Op):
             self.lhs.update(v)
 
     def _disallow_scalar_only_bool_ops(self):
-        if ((self.lhs.isscalar or self.rhs.isscalar) and
+        if ((self.lhs.is_scalar or self.rhs.is_scalar) and
             self.op in _bool_ops_dict and
             (not (issubclass(self.rhs.return_type, (bool, np.bool_)) and
                   issubclass(self.lhs.return_type, (bool, np.bool_))))):

--- a/pandas/core/dtypes/inference.py
+++ b/pandas/core/dtypes/inference.py
@@ -17,7 +17,7 @@ is_float = lib.is_float
 
 is_complex = lib.is_complex
 
-is_scalar = lib.isscalar
+is_scalar = lib.is_scalar
 
 is_decimal = lib.is_decimal
 

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -1101,7 +1101,7 @@ class Index(IndexOpsMixin, PandasObject):
 
     def _assert_can_do_op(self, value):
         """ Check value is valid for scalar op """
-        if not lib.isscalar(value):
+        if not is_scalar(value):
             msg = "'value' must be a scalar, passed: {0}"
             raise TypeError(msg.format(type(value).__name__))
 

--- a/pandas/core/indexes/datetimelike.py
+++ b/pandas/core/indexes/datetimelike.py
@@ -905,7 +905,7 @@ class DatetimeIndexOpsMixin(object):
 
 def _ensure_datetimelike_to_i8(other):
     """ helper for coercing an input scalar or array to i8 """
-    if lib.isscalar(other) and isna(other):
+    if is_scalar(other) and isna(other):
         other = iNaT
     elif isinstance(other, ABCIndexClass):
         # convert tz if needed

--- a/pandas/core/indexes/numeric.py
+++ b/pandas/core/indexes/numeric.py
@@ -38,7 +38,7 @@ class NumericIndex(Index):
         if fastpath:
             return cls._simple_new(data, name=name)
 
-        # isscalar, generators handled in coerce_to_ndarray
+        # is_scalar, generators handled in coerce_to_ndarray
         data = cls._coerce_to_ndarray(data)
 
         if issubclass(data.dtype.type, compat.string_types):

--- a/pandas/tests/dtypes/test_inference.py
+++ b/pandas/tests/dtypes/test_inference.py
@@ -1098,9 +1098,9 @@ class TestNumberScalar(object):
         assert not is_timedelta64_ns_dtype(tdi.astype('timedelta64[h]'))
 
 
-class Testisscalar(object):
+class TestIsScalar(object):
 
-    def test_isscalar_builtin_scalars(self):
+    def test_is_scalar_builtin_scalars(self):
         assert is_scalar(None)
         assert is_scalar(True)
         assert is_scalar(False)
@@ -1115,7 +1115,7 @@ class Testisscalar(object):
         assert is_scalar(timedelta(hours=1))
         assert is_scalar(pd.NaT)
 
-    def test_isscalar_builtin_nonscalars(self):
+    def test_is_scalar_builtin_nonscalars(self):
         assert not is_scalar({})
         assert not is_scalar([])
         assert not is_scalar([1])
@@ -1124,7 +1124,7 @@ class Testisscalar(object):
         assert not is_scalar(slice(None))
         assert not is_scalar(Ellipsis)
 
-    def test_isscalar_numpy_array_scalars(self):
+    def test_is_scalar_numpy_array_scalars(self):
         assert is_scalar(np.int64(1))
         assert is_scalar(np.float64(1.))
         assert is_scalar(np.int32(1))
@@ -1135,7 +1135,7 @@ class Testisscalar(object):
         assert is_scalar(np.datetime64('2014-01-01'))
         assert is_scalar(np.timedelta64(1, 'h'))
 
-    def test_isscalar_numpy_zerodim_arrays(self):
+    def test_is_scalar_numpy_zerodim_arrays(self):
         for zerodim in [np.array(1), np.array('foobar'),
                         np.array(np.datetime64('2014-01-01')),
                         np.array(np.timedelta64(1, 'h')),
@@ -1143,19 +1143,19 @@ class Testisscalar(object):
             assert not is_scalar(zerodim)
             assert is_scalar(lib.item_from_zerodim(zerodim))
 
-    def test_isscalar_numpy_arrays(self):
+    def test_is_scalar_numpy_arrays(self):
         assert not is_scalar(np.array([]))
         assert not is_scalar(np.array([[]]))
         assert not is_scalar(np.matrix('1; 2'))
 
-    def test_isscalar_pandas_scalars(self):
+    def test_is_scalar_pandas_scalars(self):
         assert is_scalar(Timestamp('2014-01-01'))
         assert is_scalar(Timedelta(hours=1))
         assert is_scalar(Period('2014-01-01'))
         assert is_scalar(Interval(left=0, right=1))
         assert is_scalar(DateOffset(days=1))
 
-    def test_lisscalar_pandas_containers(self):
+    def test_is_scalar_pandas_containers(self):
         assert not is_scalar(Series())
         assert not is_scalar(Series([1]))
         assert not is_scalar(DataFrame())


### PR DESCRIPTION
- [x] closes #18987
- [ ] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

There's also a handful of methods which call `is_scalar` that are named `isscalar`, e.g.:
https://github.com/pandas-dev/pandas/blob/84335621ad0a0d83302a80b6911d3985c00b5cee/pandas/core/computation/ops.py#L101-L103
should these be changed as well?

Also does a CLN require an entry in whatsnew?

