### PR TITLE
Fix+test DTI/TDI/PI add/sub with ndarray[datetime64/timedelta64]

### DIFF
--- a/doc/source/whatsnew/v0.23.0.txt
+++ b/doc/source/whatsnew/v0.23.0.txt
@@ -755,6 +755,7 @@ Datetimelike
 - Bug in :func:`Timestamp.floor` :func:`DatetimeIndex.floor` where time stamps far in the future and past were not rounded correctly (:issue:`19206`)
 - Bug in :func:`to_datetime` where passing an out-of-bounds datetime with ``errors='coerce'`` and ``utc=True`` would raise ``OutOfBoundsDatetime`` instead of parsing to ``NaT`` (:issue:`19612`)
 - Bug in :class:`DatetimeIndex` and :class:`TimedeltaIndex` addition and subtraction where name of the returned object was not always set consistently. (:issue:`19744`)
+- Bug in :class:`DatetimeIndex` and :class:`TimedeltaIndex` addition and subtraction where operations with numpy arrays raised ``TypeError`` (:issue:`19847`)
 -
 
 Timedelta

--- a/pandas/core/indexes/datetimelike.py
+++ b/pandas/core/indexes/datetimelike.py
@@ -655,6 +655,7 @@ class DatetimeIndexOpsMixin(object):
 
         def __add__(self, other):
             from pandas.core.index import Index
+            from pandas.core.indexes.datetimes import DatetimeIndex
             from pandas.core.indexes.timedeltas import TimedeltaIndex
             from pandas.tseries.offsets import DateOffset
 
@@ -682,6 +683,9 @@ class DatetimeIndexOpsMixin(object):
                 result = self._add_datelike(other)
             elif isinstance(other, Index):
                 result = self._add_datelike(other)
+            elif is_datetime64_dtype(other):
+                # ndarray[datetime64]; note DatetimeIndex is caught above
+                return self + DatetimeIndex(other)
             elif is_integer_dtype(other) and self.freq is None:
                 # GH#19123
                 raise NullFrequencyError("Cannot shift with no freq")
@@ -727,6 +731,9 @@ class DatetimeIndexOpsMixin(object):
                 result = self._sub_datelike(other)
             elif isinstance(other, Period):
                 result = self._sub_period(other)
+            elif is_datetime64_dtype(other):
+                # ndarray[datetime64]; note we caught DatetimeIndex earlier
+                return self - DatetimeIndex(other)
             elif isinstance(other, Index):
                 raise TypeError("cannot subtract {typ1} and {typ2}"
                                 .format(typ1=type(self).__name__,

--- a/pandas/core/indexes/datetimelike.py
+++ b/pandas/core/indexes/datetimelike.py
@@ -654,10 +654,7 @@ class DatetimeIndexOpsMixin(object):
         """
 
         def __add__(self, other):
-            from pandas.core.index import Index
-            from pandas.core.indexes.datetimes import DatetimeIndex
-            from pandas.core.indexes.timedeltas import TimedeltaIndex
-            from pandas.tseries.offsets import DateOffset
+            from pandas import Index, DatetimeIndex, TimedeltaIndex, DateOffset
 
             other = lib.item_from_zerodim(other)
             if isinstance(other, ABCSeries):
@@ -701,10 +698,7 @@ class DatetimeIndexOpsMixin(object):
         cls.__radd__ = __add__
 
         def __sub__(self, other):
-            from pandas.core.index import Index
-            from pandas.core.indexes.datetimes import DatetimeIndex
-            from pandas.core.indexes.timedeltas import TimedeltaIndex
-            from pandas.tseries.offsets import DateOffset
+            from pandas import Index, DatetimeIndex, TimedeltaIndex, DateOffset
 
             other = lib.item_from_zerodim(other)
             if isinstance(other, ABCSeries):
@@ -755,7 +749,7 @@ class DatetimeIndexOpsMixin(object):
             if is_datetime64_dtype(other) and is_timedelta64_dtype(self):
                 # ndarray[datetime64] cannot be subtracted from self, so
                 # we need to wrap in DatetimeIndex and flip the operation
-                from pandas.core.indexes.datetimes import DatetimeIndex
+                from pandas import DatetimeIndex
                 return DatetimeIndex(other) - self
             return -(self - other)
         cls.__rsub__ = __rsub__

--- a/pandas/core/indexes/datetimelike.py
+++ b/pandas/core/indexes/datetimelike.py
@@ -25,6 +25,7 @@ from pandas.core.dtypes.common import (
     is_integer_dtype,
     is_object_dtype,
     is_string_dtype,
+    is_datetime64_dtype,
     is_timedelta64_dtype)
 from pandas.core.dtypes.generic import (
     ABCIndex, ABCSeries, ABCPeriodIndex, ABCIndexClass)
@@ -744,6 +745,11 @@ class DatetimeIndexOpsMixin(object):
         cls.__sub__ = __sub__
 
         def __rsub__(self, other):
+            if is_datetime64_dtype(other) and is_timedelta64_dtype(self):
+                # ndarray[datetime64] cannot be subtracted from self, so
+                # we need to wrap in DatetimeIndex and flip the operation
+                from pandas.core.indexes.datetimes import DatetimeIndex
+                return DatetimeIndex(other) - self
             return -(self - other)
         cls.__rsub__ = __rsub__
 

--- a/pandas/core/indexes/timedeltas.py
+++ b/pandas/core/indexes/timedeltas.py
@@ -377,6 +377,10 @@ class TimedeltaIndex(DatetimeIndexOpsMixin, TimelikeOps, Int64Index):
             new_values = self._add_delta_td(delta)
         elif isinstance(delta, TimedeltaIndex):
             new_values = self._add_delta_tdi(delta)
+        elif is_timedelta64_dtype(delta):
+            # ndarray[timedelta64] --> wrap in TimedeltaIndex
+            delta = TimedeltaIndex(delta)
+            new_values = self._add_delta_tdi(delta)
         else:
             raise TypeError("cannot add the type {0} to a TimedeltaIndex"
                             .format(type(delta)))

--- a/pandas/tests/indexes/datetimes/test_arithmetic.py
+++ b/pandas/tests/indexes/datetimes/test_arithmetic.py
@@ -572,6 +572,62 @@ class TestDatetimeIndexArithmetic(object):
             addend + dti_tz
 
     # -------------------------------------------------------------
+    # __add__/__sub__ with ndarray[datetime64] and ndarray[timedelta64]
+
+    def test_dti_add_dt64_array_raises(self, tz):
+        dti = pd.date_range('2016-01-01', periods=3, tz=tz)
+        dtarr = dti.values
+
+        with pytest.raises(TypeError):
+            dti + dtarr
+        with pytest.raises(TypeError):
+            dtarr + dti
+
+    def test_dti_sub_dt64_array_naive(self):
+        dti = pd.date_range('2016-01-01', periods=3, tz=None)
+        dtarr = dti.values
+
+        expected = dti - dti
+        result = dti - dtarr
+        tm.assert_index_equal(result, expected)
+        result = dtarr - dti
+        tm.assert_index_equal(result, expected)
+
+    def test_dti_sub_dt64_array_aware_raises(self, tz):
+        if tz is None:
+            return
+        dti = pd.date_range('2016-01-01', periods=3, tz=tz)
+        dtarr = dti.values
+
+        with pytest.raises(TypeError):
+            dti - dtarr
+        with pytest.raises(TypeError):
+            dtarr - dti
+
+    def test_dti_add_td64_array(self, tz):
+        dti = pd.date_range('2016-01-01', periods=3, tz=tz)
+        tdi = dti - dti.shift(1)
+        tdarr = tdi.values
+
+        expected = dti + tdi
+        result = dti + tdarr
+        tm.assert_index_equal(result, expected)
+        result = tdarr + dti
+        tm.assert_index_equal(result, expected)
+
+    def test_dti_sub_td64_array(self, tz):
+        dti = pd.date_range('2016-01-01', periods=3, tz=tz)
+        tdi = dti - dti.shift(1)
+        tdarr = tdi.values
+
+        expected = dti - tdi
+        result = dti - tdarr
+        tm.assert_index_equal(result, expected)
+
+        with pytest.raises(TypeError):
+            tdarr - dti
+
+    # -------------------------------------------------------------
 
     def test_sub_dti_dti(self):
         # previously performed setop (deprecated in 0.16.0), now changed to

--- a/pandas/tests/indexes/timedeltas/test_arithmetic.py
+++ b/pandas/tests/indexes/timedeltas/test_arithmetic.py
@@ -499,12 +499,13 @@ class TestTimedeltaIndexArithmetic(object):
         tdi = dti - dti.shift(1)
         dtarr = dti.values
 
+        with pytest.raises(TypeError):
+            tdi - dtarr
+
+        # TimedeltaIndex.__rsub__
         expected = pd.DatetimeIndex(dtarr) - tdi
         result = dtarr - tdi
         tm.assert_index_equal(result, expected)
-
-        with pytest.raises(TypeError):
-            tdi - dtarr
 
     # -------------------------------------------------------------
 

--- a/pandas/tests/indexes/timedeltas/test_arithmetic.py
+++ b/pandas/tests/indexes/timedeltas/test_arithmetic.py
@@ -494,6 +494,9 @@ class TestTimedeltaIndexArithmetic(object):
         expected = DatetimeIndex(['2011-01-02', '2011-01-03'])
         tm.assert_index_equal(result, expected)
 
+    # -------------------------------------------------------------
+    # __add__/__sub__ with ndarray[datetime64] and ndarray[timedelta64]
+
     def test_tdi_sub_dt64_array(self):
         dti = pd.date_range('2016-01-01', periods=3)
         tdi = dti - dti.shift(1)
@@ -505,6 +508,39 @@ class TestTimedeltaIndexArithmetic(object):
         # TimedeltaIndex.__rsub__
         expected = pd.DatetimeIndex(dtarr) - tdi
         result = dtarr - tdi
+        tm.assert_index_equal(result, expected)
+
+    def test_tdi_add_dt64_array(self):
+        dti = pd.date_range('2016-01-01', periods=3)
+        tdi = dti - dti.shift(1)
+        dtarr = dti.values
+
+        expected = pd.DatetimeIndex(dtarr) + tdi
+        result = tdi + dtarr
+        tm.assert_index_equal(result, expected)
+        result = dtarr + tdi
+        tm.assert_index_equal(result, expected)
+
+    def test_tdi_add_td64_array(self):
+        dti = pd.date_range('2016-01-01', periods=3)
+        tdi = dti - dti.shift(1)
+        tdarr = tdi.values
+
+        expected = 2 * tdi
+        result = tdi + tdarr
+        tm.assert_index_equal(result, expected)
+        result = tdarr + tdi
+        tm.assert_index_equal(result, expected)
+
+    def test_tdi_sub_td64_array(self):
+        dti = pd.date_range('2016-01-01', periods=3)
+        tdi = dti - dti.shift(1)
+        tdarr = tdi.values
+
+        expected = 0 * tdi
+        result = tdi - tdarr
+        tm.assert_index_equal(result, expected)
+        result = tdarr - tdi
         tm.assert_index_equal(result, expected)
 
     # -------------------------------------------------------------

--- a/pandas/tests/indexes/timedeltas/test_arithmetic.py
+++ b/pandas/tests/indexes/timedeltas/test_arithmetic.py
@@ -494,6 +494,18 @@ class TestTimedeltaIndexArithmetic(object):
         expected = DatetimeIndex(['2011-01-02', '2011-01-03'])
         tm.assert_index_equal(result, expected)
 
+    def test_tdi_sub_dt64_array(self):
+        dti = pd.date_range('2016-01-01', periods=3)
+        tdi = dti - dti.shift(1)
+        dtarr = dti.values
+
+        expected = pd.DatetimeIndex(dtarr) - tdi
+        result = dtarr - tdi
+        tm.assert_index_equal(result, expected)
+
+        with pytest.raises(TypeError):
+            tdi - dtarr
+
     # -------------------------------------------------------------
 
     @pytest.mark.parametrize('scalar_td', [


### PR DESCRIPTION
Two notes for upcoming passes:

- the tests are pretty redundant, can be parametrized more tightly once they are all OK.
- catching ndarray[datetime64] separately from DatetimeIndex is kind of weird, but for the moment necesarry.  Once #19835 goes through and re-orders the catching, we'll be able to fix this.