### PR TITLE
DOC: update the pandas.Series.dt.is_month_start docstring

### DIFF
--- a/pandas/core/indexes/datetimes.py
+++ b/pandas/core/indexes/datetimes.py
@@ -1727,7 +1727,32 @@ class DatetimeIndex(DatelikeOps, TimelikeOps, DatetimeIndexOpsMixin,
     is_month_start = _field_accessor(
         'is_month_start',
         'is_month_start',
-        "Logical indicating if first day of month (defined by frequency)")
+        """
+        Returns a boolean indicating if the date is the first day of the month.
+
+        Returns
+        -------
+        is_month_start : Series of boolean
+
+        See Also
+        --------
+        is_month_end : Returns a boolean indicating if the date is the last day of the month.
+
+        Examples
+        --------
+        >>> import pandas as pd
+        >>> dates = pd.Series(pd.date_range("2018-02-27", periods = 3))
+        >>> dates
+        0   2018-02-27
+        1   2018-02-28
+        2   2018-03-01
+        dtype: datetime64[ns]
+        >>> dates.dt.is_month_start
+        0    False
+        1    False
+        2    True
+        dtype: bool
+        """)
     is_month_end = _field_accessor(
         'is_month_end',
         'is_month_end',

--- a/pandas/core/indexes/datetimes.py
+++ b/pandas/core/indexes/datetimes.py
@@ -1736,8 +1736,8 @@ class DatetimeIndex(DatelikeOps, TimelikeOps, DatetimeIndexOpsMixin,
 
         See Also
         --------
-        is_month_end : Returns a boolean indicating if the date is the last day
-        of the month.
+        is_month_end : Returns a boolean indicating if the date is the last day 
+                       of the month.
 
         Examples
         --------

--- a/pandas/core/indexes/datetimes.py
+++ b/pandas/core/indexes/datetimes.py
@@ -1728,16 +1728,16 @@ class DatetimeIndex(DatelikeOps, TimelikeOps, DatetimeIndexOpsMixin,
         'is_month_start',
         'is_month_start',
         """
-        Return a boolean indicating if the date is the first day of the month.
+        Return a boolean indicating whether the date is the first day of the month.
 
         Returns
         -------
-        is_month_start : Series of boolean
+        is_month_start : Series of boolean.
 
         See Also
         --------
-        is_month_end : Returns a boolean indicating if the date is the last day 
-                       of the month.
+        is_month_end : Return a boolean indicating whether the date is
+            the last day of the month.
 
         Examples
         --------

--- a/pandas/core/indexes/datetimes.py
+++ b/pandas/core/indexes/datetimes.py
@@ -1728,7 +1728,7 @@ class DatetimeIndex(DatelikeOps, TimelikeOps, DatetimeIndexOpsMixin,
         'is_month_start',
         'is_month_start',
         """
-        Returns a boolean indicating if the date is the first day of the month.
+        Return a boolean indicating if the date is the first day of the month.
 
         Returns
         -------

--- a/pandas/core/indexes/datetimes.py
+++ b/pandas/core/indexes/datetimes.py
@@ -1736,12 +1736,12 @@ class DatetimeIndex(DatelikeOps, TimelikeOps, DatetimeIndexOpsMixin,
 
         See Also
         --------
-        is_month_end : Returns a boolean indicating if the date is the last day of the month.
+        is_month_end : Returns a boolean indicating if the date is the last day
+        of the month.
 
         Examples
         --------
-        >>> import pandas as pd
-        >>> dates = pd.Series(pd.date_range("2018-02-27", periods = 3))
+        >>> dates = pd.Series(pd.date_range("2018-02-27", periods=3))
         >>> dates
         0   2018-02-27
         1   2018-02-28


### PR DESCRIPTION
Checklist for the pandas documentation sprint (ignore this if you are doing
an unrelated PR):

- [ X] PR title is "DOC: update the <your-function-or-method> docstring"
- [ X] The validation script passes: `scripts/validate_docstrings.py <your-function-or-method>`
- [ X] The PEP8 style check passes: `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ X] The html version looks good: `python doc/make.py --single <your-function-or-method>`
- [X] It has been proofread on language by another sprint participant

Please include the output of the validation script below between the "```" ticks:

```
################################################################################
################# Docstring (pandas.Series.dt.is_month_start)  #################
################################################################################

Return a boolean indicating if the date is the first day of the month.

Returns
-------
is_month_start : Series of boolean

See Also
--------
is_month_end : Returns a boolean indicating if the date is the last day of the month.

Examples
--------
>>> import pandas as pd
>>> dates = pd.Series(pd.date_range("2018-02-27", periods = 3))
>>> dates
0   2018-02-27
1   2018-02-28
2   2018-03-01
dtype: datetime64[ns]
>>> dates.dt.is_month_start
0    False
1    False
2    True
dtype: bool

################################################################################
################################## Validation ##################################
################################################################################

Errors found:
	No extended summary found
```

If the validation script still gives errors, but you think there is a good reason
to deviate in this case (and there are certainly such cases), please state this
explicitly.

This function does not require an extended summary. Peers find it very clear with a short summary too.