### PR TITLE
Implement missing tests, fix offset floordiv, rfloordiv, fix return types

### DIFF
--- a/doc/source/whatsnew/v0.23.0.txt
+++ b/doc/source/whatsnew/v0.23.0.txt
@@ -716,6 +716,8 @@ Datetimelike
 - Bug in :class:`Timestamp` and :func:`to_datetime` where a string representing a barely out-of-bounds timestamp would be incorrectly rounded down instead of raising ``OutOfBoundsDatetime`` (:issue:`19382`)
 - Bug in :func:`Timestamp.floor` :func:`DatetimeIndex.floor` where time stamps far in the future and past were not rounded correctly (:issue:`19206`)
 - Bug in :func:`to_datetime` where passing an out-of-bounds datetime with ``errors='coerce'`` and ``utc=True`` would raise ``OutOfBoundsDatetime`` instead of parsing to ``NaT`` (:issue:`19612`)
+- Bug in :func:`Timedelta.__add__`, :func:`Timedelta.__sub__` where adding or subtracting a ``np.timedelta64`` object would return another ``np.timedelta64`` instead of a ``Timedelta`` (:issue:`19738`)
+- Bug in :func:`Timedelta.__floordiv__`, :func:`Timedelta.__rfloordiv__` where operating with a ``Tick`` object would raise a ``TypeError`` instead of returning a numeric value (:issue:`19738`)
 -
 
 Timezones

--- a/pandas/tests/scalar/test_timedelta.py
+++ b/pandas/tests/scalar/test_timedelta.py
@@ -124,7 +124,6 @@ class TestTimedeltaArithmetic(object):
         assert td / td == 1
         assert td / np.timedelta64(60, 'h') == 4
 
-        assert np.isnan(td / np.timedelta64('NaT'))
         assert np.isnan(td / NaT)
 
     def test_td_div_numeric_scalar(self):

--- a/pandas/tests/scalar/test_timedelta.py
+++ b/pandas/tests/scalar/test_timedelta.py
@@ -265,10 +265,6 @@ class TestTimedeltaArithmetic(object):
     def test_binary_ops_integers(self):
         td = Timedelta(10, unit='d')
 
-        assert td * 2 == Timedelta(20, unit='d')
-        assert td / 2 == Timedelta(5, unit='d')
-        assert td // 2 == Timedelta(5, unit='d')
-
         # invert
         assert td * -1 == Timedelta('-10d')
         assert -1 * td == Timedelta('-10d')

--- a/pandas/tests/scalar/test_timedelta.py
+++ b/pandas/tests/scalar/test_timedelta.py
@@ -18,7 +18,7 @@ from pandas._libs.tslib import iNaT, NaT
 class TestTimedeltaArithmetic(object):
     @pytest.mark.parametrize('op', [operator.add, ops.radd])
     def test_td_add_datetimelike(self, op):
-        # GH#19365
+        # GH#19738
         td = Timedelta(10, unit='d')
 
         result = op(td, datetime(2016, 1, 1))
@@ -95,7 +95,7 @@ class TestTimedeltaArithmetic(object):
 
     @pytest.mark.parametrize('op', [operator.mul, ops.rmul])
     def test_td_mul_scalar(self, op):
-        # GH#19365
+        # GH#19738
         td = Timedelta(minutes=3)
 
         result = op(td, 2)
@@ -115,7 +115,7 @@ class TestTimedeltaArithmetic(object):
             op(td, td)
 
     def test_td_div_timedeltalike_scalar(self):
-        # GH#19365
+        # GH#19738
         td = Timedelta(10, unit='d')
 
         result = td / pd.offsets.Hour(1)
@@ -128,7 +128,7 @@ class TestTimedeltaArithmetic(object):
         assert np.isnan(td / NaT)
 
     def test_td_div_numeric_scalar(self):
-        # GH#19365
+        # GH#19738
         td = Timedelta(10, unit='d')
 
         result = td / 2
@@ -140,7 +140,7 @@ class TestTimedeltaArithmetic(object):
         assert result == Timedelta(days=2)
 
     def test_td_rdiv_timedeltalike_scalar(self):
-        # GH#19365
+        # GH#19738
         td = Timedelta(10, unit='d')
         result = pd.offsets.Hour(1) / td
         assert result == 1 / 240.0
@@ -278,7 +278,7 @@ class TestTimedeltaArithmetic(object):
         pytest.raises(TypeError, lambda: td - 2)
 
     def test_td_floordiv_offsets(self):
-        # GH19365
+        # GH#19738
         td = Timedelta(hours=3, minutes=4)
         assert td // pd.offsets.Hour(1) == 3
         assert td // pd.offsets.Minute(2) == 92
@@ -324,7 +324,7 @@ class TestTimedeltaArithmetic(object):
         assert res.dtype.kind == 'm'
 
     def test_td_rfloordiv_offsets(self):
-        # GH#19365
+        # GH#19738
         assert pd.offsets.Hour(1) // Timedelta(minutes=25) == 2
 
     def test_rfloordiv(self):

--- a/pandas/tests/scalar/test_timedelta.py
+++ b/pandas/tests/scalar/test_timedelta.py
@@ -145,7 +145,6 @@ class TestTimedeltaArithmetic(object):
         result = pd.offsets.Hour(1) / td
         assert result == 1 / 240.0
 
-        assert np.isnan(np.timedelta64('NaT') / td)
         assert np.timedelta64(60, 'h') / td == 0.25
 
     def test_arithmetic_overflow(self):


### PR DESCRIPTION
This splits off of #19365 a bunch of peripheral changes that were never intended to be part of #19365 in the first place.

- Implements many tests in the "how is there not already a test for that!?" category
- Fixes(+tests) Timedelta // DateOffset and DateOffset // Timedelta
- Fixes(+tests) return types for `Timedelta.__add__, __radd__, __sub__, __rsub__(np.timedelta64)` (ATM returns `timedelta64`) 
- Fixes a typo in test_construction that causes a dummy assertion to be made instead of the intended assertion.

- [ ] closes #xxxx
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry
