### PR TITLE
DOC: update the parquet docstring

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -1699,7 +1699,8 @@ class DataFrame(NDFrame):
 
         This function writes the dataframe as a `parquet file
         <https://parquet.apache.org/>`_. You can choose different parquet
-        backends, and have the option of compression.
+        backends, and have the option of compression. See
+        :ref:`the user guide <io.parquet>` for more details.
 
         Parameters
         ----------
@@ -1715,10 +1716,6 @@ class DataFrame(NDFrame):
         **kwargs
             Additional arguments passed to the parquet library. See
             :ref:`pandas io <io.parquet>` for more details.
-
-        Returns
-        -------
-        None
 
         See Also
         --------

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -1697,9 +1697,9 @@ class DataFrame(NDFrame):
 
         .. versionadded:: 0.21.0
 
-        This function writes the dataframe as a parquet file (see
-        :func:`pandas.io.parquet.to_parquet`). You can choose different parquet
-        backends, and have the option of compressing.
+        This function writes the dataframe as a `parquet file
+        <https://parquet.apache.org/>`_. You can choose different parquet
+        backends, and have the option of compression.
 
         Parameters
         ----------
@@ -1714,8 +1714,7 @@ class DataFrame(NDFrame):
             Name of the compression to use. Use ``None`` for no compression.
         **kwargs
             Additional arguments passed to the parquet library. See
-            the documentation for :func:`pandas.io.parquet.to_parquet` for
-            complete details.
+            :ref:`pandas io <io.parquet>` for more details.
 
         Returns
         -------
@@ -1730,7 +1729,7 @@ class DataFrame(NDFrame):
 
         Notes
         -----
-        This function requires either the fastparquet or pyarrow library.
+        This function requires either the `fastparquet <https://pypi.python.org/pypi/fastparquet>`_ or `pyarrow <https://arrow.apache.org/docs/python/>`_ library.
 
         Examples
         --------

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -1697,10 +1697,12 @@ class DataFrame(NDFrame):
 
         .. versionadded:: 0.21.0
 
+        Requires either fastparquet or pyarrow libraries.
+
         Parameters
         ----------
         fname : str
-            string file path
+            String file path.
         engine : {'auto', 'pyarrow', 'fastparquet'}, default 'auto'
             Parquet library to use. If 'auto', then the option
             ``io.parquet.engine`` is used. The default ``io.parquet.engine``
@@ -1708,8 +1710,23 @@ class DataFrame(NDFrame):
             'pyarrow' is unavailable.
         compression : {'snappy', 'gzip', 'brotli', None}, default 'snappy'
             Name of the compression to use. Use ``None`` for no compression.
-        kwargs
-            Additional keyword arguments passed to the engine
+        kwargs : dict
+            Additional keyword arguments passed to the engine.
+
+        Examples
+        ----------
+        >>> df = pd.DataFrame(data={'col1': [1, 2], 'col2': [3, 4]})
+        >>> df.to_parquet('df.parquet.gzip', compression='gzip')
+
+        Returns
+        ----------
+        Nothing.
+
+        See Also
+        --------
+        DataFrame.to_csv : write a csv file.
+        DataFrame.to_sql : write to a sql table.
+        DataFrame.to_hdf : write to hdf.
         """
         from pandas.io.parquet import to_parquet
         to_parquet(self, fname, engine,

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -1697,7 +1697,9 @@ class DataFrame(NDFrame):
 
         .. versionadded:: 0.21.0
 
-        Requires either fastparquet or pyarrow libraries.
+        This function writes the dataframe as a parquet file. You
+        can choose different parquet backends, and have the option
+        of compressing.
 
         Parameters
         ----------
@@ -1713,20 +1715,24 @@ class DataFrame(NDFrame):
         kwargs : dict
             Additional keyword arguments passed to the engine.
 
-        Examples
-        ----------
-        >>> df = pd.DataFrame(data={'col1': [1, 2], 'col2': [3, 4]})
-        >>> df.to_parquet('df.parquet.gzip', compression='gzip')
-
         Returns
         ----------
-        Nothing.
+        None
 
         See Also
         --------
         DataFrame.to_csv : write a csv file.
         DataFrame.to_sql : write to a sql table.
         DataFrame.to_hdf : write to hdf.
+
+        Notes
+        ----------
+        Requires either fastparquet or pyarrow libraries.
+
+        Examples
+        ----------
+        >>> df = pd.DataFrame(data={'col1': [1, 2], 'col2': [3, 4]})
+        >>> df.to_parquet('df.parquet.gzip', compression='gzip')
         """
         from pandas.io.parquet import to_parquet
         to_parquet(self, fname, engine,

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -1712,8 +1712,8 @@ class DataFrame(NDFrame):
             'pyarrow' is unavailable.
         compression : {'snappy', 'gzip', 'brotli', None}, default 'snappy'
             Name of the compression to use. Use ``None`` for no compression.
-        kwargs : dict
-            Additional keyword arguments passed to the parquet library. See
+        **kwargs
+            Additional arguments passed to the parquet library. See
             the documentation for :func:`pandas.io.parquet.to_parquet` for
             complete details.
 

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -1729,7 +1729,9 @@ class DataFrame(NDFrame):
 
         Notes
         -----
-        This function requires either the `fastparquet <https://pypi.python.org/pypi/fastparquet>`_ or `pyarrow <https://arrow.apache.org/docs/python/>`_ library.
+        This function requires either the `fastparquet
+        <https://pypi.python.org/pypi/fastparquet>`_ or `pyarrow
+        <https://arrow.apache.org/docs/python/>`_ library.
 
         Examples
         --------

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -1734,6 +1734,10 @@ class DataFrame(NDFrame):
         --------
         >>> df = pd.DataFrame(data={'col1': [1, 2], 'col2': [3, 4]})
         >>> df.to_parquet('df.parquet.gzip', compression='gzip')
+        >>> pd.read_parquet('df.parquet.gzip')
+           col1  col2
+        0     1     3
+        1     2     4
         """
         from pandas.io.parquet import to_parquet
         to_parquet(self, fname, engine,

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -1697,9 +1697,9 @@ class DataFrame(NDFrame):
 
         .. versionadded:: 0.21.0
 
-        This function writes the dataframe as a parquet file. You
-        can choose different parquet backends, and have the option
-        of compressing.
+        This function writes the dataframe as a parquet file (see
+        :func:`pandas.io.parquet.to_parquet`). You can choose different parquet
+        backends, and have the option of compressing.
 
         Parameters
         ----------
@@ -1713,24 +1713,27 @@ class DataFrame(NDFrame):
         compression : {'snappy', 'gzip', 'brotli', None}, default 'snappy'
             Name of the compression to use. Use ``None`` for no compression.
         kwargs : dict
-            Additional keyword arguments passed to the engine.
+            Additional keyword arguments passed to the parquet library. See
+            the documentation for :func:`pandas.io.parquet.to_parquet` for
+            complete details.
 
         Returns
-        ----------
+        -------
         None
 
         See Also
         --------
-        DataFrame.to_csv : write a csv file.
-        DataFrame.to_sql : write to a sql table.
-        DataFrame.to_hdf : write to hdf.
+        read_parquet : Read a parquet file.
+        DataFrame.to_csv : Write a csv file.
+        DataFrame.to_sql : Write to a sql table.
+        DataFrame.to_hdf : Write to hdf.
 
         Notes
-        ----------
-        Requires either fastparquet or pyarrow libraries.
+        -----
+        This function requires either the fastparquet or pyarrow library.
 
         Examples
-        ----------
+        --------
         >>> df = pd.DataFrame(data={'col1': [1, 2], 'col2': [3, 4]})
         >>> df.to_parquet('df.parquet.gzip', compression='gzip')
         """


### PR DESCRIPTION
Checklist for the pandas documentation sprint (ignore this if you are doing
an unrelated PR):

- [x] PR title is "DOC: update the <your-function-or-method> docstring"
- [x] The validation script passes: `scripts/validate_docstrings.py <your-function-or-method>`
- [x] The PEP8 style check passes: `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] The html version looks good: `python doc/make.py --single <your-function-or-method>`
- [x] It has been proofread on language by another sprint participant

Please include the output of the validation script below between the "```" ticks:

```
################################################################################
################### Docstring (pandas.DataFrame.to_parquet)  ###################
################################################################################

Write a DataFrame to the binary parquet format.

.. versionadded:: 0.21.0

Requires either fastparquet or pyarrow libraries.

Parameters
----------
fname : str
    String file path.
engine : {'auto', 'pyarrow', 'fastparquet'}, default 'auto'
    Parquet library to use. If 'auto', then the option
    ``io.parquet.engine`` is used. The default ``io.parquet.engine``
    behavior is to try 'pyarrow', falling back to 'fastparquet' if
    'pyarrow' is unavailable.
compression : {'snappy', 'gzip', 'brotli', None}, default 'snappy'
    Name of the compression to use. Use ``None`` for no compression.
kwargs : dict
    Additional keyword arguments passed to the engine.

Examples
----------
>>> df = pd.DataFrame(data={'col1': [1, 2], 'col2': [3, 4]})
>>> df.to_parquet('df.parquet.gzip', compression='gzip')

Returns
----------
None

See Also
--------
DataFrame.to_csv : write a csv file.
DataFrame.to_sql : write to a sql table.
DataFrame.to_hdf : write to hdf.

################################################################################
################################## Validation ##################################
################################################################################

Docstring for "pandas.DataFrame.to_parquet" correct. :)
```