### PR TITLE
Clarify equals method docstring

### DIFF
--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -1047,7 +1047,8 @@ class NDFrame(PandasObject, SelectionMixin):
 
     def equals(self, other):
         """
-        Determines if two NDFrame objects contain the same elements. NaNs in
+        Determines if two NDFrame objects have equal indices, equal
+        elements, and the same dtypes at corresponding locations. NaNs in
         the same location are considered equal.
         """
         if not isinstance(other, self._constructor):

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -1047,9 +1047,9 @@ class NDFrame(PandasObject, SelectionMixin):
 
     def equals(self, other):
         """
-        Determines if two NDFrame objects have equal indices, equal
-        elements, and the same dtypes at corresponding locations. NaNs in
-        the same location are considered equal.
+        Determines if two NDFrame objects have equal columns labels, equal
+        elements, and the same dtypes at corresponding locations. NaNs in the
+        same location are considered equal.
         """
         if not isinstance(other, self._constructor):
             return False


### PR DESCRIPTION
Make explicit that equals method requires that columns have the same dtypes but not that indices have the same types (e.g. `pd.DataFrame({1:[0], 0:[1]}).equals(pd.DataFrame({1.0:[0], 0.0:[1]}))` returns `True` while `pd.DataFrame({1:[0], 0:[1]}, dtype='float32').equals(pd.DataFrame({1:[0], 0:[1]}, dtype='float64'))` returns `False`)

- [ ] closes #xxxx
- [ ] tests added / passed
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
