### PR TITLE
Fix rfloordiv return type, un-xfail Timedelta tests

### DIFF
--- a/doc/source/whatsnew/v0.23.0.txt
+++ b/doc/source/whatsnew/v0.23.0.txt
@@ -744,6 +744,7 @@ Timedelta
 - Bug in :func:`Timedelta.__floordiv__`, :func:`Timedelta.__rfloordiv__` where operating with a ``Tick`` object would raise a ``TypeError`` instead of returning a numeric value (:issue:`19738`)
 - Bug in :func:`Period.asfreq` where periods near ``datetime(1, 1, 1)`` could be converted incorrectly (:issue:`19643`)
 - Bug in :func:`Timedelta.total_seconds()` causing precision errors i.e. ``Timedelta('30S').total_seconds()==30.000000000000004`` (:issue:`19458`)
+- Bug in :func: `Timedelta.__rmod__` where operating with a ``numpy.timedelta64`` returned a ``timedelta64`` object instead of a ``Timedelta`` (:issue:`19378`)
 -
 
 Timezones

--- a/doc/source/whatsnew/v0.23.0.txt
+++ b/doc/source/whatsnew/v0.23.0.txt
@@ -765,7 +765,7 @@ Timedelta
 - Bug in :func:`Timedelta.__floordiv__`, :func:`Timedelta.__rfloordiv__` where operating with a ``Tick`` object would raise a ``TypeError`` instead of returning a numeric value (:issue:`19738`)
 - Bug in :func:`Period.asfreq` where periods near ``datetime(1, 1, 1)`` could be converted incorrectly (:issue:`19643`)
 - Bug in :func:`Timedelta.total_seconds()` causing precision errors i.e. ``Timedelta('30S').total_seconds()==30.000000000000004`` (:issue:`19458`)
-- Bug in :func: `Timedelta.__rmod__` where operating with a ``numpy.timedelta64`` returned a ``timedelta64`` object instead of a ``Timedelta`` (:issue:`19378`)
+- Bug in :func: `Timedelta.__rmod__` where operating with a ``numpy.timedelta64`` returned a ``timedelta64`` object instead of a ``Timedelta`` (:issue:`19820`)
 - Multiplication of :class:`TimedeltaIndex` by ``TimedeltaIndex`` will now raise ``TypeError`` instead of raising ``ValueError`` in cases of length mis-match (:issue`19333`)
 -
 

--- a/pandas/_libs/tslibs/timedeltas.pyx
+++ b/pandas/_libs/tslibs/timedeltas.pyx
@@ -1109,7 +1109,11 @@ class Timedelta(_Timedelta):
                 return self // other.delta
             return NotImplemented
 
-        if hasattr(other, 'dtype'):
+        elif is_timedelta64_object(other):
+            # convert to Timedelta below
+            pass
+
+        elif hasattr(other, 'dtype'):
             if other.dtype.kind == 'm':
                 # also timedelta-like
                 return _broadcast_floordiv_td64(self.value, other, _floordiv)
@@ -1144,7 +1148,11 @@ class Timedelta(_Timedelta):
                 return other.delta // self
             return NotImplemented
 
-        if hasattr(other, 'dtype'):
+        elif is_timedelta64_object(other):
+            # convert to Timedelta below
+            pass
+
+        elif hasattr(other, 'dtype'):
             if other.dtype.kind == 'm':
                 # also timedelta-like
                 return _broadcast_floordiv_td64(self.value, other, _rfloordiv)

--- a/pandas/tests/scalar/timedelta/test_arithmetic.py
+++ b/pandas/tests/scalar/timedelta/test_arithmetic.py
@@ -441,7 +441,6 @@ class TestTimedeltaMultiplicationDivision(object):
         result = td % NaT
         assert result is NaT
 
-    @pytest.mark.xfail(reason='GH#19378 floordiv td64 returns td64')
     def test_mod_timedelta64_nat(self):
         # GH#19365
         td = Timedelta(hours=37)
@@ -449,7 +448,6 @@ class TestTimedeltaMultiplicationDivision(object):
         result = td % np.timedelta64('NaT', 'ns')
         assert result is NaT
 
-    @pytest.mark.xfail(reason='GH#19378 floordiv td64 returns td64')
     def test_mod_timedelta64(self):
         # GH#19365
         td = Timedelta(hours=37)
@@ -458,7 +456,6 @@ class TestTimedeltaMultiplicationDivision(object):
         assert isinstance(result, Timedelta)
         assert result == Timedelta(hours=1)
 
-    @pytest.mark.xfail(reason='GH#19378 floordiv by Tick not implemented')
     def test_mod_offset(self):
         # GH#19365
         td = Timedelta(hours=37)
@@ -505,7 +502,6 @@ class TestTimedeltaMultiplicationDivision(object):
         assert isinstance(result, Timedelta)
         assert result == Timedelta(minutes=1)
 
-    @pytest.mark.xfail(reason='GH#19378 floordiv by Tick not implemented')
     def test_rmod_timedelta64(self):
         # GH#19365
         td = Timedelta(minutes=3)
@@ -564,7 +560,6 @@ class TestTimedeltaMultiplicationDivision(object):
         assert np.isnan(result[0])
         assert result[1] is pd.NaT
 
-    @pytest.mark.xfail(reason='GH#19378 floordiv by Tick not implemented')
     def test_divmod_offset(self):
         # GH#19365
         td = Timedelta(days=2, hours=6)
@@ -588,7 +583,6 @@ class TestTimedeltaMultiplicationDivision(object):
         assert isinstance(result[1], Timedelta)
         assert result[1] == Timedelta(hours=6)
 
-    @pytest.mark.xfail(reason='GH#19378 floordiv by Tick not implemented')
     def test_rdivmod_offset(self):
         result = divmod(pd.offsets.Hour(54), Timedelta(hours=-4))
         assert result[0] == -14


### PR DESCRIPTION
- [ ] closes #xxxx
- [x] tests added / passed
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry