### PR TITLE
PERF: sort_values speedup for multiple columns with random numeric values

### DIFF
--- a/asv_bench/benchmarks/frame_methods.py
+++ b/asv_bench/benchmarks/frame_methods.py
@@ -440,7 +440,7 @@ class XS(object):
         self.df.xs(self.N / 2, axis=axis)
 
 
-class frame_sort_values_by_multiple_columns(object):
+class SortValuesMultipleColumns(object):
     goal_time = 0.1
 
     param_names = ['columns']
@@ -450,7 +450,8 @@ class frame_sort_values_by_multiple_columns(object):
     #                   'float', 'int_sorted', 'int_random',
     #                   'date', 'timedelta'], r=[2, 5], num=20)
     params = ['repeated_strings|int_same_cardinality_as_repeated_strings',
-              'int_same_cardinality_as_repeated_strings|int_same_cardinality_as_repeated_strings_copy']
+              'int_same_cardinality_as_repeated_strings|'
+              'int_same_cardinality_as_repeated_strings_copy']
 
     def setup(self, columns):
         N = 1000000
@@ -466,17 +467,22 @@ class frame_sort_values_by_multiple_columns(object):
                 'int_random': np.random.randint(0, 10000000, N),
                 'date': date_range('20110101', freq='s', periods=N),
                 'timedelta': timedelta_range('1 day', freq='s', periods=N),
-            })
-        self.df['repeated_category'] = self.df['repeated_strings'].astype(
-            'category')
-        self.df['less_repeated_category'] = self.df[
-            'less_repeated_strings'].astype('category')
-        self.df['int_same_cardinality_as_repeated_strings'] = self.df['repeated_strings'].rank(method='dense')
-        self.df['int_same_cardinality_as_repeated_strings_copy'] = self.df['repeated_strings'].rank(method='dense')
-        self.df['int_same_cardinality_as_less_repeated_strings'] = self.df['less_repeated_strings'].rank(method='dense')
-        assert self.df['repeated_strings'].nunique() == self.df['int_same_cardinality_as_repeated_strings'].nunique()
-        assert self.df['less_repeated_strings'].nunique() == self.df['int_same_cardinality_as_less_repeated_strings'].nunique()
-
+             })
+        self.df['repeated_category'] = \
+            self.df['repeated_strings'].astype('category')
+        self.df['less_repeated_category'] = \
+            self.df['less_repeated_strings'].astype('category')
+        self.df['int_same_cardinality_as_repeated_strings'] = \
+            self.df['repeated_strings'].rank(method='dense')
+        self.df['int_same_cardinality_as_repeated_strings_copy'] = \
+            self.df['repeated_strings'].rank(method='dense')
+        self.df['int_same_cardinality_as_less_repeated_strings'] = \
+            self.df['less_repeated_strings'].rank(method='dense')
+        assert self.df['repeated_strings'].nunique() == \
+            self.df['int_same_cardinality_as_repeated_strings'].nunique()
+        assert self.df['less_repeated_strings'].nunique() == \
+            self.df['int_same_cardinality_as_less_repeated_strings']\
+                   .nunique()
 
     def time_frame_sort_values_by_multiple_columns(self, columns):
         columns_list = columns.split('|')
@@ -497,6 +503,7 @@ class SortValues(object):
 
     def time_frame_sort_values_two_columns(self, ascending):
         self.df.sort_values(by=['A', 'B', 'C', 'D', 'E'], ascending=ascending)
+
 
 class SortIndexByColumns(object):
 

--- a/asv_bench/benchmarks/frame_methods.py
+++ b/asv_bench/benchmarks/frame_methods.py
@@ -495,6 +495,8 @@ class SortValues(object):
     def time_frame_sort_values(self, ascending):
         self.df.sort_values(by='A', ascending=ascending)
 
+    def time_frame_sort_values_two_columns(self, ascending):
+        self.df.sort_values(by=['A', 'B'], ascending=ascending)
 
 class SortIndexByColumns(object):
 

--- a/asv_bench/benchmarks/frame_methods.py
+++ b/asv_bench/benchmarks/frame_methods.py
@@ -453,7 +453,7 @@ class frame_sort_values_by_multiple_columns(object):
               'int_same_cardinality_as_repeated_strings|int_same_cardinality_as_repeated_strings_copy']
 
     def setup(self, columns):
-        N = 10000
+        N = 1000000
 
         self.df = DataFrame(
             {'repeated_strings': Series(tm.makeStringIndex(100).take(
@@ -490,13 +490,13 @@ class SortValues(object):
     param_names = ['ascending']
 
     def setup(self, ascending):
-        self.df = DataFrame(np.random.randn(1000000, 2), columns=list('AB'))
+        self.df = DataFrame(np.random.randn(1000000, 5), columns=list('ABCDE'))
 
     def time_frame_sort_values(self, ascending):
         self.df.sort_values(by='A', ascending=ascending)
 
     def time_frame_sort_values_two_columns(self, ascending):
-        self.df.sort_values(by=['A', 'B'], ascending=ascending)
+        self.df.sort_values(by=['A', 'B', 'C', 'D', 'E'], ascending=ascending)
 
 class SortIndexByColumns(object):
 

--- a/asv_bench/benchmarks/frame_methods.py
+++ b/asv_bench/benchmarks/frame_methods.py
@@ -2,7 +2,7 @@ import string
 import numpy as np
 import pandas.util.testing as tm
 from pandas import (DataFrame, Series, MultiIndex, date_range, period_range,
-                    isnull, NaT)
+                    isnull, NaT, timedelta_range)
 
 from .pandas_vb_common import setup  # noqa
 
@@ -438,6 +438,49 @@ class XS(object):
 
     def time_frame_xs(self, axis):
         self.df.xs(self.N / 2, axis=axis)
+
+
+class frame_sort_values_by_multiple_columns(object):
+    goal_time = 0.1
+
+    param_names = ['columns']
+    # params = generate_column_combinations(
+    #     column_names=['less_repeated_strings',
+    #                   'repeated_category', 'less_repeated_category',
+    #                   'float', 'int_sorted', 'int_random',
+    #                   'date', 'timedelta'], r=[2, 5], num=20)
+    params = ['repeated_strings|int_same_cardinality_as_repeated_strings',
+              'int_same_cardinality_as_repeated_strings|int_same_cardinality_as_repeated_strings_copy']
+
+    def setup(self, columns):
+        N = 10000
+
+        self.df = DataFrame(
+            {'repeated_strings': Series(tm.makeStringIndex(100).take(
+                np.random.randint(0, 100, size=N))),
+                'less_repeated_strings': Series(
+                    tm.makeStringIndex(10000).take(
+                        np.random.randint(0, 10000, size=N))),
+                'float': np.random.randn(N),
+                'int_sorted': np.arange(N),
+                'int_random': np.random.randint(0, 10000000, N),
+                'date': date_range('20110101', freq='s', periods=N),
+                'timedelta': timedelta_range('1 day', freq='s', periods=N),
+            })
+        self.df['repeated_category'] = self.df['repeated_strings'].astype(
+            'category')
+        self.df['less_repeated_category'] = self.df[
+            'less_repeated_strings'].astype('category')
+        self.df['int_same_cardinality_as_repeated_strings'] = self.df['repeated_strings'].rank(method='dense')
+        self.df['int_same_cardinality_as_repeated_strings_copy'] = self.df['repeated_strings'].rank(method='dense')
+        self.df['int_same_cardinality_as_less_repeated_strings'] = self.df['less_repeated_strings'].rank(method='dense')
+        assert self.df['repeated_strings'].nunique() == self.df['int_same_cardinality_as_repeated_strings'].nunique()
+        assert self.df['less_repeated_strings'].nunique() == self.df['int_same_cardinality_as_less_repeated_strings'].nunique()
+
+
+    def time_frame_sort_values_by_multiple_columns(self, columns):
+        columns_list = columns.split('|')
+        DataFrame(self.df[columns_list]).sort_values(by=columns_list)
 
 
 class SortValues(object):

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -3637,16 +3637,44 @@ class DataFrame(NDFrame):
             raise ValueError('Length of ascending (%d) != length of by (%d)' %
                              (len(ascending), len(by)))
         if len(by) > 1:
-            from pandas.core.sorting import lexsort_indexer
+            if any([is_object_dtype(self._get_label_or_level_values(x, axis=axis, stacklevel=stacklevel)) for x in by]):
+                from pandas.core.sorting import lexsort_indexer
 
-            keys = []
-            for x in by:
-                k = self._get_label_or_level_values(x, axis=axis,
-                                                    stacklevel=stacklevel)
-                keys.append(k)
-            indexer = lexsort_indexer(keys, orders=ascending,
-                                      na_position=na_position)
-            indexer = _ensure_platform_int(indexer)
+                keys = []
+                for x in by:
+                    k = self._get_label_or_level_values(x, axis=axis,
+                                                        stacklevel=stacklevel)
+                    keys.append(k)
+                indexer = lexsort_indexer(keys, orders=ascending,
+                                          na_position=na_position)
+                indexer = _ensure_platform_int(indexer)
+
+                new_data = self._data.take(indexer,
+                                           axis=self._get_block_manager_axis(axis),
+                                           verify=False)
+            else:  #sort non-object column faster
+                if not is_list_like(ascending):
+                    ascending = [ascending] * len(by)
+                ascending = ascending[::-1]
+                new_data = self
+                from pandas.core.sorting import nargsort
+                kind = 'mergesort'
+
+                for i, by_step in enumerate(by[::-1]):
+
+                    k = self._get_label_or_level_values(by_step, axis=axis,
+                                                stacklevel=stacklevel)
+
+                    indexer = nargsort(k, kind=kind, ascending=ascending[i],
+                                       na_position=na_position)
+
+                    new_data = new_data._data.take(
+                        indexer,
+                        axis=self._get_block_manager_axis(axis),
+                        convert=False, verify=False)
+
+                    new_data = self._constructor(new_data).__finalize__(self)
+
         else:
             from pandas.core.sorting import nargsort
 
@@ -3660,9 +3688,9 @@ class DataFrame(NDFrame):
             indexer = nargsort(k, kind=kind, ascending=ascending,
                                na_position=na_position)
 
-        new_data = self._data.take(indexer,
-                                   axis=self._get_block_manager_axis(axis),
-                                   verify=False)
+            new_data = self._data.take(indexer,
+                                       axis=self._get_block_manager_axis(axis),
+                                       verify=False)
 
         if inplace:
             return self._update_inplace(new_data)

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -3637,7 +3637,8 @@ class DataFrame(NDFrame):
             raise ValueError('Length of ascending (%d) != length of by (%d)' %
                              (len(ascending), len(by)))
         if len(by) > 1:
-            if any([is_object_dtype(self._get_label_or_level_values(x, axis=axis, stacklevel=stacklevel)) for x in by]):
+            if any([is_object_dtype(self._get_label_or_level_values(
+                    x, axis=axis, stacklevel=stacklevel)) for x in by]):
                 from pandas.core.sorting import lexsort_indexer
 
                 keys = []
@@ -3650,9 +3651,10 @@ class DataFrame(NDFrame):
                 indexer = _ensure_platform_int(indexer)
 
                 new_data = self._data.take(indexer,
-                                           axis=self._get_block_manager_axis(axis),
+                                           axis=self._get_block_manager_axis(
+                                               axis),
                                            verify=False)
-            else:  #sort non-object column faster
+            else:
                 if not is_list_like(ascending):
                     ascending = [ascending] * len(by)
                 ascending = ascending[::-1]
@@ -3661,9 +3663,8 @@ class DataFrame(NDFrame):
                 kind = 'mergesort'
 
                 for i, by_step in enumerate(by[::-1]):
-
-                    k = self._get_label_or_level_values(by_step, axis=axis,
-                                                stacklevel=stacklevel)
+                    k = self._get_label_or_level_values(
+                        by_step, axis=axis, stacklevel=stacklevel)
 
                     indexer = nargsort(k, kind=kind, ascending=ascending[i],
                                        na_position=na_position)


### PR DESCRIPTION
Continue work on #17141.
Speedup achieved for sorting by multiple columns: lexsort over multiple columns
replaced with mergesort of columns in reverse order than specified in "by"
argument of DataFrame.sort_values().
Issues:
- only works for numerical data
- only random enough data achieve sorting speedup (no factorization)
- ASV of one-column sort is worse, why?

- [ ] closes #xxxx
- [ ] tests added / passed
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
