### PR TITLE
implement timedeltas.test_scalar_compat

### DIFF
--- a/pandas/tests/indexes/timedeltas/test_arithmetic.py
+++ b/pandas/tests/indexes/timedeltas/test_arithmetic.py
@@ -10,7 +10,7 @@ from pandas import (DatetimeIndex, TimedeltaIndex, Float64Index, Int64Index,
                     to_timedelta, timedelta_range, date_range,
                     Series,
                     Timestamp, Timedelta)
-from pandas.errors import PerformanceWarning
+from pandas.errors import PerformanceWarning, NullFrequencyError
 
 
 @pytest.fixture(params=[pd.offsets.Hour(2), timedelta(hours=2),
@@ -137,6 +137,60 @@ class TestTimedeltaIndexArithmetic(object):
             tdi + 'a'
         with pytest.raises(TypeError):
             'a' + tdi
+
+    # -------------------------------------------------------------
+    # TimedeltaIndex.shift is used by __add__/__sub__
+
+    def test_tdi_shift_empty(self):
+        # GH#9903
+        idx = pd.TimedeltaIndex([], name='xxx')
+        tm.assert_index_equal(idx.shift(0, freq='H'), idx)
+        tm.assert_index_equal(idx.shift(3, freq='H'), idx)
+
+    def test_tdi_shift_hours(self):
+        # GH#9903
+        idx = pd.TimedeltaIndex(['5 hours', '6 hours', '9 hours'], name='xxx')
+        tm.assert_index_equal(idx.shift(0, freq='H'), idx)
+        exp = pd.TimedeltaIndex(['8 hours', '9 hours', '12 hours'], name='xxx')
+        tm.assert_index_equal(idx.shift(3, freq='H'), exp)
+        exp = pd.TimedeltaIndex(['2 hours', '3 hours', '6 hours'], name='xxx')
+        tm.assert_index_equal(idx.shift(-3, freq='H'), exp)
+
+    def test_tdi_shift_minutes(self):
+        # GH#9903
+        idx = pd.TimedeltaIndex(['5 hours', '6 hours', '9 hours'], name='xxx')
+        tm.assert_index_equal(idx.shift(0, freq='T'), idx)
+        exp = pd.TimedeltaIndex(['05:03:00', '06:03:00', '9:03:00'],
+                                name='xxx')
+        tm.assert_index_equal(idx.shift(3, freq='T'), exp)
+        exp = pd.TimedeltaIndex(['04:57:00', '05:57:00', '8:57:00'],
+                                name='xxx')
+        tm.assert_index_equal(idx.shift(-3, freq='T'), exp)
+
+    def test_tdi_shift_int(self):
+        # GH#8083
+        trange = pd.to_timedelta(range(5), unit='d') + pd.offsets.Hour(1)
+        result = trange.shift(1)
+        expected = TimedeltaIndex(['1 days 01:00:00', '2 days 01:00:00',
+                                   '3 days 01:00:00',
+                                   '4 days 01:00:00', '5 days 01:00:00'],
+                                  freq='D')
+        tm.assert_index_equal(result, expected)
+
+    def test_tdi_shift_nonstandard_freq(self):
+        # GH#8083
+        trange = pd.to_timedelta(range(5), unit='d') + pd.offsets.Hour(1)
+        result = trange.shift(3, freq='2D 1s')
+        expected = TimedeltaIndex(['6 days 01:00:03', '7 days 01:00:03',
+                                   '8 days 01:00:03', '9 days 01:00:03',
+                                   '10 days 01:00:03'], freq='D')
+        tm.assert_index_equal(result, expected)
+
+    def test_shift_no_freq(self):
+        # GH#19147
+        tdi = TimedeltaIndex(['1 days 01:00:00', '2 days 01:00:00'], freq=None)
+        with pytest.raises(NullFrequencyError):
+            tdi.shift(2)
 
     # -------------------------------------------------------------
 

--- a/pandas/tests/indexes/timedeltas/test_ops.py
+++ b/pandas/tests/indexes/timedeltas/test_ops.py
@@ -98,32 +98,6 @@ class TestTimedeltaIndexOps(Ops):
             tm.assert_raises_regex(
                 ValueError, errmsg, np.argmax, td, out=0)
 
-    def test_round(self):
-        td = pd.timedelta_range(start='16801 days', periods=5, freq='30Min')
-        elt = td[1]
-
-        expected_rng = TimedeltaIndex([
-            Timedelta('16801 days 00:00:00'),
-            Timedelta('16801 days 00:00:00'),
-            Timedelta('16801 days 01:00:00'),
-            Timedelta('16801 days 02:00:00'),
-            Timedelta('16801 days 02:00:00'),
-        ])
-        expected_elt = expected_rng[1]
-
-        tm.assert_index_equal(td.round(freq='H'), expected_rng)
-        assert elt.round(freq='H') == expected_elt
-
-        msg = pd._libs.tslibs.frequencies._INVALID_FREQ_ERROR
-        with tm.assert_raises_regex(ValueError, msg):
-            td.round(freq='foo')
-        with tm.assert_raises_regex(ValueError, msg):
-            elt.round(freq='foo')
-
-        msg = "<MonthEnd> is a non-fixed frequency"
-        tm.assert_raises_regex(ValueError, msg, td.round, freq='M')
-        tm.assert_raises_regex(ValueError, msg, elt.round, freq='M')
-
     def test_representation(self):
         idx1 = TimedeltaIndex([], freq='D')
         idx2 = TimedeltaIndex(['1 days'], freq='D')
@@ -387,25 +361,7 @@ dtype: timedelta64[ns]"""
         tm.assert_numpy_array_equal(result, exp)
 
     def test_shift(self):
-        # GH 9903
-        idx = pd.TimedeltaIndex([], name='xxx')
-        tm.assert_index_equal(idx.shift(0, freq='H'), idx)
-        tm.assert_index_equal(idx.shift(3, freq='H'), idx)
-
-        idx = pd.TimedeltaIndex(['5 hours', '6 hours', '9 hours'], name='xxx')
-        tm.assert_index_equal(idx.shift(0, freq='H'), idx)
-        exp = pd.TimedeltaIndex(['8 hours', '9 hours', '12 hours'], name='xxx')
-        tm.assert_index_equal(idx.shift(3, freq='H'), exp)
-        exp = pd.TimedeltaIndex(['2 hours', '3 hours', '6 hours'], name='xxx')
-        tm.assert_index_equal(idx.shift(-3, freq='H'), exp)
-
-        tm.assert_index_equal(idx.shift(0, freq='T'), idx)
-        exp = pd.TimedeltaIndex(['05:03:00', '06:03:00', '9:03:00'],
-                                name='xxx')
-        tm.assert_index_equal(idx.shift(3, freq='T'), exp)
-        exp = pd.TimedeltaIndex(['04:57:00', '05:57:00', '8:57:00'],
-                                name='xxx')
-        tm.assert_index_equal(idx.shift(-3, freq='T'), exp)
+        pass  # handled in test_arithmetic.py
 
     def test_repeat(self):
         index = pd.timedelta_range('1 days', periods=2, freq='D')

--- a/pandas/tests/indexes/timedeltas/test_scalar_compat.py
+++ b/pandas/tests/indexes/timedeltas/test_scalar_compat.py
@@ -1,0 +1,64 @@
+# -*- coding: utf-8 -*-
+"""
+Tests for TimedeltaIndex methods behaving like their Timedelta counterparts
+"""
+
+import numpy as np
+
+import pandas as pd
+import pandas.util.testing as tm
+from pandas import timedelta_range, Timedelta, TimedeltaIndex, Index, Series
+
+
+class TestVectorizedTimedelta(object):
+    def test_tdi_total_seconds(self):
+        # GH#10939
+        # test index
+        rng = timedelta_range('1 days, 10:11:12.100123456', periods=2,
+                              freq='s')
+        expt = [1 * 86400 + 10 * 3600 + 11 * 60 + 12 + 100123456. / 1e9,
+                1 * 86400 + 10 * 3600 + 11 * 60 + 13 + 100123456. / 1e9]
+        tm.assert_almost_equal(rng.total_seconds(), Index(expt))
+
+        # test Series
+        ser = Series(rng)
+        s_expt = Series(expt, index=[0, 1])
+        tm.assert_series_equal(ser.dt.total_seconds(), s_expt)
+
+        # with nat
+        ser[1] = np.nan
+        s_expt = Series([1 * 86400 + 10 * 3600 + 11 * 60 +
+                         12 + 100123456. / 1e9, np.nan], index=[0, 1])
+        tm.assert_series_equal(ser.dt.total_seconds(), s_expt)
+
+        # with both nat
+        ser = Series([np.nan, np.nan], dtype='timedelta64[ns]')
+        tm.assert_series_equal(ser.dt.total_seconds(),
+                               Series([np.nan, np.nan], index=[0, 1]))
+
+    def test_tdi_round(self):
+        td = pd.timedelta_range(start='16801 days', periods=5, freq='30Min')
+        elt = td[1]
+
+        expected_rng = TimedeltaIndex([Timedelta('16801 days 00:00:00'),
+                                       Timedelta('16801 days 00:00:00'),
+                                       Timedelta('16801 days 01:00:00'),
+                                       Timedelta('16801 days 02:00:00'),
+                                       Timedelta('16801 days 02:00:00')])
+        expected_elt = expected_rng[1]
+
+        tm.assert_index_equal(td.round(freq='H'), expected_rng)
+        assert elt.round(freq='H') == expected_elt
+
+        msg = pd._libs.tslibs.frequencies._INVALID_FREQ_ERROR
+        with tm.assert_raises_regex(ValueError, msg):
+            td.round(freq='foo')
+        with tm.assert_raises_regex(ValueError, msg):
+            elt.round(freq='foo')
+
+        msg = "<MonthEnd> is a non-fixed frequency"
+        with tm.assert_raises_regex(ValueError, msg):
+            td.round(freq='M')
+        with tm.assert_raises_regex(ValueError, msg):
+            elt.round(freq='M')    
+

--- a/pandas/tests/indexes/timedeltas/test_scalar_compat.py
+++ b/pandas/tests/indexes/timedeltas/test_scalar_compat.py
@@ -60,5 +60,4 @@ class TestVectorizedTimedelta(object):
         with tm.assert_raises_regex(ValueError, msg):
             td.round(freq='M')
         with tm.assert_raises_regex(ValueError, msg):
-            elt.round(freq='M')    
-
+            elt.round(freq='M')

--- a/pandas/tests/indexes/timedeltas/test_timedelta.py
+++ b/pandas/tests/indexes/timedeltas/test_timedelta.py
@@ -4,7 +4,6 @@ import numpy as np
 from datetime import timedelta
 
 import pandas as pd
-from pandas.errors import NullFrequencyError
 import pandas.util.testing as tm
 from pandas import (timedelta_range, date_range, Series, Timedelta,
                     TimedeltaIndex, Index, DataFrame,
@@ -34,28 +33,7 @@ class TestTimedeltaIndex(DatetimeLike):
         pass
 
     def test_shift(self):
-        # test shift for TimedeltaIndex
-        # err8083
-
-        drange = self.create_index()
-        result = drange.shift(1)
-        expected = TimedeltaIndex(['1 days 01:00:00', '2 days 01:00:00',
-                                   '3 days 01:00:00',
-                                   '4 days 01:00:00', '5 days 01:00:00'],
-                                  freq='D')
-        tm.assert_index_equal(result, expected)
-
-        result = drange.shift(3, freq='2D 1s')
-        expected = TimedeltaIndex(['6 days 01:00:03', '7 days 01:00:03',
-                                   '8 days 01:00:03', '9 days 01:00:03',
-                                   '10 days 01:00:03'], freq='D')
-        tm.assert_index_equal(result, expected)
-
-    def test_shift_no_freq(self):
-        # GH#19147
-        tdi = TimedeltaIndex(['1 days 01:00:00', '2 days 01:00:00'], freq=None)
-        with pytest.raises(NullFrequencyError):
-            tdi.shift(2)
+        pass  # this is handled in test_arithmetic.py
 
     def test_pickle_compat_construction(self):
         pass
@@ -202,31 +180,6 @@ class TestTimedeltaIndex(DatetimeLike):
         result = rng.map(f)
         exp = Int64Index([f(x) for x in rng])
         tm.assert_index_equal(result, exp)
-
-    def test_total_seconds(self):
-        # GH 10939
-        # test index
-        rng = timedelta_range('1 days, 10:11:12.100123456', periods=2,
-                              freq='s')
-        expt = [1 * 86400 + 10 * 3600 + 11 * 60 + 12 + 100123456. / 1e9,
-                1 * 86400 + 10 * 3600 + 11 * 60 + 13 + 100123456. / 1e9]
-        tm.assert_almost_equal(rng.total_seconds(), Index(expt))
-
-        # test Series
-        s = Series(rng)
-        s_expt = Series(expt, index=[0, 1])
-        tm.assert_series_equal(s.dt.total_seconds(), s_expt)
-
-        # with nat
-        s[1] = np.nan
-        s_expt = Series([1 * 86400 + 10 * 3600 + 11 * 60 +
-                         12 + 100123456. / 1e9, np.nan], index=[0, 1])
-        tm.assert_series_equal(s.dt.total_seconds(), s_expt)
-
-        # with both nat
-        s = Series([np.nan, np.nan], dtype='timedelta64[ns]')
-        tm.assert_series_equal(s.dt.total_seconds(),
-                               Series([np.nan, np.nan], index=[0, 1]))
 
     def test_pass_TimedeltaIndex_to_index(self):
 


### PR DESCRIPTION
Centralize and split redundant TDI.shift tests in test_arith
