### PR TITLE
Pin Thrift to 0.10.*

### DIFF
--- a/ci/requirements-3.6_WIN.run
+++ b/ci/requirements-3.6_WIN.run
@@ -12,5 +12,6 @@ numexpr
 pytables
 matplotlib
 blosc
+thrift=0.10*
 fastparquet
 pyarrow


### PR DESCRIPTION
fastparquet compatibility in https://github.com/dask/fastparquet/pull/281, which will be released before long. But let's pin for now.