### PR TITLE
BUG: agg with axis=1

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -4809,13 +4809,18 @@ class DataFrame(NDFrame):
 
         # TODO: flipped axis
         result = None
-        if axis == 0 or axis == 1:
+        if axis == 0:
             try:
                 result, how = self._aggregate(func,
-                                              _axis=axis,
+                                              _axis=0,
                                               *args, **kwargs)
             except TypeError:
                 pass
+        elif axis == 1:
+            try:
+                result, how = self.T._aggregate(func,
+                                                _axis=0,
+                                                *args, **kwargs).T
         if result is None:
             return self.apply(func, axis=axis, args=args, **kwargs)
         return result

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -4811,7 +4811,9 @@ class DataFrame(NDFrame):
         result = None
         if axis == 0 or axis == 1:
             try:
-                result, how = self._aggregate(func, _axis=axis, *args, **kwargs)
+                result, how = self._aggregate(func,
+                                              _axis=axis,
+                                              *args, **kwargs)
             except TypeError:
                 pass
         if result is None:

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -4809,9 +4809,9 @@ class DataFrame(NDFrame):
 
         # TODO: flipped axis
         result = None
-        if axis == 0:
+        if axis == 0 or axis == 1:
             try:
-                result, how = self._aggregate(func, axis=0, *args, **kwargs)
+                result, how = self._aggregate(func, _axis=axis, *args, **kwargs)
             except TypeError:
                 pass
         if result is None:

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -4807,8 +4807,8 @@ class DataFrame(NDFrame):
     def aggregate(self, func, axis=0, *args, **kwargs):
         axis = self._get_axis_number(axis)
 
-        # TODO: flipped axis
         result = None
+
         if axis == 0:
             try:
                 result, how = self._aggregate(func,
@@ -4821,6 +4821,8 @@ class DataFrame(NDFrame):
                 result, how = self.T._aggregate(func,
                                                 _axis=0,
                                                 *args, **kwargs).T
+            except TypeError:
+                pass
         if result is None:
             return self.apply(func, axis=axis, args=args, **kwargs)
         return result

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -4820,7 +4820,8 @@ class DataFrame(NDFrame):
             try:
                 result, how = self.T._aggregate(func,
                                                 _axis=0,
-                                                *args, **kwargs).T
+                                                *args, **kwargs)
+                result = result.T
             except TypeError:
                 pass
         if result is None:

--- a/pandas/tests/frame/test_apply.py
+++ b/pandas/tests/frame/test_apply.py
@@ -1014,12 +1014,16 @@ class TestDataFrameAggregate(TestData):
         assert result == expected
 
     def test_frame_row_and_column_aggregates(self):
-        df = DataFrame({'B':[4,5,6,7,8],
-                        'C':[7,8,9,10,11],},
-                       index=[1,2,3,4,5])
+        df = DataFrame({'B': [4, 5, 6, 7, 8],
+                        'C': [7, 8, 9, 10, 11]},
+                       index=[1, 2, 3, 4, 5])
 
-        assert_series_equal(df.agg('min',axis=1),
-                            Series({1:4,2:5,3:6,4:7,5:8}))
+        assert_series_equal(df.agg('min', axis=1),
+                            Series({1: 4,
+                                    2: 5,
+                                    3: 6,
+                                    4: 7,
+                                    5: 8}))
 
-        assert_series_equal(df.agg('min',axis=1),
+        assert_series_equal(df.agg('min', axis=1),
                             df.T.agg('min').T)

--- a/pandas/tests/frame/test_apply.py
+++ b/pandas/tests/frame/test_apply.py
@@ -1012,3 +1012,14 @@ class TestDataFrameAggregate(TestData):
         expected = df.size
 
         assert result == expected
+
+    def test_frame_row_and_column_aggregates(self):
+        df = DataFrame({'B':[4,5,6,7,8],
+                        'C':[7,8,9,10,11],},
+                       index=[1,2,3,4,5])
+
+        assert_series_equal(df.agg('min',axis=1),
+                            Series({1:4,2:5,3:6,4:7,5:8}))
+
+        assert_series_equal(df.agg('min',axis=1),
+                            df.T.agg('min').T)


### PR DESCRIPTION
This is a potentially inefficient fix to the this issue which requires a double transpose. I am unsure how inefficient this is, and if this is an acceptable solution. It solves the issue, but perhaps it would be preferable to implement this further down the stack in `_aggregate_multiple_funcs`.

An additional small fix is to pass `_axis` down the stack. `axis` was passed to `self._aggregate` previous, but had not effect since it was not referenced.

- [X] improves #16679 
- [None] tests added / passed
- [X] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
