### PR TITLE
DOC: Update the DataFrame.join() docstring 

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -5177,8 +5177,10 @@ class DataFrame(NDFrame):
     def join(self, other, on=None, how='left', lsuffix='', rsuffix='',
              sort=False):
         """
-        Join columns with other DataFrame either on index or on a key
-        column. Efficiently Join multiple DataFrame objects by index at once by
+        Join columns with other DataFrame either on index or a key
+        column.
+
+        Efficiently Join multiple DataFrame objects by index at once by
         passing a list.
 
         Parameters
@@ -5186,44 +5188,44 @@ class DataFrame(NDFrame):
         other : DataFrame, Series with name field set, or list of DataFrame
             Index should be similar to one of the columns in this one. If a
             Series is passed, its name attribute must be set, and that will be
-            used as the column name in the resulting joined DataFrame
+            used as the column name in the resulting joined DataFrame.
         on : name, tuple/list of names, or array-like
             Column or index level name(s) in the caller to join on the index
             in `other`, otherwise joins index-on-index. If multiple
             values given, the `other` DataFrame must have a MultiIndex. Can
             pass an array as the join key if it is not already contained in
-            the calling DataFrame. Like an Excel VLOOKUP operation
+            the calling DataFrame. Like an Excel VLOOKUP operation.
         how : {'left', 'right', 'outer', 'inner'}, default: 'left'
             How to handle the operation of the two objects.
 
-            * left: use calling frame's index (or column if on is specified)
-            * right: use other frame's index
+            * left: use calling frame's index (or column if on is specified).
+            * right: use other frame's index.
             * outer: form union of calling frame's index (or column if on is
               specified) with other frame's index, and sort it
-              lexicographically
+              lexicographically.
             * inner: form intersection of calling frame's index (or column if
               on is specified) with other frame's index, preserving the order
-              of the calling's one
+              of the calling's one.
         lsuffix : string
-            Suffix to use from left frame's overlapping columns
+            Suffix to use from left frame's overlapping columns.
         rsuffix : string
-            Suffix to use from right frame's overlapping columns
+            Suffix to use from right frame's overlapping columns.
         sort : boolean, default False
             Order result DataFrame lexicographically by the join key. If False,
-            the order of the join key depends on the join type (how keyword)
+            the order of the join key depends on the join type (how keyword).
 
         Notes
         -----
-        on, lsuffix, and rsuffix options are not supported when passing a list
-        of DataFrame objects
+        The on, lsuffix, and rsuffix options are not supported when passing a list
+        of DataFrame objects.
 
         Support for specifying index levels as the `on` parameter was added
-        in version 0.23.0
+        in version 0.23.0.
 
         Examples
         --------
-        >>> caller = pd.DataFrame({'key': ['K0', 'K1', 'K2', 'K3', 'K4', 'K5'],
-        ...                        'A': ['A0', 'A1', 'A2', 'A3', 'A4', 'A5']})
+        >>> caller = pd.DataFrame({'A': ['A0', 'A1', 'A2', 'A3', 'A4', 'A5'],
+        ...                        'key': ['K0', 'K1', 'K2', 'K3', 'K4', 'K5']})
 
         >>> caller
             A key
@@ -5234,8 +5236,8 @@ class DataFrame(NDFrame):
         4  A4  K4
         5  A5  K5
 
-        >>> other = pd.DataFrame({'key': ['K0', 'K1', 'K2'],
-        ...                       'B': ['B0', 'B1', 'B2']})
+        >>> other = pd.DataFrame({'B': ['B0', 'B1', 'B2'],
+        ...                       'key': ['K0', 'K1', 'K2']})
 
         >>> other
             B key
@@ -5246,30 +5248,27 @@ class DataFrame(NDFrame):
         Join DataFrames using their indexes.
 
         >>> caller.join(other, lsuffix='_caller', rsuffix='_other')
-
-        >>>     A key_caller    B key_other
-            0  A0         K0   B0        K0
-            1  A1         K1   B1        K1
-            2  A2         K2   B2        K2
-            3  A3         K3  NaN       NaN
-            4  A4         K4  NaN       NaN
-            5  A5         K5  NaN       NaN
-
+            A key_caller    B key_other
+        0  A0         K0   B0        K0
+        1  A1         K1   B1        K1
+        2  A2         K2   B2        K2
+        3  A3         K3  NaN       NaN
+        4  A4         K4  NaN       NaN
+        5  A5         K5  NaN       NaN
 
         If we want to join using the key columns, we need to set key to be
         the index in both caller and other. The joined DataFrame will have
         key as its index.
 
         >>> caller.set_index('key').join(other.set_index('key'))
-
-        >>>      A    B
-            key
-            K0   A0   B0
-            K1   A1   B1
-            K2   A2   B2
-            K3   A3  NaN
-            K4   A4  NaN
-            K5   A5  NaN
+          A    B
+        key
+        K0   A0   B0
+        K1   A1   B1
+        K2   A2   B2
+        K3   A3  NaN
+        K4   A4  NaN
+        K5   A5  NaN
 
         Another option to join using the key columns is to use the on
         parameter. DataFrame.join always uses other's index but we can use any
@@ -5277,15 +5276,13 @@ class DataFrame(NDFrame):
         index in the result.
 
         >>> caller.join(other.set_index('key'), on='key')
-
-        >>>     A key    B
-            0  A0  K0   B0
-            1  A1  K1   B1
-            2  A2  K2   B2
-            3  A3  K3  NaN
-            4  A4  K4  NaN
-            5  A5  K5  NaN
-
+            A key    B
+        0  A0  K0   B0
+        1  A1  K1   B1
+        2  A2  K2   B2
+        3  A3  K3  NaN
+        4  A4  K4  NaN
+        5  A5  K5  NaN
 
         See also
         --------

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -5295,17 +5295,14 @@ class DataFrame(NDFrame):
     def join(self, other, on=None, how='left', lsuffix='', rsuffix='',
              sort=False):
         """
-        Join columns with other DataFrame either on a key column.
-
-        Efficiently Join multiple DataFrame objects by index at once by
-        passing a list of DataFrames.
+        Join with other DataFrame on the index or a key column.
 
         Parameters
         ----------
-        other : DataFrame, Series, or list of DataFrame
+        other : DataFrames, Series, or list of DataFrame
             Index should be similar to one of the columns in this one. If a
             Series is passed, its name attribute must be set, since
-            it would be used as the name of the appended
+            it would be used as the name of the added
             column in the resulting Dataframe.
         on : name, tuple/list of names, or array-like
             Column or index level name(s) in the caller to join on the index
@@ -5334,10 +5331,14 @@ class DataFrame(NDFrame):
 
         Notes
         -----
+        Efficiently Join multiple DataFrame objects by index at once by
+        passing a list of DataFrames.
+
         The on, lsuffix, and rsuffix options are not supported when passing
         a list of DataFrame objects.
 
-        If a Series is used as other parameter it must be with name field set.
+        If a Series is used as other parameter,
+        it must be with name attribute set.
 
         Support for specifying index levels as the `on` parameter was added
         in version 0.23.0.

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -5177,18 +5177,18 @@ class DataFrame(NDFrame):
     def join(self, other, on=None, how='left', lsuffix='', rsuffix='',
              sort=False):
         """
-        Join columns with other DataFrame either on index or a key
-        column.
+        Join columns with other DataFrame either on a key column.
 
         Efficiently Join multiple DataFrame objects by index at once by
-        passing a list.
+        passing a list of DataFrames.
 
         Parameters
         ----------
-        other : DataFrame, Series with name field set, or list of DataFrame
+        other : DataFrame, Series, or list of DataFrame
             Index should be similar to one of the columns in this one. If a
-            Series is passed, its name attribute must be set, and that will be
-            used as the column name in the resulting joined DataFrame.
+            Series is passed, its name attribute must be set, since
+            it would be used as the name of the appended
+            column in the resulting Dataframe.
         on : name, tuple/list of names, or array-like
             Column or index level name(s) in the caller to join on the index
             in `other`, otherwise joins index-on-index. If multiple
@@ -5198,11 +5198,11 @@ class DataFrame(NDFrame):
         how : {'left', 'right', 'outer', 'inner'}, default: 'left'
             How to handle the operation of the two objects.
 
-            * left: use calling frame's index (or column if on is specified).
-            * right: use other frame's index.
+            * left: use calling frame's index (or column if on is specified)
+            * right: use other frame's index
             * outer: form union of calling frame's index (or column if on is
               specified) with other frame's index, and sort it
-              lexicographically.
+              lexicographically
             * inner: form intersection of calling frame's index (or column if
               on is specified) with other frame's index, preserving the order
               of the calling's one.
@@ -5219,49 +5219,51 @@ class DataFrame(NDFrame):
         The on, lsuffix, and rsuffix options are not supported when passing
         a list of DataFrame objects.
 
+        If a Series is used as other parameter it must be with name field set.
+
         Support for specifying index levels as the `on` parameter was added
         in version 0.23.0.
 
         Examples
         --------
-        >>> caller = pd.DataFrame({'A': ['A0', 'A1', 'A2', 'A3', 'A4', 'A5'],
-        ...                      'key': ['K0', 'K1', 'K2', 'K3', 'K4', 'K5']})
+        >>> caller = pd.DataFrame({'key': ['K0', 'K1', 'K2', 'K3', 'K4', 'K5'],
+        ...                     'A': ['A0', 'A1', 'A2', 'A3', 'A4', 'A5']})
 
         >>> caller
-            A key
-        0  A0  K0
-        1  A1  K1
-        2  A2  K2
-        3  A3  K3
-        4  A4  K4
-        5  A5  K5
+          key   A
+        0  K0  A0
+        1  K1  A1
+        2  K2  A2
+        3  K3  A3
+        4  K4  A4
+        5  K5  A5
 
-        >>> other = pd.DataFrame({'B': ['B0', 'B1', 'B2'],
-        ...                       'key': ['K0', 'K1', 'K2']})
+        >>> other = pd.DataFrame({'key': ['K0', 'K1', 'K2'],
+        ...                       'B': ['B0', 'B1', 'B2']})
 
         >>> other
-            B key
-        0  B0  K0
-        1  B1  K1
-        2  B2  K2
+          key   B
+        0  K0  B0
+        1  K1  B1
+        2  K2  B2
 
         Join DataFrames using their indexes.
 
         >>> caller.join(other, lsuffix='_caller', rsuffix='_other')
-            A key_caller    B key_other
-        0  A0         K0   B0        K0
-        1  A1         K1   B1        K1
-        2  A2         K2   B2        K2
-        3  A3         K3  NaN       NaN
-        4  A4         K4  NaN       NaN
-        5  A5         K5  NaN       NaN
+          key_caller   A key_other    B
+        0         K0  A0        K0   B0
+        1         K1  A1        K1   B1
+        2         K2  A2        K2   B2
+        3         K3  A3       NaN  NaN
+        4         K4  A4       NaN  NaN
+        5         K5  A5       NaN  NaN
 
         If we want to join using the key columns, we need to set key to be
         the index in both caller and other. The joined DataFrame will have
         key as its index.
 
         >>> caller.set_index('key').join(other.set_index('key'))
-          A    B
+              A    B
         key
         K0   A0   B0
         K1   A1   B1
@@ -5276,15 +5278,15 @@ class DataFrame(NDFrame):
         index in the result.
 
         >>> caller.join(other.set_index('key'), on='key')
-            A key    B
-        0  A0  K0   B0
-        1  A1  K1   B1
-        2  A2  K2   B2
-        3  A3  K3  NaN
-        4  A4  K4  NaN
-        5  A5  K5  NaN
+          key   A    B
+        0  K0  A0   B0
+        1  K1  A1   B1
+        2  K2  A2   B2
+        3  K3  A3  NaN
+        4  K4  A4  NaN
+        5  K5  A5  NaN
 
-        See also
+        See Also
         --------
         DataFrame.merge : For column(s)-on-columns(s) operations
 

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -5216,8 +5216,8 @@ class DataFrame(NDFrame):
 
         Notes
         -----
-        The on, lsuffix, and rsuffix options are not supported when passing a list
-        of DataFrame objects.
+        The on, lsuffix, and rsuffix options are not supported when passing
+        a list of DataFrame objects.
 
         Support for specifying index levels as the `on` parameter was added
         in version 0.23.0.
@@ -5225,7 +5225,7 @@ class DataFrame(NDFrame):
         Examples
         --------
         >>> caller = pd.DataFrame({'A': ['A0', 'A1', 'A2', 'A3', 'A4', 'A5'],
-        ...                        'key': ['K0', 'K1', 'K2', 'K3', 'K4', 'K5']})
+        ...                      'key': ['K0', 'K1', 'K2', 'K3', 'K4', 'K5']})
 
         >>> caller
             A key


### PR DESCRIPTION
Checklist for the pandas documentation sprint (ignore this if you are doing
an unrelated PR):

- [x] PR title is "DOC: update the <your-function-or-method> docstring"
- [x] The validation script passes: `scripts/validate_docstrings.py <your-function-or-method>`
- [x] The PEP8 style check passes: `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] The html version looks good: `python doc/make.py --single <your-function-or-method>`
- [x] It has been proofread on language by another sprint participant

Please include the output of the validation script below between the "```" ticks:

```
################################################################################
###################### Docstring (pandas.DataFrame.join)  ######################
################################################################################

Join columns with other DataFrame either on index or a key
column.

Efficiently Join multiple DataFrame objects by index at once by
passing a list.

Parameters
----------
other : DataFrame, Series with name field set, or list of DataFrame
    Index should be similar to one of the columns in this one. If a
    Series is passed, its name attribute must be set, and that will be
    used as the column name in the resulting joined DataFrame.
on : name, tuple/list of names, or array-like
    Column or index level name(s) in the caller to join on the index
    in `other`, otherwise joins index-on-index. If multiple
    values given, the `other` DataFrame must have a MultiIndex. Can
    pass an array as the join key if it is not already contained in
    the calling DataFrame. Like an Excel VLOOKUP operation.
how : {'left', 'right', 'outer', 'inner'}, default: 'left'
    How to handle the operation of the two objects.

    * left: use calling frame's index (or column if on is specified).
    * right: use other frame's index.
    * outer: form union of calling frame's index (or column if on is
      specified) with other frame's index, and sort it
      lexicographically.
    * inner: form intersection of calling frame's index (or column if
      on is specified) with other frame's index, preserving the order
      of the calling's one.
lsuffix : string
    Suffix to use from left frame's overlapping columns.
rsuffix : string
    Suffix to use from right frame's overlapping columns.
sort : boolean, default False
    Order result DataFrame lexicographically by the join key. If False,
    the order of the join key depends on the join type (how keyword).

Notes
-----
The on, lsuffix, and rsuffix options are not supported when passing
a list of DataFrame objects.

Support for specifying index levels as the `on` parameter was added
in version 0.23.0.

Examples
--------
>>> caller = pd.DataFrame({'A': ['A0', 'A1', 'A2', 'A3', 'A4', 'A5'],
...                      'key': ['K0', 'K1', 'K2', 'K3', 'K4', 'K5']})

>>> caller
    A key
0  A0  K0
1  A1  K1
2  A2  K2
3  A3  K3
4  A4  K4
5  A5  K5

>>> other = pd.DataFrame({'B': ['B0', 'B1', 'B2'],
...                       'key': ['K0', 'K1', 'K2']})

>>> other
    B key
0  B0  K0
1  B1  K1
2  B2  K2

Join DataFrames using their indexes.

>>> caller.join(other, lsuffix='_caller', rsuffix='_other')
    A key_caller    B key_other
0  A0         K0   B0        K0
1  A1         K1   B1        K1
2  A2         K2   B2        K2
3  A3         K3  NaN       NaN
4  A4         K4  NaN       NaN
5  A5         K5  NaN       NaN

If we want to join using the key columns, we need to set key to be
the index in both caller and other. The joined DataFrame will have
key as its index.

>>> caller.set_index('key').join(other.set_index('key'))
  A    B
key
K0   A0   B0
K1   A1   B1
K2   A2   B2
K3   A3  NaN
K4   A4  NaN
K5   A5  NaN

Another option to join using the key columns is to use the on
parameter. DataFrame.join always uses other's index but we can use any
column in the caller. This method preserves the original caller's
index in the result.

>>> caller.join(other.set_index('key'), on='key')
    A key    B
0  A0  K0   B0
1  A1  K1   B1
2  A2  K2   B2
3  A3  K3  NaN
4  A4  K4  NaN
5  A5  K5  NaN

See also
--------
DataFrame.merge : For column(s)-on-columns(s) operations

Returns
-------
joined : DataFrame

################################################################################
################################## Validation ##################################
################################################################################

Docstring for "pandas.DataFrame.join" correct. :)
```

If the validation script still gives errors, but you think there is a good reason
to deviate in this case (and there are certainly such cases), please state this
explicitly.
