### PR TITLE
DOC: update the pandas.IntervalIndex docstring

### DIFF
--- a/pandas/core/indexes/interval.py
+++ b/pandas/core/indexes/interval.py
@@ -148,13 +148,17 @@ class IntervalIndex(IntervalMixin, Index):
     closed : {'left', 'right', 'both', 'neither'}, default 'right'
         Whether the intervals are closed on the left-side, right-side, both or
         neither.
-    name : object, optional
-        Name to be stored in the index.
-    copy : boolean, default False
-        Copy the meta-data.
     dtype : dtype or None, default None
         If None, dtype will be inferred.
-
+    copy : boolean, default False
+        Copy the meta-data.
+    name : object, optional
+        Name to be stored in the index.
+    fastpath : boolean, default False
+        Create IntervalIndex without verifying integrity.
+    verify_integrity : boolean, default True
+        Verify that the IntervalIndex is valid.
+        
         ..versionadded:: 0.23.0.
 
     Attributes

--- a/pandas/core/indexes/interval.py
+++ b/pandas/core/indexes/interval.py
@@ -142,20 +142,20 @@ class IntervalIndex(IntervalMixin, Index):
 
     Parameters
     ----------
-    data : array-like (1-dimensional)
+    data : array-Like (1-dimensional)
         Array-like containing Interval objects from which to build the
-        IntervalIndex
+        IntervalIndex.
     closed : {'left', 'right', 'both', 'neither'}, default 'right'
         Whether the intervals are closed on the left-side, right-side, both or
         neither.
     name : object, optional
         Name to be stored in the index.
     copy : boolean, default False
-        Copy the meta-data
+        Copy the meta-data.
     dtype : dtype or None, default None
-        If None, dtype will be inferred
+        If None, dtype will be inferred.
 
-        ..versionadded:: 0.23.0
+        ..versionadded:: 0.23.0.
 
     Attributes
     ----------
@@ -198,11 +198,11 @@ class IntervalIndex(IntervalMixin, Index):
 
     See Also
     --------
-    Index : The base pandas Index type
-    Interval : A bounded slice-like interval; the elements of an IntervalIndex
-    interval_range : Function to create a fixed frequency IntervalIndex
-    cut, qcut : Convert arrays of continuous data into Categoricals/Series of
-                Intervals
+    Index : The base pandas Index type.
+    Interval : A bounded slice-like interval; the elements of an IntervalIndex.
+    qcut : Quantile-based discretization function.
+    cut : Return indices of half-open bins to which each value of x belongs.
+    interval_range : Function to create a fixed frequency IntervalIndex.
     """
     _typ = 'intervalindex'
     _comparables = ['name']


### PR DESCRIPTION
Docstring assignated to the Buenos Aires, Argentina chapter.

Checklist for the pandas documentation sprint (ignore this if you are doing
an unrelated PR):

- [x] PR title is "DOC: update the <your-function-or-method> docstring"
- [x] The validation script passes: `scripts/validate_docstrings.py <your-function-or-method>`
- [x] The PEP8 style check passes: `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] The html version looks good: `python doc/make.py --single <your-function-or-method>`
- [x] It has been proofread on language by another sprint participant

Please include the output of the validation script below between the "```" ticks:

```

################################################################################
####################### Docstring (pandas.IntervalIndex) #######################
################################################################################

Immutable Index implementing an ordered, sliceable set. IntervalIndex
represents an Index of Interval objects that are all closed on the same
side.

.. versionadded:: 0.20.0

.. warning::

   The indexing behaviors are provisional and may change in
   a future version of pandas.

Parameters
----------
data : array-Like (1-dimensional)
    Array-like containing Interval objects from which to build the
    IntervalIndex.
closed : {'left', 'right', 'both', 'neither'}, default 'right'
    Whether the intervals are closed on the left-side, right-side, both or
    neither.
dtype : dtype or None, default None
    If None, dtype will be inferred.
copy : boolean, default False
    Copy the meta-data.
name : object, optional
    Name to be stored in the index.
fastpath : boolean, default False
    Create IntervalIndex without verifying integrity.
verify_integrity : boolean, default True
    Verify that the IntervalIndex is valid.
    
    ..versionadded:: 0.23.0.

Attributes
----------
left
right
closed
mid
length
values
is_non_overlapping_monotonic

Methods
-------
from_arrays
from_tuples
from_breaks
contains

Examples
---------
A new ``IntervalIndex`` is typically constructed using
:func:`interval_range`:

>>> pd.interval_range(start=0, end=5)
IntervalIndex([(0, 1], (1, 2], (2, 3], (3, 4], (4, 5]]
              closed='right', dtype='interval[int64]')

It may also be constructed using one of the constructor
methods: :meth:`IntervalIndex.from_arrays`,
:meth:`IntervalIndex.from_breaks`, and :meth:`IntervalIndex.from_tuples`.

See further examples in the doc strings of ``interval_range`` and the
mentioned constructor methods.

Notes
------
See the `user guide
<http://pandas.pydata.org/pandas-docs/stable/advanced.html#intervalindex>`_
for more.

See Also
--------
Index : The base pandas Index type.
Interval : A bounded slice-like interval; the elements of an IntervalIndex.
qcut : Quantile-based discretization function.
cut : Return indices of half-open bins to which each value of x belongs.
interval_range : Function to create a fixed frequency IntervalIndex.

################################################################################
################################## Validation ##################################
################################################################################

Errors found:
	No returns section found
Checking `class` definition so nothing to return 
```

If the validation script still gives errors, but you think there is a good reason
to deviate in this case (and there are certainly such cases), please state this
explicitly.