### PR TITLE
Fix makeIntIndex, benchmark get loc

### DIFF
--- a/asv_bench/benchmarks/index_object.py
+++ b/asv_bench/benchmarks/index_object.py
@@ -147,6 +147,11 @@ class Indexing(object):
         self.idx = getattr(tm, 'make{}Index'.format(dtype))(N)
         self.array_mask = (np.arange(N) % 3) == 0
         self.series_mask = Series(self.array_mask)
+        self.sorted = self.idx.sort_values()
+        half = N // 2
+        self.non_unique = self.idx[:half].append(self.idx[:half])
+        self.non_unique_sorted = self.sorted[:half].append(self.sorted[:half])
+        self.key = self.sorted[N // 4]
 
     def time_boolean_array(self, dtype):
         self.idx[self.array_mask]
@@ -162,6 +167,18 @@ class Indexing(object):
 
     def time_slice_step(self, dtype):
         self.idx[::2]
+
+    def time_get_loc(self, dtype):
+        self.idx.get_loc(self.key)
+
+    def time_get_loc_sorted(self, dtype):
+        self.sorted.get_loc(self.key)
+
+    def time_get_loc_non_unique(self, dtype):
+        self.non_unique.get_loc(self.key)
+
+    def time_get_loc_non_unique_sorted(self, dtype):
+        self.non_unique_sorted.get_loc(self.key)
 
 
 class Float64IndexMethod(object):

--- a/pandas/tests/indexes/test_base.py
+++ b/pandas/tests/indexes/test_base.py
@@ -830,15 +830,16 @@ class TestIndex(Base):
 
         # Test that returning a single tuple from an Index
         #   returns an Index.
-        boolean_index = tm.makeIntIndex(3).map(lambda x: (x,))
-        expected = Index([(0,), (1,), (2,)])
-        tm.assert_index_equal(boolean_index, expected)
+        idx = tm.makeIntIndex(3)
+        result = tm.makeIntIndex(3).map(lambda x: (x,))
+        expected = Index([(i,) for i in idx])
+        tm.assert_index_equal(result, expected)
 
         # Test that returning a tuple from a map of a single index
         #   returns a MultiIndex object.
-        boolean_index = tm.makeIntIndex(3).map(lambda x: (x, x == 1))
-        expected = MultiIndex.from_tuples([(0, False), (1, True), (2, False)])
-        tm.assert_index_equal(boolean_index, expected)
+        result = idx.map(lambda x: (x, x == 1))
+        expected = MultiIndex.from_tuples([(i, i == 1) for i in idx])
+        tm.assert_index_equal(result, expected)
 
         # Test that returning a single object from a MultiIndex
         #   returns an Index.
@@ -870,7 +871,8 @@ class TestIndex(Base):
     def test_map_dictlike(self, mapper):
         # GH 12756
         expected = Index(['foo', 'bar', 'baz'])
-        result = tm.makeIntIndex(3).map(mapper(expected.values, [0, 1, 2]))
+        idx = tm.makeIntIndex(3)
+        result = idx.map(mapper(expected.values, idx))
         tm.assert_index_equal(result, expected)
 
         for name in self.indices.keys():

--- a/pandas/tests/indexing/test_floats.py
+++ b/pandas/tests/indexing/test_floats.py
@@ -4,7 +4,8 @@ import pytest
 
 from warnings import catch_warnings
 import numpy as np
-from pandas import Series, DataFrame, Index, Float64Index
+from pandas import (Series, DataFrame, Index, Float64Index, Int64Index,
+                    RangeIndex)
 from pandas.util.testing import assert_series_equal, assert_almost_equal
 import pandas.util.testing as tm
 
@@ -206,9 +207,8 @@ class TestFloatIndexers(object):
         # test how scalar float indexers work on int indexes
 
         # integer index
-        for index in [tm.makeIntIndex, tm.makeRangeIndex]:
+        for i in [Int64Index(range(5)), RangeIndex(5)]:
 
-            i = index(5)
             for s in [Series(np.arange(len(i))),
                       DataFrame(np.random.randn(len(i), len(i)),
                                 index=i, columns=i)]:
@@ -362,9 +362,9 @@ class TestFloatIndexers(object):
         # these coerce to a like integer
         # oob indicates if we are out of bounds
         # of positional indexing
-        for index, oob in [(tm.makeIntIndex(5), False),
-                           (tm.makeRangeIndex(5), False),
-                           (tm.makeIntIndex(5) + 10, True)]:
+        for index, oob in [(Int64Index(range(5)), False),
+                           (RangeIndex(5), False),
+                           (Int64Index(range(5)) + 10, True)]:
 
             # s is an in-range index
             s = Series(range(5), index=index)
@@ -486,9 +486,8 @@ class TestFloatIndexers(object):
     def test_slice_integer_frame_getitem(self):
 
         # similar to above, but on the getitem dim (of a DataFrame)
-        for index in [tm.makeIntIndex, tm.makeRangeIndex]:
+        for index in [Int64Index(range(5)), RangeIndex(5)]:
 
-            index = index(5)
             s = DataFrame(np.random.randn(5, 2), index=index)
 
             def f(idxr):

--- a/pandas/util/testing.py
+++ b/pandas/util/testing.py
@@ -1560,11 +1560,11 @@ def makeBoolIndex(k=10, name=None):
 
 
 def makeIntIndex(k=10, name=None):
-    return Index(lrange(k), name=name)
+    return Index(lrange(1, k) + [0], name=name)[:k]
 
 
 def makeUIntIndex(k=10, name=None):
-    return Index([2**63 + i for i in lrange(k)], name=name)
+    return Index([2**63 + i for i in (lrange(1, k) + [0])], name=name)[:k]
 
 
 def makeRangeIndex(k=10, name=None):


### PR DESCRIPTION
- [x] tests passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`

``makeIntIndex`` currently produces a monotonic index, and hence tests common to different classes actually test very different things (i.e. the sorted vs. unsorted code paths). I had to fix this (and to fix the tests which erroneously relied on the specific content of ``makeIntIndex(k)``) in order to add meaningful performance tests for ``get_loc``.
