### PR TITLE
Spellcheck

### DIFF
--- a/doc/source/10min.rst
+++ b/doc/source/10min.rst
@@ -48,7 +48,7 @@ a default integer index:
    s = pd.Series([1,3,5,np.nan,6,8])
    s
 
-Creating a :class:`DataFrame` by passing a numpy array, with a datetime index
+Creating a :class:`DataFrame` by passing a NumPy array, with a datetime index
 and labeled columns:
 
 .. ipython:: python
@@ -114,7 +114,7 @@ Here is how to view the top and bottom rows of the frame:
    df.head()
    df.tail(3)
 
-Display the index, columns, and the underlying numpy data:
+Display the index, columns, and the underlying NumPy data:
 
 .. ipython:: python
 
@@ -311,7 +311,7 @@ Setting values by position:
 
    df.iat[0,1] = 0
 
-Setting by assigning with a numpy array:
+Setting by assigning with a NumPy array:
 
 .. ipython:: python
 

--- a/doc/source/advanced.rst
+++ b/doc/source/advanced.rst
@@ -316,7 +316,9 @@ Basic multi-index slicing using slices, lists, and labels.
 
    dfmi.loc[(slice('A1','A3'), slice(None), ['C1', 'C3']), :]
 
-You can use :class:`pandas.IndexSlice` to facilitate a more natural syntax using ``:``, rather than using ``slice(None)``.
+
+You can use :class:`pandas.IndexSlice` to facilitate a more natural syntax 
+using ``:``, rather than using ``slice(None)``.
 
 .. ipython:: python
 
@@ -763,7 +765,6 @@ The only positional indexing is via ``iloc``.
    sf.iloc[3]
 
 A scalar index that is not found will raise a ``KeyError``.
-
 Slicing is primarily on the values of the index when using ``[],ix,loc``, and 
 **always** positional when using ``iloc``. The exception is when the slice is
 boolean, in which case it will always be positional.

--- a/doc/source/advanced.rst
+++ b/doc/source/advanced.rst
@@ -559,7 +559,7 @@ Take Methods
 
 .. _advanced.take:
 
-Similar to numpy ndarrays, pandas Index, Series, and DataFrame also provides
+Similar to NumPy ndarrays, pandas Index, Series, and DataFrame also provides
 the ``take`` method that retrieves elements along a given axis at the given
 indices. The given indices must be either a list or an ndarray of integer
 index positions. ``take`` will also accept negative integers as relative positions to the end of the object.

--- a/doc/source/advanced.rst
+++ b/doc/source/advanced.rst
@@ -731,7 +731,7 @@ This is an Immutable array implementing an ordered, sliceable set.
 Prior to 0.18.0, the ``Int64Index`` would provide the default index for all ``NDFrame`` objects.
 
 ``RangeIndex`` is a sub-class of ``Int64Index`` added in version 0.18.0, now providing the default index for all ``NDFrame`` objects.
-``RangeIndex`` is an optimized version of ``Int64Index`` that can represent a monotonic ordered set. These are analogous to python `range types <https://docs.python.org/3/library/stdtypes.html#typesseq-range>`__.
+``RangeIndex`` is an optimized version of ``Int64Index`` that can represent a monotonic ordered set. These are analogous to Python `range types <https://docs.python.org/3/library/stdtypes.html#typesseq-range>`__.
 
 .. _indexing.float64index:
 

--- a/doc/source/api.rst
+++ b/doc/source/api.rst
@@ -730,7 +730,7 @@ The dtype information is available on the ``Categorical``
    Categorical.codes
 
 ``np.asarray(categorical)`` works by implementing the array interface. Be aware, that this converts
-the Categorical back to a numpy array, so categories and order information is not preserved!
+the Categorical back to a NumPy array, so categories and order information is not preserved!
 
 .. autosummary::
    :toctree: generated/

--- a/doc/source/basics.rst
+++ b/doc/source/basics.rst
@@ -395,7 +395,7 @@ raise a ValueError:
     In [56]: pd.Series(['foo', 'bar', 'baz']) == pd.Series(['foo'])
     ValueError: Series lengths must match to compare
 
-Note that this is different from the numpy behavior where a comparison can
+Note that this is different from the NumPy behavior where a comparison can
 be broadcast:
 
 .. ipython:: python
@@ -1000,7 +1000,7 @@ We create a frame similar to the one used in the above sections.
    tsdf.iloc[3:7] = np.nan
    tsdf
 
-Transform the entire frame. ``.transform()`` allows input functions as: a numpy function, a string
+Transform the entire frame. ``.transform()`` allows input functions as: a NumPy function, a string
 function name or a user defined function.
 
 .. ipython:: python
@@ -1510,7 +1510,7 @@ To iterate over the rows of a DataFrame, you can use the following methods:
   one of the following approaches:
 
   * Look for a *vectorized* solution: many operations can be performed using
-    built-in methods or numpy functions, (boolean) indexing, ...
+    built-in methods or NumPy functions, (boolean) indexing, ...
 
   * When you have a function that cannot work on the full DataFrame/Series
     at once, it is better to use :meth:`~DataFrame.apply` instead of iterating
@@ -1971,7 +1971,7 @@ from the current type (e.g. ``int`` to ``float``).
    df3.dtypes
 
 The ``values`` attribute on a DataFrame return the *lower-common-denominator* of the dtypes, meaning
-the dtype that can accommodate **ALL** of the types in the resulting homogeneous dtyped numpy array. This can
+the dtype that can accommodate **ALL** of the types in the resulting homogeneous dtyped NumPy array. This can
 force some *upcasting*.
 
 .. ipython:: python
@@ -2253,7 +2253,7 @@ can define a function that returns a tree of child dtypes:
            return dtype
        return [dtype, [subdtypes(dt) for dt in subs]]
 
-All numpy dtypes are subclasses of ``numpy.generic``:
+All NumPy dtypes are subclasses of ``numpy.generic``:
 
 .. ipython:: python
 
@@ -2262,4 +2262,4 @@ All numpy dtypes are subclasses of ``numpy.generic``:
 .. note::
 
     Pandas also defines the types ``category``, and ``datetime64[ns, tz]``, which are not integrated into the normal
-    numpy hierarchy and wont show up with the above function.
+    NumPy hierarchy and wont show up with the above function.

--- a/doc/source/categorical.rst
+++ b/doc/source/categorical.rst
@@ -40,7 +40,7 @@ The categorical data type is useful in the following cases:
 * The lexical order of a variable is not the same as the logical order ("one", "two", "three").
   By converting to a categorical and specifying an order on the categories, sorting and
   min/max will use the logical order instead of the lexical order, see :ref:`here <categorical.sort>`.
-* As a signal to other python libraries that this column should be treated as a categorical
+* As a signal to other Python libraries that this column should be treated as a categorical
   variable (e.g. to use suitable statistical methods or plot types).
 
 See also the :ref:`API docs on categoricals<api.categorical>`.
@@ -366,7 +366,7 @@ or simply set the categories to a predefined scale, use :func:`Categorical.set_c
 .. note::
     Be aware that :func:`Categorical.set_categories` cannot know whether some category is omitted
     intentionally or because it is misspelled or (under Python3) due to a type difference (e.g.,
-    numpys S1 dtype and python strings). This can result in surprising behaviour!
+    numpys S1 dtype and Python strings). This can result in surprising behaviour!
 
 Sorting and Order
 -----------------

--- a/doc/source/comparison_with_sas.rst
+++ b/doc/source/comparison_with_sas.rst
@@ -100,7 +100,7 @@ specifying the column names.
 
 A pandas ``DataFrame`` can be constructed in many different ways,
 but for a small number of values, it is often convenient to specify it as
-a python dictionary, where the keys are the column names
+a Python dictionary, where the keys are the column names
 and the values are the data.
 
 .. ipython:: python

--- a/doc/source/comparison_with_sas.rst
+++ b/doc/source/comparison_with_sas.rst
@@ -10,7 +10,7 @@ performed in pandas.
 If you're new to pandas, you might want to first read through :ref:`10 Minutes to pandas<10min>`
 to familiarize yourself with the library.
 
-As is customary, we import pandas and numpy as follows:
+As is customary, we import pandas and NumPy as follows:
 
 .. ipython:: python
 

--- a/doc/source/comparison_with_sql.rst
+++ b/doc/source/comparison_with_sql.rst
@@ -10,7 +10,7 @@ various SQL operations would be performed using pandas.
 If you're new to pandas, you might want to first read through :ref:`10 Minutes to pandas<10min>`
 to familiarize yourself with the library.
 
-As is customary, we import pandas and numpy as follows:
+As is customary, we import pandas and NumPy as follows:
 
 .. ipython:: python
 

--- a/doc/source/computation.rst
+++ b/doc/source/computation.rst
@@ -57,9 +57,8 @@ Covariance
    s2 = pd.Series(np.random.randn(1000))
    s1.cov(s2)
 
-Analogously, :meth:`DataFrame.cov` to compute 
-pairwise covariances among the series in the DataFrame, also excluding 
-NA/null values.
+Analogously, :meth:`DataFrame.cov` to compute pairwise covariances among the 
+series in the DataFrame, also excluding NA/null values.
 
 .. _computation.covariance.caveats:
 

--- a/doc/source/contributing.rst
+++ b/doc/source/contributing.rst
@@ -118,7 +118,7 @@ Creating a development environment
 ----------------------------------
 
 To test out code changes, you'll need to build pandas from source, which
-requires a C compiler and python environment. If you're making documentation
+requires a C compiler and Python environment. If you're making documentation
 changes, you can skip to :ref:`contributing.documentation` but you won't be able
 to build the documentation locally before pushing your changes.
 
@@ -187,7 +187,7 @@ At this point you should be able to import pandas from your locally built versio
    0.22.0.dev0+29.g4ad6d4d74
 
 This will create the new environment, and not touch any of your existing environments,
-nor any existing python installation.
+nor any existing Python installation.
 
 To view your environments::
 

--- a/doc/source/cookbook.rst
+++ b/doc/source/cookbook.rst
@@ -1167,7 +1167,7 @@ Storing Attributes to a group node
 Binary Files
 ************
 
-pandas readily accepts numpy record arrays, if you need to read in a binary
+pandas readily accepts NumPy record arrays, if you need to read in a binary
 file consisting of an array of C structs. For example, given this C program
 in a file called ``main.c`` compiled with ``gcc main.c -std=gnu99`` on a
 64-bit machine,

--- a/doc/source/cookbook.rst
+++ b/doc/source/cookbook.rst
@@ -41,7 +41,7 @@ above what the in-line examples offer.
 Pandas (pd) and Numpy (np) are the only two abbreviated imported modules. The rest are kept
 explicitly imported for newer users.
 
-These examples are written for Python 3.4.  Minor tweaks might be necessary for earlier python
+These examples are written for Python 3.  Minor tweaks might be necessary for earlier python
 versions.
 
 Idioms

--- a/doc/source/cookbook.rst
+++ b/doc/source/cookbook.rst
@@ -41,7 +41,7 @@ above what the in-line examples offer.
 Pandas (pd) and Numpy (np) are the only two abbreviated imported modules. The rest are kept
 explicitly imported for newer users.
 
-These examples are written for python 3.4.  Minor tweaks might be necessary for earlier python
+These examples are written for Python 3.4.  Minor tweaks might be necessary for earlier python
 versions.
 
 Idioms
@@ -750,7 +750,7 @@ Timeseries
 <http://nipunbatra.github.io/2015/06/timeseries/>`__
 
 Turn a matrix with hours in columns and days in rows into a continuous row sequence in the form of a time series.
-`How to rearrange a python pandas DataFrame?
+`How to rearrange a Python pandas DataFrame?
 <http://stackoverflow.com/questions/15432659/how-to-rearrange-a-python-pandas-dataframe>`__
 
 `Dealing with duplicates when reindexing a timeseries to a specified frequency
@@ -1152,7 +1152,7 @@ Storing Attributes to a group node
    store = pd.HDFStore('test.h5')
    store.put('df',df)
 
-   # you can store an arbitrary python object via pickle
+   # you can store an arbitrary Python object via pickle
    store.get_storer('df').attrs.my_attribute = dict(A = 10)
    store.get_storer('df').attrs.my_attribute
 

--- a/doc/source/dsintro.rst
+++ b/doc/source/dsintro.rst
@@ -23,7 +23,7 @@ Intro to Data Structures
 We'll start with a quick, non-comprehensive overview of the fundamental data
 structures in pandas to get you started. The fundamental behavior about data
 types, indexing, and axis labeling / alignment apply across all of the
-objects. To get started, import numpy and load pandas into your namespace:
+objects. To get started, import NumPy and load pandas into your namespace:
 
 .. ipython:: python
 

--- a/doc/source/dsintro.rst
+++ b/doc/source/dsintro.rst
@@ -877,7 +877,7 @@ of DataFrames:
    wp['Item3'] = wp['Item1'] / wp['Item2']
 
 The API for insertion and deletion is the same as for DataFrame. And as with
-DataFrame, if the item is a valid python identifier, you can access it as an
+DataFrame, if the item is a valid Python identifier, you can access it as an
 attribute and tab-complete it in IPython.
 
 Transposing

--- a/doc/source/ecosystem.rst
+++ b/doc/source/ecosystem.rst
@@ -27,7 +27,7 @@ Statistics and Machine Learning
 `Statsmodels <http://www.statsmodels.org/>`__
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Statsmodels is the prominent python "statistics and econometrics library" and it has
+Statsmodels is the prominent Python "statistics and econometrics library" and it has
 a long-standing special relationship with pandas. Statsmodels provides powerful statistics,
 econometrics, analysis and modeling functionality that is out of pandas' scope.
 Statsmodels leverages pandas objects as the underlying data container for computation.
@@ -72,7 +72,7 @@ Hadley Wickham's `ggplot2 <http://ggplot2.org/>`__ is a foundational exploratory
 Based on `"The Grammar of Graphics" <http://www.cs.uic.edu/~wilkinson/TheGrammarOfGraphics/GOG.html>`__ it
 provides a powerful, declarative and extremely general way to generate bespoke plots of any kind of data.
 It's really quite incredible. Various implementations to other languages are available,
-but a faithful implementation for python users has long been missing. Although still young
+but a faithful implementation for Python users has long been missing. Although still young
 (as of Jan-2014), the `yhat/ggplot <https://github.com/yhat/ggplot>`__ project has been
 progressing quickly in that direction.
 
@@ -192,7 +192,7 @@ or multi-indexed DataFrames.
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 fredapi is a Python interface to the `Federal Reserve Economic Data (FRED) <http://research.stlouisfed.org/fred2/>`__
 provided by the Federal Reserve Bank of St. Louis. It works with both the FRED database and ALFRED database that
-contains point-in-time data (i.e. historic data revisions). fredapi provides a wrapper in python to the FRED
+contains point-in-time data (i.e. historic data revisions). fredapi provides a wrapper in Python to the FRED
 HTTP API, and also provides several convenient methods for parsing and analyzing point-in-time data from ALFRED.
 fredapi makes use of pandas and returns data in a Series or DataFrame. This module requires a FRED API key that
 you can obtain for free on the FRED website.

--- a/doc/source/enhancingperf.rst
+++ b/doc/source/enhancingperf.rst
@@ -24,12 +24,12 @@ Enhancing Performance
 Cython (Writing C extensions for pandas)
 ----------------------------------------
 
-For many use cases writing pandas in pure Python and numpy is sufficient. In some
+For many use cases writing pandas in pure Python and NumPy is sufficient. In some
 computationally heavy applications however, it can be possible to achieve sizeable
 speed-ups by offloading work to `cython <http://cython.org/>`__.
 
 This tutorial assumes you have refactored as much as possible in python, for example
-trying to remove for loops and making use of numpy vectorization, it's always worth
+trying to remove for loops and making use of NumPy vectorization, it's always worth
 optimising in Python first.
 
 This tutorial walks through a "typical" process of cythonizing a slow computation.
@@ -232,7 +232,7 @@ the rows, applying our ``integrate_f_typed``, and putting this in the zeros arra
 .. note::
 
     Loops like this would be *extremely* slow in python, but in Cython looping
-    over numpy arrays is *fast*.
+    over NumPy arrays is *fast*.
 
 .. code-block:: ipython
 
@@ -391,7 +391,7 @@ Caveats
 
     ``numba`` will execute on any function, but can only accelerate certain classes of functions.
 
-``numba`` is best at accelerating functions that apply numerical functions to numpy arrays. When passed a function that only uses operations it knows how to accelerate, it will execute in ``nopython`` mode.
+``numba`` is best at accelerating functions that apply numerical functions to NumPy arrays. When passed a function that only uses operations it knows how to accelerate, it will execute in ``nopython`` mode.
 
 If ``numba`` is passed a function that includes something it doesn't know how to work with -- a category that currently includes sets, lists, dictionaries, or string functions -- it will revert to ``object mode``. In ``object mode``, numba will execute but your code will not speed up significantly. If you would prefer that ``numba`` throw an error if it cannot compile a function in a way that speeds up your code, pass numba the argument ``nopython=True`` (e.g.  ``@numba.jit(nopython=True)``). For more on troubleshooting ``numba`` modes, see the `numba troubleshooting page <http://numba.pydata.org/numba-doc/0.20.0/user/troubleshoot.html#the-compiled-code-is-too-slow>`__.
 
@@ -779,7 +779,7 @@ Technical Minutia Regarding Expression Evaluation
 
 Expressions that would result in an object dtype or involve datetime operations
 (because of ``NaT``) must be evaluated in Python space. The main reason for
-this behavior is to maintain backwards compatibility with versions of numpy <
+this behavior is to maintain backwards compatibility with versions of NumPy <
 1.7. In those versions of ``numpy`` a call to ``ndarray.astype(str)`` will
 truncate any strings that are more than 60 characters in length. Second, we
 can't pass ``object`` arrays to ``numexpr`` thus string comparisons must be

--- a/doc/source/enhancingperf.rst
+++ b/doc/source/enhancingperf.rst
@@ -24,13 +24,13 @@ Enhancing Performance
 Cython (Writing C extensions for pandas)
 ----------------------------------------
 
-For many use cases writing pandas in pure python and numpy is sufficient. In some
+For many use cases writing pandas in pure Python and numpy is sufficient. In some
 computationally heavy applications however, it can be possible to achieve sizeable
 speed-ups by offloading work to `cython <http://cython.org/>`__.
 
 This tutorial assumes you have refactored as much as possible in python, for example
 trying to remove for loops and making use of numpy vectorization, it's always worth
-optimising in python first.
+optimising in Python first.
 
 This tutorial walks through a "typical" process of cythonizing a slow computation.
 We use an `example from the cython documentation <http://docs.cython.org/src/quickstart/cythonize.html>`__
@@ -86,8 +86,8 @@ hence we'll concentrate our efforts cythonizing these two functions.
 
 .. note::
 
-  In python 2 replacing the ``range`` with its generator counterpart (``xrange``)
-  would mean the ``range`` line would vanish. In python 3 ``range`` is already a generator.
+  In Python 2 replacing the ``range`` with its generator counterpart (``xrange``)
+  would mean the ``range`` line would vanish. In Python 3 ``range`` is already a generator.
 
 .. _enhancingperf.plain:
 
@@ -315,7 +315,7 @@ Numba works by generating optimized machine code using the LLVM compiler infrast
 Jit
 ~~~
 
-Using ``numba`` to just-in-time compile your code. We simply take the plain python code from above and annotate with the ``@jit`` decorator.
+Using ``numba`` to just-in-time compile your code. We simply take the plain Python code from above and annotate with the ``@jit`` decorator.
 
 .. code-block:: python
 

--- a/doc/source/gotchas.rst
+++ b/doc/source/gotchas.rst
@@ -91,7 +91,7 @@ See also :ref:`Categorical Memory Usage <categorical.memory>`.
 Using If/Truth Statements with pandas
 -------------------------------------
 
-pandas follows the numpy convention of raising an error when you try to convert something to a ``bool``.
+pandas follows the NumPy convention of raising an error when you try to convert something to a ``bool``.
 This happens in a ``if`` or when using the boolean operations, ``and``, ``or``, or ``not``.  It is not clear
 what the result of
 

--- a/doc/source/groupby.rst
+++ b/doc/source/groupby.rst
@@ -20,38 +20,38 @@ Group By: split-apply-combine
 *****************************
 
 By "group by" we are referring to a process involving one or more of the following
-steps
+steps:
 
- - **Splitting** the data into groups based on some criteria
- - **Applying** a function to each group independently
- - **Combining** the results into a data structure
+ - **Splitting** the data into groups based on some criteria.
+ - **Applying** a function to each group independently.
+ - **Combining** the results into a data structure.
 
-Of these, the split step is the most straightforward. In fact, in many
-situations you may wish to split the data set into groups and do something with
-those groups yourself. In the apply step, we might wish to one of the
+Out of these, the split step is the most straightforward. In fact, in many
+situations we may wish to split the data set into groups and do something with
+those groups. In the apply step, we might wish to one of the
 following:
 
- - **Aggregation**: computing a summary statistic (or statistics) about each
+ - **Aggregation**: compute a summary statistic (or statistics) for each
    group. Some examples:
 
-    - Compute group sums or means
-    - Compute group sizes / counts
+    - Compute group sums or means.
+    - Compute group sizes / counts.
 
  - **Transformation**: perform some group-specific computations and return a
-   like-indexed. Some examples:
+   like-indexed object. Some examples:
 
-    - Standardizing data (zscore) within group
-    - Filling NAs within groups with a value derived from each group
+    - Standardize data (zscore) within a group.
+    - Filling NAs within groups with a value derived from each group.
 
  - **Filtration**: discard some groups, according to a group-wise computation
    that evaluates True or False. Some examples:
 
-    - Discarding data that belongs to groups with only a few members
-    - Filtering out data based on the group sum or mean
+    - Discard data that belongs to groups with only a few members.
+    - Filter out data based on the group sum or mean.
 
  - Some combination of the above: GroupBy will examine the results of the apply
    step and try to return a sensibly combined result if it doesn't fit into
-   either of the above two categories
+   either of the above two categories.
 
 Since the set of object instance methods on pandas data structures are generally
 rich and expressive, we often simply want to invoke, say, a DataFrame function
@@ -68,7 +68,7 @@ We aim to make operations like this natural and easy to express using
 pandas. We'll address each area of GroupBy functionality then provide some
 non-trivial examples / use cases.
 
-See the :ref:`cookbook<cookbook.grouping>` for some advanced strategies
+See the :ref:`cookbook<cookbook.grouping>` for some advanced strategies.
 
 .. _groupby.split:
 
@@ -77,7 +77,7 @@ Splitting an object into groups
 
 pandas objects can be split on any of their axes. The abstract definition of
 grouping is to provide a mapping of labels to group names. To create a GroupBy
-object (more on what the GroupBy object is later), you do the following:
+object (more on what the GroupBy object is later), you may do the following:
 
 .. code-block:: ipython
 
@@ -88,14 +88,14 @@ object (more on what the GroupBy object is later), you do the following:
 
 The mapping can be specified many different ways:
 
-  - A Python function, to be called on each of the axis labels
-  - A list or NumPy array of the same length as the selected axis
-  - A dict or Series, providing a ``label -> group name`` mapping
+  - A Python function, to be called on each of the axis labels.
+  - A list or NumPy array of the same length as the selected axis.
+  - A dict or Series, providing a ``label -> group name`` mapping.
   - For DataFrame objects, a string indicating a column to be used to group. Of
     course ``df.groupby('A')`` is just syntactic sugar for
-    ``df.groupby(df['A'])``, but it makes life simpler
+    ``df.groupby(df['A'])``, but it makes life simpler.
   - For DataFrame objects, a string indicating an index level to be used to group.
-  - A list of any of the above things
+  - A list of any of the above things.
 
 Collectively we refer to the grouping objects as the **keys**. For example,
 consider the following DataFrame:
@@ -119,7 +119,8 @@ consider the following DataFrame:
                       'D' : np.random.randn(8)})
    df
 
-We could naturally group by either the ``A`` or ``B`` columns or both:
+On a DataFrame, we obtain a GroupBy object by calling :meth:`~DataFrame.groupby`. 
+We could naturally group by either the ``A`` or ``B`` columns, or both:
 
 .. ipython:: python
 
@@ -140,7 +141,7 @@ columns:
 
     In [5]: grouped = df.groupby(get_letter_type, axis=1)
 
-pandas Index objects support duplicate values. If a
+pandas :class:`~pandas.Index` objects support duplicate values. If a
 non-unique index is used as the group key in a groupby operation, all values
 for the same index value will be considered to be in one group and thus the
 output of aggregation functions will only contain unique index values:
@@ -220,7 +221,7 @@ the length of the ``groups`` dict, so it is largely just a convenience:
 
 .. _groupby.tabcompletion:
 
-``GroupBy`` will tab complete column names (and other attributes)
+``GroupBy`` will tab complete column names (and other attributes):
 
 .. ipython:: python
    :suppress:

--- a/doc/source/groupby.rst
+++ b/doc/source/groupby.rst
@@ -359,9 +359,9 @@ Index level names may be specified as keys directly to ``groupby``.
 DataFrame column selection in GroupBy
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Once you have created the GroupBy object from a DataFrame, for example, you
-might want to do something different for each of the columns. Thus, using
-``[]`` similar to getting a column from a DataFrame, you can do:
+Once you have created the GroupBy object from a DataFrame, you might want to do 
+something different for each of the columns. Thus, using ``[]`` similar to 
+getting a column from a DataFrame, you can do:
 
 .. ipython:: python
    :suppress:
@@ -394,7 +394,7 @@ Iterating through groups
 ------------------------
 
 With the GroupBy object in hand, iterating through the grouped data is very
-natural and functions similarly to ``itertools.groupby``:
+natural and functions similarly to :py:func:`itertools.groupby`:
 
 .. ipython::
 
@@ -420,7 +420,8 @@ statement if you wish: ``for (k1, k2), group in grouped:``.
 Selecting a group
 -----------------
 
-A single group can be selected using ``GroupBy.get_group()``:
+A single group can be selected using 
+:meth:`~pandas.core.groupby.DataFrameGroupBy.get_group`:
 
 .. ipython:: python
 
@@ -442,7 +443,9 @@ perform a computation on the grouped data. These operations are similar to the
 :ref:`aggregating API <basics.aggregate>`, :ref:`window functions API <stats.aggregate>`,
 and :ref:`resample API <timeseries.aggregate>`.
 
-An obvious one is aggregation via the ``aggregate`` or equivalently ``agg`` method:
+An obvious one is aggregation via the 
+:meth:`~pandas.core.groupby.DataFrameGroupBy.aggregate` or equivalently 
+:meth:`~pandas.core.groupby.DataFrameGroupBy.agg` method:
 
 .. ipython:: python
 
@@ -492,11 +495,34 @@ index are the group names and whose values are the sizes of each group.
    Passing ``as_index=False`` **will** return the groups that you are aggregating over, if they are
    named *columns*.
 
-   Aggregating functions are ones that reduce the dimension of the returned objects,
-   for example: ``mean, sum, size, count, std, var, sem, describe, first, last, nth, min, max``. This is
-   what happens when you do for example ``DataFrame.sum()`` and get back a ``Series``.
+Aggregating functions are the ones that reduce the dimension of the returned objects.
+Some common aggregating functions are tabulated below:
 
-   ``nth`` can act as a reducer *or* a filter, see :ref:`here <groupby.nth>`
+.. csv-table::
+    :header: "Function", "Description"
+    :widths: 20, 80
+    :delim: ;
+
+	:meth:`~pd.core.groupby.DataFrameGroupBy.mean`;Compute mean of groups
+	:meth:`~pd.core.groupby.DataFrameGroupBy.sum`;Compute sum of group values
+	:meth:`~pd.core.groupby.DataFrameGroupBy.size`;Compute group sizes
+	:meth:`~pd.core.groupby.DataFrameGroupBy.count`;Compute count of group
+	:meth:`~pd.core.groupby.DataFrameGroupBy.std`;Standard deviation of groups
+	:meth:`~pd.core.groupby.DataFrameGroupBy.var`;Compute variance of groups
+	:meth:`~pd.core.groupby.DataFrameGroupBy.sem`;Standard error of the mean of groups
+	:meth:`~pd.core.groupby.DataFrameGroupBy.describe`;Generates descriptive statistics
+	:meth:`~pd.core.groupby.DataFrameGroupBy.first`;Compute first of group values
+	:meth:`~pd.core.groupby.DataFrameGroupBy.last`;Compute last of group values
+	:meth:`~pd.core.groupby.DataFrameGroupBy.nth`;Take nth value, or a subset if n is a list
+	:meth:`~pd.core.groupby.DataFrameGroupBy.min`;Compute min of group values
+	:meth:`~pd.core.groupby.DataFrameGroupBy.max`;Compute max of group values
+	
+
+The aggregating functions above will exclude NA values. Any function which 
+reduces a :class:`Series` to a scalar value is an aggregation function and will work,
+a trivial example is ``df.groupby('A').agg(lambda ser: 1)``. Note that
+:meth:`~pd.core.groupby.DataFrameGroupBy.nth` can act as a reducer *or* a 
+filter, see :ref:`here <groupby.nth>`.
 
 .. _groupby.aggregate.multifunc:
 
@@ -704,11 +730,11 @@ and that the transformed data contains no NAs.
 
 .. note::
 
-   Some functions when applied to a groupby object will automatically transform
-   the input, returning an object of the same shape as the original. Passing
-   ``as_index=False`` will not affect these transformation methods.
+   Some functions will automatically transform the input when applied to a
+   GroupBy object, but returning an object of the same shape as the original. 
+   Passing ``as_index=False`` will not affect these transformation methods.
 
-   For example: ``fillna, ffill, bfill, shift``.
+   For example: ``fillna, ffill, bfill, shift.``.
 
    .. ipython:: python
 
@@ -899,7 +925,8 @@ The dimension of the returned result can also change:
 
     In [11]: grouped.apply(f)
 
-``apply`` on a Series can operate on a returned value from the applied function, that is itself a series, and possibly upcast the result to a DataFrame
+``apply`` on a Series can operate on a returned value from the applied function, 
+that is itself a series, and possibly upcast the result to a DataFrame:
 
 .. ipython:: python
 
@@ -956,15 +983,21 @@ will be (silently) dropped. Thus, this does not pose any problems:
 
    df.groupby('A').std()
 
+Note that ``df.groupby('A').colname.std().`` is more efficient than 
+``df.groupby('A').std().colname``, so if the result of an aggregation function
+is only interesting over one column (here ``colname``), it may be filtered 
+*before* applying the aggregation function.
+
 .. _groupby.missing:
 
 NA and NaT group handling
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
-If there are any NaN or NaT values in the grouping key, these will be automatically
-excluded. So there will never be an "NA group" or "NaT group". This was not the case in older
-versions of pandas, but users were generally discarding the NA group anyway
-(and supporting it was an implementation headache).
+If there are any NaN or NaT values in the grouping key, these will be 
+automatically excluded. In other words, there will never be an "NA group" or 
+"NaT group". This was not the case in older versions of pandas, but users were 
+generally discarding the NA group anyway (and supporting it was an 
+implementation headache).
 
 Grouping with ordered factors
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -1050,7 +1083,9 @@ This shows the first or last n rows from each group.
 Taking the nth row of each group
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-To select from a DataFrame or Series the nth item, use the nth method. This is a reduction method, and will return a single row (or no row) per group if you pass an int for n:
+To select from a DataFrame or Series the nth item, use 
+:meth:`~pd.core.groupby.DataFrameGroupBy.nth`. This is a reduction method, and 
+will return a single row (or no row) per group if you pass an int for n:
 
 .. ipython:: python
 
@@ -1117,8 +1152,10 @@ Enumerate groups
 .. versionadded:: 0.20.2
 
 To see the ordering of the groups (as opposed to the order of rows
-within a group given by ``cumcount``) you can use the ``ngroup``
-method.
+within a group given by ``cumcount``) you can use 
+:meth:`~pandas.core.groupby.DataFrameGroupBy.ngroup`.
+
+
 
 Note that the numbers given to the groups match the order in which the
 groups would be seen when iterating over the groupby object, not the
@@ -1179,7 +1216,7 @@ allow for a cleaner, more readable syntax. To read about ``.pipe`` in general te
 see :ref:`here <basics.pipe>`.
 
 Combining ``.groupby`` and ``.pipe`` is often useful when you need to reuse
-GroupB objects.
+GroupBy objects.
 
 For an example, imagine having a DataFrame with columns for stores, products,
 revenue and sold quantity. We'd like to do a groupwise calculation of *prices*
@@ -1234,9 +1271,9 @@ Regroup columns of a DataFrame according to their sum, and sum the aggregated on
 Multi-column factorization
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-By using ``.ngroup()``, we can extract information about the groups in
-a way similar to :func:`factorize` (as described further in the
-:ref:`reshaping API <reshaping.factorize>`) but which applies
+By using :meth:`~pandas.core.groupby.DataFrameGroupBy.ngroup`, we can extract 
+information about the groups in a way similar to :func:`factorize` (as described
+further in the :ref:`reshaping API <reshaping.factorize>`) but which applies
 naturally to multiple columns of mixed type and different
 sources. This can be useful as an intermediate categorical-like step
 in processing, when the relationships between the group rows are more

--- a/doc/source/groupby.rst
+++ b/doc/source/groupby.rst
@@ -90,15 +90,16 @@ The mapping can be specified many different ways:
 
   - A Python function, to be called on each of the axis labels.
   - A list or NumPy array of the same length as the selected axis.
-  - A dict or Series, providing a ``label -> group name`` mapping.
-  - For DataFrame objects, a string indicating a column to be used to group. Of
-    course ``df.groupby('A')`` is just syntactic sugar for
+  - A dict or ``Series``, providing a ``label -> group name`` mapping.
+  - For ``DataFrame`` objects, a string indicating a column to be used to group. 
+    Of course ``df.groupby('A')`` is just syntactic sugar for
     ``df.groupby(df['A'])``, but it makes life simpler.
-  - For DataFrame objects, a string indicating an index level to be used to group.
+  - For ``DataFrame`` objects, a string indicating an index level to be used to 
+    group.
   - A list of any of the above things.
 
 Collectively we refer to the grouping objects as the **keys**. For example,
-consider the following DataFrame:
+consider the following ``DataFrame``:
 
 .. note::
 

--- a/doc/source/indexing.rst
+++ b/doc/source/indexing.rst
@@ -228,7 +228,7 @@ as an attribute:
 
 .. warning::
 
-   - You can use this access only if the index element is a valid python identifier, e.g. ``s.1`` is not allowed.
+   - You can use this access only if the index element is a valid Python identifier, e.g. ``s.1`` is not allowed.
      See `here for an explanation of valid identifiers
      <https://docs.python.org/3/reference/lexical_analysis.html#identifiers>`__.
 
@@ -441,7 +441,7 @@ Selection By Position
    This is sometimes called ``chained assignment`` and should be avoided.
    See :ref:`Returning a View versus Copy <indexing.view_versus_copy>`.
 
-Pandas provides a suite of methods in order to get **purely integer based indexing**. The semantics follow closely python and numpy slicing. These are ``0-based`` indexing. When slicing, the start bounds is *included*, while the upper bound is *excluded*. Trying to use a non-integer, even a **valid** label will raise an ``IndexError``.
+Pandas provides a suite of methods in order to get **purely integer based indexing**. The semantics follow closely Python and numpy slicing. These are ``0-based`` indexing. When slicing, the start bounds is *included*, while the upper bound is *excluded*. Trying to use a non-integer, even a **valid** label will raise an ``IndexError``.
 
 The ``.iloc`` attribute is the primary access method. The following are valid inputs:
 
@@ -1772,7 +1772,7 @@ These both yield the same results, so which should you use? It is instructive to
 of operations on these and why method 2 (``.loc``) is much preferred over method 1 (chained ``[]``).
 
 ``dfmi['one']`` selects the first level of the columns and returns a DataFrame that is singly-indexed.
-Then another python operation ``dfmi_with_one['second']`` selects the series indexed by ``'second'`` happens.
+Then another Python operation ``dfmi_with_one['second']`` selects the series indexed by ``'second'`` happens.
 This is indicated by the variable ``dfmi_with_one`` because pandas sees these operations as separate events.
 e.g. separate calls to ``__getitem__``, so it has to treat them as linear operations, they happen one after another.
 

--- a/doc/source/indexing.rst
+++ b/doc/source/indexing.rst
@@ -441,7 +441,7 @@ Selection By Position
    This is sometimes called ``chained assignment`` and should be avoided.
    See :ref:`Returning a View versus Copy <indexing.view_versus_copy>`.
 
-Pandas provides a suite of methods in order to get **purely integer based indexing**. The semantics follow closely Python and numpy slicing. These are ``0-based`` indexing. When slicing, the start bounds is *included*, while the upper bound is *excluded*. Trying to use a non-integer, even a **valid** label will raise an ``IndexError``.
+Pandas provides a suite of methods in order to get **purely integer based indexing**. The semantics follow closely Python and NumPy slicing. These are ``0-based`` indexing. When slicing, the start bounds is *included*, while the upper bound is *excluded*. Trying to use a non-integer, even a **valid** label will raise an ``IndexError``.
 
 The ``.iloc`` attribute is the primary access method. The following are valid inputs:
 
@@ -777,7 +777,7 @@ using the ``replace`` option:
 
 By default, each row has an equal probability of being selected, but if you want rows
 to have different probabilities, you can pass the ``sample`` function sampling weights as
-``weights``. These weights can be a list, a numpy array, or a Series, but they must be of the same length as the object you are sampling. Missing values will be treated as a weight of zero, and inf values are not allowed. If weights do not sum to 1, they will be re-normalized by dividing all weights by the sum of the weights. For example:
+``weights``. These weights can be a list, a NumPy array, or a Series, but they must be of the same length as the object you are sampling. Missing values will be treated as a weight of zero, and inf values are not allowed. If weights do not sum to 1, they will be re-normalized by dividing all weights by the sum of the weights. For example:
 
 .. ipython :: python
 
@@ -805,7 +805,7 @@ as a string.
     df3 = pd.DataFrame({'col1':[1,2,3], 'col2':[2,3,4]})
     df3.sample(n=1, axis=1)
 
-Finally, one can also set a seed for ``sample``'s random number generator using the ``random_state`` argument, which will accept either an integer (as a seed) or a numpy RandomState object.
+Finally, one can also set a seed for ``sample``'s random number generator using the ``random_state`` argument, which will accept either an integer (as a seed) or a NumPy RandomState object.
 
 .. 	ipython :: python
 
@@ -893,7 +893,7 @@ evaluate an expression such as ``df.A > 2 & df.B < 3`` as
 ``df.A > (2 & df.B) < 3``, while the desired evaluation order is 
 ``(df.A > 2) & (df.B < 3)``.
 
-Using a boolean vector to index a Series works exactly as in a numpy ndarray:
+Using a boolean vector to index a Series works exactly as in a NumPy ndarray:
 
 .. ipython:: python
 

--- a/doc/source/indexing.rst
+++ b/doc/source/indexing.rst
@@ -1125,7 +1125,6 @@ as condition and ``other`` argument.
                        'C': [7, 8, 9]})
    df3.where(lambda x: x > 4, lambda x: x + 10)
 
-
 Mask
 ~~~~
 
@@ -1711,6 +1710,7 @@ As a convenience, there is a new function on DataFrame called
 :meth:`~DataFrame.reset_index` which transfers the index values into the 
 DataFrame's columns and sets a simple integer index. 
 This is the inverse operation of :meth:`~DataFrame.set_index`.
+
 
 .. ipython:: python
 

--- a/doc/source/io.rst
+++ b/doc/source/io.rst
@@ -164,7 +164,7 @@ dtype : Type name or dict of column -> type, default ``None``
   .. versionadded:: 0.20.0 support for the Python parser.
 
 engine : {``'c'``, ``'python'``}
-  Parser engine to use. The C engine is faster while the python engine is
+  Parser engine to use. The C engine is faster while the Python engine is
   currently more feature-complete.
 converters : dict, default ``None``
   Dict of functions for converting values in certain columns. Keys can either be
@@ -1529,9 +1529,9 @@ Specifying the parser engine
 ''''''''''''''''''''''''''''
 
 Under the hood pandas uses a fast and efficient parser implemented in C as well
-as a python implementation which is currently more feature-complete. Where
+as a Python implementation which is currently more feature-complete. Where
 possible pandas uses the C parser (specified as ``engine='c'``), but may fall
-back to python if C-unsupported options are specified. Currently, C-unsupported
+back to Python if C-unsupported options are specified. Currently, C-unsupported
 options include:
 
 - ``sep`` other than a single character (e.g. regex separators)
@@ -1582,7 +1582,7 @@ function takes a number of arguments. Only the first is required.
     used. (A sequence should be given if the DataFrame uses MultiIndex).
   - ``mode`` : Python write mode, default 'w'
   - ``encoding``: a string representing the encoding to use if the contents are
-    non-ASCII, for python versions prior to 3
+    non-ASCII, for Python versions prior to 3
   - ``line_terminator``: Character sequence denoting line end (default '\\n')
   - ``quoting``: Set quoting rules as in csv module (default csv.QUOTE_MINIMAL). Note that if you have set a `float_format` then floats are converted to strings and csv.QUOTE_NONNUMERIC will treat them as non-numeric
   - ``quotechar``: Character used to quote fields (default '"')
@@ -3187,7 +3187,7 @@ You can pass ``append=True`` to the writer to append to an existing pack
 
 Unlike other io methods, ``to_msgpack`` is available on both a per-object basis,
 ``df.to_msgpack()`` and using the top-level ``pd.to_msgpack(...)`` where you
-can pack arbitrary collections of python lists, dicts, scalars, while intermixing
+can pack arbitrary collections of Python lists, dicts, scalars, while intermixing
 pandas objects.
 
 .. ipython:: python
@@ -4411,7 +4411,7 @@ Several caveats.
   can ``.reset_index()`` to store the index or ``.reset_index(drop=True)`` to
   ignore it.
 - Duplicate column names and non-string columns names are not supported
-- Non supported types include ``Period`` and actual python object types. These will raise a helpful error message
+- Non supported types include ``Period`` and actual Python object types. These will raise a helpful error message
   on an attempt at serialization.
 
 See the `Full Documentation <https://github.com/wesm/feather>`__
@@ -4475,7 +4475,7 @@ Several caveats.
 - Duplicate column names and non-string columns names are not supported
 - Index level names, if specified, must be strings
 - Categorical dtypes can be serialized to parquet, but will de-serialize as ``object`` dtype.
-- Non supported types include ``Period`` and actual python object types. These will raise a helpful error message
+- Non supported types include ``Period`` and actual Python object types. These will raise a helpful error message
   on an attempt at serialization.
 
 You can specify an ``engine`` to direct the serialization. This can be one of ``pyarrow``, or ``fastparquet``, or ``auto``.

--- a/doc/source/io.rst
+++ b/doc/source/io.rst
@@ -1851,7 +1851,7 @@ is ``None``. To explicitly force ``Series`` parsing, pass ``typ=series``
 - ``convert_axes`` : boolean, try to convert the axes to the proper dtypes, default is True
 - ``convert_dates`` : a list of columns to parse for dates; If True, then try to parse date-like columns, default is True
 - ``keep_default_dates`` : boolean, default True. If parsing dates, then parse the default date-like columns
-- ``numpy`` : direct decoding to numpy arrays. default is False;
+- ``numpy`` : direct decoding to NumPy arrays. default is False;
   Supports numeric data only, although labels may be non-numeric. Also note that the JSON ordering **MUST** be the same for each term if ``numpy=True``
 - ``precise_float`` : boolean, default ``False``. Set to enable usage of higher precision (strtod) function when decoding string to double values. Default (``False``) is to use fast but less precise builtin functionality
 - ``date_unit`` : string, the timestamp unit to detect if converting dates. Default
@@ -1962,7 +1962,7 @@ The Numpy Parameter
 
 If ``numpy=True`` is passed to ``read_json`` an attempt will be made to sniff
 an appropriate dtype during deserialization and to subsequently decode directly
-to numpy arrays, bypassing the need for intermediate Python objects.
+to NumPy arrays, bypassing the need for intermediate Python objects.
 
 This can provide speedups if you are deserialising a large amount of numeric
 data:
@@ -1999,7 +1999,7 @@ The speedup is less noticeable for smaller datasets:
 
 .. warning::
 
-   Direct numpy decoding makes a number of assumptions and may fail or produce
+   Direct NumPy decoding makes a number of assumptions and may fail or produce
    unexpected output if these assumptions are not satisfied:
 
     - data is numeric.

--- a/doc/source/missing_data.rst
+++ b/doc/source/missing_data.rst
@@ -86,7 +86,7 @@ pandas provides the :func:`isna` and
 
 .. warning::
 
-   One has to be mindful that in python (and numpy), the ``nan's`` don't compare equal, but ``None's`` **do**.
+   One has to be mindful that in Python (and numpy), the ``nan's`` don't compare equal, but ``None's`` **do**.
    Note that Pandas/numpy uses the fact that ``np.nan != np.nan``, and treats ``None`` like ``np.nan``.
 
    .. ipython:: python

--- a/doc/source/missing_data.rst
+++ b/doc/source/missing_data.rst
@@ -27,7 +27,7 @@ pandas.
     NumPy will soon be able to provide a native NA type solution (similar to R)
     performant enough to be used in pandas.
 
-See the :ref:`cookbook<cookbook.missing_data>` for some advanced strategies
+See the :ref:`cookbook<cookbook.missing_data>` for some advanced strategies.
 
 Missing data basics
 -------------------
@@ -43,7 +43,7 @@ series might start on different dates. Thus, values prior to the start date
 would generally be marked as missing.
 
 In pandas, one of the most common ways that missing data is **introduced** into
-a data set is by reindexing. For example
+a data set is by reindexing. For example:
 
 .. ipython:: python
 
@@ -169,10 +169,10 @@ The descriptive statistics and computational methods discussed in the
 <api.series.stats>` and :ref:`here <api.dataframe.stats>`) are all written to
 account for missing data. For example:
 
-* When summing data, NA (missing) values will be treated as zero
-* If the data are all NA, the result will be NA
+* When summing data, NA (missing) values will be treated as zero.
+* If the data are all NA, the result will be NA.
 * Methods like **cumsum** and **cumprod** ignore NA values, but preserve them
-  in the resulting arrays
+  in the resulting arrays.
 
 .. ipython:: python
 
@@ -190,7 +190,8 @@ Sum/Prod of Empties/Nans
 .. warning::
 
    This behavior is now standard as of v0.21.0; previously sum/prod would give different
-   results if the ``bottleneck`` package was installed. See the :ref:`here <whatsnew_0210.api_breaking.bottleneck>`.
+   results if the ``bottleneck`` package was installed. 
+   See the :ref:`v0.21.0 whatsnew <whatsnew_0210.api_breaking.bottleneck>`.
 
 With ``sum`` or ``prod`` on an empty or all-``NaN`` ``Series``, or columns of a ``DataFrame``, the result will be all-``NaN``.
 
@@ -200,7 +201,7 @@ With ``sum`` or ``prod`` on an empty or all-``NaN`` ``Series``, or columns of a 
 
    s.sum()
 
-Summing of an empty ``Series``
+Summing over an empty ``Series`` will return ``NaN``:
 
 .. ipython:: python
 
@@ -250,7 +251,7 @@ of ways, which we illustrate:
 
    df2
    df2.fillna(0)
-   df2['four'].fillna('missing')
+   df2['one'].fillna('missing')
 
 **Fill gaps forward or backward**
 
@@ -328,7 +329,7 @@ Dropping axis labels with missing data: dropna
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 You may wish to simply exclude labels from a data set which refer to missing
-data. To do this, use the **dropna** method:
+data. To do this, use the :meth:`~DataFrame.dropna` method:
 
 .. ipython:: python
    :suppress:
@@ -343,7 +344,7 @@ data. To do this, use the **dropna** method:
    df.dropna(axis=1)
    df['one'].dropna()
 
-Series.dropna is a simpler method as it only has one axis to consider.
+An equivalent :meth:`~Series.dropna` method is available for Series.
 DataFrame.dropna has considerably more options than Series.dropna, which can be
 examined :ref:`in the API <api.dataframe.missing>`.
 
@@ -352,8 +353,8 @@ examined :ref:`in the API <api.dataframe.missing>`.
 Interpolation
 ~~~~~~~~~~~~~
 
-Both Series and DataFrame objects have an ``interpolate`` method that, by default,
-performs linear interpolation at missing datapoints.
+Both Series and DataFrame objects have an :meth:`~DataFrame.interpolate` method 
+that, by default, performs linear interpolation at missing datapoints.
 
 .. ipython:: python
    :suppress:
@@ -411,7 +412,7 @@ You can also interpolate with a DataFrame:
    df.interpolate()
 
 The ``method`` argument gives access to fancier interpolation methods.
-If you have scipy_ installed, you can set pass the name of a 1-d interpolation routine to ``method``.
+If you have scipy_ installed, you can pass the name of a 1-d interpolation routine to ``method``.
 You'll want to consult the full scipy interpolation documentation_ and reference guide_ for details.
 The appropriate interpolation method will depend on the type of data you are working with.
 
@@ -419,7 +420,7 @@ The appropriate interpolation method will depend on the type of data you are wor
   ``method='quadratic'`` may be appropriate.
 * If you have values approximating a cumulative distribution function,
   then ``method='pchip'`` should work well.
-* To fill missing values with goal of smooth plotting, use ``method='akima'``.
+* To fill missing values with goal of smooth plotting, consider ``method='akima'``.
 
 .. warning::
 
@@ -562,7 +563,7 @@ String/Regular Expression Replacement
    <https://docs.python.org/3/reference/lexical_analysis.html#string-literals>`__
    if this is unclear.
 
-Replace the '.' with ``NaN`` (str -> str)
+Replace the '.' with ``NaN`` (str -> str):
 
 .. ipython:: python
 
@@ -571,58 +572,58 @@ Replace the '.' with ``NaN`` (str -> str)
    df.replace('.', np.nan)
 
 Now do it with a regular expression that removes surrounding whitespace
-(regex -> regex)
+(regex -> regex):
 
 .. ipython:: python
 
    df.replace(r'\s*\.\s*', np.nan, regex=True)
 
-Replace a few different values (list -> list)
+Replace a few different values (list -> list):
 
 .. ipython:: python
 
    df.replace(['a', '.'], ['b', np.nan])
 
-list of regex -> list of regex
+list of regex -> list of regex:
 
 .. ipython:: python
 
    df.replace([r'\.', r'(a)'], ['dot', '\1stuff'], regex=True)
 
-Only search in column ``'b'`` (dict -> dict)
+Only search in column ``'b'`` (dict -> dict):
 
 .. ipython:: python
 
    df.replace({'b': '.'}, {'b': np.nan})
 
 Same as the previous example, but use a regular expression for
-searching instead (dict of regex -> dict)
+searching instead (dict of regex -> dict):
 
 .. ipython:: python
 
    df.replace({'b': r'\s*\.\s*'}, {'b': np.nan}, regex=True)
 
-You can pass nested dictionaries of regular expressions that use ``regex=True``
+You can pass nested dictionaries of regular expressions that use ``regex=True``:
 
 .. ipython:: python
 
    df.replace({'b': {'b': r''}}, regex=True)
 
-or you can pass the nested dictionary like so
+Alternatively, you can pass the nested dictionary like so:
 
 .. ipython:: python
 
    df.replace(regex={'b': {r'\s*\.\s*': np.nan}})
 
 You can also use the group of a regular expression match when replacing (dict
-of regex -> dict of regex), this works for lists as well
+of regex -> dict of regex), this works for lists as well.
 
 .. ipython:: python
 
    df.replace({'b': r'\s*(\.)\s*'}, {'b': r'\1ty'}, regex=True)
 
 You can pass a list of regular expressions, of which those that match
-will be replaced with a scalar (list of regex -> regex)
+will be replaced with a scalar (list of regex -> regex).
 
 .. ipython:: python
 
@@ -631,7 +632,7 @@ will be replaced with a scalar (list of regex -> regex)
 All of the regular expression examples can also be passed with the
 ``to_replace`` argument as the ``regex`` argument. In this case the ``value``
 argument must be passed explicitly by name or ``regex`` must be a nested
-dictionary. The previous example, in this case, would then be
+dictionary. The previous example, in this case, would then be:
 
 .. ipython:: python
 
@@ -648,7 +649,7 @@ want to use a regular expression.
 Numeric Replacement
 ~~~~~~~~~~~~~~~~~~~
 
-Similar to ``DataFrame.fillna``
+The :meth:`~DataFrame.replace` method is similar to :meth:`~DataFrame.fillna`.
 
 .. ipython:: python
 
@@ -656,7 +657,7 @@ Similar to ``DataFrame.fillna``
    df[np.random.rand(df.shape[0]) > 0.5] = 1.5
    df.replace(1.5, np.nan)
 
-Replacing more than one value via lists works as well
+Replacing more than one value is possible by passing a list.
 
 .. ipython:: python
 
@@ -664,7 +665,7 @@ Replacing more than one value via lists works as well
    df.replace([1.5, df00], [np.nan, 'a'])
    df[1].dtype
 
-You can also operate on the DataFrame in place
+You can also operate on the DataFrame in place:
 
 .. ipython:: python
 
@@ -674,7 +675,7 @@ You can also operate on the DataFrame in place
 
    When replacing multiple ``bool`` or ``datetime64`` objects, the first
    argument to ``replace`` (``to_replace``) must match the type of the value
-   being replaced type. For example,
+   being replaced. For example,
 
    .. code-block:: python
 
@@ -702,9 +703,9 @@ Missing data casting rules and indexing
 
 While pandas supports storing arrays of integer and boolean type, these types
 are not capable of storing missing data. Until we can switch to using a native
-NA type in NumPy, we've established some "casting rules" when reindexing will
-cause missing data to be introduced into, say, a Series or DataFrame. Here they
-are:
+NA type in NumPy, we've established some "casting rules". When a reindexing
+operation introduces missing data, the Series will be cast according to the
+rules introduced in the table below.
 
 .. csv-table::
     :header: "data type", "Cast to"

--- a/doc/source/missing_data.rst
+++ b/doc/source/missing_data.rst
@@ -104,7 +104,7 @@ Datetimes
 ---------
 
 For datetime64[ns] types, ``NaT`` represents missing values. This is a pseudo-native
-sentinel value that can be represented by numpy in a singular dtype (datetime64[ns]).
+sentinel value that can be represented by NumPy in a singular dtype (datetime64[ns]).
 pandas objects provide intercompatibility between ``NaT`` and ``NaN``.
 
 .. ipython:: python

--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -2894,7 +2894,7 @@ Improvements to existing features
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 - Fixed various issues with internal pprinting code, the repr() for various objects
-  including TimeStamp and Index now produces valid python code strings and
+  including TimeStamp and Index now produces valid Python code strings and
   can be used to recreate the object, (:issue:`3038`, :issue:`3379`, :issue:`3251`, :issue:`3460`)
 - ``convert_objects`` now accepts a ``copy`` parameter (defaults to ``True``)
 - ``HDFStore``

--- a/doc/source/timedeltas.rst
+++ b/doc/source/timedeltas.rst
@@ -238,7 +238,7 @@ Frequency Conversion
 
 Timedelta Series, ``TimedeltaIndex``, and ``Timedelta`` scalars can be converted to other 'frequencies' by dividing by another timedelta,
 or by astyping to a specific timedelta type. These operations yield Series and propagate ``NaT`` -> ``nan``.
-Note that division by the numpy scalar is true division, while astyping is equivalent of floor division.
+Note that division by the NumPy scalar is true division, while astyping is equivalent of floor division.
 
 .. ipython:: python
 

--- a/doc/source/timeseries.rst
+++ b/doc/source/timeseries.rst
@@ -2016,7 +2016,7 @@ Pandas provides rich support for working with timestamps in different time
 zones using ``pytz`` and ``dateutil`` libraries. ``dateutil`` currently is only
 supported for fixed offset and tzfile zones. The default library is ``pytz``.
 Support for ``dateutil`` is provided for compatibility with other
-applications e.g. if you use ``dateutil`` in other python packages.
+applications e.g. if you use ``dateutil`` in other Python packages.
 
 Working with Time Zones
 ~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/source/timeseries.rst
+++ b/doc/source/timeseries.rst
@@ -2264,15 +2264,15 @@ a convert on an aware stamp.
 
 .. note::
 
-   Using the ``.values`` accessor on a ``Series``, returns an numpy array of the data.
-   These values are converted to UTC, as numpy does not currently support timezones (even though it is *printing* in the local timezone!).
+   Using the ``.values`` accessor on a ``Series``, returns an NumPy array of the data.
+   These values are converted to UTC, as NumPy does not currently support timezones (even though it is *printing* in the local timezone!).
 
    .. ipython:: python
 
       s_naive.values
       s_aware.values
 
-   Further note that once converted to a numpy array these would lose the tz tenor.
+   Further note that once converted to a NumPy array these would lose the tz tenor.
 
    .. ipython:: python
 

--- a/doc/source/visualization.rst
+++ b/doc/source/visualization.rst
@@ -1270,7 +1270,7 @@ The layout of subplots can be specified by ``layout`` keyword. It can accept
 
 The number of axes which can be contained by rows x columns specified by ``layout`` must be
 larger than the number of required subplots. If layout can contain more axes than required,
-blank axes are not drawn. Similar to a numpy array's ``reshape`` method, you
+blank axes are not drawn. Similar to a NumPy array's ``reshape`` method, you
 can use ``-1`` for one dimension to automatically calculate the number of rows
 or columns needed, given the other.
 

--- a/doc/source/whatsnew/v0.23.0.txt
+++ b/doc/source/whatsnew/v0.23.0.txt
@@ -273,8 +273,11 @@ Performance Improvements
 Documentation Changes
 ~~~~~~~~~~~~~~~~~~~~~
 
--
--
+- Changed spelling of "numpy" to "NumPy", and "python" to "Python". (:issue:`19017`) 
+- Consistency when introducing code samples, using either colon or period.
+  Rewrote some sentences for greater clarity, added more dynamic references
+  to functions, methods and classes.
+  (:issue:`18941`, :issue:`18948`, :issue:`18973`, :issue:`19017`) 
 -
 
 .. _whatsnew_0230.bug_fixes:


### PR DESCRIPTION
This PR is a continuation of my read-through of the docs, the earlier PRs are #18941, #18973 and #18948.

**The changes included in this PR include**
- Changed spelling of "python" to "Python" for consistency, same with "numpy" to "NumPy". This change was made globally, i.e. for most documents in `/docs/source/`.
- A review of `groupby.rst` and `missing_data.rst`
  - Added punctuation where missing.
  - Added more function references (i.e. `:meth:...`) where appropriate.
  - Rewrote a few sentences.

Feedback is very welcome.

