### PR TITLE
Centralize ops kwarg specification

### DIFF
--- a/pandas/core/ops.py
+++ b/pandas/core/ops.py
@@ -362,10 +362,17 @@ def _make_flex_doc(op_name, typ):
 # methods
 
 
-def _create_methods(arith_method, comp_method, bool_method,
-                    use_numexpr, special=False, have_divmod=False):
+def _create_methods(cls, arith_method, comp_method, bool_method,
+                    special=False):
     # creates actual methods based upon arithmetic, comp and bool method
     # constructors.
+
+    subtyp = getattr(cls, '_subtyp', '')
+    use_numexpr = 'sparse' not in subtyp
+    # numexpr is available for non-sparse classes
+
+    have_divmod = issubclass(cls, ABCSeries)
+    # divmod is available for Series and SparseSeries
 
     # if we're not using numexpr, then don't pass a str_rep
     if use_numexpr:
@@ -465,16 +472,8 @@ def add_special_arithmetic_methods(cls, arith_method=None,
         if False, checks whether function is defined **on ``cls.__dict__``**
         before defining if True, always defines functions on class base
     """
-    subtyp = getattr(cls, '_subtyp', '')
-    use_numexpr = 'sparse' not in subtyp
-    # numexpr is available for non-sparse classes
-
-    have_divmod = issubclass(cls, ABCSeries)
-    # divmod is available for Series and SparseSeries
-
-    new_methods = _create_methods(arith_method, comp_method,
-                                  bool_method, use_numexpr,
-                                  special=True, have_divmod=have_divmod)
+    new_methods = _create_methods(cls, arith_method, comp_method, bool_method,
+                                  special=True)
 
     # inplace operators (I feel like these should get passed an `inplace=True`
     # or just be removed
@@ -533,12 +532,8 @@ def add_flex_arithmetic_methods(cls, flex_arith_method,
         if False, checks whether function is defined **on ``cls.__dict__``**
         before defining if True, always defines functions on class base
     """
-    subtyp = getattr(cls, '_subtyp', '')
-    use_numexpr = 'sparse' not in subtyp
-
-    new_methods = _create_methods(flex_arith_method,
+    new_methods = _create_methods(cls, flex_arith_method,
                                   flex_comp_method, flex_bool_method,
-                                  use_numexpr,
                                   special=False)
     new_methods.update(dict(multiply=new_methods['mul'],
                             subtract=new_methods['sub'],

--- a/pandas/core/ops.py
+++ b/pandas/core/ops.py
@@ -524,7 +524,7 @@ def add_flex_arithmetic_methods(cls, flex_arith_method,
     Parameters
     ----------
     flex_arith_method : function
-        factory for special arithmetic methods, with op string:
+        factory for flex arithmetic methods, with op string:
         f(op, name, str_rep)
     flex_comp_method : function, optional,
         factory for rich comparison - signature: f(op, name, str_rep)

--- a/pandas/core/ops.py
+++ b/pandas/core/ops.py
@@ -368,9 +368,9 @@ def _create_methods(cls, arith_method, comp_method, bool_method,
     # creates actual methods based upon arithmetic, comp and bool method
     # constructors.
 
+    # numexpr is available for non-sparse classes
     subtyp = getattr(cls, '_subtyp', '')
     use_numexpr = 'sparse' not in subtyp
-    # numexpr is available for non-sparse classes
 
     have_divmod = issubclass(cls, ABCSeries)
     # divmod is available for Series and SparseSeries

--- a/pandas/core/panel.py
+++ b/pandas/core/panel.py
@@ -16,7 +16,6 @@ from pandas.core.dtypes.common import (
 from pandas.core.dtypes.missing import notna
 
 import pandas.core.ops as ops
-import pandas.core.missing as missing
 import pandas.core.common as com
 from pandas import compat
 from pandas.compat import (map, zip, range, u, OrderedDict)
@@ -1521,52 +1520,6 @@ class Panel(NDFrame):
 
         return _ensure_index(index)
 
-    @classmethod
-    def _add_aggregate_operations(cls, use_numexpr=True):
-        """ add the operations to the cls; evaluate the doc strings again """
-
-        def _panel_arith_method(op, name, str_rep=None, default_axis=None):
-
-            eval_kwargs = ops._gen_eval_kwargs(name)
-            fill_zeros = ops._gen_fill_zeros(name)
-
-            def na_op(x, y):
-                import pandas.core.computation.expressions as expressions
-
-                try:
-                    result = expressions.evaluate(op, str_rep, x, y,
-                                                  errors='raise',
-                                                  **eval_kwargs)
-                except TypeError:
-                    result = op(x, y)
-
-                # handles discrepancy between numpy and numexpr on division/mod
-                # by 0 though, given that these are generally (always?)
-                # non-scalars, I'm not sure whether it's worth it at the moment
-                result = missing.fill_zeros(result, x, y, name, fill_zeros)
-                return result
-
-            if name in ops._op_descriptions:
-                doc = ops._make_flex_doc(name, 'panel')
-            else:
-                # doc strings substitors
-                doc = ops._agg_doc_PANEL.format(
-                    construct=cls._constructor_sliced.__name__,
-                    cls_name=cls.__name__, wrp_method=name,
-                    axis_order=', '.join(cls._AXIS_ORDERS))
-
-            @Appender(doc)
-            def f(self, other, axis=0):
-                return self._combine(other, na_op, axis=axis)
-
-            f.__name__ = name
-            return f
-
-        # add `div`, `mul`, `pow`, etc..
-        ops.add_flex_arithmetic_methods(
-            cls, _panel_arith_method, use_numexpr=use_numexpr,
-            flex_comp_method=ops._comp_method_PANEL)
-
 
 Panel._setup_axes(axes=['items', 'major_axis', 'minor_axis'], info_axis=0,
                   stat_axis=1, aliases={'major': 'major_axis',
@@ -1575,7 +1528,8 @@ Panel._setup_axes(axes=['items', 'major_axis', 'minor_axis'], info_axis=0,
                            'minor_axis': 'columns'})
 
 ops.add_special_arithmetic_methods(Panel, **ops.panel_special_funcs)
-Panel._add_aggregate_operations()
+ops.add_flex_arithmetic_methods(Panel, ops._flex_method_PANEL,
+                                flex_comp_method=ops._comp_method_PANEL)
 Panel._add_numeric_operations()
 
 

--- a/pandas/core/sparse/array.py
+++ b/pandas/core/sparse/array.py
@@ -43,7 +43,7 @@ from pandas.core.indexes.base import _index_shared_docs
 _sparray_doc_kwargs = dict(klass='SparseArray')
 
 
-def _arith_method_SPARSE_ARRAY(op, name, str_rep=None, default_axis=None):
+def _arith_method_SPARSE_ARRAY(op, name, str_rep=None):
     """
     Wrapper function for Series arithmetic operations, to avoid
     code duplication.
@@ -866,5 +866,4 @@ def _make_index(length, indices, kind):
 ops.add_special_arithmetic_methods(SparseArray,
                                    arith_method=_arith_method_SPARSE_ARRAY,
                                    comp_method=_arith_method_SPARSE_ARRAY,
-                                   bool_method=_arith_method_SPARSE_ARRAY,
-                                   use_numexpr=False)
+                                   bool_method=_arith_method_SPARSE_ARRAY)

--- a/pandas/core/sparse/array.py
+++ b/pandas/core/sparse/array.py
@@ -14,8 +14,7 @@ from pandas import compat
 from pandas.compat import range
 from pandas.compat.numpy import function as nv
 
-from pandas.core.dtypes.generic import (
-    ABCSparseArray, ABCSparseSeries)
+from pandas.core.dtypes.generic import ABCSparseSeries
 from pandas.core.dtypes.common import (
     _ensure_platform_int,
     is_float, is_integer,
@@ -41,38 +40,6 @@ from pandas.core.indexes.base import _index_shared_docs
 
 
 _sparray_doc_kwargs = dict(klass='SparseArray')
-
-
-def _arith_method_SPARSE_ARRAY(op, name, str_rep=None):
-    """
-    Wrapper function for Series arithmetic operations, to avoid
-    code duplication.
-    """
-
-    def wrapper(self, other):
-        if isinstance(other, np.ndarray):
-            if len(self) != len(other):
-                raise AssertionError("length mismatch: {self} vs. {other}"
-                                     .format(self=len(self), other=len(other)))
-            if not isinstance(other, ABCSparseArray):
-                dtype = getattr(other, 'dtype', None)
-                other = SparseArray(other, fill_value=self.fill_value,
-                                    dtype=dtype)
-            return _sparse_array_op(self, other, op, name)
-        elif is_scalar(other):
-            with np.errstate(all='ignore'):
-                fill = op(_get_fill(self), np.asarray(other))
-                result = op(self.sp_values, other)
-
-            return _wrap_result(name, result, self.sp_index, fill)
-        else:  # pragma: no cover
-            raise TypeError('operation with {other} not supported'
-                            .format(other=type(other)))
-
-    if name.startswith("__"):
-        name = name[2:-2]
-    wrapper.__name__ = name
-    return wrapper
 
 
 def _get_fill(arr):
@@ -864,6 +831,6 @@ def _make_index(length, indices, kind):
 
 
 ops.add_special_arithmetic_methods(SparseArray,
-                                   arith_method=_arith_method_SPARSE_ARRAY,
-                                   comp_method=_arith_method_SPARSE_ARRAY,
-                                   bool_method=_arith_method_SPARSE_ARRAY)
+                                   arith_method=ops._arith_method_SPARSE_ARRAY,
+                                   comp_method=ops._arith_method_SPARSE_ARRAY,
+                                   bool_method=ops._arith_method_SPARSE_ARRAY)

--- a/pandas/core/sparse/frame.py
+++ b/pandas/core/sparse/frame.py
@@ -981,7 +981,5 @@ def homogenize(series_dict):
 
 
 # use unaccelerated ops for sparse objects
-ops.add_flex_arithmetic_methods(SparseDataFrame, use_numexpr=False,
-                                **ops.frame_flex_funcs)
-ops.add_special_arithmetic_methods(SparseDataFrame, use_numexpr=False,
-                                   **ops.frame_special_funcs)
+ops.add_flex_arithmetic_methods(SparseDataFrame, **ops.frame_flex_funcs)
+ops.add_special_arithmetic_methods(SparseDataFrame, **ops.frame_special_funcs)

--- a/pandas/core/sparse/series.py
+++ b/pandas/core/sparse/series.py
@@ -41,13 +41,12 @@ _shared_doc_kwargs = dict(axes='index', klass='SparseSeries',
 # Wrapper function for Series arithmetic methods
 
 
-def _arith_method_SPARSE_SERIES(op, name, str_rep=None, default_axis=None):
+def _arith_method_SPARSE_SERIES(op, name, str_rep=None):
     """
     Wrapper function for Series arithmetic operations, to avoid
     code duplication.
 
-    str_rep and default_axis are not used, but are
-    present for compatibility.
+    str_rep is not used, but is present for compatibility.
     """
 
     def wrapper(self, other):
@@ -861,14 +860,11 @@ class SparseSeries(Series):
 
 
 # overwrite series methods with unaccelerated versions
-ops.add_special_arithmetic_methods(SparseSeries, use_numexpr=False,
-                                   **ops.series_special_funcs)
-ops.add_flex_arithmetic_methods(SparseSeries, use_numexpr=False,
-                                **ops.series_flex_funcs)
+ops.add_special_arithmetic_methods(SparseSeries, **ops.series_special_funcs)
+ops.add_flex_arithmetic_methods(SparseSeries, **ops.series_flex_funcs)
 # overwrite basic arithmetic to use SparseSeries version
 # force methods to overwrite previous definitions.
 ops.add_special_arithmetic_methods(SparseSeries,
                                    arith_method=_arith_method_SPARSE_SERIES,
                                    comp_method=_arith_method_SPARSE_SERIES,
-                                   bool_method=None, use_numexpr=False,
-                                   force=True)
+                                   bool_method=None, force=True)

--- a/pandas/core/sparse/series.py
+++ b/pandas/core/sparse/series.py
@@ -9,12 +9,10 @@ import numpy as np
 import warnings
 
 from pandas.core.dtypes.missing import isna, notna
-from pandas.core.dtypes.common import is_scalar
 
 from pandas.compat.numpy import function as nv
 from pandas.core.index import Index, _ensure_index, InvalidIndexError
 from pandas.core.series import Series
-from pandas.core.frame import DataFrame
 from pandas.core.internals import SingleBlockManager
 from pandas.core import generic
 import pandas.core.common as com
@@ -23,7 +21,7 @@ import pandas._libs.index as libindex
 from pandas.util._decorators import Appender
 
 from pandas.core.sparse.array import (
-    make_sparse, _sparse_array_op, SparseArray,
+    make_sparse, SparseArray,
     _make_index)
 from pandas._libs.sparse import BlockIndex, IntIndex
 import pandas._libs.sparse as splib
@@ -36,52 +34,6 @@ from pandas.core.sparse.scipy_sparse import (
 _shared_doc_kwargs = dict(axes='index', klass='SparseSeries',
                           axes_single_arg="{0, 'index'}",
                           optional_labels='', optional_axis='')
-
-# -----------------------------------------------------------------------------
-# Wrapper function for Series arithmetic methods
-
-
-def _arith_method_SPARSE_SERIES(op, name, str_rep=None):
-    """
-    Wrapper function for Series arithmetic operations, to avoid
-    code duplication.
-
-    str_rep is not used, but is present for compatibility.
-    """
-
-    def wrapper(self, other):
-        if isinstance(other, Series):
-            if not isinstance(other, SparseSeries):
-                other = other.to_sparse(fill_value=self.fill_value)
-            return _sparse_series_op(self, other, op, name)
-        elif isinstance(other, DataFrame):
-            return NotImplemented
-        elif is_scalar(other):
-            with np.errstate(all='ignore'):
-                new_values = op(self.values, other)
-            return self._constructor(new_values,
-                                     index=self.index,
-                                     name=self.name)
-        else:  # pragma: no cover
-            raise TypeError('operation with {other} not supported'
-                            .format(other=type(other)))
-
-    wrapper.__name__ = name
-    if name.startswith("__"):
-        # strip special method names, e.g. `__add__` needs to be `add` when
-        # passed to _sparse_series_op
-        name = name[2:-2]
-    return wrapper
-
-
-def _sparse_series_op(left, right, op, name):
-    left, right = left.align(right, join='outer', copy=False)
-    new_index = left.index
-    new_name = com._maybe_match_name(left, right)
-
-    result = _sparse_array_op(left.values, right.values, op, name,
-                              series=True)
-    return left._constructor(result, index=new_index, name=new_name)
 
 
 class SparseSeries(Series):
@@ -865,6 +817,6 @@ ops.add_flex_arithmetic_methods(SparseSeries, **ops.series_flex_funcs)
 # overwrite basic arithmetic to use SparseSeries version
 # force methods to overwrite previous definitions.
 ops.add_special_arithmetic_methods(SparseSeries,
-                                   arith_method=_arith_method_SPARSE_SERIES,
-                                   comp_method=_arith_method_SPARSE_SERIES,
+                                   ops._arith_method_SPARSE_SERIES,
+                                   comp_method=ops._arith_method_SPARSE_SERIES,
                                    bool_method=None, force=True)


### PR DESCRIPTION
Follow-up to #19346, making **kwargs more explicit, documenting how they are chosen, moving one method from `Panel` that belongs in `core.ops`.

- [ ] closes #xxxx
- [ ] tests added / passed
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
