### PR TITLE
Consistent Timedelta Writing for all Excel Engines

### DIFF
--- a/doc/source/whatsnew/v0.23.0.txt
+++ b/doc/source/whatsnew/v0.23.0.txt
@@ -867,7 +867,7 @@ I/O
 - Bug in :func:`read_json` where large numeric values were causing an ``OverflowError`` (:issue:`18842`)
 - Bug in :func:`DataFrame.to_parquet` where an exception was raised if the write destination is S3 (:issue:`19134`)
 - :class:`Interval` now supported in :func:`DataFrame.to_excel` for all Excel file types (:issue:`19242`)
-- :class:`Timedelta` now supported in :func:`DataFrame.to_excel` for xls file type (:issue:`19242`, :issue:`9155`)
+- :class:`Timedelta` now supported in :func:`DataFrame.to_excel` for all Excel file types (:issue:`19242`, :issue:`9155`, :issue:`19900`)
 - Bug in :meth:`pandas.io.stata.StataReader.value_labels` raising an ``AttributeError`` when called on very old files. Now returns an empty dict (:issue:`19417`)
 
 Plotting

--- a/pandas/io/excel.py
+++ b/pandas/io/excel.py
@@ -1380,6 +1380,12 @@ class _OpenpyxlWriter(ExcelWriter):
             )
             xcell.value = _conv_value(cell.val)
 
+            if isinstance(cell.val, timedelta):
+                delta = cell.val
+                xcell.value = delta.total_seconds() / float(86400)
+                # Set format to prevent conversion to datetime
+                xcell.number_format = '0'
+
             style_kwargs = {}
             if cell.style:
                 key = str(cell.style)
@@ -1748,6 +1754,9 @@ class _XlsxWriter(ExcelWriter):
                 num_format_str = self.datetime_format
             elif isinstance(cell.val, date):
                 num_format_str = self.date_format
+            elif isinstance(cell.val, timedelta):
+                delta = cell.val
+                val = delta.total_seconds() / float(86400)
 
             stylekey = json.dumps(cell.style)
             if num_format_str:

--- a/pandas/tests/io/test_excel.py
+++ b/pandas/tests/io/test_excel.py
@@ -1373,11 +1373,6 @@ class TestExcelWriter(_WriterBase):
 
     def test_to_excel_timedelta(self, merge_cells, engine, ext):
         # GH 19242, GH9155 - test writing timedelta to xls
-        if engine == 'openpyxl':
-            pytest.xfail('Timedelta roundtrip broken with openpyxl')
-        if engine == 'xlsxwriter' and (sys.version_info[0] == 2 and
-                                       sys.platform.startswith('linux')):
-            pytest.xfail('Not working on linux with Py2 and xlsxwriter')
         frame = DataFrame(np.random.randint(-10, 10, size=(20, 1)),
                           columns=['A'],
                           dtype=np.int64


### PR DESCRIPTION
- [X] closes #19900
- [X] tests added / passed
- [X] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [X] whatsnew entry

I've basically copied the implementation that was done for the `XlwtWriter` class in #19244 over to the other engine subclasses for an easy fix. This might also fix #19911