### PR TITLE
CLN: ASV timeseries

### DIFF
--- a/asv_bench/benchmarks/timeseries.py
+++ b/asv_bench/benchmarks/timeseries.py
@@ -1,358 +1,330 @@
+from datetime import timedelta
+
+import numpy as np
+from pandas import to_datetime, date_range, Series, DataFrame, period_range
+from pandas.tseries.frequencies import infer_freq
 try:
     from pandas.plotting._converter import DatetimeConverter
 except ImportError:
     from pandas.tseries.converter import DatetimeConverter
 
-import pandas as pd
-from pandas import to_datetime, date_range, Series, DataFrame, period_range
-
-import datetime as dt
-from pandas.tseries.frequencies import infer_freq
-import numpy as np
-
-if hasattr(Series, 'convert'):
-    Series.resample = Series.convert
+from .pandas_vb_common import setup  # noqa
 
 
 class DatetimeIndex(object):
+
+    goal_time = 0.2
+    params = ['dst', 'repeated', 'tz_aware', 'tz_naive']
+    param_names = ['index_type']
+
+    def setup(self, index_type):
+        N = 100000
+        dtidxes = {'dst': date_range(start='10/29/2000 1:00:00',
+                                     end='10/29/2000 1:59:59', freq='S'),
+                   'repeated': date_range(start='2000',
+                                          periods=N / 10,
+                                          freq='s').repeat(10),
+                   'tz_aware': date_range(start='2000',
+                                          periods=N,
+                                          freq='s',
+                                          tz='US/Eastern'),
+                   'tz_naive': date_range(start='2000',
+                                          periods=N,
+                                          freq='s')}
+        self.index = dtidxes[index_type]
+
+    def time_add_timedelta(self, index_type):
+        self.index + timedelta(minutes=2)
+
+    def time_normalize(self, index_type):
+        self.index.normalize()
+
+    def time_unique(self, index_type):
+        self.index.unique()
+
+    def time_to_time(self, index_type):
+        self.index.time
+
+    def time_get(self, index_type):
+        self.index[0]
+
+    def time_timeseries_is_month_start(self, index_type):
+        self.index.is_month_start
+
+    def time_to_date(self, index_type):
+        self.index.date
+
+    def time_to_pydatetime(self, index_type):
+        self.index.to_pydatetime()
+
+
+class TzLocalize(object):
+
     goal_time = 0.2
 
     def setup(self):
-        self.N = 100000
-        self.rng = date_range(start='1/1/2000', periods=self.N, freq='T')
-
-        self.rng2 = date_range(start='1/1/2000 9:30', periods=10000,
-                               freq='S', tz='US/Eastern')
-
-        self.index_repeated = date_range(start='1/1/2000',
-                                         periods=1000, freq='T').repeat(10)
-
-        self.rng3 = date_range(start='1/1/2000', periods=1000, freq='H')
-        self.df = DataFrame(np.random.randn(len(self.rng3), 2), self.rng3)
-
-        self.rng4 = date_range(start='1/1/2000', periods=1000,
-                               freq='H', tz='US/Eastern')
-        self.df2 = DataFrame(np.random.randn(len(self.rng4), 2),
-                             index=self.rng4)
-
-        N = 100000
-        self.dti = pd.date_range('2011-01-01', freq='H', periods=N).repeat(5)
-        self.dti_tz = pd.date_range('2011-01-01', freq='H', periods=N,
-                                    tz='Asia/Tokyo').repeat(5)
-
-        self.rng5 = date_range(start='1/1/2000',
-                               end='3/1/2000', tz='US/Eastern')
-
-        self.dst_rng = date_range(start='10/29/2000 1:00:00',
-                                  end='10/29/2000 1:59:59', freq='S')
+        dst_rng = date_range(start='10/29/2000 1:00:00',
+                             end='10/29/2000 1:59:59', freq='S')
         self.index = date_range(start='10/29/2000',
                                 end='10/29/2000 00:59:59', freq='S')
-        self.index = self.index.append(self.dst_rng)
-        self.index = self.index.append(self.dst_rng)
+        self.index = self.index.append(dst_rng)
+        self.index = self.index.append(dst_rng)
         self.index = self.index.append(date_range(start='10/29/2000 2:00:00',
                                                   end='10/29/2000 3:00:00',
                                                   freq='S'))
 
-        self.N = 10000
-        self.rng6 = date_range(start='1/1/1', periods=self.N, freq='B')
-
-        self.rng7 = date_range(start='1/1/1700', freq='D', periods=100000)
-        self.no_freq = self.rng7[:50000].append(self.rng7[50002:])
-        self.d_freq = self.rng7[:50000].append(self.rng7[50000:])
-
-        self.rng8 = date_range(start='1/1/1700', freq='B', periods=75000)
-        self.b_freq = self.rng8[:50000].append(self.rng8[50000:])
-
-    def time_add_timedelta(self):
-        (self.rng + dt.timedelta(minutes=2))
-
-    def time_normalize(self):
-        self.rng2.normalize()
-
-    def time_unique(self):
-        self.index_repeated.unique()
-
-    def time_reset_index(self):
-        self.df.reset_index()
-
-    def time_reset_index_tz(self):
-        self.df2.reset_index()
-
-    def time_dti_factorize(self):
-        self.dti.factorize()
-
-    def time_dti_tz_factorize(self):
-        self.dti_tz.factorize()
-
-    def time_dti_time(self):
-        self.dst_rng.time
-
-    def time_timestamp_tzinfo_cons(self):
-        self.rng5[0]
-
     def time_infer_dst(self):
         self.index.tz_localize('US/Eastern', infer_dst=True)
 
-    def time_timeseries_is_month_start(self):
-        self.rng6.is_month_start
 
-    def time_infer_freq_none(self):
-        infer_freq(self.no_freq)
+class ResetIndex(object):
 
-    def time_infer_freq_daily(self):
-        infer_freq(self.d_freq)
+    goal_time = 0.2
+    params = [None, 'US/Eastern']
+    param_names = 'tz'
 
-    def time_infer_freq_business(self):
-        infer_freq(self.b_freq)
+    def setup(self, tz):
+        idx = date_range(start='1/1/2000', periods=1000, freq='H', tz=tz)
+        self.df = DataFrame(np.random.randn(1000, 2), index=idx)
 
-    def time_to_date(self):
-        self.rng.date
+    def time_reest_datetimeindex(self, tz):
+        self.df.reset_index()
 
-    def time_to_pydatetime(self):
-        self.rng.to_pydatetime()
+
+class Factorize(object):
+
+    goal_time = 0.2
+    params = [None, 'Asia/Tokyo']
+    param_names = 'tz'
+
+    def setup(self, tz):
+        N = 100000
+        self.dti = date_range('2011-01-01', freq='H', periods=N, tz=tz)
+        self.dti = self.dti.repeat(5)
+
+    def time_factorize(self, tz):
+        self.dti.factorize()
+
+
+class InferFreq(object):
+
+    goal_time = 0.2
+    params = [None, 'D', 'B']
+    param_names = ['freq']
+
+    def setup(self, freq):
+        if freq is None:
+            self.idx = date_range(start='1/1/1700', freq='D', periods=10000)
+            self.idx.freq = None
+        else:
+            self.idx = date_range(start='1/1/1700', freq=freq, periods=10000)
+
+    def time_infer_freq(self, freq):
+        infer_freq(self.idx)
 
 
 class TimeDatetimeConverter(object):
+
     goal_time = 0.2
 
     def setup(self):
-        self.N = 100000
-        self.rng = date_range(start='1/1/2000', periods=self.N, freq='T')
+        N = 100000
+        self.rng = date_range(start='1/1/2000', periods=N, freq='T')
 
     def time_convert(self):
         DatetimeConverter.convert(self.rng, None, None)
 
 
 class Iteration(object):
+
     goal_time = 0.2
+    params = [date_range, period_range]
+    param_names = ['time_index']
 
-    def setup(self):
-        self.N = 1000000
-        self.M = 10000
-        self.idx1 = date_range(start='20140101', freq='T', periods=self.N)
-        self.idx2 = period_range(start='20140101', freq='T', periods=self.N)
+    def setup(self, time_index):
+        N = 10**6
+        self.idx = time_index(start='20140101', freq='T', periods=N)
+        self.exit = 10000
 
-    def iter_n(self, iterable, n=None):
-        self.i = 0
-        for _ in iterable:
-            self.i += 1
-            if ((n is not None) and (self.i > n)):
+    def time_iter(self, time_index):
+        for _ in self.idx:
+            pass
+
+    def time_iter_preexit(self, time_index):
+        for i, _ in enumerate(self.idx):
+            if i > self.exit:
                 break
 
-    def time_iter_datetimeindex(self):
-        self.iter_n(self.idx1)
-
-    def time_iter_datetimeindex_preexit(self):
-        self.iter_n(self.idx1, self.M)
-
-    def time_iter_periodindex(self):
-        self.iter_n(self.idx2)
-
-    def time_iter_periodindex_preexit(self):
-        self.iter_n(self.idx2, self.M)
-
-
-# ----------------------------------------------------------------------
-# Resampling
 
 class ResampleDataFrame(object):
+
     goal_time = 0.2
+    params = ['max', 'mean', 'min']
+    param_names = ['method']
 
-    def setup(self):
-        self.rng = date_range(start='20130101', periods=100000, freq='50L')
-        self.df = DataFrame(np.random.randn(100000, 2), index=self.rng)
+    def setup(self, method):
+        rng = date_range(start='20130101', periods=100000, freq='50L')
+        df = DataFrame(np.random.randn(100000, 2), index=rng)
+        self.resample = getattr(df.resample('1s'), method)
 
-    def time_max_numpy(self):
-        self.df.resample('1s', how=np.max)
-
-    def time_max_string(self):
-        self.df.resample('1s', how='max')
-
-    def time_mean_numpy(self):
-        self.df.resample('1s', how=np.mean)
-
-    def time_mean_string(self):
-        self.df.resample('1s', how='mean')
-
-    def time_min_numpy(self):
-        self.df.resample('1s', how=np.min)
-
-    def time_min_string(self):
-        self.df.resample('1s', how='min')
+    def time_method(self, method):
+        self.resample()
 
 
 class ResampleSeries(object):
+
+    goal_time = 0.2
+    params = (['period', 'datetime'], ['5min', '1D'], ['mean', 'ohlc'])
+    param_names = ['index', 'freq', 'method']
+
+    def setup(self, index, freq, method):
+        indexes = {'period': period_range(start='1/1/2000',
+                                          end='1/1/2001',
+                                          freq='T'),
+                   'datetime': date_range(start='1/1/2000',
+                                          end='1/1/2001',
+                                          freq='T')}
+        idx = indexes[index]
+        ts = Series(np.random.randn(len(idx)), index=idx)
+        self.resample = getattr(ts.resample(freq), method)
+
+    def time_resample(self, index, freq, method):
+        self.resample()
+
+
+class ResampleDatetetime64(object):
+    # GH 7754
     goal_time = 0.2
 
     def setup(self):
-        self.rng1 = period_range(start='1/1/2000', end='1/1/2001', freq='T')
-        self.ts1 = Series(np.random.randn(len(self.rng1)), index=self.rng1)
+        rng3 = date_range(start='2000-01-01 00:00:00',
+                          end='2000-01-01 10:00:00', freq='555000U')
+        self.dt_ts = Series(5, rng3, dtype='datetime64[ns]')
 
-        self.rng2 = date_range(start='1/1/2000', end='1/1/2001', freq='T')
-        self.ts2 = Series(np.random.randn(len(self.rng2)), index=self.rng2)
-
-        self.rng3 = date_range(start='2000-01-01 00:00:00',
-                               end='2000-01-01 10:00:00', freq='555000U')
-        self.int_ts = Series(5, self.rng3, dtype='int64')
-        self.dt_ts = self.int_ts.astype('datetime64[ns]')
-
-    def time_period_downsample_mean(self):
-        self.ts1.resample('D', how='mean')
-
-    def time_timestamp_downsample_mean(self):
-        self.ts2.resample('D', how='mean')
-
-    def time_resample_datetime64(self):
-        # GH 7754
-        self.dt_ts.resample('1S', how='last')
-
-    def time_1min_5min_mean(self):
-        self.ts2[:10000].resample('5min', how='mean')
-
-    def time_1min_5min_ohlc(self):
-        self.ts2[:10000].resample('5min', how='ohlc')
+    def time_resample(self):
+        self.dt_ts.resample('1S').last()
 
 
 class AsOf(object):
+
     goal_time = 0.2
+    params = ['DataFrame', 'Series']
+    param_names = ['constructor']
 
-    def setup(self):
-        self.N = 10000
-        self.rng = date_range(start='1/1/1990', periods=self.N, freq='53s')
-        self.ts = Series(np.random.randn(self.N), index=self.rng)
-        self.dates = date_range(start='1/1/1990',
-                                periods=(self.N * 10), freq='5s')
-        self.ts2 = self.ts.copy()
-        self.ts2[250:5000] = np.nan
-        self.ts3 = self.ts.copy()
-        self.ts3[-5000:] = np.nan
-
-    # test speed of pre-computing NAs.
-    def time_asof(self):
-        self.ts.asof(self.dates)
-
-    # should be roughly the same as above.
-    def time_asof_nan(self):
-        self.ts2.asof(self.dates)
-
-    # test speed of the code path for a scalar index
-    # without *while* loop
-    def time_asof_single(self):
-        self.ts.asof(self.dates[0])
-
-    # test speed of the code path for a scalar index
-    # before the start. should be the same as above.
-    def time_asof_single_early(self):
-        self.ts.asof(self.dates[0] - dt.timedelta(10))
-
-    # test the speed of the code path for a scalar index
-    # with a long *while* loop. should still be much
-    # faster than pre-computing all the NAs.
-    def time_asof_nan_single(self):
-        self.ts3.asof(self.dates[-1])
-
-
-class AsOfDataFrame(object):
-    goal_time = 0.2
-
-    def setup(self):
-        self.N = 10000
-        self.M = 100
-        self.rng = date_range(start='1/1/1990', periods=self.N, freq='53s')
-        self.dates = date_range(start='1/1/1990',
-                                periods=(self.N * 10), freq='5s')
-        self.ts = DataFrame(np.random.randn(self.N, self.M), index=self.rng)
+    def setup(self, constructor):
+        N = 10000
+        M = 10
+        rng = date_range(start='1/1/1990', periods=N, freq='53s')
+        data = {'DataFrame': DataFrame(np.random.randn(N, M)),
+                'Series': Series(np.random.randn(N))}
+        self.ts = data[constructor]
+        self.ts.index = rng
         self.ts2 = self.ts.copy()
         self.ts2.iloc[250:5000] = np.nan
         self.ts3 = self.ts.copy()
         self.ts3.iloc[-5000:] = np.nan
+        self.dates = date_range(start='1/1/1990', periods=N * 10, freq='5s')
+        self.date = self.dates[0]
+        self.date_last = self.dates[-1]
+        self.date_early = self.date - timedelta(10)
 
     # test speed of pre-computing NAs.
-    def time_asof(self):
+    def time_asof(self, constructor):
         self.ts.asof(self.dates)
 
     # should be roughly the same as above.
-    def time_asof_nan(self):
+    def time_asof_nan(self, constructor):
         self.ts2.asof(self.dates)
 
     # test speed of the code path for a scalar index
-    # with pre-computing all NAs.
-    def time_asof_single(self):
-        self.ts.asof(self.dates[0])
-
-    # should be roughly the same as above.
-    def time_asof_nan_single(self):
-        self.ts3.asof(self.dates[-1])
+    # without *while* loop
+    def time_asof_single(self, constructor):
+        self.ts.asof(self.date)
 
     # test speed of the code path for a scalar index
-    # before the start. should be without the cost of
-    # pre-computing all the NAs.
-    def time_asof_single_early(self):
-        self.ts.asof(self.dates[0] - dt.timedelta(10))
+    # before the start. should be the same as above.
+    def time_asof_single_early(self, constructor):
+        self.ts.asof(self.date_early)
+
+    # test the speed of the code path for a scalar index
+    # with a long *while* loop. should still be much
+    # faster than pre-computing all the NAs.
+    def time_asof_nan_single(self, constructor):
+        self.ts3.asof(self.date_last)
 
 
-class TimeSeries(object):
+class SortIndex(object):
+
+    goal_time = 0.2
+    params = [True, False]
+    param_names = ['monotonic']
+
+    def setup(self, monotonic):
+        N = 10**5
+        idx = date_range(start='1/1/2000', periods=N, freq='s')
+        self.s = Series(np.random.randn(N), index=idx)
+        if not monotonic:
+            self.s = self.s.sample(frac=1)
+
+    def time_sort_index(self, monotonic):
+        self.s.sort_index()
+
+    def time_get_slice(self, monotonic):
+        self.s[:10000]
+
+
+class IrregularOps(object):
+
     goal_time = 0.2
 
     def setup(self):
-        self.N = 100000
-        self.rng = date_range(start='1/1/2000', periods=self.N, freq='s')
-        self.rng = self.rng.take(np.random.permutation(self.N))
-        self.ts = Series(np.random.randn(self.N), index=self.rng)
+        N = 10**5
+        idx = date_range(start='1/1/2000', periods=N, freq='s')
+        s = Series(np.random.randn(N), index=idx)
+        self.left = s.sample(frac=1)
+        self.right = s.sample(frac=1)
 
-        self.rng2 = date_range(start='1/1/2000', periods=self.N, freq='T')
-        self.ts2 = Series(np.random.randn(self.N), index=self.rng2)
-
-        self.lindex = np.random.permutation(self.N)[:(self.N // 2)]
-        self.rindex = np.random.permutation(self.N)[:(self.N // 2)]
-        self.left = Series(self.ts2.values.take(self.lindex),
-                           index=self.ts2.index.take(self.lindex))
-        self.right = Series(self.ts2.values.take(self.rindex),
-                            index=self.ts2.index.take(self.rindex))
-
-        self.rng3 = date_range(start='1/1/2000', periods=1500000, freq='S')
-        self.ts3 = Series(1, index=self.rng3)
-
-    def time_sort_index_monotonic(self):
-        self.ts2.sort_index()
-
-    def time_sort_index_non_monotonic(self):
-        self.ts.sort_index()
-
-    def time_timeseries_slice_minutely(self):
-        self.ts2[:10000]
-
-    def time_add_irregular(self):
-        (self.left + self.right)
-
-    def time_large_lookup_value(self):
-        self.ts3[self.ts3.index[(len(self.ts3) // 2)]]
-        self.ts3.index._cleanup()
+    def time_add(self):
+        self.left + self.right
 
 
-class ToDatetime(object):
+class Lookup(object):
+
     goal_time = 0.2
 
     def setup(self):
-        self.rng = date_range(start='1/1/2000', periods=10000, freq='D')
-        self.stringsD = Series(self.rng.strftime('%Y%m%d'))
+        N = 1500000
+        rng = date_range(start='1/1/2000', periods=N, freq='S')
+        self.ts = Series(1, index=rng)
+        self.lookup_val = rng[N // 2]
 
-        self.rng = date_range(start='1/1/2000', periods=20000, freq='H')
-        self.strings = self.rng.strftime('%Y-%m-%d %H:%M:%S').tolist()
-        self.strings_nosep = self.rng.strftime('%Y%m%d %H:%M:%S').tolist()
-        self.strings_tz_space = [x.strftime('%Y-%m-%d %H:%M:%S') + ' -0800'
-                                 for x in self.rng]
+    def time_lookup_and_cleanup(self):
+        self.ts[self.lookup_val]
+        self.ts.index._cleanup()
 
-        self.s = Series((['19MAY11', '19MAY11:00:00:00'] * 100000))
-        self.s2 = self.s.str.replace(':\\S+$', '')
 
-        self.unique_numeric_seconds = range(10000)
-        self.dup_numeric_seconds = [1000] * 10000
-        self.dup_string_dates = ['2000-02-11'] * 10000
-        self.dup_string_with_tz = ['2000-02-11 15:00:00-0800'] * 10000
+class ToDatetimeYYYYMMDD(object):
+
+    goal_time = 0.2
+
+    def setup(self):
+        rng = date_range(start='1/1/2000', periods=10000, freq='D')
+        self.stringsD = Series(rng.strftime('%Y%m%d'))
 
     def time_format_YYYYMMDD(self):
         to_datetime(self.stringsD, format='%Y%m%d')
+
+
+class ToDatetimeISO8601(object):
+
+    goal_time = 0.2
+
+    def setup(self):
+        rng = date_range(start='1/1/2000', periods=20000, freq='H')
+        self.strings = rng.strftime('%Y-%m-%d %H:%M:%S').tolist()
+        self.strings_nosep = rng.strftime('%Y%m%d %H:%M:%S').tolist()
+        self.strings_tz_space = [x.strftime('%Y-%m-%d %H:%M:%S') + ' -0800'
+                                 for x in rng]
 
     def time_iso8601(self):
         to_datetime(self.strings)
@@ -369,49 +341,56 @@ class ToDatetime(object):
     def time_iso8601_tz_spaceformat(self):
         to_datetime(self.strings_tz_space)
 
-    def time_format_exact(self):
+
+class ToDatetimeFormat(object):
+
+    goal_time = 0.2
+
+    def setup(self):
+        self.s = Series(['19MAY11', '19MAY11:00:00:00'] * 100000)
+        self.s2 = self.s.str.replace(':\\S+$', '')
+
+    def time_exact(self):
         to_datetime(self.s2, format='%d%b%y')
 
-    def time_format_no_exact(self):
+    def time_no_exact(self):
         to_datetime(self.s, format='%d%b%y', exact=False)
 
-    def time_cache_true_with_unique_seconds_and_unit(self):
-        to_datetime(self.unique_numeric_seconds, unit='s', cache=True)
 
-    def time_cache_false_with_unique_seconds_and_unit(self):
-        to_datetime(self.unique_numeric_seconds, unit='s', cache=False)
+class ToDatetimeCache(object):
 
-    def time_cache_true_with_dup_seconds_and_unit(self):
-        to_datetime(self.dup_numeric_seconds, unit='s', cache=True)
+    goal_time = 0.2
+    params = [True, False]
+    param_names = ['cache']
 
-    def time_cache_false_with_dup_seconds_and_unit(self):
-        to_datetime(self.dup_numeric_seconds, unit='s', cache=False)
+    def setup(self, cache):
+        N = 10000
+        self.unique_numeric_seconds = range(N)
+        self.dup_numeric_seconds = [1000] * N
+        self.dup_string_dates = ['2000-02-11'] * N
+        self.dup_string_with_tz = ['2000-02-11 15:00:00-0800'] * N
 
-    def time_cache_true_with_dup_string_dates(self):
-        to_datetime(self.dup_string_dates, cache=True)
+    def time_unique_seconds_and_unit(self, cache):
+        to_datetime(self.unique_numeric_seconds, unit='s', cache=cache)
 
-    def time_cache_false_with_dup_string_dates(self):
-        to_datetime(self.dup_string_dates, cache=False)
+    def time_dup_seconds_and_unit(self, cache):
+        to_datetime(self.dup_numeric_seconds, unit='s', cache=cache)
 
-    def time_cache_true_with_dup_string_dates_and_format(self):
-        to_datetime(self.dup_string_dates, format='%Y-%m-%d', cache=True)
+    def time_dup_string_dates(self, cache):
+        to_datetime(self.dup_string_dates, cache=cache)
 
-    def time_cache_false_with_dup_string_dates_and_format(self):
-        to_datetime(self.dup_string_dates, format='%Y-%m-%d', cache=False)
+    def time_dup_string_dates_and_format(self, cache):
+        to_datetime(self.dup_string_dates, format='%Y-%m-%d', cache=cache)
 
-    def time_cache_true_with_dup_string_tzoffset_dates(self):
-        to_datetime(self.dup_string_with_tz, cache=True)
-
-    def time_cache_false_with_dup_string_tzoffset_dates(self):
-        to_datetime(self.dup_string_with_tz, cache=False)
+    def time_dup_string_tzoffset_dates(self, cache):
+        to_datetime(self.dup_string_with_tz, cache=cache)
 
 
 class DatetimeAccessor(object):
+
     def setup(self):
-        self.N = 100000
-        self.series = pd.Series(
-            pd.date_range(start='1/1/2000', periods=self.N, freq='T')
-        )
+        N = 100000
+        self.series = Series(date_range(start='1/1/2000', periods=N, freq='T'))
 
     def time_dt_accessor(self):
         self.series.dt


### PR DESCRIPTION
- [x] closes #8144 (benchmarks now have random seed where appropriate)

Split up the some benchmarks and utilized `param`s where available. I think `to_datetime(...,cache=True)` is tagged for v0.23 so that's probably why the `ToDatetimeCache` benchmarks don't work yet? 

```
[  0.00%] ·· Building for existing-py_home_matt_anaconda_envs_pandas_dev_bin_python
[  0.00%] ·· Benchmarking existing-py_home_matt_anaconda_envs_pandas_dev_bin_python
[  2.38%] ··· Running timeseries.AsOf.time_asof                              ok
[  2.38%] ···· 
               ============= ========
                constructor          
               ------------- --------
                 DataFrame    25.9ms 
                   Series     13.8ms 
               ============= ========

[  4.76%] ··· Running timeseries.AsOf.time_asof_nan                          ok
[  4.76%] ···· 
               ============= ========
                constructor          
               ------------- --------
                 DataFrame    27.8ms 
                   Series     13.4ms 
               ============= ========

[  7.14%] ··· Running timeseries.AsOf.time_asof_nan_single                   ok
[  7.14%] ···· 
               ============= ========
                constructor          
               ------------- --------
                 DataFrame    7.96ms 
                   Series     6.70ms 
               ============= ========

[  9.52%] ··· Running timeseries.AsOf.time_asof_single                       ok
[  9.52%] ···· 
               ============= ========
                constructor          
               ------------- --------
                 DataFrame    7.98ms 
                   Series     225μs  
               ============= ========

[ 11.90%] ··· Running timeseries.AsOf.time_asof_single_early                 ok
[ 11.90%] ···· 
               ============= =======
                constructor         
               ------------- -------
                 DataFrame    406μs 
                   Series     168μs 
               ============= =======

[ 14.29%] ··· Running timeseries.DatetimeAccessor.time_dt_accessor        141μs
[ 16.67%] ··· Running ...DatetimeAccessor.time_dt_accessor_normalize     15.5ms
[ 19.05%] ··· Running timeseries.DatetimeIndex.time_add_timedelta            ok
[ 19.05%] ···· 
               ============ ========
                index_type          
               ------------ --------
                   dst       1.09ms 
                 repeated    6.01ms 
                 tz_aware    5.13ms 
                 tz_naive    5.09ms 
               ============ ========

[ 21.43%] ··· Running timeseries.DatetimeIndex.time_get                      ok
[ 21.43%] ···· 
               ============ ========
                index_type          
               ------------ --------
                   dst       66.7μs 
                 repeated    58.7μs 
                 tz_aware    91.8μs 
                 tz_naive    65.2μs 
               ============ ========

[ 23.81%] ··· Running timeseries.DatetimeIndex.time_normalize                ok
[ 23.81%] ···· 
               ============ ========
                index_type          
               ------------ --------
                   dst       743μs  
                 repeated    11.7ms 
                 tz_aware    52.3ms 
                 tz_naive    11.6ms 
               ============ ========

[ 26.19%] ··· Running ...atetimeIndex.time_timeseries_is_month_start         ok
[ 26.19%] ···· 
               ============ ========
                index_type          
               ------------ --------
                   dst       364μs  
                 repeated    6.08ms 
                 tz_aware    11.4ms 
                 tz_naive    6.24ms 
               ============ ========

[ 28.57%] ··· Running timeseries.DatetimeIndex.time_to_date                  ok
[ 28.57%] ···· 
               ============ ========
                index_type          
               ------------ --------
                   dst       18.1ms 
                 repeated    498ms  
                 tz_aware    1.98s  
                 tz_naive    503ms  
               ============ ========

[ 30.95%] ··· Running timeseries.DatetimeIndex.time_to_pydatetime            ok
[ 30.95%] ···· 
               ============ ========
                index_type          
               ------------ --------
                   dst       2.41ms 
                 repeated    64.7ms 
                 tz_aware    602ms  
                 tz_naive    67.2ms 
               ============ ========

[ 33.33%] ··· Running timeseries.DatetimeIndex.time_to_time                  ok
[ 33.33%] ···· 
               ============ ========
                index_type          
               ------------ --------
                   dst       19.0ms 
                 repeated    506ms  
                 tz_aware    2.00s  
                 tz_naive    509ms  
               ============ ========

[ 35.71%] ··· Running timeseries.DatetimeIndex.time_unique                   ok
[ 35.71%] ···· 
               ============ ========
                index_type          
               ------------ --------
                   dst       592μs  
                 repeated    2.21ms 
                 tz_aware    7.59ms 
                 tz_naive    8.03ms 
               ============ ========

[ 38.10%] ··· Running timeseries.Factorize.time_factorize                    ok
[ 38.10%] ···· 
               ============ ========
                    t               
               ------------ --------
                   None      27.6ms 
                Asia/Tokyo   28.8ms 
               ============ ========

[ 40.48%] ··· Running timeseries.InferFreq.time_infer_freq                   ok
[ 40.48%] ···· 
               ====== ========
                freq          
               ------ --------
                None   1.84ms 
                 D     1.84ms 
                 B     2.81ms 
               ====== ========

[ 42.86%] ··· Running timeseries.IrregularOps.time_add                    477ms
[ 45.24%] ··· Running timeseries.Iteration.time_iter                         ok
[ 45.24%] ···· 
               =========================================== =======
                                time_index                        
               ------------------------------------------- -------
                 <function date_range at 0x7f428622a050>    1.06s 
                <function period_range at 0x7f4285d5c2a8>   5.69s 
               =========================================== =======

[ 47.62%] ··· Running timeseries.Iteration.time_iter_preexit                 ok
[ 47.62%] ···· 
               =========================================== ========
                                time_index                         
               ------------------------------------------- --------
                 <function date_range at 0x7f428622a050>    23.4ms 
                <function period_range at 0x7f4285d5c2a8>   61.1ms 
               =========================================== ========

[ 50.00%] ··· Running timeseries.Lookup.time_lookup_and_cleanup          6.01ms
[ 52.38%] ··· Running timeseries.ResampleDataFrame.time_method               ok
[ 52.38%] ···· 
               ======== ========
                method          
               -------- --------
                 max     6.67ms 
                 mean    5.88ms 
                 min     6.60ms 
               ======== ========

[ 54.76%] ··· Running timeseries.ResampleDatetetime64.time_resample      7.28ms
[ 57.14%] ··· Running timeseries.ResampleSeries.time_resample                ok
[ 57.14%] ···· 
               ========== ====== ======== ========
               --                      method     
               ----------------- -----------------
                 index     freq    mean     ohlc  
               ========== ====== ======== ========
                 period    5min   31.0ms   34.2ms 
                 period     1D    25.2ms   26.4ms 
                datetime   5min   18.0ms   21.6ms 
                datetime    1D    12.2ms   13.5ms 
               ========== ====== ======== ========

[ 59.52%] ··· Running timeseries.ResetIndex.time_reest_datetimeindex         ok
[ 59.52%] ···· 
               ============ ========
                    t               
               ------------ --------
                   None      1.15ms 
                US/Eastern   1.34ms 
               ============ ========

[ 61.90%] ··· Running timeseries.SortIndex.time_get_slice                    ok
[ 61.90%] ···· 
               =========== =======
                monotonic         
               ----------- -------
                   True     322μs 
                  False     283μs 
               =========== =======

[ 64.29%] ··· Running timeseries.SortIndex.time_sort_index                   ok
[ 64.29%] ···· 
               =========== ========
                monotonic          
               ----------- --------
                   True     1.72ms 
                  False     17.8ms 
               =========== ========

[ 66.67%] ··· Running timeseries.TimeDatetimeConverter.time_convert      12.5ms
[ 69.05%] ··· Running ...s.ToDatetimeCache.time_dup_seconds_and_unit     failed
[ 69.05%] ···· 
               ======= ========
                cache          
               ------- --------
                 True   failed 
                False   failed 
               ======= ========

[ 69.05%] ····· 
                
                For parameters: True
                Traceback (most recent call last):
                  File "/home/matt/anaconda/envs/pandas_dev/lib/python2.7/site-packages/asv/benchmark.py", line 818, in <module>
                    commands[mode](args)
                  File "/home/matt/anaconda/envs/pandas_dev/lib/python2.7/site-packages/asv/benchmark.py", line 795, in main_run
                    result = benchmark.do_run()
                  File "/home/matt/anaconda/envs/pandas_dev/lib/python2.7/site-packages/asv/benchmark.py", line 349, in do_run
                    return self.run(*self._current_params)
                  File "/home/matt/anaconda/envs/pandas_dev/lib/python2.7/site-packages/asv/benchmark.py", line 424, in run
                    samples, number = self.benchmark_timing(timer, repeat, warmup_time, number=number)
                  File "/home/matt/anaconda/envs/pandas_dev/lib/python2.7/site-packages/asv/benchmark.py", line 471, in benchmark_timing
                    timing = timer.timeit(number)
                  File "/home/matt/anaconda/envs/pandas_dev/lib/python2.7/timeit.py", line 202, in timeit
                    timing = self.inner(it, self.timer)
                  File "/home/matt/anaconda/envs/pandas_dev/lib/python2.7/timeit.py", line 100, in inner
                    _func()
                  File "/home/matt/anaconda/envs/pandas_dev/lib/python2.7/site-packages/asv/benchmark.py", line 415, in <lambda>
                    func = lambda: self.func(*param)
                  File "/home/matt/Projects/pandas-mroeschke/asv_bench/benchmarks/timeseries.py", line 377, in time_dup_seconds_and_unit
                    to_datetime(self.dup_numeric_seconds, unit='s', cache=cache)
                TypeError: to_datetime() got an unexpected keyword argument 'cache'
                
                For parameters: False
                Traceback (most recent call last):
                  File "/home/matt/anaconda/envs/pandas_dev/lib/python2.7/site-packages/asv/benchmark.py", line 818, in <module>
                    commands[mode](args)
                  File "/home/matt/anaconda/envs/pandas_dev/lib/python2.7/site-packages/asv/benchmark.py", line 795, in main_run
                    result = benchmark.do_run()
                  File "/home/matt/anaconda/envs/pandas_dev/lib/python2.7/site-packages/asv/benchmark.py", line 349, in do_run
                    return self.run(*self._current_params)
                  File "/home/matt/anaconda/envs/pandas_dev/lib/python2.7/site-packages/asv/benchmark.py", line 424, in run
                    samples, number = self.benchmark_timing(timer, repeat, warmup_time, number=number)
                  File "/home/matt/anaconda/envs/pandas_dev/lib/python2.7/site-packages/asv/benchmark.py", line 471, in benchmark_timing
                    timing = timer.timeit(number)
                  File "/home/matt/anaconda/envs/pandas_dev/lib/python2.7/timeit.py", line 202, in timeit
                    timing = self.inner(it, self.timer)
                  File "/home/matt/anaconda/envs/pandas_dev/lib/python2.7/timeit.py", line 100, in inner
                    _func()
                  File "/home/matt/anaconda/envs/pandas_dev/lib/python2.7/site-packages/asv/benchmark.py", line 415, in <lambda>
                    func = lambda: self.func(*param)
                  File "/home/matt/Projects/pandas-mroeschke/asv_bench/benchmarks/timeseries.py", line 377, in time_dup_seconds_and_unit
                    to_datetime(self.dup_numeric_seconds, unit='s', cache=cache)
                TypeError: to_datetime() got an unexpected keyword argument 'cache'

[ 71.43%] ··· Running ...eries.ToDatetimeCache.time_dup_string_dates     failed
[ 71.43%] ···· 
               ======= ========
                cache          
               ------- --------
                 True   failed 
                False   failed 
               ======= ========

[ 71.43%] ····· 
                
                For parameters: True
                Traceback (most recent call last):
                  File "/home/matt/anaconda/envs/pandas_dev/lib/python2.7/site-packages/asv/benchmark.py", line 818, in <module>
                    commands[mode](args)
                  File "/home/matt/anaconda/envs/pandas_dev/lib/python2.7/site-packages/asv/benchmark.py", line 795, in main_run
                    result = benchmark.do_run()
                  File "/home/matt/anaconda/envs/pandas_dev/lib/python2.7/site-packages/asv/benchmark.py", line 349, in do_run
                    return self.run(*self._current_params)
                  File "/home/matt/anaconda/envs/pandas_dev/lib/python2.7/site-packages/asv/benchmark.py", line 424, in run
                    samples, number = self.benchmark_timing(timer, repeat, warmup_time, number=number)
                  File "/home/matt/anaconda/envs/pandas_dev/lib/python2.7/site-packages/asv/benchmark.py", line 471, in benchmark_timing
                    timing = timer.timeit(number)
                  File "/home/matt/anaconda/envs/pandas_dev/lib/python2.7/timeit.py", line 202, in timeit
                    timing = self.inner(it, self.timer)
                  File "/home/matt/anaconda/envs/pandas_dev/lib/python2.7/timeit.py", line 100, in inner
                    _func()
                  File "/home/matt/anaconda/envs/pandas_dev/lib/python2.7/site-packages/asv/benchmark.py", line 415, in <lambda>
                    func = lambda: self.func(*param)
                  File "/home/matt/Projects/pandas-mroeschke/asv_bench/benchmarks/timeseries.py", line 380, in time_dup_string_dates
                    to_datetime(self.dup_string_dates, cache=cache)
                TypeError: to_datetime() got an unexpected keyword argument 'cache'
                
                For parameters: False
                Traceback (most recent call last):
                  File "/home/matt/anaconda/envs/pandas_dev/lib/python2.7/site-packages/asv/benchmark.py", line 818, in <module>
                    commands[mode](args)
                  File "/home/matt/anaconda/envs/pandas_dev/lib/python2.7/site-packages/asv/benchmark.py", line 795, in main_run
                    result = benchmark.do_run()
                  File "/home/matt/anaconda/envs/pandas_dev/lib/python2.7/site-packages/asv/benchmark.py", line 349, in do_run
                    return self.run(*self._current_params)
                  File "/home/matt/anaconda/envs/pandas_dev/lib/python2.7/site-packages/asv/benchmark.py", line 424, in run
                    samples, number = self.benchmark_timing(timer, repeat, warmup_time, number=number)
                  File "/home/matt/anaconda/envs/pandas_dev/lib/python2.7/site-packages/asv/benchmark.py", line 471, in benchmark_timing
                    timing = timer.timeit(number)
                  File "/home/matt/anaconda/envs/pandas_dev/lib/python2.7/timeit.py", line 202, in timeit
                    timing = self.inner(it, self.timer)
                  File "/home/matt/anaconda/envs/pandas_dev/lib/python2.7/timeit.py", line 100, in inner
                    _func()
                  File "/home/matt/anaconda/envs/pandas_dev/lib/python2.7/site-packages/asv/benchmark.py", line 415, in <lambda>
                    func = lambda: self.func(*param)
                  File "/home/matt/Projects/pandas-mroeschke/asv_bench/benchmarks/timeseries.py", line 380, in time_dup_string_dates
                    to_datetime(self.dup_string_dates, cache=cache)
                TypeError: to_datetime() got an unexpected keyword argument 'cache'

[ 73.81%] ··· Running ...etimeCache.time_dup_string_dates_and_format     failed
[ 73.81%] ···· 
               ======= ========
                cache          
               ------- --------
                 True   failed 
                False   failed 
               ======= ========

[ 73.81%] ····· 
                
                For parameters: True
                Traceback (most recent call last):
                  File "/home/matt/anaconda/envs/pandas_dev/lib/python2.7/site-packages/asv/benchmark.py", line 818, in <module>
                    commands[mode](args)
                  File "/home/matt/anaconda/envs/pandas_dev/lib/python2.7/site-packages/asv/benchmark.py", line 795, in main_run
                    result = benchmark.do_run()
                  File "/home/matt/anaconda/envs/pandas_dev/lib/python2.7/site-packages/asv/benchmark.py", line 349, in do_run
                    return self.run(*self._current_params)
                  File "/home/matt/anaconda/envs/pandas_dev/lib/python2.7/site-packages/asv/benchmark.py", line 424, in run
                    samples, number = self.benchmark_timing(timer, repeat, warmup_time, number=number)
                  File "/home/matt/anaconda/envs/pandas_dev/lib/python2.7/site-packages/asv/benchmark.py", line 471, in benchmark_timing
                    timing = timer.timeit(number)
                  File "/home/matt/anaconda/envs/pandas_dev/lib/python2.7/timeit.py", line 202, in timeit
                    timing = self.inner(it, self.timer)
                  File "/home/matt/anaconda/envs/pandas_dev/lib/python2.7/timeit.py", line 100, in inner
                    _func()
                  File "/home/matt/anaconda/envs/pandas_dev/lib/python2.7/site-packages/asv/benchmark.py", line 415, in <lambda>
                    func = lambda: self.func(*param)
                  File "/home/matt/Projects/pandas-mroeschke/asv_bench/benchmarks/timeseries.py", line 383, in time_dup_string_dates_and_format
                    to_datetime(self.dup_string_dates, format='%Y-%m-%d', cache=cache)
                TypeError: to_datetime() got an unexpected keyword argument 'cache'
                
                For parameters: False
                Traceback (most recent call last):
                  File "/home/matt/anaconda/envs/pandas_dev/lib/python2.7/site-packages/asv/benchmark.py", line 818, in <module>
                    commands[mode](args)
                  File "/home/matt/anaconda/envs/pandas_dev/lib/python2.7/site-packages/asv/benchmark.py", line 795, in main_run
                    result = benchmark.do_run()
                  File "/home/matt/anaconda/envs/pandas_dev/lib/python2.7/site-packages/asv/benchmark.py", line 349, in do_run
                    return self.run(*self._current_params)
                  File "/home/matt/anaconda/envs/pandas_dev/lib/python2.7/site-packages/asv/benchmark.py", line 424, in run
                    samples, number = self.benchmark_timing(timer, repeat, warmup_time, number=number)
                  File "/home/matt/anaconda/envs/pandas_dev/lib/python2.7/site-packages/asv/benchmark.py", line 471, in benchmark_timing
                    timing = timer.timeit(number)
                  File "/home/matt/anaconda/envs/pandas_dev/lib/python2.7/timeit.py", line 202, in timeit
                    timing = self.inner(it, self.timer)
                  File "/home/matt/anaconda/envs/pandas_dev/lib/python2.7/timeit.py", line 100, in inner
                    _func()
                  File "/home/matt/anaconda/envs/pandas_dev/lib/python2.7/site-packages/asv/benchmark.py", line 415, in <lambda>
                    func = lambda: self.func(*param)
                  File "/home/matt/Projects/pandas-mroeschke/asv_bench/benchmarks/timeseries.py", line 383, in time_dup_string_dates_and_format
                    to_datetime(self.dup_string_dates, format='%Y-%m-%d', cache=cache)
                TypeError: to_datetime() got an unexpected keyword argument 'cache'

[ 76.19%] ··· Running ...atetimeCache.time_dup_string_tzoffset_dates     failed
[ 76.19%] ···· 
               ======= ========
                cache          
               ------- --------
                 True   failed 
                False   failed 
               ======= ========

[ 76.19%] ····· 
                
                For parameters: True
                Traceback (most recent call last):
                  File "/home/matt/anaconda/envs/pandas_dev/lib/python2.7/site-packages/asv/benchmark.py", line 818, in <module>
                    commands[mode](args)
                  File "/home/matt/anaconda/envs/pandas_dev/lib/python2.7/site-packages/asv/benchmark.py", line 795, in main_run
                    result = benchmark.do_run()
                  File "/home/matt/anaconda/envs/pandas_dev/lib/python2.7/site-packages/asv/benchmark.py", line 349, in do_run
                    return self.run(*self._current_params)
                  File "/home/matt/anaconda/envs/pandas_dev/lib/python2.7/site-packages/asv/benchmark.py", line 424, in run
                    samples, number = self.benchmark_timing(timer, repeat, warmup_time, number=number)
                  File "/home/matt/anaconda/envs/pandas_dev/lib/python2.7/site-packages/asv/benchmark.py", line 471, in benchmark_timing
                    timing = timer.timeit(number)
                  File "/home/matt/anaconda/envs/pandas_dev/lib/python2.7/timeit.py", line 202, in timeit
                    timing = self.inner(it, self.timer)
                  File "/home/matt/anaconda/envs/pandas_dev/lib/python2.7/timeit.py", line 100, in inner
                    _func()
                  File "/home/matt/anaconda/envs/pandas_dev/lib/python2.7/site-packages/asv/benchmark.py", line 415, in <lambda>
                    func = lambda: self.func(*param)
                  File "/home/matt/Projects/pandas-mroeschke/asv_bench/benchmarks/timeseries.py", line 386, in time_dup_string_tzoffset_dates
                    to_datetime(self.dup_string_with_tz, cache=cache)
                TypeError: to_datetime() got an unexpected keyword argument 'cache'
                
                For parameters: False
                Traceback (most recent call last):
                  File "/home/matt/anaconda/envs/pandas_dev/lib/python2.7/site-packages/asv/benchmark.py", line 818, in <module>
                    commands[mode](args)
                  File "/home/matt/anaconda/envs/pandas_dev/lib/python2.7/site-packages/asv/benchmark.py", line 795, in main_run
                    result = benchmark.do_run()
                  File "/home/matt/anaconda/envs/pandas_dev/lib/python2.7/site-packages/asv/benchmark.py", line 349, in do_run
                    return self.run(*self._current_params)
                  File "/home/matt/anaconda/envs/pandas_dev/lib/python2.7/site-packages/asv/benchmark.py", line 424, in run
                    samples, number = self.benchmark_timing(timer, repeat, warmup_time, number=number)
                  File "/home/matt/anaconda/envs/pandas_dev/lib/python2.7/site-packages/asv/benchmark.py", line 471, in benchmark_timing
                    timing = timer.timeit(number)
                  File "/home/matt/anaconda/envs/pandas_dev/lib/python2.7/timeit.py", line 202, in timeit
                    timing = self.inner(it, self.timer)
                  File "/home/matt/anaconda/envs/pandas_dev/lib/python2.7/timeit.py", line 100, in inner
                    _func()
                  File "/home/matt/anaconda/envs/pandas_dev/lib/python2.7/site-packages/asv/benchmark.py", line 415, in <lambda>
                    func = lambda: self.func(*param)
                  File "/home/matt/Projects/pandas-mroeschke/asv_bench/benchmarks/timeseries.py", line 386, in time_dup_string_tzoffset_dates
                    to_datetime(self.dup_string_with_tz, cache=cache)
                TypeError: to_datetime() got an unexpected keyword argument 'cache'

[ 78.57%] ··· Running ...oDatetimeCache.time_unique_seconds_and_unit     failed
[ 78.57%] ···· 
               ======= ========
                cache          
               ------- --------
                 True   failed 
                False   failed 
               ======= ========

[ 78.57%] ····· 
                
                For parameters: True
                Traceback (most recent call last):
                  File "/home/matt/anaconda/envs/pandas_dev/lib/python2.7/site-packages/asv/benchmark.py", line 818, in <module>
                    commands[mode](args)
                  File "/home/matt/anaconda/envs/pandas_dev/lib/python2.7/site-packages/asv/benchmark.py", line 795, in main_run
                    result = benchmark.do_run()
                  File "/home/matt/anaconda/envs/pandas_dev/lib/python2.7/site-packages/asv/benchmark.py", line 349, in do_run
                    return self.run(*self._current_params)
                  File "/home/matt/anaconda/envs/pandas_dev/lib/python2.7/site-packages/asv/benchmark.py", line 424, in run
                    samples, number = self.benchmark_timing(timer, repeat, warmup_time, number=number)
                  File "/home/matt/anaconda/envs/pandas_dev/lib/python2.7/site-packages/asv/benchmark.py", line 471, in benchmark_timing
                    timing = timer.timeit(number)
                  File "/home/matt/anaconda/envs/pandas_dev/lib/python2.7/timeit.py", line 202, in timeit
                    timing = self.inner(it, self.timer)
                  File "/home/matt/anaconda/envs/pandas_dev/lib/python2.7/timeit.py", line 100, in inner
                    _func()
                  File "/home/matt/anaconda/envs/pandas_dev/lib/python2.7/site-packages/asv/benchmark.py", line 415, in <lambda>
                    func = lambda: self.func(*param)
                  File "/home/matt/Projects/pandas-mroeschke/asv_bench/benchmarks/timeseries.py", line 374, in time_unique_seconds_and_unit
                    to_datetime(self.unique_numeric_seconds, unit='s', cache=cache)
                TypeError: to_datetime() got an unexpected keyword argument 'cache'
                
                For parameters: False
                Traceback (most recent call last):
                  File "/home/matt/anaconda/envs/pandas_dev/lib/python2.7/site-packages/asv/benchmark.py", line 818, in <module>
                    commands[mode](args)
                  File "/home/matt/anaconda/envs/pandas_dev/lib/python2.7/site-packages/asv/benchmark.py", line 795, in main_run
                    result = benchmark.do_run()
                  File "/home/matt/anaconda/envs/pandas_dev/lib/python2.7/site-packages/asv/benchmark.py", line 349, in do_run
                    return self.run(*self._current_params)
                  File "/home/matt/anaconda/envs/pandas_dev/lib/python2.7/site-packages/asv/benchmark.py", line 424, in run
                    samples, number = self.benchmark_timing(timer, repeat, warmup_time, number=number)
                  File "/home/matt/anaconda/envs/pandas_dev/lib/python2.7/site-packages/asv/benchmark.py", line 471, in benchmark_timing
                    timing = timer.timeit(number)
                  File "/home/matt/anaconda/envs/pandas_dev/lib/python2.7/timeit.py", line 202, in timeit
                    timing = self.inner(it, self.timer)
                  File "/home/matt/anaconda/envs/pandas_dev/lib/python2.7/timeit.py", line 100, in inner
                    _func()
                  File "/home/matt/anaconda/envs/pandas_dev/lib/python2.7/site-packages/asv/benchmark.py", line 415, in <lambda>
                    func = lambda: self.func(*param)
                  File "/home/matt/Projects/pandas-mroeschke/asv_bench/benchmarks/timeseries.py", line 374, in time_unique_seconds_and_unit
                    to_datetime(self.unique_numeric_seconds, unit='s', cache=cache)
                TypeError: to_datetime() got an unexpected keyword argument 'cache'

[ 80.95%] ··· Running timeseries.ToDatetimeFormat.time_exact              2.02s
[ 83.33%] ··· Running timeseries.ToDatetimeFormat.time_no_exact           1.93s
[ 85.71%] ··· Running timeseries.ToDatetimeISO8601.time_iso8601          9.93ms
[ 88.10%] ··· Running ...eries.ToDatetimeISO8601.time_iso8601_format     10.2ms
[ 90.48%] ··· Running ...oDatetimeISO8601.time_iso8601_format_no_sep     9.67ms
[ 92.86%] ··· Running ...series.ToDatetimeISO8601.time_iso8601_nosep     9.84ms
[ 95.24%] ··· Running ...DatetimeISO8601.time_iso8601_tz_spaceformat      619ms
[ 97.62%] ··· Running ...ies.ToDatetimeYYYYMMDD.time_format_YYYYMMDD     15.1ms
[100.00%] ··· Running timeseries.TzLocalize.time_infer_dst               4.84ms
[100.00%] ····· /home/matt/Projects/pandas-mroeschke/asv_bench/benchmarks/timeseries.py:77: FutureWarning: the infer_dst=True keyword is deprecated, use ambiguous='infer' instead
                self.index.tz_localize('US/Eastern', infer_dst=True)
```
