### PR TITLE
DOC: Update the pandas.Series.dt.round/floor/ceil docstrings

### DIFF
--- a/pandas/core/indexes/datetimelike.py
+++ b/pandas/core/indexes/datetimelike.py
@@ -99,39 +99,38 @@ class TimelikeOps(object):
 
         Notes
         -----
-        See the following link for possible `freq` values
-        and their descriptions.\n
-        https://pandas.pydata.org/pandas-docs/stable/timeseries.html#offset-aliases
+        See :ref:`frequency aliases <timeseries.offset_aliases>` for
+        a list of possible `freq` values.
 
         Examples
         --------
         >>> rng = pd.date_range('1/1/2018 11:59:00', periods=3, freq='min')
         >>> rng
         DatetimeIndex(['2018-01-01 11:59:00', '2018-01-01 12:00:00',
-               '2018-01-01 12:01:00'],
-              dtype='datetime64[ns]', freq='T')
+                       '2018-01-01 12:01:00'],
+                       dtype='datetime64[ns]', freq='T')
         """)
 
     _round_example = (
         """>>> rng.round('H')
         DatetimeIndex(['2018-01-01 12:00:00', '2018-01-01 12:00:00',
-               '2018-01-01 12:00:00'],
-              dtype='datetime64[ns]', freq=None)
+                       '2018-01-01 12:00:00'],
+                       dtype='datetime64[ns]', freq=None)
         """)
 
     _floor_example = (
         """>>> rng.floor('H')
         DatetimeIndex(['2018-01-01 11:00:00', '2018-01-01 12:00:00',
-               '2018-01-01 12:00:00'],
-              dtype='datetime64[ns]', freq=None)
+                       '2018-01-01 12:00:00'],
+                       dtype='datetime64[ns]', freq=None)
         """
     )
 
     _ceil_example = (
         """>>> rng.ceil('H')
         DatetimeIndex(['2018-01-01 12:00:00', '2018-01-01 12:00:00',
-               '2018-01-01 13:00:00'],
-              dtype='datetime64[ns]', freq=None)
+                       '2018-01-01 13:00:00'],
+                       dtype='datetime64[ns]', freq=None)
         """
     )
 

--- a/pandas/core/indexes/datetimelike.py
+++ b/pandas/core/indexes/datetimelike.py
@@ -82,47 +82,65 @@ class TimelikeOps(object):
 
     _round_doc = (
         """
-        {op} the index to the specified `freq`.
+        {op} the data to the specified `freq`.
 
         Parameters
         ----------
-        freq : freq string/object
-            The frequency level to {op} the index to.
+        freq : str or Offset
+            The frequency level to {op} the index to. Must be a fixed
+            frequency like 'S' (second) not 'ME' (month end). See
+            :ref:`frequency aliases <timeseries.offset_aliases>` for
+            a list of possible `freq` values.
 
         Returns
         -------
-        index of same type.
+        DatetimeIndex, TimedeltaIndex, or Series
+            Index of the same type for a DatetimeIndex or TimedeltaIndex,
+            or a Series with the same index for a Series.
 
         Raises
         ------
         ValueError if the `freq` cannot be converted.
 
-        Notes
-        -----
-        See :ref:`frequency aliases <timeseries.offset_aliases>` for
-        a list of possible `freq` values.
-
         Examples
         --------
+        **DatetimeIndex**
+
         >>> rng = pd.date_range('1/1/2018 11:59:00', periods=3, freq='min')
         >>> rng
         DatetimeIndex(['2018-01-01 11:59:00', '2018-01-01 12:00:00',
                        '2018-01-01 12:01:00'],
-                       dtype='datetime64[ns]', freq='T')
+                      dtype='datetime64[ns]', freq='T')
         """)
 
     _round_example = (
         """>>> rng.round('H')
         DatetimeIndex(['2018-01-01 12:00:00', '2018-01-01 12:00:00',
                        '2018-01-01 12:00:00'],
-                       dtype='datetime64[ns]', freq=None)
+                      dtype='datetime64[ns]', freq=None)
+
+        **Series**
+
+        >>> pd.Series(rng).dt.round("H")
+        0   2018-01-01 12:00:00
+        1   2018-01-01 12:00:00
+        2   2018-01-01 12:00:00
+        dtype: datetime64[ns]
         """)
 
     _floor_example = (
         """>>> rng.floor('H')
         DatetimeIndex(['2018-01-01 11:00:00', '2018-01-01 12:00:00',
                        '2018-01-01 12:00:00'],
-                       dtype='datetime64[ns]', freq=None)
+                      dtype='datetime64[ns]', freq=None)
+
+        **Series**
+
+        >>> pd.Series(rng).dt.floor("H")
+        0   2018-01-01 11:00:00
+        1   2018-01-01 12:00:00
+        2   2018-01-01 12:00:00
+        dtype: datetime64[ns]
         """
     )
 
@@ -130,7 +148,15 @@ class TimelikeOps(object):
         """>>> rng.ceil('H')
         DatetimeIndex(['2018-01-01 12:00:00', '2018-01-01 12:00:00',
                        '2018-01-01 13:00:00'],
-                       dtype='datetime64[ns]', freq=None)
+                      dtype='datetime64[ns]', freq=None)
+
+        **Series**
+
+        >>> pd.Series(rng).dt.ceil("H")
+        0   2018-01-01 12:00:00
+        1   2018-01-01 12:00:00
+        2   2018-01-01 13:00:00
+        dtype: datetime64[ns]
         """
     )
 

--- a/pandas/core/indexes/datetimelike.py
+++ b/pandas/core/indexes/datetimelike.py
@@ -82,20 +82,58 @@ class TimelikeOps(object):
 
     _round_doc = (
         """
-        %s the index to the specified freq
+        {op} the index to the specified `freq`.
 
         Parameters
         ----------
         freq : freq string/object
+            The frequency level to {op} the index to.
 
         Returns
         -------
-        index of same type
+        index of same type.
 
         Raises
         ------
-        ValueError if the freq cannot be converted
+        ValueError if the `freq` cannot be converted.
+
+        Notes
+        -----
+        See the following link for possible `freq` values
+        and their descriptions.\n
+        https://pandas.pydata.org/pandas-docs/stable/timeseries.html#offset-aliases
+
+        Examples
+        --------
+        >>> rng = pd.date_range('1/1/2018 11:59:00', periods=3, freq='min')
+        >>> rng
+        DatetimeIndex(['2018-01-01 11:59:00', '2018-01-01 12:00:00',
+               '2018-01-01 12:01:00'],
+              dtype='datetime64[ns]', freq='T')
         """)
+
+    _round_example = (
+        """>>> rng.round('H')
+        DatetimeIndex(['2018-01-01 12:00:00', '2018-01-01 12:00:00',
+               '2018-01-01 12:00:00'],
+              dtype='datetime64[ns]', freq=None)
+        """)
+
+    _floor_example = (
+        """>>> rng.floor('H')
+        DatetimeIndex(['2018-01-01 11:00:00', '2018-01-01 12:00:00',
+               '2018-01-01 12:00:00'],
+              dtype='datetime64[ns]', freq=None)
+        """
+    )
+
+    _ceil_example = (
+        """>>> rng.ceil('H')
+        DatetimeIndex(['2018-01-01 12:00:00', '2018-01-01 12:00:00',
+               '2018-01-01 13:00:00'],
+              dtype='datetime64[ns]', freq=None)
+        """
+    )
 
     def _round(self, freq, rounder):
         # round the local times
@@ -111,15 +149,15 @@ class TimelikeOps(object):
         return self._ensure_localized(
             self._shallow_copy(result, **attribs))
 
-    @Appender(_round_doc % "round")
+    @Appender((_round_doc + _round_example).format(op="round"))
     def round(self, freq, *args, **kwargs):
         return self._round(freq, np.round)
 
-    @Appender(_round_doc % "floor")
+    @Appender((_round_doc + _floor_example).format(op="floor"))
     def floor(self, freq):
         return self._round(freq, np.floor)
 
-    @Appender(_round_doc % "ceil")
+    @Appender((_round_doc + _ceil_example).format(op="ceil"))
     def ceil(self, freq):
         return self._round(freq, np.ceil)
 


### PR DESCRIPTION
Checklist for the pandas documentation sprint (ignore this if you are doing
an unrelated PR):

- [x] PR title is "DOC: update the <your-function-or-method> docstring"
- [ ] The validation script passes: `scripts/validate_docstrings.py <your-function-or-method>`
- [x] The PEP8 style check passes: `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] The html version looks good: `python doc/make.py --single <your-function-or-method>`
- [x] It has been proofread on language by another sprint participant

```
scripts/validate_docstrings.py pandas.Series.dt.floor  

Errors found:
	Summary does not start with capital
	No extended summary found
	Errors in parameters section
		Parameters {'args', 'kwargs'} not documented
		Unknown parameters {'freq'}
	See Also section not found
```
 Same errors are received from applying `validate_docstrings.py` to `pandas.Series.dt.ceil` and `pandas.Series.dt.round` as well.  

`args` and `kwargs` parameters are not the parameters that the clients are exposed to (`freq` is). The respective errors are received because of the way code is written with accessors.
  
We wanted to keep the docstrings of `round`, `floor` and `ceil` connected to keep the code as concise as possible. For that reason we also didn't add a customized extended summary for these methods. 
