### PR TITLE
DOC: improved the docstring of pandas.Series.clip_lower

### DIFF
--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -5661,8 +5661,9 @@ class NDFrame(PandasObject, SelectionMixin):
         """
         Return copy of the input with values below given value(s) truncated.
 
-        It truncate values below a certain threshold. Threshold can be a single
-        value or an array, in the latter case it performs the truncation element-wise.
+        It truncates values below a certain threshold. Threshold can be a single
+        value or an array, in the latter case it performs the truncation
+        element-wise.
 
         Parameters
         ----------
@@ -5676,7 +5677,7 @@ class NDFrame(PandasObject, SelectionMixin):
 
         See Also
         --------
-        clip : Return copy of the input with values below and over given thresholds values truncated.
+        clip : Return copy of input with values below and above thresholds truncated.
 
         Returns
         -------

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -5644,7 +5644,8 @@ class NDFrame(PandasObject, SelectionMixin):
             Align object with threshold along the given axis.
         inplace : boolean, default False
             Whether to perform the operation in place on the data
-                .. versionadded:: 0.21.0
+
+            .. versionadded:: 0.21.0
 
         See Also
         --------
@@ -5659,19 +5660,24 @@ class NDFrame(PandasObject, SelectionMixin):
 
     def clip_lower(self, threshold, axis=None, inplace=False):
         """
-        Return copy of the input with values below given value(s) truncated.
-
-        It truncates values below a certain threshold. Threshold can be a single
-        value or an array, in the latter case it performs the truncation
-        element-wise.
+        Return copy of the input with values below a threshold truncated.
 
         Parameters
         ----------
-        threshold : float or array_like
-            Minimum value allowed. All values below threshold will be
-            set to this value.
-        axis : int or string axis name, optional
-            Align object with threshold along the given axis.
+        threshold : numeric or array-like
+            Minimum value allowed. All values below threshold will be set to
+            this value.
+
+            * float : every value is compared to `threshold`.
+            * array-like : The shape of `threshold` should match the object
+              it's compared to. When `self` is a Series, `threshold` should be
+              the length. When `self` is a DataFrame, `threshold` should 2-D
+              and the same shape as `self` for ``axis=None``, or 1-D and the
+              same length as the axis being compared.
+
+        axis : {0 or 'index', 1 or 'columns'}, default 0
+            Align `self` with `threshold` along the given axis.
+
         inplace : boolean, default False
             Whether to perform the operation in place on the data.
 
@@ -5679,8 +5685,10 @@ class NDFrame(PandasObject, SelectionMixin):
 
         See Also
         --------
-        Series.clip : Return copy of input with values below and above thresholds truncated.
-        Series.clip_upper : Return copy of input with values above threshold truncated.
+        Series.clip : Return copy of input with values below and above
+            thresholds truncated.
+        Series.clip_upper : Return copy of input with values above
+            threshold truncated.
 
         Returns
         -------
@@ -5699,7 +5707,8 @@ class NDFrame(PandasObject, SelectionMixin):
         4    9
         dtype: int64
 
-        Series clipping element-wise using an array of thresholds:
+        Series clipping element-wise using an array of thresholds. `threshold`
+        should be the same length as the Series.
 
         >>> elemwise_thresholds = [4, 8, 7, 2, 5]
         >>> s.clip_lower(elemwise_thresholds)
@@ -5709,6 +5718,46 @@ class NDFrame(PandasObject, SelectionMixin):
         3    8
         4    9
         dtype: int64
+
+        DataFrames can be compared to a scalar.
+
+        >>> df = pd.DataFrame({"A": [1, 3, 5], "B": [2, 4, 6]})
+        >>> df
+           A  B
+        0  1  2
+        1  3  4
+        2  5  6
+
+        >>> df.clip_lower(3)
+           A  B
+        0  3  3
+        1  3  4
+        2  5  6
+
+        Or to an array of values. By default, `threshold` should be the same
+        shape as the DataFrame.
+
+        >>> df.clip_lower(np.array([[3, 4], [2, 2], [6, 2]]))
+           A  B
+        0  3  4
+        1  3  4
+        2  6  6
+
+        Control how `threshold` is broadcast with `axis`. In this case
+        `threshold` should be the same length as the axis specified by
+        `axis`.
+
+        >>> df.clip_lower(np.array([3, 3, 5]), axis='index')
+           A  B
+        0  3  3
+        1  3  4
+        2  5  6
+
+        >>> df.clip_lower(np.array([4, 5]), axis='columns')
+           A  B
+        0  4  5
+        1  4  5
+        2  5  6
         """
         return self._clip_with_one_bound(threshold, method=self.ge,
                                          axis=axis, inplace=inplace)

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -5687,7 +5687,7 @@ class NDFrame(PandasObject, SelectionMixin):
 
         Examples
         --------
-        Series single threshold clipping
+        Series single threshold clipping:
 
         >>> s = pd.Series([5, 6, 7, 8, 9])
         >>> s.clip_lower(8)
@@ -5698,7 +5698,7 @@ class NDFrame(PandasObject, SelectionMixin):
         4    9
         dtype: int64
 
-        Series clipping elementwise using an array of thresholds
+        Series clipping element-wise using an array of thresholds:
 
         >>> elemwise_thresholds = [4, 8, 7, 2, 5]
         >>> s.clip_lower(elemwise_thresholds)

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -5674,7 +5674,8 @@ class NDFrame(PandasObject, SelectionMixin):
             Align object with threshold along the given axis.
         inplace : boolean, default False
             Whether to perform the operation in place on the data.
-                .. versionadded:: 0.21.0
+
+            .. versionadded:: 0.21.0
 
         See Also
         --------

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -5673,12 +5673,13 @@ class NDFrame(PandasObject, SelectionMixin):
         axis : int or string axis name, optional
             Align object with threshold along the given axis.
         inplace : boolean, default False
-            Whether to perform the operation in place on the data
-                .. versionadded:: 0.21.0.
+            Whether to perform the operation in place on the data.
+                .. versionadded:: 0.21.0
 
         See Also
         --------
-        clip : Return copy of input with values below and above thresholds truncated.
+        Series.clip : Return copy of input with values below and above thresholds truncated.
+        Series.clip_upper : Return copy of input with values above threshold truncated.
 
         Returns
         -------
@@ -5686,28 +5687,21 @@ class NDFrame(PandasObject, SelectionMixin):
 
         Examples
         --------
+        Series single threshold clipping
+
         >>> s = pd.Series([5, 6, 7, 8, 9])
-        >>> s
-        0    5
-        1    6
-        2    7
+        >>> s.clip_lower(8)
+        0    8
+        1    8
+        2    8
         3    8
         4    9
         dtype: int64
 
-        >>> s.clip_lower(4)
-        0    5
-        1    6
-        2    7
-        3    8
-        4    9
-        dtype: int64
+        Series clipping elementwise using an array of thresholds
 
-        >>> t = [4,8,7,2,5]
-        >>> t
-        [4, 8, 7, 2, 5]
-
-        >>> s.clip_lower(t)
+        >>> elemwise_thresholds = [4, 8, 7, 2, 5]
+        >>> s.clip_lower(elemwise_thresholds)
         0    5
         1    8
         2    7

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -5673,7 +5673,8 @@ class NDFrame(PandasObject, SelectionMixin):
         axis : int or string axis name, optional
             Align object with threshold along the given axis.
         inplace : boolean, default False
-            Whether to perform the operation in place on the data.
+            Whether to perform the operation in place on the data
+                .. versionadded:: 0.21.0.
 
         See Also
         --------
@@ -5685,34 +5686,34 @@ class NDFrame(PandasObject, SelectionMixin):
 
         Examples
         --------
-        >>> s = pd.Series([3.816052, 7.969235, 6.903116, 2.532261, 5.015296])
+        >>> s = pd.Series([5, 6, 7, 8, 9])
         >>> s
-        0    3.816052
-        1    7.969235
-        2    6.903116
-        3    2.532261
-        4    5.015296
-        dtype: float64
+        0    5
+        1    6
+        2    7
+        3    8
+        4    9
+        dtype: int64
 
         >>> s.clip_lower(4)
-        0    4.000000
-        1    7.969235
-        2    6.903116
-        3    4.000000
-        4    5.015296
-        dtype: float64
+        0    5
+        1    6
+        2    7
+        3    8
+        4    9
+        dtype: int64
 
         >>> t = [4,8,7,2,5]
         >>> t
         [4, 8, 7, 2, 5]
 
         >>> s.clip_lower(t)
-        0    4.000000
-        1    8.000000
-        2    7.000000
-        3    2.532261
-        4    5.015296
-        dtype: float64
+        0    5
+        1    8
+        2    7
+        3    8
+        4    9
+        dtype: int64
         """
         return self._clip_with_one_bound(threshold, method=self.ge,
                                          axis=axis, inplace=inplace)

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -5661,22 +5661,57 @@ class NDFrame(PandasObject, SelectionMixin):
         """
         Return copy of the input with values below given value(s) truncated.
 
+        It truncate values below a certain threshold. Threshold can be a single
+        value or an array, in the latter case it performs the truncation element-wise.
+
         Parameters
         ----------
         threshold : float or array_like
+            Minimum value allowed. All values below threshold will be
+            set to this value.
         axis : int or string axis name, optional
             Align object with threshold along the given axis.
         inplace : boolean, default False
-            Whether to perform the operation in place on the data
-                .. versionadded:: 0.21.0
+            Whether to perform the operation in place on the data.
 
         See Also
         --------
-        clip
+        clip : Return copy of the input with values below and over given thresholds values truncated.
 
         Returns
         -------
         clipped : same type as input
+
+        Examples
+        --------
+        >>> s = pd.Series([3.816052, 7.969235, 6.903116, 2.532261, 5.015296])
+        >>> s
+        0    3.816052
+        1    7.969235
+        2    6.903116
+        3    2.532261
+        4    5.015296
+        dtype: float64
+
+        >>> s.clip_lower(4)
+        0    4.000000
+        1    7.969235
+        2    6.903116
+        3    4.000000
+        4    5.015296
+        dtype: float64
+
+        >>> t = [4,8,7,2,5]
+        >>> t
+        [4, 8, 7, 2, 5]
+
+        >>> s.clip_lower(t)
+        0    4.000000
+        1    8.000000
+        2    7.000000
+        3    2.532261
+        4    5.015296
+        dtype: float64
         """
         return self._clip_with_one_bound(threshold, method=self.ge,
                                          axis=axis, inplace=inplace)


### PR DESCRIPTION
```
(pandas_dev) david@david-TM1604:~/repos/pandas/scripts$ python validate_docstrings.py pandas.Series.clip_lower

################################################################################
##################### Docstring (pandas.Series.clip_lower) #####################
################################################################################

Return copy of the input with values below given value(s) truncated.

It truncate values below a certain threshold. Threshold can be a single
value or an array, in the latter case it performs the truncation element-wise.

Parameters
----------
threshold : float or array_like
    Minimum value allowed. All values below threshold will be
    set to this value.
axis : int or string axis name, optional
    Align object with threshold along the given axis.
inplace : boolean, default False
    Whether to perform the operation in place on the data.

See Also
--------
clip : Return copy of the input with values below and over given thresholds values truncated.

Returns
-------
clipped : same type as input

Examples
--------
>>> s = pd.Series([3.816052, 7.969235, 6.903116, 2.532261, 5.015296])
>>> s
0    3.816052
1    7.969235
2    6.903116
3    2.532261
4    5.015296
dtype: float64

>>> s.clip_lower(4)
0    4.000000
1    7.969235
2    6.903116
3    4.000000
4    5.015296
dtype: float64

>>> t = [4,8,7,2,5]
>>> t
[4, 8, 7, 2, 5]

>>> s.clip_lower(t)
0    4.000000
1    8.000000
2    7.000000
3    2.532261
4    5.015296
dtype: float64

################################################################################
################################## Validation ##################################
################################################################################

Docstring for "pandas.Series.clip_lower" correct. :)
```