### PR TITLE
ENH: Allow literal (non-regex) replacement using .str.replace #16808

### DIFF
--- a/doc/source/text.rst
+++ b/doc/source/text.rst
@@ -118,8 +118,8 @@ i.e., from the end of the string to the beginning of the string:
 
    s2.str.rsplit('_', expand=True, n=1)
 
-Methods like ``replace`` and ``findall`` take `regular expressions
-<https://docs.python.org/3/library/re.html>`__, too:
+``replace`` by default replaces `regular expressions
+<https://docs.python.org/3/library/re.html>`__:
 
 .. ipython:: python
 
@@ -146,11 +146,24 @@ following code will cause trouble because of the regular expression meaning of
    # We need to escape the special character (for >1 len patterns)
    dollars.str.replace(r'-\$', '-')
 
+.. versionadded:: 0.23.0
+
+If you do want literal replacement of a string (equivalent to
+:meth:`str.replace`), you can set the optional ``regex`` parameter to
+``False``, rather than escaping each character. In this case both ``pat``
+and ``repl`` must be strings:
+
+.. ipython:: python
+
+    # These lines are equivalent
+    dollars.str.replace(r'-\$', '-')
+    dollars.str.replace('-$', '-', regex=False)  
+
+.. versionadded:: 0.20.0
+
 The ``replace`` method can also take a callable as replacement. It is called
 on every ``pat`` using :func:`re.sub`. The callable should expect one
 positional argument (a regex object) and return a string.
-
-.. versionadded:: 0.20.0
 
 .. ipython:: python
 
@@ -164,11 +177,11 @@ positional argument (a regex object) and return a string.
    repl = lambda m: m.group('two').swapcase()
    pd.Series(['Foo Bar Baz', np.nan]).str.replace(pat, repl)
 
+.. versionadded:: 0.20.0
+
 The ``replace`` method also accepts a compiled regular expression object
 from :func:`re.compile` as a pattern. All flags should be included in the
 compiled regular expression object.
-
-.. versionadded:: 0.20.0
 
 .. ipython:: python
 
@@ -185,6 +198,7 @@ regular expression object will raise a ``ValueError``.
     In [1]: s3.str.replace(regex_pat, 'XX-XX ', flags=re.IGNORECASE)
     ---------------------------------------------------------------------------
     ValueError: case and flags cannot be set when pat is a compiled regex
+
 
 Indexing with ``.str``
 ----------------------
@@ -432,7 +446,7 @@ Method Summary
     :meth:`~Series.str.join`;Join strings in each element of the Series with passed separator
     :meth:`~Series.str.get_dummies`;Split strings on the delimiter returning DataFrame of dummy variables
     :meth:`~Series.str.contains`;Return boolean array if each string contains pattern/regex
-    :meth:`~Series.str.replace`;Replace occurrences of pattern/regex with some other string or the return value of a callable given the occurrence
+    :meth:`~Series.str.replace`;Replace occurrences of pattern/regex/string with some other string or the return value of a callable given the occurrence
     :meth:`~Series.str.repeat`;Duplicate values (``s.str.repeat(3)`` equivalent to ``x * 3``)
     :meth:`~Series.str.pad`;"Add whitespace to left, right, or both sides of strings"
     :meth:`~Series.str.center`;Equivalent to ``str.center``

--- a/doc/source/text.rst
+++ b/doc/source/text.rst
@@ -157,7 +157,7 @@ and ``repl`` must be strings:
 
     # These lines are equivalent
     dollars.str.replace(r'-\$', '-')
-    dollars.str.replace('-$', '-', regex=False)  
+    dollars.str.replace('-$', '-', regex=False)
 
 .. versionadded:: 0.20.0
 

--- a/doc/source/whatsnew/v0.23.0.txt
+++ b/doc/source/whatsnew/v0.23.0.txt
@@ -620,6 +620,7 @@ Other API Changes
 - Set operations (union, difference...) on :class:`IntervalIndex` with incompatible index types will now raise a ``TypeError`` rather than a ``ValueError`` (:issue:`19329`)
 - :class:`DateOffset` objects render more simply, e.g. ``<DateOffset: days=1>`` instead of ``<DateOffset: kwds={'days': 1}>`` (:issue:`19403`)
 - ``Categorical.fillna`` now validates its ``value`` and ``method`` keyword arguments. It now raises when both or none are specified, matching the behavior of :meth:`Series.fillna` (:issue:`19682`)
+- :func:`Series.str.replace` now takes an optional `regex` keyword which, when set to ``False``, uses literal string replacement rather than regex replacement (:issue:`16808`) 
 
 .. _whatsnew_0230.deprecations:
 

--- a/doc/source/whatsnew/v0.23.0.txt
+++ b/doc/source/whatsnew/v0.23.0.txt
@@ -620,7 +620,7 @@ Other API Changes
 - Set operations (union, difference...) on :class:`IntervalIndex` with incompatible index types will now raise a ``TypeError`` rather than a ``ValueError`` (:issue:`19329`)
 - :class:`DateOffset` objects render more simply, e.g. ``<DateOffset: days=1>`` instead of ``<DateOffset: kwds={'days': 1}>`` (:issue:`19403`)
 - ``Categorical.fillna`` now validates its ``value`` and ``method`` keyword arguments. It now raises when both or none are specified, matching the behavior of :meth:`Series.fillna` (:issue:`19682`)
-- :func:`Series.str.replace` now takes an optional `regex` keyword which, when set to ``False``, uses literal string replacement rather than regex replacement (:issue:`16808`) 
+- :func:`Series.str.replace` now takes an optional `regex` keyword which, when set to ``False``, uses literal string replacement rather than regex replacement (:issue:`16808`)
 
 .. _whatsnew_0230.deprecations:
 

--- a/pandas/core/strings.py
+++ b/pandas/core/strings.py
@@ -368,7 +368,8 @@ def str_replace(arr, pat, repl, n=-1, case=None, flags=0, regex=True):
 
     When `pat` is a string and `regex` is True, the given `pat` is compiled
     as a regex. When `repl` is a string, it replaces matching regex patterns
-    literally as with :meth:`re.sub`:
+    as with :meth:`re.sub`:
+
     >>> pd.Series(['foo', 'fuz', np.nan]).str.replace('f.', 'ba', regex=True)
     0    bao
     1    baz

--- a/pandas/core/strings.py
+++ b/pandas/core/strings.py
@@ -348,6 +348,13 @@ def str_replace(arr, pat, repl, n=-1, case=None, flags=0, regex=True):
     -------
     replaced : Series/Index of objects
 
+    Raises
+    ------
+    ValueError
+        * if `regex` is False and `repl` is a callable or `pat` is a compiled
+          regex
+        * if `pat` is a compiled regex and `case` or `flags` is set
+
     Notes
     -----
     When `pat` is a compiled regex, all flags should be included in the
@@ -415,12 +422,6 @@ def str_replace(arr, pat, repl, n=-1, case=None, flags=0, regex=True):
     2    NaN
     dtype: object
 
-    Raises
-    ------
-    ValueError
-        * if `regex` is False and `repl` is a callable or `pat` is a compiled
-          regex
-        * if `pat` is a compiled regex and `case` or `flags` is set
     """
 
     # Check whether repl is valid (GH 13438, GH 15055)

--- a/pandas/core/strings.py
+++ b/pandas/core/strings.py
@@ -356,23 +356,23 @@ def str_replace(arr, pat, repl, n=-1, case=None, flags=0, regex=True):
 
     Examples
     --------
-    When `pat` is a string and `regex` is False, every `pat` is replaced with
-    `repl` as with :meth:`str.replace`. NaN value(s) in the Series are left as
-    is.
-
-    >>> pd.Series(['f.o', 'fuz', np.nan]).str.replace('f.', 'ba', regex=False)
-    0    bao
-    1    fuz
-    2    NaN
-    dtype: object
-
-    When `pat` is a string and `regex` is True, the given `pat` is compiled
-    as a regex. When `repl` is a string, it replaces matching regex patterns
-    as with :meth:`re.sub`:
+    When `pat` is a string and `regex` is True (the default), the given `pat`
+    is compiled as a regex. When `repl` is a string, it replaces matching
+    regex patterns as with :meth:`re.sub`. NaN value(s) in the Series are
+    left as is:
 
     >>> pd.Series(['foo', 'fuz', np.nan]).str.replace('f.', 'ba', regex=True)
     0    bao
     1    baz
+    2    NaN
+    dtype: object
+
+    When `pat` is a string and `regex` is False, every `pat` is replaced with
+    `repl` as with :meth:`str.replace`:
+
+    >>> pd.Series(['f.o', 'fuz', np.nan]).str.replace('f.', 'ba', regex=False)
+    0    bao
+    1    fuz
     2    NaN
     dtype: object
 
@@ -414,6 +414,13 @@ def str_replace(arr, pat, repl, n=-1, case=None, flags=0, regex=True):
     1    bar
     2    NaN
     dtype: object
+
+    Raises
+    ------
+    ValueError
+        * if `regex` is False and `repl` is a callable or `pat` is a compiled
+          regex
+        * if `pat` is a compiled regex and `case` or `flags` is set
     """
 
     # Check whether repl is valid (GH 13438, GH 15055)

--- a/pandas/core/strings.py
+++ b/pandas/core/strings.py
@@ -351,8 +351,8 @@ def str_replace(arr, pat, repl, n=-1, case=None, flags=0, regex=True):
     Notes
     -----
     When `pat` is a compiled regex, all flags should be included in the
-    compiled regex. Use of `case`, `flags`, or `regex` with a compiled regex
-    will raise an error.
+    compiled regex. Use of `case`, `flags`, or `regex=False` with a compiled
+    regex will raise an error.
 
     Examples
     --------

--- a/pandas/core/strings.py
+++ b/pandas/core/strings.py
@@ -342,6 +342,8 @@ def str_replace(arr, pat, repl, n=-1, case=None, flags=0, regex=True):
         - Cannot be set to False if `pat` is a compiled regex or `repl` is
           a callable.
 
+        .. versionadded:: 0.23.0
+
     Returns
     -------
     replaced : Series/Index of objects

--- a/pandas/tests/test_strings.py
+++ b/pandas/tests/test_strings.py
@@ -541,12 +541,15 @@ class TestStringMethods(object):
         result = values.str.replace('f.', 'ba', regex=False)
         tm.assert_series_equal(result, exp)
 
-        # Cannot do a literal replace if given a callable repl or compiled pattern
+        # Cannot do a literal replace if given a callable repl or compiled
+        # pattern
         callable_repl = lambda m: m.group(0).swapcase()
         compiled_pat = re.compile('[a-z][A-Z]{2}')
 
-        pytest.raises(ValueError, values.str.replace, 'abc', callable_repl, regex=False)
-        pytest.raises(ValueError, values.str.replace, compiled_pat, '', regex=False)
+        pytest.raises(ValueError, values.str.replace, 'abc', callable_repl,
+                      regex=False)
+        pytest.raises(ValueError, values.str.replace, compiled_pat, '',
+                      regex=False)
 
     def test_repeat(self):
         values = Series(['a', 'b', NA, 'c', NA, 'd'])

--- a/pandas/tests/test_strings.py
+++ b/pandas/tests/test_strings.py
@@ -431,16 +431,6 @@ class TestStringMethods(object):
                     values = klass(data)
                     pytest.raises(TypeError, values.str.replace, 'a', repl)
 
-        # GH16808 literal replace (regex=False vs regex=True)
-        values = Series(['f.o', 'foo', NA])
-        exp = Series(['bao', 'bao', NA])
-        result = values.str.replace('f.', 'ba')
-        tm.assert_series_equal(result, exp)
-
-        exp = Series(['bao', 'foo', NA])
-        result = values.str.replace('f.', 'ba', regex=False)
-        tm.assert_series_equal(result, exp)
-
     def test_replace_callable(self):
         # GH 15055
         values = Series(['fooBAD__barBAD', NA])
@@ -450,8 +440,6 @@ class TestStringMethods(object):
         result = values.str.replace('[a-z][A-Z]{2}', repl, n=2)
         exp = Series(['foObaD__baRbaD', NA])
         tm.assert_series_equal(result, exp)
-
-        pytest.raises(ValueError, values.str.replace, 'abc', repl, regex=False)
 
         # test with wrong number of arguments, raising an error
         if compat.PY2:
@@ -533,8 +521,6 @@ class TestStringMethods(object):
         with tm.assert_raises_regex(ValueError,
                                     "case and flags cannot be"):
             result = values.str.replace(pat, '', case=True)
-
-        pytest.raises(ValueError, values.str.replace, pat, '', regex=False)
 
         # test with callable
         values = Series(['fooBAD__barBAD', NA])

--- a/pandas/tests/test_strings.py
+++ b/pandas/tests/test_strings.py
@@ -431,16 +431,6 @@ class TestStringMethods(object):
                     values = klass(data)
                     pytest.raises(TypeError, values.str.replace, 'a', repl)
 
-        # GH16808 literal replace (regex=False vs regex=True)
-        values = Series(['f.o', 'foo', NA])
-        exp = Series(['bao', 'bao', NA])
-        result = values.str.replace('f.', 'ba')
-        tm.assert_series_equal(result, exp)
-
-        exp = Series(['bao', 'foo', NA])
-        result = values.str.replace('f.', 'ba', regex=False)
-        tm.assert_series_equal(result, exp)
-
     def test_replace_callable(self):
         # GH 15055
         values = Series(['fooBAD__barBAD', NA])
@@ -450,8 +440,6 @@ class TestStringMethods(object):
         result = values.str.replace('[a-z][A-Z]{2}', repl, n=2)
         exp = Series(['foObaD__baRbaD', NA])
         tm.assert_series_equal(result, exp)
-
-        pytest.raises(ValueError, values.str.replace, 'abc', repl, regex=False)
 
         # test with wrong number of arguments, raising an error
         if compat.PY2:
@@ -534,8 +522,6 @@ class TestStringMethods(object):
                                     "case and flags cannot be"):
             result = values.str.replace(pat, '', case=True)
 
-        pytest.raises(ValueError, values.str.replace, pat, '', regex=False)
-
         # test with callable
         values = Series(['fooBAD__barBAD', NA])
         repl = lambda m: m.group(0).swapcase()
@@ -543,6 +529,24 @@ class TestStringMethods(object):
         result = values.str.replace(pat, repl, n=2)
         exp = Series(['foObaD__baRbaD', NA])
         tm.assert_series_equal(result, exp)
+
+    def test_replace_literal(self):
+        # GH16808 literal replace (regex=False vs regex=True)
+        values = Series(['f.o', 'foo', NA])
+        exp = Series(['bao', 'bao', NA])
+        result = values.str.replace('f.', 'ba')
+        tm.assert_series_equal(result, exp)
+
+        exp = Series(['bao', 'foo', NA])
+        result = values.str.replace('f.', 'ba', regex=False)
+        tm.assert_series_equal(result, exp)
+
+        # Cannot do a literal replace if given a callable repl or compiled pattern
+        callable_repl = lambda m: m.group(0).swapcase()
+        compiled_pat = re.compile('[a-z][A-Z]{2}')
+
+        pytest.raises(ValueError, values.str.replace, 'abc', callable_repl, regex=False)
+        pytest.raises(ValueError, values.str.replace, compiled_pat, '', regex=False)
 
     def test_repeat(self):
         values = Series(['a', 'b', NA, 'c', NA, 'd'])

--- a/pandas/tests/test_strings.py
+++ b/pandas/tests/test_strings.py
@@ -431,6 +431,16 @@ class TestStringMethods(object):
                     values = klass(data)
                     pytest.raises(TypeError, values.str.replace, 'a', repl)
 
+        # GH16808 literal replace (regex=False vs regex=True)
+        values = Series(['f.o', 'foo', NA])
+        exp = Series(['bao', 'bao', NA])
+        result = values.str.replace('f.', 'ba')
+        tm.assert_series_equal(result, exp)
+
+        exp = Series(['bao', 'foo', NA])
+        result = values.str.replace('f.', 'ba', regex=False)
+        tm.assert_series_equal(result, exp)
+
     def test_replace_callable(self):
         # GH 15055
         values = Series(['fooBAD__barBAD', NA])
@@ -440,6 +450,8 @@ class TestStringMethods(object):
         result = values.str.replace('[a-z][A-Z]{2}', repl, n=2)
         exp = Series(['foObaD__baRbaD', NA])
         tm.assert_series_equal(result, exp)
+
+        pytest.raises(ValueError, values.str.replace, 'abc', repl, regex=False)
 
         # test with wrong number of arguments, raising an error
         if compat.PY2:
@@ -521,6 +533,8 @@ class TestStringMethods(object):
         with tm.assert_raises_regex(ValueError,
                                     "case and flags cannot be"):
             result = values.str.replace(pat, '', case=True)
+
+        pytest.raises(ValueError, values.str.replace, pat, '', regex=False)
 
         # test with callable
         values = Series(['fooBAD__barBAD', NA])


### PR DESCRIPTION
Adds `regex=True` default parameter to .str.replace. If `regex=False` is set, uses str.replace to replace occurrences of `pat` with `repl`. Raises `ValueError` if given a callable `repl` or a compiled re for `pat` in combination with `regex=False`.

- [ ] closes #16808
- [ ] tests added / passed
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
