### PR TITLE
Fix and test TimedeltaIndex.__rfloordiv__ bug

### DIFF
--- a/doc/source/whatsnew/v0.23.0.txt
+++ b/doc/source/whatsnew/v0.23.0.txt
@@ -376,7 +376,8 @@ Conversion
 - Bug in :class:`Series` with ``dtype='timedelta64[ns]`` where addition or subtraction of ``TimedeltaIndex`` could return a ``Series`` with an incorrect name (issue:`19043`)
 - Fixed bug where comparing :class:`DatetimeIndex` failed to raise ``TypeError`` when attempting to compare timezone-aware and timezone-naive datetimelike objects (:issue:`18162`)
 - Bug in :class:`DatetimeIndex` where the repr was not showing high-precision time values at the end of a day (e.g., 23:59:59.999999999) (:issue:`19030`)
-
+- Bug where dividing a scalar timedelta-like object with :class:`TimedeltaIndex` performed the reciprocal operation (:issue:`19125`)
+-
 
 Indexing
 ^^^^^^^^

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -3861,7 +3861,7 @@ class Index(IndexOpsMixin, PandasObject):
             return self._shallow_copy(self.values[~self._isnan])
         return self._shallow_copy()
 
-    def _evaluate_with_timedelta_like(self, other, op, opstr):
+    def _evaluate_with_timedelta_like(self, other, op, opstr, reversed=False):
         raise TypeError("can only perform ops with timedelta like values")
 
     def _evaluate_with_datetime_like(self, other, op, opstr):
@@ -4025,7 +4025,8 @@ class Index(IndexOpsMixin, PandasObject):
                 # handle time-based others
                 if isinstance(other, (ABCDateOffset, np.timedelta64,
                                       Timedelta, datetime.timedelta)):
-                    return self._evaluate_with_timedelta_like(other, op, opstr)
+                    return self._evaluate_with_timedelta_like(other, op, opstr,
+                                                              reversed)
                 elif isinstance(other, (Timestamp, np.datetime64)):
                     return self._evaluate_with_datetime_like(other, op, opstr)
 

--- a/pandas/tests/indexes/timedeltas/test_arithmetic.py
+++ b/pandas/tests/indexes/timedeltas/test_arithmetic.py
@@ -286,6 +286,23 @@ class TestTimedeltaIndexArithmetic(object):
 
     # -------------------------------------------------------------
 
+    @pytest.mark.parametrize('scalar_td', [
+        timedelta(minutes=10, seconds=7),
+        Timedelta('10m7s'),
+        Timedelta('10m7s').to_timedelta64()])
+    def test_tdi_floordiv_timedelta_scalar(self, scalar_td):
+        # GH#
+        tdi = TimedeltaIndex(['00:05:03', '00:05:03', pd.NaT], freq=None)
+        expected = pd.Index([2.0, 2.0, np.nan])
+
+        res = tdi.__rfloordiv__(scalar_td)
+        tm.assert_index_equal(res, expected)
+
+        expected = pd.Index([0.0, 0.0, np.nan])
+
+        res = tdi // (scalar_td)
+        tm.assert_index_equal(res, expected)
+
     # TODO: Split by operation, better name
     def test_ops_compat(self):
 

--- a/pandas/tests/indexes/timedeltas/test_arithmetic.py
+++ b/pandas/tests/indexes/timedeltas/test_arithmetic.py
@@ -291,7 +291,7 @@ class TestTimedeltaIndexArithmetic(object):
         Timedelta('10m7s'),
         Timedelta('10m7s').to_timedelta64()])
     def test_tdi_floordiv_timedelta_scalar(self, scalar_td):
-        # GH#
+        # GH#19125
         tdi = TimedeltaIndex(['00:05:03', '00:05:03', pd.NaT], freq=None)
         expected = pd.Index([2.0, 2.0, np.nan])
 


### PR DESCRIPTION
I thought we were ready to get rid of _TimeOp, but doing so turned up a couple of new bugs.

Setup:
```
scalar_td = pd.Timedelta('10m7s')
tdi = TimedeltaIndex(['00:05:03', '00:05:03', pd.NaT], freq=None)
```

Before:
```
>>> tdi.__rfloordiv__(scalar_td)
Float64Index([0.0, 0.0, nan], dtype='float64')
```

After:
```
>>> tdi.__rfloordiv__(scalar_td)
Float64Index([2.0, 2.0, nan], dtype='float64')
```

- [ ] closes #xxxx
- [x] tests added / passed
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry
