### PR TITLE
Hand written ISO parser for Timedelta construction

### DIFF
--- a/pandas/_libs/tslibs/timedeltas.pyx
+++ b/pandas/_libs/tslibs/timedeltas.pyx
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 # cython: profile=False
 import collections
-import re
 
 import sys
 cdef bint PY3 = (sys.version_info[0] >= 3)
@@ -236,6 +235,14 @@ cpdef inline int64_t cast_from_unit(object ts, object unit) except? -1:
     return <int64_t> (base *m) + <int64_t> (frac *m)
 
 
+cdef inline _decode_if_necessary(object ts):
+    # decode ts if necessary
+    if not PyUnicode_Check(ts) and not PY3:
+        ts = str(ts).decode('utf-8')
+
+    return ts
+
+
 cdef inline parse_timedelta_string(object ts):
     """
     Parse a regular format timedelta string. Return an int64_t (in ns)
@@ -258,9 +265,7 @@ cdef inline parse_timedelta_string(object ts):
     if len(ts) == 0 or ts in nat_strings:
         return NPY_NAT
 
-    # decode ts if necessary
-    if not PyUnicode_Check(ts) and not PY3:
-        ts = str(ts).decode('utf-8')
+    ts = _decode_if_necessary(ts)
 
     for c in ts:
 
@@ -507,26 +512,14 @@ def _binary_op_method_timedeltalike(op, name):
 # ----------------------------------------------------------------------
 # Timedelta Construction
 
-iso_pater = re.compile(r"""P
-                        (?P<days>-?[0-9]*)DT
-                        (?P<hours>[0-9]{1,2})H
-                        (?P<minutes>[0-9]{1,2})M
-                        (?P<seconds>[0-9]{0,2})
-                        (\.
-                        (?P<milliseconds>[0-9]{1,3})
-                        (?P<microseconds>[0-9]{0,3})
-                        (?P<nanoseconds>[0-9]{0,3})
-                        )?S""", re.VERBOSE)
-
-
-cdef int64_t parse_iso_format_string(object iso_fmt) except? -1:
+cdef inline int64_t parse_iso_format_string(object ts) except? -1:
     """
     Extracts and cleanses the appropriate values from a match object with
     groups for each component of an ISO 8601 duration
 
     Parameters
     ----------
-    iso_fmt:
+    ts:
         ISO 8601 Duration formatted string
 
     Returns
@@ -537,25 +530,93 @@ cdef int64_t parse_iso_format_string(object iso_fmt) except? -1:
     Raises
     ------
     ValueError
-        If ``iso_fmt`` cannot be parsed
+        If ``ts`` cannot be parsed
     """
 
-    cdef int64_t ns = 0
+    cdef:
+        unicode c
+        int64_t result = 0, r
+        int p=0
+        object dec_unit = 'ms', err_msg
+        bint have_dot=0, have_value=0, neg=0
+        list number=[], unit=[]
 
-    match = re.match(iso_pater, iso_fmt)
-    if match:
-        match_dict = match.groupdict(default='0')
-        for comp in ['milliseconds', 'microseconds', 'nanoseconds']:
-            match_dict[comp] = '{:0<3}'.format(match_dict[comp])
+    ts = _decode_if_necessary(ts)
 
-        for k, v in match_dict.items():
-            ns += timedelta_from_spec(v, '0', k)
+    err_msg = "Invalid ISO 8601 Duration format - {}".format(ts)
 
-    else:
-        raise ValueError("Invalid ISO 8601 Duration format - "
-                         "{}".format(iso_fmt))
+    for c in ts:
+        # number (ascii codes)
+        if ord(c) >= 48 and ord(c) <= 57:
 
-    return ns
+            have_value = 1
+            if have_dot:
+                if p == 3 and dec_unit != 'ns':
+                    unit.append(dec_unit)
+                    if dec_unit == 'ms':
+                        dec_unit = 'us'
+                    elif dec_unit == 'us':
+                        dec_unit = 'ns'
+                    p = 0
+                p += 1
+
+            if not len(unit):
+                number.append(c)
+            else:
+                # if in days, pop trailing T
+                if unit[-1] == 'T':
+                    unit.pop()
+                elif 'H' in unit or 'M' in unit:
+                    if len(number) > 2:
+                        raise ValueError(err_msg)
+                r = timedelta_from_spec(number, '0', unit)
+                result += timedelta_as_neg(r, neg)
+
+                neg = 0
+                unit, number = [], [c]
+        else:
+            if c == 'P':
+                pass  # ignore leading character
+            elif c == '-':
+                if neg or have_value:
+                    raise ValueError(err_msg)
+                else:
+                    neg = 1
+            elif c in ['D', 'T', 'H', 'M']:
+                unit.append(c)
+            elif c == '.':
+                # append any seconds
+                if len(number):
+                    r = timedelta_from_spec(number, '0', 'S')
+                    result += timedelta_as_neg(r, neg)
+                    unit, number = [], []
+                have_dot = 1
+            elif c == 'S':
+                if have_dot:  # ms, us, or ns
+                    if not len(number) or p > 3:
+                        raise ValueError(err_msg)
+                    # pad to 3 digits as required
+                    pad = 3 - p
+                    while pad > 0:
+                        number.append('0')
+                        pad -= 1
+
+                    r = timedelta_from_spec(number, '0', dec_unit)
+                    result += timedelta_as_neg(r, neg)
+                else:  # seconds
+                    if len(number) <= 2:
+                        r = timedelta_from_spec(number, '0', 'S')
+                        result += timedelta_as_neg(r, neg)
+                    else:
+                        raise ValueError(err_msg)
+            else:
+                raise ValueError(err_msg)
+
+    if not have_value:
+        # Received string only - never parsed any values
+        raise ValueError(err_msg)
+
+    return result
 
 
 cdef _to_py_int_float(v):


### PR DESCRIPTION
- [X] closes #19103 
- [X] tests added / passed
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

```
Running 16 total benchmarks (2 commits * 1 environments * 8 benchmarks)
[  0.00%] · For pandas commit hash 76475dd8:
[  0.00%] ·· Building for conda-py3.6-Cython-matplotlib-numexpr-numpy-openpyxl-pytables-pytest-scipy-sqlalchemy-xlrd-xlsxwriter-xlwt...............................................................
[  0.00%] ·· Benchmarking conda-py3.6-Cython-matplotlib-numexpr-numpy-openpyxl-pytables-pytest-scipy-sqlalchemy-xlrd-xlsxwriter-xlwt
[  6.25%] ··· Running timedelta.TimedeltaConstructor.time_from_components                                      15.4±0.4μs
[ 12.50%] ··· Running timedelta.TimedeltaConstructor.time_from_datetime_timedelta                              8.06±0.3μs
[ 18.75%] ··· Running timedelta.TimedeltaConstructor.time_from_int                                             6.24±0.2μs
[ 25.00%] ··· Running timedelta.TimedeltaConstructor.time_from_iso_format                                      12.1±0.4μs
[ 31.25%] ··· Running timedelta.TimedeltaConstructor.time_from_missing                                        2.07±0.03μs
[ 37.50%] ··· Running timedelta.TimedeltaConstructor.time_from_np_timedelta                                   5.06±0.09μs
[ 43.75%] ··· Running timedelta.TimedeltaConstructor.time_from_string                                          6.52±0.1μs
[ 50.00%] ··· Running timedelta.TimedeltaConstructor.time_from_unit                                            6.66±0.1μs
[ 50.00%] · For pandas commit hash 8acdf801:
[ 50.00%] ·· Building for conda-py3.6-Cython-matplotlib-numexpr-numpy-openpyxl-pytables-pytest-scipy-sqlalchemy-xlrd-xlsxwriter-xlwt...
[ 50.00%] ·· Benchmarking conda-py3.6-Cython-matplotlib-numexpr-numpy-openpyxl-pytables-pytest-scipy-sqlalchemy-xlrd-xlsxwriter-xlwt
[ 56.25%] ··· Running timedelta.TimedeltaConstructor.time_from_components                                      15.5±0.3μs
[ 62.50%] ··· Running timedelta.TimedeltaConstructor.time_from_datetime_timedelta                              7.90±0.2μs
[ 68.75%] ··· Running timedelta.TimedeltaConstructor.time_from_int                                             6.11±0.2μs
[ 75.00%] ··· Running timedelta.TimedeltaConstructor.time_from_iso_format                                      25.0±0.7μs
[ 81.25%] ··· Running timedelta.TimedeltaConstructor.time_from_missing                                        2.27±0.06μs
[ 87.50%] ··· Running timedelta.TimedeltaConstructor.time_from_np_timedelta                                    5.04±0.1μs
[ 93.75%] ··· Running timedelta.TimedeltaConstructor.time_from_string                                          7.04±0.2μs
[100.00%] ··· Running timedelta.TimedeltaConstructor.time_from_unit                                            6.51±0.1μs       before           after         ratio
     [8acdf801]       [76475dd8]
-      25.0±0.7μs       12.1±0.4μs     0.48  timedelta.TimedeltaConstructor.time_from_iso_format

SOME BENCHMARKS HAVE CHANGED SIGNIFICANTLY.
```