### PR TITLE
Centralize and de-duplicate comparison and arith tests

### DIFF
--- a/pandas/tests/frame/test_arithmetic.py
+++ b/pandas/tests/frame/test_arithmetic.py
@@ -1,0 +1,37 @@
+# -*- coding: utf-8 -*-
+
+import numpy as np
+
+import pandas as pd
+import pandas.util.testing as tm
+
+
+class TestPeriodFrameArithmetic(object):
+
+    def test_ops_frame_period(self):
+        # GH 13043
+        df = pd.DataFrame({'A': [pd.Period('2015-01', freq='M'),
+                                 pd.Period('2015-02', freq='M')],
+                           'B': [pd.Period('2014-01', freq='M'),
+                                 pd.Period('2014-02', freq='M')]})
+        assert df['A'].dtype == object
+        assert df['B'].dtype == object
+
+        p = pd.Period('2015-03', freq='M')
+        # dtype will be object because of original dtype
+        exp = pd.DataFrame({'A': np.array([2, 1], dtype=object),
+                            'B': np.array([14, 13], dtype=object)})
+        tm.assert_frame_equal(p - df, exp)
+        tm.assert_frame_equal(df - p, -exp)
+
+        df2 = pd.DataFrame({'A': [pd.Period('2015-05', freq='M'),
+                                  pd.Period('2015-06', freq='M')],
+                            'B': [pd.Period('2015-05', freq='M'),
+                                  pd.Period('2015-06', freq='M')]})
+        assert df2['A'].dtype == object
+        assert df2['B'].dtype == object
+
+        exp = pd.DataFrame({'A': np.array([4, 4], dtype=object),
+                            'B': np.array([16, 16], dtype=object)})
+        tm.assert_frame_equal(df2 - df, exp)
+        tm.assert_frame_equal(df - df2, -exp)

--- a/pandas/tests/indexes/datetimes/test_arithmetic.py
+++ b/pandas/tests/indexes/datetimes/test_arithmetic.py
@@ -1,12 +1,14 @@
 # -*- coding: utf-8 -*-
 import warnings
 from datetime import datetime, timedelta
+import operator
 
 import pytest
 
 import numpy as np
 
 import pandas as pd
+from pandas.compat.numpy import np_datetime64_compat
 import pandas.util.testing as tm
 from pandas.errors import PerformanceWarning
 from pandas import (Timestamp, Timedelta, Series,
@@ -39,6 +41,187 @@ def delta(request):
     ids=lambda x: type(x).__name__)
 def addend(request):
     return request.param
+
+
+class TestDatetimeIndexComparisons(object):
+    # TODO: De-duplicate with test_comparisons_nat below
+    def test_dti_cmp_nat(self):
+        left = pd.DatetimeIndex([pd.Timestamp('2011-01-01'), pd.NaT,
+                                 pd.Timestamp('2011-01-03')])
+        right = pd.DatetimeIndex([pd.NaT, pd.NaT, pd.Timestamp('2011-01-03')])
+
+        for lhs, rhs in [(left, right),
+                         (left.astype(object), right.astype(object))]:
+            result = rhs == lhs
+            expected = np.array([False, False, True])
+            tm.assert_numpy_array_equal(result, expected)
+
+            result = lhs != rhs
+            expected = np.array([True, True, False])
+            tm.assert_numpy_array_equal(result, expected)
+
+            expected = np.array([False, False, False])
+            tm.assert_numpy_array_equal(lhs == pd.NaT, expected)
+            tm.assert_numpy_array_equal(pd.NaT == rhs, expected)
+
+            expected = np.array([True, True, True])
+            tm.assert_numpy_array_equal(lhs != pd.NaT, expected)
+            tm.assert_numpy_array_equal(pd.NaT != lhs, expected)
+
+            expected = np.array([False, False, False])
+            tm.assert_numpy_array_equal(lhs < pd.NaT, expected)
+            tm.assert_numpy_array_equal(pd.NaT > lhs, expected)
+
+    @pytest.mark.parametrize('op', [operator.eq, operator.ne,
+                                    operator.gt, operator.ge,
+                                    operator.lt, operator.le])
+    def test_comparison_tzawareness_compat(self, op):
+        # GH#18162
+        dr = pd.date_range('2016-01-01', periods=6)
+        dz = dr.tz_localize('US/Pacific')
+
+        with pytest.raises(TypeError):
+            op(dr, dz)
+        with pytest.raises(TypeError):
+            op(dr, list(dz))
+        with pytest.raises(TypeError):
+            op(dz, dr)
+        with pytest.raises(TypeError):
+            op(dz, list(dr))
+
+        # Check that there isn't a problem aware-aware and naive-naive do not
+        # raise
+        assert (dr == dr).all()
+        assert (dr == list(dr)).all()
+        assert (dz == dz).all()
+        assert (dz == list(dz)).all()
+
+        # Check comparisons against scalar Timestamps
+        ts = pd.Timestamp('2000-03-14 01:59')
+        ts_tz = pd.Timestamp('2000-03-14 01:59', tz='Europe/Amsterdam')
+
+        assert (dr > ts).all()
+        with pytest.raises(TypeError):
+            op(dr, ts_tz)
+
+        assert (dz > ts_tz).all()
+        with pytest.raises(TypeError):
+            op(dz, ts)
+
+    @pytest.mark.parametrize('op', [operator.eq, operator.ne,
+                                    operator.gt, operator.ge,
+                                    operator.lt, operator.le])
+    def test_nat_comparison_tzawareness(self, op):
+        # GH#19276
+        # tzaware DatetimeIndex should not raise when compared to NaT
+        dti = pd.DatetimeIndex(['2014-01-01', pd.NaT, '2014-03-01', pd.NaT,
+                                '2014-05-01', '2014-07-01'])
+        expected = np.array([op == operator.ne] * len(dti))
+        result = op(dti, pd.NaT)
+        tm.assert_numpy_array_equal(result, expected)
+
+        result = op(dti.tz_localize('US/Pacific'), pd.NaT)
+        tm.assert_numpy_array_equal(result, expected)
+
+    def test_comparisons_coverage(self):
+        rng = date_range('1/1/2000', periods=10)
+
+        # raise TypeError for now
+        pytest.raises(TypeError, rng.__lt__, rng[3].value)
+
+        result = rng == list(rng)
+        exp = rng == rng
+        tm.assert_numpy_array_equal(result, exp)
+
+    def test_comparisons_nat(self):
+
+        fidx1 = pd.Index([1.0, np.nan, 3.0, np.nan, 5.0, 7.0])
+        fidx2 = pd.Index([2.0, 3.0, np.nan, np.nan, 6.0, 7.0])
+
+        didx1 = pd.DatetimeIndex(['2014-01-01', pd.NaT, '2014-03-01', pd.NaT,
+                                  '2014-05-01', '2014-07-01'])
+        didx2 = pd.DatetimeIndex(['2014-02-01', '2014-03-01', pd.NaT, pd.NaT,
+                                  '2014-06-01', '2014-07-01'])
+        darr = np.array([np_datetime64_compat('2014-02-01 00:00Z'),
+                         np_datetime64_compat('2014-03-01 00:00Z'),
+                         np_datetime64_compat('nat'), np.datetime64('nat'),
+                         np_datetime64_compat('2014-06-01 00:00Z'),
+                         np_datetime64_compat('2014-07-01 00:00Z')])
+
+        cases = [(fidx1, fidx2), (didx1, didx2), (didx1, darr)]
+
+        # Check pd.NaT is handles as the same as np.nan
+        with tm.assert_produces_warning(None):
+            for idx1, idx2 in cases:
+
+                result = idx1 < idx2
+                expected = np.array([True, False, False, False, True, False])
+                tm.assert_numpy_array_equal(result, expected)
+
+                result = idx2 > idx1
+                expected = np.array([True, False, False, False, True, False])
+                tm.assert_numpy_array_equal(result, expected)
+
+                result = idx1 <= idx2
+                expected = np.array([True, False, False, False, True, True])
+                tm.assert_numpy_array_equal(result, expected)
+
+                result = idx2 >= idx1
+                expected = np.array([True, False, False, False, True, True])
+                tm.assert_numpy_array_equal(result, expected)
+
+                result = idx1 == idx2
+                expected = np.array([False, False, False, False, False, True])
+                tm.assert_numpy_array_equal(result, expected)
+
+                result = idx1 != idx2
+                expected = np.array([True, True, True, True, True, False])
+                tm.assert_numpy_array_equal(result, expected)
+
+        with tm.assert_produces_warning(None):
+            for idx1, val in [(fidx1, np.nan), (didx1, pd.NaT)]:
+                result = idx1 < val
+                expected = np.array([False, False, False, False, False, False])
+                tm.assert_numpy_array_equal(result, expected)
+                result = idx1 > val
+                tm.assert_numpy_array_equal(result, expected)
+
+                result = idx1 <= val
+                tm.assert_numpy_array_equal(result, expected)
+                result = idx1 >= val
+                tm.assert_numpy_array_equal(result, expected)
+
+                result = idx1 == val
+                tm.assert_numpy_array_equal(result, expected)
+
+                result = idx1 != val
+                expected = np.array([True, True, True, True, True, True])
+                tm.assert_numpy_array_equal(result, expected)
+
+        # Check pd.NaT is handles as the same as np.nan
+        with tm.assert_produces_warning(None):
+            for idx1, val in [(fidx1, 3), (didx1, datetime(2014, 3, 1))]:
+                result = idx1 < val
+                expected = np.array([True, False, False, False, False, False])
+                tm.assert_numpy_array_equal(result, expected)
+                result = idx1 > val
+                expected = np.array([False, False, False, False, True, True])
+                tm.assert_numpy_array_equal(result, expected)
+
+                result = idx1 <= val
+                expected = np.array([True, False, True, False, False, False])
+                tm.assert_numpy_array_equal(result, expected)
+                result = idx1 >= val
+                expected = np.array([False, False, True, False, True, True])
+                tm.assert_numpy_array_equal(result, expected)
+
+                result = idx1 == val
+                expected = np.array([False, False, True, False, False, False])
+                tm.assert_numpy_array_equal(result, expected)
+
+                result = idx1 != val
+                expected = np.array([True, True, False, True, True, True])
+                tm.assert_numpy_array_equal(result, expected)
 
 
 class TestDatetimeIndexArithmetic(object):

--- a/pandas/tests/indexes/datetimes/test_datetime.py
+++ b/pandas/tests/indexes/datetimes/test_datetime.py
@@ -1,4 +1,3 @@
-import operator
 
 import pytest
 
@@ -9,7 +8,6 @@ import dateutil
 import pandas as pd
 import pandas.util.testing as tm
 from pandas.compat import lrange
-from pandas.compat.numpy import np_datetime64_compat
 from pandas import (DatetimeIndex, Index, date_range, DataFrame,
                     Timestamp, offsets)
 
@@ -249,157 +247,6 @@ class TestDatetimeIndex(object):
 
         # it works
         rng.join(idx, how='outer')
-
-    @pytest.mark.parametrize('op', [operator.eq, operator.ne,
-                                    operator.gt, operator.ge,
-                                    operator.lt, operator.le])
-    def test_comparison_tzawareness_compat(self, op):
-        # GH#18162
-        dr = pd.date_range('2016-01-01', periods=6)
-        dz = dr.tz_localize('US/Pacific')
-
-        with pytest.raises(TypeError):
-            op(dr, dz)
-        with pytest.raises(TypeError):
-            op(dr, list(dz))
-        with pytest.raises(TypeError):
-            op(dz, dr)
-        with pytest.raises(TypeError):
-            op(dz, list(dr))
-
-        # Check that there isn't a problem aware-aware and naive-naive do not
-        # raise
-        assert (dr == dr).all()
-        assert (dr == list(dr)).all()
-        assert (dz == dz).all()
-        assert (dz == list(dz)).all()
-
-        # Check comparisons against scalar Timestamps
-        ts = pd.Timestamp('2000-03-14 01:59')
-        ts_tz = pd.Timestamp('2000-03-14 01:59', tz='Europe/Amsterdam')
-
-        assert (dr > ts).all()
-        with pytest.raises(TypeError):
-            op(dr, ts_tz)
-
-        assert (dz > ts_tz).all()
-        with pytest.raises(TypeError):
-            op(dz, ts)
-
-    @pytest.mark.parametrize('op', [operator.eq, operator.ne,
-                                    operator.gt, operator.ge,
-                                    operator.lt, operator.le])
-    def test_nat_comparison_tzawareness(self, op):
-        # GH#19276
-        # tzaware DatetimeIndex should not raise when compared to NaT
-        dti = pd.DatetimeIndex(['2014-01-01', pd.NaT, '2014-03-01', pd.NaT,
-                                '2014-05-01', '2014-07-01'])
-        expected = np.array([op == operator.ne] * len(dti))
-        result = op(dti, pd.NaT)
-        tm.assert_numpy_array_equal(result, expected)
-
-        result = op(dti.tz_localize('US/Pacific'), pd.NaT)
-        tm.assert_numpy_array_equal(result, expected)
-
-    def test_comparisons_coverage(self):
-        rng = date_range('1/1/2000', periods=10)
-
-        # raise TypeError for now
-        pytest.raises(TypeError, rng.__lt__, rng[3].value)
-
-        result = rng == list(rng)
-        exp = rng == rng
-        tm.assert_numpy_array_equal(result, exp)
-
-    def test_comparisons_nat(self):
-
-        fidx1 = pd.Index([1.0, np.nan, 3.0, np.nan, 5.0, 7.0])
-        fidx2 = pd.Index([2.0, 3.0, np.nan, np.nan, 6.0, 7.0])
-
-        didx1 = pd.DatetimeIndex(['2014-01-01', pd.NaT, '2014-03-01', pd.NaT,
-                                  '2014-05-01', '2014-07-01'])
-        didx2 = pd.DatetimeIndex(['2014-02-01', '2014-03-01', pd.NaT, pd.NaT,
-                                  '2014-06-01', '2014-07-01'])
-        darr = np.array([np_datetime64_compat('2014-02-01 00:00Z'),
-                         np_datetime64_compat('2014-03-01 00:00Z'),
-                         np_datetime64_compat('nat'), np.datetime64('nat'),
-                         np_datetime64_compat('2014-06-01 00:00Z'),
-                         np_datetime64_compat('2014-07-01 00:00Z')])
-
-        cases = [(fidx1, fidx2), (didx1, didx2), (didx1, darr)]
-
-        # Check pd.NaT is handles as the same as np.nan
-        with tm.assert_produces_warning(None):
-            for idx1, idx2 in cases:
-
-                result = idx1 < idx2
-                expected = np.array([True, False, False, False, True, False])
-                tm.assert_numpy_array_equal(result, expected)
-
-                result = idx2 > idx1
-                expected = np.array([True, False, False, False, True, False])
-                tm.assert_numpy_array_equal(result, expected)
-
-                result = idx1 <= idx2
-                expected = np.array([True, False, False, False, True, True])
-                tm.assert_numpy_array_equal(result, expected)
-
-                result = idx2 >= idx1
-                expected = np.array([True, False, False, False, True, True])
-                tm.assert_numpy_array_equal(result, expected)
-
-                result = idx1 == idx2
-                expected = np.array([False, False, False, False, False, True])
-                tm.assert_numpy_array_equal(result, expected)
-
-                result = idx1 != idx2
-                expected = np.array([True, True, True, True, True, False])
-                tm.assert_numpy_array_equal(result, expected)
-
-        with tm.assert_produces_warning(None):
-            for idx1, val in [(fidx1, np.nan), (didx1, pd.NaT)]:
-                result = idx1 < val
-                expected = np.array([False, False, False, False, False, False])
-                tm.assert_numpy_array_equal(result, expected)
-                result = idx1 > val
-                tm.assert_numpy_array_equal(result, expected)
-
-                result = idx1 <= val
-                tm.assert_numpy_array_equal(result, expected)
-                result = idx1 >= val
-                tm.assert_numpy_array_equal(result, expected)
-
-                result = idx1 == val
-                tm.assert_numpy_array_equal(result, expected)
-
-                result = idx1 != val
-                expected = np.array([True, True, True, True, True, True])
-                tm.assert_numpy_array_equal(result, expected)
-
-        # Check pd.NaT is handles as the same as np.nan
-        with tm.assert_produces_warning(None):
-            for idx1, val in [(fidx1, 3), (didx1, datetime(2014, 3, 1))]:
-                result = idx1 < val
-                expected = np.array([True, False, False, False, False, False])
-                tm.assert_numpy_array_equal(result, expected)
-                result = idx1 > val
-                expected = np.array([False, False, False, False, True, True])
-                tm.assert_numpy_array_equal(result, expected)
-
-                result = idx1 <= val
-                expected = np.array([True, False, True, False, False, False])
-                tm.assert_numpy_array_equal(result, expected)
-                result = idx1 >= val
-                expected = np.array([False, False, True, False, True, True])
-                tm.assert_numpy_array_equal(result, expected)
-
-                result = idx1 == val
-                expected = np.array([False, False, True, False, False, False])
-                tm.assert_numpy_array_equal(result, expected)
-
-                result = idx1 != val
-                expected = np.array([True, True, False, True, True, True])
-                tm.assert_numpy_array_equal(result, expected)
 
     def test_map(self):
         rng = date_range('1/1/2000', periods=10)

--- a/pandas/tests/indexes/datetimes/test_datetimelike.py
+++ b/pandas/tests/indexes/datetimes/test_datetimelike.py
@@ -21,28 +21,7 @@ class TestDatetimeIndex(DatetimeLike):
         return date_range('20130101', periods=5)
 
     def test_shift(self):
-
-        # test shift for datetimeIndex and non datetimeIndex
-        # GH8083
-
-        drange = self.create_index()
-        result = drange.shift(1)
-        expected = DatetimeIndex(['2013-01-02', '2013-01-03', '2013-01-04',
-                                  '2013-01-05',
-                                  '2013-01-06'], freq='D')
-        tm.assert_index_equal(result, expected)
-
-        result = drange.shift(-1)
-        expected = DatetimeIndex(['2012-12-31', '2013-01-01', '2013-01-02',
-                                  '2013-01-03', '2013-01-04'],
-                                 freq='D')
-        tm.assert_index_equal(result, expected)
-
-        result = drange.shift(3, freq='2D')
-        expected = DatetimeIndex(['2013-01-07', '2013-01-08', '2013-01-09',
-                                  '2013-01-10',
-                                  '2013-01-11'], freq='D')
-        tm.assert_index_equal(result, expected)
+        pass  # handled in test_ops
 
     def test_pickle_compat_construction(self):
         pass

--- a/pandas/tests/indexes/datetimes/test_ops.py
+++ b/pandas/tests/indexes/datetimes/test_ops.py
@@ -385,33 +385,6 @@ class TestDatetimeIndexOps(Ops):
                                     tz=tz)
                 assert idx.resolution == expected
 
-    def test_comp_nat(self):
-        left = pd.DatetimeIndex([pd.Timestamp('2011-01-01'), pd.NaT,
-                                 pd.Timestamp('2011-01-03')])
-        right = pd.DatetimeIndex([pd.NaT, pd.NaT, pd.Timestamp('2011-01-03')])
-
-        for lhs, rhs in [(left, right),
-                         (left.astype(object), right.astype(object))]:
-            result = rhs == lhs
-            expected = np.array([False, False, True])
-            tm.assert_numpy_array_equal(result, expected)
-
-            result = lhs != rhs
-            expected = np.array([True, True, False])
-            tm.assert_numpy_array_equal(result, expected)
-
-            expected = np.array([False, False, False])
-            tm.assert_numpy_array_equal(lhs == pd.NaT, expected)
-            tm.assert_numpy_array_equal(pd.NaT == rhs, expected)
-
-            expected = np.array([True, True, True])
-            tm.assert_numpy_array_equal(lhs != pd.NaT, expected)
-            tm.assert_numpy_array_equal(pd.NaT != lhs, expected)
-
-            expected = np.array([False, False, False])
-            tm.assert_numpy_array_equal(lhs < pd.NaT, expected)
-            tm.assert_numpy_array_equal(pd.NaT > lhs, expected)
-
     def test_value_counts_unique(self):
         # GH 7735
         for tz in self.tz:
@@ -616,6 +589,29 @@ class TestDatetimeIndexOps(Ops):
             exp = pd.DatetimeIndex(['2011-01-01 07:00', '2011-01-01 08:00'
                                     '2011-01-01 09:00'], name='xxx', tz=tz)
             tm.assert_index_equal(idx.shift(-3, freq='H'), exp)
+
+    # TODO: moved from test_datetimelike; de-duplicated with test_shift above
+    def test_shift2(self):
+        # test shift for datetimeIndex and non datetimeIndex
+        # GH8083
+        drange = pd.date_range('20130101', periods=5)
+        result = drange.shift(1)
+        expected = pd.DatetimeIndex(['2013-01-02', '2013-01-03', '2013-01-04',
+                                     '2013-01-05',
+                                     '2013-01-06'], freq='D')
+        tm.assert_index_equal(result, expected)
+
+        result = drange.shift(-1)
+        expected = pd.DatetimeIndex(['2012-12-31', '2013-01-01', '2013-01-02',
+                                     '2013-01-03', '2013-01-04'],
+                                    freq='D')
+        tm.assert_index_equal(result, expected)
+
+        result = drange.shift(3, freq='2D')
+        expected = pd.DatetimeIndex(['2013-01-07', '2013-01-08', '2013-01-09',
+                                     '2013-01-10',
+                                     '2013-01-11'], freq='D')
+        tm.assert_index_equal(result, expected)
 
     def test_nat(self):
         assert pd.DatetimeIndex._na_value is pd.NaT

--- a/pandas/tests/indexes/datetimes/test_ops.py
+++ b/pandas/tests/indexes/datetimes/test_ops.py
@@ -590,7 +590,7 @@ class TestDatetimeIndexOps(Ops):
                                     '2011-01-01 09:00'], name='xxx', tz=tz)
             tm.assert_index_equal(idx.shift(-3, freq='H'), exp)
 
-    # TODO: moved from test_datetimelike; de-duplicated with test_shift above
+    # TODO: moved from test_datetimelike; de-duplicate with test_shift above
     def test_shift2(self):
         # test shift for datetimeIndex and non datetimeIndex
         # GH8083

--- a/pandas/tests/indexes/timedeltas/test_arithmetic.py
+++ b/pandas/tests/indexes/timedeltas/test_arithmetic.py
@@ -279,14 +279,16 @@ class TestTimedeltaIndexArithmetic(object):
         didx = self._holder(np.arange(5, dtype='int64') ** 2)
 
         result = idx * Series(np.arange(5, dtype='int64'))
-        tm.assert_index_equal(result, didx)
+
+        tm.assert_series_equal(result, Series(didx))
  
     def test_mul_float_series(self):
         idx = self._holder(np.arange(5, dtype='int64'))
 
         rng5f = np.arange(5, dtype='float64')
         result = idx * Series(rng5f + 0.1)
-        tm.assert_index_equal(result, self._holder(rng5f * (rng5f + 0.1)))
+        expected = Series(self._holder(rng5f * (rng5f + 0.1)))
+        tm.assert_series_equal(result, expected)
  
     def test_dti_mul_dti_raises(self):
         idx = self._holder(np.arange(5, dtype='int64'))

--- a/pandas/tests/indexes/timedeltas/test_arithmetic.py
+++ b/pandas/tests/indexes/timedeltas/test_arithmetic.py
@@ -243,22 +243,22 @@ class TestTimedeltaIndexArithmetic(object):
         idx = self._holder(np.arange(5, dtype='int64'))
         result = idx * 1
         tm.assert_index_equal(result, idx)
- 
+
     def test_rmul_int(self):
         idx = self._holder(np.arange(5, dtype='int64'))
         result = 1 * idx
         tm.assert_index_equal(result, idx)
- 
+
     def test_div_int(self):
         idx = self._holder(np.arange(5, dtype='int64'))
         result = idx / 1
         tm.assert_index_equal(result, idx)
- 
+
     def test_floordiv_int(self):
         idx = self._holder(np.arange(5, dtype='int64'))
         result = idx // 1
         tm.assert_index_equal(result, idx)
- 
+
     def test_mul_int_array_zerodim(self):
         rng5 = np.arange(5, dtype='int64')
         idx = self._holder(rng5)
@@ -270,10 +270,10 @@ class TestTimedeltaIndexArithmetic(object):
         rng5 = np.arange(5, dtype='int64')
         idx = self._holder(rng5)
         didx = self._holder(rng5 ** 2)
- 
+
         result = idx * rng5
         tm.assert_index_equal(result, didx)
- 
+
     def test_mul_int_series(self):
         idx = self._holder(np.arange(5, dtype='int64'))
         didx = self._holder(np.arange(5, dtype='int64') ** 2)
@@ -281,7 +281,7 @@ class TestTimedeltaIndexArithmetic(object):
         result = idx * Series(np.arange(5, dtype='int64'))
 
         tm.assert_series_equal(result, Series(didx))
- 
+
     def test_mul_float_series(self):
         idx = self._holder(np.arange(5, dtype='int64'))
 
@@ -289,7 +289,7 @@ class TestTimedeltaIndexArithmetic(object):
         result = idx * Series(rng5f + 0.1)
         expected = Series(self._holder(rng5f * (rng5f + 0.1)))
         tm.assert_series_equal(result, expected)
- 
+
     def test_dti_mul_dti_raises(self):
         idx = self._holder(np.arange(5, dtype='int64'))
         with pytest.raises(TypeError):

--- a/pandas/tests/indexes/timedeltas/test_arithmetic.py
+++ b/pandas/tests/indexes/timedeltas/test_arithmetic.py
@@ -26,8 +26,119 @@ def freq(request):
     return request.param
 
 
+class TestTimedeltaIndexComparisons(object):
+    def test_tdi_cmp_str_invalid(self):
+        # GH 13624
+        tdi = TimedeltaIndex(['1 day', '2 days'])
+
+        for l, r in [(tdi, 'a'), ('a', tdi)]:
+            with pytest.raises(TypeError):
+                l > r
+
+            with pytest.raises(TypeError):
+                l == r
+
+            with pytest.raises(TypeError):
+                l != r
+
+    def test_comparisons_coverage(self):
+        rng = timedelta_range('1 days', periods=10)
+
+        result = rng < rng[3]
+        exp = np.array([True, True, True] + [False] * 7)
+        tm.assert_numpy_array_equal(result, exp)
+
+        # raise TypeError for now
+        pytest.raises(TypeError, rng.__lt__, rng[3].value)
+
+        result = rng == list(rng)
+        exp = rng == rng
+        tm.assert_numpy_array_equal(result, exp)
+
+    def test_comp_nat(self):
+        left = pd.TimedeltaIndex([pd.Timedelta('1 days'), pd.NaT,
+                                  pd.Timedelta('3 days')])
+        right = pd.TimedeltaIndex([pd.NaT, pd.NaT, pd.Timedelta('3 days')])
+
+        for lhs, rhs in [(left, right),
+                         (left.astype(object), right.astype(object))]:
+            result = rhs == lhs
+            expected = np.array([False, False, True])
+            tm.assert_numpy_array_equal(result, expected)
+
+            result = rhs != lhs
+            expected = np.array([True, True, False])
+            tm.assert_numpy_array_equal(result, expected)
+
+            expected = np.array([False, False, False])
+            tm.assert_numpy_array_equal(lhs == pd.NaT, expected)
+            tm.assert_numpy_array_equal(pd.NaT == rhs, expected)
+
+            expected = np.array([True, True, True])
+            tm.assert_numpy_array_equal(lhs != pd.NaT, expected)
+            tm.assert_numpy_array_equal(pd.NaT != lhs, expected)
+
+            expected = np.array([False, False, False])
+            tm.assert_numpy_array_equal(lhs < pd.NaT, expected)
+            tm.assert_numpy_array_equal(pd.NaT > lhs, expected)
+
+    def test_comparisons_nat(self):
+        tdidx1 = pd.TimedeltaIndex(['1 day', pd.NaT, '1 day 00:00:01', pd.NaT,
+                                    '1 day 00:00:01', '5 day 00:00:03'])
+        tdidx2 = pd.TimedeltaIndex(['2 day', '2 day', pd.NaT, pd.NaT,
+                                    '1 day 00:00:02', '5 days 00:00:03'])
+        tdarr = np.array([np.timedelta64(2, 'D'),
+                          np.timedelta64(2, 'D'), np.timedelta64('nat'),
+                          np.timedelta64('nat'),
+                          np.timedelta64(1, 'D') + np.timedelta64(2, 's'),
+                          np.timedelta64(5, 'D') + np.timedelta64(3, 's')])
+
+        cases = [(tdidx1, tdidx2), (tdidx1, tdarr)]
+
+        # Check pd.NaT is handles as the same as np.nan
+        for idx1, idx2 in cases:
+
+            result = idx1 < idx2
+            expected = np.array([True, False, False, False, True, False])
+            tm.assert_numpy_array_equal(result, expected)
+
+            result = idx2 > idx1
+            expected = np.array([True, False, False, False, True, False])
+            tm.assert_numpy_array_equal(result, expected)
+
+            result = idx1 <= idx2
+            expected = np.array([True, False, False, False, True, True])
+            tm.assert_numpy_array_equal(result, expected)
+
+            result = idx2 >= idx1
+            expected = np.array([True, False, False, False, True, True])
+            tm.assert_numpy_array_equal(result, expected)
+
+            result = idx1 == idx2
+            expected = np.array([False, False, False, False, False, True])
+            tm.assert_numpy_array_equal(result, expected)
+
+            result = idx1 != idx2
+            expected = np.array([True, True, True, True, True, False])
+            tm.assert_numpy_array_equal(result, expected)
+
+
 class TestTimedeltaIndexArithmetic(object):
     _holder = TimedeltaIndex
+
+    # -------------------------------------------------------------
+    # Invalid Operations
+
+    def test_tdi_add_str_invalid(self):
+        # GH 13624
+        tdi = TimedeltaIndex(['1 day', '2 days'])
+
+        with pytest.raises(TypeError):
+            tdi + 'a'
+        with pytest.raises(TypeError):
+            'a' + tdi
+
+    # -------------------------------------------------------------
 
     @pytest.mark.parametrize('box', [np.array, pd.Index])
     def test_tdi_add_offset_array(self, box):
@@ -128,41 +239,66 @@ class TestTimedeltaIndexArithmetic(object):
             with tm.assert_produces_warning(PerformanceWarning):
                 anchored - tdi
 
-    # TODO: Split by ops, better name
-    def test_numeric_compat(self):
+    def test_mul_int(self):
         idx = self._holder(np.arange(5, dtype='int64'))
-        didx = self._holder(np.arange(5, dtype='int64') ** 2)
         result = idx * 1
         tm.assert_index_equal(result, idx)
-
+ 
+    def test_rmul_int(self):
+        idx = self._holder(np.arange(5, dtype='int64'))
         result = 1 * idx
         tm.assert_index_equal(result, idx)
-
+ 
+    def test_div_int(self):
+        idx = self._holder(np.arange(5, dtype='int64'))
         result = idx / 1
         tm.assert_index_equal(result, idx)
-
+ 
+    def test_floordiv_int(self):
+        idx = self._holder(np.arange(5, dtype='int64'))
         result = idx // 1
         tm.assert_index_equal(result, idx)
-
+ 
+    def test_mul_int_array_zerodim(self):
+        rng5 = np.arange(5, dtype='int64')
+        idx = self._holder(rng5)
+        expected = self._holder(rng5 * 5)
         result = idx * np.array(5, dtype='int64')
-        tm.assert_index_equal(result,
-                              self._holder(np.arange(5, dtype='int64') * 5))
+        tm.assert_index_equal(result, expected)
 
-        result = idx * np.arange(5, dtype='int64')
+    def test_mul_int_array(self):
+        rng5 = np.arange(5, dtype='int64')
+        idx = self._holder(rng5)
+        didx = self._holder(rng5 ** 2)
+ 
+        result = idx * rng5
         tm.assert_index_equal(result, didx)
+ 
+    def test_mul_int_series(self):
+        idx = self._holder(np.arange(5, dtype='int64'))
+        didx = self._holder(np.arange(5, dtype='int64') ** 2)
 
         result = idx * Series(np.arange(5, dtype='int64'))
-        tm.assert_series_equal(result, Series(didx))
+        tm.assert_index_equal(result, didx)
+ 
+    def test_mul_float_series(self):
+        idx = self._holder(np.arange(5, dtype='int64'))
 
-        rng5 = np.arange(5, dtype='float64')
-        result = idx * Series(rng5 + 0.1)
-        tm.assert_series_equal(result,
-                               Series(self._holder(rng5 * (rng5 + 0.1))))
+        rng5f = np.arange(5, dtype='float64')
+        result = idx * Series(rng5f + 0.1)
+        tm.assert_index_equal(result, self._holder(rng5f * (rng5f + 0.1)))
+ 
+    def test_dti_mul_dti_raises(self):
+        idx = self._holder(np.arange(5, dtype='int64'))
+        with pytest.raises(TypeError):
+            idx * idx
 
-        # invalid
-        pytest.raises(TypeError, lambda: idx * idx)
-        pytest.raises(ValueError, lambda: idx * self._holder(np.arange(3)))
-        pytest.raises(ValueError, lambda: idx * np.array([1, 2]))
+    def test_dti_mul_too_short_raises(self):
+        idx = self._holder(np.arange(5, dtype='int64'))
+        with pytest.raises(ValueError):
+            idx * self._holder(np.arange(3))
+        with pytest.raises(ValueError):
+            idx * np.array([1, 2])
 
     def test_ufunc_coercions(self):
         # normal ops are also tested in tseries/test_timedeltas.py

--- a/pandas/tests/indexes/timedeltas/test_arithmetic.py
+++ b/pandas/tests/indexes/timedeltas/test_arithmetic.py
@@ -31,15 +31,15 @@ class TestTimedeltaIndexComparisons(object):
         # GH 13624
         tdi = TimedeltaIndex(['1 day', '2 days'])
 
-        for l, r in [(tdi, 'a'), ('a', tdi)]:
+        for left, right in [(tdi, 'a'), ('a', tdi)]:
             with pytest.raises(TypeError):
-                l > r
+                left > right
 
             with pytest.raises(TypeError):
-                l == r
+                left == right
 
             with pytest.raises(TypeError):
-                l != r
+                left != right
 
     def test_comparisons_coverage(self):
         rng = timedelta_range('1 days', periods=10)

--- a/pandas/tests/indexes/timedeltas/test_ops.py
+++ b/pandas/tests/indexes/timedeltas/test_ops.py
@@ -212,33 +212,6 @@ dtype: timedelta64[ns]"""
             result = idx.summary()
             assert result == expected
 
-    def test_comp_nat(self):
-        left = pd.TimedeltaIndex([pd.Timedelta('1 days'), pd.NaT,
-                                  pd.Timedelta('3 days')])
-        right = pd.TimedeltaIndex([pd.NaT, pd.NaT, pd.Timedelta('3 days')])
-
-        for lhs, rhs in [(left, right),
-                         (left.astype(object), right.astype(object))]:
-            result = rhs == lhs
-            expected = np.array([False, False, True])
-            tm.assert_numpy_array_equal(result, expected)
-
-            result = rhs != lhs
-            expected = np.array([True, True, False])
-            tm.assert_numpy_array_equal(result, expected)
-
-            expected = np.array([False, False, False])
-            tm.assert_numpy_array_equal(lhs == pd.NaT, expected)
-            tm.assert_numpy_array_equal(pd.NaT == rhs, expected)
-
-            expected = np.array([True, True, True])
-            tm.assert_numpy_array_equal(lhs != pd.NaT, expected)
-            tm.assert_numpy_array_equal(pd.NaT != lhs, expected)
-
-            expected = np.array([False, False, False])
-            tm.assert_numpy_array_equal(lhs < pd.NaT, expected)
-            tm.assert_numpy_array_equal(pd.NaT > lhs, expected)
-
     def test_value_counts_unique(self):
         # GH 7735
 
@@ -493,23 +466,6 @@ dtype: timedelta64[ns]"""
 class TestTimedeltas(object):
     _multiprocess_can_split_ = True
 
-    def test_ops_error_str(self):
-        # GH 13624
-        tdi = TimedeltaIndex(['1 day', '2 days'])
-
-        for l, r in [(tdi, 'a'), ('a', tdi)]:
-            with pytest.raises(TypeError):
-                l + r
-
-            with pytest.raises(TypeError):
-                l > r
-
-            with pytest.raises(TypeError):
-                l == r
-
-            with pytest.raises(TypeError):
-                l != r
-
     def test_timedelta_ops(self):
         # GH4984
         # make sure ops return Timedelta
@@ -564,18 +520,3 @@ class TestTimedeltas(object):
         s = Series([Timestamp('2015-02-03'), Timestamp('2015-02-07'),
                     Timestamp('2015-02-15')])
         assert s.diff().median() == timedelta(days=6)
-
-    def test_compare_timedelta_series(self):
-        # regresssion test for GH5963
-        s = pd.Series([timedelta(days=1), timedelta(days=2)])
-        actual = s > timedelta(days=1)
-        expected = pd.Series([False, True])
-        tm.assert_series_equal(actual, expected)
-
-    def test_compare_timedelta_ndarray(self):
-        # GH11835
-        periods = [Timedelta('0 days 01:00:00'), Timedelta('0 days 01:00:00')]
-        arr = np.array(periods)
-        result = arr[0] > arr
-        expected = np.array([False, False])
-        tm.assert_numpy_array_equal(result, expected)

--- a/pandas/tests/indexes/timedeltas/test_timedelta.py
+++ b/pandas/tests/indexes/timedeltas/test_timedelta.py
@@ -203,61 +203,6 @@ class TestTimedeltaIndex(DatetimeLike):
         exp = Int64Index([f(x) for x in rng])
         tm.assert_index_equal(result, exp)
 
-    def test_comparisons_nat(self):
-
-        tdidx1 = pd.TimedeltaIndex(['1 day', pd.NaT, '1 day 00:00:01', pd.NaT,
-                                    '1 day 00:00:01', '5 day 00:00:03'])
-        tdidx2 = pd.TimedeltaIndex(['2 day', '2 day', pd.NaT, pd.NaT,
-                                    '1 day 00:00:02', '5 days 00:00:03'])
-        tdarr = np.array([np.timedelta64(2, 'D'),
-                          np.timedelta64(2, 'D'), np.timedelta64('nat'),
-                          np.timedelta64('nat'),
-                          np.timedelta64(1, 'D') + np.timedelta64(2, 's'),
-                          np.timedelta64(5, 'D') + np.timedelta64(3, 's')])
-
-        cases = [(tdidx1, tdidx2), (tdidx1, tdarr)]
-
-        # Check pd.NaT is handles as the same as np.nan
-        for idx1, idx2 in cases:
-
-            result = idx1 < idx2
-            expected = np.array([True, False, False, False, True, False])
-            tm.assert_numpy_array_equal(result, expected)
-
-            result = idx2 > idx1
-            expected = np.array([True, False, False, False, True, False])
-            tm.assert_numpy_array_equal(result, expected)
-
-            result = idx1 <= idx2
-            expected = np.array([True, False, False, False, True, True])
-            tm.assert_numpy_array_equal(result, expected)
-
-            result = idx2 >= idx1
-            expected = np.array([True, False, False, False, True, True])
-            tm.assert_numpy_array_equal(result, expected)
-
-            result = idx1 == idx2
-            expected = np.array([False, False, False, False, False, True])
-            tm.assert_numpy_array_equal(result, expected)
-
-            result = idx1 != idx2
-            expected = np.array([True, True, True, True, True, False])
-            tm.assert_numpy_array_equal(result, expected)
-
-    def test_comparisons_coverage(self):
-        rng = timedelta_range('1 days', periods=10)
-
-        result = rng < rng[3]
-        exp = np.array([True, True, True] + [False] * 7)
-        tm.assert_numpy_array_equal(result, exp)
-
-        # raise TypeError for now
-        pytest.raises(TypeError, rng.__lt__, rng[3].value)
-
-        result = rng == list(rng)
-        exp = rng == rng
-        tm.assert_numpy_array_equal(result, exp)
-
     def test_total_seconds(self):
         # GH 10939
         # test index

--- a/pandas/tests/scalar/test_timedelta.py
+++ b/pandas/tests/scalar/test_timedelta.py
@@ -276,6 +276,14 @@ class TestTimedeltaComparison(object):
         assert res.shape == expected.shape
         assert (res == expected).all()
 
+    def test_compare_timedelta_ndarray(self):
+        # GH11835
+        periods = [Timedelta('0 days 01:00:00'), Timedelta('0 days 01:00:00')]
+        arr = np.array(periods)
+        result = arr[0] > arr
+        expected = np.array([False, False])
+        tm.assert_numpy_array_equal(result, expected)
+
 
 class TestTimedeltas(object):
     _multiprocess_can_split_ = True

--- a/pandas/tests/series/test_arithmetic.py
+++ b/pandas/tests/series/test_arithmetic.py
@@ -12,3 +12,46 @@ class TestTimedeltaSeriesComparisons(object):
         actual = s > timedelta(days=1)
         expected = pd.Series([False, True])
         tm.assert_series_equal(actual, expected)
+
+
+class TestPeriodSeriesArithmetic(object):
+    def test_ops_series_timedelta(self):
+        # GH 13043
+        ser = pd.Series([pd.Period('2015-01-01', freq='D'),
+                         pd.Period('2015-01-02', freq='D')], name='xxx')
+        assert ser.dtype == object
+
+        expected = pd.Series([pd.Period('2015-01-02', freq='D'),
+                              pd.Period('2015-01-03', freq='D')], name='xxx')
+
+        result = ser + pd.Timedelta('1 days')
+        tm.assert_series_equal(result, expected)
+
+        result = pd.Timedelta('1 days') + ser
+        tm.assert_series_equal(result, expected)
+
+        result = ser + pd.tseries.offsets.Day()
+        tm.assert_series_equal(result, expected)
+
+        result = pd.tseries.offsets.Day() + ser
+        tm.assert_series_equal(result, expected)
+
+    def test_ops_series_period(self):
+        # GH 13043
+        ser = pd.Series([pd.Period('2015-01-01', freq='D'),
+                         pd.Period('2015-01-02', freq='D')], name='xxx')
+        assert ser.dtype == object
+
+        per = pd.Period('2015-01-10', freq='D')
+        # dtype will be object because of original dtype
+        expected = pd.Series([9, 8], name='xxx', dtype=object)
+        tm.assert_series_equal(per - ser, expected)
+        tm.assert_series_equal(ser - per, -expected)
+
+        s2 = pd.Series([pd.Period('2015-01-05', freq='D'),
+                        pd.Period('2015-01-04', freq='D')], name='xxx')
+        assert s2.dtype == object
+
+        expected = pd.Series([4, 2], name='xxx', dtype=object)
+        tm.assert_series_equal(s2 - ser, expected)
+        tm.assert_series_equal(ser - s2, -expected)

--- a/pandas/tests/series/test_arithmetic.py
+++ b/pandas/tests/series/test_arithmetic.py
@@ -1,0 +1,14 @@
+# -*- coding: utf-8 -*-
+from datetime import timedelta
+
+import pandas as pd
+import pandas.util.testing as tm
+
+
+class TestTimedeltaSeriesComparisons(object):
+    def test_compare_timedelta_series(self):
+        # regresssion test for GH5963
+        s = pd.Series([timedelta(days=1), timedelta(days=2)])
+        actual = s > timedelta(days=1)
+        expected = pd.Series([False, True])
+        tm.assert_series_equal(actual, expected)


### PR DESCRIPTION
These are almost all cut/paste moving tests to the appropriate places.  Two exceptions:

- Some "TODO: de-duplicate this with that" notes (mostly to myself)
- `TestTimedeltaIndexArithmetic.test_numeric_compat` badly needed to be split into more specific tests, so that is done here.