### PR TITLE
TST: Remove dupe TimdeltaIndex tests from indexes/timedeltas/test_astype.py

### DIFF
--- a/pandas/tests/indexes/timedeltas/test_astype.py
+++ b/pandas/tests/indexes/timedeltas/test_astype.py
@@ -2,36 +2,20 @@ import pytest
 
 import numpy as np
 
-import pandas as pd
 import pandas.util.testing as tm
 from pandas import (TimedeltaIndex, timedelta_range, Int64Index, Float64Index,
-                    Index, Timedelta)
-
-from ..datetimelike import DatetimeLike
+                    Index, Timedelta, NaT)
 
 
-class TestTimedeltaIndex(DatetimeLike):
-    _holder = TimedeltaIndex
+class TestTimedeltaIndex(object):
     _multiprocess_can_split_ = True
-
-    def test_numeric_compat(self):
-        # Dummy method to override super's version; this test is now done
-        # in test_arithmetic.py
-        pass
-
-    def setup_method(self, method):
-        self.indices = dict(index=tm.makeTimedeltaIndex(10))
-        self.setup_indices()
-
-    def create_index(self):
-        return pd.to_timedelta(range(5), unit='d') + pd.offsets.Hour(1)
 
     def test_astype(self):
         # GH 13149, GH 13209
-        idx = TimedeltaIndex([1e14, 'NaT', pd.NaT, np.NaN])
+        idx = TimedeltaIndex([1e14, 'NaT', NaT, np.NaN])
 
         result = idx.astype(object)
-        expected = Index([Timedelta('1 days 03:46:40')] + [pd.NaT] * 3,
+        expected = Index([Timedelta('1 days 03:46:40')] + [NaT] * 3,
                          dtype=object)
         tm.assert_index_equal(result, expected)
 
@@ -51,7 +35,7 @@ class TestTimedeltaIndex(DatetimeLike):
 
     def test_astype_timedelta64(self):
         # GH 13149, GH 13209
-        idx = TimedeltaIndex([1e14, 'NaT', pd.NaT, np.NaN])
+        idx = TimedeltaIndex([1e14, 'NaT', NaT, np.NaN])
 
         result = idx.astype('timedelta64')
         expected = Float64Index([1e+14] + [np.NaN] * 3, dtype='float64')
@@ -69,28 +53,7 @@ class TestTimedeltaIndex(DatetimeLike):
         float, 'datetime64', 'datetime64[ns]'])
     def test_astype_raises(self, dtype):
         # GH 13149, GH 13209
-        idx = TimedeltaIndex([1e14, 'NaT', pd.NaT, np.NaN])
+        idx = TimedeltaIndex([1e14, 'NaT', NaT, np.NaN])
         msg = 'Cannot cast TimedeltaIndex to dtype'
         with tm.assert_raises_regex(TypeError, msg):
             idx.astype(dtype)
-
-    def test_pickle_compat_construction(self):
-        pass
-
-    def test_shift(self):
-        # test shift for TimedeltaIndex
-        # err8083
-
-        drange = self.create_index()
-        result = drange.shift(1)
-        expected = TimedeltaIndex(['1 days 01:00:00', '2 days 01:00:00',
-                                   '3 days 01:00:00',
-                                   '4 days 01:00:00', '5 days 01:00:00'],
-                                  freq='D')
-        tm.assert_index_equal(result, expected)
-
-        result = drange.shift(3, freq='2D 1s')
-        expected = TimedeltaIndex(['6 days 01:00:03', '7 days 01:00:03',
-                                   '8 days 01:00:03', '9 days 01:00:03',
-                                   '10 days 01:00:03'], freq='D')
-        tm.assert_index_equal(result, expected)


### PR DESCRIPTION
- [X] tests added / passed
- [X] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`

Both classes in `test_astype.py` and [`test_timedelta.py`](https://github.com/pandas-dev/pandas/blob/master/pandas/tests/indexes/timedeltas/test_timedelta.py#L19) inherit from `DatetimeLike`, which in turn [inherits from `Base`](https://github.com/pandas-dev/pandas/blob/master/pandas/tests/indexes/datetimelike.py#L9), leading to 200+ dupe tests being run.

Modified `test_astype.py` to inherit from `object` instead, removed some unnecessary boilerplate, and removed some additional tests that were specified to override base class tests.
