### PR TITLE
Fix wraparound/overflow in date_range

### DIFF
--- a/doc/source/whatsnew/v0.23.0.txt
+++ b/doc/source/whatsnew/v0.23.0.txt
@@ -716,7 +716,7 @@ Datetimelike
 - Bug in :class:`Timestamp` and :func:`to_datetime` where a string representing a barely out-of-bounds timestamp would be incorrectly rounded down instead of raising ``OutOfBoundsDatetime`` (:issue:`19382`)
 - Bug in :func:`Timestamp.floor` :func:`DatetimeIndex.floor` where time stamps far in the future and past were not rounded correctly (:issue:`19206`)
 - Bug in :func:`to_datetime` where passing an out-of-bounds datetime with ``errors='coerce'`` and ``utc=True`` would raise ``OutOfBoundsDatetime`` instead of parsing to ``NaT`` (:issue:`19612`)
-- Bug in :func:`date_range` with frequency of ``Day`` or higher where dates sufficiently far in the future could wrap around to the past instead of raising ``OutOfBoundsDatetime`` (:issue:``)
+- Bug in :func:`date_range` with frequency of ``Day`` or higher where dates sufficiently far in the future could wrap around to the past instead of raising ``OutOfBoundsDatetime`` (:issue:`19740`)
 
 Timezones
 ^^^^^^^^^

--- a/doc/source/whatsnew/v0.23.0.txt
+++ b/doc/source/whatsnew/v0.23.0.txt
@@ -716,7 +716,7 @@ Datetimelike
 - Bug in :class:`Timestamp` and :func:`to_datetime` where a string representing a barely out-of-bounds timestamp would be incorrectly rounded down instead of raising ``OutOfBoundsDatetime`` (:issue:`19382`)
 - Bug in :func:`Timestamp.floor` :func:`DatetimeIndex.floor` where time stamps far in the future and past were not rounded correctly (:issue:`19206`)
 - Bug in :func:`to_datetime` where passing an out-of-bounds datetime with ``errors='coerce'`` and ``utc=True`` would raise ``OutOfBoundsDatetime`` instead of parsing to ``NaT`` (:issue:`19612`)
-- Bug in :func:`date_range` where dates sufficiently far in the future could wrap around to the past instead of raising ``OutOfBoundsDatetime`` (:issue:``)
+- Bug in :func:`date_range` with frequency of ``Day`` or higher where dates sufficiently far in the future could wrap around to the past instead of raising ``OutOfBoundsDatetime`` (:issue:``)
 
 Timezones
 ^^^^^^^^^

--- a/doc/source/whatsnew/v0.23.0.txt
+++ b/doc/source/whatsnew/v0.23.0.txt
@@ -716,7 +716,7 @@ Datetimelike
 - Bug in :class:`Timestamp` and :func:`to_datetime` where a string representing a barely out-of-bounds timestamp would be incorrectly rounded down instead of raising ``OutOfBoundsDatetime`` (:issue:`19382`)
 - Bug in :func:`Timestamp.floor` :func:`DatetimeIndex.floor` where time stamps far in the future and past were not rounded correctly (:issue:`19206`)
 - Bug in :func:`to_datetime` where passing an out-of-bounds datetime with ``errors='coerce'`` and ``utc=True`` would raise ``OutOfBoundsDatetime`` instead of parsing to ``NaT`` (:issue:`19612`)
--
+- Bug in :func:`date_range` where dates sufficiently far in the future could wrap around to the past instead of raising ``OutOfBoundsDatetime`` (:issue:``)
 
 Timezones
 ^^^^^^^^^

--- a/pandas/core/indexes/datetimes.py
+++ b/pandas/core/indexes/datetimes.py
@@ -2139,7 +2139,7 @@ def _generate_regular_range(start, end, periods, offset):
             b = Timestamp(start).value
             try:
                 with np.errstate(over='raise'):
-                    # raise instead of incorrectly wrapping around
+                    # raise instead of incorrectly wrapping around GH#19740
                     e = b + np.int64(periods) * stride
             except (FloatingPointError, OverflowError):
                 raise libts.OutOfBoundsDatetime('Cannot generate range with '
@@ -2153,7 +2153,7 @@ def _generate_regular_range(start, end, periods, offset):
             e = Timestamp(end).value + stride
             try:
                 with np.errstate(over='raise'):
-                    # raise instead of incorrectly wrapping around
+                    # raise instead of incorrectly wrapping around GH#19740
                     b = e - np.int64(periods) * stride
             except (FloatingPointError, OverflowError):
                 raise libts.OutOfBoundsDatetime('Cannot generate range with '

--- a/pandas/tests/indexes/datetimes/test_date_range.py
+++ b/pandas/tests/indexes/datetimes/test_date_range.py
@@ -80,6 +80,7 @@ class TestTimestampEquivDateRange(object):
 
 class TestDateRanges(TestData):
     def test_date_range_out_of_bounds(self):
+        # GH#19740
         with pytest.raises(OutOfBoundsDatetime):
             date_range('2016-01-01', periods=100000, freq='D')
         with pytest.raises(OutOfBoundsDatetime):

--- a/pandas/tests/indexes/datetimes/test_date_range.py
+++ b/pandas/tests/indexes/datetimes/test_date_range.py
@@ -13,6 +13,7 @@ import pandas as pd
 import pandas.util.testing as tm
 import pandas.util._test_decorators as td
 from pandas import compat
+from pandas.errors import OutOfBoundsDatetime
 from pandas import date_range, bdate_range, offsets, DatetimeIndex, Timestamp
 from pandas.tseries.offsets import (generate_range, CDay, BDay, DateOffset,
                                     MonthEnd, prefix_mapping)
@@ -78,6 +79,11 @@ class TestTimestampEquivDateRange(object):
 
 
 class TestDateRanges(TestData):
+    def test_date_range_out_of_bounds(self):
+        with pytest.raises(OutOfBoundsDatetime):
+            date_range('2016-01-01', periods=100000, freq='D')
+        with pytest.raises(OutOfBoundsDatetime):
+            date_range(end='1763-10-12', periods=100000, freq='D')
 
     def test_date_range_gen_error(self):
         rng = date_range('1/1/2000 00:00', '1/1/2000 00:18', freq='5min')


### PR DESCRIPTION
- [x] closes #14187 
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry
