### PR TITLE
BUG: DatetimeIndex(tz) & single column name, return empty df (GH19157)

### DIFF
--- a/doc/source/whatsnew/v0.23.0.txt
+++ b/doc/source/whatsnew/v0.23.0.txt
@@ -431,6 +431,7 @@ Timezones
 - :func:`Timestamp.replace` will now handle Daylight Savings transitions gracefully (:issue:`18319`)
 - Bug in tz-aware :class:`DatetimeIndex` where addition/subtraction with a :class:`TimedeltaIndex` or array with ``dtype='timedelta64[ns]'`` was incorrect (:issue:`17558`)
 - Bug in :func:`DatetimeIndex.insert` where inserting ``NaT`` into a timezone-aware index incorrectly raised (:issue:`16357`)
+- Bug in the :class:`DataFrame` constructor, where tz-aware Datetimeindex and a given column name will result in an empty ``DataFrame`` (:issue:`19157`)
 
 Offsets
 ^^^^^^^

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -512,7 +512,11 @@ class DataFrame(NDFrame):
             return _arrays_to_mgr([values], columns, index, columns,
                                   dtype=dtype)
         elif is_datetimetz(values):
-            return self._init_dict({0: values}, index, columns, dtype=dtype)
+            # GH19157
+            if columns is None:
+                columns = [0]
+            return _arrays_to_mgr([values], columns, index, columns,
+                                  dtype=dtype)
 
         # by definition an array here
         # the dtypes will be coerced to a single dtype

--- a/pandas/tests/frame/test_constructors.py
+++ b/pandas/tests/frame/test_constructors.py
@@ -2092,3 +2092,14 @@ class TestDataFrameConstructorWithDatetimeTZ(TestData):
         result['index'].dtype == 'M8[ns]'
 
         result = df.to_records(index=False)
+
+    def test_frame_timeseries_column(self):
+        # GH19157
+        dr = date_range(start='20130101T10:00:00', periods=3, freq='T',
+                        tz='US/Eastern')
+        result = DataFrame(dr, columns=['timestamps'])
+        expected = DataFrame({'timestamps': [
+            Timestamp('20130101T10:00:00', tz='US/Eastern'),
+            Timestamp('20130101T10:01:00', tz='US/Eastern'),
+            Timestamp('20130101T10:02:00', tz='US/Eastern')]})
+        tm.assert_frame_equal(result, expected)


### PR DESCRIPTION
- [x] closes #19157 
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry

This issue is due to self._init_dict({0: values}, index, columns, dtype=dtype) will call for the filtering if columns passed (`data = {k: v for k, v in compat.iteritems(data) if k in columns}`), see function ``_init_dict`` of [frame.py](https://github.com/pandas-dev/pandas/blob/master/pandas/core/frame.py) 

So `self._init_dict({0: values}, index, columns, dtype=dtype)` expects the column name of values as '0', but since we pass a column with a different name, upon filtering it will result in an empty DataFrame. 

My solution assumes that the conversion of a series of DatetimeIndex with tz_info. Hence, we will initialize a DataFrame according to the given column name. If no column name specified, index '0' is chosen. I introduced an assertion to warn the users if multiple column names are passed.

Update 27-01-2018: The updated PR includes a test, and update on whatsnew entry. The revised solution uses ``_arrays_to_mgr`` instead, such that a default column name 0 is specified if ``columns`` not specified.