### PR TITLE
DOC: corrects Expanding min_periods default in docstring 

### DIFF
--- a/pandas/core/window.py
+++ b/pandas/core/window.py
@@ -1286,7 +1286,7 @@ class Expanding(_Rolling_and_Expanding):
 
     Parameters
     ----------
-    min_periods : int, default None
+    min_periods : int, default 1
         Minimum number of observations in window required to have a value
         (otherwise result is NA).
     center : boolean, default False


### PR DESCRIPTION
Currently the doc string says the ``min_periods`` default is ``None``, while it in the code actually is 1.

This PR fixes this.