### PR TITLE
TST: series/indexing tests parameterization + moving test methods

### DIFF
--- a/pandas/tests/series/indexing/test_alter_index.py
+++ b/pandas/tests/series/indexing/test_alter_index.py
@@ -21,88 +21,72 @@ import pandas.util.testing as tm
 JOIN_TYPES = ['inner', 'outer', 'left', 'right']
 
 
-def test_align(test_data):
-    def _check_align(a, b, how='left', fill=None):
-        aa, ab = a.align(b, join=how, fill_value=fill)
+@pytest.mark.parametrize(
+    'first_slice,second_slice', [
+        [[2, None], [None, -5]],
+        [[None, 0], [None, -5]],
+        [[None, -5], [None, 0]],
+        [[None, 0], [None, 0]]
+    ])
+@pytest.mark.parametrize('join_type', JOIN_TYPES)
+@pytest.mark.parametrize('fill', [None, -1])
+def test_align(test_data, first_slice, second_slice, join_type, fill):
+    a = test_data.ts[slice(*first_slice)]
+    b = test_data.ts[slice(*second_slice)]
 
-        join_index = a.index.join(b.index, how=how)
-        if fill is not None:
-            diff_a = aa.index.difference(join_index)
-            diff_b = ab.index.difference(join_index)
-            if len(diff_a) > 0:
-                assert (aa.reindex(diff_a) == fill).all()
-            if len(diff_b) > 0:
-                assert (ab.reindex(diff_b) == fill).all()
+    aa, ab = a.align(b, join=join_type, fill_value=fill)
 
-        ea = a.reindex(join_index)
-        eb = b.reindex(join_index)
+    join_index = a.index.join(b.index, how=join_type)
+    if fill is not None:
+        diff_a = aa.index.difference(join_index)
+        diff_b = ab.index.difference(join_index)
+        if len(diff_a) > 0:
+            assert (aa.reindex(diff_a) == fill).all()
+        if len(diff_b) > 0:
+            assert (ab.reindex(diff_b) == fill).all()
 
-        if fill is not None:
-            ea = ea.fillna(fill)
-            eb = eb.fillna(fill)
+    ea = a.reindex(join_index)
+    eb = b.reindex(join_index)
 
-        assert_series_equal(aa, ea)
-        assert_series_equal(ab, eb)
-        assert aa.name == 'ts'
-        assert ea.name == 'ts'
-        assert ab.name == 'ts'
-        assert eb.name == 'ts'
+    if fill is not None:
+        ea = ea.fillna(fill)
+        eb = eb.fillna(fill)
 
-    for kind in JOIN_TYPES:
-        _check_align(test_data.ts[2:], test_data.ts[:-5], how=kind)
-        _check_align(test_data.ts[2:], test_data.ts[:-5], how=kind, fill=-1)
-
-        # empty left
-        _check_align(test_data.ts[:0], test_data.ts[:-5], how=kind)
-        _check_align(test_data.ts[:0], test_data.ts[:-5], how=kind, fill=-1)
-
-        # empty right
-        _check_align(test_data.ts[:-5], test_data.ts[:0], how=kind)
-        _check_align(test_data.ts[:-5], test_data.ts[:0], how=kind, fill=-1)
-
-        # both empty
-        _check_align(test_data.ts[:0], test_data.ts[:0], how=kind)
-        _check_align(test_data.ts[:0], test_data.ts[:0], how=kind, fill=-1)
+    assert_series_equal(aa, ea)
+    assert_series_equal(ab, eb)
+    assert aa.name == 'ts'
+    assert ea.name == 'ts'
+    assert ab.name == 'ts'
+    assert eb.name == 'ts'
 
 
-def test_align_fill_method(test_data):
-    def _check_align(a, b, how='left', method='pad', limit=None):
-        aa, ab = a.align(b, join=how, method=method, limit=limit)
+@pytest.mark.parametrize(
+    'first_slice,second_slice', [
+        [[2, None], [None, -5]],
+        [[None, 0], [None, -5]],
+        [[None, -5], [None, 0]],
+        [[None, 0], [None, 0]]
+    ])
+@pytest.mark.parametrize('join_type', JOIN_TYPES)
+@pytest.mark.parametrize('method', ['pad', 'bfill'])
+@pytest.mark.parametrize('limit', [None, 1])
+def test_align_fill_method(test_data,
+                           first_slice, second_slice,
+                           join_type, method, limit):
+    a = test_data.ts[slice(*first_slice)]
+    b = test_data.ts[slice(*second_slice)]
 
-        join_index = a.index.join(b.index, how=how)
-        ea = a.reindex(join_index)
-        eb = b.reindex(join_index)
+    aa, ab = a.align(b, join=join_type, method=method, limit=limit)
 
-        ea = ea.fillna(method=method, limit=limit)
-        eb = eb.fillna(method=method, limit=limit)
+    join_index = a.index.join(b.index, how=join_type)
+    ea = a.reindex(join_index)
+    eb = b.reindex(join_index)
 
-        assert_series_equal(aa, ea)
-        assert_series_equal(ab, eb)
+    ea = ea.fillna(method=method, limit=limit)
+    eb = eb.fillna(method=method, limit=limit)
 
-    for kind in JOIN_TYPES:
-        for meth in ['pad', 'bfill']:
-            _check_align(test_data.ts[2:], test_data.ts[:-5],
-                         how=kind, method=meth)
-            _check_align(test_data.ts[2:], test_data.ts[:-5],
-                         how=kind, method=meth, limit=1)
-
-            # empty left
-            _check_align(test_data.ts[:0], test_data.ts[:-5],
-                         how=kind, method=meth)
-            _check_align(test_data.ts[:0], test_data.ts[:-5],
-                         how=kind, method=meth, limit=1)
-
-            # empty right
-            _check_align(test_data.ts[:-5], test_data.ts[:0],
-                         how=kind, method=meth)
-            _check_align(test_data.ts[:-5], test_data.ts[:0],
-                         how=kind, method=meth, limit=1)
-
-            # both empty
-            _check_align(test_data.ts[:0], test_data.ts[:0],
-                         how=kind, method=meth)
-            _check_align(test_data.ts[:0], test_data.ts[:0],
-                         how=kind, method=meth, limit=1)
+    assert_series_equal(aa, ea)
+    assert_series_equal(ab, eb)
 
 
 def test_align_nocopy(test_data):
@@ -481,3 +465,56 @@ def test_rename():
     assert_series_equal(result, expected)
 
     assert result.name == expected.name
+
+
+def test_drop():
+    # unique
+    s = Series([1, 2], index=['one', 'two'])
+    expected = Series([1], index=['one'])
+    result = s.drop(['two'])
+    assert_series_equal(result, expected)
+    result = s.drop('two', axis='rows')
+    assert_series_equal(result, expected)
+
+    # non-unique
+    # GH 5248
+    s = Series([1, 1, 2], index=['one', 'two', 'one'])
+    expected = Series([1, 2], index=['one', 'one'])
+    result = s.drop(['two'], axis=0)
+    assert_series_equal(result, expected)
+    result = s.drop('two')
+    assert_series_equal(result, expected)
+
+    expected = Series([1], index=['two'])
+    result = s.drop(['one'])
+    assert_series_equal(result, expected)
+    result = s.drop('one')
+    assert_series_equal(result, expected)
+
+    # single string/tuple-like
+    s = Series(range(3), index=list('abc'))
+    pytest.raises(KeyError, s.drop, 'bc')
+    pytest.raises(KeyError, s.drop, ('a',))
+
+    # errors='ignore'
+    s = Series(range(3), index=list('abc'))
+    result = s.drop('bc', errors='ignore')
+    assert_series_equal(result, s)
+    result = s.drop(['a', 'd'], errors='ignore')
+    expected = s.iloc[1:]
+    assert_series_equal(result, expected)
+
+    # bad axis
+    pytest.raises(ValueError, s.drop, 'one', axis='columns')
+
+    # GH 8522
+    s = Series([2, 3], index=[True, False])
+    assert s.index.is_object()
+    result = s.drop(True)
+    expected = Series([3], index=[False])
+    assert_series_equal(result, expected)
+
+    # GH 16877
+    s = Series([2, 3], index=[0, 1])
+    with tm.assert_raises_regex(KeyError, 'not contained in axis'):
+        s.drop([False, True])

--- a/pandas/tests/series/indexing/test_boolean.py
+++ b/pandas/tests/series/indexing/test_boolean.py
@@ -283,34 +283,30 @@ def test_where_error():
                   [])
 
 
-def test_where_array_like():
+@pytest.mark.parametrize('klass', [list, tuple, np.array, Series])
+def test_where_array_like(klass):
     # see gh-15414
     s = Series([1, 2, 3])
     cond = [False, True, True]
     expected = Series([np.nan, 2, 3])
-    klasses = [list, tuple, np.array, Series]
 
-    for klass in klasses:
-        result = s.where(klass(cond))
-        assert_series_equal(result, expected)
+    result = s.where(klass(cond))
+    assert_series_equal(result, expected)
 
 
-def test_where_invalid_input():
+@pytest.mark.parametrize('cond', [
+    [1, 0, 1],
+    Series([2, 5, 7]),
+    ["True", "False", "True"],
+    [Timestamp("2017-01-01"), pd.NaT, Timestamp("2017-01-02")]
+])
+def test_where_invalid_input(cond):
     # see gh-15414: only boolean arrays accepted
     s = Series([1, 2, 3])
     msg = "Boolean array expected for the condition"
 
-    conds = [
-        [1, 0, 1],
-        Series([2, 5, 7]),
-        ["True", "False", "True"],
-        [Timestamp("2017-01-01"),
-         pd.NaT, Timestamp("2017-01-02")]
-    ]
-
-    for cond in conds:
-        with tm.assert_raises_regex(ValueError, msg):
-            s.where(cond)
+    with tm.assert_raises_regex(ValueError, msg):
+        s.where(cond)
 
     msg = "Array conditional must be same shape as self"
     with tm.assert_raises_regex(ValueError, msg):
@@ -403,37 +399,43 @@ def test_where_setitem_invalid():
     assert_series_equal(s, expected)
 
 
-def test_where_broadcast():
-    # Test a variety of differently sized series
-    for size in range(2, 6):
-        # Test a variety of boolean indices
-        for selection in [
-            # First element should be set
-            np.resize([True, False, False, False, False], size),
-            # Set alternating elements]
-            np.resize([True, False], size),
-            # No element should be set
-            np.resize([False], size)
-        ]:
+@pytest.mark.parametrize('size', range(2, 6))
+@pytest.mark.parametrize('mask', [
+    [True, False, False, False, False],
+    [True, False],
+    [False]
+])
+@pytest.mark.parametrize('item', [
+    2.0, np.nan, np.finfo(np.float).max, np.finfo(np.float).min
+])
+# Test numpy arrays, lists and tuples as the input to be
+# broadcast
+@pytest.mark.parametrize('box', [
+    lambda x: np.array([x]),
+    lambda x: [x],
+    lambda x: (x,)
+])
+def test_broadcast(size, mask, item, box):
+    selection = np.resize(mask, size)
 
-            # Test a variety of different numbers as content
-            for item in [2.0, np.nan, np.finfo(np.float).max,
-                         np.finfo(np.float).min]:
-                # Test numpy arrays, lists and tuples as the input to be
-                # broadcast
-                for arr in [np.array([item]), [item], (item,)]:
-                    data = np.arange(size, dtype=float)
-                    s = Series(data)
-                    s[selection] = arr
-                    # Construct the expected series by taking the source
-                    # data or item based on the selection
-                    expected = Series([item if use_item else data[
-                        i] for i, use_item in enumerate(selection)])
-                    assert_series_equal(s, expected)
+    data = np.arange(size, dtype=float)
 
-                    s = Series(data)
-                    result = s.where(~selection, arr)
-                    assert_series_equal(result, expected)
+    # Construct the expected series by taking the source
+    # data or item based on the selection
+    expected = Series([item if use_item else data[
+        i] for i, use_item in enumerate(selection)])
+
+    s = Series(data)
+    s[selection] = box(item)
+    assert_series_equal(s, expected)
+
+    s = Series(data)
+    result = s.where(~selection, box(item))
+    assert_series_equal(result, expected)
+
+    s = Series(data)
+    result = s.mask(selection, box(item))
+    assert_series_equal(result, expected)
 
 
 def test_where_inplace():
@@ -585,29 +587,6 @@ def test_mask():
     result = s.mask(s > 2, np.nan)
     expected = Series([1, 2, np.nan, np.nan])
     assert_series_equal(result, expected)
-
-
-def test_mask_broadcast():
-    # GH 8801
-    # copied from test_where_broadcast
-    for size in range(2, 6):
-        for selection in [
-            # First element should be set
-            np.resize([True, False, False, False, False], size),
-            # Set alternating elements]
-            np.resize([True, False], size),
-            # No element should be set
-            np.resize([False], size)
-        ]:
-            for item in [2.0, np.nan, np.finfo(np.float).max,
-                         np.finfo(np.float).min]:
-                for arr in [np.array([item]), [item], (item,)]:
-                    data = np.arange(size, dtype=float)
-                    s = Series(data)
-                    result = s.mask(selection, arr)
-                    expected = Series([item if use_item else data[
-                        i] for i, use_item in enumerate(selection)])
-                    assert_series_equal(result, expected)
 
 
 def test_mask_inplace():

--- a/pandas/tests/series/indexing/test_callable.py
+++ b/pandas/tests/series/indexing/test_callable.py
@@ -1,0 +1,33 @@
+import pandas as pd
+import pandas.util.testing as tm
+
+
+def test_getitem_callable():
+    # GH 12533
+    s = pd.Series(4, index=list('ABCD'))
+    result = s[lambda x: 'A']
+    assert result == s.loc['A']
+
+    result = s[lambda x: ['A', 'B']]
+    tm.assert_series_equal(result, s.loc[['A', 'B']])
+
+    result = s[lambda x: [True, False, True, True]]
+    tm.assert_series_equal(result, s.iloc[[0, 2, 3]])
+
+
+def test_setitem_callable():
+    # GH 12533
+    s = pd.Series([1, 2, 3, 4], index=list('ABCD'))
+    s[lambda x: 'A'] = -1
+    tm.assert_series_equal(s, pd.Series([-1, 2, 3, 4], index=list('ABCD')))
+
+
+def test_setitem_other_callable():
+    # GH 13299
+    inc = lambda x: x + 1
+
+    s = pd.Series([1, 2, -1, 4])
+    s[s < 0] = inc
+
+    expected = pd.Series([1, 2, inc, 4])
+    tm.assert_series_equal(s, expected)

--- a/pandas/tests/series/indexing/test_datetime.py
+++ b/pandas/tests/series/indexing/test_datetime.py
@@ -700,11 +700,11 @@ def test_nat_operations():
     assert s.max() == exp
 
 
-def test_round_nat():
+@pytest.mark.parametrize('method', ["round", "floor", "ceil"])
+@pytest.mark.parametrize('freq', ["s", "5s", "min", "5min", "h", "5h"])
+def test_round_nat(method, freq):
     # GH14940
     s = Series([pd.NaT])
     expected = Series(pd.NaT)
-    for method in ["round", "floor", "ceil"]:
-        round_method = getattr(s.dt, method)
-        for freq in ["s", "5s", "min", "5min", "h", "5h"]:
-            assert_series_equal(round_method(freq), expected)
+    round_method = getattr(s.dt, method)
+    assert_series_equal(round_method(freq), expected)

--- a/pandas/tests/series/indexing/test_iloc.py
+++ b/pandas/tests/series/indexing/test_iloc.py
@@ -9,8 +9,6 @@ from pandas.compat import lrange, range
 from pandas.util.testing import (assert_series_equal,
                                  assert_almost_equal)
 
-JOIN_TYPES = ['inner', 'outer', 'left', 'right']
-
 
 def test_iloc():
     s = Series(np.random.randn(10), index=lrange(0, 20, 2))

--- a/pandas/tests/series/indexing/test_indexing.py
+++ b/pandas/tests/series/indexing/test_indexing.py
@@ -21,7 +21,58 @@ from pandas.util.testing import (assert_series_equal)
 import pandas.util.testing as tm
 
 
-JOIN_TYPES = ['inner', 'outer', 'left', 'right']
+def test_basic_indexing():
+    s = Series(np.random.randn(5), index=['a', 'b', 'a', 'a', 'b'])
+
+    pytest.raises(IndexError, s.__getitem__, 5)
+    pytest.raises(IndexError, s.__setitem__, 5, 0)
+
+    pytest.raises(KeyError, s.__getitem__, 'c')
+
+    s = s.sort_index()
+
+    pytest.raises(IndexError, s.__getitem__, 5)
+    pytest.raises(IndexError, s.__setitem__, 5, 0)
+
+
+def test_basic_getitem_with_labels(test_data):
+    indices = test_data.ts.index[[5, 10, 15]]
+
+    result = test_data.ts[indices]
+    expected = test_data.ts.reindex(indices)
+    assert_series_equal(result, expected)
+
+    result = test_data.ts[indices[0]:indices[2]]
+    expected = test_data.ts.loc[indices[0]:indices[2]]
+    assert_series_equal(result, expected)
+
+    # integer indexes, be careful
+    s = Series(np.random.randn(10), index=lrange(0, 20, 2))
+    inds = [0, 2, 5, 7, 8]
+    arr_inds = np.array([0, 2, 5, 7, 8])
+    with tm.assert_produces_warning(FutureWarning,
+                                    check_stacklevel=False):
+        result = s[inds]
+    expected = s.reindex(inds)
+    assert_series_equal(result, expected)
+
+    with tm.assert_produces_warning(FutureWarning,
+                                    check_stacklevel=False):
+        result = s[arr_inds]
+    expected = s.reindex(arr_inds)
+    assert_series_equal(result, expected)
+
+    # GH12089
+    # with tz for values
+    s = Series(pd.date_range("2011-01-01", periods=3, tz="US/Eastern"),
+               index=['a', 'b', 'c'])
+    expected = Timestamp('2011-01-01', tz='US/Eastern')
+    result = s.loc['a']
+    assert result == expected
+    result = s.iloc[0]
+    assert result == expected
+    result = s['a']
+    assert result == expected
 
 
 def test_getitem_setitem_ellipsis():
@@ -34,18 +85,6 @@ def test_getitem_setitem_ellipsis():
 
     s[...] = 5
     assert (result == 5).all()
-
-
-def test_pop():
-    # GH 6600
-    df = DataFrame({'A': 0, 'B': np.arange(5, dtype='int64'), 'C': 0, })
-    k = df.iloc[4]
-
-    result = k.pop('B')
-    assert result == 4
-
-    expected = Series([0, 0], index=['A', 'C'], name=4)
-    assert_series_equal(k, expected)
 
 
 def test_getitem_get(test_data):
@@ -73,11 +112,6 @@ def test_getitem_get(test_data):
     for s in [Series(), Series(index=list('abc'))]:
         result = s.get(None)
         assert result is None
-
-
-def test_getitem_int64(test_data):
-    idx = np.int64(5)
-    assert test_data.ts[idx] == test_data.ts[5]
 
 
 def test_getitem_fancy(test_data):
@@ -199,26 +233,6 @@ def test_getitem_dups():
     assert_series_equal(result, expected)
 
 
-def test_getitem_dataframe():
-    rng = list(range(10))
-    s = pd.Series(10, index=rng)
-    df = pd.DataFrame(rng, index=rng)
-    pytest.raises(TypeError, s.__getitem__, df > 5)
-
-
-def test_getitem_callable():
-    # GH 12533
-    s = pd.Series(4, index=list('ABCD'))
-    result = s[lambda x: 'A']
-    assert result == s.loc['A']
-
-    result = s[lambda x: ['A', 'B']]
-    tm.assert_series_equal(result, s.loc[['A', 'B']])
-
-    result = s[lambda x: [True, False, True, True]]
-    tm.assert_series_equal(result, s.iloc[[0, 2, 3]])
-
-
 def test_setitem_ambiguous_keyerror():
     s = Series(lrange(10), index=lrange(0, 20, 2))
 
@@ -234,48 +248,11 @@ def test_setitem_ambiguous_keyerror():
     assert_series_equal(s2, expected)
 
 
-def test_setitem_callable():
-    # GH 12533
-    s = pd.Series([1, 2, 3, 4], index=list('ABCD'))
-    s[lambda x: 'A'] = -1
-    tm.assert_series_equal(s, pd.Series([-1, 2, 3, 4], index=list('ABCD')))
-
-
-def test_setitem_other_callable():
-    # GH 13299
-    inc = lambda x: x + 1
-
-    s = pd.Series([1, 2, -1, 4])
-    s[s < 0] = inc
-
-    expected = pd.Series([1, 2, inc, 4])
-    tm.assert_series_equal(s, expected)
-
-
-def test_slice(test_data):
-    numSlice = test_data.series[10:20]
-    numSliceEnd = test_data.series[-10:]
-    objSlice = test_data.objSeries[10:20]
-
-    assert test_data.series.index[9] not in numSlice.index
-    assert test_data.objSeries.index[9] not in objSlice.index
-
-    assert len(numSlice) == len(numSlice.index)
-    assert test_data.series[numSlice.index[0]] == numSlice[numSlice.index[0]]
-
-    assert numSlice.index[1] == test_data.series.index[11]
-    assert tm.equalContents(numSliceEnd, np.array(test_data.series)[-10:])
-
-    # Test return view.
-    sl = test_data.series[10:20]
-    sl[:] = 0
-
-    assert (test_data.series[10:20] == 0).all()
-
-
-def test_slice_can_reorder_not_uniquely_indexed():
-    s = Series(1, index=['a', 'a', 'b', 'b', 'c'])
-    s[::-1]  # it works!
+def test_getitem_dataframe():
+    rng = list(range(10))
+    s = pd.Series(10, index=rng)
+    df = pd.DataFrame(rng, index=rng)
+    pytest.raises(TypeError, s.__getitem__, df > 5)
 
 
 def test_setitem(test_data):
@@ -389,86 +366,46 @@ def test_basic_getitem_setitem_corner(test_data):
                   [5, slice(None, None)], 2)
 
 
-def test_basic_getitem_with_labels(test_data):
-    indices = test_data.ts.index[[5, 10, 15]]
+@pytest.mark.parametrize('tz', ['US/Eastern', 'UTC', 'Asia/Tokyo'])
+def test_setitem_with_tz(tz):
+    orig = pd.Series(pd.date_range('2016-01-01', freq='H', periods=3,
+                                   tz=tz))
+    assert orig.dtype == 'datetime64[ns, {0}]'.format(tz)
 
-    result = test_data.ts[indices]
-    expected = test_data.ts.reindex(indices)
-    assert_series_equal(result, expected)
+    # scalar
+    s = orig.copy()
+    s[1] = pd.Timestamp('2011-01-01', tz=tz)
+    exp = pd.Series([pd.Timestamp('2016-01-01 00:00', tz=tz),
+                     pd.Timestamp('2011-01-01 00:00', tz=tz),
+                     pd.Timestamp('2016-01-01 02:00', tz=tz)])
+    tm.assert_series_equal(s, exp)
 
-    result = test_data.ts[indices[0]:indices[2]]
-    expected = test_data.ts.loc[indices[0]:indices[2]]
-    assert_series_equal(result, expected)
+    s = orig.copy()
+    s.loc[1] = pd.Timestamp('2011-01-01', tz=tz)
+    tm.assert_series_equal(s, exp)
 
-    # integer indexes, be careful
-    s = Series(np.random.randn(10), index=lrange(0, 20, 2))
-    inds = [0, 2, 5, 7, 8]
-    arr_inds = np.array([0, 2, 5, 7, 8])
-    with tm.assert_produces_warning(FutureWarning,
-                                    check_stacklevel=False):
-        result = s[inds]
-    expected = s.reindex(inds)
-    assert_series_equal(result, expected)
+    s = orig.copy()
+    s.iloc[1] = pd.Timestamp('2011-01-01', tz=tz)
+    tm.assert_series_equal(s, exp)
 
-    with tm.assert_produces_warning(FutureWarning,
-                                    check_stacklevel=False):
-        result = s[arr_inds]
-    expected = s.reindex(arr_inds)
-    assert_series_equal(result, expected)
+    # vector
+    vals = pd.Series([pd.Timestamp('2011-01-01', tz=tz),
+                      pd.Timestamp('2012-01-01', tz=tz)], index=[1, 2])
+    assert vals.dtype == 'datetime64[ns, {0}]'.format(tz)
 
-    # GH12089
-    # with tz for values
-    s = Series(pd.date_range("2011-01-01", periods=3, tz="US/Eastern"),
-               index=['a', 'b', 'c'])
-    expected = Timestamp('2011-01-01', tz='US/Eastern')
-    result = s.loc['a']
-    assert result == expected
-    result = s.iloc[0]
-    assert result == expected
-    result = s['a']
-    assert result == expected
+    s[[1, 2]] = vals
+    exp = pd.Series([pd.Timestamp('2016-01-01 00:00', tz=tz),
+                     pd.Timestamp('2011-01-01 00:00', tz=tz),
+                     pd.Timestamp('2012-01-01 00:00', tz=tz)])
+    tm.assert_series_equal(s, exp)
 
+    s = orig.copy()
+    s.loc[[1, 2]] = vals
+    tm.assert_series_equal(s, exp)
 
-def test_setitem_with_tz():
-    for tz in ['US/Eastern', 'UTC', 'Asia/Tokyo']:
-        orig = pd.Series(pd.date_range('2016-01-01', freq='H', periods=3,
-                                       tz=tz))
-        assert orig.dtype == 'datetime64[ns, {0}]'.format(tz)
-
-        # scalar
-        s = orig.copy()
-        s[1] = pd.Timestamp('2011-01-01', tz=tz)
-        exp = pd.Series([pd.Timestamp('2016-01-01 00:00', tz=tz),
-                         pd.Timestamp('2011-01-01 00:00', tz=tz),
-                         pd.Timestamp('2016-01-01 02:00', tz=tz)])
-        tm.assert_series_equal(s, exp)
-
-        s = orig.copy()
-        s.loc[1] = pd.Timestamp('2011-01-01', tz=tz)
-        tm.assert_series_equal(s, exp)
-
-        s = orig.copy()
-        s.iloc[1] = pd.Timestamp('2011-01-01', tz=tz)
-        tm.assert_series_equal(s, exp)
-
-        # vector
-        vals = pd.Series([pd.Timestamp('2011-01-01', tz=tz),
-                          pd.Timestamp('2012-01-01', tz=tz)], index=[1, 2])
-        assert vals.dtype == 'datetime64[ns, {0}]'.format(tz)
-
-        s[[1, 2]] = vals
-        exp = pd.Series([pd.Timestamp('2016-01-01 00:00', tz=tz),
-                         pd.Timestamp('2011-01-01 00:00', tz=tz),
-                         pd.Timestamp('2012-01-01 00:00', tz=tz)])
-        tm.assert_series_equal(s, exp)
-
-        s = orig.copy()
-        s.loc[[1, 2]] = vals
-        tm.assert_series_equal(s, exp)
-
-        s = orig.copy()
-        s.iloc[[1, 2]] = vals
-        tm.assert_series_equal(s, exp)
+    s = orig.copy()
+    s.iloc[[1, 2]] = vals
+    tm.assert_series_equal(s, exp)
 
 
 def test_setitem_with_tz_dst():
@@ -550,22 +487,30 @@ def test_categorial_assigning_ops():
     tm.assert_series_equal(s, exp)
 
 
-def test_take():
-    s = Series([-1, 5, 6, 2, 4])
+def test_slice(test_data):
+    numSlice = test_data.series[10:20]
+    numSliceEnd = test_data.series[-10:]
+    objSlice = test_data.objSeries[10:20]
 
-    actual = s.take([1, 3, 4])
-    expected = Series([5, 2, 4], index=[1, 3, 4])
-    tm.assert_series_equal(actual, expected)
+    assert test_data.series.index[9] not in numSlice.index
+    assert test_data.objSeries.index[9] not in objSlice.index
 
-    actual = s.take([-1, 3, 4])
-    expected = Series([4, 2, 4], index=[4, 3, 4])
-    tm.assert_series_equal(actual, expected)
+    assert len(numSlice) == len(numSlice.index)
+    assert test_data.series[numSlice.index[0]] == numSlice[numSlice.index[0]]
 
-    pytest.raises(IndexError, s.take, [1, 10])
-    pytest.raises(IndexError, s.take, [2, 5])
+    assert numSlice.index[1] == test_data.series.index[11]
+    assert tm.equalContents(numSliceEnd, np.array(test_data.series)[-10:])
 
-    with tm.assert_produces_warning(FutureWarning):
-        s.take([-1, 3, 4], convert=False)
+    # Test return view.
+    sl = test_data.series[10:20]
+    sl[:] = 0
+
+    assert (test_data.series[10:20] == 0).all()
+
+
+def test_slice_can_reorder_not_uniquely_indexed():
+    s = Series(1, index=['a', 'a', 'b', 'b', 'c'])
+    s[::-1]  # it works!
 
 
 def test_ix_setitem(test_data):
@@ -613,20 +558,6 @@ def test_setitem_na():
     s = Series(np.arange(10))
     s[:5] = np.nan
     assert_series_equal(s, expected)
-
-
-def test_basic_indexing():
-    s = Series(np.random.randn(5), index=['a', 'b', 'a', 'a', 'b'])
-
-    pytest.raises(IndexError, s.__getitem__, 5)
-    pytest.raises(IndexError, s.__setitem__, 5, 0)
-
-    pytest.raises(KeyError, s.__getitem__, 'c')
-
-    s = s.sort_index()
-
-    pytest.raises(IndexError, s.__getitem__, 5)
-    pytest.raises(IndexError, s.__setitem__, 5, 0)
 
 
 def test_timedelta_assignment():
@@ -700,73 +631,6 @@ def test_preserve_refs(test_data):
     assert not np.isnan(test_data.ts[10])
 
 
-def test_drop():
-    # unique
-    s = Series([1, 2], index=['one', 'two'])
-    expected = Series([1], index=['one'])
-    result = s.drop(['two'])
-    assert_series_equal(result, expected)
-    result = s.drop('two', axis='rows')
-    assert_series_equal(result, expected)
-
-    # non-unique
-    # GH 5248
-    s = Series([1, 1, 2], index=['one', 'two', 'one'])
-    expected = Series([1, 2], index=['one', 'one'])
-    result = s.drop(['two'], axis=0)
-    assert_series_equal(result, expected)
-    result = s.drop('two')
-    assert_series_equal(result, expected)
-
-    expected = Series([1], index=['two'])
-    result = s.drop(['one'])
-    assert_series_equal(result, expected)
-    result = s.drop('one')
-    assert_series_equal(result, expected)
-
-    # single string/tuple-like
-    s = Series(range(3), index=list('abc'))
-    pytest.raises(KeyError, s.drop, 'bc')
-    pytest.raises(KeyError, s.drop, ('a',))
-
-    # errors='ignore'
-    s = Series(range(3), index=list('abc'))
-    result = s.drop('bc', errors='ignore')
-    assert_series_equal(result, s)
-    result = s.drop(['a', 'd'], errors='ignore')
-    expected = s.iloc[1:]
-    assert_series_equal(result, expected)
-
-    # bad axis
-    pytest.raises(ValueError, s.drop, 'one', axis='columns')
-
-    # GH 8522
-    s = Series([2, 3], index=[True, False])
-    assert s.index.is_object()
-    result = s.drop(True)
-    expected = Series([3], index=[False])
-    assert_series_equal(result, expected)
-
-    # GH 16877
-    s = Series([2, 3], index=[0, 1])
-    with tm.assert_raises_regex(KeyError, 'not contained in axis'):
-        s.drop([False, True])
-
-
-def test_select(test_data):
-    # deprecated: gh-12410
-    with tm.assert_produces_warning(FutureWarning,
-                                    check_stacklevel=False):
-        n = len(test_data.ts)
-        result = test_data.ts.select(lambda x: x >= test_data.ts.index[n // 2])
-        expected = test_data.ts.reindex(test_data.ts.index[n // 2:])
-        assert_series_equal(result, expected)
-
-        result = test_data.ts.select(lambda x: x.weekday() == 2)
-        expected = test_data.ts[test_data.ts.index.weekday == 2]
-        assert_series_equal(result, expected)
-
-
 def test_cast_on_putmask():
     # GH 2746
 
@@ -797,13 +661,6 @@ def test_type_promote_putmask():
     s2 = s[mask]
     s[mask] = s2
     assert_series_equal(s, Series([0, 'foo', 'bar', 0]))
-
-
-def test_head_tail(test_data):
-    assert_series_equal(test_data.series.head(), test_data.series[:5])
-    assert_series_equal(test_data.series.head(0), test_data.series[0:0])
-    assert_series_equal(test_data.series.tail(), test_data.series[-5:])
-    assert_series_equal(test_data.series.tail(0), test_data.series[0:0])
 
 
 def test_multilevel_preserve_name():
@@ -845,3 +702,59 @@ def test_setitem_slice_into_readonly_backing_data():
         series[1:3] = 1
 
     assert not array.any()
+
+
+"""
+miscellaneous methods
+"""
+
+
+def test_select(test_data):
+    # deprecated: gh-12410
+    with tm.assert_produces_warning(FutureWarning,
+                                    check_stacklevel=False):
+        n = len(test_data.ts)
+        result = test_data.ts.select(lambda x: x >= test_data.ts.index[n // 2])
+        expected = test_data.ts.reindex(test_data.ts.index[n // 2:])
+        assert_series_equal(result, expected)
+
+        result = test_data.ts.select(lambda x: x.weekday() == 2)
+        expected = test_data.ts[test_data.ts.index.weekday == 2]
+        assert_series_equal(result, expected)
+
+
+def test_pop():
+    # GH 6600
+    df = DataFrame({'A': 0, 'B': np.arange(5, dtype='int64'), 'C': 0, })
+    k = df.iloc[4]
+
+    result = k.pop('B')
+    assert result == 4
+
+    expected = Series([0, 0], index=['A', 'C'], name=4)
+    assert_series_equal(k, expected)
+
+
+def test_take():
+    s = Series([-1, 5, 6, 2, 4])
+
+    actual = s.take([1, 3, 4])
+    expected = Series([5, 2, 4], index=[1, 3, 4])
+    tm.assert_series_equal(actual, expected)
+
+    actual = s.take([-1, 3, 4])
+    expected = Series([4, 2, 4], index=[4, 3, 4])
+    tm.assert_series_equal(actual, expected)
+
+    pytest.raises(IndexError, s.take, [1, 10])
+    pytest.raises(IndexError, s.take, [2, 5])
+
+    with tm.assert_produces_warning(FutureWarning):
+        s.take([-1, 3, 4], convert=False)
+
+
+def test_head_tail(test_data):
+    assert_series_equal(test_data.series.head(), test_data.series[:5])
+    assert_series_equal(test_data.series.head(0), test_data.series[0:0])
+    assert_series_equal(test_data.series.tail(), test_data.series[-5:])
+    assert_series_equal(test_data.series.tail(0), test_data.series[0:0])

--- a/pandas/tests/series/indexing/test_loc.py
+++ b/pandas/tests/series/indexing/test_loc.py
@@ -12,9 +12,6 @@ from pandas.compat import lrange
 from pandas.util.testing import (assert_series_equal)
 
 
-JOIN_TYPES = ['inner', 'outer', 'left', 'right']
-
-
 def test_loc_getitem(test_data):
     inds = test_data.series.index[[3, 4, 7]]
     assert_series_equal(

--- a/pandas/tests/series/indexing/test_numeric.py
+++ b/pandas/tests/series/indexing/test_numeric.py
@@ -229,3 +229,8 @@ def test_int_indexing():
     pytest.raises(KeyError, s.__getitem__, 5)
 
     pytest.raises(KeyError, s.__getitem__, 'c')
+
+
+def test_getitem_int64(test_data):
+    idx = np.int64(5)
+    assert test_data.ts[idx] == test_data.ts[5]


### PR DESCRIPTION
Parts 2 and 3 of #20014. 
- tests parameterization
- moving some tests from test_indexing.py to other files 
- test methods reordering in test_indexing.py

- [x] closes #20014
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
