### PR TITLE
DOC: improved the scatter method

### DIFF
--- a/pandas/plotting/_core.py
+++ b/pandas/plotting/_core.py
@@ -2852,22 +2852,48 @@ class FramePlotMethods(BasePlotMethods):
 
     def scatter(self, x, y, s=None, c=None, **kwds):
         """
-        Scatter plot
+        A scatter plot with point size *s* and color *c*.
+
+        The coordinates of each point *x,y* are defined by two dataframe
+        columns and filled circles are used to represent each point.
 
         Parameters
         ----------
-        x, y : label or position, optional
-            Coordinates for each point.
+        x : column name or column position
+            Horizontal and vertical coordinates of each point.
+        y : column name or column position
+            Vertical coordinates of each point.
         s : scalar or array_like, optional
             Size of each point.
-        c : label or position, optional
+        c : label, column name or column position, optional
             Color of each point.
-        `**kwds` : optional
+        kwds : optional
             Keyword arguments to pass on to :py:meth:`pandas.DataFrame.plot`.
 
         Returns
         -------
         axes : matplotlib.AxesSubplot or np.array of them
+
+        See Also
+        --------
+        matplotlib.pyplot.scatter : scatter plot using multiple input data
+            formats.
+
+        Examples
+        --------
+
+        .. plot::
+            :context: close-figs
+
+            >>> from sklearn.datasets import load_iris
+            >>> iris = load_iris()
+            >>> df = pd.DataFrame(iris.data[:,:2],
+            ...                   columns=iris.feature_names[:2])
+            >>> df['species'] = load_iris().target
+            >>> f = df.plot.scatter(x='sepal length (cm)',
+            ...                     y='sepal width (cm)',
+            ...                     c='species',
+            ...                     colormap='viridis')
         """
         return self(kind='scatter', x=x, y=y, c=c, s=s, **kwds)
 

--- a/pandas/plotting/_core.py
+++ b/pandas/plotting/_core.py
@@ -2852,22 +2852,47 @@ class FramePlotMethods(BasePlotMethods):
 
     def scatter(self, x, y, s=None, c=None, **kwds):
         """
-        A scatter plot with point size `s` and color `c`.
+        Create a scatter plot with varying marker point size and color.
 
-        The coordinates of each point `x,y` are defined by two dataframe
-        columns and filled circles are used to represent each point.
+        The coordinates of each point are defined by two dataframe columns and
+        filled circles are used to represent each point. This kind of plot is
+        useful to see complex correlations between two variables. Points could
+        be for instance natural 2D coordinates like longitude and latitude in
+        a map or, in general, any pair of metrics that can be plotted against
+        each other.
 
         Parameters
         ----------
-        x : column name or column position
-            Horizontal coordinates of each point.
-        y : column name or column position
-            Vertical coordinates of each point.
-        s : scalar or array_like, optional
-            Size of each point.
-        c : label, column name or column position, optional
-            Color of each point.
-        kwds : optional
+        x : int, str
+            The column name or column position to be used as horizontal
+            coordinates for each point.
+        y : int, str
+            The column name or column position to be used as vertical
+            coordinates for each point.
+        s : scalar, array_like, optional
+            The size of each point. Possible values are:
+
+            - A single scalar so all points have the same size.
+
+            - A sequence of scalars, which will be used for each point's size
+            recursively. For intance [2,14] all points will be size 2 or 14,
+            alternatively.
+
+        c : str, int, array_like, optional
+            The color of each point. Possible values are:
+
+            - A single color string referred to by name, RGB or RGBA code,
+            for instance 'red' or '#a98d19'.
+
+            - A sequence of color strings referred to by name, RGB or RGBA code,
+            which will be used for each point's color recursively. For intance
+            ['green','yellow'] all points will be filled in green or yellow,
+            alternatively.
+
+            - A column name or position whose values will be used to color the
+            marker points according to a colormap.
+
+        **kwds : optional
             Keyword arguments to pass on to :py:meth:`pandas.DataFrame.plot`.
 
         Returns
@@ -2881,6 +2906,8 @@ class FramePlotMethods(BasePlotMethods):
 
         Examples
         --------
+        Let's see how to draw a scatter plot using coordinates and color from
+        the values in three DataFrame columns.
 
         .. plot::
             :context: close-figs
@@ -2888,10 +2915,13 @@ class FramePlotMethods(BasePlotMethods):
             >>> df = pd.DataFrame([[5.1, 3.5, 0], [4.9, 3.0, 0], [7.0, 3.2, 1],
             ...                    [6.4, 3.2, 1], [5.9, 3.0, 2]],
             ...                   columns = ['length', 'width', 'species'])
-            >>> f = df.plot.scatter(x='length',
-            ...                     y='width',
-            ...                     c='species',
-            ...                     colormap='viridis')
+            >>> ax1 = df.plot.scatter(x='length',
+            ...                       y='width',
+            ...                       c='DarkBlue')
+            >>> ax2 = df.plot.scatter(x='length',
+            ...                       y='width',
+            ...                       c='species',
+            ...                       colormap='viridis')
         """
         return self(kind='scatter', x=x, y=y, c=c, s=s, **kwds)
 

--- a/pandas/plotting/_core.py
+++ b/pandas/plotting/_core.py
@@ -2885,13 +2885,11 @@ class FramePlotMethods(BasePlotMethods):
         .. plot::
             :context: close-figs
 
-            >>> from sklearn.datasets import load_iris
-            >>> iris = load_iris()
-            >>> df = pd.DataFrame(iris.data[:,:2],
-            ...                   columns=iris.feature_names[:2])
-            >>> df['species'] = load_iris().target
-            >>> f = df.plot.scatter(x='sepal length (cm)',
-            ...                     y='sepal width (cm)',
+            >>> df = pd.DataFrame([[5.1, 3.5, 0], [4.9, 3.0, 0], [7.0, 3.2, 1],
+            ...                    [6.4, 3.2, 1], [5.9, 3.0, 2]],
+            ...                   columns = ['length', 'width', 'species'])
+            >>> f = df.plot.scatter(x='length',
+            ...                     y='width',
             ...                     c='species',
             ...                     colormap='viridis')
         """

--- a/pandas/plotting/_core.py
+++ b/pandas/plotting/_core.py
@@ -2860,7 +2860,7 @@ class FramePlotMethods(BasePlotMethods):
         Parameters
         ----------
         x : column name or column position
-            Horizontal and vertical coordinates of each point.
+            Horizontal coordinates of each point.
         y : column name or column position
             Vertical coordinates of each point.
         s : scalar or array_like, optional

--- a/pandas/plotting/_core.py
+++ b/pandas/plotting/_core.py
@@ -3162,22 +3162,22 @@ class FramePlotMethods(BasePlotMethods):
 
         Parameters
         ----------
-        x : int, str
+        x : int or str
             The column name or column position to be used as horizontal
             coordinates for each point.
-        y : int, str
+        y : int or str
             The column name or column position to be used as vertical
             coordinates for each point.
-        s : scalar, array_like, optional
+        s : scalar or array_like, optional
             The size of each point. Possible values are:
 
             - A single scalar so all points have the same size.
 
             - A sequence of scalars, which will be used for each point's size
-            recursively. For intance [2,14] all points will be size 2 or 14,
-            alternatively.
+            recursively. For instance, when passing [2,14] all points size will
+            be either 2 or 14, alternatively.
 
-        c : str, int, array_like, optional
+        c : str, int or array_like, optional
             The color of each point. Possible values are:
 
             - A single color string referred to by name, RGB or RGBA code,
@@ -3213,7 +3213,7 @@ class FramePlotMethods(BasePlotMethods):
 
             >>> df = pd.DataFrame([[5.1, 3.5, 0], [4.9, 3.0, 0], [7.0, 3.2, 1],
             ...                    [6.4, 3.2, 1], [5.9, 3.0, 2]],
-            ...                   columns = ['length', 'width', 'species'])
+            ...                   columns=['length', 'width', 'species'])
             >>> ax1 = df.plot.scatter(x='length',
             ...                       y='width',
             ...                       c='DarkBlue')

--- a/pandas/plotting/_core.py
+++ b/pandas/plotting/_core.py
@@ -3205,8 +3205,8 @@ class FramePlotMethods(BasePlotMethods):
 
         Examples
         --------
-        Let's see how to draw a scatter plot using coordinates and color from
-        the values in three DataFrame columns.
+        Let's see how to draw a scatter plot using coordinates from the values
+        in a DataFrame's columns.
 
         .. plot::
             :context: close-figs
@@ -3217,6 +3217,12 @@ class FramePlotMethods(BasePlotMethods):
             >>> ax1 = df.plot.scatter(x='length',
             ...                       y='width',
             ...                       c='DarkBlue')
+
+        And now with the color determined by a column as well.
+
+        .. plot::
+            :context: close-figs
+
             >>> ax2 = df.plot.scatter(x='length',
             ...                       y='width',
             ...                       c='species',

--- a/pandas/plotting/_core.py
+++ b/pandas/plotting/_core.py
@@ -3174,22 +3174,22 @@ class FramePlotMethods(BasePlotMethods):
             - A single scalar so all points have the same size.
 
             - A sequence of scalars, which will be used for each point's size
-            recursively. For instance, when passing [2,14] all points size will
-            be either 2 or 14, alternatively.
+              recursively. For instance, when passing [2,14] all points size
+              will be either 2 or 14, alternatively.
 
         c : str, int or array_like, optional
             The color of each point. Possible values are:
 
             - A single color string referred to by name, RGB or RGBA code,
-            for instance 'red' or '#a98d19'.
+              for instance 'red' or '#a98d19'.
 
-            - A sequence of color strings referred to by name, RGB or RGBA code,
-            which will be used for each point's color recursively. For intance
-            ['green','yellow'] all points will be filled in green or yellow,
-            alternatively.
+            - A sequence of color strings referred to by name, RGB or RGBA
+              code, which will be used for each point's color recursively. For
+              intance ['green','yellow'] all points will be filled in green or
+              yellow, alternatively.
 
             - A column name or position whose values will be used to color the
-            marker points according to a colormap.
+              marker points according to a colormap.
 
         **kwds : optional
             Keyword arguments to pass on to :py:meth:`pandas.DataFrame.plot`.

--- a/pandas/plotting/_core.py
+++ b/pandas/plotting/_core.py
@@ -2852,9 +2852,9 @@ class FramePlotMethods(BasePlotMethods):
 
     def scatter(self, x, y, s=None, c=None, **kwds):
         """
-        A scatter plot with point size *s* and color *c*.
+        A scatter plot with point size `s` and color `c`.
 
-        The coordinates of each point *x,y* are defined by two dataframe
+        The coordinates of each point `x,y` are defined by two dataframe
         columns and filled circles are used to represent each point.
 
         Parameters

--- a/pandas/plotting/_core.py
+++ b/pandas/plotting/_core.py
@@ -3191,8 +3191,8 @@ class FramePlotMethods(BasePlotMethods):
             - A column name or position whose values will be used to color the
               marker points according to a colormap.
 
-        **kwds : optional
-            Keyword arguments to pass on to :py:meth:`pandas.DataFrame.plot`.
+        **kwds
+            Keyword arguments to pass on to :meth:`pandas.DataFrame.plot`.
 
         Returns
         -------

--- a/pandas/plotting/_core.py
+++ b/pandas/plotting/_core.py
@@ -2852,22 +2852,49 @@ class FramePlotMethods(BasePlotMethods):
 
     def scatter(self, x, y, s=None, c=None, **kwds):
         """
-        A scatter plot with point size `s` and color `c`.
+        Create a scatter plot with varying marker point size and color.
 
-        The coordinates of each point `x,y` are defined by two dataframe
-        columns and filled circles are used to represent each point.
+        The coordinates of each point are defined by two dataframe columns and
+        filled circles are used to represent each point. This kind of plot is
+        useful to see complex correlations between two variables. Points could
+        be for instance natural 2D coordinates like longitude and latitude in a
+        map or, in general, any pair of metrics that can be plotted against each
+        other.
 
         Parameters
         ----------
-        x : column name or column position
-            Horizontal coordinates of each point.
-        y : column name or column position
-            Vertical coordinates of each point.
-        s : scalar or array_like, optional
-            Size of each point.
-        c : label, column name or column position, optional
-            Color of each point.
-        kwds : optional
+        x : int, str
+            The column name or column position to be used as horizontal
+            coordinates for each point.
+            
+        y : int, str
+            The column name or column position to be used as vertical
+            coordinates for each point.
+
+        s : scalar, array_like, optional
+            The size of each point. Possible values are:
+
+            - A single scalar so all points have the same size.
+
+            - A sequence of scalars, which will be used for each point's size
+            recursively. For intance [2,14] all points will be size 2 or 14,
+            alternatively.
+
+        c : str, int, array_like, optional
+            The color of each point. Possible values are:
+
+            - A single color string referred to by name, RGB or RGBA code,
+            for instance 'red' or '#a98d19'.
+
+            - A sequence of color strings referred to by name, RGB or RGBA code,
+            which will be used for each point's color recursively. For intance
+            ['green','yellow'] all points will be filled in green or yellow,
+            alternatively.
+
+            - A column name or position whose values will be used to color the
+            marker points according to a colormap.
+
+        **kwds : optional
             Keyword arguments to pass on to :py:meth:`pandas.DataFrame.plot`.
 
         Returns
@@ -2881,6 +2908,8 @@ class FramePlotMethods(BasePlotMethods):
 
         Examples
         --------
+        Let's see how to draw a scatter plot using coordinates and color from
+        the values in three DataFrame columns.
 
         .. plot::
             :context: close-figs
@@ -2888,10 +2917,13 @@ class FramePlotMethods(BasePlotMethods):
             >>> df = pd.DataFrame([[5.1, 3.5, 0], [4.9, 3.0, 0], [7.0, 3.2, 1],
             ...                    [6.4, 3.2, 1], [5.9, 3.0, 2]],
             ...                   columns = ['length', 'width', 'species'])
-            >>> f = df.plot.scatter(x='length',
-            ...                     y='width',
-            ...                     c='species',
-            ...                     colormap='viridis')
+            >>> ax1 = df.plot.scatter(x='length',
+            ...                       y='width',
+            ...                       c='DarkBlue')
+            >>> ax2 = df.plot.scatter(x='length',
+            ...                       y='width',
+            ...                       c='species',
+            ...                       colormap='viridis')
         """
         return self(kind='scatter', x=x, y=y, c=c, s=s, **kwds)
 

--- a/pandas/plotting/_core.py
+++ b/pandas/plotting/_core.py
@@ -3162,22 +3162,22 @@ class FramePlotMethods(BasePlotMethods):
 
         Parameters
         ----------
-        x : int, str
+        x : int or str
             The column name or column position to be used as horizontal
             coordinates for each point.
-        y : int, str
+        y : int or str
             The column name or column position to be used as vertical
             coordinates for each point.
-        s : scalar, array_like, optional
+        s : scalar or array_like, optional
             The size of each point. Possible values are:
 
             - A single scalar so all points have the same size.
 
             - A sequence of scalars, which will be used for each point's size
-            recursively. For intance [2,14] all points will be size 2 or 14,
-            alternatively.
+            recursively. For instance, when passing [2,14] all points size will
+            be either 2 or 14, alternatively.
 
-        c : str, int, array_like, optional
+        c : str, int or array_like, optional
             The color of each point. Possible values are:
 
             - A single color string referred to by name, RGB or RGBA code,


### PR DESCRIPTION
Checklist for the pandas documentation sprint (ignore this if you are doing
an unrelated PR):

- [x] PR title is "DOC: update the <your-function-or-method> docstring"
- [x] The validation script passes: `scripts/validate_docstrings.py <your-function-or-method>`
- [x] The PEP8 style check passes: `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] The html version looks good: `python doc/make.py --single <your-function-or-method>`
- [x] It has been proofread on language by another sprint participant

Please include the output of the validation script below between the "```" ticks:

```


################################################################################
################## Docstring (pandas.DataFrame.plot.scatter)  ##################
################################################################################

A scatter plot with point size *s* and color *c*.

The coordinates of each point *x,y* are defined by two dataframe
columns and filled circles are used to represent each point.

Parameters
----------
x : column name or column position
    Horizontal and vertical coordinates of each point.
y : column name or column position
    Vertical coordinates of each point.
s : scalar or array_like, optional
    Size of each point.
c : label, column name or column position, optional
    Color of each point.
kwds : optional
    Keyword arguments to pass on to :py:meth:`pandas.DataFrame.plot`.

Returns
-------
axes : matplotlib.AxesSubplot or np.array of them

See Also
--------
matplotlib.pyplot.scatter : scatter plot using multiple input data
    formats.

Examples
--------

.. plot::
    :context: close-figs

    >>> from sklearn.datasets import load_iris
    >>> iris = load_iris()
    >>> df = pd.DataFrame(iris.data[:,:2],
    ...                   columns=iris.feature_names[:2])
    >>> df['species'] = load_iris().target
    >>> f = df.plot.scatter(x='sepal length (cm)',
    ...                     y='sepal width (cm)',
    ...                     c='species',
    ...                     colormap='viridis')

################################################################################
################################## Validation ##################################
################################################################################

Docstring for "pandas.DataFrame.plot.scatter" correct. :)

```

If the validation script still gives errors, but you think there is a good reason
to deviate in this case (and there are certainly such cases), please state this
explicitly.