### PR TITLE
Continue porting period_helper; fix leftover asfreq bug

### DIFF
--- a/doc/source/whatsnew/v0.23.0.txt
+++ b/doc/source/whatsnew/v0.23.0.txt
@@ -763,7 +763,7 @@ Timedelta
 - Bug in :class:`TimedeltaIndex` where division by a ``Series`` would return a ``TimedeltaIndex`` instead of a ``Series`` (:issue:`19042`)
 - Bug in :func:`Timedelta.__add__`, :func:`Timedelta.__sub__` where adding or subtracting a ``np.timedelta64`` object would return another ``np.timedelta64`` instead of a ``Timedelta`` (:issue:`19738`)
 - Bug in :func:`Timedelta.__floordiv__`, :func:`Timedelta.__rfloordiv__` where operating with a ``Tick`` object would raise a ``TypeError`` instead of returning a numeric value (:issue:`19738`)
-- Bug in :func:`Period.asfreq` where periods near ``datetime(1, 1, 1)`` could be converted incorrectly (:issue:`19643`)
+- Bug in :func:`Period.asfreq` where periods near ``datetime(1, 1, 1)`` could be converted incorrectly (:issue:`19643`, :issue:`19834`)
 - Bug in :func:`Timedelta.total_seconds()` causing precision errors i.e. ``Timedelta('30S').total_seconds()==30.000000000000004`` (:issue:`19458`)
 -
 

--- a/pandas/_libs/src/period_helper.c
+++ b/pandas/_libs/src/period_helper.c
@@ -173,9 +173,10 @@ static npy_int64 asfreq_DTtoA(npy_int64 ordinal, asfreq_info *af_info) {
     }
 }
 
-static npy_int64 DtoQ_yq(npy_int64 ordinal, asfreq_info *af_info, int *year,
-                         int *quarter) {
+static int DtoQ_yq(npy_int64 ordinal, asfreq_info *af_info, int *year) {
     struct date_info dinfo;
+    int quarter;
+
     dInfoCalc_SetFromAbsDate(&dinfo, ordinal);
     if (af_info->to_q_year_end != 12) {
         dinfo.month -= af_info->to_q_year_end;
@@ -187,9 +188,8 @@ static npy_int64 DtoQ_yq(npy_int64 ordinal, asfreq_info *af_info, int *year,
     }
 
     *year = dinfo.year;
-    *quarter = monthToQuarter(dinfo.month);
-
-    return 0;
+    quarter = monthToQuarter(dinfo.month);
+    return quarter;
 }
 
 static npy_int64 asfreq_DTtoQ(npy_int64 ordinal, asfreq_info *af_info) {
@@ -197,7 +197,7 @@ static npy_int64 asfreq_DTtoQ(npy_int64 ordinal, asfreq_info *af_info) {
 
     ordinal = downsample_daytime(ordinal, af_info);
 
-    DtoQ_yq(ordinal, af_info, &year, &quarter);
+    quarter = DtoQ_yq(ordinal, af_info, &year);
     return (npy_int64)((year - 1970) * 4 + quarter - 1);
 }
 

--- a/pandas/_libs/src/period_helper.h
+++ b/pandas/_libs/src/period_helper.h
@@ -20,31 +20,7 @@ frequency conversion routines.
 #include "limits.h"
 #include "numpy/ndarraytypes.h"
 
-/*
- * declarations from period here
- */
-
-#define Py_Error(errortype, errorstr)         \
-    {                                         \
-        PyErr_SetString(errortype, errorstr); \
-        goto onError;                         \
-    }
-
 /*** FREQUENCY CONSTANTS ***/
-
-// HIGHFREQ_ORIG is the datetime ordinal from which to begin the second
-// frequency ordinal sequence
-
-// #define HIGHFREQ_ORIG 62135683200LL
-#define BASE_YEAR 1970
-#define ORD_OFFSET 719163LL   // days until 1970-01-01
-#define BDAY_OFFSET 513689LL  // days until 1970-01-01
-#define WEEK_OFFSET 102737LL
-#define BASE_WEEK_TO_DAY_OFFSET \
-    1  // difference between day 0 and end of week in days
-#define DAYS_PER_WEEK 7
-#define BUSINESS_DAYS_PER_WEEK 5
-#define HIGHFREQ_ORIG 0  // ORD_OFFSET * 86400LL // days until 1970-01-01
 
 #define FR_ANN 1000      /* Annual */
 #define FR_ANNDEC FR_ANN /* Annual - December year end*/

--- a/pandas/_libs/tslibs/period.pyx
+++ b/pandas/_libs/tslibs/period.pyx
@@ -1576,8 +1576,8 @@ class Period(_Period):
         return cls._from_ordinal(ordinal, freq)
 
 
-def _ordinal_from_fields(year, month, quarter, day,
-                         hour, minute, second, freq):
+cdef int64_t _ordinal_from_fields(year, month, quarter, day,
+                                  hour, minute, second, freq):
     base, mult = get_freq_code(freq)
     if quarter is not None:
         year, month = _quarter_to_myear(year, quarter, freq)

--- a/pandas/tests/scalar/period/test_period.py
+++ b/pandas/tests/scalar/period/test_period.py
@@ -1442,7 +1442,7 @@ def test_period_immutable():
         per.freq = 2 * freq
 
 
-@pytest.mark.xfail(reason='GH#??? Period parsing error')
+@pytest.mark.xfail(reason='GH#19834 Period parsing error')
 def test_small_year_parsing():
     per1 = Period('0001-01-07', 'D')
     assert per1.year == 1

--- a/pandas/tests/scalar/period/test_period.py
+++ b/pandas/tests/scalar/period/test_period.py
@@ -1440,3 +1440,10 @@ def test_period_immutable():
     freq = per.freq
     with pytest.raises(AttributeError):
         per.freq = 2 * freq
+
+
+@pytest.mark.xfail(reason='GH#??? Period parsing error')
+def test_small_year_parsing():
+    per1 = Period('0001-01-07', 'D')
+    assert per1.year == 1
+    assert per1.day == 7

--- a/pandas/tests/scalar/period/test_period_asfreq.py
+++ b/pandas/tests/scalar/period/test_period_asfreq.py
@@ -21,6 +21,15 @@ class TestFreqConversion(object):
         tup2 = (prev.year, prev.month, prev.day)
         assert tup2 < tup1
 
+    def test_asfreq_near_zero_weekly(self):
+        per1 = Period('0001-01-01', 'D') + 6
+        per2 = Period('0001-01-01', 'D') - 6
+        week1 = per1.asfreq('W')
+        week2 = per2.asfreq('W')
+        assert week1 != week2
+        assert week1.asfreq('D', 'E') >= per1
+        assert week2.asfreq('D', 'S') <= per2
+
     @pytest.mark.xfail(reason='GH#19643 period_helper asfreq functions fail '
                               'to check for overflows')
     def test_to_timestamp_out_of_bounds(self):

--- a/pandas/tests/scalar/period/test_period_asfreq.py
+++ b/pandas/tests/scalar/period/test_period_asfreq.py
@@ -22,6 +22,7 @@ class TestFreqConversion(object):
         assert tup2 < tup1
 
     def test_asfreq_near_zero_weekly(self):
+        # GH#19834
         per1 = Period('0001-01-01', 'D') + 6
         per2 = Period('0001-01-01', 'D') - 6
         week1 = per1.asfreq('W')

--- a/pandas/tests/scalar/timestamp/test_timezones.py
+++ b/pandas/tests/scalar/timestamp/test_timezones.py
@@ -28,17 +28,15 @@ class TestTimestampTZOperations(object):
         pac = Timestamp.min.tz_localize('US/Pacific')
         assert pac.value > Timestamp.min.value
         pac.tz_convert('Asia/Tokyo')  # tz_convert doesn't change value
-        with tm.assert_produces_warning(RuntimeWarning):
-            with pytest.raises(OutOfBoundsDatetime):
-                Timestamp.min.tz_localize('Asia/Tokyo')
+        with pytest.raises(OutOfBoundsDatetime):
+            Timestamp.min.tz_localize('Asia/Tokyo')
 
         # tz_localize that pushes away from the boundary is OK
         tokyo = Timestamp.max.tz_localize('Asia/Tokyo')
         assert tokyo.value < Timestamp.max.value
         tokyo.tz_convert('US/Pacific')  # tz_convert doesn't change value
-        with tm.assert_produces_warning(RuntimeWarning):
-            with pytest.raises(OutOfBoundsDatetime):
-                Timestamp.max.tz_localize('US/Pacific')
+        with pytest.raises(OutOfBoundsDatetime):
+            Timestamp.max.tz_localize('US/Pacific')
 
     def test_tz_localize_ambiguous_bool(self):
         # make sure that we are correctly accepting bool values as ambiguous

--- a/pandas/tests/scalar/timestamp/test_timezones.py
+++ b/pandas/tests/scalar/timestamp/test_timezones.py
@@ -28,15 +28,17 @@ class TestTimestampTZOperations(object):
         pac = Timestamp.min.tz_localize('US/Pacific')
         assert pac.value > Timestamp.min.value
         pac.tz_convert('Asia/Tokyo')  # tz_convert doesn't change value
-        with pytest.raises(OutOfBoundsDatetime):
-            Timestamp.min.tz_localize('Asia/Tokyo')
+        with tm.assert_produces_warning(RuntimeWarning):
+            with pytest.raises(OutOfBoundsDatetime):
+                Timestamp.min.tz_localize('Asia/Tokyo')
 
         # tz_localize that pushes away from the boundary is OK
         tokyo = Timestamp.max.tz_localize('Asia/Tokyo')
         assert tokyo.value < Timestamp.max.value
         tokyo.tz_convert('US/Pacific')  # tz_convert doesn't change value
-        with pytest.raises(OutOfBoundsDatetime):
-            Timestamp.max.tz_localize('US/Pacific')
+        with tm.assert_produces_warning(RuntimeWarning):
+            with pytest.raises(OutOfBoundsDatetime):
+                Timestamp.max.tz_localize('US/Pacific')
 
     def test_tz_localize_ambiguous_bool(self):
         # make sure that we are correctly accepting bool values as ambiguous


### PR DESCRIPTION
In #19650 we fixed a bug with asfreq but missed a weekly-frequency case.  This fixes and tests that.  I'll see if I can cook up a more thorough set of tests to make sure nothing else slips through the cracks.

Other than that, the main thing this does is substitute in `ORD_OFFSET = WEEK_OFFSET * 7 + 4` and `BDAY_OFFSET = 5 * WEEK_OFFSET + 4` and then cleans up some algebra (which is now OK because we are using non-cdivision floordiv and mod).  As a result we get rid of a bunch of calls that add ORD_OFFSET just to subtract it a few lines later.

Gets rid of CamelCase in tslibs.period, moves towards using pandas_datetimestruct directly and getting rid of the redundant `date_info`.

Catches a RuntimeWarning in the tests; closes #19767.
