### PR TITLE
remove unused block attribute

### DIFF
--- a/pandas/core/internals.py
+++ b/pandas/core/internals.py
@@ -97,7 +97,6 @@ class Block(PandasObject):
     is_sparse = False
     _box_to_block_values = True
     _can_hold_na = False
-    _downcast_dtype = None
     _can_consolidate = True
     _verify_integrity = True
     _validate_ndim = True
@@ -1841,7 +1840,6 @@ class FloatOrComplexBlock(NumericBlock):
 class FloatBlock(FloatOrComplexBlock):
     __slots__ = ()
     is_float = True
-    _downcast_dtype = 'int64'
 
     def _can_hold_element(self, element):
         tipo = maybe_infer_dtype_type(element)


### PR DESCRIPTION
grepping across the code, `_downcast_dtype` doesn't show up anywhere else.

- [ ] closes #xxxx
- [ ] tests added / passed
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
