### PR TITLE
DOC: update the dtypes/ftypes docstring (Seoul)

### DIFF
--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -4275,7 +4275,29 @@ class NDFrame(PandasObject, SelectionMixin):
 
     @property
     def dtypes(self):
-        """Return the dtypes in this object."""
+        """
+        Return the dtypes in this object.
+
+        Notes
+        -----
+        It returns a Series with the data type of each column.
+        If object contains data multiple dtypes in a single column,
+        dtypes will be chosen to accommodate all of the data types.
+        ``object`` is the most general.
+
+        Examples
+        --------
+        >>> df = pd.DataFrame({'f': pd.np.random.rand(3),
+        ...                    'i': 1,
+        ...                    'd': pd.Timestamp('20180310'),
+        ...                    'o': 'foo'})
+        >>> df.dtypes
+        f           float64
+        i             int64
+        d    datetime64[ns]
+        o            object
+        dtype: object
+        """
         from pandas import Series
         return Series(self._data.get_dtypes(), index=self._info_axis,
                       dtype=np.object_)
@@ -4285,6 +4307,31 @@ class NDFrame(PandasObject, SelectionMixin):
         """
         Return the ftypes (indication of sparse/dense and dtype)
         in this object.
+
+        Notes
+        -----
+        Sparse data should have the same dtypes as its dense representation
+
+        See Also
+        --------
+        dtypes, SparseDataFrame
+
+        Examples
+        --------
+        >>> arr = pd.np.random.randn(100, 4)
+        >>> arr[arr < .8] = pd.np.nan
+        >>> pd.DataFrame(arr).ftypes
+        0    float64:dense
+        1    float64:dense
+        2    float64:dense
+        3    float64:dense
+        dtype: object
+        >>> pd.SparseDataFrame(arr).ftypes
+        0    float64:sparse
+        1    float64:sparse
+        2    float64:sparse
+        3    float64:sparse
+        dtype: object
         """
         from pandas import Series
         return Series(self._data.get_ftypes(), index=self._info_axis,

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -4280,7 +4280,8 @@ class NDFrame(PandasObject, SelectionMixin):
 
         This returns a Series with the data type of each column.
         The result's index is the original DataFrame's columns. Columns
-        with mixed types are stored in with the ``object`` dtype.
+        with mixed types are stored with the ``object`` dtype. See
+        :ref:`the User Guide <basics.dtypes>` for more.
 
         Returns
         -------
@@ -4315,7 +4316,8 @@ class NDFrame(PandasObject, SelectionMixin):
 
         This returns a Series with the data type of each column.
         The result's index is the original DataFrame's columns. Columns
-        with mixed types are stored in with the ``object`` dtype.
+        with mixed types are stored with the ``object`` dtype.  See
+        :ref:`the User Guide <basics.dtypes>` for more.
 
         Returns
         -------

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -4278,17 +4278,25 @@ class NDFrame(PandasObject, SelectionMixin):
         """
         Return the dtypes in this object.
 
-        Notes
-        -----
-        It returns a Series with the data type of each column.
+        This returns a Series with the data type of each column.
+        The result's index is original DataFrame's columns.
         If object contains data multiple dtypes in a single column,
         dtypes will be chosen to accommodate all of the data types.
         ``object`` is the most general.
 
+        Returns
+        -------
+        pandas.Series
+            The data type of each column.
+
+        See Also
+        --------
+        pandas.DataFrame.ftypes
+
         Examples
         --------
-        >>> df = pd.DataFrame({'f': pd.np.random.rand(3),
-        ...                    'i': 1,
+        >>> df = pd.DataFrame({'f': [1.0],
+        ...                    'i': [1],
         ...                    'd': pd.Timestamp('20180310'),
         ...                    'o': 'foo'})
         >>> df.dtypes
@@ -4305,21 +4313,34 @@ class NDFrame(PandasObject, SelectionMixin):
     @property
     def ftypes(self):
         """
-        Return the ftypes (indication of sparse/dense and dtype)
-        in this object.
+        Return the ftypes (indication of sparse/dense and dtype) in this object.
 
-        Notes
-        -----
-        Sparse data should have the same dtypes as its dense representation
+        This returns a Series with the data type of each column.
+        The result's index is original DataFrame's columns.
+        If object contains data multiple dtypes in a single column,
+        dtypes will be chosen to accommodate all of the data types.
+        ``object`` is the most general.
+        All of the standard pandas data structures have a to_sparse method.
+        The result's tracks where data has been "sparsified".
+
+        Returns
+        -------
+        pandas.Series
+            The data type and indication of sparse/dense of each column.
 
         See Also
         --------
-        dtypes, SparseDataFrame
+        pandas.DataFrame.dtypes, pandas.SparseDataFrame
+
+        Notes
+        -----
+        Sparse data should have the same dtypes as its dense representation.
 
         Examples
         --------
-        >>> arr = pd.np.random.randn(100, 4)
-        >>> arr[arr < .8] = pd.np.nan
+        >>> import numpy as np
+        >>> arr = np.random.RandomState(0).randn(100, 4)
+        >>> arr[arr < .8] = np.nan
         >>> pd.DataFrame(arr).ftypes
         0    float64:dense
         1    float64:dense

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -4276,7 +4276,7 @@ class NDFrame(PandasObject, SelectionMixin):
     @property
     def dtypes(self):
         """
-        Return the dtypes in this object.
+        Return the dtypes in DataFrame.
 
         This returns a Series with the data type of each column.
         The result's index is original DataFrame's columns.
@@ -4313,7 +4313,7 @@ class NDFrame(PandasObject, SelectionMixin):
     @property
     def ftypes(self):
         """
-        Return the ftypes (indication of sparse/dense and dtype) in this object.
+        Return the ftypes (indication of sparse/dense and dtype) in DataFrame.
 
         This returns a Series with the data type of each column.
         The result's index is original DataFrame's columns.

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -4293,15 +4293,15 @@ class NDFrame(PandasObject, SelectionMixin):
 
         Examples
         --------
-        >>> df = pd.DataFrame({'f': [1.0],
-        ...                    'i': [1],
-        ...                    'd': [pd.Timestamp('20180310')],
-        ...                    'o': ['foo']})
+        >>> df = pd.DataFrame({'float': [1.0],
+        ...                    'int': [1],
+        ...                    'datetime': [pd.Timestamp('20180310')],
+        ...                    'string': ['foo']})
         >>> df.dtypes
-        f           float64
-        i             int64
-        d    datetime64[ns]
-        o            object
+        float              float64
+        int                  int64
+        datetime    datetime64[ns]
+        string              object
         dtype: object
         """
         from pandas import Series

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -4276,13 +4276,11 @@ class NDFrame(PandasObject, SelectionMixin):
     @property
     def dtypes(self):
         """
-        Return the dtypes in DataFrame.
+        Return the dtypes in the DataFrame.
 
         This returns a Series with the data type of each column.
-        The result's index is original DataFrame's columns.
-        If object contains data multiple dtypes in a single column,
-        dtypes will be chosen to accommodate all of the data types.
-        ``object`` is the most general.
+        The result's index is the original DataFrame's columns. Columns
+        with mixed types are stored in with the ``object`` dtype.
 
         Returns
         -------
@@ -4291,14 +4289,14 @@ class NDFrame(PandasObject, SelectionMixin):
 
         See Also
         --------
-        pandas.DataFrame.ftypes
+        pandas.DataFrame.ftypes : dtype and sparsity information.
 
         Examples
         --------
         >>> df = pd.DataFrame({'f': [1.0],
         ...                    'i': [1],
-        ...                    'd': pd.Timestamp('20180310'),
-        ...                    'o': 'foo'})
+        ...                    'd': [pd.Timestamp('20180310')],
+        ...                    'o': ['foo']})
         >>> df.dtypes
         f           float64
         i             int64
@@ -4316,12 +4314,8 @@ class NDFrame(PandasObject, SelectionMixin):
         Return the ftypes (indication of sparse/dense and dtype) in DataFrame.
 
         This returns a Series with the data type of each column.
-        The result's index is original DataFrame's columns.
-        If object contains data multiple dtypes in a single column,
-        dtypes will be chosen to accommodate all of the data types.
-        ``object`` is the most general.
-        All of the standard pandas data structures have a to_sparse method.
-        The result's tracks where data has been "sparsified".
+        The result's index is the original DataFrame's columns. Columns
+        with mixed types are stored in with the ``object`` dtype.
 
         Returns
         -------
@@ -4330,7 +4324,8 @@ class NDFrame(PandasObject, SelectionMixin):
 
         See Also
         --------
-        pandas.DataFrame.dtypes, pandas.SparseDataFrame
+        pandas.DataFrame.dtypes: Series with just dtype information.
+        pandas.SparseDataFrame : Container for sparse tabular data.
 
         Notes
         -----
@@ -4347,6 +4342,7 @@ class NDFrame(PandasObject, SelectionMixin):
         2    float64:dense
         3    float64:dense
         dtype: object
+
         >>> pd.SparseDataFrame(arr).ftypes
         0    float64:sparse
         1    float64:sparse


### PR DESCRIPTION
Checklist for the pandas documentation sprint (ignore this if you are doing
an unrelated PR):

- [X] PR title is "DOC: update the <your-function-or-method> docstring"
- [X] The validation script passes: `scripts/validate_docstrings.py <your-function-or-method>`
- [X] The PEP8 style check passes: `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [X] The html version looks good: `python doc/make.py --single <your-function-or-method>`
- [X] It has been proofread on language by another sprint participant

Please include the output of the validation script below between the "```" ticks:

```
# paste output of "scripts/validate_docstrings.py <your-function-or-method>" here
# between the "```" (remove this comment, but keep the "```")


################################################################################
##################### Docstring (pandas.DataFrame.dtypes)  #####################
################################################################################

Return the dtypes in this object.

Notes
-----
It returns a Series with the data type of each column.
If object contains data multiple dtypes in a single column,
dtypes will be chosen to accommodate all of the data types.
``object`` is the most general.

Examples
--------
>>> df = pd.DataFrame({'f': pd.np.random.rand(3),
...                    'i': 1,
...                    'd': pd.Timestamp('20180310'),
...                    'o': 'foo'})
>>> df.dtypes
f           float64
i             int64
d    datetime64[ns]
o            object
dtype: object

################################################################################
################################## Validation ##################################
################################################################################

Errors found:
	No extended summary found
	No returns section found
	See Also section not found


################################################################################
##################### Docstring (pandas.DataFrame.ftypes)  #####################
################################################################################

Return the ftypes (indication of sparse/dense and dtype)
in this object.

Notes
-----
Sparse data should have the same dtypes as its dense representation

See Also
--------
dtypes, SparseDataFrame

Examples
--------
>>> arr = pd.np.random.randn(100, 4)
>>> arr[arr < .8] = pd.np.nan
>>> pd.DataFrame(arr).ftypes
0    float64:dense
1    float64:dense
2    float64:dense
3    float64:dense
dtype: object
>>> pd.SparseDataFrame(arr).ftypes
0    float64:sparse
1    float64:sparse
2    float64:sparse
3    float64:sparse
dtype: object

################################################################################
################################## Validation ##################################
################################################################################

Errors found:
	No summary found (a short summary in a single line should be present at the beginning of the docstring)
	No returns section found
	Missing description for See Also "dtypes" reference
	Missing description for See Also "SparseDataFrame" reference

```

If the validation script still gives errors, but you think there is a good reason
to deviate in this case (and there are certainly such cases), please state this
explicitly.

Lastly, I left errors already occurred in the previous version without changes.