### PR TITLE
DOC: Exposed arguments in plot.kde

### DIFF
--- a/doc/source/whatsnew/v0.23.0.txt
+++ b/doc/source/whatsnew/v0.23.0.txt
@@ -536,7 +536,7 @@ Plotting
 
 - :func: `DataFrame.plot` now raises a ``ValueError`` when the ``x`` or ``y`` argument is improperly formed (:issue:`18671`)
 - Bug in formatting tick labels with ``datetime.time()`` and fractional seconds (:issue:`18478`).
-- The arguments ``ind`` and ``bw_method`` are added to the docstring of :meth:`Series.plot.kde` (:issue:`18461`). The argument ``ind`` may now also be an integer (number of sample points).
+- :meth:`Series.plot.kde` has exposed the args ``ind`` and ``bw_method`` in the docstring (:issue:`18461`). The argument ``ind`` may now also be an integer (number of sample points).
 -
 
 Groupby/Resample/Rolling

--- a/doc/source/whatsnew/v0.23.0.txt
+++ b/doc/source/whatsnew/v0.23.0.txt
@@ -536,7 +536,7 @@ Plotting
 
 - :func: `DataFrame.plot` now raises a ``ValueError`` when the ``x`` or ``y`` argument is improperly formed (:issue:`18671`)
 - Bug in formatting tick labels with ``datetime.time()`` and fractional seconds (:issue:`18478`).
--
+- The arguments ``ind`` and ``bw_method`` are added to the docstring of :meth:`Series.plot.kde` (:issue:`18461`). The argument ``ind`` may now also be an integer (number of sample points).
 -
 
 Groupby/Resample/Rolling

--- a/pandas/plotting/_core.py
+++ b/pandas/plotting/_core.py
@@ -1398,6 +1398,10 @@ class KdePlot(HistPlot):
             sample_range = np.nanmax(y) - np.nanmin(y)
             ind = np.linspace(np.nanmin(y) - 0.5 * sample_range,
                               np.nanmax(y) + 0.5 * sample_range, 1000)
+        elif isinstance(self.ind, (int, np.int)):
+            sample_range = np.nanmax(y) - np.nanmin(y)
+            ind = np.linspace(np.nanmin(y) - 0.5 * sample_range,
+                              np.nanmax(y) + 0.5 * sample_range, self.ind)
         else:
             ind = self.ind
         return ind
@@ -2598,12 +2602,22 @@ class SeriesPlotMethods(BasePlotMethods):
         """
         return self(kind='hist', bins=bins, **kwds)
 
-    def kde(self, **kwds):
+    def kde(self, bw_method = None, ind = None,  **kwds):
         """
         Kernel Density Estimate plot
 
         Parameters
         ----------
+        bw_method: str, scalar or callable, optional
+            The method used to calculate the estimator bandwidth.  This can be
+            'scott', 'silverman', a scalar constant or a callable.
+            If None (default), 'scott' is used.
+            See :scipy:class:`stats.gaussian_kde` for more information.
+        ind : NumPy array or integer, optional
+            Evaluation points. If None (default), 1000 equally spaced points
+            are used. If `ind` is a NumPy array, the kde is evaluated at the
+            points passed. If `ind` is an integer, `ind` number of equally 
+            spaced points are used.
         `**kwds` : optional
             Keyword arguments to pass on to :py:meth:`pandas.Series.plot`.
 
@@ -2611,7 +2625,7 @@ class SeriesPlotMethods(BasePlotMethods):
         -------
         axes : matplotlib.AxesSubplot or np.array of them
         """
-        return self(kind='kde', **kwds)
+        return self(kind='kde', bw_method = bw_method, ind = ind, **kwds)
 
     density = kde
 
@@ -2766,20 +2780,30 @@ class FramePlotMethods(BasePlotMethods):
         """
         return self(kind='hist', by=by, bins=bins, **kwds)
 
-    def kde(self, **kwds):
+    def kde(self, bw_method = None, ind = None,  **kwds):
         """
         Kernel Density Estimate plot
 
         Parameters
         ----------
+        bw_method: str, scalar or callable, optional
+            The method used to calculate the estimator bandwidth.  This can be
+            'scott', 'silverman', a scalar constant or a callable.
+            If None (default), 'scott' is used.
+            See :scipy:class:`stats.gaussian_kde` for more information.
+        ind : NumPy array or integer, optional
+            Evaluation points. If None (default), 1000 equally spaced points
+            are used. If `ind` is a NumPy array, the kde is evaluated at the
+            points passed. If `ind` is an integer, `ind` number of equally 
+            spaced points are used.
         `**kwds` : optional
-            Keyword arguments to pass on to :py:meth:`pandas.DataFrame.plot`.
+            Keyword arguments to pass on to :py:meth:`pandas.Series.plot`.
 
         Returns
         -------
         axes : matplotlib.AxesSubplot or np.array of them
         """
-        return self(kind='kde', **kwds)
+        return self(kind='kde', bw_method = bw_method, ind = ind, **kwds)
 
     density = kde
 
@@ -2866,3 +2890,4 @@ class FramePlotMethods(BasePlotMethods):
         if gridsize is not None:
             kwds['gridsize'] = gridsize
         return self(kind='hexbin', x=x, y=y, C=C, **kwds)
+

--- a/pandas/plotting/_core.py
+++ b/pandas/plotting/_core.py
@@ -2612,7 +2612,7 @@ class SeriesPlotMethods(BasePlotMethods):
             The method used to calculate the estimator bandwidth.  This can be
             'scott', 'silverman', a scalar constant or a callable.
             If None (default), 'scott' is used.
-            See :scipy:class:`stats.gaussian_kde` for more information.
+            See :class:`scipy.stats.gaussian_kde` for more information.
         ind : NumPy array or integer, optional
             Evaluation points. If None (default), 1000 equally spaced points
             are used. If `ind` is a NumPy array, the kde is evaluated at the
@@ -2790,7 +2790,7 @@ class FramePlotMethods(BasePlotMethods):
             The method used to calculate the estimator bandwidth.  This can be
             'scott', 'silverman', a scalar constant or a callable.
             If None (default), 'scott' is used.
-            See :scipy:class:`stats.gaussian_kde` for more information.
+            See :class:`scipy.stats.gaussian_kde` for more information.
         ind : NumPy array or integer, optional
             Evaluation points. If None (default), 1000 equally spaced points
             are used. If `ind` is a NumPy array, the kde is evaluated at the

--- a/pandas/plotting/_core.py
+++ b/pandas/plotting/_core.py
@@ -2797,7 +2797,7 @@ class FramePlotMethods(BasePlotMethods):
             points passed. If `ind` is an integer, `ind` number of equally
             spaced points are used.
         `**kwds` : optional
-            Keyword arguments to pass on to :py:meth:`pandas.Series.plot`.
+            Keyword arguments to pass on to :py:meth:`pandas.DataFrame.plot`.
 
         Returns
         -------

--- a/pandas/plotting/_core.py
+++ b/pandas/plotting/_core.py
@@ -1398,7 +1398,7 @@ class KdePlot(HistPlot):
             sample_range = np.nanmax(y) - np.nanmin(y)
             ind = np.linspace(np.nanmin(y) - 0.5 * sample_range,
                               np.nanmax(y) + 0.5 * sample_range, 1000)
-        elif isinstance(self.ind, (int, np.int)):
+        elif is_integer(self.ind):
             sample_range = np.nanmax(y) - np.nanmin(y)
             ind = np.linspace(np.nanmin(y) - 0.5 * sample_range,
                               np.nanmax(y) + 0.5 * sample_range, self.ind)
@@ -2602,7 +2602,7 @@ class SeriesPlotMethods(BasePlotMethods):
         """
         return self(kind='hist', bins=bins, **kwds)
 
-    def kde(self, bw_method = None, ind = None,  **kwds):
+    def kde(self, bw_method=None, ind=None, **kwds):
         """
         Kernel Density Estimate plot
 
@@ -2616,7 +2616,7 @@ class SeriesPlotMethods(BasePlotMethods):
         ind : NumPy array or integer, optional
             Evaluation points. If None (default), 1000 equally spaced points
             are used. If `ind` is a NumPy array, the kde is evaluated at the
-            points passed. If `ind` is an integer, `ind` number of equally 
+            points passed. If `ind` is an integer, `ind` number of equally
             spaced points are used.
         `**kwds` : optional
             Keyword arguments to pass on to :py:meth:`pandas.Series.plot`.
@@ -2625,7 +2625,7 @@ class SeriesPlotMethods(BasePlotMethods):
         -------
         axes : matplotlib.AxesSubplot or np.array of them
         """
-        return self(kind='kde', bw_method = bw_method, ind = ind, **kwds)
+        return self(kind='kde', bw_method=bw_method, ind=ind, **kwds)
 
     density = kde
 
@@ -2780,7 +2780,7 @@ class FramePlotMethods(BasePlotMethods):
         """
         return self(kind='hist', by=by, bins=bins, **kwds)
 
-    def kde(self, bw_method = None, ind = None,  **kwds):
+    def kde(self, bw_method=None, ind=None, **kwds):
         """
         Kernel Density Estimate plot
 
@@ -2794,7 +2794,7 @@ class FramePlotMethods(BasePlotMethods):
         ind : NumPy array or integer, optional
             Evaluation points. If None (default), 1000 equally spaced points
             are used. If `ind` is a NumPy array, the kde is evaluated at the
-            points passed. If `ind` is an integer, `ind` number of equally 
+            points passed. If `ind` is an integer, `ind` number of equally
             spaced points are used.
         `**kwds` : optional
             Keyword arguments to pass on to :py:meth:`pandas.Series.plot`.
@@ -2803,7 +2803,7 @@ class FramePlotMethods(BasePlotMethods):
         -------
         axes : matplotlib.AxesSubplot or np.array of them
         """
-        return self(kind='kde', bw_method = bw_method, ind = ind, **kwds)
+        return self(kind='kde', bw_method=bw_method, ind=ind, **kwds)
 
     density = kde
 
@@ -2890,4 +2890,3 @@ class FramePlotMethods(BasePlotMethods):
         if gridsize is not None:
             kwds['gridsize'] = gridsize
         return self(kind='hexbin', x=x, y=y, C=C, **kwds)
-

--- a/pandas/tests/plotting/test_series.py
+++ b/pandas/tests/plotting/test_series.py
@@ -623,6 +623,7 @@ class TestSeriesPlots(TestPlotBase):
 
         from numpy import linspace
         _check_plot_works(self.ts.plot.kde, bw_method=None, ind=20)
+        _check_plot_works(self.ts.plot.kde, bw_method=None, ind=np.int(20))
         _check_plot_works(self.ts.plot.kde, bw_method=.5,
                           ind=linspace(-100, 100, 20))
         _check_plot_works(self.ts.plot.density, bw_method=.5,
@@ -898,4 +899,3 @@ class TestSeriesPlots(TestPlotBase):
             freq=CustomBusinessDay(holidays=['2014-05-26'])))
 
         _check_plot_works(s.plot)
-

--- a/pandas/tests/plotting/test_series.py
+++ b/pandas/tests/plotting/test_series.py
@@ -626,9 +626,11 @@ class TestSeriesPlots(TestPlotBase):
         _check_plot_works(self.ts.plot.kde, bw_method=None, ind=20)
         _check_plot_works(self.ts.plot.kde, bw_method=None, ind=np.int(20))
         _check_plot_works(self.ts.plot.kde, bw_method=.5, ind=sample_points)
-        _check_plot_works(self.ts.plot.density, bw_method=.5, ind=sample_points)
+        _check_plot_works(self.ts.plot.density, bw_method=.5,
+                          flakind=sample_points)
         _, ax = self.plt.subplots()
-        ax = self.ts.plot.kde(logy=True, bw_method=.5, ind=sample_points, ax=ax)
+        ax = self.ts.plot.kde(logy=True, bw_method=.5, ind=sample_points,
+                              ax=ax)
         self._check_ax_scales(ax, yaxis='log')
         self._check_text_labels(ax.yaxis.get_label(), 'Density')
 

--- a/pandas/tests/plotting/test_series.py
+++ b/pandas/tests/plotting/test_series.py
@@ -621,16 +621,14 @@ class TestSeriesPlots(TestPlotBase):
         if not self.mpl_ge_1_5_0:
             pytest.skip("mpl is not supported")
 
-        from numpy import linspace
+        sample_points = np.linspace(-100, 100, 20)
+        _check_plot_works(self.ts.plot.kde, bw_method='scott', ind=20)
         _check_plot_works(self.ts.plot.kde, bw_method=None, ind=20)
         _check_plot_works(self.ts.plot.kde, bw_method=None, ind=np.int(20))
-        _check_plot_works(self.ts.plot.kde, bw_method=.5,
-                          ind=linspace(-100, 100, 20))
-        _check_plot_works(self.ts.plot.density, bw_method=.5,
-                          ind=linspace(-100, 100, 20))
+        _check_plot_works(self.ts.plot.kde, bw_method=.5, ind=sample_points)
+        _check_plot_works(self.ts.plot.density, bw_method=.5, ind=sample_points)
         _, ax = self.plt.subplots()
-        ax = self.ts.plot.kde(logy=True, bw_method=.5,
-                              ind=linspace(-100, 100, 20), ax=ax)
+        ax = self.ts.plot.kde(logy=True, bw_method=.5, ind=sample_points, ax=ax)
         self._check_ax_scales(ax, yaxis='log')
         self._check_text_labels(ax.yaxis.get_label(), 'Density')
 

--- a/pandas/tests/plotting/test_series.py
+++ b/pandas/tests/plotting/test_series.py
@@ -627,7 +627,7 @@ class TestSeriesPlots(TestPlotBase):
         _check_plot_works(self.ts.plot.kde, bw_method=None, ind=np.int(20))
         _check_plot_works(self.ts.plot.kde, bw_method=.5, ind=sample_points)
         _check_plot_works(self.ts.plot.density, bw_method=.5,
-                          flakind=sample_points)
+                          ind=sample_points)
         _, ax = self.plt.subplots()
         ax = self.ts.plot.kde(logy=True, bw_method=.5, ind=sample_points,
                               ax=ax)

--- a/pandas/tests/plotting/test_series.py
+++ b/pandas/tests/plotting/test_series.py
@@ -622,6 +622,7 @@ class TestSeriesPlots(TestPlotBase):
             pytest.skip("mpl is not supported")
 
         from numpy import linspace
+        _check_plot_works(self.ts.plot.kde, bw_method=None, ind=20)
         _check_plot_works(self.ts.plot.kde, bw_method=.5,
                           ind=linspace(-100, 100, 20))
         _check_plot_works(self.ts.plot.density, bw_method=.5,
@@ -897,3 +898,4 @@ class TestSeriesPlots(TestPlotBase):
             freq=CustomBusinessDay(holidays=['2014-05-26'])))
 
         _check_plot_works(s.plot)
+


### PR DESCRIPTION
The documentation for `plot.kde` did not show the `bw_method` and `ind` arguments, which are specific to `plot.kde` (and `plot.density`, which refers to the same method).

There is also a change in the actual code, and a corresponding test added. I added an option for `ind` to be an integer number of sample points, instead of necessarily a `np.array`. I image that a user typically just wants a number of equidistant sample points, and does not want to construct an array.

- [X] tests added / passed
- [X] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry

Comments very welcome.
