### PR TITLE
CLN/DOC: cache_readonly: remove allow_setting + preserve docstring

### DIFF
--- a/pandas/_libs/properties.pyx
+++ b/pandas/_libs/properties.pyx
@@ -17,8 +17,11 @@ cdef class CachedProperty(object):
         self.__doc__ = getattr(func, '__doc__', None)
 
     def __get__(self, obj, typ):
-        # Get the cache or set a default one if needed
+        if obj is None:
+            # accessed on the class, not the instance
+            return self
 
+        # Get the cache or set a default one if needed
         cache = getattr(obj, '_cache', None)
         if cache is None:
             try:

--- a/pandas/_libs/properties.pyx
+++ b/pandas/_libs/properties.pyx
@@ -9,20 +9,12 @@ from cpython cimport (
 cdef class CachedProperty(object):
 
     cdef readonly:
-        object func, name, __doc__, allow_setting
+        object func, name, __doc__
 
-    def __init__(self, func=None, allow_setting=False):
-        if func is not None:
-            self.func = func
-            self.name = func.__name__
-            self.__doc__ = getattr(func, '__doc__', None)
-        self.allow_setting = allow_setting
-
-    def __call__(self, func, doc=None):
+    def __init__(self, func):
         self.func = func
         self.name = func.__name__
         self.__doc__ = getattr(func, '__doc__', None)
-        return self
 
     def __get__(self, obj, typ):
         # Get the cache or set a default one if needed
@@ -41,21 +33,6 @@ cdef class CachedProperty(object):
             val = self.func(obj)
             PyDict_SetItem(cache, self.name, val)
         return val
-
-    def __set__(self, obj, value):
-
-        if not self.allow_setting:
-            raise Exception("cannot set values for [%s]" % self.name)
-
-        # Get the cache or set a default one if needed
-        cache = getattr(obj, '_cache', None)
-        if cache is None:
-            try:
-                cache = obj._cache = {}
-            except (AttributeError):
-                return
-
-        PyDict_SetItem(cache, self.name, value)
 
 
 cache_readonly = CachedProperty

--- a/pandas/_libs/properties.pyx
+++ b/pandas/_libs/properties.pyx
@@ -6,22 +6,22 @@ from cpython cimport (
     PyDict_Contains, PyDict_GetItem, PyDict_SetItem)
 
 
-cdef class cache_readonly(object):
+cdef class CachedProperty(object):
 
     cdef readonly:
-        object func, name, doc, allow_setting
+        object func, name, __doc__, allow_setting
 
     def __init__(self, func=None, allow_setting=False):
         if func is not None:
             self.func = func
             self.name = func.__name__
-            self.doc = getattr(func, '__doc__', None)
+            self.__doc__ = getattr(func, '__doc__', None)
         self.allow_setting = allow_setting
 
     def __call__(self, func, doc=None):
         self.func = func
         self.name = func.__name__
-        self.doc = getattr(func, '__doc__', None)
+        self.__doc__ = getattr(func, '__doc__', None)
         return self
 
     def __get__(self, obj, typ):
@@ -32,7 +32,7 @@ cdef class cache_readonly(object):
             try:
                 cache = obj._cache = {}
             except (AttributeError):
-                return type('cached', (object, ), {'__doc__': self.doc})
+                return self
 
         if PyDict_Contains(cache, self.name):
             # not necessary to Py_INCREF
@@ -56,6 +56,10 @@ cdef class cache_readonly(object):
                 return
 
         PyDict_SetItem(cache, self.name, value)
+
+
+cache_readonly = CachedProperty
+
 
 cdef class AxisProperty(object):
     cdef:

--- a/pandas/_libs/properties.pyx
+++ b/pandas/_libs/properties.pyx
@@ -9,17 +9,19 @@ from cpython cimport (
 cdef class cache_readonly(object):
 
     cdef readonly:
-        object func, name, allow_setting
+        object func, name, doc, allow_setting
 
     def __init__(self, func=None, allow_setting=False):
         if func is not None:
             self.func = func
             self.name = func.__name__
+            self.doc = getattr(func, '__doc__', None)
         self.allow_setting = allow_setting
 
     def __call__(self, func, doc=None):
         self.func = func
         self.name = func.__name__
+        self.doc = getattr(func, '__doc__', None)
         return self
 
     def __get__(self, obj, typ):
@@ -30,7 +32,7 @@ cdef class cache_readonly(object):
             try:
                 cache = obj._cache = {}
             except (AttributeError):
-                return
+                return type('cached', (object, ), {'__doc__': self.doc})
 
         if PyDict_Contains(cache, self.name):
             # not necessary to Py_INCREF

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -1401,7 +1401,7 @@ class Index(IndexOpsMixin, PandasObject):
     def is_lexsorted_for_tuple(self, tup):
         return True
 
-    @cache_readonly(allow_setting=True)
+    @cache_readonly
     def is_unique(self):
         """ return if the index has unique values """
         return self._engine.is_unique

--- a/pandas/tests/indexes/test_base.py
+++ b/pandas/tests/indexes/test_base.py
@@ -519,7 +519,6 @@ class TestIndex(Base):
         assert not ind.is_(ind.copy())
         assert not ind.is_(ind.copy(deep=False))
         assert not ind.is_(ind[:])
-        assert not ind.is_(ind.view(np.ndarray).view(Index))
         assert not ind.is_(np.array(range(10)))
 
         # quasi-implementation dependent

--- a/pandas/tests/test_lib.py
+++ b/pandas/tests/test_lib.py
@@ -3,6 +3,7 @@
 import pytest
 
 import numpy as np
+from pandas import Index
 from pandas._libs import lib, writers as libwriters
 import pandas.util.testing as tm
 
@@ -198,3 +199,8 @@ class TestIndexing(object):
         result = lib.get_reverse_indexer(indexer, 5)
         expected = np.array([4, 2, 3, 6, 7], dtype=np.int64)
         tm.assert_numpy_array_equal(result, expected)
+
+
+def test_cache_readonly_preserve_docstrings():
+    # GH18197
+    assert Index.hasnans.__doc__ is not None


### PR DESCRIPTION
Closes https://github.com/pandas-dev/pandas/issues/18197

This kind of 'works' in that `?` or `__doc__` now give the correct docstring, but it's not yet fully ideal as it is now seen as a class (which will probably mess up sphinx' autodoc/autosummary, which I didn't check yet)