### PR TITLE
DOC: update the pandas.Index.drop_duplicates and pandas.Series.drop_duplicates docstring

### DIFF
--- a/pandas/core/base.py
+++ b/pandas/core/base.py
@@ -1184,24 +1184,6 @@ class IndexOpsMixin(object):
         # needs coercion on the key (DatetimeIndex does already)
         return self.values.searchsorted(value, side=side, sorter=sorter)
 
-    _shared_docs['drop_duplicates'] = (
-        """Return %(klass)s with duplicate values removed
-
-        Parameters
-        ----------
-
-        keep : {'first', 'last', False}, default 'first'
-            - ``first`` : Drop duplicates except for the first occurrence.
-            - ``last`` : Drop duplicates except for the last occurrence.
-            - False : Drop all duplicates.
-        %(inplace)s
-
-        Returns
-        -------
-        deduplicated : %(klass)s
-        """)
-
-    @Appender(_shared_docs['drop_duplicates'] % _indexops_doc_kwargs)
     def drop_duplicates(self, keep='first', inplace=False):
         inplace = validate_bool_kwarg(inplace, 'inplace')
         if isinstance(self, ABCIndexClass):

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -4042,7 +4042,7 @@ class Index(IndexOpsMixin, PandasObject):
         Examples
         --------
         Generate an pandas.Index with duplicate values.
-        
+
         >>> idx = pd.Index(['lama', 'cow', 'lama', 'beetle', 'lama', 'hippo'])
 
         With the 'keep' parameter, the selection behaviour of duplicated values

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -4027,7 +4027,7 @@ class Index(IndexOpsMixin, PandasObject):
 
         Parameters
         ----------
-        keep : {'first', 'last', False}, default 'first'
+        keep : {'first', 'last', ``False``}, default 'first'
             - 'first' : Drop duplicates except for the first occurrence.
             - 'last' : Drop duplicates except for the last occurrence.
             - ``False`` : Drop all duplicates.

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -4037,7 +4037,7 @@ class Index(IndexOpsMixin, PandasObject):
 
         See Also
         --------
-        pandas.Series.drop_duplicates : equivalent method on pandas.Series
+        Series.drop_duplicates : equivalent method on Series
 
         Examples
         --------

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -4035,6 +4035,9 @@ class Index(IndexOpsMixin, PandasObject):
         See Also
         --------
         Series.drop_duplicates : equivalent method on Series
+        DataFrame.drop_duplicates : equivalent method on DataFrame
+        Index.duplicated : related method on Index, indicating duplicate
+            Index values.
 
         Examples
         --------

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -4042,7 +4042,7 @@ class Index(IndexOpsMixin, PandasObject):
 
         Examples
         --------
-        Generate an index with duplicate values.
+        Generate an pandas.Index with duplicate values.
         >>> idx = pd.Index(['lama', 'cow', 'lama', 'beetle', 'lama', 'hippo'])
 
         With the 'keep' parameter, the selection behaviour of duplicated values

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -4017,8 +4017,52 @@ class Index(IndexOpsMixin, PandasObject):
         result = super(Index, self).unique()
         return self._shallow_copy(result)
 
-    @Appender(base._shared_docs['drop_duplicates'] % _index_doc_kwargs)
+    #@Appender(base._shared_docs['drop_duplicates'] % _index_doc_kwargs)
     def drop_duplicates(self, keep='first'):
+        """
+        Return Index with duplicate values removed.
+
+        The drop_duplicates method can remove occurences or whole sets
+        of duplicated entries in a pandas.Index object.
+
+        Parameters
+        ----------
+        keep : {'first', 'last', False}, default 'first'
+            - 'first' : Drop duplicates except for the first occurrence.
+            - 'last' : Drop duplicates except for the last occurrence.
+            - ``False`` : Drop all duplicates.
+
+        Returns
+        -------
+        deduplicated : Index
+
+        See Also
+        --------
+        pandas.Series.drop_duplicates : equivalent method on pandas.Series
+
+        Examples
+        --------
+        Generate an index with duplicate values.
+        >>> idx = pd.Index(['lama', 'cow', 'lama', 'beetle', 'lama', 'hippo'])
+
+        With the 'keep' parameter, the selection behaviour of duplicated values
+        can be changed. The value 'first' keeps the first occurrence for each
+        set of duplicated entries. The default value of keep is 'first'.
+
+        >>> idx.drop_duplicates(keep='first')
+        Index(['lama', 'cow', 'beetle', 'hippo'], dtype='object')
+
+        The value 'last' keeps the last occurrence for each set of duplicated
+        entries.
+
+        >>> idx.drop_duplicates(keep='last')
+        Index(['cow', 'beetle', 'lama', 'hippo'], dtype='object')
+
+        The value ``False`` discards all sets of duplicated entries.
+
+        >>> idx.drop_duplicates(keep=False)
+        Index(['cow', 'beetle', 'hippo'], dtype='object')
+        """
         return super(Index, self).drop_duplicates(keep=keep)
 
     @Appender(base._shared_docs['duplicated'] % _index_doc_kwargs)

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -4042,6 +4042,7 @@ class Index(IndexOpsMixin, PandasObject):
         Examples
         --------
         Generate an pandas.Index with duplicate values.
+        
         >>> idx = pd.Index(['lama', 'cow', 'lama', 'beetle', 'lama', 'hippo'])
 
         With the 'keep' parameter, the selection behaviour of duplicated values

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -4045,8 +4045,8 @@ class Index(IndexOpsMixin, PandasObject):
 
         >>> idx = pd.Index(['lama', 'cow', 'lama', 'beetle', 'lama', 'hippo'])
 
-        With the 'keep' parameter, the selection behaviour of duplicated values
-        can be changed. The value 'first' keeps the first occurrence for each
+        The `keep` parameter controls  which duplicate values are removed.
+        The value 'first' keeps the first occurrence for each
         set of duplicated entries. The default value of keep is 'first'.
 
         >>> idx.drop_duplicates(keep='first')

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -4021,9 +4021,6 @@ class Index(IndexOpsMixin, PandasObject):
         """
         Return Index with duplicate values removed.
 
-        The drop_duplicates method can remove occurences or whole sets
-        of duplicated entries in a pandas.Index object.
-
         Parameters
         ----------
         keep : {'first', 'last', ``False``}, default 'first'

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -4017,7 +4017,6 @@ class Index(IndexOpsMixin, PandasObject):
         result = super(Index, self).unique()
         return self._shallow_copy(result)
 
-    #@Appender(base._shared_docs['drop_duplicates'] % _index_doc_kwargs)
     def drop_duplicates(self, keep='first'):
         """
         Return Index with duplicate values removed.

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -1336,8 +1336,9 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
         See Also
         --------
         Index.drop_duplicates : equivalent method on Index
-        DataFrame.drop_duplicates: equivalent method on DataFrame
-        Series.duplicated: related method on Series
+        DataFrame.drop_duplicates : equivalent method on DataFrame
+        Series.duplicated : related method on Series, indicating duplicate
+            Series values.
 
         Examples
         --------

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -1316,8 +1316,77 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
 
         return result
 
-    @Appender(base._shared_docs['drop_duplicates'] % _shared_doc_kwargs)
+    #@Appender(base._shared_docs['drop_duplicates'] % _shared_doc_kwargs)
     def drop_duplicates(self, keep='first', inplace=False):
+        """
+        Return Series with duplicate values removed.
+
+        The drop_duplicates method can remove occurences or whole sets
+        of duplicated entries in a pandas.Index object.
+
+        Parameters
+        ----------
+        keep : {'first', 'last', False}, default 'first'
+            - 'first' : Drop duplicates except for the first occurrence.
+            - 'last' : Drop duplicates except for the last occurrence.
+            - ``False`` : Drop all duplicates.
+        inplace : boolean, default ``False``
+            If ``True``, performs operation inplace and returns None.
+
+        Returns
+        -------
+        deduplicated : Series
+
+        See Also
+        --------
+        pandas.Index.drop_duplicates : equivalent method on pandas.Index
+
+        Examples
+        --------
+        Generate an Series with duplicated entries.
+        >>> s = pd.Series(['lama', 'cow', 'lama', 'beetle', 'lama', 'hippo'],
+        ...               name='animal')
+        >>> s
+        0      lama
+        1       cow
+        2      lama
+        3    beetle
+        4      lama
+        5     hippo
+        Name: animal, dtype: object
+
+        With the 'keep' parameter, the selection behaviour of duplicated values
+        can be changed. The value 'first' keeps the first occurrence for each
+        set of duplicated entries. The default value of keep is 'first'.
+
+        >>> s.drop_duplicates()
+        0      lama
+        1       cow
+        3    beetle
+        5     hippo
+        Name: animal, dtype: object
+
+        The value 'last' for parameter 'keep' keeps the last occurrence for
+        each set of duplicated entries.
+
+        >>> s.drop_duplicates(keep='last')
+        1       cow
+        3    beetle
+        4      lama
+        5     hippo
+        Name: animal, dtype: object
+
+        The value ``False`` for parameter 'keep' discards all sets of
+        duplicated entries. Setting the value of 'inplace' to ``True`` performs
+        the operation inplace and returns ``None``.
+
+        >>> s.drop_duplicates(keep=False, inplace=True)
+        >>> s
+        1       cow
+        3    beetle
+        5     hippo
+        Name: animal, dtype: object
+        """
         return super(Series, self).drop_duplicates(keep=keep, inplace=inplace)
 
     @Appender(base._shared_docs['duplicated'] % _shared_doc_kwargs)

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -1321,7 +1321,7 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
         Return Series with duplicate values removed.
 
         The drop_duplicates method can remove occurences or whole sets
-        of duplicated entries in a pandas.Index object.
+        of duplicated entries in a pandas.Series object.
 
         Parameters
         ----------

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -1316,7 +1316,6 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
 
         return result
 
-    #@Appender(base._shared_docs['drop_duplicates'] % _shared_doc_kwargs)
     def drop_duplicates(self, keep='first', inplace=False):
         """
         Return Series with duplicate values removed.

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -1336,6 +1336,8 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
         See Also
         --------
         Index.drop_duplicates : equivalent method on Index
+        DataFrame.drop_duplicates: equivalent method on DataFrame
+        Series.duplicated: related method on Series
 
         Examples
         --------

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -1325,7 +1325,7 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
 
         Parameters
         ----------
-        keep : {'first', 'last', False}, default 'first'
+        keep : {'first', 'last', ``False``}, default 'first'
             - 'first' : Drop duplicates except for the first occurrence.
             - 'last' : Drop duplicates except for the last occurrence.
             - ``False`` : Drop all duplicates.
@@ -1343,6 +1343,7 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
         Examples
         --------
         Generate an Series with duplicated entries.
+
         >>> s = pd.Series(['lama', 'cow', 'lama', 'beetle', 'lama', 'hippo'],
         ...               name='animal')
         >>> s

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -1320,9 +1320,6 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
         """
         Return Series with duplicate values removed.
 
-        The drop_duplicates method can remove occurences or whole sets
-        of duplicated entries in a pandas.Series object.
-
         Parameters
         ----------
         keep : {'first', 'last', ``False``}, default 'first'

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -1338,7 +1338,7 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
 
         See Also
         --------
-        pandas.Index.drop_duplicates : equivalent method on pandas.Index
+        Index.drop_duplicates : equivalent method on Index
 
         Examples
         --------


### PR DESCRIPTION
Checklist for the pandas documentation sprint (ignore this if you are doing
an unrelated PR):

- [X] PR title is "DOC: update the <your-function-or-method> docstring"
- [ ] The validation script passes: `scripts/validate_docstrings.py <your-function-or-method>`
- [X] The PEP8 style check passes: `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [X] The html version looks good: `python doc/make.py --single <your-function-or-method>`
- [ ] It has been proofread on language by another sprint participant

Please include the output of the validation script below between the "```" ticks:

Method ```pandas.Index.drop_duplicates```:

```
################################################################################
################### Docstring (pandas.Index.drop_duplicates) ###################
################################################################################

Return Index with duplicate values removed.

The drop_duplicates method can remove occurences or whole sets
of duplicated entries in a pandas.Index object.

Parameters
----------
keep : {'first', 'last', ``False``}, default 'first'
    - 'first' : Drop duplicates except for the first occurrence.
    - 'last' : Drop duplicates except for the last occurrence.
    - ``False`` : Drop all duplicates.

Returns
-------
deduplicated : Index

See Also
--------
pandas.Series.drop_duplicates : equivalent method on pandas.Series

Examples
--------
Generate an pandas.Index with duplicate values.

>>> idx = pd.Index(['lama', 'cow', 'lama', 'beetle', 'lama', 'hippo'])

With the 'keep' parameter, the selection behaviour of duplicated values
can be changed. The value 'first' keeps the first occurrence for each
set of duplicated entries. The default value of keep is 'first'.

>>> idx.drop_duplicates(keep='first')
Index(['lama', 'cow', 'beetle', 'hippo'], dtype='object')

The value 'last' keeps the last occurrence for each set of duplicated
entries.

>>> idx.drop_duplicates(keep='last')
Index(['cow', 'beetle', 'lama', 'hippo'], dtype='object')

The value ``False`` discards all sets of duplicated entries.

>>> idx.drop_duplicates(keep=False)
Index(['cow', 'beetle', 'hippo'], dtype='object')

################################################################################
################################## Validation ##################################
################################################################################

Errors found:
	Errors in parameters section
		Parameter "keep" description should start with capital letter

```

Method ```pandas.Series.drop_duplicates```:

```

################################################################################
################## Docstring (pandas.Series.drop_duplicates)  ##################
################################################################################

Return Series with duplicate values removed.

The drop_duplicates method can remove occurences or whole sets
of duplicated entries in a pandas.Series object.

Parameters
----------
keep : {'first', 'last', ``False``}, default 'first'
    - 'first' : Drop duplicates except for the first occurrence.
    - 'last' : Drop duplicates except for the last occurrence.
    - ``False`` : Drop all duplicates.
inplace : boolean, default ``False``
    If ``True``, performs operation inplace and returns None.

Returns
-------
deduplicated : Series

See Also
--------
pandas.Index.drop_duplicates : equivalent method on pandas.Index

Examples
--------
Generate an Series with duplicated entries.

>>> s = pd.Series(['lama', 'cow', 'lama', 'beetle', 'lama', 'hippo'],
...               name='animal')
>>> s
0      lama
1       cow
2      lama
3    beetle
4      lama
5     hippo
Name: animal, dtype: object

With the 'keep' parameter, the selection behaviour of duplicated values
can be changed. The value 'first' keeps the first occurrence for each
set of duplicated entries. The default value of keep is 'first'.

>>> s.drop_duplicates()
0      lama
1       cow
3    beetle
5     hippo
Name: animal, dtype: object

The value 'last' for parameter 'keep' keeps the last occurrence for
each set of duplicated entries.

>>> s.drop_duplicates(keep='last')
1       cow
3    beetle
4      lama
5     hippo
Name: animal, dtype: object

The value ``False`` for parameter 'keep' discards all sets of
duplicated entries. Setting the value of 'inplace' to ``True`` performs
the operation inplace and returns ``None``.

>>> s.drop_duplicates(keep=False, inplace=True)
>>> s
1       cow
3    beetle
5     hippo
Name: animal, dtype: object

################################################################################
################################## Validation ##################################
################################################################################

Errors found:
	Errors in parameters section
		Parameter "keep" description should start with capital letter


```

If the validation script still gives errors, but you think there is a good reason
to deviate in this case (and there are certainly such cases), please state this
explicitly.

The parameter keyword fails in the validation script. In the DOC sprint team, it was decided that summing up the parameter values is more valuable.