### PR TITLE
DOC: update pandas.DataFrame.boxplot docstring. Fixes #8847 

### DIFF
--- a/pandas/plotting/_core.py
+++ b/pandas/plotting/_core.py
@@ -2043,7 +2043,7 @@ _shared_docs['boxplot'] = """
 
           If ``return_type`` is `None`, a NumPy array
           of axes with the same shape as ``layout`` is returned.
-    **kwds : Keyword Arguments, optional
+    **kwds
         All other plotting keyword arguments to be passed to
         :func:`matplotlib.pyplot.boxplot`.
 
@@ -2093,11 +2093,13 @@ _shared_docs['boxplot'] = """
     .. plot::
         :context: close-figs
 
-        >>> df = pd.DataFrame(np.random.randn(10,2), columns=['Col1', 'Col2'] )
-        >>> df['X'] = pd.Series(['A','A','A','A','A','B','B','B','B','B'])
+        >>> df = pd.DataFrame(np.random.randn(10, 2),
+        ...                   columns=['Col1', 'Col2'])
+        >>> df['X'] = pd.Series(['A', 'A', 'A', 'A', 'A',
+        ...                      'B', 'B', 'B', 'B', 'B'])
         >>> boxplot = df.boxplot(by='X')
 
-    A list of strings (i.e. ``['X','Y']``) can be passed to boxplot
+    A list of strings (i.e. ``['X', 'Y']``) can be passed to boxplot
     in order to group the data by combination of the variables in the x-axis:
 
     .. plot::
@@ -2105,18 +2107,19 @@ _shared_docs['boxplot'] = """
 
         >>> df = pd.DataFrame(np.random.randn(10,3),
         ...                   columns=['Col1', 'Col2', 'Col3'])
-        >>> df['X'] = pd.Series(['A','A','A','A','A','B','B','B','B','B'])
-        >>> df['Y'] = pd.Series(['A','B','A','B','A','B','A','B','A','B'])
-        >>> boxplot = df.boxplot(column=['Col1','Col2'], by=['X','Y'])
+        >>> df['X'] = pd.Series(['A', 'A', 'A', 'A', 'A',
+        ...                      'B', 'B', 'B', 'B', 'B'])
+        >>> df['Y'] = pd.Series(['A', 'B', 'A', 'B', 'A',
+        ...                      'B', 'A', 'B', 'A', 'B'])
+        >>> boxplot = df.boxplot(column=['Col1', 'Col2'], by=['X', 'Y'])
 
     The layout of boxplot can be adjusted giving a tuple to ``layout``:
 
     .. plot::
         :context: close-figs
 
-        >>> df = pd.DataFrame(np.random.randn(10,2), columns=['Col1', 'Col2'])
-        >>> df['X'] = pd.Series(['A','A','A','A','A','B','B','B','B','B'])
-        >>> boxplot = df.boxplot(by='X', layout=(2,1))
+        >>> boxplot = df.boxplot(column=['Col1', 'Col2'], by='X',
+        ...                      layout=(2, 1))
 
     Additional formatting can be done to the boxplot, like suppressing the grid
     (``grid=False``), rotating the labels in the x-axis (i.e. ``rot=45``)
@@ -2138,7 +2141,7 @@ _shared_docs['boxplot'] = """
     When grouping with ``by``, a Series mapping columns to ``return_type``
     is returned:
 
-        >>> boxplot = df.boxplot(column=['Col1','Col2'], by='X',
+        >>> boxplot = df.boxplot(column=['Col1', 'Col2'], by='X',
         ...                      return_type='axes')
         >>> type(boxplot)
         <class 'pandas.core.series.Series'>
@@ -2146,7 +2149,7 @@ _shared_docs['boxplot'] = """
     If ``return_type`` is `None`, a NumPy array of axes with the same shape
     as ``layout`` is returned:
 
-        >>> boxplot =  df.boxplot(column=['Col1','Col2'], by='X',
+        >>> boxplot =  df.boxplot(column=['Col1', 'Col2'], by='X',
         ...                       return_type=None)
         >>> type(boxplot)
         <class 'numpy.ndarray'>

--- a/pandas/plotting/_core.py
+++ b/pandas/plotting/_core.py
@@ -2013,24 +2013,22 @@ _shared_docs['boxplot'] = """
     ----------
     column : str or list of str, optional
         Column name or list of names, or vector.
-        Can be any valid input to groupby.
-    by : str or array-like
-        Column in the DataFrame to groupby.
-    ax : object of class matplotlib.axes.Axes, default `None`
+        Can be any valid input to :meth:`pandas.DataFrame.groupby`.
+    by : str or array-like, optional
+        Column in the DataFrame to :meth:`pandas.DataFrame.groupby`.
+        One box-plot will be done per value of columns in `by`.
+    ax : object of class matplotlib.axes.Axes, optional
         The matplotlib axes to be used by boxplot.
     fontsize : float or str
-        Tick label font size in points or as a string (e.g., ‘large’)
-        (see `matplotlib.axes.Axes.tick_params
-        <https://matplotlib.org/api/_as_gen/
-        matplotlib.axes.Axes.tick_params.html>`_).
+        Tick label font size in points or as a string (e.g., ‘large’).
     rot : int or float, default 0
         The rotation angle of labels (in degrees)
         with respect to the screen coordinate sytem.
-    grid : boolean, default `True`
+    grid : boolean, default True
         Setting this to True will show the grid.
     figsize : A tuple (width, height) in inches
         The size of the figure to create in matplotlib.
-    layout : tuple (rows, columns) (optional)
+    layout : tuple (rows, columns), optional
         For example, (3, 5) will display the subplots
         using 3 columns and 5 rows, starting from the top-left.
     return_type : {None, 'axes', 'dict', 'both'}, default 'axes'
@@ -2041,22 +2039,13 @@ _shared_docs['boxplot'] = """
           Lines of the boxplot.
         * 'both' returns a namedtuple with the axes and dict.
         * when grouping with ``by``, a Series mapping columns to
-          ``return_type`` is returned (i.e.
-          ``df.boxplot(column=['Col1','Col2'], by='var',return_type='axes')``
-          may return ``Series([AxesSubplot(..),AxesSubplot(..)],
-          index=['Col1','Col2'])``).
+          ``return_type`` is returned.
 
           If ``return_type`` is `None`, a NumPy array
-          of axes with the same shape as ``layout`` is returned
-          (i.e. ``df.boxplot(column=['Col1','Col2'],
-          by='var',return_type=None)`` may return a
-          ``array([<matplotlib.axes._subplots.AxesSubplot object at ..>,
-          <matplotlib.axes._subplots.AxesSubplot object at ..>],
-          dtype=object)``).
-    **kwds : Keyword Arguments (optional)
+          of axes with the same shape as ``layout`` is returned.
+    **kwds : Keyword Arguments, optional
         All other plotting keyword arguments to be passed to
-        `matplotlib.pyplot.boxplot <https://matplotlib.org/api/_as_gen/
-        matplotlib.pyplot.boxplot.html#matplotlib.pyplot.boxplot>`_.
+        :func:`matplotlib.pyplot.boxplot`.
 
     Returns
     -------
@@ -2074,8 +2063,8 @@ _shared_docs['boxplot'] = """
 
     See Also
     --------
-    matplotlib.pyplot.boxplot: Make a box and whisker plot.
-    matplotlib.pyplot.hist: Make a hsitogram.
+    matplotlib.pyplot.boxplot : Make a box and whisker plot.
+    matplotlib.pyplot.hist : Make a histogram.
 
     Notes
     -----
@@ -2093,27 +2082,27 @@ _shared_docs['boxplot'] = """
         :context: close-figs
 
         >>> np.random.seed(1234)
-        >>> df = pd.DataFrame(np.random.rand(10,4),
+        >>> df = pd.DataFrame(np.random.randn(10,4),
         ...                   columns=['Col1', 'Col2', 'Col3', 'Col4'])
         >>> boxplot = df.boxplot(column=['Col1', 'Col2', 'Col3'])
 
-    Boxplots of variables distributions grouped by a third variable values
-    can be created using the option ``by``. For instance:
+    Boxplots of variables distributions grouped by the values of a third
+    variable can be created using the option ``by``. For instance:
 
     .. plot::
         :context: close-figs
 
-        >>> df = pd.DataFrame(np.random.rand(10,2), columns=['Col1', 'Col2'] )
+        >>> df = pd.DataFrame(np.random.randn(10,2), columns=['Col1', 'Col2'] )
         >>> df['X'] = pd.Series(['A','A','A','A','A','B','B','B','B','B'])
         >>> boxplot = df.boxplot(by='X')
 
-    A list of strings (i.e. ``['X','Y']``) containing can be passed to boxplot
+    A list of strings (i.e. ``['X','Y']``) can be passed to boxplot
     in order to group the data by combination of the variables in the x-axis:
 
     .. plot::
         :context: close-figs
 
-        >>> df = pd.DataFrame(np.random.rand(10,3),
+        >>> df = pd.DataFrame(np.random.randn(10,3),
         ...                   columns=['Col1', 'Col2', 'Col3'])
         >>> df['X'] = pd.Series(['A','A','A','A','A','B','B','B','B','B'])
         >>> df['Y'] = pd.Series(['A','B','A','B','A','B','A','B','A','B'])
@@ -2124,7 +2113,7 @@ _shared_docs['boxplot'] = """
     .. plot::
         :context: close-figs
 
-        >>> df = pd.DataFrame(np.random.rand(10,2), columns=['Col1', 'Col2'])
+        >>> df = pd.DataFrame(np.random.randn(10,2), columns=['Col1', 'Col2'])
         >>> df['X'] = pd.Series(['A','A','A','A','A','B','B','B','B','B'])
         >>> boxplot = df.boxplot(by='X', layout=(2,1))
 
@@ -2136,6 +2125,73 @@ _shared_docs['boxplot'] = """
         :context: close-figs
 
         >>> boxplot = df.boxplot(grid=False, rot=45, fontsize=15)
+
+
+    The parameter ``return_type`` can be used to select the type of element
+    returned by `boxplot`.  When ``return_type='axes'`` is selected,
+    the matplotlib axes on which the boxplot is drawn are returned:
+
+        >>> df.boxplot(column=['Col1','Col2'], return_type='axes')
+        <matplotlib.axes._subplots.AxesSubplot object at ...>
+
+    If selecting ``return_type='dict'`` a dictionary containing the
+    lines is returned:
+
+        >>> df.boxplot(column=['Col1','Col2'], return_type='dict')
+            {'boxes': [<matplotlib.lines.Line2D at ...>,
+              <matplotlib.lines.Line2D at ...>],
+             'caps': [<matplotlib.lines.Line2D at ...>,
+              <matplotlib.lines.Line2D at ...>,
+              <matplotlib.lines.Line2D at ...>,
+              <matplotlib.lines.Line2D at ...>],
+             'fliers': [<matplotlib.lines.Line2D at ...>,
+              <matplotlib.lines.Line2D at ...>],
+             'means': [],
+             'medians': [<matplotlib.lines.Line2D at ...>,
+              <matplotlib.lines.Line2D at ...>],
+             'whiskers': [<matplotlib.lines.Line2D at ...>,
+              <matplotlib.lines.Line2D at ...>,
+              <matplotlib.lines.Line2D at ...>,
+              <matplotlib.lines.Line2D at ...>]}
+
+    If selecting ``return_type='both'``, a namedtuple with matplotlib axes and
+    Line objets is returned:
+
+        >>> df.boxplot(column=['Col1','Col2'], return_type='both')
+            Boxplot(ax=<matplotlib.axes._subplots.AxesSubplot object
+            at 0x115821128>, lines={'whiskers':
+            [<matplotlib.lines.Line2D object at ...>,
+            <matplotlib.lines.Line2D object at ...>,
+            <matplotlib.lines.Line2D object at ...>,
+            <matplotlib.lines.Line2D object at ...>],
+            'caps': [<matplotlib.lines.Line2D object at ...>,
+            <matplotlib.lines.Line2D object at ...>,
+            <matplotlib.lines.Line2D object at ...>,
+            <matplotlib.lines.Line2D object at ...>],
+            'boxes': [<matplotlib.lines.Line2D object at ...>,
+            <matplotlib.lines.Line2D object at ...>],
+            'medians': [<matplotlib.lines.Line2D object at ...>,
+            <matplotlib.lines.Line2D object at ...>],
+            'fliers': [<matplotlib.lines.Line2D object at ...>,
+            <matplotlib.lines.Line2D object at ...>], 'means': []})
+
+    When grouping with ``by``, a Series mapping columns to ``return_type``
+    is returned:
+
+
+        >>> df.boxplot(column=['Col1','Col2'], by='X', return_type='axes')
+            Col1         AxesSubplot(0.1,0.15;0.363636x0.75)
+            Col2    AxesSubplot(0.536364,0.15;0.363636x0.75)
+            dtype: object
+
+    If ``return_type`` is `None`, a NumPy array of axes with the same shape
+    as ``layout`` is returned:
+
+        >>> df.boxplot(column=['Col1','Col2'], by='X', return_type=None)
+            array([<matplotlib.axes._subplots.AxesSubplot object at ...>,
+                   <matplotlib.axes._subplots.AxesSubplot object at ...>],
+                   dtype=object)
+
     """
 
 @Appender(_shared_docs['boxplot'] % _shared_doc_kwargs)

--- a/pandas/plotting/_core.py
+++ b/pandas/plotting/_core.py
@@ -1995,52 +1995,134 @@ def plot_series(data, kind='line', ax=None,                    # Series unique
 
 
 _shared_docs['boxplot'] = """
-    Make a box plot from DataFrame column optionally grouped by some columns or
-    other inputs
+    Make a box-and-whisker plot from DataFrame column optionally grouped
+    by some columns or other inputs. The box extends from the Q1 to Q3
+    quartile values of the data, with a line at the median (Q2).
+    The whiskers extend from the edges of box to show the range of the data.
+    Flier points (outliers) are those past the end of the whiskers.
+    The position of the whiskers is set by default to 1.5 IQR (`whis=1.5``)
+    from the edge of the box.
+
+    For further details see
+    Wikipedia's entry for `boxplot <https://en.wikipedia.org/wiki/Box_plot/>`_.
 
     Parameters
     ----------
-    data : the pandas object holding the data
     column : column name or list of names, or vector
-        Can be any valid input to groupby
+        Can be any valid input to groupby.
     by : string or sequence
-        Column in the DataFrame to group by
-    ax : Matplotlib axes object, optional
+        Column in the DataFrame to groupby.
+    ax :  Matplotlib axes object, (default `None`)
+        The matplotlib axes to be used by boxplot.
     fontsize : int or string
+        The font-size used by matplotlib.
     rot : label rotation angle
+        The rotation angle of labels.
+    grid : boolean( default `True`)
+        Setting this to True will show the grid.
     figsize : A tuple (width, height) in inches
-    grid : Setting this to True will show the grid
+        The size of the figure to create in inches by default.
     layout : tuple (optional)
-        (rows, columns) for the layout of the plot
+        Tuple (rows, columns) used for the layout of the plot.
     return_type : {None, 'axes', 'dict', 'both'}, default None
         The kind of object to return. The default is ``axes``
         'axes' returns the matplotlib axes the boxplot is drawn on;
         'dict' returns a dictionary whose values are the matplotlib
         Lines of the boxplot;
         'both' returns a namedtuple with the axes and dict.
-
         When grouping with ``by``, a Series mapping columns to ``return_type``
         is returned, unless ``return_type`` is None, in which case a NumPy
         array of axes is returned with the same shape as ``layout``.
         See the prose documentation for more.
-
-    `**kwds` : Keyword Arguments
+    kwds : Keyword Arguments (optional)
         All other plotting keyword arguments to be passed to
-        matplotlib's boxplot function
+        matplotlib's function.
 
     Returns
     -------
     lines : dict
     ax : matplotlib Axes
-    (ax, lines): namedtuple
+        (ax, lines): namedtuple
+
+    See Also
+    --------
+    matplotlib.pyplot.boxplot: Make a box and whisker plot.
 
     Notes
     -----
     Use ``return_type='dict'`` when you want to tweak the appearance
     of the lines after plotting. In this case a dict containing the Lines
     making up the boxes, caps, fliers, medians, and whiskers is returned.
-    """
 
+    Examples
+    --------
+    .. plot::
+        :context: close-figs
+
+        >>> np.random.seed(1234)
+
+        >>> df = pd.DataFrame({
+        ...     u'stratifying_var': np.random.uniform(0, 100, 20),
+        ...     u'price': np.random.normal(100, 5, 20),
+        ...     u'demand': np.random.normal(100, 10, 20)})
+
+        >>> df[u'quartiles'] = pd.qcut(
+        ...     df[u'stratifying_var'], 4,
+        ...     labels=[u'0-25%%', u'25-50%%', u'50-75%%', u'75-100%%'])
+
+        >>> df
+            stratifying_var       price      demand quartiles
+        0         19.151945  106.605791  108.416747     0-25%%
+        1         62.210877   92.265472  123.909605    50-75%%
+        2         43.772774   98.986768  100.761996    25-50%%
+        3         78.535858   96.720153   94.335541   75-100%%
+        4         77.997581  100.967107  100.361419    50-75%%
+        5         27.259261  102.767195   79.250224     0-25%%
+        6         27.646426  106.590758  102.477922     0-25%%
+        7         80.187218   97.653474   91.028432   75-100%%
+        8         95.813935  103.377770   98.632052   75-100%%
+        9         87.593263   90.914864  100.182892   75-100%%
+        10        35.781727   99.084457  107.554140     0-25%%
+        11        50.099513  105.294846  102.152686    25-50%%
+        12        68.346294   98.010799  108.410088    50-75%%
+        13        71.270203  101.687188   85.541899    50-75%%
+        14        37.025075  105.237893   85.980267    25-50%%
+        15        56.119619  105.229691   98.990818    25-50%%
+        16        50.308317  104.318586   94.517576    25-50%%
+        17         1.376845   99.389542   98.553805     0-25%%
+        18        77.282662  100.623565  103.540203    50-75%%
+        19        88.264119   98.386026   99.644870   75-100%%
+
+    To plot the boxplot of the ``demand`` just put:
+
+    .. plot::
+        :context: close-figs
+
+        >>> boxplot = df.boxplot(column=u'demand', by=u'quartiles')
+
+    Use ``grid=False`` to hide the grid:
+
+    .. plot::
+        :context: close-figs
+
+        >>> boxplot = df.boxplot(column=u'demand', by=u'quartiles', grid=False)
+
+    Optionally, the layout can be changed by setting ``layout=(rows, cols)``:
+
+    .. plot::
+        :context: close-figs
+
+        >>> boxplot = df.boxplot(column=[u'price',u'demand'],
+        ...                      by=u'quartiles', layout=(1,2),
+        ...                      figsize=(8,5))
+
+    .. plot::
+        :context: close-figs
+
+        >>> boxplot = df.boxplot(column=[u'price',u'demand'],
+        ...                      by=u'quartiles', layout=(2,1),
+        ...                      figsize=(5,8))
+    """
 
 @Appender(_shared_docs['boxplot'] % _shared_doc_kwargs)
 def boxplot(data, column=None, by=None, ax=None, fontsize=None,

--- a/pandas/plotting/_core.py
+++ b/pandas/plotting/_core.py
@@ -2020,7 +2020,7 @@ _shared_docs['boxplot'] = """
     ax : object of class matplotlib.axes.Axes, optional
         The matplotlib axes to be used by boxplot.
     fontsize : float or str
-        Tick label font size in points or as a string (e.g., ‘large’).
+        Tick label font size in points or as a string (e.g., `large`).
     rot : int or float, default 0
         The rotation angle of labels (in degrees)
         with respect to the screen coordinate sytem.
@@ -2126,7 +2126,6 @@ _shared_docs['boxplot'] = """
 
         >>> boxplot = df.boxplot(grid=False, rot=45, fontsize=15)
 
-
     The parameter ``return_type`` can be used to select the type of element
     returned by `boxplot`.  When ``return_type='axes'`` is selected,
     the matplotlib axes on which the boxplot is drawn are returned:
@@ -2134,50 +2133,8 @@ _shared_docs['boxplot'] = """
         >>> df.boxplot(column=['Col1','Col2'], return_type='axes')
         <matplotlib.axes._subplots.AxesSubplot object at ...>
 
-    If selecting ``return_type='dict'`` a dictionary containing the
-    lines is returned:
-
-        >>> df.boxplot(column=['Col1','Col2'], return_type='dict')
-            {'boxes': [<matplotlib.lines.Line2D at ...>,
-              <matplotlib.lines.Line2D at ...>],
-             'caps': [<matplotlib.lines.Line2D at ...>,
-              <matplotlib.lines.Line2D at ...>,
-              <matplotlib.lines.Line2D at ...>,
-              <matplotlib.lines.Line2D at ...>],
-             'fliers': [<matplotlib.lines.Line2D at ...>,
-              <matplotlib.lines.Line2D at ...>],
-             'means': [],
-             'medians': [<matplotlib.lines.Line2D at ...>,
-              <matplotlib.lines.Line2D at ...>],
-             'whiskers': [<matplotlib.lines.Line2D at ...>,
-              <matplotlib.lines.Line2D at ...>,
-              <matplotlib.lines.Line2D at ...>,
-              <matplotlib.lines.Line2D at ...>]}
-
-    If selecting ``return_type='both'``, a namedtuple with matplotlib axes and
-    Line objets is returned:
-
-        >>> df.boxplot(column=['Col1','Col2'], return_type='both')
-            Boxplot(ax=<matplotlib.axes._subplots.AxesSubplot object
-            at 0x115821128>, lines={'whiskers':
-            [<matplotlib.lines.Line2D object at ...>,
-            <matplotlib.lines.Line2D object at ...>,
-            <matplotlib.lines.Line2D object at ...>,
-            <matplotlib.lines.Line2D object at ...>],
-            'caps': [<matplotlib.lines.Line2D object at ...>,
-            <matplotlib.lines.Line2D object at ...>,
-            <matplotlib.lines.Line2D object at ...>,
-            <matplotlib.lines.Line2D object at ...>],
-            'boxes': [<matplotlib.lines.Line2D object at ...>,
-            <matplotlib.lines.Line2D object at ...>],
-            'medians': [<matplotlib.lines.Line2D object at ...>,
-            <matplotlib.lines.Line2D object at ...>],
-            'fliers': [<matplotlib.lines.Line2D object at ...>,
-            <matplotlib.lines.Line2D object at ...>], 'means': []})
-
     When grouping with ``by``, a Series mapping columns to ``return_type``
     is returned:
-
 
         >>> df.boxplot(column=['Col1','Col2'], by='X', return_type='axes')
             Col1         AxesSubplot(0.1,0.15;0.363636x0.75)
@@ -2191,8 +2148,8 @@ _shared_docs['boxplot'] = """
             array([<matplotlib.axes._subplots.AxesSubplot object at ...>,
                    <matplotlib.axes._subplots.AxesSubplot object at ...>],
                    dtype=object)
-
     """
+
 
 @Appender(_shared_docs['boxplot'] % _shared_doc_kwargs)
 def boxplot(data, column=None, by=None, ax=None, fontsize=None,

--- a/pandas/plotting/_core.py
+++ b/pandas/plotting/_core.py
@@ -1997,7 +1997,7 @@ def plot_series(data, kind='line', ax=None,                    # Series unique
 _shared_docs['boxplot'] = """
     Make a box plot from DataFrame columns.
 
-    Make a box-and-whisker plot from DataFrame columns optionally grouped
+    Make a box-and-whisker plot from DataFrame columns, optionally grouped
     by some other columns. A box plot is a method for graphically depicting
     groups of numerical data through their quartiles.
     The box extends from the Q1 to Q3 quartile values of the data,

--- a/pandas/plotting/_core.py
+++ b/pandas/plotting/_core.py
@@ -2130,24 +2130,25 @@ _shared_docs['boxplot'] = """
     returned by `boxplot`.  When ``return_type='axes'`` is selected,
     the matplotlib axes on which the boxplot is drawn are returned:
 
-        >>> df.boxplot(column=['Col1','Col2'], return_type='axes')
-        <matplotlib.axes._subplots.AxesSubplot object at ...>
+        >>> boxplot = df.boxplot(column=['Col1','Col2'], return_type='axes')
+        >>> type(boxplot)
+        <class 'matplotlib.axes._subplots.AxesSubplot'>
 
     When grouping with ``by``, a Series mapping columns to ``return_type``
     is returned:
 
-        >>> df.boxplot(column=['Col1','Col2'], by='X', return_type='axes')
-            Col1         AxesSubplot(0.1,0.15;0.363636x0.75)
-            Col2    AxesSubplot(0.536364,0.15;0.363636x0.75)
-            dtype: object
+        >>> boxplot = df.boxplot(column=['Col1','Col2'], by='X',
+        ...                      return_type='axes')
+        >>> type(boxplot)
+        <class 'pandas.core.series.Series'>
 
     If ``return_type`` is `None`, a NumPy array of axes with the same shape
     as ``layout`` is returned:
 
-        >>> df.boxplot(column=['Col1','Col2'], by='X', return_type=None)
-            array([<matplotlib.axes._subplots.AxesSubplot object at ...>,
-                   <matplotlib.axes._subplots.AxesSubplot object at ...>],
-                   dtype=object)
+        >>> boxplot =  df.boxplot(column=['Col1','Col2'], by='X',
+        ...                       return_type=None)
+        >>> type(boxplot)
+        <class 'numpy.ndarray'>
     """
 
 

--- a/pandas/plotting/_core.py
+++ b/pandas/plotting/_core.py
@@ -2001,9 +2001,9 @@ _shared_docs['boxplot'] = """
     by some other columns. A box plot is a method for graphically depicting
     groups of numerical data through their quartiles.
     The box extends from the Q1 to Q3 quartile values of the data,
-    with a line at the median (Q2).The whiskers extend from the edges
+    with a line at the median (Q2). The whiskers extend from the edges
     of box to show the range of the data. The position of the whiskers
-    is set by default to 1.5*IQR (IQR = Q3 - Q1) from the edges of the box.
+    is set by default to `1.5 * IQR (IQR = Q3 - Q1)` from the edges of the box.
     Outlier points are those past the end of the whiskers.
 
     For further details see
@@ -2031,7 +2031,7 @@ _shared_docs['boxplot'] = """
     layout : tuple (rows, columns), optional
         For example, (3, 5) will display the subplots
         using 3 columns and 5 rows, starting from the top-left.
-    return_type : {None, 'axes', 'dict', 'both'}, default 'axes'
+    return_type : {'axes', 'dict', 'both'} or None, default 'axes'
         The kind of object to return. The default is ``axes``.
 
         * 'axes' returns the matplotlib axes the boxplot is drawn on.
@@ -2049,22 +2049,23 @@ _shared_docs['boxplot'] = """
 
     Returns
     -------
-    result:
-        Options:
+    result :
 
-        * ax : object of class
-          matplotlib.axes.Axes (for ``return_type='axes'``)
-        * lines : dict (for ``return_type='dict'``)
-        * (ax, lines): namedtuple (for ``return_type='both'``)
-        * :class:`~pandas.Series` (for ``return_type != None``
-          and data grouped with ``by``)
-        * :class:`~numpy.array` (for ``return_type=None``
-          and data grouped with ``by``)
+        The return type depends on the `return_type` parameter:
+
+        * 'axes' : object of class matplotlib.axes.Axes
+        * 'dict' : dict of matplotlib.lines.Line2D objects
+        * 'both' : a nametuple with strucure (ax, lines)
+
+        For data grouped with ``by``:
+
+        * :class:`~pandas.Series`
+        * :class:`~numpy.array` (for ``return_type = None``)
 
     See Also
     --------
-    matplotlib.pyplot.boxplot : Make a box and whisker plot.
-    matplotlib.pyplot.hist : Make a histogram.
+    Series.plot.hist: Make a histogram.
+    matplotlib.pyplot.boxplot : Matplotlib equivalent plot.
 
     Notes
     -----


### PR DESCRIPTION
- [x] PR title is "DOC: update the <your-function-or-method> docstring"
- [x] The validation script passes: `scripts/validate_docstrings.py pandas.DataFrame.boxplot`
- [x] The PEP8 style check passes: `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] The html version looks good: `python doc/make.py --single pandas.DataFrame.boxplot`
- [x] It has been proofread on language by another sprint participant


```
################################################################################
##################### Docstring (pandas.DataFrame.boxplot) #####################
################################################################################

Make a box plot from DataFrame columns.

Make a box-and-whisker plot from DataFrame columns optionally grouped
by some other columns. A box plot is a method for graphically depicting
groups of numerical data through their quartiles.
The box extends from the Q1 to Q3 quartile values of the data,
with a line at the median (Q2).The whiskers extend from the edges
of box to show the range of the data. The position of the whiskers
is set by default to 1.5*IQR (IQR = Q3 - Q1) from the edges of the box.
Outlier points are those past the end of the whiskers.

For further details see
Wikipedia's entry for `boxplot <https://en.wikipedia.org/wiki/Box_plot>`_.

Parameters
----------
column : str or list of str, optional
    Column name or list of names, or vector.
    Can be any valid input to groupby.
by : str or array-like
    Column in the DataFrame to groupby.
ax : object of class matplotlib.axes.Axes, default `None`
    The matplotlib axes to be used by boxplot.
fontsize : float or str
    Tick label font size in points or as a string (e.g., ‘large’)
    (see `matplotlib.axes.Axes.tick_params
    <https://matplotlib.org/api/_as_gen/
    matplotlib.axes.Axes.tick_params.html>`_).
rot : int or float, default 0
    The rotation angle of labels (in degrees)
    with respect to the screen coordinate sytem.
grid : boolean, default `True`
    Setting this to True will show the grid.
figsize : A tuple (width, height) in inches
    The size of the figure to create in matplotlib.
layout : tuple (rows, columns) (optional)
    For example, (3, 5) will display the subplots
    using 3 columns and 5 rows, starting from the top-left.
return_type : {None, 'axes', 'dict', 'both'}, default 'axes'
    The kind of object to return. The default is ``axes``.

    * 'axes' returns the matplotlib axes the boxplot is drawn on.
    * 'dict' returns a dictionary whose values are the matplotlib
      Lines of the boxplot.
    * 'both' returns a namedtuple with the axes and dict.
    * when grouping with ``by``, a Series mapping columns to
      ``return_type`` is returned (i.e.
      ``df.boxplot(column=['Col1','Col2'], by='var',return_type='axes')``
      may return ``Series([AxesSubplot(..),AxesSubplot(..)],
      index=['Col1','Col2'])``).

      If ``return_type`` is `None`, a NumPy array
      of axes with the same shape as ``layout`` is returned
      (i.e. ``df.boxplot(column=['Col1','Col2'],
      by='var',return_type=None)`` may return a
      ``array([<matplotlib.axes._subplots.AxesSubplot object at ..>,
      <matplotlib.axes._subplots.AxesSubplot object at ..>],
      dtype=object)``).
**kwds : Keyword Arguments (optional)
    All other plotting keyword arguments to be passed to
    `matplotlib.pyplot.boxplot <https://matplotlib.org/api/_as_gen/
    matplotlib.pyplot.boxplot.html#matplotlib.pyplot.boxplot>`_.

Returns
-------
result:
    Options:

    * ax : object of class
      matplotlib.axes.Axes (for ``return_type='axes'``)
    * lines : dict (for ``return_type='dict'``)
    * (ax, lines): namedtuple (for ``return_type='both'``)
    * :class:`~pandas.Series` (for ``return_type != None``
      and data grouped with ``by``)
    * :class:`~numpy.array` (for ``return_type=None``
      and data grouped with ``by``)

See Also
--------
matplotlib.pyplot.boxplot: Make a box and whisker plot.
matplotlib.pyplot.hist: Make a hsitogram.

Notes
-----
Use ``return_type='dict'`` when you want to tweak the appearance
of the lines after plotting. In this case a dict containing the Lines
making up the boxes, caps, fliers, medians, and whiskers is returned.

Examples
--------

Boxplots can be created for every column in the dataframe
by ``df.boxplot()`` or indicating the columns to be used:

.. plot::
    :context: close-figs

    >>> np.random.seed(1234)
    >>> df = pd.DataFrame(np.random.rand(10,4),
    ...                   columns=['Col1', 'Col2', 'Col3', 'Col4'])
    >>> boxplot = df.boxplot(column=['Col1', 'Col2', 'Col3'])

Boxplots of variables distributions grouped by a third variable values
can be created using the option ``by``. For instance:

.. plot::
    :context: close-figs

    >>> df = pd.DataFrame(np.random.rand(10,2), columns=['Col1', 'Col2'] )
    >>> df['X'] = pd.Series(['A','A','A','A','A','B','B','B','B','B'])
    >>> boxplot = df.boxplot(by='X')

A list of strings (i.e. ``['X','Y']``) containing can be passed to boxplot
in order to group the data by combination of the variables in the x-axis:

.. plot::
    :context: close-figs

    >>> df = pd.DataFrame(np.random.rand(10,3),
    ...                   columns=['Col1', 'Col2', 'Col3'])
    >>> df['X'] = pd.Series(['A','A','A','A','A','B','B','B','B','B'])
    >>> df['Y'] = pd.Series(['A','B','A','B','A','B','A','B','A','B'])
    >>> boxplot = df.boxplot(column=['Col1','Col2'], by=['X','Y'])

The layout of boxplot can be adjusted giving a tuple to ``layout``:

.. plot::
    :context: close-figs

    >>> df = pd.DataFrame(np.random.rand(10,2), columns=['Col1', 'Col2'])
    >>> df['X'] = pd.Series(['A','A','A','A','A','B','B','B','B','B'])
    >>> boxplot = df.boxplot(by='X', layout=(2,1))

Additional formatting can be done to the boxplot, like suppressing the grid
(``grid=False``), rotating the labels in the x-axis (i.e. ``rot=45``)
or changing the fontsize (i.e. ``fontsize=15``):

.. plot::
    :context: close-figs

    >>> boxplot = df.boxplot(grid=False, rot=45, fontsize=15)

################################################################################
################################## Validation ##################################
################################################################################

Errors found:
	Errors in parameters section
		Parameters {'kwds'} not documented
		Unknown parameters {'**kwds'}
```
<img width="507" alt="captura de pantalla 2018-03-12 a las 0 51 51" src="https://user-images.githubusercontent.com/15342068/37260125-ab870588-258f-11e8-837d-80497fb392eb.png">
<img width="496" alt="captura de pantalla 2018-03-12 a las 0 52 04" src="https://user-images.githubusercontent.com/15342068/37260124-ab4d8d3a-258f-11e8-9dd9-9c5c7dca16cf.png">
<img width="492" alt="captura de pantalla 2018-03-12 a las 0 52 12" src="https://user-images.githubusercontent.com/15342068/37260123-ab316ed4-258f-11e8-863a-2c9e8fe1e67d.png">
<img width="494" alt="captura de pantalla 2018-03-12 a las 0 52 18" src="https://user-images.githubusercontent.com/15342068/37260122-ab1480e4-258f-11e8-9b2b-debe1c7355da.png">

@EliosMolina