### PR TITLE
TST: fix (other check of) test for MultiIndexPyIntEngine on 32 bit

### DIFF
--- a/pandas/tests/test_multilevel.py
+++ b/pandas/tests/test_multilevel.py
@@ -1617,7 +1617,7 @@ Thur,Lunch,Yes,51.51,17"""
 
         # With missing key:
         idces = range(len(keys))
-        expected = np.array([-1] + list(idces), dtype='int64')
+        expected = np.array([-1] + list(idces), dtype=np.intp)
         missing = tuple([0, 1] * 5 * N)
         result = index.get_indexer([missing] + [keys[i] for i in idces])
         tm.assert_numpy_array_equal(result, expected)


### PR DESCRIPTION
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`

Second part of #19440