### PR TITLE
DOC: update the pandas.Series.dt.total_seconds docstring

### DIFF
--- a/pandas/core/indexes/timedeltas.py
+++ b/pandas/core/indexes/timedeltas.py
@@ -501,7 +501,33 @@ class TimedeltaIndex(DatetimeIndexOpsMixin, TimelikeOps, Int64Index):
 
     def total_seconds(self):
         """
-        Total duration of each element expressed in seconds.
+        Return total duration of each element expressed in seconds.
+
+        Return a series with the same length and index as the original,
+        containing the length of each element expressed in seconds.
+
+        Returns
+        -------
+        s : pandas.Series
+            a series of type `float64`.
+
+        Examples
+        --------
+        >>> s = pd.Series(pd.to_timedelta(np.arange(5), unit='d'))
+        >>> s
+        0   0 days
+        1   1 days
+        2   2 days
+        3   3 days
+        4   4 days
+        dtype: timedelta64[ns]
+        >>> s.dt.total_seconds()
+        0         0.0
+        1     86400.0
+        2    172800.0
+        3    259200.0
+        4    345600.0
+        dtype: float64
         """
         return Index(self._maybe_mask_results(1e-9 * self.asi8),
                      name=self.name)

--- a/pandas/core/indexes/timedeltas.py
+++ b/pandas/core/indexes/timedeltas.py
@@ -508,7 +508,7 @@ class TimedeltaIndex(DatetimeIndexOpsMixin, TimelikeOps, Int64Index):
         Returns
         -------
         s : pandas.Series
-            a series of type `float64`.
+            Series of type `float64`.
 
         Examples
         --------

--- a/pandas/core/indexes/timedeltas.py
+++ b/pandas/core/indexes/timedeltas.py
@@ -502,16 +502,28 @@ class TimedeltaIndex(DatetimeIndexOpsMixin, TimelikeOps, Int64Index):
         """
         Return total duration of each element expressed in seconds.
 
-        Return a series with the same length and index as the original,
-        containing the length of each element expressed in seconds.
+        This method is available directly on TimedeltaIndex and on Series
+        containing timedelta values under the ``.dt`` namespace.
 
         Returns
         -------
-        s : pandas.Series
-            Series of type `float64`.
+        seconds : Float64Index or Series
+            When the calling object is a TimedeltaIndex, the return type is a
+            Float64Index. When the calling object is a Series, the return type
+            is Series of type `float64` whose index is the same as the
+            original.
+
+        See Also
+        --------
+        datetime.timedelta.total_seconds : Standard library version
+            of this method.
+        TimedeltaIndex.components : Return a DataFrame with components of
+            each Timedelta.
 
         Examples
         --------
+        **Series**
+
         >>> s = pd.Series(pd.to_timedelta(np.arange(5), unit='d'))
         >>> s
         0   0 days
@@ -520,6 +532,7 @@ class TimedeltaIndex(DatetimeIndexOpsMixin, TimelikeOps, Int64Index):
         3   3 days
         4   4 days
         dtype: timedelta64[ns]
+
         >>> s.dt.total_seconds()
         0         0.0
         1     86400.0
@@ -528,9 +541,16 @@ class TimedeltaIndex(DatetimeIndexOpsMixin, TimelikeOps, Int64Index):
         4    345600.0
         dtype: float64
 
-        See Also
-        --------
-        datetime.timedelta.total_seconds
+        **TimedeltaIndex**
+
+        >>> idx = pd.to_timedelta(np.arange(5), unit='d')
+        >>> idx
+        TimedeltaIndex(['0 days', '1 days', '2 days', '3 days', '4 days'],
+                       dtype='timedelta64[ns]', freq=None)
+
+        >>> idx.total_seconds()
+        Float64Index([0.0, 86400.0, 172800.0, 259200.00000000003, 345600.0],
+                     dtype='float64')
         """
         return Index(self._maybe_mask_results(1e-9 * self.asi8),
                      name=self.name)

--- a/pandas/core/indexes/timedeltas.py
+++ b/pandas/core/indexes/timedeltas.py
@@ -527,6 +527,10 @@ class TimedeltaIndex(DatetimeIndexOpsMixin, TimelikeOps, Int64Index):
         3    259200.0
         4    345600.0
         dtype: float64
+
+        See Also
+        --------
+        datetime.timedelta.total_seconds
         """
         return Index(self._maybe_mask_results(1e-9 * self.asi8),
                      name=self.name)


### PR DESCRIPTION
Checklist for the pandas documentation sprint (ignore this if you are doing
an unrelated PR):

- [X] PR title is "DOC: update the <your-function-or-method> docstring"
- [X] The validation script passes: `scripts/validate_docstrings.py <your-function-or-method>`
- [X] The PEP8 style check passes: `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [X] The html version looks good: `python doc/make.py --single <your-function-or-method>`
- [X] It has been proofread on language by another sprint participant

Please include the output of the validation script below between the "```" ticks:

```
################################################################################
################## Docstring (pandas.Series.dt.total_seconds) ##################
################################################################################

Return total duration of each element expressed in seconds.

Return a series with the same length and index as the original,
containing the length of each element expressed in seconds.

Returns
-------
s : pandas.Series
    a series of type `float64`.

Examples
--------
>>> s = pd.Series(pd.to_timedelta(np.arange(5), unit='d'))
>>> s
0   0 days
1   1 days
2   2 days
3   3 days
4   4 days
dtype: timedelta64[ns]
>>> s.dt.total_seconds()
0         0.0
1     86400.0
2    172800.0
3    259200.0
4    345600.0
dtype: float64

################################################################################
################################## Validation ##################################
################################################################################

Errors found:
        Errors in parameters section
                Parameters {'args', 'kwargs'} not documented
        See Also section not found

```

If the validation script still gives errors, but you think there is a good reason
to deviate in this case (and there are certainly such cases), please state this
explicitly.


Checklist for other PRs (remove this part if you are doing a PR for the pandas documentation sprint):

- [ ] closes #xxxx
- [ ] tests added / passed
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
