### PR TITLE
CLN: Refactor Index._validate_names()

### DIFF
--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -785,7 +785,13 @@ class Index(IndexOpsMixin, PandasObject):
             new_index = self._shallow_copy()
 
         names = kwargs.get('names')
-        names = self._validate_names(name=name, names=names, deep=deep)
+
+        if name is None and names is None:
+            from copy import deepcopy
+            names = deepcopy(self.names) if deep else self.names
+        else:
+            names = self._validate_names(name=name, names=names)
+
         new_index = new_index.set_names(names)
 
         if dtype:
@@ -800,24 +806,21 @@ class Index(IndexOpsMixin, PandasObject):
             memo = {}
         return self.copy(deep=True)
 
-    def _validate_names(self, name=None, names=None, deep=False):
+    def _validate_names(self, name=None, names=None):
         """
-        Handles the quirks of having a singular 'name' parameter for general
-        Index and plural 'names' parameter for MultiIndex.
+        Returns valid `names` considering both `names` and `name`
+        or raises TypeError in case of wrong arguments passed.
         """
-        from copy import deepcopy
         if names is not None and name is not None:
-            raise TypeError("Can only provide one of `names` and `name`")
-        elif names is None and name is None:
-            return deepcopy(self.names) if deep else self.names
-        elif names is not None:
-            if not is_list_like(names):
-                raise TypeError("Must pass list-like as `names`.")
-            return names
-        else:
-            if not is_list_like(name):
-                return [name]
-            return name
+            raise TypeError("Can provide only one of names and name arguments")
+
+        if names is not None and not is_list_like(names):
+            raise TypeError("names must be list-like")
+
+        if name is not None:
+            return name if is_list_like(name) else [name]
+
+        return names
 
     def __unicode__(self):
         """

--- a/pandas/core/indexes/multi.py
+++ b/pandas/core/indexes/multi.py
@@ -427,11 +427,16 @@ class MultiIndex(Index):
         ``deep``, but if ``deep`` is passed it will attempt to deepcopy.
         This could be potentially expensive on large MultiIndex objects.
         """
+        from copy import deepcopy
+
         name = kwargs.get('name')
-        names = self._validate_names(name=name, names=names, deep=deep)
+
+        if name is None and names is None:
+            names = deepcopy(self.names) if deep else self.names
+        else:
+            names = self._validate_names(name=name, names=names)
 
         if deep:
-            from copy import deepcopy
             if levels is None:
                 levels = deepcopy(self.levels)
             if labels is None:


### PR DESCRIPTION
- [x] closes #19171
- [x] tests passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`