### PR TITLE
[DOCS] Add example of how to preserve order of columns with usecols.

### DIFF
--- a/doc/source/io.rst
+++ b/doc/source/io.rst
@@ -136,11 +136,12 @@ usecols : array-like or callable, default ``None``
   that correspond to column names provided either by the user in `names` or
   inferred from the document header row(s). For example, a valid array-like
   `usecols` parameter would be ``[0, 1, 2]`` or ``['foo', 'bar', 'baz']``. 
-  Element order is ignored, so ``usecols=[0, 1]`` is the same as ``[1, 0]``. Element
-  order is ignored, so usecols=[1,0] is the same as [0,1]. To instantiate a
-  DataFrame with element order preserved use ``pd.read_csv(usecols=[0, 1])[[0, 1]]``
-  for columns in ``[1, 0]`` order or ``pd.read_csv(usecols=[0, 1])[[0, 1]]``
-  for ``[0, 1]`` order.
+  Element order is ignored, so ``usecols=[0, 1]`` is the same as ``[1, 0]``. To
+  instantiate a DataFrame from ``data`` with element order preserved use
+  ``pd.read_csv(data, usecols=['foo', 'bar'])[['foo', 'bar']]`` for columns
+  in ``['foo', 'bar']`` order or
+  ``pd.read_csv(data, usecols=['foo', 'bar'])[['bar', 'foo']]`` for
+  ``['bar', 'foo']`` order.
 
   If callable, the callable function will be evaluated against the column names,
   returning names where the callable function evaluates to True:

--- a/doc/source/io.rst
+++ b/doc/source/io.rst
@@ -135,7 +135,8 @@ usecols : array-like or callable, default ``None``
   be positional (i.e. integer indices into the document columns) or strings
   that correspond to column names provided either by the user in `names` or
   inferred from the document header row(s). For example, a valid array-like
-  `usecols` parameter would be ``[0, 1, 2]`` or ``['foo', 'bar', 'baz']``. 
+  `usecols` parameter would be ``[0, 1, 2]`` or ``['foo', 'bar', 'baz']``.
+
   Element order is ignored, so ``usecols=[0, 1]`` is the same as ``[1, 0]``. To
   instantiate a DataFrame from ``data`` with element order preserved use
   ``pd.read_csv(data, usecols=['foo', 'bar'])[['foo', 'bar']]`` for columns

--- a/doc/source/io.rst
+++ b/doc/source/io.rst
@@ -136,7 +136,11 @@ usecols : array-like or callable, default ``None``
   that correspond to column names provided either by the user in `names` or
   inferred from the document header row(s). For example, a valid array-like
   `usecols` parameter would be ``[0, 1, 2]`` or ``['foo', 'bar', 'baz']``. 
-  Element order is ignored, so ``usecols=[0, 1]`` is the same as ``[1, 0]``.
+  Element order is ignored, so ``usecols=[0, 1]`` is the same as ``[1, 0]``. Element
+  order is ignored, so usecols=[1,0] is the same as [0,1]. To instantiate a
+  DataFrame with element order preserved use ``pd.read_csv(usecols=[0, 1])[[0, 1]]``
+  for columns in ``[1, 0]`` order or ``pd.read_csv(usecols=[0, 1])[[0, 1]]``
+  for ``[0, 1]`` order.
 
   If callable, the callable function will be evaluated against the column names,
   returning names where the callable function evaluates to True:

--- a/pandas/io/parsers.py
+++ b/pandas/io/parsers.py
@@ -102,10 +102,12 @@ usecols : array-like or callable, default None
     that correspond to column names provided either by the user in `names` or
     inferred from the document header row(s). For example, a valid array-like
     `usecols` parameter would be [0, 1, 2] or ['foo', 'bar', 'baz']. Element
-    order is ignored, so usecols=[1,0] is the same as [0,1]. To instantiate a
-    DataFrame with element order preserved use
-    ``pd.read_csv(usecols=[0, 1])[[0, 1]]`` for columns in ``[1, 0]``
-    order or ``pd.read_csv(usecols=[0, 1])[[0, 1]]`` for ``[0, 1]`` order.
+    order is ignored, so ``usecols=[0, 1]`` is the same as ``[1, 0]``.
+    To instantiate a DataFrame from ``data`` with element order preserved use
+    ``pd.read_csv(data, usecols=['foo', 'bar'])[['foo', 'bar']]`` for columns
+    in ``['foo', 'bar']`` order or
+    ``pd.read_csv(data, usecols=['foo', 'bar'])[['bar', 'foo']]``
+    for ``['bar', 'foo']`` order.
 
     If callable, the callable function will be evaluated against the column
     names, returning names where the callable function evaluates to True. An

--- a/pandas/io/parsers.py
+++ b/pandas/io/parsers.py
@@ -102,7 +102,10 @@ usecols : array-like or callable, default None
     that correspond to column names provided either by the user in `names` or
     inferred from the document header row(s). For example, a valid array-like
     `usecols` parameter would be [0, 1, 2] or ['foo', 'bar', 'baz']. Element
-    order is ignored, so usecols=[1,0] is the same as [0,1].
+    order is ignored, so usecols=[1,0] is the same as [0,1]. To instantiate a
+    DataFrame with element order preserved use
+    ``pd.read_csv(usecols=[0, 1])[[0, 1]]`` for columns in ``[1, 0]``
+    order or ``pd.read_csv(usecols=[0, 1])[[0, 1]]`` for ``[0, 1]`` order.
 
     If callable, the callable function will be evaluated against the column
     names, returning names where the callable function evaluates to True. An


### PR DESCRIPTION
#### What's this PR do?
Adding an example of how to preserve order when using the ``usecols`` parameter.  I've noticed that some folks are still unaware that the columns will not necessarily be returned in the specified order passed to ``usecols``.
