### PR TITLE
DOC: update the pandas.Index.notna docstring

### DIFF
--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -2045,7 +2045,7 @@ class Index(IndexOpsMixin, PandasObject):
         Return a boolean same-sized object indicating if the values are not NA.
         Non-missing values get mapped to ``True``. Characters such as empty
         strings ``''`` or :attr:`numpy.inf` are not considered NA values
-        (unless you set :attr:`pandas.options.mode.use_inf_as_na` `= True`).
+        (unless you set ``pandas.options.mode.use_inf_as_na = True``).
         NA values, such as None or :attr:`numpy.NaN`, get mapped to ``False``
         values.
 
@@ -2053,18 +2053,18 @@ class Index(IndexOpsMixin, PandasObject):
 
         Returns
         -------
-        bool of type numpy.ndarray
+        numpy.ndarray
             Boolean array to indicate which entries are not NA.
 
         See also
         --------
-        notnull : alias of notna
-        isna: inverse of notna
+        Index.notnull : alias of notna
+        Index.isna: inverse of notna
         pandas.notna : top-level notna
 
         Examples
         --------
-        Show which entries in a pandas.Index are not NA. The result is an
+        Show which entries in an Index are not NA. The result is an
         array.
 
         >>> idx = pd.Index([5.2, 6.0, np.NaN])

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -2040,18 +2040,47 @@ class Index(IndexOpsMixin, PandasObject):
 
     def notna(self):
         """
-        Inverse of isna
+        Detect existing (non-missing) values.
+
+        Return a boolean same-sized object indicating if the values are not NA.
+        Non-missing values get mapped to True. Characters such as empty
+        strings `''` or :attr:`numpy.inf` are not considered NA values
+        (unless you set :attr:`pandas.options.mode.use_inf_as_na` `= True`).
+        NA values, such as None or :attr:`numpy.NaN`, get mapped to False
+        values.
 
         .. versionadded:: 0.20.0
 
         Returns
         -------
-        a boolean array of whether my values are not NA
+        bool of type numpy.ndarray
+            Boolean array to indicate which entries are not NA.
 
         See also
         --------
         notnull : alias of notna
+        isna: inverse of notna
         pandas.notna : top-level notna
+
+        Examples
+        --------
+        Show which entries in a pandas.Index are not NA. The result is an
+        array.
+
+        >>> idx = pd.Index([5.2, 6.0, np.NaN])
+        >>> idx
+        Float64Index([5.2, 6.0, nan], dtype='float64')
+        >>> idx.notna()
+        array([ True,  True, False])
+
+        Empty strings are not considered NA values. None is considered a NA
+        value.
+
+        >>> idx = pd.Index(['black', '', 'red', None])
+        >>> idx
+        Index(['black', '', 'red', None], dtype='object')
+        >>> idx.notna()
+        array([ True,  True,  True, False])
         """
         return ~self.isna()
     notnull = notna

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -2043,10 +2043,10 @@ class Index(IndexOpsMixin, PandasObject):
         Detect existing (non-missing) values.
 
         Return a boolean same-sized object indicating if the values are not NA.
-        Non-missing values get mapped to True. Characters such as empty
-        strings `''` or :attr:`numpy.inf` are not considered NA values
+        Non-missing values get mapped to ``True``. Characters such as empty
+        strings ``''`` or :attr:`numpy.inf` are not considered NA values
         (unless you set :attr:`pandas.options.mode.use_inf_as_na` `= True`).
-        NA values, such as None or :attr:`numpy.NaN`, get mapped to False
+        NA values, such as None or :attr:`numpy.NaN`, get mapped to ``False``
         values.
 
         .. versionadded:: 0.20.0


### PR DESCRIPTION
Checklist for the pandas documentation sprint (ignore this if you are doing
an unrelated PR):

- [x] PR title is "DOC: update the <your-function-or-method> docstring"
- [x] The validation script passes: `scripts/validate_docstrings.py <your-function-or-method>`
- [x] The PEP8 style check passes: `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] The html version looks good: `python doc/make.py --single <your-function-or-method>`
- [x] It has been proofread on language by another sprint participant

```
################################################################################
######################## Docstring (pandas.Index.notna) ########################
################################################################################

Detect existing (non-missing) values.

Return a boolean same-sized object indicating if the values are not NA.
Non-missing values get mapped to True. Characters such as empty
strings `''` or :attr:`numpy.inf` are not considered NA values
(unless you set :attr:`pandas.options.mode.use_inf_as_na` `= True`).
NA values, such as None or :attr:`numpy.NaN`, get mapped to False
values.

.. versionadded:: 0.20.0

Returns
-------
bool of type numpy.ndarray
    Boolean array to indicate which entries are not NA.

See also
--------
notnull : alias of notna
isna: inverse of notna
pandas.notna : top-level notna

Examples
--------
Show which entries in a pandas.Index are not NA. The result is an
array.

>>> idx = pd.Index([5.2, 6.0, np.NaN])
>>> idx
Float64Index([5.2, 6.0, nan], dtype='float64')
>>> idx.notna()
array([ True,  True, False])

Empty strings are not considered NA values. None is considered a NA
value.

>>> idx = pd.Index(['black', '', 'red', None])
>>> idx
Index(['black', '', 'red', None], dtype='object')
>>> idx.notna()
array([ True,  True,  True, False])

################################################################################
################################## Validation ##################################
################################################################################

Docstring for "pandas.Index.notna" correct. :)
```
