### PR TITLE
Bug: adds support for unary plus

### DIFF
--- a/doc/source/whatsnew/v0.23.0.txt
+++ b/doc/source/whatsnew/v0.23.0.txt
@@ -253,6 +253,7 @@ Current Behavior:
 Other Enhancements
 ^^^^^^^^^^^^^^^^^^
 
+- Unary ``+`` now permitted for ``Series`` and ``DataFrame`` as  numeric operator (:issue:`16073`)
 - Better support for :func:`Dataframe.style.to_excel` output with the ``xlsxwriter`` engine. (:issue:`16149`)
 - :func:`pandas.tseries.frequencies.to_offset` now accepts leading '+' signs e.g. '+1h'. (:issue:`18171`)
 - :func:`MultiIndex.unique` now supports the ``level=`` argument, to get unique values from a specific index level (:issue:`17896`)
@@ -463,7 +464,6 @@ To restore previous behavior, simply set ``expand`` to ``False``:
 Other API Changes
 ^^^^^^^^^^^^^^^^^
 
-- Unary ``+`` operator now permitted for ``Series`` and ``DataFrame`` (:issue:`16073`)
 - :func:`Series.astype` and :func:`Index.astype` with an incompatible dtype will now raise a ``TypeError`` rather than a ``ValueError`` (:issue:`18231`)
 - ``Series`` construction with an ``object`` dtyped tz-aware datetime and ``dtype=object`` specified, will now return an ``object`` dtyped ``Series``, previously this would infer the datetime dtype (:issue:`18231`)
 - A :class:`Series` of ``dtype=category`` constructed from an empty ``dict`` will now have categories of ``dtype=object`` rather than ``dtype=float64``, consistently with the case in which an empty list is passed (:issue:`18515`)

--- a/doc/source/whatsnew/v0.23.0.txt
+++ b/doc/source/whatsnew/v0.23.0.txt
@@ -463,6 +463,7 @@ To restore previous behavior, simply set ``expand`` to ``False``:
 Other API Changes
 ^^^^^^^^^^^^^^^^^
 
+- Unary ``+`` operator now permitted for ``Series`` and ``DataFrame`` (:issue:`16073`)
 - :func:`Series.astype` and :func:`Index.astype` with an incompatible dtype will now raise a ``TypeError`` rather than a ``ValueError`` (:issue:`18231`)
 - ``Series`` construction with an ``object`` dtyped tz-aware datetime and ``dtype=object`` specified, will now return an ``object`` dtyped ``Series``, previously this would infer the datetime dtype (:issue:`18231`)
 - A :class:`Series` of ``dtype=category`` constructed from an empty ``dict`` will now have categories of ``dtype=object`` rather than ``dtype=float64``, consistently with the case in which an empty list is passed (:issue:`18515`)

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -1029,8 +1029,22 @@ class NDFrame(PandasObject, SelectionMixin):
         values = com._values_from_object(self)
         if values.dtype == np.bool_:
             arr = operator.inv(values)
-        else:
+        elif (is_numeric_dtype(values) or is_timedelta64_dtype(values)):
             arr = operator.neg(values)
+        else:
+            raise TypeError("Unary negative expects numeric dtype, not {}"
+                            .format(values.dtype))
+        return self.__array_wrap__(arr)
+
+    def __pos__(self):
+        values = _values_from_object(self)
+        if values.dtype == np.bool_:
+            arr = values
+        elif (is_numeric_dtype(values) or is_timedelta64_dtype(values)):
+            arr = operator.pos(values)
+        else:
+            raise TypeError("Unary plus expects numeric dtype, not {}"
+                            .format(values.dtype))
         return self.__array_wrap__(arr)
 
     def __invert__(self):

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -1026,7 +1026,7 @@ class NDFrame(PandasObject, SelectionMixin):
                    for a in self._AXIS_ORDERS)
 
     def __neg__(self):
-        values = _values_from_object(self)
+        values = com._values_from_object(self)
         if is_bool_dtype(values):
             arr = operator.inv(values)
         elif (is_numeric_dtype(values) or is_timedelta64_dtype(values)):
@@ -1037,7 +1037,7 @@ class NDFrame(PandasObject, SelectionMixin):
         return self.__array_wrap__(arr)
 
     def __pos__(self):
-        values = _values_from_object(self)
+        values = com._values_from_object(self)
         if is_bool_dtype(values):
             arr = values
         elif (is_numeric_dtype(values) or is_timedelta64_dtype(values)):

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -25,6 +25,7 @@ from pandas.core.dtypes.common import (
     is_list_like,
     is_dict_like,
     is_re_compilable,
+    is_period_arraylike,
     pandas_dtype)
 from pandas.core.dtypes.cast import maybe_promote, maybe_upcast_putmask
 from pandas.core.dtypes.inference import is_hashable
@@ -1038,7 +1039,7 @@ class NDFrame(PandasObject, SelectionMixin):
 
     def __pos__(self):
         values = com._values_from_object(self)
-        if is_bool_dtype(values):
+        if (is_bool_dtype(values) or is_period_arraylike(values)):
             arr = values
         elif (is_numeric_dtype(values) or is_timedelta64_dtype(values)):
             arr = operator.pos(values)

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -1026,8 +1026,8 @@ class NDFrame(PandasObject, SelectionMixin):
                    for a in self._AXIS_ORDERS)
 
     def __neg__(self):
-        values = com._values_from_object(self)
-        if values.dtype == np.bool_:
+        values = _values_from_object(self)
+        if is_bool_dtype(values):
             arr = operator.inv(values)
         elif (is_numeric_dtype(values) or is_timedelta64_dtype(values)):
             arr = operator.neg(values)
@@ -1038,7 +1038,7 @@ class NDFrame(PandasObject, SelectionMixin):
 
     def __pos__(self):
         values = _values_from_object(self)
-        if values.dtype == np.bool_:
+        if is_bool_dtype(values):
             arr = values
         elif (is_numeric_dtype(values) or is_timedelta64_dtype(values)):
             arr = operator.pos(values)

--- a/pandas/tests/computation/test_eval.py
+++ b/pandas/tests/computation/test_eval.py
@@ -542,66 +542,42 @@ class TestEvalNumexprPandas(object):
 
         # float
         lhs = DataFrame(randn(5, 2))
-        if self.engine == 'python':
-            with pytest.raises(TypeError):
-                result = pd.eval(expr, engine=self.engine, parser=self.parser)
-        else:
-            expect = lhs
-            result = pd.eval(expr, engine=self.engine, parser=self.parser)
-            assert_frame_equal(expect, result)
+        expect = lhs
+        result = pd.eval(expr, engine=self.engine, parser=self.parser)
+        assert_frame_equal(expect, result)
 
         # int
         lhs = DataFrame(randint(5, size=(5, 2)))
-        if self.engine == 'python':
-            with pytest.raises(TypeError):
-                result = pd.eval(expr, engine=self.engine, parser=self.parser)
-        else:
-            expect = lhs
-            result = pd.eval(expr, engine=self.engine, parser=self.parser)
-            assert_frame_equal(expect, result)
+        expect = lhs
+        result = pd.eval(expr, engine=self.engine, parser=self.parser)
+        assert_frame_equal(expect, result)
 
         # bool doesn't work with numexpr but works elsewhere
         lhs = DataFrame(rand(5, 2) > 0.5)
-        if self.engine == 'python':
-            with pytest.raises(TypeError):
-                result = pd.eval(expr, engine=self.engine, parser=self.parser)
-        else:
-            expect = lhs
-            result = pd.eval(expr, engine=self.engine, parser=self.parser)
-            assert_frame_equal(expect, result)
+        expect = lhs
+        result = pd.eval(expr, engine=self.engine, parser=self.parser)
+        assert_frame_equal(expect, result)
 
     def test_series_pos(self):
         expr = self.ex('+')
 
         # float
         lhs = Series(randn(5))
-        if self.engine == 'python':
-            with pytest.raises(TypeError):
-                result = pd.eval(expr, engine=self.engine, parser=self.parser)
-        else:
-            expect = lhs
-            result = pd.eval(expr, engine=self.engine, parser=self.parser)
-            assert_series_equal(expect, result)
+        expect = lhs
+        result = pd.eval(expr, engine=self.engine, parser=self.parser)
+        assert_series_equal(expect, result)
 
         # int
         lhs = Series(randint(5, size=5))
-        if self.engine == 'python':
-            with pytest.raises(TypeError):
-                result = pd.eval(expr, engine=self.engine, parser=self.parser)
-        else:
-            expect = lhs
-            result = pd.eval(expr, engine=self.engine, parser=self.parser)
-            assert_series_equal(expect, result)
+        expect = lhs
+        result = pd.eval(expr, engine=self.engine, parser=self.parser)
+        assert_series_equal(expect, result)
 
         # bool doesn't work with numexpr but works elsewhere
         lhs = Series(rand(5) > 0.5)
-        if self.engine == 'python':
-            with pytest.raises(TypeError):
-                result = pd.eval(expr, engine=self.engine, parser=self.parser)
-        else:
-            expect = lhs
-            result = pd.eval(expr, engine=self.engine, parser=self.parser)
-            assert_series_equal(expect, result)
+        expect = lhs
+        result = pd.eval(expr, engine=self.engine, parser=self.parser)
+        assert_series_equal(expect, result)
 
     def test_scalar_unary(self):
         with pytest.raises(TypeError):

--- a/pandas/tests/frame/test_arithmetic.py
+++ b/pandas/tests/frame/test_arithmetic.py
@@ -245,7 +245,7 @@ class TestPeriodFrameArithmetic(object):
         exp = pd.DataFrame({'A': np.array([2, 1], dtype=object),
                             'B': np.array([14, 13], dtype=object)})
         tm.assert_frame_equal(p - df, exp)
-        tm.assert_frame_equal(df - p, -exp)
+        tm.assert_frame_equal(df - p, -1 * exp)
 
         df2 = pd.DataFrame({'A': [pd.Period('2015-05', freq='M'),
                                   pd.Period('2015-06', freq='M')],
@@ -257,4 +257,4 @@ class TestPeriodFrameArithmetic(object):
         exp = pd.DataFrame({'A': np.array([4, 4], dtype=object),
                             'B': np.array([16, 16], dtype=object)})
         tm.assert_frame_equal(df2 - df, exp)
-        tm.assert_frame_equal(df - df2, -exp)
+        tm.assert_frame_equal(df - df2, -1 * exp)

--- a/pandas/tests/frame/test_operators.py
+++ b/pandas/tests/frame/test_operators.py
@@ -272,11 +272,12 @@ class TestDataFrameOperators(TestData):
         assert_series_equal(result, expected)
 
     @pytest.mark.parametrize('df,expected', [
-        (pd.DataFrame({'a': [-1, 1]}), pd.DataFrame({'a': [1, -1],})),
-        (pd.DataFrame({'a': [False, True]}), pd.DataFrame({'a': [True, False]})),
+        (pd.DataFrame({'a': [-1, 1]}), pd.DataFrame({'a': [1, -1]})),
+        (pd.DataFrame({'a': [False, True]}),
+            pd.DataFrame({'a': [True, False]})),
         (pd.DataFrame({'a': pd.Series(pd.to_timedelta([-1, 1]))}),
             pd.DataFrame({'a': pd.Series(pd.to_timedelta([1, -1]))}))
-        ])
+    ])
     def test_neg_numeric(self, df, expected):
         assert_frame_equal(-df, expected)
         assert_series_equal(-df['a'], expected['a'])

--- a/pandas/tests/frame/test_operators.py
+++ b/pandas/tests/frame/test_operators.py
@@ -272,11 +272,41 @@ class TestDataFrameOperators(TestData):
         assert_series_equal(result, expected)
 
     def test_neg(self):
-        # what to do?
-        assert_frame_equal(-self.frame, -1 * self.frame)
+        numeric = pd.DataFrame({
+            'a': [-1, 0, 1],
+            'b': [1, 0, 1],
+            })
+        boolean = pd.DataFrame({
+            'a': [True, False, True],
+            'b': [False, False, True]
+        })
+        timedelta = pd.Series(pd.to_timedelta([-1, 0, 10]))
+        not_numeric = pd.DataFrame({'string': ['a', 'b', 'c']})
+        assert_frame_equal(-numeric, -1 * numeric)
+        assert_frame_equal(-boolean, ~boolean)
+        assert_series_equal(-timedelta, pd.to_timedelta(-1 * timedelta))
+        with pytest.raises(TypeError):
+            (+ not_numeric)
 
     def test_invert(self):
         assert_frame_equal(-(self.frame < 0), ~(self.frame < 0))
+
+    def test_pos(self):
+        numeric = pd.DataFrame({
+            'a': [-1, 0, 1],
+            'b': [1, 0, 1],
+            })
+        boolean = pd.DataFrame({
+            'a': [True, False, True],
+            'b': [False, False, True]
+        })
+        timedelta = pd.Series(pd.to_timedelta([-1, 0, 10]))
+        not_numeric = pd.DataFrame({'string': ['a', 'b', 'c']})
+        assert_frame_equal(+numeric, +1 * numeric)
+        assert_frame_equal(+boolean, (+1 * boolean).astype(bool))
+        assert_series_equal(+timedelta, pd.to_timedelta(+1 * timedelta))
+        with pytest.raises(TypeError):
+            (+ not_numeric)
 
     def test_arith_flex_frame(self):
         ops = ['add', 'sub', 'mul', 'div', 'truediv', 'pow', 'floordiv', 'mod']

--- a/pandas/tests/frame/test_operators.py
+++ b/pandas/tests/frame/test_operators.py
@@ -275,7 +275,7 @@ class TestDataFrameOperators(TestData):
         numeric = pd.DataFrame({
             'a': [-1, 0, 1],
             'b': [1, 0, 1],
-            })
+        })
         boolean = pd.DataFrame({
             'a': [True, False, True],
             'b': [False, False, True]
@@ -295,7 +295,7 @@ class TestDataFrameOperators(TestData):
         numeric = pd.DataFrame({
             'a': [-1, 0, 1],
             'b': [1, 0, 1],
-            })
+        })
         boolean = pd.DataFrame({
             'a': [True, False, True],
             'b': [False, False, True]

--- a/pandas/tests/frame/test_operators.py
+++ b/pandas/tests/frame/test_operators.py
@@ -271,42 +271,48 @@ class TestDataFrameOperators(TestData):
         expected = Series([True, True])
         assert_series_equal(result, expected)
 
-    def test_neg(self):
-        numeric = pd.DataFrame({
-            'a': [-1, 0, 1],
-            'b': [1, 0, 1],
-        })
-        boolean = pd.DataFrame({
-            'a': [True, False, True],
-            'b': [False, False, True]
-        })
-        timedelta = pd.Series(pd.to_timedelta([-1, 0, 10]))
-        not_numeric = pd.DataFrame({'string': ['a', 'b', 'c']})
-        assert_frame_equal(-numeric, -1 * numeric)
-        assert_frame_equal(-boolean, ~boolean)
-        assert_series_equal(-timedelta, pd.to_timedelta(-1 * timedelta))
+    @pytest.mark.parametrize('df,expected', [
+        (pd.DataFrame({'a': [-1, 1]}), pd.DataFrame({'a': [1, -1],})),
+        (pd.DataFrame({'a': [False, True]}), pd.DataFrame({'a': [True, False]})),
+        (pd.DataFrame({'a': pd.Series(pd.to_timedelta([-1, 1]))}),
+            pd.DataFrame({'a': pd.Series(pd.to_timedelta([1, -1]))}))
+        ])
+    def test_neg_numeric(self, df, expected):
+        assert_frame_equal(-df, expected)
+        assert_series_equal(-df['a'], expected['a'])
+
+    @pytest.mark.parametrize('df', [
+        pd.DataFrame({'a': ['a', 'b']}),
+        pd.DataFrame({'a': pd.to_datetime(['2017-01-22', '1970-01-01'])}),
+    ])
+    def test_neg_raises(self, df):
         with pytest.raises(TypeError):
-            (+ not_numeric)
+            (- df)
+        with pytest.raises(TypeError):
+            (- df['a'])
 
     def test_invert(self):
         assert_frame_equal(-(self.frame < 0), ~(self.frame < 0))
 
-    def test_pos(self):
-        numeric = pd.DataFrame({
-            'a': [-1, 0, 1],
-            'b': [1, 0, 1],
-        })
-        boolean = pd.DataFrame({
-            'a': [True, False, True],
-            'b': [False, False, True]
-        })
-        timedelta = pd.Series(pd.to_timedelta([-1, 0, 10]))
-        not_numeric = pd.DataFrame({'string': ['a', 'b', 'c']})
-        assert_frame_equal(+numeric, +1 * numeric)
-        assert_frame_equal(+boolean, (+1 * boolean).astype(bool))
-        assert_series_equal(+timedelta, pd.to_timedelta(+1 * timedelta))
+    @pytest.mark.parametrize('df', [
+        pd.DataFrame({'a': [-1, 1]}),
+        pd.DataFrame({'a': [False, True]}),
+        pd.DataFrame({'a': pd.Series(pd.to_timedelta([-1, 1]))}),
+    ])
+    def test_pos_numeric(self, df):
+        # GH 16073
+        assert_frame_equal(+df, df)
+        assert_series_equal(+df['a'], df['a'])
+
+    @pytest.mark.parametrize('df', [
+        pd.DataFrame({'a': ['a', 'b']}),
+        pd.DataFrame({'a': pd.to_datetime(['2017-01-22', '1970-01-01'])}),
+    ])
+    def test_pos_raises(self, df):
         with pytest.raises(TypeError):
-            (+ not_numeric)
+            (+ df)
+        with pytest.raises(TypeError):
+            (+ df['a'])
 
     def test_arith_flex_frame(self):
         ops = ['add', 'sub', 'mul', 'div', 'truediv', 'pow', 'floordiv', 'mod']

--- a/pandas/tests/series/test_arithmetic.py
+++ b/pandas/tests/series/test_arithmetic.py
@@ -315,7 +315,7 @@ class TestPeriodSeriesArithmetic(object):
         # dtype will be object because of original dtype
         expected = pd.Series([9, 8], name='xxx', dtype=object)
         tm.assert_series_equal(per - ser, expected)
-        tm.assert_series_equal(ser - per, -expected)
+        tm.assert_series_equal(ser - per, -1 * expected)
 
         s2 = pd.Series([pd.Period('2015-01-05', freq='D'),
                         pd.Period('2015-01-04', freq='D')], name='xxx')
@@ -323,7 +323,7 @@ class TestPeriodSeriesArithmetic(object):
 
         expected = pd.Series([4, 2], name='xxx', dtype=object)
         tm.assert_series_equal(s2 - ser, expected)
-        tm.assert_series_equal(ser - s2, -expected)
+        tm.assert_series_equal(ser - s2, -1 * expected)
 
 
 class TestTimestampSeriesArithmetic(object):


### PR DESCRIPTION
- [ ] closes #16073
- [ ] tests added / passed
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

Adds missing unary plus operator from #16073. Adds typechecking behavior to unary neg, along with tests for both.