### PR TITLE
DOC: update the DataFrame.update() docstring

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -4217,7 +4217,8 @@ class DataFrame(NDFrame):
             Series is passed, its name attribute must be set, and that will be
             used as the column name in the resulting joined DataFrame.
         join : {'left'}, default 'left'
-            Indicates which column values overwrite.
+            Only left join is implemented,
+            keeping the index and columns of the original object.
         overwrite : boolean, default True
             If True then overwrite values for common keys in the calling frame.
         filter_func : callable(1d-array) -> 1d-array<boolean>, default None
@@ -4248,6 +4249,8 @@ class DataFrame(NDFrame):
         1  2  5
         2  3  6
 
+        The DataFrame's length does not increase as a result of the update.
+
         >>> df = pd.DataFrame({'A': ['a', 'b', 'c'],
         ...                    'B': ['x', 'y', 'z']})
         >>> new_df = pd.DataFrame({'B': ['d', 'e', 'f', 'g', 'h', 'i']})
@@ -4257,6 +4260,8 @@ class DataFrame(NDFrame):
         0  a  d
         1  b  e
         2  c  f
+
+        For Series, it's name attribute must be set.
 
         >>> df = pd.DataFrame({'A': ['a', 'b', 'c'],
         ...                    'B': ['x', 'y', 'z']})

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -4328,8 +4328,9 @@ class DataFrame(NDFrame):
         Parameters
         ----------
         other : DataFrame, or object coercible into a DataFrame
-            Index should be similar to one of the columns in this one. If a
-            Series is passed, its name attribute must be set, and that will be
+            Should have at least one matching index/column label
+            with the original DataFrame. If a Series is passed,
+            its name attribute must be set, and that will be
             used as the column name in the resulting joined DataFrame.
         join : {'left'}, default 'left'
             Only left join is implemented, keeping the index and columns of the
@@ -4337,10 +4338,13 @@ class DataFrame(NDFrame):
         overwrite : boolean, default True
             How to handle non-NA values for overlapping keys.
 
-            * True : overwrite values in `self` with values from `other`.
-            * False : only update values that are NA in `self`.
+            * True : overwrite original DataFrame's values
+                    with values from `other`.
+            * False : only update values that are NA in
+                    the original DataFrame.
 
-        filter_func : callable(1d-array) -> 1d-array<boolean>, default None
+        filter_func : callable(1d-array) -> 1d-array<boolean>,\
+        "default None" -> "optional"
             Can choose to replace values other than NA. Return True for values
             that should be updated.
         raise_conflict : boolean
@@ -4370,7 +4374,8 @@ class DataFrame(NDFrame):
         1  2  5
         2  3  6
 
-        The DataFrame's length does not increase as a result of the update.
+        The DataFrame's length does not increase as a result of the update,
+        only values at matching index/column labels are updated.
 
         >>> df = pd.DataFrame({'A': ['a', 'b', 'c'],
         ...                    'B': ['x', 'y', 'z']})

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -4206,8 +4206,7 @@ class DataFrame(NDFrame):
     def update(self, other, join='left', overwrite=True, filter_func=None,
                raise_conflict=False):
         """
-        Modify DataFrame in place using non-NA values from passed
-        DataFrame.
+        Modify in place using non-NA values from other DataFrame.
 
         Aligns on indices.
 
@@ -4227,6 +4226,14 @@ class DataFrame(NDFrame):
         raise_conflict : boolean
             If True, will raise an error if the DataFrame and other both
             contain data in the same place.
+
+        Returns
+        -------
+        updated : DataFrame
+
+        See Also
+        --------
+        DataFrame.merge : For column(s)-on-columns(s) operations
 
         Examples
         --------
@@ -4282,14 +4289,6 @@ class DataFrame(NDFrame):
         0  1    4.0
         1  2  500.0
         2  3    6.0
-
-        See also
-        --------
-        DataFrame.merge : For column(s)-on-columns(s) operations
-
-        Returns
-        -------
-        updated : DataFrame
         """
         import pandas.core.computation.expressions as expressions
         # TODO: Support other joins

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -4293,9 +4293,9 @@ class DataFrame(NDFrame):
     def update(self, other, join='left', overwrite=True, filter_func=None,
                raise_conflict=False):
         """
-        Modify in place using non-NA values from other DataFrame.
+        Modify in place using non-NA values from another DataFrame.
 
-        Aligns on indices.
+        Aligns on indices. There is no return value.
 
         Parameters
         ----------
@@ -4304,25 +4304,30 @@ class DataFrame(NDFrame):
             Series is passed, its name attribute must be set, and that will be
             used as the column name in the resulting joined DataFrame.
         join : {'left'}, default 'left'
-            Only left join is implemented,
-            keeping the index and columns of the original object.
+            Only left join is implemented, keeping the index and columns of the
+            original object.
         overwrite : boolean, default True
-            If True then overwrite values for common keys in the calling frame.
-            If False then only NA values in the calling object are updated.
+            How to handle non-NA values for overlapping keys.
+
+            * True : overwrite values in `self` with values from `other`.
+            * False : only update values that are NA in `self`.
+
         filter_func : callable(1d-array) -> 1d-array<boolean>, default None
             Can choose to replace values other than NA. Return True for values
             that should be updated.
         raise_conflict : boolean
-            If True, will raise an error if the DataFrame and other both
-            contain data in the same place.
+            If True, will raise a `ValueError` if the DataFrame and `other`
+            both contain non-NA data in the same place.
 
-        Returns
-        -------
-        updated : DataFrame
+        Raises
+        ------
+        ValueError
+            When `raise_conflict` is True and there's overlapping non-NA data.
 
         See Also
         --------
-        DataFrame.merge : For column(s)-on-columns(s) operations
+        dict.update : Similar method for dictionaries.
+        DataFrame.merge : For column(s)-on-columns(s) operations.
 
         Examples
         --------

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -4207,17 +4207,23 @@ class DataFrame(NDFrame):
                raise_conflict=False):
         """
         Modify DataFrame in place using non-NA values from passed
-        DataFrame. Aligns on indices
+        DataFrame.
+
+        Aligns on indices.
 
         Parameters
         ----------
         other : DataFrame, or object coercible into a DataFrame
+            Index should be similar to one of the columns in this one. If a
+            Series is passed, its name attribute must be set, and that will be
+            used as the column name in the resulting joined DataFrame.
         join : {'left'}, default 'left'
+            Indicates which column values overwrite.
         overwrite : boolean, default True
-            If True then overwrite values for common keys in the calling frame
+            If True then overwrite values for common keys in the calling frame.
         filter_func : callable(1d-array) -> 1d-array<boolean>, default None
             Can choose to replace values other than NA. Return True for values
-            that should be updated
+            that should be updated.
         raise_conflict : boolean
             If True, will raise an error if the DataFrame and other both
             contain data in the same place.
@@ -4276,6 +4282,14 @@ class DataFrame(NDFrame):
         0  1    4.0
         1  2  500.0
         2  3    6.0
+
+        See also
+        --------
+        DataFrame.merge : For column(s)-on-columns(s) operations
+
+        Returns
+        -------
+        updated : DataFrame
         """
         import pandas.core.computation.expressions as expressions
         # TODO: Support other joins

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -4331,24 +4331,23 @@ class DataFrame(NDFrame):
             Should have at least one matching index/column label
             with the original DataFrame. If a Series is passed,
             its name attribute must be set, and that will be
-            used as the column name in the resulting joined DataFrame.
+            used as the column name to align with the original DataFrame.
         join : {'left'}, default 'left'
             Only left join is implemented, keeping the index and columns of the
             original object.
-        overwrite : boolean, default True
-            How to handle non-NA values for overlapping keys.
+        overwrite : bool, default True
+            How to handle non-NA values for overlapping keys:
 
-            * True : overwrite original DataFrame's values
-                    with values from `other`.
-            * False : only update values that are NA in
-                    the original DataFrame.
+            * True: overwrite original DataFrame's values
+              with values from `other`.
+            * False: only update values that are NA in
+              the original DataFrame.
 
-        filter_func : callable(1d-array) -> 1d-array<boolean>,\
-        "default None" -> "optional"
+        filter_func : callable(1d-array) -> boolean 1d-array, optional
             Can choose to replace values other than NA. Return True for values
             that should be updated.
-        raise_conflict : boolean
-            If True, will raise a `ValueError` if the DataFrame and `other`
+        raise_conflict : bool, default False
+            If True, will raise a ValueError if the DataFrame and `other`
             both contain non-NA data in the same place.
 
         Raises
@@ -4408,7 +4407,7 @@ class DataFrame(NDFrame):
         1  b  d
         2  c  e
 
-        If ``other`` contains NaNs the corresponding values are not updated
+        If `other` contains NaNs the corresponding values are not updated
         in the original dataframe.
 
         >>> df = pd.DataFrame({'A': [1, 2, 3],

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -4321,9 +4321,9 @@ class DataFrame(NDFrame):
     def update(self, other, join='left', overwrite=True, filter_func=None,
                raise_conflict=False):
         """
-        Modify in place using non-NA values from other DataFrame.
+        Modify in place using non-NA values from another DataFrame.
 
-        Aligns on indices.
+        Aligns on indices. There is no return value.
 
         Parameters
         ----------
@@ -4335,22 +4335,27 @@ class DataFrame(NDFrame):
             Only left join is implemented,
             keeping the index and columns of the original object.
         overwrite : boolean, default True
-            If True then overwrite values for common keys in the calling frame.
-            If False then only NA values in the calling object are updated.
+            How to handle non-NA values for overlapping keys.
+
+            * True : overwrite values in `self` with values from `other`.
+            * False : only update values that are NA in `self`.
+
         filter_func : callable(1d-array) -> 1d-array<boolean>, default None
             Can choose to replace values other than NA. Return True for values
             that should be updated.
         raise_conflict : boolean
-            If True, will raise an error if the DataFrame and other both
-            contain data in the same place.
+            If True, will raise a `ValueError` if the DataFrame and `other` both
+            contain non-NA data in the same place.
 
-        Returns
-        -------
-        updated : DataFrame
+        Raises
+        ------
+        ValueError
+            When `raise conflict` is True and there's overlapping non-NA data.
 
         See Also
         --------
-        DataFrame.merge : For column(s)-on-columns(s) operations
+        dict.update : Similar method for dictionaries.
+        DataFrame.merge : For column(s)-on-columns(s) operations.
 
         Examples
         --------

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -4308,6 +4308,7 @@ class DataFrame(NDFrame):
             keeping the index and columns of the original object.
         overwrite : boolean, default True
             If True then overwrite values for common keys in the calling frame.
+            If False then only NA values in the calling object are updated.
         filter_func : callable(1d-array) -> 1d-array<boolean>, default None
             Can choose to replace values other than NA. Return True for values
             that should be updated.


### PR DESCRIPTION
Checklist for the pandas documentation sprint (ignore this if you are doing
an unrelated PR):

- [x] PR title is "DOC: update the <your-function-or-method> docstring"
- [x] The validation script passes: `scripts/validate_docstrings.py <your-function-or-method>`
- [x] The PEP8 style check passes: `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] The html version looks good: `python doc/make.py --single <your-function-or-method>`
- [x] It has been proofread on language by another sprint participant

Please include the output of the validation script below between the "```" ticks:

```
################################################################################
##################### Docstring (pandas.DataFrame.update)  #####################
################################################################################

Modify DataFrame in place using non-NA values from passed
DataFrame.

Aligns on indices.

Parameters
----------
other : DataFrame, or object coercible into a DataFrame
    Index should be similar to one of the columns in this one. If a
    Series is passed, its name attribute must be set, and that will be
    used as the column name in the resulting joined DataFrame.
join : {'left'}, default 'left'
    Indicates which column values overwrite.
overwrite : boolean, default True
    If True then overwrite values for common keys in the calling frame.
filter_func : callable(1d-array) -> 1d-array<boolean>, default None
    Can choose to replace values other than NA. Return True for values
    that should be updated.
raise_conflict : boolean
    If True, will raise an error if the DataFrame and other both
    contain data in the same place.

Examples
--------
>>> df = pd.DataFrame({'A': [1, 2, 3],
...                    'B': [400, 500, 600]})
>>> new_df = pd.DataFrame({'B': [4, 5, 6],
...                        'C': [7, 8, 9]})
>>> df.update(new_df)
>>> df
   A  B
0  1  4
1  2  5
2  3  6

>>> df = pd.DataFrame({'A': ['a', 'b', 'c'],
...                    'B': ['x', 'y', 'z']})
>>> new_df = pd.DataFrame({'B': ['d', 'e', 'f', 'g', 'h', 'i']})
>>> df.update(new_df)
>>> df
   A  B
0  a  d
1  b  e
2  c  f

>>> df = pd.DataFrame({'A': ['a', 'b', 'c'],
...                    'B': ['x', 'y', 'z']})
>>> new_column = pd.Series(['d', 'e'], name='B', index=[0, 2])
>>> df.update(new_column)
>>> df
   A  B
0  a  d
1  b  y
2  c  e
>>> df = pd.DataFrame({'A': ['a', 'b', 'c'],
...                    'B': ['x', 'y', 'z']})
>>> new_df = pd.DataFrame({'B': ['d', 'e']}, index=[1, 2])
>>> df.update(new_df)
>>> df
   A  B
0  a  x
1  b  d
2  c  e

If ``other`` contains NaNs the corresponding values are not updated
in the original dataframe.

>>> df = pd.DataFrame({'A': [1, 2, 3],
...                    'B': [400, 500, 600]})
>>> new_df = pd.DataFrame({'B': [4, np.nan, 6]})
>>> df.update(new_df)
>>> df
   A      B
0  1    4.0
1  2  500.0
2  3    6.0

See also
--------
DataFrame.merge : For column(s)-on-columns(s) operations

Returns
-------
updated : DataFrame

################################################################################
################################## Validation ##################################
################################################################################

```

If the validation script still gives errors, but you think there is a good reason
to deviate in this case (and there are certainly such cases), please state this
explicitly.

