### PR TITLE
No SettingWithCopyWarning on groupby results

### DIFF
--- a/doc/source/whatsnew/v0.23.0.txt
+++ b/doc/source/whatsnew/v0.23.0.txt
@@ -425,6 +425,7 @@ Groupby/Resample/Rolling
 
 - Bug when grouping by a single column and aggregating with a class like ``list`` or ``tuple`` (:issue:`18079`)
 - Fixed regression in :func:`DataFrame.groupby` which would not emit an error when called with a tuple key not in the index (:issue:`18798`)
+- Modifying a group dataframe while generating ``groupby`` results does not trigger a ``SettingWithCopyWarning`` (:issue:`19151`)
 -
 -
 

--- a/pandas/core/groupby.py
+++ b/pandas/core/groupby.py
@@ -4722,7 +4722,9 @@ class DataSplitter(object):
             # if start >= end:
             #     raise AssertionError('Start %s must be less than end %s'
             #                          % (str(start), str(end)))
-            yield i, self._chop(sdata, slice(start, end))
+            group_data = self._chop(sdata, slice(start, end))
+            group_data._is_copy = None
+            yield i, group_data
 
     def _get_sorted_data(self):
         return self.data._take(self.sort_idx, axis=self.axis, convert=False)

--- a/pandas/tests/groupby/test_groupby.py
+++ b/pandas/tests/groupby/test_groupby.py
@@ -2758,6 +2758,12 @@ class TestGroupBy(MixIn):
         with tm.assert_raises_regex(KeyError, "(7, 8)"):
             df.groupby((7, 8)).mean()
 
+    def test_no_setting_with_copy_warning(self):
+        df = pd.DataFrame({'x': range(4), 'c': list('aabb')})
+        for _, gdf in df.groupby('c'):
+            with tm.assert_produces_warning(None):
+                gdf['x'] = 1
+
 
 def _check_groupby(df, result, keys, field, f=lambda x: x.sum()):
     tups = lmap(tuple, df[keys].values)


### PR DESCRIPTION
The dataframe referred to in the warning is a result of an
internal slicing operation and should not lead to a warning
in userspace.

- [x] closes #19151
- [ ] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry
