### PR TITLE
DOC: Add information on kind parameter to resample docstring

### DIFF
--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -5725,7 +5725,7 @@ class NDFrame(PandasObject, SelectionMixin):
             For PeriodIndex only, controls whether to use the start or end of
             `rule`
         kind: {'timestamp', 'period'}, optional
-            Pass 'timestamp' to convert the resulting index to a 
+            Pass 'timestamp' to convert the resulting index to a
             ``DateTimeIndex`` or 'period' to convert it to a ``PeriodIndex``.
             By default the input representation is retained.
         loffset : timedelta

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -5724,6 +5724,10 @@ class NDFrame(PandasObject, SelectionMixin):
         convention : {'start', 'end', 's', 'e'}
             For PeriodIndex only, controls whether to use the start or end of
             `rule`
+        kind: {'timestamp', 'period'}, optional
+            Pass 'timestamp' to convert the resulting index to a 
+            ``DateTimeIndex`` or 'period' to convert it to a ``PeriodIndex``.
+            By default the input representation is retained.
         loffset : timedelta
             Adjust the resampled time labels
         base : int, default 0


### PR DESCRIPTION
xref #5023

When working on another issue I couldn't find any information in the ``resample`` [docstring](https://pandas.pydata.org/pandas-docs/stable/generated/pandas.DataFrame.resample.html) on the ``kind`` parameter so I added it. There was some relevant information in the resample [section](http://pandas.pydata.org/pandas-docs/stable/timeseries.html#resampling) of the time-series documentation.
  