### PR TITLE
Simple solutions for users running into problems running large queries in pandas.read_gbq()

### DIFF
--- a/pandas/io/gbq.py
+++ b/pandas/io/gbq.py
@@ -1,4 +1,5 @@
 """ Google BigQuery support """
+import datetime
 
 
 def _try_import():
@@ -23,6 +24,8 @@ def _try_import():
 
 def read_gbq(query, project_id=None, index_col=None, col_order=None,
              reauth=False, verbose=True, private_key=None, dialect='legacy',
+             allow_large_results=False, query_dataset='query_dataset',
+             query_tableid=None,
              **kwargs):
     r"""Load data from Google BigQuery.
 
@@ -74,6 +77,17 @@ def read_gbq(query, project_id=None, index_col=None, col_order=None,
         see `BigQuery SQL Reference
         <https://cloud.google.com/bigquery/sql-reference/>`__
 
+    allow_large_results : boolean (default False)
+        Allows large queries greater than quota limit - Use when a GenericGBQException
+        error is thrown with "Reason: responseTooLarge" 
+        See: https://cloud.google.com/bigquery/docs/writing-results#large-results
+        
+    query_dataset : str (optional)
+        Google BigQuery dataset to which the results of a large query will
+        be saved
+    query_tableid : str (optional)
+        Google BigQuery tableid to which the results will be saved
+
     `**kwargs` : Arbitrary keyword arguments
         configuration (dict): query config parameters for job processing.
         For example:
@@ -90,6 +104,7 @@ def read_gbq(query, project_id=None, index_col=None, col_order=None,
 
     """
     pandas_gbq = _try_import()
+    kwargs = update_read_gbq_kwargs(kwargs, project_id, allow_large_results, query_dataset, query_tableid)
     return pandas_gbq.read_gbq(
         query, project_id=project_id,
         index_col=index_col, col_order=col_order,
@@ -106,3 +121,71 @@ def to_gbq(dataframe, destination_table, project_id, chunksize=10000,
                       chunksize=chunksize,
                       verbose=verbose, reauth=reauth,
                       if_exists=if_exists, private_key=private_key)
+
+
+def update_read_gbq_kwargs(read_gbq_kwargs, project_id, allow_large_results, query_dataset,
+                            query_tableid, write_disposition="WRITE_TRUNCATE"):
+    """
+    
+    Parameters
+    ----------
+    read_gbq_kwargs: dict
+        query config parameters for job processing passed to the read_gbq function 
+        For example:
+
+            configuration = {'query': {'useQueryCache': False}}
+
+        For more information see `BigQuery SQL Reference
+        <https://cloud.google.com/bigquery/docs/reference/rest/v2/jobs#configuration.query>`__
+    project_id : str
+        Google BigQuery Account project ID.    
+    allow_large_results : boolean (default False)
+        Allows large queries greater than quota limit - Use when a GenericGBQException
+        error is thrown with "Reason: responseTooLarge" 
+        See: https://cloud.google.com/bigquery/docs/writing-results#large-results
+    intermediate_dataset : str
+        Google BigQuery dataset to which the results of a large query will
+        be saved
+    query_tableid : str
+        Google BigQuery tableid to which the results will be saved
+    write_disposition : str
+        Use "WRITE_TRUNCATE" to overwrite old intermediate BigQuery query data
+
+
+
+    Returns
+    -------
+    updated kwargs
+
+    """
+
+    # Create tableId if left as None
+    if query_tableid is None:
+        # Generic name with timestamp unique down to the microsecond:
+        query_tableid = 'intermediate_query_results_' + datetime.datetime.utcnow().strftime("%Y%M%d-%H%m-%f")
+
+    # New configuration for allowing large queries:
+    updated_query_config = {'query': {
+        'allowLargeResults': allow_large_results,
+        'destinationTable': {
+            'projectId': project_id,
+            'datasetId': query_dataset,
+            'tableId': query_tableid
+        },
+        'writeDisposition': write_disposition
+    }}
+
+    # Append to predefined configuration:
+    if 'configuration' not in read_gbq_kwargs:
+        read_gbq_kwargs['configuration'] = updated_query_config
+    else:
+        # Append new configuration to user prescribed query configuration:
+        read_gbq_kwargs['configuration']
+        if 'query' not in read_gbq_kwargs['configuration']:
+            read_gbq_kwargs['configuration']['query'] = updated_query_config['query']
+        else:
+            for updated_key in updated_query_config:
+                if updated_key not in read_gbq_kwargs['configuration']['query']:
+                    read_gbq_kwargs['configuration']['query'][updated_key] = updated_query_config['query'][updated_key]
+
+    return read_gbq_kwargs


### PR DESCRIPTION
- This solves the `allowLargeResults` problem users bump into when running large queries using `pandas.read_gbq()`.  Here is an example:
```
> import pandas
> project_id = '' # add your project id:
> q = """                                             
SELECT 
contributor_id,                
FROM [bigquery-public-data:samples.wikipedia] 
LIMIT 1000000000
"""
> pandas.read_gbq(q, project_id)

GenericGBQException: Reason: 403 GET https://www.googleapis.com/bigquery/v2/projects/data-reply/queries/1777aeb7-b1e6-49ca-9ab0-6bd41d162d49?timeoutMs=900&maxResults=0: Response too large to return. Consider setting allowLargeResults to true in your job configuration. For more information, see https://cloud.google.com/bigquery/troubleshooting-errors
```

The problem is now fixed by doing the following:
1. Create an intermediate query data dataset in GBQ
1. Run the `pandas.read_gbq()` function now with `allow_large_results=True` and the name of the new dataset created in the previous step.
  ```
  > pandas.read_gbq(q, project_id, allow_large_results=True, query_dataset="name of intermediate 
  query dataset")
  ```

- This removes the undocumented annoyance users go through to figure out how to add their own customized configuration to get through this problem
- If this seems useful, I will write tests - I know it seems like code that I should add to pandas-gbq but to me the configuration modification should be done at the top level (which in this case is pandas.read_gbq)
