### PR TITLE
CI: Align pep8speaks config with setup.cfg

### DIFF
--- a/.pep8speaks.yml
+++ b/.pep8speaks.yml
@@ -6,5 +6,7 @@ scanner:
 pycodestyle:
     max-line-length: 79
     ignore:  # Errors and warnings to ignore
-        - E731
-        - E402
+        - E402,  # module level import not at top of file
+        - E731,  # do not assign a lambda expression, use a def
+        - E741,  # do not use variables named 'l', 'O', or 'I'
+        - W503   # line break before binary operator


### PR DESCRIPTION
I copy pasted the ignored flake8 codes from setup.cfg, so that the online pep8speaks does the same as our linting on CI