### PR TITLE
Change Future to DeprecationWarning for make_block_same_class

### DIFF
--- a/pandas/core/internals.py
+++ b/pandas/core/internals.py
@@ -230,7 +230,7 @@ class Block(PandasObject):
         if dtype is not None:
             # issue 19431 fastparquet is passing this
             warnings.warn("dtype argument is deprecated, will be removed "
-                          "in a future release.", FutureWarning)
+                          "in a future release.", DeprecationWarning)
         if placement is None:
             placement = self.mgr_locs
         return make_block(values, placement=placement, ndim=ndim,

--- a/pandas/tests/internals/test_internals.py
+++ b/pandas/tests/internals/test_internals.py
@@ -288,9 +288,10 @@ class TestBlock(object):
     def test_make_block_same_class(self):
         # issue 19431
         block = create_block('M8[ns, US/Eastern]', [3])
-        with tm.assert_produces_warning(FutureWarning,
+        with tm.assert_produces_warning(DeprecationWarning,
                                         check_stacklevel=False):
-            block.make_block_same_class(block.values, dtype=block.values.dtype)
+            block.make_block_same_class(block.values.values,
+                                        dtype=block.values.dtype)
 
 
 class TestDatetimeBlock(object):


### PR DESCRIPTION
xref https://github.com/pandas-dev/pandas/pull/19434

@jreback I didn't want to further discuss on the PR, so let's do that here :-)

By having it as a FutureWarning, we only annoy users, and the fastparquet developers are already aware of it. 
BTW, we do exactly the same for pyarrow's 'misuse' of internal API, we added a deprecationwarning for them.