### PR TITLE
TST/CLN: Remove legacy instances of _multiprocess_can_split_ in tests

### DIFF
--- a/pandas/tests/frame/test_apply.py
+++ b/pandas/tests/frame/test_apply.py
@@ -496,8 +496,6 @@ def zip_frames(*frames):
 
 class TestDataFrameAggregate(TestData):
 
-    _multiprocess_can_split_ = True
-
     def test_agg_transform(self):
 
         with np.errstate(all='ignore'):

--- a/pandas/tests/indexes/period/test_period.py
+++ b/pandas/tests/indexes/period/test_period.py
@@ -14,7 +14,6 @@ from ..datetimelike import DatetimeLike
 
 class TestPeriodIndex(DatetimeLike):
     _holder = PeriodIndex
-    _multiprocess_can_split_ = True
 
     def setup_method(self, method):
         self.indices = dict(index=tm.makePeriodIndex(10),

--- a/pandas/tests/indexes/timedeltas/test_astype.py
+++ b/pandas/tests/indexes/timedeltas/test_astype.py
@@ -8,7 +8,6 @@ from pandas import (TimedeltaIndex, timedelta_range, Int64Index, Float64Index,
 
 
 class TestTimedeltaIndex(object):
-    _multiprocess_can_split_ = True
 
     def test_astype(self):
         # GH 13149, GH 13209

--- a/pandas/tests/indexes/timedeltas/test_construction.py
+++ b/pandas/tests/indexes/timedeltas/test_construction.py
@@ -9,7 +9,6 @@ from pandas import TimedeltaIndex, timedelta_range, to_timedelta
 
 
 class TestTimedeltaIndex(object):
-    _multiprocess_can_split_ = True
 
     def test_construction_base_constructor(self):
         arr = [pd.Timedelta('1 days'), pd.NaT, pd.Timedelta('3 days')]

--- a/pandas/tests/indexes/timedeltas/test_indexing.py
+++ b/pandas/tests/indexes/timedeltas/test_indexing.py
@@ -9,7 +9,6 @@ from pandas import TimedeltaIndex, timedelta_range, compat, Index, Timedelta
 
 
 class TestTimedeltaIndex(object):
-    _multiprocess_can_split_ = True
 
     def test_insert(self):
 

--- a/pandas/tests/indexes/timedeltas/test_ops.py
+++ b/pandas/tests/indexes/timedeltas/test_ops.py
@@ -420,7 +420,6 @@ dtype: timedelta64[ns]"""
 
 
 class TestTimedeltas(object):
-    _multiprocess_can_split_ = True
 
     def test_timedelta_ops(self):
         # GH4984

--- a/pandas/tests/indexes/timedeltas/test_setops.py
+++ b/pandas/tests/indexes/timedeltas/test_setops.py
@@ -6,7 +6,6 @@ from pandas import TimedeltaIndex, timedelta_range, Int64Index
 
 
 class TestTimedeltaIndex(object):
-    _multiprocess_can_split_ = True
 
     def test_union(self):
 

--- a/pandas/tests/indexes/timedeltas/test_timedelta.py
+++ b/pandas/tests/indexes/timedeltas/test_timedelta.py
@@ -18,7 +18,6 @@ randn = np.random.randn
 
 class TestTimedeltaIndex(DatetimeLike):
     _holder = TimedeltaIndex
-    _multiprocess_can_split_ = True
 
     def setup_method(self, method):
         self.indices = dict(index=tm.makeTimedeltaIndex(10))
@@ -300,7 +299,6 @@ class TestTimedeltaIndex(DatetimeLike):
 
 
 class TestTimeSeries(object):
-    _multiprocess_can_split_ = True
 
     def test_series_box_timedelta(self):
         rng = timedelta_range('1 day 1 s', periods=5, freq='h')

--- a/pandas/tests/indexes/timedeltas/test_timedelta_range.py
+++ b/pandas/tests/indexes/timedeltas/test_timedelta_range.py
@@ -7,7 +7,6 @@ from pandas.util.testing import assert_frame_equal
 
 
 class TestTimedeltas(object):
-    _multiprocess_can_split_ = True
 
     def test_timedelta_range(self):
 

--- a/pandas/tests/indexes/timedeltas/test_tools.py
+++ b/pandas/tests/indexes/timedeltas/test_tools.py
@@ -11,7 +11,6 @@ from pandas._libs.tslib import iNaT
 
 
 class TestTimedeltas(object):
-    _multiprocess_can_split_ = True
 
     def test_to_timedelta(self):
         def conv(v):

--- a/pandas/tests/scalar/test_timedelta.py
+++ b/pandas/tests/scalar/test_timedelta.py
@@ -13,7 +13,6 @@ from pandas._libs.tslib import iNaT, NaT
 
 
 class TestTimedeltaArithmetic(object):
-    _multiprocess_can_split_ = True
 
     def test_arithmetic_overflow(self):
         with pytest.raises(OverflowError):
@@ -286,7 +285,6 @@ class TestTimedeltaComparison(object):
 
 
 class TestTimedeltas(object):
-    _multiprocess_can_split_ = True
 
     def setup_method(self, method):
         pass

--- a/pandas/tests/series/test_apply.py
+++ b/pandas/tests/series/test_apply.py
@@ -164,8 +164,6 @@ class TestSeriesApply(TestData):
 
 class TestSeriesAggregate(TestData):
 
-    _multiprocess_can_split_ = True
-
     def test_transform(self):
         # transforming functions
 


### PR DESCRIPTION
- [X] closes #19532
- [X] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`

xref https://github.com/pandas-dev/pandas/pull/19509#discussion_r165848506