### PR TITLE
CLN: ASV stat_ops

### DIFF
--- a/asv_bench/benchmarks/rolling.py
+++ b/asv_bench/benchmarks/rolling.py
@@ -39,3 +39,18 @@ class Quantile(object):
 
     def time_quantile(self, contructor, window, dtype, percentile):
         self.roll.quantile(percentile)
+
+
+class DepreciatedRolling(object):
+
+    sample_time = 0.2
+    params = ['rolling_median', 'rolling_mean', 'rolling_min', 'rolling_max',
+              'rolling_var', 'rolling_skew', 'rolling_kurt', 'rolling_std']
+    param_names = ['method']
+
+    def setup(self, method):
+        self.arr = np.random.randn(100000)
+        self.win = 100
+
+    def time_method(self, method):
+        getattr(pd, method)(self.arr, self.win)

--- a/asv_bench/benchmarks/rolling.py
+++ b/asv_bench/benchmarks/rolling.py
@@ -39,18 +39,3 @@ class Quantile(object):
 
     def time_quantile(self, contructor, window, dtype, percentile):
         self.roll.quantile(percentile)
-
-
-class DepreciatedRolling(object):
-
-    sample_time = 0.2
-    params = ['rolling_median', 'rolling_mean', 'rolling_min', 'rolling_max',
-              'rolling_var', 'rolling_skew', 'rolling_kurt', 'rolling_std']
-    param_names = ['method']
-
-    def setup(self, method):
-        self.arr = np.random.randn(100000)
-        self.win = 100
-
-    def time_method(self, method):
-        getattr(pd, method)(self.arr, self.win)

--- a/asv_bench/benchmarks/stat_ops.py
+++ b/asv_bench/benchmarks/stat_ops.py
@@ -4,45 +4,33 @@ import pandas as pd
 from .pandas_vb_common import setup  # noqa
 
 
-class Bottleneck(object):
-
-    goal_time = 0.2
-    params = ([True, False], ['DataFrame', 'Series'])
-    param_names = ['use_bottleneck', 'constructor']
-
-    def setup(self, use_bottleneck, constructor):
-        values = np.random.randn(10**6)
-        self.data = getattr(pd, constructor)(values)
-        try:
-            pd.options.compute.use_bottleneck = use_bottleneck
-        except:
-            from pandas.core import nanops
-            nanops._USE_BOTTLENECK = use_bottleneck
-
-    def time_mean(self, use_bottleneck, constructor):
-        self.data.mean()
+ops = ['mean', 'sum', 'median', 'std', 'skew', 'kurt', 'mad', 'prod', 'sem',
+       'var']
 
 
 class FrameOps(object):
 
     goal_time = 0.2
-    param_names = ['op', 'dtype', 'axis']
-    params = [['mean', 'sum', 'median', 'std'],
-              ['float', 'int'],
-              [0, 1]]
+    params = [ops, ['float', 'int'], [0, 1], [True, False]]
+    param_names = ['op', 'dtype', 'axis', 'use_bottleneck']
 
-    def setup(self, op, dtype, axis):
+    def setup(self, op, dtype, axis, use_bottleneck):
         df = pd.DataFrame(np.random.randn(100000, 4)).astype(dtype)
+        try:
+            pd.options.compute.use_bottleneck = use_bottleneck
+        except:
+            from pandas.core import nanops
+            nanops._USE_BOTTLENECK = use_bottleneck
         self.df_func = getattr(df, op)
 
-    def time_op(self, op, dtype, axis):
+    def time_op(self, op, dtype, axis, use_bottleneck):
         self.df_func(axis=axis)
 
 
 class FrameMultiIndexOps(object):
 
     goal_time = 0.2
-    params = ([0, 1, [0, 1]], ['mean', 'sum', 'median'])
+    params = ([0, 1, [0, 1]], ops)
     param_names = ['level', 'op']
 
     def setup(self, level, op):
@@ -61,22 +49,26 @@ class FrameMultiIndexOps(object):
 class SeriesOps(object):
 
     goal_time = 0.2
-    param_names = ['op', 'dtype']
-    params = [['mean', 'sum', 'median', 'std'],
-              ['float', 'int']]
+    params = [ops, ['float', 'int'], [True, False]]
+    param_names = ['op', 'dtype', 'use_bottleneck']
 
-    def setup(self, op, dtype):
+    def setup(self, op, dtype, use_bottleneck):
         s = pd.Series(np.random.randn(100000)).astype(dtype)
+        try:
+            pd.options.compute.use_bottleneck = use_bottleneck
+        except:
+            from pandas.core import nanops
+            nanops._USE_BOTTLENECK = use_bottleneck
         self.s_func = getattr(s, op)
 
-    def time_op(self, op, dtype):
+    def time_op(self, op, dtype, use_bottleneck):
         self.s_func()
 
 
 class SeriesMultiIndexOps(object):
 
     goal_time = 0.2
-    params = ([0, 1, [0, 1]], ['mean', 'sum', 'median'])
+    params = ([0, 1, [0, 1]], ops)
     param_names = ['level', 'op']
 
     def setup(self, level, op):

--- a/asv_bench/benchmarks/stat_ops.py
+++ b/asv_bench/benchmarks/stat_ops.py
@@ -1,205 +1,115 @@
-from .pandas_vb_common import *
+import numpy as np
+import pandas as pd
 
-
-def _set_use_bottleneck_False():
-    try:
-        pd.options.compute.use_bottleneck = False
-    except:
-        from pandas.core import nanops
-        nanops._USE_BOTTLENECK = False
+from .pandas_vb_common import setup  # noqa
 
 
 class FrameOps(object):
-    goal_time = 0.2
 
+    goal_time = 0.2
     param_names = ['op', 'use_bottleneck', 'dtype', 'axis']
-    params = [['mean', 'sum', 'median'],
+    params = [['mean', 'sum', 'median', 'std'],
               [True, False],
               ['float', 'int'],
               [0, 1]]
 
     def setup(self, op, use_bottleneck, dtype, axis):
-        if dtype == 'float':
-            self.df = DataFrame(np.random.randn(100000, 4))
-        elif dtype == 'int':
-            self.df = DataFrame(np.random.randint(1000, size=(100000, 4)))
-
-        if not use_bottleneck:
-            _set_use_bottleneck_False()
-
-        self.func = getattr(self.df, op)
+        df = pd.DataFrame(np.random.randn(100000, 4)).astype(dtype)
+        try:
+            pd.options.compute.use_bottleneck = use_bottleneck
+        except:
+            from pandas.core import nanops
+            nanops._USE_BOTTLENECK = use_bottleneck
+        self.df_func = getattr(df, op)
 
     def time_op(self, op, use_bottleneck, dtype, axis):
-        self.func(axis=axis)
+        self.df_func(axis=axis)
 
 
-class stat_ops_level_frame_sum(object):
+class FrameMultiIndexOps(object):
+
     goal_time = 0.2
+    params = ([0, 1, [0, 1]], ['mean', 'sum', 'median'])
+    param_names = ['level', 'op']
 
-    def setup(self):
-        self.index = MultiIndex(levels=[np.arange(10), np.arange(100), np.arange(100)], labels=[np.arange(10).repeat(10000), np.tile(np.arange(100).repeat(100), 10), np.tile(np.tile(np.arange(100), 100), 10)])
-        random.shuffle(self.index.values)
-        self.df = DataFrame(np.random.randn(len(self.index), 4), index=self.index)
-        self.df_level = DataFrame(np.random.randn(100, 4), index=self.index.levels[1])
+    def setup(self, level, op):
+        levels = [np.arange(10), np.arange(100), np.arange(100)]
+        labels = [np.arange(10).repeat(10000),
+                  np.tile(np.arange(100).repeat(100), 10),
+                  np.tile(np.tile(np.arange(100), 100), 10)]
+        index = pd.MultiIndex(levels=levels, labels=labels)
+        df = pd.DataFrame(np.random.randn(len(index), 4), index=index)
+        self.df_func = getattr(df, op)
 
-    def time_stat_ops_level_frame_sum(self):
-        self.df.sum(level=1)
+    def time_op(self, level, op):
+        self.df_func(level=level)
 
 
-class stat_ops_level_frame_sum_multiple(object):
+class SeriesOps(object):
+
     goal_time = 0.2
+    param_names = ['op', 'use_bottleneck', 'dtype']
+    params = [['mean', 'sum', 'median', 'std'],
+              [True, False],
+              ['float', 'int']]
 
-    def setup(self):
-        self.index = MultiIndex(levels=[np.arange(10), np.arange(100), np.arange(100)], labels=[np.arange(10).repeat(10000), np.tile(np.arange(100).repeat(100), 10), np.tile(np.tile(np.arange(100), 100), 10)])
-        random.shuffle(self.index.values)
-        self.df = DataFrame(np.random.randn(len(self.index), 4), index=self.index)
-        self.df_level = DataFrame(np.random.randn(100, 4), index=self.index.levels[1])
+    def setup(self, op, use_bottleneck, dtype):
+        s = pd.Series(np.random.randn(100000)).astype(dtype)
+        try:
+            pd.options.compute.use_bottleneck = use_bottleneck
+        except:
+            from pandas.core import nanops
+            nanops._USE_BOTTLENECK = use_bottleneck
+        self.s_func = getattr(s, op)
 
-    def time_stat_ops_level_frame_sum_multiple(self):
-        self.df.sum(level=[0, 1])
+    def time_op(self, op, use_bottleneck, dtype):
+        self.s_func()
 
 
-class stat_ops_level_series_sum(object):
+class SeriesMultiIndexOps(object):
+
     goal_time = 0.2
+    params = ([0, 1, [0, 1]], ['mean', 'sum', 'median'])
+    param_names = ['level', 'op']
 
-    def setup(self):
-        self.index = MultiIndex(levels=[np.arange(10), np.arange(100), np.arange(100)], labels=[np.arange(10).repeat(10000), np.tile(np.arange(100).repeat(100), 10), np.tile(np.tile(np.arange(100), 100), 10)])
-        random.shuffle(self.index.values)
-        self.df = DataFrame(np.random.randn(len(self.index), 4), index=self.index)
-        self.df_level = DataFrame(np.random.randn(100, 4), index=self.index.levels[1])
+    def setup(self, level, op):
+        levels = [np.arange(10), np.arange(100), np.arange(100)]
+        labels = [np.arange(10).repeat(10000),
+                  np.tile(np.arange(100).repeat(100), 10),
+                  np.tile(np.tile(np.arange(100), 100), 10)]
+        index = pd.MultiIndex(levels=levels, labels=labels)
+        s = pd.Series(np.random.randn(len(index)), index=index)
+        self.s_func = getattr(s, op)
 
-    def time_stat_ops_level_series_sum(self):
-        self.df[1].sum(level=1)
+    def time_op(self, level, op):
+        self.s_func(level=level)
 
 
-class stat_ops_level_series_sum_multiple(object):
+class Rank(object):
+
     goal_time = 0.2
+    params = [['DataFrame', 'Series'], [True, False]]
+    param_names = ['constructor', 'pct']
 
-    def setup(self):
-        self.index = MultiIndex(levels=[np.arange(10), np.arange(100), np.arange(100)], labels=[np.arange(10).repeat(10000), np.tile(np.arange(100).repeat(100), 10), np.tile(np.tile(np.arange(100), 100), 10)])
-        random.shuffle(self.index.values)
-        self.df = DataFrame(np.random.randn(len(self.index), 4), index=self.index)
-        self.df_level = DataFrame(np.random.randn(100, 4), index=self.index.levels[1])
+    def setup(self, constructor, pct):
+        values = np.random.randn(10**5)
+        self.data = getattr(pd, constructor)(values)
 
-    def time_stat_ops_level_series_sum_multiple(self):
-        self.df[1].sum(level=[0, 1])
+    def time_rank(self, constructor, pct):
+        self.data.rank(pct=pct)
+
+    def time_average_old(self, constructor, pct):
+        self.data.rank(pct=pct) / len(self.data)
 
 
-class stat_ops_series_std(object):
+class Correlation(object):
+
     goal_time = 0.2
+    params = ['spearman', 'kendall', 'pearson']
+    param_names = ['method']
 
-    def setup(self):
-        self.s = Series(np.random.randn(100000), index=np.arange(100000))
-        self.s[::2] = np.nan
+    def setup(self, method):
+        self.df = pd.DataFrame(np.random.randn(1000, 30))
 
-    def time_stat_ops_series_std(self):
-        self.s.std()
-
-
-class stats_corr_spearman(object):
-    goal_time = 0.2
-
-    def setup(self):
-        self.df = DataFrame(np.random.randn(1000, 30))
-
-    def time_stats_corr_spearman(self):
-        self.df.corr(method='spearman')
-
-
-class stats_rank2d_axis0_average(object):
-    goal_time = 0.2
-
-    def setup(self):
-        self.df = DataFrame(np.random.randn(5000, 50))
-
-    def time_stats_rank2d_axis0_average(self):
-        self.df.rank()
-
-
-class stats_rank2d_axis1_average(object):
-    goal_time = 0.2
-
-    def setup(self):
-        self.df = DataFrame(np.random.randn(5000, 50))
-
-    def time_stats_rank2d_axis1_average(self):
-        self.df.rank(1)
-
-
-class stats_rank_average(object):
-    goal_time = 0.2
-
-    def setup(self):
-        self.values = np.concatenate([np.arange(100000), np.random.randn(100000), np.arange(100000)])
-        self.s = Series(self.values)
-
-    def time_stats_rank_average(self):
-        self.s.rank()
-
-
-class stats_rank_average_int(object):
-    goal_time = 0.2
-
-    def setup(self):
-        self.values = np.random.randint(0, 100000, size=200000)
-        self.s = Series(self.values)
-
-    def time_stats_rank_average_int(self):
-        self.s.rank()
-
-
-class stats_rank_pct_average(object):
-    goal_time = 0.2
-
-    def setup(self):
-        self.values = np.concatenate([np.arange(100000), np.random.randn(100000), np.arange(100000)])
-        self.s = Series(self.values)
-
-    def time_stats_rank_pct_average(self):
-        self.s.rank(pct=True)
-
-
-class stats_rank_pct_average_old(object):
-    goal_time = 0.2
-
-    def setup(self):
-        self.values = np.concatenate([np.arange(100000), np.random.randn(100000), np.arange(100000)])
-        self.s = Series(self.values)
-
-    def time_stats_rank_pct_average_old(self):
-        (self.s.rank() / len(self.s))
-
-
-class stats_rolling_mean(object):
-    goal_time = 0.2
-
-    def setup(self):
-        self.arr = np.random.randn(100000)
-        self.win = 100
-
-    def time_rolling_mean(self):
-        rolling_mean(self.arr, self.win)
-
-    def time_rolling_median(self):
-        rolling_median(self.arr, self.win)
-
-    def time_rolling_min(self):
-        rolling_min(self.arr, self.win)
-
-    def time_rolling_max(self):
-        rolling_max(self.arr, self.win)
-
-    def time_rolling_sum(self):
-        rolling_sum(self.arr, self.win)
-
-    def time_rolling_std(self):
-        rolling_std(self.arr, self.win)
-
-    def time_rolling_var(self):
-        rolling_var(self.arr, self.win)
-
-    def time_rolling_skew(self):
-        rolling_skew(self.arr, self.win)
-
-    def time_rolling_kurt(self):
-        rolling_kurt(self.arr, self.win)
+    def time_corr(self, method):
+        self.df.corr(method=method)


### PR DESCRIPTION
There were some old `pd.rolling_*` methods being tested in `stat_ops.py` that I moved to `rolling.py` (or should they just be removed?), otherwise the usual cleanup:

```
$ asv dev -b ^stat_ops
· Discovering benchmarks
· Running 7 total benchmarks (1 commits * 1 environments * 7 benchmarks)
[  0.00%] ·· Building for existing-py_home_matt_anaconda_envs_pandas_dev_bin_python
[  0.00%] ·· Benchmarking existing-py_home_matt_anaconda_envs_pandas_dev_bin_python
[ 14.29%] ··· Running stat_ops.Correlation.time_corr                         ok
[ 14.29%] ···· 
               ========== ========
                 method           
               ---------- --------
                spearman   118ms  
                kendall    693ms  
                pearson    5.80ms 
               ========== ========

[ 28.57%] ··· Running stat_ops.FrameMultiIndexOps.time_op                    ok
[ 28.57%] ···· 
               ======== ======== ======== ========
               --                   op            
               -------- --------------------------
                level     mean     sum     median 
               ======== ======== ======== ========
                  0      8.40ms   8.51ms   21.8ms 
                  1      8.57ms   8.52ms   22.6ms 
                [0, 1]   17.3ms   17.0ms   31.9ms 
               ======== ======== ======== ========

[ 42.86%] ··· Running stat_ops.FrameOps.time_op                              ok
[ 42.86%] ···· 
               ======== ================ ======= ======== ========
               --                                       axis      
               --------------------------------- -----------------
                  op     use_bottleneck   dtype     0        1    
               ======== ================ ======= ======== ========
                 mean         True        float   1.16ms   2.07ms 
                 mean         True         int    1.27ms   2.10ms 
                 mean        False        float   11.8ms   12.2ms 
                 mean        False         int    10.2ms   11.0ms 
                 sum          True        float   11.6ms   11.6ms 
                 sum          True         int    7.41ms   8.42ms 
                 sum         False        float   11.7ms   11.6ms 
                 sum         False         int    7.41ms   8.19ms 
                median        True        float   6.86ms   6.05ms 
                median        True         int    4.53ms   5.67ms 
                median       False        float   23.4ms   7.45s  
                median       False         int    24.9ms   7.44s  
                 std          True        float   1.95ms   4.51ms 
                 std          True         int    3.42ms   6.06ms 
                 std         False        float   23.2ms   26.6ms 
                 std         False         int    24.5ms   25.8ms 
               ======== ================ ======= ======== ========

[ 57.14%] ··· Running stat_ops.Rank.time_average_old                         ok
[ 57.14%] ···· 
               ============= ======= =======
               --                  pct      
               ------------- ---------------
                constructor    True   False 
               ============= ======= =======
                 DataFrame    435ms   432ms 
                   Series     432ms   435ms 
               ============= ======= =======

[ 71.43%] ··· Running stat_ops.Rank.time_rank                                ok
[ 71.43%] ···· 
               ============= ======== ========
               --                   pct       
               ------------- -----------------
                constructor    True    False  
               ============= ======== ========
                 DataFrame    18.6ms   18.4ms 
                   Series     18.9ms   18.2ms 
               ============= ======== ========

[ 85.71%] ··· Running stat_ops.SeriesMultiIndexOps.time_op                   ok
[ 85.71%] ···· 
               ======== ======== ======== ========
               --                   op            
               -------- --------------------------
                level     mean     sum     median 
               ======== ======== ======== ========
                  0      21.2ms   20.3ms   23.6ms 
                  1      21.0ms   21.0ms   25.0ms 
                [0, 1]   15.2ms   15.6ms   18.9ms 
               ======== ======== ======== ========

[100.00%] ··· Running stat_ops.SeriesOps.time_op                             ok
[100.00%] ···· 
               ======== ================ ======== ========
               --                              dtype      
               ------------------------- -----------------
                  op     use_bottleneck   float     int   
               ======== ================ ======== ========
                 mean         True        421μs    388μs  
                 mean        False        2.01ms   2.20ms 
                 sum          True        2.02ms   2.09ms 
                 sum         False        2.01ms   2.04ms 
                median        True        2.23ms   1.30ms 
                median       False        6.25ms   6.73ms 
                 std          True        603μs    951μs  
                 std         False        3.26ms   3.67ms 
               ======== ================ ======== ========
```
```
$ asv dev -b ^rolling.DepreciatedRolling
· Discovering benchmarks
· Running 1 total benchmarks (1 commits * 1 environments * 1 benchmarks)
[  0.00%] ·· Building for existing-py_home_matt_anaconda_envs_pandas_dev_bin_python
[  0.00%] ·· Benchmarking existing-py_home_matt_anaconda_envs_pandas_dev_bin_python
[100.00%] ··· Running rolling.DepreciatedRolling.time_method                 ok
[100.00%] ···· 
               ================ ========
                    method              
               ---------------- --------
                rolling_median   88.8ms 
                 rolling_mean    11.0ms 
                 rolling_min     12.4ms 
                 rolling_max     12.1ms 
                 rolling_var     12.9ms 
                 rolling_skew    16.2ms 
                 rolling_kurt    16.0ms 
                 rolling_std     14.2ms 
               ================ ========

[100.00%] ····· 
                
                For parameters: 'rolling_median'
                /home/matt/Projects/pandas-mroeschke/asv_bench/benchmarks/rolling.py:56: FutureWarning: pd.rolling_median is deprecated for ndarrays and will be removed in a future version
                  getattr(pd, method)(self.arr, self.win)
                
                For parameters: 'rolling_mean'
                /home/matt/Projects/pandas-mroeschke/asv_bench/benchmarks/rolling.py:56: FutureWarning: pd.rolling_mean is deprecated for ndarrays and will be removed in a future version
                  getattr(pd, method)(self.arr, self.win)
                
                For parameters: 'rolling_min'
                /home/matt/Projects/pandas-mroeschke/asv_bench/benchmarks/rolling.py:56: FutureWarning: pd.rolling_min is deprecated for ndarrays and will be removed in a future version
                  getattr(pd, method)(self.arr, self.win)
                
                For parameters: 'rolling_max'
                /home/matt/Projects/pandas-mroeschke/asv_bench/benchmarks/rolling.py:56: FutureWarning: pd.rolling_max is deprecated for ndarrays and will be removed in a future version
                  getattr(pd, method)(self.arr, self.win)
                
                For parameters: 'rolling_var'
                /home/matt/Projects/pandas-mroeschke/asv_bench/benchmarks/rolling.py:56: FutureWarning: pd.rolling_var is deprecated for ndarrays and will be removed in a future version
                  getattr(pd, method)(self.arr, self.win)
                
                For parameters: 'rolling_skew'
                /home/matt/Projects/pandas-mroeschke/asv_bench/benchmarks/rolling.py:56: FutureWarning: pd.rolling_skew is deprecated for ndarrays and will be removed in a future version
                  getattr(pd, method)(self.arr, self.win)
                
                For parameters: 'rolling_kurt'
                /home/matt/Projects/pandas-mroeschke/asv_bench/benchmarks/rolling.py:56: FutureWarning: pd.rolling_kurt is deprecated for ndarrays and will be removed in a future version
                  getattr(pd, method)(self.arr, self.win)
                
                For parameters: 'rolling_std'
                /home/matt/Projects/pandas-mroeschke/asv_bench/benchmarks/rolling.py:56: FutureWarning: pd.rolling_std is deprecated for ndarrays and will be removed in a future version
                  getattr(pd, method)(self.arr, self.win)
```