### PR TITLE
DOC: update the Index.shift docstring

### DIFF
--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -2256,18 +2256,19 @@ class Index(IndexOpsMixin, PandasObject):
         return self.sort_values(return_indexer=True, ascending=ascending)
 
     def shift(self, periods=1, freq=None):
-        """Shift index by desired number of time frequency increments.
+        """
+        Shift index by desired number of time frequency increments.
 
         This method is for shifting the values of datetime-like indexes
         by a specified time increment a given number of times.
 
         Parameters
         ----------
-        periods : int
+        periods : int, default 1
             Number of periods (or increments) to shift by,
-            can be positive or negative (default is 1).
-        freq : pandas.DateOffset, pandas.Timedelta or string
-            Frequency increment to shift by (default is None).
+            can be positive or negative.
+        freq : pandas.DateOffset, pandas.Timedelta or string, optional
+            Frequency increment to shift by.
             If None, the index is shifted by its own `freq` attribute.
             Offset aliases are valid strings, e.g., 'D', 'W', 'M' etc.
 

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -2279,7 +2279,7 @@ class Index(IndexOpsMixin, PandasObject):
 
         See Also
         --------
-        :meth:`Series.shift` : Shift values of Series.
+        Series.shift : Shift values of Series.
 
         Examples
         --------

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -2277,6 +2277,10 @@ class Index(IndexOpsMixin, PandasObject):
         pandas.Index
             shifted index
 
+        See Also
+        --------
+        :meth:`Series.shift` : Shift values of Series.
+
         Examples
         --------
         Put the first 5 month starts of 2011 into an index.


### PR DESCRIPTION
Checklist for the pandas documentation sprint (ignore this if you are doing
an unrelated PR):

- [x] PR title is "DOC: update the <your-function-or-method> docstring"
- [ ] The validation script passes: `scripts/validate_docstrings.py <your-function-or-method>`
- [x] The PEP8 style check passes: `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] The html version looks good: `python doc/make.py --single <your-function-or-method>`
- [x] It has been proofread on language by another sprint participant

Please include the output of the validation script below between the "```" ticks:

```
################################################################################
######################## Docstring (pandas.Index.shift) ########################
################################################################################

Shift index by desired number of time frequency increments.

This method is for shifting the values of datetime-like indexes
by a specified time increment a given number of times.

Parameters
----------
periods : int, default 1
    Number of periods (or increments) to shift by,
    can be positive or negative.
freq : pandas.DateOffset, pandas.Timedelta or string, optional
    Frequency increment to shift by.
    If None, the index is shifted by its own `freq` attribute.
    Offset aliases are valid strings, e.g., 'D', 'W', 'M' etc.

Returns
-------
pandas.Index
    shifted index

Examples
--------
Put the first 5 month starts of 2011 into an index.

>>> month_starts = pd.date_range('1/1/2011', periods=5, freq='MS')
>>> month_starts
DatetimeIndex(['2011-01-01', '2011-02-01', '2011-03-01', '2011-04-01',
               '2011-05-01'],
              dtype='datetime64[ns]', freq='MS')

Shift the index by 10 days.

>>> month_starts.shift(10, freq='D')
DatetimeIndex(['2011-01-11', '2011-02-11', '2011-03-11', '2011-04-11',
               '2011-05-11'],
              dtype='datetime64[ns]', freq=None)

The default value of `freq` is the `freq` attribute of the index,
which is 'MS' (month start) in this example.

>>> month_starts.shift(10)
DatetimeIndex(['2011-11-01', '2011-12-01', '2012-01-01', '2012-02-01',
               '2012-03-01'],
              dtype='datetime64[ns]', freq='MS')

Notes
-----
This method is only implemented for datetime-like index classes,
i.e., DatetimeIndex, PeriodIndex and TimedeltaIndex.

################################################################################
################################## Validation ##################################
################################################################################

Errors found:
	See Also section not found

```

If the validation script still gives errors, but you think there is a good reason
to deviate in this case (and there are certainly such cases), please state this
explicitly.

-- We haven't included a See Also section because there are no functions in pandas that are related to this.


Checklist for other PRs (remove this part if you are doing a PR for the pandas documentation sprint):

- [ ] closes #xxxx
- [ ] tests added / passed
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
