### PR TITLE
DOC: Improve the docstring of Series.take

### DIFF
--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -2525,24 +2525,35 @@ class NDFrame(PandasObject, SelectionMixin):
             The axis on which to select elements. "0" means that we are
             selecting rows, "1" means that we are selecting columns, etc.
         convert : bool, default True
-            .. deprecated:: 0.21.0
-               In the future, negative indices will always be converted.
-
             Whether to convert negative indices into positive ones.
             For example, ``-1`` would map to the ``len(axis) - 1``.
             The conversions are similar to the behavior of indexing a
             regular Python list.
+            .. deprecated:: 0.21.0
+               In the future, negative indices will always be converted.
         is_copy : bool, default True
             Whether to return a copy of the original object or not.
+        kwargs : xxx, default xxx
+            TODO MUST ADD A REASONABLE DESCRIPTION.
+
+        Returns
+        -------
+        taken : type of caller
+            An array-like containing the elements taken from the object.
+
+        See Also
+        --------
+        numpy.ndarray.take : TODO
+        numpy.take : TODO
 
         Examples
         --------
         >>> df = pd.DataFrame([('falcon', 'bird',    389.0),
-                               ('parrot', 'bird',     24.0),
-                               ('lion',   'mammal',   80.5),
-                               ('monkey', 'mammal', np.nan)],
-                              columns=('name', 'class', 'max_speed'),
-                              index=[0, 2, 3, 1])
+        ...                    ('parrot', 'bird',     24.0),
+        ...                    ('lion',   'mammal',   80.5),
+        ...                    ('monkey', 'mammal', np.nan)],
+        ...                    columns=('name', 'class', 'max_speed'),
+        ...                    index=[0, 2, 3, 1])
         >>> df
              name   class  max_speed
         0  falcon    bird      389.0
@@ -2557,6 +2568,7 @@ class NDFrame(PandasObject, SelectionMixin):
         and 3rd rows, not rows whose indices equal 0 and 3.
 
         >>> df.take([0, 3])
+             name   class  max_speed
         0  falcon    bird      389.0
         1  monkey  mammal        NaN
 
@@ -2576,16 +2588,6 @@ class NDFrame(PandasObject, SelectionMixin):
              name   class  max_speed
         1  monkey  mammal        NaN
         3    lion  mammal       80.5
-
-        Returns
-        -------
-        taken : type of caller
-            An array-like containing the elements taken from the object.
-
-        See Also
-        --------
-        numpy.ndarray.take
-        numpy.take
         """
 
     @Appender(_shared_docs['take'])

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -2521,21 +2521,23 @@ class NDFrame(PandasObject, SelectionMixin):
         ----------
         indices : array-like
             An array of ints indicating which positions to take.
-        axis : int, default 0
-            The axis on which to select elements. "0" means that we are
-            selecting rows, "1" means that we are selecting columns, etc.
+        axis : {0 or ‘index’, 1 or ‘columns’, None}, default 0
+            The axis on which to select elements. ``0`` means that we are
+            selecting rows, ``1`` means that we are selecting columns.
         convert : bool, default True
             Whether to convert negative indices into positive ones.
             For example, ``-1`` would map to the ``len(axis) - 1``.
             The conversions are similar to the behavior of indexing a
             regular Python list.
+
             .. deprecated:: 0.21.0
                In the future, negative indices will always be converted.
+
         is_copy : bool, default True
             Whether to return a copy of the original object or not.
-        kwargs : mapping, optional
-            Optional keyword arguments to
-            ``:meth:pandas.compat.numpy.function.validate_take``.
+        **kwargs
+            For compatibility with :meth:`numpy.take`. Has no effect on the
+            output.
 
         Returns
         -------
@@ -2544,9 +2546,9 @@ class NDFrame(PandasObject, SelectionMixin):
 
         See Also
         --------
-        numpy.ndarray.take : Return an array formed from the elements
-            at given indices
-        numpy.take : Take elements from an array along an axis
+        DataFrame.loc : Select a subset of a DataFrame by label.
+        DataFrame.iloc : Select a subset of a DataFrame by position.
+        numpy.take : Take elements from an array along an axis.
 
         Examples
         --------
@@ -2554,7 +2556,7 @@ class NDFrame(PandasObject, SelectionMixin):
         ...                    ('parrot', 'bird',     24.0),
         ...                    ('lion',   'mammal',   80.5),
         ...                    ('monkey', 'mammal', np.nan)],
-        ...                    columns=('name', 'class', 'max_speed'),
+        ...                    columns=['name', 'class', 'max_speed'],
         ...                    index=[0, 2, 3, 1])
         >>> df
              name   class  max_speed

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -2546,8 +2546,8 @@ class NDFrame(PandasObject, SelectionMixin):
 
         See Also
         --------
-        DataFrame.loc : Select a subset of a DataFrame by label.
-        DataFrame.iloc : Select a subset of a DataFrame by position.
+        DataFrame.loc : Select a subset of a DataFrame by labels.
+        DataFrame.iloc : Select a subset of a DataFrame by positions.
         numpy.take : Take elements from an array along an axis.
 
         Examples

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -2533,8 +2533,9 @@ class NDFrame(PandasObject, SelectionMixin):
                In the future, negative indices will always be converted.
         is_copy : bool, default True
             Whether to return a copy of the original object or not.
-        kwargs : xxx, default xxx
-            TODO MUST ADD A REASONABLE DESCRIPTION.
+        kwargs : mapping, optional
+            Optional keyword arguments to
+            ``:meth:pandas.compat.numpy.function.validate_take``.
 
         Returns
         -------
@@ -2543,8 +2544,9 @@ class NDFrame(PandasObject, SelectionMixin):
 
         See Also
         --------
-        numpy.ndarray.take : TODO
-        numpy.take : TODO
+        numpy.ndarray.take : Return an array formed from the elements
+            at given indices
+        numpy.take : Take elements from an array along an axis
 
         Examples
         --------

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -2521,7 +2521,7 @@ class NDFrame(PandasObject, SelectionMixin):
         ----------
         indices : array-like
             An array of ints indicating which positions to take.
-        axis : {0 or ‘index’, 1 or ‘columns’, None}, default 0
+        axis : {0 or 'index', 1 or 'columns', None}, default 0
             The axis on which to select elements. ``0`` means that we are
             selecting rows, ``1`` means that we are selecting columns.
         convert : bool, default True


### PR DESCRIPTION
Checklist for the pandas documentation sprint (ignore this if you are doing
an unrelated PR):

- [x] PR title is "DOC: update the <your-function-or-method> docstring"
- [x] The validation script passes: `scripts/validate_docstrings.py <your-function-or-method>`
- [x] The PEP8 style check passes: `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] The html version looks good: `python doc/make.py --single <your-function-or-method>`
- [x] It has been proofread on language by another sprint participant

Please include the output of the validation script below between the "```" ticks:

```
################################################################################
######################## Docstring (pandas.Series.take) ########################
################################################################################

Return the elements in the given *positional* indices along an axis.

This means that we are not indexing according to actual values in
the index attribute of the object. We are indexing according to the
actual position of the element in the object.

Parameters
----------
indices : array-like
    An array of ints indicating which positions to take.
axis : int, default 0
    The axis on which to select elements. "0" means that we are
    selecting rows, "1" means that we are selecting columns, etc.
convert : bool, default True
    Whether to convert negative indices into positive ones.
    For example, ``-1`` would map to the ``len(axis) - 1``.
    The conversions are similar to the behavior of indexing a
    regular Python list.
    .. deprecated:: 0.21.0
       In the future, negative indices will always be converted.
is_copy : bool, default True
    Whether to return a copy of the original object or not.
kwargs : xxx, default xxx
    TODO MUST ADD A REASONABLE DESCRIPTION.

Returns
-------
taken : type of caller
    An array-like containing the elements taken from the object.

See Also
--------
numpy.ndarray.take : TODO
numpy.take : TODO

Examples
--------
>>> df = pd.DataFrame([('falcon', 'bird',    389.0),
...                    ('parrot', 'bird',     24.0),
...                    ('lion',   'mammal',   80.5),
...                    ('monkey', 'mammal', np.nan)],
...                    columns=('name', 'class', 'max_speed'),
...                    index=[0, 2, 3, 1])
>>> df
     name   class  max_speed
0  falcon    bird      389.0
2  parrot    bird       24.0
3    lion  mammal       80.5
1  monkey  mammal        NaN

Take elements at positions 0 and 3 along the axis 0 (default).

Note how the actual indices selected (0 and 1) do not correspond to
our selected indices 0 and 3. That's because we are selecting the 0th
and 3rd rows, not rows whose indices equal 0 and 3.

>>> df.take([0, 3])
     name   class  max_speed
0  falcon    bird      389.0
1  monkey  mammal        NaN

Take elements at indices 1 and 2 along the axis 1 (column selection).

>>> df.take([1, 2], axis=1)
    class  max_speed
0    bird      389.0
2    bird       24.0
3  mammal       80.5
1  mammal        NaN

We may take elements using negative integers for positive indices,
starting from the end of the object, just like with Python lists.

>>> df.take([-1, -2])
     name   class  max_speed
1  monkey  mammal        NaN
3    lion  mammal       80.5

################################################################################
################################## Validation ##################################
################################################################################

Docstring for "pandas.Series.take" correct. :)
```

If the validation script still gives errors, but you think there is a good reason
to deviate in this case (and there are certainly such cases), please state this
explicitly.

Signed-off-by: Gianpaolo Macario <gmacario@gmail.com>