### PR TITLE
TST: limit printing of xfail cases & catch Performance Warnings

### DIFF
--- a/pandas/tests/indexes/datetimes/test_arithmetic.py
+++ b/pandas/tests/indexes/datetimes/test_arithmetic.py
@@ -368,12 +368,15 @@ class TestDatetimeIndexArithmetic(object):
         # GH#18849
         dti = pd.date_range('2017-01-01', periods=2, tz=tz)
         other = box([pd.offsets.MonthEnd(), pd.offsets.Day(n=2)])
-        res = dti + other
+
+        with tm.assert_produces_warning(PerformanceWarning):
+            res = dti + other
         expected = DatetimeIndex([dti[n] + other[n] for n in range(len(dti))],
                                  name=dti.name, freq='infer')
         tm.assert_index_equal(res, expected)
 
-        res2 = other + dti
+        with tm.assert_produces_warning(PerformanceWarning):
+            res2 = other + dti
         tm.assert_index_equal(res2, expected)
 
     @pytest.mark.parametrize('box', [np.array, pd.Index])
@@ -381,7 +384,9 @@ class TestDatetimeIndexArithmetic(object):
         # GH#18824
         dti = pd.date_range('2017-01-01', periods=2, tz=tz)
         other = box([pd.offsets.MonthEnd(), pd.offsets.Day(n=2)])
-        res = dti - other
+
+        with tm.assert_produces_warning(PerformanceWarning):
+            res = dti - other
         expected = DatetimeIndex([dti[n] - other[n] for n in range(len(dti))],
                                  name=dti.name, freq='infer')
         tm.assert_index_equal(res, expected)
@@ -392,20 +397,25 @@ class TestDatetimeIndexArithmetic(object):
     def test_dti_with_offset_series(self, tz, names):
         # GH#18849
         dti = pd.date_range('2017-01-01', periods=2, tz=tz, name=names[0])
-        other = pd.Series([pd.offsets.MonthEnd(), pd.offsets.Day(n=2)],
-                          name=names[1])
+        other = Series([pd.offsets.MonthEnd(), pd.offsets.Day(n=2)],
+                       name=names[1])
 
-        expected_add = pd.Series([dti[n] + other[n] for n in range(len(dti))],
-                                 name=names[2])
-        res = dti + other
+        expected_add = Series([dti[n] + other[n] for n in range(len(dti))],
+                              name=names[2])
+
+        with tm.assert_produces_warning(PerformanceWarning):
+            res = dti + other
         tm.assert_series_equal(res, expected_add)
-        res2 = other + dti
+
+        with tm.assert_produces_warning(PerformanceWarning):
+            res2 = other + dti
         tm.assert_series_equal(res2, expected_add)
 
-        expected_sub = pd.Series([dti[n] - other[n] for n in range(len(dti))],
-                                 name=names[2])
+        expected_sub = Series([dti[n] - other[n] for n in range(len(dti))],
+                              name=names[2])
 
-        res3 = dti - other
+        with tm.assert_produces_warning(PerformanceWarning):
+            res3 = dti - other
         tm.assert_series_equal(res3, expected_sub)
 
 

--- a/pandas/tests/indexing/test_coercion.py
+++ b/pandas/tests/indexing/test_coercion.py
@@ -819,8 +819,8 @@ class TestReplaceSeriesCoercion(CoercionBase):
         assert obj.dtype == from_key
 
         if (from_key.startswith('datetime') and to_key.startswith('datetime')):
-            pytest.xfail("different tz, currently mask_missing "
-                         "raises SystemError")
+            # tested below
+            return
 
         if how == 'dict':
             replacer = dict(zip(self.rep[from_key], self.rep[to_key]))
@@ -846,6 +846,39 @@ class TestReplaceSeriesCoercion(CoercionBase):
         else:
             exp = pd.Series(self.rep[to_key], index=index, name='yyy')
             assert exp.dtype == to_key
+
+        tm.assert_series_equal(result, exp)
+
+    # TODO(jreback) commented out to only have a single xfail printed
+    @pytest.mark.xfail(reason="different tz, "
+                       "currently mask_missing raises SystemError")
+    # @pytest.mark.parametrize('how', ['dict', 'series'])
+    # @pytest.mark.parametrize('to_key', [
+    #     'datetime64[ns]', 'datetime64[ns, UTC]',
+    #     'datetime64[ns, US/Eastern]'])
+    # @pytest.mark.parametrize('from_key', [
+    #    'datetime64[ns]', 'datetime64[ns, UTC]',
+    #    'datetime64[ns, US/Eastern]'])
+    # def test_replace_series_datetime_datetime(self, how, to_key, from_key):
+    def test_replace_series_datetime_datetime(self):
+        how = 'dict'
+        to_key = 'datetime64[ns]'
+        from_key = 'datetime64[ns]'
+
+        index = pd.Index([3, 4], name='xxx')
+        obj = pd.Series(self.rep[from_key], index=index, name='yyy')
+        assert obj.dtype == from_key
+
+        if how == 'dict':
+            replacer = dict(zip(self.rep[from_key], self.rep[to_key]))
+        elif how == 'series':
+            replacer = pd.Series(self.rep[to_key], index=self.rep[from_key])
+        else:
+            raise ValueError
+
+        result = obj.replace(replacer)
+        exp = pd.Series(self.rep[to_key], index=index, name='yyy')
+        assert exp.dtype == to_key
 
         tm.assert_series_equal(result, exp)
 

--- a/pandas/tests/series/test_rank.py
+++ b/pandas/tests/series/test_rank.py
@@ -209,11 +209,9 @@ class TestSeriesRank(TestData):
         pytest.param([np.iinfo(np.int64).min, -100, 0, 1, 9999, 100000,
                       1e10, np.iinfo(np.int64).max],
                      'int64',
-                     marks=pytest.mark.xfail(reason='''iNaT is equivalent to
-                                                      minimum value of dtype
-                                                      int64 pending issue
-                                                      #16674'''),
-                     ),
+                     marks=pytest.mark.xfail(
+                         reason="iNaT is equivalent to minimum value of dtype"
+                         "int64 pending issue #16674")),
         ([NegInfinity(), '1', 'A', 'BA', 'Ba', 'C', Infinity()],
          'object')
     ])

--- a/pandas/tests/tseries/offsets/test_offsets.py
+++ b/pandas/tests/tseries/offsets/test_offsets.py
@@ -144,9 +144,7 @@ class Base(object):
         except tslib.OutOfBoundsDatetime:
             raise
         except (ValueError, KeyError) as e:
-            pytest.skip(
-                "cannot create out_of_range offset: {0} {1}".format(
-                    str(self).split('.')[-1], e))
+            pass
 
 
 class TestCommon(Base):

--- a/pandas/tests/tseries/offsets/test_offsets.py
+++ b/pandas/tests/tseries/offsets/test_offsets.py
@@ -113,7 +113,7 @@ class Base(object):
         else:
             try:
                 klass = klass(value, normalize=normalize)
-            except:
+            except Exception:
                 klass = klass(normalize=normalize)
         return klass
 
@@ -143,7 +143,9 @@ class Base(object):
 
         except tslib.OutOfBoundsDatetime:
             raise
-        except (ValueError, KeyError) as e:
+        except (ValueError, KeyError):
+            # we are creating an invalid offset
+            # so ignore
             pass
 
 


### PR DESCRIPTION
TST: limit printing of xfail cases
no need to report invalid offset creation
STYLE/DEPR: catch PerformanceWarnings
    
closes #18989
