### PR TITLE
DOC: update the Series.reset_index DocString

### DIFF
--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -1005,27 +1005,27 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
         Reset the index of the Serie.
         
         For an Index, the index name will be used (if set), 
-        otherwise a default index or `level_0` (if `index` is already taken) 
+        otherwise a default index or level_0 (if index is already taken) 
         will be used.
         For a MultiIndex, return a new Series with labeling
         information in the columns under the index names, defaulting to
-        `level_0`, `level_1`, etc. if any are None. 
+        level_0, level_1, etc. if any are None. 
 
         Parameters
         ----------
-        level : int, str, tuple, or list, default `None`
+        level : int, str, tuple, or list, default None
             Only remove the given levels from the index. Removes all levels by
             default.
-        drop : `bool`, default `False`
+        drop : bool, default False
             Do not try to insert index into dataframe columns.
-        name : `object`, default `None`
+        name : object, default None
             The name of the column corresponding to the Series values.
-        inplace : `bool`, default `False`
+        inplace : `bool`, default False
             Modify the Series in place (do not create a new object).
 
         Returns
         ----------
-        reset : `DataFrame`, or Series if `drop == True`
+        reset : DataFrame, or Series if `drop == True`
 
         See Also
         --------
@@ -1033,8 +1033,15 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
 
         Examples
         --------
+
+        Generate a pandas.Series with a given Index.
+
         >>> s = pd.Series([1, 2, 3, 4], index=pd.Index(['a', 'b', 'c', 'd'],
         ...                                            name = 'idx'))
+
+        To generate a pandas.DataFrame with resetted index, 
+        call the reset_index() method.
+
         >>> s.reset_index()
           idx  0
         0   a  1
@@ -1042,8 +1049,19 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
         2   c  3
         3   d  4
 
-        >>> s = pd.Series([1, 2, 3, 4], index=pd.Index(['a', 'b', 'c', 'd'],
-        ...                                            name = 'idx'))
+        To specify the name of the column corrisponding
+        to the Series values, use the name parameter.
+
+        >>> s.reset_index(name='values')
+          idx  values
+        0   a       1
+        1   b       2
+        2   c       3
+        3   d       4
+
+        To generate a new pandas.Series with the resetted
+        index, set the drop parameter to True.
+
         >>> s.reset_index(drop=True)
         0    1
         1    2
@@ -1051,17 +1069,9 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
         3    4
         dtype: int64
 
-        >>> s = pd.Series([1, 2, 3, 4], index=pd.Index(['a', 'b', 'c', 'd'],
-        ...                                            name = 'idx'))
-        >>> s.reset_index(name = 'new_idx')
-          idx  new_idx
-        0   a        1
-        1   b        2
-        2   c        3
-        3   d        4
+        To update the Series in place, without generating a new one
+        set inplace to True. Note that it also requires drop=True.
 
-        >>> s = pd.Series([1, 2, 3, 4], index=pd.Index(['a', 'b', 'c', 'd'],
-        ...                                            name = 'idx'))
         >>> s.reset_index(inplace=True, drop=True)
         >>> s
         0    1
@@ -1069,6 +1079,8 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
         2    3
         3    4
         dtype: int64
+
+        Generate a MultiIndex Series.
 
         >>> arrays = [np.array(['bar', 'bar', 'baz', 'baz', 'foo',
         ...                     'foo', 'qux', 'qux']),
@@ -1078,6 +1090,10 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
         ...     range(8),
         ...     index=pd.MultiIndex.from_arrays(arrays,
         ...                                     names=['a', 'b']))
+
+        To remove a specific level from the Index, use the 
+        level parameter.
+
         >>> s2.reset_index(level='a')
                a  0
         b
@@ -1089,7 +1105,23 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
         two  foo  5
         one  qux  6
         two  qux  7
+
+        If level parameter is not set, all levels are removed
+        from the Index.
+        
+        >>> s2.reset_index()
+             a    b  0
+        0  bar  one  0
+        1  bar  two  1
+        2  baz  one  2
+        3  baz  two  3
+        4  foo  one  4
+        5  foo  two  5
+        6  qux  one  6
+        7  qux  two  7
         """
+
+
         inplace = validate_bool_kwarg(inplace, 'inplace')
         if drop:
             new_index = com._default_index(len(self))

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -1004,10 +1004,10 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
         """
         Reset the index of the Serie.
 
-        For a Serie with multi-level index, return a new Serie with labeling 
-        information in the columns under the index names, defaulting to ‘level_0’, 
-        ‘level_1’, etc. if any are None. For a standard index, 
-        the index name will be used (if set), otherwise a default 
+        For a Serie with multi-level index, return a new Serie with labeling
+        information in the columns under the index names, defaulting to
+        ‘level_0’, ‘level_1’, etc. if any are None. For a standard index,
+        the index name will be used (if set), otherwise a default
         ‘index’ or ‘level_0’ (if ‘index’ is already taken) will be used.
 
         Parameters

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -1002,7 +1002,7 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
 
     def reset_index(self, level=None, drop=False, name=None, inplace=False):
         """
-        Reset the index of the Serie.
+        Reset the index of the Series.
         
         For an Index, the index name will be used (if set), 
         otherwise a default index or level_0 (if index is already taken) 
@@ -1108,7 +1108,7 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
 
         If level parameter is not set, all levels are removed
         from the Index.
-        
+
         >>> s2.reset_index()
              a    b  0
         0  bar  one  0

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -1004,15 +1004,15 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
         """
         Reset the index of the Serie.
 
-        For a Serie with multi-level index, return a new Serie with labeling
+        For a Series with multi-level index, return a new Series with labeling
         information in the columns under the index names, defaulting to
-        ‘level_0’, ‘level_1’, etc. if any are None. For a standard index,
+        `level_0`, `level_1`, etc. if any are None. For a standard index,
         the index name will be used (if set), otherwise a default
-        ‘index’ or ‘level_0’ (if ‘index’ is already taken) will be used.
+        `index` or `level_0` (if `index` is already taken) will be used.
 
         Parameters
         ----------
-        level : `int`, `str`, `tuple`, or `list`, default `None`
+        level : int, str, tuple, or list, default `None`
             Only remove the given levels from the index. Removes all levels by
             default.
         drop : `boolean`, default `False`
@@ -1028,7 +1028,7 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
 
         See Also
         --------
-        :meth:`pandas.DataFrame.reset_index`: Analogous funciton for DataFrame
+        :meth:`pandas.DataFrame.reset_index`: Analogous function for DataFrame
 
         Examples
         --------

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -1028,7 +1028,7 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
 
         See Also
         --------
-        :meth:`pandas.DataFrame.reset_index`: Analogous function for DataFrame
+        pandas.DataFrame.reset_index: Analogous function for DataFrame
 
         Examples
         --------
@@ -1040,6 +1040,13 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
         1   b  2
         2   c  3
         3   d  4
+
+        >>> s.reset_index(drop=True)
+        0    1
+        1    2
+        2    3
+        3    4
+        dtype: int64
 
         >>> arrays = [np.array(['bar', 'bar', 'baz', 'baz', 'foo',
         ...                     'foo', 'qux', 'qux']),

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -1002,24 +1002,33 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
 
     def reset_index(self, level=None, drop=False, name=None, inplace=False):
         """
-        Analogous to the :meth:`pandas.DataFrame.reset_index` function, see
-        docstring there.
+        Reset the index of the Serie.
+
+        For a Serie with multi-level index, return a new Serie with labeling 
+        information in the columns under the index names, defaulting to ‘level_0’, 
+        ‘level_1’, etc. if any are None. For a standard index, 
+        the index name will be used (if set), otherwise a default 
+        ‘index’ or ‘level_0’ (if ‘index’ is already taken) will be used.
 
         Parameters
         ----------
-        level : int, str, tuple, or list, default None
+        level : `int`, `str`, `tuple`, or `list`, default `None`
             Only remove the given levels from the index. Removes all levels by
-            default
-        drop : boolean, default False
-            Do not try to insert index into dataframe columns
-        name : object, default None
-            The name of the column corresponding to the Series values
-        inplace : boolean, default False
-            Modify the Series in place (do not create a new object)
+            default.
+        drop : `boolean`, default `False`
+            Do not try to insert index into dataframe columns.
+        name : `object`, default `None`
+            The name of the column corresponding to the Series values.
+        inplace : `boolean`, default `False`
+            Modify the Series in place (do not create a new object).
 
         Returns
         ----------
-        resetted : DataFrame, or Series if drop == True
+        resetted : `DataFrame`, or Series if `drop == True`
+
+        See Also
+        --------
+        :meth:`pandas.DataFrame.reset_index`: Analogous funciton for DataFrame
 
         Examples
         --------

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -1109,7 +1109,6 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
         2  baz  one    2
         3  baz  two    3
         """
-
         inplace = validate_bool_kwarg(inplace, 'inplace')
         if drop:
             new_index = com._default_index(len(self))

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -1003,12 +1003,13 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
     def reset_index(self, level=None, drop=False, name=None, inplace=False):
         """
         Reset the index of the Serie.
-
+        
+        For a standard index, the index name will be used (if set), 
+        otherwise a default index or `level_0` (if `index` is already taken) 
+        will be used.
         For a Series with multi-level index, return a new Series with labeling
         information in the columns under the index names, defaulting to
-        `level_0`, `level_1`, etc. if any are None. For a standard index,
-        the index name will be used (if set), otherwise a default
-        `index` or `level_0` (if `index` is already taken) will be used.
+        `level_0`, `level_1`, etc. if any are None. 
 
         Parameters
         ----------

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -1004,10 +1004,10 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
         """
         Reset the index of the Serie.
         
-        For a standard index, the index name will be used (if set), 
+        For an Index, the index name will be used (if set), 
         otherwise a default index or `level_0` (if `index` is already taken) 
         will be used.
-        For a Series with multi-level index, return a new Series with labeling
+        For a MultiIndex, return a new Series with labeling
         information in the columns under the index names, defaulting to
         `level_0`, `level_1`, etc. if any are None. 
 
@@ -1016,16 +1016,16 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
         level : int, str, tuple, or list, default `None`
             Only remove the given levels from the index. Removes all levels by
             default.
-        drop : `boolean`, default `False`
+        drop : `bool`, default `False`
             Do not try to insert index into dataframe columns.
         name : `object`, default `None`
             The name of the column corresponding to the Series values.
-        inplace : `boolean`, default `False`
+        inplace : `bool`, default `False`
             Modify the Series in place (do not create a new object).
 
         Returns
         ----------
-        resetted : `DataFrame`, or Series if `drop == True`
+        reset : `DataFrame`, or Series if `drop == True`
 
         See Also
         --------
@@ -1042,7 +1042,28 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
         2   c  3
         3   d  4
 
+        >>> s = pd.Series([1, 2, 3, 4], index=pd.Index(['a', 'b', 'c', 'd'],
+        ...                                            name = 'idx'))
         >>> s.reset_index(drop=True)
+        0    1
+        1    2
+        2    3
+        3    4
+        dtype: int64
+
+        >>> s = pd.Series([1, 2, 3, 4], index=pd.Index(['a', 'b', 'c', 'd'],
+        ...                                            name = 'idx'))
+        >>> s.reset_index(name = 'new_idx')
+          idx  new_idx
+        0   a        1
+        1   b        2
+        2   c        3
+        3   d        4
+
+        >>> s = pd.Series([1, 2, 3, 4], index=pd.Index(['a', 'b', 'c', 'd'],
+        ...                                            name = 'idx'))
+        >>> s.reset_index(inplace=True, drop=True)
+        >>> s
         0    1
         1    2
         2    3

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -1002,16 +1002,14 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
 
     def reset_index(self, level=None, drop=False, name=None, inplace=False):
         """
-        Generate a new DataFrame with columns containing the data and 
-        the index of the original Series, or, if drop is True, 
-        a Series with numeric index.
+        Generate a new DataFrame or Series with resetted index.
         
-        For an Index Series, the results is a two-column DataFrame with 
-        index tourned in column.
-        For a MultiIndex Series, the results is a multi-column 
-        DataFrame with each level being turned into a column.
-        The new columns will be named level_n (with n increasing frm 0) 
-        if the name is None. 
+        For a Series with a single level index (Index), the results is a 
+        two-column DataFrame with index tourned in column.
+        For a Series with multi-level index (MultiIndex), the results is a 
+        multi-column DataFrame with each level being turned into a column.
+        The new columns will be named level_n (with n increasing from 0) 
+        if the name parameter is None. 
 
         Parameters
         ----------
@@ -1022,12 +1020,13 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
             Do not try to insert index into dataframe columns.
         name : object, default None
             The name of the column corresponding to the Series values.
-        inplace : `bool`, default False
+        inplace : bool, default False
             Modify the Series in place (do not create a new object).
 
         Returns
-        ----------
-        reset : DataFrame, or Series if drop == True
+        -------
+        reset : DataFrame, or 
+        reset : Series
 
         See Also
         --------
@@ -1036,13 +1035,12 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
         Examples
         --------
 
-        Generate a pandas.Series.
+        Generate a Series.
 
         >>> s = pd.Series([1, 2, 3, 4], index=pd.Index(['a', 'b', 'c', 'd'],
-        ...                                            name = 'idx'))
+        ...                                            name='idx'))
 
-        To generate a pandas.DataFrame with default index, 
-        call the reset_index() method.
+        Generate a DataFrame with default index.
 
         >>> s.reset_index()
           idx  0
@@ -1051,7 +1049,7 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
         2   c  3
         3   d  4
 
-        To specify the name of the column corrisponding
+        To specify the name of the column corresponding
         to the Series values, use the name parameter.
 
         >>> s.reset_index(name='values')
@@ -1061,7 +1059,7 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
         2   c       3
         3   d       4
 
-        To generate a new pandas.Series with the default
+        To generate a new Series with the default
         index, set the drop parameter to True.
 
         >>> s.reset_index(drop=True)
@@ -1082,14 +1080,12 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
         3    4
         dtype: int64
 
-        Generate a MultiIndex Series.
+        Generate a Series with multi-level index (MultiIndex).
 
-        >>> arrays = [np.array(['bar', 'bar', 'baz', 'baz', 'foo',
-        ...                     'foo', 'qux', 'qux']),
-        ...           np.array(['one', 'two', 'one', 'two', 'one', 'two',
-        ...                     'one', 'two'])]
+        >>> arrays = [np.array(['bar', 'bar', 'baz', 'baz']),
+        ...           np.array(['one', 'two', 'one', 'two'])]
         >>> s2 = pd.Series(
-        ...     range(8),
+        ...     range(4),
         ...     index=pd.MultiIndex.from_arrays(arrays,
         ...                                     names=['a', 'b']))
 
@@ -1103,10 +1099,6 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
         two  bar  1
         one  baz  2
         two  baz  3
-        one  foo  4
-        two  foo  5
-        one  qux  6
-        two  qux  7
 
         If level parameter is not set, all levels are removed
         from the Index.
@@ -1117,12 +1109,7 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
         1  bar  two  1
         2  baz  one  2
         3  baz  two  3
-        4  foo  one  4
-        5  foo  two  5
-        6  qux  one  6
-        7  qux  two  7
         """
-
 
         inplace = validate_bool_kwarg(inplace, 'inplace')
         if drop:

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -1002,55 +1002,56 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
 
     def reset_index(self, level=None, drop=False, name=None, inplace=False):
         """
-        Generate a new DataFrame or Series with resetted index.
-        
-        For a Series with a single level index (Index), the results is a 
-        two-column DataFrame with index tourned in column.
-        For a Series with multi-level index (MultiIndex), the results is a 
-        multi-column DataFrame with each level being turned into a column.
-        The new columns will be named level_n (with n increasing from 0) 
-        if the name parameter is None. 
+        Generate a new DataFrame or Series with the index reset.
+
+        This is useful when the index needs to be treated as a column, or
+        when the index is meaningless and needs to be reset to the default
+        before another operation.
 
         Parameters
         ----------
-        level : int, str, tuple, or list, default None
-            Only remove the given levels from the index. Removes all levels by
-            default.
+        level : int, str, tuple, or list, default optional
+            For a Series with a MultiIndex, only remove the specified levels
+            from the index. Removes all levels by default.
         drop : bool, default False
-            Do not try to insert index into dataframe columns.
-        name : object, default None
-            The name of the column corresponding to the Series values.
+            Just reset the index, without inserting it as a column in
+            the new DataFrame.
+        name : object, optional
+            The name to use for the column containing the original Series
+            values. Uses ``self.name`` by default. This argument is ignored
+            when `drop` is True.
         inplace : bool, default False
             Modify the Series in place (do not create a new object).
 
         Returns
         -------
-        reset : DataFrame, or 
-        reset : Series
+        Series or DataFrame
+            When `drop` is False (the default), a DataFrame is returned.
+            The newly created columns will come first in the DataFrame,
+            followed by the original Series values.
+            When `drop` is True, a `Series` is returned.
+            In either case, if ``inplace=True``, no value is returned.
 
         See Also
         --------
-        pandas.DataFrame.reset_index: Analogous function for DataFrame
+        DataFrame.reset_index: Analogous function for DataFrame.
 
         Examples
         --------
 
-        Generate a Series.
-
-        >>> s = pd.Series([1, 2, 3, 4], index=pd.Index(['a', 'b', 'c', 'd'],
-        ...                                            name='idx'))
+        >>> s = pd.Series([1, 2, 3, 4], name='foo',
+        ...               index=pd.Index(['a', 'b', 'c', 'd'], name='idx'))
 
         Generate a DataFrame with default index.
 
         >>> s.reset_index()
-          idx  0
-        0   a  1
-        1   b  2
-        2   c  3
-        3   d  4
+          idx  foo
+        0   a    1
+        1   b    2
+        2   c    3
+        3   d    4
 
-        To specify the name of the column corresponding
-        to the Series values, use the name parameter.
+        To specify the name of the new column use `name`.
 
         >>> s.reset_index(name='values')
           idx  values
@@ -1059,18 +1060,17 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
         2   c       3
         3   d       4
 
-        To generate a new Series with the default
-        index, set the drop parameter to True.
+        To generate a new Series with the default set `drop` to True.
 
         >>> s.reset_index(drop=True)
         0    1
         1    2
         2    3
         3    4
-        dtype: int64
+        Name: foo, dtype: int64
 
         To update the Series in place, without generating a new one
-        set inplace to True. Note that it also requires drop=True.
+        set `inplace` to True. Note that it also requires ``drop=True``.
 
         >>> s.reset_index(inplace=True, drop=True)
         >>> s
@@ -1078,37 +1078,36 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
         1    2
         2    3
         3    4
-        dtype: int64
+        Name: foo, dtype: int64
 
-        Generate a Series with multi-level index (MultiIndex).
+        The `level` parameter is interesting for Series with a multi-level
+        index.
 
         >>> arrays = [np.array(['bar', 'bar', 'baz', 'baz']),
         ...           np.array(['one', 'two', 'one', 'two'])]
         >>> s2 = pd.Series(
-        ...     range(4),
+        ...     range(4), name='foo',
         ...     index=pd.MultiIndex.from_arrays(arrays,
         ...                                     names=['a', 'b']))
 
-        To remove a specific level from the Index, use the 
-        level parameter.
+        To remove a specific level from the Index, use `level`.
 
         >>> s2.reset_index(level='a')
-               a  0
+               a  foo
         b
-        one  bar  0
-        two  bar  1
-        one  baz  2
-        two  baz  3
+        one  bar    0
+        two  bar    1
+        one  baz    2
+        two  baz    3
 
-        If level parameter is not set, all levels are removed
-        from the Index.
+        If `level` is not set, all levels are removed from the Index.
 
         >>> s2.reset_index()
-             a    b  0
-        0  bar  one  0
-        1  bar  two  1
-        2  baz  one  2
-        3  baz  two  3
+             a    b  foo
+        0  bar  one    0
+        1  bar  two    1
+        2  baz  one    2
+        3  baz  two    3
         """
 
         inplace = validate_bool_kwarg(inplace, 'inplace')

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -1002,14 +1002,16 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
 
     def reset_index(self, level=None, drop=False, name=None, inplace=False):
         """
-        Reset the index of the Series.
+        Generate a new DataFrame with columns containing the data and 
+        the index of the original Series, or, if drop is True, 
+        a Series with numeric index.
         
-        For an Index, the index name will be used (if set), 
-        otherwise a default index or level_0 (if index is already taken) 
-        will be used.
-        For a MultiIndex, return a new Series with labeling
-        information in the columns under the index names, defaulting to
-        level_0, level_1, etc. if any are None. 
+        For an Index Series, the results is a two-column DataFrame with 
+        index tourned in column.
+        For a MultiIndex Series, the results is a multi-column 
+        DataFrame with each level being turned into a column.
+        The new columns will be named level_n (with n increasing frm 0) 
+        if the name is None. 
 
         Parameters
         ----------
@@ -1025,7 +1027,7 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
 
         Returns
         ----------
-        reset : DataFrame, or Series if `drop == True`
+        reset : DataFrame, or Series if drop == True
 
         See Also
         --------
@@ -1034,12 +1036,12 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
         Examples
         --------
 
-        Generate a pandas.Series with a given Index.
+        Generate a pandas.Series.
 
         >>> s = pd.Series([1, 2, 3, 4], index=pd.Index(['a', 'b', 'c', 'd'],
         ...                                            name = 'idx'))
 
-        To generate a pandas.DataFrame with resetted index, 
+        To generate a pandas.DataFrame with default index, 
         call the reset_index() method.
 
         >>> s.reset_index()
@@ -1059,7 +1061,7 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
         2   c       3
         3   d       4
 
-        To generate a new pandas.Series with the resetted
+        To generate a new pandas.Series with the default
         index, set the drop parameter to True.
 
         >>> s.reset_index(drop=True)


### PR DESCRIPTION
Checklist for the pandas documentation sprint (ignore this if you are doing
an unrelated PR):

- [x] PR title is "DOC: update the <your-function-or-method> docstring"
- [x] The validation script passes: `scripts/validate_docstrings.py <your-function-or-method>`
- [x] The PEP8 style check passes: `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] The html version looks good: `python doc/make.py --single <your-function-or-method>`
- [x] It has been proofread on language by another sprint participant

Please include the output of the validation script below between the "```" ticks:

```
# paste output of "scripts/validate_docstrings.py <your-function-or-method>" here
# between the "```" (remove this comment, but keep the "```")

################################################################################
############## Docstring (pandas.core.series.Series.reset_index)  ##############
################################################################################

Reset the index of the Serie.

For a Serie with multi-level index, return a new Serie with labeling
information in the columns under the index names, defaulting to ‘level_0’,
‘level_1’, etc. if any are None. For a standard index,
the index name will be used (if set), otherwise a default
‘index’ or ‘level_0’ (if ‘index’ is already taken) will be used.

Parameters
----------
level : `int`, `str`, `tuple`, or `list`, default `None`
    Only remove the given levels from the index. Removes all levels by
    default.
drop : `boolean`, default `False`
    Do not try to insert index into dataframe columns.
name : `object`, default `None`
    The name of the column corresponding to the Series values.
inplace : `boolean`, default `False`
    Modify the Series in place (do not create a new object).

Returns
----------
resetted : `DataFrame`, or Series if `drop == True`

See Also
--------
:meth:`pandas.DataFrame.reset_index`: Analogous funciton for DataFrame

Examples
--------
>>> s = pd.Series([1, 2, 3, 4], index=pd.Index(['a', 'b', 'c', 'd'],
...                                            name = 'idx'))
>>> s.reset_index()
  idx  0
0   a  1
1   b  2
2   c  3
3   d  4

>>> arrays = [np.array(['bar', 'bar', 'baz', 'baz', 'foo',
...                     'foo', 'qux', 'qux']),
...           np.array(['one', 'two', 'one', 'two', 'one', 'two',
...                     'one', 'two'])]
>>> s2 = pd.Series(
...     range(8),
...     index=pd.MultiIndex.from_arrays(arrays,
...                                     names=['a', 'b']))
>>> s2.reset_index(level='a')
       a  0
b
one  bar  0
two  bar  1
one  baz  2
two  baz  3
one  foo  4
two  foo  5
one  qux  6
two  qux  7

################################################################################
################################## Validation ##################################
################################################################################

Docstring for "pandas.core.series.Series.reset_index" correct. :)
```
