### PR TITLE
Separate non-scalar tests from test_timestamps

### DIFF
--- a/pandas/tests/frame/test_apply.py
+++ b/pandas/tests/frame/test_apply.py
@@ -428,6 +428,16 @@ class TestDataFrameApply(TestData):
                 result = frame.applymap(func)
                 tm.assert_frame_equal(result, frame)
 
+    def test_applymap_box_timestamps(self):
+        # #2689, #2627
+        ser = pd.Series(date_range('1/1/2000', periods=10))
+
+        def func(x):
+            return (x.hour, x.day, x.month)
+
+        # it works!
+        pd.DataFrame(ser).applymap(func)
+
     def test_applymap_box(self):
         # ufunc will not be boxed. Same test cases as the test_map_box
         df = pd.DataFrame({'a': [pd.Timestamp('2011-01-01'),

--- a/pandas/tests/indexes/datetimes/test_ops.py
+++ b/pandas/tests/indexes/datetimes/test_ops.py
@@ -144,6 +144,25 @@ class TestDatetimeIndexOps(Ops):
             tm.assert_raises_regex(
                 ValueError, errmsg, np.argmax, dr, out=0)
 
+    def test_round_daily(self):
+        dti = pd.date_range('20130101 09:10:11', periods=5)
+        result = dti.round('D')
+        expected = pd.date_range('20130101', periods=5)
+        tm.assert_index_equal(result, expected)
+
+        dti = dti.tz_localize('UTC').tz_convert('US/Eastern')
+        result = dti.round('D')
+        expected = pd.date_range('20130101',
+                                 periods=5).tz_localize('US/Eastern')
+        tm.assert_index_equal(result, expected)
+
+        result = dti.round('s')
+        tm.assert_index_equal(result, dti)
+
+        # invalid
+        for freq in ['Y', 'M', 'foobar']:
+            pytest.raises(ValueError, lambda: dti.round(freq))
+
     def test_round(self):
         for tz in self.tz:
             rng = pd.date_range(start='2016-01-01', periods=5,

--- a/pandas/tests/io/test_html.py
+++ b/pandas/tests/io/test_html.py
@@ -868,6 +868,13 @@ class TestReadHtmlLxml(ReadHtmlMixin):
         banklist_data = os.path.join(DATA_PATH, 'banklist.html')
         self.read_html(banklist_data, '.*Water.*', flavor=['lxml', 'html5lib'])
 
+    def test_to_html_timestamp(self):
+        rng = date_range('2000-01-01', periods=10)
+        df = DataFrame(np.random.randn(10, 4), index=rng)
+
+        result = df.to_html()
+        assert '2000-01-01' in result
+
     def test_parse_dates_list(self):
         df = DataFrame({'date': date_range('1/1/2001', periods=10)})
         expected = df.to_html()

--- a/pandas/tests/series/test_apply.py
+++ b/pandas/tests/series/test_apply.py
@@ -77,6 +77,17 @@ class TestSeriesApply(TestData):
         assert result[0] == ['foo', 'bar']
         assert isinstance(result[0], list)
 
+    def test_series_map_box_timestamps(self):
+        # GH#2689, GH#2627
+        ser = Series(pd.date_range('1/1/2000', periods=10))
+
+        def func(x):
+            return (x.hour, x.day, x.month)
+
+        # it works!
+        ser.map(func)
+        ser.apply(func)
+
     def test_apply_box(self):
         # ufunc will not be boxed. Same test cases as the test_map_box
         vals = [pd.Timestamp('2011-01-01'), pd.Timestamp('2011-01-02')]

--- a/pandas/tests/series/test_arithmetic.py
+++ b/pandas/tests/series/test_arithmetic.py
@@ -1,8 +1,75 @@
 # -*- coding: utf-8 -*-
 from datetime import timedelta
+import operator
+
+import numpy as np
 
 import pandas as pd
 import pandas.util.testing as tm
+
+
+class TestSeriesComparison(object):
+    def test_compare_invalid(self):
+        # GH#8058
+        # ops testing
+        a = pd.Series(np.random.randn(5), name=0)
+        b = pd.Series(np.random.randn(5))
+        b.name = pd.Timestamp('2000-01-01')
+        tm.assert_series_equal(a / b, 1 / (b / a))
+
+
+class TestTimestampSeriesComparison(object):
+    def test_timestamp_compare_series(self):
+        # make sure we can compare Timestamps on the right AND left hand side
+        # GH#4982
+        ser = pd.Series(pd.date_range('20010101', periods=10), name='dates')
+        s_nat = ser.copy(deep=True)
+
+        ser[0] = pd.Timestamp('nat')
+        ser[3] = pd.Timestamp('nat')
+
+        ops = {'lt': 'gt', 'le': 'ge', 'eq': 'eq', 'ne': 'ne'}
+
+        for left, right in ops.items():
+            left_f = getattr(operator, left)
+            right_f = getattr(operator, right)
+
+            # no nats
+            expected = left_f(ser, pd.Timestamp('20010109'))
+            result = right_f(pd.Timestamp('20010109'), ser)
+            tm.assert_series_equal(result, expected)
+
+            # nats
+            expected = left_f(ser, pd.Timestamp('nat'))
+            result = right_f(pd.Timestamp('nat'), ser)
+            tm.assert_series_equal(result, expected)
+
+            # compare to timestamp with series containing nats
+            expected = left_f(s_nat, pd.Timestamp('20010109'))
+            result = right_f(pd.Timestamp('20010109'), s_nat)
+            tm.assert_series_equal(result, expected)
+
+            # compare to nat with series containing nats
+            expected = left_f(s_nat, pd.Timestamp('nat'))
+            result = right_f(pd.Timestamp('nat'), s_nat)
+            tm.assert_series_equal(result, expected)
+
+    def test_timestamp_equality(self):
+        # GH#11034
+        ser = pd.Series([pd.Timestamp('2000-01-29 01:59:00'), 'NaT'])
+        result = ser != ser
+        tm.assert_series_equal(result, pd.Series([False, True]))
+        result = ser != ser[0]
+        tm.assert_series_equal(result, pd.Series([False, True]))
+        result = ser != ser[1]
+        tm.assert_series_equal(result, pd.Series([True, True]))
+
+        result = ser == ser
+        tm.assert_series_equal(result, pd.Series([True, False]))
+        result = ser == ser[0]
+        tm.assert_series_equal(result, pd.Series([True, False]))
+        result = ser == ser[1]
+        tm.assert_series_equal(result, pd.Series([False, False]))
 
 
 class TestTimedeltaSeriesComparisons(object):
@@ -55,3 +122,15 @@ class TestPeriodSeriesArithmetic(object):
         expected = pd.Series([4, 2], name='xxx', dtype=object)
         tm.assert_series_equal(s2 - ser, expected)
         tm.assert_series_equal(ser - s2, -expected)
+
+
+class TestTimestampSeriesArithmetic(object):
+    def test_timestamp_sub_series(self):
+        ser = pd.Series(pd.date_range('2014-03-17', periods=2, freq='D',
+                                      tz='US/Eastern'))
+        ts = ser[0]
+
+        delta_series = pd.Series([np.timedelta64(0, 'D'),
+                                  np.timedelta64(1, 'D')])
+        tm.assert_series_equal(ser - ts, delta_series)
+        tm.assert_series_equal(ts - ser, -delta_series)

--- a/pandas/tests/series/test_indexing.py
+++ b/pandas/tests/series/test_indexing.py
@@ -610,6 +610,18 @@ class TestSeriesIndexing(TestData):
         value = self.ts[5]
         assert isinstance(value, np.float64)
 
+    def test_series_box_timestamp(self):
+        rng = pd.date_range('20090415', '20090519', freq='B')
+        ser = Series(rng)
+
+        assert isinstance(ser[5], pd.Timestamp)
+
+        rng = pd.date_range('20090415', '20090519', freq='B')
+        ser = Series(rng, index=rng)
+        assert isinstance(ser[5], pd.Timestamp)
+
+        assert isinstance(ser.iat[5], pd.Timestamp)
+
     def test_getitem_ambiguous_keyerror(self):
         s = Series(lrange(10), index=lrange(0, 20, 2))
         pytest.raises(KeyError, s.__getitem__, 1)


### PR DESCRIPTION
Getting DataFrame, Series, Index tests out of tests.scalars and organizing them better, should make it easier to go and parametrize some older tests, in particular arithmetic and comparisons.