### PR TITLE
DOC: update the docstring of pandas.DataFrame.info

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -1813,7 +1813,7 @@ class DataFrame(NDFrame):
     def info(self, verbose=None, buf=None, max_cols=None, memory_usage=None,
              null_counts=None):
         """
-        Concise summary of a DataFrame.
+        Prints a concise summary of a DataFrame.
 
         This method prints information about DataFrame: index dtype, columns
         dtypes, non-null values and memory usage.

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -1815,8 +1815,8 @@ class DataFrame(NDFrame):
         """
         Print a concise summary of a DataFrame.
 
-        This method prints information about DataFrame: index dtype, columns
-        dtypes, non-null values and memory usage.
+        This method prints information about a DataFrame including
+        the index dtype and column dtypes, non-null values and memory usage.
 
         Parameters
         ----------

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -1813,50 +1813,53 @@ class DataFrame(NDFrame):
     def info(self, verbose=None, buf=None, max_cols=None, memory_usage=None,
              null_counts=None):
         """
-        Prints a concise summary of a DataFrame.
+        Print a concise summary of a DataFrame.
 
         This method prints information about DataFrame: index dtype, columns
         dtypes, non-null values and memory usage.
 
         Parameters
         ----------
-        verbose : {None, True, False}, optional
-            Whether to print the full summary.
-            None follows the `display.max_info_columns` setting.
-            True or False overrides the `display.max_info_columns` setting.
+        verbose : bool, optional
+            Whether to print the full summary. By default, the setting in
+            ``pandas.options.display.max_info_columns`` is followed. This can
+            be overridden by passing `verbose`.
         buf : writable buffer, defaults to sys.stdout
-            Whether to pipe the output.
-        max_cols : int, default None
-            Determines whether full summary or short summary is printed.
-            None follows the `display.max_info_columns` setting.
-        memory_usage : boolean/string, default None
+            Where to send the output. By default, the output is printed to
+            sys.stdout. Pass a writable buffer if you need to further process
+            the output.
+        max_cols : int, optional
+            When to switch from the verbose to the truncated output. By
+            default, the setting in ``pandas.options.display.max_info_columns``
+            is used. This can be overridden by passing `max_cols`.
+        memory_usage : bool, str, optional
             Specifies whether total memory usage of the DataFrame
-            elements (including index) should be displayed. None follows
-            the `display.memory_usage` setting. True or False overrides
-            the `display.memory_usage` setting. A value of 'deep' is equivalent
-            of True, with deep introspection. Memory usage is shown in
-            human-readable units (base-2 representation). Without deep introspection
-            a memory estimation is made based in column dtype and number of rows
-            assuming values consume the same memory amount for corresponding dtypes.
-            With deep memory introspection, a real memory usage calculation is performed
+            elements (including the index) should be displayed. By default,
+            this follows the ``pandas.options.display.memory_usage`` setting.
+            This can be overridden by passing `memory_usage`.
+            A value of 'deep' is equivalent to "True with deep introspection".
+            Memory usage is shown in human-readable units (base-2
+            representation). Without deep introspection a memory estimation is
+            made based in column dtype and number of rows assuming values
+            consume the same memory amount for corresponding dtypes. With deep
+            memory introspection, a real memory usage calculation is performed
             at the cost of computational resources.
-        null_counts : boolean, default None
-            Whether to show the non-null counts
-
-            - If None, then only show if the frame is smaller than
-              max_info_rows and max_info_columns.
-            - If True, always show counts.
-            - If False, never show counts.
+        null_counts : bool, optional
+            Whether to show the non-null counts. By default, this is shown
+            only if the frame is smaller than
+            ``pandas.options.display.max_info_rows`` and
+            ``pandas.options.display.max_info_columns``. A value of True always
+            shows the counts, and False never shows the counts.
 
         Returns
         -------
-        None: NoneType
+        None
             This method prints a summary of a DataFrame and returns None.
 
         See Also
         --------
-
-        DataFrame.describe: Generate descriptive statistics of DataFrame columns.
+        DataFrame.describe: Generate descriptive statistics of DataFrame
+            columns.
         DataFrame.memory_usage: Memory usage of DataFrame columns.
 
         Examples
@@ -1864,7 +1867,8 @@ class DataFrame(NDFrame):
         >>> int_values = [1, 2, 3, 4, 5]
         >>> text_values = ['alpha', 'beta', 'gamma', 'delta', 'epsilon']
         >>> float_values = [0.0, 0.25, 0.5, 0.75, 1.0]
-        >>> df = pd.DataFrame({"int_col": int_values, "text_col": text_values, "float_col": float_values})
+        >>> df = pd.DataFrame({"int_col": int_values, "text_col": text_values,
+        ...                   "float_col": float_values})
         >>> df
            int_col text_col  float_col
         0        1    alpha       0.00
@@ -1873,7 +1877,7 @@ class DataFrame(NDFrame):
         3        4    delta       0.75
         4        5  epsilon       1.00
 
-        Prints information of all columns overriding default `display.max_info_columns` setting:
+        Prints information of all columns:
 
         >>> df.info(verbose=True)
         <class 'pandas.core.frame.DataFrame'>
@@ -1885,7 +1889,8 @@ class DataFrame(NDFrame):
         dtypes: float64(1), int64(1), object(1)
         memory usage: 200.0+ bytes
 
-        Prints a summary of columns count and its dtypes but not per column information:
+        Prints a summary of columns count and its dtypes but not per column
+        information:
 
         >>> df.info(verbose=False)
         <class 'pandas.core.frame.DataFrame'>
@@ -1894,8 +1899,8 @@ class DataFrame(NDFrame):
         dtypes: float64(1), int64(1), object(1)
         memory usage: 200.0+ bytes
 
-        Pipe output of DataFrame.info to buffer instead of sys.stdout, get buffer content
-        and writes to a text file:
+        Pipe output of DataFrame.info to buffer instead of sys.stdout, get
+        buffer content and writes to a text file:
 
         >>> import io
         >>> buffer = io.StringIO()
@@ -1905,13 +1910,15 @@ class DataFrame(NDFrame):
         ...     f.write(s)
         260
 
-        The `memory_usage` parameter allows deep introspection mode, specially useful for
-        big DataFrames and fine-tune memory optimization:
+        The `memory_usage` parameter allows deep introspection mode, specially
+        useful for big DataFrames and fine-tune memory optimization:
 
         >>> random_strings_array = np.random.choice(['a', 'b', 'c'], 10 ** 6)
-        >>> df = pd.DataFrame({'column_1': np.random.choice(['a', 'b', 'c'], 10 ** 6),
-        ...                    'column_2': np.random.choice(['a', 'b', 'c'], 10 ** 6),
-        ...                    'column_3': np.random.choice(['a', 'b', 'c'], 10 ** 6)})
+        >>> df = pd.DataFrame({
+        ...     'column_1': np.random.choice(['a', 'b', 'c'], 10 ** 6),
+        ...     'column_2': np.random.choice(['a', 'b', 'c'], 10 ** 6),
+        ...     'column_3': np.random.choice(['a', 'b', 'c'], 10 ** 6)
+        ... })
         >>> df.info()
         <class 'pandas.core.frame.DataFrame'>
         RangeIndex: 1000000 entries, 0 to 999999
@@ -1921,6 +1928,7 @@ class DataFrame(NDFrame):
         column_3    1000000 non-null object
         dtypes: object(3)
         memory usage: 22.9+ MB
+
         >>> df.info(memory_usage='deep')
         <class 'pandas.core.frame.DataFrame'>
         RangeIndex: 1000000 entries, 0 to 999999

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -1822,21 +1822,22 @@ class DataFrame(NDFrame):
         ----------
         verbose : bool, optional
             Whether to print the full summary. By default, the setting in
-            ``pandas.options.display.max_info_columns`` is followed. This can
-            be overridden by passing `verbose`.
+            ``pandas.options.display.max_info_columns`` is followed.
         buf : writable buffer, defaults to sys.stdout
             Where to send the output. By default, the output is printed to
             sys.stdout. Pass a writable buffer if you need to further process
             the output.
         max_cols : int, optional
-            When to switch from the verbose to the truncated output. By
-            default, the setting in ``pandas.options.display.max_info_columns``
-            is used. This can be overridden by passing `max_cols`.
+            When to switch from the verbose to the truncated output. If the
+            DataFrame has more than `max_cols` columns, the truncated output
+            is used. By default, the setting in
+            ``pandas.options.display.max_info_columns`` is used.
         memory_usage : bool, str, optional
             Specifies whether total memory usage of the DataFrame
             elements (including the index) should be displayed. By default,
             this follows the ``pandas.options.display.memory_usage`` setting.
-            This can be overridden by passing `memory_usage`.
+
+            True always show memory usage. False never shows memory usage.
             A value of 'deep' is equivalent to "True with deep introspection".
             Memory usage is shown in human-readable units (base-2
             representation). Without deep introspection a memory estimation is

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -1815,6 +1815,9 @@ class DataFrame(NDFrame):
         """
         Concise summary of a DataFrame.
 
+        This method shows information about DataFrame type of index, columns
+        dtypes and non-null values and memory usage.
+
         Parameters
         ----------
         verbose : {None, True, False}, optional
@@ -1822,6 +1825,7 @@ class DataFrame(NDFrame):
             None follows the `display.max_info_columns` setting.
             True or False overrides the `display.max_info_columns` setting.
         buf : writable buffer, defaults to sys.stdout
+            Whether to pipe the output.
         max_cols : int, default None
             Determines whether full summary or short summary is printed.
             None follows the `display.max_info_columns` setting.
@@ -1840,6 +1844,56 @@ class DataFrame(NDFrame):
             - If True, always show counts.
             - If False, never show counts.
 
+        Returns
+        -------
+        None: NoneType
+            This method outputs a summary of a DataFrame and returns None.
+
+        Examples
+        --------
+        >>> df = pd.DataFrame({"int_col": [1, 2, 3, 4, 5], "text_col": ['alpha', 'beta', 'gamma', 'delta', 'epsilon'], "float_col": [0.0, 0.25, 0.5, 0.75, 1.0]})
+        >>> df
+           int_col text_col  float_col
+        0        1    alpha       0.00
+        1        2     beta       0.25
+        2        3    gamma       0.50
+        3        4    delta       0.75
+        4        5  epsilon       1.00
+
+        >>> df.info(verbose=True)
+        <class 'pandas.core.frame.DataFrame'>
+        RangeIndex: 5 entries, 0 to 4
+        Data columns (total 3 columns):
+        int_col      5 non-null int64
+        text_col     5 non-null object
+        float_col    5 non-null float64
+        dtypes: float64(1), int64(1), object(1)
+        memory usage: 200.0+ bytes
+
+        >>> df.info(verbose=False)
+        <class 'pandas.core.frame.DataFrame'>
+        RangeIndex: 5 entries, 0 to 4
+        Columns: 3 entries, int_col to float_col
+        dtypes: float64(1), int64(1), object(1)
+        memory usage: 200.0+ bytes
+
+        >>> file = open("df_info.txt", "w", encoding="utf-8")
+        >>> df.info(buf=file)
+
+        >>> df.drop('text_col', axis=1, inplace=True)
+        >>> df.info(memory_usage='Deep')
+        <class 'pandas.core.frame.DataFrame'>
+        RangeIndex: 5 entries, 0 to 4
+        Data columns (total 2 columns):
+        int_col      5 non-null int64
+        float_col    5 non-null float64
+        dtypes: float64(1), int64(1)
+        memory usage: 160.0 bytes
+
+        See Also
+        --------
+
+        describe: Generate descriptive statistics of DataFrame columns.
         """
         from pandas.io.formats.format import _put_lines
 

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -1851,7 +1851,10 @@ class DataFrame(NDFrame):
 
         Examples
         --------
-        >>> df = pd.DataFrame({"int_col": [1, 2, 3, 4, 5], "text_col": ['alpha', 'beta', 'gamma', 'delta', 'epsilon'], "float_col": [0.0, 0.25, 0.5, 0.75, 1.0]})
+        >>> int_values = [1, 2, 3, 4, 5]
+        >>> text_values = ['alpha', 'beta', 'gamma', 'delta', 'epsilon']
+        >>> float_values = [0.0, 0.25, 0.5, 0.75, 1.0]
+        >>> df = pd.DataFrame({"int_col": int_values, "text_col": text_values, "float_col": float_values})
         >>> df
            int_col text_col  float_col
         0        1    alpha       0.00

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -1816,7 +1816,7 @@ class DataFrame(NDFrame):
         Concise summary of a DataFrame.
 
         This method shows information about DataFrame type of index, columns
-        dtypes and non-null values and memory usage.
+        dtypes, non-null values and memory usage.
 
         Parameters
         ----------
@@ -1882,6 +1882,7 @@ class DataFrame(NDFrame):
 
         >>> file = open("df_info.txt", "w", encoding="utf-8")
         >>> df.info(buf=file)
+        >>> file.close()
 
         >>> df.drop('text_col', axis=1, inplace=True)
         >>> df.info(memory_usage='Deep')

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -1835,7 +1835,7 @@ class DataFrame(NDFrame):
             the `display.memory_usage` setting. True or False overrides
             the `display.memory_usage` setting. A value of 'deep' is equivalent
             of True, with deep introspection. Memory usage is shown in
-            human-readable units (base-2 representation). Without deep instrospection
+            human-readable units (base-2 representation). Without deep introspection
             a memory estimation is made based in column dtype and number of rows
             assuming values consume the same memory amount for corresponding dtypes.
             With deep memory introspection, a real memory usage calculation is performed
@@ -1856,7 +1856,8 @@ class DataFrame(NDFrame):
         See Also
         --------
 
-        describe: Generate descriptive statistics of DataFrame columns.
+        DataFrame.describe: Generate descriptive statistics of DataFrame columns.
+        DataFrame.memory_usage: Memory usage of DataFrame columns.
 
         Examples
         --------
@@ -1872,6 +1873,8 @@ class DataFrame(NDFrame):
         3        4    delta       0.75
         4        5  epsilon       1.00
 
+        Prints information of all columns overriding default `display.max_info_columns` setting:
+
         >>> df.info(verbose=True)
         <class 'pandas.core.frame.DataFrame'>
         RangeIndex: 5 entries, 0 to 4
@@ -1882,12 +1885,17 @@ class DataFrame(NDFrame):
         dtypes: float64(1), int64(1), object(1)
         memory usage: 200.0+ bytes
 
+        Prints a summary of columns count and its dtypes but not per column information:
+
         >>> df.info(verbose=False)
         <class 'pandas.core.frame.DataFrame'>
         RangeIndex: 5 entries, 0 to 4
         Columns: 3 entries, int_col to float_col
         dtypes: float64(1), int64(1), object(1)
         memory usage: 200.0+ bytes
+
+        Pipe output of DataFrame.info to buffer instead of sys.stdout, get buffer content
+        and writes to a text file:
 
         >>> import io
         >>> buffer = io.StringIO()
@@ -1896,6 +1904,9 @@ class DataFrame(NDFrame):
         >>> with open("df_info.txt", "w", encoding="utf-8") as f:
         ...     f.write(s)
         260
+
+        The `memory_usage` parameter allows deep introspection mode, specially useful for
+        big DataFrames and fine-tune memory optimization:
 
         >>> random_strings_array = np.random.choice(['a', 'b', 'c'], 10 ** 6)
         >>> df = pd.DataFrame({'column_1': np.random.choice(['a', 'b', 'c'], 10 ** 6),

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -1815,7 +1815,7 @@ class DataFrame(NDFrame):
         """
         Concise summary of a DataFrame.
 
-        This method shows information about DataFrame type of index, columns
+        This method prints information about DataFrame: index dtype, columns
         dtypes, non-null values and memory usage.
 
         Parameters
@@ -1835,7 +1835,11 @@ class DataFrame(NDFrame):
             the `display.memory_usage` setting. True or False overrides
             the `display.memory_usage` setting. A value of 'deep' is equivalent
             of True, with deep introspection. Memory usage is shown in
-            human-readable units (base-2 representation).
+            human-readable units (base-2 representation). Without deep instrospection
+            a memory estimation is made based in column dtype and number of rows
+            assuming values consume the same memory amount for corresponding dtypes.
+            With deep memory introspection, a real memory usage calculation is performed
+            at the cost of computational resources.
         null_counts : boolean, default None
             Whether to show the non-null counts
 
@@ -1847,7 +1851,12 @@ class DataFrame(NDFrame):
         Returns
         -------
         None: NoneType
-            This method outputs a summary of a DataFrame and returns None.
+            This method prints a summary of a DataFrame and returns None.
+
+        See Also
+        --------
+
+        describe: Generate descriptive statistics of DataFrame columns.
 
         Examples
         --------
@@ -1880,24 +1889,36 @@ class DataFrame(NDFrame):
         dtypes: float64(1), int64(1), object(1)
         memory usage: 200.0+ bytes
 
-        >>> file = open("df_info.txt", "w", encoding="utf-8")
-        >>> df.info(buf=file)
-        >>> file.close()
+        >>> import io
+        >>> buffer = io.StringIO()
+        >>> df.info(buf=buffer)
+        >>> s = buffer.getvalue()
+        >>> with open("df_info.txt", "w", encoding="utf-8") as f:
+        ...     f.write(s)
+        260
 
-        >>> df.drop('text_col', axis=1, inplace=True)
-        >>> df.info(memory_usage='Deep')
+        >>> random_strings_array = np.random.choice(['a', 'b', 'c'], 10 ** 6)
+        >>> df = pd.DataFrame({'column_1': np.random.choice(['a', 'b', 'c'], 10 ** 6),
+        ...                    'column_2': np.random.choice(['a', 'b', 'c'], 10 ** 6),
+        ...                    'column_3': np.random.choice(['a', 'b', 'c'], 10 ** 6)})
+        >>> df.info()
         <class 'pandas.core.frame.DataFrame'>
-        RangeIndex: 5 entries, 0 to 4
-        Data columns (total 2 columns):
-        int_col      5 non-null int64
-        float_col    5 non-null float64
-        dtypes: float64(1), int64(1)
-        memory usage: 160.0 bytes
-
-        See Also
-        --------
-
-        describe: Generate descriptive statistics of DataFrame columns.
+        RangeIndex: 1000000 entries, 0 to 999999
+        Data columns (total 3 columns):
+        column_1    1000000 non-null object
+        column_2    1000000 non-null object
+        column_3    1000000 non-null object
+        dtypes: object(3)
+        memory usage: 22.9+ MB
+        >>> df.info(memory_usage='deep')
+        <class 'pandas.core.frame.DataFrame'>
+        RangeIndex: 1000000 entries, 0 to 999999
+        Data columns (total 3 columns):
+        column_1    1000000 non-null object
+        column_2    1000000 non-null object
+        column_3    1000000 non-null object
+        dtypes: object(3)
+        memory usage: 188.8 MB
         """
         from pandas.io.formats.format import _put_lines
 


### PR DESCRIPTION
Checklist for the pandas documentation sprint (ignore this if you are doing
an unrelated PR):

- [x] PR title is "DOC: update the <your-function-or-method> docstring"
- [x] The validation script passes: `scripts/validate_docstrings.py <your-function-or-method>`
- [x] The PEP8 style check passes: `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] The html version looks good: `python doc/make.py --single <your-function-or-method>`
- [x] It has been proofread on language by another sprint participant

Please include the output of the validation script below between the "```" ticks:

```
(pandas_dev) david@david-TM1604:~/repos/pandas/scripts$ python validate_docstrings.py pandas.DataFrame.info

################################################################################
###################### Docstring (pandas.DataFrame.info)  ######################
################################################################################

Concise summary of a DataFrame.

This method shows information about DataFrame type of index, columns
dtypes and non-null values and memory usage.

Parameters
----------
verbose : {None, True, False}, optional
    Whether to print the full summary.
    None follows the `display.max_info_columns` setting.
    True or False overrides the `display.max_info_columns` setting.
buf : writable buffer, defaults to sys.stdout
    Whether to pipe the output.
max_cols : int, default None
    Determines whether full summary or short summary is printed.
    None follows the `display.max_info_columns` setting.
memory_usage : boolean/string, default None
    Specifies whether total memory usage of the DataFrame
    elements (including index) should be displayed. None follows
    the `display.memory_usage` setting. True or False overrides
    the `display.memory_usage` setting. A value of 'deep' is equivalent
    of True, with deep introspection. Memory usage is shown in
    human-readable units (base-2 representation).
null_counts : boolean, default None
    Whether to show the non-null counts

    - If None, then only show if the frame is smaller than
      max_info_rows and max_info_columns.
    - If True, always show counts.
    - If False, never show counts.

Returns
-------
None: NoneType
    This method outputs a summary of a DataFrame and returns None.

Examples
--------
>>> int_values = [1, 2, 3, 4, 5]
>>> text_values = ['alpha', 'beta', 'gamma', 'delta', 'epsilon']
>>> float_values = [0.0, 0.25, 0.5, 0.75, 1.0]
>>> df = pd.DataFrame({"int_col": int_values, "text_col": text_values, "float_col": float_values})
>>> df
   int_col text_col  float_col
0        1    alpha       0.00
1        2     beta       0.25
2        3    gamma       0.50
3        4    delta       0.75
4        5  epsilon       1.00

>>> df.info(verbose=True)
<class 'pandas.core.frame.DataFrame'>
RangeIndex: 5 entries, 0 to 4
Data columns (total 3 columns):
int_col      5 non-null int64
text_col     5 non-null object
float_col    5 non-null float64
dtypes: float64(1), int64(1), object(1)
memory usage: 200.0+ bytes

>>> df.info(verbose=False)
<class 'pandas.core.frame.DataFrame'>
RangeIndex: 5 entries, 0 to 4
Columns: 3 entries, int_col to float_col
dtypes: float64(1), int64(1), object(1)
memory usage: 200.0+ bytes

>>> file = open("df_info.txt", "w", encoding="utf-8")
>>> df.info(buf=file)

>>> df.drop('text_col', axis=1, inplace=True)
>>> df.info(memory_usage='Deep')
<class 'pandas.core.frame.DataFrame'>
RangeIndex: 5 entries, 0 to 4
Data columns (total 2 columns):
int_col      5 non-null int64
float_col    5 non-null float64
dtypes: float64(1), int64(1)
memory usage: 160.0 bytes

See Also
--------

describe: Generate descriptive statistics of DataFrame columns.

################################################################################
################################## Validation ##################################
################################################################################

Docstring for "pandas.DataFrame.info" correct. :)
```

If the validation script still gives errors, but you think there is a good reason
to deviate in this case (and there are certainly such cases), please state this
explicitly.


Checklist for other PRs (remove this part if you are doing a PR for the pandas documentation sprint):

- [ ] closes #xxxx
- [ ] tests added / passed
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
