### PR TITLE
clarify redirection in ops

### DIFF
--- a/pandas/core/panel.py
+++ b/pandas/core/panel.py
@@ -1547,50 +1547,10 @@ class Panel(NDFrame):
                 return result
 
             if name in ops._op_descriptions:
-                op_name = name.replace('__', '')
-                op_desc = ops._op_descriptions[op_name]
-                if op_desc['reversed']:
-                    equiv = 'other ' + op_desc['op'] + ' panel'
-                else:
-                    equiv = 'panel ' + op_desc['op'] + ' other'
-
-                _op_doc = """
-{desc} of series and other, element-wise (binary operator `{op_name}`).
-Equivalent to ``{equiv}``.
-
-Parameters
-----------
-other : {construct} or {cls_name}
-axis : {{{axis_order}}}
-    Axis to broadcast over
-
-Returns
--------
-{cls_name}
-
-See also
---------
-{cls_name}.{reverse}\n"""
-                doc = _op_doc.format(
-                    desc=op_desc['desc'], op_name=op_name, equiv=equiv,
-                    construct=cls._constructor_sliced.__name__,
-                    cls_name=cls.__name__, reverse=op_desc['reverse'],
-                    axis_order=', '.join(cls._AXIS_ORDERS))
+                doc = ops._make_flex_doc(name, 'panel')
             else:
                 # doc strings substitors
-                _agg_doc = """
-                Wrapper method for {wrp_method}
-
-                Parameters
-                ----------
-                other : {construct} or {cls_name}
-                axis : {{{axis_order}}}
-                    Axis to broadcast over
-
-                Returns
-                -------
-                {cls_name}\n"""
-                doc = _agg_doc.format(
+                doc = ops._agg_doc_PANEL.format(
                     construct=cls._constructor_sliced.__name__,
                     cls_name=cls.__name__, wrp_method=name,
                     axis_order=', '.join(cls._AXIS_ORDERS))

--- a/pandas/core/panel.py
+++ b/pandas/core/panel.py
@@ -1525,8 +1525,11 @@ class Panel(NDFrame):
     def _add_aggregate_operations(cls, use_numexpr=True):
         """ add the operations to the cls; evaluate the doc strings again """
 
-        def _panel_arith_method(op, name, str_rep=None, default_axis=None,
-                                fill_zeros=None, **eval_kwargs):
+        def _panel_arith_method(op, name, str_rep=None, default_axis=None):
+
+            eval_kwargs = ops._gen_eval_kwargs(name)
+            fill_zeros = ops._gen_fill_zeros(name)
+
             def na_op(x, y):
                 import pandas.core.computation.expressions as expressions
 

--- a/pandas/core/sparse/array.py
+++ b/pandas/core/sparse/array.py
@@ -43,8 +43,7 @@ from pandas.core.indexes.base import _index_shared_docs
 _sparray_doc_kwargs = dict(klass='SparseArray')
 
 
-def _arith_method(op, name, str_rep=None, default_axis=None, fill_zeros=None,
-                  **eval_kwargs):
+def _arith_method(op, name, str_rep=None, default_axis=None):
     """
     Wrapper function for Series arithmetic operations, to avoid
     code duplication.

--- a/pandas/core/sparse/array.py
+++ b/pandas/core/sparse/array.py
@@ -43,7 +43,7 @@ from pandas.core.indexes.base import _index_shared_docs
 _sparray_doc_kwargs = dict(klass='SparseArray')
 
 
-def _arith_method(op, name, str_rep=None, default_axis=None):
+def _arith_method_SPARSE_ARRAY(op, name, str_rep=None, default_axis=None):
     """
     Wrapper function for Series arithmetic operations, to avoid
     code duplication.
@@ -863,7 +863,8 @@ def _make_index(length, indices, kind):
     return index
 
 
-ops.add_special_arithmetic_methods(SparseArray, arith_method=_arith_method,
-                                   comp_method=_arith_method,
-                                   bool_method=_arith_method,
+ops.add_special_arithmetic_methods(SparseArray,
+                                   arith_method=_arith_method_SPARSE_ARRAY,
+                                   comp_method=_arith_method_SPARSE_ARRAY,
+                                   bool_method=_arith_method_SPARSE_ARRAY,
                                    use_numexpr=False)

--- a/pandas/core/sparse/series.py
+++ b/pandas/core/sparse/series.py
@@ -41,7 +41,7 @@ _shared_doc_kwargs = dict(axes='index', klass='SparseSeries',
 # Wrapper function for Series arithmetic methods
 
 
-def _arith_method(op, name, str_rep=None, default_axis=None):
+def _arith_method_SPARSE_SERIES(op, name, str_rep=None, default_axis=None):
     """
     Wrapper function for Series arithmetic operations, to avoid
     code duplication.
@@ -863,7 +863,8 @@ ops.add_flex_arithmetic_methods(SparseSeries, use_numexpr=False,
                                 **ops.series_flex_funcs)
 # overwrite basic arithmetic to use SparseSeries version
 # force methods to overwrite previous definitions.
-ops.add_special_arithmetic_methods(SparseSeries, _arith_method,
-                                   comp_method=_arith_method,
+ops.add_special_arithmetic_methods(SparseSeries,
+                                   arith_method=_arith_method_SPARSE_SERIES,
+                                   comp_method=_arith_method_SPARSE_SERIES,
                                    bool_method=None, use_numexpr=False,
                                    force=True)

--- a/pandas/core/sparse/series.py
+++ b/pandas/core/sparse/series.py
@@ -41,13 +41,12 @@ _shared_doc_kwargs = dict(axes='index', klass='SparseSeries',
 # Wrapper function for Series arithmetic methods
 
 
-def _arith_method(op, name, str_rep=None, default_axis=None, fill_zeros=None,
-                  **eval_kwargs):
+def _arith_method(op, name, str_rep=None, default_axis=None):
     """
     Wrapper function for Series arithmetic operations, to avoid
     code duplication.
 
-    str_rep, default_axis, fill_zeros and eval_kwargs are not used, but are
+    str_rep and default_axis are not used, but are
     present for compatibility.
     """
 


### PR DESCRIPTION
core.ops involves a _lot_ of redirection.  This decreases some of that redirection (and some redundancy) by implementing functions that show the logic of how some of the args/kwargs are chosen.  The goal is to make it so future debugging can be done without going through `func.im_func.func_closure[1].cell_contents.func_closure...`

- [ ] closes #xxxx
- [ ] tests added / passed
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
