### PR TITLE
BUG: IntervalIndex set op bugs for empty results

### DIFF
--- a/doc/source/whatsnew/v0.23.0.txt
+++ b/doc/source/whatsnew/v0.23.0.txt
@@ -405,6 +405,7 @@ Indexing
 - Bug in :func:`MultiIndex.__contains__` where non-tuple keys would return ``True`` even if they had been dropped (:issue:`19027`)
 - Bug in :func:`MultiIndex.set_labels` which would cause casting (and potentially clipping) of the new labels if the ``level`` argument is not 0 or a list like [0, 1, ... ]  (:issue:`19057`)
 - Bug in ``str.extractall`` when there were no matches empty :class:`Index` was returned instead of appropriate :class:`MultiIndex` (:issue:`19034`)
+- Bug in :class:`IntervalIndex` where set operations that returned an empty ``IntervalIndex`` had the wrong dtype (:issue:`19101`)
 
 I/O
 ^^^

--- a/pandas/tests/indexes/interval/test_interval.py
+++ b/pandas/tests/indexes/interval/test_interval.py
@@ -880,6 +880,16 @@ class TestIntervalIndex(Base):
         tm.assert_index_equal(index.union(index), index)
         tm.assert_index_equal(index.union(index[:1]), index)
 
+        # GH 19101: empty result, same dtype
+        index = IntervalIndex(np.array([], dtype='int64'), closed=closed)
+        result = index.union(index)
+        tm.assert_index_equal(result, index)
+
+        # GH 19101: empty result, different dtypes
+        other = IntervalIndex(np.array([], dtype='float64'), closed=closed)
+        result = index.union(other)
+        tm.assert_index_equal(result, other)
+
     def test_intersection(self, closed):
         index = self.create_index(closed=closed)
         other = IntervalIndex.from_breaks(range(5, 13), closed=closed)
@@ -893,14 +903,49 @@ class TestIntervalIndex(Base):
 
         tm.assert_index_equal(index.intersection(index), index)
 
+        # GH 19101: empty result, same dtype
+        other = IntervalIndex.from_breaks(range(300, 314), closed=closed)
+        expected = IntervalIndex(np.array([], dtype='int64'), closed=closed)
+        result = index.intersection(other)
+        tm.assert_index_equal(result, expected)
+
+        # GH 19101: empty result, different dtypes
+        breaks = np.arange(300, 314, dtype='float64')
+        other = IntervalIndex.from_breaks(breaks, closed=closed)
+        result = index.intersection(other)
+        tm.assert_index_equal(result, expected)
+
     def test_difference(self, closed):
         index = self.create_index(closed=closed)
         tm.assert_index_equal(index.difference(index[:1]), index[1:])
 
+        # GH 19101: empty result, same dtype
+        result = index.difference(index)
+        expected = IntervalIndex(np.array([], dtype='int64'), closed=closed)
+        tm.assert_index_equal(result, expected)
+
+        # GH 19101: empty result, different dtypes
+        other = IntervalIndex.from_arrays(index.left.astype('float64'),
+                                          index.right, closed=closed)
+        result = index.difference(other)
+        tm.assert_index_equal(result, expected)
+
     def test_symmetric_difference(self, closed):
-        idx = self.create_index(closed=closed)
-        result = idx[1:].symmetric_difference(idx[:-1])
-        expected = IntervalIndex([idx[0], idx[-1]])
+        index = self.create_index(closed=closed)
+        result = index[1:].symmetric_difference(index[:-1])
+        expected = IntervalIndex([index[0], index[-1]])
+        tm.assert_index_equal(result, expected)
+
+        # GH 19101: empty result, same dtype
+        result = index.symmetric_difference(index)
+        expected = IntervalIndex(np.array([], dtype='int64'), closed=closed)
+        tm.assert_index_equal(result, expected)
+
+        # GH 19101: empty result, different dtypes
+        other = IntervalIndex.from_arrays(index.left.astype('float64'),
+                                          index.right, closed=closed)
+        result = index.symmetric_difference(other)
+        expected = IntervalIndex(np.array([], dtype='float64'), closed=closed)
         tm.assert_index_equal(result, expected)
 
     @pytest.mark.parametrize('op_name', [
@@ -909,16 +954,28 @@ class TestIntervalIndex(Base):
         index = self.create_index(closed=closed)
         set_op = getattr(index, op_name)
 
-        # test errors
+        # non-IntervalIndex
         msg = ('can only do set operations between two IntervalIndex objects '
                'that are closed on the same side')
         with tm.assert_raises_regex(ValueError, msg):
             set_op(Index([1, 2, 3]))
 
+        # mixed closed
         for other_closed in {'right', 'left', 'both', 'neither'} - {closed}:
             other = self.create_index(closed=other_closed)
             with tm.assert_raises_regex(ValueError, msg):
                 set_op(other)
+
+        # GH 19016: incompatible dtypes
+        other = interval_range(Timestamp('20180101'), periods=9, closed=closed)
+        if op_name in ('union', 'symmetric_difference'):
+            msg = ('can only do {op} between two IntervalIndex objects '
+                   'that have compatible dtypes').format(op=op_name)
+            with tm.assert_raises_regex(TypeError, msg):
+                set_op(other)
+        else:
+            # should not raise
+            set_op(other)
 
     def test_isin(self, closed):
         index = self.create_index(closed=closed)

--- a/pandas/tests/indexes/interval/test_interval.py
+++ b/pandas/tests/indexes/interval/test_interval.py
@@ -888,7 +888,7 @@ class TestIntervalIndex(Base):
         # GH 19101: empty result, different dtypes
         other = IntervalIndex(np.array([], dtype='float64'), closed=closed)
         result = index.union(other)
-        tm.assert_index_equal(result, other)
+        tm.assert_index_equal(result, index)
 
     def test_intersection(self, closed):
         index = self.create_index(closed=closed)
@@ -945,7 +945,6 @@ class TestIntervalIndex(Base):
         other = IntervalIndex.from_arrays(index.left.astype('float64'),
                                           index.right, closed=closed)
         result = index.symmetric_difference(other)
-        expected = IntervalIndex(np.array([], dtype='float64'), closed=closed)
         tm.assert_index_equal(result, expected)
 
     @pytest.mark.parametrize('op_name', [
@@ -968,13 +967,9 @@ class TestIntervalIndex(Base):
 
         # GH 19016: incompatible dtypes
         other = interval_range(Timestamp('20180101'), periods=9, closed=closed)
-        if op_name in ('union', 'symmetric_difference'):
-            msg = ('can only do {op} between two IntervalIndex objects '
-                   'that have compatible dtypes').format(op=op_name)
-            with tm.assert_raises_regex(TypeError, msg):
-                set_op(other)
-        else:
-            # should not raise
+        msg = ('can only do {op} between two IntervalIndex objects that have '
+               'compatible dtypes').format(op=op_name)
+        with tm.assert_raises_regex(TypeError, msg):
             set_op(other)
 
     def test_isin(self, closed):


### PR DESCRIPTION
- [X] closes #19101
- [X] tests added / passed
- [X] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [X] whatsnew entry

Fixed bugs described in the issue:
- Set ops that result in an empty index no longer raises.
- For empty results, the return dtype now matches the dtype of the first index.
  - Previously would always return `float64`  or `object` for empty results, depending on the op.
-  Didn't mention the raising issue in the whatsnew, since that behavior never occurred on a release, but did mention the dtype change since it occurs on 0.22.0.

Added an additional  #19016 follow-up:
 - Raise when set operation would result in a prohibited dtype:
   - Occurs when the common subtype between the two indexes is `object`.
   - Ex: `union` between `interval[int64]` and `interval[datetime64[ns]]`.
 - Behavior is generally still the same as after #19016, but improved _how_ the behavior comes about:
    - Previously the error was raised _after_ the set op data was computed, now the check occurs before.
    - Previous error message was generic, now the error message is more specific.
  
  