### PR TITLE
Spellcheck of enhancingperf.rst

### DIFF
--- a/doc/source/enhancingperf.rst
+++ b/doc/source/enhancingperf.rst
@@ -414,7 +414,7 @@ prefer that Numba throw an error if it cannot compile a function in a way that
 speeds up your code, pass Numba the argument 
 ``nopython=True`` (e.g.  ``@numba.jit(nopython=True)``). For more on 
 troubleshooting Numba modes, see the `Numba troubleshooting page 
-<http://numba.pydata.org/numba-doc/0.20.0/user/troubleshoot.html#the-compiled-code-is-too-slow>`__.
+<http://numba.pydata.org/numba-doc/latest/user/troubleshoot.html#the-compiled-code-is-too-slow>`__.
 
 Read more in the `Numba docs <http://numba.pydata.org/>`__.
 

--- a/doc/source/enhancingperf.rst
+++ b/doc/source/enhancingperf.rst
@@ -29,20 +29,20 @@ computationally heavy applications however, it can be possible to achieve sizeab
 speed-ups by offloading work to `cython <http://cython.org/>`__.
 
 This tutorial assumes you have refactored as much as possible in Python, for example
-trying to remove for loops and making use of NumPy vectorization, it's always worth
+by trying to remove for-loops and making use of NumPy vectorization. It's always worth
 optimising in Python first.
 
 This tutorial walks through a "typical" process of cythonizing a slow computation.
 We use an `example from the cython documentation <http://docs.cython.org/src/quickstart/cythonize.html>`__
 but in the context of pandas. Our final cythonized solution is around 100 times
-faster than the pure Python.
+faster than the pure Python solution.
 
 .. _enhancingperf.pure:
 
 Pure python
 ~~~~~~~~~~~
 
-We have a DataFrame to which we want to apply a function row-wise.
+We have a ``DataFrame`` to which we want to apply a function row-wise.
 
 .. ipython:: python
 
@@ -214,8 +214,8 @@ the rows, applying our ``integrate_f_typed``, and putting this in the zeros arra
 
    You can **not pass** a ``Series`` directly as a ``ndarray`` typed parameter
    to a cython function. Instead pass the actual ``ndarray`` using the
-   ``.values`` attribute of the Series. The reason is that the cython
-   definition is specific to an ndarray and not the passed Series.
+   ``.values`` attribute of the ``Series``. The reason is that the cython
+   definition is specific to an ndarray and not the passed ``Series``.
 
    So, do not do this:
 
@@ -223,7 +223,7 @@ the rows, applying our ``integrate_f_typed``, and putting this in the zeros arra
 
         apply_integrate_f(df['a'], df['b'], df['N'])
 
-   But rather, use ``.values`` to get the underlying ``ndarray``
+   But rather, use ``.values`` to get the underlying ``ndarray``:
 
    .. code-block:: python
 
@@ -291,7 +291,8 @@ advanced cython techniques:
 
 Even faster, with the caveat that a bug in our cython code (an off-by-one error,
 for example) might cause a segfault because memory access isn't checked.
-
+For more about ``boundscheck`` and ``wraparound``, see the Cython docs on 
+`compiler directives <http://cython.readthedocs.io/en/latest/src/reference/compilation.html?highlight=wraparound#compiler-directives>`__.
 
 .. _enhancingperf.numba:
 
@@ -315,7 +316,8 @@ Numba works by generating optimized machine code using the LLVM compiler infrast
 Jit
 ~~~
 
-Using ``numba`` to just-in-time compile your code. We simply take the plain Python code from above and annotate with the ``@jit`` decorator.
+We demonstrate how to use ``numba`` to just-in-time compile our code. We simply 
+take the plain Python code from above and annotate with the ``@jit`` decorator.
 
 .. code-block:: python
 
@@ -346,12 +348,14 @@ Using ``numba`` to just-in-time compile your code. We simply take the plain Pyth
        result = apply_integrate_f_numba(df['a'].values, df['b'].values, df['N'].values)
        return pd.Series(result, index=df.index, name='result')
 
-Note that we directly pass ``numpy`` arrays to the numba function. ``compute_numba`` is just a wrapper that provides a nicer interface by passing/returning pandas objects.
+Note that we directly pass ``numpy`` arrays to the Numba function. ``compute_numba`` is just a wrapper that provides a nicer interface by passing/returning pandas objects.
 
 .. code-block:: ipython
 
     In [4]: %timeit compute_numba(df)
     1000 loops, best of 3: 798 us per loop
+
+In this example, using Numba was faster than Cython.
 
 Vectorize
 ~~~~~~~~~
@@ -448,7 +452,7 @@ These operations are supported by :func:`pandas.eval`:
 - Attribute access, e.g., ``df.a``
 - Subscript expressions, e.g., ``df[0]``
 - Simple variable evaluation, e.g., ``pd.eval('df')`` (this is not very useful)
-- Math functions, `sin`, `cos`, `exp`, `log`, `expm1`, `log1p`,
+- Math functions: `sin`, `cos`, `exp`, `log`, `expm1`, `log1p`,
   `sqrt`, `sinh`, `cosh`, `tanh`, `arcsin`, `arccos`, `arctan`, `arccosh`,
   `arcsinh`, `arctanh`, `abs` and `arctan2`.
 
@@ -581,7 +585,7 @@ on the original ``DataFrame`` or return a copy with the new column.
    For backwards compatibility, ``inplace`` defaults to ``True`` if not
    specified. This will change in a future version of pandas - if your
    code depends on an inplace assignment you should update to explicitly
-   set ``inplace=True``
+   set ``inplace=True``.
 
 .. ipython:: python
 

--- a/doc/source/enhancingperf.rst
+++ b/doc/source/enhancingperf.rst
@@ -33,7 +33,7 @@ by trying to remove for-loops and making use of NumPy vectorization. It's always
 optimising in Python first.
 
 This tutorial walks through a "typical" process of cythonizing a slow computation.
-We use an `example from the cython documentation <http://docs.cython.org/src/quickstart/cythonize.html>`__
+We use an `example from the Cython documentation <http://docs.cython.org/src/quickstart/cythonize.html>`__
 but in the context of pandas. Our final cythonized solution is around 100 times
 faster than the pure Python solution.
 
@@ -91,10 +91,10 @@ hence we'll concentrate our efforts cythonizing these two functions.
 
 .. _enhancingperf.plain:
 
-Plain cython
+Plain Cython
 ~~~~~~~~~~~~
 
-First we're going to need to import the cython magic function to ipython:
+First we're going to need to import the Cython magic function to ipython:
 
 .. ipython:: python
    :okwarning:
@@ -102,7 +102,7 @@ First we're going to need to import the cython magic function to ipython:
    %load_ext Cython
 
 
-Now, let's simply copy our functions over to cython as is (the suffix
+Now, let's simply copy our functions over to Cython as is (the suffix
 is here to distinguish between function versions):
 
 .. ipython::
@@ -177,7 +177,7 @@ in Python, so maybe we could minimize these by cythonizing the apply part.
 
 .. note::
 
-  We are now passing ndarrays into the cython function, fortunately cython plays
+  We are now passing ndarrays into the Cython function, fortunately Cython plays
   very nicely with numpy.
 
 .. ipython::
@@ -213,8 +213,8 @@ the rows, applying our ``integrate_f_typed``, and putting this in the zeros arra
 .. warning::
 
    You can **not pass** a ``Series`` directly as a ``ndarray`` typed parameter
-   to a cython function. Instead pass the actual ``ndarray`` using the
-   ``.values`` attribute of the ``Series``. The reason is that the cython
+   to a Cython function. Instead pass the actual ``ndarray`` using the
+   ``.values`` attribute of the ``Series``. The reason is that the Cython
    definition is specific to an ndarray and not the passed ``Series``.
 
    So, do not do this:
@@ -255,7 +255,7 @@ More advanced techniques
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
 There is still hope for improvement. Here's an example of using some more
-advanced cython techniques:
+advanced Cython techniques:
 
 .. ipython::
 
@@ -289,7 +289,7 @@ advanced cython techniques:
    In [4]: %timeit apply_integrate_f_wrap(df['a'].values, df['b'].values, df['N'].values)
    1000 loops, best of 3: 987 us per loop
 
-Even faster, with the caveat that a bug in our cython code (an off-by-one error,
+Even faster, with the caveat that a bug in our Cython code (an off-by-one error,
 for example) might cause a segfault because memory access isn't checked.
 For more about ``boundscheck`` and ``wraparound``, see the Cython docs on 
 `compiler directives <http://cython.readthedocs.io/en/latest/src/reference/compilation.html?highlight=wraparound#compiler-directives>`__.
@@ -299,7 +299,7 @@ For more about ``boundscheck`` and ``wraparound``, see the Cython docs on
 Using numba
 -----------
 
-A recent alternative to statically compiling cython code, is to use a *dynamic jit-compiler*, ``numba``.
+A recent alternative to statically compiling Cython code, is to use a *dynamic jit-compiler*, ``numba``.
 
 Numba gives you the power to speed up your applications with high performance functions written directly in Python. With a few annotations, array-oriented and math-heavy Python code can be just-in-time compiled to native machine instructions, similar in performance to C, C++ and Fortran, without having to switch languages or Python interpreters.
 

--- a/doc/source/sparse.rst
+++ b/doc/source/sparse.rst
@@ -17,11 +17,11 @@ Sparse data structures
 
 .. note:: The ``SparsePanel`` class has been removed in 0.19.0
 
-We have implemented "sparse" versions of Series and DataFrame. These are not sparse
+We have implemented "sparse" versions of ``Series`` and ``DataFrame``. These are not sparse
 in the typical "mostly 0". Rather, you can view these objects as being "compressed"
 where any data matching a specific value (``NaN`` / missing value, though any value
 can be chosen) is omitted. A special ``SparseIndex`` object tracks where data has been
-"sparsified". This will make much more sense in an example. All of the standard pandas
+"sparsified". This will make much more sense with an example. All of the standard pandas
 data structures have a ``to_sparse`` method:
 
 .. ipython:: python
@@ -32,7 +32,7 @@ data structures have a ``to_sparse`` method:
    sts
 
 The ``to_sparse`` method takes a ``kind`` argument (for the sparse index, see
-below) and a ``fill_value``. So if we had a mostly zero Series, we could
+below) and a ``fill_value``. So if we had a mostly zero ``Series``, we could
 convert it to sparse with ``fill_value=0``:
 
 .. ipython:: python
@@ -40,7 +40,7 @@ convert it to sparse with ``fill_value=0``:
    ts.fillna(0).to_sparse(fill_value=0)
 
 The sparse objects exist for memory efficiency reasons. Suppose you had a
-large, mostly NA DataFrame:
+large, mostly NA ``DataFrame``:
 
 .. ipython:: python
 


### PR DESCRIPTION
Spellcheck of the docs, mostly `enhancingperf.rst`, and a sentence or two on `sparse.rst`.

* Added a short introductory paragraph on enhancing performance.
* Backticks ` `` ` around Series, DataFrame.
* Typeset variants of ` ``numba`` `, `(n|N)umba`, `(c|C)ython`, etc as **Numba** and **Cython**.
* Minor rephrasing of sentences, spelling, periods, colons etc.

Cheers. Comments very welcome :)
