### PR TITLE
templatize timedelta arith ops

### DIFF
--- a/pandas/_libs/tslibs/timedeltas.pyx
+++ b/pandas/_libs/tslibs/timedeltas.pyx
@@ -471,9 +471,12 @@ def _binary_op_method_timedeltalike(op, name):
     # define a binary operation that only works if the other argument is
     # timedelta like or an array of timedeltalike
     def f(self, other):
-        if hasattr(other, 'delta') and not PyDelta_Check(other):
-            # offsets.Tick
-            return op(self, other.delta)
+        if hasattr(other, '_typ'):
+            # Series, DataFrame, ...
+            if other._typ == 'dateoffset' and hasattr(other, 'delta'):
+                # Tick offset; this op will raise TypeError
+                return op(self, other.delta)
+            return NotImplemented
 
         elif other is NaT:
             return NaT
@@ -1052,7 +1055,14 @@ class Timedelta(_Timedelta):
     __rsub__ = _binary_op_method_timedeltalike(lambda x, y: y - x, '__rsub__')
 
     def __mul__(self, other):
-        if hasattr(other, 'dtype'):
+        if hasattr(other, '_typ'):
+            # Series, DataFrame, ...
+            if other._typ == 'dateoffset' and hasattr(other, 'delta'):
+                # Tick offset; this op will raise TypeError
+                return other.delta * self
+            return NotImplemented
+
+        elif hasattr(other, 'dtype'):
             # ndarray-like
             return other * self.to_timedelta64()
 
@@ -1068,7 +1078,18 @@ class Timedelta(_Timedelta):
     __rmul__ = __mul__
 
     def __truediv__(self, other):
-        if hasattr(other, 'dtype'):
+        if hasattr(other, '_typ'):
+            # Series, DataFrame, ...
+            if other._typ == 'dateoffset' and hasattr(other, 'delta'):
+                # Tick offset
+                return self / other.delta
+            return NotImplemented
+
+        elif is_timedelta64_object(other):
+            # convert to Timedelta below
+            pass
+
+        elif hasattr(other, 'dtype'):
             return self.to_timedelta64() / other
 
         elif is_integer_object(other) or is_float_object(other):
@@ -1084,7 +1105,18 @@ class Timedelta(_Timedelta):
         return self.value / float(other.value)
 
     def __rtruediv__(self, other):
-        if hasattr(other, 'dtype'):
+        if hasattr(other, '_typ'):
+            # Series, DataFrame, ...
+            if other._typ == 'dateoffset' and hasattr(other, 'delta'):
+                # Tick offset
+                return other.delta / self
+            return NotImplemented
+
+        elif is_timedelta64_object(other):
+            # convert to Timedelta below
+            pass
+
+        elif hasattr(other, 'dtype'):
             return other / self.to_timedelta64()
 
         elif not _validate_ops_compat(other):
@@ -1160,9 +1192,10 @@ class Timedelta(_Timedelta):
                             '{op}'.format(dtype=other.dtype,
                                           op='__floordiv__'))
 
-        if is_float_object(other) and util._checknull(other):
+        elif is_float_object(other) and util._checknull(other):
             # i.e. np.nan
             return NotImplemented
+
         elif not _validate_ops_compat(other):
             return NotImplemented
 

--- a/pandas/_libs/tslibs/timedeltas.pyx
+++ b/pandas/_libs/tslibs/timedeltas.pyx
@@ -474,7 +474,7 @@ def _binary_op_method_timedeltalike(op, name):
         if hasattr(other, '_typ'):
             # Series, DataFrame, ...
             if other._typ == 'dateoffset' and hasattr(other, 'delta'):
-                # Tick offset; this op will raise TypeError
+                # Tick offset
                 return op(self, other.delta)
             return NotImplemented
 


### PR DESCRIPTION
Some Timedelta operations are constructed using `_binary_op_method_timedeltalike`, while a bunch of others re-implement shared logic.  This PR is an attempt to get rid of the small differences in this shared logic so they can eventually use a single template.
