### PR TITLE
DOC fix incorrect example in DataFrame.to_dict docstring. Close GH19868

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -957,8 +957,8 @@ class DataFrame(NDFrame):
                 {'col1': [1, 2], 'col2': [0.5, 0.75]}, index=['a', 'b'])
         >>> df
            col1  col2
-        a     1   0.1
-        b     2   0.2
+        a     1   0.50
+        b     2   0.75
         >>> df.to_dict()
         {'col1': {'a': 1, 'b': 2}, 'col2': {'a': 0.5, 'b': 0.75}}
 


### PR DESCRIPTION
- [x] closes #19868 
- [ ] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] What's new: Fix incorrect example
