### PR TITLE
[WIP] ENH: interval accessor

### DIFF
--- a/pandas/core/dtypes/common.py
+++ b/pandas/core/dtypes/common.py
@@ -13,7 +13,7 @@ from .dtypes import (CategoricalDtype, CategoricalDtypeType,
 from .generic import (ABCCategorical, ABCPeriodIndex,
                       ABCDatetimeIndex, ABCSeries,
                       ABCSparseArray, ABCSparseSeries, ABCCategoricalIndex,
-                      ABCIndexClass, ABCDateOffset)
+                      ABCIndexClass, ABCDateOffset, ABCIntervalIndex)
 from .inference import is_string_like, is_list_like
 from .inference import *  # noqa
 
@@ -508,6 +508,39 @@ def is_interval_dtype(arr_or_dtype):
     if arr_or_dtype is None:
         return False
     return IntervalDtype.is_dtype(arr_or_dtype)
+
+
+def is_interval_arraylike(arr):
+    """
+    Check whether an array-like is interval array-like or IntervalIndex.
+
+    Parameters
+    ----------
+    arr : array-like
+        The array-like to check.
+
+    Returns
+    -------
+    boolean : Whether or not the array-like is a periodical
+              array-like or PeriodIndex instance.
+
+    Examples
+    --------
+    >>> is_interval_arraylike([1, 2, 3])
+    False
+    >>> is_interval_arraylike(pd.Index([1, 2, 3]))
+    False
+    >>> is_interval_arraylike(pd.IntervalIndex.from_breaks([0, 1, 2, 3]))
+    True
+    >>> is_interval_arraylike(pd.Series(pd.interval_range(0, 5)))
+    True
+    """
+
+    if isinstance(arr, ABCIntervalIndex):
+        return True
+    elif isinstance(arr, (np.ndarray, ABCSeries)):
+        return arr.dtype == object and lib.infer_dtype(arr) == 'interval'
+    return getattr(arr, 'inferred_type', None) == 'interval'
 
 
 def is_categorical_dtype(arr_or_dtype):

--- a/pandas/core/indexes/interval.py
+++ b/pandas/core/indexes/interval.py
@@ -208,6 +208,10 @@ class IntervalIndex(IntervalMixin, Index):
     _comparables = ['name']
     _attributes = ['name', 'closed']
 
+    # define my properties & methods for delegation
+    _interval_ops = ['left', 'right', 'mid', 'length']
+    _interval_methods = []
+
     # we would like our indexing holder to defer to us
     _defer_to_indexing = True
 

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -45,7 +45,8 @@ from pandas.core.indexing import check_bool_indexer, maybe_convert_indices
 from pandas.core import generic, base
 from pandas.core.internals import SingleBlockManager
 from pandas.core.arrays.categorical import Categorical, CategoricalAccessor
-from pandas.core.indexes.accessors import CombinedDatetimelikeProperties
+from pandas.core.indexes.accessors import (
+    CombinedDatetimelikeProperties, IntervalAccessor)
 from pandas.core.indexes.datetimes import DatetimeIndex
 from pandas.core.indexes.timedeltas import TimedeltaIndex
 from pandas.core.indexes.period import PeriodIndex
@@ -140,7 +141,7 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
         Copy input data
     """
     _metadata = ['name']
-    _accessors = frozenset(['dt', 'cat', 'str'])
+    _accessors = frozenset(['dt', 'cat', 'str', 'iv'])
     _deprecations = generic.NDFrame._deprecations | frozenset(
         ['asobject', 'sortlevel', 'reshape', 'get_value', 'set_value',
          'from_csv', 'valid'])
@@ -3085,6 +3086,7 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
     dt = CachedAccessor("dt", CombinedDatetimelikeProperties)
     cat = CachedAccessor("cat", CategoricalAccessor)
     plot = CachedAccessor("plot", gfx.SeriesPlotMethods)
+    iv = CachedAccessor("iv", IntervalAccessor)
 
     # ----------------------------------------------------------------------
     # Add plotting methods to Series

--- a/pandas/tests/series/test_interval_values.py
+++ b/pandas/tests/series/test_interval_values.py
@@ -1,0 +1,52 @@
+import pytest
+from pandas import (
+    Categorical,
+    IntervalIndex,
+    interval_range,
+    Series)
+from pandas.core.dtypes.common import is_categorical_dtype
+from pandas.core.indexes.accessors import IntervalAccessor
+import pandas.util.testing as tm
+
+
+class TestSeriesIntervalAccessor(object):
+
+    @pytest.mark.parametrize('prop', IntervalIndex._interval_ops)
+    @pytest.mark.parametrize('data', [
+        IntervalIndex.from_breaks([0, 1, 3, 6, 10]),
+        Categorical(interval_range(0, 3).repeat(2))])
+    def test_iv_properties(self, prop, data):
+        s = Series(data)
+        if is_categorical_dtype(data):
+            ii = IntervalIndex(data.get_values())
+        else:
+            ii = data
+
+        # check values
+        result = getattr(s.iv, prop)
+        expected = Series(getattr(ii, prop))
+        tm.assert_series_equal(result, expected)
+
+        # no modifications
+        msg = ('modifications to a property of an IntervalIndex object are '
+               'not supported. Change values on the original.')
+        with tm.assert_raises_regex(ValueError, msg):
+            setattr(s.iv, prop, 1)
+
+    def test_iv_accessor_api(self):
+        assert Series.iv is IntervalAccessor
+
+        s = Series(interval_range(0, 5))
+        assert isinstance(s.iv, IntervalAccessor)
+
+        invalid = Series(list('abcde'))
+        assert not hasattr(invalid, 'iv')
+
+        with tm.assert_raises_regex(AttributeError, "only use .iv accessor"):
+            invalid.iv
+
+    def test_no_new_attributes(self):
+        s = Series(interval_range(0, 5))
+        msg = 'You cannot add any new attribute'
+        with tm.assert_raises_regex(AttributeError, msg):
+            s.iv.new_attribute = 'foo'


### PR DESCRIPTION
- [ ] closes #16401
- [ ] tests added / passed
- [X] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

Still have a quite a few things to do, but wanted to make sure I'm on the right track, and have this PR in place to motivate any additional issues/PR that need to be done as a prereq for this.

TODO:
- Add `IntervalIndex` methods to the accessor
   - I don't immediately see any existing methods that are appropriate for this
   - There are a few open issues/PR related to methods that could be appropriate here
- Documentation
   - whatsnew entry
   - Add a section to the main docs (top level?) with examples (xref #16400)
- More tests
  - Tests for  `IntervalIndex` methods once they've been added
  - Anything else I'm missing?

Example usage:
```python
In [2]: s = pd.Series(pd.IntervalIndex.from_breaks([0, 1, 3, 6, 10]))

In [3]: s
Out[3]:
0     (0, 1]
1     (1, 3]
2     (3, 6]
3    (6, 10]
dtype: object

In [4]: s.iv.length
Out[4]:
0    1
1    2
2    3
3    4
dtype: int64

In [5]: s.iv.mid
Out[5]:
0    0.5
1    2.0
2    4.5
3    8.0
dtype: float64
```

cc @TomAugspurger : thought you'd be interested as this relates to the new extension accessor code