### PR TITLE
TST: Clean up DataFrame.to_csv compression tests

### DIFF
--- a/pandas/tests/conftest.py
+++ b/pandas/tests/conftest.py
@@ -1,0 +1,12 @@
+import pytest
+import pandas
+import pandas.util._test_decorators as td
+
+
+@pytest.fixture(params=[None, 'gzip', 'bz2',
+                        pytest.param('xz', marks=td.skip_if_no_lzma)])
+def compression(request):
+    """
+    Fixture for trying common compression types in compression tests
+    """
+    return request.param

--- a/pandas/tests/conftest.py
+++ b/pandas/tests/conftest.py
@@ -1,5 +1,4 @@
 import pytest
-import pandas
 import pandas.util._test_decorators as td
 
 

--- a/pandas/tests/frame/test_to_csv.py
+++ b/pandas/tests/frame/test_to_csv.py
@@ -949,7 +949,6 @@ class TestDataFrameToCSV(TestData):
 
             f = tm.decompress_file(filename, compression)
             assert_frame_equal(df, read_csv(f, index_col=0))
-            f.close()
 
     def test_to_csv_compression_value_error(self):
         # GH7615

--- a/pandas/tests/frame/test_to_csv.py
+++ b/pandas/tests/frame/test_to_csv.py
@@ -21,7 +21,6 @@ from pandas.util.testing import (assert_almost_equal,
                                  ensure_clean,
                                  makeCustomDataframe as mkdf)
 import pandas.util.testing as tm
-import pandas.util._test_decorators as td
 
 from pandas.tests.frame.common import TestData
 

--- a/pandas/tests/io/parser/test_network.py
+++ b/pandas/tests/io/parser/test_network.py
@@ -15,15 +15,17 @@ from pandas.compat import BytesIO
 
 @pytest.mark.network
 @pytest.mark.parametrize(
-    "compression,extension", [
+    "compress_type, extension", [
         ('gzip', '.gz'), ('bz2', '.bz2'), ('zip', '.zip'),
         pytest.param('xz', '.xz', marks=td.skip_if_no_lzma)
     ]
 )
 @pytest.mark.parametrize('mode', ['explicit', 'infer'])
 @pytest.mark.parametrize('engine', ['python', 'c'])
-def test_compressed_urls(salaries_table, compression, extension, mode, engine):
-    check_compressed_urls(salaries_table, compression, extension, mode, engine)
+def test_compressed_urls(salaries_table, compress_type, extension, mode,
+                         engine):
+    check_compressed_urls(salaries_table, compress_type, extension, mode,
+                          engine)
 
 
 @tm.network

--- a/pandas/tests/series/test_io.py
+++ b/pandas/tests/series/test_io.py
@@ -139,12 +139,6 @@ class TestSeriesToCSV(TestData):
         csv_str = s.to_csv(path=None)
         assert isinstance(csv_str, str)
 
-    @pytest.mark.parametrize('compression', [
-        None,
-        'gzip',
-        'bz2',
-        pytest.param('xz', marks=td.skip_if_no_lzma),
-    ])
     def test_to_csv_compression(self, compression):
 
         s = Series([0.123456, 0.234567, 0.567567], index=['A', 'B', 'C'],
@@ -160,14 +154,13 @@ class TestSeriesToCSV(TestData):
             assert_series_equal(s, rs)
 
             # explicitly ensure file was compressed
-            f = tm.decompress_file(filename, compression=compression)
-            text = f.read().decode('utf8')
-            assert s.name in text
-            f.close()
+            with tm.decompress_file(filename, compression=compression) as fh:
+                text = fh.read().decode('utf8')
+                assert s.name in text
 
-            f = tm.decompress_file(filename, compression=compression)
-            assert_series_equal(s, pd.read_csv(f, index_col=0, squeeze=True))
-            f.close()
+            with tm.decompress_file(filename, compression=compression) as fh:
+                assert_series_equal(s, pd.read_csv(fh,
+                                                   index_col=0, squeeze=True))
 
 
 class TestSeriesIO(TestData):

--- a/pandas/tests/series/test_io.py
+++ b/pandas/tests/series/test_io.py
@@ -14,7 +14,6 @@ from pandas.compat import StringIO, u
 from pandas.util.testing import (assert_series_equal, assert_almost_equal,
                                  assert_frame_equal, ensure_clean)
 import pandas.util.testing as tm
-import pandas.util._test_decorators as td
 
 from .common import TestData
 

--- a/pandas/util/testing.py
+++ b/pandas/util/testing.py
@@ -162,6 +162,7 @@ def round_trip_localpath(writer, reader, path=None):
     return obj
 
 
+@contextmanager
 def decompress_file(path, compression):
     """
     Open a compressed file and return a file object
@@ -194,7 +195,7 @@ def decompress_file(path, compression):
         msg = 'Unrecognized compression type: {}'.format(compression)
         raise ValueError(msg)
 
-    return f
+    yield f
 
 
 def assert_almost_equal(left, right, check_exact=False,


### PR DESCRIPTION
xref #19226 

Parametrized some of the compression tests in ``tests/frame/test_to_csv.py`` and used the new ``decompress_file`` function.