### PR TITLE
order of exceptions in array_to_datetime

### DIFF
--- a/pandas/_libs/tslib.pyx
+++ b/pandas/_libs/tslib.pyx
@@ -693,7 +693,6 @@ cpdef array_to_datetime(ndarray[object] values, errors='raise',
 
         return result
     except OutOfBoundsDatetime:
-        raise
         if is_raise:
             raise
 
@@ -716,7 +715,6 @@ cpdef array_to_datetime(ndarray[object] values, errors='raise',
                 oresult[i] = val
         return oresult
     except TypeError:
-        raise
         oresult = np.empty(n, dtype=object)
 
         for i in range(n):

--- a/pandas/_libs/tslib.pyx
+++ b/pandas/_libs/tslib.pyx
@@ -549,10 +549,10 @@ cpdef array_to_datetime(ndarray[object] values, errors='raise',
                         raise
 
             elif PyDate_Check(val):
+                seen_datetime = 1
                 iresult[i] = pydate_to_dt64(val, &dts)
                 try:
                     check_dts_bounds(&dts)
-                    seen_datetime = 1
                 except ValueError:
                     if is_coerce:
                         iresult[i] = NPY_NAT
@@ -560,12 +560,12 @@ cpdef array_to_datetime(ndarray[object] values, errors='raise',
                     raise
 
             elif is_datetime64_object(val):
+                seen_datetime = 1
                 if get_datetime64_value(val) == NPY_NAT:
                     iresult[i] = NPY_NAT
                 else:
                     try:
                         iresult[i] = get_datetime64_nanos(val)
-                        seen_datetime = 1
                     except ValueError:
                         if is_coerce:
                             iresult[i] = NPY_NAT
@@ -574,19 +574,18 @@ cpdef array_to_datetime(ndarray[object] values, errors='raise',
 
             elif is_integer_object(val) or is_float_object(val):
                 # these must be ns unit by-definition
+                seen_integer = 1
 
                 if val != val or val == NPY_NAT:
                     iresult[i] = NPY_NAT
                 elif is_raise or is_ignore:
                     iresult[i] = val
-                    seen_integer = 1
                 else:
                     # coerce
                     # we now need to parse this as if unit='ns'
                     # we can ONLY accept integers at this point
                     # if we have previously (or in future accept
                     # datetimes/strings, then we must coerce)
-                    seen_integer = 1
                     try:
                         iresult[i] = cast_from_unit(val, 'ns')
                     except:
@@ -594,12 +593,11 @@ cpdef array_to_datetime(ndarray[object] values, errors='raise',
 
             elif is_string_object(val):
                 # string
+                seen_string = 1
 
                 if len(val) == 0 or val in nat_strings:
                     iresult[i] = NPY_NAT
                     continue
-
-                seen_string = 1
 
                 try:
                     _string_to_dts(val, &dts, &out_local, &out_tzoffset)

--- a/pandas/_libs/tslib.pyx
+++ b/pandas/_libs/tslib.pyx
@@ -56,6 +56,8 @@ from tslibs.timestamps cimport (create_timestamp_from_ts,
                                 _NS_UPPER_BOUND, _NS_LOWER_BOUND)
 from tslibs.timestamps import Timestamp
 
+cdef bint PY2 = str == bytes
+
 
 cdef inline object create_datetime_from_ts(
         int64_t value, pandas_datetimestruct dts,
@@ -598,7 +600,7 @@ cpdef array_to_datetime(ndarray[object] values, errors='raise',
                 if len(val) == 0 or val in nat_strings:
                     iresult[i] = NPY_NAT
                     continue
-                if PyUnicode_Check(val):
+                if PyUnicode_Check(val) and PY2:
                     val = val.encode('utf-8')
 
                 try:
@@ -745,14 +747,14 @@ cpdef array_to_datetime(ndarray[object] values, errors='raise',
         return oresult
 
 
-cdef inline bint _parse_today_now(bytes val, int64_t* iresult):
+cdef inline bint _parse_today_now(str val, int64_t* iresult):
     # We delay this check for as long as possible
     # because it catches relatively rare cases
-    if val == b'now':
+    if val == 'now':
         # Note: this is *not* the same as Timestamp('now')
         iresult[0] = Timestamp.utcnow().value
         return True
-    elif val == b'today':
+    elif val == 'today':
         # Note: this is *not* the same as Timestamp('today')
         iresult[0] = Timestamp.now().normalize().value
         return True

--- a/pandas/tests/indexes/datetimes/test_tools.py
+++ b/pandas/tests/indexes/datetimes/test_tools.py
@@ -18,7 +18,7 @@ from pandas._libs.tslibs import parsing
 from pandas.core.tools import datetimes as tools
 
 from pandas.errors import OutOfBoundsDatetime
-from pandas.compat import lmap
+from pandas.compat import lmap, PY3
 from pandas.compat.numpy import np_array_datetime64_compat
 from pandas.core.dtypes.common import is_datetime64_ns_dtype
 from pandas.util import testing as tm
@@ -237,6 +237,13 @@ class TestToDatetime(object):
 
             assert pdtoday.tzinfo is None
             assert pdtoday2.tzinfo is None
+
+    def test_to_datetime_today_now_unicode_bytes(self):
+        to_datetime([u'now'])
+        to_datetime([u'today'])
+        if not PY3:
+            to_datetime(['now'])
+            to_datetime(['today'])
 
     @pytest.mark.parametrize('cache', [True, False])
     def test_to_datetime_dt64s(self, cache):


### PR DESCRIPTION
First, cleans things up by moving all the seen_datetime and seen_integer variables to the tops of their respective blocks.

Mainly splits the `try:` block for `string_to_dts` up into two pieces based on the two lines in that block that _could_ raise and handles errors more specfically.