### PR TITLE
DOC: Extend docstring pandas core index to_frame method

### DIFF
--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -1124,6 +1124,23 @@ class Index(IndexOpsMixin, PandasObject):
         -------
         DataFrame
             DataFrame containing the original Index data.
+
+        Examples
+        --------
+        >>> idx = pd.Index(['Ant', 'Bear', 'Cow'])
+        >>> idx.to_frame()
+                0
+        Ant    Ant
+        Bear  Bear
+        Cow    Cow
+
+        By default, the original Index is reused. To enforce a new Index:
+
+        >>> idx.to_frame(index=False)
+            0
+        0   Ant
+        1  Bear
+        2   Cow
         """
 
         from pandas import DataFrame

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -1117,7 +1117,7 @@ class Index(IndexOpsMixin, PandasObject):
         Parameters
         ----------
         index : boolean
-            Set the index of the returned DataFrame as the original Index 
+            Set the index of the returned DataFrame as the original Index
             (default True).
 
         Returns

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -1116,8 +1116,9 @@ class Index(IndexOpsMixin, PandasObject):
 
         Parameters
         ----------
-        index : boolean, default True
-            Set the index of the returned DataFrame as the original Index.
+        index : boolean
+            Set the index of the returned DataFrame as the original Index 
+            (default True).
 
         Returns
         -------

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -1127,17 +1127,18 @@ class Index(IndexOpsMixin, PandasObject):
 
         Examples
         --------
-        >>> idx = pd.Index(['Ant', 'Bear', 'Cow'])
+        >>> idx = pd.Index(['Ant', 'Bear', 'Cow'], name='animal')
         >>> idx.to_frame()
-                0
-        Ant    Ant
-        Bear  Bear
-        Cow    Cow
+            animal
+        animal       
+        Ant       Ant
+        Bear     Bear
+        Cow       Cow
 
         By default, the original Index is reused. To enforce a new Index:
 
         >>> idx.to_frame(index=False)
-            0
+            animal
         0   Ant
         1  Bear
         2   Cow

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -1110,8 +1110,7 @@ class Index(IndexOpsMixin, PandasObject):
         return Series(self._to_embed(), index=index, name=name)
 
     def to_frame(self, index=True):
-        """
-        Create a DataFrame with a column containing the Index.
+        """Create a DataFrame with a column containing the Index.
 
         .. versionadded:: 0.21.0
 

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -1116,9 +1116,8 @@ class Index(IndexOpsMixin, PandasObject):
 
         Parameters
         ----------
-        index : boolean
-            Set the index of the returned DataFrame as the original Index
-            (default True).
+        index : boolean (default True)
+            Set the index of the returned DataFrame as the original Index.
 
         Returns
         -------

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -1110,13 +1110,14 @@ class Index(IndexOpsMixin, PandasObject):
         return Series(self._to_embed(), index=index, name=name)
 
     def to_frame(self, index=True):
-        """Create a DataFrame with a column containing the Index.
+        """
+        Create a DataFrame with a column containing the Index.
 
         .. versionadded:: 0.21.0
 
         Parameters
         ----------
-        index : boolean (default True)
+        index : boolean, default True
             Set the index of the returned DataFrame as the original Index.
 
         Returns

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -1122,7 +1122,8 @@ class Index(IndexOpsMixin, PandasObject):
 
         Returns
         -------
-        DataFrame : a DataFrame containing the original Index data.
+        DataFrame
+            DataFrame containing the original Index data.
         """
 
         from pandas import DataFrame


### PR DESCRIPTION
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

This PR provides adaptations of the original `to_frame` docstring, taking into account the [docstring guide](https://python-sprints.github.io/pandas/guide/pandas_docstring.html). 
