### PR TITLE
RFC/DOC: Standardize the column index type

### DIFF
--- a/doc/source/developer.rst
+++ b/doc/source/developer.rst
@@ -40,7 +40,7 @@ where ``KeyValue`` is
    }
 
 So that a ``pandas.DataFrame`` can be faithfully reconstructed, we store a
-``pandas`` metadata key in the ``FileMetaData`` with the value stored as :
+``pandas`` metadata key in the ``FileMetaData`` with the the value stored as:
 
 .. code-block:: text
 
@@ -58,6 +58,18 @@ for each column. This has JSON form:
     'pandas_type': pandas_type,
     'numpy_type': numpy_type,
     'metadata': metadata}
+
+.. note::
+
+   Column names will be serialized using whatever type ``six.text_type``
+   corresponds to.
+
+   In Python 2, ``six.text_type`` is the ``unicode`` type, in Python 3 this is
+   the ``str`` type. Both of these types support Unicode column names.
+
+   This means that whatever the types of the column indexes are going into a
+   parquet file, they will *always* come out as unicode (in Python 2) or str
+   (in Python 3).
 
 ``pandas_type`` is the logical type of the column, and is one of:
 

--- a/doc/source/developer.rst
+++ b/doc/source/developer.rst
@@ -71,6 +71,9 @@ for each column. This has JSON form:
    parquet file, they will *always* come out as unicode (in Python 2) or str
    (in Python 3).
 
+   If the column name is a subclass of or equal to ``six.binary_type``, it will
+   be decoded into a UTF-8 string.
+
 ``pandas_type`` is the logical type of the column, and is one of:
 
 * Boolean: ``'bool'``


### PR DESCRIPTION
In [ARROW-1976](https://issues.apache.org/jira/browse/ARROW-1976) a user hit
an issue with serialization of unicode column index values using Python 2.

This PR proproses to make all column names into whatever the type of
`six.text_type` is, therefore handling Unicode in as uniform a way as possible
given the terrible state of Unicode in Python 2.

cc @wesm @TomAugspurger @jorisvandenbossche

I considered doing this by adding another field to indicate the individual type of the name, but that adds quite a bit of technical debt and backwards incompatibility. Since `json.loads`/`json.dumps` can read unicode strings across Pythons, this seemed like a backwards compatible way to support unicode column names across files written in different versions of Python (and pyarrow).