### PR TITLE
DOC: update the to_json() docstring

### DIFF
--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -1694,7 +1694,7 @@ class NDFrame(PandasObject, SelectionMixin):
                 describing the data, and the data component is
                 like ``orient='records'``.
 
-                .. versionchanged:: 0.20.0.
+                .. versionchanged:: 0.20.0
 
         date_format : {None, 'epoch', 'iso'}
             Type of date conversion. 'epoch' = epoch milliseconds,
@@ -1719,24 +1719,20 @@ class NDFrame(PandasObject, SelectionMixin):
             throw ValueError if incorrect 'orient' since others are not list
             like.
 
-            .. versionadded:: 0.19.0.
+            .. versionadded:: 0.19.0
 
         compression : {None, 'gzip', 'bz2', 'xz'}
             A string representing the compression to use in the output file,
             only used when the first argument is a filename
 
-            .. versionadded:: 0.21.0.
+            .. versionadded:: 0.21.0
 
         index : boolean, default True
             Whether to include the index values in the JSON string. Not
             including the index (``index=False``) is only supported when
             orient is 'split' or 'table'.
 
-            .. versionadded:: 0.23.0.
-
-        Returns
-        -------
-        same type as input object with filtered info axis
+            .. versionadded:: 0.23.0
 
         See Also
         --------

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -1664,8 +1664,9 @@ class NDFrame(PandasObject, SelectionMixin):
 
         Parameters
         ----------
-        path_or_buf : the path or buffer to write the result string
-            If this is None, return the converted string.
+        path_or_buf : string or file handle, default None
+            File path or object, if None is provided the result is returned as
+            a string.
         orient : string
             Indication of expected JSON string format.
 
@@ -1682,14 +1683,14 @@ class NDFrame(PandasObject, SelectionMixin):
 
             * The format of the JSON string
 
-              - split : dict like
+              - 'split' : dict like
                 {index -> [index], columns -> [columns], data -> [values]}
-              - records : list like
+              - 'records' : list like
                 [{column -> value}, ... , {column -> value}]
-              - index : dict like {index -> {column -> value}}
-              - columns : dict like {column -> {index -> value}}
-              - values : just the values array
-              - table : dict like {'schema': {schema}, 'data': {data}}
+              - 'index' : dict like {index -> {column -> value}}
+              - 'columns' : dict like {column -> {index -> value}}
+              - 'values' : just the values array
+              - 'table' : dict like {'schema': {schema}, 'data': {data}}
                 describing the data, and the data component is
                 like ``orient='records'``.
 
@@ -1739,7 +1740,7 @@ class NDFrame(PandasObject, SelectionMixin):
 
         See Also
         --------
-        pd.read_json
+        pandas.read_json
 
         Examples
         --------

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -1665,8 +1665,9 @@ class NDFrame(PandasObject, SelectionMixin):
         Parameters
         ----------
         path_or_buf : the path or buffer to write the result string
-            if this is None, return the converted string
+            If this is None, return the converted string.
         orient : string
+            Indication of expected JSON string format.
 
             * Series
 
@@ -1692,16 +1693,18 @@ class NDFrame(PandasObject, SelectionMixin):
                 describing the data, and the data component is
                 like ``orient='records'``.
 
-                .. versionchanged:: 0.20.0
+                .. versionchanged:: 0.20.0.
 
         date_format : {None, 'epoch', 'iso'}
             Type of date conversion. `epoch` = epoch milliseconds,
             `iso` = ISO8601. The default depends on the `orient`. For
             `orient='table'`, the default is `'iso'`. For all other orients,
             the default is `'epoch'`.
-        double_precision : The number of decimal places to use when encoding
-            floating point values, default 10.
-        force_ascii : force encoded string to be ASCII, default True.
+        double_precision : int, default 10
+            The number of decimal places to use when encoding
+            floating point values.
+        force_ascii : boolean, default True
+            Force encoded string to be ASCII.
         date_unit : string, default 'ms' (milliseconds)
             The time unit to encode to, governs timestamp and ISO8601
             precision.  One of 's', 'ms', 'us', 'ns' for second, millisecond,
@@ -1715,20 +1718,20 @@ class NDFrame(PandasObject, SelectionMixin):
             throw ValueError if incorrect 'orient' since others are not list
             like.
 
-            .. versionadded:: 0.19.0
+            .. versionadded:: 0.19.0.
 
         compression : {None, 'gzip', 'bz2', 'xz'}
             A string representing the compression to use in the output file,
             only used when the first argument is a filename
 
-            .. versionadded:: 0.21.0
+            .. versionadded:: 0.21.0.
 
         index : boolean, default True
             Whether to include the index values in the JSON string. Not
             including the index (``index=False``) is only supported when
             orient is 'split' or 'table'.
 
-            .. versionadded:: 0.23.0
+            .. versionadded:: 0.23.0.
 
         Returns
         -------
@@ -1749,16 +1752,26 @@ class NDFrame(PandasObject, SelectionMixin):
           "index":["row 1","row 2"],
           "data":[["a","b"],["c","d"]]}'
 
-        Encoding/decoding a Dataframe using ``'index'`` formatted JSON:
-
-        >>> df.to_json(orient='index')
-        '{"row 1":{"col 1":"a","col 2":"b"},"row 2":{"col 1":"c","col 2":"d"}}'
-
         Encoding/decoding a Dataframe using ``'records'`` formatted JSON.
         Note that index labels are not preserved with this encoding.
 
         >>> df.to_json(orient='records')
         '[{"col 1":"a","col 2":"b"},{"col 1":"c","col 2":"d"}]'
+
+        Encoding/decoding a Dataframe using ``'index'`` formatted JSON:
+
+        >>> df.to_json(orient='index')
+        '{"row 1":{"col 1":"a","col 2":"b"},"row 2":{"col 1":"c","col 2":"d"}}'
+
+        Encoding/decoding a Dataframe using ``'columns'`` formatted JSON:
+
+        >>> df.to_json(orient='columns')
+        '{"col 1":{"row 1":"a","row 2":"c"},"col 2":{"row 1":"b","row 2":"d"}}'
+
+        Encoding/decoding a Dataframe using ``'values'`` formatted JSON:
+
+        >>> df.to_json(orient='values')
+        '[["a","b"],["c","d"]]'
 
         Encoding with Table Schema
 

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -1664,8 +1664,8 @@ class NDFrame(PandasObject, SelectionMixin):
 
         Parameters
         ----------
-        path_or_buf : string or file handle, default None
-            File path or object, if None is provided the result is returned as
+        path_or_buf : string or file handle, optional
+            File path or object. If not specified, the result is returned as
             a string.
         orient : string
             Indication of expected JSON string format.
@@ -1683,8 +1683,8 @@ class NDFrame(PandasObject, SelectionMixin):
 
             * The format of the JSON string
 
-              - 'split' : dict like
-                {index -> [index], columns -> [columns], data -> [values]}
+              - 'split' : dict like {'index' -> [index],
+                'columns' -> [columns], 'data' -> [values]}
               - 'records' : list like
                 [{column -> value}, ... , {column -> value}]
               - 'index' : dict like {index -> {column -> value}}
@@ -1697,10 +1697,10 @@ class NDFrame(PandasObject, SelectionMixin):
                 .. versionchanged:: 0.20.0.
 
         date_format : {None, 'epoch', 'iso'}
-            Type of date conversion. `epoch` = epoch milliseconds,
-            `iso` = ISO8601. The default depends on the `orient`. For
-            `orient='table'`, the default is `'iso'`. For all other orients,
-            the default is `'epoch'`.
+            Type of date conversion. 'epoch' = epoch milliseconds,
+            'iso' = ISO8601. The default depends on the `orient`. For
+            ``orient='table'``, the default is 'iso'. For all other orients,
+            the default is 'epoch'.
         double_precision : int, default 10
             The number of decimal places to use when encoding
             floating point values.


### PR DESCRIPTION
Fixes validation errors and adds an example for each orientation.

- [ x] PR title is "DOC: update the <your-function-or-method> docstring"
- [ x] The validation script passes: `scripts/validate_docstrings.py <your-function-or-method>`
- [ x] The PEP8 style check passes: `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x ] The html version looks good: `python doc/make.py --single <your-function-or-method>`
- [x ] It has been proofread on language by another sprint participant

```
Errors found:
	Missing description for See Also "pandas.read_json" reference
	Examples do not pass tests
```

I'm not able to make this pass.