### PR TITLE
DOC: remove empty attribute/method lists from class docstrings html page

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -583,7 +583,7 @@ def process_class_docstrings(app, what, name, obj, options, lines):
 
    None
 """
-                    ]
+        ]
 
         for template in templates:
             if template in joined:

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -552,6 +552,45 @@ def remove_flags_docstring(app, what, name, obj, options, lines):
         del lines[:]
 
 
+def process_class_docstrings(app, what, name, obj, options, lines):
+    """
+    For those classes for which we use ::
+
+    :template: autosummary/class_without_autosummary.rst
+
+    the documented attributes/methods have to be listed in the class
+    docstring. However, if one of those lists is empty, we use 'None',
+    which then generates warnings in sphinx / ugly html output.
+    This "autodoc-process-docstring" event connector removes that part
+    from the processed docstring.
+
+    """
+    if what == "class":
+        joined = '\n'.join(lines)
+
+        templates =
+            [""".. rubric:: Attributes
+
+.. autosummary::
+   :toctree:
+
+   None
+""",
+             """.. rubric:: Methods
+
+.. autosummary::
+   :toctree:
+
+   None
+"""
+            ]
+
+        for template in templates:
+            if template in joined:
+                joined = joined.replace(template, '')
+        lines[:] = joined.split('\n')
+
+
 suppress_warnings = [
     # We "overwrite" autosummary with our PandasAutosummary, but
     # still want the regular autosummary setup to run. So we just
@@ -562,6 +601,7 @@ suppress_warnings = [
 
 def setup(app):
     app.connect("autodoc-process-docstring", remove_flags_docstring)
+    app.connect("autodoc-process-docstring", process_class_docstrings)
     app.add_autodocumenter(AccessorDocumenter)
     app.add_autodocumenter(AccessorAttributeDocumenter)
     app.add_autodocumenter(AccessorMethodDocumenter)

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -568,22 +568,22 @@ def process_class_docstrings(app, what, name, obj, options, lines):
     if what == "class":
         joined = '\n'.join(lines)
 
-        templates =
-            [""".. rubric:: Attributes
+        templates = [
+            """.. rubric:: Attributes
 
 .. autosummary::
    :toctree:
 
    None
 """,
-             """.. rubric:: Methods
+            """.. rubric:: Methods
 
 .. autosummary::
    :toctree:
 
    None
 """
-            ]
+                    ]
 
         for template in templates:
             if template in joined:

--- a/pandas/core/indexes/numeric.py
+++ b/pandas/core/indexes/numeric.py
@@ -129,14 +129,6 @@ _num_index_shared_docs['class_descr'] = """
     name : object
         Name to be stored in the index
 
-    Attributes
-    ----------
-    inferred_type
-
-    Methods
-    -------
-    None
-
     Notes
     -----
     An Index instance can **only** contain hashable objects.

--- a/pandas/core/indexes/numeric.py
+++ b/pandas/core/indexes/numeric.py
@@ -129,6 +129,14 @@ _num_index_shared_docs['class_descr'] = """
     name : object
         Name to be stored in the index
 
+    Attributes
+    ----------
+    None
+
+    Methods
+    -------
+    None
+
     Notes
     -----
     An Index instance can **only** contain hashable objects.

--- a/pandas/core/indexes/range.py
+++ b/pandas/core/indexes/range.py
@@ -53,6 +53,10 @@ class RangeIndex(Int64Index):
     Index : The base pandas Index type
     Int64Index : Index of int64 data
 
+    Attributes
+    ----------
+    None
+
     Methods
     -------
     from_range


### PR DESCRIPTION
Follow-up on https://github.com/pandas-dev/pandas/pull/18202 (RangeIndex was forgotten)

This is not really ideal, as we then get warnings about None not being a method. Maybe we could somehow connect with the numpydoc process and after its processing remove it ..