### PR TITLE
DOC: update the Seriex.idxmax and Series.idxmin docstring

### DIFF
--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -1328,9 +1328,6 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
         """
         Index label of the first occurrence of minimum of values.
 
-        Look for the first occurence of maximum of values and return the
-        index label. When data contains NA/null values, return nan.
-
         Parameters
         ----------
         skipna : boolean, default True
@@ -1359,7 +1356,7 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
 
         See Also
         --------
-        numpy.ndarray.argmin : Return indices of the minimum values
+        numpy.argmin : Return indices of the minimum values
             along the given axis.
         DataFrame.idxmin : Return index of first occurrence of minimum
             over requested axis.
@@ -1368,7 +1365,8 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
 
         Examples
         --------
-        >>> s = pd.Series(data=[1,None,4,1], index=['A','B','C','D'])
+        >>> s = pd.Series(data=[1, None, 4, 1],
+        ...               index=['A' ,'B' ,'C' ,'D'])
         >>> s
         A    1.0
         B    NaN
@@ -1379,7 +1377,10 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
         >>> s.idxmin()
         'A'
 
-        s.idxmin(skipna=False)
+        If skipna=False and there is an NA value in the data,
+        the function returns nan.
+
+        >>> s.idxmin(skipna=False)
         nan
         """
         skipna = nv.validate_argmin_with_skipna(skipna, args, kwargs)
@@ -1391,9 +1392,6 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
     def idxmax(self, axis=0, skipna=True, *args, **kwargs):
         """
         Return index label of the first occurrence of maximum of values.
-
-        Look for the first occurence of maximum of values and return the
-        index label. When data contains NA/null values, return nan.
 
         Parameters
         ----------
@@ -1423,7 +1421,7 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
 
         See Also
         --------
-        numpy.ndarray.argmax : Return indices of the maximum values
+        numpy.argmax : Return indices of the maximum values
             along the given axis.
         DataFrame.idxmax : Return index of first occurrence of maximum
             over requested axis.
@@ -1432,7 +1430,8 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
 
         Examples
         --------
-        >>> s = pd.Series(data=[1,None,4,3,4], index=['A','B','C','D','E'])
+        >>> s = pd.Series(data=[1, None, 4, 3, 4],
+        ...               index=['A', 'B', 'C', 'D', 'E'])
         >>> s
         A    1.0
         B    NaN
@@ -1444,7 +1443,10 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
         >>> s.idxmax()
         'C'
 
-        s.idxmax(skipna=False)
+        If skipna=False and there is an NA value in the data,
+        the function returns nan.
+
+        >>> s.idxmax(skipna=False)
         nan
         """
         skipna = nv.validate_argmax_with_skipna(skipna, args, kwargs)

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -1326,18 +1326,26 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
 
     def idxmin(self, axis=None, skipna=True, *args, **kwargs):
         """
-        Index *label* of the first occurrence of minimum of values.
+        Index label of the first occurrence of minimum of values.
+
+        Look for the first occurence of maximum of values and return the
+        index label. When data contains NA/null values, return nan.
 
         Parameters
         ----------
         skipna : boolean, default True
             Exclude NA/null values. If the entire Series is NA, the result
             will be NA.
+        axis : int, default 0
+            Redundant for application on series.
+        *args, **kwargs :
+            Additional keywors have no effect but might be accepted
+            for compatibility with numpy.
 
         Raises
         ------
         ValueError
-            * If the Series is empty
+            If the Series is empty
 
         Returns
         -------
@@ -1351,8 +1359,28 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
 
         See Also
         --------
-        DataFrame.idxmin
-        numpy.ndarray.argmin
+        numpy.ndarray.argmin : Return indices of the minimum values
+            along the given axis.
+        DataFrame.idxmin : Return index of first occurrence of minimum
+            over requested axis.
+        Series.idxmax : Return index *label* of the first occurrence
+            of maximum of values.
+
+        Examples
+        --------
+        >>> s = pd.Series(data=[1,None,4,1], index=['A','B','C','D'])
+        >>> s
+        A    1.0
+        B    NaN
+        C    4.0
+        D    1.0
+        dtype: float64
+
+        >>> s.idxmin()
+        'A'
+
+        s.idxmin(skipna=False)
+        nan
         """
         skipna = nv.validate_argmin_with_skipna(skipna, args, kwargs)
         i = nanops.nanargmin(com._values_from_object(self), skipna=skipna)
@@ -1360,20 +1388,28 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
             return np.nan
         return self.index[i]
 
-    def idxmax(self, axis=None, skipna=True, *args, **kwargs):
+    def idxmax(self, axis=0, skipna=True, *args, **kwargs):
         """
-        Index *label* of the first occurrence of maximum of values.
+        Return index label of the first occurrence of maximum of values.
+
+        Look for the first occurence of maximum of values and return the
+        index label. When data contains NA/null values, return nan.
 
         Parameters
         ----------
         skipna : boolean, default True
             Exclude NA/null values. If the entire Series is NA, the result
             will be NA.
+        axis : int, default 0
+            Redundant for application on series.
+        *args, **kwargs :
+            Additional keywors have no effect but might be accepted
+            for compatibility with numpy.
 
         Raises
         ------
         ValueError
-            * If the Series is empty
+            If the Series is empty
 
         Returns
         -------
@@ -1387,8 +1423,29 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
 
         See Also
         --------
-        DataFrame.idxmax
-        numpy.ndarray.argmax
+        numpy.ndarray.argmax : Return indices of the maximum values
+            along the given axis.
+        DataFrame.idxmax : Return index of first occurrence of maximum
+            over requested axis.
+        Series.idxmin : Return index *label* of the first occurrence
+            of minimum of values.
+
+        Examples
+        --------
+        >>> s = pd.Series(data=[1,None,4,3,4], index=['A','B','C','D','E'])
+        >>> s
+        A    1.0
+        B    NaN
+        C    4.0
+        D    3.0
+        E    4.0
+        dtype: float64
+
+        >>> s.idxmax()
+        'C'
+
+        s.idxmax(skipna=False)
+        nan
         """
         skipna = nv.validate_argmax_with_skipna(skipna, args, kwargs)
         i = nanops.nanargmax(com._values_from_object(self), skipna=skipna)

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -1381,7 +1381,7 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
         >>> s.idxmin()
         'A'
 
-        If 'skipna' is False and there is an NA value in the data,
+        If `skipna` is False and there is an NA value in the data,
         the function returns ``nan``.
 
         >>> s.idxmin(skipna=False)
@@ -1451,7 +1451,7 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
         >>> s.idxmax()
         'C'
 
-        If 'skipna' is False and there is an NA value in the data,
+        If `skipna` is False and there is an NA value in the data,
         the function returns ``nan``.
 
         >>> s.idxmax(skipna=False)

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -1326,7 +1326,10 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
 
     def idxmin(self, axis=None, skipna=True, *args, **kwargs):
         """
-        Index label of the first occurrence of minimum of values.
+        Return the row label of the minimum value.
+
+        If multiple values equal the minimum, the first row label with that
+        value is returned.
 
         Parameters
         ----------
@@ -1334,19 +1337,20 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
             Exclude NA/null values. If the entire Series is NA, the result
             will be NA.
         axis : int, default 0
-            Redundant for application on series.
-        *args, **kwargs :
+            For compatibility with DataFrame.idxmin. Redundant for application
+            on Series.
+        *args, **kwargs
             Additional keywors have no effect but might be accepted
-            for compatibility with numpy.
+            for compatibility with NumPy.
+
+        Returns
+        -------
+        idxmin : Index of minimum of values.
 
         Raises
         ------
         ValueError
-            If the Series is empty
-
-        Returns
-        -------
-        idxmin : Index of minimum of values
+            If the Series is empty.
 
         Notes
         -----
@@ -1378,7 +1382,7 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
         'A'
 
         If skipna=False and there is an NA value in the data,
-        the function returns nan.
+        the function returns ``nan``.
 
         >>> s.idxmin(skipna=False)
         nan
@@ -1391,7 +1395,10 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
 
     def idxmax(self, axis=0, skipna=True, *args, **kwargs):
         """
-        Return index label of the first occurrence of maximum of values.
+        Return the row label of the maximum value.
+
+        If multiple values equal the maximum, the first row label with that
+        value is returned.
 
         Parameters
         ----------
@@ -1399,19 +1406,20 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
             Exclude NA/null values. If the entire Series is NA, the result
             will be NA.
         axis : int, default 0
-            Redundant for application on series.
-        *args, **kwargs :
+            For compatibility with DataFrame.idxmax. Redundant for application
+            on Series.
+        *args, **kwargs
             Additional keywors have no effect but might be accepted
-            for compatibility with numpy.
+            for compatibility with NumPy.
+
+        Returns
+        -------
+        idxmax : Index of maximum of values.
 
         Raises
         ------
         ValueError
-            If the Series is empty
-
-        Returns
-        -------
-        idxmax : Index of maximum of values
+            If the Series is empty.
 
         Notes
         -----
@@ -1444,7 +1452,7 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
         'C'
 
         If skipna=False and there is an NA value in the data,
-        the function returns nan.
+        the function returns ``nan``.
 
         >>> s.idxmax(skipna=False)
         nan

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -1381,7 +1381,7 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
         >>> s.idxmin()
         'A'
 
-        If skipna=False and there is an NA value in the data,
+        If 'skipna' is False and there is an NA value in the data,
         the function returns ``nan``.
 
         >>> s.idxmin(skipna=False)
@@ -1451,7 +1451,7 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
         >>> s.idxmax()
         'C'
 
-        If skipna=False and there is an NA value in the data,
+        If 'skipna' is False and there is an NA value in the data,
         the function returns ``nan``.
 
         >>> s.idxmax(skipna=False)


### PR DESCRIPTION
Checklist for the pandas documentation sprint (ignore this if you are doing
an unrelated PR):

- [X] PR title is "DOC: update the <your-function-or-method> docstring"
- [X] The validation script passes: `scripts/validate_docstrings.py <your-function-or-method>`
- [X] The PEP8 style check passes: `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [X] The html version looks good: `python doc/make.py --single <your-function-or-method>`
- [X] It has been proofread on language by another sprint participant

Please include the output of the validation script below between the "```" ticks:

```
Errors found:
	Errors in parameters section
		Parameters {'args', 'kwargs'} not documented
		Unknown parameters {'*args, **kwargs :'}
		Parameter "*args, **kwargs :" has no type
```

Parameters args and kwargs don't need types, put them on one line to keep it concise.