### PR TITLE
Cythonized GroupBy pct_change

### DIFF
--- a/doc/source/whatsnew/v0.23.0.txt
+++ b/doc/source/whatsnew/v0.23.0.txt
@@ -794,6 +794,7 @@ Performance Improvements
 - Improved performance of variable ``.rolling()`` on ``.min()`` and ``.max()`` (:issue:`19521`)
 - Improved performance of :func:`pandas.core.groupby.GroupBy.ffill` and :func:`pandas.core.groupby.GroupBy.bfill` (:issue:`11296`)
 - Improved performance of :func:`pandas.core.groupby.GroupBy.any` and :func:`pandas.core.groupby.GroupBy.all` (:issue:`15435`)
+- Improved performance of :func:`pandas.core.groupby.GroupBy.pct_change` (:issue:`19165`)
 
 .. _whatsnew_0230.docs:
 

--- a/pandas/core/groupby.py
+++ b/pandas/core/groupby.py
@@ -3901,6 +3901,13 @@ class SeriesGroupBy(GroupBy):
         """ return a pass thru """
         return func(self)
 
+    def pct_change(self, periods=1, fill_method='pad', limit=None, freq=None):
+        """Calculate percent change of each value to previous entry in group"""
+        filled = getattr(self, fill_method)(limit=limit)
+        shifted = filled.shift(periods=periods, freq=freq)
+
+        return (filled / shifted) - 1
+
 
 class NDFrameGroupBy(GroupBy):
 

--- a/pandas/core/groupby.py
+++ b/pandas/core/groupby.py
@@ -2046,6 +2046,23 @@ class GroupBy(_GroupBy):
 
     @Substitution(name='groupby')
     @Appender(_doc_template)
+    def pct_change(self, periods=1, fill_method='pad', limit=None, freq=None,
+                   axis=0):
+        """Calcuate pct_change of each value to previous entry in group"""
+        if freq is not None or axis != 0:
+            return self.apply(lambda x: x.pct_change(periods=periods,
+                                                     fill_method=fill_method,
+                                                     limit=limit, freq=freq,
+                                                     axis=axis))
+
+        filled = getattr(self, fill_method)(limit=limit).drop(
+            self.grouper.names, axis=1)
+        shifted = filled.shift(periods=periods, freq=freq)
+
+        return (filled / shifted) - 1
+
+    @Substitution(name='groupby')
+    @Appender(_doc_template)
     def head(self, n=5):
         """
         Returns first n rows of each group.

--- a/pandas/tests/groupby/test_groupby.py
+++ b/pandas/tests/groupby/test_groupby.py
@@ -2062,61 +2062,6 @@ class TestGroupBy(MixIn):
                                    ascending=ascending,
                                    na_option=na_option, pct=pct)
 
-    @pytest.mark.parametrize("mix_groupings", [True, False])
-    @pytest.mark.parametrize("as_series", [True, False])
-    @pytest.mark.parametrize("val1,val2", [
-        ('foo', 'bar'), (1, 2), (1., 2.)])
-    @pytest.mark.parametrize("fill_method,limit,exp_vals", [
-        ("ffill", None,
-         [np.nan, np.nan, 'val1', 'val1', 'val1', 'val2', 'val2', 'val2']),
-        ("ffill", 1,
-         [np.nan, np.nan, 'val1', 'val1', np.nan, 'val2', 'val2', np.nan]),
-        ("bfill", None,
-         ['val1', 'val1', 'val1', 'val2', 'val2', 'val2', np.nan, np.nan]),
-        ("bfill", 1,
-         [np.nan, 'val1', 'val1', np.nan, 'val2', 'val2', np.nan, np.nan])
-    ])
-    def test_group_fill_methods(self, mix_groupings, as_series, val1, val2,
-                                fill_method, limit, exp_vals):
-        vals = [np.nan, np.nan, val1, np.nan, np.nan, val2, np.nan, np.nan]
-        _exp_vals = list(exp_vals)
-        # Overwrite placeholder values
-        for index, exp_val in enumerate(_exp_vals):
-            if exp_val == 'val1':
-                _exp_vals[index] = val1
-            elif exp_val == 'val2':
-                _exp_vals[index] = val2
-
-        # Need to modify values and expectations depending on the
-        # Series / DataFrame that we ultimately want to generate
-        if mix_groupings:  # ['a', 'b', 'a, 'b', ...]
-            keys = ['a', 'b'] * len(vals)
-
-            def interweave(list_obj):
-                temp = list()
-                for x in list_obj:
-                    temp.extend([x, x])
-
-                return temp
-
-            _exp_vals = interweave(_exp_vals)
-            vals = interweave(vals)
-        else:  # ['a', 'a', 'a', ... 'b', 'b', 'b']
-            keys = ['a'] * len(vals) + ['b'] * len(vals)
-            _exp_vals = _exp_vals * 2
-            vals = vals * 2
-
-        df = DataFrame({'key': keys, 'val': vals})
-        if as_series:
-            result = getattr(
-                df.groupby('key')['val'], fill_method)(limit=limit)
-            exp = Series(_exp_vals, name='val')
-            assert_series_equal(result, exp)
-        else:
-            result = getattr(df.groupby('key'), fill_method)(limit=limit)
-            exp = DataFrame({'key': keys, 'val': _exp_vals})
-            assert_frame_equal(result, exp)
-
     @pytest.mark.parametrize("agg_func", ['any', 'all'])
     @pytest.mark.parametrize("skipna", [True, False])
     @pytest.mark.parametrize("vals", [

--- a/pandas/tests/groupby/test_transform.py
+++ b/pandas/tests/groupby/test_transform.py
@@ -636,3 +636,90 @@ class TestGroupBy(MixIn):
             exp = exp.astype('float')
 
         comp_func(result, exp)
+
+    @pytest.mark.parametrize("mix_groupings", [True, False])
+    @pytest.mark.parametrize("as_series", [True, False])
+    @pytest.mark.parametrize("val1,val2", [
+        ('foo', 'bar'), (1, 2), (1., 2.)])
+    @pytest.mark.parametrize("fill_method,limit,exp_vals", [
+        ("ffill", None,
+         [np.nan, np.nan, 'val1', 'val1', 'val1', 'val2', 'val2', 'val2']),
+        ("ffill", 1,
+         [np.nan, np.nan, 'val1', 'val1', np.nan, 'val2', 'val2', np.nan]),
+        ("bfill", None,
+         ['val1', 'val1', 'val1', 'val2', 'val2', 'val2', np.nan, np.nan]),
+        ("bfill", 1,
+         [np.nan, 'val1', 'val1', np.nan, 'val2', 'val2', np.nan, np.nan])
+    ])
+    def test_group_fill_methods(self, mix_groupings, as_series, val1, val2,
+                                fill_method, limit, exp_vals):
+        vals = [np.nan, np.nan, val1, np.nan, np.nan, val2, np.nan, np.nan]
+        _exp_vals = list(exp_vals)
+        # Overwrite placeholder values
+        for index, exp_val in enumerate(_exp_vals):
+            if exp_val == 'val1':
+                _exp_vals[index] = val1
+            elif exp_val == 'val2':
+                _exp_vals[index] = val2
+
+        # Need to modify values and expectations depending on the
+        # Series / DataFrame that we ultimately want to generate
+        if mix_groupings:  # ['a', 'b', 'a, 'b', ...]
+            keys = ['a', 'b'] * len(vals)
+
+            def interweave(list_obj):
+                temp = list()
+                for x in list_obj:
+                    temp.extend([x, x])
+
+                return temp
+
+            _exp_vals = interweave(_exp_vals)
+            vals = interweave(vals)
+        else:  # ['a', 'a', 'a', ... 'b', 'b', 'b']
+            keys = ['a'] * len(vals) + ['b'] * len(vals)
+            _exp_vals = _exp_vals * 2
+            vals = vals * 2
+
+        df = DataFrame({'key': keys, 'val': vals})
+        if as_series:
+            result = getattr(
+                df.groupby('key')['val'], fill_method)(limit=limit)
+            exp = Series(_exp_vals, name='val')
+            assert_series_equal(result, exp)
+        else:
+            result = getattr(df.groupby('key'), fill_method)(limit=limit)
+            exp = DataFrame({'key': keys, 'val': _exp_vals})
+            assert_frame_equal(result, exp)
+
+    @pytest.mark.parametrize("test_series", [True, False])
+    @pytest.mark.parametrize("periods,fill_method,limit", [
+        (1, 'ffill', None), (1, 'ffill', 1),
+        (1, 'bfill', None), (1, 'bfill', 1),
+        (-1, 'ffill', None), (-1, 'ffill', 1),
+        (-1, 'bfill', None), (-1, 'bfill', 1)])
+    def test_pct_change(self, test_series, periods, fill_method, limit):
+        vals = [np.nan, np.nan, 1, 2, 4, 10, np.nan, np.nan]
+        exp_vals = Series(vals).pct_change(periods=periods,
+                                           fill_method=fill_method,
+                                           limit=limit).tolist()
+
+        df = DataFrame({'key': ['a'] * len(vals) + ['b'] * len(vals),
+                        'vals': vals * 2})
+        grp = df.groupby('key')
+
+        def get_result(grp_obj):
+            return grp_obj.pct_change(periods=periods,
+                                      fill_method=fill_method,
+                                      limit=limit)
+
+        if test_series:
+            exp = pd.Series(exp_vals * 2)
+            exp.name = 'vals'
+            grp = grp['vals']
+            result = get_result(grp)
+            tm.assert_series_equal(result, exp)
+        else:
+            exp = DataFrame({'vals': exp_vals * 2})
+            result = get_result(grp)
+            tm.assert_frame_equal(result, exp)


### PR DESCRIPTION
- [ ] progress towards #19165
- [X] tests added / passed
- [X] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [X] whatsnew entry

This seemed like a logical follow up to #19673. ASV benchmarks below:

```bash
       before           after         ratio
     [1e4c50a5]       [c8285b5c]
+         170±7μs         239±20μs     1.41  groupby.GroupByMethods.time_method('int', 'min')
+        702±20μs         968±50μs     1.38  groupby.GroupByMethods.time_method('int', 'cumprod')
+         339±2μs          391±6μs     1.15  groupby.GroupByMethods.time_method('float', 'prod')
+      90.2±0.3μs          104±3μs     1.15  groupby.GroupByMethods.time_method('float', 'count')
-      617±0.09ms         917±40μs     0.00  groupby.GroupByMethods.time_method('int', 'pct_change')
-           1.07s       1.08±0.1ms     0.00  groupby.GroupByMethods.time_method('float', 'pct_change')
```