### PR TITLE
move panel-specific swaplevel to panel

### DIFF
--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -720,31 +720,6 @@ class NDFrame(PandasObject, SelectionMixin):
         except Exception:
             return self
 
-    def swaplevel(self, i=-2, j=-1, axis=0):
-        """
-        Swap levels i and j in a MultiIndex on a particular axis
-
-        Parameters
-        ----------
-        i, j : int, string (can be mixed)
-            Level of index to be swapped. Can pass level name as string.
-
-        Returns
-        -------
-        swapped : type of caller (new object)
-
-        .. versionchanged:: 0.18.1
-
-           The indexes ``i`` and ``j`` are now optional, and default to
-           the two innermost levels of the index.
-
-        """
-        axis = self._get_axis_number(axis)
-        result = self.copy()
-        labels = result._data.axes[axis]
-        result._data.set_axis(axis, labels.swaplevel(i, j))
-        return result
-
     # ----------------------------------------------------------------------
     # Rename
 

--- a/pandas/core/panel.py
+++ b/pandas/core/panel.py
@@ -1241,6 +1241,31 @@ class Panel(NDFrame):
                                                copy=copy, limit=limit,
                                                fill_value=fill_value)
 
+    def swaplevel(self, i=-2, j=-1, axis=0):
+        """
+        Swap levels i and j in a MultiIndex on a particular axis
+
+        Parameters
+        ----------
+        i, j : int, string (can be mixed)
+            Level of index to be swapped. Can pass level name as string.
+
+        Returns
+        -------
+        swapped : type of caller (new object)
+
+        .. versionchanged:: 0.18.1
+
+           The indexes ``i`` and ``j`` are now optional, and default to
+           the two innermost levels of the index.
+
+        """
+        axis = self._get_axis_number(axis)
+        result = self.copy()
+        labels = result._data.axes[axis]
+        result._data.set_axis(axis, labels.swaplevel(i, j))
+        return result
+
     @Appender(_shared_docs['transpose'] % _shared_doc_kwargs)
     def transpose(self, *args, **kwargs):
         # check if a list of axes was passed in instead as a


### PR DESCRIPTION
NDFrame.swaplevel is overriden by both Series and DataFrame, so in practice the "generic" implementation is specific to Panel.  This PR just moves the method from NDFrame to Panel.

- [ ] closes #xxxx
- [ ] tests added / passed
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
