### PR TITLE
Keep subclassing in apply

### DIFF
--- a/doc/source/whatsnew/v0.23.0.txt
+++ b/doc/source/whatsnew/v0.23.0.txt
@@ -295,7 +295,7 @@ Other Enhancements
 - ``IntervalIndex.astype`` now supports conversions between subtypes when passed an ``IntervalDtype`` (:issue:`19197`)
 - :class:`IntervalIndex` and its associated constructor methods (``from_arrays``, ``from_breaks``, ``from_tuples``) have gained a ``dtype`` parameter (:issue:`19262`)
 - Added :func:`SeriesGroupBy.is_monotonic_increasing` and :func:`SeriesGroupBy.is_monotonic_decreasing` (:issue:`17015`)
-- :func:``DataFrame.apply`` keeps provides the specified ``Series`` subclass when `DataFrame._constructor_sliced`` is defined (:issue:`19822`)
+- :func:``DataFrame.apply`` keeps the specified ``Series`` subclass when ``Series`` and ``DataFrame`` subclasses are defined (:issue:`19822`)
 
 .. _whatsnew_0230.api_breaking:
 

--- a/doc/source/whatsnew/v0.23.0.txt
+++ b/doc/source/whatsnew/v0.23.0.txt
@@ -295,6 +295,7 @@ Other Enhancements
 - ``IntervalIndex.astype`` now supports conversions between subtypes when passed an ``IntervalDtype`` (:issue:`19197`)
 - :class:`IntervalIndex` and its associated constructor methods (``from_arrays``, ``from_breaks``, ``from_tuples``) have gained a ``dtype`` parameter (:issue:`19262`)
 - Added :func:`SeriesGroupBy.is_monotonic_increasing` and :func:`SeriesGroupBy.is_monotonic_decreasing` (:issue:`17015`)
+- :func:``DataFrame.apply`` keeps provides the specified ``Series`` subclass when `DataFrame._constructor_sliced`` is defined (:issue:`19822`)
 
 .. _whatsnew_0230.api_breaking:
 

--- a/doc/source/whatsnew/v0.23.0.txt
+++ b/doc/source/whatsnew/v0.23.0.txt
@@ -295,7 +295,7 @@ Other Enhancements
 - ``IntervalIndex.astype`` now supports conversions between subtypes when passed an ``IntervalDtype`` (:issue:`19197`)
 - :class:`IntervalIndex` and its associated constructor methods (``from_arrays``, ``from_breaks``, ``from_tuples``) have gained a ``dtype`` parameter (:issue:`19262`)
 - Added :func:`SeriesGroupBy.is_monotonic_increasing` and :func:`SeriesGroupBy.is_monotonic_decreasing` (:issue:`17015`)
-- :func:``DataFrame.apply`` keeps the specified ``Series`` subclass when ``Series`` and ``DataFrame`` subclasses are defined (:issue:`19822`)
+- For subclassed ``DataFrames``, :func:`DataFrame.apply` will now preserve the ``Series`` subclass (if defined) when passing the data to the applied function (:issue:`19822`)
 - :func:`DataFrame.from_dict` now accepts a ``columns`` argument that can be used to specify the column names when ``orient='index'`` is used (:issue:`18529`)
 
 

--- a/pandas/core/apply.py
+++ b/pandas/core/apply.py
@@ -153,6 +153,7 @@ class FrameApply(object):
 
         from pandas import Series
         if not reduce:
+
             EMPTY_SERIES = Series([])
             try:
                 r = self.f(EMPTY_SERIES, *self.args, **self.kwds)

--- a/pandas/core/apply.py
+++ b/pandas/core/apply.py
@@ -151,8 +151,8 @@ class FrameApply(object):
         # we may need to infer
         reduce = self.result_type == 'reduce'
 
+        from pandas import Series
         if not reduce:
-            from pandas import Series
             EMPTY_SERIES = Series([])
             try:
                 r = self.f(EMPTY_SERIES, *self.args, **self.kwds)
@@ -386,7 +386,7 @@ class FrameColumnApply(FrameApply):
         else:
             result = self.infer_to_same_shape()
 
-        return self.obj._constructor_sliced(result)
+        return result
 
     def infer_to_same_shape(self):
         """ infer the results to the same shape as the input object """

--- a/pandas/tests/frame/test_subclass.py
+++ b/pandas/tests/frame/test_subclass.py
@@ -546,7 +546,11 @@ class TestDataFrameSubclassing(TestData):
             [1, 2, 3],
             [1, 2, 3]])
 
-        expected3 = tm.SubclassedSeries([[1, 2, 3], [1, 2, 3], [1, 2, 3], [1, 2, 3]])
+        expected3 = tm.SubclassedSeries([
+            [1, 2, 3],
+            [1, 2, 3],
+            [1, 2, 3],
+            [1, 2, 3]])
 
         df.apply(lambda x: check_row_subclass(x))
         df.apply(lambda x: check_row_subclass(x), axis=1)

--- a/pandas/tests/frame/test_subclass.py
+++ b/pandas/tests/frame/test_subclass.py
@@ -546,7 +546,7 @@ class TestDataFrameSubclassing(TestData):
             [1, 2, 3],
             [1, 2, 3]])
 
-        expected3 = DesignSeries([[1, 2, 3], [1, 2, 3], [1, 2, 3], [1, 2, 3]])
+        expected3 = tm.SubclassedSeries([[1, 2, 3], [1, 2, 3], [1, 2, 3], [1, 2, 3]])
 
         df.apply(lambda x: check_row_subclass(x))
         df.apply(lambda x: check_row_subclass(x), axis=1)

--- a/pandas/tests/frame/test_subclass.py
+++ b/pandas/tests/frame/test_subclass.py
@@ -544,9 +544,9 @@ class TestDataFrameSubclassing(TestData):
             [1, 2, 3],
             [1, 2, 3],
             [1, 2, 3],
-            [1, 2, 3],])
+            [1, 2, 3]])
 
-        expected3 = DesignSeries([[1,2,3],[1,2,3],[1,2,3],[1,2,3],])
+        expected3 = DesignSeries([[1, 2, 3], [1, 2, 3], [1, 2, 3], [1, 2, 3]])
 
         df.apply(lambda x: check_row_subclass(x))
         df.apply(lambda x: check_row_subclass(x), axis=1)
@@ -566,5 +566,3 @@ class TestDataFrameSubclassing(TestData):
         result4 = df.apply(lambda x: [1, 2, 3], axis=1, result_type="expand")
         assert isinstance(result4, tm.SubclassedDataFrame)
         tm.assert_frame_equal(result4, expected2)
-
-

--- a/pandas/tests/frame/test_subclass.py
+++ b/pandas/tests/frame/test_subclass.py
@@ -514,3 +514,20 @@ class TestDataFrameSubclassing(TestData):
         long_frame = pd.wide_to_long(df, ["A", "B"], i="id", j="year")
 
         tm.assert_frame_equal(long_frame, expected)
+
+    def test_subclassed_apply(self):
+        #GH 19822
+
+        def check_row_subclass( row ):
+            assert isinstance(row, tm.SubclassedSeries)
+
+        df = tm.SubclassedDataFrame({
+            ['John', 'Doe', 'height', 5.5],
+            ['Mary', 'Bo', 'height', 6.0],
+            ['John', 'Doe', 'weight', 130],
+            ['Mary', 'Bo', 'weight', 150]],
+            columns=['first', 'last', 'variable', 'value']
+        })
+
+        df.apply(lambda x: check_row_subclass(x))
+        df.apply(lambda x: check_row_subclass(x), axis=1)

--- a/pandas/tests/frame/test_subclass.py
+++ b/pandas/tests/frame/test_subclass.py
@@ -555,7 +555,7 @@ class TestDataFrameSubclassing(TestData):
         assert isinstance(result1, tm.SubclassedDataFrame)
         tm.assert_frame_equal(result1, expected1)
 
-        result2 = df.apply(lambda x: DesignSeries([1, 2, 3]), axis=1)
+        result2 = df.apply(lambda x: tm.SubclassedSeries([1, 2, 3]), axis=1)
         assert isinstance(result2, tm.SubclassedDataFrame)
         tm.assert_frame_equal(result2, expected2)
 

--- a/pandas/tests/frame/test_subclass.py
+++ b/pandas/tests/frame/test_subclass.py
@@ -533,40 +533,40 @@ class TestDataFrameSubclassing(TestData):
             ['Mary', 'Bo', 'weight', 150]],
             columns=['first', 'last', 'variable', 'value'])
 
-        expected1 = tm.SubclassedDataFrame([
+        df.apply(lambda x: check_row_subclass(x))
+        df.apply(lambda x: check_row_subclass(x), axis=1)
+
+        expected = tm.SubclassedDataFrame([
             ['John', 'Doe', 'height', 6.0],
             ['Mary', 'Bo', 'height', 6.5],
             ['John', 'Doe', 'weight', 130],
             ['Mary', 'Bo', 'weight', 150]],
             columns=['first', 'last', 'variable', 'value'])
 
-        expected2 = tm.SubclassedDataFrame([
+        result = df.apply(lambda x: strech(x), axis=1)
+        assert isinstance(result, tm.SubclassedDataFrame)
+        tm.assert_frame_equal(result, expected1)
+
+        expected = tm.SubclassedDataFrame([
             [1, 2, 3],
             [1, 2, 3],
             [1, 2, 3],
             [1, 2, 3]])
 
-        expected3 = tm.SubclassedSeries([
+        result = df.apply(lambda x: tm.SubclassedSeries([1, 2, 3]), axis=1)
+        assert isinstance(result, tm.SubclassedDataFrame)
+        tm.assert_frame_equal(result, expected)
+
+        result = df.apply(lambda x: [1, 2, 3], axis=1, result_type="expand")
+        assert isinstance(result, tm.SubclassedDataFrame)
+        tm.assert_frame_equal(result, expected)
+
+        expected = tm.SubclassedSeries([
             [1, 2, 3],
             [1, 2, 3],
             [1, 2, 3],
             [1, 2, 3]])
 
-        df.apply(lambda x: check_row_subclass(x))
-        df.apply(lambda x: check_row_subclass(x), axis=1)
-
-        result1 = df.apply(lambda x: strech(x), axis=1)
-        assert isinstance(result1, tm.SubclassedDataFrame)
-        tm.assert_frame_equal(result1, expected1)
-
-        result2 = df.apply(lambda x: tm.SubclassedSeries([1, 2, 3]), axis=1)
-        assert isinstance(result2, tm.SubclassedDataFrame)
-        tm.assert_frame_equal(result2, expected2)
-
-        result3 = df.apply(lambda x: [1, 2, 3], axis=1)
-        assert not isinstance(result3, tm.SubclassedDataFrame)
-        tm.assert_series_equal(result3, expected3)
-
-        result4 = df.apply(lambda x: [1, 2, 3], axis=1, result_type="expand")
-        assert isinstance(result4, tm.SubclassedDataFrame)
-        tm.assert_frame_equal(result4, expected2)
+        result = df.apply(lambda x: [1, 2, 3], axis=1)
+        assert not isinstance(result, tm.SubclassedDataFrame)
+        tm.assert_series_equal(result, expected)

--- a/pandas/tests/frame/test_subclass.py
+++ b/pandas/tests/frame/test_subclass.py
@@ -521,13 +521,12 @@ class TestDataFrameSubclassing(TestData):
         def check_row_subclass( row ):
             assert isinstance(row, tm.SubclassedSeries)
 
-        df = tm.SubclassedDataFrame({
+        df = tm.SubclassedDataFrame([
             ['John', 'Doe', 'height', 5.5],
             ['Mary', 'Bo', 'height', 6.0],
             ['John', 'Doe', 'weight', 130],
             ['Mary', 'Bo', 'weight', 150]],
-            columns=['first', 'last', 'variable', 'value']
-        })
+            columns=['first', 'last', 'variable', 'value'])
 
         df.apply(lambda x: check_row_subclass(x))
         df.apply(lambda x: check_row_subclass(x), axis=1)

--- a/pandas/tests/frame/test_subclass.py
+++ b/pandas/tests/frame/test_subclass.py
@@ -545,7 +545,7 @@ class TestDataFrameSubclassing(TestData):
 
         result = df.apply(lambda x: strech(x), axis=1)
         assert isinstance(result, tm.SubclassedDataFrame)
-        tm.assert_frame_equal(result, expected1)
+        tm.assert_frame_equal(result, expected)
 
         expected = tm.SubclassedDataFrame([
             [1, 2, 3],


### PR DESCRIPTION
When generating new objects on apply, it calls `self.obj._constructor` and `self.obj._constructior_sliced` instead of:  `DataFrame` and `Series`; keeping subclassing.

- [x] closes #19822
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] keeps subclass inside `DataFrame.apply`
