### PR TITLE
BUG: DataFrame.diff(axis=0) with DatetimeTZ data

### DIFF
--- a/doc/source/whatsnew/v0.23.0.txt
+++ b/doc/source/whatsnew/v0.23.0.txt
@@ -833,6 +833,7 @@ Timezones
 - Bug in the :class:`DataFrame` constructor, where tz-aware Datetimeindex and a given column name will result in an empty ``DataFrame`` (:issue:`19157`)
 - Bug in :func:`Timestamp.tz_localize` where localizing a timestamp near the minimum or maximum valid values could overflow and return a timestamp with an incorrect nanosecond value (:issue:`12677`)
 - Bug when iterating over :class:`DatetimeIndex` that was localized with fixed timezone offset that rounded nanosecond precision to microseconds (:issue:`19603`)
+- Bug in :func:`DataFrame.diff` that raised an ``IndexError`` with tz-aware values (:issue:`18578`)
 
 Offsets
 ^^^^^^^

--- a/pandas/core/internals.py
+++ b/pandas/core/internals.py
@@ -2905,6 +2905,18 @@ class DatetimeTZBlock(NonConsolidatableMixIn, DatetimeBlock):
         return [self.make_block_same_class(new_values,
                                            placement=self.mgr_locs)]
 
+    def diff(self, n, axis=0, mgr=None):
+        """1st discrete difference"""
+        if axis == 0:
+            # Cannot currently calculate diff across multiple blocks since this
+            # function is invoked via apply
+            raise NotImplementedError
+        new_values = (self.values - self.shift(n, axis=axis)[0].values).asi8
+        # Reshape the new_values like how algos.diff does for timedelta data
+        new_values = new_values.reshape(1, len(new_values))
+        new_values = new_values.astype('timedelta64[ns]')
+        return [TimeDeltaBlock(new_values, placement=self.mgr_locs.indexer)]
+
     def concat_same_type(self, to_concat, placement=None):
         """
         Concatenate list of single blocks of the same type.

--- a/pandas/core/internals.py
+++ b/pandas/core/internals.py
@@ -2906,7 +2906,23 @@ class DatetimeTZBlock(NonConsolidatableMixIn, DatetimeBlock):
                                            placement=self.mgr_locs)]
 
     def diff(self, n, axis=0, mgr=None):
-        """1st discrete difference"""
+        """1st discrete difference
+
+        Parameters
+        ----------
+        n : int, number of periods to diff
+        axis : int, axis to diff upon. default 0
+        mgr : default None
+
+        Return
+        ------
+        A list with a new TimeDeltaBlock.
+
+        Note
+        ----
+        The arguments here are mimicking shift so they are called correctly
+        by apply.
+        """
         if axis == 0:
             # Cannot currently calculate diff across multiple blocks since this
             # function is invoked via apply

--- a/pandas/core/internals.py
+++ b/pandas/core/internals.py
@@ -2928,6 +2928,7 @@ class DatetimeTZBlock(NonConsolidatableMixIn, DatetimeBlock):
             # function is invoked via apply
             raise NotImplementedError
         new_values = (self.values - self.shift(n, axis=axis)[0].values).asi8
+
         # Reshape the new_values like how algos.diff does for timedelta data
         new_values = new_values.reshape(1, len(new_values))
         new_values = new_values.astype('timedelta64[ns]')

--- a/pandas/tests/frame/test_timeseries.py
+++ b/pandas/tests/frame/test_timeseries.py
@@ -57,6 +57,29 @@ class TestDataFrameTimeSeriesMethods(TestData):
             1), 'z': pd.Series(1)}).astype('float64')
         assert_frame_equal(result, expected)
 
+    @pytest.mark.parametrize('axis', [0, 1])
+    @pytest.mark.parametrize('tz', [None, 'UTC'])
+    def test_diff_datetime(self, axis, tz):
+        # GH 18578
+        df = DataFrame({0: date_range('2010', freq='D', periods=2, tz=tz),
+                        1: date_range('2010', freq='D', periods=2, tz=tz)})
+        if axis == 1:
+            if tz is None:
+                result = df.diff(axis=axis)
+                expected = DataFrame({0: pd.TimedeltaIndex(['NaT', 'NaT']),
+                                      1: pd.TimedeltaIndex(['0 days',
+                                                            '0 days'])})
+                assert_frame_equal(result, expected)
+            else:
+                with pytest.raises(NotImplementedError):
+                    result = df.diff(axis=axis)
+
+        else:
+            result = df.diff(axis=axis)
+            expected = DataFrame({0: pd.TimedeltaIndex(['NaT', '1 days']),
+                                  1: pd.TimedeltaIndex(['NaT', '1 days'])})
+            assert_frame_equal(result, expected)
+
     def test_diff_timedelta(self):
         # GH 4533
         df = DataFrame(dict(time=[Timestamp('20130101 9:01'),

--- a/pandas/tests/frame/test_timeseries.py
+++ b/pandas/tests/frame/test_timeseries.py
@@ -57,28 +57,31 @@ class TestDataFrameTimeSeriesMethods(TestData):
             1), 'z': pd.Series(1)}).astype('float64')
         assert_frame_equal(result, expected)
 
-    @pytest.mark.parametrize('axis', [0, 1])
     @pytest.mark.parametrize('tz', [None, 'UTC'])
-    def test_diff_datetime(self, axis, tz):
+    def test_diff_datetime_axis0(self, tz):
         # GH 18578
         df = DataFrame({0: date_range('2010', freq='D', periods=2, tz=tz),
                         1: date_range('2010', freq='D', periods=2, tz=tz)})
-        if axis == 1:
-            if tz is None:
-                result = df.diff(axis=axis)
-                expected = DataFrame({0: pd.TimedeltaIndex(['NaT', 'NaT']),
-                                      1: pd.TimedeltaIndex(['0 days',
-                                                            '0 days'])})
-                assert_frame_equal(result, expected)
-            else:
-                with pytest.raises(NotImplementedError):
-                    result = df.diff(axis=axis)
 
-        else:
-            result = df.diff(axis=axis)
-            expected = DataFrame({0: pd.TimedeltaIndex(['NaT', '1 days']),
-                                  1: pd.TimedeltaIndex(['NaT', '1 days'])})
+        result = df.diff(axis=0)
+        expected = DataFrame({0: pd.TimedeltaIndex(['NaT', '1 days']),
+                              1: pd.TimedeltaIndex(['NaT', '1 days'])})
+        assert_frame_equal(result, expected)
+
+    @pytest.mark.parametrize('tz', [None, 'UTC'])
+    def test_diff_datetime_axis1(self, tz):
+        # GH 18578
+        df = DataFrame({0: date_range('2010', freq='D', periods=2, tz=tz),
+                        1: date_range('2010', freq='D', periods=2, tz=tz)})
+        if tz is None:
+            result = df.diff(axis=1)
+            expected = DataFrame({0: pd.TimedeltaIndex(['NaT', 'NaT']),
+                                  1: pd.TimedeltaIndex(['0 days',
+                                                        '0 days'])})
             assert_frame_equal(result, expected)
+        else:
+            with pytest.raises(NotImplementedError):
+                result = df.diff(axis=1)
 
     def test_diff_timedelta(self):
         # GH 4533


### PR DESCRIPTION
- [x] closes #18578
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry

Unfortunately, `DataFrame.diff` doesn't work correctly with axis=1; it returns values like so after this patch:

```
In [2]:         df = DataFrame({0: date_range('2010', freq='D', periods=2, tz='utc'),
   ...:                         1: date_range('2010', freq='D', periods=2, tz='utc')})
   ...:

In [3]: df.diff(axis=1)
Out[3]:
       0      1
0    NaT    NaT
1    NaT    NaT
```

I believe this is because `diff` is implemented by iterating over the 2 DatetimeTZBlocks (via `BlockManager.apply`, but `diff` needs data from both blocks at once. (Is it possible to consolidate 2 DatetimeTZBlocks?) I made this raise a `NotImplimentedError` for now. 