### PR TITLE
Docstring changes to pandas.Series.dt.to_pydatetime

### DIFF
--- a/pandas/core/indexes/accessors.py
+++ b/pandas/core/indexes/accessors.py
@@ -127,27 +127,41 @@ class DatetimeProperties(Properties):
 
     def to_pydatetime(self):
         """
-        Return Series as a native Python datetime objects.
+        Return an ndarray of native Python datetime objects.
+
+        Timezone information is retained if present.
 
         Returns
         -------
-        Series of object dtype
-
-        See Also
-        --------
-        pandas.DatetimeIndex.to_pydatetime : Convert a Timestamp object to a native
-            Python datetime object.
+        numpy.ndarray
+            object dtype array containing native Python datetime objects.
 
         Examples
         --------
+        This method is available on both Series with datetime values, under the
+        ``.dt`` accessor, and directly on DatetimeIndex.
+
+        **Series**
+
         >>> s = pd.Series(pd.date_range('20180310', periods=2))
         >>> s.head()
         0   2018-03-10
         1   2018-03-11
         dtype: datetime64[ns]
+
         >>> s.dt.to_pydatetime()
         array([datetime.datetime(2018, 3, 10, 0, 0),
-            datetime.datetime(2018, 3, 11, 0, 0)], dtype=object)
+               datetime.datetime(2018, 3, 11, 0, 0)], dtype=object)
+
+        **DatetimeIndex**
+        >>> idx = pd.date_range("2018-03-10", periods=2)
+        >>> idx  # doctest: +NORMALIZE_WHITESPACE
+        DatetimeIndex(['2018-03-10', '2018-03-11'],
+                      dtype='datetime64[ns]', freq='D')
+
+        >>> idx.to_pydatetime()
+        array([datetime.datetime(2018, 3, 10, 0, 0),
+               datetime.datetime(2018, 3, 11, 0, 0)], dtype=object)
         """
         return self._get_values().to_pydatetime()
 

--- a/pandas/core/indexes/accessors.py
+++ b/pandas/core/indexes/accessors.py
@@ -127,29 +127,23 @@ class DatetimeProperties(Properties):
 
     def to_pydatetime(self):
         """
-        Return DatetimeIndex as object ndarray of datetime.datetime objects.
-
-        This function converts the Pandas Series DatetimeIndex to
-        a ndarray object. These two types are different and hence
-        2 differnt functions.
+        Return DatetimeIndex as an object ndarray.
 
         Returns
         -------
-        datetimes : ndarray
+        ndarray of object dtype
 
         See Also
         --------
-        pd.DatetimeIndex.to_pydatetime : Convert a Timestamp object to a native
+        pandas.DatetimeIndex.to_pydatetime : Convert a Timestamp object to a native
             Python datetime object.
-        pd.date.dt.values.to_datetime : For an Index containing strings or
-            datetime.datetime objects, attempt conversion to DatetimeIndex.
 
         Examples
         --------
-        >>> df = pd.DataFrame({'date': [pd.to_datetime('2018-03-10'), pd.to_datetime('2017-02-01')]})
+        >>> df = pd.Series(pd.date_range('20180310', periods=2))
         >>> type(df)
-        <class 'pandas.core.frame.DataFrame'>
-        >>> type(df.date.dt.to_pydatetime())
+        <class 'pandas.core.series.Series'>
+        >>> type(df.dt.to_pydatetime())
         <class 'numpy.ndarray'>
         """
         return self._get_values().to_pydatetime()

--- a/pandas/core/indexes/accessors.py
+++ b/pandas/core/indexes/accessors.py
@@ -133,8 +133,8 @@ class DatetimeProperties(Properties):
 
         .. warning::
 
-           Python's datetimes use microsecond resolution, which is lower than
-           pandas' (nanosecond). The values are truncated.
+           Python's datetime uses microsecond resolution, which is lower than
+           pandas (nanosecond). The values are truncated.
 
         Returns
         -------
@@ -148,7 +148,7 @@ class DatetimeProperties(Properties):
         Examples
         --------
         >>> s = pd.Series(pd.date_range('20180310', periods=2))
-        >>> s.head()
+        >>> s
         0   2018-03-10
         1   2018-03-11
         dtype: datetime64[ns]
@@ -159,14 +159,15 @@ class DatetimeProperties(Properties):
 
         pandas' nanosecond precision is truncated to microseconds.
 
-        >>> idx = pd.date_range('2017', periods=2, freq='ns')
-        >>> idx
-        DatetimeIndex(['2017-01-01 00:00:00', '2017-01-01 00:00:00.000000001'],
-                      dtype='datetime64[ns]', freq='N')
+        >>> s = pd.Series(pd.date_range('20180310', periods=2, freq='ns'))
+        >>> s
+        0   2018-03-10 00:00:00.000000000
+        1   2018-03-10 00:00:00.000000001
+        dtype: datetime64[ns]
 
-        >>> idx.to_pydatetime()
-        array([datetime.datetime(2017, 1, 1, 0, 0),
-               datetime.datetime(2017, 1, 1, 0, 0)], dtype=object)
+        >>> s.dt.to_pydatetime()
+        array([datetime.datetime(2018, 3, 10, 0, 0),
+               datetime.datetime(2018, 3, 10, 0, 0)], dtype=object)
         """
         return self._get_values().to_pydatetime()
 

--- a/pandas/core/indexes/accessors.py
+++ b/pandas/core/indexes/accessors.py
@@ -126,6 +126,31 @@ class DatetimeProperties(Properties):
     """
 
     def to_pydatetime(self):
+        """
+        Return DatetimeIndex as object ndarray of datetime.datetime objects.
+
+        This function converts the Pandas Series DatetimeIndex to
+        a ndarray object. These two types are different and hence
+        2 differnt functions.
+
+        Returns
+        -------
+        datetimes : ndarray
+
+        See Also
+        --------
+        pd.DatetimeIndex.to_pydatetime : Convert a Timestamp object to a native Python datetime object.
+        pd.date.dt.values.to_datetime : For an Index containing strings or datetime.datetime objects, attempt
+            conversion to DatetimeIndex.
+
+        Examples
+        --------
+        >>> df = pd.DataFrame({'date': [pd.to_datetime('2018-03-10'), pd.to_datetime('2017-02-01')]})
+        >>> type(df)
+        <class 'pandas.core.frame.DataFrame'>
+        >>> type(df.date.dt.to_pydatetime())
+        <class 'numpy.ndarray'>
+        """
         return self._get_values().to_pydatetime()
 
     @property

--- a/pandas/core/indexes/accessors.py
+++ b/pandas/core/indexes/accessors.py
@@ -139,9 +139,10 @@ class DatetimeProperties(Properties):
 
         See Also
         --------
-        pd.DatetimeIndex.to_pydatetime : Convert a Timestamp object to a native Python datetime object.
-        pd.date.dt.values.to_datetime : For an Index containing strings or datetime.datetime objects, attempt
-            conversion to DatetimeIndex.
+        pd.DatetimeIndex.to_pydatetime : Convert a Timestamp object to a native
+            Python datetime object.
+        pd.date.dt.values.to_datetime : For an Index containing strings or
+            datetime.datetime objects, attempt conversion to DatetimeIndex.
 
         Examples
         --------

--- a/pandas/core/indexes/accessors.py
+++ b/pandas/core/indexes/accessors.py
@@ -127,11 +127,11 @@ class DatetimeProperties(Properties):
 
     def to_pydatetime(self):
         """
-        Return DatetimeIndex as an object ndarray.
+        Return Series as a native Python datetime objects.
 
         Returns
         -------
-        ndarray of object dtype
+        Series of object dtype
 
         See Also
         --------
@@ -140,11 +140,14 @@ class DatetimeProperties(Properties):
 
         Examples
         --------
-        >>> df = pd.Series(pd.date_range('20180310', periods=2))
-        >>> type(df)
-        <class 'pandas.core.series.Series'>
-        >>> type(df.dt.to_pydatetime())
-        <class 'numpy.ndarray'>
+        >>> s = pd.Series(pd.date_range('20180310', periods=2))
+        >>> s.head()
+        0   2018-03-10
+        1   2018-03-11
+        dtype: datetime64[ns]
+        >>> s.dt.to_pydatetime()
+        array([datetime.datetime(2018, 3, 10, 0, 0),
+            datetime.datetime(2018, 3, 11, 0, 0)], dtype=object)
         """
         return self._get_values().to_pydatetime()
 

--- a/pandas/core/indexes/accessors.py
+++ b/pandas/core/indexes/accessors.py
@@ -127,7 +127,7 @@ class DatetimeProperties(Properties):
 
     def to_pydatetime(self):
         """
-        Return an ndarray of native Python datetime objects.
+        Return the data as an array of native Python datetime objects
 
         Timezone information is retained if present.
 

--- a/pandas/core/indexes/accessors.py
+++ b/pandas/core/indexes/accessors.py
@@ -131,10 +131,19 @@ class DatetimeProperties(Properties):
 
         Timezone information is retained if present.
 
+        .. warning::
+
+           Python's datetimes use microsecond resolution, which is lower than
+           pandas' (nanosecond). The values are truncated.
+
         Returns
         -------
         numpy.ndarray
             object dtype array containing native Python datetime objects.
+
+        See Also
+        --------
+        datetime.datetime : Standard library value for a datetime.
 
         Examples
         --------
@@ -147,6 +156,17 @@ class DatetimeProperties(Properties):
         >>> s.dt.to_pydatetime()
         array([datetime.datetime(2018, 3, 10, 0, 0),
                datetime.datetime(2018, 3, 11, 0, 0)], dtype=object)
+
+        pandas' nanosecond precision is truncated to microseconds.
+
+        >>> idx = pd.date_range('2017', periods=2, freq='ns')
+        >>> idx
+        DatetimeIndex(['2017-01-01 00:00:00', '2017-01-01 00:00:00.000000001'],
+                      dtype='datetime64[ns]', freq='N')
+
+        >>> idx.to_pydatetime()
+        array([datetime.datetime(2017, 1, 1, 0, 0),
+               datetime.datetime(2017, 1, 1, 0, 0)], dtype=object)
         """
         return self._get_values().to_pydatetime()
 

--- a/pandas/core/indexes/accessors.py
+++ b/pandas/core/indexes/accessors.py
@@ -138,11 +138,6 @@ class DatetimeProperties(Properties):
 
         Examples
         --------
-        This method is available on both Series with datetime values, under the
-        ``.dt`` accessor, and directly on DatetimeIndex.
-
-        **Series**
-
         >>> s = pd.Series(pd.date_range('20180310', periods=2))
         >>> s.head()
         0   2018-03-10
@@ -150,16 +145,6 @@ class DatetimeProperties(Properties):
         dtype: datetime64[ns]
 
         >>> s.dt.to_pydatetime()
-        array([datetime.datetime(2018, 3, 10, 0, 0),
-               datetime.datetime(2018, 3, 11, 0, 0)], dtype=object)
-
-        **DatetimeIndex**
-        >>> idx = pd.date_range("2018-03-10", periods=2)
-        >>> idx  # doctest: +NORMALIZE_WHITESPACE
-        DatetimeIndex(['2018-03-10', '2018-03-11'],
-                      dtype='datetime64[ns]', freq='D')
-
-        >>> idx.to_pydatetime()
         array([datetime.datetime(2018, 3, 10, 0, 0),
                datetime.datetime(2018, 3, 11, 0, 0)], dtype=object)
         """


### PR DESCRIPTION
Checklist for the pandas documentation sprint (ignore this if you are doing
an unrelated PR):

- [x] PR title is "DOC: update the <your-function-or-method> docstring"
- [x] The validation script passes: `scripts/validate_docstrings.py <your-function-or-method>`
- [x] The PEP8 style check passes: `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] The html version looks good: `python doc/make.py --single <your-function-or-method>`
- [x] It has been proofread on language by another sprint participant

Please include the output of the validation script below between the "```" ticks:

```
scripts/validate_docstrings.py pandas.Series.dt.to_pydatetime

Errors found:
        No extended summary found

Extended Summary removed as per Reviewers suggestion.


Checklist for other PRs (remove this part if you are doing a PR for the pandas documentation sprint):

- [x] closes #xxxx
- [ ] tests added / passed
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
