### PR TITLE
DOC: update the pandas.Series.set_axis docstring

### DIFF
--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -487,11 +487,19 @@ class NDFrame(PandasObject, SelectionMixin):
 
         return new_axes
 
-    _shared_docs['set_axis'] = """
+    def set_axis(self, labels, axis=0, inplace=None):
+        """
         Assign desired index to given axis.
 
-        Indexes for columns or rows can be changed by assigning
+        Indexes for column or row labels can be changed by assigning
         a list-like or Index.
+
+        .. versionchanged:: 0.21.0
+
+           The signature is now `labels` and `axis`, consistent with
+           the rest of pandas API. Previously, the `axis` and `labels`
+           arguments were respectively the first and second positional
+           arguments.
 
         Parameters
         ----------
@@ -499,19 +507,17 @@ class NDFrame(PandasObject, SelectionMixin):
             The values for the new index.
 
         axis : {0 or 'index', 1 or 'columns'}, default 0
-            The value 0 indentify the rows, 1 identify the columns.
+            The axis to update. The value 0 identifies the rows, and 1
+            identifies the columns.
 
         inplace : boolean, default None
             Whether to return a new %(klass)s instance.
 
-            WARNING: inplace=None currently falls back to to True, but
-            in a future version, will default to False.  Use inplace=True
-            explicitly rather than relying on the default.
+            .. warning::
 
-            .. versionadded:: 0.21.0
-                The signature is make consistent to the rest of the API.
-                Previously, the "axis" and "labels" arguments were respectively
-                the first and second positional arguments.
+               ``inplace=None`` currently falls back to to True, but in a
+               future version, will default to False. Use inplace=True
+               explicitly rather than relying on the default.
 
         Returns
         -------
@@ -524,38 +530,58 @@ class NDFrame(PandasObject, SelectionMixin):
 
         Examples
         --------
+        **Series**
+
         >>> s = pd.Series([1, 2, 3])
         >>> s
         0    1
         1    2
         2    3
         dtype: int64
+
         >>> s.set_axis(['a', 'b', 'c'], axis=0, inplace=False)
         a    1
         b    2
         c    3
         dtype: int64
+
+        The original object is not modified.
+
+        >>> s
+        0    1
+        1    2
+        2    3
+        dtype: int64
+
+        **DataFrame**
+
         >>> df = pd.DataFrame({"A": [1, 2, 3], "B": [4, 5, 6]})
-        >>> df.set_axis(['a', 'b', 'c'], axis=0, inplace=False)
+
+        Change the row labels.
+
+        >>> df.set_axis(['a', 'b', 'c'], axis='index', inplace=False)
            A  B
         a  1  4
         b  2  5
         c  3  6
-        >>> df.set_axis(['I', 'II'], axis=1, inplace=False)
+
+        Change the column labels.
+
+        >>> df.set_axis(['I', 'II'], axis='columns', inplace=False)
            I  II
         0  1   4
         1  2   5
         2  3   6
-        >>> df.set_axis(['i', 'ii'], axis=1, inplace=True)
+
+        Now, update the labels inplace.
+
+        >>> df.set_axis(['i', 'ii'], axis='columns', inplace=True)
         >>> df
            i  ii
         0  1   4
         1  2   5
         2  3   6
         """
-
-    @Appender(_shared_docs['set_axis'] % dict(klass='NDFrame'))
-    def set_axis(self, labels, axis=0, inplace=None):
         if is_scalar(labels):
             warnings.warn(
                 'set_axis now takes "labels" as first argument, and '

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -487,13 +487,20 @@ class NDFrame(PandasObject, SelectionMixin):
 
         return new_axes
 
-    _shared_docs['set_axis'] = """Assign desired index to given axis
+    _shared_docs['set_axis'] = """
+        Assign desired index to given axis.
+
+        Indexes for columns or rows can be changed by assigning
+        a list-like or Index.
 
         Parameters
         ----------
-        labels: list-like or Index
-            The values for the new index
-        axis : int or string, default 0
+        labels : list-like, Index
+            The values for the new index.
+
+        axis : {0 or 'index', 1 or 'columns'}, default 0
+            The value 0 indentify the rows, 1 identify the columns.
+
         inplace : boolean, default None
             Whether to return a new %(klass)s instance.
 
@@ -501,10 +508,10 @@ class NDFrame(PandasObject, SelectionMixin):
             in a future version, will default to False.  Use inplace=True
             explicitly rather than relying on the default.
 
-        .. versionadded:: 0.21.0
-            The signature is make consistent to the rest of the API.
-            Previously, the "axis" and "labels" arguments were respectively
-            the first and second positional arguments.
+            .. versionadded:: 0.21.0
+                The signature is make consistent to the rest of the API.
+                Previously, the "axis" and "labels" arguments were respectively
+                the first and second positional arguments.
 
         Returns
         -------
@@ -513,7 +520,7 @@ class NDFrame(PandasObject, SelectionMixin):
 
         See Also
         --------
-        pandas.NDFrame.rename
+        pandas.DataFrame.rename_axis : Alter the name of the index or columns.
 
         Examples
         --------
@@ -545,7 +552,6 @@ class NDFrame(PandasObject, SelectionMixin):
         0  1   4
         1  2   5
         2  3   6
-
         """
 
     @Appender(_shared_docs['set_axis'] % dict(klass='NDFrame'))


### PR DESCRIPTION
Checklist for the pandas documentation sprint (ignore this if you are doing
an unrelated PR):

- [x] PR title is "DOC: update the <your-function-or-method> docstring"
- [x] The validation script passes: `scripts/validate_docstrings.py <your-function-or-method>`
- [x] The PEP8 style check passes: `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] The html version looks good: `python doc/make.py --single <your-function-or-method>`
- [x] It has been proofread on language by another sprint participant

Please include the output of the validation script below between the "```" ticks:

```


################################################################################
###################### Docstring (pandas.Series.set_axis) ######################
################################################################################

Assign desired index to given axis.

Indexes for columns or rows can be changed by assigning
a list-like or Index.

Parameters
----------
labels : list-like, Index
    The values for the new index.

axis : int, default 0
    The value 0 indentify the rows, 1 identify the columns.

inplace : boolean, default None
    Whether to return a new NDFrame instance.

    WARNING: inplace=None currently falls back to to True, but
    in a future version, will default to False.  Use inplace=True
    explicitly rather than relying on the default.

    .. versionadded:: 0.21.0
        The signature is make consistent to the rest of the API.
        Previously, the "axis" and "labels" arguments were respectively
        the first and second positional arguments.

Returns
-------
renamed : NDFrame or None
    An object of same type as caller if inplace=False, None otherwise.

See Also
--------
pandas.DataFrame.rename_axis : Alter the name of the index or columns.

Examples
--------
>>> s = pd.Series([1, 2, 3])
>>> s
0    1
1    2
2    3
dtype: int64
>>> s.set_axis(['a', 'b', 'c'], axis=0, inplace=False)
a    1
b    2
c    3
dtype: int64
>>> df = pd.DataFrame({"A": [1, 2, 3], "B": [4, 5, 6]})
>>> df.set_axis(['a', 'b', 'c'], axis=0, inplace=False)
   A  B
a  1  4
b  2  5
c  3  6
>>> df.set_axis(['I', 'II'], axis=1, inplace=False)
   I  II
0  1   4
1  2   5
2  3   6
>>> df.set_axis(['i', 'ii'], axis=1, inplace=True)
>>> df
   i  ii
0  1   4
1  2   5
2  3   6

################################################################################
################################## Validation ##################################
################################################################################

Errors found:
	Private classes (['NDFrame']) should not be mentioned in public docstring.
```

If the validation script still gives errors, but you think there is a good reason
to deviate in this case (and there are certainly such cases), please state this
explicitly.
