### PR TITLE
DOC: update the str_cat() docstring (Delhi) 

### DIFF
--- a/pandas/core/strings.py
+++ b/pandas/core/strings.py
@@ -52,10 +52,10 @@ def str_cat(arr, others=None, sep=None, na_rep=None):
     Concatenate strings in the Series/Index with given separator.
 
     This function concatenates elements of Series/Index and elements 
-    of lists or list-like objects having same length. 
-    The concatenation is done at corresponding indices of 
-    iterable specified by `Series` when two or more iterables 
-    are present. The final concatenation is done with a given `sep` 
+    of lists or list-like objects having same length.
+    The concatenation is done at corresponding indices of
+    iterable specified by `Series` when two or more iterables
+    are present. The final concatenation is done with a given `sep`
     and a string is returned.
 
     Parameters
@@ -66,7 +66,7 @@ def str_cat(arr, others=None, sep=None, na_rep=None):
         If None, concatenates without any separator.
     na_rep : string or None, default None
         If None, NA in the series are ignored.
-
+        
     Returns
     -------
     concat : Series/Index of objects or str

--- a/pandas/core/strings.py
+++ b/pandas/core/strings.py
@@ -55,14 +55,16 @@ def str_cat(arr, others=None, sep=None, na_rep=None):
     of lists or list-like objects having same length.
     The concatenation is done at corresponding indices of
     iterable specified by `Series` when two or more iterables
-    are present. The final concatenation is done with a given `sep`
-    and a string is returned.
+    are present. If `others` is not being passed then
+    all values in the Series are concatenated in a single string.
+    The final concatenation is done with a given `sep`
+    and a string is returned, `sep` is optional.
 
     Parameters
     ----------
     others : list-like, or list of list-likes
         If None, returns str concatenating strings of the Series.
-    sep : string or None, default None.
+    sep : string or None, default None
         If None, concatenates without any separator.
     na_rep : string or None, default None
         If None, NA in the series are ignored.
@@ -71,12 +73,17 @@ def str_cat(arr, others=None, sep=None, na_rep=None):
     -------
     concat : Series/Index of objects or str
 
+    See Also
+    --------
+    str_split : Split each string in the Series/Index
+
     Examples
     --------
     When ``na_rep`` is `None` (default behavior), NaN value(s)
     in the Series are ignored.
 
-    >>> pd.Series(['a','b',np.nan,'c']).str.cat(sep=' ')
+    >>> s = pd.Series(['a','b',np.nan,'c'])
+    >>> s.str.cat(sep=' ')
     'a b c'
 
     >>> pd.Series(['a','b',np.nan,'c']).str.cat(sep=' ', na_rep='?')

--- a/pandas/core/strings.py
+++ b/pandas/core/strings.py
@@ -51,11 +51,16 @@ def str_cat(arr, others=None, sep=None, na_rep=None):
     """
     Concatenate strings in the Series/Index with given separator.
 
+    This function concatenates elements of Series/Index and elements of lists or list-like objects having same length. 
+    The concatenation is done at corresponding indices of iterable specified by `Series` when two or 
+    more iterables are present. The final concatenation is done with a given `sep` and a string is returned.
+
     Parameters
     ----------
     others : list-like, or list of list-likes
-      If None, returns str concatenating strings of the Series
-    sep : string or None, default None
+        If None, returns str concatenating strings of the Series.
+    sep : string or None, default None.
+        If None, concatenates without any separator.
     na_rep : string or None, default None
         If None, NA in the series are ignored.
 
@@ -68,16 +73,16 @@ def str_cat(arr, others=None, sep=None, na_rep=None):
     When ``na_rep`` is `None` (default behavior), NaN value(s)
     in the Series are ignored.
 
-    >>> Series(['a','b',np.nan,'c']).str.cat(sep=' ')
+    >>> pd.Series(['a','b',np.nan,'c']).str.cat(sep=' ')
     'a b c'
 
-    >>> Series(['a','b',np.nan,'c']).str.cat(sep=' ', na_rep='?')
+    >>> pd.Series(['a','b',np.nan,'c']).str.cat(sep=' ', na_rep='?')
     'a b ? c'
 
     If ``others`` is specified, corresponding values are
     concatenated with the separator. Result will be a Series of strings.
 
-    >>> Series(['a', 'b', 'c']).str.cat(['A', 'B', 'C'], sep=',')
+    >>> pd.Series(['a', 'b', 'c']).str.cat(['A', 'B', 'C'], sep=',')
     0    a,A
     1    b,B
     2    c,C
@@ -85,12 +90,12 @@ def str_cat(arr, others=None, sep=None, na_rep=None):
 
     Otherwise, strings in the Series are concatenated. Result will be a string.
 
-    >>> Series(['a', 'b', 'c']).str.cat(sep=',')
+    >>> pd.Series(['a', 'b', 'c']).str.cat(sep=',')
     'a,b,c'
 
     Also, you can pass a list of list-likes.
 
-    >>> Series(['a', 'b']).str.cat([['x', 'y'], ['1', '2']], sep=',')
+    >>> pd.Series(['a', 'b']).str.cat([['x', 'y'], ['1', '2']], sep=',')
     0    a,x,1
     1    b,y,2
     dtype: object

--- a/pandas/core/strings.py
+++ b/pandas/core/strings.py
@@ -51,7 +51,7 @@ def str_cat(arr, others=None, sep=None, na_rep=None):
     """
     Concatenate strings in the Series/Index with given separator.
 
-    This function concatenates elements of Series/Index and elements 
+    This function concatenates elements of Series/Index and elements
     of lists or list-like objects having same length.
     The concatenation is done at corresponding indices of
     iterable specified by `Series` when two or more iterables
@@ -66,7 +66,7 @@ def str_cat(arr, others=None, sep=None, na_rep=None):
         If None, concatenates without any separator.
     na_rep : string or None, default None
         If None, NA in the series are ignored.
-        
+
     Returns
     -------
     concat : Series/Index of objects or str

--- a/pandas/core/strings.py
+++ b/pandas/core/strings.py
@@ -51,9 +51,12 @@ def str_cat(arr, others=None, sep=None, na_rep=None):
     """
     Concatenate strings in the Series/Index with given separator.
 
-    This function concatenates elements of Series/Index and elements of lists or list-like objects having same length. 
-    The concatenation is done at corresponding indices of iterable specified by `Series` when two or 
-    more iterables are present. The final concatenation is done with a given `sep` and a string is returned.
+    This function concatenates elements of Series/Index and elements 
+    of lists or list-like objects having same length. 
+    The concatenation is done at corresponding indices of 
+    iterable specified by `Series` when two or more iterables 
+    are present. The final concatenation is done with a given `sep` 
+    and a string is returned.
 
     Parameters
     ----------

--- a/pandas/core/strings.py
+++ b/pandas/core/strings.py
@@ -51,18 +51,15 @@ def str_cat(arr, others=None, sep=None, na_rep=None):
     """
     Concatenate strings in the Series/Index with given separator.
 
-    This function concatenates elements of Series/Index and elements
-    of lists or list-like objects having same length.
-    The concatenation is done at corresponding indices of
-    iterable specified by `Series` when two or more iterables
-    are present. If `others` is not being passed then
-    all values in the Series are concatenated in a single string.
-    The final concatenation is done with a given `sep`
-    and a string is returned, `sep` is optional.
+    If `others` is specified, this function concatenates the Series/Index
+    and elements of `others` element-wise.
+    If `others` is not being passed then all values in the Series are
+    concatenated in a single string with a given `sep`.
 
     Parameters
     ----------
-    others : list-like, or list of list-likes
+    others : list-like, or list of list-likes, optional
+        List-likes (or a list of them) of the same length as calling object.
         If None, returns str concatenating strings of the Series.
     sep : string or None, default None
         If None, concatenates without any separator.
@@ -75,21 +72,24 @@ def str_cat(arr, others=None, sep=None, na_rep=None):
 
     See Also
     --------
-    str_split : Split each string in the Series/Index
+    split : Split each string in the Series/Index
 
     Examples
     --------
-    When ``na_rep`` is `None` (default behavior), NaN value(s)
-    in the Series are ignored.
+    When not passing `other`, all values are concatenated into a single
+    string:
 
-    >>> s = pd.Series(['a','b',np.nan,'c'])
+    >>> s = pd.Series(['a', 'b', np.nan, 'c'])
     >>> s.str.cat(sep=' ')
     'a b c'
 
-    >>> pd.Series(['a','b',np.nan,'c']).str.cat(sep=' ', na_rep='?')
+    By default, NA values in the Series are ignored. Using `na_rep`, they
+    can be given a representation:
+
+    >>> pd.Series(['a', 'b', np.nan, 'c']).str.cat(sep=' ', na_rep='?')
     'a b ? c'
 
-    If ``others`` is specified, corresponding values are
+    If `others` is specified, corresponding values are
     concatenated with the separator. Result will be a Series of strings.
 
     >>> pd.Series(['a', 'b', 'c']).str.cat(['A', 'B', 'C'], sep=',')
@@ -97,11 +97,6 @@ def str_cat(arr, others=None, sep=None, na_rep=None):
     1    b,B
     2    c,C
     dtype: object
-
-    Otherwise, strings in the Series are concatenated. Result will be a string.
-
-    >>> pd.Series(['a', 'b', 'c']).str.cat(sep=',')
-    'a,b,c'
 
     Also, you can pass a list of list-likes.
 


### PR DESCRIPTION
Checklist for the pandas documentation sprint (ignore this if you are doing
an unrelated PR):

- [X] PR title is "DOC: update the <your-function-or-method> docstring"
- [X] The validation script passes: `scripts/validate_docstrings.py <your-function-or-method>`
- [X] The PEP8 style check passes: `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [X] The html version looks good: `python doc/make.py --single <your-function-or-method>`
- [X] It has been proofread on language by another sprint participant

Please include the output of the validation script below between the "```" ticks:

```
# paste output of "scripts/validate_docstrings.py <your-function-or-method>" here
"Docstring for "pandas.Series.str.cat" correct. :)"
```

If the validation script still gives errors, but you think there is a good reason
to deviate in this case (and there are certainly such cases), please state this
explicitly.


Checklist for other PRs (remove this part if you are doing a PR for the pandas documentation sprint):

- [ ] closes #xxxx
- [ ] tests added / passed
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
