### PR TITLE
CLN: ASV series_methods

### DIFF
--- a/asv_bench/benchmarks/series_methods.py
+++ b/asv_bench/benchmarks/series_methods.py
@@ -1,185 +1,119 @@
-from .pandas_vb_common import *
+from datetime import datetime
+
+import numpy as np
+import pandas.util.testing as tm
+from pandas import Series, date_range, NaT
+
+from .pandas_vb_common import setup  # noqa
 
 
-class series_constructor_no_data_datetime_index(object):
+class SeriesConstructor(object):
+
     goal_time = 0.2
+    params = [None, 'dict']
+    param_names = ['data']
 
-    def setup(self):
-        self.dr = pd.date_range(
-            start=datetime(2015,10,26),
-            end=datetime(2016,1,1),
-            freq='50s'
-        )  # ~100k long
+    def setup(self, data):
+        self.idx = date_range(start=datetime(2015, 10, 26),
+                              end=datetime(2016, 1, 1),
+                              freq='50s')
+        dict_data = dict(zip(self.idx, range(len(self.idx))))
+        self.data = None if data is None else dict_data
 
-    def time_series_constructor_no_data_datetime_index(self):
-        Series(data=None, index=self.dr)
+    def time_constructor(self, data):
+        Series(data=self.data, index=self.idx)
 
 
-class series_constructor_dict_data_datetime_index(object):
+class IsIn(object):
+
     goal_time = 0.2
+    params = ['int64', 'object']
+    param_names = ['dtype']
 
-    def setup(self):
-        self.dr = pd.date_range(
-            start=datetime(2015, 10, 26),
-            end=datetime(2016, 1, 1),
-            freq='50s'
-        )  # ~100k long
-        self.data = {d: v for d, v in zip(self.dr, range(len(self.dr)))}
-
-    def time_series_constructor_no_data_datetime_index(self):
-        Series(data=self.data, index=self.dr)
-
-
-class series_isin_int64(object):
-    goal_time = 0.2
-
-    def setup(self):
-        self.s3 = Series(np.random.randint(1, 10, 100000)).astype('int64')
-        self.s4 = Series(np.random.randint(1, 100, 10000000)).astype('int64')
+    def setup(self, dtype):
+        self.s = Series(np.random.randint(1, 10, 100000)).astype(dtype)
         self.values = [1, 2]
 
-    def time_series_isin_int64(self):
-        self.s3.isin(self.values)
-
-    def time_series_isin_int64_large(self):
-        self.s4.isin(self.values)
+    def time_isin(self, dtypes):
+        self.s.isin(self.values)
 
 
-class series_isin_object(object):
+class NSort(object):
+
     goal_time = 0.2
+    params = ['last', 'first']
+    param_names = ['keep']
 
-    def setup(self):
-        self.s3 = Series(np.random.randint(1, 10, 100000)).astype('int64')
-        self.values = [1, 2]
-        self.s4 = self.s3.astype('object')
+    def setup(self, keep):
+        self.s = Series(np.random.randint(1, 10, 100000))
 
-    def time_series_isin_object(self):
-        self.s4.isin(self.values)
+    def time_nlargest(self, keep):
+        self.s.nlargest(3, keep=keep)
+
+    def time_nsmallest(self, keep):
+        self.s.nsmallest(3, keep=keep)
 
 
-class series_nlargest1(object):
+class Dropna(object):
+
     goal_time = 0.2
+    params = ['int', 'datetime']
+    param_names = ['dtype']
 
-    def setup(self):
-        self.s1 = Series(np.random.randn(10000))
-        self.s2 = Series(np.random.randint(1, 10, 10000))
-        self.s3 = Series(np.random.randint(1, 10, 100000)).astype('int64')
-        self.values = [1, 2]
-        self.s4 = self.s3.astype('object')
+    def setup(self, dtype):
+        N = 10**6
+        data = {'int': np.random.randint(1, 10, N),
+                'datetime': date_range('2000-01-01', freq='S', periods=N)}
+        self.s = Series(data[dtype])
+        if dtype == 'datetime':
+            self.s[np.random.randint(1, N, 100)] = NaT
 
-    def time_series_nlargest1(self):
-        self.s1.nlargest(3, keep='last')
-        self.s1.nlargest(3, keep='first')
-
-
-class series_nlargest2(object):
-    goal_time = 0.2
-
-    def setup(self):
-        self.s1 = Series(np.random.randn(10000))
-        self.s2 = Series(np.random.randint(1, 10, 10000))
-        self.s3 = Series(np.random.randint(1, 10, 100000)).astype('int64')
-        self.values = [1, 2]
-        self.s4 = self.s3.astype('object')
-
-    def time_series_nlargest2(self):
-        self.s2.nlargest(3, keep='last')
-        self.s2.nlargest(3, keep='first')
-
-
-class series_nsmallest2(object):
-    goal_time = 0.2
-
-    def setup(self):
-        self.s1 = Series(np.random.randn(10000))
-        self.s2 = Series(np.random.randint(1, 10, 10000))
-        self.s3 = Series(np.random.randint(1, 10, 100000)).astype('int64')
-        self.values = [1, 2]
-        self.s4 = self.s3.astype('object')
-
-    def time_series_nsmallest2(self):
-        self.s2.nsmallest(3, keep='last')
-        self.s2.nsmallest(3, keep='first')
-
-
-class series_dropna_int64(object):
-    goal_time = 0.2
-
-    def setup(self):
-        self.s = Series(np.random.randint(1, 10, 1000000))
-
-    def time_series_dropna_int64(self):
+    def time_dropna(self, dtype):
         self.s.dropna()
 
 
-class series_dropna_datetime(object):
+class Map(object):
+
     goal_time = 0.2
+    params = ['dict', 'Series']
+    param_names = 'mapper'
 
-    def setup(self):
-        self.s = Series(pd.date_range('2000-01-01', freq='S', periods=1000000))
-        self.s[np.random.randint(1, 1000000, 100)] = pd.NaT
-
-    def time_series_dropna_datetime(self):
-        self.s.dropna()
-
-
-class series_map_dict(object):
-    goal_time = 0.2
-
-    def setup(self):
+    def setup(self, mapper):
         map_size = 1000
+        map_data = Series(map_size - np.arange(map_size))
+        self.map_data = map_data if mapper == 'Series' else map_data.to_dict()
         self.s = Series(np.random.randint(0, map_size, 10000))
-        self.map_dict = {i: map_size - i for i in range(map_size)}
 
-    def time_series_map_dict(self):
-        self.s.map(self.map_dict)
+    def time_map(self, mapper):
+        self.s.map(self.map_data)
 
 
-class series_map_series(object):
+class Clip(object):
+
     goal_time = 0.2
 
     def setup(self):
-        map_size = 1000
-        self.s = Series(np.random.randint(0, map_size, 10000))
-        self.map_series = Series(map_size - np.arange(map_size))
+        self.s = Series(np.random.randn(50))
 
-    def time_series_map_series(self):
-        self.s.map(self.map_series)
-
-
-class series_clip(object):
-    goal_time = 0.2
-
-    def setup(self):
-        self.s = pd.Series(np.random.randn(50))
-
-    def time_series_dropna_datetime(self):
+    def time_clip(self):
         self.s.clip(0, 1)
 
 
-class series_value_counts(object):
+class ValueCounts(object):
+
     goal_time = 0.2
+    params = ['int', 'float', 'object']
+    param_names = ['dtype']
 
-    def setup(self):
-        self.s = Series(np.random.randint(0, 1000, size=100000))
-        self.s2 = self.s.astype(float)
+    def setup(self, dtype):
+        self.s = Series(np.random.randint(0, 1000, size=100000)).astype(dtype)
 
-        self.K = 1000
-        self.N = 100000
-        self.uniques = tm.makeStringIndex(self.K).values
-        self.s3 = Series(np.tile(self.uniques, (self.N // self.K)))
-
-    def time_value_counts_int64(self):
-        self.s.value_counts()
-
-    def time_value_counts_float64(self):
-        self.s2.value_counts()
-
-    def time_value_counts_strings(self):
+    def time_value_counts(self, dtype):
         self.s.value_counts()
 
 
-class series_dir(object):
+class Dir(object):
+
     goal_time = 0.2
 
     def setup(self):


### PR DESCRIPTION
Utilized `param` and cleaned up some benchmarks.

```
asv dev -b ^series_methods
· Discovering benchmarks
· Running 9 total benchmarks (1 commits * 1 environments * 9 benchmarks)
[  0.00%] ·· Building for existing-py_home_matt_anaconda_envs_pandas_dev_bin_python
[  0.00%] ·· Benchmarking existing-py_home_matt_anaconda_envs_pandas_dev_bin_python
[ 11.11%] ··· Running series_methods.Clip.time_clip                       290μs
[ 22.22%] ··· Running series_methods.Dir.time_dir_strings                30.5ms
[ 33.33%] ··· Running series_methods.Dropna.time_dropna                      ok
[ 33.33%] ···· 
               ========== ========
                 dtype            
               ---------- --------
                  int      4.20ms 
                datetime   19.4ms 
               ========== ========

[ 44.44%] ··· Running series_methods.IsIn.time_isin                          ok
[ 44.44%] ···· 
               ======== ========
                dtype           
               -------- --------
                int64    2.63ms 
                object   5.03ms 
               ======== ========

[ 55.56%] ··· Running series_methods.Map.time_map                            ok
[ 55.56%] ···· 
               ======== ========
                  m             
               -------- --------
                 dict    3.54ms 
                Series   2.31ms 
               ======== ========

[ 66.67%] ··· Running series_methods.NSort.time_nlargest                     ok
[ 66.67%] ···· 
               ======= ========
                 keep          
               ------- --------
                 last   5.20ms 
                first   5.53ms 
               ======= ========

[ 77.78%] ··· Running series_methods.NSort.time_nsmallest                    ok
[ 77.78%] ···· 
               ======= ========
                 keep          
               ------- --------
                 last   4.19ms 
                first   5.00ms 
               ======= ========

[ 88.89%] ··· Running ..._methods.SeriesConstructor.time_constructor         ok
[ 88.89%] ···· 
               ====== =======
                data         
               ------ -------
                None   726μs 
                dict   1.56s 
               ====== =======

[100.00%] ··· Running series_methods.ValueCounts.time_value_counts           ok
[100.00%] ···· 
               ======== ========
                dtype           
               -------- --------
                 int     4.63ms 
                float    7.00ms 
                object   24.7ms 
               ======== ========
```
