### PR TITLE
DOC: update the Series.dt.strftime docstring

### DIFF
--- a/pandas/core/indexes/datetimelike.py
+++ b/pandas/core/indexes/datetimelike.py
@@ -61,18 +61,26 @@ class DatelikeOps(object):
         return np.asarray(self.format(date_format=date_format),
                           dtype=compat.text_type)
     strftime.__doc__ = """
-    Return an array of formatted strings specified by date_format, which
+    Format series values with a date format string.
+
+    This function formats series values as specified by `date_format`, which
     supports the same string format as the python standard library. Details
-    of the string format can be found in `python string format doc <{0}>`__
+    of the string format can be found in `python string format doc <{0}>`__.
 
     Parameters
     ----------
     date_format : str
-        date format string (e.g. "%Y-%m-%d")
+        Date format string (e.g. "%Y-%m-%d").
 
     Returns
     -------
     ndarray of formatted strings
+
+    Examples
+    --------
+    >>> rng = pd.date_range('10/3/2018 16:20:10', periods=2, freq='H')
+    >>> rng.strftime("%Y-%m-%d")
+    array(['2018-10-03', '2018-10-03'], dtype='<U10')
     """.format("https://docs.python.org/3/library/datetime.html"
                "#strftime-and-strptime-behavior")
 


### PR DESCRIPTION
Checklist for the pandas documentation sprint (ignore this if you are doing
an unrelated PR):

- [x] PR title is "DOC: update the <your-function-or-method> docstring"
- [ ] The validation script passes: `scripts/validate_docstrings.py <your-function-or-method>`
- [x] The PEP8 style check passes: `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] The html version looks good: `python doc/make.py --single <your-function-or-method>`
- [x] It has been proofread on language by another sprint participant

Please include the output of the validation script below between the "```" ticks:

```
################################################################################
#################### Docstring (pandas.Series.dt.strftime)  ####################
################################################################################

Format series values with a date format string.

This function formats series values as specified by `date_format`, which
supports the same string format as the python standard library. Details
of the string format can be found in `python string format doc <https://docs.python.org/3/library/datetime.html#strftime-and-strptime-behavior>`__.

Parameters
----------
date_format : str
    Date format string (e.g. "%Y-%m-%d").

Returns
-------
ndarray of formatted strings

Examples
--------
>>> rng = pd.date_range('10/3/2018 16:20:10', periods=2, freq='H')
>>> rng.strftime("%Y-%m-%d")
array(['2018-10-03', '2018-10-03'], dtype='<U10')

################################################################################
################################## Validation ##################################
################################################################################

Errors found:
        Errors in parameters section
                Parameters {'kwargs', 'args'} not documented
                Unknown parameters {'date_format'}
        See Also section not found
```

If the validation script still gives errors, but you think there is a good reason
to deviate in this case (and there are certainly such cases), please state this
explicitly.

The method is injected with `_add_delegate_accessors` and the resulting signature on the object has `*args` and `**kwargs` instead of the actual `date_format`
