### PR TITLE
Remove reference to deprecated .ix from 10min.rst

### DIFF
--- a/doc/source/10min.rst
+++ b/doc/source/10min.rst
@@ -154,7 +154,7 @@ Selection
    While standard Python / Numpy expressions for selecting and setting are
    intuitive and come in handy for interactive work, for production code, we
    recommend the optimized pandas data access methods, ``.at``, ``.iat``,
-   ``.loc``, ``.iloc`` and ``.ix``.
+   ``.loc`` and ``.iloc``.
 
 See the indexing documentation :ref:`Indexing and Selecting Data <indexing>` and :ref:`MultiIndex / Advanced Indexing <advanced>`.
 


### PR DESCRIPTION
The deprecated `.ix` should not be advertised anymore in the "10 minutes guide to pandas".
