### PR TITLE
CI: pin pymysql<0.8.0

### DIFF
--- a/ci/requirements-3.6.run
+++ b/ci/requirements-3.6.run
@@ -13,7 +13,7 @@ lxml
 html5lib
 jinja2
 sqlalchemy
-pymysql
+pymysql<0.8.0
 feather-format
 pyarrow
 psycopg2


### PR DESCRIPTION
looks like builds failing on change in ``pymqsql`` verion from 0.7.11 to 0.8.0:https://travis-ci.org/pandas-dev/pandas/jobs/334960629