### PR TITLE
Separate test_numeric_compat into method-specific tests

### DIFF
--- a/pandas/tests/indexes/test_numeric.py
+++ b/pandas/tests/indexes/test_numeric.py
@@ -88,8 +88,8 @@ class Numeric(Base):
         rng5 = np.arange(5, dtype='float64')
 
         result = idx * Series(rng5 + 0.1)
-        expected = Float64Index(rng5 * (rng5 + 0.1))
-        tm.assert_index_equal(result, expected)
+        expected = Series(rng5 * (rng5 + 0.1))
+        tm.assert_series_equal(result, expected)
 
     def test_mul_index(self):
         idx = self.create_index()

--- a/pandas/tests/indexes/test_numeric.py
+++ b/pandas/tests/indexes/test_numeric.py
@@ -81,7 +81,7 @@ class Numeric(Base):
 
         arr_dtype = 'uint64' if isinstance(idx, UInt64Index) else 'int64'
         result = idx * Series(np.arange(5, dtype=arr_dtype))
-        tm.assert_index_equal(result, didx)
+        tm.assert_series_equal(result, Series(didx))
 
     def test_mul_float_series(self):
         idx = self.create_index()
@@ -123,13 +123,6 @@ class Numeric(Base):
             tm.assert_index_equal(r, e)
 
         result = divmod(idx, full_like(idx.values, 2))
-        with np.errstate(all='ignore'):
-            div, mod = divmod(idx.values, full_like(idx.values, 2))
-            expected = Index(div), Index(mod)
-        for r, e in zip(result, expected):
-            tm.assert_index_equal(r, e)
-
-        result = divmod(idx, Series(full_like(idx.values, 2)))
         with np.errstate(all='ignore'):
             div, mod = divmod(idx.values, full_like(idx.values, 2))
             expected = Index(div), Index(mod)


### PR DESCRIPTION
A more reasonably-scoped attempt at #19255.

- [ ] closes #xxxx
- [ ] tests added / passed
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
