### PR TITLE
MAINT: Remove pytest.warns in tests

### DIFF
--- a/ci/lint.sh
+++ b/ci/lint.sh
@@ -89,6 +89,14 @@ if [ "$LINT" ]; then
     if [ $? = "0" ]; then
         RET=1
     fi
+
+    # Check for pytest.warns
+    grep -r -E --include '*.py' 'pytest\.warns' pandas/tests/
+
+    if [ $? = "0" ]; then
+        RET=1
+    fi
+
     echo "Check for invalid testing DONE"
 
     # Check for imports from pandas.core.common instead

--- a/pandas/tests/series/test_timeseries.py
+++ b/pandas/tests/series/test_timeseries.py
@@ -937,7 +937,7 @@ class TestTimeSeries(TestData):
         assert isinstance(s[0], Timestamp)
         assert s[0] == dates[0][0]
 
-        with pytest.warns(FutureWarning):
+        with tm.assert_produces_warning(FutureWarning, check_stacklevel=False):
             s = Series.from_array(arr['Date'], Index([0]))
             assert s[0] == dates[0][0]
 


### PR DESCRIPTION
Per discussion in #18258, we are prohibiting its use in tests, at least for the time being.