### PR TITLE
DOC:update the DatetimeIndex.tz_convert(tz)

### DIFF
--- a/pandas/core/indexes/datetimes.py
+++ b/pandas/core/indexes/datetimes.py
@@ -1904,11 +1904,12 @@ class DatetimeIndex(DatelikeOps, TimelikeOps, DatetimeIndexOpsMixin,
 
     def tz_convert(self, tz):
         """
-        A Method to Convert tz-aware DatetimeIndex from one time zone 
-		to another.
-		
-		When using DatetimeIndex providing with timezone this method 
-		converts tz-aware DatetimeIndex using pytz/dateutil.
+	A Method to Convert tz-aware DatetimeIndex from one time 
+	zone to another.
+
+	When using DatetimeIndex providing with timezone
+	this method converts tz-aware DatetimeIndex using
+	pytz/dateutil.
 
         Parameters
         ----------
@@ -1916,35 +1917,35 @@ class DatetimeIndex(DatelikeOps, TimelikeOps, DatetimeIndexOpsMixin,
             Time zone for time. Corresponding timestamps would be converted to
             time zone of the TimeSeries.
             None will remove timezone holding UTC time.
-        
+
         Returns
         -------
         normalized : DatetimeIndex
        
-        Raises
-        -------
-        TypeError
-            If DatetimeIndex is tz-naive.
+	Raises
+	-------
+	TypeError
+		If DatetimeIndex is tz-naive.
 
-	    See Also
-        --------
-        tz_localize : Localize tz-naive DatetimeIndex to given time zone 
-        (using pytz/dateutil), or remove timezone from tz-aware DatetimeIndex.
+	See Also
+	--------
+	tz_localize : Localize tz-naive DatetimeIndex to given time zone
+	(using pytz/dateutil), or remove timezone from tz-aware DatetimeIndex.
 
-	    Examples
-        --------
-	    >>> datetime=pd.Series(pd.date_range('20180301',periods=3))
-	    >>> datetime
-	    0   2018-03-01
-	    1   2018-03-02
-	    2   2018-03-03
-	    dtype: datetime64[ns]
+	Examples
+	--------
+	>>> datetime=pd.Series(pd.date_range('20180301',periods=3))
+	>>> datetime
+	0   2018-03-01
+	1   2018-03-02
+	2   2018-03-03
+	dtype: datetime64[ns]
 
-	    >>> datetime.dt.tz_localize('UTC').dt.tz_convert('US/Eastern')
-	    0   2018-02-28 19:00:00-05:00
-	    1   2018-03-01 19:00:00-05:00
-	    2   2018-03-02 19:00:00-05:00
-	    dtype: datetime64[ns, US/Eastern]
+	>>> datetime.dt.tz_localize('UTC').dt.tz_convert('US/Eastern')
+	0   2018-02-28 19:00:00-05:00
+	1   2018-03-01 19:00:00-05:00
+	2   2018-03-02 19:00:00-05:00
+	dtype: datetime64[ns, US/Eastern]
         """
         tz = timezones.maybe_get_tz(tz)
 

--- a/pandas/core/indexes/datetimes.py
+++ b/pandas/core/indexes/datetimes.py
@@ -1904,11 +1904,11 @@ class DatetimeIndex(DatelikeOps, TimelikeOps, DatetimeIndexOpsMixin,
 
     def tz_convert(self, tz):
         """
-        A Method to Convert tz-aware DatetimeIndex from one time zone to another.
-	
-	When using DatetimeIndex providing with timezone
-	this method converts tz-aware DatetimeIndex using
-        pytz/dateutil.
+        A Method to Convert tz-aware DatetimeIndex from one time zone 
+		to another.
+		
+		When using DatetimeIndex providing with timezone this method 
+		converts tz-aware DatetimeIndex using pytz/dateutil.
 
         Parameters
         ----------
@@ -1916,35 +1916,35 @@ class DatetimeIndex(DatelikeOps, TimelikeOps, DatetimeIndexOpsMixin,
             Time zone for time. Corresponding timestamps would be converted to
             time zone of the TimeSeries.
             None will remove timezone holding UTC time.
-
+        
         Returns
         -------
         normalized : DatetimeIndex
        
-	Raises
+        Raises
         -------
         TypeError
             If DatetimeIndex is tz-naive.
 
-	See Also
+	    See Also
         --------
-        tz_localize : Localize tz-naive DatetimeIndex to given time zone (using pytz/dateutil),
-	    or remove timezone from tz-aware DatetimeIndex.
+        tz_localize : Localize tz-naive DatetimeIndex to given time zone 
+        (using pytz/dateutil), or remove timezone from tz-aware DatetimeIndex.
 
-	Examples
+	    Examples
         --------
-	>>> datetime=pd.Series(pd.date_range('20180301',periods=3))
-	>>> datetime
-	0   2018-03-01
-	1   2018-03-02
-	2   2018-03-03
-	dtype: datetime64[ns]
+	    >>> datetime=pd.Series(pd.date_range('20180301',periods=3))
+	    >>> datetime
+	    0   2018-03-01
+	    1   2018-03-02
+	    2   2018-03-03
+	    dtype: datetime64[ns]
 
-	>>> datetime.dt.tz_localize('UTC').dt.tz_convert('US/Eastern')
-	0   2018-02-28 19:00:00-05:00
-	1   2018-03-01 19:00:00-05:00
-	2   2018-03-02 19:00:00-05:00
-	dtype: datetime64[ns, US/Eastern]
+	    >>> datetime.dt.tz_localize('UTC').dt.tz_convert('US/Eastern')
+	    0   2018-02-28 19:00:00-05:00
+	    1   2018-03-01 19:00:00-05:00
+	    2   2018-03-02 19:00:00-05:00
+	    dtype: datetime64[ns, US/Eastern]
         """
         tz = timezones.maybe_get_tz(tz)
 

--- a/pandas/core/indexes/datetimes.py
+++ b/pandas/core/indexes/datetimes.py
@@ -1904,8 +1904,11 @@ class DatetimeIndex(DatelikeOps, TimelikeOps, DatetimeIndexOpsMixin,
 
     def tz_convert(self, tz):
         """
-        Convert tz-aware DatetimeIndex from one time zone to another (using
-        pytz/dateutil)
+        A Method to Convert tz-aware DatetimeIndex from one time zone to another.
+	
+	When using DatetimeIndex providing with timezone
+	this method converts tz-aware DatetimeIndex using
+        pytz/dateutil.
 
         Parameters
         ----------
@@ -1917,11 +1920,31 @@ class DatetimeIndex(DatelikeOps, TimelikeOps, DatetimeIndexOpsMixin,
         Returns
         -------
         normalized : DatetimeIndex
-
-        Raises
-        ------
+       
+	Raises
+        -------
         TypeError
             If DatetimeIndex is tz-naive.
+
+	See Also
+        --------
+        tz_localize : Localize tz-naive DatetimeIndex to given time zone (using pytz/dateutil),
+	    or remove timezone from tz-aware DatetimeIndex.
+
+	Examples
+        --------
+	>>> datetime=pd.Series(pd.date_range('20180301',periods=3))
+	>>> datetime
+	0   2018-03-01
+	1   2018-03-02
+	2   2018-03-03
+	dtype: datetime64[ns]
+
+	>>> datetime.dt.tz_localize('UTC').dt.tz_convert('US/Eastern')
+	0   2018-02-28 19:00:00-05:00
+	1   2018-03-01 19:00:00-05:00
+	2   2018-03-02 19:00:00-05:00
+	dtype: datetime64[ns, US/Eastern]
         """
         tz = timezones.maybe_get_tz(tz)
 


### PR DESCRIPTION
Checklist for the pandas documentation sprint (ignore this if you are doing
an unrelated PR):

- [x] PR title is "DOC: update the <your-function-or-method> docstring"
- [x] The validation script passes: `scripts/validate_docstrings.py <your-function-or-method>`
- [ ] The PEP8 style check passes: `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] The html version looks good: `python doc/make.py --single <your-function-or-method>`
- [ ] It has been proofread on language by another sprint participant

Please include the output of the validation script below between the "```" ticks:

```
(pandas_dev) root@kalih:~/pythonpanda/pandas# python scripts/validate_docstrings.py pandas.DatetimeIndex.tz_convert

################################################################################
################# Docstring (pandas.DatetimeIndex.tz_convert)  #################
################################################################################

A Method to Convert tz-aware DatetimeIndex from one time zone to another.

When using DatetimeIndex providing with timezone
this method converts tz-aware DatetimeIndex using
pytz/dateutil.

Parameters
----------
tz : string, pytz.timezone, dateutil.tz.tzfile or None
    Time zone for time. Corresponding timestamps would be converted to
    time zone of the TimeSeries.
    None will remove timezone holding UTC time.

Returns
-------
normalized : DatetimeIndex

Raises
-------
TypeError
    If DatetimeIndex is tz-naive.

See Also
--------
tz_localize : Localize tz-naive DatetimeIndex to given time zone (using pytz/dateutil),
    or remove timezone from tz-aware DatetimeIndex.

Examples
--------
>>> datetime=pd.Series(pd.date_range('20180301',periods=3))
>>> datetime
0   2018-03-01
1   2018-03-02
2   2018-03-03
dtype: datetime64[ns]

>>> datetime.dt.tz_localize('UTC').dt.tz_convert('US/Eastern')
0   2018-02-28 19:00:00-05:00
1   2018-03-01 19:00:00-05:00
2   2018-03-02 19:00:00-05:00
dtype: datetime64[ns, US/Eastern]

################################################################################
################################## Validation ##################################
################################################################################

Docstring for "pandas.DatetimeIndex.tz_convert" correct. :)


```

If the validation script still gives errors, but you think there is a good reason
to deviate in this case (and there are certainly such cases), please state this
explicitly.

