### PR TITLE
Docstring for pd.core.window.Expanding.kurt

### DIFF
--- a/pandas/core/window.py
+++ b/pandas/core/window.py
@@ -926,28 +926,7 @@ class _Rolling_and_Expanding(_Rolling):
 
     Notes
     -----
-    A minimum of 4 periods is required for the rolling calculation.
-
-    Examples
-    --------
-    The below example will show a rolling calculation with a window size of
-    four matching the equivalent function call using `scipy.stats`.
-
-    >>> arr = [1, 2, 3, 4, 999]
-    >>> fmt = "{0:.6f}"  # limit the printed precision to 6 digits
-    >>> import scipy.stats
-    >>> print(fmt.format(scipy.stats.kurtosis(arr[:-1], bias=False)))
-    -1.200000
-    >>> print(fmt.format(scipy.stats.kurtosis(arr[1:], bias=False)))
-    3.999946
-    >>> s = pd.Series(arr)
-    >>> s.rolling(4).kurt()
-    0         NaN
-    1         NaN
-    2         NaN
-    3   -1.200000
-    4    3.999946
-    dtype: float64
+    A minimum of 4 periods is required for the %(name)s calculation.
     """)
 
     def kurt(self, **kwargs):
@@ -1269,6 +1248,31 @@ class Rolling(_Rolling_and_Expanding):
     def skew(self, **kwargs):
         return super(Rolling, self).skew(**kwargs)
 
+    _agg_doc = dedent("""
+    Examples
+    --------
+
+    The example below will show a rolling calculation with a window size of
+    four matching the equivalent function call using `scipy.stats`.
+
+    >>> arr = [1, 2, 3, 4, 999]
+    >>> fmt = "{0:.6f}"  # limit the printed precision to 6 digits
+    >>> import scipy.stats
+    >>> print(fmt.format(scipy.stats.kurtosis(arr[:-1], bias=False)))
+    -1.200000
+    >>> print(fmt.format(scipy.stats.kurtosis(arr[1:], bias=False)))
+    3.999946
+    >>> s = pd.Series(arr)
+    >>> s.rolling(4).kurt()
+    0         NaN
+    1         NaN
+    2         NaN
+    3   -1.200000
+    4    3.999946
+    dtype: float64
+    """)
+
+    @Appender(_agg_doc)
     @Substitution(name='rolling')
     @Appender(_shared_docs['kurt'])
     def kurt(self, **kwargs):
@@ -1508,6 +1512,31 @@ class Expanding(_Rolling_and_Expanding):
     def skew(self, **kwargs):
         return super(Expanding, self).skew(**kwargs)
 
+    _agg_doc = dedent("""
+    Examples
+    --------
+
+    The example below will show an expanding calculation with a window size of
+    four matching the equivalent function call using `scipy.stats`.
+
+    >>> arr = [1, 2, 3, 4, 999]
+    >>> import scipy.stats
+    >>> fmt = "{0:.6f}"  # limit the printed precision to 6 digits
+    >>> print(fmt.format(scipy.stats.kurtosis(arr[:-1], bias=False)))
+    -1.200000
+    >>> print(fmt.format(scipy.stats.kurtosis(arr, bias=False)))
+    4.999874
+    >>> s = pd.Series(arr)
+    >>> s.expanding(4).kurt()
+    0         NaN
+    1         NaN
+    2         NaN
+    3   -1.200000
+    4    4.999874
+    dtype: float64
+    """)
+
+    @Appender(_agg_doc)
     @Substitution(name='expanding')
     @Appender(_shared_docs['kurt'])
     def kurt(self, **kwargs):


### PR DESCRIPTION
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`

Notice that I made two small changes to the ``Rolling.kurt``(by @WillAyd ) docstring too.

Namely:
- since window methods have ``kurt`` but not ``kurtosis`` (while e.g. ``Series`` has both), I guess it is best to tell users that ``kurt`` is the default in pandas - that is, use it in "See also"
- it is true that a ``DataFrame`` can be constructed directly from a list, but this is not the standard use, so I replaced with ``Series``