### PR TITLE
TST: fix test for MultiIndexPyIntEngine on 32 bit

### DIFF
--- a/pandas/tests/test_multilevel.py
+++ b/pandas/tests/test_multilevel.py
@@ -1611,7 +1611,7 @@ Thur,Lunch,Yes,51.51,17"""
             index = MultiIndex.from_tuples(keys)
             assert index.get_loc(keys[idx]) == idx
 
-            expected = np.arange(idx + 1, dtype='int64')
+            expected = np.arange(idx + 1, dtype=np.intp)
             result = index.get_indexer([keys[i] for i in expected])
             tm.assert_numpy_array_equal(result, expected)
 


### PR DESCRIPTION
- [x] closes #19439
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`

It was just a problem in the test.