### PR TITLE
COMPAT: empty IntervalIndexis np.int64 dtype

### DIFF
--- a/pandas/core/indexes/interval.py
+++ b/pandas/core/indexes/interval.py
@@ -114,7 +114,7 @@ def maybe_convert_platform_interval(values):
         # GH 19016
         # empty lists/tuples get object dtype by default, but this is not
         # prohibited for IntervalIndex, so coerce to integer instead
-        return np.array([], dtype=np.intp)
+        return np.array([], dtype=np.int64)
     return maybe_convert_platform(values)
 
 

--- a/pandas/tests/indexes/interval/test_interval.py
+++ b/pandas/tests/indexes/interval/test_interval.py
@@ -140,7 +140,7 @@ class TestIntervalIndex(Base):
         np.array([], dtype='datetime64[ns]')])
     def test_constructors_empty(self, data, closed):
         # GH 18421
-        expected_dtype = getattr(data, 'dtype', np.intp)
+        expected_dtype = getattr(data, 'dtype', np.int64)
         expected_values = np.array([], dtype=object)
         expected_index = IntervalIndex(data, closed=closed)
 


### PR DESCRIPTION
xref #19022
32-bit wheel failure: https://travis-ci.org/MacPython/pandas-wheels/jobs/325678205