### PR TITLE
Centralize Arithmetic Tests

### DIFF
--- a/pandas/tests/frame/test_arithmetic.py
+++ b/pandas/tests/frame/test_arithmetic.py
@@ -1,10 +1,66 @@
 # -*- coding: utf-8 -*-
 
+import pytest
 import numpy as np
 
 import pandas as pd
 import pandas.util.testing as tm
 
+
+# -------------------------------------------------------------------
+# Comparisons
+
+class TestFrameComparisons(object):
+    def test_df_boolean_comparison_error(self):
+        # GH#4576
+        # boolean comparisons with a tuple/list give unexpected results
+        df = pd.DataFrame(np.arange(6).reshape((3, 2)))
+
+        # not shape compatible
+        with pytest.raises(ValueError):
+            df == (2, 2)
+        with pytest.raises(ValueError):
+            df == [2, 2]
+
+    def test_df_float_none_comparison(self):
+        df = pd.DataFrame(np.random.randn(8, 3), index=range(8),
+                          columns=['A', 'B', 'C'])
+
+        with pytest.raises(TypeError):
+            df.__eq__(None)
+
+    def test_df_string_comparison(self):
+        df = pd.DataFrame([{"a": 1, "b": "foo"}, {"a": 2, "b": "bar"}])
+        mask_a = df.a > 1
+        tm.assert_frame_equal(df[mask_a], df.loc[1:1, :])
+        tm.assert_frame_equal(df[-mask_a], df.loc[0:0, :])
+
+        mask_b = df.b == "foo"
+        tm.assert_frame_equal(df[mask_b], df.loc[0:0, :])
+        tm.assert_frame_equal(df[-mask_b], df.loc[1:1, :])
+
+    @pytest.mark.parametrize('opname', ['eq', 'ne', 'gt', 'lt', 'ge', 'le'])
+    def test_df_flex_cmp_constant_return_types(self, opname):
+        # GH#15077, non-empty DataFrame
+        df = pd.DataFrame({'x': [1, 2, 3], 'y': [1., 2., 3.]})
+        const = 2
+
+        result = getattr(df, opname)(const).get_dtype_counts()
+        tm.assert_series_equal(result, pd.Series([2], ['bool']))
+
+    @pytest.mark.parametrize('opname', ['eq', 'ne', 'gt', 'lt', 'ge', 'le'])
+    def test_df_flex_cmp_constant_return_types_empty(self, opname):
+        # GH#15077 empty DataFrame
+        df = pd.DataFrame({'x': [1, 2, 3], 'y': [1., 2., 3.]})
+        const = 2
+
+        empty = df.iloc[:0]
+        result = getattr(empty, opname)(const).get_dtype_counts()
+        tm.assert_series_equal(result, pd.Series([2], ['bool']))
+
+
+# -------------------------------------------------------------------
+# Arithmetic
 
 class TestPeriodFrameArithmetic(object):
 

--- a/pandas/tests/frame/test_arithmetic.py
+++ b/pandas/tests/frame/test_arithmetic.py
@@ -62,6 +62,53 @@ class TestFrameComparisons(object):
 # -------------------------------------------------------------------
 # Arithmetic
 
+class TestFrameArithmetic(object):
+
+    @pytest.mark.xfail(reason='GH#7996 datetime64 units not converted to nano')
+    def test_df_sub_datetime64_not_ns(self):
+        df = pd.DataFrame(pd.date_range('20130101', periods=3))
+        dt64 = np.datetime64('2013-01-01')
+        assert dt64.dtype == 'datetime64[D]'
+        res = df - dt64
+        expected = pd.DataFrame([pd.Timedelta(days=0), pd.Timedelta(days=1),
+                                 pd.Timedelta(days=2)])
+        tm.assert_frame_equal(res, expected)
+
+    @pytest.mark.parametrize('data', [
+        [1, 2, 3],
+        [1.1, 2.2, 3.3],
+        [pd.Timestamp('2011-01-01'), pd.Timestamp('2011-01-02'), pd.NaT],
+        ['x', 'y', 1]])
+    @pytest.mark.parametrize('dtype', [None, object])
+    def test_df_radd_str_invalid(self, dtype, data):
+        df = pd.DataFrame(data, dtype=dtype)
+        with pytest.raises(TypeError):
+            'foo_' + df
+
+    @pytest.mark.parametrize('dtype', [None, object])
+    def test_df_with_dtype_radd_int(self, dtype):
+        df = pd.DataFrame([1, 2, 3], dtype=dtype)
+        expected = pd.DataFrame([2, 3, 4], dtype=dtype)
+        result = 1 + df
+        tm.assert_frame_equal(result, expected)
+        result = df + 1
+        tm.assert_frame_equal(result, expected)
+
+    @pytest.mark.parametrize('dtype', [None, object])
+    def test_df_with_dtype_radd_nan(self, dtype):
+        df = pd.DataFrame([1, 2, 3], dtype=dtype)
+        expected = pd.DataFrame([np.nan, np.nan, np.nan], dtype=dtype)
+        result = np.nan + df
+        tm.assert_frame_equal(result, expected)
+        result = df + np.nan
+        tm.assert_frame_equal(result, expected)
+
+    def test_df_radd_str(self):
+        df = pd.DataFrame(['x', np.nan, 'x'])
+        tm.assert_frame_equal('a' + df, pd.DataFrame(['ax', np.nan, 'ax']))
+        tm.assert_frame_equal(df + 'a', pd.DataFrame(['xa', np.nan, 'xa']))
+
+
 class TestPeriodFrameArithmetic(object):
 
     def test_ops_frame_period(self):

--- a/pandas/tests/frame/test_operators.py
+++ b/pandas/tests/frame/test_operators.py
@@ -28,53 +28,6 @@ from pandas.tests.frame.common import (TestData, _check_mixed_float,
                                        _check_mixed_int)
 
 
-class TestDataFrameArithmetic(object):
-
-    @pytest.mark.xfail(reason='GH#7996 datetime64 units not converted to nano')
-    def test_frame_sub_datetime64_not_ns(self):
-        df = pd.DataFrame(date_range('20130101', periods=3))
-        dt64 = np.datetime64('2013-01-01')
-        assert dt64.dtype == 'datetime64[D]'
-        res = df - dt64
-        expected = pd.DataFrame([pd.Timedelta(days=0), pd.Timedelta(days=1),
-                                 pd.Timedelta(days=2)])
-        tm.assert_frame_equal(res, expected)
-
-    @pytest.mark.parametrize('data', [
-        [1, 2, 3],
-        [1.1, 2.2, 3.3],
-        [pd.Timestamp('2011-01-01'), pd.Timestamp('2011-01-02'), pd.NaT],
-        ['x', 'y', 1]])
-    @pytest.mark.parametrize('dtype', [None, object])
-    def test_frame_radd_str_invalid(self, dtype, data):
-        df = DataFrame(data, dtype=dtype)
-        with pytest.raises(TypeError):
-            'foo_' + df
-
-    @pytest.mark.parametrize('dtype', [None, object])
-    def test_frame_with_dtype_radd_int(self, dtype):
-        df = pd.DataFrame([1, 2, 3], dtype=dtype)
-        expected = pd.DataFrame([2, 3, 4], dtype=dtype)
-        result = 1 + df
-        assert_frame_equal(result, expected)
-        result = df + 1
-        assert_frame_equal(result, expected)
-
-    @pytest.mark.parametrize('dtype', [None, object])
-    def test_frame_with_dtype_radd_nan(self, dtype):
-        df = pd.DataFrame([1, 2, 3], dtype=dtype)
-        expected = pd.DataFrame([np.nan, np.nan, np.nan], dtype=dtype)
-        result = np.nan + df
-        assert_frame_equal(result, expected)
-        result = df + np.nan
-        assert_frame_equal(result, expected)
-
-    def test_frame_radd_str(self):
-        df = pd.DataFrame(['x', np.nan, 'x'])
-        assert_frame_equal('a' + df, pd.DataFrame(['ax', np.nan, 'ax']))
-        assert_frame_equal(df + 'a', pd.DataFrame(['xa', np.nan, 'xa']))
-
-
 class TestDataFrameOperators(TestData):
 
     def test_operators(self):

--- a/pandas/tests/frame/test_operators.py
+++ b/pandas/tests/frame/test_operators.py
@@ -10,7 +10,7 @@ import pytest
 from numpy import nan, random
 import numpy as np
 
-from pandas.compat import lrange, range
+from pandas.compat import range
 from pandas import compat
 from pandas import (DataFrame, Series, MultiIndex, Timestamp,
                     date_range)
@@ -714,22 +714,6 @@ class TestDataFrameOperators(TestData):
         exp = DataFrame({'col': [False, True, False]})
         assert_frame_equal(result, exp)
 
-    def test_return_dtypes_bool_op_costant(self):
-        # GH15077
-        df = DataFrame({'x': [1, 2, 3], 'y': [1., 2., 3.]})
-        const = 2
-
-        # not empty DataFrame
-        for op in ['eq', 'ne', 'gt', 'lt', 'ge', 'le']:
-            result = getattr(df, op)(const).get_dtype_counts()
-            tm.assert_series_equal(result, Series([2], ['bool']))
-
-        # empty DataFrame
-        empty = df.iloc[:0]
-        for op in ['eq', 'ne', 'gt', 'lt', 'ge', 'le']:
-            result = getattr(empty, op)(const).get_dtype_counts()
-            tm.assert_series_equal(result, Series([2], ['bool']))
-
     def test_dti_tz_convert_to_utc(self):
         base = pd.DatetimeIndex(['2011-01-01', '2011-01-02',
                                  '2011-01-03'], tz='UTC')
@@ -1009,22 +993,6 @@ class TestDataFrameOperators(TestData):
             result = (missing_df < 0).values
         tm.assert_numpy_array_equal(result, expected)
 
-    def test_string_comparison(self):
-        df = DataFrame([{"a": 1, "b": "foo"}, {"a": 2, "b": "bar"}])
-        mask_a = df.a > 1
-        assert_frame_equal(df[mask_a], df.loc[1:1, :])
-        assert_frame_equal(df[-mask_a], df.loc[0:0, :])
-
-        mask_b = df.b == "foo"
-        assert_frame_equal(df[mask_b], df.loc[0:0, :])
-        assert_frame_equal(df[-mask_b], df.loc[1:1, :])
-
-    def test_float_none_comparison(self):
-        df = DataFrame(np.random.randn(8, 3), index=lrange(8),
-                       columns=['A', 'B', 'C'])
-
-        pytest.raises(TypeError, df.__eq__, None)
-
     def test_boolean_comparison(self):
 
         # GH 4576
@@ -1090,16 +1058,6 @@ class TestDataFrameOperators(TestData):
 
         result = df == tup
         assert_frame_equal(result, expected)
-
-    def test_boolean_comparison_error(self):
-
-        # GH 4576
-        # boolean comparisons with a tuple/list give unexpected results
-        df = DataFrame(np.arange(6).reshape((3, 2)))
-
-        # not shape compatible
-        pytest.raises(ValueError, lambda: df == (2, 2))
-        pytest.raises(ValueError, lambda: df == [2, 2])
 
     def test_combine_generic(self):
         df1 = self.frame

--- a/pandas/tests/series/test_arithmetic.py
+++ b/pandas/tests/series/test_arithmetic.py
@@ -120,7 +120,7 @@ class TestTimedeltaSeriesComparisons(object):
 
 
 class TestPeriodSeriesComparisons(object):
-    @pytest.mark.paramtrize('freq', ['M', '2M', '3M'])
+    @pytest.mark.parametrize('freq', ['M', '2M', '3M'])
     def test_cmp_series_period_scalar(self, freq):
         # GH 13200
         base = Series([Period(x, freq=freq) for x in
@@ -159,7 +159,7 @@ class TestPeriodSeriesComparisons(object):
         with tm.assert_raises_regex(IncompatibleFrequency, msg):
             Period('2011', freq='A') >= base
 
-    @pytest.mark.paramtrize('freq', ['M', '2M', '3M'])
+    @pytest.mark.parametrize('freq', ['M', '2M', '3M'])
     def test_cmp_series_period_series(self, freq):
         # GH#13200
         base = Series([Period(x, freq=freq) for x in

--- a/pandas/tests/series/test_arithmetic.py
+++ b/pandas/tests/series/test_arithmetic.py
@@ -45,6 +45,18 @@ class TestSeriesComparison(object):
 
 
 class TestTimestampSeriesComparison(object):
+    def test_dt64ser_cmp_period_scalar(self):
+        ser = Series(pd.period_range('2000-01-01', periods=10, freq='D'))
+        val = Period('2000-01-04', freq='D')
+        result = ser > val
+        expected = Series([x > val for x in ser])
+        tm.assert_series_equal(result, expected)
+
+        val = ser[5]
+        result = ser > val
+        expected = Series([x > val for x in ser])
+        tm.assert_series_equal(result, expected)
+
     def test_timestamp_compare_series(self):
         # make sure we can compare Timestamps on the right AND left hand side
         # GH#4982
@@ -108,20 +120,8 @@ class TestTimedeltaSeriesComparisons(object):
 
 
 class TestPeriodSeriesComparisons(object):
-    def test_series_comparison_scalars(self):
-        ser = Series(pd.period_range('2000-01-01', periods=10, freq='D'))
-        val = Period('2000-01-04', freq='D')
-        result = ser > val
-        expected = Series([x > val for x in ser])
-        tm.assert_series_equal(result, expected)
-
-        val = ser[5]
-        result = ser > val
-        expected = Series([x > val for x in ser])
-        tm.assert_series_equal(result, expected)
-
     @pytest.mark.paramtrize('freq', ['M', '2M', '3M'])
-    def test_comp_series_period_scalar(self, freq):
+    def test_cmp_series_period_scalar(self, freq):
         # GH 13200
         base = Series([Period(x, freq=freq) for x in
                        ['2011-01', '2011-02', '2011-03', '2011-04']])
@@ -194,7 +194,7 @@ class TestPeriodSeriesComparisons(object):
         with tm.assert_raises_regex(IncompatibleFrequency, msg):
             base <= ser2
 
-    def test_cmp_series_period_scalar(self):
+    def test_cmp_series_period_series_mixed_freq(self):
         # GH#13200
         base = Series([Period('2011', freq='A'),
                        Period('2011-02', freq='M'),
@@ -223,6 +223,7 @@ class TestPeriodSeriesComparisons(object):
 
         exp = Series([True, False, True, True])
         tm.assert_series_equal(base <= ser, exp)
+
 
 # ------------------------------------------------------------------
 # Arithmetic
@@ -260,10 +261,10 @@ class TestSeriesArithmetic(object):
         expected = pd.Series([np.nan, np.nan, np.nan], dtype=dtype)
 
         result = np.nan + ser
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         result = ser + np.nan
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
     @pytest.mark.parametrize('dtype', [None, object])
     def test_series_with_dtype_radd_int(self, dtype):
@@ -271,15 +272,15 @@ class TestSeriesArithmetic(object):
         expected = pd.Series([2, 3, 4], dtype=dtype)
 
         result = 1 + ser
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
         result = ser + 1
-        assert_series_equal(result, expected)
+        tm.assert_series_equal(result, expected)
 
     def test_series_radd_str(self):
         ser = pd.Series(['x', np.nan, 'x'])
-        assert_series_equal('a' + ser, pd.Series(['ax', np.nan, 'ax']))
-        assert_series_equal(ser + 'a', pd.Series(['xa', np.nan, 'xa']))
+        tm.assert_series_equal('a' + ser, pd.Series(['ax', np.nan, 'ax']))
+        tm.assert_series_equal(ser + 'a', pd.Series(['xa', np.nan, 'xa']))
 
 
 class TestPeriodSeriesArithmetic(object):

--- a/pandas/tests/series/test_arithmetic.py
+++ b/pandas/tests/series/test_arithmetic.py
@@ -25,7 +25,7 @@ class TestSeriesComparison(object):
         tm.assert_series_equal(a / b, 1 / (b / a))
 
     @pytest.mark.parametrize('opname', ['eq', 'ne', 'gt', 'lt', 'ge', 'le'])
-    def test_return_dtypes_flex_cmp_constant(self, opname):
+    def test_ser_flex_cmp_return_dtypes(self, opname):
         # GH#15115
         ser = Series([1, 3, 2], index=range(3))
         const = 2
@@ -34,7 +34,7 @@ class TestSeriesComparison(object):
         tm.assert_series_equal(result, Series([1], ['bool']))
 
     @pytest.mark.parametrize('opname', ['eq', 'ne', 'gt', 'lt', 'ge', 'le'])
-    def test_return_dtypes_flex_cmp_empty(self, opname):
+    def test_ser_flex_cmp_return_dtypes_empty(self, opname):
         # GH#15115 empty Series case
         ser = Series([1, 3, 2], index=range(3))
         empty = ser.iloc[:0]

--- a/pandas/tests/series/test_datetime_values.py
+++ b/pandas/tests/series/test_datetime_values.py
@@ -11,7 +11,7 @@ import pandas as pd
 from pandas.core.dtypes.common import is_integer_dtype, is_list_like
 from pandas import (Index, Series, DataFrame, bdate_range,
                     date_range, period_range, timedelta_range,
-                    PeriodIndex, Timestamp, DatetimeIndex, TimedeltaIndex)
+                    PeriodIndex, DatetimeIndex, TimedeltaIndex)
 import pandas.core.common as com
 
 from pandas.util.testing import assert_series_equal
@@ -376,15 +376,6 @@ class TestSeriesDatetimeValues(TestData):
                                         "only use .dt accessor"):
                 s.dt
             assert not hasattr(s, 'dt')
-
-    def test_sub_of_datetime_from_TimeSeries(self):
-        from pandas.core.tools.timedeltas import to_timedelta
-        from datetime import datetime
-        a = Timestamp(datetime(1993, 0o1, 0o7, 13, 30, 00))
-        b = datetime(1993, 6, 22, 13, 30)
-        a = Series([a])
-        result = to_timedelta(np.abs(a - b))
-        assert result.dtype == 'timedelta64[ns]'
 
     def test_between(self):
         s = Series(bdate_range('1/1/2000', periods=20).astype(object))

--- a/pandas/tests/series/test_operators.py
+++ b/pandas/tests/series/test_operators.py
@@ -1686,15 +1686,6 @@ class TestSeriesOperators(TestData):
         s2 = Series({'x': 0.})
         assert_series_equal(s1 * s2, Series([np.nan], index=['x']))
 
-    def test_invalid_ops(self):
-        # invalid ops
-        pytest.raises(Exception, self.objSeries.__add__, 1)
-        pytest.raises(Exception, self.objSeries.__add__,
-                      np.array(1, dtype=np.int64))
-        pytest.raises(Exception, self.objSeries.__sub__, 1)
-        pytest.raises(Exception, self.objSeries.__sub__,
-                      np.array(1, dtype=np.int64))
-
     @pytest.mark.parametrize("m", [1, 3, 10])
     @pytest.mark.parametrize("unit", ['D', 'h', 'm', 's', 'ms', 'us', 'ns'])
     def test_timedelta64_conversions(self, m, unit):
@@ -2101,11 +2092,6 @@ class TestSeriesOperators(TestData):
         with pytest.raises(TypeError):
             self.ts + datetime.now()
 
-    def test_series_radd_str(self):
-        ser = pd.Series(['x', np.nan, 'x'])
-        assert_series_equal('a' + ser, pd.Series(['ax', np.nan, 'ax']))
-        assert_series_equal(ser + 'a', pd.Series(['xa', np.nan, 'xa']))
-
     @pytest.mark.parametrize('dtype', [None, object])
     def test_series_with_dtype_radd_timedelta(self, dtype):
         ser = pd.Series([pd.Timedelta('1 days'), pd.Timedelta('2 days'),
@@ -2118,39 +2104,6 @@ class TestSeriesOperators(TestData):
 
         result = ser + pd.Timedelta('3 days')
         assert_series_equal(result, expected)
-
-    @pytest.mark.parametrize('dtype', [None, object])
-    def test_series_with_dtype_radd_int(self, dtype):
-        ser = pd.Series([1, 2, 3], dtype=dtype)
-        expected = pd.Series([2, 3, 4], dtype=dtype)
-
-        result = 1 + ser
-        assert_series_equal(result, expected)
-
-        result = ser + 1
-        assert_series_equal(result, expected)
-
-    @pytest.mark.parametrize('dtype', [None, object])
-    def test_series_with_dtype_radd_nan(self, dtype):
-        ser = pd.Series([1, 2, 3], dtype=dtype)
-        expected = pd.Series([np.nan, np.nan, np.nan], dtype=dtype)
-
-        result = np.nan + ser
-        assert_series_equal(result, expected)
-
-        result = ser + np.nan
-        assert_series_equal(result, expected)
-
-    @pytest.mark.parametrize('data', [
-        [1, 2, 3],
-        [1.1, 2.2, 3.3],
-        [pd.Timestamp('2011-01-01'), pd.Timestamp('2011-01-02'), pd.NaT],
-        ['x', 'y', 1]])
-    @pytest.mark.parametrize('dtype', [None, object])
-    def test_series_radd_str_invalid(self, dtype, data):
-        ser = Series(data, dtype=dtype)
-        with pytest.raises(TypeError):
-            'foo_' + ser
 
     def test_operators_frame(self):
         # rpow does not work with DataFrame

--- a/pandas/tests/series/test_operators.py
+++ b/pandas/tests/series/test_operators.py
@@ -1817,20 +1817,6 @@ class TestSeriesOperators(TestData):
         result = (dt2.to_frame() - dt.to_frame())[0]
         assert_series_equal(result, expected)
 
-    def test_return_dtypes_bool_op_costant(self):
-        # gh15115
-        s = pd.Series([1, 3, 2], index=range(3))
-        const = 2
-        for op in ['eq', 'ne', 'gt', 'lt', 'ge', 'le']:
-            result = getattr(s, op)(const).get_dtype_counts()
-            tm.assert_series_equal(result, Series([1], ['bool']))
-
-        # empty Series
-        empty = s.iloc[:0]
-        for op in ['eq', 'ne', 'gt', 'lt', 'ge', 'le']:
-            result = getattr(empty, op)(const).get_dtype_counts()
-            tm.assert_series_equal(result, Series([1], ['bool']))
-
     def test_operators_bitwise(self):
         # GH 9016: support bitwise op for integer types
         index = list('bca')

--- a/pandas/tests/series/test_period.py
+++ b/pandas/tests/series/test_period.py
@@ -3,7 +3,7 @@ import numpy as np
 import pandas as pd
 import pandas.util.testing as tm
 import pandas.core.indexes.period as period
-from pandas import Series, period_range, DataFrame, Period
+from pandas import Series, period_range, DataFrame
 
 
 def _permute(obj):
@@ -63,17 +63,6 @@ class TestSeriesPeriod(object):
         tm.assert_series_equal(s.dropna(),
                                Series([pd.Period('2011-01', freq='M')]))
 
-    def test_series_comparison_scalars(self):
-        val = pd.Period('2000-01-04', freq='D')
-        result = self.series > val
-        expected = pd.Series([x > val for x in self.series])
-        tm.assert_series_equal(result, expected)
-
-        val = self.series[5]
-        result = self.series > val
-        expected = pd.Series([x > val for x in self.series])
-        tm.assert_series_equal(result, expected)
-
     def test_between(self):
         left, right = self.series[[2, 7]]
         result = self.series.between(left, right)
@@ -127,109 +116,6 @@ class TestSeriesPeriod(object):
 
         result = df.values.squeeze()
         assert (result[:, 0] == expected.values).all()
-
-    def test_comp_series_period_scalar(self):
-        # GH 13200
-        for freq in ['M', '2M', '3M']:
-            base = Series([Period(x, freq=freq) for x in
-                           ['2011-01', '2011-02', '2011-03', '2011-04']])
-            p = Period('2011-02', freq=freq)
-
-            exp = pd.Series([False, True, False, False])
-            tm.assert_series_equal(base == p, exp)
-            tm.assert_series_equal(p == base, exp)
-
-            exp = pd.Series([True, False, True, True])
-            tm.assert_series_equal(base != p, exp)
-            tm.assert_series_equal(p != base, exp)
-
-            exp = pd.Series([False, False, True, True])
-            tm.assert_series_equal(base > p, exp)
-            tm.assert_series_equal(p < base, exp)
-
-            exp = pd.Series([True, False, False, False])
-            tm.assert_series_equal(base < p, exp)
-            tm.assert_series_equal(p > base, exp)
-
-            exp = pd.Series([False, True, True, True])
-            tm.assert_series_equal(base >= p, exp)
-            tm.assert_series_equal(p <= base, exp)
-
-            exp = pd.Series([True, True, False, False])
-            tm.assert_series_equal(base <= p, exp)
-            tm.assert_series_equal(p >= base, exp)
-
-            # different base freq
-            msg = "Input has different freq=A-DEC from Period"
-            with tm.assert_raises_regex(
-                    period.IncompatibleFrequency, msg):
-                base <= Period('2011', freq='A')
-
-            with tm.assert_raises_regex(
-                    period.IncompatibleFrequency, msg):
-                Period('2011', freq='A') >= base
-
-    def test_comp_series_period_series(self):
-        # GH 13200
-        for freq in ['M', '2M', '3M']:
-            base = Series([Period(x, freq=freq) for x in
-                           ['2011-01', '2011-02', '2011-03', '2011-04']])
-
-            s = Series([Period(x, freq=freq) for x in
-                        ['2011-02', '2011-01', '2011-03', '2011-05']])
-
-            exp = Series([False, False, True, False])
-            tm.assert_series_equal(base == s, exp)
-
-            exp = Series([True, True, False, True])
-            tm.assert_series_equal(base != s, exp)
-
-            exp = Series([False, True, False, False])
-            tm.assert_series_equal(base > s, exp)
-
-            exp = Series([True, False, False, True])
-            tm.assert_series_equal(base < s, exp)
-
-            exp = Series([False, True, True, False])
-            tm.assert_series_equal(base >= s, exp)
-
-            exp = Series([True, False, True, True])
-            tm.assert_series_equal(base <= s, exp)
-
-            s2 = Series([Period(x, freq='A') for x in
-                         ['2011', '2011', '2011', '2011']])
-
-            # different base freq
-            msg = "Input has different freq=A-DEC from Period"
-            with tm.assert_raises_regex(
-                    period.IncompatibleFrequency, msg):
-                base <= s2
-
-    def test_comp_series_period_object(self):
-        # GH 13200
-        base = Series([Period('2011', freq='A'), Period('2011-02', freq='M'),
-                       Period('2013', freq='A'), Period('2011-04', freq='M')])
-
-        s = Series([Period('2012', freq='A'), Period('2011-01', freq='M'),
-                    Period('2013', freq='A'), Period('2011-05', freq='M')])
-
-        exp = Series([False, False, True, False])
-        tm.assert_series_equal(base == s, exp)
-
-        exp = Series([True, True, False, True])
-        tm.assert_series_equal(base != s, exp)
-
-        exp = Series([False, True, False, False])
-        tm.assert_series_equal(base > s, exp)
-
-        exp = Series([True, False, False, True])
-        tm.assert_series_equal(base < s, exp)
-
-        exp = Series([False, True, True, False])
-        tm.assert_series_equal(base >= s, exp)
-
-        exp = Series([True, False, True, True])
-        tm.assert_series_equal(base <= s, exp)
 
     def test_align_series(self):
         rng = period_range('1/1/2000', '1/1/2010', freq='A')


### PR DESCRIPTION
Lots of tests in tests.series.test_operators and tests.frame.test_operators that need to be split up, parametrized, and moved to the appropriate test_arithmetic module+class.  This handles the most obvious cases.