### PR TITLE
PERF: Cythonize Groupby Rank

### DIFF
--- a/doc/source/whatsnew/v0.23.0.txt
+++ b/doc/source/whatsnew/v0.23.0.txt
@@ -581,6 +581,7 @@ Performance Improvements
 - Improved performance of :func:`DataFrame.median` with ``axis=1`` when bottleneck is not installed (:issue:`16468`)
 - Improved performance of :func:`MultiIndex.get_loc` for large indexes, at the cost of a reduction in performance for small ones (:issue:`18519`)
 - Improved performance of pairwise ``.rolling()`` and ``.expanding()`` with ``.cov()`` and ``.corr()`` operations (:issue:`17917`)
+- Improved performance of :func:`DataFrameGroupBy.rank` (:issue:`15779`)
 
 .. _whatsnew_0230.docs:
 

--- a/pandas/_libs/algos.pxd
+++ b/pandas/_libs/algos.pxd
@@ -11,3 +11,11 @@ cdef inline Py_ssize_t swap(numeric *a, numeric *b) nogil:
     a[0] = b[0]
     b[0] = t
     return 0
+
+cdef:
+    int TIEBREAK_AVERAGE = 0
+    int TIEBREAK_MIN = 1
+    int TIEBREAK_MAX = 2
+    int TIEBREAK_FIRST = 3
+    int TIEBREAK_FIRST_DESCENDING = 4
+    int TIEBREAK_DENSE = 5

--- a/pandas/_libs/algos.pxd
+++ b/pandas/_libs/algos.pxd
@@ -12,10 +12,10 @@ cdef inline Py_ssize_t swap(numeric *a, numeric *b) nogil:
     b[0] = t
     return 0
 
-cdef:
-    int TIEBREAK_AVERAGE = 0
-    int TIEBREAK_MIN = 1
-    int TIEBREAK_MAX = 2
-    int TIEBREAK_FIRST = 3
-    int TIEBREAK_FIRST_DESCENDING = 4
-    int TIEBREAK_DENSE = 5
+cdef enum TiebreakEnumType:
+    TIEBREAK_AVERAGE
+    TIEBREAK_MIN,
+    TIEBREAK_MAX
+    TIEBREAK_FIRST
+    TIEBREAK_FIRST_DESCENDING
+    TIEBREAK_DENSE

--- a/pandas/_libs/algos.pyx
+++ b/pandas/_libs/algos.pyx
@@ -31,20 +31,12 @@ cdef double nan = NaN
 
 cdef int64_t iNaT = get_nat()
 
-cdef:
-    int TIEBREAK_AVERAGE = 0
-    int TIEBREAK_MIN = 1
-    int TIEBREAK_MAX = 2
-    int TIEBREAK_FIRST = 3
-    int TIEBREAK_FIRST_DESCENDING = 4
-    int TIEBREAK_DENSE = 5
-
 tiebreakers = {
-    'average': TIEBREAK_AVERAGE,
-    'min': TIEBREAK_MIN,
-    'max': TIEBREAK_MAX,
-    'first': TIEBREAK_FIRST,
-    'dense': TIEBREAK_DENSE,
+    'average': TiebreakEnumType.TIEBREAK_AVERAGE,
+    'min': TiebreakEnumType.TIEBREAK_MIN,
+    'max': TiebreakEnumType.TIEBREAK_MAX,
+    'first': TiebreakEnumType.TIEBREAK_FIRST,
+    'dense': TiebreakEnumType.TIEBREAK_DENSE,
 }
 
 

--- a/pandas/_libs/algos.pyx
+++ b/pandas/_libs/algos.pyx
@@ -32,11 +32,11 @@ cdef double nan = NaN
 cdef int64_t iNaT = get_nat()
 
 tiebreakers = {
-    'average': TiebreakEnumType.TIEBREAK_AVERAGE,
-    'min': TiebreakEnumType.TIEBREAK_MIN,
-    'max': TiebreakEnumType.TIEBREAK_MAX,
-    'first': TiebreakEnumType.TIEBREAK_FIRST,
-    'dense': TiebreakEnumType.TIEBREAK_DENSE,
+    'average': TIEBREAK_AVERAGE,
+    'min': TIEBREAK_MIN,
+    'max': TIEBREAK_MAX,
+    'first': TIEBREAK_FIRST,
+    'dense': TIEBREAK_DENSE,
 }
 
 

--- a/pandas/_libs/algos_rank_helper.pxi.in
+++ b/pandas/_libs/algos_rank_helper.pxi.in
@@ -121,11 +121,11 @@ def rank_1d_{{dtype}}(object in_arr, ties_method='average', ascending=True,
         _values = np.asarray(list(zip(order[0], order[1])), dtype=_dt)
         _as = np.argsort(_values, kind='mergesort', order=('mask', 'values'))
     {{else}}
-    if tiebreak == TiebreakEnumType.TIEBREAK_FIRST:
+    if tiebreak == TIEBREAK_FIRST:
         # need to use a stable sort here
         _as = np.lexsort(keys=order)
         if not ascending:
-            tiebreak = TiebreakEnumType.TIEBREAK_FIRST_DESCENDING
+            tiebreak = TIEBREAK_FIRST_DESCENDING
     else:
         _as = np.lexsort(keys=order)
     {{endif}}
@@ -154,21 +154,21 @@ def rank_1d_{{dtype}}(object in_arr, ties_method='average', ascending=True,
         if (i == n - 1 or
                 are_diff(util.get_value_at(sorted_data, i + 1), val) or
                 i == non_na_idx - 1):
-            if tiebreak == TiebreakEnumType.TIEBREAK_AVERAGE:
+            if tiebreak == TIEBREAK_AVERAGE:
                 for j in range(i - dups + 1, i + 1):
                     ranks[argsorted[j]] = sum_ranks / dups
-            elif tiebreak == TiebreakEnumType.TIEBREAK_MIN:
+            elif tiebreak == TIEBREAK_MIN:
                 for j in range(i - dups + 1, i + 1):
                     ranks[argsorted[j]] = i - dups + 2
-            elif tiebreak == TiebreakEnumType.TIEBREAK_MAX:
+            elif tiebreak == TIEBREAK_MAX:
                 for j in range(i - dups + 1, i + 1):
                     ranks[argsorted[j]] = i + 1
-            elif tiebreak == TiebreakEnumType.TIEBREAK_FIRST:
+            elif tiebreak == TIEBREAK_FIRST:
                 raise ValueError('first not supported for non-numeric data')
-            elif tiebreak == TiebreakEnumType.TIEBREAK_FIRST_DESCENDING:
+            elif tiebreak == TIEBREAK_FIRST_DESCENDING:
                 for j in range(i - dups + 1, i + 1):
                     ranks[argsorted[j]] = 2 * i - j - dups + 2
-            elif tiebreak == TiebreakEnumType.TIEBREAK_DENSE:
+            elif tiebreak == TIEBREAK_DENSE:
                 total_tie_count += 1
                 for j in range(i - dups + 1, i + 1):
                     ranks[argsorted[j]] = total_tie_count
@@ -191,22 +191,22 @@ def rank_1d_{{dtype}}(object in_arr, ties_method='average', ascending=True,
 
             if (i == n - 1 or sorted_data[i + 1] != val or
                 i == non_na_idx - 1):
-                if tiebreak == TiebreakEnumType.TIEBREAK_AVERAGE:
+                if tiebreak == TIEBREAK_AVERAGE:
                     for j in range(i - dups + 1, i + 1):
                         ranks[argsorted[j]] = sum_ranks / dups
-                elif tiebreak == TiebreakEnumType.TIEBREAK_MIN:
+                elif tiebreak == TIEBREAK_MIN:
                     for j in range(i - dups + 1, i + 1):
                         ranks[argsorted[j]] = i - dups + 2
-                elif tiebreak == TiebreakEnumType.TIEBREAK_MAX:
+                elif tiebreak == TIEBREAK_MAX:
                     for j in range(i - dups + 1, i + 1):
                         ranks[argsorted[j]] = i + 1
-                elif tiebreak == TiebreakEnumType.TIEBREAK_FIRST:
+                elif tiebreak == TIEBREAK_FIRST:
                     for j in range(i - dups + 1, i + 1):
                         ranks[argsorted[j]] = j + 1
-                elif tiebreak == TiebreakEnumType.TIEBREAK_FIRST_DESCENDING:
+                elif tiebreak == TIEBREAK_FIRST_DESCENDING:
                     for j in range(i - dups + 1, i + 1):
                         ranks[argsorted[j]] = 2 * i - j - dups + 2
-                elif tiebreak == TiebreakEnumType.TIEBREAK_DENSE:
+                elif tiebreak == TIEBREAK_DENSE:
                     total_tie_count += 1
                     for j in range(i - dups + 1, i + 1):
                         ranks[argsorted[j]] = total_tie_count
@@ -300,11 +300,11 @@ def rank_2d_{{dtype}}(object in_arr, axis=0, ties_method='average',
         else:
             return ranks
     {{else}}
-    if tiebreak == TiebreakEnumType.TIEBREAK_FIRST:
+    if tiebreak == TIEBREAK_FIRST:
         # need to use a stable sort here
         _as = values.argsort(axis=1, kind='mergesort')
         if not ascending:
-            tiebreak = TiebreakEnumType.TIEBREAK_FIRST_DESCENDING
+            tiebreak = TIEBREAK_FIRST_DESCENDING
     else:
         _as = values.argsort(1)
     {{endif}}
@@ -359,16 +359,16 @@ def rank_2d_{{dtype}}(object in_arr, axis=0, ties_method='average',
             {{else}}
             if j == k - 1 or values[i, j + 1] != val:
             {{endif}}
-                if tiebreak == TiebreakEnumType.TIEBREAK_AVERAGE:
+                if tiebreak == TIEBREAK_AVERAGE:
                     for z in range(j - dups + 1, j + 1):
                         ranks[i, argsorted[i, z]] = sum_ranks / dups
-                elif tiebreak == TiebreakEnumType.TIEBREAK_MIN:
+                elif tiebreak == TIEBREAK_MIN:
                     for z in range(j - dups + 1, j + 1):
                         ranks[i, argsorted[i, z]] = j - dups + 2
-                elif tiebreak == TiebreakEnumType.TIEBREAK_MAX:
+                elif tiebreak == TIEBREAK_MAX:
                     for z in range(j - dups + 1, j + 1):
                         ranks[i, argsorted[i, z]] = j + 1
-                elif tiebreak == TiebreakEnumType.TIEBREAK_FIRST:
+                elif tiebreak == TIEBREAK_FIRST:
                     {{if dtype == 'object'}}
                     raise ValueError('first not supported '
                                      'for non-numeric data')
@@ -376,10 +376,10 @@ def rank_2d_{{dtype}}(object in_arr, axis=0, ties_method='average',
                     for z in range(j - dups + 1, j + 1):
                         ranks[i, argsorted[i, z]] = z + 1
                     {{endif}}
-                elif tiebreak == TiebreakEnumType.TIEBREAK_FIRST_DESCENDING:
+                elif tiebreak == TIEBREAK_FIRST_DESCENDING:
                     for z in range(j - dups + 1, j + 1):
                         ranks[i, argsorted[i, z]] = 2 * j - z - dups + 2
-                elif tiebreak == TiebreakEnumType.TIEBREAK_DENSE:
+                elif tiebreak == TIEBREAK_DENSE:
                     total_tie_count += 1
                     for z in range(j - dups + 1, j + 1):
                         ranks[i, argsorted[i, z]] = total_tie_count

--- a/pandas/_libs/algos_rank_helper.pxi.in
+++ b/pandas/_libs/algos_rank_helper.pxi.in
@@ -121,11 +121,11 @@ def rank_1d_{{dtype}}(object in_arr, ties_method='average', ascending=True,
         _values = np.asarray(list(zip(order[0], order[1])), dtype=_dt)
         _as = np.argsort(_values, kind='mergesort', order=('mask', 'values'))
     {{else}}
-    if tiebreak == TIEBREAK_FIRST:
+    if tiebreak == TiebreakEnumType.TIEBREAK_FIRST:
         # need to use a stable sort here
         _as = np.lexsort(keys=order)
         if not ascending:
-            tiebreak = TIEBREAK_FIRST_DESCENDING
+            tiebreak = TiebreakEnumType.TIEBREAK_FIRST_DESCENDING
     else:
         _as = np.lexsort(keys=order)
     {{endif}}
@@ -154,21 +154,21 @@ def rank_1d_{{dtype}}(object in_arr, ties_method='average', ascending=True,
         if (i == n - 1 or
                 are_diff(util.get_value_at(sorted_data, i + 1), val) or
                 i == non_na_idx - 1):
-            if tiebreak == TIEBREAK_AVERAGE:
+            if tiebreak == TiebreakEnumType.TIEBREAK_AVERAGE:
                 for j in range(i - dups + 1, i + 1):
                     ranks[argsorted[j]] = sum_ranks / dups
-            elif tiebreak == TIEBREAK_MIN:
+            elif tiebreak == TiebreakEnumType.TIEBREAK_MIN:
                 for j in range(i - dups + 1, i + 1):
                     ranks[argsorted[j]] = i - dups + 2
-            elif tiebreak == TIEBREAK_MAX:
+            elif tiebreak == TiebreakEnumType.TIEBREAK_MAX:
                 for j in range(i - dups + 1, i + 1):
                     ranks[argsorted[j]] = i + 1
-            elif tiebreak == TIEBREAK_FIRST:
+            elif tiebreak == TiebreakEnumType.TIEBREAK_FIRST:
                 raise ValueError('first not supported for non-numeric data')
-            elif tiebreak == TIEBREAK_FIRST_DESCENDING:
+            elif tiebreak == TiebreakEnumType.TIEBREAK_FIRST_DESCENDING:
                 for j in range(i - dups + 1, i + 1):
                     ranks[argsorted[j]] = 2 * i - j - dups + 2
-            elif tiebreak == TIEBREAK_DENSE:
+            elif tiebreak == TiebreakEnumType.TIEBREAK_DENSE:
                 total_tie_count += 1
                 for j in range(i - dups + 1, i + 1):
                     ranks[argsorted[j]] = total_tie_count
@@ -191,22 +191,22 @@ def rank_1d_{{dtype}}(object in_arr, ties_method='average', ascending=True,
 
             if (i == n - 1 or sorted_data[i + 1] != val or
                 i == non_na_idx - 1):
-                if tiebreak == TIEBREAK_AVERAGE:
+                if tiebreak == TiebreakEnumType.TIEBREAK_AVERAGE:
                     for j in range(i - dups + 1, i + 1):
                         ranks[argsorted[j]] = sum_ranks / dups
-                elif tiebreak == TIEBREAK_MIN:
+                elif tiebreak == TiebreakEnumType.TIEBREAK_MIN:
                     for j in range(i - dups + 1, i + 1):
                         ranks[argsorted[j]] = i - dups + 2
-                elif tiebreak == TIEBREAK_MAX:
+                elif tiebreak == TiebreakEnumType.TIEBREAK_MAX:
                     for j in range(i - dups + 1, i + 1):
                         ranks[argsorted[j]] = i + 1
-                elif tiebreak == TIEBREAK_FIRST:
+                elif tiebreak == TiebreakEnumType.TIEBREAK_FIRST:
                     for j in range(i - dups + 1, i + 1):
                         ranks[argsorted[j]] = j + 1
-                elif tiebreak == TIEBREAK_FIRST_DESCENDING:
+                elif tiebreak == TiebreakEnumType.TIEBREAK_FIRST_DESCENDING:
                     for j in range(i - dups + 1, i + 1):
                         ranks[argsorted[j]] = 2 * i - j - dups + 2
-                elif tiebreak == TIEBREAK_DENSE:
+                elif tiebreak == TiebreakEnumType.TIEBREAK_DENSE:
                     total_tie_count += 1
                     for j in range(i - dups + 1, i + 1):
                         ranks[argsorted[j]] = total_tie_count
@@ -300,11 +300,11 @@ def rank_2d_{{dtype}}(object in_arr, axis=0, ties_method='average',
         else:
             return ranks
     {{else}}
-    if tiebreak == TIEBREAK_FIRST:
+    if tiebreak == TiebreakEnumType.TIEBREAK_FIRST:
         # need to use a stable sort here
         _as = values.argsort(axis=1, kind='mergesort')
         if not ascending:
-            tiebreak = TIEBREAK_FIRST_DESCENDING
+            tiebreak = TiebreakEnumType.TIEBREAK_FIRST_DESCENDING
     else:
         _as = values.argsort(1)
     {{endif}}
@@ -359,16 +359,16 @@ def rank_2d_{{dtype}}(object in_arr, axis=0, ties_method='average',
             {{else}}
             if j == k - 1 or values[i, j + 1] != val:
             {{endif}}
-                if tiebreak == TIEBREAK_AVERAGE:
+                if tiebreak == TiebreakEnumType.TIEBREAK_AVERAGE:
                     for z in range(j - dups + 1, j + 1):
                         ranks[i, argsorted[i, z]] = sum_ranks / dups
-                elif tiebreak == TIEBREAK_MIN:
+                elif tiebreak == TiebreakEnumType.TIEBREAK_MIN:
                     for z in range(j - dups + 1, j + 1):
                         ranks[i, argsorted[i, z]] = j - dups + 2
-                elif tiebreak == TIEBREAK_MAX:
+                elif tiebreak == TiebreakEnumType.TIEBREAK_MAX:
                     for z in range(j - dups + 1, j + 1):
                         ranks[i, argsorted[i, z]] = j + 1
-                elif tiebreak == TIEBREAK_FIRST:
+                elif tiebreak == TiebreakEnumType.TIEBREAK_FIRST:
                     {{if dtype == 'object'}}
                     raise ValueError('first not supported '
                                      'for non-numeric data')
@@ -376,10 +376,10 @@ def rank_2d_{{dtype}}(object in_arr, axis=0, ties_method='average',
                     for z in range(j - dups + 1, j + 1):
                         ranks[i, argsorted[i, z]] = z + 1
                     {{endif}}
-                elif tiebreak == TIEBREAK_FIRST_DESCENDING:
+                elif tiebreak == TiebreakEnumType.TIEBREAK_FIRST_DESCENDING:
                     for z in range(j - dups + 1, j + 1):
                         ranks[i, argsorted[i, z]] = 2 * j - z - dups + 2
-                elif tiebreak == TIEBREAK_DENSE:
+                elif tiebreak == TiebreakEnumType.TIEBREAK_DENSE:
                     total_tie_count += 1
                     for z in range(j - dups + 1, j + 1):
                         ranks[i, argsorted[i, z]] = total_tie_count

--- a/pandas/_libs/groupby.pyx
+++ b/pandas/_libs/groupby.pyx
@@ -137,7 +137,7 @@ def group_rank_object(ndarray[float64_t, ndim=2] out,
     cdef:
         int tiebreak
         Py_ssize_t i, j, N, K
-        int64_t val_start=0, grp_start=0, dups=0, sum_ranks=0
+        int64_t val_start=0, grp_start=0, dups=0, sum_ranks=0, vals_seen=1
         ndarray[int64_t] _as
         bint pct, ascending
 
@@ -166,13 +166,13 @@ def group_rank_object(ndarray[float64_t, ndim=2] out,
                 out[_as[j], 0] = i - grp_start + 1
         elif tiebreak == TIEBREAK_FIRST:
             for j in range(i - dups + 1, i + 1):
-                out[_as[j], 0] = j + 1
-        elif tiebreak == TIEBREAK_FIRST_DESCENDING:
-            for j in range(i - dups + 1, i + 1):
-                out[_as[j], 0]  = 2 * (i - grp_start) - j - dups + 2
+                if ascending:
+                    out[_as[j], 0] = j + 1
+                else:
+                    out[_as[j], 0] = 2 * i - j - dups + 2
         elif tiebreak == TIEBREAK_DENSE:
             for j in range(i - dups + 1, i + 1):
-                out[_as[j], 0] = val_start - grp_start
+                out[_as[j], 0] = vals_seen
 
         if (i == N - 1 or (
                 (values[_as[i], 0] != values[_as[i+1], 0]) and not
@@ -180,6 +180,7 @@ def group_rank_object(ndarray[float64_t, ndim=2] out,
                 )):
             dups = sum_ranks = 0
             val_start = i
+            vals_seen += 1
 
         if i == N - 1 or labels[_as[i]] != labels[_as[i+1]]:
             if pct:

--- a/pandas/_libs/groupby.pyx
+++ b/pandas/_libs/groupby.pyx
@@ -139,13 +139,17 @@ def group_rank_object(ndarray[float64_t, ndim=2] out,
         Py_ssize_t i, j, N, K
         int64_t val_start=0, grp_start=0, dups=0, sum_ranks=0
         ndarray[int64_t] _as
-        bint pct
+        bint pct, ascending
 
     tiebreak = tiebreakers[kwargs['ties_method']]
     pct = kwargs['pct']
+    ascending = kwargs['ascending']
     N, K = (<object> values).shape
 
     _as = np.lexsort((values[:, 0], labels))
+
+    if not ascending:
+        _as = _as[::-1]
 
     for i in range(N):
         dups += 1

--- a/pandas/_libs/groupby.pyx
+++ b/pandas/_libs/groupby.pyx
@@ -13,7 +13,6 @@ from numpy cimport (ndarray,
                     int8_t, int16_t, int32_t, int64_t, uint8_t, uint16_t,
                     uint32_t, uint64_t, float32_t, float64_t)
 
-from libc.math cimport isnan
 from libc.stdlib cimport malloc, free
 
 from util cimport numeric, get_nat
@@ -25,6 +24,9 @@ cdef int64_t iNaT = get_nat()
 
 cdef double NaN = <double> np.NaN
 cdef double nan = NaN
+
+cdef extern from "numpy/npy_math.h" nogil:
+    bint npy_isnan(double x)
 
 import missing
 

--- a/pandas/_libs/groupby.pyx
+++ b/pandas/_libs/groupby.pyx
@@ -18,7 +18,7 @@ from libc.stdlib cimport malloc, free
 
 from util cimport numeric, get_nat
 from algos cimport (swap, TIEBREAK_AVERAGE, TIEBREAK_MIN, TIEBREAK_MAX,
-                    TIEBREAK_FIRST, TIEBREAK_FIRST_DESCENDING, TIEBREAK_DENSE)
+                    TIEBREAK_FIRST, TIEBREAK_DENSE)
 from algos import take_2d_axis1_float64_float64, groupsort_indexer, tiebreakers
 
 cdef int64_t iNaT = get_nat()
@@ -195,9 +195,9 @@ def group_rank_object(ndarray[float64_t, ndim=2] out,
             elif tiebreak == TIEBREAK_FIRST:
                 for j in range(i - dups + 1, i + 1):
                     if ascending:
-                        out[_as[j], 0] = j + 1
+                        out[_as[j], 0] = j + 1 - grp_start
                     else:
-                        out[_as[j], 0] = 2 * i - j - dups + 2
+                        out[_as[j], 0] = 2 * i - j - dups + 2 - grp_start
             elif tiebreak == TIEBREAK_DENSE:
                 for j in range(i - dups + 1, i + 1):
                     out[_as[j], 0] = vals_seen

--- a/pandas/_libs/groupby.pyx
+++ b/pandas/_libs/groupby.pyx
@@ -28,8 +28,6 @@ cdef double nan = NaN
 cdef extern from "numpy/npy_math.h" nogil:
     bint npy_isnan(double x)
 
-import missing
-
 
 # TODO: aggregate multiple columns in single pass
 # ----------------------------------------------------------------------

--- a/pandas/_libs/groupby.pyx
+++ b/pandas/_libs/groupby.pyx
@@ -130,14 +130,6 @@ def group_last_object(ndarray[object, ndim=2] out,
                 out[i, j] = resx[i, j]
 
 
-def group_rank_object(ndarray[float64_t, ndim=2] out,
-                      ndarray[object, ndim=2] values,
-                      ndarray[int64_t] labels,
-                      bint is_datetimelike, object ties_method,
-                      bint ascending, bint pct, object na_option):
-    raise ValueError("rank not supported for object dtypes")
-
-
 cdef inline float64_t median_linear(float64_t* a, int n) nogil:
     cdef int i, j, na_count = 0
     cdef float64_t result

--- a/pandas/_libs/groupby.pyx
+++ b/pandas/_libs/groupby.pyx
@@ -139,8 +139,10 @@ def group_rank_object(ndarray[float64_t, ndim=2] out,
         Py_ssize_t i, j, N, K
         int64_t val_start=0, grp_start=0, dups=0, sum_ranks=0
         ndarray[int64_t] _as
+        bint pct
 
     tiebreak = tiebreakers[kwargs['ties_method']]
+    pct = kwargs['pct']
     N, K = (<object> values).shape
 
     _as = np.lexsort((values[:, 0], labels))
@@ -175,8 +177,11 @@ def group_rank_object(ndarray[float64_t, ndim=2] out,
             dups = sum_ranks = 0
             val_start = i
 
-        if i == 0 or labels[_as[i]] != labels[_as[i-1]]:
-            grp_start = i
+        if i == N - 1 or labels[_as[i]] != labels[_as[i+1]]:
+            if pct:
+                for j in range(grp_start, i + 1):
+                    out[_as[j], 0] = out[_as[j], 0] / (i - grp_start + 1)
+            grp_start = i + 1
 
 
 cdef inline float64_t median_linear(float64_t* a, int n) nogil:

--- a/pandas/_libs/groupby.pyx
+++ b/pandas/_libs/groupby.pyx
@@ -18,7 +18,7 @@ from libc.stdlib cimport malloc, free
 
 from util cimport numeric, get_nat
 from algos cimport (swap, TIEBREAK_AVERAGE, TIEBREAK_MIN, TIEBREAK_MAX,
-                    TIEBREAK_FIRST, TIEBREAK_DENSE)
+                    TIEBREAK_FIRST, TIEBREAK_FIRST_DESCENDING, TIEBREAK_DENSE)
 from algos import take_2d_axis1_float64_float64, groupsort_indexer, tiebreakers
 
 cdef int64_t iNaT = get_nat()

--- a/pandas/_libs/groupby.pyx
+++ b/pandas/_libs/groupby.pyx
@@ -25,9 +25,6 @@ cdef int64_t iNaT = get_nat()
 cdef double NaN = <double> np.NaN
 cdef double nan = NaN
 
-cdef extern from "numpy/npy_math.h" nogil:
-    bint npy_isnan(double x)
-
 
 # TODO: aggregate multiple columns in single pass
 # ----------------------------------------------------------------------

--- a/pandas/_libs/groupby.pyx
+++ b/pandas/_libs/groupby.pyx
@@ -127,6 +127,7 @@ def group_last_object(ndarray[object, ndim=2] out,
             else:
                 out[i, j] = resx[i, j]
 
+
 @cython.boundscheck(False)
 @cython.wraparound(False)
 def group_rank_object(ndarray[float64_t, ndim=2] out,
@@ -201,10 +202,10 @@ def group_rank_object(ndarray[float64_t, ndim=2] out,
                 for j in range(i - dups + 1, i + 1):
                     out[_as[j], 0] = grp_vals_seen
 
-        if (i == N - 1 or (
+        if i == N - 1 or (
                 (values[_as[i], 0] != values[_as[i+1], 0]) and not
                 (values[_as[i], 0] is np.nan and values[_as[i+1], 0] is np.nan)
-                )):
+        ):
             dups = sum_ranks = 0
             val_start = i
             grp_vals_seen += 1

--- a/pandas/_libs/groupby.pyx
+++ b/pandas/_libs/groupby.pyx
@@ -13,11 +13,13 @@ from numpy cimport (ndarray,
                     int8_t, int16_t, int32_t, int64_t, uint8_t, uint16_t,
                     uint32_t, uint64_t, float32_t, float64_t)
 
+from libc.math cimport isnan
 from libc.stdlib cimport malloc, free
 
 from util cimport numeric, get_nat
-from algos cimport swap
-from algos import take_2d_axis1_float64_float64, groupsort_indexer
+from algos cimport (swap, TIEBREAK_AVERAGE, TIEBREAK_MIN, TIEBREAK_MAX,
+                    TIEBREAK_FIRST, TIEBREAK_DENSE)
+from algos import take_2d_axis1_float64_float64, groupsort_indexer, tiebreakers
 
 cdef int64_t iNaT = get_nat()
 

--- a/pandas/_libs/groupby.pyx
+++ b/pandas/_libs/groupby.pyx
@@ -17,8 +17,7 @@ from libc.math cimport isnan
 from libc.stdlib cimport malloc, free
 
 from util cimport numeric, get_nat
-from algos cimport (swap, TIEBREAK_AVERAGE, TIEBREAK_MIN, TIEBREAK_MAX,
-                    TIEBREAK_FIRST, TIEBREAK_DENSE)
+from algos cimport swap, TiebreakEnumType
 from algos import take_2d_axis1_float64_float64, groupsort_indexer, tiebreakers
 
 cdef int64_t iNaT = get_nat()
@@ -138,7 +137,7 @@ def group_rank_object(ndarray[float64_t, ndim=2] out,
     Only transforms on axis=0
     """
     cdef:
-        int tiebreak
+        TiebreakEnumType tiebreak
         Py_ssize_t i, j, N, K
         int64_t val_start=0, grp_start=0, dups=0, sum_ranks=0, grp_vals_seen=1
         int64_t grp_na_count=0
@@ -182,22 +181,22 @@ def group_rank_object(ndarray[float64_t, ndim=2] out,
             grp_na_count += 1
             out[_as[i], 0] = np.nan
         else:
-            if tiebreak == TIEBREAK_AVERAGE:
+            if tiebreak == TiebreakEnumType.TIEBREAK_AVERAGE:
                 for j in range(i - dups + 1, i + 1):
                     out[_as[j], 0] = sum_ranks / dups
-            elif tiebreak == TIEBREAK_MIN:
+            elif tiebreak == TiebreakEnumType.TIEBREAK_MIN:
                 for j in range(i - dups + 1, i + 1):
                     out[_as[j], 0] = i - grp_start - dups + 2
-            elif tiebreak == TIEBREAK_MAX:
+            elif tiebreak == TiebreakEnumType.TIEBREAK_MAX:
                 for j in range(i - dups + 1, i + 1):
                     out[_as[j], 0] = i - grp_start + 1
-            elif tiebreak == TIEBREAK_FIRST:
+            elif tiebreak == TiebreakEnumType.TIEBREAK_FIRST:
                 for j in range(i - dups + 1, i + 1):
                     if ascending:
                         out[_as[j], 0] = j + 1 - grp_start
                     else:
                         out[_as[j], 0] = 2 * i - j - dups + 2 - grp_start
-            elif tiebreak == TIEBREAK_DENSE:
+            elif tiebreak == TiebreakEnumType.TIEBREAK_DENSE:
                 for j in range(i - dups + 1, i + 1):
                     out[_as[j], 0] = grp_vals_seen
 

--- a/pandas/_libs/groupby.pyx
+++ b/pandas/_libs/groupby.pyx
@@ -17,7 +17,8 @@ from libc.math cimport isnan
 from libc.stdlib cimport malloc, free
 
 from util cimport numeric, get_nat
-from algos cimport swap, TiebreakEnumType
+from algos cimport (swap, TiebreakEnumType, TIEBREAK_AVERAGE, TIEBREAK_MIN,
+                    TIEBREAK_MAX, TIEBREAK_FIRST, TIEBREAK_DENSE)
 from algos import take_2d_axis1_float64_float64, groupsort_indexer, tiebreakers
 
 cdef int64_t iNaT = get_nat()
@@ -181,22 +182,22 @@ def group_rank_object(ndarray[float64_t, ndim=2] out,
             grp_na_count += 1
             out[_as[i], 0] = np.nan
         else:
-            if tiebreak == TiebreakEnumType.TIEBREAK_AVERAGE:
+            if tiebreak == TIEBREAK_AVERAGE:
                 for j in range(i - dups + 1, i + 1):
                     out[_as[j], 0] = sum_ranks / dups
-            elif tiebreak == TiebreakEnumType.TIEBREAK_MIN:
+            elif tiebreak == TIEBREAK_MIN:
                 for j in range(i - dups + 1, i + 1):
                     out[_as[j], 0] = i - grp_start - dups + 2
-            elif tiebreak == TiebreakEnumType.TIEBREAK_MAX:
+            elif tiebreak == TIEBREAK_MAX:
                 for j in range(i - dups + 1, i + 1):
                     out[_as[j], 0] = i - grp_start + 1
-            elif tiebreak == TiebreakEnumType.TIEBREAK_FIRST:
+            elif tiebreak == TIEBREAK_FIRST:
                 for j in range(i - dups + 1, i + 1):
                     if ascending:
                         out[_as[j], 0] = j + 1 - grp_start
                     else:
                         out[_as[j], 0] = 2 * i - j - dups + 2 - grp_start
-            elif tiebreak == TiebreakEnumType.TIEBREAK_DENSE:
+            elif tiebreak == TIEBREAK_DENSE:
                 for j in range(i - dups + 1, i + 1):
                     out[_as[j], 0] = grp_vals_seen
 

--- a/pandas/_libs/groupby.pyx
+++ b/pandas/_libs/groupby.pyx
@@ -132,7 +132,8 @@ def group_last_object(ndarray[object, ndim=2] out,
 def group_rank_object(ndarray[float64_t, ndim=2] out,
                       ndarray[object, ndim=2] values,
                       ndarray[int64_t] labels,
-                      bint is_datetimelike, **kwargs):
+                      bint is_datetimelike, object ties_method,
+                      bint ascending, bint pct, object na_option):
     """
     Only transforms on axis=0
     """
@@ -143,18 +144,16 @@ def group_rank_object(ndarray[float64_t, ndim=2] out,
         int64_t grp_na_count=0
         ndarray[int64_t] _as
         ndarray[object] _values
-        bint pct, ascending, keep_na
+        bint keep_na
 
-    tiebreak = tiebreakers[kwargs['ties_method']]
-    ascending = kwargs['ascending']
-    pct = kwargs['pct']
-    keep_na = kwargs['na_option'] == 'keep'
+    tiebreak = tiebreakers[ties_method]
+    keep_na = na_option == 'keep'
     N, K = (<object> values).shape
 
     masked_vals = np.array(values[:, 0], copy=True)
     mask = missing.isnaobj(masked_vals)
 
-    if ascending ^ (kwargs['na_option'] == 'top'):
+    if ascending ^ (na_option == 'top'):
         nan_fill_val = np.inf
         order = (masked_vals, mask, labels)
     else:

--- a/pandas/_libs/groupby_helper.pxi.in
+++ b/pandas/_libs/groupby_helper.pxi.in
@@ -520,9 +520,9 @@ def group_rank_{{name}}(ndarray[float64_t, ndim=2] out,
                 elif tiebreak == TIEBREAK_FIRST:
                     for j in range(i - dups + 1, i + 1):
                         if ascending:
-                            out[_as[j], 0] = j + 1
+                            out[_as[j], 0] = j + 1 - grp_start
                         else:
-                            out[_as[j], 0] = 2 * i - j - dups + 2
+                            out[_as[j], 0] = 2 * i - j - dups + 2 - grp_start
                 elif tiebreak == TIEBREAK_DENSE:
                     for j in range(i - dups + 1, i + 1):
                         out[_as[j], 0] = vals_seen

--- a/pandas/_libs/groupby_helper.pxi.in
+++ b/pandas/_libs/groupby_helper.pxi.in
@@ -457,9 +457,8 @@ def group_rank_{{name}}(ndarray[float64_t, ndim=2] out,
     """
     cdef:
         TiebreakEnumType tiebreak
-        Py_ssize_t i, j, N, K
-        int64_t val_start=0, grp_start=0, dups=0, sum_ranks=0, grp_vals_seen=1
-        int64_t grp_na_count=0
+        Py_ssize_t i, j, N, K, val_start=0, grp_start=0, dups=0, sum_ranks=0
+        Py_ssize_t grp_vals_seen=1, grp_na_count=0
         ndarray[int64_t] _as
         ndarray[{{c_type}}] masked_vals
         ndarray[uint8_t] mask
@@ -539,7 +538,7 @@ def group_rank_{{name}}(ndarray[float64_t, ndim=2] out,
                 # result once the last duplicate value is encountered
                 if tiebreak == TIEBREAK_AVERAGE:
                     for j in range(i - dups + 1, i + 1):
-                        out[_as[j], 0] = sum_ranks / dups
+                        out[_as[j], 0] = sum_ranks / <float64_t>dups
                 elif tiebreak == TIEBREAK_MIN:
                     for j in range(i - dups + 1, i + 1):
                         out[_as[j], 0] = i - grp_start - dups + 2
@@ -583,6 +582,7 @@ def group_rank_{{name}}(ndarray[float64_t, ndim=2] out,
             # so the tiebreaker calculations can decrement that from their position
             # if the pct flag is True, go back and overwrite the result for
             # the group to be divided by the size of the group (excluding na values)
+            # also be sure to reset any of the items helping to calculate dups
             if i == N - 1 or labels[_as[i]] != labels[_as[i+1]]:
                 if pct:
                     for j in range(grp_start, i + 1):

--- a/pandas/_libs/groupby_helper.pxi.in
+++ b/pandas/_libs/groupby_helper.pxi.in
@@ -446,7 +446,7 @@ def group_nth_{{name}}(ndarray[{{dest_type2}}, ndim=2] out,
 
 @cython.boundscheck(False)
 @cython.wraparound(False)
-def group_rank_{{name}}(ndarray[{{dest_type2}}, ndim=2] out,
+def group_rank_{{name}}(ndarray[float64_t, ndim=2] out,
                         ndarray[{{c_type}}, ndim=2] values,
                         ndarray[int64_t] labels,
                         bint is_datetimelike, **kwargs):
@@ -472,7 +472,21 @@ def group_rank_{{name}}(ndarray[{{dest_type2}}, ndim=2] out,
             if tiebreak == TIEBREAK_AVERAGE:
                 for j in range(i - dups + 1, i + 1):
                     out[_as[j], 0] = sum_ranks / dups
-
+            elif tiebreak == TIEBREAK_MIN:
+                for j in range(i - dups + 1, i + 1):
+                    out[_as[j], 0] = i - grp_start - dups + 2
+            elif tiebreak == TIEBREAK_MAX:
+                for j in range(i - dups + 1, i + 1):
+                    out[_as[j], 0] = i - grp_start + 1
+            elif tiebreak == TIEBREAK_FIRST:
+                for j in range(i - dups + 1, i + 1):
+                    out[_as[j], 0] = j + 1
+            elif tiebreak == TIEBREAK_FIRST_DESCENDING:
+                for j in range(i - dups + 1, i + 1):
+                   out[_as[j], 0]  = 2 * (i - grp_start) - j - dups + 2
+            elif tiebreak == TIEBREAK_DENSE:
+                for j in range(i - dups + 1, i + 1):
+                    out[_as[j], 0] = val_start - grp_start
             if (i == N - 1 or (
                     (values[_as[i], 0] != values[_as[i+1], 0]) and not
                     (isnan(values[_as[i], 0]) and

--- a/pandas/_libs/groupby_helper.pxi.in
+++ b/pandas/_libs/groupby_helper.pxi.in
@@ -444,7 +444,6 @@ def group_nth_{{name}}(ndarray[{{dest_type2}}, ndim=2] out,
                 else:
                     out[i, j] = resx[i, j]
 
-
 @cython.boundscheck(False)
 @cython.wraparound(False)
 def group_rank_{{name}}(ndarray[{{dest_type2}}, ndim=2] out,
@@ -455,27 +454,35 @@ def group_rank_{{name}}(ndarray[{{dest_type2}}, ndim=2] out,
     Only transforms on axis=0
     """
     cdef:
+        int tiebreak
         Py_ssize_t i, j, N, K
-        int64_t lab, idx, counter=1
+        int64_t val_start=0, grp_start=0, dups=0, sum_ranks=0
         ndarray[int64_t] _as
 
+    tiebreak = tiebreakers[kwargs['ties_method']]
     N, K = (<object> values).shape
 
     _as = np.lexsort((values[:, 0], labels))
 
     with nogil:
         for i in range(N):
-            idx = _as[i]
-            lab = labels[idx]
-            if i > 0 and lab == labels[_as[i-1]]:
-                counter += 1
-            else:
-                counter = 1
-            if lab < 0:
-                continue
+            dups += 1
+            sum_ranks += i - grp_start + 1
 
-            for j in range(K):
-                out[idx, j] = counter
+            if tiebreak == TIEBREAK_AVERAGE:
+                for j in range(i - dups + 1, i + 1):
+                    out[_as[j], 0] = sum_ranks / dups
+
+            if (i == N - 1 or (
+                    (values[_as[i], 0] != values[_as[i+1], 0]) and not
+                    (isnan(values[_as[i], 0]) and
+                     isnan(values[_as[i+1], 0])
+                    ))):
+                dups = sum_ranks = 0
+                val_start = i
+
+            if i == 0 or labels[_as[i]] != labels[_as[i-1]]:
+                grp_start = i
 
 {{endfor}}
 

--- a/pandas/_libs/groupby_helper.pxi.in
+++ b/pandas/_libs/groupby_helper.pxi.in
@@ -507,22 +507,22 @@ def group_rank_{{name}}(ndarray[float64_t, ndim=2] out,
                 grp_na_count += 1
                 out[_as[i], 0] = nan
             else:
-                if tiebreak == TiebreakEnumType.TIEBREAK_AVERAGE:
+                if tiebreak == TIEBREAK_AVERAGE:
                     for j in range(i - dups + 1, i + 1):
                         out[_as[j], 0] = sum_ranks / dups
-                elif tiebreak == TiebreakEnumType.TIEBREAK_MIN:
+                elif tiebreak == TIEBREAK_MIN:
                     for j in range(i - dups + 1, i + 1):
                         out[_as[j], 0] = i - grp_start - dups + 2
-                elif tiebreak == TiebreakEnumType.TIEBREAK_MAX:
+                elif tiebreak == TIEBREAK_MAX:
                     for j in range(i - dups + 1, i + 1):
                         out[_as[j], 0] = i - grp_start + 1
-                elif tiebreak == TiebreakEnumType.TIEBREAK_FIRST:
+                elif tiebreak == TIEBREAK_FIRST:
                     for j in range(i - dups + 1, i + 1):
                         if ascending:
                             out[_as[j], 0] = j + 1 - grp_start
                         else:
                             out[_as[j], 0] = 2 * i - j - dups + 2 - grp_start
-                elif tiebreak == TiebreakEnumType.TIEBREAK_DENSE:
+                elif tiebreak == TIEBREAK_DENSE:
                     for j in range(i - dups + 1, i + 1):
                         out[_as[j], 0] = grp_vals_seen
 

--- a/pandas/_libs/groupby_helper.pxi.in
+++ b/pandas/_libs/groupby_helper.pxi.in
@@ -481,6 +481,7 @@ def group_rank_{{name}}(ndarray[float64_t, ndim=2] out,
         Py_ssize_t i, j, N, K, val_start=0, grp_start=0, dups=0, sum_ranks=0
         Py_ssize_t grp_vals_seen=1, grp_na_count=0
         ndarray[int64_t] _as
+        ndarray[float64_t, ndim=2] grp_sizes
         ndarray[{{c_type}}] masked_vals
         ndarray[uint8_t] mask
         bint keep_na
@@ -489,6 +490,7 @@ def group_rank_{{name}}(ndarray[float64_t, ndim=2] out,
     tiebreak = tiebreakers[ties_method]
     keep_na = na_option == 'keep'
     N, K = (<object> values).shape
+    grp_sizes = np.ones_like(out)
 
     # Copy values into new array in order to fill missing data
     # with mask, without obfuscating location of missing data
@@ -588,24 +590,26 @@ def group_rank_{{name}}(ndarray[float64_t, ndim=2] out,
                 val_start = i
                 grp_vals_seen += 1
 
-            # Similar to the previous conditional, check now if we are moving to a
-            # new group. If so, keep track of the index where the new group occurs,
-            # so the tiebreaker calculations can decrement that from their position
-            # if the pct flag is True, go back and overwrite the result for
-            # the group to be divided by the size of the group (excluding na values)
-            # also be sure to reset any of the items helping to calculate dups
+            # Similar to the previous conditional, check now if we are moving
+            # to a new group. If so, keep track of the index where the new
+            # group occurs, so the tiebreaker calculations can decrement that
+            # from their position. fill in the size of each group encountered
+            # (used by pct calculations later). also be sure to reset any of
+            # the items helping to calculate dups
             if i == N - 1 or labels[_as[i]] != labels[_as[i+1]]:
-                if pct:
-                    for j in range(grp_start, i + 1):
-                        out[_as[j], 0] = out[_as[j], 0] / (i - grp_start + 1
-                                                           - grp_na_count)
+                for j in range(grp_start, i + 1):
+                    grp_sizes[_as[j], 0] = i - grp_start + 1 - grp_na_count
                 dups = sum_ranks = 0
                 grp_na_count = 0
                 val_start = i + 1
                 grp_start = i + 1
                 grp_vals_seen = 1
 
+        if pct:
+            for i in range(N):
+                out[i, 0] = out[i, 0] / grp_sizes[i, 0]
 {{endfor}}
+
 
 #----------------------------------------------------------------------
 # group_min, group_max

--- a/pandas/_libs/groupby_helper.pxi.in
+++ b/pandas/_libs/groupby_helper.pxi.in
@@ -459,13 +459,17 @@ def group_rank_{{name}}(ndarray[float64_t, ndim=2] out,
         Py_ssize_t i, j, N, K
         int64_t val_start=0, grp_start=0, dups=0, sum_ranks=0
         ndarray[int64_t] _as
-        bint pct
+        bint pct, ascending
 
     tiebreak = tiebreakers[kwargs['ties_method']]
+    ascending = kwargs['ascending']
     pct = kwargs['pct']
     N, K = (<object> values).shape
 
     _as = np.lexsort((values[:, 0], labels))
+
+    if not ascending:
+        _as = _as[::-1]
 
     with nogil:
         for i in range(N):
@@ -483,10 +487,10 @@ def group_rank_{{name}}(ndarray[float64_t, ndim=2] out,
                     out[_as[j], 0] = i - grp_start + 1
             elif tiebreak == TIEBREAK_FIRST:
                 for j in range(i - dups + 1, i + 1):
-                    out[_as[j], 0] = j + 1
-            elif tiebreak == TIEBREAK_FIRST_DESCENDING:
-                for j in range(i - dups + 1, i + 1):
-                   out[_as[j], 0]  = 2 * (i - grp_start) - j - dups + 2
+                    if ascending:
+                        out[_as[j], 0] = j + 1
+                    else:
+                        out[_as[j], 0] = 2 * i - j - dups + 2
             elif tiebreak == TIEBREAK_DENSE:
                 for j in range(i - dups + 1, i + 1):
                     out[_as[j], 0] = val_start - grp_start

--- a/pandas/_libs/groupby_helper.pxi.in
+++ b/pandas/_libs/groupby_helper.pxi.in
@@ -463,6 +463,7 @@ def group_rank_{{name}}(ndarray[float64_t, ndim=2] out,
         ndarray[{{c_type}}] _values
         ndarray[uint8_t] mask
         bint pct, ascending, keep_na
+        {{c_type}} nan_value
 
     tiebreak = tiebreakers[kwargs['ties_method']]
     ascending = kwargs['ascending']
@@ -471,19 +472,27 @@ def group_rank_{{name}}(ndarray[float64_t, ndim=2] out,
     N, K = (<object> values).shape
 
     _values = np.array(values[:, 0], copy=True)
-    mask = np.isnan(_values).astype(np.uint8)
-
-    {{if name == 'int64' }}
-    order = (_values, labels)
+    {{if name=='int64'}}
+    mask = (_values == {{nan_val}}).astype(np.uint8)
     {{else}}
+    mask = np.isnan(_values).astype(np.uint8)
+    {{endif}}
+
     if ascending ^ (kwargs['na_option'] == 'top'):
+        {{if name == 'int64'}}
+        nan_value = np.iinfo(np.int64).max
+        {{else}}
         nan_value = np.inf
+        {{endif}}
         order = (_values, mask, labels)
     else:
+        {{if name == 'int64'}}
+        nan_value = np.iinfo(np.int64).min
+        {{else}}
         nan_value = -np.inf
+        {{endif}}
         order = (_values, ~mask, labels)
     np.putmask(_values, mask, nan_value)
-    {{endif}}
 
     _as = np.lexsort(order)
 
@@ -495,9 +504,9 @@ def group_rank_{{name}}(ndarray[float64_t, ndim=2] out,
             dups += 1
             sum_ranks += i - grp_start + 1
 
-            if keep_na and (values[_as[i], 0] != values[_as[i], 0]):
+            if keep_na and _values[_as[i]] == nan_value:
                 grp_na_count += 1
-                out[_as[i], 0] = {{nan_val}}
+                out[_as[i], 0] = nan
             else:
                 if tiebreak == TIEBREAK_AVERAGE:
                     for j in range(i - dups + 1, i + 1):
@@ -518,11 +527,19 @@ def group_rank_{{name}}(ndarray[float64_t, ndim=2] out,
                     for j in range(i - dups + 1, i + 1):
                         out[_as[j], 0] = vals_seen
 
+            {{if name=='int64'}}
+            if (i == N - 1 or (
+                    (_values[_as[i]] != _values[_as[i+1]]) and not
+                    (_values[_as[i]] == nan_value and
+                     _values[_as[i+1]] == nan_value
+                    ))):
+            {{else}}
             if (i == N - 1 or (
                     (_values[_as[i]] != _values[_as[i+1]]) and not
                     (isnan(_values[_as[i]]) and
                      isnan(_values[_as[i+1]])
                     ))):
+            {{endif}}
                 dups = sum_ranks = 0
                 val_start = i
                 vals_seen += 1

--- a/pandas/_libs/groupby_helper.pxi.in
+++ b/pandas/_libs/groupby_helper.pxi.in
@@ -450,7 +450,7 @@ def group_nth_{{name}}(ndarray[{{dest_type2}}, ndim=2] out,
 def group_rank_{{name}}(ndarray[{{dest_type2}}, ndim=2] out,
                         ndarray[{{c_type}}, ndim=2] values,
                         ndarray[int64_t] labels,
-                        bint is_datetimelike):
+                        bint is_datetimelike, **kwargs):
     """
     Only transforms on axis=0
     """

--- a/pandas/_libs/groupby_helper.pxi.in
+++ b/pandas/_libs/groupby_helper.pxi.in
@@ -450,7 +450,8 @@ def group_nth_{{name}}(ndarray[{{dest_type2}}, ndim=2] out,
 def group_rank_{{name}}(ndarray[float64_t, ndim=2] out,
                         ndarray[{{c_type}}, ndim=2] values,
                         ndarray[int64_t] labels,
-                        bint is_datetimelike, **kwargs):
+                        bint is_datetimelike, object ties_method,
+                        bint ascending, bint pct, object na_option):
     """
     Only transforms on axis=0
     """
@@ -462,13 +463,11 @@ def group_rank_{{name}}(ndarray[float64_t, ndim=2] out,
         ndarray[int64_t] _as
         ndarray[{{c_type}}] masked_vals
         ndarray[uint8_t] mask
-        bint pct, ascending, keep_na
+        bint keep_na
         {{c_type}} nan_fill_val
 
-    tiebreak = tiebreakers[kwargs['ties_method']]
-    ascending = kwargs['ascending']
-    pct = kwargs['pct']
-    keep_na = kwargs['na_option'] == 'keep'
+    tiebreak = tiebreakers[ties_method]
+    keep_na = na_option == 'keep'
     N, K = (<object> values).shape
 
     masked_vals = np.array(values[:, 0], copy=True)
@@ -478,7 +477,7 @@ def group_rank_{{name}}(ndarray[float64_t, ndim=2] out,
     mask = np.isnan(masked_vals).astype(np.uint8)
     {{endif}}
 
-    if ascending ^ (kwargs['na_option'] == 'top'):
+    if ascending ^ (na_option == 'top'):
         {{if name == 'int64'}}
         nan_fill_val = np.iinfo(np.int64).max
         {{else}}

--- a/pandas/_libs/groupby_helper.pxi.in
+++ b/pandas/_libs/groupby_helper.pxi.in
@@ -444,6 +444,39 @@ def group_nth_{{name}}(ndarray[{{dest_type2}}, ndim=2] out,
                 else:
                     out[i, j] = resx[i, j]
 
+
+@cython.boundscheck(False)
+@cython.wraparound(False)
+def group_rank_{{name}}(ndarray[{{dest_type2}}, ndim=2] out,
+                        ndarray[{{c_type}}, ndim=2] values,
+                        ndarray[int64_t] labels,
+                        bint is_datetimelike):
+    """
+    Only transforms on axis=0
+    """
+    cdef:
+        Py_ssize_t i, j, N, K
+        int64_t lab, idx, counter=1
+        ndarray[int64_t] _as
+
+    N, K = (<object> values).shape
+
+    _as = np.lexsort((values[:, 0], labels))
+
+    with nogil:
+        for i in range(N):
+            idx = _as[i]
+            lab = labels[idx]
+            if i > 0 and lab == labels[_as[i-1]]:
+                counter += 1
+            else:
+                counter = 1
+            if lab < 0:
+                continue
+
+            for j in range(K):
+                out[idx, j] = counter
+
 {{endfor}}
 
 #----------------------------------------------------------------------

--- a/pandas/_libs/groupby_helper.pxi.in
+++ b/pandas/_libs/groupby_helper.pxi.in
@@ -588,7 +588,9 @@ def group_rank_{{name}}(ndarray[float64_t, ndim=2] out,
                     for j in range(grp_start, i + 1):
                         out[_as[j], 0] = out[_as[j], 0] / (i - grp_start + 1
                                                            - grp_na_count)
+                dups = sum_ranks = 0
                 grp_na_count = 0
+                val_start = i + 1
                 grp_start = i + 1
                 grp_vals_seen = 1
 

--- a/pandas/_libs/groupby_helper.pxi.in
+++ b/pandas/_libs/groupby_helper.pxi.in
@@ -452,8 +452,29 @@ def group_rank_{{name}}(ndarray[float64_t, ndim=2] out,
                         ndarray[int64_t] labels,
                         bint is_datetimelike, object ties_method,
                         bint ascending, bint pct, object na_option):
-    """
-    Only transforms on axis=0
+    """Provides the rank of values within each group
+
+    Parameters
+    ----------
+    out : array of float64_t values which this method will write its results to
+    values : array of {{c_type}} values to be ranked
+    labels : array containing unique label for each group, with its ordering
+        matching up to the corresponding record in `values`
+    is_datetimelike : bool
+        unused in this method but provided for call compatability with other
+        Cython transformations
+    ties_method :  {'keep', 'top', 'bottom'}
+        * keep: leave NA values where they are
+        * top: smallest rank if ascending
+        * bottom: smallest rank if descending
+    ascending : boolean
+        False for ranks by high (1) to low (N)
+    pct : boolean
+        Compute percentage rank of data within each group
+
+    Notes
+    -----
+    This method modifies the `out` parameter rather than returning an object
     """
     cdef:
         TiebreakEnumType tiebreak

--- a/pandas/_libs/groupby_helper.pxi.in
+++ b/pandas/_libs/groupby_helper.pxi.in
@@ -457,7 +457,7 @@ def group_rank_{{name}}(ndarray[float64_t, ndim=2] out,
     cdef:
         int tiebreak
         Py_ssize_t i, j, N, K
-        int64_t val_start=0, grp_start=0, dups=0, sum_ranks=0
+        int64_t val_start=0, grp_start=0, dups=0, sum_ranks=0, vals_seen=1
         ndarray[int64_t] _as
         bint pct, ascending
 
@@ -493,7 +493,8 @@ def group_rank_{{name}}(ndarray[float64_t, ndim=2] out,
                         out[_as[j], 0] = 2 * i - j - dups + 2
             elif tiebreak == TIEBREAK_DENSE:
                 for j in range(i - dups + 1, i + 1):
-                    out[_as[j], 0] = val_start - grp_start
+                    out[_as[j], 0] = vals_seen
+
             if (i == N - 1 or (
                     (values[_as[i], 0] != values[_as[i+1], 0]) and not
                     (isnan(values[_as[i], 0]) and
@@ -501,12 +502,14 @@ def group_rank_{{name}}(ndarray[float64_t, ndim=2] out,
                     ))):
                 dups = sum_ranks = 0
                 val_start = i
+                vals_seen += 1
 
             if i == N - 1 or labels[_as[i]] != labels[_as[i+1]]:
                 if pct:
                     for j in range(grp_start, i + 1):
                         out[_as[j], 0] = out[_as[j], 0] / (i - grp_start + 1)
                 grp_start = i + 1
+                vals_seen = 1
 
 {{endfor}}
 

--- a/pandas/_libs/groupby_helper.pxi.in
+++ b/pandas/_libs/groupby_helper.pxi.in
@@ -456,7 +456,7 @@ def group_rank_{{name}}(ndarray[float64_t, ndim=2] out,
     Only transforms on axis=0
     """
     cdef:
-        int tiebreak
+        TiebreakEnumType tiebreak
         Py_ssize_t i, j, N, K
         int64_t val_start=0, grp_start=0, dups=0, sum_ranks=0, grp_vals_seen=1
         int64_t grp_na_count=0
@@ -507,22 +507,22 @@ def group_rank_{{name}}(ndarray[float64_t, ndim=2] out,
                 grp_na_count += 1
                 out[_as[i], 0] = nan
             else:
-                if tiebreak == TIEBREAK_AVERAGE:
+                if tiebreak == TiebreakEnumType.TIEBREAK_AVERAGE:
                     for j in range(i - dups + 1, i + 1):
                         out[_as[j], 0] = sum_ranks / dups
-                elif tiebreak == TIEBREAK_MIN:
+                elif tiebreak == TiebreakEnumType.TIEBREAK_MIN:
                     for j in range(i - dups + 1, i + 1):
                         out[_as[j], 0] = i - grp_start - dups + 2
-                elif tiebreak == TIEBREAK_MAX:
+                elif tiebreak == TiebreakEnumType.TIEBREAK_MAX:
                     for j in range(i - dups + 1, i + 1):
                         out[_as[j], 0] = i - grp_start + 1
-                elif tiebreak == TIEBREAK_FIRST:
+                elif tiebreak == TiebreakEnumType.TIEBREAK_FIRST:
                     for j in range(i - dups + 1, i + 1):
                         if ascending:
                             out[_as[j], 0] = j + 1 - grp_start
                         else:
                             out[_as[j], 0] = 2 * i - j - dups + 2 - grp_start
-                elif tiebreak == TIEBREAK_DENSE:
+                elif tiebreak == TiebreakEnumType.TIEBREAK_DENSE:
                     for j in range(i - dups + 1, i + 1):
                         out[_as[j], 0] = grp_vals_seen
 

--- a/pandas/_libs/groupby_helper.pxi.in
+++ b/pandas/_libs/groupby_helper.pxi.in
@@ -470,6 +470,9 @@ def group_rank_{{name}}(ndarray[float64_t, ndim=2] out,
     keep_na = na_option == 'keep'
     N, K = (<object> values).shape
 
+    # Copy values into new array in order to fill missing data
+    # with mask, without obfuscating location of missing data
+    # in values array
     masked_vals = np.array(values[:, 0], copy=True)
     {{if name=='int64'}}
     mask = (masked_vals == {{nan_val}}).astype(np.uint8)
@@ -493,20 +496,47 @@ def group_rank_{{name}}(ndarray[float64_t, ndim=2] out,
         order = (masked_vals, ~mask, labels)
     np.putmask(masked_vals, mask, nan_fill_val)
 
+    # lexsort using labels, then mask, then actual values
+    # each label corresponds to a different group value,
+    # the mask helps you differentiate missing values before
+    # performing sort on the actual values
     _as = np.lexsort(order)
 
     if not ascending:
         _as = _as[::-1]
 
     with nogil:
+        # Loop over the length of the value array
+        # each incremental i value can be looked up in the _as array
+        # that we sorted previously, which gives us the location of
+        # that sorted value for retrieval back from the original
+        # values / masked_vals arrays
         for i in range(N):
+            # dups and sum_ranks will be incremented each loop where
+            # the value / group remains the same, and should be reset
+            # when either of those change
+            # Used to calculate tiebreakers
             dups += 1
             sum_ranks += i - grp_start + 1
 
+            # if keep_na, check for missing values and assign back
+            # to the result where appropriate
             if keep_na and masked_vals[_as[i]] == nan_fill_val:
                 grp_na_count += 1
                 out[_as[i], 0] = nan
             else:
+                # this implementation is inefficient because it will
+                # continue overwriting previously encountered dups
+                # i.e. if 5 duplicated values are encountered it will
+                # write to the result as follows (assumes avg tiebreaker):
+                # 1
+                # .5  .5
+                # .33 .33 .33
+                # .25 .25 .25 .25
+                # .2  .2  .2  .2  .2
+                #
+                # could potentially be optimized to only write to the
+                # result once the last duplicate value is encountered
                 if tiebreak == TIEBREAK_AVERAGE:
                     for j in range(i - dups + 1, i + 1):
                         out[_as[j], 0] = sum_ranks / dups
@@ -526,6 +556,11 @@ def group_rank_{{name}}(ndarray[float64_t, ndim=2] out,
                     for j in range(i - dups + 1, i + 1):
                         out[_as[j], 0] = grp_vals_seen
 
+            # look forward to the next value (using the sorting in _as)
+            # if the value does not equal the current value then we need to
+            # reset the dups and sum_ranks, knowing that a new value is coming
+            # up. the conditional also needs to handle nan equality and the
+            # end of iteration
             {{if name=='int64'}}
             if (i == N - 1 or (
                     (masked_vals[_as[i]] != masked_vals[_as[i+1]]) and not
@@ -543,7 +578,11 @@ def group_rank_{{name}}(ndarray[float64_t, ndim=2] out,
                 val_start = i
                 grp_vals_seen += 1
 
-            # Move to the next group, cleaning up any values
+            # Similar to the previous conditional, check now if we are moving to a
+            # new group. If so, keep track of the index where the new group occurs,
+            # so the tiebreaker calculations can decrement that from their position
+            # if the pct flag is True, go back and overwrite the result for
+            # the group to be divided by the size of the group (excluding na values)
             if i == N - 1 or labels[_as[i]] != labels[_as[i+1]]:
                 if pct:
                     for j in range(grp_start, i + 1):

--- a/pandas/_libs/groupby_helper.pxi.in
+++ b/pandas/_libs/groupby_helper.pxi.in
@@ -581,19 +581,9 @@ def group_rank_{{name}}(ndarray[float64_t, ndim=2] out,
             # reset the dups and sum_ranks, knowing that a new value is coming
             # up. the conditional also needs to handle nan equality and the
             # end of iteration
-            {{if name=='int64'}}
             if (i == N - 1 or (
                     (masked_vals[_as[i]] != masked_vals[_as[i+1]]) and not
-                    (masked_vals[_as[i]] == nan_fill_val and
-                     masked_vals[_as[i+1]] == nan_fill_val
-                    ))):
-            {{else}}
-            if (i == N - 1 or (
-                    (masked_vals[_as[i]] != masked_vals[_as[i+1]]) and not
-                    (npy_isnan(masked_vals[_as[i]]) and
-                     npy_isnan(masked_vals[_as[i+1]])
-                    ))):
-            {{endif}}
+                    (mask[_as[i]] and mask[_as[i+1]]))):
                 dups = sum_ranks = 0
                 val_start = i
                 grp_vals_seen += 1

--- a/pandas/_libs/groupby_helper.pxi.in
+++ b/pandas/_libs/groupby_helper.pxi.in
@@ -444,6 +444,7 @@ def group_nth_{{name}}(ndarray[{{dest_type2}}, ndim=2] out,
                 else:
                     out[i, j] = resx[i, j]
 
+
 @cython.boundscheck(False)
 @cython.wraparound(False)
 def group_rank_{{name}}(ndarray[float64_t, ndim=2] out,
@@ -458,8 +459,10 @@ def group_rank_{{name}}(ndarray[float64_t, ndim=2] out,
         Py_ssize_t i, j, N, K
         int64_t val_start=0, grp_start=0, dups=0, sum_ranks=0
         ndarray[int64_t] _as
+        bint pct
 
     tiebreak = tiebreakers[kwargs['ties_method']]
+    pct = kwargs['pct']
     N, K = (<object> values).shape
 
     _as = np.lexsort((values[:, 0], labels))
@@ -495,8 +498,11 @@ def group_rank_{{name}}(ndarray[float64_t, ndim=2] out,
                 dups = sum_ranks = 0
                 val_start = i
 
-            if i == 0 or labels[_as[i]] != labels[_as[i-1]]:
-                grp_start = i
+            if i == N - 1 or labels[_as[i]] != labels[_as[i+1]]:
+                if pct:
+                    for j in range(grp_start, i + 1):
+                        out[_as[j], 0] = out[_as[j], 0] / (i - grp_start + 1)
+                grp_start = i + 1
 
 {{endfor}}
 

--- a/pandas/_libs/groupby_helper.pxi.in
+++ b/pandas/_libs/groupby_helper.pxi.in
@@ -535,8 +535,8 @@ def group_rank_{{name}}(ndarray[float64_t, ndim=2] out,
             {{else}}
             if (i == N - 1 or (
                     (masked_vals[_as[i]] != masked_vals[_as[i+1]]) and not
-                    (isnan(masked_vals[_as[i]]) and
-                     isnan(masked_vals[_as[i+1]])
+                    (npy_isnan(masked_vals[_as[i]]) and
+                     npy_isnan(masked_vals[_as[i+1]])
                     ))):
             {{endif}}
                 dups = sum_ranks = 0

--- a/pandas/_libs/groupby_helper.pxi.in
+++ b/pandas/_libs/groupby_helper.pxi.in
@@ -458,15 +458,35 @@ def group_rank_{{name}}(ndarray[float64_t, ndim=2] out,
         int tiebreak
         Py_ssize_t i, j, N, K
         int64_t val_start=0, grp_start=0, dups=0, sum_ranks=0, vals_seen=1
+        int64_t grp_na_count=0
         ndarray[int64_t] _as
-        bint pct, ascending
+        ndarray[{{c_type}}] _values
+        ndarray[uint8_t] mask
+        bint pct, ascending, keep_na
 
     tiebreak = tiebreakers[kwargs['ties_method']]
     ascending = kwargs['ascending']
     pct = kwargs['pct']
+    keep_na = kwargs['na_option'] == 'keep'
     N, K = (<object> values).shape
 
-    _as = np.lexsort((values[:, 0], labels))
+    _values = np.array(values[:, 0], copy=True)
+
+    mask = np.isnan(_values).astype(np.uint8)
+    {{if name == 'int64' }}
+    order = (_values, labels)
+    {{else}}
+    if ascending ^ (kwargs['na_option'] == 'top'):
+        nan_value = np.inf
+        order = (_values, mask, labels)
+    else:
+        nan_value = -np.inf
+        order = (_values, ~mask, labels)
+    np.putmask(_values, mask, nan_value)
+    {{endif}}
+
+    _as = np.lexsort(order)
+
 
     if not ascending:
         _as = _as[::-1]
@@ -476,38 +496,45 @@ def group_rank_{{name}}(ndarray[float64_t, ndim=2] out,
             dups += 1
             sum_ranks += i - grp_start + 1
 
-            if tiebreak == TIEBREAK_AVERAGE:
-                for j in range(i - dups + 1, i + 1):
-                    out[_as[j], 0] = sum_ranks / dups
-            elif tiebreak == TIEBREAK_MIN:
-                for j in range(i - dups + 1, i + 1):
-                    out[_as[j], 0] = i - grp_start - dups + 2
-            elif tiebreak == TIEBREAK_MAX:
-                for j in range(i - dups + 1, i + 1):
-                    out[_as[j], 0] = i - grp_start + 1
-            elif tiebreak == TIEBREAK_FIRST:
-                for j in range(i - dups + 1, i + 1):
-                    if ascending:
-                        out[_as[j], 0] = j + 1
-                    else:
-                        out[_as[j], 0] = 2 * i - j - dups + 2
-            elif tiebreak == TIEBREAK_DENSE:
-                for j in range(i - dups + 1, i + 1):
-                    out[_as[j], 0] = vals_seen
+            if keep_na and (values[_as[i], 0] != values[_as[i], 0]):
+                grp_na_count += 1
+                out[_as[i], 0] = {{nan_val}}
+            else:
+                if tiebreak == TIEBREAK_AVERAGE:
+                    for j in range(i - dups + 1, i + 1):
+                        out[_as[j], 0] = sum_ranks / dups
+                elif tiebreak == TIEBREAK_MIN:
+                    for j in range(i - dups + 1, i + 1):
+                        out[_as[j], 0] = i - grp_start - dups + 2
+                elif tiebreak == TIEBREAK_MAX:
+                    for j in range(i - dups + 1, i + 1):
+                        out[_as[j], 0] = i - grp_start + 1
+                elif tiebreak == TIEBREAK_FIRST:
+                    for j in range(i - dups + 1, i + 1):
+                        if ascending:
+                            out[_as[j], 0] = j + 1
+                        else:
+                            out[_as[j], 0] = 2 * i - j - dups + 2
+                elif tiebreak == TIEBREAK_DENSE:
+                    for j in range(i - dups + 1, i + 1):
+                        out[_as[j], 0] = vals_seen
 
             if (i == N - 1 or (
-                    (values[_as[i], 0] != values[_as[i+1], 0]) and not
-                    (isnan(values[_as[i], 0]) and
-                     isnan(values[_as[i+1], 0])
+                    (_values[_as[i]] != _values[_as[i+1]]) and not
+                    (isnan(_values[_as[i]]) and
+                     isnan(_values[_as[i+1]])
                     ))):
                 dups = sum_ranks = 0
                 val_start = i
                 vals_seen += 1
 
+            # Move to the next group, cleaning up any values
             if i == N - 1 or labels[_as[i]] != labels[_as[i+1]]:
                 if pct:
                     for j in range(grp_start, i + 1):
-                        out[_as[j], 0] = out[_as[j], 0] / (i - grp_start + 1)
+                        out[_as[j], 0] = out[_as[j], 0] / (i - grp_start + 1
+                                                           - grp_na_count)
+                grp_na_count = 0
                 grp_start = i + 1
                 vals_seen = 1
 

--- a/pandas/_libs/groupby_helper.pxi.in
+++ b/pandas/_libs/groupby_helper.pxi.in
@@ -471,8 +471,8 @@ def group_rank_{{name}}(ndarray[float64_t, ndim=2] out,
     N, K = (<object> values).shape
 
     _values = np.array(values[:, 0], copy=True)
-
     mask = np.isnan(_values).astype(np.uint8)
+
     {{if name == 'int64' }}
     order = (_values, labels)
     {{else}}
@@ -486,7 +486,6 @@ def group_rank_{{name}}(ndarray[float64_t, ndim=2] out,
     {{endif}}
 
     _as = np.lexsort(order)
-
 
     if not ascending:
         _as = _as[::-1]

--- a/pandas/_libs/groupby_helper.pxi.in
+++ b/pandas/_libs/groupby_helper.pxi.in
@@ -457,13 +457,13 @@ def group_rank_{{name}}(ndarray[float64_t, ndim=2] out,
     cdef:
         int tiebreak
         Py_ssize_t i, j, N, K
-        int64_t val_start=0, grp_start=0, dups=0, sum_ranks=0, vals_seen=1
+        int64_t val_start=0, grp_start=0, dups=0, sum_ranks=0, grp_vals_seen=1
         int64_t grp_na_count=0
         ndarray[int64_t] _as
-        ndarray[{{c_type}}] _values
+        ndarray[{{c_type}}] masked_vals
         ndarray[uint8_t] mask
         bint pct, ascending, keep_na
-        {{c_type}} nan_value
+        {{c_type}} nan_fill_val
 
     tiebreak = tiebreakers[kwargs['ties_method']]
     ascending = kwargs['ascending']
@@ -471,28 +471,28 @@ def group_rank_{{name}}(ndarray[float64_t, ndim=2] out,
     keep_na = kwargs['na_option'] == 'keep'
     N, K = (<object> values).shape
 
-    _values = np.array(values[:, 0], copy=True)
+    masked_vals = np.array(values[:, 0], copy=True)
     {{if name=='int64'}}
-    mask = (_values == {{nan_val}}).astype(np.uint8)
+    mask = (masked_vals == {{nan_val}}).astype(np.uint8)
     {{else}}
-    mask = np.isnan(_values).astype(np.uint8)
+    mask = np.isnan(masked_vals).astype(np.uint8)
     {{endif}}
 
     if ascending ^ (kwargs['na_option'] == 'top'):
         {{if name == 'int64'}}
-        nan_value = np.iinfo(np.int64).max
+        nan_fill_val = np.iinfo(np.int64).max
         {{else}}
-        nan_value = np.inf
+        nan_fill_val = np.inf
         {{endif}}
-        order = (_values, mask, labels)
+        order = (masked_vals, mask, labels)
     else:
         {{if name == 'int64'}}
-        nan_value = np.iinfo(np.int64).min
+        nan_fill_val = np.iinfo(np.int64).min
         {{else}}
-        nan_value = -np.inf
+        nan_fill_val = -np.inf
         {{endif}}
-        order = (_values, ~mask, labels)
-    np.putmask(_values, mask, nan_value)
+        order = (masked_vals, ~mask, labels)
+    np.putmask(masked_vals, mask, nan_fill_val)
 
     _as = np.lexsort(order)
 
@@ -504,7 +504,7 @@ def group_rank_{{name}}(ndarray[float64_t, ndim=2] out,
             dups += 1
             sum_ranks += i - grp_start + 1
 
-            if keep_na and _values[_as[i]] == nan_value:
+            if keep_na and masked_vals[_as[i]] == nan_fill_val:
                 grp_na_count += 1
                 out[_as[i], 0] = nan
             else:
@@ -525,24 +525,24 @@ def group_rank_{{name}}(ndarray[float64_t, ndim=2] out,
                             out[_as[j], 0] = 2 * i - j - dups + 2 - grp_start
                 elif tiebreak == TIEBREAK_DENSE:
                     for j in range(i - dups + 1, i + 1):
-                        out[_as[j], 0] = vals_seen
+                        out[_as[j], 0] = grp_vals_seen
 
             {{if name=='int64'}}
             if (i == N - 1 or (
-                    (_values[_as[i]] != _values[_as[i+1]]) and not
-                    (_values[_as[i]] == nan_value and
-                     _values[_as[i+1]] == nan_value
+                    (masked_vals[_as[i]] != masked_vals[_as[i+1]]) and not
+                    (masked_vals[_as[i]] == nan_fill_val and
+                     masked_vals[_as[i+1]] == nan_fill_val
                     ))):
             {{else}}
             if (i == N - 1 or (
-                    (_values[_as[i]] != _values[_as[i+1]]) and not
-                    (isnan(_values[_as[i]]) and
-                     isnan(_values[_as[i+1]])
+                    (masked_vals[_as[i]] != masked_vals[_as[i+1]]) and not
+                    (isnan(masked_vals[_as[i]]) and
+                     isnan(masked_vals[_as[i+1]])
                     ))):
             {{endif}}
                 dups = sum_ranks = 0
                 val_start = i
-                vals_seen += 1
+                grp_vals_seen += 1
 
             # Move to the next group, cleaning up any values
             if i == N - 1 or labels[_as[i]] != labels[_as[i+1]]:
@@ -552,7 +552,7 @@ def group_rank_{{name}}(ndarray[float64_t, ndim=2] out,
                                                            - grp_na_count)
                 grp_na_count = 0
                 grp_start = i + 1
-                vals_seen = 1
+                grp_vals_seen = 1
 
 {{endfor}}
 

--- a/pandas/core/groupby.py
+++ b/pandas/core/groupby.py
@@ -2172,15 +2172,6 @@ class BaseGrouper(object):
     # ------------------------------------------------------------
     # Aggregation functions
 
-    def _group_rank_wrapper(func, *args, **kwargs):
-        # Need to explicity unpack *args to support Py < 3.5
-        # See PEP 448
-        return func(args[0], args[1], args[2], args[3],
-                    kwargs.get('ties_method', 'average'),
-                    kwargs.get('ascending', True),
-                    kwargs.get('pct', False),
-                    kwargs.get('na_option', 'keep'))
-
     _cython_functions = {
         'aggregate': {
             'add': 'group_add',
@@ -2207,7 +2198,12 @@ class BaseGrouper(object):
             'cummax': 'group_cummax',
             'rank': {
                 'name': 'group_rank',
-                'f': _group_rank_wrapper
+                'f': lambda func, a, b, c, d, **kwargs: func(a, b, c, d,
+                        kwargs.get('ties_method', 'average'),
+                        kwargs.get('ascending', True),
+                        kwargs.get('pct', False),
+                        kwargs.get('na_option', 'keep')
+                )
             }
         }
     }

--- a/pandas/core/groupby.py
+++ b/pandas/core/groupby.py
@@ -1776,7 +1776,29 @@ class GroupBy(_GroupBy):
     @Appender(_doc_template)
     def rank(self, method='average', ascending=True, na_option='keep',
              pct=False, axis=0):
-        """Rank within each group"""
+        """Provides the rank of values within each group
+
+        Parameters
+        ----------
+        method : {'average', 'min', 'max', 'first', 'dense'}, efault 'average'
+            * average: average rank of group
+            * min: lowest rank in group
+            * max: highest rank in group
+            * first: ranks assigned in order they appear in the array
+            * dense: like 'min', but rank always increases by 1 between groups
+        method :  {'keep', 'top', 'bottom'}, default 'keep'
+            * keep: leave NA values where they are
+            * top: smallest rank if ascending
+            * bottom: smallest rank if descending
+        ascending : boolean, default True
+            False for ranks by high (1) to low (N)
+        pct : boolean, default False
+            Compute percentage rank of data within each group
+
+        Returns
+        -----
+        DataFrame with ranking of values within each group
+        """
         return self._cython_transform('rank', numeric_only=False,
                                       ties_method=method, ascending=ascending,
                                       na_option=na_option, pct=pct, axis=axis)
@@ -2198,11 +2220,12 @@ class BaseGrouper(object):
             'cummax': 'group_cummax',
             'rank': {
                 'name': 'group_rank',
-                'f': lambda func, a, b, c, d, **kwargs: func(a, b, c, d,
-                        kwargs.get('ties_method', 'average'),
-                        kwargs.get('ascending', True),
-                        kwargs.get('pct', False),
-                        kwargs.get('na_option', 'keep')
+                'f': lambda func, a, b, c, d, **kwargs: func(
+                    a, b, c, d,
+                    kwargs.get('ties_method', 'average'),
+                    kwargs.get('ascending', True),
+                    kwargs.get('pct', False),
+                    kwargs.get('na_option', 'keep')
                 )
             }
         }

--- a/pandas/core/groupby.py
+++ b/pandas/core/groupby.py
@@ -2173,7 +2173,10 @@ class BaseGrouper(object):
     # Aggregation functions
 
     def _group_rank_wrapper(func, *args, **kwargs):
-        return func(*args, kwargs.get('ties_method', 'average'),
+        # Need to explicity unpack *args to support Py < 3.5
+        # See PEP 448
+        return func(args[0], args[1], args[2], args[3],
+                    kwargs.get('ties_method', 'average'),
                     kwargs.get('ascending', True),
                     kwargs.get('pct', False),
                     kwargs.get('na_option', 'keep'))

--- a/pandas/core/groupby.py
+++ b/pandas/core/groupby.py
@@ -2171,6 +2171,12 @@ class BaseGrouper(object):
     # ------------------------------------------------------------
     # Aggregation functions
 
+    def _group_rank_wrapper(func, *args, **kwargs):
+        return func(*args, kwargs.get('ties_method', 'average'),
+                    kwargs.get('ascending', True),
+                    kwargs.get('pct', False),
+                    kwargs.get('na_option', 'keep'))
+
     _cython_functions = {
         'aggregate': {
             'add': 'group_add',
@@ -2195,7 +2201,10 @@ class BaseGrouper(object):
             'cumsum': 'group_cumsum',
             'cummin': 'group_cummin',
             'cummax': 'group_cummax',
-            'rank': 'group_rank',
+            'rank': {
+                'name': 'group_rank',
+                'f': _group_rank_wrapper
+            }
         }
     }
 
@@ -2424,7 +2433,7 @@ class BaseGrouper(object):
 
                 chunk = chunk.squeeze()
                 transform_func(result[:, :, i], values,
-                               comp_ids, is_datetimelike)
+                               comp_ids, is_datetimelike, **kwargs)
         else:
             transform_func(result, values, comp_ids, is_datetimelike, **kwargs)
 

--- a/pandas/core/groupby.py
+++ b/pandas/core/groupby.py
@@ -1776,7 +1776,7 @@ class GroupBy(_GroupBy):
     def rank(self, method='average', ascending=True, na_option='keep',
              pct=False, axis=0):
         """Rank within each group"""
-        return self._cython_transform('rank', ties_method=method,
+        return self._cython_transform('rank', numeric_only=False, ties_method=method,
                                       ascending=ascending, na_option=na_option,
                                       pct=pct, axis=axis)
 

--- a/pandas/core/groupby.py
+++ b/pandas/core/groupby.py
@@ -1002,7 +1002,8 @@ b  2""")
                 continue
 
             try:
-                result, names = self.grouper.transform(obj.values, how, **kwargs)
+                result, names = self.grouper.transform(obj.values, how,
+                                                       **kwargs)
             except NotImplementedError:
                 continue
             except AssertionError as e:
@@ -1776,9 +1777,9 @@ class GroupBy(_GroupBy):
     def rank(self, method='average', ascending=True, na_option='keep',
              pct=False, axis=0):
         """Rank within each group"""
-        return self._cython_transform('rank', numeric_only=False, ties_method=method,
-                                      ascending=ascending, na_option=na_option,
-                                      pct=pct, axis=axis)
+        return self._cython_transform('rank', numeric_only=False,
+                                      ties_method=method, ascending=ascending,
+                                      na_option=na_option, pct=pct, axis=axis)
 
     @Substitution(name='groupby')
     @Appender(_doc_template)

--- a/pandas/core/groupby.py
+++ b/pandas/core/groupby.py
@@ -1770,6 +1770,12 @@ class GroupBy(_GroupBy):
 
     @Substitution(name='groupby')
     @Appender(_doc_template)
+    def rank(self, axis=0, *args, **kwargs):
+        """Rank within each group"""
+        return self._cython_transform('rank', **kwargs)
+
+    @Substitution(name='groupby')
+    @Appender(_doc_template)
     def cumprod(self, axis=0, *args, **kwargs):
         """Cumulative product for each group"""
         nv.validate_groupby_func('cumprod', args, kwargs, ['numeric_only'])
@@ -2183,6 +2189,7 @@ class BaseGrouper(object):
             'cumsum': 'group_cumsum',
             'cummin': 'group_cummin',
             'cummax': 'group_cummax',
+            'rank': 'group_rank',
         }
     }
 

--- a/pandas/core/groupby.py
+++ b/pandas/core/groupby.py
@@ -1770,10 +1770,10 @@ class GroupBy(_GroupBy):
 
     @Substitution(name='groupby')
     @Appender(_doc_template)
-    def rank(self, ties_method='average', ascending=True, na_option='keep',
+    def rank(self, method='average', ascending=True, na_option='keep',
              pct=False, axis=0):
         """Rank within each group"""
-        return self._cython_transform('rank', ties_method=ties_method,
+        return self._cython_transform('rank', ties_method=method,
                                       ascending=ascending, na_option=na_option,
                                       pct=pct, axis=axis)
 

--- a/pandas/core/groupby.py
+++ b/pandas/core/groupby.py
@@ -1007,7 +1007,10 @@ b  2""")
                 continue
             except AssertionError as e:
                 raise GroupByError(str(e))
-            output[name] = self._try_cast(result, obj)
+            if self._transform_should_cast(how):
+                output[name] = self._try_cast(result, obj)
+            else:
+                output[name] = result
 
         if len(output) == 0:
             raise DataError('No numeric types to aggregate')
@@ -2325,10 +2328,13 @@ class BaseGrouper(object):
             else:
                 raise
 
-        if is_numeric:
-            out_dtype = '%s%d' % (values.dtype.kind, values.dtype.itemsize)
+        if how == 'rank':
+            out_dtype = 'float'
         else:
-            out_dtype = 'object'
+            if is_numeric:
+                out_dtype = '%s%d' % (values.dtype.kind, values.dtype.itemsize)
+            else:
+                out_dtype = 'object'
 
         labels, _, _ = self.group_info
 

--- a/pandas/tests/groupby/test_groupby.py
+++ b/pandas/tests/groupby/test_groupby.py
@@ -1952,7 +1952,7 @@ class TestGroupBy(MixIn):
 
     @pytest.mark.parametrize("vals", [
         [2, 2, np.nan, 8, 2, 6, np.nan, np.nan],  # floats
-        #['bar', 'bar', np.nan, 'foo', 'bar', 'baz', np.nan, np.nan],  # objects
+        ['bar', 'bar', np.nan, 'foo', 'bar', 'baz', np.nan, np.nan],  # objects
         #[pd.Timestamp('2018-01-02'), pd.Timestamp('2018-01-02'), np.nan,
         # pd.Timestamp('2018-01-08'), pd.Timestamp('2018-01-02'),
         # pd.Timestamp('2018-01-06'), np.nan, np.nan]

--- a/pandas/tests/groupby/test_groupby.py
+++ b/pandas/tests/groupby/test_groupby.py
@@ -1895,61 +1895,49 @@ class TestGroupBy(MixIn):
         expected = expected.reindex(result.index)
         assert_series_equal(result, expected)
 
+    @pytest.mark.parametrize("grps", [
+        ['qux'], ['qux', 'quux']])
     @pytest.mark.parametrize("vals", [
         [2, 2, 8, 2, 6], ['bar', 'bar', 'foo', 'bar', 'baz'],
         [pd.Timestamp('2018-01-02'), pd.Timestamp('2018-01-02'),
          pd.Timestamp('2018-01-08'), pd.Timestamp('2018-01-02'),
          pd.Timestamp('2018-01-06')]])
     @pytest.mark.parametrize("ties_method,ascending,pct,exp", [
-        ('average', True, False, DataFrame(
-            [2., 2., 5., 2., 4.], columns=['val'])),
-        ('average', True, True, DataFrame(
-            [0.4, 0.4, 1.0, 0.4, 0.8], columns=['val'])),
-        ('average', False, False, DataFrame(
-            [4., 4., 1., 4., 2.], columns=['val'])),
-        ('average', False, True, DataFrame(
-            [.8, .8, .2, .8, .4], columns=['val'])),
-        ('min', True, False, DataFrame(
-            [1., 1., 5., 1., 4.], columns=['val'])),
-        ('min', True, True, DataFrame(
-            [0.2, 0.2, 1.0, 0.2, 0.8], columns=['val'])),
-        ('min', False, False, DataFrame(
-            [3., 3., 1., 3., 2.], columns=['val'])),
-        ('min', False, True, DataFrame(
-            [.6, .6, .2, .6, .4], columns=['val'])),
-        ('max', True, False, DataFrame(
-            [3., 3., 5., 3., 4.], columns=['val'])),
-        ('max', True, True, DataFrame(
-            [0.6, 0.6, 1.0, 0.6, 0.8], columns=['val'])),
-        ('max', False, False, DataFrame(
-            [5., 5., 1., 5., 2.], columns=['val'])),
-        ('max', False, True, DataFrame(
-            [1., 1., .2, 1., .4], columns=['val'])),
-        ('first', True, False, DataFrame(
-            [1., 2., 5., 3., 4.], columns=['val'])),
-        ('first', True, True, DataFrame(
-            [0.2, 0.4, 1.0, 0.6, 0.8], columns=['val'])),
-        ('first', False, False, DataFrame(
-            [3., 4., 1., 5., 2.], columns=['val'])),
-        ('first', False, True, DataFrame(
-            [.6, .8, .2, 1., .4], columns=['val'])),
-        ('dense', True, False, DataFrame(
-            [1., 1., 3., 1., 2.], columns=['val'])),
-        ('dense', True, True, DataFrame(
-            [0.2, 0.2, 0.6, 0.2, 0.4], columns=['val'])),
-        ('dense', False, False, DataFrame(
-            [3., 3., 1., 3., 2.], columns=['val'])),
-        ('dense', False, True, DataFrame(
-            [.6, .6, .2, .6, .4], columns=['val'])),
+        ('average', True, False, [2., 2., 5., 2., 4.]),
+        ('average', True, True, [0.4, 0.4, 1.0, 0.4, 0.8]),
+        ('average', False, False, [4., 4., 1., 4., 2.]),
+        ('average', False, True, [.8, .8, .2, .8, .4]),
+        ('min', True, False, [1., 1., 5., 1., 4.]),
+        ('min', True, True, [0.2, 0.2, 1.0, 0.2, 0.8]),
+        ('min', False, False, [3., 3., 1., 3., 2.]),
+        ('min', False, True, [.6, .6, .2, .6, .4]),
+        ('max', True, False, [3., 3., 5., 3., 4.]),
+        ('max', True, True, [0.6, 0.6, 1.0, 0.6, 0.8]),
+        ('max', False, False, [5., 5., 1., 5., 2.]),
+        ('max', False, True, [1., 1., .2, 1., .4]),
+        ('first', True, False, [1., 2., 5., 3., 4.]),
+        ('first', True, True, [0.2, 0.4, 1.0, 0.6, 0.8]),
+        ('first', False, False, [3., 4., 1., 5., 2.]),
+        ('first', False, True, [.6, .8, .2, 1., .4]),
+        ('dense', True, False, [1., 1., 3., 1., 2.]),
+        ('dense', True, True, [0.2, 0.2, 0.6, 0.2, 0.4]),
+        ('dense', False, False, [3., 3., 1., 3., 2.]),
+        ('dense', False, True, [.6, .6, .2, .6, .4]),
     ])
-    def test_rank_args(self, vals, ties_method, ascending, pct, exp):
+    def test_rank_args(self, grps, vals, ties_method, ascending, pct, exp):
         if ties_method == 'first' and vals[0] == 'bar':
             pytest.xfail("See GH 19482")
-        df = DataFrame({'key': ['foo']*5, 'val': vals})
+        key = np.repeat(grps, len(vals))
+        vals = vals * len(grps)
+        df = DataFrame({'key': key, 'val': vals})
         result = df.groupby('key').rank(method=ties_method, ascending=ascending,
                                         pct=pct)
-        assert_frame_equal(result, exp)
 
+        exp_df = DataFrame(exp * len(grps), columns=['val'])
+        assert_frame_equal(result, exp_df)
+
+    @pytest.mark.parametrize("grps", [
+        ['qux'], ['qux', 'quux']])
     @pytest.mark.parametrize("vals", [
         [2, 2, np.nan, 8, 2, 6, np.nan, np.nan],  # floats
         ['bar', 'bar', np.nan, 'foo', 'bar', 'baz', np.nan, np.nan],  # objects
@@ -1958,110 +1946,89 @@ class TestGroupBy(MixIn):
          pd.Timestamp('2018-01-06'), np.nan, np.nan]
     ])
     @pytest.mark.parametrize("ties_method,ascending,na_option,pct,exp", [
-        ('average', True, 'keep', False, DataFrame(
-            [2., 2., np.nan, 5., 2., 4., np.nan, np.nan], columns=['val'])),
-        ('average', True, 'keep', True, DataFrame(
-            [0.4, 0.4, np.nan, 1.0, 0.4, 0.8, np.nan, np.nan],
-            columns=['val'])),
-        ('average', False, 'keep', False, DataFrame(
-            [4., 4., np.nan, 1., 4., 2., np.nan, np.nan], columns=['val'])),
-        ('average', False, 'keep', True, DataFrame(
-            [.8, 0.8, np.nan, 0.2, 0.8, 0.4, np.nan, np.nan], columns=['val'])),
-        ('min', True, 'keep', False, DataFrame(
-            [1., 1., np.nan, 5., 1., 4., np.nan, np.nan], columns=['val'])),
-        ('min', True, 'keep', True, DataFrame(
-            [0.2, 0.2, np.nan, 1.0, 0.2, 0.8, np.nan, np.nan],
-            columns=['val'])),
-        ('min', False, 'keep', False, DataFrame(
-            [3., 3., np.nan, 1., 3., 2., np.nan, np.nan], columns=['val'])),
-        ('min', False, 'keep', True, DataFrame(
-            [.6, 0.6, np.nan, 0.2, 0.6, 0.4, np.nan, np.nan], columns=['val'])),
-        ('max', True, 'keep', False, DataFrame(
-            [3., 3., np.nan, 5., 3., 4., np.nan, np.nan], columns=['val'])),
-        ('max', True, 'keep', True, DataFrame(
-            [0.6, 0.6, np.nan, 1.0, 0.6, 0.8, np.nan, np.nan],
-            columns=['val'])),
-        ('max', False, 'keep', False, DataFrame(
-            [5., 5., np.nan, 1., 5., 2., np.nan, np.nan], columns=['val'])),
-        ('max', False, 'keep', True, DataFrame(
-            [1., 1., np.nan, 0.2, 1., 0.4, np.nan, np.nan], columns=['val'])),
-        ('first', True, 'keep', False, DataFrame(
-            [1., 2., np.nan, 5., 3., 4., np.nan, np.nan], columns=['val'])),
-        ('first', True, 'keep', True, DataFrame(
-            [0.2, 0.4, np.nan, 1.0, 0.6, 0.8, np.nan, np.nan],
-            columns=['val'])),
-        ('first', False, 'keep', False, DataFrame(
-            [3., 4., np.nan, 1., 5., 2., np.nan, np.nan], columns=['val'])),
-        ('first', False, 'keep', True, DataFrame(
-            [.6, 0.8, np.nan, 0.2, 1., 0.4, np.nan, np.nan], columns=['val'])),
-        ('dense', True, 'keep', False, DataFrame(
-            [1., 1., np.nan, 3., 1., 2., np.nan, np.nan], columns=['val'])),
-        ('dense', True, 'keep', True, DataFrame(
-            [0.2, 0.2, np.nan, 0.6, 0.2, 0.4, np.nan, np.nan],
-            columns=['val'])),
-        ('dense', False, 'keep', False, DataFrame(
-            [3., 3., np.nan, 1., 3., 2., np.nan, np.nan], columns=['val'])),
-        ('dense', False, 'keep', True, DataFrame(
-            [.6, 0.6, np.nan, 0.2, 0.6, 0.4, np.nan, np.nan], columns=['val'])),
-        ('average', True, 'no_na', False, DataFrame(
-            [2., 2., 7., 5., 2., 4., 7., 7.], columns=['val'])),
-        ('average', True, 'no_na', True, DataFrame(
-            [0.25, 0.25, 0.875, 0.625, 0.25, 0.5, 0.875, 0.875],
-            columns=['val'])),
-        ('average', False, 'no_na', False, DataFrame(
-            [4., 4., 7.0, 1., 4., 2., 7.0, 7.0], columns=['val'])),
-        ('average', False, 'no_na', True, DataFrame(
-            [0.5, 0.5, 0.875, 0.125, 0.5, 0.25, 0.875, 0.875],
-            columns=['val'])),
-        ('min', True, 'no_na', False, DataFrame(
-            [1., 1., 6., 5., 1., 4., 6., 6.], columns=['val'])),
-        ('min', True, 'no_na', True, DataFrame(
-            [0.125, 0.125, 0.75, 0.625, 0.125, 0.5, 0.75, 0.75],
-            columns=['val'])),
-        ('min', False, 'no_na', False, DataFrame(
-            [3., 3., 6., 1., 3., 2., 6., 6.], columns=['val'])),
-        ('min', False, 'no_na', True, DataFrame(
-            [0.375, 0.375, 0.75, 0.125, 0.375, 0.25, 0.75, 0.75],
-            columns=['val'])),
-        ('max', True, 'no_na', False, DataFrame(
-            [3., 3., 8., 5., 3., 4., 8., 8.], columns=['val'])),
-        ('max', True, 'no_na', True, DataFrame(
-            [0.375, 0.375, 1., 0.625, 0.375, 0.5, 1., 1.], columns=['val'])),
-        ('max', False, 'no_na', False, DataFrame(
-            [5., 5., 8., 1., 5., 2., 8., 8.], columns=['val'])),
-        ('max', False, 'no_na', True, DataFrame(
-            [0.625, 0.625, 1., 0.125, 0.625, 0.25, 1., 1.], columns=['val'])),
-        ('first', True, 'no_na', False, DataFrame(
-            [1., 2., 6., 5., 3., 4., 7., 8.], columns=['val'])),
-        ('first', True, 'no_na', True, DataFrame(
-            [0.125, 0.25, 0.75, 0.625, 0.375, 0.5, 0.875, 1.],
-            columns=['val'])),
-        ('first', False, 'no_na', False, DataFrame(
-            [3., 4., 6., 1., 5., 2., 7., 8.], columns=['val'])),
-        ('first', False, 'no_na', True, DataFrame(
-            [0.375, 0.5, 0.75, 0.125, 0.625, 0.25, 0.875, 1.],
-            columns=['val'])),
-        ('dense', True, 'no_na', False, DataFrame(
-            [1., 1., 4., 3., 1., 2., 4., 4.], columns=['val'])),
-        ('dense', True, 'no_na', True, DataFrame(
-            [0.125, 0.125, 0.5, 0.375, 0.125, 0.25, 0.5, 0.5],
-            columns=['val'])),
-        ('dense', False, 'no_na', False, DataFrame(
-            [3., 3., 4., 1., 3., 2., 4., 4.], columns=['val'])),
-        ('dense', False, 'no_na', True, DataFrame(
-            [0.375, 0.375, 0.5, 0.125, 0.375, 0.25, 0.5, 0.5],
-            columns=['val'])),
+        ('average', True, 'keep', False,
+            [2., 2., np.nan, 5., 2., 4., np.nan, np.nan]),
+        ('average', True, 'keep', True,
+            [0.4, 0.4, np.nan, 1.0, 0.4, 0.8, np.nan, np.nan]),
+        ('average', False, 'keep', False,
+            [4., 4., np.nan, 1., 4., 2., np.nan, np.nan]),
+        ('average', False, 'keep', True,
+            [.8, 0.8, np.nan, 0.2, 0.8, 0.4, np.nan, np.nan]),
+        ('min', True, 'keep', False,
+            [1., 1., np.nan, 5., 1., 4., np.nan, np.nan]),
+        ('min', True, 'keep', True,
+            [0.2, 0.2, np.nan, 1.0, 0.2, 0.8, np.nan, np.nan]),
+        ('min', False, 'keep', False,
+            [3., 3., np.nan, 1., 3., 2., np.nan, np.nan]),
+        ('min', False, 'keep', True,
+            [.6, 0.6, np.nan, 0.2, 0.6, 0.4, np.nan, np.nan]),
+        ('max', True, 'keep', False,
+            [3., 3., np.nan, 5., 3., 4., np.nan, np.nan]),
+        ('max', True, 'keep', True,
+            [0.6, 0.6, np.nan, 1.0, 0.6, 0.8, np.nan, np.nan]),
+        ('max', False, 'keep', False,
+            [5., 5., np.nan, 1., 5., 2., np.nan, np.nan]),
+        ('max', False, 'keep', True,
+            [1., 1., np.nan, 0.2, 1., 0.4, np.nan, np.nan]),
+        ('first', True, 'keep', False,
+            [1., 2., np.nan, 5., 3., 4., np.nan, np.nan]),
+        ('first', True, 'keep', True,
+            [0.2, 0.4, np.nan, 1.0, 0.6, 0.8, np.nan, np.nan]),
+        ('first', False, 'keep', False,
+            [3., 4., np.nan, 1., 5., 2., np.nan, np.nan]),
+        ('first', False, 'keep', True,
+            [.6, 0.8, np.nan, 0.2, 1., 0.4, np.nan, np.nan]),
+        ('dense', True, 'keep', False,
+            [1., 1., np.nan, 3., 1., 2., np.nan, np.nan]),
+        ('dense', True, 'keep', True,
+            [0.2, 0.2, np.nan, 0.6, 0.2, 0.4, np.nan, np.nan]),
+        ('dense', False, 'keep', False,
+            [3., 3., np.nan, 1., 3., 2., np.nan, np.nan]),
+        ('dense', False, 'keep', True,
+            [.6, 0.6, np.nan, 0.2, 0.6, 0.4, np.nan, np.nan]),
+        ('average', True, 'no_na', False, [2., 2., 7., 5., 2., 4., 7., 7.]),
+        ('average', True, 'no_na', True,
+            [0.25, 0.25, 0.875, 0.625, 0.25, 0.5, 0.875, 0.875]),
+        ('average', False, 'no_na', False, [4., 4., 7., 1., 4., 2., 7., 7.]),
+        ('average', False, 'no_na', True,
+            [0.5, 0.5, 0.875, 0.125, 0.5, 0.25, 0.875, 0.875]),
+        ('min', True, 'no_na', False, [1., 1., 6., 5., 1., 4., 6., 6.]),
+        ('min', True, 'no_na', True,
+            [0.125, 0.125, 0.75, 0.625, 0.125, 0.5, 0.75, 0.75]),
+        ('min', False, 'no_na', False, [3., 3., 6., 1., 3., 2., 6., 6.]),
+        ('min', False, 'no_na', True,
+            [0.375, 0.375, 0.75, 0.125, 0.375, 0.25, 0.75, 0.75]),
+        ('max', True, 'no_na', False, [3., 3., 8., 5., 3., 4., 8., 8.]),
+        ('max', True, 'no_na', True,
+            [0.375, 0.375, 1., 0.625, 0.375, 0.5, 1., 1.]),
+        ('max', False, 'no_na', False, [5., 5., 8., 1., 5., 2., 8., 8.]),
+        ('max', False, 'no_na', True,
+            [0.625, 0.625, 1., 0.125, 0.625, 0.25, 1., 1.]),
+        ('first', True, 'no_na', False, [1., 2., 6., 5., 3., 4., 7., 8.]),
+        ('first', True, 'no_na', True,
+            [0.125, 0.25, 0.75, 0.625, 0.375, 0.5, 0.875, 1.]),
+        ('first', False, 'no_na', False, [3., 4., 6., 1., 5., 2., 7., 8.]),
+        ('first', False, 'no_na', True,
+            [0.375, 0.5, 0.75, 0.125, 0.625, 0.25, 0.875, 1.]),
+        ('dense', True, 'no_na', False, [1., 1., 4., 3., 1., 2., 4., 4.]),
+        ('dense', True, 'no_na', True,
+            [0.125, 0.125, 0.5, 0.375, 0.125, 0.25, 0.5, 0.5]),
+        ('dense', False, 'no_na', False, [3., 3., 4., 1., 3., 2., 4., 4.]),
+        ('dense', False, 'no_na', True,
+            [0.375, 0.375, 0.5, 0.125, 0.375, 0.25, 0.5, 0.5])
     ])
-    def test_rank_args_missing(self, vals, ties_method, ascending, na_option,
-                               pct, exp):
+    def test_rank_args_missing(self, grps, vals, ties_method, ascending,
+                               na_option, pct, exp):
         if ties_method == 'first' and vals[0] == 'bar':
             pytest.xfail("See GH 19482")
-
-        df = DataFrame({'key': ['foo']*8, 'val': vals})
+        key = np.repeat(grps, len(vals))
+        vals = vals * len(grps)
+        df = DataFrame({'key': key, 'val': vals})
         result = df.groupby('key').rank(method=ties_method, ascending=ascending,
                                         na_option=na_option, pct=pct)
 
-        assert_frame_equal(result, exp)
+        exp_df = DataFrame(exp * len(grps), columns=['val'])
+        assert_frame_equal(result, exp_df)
 
     def test_dont_clobber_name_column(self):
         df = DataFrame({'key': ['a', 'a', 'a', 'b', 'b', 'b'],

--- a/pandas/tests/groupby/test_groupby.py
+++ b/pandas/tests/groupby/test_groupby.py
@@ -1953,9 +1953,9 @@ class TestGroupBy(MixIn):
     @pytest.mark.parametrize("vals", [
         [2, 2, np.nan, 8, 2, 6, np.nan, np.nan],  # floats
         ['bar', 'bar', np.nan, 'foo', 'bar', 'baz', np.nan, np.nan],  # objects
-        #[pd.Timestamp('2018-01-02'), pd.Timestamp('2018-01-02'), np.nan,
-        # pd.Timestamp('2018-01-08'), pd.Timestamp('2018-01-02'),
-        # pd.Timestamp('2018-01-06'), np.nan, np.nan]
+        [pd.Timestamp('2018-01-02'), pd.Timestamp('2018-01-02'), np.nan,
+         pd.Timestamp('2018-01-08'), pd.Timestamp('2018-01-02'),
+         pd.Timestamp('2018-01-06'), np.nan, np.nan]
     ])
     @pytest.mark.parametrize("ties_method,ascending,na_option,pct,exp", [
         ('average', True, 'keep', False, DataFrame(

--- a/pandas/tests/groupby/test_groupby.py
+++ b/pandas/tests/groupby/test_groupby.py
@@ -1945,7 +1945,6 @@ class TestGroupBy(MixIn):
         df = DataFrame({'key': ['foo']*5, 'val': vals})
         result = df.groupby('key').rank(method=ties_method, ascending=ascending,
                                         pct=pct)
-
         assert_frame_equal(result, exp)
 
     @pytest.mark.parametrize("vals", [

--- a/pandas/tests/groupby/test_groupby.py
+++ b/pandas/tests/groupby/test_groupby.py
@@ -1896,7 +1896,10 @@ class TestGroupBy(MixIn):
         assert_series_equal(result, expected)
 
     @pytest.mark.parametrize("vals", [
-        [2, 2, 8, 2, 6], ['bar', 'bar', 'foo', 'bar', 'baz']])
+        [2, 2, 8, 2, 6], ['bar', 'bar', 'foo', 'bar', 'baz'],
+        [pd.Timestamp('2018-01-02'), pd.Timestamp('2018-01-02'),
+         pd.Timestamp('2018-01-08'), pd.Timestamp('2018-01-02'),
+         pd.Timestamp('2018-01-06')]])
     @pytest.mark.parametrize("ties_method,ascending,pct,exp", [
         ('average', True, False, DataFrame(
             [2., 2., 5., 2., 4.], columns=['val'])),
@@ -1949,8 +1952,10 @@ class TestGroupBy(MixIn):
 
     @pytest.mark.parametrize("vals", [
         [2, 2, np.nan, 8, 2, 6, np.nan, np.nan],  # floats
-        ['bar', 'bar', np.nan, 'foo', 'bar', 'baz', np.nan, np.nan]  # objects
-    ])
+        ['bar', 'bar', np.nan, 'foo', 'bar', 'baz', np.nan, np.nan],  # objects
+        [pd.Timestamp('2018-01-02'), pd.Timestamp('2018-01-02'), np.nan,
+         pd.Timestamp('2018-01-08'), pd.Timestamp('2018-01-02'),
+         pd.Timestamp('2018-01-06'), np.nan, np.nan]])
     @pytest.mark.parametrize("ties_method,ascending,na_option,pct,exp", [
         ('average', True, 'keep', False, DataFrame(
             [2., 2., np.nan, 5., 2., 4., np.nan, np.nan], columns=['val'])),
@@ -2005,7 +2010,8 @@ class TestGroupBy(MixIn):
         ('average', False, 'no_na', False, DataFrame(
             [4., 4., 7.0, 1., 4., 2., 7.0, 7.0], columns=['val'])),
         ('average', False, 'no_na', True, DataFrame(
-            [0.5, 0.5, 0.875, 0.125, 0.5, 0.25, 0.875, 0.875], columns=['val'])),
+            [0.5, 0.5, 0.875, 0.125, 0.5, 0.25, 0.875, 0.875],
+            columns=['val'])),
         ('min', True, 'no_na', False, DataFrame(
             [1., 1., 6., 5., 1., 4., 6., 6.], columns=['val'])),
         ('min', True, 'no_na', True, DataFrame(

--- a/pandas/tests/groupby/test_groupby.py
+++ b/pandas/tests/groupby/test_groupby.py
@@ -2026,6 +2026,24 @@ class TestGroupBy(MixIn):
         exp_df = DataFrame(exp * len(grps), columns=['val'])
         assert_frame_equal(result, exp_df)
 
+    @pytest.mark.parametrize("pct,exp", [
+        (False, [3., 3., 3., 3., 3.]),
+        (True, [.6, .6, .6, .6, .6])])
+    def test_rank_resets_each_group(self, pct, exp):
+        df = DataFrame(
+            {'key': ['a', 'a', 'a', 'a', 'a', 'b', 'b', 'b', 'b', 'b'],
+             'val': [1] * 10}
+        )
+        result = df.groupby('key').rank(pct=pct)
+        exp_df = DataFrame(exp * 2, columns=['val'])
+        assert_frame_equal(result, exp_df)
+
+    def test_rank_avg_even_vals(self):
+        df = DataFrame({'key': ['a'] * 4, 'val': [1] * 4})
+        result = df.groupby('key').rank()
+        exp_df = DataFrame([2.5, 2.5, 2.5, 2.5], columns=['val'])
+        assert_frame_equal(result, exp_df)
+
     @pytest.mark.parametrize("ties_method", [
         'average', 'min', 'max', 'first', 'dense'])
     @pytest.mark.parametrize("ascending", [True, False])

--- a/pandas/tests/groupby/test_groupby.py
+++ b/pandas/tests/groupby/test_groupby.py
@@ -1895,6 +1895,168 @@ class TestGroupBy(MixIn):
         expected = expected.reindex(result.index)
         assert_series_equal(result, expected)
 
+    @pytest.mark.parametrize("vals", [
+        [2, 2, 8, 2, 6], ['bar', 'bar', 'foo', 'bar', 'baz']])
+    @pytest.mark.parametrize("ties_method,ascending,pct,exp", [
+        ('average', True, False, DataFrame(
+            [2., 2., 5., 2., 4.], columns=['val'])),
+        ('average', True, True, DataFrame(
+            [0.4, 0.4, 1.0, 0.4, 0.8], columns=['val'])),
+        ('average', False, False, DataFrame(
+            [4., 4., 1., 4., 2.], columns=['val'])),
+        ('average', False, True, DataFrame(
+            [.8, .8, .2, .8, .4], columns=['val'])),
+        ('min', True, False, DataFrame(
+            [1., 1., 5., 1., 4.], columns=['val'])),
+        ('min', True, True, DataFrame(
+            [0.2, 0.2, 1.0, 0.2, 0.8], columns=['val'])),
+        ('min', False, False, DataFrame(
+            [3., 3., 1., 3., 2.], columns=['val'])),
+        ('min', False, True, DataFrame(
+            [.6, .6, .2, .6, .4], columns=['val'])),
+        ('max', True, False, DataFrame(
+            [3., 3., 5., 3., 4.], columns=['val'])),
+        ('max', True, True, DataFrame(
+            [0.6, 0.6, 1.0, 0.6, 0.8], columns=['val'])),
+        ('max', False, False, DataFrame(
+            [5., 5., 1., 5., 2.], columns=['val'])),
+        ('max', False, True, DataFrame(
+            [1., 1., .2, 1., .4], columns=['val'])),
+        ('first', True, False, DataFrame(
+            [1., 2., 5., 3., 4.], columns=['val'])),
+        ('first', True, True, DataFrame(
+            [0.2, 0.4, 1.0, 0.6, 0.8], columns=['val'])),
+        ('first', False, False, DataFrame(
+            [3., 4., 1., 5., 2.], columns=['val'])),
+        ('first', False, True, DataFrame(
+            [.6, .8, .2, 1., .4], columns=['val'])),
+        ('dense', True, False, DataFrame(
+            [1., 1., 3., 1., 2.], columns=['val'])),
+        ('dense', True, True, DataFrame(
+            [0.2, 0.2, 0.6, 0.2, 0.4], columns=['val'])),
+        ('dense', False, False, DataFrame(
+            [3., 3., 1., 3., 2.], columns=['val'])),
+        ('dense', False, True, DataFrame(
+            [.6, .6, .2, .6, .4], columns=['val'])),
+    ])
+    def test_rank_args(self, vals, ties_method, ascending, pct, exp):
+        if ties_method == 'first' and vals[0] == 'bar':
+            pytest.xfail("See GH 19482")
+        df = DataFrame({'key': ['foo']*5, 'val': vals})
+        result = df.groupby('key').rank(method=ties_method, ascending=ascending,
+                                        pct=pct)
+
+        assert_frame_equal(result, exp)
+
+    @pytest.mark.parametrize("vals", [
+        [2, 2, np.nan, 8, 2, 6, np.nan, np.nan],  # floats
+        ['bar', 'bar', np.nan, 'foo', 'bar', 'baz', np.nan, np.nan]  # objects
+    ])
+    @pytest.mark.parametrize("ties_method,ascending,na_option,pct,exp", [
+        ('average', True, 'keep', False, DataFrame(
+            [2., 2., np.nan, 5., 2., 4., np.nan, np.nan], columns=['val'])),
+        ('average', True, 'keep', True, DataFrame(
+            [0.4, 0.4, np.nan, 1.0, 0.4, 0.8, np.nan, np.nan],
+            columns=['val'])),
+        ('average', False, 'keep', False, DataFrame(
+            [4., 4., np.nan, 1., 4., 2., np.nan, np.nan], columns=['val'])),
+        ('average', False, 'keep', True, DataFrame(
+            [.8, 0.8, np.nan, 0.2, 0.8, 0.4, np.nan, np.nan], columns=['val'])),
+        ('min', True, 'keep', False, DataFrame(
+            [1., 1., np.nan, 5., 1., 4., np.nan, np.nan], columns=['val'])),
+        ('min', True, 'keep', True, DataFrame(
+            [0.2, 0.2, np.nan, 1.0, 0.2, 0.8, np.nan, np.nan],
+            columns=['val'])),
+        ('min', False, 'keep', False, DataFrame(
+            [3., 3., np.nan, 1., 3., 2., np.nan, np.nan], columns=['val'])),
+        ('min', False, 'keep', True, DataFrame(
+            [.6, 0.6, np.nan, 0.2, 0.6, 0.4, np.nan, np.nan], columns=['val'])),
+        ('max', True, 'keep', False, DataFrame(
+            [3., 3., np.nan, 5., 3., 4., np.nan, np.nan], columns=['val'])),
+        ('max', True, 'keep', True, DataFrame(
+            [0.6, 0.6, np.nan, 1.0, 0.6, 0.8, np.nan, np.nan],
+            columns=['val'])),
+        ('max', False, 'keep', False, DataFrame(
+            [5., 5., np.nan, 1., 5., 2., np.nan, np.nan], columns=['val'])),
+        ('max', False, 'keep', True, DataFrame(
+            [1., 1., np.nan, 0.2, 1., 0.4, np.nan, np.nan], columns=['val'])),
+        ('first', True, 'keep', False, DataFrame(
+            [1., 2., np.nan, 5., 3., 4., np.nan, np.nan], columns=['val'])),
+        ('first', True, 'keep', True, DataFrame(
+            [0.2, 0.4, np.nan, 1.0, 0.6, 0.8, np.nan, np.nan],
+            columns=['val'])),
+        ('first', False, 'keep', False, DataFrame(
+            [3., 4., np.nan, 1., 5., 2., np.nan, np.nan], columns=['val'])),
+        ('first', False, 'keep', True, DataFrame(
+            [.6, 0.8, np.nan, 0.2, 1., 0.4, np.nan, np.nan], columns=['val'])),
+        ('dense', True, 'keep', False, DataFrame(
+            [1., 1., np.nan, 3., 1., 2., np.nan, np.nan], columns=['val'])),
+        ('dense', True, 'keep', True, DataFrame(
+            [0.2, 0.2, np.nan, 0.6, 0.2, 0.4, np.nan, np.nan],
+            columns=['val'])),
+        ('dense', False, 'keep', False, DataFrame(
+            [3., 3., np.nan, 1., 3., 2., np.nan, np.nan], columns=['val'])),
+        ('dense', False, 'keep', True, DataFrame(
+            [.6, 0.6, np.nan, 0.2, 0.6, 0.4, np.nan, np.nan], columns=['val'])),
+        ('average', True, 'no_na', False, DataFrame(
+            [2., 2., 7., 5., 2., 4., 7., 7.], columns=['val'])),
+        ('average', True, 'no_na', True, DataFrame(
+            [0.25, 0.25, 0.875, 0.625, 0.25, 0.5, 0.875, 0.875],
+            columns=['val'])),
+        ('average', False, 'no_na', False, DataFrame(
+            [4., 4., 7.0, 1., 4., 2., 7.0, 7.0], columns=['val'])),
+        ('average', False, 'no_na', True, DataFrame(
+            [0.5, 0.5, 0.875, 0.125, 0.5, 0.25, 0.875, 0.875], columns=['val'])),
+        ('min', True, 'no_na', False, DataFrame(
+            [1., 1., 6., 5., 1., 4., 6., 6.], columns=['val'])),
+        ('min', True, 'no_na', True, DataFrame(
+            [0.125, 0.125, 0.75, 0.625, 0.125, 0.5, 0.75, 0.75],
+            columns=['val'])),
+        ('min', False, 'no_na', False, DataFrame(
+            [3., 3., 6., 1., 3., 2., 6., 6.], columns=['val'])),
+        ('min', False, 'no_na', True, DataFrame(
+            [0.375, 0.375, 0.75, 0.125, 0.375, 0.25, 0.75, 0.75],
+            columns=['val'])),
+        ('max', True, 'no_na', False, DataFrame(
+            [3., 3., 8., 5., 3., 4., 8., 8.], columns=['val'])),
+        ('max', True, 'no_na', True, DataFrame(
+            [0.375, 0.375, 1., 0.625, 0.375, 0.5, 1., 1.], columns=['val'])),
+        ('max', False, 'no_na', False, DataFrame(
+            [5., 5., 8., 1., 5., 2., 8., 8.], columns=['val'])),
+        ('max', False, 'no_na', True, DataFrame(
+            [0.625, 0.625, 1., 0.125, 0.625, 0.25, 1., 1.], columns=['val'])),
+        ('first', True, 'no_na', False, DataFrame(
+            [1., 2., 6., 5., 3., 4., 7., 8.], columns=['val'])),
+        ('first', True, 'no_na', True, DataFrame(
+            [0.125, 0.25, 0.75, 0.625, 0.375, 0.5, 0.875, 1.],
+            columns=['val'])),
+        ('first', False, 'no_na', False, DataFrame(
+            [3., 4., 6., 1., 5., 2., 7., 8.], columns=['val'])),
+        ('first', False, 'no_na', True, DataFrame(
+            [0.375, 0.5, 0.75, 0.125, 0.625, 0.25, 0.875, 1.],
+            columns=['val'])),
+        ('dense', True, 'no_na', False, DataFrame(
+            [1., 1., 4., 3., 1., 2., 4., 4.], columns=['val'])),
+        ('dense', True, 'no_na', True, DataFrame(
+            [0.125, 0.125, 0.5, 0.375, 0.125, 0.25, 0.5, 0.5],
+            columns=['val'])),
+        ('dense', False, 'no_na', False, DataFrame(
+            [3., 3., 4., 1., 3., 2., 4., 4.], columns=['val'])),
+        ('dense', False, 'no_na', True, DataFrame(
+            [0.375, 0.375, 0.5, 0.125, 0.375, 0.25, 0.5, 0.5],
+            columns=['val'])),
+    ])
+    def test_rank_args_missing(self, vals, ties_method, ascending, na_option,
+                               pct, exp):
+        if ties_method == 'first' and vals[0] == 'bar':
+            pytest.xfail("See GH 19482")
+
+        df = DataFrame({'key': ['foo']*8, 'val': vals})
+        result = df.groupby('key').rank(method=ties_method, ascending=ascending,
+                                        na_option=na_option, pct=pct)
+
+        assert_frame_equal(result, exp)
+
     def test_dont_clobber_name_column(self):
         df = DataFrame({'key': ['a', 'a', 'a', 'b', 'b', 'b'],
                         'name': ['foo', 'bar', 'baz'] * 2})

--- a/pandas/tests/groupby/test_groupby.py
+++ b/pandas/tests/groupby/test_groupby.py
@@ -1930,8 +1930,8 @@ class TestGroupBy(MixIn):
         key = np.repeat(grps, len(vals))
         vals = vals * len(grps)
         df = DataFrame({'key': key, 'val': vals})
-        result = df.groupby('key').rank(method=ties_method, ascending=ascending,
-                                        pct=pct)
+        result = df.groupby('key').rank(method=ties_method,
+                                        ascending=ascending, pct=pct)
 
         exp_df = DataFrame(exp * len(grps), columns=['val'])
         assert_frame_equal(result, exp_df)
@@ -2024,7 +2024,8 @@ class TestGroupBy(MixIn):
         key = np.repeat(grps, len(vals))
         vals = vals * len(grps)
         df = DataFrame({'key': key, 'val': vals})
-        result = df.groupby('key').rank(method=ties_method, ascending=ascending,
+        result = df.groupby('key').rank(method=ties_method,
+                                        ascending=ascending,
                                         na_option=na_option, pct=pct)
 
         exp_df = DataFrame(exp * len(grps), columns=['val'])

--- a/pandas/tests/groupby/test_groupby.py
+++ b/pandas/tests/groupby/test_groupby.py
@@ -1952,10 +1952,11 @@ class TestGroupBy(MixIn):
 
     @pytest.mark.parametrize("vals", [
         [2, 2, np.nan, 8, 2, 6, np.nan, np.nan],  # floats
-        ['bar', 'bar', np.nan, 'foo', 'bar', 'baz', np.nan, np.nan],  # objects
-        [pd.Timestamp('2018-01-02'), pd.Timestamp('2018-01-02'), np.nan,
-         pd.Timestamp('2018-01-08'), pd.Timestamp('2018-01-02'),
-         pd.Timestamp('2018-01-06'), np.nan, np.nan]])
+        #['bar', 'bar', np.nan, 'foo', 'bar', 'baz', np.nan, np.nan],  # objects
+        #[pd.Timestamp('2018-01-02'), pd.Timestamp('2018-01-02'), np.nan,
+        # pd.Timestamp('2018-01-08'), pd.Timestamp('2018-01-02'),
+        # pd.Timestamp('2018-01-06'), np.nan, np.nan]
+    ])
     @pytest.mark.parametrize("ties_method,ascending,na_option,pct,exp", [
         ('average', True, 'keep', False, DataFrame(
             [2., 2., np.nan, 5., 2., 4., np.nan, np.nan], columns=['val'])),

--- a/pandas/tests/groupby/test_groupby.py
+++ b/pandas/tests/groupby/test_groupby.py
@@ -2038,8 +2038,7 @@ class TestGroupBy(MixIn):
     def test_rank_object_raises(self, ties_method, ascending, na_option,
                                 pct, vals):
         df = DataFrame({'key': ['foo'] * 5, 'val': vals})
-        with tm.assert_raises_regex(ValueError,
-                                    "rank not supported for object dtypes"):
+        with tm.assert_raises_regex(TypeError, "not callable"):
             df.groupby('key').rank(method=ties_method,
                                    ascending=ascending,
                                    na_option=na_option, pct=pct)


### PR DESCRIPTION
- [x] closes #15779
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry

~~This is not complete~~ but I wanted to submit for review on the direction. In particular, I wanted to know if my way of passing the named rank arguments back to the Cython layer makes sense, or if we'd rather bypass using kwargs and call that function directly from the `GroupBy` instance method (similar to how `shift` does it).

Right now this only increments values ascending, doesn't handle tiebreakers, nor does it allow for the return of a percentage. I also plan on adding some test cases to cover the arguments as I can't find them in the `pandas.tests.groupby` package. More to come but again wanted feedback before going too far in