### PR TITLE
DOC: enable matplotlib plot_directive to include figures in docstrings

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -63,6 +63,7 @@ extensions = ['sphinx.ext.autodoc',
               'ipython_sphinxext.ipython_console_highlighting',
               # lowercase didn't work
               'IPython.sphinxext.ipython_console_highlighting',
+              'matplotlib.sphinxext.plot_directive',
               'sphinx.ext.intersphinx',
               'sphinx.ext.coverage',
               'sphinx.ext.mathjax',
@@ -84,6 +85,14 @@ autosummary_generate = False
 
 if any(re.match("\s*api\s*", l) for l in index_rst_lines):
     autosummary_generate = True
+
+# matplotlib plot directive
+plot_include_source = True
+plot_formats = [("png", 90)]
+plot_html_show_formats = False
+plot_html_show_source_link = False
+plot_pre_code = """import numpy as np
+import pandas as pd"""
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['../_templates']

--- a/pandas/plotting/_core.py
+++ b/pandas/plotting/_core.py
@@ -2542,6 +2542,7 @@ class SeriesPlotMethods(BasePlotMethods):
         --------
 
         .. plot::
+            :context: close-figs
 
             >>> s = pd.Series([1, 3, 2])
             >>> s.plot.line()

--- a/pandas/plotting/_core.py
+++ b/pandas/plotting/_core.py
@@ -2537,6 +2537,14 @@ class SeriesPlotMethods(BasePlotMethods):
         Returns
         -------
         axes : matplotlib.AxesSubplot or np.array of them
+
+        Examples
+        --------
+
+        .. plot::
+
+            >>> s = pd.Series([1, 3, 2])
+            >>> s.plot.line()
         """
         return self(kind='line', **kwds)
 


### PR DESCRIPTION
This adds the matplotlib.sphinxext.plot_directive as extension to conf.py, and added a small example in the `Series.plot.line` docstring