### PR TITLE
Continue de-nesting core.ops

### DIFF
--- a/pandas/core/ops.py
+++ b/pandas/core/ops.py
@@ -39,7 +39,7 @@ from pandas.core.dtypes.generic import (
     ABCSeries,
     ABCDataFrame,
     ABCIndex,
-    ABCSparseSeries)
+    ABCSparseSeries, ABCSparseArray)
 
 
 def _gen_eval_kwargs(name):
@@ -448,7 +448,8 @@ def add_methods(cls, new_methods):
     for name, method in new_methods.items():
         # inplace SparseArray methods do not get overriden; everything else
         # does
-        force = not (issubclass(cls, np.ndarray) and name.startswith('__i'))
+        force = not (issubclass(cls, ABCSparseArray) and
+                     name.startswith('__i'))
         if force or name not in cls.__dict__:
             bind_method(cls, name, method)
 

--- a/pandas/core/ops.py
+++ b/pandas/core/ops.py
@@ -1020,6 +1020,12 @@ def _arith_method_FRAME(op, name, str_rep=None):
                 mask = notna(xrav) & notna(yrav)
                 xrav = xrav[mask]
 
+                if yrav.shape != mask.shape:
+                    # FIXME: GH#5284, GH#5035, GH#19448
+                    # Without specifically raising here we get mismatched
+                    # errors in Py3 (TypeError) vs Py2 (ValueError)
+                    raise ValueError('Cannot broadcast operands together.')
+
                 yrav = yrav[mask]
                 if xrav.size:
                     with np.errstate(all='ignore'):

--- a/pandas/core/sparse/series.py
+++ b/pandas/core/sparse/series.py
@@ -819,4 +819,4 @@ ops.add_flex_arithmetic_methods(SparseSeries, **ops.series_flex_funcs)
 ops.add_special_arithmetic_methods(SparseSeries,
                                    ops._arith_method_SPARSE_SERIES,
                                    comp_method=ops._arith_method_SPARSE_SERIES,
-                                   bool_method=None, force=True)
+                                   bool_method=None)


### PR DESCRIPTION
- Move `isinstance(other, ABCDataFrame)` checks to consistently be the first thing checked in Series ops

- Remove `force` kwarg, define it in the one place it is used.

- Remove kludge for `PeriodIndex`

- Handle categorical_dtype earlier in arith_method_SERIES, decreasing complexity of the closure.

- Handle scalar na other earlier in _comp_method_SERIES, decreasing complexity of the closure.

- Remove broken broadcasting case from _arith_method_FRAME (closes #19421)