### PR TITLE
Fix to_csv of DataFrame with single level multiindex.

### DIFF
--- a/doc/source/whatsnew/v0.24.0.txt
+++ b/doc/source/whatsnew/v0.24.0.txt
@@ -188,7 +188,7 @@ Renaming names in a MultiIndex
 :func:`DataFrame.rename_axis` now supports ``index`` and ``columns`` arguments
 and :func:`Series.rename_axis` supports ``index`` argument (:issue:`19978`)
 
-This change allows a dictionary to be passed so that some of the names 
+This change allows a dictionary to be passed so that some of the names
 of a ``MultiIndex`` can be changed.
 
 Example:
@@ -1216,6 +1216,7 @@ Notice how we now instead output ``np.nan`` itself instead of a stringified form
 - :func:`read_sas()` will correctly parse sas7bdat files with data page types having also bit 7 set (so page type is 128 + 256 = 384) (:issue:`16615`)
 - Bug in :meth:`detect_client_encoding` where potential ``IOError`` goes unhandled when importing in a mod_wsgi process due to restricted access to stdout. (:issue:`21552`)
 - Bug in :func:`to_string()` that broke column alignment when ``index=False`` and width of first column's values is greater than the width of first column's header (:issue:`16839`, :issue:`13032`)
+- Bug in :func:`DataFrame.to_csv` where a single level MultiIndex incorrectly wrote a tuple. Now just the value of the index is written (:issue:`19589`).
 
 Plotting
 ^^^^^^^^

--- a/pandas/core/indexes/multi.py
+++ b/pandas/core/indexes/multi.py
@@ -732,11 +732,14 @@ class MultiIndex(Index):
             new_levels.append(level)
             new_labels.append(label)
 
-        # reconstruct the multi-index
-        mi = MultiIndex(levels=new_levels, labels=new_labels, names=self.names,
-                        sortorder=self.sortorder, verify_integrity=False)
-
-        return mi.values
+        if len(new_levels) == 1:
+            return Index(new_levels[0])._format_native_types()
+        else:
+            # reconstruct the multi-index
+            mi = MultiIndex(levels=new_levels, labels=new_labels,
+                            names=self.names, sortorder=self.sortorder,
+                            verify_integrity=False)
+            return mi.values
 
     @Appender(_index_shared_docs['_get_grouper_for_level'])
     def _get_grouper_for_level(self, mapper, level):

--- a/pandas/tests/io/formats/test_to_csv.py
+++ b/pandas/tests/io/formats/test_to_csv.py
@@ -325,6 +325,25 @@ $1$,$2$
         exp = tm.convert_rows_list_to_csv_str(exp_rows)
         assert df.to_csv(index=False) == exp
 
+    @pytest.mark.parametrize("ind,expected", [
+        (pd.MultiIndex(levels=[[1.0]],
+                       labels=[[0]],
+                       names=["x"]),
+         "x,data\n1.0,1\n"),
+        (pd.MultiIndex(levels=[[1.], [2.]],
+                       labels=[[0], [0]],
+                       names=["x", "y"]),
+         "x,y,data\n1.0,2.0,1\n")
+    ])
+    @pytest.mark.parametrize("klass", [
+        pd.DataFrame, pd.Series
+    ])
+    def test_to_csv_single_level_multi_index(self, ind, expected, klass):
+        # see gh-19589
+        result = klass(pd.Series([1], ind, name="data")).to_csv(
+            line_terminator="\n", header=True)
+        assert result == expected
+
     def test_to_csv_string_array_ascii(self):
         # GH 10813
         str_array = [{'names': ['foo', 'bar']}, {'names': ['baz', 'qux']}]


### PR DESCRIPTION
### What's this PR do?
Fixes the output of to_csv to show the value instead of the tuple when a ``DataFrame`` or ``Series`` is constructed using a ``MultiIndex`` with one level.  Although, I'm not sure if it's more desirable to require a MultiIndex to be instantiated with more than one level in the future. 

- [X] closes #19589
- [X] tests added / passed
- [X] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [X] whatsnew entry
