### PR TITLE
DOC: Update the pandas.DataFrame.abs docstring

### DIFF
--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -7115,14 +7115,14 @@ class NDFrame(PandasObject, SelectionMixin):
     # Numeric Methods
     def abs(self):
         """
-        Return a Series/DataFrame with absolute numeric value of each object.
+        Return a Series/DataFrame with absolute numeric value of each element.
 
-        This function only applies to objects that are all numeric.
+        This function only applies to elements that are all numeric.
 
         Returns
         -------
         abs
-            Series/DataFrame containing the absolute value of each object.
+            Series/DataFrame containing the absolute value of each element.
 
         Notes
         -----
@@ -7149,8 +7149,7 @@ class NDFrame(PandasObject, SelectionMixin):
         dtype: float64
 
         Select rows with data closest to certian value using argsort (from
-        `StackOverflow
-        <http://stackoverflow.com/questions/17758023/return-rows-in-a-dataframe-closest-to-a-user-defined-number>`__).
+        `StackOverflow <https://stackoverflow.com/a/17758115>`__).
 
         >>> df = pd.DataFrame({
         ...     'a': [4, 5, 6, 7],
@@ -7163,8 +7162,7 @@ class NDFrame(PandasObject, SelectionMixin):
         1    5   20   50
         2    6   30  -30
         3    7   40  -50
-        >>> a_value = 43.0
-        >>> df.loc[(df.c - a_value).abs().argsort()]
+        >>> df.loc[(df.c - 43).abs().argsort()]
              a    b    c
         1    5   20   50
         0    4   10  100

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -7127,11 +7127,11 @@ class NDFrame(PandasObject, SelectionMixin):
         Notes
         -----
         For ``complex`` inputs, ``1.2 + 1j``, the absolute value is
-        :math:`\\sqrt{ a^2 + b^2 }`. See the Python
+        :math:`\\sqrt{ a^2 + b^2 }`.
 
         Examples
         --------
-        Absolute numeric values in a ``Series``.
+        Absolute numeric values in a Series.
 
         >>> s = pd.Series([-1.10, 2, -3.33, 4])
         >>> s.abs()
@@ -7141,7 +7141,7 @@ class NDFrame(PandasObject, SelectionMixin):
         3    4.00
         dtype: float64
 
-        Absolute numeric values in a ``Series`` with ``complex`` numbers.
+        Absolute numeric values in a Series with complex numbers.
 
         >>> s = pd.Series([1.2 + 1j])
         >>> s.abs()

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -7168,6 +7168,10 @@ class NDFrame(PandasObject, SelectionMixin):
         0    4   10  100
         2    6   30  -30
         3    7   40  -50
+
+        See Also
+        --------
+        numpy.absolute
         """
         return np.abs(self)
 

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -7115,12 +7115,61 @@ class NDFrame(PandasObject, SelectionMixin):
     # Numeric Methods
     def abs(self):
         """
-        Return an object with absolute value taken--only applicable to objects
-        that are all numeric.
+        Return a Series/DataFrame with absolute numeric value of each object.
+
+        This function only applies to objects that are all numeric.
 
         Returns
         -------
-        abs: type of caller
+        abs
+            Series/DataFrame containing the absolute value of each object.
+
+        Notes
+        -----
+        For ``complex`` inputs, ``1.2 + 1j``, the absolute value is
+        :math:`\\sqrt{ a^2 + b^2 }`. See the Python
+
+        Examples
+        --------
+        Absolute numeric values in a ``Series``.
+
+        >>> s = pd.Series([-1.10, 2, -3.33, 4])
+        >>> s.abs()
+        0    1.10
+        1    2.00
+        2    3.33
+        3    4.00
+        dtype: float64
+
+        Absolute numeric values in a ``Series`` with ``complex`` numbers.
+
+        >>> s = pd.Series([1.2 + 1j])
+        >>> s.abs()
+        0    1.56205
+        dtype: float64
+
+        Select rows with data closest to certian value using argsort (from
+        `StackOverflow
+        <http://stackoverflow.com/questions/17758023/return-rows-in-a-dataframe-closest-to-a-user-defined-number>`__).
+
+        >>> df = pd.DataFrame({
+        ...     'a': [4, 5, 6, 7],
+        ...     'b': [10,20,30,40],
+        ...     'c': [100,50,-30,-50]
+        ... })
+        >>> df
+             a    b    c
+        0    4   10  100
+        1    5   20   50
+        2    6   30  -30
+        3    7   40  -50
+        >>> a_value = 43.0
+        >>> df.loc[(df.c - a_value).abs().argsort()]
+             a    b    c
+        1    5   20   50
+        0    4   10  100
+        2    6   30  -30
+        3    7   40  -50
         """
         return np.abs(self)
 

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -7154,8 +7154,8 @@ class NDFrame(PandasObject, SelectionMixin):
 
         >>> df = pd.DataFrame({
         ...     'a': [4, 5, 6, 7],
-        ...     'b': [10,20,30,40],
-        ...     'c': [100,50,-30,-50]
+        ...     'b': [10, 20, 30, 40],
+        ...     'c': [100, 50, -30, -50]
         ... })
         >>> df
              a    b    c

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -7171,7 +7171,7 @@ class NDFrame(PandasObject, SelectionMixin):
 
         See Also
         --------
-        numpy.absolute
+        numpy.absolute : calculate the absolute value element-wise.
         """
         return np.abs(self)
 

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -7148,6 +7148,13 @@ class NDFrame(PandasObject, SelectionMixin):
         0    1.56205
         dtype: float64
 
+        Absolute numeric values in a Series with a Timedelta element.
+
+        >>> s = pd.Series([pd.Timedelta('1 days')])
+        >>> s.abs()
+        0   1 days
+        dtype: timedelta64[ns]
+
         Select rows with data closest to certian value using argsort (from
         `StackOverflow <https://stackoverflow.com/a/17758115>`__).
 


### PR DESCRIPTION
Improve description and returns, and added notes and examples.

Checklist for the pandas documentation sprint (ignore this if you are doing
an unrelated PR):

- [x] PR title is "DOC: update the <your-function-or-method> docstring"
- [x] The validation script passes: `scripts/validate_docstrings.py <your-function-or-method>`
- [x] The PEP8 style check passes: `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] The html version looks good: `python doc/make.py --single <your-function-or-method>`
- [x] It has been proofread on language by another sprint participant

Please include the output of the validation script below between the "```" ticks:

```
################################################################################
####################### Docstring (pandas.DataFrame.abs) #######################
################################################################################

Return a Series/DataFrame with absolute numeric value of each element.

This function only applies to elements that are all numeric.

Returns
-------
abs
    Series/DataFrame containing the absolute value of each element.

Notes
-----
For ``complex`` inputs, ``1.2 + 1j``, the absolute value is
:math:`\sqrt{ a^2 + b^2 }`. See the Python

Examples
--------
Absolute numeric values in a ``Series``.

>>> s = pd.Series([-1.10, 2, -3.33, 4])
>>> s.abs()
0    1.10
1    2.00
2    3.33
3    4.00
dtype: float64

Absolute numeric values in a ``Series`` with ``complex`` numbers.

>>> s = pd.Series([1.2 + 1j])
>>> s.abs()
0    1.56205
dtype: float64

Select rows with data closest to certian value using argsort (from
`StackOverflow <https://stackoverflow.com/a/17758115>`__).

>>> df = pd.DataFrame({
...     'a': [4, 5, 6, 7],
...     'b': [10, 20, 30, 40],
...     'c': [100, 50, -30, -50]
... })
>>> df
     a    b    c
0    4   10  100
1    5   20   50
2    6   30  -30
3    7   40  -50
>>> df.loc[(df.c - 43).abs().argsort()]
     a    b    c
1    5   20   50
0    4   10  100
2    6   30  -30
3    7   40  -50

See Also
--------
numpy.absolute : calculate the absolute value element-wise.

################################################################################
################################## Validation ##################################
################################################################################

Docstring for "pandas.DataFrame.abs" correct. :)
```

I feel there aren't any similar methods for the See Also section.