### PR TITLE
DEPR/CLN: fix from_items deprecation warnings

### DIFF
--- a/pandas/tests/groupby/aggregate/test_other.py
+++ b/pandas/tests/groupby/aggregate/test_other.py
@@ -7,6 +7,7 @@ test all other .agg behavior
 from __future__ import print_function
 
 import pytest
+from collections import OrderedDict
 
 import datetime as dt
 from functools import partial
@@ -81,7 +82,7 @@ def test_agg_period_index():
     s1 = Series(np.random.rand(len(index)), index=index)
     s2 = Series(np.random.rand(len(index)), index=index)
     series = [('s1', s1), ('s2', s2)]
-    df = DataFrame.from_items(series)
+    df = DataFrame.from_dict(OrderedDict(series))
     grouped = df.groupby(df.index.month)
     list(grouped)
 

--- a/pandas/tests/reshape/test_reshape.py
+++ b/pandas/tests/reshape/test_reshape.py
@@ -3,6 +3,7 @@
 
 from warnings import catch_warnings
 import pytest
+from collections import OrderedDict
 
 from pandas import DataFrame, Series
 import pandas as pd
@@ -457,7 +458,8 @@ class TestGetDummies(object):
     @pytest.mark.parametrize('sparse', [True, False])
     def test_get_dummies_dont_sparsify_all_columns(self, sparse):
         # GH18914
-        df = DataFrame.from_items([('GDP', [1, 2]), ('Nation', ['AB', 'CD'])])
+        df = DataFrame.from_dict(OrderedDict([('GDP', [1, 2]),
+                                              ('Nation', ['AB', 'CD'])]))
         df = get_dummies(df, columns=['Nation'], sparse=sparse)
         df2 = df.reindex(columns=['GDP'])
 


### PR DESCRIPTION
xref #18529 

Replacing some cases of the deprecated ``from_items`` with ``from_dict(OrderedDict())``