### PR TITLE
DOC: update the pandas.core.generic.NDFrame.to_clipboard docstring

### DIFF
--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -1951,10 +1951,6 @@ class NDFrame(PandasObject, SelectionMixin):
             or :py:meth:`pandas.Series.to_csv` methods depending on the
             Object type.
 
-        Returns
-        -------
-            None
-
         See Also
         --------
         pandas.core.frame.DataFrame.to_csv : Write a DataFrame to a

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -1943,7 +1943,7 @@ class NDFrame(PandasObject, SelectionMixin):
             - False, write a string representation of the object to the
               clipboard.
 
-        sep : str, ``\t``
+        sep : str, default ``'\t'``
             Field delimiter.
         **kwargs
             These parameters will be passed to DataFrame.to_csv.

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -1929,7 +1929,7 @@ class NDFrame(PandasObject, SelectionMixin):
                          protocol=protocol)
 
     def to_clipboard(self, excel=True, sep=None, **kwargs):
-        """
+        r"""
         Copy object to the system clipboard.
 
         Write a text representation of object to the system clipboard.
@@ -1939,23 +1939,25 @@ class NDFrame(PandasObject, SelectionMixin):
         ----------
         excel : bool, default True
             - True, use the provided separator, writing in a csv format for
-            allowing easy pasting into excel.
+              allowing easy pasting into excel.
             - False, write a string representation of the object to the
-            clipboard.
-        sep : str, default tab
+              clipboard.
+
+        sep : str, ``\t``
             Field delimiter.
-        kwargs : optional -> **kwargs
-            These parameters will be passed to meth:`pandas.DataFrame.to_csv`
+        **kwargs
+            These parameters will be passed to DataFrame.to_csv.
 
         See Also
         --------
         DataFrame.to_csv : Write a DataFrame to a comma-separated values
-        (csv) file.
+            (csv) file.
         read_clipboard : Read text from clipboard and pass to read_table.
 
         Notes
         -----
         Requirements for your platform.
+
           - Linux : `xclip`, or `xsel` (with `gtk` or `PyQt4` modules)
           - Windows : none
           - OS X : none
@@ -1965,12 +1967,20 @@ class NDFrame(PandasObject, SelectionMixin):
         Copy the contents of a DataFrame to the clipboard.
 
         >>> df = pd.DataFrame([[1, 2, 3], [4, 5, 6]], columns=['A', 'B', 'C'])
-        >>> df.to_clipboard()
+        >>> df.to_clipboard(sep=',')
+        ... # Wrote the following to the system clipboard:
+        ... # ,A,B,C
+        ... # 0,1,2,3
+        ... # 1,4,5,6
 
         We can omit the the index by passing the keyword `index` and setting
         it to false.
 
-        >>> df.to_clipboard(index=False)
+        >>> df.to_clipboard(sep=',', index=False)
+        ... # Wrote the following to the system clipboard:
+        ... # A,B,C
+        ... # 1,2,3
+        ... # 4,5,6
         """
         from pandas.io import clipboards
         clipboards.to_clipboard(self, excel=excel, sep=sep, **kwargs)

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -1972,7 +1972,8 @@ class NDFrame(PandasObject, SelectionMixin):
         >>> df = pd.DataFrame([[1, 2, 3], [4, 5, 6]], columns=['A', 'B', 'C'])
         >>> df.to_clipboard()
 
-        We can omit the the index by passing the keyword 'index' and setting it to false.
+        We can omit the the index by passing the keyword 'index' and setting
+         it to false.
 
         >>> df.to_clipboard(index=False)
         """

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -1937,26 +1937,21 @@ class NDFrame(PandasObject, SelectionMixin):
 
         Parameters
         ----------
-        excel : bool
-            Default setting for this argument is True.
-            If True, use the provided separator, writing in a csv format for
+        excel : bool, default True
+            - True, use the provided separator, writing in a csv format for
             allowing easy pasting into excel.
-            If False, write a string representation of the object to the
+            - False, write a string representation of the object to the
             clipboard.
         sep : str, default tab
             Field delimiter.
-        kwargs : optional
-            These parameters will be passed to either
-            :py:meth:`pandas.DataFrame.to_csv`
-            or :py:meth:`pandas.Series.to_csv` methods depending on the
-            Object type.
+        kwargs : optional -> **kwargs
+            These parameters will be passed to meth:`pandas.DataFrame.to_csv`
 
         See Also
         --------
-        pandas.core.frame.DataFrame.to_csv : Write a DataFrame to a
-            comma-separated values (csv) file.
-        pandas.core.series.Series.to_csv : Write a Series to a
-            comma-separated values (csv) file.
+        DataFrame.to_csv : Write a DataFrame to a comma-separated values
+        (csv) file.
+        read_clipboard : Read text from clipboard and pass to read_table.
 
         Notes
         -----
@@ -1972,8 +1967,8 @@ class NDFrame(PandasObject, SelectionMixin):
         >>> df = pd.DataFrame([[1, 2, 3], [4, 5, 6]], columns=['A', 'B', 'C'])
         >>> df.to_clipboard()
 
-        We can omit the the index by passing the keyword 'index' and setting
-         it to false.
+        We can omit the the index by passing the keyword `index` and setting
+        it to false.
 
         >>> df.to_clipboard(index=False)
         """

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -1958,9 +1958,9 @@ class NDFrame(PandasObject, SelectionMixin):
         See Also
         --------
         pandas.core.frame.DataFrame.to_csv : Write a DataFrame to a
-        comma-separated values (csv) file.
+            comma-separated values (csv) file.
         pandas.core.series.Series.to_csv : Write a Series to a
-        comma-separated values (csv) file.
+            comma-separated values (csv) file.
 
         Notes
         -----

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -1941,12 +1941,15 @@ class NDFrame(PandasObject, SelectionMixin):
             Default setting for this argument is True.
             If True, use the provided separator, writing in a csv format for
             allowing easy pasting into excel.
-            If False, write a string representation of the object to the clipboard.
+            If False, write a string representation of the object to the
+            clipboard.
         sep : str, default tab
             Field delimiter.
         kwargs : optional
-            These parameters will be passed to either :py:meth:`pandas.DataFrame.to_csv`
-            or :py:meth:`pandas.Series.to_csv` methods depending on the Object type.
+            These parameters will be passed to either
+            :py:meth:`pandas.DataFrame.to_csv`
+            or :py:meth:`pandas.Series.to_csv` methods depending on the
+            Object type.
 
         Returns
         -------
@@ -1954,8 +1957,10 @@ class NDFrame(PandasObject, SelectionMixin):
 
         See Also
         --------
-        pandas.core.frame.DataFrame.to_csv : Write a DataFrame to a comma-separated values (csv) file.
-        pandas.core.series.Series.to_csv : Write a Series to a comma-separated values (csv) file.
+        pandas.core.frame.DataFrame.to_csv : Write a DataFrame to a
+        comma-separated values (csv) file.
+        pandas.core.series.Series.to_csv : Write a Series to a
+        comma-separated values (csv) file.
 
         Notes
         -----

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -1930,25 +1930,50 @@ class NDFrame(PandasObject, SelectionMixin):
 
     def to_clipboard(self, excel=True, sep=None, **kwargs):
         """
-        Attempt to write text representation of object to the system clipboard
+        Copy object to the system clipboard.
+
+        Attempt to write text representation of object to the system clipboard.
         This can be pasted into Excel, for example.
 
         Parameters
         ----------
-        excel : boolean, defaults to True
-                if True, use the provided separator, writing in a csv
-                format for allowing easy pasting into excel.
-                if False, write a string representation of the object
-                to the clipboard
-        sep : optional, defaults to tab
-        other keywords are passed to to_csv
+        excel : bool
+            Default setting for this argument is True.
+            If True, use the provided separator, writing in a csv format for
+            allowing easy pasting into excel.
+            If False, write a string representation of the object to the clipboard.
+        sep : str, default tab
+            Field delimiter.
+        kwargs : optional
+            These parameters will be passed to either :py:meth:`pandas.DataFrame.to_csv`
+            or :py:meth:`pandas.Series.to_csv` methods depending on the Object type.
+
+        Returns
+        -------
+            None
+
+        See Also
+        --------
+        pandas.core.frame.DataFrame.to_csv : Write a DataFrame to a comma-separated values (csv) file.
+        pandas.core.series.Series.to_csv : Write a Series to a comma-separated values (csv) file.
 
         Notes
         -----
-        Requirements for your platform
-          - Linux: xclip, or xsel (with gtk or PyQt4 modules)
-          - Windows: none
-          - OS X: none
+        Requirements for your platform.
+          - Linux : `xclip`, or `xsel` (with `gtk` or `PyQt4` modules)
+          - Windows : none
+          - OS X : none
+
+        Examples
+        --------
+        Copy the contents of a DataFrame to the clipboard.
+
+        >>> df = pd.DataFrame([[1, 2, 3], [4, 5, 6]], columns=['A', 'B', 'C'])
+        >>> df.to_clipboard()
+
+        We can emit the the index by passing the keyword 'index'.
+
+        >>> df.to_clipboard(index=False)
         """
         from pandas.io import clipboards
         clipboards.to_clipboard(self, excel=excel, sep=sep, **kwargs)

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -1932,7 +1932,7 @@ class NDFrame(PandasObject, SelectionMixin):
         """
         Copy object to the system clipboard.
 
-        Attempt to write text representation of object to the system clipboard.
+        Write a text representation of object to the system clipboard.
         This can be pasted into Excel, for example.
 
         Parameters
@@ -1972,7 +1972,7 @@ class NDFrame(PandasObject, SelectionMixin):
         >>> df = pd.DataFrame([[1, 2, 3], [4, 5, 6]], columns=['A', 'B', 'C'])
         >>> df.to_clipboard()
 
-        We can emit the the index by passing the keyword 'index'.
+        We can omit the the index by passing the keyword 'index' and setting it to false.
 
         >>> df.to_clipboard(index=False)
         """


### PR DESCRIPTION
Checklist for the pandas documentation sprint (ignore this if you are doing
an unrelated PR):

- [X] PR title is "DOC: update the <your-function-or-method> docstring"
- [X] The validation script passes: `scripts/validate_docstrings.py pandas.core.generic.NDFrame.to_clipboard`
- [X] The PEP8 style check passes: `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [X] The html version looks good: `python doc/make.py --single pandas.core.generic.NDFrame.to_clipboard`
- [X] It has been proofread on language by another sprint participant

Please include the output of the validation script below between the "```" ticks:

```
################################################################################
############# Docstring (pandas.core.generic.NDFrame.to_clipboard) #############
################################################################################

Copy object to the system clipboard.

Write a text representation of object to the system clipboard.
This can be pasted into Excel, for example.

Parameters
----------
excel : bool
    Default setting for this argument is True.
    If True, use the provided separator, writing in a csv format for
    allowing easy pasting into excel.
    If False, write a string representation of the object to the
    clipboard.
sep : str, default tab
    Field delimiter.
kwargs : optional
    These parameters will be passed to either
    :py:meth:`pandas.DataFrame.to_csv`
    or :py:meth:`pandas.Series.to_csv` methods depending on the
    Object type.

See Also
--------
pandas.core.frame.DataFrame.to_csv : Write a DataFrame to a
    comma-separated values (csv) file.
pandas.core.series.Series.to_csv : Write a Series to a
    comma-separated values (csv) file.

Notes
-----
Requirements for your platform.
  - Linux : `xclip`, or `xsel` (with `gtk` or `PyQt4` modules)
  - Windows : none
  - OS X : none

Examples
--------
Copy the contents of a DataFrame to the clipboard.

>>> df = pd.DataFrame([[1, 2, 3], [4, 5, 6]], columns=['A', 'B', 'C'])
>>> df.to_clipboard()

We can omit the the index by passing the keyword 'index' and setting it to false.

>>> df.to_clipboard(index=False)

################################################################################
################################## Validation ##################################
################################################################################
```

If the validation script still gives errors, but you think there is a good reason
to deviate in this case (and there are certainly such cases), please state this
explicitly.