### PR TITLE
COMPAT: Drop reference to deprecated dateutil.zoneinfo.gettz

### DIFF
--- a/pandas/_libs/tslibs/timezones.pyx
+++ b/pandas/_libs/tslibs/timezones.pyx
@@ -11,12 +11,7 @@ from dateutil.tz import (
     tzfile as _dateutil_tzfile)
 
 import sys
-if sys.platform == 'win32' or sys.platform == 'cygwin':
-    # equiv pd.compat.is_platform_windows()
-    from dateutil.zoneinfo import gettz as dateutil_gettz
-else:
-    from dateutil.tz import gettz as dateutil_gettz
-
+from dateutil.tz import gettz as dateutil_gettz
 
 from pytz.tzinfo import BaseTzInfo as _pytz_BaseTzInfo
 import pytz

--- a/pandas/_libs/tslibs/timezones.pyx
+++ b/pandas/_libs/tslibs/timezones.pyx
@@ -10,7 +10,6 @@ from dateutil.tz import (
     tzlocal as _dateutil_tzlocal,
     tzfile as _dateutil_tzfile)
 
-import sys
 from dateutil.tz import gettz as dateutil_gettz
 
 from pytz.tzinfo import BaseTzInfo as _pytz_BaseTzInfo


### PR DESCRIPTION
- [X] closes #19004

I'm assuming these will be handled by CI:
- [ ] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`

Not sure this is necessary, it's a very "behind the scenes" fix, replacing `zoneinfo.gettz` with the superior `tz.gettz()`:

- [ ] whatsnew entry
