### PR TITLE
Update df.to_stata() docstring

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -1640,6 +1640,16 @@ class DataFrame(NDFrame):
         Or with dates
 
         >>> data.to_stata('./date_data_file.dta', {2 : 'tw'})
+
+        Alternatively you can create an instance of the StataWriter class
+
+        >>> writer = StataWriter('./data_file.dta', data)
+        >>> writer.write_file()
+
+        With dates:
+
+        >>> writer = StataWriter('./date_data_file.dta', data, {2 : 'tw'})
+        >>> writer.write_file()
         """
         from pandas.io.stata import StataWriter
         writer = StataWriter(fname, self, convert_dates=convert_dates,

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -1612,7 +1612,7 @@ class DataFrame(NDFrame):
         time_stamp : datetime
             A datetime to use as file creation date.  Default is the current
             time.
-        dataset_label : str
+        data_label : str
             A label for the data set.  Must be 80 characters or smaller.
         variable_labels : dict
             Dictionary containing columns as keys and variable labels as
@@ -1635,13 +1635,11 @@ class DataFrame(NDFrame):
 
         Examples
         --------
-        >>> writer = StataWriter('./data_file.dta', data)
-        >>> writer.write_file()
+        >>> data.to_stata('./data_file.dta')
 
         Or with dates
 
-        >>> writer = StataWriter('./date_data_file.dta', data, {2 : 'tw'})
-        >>> writer.write_file()
+        >>> data.to_stata('./date_data_file.dta', {2 : 'tw'})
         """
         from pandas.io.stata import StataWriter
         writer = StataWriter(fname, self, convert_dates=convert_dates,


### PR DESCRIPTION
Updates the docstring for the `to_stata()` method to fix the `dataset_label` parameter. See #19817. Also changes the examples; it's a little weird for the examples for `to_stata()` to detail the `StataWriter` class.

- [ ] closes #19817
- [ ] tests added / passed
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
