### PR TITLE
DOC: Update the pandas.Series.str.find() (Delhi)

### DIFF
--- a/pandas/core/strings.py
+++ b/pandas/core/strings.py
@@ -1842,7 +1842,7 @@ class StringMethods(NoNewAttributesMixin):
         return str_extractall(self._orig, pat, flags=flags)
 
     _shared_docs['find'] = ("""
-    Retrieve least index of substring.
+    Return the lowest index of the substring.
 
     Return %(side)s indexes in each strings in the Series/Index
     where the substring is fully contained between [start:end].
@@ -1868,7 +1868,7 @@ class StringMethods(NoNewAttributesMixin):
     0    8
     dtype: int64
 
-    Returns -1 if the substring is not found in S
+    Return -1 if the substring is not found.
 
     >>> s.str.find('wi', start=0, end=5)
     0   -1

--- a/pandas/core/strings.py
+++ b/pandas/core/strings.py
@@ -1878,9 +1878,9 @@ class StringMethods(NoNewAttributesMixin):
     >>> s.str.find('find')
     0    -1
     1     8
-    2     16
+    2    16
     dtype: int64
-
+    
     See Also
     --------
     %(also)s

--- a/pandas/core/strings.py
+++ b/pandas/core/strings.py
@@ -1874,6 +1874,13 @@ class StringMethods(NoNewAttributesMixin):
     0   -1
     dtype: int64
 
+    >>> s = pd.Series(['get pandas','Did you find it','i think you can find it'])
+    >>> s.str.find('find')
+    0    -1
+    1     8
+    2     16
+    dtype: int64
+
     See Also
     --------
     %(also)s

--- a/pandas/core/strings.py
+++ b/pandas/core/strings.py
@@ -1880,7 +1880,7 @@ class StringMethods(NoNewAttributesMixin):
     1     8
     2    16
     dtype: int64
-    
+
     See Also
     --------
     %(also)s

--- a/pandas/core/strings.py
+++ b/pandas/core/strings.py
@@ -1842,7 +1842,7 @@ class StringMethods(NoNewAttributesMixin):
         return str_extractall(self._orig, pat, flags=flags)
 
     _shared_docs['find'] = ("""
-    Return the lowest index of the substring.
+    Return the %(side)s index of the substring.
 
     Return %(side)s indexes in each strings in the Series/Index
     where the substring is fully contained between [start:end].
@@ -1874,11 +1874,15 @@ class StringMethods(NoNewAttributesMixin):
     0   -1
     dtype: int64
 
-    >>> s = pd.Series(['get pandas','Did you find it','i think you can find it'])
+    >>> s = pd.Series(['Did you find it','find find'])
     >>> s.str.find('find')
-    0    -1
-    1     8
-    2    16
+    0     8
+    1     0
+    dtype: int64
+
+    >>> s.str.find('find', start=1, end=14)
+    0    8
+    1    5
     dtype: int64
 
     See Also

--- a/pandas/core/strings.py
+++ b/pandas/core/strings.py
@@ -1842,6 +1842,8 @@ class StringMethods(NoNewAttributesMixin):
         return str_extractall(self._orig, pat, flags=flags)
 
     _shared_docs['find'] = ("""
+    Retrieve least index of substring.
+
     Return %(side)s indexes in each strings in the Series/Index
     where the substring is fully contained between [start:end].
     Return -1 on failure. Equivalent to standard :meth:`str.%(method)s`.
@@ -1849,15 +1851,28 @@ class StringMethods(NoNewAttributesMixin):
     Parameters
     ----------
     sub : str
-        Substring being searched
+        Substring being searched.
     start : int
-        Left edge index
+        Left edge index.
     end : int
-        Right edge index
+        Right edge index.
 
     Returns
     -------
     found : Series/Index of integer values
+
+    Examples
+    --------
+    >>> s = pd.Series('Finding with pandas')
+    >>> s.str.find('wi')
+    0    8
+    dtype: int64
+
+    Returns -1 if the substring is not found in S
+
+    >>> s.str.find('wi', start=0, end=5)
+    0   -1
+    dtype: int64
 
     See Also
     --------


### PR DESCRIPTION
Checklist for the pandas documentation sprint (ignore this if you are doing
an unrelated PR):

- [x] PR title is "DOC: update the pandas.Series.str.find docstring"
- [x] The validation script passes: `scripts/validate_docstrings.py pandas.Series.str.find`
- [x] The PEP8 style check passes: `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] The html version looks good: `python doc/make.py --single pandas.Series.str.find`
- [x] It has been proofread on language by another sprint participant

Please include the output of the validation script below between the "```" ticks:

```
################################################################################
###################### Docstring (pandas.Series.str.find) ######################
################################################################################

Retrieve least index of substring.

Return lowest indexes in each strings in the Series/Index
where the substring is fully contained between [start:end].
Return -1 on failure. Equivalent to standard :meth:`str.find`.

Parameters
----------
sub : str
    Substring being searched.
start : int
    Left edge index.
end : int
    Right edge index.

Returns
-------
found : Series/Index of integer values

Examples
--------
>>> s = pd.Series('Finding with pandas')
>>> s.str.find('wi')
0    8
dtype: int64

Returns -1 if the substring is not found in S

>>> s.str.find('wi', start=0, end=5)
0   -1
dtype: int64

See Also
--------
rfind : Return highest indexes in each strings

################################################################################
################################## Validation ##################################
################################################################################
```

If the validation script still gives errors, but you think there is a good reason
to deviate in this case (and there are certainly such cases), please state this
explicitly.


Checklist for other PRs (remove this part if you are doing a PR for the pandas documentation sprint):

- [ ] closes #xxxx
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
