### PR TITLE
CLN: ASV Timestamp

### DIFF
--- a/asv_bench/benchmarks/timestamp.py
+++ b/asv_bench/benchmarks/timestamp.py
@@ -1,10 +1,10 @@
+import datetime
+
 from pandas import Timestamp
 import pytz
-import datetime
 
 
 class TimestampConstruction(object):
-    # TODO: classmethod constructors: fromordinal, fromtimestamp...
 
     def time_parse_iso8601_no_tz(self):
         Timestamp('2017-08-25 08:16:14')
@@ -20,6 +20,12 @@ class TimestampConstruction(object):
 
     def time_parse_now(self):
         Timestamp('now')
+
+    def time_fromordinal(self):
+        Timestamp.fromordinal(730120)
+
+    def time_fromtimestamp(self):
+        Timestamp.fromtimestamp(1515448538)
 
 
 class TimestampProperties(object):


### PR DESCRIPTION
Just rearranged the import order and added some contructor benchmarks in a TODO comment:

```
[  0.00%] ·· Building for existing-py_home_matt_anaconda_envs_pandas_dev_bin_python
[  0.00%] ·· Benchmarking existing-py_home_matt_anaconda_envs_pandas_dev_bin_python
[  3.57%] ··· Running ....TimestampAcrossDst.time_replace_across_dst     37.5μs
[  7.14%] ··· Running ...tamp.TimestampConstruction.time_fromordinal     15.5μs
[ 10.71%] ··· Running ...mp.TimestampConstruction.time_fromtimestamp     21.4μs
[ 14.29%] ··· Running ...p.TimestampConstruction.time_parse_dateutil      428μs
[ 17.86%] ··· Running ...estampConstruction.time_parse_iso8601_no_tz     14.4μs
[ 21.43%] ··· Running ...TimestampConstruction.time_parse_iso8601_tz     51.2μs
[ 25.00%] ··· Running timestamp.TimestampConstruction.time_parse_now     22.3μs
[ 28.57%] ··· Running ...tamp.TimestampConstruction.time_parse_today     22.4μs
[ 32.14%] ··· Running timestamp.TimestampOps.time_replace_None               ok
[ 32.14%] ···· 
               ============ ========
                    tz              
               ------------ --------
                   None      18.1μs 
                US/Eastern   37.9μs 
               ============ ========

[ 35.71%] ··· Running timestamp.TimestampOps.time_replace_tz                 ok
[ 35.71%] ···· 
               ============ ========
                    tz              
               ------------ --------
                   None      45.6μs 
                US/Eastern   70.2μs 
               ============ ========

[ 39.29%] ··· Running timestamp.TimestampOps.time_to_pydatetime              ok
[ 39.29%] ···· 
               ============ ========
                    tz              
               ------------ --------
                   None      12.2μs 
                US/Eastern   13.7μs 
               ============ ========

[ 42.86%] ··· Running timestamp.TimestampProperties.time_dayofweek           ok
[ 42.86%] ···· 
               ================================================ ====== ========
                                      tz                         freq          
               ------------------------------------------------ ------ --------
                                     None                        None   9.95μs 
                                     None                         B     11.6μs 
                <DstTzInfo 'Europe/Amsterdam' LMT+0:20:00 STD>   None   9.91μs 
                <DstTzInfo 'Europe/Amsterdam' LMT+0:20:00 STD>    B     11.3μs 
               ================================================ ====== ========

[ 46.43%] ··· Running timestamp.TimestampProperties.time_dayofyear           ok
[ 46.43%] ···· 
               ================================================ ====== ========
                                      tz                         freq          
               ------------------------------------------------ ------ --------
                                     None                        None   40.3μs 
                                     None                         B     45.4μs 
                <DstTzInfo 'Europe/Amsterdam' LMT+0:20:00 STD>   None   40.3μs 
                <DstTzInfo 'Europe/Amsterdam' LMT+0:20:00 STD>    B     44.1μs 
               ================================================ ====== ========

[ 50.00%] ··· Running ...tamp.TimestampProperties.time_days_in_month         ok
[ 50.00%] ···· 
               ================================================ ====== ========
                                      tz                         freq          
               ------------------------------------------------ ------ --------
                                     None                        None   40.3μs 
                                     None                         B     44.1μs 
                <DstTzInfo 'Europe/Amsterdam' LMT+0:20:00 STD>   None   40.8μs 
                <DstTzInfo 'Europe/Amsterdam' LMT+0:20:00 STD>    B     44.5μs 
               ================================================ ====== ========

[ 53.57%] ··· Running timestamp.TimestampProperties.time_freqstr             ok
[ 53.57%] ···· 
               ================================================ ====== ========
                                      tz                         freq          
               ------------------------------------------------ ------ --------
                                     None                        None   11.0μs 
                                     None                         B     13.3μs 
                <DstTzInfo 'Europe/Amsterdam' LMT+0:20:00 STD>   None   11.5μs 
                <DstTzInfo 'Europe/Amsterdam' LMT+0:20:00 STD>    B     13.0μs 
               ================================================ ====== ========

[ 57.14%] ··· Running ...stamp.TimestampProperties.time_is_leap_year         ok
[ 57.14%] ···· 
               ================================================ ====== ========
                                      tz                         freq          
               ------------------------------------------------ ------ --------
                                     None                        None   42.7μs 
                                     None                         B     52.1μs 
                <DstTzInfo 'Europe/Amsterdam' LMT+0:20:00 STD>   None   43.0μs 
                <DstTzInfo 'Europe/Amsterdam' LMT+0:20:00 STD>    B     50.8μs 
               ================================================ ====== ========

[ 60.71%] ··· Running ...stamp.TimestampProperties.time_is_month_end         ok
[ 60.71%] ···· 
               ================================================ ====== ========
                                      tz                         freq          
               ------------------------------------------------ ------ --------
                                     None                        None   42.1μs 
                                     None                         B     51.6μs 
                <DstTzInfo 'Europe/Amsterdam' LMT+0:20:00 STD>   None   43.1μs 
                <DstTzInfo 'Europe/Amsterdam' LMT+0:20:00 STD>    B     49.7μs 
               ================================================ ====== ========

[ 64.29%] ··· Running ...amp.TimestampProperties.time_is_month_start         ok
[ 64.29%] ···· 
               ================================================ ====== ========
                                      tz                         freq          
               ------------------------------------------------ ------ --------
                                     None                        None   42.5μs 
                                     None                         B     51.6μs 
                <DstTzInfo 'Europe/Amsterdam' LMT+0:20:00 STD>   None   42.4μs 
                <DstTzInfo 'Europe/Amsterdam' LMT+0:20:00 STD>    B     50.4μs 
               ================================================ ====== ========

[ 67.86%] ··· Running ...amp.TimestampProperties.time_is_quarter_end         ok
[ 67.86%] ···· 
               ================================================ ====== ========
                                      tz                         freq          
               ------------------------------------------------ ------ --------
                                     None                        None   43.1μs 
                                     None                         B     49.0μs 
                <DstTzInfo 'Europe/Amsterdam' LMT+0:20:00 STD>   None   42.9μs 
                <DstTzInfo 'Europe/Amsterdam' LMT+0:20:00 STD>    B     50.8μs 
               ================================================ ====== ========

[ 71.43%] ··· Running ...p.TimestampProperties.time_is_quarter_start         ok
[ 71.43%] ···· 
               ================================================ ====== ========
                                      tz                         freq          
               ------------------------------------------------ ------ --------
                                     None                        None   42.5μs 
                                     None                         B     50.5μs 
                <DstTzInfo 'Europe/Amsterdam' LMT+0:20:00 STD>   None   43.1μs 
                <DstTzInfo 'Europe/Amsterdam' LMT+0:20:00 STD>    B     50.0μs 
               ================================================ ====== ========

[ 75.00%] ··· Running timestamp.TimestampProperties.time_is_year_end         ok
[ 75.00%] ···· 
               ================================================ ====== ========
                                      tz                         freq          
               ------------------------------------------------ ------ --------
                                     None                        None   43.1μs 
                                     None                         B     50.8μs 
                <DstTzInfo 'Europe/Amsterdam' LMT+0:20:00 STD>   None   42.2μs 
                <DstTzInfo 'Europe/Amsterdam' LMT+0:20:00 STD>    B     51.9μs 
               ================================================ ====== ========

[ 78.57%] ··· Running ...tamp.TimestampProperties.time_is_year_start         ok
[ 78.57%] ···· 
               ================================================ ====== ========
                                      tz                         freq          
               ------------------------------------------------ ------ --------
                                     None                        None   43.0μs 
                                     None                         B     51.0μs 
                <DstTzInfo 'Europe/Amsterdam' LMT+0:20:00 STD>   None   42.5μs 
                <DstTzInfo 'Europe/Amsterdam' LMT+0:20:00 STD>    B     51.6μs 
               ================================================ ====== ========

[ 82.14%] ··· Running timestamp.TimestampProperties.time_microsecond         ok
[ 82.14%] ···· 
               ================================================ ====== ========
                                      tz                         freq          
               ------------------------------------------------ ------ --------
                                     None                        None   8.91μs 
                                     None                         B     9.93μs 
                <DstTzInfo 'Europe/Amsterdam' LMT+0:20:00 STD>   None   8.64μs 
                <DstTzInfo 'Europe/Amsterdam' LMT+0:20:00 STD>    B     9.49μs 
               ================================================ ====== ========

[ 85.71%] ··· Running timestamp.TimestampProperties.time_offset              ok
[ 85.71%] ···· 
               ================================================ ====== ========
                                      tz                         freq          
               ------------------------------------------------ ------ --------
                                     None                        None   14.9μs 
                                     None                         B     15.8μs 
                <DstTzInfo 'Europe/Amsterdam' LMT+0:20:00 STD>   None   14.5μs 
                <DstTzInfo 'Europe/Amsterdam' LMT+0:20:00 STD>    B     16.2μs 
               ================================================ ====== ========

[ 85.71%] ····· 
                
                For parameters: None, None
                /home/matt/Projects/pandas-mroeschke/asv_bench/benchmarks/timestamp.py:46: FutureWarning: .offset is deprecated. Use .freq instead
                  self.ts.offset
                
                For parameters: None, 'B'
                /home/matt/Projects/pandas-mroeschke/asv_bench/benchmarks/timestamp.py:46: FutureWarning: .offset is deprecated. Use .freq instead
                  self.ts.offset
                
                For parameters: <DstTzInfo 'Europe/Amsterdam' LMT+0:20:00 STD>, None
                /home/matt/Projects/pandas-mroeschke/asv_bench/benchmarks/timestamp.py:46: FutureWarning: .offset is deprecated. Use .freq instead
                  self.ts.offset
                
                For parameters: <DstTzInfo 'Europe/Amsterdam' LMT+0:20:00 STD>, 'B'
                /home/matt/Projects/pandas-mroeschke/asv_bench/benchmarks/timestamp.py:46: FutureWarning: .offset is deprecated. Use .freq instead
                  self.ts.offset

[ 89.29%] ··· Running timestamp.TimestampProperties.time_quarter             ok
[ 89.29%] ···· 
               ================================================ ====== ========
                                      tz                         freq          
               ------------------------------------------------ ------ --------
                                     None                        None   40.5μs 
                                     None                         B     44.8μs 
                <DstTzInfo 'Europe/Amsterdam' LMT+0:20:00 STD>   None   40.5μs 
                <DstTzInfo 'Europe/Amsterdam' LMT+0:20:00 STD>    B     52.4μs 
               ================================================ ====== ========

[ 92.86%] ··· Running timestamp.TimestampProperties.time_tz                  ok
[ 92.86%] ···· 
               ================================================ ====== ========
                                      tz                         freq          
               ------------------------------------------------ ------ --------
                                     None                        None   9.82μs 
                                     None                         B     10.5μs 
                <DstTzInfo 'Europe/Amsterdam' LMT+0:20:00 STD>   None   9.78μs 
                <DstTzInfo 'Europe/Amsterdam' LMT+0:20:00 STD>    B     10.5μs 
               ================================================ ====== ========

[ 96.43%] ··· Running timestamp.TimestampProperties.time_week                ok
[ 96.43%] ···· 
               ================================================ ====== ========
                                      tz                         freq          
               ------------------------------------------------ ------ --------
                                     None                        None   40.9μs 
                                     None                         B     44.0μs 
                <DstTzInfo 'Europe/Amsterdam' LMT+0:20:00 STD>   None   39.4μs 
                <DstTzInfo 'Europe/Amsterdam' LMT+0:20:00 STD>    B     45.1μs 
               ================================================ ====== ========

[100.00%] ··· Running ...stamp.TimestampProperties.time_weekday_name         ok
[100.00%] ···· 
               ================================================ ====== ========
                                      tz                         freq          
               ------------------------------------------------ ------ --------
                                     None                        None   11.7μs 
                                     None                         B     13.8μs 
                <DstTzInfo 'Europe/Amsterdam' LMT+0:20:00 STD>   None   11.9μs 
                <DstTzInfo 'Europe/Amsterdam' LMT+0:20:00 STD>    B     13.5μs 
               ================================================ ====== ========
```