### PR TITLE
implement test_scalar_compat

### DIFF
--- a/pandas/tests/indexes/datetimes/test_arithmetic.py
+++ b/pandas/tests/indexes/datetimes/test_arithmetic.py
@@ -10,7 +10,7 @@ import numpy as np
 import pandas as pd
 from pandas.compat.numpy import np_datetime64_compat
 import pandas.util.testing as tm
-from pandas.errors import PerformanceWarning
+from pandas.errors import PerformanceWarning, NullFrequencyError
 from pandas import (Timestamp, Timedelta, Series,
                     DatetimeIndex, TimedeltaIndex,
                     date_range)
@@ -273,6 +273,64 @@ class TestDatetimeIndexArithmetic(object):
                                  periods=10, tz=tz)
         rng -= one
         tm.assert_index_equal(rng, expected)
+
+    # -------------------------------------------------------------
+    # DatetimeIndex.shift is used in integer addition
+
+    def test_dti_shift_tzaware(self, tz):
+        # GH#9903
+        idx = pd.DatetimeIndex([], name='xxx', tz=tz)
+        tm.assert_index_equal(idx.shift(0, freq='H'), idx)
+        tm.assert_index_equal(idx.shift(3, freq='H'), idx)
+
+        idx = pd.DatetimeIndex(['2011-01-01 10:00', '2011-01-01 11:00'
+                                '2011-01-01 12:00'], name='xxx', tz=tz)
+        tm.assert_index_equal(idx.shift(0, freq='H'), idx)
+        exp = pd.DatetimeIndex(['2011-01-01 13:00', '2011-01-01 14:00'
+                                '2011-01-01 15:00'], name='xxx', tz=tz)
+        tm.assert_index_equal(idx.shift(3, freq='H'), exp)
+        exp = pd.DatetimeIndex(['2011-01-01 07:00', '2011-01-01 08:00'
+                                '2011-01-01 09:00'], name='xxx', tz=tz)
+        tm.assert_index_equal(idx.shift(-3, freq='H'), exp)
+
+    def test_dti_shift_freqs(self):
+        # test shift for DatetimeIndex and non DatetimeIndex
+        # GH#8083
+        drange = pd.date_range('20130101', periods=5)
+        result = drange.shift(1)
+        expected = pd.DatetimeIndex(['2013-01-02', '2013-01-03', '2013-01-04',
+                                     '2013-01-05',
+                                     '2013-01-06'], freq='D')
+        tm.assert_index_equal(result, expected)
+
+        result = drange.shift(-1)
+        expected = pd.DatetimeIndex(['2012-12-31', '2013-01-01', '2013-01-02',
+                                     '2013-01-03', '2013-01-04'],
+                                    freq='D')
+        tm.assert_index_equal(result, expected)
+
+        result = drange.shift(3, freq='2D')
+        expected = pd.DatetimeIndex(['2013-01-07', '2013-01-08', '2013-01-09',
+                                     '2013-01-10',
+                                     '2013-01-11'], freq='D')
+        tm.assert_index_equal(result, expected)
+
+    def test_dti_shift_int(self):
+        rng = date_range('1/1/2000', periods=20)
+
+        result = rng + 5
+        expected = rng.shift(5)
+        tm.assert_index_equal(result, expected)
+
+        result = rng - 5
+        expected = rng.shift(-5)
+        tm.assert_index_equal(result, expected)
+
+    def test_dti_shift_no_freq(self):
+        # GH#19147
+        dti = pd.DatetimeIndex(['2011-01-01 10:00', '2011-01-01'], freq=None)
+        with pytest.raises(NullFrequencyError):
+            dti.shift(2)
 
     # -------------------------------------------------------------
     # Binary operations DatetimeIndex and timedelta-like

--- a/pandas/tests/indexes/datetimes/test_datetime.py
+++ b/pandas/tests/indexes/datetimes/test_datetime.py
@@ -2,7 +2,7 @@
 import pytest
 
 import numpy as np
-from datetime import date, timedelta, time, datetime
+from datetime import date, timedelta, time
 
 import dateutil
 import pandas as pd
@@ -14,31 +14,6 @@ from pandas import (DatetimeIndex, Index, date_range, DataFrame,
 from pandas.util.testing import assert_almost_equal
 
 randn = np.random.randn
-
-
-class TestDatetimeIndexLikeTimestamp(object):
-    # Tests for DatetimeIndex behaving like a vectorized Timestamp
-
-    def test_dti_date_out_of_range(self):
-        # see gh-1475
-        pytest.raises(ValueError, DatetimeIndex, ['1400-01-01'])
-        pytest.raises(ValueError, DatetimeIndex, [datetime(1400, 1, 1)])
-
-    def test_timestamp_fields(self):
-        # extra fields from DatetimeIndex like quarter and week
-        idx = tm.makeDateIndex(100)
-
-        fields = ['dayofweek', 'dayofyear', 'week', 'weekofyear', 'quarter',
-                  'days_in_month', 'is_month_start', 'is_month_end',
-                  'is_quarter_start', 'is_quarter_end', 'is_year_start',
-                  'is_year_end', 'weekday_name']
-        for f in fields:
-            expected = getattr(idx, f)[-1]
-            result = getattr(Timestamp(idx[-1]), f)
-            assert result == expected
-
-        assert idx.freq == Timestamp(idx[-1], idx.freq).freq
-        assert idx.freqstr == Timestamp(idx[-1], idx.freq).freqstr
 
 
 class TestDatetimeIndex(object):
@@ -370,18 +345,6 @@ class TestDatetimeIndex(object):
 
         assert_almost_equal(index.isin([index[2], 5]),
                             np.array([False, False, True, False]))
-
-    def test_time(self):
-        rng = pd.date_range('1/1/2000', freq='12min', periods=10)
-        result = pd.Index(rng).time
-        expected = [t.time() for t in rng]
-        assert (result == expected).all()
-
-    def test_date(self):
-        rng = pd.date_range('1/1/2000', freq='12H', periods=10)
-        result = pd.Index(rng).date
-        expected = [t.date() for t in rng]
-        assert (result == expected).all()
 
     def test_does_not_convert_mixed_integer(self):
         df = tm.makeCustomDataframe(10, 10,

--- a/pandas/tests/indexes/datetimes/test_datetimelike.py
+++ b/pandas/tests/indexes/datetimes/test_datetimelike.py
@@ -1,9 +1,7 @@
 """ generic tests from the Datetimelike class """
 
-import numpy as np
-import pandas as pd
 from pandas.util import testing as tm
-from pandas import Series, Index, DatetimeIndex, date_range
+from pandas import DatetimeIndex, date_range
 
 from ..datetimelike import DatetimeLike
 
@@ -27,31 +25,7 @@ class TestDatetimeIndex(DatetimeLike):
         pass
 
     def test_intersection(self):
-        first = self.index
-        second = self.index[5:]
-        intersect = first.intersection(second)
-        assert tm.equalContents(intersect, second)
-
-        # GH 10149
-        cases = [klass(second.values) for klass in [np.array, Series, list]]
-        for case in cases:
-            result = first.intersection(case)
-            assert tm.equalContents(result, second)
-
-        third = Index(['a', 'b', 'c'])
-        result = first.intersection(third)
-        expected = pd.Index([], dtype=object)
-        tm.assert_index_equal(result, expected)
+        pass  # handled in test_setops
 
     def test_union(self):
-        first = self.index[:5]
-        second = self.index[5:]
-        everything = self.index
-        union = first.union(second)
-        assert tm.equalContents(union, everything)
-
-        # GH 10149
-        cases = [klass(second.values) for klass in [np.array, Series, list]]
-        for case in cases:
-            result = first.union(case)
-            assert tm.equalContents(result, everything)
+        pass  # handled in test_setops

--- a/pandas/tests/indexes/datetimes/test_misc.py
+++ b/pandas/tests/indexes/datetimes/test_misc.py
@@ -4,53 +4,7 @@ import numpy as np
 import pandas as pd
 import pandas.util.testing as tm
 from pandas import (Index, DatetimeIndex, datetime, offsets,
-                    Float64Index, date_range, Timestamp)
-
-
-class TestDateTimeIndexToJulianDate(object):
-
-    def test_1700(self):
-        r1 = Float64Index([2345897.5, 2345898.5, 2345899.5, 2345900.5,
-                           2345901.5])
-        r2 = date_range(start=Timestamp('1710-10-01'), periods=5,
-                        freq='D').to_julian_date()
-        assert isinstance(r2, Float64Index)
-        tm.assert_index_equal(r1, r2)
-
-    def test_2000(self):
-        r1 = Float64Index([2451601.5, 2451602.5, 2451603.5, 2451604.5,
-                           2451605.5])
-        r2 = date_range(start=Timestamp('2000-02-27'), periods=5,
-                        freq='D').to_julian_date()
-        assert isinstance(r2, Float64Index)
-        tm.assert_index_equal(r1, r2)
-
-    def test_hour(self):
-        r1 = Float64Index(
-            [2451601.5, 2451601.5416666666666666, 2451601.5833333333333333,
-             2451601.625, 2451601.6666666666666666])
-        r2 = date_range(start=Timestamp('2000-02-27'), periods=5,
-                        freq='H').to_julian_date()
-        assert isinstance(r2, Float64Index)
-        tm.assert_index_equal(r1, r2)
-
-    def test_minute(self):
-        r1 = Float64Index(
-            [2451601.5, 2451601.5006944444444444, 2451601.5013888888888888,
-             2451601.5020833333333333, 2451601.5027777777777777])
-        r2 = date_range(start=Timestamp('2000-02-27'), periods=5,
-                        freq='T').to_julian_date()
-        assert isinstance(r2, Float64Index)
-        tm.assert_index_equal(r1, r2)
-
-    def test_second(self):
-        r1 = Float64Index(
-            [2451601.5, 2451601.500011574074074, 2451601.5000231481481481,
-             2451601.5000347222222222, 2451601.5000462962962962])
-        r2 = date_range(start=Timestamp('2000-02-27'), periods=5,
-                        freq='S').to_julian_date()
-        assert isinstance(r2, Float64Index)
-        tm.assert_index_equal(r1, r2)
+                    date_range, Timestamp)
 
 
 class TestTimeSeries(object):
@@ -129,17 +83,6 @@ class TestTimeSeries(object):
                              '1970-01-03', '1970-01-04'])
         tm.assert_index_equal(idx, exp)
 
-    def test_datetimeindex_integers_shift(self):
-        rng = date_range('1/1/2000', periods=20)
-
-        result = rng + 5
-        expected = rng.shift(5)
-        tm.assert_index_equal(result, expected)
-
-        result = rng - 5
-        expected = rng.shift(-5)
-        tm.assert_index_equal(result, expected)
-
     def test_datetimeindex_repr_short(self):
         dr = date_range(start='1/1/2012', periods=1)
         repr(dr)
@@ -149,25 +92,6 @@ class TestTimeSeries(object):
 
         dr = date_range(start='1/1/2012', periods=3)
         repr(dr)
-
-    def test_normalize(self):
-        rng = date_range('1/1/2000 9:30', periods=10, freq='D')
-
-        result = rng.normalize()
-        expected = date_range('1/1/2000', periods=10, freq='D')
-        tm.assert_index_equal(result, expected)
-
-        rng_ns = pd.DatetimeIndex(np.array([1380585623454345752,
-                                            1380585612343234312]).astype(
-                                                "datetime64[ns]"))
-        rng_ns_normalized = rng_ns.normalize()
-        expected = pd.DatetimeIndex(np.array([1380585600000000000,
-                                              1380585600000000000]).astype(
-                                                  "datetime64[ns]"))
-        tm.assert_index_equal(rng_ns_normalized, expected)
-
-        assert result.is_normalized
-        assert not rng.is_normalized
 
 
 class TestDatetime64(object):

--- a/pandas/tests/indexes/datetimes/test_scalar_compat.py
+++ b/pandas/tests/indexes/datetimes/test_scalar_compat.py
@@ -1,0 +1,188 @@
+# -*- coding: utf-8 -*-
+"""
+Tests for DatetimeIndex methods behaving like their Timestamp counterparts
+"""
+from datetime import datetime
+
+import numpy as np
+import pytest
+
+import pandas.util.testing as tm
+import pandas as pd
+
+from pandas import date_range, Timestamp, DatetimeIndex
+
+
+@pytest.fixture(params=[None, 'UTC', 'Asia/Tokyo',
+                        'US/Eastern', 'dateutil/Asia/Singapore',
+                        'dateutil/US/Pacific'])
+def tz(request):
+    return request.param
+
+
+class TestDatetimeIndexOps(object):
+    def test_dti_time(self):
+        rng = date_range('1/1/2000', freq='12min', periods=10)
+        result = pd.Index(rng).time
+        expected = [t.time() for t in rng]
+        assert (result == expected).all()
+
+    def test_dti_date(self):
+        rng = date_range('1/1/2000', freq='12H', periods=10)
+        result = pd.Index(rng).date
+        expected = [t.date() for t in rng]
+        assert (result == expected).all()
+
+    def test_dti_date_out_of_range(self):
+        # GH#1475
+        pytest.raises(ValueError, DatetimeIndex, ['1400-01-01'])
+        pytest.raises(ValueError, DatetimeIndex, [datetime(1400, 1, 1)])
+
+    def test_dti_timestamp_fields(self):
+        # extra fields from DatetimeIndex like quarter and week
+        idx = tm.makeDateIndex(100)
+
+        fields = ['dayofweek', 'dayofyear', 'week', 'weekofyear', 'quarter',
+                  'days_in_month', 'is_month_start', 'is_month_end',
+                  'is_quarter_start', 'is_quarter_end', 'is_year_start',
+                  'is_year_end', 'weekday_name']
+        for f in fields:
+            expected = getattr(idx, f)[-1]
+            result = getattr(Timestamp(idx[-1]), f)
+            assert result == expected
+
+        assert idx.freq == Timestamp(idx[-1], idx.freq).freq
+        assert idx.freqstr == Timestamp(idx[-1], idx.freq).freqstr
+
+    # ----------------------------------------------------------------
+    # DatetimeIndex.round
+
+    def test_round_daily(self):
+        dti = date_range('20130101 09:10:11', periods=5)
+        result = dti.round('D')
+        expected = date_range('20130101', periods=5)
+        tm.assert_index_equal(result, expected)
+
+        dti = dti.tz_localize('UTC').tz_convert('US/Eastern')
+        result = dti.round('D')
+        expected = date_range('20130101',
+                              periods=5).tz_localize('US/Eastern')
+        tm.assert_index_equal(result, expected)
+
+        result = dti.round('s')
+        tm.assert_index_equal(result, dti)
+
+        # invalid
+        for freq in ['Y', 'M', 'foobar']:
+            pytest.raises(ValueError, lambda: dti.round(freq))
+
+    def test_round(self, tz):
+        rng = date_range(start='2016-01-01', periods=5,
+                         freq='30Min', tz=tz)
+        elt = rng[1]
+
+        expected_rng = DatetimeIndex([
+            Timestamp('2016-01-01 00:00:00', tz=tz, freq='30T'),
+            Timestamp('2016-01-01 00:00:00', tz=tz, freq='30T'),
+            Timestamp('2016-01-01 01:00:00', tz=tz, freq='30T'),
+            Timestamp('2016-01-01 02:00:00', tz=tz, freq='30T'),
+            Timestamp('2016-01-01 02:00:00', tz=tz, freq='30T'),
+        ])
+        expected_elt = expected_rng[1]
+
+        tm.assert_index_equal(rng.round(freq='H'), expected_rng)
+        assert elt.round(freq='H') == expected_elt
+
+        msg = pd._libs.tslibs.frequencies._INVALID_FREQ_ERROR
+        with tm.assert_raises_regex(ValueError, msg):
+            rng.round(freq='foo')
+        with tm.assert_raises_regex(ValueError, msg):
+            elt.round(freq='foo')
+
+        msg = "<MonthEnd> is a non-fixed frequency"
+        tm.assert_raises_regex(ValueError, msg, rng.round, freq='M')
+        tm.assert_raises_regex(ValueError, msg, elt.round, freq='M')
+
+        # GH#14440 & GH#15578
+        index = DatetimeIndex(['2016-10-17 12:00:00.0015'], tz=tz)
+        result = index.round('ms')
+        expected = DatetimeIndex(['2016-10-17 12:00:00.002000'], tz=tz)
+        tm.assert_index_equal(result, expected)
+
+        for freq in ['us', 'ns']:
+            tm.assert_index_equal(index, index.round(freq))
+
+        index = DatetimeIndex(['2016-10-17 12:00:00.00149'], tz=tz)
+        result = index.round('ms')
+        expected = DatetimeIndex(['2016-10-17 12:00:00.001000'], tz=tz)
+        tm.assert_index_equal(result, expected)
+
+        index = DatetimeIndex(['2016-10-17 12:00:00.001501031'])
+        result = index.round('10ns')
+        expected = DatetimeIndex(['2016-10-17 12:00:00.001501030'])
+        tm.assert_index_equal(result, expected)
+
+        with tm.assert_produces_warning():
+            ts = '2016-10-17 12:00:00.001501031'
+            DatetimeIndex([ts]).round('1010ns')
+
+    # ----------------------------------------------------------------
+    # DatetimeIndex.normalize
+
+    def test_normalize(self):
+        rng = date_range('1/1/2000 9:30', periods=10, freq='D')
+
+        result = rng.normalize()
+        expected = date_range('1/1/2000', periods=10, freq='D')
+        tm.assert_index_equal(result, expected)
+
+        arr_ns = np.array([1380585623454345752,
+                           1380585612343234312]).astype("datetime64[ns]")
+        rng_ns = DatetimeIndex(arr_ns)
+        rng_ns_normalized = rng_ns.normalize()
+
+        arr_ns = np.array([1380585600000000000,
+                           1380585600000000000]).astype("datetime64[ns]")
+        expected = DatetimeIndex(arr_ns)
+        tm.assert_index_equal(rng_ns_normalized, expected)
+
+        assert result.is_normalized
+        assert not rng.is_normalized
+
+
+class TestDateTimeIndexToJulianDate(object):
+
+    def test_1700(self):
+        dr = date_range(start=Timestamp('1710-10-01'), periods=5, freq='D')
+        r1 = pd.Index([x.to_julian_date() for x in dr])
+        r2 = dr.to_julian_date()
+        assert isinstance(r2, pd.Float64Index)
+        tm.assert_index_equal(r1, r2)
+
+    def test_2000(self):
+        dr = date_range(start=Timestamp('2000-02-27'), periods=5, freq='D')
+        r1 = pd.Index([x.to_julian_date() for x in dr])
+        r2 = dr.to_julian_date()
+        assert isinstance(r2, pd.Float64Index)
+        tm.assert_index_equal(r1, r2)
+
+    def test_hour(self):
+        dr = date_range(start=Timestamp('2000-02-27'), periods=5, freq='H')
+        r1 = pd.Index([x.to_julian_date() for x in dr])
+        r2 = dr.to_julian_date()
+        assert isinstance(r2, pd.Float64Index)
+        tm.assert_index_equal(r1, r2)
+
+    def test_minute(self):
+        dr = date_range(start=Timestamp('2000-02-27'), periods=5, freq='T')
+        r1 = pd.Index([x.to_julian_date() for x in dr])
+        r2 = dr.to_julian_date()
+        assert isinstance(r2, pd.Float64Index)
+        tm.assert_index_equal(r1, r2)
+
+    def test_second(self):
+        dr = date_range(start=Timestamp('2000-02-27'), periods=5, freq='S')
+        r1 = pd.Index([x.to_julian_date() for x in dr])
+        r2 = dr.to_julian_date()
+        assert isinstance(r2, pd.Float64Index)
+        tm.assert_index_equal(r1, r2)

--- a/pandas/tests/indexes/datetimes/test_setops.py
+++ b/pandas/tests/indexes/datetimes/test_setops.py
@@ -17,6 +17,20 @@ class TestDatetimeIndexSetOps(object):
     tz = [None, 'UTC', 'Asia/Tokyo', 'US/Eastern', 'dateutil/Asia/Singapore',
           'dateutil/US/Pacific']
 
+    # TODO: moved from test_datetimelike; dedup with version below
+    def test_union2(self):
+        first = self.index[:5]
+        second = self.index[5:]
+        everything = self.index
+        union = first.union(second)
+        assert tm.equalContents(union, everything)
+
+        # GH 10149
+        cases = [klass(second.values) for klass in [np.array, Series, list]]
+        for case in cases:
+            result = first.union(case)
+            assert tm.equalContents(result, everything)
+
     @pytest.mark.parametrize("tz", tz)
     def test_union(self, tz):
         rng1 = pd.date_range('1/1/2000', freq='D', periods=5, tz=tz)
@@ -100,6 +114,24 @@ class TestDatetimeIndexSetOps(object):
         i2 = DatetimeIndex(start='2012-01-03 00:00:00', periods=10, freq='D')
         i1.union(i2)  # Works
         i2.union(i1)  # Fails with "AttributeError: can't set attribute"
+
+    # TODO: moved from test_datetimelike; de-duplicate with version below
+    def test_intersection2(self):
+        first = tm.makeDateIndex(10)
+        second = first[5:]
+        intersect = first.intersection(second)
+        assert tm.equalContents(intersect, second)
+
+        # GH 10149
+        cases = [klass(second.values) for klass in [np.array, Series, list]]
+        for case in cases:
+            result = first.intersection(case)
+            assert tm.equalContents(result, second)
+
+        third = Index(['a', 'b', 'c'])
+        result = first.intersection(third)
+        expected = pd.Index([], dtype=object)
+        tm.assert_index_equal(result, expected)
 
     @pytest.mark.parametrize("tz", [None, 'Asia/Tokyo', 'US/Eastern',
                                     'dateutil/US/Pacific'])

--- a/pandas/tests/indexes/datetimes/test_setops.py
+++ b/pandas/tests/indexes/datetimes/test_setops.py
@@ -19,9 +19,9 @@ class TestDatetimeIndexSetOps(object):
 
     # TODO: moved from test_datetimelike; dedup with version below
     def test_union2(self):
-        first = self.index[:5]
-        second = self.index[5:]
-        everything = self.index
+        everything = tm.makeDateIndex(10)
+        first = everything[:5]
+        second = everything[5:]
         union = first.union(second)
         assert tm.equalContents(union, everything)
 


### PR DESCRIPTION
More test organizing, this one focusing on tests.indexes.datetimes.

- continue collecting staggler arithmetic tests
- new test module for testing that DatetimeIndex.foo behaves like Timestamp.foo
- de-duplicate some tests scattered across modules
- parametrize a handful of tests