### PR TITLE
Fix TimedeltaIndex +/- offset array

### DIFF
--- a/doc/source/whatsnew/v0.23.0.txt
+++ b/doc/source/whatsnew/v0.23.0.txt
@@ -308,7 +308,7 @@ Conversion
 - Bug in :class:`WeekOfMonth` and class:`Week` where addition and subtraction did not roll correctly (:issue:`18510`,:issue:`18672`,:issue:`18864`)
 - Bug in :meth:`DatetimeIndex.astype` when converting between timezone aware dtypes, and converting from timezone aware to naive (:issue:`18951`)
 - Bug in :class:`FY5253` where ``datetime`` addition and subtraction incremented incorrectly for dates on the year-end but not normalized to midnight (:issue:`18854`)
-- Bug in :class:`DatetimeIndex` where adding or subtracting an array-like of ``DateOffset`` objects either raised (``np.array``, ``pd.Index``) or broadcast incorrectly (``pd.Series``) (:issue:`18849`)
+- Bug in :class:`DatetimeIndex` and :class:`TimedeltaIndex` where adding or subtracting an array-like of ``DateOffset`` objects either raised (``np.array``, ``pd.Index``) or broadcast incorrectly (``pd.Series``) (:issue:`18849`)
 - Bug in :class:`Series` floor-division where operating on a scalar ``timedelta`` raises an exception (:issue:`18846`)
 - Bug in :class:`FY5253Quarter`, :class:`LastWeekOfMonth` where rollback and rollforward behavior was inconsistent with addition and subtraction behavior (:issue:`18854`)
 - Bug in :class:`Index` constructor with ``dtype=CategoricalDtype(...)`` where ``categories`` and ``ordered`` are not maintained (issue:`19032`)

--- a/pandas/core/indexes/datetimelike.py
+++ b/pandas/core/indexes/datetimelike.py
@@ -675,20 +675,20 @@ class DatetimeIndexOpsMixin(object):
                 return NotImplemented
             elif is_timedelta64_dtype(other):
                 return self._add_delta(other)
+            elif isinstance(other, (DateOffset, timedelta)):
+                return self._add_delta(other)
+            elif is_offsetlike(other):
+                # Array/Index of DateOffset objects
+                return self._add_offset_array(other)
             elif isinstance(self, TimedeltaIndex) and isinstance(other, Index):
                 if hasattr(other, '_add_delta'):
                     return other._add_delta(self)
                 raise TypeError("cannot add TimedeltaIndex and {typ}"
                                 .format(typ=type(other)))
-            elif isinstance(other, (DateOffset, timedelta)):
-                return self._add_delta(other)
             elif is_integer(other):
                 return self.shift(other)
             elif isinstance(other, (datetime, np.datetime64)):
                 return self._add_datelike(other)
-            elif is_offsetlike(other):
-                # Array/Index of DateOffset objects
-                return self._add_offset_array(other)
             elif isinstance(other, Index):
                 return self._add_datelike(other)
             else:  # pragma: no cover
@@ -708,6 +708,11 @@ class DatetimeIndexOpsMixin(object):
                 return NotImplemented
             elif is_timedelta64_dtype(other):
                 return self._add_delta(-other)
+            elif isinstance(other, (DateOffset, timedelta)):
+                return self._add_delta(-other)
+            elif is_offsetlike(other):
+                # Array/Index of DateOffset objects
+                return self._sub_offset_array(other)
             elif isinstance(self, TimedeltaIndex) and isinstance(other, Index):
                 if not isinstance(other, TimedeltaIndex):
                     raise TypeError("cannot subtract TimedeltaIndex and {typ}"
@@ -715,17 +720,12 @@ class DatetimeIndexOpsMixin(object):
                 return self._add_delta(-other)
             elif isinstance(other, DatetimeIndex):
                 return self._sub_datelike(other)
-            elif isinstance(other, (DateOffset, timedelta)):
-                return self._add_delta(-other)
             elif is_integer(other):
                 return self.shift(-other)
             elif isinstance(other, (datetime, np.datetime64)):
                 return self._sub_datelike(other)
             elif isinstance(other, Period):
                 return self._sub_period(other)
-            elif is_offsetlike(other):
-                # Array/Index of DateOffset objects
-                return self._sub_offset_array(other)
             elif isinstance(other, Index):
                 raise TypeError("cannot subtract {typ1} and {typ2}"
                                 .format(typ1=type(self).__name__,

--- a/pandas/core/indexes/timedeltas.py
+++ b/pandas/core/indexes/timedeltas.py
@@ -1,6 +1,8 @@
 """ implement the TimedeltaIndex """
 
 from datetime import timedelta
+import warnings
+
 import numpy as np
 from pandas.core.dtypes.common import (
     _TD_DTYPE,
@@ -364,8 +366,8 @@ class TimedeltaIndex(DatetimeIndexOpsMixin, TimelikeOps, Int64Index):
             # update name when delta is index
             name = com._maybe_match_name(self, delta)
         else:
-            raise ValueError("cannot add the type {0} to a TimedeltaIndex"
-                             .format(type(delta)))
+            raise TypeError("cannot add the type {0} to a TimedeltaIndex"
+                            .format(type(delta)))
 
         result = TimedeltaIndex(new_values, freq='infer', name=name)
         return result
@@ -410,6 +412,47 @@ class TimedeltaIndex(DatetimeIndexOpsMixin, TimelikeOps, Int64Index):
         else:
             raise TypeError("cannot subtract a datelike from a TimedeltaIndex")
         return DatetimeIndex(result, name=self.name, copy=False)
+
+    def _add_offset_array(self, other):
+        # Array/Index of DateOffset objects
+        try:
+            # TimedeltaIndex can only operate with a subset of DateOffset
+            # subclasses.  Incompatible classes will raise AttributeError,
+            # which we re-raise as TypeError
+            if isinstance(other, ABCSeries):
+                return NotImplemented
+            elif len(other) == 1:
+                return self + other[0]
+            else:
+                from pandas.errors import PerformanceWarning
+                warnings.warn("Adding/subtracting array of DateOffsets to "
+                              "{} not vectorized".format(type(self)),
+                              PerformanceWarning)
+                return self.astype('O') + np.array(other)
+                # TODO: This works for __add__ but loses dtype in __sub__
+        except AttributeError:
+            raise TypeError("Cannot add non-tick DateOffset to TimedeltaIndex")
+
+    def _sub_offset_array(self, other):
+        # Array/Index of DateOffset objects
+        try:
+            # TimedeltaIndex can only operate with a subset of DateOffset
+            # subclasses.  Incompatible classes will raise AttributeError,
+            # which we re-raise as TypeError
+            if isinstance(other, ABCSeries):
+                return NotImplemented
+            elif len(other) == 1:
+                return self - other[0]
+            else:
+                from pandas.errors import PerformanceWarning
+                warnings.warn("Adding/subtracting array of DateOffsets to "
+                              "{} not vectorized".format(type(self)),
+                              PerformanceWarning)
+                res_values = self.astype('O').values - np.array(other)
+                return self.__class__(res_values, freq='infer')
+        except AttributeError:
+            raise TypeError("Cannot subtrack non-tick DateOffset from"
+                            " TimedeltaIndex")
 
     def _format_native_types(self, na_rep=u('NaT'),
                              date_format=None, **kwargs):

--- a/pandas/tests/indexes/timedeltas/test_arithmetic.py
+++ b/pandas/tests/indexes/timedeltas/test_arithmetic.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-import operator
-
 import pytest
 import numpy as np
 from datetime import timedelta
@@ -28,12 +26,6 @@ def freq(request):
     return request.param
 
 
-def _raises_and_warns(op, left, right):
-    with pytest.raises(TypeError):
-        with tm.assert_produces_warning(PerformanceWarning):
-            op(left, right)
-
-
 class TestTimedeltaIndexArithmetic(object):
     _holder = TimedeltaIndex
 
@@ -56,8 +48,12 @@ class TestTimedeltaIndexArithmetic(object):
 
         anchored = box([pd.offsets.QuarterEnd(),
                         pd.offsets.Week(weekday=2)])
-        _raises_and_warns(operator.add, tdi, anchored)
-        _raises_and_warns(operator.add, anchored, tdi)
+        with pytest.raises(TypeError):
+            with tm.assert_produces_warning(PerformanceWarning):
+                tdi + anchored
+        with pytest.raises(TypeError):
+            with tm.assert_produces_warning(PerformanceWarning):
+                anchored + tdi
 
     @pytest.mark.parametrize('box', [np.array, pd.Index])
     def test_tdi_sub_offset_array(self, box):
@@ -73,8 +69,12 @@ class TestTimedeltaIndexArithmetic(object):
         tm.assert_index_equal(res, expected)
 
         anchored = box([pd.offsets.MonthEnd(), pd.offsets.Day(n=2)])
-        _raises_and_warns(operator.sub, tdi, anchored)
-        _raises_and_warns(operator.sub, anchored, tdi)
+        with pytest.raises(TypeError):
+            with tm.assert_produces_warning(PerformanceWarning):
+                tdi - anchored
+        with pytest.raises(TypeError):
+            with tm.assert_produces_warning(PerformanceWarning):
+                anchored - tdi
 
     @pytest.mark.parametrize('names', [(None, None, None),
                                        ('foo', 'bar', None),
@@ -106,10 +106,18 @@ class TestTimedeltaIndexArithmetic(object):
 
         anchored = Series([pd.offsets.MonthEnd(), pd.offsets.Day(n=2)],
                           name=names[1])
-        _raises_and_warns(operator.add, anchored, tdi)
-        _raises_and_warns(operator.add, tdi, anchored)
-        _raises_and_warns(operator.sub, anchored, tdi)
-        _raises_and_warns(operator.sub, tdi, anchored)
+        with pytest.raises(TypeError):
+            with tm.assert_produces_warning(PerformanceWarning):
+                tdi + anchored
+        with pytest.raises(TypeError):
+            with tm.assert_produces_warning(PerformanceWarning):
+                anchored + tdi
+        with pytest.raises(TypeError):
+            with tm.assert_produces_warning(PerformanceWarning):
+                tdi - anchored
+        with pytest.raises(TypeError):
+            with tm.assert_produces_warning(PerformanceWarning):
+                anchored - tdi
 
     # TODO: Split by ops, better name
     def test_numeric_compat(self):

--- a/pandas/tests/indexes/timedeltas/test_arithmetic.py
+++ b/pandas/tests/indexes/timedeltas/test_arithmetic.py
@@ -48,6 +48,9 @@ class TestTimedeltaIndexArithmetic(object):
 
         anchored = box([pd.offsets.QuarterEnd(),
                         pd.offsets.Week(weekday=2)])
+
+        # addition/subtraction ops with anchored offsets should issue
+        # a PerformanceWarning and _then_ raise a TypeError.
         with pytest.raises(TypeError):
             with tm.assert_produces_warning(PerformanceWarning):
                 tdi + anchored
@@ -69,6 +72,9 @@ class TestTimedeltaIndexArithmetic(object):
         tm.assert_index_equal(res, expected)
 
         anchored = box([pd.offsets.MonthEnd(), pd.offsets.Day(n=2)])
+
+        # addition/subtraction ops with anchored offsets should issue
+        # a PerformanceWarning and _then_ raise a TypeError.
         with pytest.raises(TypeError):
             with tm.assert_produces_warning(PerformanceWarning):
                 tdi - anchored
@@ -106,6 +112,9 @@ class TestTimedeltaIndexArithmetic(object):
 
         anchored = Series([pd.offsets.MonthEnd(), pd.offsets.Day(n=2)],
                           name=names[1])
+
+        # addition/subtraction ops with anchored offsets should issue
+        # a PerformanceWarning and _then_ raise a TypeError.
         with pytest.raises(TypeError):
             with tm.assert_produces_warning(PerformanceWarning):
                 tdi + anchored


### PR DESCRIPTION
No issue specific to this, but analogus to #18849.  There is a checkbox for this in #18824.

- [ ] closes #xxxx
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry
