### PR TITLE
CLN: ASV timedelta

### DIFF
--- a/asv_bench/benchmarks/timedelta.py
+++ b/asv_bench/benchmarks/timedelta.py
@@ -1,12 +1,11 @@
 import datetime
 
 import numpy as np
-import pandas as pd
-
-from pandas import to_timedelta, Timestamp, Timedelta
+from pandas import Series, timedelta_range, to_timedelta, Timestamp, Timedelta
 
 
 class TimedeltaConstructor(object):
+
     goal_time = 0.2
 
     def time_from_int(self):
@@ -36,35 +35,44 @@ class TimedeltaConstructor(object):
 
 
 class ToTimedelta(object):
+
     goal_time = 0.2
 
     def setup(self):
-        self.arr = np.random.randint(0, 1000, size=10000)
-        self.arr2 = ['{0} days'.format(i) for i in self.arr]
-
-        self.arr3 = np.random.randint(0, 60, size=10000)
-        self.arr3 = ['00:00:{0:02d}'.format(i) for i in self.arr3]
-
-        self.arr4 = list(self.arr2)
-        self.arr4[-1] = 'apple'
+        self.ints = np.random.randint(0, 60, size=10000)
+        self.str_days = []
+        self.str_seconds = []
+        for i in self.ints:
+            self.str_days.append('{0} days'.format(i))
+            self.str_seconds.append('00:00:{0:02d}'.format(i))
 
     def time_convert_int(self):
-        to_timedelta(self.arr, unit='s')
+        to_timedelta(self.ints, unit='s')
 
-    def time_convert_string(self):
-        to_timedelta(self.arr2)
+    def time_convert_string_days(self):
+        to_timedelta(self.str_days)
 
     def time_convert_string_seconds(self):
-        to_timedelta(self.arr3)
+        to_timedelta(self.str_seconds)
 
-    def time_convert_coerce(self):
-        to_timedelta(self.arr4, errors='coerce')
 
-    def time_convert_ignore(self):
-        to_timedelta(self.arr4, errors='ignore')
+class ToTimedeltaErrors(object):
+
+    goal_time = 0.2
+    params = ['coerce', 'ignore']
+    param_names = ['errors']
+
+    def setup(self, errors):
+        ints = np.random.randint(0, 60, size=10000)
+        self.arr = ['{0} days'.format(i) for i in ints]
+        self.arr[-1] = 'apple'
+
+    def time_convert(self, errors):
+        to_timedelta(self.arr, errors=errors)
 
 
 class TimedeltaOps(object):
+
     goal_time = 0.2
 
     def setup(self):
@@ -76,43 +84,46 @@ class TimedeltaOps(object):
 
 
 class TimedeltaProperties(object):
+
     goal_time = 0.2
 
-    def setup(self):
-        self.td = Timedelta(days=365, minutes=35, seconds=25, milliseconds=35)
+    def setup_cache(self):
+        td = Timedelta(days=365, minutes=35, seconds=25, milliseconds=35)
+        return td
 
-    def time_timedelta_days(self):
-        self.td.days
+    def time_timedelta_days(self, td):
+        td.days
 
-    def time_timedelta_seconds(self):
-        self.td.seconds
+    def time_timedelta_seconds(self, td):
+        td.seconds
 
-    def time_timedelta_microseconds(self):
-        self.td.microseconds
+    def time_timedelta_microseconds(self, td):
+        td.microseconds
 
-    def time_timedelta_nanoseconds(self):
-        self.td.nanoseconds
+    def time_timedelta_nanoseconds(self, td):
+        td.nanoseconds
 
 
 class DatetimeAccessor(object):
+
     goal_time = 0.2
 
-    def setup(self):
-        self.N = 100000
-        self.series = pd.Series(
-            pd.timedelta_range('1 days', periods=self.N, freq='h'))
+    def setup_cache(self):
+        N = 100000
+        series = Series(timedelta_range('1 days', periods=N, freq='h'))
+        return series
 
-    def time_dt_accessor(self):
-        self.series.dt
+    def time_dt_accessor(self, series):
+        series.dt
 
-    def time_timedelta_dt_accessor_days(self):
-        self.series.dt.days
+    def time_timedelta_days(self, series):
+        series.dt.days
 
-    def time_timedelta_dt_accessor_seconds(self):
-        self.series.dt.seconds
+    def time_timedelta_seconds(self, series):
+        series.dt.seconds
 
-    def time_timedelta_dt_accessor_microseconds(self):
-        self.series.dt.microseconds
+    def time_timedelta_microseconds(self, series):
+        series.dt.microseconds
 
-    def time_timedelta_dt_accessor_nanoseconds(self):
-        self.series.dt.nanoseconds
+    def time_timedelta_nanoseconds(self, series):
+        series.dt.nanoseconds


### PR DESCRIPTION
Cleaned up some setups and used `setup_cache` where applicable. Although the `time_from_iso_format` benchmark failed here, it looks like it passed in #19065. 

```
[  0.00%] ··· Setting up /home/matt/Projects/pandas-mroeschke/asv_bench/benchmarks/timedelta.py:111
[  4.55%] ··· Running timedelta.DatetimeAccessor.time_dt_accessor        99.1μs
[  9.09%] ··· Running timedelta.DatetimeAccessor.time_timedelta_days      2.17s
[ 13.64%] ··· Running ...atetimeAccessor.time_timedelta_microseconds      2.15s
[ 18.18%] ··· Running ...DatetimeAccessor.time_timedelta_nanoseconds      2.14s
[ 22.73%] ··· Running ...lta.DatetimeAccessor.time_timedelta_seconds      2.16s
[ 22.73%] ··· Setting up /home/matt/Projects/pandas-mroeschke/asv_bench/benchmarks/timedelta.py:90
[ 27.27%] ··· Running ...lta.TimedeltaProperties.time_timedelta_days     10.2μs
[ 31.82%] ··· Running ...deltaProperties.time_timedelta_microseconds     10.2μs
[ 36.36%] ··· Running ...edeltaProperties.time_timedelta_nanoseconds     9.99μs
[ 40.91%] ··· Running ....TimedeltaProperties.time_timedelta_seconds     11.3μs
[ 45.45%] ··· Running ...a.TimedeltaConstructor.time_from_components     63.7μs
[ 50.00%] ··· Running ...ltaConstructor.time_from_datetime_timedelta     34.9μs
[ 54.55%] ··· Running timedelta.TimedeltaConstructor.time_from_int       32.7μs
[ 59.09%] ··· Running ...a.TimedeltaConstructor.time_from_iso_format     failed
[ 59.09%] ····· Traceback (most recent call last):
                  File "/home/matt/anaconda/envs/pandas_dev/lib/python2.7/site-packages/asv/benchmark.py", line 818, in <module>
                    commands[mode](args)
                  File "/home/matt/anaconda/envs/pandas_dev/lib/python2.7/site-packages/asv/benchmark.py", line 795, in main_run
                    result = benchmark.do_run()
                  File "/home/matt/anaconda/envs/pandas_dev/lib/python2.7/site-packages/asv/benchmark.py", line 349, in do_run
                    return self.run(*self._current_params)
                  File "/home/matt/anaconda/envs/pandas_dev/lib/python2.7/site-packages/asv/benchmark.py", line 424, in run
                    samples, number = self.benchmark_timing(timer, repeat, warmup_time, number=number)
                  File "/home/matt/anaconda/envs/pandas_dev/lib/python2.7/site-packages/asv/benchmark.py", line 471, in benchmark_timing
                    timing = timer.timeit(number)
                  File "/home/matt/anaconda/envs/pandas_dev/lib/python2.7/timeit.py", line 202, in timeit
                    timing = self.inner(it, self.timer)
                  File "/home/matt/anaconda/envs/pandas_dev/lib/python2.7/timeit.py", line 100, in inner
                    _func()
                  File "/home/matt/Projects/pandas-mroeschke/asv_bench/benchmarks/timedelta.py", line 31, in time_from_iso_format
                    Timedelta('P4DT12H30M5S')
                  File "pandas/_libs/tslib.pyx", line 2588, in pandas._libs.tslib.Timedelta.__new__
                  File "pandas/_libs/tslibs/timedeltas.pyx", line 159, in pandas._libs.tslibs.timedeltas.parse_timedelta_string
                  File "pandas/_libs/tslibs/timedeltas.pyx", line 296, in pandas._libs.tslibs.timedeltas.timedelta_from_spec
                ValueError: invalid abbreviation: P

[ 63.64%] ··· Running ...elta.TimedeltaConstructor.time_from_missing     19.2μs
[ 68.18%] ··· Running ...TimedeltaConstructor.time_from_np_timedelta     31.3μs
[ 72.73%] ··· Running ...delta.TimedeltaConstructor.time_from_string     42.1μs
[ 77.27%] ··· Running timedelta.TimedeltaConstructor.time_from_unit      40.0μs
[ 81.82%] ··· Running timedelta.TimedeltaOps.time_add_td_ts              26.3ms
[ 86.36%] ··· Running timedelta.ToTimedelta.time_convert_int              545μs
[ 90.91%] ··· Running timedelta.ToTimedelta.time_convert_string_days      152ms
[ 95.45%] ··· Running ...lta.ToTimedelta.time_convert_string_seconds      146ms
[100.00%] ··· Running timedelta.ToTimedeltaErrors.time_convert               ok
[100.00%] ···· 
               ======== =======
                errors         
               -------- -------
                coerce   401ms 
                ignore   394ms 
               ======== =======
```

  