### PR TITLE
BUG: Avoid using realpath to make list_future_warnings.sh compatible on macosx

### DIFF
--- a/scripts/list_future_warnings.sh
+++ b/scripts/list_future_warnings.sh
@@ -28,7 +28,7 @@ EXCLUDE+="^pandas/util/_depr_module.py$|"  # generic deprecate module that raise
 EXCLUDE+="^pandas/util/testing.py$|" # contains function to evaluate if warning is raised
 EXCLUDE+="^pandas/io/parsers.py$"  # implements generic deprecation system in io reading
 
-BASE_DIR="$(dirname $(dirname $(realpath $0)))"
+BASE_DIR="$(dirname $0)/.."
 cd $BASE_DIR
 FILES=`grep -RIl "FutureWarning" pandas/* | grep -vE "$EXCLUDE"`
 OUTPUT=()


### PR DESCRIPTION
…with Mac

- [ ] closes #xxxx
- [X] tests added / passed
- [X] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
