### PR TITLE
Added .pytest_cache to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -88,8 +88,9 @@ scikits
 *.c
 *.cpp
 
-# Performance Testing #
-#######################
+# Unit / Performance Testing #
+##############################
+.pytest_cache/
 asv_bench/env/
 asv_bench/html/
 asv_bench/results/


### PR DESCRIPTION
After running the unit test suite `.pytest_cache/` keeps showing up in the project root. Figured it was worth adding to `.gitignore` to prevent this from being inadvertently committed