### PR TITLE
DOC: Docstring for pandas.index.max

### DIFF
--- a/pandas/core/base.py
+++ b/pandas/core/base.py
@@ -788,9 +788,7 @@ class IndexOpsMixin(object):
 
     def max(self):
         """
-        Return the maximum value of the object.
-
-        Return the maximum value of the object within the same type.
+        Return the maximum value of the Index.
 
         Returns
         -------
@@ -799,9 +797,9 @@ class IndexOpsMixin(object):
 
         See Also
         --------
-        Series.max : Return the maximum value of the object.
-        DataFrame.max : Return the maximum value of the object.
-        Index.min : Return the minimum value of the object.
+        Index.min : Return the minimum value in an Index.
+        Series.max : Return the maximum value in a Series.
+        DataFrame.max : Return the maximum values in a DataFrame.
 
         Examples
         --------
@@ -812,6 +810,12 @@ class IndexOpsMixin(object):
         >>> idx = pd.Index(['c', 'b', 'a'])
         >>> idx.max()
         'c'
+
+        For a MultiIndex, the maximum is determined lexicographically.
+
+        >>> idx = pd.MultiIndex.from_product([('a', 'b'), (2, 1)])
+        >>> idx.max()
+        ('b', 2)
         """
         return nanops.nanmax(self.values)
 

--- a/pandas/core/base.py
+++ b/pandas/core/base.py
@@ -787,7 +787,31 @@ class IndexOpsMixin(object):
         return not self.size
 
     def max(self):
-        """ The maximum value of the object """
+        """
+        Return the maximum value of the object.
+
+        Return the maximum value of the object within the same type.
+        Remember you also can access to a Dataframe's index as Dataframe.index.
+
+        Returns
+        -------
+        object
+            Maximum value.
+
+        See Also
+        --------
+        Index.min : Return the minimum value of the object.
+
+        Examples
+        --------
+        >>> idx = pd.Index([3, 2, 1])
+        >>> idx.max()
+        3
+
+        >>> idx = pd.Index(['c', 'b', 'a'])
+        >>> idx.max()
+        'c'
+        """
         return nanops.nanmax(self.values)
 
     def argmax(self, axis=None):

--- a/pandas/core/base.py
+++ b/pandas/core/base.py
@@ -791,7 +791,7 @@ class IndexOpsMixin(object):
         Return the maximum value of the object.
 
         Return the maximum value of the object within the same type.
-        Remember you also can access to a Dataframe's index as Dataframe.index.
+        The Index of a DataFrame can be accessed as pandas.DataFrame.index.
 
         Returns
         -------

--- a/pandas/core/base.py
+++ b/pandas/core/base.py
@@ -791,7 +791,7 @@ class IndexOpsMixin(object):
         Return the maximum value of the object.
 
         Return the maximum value of the object within the same type.
-        Remember you also can access to a Dataframe's index as Dataframe.index.
+        The DataFrame Index can be accessed using pandas.DataFrame.index.
 
         Returns
         -------

--- a/pandas/core/base.py
+++ b/pandas/core/base.py
@@ -791,15 +791,16 @@ class IndexOpsMixin(object):
         Return the maximum value of the object.
 
         Return the maximum value of the object within the same type.
-        The DataFrame Index can be accessed using pandas.DataFrame.index.
 
         Returns
         -------
-        object
+        scalar
             Maximum value.
 
         See Also
         --------
+        Series.max : Return the maximum value of the object.
+        DataFrame.max : Return the maximum value of the object.
         Index.min : Return the minimum value of the object.
 
         Examples


### PR DESCRIPTION
Checklist for the pandas documentation sprint (ignore this if you are doing
an unrelated PR):

- [X] PR title is "DOC: update the <your-function-or-method> docstring"
- [X] The validation script passes: `scripts/validate_docstrings.py <your-function-or-method>`
- [X] The PEP8 style check passes: `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [X] The html version looks good: `python doc/make.py --single <your-function-or-method>`
- [X] It has been proofread on language by another sprint participant

Please include the output of the validation script below between the "```" ticks:

```
################################################################################
######################### Docstring (pandas.Index.max) #########################
################################################################################

Return the maximum value of the object.

Return the maximum value of the object within the same type.

Returns
-------
scalar
    Maximum value.

See Also
--------
Series.max : Return the maximum value of the object.
DataFrame.max : Return the maximum value of the object.
Index.min : Return the minimum value of the object.

Examples
--------
>>> idx = pd.Index([3, 2, 1])
>>> idx.max()
3

>>> idx = pd.Index(['c', 'b', 'a'])
>>> idx.max()
'c'

################################################################################
################################## Validation ##################################
################################################################################

Docstring for "pandas.Index.max" correct. :)
```

If the validation script still gives errors, but you think there is a good reason
to deviate in this case (and there are certainly such cases), please state this
explicitly.