### PR TITLE
BUG: drop_duplicates not raising KeyError on missing key

### DIFF
--- a/doc/source/whatsnew/v0.23.0.txt
+++ b/doc/source/whatsnew/v0.23.0.txt
@@ -767,6 +767,8 @@ Indexing
 - Bug in :class:`IntervalIndex` where empty and purely NA data was constructed inconsistently depending on the construction method (:issue:`18421`)
 - Bug in :func:`IntervalIndex.symmetric_difference` where the symmetric difference with a non-``IntervalIndex`` did not raise (:issue:`18475`)
 - Bug in :class:`IntervalIndex` where set operations that returned an empty ``IntervalIndex`` had the wrong dtype (:issue:`19101`)
+- Bug in :meth:`DataFrame.drop_duplicates` where no ``KeyError`` is raised when passing in columns that don't exist on the ``DataFrame`` (issue:`19726`)
+
 
 MultiIndex
 ^^^^^^^^^^

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -3659,7 +3659,7 @@ class DataFrame(NDFrame):
         # Otherwise, raise a KeyError, same as if you try to __getitem__ with a
         # key that doesn't exist.
         diff = Index(subset).difference(self.columns)
-        if len(diff):
+        if not diff.empty:
             raise KeyError(diff)
 
         vals = (col.values for name, col in self.iteritems()

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -3655,9 +3655,12 @@ class DataFrame(NDFrame):
               isinstance(subset, tuple) and subset in self.columns):
             subset = subset,
 
-        for name in subset:
-            if name not in self.columns:
-                raise KeyError(name)
+        # Verify all columns in subset exist in the queried dataframe
+        # Otherwise, raise a KeyError, same as if you try to __getitem__ with a
+        # key that doesn't exist.
+        diff = Index(subset).difference(self.columns)
+        if len(diff):
+            raise KeyError(diff)
 
         vals = (col.values for name, col in self.iteritems()
                 if name in subset)

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -3655,6 +3655,10 @@ class DataFrame(NDFrame):
               isinstance(subset, tuple) and subset in self.columns):
             subset = subset,
 
+        for name in subset:
+            if name not in self.columns:
+                raise KeyError(name)
+
         vals = (col.values for name, col in self.iteritems()
                 if name in subset)
         labels, shape = map(list, zip(*map(f, vals)))

--- a/pandas/tests/frame/test_analytics.py
+++ b/pandas/tests/frame/test_analytics.py
@@ -1492,14 +1492,18 @@ class TestDataFrameAnalytics(TestData):
         for keep in ['first', 'last', False]:
             assert df.duplicated(keep=keep).sum() == 0
 
-    def test_drop_duplicates_with_misspelled_column_name(self):
-        # GH 18XXX
-        df = pd.DataFrame({'A': [0, 1, 2, 3, 4, 5],
-                           'B': [0, 1, 2, 3, 4, 5],
-                           'C': [0, 1, 2, 3, 4, 6]})
+    @pytest.mark.parametrize('subset', ['a', ['a'], ['a', 'B']])
+    def test_duplicated_with_misspelled_column_name(self, subset):
+        # GH 19730
+        df = pd.DataFrame({'A': [0, 0, 1],
+                           'B': [0, 0, 1],
+                           'C': [0, 0, 1]})
 
         with pytest.raises(KeyError):
-            df.drop_duplicates(['a', 'B'])
+            df.duplicated(subset)
+
+        with pytest.raises(KeyError):
+            df.drop_duplicates(subset)
 
     def test_drop_duplicates_with_duplicate_column_names(self):
         # GH17836

--- a/pandas/tests/frame/test_analytics.py
+++ b/pandas/tests/frame/test_analytics.py
@@ -1492,6 +1492,15 @@ class TestDataFrameAnalytics(TestData):
         for keep in ['first', 'last', False]:
             assert df.duplicated(keep=keep).sum() == 0
 
+    def test_drop_duplicates_with_misspelled_column_name(self):
+        # GH 18XXX
+        df = pd.DataFrame({'A': [0, 1, 2, 3, 4, 5],
+                           'B': [0, 1, 2, 3, 4, 5],
+                           'C': [0, 1, 2, 3, 4, 6]})
+
+        with pytest.raises(KeyError):
+            df.drop_duplicates(['a', 'B'])
+
     def test_drop_duplicates_with_duplicate_column_names(self):
         # GH17836
         df = DataFrame([


### PR DESCRIPTION
Fix #17879 introduced an error by iterating over the columns in the dataframe, not the columns in the subset. This meant that passing in a column name missing from the dataframe would no longer raise a `KeyError` like it had previously.

This fix checks the subset first before pulling necessary columns from the dataframe, and raises the necessary `KeyError` when a given column doesn't exist.

- [x] closes #19726 
- [x] tests added / passed
- [x] passes git diff upstream/master -u -- "*.py" | flake8 --diff
- [x] whatsnew entry