### PR TITLE
Ignore warnings when reading pickle files

### DIFF
--- a/pandas/io/pickle.py
+++ b/pandas/io/pickle.py
@@ -97,7 +97,8 @@ def read_pickle(path, compression='infer'):
         # cpickle
         # GH 6899
         try:
-            with warnings.simplefilter('ignore'):
+            with warnings.catch_warnings():
+                warnings.simplefilter('ignore')
                 return read_wrapper(lambda f: pkl.load(f))
         except Exception:
             # reg/patched pickle

--- a/pandas/io/pickle.py
+++ b/pandas/io/pickle.py
@@ -1,4 +1,5 @@
 """ pickle compat """
+import warnings
 
 import numpy as np
 from numpy.lib.format import read_array, write_array
@@ -96,7 +97,8 @@ def read_pickle(path, compression='infer'):
         # cpickle
         # GH 6899
         try:
-            return read_wrapper(lambda f: pkl.load(f))
+            with warnings.simplefilter('ignore'):
+                return read_wrapper(lambda f: pkl.load(f))
         except Exception:
             # reg/patched pickle
             try:

--- a/pandas/io/pickle.py
+++ b/pandas/io/pickle.py
@@ -97,8 +97,8 @@ def read_pickle(path, compression='infer'):
         # cpickle
         # GH 6899
         try:
-            with warnings.catch_warnings():
-                warnings.simplefilter('ignore')
+            with warnings.catch_warnings(record=True):
+                # We want to silencce any warnings about, e.g. moved modules.
                 return read_wrapper(lambda f: pkl.load(f))
         except Exception:
             # reg/patched pickle


### PR DESCRIPTION
Silences a warning from our tests about

```
pandas/tests/io/test_common.py::TestCommonIOCapabilities::()::test_read_fspath_all[reader10-os-/home/travis/build/pandas-dev/pandas/pandas/tests/io/data/categorical_0_14_1.pickle]
  /home/travis/build/pandas-dev/pandas/pandas/io/pickle.py:99: FutureWarning: 'pandas.core' is private. Use 'pandas.Categorical'
    return read_wrapper(lambda f: pkl.load(f))
```