### PR TITLE
FIX: const-correctness in numpy helpers

### DIFF
--- a/pandas/_libs/src/numpy_helper.h
+++ b/pandas/_libs/src/numpy_helper.h
@@ -32,7 +32,7 @@ PANDAS_INLINE PyObject* get_value_1d(PyArrayObject* ap, Py_ssize_t i) {
 
 // returns ASCII or UTF8 (py3) view on python str
 // python object owns memory, should not be freed
-PANDAS_INLINE char* get_c_string(PyObject* obj) {
+PANDAS_INLINE const char* get_c_string(PyObject* obj) {
 #if PY_VERSION_HEX >= 0x03000000
     return PyUnicode_AsUTF8(obj);
 #else
@@ -40,7 +40,7 @@ PANDAS_INLINE char* get_c_string(PyObject* obj) {
 #endif
 }
 
-PANDAS_INLINE PyObject* char_to_string(char* data) {
+PANDAS_INLINE PyObject* char_to_string(const char* data) {
 #if PY_VERSION_HEX >= 0x03000000
     return PyUnicode_FromString(data);
 #else


### PR DESCRIPTION
In python 3.7 the return type of PyUnicode_AsUTF8 changed
from (char *) to (const char *).

PyUnicode_FromString also takes (const char *) as input, also be
explicit about that.

https://bugs.python.org/issue28769
commit 2a404b63d48d73bbaa007d89efb7a01048475acd in cpython

- [ ] closes #xxxx
- [ ] tests added / passed
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
