### PR TITLE
BUG: Index constructor does not maintain CategoricalDtype

### DIFF
--- a/doc/source/whatsnew/v0.23.0.txt
+++ b/doc/source/whatsnew/v0.23.0.txt
@@ -300,6 +300,7 @@ Conversion
 - Bug in :class:`FY5253` where ``datetime`` addition and subtraction incremented incorrectly for dates on the year-end but not normalized to midnight (:issue:`18854`)
 - Bug in :class:`DatetimeIndex` where adding or subtracting an array-like of ``DateOffset`` objects either raised (``np.array``, ``pd.Index``) or broadcast incorrectly (``pd.Series``) (:issue:`18849`)
 - Bug in :class:`Series` floor-division where operating on a scalar ``timedelta`` raises an exception (:issue:`18846`)
+- Bug in :class:`Index` constructor with ``dtype=CategoricalDtype(...)`` where ``categories`` and ``ordered`` are not maintained (issue:`19032`) 
 
 
 Indexing

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -197,13 +197,13 @@ class Index(IndexOpsMixin, PandasObject):
         # categorical
         if is_categorical_dtype(data) or is_categorical_dtype(dtype):
             from .category import CategoricalIndex
-            return CategoricalIndex(data, copy=copy, name=name, **kwargs)
+            return CategoricalIndex(data, dtype=dtype, copy=copy, name=name,
+                                    **kwargs)
 
         # interval
-        if is_interval_dtype(data):
+        if is_interval_dtype(data) or is_interval_dtype(dtype):
             from .interval import IntervalIndex
-            return IntervalIndex.from_intervals(data, name=name,
-                                                copy=copy)
+            return IntervalIndex(data, dtype=dtype, name=name, copy=copy)
 
         # index-like
         elif isinstance(data, (np.ndarray, Index, ABCSeries)):

--- a/pandas/tests/indexes/test_category.py
+++ b/pandas/tests/indexes/test_category.py
@@ -137,18 +137,27 @@ class TestCategoricalIndex(Base):
         data, cats, ordered = 'a a b b'.split(), 'c b a'.split(), True
         dtype = CategoricalDtype(categories=cats, ordered=ordered)
 
-        result = pd.CategoricalIndex(data, dtype=dtype)
-        expected = pd.CategoricalIndex(data, categories=cats,
-                                       ordered=ordered)
+        result = CategoricalIndex(data, dtype=dtype)
+        expected = CategoricalIndex(data, categories=cats, ordered=ordered)
         tm.assert_index_equal(result, expected, exact=True)
 
-        # error to combine categories or ordered and dtype keywords args
-        with pytest.raises(ValueError, match="Cannot specify both `dtype` and "
-                                             "`categories` or `ordered`."):
-            pd.CategoricalIndex(data, categories=cats, dtype=dtype)
-        with pytest.raises(ValueError, match="Cannot specify both `dtype` and "
-                                             "`categories` or `ordered`."):
-            pd.CategoricalIndex(data, ordered=ordered, dtype=dtype)
+        # GH 19032
+        result = Index(data, dtype=dtype)
+        tm.assert_index_equal(result, expected, exact=True)
+
+        # error when combining categories/ordered and dtype kwargs
+        msg = 'Cannot specify both `dtype` and `categories` or `ordered`.'
+        with pytest.raises(ValueError, match=msg):
+            CategoricalIndex(data, categories=cats, dtype=dtype)
+
+        with pytest.raises(ValueError, match=msg):
+            Index(data, categories=cats, dtype=dtype)
+
+        with pytest.raises(ValueError, match=msg):
+            CategoricalIndex(data, ordered=ordered, dtype=dtype)
+
+        with pytest.raises(ValueError, match=msg):
+            Index(data, ordered=ordered, dtype=dtype)
 
     def test_create_categorical(self):
         # https://github.com/pandas-dev/pandas/pull/17513


### PR DESCRIPTION
- [X] closes #19032
- [X] tests added / passed
- [X] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [X] whatsnew entry
