### PR TITLE
DOC: update validate_docstrings.py Validation script checks for tabs

### DIFF
--- a/scripts/validate_docstrings.py
+++ b/scripts/validate_docstrings.py
@@ -455,6 +455,12 @@ def validate_one(func_name):
             if not rel_desc:
                 errs.append('Missing description for '
                             'See Also "{}" reference'.format(rel_name))
+
+    for line in doc.raw_doc.splitlines():
+        if re.match("^ *\t", line):
+            errs.append('Tabs found at the start of line "{}", '
+                        'please use whitespace only'.format(line.lstrip()))
+
     examples_errs = ''
     if not doc.examples:
         errs.append('No examples section found')


### PR DESCRIPTION
Add a check to validate the docstrings don't have tabs.
The documentation uses whitespace only, adding the check will prevent
tabs being added in the sprint or future submissions

Sample output (elided non changed parts)
```
...

################################################################################
################################## Validation ##################################
################################################################################

Errors found:
	...
	Tabs found in the docstring, please use whitespace only
	...

```
