### PR TITLE
Doc: Update the DatetimeIndex.strftime docstring

### DIFF
--- a/pandas/core/indexes/datetimelike.py
+++ b/pandas/core/indexes/datetimelike.py
@@ -61,6 +61,8 @@ class DatelikeOps(object):
         return np.asarray(self.format(date_format=date_format),
                           dtype=compat.text_type)
     strftime.__doc__ = """
+    Convert to specified date_format.
+
     Return an array of formatted strings specified by date_format, which
     supports the same string format as the python standard library. Details
     of the string format can be found in `python string format doc <{0}>`__
@@ -68,11 +70,30 @@ class DatelikeOps(object):
     Parameters
     ----------
     date_format : str
-        date format string (e.g. "%Y-%m-%d")
+        Date format string (e.g. "%Y-%m-%d").
 
     Returns
     -------
-    ndarray of formatted strings
+    numpy.ndarray
+        n dimensional array of formatted strings
+
+    See Also
+    --------
+    DatetimeIndex.normalize : Return DatetimeIndex with times to midnight.
+    DatetimeIndex.round : Round the DatetimeIndex to the specified freq.
+    DatetimeIndex.floor : Floor the DatetimeIndex to the specified freq.
+
+    Examples
+    --------
+    >>> data = ['2015-05-01 18:47:05.060000','2014-05-01 18:47:05.110000']
+    >>> df = pd.DataFrame(data, columns=['date'])
+    >>> df.date = pd.to_datetime(df.date)
+    >>> df.date[1]
+    Timestamp('2014-05-01 18:47:05.110000')
+    >>> df.date[1].strftime('%d-%m-%Y')
+    '01-05-2014'
+    >>> df.date[1].strftime('%B %d, %Y, %r')
+    'May 01, 2014, 06:47:05 PM'
     """.format("https://docs.python.org/3/library/datetime.html"
                "#strftime-and-strptime-behavior")
 

--- a/pandas/core/indexes/datetimelike.py
+++ b/pandas/core/indexes/datetimelike.py
@@ -75,7 +75,7 @@ class DatelikeOps(object):
     Returns
     -------
     numpy.ndarray
-        n dimensional array of formatted strings
+        n-dimensional array of formatted strings
 
     See Also
     --------

--- a/pandas/core/indexes/datetimelike.py
+++ b/pandas/core/indexes/datetimelike.py
@@ -61,7 +61,7 @@ class DatelikeOps(object):
         return np.asarray(self.format(date_format=date_format),
                           dtype=compat.text_type)
     strftime.__doc__ = """
-    Convert to specified date_format.
+    Convert to string array using specified date_format.
 
     Return an array of formatted strings specified by date_format, which
     supports the same string format as the python standard library. Details
@@ -75,25 +75,27 @@ class DatelikeOps(object):
     Returns
     -------
     numpy.ndarray
-        n-dimensional array of formatted strings
+        NumPy array of formatted strings
 
     See Also
     --------
+    pandas.to_datetime : Convert the given argument to datetime
     DatetimeIndex.normalize : Return DatetimeIndex with times to midnight.
     DatetimeIndex.round : Round the DatetimeIndex to the specified freq.
     DatetimeIndex.floor : Floor the DatetimeIndex to the specified freq.
 
     Examples
     --------
-    >>> data = ['2015-05-01 18:47:05.060000','2014-05-01 18:47:05.110000']
+    >>> import datetime
+    >>> data = pd.date_range(datetime.datetime(2018,3,10,19,27,52),
+    ...                      periods=4, freq='B')
     >>> df = pd.DataFrame(data, columns=['date'])
-    >>> df.date = pd.to_datetime(df.date)
     >>> df.date[1]
-    Timestamp('2014-05-01 18:47:05.110000')
+    Timestamp('2018-03-13 19:27:52')
     >>> df.date[1].strftime('%d-%m-%Y')
-    '01-05-2014'
+    '13-03-2018'
     >>> df.date[1].strftime('%B %d, %Y, %r')
-    'May 01, 2014, 06:47:05 PM'
+    'March 13, 2018, 07:27:52 PM'
     """.format("https://docs.python.org/3/library/datetime.html"
                "#strftime-and-strptime-behavior")
 


### PR DESCRIPTION
Checklist for the pandas documentation sprint (ignore this if you are doing
an unrelated PR):

- [ ] PR title is "DOC: update the <your-function-or-method> docstring"
- [ ] The validation script passes: `scripts/validate_docstrings.py <your-function-or-method>`
- [ ] The PEP8 style check passes: `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] The html version looks good: `python doc/make.py --single <your-function-or-method>`
- [ ] It has been proofread on language by another sprint participant

Please include the output of the validation script below between the "```" ticks:

```
################################################################################
################## Docstring (pandas.DatetimeIndex.strftime)  ##################
################################################################################

Convert to specified date_format.

Return an array of formatted strings specified by date_format, which
supports the same string format as the python standard library. Details
of the string format can be found in `python string format doc <https://docs.python.org/3/library/datetime.html#strftime-and-strptime-behavior>`__

Parameters
----------
date_format : str
    Date format string (e.g. "%Y-%m-%d").

Returns
-------
numpy.ndarray
    n-dimensional array of formatted strings

See Also
--------
DatetimeIndex.normalize : Return DatetimeIndex with times to midnight.
DatetimeIndex.round : Round the DatetimeIndex to the specified freq.
DatetimeIndex.floor : Floor the DatetimeIndex to the specified freq.

Examples
--------
>>> data = ['2015-05-01 18:47:05.060000','2014-05-01 18:47:05.110000']
>>> df = pd.DataFrame(data, columns=['date'])
>>> df.date = pd.to_datetime(df.date)
>>> df.date[1]
Timestamp('2014-05-01 18:47:05.110000')
>>> df.date[1].strftime('%d-%m-%Y')
'01-05-2014'
>>> df.date[1].strftime('%B %d, %Y, %r')
'May 01, 2014, 06:47:05 PM'

################################################################################
################################## Validation ##################################
################################################################################

Docstring for "pandas.DatetimeIndex.strftime" correct. :)
```

If the validation script still gives errors, but you think there is a good reason
to deviate in this case (and there are certainly such cases), please state this
explicitly.


Checklist for other PRs (remove this part if you are doing a PR for the pandas documentation sprint):