### PR TITLE
DOC: update the docstring of pandas.DataFrame.to_dict

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -936,14 +936,14 @@ class DataFrame(NDFrame):
         orient : str {'dict', 'list', 'series', 'split', 'records', 'index'}
             Determines the type of the values of the dictionary.
 
-            - dict (default) : dict like {column -> {index -> value}}
-            - list : dict like {column -> [values]}
-            - series : dict like {column -> Series(values)}
-            - split : dict like
-              {index -> [index], columns -> [columns], data -> [values]}
-            - records : list like
+            - 'dict' (default) : dict like {column -> {index -> value}}
+            - 'list' : dict like {column -> [values]}
+            - 'series' : dict like {column -> Series(values)}
+            - 'split' : dict like
+              {index' -> [index], columns -> [columns], data -> [values]}
+            - 'records' : list like
               [{column -> value}, ... , {column -> value}]
-            - index : dict like {index -> {column -> value}}
+            - 'index' : dict like {index -> {column -> value}}
 
             Abbreviations are allowed. `s` indicates `series` and `sp`
             indicates `split`.
@@ -962,7 +962,7 @@ class DataFrame(NDFrame):
 
         See Also
         --------
-        from_dict: create a DataFrame from a dictionary
+        DataFrame.from_dict: create a DataFrame from a dictionary
 
         Examples
         --------

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -927,8 +927,7 @@ class DataFrame(NDFrame):
         """
         Convert DataFrame to dictionary.
 
-        Method converting the DataFrame to a Python dictionary,
-        the type of the key-value pairs can be customized with
+        The type of the key-value pairs can be customized with
         the parameters (see below).
 
         Parameters
@@ -940,7 +939,7 @@ class DataFrame(NDFrame):
             - 'list' : dict like {column -> [values]}
             - 'series' : dict like {column -> Series(values)}
             - 'split' : dict like
-              {index' -> [index], columns -> [columns], data -> [values]}
+              {'index' -> [index], 'columns' -> [columns], 'data' -> [values]}
             - 'records' : list like
               [{column -> value}, ... , {column -> value}]
             - 'index' : dict like {index -> {column -> value}}
@@ -954,7 +953,7 @@ class DataFrame(NDFrame):
             instance of the mapping type you want.  If you want a
             collections.defaultdict, you must pass it initialized.
 
-            .. versionadded:: 0.21.0.
+            .. versionadded:: 0.21.0
 
         Returns
         -------
@@ -963,6 +962,7 @@ class DataFrame(NDFrame):
         See Also
         --------
         DataFrame.from_dict: create a DataFrame from a dictionary
+        DataFrame.to_json: convert a DataFrame to JSON format
 
         Examples
         --------

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -924,7 +924,12 @@ class DataFrame(NDFrame):
         return cls(data, index=index, columns=columns, dtype=dtype)
 
     def to_dict(self, orient='dict', into=dict):
-        """Convert DataFrame to dictionary.
+        """
+        Convert DataFrame to dictionary.
+
+        Method converting the DataFrame to a Python dictionary,
+        the type of the key-value pairs can be customized with
+        the parameters (see below).
 
         Parameters
         ----------
@@ -949,16 +954,21 @@ class DataFrame(NDFrame):
             instance of the mapping type you want.  If you want a
             collections.defaultdict, you must pass it initialized.
 
-            .. versionadded:: 0.21.0
+            .. versionadded:: 0.21.0.
 
         Returns
         -------
         result : collections.Mapping like {column -> {index -> value}}
 
+        See Also
+        --------
+        from_dict: create a DataFrame from a dictionary
+
         Examples
         --------
-        >>> df = pd.DataFrame(
-                {'col1': [1, 2], 'col2': [0.5, 0.75]}, index=['a', 'b'])
+        >>> df = pd.DataFrame({'col1': [1, 2],
+        ...                    'col2': [0.5, 0.75]},
+        ...                   index=['a', 'b'])
         >>> df
            col1  col2
         a     1   0.50
@@ -975,9 +985,8 @@ class DataFrame(NDFrame):
         b    0.75
         Name: col2, dtype: float64}
         >>> df.to_dict('split')
-        {'columns': ['col1', 'col2'],
-        'data': [[1.0, 0.5], [2.0, 0.75]],
-        'index': ['a', 'b']}
+        {'index': ['a', 'b'], 'columns': ['col1', 'col2'],
+        'data': [[1.0, 0.5], [2.0, 0.75]]}
         >>> df.to_dict('records')
         [{'col1': 1.0, 'col2': 0.5}, {'col1': 2.0, 'col2': 0.75}]
         >>> df.to_dict('index')
@@ -994,8 +1003,8 @@ class DataFrame(NDFrame):
 
         >>> dd = defaultdict(list)
         >>> df.to_dict('records', into=dd)
-        [defaultdict(<type 'list'>, {'col2': 0.5, 'col1': 1.0}),
-        defaultdict(<type 'list'>, {'col2': 0.75, 'col1': 2.0})]
+        [defaultdict(<class 'list'>, {'col1': 1.0, 'col2': 0.5}),
+        defaultdict(<class 'list'>, {'col1': 2.0, 'col2': 0.75})]
         """
         if not self.columns.is_unique:
             warnings.warn("DataFrame columns are not unique, some "

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -925,10 +925,10 @@ class DataFrame(NDFrame):
 
     def to_dict(self, orient='dict', into=dict):
         """
-        Convert DataFrame to dictionary.
+        Convert the DataFrame to a dictionary.
 
-        The type of the key-value pairs can be customized with
-        the parameters (see below).
+        The type of the key-value pairs can be customized with the parameters
+        (see below).
 
         Parameters
         ----------
@@ -980,15 +980,19 @@ class DataFrame(NDFrame):
 
         >>> df.to_dict('series')
         {'col1': a    1
-        b    2
-        Name: col1, dtype: int64, 'col2': a    0.50
-        b    0.75
-        Name: col2, dtype: float64}
+                 b    2
+                 Name: col1, dtype: int64,
+         'col2': a    0.50
+                 b    0.75
+                 Name: col2, dtype: float64}
+
         >>> df.to_dict('split')
         {'index': ['a', 'b'], 'columns': ['col1', 'col2'],
-        'data': [[1.0, 0.5], [2.0, 0.75]]}
+         'data': [[1.0, 0.5], [2.0, 0.75]]}
+
         >>> df.to_dict('records')
         [{'col1': 1.0, 'col2': 0.5}, {'col1': 2.0, 'col2': 0.75}]
+
         >>> df.to_dict('index')
         {'a': {'col1': 1.0, 'col2': 0.5}, 'b': {'col1': 2.0, 'col2': 0.75}}
 
@@ -997,14 +1001,14 @@ class DataFrame(NDFrame):
         >>> from collections import OrderedDict, defaultdict
         >>> df.to_dict(into=OrderedDict)
         OrderedDict([('col1', OrderedDict([('a', 1), ('b', 2)])),
-                   ('col2', OrderedDict([('a', 0.5), ('b', 0.75)]))])
+                     ('col2', OrderedDict([('a', 0.5), ('b', 0.75)]))])
 
         If you want a `defaultdict`, you need to initialize it:
 
         >>> dd = defaultdict(list)
         >>> df.to_dict('records', into=dd)
         [defaultdict(<class 'list'>, {'col1': 1.0, 'col2': 0.5}),
-        defaultdict(<class 'list'>, {'col1': 2.0, 'col2': 0.75})]
+         defaultdict(<class 'list'>, {'col1': 2.0, 'col2': 0.75})]
         """
         if not self.columns.is_unique:
             warnings.warn("DataFrame columns are not unique, some "


### PR DESCRIPTION
Checklist for the pandas documentation sprint (ignore this if you are doing
an unrelated PR):

- [X] PR title is "DOC: update the <your-function-or-method> docstring"
- [X] The validation script passes: `scripts/validate_docstrings.py <your-function-or-method>`
- [X] The PEP8 style check passes: `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [X] The html version looks good: `python doc/make.py --single <your-function-or-method>`
- [X] It has been proofread on language by another sprint participant

Please include the output of the validation script below between the "```" ticks:

```
################################################################################

##################### Docstring (pandas.DataFrame.to_dict) #####################

################################################################################


Convert DataFrame to dictionary.

Method converting the DataFrame to a Python dictionary,
the type of the key-value pairs can be customized with
the parameters (see below).

Parameters
----------
orient : str {'dict', 'list', 'series', 'split', 'records', 'index'}
    Determines the type of the values of the dictionary.

    - dict (default) : dict like {column -> {index -> value}}
    - list : dict like {column -> [values]}
    - series : dict like {column -> Series(values)}
    - split : dict like
      {index -> [index], columns -> [columns], data -> [values]}
    - records : list like
      [{column -> value}, ... , {column -> value}]
    - index : dict like {index -> {column -> value}}

    Abbreviations are allowed. `s` indicates `series` and `sp`
    indicates `split`.

into : class, default dict
    The collections.Mapping subclass used for all Mappings
    in the return value.  Can be the actual class or an empty
    instance of the mapping type you want.  If you want a
    collections.defaultdict, you must pass it initialized.

    .. versionadded:: 0.21.0.

Returns
-------
result : collections.Mapping like {column -> {index -> value}}

See Also
--------
from_dict: create a DataFrame from a dictionary

Examples
--------
>>> df = pd.DataFrame({'col1': [1, 2],
...                    'col2': [0.5, 0.75]},
...                   index=['a', 'b'])
>>> df
   col1  col2
a     1   0.50
b     2   0.75
>>> df.to_dict()
{'col1': {'a': 1, 'b': 2}, 'col2': {'a': 0.5, 'b': 0.75}}

You can specify the return orientation.

>>> df.to_dict('series')
{'col1': a    1
b    2
Name: col1, dtype: int64, 'col2': a    0.50
b    0.75
Name: col2, dtype: float64}
>>> df.to_dict('split')
{'index': ['a', 'b'], 'columns': ['col1', 'col2'],
'data': [[1.0, 0.5], [2.0, 0.75]]}
>>> df.to_dict('records')
[{'col1': 1.0, 'col2': 0.5}, {'col1': 2.0, 'col2': 0.75}]
>>> df.to_dict('index')
{'a': {'col1': 1.0, 'col2': 0.5}, 'b': {'col1': 2.0, 'col2': 0.75}}

You can also specify the mapping type.

>>> from collections import OrderedDict, defaultdict
>>> df.to_dict(into=OrderedDict)
OrderedDict([('col1', OrderedDict([('a', 1), ('b', 2)])),
           ('col2', OrderedDict([('a', 0.5), ('b', 0.75)]))])

If you want a `defaultdict`, you need to initialize it:

>>> dd = defaultdict(list)
>>> df.to_dict('records', into=dd)
[defaultdict(<class 'list'>, {'col1': 1.0, 'col2': 0.5}),
defaultdict(<class 'list'>, {'col1': 2.0, 'col2': 0.75})]

################################################################################

################################## Validation ##################################

################################################################################


Docstring for "pandas.DataFrame.to_dict" correct. :)
```

If the validation script still gives errors, but you think there is a good reason
to deviate in this case (and there are certainly such cases), please state this
explicitly.
