### PR TITLE
DOC: ignore Panel deprecation warnings during doc build

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -15,6 +15,8 @@ import os
 import re
 import inspect
 import importlib
+import warnings
+
 from pandas.compat import u, PY3
 
 try:
@@ -375,12 +377,15 @@ extlinks = {'issue': ('https://github.com/pandas-dev/pandas/issues/%s',
             'wiki': ('https://github.com/pandas-dev/pandas/wiki/%s',
                      'wiki ')}
 
+
+# ignore all deprecation warnings from Panel during doc build
+# (to avoid the need to add :okwarning: in many places)
+import warnings
+warnings.filterwarnings("ignore", message="\nPanel is deprecated",
+                        category=FutureWarning)
+
+
 ipython_exec_lines = [
-    # ignore all deprecation warnings from Panel
-    # (to avoid the need to add :okwarning: in many places)
-    'import warnings',
-    'warnings.filterwarnings("ignore", message="\nPanel is deprecated", category=FutureWarning)'  # noqa
-    # standard imports
     'import numpy as np',
     'import pandas as pd',
     # This ensures correct rendering on system with console encoding != utf8

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -376,6 +376,11 @@ extlinks = {'issue': ('https://github.com/pandas-dev/pandas/issues/%s',
                      'wiki ')}
 
 ipython_exec_lines = [
+    # ignore all deprecation warnings from Panel
+    # (to avoid the need to add :okwarning: in many places)
+    'import warnings',
+    'warnings.filterwarnings("ignore", message="\nPanel is deprecated", category=FutureWarning)'  # noqa
+    # standard imports
     'import numpy as np',
     'import pandas as pd',
     # This ensures correct rendering on system with console encoding != utf8

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -380,7 +380,6 @@ extlinks = {'issue': ('https://github.com/pandas-dev/pandas/issues/%s',
 
 # ignore all deprecation warnings from Panel during doc build
 # (to avoid the need to add :okwarning: in many places)
-import warnings
 warnings.filterwarnings("ignore", message="\nPanel is deprecated",
                         category=FutureWarning)
 


### PR DESCRIPTION
The doc build log is currently full of Panel deprecation warnings. To avoid having to put `:okwarning:` on all code-blocks that use Panel, I put a general filterwarnings for this warning in the conf.py file  which hopefully works (alternative would be to put this inside the .rst file itself at the top in a suppressed ipython code block)