### PR TITLE
CLN: deprecate the pandas.tseries.plotting.tsplot function (GH18627)

### DIFF
--- a/doc/source/whatsnew/v0.23.0.txt
+++ b/doc/source/whatsnew/v0.23.0.txt
@@ -731,6 +731,8 @@ Deprecations
 - The ``order`` parameter of :func:`factorize` is deprecated and will be removed in a future release (:issue:`19727`)
 - :attr:`Timestamp.weekday_name`, :attr:`DatetimeIndex.weekday_name`, and :attr:`Series.dt.weekday_name` are deprecated in favor of :meth:`Timestamp.day_name`, :meth:`DatetimeIndex.day_name`, and :meth:`Series.dt.day_name` (:issue:`12806`)
 
+- ``pandas.tseries.plotting.tsplot`` is deprecated. Use :func:`Series.plot` instead (:issue:`18627`)
+
 .. _whatsnew_0230.prior_deprecations:
 
 Removal of prior version deprecations/changes

--- a/pandas/plotting/_timeseries.py
+++ b/pandas/plotting/_timeseries.py
@@ -23,6 +23,7 @@ from pandas.plotting._converter import (TimeSeries_DateLocator,
 
 
 def tsplot(series, plotf, ax=None, **kwargs):
+    import warnings
     """
     Plots a Series on the given Matplotlib axes or the current axes
 
@@ -35,7 +36,14 @@ def tsplot(series, plotf, ax=None, **kwargs):
     _____
     Supports same kwargs as Axes.plot
 
+
+    .. deprecated:: 0.23.0
+       Use Series.plot() instead
     """
+    warnings.warn("'tsplot' is deprecated and will be removed in a "
+                  "future version. Please use Series.plot() instead.",
+                  FutureWarning, stacklevel=2)
+
     # Used inferred freq is possible, need a test case for inferred
     if ax is None:
         import matplotlib.pyplot as plt

--- a/pandas/tests/plotting/test_datetimelike.py
+++ b/pandas/tests/plotting/test_datetimelike.py
@@ -100,6 +100,15 @@ class TestTSPlot(TestPlotBase):
 
         pytest.raises(TypeError, df['A'].plot)
 
+    def test_tsplot_deprecated(self):
+        from pandas.tseries.plotting import tsplot
+
+        _, ax = self.plt.subplots()
+        ts = tm.makeTimeSeries()
+
+        with tm.assert_produces_warning(FutureWarning):
+            tsplot(ts, self.plt.Axes.plot, ax=ax)
+
     @pytest.mark.slow
     def test_tsplot(self):
         from pandas.tseries.plotting import tsplot


### PR DESCRIPTION
- [X] closes #18627 
- [X] tests added / passed
- [X] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [X] whatsnew entry
