### PR TITLE
DOC: Update the pandas.Series.str.count() docstring (Delhi)

### DIFF
--- a/pandas/core/strings.py
+++ b/pandas/core/strings.py
@@ -202,15 +202,43 @@ def str_count(arr, pat, flags=0):
     """
     Count occurrences of pattern in each string of the Series/Index.
 
+    This function is used to count the number of times a particular regex
+    pattern is repeated in each of the string elements of the
+    :class:`~pandas.Series`.
+
     Parameters
     ----------
-    pat : string, valid regular expression
-    flags : int, default 0 (no flags)
-        re module flags, e.g. re.IGNORECASE
+    pat : str
+        Valid regular expression.
+    flags : int, default 0, meaning no flags
+        Flags for re module, e.g. re.IGNORECASE.
 
     Returns
     -------
     counts : Series/Index of integer values
+
+    Notes
+    -----
+    Some characters need to be escaped when passing in pat.
+    eg. '$' has a special meaning in regex and must be escaped when finding
+    specifinally this char.
+
+    Examples
+    --------
+    Take a look at
+    `this link <https://docs.python.org/3/howto/regex.html#compilation-flags>`_ 
+    for the list of all possible flags that can be used.
+
+    >>> s = pd.Series(['A', 'B', 'Aaba', 'Baca', np.nan, 'CABA', 'cat'])
+    >>> s.str.count('a')
+    0    0.0
+    1    0.0
+    2    2.0
+    3    2.0
+    4    NaN
+    5    0.0
+    6    1.0
+    dtype: float64
     """
     regex = re.compile(pat, flags=flags)
     f = lambda x: len(regex.findall(x))

--- a/pandas/core/strings.py
+++ b/pandas/core/strings.py
@@ -221,12 +221,12 @@ def str_count(arr, pat, flags=0):
     -----
     Some characters need to be escaped when passing in pat.
     eg. '$' has a special meaning in regex and must be escaped when finding
-    specifinally this char.
+    specifically this char.
 
     Examples
     --------
     Take a look at
-    `this link <https://docs.python.org/3/howto/regex.html#compilation-flags>`_ 
+    `this link <https://docs.python.org/3/howto/regex.html#compilation-flags>`_
     for the list of all possible flags that can be used.
 
     >>> s = pd.Series(['A', 'B', 'Aaba', 'Baca', np.nan, 'CABA', 'cat'])

--- a/pandas/core/strings.py
+++ b/pandas/core/strings.py
@@ -211,7 +211,9 @@ def str_count(arr, pat, flags=0):
     pat : str
         Valid regular expression.
     flags : int, default 0, meaning no flags
-        Flags for re module, e.g. re.IGNORECASE.
+        Flags for re module, for a complete list
+        `look at this
+        <https://docs.python.org/3/howto/regex.html#compilation-flags>`_.
 
     Returns
     -------
@@ -225,10 +227,6 @@ def str_count(arr, pat, flags=0):
 
     Examples
     --------
-    Take a look at
-    `this link <https://docs.python.org/3/howto/regex.html#compilation-flags>`_
-    for the list of all possible flags that can be used.
-
     >>> s = pd.Series(['A', 'B', 'Aaba', 'Baca', np.nan, 'CABA', 'cat'])
     >>> s.str.count('a')
     0    0.0
@@ -239,6 +237,16 @@ def str_count(arr, pat, flags=0):
     5    0.0
     6    1.0
     dtype: float64
+
+    >>> s = pd.Series(['$', 'B', 'Aab$', '$$ca', 'C$B$', 'cat'])
+    >>> s.str.count('\$')
+    0    1
+    1    0
+    2    1
+    3    2
+    4    2
+    5    0
+    dtype: int64
     """
     regex = re.compile(pat, flags=flags)
     f = lambda x: len(regex.findall(x))

--- a/pandas/core/strings.py
+++ b/pandas/core/strings.py
@@ -211,19 +211,26 @@ def str_count(arr, pat, flags=0):
     pat : str
         Valid regular expression.
     flags : int, default 0, meaning no flags
-        Flags for re module, for a complete list
-        `look at this
+        Flags for the `re` module. For a complete list, `see here
         <https://docs.python.org/3/howto/regex.html#compilation-flags>`_.
+    **kwargs
+        For compatability with other string methods. Not used.
 
     Returns
     -------
-    counts : Series/Index of integer values
+    counts : Series or Index
+        Same type as the calling object containing the integer counts.
 
     Notes
     -----
-    Some characters need to be escaped when passing in pat.
-    eg. '$' has a special meaning in regex and must be escaped when finding
-    specifically this char.
+    Some characters need to be escaped when passing in `pat`.
+    eg. ``'$'`` has a special meaning in regex and must be escaped when
+    finding this literal character.
+
+    See Also
+    --------
+    re : Standard library module for regular expressions.
+    str.count : Standard library version, without regular expression support.
 
     Examples
     --------
@@ -238,6 +245,8 @@ def str_count(arr, pat, flags=0):
     6    1.0
     dtype: float64
 
+    Escape ``'$'`` to find the literal dollar sign.
+
     >>> s = pd.Series(['$', 'B', 'Aab$', '$$ca', 'C$B$', 'cat'])
     >>> s.str.count('\$')
     0    1
@@ -247,6 +256,11 @@ def str_count(arr, pat, flags=0):
     4    2
     5    0
     dtype: int64
+
+    This is also available on Index
+
+    >>> pd.Index(['A', 'A', 'Aaba', 'cat']).str.count('a')
+    Int64Index([0, 0, 2, 1], dtype='int64')
     """
     regex = re.compile(pat, flags=flags)
     f = lambda x: len(regex.findall(x))


### PR DESCRIPTION
Checklist for the pandas documentation sprint (ignore this if you are doing
an unrelated PR):

- [x] PR title is "DOC: update the <your-function-or-method> docstring"
- [ ] The validation script passes: `scripts/validate_docstrings.py <your-function-or-method>`
- [x] The PEP8 style check passes: `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] The html version looks good: `python doc/make.py --single <your-function-or-method>`
- [x] It has been proofread on language by another sprint participant

Please include the output of the validation script below between the "```" ticks:

```
################################################################################
##################### Docstring (pandas.Series.str.count)  #####################
################################################################################

Count occurrences of pattern in each string of the Series/Index.

This function is used to count the number of times a particular regex
pattern is repeated in each of the string elements of the
:class:`~pandas.Series`.

Parameters
----------
pat : str
    Valid regular expression.
flags : int, default 0, meaning no flags
    Flags for re module, e.g. re.IGNORECASE.

Returns
-------
counts : Series/Index of integer values

Notes
-----
Some characters need to be escaped when passing in pat.
eg. '$' has a special meaning in regex and must be escaped when finding
specifically this char.

Examples
--------
Take a look at
`this link <https://docs.python.org/3/howto/regex.html#compilation-flags>`_
for the list of all possible flags that can be used.

>>> s = pd.Series(['A', 'B', 'Aaba', 'Baca', np.nan, 'CABA', 'cat'])
>>> s.str.count('a')
0    0.0
1    0.0
2    2.0
3    2.0
4    NaN
5    0.0
6    1.0
dtype: float64

################################################################################
################################## Validation ##################################
################################################################################

Errors found:
	Errors in parameters section
		Parameters {'kwargs'} not documented
	See Also section not found

```
As discussed in the gitter channel it was suggested to ignore kwargs for now.
Not sure what should be a part of see also here.