### PR TITLE
month_name/day_name warnings followup

### DIFF
--- a/pandas/_libs/tslibs/timestamps.pyx
+++ b/pandas/_libs/tslibs/timestamps.pyx
@@ -766,7 +766,7 @@ class Timestamp(_Timestamp):
         """
         warnings.warn("`weekday_name` is deprecated and will be removed in a "
                       "future version. Use `day_name` instead",
-                      DeprecationWarning)
+                      FutureWarning)
         return self.day_name()
 
     @property

--- a/pandas/tests/indexes/datetimes/test_misc.py
+++ b/pandas/tests/indexes/datetimes/test_misc.py
@@ -271,7 +271,9 @@ class TestDatetime64(object):
             assert dti.weekday_name[day] == eng_name
             assert dti.day_name(locale=time_locale)[day] == name
             ts = Timestamp(datetime(2016, 4, day))
-            assert ts.weekday_name == eng_name
+            with tm.assert_produces_warning(FutureWarning,
+                                            check_stacklevel=False):
+                assert ts.weekday_name == eng_name
             assert ts.day_name(locale=time_locale) == name
         dti = dti.append(DatetimeIndex([pd.NaT]))
         assert np.isnan(dti.day_name(locale=time_locale)[-1])

--- a/pandas/tests/indexes/datetimes/test_scalar_compat.py
+++ b/pandas/tests/indexes/datetimes/test_scalar_compat.py
@@ -47,7 +47,12 @@ class TestDatetimeIndexOps(object):
         # extra fields from DatetimeIndex like quarter and week
         idx = tm.makeDateIndex(100)
         expected = getattr(idx, field)[-1]
-        result = getattr(Timestamp(idx[-1]), field)
+        if field == 'weekday_name':
+            with tm.assert_produces_warning(FutureWarning,
+                                            check_stacklevel=False):
+                result = getattr(Timestamp(idx[-1]), field)
+        else:
+            result = getattr(Timestamp(idx[-1]), field)
         assert result == expected
 
     def test_dti_timestamp_freq_fields(self):

--- a/pandas/tests/scalar/timestamp/test_timestamp.py
+++ b/pandas/tests/scalar/timestamp/test_timestamp.py
@@ -105,7 +105,7 @@ class TestTimestampProperties(object):
     def test_names(self, data, time_locale):
         # GH 17354
         # Test .weekday_name, .day_name(), .month_name
-        with tm.assert_produces_warning(DeprecationWarning,
+        with tm.assert_produces_warning(FutureWarning,
                                         check_stacklevel=False):
             assert data.weekday_name == 'Monday'
         if time_locale is None:


### PR DESCRIPTION
xref https://github.com/pandas-dev/pandas/pull/18164#issuecomment-370390747
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`

Changed the `weekday_name` warning to a `FutureWarning` and catching them in 2 additional tests. 