### PR TITLE
DOC: Some doc cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,9 +106,8 @@ Here are just a few of the things that pandas does well:
   - Make it [**easy to convert**][conversion] ragged,
     differently-indexed data in other Python and NumPy data structures
     into DataFrame objects
-  - Intelligent label-based [**slicing**][slicing], [**fancy
-    indexing**][fancy-indexing], and [**subsetting**][subsetting] of
-    large data sets
+  - Intelligent label-based [**slicing**][slicing], [**selecting**][selecting],
+    and [**subsetting**][subsetting] of large data sets
   - Intuitive [**merging**][merging] and [**joining**][joining] data
     sets
   - Flexible [**reshaping**][reshape] and [**pivoting**][pivot-table] of
@@ -129,7 +128,7 @@ Here are just a few of the things that pandas does well:
    [groupby]: https://pandas.pydata.org/pandas-docs/stable/groupby.html#group-by-split-apply-combine
    [conversion]: https://pandas.pydata.org/pandas-docs/stable/dsintro.html#dataframe
    [slicing]: https://pandas.pydata.org/pandas-docs/stable/indexing.html#slicing-ranges
-   [fancy-indexing]: https://pandas.pydata.org/pandas-docs/stable/indexing.html#advanced-indexing-with-ix
+   [selecting]: https://pandas.pydata.org/pandas-docs/stable/indexing.html#selection-by-label
    [subsetting]: https://pandas.pydata.org/pandas-docs/stable/indexing.html#boolean-indexing
    [merging]: https://pandas.pydata.org/pandas-docs/stable/merging.html#database-style-dataframe-joining-merging
    [joining]: https://pandas.pydata.org/pandas-docs/stable/merging.html#joining-on-index

--- a/doc/source/indexing.rst
+++ b/doc/source/indexing.rst
@@ -312,27 +312,6 @@ Selection By Label
 
 .. warning::
 
-   ``.loc`` is strict when you present slicers that are not compatible (or convertible) with the index type. For example
-   using integers in a ``DatetimeIndex``. These will raise a ``TypeError``.
-
-  .. ipython:: python
-
-     dfl = pd.DataFrame(np.random.randn(5,4), columns=list('ABCD'), index=pd.date_range('20130101',periods=5))
-     dfl
-
-  .. code-block:: ipython
-
-     In [4]: dfl.loc[2:3]
-     TypeError: cannot do slice indexing on <class 'pandas.tseries.index.DatetimeIndex'> with these indexers [2] of <type 'int'>
-
-  String likes in slicing *can* be convertible to the type of the index and lead to natural slicing.
-
-  .. ipython:: python
-
-     dfl.loc['20130102':'20130104']
-
-.. warning::
-
    Starting in 0.21.0, pandas will show a ``FutureWarning`` if indexing with a list with missing labels. In the future
    this will raise a ``KeyError``. See :ref:`list-like Using loc with missing keys in a list is Deprecated <indexing.deprecate_loc_reindex_listlike>`.
 
@@ -429,6 +408,29 @@ However, if at least one of the two is absent *and* the index is not sorted, an
 error will be raised (since doing otherwise would be computationally expensive,
 as well as potentially ambiguous for mixed type indexes). For instance, in the
 above example, ``s.loc[1:6]`` would raise ``KeyError``.
+
+.. warning::
+
+   ``.loc`` is strict when you present slicers that are not compatible
+   (or convertible) with the index type. For example using integers in a
+   ``DatetimeIndex``. These will raise a ``TypeError``.
+
+  .. ipython:: python
+
+     dfl = pd.DataFrame(np.random.randn(5,4), columns=list('ABCD'),
+                        index=pd.date_range('20130101',periods=5))
+     dfl
+
+  .. code-block:: ipython
+
+     In [4]: dfl.loc[2:3]
+     TypeError: cannot do slice indexing on <class 'pandas.tseries.index.DatetimeIndex'> with these indexers [2] of <type 'int'>
+
+  String likes in slicing *can* be convertible to the type of the index and lead to natural slicing.
+
+  .. ipython:: python
+
+     dfl.loc['20130102':'20130104']
 
 .. _indexing.integer:
 


### PR DESCRIPTION
Some minor stuff regarding ``.ix`` and ``.loc``.

1:
The [README](https://github.com/pandas-dev/pandas) has a link about ``DataFrame.ix``. As ``ix`` is deprecated, the link is changed to [selection-by-label](https://pandas.pydata.org/pandas-docs/stable/indexing.html#selection-by-label).

2:
In [selection-by-label](https://pandas.pydata.org/pandas-docs/stable/indexing.html#selection-by-label) a minor wall of warnings come before the reader even knows what the warning are about (because this is the section about `´loc.``...). This is very "scary" introduction.

I've moved the chained-assignment warning to after the intro, and the rest to the end of the section, so the reader first gets an understanding about ``loc`` in general and then only after that gets the warnings about the pitfalls of ``loc``.