### PR TITLE
simplify CBMonth.apply to remove roll_monthday

### DIFF
--- a/pandas/_libs/tslibs/offsets.pyx
+++ b/pandas/_libs/tslibs/offsets.pyx
@@ -847,29 +847,6 @@ cpdef int roll_convention(int other, int n, int compare):
     return n
 
 
-cpdef int roll_monthday(datetime other, int n, datetime compare):
-    """
-    Possibly increment or decrement the number of periods to shift
-    based on rollforward/rollbackward conventions.
-
-    Parameters
-    ----------
-    other : datetime
-    n : number of periods to increment, before adjusting for rolling
-    compare : datetime
-
-    Returns
-    -------
-    n : int number of periods to increment
-    """
-    if n > 0 and other < compare:
-        n -= 1
-    elif n <= 0 and other > compare:
-        # as if rolled forward already
-        n += 1
-    return n
-
-
 cpdef int roll_qtrday(datetime other, int n, int month, object day_opt,
                       int modby=3) except? -1:
     """

--- a/pandas/tests/tseries/offsets/test_liboffsets.py
+++ b/pandas/tests/tseries/offsets/test_liboffsets.py
@@ -156,22 +156,6 @@ def test_roll_qtrday():
     assert roll_qtrday(other, n, month, 'business_end', modby=3) == n
 
 
-def test_roll_monthday():
-    other = Timestamp('2017-12-29', tz='US/Pacific')
-    before = Timestamp('2017-12-01', tz='US/Pacific')
-    after = Timestamp('2017-12-31', tz='US/Pacific')
-
-    n = 42
-    assert liboffsets.roll_monthday(other, n, other) == n
-    assert liboffsets.roll_monthday(other, n, before) == n
-    assert liboffsets.roll_monthday(other, n, after) == n - 1
-
-    n = -4
-    assert liboffsets.roll_monthday(other, n, other) == n
-    assert liboffsets.roll_monthday(other, n, before) == n + 1
-    assert liboffsets.roll_monthday(other, n, after) == n
-
-
 def test_roll_convention():
     other = 29
     before = 1

--- a/pandas/tseries/offsets.py
+++ b/pandas/tseries/offsets.py
@@ -1049,7 +1049,6 @@ class _CustomBusinessMonth(_CustomMixin, BusinessMixin, MonthOffset):
         else:
             # MonthEnd
             cbday.roll_func = cbday.rollback
-        kwds = self.kwds
         return cbday
 
     @cache_readonly

--- a/pandas/tseries/offsets.py
+++ b/pandas/tseries/offsets.py
@@ -1040,9 +1040,9 @@ class _CustomBusinessMonth(_CustomMixin, BusinessMixin, MonthOffset):
 
     @cache_readonly
     def cbday_roll(self):
+        """Define default roll function to be called in apply method"""
         cbday = CustomBusinessDay(n=self.n, normalize=False, **self.kwds)
 
-        # Define default roll function to be called in apply method
         if self._prefix.endswith('S'):
             # MonthBegin
             roll_func = cbday.rollforward
@@ -1063,6 +1063,7 @@ class _CustomBusinessMonth(_CustomMixin, BusinessMixin, MonthOffset):
 
     @cache_readonly
     def month_roll(self):
+        """Define default roll function to be called in apply method"""
         if self._prefix.endswith('S'):
             # MonthBegin
             roll_func = self.m_offset.rollback


### PR DESCRIPTION
The implementations of CustomBusinessMonthBegin.apply and CustomBusinessMonthEnd.apply are merged.

Simplify CustomBusinessMonth.apply so that it uses liboffsets.roll_convention instead of liboffsets.roll_monthday (the latter being much more of a footgun).  This is the last place where roll_monthday was used, so this removes it.

- [ ] closes #xxxx
- [ ] tests added / passed
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
