### PR TITLE
DOC: Improve docstring for pandas.Index.repeat

### DIFF
--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -695,13 +695,31 @@ class Index(IndexOpsMixin, PandasObject):
     # ops compat
     @deprecate_kwarg(old_arg_name='n', new_arg_name='repeats')
     def repeat(self, repeats, *args, **kwargs):
-        """
-        Repeat elements of an Index. Refer to `numpy.ndarray.repeat`
-        for more information about the `repeats` argument.
+        """Repeat elements of an Index.
+
+        Parameters
+        ----------
+        repeats : int
+            The number of repetitions for each element.
+
+        Returns
+        -------
+        pandas.Index
+            Newly created Index with repeated elements.
 
         See also
         --------
         numpy.ndarray.repeat
+
+        Examples
+        --------
+        >>> idx = pd.Index([1, 2, 3])
+        >>> idx
+        Int64Index([1, 2, 3], dtype='int64')
+        >>> idx.repeat(2)
+        Int64Index([1, 1, 2, 2, 3, 3], dtype='int64')
+        >>> idx.repeat(3)
+        Int64Index([1, 1, 1, 2, 2, 2, 3, 3, 3], dtype='int64')
         """
         nv.validate_repeat(args, kwargs)
         return self._shallow_copy(self._values.repeat(repeats))

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -705,7 +705,7 @@ class Index(IndexOpsMixin, PandasObject):
         ----------
         repeats : int
             The number of repetitions for each element.
-        kwargs : keyword, value pairs
+        **kwargs
             Additional keywords have no effect but might be accepted for
             compatibility with numpy.
 

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -704,6 +704,9 @@ class Index(IndexOpsMixin, PandasObject):
         ----------
         repeats : int
             The number of repetitions for each element.
+        kwargs : keyword, value pairs
+            Additional keywords have no effect but might be accepted for
+            compatibility with numpy.
 
         Returns
         -------

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -695,7 +695,8 @@ class Index(IndexOpsMixin, PandasObject):
     # ops compat
     @deprecate_kwarg(old_arg_name='n', new_arg_name='repeats')
     def repeat(self, repeats, *args, **kwargs):
-        """Repeat elements of an Index.
+        """
+        Repeat elements of an Index.
 
         Returns a new index where each element of the current index
         is repeated consecutively a given number of times.

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -697,6 +697,10 @@ class Index(IndexOpsMixin, PandasObject):
     def repeat(self, repeats, *args, **kwargs):
         """Repeat elements of an Index.
 
+        Returns a new index where each element of the current index
+        is repeated consecutively a given number of times. Can be used
+        to create an index that quickly summarizes data (see Examples).
+
         Parameters
         ----------
         repeats : int
@@ -707,9 +711,10 @@ class Index(IndexOpsMixin, PandasObject):
         pandas.Index
             Newly created Index with repeated elements.
 
-        See also
+        See Also
         --------
-        numpy.repeat
+        Series.repeat : Equivalent function for Series
+        numpy.repeat : Underlying implementation
 
         Examples
         --------
@@ -720,6 +725,22 @@ class Index(IndexOpsMixin, PandasObject):
         Int64Index([1, 1, 2, 2, 3, 3], dtype='int64')
         >>> idx.repeat(3)
         Int64Index([1, 1, 1, 2, 2, 2, 3, 3, 3], dtype='int64')
+
+        >>> idx = pd.Index([1, 2, 3]). repeat(2)
+        >>> df = pd.DataFrame([5, 6, 7, 3, 4, 1], index=idx)
+        >>> df
+           0
+        1  5
+        1  6
+        2  7
+        2  3
+        3  4
+        3  1
+        >>> df.groupby(level=0).mean()
+             0
+        1  5.5
+        2  5.0
+        3  2.5
         """
         nv.validate_repeat(args, kwargs)
         return self._shallow_copy(self._values.repeat(repeats))

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -698,8 +698,7 @@ class Index(IndexOpsMixin, PandasObject):
         """Repeat elements of an Index.
 
         Returns a new index where each element of the current index
-        is repeated consecutively a given number of times. Can be used
-        to create an index that quickly summarizes data (see Examples).
+        is repeated consecutively a given number of times.
 
         Parameters
         ----------
@@ -725,22 +724,6 @@ class Index(IndexOpsMixin, PandasObject):
         Int64Index([1, 1, 2, 2, 3, 3], dtype='int64')
         >>> idx.repeat(3)
         Int64Index([1, 1, 1, 2, 2, 2, 3, 3, 3], dtype='int64')
-
-        >>> idx = pd.Index([1, 2, 3]). repeat(2)
-        >>> df = pd.DataFrame([5, 6, 7, 3, 4, 1], index=idx)
-        >>> df
-           0
-        1  5
-        1  6
-        2  7
-        2  3
-        3  4
-        3  1
-        >>> df.groupby(level=0).mean()
-             0
-        1  5.5
-        2  5.0
-        3  2.5
         """
         nv.validate_repeat(args, kwargs)
         return self._shallow_copy(self._values.repeat(repeats))

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -709,7 +709,7 @@ class Index(IndexOpsMixin, PandasObject):
 
         See also
         --------
-        numpy.ndarray.repeat
+        numpy.repeat
 
         Examples
         --------


### PR DESCRIPTION
String assigned to ChiPy (Chicago Python Users Group) chapter of the Worldwide Documentation Sprint

While `Index.repeat` does accept `args` and `kwargs`, it does not pass them through to the underlying `numpy` function.

The only additional parameter the numpy function takes is `axis` ([numpy docs](https://docs.scipy.org/doc/numpy/reference/generated/numpy.repeat.html#numpy.repeat)), which is not supported by pandas:

```python
>>> pd.Index([1, 2, 3]).repeat(2, axis=2)
ValueError: the 'axis' parameter is not supported in the pandas implementation of repeat()
```

Should the *args and **kwargs be removed?

Thanks