### PR TITLE
Added seek to buffer to fix xlwt asv failure

### DIFF
--- a/pandas/io/excel.py
+++ b/pandas/io/excel.py
@@ -387,7 +387,10 @@ class ExcelFile(object):
             self.book = io
         elif not isinstance(io, xlrd.Book) and hasattr(io, "read"):
             # N.B. xlrd.Book has a read attribute too
-            io.seek(0)  # GH 19779
+            if hasattr(io, 'seek'):
+                # GH 19779
+                io.seek(0)
+
             data = io.read()
             self.book = xlrd.open_workbook(file_contents=data)
         elif isinstance(self._io, compat.string_types):

--- a/pandas/io/excel.py
+++ b/pandas/io/excel.py
@@ -387,6 +387,7 @@ class ExcelFile(object):
             self.book = io
         elif not isinstance(io, xlrd.Book) and hasattr(io, "read"):
             # N.B. xlrd.Book has a read attribute too
+            io.seek(0)  # GH 19779
             data = io.read()
             self.book = xlrd.open_workbook(file_contents=data)
         elif isinstance(self._io, compat.string_types):


### PR DESCRIPTION
- [X] closes #19779
- [X] tests added / passed
- [X] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

Sample ASV results from this as follows. Across 5 runs I got the upstream/master error every time and none on HEAD

```bash

(pandas_dev) williams-imac:asv_bench williamayd$ asv continuous -f 1.1 upstream/master HEAD -b io.excel.Excel.time_read_excel --show-stderr
· Creating environments
· Discovering benchmarks
·· Uninstalling from conda-py3.6-Cython-matplotlib-numexpr-numpy-openpyxl-pytables-pytest-scipy-sqlalchemy-xlrd-xlsxwriter-xlwt.
·· Installing into conda-py3.6-Cython-matplotlib-numexpr-numpy-openpyxl-pytables-pytest-scipy-sqlalchemy-xlrd-xlsxwriter-xlwt..
· Running 2 total benchmarks (2 commits * 1 environments * 1 benchmarks)
[  0.00%] · For pandas commit hash 15cd9d2d:
[  0.00%] ·· Building for conda-py3.6-Cython-matplotlib-numexpr-numpy-openpyxl-pytables-pytest-scipy-sqlalchemy-xlrd-xlsxwriter-xlwt...
[  0.00%] ·· Benchmarking conda-py3.6-Cython-matplotlib-numexpr-numpy-openpyxl-pytables-pytest-scipy-sqlalchemy-xlrd-xlsxwriter-xlwt
[ 50.00%] ··· Running io.excel.Excel.time_read_excel                                                                                         ok
[ 50.00%] ···· 
               ============ =============
                  engine                 
               ------------ -------------
                 openpyxl      133±4ms   
                xlsxwriter    118±0.7ms  
                   xlwt      54.2±0.05ms 
               ============ =============

[ 50.00%] · For pandas commit hash f4c9d966:
[ 50.00%] ·· Building for conda-py3.6-Cython-matplotlib-numexpr-numpy-openpyxl-pytables-pytest-scipy-sqlalchemy-xlrd-xlsxwriter-xlwt...
[ 50.00%] ·· Benchmarking conda-py3.6-Cython-matplotlib-numexpr-numpy-openpyxl-pytables-pytest-scipy-sqlalchemy-xlrd-xlsxwriter-xlwt
[100.00%] ··· Running io.excel.Excel.time_read_excel                                                                                 1/3 failed
[100.00%] ···· 
               ============ ===========
                  engine               
               ------------ -----------
                 openpyxl    130±0.7ms 
                xlsxwriter   117±0.4ms 
                   xlwt        failed  
               ============ ===========

[100.00%] ····· 
                
                For parameters: 'xlwt'
                Traceback (most recent call last):
                  File "/Users/williamayd/miniconda3/envs/pandas_dev/lib/python3.6/site-packages/asv/benchmark.py", line 867, in <module>
                    commands[mode](args)
                  File "/Users/williamayd/miniconda3/envs/pandas_dev/lib/python3.6/site-packages/asv/benchmark.py", line 844, in main_run
                    result = benchmark.do_run()
                  File "/Users/williamayd/miniconda3/envs/pandas_dev/lib/python3.6/site-packages/asv/benchmark.py", line 398, in do_run
                    return self.run(*self._current_params)
                  File "/Users/williamayd/miniconda3/envs/pandas_dev/lib/python3.6/site-packages/asv/benchmark.py", line 473, in run
                    samples, number = self.benchmark_timing(timer, repeat, warmup_time, number=number)
                  File "/Users/williamayd/miniconda3/envs/pandas_dev/lib/python3.6/site-packages/asv/benchmark.py", line 500, in benchmark_timing
                    timing = timer.timeit(number)
                  File "/Users/williamayd/clones/pandas/asv_bench/env/83b3be1235aa7b08e8a17448e2f70790/lib/python3.6/timeit.py", line 178, in timeit
                    timing = self.inner(it, self.timer)
                  File "<timeit-src>", line 6, in inner
                  File "/Users/williamayd/miniconda3/envs/pandas_dev/lib/python3.6/site-packages/asv/benchmark.py", line 464, in <lambda>
                    func = lambda: self.func(*param)
                  File "/Users/williamayd/clones/pandas/asv_bench/benchmarks/io/excel.py", line 29, in time_read_excel
                    read_excel(self.bio_read)
                  File "/Users/williamayd/clones/pandas/asv_bench/env/83b3be1235aa7b08e8a17448e2f70790/lib/python3.6/site-packages/pandas/util/_decorators.py", line 172, in wrapper
                    return func(*args, **kwargs)
                  File "/Users/williamayd/clones/pandas/asv_bench/env/83b3be1235aa7b08e8a17448e2f70790/lib/python3.6/site-packages/pandas/util/_decorators.py", line 172, in wrapper
                    return func(*args, **kwargs)
                  File "/Users/williamayd/clones/pandas/asv_bench/env/83b3be1235aa7b08e8a17448e2f70790/lib/python3.6/site-packages/pandas/io/excel.py", line 315, in read_excel
                    io = ExcelFile(io, engine=engine)
                  File "/Users/williamayd/clones/pandas/asv_bench/env/83b3be1235aa7b08e8a17448e2f70790/lib/python3.6/site-packages/pandas/io/excel.py", line 391, in __init__
                    self.book = xlrd.open_workbook(file_contents=data)
                  File "/Users/williamayd/clones/pandas/asv_bench/env/83b3be1235aa7b08e8a17448e2f70790/lib/python3.6/site-packages/xlrd/__init__.py", line 116, in open_workbook
                    with open(filename, "rb") as f:
                TypeError: expected str, bytes or os.PathLike object, not NoneType

SOME BENCHMARKS HAVE CHANGED SIGNIFICANTLY.

```