### PR TITLE
DOC: Improved the docstring of errors.ParserWarning

### DIFF
--- a/pandas/errors/__init__.py
+++ b/pandas/errors/__init__.py
@@ -84,9 +84,7 @@ class ParserWarning(Warning):
     ...           1;1,8
     ...           1;2,1'''
     >>> df = pd.read_csv(io.StringIO(csv), sep='[;,]')
-    Traceback (most recent call last):
-    ...
-    ParserWarning: Falling back to the 'python' engine...
+    ... # ParserWarning: Falling back to the 'python' engine...
 
     Adding `engine='python'` to `pd.read_csv` removes the Warning:
 

--- a/pandas/errors/__init__.py
+++ b/pandas/errors/__init__.py
@@ -53,10 +53,37 @@ class EmptyDataError(ValueError):
 
 class ParserWarning(Warning):
     """
-    Warning that is raised in `pd.read_csv` whenever it is necessary
-    to change parsers (generally from 'c' to 'python') contrary to the
-    one specified by the user due to lack of support or functionality for
-    parsing particular attributes of a CSV file with the requested engine.
+    Warning raised in `pd.read_csv` and `pd.read_table` when it is
+    necessary to change parsers, generally from 'c' to 'python'.
+    
+    It happens due to lack of support or functionality for parsing
+    particular attributes of a CSV file with the requested engine.
+
+    Currently, C-unsupported options include the following parameters:
+
+    1. `sep` other than a single character (e.g. regex separators)
+    2. `skipfooter` higher than 0
+    3. `sep=None` with `delim_whitespace=False`
+
+    The warning can be avoided by adding `engine='python'` as a parameter
+    in `pd.read_csv` and `pd.read_table` methods.
+
+    Examples
+    --------
+    Using a `sep` in `pd.read_csv` other than a single character:
+
+    >>> import io
+    >>> csv = u'''a;b;c
+    ...           1;1,8
+    ...           1;2,1'''
+    >>> df = pd.read_csv(io.StringIO(csv), sep='[;,]')
+    Traceback (most recent call last):
+    ...
+    ParserWarning: Falling back to the 'python' engine...
+
+    Adding `engine='python'` to `pd.read_csv` removes the Warning:
+
+    >>> df = pd.read_csv(io.StringIO(csv), sep='[;,]', engine='python')
     """
 
 

--- a/pandas/errors/__init__.py
+++ b/pandas/errors/__init__.py
@@ -55,20 +55,20 @@ class ParserWarning(Warning):
     """
     Warning raised when reading a file that doesn't use the default parser.
 
-    Thrown by `pd.read_csv` and `pd.read_table` when it is necessary to
-    change parsers, generally from 'c' to 'python'.
+    Raised by `pd.read_csv` and `pd.read_table` when it is necessary to change
+    parsers, generally from the default 'c' parser to 'python'.
 
-    It happens due to lack of support or functionality for parsing
-    particular attributes of a CSV file with the requested engine.
+    It happens due to a lack of support or functionality for parsing a
+    particular attribute of a CSV file with the requested engine.
 
-    Currently, C-unsupported options include the following parameters:
+    Currently, 'c' unsupported options include the following parameters:
 
     1. `sep` other than a single character (e.g. regex separators)
     2. `skipfooter` higher than 0
     3. `sep=None` with `delim_whitespace=False`
 
-    The warning can be avoided by adding `engine='python'` as a parameter
-    in `pd.read_csv` and `pd.read_table` methods.
+    The warning can be avoided by adding `engine='python'` as a parameter in
+    `pd.read_csv` and `pd.read_table` methods.
 
     See Also
     --------

--- a/pandas/errors/__init__.py
+++ b/pandas/errors/__init__.py
@@ -70,6 +70,11 @@ class ParserWarning(Warning):
     The warning can be avoided by adding `engine='python'` as a parameter
     in `pd.read_csv` and `pd.read_table` methods.
 
+    See Also
+    --------
+    pd.read_csv : Read CSV (comma-separated) file into DataFrame.
+    pd.read_table : Read general delimited file into DataFrame.
+
     Examples
     --------
     Using a `sep` in `pd.read_csv` other than a single character:

--- a/pandas/errors/__init__.py
+++ b/pandas/errors/__init__.py
@@ -53,7 +53,7 @@ class EmptyDataError(ValueError):
 
 class ParserWarning(Warning):
     """
-    Warning raised when reading a file that doesn't use the default parser.
+    Warning raised when reading a file that doesn't use the default 'c' parser.
 
     Raised by `pd.read_csv` and `pd.read_table` when it is necessary to change
     parsers, generally from the default 'c' parser to 'python'.

--- a/pandas/errors/__init__.py
+++ b/pandas/errors/__init__.py
@@ -55,8 +55,8 @@ class ParserWarning(Warning):
     """
     Warning raised when reading a file that doesn't use the default parser.
 
-    Thrown by `pd.read_csv` and `pd.read_table` when it is
-    necessary to change parsers, generally from 'c' to 'python'.
+    Thrown by `pd.read_csv` and `pd.read_table` when it is necessary to
+    change parsers, generally from 'c' to 'python'.
 
     It happens due to lack of support or functionality for parsing
     particular attributes of a CSV file with the requested engine.

--- a/pandas/errors/__init__.py
+++ b/pandas/errors/__init__.py
@@ -55,7 +55,7 @@ class ParserWarning(Warning):
     """
     Warning raised in `pd.read_csv` and `pd.read_table` when it is
     necessary to change parsers, generally from 'c' to 'python'.
-    
+
     It happens due to lack of support or functionality for parsing
     particular attributes of a CSV file with the requested engine.
 

--- a/pandas/errors/__init__.py
+++ b/pandas/errors/__init__.py
@@ -53,7 +53,9 @@ class EmptyDataError(ValueError):
 
 class ParserWarning(Warning):
     """
-    Warning raised in `pd.read_csv` and `pd.read_table` when it is
+    Warning raised when reading a file that doesn't use the default parser.
+
+    Thrown by `pd.read_csv` and `pd.read_table` when it is
     necessary to change parsers, generally from 'c' to 'python'.
 
     It happens due to lack of support or functionality for parsing


### PR DESCRIPTION
Checklist for the pandas documentation sprint (ignore this if you are doing
an unrelated PR):

- [X] PR title is "DOC: update the <your-function-or-method> docstring"
- [ ] The validation script passes: `scripts/validate_docstrings.py <your-function-or-method>`
- [X] The PEP8 style check passes: `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [X] The html version looks good: `python doc/make.py --single <your-function-or-method>`
- [X] It has been proofread on language by another sprint participant

Please include the output of the validation script below between the "```" ticks:

```
################################################################################
################### Docstring (pandas.errors.ParserWarning)  ###################
################################################################################

Warning raised when reading a file that doesn't use the default parser.

Thrown by `pd.read_csv` and `pd.read_table` when it is necessary to
change parsers, generally from 'c' to 'python'.

It happens due to lack of support or functionality for parsing
particular attributes of a CSV file with the requested engine.

Currently, C-unsupported options include the following parameters:

1. `sep` other than a single character (e.g. regex separators)
2. `skipfooter` higher than 0
3. `sep=None` with `delim_whitespace=False`

The warning can be avoided by adding `engine='python'` as a parameter
in `pd.read_csv` and `pd.read_table` methods.

See Also
--------
pd.read_csv : Read CSV (comma-separated) file into DataFrame.
pd.read_table : Read general delimited file into DataFrame.

Examples
--------
Using a `sep` in `pd.read_csv` other than a single character:

>>> import io
>>> csv = u'''a;b;c
...           1;1,8
...           1;2,1'''
>>> df = pd.read_csv(io.StringIO(csv), sep='[;,]')
Traceback (most recent call last):
...
ParserWarning: Falling back to the 'python' engine...

Adding `engine='python'` to `pd.read_csv` removes the Warning:

>>> df = pd.read_csv(io.StringIO(csv), sep='[;,]', engine='python')
scripts/validate_docstrings.py:1: ParserWarning: Falling back to the 'python' engine because the 'c' engine does not support regex separators (separators > 1 char and different from '\s+' are interpreted as regex); you can avoid this warning by specifying engine='python'.
  #!/usr/bin/env python

################################################################################
################################## Validation ##################################
################################################################################

Errors found:
        No returns section found
        Examples do not pass tests

################################################################################
################################### Doctests ###################################
################################################################################

**********************************************************************
Line 32, in pandas.errors.ParserWarning
Failed example:
    df = pd.read_csv(io.StringIO(csv), sep='[;,]')
Expected:
    Traceback (most recent call last):
    ...
    ParserWarning: Falling back to the 'python' engine...
Got nothing

```


I am documenting a Warning and I could not find a better way to display the warning in the html example other than using a "Traceback (most recent call last):" followed by "ParserWarning: Falling back to the 'python' engine..." in the docstring.

It also says that it found errors about "No returns sections found". On what I understood this is not relevant to the docstring in hand.

