### PR TITLE
Sparse Ops Cleanup

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -3995,7 +3995,7 @@ class DataFrame(NDFrame):
                                    try_cast=try_cast)
         return self._constructor(new_data)
 
-    def _compare_frame(self, other, func, str_rep, try_cast=True):
+    def _compare_frame(self, other, func, str_rep):
         # compare_frame assumes self._indexed_same(other)
 
         import pandas.core.computation.expressions as expressions

--- a/pandas/core/indexes/timedeltas.py
+++ b/pandas/core/indexes/timedeltas.py
@@ -928,7 +928,7 @@ class TimedeltaIndex(DatetimeIndexOpsMixin, TimelikeOps, Int64Index):
 
     def delete(self, loc):
         """
-        Make a new DatetimeIndex with passed location(s) deleted.
+        Make a new TimedeltaIndex with passed location(s) deleted.
 
         Parameters
         ----------

--- a/pandas/core/sparse/array.py
+++ b/pandas/core/sparse/array.py
@@ -54,6 +54,9 @@ def _get_fill(arr):
 
 
 def _sparse_array_op(left, right, op, name, series=False):
+    if name.startswith('__'):
+        # For lookups in _libs.sparse we need non-dunder op name
+        name = name[2:-2]
 
     if series and is_integer_dtype(left) and is_integer_dtype(right):
         # series coerces to float64 if result should have NaN/inf
@@ -119,6 +122,10 @@ def _sparse_array_op(left, right, op, name, series=False):
 
 def _wrap_result(name, data, sparse_index, fill_value, dtype=None):
     """ wrap op result to have correct dtype """
+    if name.startswith('__'):
+        # e.g. __eq__ --> eq
+        name = name[2:-2]
+
     if name in ('eq', 'ne', 'lt', 'gt', 'le', 'ge'):
         dtype = np.bool
 

--- a/pandas/core/sparse/frame.py
+++ b/pandas/core/sparse/frame.py
@@ -551,7 +551,6 @@ class SparseDataFrame(DataFrame):
             return self._constructor(index=new_index).__finalize__(self)
 
         new_data = {}
-        new_fill_value = None
         if fill_value is not None:
             # TODO: be a bit more intelligent here
             for col in new_columns:
@@ -568,6 +567,7 @@ class SparseDataFrame(DataFrame):
                     new_data[col] = func(this[col], other[col])
 
         # if the fill values are the same use them? or use a valid one
+        new_fill_value = None
         other_fill_value = getattr(other, 'default_fill_value', np.nan)
         if self.default_fill_value == other_fill_value:
             new_fill_value = self.default_fill_value

--- a/pandas/core/sparse/series.py
+++ b/pandas/core/sparse/series.py
@@ -811,10 +811,7 @@ class SparseSeries(Series):
         return _coo_to_sparse_series(A, dense_index=dense_index)
 
 
-# overwrite series methods with unaccelerated versions
-ops.add_special_arithmetic_methods(SparseSeries, **ops.series_special_funcs)
+# overwrite series methods with unaccelerated Sparse-specific versions
 ops.add_flex_arithmetic_methods(SparseSeries, **ops.series_flex_funcs)
-# overwrite basic arithmetic to use SparseSeries version
-# force methods to overwrite previous definitions.
 ops.add_special_arithmetic_methods(SparseSeries,
                                    **ops.sparse_series_special_funcs)


### PR DESCRIPTION
This is in preparation for implementing the direct-pinning discussed [here](https://github.com/pandas-dev/pandas/pull/19649#discussion_r167527010).  The main roadblock to that is SparseSeries which calls ops.add_special_arithmetic_methods twice.  This PR gets rid of the double-call, so the follow-up will be straight-forward.

A handful of cleanups are done here too:
 - unrelated docstring fix for TimedeltaIndex.replace
 - minor formatting improvements
 - remove an unused kwarg for DataFrame._compare_frame
 - remove a loop in add_flex_arithmetic_methods, replace with an assertion that it is unnecessary
 - fix names for some SparseArray method names, e.g. ATM `SparseArray.__eq__.__name__ == 'eq'`
