### PR TITLE
TST: Add test for setting with loc on DataFrame with one row

### DIFF
--- a/pandas/tests/indexing/test_loc.py
+++ b/pandas/tests/indexing/test_loc.py
@@ -420,6 +420,13 @@ class TestLoc(Base):
         df.loc[:, 'date'] = 1.0
         tm.assert_frame_equal(df, expected)
 
+        # GH 15494
+        # setting on frame with single row
+        df = DataFrame({'date': Series([Timestamp('20180101')])})
+        df.loc[:, 'date'] = 'string'
+        expected = DataFrame({'date': Series(['string'])})
+        tm.assert_frame_equal(df, expected)
+
     def test_loc_setitem_consistency_empty(self):
         # empty (essentially noops)
         expected = DataFrame(columns=['x', 'y'])


### PR DESCRIPTION
- [X] closes #15494
- [X] tests added / passed
- [X] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`

Issue appears to be have been fixed for a while, since 0.21.x at least, just added a test to ensure there's no regression.
  