### PR TITLE
Added flake8 to DEV requirements

### DIFF
--- a/ci/environment-dev.yaml
+++ b/ci/environment-dev.yaml
@@ -5,6 +5,7 @@ channels:
 dependencies:
   - Cython
   - NumPy
+  - flake8
   - moto
   - pytest>=3.1
   - python-dateutil>=2.5.0

--- a/ci/requirements_dev.txt
+++ b/ci/requirements_dev.txt
@@ -2,6 +2,7 @@
 # Do not modify directly
 Cython
 NumPy
+flake8
 moto
 pytest>=3.1
 python-dateutil>=2.5.0


### PR DESCRIPTION
In advanced of the doc sprint this Saturday it looks like some users were confused by `git diff upstream/master -u -- "*.py" | flake8 --diff` failing even though they though they installed all development dependencies. Updating the .yml file to include this
