### PR TITLE
standardize cimports of numpy as "cnp"

### DIFF
--- a/pandas/_libs/algos.pyx
+++ b/pandas/_libs/algos.pyx
@@ -1,20 +1,14 @@
 # cython: profile=False
 
-cimport numpy as np
-import numpy as np
-
 cimport cython
 from cython cimport Py_ssize_t
 
-np.import_array()
-
-cdef float64_t FP_ERR = 1e-13
-
-cimport util
-
 from libc.stdlib cimport malloc, free
 from libc.string cimport memmove
+from libc.math cimport fabs, sqrt
 
+import numpy as np
+cimport numpy as cnp
 from numpy cimport (ndarray,
                     NPY_INT64, NPY_UINT64, NPY_INT32, NPY_INT16, NPY_INT8,
                     NPY_FLOAT32, NPY_FLOAT64,
@@ -22,17 +16,18 @@ from numpy cimport (ndarray,
                     int8_t, int16_t, int32_t, int64_t, uint8_t, uint16_t,
                     uint32_t, uint64_t, float32_t, float64_t,
                     double_t)
+cnp.import_array()
 
 
-cdef double NaN = <double> np.NaN
-cdef double nan = NaN
-
-from libc.math cimport fabs, sqrt
-
-# this is our util.pxd
+cimport util
 from util cimport numeric, get_nat
 
 import missing
+
+cdef float64_t FP_ERR = 1e-13
+
+cdef double NaN = <double> np.NaN
+cdef double nan = NaN
 
 cdef int64_t iNaT = get_nat()
 

--- a/pandas/_libs/algos_rank_helper.pxi.in
+++ b/pandas/_libs/algos_rank_helper.pxi.in
@@ -50,7 +50,7 @@ def rank_1d_{{dtype}}(object in_arr, ties_method='average', ascending=True,
 
         ndarray[float64_t] ranks
         ndarray[int64_t] argsorted
-        ndarray[np.uint8_t, cast=True] sorted_mask
+        ndarray[uint8_t, cast=True] sorted_mask
 
         {{if dtype == 'uint64'}}
         {{ctype}} val

--- a/pandas/_libs/hashtable.pyx
+++ b/pandas/_libs/hashtable.pyx
@@ -2,7 +2,7 @@
 
 cimport cython
 
-from cpython cimport (PyObject, Py_INCREF, PyList_Check, PyTuple_Check
+from cpython cimport (PyObject, Py_INCREF, PyList_Check, PyTuple_Check,
                       PyMem_Malloc, PyMem_Realloc, PyMem_Free,
                       PyString_Check, PyBytes_Check,
                       PyUnicode_Check)

--- a/pandas/_libs/hashtable.pyx
+++ b/pandas/_libs/hashtable.pyx
@@ -1,6 +1,22 @@
 # cython: profile=False
 
-from cpython cimport PyObject, Py_INCREF, PyList_Check, PyTuple_Check
+cimport cython
+
+from cpython cimport (PyObject, Py_INCREF, PyList_Check, PyTuple_Check
+                      PyMem_Malloc, PyMem_Realloc, PyMem_Free,
+                      PyString_Check, PyBytes_Check,
+                      PyUnicode_Check)
+
+from libc.stdlib cimport malloc, free
+
+import numpy as np
+cimport numpy as cnp
+from numpy cimport ndarray, uint8_t, uint32_t
+cnp.import_array()
+
+cdef extern from "numpy/npy_math.h":
+    double NAN "NPY_NAN"
+
 
 from khash cimport (
     khiter_t,
@@ -23,29 +39,13 @@ from khash cimport (
     kh_put_pymap, kh_resize_pymap)
 
 
-from numpy cimport ndarray, uint8_t, uint32_t
-
-from libc.stdlib cimport malloc, free
-from cpython cimport (PyMem_Malloc, PyMem_Realloc, PyMem_Free,
-                      PyString_Check, PyBytes_Check,
-                      PyUnicode_Check)
-
 from util cimport _checknan
 cimport util
 
-import numpy as np
-nan = np.nan
-
-cdef extern from "numpy/npy_math.h":
-    double NAN "NPY_NAN"
-
-cimport cython
-cimport numpy as cnp
-
 from missing cimport checknull
 
-cnp.import_array()
-cnp.import_ufunc()
+
+nan = np.nan
 
 cdef int64_t iNaT = util.get_nat()
 _SIZE_HINT_LIMIT = (1 << 20) + 7

--- a/pandas/_libs/index.pyx
+++ b/pandas/_libs/index.pyx
@@ -1,17 +1,19 @@
 # cython: profile=False
+from datetime import datetime, timedelta, date
 
-from numpy cimport (ndarray, float64_t, int32_t, int64_t, uint8_t, uint64_t,
-                    NPY_DATETIME, NPY_TIMEDELTA)
 cimport cython
 
-cimport numpy as cnp
-
-cnp.import_array()
-cnp.import_ufunc()
-
-cimport util
+from cpython cimport PyTuple_Check, PyList_Check
+from cpython.slice cimport PySlice_Check
 
 import numpy as np
+cimport numpy as cnp
+from numpy cimport (ndarray, float64_t, int32_t, int64_t, uint8_t, uint64_t,
+                    NPY_DATETIME, NPY_TIMEDELTA)
+cnp.import_array()
+
+
+cimport util
 
 from tslibs.conversion cimport maybe_datetimelike_to_i8
 
@@ -20,10 +22,6 @@ from hashtable cimport HashTable
 from pandas._libs import algos, hashtable as _hash
 from pandas._libs.tslibs import period as periodlib
 from pandas._libs.tslib import Timestamp, Timedelta
-from datetime import datetime, timedelta, date
-
-from cpython cimport PyTuple_Check, PyList_Check
-from cpython.slice cimport PySlice_Check
 
 cdef int64_t iNaT = util.get_nat()
 

--- a/pandas/_libs/internals.pyx
+++ b/pandas/_libs/internals.pyx
@@ -10,7 +10,6 @@ cdef extern from "Python.h":
     Py_ssize_t PY_SSIZE_T_MAX
 
 import numpy as np
-cimport numpy as np
 from numpy cimport int64_t
 
 cdef extern from "compat_helper.h":

--- a/pandas/_libs/interval.pyx
+++ b/pandas/_libs/interval.pyx
@@ -1,4 +1,4 @@
-cimport numpy as np
+cimport numpy as cnp
 import numpy as np
 
 cimport util

--- a/pandas/_libs/join.pyx
+++ b/pandas/_libs/join.pyx
@@ -1,16 +1,15 @@
 # cython: profile=False
 
-cimport numpy as np
-import numpy as np
-
 cimport cython
 from cython cimport Py_ssize_t
 
-np.import_array()
-
+import numpy as np
+cimport numpy as cnp
 from numpy cimport (ndarray,
                     int8_t, int16_t, int32_t, int64_t, uint8_t, uint16_t,
                     uint32_t, uint64_t, float32_t, float64_t)
+cnp.import_array()
+
 
 cdef double NaN = <double> np.NaN
 cdef double nan = NaN

--- a/pandas/_libs/lib.pyx
+++ b/pandas/_libs/lib.pyx
@@ -5,7 +5,7 @@ cimport cython
 from cython cimport Py_ssize_t
 
 import numpy as np
-cimport numpy as np
+cimport numpy as cnp
 from numpy cimport (ndarray, PyArray_NDIM, PyArray_GETITEM,
                     PyArray_ITER_DATA, PyArray_ITER_NEXT, PyArray_IterNew,
                     flatiter, NPY_OBJECT,
@@ -13,9 +13,7 @@ from numpy cimport (ndarray, PyArray_NDIM, PyArray_GETITEM,
                     float32_t, float64_t,
                     uint8_t, uint64_t,
                     complex128_t)
-# initialize numpy
-np.import_array()
-np.import_ufunc()
+cnp.import_array()
 
 from cpython cimport (Py_INCREF, PyTuple_SET_ITEM,
                       PyList_Check, PyFloat_Check,
@@ -95,7 +93,7 @@ cpdef bint is_scalar(object val):
 
     """
 
-    return (np.PyArray_IsAnyScalar(val)
+    return (cnp.PyArray_IsAnyScalar(val)
             # As of numpy-1.9, PyArray_IsAnyScalar misses bytearrays on Py3.
             or PyBytes_Check(val)
             # We differ from numpy (as of 1.10), which claims that None is
@@ -710,7 +708,7 @@ def clean_index_list(list obj):
 
     for i in range(n):
         v = obj[i]
-        if not (PyList_Check(v) or np.PyArray_Check(v) or hasattr(v, '_data')):
+        if not (PyList_Check(v) or util.is_array(v) or hasattr(v, '_data')):
             all_arrays = 0
             break
 

--- a/pandas/_libs/missing.pyx
+++ b/pandas/_libs/missing.pyx
@@ -7,9 +7,9 @@ cimport cython
 from cython cimport Py_ssize_t
 
 import numpy as np
-cimport numpy as np
+cimport numpy as cnp
 from numpy cimport ndarray, int64_t, uint8_t
-np.import_array()
+cnp.import_array()
 
 cimport util
 

--- a/pandas/_libs/reduction.pyx
+++ b/pandas/_libs/reduction.pyx
@@ -8,13 +8,13 @@ from cpython cimport Py_INCREF
 from libc.stdlib cimport malloc, free
 
 import numpy as np
-cimport numpy as np
+cimport numpy as cnp
 from numpy cimport (ndarray,
                     int64_t,
                     PyArray_SETITEM,
                     PyArray_ITER_NEXT, PyArray_ITER_DATA, PyArray_IterNew,
                     flatiter)
-np.import_array()
+cnp.import_array()
 
 cimport util
 from lib import maybe_convert_objects

--- a/pandas/_libs/reshape.pyx
+++ b/pandas/_libs/reshape.pyx
@@ -1,16 +1,15 @@
 # cython: profile=False
 
-cimport numpy as np
-import numpy as np
-
 cimport cython
 from cython cimport Py_ssize_t
 
-np.import_array()
-
+import numpy as np
+cimport numpy as cnp
 from numpy cimport (ndarray,
                     int8_t, int16_t, int32_t, int64_t, uint8_t, uint16_t,
                     uint32_t, uint64_t, float32_t, float64_t)
+cnp.import_array()
+
 
 cdef double NaN = <double> np.NaN
 cdef double nan = NaN

--- a/pandas/_libs/skiplist.pyx
+++ b/pandas/_libs/skiplist.pyx
@@ -8,19 +8,19 @@
 
 from libc.math cimport log
 
+import numpy as np
+cimport numpy as cnp
+from numpy cimport double_t
+cnp.import_array()
+
+
 # MSVC does not have log2!
 
 cdef double Log2(double x):
     return log(x) / log(2.)
 
-cimport numpy as np
-import numpy as np
-from numpy cimport double_t
 
 from random import random
-
-# initialize numpy
-np.import_array()
 
 # TODO: optimize this, make less messy
 

--- a/pandas/_libs/sparse.pyx
+++ b/pandas/_libs/sparse.pyx
@@ -1,12 +1,15 @@
-from numpy cimport (ndarray, uint8_t, int64_t, int32_t, int16_t, int8_t,
-                    float64_t, float32_t)
-cimport numpy as np
+# -*- coding: utf-8 -*-
+import operator
+import sys
 
 cimport cython
 
 import numpy as np
-import operator
-import sys
+cimport numpy as cnp
+from numpy cimport (ndarray, uint8_t, int64_t, int32_t, int16_t, int8_t,
+                    float64_t, float32_t)
+cnp.import_array()
+
 
 from distutils.version import LooseVersion
 
@@ -15,8 +18,6 @@ _np_version = np.version.short_version
 _np_version_under1p10 = LooseVersion(_np_version) < LooseVersion('1.10')
 _np_version_under1p11 = LooseVersion(_np_version) < LooseVersion('1.11')
 
-np.import_array()
-np.import_ufunc()
 
 # -----------------------------------------------------------------------------
 # Preamble stuff

--- a/pandas/_libs/src/inference.pyx
+++ b/pandas/_libs/src/inference.pyx
@@ -609,13 +609,13 @@ cdef class Validator:
 
     cdef:
         Py_ssize_t n
-        np.dtype dtype
+        cnp.dtype dtype
         bint skipna
 
     def __cinit__(
         self,
         Py_ssize_t n,
-        np.dtype dtype=np.dtype(np.object_),
+        cnp.dtype dtype=np.dtype(np.object_),
         bint skipna=False
     ):
         self.n = n
@@ -823,7 +823,7 @@ cdef class TemporalValidator(Validator):
     def __cinit__(
         self,
         Py_ssize_t n,
-        np.dtype dtype=np.dtype(np.object_),
+        cnp.dtype dtype=np.dtype(np.object_),
         bint skipna=False
     ):
         self.n = n

--- a/pandas/_libs/tslib.pyx
+++ b/pandas/_libs/tslib.pyx
@@ -1,10 +1,10 @@
 # -*- coding: utf-8 -*-
 # cython: profile=False
 
-cimport numpy as np
+cimport numpy as cnp
 from numpy cimport int64_t, ndarray, float64_t
 import numpy as np
-np.import_array()
+cnp.import_array()
 
 
 from cpython cimport PyFloat_Check

--- a/pandas/_libs/tslibs/ccalendar.pyx
+++ b/pandas/_libs/tslibs/ccalendar.pyx
@@ -8,10 +8,9 @@ Cython implementations of functions resembling the stdlib calendar module
 cimport cython
 from cython cimport Py_ssize_t
 
-import numpy as np
-cimport numpy as np
+cimport numpy as cnp
 from numpy cimport int64_t, int32_t
-np.import_array()
+cnp.import_array()
 
 
 # ----------------------------------------------------------------------

--- a/pandas/_libs/tslibs/conversion.pyx
+++ b/pandas/_libs/tslibs/conversion.pyx
@@ -5,9 +5,9 @@ cimport cython
 from cython cimport Py_ssize_t
 
 import numpy as np
-cimport numpy as np
+cimport numpy as cnp
 from numpy cimport int64_t, int32_t, ndarray
-np.import_array()
+cnp.import_array()
 
 import pytz
 

--- a/pandas/_libs/tslibs/fields.pyx
+++ b/pandas/_libs/tslibs/fields.pyx
@@ -9,9 +9,9 @@ cimport cython
 from cython cimport Py_ssize_t
 
 import numpy as np
-cimport numpy as np
+cimport numpy as cnp
 from numpy cimport ndarray, int64_t, int32_t, int8_t
-np.import_array()
+cnp.import_array()
 
 
 from ccalendar cimport (get_days_in_month, is_leapyear, dayofweek,

--- a/pandas/_libs/tslibs/frequencies.pyx
+++ b/pandas/_libs/tslibs/frequencies.pyx
@@ -4,10 +4,9 @@ import re
 
 cimport cython
 
-import numpy as np
-cimport numpy as np
+cimport numpy as cnp
 from numpy cimport int64_t
-np.import_array()
+cnp.import_array()
 
 from util cimport is_integer_object, is_string_object
 

--- a/pandas/_libs/tslibs/nattype.pyx
+++ b/pandas/_libs/tslibs/nattype.pyx
@@ -13,9 +13,9 @@ from cpython.datetime cimport (datetime,
 PyDateTime_IMPORT
 
 import numpy as np
-cimport numpy as np
+cimport numpy as cnp
 from numpy cimport int64_t
-np.import_array()
+cnp.import_array()
 
 from util cimport (get_nat,
                    is_integer_object, is_float_object,

--- a/pandas/_libs/tslibs/offsets.pyx
+++ b/pandas/_libs/tslibs/offsets.pyx
@@ -10,9 +10,9 @@ from cpython.datetime cimport datetime, timedelta, time as dt_time
 from dateutil.relativedelta import relativedelta
 
 import numpy as np
-cimport numpy as np
+cimport numpy as cnp
 from numpy cimport int64_t
-np.import_array()
+cnp.import_array()
 
 
 from util cimport is_string_object, is_integer_object

--- a/pandas/_libs/tslibs/parsing.pyx
+++ b/pandas/_libs/tslibs/parsing.pyx
@@ -18,9 +18,9 @@ from datetime import datetime
 import time
 
 import numpy as np
-cimport numpy as np
+cimport numpy as cnp
 from numpy cimport int64_t, ndarray
-np.import_array()
+cnp.import_array()
 
 # Avoid import from outside _libs
 if sys.version_info.major == 2:

--- a/pandas/_libs/tslibs/resolution.pyx
+++ b/pandas/_libs/tslibs/resolution.pyx
@@ -4,9 +4,9 @@
 from cython cimport Py_ssize_t
 
 import numpy as np
-cimport numpy as np
+cimport numpy as cnp
 from numpy cimport ndarray, int64_t
-np.import_array()
+cnp.import_array()
 
 from util cimport is_string_object, get_nat
 

--- a/pandas/_libs/tslibs/strptime.pyx
+++ b/pandas/_libs/tslibs/strptime.pyx
@@ -27,7 +27,6 @@ from cpython cimport PyFloat_Check
 cimport cython
 
 import numpy as np
-cimport numpy as np
 from numpy cimport ndarray, int64_t
 
 from datetime import date as datetime_date

--- a/pandas/_libs/tslibs/timedeltas.pyx
+++ b/pandas/_libs/tslibs/timedeltas.pyx
@@ -10,9 +10,9 @@ from cython cimport Py_ssize_t
 from cpython cimport PyUnicode_Check, Py_NE, Py_EQ, PyObject_RichCompare
 
 import numpy as np
-cimport numpy as np
+cimport numpy as cnp
 from numpy cimport int64_t, ndarray
-np.import_array()
+cnp.import_array()
 
 from cpython.datetime cimport (datetime, timedelta,
                                PyDateTime_CheckExact,

--- a/pandas/_libs/tslibs/timestamps.pyx
+++ b/pandas/_libs/tslibs/timestamps.pyx
@@ -6,9 +6,9 @@ from cpython cimport (PyObject_RichCompareBool, PyObject_RichCompare,
                       Py_GT, Py_GE, Py_EQ, Py_NE, Py_LT, Py_LE)
 
 import numpy as np
-cimport numpy as np
+cimport numpy as cnp
 from numpy cimport int64_t, int32_t, ndarray
-np.import_array()
+cnp.import_array()
 
 from datetime import time as datetime_time
 from cpython.datetime cimport (datetime,

--- a/pandas/_libs/tslibs/timezones.pyx
+++ b/pandas/_libs/tslibs/timezones.pyx
@@ -18,9 +18,9 @@ UTC = pytz.utc
 
 
 import numpy as np
-cimport numpy as np
+cimport numpy as cnp
 from numpy cimport ndarray, int64_t
-np.import_array()
+cnp.import_array()
 
 # ----------------------------------------------------------------------
 from util cimport is_string_object, is_integer_object, get_nat

--- a/pandas/_libs/window.pyx
+++ b/pandas/_libs/window.pyx
@@ -1,42 +1,39 @@
 # cython: profile=False
 # cython: boundscheck=False, wraparound=False, cdivision=True
 
-from cython cimport Py_ssize_t
-
-cimport numpy as np
-import numpy as np
-
 cimport cython
-
-np.import_array()
-
-cimport util
+from cython cimport Py_ssize_t
 
 from libc.stdlib cimport malloc, free
 
+import numpy as np
+cimport numpy as cnp
 from numpy cimport ndarray, double_t, int64_t, float64_t
+cnp.import_array()
+
+
+cdef extern from "../src/headers/math.h":
+    int signbit(double) nogil
+    double sqrt(double x) nogil
+
+cimport util
+from util cimport numeric
 
 from skiplist cimport (IndexableSkiplist,
                        node_t, skiplist_t,
                        skiplist_init, skiplist_destroy,
                        skiplist_get, skiplist_insert, skiplist_remove)
 
-cdef np.float32_t MINfloat32 = np.NINF
-cdef np.float64_t MINfloat64 = np.NINF
+cdef cnp.float32_t MINfloat32 = np.NINF
+cdef cnp.float64_t MINfloat64 = np.NINF
 
-cdef np.float32_t MAXfloat32 = np.inf
-cdef np.float64_t MAXfloat64 = np.inf
+cdef cnp.float32_t MAXfloat32 = np.inf
+cdef cnp.float64_t MAXfloat64 = np.inf
 
 cdef double NaN = <double> np.NaN
 
 cdef inline int int_max(int a, int b): return a if a >= b else b
 cdef inline int int_min(int a, int b): return a if a <= b else b
-
-from util cimport numeric
-
-cdef extern from "../src/headers/math.h":
-    int signbit(double) nogil
-    double sqrt(double x) nogil
 
 
 # Cython implementations of rolling sum, mean, variance, skewness,

--- a/pandas/io/sas/sas.pyx
+++ b/pandas/io/sas/sas.pyx
@@ -2,16 +2,16 @@
 # cython: boundscheck=False, initializedcheck=False
 
 import numpy as np
-cimport numpy as np
-from numpy cimport uint8_t, uint16_t, int8_t, int64_t
+cimport numpy as cnp
+from numpy cimport uint8_t, uint16_t, int8_t, int64_t, ndarray
 import sas_constants as const
 
 # rle_decompress decompresses data using a Run Length Encoding
 # algorithm.  It is partially documented here:
 #
 # https://cran.r-project.org/web/packages/sas7bdat/vignettes/sas7bdat.pdf
-cdef np.ndarray[uint8_t, ndim=1] rle_decompress(
-        int result_length, np.ndarray[uint8_t, ndim=1] inbuff):
+cdef ndarray[uint8_t, ndim=1] rle_decompress(
+        int result_length, ndarray[uint8_t, ndim=1] inbuff):
 
     cdef:
         uint8_t control_byte, x
@@ -114,8 +114,8 @@ cdef np.ndarray[uint8_t, ndim=1] rle_decompress(
 # rdc_decompress decompresses data using the Ross Data Compression algorithm:
 #
 # http://collaboration.cmc.ec.gc.ca/science/rpn/biblio/ddj/Website/articles/CUJ/1992/9210/ross/ross.htm
-cdef np.ndarray[uint8_t, ndim=1] rdc_decompress(
-        int result_length, np.ndarray[uint8_t, ndim=1] inbuff):
+cdef ndarray[uint8_t, ndim=1] rdc_decompress(
+        int result_length, ndarray[uint8_t, ndim=1] inbuff):
 
     cdef:
         uint8_t cmd
@@ -226,8 +226,8 @@ cdef class Parser(object):
         int subheader_pointer_length
         int current_page_type
         bint is_little_endian
-        np.ndarray[uint8_t, ndim=1] (*decompress)(
-            int result_length, np.ndarray[uint8_t, ndim=1] inbuff)
+        ndarray[uint8_t, ndim=1] (*decompress)(
+            int result_length, ndarray[uint8_t, ndim=1] inbuff)
         object parser
 
     def __init__(self, object parser):
@@ -391,7 +391,7 @@ cdef class Parser(object):
             Py_ssize_t j
             int s, k, m, jb, js, current_row
             int64_t lngt, start, ct
-            np.ndarray[uint8_t, ndim=1] source
+            ndarray[uint8_t, ndim=1] source
             int64_t[:] column_types
             int64_t[:] lengths
             int64_t[:] offsets


### PR DESCRIPTION
In a few files this collects scattered numpy imports and puts them all in one place.

Removes unnecessary `np.import_ufunc()` calls.

- [ ] closes #xxxx
- [ ] tests added / passed
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
