### PR TITLE
DOC: Spellcheck of categorical.rst and visualization.rst

### DIFF
--- a/doc/source/categorical.rst
+++ b/doc/source/categorical.rst
@@ -66,13 +66,13 @@ By converting an existing ``Series`` or column to a ``category`` dtype:
     df["B"] = df["A"].astype('category')
     df
 
-By using special functions, such as :func:`~pandas.cut` (:ref:`docs here 
-<reshaping.tile.cut>`):
+By using special functions, such as :func:`~pandas.cut`, which groups data into
+discrete bins. See the :ref:`example on tiling <reshaping.tile.cut>` in the docs.
 
 .. ipython:: python
 
     df = pd.DataFrame({'value': np.random.randint(0, 100, 20)})
-    labels = [ "{0} - {1}".format(i, i + 9) for i in range(0, 100, 10) ]
+    labels = ["{0} - {1}".format(i, i + 9) for i in range(0, 100, 10)]
 
     df['group'] = pd.cut(df.value, range(0, 105, 10), right=False, labels=labels)
     df.head(10)

--- a/doc/source/categorical.rst
+++ b/doc/source/categorical.rst
@@ -382,7 +382,7 @@ Sorting and Order
 .. _categorical.sort:
 
 If categorical data is ordered (``s.cat.ordered == True``), then the order of the categories has a
-meaning and certain operations are possible. If the categorical is unordered, ``.min()/.max()`` will raise a `TypeError`.
+meaning and certain operations are possible. If the categorical is unordered, ``.min()/.max()`` will raise a ``TypeError``.
 
 .. ipython:: python
 
@@ -436,16 +436,16 @@ necessarily make the sort order the same as the categories order.
 .. note::
 
     Note the difference between assigning new categories and reordering the categories: the first
-    renames categories and therefore the individual values in the `Series`, but if the first
+    renames categories and therefore the individual values in the ``Series``, but if the first
     position was sorted last, the renamed value will still be sorted last. Reordering means that the
     way values are sorted is different afterwards, but not that individual values in the
-    `Series` are changed.
+    ``Series`` are changed.
 
 .. note::
 
-    If the `Categorical` is not ordered, ``Series.min()`` and ``Series.max()`` will raise
+    If the ``Categorical`` is not ordered, :meth:`Series.min` and :meth:`Series.max` will raise
     ``TypeError``. Numeric operations like ``+``, ``-``, ``*``, ``/`` and operations based on them
-    (e.g. ``Series.median()``, which would need to compute the mean between two values if the length
+    (e.g. :meth:`Series.median`, which would need to compute the mean between two values if the length
     of an array is even) do not work and raise a ``TypeError``.
 
 Multi Column Sorting
@@ -472,19 +472,19 @@ Comparisons
 
 Comparing categorical data with other objects is possible in three cases:
 
- * comparing equality (``==`` and ``!=``) to a list-like object (list, Series, array,
+ * Comparing equality (``==`` and ``!=``) to a list-like object (list, Series, array,
    ...) of the same length as the categorical data.
- * all comparisons (``==``, ``!=``, ``>``, ``>=``, ``<``, and ``<=``) of categorical data to
+ * All comparisons (``==``, ``!=``, ``>``, ``>=``, ``<``, and ``<=``) of categorical data to
    another categorical Series, when ``ordered==True`` and the `categories` are the same.
- * all comparisons of a categorical data to a scalar.
+ * All comparisons of a categorical data to a scalar.
 
 All other comparisons, especially "non-equality" comparisons of two categoricals with different
-categories or a categorical with any list-like object, will raise a TypeError.
+categories or a categorical with any list-like object, will raise a ``TypeError``.
 
 .. note::
 
-    Any "non-equality" comparisons of categorical data with a `Series`, `np.array`, `list` or
-    categorical data with different categories or ordering will raise an `TypeError` because custom
+    Any "non-equality" comparisons of categorical data with a ``Series``, ``np.array``, ``list`` or
+    categorical data with different categories or ordering will raise a ``TypeError`` because custom
     categories ordering could be interpreted in two ways: one with taking into account the
     ordering and one without.
 
@@ -554,11 +554,11 @@ When you compare two unordered categoricals with the same categories, the order 
 Operations
 ----------
 
-Apart from ``Series.min()``, ``Series.max()`` and ``Series.mode()``, the following operations are
-possible with categorical data:
+Apart from :meth:`Series.min`, :meth:`Series.max` and :meth:`Series.mode`, the 
+following operations are possible with categorical data:
 
-`Series` methods like `Series.value_counts()` will use all categories, even if some categories are not
-present in the data:
+``Series`` methods like :meth:`Series.value_counts` will use all categories, 
+even if some categories are not present in the data:
 
 .. ipython:: python
 
@@ -596,8 +596,8 @@ that only values already in `categories` can be assigned.
 Getting
 ~~~~~~~
 
-If the slicing operation returns either a `DataFrame` or a column of type `Series`,
-the ``category`` dtype is preserved.
+If the slicing operation returns either a ``DataFrame`` or a column of type 
+``Series``, the ``category`` dtype is preserved.
 
 .. ipython:: python
 
@@ -610,8 +610,8 @@ the ``category`` dtype is preserved.
     df.loc["h":"j","cats"]
     df[df["cats"] == "b"]
 
-An example where the category type is not preserved is if you take one single row: the
-resulting `Series` is of dtype ``object``:
+An example where the category type is not preserved is if you take one single 
+row: the resulting ``Series`` is of dtype ``object``:
 
 .. ipython:: python
 
@@ -628,10 +628,11 @@ of length "1".
     df.at["h","cats"] # returns a string
 
 .. note::
-    This is a difference to R's `factor` function, where ``factor(c(1,2,3))[1]``
+    The is in contrast to R's `factor` function, where ``factor(c(1,2,3))[1]``
     returns a single value `factor`.
 
-To get a single value `Series` of type ``category`` pass in a list with a single value:
+To get a single value ``Series`` of type ``category``, you pass in a list with 
+a single value:
 
 .. ipython:: python
 
@@ -640,8 +641,8 @@ To get a single value `Series` of type ``category`` pass in a list with a single
 String and datetime accessors
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The accessors  ``.dt`` and ``.str`` will work if the ``s.cat.categories`` are of an appropriate
-type:
+The accessors  ``.dt`` and ``.str`` will work if the ``s.cat.categories`` are of
+an appropriate type:
 
 
 .. ipython:: python
@@ -684,8 +685,8 @@ That means, that the returned values from methods and properties on the accessor
 Setting
 ~~~~~~~
 
-Setting values in a categorical column (or `Series`) works as long as the value is included in the
-`categories`:
+Setting values in a categorical column (or ``Series``) works as long as the 
+value is included in the `categories`:
 
 .. ipython:: python
 
@@ -712,7 +713,7 @@ Setting values by assigning categorical data will also check that the `categorie
     except ValueError as e:
         print("ValueError: " + str(e))
 
-Assigning a `Categorical` to parts of a column of other types will use the values:
+Assigning a ``Categorical`` to parts of a column of other types will use the values:
 
 .. ipython:: python
 
@@ -727,7 +728,7 @@ Assigning a `Categorical` to parts of a column of other types will use the value
 Merging
 ~~~~~~~
 
-You can concat two `DataFrames` containing categorical data together,
+You can concat two ``DataFrames`` containing categorical data together,
 but the categories of these categoricals need to be the same:
 
 .. ipython:: python
@@ -739,7 +740,7 @@ but the categories of these categoricals need to be the same:
     res
     res.dtypes
 
-In this case the categories are not the same and so an error is raised:
+In this case the categories are not the same, and therefore an error is raised:
 
 .. ipython:: python
 
@@ -762,10 +763,10 @@ Unioning
 
 .. versionadded:: 0.19.0
 
-If you want to combine categoricals that do not necessarily have
-the same categories, the ``union_categoricals`` function will
-combine a list-like of categoricals. The new categories
-will be the union of the categories being combined.
+If you want to combine categoricals that do not necessarily have the same 
+categories, the :func:`~pandas.api.types.union_categoricals` function will
+combine a list-like of categoricals. The new categories will be the union of 
+the categories being combined.
 
 .. ipython:: python
 
@@ -813,8 +814,9 @@ using the ``ignore_ordered=True`` argument.
     b = pd.Categorical(["c", "b", "a"], ordered=True)
     union_categoricals([a, b], ignore_order=True)
 
-``union_categoricals`` also works with a ``CategoricalIndex``, or ``Series`` containing
-categorical data, but note that the resulting array will always be a plain ``Categorical``
+:func:`~pandas.api.types.union_categoricals` also works with a 
+``CategoricalIndex``, or ``Series`` containing categorical data, but note that 
+the resulting array will always be a plain ``Categorical``:
 
 .. ipython:: python
 
@@ -964,7 +966,7 @@ Differences to R's `factor`
 
 The following differences to R's factor functions can be observed:
 
-* R's `levels` are named `categories`
+* R's `levels` are named `categories`.
 * R's `levels` are always of type string, while `categories` in pandas can be of any dtype.
 * It's not possible to specify labels at creation time. Use ``s.cat.rename_categories(new_labels)``
   afterwards.
@@ -1017,10 +1019,10 @@ an ``object`` dtype is a constant times the length of the data.
 `Categorical` is not a `numpy` array
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Currently, categorical data and the underlying `Categorical` is implemented as a python
-object and not as a low-level `numpy` array dtype. This leads to some problems.
+Currently, categorical data and the underlying ``Categorical`` is implemented as a Python
+object and not as a low-level NumPy array dtype. This leads to some problems.
 
-`numpy` itself doesn't know about the new `dtype`:
+NumPy itself doesn't know about the new `dtype`:
 
 .. ipython:: python
 
@@ -1049,7 +1051,7 @@ To check if a Series contains Categorical data, use ``hasattr(s, 'cat')``:
     hasattr(pd.Series(['a'], dtype='category'), 'cat')
     hasattr(pd.Series(['a']), 'cat')
 
-Using `numpy` functions on a `Series` of type ``category`` should not work as `Categoricals`
+Using NumPy functions on a ``Series`` of type ``category`` should not work as `Categoricals`
 are not numeric data (even in the case that ``.categories`` is numeric).
 
 .. ipython:: python
@@ -1088,7 +1090,7 @@ and allows efficient indexing and storage of an index with a large number of dup
 See the :ref:`advanced indexing docs <indexing.categoricalindex>` for a more detailed
 explanation.
 
-Setting the index will create a ``CategoricalIndex``
+Setting the index will create a ``CategoricalIndex``:
 
 .. ipython:: python
 
@@ -1103,8 +1105,9 @@ Setting the index will create a ``CategoricalIndex``
 Side Effects
 ~~~~~~~~~~~~
 
-Constructing a `Series` from a `Categorical` will not copy the input `Categorical`. This
-means that changes to the `Series` will in most cases change the original `Categorical`:
+Constructing a ``Series`` from a ``Categorical`` will not copy the input 
+``Categorical``. This means that changes to the ``Series`` will in most cases 
+change the original ``Categorical``:
 
 .. ipython:: python
 
@@ -1117,7 +1120,7 @@ means that changes to the `Series` will in most cases change the original `Categ
     df["cat"].cat.categories = [1,2,3,4,5]
     cat
 
-Use ``copy=True`` to prevent such a behaviour or simply don't reuse `Categoricals`:
+Use ``copy=True`` to prevent such a behaviour or simply don't reuse ``Categoricals``:
 
 .. ipython:: python
 
@@ -1128,6 +1131,6 @@ Use ``copy=True`` to prevent such a behaviour or simply don't reuse `Categorical
     cat
 
 .. note::
-    This also happens in some cases when you supply a `numpy` array instead of a `Categorical`:
-    using an int array (e.g. ``np.array([1,2,3,4])``) will exhibit the same behaviour, while using
+    This also happens in some cases when you supply a NumPy array instead of a ``Categorical``:
+    using an int array (e.g. ``np.array([1,2,3,4])``) will exhibit the same behavior, while using
     a string array (e.g. ``np.array(["a","b","c","a"])``) will not.

--- a/doc/source/categorical.rst
+++ b/doc/source/categorical.rst
@@ -19,10 +19,11 @@ Categorical Data
 This is an introduction to pandas categorical data type, including a short comparison
 with R's ``factor``.
 
-`Categoricals` are a pandas data type, which correspond to categorical variables in
-statistics: a variable, which can take on only a limited, and usually fixed,
-number of possible values (`categories`; `levels` in R). Examples are gender, social class,
-blood types, country affiliations, observation time or ratings via Likert scales.
+`Categoricals` are a pandas data type corresponding to categorical variables in
+statistics. A categorical variable takes on a limited, and usually fixed,
+number of possible values (`categories`; `levels` in R). Examples are gender, 
+social class, blood type, country affiliation, observation time or rating via 
+Likert scales.
 
 In contrast to statistical categorical variables, categorical data might have an order (e.g.
 'strongly agree' vs 'agree' or 'first observation' vs. 'second observation'), but numerical
@@ -48,16 +49,16 @@ See also the :ref:`API docs on categoricals<api.categorical>`.
 Object Creation
 ---------------
 
-Categorical `Series` or columns in a `DataFrame` can be created in several ways:
+Categorical ``Series`` or columns in a ``DataFrame`` can be created in several ways:
 
-By specifying ``dtype="category"`` when constructing a `Series`:
+By specifying ``dtype="category"`` when constructing a ``Series``:
 
 .. ipython:: python
 
     s = pd.Series(["a","b","c","a"], dtype="category")
     s
 
-By converting an existing `Series` or column to a ``category`` dtype:
+By converting an existing ``Series`` or column to a ``category`` dtype:
 
 .. ipython:: python
 
@@ -65,7 +66,8 @@ By converting an existing `Series` or column to a ``category`` dtype:
     df["B"] = df["A"].astype('category')
     df
 
-By using some special functions:
+By using special functions, such as :func:`~pandas.cut` (:ref:`docs here 
+<reshaping.tile.cut>`):
 
 .. ipython:: python
 
@@ -74,8 +76,6 @@ By using some special functions:
 
     df['group'] = pd.cut(df.value, range(0, 105, 10), right=False, labels=labels)
     df.head(10)
-
-See :ref:`documentation <reshaping.tile.cut>` for :func:`~pandas.cut`.
 
 By passing a :class:`pandas.Categorical` object to a `Series` or assigning it to a `DataFrame`.
 
@@ -89,10 +89,11 @@ By passing a :class:`pandas.Categorical` object to a `Series` or assigning it to
     df["B"] = raw_cat
     df
 
-Anywhere above we passed a keyword ``dtype='category'``, we used the default behavior of
+In the examples above where we passed ``dtype='category'``, we used the default 
+behavior:
 
-1. categories are inferred from the data
-2. categories are unordered.
+1. Categories are inferred from the data.
+2. Categories are unordered.
 
 To control those behaviors, instead of passing ``'category'``, use an instance
 of :class:`~pandas.api.types.CategoricalDtype`.
@@ -123,8 +124,8 @@ Categorical data has a specific ``category`` :ref:`dtype <basics.dtypes>`:
     In contrast to R's `factor` function, there is currently no way to assign/change labels at
     creation time. Use `categories` to change the categories after creation time.
 
-To get back to the original Series or `numpy` array, use ``Series.astype(original_dtype)`` or
-``np.asarray(categorical)``:
+To get back to the original ``Series`` or NumPy array, use 
+``Series.astype(original_dtype)`` or ``np.asarray(categorical)``:
 
 .. ipython:: python
 
@@ -135,8 +136,9 @@ To get back to the original Series or `numpy` array, use ``Series.astype(origina
     s2.astype(str)
     np.asarray(s2)
 
-If you have already `codes` and `categories`, you can use the :func:`~pandas.Categorical.from_codes`
-constructor to save the factorize step during normal constructor mode:
+If you already have `codes` and `categories`, you can use the 
+:func:`~pandas.Categorical.from_codes` constructor to save the factorize step 
+during normal constructor mode:
 
 .. ipython:: python
 
@@ -171,7 +173,7 @@ by default.
 
 A :class:`~pandas.api.types.CategoricalDtype` can be used in any place pandas
 expects a `dtype`. For example :func:`pandas.read_csv`,
-:func:`pandas.DataFrame.astype`, or in the Series constructor.
+:func:`pandas.DataFrame.astype`, or in the ``Series`` constructor.
 
 .. note::
 
@@ -185,8 +187,8 @@ Equality Semantics
 ~~~~~~~~~~~~~~~~~~
 
 Two instances of :class:`~pandas.api.types.CategoricalDtype` compare equal
-whenever they have the same categories and orderedness. When comparing two
-unordered categoricals, the order of the ``categories`` is not considered
+whenever they have the same categories and order. When comparing two
+unordered categoricals, the order of the ``categories`` is not considered.
 
 .. ipython:: python
 
@@ -198,7 +200,7 @@ unordered categoricals, the order of the ``categories`` is not considered
    # Unequal, since the second CategoricalDtype is ordered
    c1 == CategoricalDtype(['a',  'b', 'c'], ordered=True)
 
-All instances of ``CategoricalDtype`` compare equal to the string ``'category'``
+All instances of ``CategoricalDtype`` compare equal to the string ``'category'``.
 
 .. ipython:: python
 
@@ -215,8 +217,8 @@ All instances of ``CategoricalDtype`` compare equal to the string ``'category'``
 Description
 -----------
 
-Using ``.describe()`` on categorical data will produce similar output to a `Series` or
-`DataFrame` of type ``string``.
+Using :meth:`~DataFrame.describe` on categorical data will produce similar 
+output to a ``Series`` or ``DataFrame`` of type ``string``.
 
 .. ipython:: python
 
@@ -230,10 +232,10 @@ Using ``.describe()`` on categorical data will produce similar output to a `Seri
 Working with categories
 -----------------------
 
-Categorical data has a `categories` and a `ordered` property, which list their possible values and
-whether the ordering matters or not. These properties are exposed as ``s.cat.categories`` and
-``s.cat.ordered``. If you don't manually specify categories and ordering, they are inferred from the
-passed in values.
+Categorical data has a `categories` and a `ordered` property, which list their 
+possible values and whether the ordering matters or not. These properties are 
+exposed as ``s.cat.categories`` and ``s.cat.ordered``. If you don't manually 
+specify categories and ordering, they are inferred from the passed arguments.
 
 .. ipython:: python
 
@@ -251,13 +253,13 @@ It's also possible to pass in the categories in a specific order:
 
 .. note::
 
-    New categorical data are NOT automatically ordered. You must explicitly pass ``ordered=True`` to
-    indicate an ordered ``Categorical``.
+    New categorical data are **not** automatically ordered. You must explicitly 
+    pass ``ordered=True`` to indicate an ordered ``Categorical``.
 
 
 .. note::
 
-    The result of ``Series.unique()`` is not always the same as ``Series.cat.categories``,
+    The result of :meth:`~Series.unique` is not always the same as ``Series.cat.categories``,
     because ``Series.unique()`` has a couple of guarantees, namely that it returns categories
     in the order of appearance, and it only includes values that are actually present.
 
@@ -275,8 +277,10 @@ It's also possible to pass in the categories in a specific order:
 Renaming categories
 ~~~~~~~~~~~~~~~~~~~
 
-Renaming categories is done by assigning new values to the ``Series.cat.categories`` property or
-by using the :func:`Categorical.rename_categories` method:
+Renaming categories is done by assigning new values to the 
+``Series.cat.categories`` property or by using the 
+:meth:`~pandas.Categorical.rename_categories` method:
+
 
 .. ipython:: python
 
@@ -296,8 +300,8 @@ by using the :func:`Categorical.rename_categories` method:
 
 .. note::
 
-    Be aware that assigning new categories is an inplace operations, while most other operation
-    under ``Series.cat`` per default return a new Series of dtype `category`.
+    Be aware that assigning new categories is an inplace operation, while most other operations
+    under ``Series.cat`` per default return a new ``Series`` of dtype `category`.
 
 Categories must be unique or a `ValueError` is raised:
 
@@ -320,7 +324,8 @@ Categories must also not be ``NaN`` or a `ValueError` is raised:
 Appending new categories
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
-Appending categories can be done by using the :func:`Categorical.add_categories` method:
+Appending categories can be done by using the 
+:meth:`~pandas.Categorical.add_categories` method:
 
 .. ipython:: python
 
@@ -331,8 +336,9 @@ Appending categories can be done by using the :func:`Categorical.add_categories`
 Removing categories
 ~~~~~~~~~~~~~~~~~~~
 
-Removing categories can be done by using the :func:`Categorical.remove_categories` method. Values
-which are removed are replaced by ``np.nan``.:
+Removing categories can be done by using the 
+:meth:`~pandas.Categorical.remove_categories` method. Values which are removed 
+are replaced by ``np.nan``.:
 
 .. ipython:: python
 
@@ -353,8 +359,10 @@ Removing unused categories can also be done:
 Setting categories
 ~~~~~~~~~~~~~~~~~~
 
-If you want to do remove and add new categories in one step (which has some speed advantage),
-or simply set the categories to a predefined scale, use :func:`Categorical.set_categories`.
+If you want to do remove and add new categories in one step (which has some 
+speed advantage), or simply set the categories to a predefined scale, 
+use :meth:`~pandas.Categorical.set_categories`.
+
 
 .. ipython:: python
 
@@ -366,7 +374,7 @@ or simply set the categories to a predefined scale, use :func:`Categorical.set_c
 .. note::
     Be aware that :func:`Categorical.set_categories` cannot know whether some category is omitted
     intentionally or because it is misspelled or (under Python3) due to a type difference (e.g.,
-    numpys S1 dtype and Python strings). This can result in surprising behaviour!
+    NumPy S1 dtype and Python strings). This can result in surprising behaviour!
 
 Sorting and Order
 -----------------
@@ -411,8 +419,8 @@ This is even true for strings and numeric data:
 Reordering
 ~~~~~~~~~~
 
-Reordering the categories is possible via the :func:`Categorical.reorder_categories` and
-the :func:`Categorical.set_categories` methods. For :func:`Categorical.reorder_categories`, all
+Reordering the categories is possible via the :meth:`Categorical.reorder_categories` and
+the :meth:`Categorical.set_categories` methods. For :meth:`Categorical.reorder_categories`, all
 old categories must be included in the new categories and no new categories are allowed. This will
 necessarily make the sort order the same as the categories order.
 

--- a/doc/source/visualization.rst
+++ b/doc/source/visualization.rst
@@ -37,7 +37,8 @@ libraries that go beyond the basics documented here.
 Basic Plotting: ``plot``
 ------------------------
 
-See the :ref:`cookbook<cookbook.plotting>` for some advanced strategies
+We will demonstrate the basics, see the :ref:`cookbook<cookbook.plotting>` for 
+some advanced strategies.
 
 The ``plot`` method on Series and DataFrame is just a simple wrapper around
 :meth:`plt.plot() <matplotlib.axes.Axes.plot>`:
@@ -94,7 +95,8 @@ You can plot one column versus another using the `x` and `y` keywords in
 
 .. note::
 
-   For more formatting and styling options, see :ref:`below <visualization.formatting>`.
+   For more formatting and styling options, see 
+   :ref:`formatting <visualization.formatting>` below.
 
 .. ipython:: python
     :suppress:
@@ -107,14 +109,13 @@ Other Plots
 -----------
 
 Plotting methods allow for a handful of plot styles other than the
-default Line plot. These methods can be provided as the ``kind``
-keyword argument to :meth:`~DataFrame.plot`.
-These include:
+default line plot. These methods can be provided as the ``kind``
+keyword argument to :meth:`~DataFrame.plot`, and include:
 
 * :ref:`'bar' <visualization.barplot>` or :ref:`'barh' <visualization.barplot>` for bar plots
 * :ref:`'hist' <visualization.hist>` for histogram
 * :ref:`'box' <visualization.box>` for boxplot
-* :ref:`'kde' <visualization.kde>` or ``'density'`` for density plots
+* :ref:`'kde' <visualization.kde>` or :ref:`'density' <visualization.kde>` for density plots
 * :ref:`'area' <visualization.area_plot>` for area plots
 * :ref:`'scatter' <visualization.scatter>` for scatter plots
 * :ref:`'hexbin' <visualization.hexbin>` for hexagonal bin plots
@@ -220,7 +221,7 @@ To get horizontal bar plots, use the ``barh`` method:
 Histograms
 ~~~~~~~~~~
 
-Histogram can be drawn by using the :meth:`DataFrame.plot.hist` and :meth:`Series.plot.hist` methods.
+Histograms can be drawn by using the :meth:`DataFrame.plot.hist` and :meth:`Series.plot.hist` methods.
 
 .. ipython:: python
 
@@ -238,7 +239,8 @@ Histogram can be drawn by using the :meth:`DataFrame.plot.hist` and :meth:`Serie
 
    plt.close('all')
 
-Histogram can be stacked by ``stacked=True``. Bin size can be changed by ``bins`` keyword.
+A histogram can be stacked using ``stacked=True``. Bin size can be changed 
+using the ``bins`` keyword.
 
 .. ipython:: python
 
@@ -252,7 +254,9 @@ Histogram can be stacked by ``stacked=True``. Bin size can be changed by ``bins`
 
    plt.close('all')
 
-You can pass other keywords supported by matplotlib ``hist``. For example, horizontal and cumulative histogram can be drawn by ``orientation='horizontal'`` and ``cumulative=True``.
+You can pass other keywords supported by matplotlib ``hist``. For example, 
+horizontal and cumulative histograms can be drawn by 
+``orientation='horizontal'`` and ``cumulative=True``.
 
 .. ipython:: python
 
@@ -463,7 +467,7 @@ keyword, will affect the output type as well:
 ``'both'``       Yes     Series of namedtuples
 ================ ======= ==========================
 
-``Groupby.boxplot`` always returns a Series of ``return_type``.
+``Groupby.boxplot`` always returns a ``Series`` of ``return_type``.
 
 .. ipython:: python
    :okwarning:
@@ -481,7 +485,9 @@ keyword, will affect the output type as well:
 
    plt.close('all')
 
-Compare to:
+The subplots above are split by the numeric columns first, then the value of 
+the ``g`` column. Below the subplots are first split by the value of ``g``,
+then by the numeric columns.
 
 .. ipython:: python
    :okwarning:
@@ -536,8 +542,8 @@ Scatter Plot
 ~~~~~~~~~~~~
 
 Scatter plot can be drawn by using the :meth:`DataFrame.plot.scatter` method.
-Scatter plot requires numeric columns for x and y axis.
-These can be specified by ``x`` and ``y`` keywords each.
+Scatter plot requires numeric columns for the x and y axes.
+These can be specified by the ``x`` and ``y`` keywords.
 
 .. ipython:: python
    :suppress:
@@ -581,8 +587,9 @@ each point:
 
    plt.close('all')
 
-You can pass other keywords supported by matplotlib ``scatter``.
-Below example shows a bubble chart using a dataframe column values as bubble size.
+You can pass other keywords supported by matplotlib 
+:meth:`scatter <matplotlib.axes.Axes.scatter>`. The example  below shows a 
+bubble chart using a column of the ``DataFrame`` as the bubble size.
 
 .. ipython:: python
 
@@ -631,7 +638,7 @@ You can specify alternative aggregations by passing values to the ``C`` and
 and ``reduce_C_function`` is a function of one argument that reduces all the
 values in a bin to a single number (e.g. ``mean``, ``max``, ``sum``, ``std``).  In this
 example the positions are given by columns ``a`` and ``b``, while the value is
-given by column ``z``. The bins are aggregated with numpy's ``max`` function.
+given by column ``z``. The bins are aggregated with NumPy's ``max`` function.
 
 .. ipython:: python
    :suppress:
@@ -685,14 +692,16 @@ A ``ValueError`` will be raised if there are any negative values in your data.
 
    plt.close('all')
 
-For pie plots it's best to use square figures, one's with an equal aspect ratio. You can create the
-figure with equal width and height, or force the aspect ratio to be equal after plotting by
-calling ``ax.set_aspect('equal')`` on the returned ``axes`` object.
+For pie plots it's best to use square figures, i.e. a figure aspect ratio 1. 
+You can create the figure with equal width and height, or force the aspect ratio 
+to be equal after plotting by calling ``ax.set_aspect('equal')`` on the returned 
+``axes`` object.
 
-Note that pie plot with :class:`DataFrame` requires that you either specify a target column by the ``y``
-argument or ``subplots=True``. When ``y`` is specified, pie plot of selected column
-will be drawn. If ``subplots=True`` is specified, pie plots for each column are drawn as subplots.
-A legend will be drawn in each pie plots by default; specify ``legend=False`` to hide it.
+Note that pie plot with :class:`DataFrame` requires that you either specify a 
+target column by the ``y`` argument or ``subplots=True``. When ``y`` is 
+specified, pie plot of selected column will be drawn. If ``subplots=True`` is 
+specified, pie plots for each column are drawn as subplots. A legend will be 
+drawn in each pie plots by default; specify ``legend=False`` to hide it.
 
 .. ipython:: python
    :suppress:
@@ -762,7 +771,7 @@ See the `matplotlib pie documentation <http://matplotlib.org/api/pyplot_api.html
 Plotting with Missing Data
 --------------------------
 
-Pandas tries to be pragmatic about plotting DataFrames or Series
+Pandas tries to be pragmatic about plotting ``DataFrames`` or ``Series``
 that contain missing data. Missing values are dropped, left out, or filled
 depending on the plot type.
 
@@ -861,7 +870,8 @@ Andrews Curves
 
 Andrews curves allow one to plot multivariate data as a large number
 of curves that are created using the attributes of samples as coefficients
-for Fourier series. By coloring these curves differently for each class
+for Fourier series, see the `Wikipedia entry<https://en.wikipedia.org/wiki/Andrews_plot>`_
+for more information. By coloring these curves differently for each class
 it is possible to visualize data clustering. Curves belonging to samples
 of the same class will usually be closer together and form larger structures.
 
@@ -883,8 +893,10 @@ of the same class will usually be closer together and form larger structures.
 Parallel Coordinates
 ~~~~~~~~~~~~~~~~~~~~
 
-Parallel coordinates is a plotting technique for plotting multivariate data.
-It allows one to see clusters in data and to estimate other statistics visually.
+Parallel coordinates is a plotting technique for plotting multivariate data,
+see the `Wikipedia entry<https://en.wikipedia.org/wiki/Parallel_coordinates>`_
+for an introduction.
+Parallel coordinates allows one to see clusters in data and to estimate other statistics visually.
 Using parallel coordinates points are represented as connected line segments.
 Each vertical line represents one attribute. One set of connected line segments
 represents one data point. Points that tend to cluster will appear closer together.
@@ -912,7 +924,9 @@ Lag Plot
 
 Lag plots are used to check if a data set or time series is random. Random
 data should not exhibit any structure in the lag plot. Non-random structure
-implies that the underlying data are not random.
+implies that the underlying data are not random. The ``lag`` argument may
+be passed, and when ``lag=1`` the plot is essentially ``data[:-1]`` vs. 
+``data[1:]``.
 
 .. ipython:: python
    :suppress:
@@ -947,7 +961,9 @@ If time series is random, such autocorrelations should be near zero for any and
 all time-lag separations. If time series is non-random then one or more of the
 autocorrelations will be significantly non-zero. The horizontal lines displayed
 in the plot correspond to 95% and 99% confidence bands. The dashed line is 99%
-confidence band.
+confidence band. See the 
+`Wikipedia entry<https://en.wikipedia.org/wiki/Correlogram>`_ for more about
+autocorrelation plots.
 
 .. ipython:: python
    :suppress:
@@ -1016,6 +1032,8 @@ unit interval). The point in the plane, where our sample settles to (where the
 forces acting on our sample are at an equilibrium) is where a dot representing
 our sample will be drawn. Depending on which class that sample belongs it will
 be colored differently.
+See the R package `Radviz<https://cran.r-project.org/web/packages/Radviz/>`_
+for more information.
 
 **Note**: The "Iris" dataset is available `here <https://raw.github.com/pandas-dev/pandas/master/pandas/tests/data/iris.csv>`__.
 
@@ -1046,7 +1064,7 @@ Setting the plot style
 From version 1.5 and up, matplotlib offers a range of preconfigured plotting styles. Setting the
 style can be used to easily give plots the general look that you want.
 Setting the style is as easy as calling ``matplotlib.style.use(my_plot_style)`` before
-creating your plot. For example you could do ``matplotlib.style.use('ggplot')`` for ggplot-style
+creating your plot. For example you could write ``matplotlib.style.use('ggplot')`` for ggplot-style
 plots.
 
 You can see the various available style names at ``matplotlib.style.available`` and it's very
@@ -1147,7 +1165,7 @@ To plot data on a secondary y-axis, use the ``secondary_y`` keyword:
 
    plt.close('all')
 
-To plot some columns in a DataFrame, give the column names to the ``secondary_y``
+To plot some columns in a ``DataFrame``, give the column names to the ``secondary_y``
 keyword:
 
 .. ipython:: python
@@ -1248,7 +1266,7 @@ See the :meth:`autofmt_xdate <matplotlib.figure.autofmt_xdate>` method and the
 Subplots
 ~~~~~~~~
 
-Each Series in a DataFrame can be plotted on a different axis
+Each ``Series`` in a ``DataFrame`` can be plotted on a different axis
 with the ``subplots`` keyword:
 
 .. ipython:: python
@@ -1264,9 +1282,9 @@ with the ``subplots`` keyword:
 Using Layout and Targeting Multiple Axes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The layout of subplots can be specified by ``layout`` keyword. It can accept
+The layout of subplots can be specified by the ``layout`` keyword. It can accept
 ``(rows, columns)``. The ``layout`` keyword can be used in
-``hist`` and ``boxplot`` also. If input is invalid, ``ValueError`` will be raised.
+``hist`` and ``boxplot`` also. If the input is invalid, a ``ValueError`` will be raised.
 
 The number of axes which can be contained by rows x columns specified by ``layout`` must be
 larger than the number of required subplots. If layout can contain more axes than required,
@@ -1284,7 +1302,7 @@ or columns needed, given the other.
 
    plt.close('all')
 
-The above example is identical to using
+The above example is identical to using:
 
 .. ipython:: python
 
@@ -1298,11 +1316,11 @@ The above example is identical to using
 The required number of columns (3) is inferred from the number of series to plot
 and the given number of rows (2).
 
-Also, you can pass multiple axes created beforehand as list-like via ``ax`` keyword.
-This allows to use more complicated layout.
+You can pass multiple axes created beforehand as list-like via ``ax`` keyword.
+This allows more complicated layouts.
 The passed axes must be the same number as the subplots being drawn.
 
-When multiple axes are passed via ``ax`` keyword, ``layout``, ``sharex`` and ``sharey`` keywords
+When multiple axes are passed via the ``ax`` keyword, ``layout``, ``sharex`` and ``sharey`` keywords
 don't affect to the output. You should explicitly pass ``sharex=False`` and ``sharey=False``,
 otherwise you will see a warning.
 
@@ -1359,13 +1377,13 @@ Another option is passing an ``ax`` argument to :meth:`Series.plot` to plot on a
 Plotting With Error Bars
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
-Plotting with error bars is now supported in the :meth:`DataFrame.plot` and :meth:`Series.plot`
+Plotting with error bars is supported in :meth:`DataFrame.plot` and :meth:`Series.plot`.
 
-Horizontal and vertical errorbars can be supplied to the ``xerr`` and ``yerr`` keyword arguments to :meth:`~DataFrame.plot()`. The error values can be specified using a variety of formats.
+Horizontal and vertical error bars can be supplied to the ``xerr`` and ``yerr`` keyword arguments to :meth:`~DataFrame.plot()`. The error values can be specified using a variety of formats:
 
-- As a :class:`DataFrame` or ``dict`` of errors with column names matching the ``columns`` attribute of the plotting :class:`DataFrame` or matching the ``name`` attribute of the :class:`Series`
-- As a ``str`` indicating which of the columns of plotting :class:`DataFrame` contain the error values
-- As raw values (``list``, ``tuple``, or ``np.ndarray``). Must be the same length as the plotting :class:`DataFrame`/:class:`Series`
+- As a :class:`DataFrame` or ``dict`` of errors with column names matching the ``columns`` attribute of the plotting :class:`DataFrame` or matching the ``name`` attribute of the :class:`Series`.
+- As a ``str`` indicating which of the columns of plotting :class:`DataFrame` contain the error values.
+- As raw values (``list``, ``tuple``, or ``np.ndarray``). Must be the same length as the plotting :class:`DataFrame`/:class:`Series`.
 
 Asymmetrical error bars are also supported, however raw error values must be provided in this case. For a ``M`` length :class:`Series`, a ``Mx2`` array should be provided indicating lower and upper (or left and right) errors. For a ``MxN`` :class:`DataFrame`, asymmetrical errors should be in a ``Mx2xN`` array.
 
@@ -1420,7 +1438,10 @@ Plotting with matplotlib table is now supported in  :meth:`DataFrame.plot` and :
 
    plt.close('all')
 
-Also, you can pass different :class:`DataFrame` or :class:`Series` for ``table`` keyword. The data will be drawn as displayed in print method (not transposed automatically). If required, it should be transposed manually as below example.
+Also, you can pass a different :class:`DataFrame` or :class:`Series` to the 
+``table`` keyword. The data will be drawn as displayed in print method 
+(not transposed automatically). If required, it should be transposed manually 
+as seen in the example below.
 
 .. ipython:: python
 
@@ -1434,7 +1455,10 @@ Also, you can pass different :class:`DataFrame` or :class:`Series` for ``table``
 
    plt.close('all')
 
-Finally, there is a helper function ``pandas.plotting.table`` to create a table from :class:`DataFrame` and :class:`Series`, and add it to an ``matplotlib.Axes``. This function can accept keywords which matplotlib table has.
+There also exists a helper function ``pandas.plotting.table``, which creates a 
+table from :class:`DataFrame` or :class:`Series`, and adds it to an 
+``matplotlib.Axes`` instance. This function can accept keywords which the 
+matplotlib `table <http://matplotlib.org/api/axes_api.html#matplotlib.axes.Axes.table>`__ has.
 
 .. ipython:: python
 
@@ -1461,18 +1485,18 @@ Colormaps
 
 A potential issue when plotting a large number of columns is that it can be
 difficult to distinguish some series due to repetition in the default colors. To
-remedy this, DataFrame plotting supports the use of the ``colormap=`` argument,
+remedy this, ``DataFrame`` plotting supports the use of the ``colormap`` argument,
 which accepts either a Matplotlib `colormap <http://matplotlib.org/api/cm_api.html>`__
 or a string that is a name of a colormap registered with Matplotlib. A
 visualization of the default matplotlib colormaps is available `here
-<http://wiki.scipy.org/Cookbook/Matplotlib/Show_colormaps>`__.
+<https://matplotlib.org/examples/color/colormaps_reference.html>`__.
 
 As matplotlib does not directly support colormaps for line-based plots, the
 colors are selected based on an even spacing determined by the number of columns
-in the DataFrame. There is no consideration made for background color, so some
+in the ``DataFrame``. There is no consideration made for background color, so some
 colormaps will produce lines that are not easily visible.
 
-To use the cubehelix colormap, we can simply pass ``'cubehelix'`` to ``colormap=``
+To use the cubehelix colormap, we can pass ``colormap='cubehelix'``.
 
 .. ipython:: python
    :suppress:
@@ -1494,7 +1518,7 @@ To use the cubehelix colormap, we can simply pass ``'cubehelix'`` to ``colormap=
 
    plt.close('all')
 
-or we can pass the colormap itself
+Alternatively, we can pass the colormap itself:
 
 .. ipython:: python
 
@@ -1565,9 +1589,9 @@ Plotting directly with matplotlib
 
 In some situations it may still be preferable or necessary to prepare plots
 directly with matplotlib, for instance when a certain type of plot or
-customization is not (yet) supported by pandas. Series and DataFrame objects
-behave like arrays and can therefore be passed directly to matplotlib functions
-without explicit casts.
+customization is not (yet) supported by pandas. ``Series`` and ``DataFrame`` 
+objects behave like arrays and can therefore be passed directly to 
+matplotlib functions without explicit casts.
 
 pandas also automatically registers formatters and locators that recognize date
 indices, thereby extending date and time support to practically all plot types


### PR DESCRIPTION
Minor changes to the documentation, specifically `categorical.rst` and `visualization.rst`:

* Function references as links.
* Backticks ` `` ` around Series, DataFrame.
* Minor rephrasing of sentences, spelling, etc.
* For plots such as lag plots, Andrews plot, Radviz, I added links to Wikipedia entries.

Comments very welcome.
