### PR TITLE
DOC: update the pandas.DataFrame.notna and pandas.Series.notna docstring

### DIFF
--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -5656,10 +5656,10 @@ class NDFrame(PandasObject, SelectionMixin):
         Detect existing (non-missing) values.
 
         Return a boolean same-sized object indicating if the values are not NA.
-        Non-missing values gets mapped to True. Characters such as empty
+        Non-missing values get mapped to True. Characters such as empty
         strings ``''`` or :attr:`numpy.inf` are not considered NA values
         (unless you set ``pandas.options.mode.use_inf_as_na = True``).
-        NA values, such as None or :attr:`numpy.NaN`, gets mapped to False
+        NA values, such as None or :attr:`numpy.NaN`, get mapped to False
         values.
 
         Returns

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -5537,9 +5537,9 @@ class NDFrame(PandasObject, SelectionMixin):
 
         Returns
         -------
-        bool of type %(klass)s
-            Mask of True/False values for each element in %(klass)s that
-            indicates whether an element is not an NA value
+        %(klass)s
+            Mask of bool values for each element in %(klass)s that
+            indicates whether an element is not an NA value.
 
         See Also
         --------

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -5529,10 +5529,10 @@ class NDFrame(PandasObject, SelectionMixin):
         Detect existing (non-missing) values.
 
         Return a boolean same-sized object indicating if the values are not NA.
-        Non-missing values get mapped to True. Characters such as empty
+        Non-missing values gets mapped to True. Characters such as empty
         strings `''` or :attr:`numpy.inf` are not considered NA values
-        (unless you set :attr:`pandas.options.mode.use_inf_as_na` `= True`).
-        NA values, such as None or :attr:`numpy.NaN`, get mapped to False
+        (unless you set ``pandas.options.mode.use_inf_as_na = True``).
+        NA values, such as None or :attr:`numpy.NaN`, gets mapped to False
         values.
 
         Returns

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -5526,14 +5526,63 @@ class NDFrame(PandasObject, SelectionMixin):
         return isna(self).__finalize__(self)
 
     _shared_docs['notna'] = """
-        Return a boolean same-sized object indicating if the values are
-        not NA.
+        Detect existing (non-missing) values.
+
+        Return a boolean same-sized object indicating if the values are not NA.
+        Non-missing values get mapped to True. Characters such as empty
+        strings `''` or :attr:`numpy.inf` are not considered NA values
+        (unless you set :attr:`pandas.options.mode.use_inf_as_na` `= True`).
+        NA values, such as None or :attr:`numpy.NaN`, get mapped to False
+        values.
+
+        Returns
+        -------
+        bool of type %(klass)s
+            Mask of True/False values for each element in %(klass)s that
+            indicates whether an element is not an NA value
 
         See Also
         --------
-        %(klass)s.isna : boolean inverse of notna
         %(klass)s.notnull : alias of notna
+        %(klass)s.isna : boolean inverse of notna
+        %(klass)s.dropna : omit axes labels with missing values
         notna : top-level notna
+
+        Examples
+        --------
+        Show which entries in a DataFrame are not NA.
+
+        >>> df = pd.DataFrame({'age': [5, 6, np.NaN],
+        ...                    'born': [pd.NaT, pd.Timestamp('1939-05-27'),
+        ...                             pd.Timestamp('1940-04-25')],
+        ...                    'name': ['Alfred', 'Batman', ''],
+        ...                    'toy': [None, 'Batmobile', 'Joker']})
+        >>> df
+           age       born    name        toy
+        0  5.0        NaT  Alfred       None
+        1  6.0 1939-05-27  Batman  Batmobile
+        2  NaN 1940-04-25              Joker
+
+        >>> df.notna()
+             age   born  name    toy
+        0   True  False  True  False
+        1   True   True  True   True
+        2  False   True  True   True
+
+        Show which entries in a Series are not NA.
+
+        >>> ser = pd.Series([5, 6, np.NaN])
+        >>> ser
+        0    5.0
+        1    6.0
+        2    NaN
+        dtype: float64
+
+        >>> ser.notna()
+        0     True
+        1     True
+        2    False
+        dtype: bool
         """
 
     @Appender(_shared_docs['notna'] % _shared_doc_kwargs)

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -5458,13 +5458,63 @@ class NDFrame(PandasObject, SelectionMixin):
     # Action Methods
 
     _shared_docs['isna'] = """
+        Detect missing values.
+
         Return a boolean same-sized object indicating if the values are NA.
+        NA values, such as None or :attr:`numpy.NaN`, get mapped to True
+        values.
+        Everything else get mapped to False values. Characters such as empty
+        strings `''` or :attr:`numpy.inf` are not considered NA values
+        (unless you set :attr:`pandas.options.mode.use_inf_as_na` `= True`).
+
+        Returns
+        -------
+        bool of type %(klass)s
+            Mask of True/False values for each element in %(klass)s that
+            indicates whether an element is an NA value
 
         See Also
         --------
-        %(klass)s.notna : boolean inverse of isna
         %(klass)s.isnull : alias of isna
+        %(klass)s.notna : boolean inverse of isna
+        %(klass)s.dropna : omit axes labels with missing values
         isna : top-level isna
+
+        Examples
+        --------
+        Show which entries in a DataFrame are NA.
+
+        >>> df = pd.DataFrame({'age': [5, 6, np.NaN],
+        ...                    'born': [pd.NaT, pd.Timestamp('1939-05-27'),
+        ...                             pd.Timestamp('1940-04-25')],
+        ...                    'name': ['Alfred', 'Batman', ''],
+        ...                    'toy': [None, 'Batmobile', 'Joker']})
+        >>> df
+           age       born    name        toy
+        0  5.0        NaT  Alfred       None
+        1  6.0 1939-05-27  Batman  Batmobile
+        2  NaN 1940-04-25              Joker
+
+        >>> df.isna()
+             age   born   name    toy
+        0  False   True  False   True
+        1  False  False  False  False
+        2   True  False  False  False
+
+        Show which entries in a Series are NA.
+
+        >>> ser = pd.Series([5, 6, np.NaN])
+        >>> ser
+        0    5.0
+        1    6.0
+        2    NaN
+        dtype: float64
+
+        >>> ser.isna()
+        0    False
+        1    False
+        2     True
+        dtype: bool
         """
 
     @Appender(_shared_docs['isna'] % _shared_doc_kwargs)

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -2025,7 +2025,8 @@ class Index(IndexOpsMixin, PandasObject):
         Detect missing values.
 
         Return a boolean same-sized object indicating if the values are NA.
-        NA values, such as None or :attr:`numpy.NaN`, get mapped to True values.
+        NA values, such as None or :attr:`numpy.NaN`, get mapped to True
+        values.
         Everything else get mapped to False values. Characters such as empty
         strings `''` or :attr:`numpy.inf` are not considered NA values
         (unless you set :attr:`pandas.options.mode.use_inf_as_na` `= True`).
@@ -2055,7 +2056,8 @@ class Index(IndexOpsMixin, PandasObject):
         >>> idx.isna()
         array([False, False,  True])
 
-        Empty strings are not considered NA values. None is considered NA value.
+        Empty strings are not considered NA values. None is considered a NA
+        value.
 
         >>> idx = pd.Index(['black', '', 'red', None])
         >>> idx

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -1156,7 +1156,7 @@ class Index(IndexOpsMixin, PandasObject):
         >>> idx = pd.Index(['Ant', 'Bear', 'Cow'], name='animal')
         >>> idx.to_frame()
             animal
-        animal
+        animal        
         Ant       Ant
         Bear     Bear
         Cow       Cow

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -1156,7 +1156,7 @@ class Index(IndexOpsMixin, PandasObject):
         >>> idx = pd.Index(['Ant', 'Bear', 'Cow'], name='animal')
         >>> idx.to_frame()
             animal
-        animal        
+        animal
         Ant       Ant
         Bear     Bear
         Cow       Cow

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -2022,18 +2022,46 @@ class Index(IndexOpsMixin, PandasObject):
 
     def isna(self):
         """
-        Detect missing values
+        Detect missing values.
+
+        Return a boolean same-sized object indicating if the values are NA.
+        NA values, such as None or :attr:`numpy.NaN`, get mapped to True values.
+        Everything else get mapped to False values. Characters such as empty
+        strings `''` or :attr:`numpy.inf` are not considered NA values
+        (unless you set :attr:`pandas.options.mode.use_inf_as_na` `= True`).
 
         .. versionadded:: 0.20.0
 
         Returns
         -------
-        a boolean array of whether my values are NA
+        numpy.ndarray
+            A boolean array of whether my values are NA
 
         See also
         --------
-        isnull : alias of isna
+        pandas.Index.isnull : alias of isna
+        pandas.Index.notna : boolean inverse of isna
+        pandas.Index.dropna : omit entries with missing values
         pandas.isna : top-level isna
+
+        Examples
+        --------
+        Show which entries in a pandas.Index are NA. The result is a
+        array.
+
+        >>> idx = pd.Index([5.2, 6.0, np.NaN])
+        >>> idx
+        Float64Index([5.2, 6.0, nan], dtype='float64')
+        >>> idx.isna()
+        array([False, False,  True])
+
+        Empty strings are not considered NA values. None is considered NA value.
+
+        >>> idx = pd.Index(['black', '', 'red', None])
+        >>> idx
+        Index(['black', '', 'red', None], dtype='object')
+        >>> idx.isna()
+        array([False, False, False,  True])
         """
         return self._isnan
     isnull = isna

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -1156,7 +1156,7 @@ class Index(IndexOpsMixin, PandasObject):
         >>> idx = pd.Index(['Ant', 'Bear', 'Cow'], name='animal')
         >>> idx.to_frame()
             animal
-        animal       
+        animal
         Ant       Ant
         Bear     Bear
         Cow       Cow
@@ -2022,48 +2022,18 @@ class Index(IndexOpsMixin, PandasObject):
 
     def isna(self):
         """
-        Detect missing values.
-
-        Return a boolean same-sized object indicating if the values are NA.
-        NA values, such as None or :attr:`numpy.NaN`, get mapped to True
-        values.
-        Everything else get mapped to False values. Characters such as empty
-        strings `''` or :attr:`numpy.inf` are not considered NA values
-        (unless you set :attr:`pandas.options.mode.use_inf_as_na` `= True`).
+        Detect missing values
 
         .. versionadded:: 0.20.0
 
         Returns
         -------
-        numpy.ndarray
-            A boolean array of whether my values are NA
+        a boolean array of whether my values are NA
 
         See also
         --------
-        pandas.Index.isnull : alias of isna
-        pandas.Index.notna : boolean inverse of isna
-        pandas.Index.dropna : omit entries with missing values
+        isnull : alias of isna
         pandas.isna : top-level isna
-
-        Examples
-        --------
-        Show which entries in a pandas.Index are NA. The result is a
-        array.
-
-        >>> idx = pd.Index([5.2, 6.0, np.NaN])
-        >>> idx
-        Float64Index([5.2, 6.0, nan], dtype='float64')
-        >>> idx.isna()
-        array([False, False,  True])
-
-        Empty strings are not considered NA values. None is considered a NA
-        value.
-
-        >>> idx = pd.Index(['black', '', 'red', None])
-        >>> idx
-        Index(['black', '', 'red', None], dtype='object')
-        >>> idx.isna()
-        array([False, False, False,  True])
         """
         return self._isnan
     isnull = isna

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -1156,7 +1156,7 @@ class Index(IndexOpsMixin, PandasObject):
         >>> idx = pd.Index(['Ant', 'Bear', 'Cow'], name='animal')
         >>> idx.to_frame()
             animal
-        animal
+        animal       
         Ant       Ant
         Bear     Bear
         Cow       Cow


### PR DESCRIPTION
Checklist for the pandas documentation sprint (ignore this if you are doing
an unrelated PR):

- [x] PR title is "DOC: update the <your-function-or-method> docstring"
- [x] The validation script passes: `scripts/validate_docstrings.py <your-function-or-method>`
- [x] The PEP8 style check passes: `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] The html version looks good: `python doc/make.py --single <your-function-or-method>`
- [x] It has been proofread on language by another sprint participant

Two Validations for pandas.DataFrame.notna and pandas.Series.notna (shared docs).
```
################################################################################
###################### Docstring (pandas.DataFrame.notna) ######################
################################################################################

Detect existing (non-missing) values.

Return a boolean same-sized object indicating if the values are not NA.
Non-missing values get mapped to True. Characters such as empty
strings `''` or :attr:`numpy.inf` are not considered NA values
(unless you set :attr:`pandas.options.mode.use_inf_as_na` `= True`).
NA values, such as None or :attr:`numpy.NaN`, get mapped to False
values.

Returns
-------
bool of type DataFrame
    Mask of True/False values for each element in DataFrame that
    indicates whether an element is not an NA value

See Also
--------
DataFrame.notnull : alias of notna
DataFrame.isna : boolean inverse of notna
DataFrame.dropna : omit axes labels with missing values
notna : top-level notna

Examples
--------
Show which entries in a DataFrame are not NA.

>>> df = pd.DataFrame({'age': [5, 6, np.NaN],
...                    'born': [pd.NaT, pd.Timestamp('1939-05-27'),
...                             pd.Timestamp('1940-04-25')],
...                    'name': ['Alfred', 'Batman', ''],
...                    'toy': [None, 'Batmobile', 'Joker']})
>>> df
   age       born    name        toy
0  5.0        NaT  Alfred       None
1  6.0 1939-05-27  Batman  Batmobile
2  NaN 1940-04-25              Joker

>>> df.notna()
     age   born  name    toy
0   True  False  True  False
1   True   True  True   True
2  False   True  True   True

Show which entries in a Series are not NA.

>>> ser = pd.Series([5, 6, np.NaN])
>>> ser
0    5.0
1    6.0
2    NaN
dtype: float64

>>> ser.notna()
0     True
1     True
2    False
dtype: bool

################################################################################
################################## Validation ##################################
################################################################################

Docstring for "pandas.DataFrame.notna" correct. :)
```

```
################################################################################
####################### Docstring (pandas.Series.notna)  #######################
################################################################################

Detect existing (non-missing) values.

Return a boolean same-sized object indicating if the values are not NA.
Non-missing values get mapped to True. Characters such as empty
strings `''` or :attr:`numpy.inf` are not considered NA values
(unless you set :attr:`pandas.options.mode.use_inf_as_na` `= True`).
NA values, such as None or :attr:`numpy.NaN`, get mapped to False
values.

Returns
-------
bool of type Series
    Mask of True/False values for each element in Series that
    indicates whether an element is not an NA value

See Also
--------
Series.notnull : alias of notna
Series.isna : boolean inverse of notna
Series.dropna : omit axes labels with missing values
notna : top-level notna

Examples
--------
Show which entries in a DataFrame are not NA.

>>> df = pd.DataFrame({'age': [5, 6, np.NaN],
...                    'born': [pd.NaT, pd.Timestamp('1939-05-27'),
...                             pd.Timestamp('1940-04-25')],
...                    'name': ['Alfred', 'Batman', ''],
...                    'toy': [None, 'Batmobile', 'Joker']})
>>> df
   age       born    name        toy
0  5.0        NaT  Alfred       None
1  6.0 1939-05-27  Batman  Batmobile
2  NaN 1940-04-25              Joker

>>> df.notna()
     age   born  name    toy
0   True  False  True  False
1   True   True  True   True
2  False   True  True   True

Show which entries in a Series are not NA.

>>> ser = pd.Series([5, 6, np.NaN])
>>> ser
0    5.0
1    6.0
2    NaN
dtype: float64

>>> ser.notna()
0     True
1     True
2    False
dtype: bool

################################################################################
################################## Validation ##################################
################################################################################

Docstring for "pandas.Series.notna" correct. :)
```
