### PR TITLE
DOC: updated the examples in date_range function of Pandas

### DIFF
--- a/pandas/core/indexes/datetimes.py
+++ b/pandas/core/indexes/datetimes.py
@@ -2266,7 +2266,16 @@ def date_range(start=None, end=None, periods=None, freq='D', tz=None,
                    '2018-01-05', '2018-01-06', '2018-01-07', '2018-01-08'],
                   dtype='datetime64[ns]', freq='D')
 
-    Specify `end` and `periods`.
+    Specify `end` and `periods`, the number of periods (days).
+
+    >>> pd.date_range(end='1/1/2018', periods=8)
+    DatetimeIndex(['2017-12-25', '2017-12-26', '2017-12-27', '2017-12-28',
+                   '2017-12-29', '2017-12-30', '2017-12-31', '2018-01-01'],
+                  dtype='datetime64[ns]', freq='D')
+
+    Given the ``start`` and ``periods`` mandatory parameters,
+    periods would be the number of the days, with default `freq='D'`
+    (D=calendar day frequency)
 
     >>> pd.date_range(end='1/8/2018', periods=8)
     DatetimeIndex(['2018-01-01', '2018-01-02', '2018-01-03', '2018-01-04',

--- a/pandas/core/indexes/datetimes.py
+++ b/pandas/core/indexes/datetimes.py
@@ -2206,7 +2206,7 @@ def date_range(start=None, end=None, periods=None, freq='D', tz=None,
     """
     Return a fixed frequency DatetimeIndex.
 
-    Exactly two of the three parameters `start``, `end` and `periods`
+    Exactly two of the three parameters `start`, `end` and `periods`
     must be specified.
 
     Parameters
@@ -2247,7 +2247,7 @@ def date_range(start=None, end=None, periods=None, freq='D', tz=None,
 
     Examples
     --------
-    **Specifying the values***
+    **Specifying the values**
 
     The next three examples generate the same `DatetimeIndex`, but vary
     the combination of `start`, `end` and `periods`.
@@ -2271,15 +2271,6 @@ def date_range(start=None, end=None, periods=None, freq='D', tz=None,
     >>> pd.date_range(end='1/1/2018', periods=8)
     DatetimeIndex(['2017-12-25', '2017-12-26', '2017-12-27', '2017-12-28',
                    '2017-12-29', '2017-12-30', '2017-12-31', '2018-01-01'],
-                  dtype='datetime64[ns]', freq='D')
-
-    Given the ``start`` and ``periods`` mandatory parameters,
-    periods would be the number of the days, with default `freq='D'`
-    (D=calendar day frequency)
-
-    >>> pd.date_range(end='1/8/2018', periods=8)
-    DatetimeIndex(['2018-01-01', '2018-01-02', '2018-01-03', '2018-01-04',
-                   '2018-01-05', '2018-01-06', '2018-01-07', '2018-01-08'],
                   dtype='datetime64[ns]', freq='D')
 
     **Other Parameters**

--- a/pandas/core/indexes/datetimes.py
+++ b/pandas/core/indexes/datetimes.py
@@ -2230,7 +2230,7 @@ def date_range(start=None, end=None, periods=None, freq='D', tz=None,
 
     Notes
     -----
-    Of the three parameters: ``start``, ``end``, and ``periods``, exactly two
+    Of the three parameters: ``start``, ``end`` and ``periods``, exactly two
     must be specified.
 
     To learn more about the frequency strings, please see `this link

--- a/pandas/core/indexes/datetimes.py
+++ b/pandas/core/indexes/datetimes.py
@@ -2206,36 +2206,34 @@ def date_range(start=None, end=None, periods=None, freq='D', tz=None,
     """
     Return a fixed frequency DatetimeIndex.
 
-    The default frequency is day (calendar).
+    Exactly two of the three parameters `start``, `end` and `periods`
+    must be specified.
 
     Parameters
     ----------
-    start : str or datetime-like, default None
+    start : str or datetime-like, optional
         Left bound for generating dates.
-    end : str or datetime-like, default None
+    end : str or datetime-like, optional
         Right bound for generating dates.
-    periods : integer, default None
+    periods : integer, optional
         Number of periods to generate.
     freq : str or DateOffset, default 'D' (calendar daily)
-        Frequency strings can have multiples, e.g. '5H'.
-    tz : str, default None
+        Frequency strings can have multiples, e.g. '5H'. See
+        :ref:`here <timeseries.offset_aliases>` for a list of
+        frequency aliases.
+    tz : str or tzinfo, optional
         Time zone name for returning localized DatetimeIndex, for example
-        Asia/Hong_Kong.
+        'Asia/Hong_Kong'. By default, the resulting DatetimeIndex is
+        timezone-naive.
     normalize : bool, default False
         Normalize start/end dates to midnight before generating date range.
     name : str, default None
         Name of the resulting DatetimeIndex.
-    closed : str, default None
+    closed : {None, 'left', 'right'}, optional
         Make the interval closed with respect to the given frequency to
-        the 'left', 'right', or both sides (None).
-
-    Notes
-    -----
-    Of the three parameters: ``start``, ``end`` and ``periods``, exactly two
-    must be specified.
-
-    To learn more about the frequency strings, please see `this link
-    <http://pandas.pydata.org/pandas-docs/stable/timeseries.html#offset-aliases>`__.
+        the 'left', 'right', or both sides (None, the default).
+    **kwargs
+        For compatibility. Has no effect on the result.
 
     Returns
     -------
@@ -2243,49 +2241,87 @@ def date_range(start=None, end=None, periods=None, freq='D', tz=None,
 
     See Also
     --------
+    pandas.DatetimeIndex : An immutable container for datetimes.
     pandas.period_range : Return a fixed frequency PeriodIndex.
     pandas.interval_range : Return a fixed frequency IntervalIndex.
-    Numpy daterange: `numpy daterange<https://docs.scipy.org/doc/numpy/reference/arrays.datetime.html>`__.
 
     Examples
     --------
+    **Specifying the values***
 
-    Given the `start` and `end` mandatory parameters,
-    with default ``freq='D'`` (Days)
+    The next three examples generate the same `DatetimeIndex`, but vary
+    the combination of `start`, `end` and `periods`.
 
-    >>> pd.date_range(start='1/1/2018', end='1/10/2018')
+    Specify `start` and `end`, with the default daily frequency.
+
+    >>> pd.date_range(start='1/1/2018', end='1/08/2018')
     DatetimeIndex(['2018-01-01', '2018-01-02', '2018-01-03', '2018-01-04',
-                   '2018-01-05', '2018-01-06', '2018-01-07', '2018-01-08',
-                   '2018-01-09', '2018-01-10'],
+                   '2018-01-05', '2018-01-06', '2018-01-07', '2018-01-08'],
                   dtype='datetime64[ns]', freq='D')
 
-    Given the ``start`` and ``periods`` mandatory parameters,
-    periods would be the limit of the DatetimeIndex, with default `freq='D'`
-    (D=calendar day frequency)
+    Specify `start` and `periods`, the number of periods (days).
 
-    >>> pd.date_range(start='1/1/2018', periods=5)
+    >>> pd.date_range(start='1/1/2018', periods=8)
     DatetimeIndex(['2018-01-01', '2018-01-02', '2018-01-03', '2018-01-04',
-                   '2018-01-05'],
+                   '2018-01-05', '2018-01-06', '2018-01-07', '2018-01-08'],
                   dtype='datetime64[ns]', freq='D')
 
-    Changed the `freq` (frequency) to `'M'` (month end frequency) and `tz` to `'UTC'`
+    Specify `end` and `periods`.
 
-    >>> pd.date_range(start='1/1/2018', periods=5, freq='M', tz='UTC')
+    >>> pd.date_range(end='1/8/2018', periods=8)
+    DatetimeIndex(['2018-01-01', '2018-01-02', '2018-01-03', '2018-01-04',
+                   '2018-01-05', '2018-01-06', '2018-01-07', '2018-01-08'],
+                  dtype='datetime64[ns]', freq='D')
+
+    **Other Parameters**
+
+    Changed the `freq` (frequency) to ``'M'`` (month end frequency).
+
+    >>> pd.date_range(start='1/1/2018', periods=5, freq='M')
     DatetimeIndex(['2018-01-31', '2018-02-28', '2018-03-31', '2018-04-30',
                    '2018-05-31'],
-                  dtype='datetime64[ns, UTC]', freq='M')
+                  dtype='datetime64[ns]', freq='M')
 
-    closed set to `'left'`, this makes the month range with the starting month
-    (inclusive of dec to feb)
+    Multiples are allowed
 
-    >>> pd.date_range(start='31/12/2017', end='3/1/2018', freq='M', closed='left')
-    DatetimeIndex(['2017-12-31', '2018-01-31', '2018-02-28'], dtype='datetime64[ns]', freq='M')
+    >>> pd.date_range(start='1/1/2018', periods=5, freq='3M')
+    DatetimeIndex(['2018-01-31', '2018-04-30', '2018-07-31', '2018-10-31',
+                   '2019-01-31'],
+                  dtype='datetime64[ns]', freq='3M')
 
-    closed set to `'right'`, this makes the month range after the starting month
-    (inclusive of jan to feb)
+    `freq` can also be specified as an Offset object.
 
-    >>> pd.date_range(start='31/12/2017', end='3/1/2018', freq='M', closed='right')
-    DatetimeIndex(['2018-01-31', '2018-02-28'], dtype='datetime64[ns]', freq='M')
+    >>> pd.date_range(start='1/1/2018', periods=5, freq=pd.offsets.MonthEnd(3))
+    DatetimeIndex(['2018-01-31', '2018-04-30', '2018-07-31', '2018-10-31',
+                   '2019-01-31'],
+                  dtype='datetime64[ns]', freq='3M')
+
+    Specify `tz` to set the timezone.
+
+    >>> pd.date_range(start='1/1/2018', periods=5, tz='Asia/Tokyo')
+    DatetimeIndex(['2018-01-01 00:00:00+09:00', '2018-01-02 00:00:00+09:00',
+                   '2018-01-03 00:00:00+09:00', '2018-01-04 00:00:00+09:00',
+                   '2018-01-05 00:00:00+09:00'],
+                  dtype='datetime64[ns, Asia/Tokyo]', freq='D')
+
+    `closed` controls whether to include `start` and `end` that are on the
+    boundary. The default includes boundary points on either end.
+
+    >>> pd.date_range(start='2017-01-01', end='2017-01-04', closed=None)
+    DatetimeIndex(['2017-01-01', '2017-01-02', '2017-01-03', '2017-01-04'],
+                  dtype='datetime64[ns]', freq='D')
+
+    Use ``closed='left'`` to exclude `end` if it falls on the boundary.
+
+    >>> pd.date_range(start='2017-01-01', end='2017-01-04', closed='left')
+    DatetimeIndex(['2017-01-01', '2017-01-02', '2017-01-03'],
+                  dtype='datetime64[ns]', freq='D')
+
+    Use ``closed='right'`` to exclude `start` if it falls on the boundary.
+
+    >>> pd.date_range(start='2017-01-01', end='2017-01-04', closed='right')
+    DatetimeIndex(['2017-01-02', '2017-01-03', '2017-01-04'],
+                  dtype='datetime64[ns]', freq='D')
     """
     return DatetimeIndex(start=start, end=end, periods=periods,
                          freq=freq, tz=tz, normalize=normalize, name=name,

--- a/pandas/core/indexes/datetimes.py
+++ b/pandas/core/indexes/datetimes.py
@@ -2242,24 +2242,45 @@ def date_range(start=None, end=None, periods=None, freq='D', tz=None,
 
     Examples
     --------
-    >>> pd1 = pd.date_range(start='1/1/2018', end='2/1/2018')
+
+    Given the ``start`` and ``end`` mandatory parameters,
+    with default `freq='D'` (Days)
+
+    >>> pd1 = pd.date_range(start='1/1/2018', end='1/10/2018')
     >>> pd1
     DatetimeIndex(['2018-01-01', '2018-01-02', '2018-01-03', '2018-01-04',
-               '2018-01-05', '2018-01-06', '2018-01-07', '2018-01-08',
-               '2018-01-09', '2018-01-10', '2018-01-11', '2018-01-12',
-               '2018-01-13', '2018-01-14', '2018-01-15', '2018-01-16',
-               '2018-01-17', '2018-01-18', '2018-01-19', '2018-01-20',
-               '2018-01-21', '2018-01-22', '2018-01-23', '2018-01-24',
-               '2018-01-25', '2018-01-26', '2018-01-27', '2018-01-28',
-               '2018-01-29', '2018-01-30', '2018-01-31', '2018-02-01'],
-              dtype='datetime64[ns]', freq='D')
+                   '2018-01-05', '2018-01-06', '2018-01-07', '2018-01-08',
+                   '2018-01-09', '2018-01-10'],
+                  dtype='datetime64[ns]', freq='D')
 
+    Given the ``start`` and ``periods`` mandatory parameters,
+    periods would be the limit of the DatetimeIndex, with default `freq='D'` (calendar day frequency)
 
     >>> pd2 = pd.date_range(start='1/1/2018', periods=5)
     >>> pd2
     DatetimeIndex(['2018-01-01', '2018-01-02', '2018-01-03', '2018-01-04',
-               '2018-01-05'],
-              dtype='datetime64[ns]', freq='D')
+                   '2018-01-05'],
+                  dtype='datetime64[ns]', freq='D')
+
+    Changed the `freq` (frequency) to `'M'` (month end frequency) and `tz` to `'UTC'`
+
+    >>> pd3 = pd.date_range(start='1/1/2018', periods=5, freq='M', tz='UTC')
+    >>> pd3
+    DatetimeIndex(['2018-01-31', '2018-02-28', '2018-03-31', '2018-04-30',
+                   '2018-05-31'],
+                  dtype='datetime64[ns, UTC]', freq='M')
+
+    closed set to `'left'`, this makes the month range with the starting month (therefore inclusive of dec to feb)
+
+    >>> pd4 = pd.date_range(start='31/12/2017', end='3/1/2018', freq='M', closed='left')
+    >>> pd4
+    DatetimeIndex(['2017-12-31', '2018-01-31', '2018-02-28'], dtype='datetime64[ns]', freq='M')
+
+    closed set to `'right'`, this makes the month range after the starting month (therefore inclusive of jan to feb)
+
+    >>> pd4 = pd.date_range(start='31/12/2017', end='3/1/2018', freq='M', closed='right')
+    >>> pd4
+    DatetimeIndex(['2018-01-31', '2018-02-28'], dtype='datetime64[ns]', freq='M')
     """
     return DatetimeIndex(start=start, end=end, periods=periods,
                          freq=freq, tz=tz, normalize=normalize, name=name,

--- a/pandas/core/indexes/datetimes.py
+++ b/pandas/core/indexes/datetimes.py
@@ -2254,7 +2254,8 @@ def date_range(start=None, end=None, periods=None, freq='D', tz=None,
                   dtype='datetime64[ns]', freq='D')
 
     Given the ``start`` and ``periods`` mandatory parameters,
-    periods would be the limit of the DatetimeIndex, with default `freq='D'` (calendar day frequency)
+    periods would be the limit of the DatetimeIndex, with default `freq='D'`
+    (D=calendar day frequency)
 
     >>> pd2 = pd.date_range(start='1/1/2018', periods=5)
     >>> pd2
@@ -2270,13 +2271,15 @@ def date_range(start=None, end=None, periods=None, freq='D', tz=None,
                    '2018-05-31'],
                   dtype='datetime64[ns, UTC]', freq='M')
 
-    closed set to `'left'`, this makes the month range with the starting month (therefore inclusive of dec to feb)
+    closed set to `'left'`, this makes the month range with the starting month
+    (inclusive of dec to feb)
 
     >>> pd4 = pd.date_range(start='31/12/2017', end='3/1/2018', freq='M', closed='left')
     >>> pd4
     DatetimeIndex(['2017-12-31', '2018-01-31', '2018-02-28'], dtype='datetime64[ns]', freq='M')
 
-    closed set to `'right'`, this makes the month range after the starting month (therefore inclusive of jan to feb)
+    closed set to `'right'`, this makes the month range after the starting month
+    (inclusive of jan to feb)
 
     >>> pd4 = pd.date_range(start='31/12/2017', end='3/1/2018', freq='M', closed='right')
     >>> pd4

--- a/pandas/core/indexes/datetimes.py
+++ b/pandas/core/indexes/datetimes.py
@@ -2285,6 +2285,10 @@ def date_range(start=None, end=None, periods=None, freq='D', tz=None,
     >>> pd4 = pd.date_range(start='31/12/2017', end='3/1/2018', freq='M', closed='right')
     >>> pd4
     DatetimeIndex(['2018-01-31', '2018-02-28'], dtype='datetime64[ns]', freq='M')
+
+    See Also
+    --------
+    Numpy daterange: `numpy daterange<https://docs.scipy.org/doc/numpy/reference/arrays.datetime.html>`__.
     """
     return DatetimeIndex(start=start, end=end, periods=periods,
                          freq=freq, tz=tz, normalize=normalize, name=name,

--- a/pandas/core/indexes/datetimes.py
+++ b/pandas/core/indexes/datetimes.py
@@ -2210,22 +2210,22 @@ def date_range(start=None, end=None, periods=None, freq='D', tz=None,
 
     Parameters
     ----------
-    start : string or datetime-like, default None
+    start : str or datetime-like, default None
         Left bound for generating dates.
-    end : string or datetime-like, default None
+    end : str or datetime-like, default None
         Right bound for generating dates.
     periods : integer, default None
         Number of periods to generate.
-    freq : string or DateOffset, default 'D' (calendar daily)
+    freq : str or DateOffset, default 'D' (calendar daily)
         Frequency strings can have multiples, e.g. '5H'.
-    tz : string, default None
+    tz : str, default None
         Time zone name for returning localized DatetimeIndex, for example
         Asia/Hong_Kong.
     normalize : bool, default False
         Normalize start/end dates to midnight before generating date range.
-    name : string, default None
+    name : str, default None
         Name of the resulting DatetimeIndex.
-    closed : string, default None
+    closed : str, default None
         Make the interval closed with respect to the given frequency to
         the 'left', 'right', or both sides (None).
 
@@ -2241,14 +2241,19 @@ def date_range(start=None, end=None, periods=None, freq='D', tz=None,
     -------
     rng : DatetimeIndex
 
+    See Also
+    --------
+    pandas.period_range : Return a fixed frequency PeriodIndex.
+    pandas.interval_range : Return a fixed frequency IntervalIndex.
+    Numpy daterange: `numpy daterange<https://docs.scipy.org/doc/numpy/reference/arrays.datetime.html>`__.
+
     Examples
     --------
 
-    Given the ``start`` and ``end`` mandatory parameters,
-    with default `freq='D'` (Days)
+    Given the `start` and `end` mandatory parameters,
+    with default ``freq='D'`` (Days)
 
-    >>> pd1 = pd.date_range(start='1/1/2018', end='1/10/2018')
-    >>> pd1
+    >>> pd.date_range(start='1/1/2018', end='1/10/2018')
     DatetimeIndex(['2018-01-01', '2018-01-02', '2018-01-03', '2018-01-04',
                    '2018-01-05', '2018-01-06', '2018-01-07', '2018-01-08',
                    '2018-01-09', '2018-01-10'],
@@ -2258,16 +2263,14 @@ def date_range(start=None, end=None, periods=None, freq='D', tz=None,
     periods would be the limit of the DatetimeIndex, with default `freq='D'`
     (D=calendar day frequency)
 
-    >>> pd2 = pd.date_range(start='1/1/2018', periods=5)
-    >>> pd2
+    >>> pd.date_range(start='1/1/2018', periods=5)
     DatetimeIndex(['2018-01-01', '2018-01-02', '2018-01-03', '2018-01-04',
                    '2018-01-05'],
                   dtype='datetime64[ns]', freq='D')
 
     Changed the `freq` (frequency) to `'M'` (month end frequency) and `tz` to `'UTC'`
 
-    >>> pd3 = pd.date_range(start='1/1/2018', periods=5, freq='M', tz='UTC')
-    >>> pd3
+    >>> pd.date_range(start='1/1/2018', periods=5, freq='M', tz='UTC')
     DatetimeIndex(['2018-01-31', '2018-02-28', '2018-03-31', '2018-04-30',
                    '2018-05-31'],
                   dtype='datetime64[ns, UTC]', freq='M')
@@ -2275,22 +2278,14 @@ def date_range(start=None, end=None, periods=None, freq='D', tz=None,
     closed set to `'left'`, this makes the month range with the starting month
     (inclusive of dec to feb)
 
-    >>> pd4 = pd.date_range(start='31/12/2017', end='3/1/2018', freq='M', closed='left')
-    >>> pd4
+    >>> pd.date_range(start='31/12/2017', end='3/1/2018', freq='M', closed='left')
     DatetimeIndex(['2017-12-31', '2018-01-31', '2018-02-28'], dtype='datetime64[ns]', freq='M')
 
     closed set to `'right'`, this makes the month range after the starting month
     (inclusive of jan to feb)
 
-    >>> pd4 = pd.date_range(start='31/12/2017', end='3/1/2018', freq='M', closed='right')
-    >>> pd4
+    >>> pd.date_range(start='31/12/2017', end='3/1/2018', freq='M', closed='right')
     DatetimeIndex(['2018-01-31', '2018-02-28'], dtype='datetime64[ns]', freq='M')
-
-    See Also
-    --------
-    pandas.period_range : Return a fixed frequency PeriodIndex.
-    pandas.interval_range : Return a fixed frequency IntervalIndex.
-    Numpy daterange: `numpy daterange<https://docs.scipy.org/doc/numpy/reference/arrays.datetime.html>`__.
     """
     return DatetimeIndex(start=start, end=end, periods=periods,
                          freq=freq, tz=tz, normalize=normalize, name=name,

--- a/pandas/core/indexes/datetimes.py
+++ b/pandas/core/indexes/datetimes.py
@@ -2210,23 +2210,23 @@ def date_range(start=None, end=None, periods=None, freq='D', tz=None,
     Parameters
     ----------
     start : string or datetime-like, default None
-        Left bound for generating dates
+        Left bound for generating dates.
     end : string or datetime-like, default None
-        Right bound for generating dates
+        Right bound for generating dates.
     periods : integer, default None
-        Number of periods to generate
+        Number of periods to generate.
     freq : string or DateOffset, default 'D' (calendar daily)
-        Frequency strings can have multiples, e.g. '5H'
+        Frequency strings can have multiples, e.g. '5H'.
     tz : string, default None
         Time zone name for returning localized DatetimeIndex, for example
-        Asia/Hong_Kong
+        Asia/Hong_Kong.
     normalize : bool, default False
-        Normalize start/end dates to midnight before generating date range
+        Normalize start/end dates to midnight before generating date range.
     name : string, default None
-        Name of the resulting DatetimeIndex
+        Name of the resulting DatetimeIndex.
     closed : string, default None
         Make the interval closed with respect to the given frequency to
-        the 'left', 'right', or both sides (None)
+        the 'left', 'right', or both sides (None).
 
     Notes
     -----
@@ -2239,6 +2239,27 @@ def date_range(start=None, end=None, periods=None, freq='D', tz=None,
     Returns
     -------
     rng : DatetimeIndex
+
+    Examples
+    --------
+    >>> pd1 = pd.date_range(start='1/1/2018', end='2/1/2018')
+    >>> pd1
+    DatetimeIndex(['2018-01-01', '2018-01-02', '2018-01-03', '2018-01-04',
+               '2018-01-05', '2018-01-06', '2018-01-07', '2018-01-08',
+               '2018-01-09', '2018-01-10', '2018-01-11', '2018-01-12',
+               '2018-01-13', '2018-01-14', '2018-01-15', '2018-01-16',
+               '2018-01-17', '2018-01-18', '2018-01-19', '2018-01-20',
+               '2018-01-21', '2018-01-22', '2018-01-23', '2018-01-24',
+               '2018-01-25', '2018-01-26', '2018-01-27', '2018-01-28',
+               '2018-01-29', '2018-01-30', '2018-01-31', '2018-02-01'],
+              dtype='datetime64[ns]', freq='D')
+
+
+    >>> pd2 = pd.date_range(start='1/1/2018', periods=5)
+    >>> pd2
+    DatetimeIndex(['2018-01-01', '2018-01-02', '2018-01-03', '2018-01-04',
+               '2018-01-05'],
+              dtype='datetime64[ns]', freq='D')
     """
     return DatetimeIndex(start=start, end=end, periods=periods,
                          freq=freq, tz=tz, normalize=normalize, name=name,

--- a/pandas/core/indexes/datetimes.py
+++ b/pandas/core/indexes/datetimes.py
@@ -2288,6 +2288,8 @@ def date_range(start=None, end=None, periods=None, freq='D', tz=None,
 
     See Also
     --------
+    pandas.period_range : Return a fixed frequency PeriodIndex.
+    pandas.interval_range : Return a fixed frequency IntervalIndex.
     Numpy daterange: `numpy daterange<https://docs.scipy.org/doc/numpy/reference/arrays.datetime.html>`__.
     """
     return DatetimeIndex(start=start, end=end, periods=periods,


### PR DESCRIPTION
I have updated some little typos of full stop that I came across while validating and added some examples for `date_range` function in pandas/core/indexes/datetimes.py . Please review this and let me know if I can make it better.

thanks