### PR TITLE
TST: Add to_csv test when writing the single column CSV

### DIFF
--- a/pandas/tests/io/formats/test_to_csv.py
+++ b/pandas/tests/io/formats/test_to_csv.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+import sys
 import numpy as np
 import pandas as pd
 import pytest
@@ -8,6 +9,30 @@ from pandas.util import testing as tm
 
 
 class TestToCSV(object):
+
+    @pytest.mark.xfail((3, 6, 5) > sys.version_info >= (3, 5),
+                       reason='Python csv library bug')
+    def test_to_csv_with_single_column(self):
+        # GH18676
+        df1 = DataFrame([None, 1])
+        expected1 = """\
+""
+1.0
+"""
+        with tm.ensure_clean('test.csv') as path:
+            df1.to_csv(path, header=None, index=None)
+            with open(path, 'r') as f:
+                assert f.read() == expected1
+
+        df2 = DataFrame([1, None])
+        expected2 = """\
+1.0
+""
+"""
+        with tm.ensure_clean('test.csv') as path:
+            df2.to_csv(path, header=None, index=None)
+            with open(path, 'r') as f:
+                assert f.read() == expected2
 
     def test_to_csv_defualt_encoding(self):
         # GH17097

--- a/pandas/tests/io/formats/test_to_csv.py
+++ b/pandas/tests/io/formats/test_to_csv.py
@@ -11,9 +11,16 @@ from pandas.util import testing as tm
 class TestToCSV(object):
 
     @pytest.mark.xfail((3, 6, 5) > sys.version_info >= (3, 5),
-                       reason='Python csv library bug')
+                       reason=("Python csv library bug "
+                               "(see https://bugs.python.org/issue32255)"))
     def test_to_csv_with_single_column(self):
-        # GH18676
+        # see gh-18676, https://bugs.python.org/issue32255
+        #
+        # Python's CSV library adds an extraneous '""'
+        # before the newline when the NaN-value is in
+        # the first row. Otherwise, only the newline
+        # character is added. This behavior is inconsistent
+        # and was patched in https://bugs.python.org/pull_request4672.
         df1 = DataFrame([None, 1])
         expected1 = """\
 ""


### PR DESCRIPTION
- [x] closes #18676
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
