### PR TITLE
TST: Debug flaky plotting test

### DIFF
--- a/pandas/tests/plotting/test_datetimelike.py
+++ b/pandas/tests/plotting/test_datetimelike.py
@@ -689,14 +689,17 @@ class TestTSPlot(TestPlotBase):
         s2 = s1[[0, 5, 10, 11, 12, 13, 14, 15]]
 
         # it works!
-        s1.plot()
+        _, ax = self.plt.subplots()
+        s1.plot(ax=ax)
 
-        ax2 = s2.plot(style='g')
+        ax2 = s2.plot(style='g', ax=ax)
         lines = ax2.get_lines()
         idx1 = PeriodIndex(lines[0].get_xdata())
         idx2 = PeriodIndex(lines[1].get_xdata())
-        assert idx1.equals(s1.index.to_period('B'))
-        assert idx2.equals(s2.index.to_period('B'))
+
+        tm.assert_index_equal(idx1, s1.index.to_period('B'))
+        tm.assert_index_equal(idx2, s2.index.to_period('B'))
+
         left, right = ax2.get_xlim()
         pidx = s1.index.to_period()
         assert left <= pidx[0].ordinal


### PR DESCRIPTION
Maybe closes https://github.com/pandas-dev/pandas/issues/19924. I can't reproduce this locally so who knows.

A while back I went through and added `plt.subplots()`  and explicit `ax=ax` to a bunch of the plotting tests. I apparently missed this one. It seemed to help, but they're flaky tests so who knows.

Also chanegd `idx1.equals(idx2)` to `tm.assert_frame_equal` so we get a better error message when it does fail.