### PR TITLE
function for frequently repeated tz-conversion code

### DIFF
--- a/pandas/_libs/tslibs/conversion.pxd
+++ b/pandas/_libs/tslibs/conversion.pxd
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # cython: profile=False
 
-from cpython.datetime cimport datetime
+from cpython.datetime cimport datetime, tzinfo
 
 from numpy cimport int64_t, int32_t
 
@@ -30,3 +30,5 @@ cdef int64_t get_datetime64_nanos(object val) except? -1
 cpdef int64_t pydt_to_i8(object pydt) except? -1
 
 cdef maybe_datetimelike_to_i8(object val)
+
+cdef int64_t tz_convert_utc_to_tzlocal(int64_t utc_val, tzinfo tz)

--- a/pandas/_libs/tslibs/resolution.pyx
+++ b/pandas/_libs/tslibs/resolution.pyx
@@ -23,6 +23,7 @@ from timezones cimport (is_utc, is_tzlocal,
                         maybe_get_tz, get_dst_info, get_utcoffset)
 from fields import build_field_sarray
 from conversion import tz_convert
+from conversion cimport tz_convert_utc_to_tzlocal
 from ccalendar import MONTH_ALIASES, int_to_weekday
 
 from pandas._libs.properties import cache_readonly
@@ -78,6 +79,7 @@ cdef _reso_local(ndarray[int64_t] stamps, object tz):
         int reso = RESO_DAY, curr_reso
         ndarray[int64_t] trans, deltas, pos
         pandas_datetimestruct dts
+        int64_t local_val
 
     if is_utc(tz):
         for i in range(n):
@@ -91,11 +93,8 @@ cdef _reso_local(ndarray[int64_t] stamps, object tz):
         for i in range(n):
             if stamps[i] == NPY_NAT:
                 continue
-            dt64_to_dtstruct(stamps[i], &dts)
-            dt = datetime(dts.year, dts.month, dts.day, dts.hour,
-                          dts.min, dts.sec, dts.us, tz)
-            delta = int(get_utcoffset(tz, dt).total_seconds()) * 1000000000
-            dt64_to_dtstruct(stamps[i] + delta, &dts)
+            local_val = tz_convert_utc_to_tzlocal(stamps[i], tz)
+            dt64_to_dtstruct(local_val, &dts)
             curr_reso = _reso_stamp(&dts)
             if curr_reso < reso:
                 reso = curr_reso


### PR DESCRIPTION
If cython did generators efficiently we could get rid of a ton of boilerplate where these are used.