### PR TITLE
DOC: Improved the docstring of pandas.Series.dt.to_pytimedelta

### DIFF
--- a/pandas/core/indexes/accessors.py
+++ b/pandas/core/indexes/accessors.py
@@ -158,12 +158,12 @@ class TimedeltaProperties(Properties):
 
     def to_pytimedelta(self):
         """
-        Return array of Timedeltas as `datetime.timedelta`.
+        Return an array of native `datetime.timedelta` objects.
 
-        Python's standard `datetime` library uses a different representation to
-        what pandas for differences between times. This method converts a
-        Series of pandas Timedeltas to `datetime.timedelta` format with
-        the same length as the original Series.
+        Python's standard `datetime` library uses a different representation
+        timedelta's. This method converts a Series of pandas Timedeltas
+        to `datetime.timedelta` format with the same length as the original
+        Series.
 
         Returns
         -------

--- a/pandas/core/indexes/accessors.py
+++ b/pandas/core/indexes/accessors.py
@@ -158,13 +158,15 @@ class TimedeltaProperties(Properties):
 
     def to_pytimedelta(self):
         """
+        Return array of Timedeltas as `datetime.timedelta`.
+
         Return an array of the Timedeltas in `datetime.timedelta` format with
         the same length as the original Series.
 
         Returns
         -------
         a : numpy.ndarray
-            1D array containing data with `datetime.timedelta` type
+            1D array containing data with `datetime.timedelta` type.
 
         Examples
         --------

--- a/pandas/core/indexes/accessors.py
+++ b/pandas/core/indexes/accessors.py
@@ -157,6 +157,30 @@ class TimedeltaProperties(Properties):
     """
 
     def to_pytimedelta(self):
+        """
+        Return an array of the Timedeltas in `datetime.timedelta` format with
+        the same length as the original Series.
+
+        Returns
+        -------
+        a : numpy.ndarray
+            1D array containing data with `datetime.timedelta` type
+
+        Examples
+        --------
+        >>> s = pd.Series(pd.to_timedelta(np.arange(5), unit='d'))
+        >>> s
+        0   0 days
+        1   1 days
+        2   2 days
+        3   3 days
+        4   4 days
+        dtype: timedelta64[ns]
+        >>> s.dt.to_pytimedelta()
+        array([datetime.timedelta(0), datetime.timedelta(1),
+               datetime.timedelta(2), datetime.timedelta(3),
+               datetime.timedelta(4)], dtype=object)
+        """
         return self._get_values().to_pytimedelta()
 
     @property

--- a/pandas/core/indexes/accessors.py
+++ b/pandas/core/indexes/accessors.py
@@ -161,8 +161,8 @@ class TimedeltaProperties(Properties):
         Return array of Timedeltas as `datetime.timedelta`.
 
         Python's standard `datetime` library uses a different representation to
-        what pandas for differences between times. This method converts a Series
-        of pandas Timedeltas to `datetime.timedelta` format with
+        what pandas for differences between times. This method converts a
+        Series of pandas Timedeltas to `datetime.timedelta` format with
         the same length as the original Series.
 
         Returns

--- a/pandas/core/indexes/accessors.py
+++ b/pandas/core/indexes/accessors.py
@@ -160,7 +160,9 @@ class TimedeltaProperties(Properties):
         """
         Return array of Timedeltas as `datetime.timedelta`.
 
-        Return an array of the Timedeltas in `datetime.timedelta` format with
+        Python's standard `datetime` library uses a different representation to
+        what pandas for differences between times. This method converts a Series
+        of pandas Timedeltas to `datetime.timedelta` format with
         the same length as the original Series.
 
         Returns
@@ -178,10 +180,15 @@ class TimedeltaProperties(Properties):
         3   3 days
         4   4 days
         dtype: timedelta64[ns]
+
         >>> s.dt.to_pytimedelta()
         array([datetime.timedelta(0), datetime.timedelta(1),
                datetime.timedelta(2), datetime.timedelta(3),
                datetime.timedelta(4)], dtype=object)
+
+        See Also
+        --------
+        datetime.timedelta
         """
         return self._get_values().to_pytimedelta()
 


### PR DESCRIPTION
Checklist for the pandas documentation sprint (ignore this if you are doing
an unrelated PR):

- [X ] PR title is "DOC: update the <your-function-or-method> docstring"
- [X] The validation script passes: `scripts/validate_docstrings.py <your-function-or-method>`
- [X] The PEP8 style check passes: `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [X] The html version looks good: `python doc/make.py --single <your-function-or-method>`
- [X] It has been proofread on language by another sprint participant

Please include the output of the validation script below between the "```" ticks:

```################################################################################
################# Docstring (pandas.Series.dt.to_pytimedelta)  #################
################################################################################

Return an array of the Timedeltas in `datetime.timedelta` format with
the same length as the original Series.

Returns
-------
a : numpy.ndarray
    1D array containing data with `datetime.timedelta` type

Examples
--------
>>> s = pd.Series(pd.to_timedelta(np.arange(5), unit='d'))
>>> s
0   0 days
1   1 days
2   2 days
3   3 days
4   4 days
dtype: timedelta64[ns]
>>> s.dt.to_pytimedelta()
array([datetime.timedelta(0), datetime.timedelta(1),
       datetime.timedelta(2), datetime.timedelta(3),
       datetime.timedelta(4)], dtype=object)

################################################################################
################################## Validation ##################################
################################################################################

Errors found:
        No summary found (a short summary in a single line should be present at the beginning of the docstring)
        See Also section not found

```

If the validation script still gives errors, but you think there is a good reason
to deviate in this case (and there are certainly such cases), please state this
explicitly.

No extended summary needed.

Checklist for other PRs (remove this part if you are doing a PR for the pandas documentation sprint):

- [ ] closes #xxxx
- [ ] tests added / passed
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
