### PR TITLE
BUG: Fix Series constructor for Categorical with index

### DIFF
--- a/doc/source/whatsnew/v0.23.0.txt
+++ b/doc/source/whatsnew/v0.23.0.txt
@@ -919,6 +919,7 @@ Reshaping
 - Comparisons between :class:`Series` and :class:`Index` would return a ``Series`` with an incorrect name, ignoring the ``Index``'s name attribute (:issue:`19582`)
 - Bug in :func:`qcut` where datetime and timedelta data with ``NaT`` present raised a ``ValueError`` (:issue:`19768`)
 - Bug in :func:`DataFrame.iterrows`, which would infers strings not compliant to `ISO8601 <https://en.wikipedia.org/wiki/ISO_8601>`_ to datetimes (:issue:`19671`)
+- Bug in :class:`Series` constructor with ``Categorical`` where a ```ValueError`` is not raised when an index of different length is given (:issue:`19342`)
 
 Other
 ^^^^^

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -239,7 +239,7 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
                 # a scalar numpy array is list-like but doesn't
                 # have a proper length
                 try:
-                    if len(data) != 1 and len(index) != len(data):
+                    if len(index) != len(data):
                         raise ValueError(
                             'Length of passed values is {val}, '
                             'index implies {ind}'

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -239,7 +239,7 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
                 # a scalar numpy array is list-like but doesn't
                 # have a proper length
                 try:
-                    if len(data) > 1 and len(index) != len(data):
+                    if len(data) != 1 and len(index) != len(data):
                         raise ValueError(
                             'Length of passed values is {val}, '
                             'index implies {ind}'

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -212,12 +212,11 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
                                          'be False.')
 
             elif is_extension_array_dtype(data) and dtype is not None:
-                # GH12574: Allow dtype=category only, otherwise error
-                if ((dtype is not None) and
-                        not is_categorical_dtype(dtype)):
-                    raise ValueError("cannot specify a dtype with a "
-                                     "Categorical unless "
-                                     "dtype='category'")
+                if not data.dtype.is_dtype(dtype):
+                    raise ValueError("Cannot specify a dtype '{}' with an "
+                                     "extension array of a different "
+                                     "dtype ('{}').".format(dtype,
+                                                            data.dtype))
 
             elif (isinstance(data, types.GeneratorType) or
                   (compat.PY3 and isinstance(data, map))):

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -235,8 +235,7 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
                 if not is_list_like(data):
                     data = [data]
                 index = com._default_index(len(data))
-            else:
-                if not is_scalar(data) and len(index) != len(data):
+            elif is_list_like(data) and len(index) != len(data):
                     raise ValueError('Length of passed values is {val}, '
                                      'index implies {ind}'
                                      .format(val=len(data), ind=len(index)))

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -234,10 +234,18 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
                 if not is_list_like(data):
                     data = [data]
                 index = com._default_index(len(data))
-            elif is_list_like(data) and len(index) != len(data):
-                    raise ValueError('Length of passed values is {val}, '
-                                     'index implies {ind}'
-                                     .format(val=len(data), ind=len(index)))
+            elif is_list_like(data):
+
+                # a scalar numpy array is list-like but doesn't
+                # have a proper length
+                try:
+                    if len(index) != len(data):
+                        raise ValueError(
+                            'Length of passed values is {val}, '
+                            'index implies {ind}'
+                            .format(val=len(data), ind=len(index)))
+                except TypeError:
+                    pass
 
             # create/copy the manager
             if isinstance(data, SingleBlockManager):

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -239,7 +239,7 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
                 # a scalar numpy array is list-like but doesn't
                 # have a proper length
                 try:
-                    if len(index) != len(data):
+                    if len(data) > 1 and len(index) != len(data):
                         raise ValueError(
                             'Length of passed values is {val}, '
                             'index implies {ind}'

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -213,11 +213,11 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
 
             elif is_extension_array_dtype(data) and dtype is not None:
                 # GH12574: Allow dtype=category only, otherwise error
-                if not data.dtype.is_dtype(dtype):
-                    raise ValueError("Cannot specify a dtype '{}' with an "
-                                     "extension array of a different "
-                                     "dtype ('{}').".format(dtype,
-                                                            data.dtype))
+                if ((dtype is not None) and
+                        not is_categorical_dtype(dtype)):
+                    raise ValueError("cannot specify a dtype with a "
+                                     "Categorical unless "
+                                     "dtype='category'")
 
             elif (isinstance(data, types.GeneratorType) or
                   (compat.PY3 and isinstance(data, map))):
@@ -235,6 +235,11 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
                 if not is_list_like(data):
                     data = [data]
                 index = com._default_index(len(data))
+            else:
+                if not is_scalar(data) and len(index) != len(data):
+                    raise ValueError('Length of passed values is {val}, '
+                                     'index implies {ind}'
+                                     .format(val=len(data), ind=len(index)))
 
             # create/copy the manager
             if isinstance(data, SingleBlockManager):

--- a/pandas/tests/io/formats/test_style.py
+++ b/pandas/tests/io/formats/test_style.py
@@ -24,7 +24,7 @@ class TestStyler(object):
 
         def h(x, foo='bar'):
             return pd.Series(
-                ['color: {foo}'.format(foo=foo)], index=x.index, name=x.name)
+                'color: {foo}'.format(foo=foo), index=x.index, name=x.name)
 
         self.h = h
         self.styler = Styler(self.df)

--- a/pandas/tests/series/test_constructors.py
+++ b/pandas/tests/series/test_constructors.py
@@ -422,6 +422,14 @@ class TestSeriesConstructors(TestData):
         expected = Series(100, index=np.arange(4), dtype='int64')
         tm.assert_series_equal(result, expected)
 
+    def test_constructor_broadcast_list(self):
+        # GH 19342
+        # construction with single-element container and index
+        # should not raise
+        result = Series(['foo'], index=['a', 'b', 'c'])
+        expected = Series(['foo'] * 3, index=['a', 'b', 'c'])
+        tm.assert_series_equal(result, expected)
+
     def test_constructor_corner(self):
         df = tm.makeTimeDataFrame()
         objs = [df, df]

--- a/pandas/tests/series/test_constructors.py
+++ b/pandas/tests/series/test_constructors.py
@@ -418,8 +418,8 @@ class TestSeriesConstructors(TestData):
         # GH 19342
         # construction with a numpy scalar
         # should not raise
-        result = Series(np.array(100), index=np.arange(4))
-        expected = Series(100, index=np.arange(4))
+        result = Series(np.array(100), index=np.arange(4), dtype='int64')
+        expected = Series(100, index=np.arange(4), dtype='int64')
         tm.assert_series_equal(result, expected)
 
     def test_constructor_corner(self):

--- a/pandas/tests/series/test_constructors.py
+++ b/pandas/tests/series/test_constructors.py
@@ -425,10 +425,8 @@ class TestSeriesConstructors(TestData):
     def test_constructor_broadcast_list(self):
         # GH 19342
         # construction with single-element container and index
-        # should not raise
-        result = Series(['foo'], index=['a', 'b', 'c'])
-        expected = Series(['foo'] * 3, index=['a', 'b', 'c'])
-        tm.assert_series_equal(result, expected)
+        # should raise
+        pytest.raises(ValueError, Series, ['foo'], index=['a', 'b', 'c'])
 
     def test_constructor_corner(self):
         df = tm.makeTimeDataFrame()

--- a/pandas/tests/series/test_constructors.py
+++ b/pandas/tests/series/test_constructors.py
@@ -414,6 +414,14 @@ class TestSeriesConstructors(TestData):
         with pytest.raises(ValueError, message=msg):
             Series(input, index=np.arange(4))
 
+    def test_constructor_numpy_scalar(self):
+        # GH 19342
+        # construction with a numpy scalar
+        # should not raise
+        result = Series(np.array(100), index=np.arange(4))
+        expected = Series(100, index=np.arange(4))
+        tm.assert_series_equal(result, expected)
+
     def test_constructor_corner(self):
         df = tm.makeTimeDataFrame()
         objs = [df, df]

--- a/pandas/tests/series/test_constructors.py
+++ b/pandas/tests/series/test_constructors.py
@@ -400,6 +400,20 @@ class TestSeriesConstructors(TestData):
         s = Series([0, 1, 2])
         tm.assert_index_equal(s.index, pd.Index(np.arange(3)))
 
+    @pytest.mark.parametrize('input', [[1, 2, 3],
+                                       (1, 2, 3),
+                                       list(range(3)),
+                                       pd.Categorical(['a', 'b', 'a']),
+                                       (i for i in range(3)),
+                                       map(lambda x: x, range(3))])
+    def test_constructor_index_mismatch(self, input):
+        # GH 19342
+        # test that construction of a Series with an index of different length
+        # raises an error
+        msg = 'Length of passed values is 3, index implies 4'
+        with pytest.raises(ValueError, message=msg):
+            Series(input, index=np.arange(4))
+
     def test_constructor_corner(self):
         df = tm.makeTimeDataFrame()
         objs = [df, df]


### PR DESCRIPTION
Fixes Series constructor so that ValueError is raised when a Categorical and index of incorrect length are given. Closes issue #19342

- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry
