### PR TITLE
BUG: read_parquet, to_parquet for s3 destinations

### DIFF
--- a/doc/source/whatsnew/v0.23.0.txt
+++ b/doc/source/whatsnew/v0.23.0.txt
@@ -415,7 +415,7 @@ I/O
 - Bug in :func:`read_sas` where a file with 0 variables gave an ``AttributeError`` incorrectly. Now it gives an ``EmptyDataError`` (:issue:`18184`)
 - Bug in :func:`DataFrame.to_latex()` where pairs of braces meant to serve as invisible placeholders were escaped (:issue:`18667`)
 - Bug in :func:`read_json` where large numeric values were causing an ``OverflowError`` (:issue:`18842`)
-- Bug in :func:`DataFrame.to_parquet` where an attempt to write to S3 path fails with ``ValueError`` (:issue:`19134`)
+- Bug in :func:`DataFrame.to_parquet` exception is thrown if write destination is S3 (:issue:`19134`)
 -
 
 Plotting

--- a/doc/source/whatsnew/v0.23.0.txt
+++ b/doc/source/whatsnew/v0.23.0.txt
@@ -415,6 +415,7 @@ I/O
 - Bug in :func:`read_sas` where a file with 0 variables gave an ``AttributeError`` incorrectly. Now it gives an ``EmptyDataError`` (:issue:`18184`)
 - Bug in :func:`DataFrame.to_latex()` where pairs of braces meant to serve as invisible placeholders were escaped (:issue:`18667`)
 - Bug in :func:`read_json` where large numeric values were causing an ``OverflowError`` (:issue:`18842`)
+- Bug in :func:`DataFrame.to_parquet` where an attempt to write to S3 path fails with ``ValueError`` (:issue:`19134`)
 -
 
 Plotting

--- a/doc/source/whatsnew/v0.23.0.txt
+++ b/doc/source/whatsnew/v0.23.0.txt
@@ -415,7 +415,7 @@ I/O
 - Bug in :func:`read_sas` where a file with 0 variables gave an ``AttributeError`` incorrectly. Now it gives an ``EmptyDataError`` (:issue:`18184`)
 - Bug in :func:`DataFrame.to_latex()` where pairs of braces meant to serve as invisible placeholders were escaped (:issue:`18667`)
 - Bug in :func:`read_json` where large numeric values were causing an ``OverflowError`` (:issue:`18842`)
-- Bug in :func:`DataFrame.to_parquet` exception is thrown if write destination is S3 (:issue:`19134`)
+- Bug in :func:`DataFrame.to_parquet` where an exception was raised if the write destination is S3 (:issue:`19134`)
 -
 
 Plotting

--- a/pandas/io/common.py
+++ b/pandas/io/common.py
@@ -164,7 +164,7 @@ def is_s3_url(url):
     """Check for an s3, s3n, or s3a url"""
     try:
         return parse_url(url).scheme in ['s3', 's3n', 's3a']
-    except: # noqa
+    except:  # noqa
         return False
 
 

--- a/pandas/io/common.py
+++ b/pandas/io/common.py
@@ -11,7 +11,6 @@ from pandas import compat
 from pandas.io.formats.printing import pprint_thing
 from pandas.core.common import AbstractMethodError
 from pandas.core.dtypes.common import is_number, is_file_like
-from pandas.io.s3 import is_s3_url
 
 # compat
 from pandas.errors import (ParserError, DtypeWarning,  # noqa
@@ -159,6 +158,14 @@ def _stringify_path(filepath_or_buffer):
     if _PY_PATH_INSTALLED and isinstance(filepath_or_buffer, LocalPath):
         return filepath_or_buffer.strpath
     return filepath_or_buffer
+
+
+def is_s3_url(url):
+    """Check for an s3, s3n, or s3a url"""
+    try:
+        return parse_url(url).scheme in ['s3', 's3n', 's3a']
+    except:
+        return False
 
 
 def get_filepath_or_buffer(filepath_or_buffer, encoding=None,

--- a/pandas/io/common.py
+++ b/pandas/io/common.py
@@ -179,7 +179,7 @@ def get_filepath_or_buffer(filepath_or_buffer, encoding=None,
     filepath_or_buffer : a url, filepath (str, py.path.local or pathlib.Path),
                          or buffer
     encoding : the encoding to use to decode py3 bytes, default is 'utf-8'
-    mode : str, optional applies when opening S3 destinations for writing
+    mode : str, optional
 
     Returns
     -------

--- a/pandas/io/common.py
+++ b/pandas/io/common.py
@@ -164,7 +164,7 @@ def is_s3_url(url):
     """Check for an s3, s3n, or s3a url"""
     try:
         return parse_url(url).scheme in ['s3', 's3n', 's3a']
-    except:
+    except: # noqa
         return False
 
 

--- a/pandas/io/common.py
+++ b/pandas/io/common.py
@@ -179,7 +179,7 @@ def get_filepath_or_buffer(filepath_or_buffer, encoding=None,
     filepath_or_buffer : a url, filepath (str, py.path.local or pathlib.Path),
                          or buffer
     encoding : the encoding to use to decode py3 bytes, default is 'utf-8'
-    mode : One of 'rb' or 'wb' or 'ab'. default: 'rb'
+    mode : {'rb', 'wb', 'ab'}
 
     Returns
     -------

--- a/pandas/io/common.py
+++ b/pandas/io/common.py
@@ -179,6 +179,7 @@ def get_filepath_or_buffer(filepath_or_buffer, encoding=None,
     filepath_or_buffer : a url, filepath (str, py.path.local or pathlib.Path),
                          or buffer
     encoding : the encoding to use to decode py3 bytes, default is 'utf-8'
+    mode : One of 'rb' or 'wb' or 'ab'. default: 'rb'
 
     Returns
     -------

--- a/pandas/io/common.py
+++ b/pandas/io/common.py
@@ -179,12 +179,11 @@ def get_filepath_or_buffer(filepath_or_buffer, encoding=None,
     filepath_or_buffer : a url, filepath (str, py.path.local or pathlib.Path),
                          or buffer
     encoding : the encoding to use to decode py3 bytes, default is 'utf-8'
-    mode : {'rb', 'wb', 'ab'} applies to S3 where a write mandates opening the
-            file in 'wb' mode.
+    mode : str, optional applies when opening S3 destinations for writing
 
     Returns
     -------
-    a filepath_or_buffer, the encoding, the compression
+    a filepath_ or buffer or S3File instance, the encoding, the compression
     """
     filepath_or_buffer = _stringify_path(filepath_or_buffer)
 

--- a/pandas/io/common.py
+++ b/pandas/io/common.py
@@ -169,7 +169,7 @@ def _stringify_path(filepath_or_buffer):
 
 
 def get_filepath_or_buffer(filepath_or_buffer, encoding=None,
-                           compression=None):
+                           compression=None, mode='rb'):
     """
     If the filepath_or_buffer is a url, translate and return the buffer.
     Otherwise passthrough.
@@ -199,7 +199,8 @@ def get_filepath_or_buffer(filepath_or_buffer, encoding=None,
         from pandas.io import s3
         return s3.get_filepath_or_buffer(filepath_or_buffer,
                                          encoding=encoding,
-                                         compression=compression)
+                                         compression=compression,
+                                         mode=mode)
 
     if isinstance(filepath_or_buffer, (compat.string_types,
                                        compat.binary_type,

--- a/pandas/io/parquet.py
+++ b/pandas/io/parquet.py
@@ -196,7 +196,10 @@ class FastParquetImpl(BaseImpl):
         # Use tobytes() instead.
 
         if is_s3_url(path):
+            # path is s3:// so we need to open the s3file in 'wb' mode.
+            # TODO: Support 'ab'
             path, _, _ = get_filepath_or_buffer(path, mode='wb')
+            # And pass the opened s3file to the fastparquet internal impl.
             kwargs['open_with'] = lambda path, _: path
         else:
             path, _, _ = get_filepath_or_buffer(path)
@@ -207,6 +210,9 @@ class FastParquetImpl(BaseImpl):
 
     def read(self, path, columns=None, **kwargs):
         if is_s3_url(path):
+            # When path is s3:// an S3File is returned.
+            # We need to retain the original path(str) while also
+            # pass the S3File().open function to fsatparquet impl.
             s3, _, _ = get_filepath_or_buffer(path)
             parquet_file = self.api.ParquetFile(path, open_with=s3.s3.open)
         else:

--- a/pandas/io/parquet.py
+++ b/pandas/io/parquet.py
@@ -5,8 +5,7 @@ from distutils.version import LooseVersion
 from pandas import DataFrame, RangeIndex, Int64Index, get_option
 from pandas.compat import string_types
 from pandas.core.common import AbstractMethodError
-from pandas.io.common import get_filepath_or_buffer
-from pandas.io.s3 import is_s3_url
+from pandas.io.common import get_filepath_or_buffer, is_s3_url
 
 
 def get_engine(engine):

--- a/pandas/io/parquet.py
+++ b/pandas/io/parquet.py
@@ -194,14 +194,16 @@ class FastParquetImpl(BaseImpl):
         # thriftpy/protocol/compact.py:339:
         # DeprecationWarning: tostring() is deprecated.
         # Use tobytes() instead.
-        path, _, _ = get_filepath_or_buffer(path)
+        path, _, _ = get_filepath_or_buffer(path, mode='wb')
         with catch_warnings(record=True):
             self.api.write(path, df,
-                           compression=compression, **kwargs)
+                           compression=compression,
+                           open_with=lambda path, mode: path,
+                           **kwargs)
 
     def read(self, path, columns=None, **kwargs):
         path, _, _ = get_filepath_or_buffer(path)
-        parquet_file = self.api.ParquetFile(path)
+        parquet_file = self.api.ParquetFile(path, open_with=lambda path, mode: path)
         return parquet_file.to_pandas(columns=columns, **kwargs)
 
 

--- a/pandas/io/parquet.py
+++ b/pandas/io/parquet.py
@@ -194,16 +194,14 @@ class FastParquetImpl(BaseImpl):
         # thriftpy/protocol/compact.py:339:
         # DeprecationWarning: tostring() is deprecated.
         # Use tobytes() instead.
-        path, _, _ = get_filepath_or_buffer(path, mode='wb')
+        path, _, _ = get_filepath_or_buffer(path)
         with catch_warnings(record=True):
             self.api.write(path, df,
-                           compression=compression,
-                           open_with=lambda path, mode: path,
-                           **kwargs)
+                           compression=compression, **kwargs)
 
     def read(self, path, columns=None, **kwargs):
         path, _, _ = get_filepath_or_buffer(path)
-        parquet_file = self.api.ParquetFile(path, open_with=lambda path, mode: path)
+        parquet_file = self.api.ParquetFile(path)
         return parquet_file.to_pandas(columns=columns, **kwargs)
 
 

--- a/pandas/io/parquet.py
+++ b/pandas/io/parquet.py
@@ -198,6 +198,7 @@ class FastParquetImpl(BaseImpl):
         if is_s3_url(path):
             # path is s3:// so we need to open the s3file in 'wb' mode.
             # TODO: Support 'ab'
+
             path, _, _ = get_filepath_or_buffer(path, mode='wb')
             # And pass the opened s3file to the fastparquet internal impl.
             kwargs['open_with'] = lambda path, _: path

--- a/pandas/io/parquet.py
+++ b/pandas/io/parquet.py
@@ -107,7 +107,7 @@ class PyArrowImpl(BaseImpl):
         self.validate_dataframe(df)
         if self._pyarrow_lt_070:
             self._validate_write_lt_070(df)
-        path, _, _ = get_filepath_or_buffer(path)
+        path, _, _ = get_filepath_or_buffer(path, mode='wb')
 
         if self._pyarrow_lt_060:
             table = self.api.Table.from_pandas(df, timestamps_to_ms=True)

--- a/pandas/io/parquet.py
+++ b/pandas/io/parquet.py
@@ -6,7 +6,7 @@ from pandas import DataFrame, RangeIndex, Int64Index, get_option
 from pandas.compat import string_types
 from pandas.core.common import AbstractMethodError
 from pandas.io.common import get_filepath_or_buffer
-
+from pandas.io.s3 import is_s3_url
 
 def get_engine(engine):
     """ return our implementation """
@@ -190,6 +190,10 @@ class FastParquetImpl(BaseImpl):
         self.api = fastparquet
 
     def write(self, df, path, compression='snappy', **kwargs):
+        if is_s3_url(path):
+            raise NotImplementedError("fastparquet s3 write is not implemented."
+                                      " Consider using pyarrow instead.")
+
         self.validate_dataframe(df)
         # thriftpy/protocol/compact.py:339:
         # DeprecationWarning: tostring() is deprecated.

--- a/pandas/io/parquet.py
+++ b/pandas/io/parquet.py
@@ -8,6 +8,7 @@ from pandas.core.common import AbstractMethodError
 from pandas.io.common import get_filepath_or_buffer
 from pandas.io.s3 import is_s3_url
 
+
 def get_engine(engine):
     """ return our implementation """
 
@@ -191,7 +192,7 @@ class FastParquetImpl(BaseImpl):
 
     def write(self, df, path, compression='snappy', **kwargs):
         if is_s3_url(path):
-            raise NotImplementedError("fastparquet s3 write is not implemented."
+            raise NotImplementedError("fastparquet s3 write isn't implemented."
                                       " Consider using pyarrow instead.")
 
         self.validate_dataframe(df)

--- a/pandas/io/s3.py
+++ b/pandas/io/s3.py
@@ -18,14 +18,6 @@ def _strip_schema(url):
     return result.netloc + result.path
 
 
-def is_s3_url(url):
-    """Check for an s3, s3n, or s3a url"""
-    try:
-        return parse_url(url).scheme in ['s3', 's3n', 's3a']
-    except:
-        return False
-
-
 def get_filepath_or_buffer(filepath_or_buffer, encoding=None,
                            compression=None, mode=None):
 

--- a/pandas/io/s3.py
+++ b/pandas/io/s3.py
@@ -18,8 +18,20 @@ def _strip_schema(url):
     return result.netloc + result.path
 
 
+def is_s3_url(url):
+    """Check for an s3, s3n, or s3a url"""
+    try:
+        return parse_url(url).scheme in ['s3', 's3n', 's3a']
+    except:
+        return False
+
+
 def get_filepath_or_buffer(filepath_or_buffer, encoding=None,
-                           compression=None, mode='rb'):
+                           compression=None, mode=None):
+
+    if mode is None:
+        mode = 'rb'
+
     fs = s3fs.S3FileSystem(anon=False)
     try:
         filepath_or_buffer = fs.open(_strip_schema(filepath_or_buffer), mode)

--- a/pandas/io/s3.py
+++ b/pandas/io/s3.py
@@ -19,10 +19,10 @@ def _strip_schema(url):
 
 
 def get_filepath_or_buffer(filepath_or_buffer, encoding=None,
-                           compression=None):
+                           compression=None, mode='rb'):
     fs = s3fs.S3FileSystem(anon=False)
     try:
-        filepath_or_buffer = fs.open(_strip_schema(filepath_or_buffer))
+        filepath_or_buffer = fs.open(_strip_schema(filepath_or_buffer), mode)
     except (OSError, NoCredentialsError):
         # boto3 has troubles when trying to access a public file
         # when credentialed...
@@ -31,5 +31,5 @@ def get_filepath_or_buffer(filepath_or_buffer, encoding=None,
         # A NoCredentialsError is raised if you don't have creds
         # for that bucket.
         fs = s3fs.S3FileSystem(anon=True)
-        filepath_or_buffer = fs.open(_strip_schema(filepath_or_buffer))
+        filepath_or_buffer = fs.open(_strip_schema(filepath_or_buffer), mode)
     return filepath_or_buffer, None, compression

--- a/pandas/tests/io/test_parquet.py
+++ b/pandas/tests/io/test_parquet.py
@@ -203,6 +203,16 @@ def test_cross_engine_fp_pa(df_cross_compat, pa, fp):
         result = read_parquet(path, engine=pa, columns=['a', 'd'])
         tm.assert_frame_equal(result, df[['a', 'd']])
 
+def test_s3_roundtrip(df_compat, s3_resource, engine):
+    # GH #19134
+    if engine == 'pyarrow':
+        df_compat.to_parquet('s3://pandas-test/test.parquet',
+                             engine, compression=None)
+
+        expected = df_compat
+        actual = pd.read_parquet('s3://pandas-test/test.parquet', engine)
+
+        tm.assert_frame_equal(expected, actual)
 
 class Base(object):
 
@@ -487,15 +497,3 @@ class TestParquetFastParquet(Base):
             result = read_parquet(path, fp, filters=[('a', '==', 0)])
         assert len(result) == 1
 
-
-class TestIntegrationWithS3(Base):
-    def test_s3_roundtrip(self, df_compat, s3_resource, engine):
-        # GH #19134
-        if engine == 'pyarrow':
-            df_compat.to_parquet('s3://pandas-test/test.parquet',
-                                 engine, compression=None)
-
-            expected = df_compat
-            actual = pd.read_parquet('s3://pandas-test/test.parquet', engine)
-
-            tm.assert_frame_equal(expected, actual)

--- a/pandas/tests/io/test_parquet.py
+++ b/pandas/tests/io/test_parquet.py
@@ -236,12 +236,14 @@ class Base(object):
 
         with tm.ensure_clean() as path:
             self.do_round_trip(df, path, engine, expected,
-                               write_kwargs=write_kwargs, read_kwargs=read_kwargs,
+                               write_kwargs=write_kwargs,
+                               read_kwargs=read_kwargs,
                                check_names=check_names)
 
             # repeat
             self.do_round_trip(df, path, engine, expected,
-                               write_kwargs=write_kwargs, read_kwargs=read_kwargs,
+                               write_kwargs=write_kwargs,
+                               read_kwargs=read_kwargs,
                                check_names=check_names)
 
 
@@ -433,7 +435,7 @@ class TestParquetPyArrow(Base):
 
     def test_s3_roundtrip(self, df_compat, s3_resource, pa):
         # GH #19134
-        self.do_round_trip(df_compat, 's3://pandas-test/test.parquet', pa)
+        self.do_round_trip(df_compat, 's3://pandas-test/pyarrow.parquet', pa)
 
 
 class TestParquetFastParquet(Base):
@@ -495,9 +497,6 @@ class TestParquetFastParquet(Base):
         assert len(result) == 1
 
     def test_s3_roundtrip(self, df_compat, s3_resource, fp):
-        print(s3_resource, fp)
-
         # GH #19134
-        with pytest.raises(TypeError):
-            self.do_round_trip(df_compat, 's3://pandas-test/test.parquet', fp)
-
+        with pytest.raises(NotImplementedError):
+            self.do_round_trip(df_compat, 's3://pandas-test/fastparquet.parquet', fp)

--- a/pandas/tests/io/test_parquet.py
+++ b/pandas/tests/io/test_parquet.py
@@ -212,28 +212,37 @@ class Base(object):
             with tm.ensure_clean() as path:
                 to_parquet(df, path, engine, compression=None)
 
+    def do_round_trip(self, df, path, engine_impl, expected=None,
+                      write_kwargs=None, read_kwargs=None,
+                      check_names=True):
+
+        if write_kwargs is None:
+            write_kwargs = {'compression': None}
+
+        if read_kwargs is None:
+            read_kwargs = {}
+
+        df.to_parquet(path, engine_impl, **write_kwargs)
+        actual = read_parquet(path, engine_impl, **read_kwargs)
+
+        if expected is None:
+            expected = df
+
+        tm.assert_frame_equal(expected, actual, check_names=check_names)
+
     def check_round_trip(self, df, engine, expected=None,
                          write_kwargs=None, read_kwargs=None,
                          check_names=True):
-        if write_kwargs is None:
-            write_kwargs = {}
-        if read_kwargs is None:
-            read_kwargs = {}
-        with tm.ensure_clean() as path:
-            df.to_parquet(path, engine, **write_kwargs)
-            result = read_parquet(path, engine, **read_kwargs)
 
-            if expected is None:
-                expected = df
-            tm.assert_frame_equal(result, expected, check_names=check_names)
+        with tm.ensure_clean() as path:
+            self.do_round_trip(df, path, engine, expected,
+                               write_kwargs=write_kwargs, read_kwargs=read_kwargs,
+                               check_names=check_names)
 
             # repeat
-            to_parquet(df, path, engine, **write_kwargs)
-            result = pd.read_parquet(path, engine, **read_kwargs)
-
-            if expected is None:
-                expected = df
-            tm.assert_frame_equal(result, expected, check_names=check_names)
+            self.do_round_trip(df, path, engine, expected,
+                               write_kwargs=write_kwargs, read_kwargs=read_kwargs,
+                               check_names=check_names)
 
 
 class TestBasic(Base):
@@ -251,7 +260,7 @@ class TestBasic(Base):
 
         # unicode
         df.columns = [u'foo', u'bar']
-        self.check_round_trip(df, engine, write_kwargs={'compression': None})
+        self.check_round_trip(df, engine)
 
     def test_columns_dtypes_invalid(self, engine):
 
@@ -292,7 +301,6 @@ class TestBasic(Base):
 
         expected = pd.DataFrame({'string': list('abc')})
         self.check_round_trip(df, engine, expected=expected,
-                              write_kwargs={'compression': None},
                               read_kwargs={'columns': ['string']})
 
     def test_write_index(self, engine):
@@ -304,7 +312,7 @@ class TestBasic(Base):
                 pytest.skip("pyarrow is < 0.7.0")
 
         df = pd.DataFrame({'A': [1, 2, 3]})
-        self.check_round_trip(df, engine, write_kwargs={'compression': None})
+        self.check_round_trip(df, engine)
 
         indexes = [
             [2, 3, 4],
@@ -315,15 +323,12 @@ class TestBasic(Base):
         # non-default index
         for index in indexes:
             df.index = index
-            self.check_round_trip(
-                df, engine,
-                write_kwargs={'compression': None},
-                check_names=check_names)
+            self.check_round_trip(df, engine, check_names=check_names)
 
         # index with meta-data
         df.index = [0, 1, 2]
         df.index.name = 'foo'
-        self.check_round_trip(df, engine, write_kwargs={'compression': None})
+        self.check_round_trip(df, engine)
 
     def test_write_multiindex(self, pa_ge_070):
         # Not suppoprted in fastparquet as of 0.1.3 or older pyarrow version
@@ -332,7 +337,7 @@ class TestBasic(Base):
         df = pd.DataFrame({'A': [1, 2, 3]})
         index = pd.MultiIndex.from_tuples([('a', 1), ('a', 2), ('b', 1)])
         df.index = index
-        self.check_round_trip(df, engine, write_kwargs={'compression': None})
+        self.check_round_trip(df, engine)
 
     def test_write_column_multiindex(self, engine):
         # column multi-index
@@ -428,13 +433,7 @@ class TestParquetPyArrow(Base):
 
     def test_s3_roundtrip(self, df_compat, s3_resource, pa):
         # GH #19134
-        df_compat.to_parquet('s3://pandas-test/test.parquet',
-                             engine=pa, compression=None)
-
-        expected = df_compat
-        actual = read_parquet('s3://pandas-test/test.parquet', engine=pa)
-
-        tm.assert_frame_equal(expected, actual)
+        self.do_round_trip(df_compat, 's3://pandas-test/test.parquet', pa)
 
 
 class TestParquetFastParquet(Base):
@@ -446,7 +445,7 @@ class TestParquetFastParquet(Base):
         # additional supported types for fastparquet
         df['timedelta'] = pd.timedelta_range('1 day', periods=3)
 
-        self.check_round_trip(df, fp, write_kwargs={'compression': None})
+        self.check_round_trip(df, fp)
 
     @pytest.mark.skip(reason="not supported")
     def test_duplicate_columns(self, fp):
@@ -459,8 +458,7 @@ class TestParquetFastParquet(Base):
     def test_bool_with_none(self, fp):
         df = pd.DataFrame({'a': [True, None, False]})
         expected = pd.DataFrame({'a': [1.0, np.nan, 0.0]}, dtype='float16')
-        self.check_round_trip(df, fp, expected=expected,
-                              write_kwargs={'compression': None})
+        self.check_round_trip(df, fp, expected=expected)
 
     def test_unsupported(self, fp):
 
@@ -476,7 +474,7 @@ class TestParquetFastParquet(Base):
         if LooseVersion(fastparquet.__version__) < LooseVersion("0.1.3"):
             pytest.skip("CategoricalDtype not supported for older fp")
         df = pd.DataFrame({'a': pd.Categorical(list('abc'))})
-        self.check_round_trip(df, fp, write_kwargs={'compression': None})
+        self.check_round_trip(df, fp)
 
     def test_datetime_tz(self, fp):
         # doesn't preserve tz
@@ -485,8 +483,7 @@ class TestParquetFastParquet(Base):
 
         # warns on the coercion
         with catch_warnings(record=True):
-            self.check_round_trip(df, fp, df.astype('datetime64[ns]'),
-                                  write_kwargs={'compression': None})
+            self.check_round_trip(df, fp, df.astype('datetime64[ns]'))
 
     def test_filter_row_groups(self, fp):
         d = {'a': list(range(0, 3))}
@@ -496,4 +493,11 @@ class TestParquetFastParquet(Base):
                           row_group_offsets=1)
             result = read_parquet(path, fp, filters=[('a', '==', 0)])
         assert len(result) == 1
+
+    def test_s3_roundtrip(self, df_compat, s3_resource, fp):
+        print(s3_resource, fp)
+
+        # GH #19134
+        with pytest.raises(TypeError):
+            self.do_round_trip(df_compat, 's3://pandas-test/test.parquet', fp)
 

--- a/pandas/tests/io/test_parquet.py
+++ b/pandas/tests/io/test_parquet.py
@@ -488,18 +488,11 @@ class TestParquetFastParquet(Base):
         assert len(result) == 1
 
 class TestIntegrationWithS3(Base):
-    def test_s3_roundtrip(self):
-        expected = pd.DataFrame({'A': [1, 2, 3], 'B': 'foo'})
+    def test_s3_roundtrip(self, df_compat, s3_resource):
+        df_compat.to_parquet('s3://pandas-test/test.parquet')
 
-        boto3 = pytest.importorskip('boto3')
-        moto = pytest.importorskip('moto')
+        expected = df_compat
+        actual = pd.read_parquet('s3://pandas-test/test.parquet')
 
-        with moto.mock_s3():
-            conn = boto3.resource("s3", region_name="us-east-1")
-            conn.create_bucket(Bucket="pandas-test")
-
-            expected.to_parquet('s3://pandas-test/test.parquet')
-            actual = pd.read_parquet('s3://pandas-test/test.parquet')
-
-            tm.assert_frame_equal(actual, expected)
+        tm.assert_frame_equal(expected, actual)
 

--- a/pandas/tests/io/test_parquet.py
+++ b/pandas/tests/io/test_parquet.py
@@ -229,21 +229,26 @@ class Base(object):
             with tm.ensure_clean() as path:
                 df.to_parquet(path, engine, **write_kwargs)
                 actual = read_parquet(path, engine, **read_kwargs)
-                tm.assert_frame_equal(expected, actual, check_names=check_names)
+                tm.assert_frame_equal(expected, actual,
+                                      check_names=check_names)
 
                 # repeat
                 df.to_parquet(path, engine, **write_kwargs)
                 actual = read_parquet(path, engine, **read_kwargs)
-                tm.assert_frame_equal(expected, actual, check_names=check_names)
+                tm.assert_frame_equal(expected, actual,
+                                      check_names=check_names)
         else:
             df.to_parquet(path, engine, **write_kwargs)
             actual = read_parquet(path, engine, **read_kwargs)
-            tm.assert_frame_equal(expected, actual, check_names=check_names)
+            tm.assert_frame_equal(expected, actual,
+                                  check_names=check_names)
 
             # repeat
             df.to_parquet(path, engine, **write_kwargs)
             actual = read_parquet(path, engine, **read_kwargs)
-            tm.assert_frame_equal(expected, actual, check_names=check_names)
+            tm.assert_frame_equal(expected, actual,
+                                  check_names=check_names)
+
 
 class TestBasic(Base):
 
@@ -433,7 +438,8 @@ class TestParquetPyArrow(Base):
 
     def test_s3_roundtrip(self, df_compat, s3_resource, pa):
         # GH #19134
-        self.check_round_trip(df_compat, pa, path='s3://pandas-test/pyarrow.parquet')
+        self.check_round_trip(df_compat, pa,
+                              path='s3://pandas-test/pyarrow.parquet')
 
 
 class TestParquetFastParquet(Base):
@@ -497,4 +503,5 @@ class TestParquetFastParquet(Base):
     def test_s3_roundtrip(self, df_compat, s3_resource, fp):
         # GH #19134
         with pytest.raises(NotImplementedError):
-            self.check_round_trip(df_compat, fp, path='s3://pandas-test/fastparquet.parquet')
+            self.check_round_trip(df_compat, fp,
+                                  path='s3://pandas-test/fastparquet.parquet')

--- a/pandas/tests/io/test_parquet.py
+++ b/pandas/tests/io/test_parquet.py
@@ -491,9 +491,9 @@ class TestParquetFastParquet(Base):
 class TestIntegrationWithS3(Base):
     def test_s3_roundtrip(self, df_compat, s3_resource, engine):
         # GH #19134
-
         if engine == 'pyarrow':
-            df_compat.to_parquet('s3://pandas-test/test.parquet', engine)
+            df_compat.to_parquet('s3://pandas-test/test.parquet',
+                                 engine, compression=None)
 
             expected = df_compat
             actual = pd.read_parquet('s3://pandas-test/test.parquet', engine)

--- a/pandas/tests/io/test_parquet.py
+++ b/pandas/tests/io/test_parquet.py
@@ -489,6 +489,7 @@ class TestParquetFastParquet(Base):
 
 class TestIntegrationWithS3(Base):
     def test_s3_roundtrip(self, df_compat, s3_resource):
+        # GH #19134
         df_compat.to_parquet('s3://pandas-test/test.parquet')
 
         expected = df_compat

--- a/pandas/tests/io/test_parquet.py
+++ b/pandas/tests/io/test_parquet.py
@@ -204,6 +204,21 @@ def test_cross_engine_fp_pa(df_cross_compat, pa, fp):
         tm.assert_frame_equal(result, df[['a', 'd']])
 
 
+def check_round_trip_equals(df, path, engine,
+                           write_kwargs, read_kwargs,
+                           expected, check_names):
+
+    df.to_parquet(path, engine, **write_kwargs)
+    actual = read_parquet(path, engine, **read_kwargs)
+    tm.assert_frame_equal(expected, actual,
+                          check_names=check_names)
+
+    # repeat
+    df.to_parquet(path, engine, **write_kwargs)
+    actual = read_parquet(path, engine, **read_kwargs)
+    tm.assert_frame_equal(expected, actual,
+                          check_names=check_names)
+
 class Base(object):
 
     def check_error_on_write(self, df, engine, exc):
@@ -227,27 +242,13 @@ class Base(object):
 
         if path is None:
             with tm.ensure_clean() as path:
-                df.to_parquet(path, engine, **write_kwargs)
-                actual = read_parquet(path, engine, **read_kwargs)
-                tm.assert_frame_equal(expected, actual,
-                                      check_names=check_names)
-
-                # repeat
-                df.to_parquet(path, engine, **write_kwargs)
-                actual = read_parquet(path, engine, **read_kwargs)
-                tm.assert_frame_equal(expected, actual,
-                                      check_names=check_names)
+                check_round_trip_equals(df, path, engine,
+                                        write_kwargs=write_kwargs, read_kwargs=read_kwargs,
+                                        expected=expected, check_names=check_names)
         else:
-            df.to_parquet(path, engine, **write_kwargs)
-            actual = read_parquet(path, engine, **read_kwargs)
-            tm.assert_frame_equal(expected, actual,
-                                  check_names=check_names)
-
-            # repeat
-            df.to_parquet(path, engine, **write_kwargs)
-            actual = read_parquet(path, engine, **read_kwargs)
-            tm.assert_frame_equal(expected, actual,
-                                  check_names=check_names)
+            check_round_trip_equals(df, path, engine,
+                                    write_kwargs=write_kwargs, read_kwargs=read_kwargs,
+                                    expected=expected, check_names=check_names)
 
 
 class TestBasic(Base):

--- a/pandas/tests/io/test_parquet.py
+++ b/pandas/tests/io/test_parquet.py
@@ -487,13 +487,15 @@ class TestParquetFastParquet(Base):
             result = read_parquet(path, fp, filters=[('a', '==', 0)])
         assert len(result) == 1
 
+
 class TestIntegrationWithS3(Base):
-    def test_s3_roundtrip(self, df_compat, s3_resource):
+    def test_s3_roundtrip(self, df_compat, s3_resource, engine):
         # GH #19134
-        df_compat.to_parquet('s3://pandas-test/test.parquet')
 
-        expected = df_compat
-        actual = pd.read_parquet('s3://pandas-test/test.parquet')
+        if engine == 'pyarrow':
+            df_compat.to_parquet('s3://pandas-test/test.parquet', engine)
 
-        tm.assert_frame_equal(expected, actual)
+            expected = df_compat
+            actual = pd.read_parquet('s3://pandas-test/test.parquet', engine)
 
+            tm.assert_frame_equal(expected, actual)

--- a/pandas/tests/io/test_parquet.py
+++ b/pandas/tests/io/test_parquet.py
@@ -503,5 +503,7 @@ class TestParquetFastParquet(Base):
     def test_s3_roundtrip(self, df_compat, s3_resource, fp):
         # GH #19134
         with pytest.raises(NotImplementedError):
+            # Known limitation, fastparquet doesn't support writing to S3.
+            # https://git.io/vNCcz
             self.check_round_trip(df_compat, fp,
                                   path='s3://pandas-test/fastparquet.parquet')

--- a/pandas/tests/io/test_parquet.py
+++ b/pandas/tests/io/test_parquet.py
@@ -502,8 +502,5 @@ class TestParquetFastParquet(Base):
 
     def test_s3_roundtrip(self, df_compat, s3_resource, fp):
         # GH #19134
-        with pytest.raises(NotImplementedError):
-            # Known limitation, fastparquet doesn't support writing to S3.
-            # https://git.io/vNCcz
-            self.check_round_trip(df_compat, fp,
-                                  path='s3://pandas-test/fastparquet.parquet')
+        self.check_round_trip(df_compat, fp,
+                              path='s3://pandas-test/fastparquet.parquet')

--- a/pandas/tests/io/test_parquet.py
+++ b/pandas/tests/io/test_parquet.py
@@ -205,8 +205,8 @@ def test_cross_engine_fp_pa(df_cross_compat, pa, fp):
 
 
 def check_round_trip_equals(df, path, engine,
-                           write_kwargs, read_kwargs,
-                           expected, check_names):
+                            write_kwargs, read_kwargs,
+                            expected, check_names):
 
     df.to_parquet(path, engine, **write_kwargs)
     actual = read_parquet(path, engine, **read_kwargs)
@@ -218,6 +218,7 @@ def check_round_trip_equals(df, path, engine,
     actual = read_parquet(path, engine, **read_kwargs)
     tm.assert_frame_equal(expected, actual,
                           check_names=check_names)
+
 
 class Base(object):
 
@@ -243,12 +244,16 @@ class Base(object):
         if path is None:
             with tm.ensure_clean() as path:
                 check_round_trip_equals(df, path, engine,
-                                        write_kwargs=write_kwargs, read_kwargs=read_kwargs,
-                                        expected=expected, check_names=check_names)
+                                        write_kwargs=write_kwargs,
+                                        read_kwargs=read_kwargs,
+                                        expected=expected,
+                                        check_names=check_names)
         else:
             check_round_trip_equals(df, path, engine,
-                                    write_kwargs=write_kwargs, read_kwargs=read_kwargs,
-                                    expected=expected, check_names=check_names)
+                                    write_kwargs=write_kwargs,
+                                    read_kwargs=read_kwargs,
+                                    expected=expected,
+                                    check_names=check_names)
 
 
 class TestBasic(Base):

--- a/pandas/tests/io/test_parquet.py
+++ b/pandas/tests/io/test_parquet.py
@@ -203,16 +203,6 @@ def test_cross_engine_fp_pa(df_cross_compat, pa, fp):
         result = read_parquet(path, engine=pa, columns=['a', 'd'])
         tm.assert_frame_equal(result, df[['a', 'd']])
 
-def test_s3_roundtrip(df_compat, s3_resource, engine):
-    # GH #19134
-    if engine == 'pyarrow':
-        df_compat.to_parquet('s3://pandas-test/test.parquet',
-                             engine, compression=None)
-
-        expected = df_compat
-        actual = pd.read_parquet('s3://pandas-test/test.parquet', engine)
-
-        tm.assert_frame_equal(expected, actual)
 
 class Base(object):
 
@@ -435,6 +425,16 @@ class TestParquetPyArrow(Base):
         # supported in >= 0.7.0
         df = pd.DataFrame({'a': pd.Categorical(list('abc'))})
         self.check_error_on_write(df, pa, NotImplementedError)
+
+    def test_s3_roundtrip(self, df_compat, s3_resource, pa):
+        # GH #19134
+        df_compat.to_parquet('s3://pandas-test/test.parquet',
+                             engine=pa, compression=None)
+
+        expected = df_compat
+        actual = read_parquet('s3://pandas-test/test.parquet', engine=pa)
+
+        tm.assert_frame_equal(expected, actual)
 
 
 class TestParquetFastParquet(Base):

--- a/pandas/tests/io/test_s3.py
+++ b/pandas/tests/io/test_s3.py
@@ -1,28 +1,9 @@
-import pytest
-import pandas as pd
-
 from pandas.io.common import _is_s3_url
-from pandas.util import testing as tm
+
 
 class TestS3URL(object):
 
     def test_is_s3_url(self):
         assert _is_s3_url("s3://pandas/somethingelse.com")
         assert not _is_s3_url("s4://pandas/somethingelse.com")
-
-class TestIntegration(object):
-    def test_s3_roundtrip(self):
-        expected = pd.DataFrame({'A': [1, 2, 3], 'B': 'foo'})
-
-        boto3 = pytest.importorskip('boto3')
-        moto = pytest.importorskip('moto')
-
-        with moto.mock_s3():
-            conn = boto3.resource("s3", region_name="us-east-1")
-            conn.create_bucket(Bucket="pandas-test")
-
-            expected.to_parquet('s3://pandas-test/test.parquet')
-            actual = pd.read_parquet('s3://pandas-test/test.parquet')
-
-            tm.assert_frame_equal(actual, expected)
 

--- a/pandas/tests/io/test_s3.py
+++ b/pandas/tests/io/test_s3.py
@@ -25,3 +25,4 @@ class TestIntegration(object):
             actual = pd.read_parquet('s3://pandas-test/test.parquet')
 
             tm.assert_frame_equal(actual, expected)
+

--- a/pandas/tests/io/test_s3.py
+++ b/pandas/tests/io/test_s3.py
@@ -6,4 +6,3 @@ class TestS3URL(object):
     def test_is_s3_url(self):
         assert is_s3_url("s3://pandas/somethingelse.com")
         assert not is_s3_url("s4://pandas/somethingelse.com")
-

--- a/pandas/tests/io/test_s3.py
+++ b/pandas/tests/io/test_s3.py
@@ -1,8 +1,27 @@
-from pandas.io.common import _is_s3_url
+import pytest
+import pandas as pd
 
+from pandas.io.common import _is_s3_url
+from pandas.util import testing as tm
 
 class TestS3URL(object):
 
     def test_is_s3_url(self):
         assert _is_s3_url("s3://pandas/somethingelse.com")
         assert not _is_s3_url("s4://pandas/somethingelse.com")
+
+class TestIntegration(object):
+    def test_s3_roundtrip(self):
+        expected = pd.DataFrame({'A': [1, 2, 3], 'B': 'foo'})
+
+        boto3 = pytest.importorskip('boto3')
+        moto = pytest.importorskip('moto')
+
+        with moto.mock_s3():
+            conn = boto3.resource("s3", region_name="us-east-1")
+            conn.create_bucket(Bucket="pandas-test")
+
+            expected.to_parquet('s3://pandas-test/test.parquet')
+            actual = pd.read_parquet('s3://pandas-test/test.parquet')
+
+            tm.assert_frame_equal(actual, expected)

--- a/pandas/tests/io/test_s3.py
+++ b/pandas/tests/io/test_s3.py
@@ -1,9 +1,9 @@
-from pandas.io.common import _is_s3_url
+from pandas.io.s3 import is_s3_url
 
 
 class TestS3URL(object):
 
     def test_is_s3_url(self):
-        assert _is_s3_url("s3://pandas/somethingelse.com")
-        assert not _is_s3_url("s4://pandas/somethingelse.com")
+        assert is_s3_url("s3://pandas/somethingelse.com")
+        assert not is_s3_url("s4://pandas/somethingelse.com")
 

--- a/pandas/tests/io/test_s3.py
+++ b/pandas/tests/io/test_s3.py
@@ -1,4 +1,4 @@
-from pandas.io.s3 import is_s3_url
+from pandas.io.common import is_s3_url
 
 
 class TestS3URL(object):


### PR DESCRIPTION
- [x] closes #19134
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`

closes #19134 