### PR TITLE
DOC: Updating pandas.Interval docstring

### DIFF
--- a/pandas/_libs/interval.pyx
+++ b/pandas/_libs/interval.pyx
@@ -81,43 +81,68 @@ cdef class Interval(IntervalMixin):
 
     Parameters
     ----------
-    left : orderable object
+    left : orderable scalar
         Left bound for the interval.
-    right : orderable object
+    right : orderable scalar
         Right bound for the interval.
     closed : {'left', 'right', 'both', 'neither'}, default 'right'
         Whether the interval is closed on the left-side, right-side, both or
         neither.
-    
+
     Notes
     -----
     You must be able to compare the parameters `left` and `right`,
-    and they must satisfy ``left <= right``. 
+    and they must satisfy ``left <= right``.
 
     Examples
     --------
-    The examples below show how you can build Intervals of various types
-    of elements. In particular a numeric interval, a time interval and
-    finally a string interval. Given an Interval you can check whether 
-    an element belongs to it.
+    It is possible to build Intervals of different types, like numeric ones
 
     >>> iv = pd.Interval(left=0, right=5)
     >>> iv
     Interval(0, 5, closed='right')
+
+    In which you can check if an element belongs to it
+
     >>> 2.5 in iv
     True
+
+    You can test the bounds
+
+    >>> 0 in iv
+    False
+    >>> 5 in iv
+    True
+
+    Calculate its length
+
+    >>> iv.length
+    5
+
+    You can operate with `+` and `*` over an Interval and the operation
+    is applied to each of its bounds, so the result depends on the type
+    of the bound elements
+
     >>> shifted_iv = iv + 3
-    >>> shifted_iv 
+    >>> shifted_iv
     Interval(3, 8, closed='right')
-    
-    >>> year_2017 = pd.Interval(pd.Timestamp('2017-01-01'),
-    ...                         pd.Timestamp('2017-12-31'), closed='both')
+    >>> extended_iv = iv * 10.0
+    >>> extended_iv
+    Interval(0.0, 50.0, closed='right')
+
+    To create a time interval you can use Timestamps as the bounds
+
+    >>> year_2017 = pd.Interval(pd.Timestamp('2017-01-01 00:00:00'),
+    ...                         pd.Timestamp('2018-01-01 00:00:00'),
+    ...                         closed='left')
     >>> pd.Timestamp('2017-01-01 00:00') in year_2017
     True
     >>> year_2017.length
-    Timedelta('364 days 00:00:00')
+    Timedelta('365 days 00:00:00')
 
-    >>> volume_1 = pd.Interval('Ant','Dog',closed='both')
+    And also you can create string intervals
+
+    >>> volume_1 = pd.Interval('Ant', 'Dog', closed='both')
     >>> 'Bee' in volume_1
     True
 

--- a/pandas/_libs/interval.pyx
+++ b/pandas/_libs/interval.pyx
@@ -81,25 +81,44 @@ cdef class Interval(IntervalMixin):
 
     Parameters
     ----------
-    left : value
-        Left bound for the interval
-    right : value
-        Right bound for the interval
+    left : orderable object
+        Left bound for the interval.
+    right : orderable object
+        Right bound for the interval.
     closed : {'left', 'right', 'both', 'neither'}, default 'right'
         Whether the interval is closed on the left-side, right-side, both or
-        neither
+        neither.
+    
+    Notes
+    -----
+    You must be able to compare the parameters **left** and **right**,
+    and they must satisfy **left <= right**. 
 
     Examples
     --------
+    The examples below show how you can build Intervals of various types
+    of elements. In particular a numeric interval, a time interval and
+    finally a string interval. Given an Interval you can check whether 
+    an element belongs to it.
+
     >>> iv = pd.Interval(left=0, right=5)
     >>> iv
     Interval(0, 5, closed='right')
     >>> 2.5 in iv
     True
-
+    >>> shifted_iv = iv + 3
+    >>> shifted_iv 
+    Interval(3, 8, closed='right')
+    
     >>> year_2017 = pd.Interval(pd.Timestamp('2017-01-01'),
     ...                         pd.Timestamp('2017-12-31'), closed='both')
     >>> pd.Timestamp('2017-01-01 00:00') in year_2017
+    True
+    >>> year_2017.length
+    Timedelta('364 days 00:00:00')
+
+    >>> volume_1 = pd.Interval('Ant','Dog',closed='both')
+    >>> 'Bee' in volume_1
     True
 
     See Also

--- a/pandas/_libs/interval.pyx
+++ b/pandas/_libs/interval.pyx
@@ -91,8 +91,8 @@ cdef class Interval(IntervalMixin):
 
     Notes
     -----
-    You must be able to compare the parameters `left` and `right`,
-    and they must satisfy ``left <= right``.
+    The parameters `left` and `right` must be from the `same` type,you must be
+    able to `compare` them and they must satisfy ``left <= right``.
 
     Examples
     --------
@@ -150,8 +150,9 @@ cdef class Interval(IntervalMixin):
     --------
     IntervalIndex : An Index of Interval objects that are all closed on the
                     same side.
-    cut, qcut : Convert arrays of continuous data into Categoricals/Series of
-                Interval.
+    cut : Return indices of half-open bins.
+    qcut : Discretize variable into equal-sized buckets based on rank or
+           based on sample quantiles.
     """
     _typ = "interval"
 

--- a/pandas/_libs/interval.pyx
+++ b/pandas/_libs/interval.pyx
@@ -153,6 +153,7 @@ cdef class Interval(IntervalMixin):
     cut : Return indices of half-open bins.
     qcut : Discretize variable into equal-sized buckets based on rank or
            based on sample quantiles.
+    Period : Represents a period of time.
     """
     _typ = "interval"
 

--- a/pandas/_libs/interval.pyx
+++ b/pandas/_libs/interval.pyx
@@ -91,8 +91,8 @@ cdef class Interval(IntervalMixin):
     
     Notes
     -----
-    You must be able to compare the parameters **left** and **right**,
-    and they must satisfy **left <= right**. 
+    You must be able to compare the parameters `left` and `right`,
+    and they must satisfy ``left <= right``. 
 
     Examples
     --------

--- a/pandas/_libs/interval.pyx
+++ b/pandas/_libs/interval.pyx
@@ -91,18 +91,18 @@ cdef class Interval(IntervalMixin):
 
     Notes
     -----
-    The parameters `left` and `right` must be from the `same` type,you must be
-    able to `compare` them and they must satisfy ``left <= right``.
+    The parameters `left` and `right` must be from the same type, you must be
+    able to compare them and they must satisfy ``left <= right``.
 
     Examples
     --------
-    It is possible to build Intervals of different types, like numeric ones
+    It is possible to build Intervals of different types, like numeric ones:
 
     >>> iv = pd.Interval(left=0, right=5)
     >>> iv
     Interval(0, 5, closed='right')
 
-    In which you can check if an element belongs to it
+    You can check if an element belongs to it
 
     >>> 2.5 in iv
     True
@@ -149,9 +149,9 @@ cdef class Interval(IntervalMixin):
     See Also
     --------
     IntervalIndex : An Index of Interval objects that are all closed on the
-                    same side.
-    cut : Return indices of half-open bins.
-    qcut : Discretize variable into equal-sized buckets based on rank or
+        same side.
+    cut : Bin values into discrete intervals.
+    qcut : Discretize values into equal-sized buckets based on rank or
            based on sample quantiles.
     Period : Represents a period of time.
     """


### PR DESCRIPTION
Docstring assigned to the Buenos Aires chapter for the sprint.

Hi, I have a few doubts about the changes.

First about the type of the parameters *left* and *right*, it's ok to refer to them as *orderable*?
In the implementation, the constructor takes any pair of objects that satisfy `left <= right` and the comparison returns a boolean value.
 I tried to pass two numpy arrays and it breaks because of ambiguity, but still it's so general that you can even make Intervals of Intervals, sets or booleans. And I believe this is too permissive and prone to error. 

So what it's better, put a warning about this or add an example that is a little more complex and uses this capability (I tried to think one, but nothing came up to my mind).

And last,  validate_docstrings.py returned this error

`2341, in _signature_from_callable 
   'no signature found for builtin type {!r}'.format(obj)) 
ValueError: no signature found for builtin type <class 'pandas._libs.interval.Interval'>
`

Thanks, happy to collaborate.

PS: Given that this is a Cython file I needed to recompile the project to see the changes in the documentation. I mention this because is not in the sprint guide and I don't know if I will able to add it before the event.