### PR TITLE
ENH: DataFrame.append preserves columns dtype if possible

### DIFF
--- a/doc/source/whatsnew/v0.23.0.txt
+++ b/doc/source/whatsnew/v0.23.0.txt
@@ -380,6 +380,7 @@ Other Enhancements
 - :class:`IntervalIndex` now supports time zone aware ``Interval`` objects (:issue:`18537`, :issue:`18538`)
 - :func:`Series` / :func:`DataFrame` tab completion also returns identifiers in the first level of a :func:`MultiIndex`. (:issue:`16326`)
 - :func:`read_excel()` has gained the ``nrows`` parameter (:issue:`16645`)
+- :meth:`DataFrame.append` can now in more cases preserve the type of the calling dataframe's columns (e.g. if both are ``CategoricalIndex``) (:issue:`18359`)
 - :func:``DataFrame.to_json`` and ``Series.to_json`` now accept an ``index`` argument which allows the user to exclude the index from the JSON output (:issue:`17394`)
 - ``IntervalIndex.to_tuples()`` has gained the ``na_tuple`` parameter to control whether NA is returned as a tuple of NA, or NA itself (:issue:`18756`)
 - ``Categorical.rename_categories``, ``CategoricalIndex.rename_categories`` and :attr:`Series.cat.rename_categories`

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -6113,8 +6113,11 @@ class DataFrame(NDFrame):
                 # index name will be reset
                 index = Index([other.name], name=self.index.name)
 
-            combined_columns = self.columns.tolist() + self.columns.union(
-                other.index).difference(self.columns).tolist()
+            idx_diff = other.index.difference(self.columns)
+            try:
+                combined_columns = self.columns.append(idx_diff)
+            except TypeError:
+                combined_columns = self.columns.astype(object).append(idx_diff)
             other = other.reindex(combined_columns, copy=False)
             other = DataFrame(other.values.reshape((1, len(other))),
                               index=index,

--- a/pandas/tests/reshape/test_concat.py
+++ b/pandas/tests/reshape/test_concat.py
@@ -834,13 +834,14 @@ class TestAppend(ConcatenateBase):
     @pytest.mark.parametrize("df_columns", [
         pd.RangeIndex(3),
         pd.CategoricalIndex('A B C'.split()),
+        pd.CategoricalIndex('A B C'.split(), ordered=True),
         pd.MultiIndex.from_arrays(['A B C'.split(), 'D E F'.split()]),
         pd.IntervalIndex.from_breaks([0, 1, 2, 3]),
         pd.DatetimeIndex([dt.datetime(2013, 1, 3, 0, 0),
                           dt.datetime(2013, 1, 3, 6, 10),
                           dt.datetime(2013, 1, 3, 7, 12)]),
         pd.Index([1, 2, 3]),
-    ], ids=lambda x: x.__class__.__name__)
+    ], ids=lambda x: str(x.dtype))
     def test_append_same_columns_type(self, df_columns):
         # GH18359
 
@@ -870,10 +871,11 @@ class TestAppend(ConcatenateBase):
         pd.Index([4, 5, 6]),
         pd.Index([7.5, 8.5, 9.5]),
         pd.CategoricalIndex('A B C'.split()),
+        # pd.CategoricalIndex('A B C'.split(), ordered=True),
         pd.DatetimeIndex([dt.datetime(2013, 1, 3, 0, 0),
                           dt.datetime(2013, 1, 3, 6, 10),
                           dt.datetime(2013, 1, 3, 7, 12)]),
-    ], r=2), ids=lambda x: x.__class__.__name__)
+    ], r=2), ids=lambda x: str(x.dtype))
     def test_append_different_columns_types(self, df_columns, series_index):
         # GH18359
         # see also tests 'test_append_multi_index_raises' and
@@ -895,12 +897,13 @@ class TestAppend(ConcatenateBase):
     @pytest.mark.parametrize("other_type", [
         pd.RangeIndex(3),
         pd.CategoricalIndex('A B C'.split()),
+        pd.CategoricalIndex('A B C'.split(), ordered=True),
         pd.IntervalIndex.from_breaks([0, 1, 2, 3]),
         pd.DatetimeIndex([dt.datetime(2013, 1, 3, 0, 0),
                           dt.datetime(2013, 1, 3, 6, 10),
                           dt.datetime(2013, 1, 3, 7, 12)]),
         pd.Index([4, 5, 6]),
-    ], ids=lambda x: x.__class__.__name__)
+    ], ids=lambda x: str(x.dtype))
     def test_append_multi_index_raises(self, other_type):
         # GH18359
         # .append will raise if MultiIndex appends or is appended to a
@@ -923,12 +926,13 @@ class TestAppend(ConcatenateBase):
     @pytest.mark.parametrize("other_type", [
         pd.RangeIndex(3),
         pd.CategoricalIndex('A B C'.split()),
+        pd.CategoricalIndex('A B C'.split(), ordered=True),
         pd.MultiIndex.from_arrays(['A B C'.split(), 'D E F'.split()]),
         pd.DatetimeIndex([dt.datetime(2013, 1, 3, 0, 0),
                           dt.datetime(2013, 1, 3, 6, 10),
                           dt.datetime(2013, 1, 3, 7, 12)]),
         pd.Index([4, 5, 6]),
-    ], ids=lambda x: x.__class__.__name__)
+    ], ids=lambda x: str(x.dtype))
     def test_append_interval_index_raises(self, other_type):
         # GH18359
         # .append will raise if IntervalIndex appends or is appended to a

--- a/pandas/tests/reshape/test_concat.py
+++ b/pandas/tests/reshape/test_concat.py
@@ -840,7 +840,7 @@ class TestAppend(ConcatenateBase):
                           dt.datetime(2013, 1, 3, 6, 10),
                           dt.datetime(2013, 1, 3, 7, 12)]),
         pd.Index([1, 2, 3]),
-    ])
+    ], ids=lambda x: x.__class__.__name__)
     def test_append_same_columns_type(self, df_columns):
         # GH18359
 
@@ -873,7 +873,7 @@ class TestAppend(ConcatenateBase):
         pd.DatetimeIndex([dt.datetime(2013, 1, 3, 0, 0),
                           dt.datetime(2013, 1, 3, 6, 10),
                           dt.datetime(2013, 1, 3, 7, 12)]),
-    ], r=2))
+    ], r=2), ids=lambda x: x.__class__.__name__)
     def test_append_different_columns_types(self, df_columns, series_index):
         # GH18359
         # see also tests 'test_append_multi_index_raises' and
@@ -900,7 +900,7 @@ class TestAppend(ConcatenateBase):
                           dt.datetime(2013, 1, 3, 6, 10),
                           dt.datetime(2013, 1, 3, 7, 12)]),
         pd.Index([4, 5, 6]),
-    ])
+    ], ids=lambda x: x.__class__.__name__)
     def test_append_multi_index_raises(self, other_type):
         # GH18359
         # .append will raise if MultiIndex appends or is appended to a
@@ -928,7 +928,7 @@ class TestAppend(ConcatenateBase):
                           dt.datetime(2013, 1, 3, 6, 10),
                           dt.datetime(2013, 1, 3, 7, 12)]),
         pd.Index([4, 5, 6]),
-    ])
+    ], ids=lambda x: x.__class__.__name__)
     def test_append_interval_index_raises(self, other_type):
         # GH18359
         # .append will raise if IntervalIndex appends or is appended to a

--- a/pandas/tests/reshape/test_pivot.py
+++ b/pandas/tests/reshape/test_pivot.py
@@ -1540,12 +1540,14 @@ class TestCrosstab(object):
                                           index=pd.Index([1, 2, 'All'],
                                                          name='a',
                                                          dtype='object'),
-                                          columns=pd.Index([3, 4], name='b'))
+                                          columns=pd.Index([3, 4], name='b',
+                                                           dtype='object'))
         col_normal_margins = pd.DataFrame([[0.5, 0, 0.2], [0.5, 1.0, 0.8]],
                                           index=pd.Index([1, 2], name='a',
                                                          dtype='object'),
                                           columns=pd.Index([3, 4, 'All'],
-                                                           name='b'))
+                                                           name='b',
+                                                           dtype='object'))
 
         all_normal_margins = pd.DataFrame([[0.2, 0, 0.2],
                                            [0.2, 0.6, 0.8],
@@ -1554,7 +1556,8 @@ class TestCrosstab(object):
                                                          name='a',
                                                          dtype='object'),
                                           columns=pd.Index([3, 4, 'All'],
-                                                           name='b'))
+                                                           name='b',
+                                                           dtype='object'))
         tm.assert_frame_equal(pd.crosstab(df.a, df.b, normalize='index',
                                           margins=True), row_normal_margins)
         tm.assert_frame_equal(pd.crosstab(df.a, df.b, normalize='columns',


### PR DESCRIPTION
- [x] closes #18359
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry

This  PR makes ``DataFrame.append`` preserve columns dtype, e.g.:

```python
>>> idx = pd.CategoricalIndex('a b'.split())
>>> df = pd.DataFrame([[1, 2]], columns=idx)
>>> ser = pd.Series([3, 4], index=idx, name=1)
>>> df.append(ser).columns
CategoricalIndex(['a', 'b'], categories=['a', 'b'], ordered=False, dtype='category')
```

Previously, the above returned ``Index(['a', 'b'], dtype='object')``, i.e. the index type information was lost when using ``append``.