### PR TITLE
DOC: Improved the docstring of pandas.DataFrame.values

### DIFF
--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -4241,7 +4241,7 @@ class NDFrame(PandasObject, SelectionMixin):
         Returns
         -------
         numpy.ndarray
-            The values of the DataFrame
+            The values of the DataFrame.
 
         Examples
         --------
@@ -4296,9 +4296,7 @@ class NDFrame(PandasObject, SelectionMixin):
 
         See Also
         --------
-        pandas.DataFrame.from_records : Inverse operation; creating a 
-            DataFrame from an ndarray
-        pandas.DataFrame.keys : Retrieving the 'info axis' (column names)
+        pandas.DataFrame.index : Retrievie the index labels
         pandas.DataFrame.columns : Retrieving the column names
         """
         self._consolidate_inplace()

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -4271,7 +4271,7 @@ class NDFrame(PandasObject, SelectionMixin):
 
         e.g. If the dtypes are float16 and float32, dtype will be upcast to
         float32.  If dtypes are int32 and uint8, dtype will be upcast to
-        int32. By numpy.find_common_type convention, mixing int64 and uint64
+        int32. By :func:`numpy.find_common_type` convention, mixing int64 and uint64
         will result in a flot64 dtype.
         """
         self._consolidate_inplace()

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -4291,7 +4291,7 @@ class NDFrame(PandasObject, SelectionMixin):
 
         See Also
         --------
-        pandas.DataFrame.from_records : Creating a DataFrame from a numpy.ndarray
+        pandas.DataFrame.from_records : Creating a DataFrame from an ndarray
         pandas.DataFrame.keys : Retrieving the 'info axis' (column names)
         pandas.DataFrame.columns : Retrieving the column names
         """

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -4233,9 +4233,9 @@ class NDFrame(PandasObject, SelectionMixin):
     @property
     def values(self):
         """
-        Generate and return a Numpy representation of NDFrame.
+        Return a Numpy representation of the DataFrame.
 
-        Only the values in the NDFrame will be returned, the axes labels will
+        Only the values in the DataFrame will be returned, the axes labels will
         be removed.
 
         Returns

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -4235,8 +4235,8 @@ class NDFrame(PandasObject, SelectionMixin):
         """
         Return a Numpy representation of the DataFrame.
 
-        Only the values in the DataFrame will be returned, the axes labels will
-        be removed.
+        Only the values in the DataFrame will be returned, the axes labels
+        will be removed.
 
         Returns
         -------
@@ -4271,8 +4271,8 @@ class NDFrame(PandasObject, SelectionMixin):
 
         e.g. If the dtypes are float16 and float32, dtype will be upcast to
         float32.  If dtypes are int32 and uint8, dtype will be upcast to
-        int32. By :func:`numpy.find_common_type` convention, mixing int64 and uint64
-        will result in a flot64 dtype.
+        int32. By :func:`numpy.find_common_type` convention, mixing int64
+        and uint64 will result in a flot64 dtype.
         """
         self._consolidate_inplace()
         return self._data.as_array(transpose=self._AXIS_REVERSED)

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -4245,22 +4245,37 @@ class NDFrame(PandasObject, SelectionMixin):
 
         Examples
         --------
-        >>> df = pd.DataFrame([('falcon', 'bird',    389.0),
-        ...                    ('parrot', 'bird',     24.0),
-        ...                    ('lion',   'mammal',   80.5),
-        ...                    ('monkey', 'mammal', np.nan)],
-        ...                   columns=('name', 'class', 'max_speed'))
+        A DataFrame where all columns are the same type (e.g., int64) results
+        in an ndarray of the same type.
+
+        >>> df = pd.DataFrame({'age':    [ 3,  29],
+        ...                    'height': [94, 170],
+        ...                    'weight': [31, 115]})
         >>> df
-             name   class  max_speed
-        0  falcon    bird      389.0
-        1  parrot    bird       24.0
-        2    lion  mammal       80.5
-        3  monkey  mammal        NaN
+           age  height  weight
+        0    3      94      31
+        1   29     170     115
         >>> df.values
-        array([['falcon', 'bird', 389.0],
-               ['parrot', 'bird', 24.0],
-               ['lion', 'mammal', 80.5],
-               ['monkey', 'mammal', nan]], dtype=object)
+        array([[  3,  94,  31],
+               [ 29, 170, 115]], dtype=int64)
+
+        A DataFrame with mixed type columns(e.g., str/object, int64, float32)
+        results in an ndarray of the broadest type encompasing these mixed
+        types (e.g., object).
+
+        >>> df2 = pd.DataFrame([('parrot',   24.0, 'second'),
+        ...                     ('lion',     80.5, 1),
+        ...                     ('monkey', np.nan, None)],
+        ...                   columns=('name', 'max_speed', 'rank'))
+        >>> df2.dtypes
+        name          object
+        max_speed    float64
+        rank          object
+        dtype: object
+        >>> df2.values
+        array([['parrot', 24.0, 'second'],
+               ['lion', 80.5, 1],
+               ['monkey', nan, None]], dtype=object)
 
         Notes
         -----
@@ -4272,7 +4287,13 @@ class NDFrame(PandasObject, SelectionMixin):
         e.g. If the dtypes are float16 and float32, dtype will be upcast to
         float32.  If dtypes are int32 and uint8, dtype will be upcast to
         int32. By :func:`numpy.find_common_type` convention, mixing int64
-        and uint64 will result in a flot64 dtype.
+        and uint64 will result in a float64 dtype.
+
+        See Also
+        --------
+        pandas.DataFrame.from_records : Creating a DataFrame from a numpy.ndarray
+        pandas.DataFrame.keys : Retrieving the 'info axis' (column names)
+        pandas.DataFrame.columns : Retrieving the column names
         """
         self._consolidate_inplace()
         return self._data.as_array(transpose=self._AXIS_REVERSED)

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -4246,7 +4246,7 @@ class NDFrame(PandasObject, SelectionMixin):
         Examples
         --------
         A DataFrame where all columns are the same type (e.g., int64) results
-        in an ndarray of the same type.
+        in an array of the same type.
 
         >>> df = pd.DataFrame({'age':    [ 3,  29],
         ...                    'height': [94, 170],
@@ -4255,13 +4255,18 @@ class NDFrame(PandasObject, SelectionMixin):
            age  height  weight
         0    3      94      31
         1   29     170     115
+        >>> df.dtypes
+        age       int64
+        height    int64
+        weight    int64
+        dtype: object
         >>> df.values
         array([[  3,  94,  31],
                [ 29, 170, 115]], dtype=int64)
 
         A DataFrame with mixed type columns(e.g., str/object, int64, float32)
-        results in an ndarray of the broadest type encompasing these mixed
-        types (e.g., object).
+        results in an ndarray of the broadest type that accommodates these
+        mixed types (e.g., object).
 
         >>> df2 = pd.DataFrame([('parrot',   24.0, 'second'),
         ...                     ('lion',     80.5, 1),
@@ -4291,7 +4296,8 @@ class NDFrame(PandasObject, SelectionMixin):
 
         See Also
         --------
-        pandas.DataFrame.from_records : Creating a DataFrame from an ndarray
+        pandas.DataFrame.from_records : Inverse operation; creating a 
+            DataFrame from an ndarray
         pandas.DataFrame.keys : Retrieving the 'info axis' (column names)
         pandas.DataFrame.columns : Retrieving the column names
         """

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -4232,7 +4232,35 @@ class NDFrame(PandasObject, SelectionMixin):
 
     @property
     def values(self):
-        """Numpy representation of NDFrame
+        """
+        Generate and return a Numpy representation of NDFrame.
+
+        Only the values in the NDFrame will be returned, the axes labels will
+        be removed.
+
+        Returns
+        -------
+        numpy.ndarray
+            The values of the NDFrame
+
+        Examples
+        --------
+        >>> df = pd.DataFrame([('falcon', 'bird',    389.0),
+        ...                    ('parrot', 'bird',     24.0),
+        ...                    ('lion',   'mammal',   80.5),
+        ...                    ('monkey', 'mammal', np.nan)],
+        ...                   columns=('name', 'class', 'max_speed'))
+        >>> df
+             name   class  max_speed
+        0  falcon    bird      389.0
+        1  parrot    bird       24.0
+        2    lion  mammal       80.5
+        3  monkey  mammal        NaN
+        >>> df.values
+        array([['falcon', 'bird', 389.0],
+               ['parrot', 'bird', 24.0],
+               ['lion', 'mammal', 80.5],
+               ['monkey', 'mammal', nan]], dtype=object)
 
         Notes
         -----

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -4241,7 +4241,7 @@ class NDFrame(PandasObject, SelectionMixin):
         Returns
         -------
         numpy.ndarray
-            The values of the NDFrame
+            The values of the DataFrame
 
         Examples
         --------


### PR DESCRIPTION
- [ ] closes #xxxx
- [ ] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

```
################################################################################
############ Docstring (pandas.pandas.core.generic.NDFrame.values)  ############
################################################################################

Generate and return a Numpy representation of NDFrame.

Only the values in the NDFrame will be returned, the axes labels will
be removed.

Returns
-------
numpy.ndarray
    The values of the NDFrame

Examples
--------
>>> df = pd.DataFrame([('falcon', 'bird',    389.0),
...                    ('parrot', 'bird',     24.0),
...                    ('lion',   'mammal',   80.5),
...                    ('monkey', 'mammal', np.nan)],
...                   columns=('name', 'class', 'max_speed'))
>>> df
     name   class  max_speed
0  falcon    bird      389.0
1  parrot    bird       24.0
2    lion  mammal       80.5
3  monkey  mammal        NaN
>>> df.values
array([['falcon', 'bird', 389.0],
       ['parrot', 'bird', 24.0],
       ['lion', 'mammal', 80.5],
       ['monkey', 'mammal', nan]], dtype=object)

Notes
-----
The dtype will be a lower-common-denominator dtype (implicit
upcasting); that is to say if the dtypes (even of numeric types)
are mixed, the one that accommodates all will be chosen. Use this
with care if you are not dealing with the blocks.

e.g. If the dtypes are float16 and float32, dtype will be upcast to
float32.  If dtypes are int32 and uint8, dtype will be upcast to
int32. By numpy.find_common_type convention, mixing int64 and uint64
will result in a flot64 dtype.

################################################################################
################################## Validation ##################################
################################################################################

Errors found:
        Private classes (['NDFrame']) should not be mentioned in public docstring.
        See Also section not found
```