### PR TITLE
Followup Cleanup DTI test_arithmetic, ASV

### DIFF
--- a/asv_bench/benchmarks/timestamp.py
+++ b/asv_bench/benchmarks/timestamp.py
@@ -36,9 +36,6 @@ class TimestampProperties(object):
     def time_tz(self, tz, freq):
         self.ts.tz
 
-    def time_offset(self, tz, freq):
-        self.ts.offset
-
     def time_dayofweek(self, tz, freq):
         self.ts.dayofweek
 

--- a/pandas/tests/indexes/datetimes/test_arithmetic.py
+++ b/pandas/tests/indexes/datetimes/test_arithmetic.py
@@ -447,9 +447,9 @@ class TestDatetimeIndexArithmetic(object):
         tm.assert_series_equal(res3, expected_sub)
 
 
-@pytest.mark.parametrize('klass,assert_func', zip([Series, DatetimeIndex],
-                                                  [tm.assert_series_equal,
-                                                   tm.assert_index_equal]))
+@pytest.mark.parametrize('klass,assert_func', [
+    (Series, tm.assert_series_equal),
+    (DatetimeIndex, tm.assert_index_equal)])
 def test_dt64_with_offset_array(klass, assert_func):
     # GH#10699
     # array of offsets
@@ -468,9 +468,9 @@ def test_dt64_with_offset_array(klass, assert_func):
         assert_func(result, exp)
 
 
-@pytest.mark.parametrize('klass,assert_func', zip([Series, DatetimeIndex],
-                                                  [tm.assert_series_equal,
-                                                   tm.assert_index_equal]))
+@pytest.mark.parametrize('klass,assert_func', [
+    (Series, tm.assert_series_equal),
+    (DatetimeIndex, tm.assert_index_equal)])
 def test_dt64_with_DateOffsets_relativedelta(klass, assert_func):
     # GH#10699
     vec = klass([Timestamp('2000-01-05 00:15:00'),
@@ -515,9 +515,9 @@ def test_dt64_with_DateOffsets_relativedelta(klass, assert_func):
     'Easter', ('DateOffset', {'day': 4}),
     ('DateOffset', {'month': 5})])
 @pytest.mark.parametrize('normalize', [True, False])
-@pytest.mark.parametrize('klass,assert_func', zip([Series, DatetimeIndex],
-                                                  [tm.assert_series_equal,
-                                                   tm.assert_index_equal]))
+@pytest.mark.parametrize('klass,assert_func', [
+    (Series, tm.assert_series_equal),
+    (DatetimeIndex, tm.assert_index_equal)])
 def test_dt64_with_DateOffsets(klass, assert_func, normalize, cls_name):
     # GH#10699
     # assert these are equal on a piecewise basis

--- a/pandas/tests/indexes/datetimes/test_arithmetic.py
+++ b/pandas/tests/indexes/datetimes/test_arithmetic.py
@@ -541,12 +541,12 @@ def test_dt64_with_DateOffsets(klass, assert_func, cls_name):
                 if (cls_name in ['WeekOfMonth', 'LastWeekOfMonth',
                                  'FY5253Quarter', 'FY5253'] and n == 0):
                     continue
-            offset = getattr(pd.offsets, cls_name)(n,
-                                                   normalize=normalize,
-                                                   **kwargs)
-            assert_func(klass([x + offset for x in vec]), vec + offset)
-            assert_func(klass([x - offset for x in vec]), vec - offset)
-            assert_func(klass([offset + x for x in vec]), offset + vec)
+                offset = getattr(pd.offsets, cls_name)(n,
+                                                       normalize=normalize,
+                                                       **kwargs)
+                assert_func(klass([x + offset for x in vec]), vec + offset)
+                assert_func(klass([x - offset for x in vec]), vec - offset)
+                assert_func(klass([offset + x for x in vec]), offset + vec)
 
 
 # GH 10699

--- a/pandas/tests/indexes/datetimes/test_arithmetic.py
+++ b/pandas/tests/indexes/datetimes/test_arithmetic.py
@@ -447,6 +447,108 @@ class TestDatetimeIndexArithmetic(object):
         tm.assert_series_equal(res3, expected_sub)
 
 
+@pytest.mark.parametrize('klass,assert_func', zip([Series, DatetimeIndex],
+                                                  [tm.assert_series_equal,
+                                                   tm.assert_index_equal]))
+def test_dt64_with_offset_array(klass, assert_func):
+    # GH#10699
+    # array of offsets
+    box = Series if klass is Series else pd.Index
+    with tm.assert_produces_warning(PerformanceWarning):
+        s = klass([Timestamp('2000-1-1'), Timestamp('2000-2-1')])
+        result = s + box([pd.offsets.DateOffset(years=1),
+                          pd.offsets.MonthEnd()])
+        exp = klass([Timestamp('2001-1-1'), Timestamp('2000-2-29')])
+        assert_func(result, exp)
+
+        # same offset
+        result = s + box([pd.offsets.DateOffset(years=1),
+                          pd.offsets.DateOffset(years=1)])
+        exp = klass([Timestamp('2001-1-1'), Timestamp('2001-2-1')])
+        assert_func(result, exp)
+
+
+@pytest.mark.parametrize('klass,assert_func', zip([Series, DatetimeIndex],
+                                                  [tm.assert_series_equal,
+                                                   tm.assert_index_equal]))
+def test_dt64_with_DateOffsets_relativedelta(klass, assert_func):
+    # GH#10699
+    vec = klass([Timestamp('2000-01-05 00:15:00'),
+                 Timestamp('2000-01-31 00:23:00'),
+                 Timestamp('2000-01-01'),
+                 Timestamp('2000-03-31'),
+                 Timestamp('2000-02-29'),
+                 Timestamp('2000-12-31'),
+                 Timestamp('2000-05-15'),
+                 Timestamp('2001-06-15')])
+
+    # DateOffset relativedelta fastpath
+    relative_kwargs = [('years', 2), ('months', 5), ('days', 3),
+                       ('hours', 5), ('minutes', 10), ('seconds', 2),
+                       ('microseconds', 5)]
+    for i, kwd in enumerate(relative_kwargs):
+        op = pd.DateOffset(**dict([kwd]))
+        assert_func(klass([x + op for x in vec]), vec + op)
+        assert_func(klass([x - op for x in vec]), vec - op)
+        op = pd.DateOffset(**dict(relative_kwargs[:i + 1]))
+        assert_func(klass([x + op for x in vec]), vec + op)
+        assert_func(klass([x - op for x in vec]), vec - op)
+
+
+@pytest.mark.parametrize('cls_name', [
+    'YearBegin', ('YearBegin', {'month': 5}),
+    'YearEnd', ('YearEnd', {'month': 5}),
+    'MonthBegin', 'MonthEnd',
+    'SemiMonthEnd', 'SemiMonthBegin',
+    'Week', ('Week', {'weekday': 3}),
+    'BusinessDay', 'BDay', 'QuarterEnd', 'QuarterBegin',
+    'CustomBusinessDay', 'CDay', 'CBMonthEnd',
+    'CBMonthBegin', 'BMonthBegin', 'BMonthEnd',
+    'BusinessHour', 'BYearBegin', 'BYearEnd',
+    'BQuarterBegin', ('LastWeekOfMonth', {'weekday': 2}),
+    ('FY5253Quarter', {'qtr_with_extra_week': 1,
+                       'startingMonth': 1,
+                       'weekday': 2,
+                       'variation': 'nearest'}),
+    ('FY5253', {'weekday': 0, 'startingMonth': 2, 'variation': 'nearest'}),
+    ('WeekOfMonth', {'weekday': 2, 'week': 2}),
+    'Easter', ('DateOffset', {'day': 4}),
+    ('DateOffset', {'month': 5})])
+@pytest.mark.parametrize('klass,assert_func', zip([Series, DatetimeIndex],
+                                                  [tm.assert_series_equal,
+                                                   tm.assert_index_equal]))
+def test_dt64_with_DateOffsets(klass, assert_func, cls_name):
+    # GH#10699
+    # assert these are equal on a piecewise basis
+    vec = klass([Timestamp('2000-01-05 00:15:00'),
+                 Timestamp('2000-01-31 00:23:00'),
+                 Timestamp('2000-01-01'),
+                 Timestamp('2000-03-31'),
+                 Timestamp('2000-02-29'),
+                 Timestamp('2000-12-31'),
+                 Timestamp('2000-05-15'),
+                 Timestamp('2001-06-15')])
+
+    with warnings.catch_warnings(record=True):
+        for normalize in (True, False):
+            if isinstance(cls_name, tuple):
+                cls_name, kwargs = cls_name
+            else:
+                cls_name = cls_name
+                kwargs = {}
+
+            for n in [0, 5]:
+                if (cls_name in ['WeekOfMonth', 'LastWeekOfMonth',
+                                 'FY5253Quarter', 'FY5253'] and n == 0):
+                    continue
+            offset = getattr(pd.offsets, cls_name)(n,
+                                                   normalize=normalize,
+                                                   **kwargs)
+            assert_func(klass([x + offset for x in vec]), vec + offset)
+            assert_func(klass([x - offset for x in vec]), vec - offset)
+            assert_func(klass([offset + x for x in vec]), offset + vec)
+
+
 # GH 10699
 @pytest.mark.parametrize('klass,assert_func', zip([Series, DatetimeIndex],
                                                   [tm.assert_series_equal,
@@ -480,84 +582,3 @@ def test_datetime64_with_DateOffset(klass, assert_func):
                  Timestamp('2000-02-29', tz='US/Central')], name='a')
     assert_func(result, exp)
     assert_func(result2, exp)
-
-    # array of offsets - valid for Series only
-    if klass is Series:
-        with tm.assert_produces_warning(PerformanceWarning):
-            s = klass([Timestamp('2000-1-1'), Timestamp('2000-2-1')])
-            result = s + Series([pd.offsets.DateOffset(years=1),
-                                 pd.offsets.MonthEnd()])
-            exp = klass([Timestamp('2001-1-1'), Timestamp('2000-2-29')
-                         ])
-            assert_func(result, exp)
-
-            # same offset
-            result = s + Series([pd.offsets.DateOffset(years=1),
-                                 pd.offsets.DateOffset(years=1)])
-            exp = klass([Timestamp('2001-1-1'), Timestamp('2001-2-1')])
-            assert_func(result, exp)
-
-    s = klass([Timestamp('2000-01-05 00:15:00'),
-               Timestamp('2000-01-31 00:23:00'),
-               Timestamp('2000-01-01'),
-               Timestamp('2000-03-31'),
-               Timestamp('2000-02-29'),
-               Timestamp('2000-12-31'),
-               Timestamp('2000-05-15'),
-               Timestamp('2001-06-15')])
-
-    # DateOffset relativedelta fastpath
-    relative_kwargs = [('years', 2), ('months', 5), ('days', 3),
-                       ('hours', 5), ('minutes', 10), ('seconds', 2),
-                       ('microseconds', 5)]
-    for i, kwd in enumerate(relative_kwargs):
-        op = pd.DateOffset(**dict([kwd]))
-        assert_func(klass([x + op for x in s]), s + op)
-        assert_func(klass([x - op for x in s]), s - op)
-        op = pd.DateOffset(**dict(relative_kwargs[:i + 1]))
-        assert_func(klass([x + op for x in s]), s + op)
-        assert_func(klass([x - op for x in s]), s - op)
-
-    # assert these are equal on a piecewise basis
-    offsets = ['YearBegin', ('YearBegin', {'month': 5}),
-               'YearEnd', ('YearEnd', {'month': 5}),
-               'MonthBegin', 'MonthEnd',
-               'SemiMonthEnd', 'SemiMonthBegin',
-               'Week', ('Week', {'weekday': 3}),
-               'BusinessDay', 'BDay', 'QuarterEnd', 'QuarterBegin',
-               'CustomBusinessDay', 'CDay', 'CBMonthEnd',
-               'CBMonthBegin', 'BMonthBegin', 'BMonthEnd',
-               'BusinessHour', 'BYearBegin', 'BYearEnd',
-               'BQuarterBegin', ('LastWeekOfMonth', {'weekday': 2}),
-               ('FY5253Quarter', {'qtr_with_extra_week': 1,
-                                  'startingMonth': 1,
-                                  'weekday': 2,
-                                  'variation': 'nearest'}),
-               ('FY5253', {'weekday': 0,
-                           'startingMonth': 2,
-                           'variation':
-                           'nearest'}),
-               ('WeekOfMonth', {'weekday': 2,
-                                'week': 2}),
-               'Easter', ('DateOffset', {'day': 4}),
-               ('DateOffset', {'month': 5})]
-
-    with warnings.catch_warnings(record=True):
-        for normalize in (True, False):
-            for do in offsets:
-                if isinstance(do, tuple):
-                    do, kwargs = do
-                else:
-                    do = do
-                    kwargs = {}
-
-                    for n in [0, 5]:
-                        if (do in ['WeekOfMonth', 'LastWeekOfMonth',
-                                   'FY5253Quarter', 'FY5253'] and n == 0):
-                            continue
-                    op = getattr(pd.offsets, do)(n,
-                                                 normalize=normalize,
-                                                 **kwargs)
-                    assert_func(klass([x + op for x in s]), s + op)
-                    assert_func(klass([x - op for x in s]), s - op)
-                    assert_func(klass([op + x for x in s]), op + s)

--- a/pandas/tests/indexes/datetimes/test_arithmetic.py
+++ b/pandas/tests/indexes/datetimes/test_arithmetic.py
@@ -537,14 +537,16 @@ def test_dt64_with_DateOffsets(klass, assert_func, normalize, cls_name):
     else:
         kwargs = {}
 
+    offset_cls = getattr(pd.offsets, cls_name)
+
     with warnings.catch_warnings(record=True):
         for n in [0, 5]:
             if (cls_name in ['WeekOfMonth', 'LastWeekOfMonth',
                              'FY5253Quarter', 'FY5253'] and n == 0):
+                # passing n = 0 is invalid for these offset classes
                 continue
-            offset = getattr(pd.offsets, cls_name)(n,
-                                                   normalize=normalize,
-                                                   **kwargs)
+
+            offset = offset_cls(n, normalize=normalize, **kwargs)
             assert_func(klass([x + offset for x in vec]), vec + offset)
             assert_func(klass([x - offset for x in vec]), vec - offset)
             assert_func(klass([offset + x for x in vec]), offset + vec)

--- a/pandas/tests/indexes/datetimes/test_arithmetic.py
+++ b/pandas/tests/indexes/datetimes/test_arithmetic.py
@@ -535,7 +535,6 @@ def test_dt64_with_DateOffsets(klass, assert_func, normalize, cls_name):
         # the offset constructor
         cls_name, kwargs = cls_name
     else:
-        cls_name = cls_name
         kwargs = {}
 
     with warnings.catch_warnings(record=True):

--- a/pandas/tests/series/test_operators.py
+++ b/pandas/tests/series/test_operators.py
@@ -1379,21 +1379,23 @@ class TestDatetimeSeriesArithmetic(object):
         assert_series_equal(NaT + nat_series_dtype_timestamp,
                             nat_series_dtype_timestamp)
 
+    @pytest.mark.parametrize('dt64_series', [
+        Series([Timestamp('19900315'), Timestamp('19900315')]),
+        Series([NaT, Timestamp('19900315')]),
+        Series([NaT, NaT], dtype='datetime64[ns]')])
+    @pytest.mark.parametrize('one', [1, 1.0, np.array(1)])
+    def test_dt64_mul_div_numeric_invalid(self, one, dt64_series):
         # multiplication
         with pytest.raises(TypeError):
-            datetime_series * 1
+            dt64_series * one
         with pytest.raises(TypeError):
-            nat_series_dtype_timestamp * 1
-        with pytest.raises(TypeError):
-            datetime_series * 1.0
-        with pytest.raises(TypeError):
-            nat_series_dtype_timestamp * 1.0
+            one * dt64_series
 
         # division
         with pytest.raises(TypeError):
-            nat_series_dtype_timestamp / 1.0
+            dt64_series / one
         with pytest.raises(TypeError):
-            nat_series_dtype_timestamp / 1
+            one / dt64_series
 
     def test_dt64series_arith_overflow(self):
         # GH#12534, fixed by #19024

--- a/pandas/tests/series/test_operators.py
+++ b/pandas/tests/series/test_operators.py
@@ -1005,9 +1005,7 @@ class TestTimedeltaSeriesArithmetic(object):
 
     @pytest.mark.parametrize('scalar_td', [
         timedelta(minutes=5, seconds=4),
-        pytest.param(Timedelta('5m4s'),
-                     marks=pytest.mark.xfail(reason="Timedelta.__floordiv__ "
-                                                    "bug GH#18846")),
+        Timedelta('5m4s'),
         Timedelta('5m4s').to_timedelta64()])
     def test_timedelta_rfloordiv(self, scalar_td):
         # GH#18831

--- a/pandas/tests/series/test_operators.py
+++ b/pandas/tests/series/test_operators.py
@@ -1572,6 +1572,7 @@ class TestSeriesOperators(TestData):
                 expected = s1.apply(
                     lambda x: Timedelta(np.timedelta64(m, unit)) / x)
                 result = np.timedelta64(m, unit) / s1
+                assert_series_equal(result, expected)
 
         # astype
         s = Series(date_range('20130101', periods=3))

--- a/pandas/tests/series/test_operators.py
+++ b/pandas/tests/series/test_operators.py
@@ -1988,69 +1988,69 @@ class TestSeriesOperators(TestData):
         with pytest.raises(TypeError):
             self.ts + datetime.now()
 
-    def test_series_radd_more(self):
-        data = [[1, 2, 3],
-                [1.1, 2.2, 3.3],
-                [pd.Timestamp('2011-01-01'), pd.Timestamp('2011-01-02'),
-                 pd.NaT],
-                ['x', 'y', 1]]
+    def test_series_radd_str(self):
+        ser = pd.Series(['x', np.nan, 'x'])
+        assert_series_equal('a' + ser, pd.Series(['ax', np.nan, 'ax']))
+        assert_series_equal(ser + 'a', pd.Series(['xa', np.nan, 'xa']))
 
-        for d in data:
-            for dtype in [None, object]:
-                s = Series(d, dtype=dtype)
-                with pytest.raises(TypeError):
-                    'foo_' + s
+    @pytest.mark.parametrize('dtype', [None, object])
+    def test_series_radd_more(self, dtype):
+        res = 1 + pd.Series([1, 2, 3], dtype=dtype)
+        exp = pd.Series([2, 3, 4], dtype=dtype)
+        assert_series_equal(res, exp)
+        res = pd.Series([1, 2, 3], dtype=dtype) + 1
+        assert_series_equal(res, exp)
 
-        for dtype in [None, object]:
-            res = 1 + pd.Series([1, 2, 3], dtype=dtype)
-            exp = pd.Series([2, 3, 4], dtype=dtype)
-            assert_series_equal(res, exp)
-            res = pd.Series([1, 2, 3], dtype=dtype) + 1
-            assert_series_equal(res, exp)
+        res = np.nan + pd.Series([1, 2, 3], dtype=dtype)
+        exp = pd.Series([np.nan, np.nan, np.nan], dtype=dtype)
+        assert_series_equal(res, exp)
+        res = pd.Series([1, 2, 3], dtype=dtype) + np.nan
+        assert_series_equal(res, exp)
 
-            res = np.nan + pd.Series([1, 2, 3], dtype=dtype)
-            exp = pd.Series([np.nan, np.nan, np.nan], dtype=dtype)
-            assert_series_equal(res, exp)
-            res = pd.Series([1, 2, 3], dtype=dtype) + np.nan
-            assert_series_equal(res, exp)
+        s = pd.Series([pd.Timedelta('1 days'), pd.Timedelta('2 days'),
+                       pd.Timedelta('3 days')], dtype=dtype)
+        exp = pd.Series([pd.Timedelta('4 days'), pd.Timedelta('5 days'),
+                         pd.Timedelta('6 days')])
+        assert_series_equal(pd.Timedelta('3 days') + s, exp)
+        assert_series_equal(s + pd.Timedelta('3 days'), exp)
 
-            s = pd.Series([pd.Timedelta('1 days'), pd.Timedelta('2 days'),
-                           pd.Timedelta('3 days')], dtype=dtype)
-            exp = pd.Series([pd.Timedelta('4 days'), pd.Timedelta('5 days'),
-                             pd.Timedelta('6 days')])
-            assert_series_equal(pd.Timedelta('3 days') + s, exp)
-            assert_series_equal(s + pd.Timedelta('3 days'), exp)
+    @pytest.mark.parametrize('data', [
+        [1, 2, 3],
+        [1.1, 2.2, 3.3],
+        [pd.Timestamp('2011-01-01'), pd.Timestamp('2011-01-02'), pd.NaT],
+        ['x', 'y', 1]])
+    @pytest.mark.parametrize('dtype', [None, object])
+    def test_series_radd_str_invalid(self, dtype, data):
+        ser = Series(data, dtype=dtype)
+        with pytest.raises(TypeError):
+            'foo_' + ser
 
-        s = pd.Series(['x', np.nan, 'x'])
-        assert_series_equal('a' + s, pd.Series(['ax', np.nan, 'ax']))
-        assert_series_equal(s + 'a', pd.Series(['xa', np.nan, 'xa']))
+    @pytest.mark.parametrize('data', [
+        [1, 2, 3],
+        [1.1, 2.2, 3.3],
+        [pd.Timestamp('2011-01-01'), pd.Timestamp('2011-01-02'), pd.NaT],
+        ['x', 'y', 1]])
+    @pytest.mark.parametrize('dtype', [None, object])
+    def test_frame_radd_str_invalid(self, dtype, data):
+        df = DataFrame(data, dtype=dtype)
+        with pytest.raises(TypeError):
+            'foo_' + df
 
-    def test_frame_radd_more(self):
-        data = [[1, 2, 3],
-                [1.1, 2.2, 3.3],
-                [pd.Timestamp('2011-01-01'), pd.Timestamp('2011-01-02'),
-                 pd.NaT],
-                ['x', 'y', 1]]
+    @pytest.mark.parametrize('dtype', [None, object])
+    def test_frame_radd_more(self, dtype):
+        res = 1 + pd.DataFrame([1, 2, 3], dtype=dtype)
+        exp = pd.DataFrame([2, 3, 4], dtype=dtype)
+        assert_frame_equal(res, exp)
+        res = pd.DataFrame([1, 2, 3], dtype=dtype) + 1
+        assert_frame_equal(res, exp)
 
-        for d in data:
-            for dtype in [None, object]:
-                s = DataFrame(d, dtype=dtype)
-                with pytest.raises(TypeError):
-                    'foo_' + s
+        res = np.nan + pd.DataFrame([1, 2, 3], dtype=dtype)
+        exp = pd.DataFrame([np.nan, np.nan, np.nan], dtype=dtype)
+        assert_frame_equal(res, exp)
+        res = pd.DataFrame([1, 2, 3], dtype=dtype) + np.nan
+        assert_frame_equal(res, exp)
 
-        for dtype in [None, object]:
-            res = 1 + pd.DataFrame([1, 2, 3], dtype=dtype)
-            exp = pd.DataFrame([2, 3, 4], dtype=dtype)
-            assert_frame_equal(res, exp)
-            res = pd.DataFrame([1, 2, 3], dtype=dtype) + 1
-            assert_frame_equal(res, exp)
-
-            res = np.nan + pd.DataFrame([1, 2, 3], dtype=dtype)
-            exp = pd.DataFrame([np.nan, np.nan, np.nan], dtype=dtype)
-            assert_frame_equal(res, exp)
-            res = pd.DataFrame([1, 2, 3], dtype=dtype) + np.nan
-            assert_frame_equal(res, exp)
-
+    def test_frame_radd_str(self):
         df = pd.DataFrame(['x', np.nan, 'x'])
         assert_frame_equal('a' + df, pd.DataFrame(['ax', np.nan, 'ax']))
         assert_frame_equal(df + 'a', pd.DataFrame(['xa', np.nan, 'xa']))


### PR DESCRIPTION
Remove ASV for Timestamp.offset since that attribute has been removed.

tests.indexes.datetimes.test_arithmetic has a giant offsets test that this splits up into reasonably sized pieces.
 - one piece of that test currently only runs if `klass is Series`, but that sub-test is now valid for DatetimeIndex too, so this PR removes that condition.
 - parametrize tests that currently iterate over a dictionary of inputs.
 - A mistaken-looking indentation in that iteration ATM prevents a bunch of cases from running.  This PR fixes that.

- [ ] closes #xxxx
- [ ] tests added / passed
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
