### PR TITLE
Added ISO 8601 Duration string constructor for Timedelta

### DIFF
--- a/asv_bench/benchmarks/timedelta.py
+++ b/asv_bench/benchmarks/timedelta.py
@@ -1,7 +1,38 @@
+import datetime
+
 import numpy as np
 import pandas as pd
 
 from pandas import to_timedelta, Timestamp, Timedelta
+
+
+class TimedeltaConstructor(object):
+    goal_time = 0.2
+
+    def time_from_int(self):
+        Timedelta(123456789)
+
+    def time_from_unit(self):
+        Timedelta(1, unit='d')
+
+    def time_from_components(self):
+        Timedelta(days=1, hours=2, minutes=3, seconds=4, milliseconds=5,
+                  microseconds=6, nanoseconds=7)
+
+    def time_from_datetime_timedelta(self):
+        Timedelta(datetime.timedelta(days=1, seconds=1))
+
+    def time_from_np_timedelta(self):
+        Timedelta(np.timedelta64(1, 'ms'))
+
+    def time_from_string(self):
+        Timedelta('1 days')
+
+    def time_from_iso_format(self):
+        Timedelta('P4DT12H30M5S')
+
+    def time_from_missing(self):
+        Timedelta('nat')
 
 
 class ToTimedelta(object):

--- a/doc/source/timedeltas.rst
+++ b/doc/source/timedeltas.rst
@@ -67,6 +67,7 @@ You can construct a ``Timedelta`` scalar through various arguments:
    pd.Timedelta('P0DT0H0M0.000000123S')
 
 .. versionadded:: 0.23.0
+
    Added constructor for `ISO 8601 Duration`_ strings
 
 :ref:`DateOffsets<timeseries.offsets>` (``Day, Hour, Minute, Second, Milli, Micro, Nano``) can also be used in construction.

--- a/doc/source/timedeltas.rst
+++ b/doc/source/timedeltas.rst
@@ -62,6 +62,13 @@ You can construct a ``Timedelta`` scalar through various arguments:
    pd.Timedelta('nan')
    pd.Timedelta('nat')
 
+   # ISO 8601 Duration strings
+   pd.Timedelta('P0DT0H1M0S')
+   pd.Timedelta('P0DT0H0M0.000000123S')
+
+.. versionadded:: 0.23.0
+   Added constructor for `ISO 8601 Duration`_ strings
+
 :ref:`DateOffsets<timeseries.offsets>` (``Day, Hour, Minute, Second, Milli, Micro, Nano``) can also be used in construction.
 
 .. ipython:: python

--- a/doc/source/whatsnew/v0.23.0.txt
+++ b/doc/source/whatsnew/v0.23.0.txt
@@ -211,6 +211,7 @@ Other API Changes
 - Subtracting ``NaT`` from a :class:`Series` with ``dtype='datetime64[ns]'`` returns a ``Series`` with ``dtype='timedelta64[ns]'`` instead of ``dtype='datetime64[ns]'``(:issue:`18808`)
 - Operations between a :class:`Series` with dtype ``dtype='datetime64[ns]'`` and a :class:`PeriodIndex` will correctly raises ``TypeError`` (:issue:`18850`)
 - Subtraction of :class:`Series` with timezone-aware ``dtype='datetime64[ns]'`` with mis-matched timezones will raise ``TypeError`` instead of ``ValueError`` (issue:`18817`)
+- The default ``Timedelta`` constructor now accepts an ``ISO 8601 Duration`` string as an argument (:issue:`19040`)
 
 .. _whatsnew_0230.deprecations:
 

--- a/pandas/tests/scalar/test_timedelta.py
+++ b/pandas/tests/scalar/test_timedelta.py
@@ -865,6 +865,17 @@ class TestTimedeltas(object):
         ('P0DT0H0M0.000000123S', Timedelta(nanoseconds=123)),
         ('P0DT0H0M0.00001S', Timedelta(microseconds=10)),
         ('P0DT0H0M0.001S', Timedelta(milliseconds=1)),
-        ('P0DT0H1M0S', Timedelta(minutes=1))])
+        ('P0DT0H1M0S', Timedelta(minutes=1)),
+        ('P1DT25H61M61S', Timedelta(days=1, hours=25, minutes=61, seconds=61))
+    ])
     def test_iso_constructor(self, fmt, exp):
         assert Timedelta(fmt) == exp
+
+    @pytest.mark.parametrize('fmt', [
+        'PPPPPPPPPPPP', 'PDTHMS', 'P0DT999H999M999S',
+        'P1DT0H0M0.0000000000000S', 'P1DT0H0M00000000000S',
+        'P1DT0H0M0.S'])
+    def test_iso_constructor_raises(self, fmt):
+        with tm.assert_raises_regex(ValueError, 'Invalid ISO 8601 Duration '
+                                    'format - {}'.format(fmt)):
+            Timedelta(fmt)

--- a/pandas/tests/scalar/test_timedelta.py
+++ b/pandas/tests/scalar/test_timedelta.py
@@ -853,3 +853,18 @@ class TestTimedeltas(object):
         result = Timedelta(minutes=1).isoformat()
         expected = 'P0DT0H1M0S'
         assert result == expected
+
+    @pytest.mark.parametrize('fmt,exp', [
+        ('P6DT0H50M3.010010012S', Timedelta(days=6, minutes=50, seconds=3,
+                                            milliseconds=10, microseconds=10,
+                                            nanoseconds=12)),
+        ('P-6DT0H50M3.010010012S', Timedelta(days=-6, minutes=50, seconds=3,
+                                             milliseconds=10, microseconds=10,
+                                             nanoseconds=12)),
+        ('P4DT12H30M5S', Timedelta(days=4, hours=12, minutes=30, seconds=5)),
+        ('P0DT0H0M0.000000123S', Timedelta(nanoseconds=123)),
+        ('P0DT0H0M0.00001S', Timedelta(microseconds=10)),
+        ('P0DT0H0M0.001S', Timedelta(milliseconds=1)),
+        ('P0DT0H1M0S', Timedelta(minutes=1))])
+    def test_iso_constructor(self, fmt, exp):
+        assert Timedelta(fmt) == exp


### PR DESCRIPTION
- [X] closes #19040 
- [X] tests added / passed
- [X] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [X] whatsnew entry

ASV results below

```
· Running 16 total benchmarks (2 commits * 1 environments * 8 benchmarks)
[  0.00%] · For pandas commit hash 6eda5188:
[  0.00%] ·· Building for conda-py3.6-Cython-matplotlib-numexpr-numpy-openpyxl-pytables-pytest-scipy-sqlalchemy-xlrd-xlsxwriter-xlwt...
[  0.00%] ·· Benchmarking conda-py3.6-Cython-matplotlib-numexpr-numpy-openpyxl-pytables-pytest-scipy-sqlalchemy-xlrd-xlsxwriter-xlwt
[  6.25%] ··· Running timedelta.TimedeltaConstructor.time_from_components                                                               14.6±0.2μs
[ 12.50%] ··· Running timedelta.TimedeltaConstructor.time_from_datetime_timedelta                                                       7.17±0.1μs
[ 18.75%] ··· Running timedelta.TimedeltaConstructor.time_from_int                                                                     5.86±0.08μs
[ 25.00%] ··· Running timedelta.TimedeltaConstructor.time_from_iso_format                                                               20.7±0.4μs
[ 31.25%] ··· Running timedelta.TimedeltaConstructor.time_from_missing                                                                 2.11±0.03μs
[ 37.50%] ··· Running timedelta.TimedeltaConstructor.time_from_np_timedelta                                                             4.79±0.1μs
[ 43.75%] ··· Running timedelta.TimedeltaConstructor.time_from_string                                                                  6.32±0.08μs
[ 50.00%] ··· Running timedelta.TimedeltaConstructor.time_from_unit                                                                     6.22±0.1μs
[ 50.00%] · For pandas commit hash 6552718d:
[ 50.00%] ·· Building for conda-py3.6-Cython-matplotlib-numexpr-numpy-openpyxl-pytables-pytest-scipy-sqlalchemy-xlrd-xlsxwriter-xlwt...
[ 50.00%] ·· Benchmarking conda-py3.6-Cython-matplotlib-numexpr-numpy-openpyxl-pytables-pytest-scipy-sqlalchemy-xlrd-xlsxwriter-xlwt
[ 56.25%] ··· Running timedelta.TimedeltaConstructor.time_from_components                                                               14.8±0.2μs
[ 62.50%] ··· Running timedelta.TimedeltaConstructor.time_from_datetime_timedelta                                                      7.28±0.09μs
[ 68.75%] ··· Running timedelta.TimedeltaConstructor.time_from_int                                                                      5.67±0.1μs
[ 75.00%] ··· Running timedelta.TimedeltaConstructor.time_from_iso_format                                                                   failed
[ 81.25%] ··· Running timedelta.TimedeltaConstructor.time_from_missing                                                                 2.09±0.05μs
[ 87.50%] ··· Running timedelta.TimedeltaConstructor.time_from_np_timedelta                                                            4.74±0.04μs
[ 93.75%] ··· Running timedelta.TimedeltaConstructor.time_from_string                                                                   5.97±0.1μs
[100.00%] ··· Running timedelta.TimedeltaConstructor.time_from_unit                                                                     6.29±0.1μs
SOME BENCHMARKS HAVE CHANGED SIGNIFICANTLY.
```