### PR TITLE
DEPR: Removing previously deprecated Categorical.labels (#6581)

### DIFF
--- a/doc/source/whatsnew/v0.23.0.txt
+++ b/doc/source/whatsnew/v0.23.0.txt
@@ -314,6 +314,7 @@ Removal of prior version deprecations/changes
 - The ``Panel4D`` and ``PanelND`` classes have been removed (:issue:`13776`)
 - The ``Panel``class has dropped the ``to_long``and ``toLong`` methods (:issue:`19077`)
 - The options ``display.line_with`` and ``display.height`` are removed in favor of ``display.width`` and ``display.max_rows`` respectively (:issue:`4391`, :issue:`19107`)
+- The ``labels`` attribute of the ``Categorical`` class has been removed in favor of :attribute:`Categorical.codes` (:issue:`7768`)
 
 .. _whatsnew_0230.performance:
 

--- a/pandas/core/categorical.py
+++ b/pandas/core/categorical.py
@@ -590,19 +590,6 @@ class Categorical(PandasObject):
 
     codes = property(fget=_get_codes, fset=_set_codes, doc=_codes_doc)
 
-    def _get_labels(self):
-        """
-        Get the category labels (deprecated).
-
-        .. deprecated:: 0.15.0
-            Use `.codes()` instead.
-        """
-        warn("'labels' is deprecated. Use 'codes' instead", FutureWarning,
-             stacklevel=2)
-        return self.codes
-
-    labels = property(fget=_get_labels, fset=_set_codes)
-
     def _set_categories(self, categories, fastpath=False):
         """ Sets new categories inplace
 

--- a/pandas/tests/categorical/test_api.py
+++ b/pandas/tests/categorical/test_api.py
@@ -400,15 +400,6 @@ class TestCategoricalAPI(object):
         out = cat.remove_unused_categories()
         assert out.get_values().tolist() == val.tolist()
 
-    def test_deprecated_labels(self):
-        # TODO: labels is deprecated and should be removed in 0.18 or 2017,
-        # whatever is earlier
-        cat = Categorical([1, 2, 3, np.nan], categories=[1, 2, 3])
-        exp = cat.codes
-        with tm.assert_produces_warning(FutureWarning):
-            res = cat.labels
-        tm.assert_numpy_array_equal(res, exp)
-
 
 class TestCategoricalAPIWithFactor(TestCategorical):
 


### PR DESCRIPTION
- [X] related to #6581
- [X] tests added / passed
- [X] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [X] whatsnew entry
