### PR TITLE
WIP: reduce unwanted type conversions of pd.Series.isin

### DIFF
--- a/pandas/core/algorithms.py
+++ b/pandas/core/algorithms.py
@@ -404,12 +404,16 @@ def isin(comps, values):
     if not isinstance(values, (ABCIndex, ABCSeries, np.ndarray)):
         values = construct_1d_object_array_from_listlike(list(values))
 
-    from pandas.core.dtypes.common import is_datetimelike
+    from pandas.core.dtypes.common import is_datetimelike, is_float
     comps, dtype, _ = _ensure_data(comps)
-    # Convert `values` to `dtype` if `values` is datetime-like and `dtype` is datetime-like
+    # Convert `values` to `dtype` if `values` is datetime/float-like and `dtype` is datetime/float-like
     if (is_datetime_or_timedelta_dtype(dtype) and
         (is_datetime_or_timedelta_dtype(values) or
          all(is_datetimelike(i) for i in values))):
+        values, _, _ = _ensure_data(values, dtype=dtype)
+    elif (is_float_dtype(dtype) and
+          (is_float_dtype(values) or
+           all(is_float(i) for i in values))):
         values, _, _ = _ensure_data(values, dtype=dtype)
     else:
         values, _, _ = _ensure_data(values)

--- a/pandas/core/algorithms.py
+++ b/pandas/core/algorithms.py
@@ -404,9 +404,12 @@ def isin(comps, values):
     if not isinstance(values, (ABCIndex, ABCSeries, np.ndarray)):
         values = construct_1d_object_array_from_listlike(list(values))
 
+    from pandas.core.dtypes.common import is_datetimelike
     comps, dtype, _ = _ensure_data(comps)
-    if (all(is_datetime_or_timedelta_dtype(i) for i in values) and
-        is_datetime_or_timedelta_dtype(dtype)):
+    # Convert `values` to `dtype` if `values` is datetime-like and `dtype` is datetime-like
+    if (is_datetime_or_timedelta_dtype(dtype) and
+        (is_datetime_or_timedelta_dtype(values) or
+         all(is_datetimelike(i) for i in values))):
         values, _, _ = _ensure_data(values, dtype=dtype)
     else:
         values, _, _ = _ensure_data(values)

--- a/pandas/core/algorithms.py
+++ b/pandas/core/algorithms.py
@@ -13,14 +13,14 @@ from pandas.core.dtypes.generic import (
     ABCIndexClass, ABCCategorical)
 from pandas.core.dtypes.common import (
     is_unsigned_integer_dtype, is_signed_integer_dtype,
-    is_integer_dtype, is_complex_dtype,
+    is_integer_dtype, is_complex_dtype, is_integer, is_float,
     is_object_dtype,
     is_categorical_dtype, is_sparse,
     is_period_dtype,
     is_numeric_dtype, is_float_dtype,
     is_bool_dtype, needs_i8_conversion,
     is_categorical, is_datetimetz, is_datetime_or_timedelta_dtype,
-    is_datetime64_any_dtype, is_datetime64tz_dtype,
+    is_datetime64_any_dtype, is_datetime64tz_dtype, is_datetimelike,
     is_timedelta64_dtype, is_interval_dtype,
     is_scalar, is_list_like,
     _ensure_platform_int, _ensure_object,
@@ -404,16 +404,18 @@ def isin(comps, values):
     if not isinstance(values, (ABCIndex, ABCSeries, np.ndarray)):
         values = construct_1d_object_array_from_listlike(list(values))
 
-    from pandas.core.dtypes.common import is_datetimelike, is_float
     comps, dtype, _ = _ensure_data(comps)
-    # Convert `values` to `dtype` if `values` is datetime/float-like and `dtype` is datetime/float-like
-    if (is_datetime_or_timedelta_dtype(dtype) and
-        (is_datetime_or_timedelta_dtype(values) or
-         all(is_datetimelike(i) for i in values))):
-        values, _, _ = _ensure_data(values, dtype=dtype)
-    elif (is_float_dtype(dtype) and
-          (is_float_dtype(values) or
-           all(is_float(i) for i in values))):
+    # Convert `values` to `dtype` if dtype of `values` is like `dtype`
+    check_int = (is_integer_dtype(dtype) and
+                 (is_integer_dtype(values) or
+                  all(is_integer(i) for i in values)))
+    check_float = (is_float_dtype(dtype) and
+                   (is_float_dtype(values) or
+                    all(is_float(i) for i in values)))
+    check_datetime = (is_datetime_or_timedelta_dtype(dtype) and
+                      (is_datetime_or_timedelta_dtype(values) or
+                       all(is_datetimelike(i) for i in values)))
+    if check_int or check_float or check_datetime:
         values, _, _ = _ensure_data(values, dtype=dtype)
     else:
         values, _, _ = _ensure_data(values)

--- a/pandas/core/algorithms.py
+++ b/pandas/core/algorithms.py
@@ -32,6 +32,7 @@ from pandas.core.dtypes.missing import isna
 from pandas.core import common as com
 from pandas._libs import algos, lib, hashtable as htable
 from pandas._libs.tslib import iNaT
+from pandas._libs.tslibs.timestamps import Timestamp
 
 
 # --------------- #
@@ -414,7 +415,8 @@ def isin(comps, values):
                     all(is_float(i) for i in values)))
     check_datetime = (is_datetime_or_timedelta_dtype(dtype) and
                       (is_datetime_or_timedelta_dtype(values) or
-                       all(is_datetimelike(i) for i in values)))
+                       all(is_datetimelike(i) for i in values) or
+                       all(isinstance(i, Timestamp) for i in values)))
     if check_int or check_float or check_datetime:
         values, _, _ = _ensure_data(values, dtype=dtype)
     else:

--- a/pandas/core/algorithms.py
+++ b/pandas/core/algorithms.py
@@ -70,9 +70,9 @@ def _ensure_data(values, dtype=None):
             # we are actually coercing to uint64
             # until our algos support uint8 directly (see TODO)
             return np.asarray(values).astype('uint64'), 'bool', 'uint64'
-        elif is_signed_integer_dtype(values) or is_signed_integer_dtype(dtype):
+        elif is_signed_integer_dtype(values) and is_signed_integer_dtype(dtype):
             return _ensure_int64(values), 'int64', 'int64'
-        elif (is_unsigned_integer_dtype(values) or
+        elif (is_unsigned_integer_dtype(values) and
               is_unsigned_integer_dtype(dtype)):
             return _ensure_uint64(values), 'uint64', 'uint64'
         elif is_float_dtype(values) or is_float_dtype(dtype):

--- a/pandas/tests/test_algos.py
+++ b/pandas/tests/test_algos.py
@@ -555,6 +555,19 @@ class TestIsin(object):
         result = algos.isin(vals, empty)
         tm.assert_numpy_array_equal(expected, result)
 
+    def test_regression_issue_19356(self):
+        # Regression test for GH19356
+        l = [-9, -0.5]
+        expected = np.array([True, False])
+
+        series_float = pd.Series([-9.0, 0.0])
+        result_float = series_float.isin(l)
+        tm.assert_numpy_array_equal(expected, result_float.values)
+
+        series_int = pd.Series([-9, 0])
+        result_int = series_int.isin(l)
+        tm.assert_numpy_array_equal(expected, result_int.values)
+
 
 class TestValueCounts(object):
 

--- a/pandas/tests/test_algos.py
+++ b/pandas/tests/test_algos.py
@@ -557,16 +557,16 @@ class TestIsin(object):
 
     def test_regression_issue_19356(self):
         # Regression test for GH19356
-        l = [-9, -0.5]
+        comp_list = [1, 0.5]
         expected = np.array([True, False])
 
-        series_float = pd.Series([-9.0, 0.0])
-        result_float = series_float.isin(l)
-        tm.assert_numpy_array_equal(expected, result_float.values)
-
-        series_int = pd.Series([-9, 0])
-        result_int = series_int.isin(l)
+        series_int = pd.Series([1, 0])
+        result_int = series_int.isin(comp_list)
         tm.assert_numpy_array_equal(expected, result_int.values)
+
+        series_float = pd.Series([1.0, 0.0])
+        result_float = series_float.isin(comp_list)
+        tm.assert_numpy_array_equal(expected, result_float.values)
 
 
 class TestValueCounts(object):

--- a/pandas/tests/test_algos.py
+++ b/pandas/tests/test_algos.py
@@ -557,16 +557,17 @@ class TestIsin(object):
 
     def test_regression_issue_19356(self):
         # Regression test for GH19356
-        comp_list = [1, 0.5]
-        expected = np.array([True, False])
+        result1 = pd.Series([1, 0]).isin([1, 0.5])
+        expected1 = np.array([True, False])
+        tm.assert_numpy_array_equal(expected1, result1.values)
 
-        series_int = pd.Series([1, 0])
-        result_int = series_int.isin(comp_list)
-        tm.assert_numpy_array_equal(expected, result_int.values)
+        result2 = pd.Series([1.0, 0.0]).isin([1, 0.5])
+        expected2 = np.array([True, False])
+        tm.assert_numpy_array_equal(expected2, result2.values)
 
-        series_float = pd.Series([1.0, 0.0])
-        result_float = series_float.isin(comp_list)
-        tm.assert_numpy_array_equal(expected, result_float.values)
+        result3 = pd.Series([1, 0]).isin([1.0, 0.5])
+        expected3 = np.array([True, False])
+        tm.assert_numpy_array_equal(expected3, result3.values)
 
 
 class TestValueCounts(object):


### PR DESCRIPTION
Addresses the bug in pd.Series.isin(values) that sometimes undesirably converts the dtype of `values` to the the dtype of the series before the `isin` comparison. Here is an example where `values` is converted to `int`, and hence the output `(True, True)` is yielded, while `(True, False)` is expected:
```python
>>>  values = [1, 0.5]
>>> pd.Series([1, 0]).isin(values)
0    True
1    True
dtype: bool
```

In my understanding, the bug has two sources:

**1) L407-408 in `pandas/core/algorithms.py`**

```python
comps, dtype, _ = _ensure_data(comps)
values, _, _ = _ensure_data(values, dtype=dtype)
```
Here, first the dtype of the series (`comps`) is determined, and then `values` is forcefully converted to that dtype. This e.g. leads to the undesired conversion of the example above.

**2) L417-434 in `pandas/core/algorithms.py`**
```python
    elif is_integer_dtype(comps):
        try:
            values = values.astype('int64', copy=False)
            comps = comps.astype('int64', copy=False)
            f = lambda x, y: htable.ismember_int64(x, y)
        except (TypeError, ValueError):
            values = values.astype(object)
            comps = comps.astype(object)

    elif is_float_dtype(comps):
        try:
            values = values.astype('float64', copy=False)
            comps = comps.astype('float64', copy=False)
            checknull = isna(values).any()
            f = lambda x, y: htable.ismember_float64(x, y, checknull)
        except (TypeError, ValueError):
            values = values.astype(object)
            comps = comps.astype(object)
```
Here, if the dtype of the series (`comps`) is either `float` or `int`, a forced conversion of `values` takes place again.

The fix:
**1) L408ff**
Only force the dtype of `comps` to `values` if *both* are int-like, float-like, or datetime-like.  If not, use `_ensure_data(values)`  *without* the `dtype` argument. I tried to keep the cost of the dtype checks low by exploiting lazy evaluation.

**2) L432ff** 
Add `and` statements such that the conversion only takes place when *both* `comps` and `values` are either `float` or `int`. If they are none of the above is true, both are converted to `object` type in the `else` block. This ensures that `return f(comps, values)` works (since `f = lambda x, y: htable.ismember_object(x, values)` from L426).

- [x] fixes #19356
- [x] tests added / passed
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
