### PR TITLE
DOC: update the pd.DataFrame.memory_usage/empty docstring(Seoul)

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -1953,11 +1953,11 @@ class DataFrame(NDFrame):
 
         Parameters
         ----------
-        index : bool, default False
+        index : bool, default True
             Specifies whether to include the memory usage of the DataFrame's
             index in returned Series. If ``index=True`` the memory usage of the
             index the first item in the output.
-        deep : bool
+        deep : bool, default False
             If True, introspect the data deeply by interrogating
             `object` dtypes for system-level memory consumption, and include
             it in the returned values.
@@ -2007,16 +2007,8 @@ class DataFrame(NDFrame):
         bool           5000
         dtype: int64
 
-        >>> df.memory_usage(index=True)
-        Index            80
-        int64         40000
-        float64       40000
-        complex128    80000
-        object        40000
-        bool           5000
-        dtype: int64
-
         The memory footprint of `object` dtype columns is ignored by default:
+
         >>> df.memory_usage(deep=True)
         Index             80
         int64          40000

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -1949,7 +1949,8 @@ class DataFrame(NDFrame):
         The memory usage can optionally include the contribution of
         the index and elements of `object` dtype.
 
-        A configuration option, `display.memory_usage` (see Parameters)
+        This value is displayed in `DataFrame.info` by default. This can be
+        suppressed by setting ``pandas.options.display.memory_usage`` to False.
 
         Parameters
         ----------
@@ -1975,6 +1976,7 @@ class DataFrame(NDFrame):
         Series.memory_usage : Bytes consumed by a Series.
         pandas.Categorical : Memory-efficient array for string values with
             many repeated values.
+        DataFrame.info : Concise summary of a DataFrame.
 
         Examples
         --------

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -1943,7 +1943,11 @@ class DataFrame(NDFrame):
         _put_lines(buf, lines)
 
     def memory_usage(self, index=True, deep=False):
-        """Memory usage of DataFrame columns.
+        """
+        Memory usage of DataFrame columns.
+
+        Memory usage of DataFrame is accessing pandas.DataFrame.info method.
+        A configuration option, `display.memory_usage` (see Parameters)
 
         Parameters
         ----------
@@ -1953,7 +1957,7 @@ class DataFrame(NDFrame):
             the first index of the Series is `Index`.
         deep : bool
             Introspect the data deeply, interrogate
-            `object` dtypes for system-level memory consumption
+            `object` dtypes for system-level memory consumption.
 
         Returns
         -------
@@ -1969,6 +1973,38 @@ class DataFrame(NDFrame):
         See Also
         --------
         numpy.ndarray.nbytes
+
+        Examples
+        --------
+        >>> dtypes = ['int64', 'float64', 'complex128', 'object', 'bool']
+        >>> data = dict([(t, np.random.randint(100, size=5000).astype(t))
+        ...              for t in dtypes])
+        >>> df = pd.DataFrame(data)
+        >>> df.memory_usage()
+        Index            80
+        int64         40000
+        float64       40000
+        complex128    80000
+        object        40000
+        bool           5000
+        dtype: int64
+        >>> df.memory_usage(index=False)
+        int64         40000
+        float64       40000
+        complex128    80000
+        object        40000
+        bool           5000
+        dtype: int64
+        >>> df.memory_usage(index=True)
+        Index            80
+        int64         40000
+        float64       40000
+        complex128    80000
+        object        40000
+        bool           5000
+        dtype: int64
+        >>> df.memory_usage(index=True).sum()
+        205080
         """
         result = Series([c.memory_usage(index=False, deep=deep)
                          for col, c in self.iteritems()], index=self.columns)

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -1944,42 +1944,52 @@ class DataFrame(NDFrame):
 
     def memory_usage(self, index=True, deep=False):
         """
-        Memory usage of DataFrame columns.
+        Return the memory usage of each column in bytes.
 
-        Memory usage of DataFrame is accessing pandas.DataFrame.info method.
+        The memory usage can optionally include the contribution of
+        the index and elements of `object` dtype.
+
         A configuration option, `display.memory_usage` (see Parameters)
 
         Parameters
         ----------
-        index : bool
-            Specifies whether to include memory usage of DataFrame's
-            index in returned Series. If `index=True` (default is False)
-            the first index of the Series is `Index`.
+        index : bool, default False
+            Specifies whether to include the memory usage of the DataFrame's
+            index in returned Series. If ``index=True`` the memory usage of the
+            index the first item in the output.
         deep : bool
-            Introspect the data deeply, interrogate
-            `object` dtypes for system-level memory consumption.
+            If True, introspect the data deeply by interrogating
+            `object` dtypes for system-level memory consumption, and include
+            it in the returned values.
 
         Returns
         -------
         sizes : Series
-            A series with column names as index and memory usage of
-            columns with units of bytes.
-
-        Notes
-        -----
-        Memory usage does not include memory consumed by elements that
-        are not components of the array if deep=False
+            A Series whose index is the original column names and whose values
+            is the memory usage of each column in bytes.
 
         See Also
         --------
-        numpy.ndarray.nbytes
+        numpy.ndarray.nbytes : Total bytes consumed by the elements of an
+            ndarray.
+        Series.memory_usage : Bytes consumed by a Series.
+        pandas.Categorical : Memory-efficient array for string values with
+            many repeated values.
 
         Examples
         --------
         >>> dtypes = ['int64', 'float64', 'complex128', 'object', 'bool']
-        >>> data = dict([(t, np.random.randint(100, size=5000).astype(t))
+        >>> data = dict([(t, np.ones(shape=5000).astype(t))
         ...              for t in dtypes])
         >>> df = pd.DataFrame(data)
+        >>> df.head()
+           int64  float64  complex128 object  bool
+        0      1      1.0      (1+0j)      1  True
+        1      1      1.0      (1+0j)      1  True
+        2      1      1.0      (1+0j)      1  True
+        3      1      1.0      (1+0j)      1  True
+        4      1      1.0      (1+0j)      1  True
+
         >>> df.memory_usage()
         Index            80
         int64         40000
@@ -1988,6 +1998,7 @@ class DataFrame(NDFrame):
         object        40000
         bool           5000
         dtype: int64
+
         >>> df.memory_usage(index=False)
         int64         40000
         float64       40000
@@ -1995,6 +2006,7 @@ class DataFrame(NDFrame):
         object        40000
         bool           5000
         dtype: int64
+
         >>> df.memory_usage(index=True)
         Index            80
         int64         40000
@@ -2003,8 +2015,22 @@ class DataFrame(NDFrame):
         object        40000
         bool           5000
         dtype: int64
-        >>> df.memory_usage(index=True).sum()
-        205080
+
+        The memory footprint of `object` dtype columns is ignored by default:
+        >>> df.memory_usage(deep=True)
+        Index             80
+        int64          40000
+        float64        40000
+        complex128     80000
+        object        160000
+        bool            5000
+        dtype: int64
+
+        Use a Categorical for efficient storage of an object-dtype column with
+        many repeated values.
+
+        >>> df['object'].astype('category').memory_usage(deep=True)
+        5168
         """
         result = Series([c.memory_usage(index=False, deep=deep)
                          for col, c in self.iteritems()], index=self.columns)

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -1440,7 +1440,7 @@ class NDFrame(PandasObject, SelectionMixin):
         Indicator whether DataFrame is empty.
 
         True if DataFrame is entirely empty (no items), meaning any of the
-        axes are of length 0. O
+        axes are of length 0.
 
         Returns
         -------

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -1436,12 +1436,20 @@ class NDFrame(PandasObject, SelectionMixin):
 
     @property
     def empty(self):
-        """True if NDFrame is entirely empty [no items], meaning any of the
+        """
+        True if DataFrame is empty.
+
+        True if DataFrame is entirely empty [no items], meaning any of the
         axes are of length 0.
+
+        Returns
+        -------
+        empty : boolean
+            if DataFrame is empty, return true, if not return false.
 
         Notes
         -----
-        If NDFrame contains only NaNs, it is still not considered empty. See
+        If DataFrame contains only NaNs, it is still not considered empty. See
         the example below.
 
         Examples

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -1437,15 +1437,15 @@ class NDFrame(PandasObject, SelectionMixin):
     @property
     def empty(self):
         """
-        True if DataFrame is empty.
+        Indicator whether DataFrame is empty.
 
-        True if DataFrame is entirely empty [no items], meaning any of the
-        axes are of length 0.
+        True if DataFrame is entirely empty (no items), meaning any of the
+        axes are of length 0. O
 
         Returns
         -------
-        empty : boolean
-            if DataFrame is empty, return true, if not return false.
+        bool
+            If DataFrame is empty, return True, if not return False.
 
         Notes
         -----


### PR DESCRIPTION
Checklist for the pandas documentation sprint (ignore this if you are doing
an unrelated PR):

- [X] PR title is "DOC: update the <your-function-or-method> docstring"
- [X] The validation script passes: `scripts/validate_docstrings.py <your-function-or-method>`
- [X] The PEP8 style check passes: `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [X] The html version looks good: `python doc/make.py --single <your-function-or-method>`
- [X] It has been proofread on language by another sprint participant

Please include the output of the validation script below between the "```" ticks:

```
# paste output of "scripts/validate_docstrings.py <your-function-or-method>" here
# between the "```" (remove this comment, but keep the "```")

################################################################################
###################### Docstring (pandas.DataFrame.empty) ######################
################################################################################

True if DataFrame is empty.

True if DataFrame is entirely empty [no items], meaning any of the
axes are of length 0.

Returns
-------
empty : boolean
    if DataFrame is empty, return true, if not return false.

Notes
-----
If DataFrame contains only NaNs, it is still not considered empty. See
the example below.

Examples
--------
An example of an actual empty DataFrame. Notice the index is empty:

>>> df_empty = pd.DataFrame({'A' : []})
>>> df_empty
Empty DataFrame
Columns: [A]
Index: []
>>> df_empty.empty
True

If we only have NaNs in our DataFrame, it is not considered empty! We
will need to drop the NaNs to make the DataFrame empty:

>>> df = pd.DataFrame({'A' : [np.nan]})
>>> df
    A
0 NaN
>>> df.empty
False
>>> df.dropna().empty
True

See also
--------
pandas.Series.dropna
pandas.DataFrame.dropna

################################################################################
################################## Validation ##################################
################################################################################

Errors found:
	Missing description for See Also "pandas.Series.dropna" reference
	Missing description for See Also "pandas.DataFrame.dropna" reference


################################################################################
################## Docstring (pandas.DataFrame.memory_usage)  ##################
################################################################################

Memory usage of DataFrame columns.

Memory usage of DataFrame is accessing pandas.DataFrame.info method.
A configuration option, `display.memory_usage` (see Parameters)

Parameters
----------
index : bool
    Specifies whether to include memory usage of DataFrame's
    index in returned Series. If `index=True` (default is False)
    the first index of the Series is `Index`.
deep : bool
    Introspect the data deeply, interrogate
    `object` dtypes for system-level memory consumption.

Returns
-------
sizes : Series
    A series with column names as index and memory usage of
    columns with units of bytes.

Notes
-----
Memory usage does not include memory consumed by elements that
are not components of the array if deep=False

See Also
--------
numpy.ndarray.nbytes

Examples
--------
>>> dtypes = ['int64', 'float64', 'complex128', 'object', 'bool']
>>> data = dict([(t, np.random.randint(100, size=5000).astype(t))
...              for t in dtypes])
>>> df = pd.DataFrame(data)
>>> df.memory_usage()
Index            80
int64         40000
float64       40000
complex128    80000
object        40000
bool           5000
dtype: int64
>>> df.memory_usage(index=False)
int64         40000
float64       40000
complex128    80000
object        40000
bool           5000
dtype: int64
>>> df.memory_usage(index=True)
Index            80
int64         40000
float64       40000
complex128    80000
object        40000
bool           5000
dtype: int64
>>> df.memory_usage(index=True).sum()
205080

################################################################################
################################## Validation ##################################
################################################################################

Errors found:
	Missing description for See Also "numpy.ndarray.nbytes" reference

```
If the validation script still gives errors, but you think there is a good reason
to deviate in this case (and there are certainly such cases), please state this
explicitly.

Lastly, I left errors already occurred in the previous version without changes.