### PR TITLE
Explicitly set dtype of np.lexsort in group_rank

### DIFF
--- a/pandas/_libs/groupby_helper.pxi.in
+++ b/pandas/_libs/groupby_helper.pxi.in
@@ -531,7 +531,7 @@ def group_rank_{{name}}(ndarray[float64_t, ndim=2] out,
     # each label corresponds to a different group value,
     # the mask helps you differentiate missing values before
     # performing sort on the actual values
-    _as = np.lexsort(order)
+    _as = np.lexsort(order).view(dtype=np.int64)
 
     if not ascending:
         _as = _as[::-1]


### PR DESCRIPTION
xref #19481

I didn't see any other instance in `group_rank` where the dtype was open to interpretation, so I'm wondering if `np.lexsort` is returning a plain `int` on 32 bit systems. Hoping that explicitly getting a view of that `np.lexsort` result to match the dtype of `_as` will resolve the test issues