### PR TITLE
ENH: Let initialisation from dicts use insertion order for python >= 3.6 (part I)

### DIFF
--- a/pandas/tests/frame/test_apply.py
+++ b/pandas/tests/frame/test_apply.py
@@ -646,7 +646,7 @@ class TestInferOutputShape(object):
                         'datetime': [pd.Timestamp('2017-11-29 03:30:00'),
                                      pd.Timestamp('2017-11-29 03:45:00')]})
         result = df.apply(lambda row: (row.number, row.string), axis=1)
-        expected = Series([t[2:] for t in df.itertuples()])
+        expected = Series([(t.number, t.string) for t in df.itertuples()])
         assert_series_equal(result, expected)
 
     def test_infer_output_shape_listlike_columns(self):

--- a/pandas/tests/frame/test_block_internals.py
+++ b/pandas/tests/frame/test_block_internals.py
@@ -405,8 +405,8 @@ starting,ending,measure
         result = df.get_dtype_counts()
         expected = Series({'int64': 1, 'float64': 1,
                            datetime64name: 1, objectname: 1})
-        result.sort_index()
-        expected.sort_index()
+        result = result.sort_index()
+        expected = expected.sort_index()
         assert_series_equal(result, expected)
 
         df = DataFrame({'a': 1., 'b': 2, 'c': 'foo',

--- a/pandas/tests/frame/test_constructors.py
+++ b/pandas/tests/frame/test_constructors.py
@@ -1362,9 +1362,8 @@ class TestDataFrameConstructors(TestData):
             expected['float64'] = 1
             expected[floatname] = 1
 
-        result.sort_index()
-        expected = Series(expected)
-        expected.sort_index()
+        result = result.sort_index()
+        expected = Series(expected).sort_index()
         tm.assert_series_equal(result, expected)
 
         # check with ndarray construction ndim>0
@@ -1373,7 +1372,7 @@ class TestDataFrameConstructors(TestData):
                         intname: np.array([1] * 10, dtype=intname)},
                        index=np.arange(10))
         result = df.get_dtype_counts()
-        result.sort_index()
+        result = result.sort_index()
         tm.assert_series_equal(result, expected)
 
         # GH 2809
@@ -1384,8 +1383,8 @@ class TestDataFrameConstructors(TestData):
         df = DataFrame({'datetime_s': datetime_s})
         result = df.get_dtype_counts()
         expected = Series({datetime64name: 1})
-        result.sort_index()
-        expected.sort_index()
+        result = result.sort_index()
+        expected = expected.sort_index()
         tm.assert_series_equal(result, expected)
 
         # GH 2810
@@ -1395,8 +1394,8 @@ class TestDataFrameConstructors(TestData):
         df = DataFrame({'datetimes': datetimes, 'dates': dates})
         result = df.get_dtype_counts()
         expected = Series({datetime64name: 1, objectname: 1})
-        result.sort_index()
-        expected.sort_index()
+        result = result.sort_index()
+        expected = expected.sort_index()
         tm.assert_series_equal(result, expected)
 
         # GH 7594
@@ -1519,8 +1518,8 @@ class TestDataFrameConstructors(TestData):
         result = df.get_dtype_counts()
         expected = Series(
             {'int64': 1, 'float64': 2, datetime64name: 1, objectname: 1})
-        result.sort_index()
-        expected.sort_index()
+        result = result.sort_index()
+        expected = expected.sort_index()
         tm.assert_series_equal(result, expected)
 
     def test_constructor_frame_copy(self):
@@ -1832,7 +1831,7 @@ class TestDataFrameConstructors(TestData):
         rows.append([datetime(2010, 1, 1), 1])
         rows.append([datetime(2010, 1, 2), 1])
         df2_obj = DataFrame.from_records(rows, columns=['date', 'test'])
-        results = df2_obj.get_dtype_counts()
+        results = df2_obj.get_dtype_counts().sort_index()
         expected = Series({'datetime64[ns]': 1, 'int64': 1})
         tm.assert_series_equal(results, expected)
 

--- a/pandas/tests/frame/test_dtypes.py
+++ b/pandas/tests/frame/test_dtypes.py
@@ -725,9 +725,9 @@ class TestDataFrameDataTypes(TestData):
         df = DataFrame(dict(A=Series(date_range('2012-1-1', periods=3,
                                                 freq='D')),
                             B=Series([timedelta(days=i) for i in range(3)])))
-        result = df.get_dtype_counts().sort_values()
+        result = df.get_dtype_counts().sort_index()
         expected = Series(
-            {'datetime64[ns]': 1, 'timedelta64[ns]': 1}).sort_values()
+            {'datetime64[ns]': 1, 'timedelta64[ns]': 1}).sort_index()
         assert_series_equal(result, expected)
 
         df['C'] = df['A'] + df['B']

--- a/pandas/tests/frame/test_indexing.py
+++ b/pandas/tests/frame/test_indexing.py
@@ -2430,8 +2430,8 @@ class TestDataFrameIndexing(TestData):
 
         # upcasting case (GH # 2794)
         df = DataFrame(dict((c, Series([1] * 3, dtype=c))
-                            for c in ['int64', 'int32',
-                                      'float32', 'float64']))
+                            for c in ['float32', 'float64',
+                                      'int32', 'int64']))
         df.iloc[1, :] = 0
         result = df.where(df >= 0).get_dtype_counts()
 

--- a/pandas/tests/frame/test_mutate_columns.py
+++ b/pandas/tests/frame/test_mutate_columns.py
@@ -166,17 +166,17 @@ class TestDataFrameMutateColumns(TestData):
 
         # new item
         df['x'] = df['a'].astype('float32')
-        result = Series(dict(float64=5, float32=1))
-        assert (df.get_dtype_counts() == result).all()
+        result = Series(dict(float32=1, float64=5))
+        assert (df.get_dtype_counts().sort_index() == result).all()
 
         # replacing current (in different block)
         df['a'] = df['a'].astype('float32')
-        result = Series(dict(float64=4, float32=2))
-        assert (df.get_dtype_counts() == result).all()
+        result = Series(dict(float32=2, float64=4))
+        assert (df.get_dtype_counts().sort_index() == result).all()
 
         df['y'] = df['a'].astype('int32')
-        result = Series(dict(float64=4, float32=2, int32=1))
-        assert (df.get_dtype_counts() == result).all()
+        result = Series(dict(float32=2, float64=4, int32=1))
+        assert (df.get_dtype_counts().sort_index() == result).all()
 
         with tm.assert_raises_regex(ValueError, 'already exists'):
             df.insert(1, 'a', df['b'])

--- a/pandas/tests/frame/test_nonunique_indexes.py
+++ b/pandas/tests/frame/test_nonunique_indexes.py
@@ -155,14 +155,14 @@ class TestDataFrameNonuniqueIndexes(TestData):
 
         # rename, GH 4403
         df4 = DataFrame(
-            {'TClose': [22.02],
-             'RT': [0.0454],
+            {'RT': [0.0454],
+             'TClose': [22.02],
              'TExg': [0.0422]},
             index=MultiIndex.from_tuples([(600809, 20130331)],
                                          names=['STK_ID', 'RPT_Date']))
 
-        df5 = DataFrame({'STK_ID': [600809] * 3,
-                         'RPT_Date': [20120930, 20121231, 20130331],
+        df5 = DataFrame({'RPT_Date': [20120930, 20121231, 20130331],
+                         'STK_ID': [600809] * 3,
                          'STK_Name': [u('饡驦'), u('饡驦'), u('饡驦')],
                          'TClose': [38.05, 41.66, 30.01]},
                         index=MultiIndex.from_tuples(

--- a/pandas/tests/frame/test_reshape.py
+++ b/pandas/tests/frame/test_reshape.py
@@ -719,9 +719,10 @@ class TestDataFrameReshape(TestData):
         assert_frame_equal(left, right)
 
         # GH7401
-        df = pd.DataFrame({'A': list('aaaaabbbbb'), 'C': np.arange(10),
+        df = pd.DataFrame({'A': list('aaaaabbbbb'),
                            'B': (date_range('2012-01-01', periods=5)
-                                 .tolist() * 2)})
+                                 .tolist() * 2),
+                           'C': np.arange(10)})
 
         df.iloc[3, 1] = np.NaN
         left = df.set_index(['A', 'B']).unstack()

--- a/pandas/tests/frame/test_to_csv.py
+++ b/pandas/tests/frame/test_to_csv.py
@@ -1054,10 +1054,10 @@ class TestDataFrameToCSV(TestData):
 
     def test_to_csv_quoting(self):
         df = DataFrame({
-            'c_string': ['a', 'b,c'],
-            'c_int': [42, np.nan],
-            'c_float': [1.0, 3.2],
             'c_bool': [True, False],
+            'c_float': [1.0, 3.2],
+            'c_int': [42, np.nan],
+            'c_string': ['a', 'b,c'],
         })
 
         expected = """\


### PR DESCRIPTION
- [x] xref #19018
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`

This PR prepares pandas to allow initialisation using insertion order for python>=3.6. E.g. ``Series({'B': 1, 'A': 2})`` will then retain order and not convert to ``Series({'A': 2, 'B': 1})``.

Letting dataframe/series initialisation from dicts preserve order for python >=3.6 is a relative simple change, just change a line each in core/frame.py and core/series.py. However, this makes some 36 tests fail, as the tests have been set up to depend on conversion to alphabetical order.

This PR makes all tests in ``pandas/tests/frame`` pass both if dict initialisation uses insertion order and alphabetical order. No test functionality is changed in this PR.

After this PR I will do 1 or 2 more similar PRs, so all tests pass independent of dict initialisation rule, and then core/frame.py and core/series.py will be changed to use insertion order for python>=3.6.