### PR TITLE
Remove unused calendar options from period_helper

### DIFF
--- a/pandas/_libs/src/period_helper.h
+++ b/pandas/_libs/src/period_helper.h
@@ -24,9 +24,6 @@ frequency conversion routines.
  * declarations from period here
  */
 
-#define GREGORIAN_CALENDAR 0
-#define JULIAN_CALENDAR 1
-
 #define SECONDS_PER_DAY ((double)86400.0)
 
 #define Py_AssertWithArg(x, errortype, errorstr, a1) \
@@ -138,7 +135,6 @@ typedef struct date_info {
     int year;
     int day_of_week;
     int day_of_year;
-    int calendar;
 } date_info;
 
 typedef npy_int64 (*freq_conv_func)(npy_int64, char, asfreq_info *);

--- a/pandas/_libs/tslibs/period.pyx
+++ b/pandas/_libs/tslibs/period.pyx
@@ -59,7 +59,6 @@ cdef extern from "period_helper.h":
         int year
         int day_of_week
         int day_of_year
-        int calendar
 
     ctypedef struct asfreq_info:
         int from_week_end


### PR DESCRIPTION
period_helper supports GREGORIAN_CALENDAR and JULIAN_CALENDAR, but only Gregorian is ever used.  This removes that argument, which will allow for the following in follow-ups:

- Remove a bunch of error checking and propogation boilerplate.
- Get a a bunch of functions from datetime/np_datetime.h instead of re-implementing them in period_helper.
- Do the same removals to simplify #19498 