### PR TITLE
implement bits of numpy_helper in cython where possible

### DIFF
--- a/pandas/_libs/src/numpy_helper.h
+++ b/pandas/_libs/src/numpy_helper.h
@@ -18,33 +18,6 @@ The full license is in the LICENSE file, distributed with this software.
 
 PANDAS_INLINE npy_int64 get_nat(void) { return NPY_MIN_INT64; }
 
-PANDAS_INLINE int is_integer_object(PyObject* obj) {
-    return (!PyBool_Check(obj)) && PyArray_IsIntegerScalar(obj);
-}
-
-PANDAS_INLINE int is_float_object(PyObject* obj) {
-    return (PyFloat_Check(obj) || PyArray_IsScalar(obj, Floating));
-}
-PANDAS_INLINE int is_complex_object(PyObject* obj) {
-    return (PyComplex_Check(obj) || PyArray_IsScalar(obj, ComplexFloating));
-}
-
-PANDAS_INLINE int is_bool_object(PyObject* obj) {
-    return (PyBool_Check(obj) || PyArray_IsScalar(obj, Bool));
-}
-
-PANDAS_INLINE int is_string_object(PyObject* obj) {
-    return (PyString_Check(obj) || PyUnicode_Check(obj));
-}
-
-PANDAS_INLINE int is_datetime64_object(PyObject* obj) {
-    return PyArray_IsScalar(obj, Datetime);
-}
-
-PANDAS_INLINE int is_timedelta64_object(PyObject* obj) {
-    return PyArray_IsScalar(obj, Timedelta);
-}
-
 PANDAS_INLINE int assign_value_1d(PyArrayObject* ap, Py_ssize_t _i,
                                   PyObject* v) {
     npy_intp i = (npy_intp)_i;
@@ -78,19 +51,6 @@ PANDAS_INLINE PyObject* char_to_string(char* data) {
 
 void set_array_not_contiguous(PyArrayObject* ao) {
     ao->flags &= ~(NPY_C_CONTIGUOUS | NPY_F_CONTIGUOUS);
-}
-
-// If arr is zerodim array, return a proper array scalar (e.g. np.int64).
-// Otherwise, return arr as is.
-PANDAS_INLINE PyObject* unbox_if_zerodim(PyObject* arr) {
-    if (PyArray_IsZeroDim(arr)) {
-        PyObject* ret;
-        ret = PyArray_ToScalar(PyArray_DATA(arr), arr);
-        return ret;
-    } else {
-        Py_INCREF(arr);
-        return arr;
-    }
 }
 
 #endif  // PANDAS__LIBS_SRC_NUMPY_HELPER_H_

--- a/pandas/_libs/src/util.pxd
+++ b/pandas/_libs/src/util.pxd
@@ -1,24 +1,76 @@
-from numpy cimport ndarray
+from numpy cimport ndarray, NPY_C_CONTIGUOUS, NPY_F_CONTIGUOUS
 cimport numpy as cnp
-cimport cpython
+cnp.import_array()
 
+cimport cpython
+from cpython cimport PyTypeObject
+
+cdef extern from "Python.h":
+    # Note: importing extern-style allows us to declare these as nogil
+    # functions, whereas `from cpython cimport` does not.
+    bint PyUnicode_Check(object obj) nogil
+    bint PyString_Check(object obj) nogil
+    bint PyBool_Check(object obj) nogil
+    bint PyFloat_Check(object obj) nogil
+    bint PyComplex_Check(object obj) nogil
+    bint PyObject_TypeCheck(object obj, PyTypeObject* type) nogil
+
+
+cdef extern from "numpy/arrayobject.h":
+    PyTypeObject PyFloatingArrType_Type
+
+cdef extern from "numpy/ndarrayobject.h":
+    PyTypeObject PyTimedeltaArrType_Type
+    PyTypeObject PyDatetimeArrType_Type
+    PyTypeObject PyComplexFloatingArrType_Type
+    PyTypeObject PyBoolArrType_Type
+
+    bint PyArray_IsIntegerScalar(obj) nogil
+    bint PyArray_Check(obj) nogil
+
+# --------------------------------------------------------------------
+# Type Checking
+
+cdef inline bint is_string_object(object obj) nogil:
+    return PyString_Check(obj) or PyUnicode_Check(obj)
+
+
+cdef inline bint is_integer_object(object obj) nogil:
+    return not PyBool_Check(obj) and PyArray_IsIntegerScalar(obj)
+
+
+cdef inline bint is_float_object(object obj) nogil:
+    return (PyFloat_Check(obj) or
+            (PyObject_TypeCheck(obj, &PyFloatingArrType_Type)))
+
+
+cdef inline bint is_complex_object(object obj) nogil:
+    return (PyComplex_Check(obj) or
+            PyObject_TypeCheck(obj, &PyComplexFloatingArrType_Type))
+
+
+cdef inline bint is_bool_object(object obj) nogil:
+    return (PyBool_Check(obj) or
+            PyObject_TypeCheck(obj, &PyBoolArrType_Type))
+
+
+cdef inline bint is_timedelta64_object(object obj) nogil:
+    return PyObject_TypeCheck(obj, &PyTimedeltaArrType_Type)
+
+
+cdef inline bint is_datetime64_object(object obj) nogil:
+    return PyObject_TypeCheck(obj, &PyDatetimeArrType_Type)
+
+# --------------------------------------------------------------------
 
 cdef extern from "numpy_helper.h":
     void set_array_not_contiguous(ndarray ao)
 
-    int is_integer_object(object)
-    int is_float_object(object)
-    int is_complex_object(object)
-    int is_bool_object(object)
-    int is_string_object(object)
-    int is_datetime64_object(object)
-    int is_timedelta64_object(object)
     int assign_value_1d(ndarray, Py_ssize_t, object) except -1
     cnp.int64_t get_nat()
     object get_value_1d(ndarray, Py_ssize_t)
     char *get_c_string(object) except NULL
     object char_to_string(char*)
-    object unbox_if_zerodim(object arr)
 
 ctypedef fused numeric:
     cnp.int8_t
@@ -112,3 +164,22 @@ cdef inline bint _checknan(object val):
 
 cdef inline bint is_period_object(object val):
     return getattr(val, '_typ', '_typ') == 'period'
+
+
+cdef inline object unbox_if_zerodim(object arr):
+    """
+    If arr is zerodim array, return a proper array scalar (e.g. np.int64).
+    Otherwise, return arr as is.
+
+    Parameters
+    ----------
+    arr : object
+
+    Returns
+    -------
+    result : object
+    """
+    if cnp.PyArray_IsZeroDim(arr):
+        return cnp.PyArray_ToScalar(cnp.PyArray_DATA(arr), arr)
+    else:
+        return arr

--- a/setup.py
+++ b/setup.py
@@ -686,8 +686,7 @@ if suffix == '.pyx':
             ext.sources[0] = root + suffix
 
 ujson_ext = Extension('pandas._libs.json',
-                      depends=['pandas/_libs/src/ujson/lib/ultrajson.h',
-                               'pandas/_libs/src/numpy_helper.h'],
+                      depends=['pandas/_libs/src/ujson/lib/ultrajson.h'],
                       sources=(['pandas/_libs/src/ujson/python/ujson.c',
                                 'pandas/_libs/src/ujson/python/objToJSON.c',
                                 'pandas/_libs/src/ujson/python/JSONtoObj.c',


### PR DESCRIPTION
Like with the transition to tslibs.np_datetime, this implements pieces of numpy_helper.h directly in cython in util.pxd.  The generated C should be equivalent to existing versions, but that is worth double-checking.

One dependency is removed from setup.py that was missed in #19415, should have been deleted there.