### PR TITLE
CLN: Removed Unnecessary Conditionals in groupby_helper

### DIFF
--- a/pandas/_libs/groupby_helper.pxi.in
+++ b/pandas/_libs/groupby_helper.pxi.in
@@ -56,36 +56,19 @@ def group_add_{{name}}(ndarray[{{dest_type2}}, ndim=2] out,
 
     with nogil:
 
-        if K > 1:
+        for i in range(N):
+            lab = labels[i]
+            if lab < 0:
+                continue
 
-            for i in range(N):
-                lab = labels[i]
-                if lab < 0:
-                    continue
-
-                counts[lab] += 1
-                for j in range(K):
-                    val = values[i, j]
-
-                    # not nan
-                    if val == val:
-                        nobs[lab, j] += 1
-                        sumx[lab, j] += val
-
-        else:
-
-            for i in range(N):
-                lab = labels[i]
-                if lab < 0:
-                    continue
-
-                counts[lab] += 1
-                val = values[i, 0]
+            counts[lab] += 1
+            for j in range(K):
+                val = values[i, j]
 
                 # not nan
                 if val == val:
-                    nobs[lab, 0] += 1
-                    sumx[lab, 0] += val
+                    nobs[lab, j] += 1
+                    sumx[lab, j] += val
 
         for i in range(ncounts):
             for j in range(K):
@@ -119,33 +102,19 @@ def group_prod_{{name}}(ndarray[{{dest_type2}}, ndim=2] out,
     N, K = (<object> values).shape
 
     with nogil:
-        if K > 1:
-            for i in range(N):
-                lab = labels[i]
-                if lab < 0:
-                    continue
+        for i in range(N):
+            lab = labels[i]
+            if lab < 0:
+                continue
 
-                counts[lab] += 1
-                for j in range(K):
-                    val = values[i, j]
-
-                    # not nan
-                    if val == val:
-                        nobs[lab, j] += 1
-                        prodx[lab, j] *= val
-        else:
-            for i in range(N):
-                lab = labels[i]
-                if lab < 0:
-                    continue
-
-                counts[lab] += 1
-                val = values[i, 0]
+            counts[lab] += 1
+            for j in range(K):
+                val = values[i, j]
 
                 # not nan
                 if val == val:
-                    nobs[lab, 0] += 1
-                    prodx[lab, 0] *= val
+                    nobs[lab, j] += 1
+                    prodx[lab, j] *= val
 
         for i in range(ncounts):
             for j in range(K):
@@ -231,31 +200,18 @@ def group_mean_{{name}}(ndarray[{{dest_type2}}, ndim=2] out,
     N, K = (<object> values).shape
 
     with nogil:
-        if K > 1:
-            for i in range(N):
-                lab = labels[i]
-                if lab < 0:
-                    continue
+        for i in range(N):
+            lab = labels[i]
+            if lab < 0:
+                continue
 
-                counts[lab] += 1
-                for j in range(K):
-                    val = values[i, j]
-                    # not nan
-                    if val == val:
-                        nobs[lab, j] += 1
-                        sumx[lab, j] += val
-        else:
-            for i in range(N):
-                lab = labels[i]
-                if lab < 0:
-                    continue
-
-                counts[lab] += 1
-                val = values[i, 0]
+            counts[lab] += 1
+            for j in range(K):
+                val = values[i, j]
                 # not nan
                 if val == val:
-                    nobs[lab, 0] += 1
-                    sumx[lab, 0] += val
+                    nobs[lab, j] += 1
+                    sumx[lab, j] += val
 
         for i in range(ncounts):
             for j in range(K):
@@ -670,33 +626,14 @@ def group_max_{{name}}(ndarray[{{dest_type2}}, ndim=2] out,
     N, K = (<object> values).shape
 
     with nogil:
-        if K > 1:
-            for i in range(N):
-                lab = labels[i]
-                if lab < 0:
-                    continue
+        for i in range(N):
+            lab = labels[i]
+            if lab < 0:
+                continue
 
-                counts[lab] += 1
-                for j in range(K):
-                    val = values[i, j]
-
-                    # not nan
-                    {{if name == 'int64'}}
-                    if val != {{nan_val}}:
-                    {{else}}
-                    if val == val and val != {{nan_val}}:
-                    {{endif}}
-                        nobs[lab, j] += 1
-                        if val > maxx[lab, j]:
-                            maxx[lab, j] = val
-        else:
-            for i in range(N):
-                lab = labels[i]
-                if lab < 0:
-                    continue
-
-                counts[lab] += 1
-                val = values[i, 0]
+            counts[lab] += 1
+            for j in range(K):
+                val = values[i, j]
 
                 # not nan
                 {{if name == 'int64'}}
@@ -704,9 +641,9 @@ def group_max_{{name}}(ndarray[{{dest_type2}}, ndim=2] out,
                 {{else}}
                 if val == val and val != {{nan_val}}:
                 {{endif}}
-                    nobs[lab, 0] += 1
-                    if val > maxx[lab, 0]:
-                        maxx[lab, 0] = val
+                    nobs[lab, j] += 1
+                    if val > maxx[lab, j]:
+                        maxx[lab, j] = val
 
         for i in range(ncounts):
             for j in range(K):
@@ -744,33 +681,14 @@ def group_min_{{name}}(ndarray[{{dest_type2}}, ndim=2] out,
     N, K = (<object> values).shape
 
     with nogil:
-        if K > 1:
-            for i in range(N):
-                lab = labels[i]
-                if lab < 0:
-                    continue
+        for i in range(N):
+            lab = labels[i]
+            if lab < 0:
+                continue
 
-                counts[lab] += 1
-                for j in range(K):
-                    val = values[i, j]
-
-                    # not nan
-                    {{if name == 'int64'}}
-                    if val != {{nan_val}}:
-                    {{else}}
-                    if val == val and val != {{nan_val}}:
-                    {{endif}}
-                        nobs[lab, j] += 1
-                        if val < minx[lab, j]:
-                            minx[lab, j] = val
-        else:
-            for i in range(N):
-                lab = labels[i]
-                if lab < 0:
-                    continue
-
-                counts[lab] += 1
-                val = values[i, 0]
+            counts[lab] += 1
+            for j in range(K):
+                val = values[i, j]
 
                 # not nan
                 {{if name == 'int64'}}
@@ -778,9 +696,9 @@ def group_min_{{name}}(ndarray[{{dest_type2}}, ndim=2] out,
                 {{else}}
                 if val == val and val != {{nan_val}}:
                 {{endif}}
-                    nobs[lab, 0] += 1
-                    if val < minx[lab, 0]:
-                        minx[lab, 0] = val
+                    nobs[lab, j] += 1
+                    if val < minx[lab, j]:
+                        minx[lab, j] = val
 
         for i in range(ncounts):
             for j in range(K):


### PR DESCRIPTION
- [X] closes #19724 
- [X] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

ASV results are pretty inconsistent but I couldn't find anything directly related from this change. Of the marks below, only `max` was touched by this change, and that doesn't appear consistently in the results

```bash
       before           after         ratio
     [2fdf1e25]       [458210c1]
+         155±1μs          173±4μs     1.12  groupby.GroupByMethods.time_method('float', 'max')
+         324±1μs          361±5μs     1.12  groupby.GroupByMethods.time_method('float', 'median')
-         722±5μs          638±8μs     0.88  groupby.GroupByMethods.time_method('int', 'cumprod')
-        540±10μs          463±1μs     0.86  groupby.GroupByMethods.time_method('int', 'cummax')
-        551±20μs          459±1μs     0.83  groupby.GroupByMethods.time_method('int', 'cummin')
-      1.17±0.1ms          475±7μs     0.40  groupby.GroupByMethods.time_method('float', 'sem')
```