### PR TITLE
DOC: misc. typos

### DIFF
--- a/doc/source/basics.rst
+++ b/doc/source/basics.rst
@@ -2312,4 +2312,4 @@ All NumPy dtypes are subclasses of ``numpy.generic``:
 .. note::
 
     Pandas also defines the types ``category``, and ``datetime64[ns, tz]``, which are not integrated into the normal
-    NumPy hierarchy and wont show up with the above function.
+    NumPy hierarchy and won't show up with the above function.

--- a/doc/source/dsintro.rst
+++ b/doc/source/dsintro.rst
@@ -539,7 +539,7 @@ To write code compatible with all versions of Python, split the assignment in tw
    you'll need to take care when passing ``assign`` expressions that
 
    * Updating an existing column
-   * Refering to the newly updated column in the same ``assign``
+   * Referring to the newly updated column in the same ``assign``
 
    For example, we'll update column "A" and then refer to it when creating "B".
 

--- a/doc/source/whatsnew/v0.14.1.txt
+++ b/doc/source/whatsnew/v0.14.1.txt
@@ -145,7 +145,7 @@ Performance
 ~~~~~~~~~~~
 - Improvements in dtype inference for numeric operations involving yielding performance gains for dtypes: ``int64``, ``timedelta64``, ``datetime64`` (:issue:`7223`)
 - Improvements in Series.transform for significant performance gains (:issue:`6496`)
-- Improvements in DataFrame.transform with ufuncs and built-in grouper functions for signifcant performance gains (:issue:`7383`)
+- Improvements in DataFrame.transform with ufuncs and built-in grouper functions for significant performance gains (:issue:`7383`)
 - Regression in groupby aggregation of datetime64 dtypes (:issue:`7555`)
 - Improvements in `MultiIndex.from_product` for large iterables (:issue:`7627`)
 

--- a/pandas/_libs/groupby_helper.pxi.in
+++ b/pandas/_libs/groupby_helper.pxi.in
@@ -426,7 +426,7 @@ def group_rank_{{name}}(ndarray[float64_t, ndim=2] out,
     labels : array containing unique label for each group, with its ordering
         matching up to the corresponding record in `values`
     is_datetimelike : bool
-        unused in this method but provided for call compatability with other
+        unused in this method but provided for call compatibility with other
         Cython transformations
     ties_method :  {'keep', 'top', 'bottom'}
         * keep: leave NA values where they are

--- a/pandas/core/arrays/categorical.py
+++ b/pandas/core/arrays/categorical.py
@@ -521,7 +521,7 @@ class Categorical(ExtensionArray, PandasObject):
                 cats = to_timedelta(inferred_categories, errors='coerce')
 
         if known_categories:
-            # recode from observation oder to dtype.categories order
+            # recode from observation order to dtype.categories order
             categories = dtype.categories
             codes = _recode_for_categories(inferred_codes, cats, categories)
         elif not cats.is_monotonic_increasing:

--- a/pandas/core/internals.py
+++ b/pandas/core/internals.py
@@ -2600,12 +2600,12 @@ class DatetimeBlock(DatetimeLikeBlockMixin, Block):
 
     def _maybe_coerce_values(self, values):
         """Input validation for values passed to __init__. Ensure that
-        we have datetime64ns, coercing if nescessary.
+        we have datetime64ns, coercing if necessary.
 
         Parametetrs
         -----------
         values : array-like
-            Must be convertable to datetime64
+            Must be convertible to datetime64
 
         Returns
         -------
@@ -2760,12 +2760,12 @@ class DatetimeTZBlock(NonConsolidatableMixIn, DatetimeBlock):
 
     def _maybe_coerce_values(self, values, dtype=None):
         """Input validation for values passed to __init__. Ensure that
-        we have datetime64TZ, coercing if nescessary.
+        we have datetime64TZ, coercing if necessary.
 
         Parametetrs
         -----------
         values : array-like
-            Must be convertable to datetime64
+            Must be convertible to datetime64
         dtype : string or DatetimeTZDtype, optional
             Does a shallow copy to this tz
 

--- a/pandas/plotting/_converter.py
+++ b/pandas/plotting/_converter.py
@@ -197,7 +197,7 @@ class TimeFormatter(Formatter):
         ----------
         x : float
             The time of day specified as seconds since 00:00 (midnight),
-            with upto microsecond precision.
+            with up to microsecond precision.
         pos
             Unused
 

--- a/pandas/tests/extension/category/test_categorical.py
+++ b/pandas/tests/extension/category/test_categorical.py
@@ -60,7 +60,7 @@ class TestReshaping(base.BaseReshapingTests):
 
 
 class TestGetitem(base.BaseGetitemTests):
-    @pytest.mark.skip(reason="Backwards compatability")
+    @pytest.mark.skip(reason="Backwards compatibility")
     def test_getitem_scalar(self):
         # CategoricalDtype.type isn't "correct" since it should
         # be a parent of the elements (object). But don't want

--- a/pandas/tests/extension/conftest.py
+++ b/pandas/tests/extension/conftest.py
@@ -37,7 +37,7 @@ def na_cmp():
     Should return a function of two arguments that returns
     True if both arguments are (scalar) NA for your type.
 
-    By defult, uses ``operator.or``
+    By default, uses ``operator.or``
     """
     return operator.is_
 

--- a/pandas/tests/frame/test_mutate_columns.py
+++ b/pandas/tests/frame/test_mutate_columns.py
@@ -95,7 +95,7 @@ class TestDataFrameMutateColumns(TestData):
     def test_assign_dependent_old_python(self):
         df = DataFrame({'A': [1, 2, 3], 'B': [4, 5, 6]})
 
-        # Key C does not exist at defition time of df
+        # Key C does not exist at definition time of df
         with pytest.raises(KeyError):
             df.assign(C=lambda df: df.A,
                       D=lambda df: df['A'] + df['C'])

--- a/pandas/tests/frame/test_repr_info.py
+++ b/pandas/tests/frame/test_repr_info.py
@@ -307,7 +307,7 @@ class TestDataFrameReprInfoEtc(TestData):
         res = buf.getvalue().splitlines()
         assert "memory usage: " in res[-1]
 
-        # do not display memory usage cas
+        # do not display memory usage case
         df.info(buf=buf, memory_usage=False)
         res = buf.getvalue().splitlines()
         assert "memory usage: " not in res[-1]

--- a/pandas/tests/io/test_excel.py
+++ b/pandas/tests/io/test_excel.py
@@ -1786,7 +1786,7 @@ class ExcelWriterBase(SharedItems):
         nrows = 5
         ncols = 3
         for use_headers in (True, False):
-            for i in range(1, 4):  # row multindex upto nlevel=3
+            for i in range(1, 4):  # row multindex up to nlevel=3
                 for j in range(1, 4):  # col ""
                     df = mkdf(nrows, ncols, r_idx_nlevels=i, c_idx_nlevels=j)
 

--- a/pandas/tests/io/test_stata.py
+++ b/pandas/tests/io/test_stata.py
@@ -336,7 +336,7 @@ class TestStata(object):
         with tm.ensure_clean() as path:
             original.to_stata(path, {'datetime': 'tc'})
             written_and_read_again = self.read_dta(path)
-            # original.index is np.int32, readed index is np.int64
+            # original.index is np.int32, read index is np.int64
             tm.assert_frame_equal(written_and_read_again.set_index('index'),
                                   original, check_index_type=False)
 

--- a/pandas/tests/reshape/test_concat.py
+++ b/pandas/tests/reshape/test_concat.py
@@ -473,7 +473,7 @@ class TestConcatAppendCommon(ConcatenateBase):
         tm.assert_series_equal(pd.concat([s1, s2], ignore_index=True), exp)
         tm.assert_series_equal(s1.append(s2, ignore_index=True), exp)
 
-        # completelly different categories (same dtype) => not-category
+        # completely different categories (same dtype) => not-category
         s1 = pd.Series([10, 11, np.nan], dtype='category')
         s2 = pd.Series([np.nan, 1, 3, 2], dtype='category')
 
@@ -518,7 +518,7 @@ class TestConcatAppendCommon(ConcatenateBase):
         tm.assert_series_equal(pd.concat([s2, s1], ignore_index=True), exp)
         tm.assert_series_equal(s2.append(s1, ignore_index=True), exp)
 
-        # completelly different categories => not-category
+        # completely different categories => not-category
         s1 = pd.Series([10, 11, np.nan], dtype='category')
         s2 = pd.Series([1, 3, 2])
 

--- a/pandas/tests/sparse/frame/test_frame.py
+++ b/pandas/tests/sparse/frame/test_frame.py
@@ -247,10 +247,10 @@ class TestSparseDataFrame(SharedWithSparse):
     def test_constructor_nan_dataframe(self):
         # GH 10079
         trains = np.arange(100)
-        tresholds = [10, 20, 30, 40, 50, 60]
-        tuples = [(i, j) for i in trains for j in tresholds]
+        thresholds = [10, 20, 30, 40, 50, 60]
+        tuples = [(i, j) for i in trains for j in thresholds]
         index = pd.MultiIndex.from_tuples(tuples,
-                                          names=['trains', 'tresholds'])
+                                          names=['trains', 'thresholds'])
         matrix = np.empty((len(index), len(trains)))
         matrix.fill(np.nan)
         df = pd.DataFrame(matrix, index=index, columns=trains, dtype=float)


### PR DESCRIPTION
Found via `codespell -q 3 -I ../pandas-whitelist.txt`
Where whitelists consists of:
```
ans
behaviour
doubleclick
indicies
initialise
initialised
initialising
nd
resetted
splitted
thru
valu
```