### PR TITLE
Remove unused fastpath kwarg from Blocks

### DIFF
--- a/pandas/core/internals.py
+++ b/pandas/core/internals.py
@@ -226,7 +226,6 @@ class Block(PandasObject):
         """ Wrap given values in a block of same type as self. """
         if placement is None:
             placement = self.mgr_locs
-        # TODO: Why not set default for ndim like we do for self.make_block?
         return make_block(values, placement=placement, ndim=ndim,
                           klass=self.__class__)
 

--- a/pandas/core/internals.py
+++ b/pandas/core/internals.py
@@ -4737,8 +4737,7 @@ def form_blocks(arrays, names, axes):
         blocks.extend(sparse_blocks)
 
     if len(items_dict['CategoricalBlock']) > 0:
-        cat_blocks = [make_block(array, klass=CategoricalBlock,
-                                 placement=[i])
+        cat_blocks = [make_block(array, klass=CategoricalBlock, placement=[i])
                       for i, _, array in items_dict['CategoricalBlock']]
         blocks.extend(cat_blocks)
 

--- a/pandas/tests/internals/test_internals.py
+++ b/pandas/tests/internals/test_internals.py
@@ -1254,3 +1254,11 @@ class TestCanHoldElement(object):
         result = op(s, e).dtypes
         expected = op(s, value).dtypes
         assert_series_equal(result, expected)
+
+
+def test_deprecated_fastpath():
+    # GH#19265
+    values = np.random.rand(3, 3)
+    with tm.assert_produces_warning(DeprecationWarning,
+                                    check_stacklevel=False):
+        make_block(values, placement=np.arange(3), fastpath=True)


### PR DESCRIPTION
The `fastpath` kwarg in `Block.__init__` must be vestigial or something.  It isn't used anywhere in the blocks themselves.  This PR removes the unused kwarg.