### PR TITLE
DOC: Improved the docstring of pandas.Series.truncate

### DIFF
--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -6888,29 +6888,33 @@ class NDFrame(PandasObject, SelectionMixin):
 
     def truncate(self, before=None, after=None, axis=None, copy=True):
         """
-        Truncates a sorted DataFrame/Series before and/or after some
-        particular index value. If the axis contains only datetime values,
+        Truncate a DataFrame/Series before/after some index value.
+
+        If the axis contains only datetime values,
         before/after parameters are converted to datetime values.
 
         Parameters
         ----------
         before : date, string, int
-            Truncate all rows before this index value
+            Truncate all rows before this index value.
         after : date, string, int
-            Truncate all rows after this index value
+            Truncate all rows after this index value.
         axis : {0 or 'index', 1 or 'columns'}
-
-            * 0 or 'index': apply truncation to rows
-            * 1 or 'columns': apply truncation to columns
-
             Default is stat axis for given data type (0 for Series and
-            DataFrames, 1 for Panels)
+            DataFrames).
         copy : boolean, default is True,
-            return a copy of the truncated section
+            Return a copy of the truncated section.
 
         Returns
         -------
-        truncated : type of caller
+        type of caller
+            The truncated DataFrame/Series.
+
+        See Also
+        --------
+        DataFrame.truncate : Truncate a DataFrame before/after some index
+            value.
+        Series.truncate : Truncate a Series before/after some index value.
 
         Examples
         --------

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -6888,10 +6888,10 @@ class NDFrame(PandasObject, SelectionMixin):
 
     def truncate(self, before=None, after=None, axis=None, copy=True):
         """
-        Truncate a DataFrame/Series before/after some index value.
+        Truncate a Series or DataFrame before and after some index value.
 
-        If the axis contains only datetime values,
-        before/after parameters are converted to datetime values.
+        This is a useful shorthand for boolean indexing based on index
+        values above or below certain thresholds.
 
         Parameters
         ----------
@@ -6899,22 +6899,26 @@ class NDFrame(PandasObject, SelectionMixin):
             Truncate all rows before this index value.
         after : date, string, int
             Truncate all rows after this index value.
-        axis : {0 or 'index', 1 or 'columns'}
-            Default is stat axis for given data type (0 for Series and
-            DataFrames).
+        axis : {0 or 'index', 1 or 'columns'}, optional
+            Axis to truncate. Truncates the index (rows) by default.
         copy : boolean, default is True,
             Return a copy of the truncated section.
 
         Returns
         -------
         type of caller
-            The truncated DataFrame/Series.
+            The truncated Series or DataFrame.
 
         See Also
         --------
-        DataFrame.truncate : Truncate a DataFrame before/after some index
-            value.
-        Series.truncate : Truncate a Series before/after some index value.
+        DataFrame.loc : Select a subset of a DataFrame by label.
+        DataFrame.iloc : Select a subset of a DataFrame by position.
+
+        Notes
+        -----
+        If the index being truncated contains only datetime values,
+        `before` and `after` may be specified as strings instead of
+        Timestamps.
 
         Examples
         --------
@@ -6922,28 +6926,63 @@ class NDFrame(PandasObject, SelectionMixin):
         ...                    'B': ['f', 'g', 'h', 'i', 'j'],
         ...                    'C': ['k', 'l', 'm', 'n', 'o']},
         ...                    index=[1, 2, 3, 4, 5])
+        >>> df
+           A  B  C
+        1  a  f  k
+        2  b  g  l
+        3  c  h  m
+        4  d  i  n
+        5  e  j  o
+
         >>> df.truncate(before=2, after=4)
            A  B  C
         2  b  g  l
         3  c  h  m
         4  d  i  n
-        >>> df = pd.DataFrame({'A': [1, 2, 3, 4, 5],
-        ...                    'B': [6, 7, 8, 9, 10],
-        ...                    'C': [11, 12, 13, 14, 15]},
-        ...                    index=['a', 'b', 'c', 'd', 'e'])
-        >>> df.truncate(before='b', after='d')
-           A  B   C
-        b  2  7  12
-        c  3  8  13
-        d  4  9  14
+
+        The columns of a DataFrame can be truncated.
+
+        >>> df.truncate(before="A", after="B", axis="columns")
+           A  B
+        1  a  f
+        2  b  g
+        3  c  h
+        4  d  i
+        5  e  j
+
+        For Series, only rows can be truncated.
+
+        >>> df['A'].truncate(before=2, after=4)
+        2    b
+        3    c
+        4    d
+        Name: A, dtype: object
 
         The index values in ``truncate`` can be datetimes or string
-        dates. Note that ``truncate`` assumes a 0 value for any unspecified
-        date component in a ``DatetimeIndex`` in contrast to slicing which
-        returns any partially matching dates.
-
+        dates.
         >>> dates = pd.date_range('2016-01-01', '2016-02-01', freq='s')
         >>> df = pd.DataFrame(index=dates, data={'A': 1})
+        >>> df.tail()
+                             A
+        2016-01-31 23:59:56  1
+        2016-01-31 23:59:57  1
+        2016-01-31 23:59:58  1
+        2016-01-31 23:59:59  1
+        2016-02-01 00:00:00  1
+
+        >>> df.truncate(before=pd.Timestamp('2016-01-05'),
+        ...             after=pd.Timestamp('2016-01-10')).tail()
+                             A
+        2016-01-09 23:59:56  1
+        2016-01-09 23:59:57  1
+        2016-01-09 23:59:58  1
+        2016-01-09 23:59:59  1
+        2016-01-10 00:00:00  1
+
+        Because the index is a DatetimeIndex containing only dates, we can
+        specify `before` and `after` as strings. They will be coerced to
+        Timestamps before truncation.
+
         >>> df.truncate('2016-01-05', '2016-01-10').tail()
                              A
         2016-01-09 23:59:56  1
@@ -6951,6 +6990,11 @@ class NDFrame(PandasObject, SelectionMixin):
         2016-01-09 23:59:58  1
         2016-01-09 23:59:59  1
         2016-01-10 00:00:00  1
+
+        Note that ``truncate`` assumes a 0 value for any unspecified time
+        component (midnight). This differs from partial string slicing, which
+        returns any partially matching dates.
+
         >>> df.loc['2016-01-05':'2016-01-10', :].tail()
                              A
         2016-01-10 23:59:55  1


### PR DESCRIPTION
Checklist for the pandas documentation sprint (ignore this if you are doing
an unrelated PR):

- [x] PR title is "DOC: update the <your-function-or-method> docstring"
- [x] The validation script passes: `scripts/validate_docstrings.py <your-function-or-method>`
- [x] The PEP8 style check passes: `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] The html version looks good: `python doc/make.py --single <your-function-or-method>`
- [x] It has been proofread on language by another sprint participant

Please include the output of the validation script below between the "```" ticks:

```

################################################################################
###################### Docstring (pandas.Series.truncate) ######################
################################################################################

Truncate a DataFrame/Series before/after some index value.

If the axis contains only datetime values,
before/after parameters are converted to datetime values.

Parameters
----------
before : date, string, int
    Truncate all rows before this index value.
after : date, string, int
    Truncate all rows after this index value.
axis : {0 or 'index', 1 or 'columns'}
    Default is stat axis for given data type (0 for Series and
    DataFrames, 1 for Panels).
copy : boolean, default is True,
    Return a copy of the truncated section.

Returns
-------
truncated : type of caller

See Also
--------
DataFrame.truncate : Truncate a DataFrame before/after some index value.
Series.truncate : Truncate a Series before/after some index value.

Examples
--------
>>> df = pd.DataFrame({'A': ['a', 'b', 'c', 'd', 'e'],
...                    'B': ['f', 'g', 'h', 'i', 'j'],
...                    'C': ['k', 'l', 'm', 'n', 'o']},
...                    index=[1, 2, 3, 4, 5])
>>> df.truncate(before=2, after=4)
   A  B  C
2  b  g  l
3  c  h  m
4  d  i  n
>>> df = pd.DataFrame({'A': [1, 2, 3, 4, 5],
...                    'B': [6, 7, 8, 9, 10],
...                    'C': [11, 12, 13, 14, 15]},
...                    index=['a', 'b', 'c', 'd', 'e'])
>>> df.truncate(before='b', after='d')
   A  B   C
b  2  7  12
c  3  8  13
d  4  9  14

The index values in ``truncate`` can be datetimes or string
dates. Note that ``truncate`` assumes a 0 value for any unspecified
date component in a ``DatetimeIndex`` in contrast to slicing which
returns any partially matching dates.

>>> dates = pd.date_range('2016-01-01', '2016-02-01', freq='s')
>>> df = pd.DataFrame(index=dates, data={'A': 1})
>>> df.truncate('2016-01-05', '2016-01-10').tail()
                     A
2016-01-09 23:59:56  1
2016-01-09 23:59:57  1
2016-01-09 23:59:58  1
2016-01-09 23:59:59  1
2016-01-10 00:00:00  1
>>> df.loc['2016-01-05':'2016-01-10', :].tail()
                     A
2016-01-10 23:59:55  1
2016-01-10 23:59:56  1
2016-01-10 23:59:57  1
2016-01-10 23:59:58  1
2016-01-10 23:59:59  1

################################################################################
################################## Validation ##################################
################################################################################

Docstring for "pandas.Series.truncate" correct. :)
```
