### PR TITLE
remove 1 char line terminator limit

### DIFF
--- a/doc/source/whatsnew/v0.23.0.txt
+++ b/doc/source/whatsnew/v0.23.0.txt
@@ -283,6 +283,7 @@ Other Enhancements
 
 - ``IntervalIndex.astype`` now supports conversions between subtypes when passed an ``IntervalDtype`` (:issue:`19197`)
 - :class:`IntervalIndex` and its associated constructor methods (``from_arrays``, ``from_breaks``, ``from_tuples``) have gained a ``dtype`` parameter (:issue:`19262`)
+- `read_csv` now accepts multi-character line terminators (:issue:`19601`)
 
 .. _whatsnew_0230.api_breaking:
 

--- a/pandas/_libs/parsers.pyx
+++ b/pandas/_libs/parsers.pyx
@@ -389,8 +389,6 @@ cdef class TextReader:
         if delim_whitespace:
             self.parser.delim_whitespace = delim_whitespace
         else:
-            if len(delimiter) > 1:
-                raise ValueError('only length-1 separators excluded right now')
             self.parser.delimiter = ord(delimiter)
 
         # ----------------------------------------
@@ -401,8 +399,6 @@ cdef class TextReader:
         self.parser.skip_empty_lines = skip_blank_lines
 
         if lineterminator is not None:
-            if len(lineterminator) != 1:
-                raise ValueError('Only length-1 line terminators supported')
             self.parser.lineterminator = ord(lineterminator)
 
         if len(decimal) != 1:

--- a/pandas/tests/io/parser/c_parser_only.py
+++ b/pandas/tests/io/parser/c_parser_only.py
@@ -205,6 +205,22 @@ No,No,No"""
 
         tm.assert_frame_equal(result, expected)
 
+    def test_crlf_lineterminator(self):
+        # #19601
+        data = 'a,b,c\r\n1,2,3\r\n4,5,6'
+
+        result = self.read_csv(StringIO(data), lineterminator='\r\n')
+        expected = self.read_csv(StringIO(data.replace('\r\n', '\n')))
+
+        tm.assert_frame_equal(result, expected)
+
+    def test_arbitrary_lineterminator(self):
+        data = 'a,b,c~~1,2,3~~4,5,6'
+        result = self.read_csv(StringIO(data), lineterminator='~~')
+        expected = self.read_csv(StringIO(data.replace('~~', '\n')))
+
+        tm.assert_frame_equal(result, expected)
+
     def test_parse_ragged_csv(self):
         data = """1,2,3
 1,2,3,4

--- a/pandas/tests/io/parser/test_unsupported.py
+++ b/pandas/tests/io/parser/test_unsupported.py
@@ -84,11 +84,6 @@ x   q   30      3    -0.6662 -0.5243 -0.3580  0.89145  2.5838"""
         with tm.assert_raises_regex(ValueError, msg):
             read_csv(StringIO(data), thousands='')
 
-        msg = "Only length-1 line terminators supported"
-        data = 'a,b,c~~1,2,3~~4,5,6'
-        with tm.assert_raises_regex(ValueError, msg):
-            read_csv(StringIO(data), lineterminator='~~')
-
     def test_python_engine(self, python_engine):
         from pandas.io.parsers import _python_unsupported as py_unsupported
 


### PR DESCRIPTION
This PR closes #3501
This restriction is preventing the loading of CRLF delimited CSVs


Steps to reproduce:

```
import pandas as pd
import StringIO
pd.read_csv(StringIO.StringIO(' a,b,c\r\n'), header=None, lineterminator='\r\n')

ValueError: Only length-1 line terminators supported

```

while the following parses the CSV successfully: 

```
import pandas as pd
import StringIO
pd.read_csv(StringIO.StringIO(' a,b,c\r\n'), header=None)
```

