### PR TITLE
 DOC: Fixed example & description for pandas.cut

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,3 +1,27 @@
+Checklist for the pandas documentation sprint (ignore this if you are doing
+an unrelated PR):
+
+- [ ] PR title is "DOC: update the <your-function-or-method> docstring"
+- [ ] The validation script passes: `scripts/validate_docstrings.py <your-function-or-method>`
+- [ ] The PEP8 style check passes: `git diff upstream/master -u -- "*.py" | flake8 --diff`
+- [ ] The html version looks good: `python doc/make.py --single <your-function-or-method>`
+- [ ] It has been proofread on language by another sprint participant
+
+Please include the output of the validation script below between the "```" ticks:
+
+```
+# paste output of "scripts/validate_docstrings.py <your-function-or-method>" here
+# between the "```" (remove this comment, but keep the "```")
+
+```
+
+If the validation script still gives errors, but you think there is a good reason
+to deviate in this case (and there are certainly such cases), please state this
+explicitly.
+
+
+Checklist for other PRs (remove this part if you are doing a PR for the pandas documentation sprint):
+
 - [ ] closes #xxxx
 - [ ] tests added / passed
 - [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`

--- a/asv_bench/benchmarks/groupby.py
+++ b/asv_bench/benchmarks/groupby.py
@@ -14,7 +14,10 @@ from .pandas_vb_common import setup  # noqa
 method_blacklist = {
     'object': {'median', 'prod', 'sem', 'cumsum', 'sum', 'cummin', 'mean',
                'max', 'skew', 'cumprod', 'cummax', 'rank', 'pct_change', 'min',
-               'var', 'mad', 'describe', 'std'}
+               'var', 'mad', 'describe', 'std'},
+    'datetime': {'median', 'prod', 'sem', 'cumsum', 'sum', 'mean', 'skew',
+                 'cumprod', 'cummax', 'pct_change', 'var', 'mad', 'describe',
+                 'std'}
 }
 
 
@@ -90,45 +93,6 @@ class Groups(object):
         self.ser.groupby(self.ser).groups
 
 
-class FirstLast(object):
-
-    goal_time = 0.2
-
-    param_names = ['dtype']
-    params = ['float32', 'float64', 'datetime', 'object']
-
-    def setup(self, dtype):
-        N = 10**5
-        # with datetimes (GH7555)
-        if dtype == 'datetime':
-            self.df = DataFrame({'values': date_range('1/1/2011',
-                                                      periods=N,
-                                                      freq='s'),
-                                 'key': range(N)})
-        elif dtype == 'object':
-            self.df = DataFrame({'values': ['foo'] * N,
-                                 'key': range(N)})
-        else:
-            labels = np.arange(N / 10).repeat(10)
-            data = Series(np.random.randn(len(labels)), dtype=dtype)
-            data[::3] = np.nan
-            data[1::3] = np.nan
-            labels = labels.take(np.random.permutation(len(labels)))
-            self.df = DataFrame({'values': data, 'key': labels})
-
-    def time_groupby_first(self, dtype):
-        self.df.groupby('key').first()
-
-    def time_groupby_last(self, dtype):
-        self.df.groupby('key').last()
-
-    def time_groupby_nth_all(self, dtype):
-        self.df.groupby('key').nth(0, dropna='all')
-
-    def time_groupby_nth_none(self, dtype):
-        self.df.groupby('key').nth(0)
-
-
 class GroupManyLabels(object):
 
     goal_time = 0.2
@@ -149,39 +113,40 @@ class Nth(object):
 
     goal_time = 0.2
 
-    def setup_cache(self):
-        df = DataFrame(np.random.randint(1, 100, (10000, 2)))
-        df.iloc[1, 1] = np.nan
-        return df
+    param_names = ['dtype']
+    params = ['float32', 'float64', 'datetime', 'object']
 
-    def time_frame_nth_any(self, df):
-        df.groupby(0).nth(0, dropna='any')
+    def setup(self, dtype):
+        N = 10**5
+        # with datetimes (GH7555)
+        if dtype == 'datetime':
+            values = date_range('1/1/2011', periods=N, freq='s')
+        elif dtype == 'object':
+            values = ['foo'] * N
+        else:
+            values = np.arange(N).astype(dtype)
 
-    def time_frame_nth(self, df):
-        df.groupby(0).nth(0)
+        key = np.arange(N)
+        self.df = DataFrame({'key': key, 'values': values})
+        self.df.iloc[1, 1] = np.nan  # insert missing data
 
+    def time_frame_nth_any(self, dtype):
+        self.df.groupby('key').nth(0, dropna='any')
 
-    def time_series_nth_any(self, df):
-        df[1].groupby(df[0]).nth(0, dropna='any')
+    def time_groupby_nth_all(self, dtype):
+        self.df.groupby('key').nth(0, dropna='all')
 
-    def time_series_nth(self, df):
-        df[1].groupby(df[0]).nth(0)
+    def time_frame_nth(self, dtype):
+        self.df.groupby('key').nth(0)
 
+    def time_series_nth_any(self, dtype):
+        self.df['values'].groupby(self.df['key']).nth(0, dropna='any')
 
-class NthObject(object):
+    def time_groupby_nth_all(self, dtype):
+        self.df['values'].groupby(self.df['key']).nth(0, dropna='all')
 
-    goal_time = 0.2
-
-    def setup_cache(self):
-        df = DataFrame(np.random.randint(1, 100, (10000,)), columns=['g'])
-        df['obj'] = ['a'] * 5000 + ['b'] * 5000
-        return df
-
-    def time_nth(self, df):
-        df.groupby('g').nth(5)
-
-    def time_nth_last(self, df):
-        df.groupby('g').last()
+    def time_series_nth(self, dtype):
+        self.df['values'].groupby(self.df['key']).nth(0)
 
 
 class DateAttributes(object):
@@ -243,7 +208,7 @@ class CountMultiDtype(object):
         df.groupby(['key1', 'key2']).count()
 
 
-class CountInt(object):
+class CountMultiInt(object):
 
     goal_time = 0.2
 
@@ -255,10 +220,10 @@ class CountInt(object):
                         'ints2': np.random.randint(0, 1000, size=n)})
         return df
 
-    def time_int_count(self, df):
+    def time_multi_int_count(self, df):
         df.groupby(['key1', 'key2']).count()
 
-    def time_int_nunique(self, df):
+    def time_multi_int_nunique(self, df):
         df.groupby(['key1', 'key2']).nunique()
 
 
@@ -266,7 +231,7 @@ class AggFunctions(object):
 
     goal_time = 0.2
 
-    def setup_cache(self):
+    def setup_cache():
         N = 10**5
         fac1 = np.array(['A', 'B', 'C'], dtype='O')
         fac2 = np.array(['one', 'two'], dtype='O')
@@ -361,9 +326,6 @@ class Size(object):
     def time_multi_size(self):
         self.df.groupby(['key1', 'key2']).size()
 
-    def time_dt_size(self):
-        self.df.groupby(['dates']).size()
-
     def time_dt_timegrouper_size(self):
         with warnings.catch_warnings(record=True):
             self.df.groupby(TimeGrouper(key='dates', freq='M')).size()
@@ -376,15 +338,16 @@ class GroupByMethods(object):
 
     goal_time = 0.2
 
-    param_names = ['dtype', 'method']
-    params = [['int', 'float', 'object'],
+    param_names = ['dtype', 'method', 'application']
+    params = [['int', 'float', 'object', 'datetime'],
               ['all', 'any', 'bfill', 'count', 'cumcount', 'cummax', 'cummin',
                'cumprod', 'cumsum', 'describe', 'ffill', 'first', 'head',
                'last', 'mad', 'max', 'min', 'median', 'mean', 'nunique',
                'pct_change', 'prod', 'rank', 'sem', 'shift', 'size', 'skew',
-               'std', 'sum', 'tail', 'unique', 'value_counts', 'var']]
+               'std', 'sum', 'tail', 'unique', 'value_counts', 'var'],
+              ['direct', 'transformation']]
 
-    def setup(self, dtype, method):
+    def setup(self, dtype, method, application):
         if method in method_blacklist.get(dtype, {}):
             raise NotImplementedError  # skip benchmark
         ngroups = 1000
@@ -398,12 +361,28 @@ class GroupByMethods(object):
                                   np.random.random(ngroups) * 10.0])
         elif dtype == 'object':
             key = ['foo'] * size
+        elif dtype == 'datetime':
+            key = date_range('1/1/2011', periods=size, freq='s')
 
         df = DataFrame({'values': values, 'key': key})
-        self.df_groupby_method = getattr(df.groupby('key')['values'], method)
 
-    def time_method(self, dtype, method):
-        self.df_groupby_method()
+        if application == 'transform':
+            if method == 'describe':
+                raise NotImplementedError
+
+            self.as_group_method = lambda: df.groupby(
+                'key')['values'].transform(method)
+            self.as_field_method = lambda: df.groupby(
+                'values')['key'].transform(method)
+        else:
+            self.as_group_method = getattr(df.groupby('key')['values'], method)
+            self.as_field_method = getattr(df.groupby('values')['key'], method)
+
+    def time_dtype_as_group(self, dtype, method, application):
+        self.as_group_method()
+
+    def time_dtype_as_field(self, dtype, method, application):
+        self.as_field_method()
 
 
 class Float32(object):

--- a/doc/source/comparison_with_sas.rst
+++ b/doc/source/comparison_with_sas.rst
@@ -25,7 +25,7 @@ As is customary, we import pandas and NumPy as follows:
    This is often used in interactive work (e.g. `Jupyter notebook
    <https://jupyter.org/>`_ or terminal) - the equivalent in SAS would be:
 
-   .. code-block:: none
+   .. code-block:: sas
 
       proc print data=df(obs=5);
       run;
@@ -65,7 +65,7 @@ in the ``DATA`` step.
 
 Every ``DataFrame`` and ``Series`` has an ``Index`` - which are labels on the
 *rows* of the data. SAS does not have an exactly analogous concept. A data set's
-row are essentially unlabeled, other than an implicit integer index that can be
+rows are essentially unlabeled, other than an implicit integer index that can be
 accessed during the ``DATA`` step (``_N_``).
 
 In pandas, if no index is specified, an integer index is also used by default
@@ -87,7 +87,7 @@ A SAS data set can be built from specified values by
 placing the data after a ``datalines`` statement and
 specifying the column names.
 
-.. code-block:: none
+.. code-block:: sas
 
    data df;
        input x y;
@@ -121,7 +121,7 @@ will be used in many of the following examples.
 
 SAS provides ``PROC IMPORT`` to read csv data into a data set.
 
-.. code-block:: none
+.. code-block:: sas
 
    proc import datafile='tips.csv' dbms=csv out=tips replace;
        getnames=yes;
@@ -156,7 +156,7 @@ Exporting Data
 
 The inverse of ``PROC IMPORT`` in SAS is ``PROC EXPORT``
 
-.. code-block:: none
+.. code-block:: sas
 
    proc export data=tips outfile='tips2.csv' dbms=csv;
    run;
@@ -178,7 +178,7 @@ Operations on Columns
 In the ``DATA`` step, arbitrary math expressions can
 be used on new or existing columns.
 
-.. code-block:: none
+.. code-block:: sas
 
    data tips;
        set tips;
@@ -207,7 +207,7 @@ Filtering
 Filtering in SAS is done with an ``if`` or ``where`` statement, on one
 or more columns.
 
-.. code-block:: none
+.. code-block:: sas
 
    data tips;
        set tips;
@@ -233,7 +233,7 @@ If/Then Logic
 
 In SAS, if/then logic can be used to create new columns.
 
-.. code-block:: none
+.. code-block:: sas
 
    data tips;
        set tips;
@@ -262,7 +262,7 @@ Date Functionality
 SAS provides a variety of functions to do operations on
 date/datetime columns.
 
-.. code-block:: none
+.. code-block:: sas
 
    data tips;
        set tips;
@@ -307,7 +307,7 @@ Selection of Columns
 SAS provides keywords in the ``DATA`` step to select,
 drop, and rename columns.
 
-.. code-block:: none
+.. code-block:: sas
 
    data tips;
        set tips;
@@ -343,7 +343,7 @@ Sorting by Values
 
 Sorting in SAS is accomplished via ``PROC SORT``
 
-.. code-block:: none
+.. code-block:: sas
 
    proc sort data=tips;
        by sex total_bill;
@@ -369,7 +369,7 @@ SAS determines the length of a character string with the
 and `LENGTHC <http://support.sas.com/documentation/cdl/en/lrdict/64316/HTML/default/viewer.htm#a002283942.htm>`__ 
 functions. ``LENGTHN`` excludes trailing blanks and ``LENGTHC`` includes trailing blanks.
 
-.. code-block:: none
+.. code-block:: sas
 
    data _null_;
    set tips;
@@ -395,7 +395,7 @@ SAS determines the position of a character in a string with the
 ``FINDW`` takes the string defined by the first argument and searches for the first position of the substring 
 you supply as the second argument.
 
-.. code-block:: none
+.. code-block:: sas
 
    data _null_;
    set tips;
@@ -419,7 +419,7 @@ Substring
 SAS extracts a substring from a string based on its position with the 
 `SUBSTR <http://www2.sas.com/proceedings/sugi25/25/cc/25p088.pdf>`__ function. 
 
-.. code-block:: none
+.. code-block:: sas
 
    data _null_;
    set tips;
@@ -442,7 +442,7 @@ The SAS `SCAN <http://support.sas.com/documentation/cdl/en/lrdict/64316/HTML/def
 function returns the nth word from a string. The first argument is the string you want to parse and the 
 second argument specifies which word you want to extract.
 
-.. code-block:: none
+.. code-block:: sas
 
    data firstlast;
    input String $60.;
@@ -474,7 +474,7 @@ The SAS `UPCASE <http://support.sas.com/documentation/cdl/en/lrdict/64316/HTML/d
 `PROPCASE <http://support.sas.com/documentation/cdl/en/lrdict/64316/HTML/default/a002598106.htm>`__ 
 functions change the case of the argument.
 
-.. code-block:: none
+.. code-block:: sas
 
    data firstlast;
    input String $60.;
@@ -516,7 +516,7 @@ types of joins are accomplished using the ``in=`` dummy
 variables to track whether a match was found in one or both
 input frames.
 
-.. code-block:: none
+.. code-block:: sas
 
    proc sort data=df1;
        by key;
@@ -572,7 +572,7 @@ operations, and is ignored by default for aggregations.
 One difference is that missing data cannot be compared to its sentinel value.
 For example, in SAS you could do this to filter missing values.
 
-.. code-block:: none
+.. code-block:: sas
 
    data outer_join_nulls;
        set outer_join;
@@ -615,7 +615,7 @@ SAS's PROC SUMMARY can be used to group by one or
 more key variables and compute aggregations on
 numeric columns.
 
-.. code-block:: none
+.. code-block:: sas
 
    proc summary data=tips nway;
        class sex smoker;
@@ -640,7 +640,7 @@ In SAS, if the group aggregations need to be used with
 the original frame, it must be merged back together.  For
 example, to subtract the mean for each observation by smoker group.
 
-.. code-block:: none
+.. code-block:: sas
 
    proc summary data=tips missing nway;
        class smoker;
@@ -679,7 +679,7 @@ replicate most other by group processing from SAS. For example,
 this ``DATA`` step reads the data by sex/smoker group and filters to
 the first entry for each.
 
-.. code-block:: none
+.. code-block:: sas
 
    proc sort data=tips;
       by sex smoker;
@@ -719,7 +719,7 @@ Data Interop
 pandas provides a :func:`read_sas` method that can read SAS data saved in
 the XPORT or SAS7BDAT binary format.
 
-.. code-block:: none
+.. code-block:: sas
 
    libname xportout xport 'transport-file.xpt';
    data xportout.tips;

--- a/doc/source/whatsnew/v0.23.0.txt
+++ b/doc/source/whatsnew/v0.23.0.txt
@@ -343,6 +343,7 @@ Other Enhancements
 - :meth:`Timestamp.day_name` and :meth:`DatetimeIndex.day_name` are now available to return day names with a specified locale (:issue:`12806`)
 - :meth:`DataFrame.to_sql` now performs a multivalue insert if the underlying connection supports itk rather than inserting row by row.
   ``SQLAlchemy`` dialects supporting multivalue inserts include: ``mysql``, ``postgresql``, ``sqlite`` and any dialect with ``supports_multivalues_insert``. (:issue:`14315`, :issue:`8953`)
+- :func:`read_html` now accepts a ``displayed_only`` keyword argument to controls whether or not hidden elements are parsed (``True`` by default) (:issue:`20027`)
 
 .. _whatsnew_0230.api_breaking:
 

--- a/doc/source/whatsnew/v0.23.0.txt
+++ b/doc/source/whatsnew/v0.23.0.txt
@@ -1019,6 +1019,7 @@ Reshaping
 - Bug in :func:`DataFrame.iterrows`, which would infers strings not compliant to `ISO8601 <https://en.wikipedia.org/wiki/ISO_8601>`_ to datetimes (:issue:`19671`)
 - Bug in :class:`Series` constructor with ``Categorical`` where a ```ValueError`` is not raised when an index of different length is given (:issue:`19342`)
 - Bug in :meth:`DataFrame.astype` where column metadata is lost when converting to categorical or a dictionary of dtypes (:issue:`19920`)
+- Bug in :func:`cut` and :func:`qcut` where timezone information was dropped (:issue:`19872`)
 
 Other
 ^^^^^

--- a/doc/source/whatsnew/v0.23.0.txt
+++ b/doc/source/whatsnew/v0.23.0.txt
@@ -795,6 +795,7 @@ Performance Improvements
 - Improved performance of variable ``.rolling()`` on ``.min()`` and ``.max()`` (:issue:`19521`)
 - Improved performance of :func:`pandas.core.groupby.GroupBy.ffill` and :func:`pandas.core.groupby.GroupBy.bfill` (:issue:`11296`)
 - Improved performance of :func:`pandas.core.groupby.GroupBy.any` and :func:`pandas.core.groupby.GroupBy.all` (:issue:`15435`)
+- Improved performance of :func:`pandas.core.groupby.GroupBy.pct_change` (:issue:`19165`)
 
 .. _whatsnew_0230.docs:
 

--- a/pandas/core/apply.py
+++ b/pandas/core/apply.py
@@ -191,7 +191,7 @@ class FrameApply(object):
 
         for i, col in enumerate(target.columns):
             res = self.f(target[col])
-            ares = np. asarray(res).ndim
+            ares = np.asarray(res).ndim
 
             # must be a scalar or 1d
             if ares > 1:

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -696,12 +696,38 @@ class Index(IndexOpsMixin, PandasObject):
     @deprecate_kwarg(old_arg_name='n', new_arg_name='repeats')
     def repeat(self, repeats, *args, **kwargs):
         """
-        Repeat elements of an Index. Refer to `numpy.ndarray.repeat`
-        for more information about the `repeats` argument.
+        Repeat elements of an Index.
 
-        See also
+        Returns a new index where each element of the current index
+        is repeated consecutively a given number of times.
+
+        Parameters
+        ----------
+        repeats : int
+            The number of repetitions for each element.
+        **kwargs
+            Additional keywords have no effect but might be accepted for
+            compatibility with numpy.
+
+        Returns
+        -------
+        pandas.Index
+            Newly created Index with repeated elements.
+
+        See Also
         --------
-        numpy.ndarray.repeat
+        Series.repeat : Equivalent function for Series
+        numpy.repeat : Underlying implementation
+
+        Examples
+        --------
+        >>> idx = pd.Index([1, 2, 3])
+        >>> idx
+        Int64Index([1, 2, 3], dtype='int64')
+        >>> idx.repeat(2)
+        Int64Index([1, 1, 2, 2, 3, 3], dtype='int64')
+        >>> idx.repeat(3)
+        Int64Index([1, 1, 1, 2, 2, 2, 3, 3, 3], dtype='int64')
         """
         nv.validate_repeat(args, kwargs)
         return self._shallow_copy(self._values.repeat(repeats))

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -1148,7 +1148,26 @@ class Index(IndexOpsMixin, PandasObject):
 
         Returns
         -------
-        DataFrame : a DataFrame containing the original Index data.
+        DataFrame
+            DataFrame containing the original Index data.
+
+        Examples
+        --------
+        >>> idx = pd.Index(['Ant', 'Bear', 'Cow'], name='animal')
+        >>> idx.to_frame()
+            animal
+        animal       
+        Ant       Ant
+        Bear     Bear
+        Cow       Cow
+
+        By default, the original Index is reused. To enforce a new Index:
+
+        >>> idx.to_frame(index=False)
+            animal
+        0   Ant
+        1  Bear
+        2   Cow
         """
 
         from pandas import DataFrame

--- a/pandas/core/reshape/tile.py
+++ b/pandas/core/reshape/tile.py
@@ -25,6 +25,11 @@ def cut(x, bins, right=True, labels=None, retbins=False, precision=3,
         include_lowest=False):
     """
     Return indices of half-open `bins` to which each value of `x` belongs.
+
+    Use `cut` when you need to segment and sort data values into bins or 
+    buckets of data. This function is also useful for going from a continuous
+    variable to a categorical variable. For example, `cut` could convert ages
+    to groups of age ranges.
     
     Parameters
     ----------
@@ -74,10 +79,6 @@ def cut(x, bins, right=True, labels=None, retbins=False, precision=3,
 
     Notes
     -----
-    The `cut` function is useful for going from a continuous variable to
-    a categorical variable. For example, `cut` could convert ages to groups
-    of age ranges.
-
     Any NA values will be NA in the result. Out of bounds values will be NA in
     the resulting pandas.Categorical object.
 
@@ -95,7 +96,7 @@ def cut(x, bins, right=True, labels=None, retbins=False, precision=3,
     Categories (3, object): [good < medium < bad]
 
     >>> pd.cut(np.ones(5), 4, labels=False)
-    array([1, 1, 1, 1, 1])
+    array([1, 1, 1, 1, 1], dtype=int64)
     """
     # NOTE: this binning code is changed a bit from histogram for var(x) == 0
 

--- a/pandas/core/reshape/tile.py
+++ b/pandas/core/reshape/tile.py
@@ -27,6 +27,11 @@ def cut(x, bins, right=True, labels=None, retbins=False, precision=3,
         include_lowest=False):
     """
     Return indices of half-open `bins` to which each value of `x` belongs.
+
+    Use `cut` when you need to segment and sort data values into bins or 
+    buckets of data. This function is also useful for going from a continuous
+    variable to a categorical variable. For example, `cut` could convert ages
+    to groups of age ranges.
     
     Parameters
     ----------
@@ -76,10 +81,6 @@ def cut(x, bins, right=True, labels=None, retbins=False, precision=3,
 
     Notes
     -----
-    The `cut` function is useful for going from a continuous variable to
-    a categorical variable. For example, `cut` could convert ages to groups
-    of age ranges.
-
     Any NA values will be NA in the result. Out of bounds values will be NA in
     the resulting pandas.Categorical object.
 
@@ -97,7 +98,7 @@ def cut(x, bins, right=True, labels=None, retbins=False, precision=3,
     Categories (3, object): [good < medium < bad]
 
     >>> pd.cut(np.ones(5), 4, labels=False)
-    array([1, 1, 1, 1, 1])
+    array([1, 1, 1, 1, 1], dtype=int64)
     """
     # NOTE: this binning code is changed a bit from histogram for var(x) == 0
 

--- a/pandas/core/reshape/tile.py
+++ b/pandas/core/reshape/tile.py
@@ -24,53 +24,62 @@ import numpy as np
 def cut(x, bins, right=True, labels=None, retbins=False, precision=3,
         include_lowest=False):
     """
-    Return indices of half-open bins to which each value of `x` belongs.
-
+    Return indices of half-open `bins` to which each value of `x` belongs.
+    
     Parameters
     ----------
     x : array-like
         Input array to be binned. It has to be 1-dimensional.
-    bins : int, sequence of scalars, or IntervalIndex
-        If `bins` is an int, it defines the number of equal-width bins in the
-        range of `x`. However, in this case, the range of `x` is extended
-        by .1% on each side to include the min or max values of `x`. If
-        `bins` is a sequence it defines the bin edges allowing for
-        non-uniform bin width. No extension of the range of `x` is done in
-        this case.
-    right : bool, optional
-        Indicates whether the bins include the rightmost edge or not. If
-        right == True (the default), then the bins [1,2,3,4] indicate
+    bins : int, sequence of scalars, or pandas.IntervalIndex
+        If `bins` is an int, defines the number of equal-width bins in the
+        range of `x`. The range of `x` is extended by .1% on each side to 
+        include the min or max values of `x`. 
+        If `bins` is a sequence, defines the bin edges allowing for
+        non-uniform bin width. No extension of the range of `x` is done.
+    right : bool, optional, default 'True'
+        Indicates whether the `bins` include the rightmost edge or not. If
+        `right == True` (the default), then the `bins` [1,2,3,4] indicate
         (1,2], (2,3], (3,4].
-    labels : array or boolean, default None
-        Used as labels for the resulting bins. Must be of the same length as
-        the resulting bins. If False, return only integer indicators of the
-        bins.
-    retbins : bool, optional
-        Whether to return the bins or not. Can be useful if bins is given
+    labels : array or bool, optional
+        Used as labels for the resulting `bins`. Must be of the same length as
+        the resulting `bins`. If False, returns only integer indicators of the
+        `bins`.
+    retbins : bool, optional, default 'False'
+        Whether to return the `bins` or not. Useful when `bins` is provided
         as a scalar.
-    precision : int, optional
-        The precision at which to store and display the bins labels
-    include_lowest : bool, optional
+    precision : int, optional, default '3'
+        The precision at which to store and display the `bins` labels.
+    include_lowest : bool, optional, default 'False'
         Whether the first interval should be left-inclusive or not.
 
     Returns
     -------
-    out : Categorical or Series or array of integers if labels is False
-        The return type (Categorical or Series) depends on the input: a Series
-        of type category if input is a Series else Categorical. Bins are
-        represented as categories when categorical data is returned.
-    bins : ndarray of floats
-        Returned only if `retbins` is True.
+    out : pandas.Categorical or Series, or array of integers if `labels` is 'False'
+        The return type depends on the input. If the input is a Series, a Series
+        of type category is returned. Else - pandas.Categorical is returned. 
+        `Bins` are represented as categories when categorical data is returned.
+    bins : numpy.ndarray of floats
+        Returned only if `retbins` is 'True'.
+    
+    See Also
+    --------
+    qcut : Discretize variable into equal-sized buckets based on rank 
+        or based on sample quantiles.
+    pandas.Categorical : Represents a categorical variable in 
+        classic R / S-plus fashion.
+    Series : One-dimensional ndarray with axis labels (including time series).
+    pandas.IntervalIndex : Immutable Index implementing an ordered, sliceable set.
+        IntervalIndex represents an Index of intervals that are all closed on the 
+        same side.
 
     Notes
     -----
-    The `cut` function can be useful for going from a continuous variable to
+    The `cut` function is useful for going from a continuous variable to
     a categorical variable. For example, `cut` could convert ages to groups
     of age ranges.
 
-    Any NA values will be NA in the result.  Out of bounds values will be NA in
-    the resulting Categorical object
-
+    Any NA values will be NA in the result. Out of bounds values will be NA in
+    the resulting pandas.Categorical object.
 
     Examples
     --------

--- a/pandas/core/reshape/tile.py
+++ b/pandas/core/reshape/tile.py
@@ -28,19 +28,19 @@ def cut(x, bins, right=True, labels=None, retbins=False, precision=3,
     """
     Return indices of half-open `bins` to which each value of `x` belongs.
 
-    Use `cut` when you need to segment and sort data values into bins or 
+    Use `cut` when you need to segment and sort data values into bins or
     buckets of data. This function is also useful for going from a continuous
     variable to a categorical variable. For example, `cut` could convert ages
     to groups of age ranges.
-    
+
     Parameters
     ----------
     x : array-like
         Input array to be binned. It has to be 1-dimensional.
     bins : int, sequence of scalars, or pandas.IntervalIndex
         If `bins` is an int, defines the number of equal-width bins in the
-        range of `x`. The range of `x` is extended by .1% on each side to 
-        include the min or max values of `x`. 
+        range of `x`. The range of `x` is extended by .1% on each side to
+        include the min or max values of `x`.
         If `bins` is a sequence, defines the bin edges allowing for
         non-uniform bin width. No extension of the range of `x` is done.
     right : bool, optional, default 'True'
@@ -61,23 +61,24 @@ def cut(x, bins, right=True, labels=None, retbins=False, precision=3,
 
     Returns
     -------
-    out : pandas.Categorical or Series, or array of integers if `labels` is 'False'
-        The return type depends on the input. If the input is a Series, a Series
-        of type category is returned. Else - pandas.Categorical is returned. 
-        `Bins` are represented as categories when categorical data is returned.
+    out : pandas.Categorical or Series, or array of int if `labels` is 'False'
+        The return type depends on the input.
+        If the input is a Series, a Series of type category is returned.
+        Else - pandas.Categorical is returned. `Bins` are represented as
+        categories when categorical data is returned.
     bins : numpy.ndarray of floats
         Returned only if `retbins` is 'True'.
-    
+
     See Also
     --------
-    qcut : Discretize variable into equal-sized buckets based on rank 
+    qcut : Discretize variable into equal-sized buckets based on rank
         or based on sample quantiles.
-    pandas.Categorical : Represents a categorical variable in 
+    pandas.Categorical : Represents a categorical variable in
         classic R / S-plus fashion.
     Series : One-dimensional ndarray with axis labels (including time series).
-    pandas.IntervalIndex : Immutable Index implementing an ordered, sliceable set.
-        IntervalIndex represents an Index of intervals that are all closed on the 
-        same side.
+    pandas.IntervalIndex : Immutable Index implementing an ordered,
+        sliceable set. IntervalIndex represents an Index of intervals that
+        are all closed on the same side.
 
     Notes
     -----

--- a/pandas/core/reshape/tile.py
+++ b/pandas/core/reshape/tile.py
@@ -26,19 +26,19 @@ def cut(x, bins, right=True, labels=None, retbins=False, precision=3,
     """
     Return indices of half-open `bins` to which each value of `x` belongs.
 
-    Use `cut` when you need to segment and sort data values into bins or 
+    Use `cut` when you need to segment and sort data values into bins or
     buckets of data. This function is also useful for going from a continuous
     variable to a categorical variable. For example, `cut` could convert ages
     to groups of age ranges.
-    
+
     Parameters
     ----------
     x : array-like
         Input array to be binned. It has to be 1-dimensional.
     bins : int, sequence of scalars, or pandas.IntervalIndex
         If `bins` is an int, defines the number of equal-width bins in the
-        range of `x`. The range of `x` is extended by .1% on each side to 
-        include the min or max values of `x`. 
+        range of `x`. The range of `x` is extended by .1% on each side to
+        include the min or max values of `x`.
         If `bins` is a sequence, defines the bin edges allowing for
         non-uniform bin width. No extension of the range of `x` is done.
     right : bool, optional, default 'True'
@@ -59,23 +59,24 @@ def cut(x, bins, right=True, labels=None, retbins=False, precision=3,
 
     Returns
     -------
-    out : pandas.Categorical or Series, or array of integers if `labels` is 'False'
-        The return type depends on the input. If the input is a Series, a Series
-        of type category is returned. Else - pandas.Categorical is returned. 
-        `Bins` are represented as categories when categorical data is returned.
+    out : pandas.Categorical or Series, or array of int if `labels` is 'False'
+        The return type depends on the input.
+        If the input is a Series, a Series of type category is returned.
+        Else - pandas.Categorical is returned. `Bins` are represented as
+        categories when categorical data is returned.
     bins : numpy.ndarray of floats
         Returned only if `retbins` is 'True'.
-    
+
     See Also
     --------
-    qcut : Discretize variable into equal-sized buckets based on rank 
+    qcut : Discretize variable into equal-sized buckets based on rank
         or based on sample quantiles.
-    pandas.Categorical : Represents a categorical variable in 
+    pandas.Categorical : Represents a categorical variable in
         classic R / S-plus fashion.
     Series : One-dimensional ndarray with axis labels (including time series).
-    pandas.IntervalIndex : Immutable Index implementing an ordered, sliceable set.
-        IntervalIndex represents an Index of intervals that are all closed on the 
-        same side.
+    pandas.IntervalIndex : Immutable Index implementing an ordered,
+        sliceable set. IntervalIndex represents an Index of intervals that
+        are all closed on the same side.
 
     Notes
     -----

--- a/pandas/core/reshape/tile.py
+++ b/pandas/core/reshape/tile.py
@@ -1,6 +1,7 @@
 """
 Quantilization functions and related stuff
 """
+from functools import partial
 
 from pandas.core.dtypes.missing import isna
 from pandas.core.dtypes.common import (
@@ -9,6 +10,7 @@ from pandas.core.dtypes.common import (
     is_categorical_dtype,
     is_datetime64_dtype,
     is_timedelta64_dtype,
+    is_datetime64tz_dtype,
     _ensure_int64)
 
 import pandas.core.algorithms as algos
@@ -239,7 +241,8 @@ def _bins_to_cuts(x, bins, right=True, labels=None,
     ids = _ensure_int64(bins.searchsorted(x, side=side))
 
     if include_lowest:
-        ids[x == bins[0]] = 1
+        # Numpy 1.9 support: ensure this mask is a Numpy array
+        ids[np.asarray(x == bins[0])] = 1
 
     na_mask = isna(x) | (ids == len(bins)) | (ids == 0)
     has_nas = na_mask.any()
@@ -284,12 +287,14 @@ def _coerce_to_type(x):
     """
     dtype = None
 
-    if is_timedelta64_dtype(x):
-        x = to_timedelta(x)
-        dtype = np.timedelta64
+    if is_datetime64tz_dtype(x):
+        dtype = x.dtype
     elif is_datetime64_dtype(x):
         x = to_datetime(x)
         dtype = np.datetime64
+    elif is_timedelta64_dtype(x):
+        x = to_timedelta(x)
+        dtype = np.timedelta64
 
     if dtype is not None:
         # GH 19768: force NaT to NaN during integer conversion
@@ -305,7 +310,7 @@ def _convert_bin_to_numeric_type(bins, dtype):
 
     Parameters
     ----------
-    bins : list-liek of bins
+    bins : list-like of bins
     dtype : dtype of data
 
     Raises
@@ -318,7 +323,7 @@ def _convert_bin_to_numeric_type(bins, dtype):
             bins = to_timedelta(bins).view(np.int64)
         else:
             raise ValueError("bins must be of timedelta64 dtype")
-    elif is_datetime64_dtype(dtype):
+    elif is_datetime64_dtype(dtype) or is_datetime64tz_dtype(dtype):
         if bins_dtype in ['datetime', 'datetime64']:
             bins = to_datetime(bins).view(np.int64)
         else:
@@ -333,7 +338,10 @@ def _format_labels(bins, precision, right=True,
 
     closed = 'right' if right else 'left'
 
-    if is_datetime64_dtype(dtype):
+    if is_datetime64tz_dtype(dtype):
+        formatter = partial(Timestamp, tz=dtype.tz)
+        adjust = lambda x: x - Timedelta('1ns')
+    elif is_datetime64_dtype(dtype):
         formatter = Timestamp
         adjust = lambda x: x - Timedelta('1ns')
     elif is_timedelta64_dtype(dtype):
@@ -372,7 +380,13 @@ def _preprocess_for_cut(x):
         series_index = x.index
         name = x.name
 
-    x = np.asarray(x)
+    # Check that the passed array is a Pandas or Numpy object
+    # We don't want to strip away a Pandas data-type here (e.g. datetimetz)
+    ndim = getattr(x, 'ndim', None)
+    if ndim is None:
+        x = np.asarray(x)
+    if x.ndim != 1:
+        raise ValueError("Input array must be 1 dimensional")
 
     return x_is_series, series_index, name, x
 

--- a/pandas/core/reshape/tile.py
+++ b/pandas/core/reshape/tile.py
@@ -26,53 +26,62 @@ import numpy as np
 def cut(x, bins, right=True, labels=None, retbins=False, precision=3,
         include_lowest=False):
     """
-    Return indices of half-open bins to which each value of `x` belongs.
-
+    Return indices of half-open `bins` to which each value of `x` belongs.
+    
     Parameters
     ----------
     x : array-like
         Input array to be binned. It has to be 1-dimensional.
-    bins : int, sequence of scalars, or IntervalIndex
-        If `bins` is an int, it defines the number of equal-width bins in the
-        range of `x`. However, in this case, the range of `x` is extended
-        by .1% on each side to include the min or max values of `x`. If
-        `bins` is a sequence it defines the bin edges allowing for
-        non-uniform bin width. No extension of the range of `x` is done in
-        this case.
-    right : bool, optional
-        Indicates whether the bins include the rightmost edge or not. If
-        right == True (the default), then the bins [1,2,3,4] indicate
+    bins : int, sequence of scalars, or pandas.IntervalIndex
+        If `bins` is an int, defines the number of equal-width bins in the
+        range of `x`. The range of `x` is extended by .1% on each side to 
+        include the min or max values of `x`. 
+        If `bins` is a sequence, defines the bin edges allowing for
+        non-uniform bin width. No extension of the range of `x` is done.
+    right : bool, optional, default 'True'
+        Indicates whether the `bins` include the rightmost edge or not. If
+        `right == True` (the default), then the `bins` [1,2,3,4] indicate
         (1,2], (2,3], (3,4].
-    labels : array or boolean, default None
-        Used as labels for the resulting bins. Must be of the same length as
-        the resulting bins. If False, return only integer indicators of the
-        bins.
-    retbins : bool, optional
-        Whether to return the bins or not. Can be useful if bins is given
+    labels : array or bool, optional
+        Used as labels for the resulting `bins`. Must be of the same length as
+        the resulting `bins`. If False, returns only integer indicators of the
+        `bins`.
+    retbins : bool, optional, default 'False'
+        Whether to return the `bins` or not. Useful when `bins` is provided
         as a scalar.
-    precision : int, optional
-        The precision at which to store and display the bins labels
-    include_lowest : bool, optional
+    precision : int, optional, default '3'
+        The precision at which to store and display the `bins` labels.
+    include_lowest : bool, optional, default 'False'
         Whether the first interval should be left-inclusive or not.
 
     Returns
     -------
-    out : Categorical or Series or array of integers if labels is False
-        The return type (Categorical or Series) depends on the input: a Series
-        of type category if input is a Series else Categorical. Bins are
-        represented as categories when categorical data is returned.
-    bins : ndarray of floats
-        Returned only if `retbins` is True.
+    out : pandas.Categorical or Series, or array of integers if `labels` is 'False'
+        The return type depends on the input. If the input is a Series, a Series
+        of type category is returned. Else - pandas.Categorical is returned. 
+        `Bins` are represented as categories when categorical data is returned.
+    bins : numpy.ndarray of floats
+        Returned only if `retbins` is 'True'.
+    
+    See Also
+    --------
+    qcut : Discretize variable into equal-sized buckets based on rank 
+        or based on sample quantiles.
+    pandas.Categorical : Represents a categorical variable in 
+        classic R / S-plus fashion.
+    Series : One-dimensional ndarray with axis labels (including time series).
+    pandas.IntervalIndex : Immutable Index implementing an ordered, sliceable set.
+        IntervalIndex represents an Index of intervals that are all closed on the 
+        same side.
 
     Notes
     -----
-    The `cut` function can be useful for going from a continuous variable to
+    The `cut` function is useful for going from a continuous variable to
     a categorical variable. For example, `cut` could convert ages to groups
     of age ranges.
 
-    Any NA values will be NA in the result.  Out of bounds values will be NA in
-    the resulting Categorical object
-
+    Any NA values will be NA in the result. Out of bounds values will be NA in
+    the resulting pandas.Categorical object.
 
     Examples
     --------

--- a/pandas/core/window.py
+++ b/pandas/core/window.py
@@ -906,21 +906,23 @@ class _Rolling_and_Expanding(_Rolling):
 
     Parameters
     ----------
-    kwargs : Under Review
+    **kwargs
+        Under Review.
 
     Returns
     -------
-    Series or DataFrame (matches input)
-        Like-indexed object containing the result of function application
+    Series or DataFrame
+        Returned object type is determined by the caller of the %(name)s
+        calculation
 
     See Also
     --------
-    pandas.Series.%(name)s
-    pandas.DataFrame.%(name)s
-    pandas.Series.kurtosis
-    pandas.DataFrame.kurtosis
-    scipy.stats.skew
-    scipy.stats.kurtosis
+    Series.%(name)s : Calling object with Series data
+    DataFrame.%(name)s : Calling object with DataFrames
+    Series.kurt : Equivalent method for Series
+    DataFrame.kurt : Equivalent method for DataFrame
+    scipy.stats.skew : Third moment of a probability density
+    scipy.stats.kurtosis : Reference SciPy method
 
     Notes
     -----
@@ -932,19 +934,20 @@ class _Rolling_and_Expanding(_Rolling):
     four matching the equivalent function call using `scipy.stats`.
 
     >>> arr = [1, 2, 3, 4, 999]
+    >>> fmt = "{0:.6f}"  # limit the printed precision to 6 digits
     >>> import scipy.stats
-    >>> print("{0:.6f}".format(scipy.stats.kurtosis(arr[:-1], bias=False)))
+    >>> print(fmt.format(scipy.stats.kurtosis(arr[:-1], bias=False)))
     -1.200000
-    >>> print("{0:.6f}".format(scipy.stats.kurtosis(arr[1:], bias=False)))
+    >>> print(fmt.format(scipy.stats.kurtosis(arr[1:], bias=False)))
     3.999946
-    >>> df = pd.DataFrame(arr)
-    >>> df.rolling(4).kurt()
-              0
-    0       NaN
-    1       NaN
-    2       NaN
-    3 -1.200000
-    4  3.999946
+    >>> s = pd.Series(arr)
+    >>> s.rolling(4).kurt()
+    0         NaN
+    1         NaN
+    2         NaN
+    3   -1.200000
+    4    3.999946
+    dtype: float64
     """)
 
     def kurt(self, **kwargs):

--- a/pandas/io/html.py
+++ b/pandas/io/html.py
@@ -160,6 +160,14 @@ class _HtmlFrameParser(object):
     attrs : dict
         List of HTML <table> element attributes to match.
 
+    encoding : str
+        Encoding to be used by parser
+
+    displayed_only : bool
+        Whether or not items with "display:none" should be ignored
+
+        .. versionadded:: 0.23.0
+
     Attributes
     ----------
     io : str or file-like
@@ -171,6 +179,14 @@ class _HtmlFrameParser(object):
     attrs : dict-like
         A dictionary of valid table attributes to use to search for table
         elements.
+
+    encoding : str
+        Encoding to be used by parser
+
+    displayed_only : bool
+        Whether or not items with "display:none" should be ignored
+
+        .. versionadded:: 0.23.0
 
     Notes
     -----
@@ -187,11 +203,12 @@ class _HtmlFrameParser(object):
     functionality.
     """
 
-    def __init__(self, io, match, attrs, encoding):
+    def __init__(self, io, match, attrs, encoding, displayed_only):
         self.io = io
         self.match = match
         self.attrs = attrs
         self.encoding = encoding
+        self.displayed_only = displayed_only
 
     def parse_tables(self):
         tables = self._parse_tables(self._build_doc(), self.match, self.attrs)
@@ -380,6 +397,27 @@ class _HtmlFrameParser(object):
             res = self._parse_tr(table)
         return self._parse_raw_data(res)
 
+    def _handle_hidden_tables(self, tbl_list, attr_name):
+        """Returns list of tables, potentially removing hidden elements
+
+        Parameters
+        ----------
+        tbl_list : list of Tag or list of Element
+            Type of list elements will vary depending upon parser used
+        attr_name : str
+            Name of the accessor for retrieving HTML attributes
+
+        Returns
+        -------
+        list of Tag or list of Element
+            Return type matches `tbl_list`
+        """
+        if not self.displayed_only:
+            return tbl_list
+
+        return [x for x in tbl_list if "display:none" not in
+                getattr(x, attr_name).get('style', '').replace(" ", "")]
+
 
 class _BeautifulSoupHtml5LibFrameParser(_HtmlFrameParser):
     """HTML to DataFrame parser that uses BeautifulSoup under the hood.
@@ -431,8 +469,14 @@ class _BeautifulSoupHtml5LibFrameParser(_HtmlFrameParser):
 
         result = []
         unique_tables = set()
+        tables = self._handle_hidden_tables(tables, "attrs")
 
         for table in tables:
+            if self.displayed_only:
+                for elem in table.find_all(
+                        style=re.compile(r"display:\s*none")):
+                    elem.decompose()
+
             if (table not in unique_tables and
                     table.find(text=match) is not None):
                 result.append(table)
@@ -527,6 +571,17 @@ class _LxmlFrameParser(_HtmlFrameParser):
             xpath_expr += _build_xpath_expr(kwargs)
 
         tables = doc.xpath(xpath_expr, namespaces=_re_namespace)
+
+        tables = self._handle_hidden_tables(tables, "attrib")
+        if self.displayed_only:
+            for table in tables:
+                # lxml utilizes XPATH 1.0 which does not have regex
+                # support. As a result, we find all elements with a style
+                # attribute and iterate them to check for display:none
+                for elem in table.xpath('.//*[@style]'):
+                    if "display:none" in elem.attrib.get(
+                            "style", "").replace(" ", ""):
+                        elem.getparent().remove(elem)
 
         if not tables:
             raise ValueError("No tables found matching regex {patt!r}"
@@ -729,7 +784,7 @@ def _validate_flavor(flavor):
     return flavor
 
 
-def _parse(flavor, io, match, attrs, encoding, **kwargs):
+def _parse(flavor, io, match, attrs, encoding, displayed_only, **kwargs):
     flavor = _validate_flavor(flavor)
     compiled_match = re.compile(match)  # you can pass a compiled regex here
 
@@ -737,7 +792,7 @@ def _parse(flavor, io, match, attrs, encoding, **kwargs):
     retained = None
     for flav in flavor:
         parser = _parser_dispatch(flav)
-        p = parser(io, compiled_match, attrs, encoding)
+        p = parser(io, compiled_match, attrs, encoding, displayed_only)
 
         try:
             tables = p.parse_tables()
@@ -773,7 +828,7 @@ def read_html(io, match='.+', flavor=None, header=None, index_col=None,
               skiprows=None, attrs=None, parse_dates=False,
               tupleize_cols=None, thousands=',', encoding=None,
               decimal='.', converters=None, na_values=None,
-              keep_default_na=True):
+              keep_default_na=True, displayed_only=True):
     r"""Read HTML tables into a ``list`` of ``DataFrame`` objects.
 
     Parameters
@@ -877,6 +932,11 @@ def read_html(io, match='.+', flavor=None, header=None, index_col=None,
 
         .. versionadded:: 0.19.0
 
+    display_only : bool, default True
+        Whether elements with "display: none" should be parsed
+
+        .. versionadded:: 0.23.0
+
     Returns
     -------
     dfs : list of DataFrames
@@ -924,4 +984,5 @@ def read_html(io, match='.+', flavor=None, header=None, index_col=None,
                   parse_dates=parse_dates, tupleize_cols=tupleize_cols,
                   thousands=thousands, attrs=attrs, encoding=encoding,
                   decimal=decimal, converters=converters, na_values=na_values,
-                  keep_default_na=keep_default_na)
+                  keep_default_na=keep_default_na,
+                  displayed_only=displayed_only)

--- a/pandas/tests/groupby/test_groupby.py
+++ b/pandas/tests/groupby/test_groupby.py
@@ -2062,61 +2062,6 @@ class TestGroupBy(MixIn):
                                    ascending=ascending,
                                    na_option=na_option, pct=pct)
 
-    @pytest.mark.parametrize("mix_groupings", [True, False])
-    @pytest.mark.parametrize("as_series", [True, False])
-    @pytest.mark.parametrize("val1,val2", [
-        ('foo', 'bar'), (1, 2), (1., 2.)])
-    @pytest.mark.parametrize("fill_method,limit,exp_vals", [
-        ("ffill", None,
-         [np.nan, np.nan, 'val1', 'val1', 'val1', 'val2', 'val2', 'val2']),
-        ("ffill", 1,
-         [np.nan, np.nan, 'val1', 'val1', np.nan, 'val2', 'val2', np.nan]),
-        ("bfill", None,
-         ['val1', 'val1', 'val1', 'val2', 'val2', 'val2', np.nan, np.nan]),
-        ("bfill", 1,
-         [np.nan, 'val1', 'val1', np.nan, 'val2', 'val2', np.nan, np.nan])
-    ])
-    def test_group_fill_methods(self, mix_groupings, as_series, val1, val2,
-                                fill_method, limit, exp_vals):
-        vals = [np.nan, np.nan, val1, np.nan, np.nan, val2, np.nan, np.nan]
-        _exp_vals = list(exp_vals)
-        # Overwrite placeholder values
-        for index, exp_val in enumerate(_exp_vals):
-            if exp_val == 'val1':
-                _exp_vals[index] = val1
-            elif exp_val == 'val2':
-                _exp_vals[index] = val2
-
-        # Need to modify values and expectations depending on the
-        # Series / DataFrame that we ultimately want to generate
-        if mix_groupings:  # ['a', 'b', 'a, 'b', ...]
-            keys = ['a', 'b'] * len(vals)
-
-            def interweave(list_obj):
-                temp = list()
-                for x in list_obj:
-                    temp.extend([x, x])
-
-                return temp
-
-            _exp_vals = interweave(_exp_vals)
-            vals = interweave(vals)
-        else:  # ['a', 'a', 'a', ... 'b', 'b', 'b']
-            keys = ['a'] * len(vals) + ['b'] * len(vals)
-            _exp_vals = _exp_vals * 2
-            vals = vals * 2
-
-        df = DataFrame({'key': keys, 'val': vals})
-        if as_series:
-            result = getattr(
-                df.groupby('key')['val'], fill_method)(limit=limit)
-            exp = Series(_exp_vals, name='val')
-            assert_series_equal(result, exp)
-        else:
-            result = getattr(df.groupby('key'), fill_method)(limit=limit)
-            exp = DataFrame({'key': keys, 'val': _exp_vals})
-            assert_frame_equal(result, exp)
-
     @pytest.mark.parametrize("agg_func", ['any', 'all'])
     @pytest.mark.parametrize("skipna", [True, False])
     @pytest.mark.parametrize("vals", [

--- a/pandas/tests/groupby/test_transform.py
+++ b/pandas/tests/groupby/test_transform.py
@@ -636,3 +636,90 @@ class TestGroupBy(MixIn):
             exp = exp.astype('float')
 
         comp_func(result, exp)
+
+    @pytest.mark.parametrize("mix_groupings", [True, False])
+    @pytest.mark.parametrize("as_series", [True, False])
+    @pytest.mark.parametrize("val1,val2", [
+        ('foo', 'bar'), (1, 2), (1., 2.)])
+    @pytest.mark.parametrize("fill_method,limit,exp_vals", [
+        ("ffill", None,
+         [np.nan, np.nan, 'val1', 'val1', 'val1', 'val2', 'val2', 'val2']),
+        ("ffill", 1,
+         [np.nan, np.nan, 'val1', 'val1', np.nan, 'val2', 'val2', np.nan]),
+        ("bfill", None,
+         ['val1', 'val1', 'val1', 'val2', 'val2', 'val2', np.nan, np.nan]),
+        ("bfill", 1,
+         [np.nan, 'val1', 'val1', np.nan, 'val2', 'val2', np.nan, np.nan])
+    ])
+    def test_group_fill_methods(self, mix_groupings, as_series, val1, val2,
+                                fill_method, limit, exp_vals):
+        vals = [np.nan, np.nan, val1, np.nan, np.nan, val2, np.nan, np.nan]
+        _exp_vals = list(exp_vals)
+        # Overwrite placeholder values
+        for index, exp_val in enumerate(_exp_vals):
+            if exp_val == 'val1':
+                _exp_vals[index] = val1
+            elif exp_val == 'val2':
+                _exp_vals[index] = val2
+
+        # Need to modify values and expectations depending on the
+        # Series / DataFrame that we ultimately want to generate
+        if mix_groupings:  # ['a', 'b', 'a, 'b', ...]
+            keys = ['a', 'b'] * len(vals)
+
+            def interweave(list_obj):
+                temp = list()
+                for x in list_obj:
+                    temp.extend([x, x])
+
+                return temp
+
+            _exp_vals = interweave(_exp_vals)
+            vals = interweave(vals)
+        else:  # ['a', 'a', 'a', ... 'b', 'b', 'b']
+            keys = ['a'] * len(vals) + ['b'] * len(vals)
+            _exp_vals = _exp_vals * 2
+            vals = vals * 2
+
+        df = DataFrame({'key': keys, 'val': vals})
+        if as_series:
+            result = getattr(
+                df.groupby('key')['val'], fill_method)(limit=limit)
+            exp = Series(_exp_vals, name='val')
+            assert_series_equal(result, exp)
+        else:
+            result = getattr(df.groupby('key'), fill_method)(limit=limit)
+            exp = DataFrame({'key': keys, 'val': _exp_vals})
+            assert_frame_equal(result, exp)
+
+    @pytest.mark.parametrize("test_series", [True, False])
+    @pytest.mark.parametrize("periods,fill_method,limit", [
+        (1, 'ffill', None), (1, 'ffill', 1),
+        (1, 'bfill', None), (1, 'bfill', 1),
+        (-1, 'ffill', None), (-1, 'ffill', 1),
+        (-1, 'bfill', None), (-1, 'bfill', 1)])
+    def test_pct_change(self, test_series, periods, fill_method, limit):
+        vals = [np.nan, np.nan, 1, 2, 4, 10, np.nan, np.nan]
+        exp_vals = Series(vals).pct_change(periods=periods,
+                                           fill_method=fill_method,
+                                           limit=limit).tolist()
+
+        df = DataFrame({'key': ['a'] * len(vals) + ['b'] * len(vals),
+                        'vals': vals * 2})
+        grp = df.groupby('key')
+
+        def get_result(grp_obj):
+            return grp_obj.pct_change(periods=periods,
+                                      fill_method=fill_method,
+                                      limit=limit)
+
+        if test_series:
+            exp = pd.Series(exp_vals * 2)
+            exp.name = 'vals'
+            grp = grp['vals']
+            result = get_result(grp)
+            tm.assert_series_equal(result, exp)
+        else:
+            exp = DataFrame({'vals': exp_vals * 2})
+            result = get_result(grp)
+            tm.assert_frame_equal(result, exp)

--- a/pandas/tests/io/test_html.py
+++ b/pandas/tests/io/test_html.py
@@ -674,6 +674,39 @@ class TestReadHtml(ReadHtmlMixin):
         result = self.read_html(data, 'Arizona', header=1)[0]
         assert result['sq mi'].dtype == np.dtype('float64')
 
+    @pytest.mark.parametrize("displayed_only,exp0,exp1", [
+        (True, DataFrame(["foo"]), None),
+        (False, DataFrame(["foo  bar  baz  qux"]), DataFrame(["foo"]))])
+    def test_displayed_only(self, displayed_only, exp0, exp1):
+        # GH 20027
+        data = StringIO("""<html>
+          <body>
+            <table>
+              <tr>
+                <td>
+                  foo
+                  <span style="display:none;text-align:center">bar</span>
+                  <span style="display:none">baz</span>
+                  <span style="display: none">qux</span>
+                </td>
+              </tr>
+            </table>
+            <table style="display: none">
+              <tr>
+                <td>foo</td>
+              </tr>
+            </table>
+          </body>
+        </html>""")
+
+        dfs = self.read_html(data, displayed_only=displayed_only)
+        tm.assert_frame_equal(dfs[0], exp0)
+
+        if exp1 is not None:
+            tm.assert_frame_equal(dfs[1], exp1)
+        else:
+            assert len(dfs) == 1  # Should not parse hidden table
+
     def test_decimal_rows(self):
 
         # GH 12907
@@ -895,6 +928,39 @@ class TestReadHtmlLxml(ReadHtmlMixin):
     def test_computer_sales_page(self):
         data = os.path.join(DATA_PATH, 'computer_sales_page.html')
         self.read_html(data, header=[0, 1])
+
+    @pytest.mark.parametrize("displayed_only,exp0,exp1", [
+        (True, DataFrame(["foo"]), None),
+        (False, DataFrame(["foo  bar  baz  qux"]), DataFrame(["foo"]))])
+    def test_displayed_only(self, displayed_only, exp0, exp1):
+        # GH 20027
+        data = StringIO("""<html>
+          <body>
+            <table>
+              <tr>
+                <td>
+                  foo
+                  <span style="display:none;text-align:center">bar</span>
+                  <span style="display:none">baz</span>
+                  <span style="display: none">qux</span>
+                </td>
+              </tr>
+            </table>
+            <table style="display: none">
+              <tr>
+                <td>foo</td>
+              </tr>
+            </table>
+          </body>
+        </html>""")
+
+        dfs = self.read_html(data, displayed_only=displayed_only)
+        tm.assert_frame_equal(dfs[0], exp0)
+
+        if exp1 is not None:
+            tm.assert_frame_equal(dfs[1], exp1)
+        else:
+            assert len(dfs) == 1  # Should not parse hidden table
 
 
 def test_invalid_flavor():

--- a/pandas/tests/reshape/test_tile.py
+++ b/pandas/tests/reshape/test_tile.py
@@ -4,7 +4,7 @@ import pytest
 import numpy as np
 from pandas.compat import zip
 
-from pandas import (Series, isna, to_datetime, DatetimeIndex,
+from pandas import (DataFrame, Series, isna, to_datetime, DatetimeIndex, Index,
                     Timestamp, Interval, IntervalIndex, Categorical,
                     cut, qcut, date_range, NaT, TimedeltaIndex)
 from pandas.tseries.offsets import Nano, Day
@@ -103,6 +103,12 @@ class TestCut(object):
         pytest.raises(ValueError, cut, [], 2)
 
         pytest.raises(ValueError, cut, [1, 2, 3], 0.5)
+
+    @pytest.mark.parametrize('arg', [2, np.eye(2), DataFrame(np.eye(2))])
+    @pytest.mark.parametrize('cut_func', [cut, qcut])
+    def test_cut_not_1d_arg(self, arg, cut_func):
+        with pytest.raises(ValueError):
+            cut_func(arg, 2)
 
     def test_cut_out_of_range_more(self):
         # #1511
@@ -250,18 +256,6 @@ class TestCut(object):
 
         result = qcut(arr, 4)
         assert isna(result[:20]).all()
-
-    @pytest.mark.parametrize('s', [
-        Series(DatetimeIndex(['20180101', NaT, '20180103'])),
-        Series(TimedeltaIndex(['0 days', NaT, '2 days']))],
-        ids=lambda x: str(x.dtype))
-    def test_qcut_nat(self, s):
-        # GH 19768
-        intervals = IntervalIndex.from_tuples(
-            [(s[0] - Nano(), s[2] - Day()), np.nan, (s[2] - Day(), s[2])])
-        expected = Series(Categorical(intervals, ordered=True))
-        result = qcut(s, 2)
-        tm.assert_series_equal(result, expected)
 
     def test_qcut_index(self):
         result = qcut([0, 2], 2)
@@ -452,6 +446,37 @@ class TestCut(object):
         result = cut(s, 1, labels=False)
         tm.assert_series_equal(result, expected)
 
+    @pytest.mark.parametrize(
+        "array_1_writeable, array_2_writeable",
+        [(True, True), (True, False), (False, False)])
+    def test_cut_read_only(self, array_1_writeable, array_2_writeable):
+        # issue 18773
+        array_1 = np.arange(0, 100, 10)
+        array_1.flags.writeable = array_1_writeable
+
+        array_2 = np.arange(0, 100, 10)
+        array_2.flags.writeable = array_2_writeable
+
+        hundred_elements = np.arange(100)
+
+        tm.assert_categorical_equal(cut(hundred_elements, array_1),
+                                    cut(hundred_elements, array_2))
+
+
+class TestDatelike(object):
+
+    @pytest.mark.parametrize('s', [
+        Series(DatetimeIndex(['20180101', NaT, '20180103'])),
+        Series(TimedeltaIndex(['0 days', NaT, '2 days']))],
+        ids=lambda x: str(x.dtype))
+    def test_qcut_nat(self, s):
+        # GH 19768
+        intervals = IntervalIndex.from_tuples(
+            [(s[0] - Nano(), s[2] - Day()), np.nan, (s[2] - Day(), s[2])])
+        expected = Series(Categorical(intervals, ordered=True))
+        result = qcut(s, 2)
+        tm.assert_series_equal(result, expected)
+
     def test_datetime_cut(self):
         # GH 14714
         # testing for time data to be present as series
@@ -488,6 +513,47 @@ class TestCut(object):
         result, bins = cut(data, 3, retbins=True)
         tm.assert_series_equal(Series(result), expected)
 
+    @pytest.mark.parametrize('bins', [
+        3, [Timestamp('2013-01-01 04:57:07.200000'),
+            Timestamp('2013-01-01 21:00:00'),
+            Timestamp('2013-01-02 13:00:00'),
+            Timestamp('2013-01-03 05:00:00')]])
+    @pytest.mark.parametrize('box', [list, np.array, Index, Series])
+    def test_datetimetz_cut(self, bins, box):
+        # GH 19872
+        tz = 'US/Eastern'
+        s = Series(date_range('20130101', periods=3, tz=tz))
+        if not isinstance(bins, int):
+            bins = box(bins)
+        result = cut(s, bins)
+        expected = (
+            Series(IntervalIndex([
+                Interval(Timestamp('2012-12-31 23:57:07.200000', tz=tz),
+                         Timestamp('2013-01-01 16:00:00', tz=tz)),
+                Interval(Timestamp('2013-01-01 16:00:00', tz=tz),
+                         Timestamp('2013-01-02 08:00:00', tz=tz)),
+                Interval(Timestamp('2013-01-02 08:00:00', tz=tz),
+                         Timestamp('2013-01-03 00:00:00', tz=tz))]))
+            .astype(CDT(ordered=True)))
+        tm.assert_series_equal(result, expected)
+
+    @pytest.mark.parametrize('bins', [3, np.linspace(0, 1, 4)])
+    def test_datetimetz_qcut(self, bins):
+        # GH 19872
+        tz = 'US/Eastern'
+        s = Series(date_range('20130101', periods=3, tz=tz))
+        result = qcut(s, bins)
+        expected = (
+            Series(IntervalIndex([
+                Interval(Timestamp('2012-12-31 23:59:59.999999999', tz=tz),
+                         Timestamp('2013-01-01 16:00:00', tz=tz)),
+                Interval(Timestamp('2013-01-01 16:00:00', tz=tz),
+                         Timestamp('2013-01-02 08:00:00', tz=tz)),
+                Interval(Timestamp('2013-01-02 08:00:00', tz=tz),
+                         Timestamp('2013-01-03 00:00:00', tz=tz))]))
+            .astype(CDT(ordered=True)))
+        tm.assert_series_equal(result, expected)
+
     def test_datetime_bin(self):
         data = [np.datetime64('2012-12-13'), np.datetime64('2012-12-15')]
         bin_data = ['2012-12-12', '2012-12-14', '2012-12-16']
@@ -523,19 +589,3 @@ class TestCut(object):
         mask = result.isna()
         tm.assert_numpy_array_equal(
             mask, np.array([False, True, True, True, True]))
-
-    @pytest.mark.parametrize(
-        "array_1_writeable, array_2_writeable",
-        [(True, True), (True, False), (False, False)])
-    def test_cut_read_only(self, array_1_writeable, array_2_writeable):
-        # issue 18773
-        array_1 = np.arange(0, 100, 10)
-        array_1.flags.writeable = array_1_writeable
-
-        array_2 = np.arange(0, 100, 10)
-        array_2.flags.writeable = array_2_writeable
-
-        hundred_elements = np.arange(100)
-
-        tm.assert_categorical_equal(cut(hundred_elements, array_1),
-                                    cut(hundred_elements, array_2))

--- a/pandas/tests/series/indexing/test_alter_index.py
+++ b/pandas/tests/series/indexing/test_alter_index.py
@@ -21,88 +21,72 @@ import pandas.util.testing as tm
 JOIN_TYPES = ['inner', 'outer', 'left', 'right']
 
 
-def test_align(test_data):
-    def _check_align(a, b, how='left', fill=None):
-        aa, ab = a.align(b, join=how, fill_value=fill)
+@pytest.mark.parametrize(
+    'first_slice,second_slice', [
+        [[2, None], [None, -5]],
+        [[None, 0], [None, -5]],
+        [[None, -5], [None, 0]],
+        [[None, 0], [None, 0]]
+    ])
+@pytest.mark.parametrize('join_type', JOIN_TYPES)
+@pytest.mark.parametrize('fill', [None, -1])
+def test_align(test_data, first_slice, second_slice, join_type, fill):
+    a = test_data.ts[slice(*first_slice)]
+    b = test_data.ts[slice(*second_slice)]
 
-        join_index = a.index.join(b.index, how=how)
-        if fill is not None:
-            diff_a = aa.index.difference(join_index)
-            diff_b = ab.index.difference(join_index)
-            if len(diff_a) > 0:
-                assert (aa.reindex(diff_a) == fill).all()
-            if len(diff_b) > 0:
-                assert (ab.reindex(diff_b) == fill).all()
+    aa, ab = a.align(b, join=join_type, fill_value=fill)
 
-        ea = a.reindex(join_index)
-        eb = b.reindex(join_index)
+    join_index = a.index.join(b.index, how=join_type)
+    if fill is not None:
+        diff_a = aa.index.difference(join_index)
+        diff_b = ab.index.difference(join_index)
+        if len(diff_a) > 0:
+            assert (aa.reindex(diff_a) == fill).all()
+        if len(diff_b) > 0:
+            assert (ab.reindex(diff_b) == fill).all()
 
-        if fill is not None:
-            ea = ea.fillna(fill)
-            eb = eb.fillna(fill)
+    ea = a.reindex(join_index)
+    eb = b.reindex(join_index)
 
-        assert_series_equal(aa, ea)
-        assert_series_equal(ab, eb)
-        assert aa.name == 'ts'
-        assert ea.name == 'ts'
-        assert ab.name == 'ts'
-        assert eb.name == 'ts'
+    if fill is not None:
+        ea = ea.fillna(fill)
+        eb = eb.fillna(fill)
 
-    for kind in JOIN_TYPES:
-        _check_align(test_data.ts[2:], test_data.ts[:-5], how=kind)
-        _check_align(test_data.ts[2:], test_data.ts[:-5], how=kind, fill=-1)
-
-        # empty left
-        _check_align(test_data.ts[:0], test_data.ts[:-5], how=kind)
-        _check_align(test_data.ts[:0], test_data.ts[:-5], how=kind, fill=-1)
-
-        # empty right
-        _check_align(test_data.ts[:-5], test_data.ts[:0], how=kind)
-        _check_align(test_data.ts[:-5], test_data.ts[:0], how=kind, fill=-1)
-
-        # both empty
-        _check_align(test_data.ts[:0], test_data.ts[:0], how=kind)
-        _check_align(test_data.ts[:0], test_data.ts[:0], how=kind, fill=-1)
+    assert_series_equal(aa, ea)
+    assert_series_equal(ab, eb)
+    assert aa.name == 'ts'
+    assert ea.name == 'ts'
+    assert ab.name == 'ts'
+    assert eb.name == 'ts'
 
 
-def test_align_fill_method(test_data):
-    def _check_align(a, b, how='left', method='pad', limit=None):
-        aa, ab = a.align(b, join=how, method=method, limit=limit)
+@pytest.mark.parametrize(
+    'first_slice,second_slice', [
+        [[2, None], [None, -5]],
+        [[None, 0], [None, -5]],
+        [[None, -5], [None, 0]],
+        [[None, 0], [None, 0]]
+    ])
+@pytest.mark.parametrize('join_type', JOIN_TYPES)
+@pytest.mark.parametrize('method', ['pad', 'bfill'])
+@pytest.mark.parametrize('limit', [None, 1])
+def test_align_fill_method(test_data,
+                           first_slice, second_slice,
+                           join_type, method, limit):
+    a = test_data.ts[slice(*first_slice)]
+    b = test_data.ts[slice(*second_slice)]
 
-        join_index = a.index.join(b.index, how=how)
-        ea = a.reindex(join_index)
-        eb = b.reindex(join_index)
+    aa, ab = a.align(b, join=join_type, method=method, limit=limit)
 
-        ea = ea.fillna(method=method, limit=limit)
-        eb = eb.fillna(method=method, limit=limit)
+    join_index = a.index.join(b.index, how=join_type)
+    ea = a.reindex(join_index)
+    eb = b.reindex(join_index)
 
-        assert_series_equal(aa, ea)
-        assert_series_equal(ab, eb)
+    ea = ea.fillna(method=method, limit=limit)
+    eb = eb.fillna(method=method, limit=limit)
 
-    for kind in JOIN_TYPES:
-        for meth in ['pad', 'bfill']:
-            _check_align(test_data.ts[2:], test_data.ts[:-5],
-                         how=kind, method=meth)
-            _check_align(test_data.ts[2:], test_data.ts[:-5],
-                         how=kind, method=meth, limit=1)
-
-            # empty left
-            _check_align(test_data.ts[:0], test_data.ts[:-5],
-                         how=kind, method=meth)
-            _check_align(test_data.ts[:0], test_data.ts[:-5],
-                         how=kind, method=meth, limit=1)
-
-            # empty right
-            _check_align(test_data.ts[:-5], test_data.ts[:0],
-                         how=kind, method=meth)
-            _check_align(test_data.ts[:-5], test_data.ts[:0],
-                         how=kind, method=meth, limit=1)
-
-            # both empty
-            _check_align(test_data.ts[:0], test_data.ts[:0],
-                         how=kind, method=meth)
-            _check_align(test_data.ts[:0], test_data.ts[:0],
-                         how=kind, method=meth, limit=1)
+    assert_series_equal(aa, ea)
+    assert_series_equal(ab, eb)
 
 
 def test_align_nocopy(test_data):
@@ -481,3 +465,56 @@ def test_rename():
     assert_series_equal(result, expected)
 
     assert result.name == expected.name
+
+
+def test_drop():
+    # unique
+    s = Series([1, 2], index=['one', 'two'])
+    expected = Series([1], index=['one'])
+    result = s.drop(['two'])
+    assert_series_equal(result, expected)
+    result = s.drop('two', axis='rows')
+    assert_series_equal(result, expected)
+
+    # non-unique
+    # GH 5248
+    s = Series([1, 1, 2], index=['one', 'two', 'one'])
+    expected = Series([1, 2], index=['one', 'one'])
+    result = s.drop(['two'], axis=0)
+    assert_series_equal(result, expected)
+    result = s.drop('two')
+    assert_series_equal(result, expected)
+
+    expected = Series([1], index=['two'])
+    result = s.drop(['one'])
+    assert_series_equal(result, expected)
+    result = s.drop('one')
+    assert_series_equal(result, expected)
+
+    # single string/tuple-like
+    s = Series(range(3), index=list('abc'))
+    pytest.raises(KeyError, s.drop, 'bc')
+    pytest.raises(KeyError, s.drop, ('a',))
+
+    # errors='ignore'
+    s = Series(range(3), index=list('abc'))
+    result = s.drop('bc', errors='ignore')
+    assert_series_equal(result, s)
+    result = s.drop(['a', 'd'], errors='ignore')
+    expected = s.iloc[1:]
+    assert_series_equal(result, expected)
+
+    # bad axis
+    pytest.raises(ValueError, s.drop, 'one', axis='columns')
+
+    # GH 8522
+    s = Series([2, 3], index=[True, False])
+    assert s.index.is_object()
+    result = s.drop(True)
+    expected = Series([3], index=[False])
+    assert_series_equal(result, expected)
+
+    # GH 16877
+    s = Series([2, 3], index=[0, 1])
+    with tm.assert_raises_regex(KeyError, 'not contained in axis'):
+        s.drop([False, True])

--- a/pandas/tests/series/indexing/test_boolean.py
+++ b/pandas/tests/series/indexing/test_boolean.py
@@ -283,34 +283,30 @@ def test_where_error():
                   [])
 
 
-def test_where_array_like():
+@pytest.mark.parametrize('klass', [list, tuple, np.array, Series])
+def test_where_array_like(klass):
     # see gh-15414
     s = Series([1, 2, 3])
     cond = [False, True, True]
     expected = Series([np.nan, 2, 3])
-    klasses = [list, tuple, np.array, Series]
 
-    for klass in klasses:
-        result = s.where(klass(cond))
-        assert_series_equal(result, expected)
+    result = s.where(klass(cond))
+    assert_series_equal(result, expected)
 
 
-def test_where_invalid_input():
+@pytest.mark.parametrize('cond', [
+    [1, 0, 1],
+    Series([2, 5, 7]),
+    ["True", "False", "True"],
+    [Timestamp("2017-01-01"), pd.NaT, Timestamp("2017-01-02")]
+])
+def test_where_invalid_input(cond):
     # see gh-15414: only boolean arrays accepted
     s = Series([1, 2, 3])
     msg = "Boolean array expected for the condition"
 
-    conds = [
-        [1, 0, 1],
-        Series([2, 5, 7]),
-        ["True", "False", "True"],
-        [Timestamp("2017-01-01"),
-         pd.NaT, Timestamp("2017-01-02")]
-    ]
-
-    for cond in conds:
-        with tm.assert_raises_regex(ValueError, msg):
-            s.where(cond)
+    with tm.assert_raises_regex(ValueError, msg):
+        s.where(cond)
 
     msg = "Array conditional must be same shape as self"
     with tm.assert_raises_regex(ValueError, msg):
@@ -403,37 +399,43 @@ def test_where_setitem_invalid():
     assert_series_equal(s, expected)
 
 
-def test_where_broadcast():
-    # Test a variety of differently sized series
-    for size in range(2, 6):
-        # Test a variety of boolean indices
-        for selection in [
-            # First element should be set
-            np.resize([True, False, False, False, False], size),
-            # Set alternating elements]
-            np.resize([True, False], size),
-            # No element should be set
-            np.resize([False], size)
-        ]:
+@pytest.mark.parametrize('size', range(2, 6))
+@pytest.mark.parametrize('mask', [
+    [True, False, False, False, False],
+    [True, False],
+    [False]
+])
+@pytest.mark.parametrize('item', [
+    2.0, np.nan, np.finfo(np.float).max, np.finfo(np.float).min
+])
+# Test numpy arrays, lists and tuples as the input to be
+# broadcast
+@pytest.mark.parametrize('box', [
+    lambda x: np.array([x]),
+    lambda x: [x],
+    lambda x: (x,)
+])
+def test_broadcast(size, mask, item, box):
+    selection = np.resize(mask, size)
 
-            # Test a variety of different numbers as content
-            for item in [2.0, np.nan, np.finfo(np.float).max,
-                         np.finfo(np.float).min]:
-                # Test numpy arrays, lists and tuples as the input to be
-                # broadcast
-                for arr in [np.array([item]), [item], (item,)]:
-                    data = np.arange(size, dtype=float)
-                    s = Series(data)
-                    s[selection] = arr
-                    # Construct the expected series by taking the source
-                    # data or item based on the selection
-                    expected = Series([item if use_item else data[
-                        i] for i, use_item in enumerate(selection)])
-                    assert_series_equal(s, expected)
+    data = np.arange(size, dtype=float)
 
-                    s = Series(data)
-                    result = s.where(~selection, arr)
-                    assert_series_equal(result, expected)
+    # Construct the expected series by taking the source
+    # data or item based on the selection
+    expected = Series([item if use_item else data[
+        i] for i, use_item in enumerate(selection)])
+
+    s = Series(data)
+    s[selection] = box(item)
+    assert_series_equal(s, expected)
+
+    s = Series(data)
+    result = s.where(~selection, box(item))
+    assert_series_equal(result, expected)
+
+    s = Series(data)
+    result = s.mask(selection, box(item))
+    assert_series_equal(result, expected)
 
 
 def test_where_inplace():
@@ -585,29 +587,6 @@ def test_mask():
     result = s.mask(s > 2, np.nan)
     expected = Series([1, 2, np.nan, np.nan])
     assert_series_equal(result, expected)
-
-
-def test_mask_broadcast():
-    # GH 8801
-    # copied from test_where_broadcast
-    for size in range(2, 6):
-        for selection in [
-            # First element should be set
-            np.resize([True, False, False, False, False], size),
-            # Set alternating elements]
-            np.resize([True, False], size),
-            # No element should be set
-            np.resize([False], size)
-        ]:
-            for item in [2.0, np.nan, np.finfo(np.float).max,
-                         np.finfo(np.float).min]:
-                for arr in [np.array([item]), [item], (item,)]:
-                    data = np.arange(size, dtype=float)
-                    s = Series(data)
-                    result = s.mask(selection, arr)
-                    expected = Series([item if use_item else data[
-                        i] for i, use_item in enumerate(selection)])
-                    assert_series_equal(result, expected)
 
 
 def test_mask_inplace():

--- a/pandas/tests/series/indexing/test_callable.py
+++ b/pandas/tests/series/indexing/test_callable.py
@@ -1,0 +1,33 @@
+import pandas as pd
+import pandas.util.testing as tm
+
+
+def test_getitem_callable():
+    # GH 12533
+    s = pd.Series(4, index=list('ABCD'))
+    result = s[lambda x: 'A']
+    assert result == s.loc['A']
+
+    result = s[lambda x: ['A', 'B']]
+    tm.assert_series_equal(result, s.loc[['A', 'B']])
+
+    result = s[lambda x: [True, False, True, True]]
+    tm.assert_series_equal(result, s.iloc[[0, 2, 3]])
+
+
+def test_setitem_callable():
+    # GH 12533
+    s = pd.Series([1, 2, 3, 4], index=list('ABCD'))
+    s[lambda x: 'A'] = -1
+    tm.assert_series_equal(s, pd.Series([-1, 2, 3, 4], index=list('ABCD')))
+
+
+def test_setitem_other_callable():
+    # GH 13299
+    inc = lambda x: x + 1
+
+    s = pd.Series([1, 2, -1, 4])
+    s[s < 0] = inc
+
+    expected = pd.Series([1, 2, inc, 4])
+    tm.assert_series_equal(s, expected)

--- a/pandas/tests/series/indexing/test_datetime.py
+++ b/pandas/tests/series/indexing/test_datetime.py
@@ -700,11 +700,11 @@ def test_nat_operations():
     assert s.max() == exp
 
 
-def test_round_nat():
+@pytest.mark.parametrize('method', ["round", "floor", "ceil"])
+@pytest.mark.parametrize('freq', ["s", "5s", "min", "5min", "h", "5h"])
+def test_round_nat(method, freq):
     # GH14940
     s = Series([pd.NaT])
     expected = Series(pd.NaT)
-    for method in ["round", "floor", "ceil"]:
-        round_method = getattr(s.dt, method)
-        for freq in ["s", "5s", "min", "5min", "h", "5h"]:
-            assert_series_equal(round_method(freq), expected)
+    round_method = getattr(s.dt, method)
+    assert_series_equal(round_method(freq), expected)

--- a/pandas/tests/series/indexing/test_iloc.py
+++ b/pandas/tests/series/indexing/test_iloc.py
@@ -9,8 +9,6 @@ from pandas.compat import lrange, range
 from pandas.util.testing import (assert_series_equal,
                                  assert_almost_equal)
 
-JOIN_TYPES = ['inner', 'outer', 'left', 'right']
-
 
 def test_iloc():
     s = Series(np.random.randn(10), index=lrange(0, 20, 2))

--- a/pandas/tests/series/indexing/test_indexing.py
+++ b/pandas/tests/series/indexing/test_indexing.py
@@ -21,7 +21,58 @@ from pandas.util.testing import (assert_series_equal)
 import pandas.util.testing as tm
 
 
-JOIN_TYPES = ['inner', 'outer', 'left', 'right']
+def test_basic_indexing():
+    s = Series(np.random.randn(5), index=['a', 'b', 'a', 'a', 'b'])
+
+    pytest.raises(IndexError, s.__getitem__, 5)
+    pytest.raises(IndexError, s.__setitem__, 5, 0)
+
+    pytest.raises(KeyError, s.__getitem__, 'c')
+
+    s = s.sort_index()
+
+    pytest.raises(IndexError, s.__getitem__, 5)
+    pytest.raises(IndexError, s.__setitem__, 5, 0)
+
+
+def test_basic_getitem_with_labels(test_data):
+    indices = test_data.ts.index[[5, 10, 15]]
+
+    result = test_data.ts[indices]
+    expected = test_data.ts.reindex(indices)
+    assert_series_equal(result, expected)
+
+    result = test_data.ts[indices[0]:indices[2]]
+    expected = test_data.ts.loc[indices[0]:indices[2]]
+    assert_series_equal(result, expected)
+
+    # integer indexes, be careful
+    s = Series(np.random.randn(10), index=lrange(0, 20, 2))
+    inds = [0, 2, 5, 7, 8]
+    arr_inds = np.array([0, 2, 5, 7, 8])
+    with tm.assert_produces_warning(FutureWarning,
+                                    check_stacklevel=False):
+        result = s[inds]
+    expected = s.reindex(inds)
+    assert_series_equal(result, expected)
+
+    with tm.assert_produces_warning(FutureWarning,
+                                    check_stacklevel=False):
+        result = s[arr_inds]
+    expected = s.reindex(arr_inds)
+    assert_series_equal(result, expected)
+
+    # GH12089
+    # with tz for values
+    s = Series(pd.date_range("2011-01-01", periods=3, tz="US/Eastern"),
+               index=['a', 'b', 'c'])
+    expected = Timestamp('2011-01-01', tz='US/Eastern')
+    result = s.loc['a']
+    assert result == expected
+    result = s.iloc[0]
+    assert result == expected
+    result = s['a']
+    assert result == expected
 
 
 def test_getitem_setitem_ellipsis():
@@ -34,18 +85,6 @@ def test_getitem_setitem_ellipsis():
 
     s[...] = 5
     assert (result == 5).all()
-
-
-def test_pop():
-    # GH 6600
-    df = DataFrame({'A': 0, 'B': np.arange(5, dtype='int64'), 'C': 0, })
-    k = df.iloc[4]
-
-    result = k.pop('B')
-    assert result == 4
-
-    expected = Series([0, 0], index=['A', 'C'], name=4)
-    assert_series_equal(k, expected)
 
 
 def test_getitem_get(test_data):
@@ -73,11 +112,6 @@ def test_getitem_get(test_data):
     for s in [Series(), Series(index=list('abc'))]:
         result = s.get(None)
         assert result is None
-
-
-def test_getitem_int64(test_data):
-    idx = np.int64(5)
-    assert test_data.ts[idx] == test_data.ts[5]
 
 
 def test_getitem_fancy(test_data):
@@ -199,26 +233,6 @@ def test_getitem_dups():
     assert_series_equal(result, expected)
 
 
-def test_getitem_dataframe():
-    rng = list(range(10))
-    s = pd.Series(10, index=rng)
-    df = pd.DataFrame(rng, index=rng)
-    pytest.raises(TypeError, s.__getitem__, df > 5)
-
-
-def test_getitem_callable():
-    # GH 12533
-    s = pd.Series(4, index=list('ABCD'))
-    result = s[lambda x: 'A']
-    assert result == s.loc['A']
-
-    result = s[lambda x: ['A', 'B']]
-    tm.assert_series_equal(result, s.loc[['A', 'B']])
-
-    result = s[lambda x: [True, False, True, True]]
-    tm.assert_series_equal(result, s.iloc[[0, 2, 3]])
-
-
 def test_setitem_ambiguous_keyerror():
     s = Series(lrange(10), index=lrange(0, 20, 2))
 
@@ -234,48 +248,11 @@ def test_setitem_ambiguous_keyerror():
     assert_series_equal(s2, expected)
 
 
-def test_setitem_callable():
-    # GH 12533
-    s = pd.Series([1, 2, 3, 4], index=list('ABCD'))
-    s[lambda x: 'A'] = -1
-    tm.assert_series_equal(s, pd.Series([-1, 2, 3, 4], index=list('ABCD')))
-
-
-def test_setitem_other_callable():
-    # GH 13299
-    inc = lambda x: x + 1
-
-    s = pd.Series([1, 2, -1, 4])
-    s[s < 0] = inc
-
-    expected = pd.Series([1, 2, inc, 4])
-    tm.assert_series_equal(s, expected)
-
-
-def test_slice(test_data):
-    numSlice = test_data.series[10:20]
-    numSliceEnd = test_data.series[-10:]
-    objSlice = test_data.objSeries[10:20]
-
-    assert test_data.series.index[9] not in numSlice.index
-    assert test_data.objSeries.index[9] not in objSlice.index
-
-    assert len(numSlice) == len(numSlice.index)
-    assert test_data.series[numSlice.index[0]] == numSlice[numSlice.index[0]]
-
-    assert numSlice.index[1] == test_data.series.index[11]
-    assert tm.equalContents(numSliceEnd, np.array(test_data.series)[-10:])
-
-    # Test return view.
-    sl = test_data.series[10:20]
-    sl[:] = 0
-
-    assert (test_data.series[10:20] == 0).all()
-
-
-def test_slice_can_reorder_not_uniquely_indexed():
-    s = Series(1, index=['a', 'a', 'b', 'b', 'c'])
-    s[::-1]  # it works!
+def test_getitem_dataframe():
+    rng = list(range(10))
+    s = pd.Series(10, index=rng)
+    df = pd.DataFrame(rng, index=rng)
+    pytest.raises(TypeError, s.__getitem__, df > 5)
 
 
 def test_setitem(test_data):
@@ -389,86 +366,46 @@ def test_basic_getitem_setitem_corner(test_data):
                   [5, slice(None, None)], 2)
 
 
-def test_basic_getitem_with_labels(test_data):
-    indices = test_data.ts.index[[5, 10, 15]]
+@pytest.mark.parametrize('tz', ['US/Eastern', 'UTC', 'Asia/Tokyo'])
+def test_setitem_with_tz(tz):
+    orig = pd.Series(pd.date_range('2016-01-01', freq='H', periods=3,
+                                   tz=tz))
+    assert orig.dtype == 'datetime64[ns, {0}]'.format(tz)
 
-    result = test_data.ts[indices]
-    expected = test_data.ts.reindex(indices)
-    assert_series_equal(result, expected)
+    # scalar
+    s = orig.copy()
+    s[1] = pd.Timestamp('2011-01-01', tz=tz)
+    exp = pd.Series([pd.Timestamp('2016-01-01 00:00', tz=tz),
+                     pd.Timestamp('2011-01-01 00:00', tz=tz),
+                     pd.Timestamp('2016-01-01 02:00', tz=tz)])
+    tm.assert_series_equal(s, exp)
 
-    result = test_data.ts[indices[0]:indices[2]]
-    expected = test_data.ts.loc[indices[0]:indices[2]]
-    assert_series_equal(result, expected)
+    s = orig.copy()
+    s.loc[1] = pd.Timestamp('2011-01-01', tz=tz)
+    tm.assert_series_equal(s, exp)
 
-    # integer indexes, be careful
-    s = Series(np.random.randn(10), index=lrange(0, 20, 2))
-    inds = [0, 2, 5, 7, 8]
-    arr_inds = np.array([0, 2, 5, 7, 8])
-    with tm.assert_produces_warning(FutureWarning,
-                                    check_stacklevel=False):
-        result = s[inds]
-    expected = s.reindex(inds)
-    assert_series_equal(result, expected)
+    s = orig.copy()
+    s.iloc[1] = pd.Timestamp('2011-01-01', tz=tz)
+    tm.assert_series_equal(s, exp)
 
-    with tm.assert_produces_warning(FutureWarning,
-                                    check_stacklevel=False):
-        result = s[arr_inds]
-    expected = s.reindex(arr_inds)
-    assert_series_equal(result, expected)
+    # vector
+    vals = pd.Series([pd.Timestamp('2011-01-01', tz=tz),
+                      pd.Timestamp('2012-01-01', tz=tz)], index=[1, 2])
+    assert vals.dtype == 'datetime64[ns, {0}]'.format(tz)
 
-    # GH12089
-    # with tz for values
-    s = Series(pd.date_range("2011-01-01", periods=3, tz="US/Eastern"),
-               index=['a', 'b', 'c'])
-    expected = Timestamp('2011-01-01', tz='US/Eastern')
-    result = s.loc['a']
-    assert result == expected
-    result = s.iloc[0]
-    assert result == expected
-    result = s['a']
-    assert result == expected
+    s[[1, 2]] = vals
+    exp = pd.Series([pd.Timestamp('2016-01-01 00:00', tz=tz),
+                     pd.Timestamp('2011-01-01 00:00', tz=tz),
+                     pd.Timestamp('2012-01-01 00:00', tz=tz)])
+    tm.assert_series_equal(s, exp)
 
+    s = orig.copy()
+    s.loc[[1, 2]] = vals
+    tm.assert_series_equal(s, exp)
 
-def test_setitem_with_tz():
-    for tz in ['US/Eastern', 'UTC', 'Asia/Tokyo']:
-        orig = pd.Series(pd.date_range('2016-01-01', freq='H', periods=3,
-                                       tz=tz))
-        assert orig.dtype == 'datetime64[ns, {0}]'.format(tz)
-
-        # scalar
-        s = orig.copy()
-        s[1] = pd.Timestamp('2011-01-01', tz=tz)
-        exp = pd.Series([pd.Timestamp('2016-01-01 00:00', tz=tz),
-                         pd.Timestamp('2011-01-01 00:00', tz=tz),
-                         pd.Timestamp('2016-01-01 02:00', tz=tz)])
-        tm.assert_series_equal(s, exp)
-
-        s = orig.copy()
-        s.loc[1] = pd.Timestamp('2011-01-01', tz=tz)
-        tm.assert_series_equal(s, exp)
-
-        s = orig.copy()
-        s.iloc[1] = pd.Timestamp('2011-01-01', tz=tz)
-        tm.assert_series_equal(s, exp)
-
-        # vector
-        vals = pd.Series([pd.Timestamp('2011-01-01', tz=tz),
-                          pd.Timestamp('2012-01-01', tz=tz)], index=[1, 2])
-        assert vals.dtype == 'datetime64[ns, {0}]'.format(tz)
-
-        s[[1, 2]] = vals
-        exp = pd.Series([pd.Timestamp('2016-01-01 00:00', tz=tz),
-                         pd.Timestamp('2011-01-01 00:00', tz=tz),
-                         pd.Timestamp('2012-01-01 00:00', tz=tz)])
-        tm.assert_series_equal(s, exp)
-
-        s = orig.copy()
-        s.loc[[1, 2]] = vals
-        tm.assert_series_equal(s, exp)
-
-        s = orig.copy()
-        s.iloc[[1, 2]] = vals
-        tm.assert_series_equal(s, exp)
+    s = orig.copy()
+    s.iloc[[1, 2]] = vals
+    tm.assert_series_equal(s, exp)
 
 
 def test_setitem_with_tz_dst():
@@ -550,22 +487,30 @@ def test_categorial_assigning_ops():
     tm.assert_series_equal(s, exp)
 
 
-def test_take():
-    s = Series([-1, 5, 6, 2, 4])
+def test_slice(test_data):
+    numSlice = test_data.series[10:20]
+    numSliceEnd = test_data.series[-10:]
+    objSlice = test_data.objSeries[10:20]
 
-    actual = s.take([1, 3, 4])
-    expected = Series([5, 2, 4], index=[1, 3, 4])
-    tm.assert_series_equal(actual, expected)
+    assert test_data.series.index[9] not in numSlice.index
+    assert test_data.objSeries.index[9] not in objSlice.index
 
-    actual = s.take([-1, 3, 4])
-    expected = Series([4, 2, 4], index=[4, 3, 4])
-    tm.assert_series_equal(actual, expected)
+    assert len(numSlice) == len(numSlice.index)
+    assert test_data.series[numSlice.index[0]] == numSlice[numSlice.index[0]]
 
-    pytest.raises(IndexError, s.take, [1, 10])
-    pytest.raises(IndexError, s.take, [2, 5])
+    assert numSlice.index[1] == test_data.series.index[11]
+    assert tm.equalContents(numSliceEnd, np.array(test_data.series)[-10:])
 
-    with tm.assert_produces_warning(FutureWarning):
-        s.take([-1, 3, 4], convert=False)
+    # Test return view.
+    sl = test_data.series[10:20]
+    sl[:] = 0
+
+    assert (test_data.series[10:20] == 0).all()
+
+
+def test_slice_can_reorder_not_uniquely_indexed():
+    s = Series(1, index=['a', 'a', 'b', 'b', 'c'])
+    s[::-1]  # it works!
 
 
 def test_ix_setitem(test_data):
@@ -613,20 +558,6 @@ def test_setitem_na():
     s = Series(np.arange(10))
     s[:5] = np.nan
     assert_series_equal(s, expected)
-
-
-def test_basic_indexing():
-    s = Series(np.random.randn(5), index=['a', 'b', 'a', 'a', 'b'])
-
-    pytest.raises(IndexError, s.__getitem__, 5)
-    pytest.raises(IndexError, s.__setitem__, 5, 0)
-
-    pytest.raises(KeyError, s.__getitem__, 'c')
-
-    s = s.sort_index()
-
-    pytest.raises(IndexError, s.__getitem__, 5)
-    pytest.raises(IndexError, s.__setitem__, 5, 0)
 
 
 def test_timedelta_assignment():
@@ -700,73 +631,6 @@ def test_preserve_refs(test_data):
     assert not np.isnan(test_data.ts[10])
 
 
-def test_drop():
-    # unique
-    s = Series([1, 2], index=['one', 'two'])
-    expected = Series([1], index=['one'])
-    result = s.drop(['two'])
-    assert_series_equal(result, expected)
-    result = s.drop('two', axis='rows')
-    assert_series_equal(result, expected)
-
-    # non-unique
-    # GH 5248
-    s = Series([1, 1, 2], index=['one', 'two', 'one'])
-    expected = Series([1, 2], index=['one', 'one'])
-    result = s.drop(['two'], axis=0)
-    assert_series_equal(result, expected)
-    result = s.drop('two')
-    assert_series_equal(result, expected)
-
-    expected = Series([1], index=['two'])
-    result = s.drop(['one'])
-    assert_series_equal(result, expected)
-    result = s.drop('one')
-    assert_series_equal(result, expected)
-
-    # single string/tuple-like
-    s = Series(range(3), index=list('abc'))
-    pytest.raises(KeyError, s.drop, 'bc')
-    pytest.raises(KeyError, s.drop, ('a',))
-
-    # errors='ignore'
-    s = Series(range(3), index=list('abc'))
-    result = s.drop('bc', errors='ignore')
-    assert_series_equal(result, s)
-    result = s.drop(['a', 'd'], errors='ignore')
-    expected = s.iloc[1:]
-    assert_series_equal(result, expected)
-
-    # bad axis
-    pytest.raises(ValueError, s.drop, 'one', axis='columns')
-
-    # GH 8522
-    s = Series([2, 3], index=[True, False])
-    assert s.index.is_object()
-    result = s.drop(True)
-    expected = Series([3], index=[False])
-    assert_series_equal(result, expected)
-
-    # GH 16877
-    s = Series([2, 3], index=[0, 1])
-    with tm.assert_raises_regex(KeyError, 'not contained in axis'):
-        s.drop([False, True])
-
-
-def test_select(test_data):
-    # deprecated: gh-12410
-    with tm.assert_produces_warning(FutureWarning,
-                                    check_stacklevel=False):
-        n = len(test_data.ts)
-        result = test_data.ts.select(lambda x: x >= test_data.ts.index[n // 2])
-        expected = test_data.ts.reindex(test_data.ts.index[n // 2:])
-        assert_series_equal(result, expected)
-
-        result = test_data.ts.select(lambda x: x.weekday() == 2)
-        expected = test_data.ts[test_data.ts.index.weekday == 2]
-        assert_series_equal(result, expected)
-
-
 def test_cast_on_putmask():
     # GH 2746
 
@@ -797,13 +661,6 @@ def test_type_promote_putmask():
     s2 = s[mask]
     s[mask] = s2
     assert_series_equal(s, Series([0, 'foo', 'bar', 0]))
-
-
-def test_head_tail(test_data):
-    assert_series_equal(test_data.series.head(), test_data.series[:5])
-    assert_series_equal(test_data.series.head(0), test_data.series[0:0])
-    assert_series_equal(test_data.series.tail(), test_data.series[-5:])
-    assert_series_equal(test_data.series.tail(0), test_data.series[0:0])
 
 
 def test_multilevel_preserve_name():
@@ -845,3 +702,59 @@ def test_setitem_slice_into_readonly_backing_data():
         series[1:3] = 1
 
     assert not array.any()
+
+
+"""
+miscellaneous methods
+"""
+
+
+def test_select(test_data):
+    # deprecated: gh-12410
+    with tm.assert_produces_warning(FutureWarning,
+                                    check_stacklevel=False):
+        n = len(test_data.ts)
+        result = test_data.ts.select(lambda x: x >= test_data.ts.index[n // 2])
+        expected = test_data.ts.reindex(test_data.ts.index[n // 2:])
+        assert_series_equal(result, expected)
+
+        result = test_data.ts.select(lambda x: x.weekday() == 2)
+        expected = test_data.ts[test_data.ts.index.weekday == 2]
+        assert_series_equal(result, expected)
+
+
+def test_pop():
+    # GH 6600
+    df = DataFrame({'A': 0, 'B': np.arange(5, dtype='int64'), 'C': 0, })
+    k = df.iloc[4]
+
+    result = k.pop('B')
+    assert result == 4
+
+    expected = Series([0, 0], index=['A', 'C'], name=4)
+    assert_series_equal(k, expected)
+
+
+def test_take():
+    s = Series([-1, 5, 6, 2, 4])
+
+    actual = s.take([1, 3, 4])
+    expected = Series([5, 2, 4], index=[1, 3, 4])
+    tm.assert_series_equal(actual, expected)
+
+    actual = s.take([-1, 3, 4])
+    expected = Series([4, 2, 4], index=[4, 3, 4])
+    tm.assert_series_equal(actual, expected)
+
+    pytest.raises(IndexError, s.take, [1, 10])
+    pytest.raises(IndexError, s.take, [2, 5])
+
+    with tm.assert_produces_warning(FutureWarning):
+        s.take([-1, 3, 4], convert=False)
+
+
+def test_head_tail(test_data):
+    assert_series_equal(test_data.series.head(), test_data.series[:5])
+    assert_series_equal(test_data.series.head(0), test_data.series[0:0])
+    assert_series_equal(test_data.series.tail(), test_data.series[-5:])
+    assert_series_equal(test_data.series.tail(0), test_data.series[0:0])

--- a/pandas/tests/series/indexing/test_loc.py
+++ b/pandas/tests/series/indexing/test_loc.py
@@ -12,9 +12,6 @@ from pandas.compat import lrange
 from pandas.util.testing import (assert_series_equal)
 
 
-JOIN_TYPES = ['inner', 'outer', 'left', 'right']
-
-
 def test_loc_getitem(test_data):
     inds = test_data.series.index[[3, 4, 7]]
     assert_series_equal(

--- a/pandas/tests/series/indexing/test_numeric.py
+++ b/pandas/tests/series/indexing/test_numeric.py
@@ -229,3 +229,8 @@ def test_int_indexing():
     pytest.raises(KeyError, s.__getitem__, 5)
 
     pytest.raises(KeyError, s.__getitem__, 'c')
+
+
+def test_getitem_int64(test_data):
+    idx = np.int64(5)
+    assert test_data.ts[idx] == test_data.ts[5]


### PR DESCRIPTION
- [ ] closes #xxxx
- [ ] tests added / passed
- [X] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

```
################################################################################
############################ Docstring (pandas.cut) ############################
################################################################################

Return indices of half-open `bins` to which each value of `x` belongs.

Use `cut` when you need to segment and sort data values into bins or
buckets of data. This function is also useful for going from a continuous
variable to a categorical variable. For example, `cut` could convert ages
to groups of age ranges.

Parameters
----------
x : array-like
    Input array to be binned. It has to be 1-dimensional.
bins : int, sequence of scalars, or pandas.IntervalIndex
    If `bins` is an int, defines the number of equal-width bins in the
    range of `x`. The range of `x` is extended by .1% on each side to
    include the min or max values of `x`.
    If `bins` is a sequence, defines the bin edges allowing for
    non-uniform bin width. No extension of the range of `x` is done.
right : bool, optional, default 'True'
    Indicates whether the `bins` include the rightmost edge or not. If
    `right == True` (the default), then the `bins` [1,2,3,4] indicate
    (1,2], (2,3], (3,4].
labels : array or bool, optional
    Used as labels for the resulting `bins`. Must be of the same length as
    the resulting `bins`. If False, returns only integer indicators of the
    `bins`.
retbins : bool, optional, default 'False'
    Whether to return the `bins` or not. Useful when `bins` is provided
    as a scalar.
precision : int, optional, default '3'
    The precision at which to store and display the `bins` labels.
include_lowest : bool, optional, default 'False'
    Whether the first interval should be left-inclusive or not.

Returns
-------
out : pandas.Categorical or Series, or array of int if `labels` is 'False'
    The return type depends on the input.
    If the input is a Series, a Series of type category is returned.
    Else - pandas.Categorical is returned. `Bins` are represented as
    categories when categorical data is returned.
bins : numpy.ndarray of floats
    Returned only if `retbins` is 'True'.

See Also
--------
qcut : Discretize variable into equal-sized buckets based on rank
    or based on sample quantiles.
pandas.Categorical : Represents a categorical variable in
    classic R / S-plus fashion.
Series : One-dimensional ndarray with axis labels (including time series).
pandas.IntervalIndex : Immutable Index implementing an ordered,
    sliceable set. IntervalIndex represents an Index of intervals that
    are all closed on the same side.

Notes
-----
Any NA values will be NA in the result. Out of bounds values will be NA in
the resulting pandas.Categorical object.

Examples
--------
>>> pd.cut(np.array([.2, 1.4, 2.5, 6.2, 9.7, 2.1]), 3, retbins=True)
... # doctest: +ELLIPSIS
([(0.19, 3.367], (0.19, 3.367], (0.19, 3.367], (3.367, 6.533], ...
Categories (3, interval[float64]): [(0.19, 3.367] < (3.367, 6.533] ...

>>> pd.cut(np.array([.2, 1.4, 2.5, 6.2, 9.7, 2.1]),
...        3, labels=["good", "medium", "bad"])
... # doctest: +SKIP
[good, good, good, medium, bad, good]
Categories (3, object): [good < medium < bad]

>>> pd.cut(np.ones(5), 4, labels=False)
array([1, 1, 1, 1, 1], dtype=int64)

################################################################################
################################## Validation ##################################
################################################################################

Docstring for "pandas.cut" correct. :)
```