### PR TITLE
PERF: remove use of Panel & perf in rolling corr/cov

### DIFF
--- a/asv_bench/benchmarks/rolling.py
+++ b/asv_bench/benchmarks/rolling.py
@@ -11,8 +11,8 @@ class Methods(object):
               [10, 1000],
               ['int', 'float'],
               ['median', 'mean', 'max', 'min', 'std', 'count', 'skew', 'kurt',
-               'sum', 'corr', 'cov'])
-    param_names = ['constructor', 'window', 'dtype', 'method']
+               'sum'])
+    param_names = ['contructor', 'window', 'dtype', 'method']
 
     def setup(self, constructor, window, dtype, method):
         N = 10**5
@@ -21,6 +21,27 @@ class Methods(object):
 
     def time_rolling(self, constructor, window, dtype, method):
         getattr(self.roll, method)()
+
+
+class Pairwise(object):
+
+    sample_time = 0.2
+    params = ([10, 1000, None],
+              ['corr', 'cov'],
+              [True, False])
+    param_names = ['window', 'method', 'pairwise']
+
+    def setup(self, window, method, pairwise):
+        N = 10**4
+        arr = np.random.random(N)
+        self.df = pd.DataFrame(arr)
+
+    def time_pairwise(self, window, method, pairwise):
+        if window is None:
+            r = self.df.expanding()
+        else:
+            r = self.df.rolling(window=window)
+        getattr(r, method)(self.df, pairwise=pairwise)
 
 
 class Quantile(object):

--- a/doc/source/whatsnew/v0.23.0.txt
+++ b/doc/source/whatsnew/v0.23.0.txt
@@ -383,7 +383,7 @@ Performance Improvements
 - :func:`Series` / :func:`DataFrame` tab completion limits to 100 values, for better performance. (:issue:`18587`)
 - Improved performance of :func:`DataFrame.median` with ``axis=1`` when bottleneck is not installed (:issue:`16468`)
 - Improved performance of :func:`MultiIndex.get_loc` for large indexes, at the cost of a reduction in performance for small ones (:issue:`18519`)
-
+- Improved performance of pairwise ``.rolling()`` and ``.expanding()`` with ``.cov()`` and ``.corr()`` operations (:issue:`17917`)
 
 .. _whatsnew_0230.docs:
 

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -1102,6 +1102,11 @@ class Index(IndexOpsMixin, PandasObject):
     def nlevels(self):
         return 1
 
+    @property
+    def levels(self):
+        """ return a list my levels """
+        return [list(self)]
+
     def _get_names(self):
         return FrozenList((self.name, ))
 

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -1102,11 +1102,6 @@ class Index(IndexOpsMixin, PandasObject):
     def nlevels(self):
         return 1
 
-    @property
-    def levels(self):
-        """ return a list my levels """
-        return [list(self)]
-
     def _get_names(self):
         return FrozenList((self.name, ))
 

--- a/pandas/core/reshape/pivot.py
+++ b/pandas/core/reshape/pivot.py
@@ -99,19 +99,15 @@ def pivot_table(data, values=None, index=None, columns=None, aggfunc='mean',
 
     if not dropna:
         from pandas import MultiIndex
-        try:
+        if table.index.nlevels > 1:
             m = MultiIndex.from_arrays(cartesian_product(table.index.levels),
                                        names=table.index.names)
             table = table.reindex(m, axis=0)
-        except AttributeError:
-            pass  # it's a single level
 
-        try:
+        if table.columns.nlevels > 1:
             m = MultiIndex.from_arrays(cartesian_product(table.columns.levels),
                                        names=table.columns.names)
             table = table.reindex(m, axis=1)
-        except AttributeError:
-            pass  # it's a single level or a series
 
     if isinstance(table, ABCDataFrame):
         table = table.sort_index(axis=1)

--- a/pandas/core/window.py
+++ b/pandas/core/window.py
@@ -1881,7 +1881,7 @@ def _flex_binary_moment(arg1, arg2, f, pairwise=False):
                     # set the index and reorder
                     if arg2.columns.nlevels > 1:
                         result.index = MultiIndex.from_product(
-                            arg2.columns.levels + result_index.levels)
+                            arg2.columns.levels + [result_index])
                         result = result.reorder_levels([2, 0, 1]).sort_index()
                     else:
                         result.index = MultiIndex.from_product(
@@ -1889,7 +1889,7 @@ def _flex_binary_moment(arg1, arg2, f, pairwise=False):
                              range(len(result_index))])
                         result = result.swaplevel(1, 0).sort_index()
                         result.index = MultiIndex.from_product(
-                            result_index.levels + arg2.columns.levels)
+                            [result_index] + [arg2.columns])
                 else:
 
                     # empty result


### PR DESCRIPTION
closes #17917

```
    before     after       ratio
  [aa9e0024] [872fe711]
-     1.70s    16.02ms      0.01  rolling.Pairwise.time_pairwise(None, 'corr', True)
-     1.84s    17.12ms      0.01  rolling.Pairwise.time_pairwise(10, 'corr', True)
-     1.84s    16.98ms      0.01  rolling.Pairwise.time_pairwise(1000, 'corr', True)
-     1.74s    15.59ms      0.01  rolling.Pairwise.time_pairwise(None, 'cov', True)
-     1.77s    15.63ms      0.01  rolling.Pairwise.time_pairwise(1000, 'cov', True)
-     1.83s    14.62ms      0.01  rolling.Pairwise.time_pairwise(10, 'cov', True)
```