### PR TITLE
pandas.read_csv tries to convert "NaN" even when specifying dtype argument #19644

### DIFF
--- a/pandas/_libs/parsers.pyx
+++ b/pandas/_libs/parsers.pyx
@@ -1100,7 +1100,7 @@ cdef class TextReader:
                 self._free_na_set(na_hashset)
 
             if upcast_na and na_count > 0:
-                col_res = _maybe_upcast(col_res)
+                col_res = _maybe_upcast(self, col_res)
 
             if col_res is None:
                 raise ParserError('Unable to parse column %d' % i)
@@ -1360,7 +1360,7 @@ cdef asbytes(object o):
 _NA_VALUES = _ensure_encoded(list(com._NA_VALUES))
 
 
-def _maybe_upcast(arr):
+def _maybe_upcast(self, arr):
     """
     If the dtype argument is set to type str, when a NaN 
     is inserted into the column it will also be treated as 
@@ -1375,7 +1375,7 @@ def _maybe_upcast(arr):
         mask = arr.view(np.uint8) == na_values[np.uint8]
         arr = arr.astype(object)
         np.putmask(arr, mask, np.nan)
-    elif arr.dtype.kind == 'O':
+    elif arr.dtype.kind == 'O' and arr == np.nan and arr.dtype == np.object_:
         na_value = na_values[arr.dtype]
         arr = arr.astype(str)
         np.putmask(arr, arr == na_value, np.nan)

--- a/pandas/_libs/parsers.pyx
+++ b/pandas/_libs/parsers.pyx
@@ -1362,7 +1362,10 @@ _NA_VALUES = _ensure_encoded(list(com._NA_VALUES))
 
 def _maybe_upcast(arr):
     """
-
+    If the dtype argument is set to type str, when a NaN 
+    is inserted into the column it will also be treated as 
+    str. It is important to pay attention to this point, 
+    since a NaN is in its specification a float.
     """
     if issubclass(arr.dtype.type, np.integer):
         na_value = na_values[arr.dtype]
@@ -1372,7 +1375,9 @@ def _maybe_upcast(arr):
         mask = arr.view(np.uint8) == na_values[np.uint8]
         arr = arr.astype(object)
         np.putmask(arr, mask, np.nan)
-
+    elif arr.dtype.kind == 'O':
+        arr = arr.astype(str)
+        np.putmask(arr, True, np.nan)
     return arr
 
 

--- a/pandas/_libs/parsers.pyx
+++ b/pandas/_libs/parsers.pyx
@@ -1376,8 +1376,9 @@ def _maybe_upcast(arr):
         arr = arr.astype(object)
         np.putmask(arr, mask, np.nan)
     elif arr.dtype.kind == 'O':
+        na_value = na_values[arr.dtype]
         arr = arr.astype(str)
-        np.putmask(arr, True, np.nan)
+        np.putmask(arr, arr == na_value, np.nan)
     return arr
 
 

--- a/pandas/_libs/parsers.pyx
+++ b/pandas/_libs/parsers.pyx
@@ -1375,7 +1375,7 @@ def _maybe_upcast(self, arr):
         mask = arr.view(np.uint8) == na_values[np.uint8]
         arr = arr.astype(object)
         np.putmask(arr, mask, np.nan)
-    elif arr.dtype.kind == 'O' and arr == np.nan and arr.dtype == np.object_:
+    elif arr.dtype.kind == 'O' and arr == np.nan:
         na_value = na_values[arr.dtype]
         arr = arr.astype(str)
         np.putmask(arr, arr == na_value, np.nan)

--- a/pandas/_libs/parsers.pyx
+++ b/pandas/_libs/parsers.pyx
@@ -1375,7 +1375,7 @@ def _maybe_upcast(self, arr):
         mask = arr.view(np.uint8) == na_values[np.uint8]
         arr = arr.astype(object)
         np.putmask(arr, mask, np.nan)
-    elif arr.dtype.kind == 'O' and arr == np.nan:
+    elif arr.all(arr.dtype.kind == 'O'):
         na_value = na_values[arr.dtype]
         arr = arr.astype(str)
         np.putmask(arr, arr == na_value, np.nan)

--- a/pandas/tests/io/parser/test_parsers.py
+++ b/pandas/tests/io/parser/test_parsers.py
@@ -7,6 +7,7 @@ from pandas import read_csv, read_table, DataFrame
 import pandas.core.common as com
 from pandas._libs.tslib import Timestamp
 from pandas.compat import StringIO
+import pandas as pd
 
 from .common import ParserTests
 from .header import HeaderTests
@@ -150,3 +151,17 @@ class TestUnsortedUsecols(object):
         df = parser.read()
 
         tm.assert_frame_equal(df, expected)
+
+    def test_NaN_conversion(object):
+        t1 = """column
+        0
+        """
+        t2 = """column
+        NaN
+        """
+
+        df1 = pd.read_csv(StringIO(t1), dtype={'column': str})
+        df2 = pd.read_csv(StringIO(t2), dtype={'column': str})
+
+        assert(type(df1['column'][0]) == str)
+        assert(type(df2['column'][0]) == str)


### PR DESCRIPTION
When the user informs the dtype must be cast for the type defined by him.
More information: #19644 

- [x] closes #19644
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry
