### PR TITLE
DOC: update the pandas.Index.is_categorical docstring

### DIFF
--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -1472,20 +1472,21 @@ class Index(IndexOpsMixin, PandasObject):
 
     def is_categorical(self):
         """
-        Check if the index type is categorical.
+        Check if the Index type is categorical.
 
-        The given object must be a pandas dataframe or pandas Series.
+        The given object must be a pandas DataFrame or pandas Series.
 
         Returns
-        ----------
+        -------
         boolean
             True if index is categorical.
 
         Examples
         --------
-        >>> s = pd.Series(["Watermelon","Orange","Apple",
+        >>> s = pd.Series(["Watermelon", "Orange", "Apple",
         ...                 "Watermelon"]).astype('category')
-        >>> df = pd.DataFrame({'Weight (grams)':[2000,230,160,1300]}, index=s)
+        >>> df = pd.DataFrame({'Weight (grams)': [2000, 230, 160, 1300]},
+        ...                     index=s)
         >>> df
                     Weight (grams)
         Watermelon            2000
@@ -1495,14 +1496,14 @@ class Index(IndexOpsMixin, PandasObject):
         >>> df.index.is_categorical()
         True
 
-        >>> df = pd.Series(["Peter","Adam","Elisabeth","Margareth"])
-        >>> df
+        >>> s = pd.Series(["Peter", "Adam", "Elisabeth", "Margareth"])
+        >>> s
         0        Peter
         1         Adam
         2    Elisabeth
         3    Margareth
         dtype: object
-        >>> df.index.is_categorical()
+        >>> s.index.is_categorical()
         False
         """
         return self.inferred_type in ['categorical']

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -1156,7 +1156,7 @@ class Index(IndexOpsMixin, PandasObject):
         >>> idx = pd.Index(['Ant', 'Bear', 'Cow'], name='animal')
         >>> idx.to_frame()
             animal
-        animal       
+        animal
         Ant       Ant
         Bear     Bear
         Cow       Cow
@@ -1471,6 +1471,40 @@ class Index(IndexOpsMixin, PandasObject):
         return is_object_dtype(self.dtype)
 
     def is_categorical(self):
+        """
+        Check if the index type is categorical.
+
+        The given object must be a pandas dataframe or pandas Series.
+
+        Returns
+        ----------
+        boolean
+            True if index is categorical.
+
+        Examples
+        --------
+        >>> s = pd.Series(["Watermelon","Orange","Apple",
+        ...                 "Watermelon"]).astype('category')
+        >>> df = pd.DataFrame({'Weight (grams)':[2000,230,160,1300]}, index=s)
+        >>> df
+                    Weight (grams)
+        Watermelon            2000
+        Orange                 230
+        Apple                  160
+        Watermelon            1300
+        >>> df.index.is_categorical()
+        True
+
+        >>> df = pd.Series(["Peter","Adam","Elisabeth","Margareth"])
+        >>> df
+        0        Peter
+        1         Adam
+        2    Elisabeth
+        3    Margareth
+        dtype: object
+        >>> df.index.is_categorical()
+        False
+        """
         return self.inferred_type in ['categorical']
 
     def is_interval(self):

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -1474,7 +1474,8 @@ class Index(IndexOpsMixin, PandasObject):
         """
         Check if the Index type is categorical.
 
-        The given object must be a pandas DataFrame or pandas Series.
+        The given object must be a pandas DataFrame index or a pandas Series
+        index.
 
         Returns
         -------
@@ -1483,25 +1484,21 @@ class Index(IndexOpsMixin, PandasObject):
 
         Examples
         --------
-        >>> s = pd.Series(["Watermelon", "Orange", "Apple",
-        ...                 "Watermelon"]).astype('category')
-        >>> df = pd.DataFrame({'Weight (grams)': [2000, 230, 160, 1300]},
-        ...                     index=s)
-        >>> df
-                    Weight (grams)
-        Watermelon            2000
-        Orange                 230
-        Apple                  160
-        Watermelon            1300
-        >>> df.index.is_categorical()
+        >>> idx = pd.Index(["Watermelon", "Orange", "Apple",
+        ...                 "Watermelon"]).astype("category")
+        >>> idx.is_categorical()
         True
 
-        >>> s = pd.Series(["Peter", "Adam", "Elisabeth", "Margareth"])
+        >>> idx = pd.Index([1, 3, 5, 7])
+        >>> idx.is_categorical()
+        False
+
+        >>> s = pd.Series(["Peter", "Víctor", "Elisabeth", "Mar"])
         >>> s
         0        Peter
-        1         Adam
+        1       Víctor
         2    Elisabeth
-        3    Margareth
+        3          Mar
         dtype: object
         >>> s.index.is_categorical()
         False

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -1472,15 +1472,16 @@ class Index(IndexOpsMixin, PandasObject):
 
     def is_categorical(self):
         """
-        Check if the Index type is categorical.
-
-        The given object must be a pandas DataFrame index or a pandas Series
-        index.
+        Check if the Index holds categorical data.
 
         Returns
         -------
         boolean
-            True if index is categorical.
+            True if the Index is categorical.
+
+        See Also
+        --------
+        CategoricalIndex : Index for categorical data.
 
         Examples
         --------

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -1155,8 +1155,8 @@ class Index(IndexOpsMixin, PandasObject):
         --------
         >>> idx = pd.Index(['Ant', 'Bear', 'Cow'], name='animal')
         >>> idx.to_frame()
-            animal
-        animal       
+               animal
+        animal
         Ant       Ant
         Bear     Bear
         Cow       Cow

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -1156,7 +1156,7 @@ class Index(IndexOpsMixin, PandasObject):
         >>> idx = pd.Index(['Ant', 'Bear', 'Cow'], name='animal')
         >>> idx.to_frame()
             animal
-        animal
+        animal       
         Ant       Ant
         Bear     Bear
         Cow       Cow


### PR DESCRIPTION
Checklist for the pandas documentation sprint (ignore this if you are doing
an unrelated PR):

- [X] PR title is "DOC: update the <your-function-or-method> docstring"
- [ ] The validation script passes: `scripts/validate_docstrings.py <your-function-or-method>`
- [X] The PEP8 style check passes: `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [X] The html version looks good: `python doc/make.py --single <your-function-or-method>`
- [X] It has been proofread on language by another sprint participant

Please include the output of the validation script below between the "```" ticks:

```
################################################################################
################################## Validation ##################################
################################################################################

Errors found:
        See Also section not found

```

If the validation script still gives errors, but you think there is a good reason
to deviate in this case (and there are certainly such cases), please state this
explicitly.

We think that See Also is not necessary for this function.
