### PR TITLE
DOC: update the DatetimeIndex.tz_convert(tz) docstring

### DIFF
--- a/pandas/core/indexes/datetimes.py
+++ b/pandas/core/indexes/datetimes.py
@@ -1904,15 +1904,16 @@ class DatetimeIndex(DatelikeOps, TimelikeOps, DatetimeIndexOpsMixin,
 
     def tz_convert(self, tz):
         """
-        Convert tz(timezone)-aware DatetimeIndex using pytz/dateutil.
+        Convert tz-aware DatetimeIndex from one time zone to another.
 
         When using DatetimeIndex providing with timezone this method
-        converts tz-aware DatetimeIndex from one timezone to another.
+        converts tz(timezone)-aware DatetimeIndex from one timezone
+        to another using pytz/dateutil.
 
         Parameters
         ----------
         tz : string, pytz.timezone, dateutil.tz.tzfile or None
-            Time zone for time.Corresponding timestamps would be converted
+            Time zone for time. Corresponding timestamps would be converted
             to time zone of the TimeSeries.
             None will remove timezone holding UTC time.
 
@@ -1921,30 +1922,44 @@ class DatetimeIndex(DatelikeOps, TimelikeOps, DatetimeIndexOpsMixin,
         normalized : DatetimeIndex
 
         Raises
-        -------
+        ------
         TypeError
             If DatetimeIndex is tz-naive.
 
         See Also
         --------
         tz_localize : Localize tz-naive DatetimeIndex to given time zone
-            (using pytz/dateutil),or remove timezone from tz-aware
+            (using pytz/dateutil), or remove timezone from tz-aware
             DatetimeIndex.
 
         Examples
         --------
-        >>> datetime=pd.Series(pd.date_range('20180301',periods=3))
-        >>> datetime
-        0   2018-03-01
-        1   2018-03-02
-        2   2018-03-03
-        dtype: datetime64[ns]
+        >>> didx = pd.DatetimeIndex
+        (start='2014-08-01 09:00', freq='H', periods=10, tz='Europe/Berlin')
 
-        >>> datetime.dt.tz_localize('UTC').dt.tz_convert('US/Eastern')
-        0   2018-02-28 19:00:00-05:00
-        1   2018-03-01 19:00:00-05:00
-        2   2018-03-02 19:00:00-05:00
-        dtype: datetime64[ns, US/Eastern]
+        >>> didx
+        DatetimeIndex(['2014-08-01 09:00:00+02:00','2014-08-01 10:00:00+02:00',
+        '2014-08-01 11:00:00+02:00', '2014-08-01 12:00:00+02:00',
+        '2014-08-01 13:00:00+02:00', '2014-08-01 14:00:00+02:00',
+        '2014-08-01 15:00:00+02:00', '2014-08-01 16:00:00+02:00',
+        '2014-08-01 17:00:00+02:00', '2014-08-01 18:00:00+02:00'],
+        dtype='datetime64[ns, Europe/Berlin]', freq='H')
+
+        >>> didx.tz_convert('US/Eastern')
+        DatetimeIndex(['2014-08-01 03:00:00-04:00','2014-08-01 04:00:00-04:00',
+        '2014-08-01 05:00:00-04:00', '2014-08-01 06:00:00-04:00',
+        '2014-08-01 07:00:00-04:00', '2014-08-01 08:00:00-04:00',
+        '2014-08-01 09:00:00-04:00', '2014-08-01 10:00:00-04:00',
+        '2014-08-01 11:00:00-04:00', '2014-08-01 12:00:00-04:00'],
+        dtype='datetime64[ns, US/Eastern]', freq='H')
+
+        >>> didx.tz_convert(None)
+        DatetimeIndex(['2014-08-01 07:00:00','2014-08-01 08:00:00',
+        '2014-08-01 09:00:00', '2014-08-01 10:00:00',
+        '2014-08-01 11:00:00', '2014-08-01 12:00:00',
+        '2014-08-01 13:00:00', '2014-08-01 14:00:00',
+        '2014-08-01 15:00:00', '2014-08-01 16:00:00'],
+        dtype='datetime64[ns]', freq='H')
         """
         tz = timezones.maybe_get_tz(tz)
 

--- a/pandas/core/indexes/datetimes.py
+++ b/pandas/core/indexes/datetimes.py
@@ -1948,15 +1948,11 @@ class DatetimeIndex(DatelikeOps, TimelikeOps, DatetimeIndexOpsMixin,
         """
         Convert tz-aware DatetimeIndex from one time zone to another.
 
-        When using DatetimeIndex providing with timezone this method
-        converts tz(timezone)-aware DatetimeIndex from one timezone
-        to another.
-
         Parameters
         ----------
         tz : string, pytz.timezone, dateutil.tz.tzfile or None
             Time zone for time. Corresponding timestamps would be converted
-            to time zone of the DatetimeIndex.
+            to this time zone of the DatetimeIndex.
             None will remove timezone holding UTC time.
 
         Returns
@@ -1970,8 +1966,8 @@ class DatetimeIndex(DatelikeOps, TimelikeOps, DatetimeIndexOpsMixin,
 
         See Also
         --------
-        tz_localize : Localize tz-naive DatetimeIndex to given time zone,
-                      or remove timezone from tz-aware DatetimeIndex.
+        tz_localize : Localize tz-naive DatetimeIndex to a given time zone,
+                      or remove timezone from a tz-aware DatetimeIndex.
 
         Examples
         --------

--- a/pandas/core/indexes/datetimes.py
+++ b/pandas/core/indexes/datetimes.py
@@ -1904,47 +1904,48 @@ class DatetimeIndex(DatelikeOps, TimelikeOps, DatetimeIndexOpsMixin,
 
     def tz_convert(self, tz):
         """
-        A Method to Convert tz-aware DatetimeIndex from one time zone to another.
-	
-	When using DatetimeIndex providing with timezone
-	this method converts tz-aware DatetimeIndex using
-        pytz/dateutil.
+        Convert tz-aware DatetimeIndex from one
+        time zone to another.
+
+        When using DatetimeIndex providing with timezone this method
+        converts tz-aware DatetimeIndex using pytz/dateutil.
 
         Parameters
         ----------
         tz : string, pytz.timezone, dateutil.tz.tzfile or None
-            Time zone for time. Corresponding timestamps would be converted to
-            time zone of the TimeSeries.
+            Time zone for time.Corresponding timestamps would be converted
+            to time zone of the TimeSeries.
             None will remove timezone holding UTC time.
 
         Returns
         -------
         normalized : DatetimeIndex
-       
-	Raises
+
+        Raises
         -------
         TypeError
             If DatetimeIndex is tz-naive.
 
-	See Also
+        See Also
         --------
-        tz_localize : Localize tz-naive DatetimeIndex to given time zone (using pytz/dateutil),
-	    or remove timezone from tz-aware DatetimeIndex.
+        tz_localize : Localize tz-naive DatetimeIndex to given time zone
+            (using pytz/dateutil),or remove timezone from tz-aware
+            DatetimeIndex.
 
-	Examples
+        Examples
         --------
-	>>> datetime=pd.Series(pd.date_range('20180301',periods=3))
-	>>> datetime
-	0   2018-03-01
-	1   2018-03-02
-	2   2018-03-03
-	dtype: datetime64[ns]
+        >>> datetime=pd.Series(pd.date_range('20180301',periods=3))
+        >>> datetime
+        0   2018-03-01
+        1   2018-03-02
+        2   2018-03-03
+        dtype: datetime64[ns]
 
-	>>> datetime.dt.tz_localize('UTC').dt.tz_convert('US/Eastern')
-	0   2018-02-28 19:00:00-05:00
-	1   2018-03-01 19:00:00-05:00
-	2   2018-03-02 19:00:00-05:00
-	dtype: datetime64[ns, US/Eastern]
+        >>> datetime.dt.tz_localize('UTC').dt.tz_convert('US/Eastern')
+        0   2018-02-28 19:00:00-05:00
+        1   2018-03-01 19:00:00-05:00
+        2   2018-03-02 19:00:00-05:00
+        dtype: datetime64[ns, US/Eastern]
         """
         tz = timezones.maybe_get_tz(tz)
 

--- a/pandas/core/indexes/datetimes.py
+++ b/pandas/core/indexes/datetimes.py
@@ -1945,11 +1945,11 @@ class DatetimeIndex(DatelikeOps, TimelikeOps, DatetimeIndexOpsMixin,
                        '2014-08-01 11:00:00'],
                         dtype='datetime64[ns]', freq='H')
 
-        >>> dti.tz_localize('Europe/Berlin').tz_convert('US/Eastern')
-        DatetimeIndex(['2014-08-01 03:00:00-04:00',
-                       '2014-08-01 04:00:00-04:00',
-                       '2014-08-01 05:00:00-04:00'],
-                        dtype='datetime64[ns, US/Eastern]', freq='H')
+        >>> dti.tz_localize('Europe/Berlin')
+        DatetimeIndex(['2014-08-01 09:00:00+02:00',
+                       '2014-08-01 10:00:00+02:00',
+                       '2014-08-01 11:00:00+02:00'],
+                        dtype='datetime64[ns, Europe/Berlin]', freq='H')
 
         With the `None` parameter, we can remove the timezone:
 

--- a/pandas/core/indexes/datetimes.py
+++ b/pandas/core/indexes/datetimes.py
@@ -1933,25 +1933,34 @@ class DatetimeIndex(DatelikeOps, TimelikeOps, DatetimeIndexOpsMixin,
 
         Examples
         --------
-        >>> dti = pd.DatetimeIndex(start='2014-08-01 09:00',
-        ...                       freq='H', periods=3, tz='Europe/Berlin')
-
-        >>> dti
-        DatetimeIndex(['2014-08-01 09:00:00+02:00',
-                       '2014-08-01 10:00:00+02:00',
-                       '2014-08-01 11:00:00+02:00'],
-                        dtype='datetime64[ns, Europe/Berlin]', freq='H')
-
         With the `tz` parameter, we can change the DatetimeIndex
         to other time zones:
 
-        >>> dti.tz_convert('US/Eastern')
+        >>> dti = pd.DatetimeIndex(start='2014-08-01 09:00',
+        ...                       freq='H', periods=3)
+
+        >>> dti
+        DatetimeIndex(['2014-08-01 09:00:00',
+                       '2014-08-01 10:00:00',
+                       '2014-08-01 11:00:00'],
+                        dtype='datetime64[ns]', freq='H')
+
+        >>> dti.tz_localize('Europe/Berlin').tz_convert('US/Eastern')
         DatetimeIndex(['2014-08-01 03:00:00-04:00',
                        '2014-08-01 04:00:00-04:00',
                        '2014-08-01 05:00:00-04:00'],
                         dtype='datetime64[ns, US/Eastern]', freq='H')
 
         With the `None` parameter, we can remove the timezone:
+
+        >>> dti = pd.DatetimeIndex(start='2014-08-01 09:00',freq='H',
+        ...                        periods=3, tz='Europe/Berlin')
+
+        >>> dti
+        DatetimeIndex(['2014-08-01 09:00:00+02:00',
+                       '2014-08-01 10:00:00+02:00',
+                       '2014-08-01 11:00:00+02:00'],
+                        dtype='datetime64[ns, Europe/Berlin]', freq='H')
 
         >>> dti.tz_convert(None)
         DatetimeIndex(['2014-08-01 07:00:00',

--- a/pandas/core/indexes/datetimes.py
+++ b/pandas/core/indexes/datetimes.py
@@ -1952,8 +1952,8 @@ class DatetimeIndex(DatelikeOps, TimelikeOps, DatetimeIndexOpsMixin,
         ----------
         tz : string, pytz.timezone, dateutil.tz.tzfile or None
             Time zone for time. Corresponding timestamps would be converted
-            to this time zone of the DatetimeIndex.
-            None will remove timezone holding UTC time.
+            to this time zone of the DatetimeIndex. A `tz` of None will
+            convert to UTC and remove the timezone information.
 
         Returns
         -------
@@ -1966,8 +1966,9 @@ class DatetimeIndex(DatelikeOps, TimelikeOps, DatetimeIndexOpsMixin,
 
         See Also
         --------
-        tz_localize : Localize tz-naive DatetimeIndex to a given time zone,
-                      or remove timezone from a tz-aware DatetimeIndex.
+        DatetimeIndex.tz : A timezone that has a variable offset from UTC
+        DatetimeIndex.tz_localize : Localize tz-naive DatetimeIndex to a
+            given time zone, or remove timezone from a tz-aware DatetimeIndex.
 
         Examples
         --------
@@ -1975,21 +1976,22 @@ class DatetimeIndex(DatelikeOps, TimelikeOps, DatetimeIndexOpsMixin,
         to other time zones:
 
         >>> dti = pd.DatetimeIndex(start='2014-08-01 09:00',
-        ...                       freq='H', periods=3)
+        ...                        freq='H', periods=3, tz='Europe/Berlin')
 
         >>> dti
-        DatetimeIndex(['2014-08-01 09:00:00',
-                       '2014-08-01 10:00:00',
-                       '2014-08-01 11:00:00'],
-                        dtype='datetime64[ns]', freq='H')
-
-        >>> dti.tz_localize('Europe/Berlin')
         DatetimeIndex(['2014-08-01 09:00:00+02:00',
                        '2014-08-01 10:00:00+02:00',
                        '2014-08-01 11:00:00+02:00'],
-                        dtype='datetime64[ns, Europe/Berlin]', freq='H')
+                      dtype='datetime64[ns, Europe/Berlin]', freq='H')
 
-        With the `None` parameter, we can remove the timezone:
+        >>> dti.tz_convert('US/Central')
+        DatetimeIndex(['2014-08-01 02:00:00-05:00',
+                       '2014-08-01 03:00:00-05:00',
+                       '2014-08-01 04:00:00-05:00'],
+                      dtype='datetime64[ns, US/Central]', freq='H')
+
+        With the ``tz=None``, we can remove the timezone (after converting
+        to UTC if necessary):
 
         >>> dti = pd.DatetimeIndex(start='2014-08-01 09:00',freq='H',
         ...                        periods=3, tz='Europe/Berlin')

--- a/pandas/core/indexes/datetimes.py
+++ b/pandas/core/indexes/datetimes.py
@@ -1908,7 +1908,7 @@ class DatetimeIndex(DatelikeOps, TimelikeOps, DatetimeIndexOpsMixin,
 
         When using DatetimeIndex providing with timezone this method
         converts tz(timezone)-aware DatetimeIndex from one timezone
-        to another using pytz/dateutil.
+        to another.
 
         Parameters
         ----------
@@ -1934,32 +1934,31 @@ class DatetimeIndex(DatelikeOps, TimelikeOps, DatetimeIndexOpsMixin,
 
         Examples
         --------
-        >>> didx = pd.DatetimeIndex
-        (start='2014-08-01 09:00', freq='H', periods=10, tz='Europe/Berlin')
+        >>> data=pd.DatetimeIndex(start='2014-08-01 09:00',
+        ...                       freq='H', periods=3, tz='Europe/Berlin')
 
-        >>> didx
-        DatetimeIndex(['2014-08-01 09:00:00+02:00','2014-08-01 10:00:00+02:00',
-        '2014-08-01 11:00:00+02:00', '2014-08-01 12:00:00+02:00',
-        '2014-08-01 13:00:00+02:00', '2014-08-01 14:00:00+02:00',
-        '2014-08-01 15:00:00+02:00', '2014-08-01 16:00:00+02:00',
-        '2014-08-01 17:00:00+02:00', '2014-08-01 18:00:00+02:00'],
-        dtype='datetime64[ns, Europe/Berlin]', freq='H')
+        >>> data
+        DatetimeIndex(['2014-08-01 09:00:00+02:00',
+                       '2014-08-01 10:00:00+02:00',
+                       '2014-08-01 11:00:00+02:00'],
+                        dtype='datetime64[ns, Europe/Berlin]', freq='H')
 
-        >>> didx.tz_convert('US/Eastern')
-        DatetimeIndex(['2014-08-01 03:00:00-04:00','2014-08-01 04:00:00-04:00',
-        '2014-08-01 05:00:00-04:00', '2014-08-01 06:00:00-04:00',
-        '2014-08-01 07:00:00-04:00', '2014-08-01 08:00:00-04:00',
-        '2014-08-01 09:00:00-04:00', '2014-08-01 10:00:00-04:00',
-        '2014-08-01 11:00:00-04:00', '2014-08-01 12:00:00-04:00'],
-        dtype='datetime64[ns, US/Eastern]', freq='H')
+        With the `tz` parameter, we can change DatetimeIndex
+        to other time zones:
 
-        >>> didx.tz_convert(None)
-        DatetimeIndex(['2014-08-01 07:00:00','2014-08-01 08:00:00',
-        '2014-08-01 09:00:00', '2014-08-01 10:00:00',
-        '2014-08-01 11:00:00', '2014-08-01 12:00:00',
-        '2014-08-01 13:00:00', '2014-08-01 14:00:00',
-        '2014-08-01 15:00:00', '2014-08-01 16:00:00'],
-        dtype='datetime64[ns]', freq='H')
+        >>> data.tz_convert('US/Eastern')
+        DatetimeIndex(['2014-08-01 03:00:00-04:00',
+                       '2014-08-01 04:00:00-04:00',
+                       '2014-08-01 05:00:00-04:00'],
+                        dtype='datetime64[ns, US/Eastern]', freq='H')
+
+        With the `None` parameter, we can remove timezone:
+
+        >>> data.tz_convert(None)
+        DatetimeIndex(['2014-08-01 07:00:00',
+                       '2014-08-01 08:00:00',
+                       '2014-08-01 09:00:00'],
+                        dtype='datetime64[ns]', freq='H')
         """
         tz = timezones.maybe_get_tz(tz)
 

--- a/pandas/core/indexes/datetimes.py
+++ b/pandas/core/indexes/datetimes.py
@@ -1933,10 +1933,10 @@ class DatetimeIndex(DatelikeOps, TimelikeOps, DatetimeIndexOpsMixin,
 
         Examples
         --------
-        >>> data=pd.DatetimeIndex(start='2014-08-01 09:00',
+        >>> dti = pd.DatetimeIndex(start='2014-08-01 09:00',
         ...                       freq='H', periods=3, tz='Europe/Berlin')
 
-        >>> data
+        >>> dti
         DatetimeIndex(['2014-08-01 09:00:00+02:00',
                        '2014-08-01 10:00:00+02:00',
                        '2014-08-01 11:00:00+02:00'],
@@ -1945,7 +1945,7 @@ class DatetimeIndex(DatelikeOps, TimelikeOps, DatetimeIndexOpsMixin,
         With the `tz` parameter, we can change the DatetimeIndex
         to other time zones:
 
-        >>> data.tz_convert('US/Eastern')
+        >>> dti.tz_convert('US/Eastern')
         DatetimeIndex(['2014-08-01 03:00:00-04:00',
                        '2014-08-01 04:00:00-04:00',
                        '2014-08-01 05:00:00-04:00'],
@@ -1953,7 +1953,7 @@ class DatetimeIndex(DatelikeOps, TimelikeOps, DatetimeIndexOpsMixin,
 
         With the `None` parameter, we can remove the timezone:
 
-        >>> data.tz_convert(None)
+        >>> dti.tz_convert(None)
         DatetimeIndex(['2014-08-01 07:00:00',
                        '2014-08-01 08:00:00',
                        '2014-08-01 09:00:00'],

--- a/pandas/core/indexes/datetimes.py
+++ b/pandas/core/indexes/datetimes.py
@@ -1904,8 +1904,11 @@ class DatetimeIndex(DatelikeOps, TimelikeOps, DatetimeIndexOpsMixin,
 
     def tz_convert(self, tz):
         """
-        Convert tz-aware DatetimeIndex from one time zone to another (using
-        pytz/dateutil)
+        A Method to Convert tz-aware DatetimeIndex from one time zone to another.
+	
+	When using DatetimeIndex providing with timezone
+	this method converts tz-aware DatetimeIndex using
+        pytz/dateutil.
 
         Parameters
         ----------
@@ -1917,11 +1920,31 @@ class DatetimeIndex(DatelikeOps, TimelikeOps, DatetimeIndexOpsMixin,
         Returns
         -------
         normalized : DatetimeIndex
-
-        Raises
-        ------
+       
+	Raises
+        -------
         TypeError
             If DatetimeIndex is tz-naive.
+
+	See Also
+        --------
+        tz_localize : Localize tz-naive DatetimeIndex to given time zone (using pytz/dateutil),
+	    or remove timezone from tz-aware DatetimeIndex.
+
+	Examples
+        --------
+	>>> datetime=pd.Series(pd.date_range('20180301',periods=3))
+	>>> datetime
+	0   2018-03-01
+	1   2018-03-02
+	2   2018-03-03
+	dtype: datetime64[ns]
+
+	>>> datetime.dt.tz_localize('UTC').dt.tz_convert('US/Eastern')
+	0   2018-02-28 19:00:00-05:00
+	1   2018-03-01 19:00:00-05:00
+	2   2018-03-02 19:00:00-05:00
+	dtype: datetime64[ns, US/Eastern]
         """
         tz = timezones.maybe_get_tz(tz)
 

--- a/pandas/core/indexes/datetimes.py
+++ b/pandas/core/indexes/datetimes.py
@@ -1904,11 +1904,10 @@ class DatetimeIndex(DatelikeOps, TimelikeOps, DatetimeIndexOpsMixin,
 
     def tz_convert(self, tz):
         """
-        Convert tz-aware DatetimeIndex from one
-        time zone to another.
+        Convert tz(timezone)-aware DatetimeIndex using pytz/dateutil.
 
         When using DatetimeIndex providing with timezone this method
-        converts tz-aware DatetimeIndex using pytz/dateutil.
+        converts tz-aware DatetimeIndex from one timezone to another.
 
         Parameters
         ----------

--- a/pandas/core/indexes/datetimes.py
+++ b/pandas/core/indexes/datetimes.py
@@ -1914,7 +1914,7 @@ class DatetimeIndex(DatelikeOps, TimelikeOps, DatetimeIndexOpsMixin,
         ----------
         tz : string, pytz.timezone, dateutil.tz.tzfile or None
             Time zone for time. Corresponding timestamps would be converted
-            to time zone of the TimeSeries.
+            to time zone of the DatetimeIndex.
             None will remove timezone holding UTC time.
 
         Returns
@@ -1928,9 +1928,8 @@ class DatetimeIndex(DatelikeOps, TimelikeOps, DatetimeIndexOpsMixin,
 
         See Also
         --------
-        tz_localize : Localize tz-naive DatetimeIndex to given time zone
-            (using pytz/dateutil), or remove timezone from tz-aware
-            DatetimeIndex.
+        tz_localize : Localize tz-naive DatetimeIndex to given time zone,
+                      or remove timezone from tz-aware DatetimeIndex.
 
         Examples
         --------
@@ -1943,7 +1942,7 @@ class DatetimeIndex(DatelikeOps, TimelikeOps, DatetimeIndexOpsMixin,
                        '2014-08-01 11:00:00+02:00'],
                         dtype='datetime64[ns, Europe/Berlin]', freq='H')
 
-        With the `tz` parameter, we can change DatetimeIndex
+        With the `tz` parameter, we can change the DatetimeIndex
         to other time zones:
 
         >>> data.tz_convert('US/Eastern')
@@ -1952,7 +1951,7 @@ class DatetimeIndex(DatelikeOps, TimelikeOps, DatetimeIndexOpsMixin,
                        '2014-08-01 05:00:00-04:00'],
                         dtype='datetime64[ns, US/Eastern]', freq='H')
 
-        With the `None` parameter, we can remove timezone:
+        With the `None` parameter, we can remove the timezone:
 
         >>> data.tz_convert(None)
         DatetimeIndex(['2014-08-01 07:00:00',


### PR DESCRIPTION
Checklist for the pandas documentation sprint (ignore this if you are doing
an unrelated PR):

- [x] PR title is "DOC: update the <your-function-or-method> docstring"
- [x] The validation script passes: `scripts/validate_docstrings.py <your-function-or-method>`
- [x] The PEP8 style check passes: `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] The html version looks good: `python doc/make.py --single <your-function-or-method>`
- [x] It has been proofread on language by another sprint participant

Please include the output of the validation script below between the "```" ticks:

```
(pandas_dev) root@kalih:~/pythonpanda/pandas# python -m flake8 ./pandas/core/indexes/datetimes.py
(pandas_dev) root@kalih:~/pythonpanda/pandas# python scripts/validate_docstrings.py pandas.DatetimeIndex.tz_convert

################################################################################
################# Docstring (pandas.DatetimeIndex.tz_convert)  #################
################################################################################

Convert tz-aware DatetimeIndex from one time zone to another.

When using DatetimeIndex providing with timezone this method
converts tz(timezone)-aware DatetimeIndex from one timezone
to another.

Parameters
----------
tz : string, pytz.timezone, dateutil.tz.tzfile or None
    Time zone for time. Corresponding timestamps would be converted
    to time zone of the DatetimeIndex.
    None will remove timezone holding UTC time.

Returns
-------
normalized : DatetimeIndex

Raises
------
TypeError
    If DatetimeIndex is tz-naive.

See Also
--------
tz_localize : Localize tz-naive DatetimeIndex to given time zone,
              or remove timezone from tz-aware DatetimeIndex.

Examples
--------
With the `tz` parameter, we can change the DatetimeIndex
to other time zones:

>>> dti = pd.DatetimeIndex(start='2014-08-01 09:00',
...                       freq='H', periods=3)

>>> dti
DatetimeIndex(['2014-08-01 09:00:00',
               '2014-08-01 10:00:00',
               '2014-08-01 11:00:00'],
                dtype='datetime64[ns]', freq='H')

>>> dti.tz_localize('Europe/Berlin').tz_convert('US/Eastern')
DatetimeIndex(['2014-08-01 03:00:00-04:00',
               '2014-08-01 04:00:00-04:00',
               '2014-08-01 05:00:00-04:00'],
                dtype='datetime64[ns, US/Eastern]', freq='H')

With the `None` parameter, we can remove the timezone:

>>> dti = pd.DatetimeIndex(start='2014-08-01 09:00',freq='H',
...                        periods=3, tz='Europe/Berlin')

>>> dti
DatetimeIndex(['2014-08-01 09:00:00+02:00',
               '2014-08-01 10:00:00+02:00',
               '2014-08-01 11:00:00+02:00'],
                dtype='datetime64[ns, Europe/Berlin]', freq='H')

>>> dti.tz_convert(None)
DatetimeIndex(['2014-08-01 07:00:00',
               '2014-08-01 08:00:00',
               '2014-08-01 09:00:00'],
                dtype='datetime64[ns]', freq='H')

################################################################################
################################## Validation ##################################
################################################################################

Docstring for "pandas.DatetimeIndex.tz_convert" correct. :)
```

If the validation script still gives errors, but you think there is a good reason
to deviate in this case (and there are certainly such cases), please state this
explicitly.
