### PR TITLE
DOC: Improved the docstring of pandas.Series.sample

### DIFF
--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -3718,7 +3718,9 @@ class NDFrame(PandasObject, SelectionMixin):
     def sample(self, n=None, frac=None, replace=False, weights=None,
                random_state=None, axis=None):
         """
-        Returns a random sample of items from an axis of object.
+        Return a random sample of items from an axis of object.
+
+        You can use `random_state` for reproducibility.
 
         Parameters
         ----------
@@ -3753,9 +3755,15 @@ class NDFrame(PandasObject, SelectionMixin):
         -------
         A new object of same type as caller.
 
+        See Also
+        --------
+        Series.sample : Returns a random sample of items
+            from an axis of object.
+        DataFrame.sample : Returns a random sample of items
+            from an axis of object.
+
         Examples
         --------
-
         Generate an example ``Series`` and ``DataFrame``:
 
         >>> s = pd.Series(np.random.randn(50))
@@ -3794,6 +3802,16 @@ class NDFrame(PandasObject, SelectionMixin):
         40  0.823173 -0.078816  1.009536  1.015108
         15  1.421154 -0.055301 -1.922594 -0.019696
         6  -0.148339  0.832938  1.787600 -1.383767
+
+        You can use `random state` for reproducibility:
+
+        >>> df.sample(random_state=1)
+        A         B         C         D
+        37 -2.027662  0.103611  0.237496 -0.165867
+        43 -0.259323 -0.583426  1.516140 -0.479118
+        12 -1.686325 -0.579510  0.985195 -0.460286
+        8   1.167946  0.429082  1.215742 -1.636041
+        9   1.197475 -0.864188  1.554031 -1.505264
         """
 
         if axis is None:

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -3755,13 +3755,6 @@ class NDFrame(PandasObject, SelectionMixin):
         -------
         A new object of same type as caller.
 
-        See Also
-        --------
-        Series.sample : Returns a random sample of items
-            from an axis of object.
-        DataFrame.sample : Returns a random sample of items
-            from an axis of object.
-
         Examples
         --------
         Generate an example ``Series`` and ``DataFrame``:


### PR DESCRIPTION
Checklist for the pandas documentation sprint (ignore this if you are doing
an unrelated PR):

- [x] PR title is "DOC: update the <your-function-or-method> docstring"
- [x] The validation script passes: `scripts/validate_docstrings.py <your-function-or-method>`
- [x] The PEP8 style check passes: `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] The html version looks good: `python doc/make.py --single <your-function-or-method>`
- [x] It has been proofread on language by another sprint participant

Please include the output of the validation script below between the "```" ticks:

```
 
################################################################################
####################### Docstring (pandas.Series.sample) #######################
################################################################################

Return a random sample of items from an axis of object.

You can use `random state` for reproducibility

Parameters
----------
n : int, optional
    Number of items from axis to return. Cannot be used with `frac`.
    Default = 1 if `frac` = None.
frac : float, optional
    Fraction of axis items to return. Cannot be used with `n`.
replace : boolean, optional
    Sample with or without replacement. Default = False.
weights : str or ndarray-like, optional
    Default 'None' results in equal probability weighting.
    If passed a Series, will align with target object on index. Index
    values in weights not found in sampled object will be ignored and
    index values in sampled object not in weights will be assigned
    weights of zero.
    If called on a DataFrame, will accept the name of a column
    when axis = 0.
    Unless weights are a Series, weights must be same length as axis
    being sampled.
    If weights do not sum to 1, they will be normalized to sum to 1.
    Missing values in the weights column will be treated as zero.
    inf and -inf values not allowed.
random_state : int or numpy.random.RandomState, optional
    Seed for the random number generator (if int), or numpy RandomState
    object.
axis : int or string, optional
    Axis to sample. Accepts axis number or name. Default is stat axis
    for given data type (0 for Series and DataFrames, 1 for Panels).

Returns
-------
A new object of same type as caller.

See Also
--------
Series.sample : Returns a random sample of items
    from an axis of object.
DataFrame.sample : Returns a random sample of items
    from an axis of object.
Panel.sample : Returns a random sample of items
    from an axis of object.

Examples
--------
Generate an example ``Series`` and ``DataFrame``:

>>> s = pd.Series(np.random.randn(50))
>>> s.head()
0   -0.038497
1    1.820773
2   -0.972766
3   -1.598270
4   -1.095526
dtype: float64
>>> df = pd.DataFrame(np.random.randn(50, 4), columns=list('ABCD'))
>>> df.head()
          A         B         C         D
0  0.016443 -2.318952 -0.566372 -1.028078
1 -1.051921  0.438836  0.658280 -0.175797
2 -1.243569 -0.364626 -0.215065  0.057736
3  1.768216  0.404512 -0.385604 -1.457834
4  1.072446 -1.137172  0.314194 -0.046661

Next extract a random sample from both of these objects...

3 random elements from the ``Series``:

>>> s.sample(n=3)
27   -0.994689
55   -1.049016
67   -0.224565
dtype: float64

And a random 10% of the ``DataFrame`` with replacement:

>>> df.sample(frac=0.1, replace=True)
           A         B         C         D
35  1.981780  0.142106  1.817165 -0.290805
49 -1.336199 -0.448634 -0.789640  0.217116
40  0.823173 -0.078816  1.009536  1.015108
15  1.421154 -0.055301 -1.922594 -0.019696
6  -0.148339  0.832938  1.787600 -1.383767

################################################################################
################################## Validation ##################################
################################################################################

Errors found:
	Examples do not pass tests

################################################################################
################################### Doctests ###################################
################################################################################

**********************************************************************
Line 53, in pandas.Series.sample
Failed example:
    s.head()
Expected:
    0   -0.038497
    1    1.820773
    2   -0.972766
    3   -1.598270
    4   -1.095526
    dtype: float64
Got:
    0   -0.316288
    1   -0.109803
    2    0.398450
    3   -0.307658
    4   -0.210365
    dtype: float64
**********************************************************************
Line 61, in pandas.Series.sample
Failed example:
    df.head()
Expected:
              A         B         C         D
    0  0.016443 -2.318952 -0.566372 -1.028078
    1 -1.051921  0.438836  0.658280 -0.175797
    2 -1.243569 -0.364626 -0.215065  0.057736
    3  1.768216  0.404512 -0.385604 -1.457834
    4  1.072446 -1.137172  0.314194 -0.046661
Got:
              A         B         C         D
    0  0.374238 -0.608431 -0.126340 -0.764207
    1  0.433942  0.576081 -0.704511  1.708611
    2  1.145009 -0.051829 -0.614948 -0.458692
    3  0.153273 -0.692912 -0.200969 -0.725891
    4  0.780466  0.616172  2.143758 -2.081198
**********************************************************************
Line 73, in pandas.Series.sample
Failed example:
    s.sample(n=3)
Expected:
    27   -0.994689
    55   -1.049016
    67   -0.224565
    dtype: float64
Got:
    20    1.077020
    41   -0.847340
    11   -1.567316
    dtype: float64
**********************************************************************
Line 81, in pandas.Series.sample
Failed example:
    df.sample(frac=0.1, replace=True)
Expected:
               A         B         C         D
    35  1.981780  0.142106  1.817165 -0.290805
    49 -1.336199 -0.448634 -0.789640  0.217116
    40  0.823173 -0.078816  1.009536  1.015108
    15  1.421154 -0.055301 -1.922594 -0.019696
    6  -0.148339  0.832938  1.787600 -1.383767
Got:
               A         B         C         D
    7   0.663274  0.980879 -0.290907 -0.063392
    7   0.663274  0.980879 -0.290907 -0.063392
    37  2.074749 -0.062022 -0.766187 -0.501413
    36 -0.315902  0.125332 -1.271485 -1.619816
    44  1.438970 -1.112939  0.386373  0.828501

```

The validation errors are correct because sample requires a randomic and unpredictable output.


Checklist for other PRs (remove this part if you are doing a PR for the pandas documentation sprint):

