### PR TITLE
DOC: update the Series.memory_usage() docstring

### DIFF
--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -2705,9 +2705,9 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
         Parameters
         ----------
         index : bool, default True
-            Specifies whether to include memory usage of Series index.
+            Specifies whether to include the memory usage of the Series index.
         deep : bool, default False
-            Specifies whether to introspect the data deeply, interrogate
+            If True, introspect the data deeply by interrogating
             `object` dtypes for system-level memory consumption, and include
             it in the returned value.
 
@@ -2728,7 +2728,8 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
         >>> s.memory_usage()
         104
 
-        Not including the index gives the size of the rest of the data:
+        Not including the index gives the size of the rest of the data, which
+        is necessarily smaller:
 
         >>> s.memory_usage(index=False)
         24
@@ -2736,6 +2737,9 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
         The memory footprint of `object` values is ignored by default:
 
         >>> s = pd.Series(object())
+        >>> s
+        0    <object object at 0x118acf230>
+        dtype: object
         >>> s.memory_usage()
         88
         >>> s.memory_usage(deep=True)  # Footprint of object() included

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -2720,6 +2720,7 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
         --------
         numpy.ndarray.nbytes : Total bytes consumed by the elements of the
             array.
+        DataFrame.memory_usage : Bytes consumed by a DataFrame.
 
         Examples
         --------

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -2738,7 +2738,7 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
 
         >>> s = pd.Series(object())
         >>> s
-        0    <object object at 0x118acf230>
+        0    <object object at ...>
         dtype: object
         >>> s.memory_usage()
         88

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -2696,28 +2696,50 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
         return self.reindex(index=labels, **kwargs)
 
     def memory_usage(self, index=True, deep=False):
-        """Memory usage of the Series
+        """
+        Return the memory usage of the Series.
+
+        The memory usage can optionally include the contribution of
+        the index and of elements of `object` dtype.
 
         Parameters
         ----------
-        index : bool
-            Specifies whether to include memory usage of Series index
-        deep : bool
-            Introspect the data deeply, interrogate
-            `object` dtypes for system-level memory consumption
+        index : bool, default True
+            Specifies whether to include memory usage of Series index.
+        deep : bool, default False
+            Specifies whether to introspect the data deeply, interrogate
+            `object` dtypes for system-level memory consumption, and include
+            it in the returned value.
 
         Returns
         -------
-        scalar bytes of memory consumed
-
-        Notes
-        -----
-        Memory usage does not include memory consumed by elements that
-        are not components of the array if deep=False
+        int
+            Bytes of memory consumed.
 
         See Also
         --------
-        numpy.ndarray.nbytes
+        numpy.ndarray.nbytes : Total bytes consumed by the elements of the
+            array.
+
+        Examples
+        --------
+
+        >>> s = pd.Series(range(3))
+        >>> s.memory_usage()
+        104
+
+        Not including the index gives the size of the rest of the data:
+
+        >>> s.memory_usage(index=False)
+        24
+
+        The memory footprint of `object` values is ignored by default:
+
+        >>> s = pd.Series(object())
+        >>> s.memory_usage()
+        88
+        >>> s.memory_usage(deep=True)  # Footprint of object() included
+        104
         """
         v = super(Series, self).memory_usage(deep=deep)
         if index:

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -2737,15 +2737,13 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
 
         The memory footprint of `object` values is ignored by default:
 
-        >>> class MyClass: pass
-        >>> s = pd.Series(MyClass())
-        >>> s
-        0    <__main__.MyClass object at ...>
-        dtype: object
+        >>> s = pd.Series(["a", "b"])
+        >>> s.values
+        array(['a', 'b'], dtype=object)
         >>> s.memory_usage()
-        88
+        96
         >>> s.memory_usage(deep=True)
-        120
+        212
         """
         v = super(Series, self).memory_usage(deep=deep)
         if index:

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -2736,14 +2736,15 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
 
         The memory footprint of `object` values is ignored by default:
 
-        >>> s = pd.Series(object())
+        >>> class MyClass: pass
+        >>> s = pd.Series(MyClass())
         >>> s
-        0    <object object at ...>
+        0    <__main__.MyClass object at ...>
         dtype: object
         >>> s.memory_usage()
         88
-        >>> s.memory_usage(deep=True)  # Footprint of object() included
-        104
+        >>> s.memory_usage(deep=True)
+        120
         """
         v = super(Series, self).memory_usage(deep=deep)
         if index:


### PR DESCRIPTION
Checklist for the pandas documentation sprint (ignore this if you are doing
an unrelated PR):

- [X] PR title is "DOC: update the <your-function-or-method> docstring"
- [ ] The validation script passes: `scripts/validate_docstrings.py <your-function-or-method>`
- [X] The PEP8 style check passes: `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [X] The html version looks good: `python doc/make.py --single <your-function-or-method>`
- [ ] It has been proofread on language by another sprint participant

Output of the validation script:

```
################################################################################
#################### Docstring (pandas.Series.memory_usage) ####################
################################################################################

Return the memory usage of the Series.

The memory usage can optionally include the contribution of
the index and of elements of `object` dtype.

Parameters
----------
index : bool, default True
    Specifies whether to include the memory usage of the Series index.
deep : bool, default False
    If True, introspect the data deeply by interrogating
    `object` dtypes for system-level memory consumption, and include
    it in the returned value.

Returns
-------
int
    Bytes of memory consumed.

See Also
--------
numpy.ndarray.nbytes : Total bytes consumed by the elements of the
    array.

Examples
--------

>>> s = pd.Series(range(3))
>>> s.memory_usage()
104

Not including the index gives the size of the rest of the data, which
is necessarily smaller:

>>> s.memory_usage(index=False)
24

The memory footprint of `object` values is ignored by default:

>>> class MyClass: pass
>>> s = pd.Series(MyClass())
>>> s
0    <__main__.MyClass object at ...>
dtype: object
>>> s.memory_usage()
88
>>> s.memory_usage(deep=True)
120

################################################################################
################################## Validation ##################################
################################################################################

Errors found:
        Examples do not pass tests

################################################################################
################################### Doctests ###################################
################################################################################

**********************************************************************
Line 43, in pandas.Series.memory_usage
Failed example:
    s
Expected:
    0    <__main__.MyClass object at ...>
    dtype: object
Got:
    0    <__main__.MyClass object at 0x10f8076d8>
    dtype: object
```

Error due to following the recommendation about not giving non-reproducible addresses.