### PR TITLE
DEPR: removing to_long and toLong, deprecated in 0.7.0

### DIFF
--- a/doc/source/whatsnew/v0.23.0.txt
+++ b/doc/source/whatsnew/v0.23.0.txt
@@ -253,6 +253,7 @@ Removal of prior version deprecations/changes
 - ``pandas.tseries.frequencies.get_standard_freq`` has been removed in favor of ``pandas.tseries.frequencies.to_offset(freq).rule_code`` (:issue:`13874`)
 - The ``freqstr`` keyword has been removed from ``pandas.tseries.frequencies.to_offset`` in favor of ``freq`` (:issue:`13874`)
 - The ``Panel4D`` and ``PanelND`` classes have been removed (:issue:`13776`)
+- The ``Panel``class has dropped the ``to_long``and ``toLong`` methods (:issue:`19077`)
 
 .. _whatsnew_0230.performance:
 

--- a/pandas/core/panel.py
+++ b/pandas/core/panel.py
@@ -996,9 +996,6 @@ class Panel(NDFrame):
 
         return DataFrame(data, index=index, columns=self.items)
 
-    to_long = deprecate('to_long', to_frame)
-    toLong = deprecate('toLong', to_frame)
-
     def apply(self, func, axis='major', **kwargs):
         """
         Applies function along axis (or axes) of the Panel


### PR DESCRIPTION
- [X] closes #19077 
- [X] tests added / passed
- [X] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [X] whatsnew entry

  