### PR TITLE
DOC: update and seperate the Series.drop and Dataframe.drop docstring

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -3038,7 +3038,7 @@ class DataFrame(NDFrame):
     def drop(self, labels=None, axis=0, index=None, columns=None,
              level=None, inplace=False, errors='raise'):
         """
-        Drop rows or columns.
+        Drop specified labels from rows or columns.
 
         Remove rows or columns by specifying label names and corresponding
         axis, or by specifying directly index or column names. When using a
@@ -3049,19 +3049,15 @@ class DataFrame(NDFrame):
         ----------
         labels : single label or list-like
             Index or column labels to drop.
-        axis : int or axis name, default 0
+        axis : {0 or 'index', 1 or 'columns'}, default 0
             Whether to drop labels from the index (0 / 'index') or
             columns (1 / 'columns').
-        index : None
-            Redundant for application on Series, but index can be used instead
-            of labels.
-        columns : None
-            Redundant for application on Series, but index can be used instead
-            of labels.
-
+        index, columns : single label or list-like
+            Alternative to specifying axis (labels, axis=1
+            is equivalent to columns=labels).
             .. versionadded:: 0.21.0
         level : int or level name, optional
-            For MultiIndex.
+            For MultiIndex, level for which the labels will be removed.
         inplace : bool, default False
             If True, do operation inplace and return None.
         errors : {'ignore', 'raise'}, default 'raise'
@@ -3069,14 +3065,16 @@ class DataFrame(NDFrame):
 
         Returns
         -------
-        dropped : type of caller
+        dropped : pandas.DataFrame
 
         See Also
         --------
+        DataFrame.loc : Label-location based indexer for selection by label.
         DataFrame.dropna : Return DataFrame with labels on given axis omitted
             where (all or any) data are missing
         DataFrame.drop_duplicates : Return DataFrame with duplicate rows
             removed, optionally only considering certain columns
+        Series.drop : Return Series with specified index labels removed.
 
         Raises
         ------
@@ -3113,29 +3111,29 @@ class DataFrame(NDFrame):
            A  B   C   D
         2  8  9  10  11
 
-        Drop columns and/or rows of MultiIndex
+        Drop columns and/or rows of MultiIndex DataFrame
 
-        >>> midx = pd.MultiIndex(levels=[['lama','cow','falcon'],
-        ...                              ['speed','weight','length']],
+        >>> midx = pd.MultiIndex(levels=[['lama', 'cow', 'falcon'],
+        ...                              ['speed', 'weight', 'length']],
         ...                      labels=[[0, 0, 0, 1, 1, 1, 2, 2, 2],
         ...                              [0, 1, 2, 0, 1, 2, 0, 1, 2]])
-        >>> df = pd.DataFrame(index=midx, columns=['big','small'],
-        ...                   data=[[45,30],[200,100],[1.5,1],[30,20],
-                                    [250,150],[1.5,0.8],[320,250],[1,0.8],
-                                    [0.3,0.2]])
+        >>> df = pd.DataFrame(index=midx, columns=['big', 'small'],
+        ...                   data=[[45,30], [200,100], [1.5,1], [30,20],
+        ...                         [250,150], [1.5,0.8], [320,250], [1,0.8],
+        ...                         [0.3,0.2]])
         >>> df
                         big 	small
-        lama 	speed 	45.0 	30.0
+        lama 	speed   45.0 	30.0
                 weight  200.0 	100.0
                 length 	1.5 	1.0
-        cow 	speed 	30.0 	20.0
+        cow 	speed   30.0 	20.0
                 weight 	250.0 	150.0
                 length 	1.5 	0.8
         falcon 	speed 	320.0 	250.0
                 weight 	1.0 	0.8
                 length 	0.3 	0.2
 
-        >>> df.drop(index='cow',columns='small')
+        >>> df.drop(index='cow', columns='small')
                         big
         lama 	speed 	45.0
                 weight 	200.0
@@ -3153,10 +3151,10 @@ class DataFrame(NDFrame):
         falcon 	speed 	320.0 	250.0
                 weight 	1.0 	0.8
         """
-        return super(DataFrame,
-                     self).drop(labels=labels, axis=axis, index=index,
-                                columns=columns, level=level, inplace=inplace,
-                                errors=errors)
+        return super(DataFrame,self).drop(labels=labels, axis=axis,
+                                          index=index, columns=columns,
+                                          level=level, inplace=inplace,
+                                          errors=errors)
 
     @rewrite_axis_style_signature('mapper', [('copy', True),
                                              ('inplace', False),

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -3035,6 +3035,128 @@ class DataFrame(NDFrame):
                                         method=method, level=level, copy=copy,
                                         limit=limit, fill_value=fill_value)
 
+    def drop(self, labels=None, axis=0, index=None, columns=None,
+                     level=None, inplace=False, errors='raise'):
+        """
+        Drop rows or columns.
+
+        Remove rows or columns by specifying label names and corresponding axis,
+        or by specifying directly index or column names. When using a
+        multi-index, labels on different levels can be removed by specifying
+        the level name or int.
+
+        Parameters
+        ----------
+        labels : single label or list-like
+            Index or column labels to drop.
+        axis : int or axis name, default 0
+            Whether to drop labels from the index (0 / 'index') or
+            columns (1 / 'columns').
+        index : None
+            Redundant for application on Series, but index can be used instead
+            of labels.
+        columns : None
+            Redundant for application on Series, but index can be used instead
+            of labels.
+
+            .. versionadded:: 0.21.0
+        level : int or level name, optional
+            For MultiIndex.
+        inplace : bool, default False
+            If True, do operation inplace and return None.
+        errors : {'ignore', 'raise'}, default 'raise'
+            If 'ignore', suppress error and existing labels are dropped.
+
+        Returns
+        -------
+        dropped : type of caller
+
+        See Also
+        --------
+        DataFrame.dropna : Return DataFrame with labels on given axis omitted
+            where (all or any) data are missing
+        DataFrame.drop_duplicates : Return DataFrame with duplicate rows removed,
+            optionally only considering certain columns
+
+        Raises
+        ------
+        KeyError
+            If none of the labels are found in the selected axis
+
+        Examples
+        --------
+        >>> df = pd.DataFrame(np.arange(12).reshape(3,4),
+        ...                   columns=['A', 'B', 'C', 'D'])
+        >>> df
+           A  B   C   D
+        0  0  1   2   3
+        1  4  5   6   7
+        2  8  9  10  11
+
+        Drop columns
+
+        >>> df.drop(['B', 'C'], axis=1)
+           A   D
+        0  0   3
+        1  4   7
+        2  8  11
+
+        >>> df.drop(columns=['B', 'C'])
+           A   D
+        0  0   3
+        1  4   7
+        2  8  11
+
+        Drop a row by index
+
+        >>> df.drop([0, 1])
+           A  B   C   D
+        2  8  9  10  11
+
+        Drop columns and/or rows of MultiIndex
+
+        >>> midx = pd.MultiIndex(levels=[['lama','cow','falcon'],
+        ...                              ['speed','weight','length']],
+        ...                      labels=[[0, 0, 0, 1, 1, 1, 2, 2, 2],
+        ...                              [0, 1, 2, 0, 1, 2, 0, 1, 2]])
+        >>> df = pd.DataFrame(index=midx, columns=['big','small'],
+        ...                   data=[[45,30],[200,100],[1.5,1],[30,20],[250,150],
+        ...                         [1.5,0.8],[320,250],[1,0.8],[0.3,0.2]])
+        >>> df
+        		        big 	small
+        lama 	speed 	45.0 	30.0
+                weight 	200.0 	100.0
+                length 	1.5 	1.0
+        cow 	speed 	30.0 	20.0
+                weight 	250.0 	150.0
+                length 	1.5 	0.8
+        falcon 	speed 	320.0 	250.0
+                weight 	1.0 	0.8
+                length 	0.3 	0.2
+
+        >>> df.drop(index='cow',columns='small')
+                        big
+        lama 	speed 	45.0
+                weight 	200.0
+                length 	1.5
+        falcon 	speed 	320.0
+                weight 	1.0
+                length 	0.3
+
+        >>> df.drop(index='length', level=1)
+        		        big 	small
+        lama 	speed 	45.0 	30.0
+                weight 	200.0 	100.0
+        cow 	speed 	30.0 	20.0
+                weight 	250.0 	150.0
+        falcon 	speed 	320.0 	250.0
+                weight 	1.0 	0.8
+        """
+        return super(DataFrame,
+                     self).drop(labels=labels, axis=axis, index=index,
+                                columns=columns, level=level, inplace=inplace,
+                                errors=errors)
+
     @rewrite_axis_style_signature('mapper', [('copy', True),
                                              ('inplace', False),
                                              ('level', None)])

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -3038,7 +3038,7 @@ class DataFrame(NDFrame):
     def drop(self, labels=None, axis=0, index=None, columns=None,
              level=None, inplace=False, errors='raise'):
         """
-        Drop rows or columns.
+        Drop specified labels from rows or columns.
 
         Remove rows or columns by specifying label names and corresponding
         axis, or by specifying directly index or column names. When using a

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -3038,7 +3038,7 @@ class DataFrame(NDFrame):
     def drop(self, labels=None, axis=0, index=None, columns=None,
              level=None, inplace=False, errors='raise'):
         """
-        Drop specified labels from rows or columns.
+        Drop rows or columns.
 
         Remove rows or columns by specifying label names and corresponding
         axis, or by specifying directly index or column names. When using a

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -3120,43 +3120,43 @@ class DataFrame(NDFrame):
         ...                      labels=[[0, 0, 0, 1, 1, 1, 2, 2, 2],
         ...                              [0, 1, 2, 0, 1, 2, 0, 1, 2]])
         >>> df = pd.DataFrame(index=midx, columns=['big', 'small'],
-        ...                   data=[[45,30], [200,100], [1.5,1], [30,20],
-        ...                         [250,150], [1.5,0.8], [320,250], [1,0.8],
-        ...                         [0.3,0.2]])
+        ...                   data=[[45, 30], [200, 100], [1.5, 1], [30, 20],
+        ...                         [250, 150], [1.5, 0.8], [320, 250],
+        ...                         [1, 0.8], [0.3,0.2]])
         >>> df
-                        big 	small
-        lama 	speed   45.0 	30.0
-                weight  200.0 	100.0
-                length 	1.5 	1.0
-        cow 	speed   30.0 	20.0
-                weight 	250.0 	150.0
-                length 	1.5 	0.8
-        falcon 	speed 	320.0 	250.0
-                weight 	1.0 	0.8
-                length 	0.3 	0.2
+                        big     small
+        lama    speed   45.0    30.0
+                weight  200.0   100.0
+                length  1.5     1.0
+        cow     speed   30.0    20.0
+                weight  250.0   150.0
+                length  1.5     0.8
+        falcon  speed   320.0   250.0
+                weight  1.0     0.8
+                length  0.3     0.2
 
         >>> df.drop(index='cow', columns='small')
                         big
         lama    speed   45.0
                 weight  200.0
-                length 	1.5
-        falcon 	speed   320.0
-                weight 	1.0
-                length 	0.3
+                length  1.5
+        falcon  speed   320.0
+                weight  1.0
+                length  0.3
 
         >>> df.drop(index='length', level=1)
-                        big 	small
-        lama 	speed 	45.0 	30.0
-                weight 	200.0 	100.0
-        cow 	speed 	30.0 	20.0
-                weight 	250.0 	150.0
-        falcon 	speed 	320.0 	250.0
-                weight 	1.0 	0.8
+                        big     small
+        lama    speed   45.0    30.0
+                weight  200.0   100.0
+        cow     speed   30.0    20.0
+                weight  250.0   150.0
+        falcon  speed   320.0   250.0
+                weight  1.0     0.8
         """
-        return super(DataFrame,self).drop(labels=labels, axis=axis,
-                                          index=index, columns=columns,
-                                          level=level, inplace=inplace,
-                                          errors=errors)
+        return super(DataFrame, self).drop(labels=labels, axis=axis,
+                                           index=index, columns=columns,
+                                           level=level, inplace=inplace,
+                                           errors=errors)
 
     @rewrite_axis_style_signature('mapper', [('copy', True),
                                              ('inplace', False),

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -3043,25 +3043,27 @@ class DataFrame(NDFrame):
         Remove rows or columns by specifying label names and corresponding
         axis, or by specifying directly index or column names. When using a
         multi-index, labels on different levels can be removed by specifying
-        the level name or int.
+        the level.
 
         Parameters
         ----------
         labels : single label or list-like
             Index or column labels to drop.
         axis : {0 or 'index', 1 or 'columns'}, default 0
-            Whether to drop labels from the index (0 / 'index') or
-            columns (1 / 'columns').
+            Whether to drop labels from the index (0 or 'index') or
+            columns (1 or 'columns').
         index, columns : single label or list-like
-            Alternative to specifying axis (labels, axis=1
-            is equivalent to columns=labels).
+            Alternative to specifying axis (``labels, axis=1``
+            is equivalent to ``columns=labels``).
+
             .. versionadded:: 0.21.0
         level : int or level name, optional
-            For MultiIndex, level for which the labels will be removed.
+            For MultiIndex, level from which the labels will be removed.
         inplace : bool, default False
             If True, do operation inplace and return None.
         errors : {'ignore', 'raise'}, default 'raise'
-            If 'ignore', suppress error and existing labels are dropped.
+            If 'ignore', suppress error and only existing labels are
+            dropped.
 
         Returns
         -------
@@ -3135,10 +3137,10 @@ class DataFrame(NDFrame):
 
         >>> df.drop(index='cow', columns='small')
                         big
-        lama 	speed 	45.0
-                weight 	200.0
+        lama    speed   45.0
+                weight  200.0
                 length 	1.5
-        falcon 	speed 	320.0
+        falcon 	speed   320.0
                 weight 	1.0
                 length 	0.3
 

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -2797,75 +2797,10 @@ class NDFrame(PandasObject, SelectionMixin):
 
         return self.reindex(**d)
 
+
     def drop(self, labels=None, axis=0, index=None, columns=None, level=None,
              inplace=False, errors='raise'):
-        """
-        Return new object with labels in requested axis removed.
-
-        Parameters
-        ----------
-        labels : single label or list-like
-            Index or column labels to drop.
-        axis : int or axis name
-            Whether to drop labels from the index (0 / 'index') or
-            columns (1 / 'columns').
-        index, columns : single label or list-like
-            Alternative to specifying `axis` (``labels, axis=1`` is
-            equivalent to ``columns=labels``).
-
-            .. versionadded:: 0.21.0
-        level : int or level name, default None
-            For MultiIndex
-        inplace : bool, default False
-            If True, do operation inplace and return None.
-        errors : {'ignore', 'raise'}, default 'raise'
-            If 'ignore', suppress error and existing labels are dropped.
-
-        Returns
-        -------
-        dropped : type of caller
-
-        Raises
-        ------
-        KeyError
-            If none of the labels are found in the selected axis
-
-        Examples
-        --------
-        >>> df = pd.DataFrame(np.arange(12).reshape(3,4),
-                              columns=['A', 'B', 'C', 'D'])
-        >>> df
-           A  B   C   D
-        0  0  1   2   3
-        1  4  5   6   7
-        2  8  9  10  11
-
-        Drop columns
-
-        >>> df.drop(['B', 'C'], axis=1)
-           A   D
-        0  0   3
-        1  4   7
-        2  8  11
-
-        >>> df.drop(columns=['B', 'C'])
-           A   D
-        0  0   3
-        1  4   7
-        2  8  11
-
-        Drop a row by index
-
-        >>> df.drop([0, 1])
-           A  B   C   D
-        2  8  9  10  11
-
-        Notes
-        -----
-        Specifying both `labels` and `index` or `columns` will raise a
-        ValueError.
-
-        """
+             
         inplace = validate_bool_kwarg(inplace, 'inplace')
 
         if labels is not None:

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -2720,11 +2720,12 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
 
         Drop 2nd level label in MultiIndex Series
 
-        >>> midx = pd.MultiIndex(levels=[['lama','cow','falcon'],
-        ...                              ['speed','weight','length']],
+        >>> midx = pd.MultiIndex(levels=[['lama', 'cow', 'falcon'],
+        ...                              ['speed', 'weight', 'length']],
         ...                      labels=[[0, 0, 0, 1, 1, 1, 2, 2, 2],
         ...                              [0, 1, 2, 0, 1, 2, 0, 1, 2]])
-        >>> s = pd.Series(data=[45,200,1.2,30,250,1.5,320,1,0.3], index=midx)
+        >>> s = pd.Series([45, 200, 1.2, 30, 250, 1.5, 320, 1, 0.3],
+        ...               index=midx)
         >>> s
         lama    speed      45.0
                 weight    200.0

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -2660,6 +2660,97 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
     def reindex(self, index=None, **kwargs):
         return super(Series, self).reindex(index=index, **kwargs)
 
+    def drop(self, labels=None, axis=0, index=None, columns=None,
+                level=None, inplace=False, errors='raise'):
+        """
+        Return Series with specified index labels removed.
+
+        Remove elements of a Series based on specifying the index labels.
+        When using a multi-index, labels on different levels can be removed
+        by specifying the level name or int.
+
+        Parameters
+        ----------
+        labels : single label or list-like
+            Index labels to drop.
+        axis : 0, default 0
+            Redundant for application on Series.
+        index : None
+            Redundant for application on Series, but index can be used instead
+            of labels.
+        columns : None
+            Redundant for application on Series, but index can be used instead
+            of labels.
+            .. versionadded:: 0.21.0
+        level : int or level name, optional
+            For MultiIndex.
+        inplace : bool, default False
+            If True, do operation inplace and return None.
+        errors : {'ignore', 'raise'}, default 'raise'
+            If 'ignore', suppress error and existing labels are dropped.
+
+        Returns
+        -------
+        dropped : type of caller
+
+        See Also
+        --------
+        Series.reindex : Return only specified index labels of Series.
+        Series.dropna : Return series without null values.
+        Series.drop_duplicates : Return Series with duplicate values removed.
+
+        Raises
+        ------
+        KeyError
+            If none of the labels are found in the index.
+
+        Examples
+        --------
+        >>> s = pd.Series(data=np.arange(3), index=['A','B','C'])
+        >>> s
+        A  0
+        B  1
+        C  2
+        dtype: int64
+
+        Drop labels B en C
+
+        >>> s.drop(labels=['B','C'])
+        A  0
+        dtype: int64
+
+        Drop 2nd level label in MultiIndex Series
+
+        >>> midx = pd.MultiIndex(levels=[['lama','cow','falcon'],
+        ...                              ['speed','weight','length']],
+        ...                      labels=[[0, 0, 0, 1, 1, 1, 2, 2, 2],
+        ...                              [0, 1, 2, 0, 1, 2, 0, 1, 2]])
+        >>> s = pd.Series(data=[45,200,1.2,30,250,1.5,320,1,0.3], index=midx)
+        >>> s
+        lama    speed      45.0
+                weight    200.0
+                length      1.2
+        cow     speed      30.0
+                weight    250.0
+                length      1.5
+        falcon  speed     320.0
+                weight      1.0
+                length      0.3
+        dtype: float64
+
+        >>> s.drop(labels='weight', level=1)
+        lama    speed      45.0
+                length      1.2
+        cow     speed      30.0
+                length      1.5
+        falcon  speed     320.0
+                length      0.3
+        dtype: float64
+        """
+        return super(Series, self).drop(labels=labels, axis=axis, index=index,
+                                        columns=columns, level=level,
+                                        inplace=inplace, errors=errors)
+
     @Appender(generic._shared_docs['fillna'] % _shared_doc_kwargs)
     def fillna(self, value=None, method=None, axis=None, inplace=False,
                limit=None, downcast=None, **kwargs):

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -2695,7 +2695,7 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
         Series.reindex : Return only specified index labels of Series.
         Series.dropna : Return series without null values.
         Series.drop_duplicates : Return Series with duplicate values removed.
-        DataFrame.drop : Drop rows or columns
+        DataFrame.drop : Drop specified labels from rows or columns.
 
         Raises
         ------

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -2675,10 +2675,7 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
             Index labels to drop.
         axis : 0, default 0
             Redundant for application on Series.
-        index : None
-            Redundant for application on Series, but index can be used instead
-            of labels.
-        columns : None
+        index, columns : None
             Redundant for application on Series, but index can be used instead
             of labels.
             .. versionadded:: 0.21.0
@@ -2691,13 +2688,14 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
 
         Returns
         -------
-        dropped : type of caller
+        dropped : pandas.Series
 
         See Also
         --------
         Series.reindex : Return only specified index labels of Series.
         Series.dropna : Return series without null values.
         Series.drop_duplicates : Return Series with duplicate values removed.
+        DataFrame.drop : Drop specified labels from rows or columns.
 
         Raises
         ------

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -2667,7 +2667,7 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
 
         Remove elements of a Series based on specifying the index labels.
         When using a multi-index, labels on different levels can be removed
-        by specifying the level name or int.
+        by specifying the level.
 
         Parameters
         ----------
@@ -2678,13 +2678,14 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
         index, columns : None
             Redundant for application on Series, but index can be used instead
             of labels.
+
             .. versionadded:: 0.21.0
         level : int or level name, optional
-            For MultiIndex.
+            For MultiIndex, level for which the labels will be removed.
         inplace : bool, default False
             If True, do operation inplace and return None.
         errors : {'ignore', 'raise'}, default 'raise'
-            If 'ignore', suppress error and existing labels are dropped.
+            If 'ignore', suppress error and only existing labels are dropped.
 
         Returns
         -------

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -2695,7 +2695,7 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
         Series.reindex : Return only specified index labels of Series.
         Series.dropna : Return series without null values.
         Series.drop_duplicates : Return Series with duplicate values removed.
-        DataFrame.drop : Drop specified labels from rows or columns.
+        DataFrame.drop : Drop rows or columns
 
         Raises
         ------


### PR DESCRIPTION
Checklist for the pandas documentation sprint (ignore this if you are doing
an unrelated PR):

- [X] PR title is "DOC: update the <your-function-or-method> docstring"
- [X] The validation script passes: `scripts/validate_docstrings.py <your-function-or-method>`
- [X] The PEP8 style check passes: `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [X] The html version looks good: `python doc/make.py --single <your-function-or-method>`
- [X] It has been proofread on language by another sprint participant

Please include the output of the validation script below between the "```" ticks:

```
Errors found:
Errors in parameters section
Parameter "columns" description should finish with "."
```

This error is caused by `.. versionadded:: 0.21.0`, which needs to stay in place.
