### PR TITLE
DOC: update the DataFrame.plot.line docstring

### DIFF
--- a/pandas/plotting/_core.py
+++ b/pandas/plotting/_core.py
@@ -2704,18 +2704,55 @@ class FramePlotMethods(BasePlotMethods):
 
     def line(self, x=None, y=None, **kwds):
         """
-        Line plot
+        Plot DataFrame columns as lines.
+
+        This function is useful to plot lines using DataFrame's values
+        as coordinates.
 
         Parameters
         ----------
-        x, y : label or position, optional
-            Coordinates for each point.
-        `**kwds` : optional
-            Keyword arguments to pass on to :py:meth:`pandas.DataFrame.plot`.
+        x : int or str, optional
+            Columns to use for the horizontal axis.
+            Either the location or the label of the columns to be used.
+            By default, it will use the `DataFrame` indices.
+        y : int, str, or list of them, optional
+            The values to be plotted.
+            Either the location or the label of the columns to be used.
+            By default, it will use the remaining DataFrame numeric columns.
+        kwds : optional
+            Keyword arguments to pass on to :py:meth:pandas.DataFrame.plot.
 
         Returns
         -------
-        axes : matplotlib.AxesSubplot or np.array of them
+        axes : :class:matplotlib.AxesSubplot or :class:numpy.ndarray of
+               them.
+
+        See Also
+        --------
+        matplotlib.pyplot.plot : Plot y versus x as lines and/or markers.
+
+        Examples
+        --------
+
+        .. plot::
+            :context: close-figs
+
+            The following example shows the populations for some animals
+            over the years.
+
+            >>> df = pd.DataFrame({
+            ...    'pig': [20, 18, 489, 675, 1776],
+            ...    'horse': [4, 25, 281, 600, 1900]
+            ...    }, index=[1990, 1997, 2003, 2009, 2014])
+            >>> lines = df.plot.line()
+
+        .. plot::
+            :context: close-figs
+
+            The following example shows the relationship between both
+            populations.
+
+            >>> lines = df.plot.line(x='pig', y='horse')
         """
         return self(kind='line', x=x, y=y, **kwds)
 

--- a/pandas/plotting/_core.py
+++ b/pandas/plotting/_core.py
@@ -2787,7 +2787,7 @@ class FramePlotMethods(BasePlotMethods):
             The values to be plotted.
             Either the location or the label of the columns to be used.
             By default, it will use the remaining DataFrame numeric columns.
-        **kwds : optional
+        **kwds
             Keyword arguments to pass on to :meth:`pandas.DataFrame.plot`.
 
         Returns

--- a/pandas/plotting/_core.py
+++ b/pandas/plotting/_core.py
@@ -2774,7 +2774,7 @@ class FramePlotMethods(BasePlotMethods):
             The values to be plotted.
             Either the location or the label of the columns to be used.
             By default, it will use the remaining DataFrame numeric columns.
-        kwds : optional
+        **kwds : optional
             Keyword arguments to pass on to :meth:`pandas.DataFrame.plot`.
 
         Returns

--- a/pandas/plotting/_core.py
+++ b/pandas/plotting/_core.py
@@ -2714,18 +2714,18 @@ class FramePlotMethods(BasePlotMethods):
         x : int or str, optional
             Columns to use for the horizontal axis.
             Either the location or the label of the columns to be used.
-            By default, it will use the `DataFrame` indices.
+            By default, it will use the DataFrame indices.
         y : int, str, or list of them, optional
             The values to be plotted.
             Either the location or the label of the columns to be used.
             By default, it will use the remaining DataFrame numeric columns.
         kwds : optional
-            Keyword arguments to pass on to :py:meth:pandas.DataFrame.plot.
+            Keyword arguments to pass on to :meth:`pandas.DataFrame.plot`.
 
         Returns
         -------
-        axes : :class:matplotlib.AxesSubplot or :class:numpy.ndarray of
-               them.
+        axes : :class:`matplotlib.axes.Axes` or :class:`numpy.ndarray`
+            Returns an ndarray when ``subplots=True``.
 
         See Also
         --------
@@ -2745,6 +2745,15 @@ class FramePlotMethods(BasePlotMethods):
             ...    'horse': [4, 25, 281, 600, 1900]
             ...    }, index=[1990, 1997, 2003, 2009, 2014])
             >>> lines = df.plot.line()
+
+        .. plot::
+           :context: close-figs
+
+           An example with subplots, so an array of axes is returned.
+
+           >>> axes = df.plot.line(subplots=True)
+           >>> type(axes)
+           <class 'numpy.ndarray'>
 
         .. plot::
             :context: close-figs


### PR DESCRIPTION
Checklist for the pandas documentation sprint (ignore this if you are doing
an unrelated PR):

- [X] PR title is "DOC: update the <your-function-or-method> docstring"
- [X] The validation script passes: `scripts/validate_docstrings.py <your-function-or-method>`
- [X] The PEP8 style check passes: `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [X] The html version looks good: `python doc/make.py --single <your-function-or-method>`
- [X] It has been proofread on language by another sprint participant

Please include the output of the validation script below between the "```" ticks:

```❯ python scripts/validate_docstrings.py pandas.DataFrame.plot.line

################################################################################
#################### Docstring (pandas.DataFrame.plot.line) ####################
################################################################################

Plot DataFrame columns as lines.

This function is useful to plot lines using DataFrame's values
as coordinates.

Parameters
----------
x : int or str, optional
    Columns to use for the horizontal axis.
    Either the location or the label of the columns to be used.
    By default, it will use the `DataFrame` indices.
y : int, str, or list of them, optional
    The values to be plotted.
    Either the location or the label of the columns to be used.
    By default, it will use the remaining DataFrame numeric columns.
kwds : optional
    Keyword arguments to pass on to :py:meth:pandas.DataFrame.plot.

Returns
-------
axes : :class:matplotlib.AxesSubplot or :class:numpy.ndarray of
       them.

See Also
--------
matplotlib.pyplot.plot : Plot y versus x as lines and/or markers.

Examples
--------

.. plot::
    :context: close-figs

    The following example shows the populations for some animals
    over the years.

    >>> df = pd.DataFrame({
    ...    'pig': [20, 18, 489, 675, 1776],
    ...    'horse': [4, 25, 281, 600, 1900]
    ...    }, index=[1990, 1997, 2003, 2009, 2014])
    >>> lines = df.plot.line()

.. plot::
    :context: close-figs

    The following example shows the relationship between both
    populations.

    >>> lines = df.plot.line(x='pig', y='horse')

################################################################################
################################## Validation ##################################
################################################################################

Docstring for "pandas.DataFrame.plot.line" correct. :)
```

If the validation script still gives errors, but you think there is a good reason
to deviate in this case (and there are certainly such cases), please state this
explicitly.


