### PR TITLE
CLN: Remove tseries v0.19.0 deprecations

### DIFF
--- a/doc/source/whatsnew/v0.23.0.txt
+++ b/doc/source/whatsnew/v0.23.0.txt
@@ -247,6 +247,8 @@ Removal of prior version deprecations/changes
 - :func:`read_csv` has dropped the ``compact_ints`` and ``use_unsigned`` parameters (:issue:`13323`)
 - The ``Timestamp`` class has dropped the ``offset`` attribute in favor of ``freq`` (:issue:`13593`)
 - The ``Series``, ``Categorical``, and ``Index`` classes have dropped the ``reshape`` method (:issue:`13012`)
+- ``pandas.tseries.frequencies.get_standard_freq`` has been removed in favor of ``pandas.tseries.frequencies.to_offset(freq).rule_code`` (:issue:`13874`)
+- The ``freqstr`` keyword has been removed from ``pandas.tseries.frequencies.to_offset`` in favor of ``freq`` (:issue:`13874`)
 
 .. _whatsnew_0230.performance:
 

--- a/pandas/tests/tseries/offsets/test_offsets.py
+++ b/pandas/tests/tseries/offsets/test_offsets.py
@@ -11,9 +11,8 @@ import numpy as np
 from pandas.compat.numpy import np_datetime64_compat
 
 from pandas.core.series import Series
-from pandas.tseries.frequencies import (_offset_map, get_freq_code,
-                                        _get_freq_str, _INVALID_FREQ_ERROR,
-                                        get_offset, get_standard_freq)
+from pandas.tseries.frequencies import (_offset_map, get_freq_code, get_offset,
+                                        _get_freq_str, _INVALID_FREQ_ERROR)
 from pandas.core.indexes.datetimes import (
     _to_m8, DatetimeIndex, _daterange_cache)
 import pandas._libs.tslibs.offsets as liboffsets
@@ -2784,33 +2783,6 @@ def test_get_offset_legacy():
     for name, expected in pairs:
         with tm.assert_raises_regex(ValueError, _INVALID_FREQ_ERROR):
             get_offset(name)
-
-
-def test_get_standard_freq():
-    with tm.assert_produces_warning(FutureWarning, check_stacklevel=False):
-        fstr = get_standard_freq('W')
-    with tm.assert_produces_warning(FutureWarning, check_stacklevel=False):
-        assert fstr == get_standard_freq('w')
-    with tm.assert_produces_warning(FutureWarning, check_stacklevel=False):
-        assert fstr == get_standard_freq('1w')
-    with tm.assert_produces_warning(FutureWarning, check_stacklevel=False):
-        assert fstr == get_standard_freq(('W', 1))
-
-    with tm.assert_raises_regex(ValueError, _INVALID_FREQ_ERROR):
-        with tm.assert_produces_warning(FutureWarning, check_stacklevel=False):
-            get_standard_freq('WeEk')
-
-    with tm.assert_produces_warning(FutureWarning, check_stacklevel=False):
-        fstr = get_standard_freq('5Q')
-    with tm.assert_produces_warning(FutureWarning, check_stacklevel=False):
-        assert fstr == get_standard_freq('5q')
-
-    with tm.assert_raises_regex(ValueError, _INVALID_FREQ_ERROR):
-        with tm.assert_produces_warning(FutureWarning, check_stacklevel=False):
-            get_standard_freq('5QuarTer')
-
-    with tm.assert_produces_warning(FutureWarning, check_stacklevel=False):
-        assert fstr == get_standard_freq(('q', 5))
 
 
 class TestOffsetAliases(object):

--- a/pandas/tests/tseries/test_frequencies.py
+++ b/pandas/tests/tseries/test_frequencies.py
@@ -551,10 +551,6 @@ class TestFrequencyCode(object):
         with tm.assert_raises_regex(ValueError, 'Could not evaluate'):
             frequencies.to_offset(('', ''))
 
-        with tm.assert_produces_warning(FutureWarning, check_stacklevel=False):
-            result = frequencies.get_standard_freq(offsets.Hour())
-        assert result == 'H'
-
 
 _dti = DatetimeIndex
 

--- a/pandas/tseries/frequencies.py
+++ b/pandas/tseries/frequencies.py
@@ -3,7 +3,6 @@ from datetime import timedelta
 from pandas.compat import zip
 from pandas import compat
 import re
-import warnings
 
 import numpy as np
 
@@ -14,7 +13,6 @@ from pandas.core.dtypes.common import (
     is_datetime64_dtype)
 
 from pandas.tseries.offsets import DateOffset
-from pandas.util._decorators import deprecate_kwarg
 import pandas.tseries.offsets as offsets
 
 from pandas._libs.tslib import Timedelta
@@ -143,7 +141,6 @@ _name_to_offset_map = {'days': Day(1),
                        'nanoseconds': Nano(1)}
 
 
-@deprecate_kwarg(old_arg_name='freqstr', new_arg_name='freq')
 def to_offset(freq):
     """
     Return DateOffset object from string or tuple representation
@@ -293,18 +290,6 @@ def get_offset(name):
 
 
 getOffset = get_offset
-
-
-def get_standard_freq(freq):
-    """
-    Return the standardized frequency string
-    """
-
-    msg = ("get_standard_freq is deprecated. Use to_offset(freq).rule_code "
-           "instead.")
-    warnings.warn(msg, FutureWarning, stacklevel=2)
-    return to_offset(freq).rule_code
-
 
 # ---------------------------------------------------------------------
 # Period codes


### PR DESCRIPTION
* Remove frequencies.get_standard_freq
* Drop the "freqstr" keyword from frequencies.to_offset

Deprecated in v0.19.0

xref #13874