### PR TITLE
DOC: update the axes, shape, dim and size property docstring (Seoul)

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -550,8 +550,17 @@ class DataFrame(NDFrame):
     @property
     def axes(self):
         """
-        Return a list with the row axis labels and column axis labels as the
-        only members. They are returned in that order.
+        Return a list representing the axes of the DataFrame.
+
+        It has the row axis labels and column axis labels as the only members.
+        They are returned in that order.
+
+        Examples
+        --------
+        >>> df = pd.DataFrame({'col1': [1, 2], 'col2': [3, 4]})
+        >>> df.axes
+        [RangeIndex(start=0, stop=2, step=1), Index(['coll', 'col2'],
+        dtype='object')]
         """
         return [self.index, self.columns]
 
@@ -559,6 +568,21 @@ class DataFrame(NDFrame):
     def shape(self):
         """
         Return a tuple representing the dimensionality of the DataFrame.
+
+        See Also
+        --------
+        ndarray.shape
+
+        Examples
+        --------
+        >>> df = pd.DataFrame({'col1': [1, 2], 'col2': [3, 4]})
+        >>> df.shape
+        (2, 2)
+
+        >>> df = pd.DataFrame({'col1': [1, 2], 'col2': [3, 4],
+        ...                    'col3': [5, 6]})
+        >>> df.shape
+        (2, 3)
         """
         return len(self.index), len(self.columns)
 

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -457,12 +457,49 @@ class NDFrame(PandasObject, SelectionMixin):
 
     @property
     def ndim(self):
-        """Number of axes / array dimensions"""
+        """
+        Return an int representing the number of axes / array dimensions.
+
+        Return 1 if Series. Otherwise return 2 if DataFrame.
+
+        See Also
+        --------
+        ndarray.ndim
+
+        Examples
+        --------
+        >>> s = pd.Series({'a': 1, 'b': 2, 'c': 3})
+        >>> s.ndim
+        1
+
+        >>> df = pd.DataFrame({'col1': [1, 2], 'col2': [3, 4]})
+        >>> df.ndim
+        2
+        """
         return self._data.ndim
 
     @property
     def size(self):
-        """number of elements in the NDFrame"""
+        """
+        Return an int representing the number of elements in this object.
+
+        Return the number of rows if Series. Otherwise return the number of
+        rows times number of columns if DataFrame.
+
+        See Also
+        --------
+        ndarray.size
+
+        Examples
+        --------
+        >>> s = pd.Series({'a': 1, 'b': 2, 'c': 3})
+        >>> s.size
+        3
+
+        >>> df = pd.DataFrame({'col1': [1, 2], 'col2': [3, 4]})
+        >>> df.size
+        4
+        """
         return np.prod(self.shape)
 
     @property


### PR DESCRIPTION
This change includes the following property axes, shape, ndim, size

Checklist for the pandas documentation sprint (ignore this if you are doing
an unrelated PR):

- [X] PR title is "DOC: update the <your-function-or-method> docstring"
- [X] The validation script passes: `scripts/validate_docstrings.py <your-function-or-method>`
- [X] The PEP8 style check passes: `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [X] The html version looks good: `python doc/make.py --single <your-function-or-method>`
- [X] It has been proofread on language by another sprint participant

Please include the output of the validation script below between the "```" ticks:

```
# paste output of "scripts/validate_docstrings.py <your-function-or-method>" here
# between the "```" (remove this comment, but keep the "```")

$ scripts/validate_docstrings.py pandas.DataFrame.axes

################################################################################
###################### Docstring (pandas.DataFrame.axes)  ######################
################################################################################

Return a list representing the row axis labels and column axis labels
as the only members. They are returned in that order.

Examples
--------
>>> df = pd.DataFrame({'col1': [1, 2], 'col2': [3, 4]})
>>> df.axes
[RangeIndex(start=0, stop=2, step=1), Index(['coll', 'col2'],
dtype='object')]

################################################################################
################################## Validation ##################################
################################################################################

Errors found:
	No summary found (a short summary in a single line should be present at the beginning of the docstring)
	No returns section found
	See Also section not found
	Examples do not pass tests

################################################################################
################################### Doctests ###################################
################################################################################

**********************************************************************
Line 8, in pandas.DataFrame.axes
Failed example:
    df.axes
Expected:
    [RangeIndex(start=0, stop=2, step=1), Index(['coll', 'col2'],
    dtype='object')]
Got:
    [RangeIndex(start=0, stop=2, step=1), Index(['col1', 'col2'], dtype='object')]


$ scripts/validate_docstrings.py pandas.DataFrame.ndim

################################################################################
###################### Docstring (pandas.DataFrame.ndim)  ######################
################################################################################

Return an int representing the number of axes / array dimensions.

Examples
--------
>>> df = pd.DataFrame({'col1': [1, 2], 'col2': [3, 4]})
>>> df.ndim
2

>>> df = pd.DataFrame({'col1': [1, 2, 3], 'col2': [4, 5, 6],
...                    'col3': [7, 8, 9]})
>>> df.ndim
2

################################################################################
################################## Validation ##################################
################################################################################

Errors found:
	No extended summary found
	No returns section found
	See Also section not found


$ scripts/validate_docstrings.py pandas.DataFrame.size

################################################################################
###################### Docstring (pandas.DataFrame.size)  ######################
################################################################################

Return a numpy.int64 representing the number of elements
in this object.

Examples
--------
>>> df = pd.DataFrame({'col1': [1, 2], 'col2': [3, 4]})
>>> df.size
4

>>> df = pd.DataFrame({'col1': [1, 2, 3], 'col2': [4, 5, 6],
...                    'col3': [7, 8, 9]})
>>> df.size
9

################################################################################
################################## Validation ##################################
################################################################################

Errors found:
	No summary found (a short summary in a single line should be present at the beginning of the docstring)
	No returns section found
	See Also section not found


$ scripts/validate_docstrings.py pandas.DataFrame.shape

################################################################################
###################### Docstring (pandas.DataFrame.shape) ######################
################################################################################

Return a tuple representing the dimensionality of the DataFrame.

Examples
--------
>>> df = pd.DataFrame({'col1': [1, 2], 'col2': [3, 4]})
>>> df.shape
(2, 2)

>>> df = pd.DataFrame({'col0': [1, 2, 3], 'col2': [4, 5, 6],
...                    'col3': [7, 8, 9]})
>>> df.shape
(3, 3)

################################################################################
################################## Validation ##################################
################################################################################

Errors found:
	No extended summary found
	No returns section found
	See Also section not found
```

If the validation script still gives errors, but you think there is a good reason
to deviate in this case (and there are certainly such cases), please state this
explicitly.

Current change [1][2][3][4] occurred following error "No returns section found", "See Also section nod found". 
Because this function is property. so I did not make Return and Also section.
And then axes[1] property occurred "Examples do not pass tests". I made a newline in the result to avoid flake8 error. It raises the above error.

[1] pandas.DataFrame.axes
[2] pandas.DataFrame.ndim
[3] pandas.DataFrame.size
[4] pandas.DataFrame.shape