### PR TITLE
DOC: add missing period to DataFrame docstring

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -250,7 +250,7 @@ class DataFrame(NDFrame):
     """ Two-dimensional size-mutable, potentially heterogeneous tabular data
     structure with labeled axes (rows and columns). Arithmetic operations
     align on both row and column labels. Can be thought of as a dict-like
-    container for Series objects. The primary pandas data structure
+    container for Series objects. The primary pandas data structure.
 
     Parameters
     ----------


### PR DESCRIPTION
- [x] closes #19141 

Went ahead and did this one manually. Working on a regex that will apply this to all docstrings in general and will make a new PR when it's ready.



