### PR TITLE
Remove duplicate is_lexsorted function

### DIFF
--- a/pandas/_libs/lib.pyx
+++ b/pandas/_libs/lib.pyx
@@ -896,38 +896,6 @@ def write_csv_rows(list data, ndarray data_index,
 # ------------------------------------------------------------------------------
 # Groupby-related functions
 
-@cython.wraparound(False)
-@cython.boundscheck(False)
-def is_lexsorted(list list_of_arrays):
-    cdef:
-        int i
-        Py_ssize_t n, nlevels
-        int64_t k, cur, pre
-        ndarray arr
-
-    nlevels = len(list_of_arrays)
-    n = len(list_of_arrays[0])
-
-    cdef int64_t **vecs = <int64_t**> malloc(nlevels * sizeof(int64_t*))
-    for i from 0 <= i < nlevels:
-        arr = list_of_arrays[i]
-        vecs[i] = <int64_t *> arr.data
-
-    # Assume uniqueness??
-    for i from 1 <= i < n:
-        for k from 0 <= k < nlevels:
-            cur = vecs[k][i]
-            pre = vecs[k][i - 1]
-            if cur == pre:
-                continue
-            elif cur > pre:
-                break
-            else:
-                return False
-    free(vecs)
-    return True
-
-
 # TODO: could do even better if we know something about the data. eg, index has
 # 1-min data, binner has 5-min data, then bins are just strides in index. This
 # is a general, O(max(len(values), len(binner))) method.

--- a/pandas/core/indexes/multi.py
+++ b/pandas/core/indexes/multi.py
@@ -5,7 +5,7 @@ import warnings
 from sys import getsizeof
 
 import numpy as np
-from pandas._libs import index as libindex, lib, Timestamp
+from pandas._libs import algos as libalgos, index as libindex, lib, Timestamp
 
 from pandas.compat import range, zip, lrange, lzip, map
 from pandas.compat.numpy import function as nv
@@ -1137,7 +1137,7 @@ class MultiIndex(Index):
 
         int64_labels = [_ensure_int64(lab) for lab in self.labels]
         for k in range(self.nlevels, 0, -1):
-            if lib.is_lexsorted(int64_labels[:k]):
+            if libalgos.is_lexsorted(int64_labels[:k]):
                 return k
 
         return 0


### PR DESCRIPTION
`_libs.lib` and `_libs.algos` have near-identical `is_lexsorted` functions.  The only differences appear to be small optimizations/modernizations in the `algos` version.  AFAICT the `algos` version is only used in `tests.test_algos` ATM.  This PR removes the `libs._lib` version and changes the one usage (in `indexes.multi`) to use the `algos` version.
