### PR TITLE
Fix URL in FutureWarning for .loc[list-of-labels] with missing labels

### DIFF
--- a/doc/source/indexing.rst
+++ b/doc/source/indexing.rst
@@ -640,6 +640,7 @@ For getting *multiple* indexers, using ``.get_indexer``:
   dfd.iloc[[0, 2], dfd.columns.get_indexer(['A', 'B'])]
 
 
+.. _deprecate_loc_reindex_listlike:
 .. _indexing.deprecate_loc_reindex_listlike:
 
 Indexing with list with missing labels is Deprecated

--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -1479,7 +1479,7 @@ class _LocIndexer(_LocationIndexer):
                         KeyError in the future, you can use .reindex() as an alternative.
 
                         See the documentation here:
-                        http://pandas.pydata.org/pandas-docs/stable/indexing.html#deprecate-loc-reindex-listlike""")  # noqa
+                        https://pandas.pydata.org/pandas-docs/stable/indexing.html#deprecate-loc-reindex-listlike""")  # noqa
 
                         if not (ax.is_categorical() or ax.is_interval()):
                             warnings.warn(_missing_key_warning,


### PR DESCRIPTION
- [X] closes #19143
- [X] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`

