### PR TITLE
BUG: Fixed accessor for Categorical[Datetime]

### DIFF
--- a/pandas/core/indexes/accessors.py
+++ b/pandas/core/indexes/accessors.py
@@ -72,9 +72,12 @@ class Properties(PandasDelegate, PandasObject, NoNewAttributesMixin):
         # blow up if we operate on categories
         if self.orig is not None:
             result = take_1d(result, self.orig.cat.codes)
+            index = self.orig.index
+        else:
+            index = self.index
 
         # return the result as a Series, which is by definition a copy
-        result = Series(result, index=self.index, name=self.name)
+        result = Series(result, index=index, name=self.name)
 
         # setting this object will show a SettingWithCopyWarning/Error
         result._is_copy = ("modifications to a property of a datetimelike "

--- a/pandas/tests/series/test_datetime_values.py
+++ b/pandas/tests/series/test_datetime_values.py
@@ -261,10 +261,10 @@ class TestSeriesDatetimeValues(TestData):
 
     def test_dt_namespace_accessor_categorical(self):
         # GH 19468
-        dti = pd.DatetimeIndex(['20171111', '20181212']).repeat(2)
-        s = pd.Series(pd.Categorical(dti), name='foo')
+        dti = DatetimeIndex(['20171111', '20181212']).repeat(2)
+        s = Series(pd.Categorical(dti), name='foo')
         result = s.dt.year
-        expected = pd.Series([2017, 2017, 2018, 2018], name='foo')
+        expected = Series([2017, 2017, 2018, 2018], name='foo')
         tm.assert_series_equal(result, expected)
 
     def test_dt_accessor_no_new_attributes(self):

--- a/pandas/tests/series/test_datetime_values.py
+++ b/pandas/tests/series/test_datetime_values.py
@@ -259,6 +259,14 @@ class TestSeriesDatetimeValues(TestData):
 
             pytest.raises(com.SettingWithCopyError, f)
 
+    def test_dt_namespace_accessor_categorical(self):
+        # GH 19468
+        dti = pd.DatetimeIndex(['20171111', '20181212']).repeat(2)
+        s = pd.Series(pd.Categorical(dti), name='foo')
+        result = s.dt.year
+        expected = pd.Series([2017, 2017, 2018, 2018], name='foo')
+        tm.assert_series_equal(result, expected)
+
     def test_dt_accessor_no_new_attributes(self):
         # https://github.com/pandas-dev/pandas/issues/10673
         s = Series(date_range('20130101', periods=5, freq='D'))


### PR DESCRIPTION
Closes https://github.com/pandas-dev/pandas/issues/19468

No release note, since this was only a regression on master.

cc @jschendel.