### PR TITLE
BUG: Do not round DatetimeIndex nanosecond precision when iterating

### DIFF
--- a/doc/source/whatsnew/v0.23.0.txt
+++ b/doc/source/whatsnew/v0.23.0.txt
@@ -729,6 +729,7 @@ Timezones
 - Bug in :func:`DatetimeIndex.insert` where inserting ``NaT`` into a timezone-aware index incorrectly raised (:issue:`16357`)
 - Bug in the :class:`DataFrame` constructor, where tz-aware Datetimeindex and a given column name will result in an empty ``DataFrame`` (:issue:`19157`)
 - Bug in :func:`Timestamp.tz_localize` where localizing a timestamp near the minimum or maximum valid values could overflow and return a timestamp with an incorrect nanosecond value (:issue:`12677`)
+- Bug when iterating over :class:`DatetimeIndex` that was localized with fixed timezone offset that rounded nanosecond precision to microseconds (:issue:`19603`)
 
 Offsets
 ^^^^^^^

--- a/pandas/conftest.py
+++ b/pandas/conftest.py
@@ -93,3 +93,10 @@ def compression_no_zip(request):
     except zip
     """
     return request.param
+
+
+@pytest.fixture(scope='module')
+@pytest.mark.skipif(not pandas.compat.PY3)
+def datetime_tz_utc():
+    from datetime import timezone
+    return timezone.utc

--- a/pandas/conftest.py
+++ b/pandas/conftest.py
@@ -96,7 +96,6 @@ def compression_no_zip(request):
 
 
 @pytest.fixture(scope='module')
-@pytest.mark.skipif(not pandas.compat.PY3)
 def datetime_tz_utc():
     from datetime import timezone
     return timezone.utc

--- a/pandas/tests/indexes/datetimes/test_timezones.py
+++ b/pandas/tests/indexes/datetimes/test_timezones.py
@@ -17,7 +17,7 @@ import pandas.util._test_decorators as td
 import pandas as pd
 from pandas._libs import tslib
 from pandas._libs.tslibs import timezones
-from pandas.compat import lrange, zip
+from pandas.compat import lrange, zip, PY3
 from pandas import (DatetimeIndex, date_range, bdate_range,
                     Timestamp, isna, to_datetime, Index)
 
@@ -952,6 +952,7 @@ class TestDatetimeIndexTimezones(object):
     @pytest.mark.parametrize('tz', [None, 'UTC', "US/Central",
                                     dateutil.tz.tzoffset(None, -28800)])
     @pytest.mark.usefixtures("datetime_tz_utc")
+    @pytest.mark.skipif(not PY3, reason="datetime.timezone not in PY2")
     def test_iteration_preserves_nanoseconds(self, tz):
         # GH 19603
         index = DatetimeIndex(["2018-02-08 15:00:00.168456358",

--- a/pandas/tests/indexes/datetimes/test_timezones.py
+++ b/pandas/tests/indexes/datetimes/test_timezones.py
@@ -949,6 +949,16 @@ class TestDatetimeIndexTimezones(object):
         result = rng.union(rng2)
         assert result.tz.zone == 'UTC'
 
+    @pytest.mark.parametrize('tz', [None, 'UTC', "US/Central",
+                                    dateutil.tz.tzoffset(None, -28800)])
+    @pytest.mark.usefixtures("datetime_tz_utc")
+    def test_iteration_preserves_nanoseconds(self, tz):
+        # GH 19603
+        index = DatetimeIndex(["2018-02-08 15:00:00.168456358",
+                               "2018-02-08 15:00:00.168456359"], tz=tz)
+        for i, ts in enumerate(index):
+            assert ts == index[i]
+
 
 class TestDateRange(object):
     """Tests for date_range with timezones"""


### PR DESCRIPTION
- [x] closes #19603
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry

~~This issue was actually very specific to localizing a `DatetimeIndex` with `datetime.timezone.utc`~~

```
# On master
In [1]: import pandas as pd

In [2]: datetimeindex = pd.DatetimeIndex(["2018-02-08 15:00:00.168456358"], tz='UTC')

In [3]: list(datetimeindex)[0] == datetimeindex[0] # returned False with datetime.timezone.utc
Out[3]: True 
```

~~I realize our timezone support relies heavily on pytz and dateutil, but I am curious how much support we have for `datetime.timezone` objects.~~

So the actual issue was that `datetime.timezone.utc` is (rightly) considered a fixed offset, and the code path was calculating the new value with Python `datetimes` and `timedeltas` which doesn't yet support nanosecond resolution. 

