### PR TITLE
Change IntervalIndex set-ops error code type

### DIFF
--- a/doc/source/whatsnew/v0.23.0.txt
+++ b/doc/source/whatsnew/v0.23.0.txt
@@ -312,6 +312,7 @@ Other API Changes
 - Addition or subtraction of ``NaT`` from :class:`TimedeltaIndex` will return ``TimedeltaIndex`` instead of ``DatetimeIndex`` (:issue:`19124`)
 - :func:`DatetimeIndex.shift` and :func:`TimedeltaIndex.shift` will now raise ``NullFrequencyError`` (which subclasses ``ValueError``, which was raised in older versions) when the index object frequency is ``None`` (:issue:`19147`)
 - Addition and subtraction of ``NaN`` from a :class:`Series` with ``dtype='timedelta64[ns]'`` will raise a ``TypeError` instead of treating the ``NaN`` as ``NaT`` (:issue:`19274`)
+- Set operations (union, difference...) on :class:`IntervalIndex` with incompatible index types will now raise a ``TypeError`` rather than a ``ValueError`` (:issue:`19329`)
 
 .. _whatsnew_0230.deprecations:
 

--- a/pandas/tests/indexes/interval/test_interval.py
+++ b/pandas/tests/indexes/interval/test_interval.py
@@ -934,12 +934,14 @@ class TestIntervalIndex(Base):
         set_op = getattr(index, op_name)
 
         # non-IntervalIndex
-        msg = ('can only do set operations between two IntervalIndex objects '
-               'that are closed on the same side')
-        with tm.assert_raises_regex(ValueError, msg):
+        msg = ('the other index needs to be an IntervalIndex too, but '
+               'was type Int64Index')
+        with tm.assert_raises_regex(TypeError, msg):
             set_op(Index([1, 2, 3]))
 
         # mixed closed
+        msg = ('can only do set operations between two IntervalIndex objects '
+               'that are closed on the same side')
         for other_closed in {'right', 'left', 'both', 'neither'} - {closed}:
             other = self.create_index(closed=other_closed)
             with tm.assert_raises_regex(ValueError, msg):


### PR DESCRIPTION
- [x] xref #19021
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry

Set operations (union, difference...) on ``IntervalIndex`` with incompatible index types will now raise a ``TypeError`` rather than a ``ValueError``.

This PR is needed to make the changes requested in #19021.

EDIT: I've improved the error message also. Previously, you'd get:

```python
>>> pd.IntervalIndex.from_breaks([0,1,2,3]).union(pd.RangeIndex(3))
ValueError: can only do set operations between two IntervalIndex objects that are closed on the same side
```

Which made no sense in this case. Now we get:

```python
>>> pd.IntervalIndex.from_breaks([0,1,2,3]).union(pd.RangeIndex(3))
TypeError: the other index needs to be an IntervalIndex too, but was type RangeIndex
```