### PR TITLE
DOC: update pandas.DatetimeIndex.to_period docstring(Nairobi)

### DIFF
--- a/pandas/core/indexes/datetimes.py
+++ b/pandas/core/indexes/datetimes.py
@@ -1059,7 +1059,7 @@ class DatetimeIndex(DatelikeOps, TimelikeOps, DatetimeIndexOpsMixin,
         """
         Cast to PeriodIndex at a particular frequency.
 
-        Converts DatetimeIndex to PeriodIndex.
+        Converts DatetimeIndex to PeriodIndex
 
         Parameters
         ----------
@@ -1068,7 +1068,7 @@ class DatetimeIndex(DatelikeOps, TimelikeOps, DatetimeIndexOpsMixin,
 
         Returns
         -------
-        period : DatetimeIndex
+        period: DatetineIndex
 
         Examples
         --------
@@ -1078,11 +1078,11 @@ class DatetimeIndex(DatelikeOps, TimelikeOps, DatetimeIndexOpsMixin,
         ...                                         "2000-08-31 00:00:00"]))
         >>> df.index = df.index.to_period("M")
         >>> df
-        	    y
-        2000-03	1
-        2000-05	2
-        2000-08	3
-        
+                    y
+        2000-03 1
+        2000-05 2
+        2000-08 3
+
         See also
         --------
         pandas.PeriodIndex: Immutable ndarray holding ordinal values
@@ -1175,17 +1175,17 @@ class DatetimeIndex(DatelikeOps, TimelikeOps, DatetimeIndexOpsMixin,
 
     def to_perioddelta(self, freq):
         """
-        Calculates TimedeltaIndex of difference between index
-        values and index converted to PeriodIndex at specified
-        freq.  Used for vectorized offsets
+        Calculate TimedeltaIndex of difference between index
+        values and index converted to periodIndex at specified
+        freq. Used for vectorized offsets
 
         Parameters
         ----------
-        freq : Period frequency
+        freq: Period frequency
 
         Returns
         -------
-        y : TimedeltaIndex
+        y: TimedeltaIndex
         """
         return to_timedelta(self.asi8 - self.to_period(freq)
                             .to_timestamp().asi8)

--- a/pandas/core/indexes/datetimes.py
+++ b/pandas/core/indexes/datetimes.py
@@ -1068,19 +1068,21 @@ class DatetimeIndex(DatelikeOps, TimelikeOps, DatetimeIndexOpsMixin,
 
         Returns
         -------
-        period: period[D]
+        period : DatetimeIndex
 
         Examples
         --------
-        >>> df = pd.DataFrame({"y": [1,2,3]},
-        ...                     index=pd.to_datetime(["2000-03-31 00:00:00",
-        ...                                           "2000-05-31 00:00:00",
-        ...                                           "2000-08-31 00:00:00"]))
-        >>> df.index = df.index.to_period("M")
+        >>> index=pd.to_datetime(["2000-03-31 00:00:00",
+        ...                       "2000-08-31 00:00:00"])
+        >>> index.to_period("M")
+        PeriodIndex(['2000-03', '2000-08'],
+        ...         dtype='period[M]',
+        ...         freq='M')
 
         See also
         --------
-        Index: base pandas index type
+        pandas.PeriodIndex: Immutable ndarray holding ordinal values
+        pandas.DatetimeIndex.to_pydatetime: Return DatetimeIndex as object
         """
         from pandas.core.indexes.period import PeriodIndex
 

--- a/pandas/core/indexes/datetimes.py
+++ b/pandas/core/indexes/datetimes.py
@@ -1059,16 +1059,23 @@ class DatetimeIndex(DatelikeOps, TimelikeOps, DatetimeIndexOpsMixin,
         """
         Cast to PeriodIndex at a particular frequency.
 
-        Converts DatetimeIndex to PeriodIndex
+        Converts DatetimeIndex to PeriodIndex.
 
         Parameters
         ----------
-        freq : string or pandas offset object, optional
-            One of pandas date offset string or corresponding objects.
+        freq : string or Offset, optional
+            One of pandas' :ref:`offset strings <timeseries.offset_aliases>`
+            or an Offset object. Will be inferred by default.
 
         Returns
         -------
-        period: DatetineIndex
+        PeriodIndex
+
+        Raises
+        ------
+        ValueError
+            When converting a DatetimeIndex with non-regular values, so that a
+            frequency cannot be inferred.
 
         Examples
         --------
@@ -1076,12 +1083,16 @@ class DatetimeIndex(DatelikeOps, TimelikeOps, DatetimeIndexOpsMixin,
         ...                   index=pd.to_datetime(["2000-03-31 00:00:00",
         ...                                         "2000-05-31 00:00:00",
         ...                                         "2000-08-31 00:00:00"]))
-        >>> df.index = df.index.to_period("M")
-        >>> df
-                    y
-        2000-03 1
-        2000-05 2
-        2000-08 3
+        >>> df.index.to_period("M")
+        PeriodIndex(['2000-03', '2000-05', '2000-08'],
+                    dtype='period[M]', freq='M')
+
+        Infer the daily frequency
+
+        >>> idx = pd.date_range("2017-01-01", periods=2)
+        >>> idx.to_period()
+        PeriodIndex(['2017-01-01', '2017-01-02'],
+                    dtype='period[D]', freq='D')
 
         See also
         --------

--- a/pandas/core/indexes/datetimes.py
+++ b/pandas/core/indexes/datetimes.py
@@ -1057,7 +1057,30 @@ class DatetimeIndex(DatelikeOps, TimelikeOps, DatetimeIndexOpsMixin,
 
     def to_period(self, freq=None):
         """
-        Cast to PeriodIndex at a particular frequency
+        Cast to PeriodIndex at a particular frequency.
+
+        Converts timestamps index to period.
+
+        Parameters
+        ----------
+        freq : string or pandas offset object,optional
+            One of pandas date offset string or corresponding objects.
+
+        Returns
+        -------
+        period: period[D]
+
+        Examples
+        --------
+        >>> df = pd.DataFrame({"y": [1,2,3]},
+        ...                     index=pd.to_datetime(["2000-03-31 00:00:00",
+        ...                                           "2000-05-31 00:00:00",
+        ...                                           "2000-08-31 00:00:00"]))
+        >>> df.index = df.index.to_period("M")
+
+        See also
+        --------
+        Index: base pandas index type
         """
         from pandas.core.indexes.period import PeriodIndex
 

--- a/pandas/core/indexes/datetimes.py
+++ b/pandas/core/indexes/datetimes.py
@@ -1072,13 +1072,17 @@ class DatetimeIndex(DatelikeOps, TimelikeOps, DatetimeIndexOpsMixin,
 
         Examples
         --------
-        >>> index=pd.to_datetime(["2000-03-31 00:00:00",
-        ...                       "2000-08-31 00:00:00"])
-        >>> index.to_period("M")
-        PeriodIndex(['2000-03', '2000-08'],
-        ...         dtype='period[M]',
-        ...         freq='M')
-
+        >>> df = pd.DataFrame({"y": [1,2,3]},
+        ...                   index=pd.to_datetime(["2000-03-31 00:00:00",
+        ...                                         "2000-05-31 00:00:00",
+        ...                                         "2000-08-31 00:00:00"]))
+        >>> df.index = df.index.to_period("M")
+        >>> df
+        	    y
+        2000-03	1
+        2000-05	2
+        2000-08	3
+        
         See also
         --------
         pandas.PeriodIndex: Immutable ndarray holding ordinal values

--- a/pandas/core/indexes/datetimes.py
+++ b/pandas/core/indexes/datetimes.py
@@ -1059,7 +1059,7 @@ class DatetimeIndex(DatelikeOps, TimelikeOps, DatetimeIndexOpsMixin,
         """
         Cast to PeriodIndex at a particular frequency.
 
-        Converts DatetimeIndex  to periodIndex.
+        Converts DatetimeIndex to PeriodIndex.
 
         Parameters
         ----------

--- a/pandas/core/indexes/datetimes.py
+++ b/pandas/core/indexes/datetimes.py
@@ -1059,11 +1059,11 @@ class DatetimeIndex(DatelikeOps, TimelikeOps, DatetimeIndexOpsMixin,
         """
         Cast to PeriodIndex at a particular frequency.
 
-        Converts timestamps index to period.
+        Converts DatetimeIndex  to periodIndex.
 
         Parameters
         ----------
-        freq : string or pandas offset object,optional
+        freq : string or pandas offset object, optional
             One of pandas date offset string or corresponding objects.
 
         Returns


### PR DESCRIPTION
Checklist for the pandas documentation sprint (ignore this if you are doing
an unrelated PR):

- [ x] PR title is "DOC: update the pandas.DatetimeIndex.to_period docstring"
- [ x] The validation script passes: `scripts/validate_docstrings.py pandas.DatetimeIndex.to_period `
- [ x] The PEP8 style check passes: `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ x] The html version looks good: `python doc/make.py --single pandas.DatetimeIndex.to_period `
- [ x] It has been proofread on language by another sprint participant

Please include the output of the validation script below between the "```" ticks:

```

################################################################################
################## Docstring (pandas.DatetimeIndex.to_period) ##################
################################################################################

Cast to PeriodIndex at a particular frequency.

Converts DatetimeIndex to PeriodIndex.

Parameters
----------
freq : string or pandas offset object, optional
    One of pandas date offset string or corresponding objects.

Returns
-------
period : DatetimeIndex

Examples
--------
>>> df = pd.DataFrame({"y": [1,2,3]},
...                   index=pd.to_datetime(["2000-03-31 00:00:00",
...                                         "2000-05-31 00:00:00",
...                                         "2000-08-31 00:00:00"]))
>>> df.index = df.index.to_period("M")
>>> df
            y
2000-03 1
2000-05 2
2000-08 3

See also
--------
pandas.PeriodIndex: Immutable ndarray holding ordinal values
pandas.DatetimeIndex.to_pydatetime: Return DatetimeIndex as object

################################################################################
################################## Validation ##################################
################################################################################

Docstring for "pandas.DatetimeIndex.to_period" correct. :)

```

If the validation script still gives errors, but you think there is a good reason
to deviate in this case (and there are certainly such cases), please state this
explicitly.



