### PR TITLE
PERF: improve get_loc on unsorted, non-unique indexes

### DIFF
--- a/doc/source/whatsnew/v0.23.0.txt
+++ b/doc/source/whatsnew/v0.23.0.txt
@@ -1063,6 +1063,7 @@ Performance Improvements
 - Improved performance of :func:`DataFrame.median` with ``axis=1`` when bottleneck is not installed (:issue:`16468`)
 - Improved performance of :func:`MultiIndex.get_loc` for large indexes, at the cost of a reduction in performance for small ones (:issue:`18519`)
 - Improved performance of :func:`MultiIndex.remove_unused_levels` when there are no unused levels, at the cost of a reduction in performance when there are (:issue:`19289`)
+- Improved performance of :func:`Index.get_loc` for non-unique indexes (:issue:`19478`)
 - Improved performance of pairwise ``.rolling()`` and ``.expanding()`` with ``.cov()`` and ``.corr()`` operations (:issue:`17917`)
 - Improved performance of :func:`pandas.core.groupby.GroupBy.rank` (:issue:`15779`)
 - Improved performance of variable ``.rolling()`` on ``.min()`` and ``.max()`` (:issue:`19521`)

--- a/pandas/_libs/index.pyx
+++ b/pandas/_libs/index.pyx
@@ -194,7 +194,7 @@ cdef class IndexEngine:
         if count > 1:
             return indexer
         if count == 1:
-            return found[0]
+            return int(found[0])
 
         raise KeyError(val)
 

--- a/pandas/_libs/index.pyx
+++ b/pandas/_libs/index.pyx
@@ -183,32 +183,20 @@ cdef class IndexEngine:
 
     cdef _maybe_get_bool_indexer(self, object val):
         cdef:
-            ndarray[uint8_t] indexer
-            ndarray[object] values
-            int count = 0
-            Py_ssize_t i, n
-            int last_true
+            ndarray[cnp.uint8_t, ndim=1, cast=True] indexer
+            ndarray[int64_t, ndim=1] found
+            int count
 
-        values = np.array(self._get_index_values(), copy=False)
-        n = len(values)
+        indexer = self._get_index_values() == val
+        found = np.where(indexer)[0]
+        count = len(found)
 
-        result = np.empty(n, dtype=bool)
-        indexer = result.view(np.uint8)
-
-        for i in range(n):
-            if values[i] == val:
-                count += 1
-                indexer[i] = 1
-                last_true = i
-            else:
-                indexer[i] = 0
-
-        if count == 0:
-            raise KeyError(val)
+        if count > 1:
+            return indexer
         if count == 1:
-            return last_true
+            return found[0]
 
-        return result
+        raise KeyError(val)
 
     def sizeof(self, deep=False):
         """ return the sizeof our mapping """
@@ -541,9 +529,6 @@ cdef class PeriodEngine(Int64Engine):
         ordinal_array = np.asarray(ordinal)
 
         return super(PeriodEngine, self).get_indexer_non_unique(ordinal_array)
-
-    cdef _get_index_values_for_bool_indexer(self):
-        return self._get_index_values().view('i8')
 
 
 cpdef convert_scalar(ndarray arr, object value):

--- a/pandas/_libs/index_class_helper.pxi.in
+++ b/pandas/_libs/index_class_helper.pxi.in
@@ -74,7 +74,7 @@ cdef class {{name}}Engine(IndexEngine):
         if count > 1:
             return indexer
         if count == 1:
-            return found[0]
+            return int(found[0])
 
         raise KeyError(val)
 

--- a/pandas/_libs/index_class_helper.pxi.in
+++ b/pandas/_libs/index_class_helper.pxi.in
@@ -55,40 +55,29 @@ cdef class {{name}}Engine(IndexEngine):
 
     cdef _maybe_get_bool_indexer(self, object val):
         cdef:
-            ndarray[uint8_t, cast=True] indexer
+            ndarray[cnp.uint8_t, ndim=1, cast=True] indexer
+            ndarray[int64_t, ndim=1] found
             ndarray[{{ctype}}] values
             int count = 0
-            Py_ssize_t i, n
-            int last_true
 
         {{if name != 'Float64'}}
         if not util.is_integer_object(val):
             raise KeyError(val)
         {{endif}}
 
-        values = self._get_index_values_for_bool_indexer()
-        n = len(values)
+        # A view is needed for some subclasses, such as PeriodEngine:
+        values = self._get_index_values().view('{{dtype}}')
+        indexer = values == val
+        found = np.where(indexer)[0]
+        count = len(found)
 
-        result = np.empty(n, dtype=bool)
-        indexer = result.view(np.uint8)
-
-        for i in range(n):
-            if values[i] == val:
-                count += 1
-                indexer[i] = 1
-                last_true = i
-            else:
-                indexer[i] = 0
-
-        if count == 0:
-            raise KeyError(val)
+        if count > 1:
+            return indexer
         if count == 1:
-            return last_true
+            return found[0]
 
-        return result
+        raise KeyError(val)
 
-    cdef _get_index_values_for_bool_indexer(self):
-        return self._get_index_values()
     {{endif}}
 
 {{endfor}}


### PR DESCRIPTION
- [x] closes #19478
- [x] tests passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry

asv run:
```
     [bd4332f4]       [9ac7be34]
-         475±5μs          422±7μs     0.89  multiindex_object.Duplicates.time_remove_unused_levels
-      15.4±0.3ms       13.5±0.2ms     0.88  multiindex_object.GetLoc.time_small_get_loc_warm
-         197±5ns          171±2ns     0.87  index_object.Datetime.time_is_dates_only
-      8.68±0.3μs       6.88±0.1μs     0.79  index_object.Float64IndexMethod.time_get_loc
-          15.4μs       12.0±0.2μs     0.78  index_object.Indexing.time_get_loc_sorted('Float')
-         283±9μs          215±2μs     0.76  multiindex_object.Values.time_datetime_level_values_sliced
-          15.0μs           11.1μs     0.74  index_object.Indexing.time_get_loc('Float')
-     7.38±0.04μs      5.03±0.05μs     0.68  index_object.Indexing.time_get_loc_sorted('Int')
-     7.15±0.04μs      4.58±0.04μs     0.64  index_object.Indexing.time_get_loc('Int')
-       121±0.9ms           1.62ms     0.01  index_object.Indexing.time_get_loc_non_unique_sorted('Float')
-           136ms           1.51ms     0.01  index_object.Indexing.time_get_loc_non_unique('Float')
-         166±1ms      1.29±0.03ms     0.01  index_object.Indexing.time_get_loc_non_unique_sorted('Int')
-       175±0.9ms      1.29±0.01ms     0.01  index_object.Indexing.time_get_loc_non_unique('Int')

SOME BENCHMARKS HAVE CHANGED SIGNIFICANTLY.
```