### PR TITLE
BUG: Fix qcut with NaT present

### DIFF
--- a/doc/source/whatsnew/v0.23.0.txt
+++ b/doc/source/whatsnew/v0.23.0.txt
@@ -896,6 +896,7 @@ Reshaping
 - Bug in :func:`DataFrame.join` which does an ``outer`` instead of a ``left`` join when being called with multiple DataFrames and some have non-unique indices (:issue:`19624`)
 - :func:`Series.rename` now accepts ``axis`` as a kwarg (:issue:`18589`)
 - Comparisons between :class:`Series` and :class:`Index` would return a ``Series`` with an incorrect name, ignoring the ``Index``'s name attribute (:issue:`19582`)
+- Bug in :func:`qcut` where datetime and timedelta data with ``NaT`` present raised a ``ValueError`` (:issue:`19768`)
 
 Other
 ^^^^^

--- a/pandas/core/reshape/tile.py
+++ b/pandas/core/reshape/tile.py
@@ -279,17 +279,21 @@ def _trim_zeros(x):
 def _coerce_to_type(x):
     """
     if the passed data is of datetime/timedelta type,
-    this method converts it to integer so that cut method can
+    this method converts it to numeric so that cut method can
     handle it
     """
     dtype = None
 
     if is_timedelta64_dtype(x):
-        x = to_timedelta(x).view(np.int64)
+        x = to_timedelta(x)
         dtype = np.timedelta64
     elif is_datetime64_dtype(x):
-        x = to_datetime(x).view(np.int64)
+        x = to_datetime(x)
         dtype = np.datetime64
+
+    if dtype is not None:
+        # GH 19768: force NaT to NaN during integer conversion
+        x = np.where(x.notna(), x.view(np.int64), np.nan)
 
     return x, dtype
 


### PR DESCRIPTION
- [X] closes #19768
- [X] tests added / passed
- [X] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [X] whatsnew entry
