### PR TITLE
COMPAT: Matplotlib 2.2 compatability

### DIFF
--- a/doc/source/whatsnew/v0.23.0.txt
+++ b/doc/source/whatsnew/v0.23.0.txt
@@ -343,6 +343,7 @@ Other Enhancements
 - :meth:`Timestamp.day_name` and :meth:`DatetimeIndex.day_name` are now available to return day names with a specified locale (:issue:`12806`)
 - :meth:`DataFrame.to_sql` now performs a multivalue insert if the underlying connection supports itk rather than inserting row by row.
   ``SQLAlchemy`` dialects supporting multivalue inserts include: ``mysql``, ``postgresql``, ``sqlite`` and any dialect with ``supports_multivalues_insert``. (:issue:`14315`, :issue:`8953`)
+- Compatability with matplotlib 2.2
 
 .. _whatsnew_0230.api_breaking:
 

--- a/pandas/plotting/_compat.py
+++ b/pandas/plotting/_compat.py
@@ -1,76 +1,30 @@
 # being a bit too dynamic
 # pylint: disable=E1101
 from __future__ import division
+import operator
 
 from distutils.version import LooseVersion
 
 
-def _mpl_le_1_2_1():
-    try:
-        import matplotlib as mpl
-        return (LooseVersion(mpl.__version__) <= LooseVersion('1.2.1') and
+def _mpl_version(version, op):
+    def inner():
+        try:
+            import matplotlib as mpl
+        except ImportError:
+            return False
+        return (op(LooseVersion(mpl.__version__), LooseVersion(version)) and
                 str(mpl.__version__)[0] != '0')
-    except ImportError:
-        return False
 
+    return inner
 
-def _mpl_ge_1_3_1():
-    try:
-        import matplotlib
-        # The or v[0] == '0' is because their versioneer is
-        # messed up on dev
-        return (LooseVersion(matplotlib.__version__) >=
-                LooseVersion('1.3.1') or
-                str(matplotlib.__version__)[0] == '0')
-    except ImportError:
-        return False
-
-
-def _mpl_ge_1_4_0():
-    try:
-        import matplotlib
-        return (LooseVersion(matplotlib.__version__) >= LooseVersion('1.4') or
-                str(matplotlib.__version__)[0] == '0')
-    except ImportError:
-        return False
-
-
-def _mpl_ge_1_5_0():
-    try:
-        import matplotlib
-        return (LooseVersion(matplotlib.__version__) >= LooseVersion('1.5') or
-                str(matplotlib.__version__)[0] == '0')
-    except ImportError:
-        return False
-
-
-def _mpl_ge_2_0_0():
-    try:
-        import matplotlib
-        return LooseVersion(matplotlib.__version__) >= LooseVersion('2.0')
-    except ImportError:
-        return False
-
-
-def _mpl_le_2_0_0():
-    try:
-        import matplotlib
-        return matplotlib.compare_versions('2.0.0', matplotlib.__version__)
-    except ImportError:
-        return False
-
-
-def _mpl_ge_2_0_1():
-    try:
-        import matplotlib
-        return LooseVersion(matplotlib.__version__) >= LooseVersion('2.0.1')
-    except ImportError:
-        return False
-
-
-def _mpl_ge_2_1_0():
-    try:
-        import matplotlib
-        return LooseVersion(matplotlib.__version__) >= LooseVersion('2.1')
-    except ImportError:
-        return False
+_mpl_ge_1_2_1 = _mpl_version('1.2.1', operator.ge)
+_mpl_le_1_2_1 = _mpl_version('1.2.1', operator.le)
+_mpl_ge_1_3_1 = _mpl_version('1.3.1', operator.ge)
+_mpl_ge_1_4_0 = _mpl_version('1.4.0', operator.ge)
+_mpl_ge_1_4_1 = _mpl_version('1.4.1', operator.ge)
+_mpl_ge_1_5_0 = _mpl_version('1.5.0', operator.ge)
+_mpl_ge_2_0_0 = _mpl_version('2.0.0', operator.ge)
+_mpl_le_2_0_0 = _mpl_version('2.0.0', operator.le)
+_mpl_ge_2_0_1 = _mpl_version('2.0.1', operator.ge)
+_mpl_ge_2_1_0 = _mpl_version('2.1.0', operator.ge)
+_mpl_ge_2_2_0 = _mpl_version('2.2.0', operator.ge)

--- a/pandas/plotting/_compat.py
+++ b/pandas/plotting/_compat.py
@@ -17,6 +17,7 @@ def _mpl_version(version, op):
 
     return inner
 
+
 _mpl_ge_1_2_1 = _mpl_version('1.2.1', operator.ge)
 _mpl_le_1_2_1 = _mpl_version('1.2.1', operator.le)
 _mpl_ge_1_3_1 = _mpl_version('1.3.1', operator.ge)

--- a/pandas/tests/plotting/common.py
+++ b/pandas/tests/plotting/common.py
@@ -56,6 +56,7 @@ class TestPlotBase(object):
         self.mpl_ge_1_5_0 = plotting._compat._mpl_ge_1_5_0()
         self.mpl_ge_2_0_0 = plotting._compat._mpl_ge_2_0_0()
         self.mpl_ge_2_0_1 = plotting._compat._mpl_ge_2_0_1()
+        self.mpl_ge_2_2_0 = plotting._compat._mpl_ge_2_2_0()
 
         if self.mpl_ge_1_4_0:
             self.bp_n_objects = 7

--- a/pandas/tests/plotting/test_datetimelike.py
+++ b/pandas/tests/plotting/test_datetimelike.py
@@ -8,7 +8,7 @@ from pandas.compat import lrange, zip
 
 import numpy as np
 from pandas import Index, Series, DataFrame, NaT
-from pandas.compat import is_platform_mac, PY3
+from pandas.compat import PY3
 from pandas.core.indexes.datetimes import date_range, bdate_range
 from pandas.core.indexes.timedeltas import timedelta_range
 from pandas.tseries.offsets import DateOffset

--- a/pandas/tests/plotting/test_datetimelike.py
+++ b/pandas/tests/plotting/test_datetimelike.py
@@ -1357,13 +1357,13 @@ class TestTSPlot(TestPlotBase):
         values = [datetime(1677, 1, 1, 12), datetime(1677, 1, 2, 12)]
         ax.plot(values)
 
-    @td.xfail_if_mpl_2_2
-    @pytest.mark.skip(
-        is_platform_mac(),
-        "skip on mac for precision display issue on older mpl")
     def test_format_timedelta_ticks_narrow(self):
 
-        if self.mpl_ge_2_0_0:
+        if self.mpl_ge_2_2_0:
+            expected_labels = (['-1 days 23:59:59.999999998'] +
+                               ['00:00:00.0000000{:0>2d}'.format(2 * i)
+                                for i in range(6)])
+        elif self.mpl_ge_2_0_0:
             expected_labels = [''] + [
                 '00:00:00.00000000{:d}'.format(2 * i)
                 for i in range(5)] + ['']
@@ -1382,10 +1382,6 @@ class TestTSPlot(TestPlotBase):
         for l, l_expected in zip(labels, expected_labels):
             assert l.get_text() == l_expected
 
-    @td.xfail_if_mpl_2_2
-    @pytest.mark.skip(
-        is_platform_mac(),
-        "skip on mac for precision display issue on older mpl")
     def test_format_timedelta_ticks_wide(self):
 
         if self.mpl_ge_2_0_0:
@@ -1402,6 +1398,9 @@ class TestTSPlot(TestPlotBase):
                 '9 days 06:13:20',
                 ''
             ]
+            if self.mpl_ge_2_2_0:
+                expected_labels[0] = '-2 days 20:13:20'
+                expected_labels[-1] = '10 days 10:00:00'
         else:
             expected_labels = [
                 '00:00:00',


### PR DESCRIPTION
Summary of changes

- clean up version detection in compat
- Update timedelta tick formatting tests. Matplotlib fixed tick formatting of timedeltas so they're consistent with non-timedelta formatting.

closes #20031 