### PR TITLE
Parametrize tests for Series[timedelta64] integer arithmetic

### DIFF
--- a/pandas/tests/series/test_operators.py
+++ b/pandas/tests/series/test_operators.py
@@ -835,17 +835,20 @@ class TestTimedeltaSeriesArithmeticWithIntegers(object):
 
 
 class TestTimedeltaSeriesArithmetic(object):
-    def test_timedelta_series_ops(self):
+    def test_td64series_add_sub_timestamp(self):
         # GH11925
-        s = Series(timedelta_range('1 day', periods=3))
+        tdser = Series(timedelta_range('1 day', periods=3))
         ts = Timestamp('2012-01-01')
         expected = Series(date_range('2012-01-02', periods=3))
-        assert_series_equal(ts + s, expected)
-        assert_series_equal(s + ts, expected)
+        assert_series_equal(ts + tdser, expected)
+        assert_series_equal(tdser + ts, expected)
 
         expected2 = Series(date_range('2011-12-31', periods=3, freq='-1D'))
-        assert_series_equal(ts - s, expected2)
-        assert_series_equal(ts + (-s), expected2)
+        assert_series_equal(ts - tdser, expected2)
+        assert_series_equal(ts + (-tdser), expected2)
+
+        with pytest.raises(TypeError):
+            tdser - ts
 
     def test_timedelta64_operations_with_DateOffset(self):
         # GH 10699

--- a/pandas/tests/series/test_operators.py
+++ b/pandas/tests/series/test_operators.py
@@ -730,31 +730,25 @@ class TestTimedeltaSeriesArithmeticWithIntegers(object):
     # ------------------------------------------------------------------
     # Multiplicaton and Division
 
-    def test_timedelta64_operations_with_integers(self):
+    @pytest.mark.parametrize('dtype', ['int64', 'int32', 'int16',
+                                       'uint64', 'uint32', 'uint16', 'uint8',
+                                       'float64', 'float32', 'float16'])
+    @pytest.mark.parametrize('vector', [np.array([20, 30, 40]),
+                                        pd.Index([20, 30, 40]),
+                                        Series([20, 30, 40])])
+    def test_td64series_div_numeric_array(self, vector, dtype):
         # GH 4521
         # divide/multiply by integers
-        s1 = self.tdser
-        s2 = self.intser
-        expected = Series(['29.5D', '19D 16H', 'NaT'], dtype='timedelta64[ns]')
-        result = s1 / s2
-        assert_series_equal(result, expected)
-
+        tdser = self.tdser
+        vector = vector.astype(dtype)
         expected = Series(['2.95D', '1D 23H 12m', 'NaT'],
                           dtype='timedelta64[ns]')
-        result = s1 / Series([20, 30, 40])
-        assert_series_equal(result, expected)
-        result = s1 / Series([20, 30, 40]).astype(float)
+
+        result = tdser / vector
         assert_series_equal(result, expected)
 
-        expected = Series(['1180 Days', '1770 Days', 'NaT'],
-                          dtype='timedelta64[ns]')
-        result = s1 * Series([20, 30, 40])
-        assert_series_equal(result, expected)
-
-        for dtype in ['int32', 'int16', 'uint32', 'uint64', 'uint32', 'uint16',
-                      'uint8']:
-            result = s1 * Series([20, 30, 40], dtype=dtype)
-            assert_series_equal(result, expected)
+        with pytest.raises(TypeError):
+            vector / tdser
 
     @pytest.mark.parametrize('dtype', ['int64', 'int32', 'int16',
                                        'uint64', 'uint32', 'uint16', 'uint8',

--- a/pandas/tests/series/test_operators.py
+++ b/pandas/tests/series/test_operators.py
@@ -668,43 +668,45 @@ class TestSeriesArithmetic(object):
 
 
 class TestTimedeltaSeriesArithmeticWithIntegers(object):
-    @classmethod
-    def setup_class(cls):
-        cls.tdser = Series(['59 Days', '59 Days', 'NaT'],
-                           dtype='timedelta64[ns]')
-        cls.intser = Series([2, 3, 4])
+    # Tests for Series with dtype 'timedelta64[ns]' arithmetic operations
+    # with integer and int-like others
 
     # ------------------------------------------------------------------
     # Addition and Subtraction
 
     def test_td64series_add_int_series_invalid(self):
+        tdser = Series(['59 Days', '59 Days', 'NaT'], dtype='timedelta64[ns]')
         with pytest.raises(TypeError):
-            self.tdser + self.intser
+            tdser + Series([2, 3, 4])
 
     @pytest.mark.xfail(reason='GH#19123 integer interpreted as nanoseconds')
     def test_td64series_radd_int_series_invalid(self):
+        tdser = Series(['59 Days', '59 Days', 'NaT'], dtype='timedelta64[ns]')
         with pytest.raises(TypeError):
-            self.intser + self.tdser
+            Series([2, 3, 4]) + tdser
 
     def test_td64series_sub_int_series_invalid(self):
+        tdser = Series(['59 Days', '59 Days', 'NaT'], dtype='timedelta64[ns]')
         with pytest.raises(TypeError):
-            self.tdser - self.intser
+            tdser - Series([2, 3, 4])
 
     @pytest.mark.xfail(reason='GH#19123 integer interpreted as nanoseconds')
     def test_td64series_rsub_int_series_invalid(self):
+        tdser = Series(['59 Days', '59 Days', 'NaT'], dtype='timedelta64[ns]')
         with pytest.raises(TypeError):
-            self.intser - self.tdser
+            Series([2, 3, 4]) - tdser
 
     @pytest.mark.parametrize('scalar', [1, 1.5, np.array(2)])
     def test_td64series_add_sub_numeric_scalar_invalid(self, scalar):
+        tdser = Series(['59 Days', '59 Days', 'NaT'], dtype='timedelta64[ns]')
         with pytest.raises(TypeError):
-            self.tdser + scalar
+            tdser + scalar
         with pytest.raises(TypeError):
-            scalar + self.tdser
+            scalar + tdser
         with pytest.raises(TypeError):
-            self.tdser - scalar
+            tdser - scalar
         with pytest.raises(TypeError):
-            scalar - self.tdser
+            scalar - tdser
 
     @pytest.mark.parametrize('dtype', ['int64', 'int32', 'int16',
                                        'uint64', 'uint32', 'uint16', 'uint8',
@@ -717,15 +719,16 @@ class TestTimedeltaSeriesArithmeticWithIntegers(object):
                                                     'interpreted as nanos'))
     ])
     def test_td64series_add_sub_numeric_array_invalid(self, vector, dtype):
+        tdser = Series(['59 Days', '59 Days', 'NaT'], dtype='timedelta64[ns]')
         vector = vector.astype(dtype)
         with pytest.raises(TypeError):
-            self.tdser + vector
+            tdser + vector
         with pytest.raises(TypeError):
-            vector + self.tdser
+            vector + tdser
         with pytest.raises(TypeError):
-            self.tdser - vector
+            tdser - vector
         with pytest.raises(TypeError):
-            vector - self.tdser
+            vector - tdser
 
     # ------------------------------------------------------------------
     # Multiplicaton and Division
@@ -739,7 +742,7 @@ class TestTimedeltaSeriesArithmeticWithIntegers(object):
     def test_td64series_div_numeric_array(self, vector, dtype):
         # GH 4521
         # divide/multiply by integers
-        tdser = self.tdser
+        tdser = Series(['59 Days', '59 Days', 'NaT'], dtype='timedelta64[ns]')
         vector = vector.astype(dtype)
         expected = Series(['2.95D', '1D 23H 12m', 'NaT'],
                           dtype='timedelta64[ns]')
@@ -759,7 +762,7 @@ class TestTimedeltaSeriesArithmeticWithIntegers(object):
     def test_td64series_mul_numeric_array(self, vector, dtype):
         # GH 4521
         # divide/multiply by integers
-        tdser = self.tdser
+        tdser = Series(['59 Days', '59 Days', 'NaT'], dtype='timedelta64[ns]')
         vector = vector.astype(dtype)
 
         expected = Series(['1180 Days', '1770 Days', 'NaT'],
@@ -782,7 +785,7 @@ class TestTimedeltaSeriesArithmeticWithIntegers(object):
     def test_td64series_rmul_numeric_array(self, vector, dtype):
         # GH 4521
         # divide/multiply by integers
-        tdser = self.tdser
+        tdser = Series(['59 Days', '59 Days', 'NaT'], dtype='timedelta64[ns]')
         vector = vector.astype(dtype)
 
         expected = Series(['1180 Days', '1770 Days', 'NaT'],
@@ -795,7 +798,7 @@ class TestTimedeltaSeriesArithmeticWithIntegers(object):
     def test_td64series_mul_numeric_scalar(self, one):
         # GH 4521
         # divide/multiply by integers
-        tdser = self.tdser
+        tdser = Series(['59 Days', '59 Days', 'NaT'], dtype='timedelta64[ns]')
         expected = Series(['-59 Days', '-59 Days', 'NaT'],
                           dtype='timedelta64[ns]')
 
@@ -824,7 +827,7 @@ class TestTimedeltaSeriesArithmeticWithIntegers(object):
     def test_td64series_div_numeric_scalar(self, two):
         # GH 4521
         # divide/multiply by integers
-        tdser = self.tdser
+        tdser = Series(['59 Days', '59 Days', 'NaT'], dtype='timedelta64[ns]')
         expected = Series(['29.5D', '29.5D', 'NaT'], dtype='timedelta64[ns]')
 
         result = tdser / two

--- a/pandas/tests/series/test_operators.py
+++ b/pandas/tests/series/test_operators.py
@@ -28,6 +28,11 @@ import pandas.util.testing as tm
 from .common import TestData
 
 
+@pytest.fixture
+def tdser():
+    return Series(['59 Days', '59 Days', 'NaT'], dtype='timedelta64[ns]')
+
+
 class TestSeriesComparisons(object):
     def test_series_comparison_scalars(self):
         series = Series(date_range('1/1/2000', periods=10))
@@ -674,31 +679,26 @@ class TestTimedeltaSeriesArithmeticWithIntegers(object):
     # ------------------------------------------------------------------
     # Addition and Subtraction
 
-    def test_td64series_add_int_series_invalid(self):
-        tdser = Series(['59 Days', '59 Days', 'NaT'], dtype='timedelta64[ns]')
+    def test_td64series_add_int_series_invalid(self, tdser):
         with pytest.raises(TypeError):
             tdser + Series([2, 3, 4])
 
     @pytest.mark.xfail(reason='GH#19123 integer interpreted as nanoseconds')
-    def test_td64series_radd_int_series_invalid(self):
-        tdser = Series(['59 Days', '59 Days', 'NaT'], dtype='timedelta64[ns]')
+    def test_td64series_radd_int_series_invalid(self, tdser):
         with pytest.raises(TypeError):
             Series([2, 3, 4]) + tdser
 
-    def test_td64series_sub_int_series_invalid(self):
-        tdser = Series(['59 Days', '59 Days', 'NaT'], dtype='timedelta64[ns]')
+    def test_td64series_sub_int_series_invalid(self, tdser):
         with pytest.raises(TypeError):
             tdser - Series([2, 3, 4])
 
     @pytest.mark.xfail(reason='GH#19123 integer interpreted as nanoseconds')
-    def test_td64series_rsub_int_series_invalid(self):
-        tdser = Series(['59 Days', '59 Days', 'NaT'], dtype='timedelta64[ns]')
+    def test_td64series_rsub_int_series_invalid(self, tdser):
         with pytest.raises(TypeError):
             Series([2, 3, 4]) - tdser
 
     @pytest.mark.parametrize('scalar', [1, 1.5, np.array(2)])
-    def test_td64series_add_sub_numeric_scalar_invalid(self, scalar):
-        tdser = Series(['59 Days', '59 Days', 'NaT'], dtype='timedelta64[ns]')
+    def test_td64series_add_sub_numeric_scalar_invalid(self, scalar, tdser):
         with pytest.raises(TypeError):
             tdser + scalar
         with pytest.raises(TypeError):
@@ -718,8 +718,8 @@ class TestTimedeltaSeriesArithmeticWithIntegers(object):
                      marks=pytest.mark.xfail(reason='GH#19123 integer '
                                                     'interpreted as nanos'))
     ])
-    def test_td64series_add_sub_numeric_array_invalid(self, vector, dtype):
-        tdser = Series(['59 Days', '59 Days', 'NaT'], dtype='timedelta64[ns]')
+    def test_td64series_add_sub_numeric_array_invalid(self, vector,
+                                                      dtype, tdser):
         vector = vector.astype(dtype)
         with pytest.raises(TypeError):
             tdser + vector
@@ -739,10 +739,9 @@ class TestTimedeltaSeriesArithmeticWithIntegers(object):
     @pytest.mark.parametrize('vector', [np.array([20, 30, 40]),
                                         pd.Index([20, 30, 40]),
                                         Series([20, 30, 40])])
-    def test_td64series_div_numeric_array(self, vector, dtype):
+    def test_td64series_div_numeric_array(self, vector, dtype, tdser):
         # GH 4521
         # divide/multiply by integers
-        tdser = Series(['59 Days', '59 Days', 'NaT'], dtype='timedelta64[ns]')
         vector = vector.astype(dtype)
         expected = Series(['2.95D', '1D 23H 12m', 'NaT'],
                           dtype='timedelta64[ns]')
@@ -759,10 +758,9 @@ class TestTimedeltaSeriesArithmeticWithIntegers(object):
     @pytest.mark.parametrize('vector', [np.array([20, 30, 40]),
                                         pd.Index([20, 30, 40]),
                                         Series([20, 30, 40])])
-    def test_td64series_mul_numeric_array(self, vector, dtype):
+    def test_td64series_mul_numeric_array(self, vector, dtype, tdser):
         # GH 4521
         # divide/multiply by integers
-        tdser = Series(['59 Days', '59 Days', 'NaT'], dtype='timedelta64[ns]')
         vector = vector.astype(dtype)
 
         expected = Series(['1180 Days', '1770 Days', 'NaT'],
@@ -782,10 +780,9 @@ class TestTimedeltaSeriesArithmeticWithIntegers(object):
                                                     'NotImplemented')),
         Series([20, 30, 40])
     ])
-    def test_td64series_rmul_numeric_array(self, vector, dtype):
+    def test_td64series_rmul_numeric_array(self, vector, dtype, tdser):
         # GH 4521
         # divide/multiply by integers
-        tdser = Series(['59 Days', '59 Days', 'NaT'], dtype='timedelta64[ns]')
         vector = vector.astype(dtype)
 
         expected = Series(['1180 Days', '1770 Days', 'NaT'],
@@ -795,10 +792,9 @@ class TestTimedeltaSeriesArithmeticWithIntegers(object):
         assert_series_equal(result, expected)
 
     @pytest.mark.parametrize('one', [1, np.array(1), 1.0, np.array(1.0)])
-    def test_td64series_mul_numeric_scalar(self, one):
+    def test_td64series_mul_numeric_scalar(self, one, tdser):
         # GH 4521
         # divide/multiply by integers
-        tdser = Series(['59 Days', '59 Days', 'NaT'], dtype='timedelta64[ns]')
         expected = Series(['-59 Days', '-59 Days', 'NaT'],
                           dtype='timedelta64[ns]')
 
@@ -824,10 +820,9 @@ class TestTimedeltaSeriesArithmeticWithIntegers(object):
                      marks=pytest.mark.xfail(reason='GH#19011 is_list_like '
                                                     'incorrectly True.')),
     ])
-    def test_td64series_div_numeric_scalar(self, two):
+    def test_td64series_div_numeric_scalar(self, two, tdser):
         # GH 4521
         # divide/multiply by integers
-        tdser = Series(['59 Days', '59 Days', 'NaT'], dtype='timedelta64[ns]')
         expected = Series(['29.5D', '29.5D', 'NaT'], dtype='timedelta64[ns]')
 
         result = tdser / two


### PR DESCRIPTION
Breaks up a few big tests, parametrizes, covers cases much more thoroughly including identifying a few new xfails.

- [ ] closes #xxxx
- [ ] tests added / passed
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
