### PR TITLE
Datetimelike add/sub catch cases more explicitly, tests

### DIFF
--- a/pandas/core/indexes/datetimelike.py
+++ b/pandas/core/indexes/datetimelike.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """
 Base and utility classes for tseries type pandas objects.
 """

--- a/pandas/core/indexes/datetimelike.py
+++ b/pandas/core/indexes/datetimelike.py
@@ -37,7 +37,7 @@ from pandas.core.dtypes.common import (
     is_period_dtype,
     is_timedelta64_dtype)
 from pandas.core.dtypes.generic import (
-    ABCIndex, ABCSeries, ABCDataFrame, ABCPanel, ABCPeriodIndex, ABCIndexClass)
+    ABCIndex, ABCSeries, ABCDataFrame, ABCPeriodIndex, ABCIndexClass)
 from pandas.core.dtypes.missing import isna
 from pandas.core import common as com, algorithms, ops
 from pandas.core.algorithms import checked_add_with_arr
@@ -709,7 +709,7 @@ class DatetimeIndexOpsMixin(object):
             from pandas import DateOffset
 
             other = lib.item_from_zerodim(other)
-            if isinstance(other, (ABCSeries, ABCDataFrame, ABCPanel)):
+            if isinstance(other, (ABCSeries, ABCDataFrame)):
                 return NotImplemented
 
             # scalar others
@@ -769,7 +769,7 @@ class DatetimeIndexOpsMixin(object):
             from pandas import Index
 
             other = lib.item_from_zerodim(other)
-            if isinstance(other, (ABCSeries, ABCDataFrame, ABCPanel)):
+            if isinstance(other, (ABCSeries, ABCDataFrame)):
                 return NotImplemented
 
             # scalar others

--- a/pandas/core/indexes/datetimelike.py
+++ b/pandas/core/indexes/datetimelike.py
@@ -36,7 +36,7 @@ from pandas.core.dtypes.common import (
     is_period_dtype,
     is_timedelta64_dtype)
 from pandas.core.dtypes.generic import (
-    ABCIndex, ABCSeries, ABCPeriodIndex, ABCIndexClass)
+    ABCIndex, ABCSeries, ABCDataFrame, ABCPanel, ABCPeriodIndex, ABCIndexClass)
 from pandas.core.dtypes.missing import isna
 from pandas.core import common as com, algorithms, ops
 from pandas.core.algorithms import checked_add_with_arr
@@ -47,6 +47,7 @@ from pandas.core.indexes.base import Index, _index_shared_docs
 from pandas.util._decorators import Appender, cache_readonly
 import pandas.core.dtypes.concat as _concat
 import pandas.tseries.frequencies as frequencies
+from pandas.tseries.offsets import Tick, DateOffset
 
 import pandas.core.indexes.base as ibase
 _index_doc_kwargs = dict(ibase._index_doc_kwargs)
@@ -643,6 +644,9 @@ class DatetimeIndexOpsMixin(object):
     def _sub_period(self, other):
         return NotImplemented
 
+    def _add_offset(self, offset):
+        raise com.AbstractMethodError(self)
+
     def _addsub_offset_array(self, other, op):
         """
         Add or subtract array-like of DateOffset objects
@@ -682,12 +686,15 @@ class DatetimeIndexOpsMixin(object):
             from pandas import DateOffset
 
             other = lib.item_from_zerodim(other)
-            if isinstance(other, ABCSeries):
+            if isinstance(other, (ABCSeries, ABCDataFrame, ABCPanel)):
                 return NotImplemented
 
             # scalar others
-            elif isinstance(other, (DateOffset, timedelta, np.timedelta64)):
+            elif isinstance(other, (Tick, timedelta, np.timedelta64)):
                 result = self._add_delta(other)
+            elif isinstance(other, DateOffset):
+                # specifically _not_ a Tick
+                result = self._add_offset(other)
             elif isinstance(other, (datetime, np.datetime64)):
                 result = self._add_datelike(other)
             elif is_integer(other):
@@ -708,6 +715,12 @@ class DatetimeIndexOpsMixin(object):
             elif is_integer_dtype(other) and self.freq is None:
                 # GH#19123
                 raise NullFrequencyError("Cannot shift with no freq")
+            elif is_float_dtype(other):
+                # Explicitly catch invalid dtypes
+                raise TypeError("cannot add {dtype}-dtype to {cls}"
+                                .format(dtype=other.dtype,
+                                        cls=type(self).__name__))
+
             else:  # pragma: no cover
                 return NotImplemented
 
@@ -724,15 +737,18 @@ class DatetimeIndexOpsMixin(object):
         cls.__radd__ = __radd__
 
         def __sub__(self, other):
-            from pandas import Index, DateOffset
+            from pandas import Index
 
             other = lib.item_from_zerodim(other)
-            if isinstance(other, ABCSeries):
+            if isinstance(other, (ABCSeries, ABCDataFrame, ABCPanel)):
                 return NotImplemented
 
             # scalar others
-            elif isinstance(other, (DateOffset, timedelta, np.timedelta64)):
+            elif isinstance(other, (Tick, timedelta, np.timedelta64)):
                 result = self._add_delta(-other)
+            elif isinstance(other, DateOffset):
+                # specifically _not_ a Tick
+                result = self._add_offset(-other)
             elif isinstance(other, (datetime, np.datetime64)):
                 result = self._sub_datelike(other)
             elif is_integer(other):
@@ -759,6 +775,12 @@ class DatetimeIndexOpsMixin(object):
             elif is_integer_dtype(other) and self.freq is None:
                 # GH#19123
                 raise NullFrequencyError("Cannot shift with no freq")
+
+            elif is_float_dtype(other):
+                # Explicitly catch invalid dtypes
+                raise TypeError("cannot subtract {dtype}-dtype from {cls}"
+                                .format(dtype=other.dtype,
+                                        cls=type(self).__name__))
             else:  # pragma: no cover
                 return NotImplemented
 

--- a/pandas/core/indexes/timedeltas.py
+++ b/pandas/core/indexes/timedeltas.py
@@ -353,6 +353,12 @@ class TimedeltaIndex(DatetimeIndexOpsMixin, TimelikeOps, Int64Index):
             attrs['freq'] = 'infer'
         return attrs
 
+    def _add_offset(self, other):
+        assert not isinstance(other, Tick)
+        raise TypeError("cannot add the type {typ} to a {cls}"
+                        .format(typ=type(other).__name__,
+                                cls=type(self).__name__))
+
     def _add_delta(self, delta):
         """
         Add a timedelta-like, Tick, or TimedeltaIndex-like object

--- a/pandas/tests/indexes/datetimes/test_arithmetic.py
+++ b/pandas/tests/indexes/datetimes/test_arithmetic.py
@@ -315,7 +315,7 @@ class TestDatetimeIndexArithmetic(object):
     @pytest.mark.parametrize('op', [operator.add, ops.radd,
                                     operator.sub, ops.rsub])
     def test_dti_add_sub_float(self, op, other):
-        dti = DatetimeIndex(['2011-01-01', '2011-01-02'])
+        dti = DatetimeIndex(['2011-01-01', '2011-01-02'], freq='D')
         with pytest.raises(TypeError):
             op(dti, other)
 

--- a/pandas/tests/indexes/datetimes/test_arithmetic.py
+++ b/pandas/tests/indexes/datetimes/test_arithmetic.py
@@ -14,6 +14,7 @@ from pandas.errors import PerformanceWarning, NullFrequencyError
 from pandas import (Timestamp, Timedelta, Series,
                     DatetimeIndex, TimedeltaIndex,
                     date_range)
+from pandas.core import ops
 from pandas._libs import tslib
 from pandas._libs.tslibs.offsets import shift_months
 
@@ -306,6 +307,17 @@ class TestDatetimeIndexComparisons(object):
 
 
 class TestDatetimeIndexArithmetic(object):
+
+    # -------------------------------------------------------------
+    # Invalid Operations
+
+    @pytest.mark.parametrize('other', [3.14, np.array([2.0, 3.0])])
+    @pytest.mark.parametrize('op', [operator.add, ops.radd,
+                                    operator.sub, ops.rsub])
+    def test_dti_add_sub_float(self, op, other):
+        dti = DatetimeIndex(['2011-01-01', '2011-01-02'])
+        with pytest.raises(TypeError):
+            op(dti, other)
 
     def test_dti_add_timestamp_raises(self):
         idx = DatetimeIndex(['2011-01-01', '2011-01-02'])

--- a/pandas/tests/indexes/period/test_arithmetic.py
+++ b/pandas/tests/indexes/period/test_arithmetic.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 from datetime import timedelta
+import operator
+
 import pytest
 import numpy as np
 
@@ -9,6 +11,7 @@ from pandas import (Timedelta,
                     period_range, Period, PeriodIndex,
                     _np_version_under1p10)
 import pandas.core.indexes.period as period
+from pandas.core import ops
 from pandas.errors import PerformanceWarning
 
 
@@ -255,6 +258,18 @@ class TestPeriodIndexComparisons(object):
 
 
 class TestPeriodIndexArithmetic(object):
+
+    # -------------------------------------------------------------
+    # Invalid Operations
+
+    @pytest.mark.parametrize('other', [3.14, np.array([2.0, 3.0])])
+    @pytest.mark.parametrize('op', [operator.add, ops.radd,
+                                    operator.sub, ops.rsub])
+    def test_tdi_add_sub_float(self, op, other):
+        dti = pd.DatetimeIndex(['2011-01-01', '2011-01-02'])
+        pi = dti.to_period('D')
+        with pytest.raises(TypeError):
+            op(pi, other)
 
     # -----------------------------------------------------------------
     # __add__/__sub__ with ndarray[datetime64] and ndarray[timedelta64]

--- a/pandas/tests/indexes/period/test_arithmetic.py
+++ b/pandas/tests/indexes/period/test_arithmetic.py
@@ -265,7 +265,7 @@ class TestPeriodIndexArithmetic(object):
     @pytest.mark.parametrize('other', [3.14, np.array([2.0, 3.0])])
     @pytest.mark.parametrize('op', [operator.add, ops.radd,
                                     operator.sub, ops.rsub])
-    def test_tdi_add_sub_float(self, op, other):
+    def test_pi_add_sub_float(self, op, other):
         dti = pd.DatetimeIndex(['2011-01-01', '2011-01-02'])
         pi = dti.to_period('D')
         with pytest.raises(TypeError):

--- a/pandas/tests/indexes/period/test_arithmetic.py
+++ b/pandas/tests/indexes/period/test_arithmetic.py
@@ -266,7 +266,7 @@ class TestPeriodIndexArithmetic(object):
     @pytest.mark.parametrize('op', [operator.add, ops.radd,
                                     operator.sub, ops.rsub])
     def test_pi_add_sub_float(self, op, other):
-        dti = pd.DatetimeIndex(['2011-01-01', '2011-01-02'])
+        dti = pd.DatetimeIndex(['2011-01-01', '2011-01-02'], freq='D')
         pi = dti.to_period('D')
         with pytest.raises(TypeError):
             op(pi, other)

--- a/pandas/tests/indexes/timedeltas/test_arithmetic.py
+++ b/pandas/tests/indexes/timedeltas/test_arithmetic.py
@@ -277,7 +277,7 @@ class TestTimedeltaIndexArithmetic(object):
     @pytest.mark.parametrize('op', [operator.add, ops.radd,
                                     operator.sub, ops.rsub])
     def test_tdi_add_sub_float(self, op, other):
-        dti = DatetimeIndex(['2011-01-01', '2011-01-02'])
+        dti = DatetimeIndex(['2011-01-01', '2011-01-02'], freq='D')
         tdi = dti - dti.shift(1)
         with pytest.raises(TypeError):
             op(tdi, other)

--- a/pandas/tests/indexes/timedeltas/test_arithmetic.py
+++ b/pandas/tests/indexes/timedeltas/test_arithmetic.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+import operator
+
 import pytest
 import numpy as np
 from datetime import timedelta
@@ -11,6 +13,7 @@ from pandas import (DatetimeIndex, TimedeltaIndex, Float64Index, Int64Index,
                     Series,
                     Timestamp, Timedelta)
 from pandas.errors import PerformanceWarning, NullFrequencyError
+from pandas.core import ops
 
 
 @pytest.fixture(params=[pd.offsets.Hour(2), timedelta(hours=2),
@@ -269,6 +272,15 @@ class TestTimedeltaIndexArithmetic(object):
 
     # -------------------------------------------------------------
     # Invalid Operations
+
+    @pytest.mark.parametrize('other', [3.14, np.array([2.0, 3.0])])
+    @pytest.mark.parametrize('op', [operator.add, ops.radd,
+                                    operator.sub, ops.rsub])
+    def test_tdi_add_sub_float(self, op, other):
+        dti = DatetimeIndex(['2011-01-01', '2011-01-02'])
+        tdi = dti - dti.shift(1)
+        with pytest.raises(TypeError):
+            op(tdi, other)
 
     def test_tdi_add_str_invalid(self):
         # GH 13624


### PR DESCRIPTION
Align some of the dispatching logic between that is currently special-cased by PeriodIndex.

Should avoid overlap with #19903.

Catch some currently-implicit cases explicitly.