### PR TITLE
DOC: update the pandas.DataFrame.apply docstring

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -4859,18 +4859,18 @@ class DataFrame(NDFrame):
               achieve much better performance.
         reduce : bool or `None`, default `None`
             Try to apply reduction procedures. If the `DataFrame` is empty,
-            :meth:`apply` will use reduce to determine whether the result
+            :meth:`apply` will use `reduce` to determine whether the result
             should be a Series or a `DataFrame`. If ``reduce is None`` (the
             default), :meth:`apply`'s return value will be guessed by calling
-            func on an empty Series
+            `func` on an empty Series
             (note: while guessing, exceptions raised by `func` will be
             ignored).
-            If reduce is True a Series will always be returned, and if
-            `False` a `DataFrame` will always be returned.
+            If ``reduce is True`` a Series will always be returned, and if
+            ``reduce is False`` a `DataFrame` will always be returned.
 
             .. deprecated:: 0.23.0.
                This argument will be removed in a future version, replaced
-               by result_type='reduce'.
+               by ``result_type='reduce'``.
 
         result_type : {'expand', 'reduce', 'broadcast', `None`}
             These only act when ``axis=1`` (columns):
@@ -4898,9 +4898,9 @@ class DataFrame(NDFrame):
 
         Notes
         -----
-        In the current implementation apply calls func twice on the
+        In the current implementation apply calls `func` twice on the
         first column/row to decide whether it can take a fast or slow
-        code path. This can lead to unexpected behavior if func has
+        code path. This can lead to unexpected behavior if `func` has
         side-effects, as they will take effect twice for the first
         column/row.
 

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -4855,8 +4855,8 @@ class DataFrame(NDFrame):
               function.
             * `True` : the passed function will receive ndarray objects
               instead.
-            If you are just applying a NumPy reduction function this will
-            achieve much better performance.
+              If you are just applying a NumPy reduction function this will
+              achieve much better performance.
         reduce : bool or `None`, default `None`
             Try to apply reduction procedures. If the `DataFrame` is empty,
             :meth:`apply` will use reduce to determine whether the result

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -4823,9 +4823,9 @@ class DataFrame(NDFrame):
 
         Objects passed to the function are Series objects whose index is
         either the DataFrame's index (``axis=0``) or the DataFrame's columns
-        (``axis=1``). If ``result_type is None``, the final return type is the
-        return type of the applied function. Otherwise, it depends on the
-        `result_type` argument.
+        (``axis=1``). If ``result_type is None``, the final return type is
+        inferred from the return type of the applied function. Otherwise, it
+        depends on the `result_type` argument.
 
         Parameters
         ----------

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -4892,7 +4892,7 @@ class DataFrame(NDFrame):
         args : tuple
             Positional arguments to pass to function in addition to the
             array/series.
-        kwds :
+        **kwds
             Additional keyword arguments to pass as keywords to the function.
 
         Notes

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -4822,8 +4822,8 @@ class DataFrame(NDFrame):
         Apply a function along an axis of the DataFrame.
 
         Objects passed to the function are Series objects having as index
-        either the DataFrame's index (`axis=0`)
-        or the DataFrame's columns (`axis=1`).
+        either the DataFrame's index (``axis=0``)
+        or the DataFrame's columns (``axis=1``).
         If `result_type` is None, the final return type is the return
         type of the applied function.
         Otherwise, it depends on the `result_type` argument.
@@ -4873,7 +4873,7 @@ class DataFrame(NDFrame):
                by result_type='reduce'.
 
         result_type : {'expand', 'reduce', 'broadcast', None}
-            These only act when `axis=1` (columns):
+            These only act when ``axis=1`` (columns):
 
             * 'expand' : list-like results will be turned into columns.
             * 'reduce' : returns a Series if possible rather than expanding

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -4821,7 +4821,7 @@ class DataFrame(NDFrame):
         """
         Apply a function along an axis of the DataFrame.
 
-        Objects passed to the function are Series objects having as index
+        Objects passed to the function are Series objects whose index is
         either the DataFrame's index (``axis=0``)
         or the DataFrame's columns (``axis=1``).
         If ``result_type is None``, the final return type is the return

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -4858,15 +4858,15 @@ class DataFrame(NDFrame):
               If you are just applying a NumPy reduction function this will
               achieve much better performance.
         reduce : bool or `None`, default `None`
-            Try to apply reduction procedures. If the `DataFrame` is empty,
+            Try to apply reduction procedures. If the DataFrame is empty,
             :meth:`apply` will use `reduce` to determine whether the result
-            should be a Series or a `DataFrame`. If ``reduce is None`` (the
+            should be a Series or a DataFrame. If ``reduce is None`` (the
             default), :meth:`apply`'s return value will be guessed by calling
             `func` on an empty Series
             (note: while guessing, exceptions raised by `func` will be
             ignored).
             If ``reduce is True`` a Series will always be returned, and if
-            ``reduce is False`` a `DataFrame` will always be returned.
+            ``reduce is False`` a DataFrame will always be returned.
 
             .. deprecated:: 0.23.0.
                This argument will be removed in a future version, replaced
@@ -4879,7 +4879,7 @@ class DataFrame(NDFrame):
             * 'reduce' : returns a Series if possible rather than expanding
               list-like results. This is the opposite of 'expand'.
             * 'broadcast' : results will be broadcast to the original shape
-              of the `DataFrame`, the original index and columns will be
+              of the DataFrame, the original index and columns will be
               retained.
 
             The default behaviour (`None`) depends on the return value of the

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -4859,13 +4859,13 @@ class DataFrame(NDFrame):
         reduce : bool or `None`, default `None`
             Try to apply reduction procedures. If the DataFrame is empty,
             `apply` will use `reduce` to determine whether the result
-            should be a Series or a DataFrame. If ``reduce is None`` (the
+            should be a Series or a DataFrame. If ``reduce=None`` (the
             default), `apply`'s return value will be guessed by calling
             `func` on an empty Series
             (note: while guessing, exceptions raised by `func` will be
             ignored).
-            If ``reduce is True`` a Series will always be returned, and if
-            ``reduce is False`` a DataFrame will always be returned.
+            If ``reduce=True`` a Series will always be returned, and if
+            ``reduce=False`` a DataFrame will always be returned.
 
             .. deprecated:: 0.23.0
                This argument will be removed in a future version, replaced

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -4867,7 +4867,7 @@ class DataFrame(NDFrame):
             If ``reduce is True`` a Series will always be returned, and if
             ``reduce is False`` a DataFrame will always be returned.
 
-            .. deprecated:: 0.23.0.
+            .. deprecated:: 0.23.0
                This argument will be removed in a future version, replaced
                by ``result_type='reduce'``.
 
@@ -4886,7 +4886,7 @@ class DataFrame(NDFrame):
             of those. However if the apply function returns a Series these
             are expanded to columns.
 
-            .. versionadded:: 0.23.0.
+            .. versionadded:: 0.23.0
 
         args : tuple
             Positional arguments to pass to `func` in addition to the

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -4890,10 +4890,11 @@ class DataFrame(NDFrame):
             .. versionadded:: 0.23.0.
 
         args : tuple
-            Positional arguments to pass to function in addition to the
+            Positional arguments to pass to `func` in addition to the
             array/series.
         **kwds
-            Additional keyword arguments to pass as keywords to the function.
+            Additional keyword arguments to pass as keywords arguments to
+            `func`.
 
         Notes
         -----

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -4823,9 +4823,9 @@ class DataFrame(NDFrame):
 
         Objects passed to the function are Series objects whose index is
         either the DataFrame's index (``axis=0``) or the DataFrame's columns
-        (``axis=1``). If ``result_type is None``, the final return type is
-        inferred from the return type of the applied function. Otherwise, it
-        depends on the `result_type` argument.
+        (``axis=1``). By default (``result_type=None``), the final return type
+        is inferred from the return type of the applied function. Otherwise,
+        it depends on the `result_type` argument.
 
         Parameters
         ----------
@@ -4839,10 +4839,10 @@ class DataFrame(NDFrame):
         broadcast : bool, optional
             Only relevant for aggregation functions:
 
-            * `False` or `None` : returns a Series whose length is the length
+            * ``False`` or ``None`` : returns a Series whose length is the length
               of the index or the number of columns (based on the `axis`
               parameter)
-            * `True` : results will be broadcast to the original shape
+            * ``True`` : results will be broadcast to the original shape
               of the frame, the original index and columns will be retained.
 
             .. deprecated:: 0.23.0
@@ -4850,9 +4850,9 @@ class DataFrame(NDFrame):
                by result_type='broadcast'.
 
         raw : bool, default False
-            * `False` : passes each row or column as a Series to the
+            * ``False`` : passes each row or column as a Series to the
               function.
-            * `True` : the passed function will receive ndarray objects
+            * ``True`` : the passed function will receive ndarray objects
               instead.
               If you are just applying a NumPy reduction function this will
               achieve much better performance.
@@ -4871,7 +4871,7 @@ class DataFrame(NDFrame):
                This argument will be removed in a future version, replaced
                by ``result_type='reduce'``.
 
-        result_type : {'expand', 'reduce', 'broadcast', `None`}
+        result_type : {'expand', 'reduce', 'broadcast', None}, default None
             These only act when ``axis=1`` (columns):
 
             * 'expand' : list-like results will be turned into columns.
@@ -4881,7 +4881,7 @@ class DataFrame(NDFrame):
               of the DataFrame, the original index and columns will be
               retained.
 
-            The default behaviour `None` depends on the return value of the
+            The default behaviour (None) depends on the return value of the
             applied function: list-like results will be returned as a Series
             of those. However if the apply function returns a Series these
             are expanded to columns.

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -4882,7 +4882,7 @@ class DataFrame(NDFrame):
               of the DataFrame, the original index and columns will be
               retained.
 
-            The default behaviour (`None`) depends on the return value of the
+            The default behaviour `None` depends on the return value of the
             applied function: list-like results will be returned as a Series
             of those. However if the apply function returns a Series these
             are expanded to columns.

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -4819,9 +4819,9 @@ class DataFrame(NDFrame):
     def apply(self, func, axis=0, broadcast=None, raw=False, reduce=None,
               result_type=None, args=(), **kwds):
         """
-        Apply a function along an axis of the `Series`.
+        Apply a function along an axis of the DataFrame.
 
-        Objects passed to the function are `Series` objects having as index
+        Objects passed to the function are Series objects having as index
         either the DataFrame's index (`axis=0`)
         or the DataFrame's columns (`axis=1`).
         If `result_type` is None, the final return type is the return
@@ -4840,7 +4840,7 @@ class DataFrame(NDFrame):
         broadcast : boolean, optional
             Only relevant for aggregation functions:
 
-            * `False` or `None` : returns a `Series` whose length is the length
+            * `False` or `None` : returns a Series whose length is the length
               of the index or the number of columns (based on the `axis`
               parameter)
             * `True` : results will be broadcast to the original shape
@@ -4851,7 +4851,7 @@ class DataFrame(NDFrame):
                by result_type='broadcast'.
 
         raw : boolean, default False
-            * `False` : passes each row or column into a `Series` to the
+            * `False` : passes each row or column into a Series to the
               function.
             * `True` : the passed function will receive ndarray objects
               instead.
@@ -4860,12 +4860,12 @@ class DataFrame(NDFrame):
         reduce : boolean or None, default None
             Try to apply reduction procedures. If the `DataFrame` is empty,
             :meth:`apply` will use reduce to determine whether the result
-            should be a `Series` or a `DataFrame`. If reduce is None (the
+            should be a Series or a `DataFrame`. If reduce is None (the
             default), :meth:`apply`'s return value will be guessed by calling
-            func on an empty `Series`
+            func on an empty Series
             (note: while guessing, exceptions raised by `func` will be
             ignored).
-            If reduce is True a `Series` will always be returned, and if
+            If reduce is True a Series will always be returned, and if
             `False` a `DataFrame` will always be returned.
 
             .. deprecated:: 0.23.0.
@@ -4876,15 +4876,15 @@ class DataFrame(NDFrame):
             These only act when `axis=1` (columns):
 
             * 'expand' : list-like results will be turned into columns.
-            * 'reduce' : returns a `Series` if possible rather than expanding
+            * 'reduce' : returns a Series if possible rather than expanding
               list-like results. This is the opposite of 'expand'.
             * 'broadcast' : results will be broadcast to the original shape
               of the `DataFrame`, the original index and columns will be
               retained.
 
             The default behaviour (`None`) depends on the return value of the
-            applied function: list-like results will be returned as a `Series`
-            of those. However if the apply function returns a `Series` these
+            applied function: list-like results will be returned as a Series
+            of those. However if the apply function returns a Series these
             are expanded to columns.
 
             .. versionadded:: 0.23.0.

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -4859,9 +4859,9 @@ class DataFrame(NDFrame):
               achieve much better performance.
         reduce : bool or `None`, default `None`
             Try to apply reduction procedures. If the DataFrame is empty,
-            :meth:`apply` will use `reduce` to determine whether the result
+            `apply` will use `reduce` to determine whether the result
             should be a Series or a DataFrame. If ``reduce is None`` (the
-            default), :meth:`apply`'s return value will be guessed by calling
+            default), `apply`'s return value will be guessed by calling
             `func` on an empty Series
             (note: while guessing, exceptions raised by `func` will be
             ignored).

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -4818,66 +4818,82 @@ class DataFrame(NDFrame):
 
     def apply(self, func, axis=0, broadcast=None, raw=False, reduce=None,
               result_type=None, args=(), **kwds):
-        """Applies function along an axis of the DataFrame.
+        """
+        Apply a function along an axis of the `Series`.
 
-        Objects passed to functions are Series objects having index
-        either the DataFrame's index (axis=0) or the columns (axis=1).
-        Final return type depends on the return type of the applied function,
-        or on the `result_type` argument.
+        Objects passed to the function are `Series` objects having as index
+        either the DataFrame's index (`axis=0`)
+        or the DataFrame's columns (`axis=1`).
+        If `result_type` is None, the final return type is the return
+        type of the applied function.
+        Otherwise, it depends on the `result_type` argument.
 
         Parameters
         ----------
         func : function
-            Function to apply to each column/row
+            Function to apply to each column or row.
         axis : {0 or 'index', 1 or 'columns'}, default 0
-            * 0 or 'index': apply function to each column
-            * 1 or 'columns': apply function to each row
+            Axis along which the function is applied:
+
+            * 0 or 'index': apply function to each column.
+            * 1 or 'columns': apply function to each row.
         broadcast : boolean, optional
-            For aggregation functions, return object of same size with values
-            propagated
+            Only relevant for aggregation functions:
+
+            * `False` or `None` : returns a `Series` whose length is the length
+              of the index or the number of columns (based on the `axis`
+              parameter)
+            * `True` : results will be broadcast to the original shape
+              of the frame, the original index and columns will be retained.
 
             .. deprecated:: 0.23.0
                This argument will be removed in a future version, replaced
                by result_type='broadcast'.
 
         raw : boolean, default False
-            If False, convert each row or column into a Series. If raw=True the
-            passed function will receive ndarray objects instead. If you are
-            just applying a NumPy reduction function this will achieve much
-            better performance
+            * `False` : passes each row or column into a `Series` to the
+              function.
+            * `True` : the passed function will receive ndarray objects
+              instead.
+            If you are just applying a NumPy reduction function this will
+            achieve much better performance.
         reduce : boolean or None, default None
-            Try to apply reduction procedures. If the DataFrame is empty,
-            apply will use reduce to determine whether the result should be a
-            Series or a DataFrame. If reduce is None (the default), apply's
-            return value will be guessed by calling func an empty Series (note:
-            while guessing, exceptions raised by func will be ignored). If
-            reduce is True a Series will always be returned, and if False a
-            DataFrame will always be returned.
+            Try to apply reduction procedures. If the `DataFrame` is empty,
+            :meth:`apply` will use reduce to determine whether the result
+            should be a `Series` or a `DataFrame`. If reduce is None (the
+            default), :meth:`apply`'s return value will be guessed by calling
+            func on an empty `Series`
+            (note: while guessing, exceptions raised by `func` will be
+            ignored).
+            If reduce is True a `Series` will always be returned, and if
+            `False` a `DataFrame` will always be returned.
 
-            .. deprecated:: 0.23.0
+            .. deprecated:: 0.23.0.
                This argument will be removed in a future version, replaced
                by result_type='reduce'.
 
-        result_type : {'expand', 'reduce', 'broadcast, None}
-            These only act when axis=1 {columns}:
+        result_type : {'expand', 'reduce', 'broadcast', None}
+            These only act when `axis=1` (columns):
 
             * 'expand' : list-like results will be turned into columns.
-            * 'reduce' : return a Series if possible rather than expanding
-              list-like results. This is the opposite to 'expand'.
+            * 'reduce' : returns a `Series` if possible rather than expanding
+              list-like results. This is the opposite of 'expand'.
             * 'broadcast' : results will be broadcast to the original shape
-              of the frame, the original index & columns will be retained.
+              of the `DataFrame`, the original index and columns will be
+              retained.
 
-            The default behaviour (None) depends on the return value of the
-            applied function: list-like results will be returned as a Series
-            of those. However if the apply function returns a Series these
+            The default behaviour (`None`) depends on the return value of the
+            applied function: list-like results will be returned as a `Series`
+            of those. However if the apply function returns a `Series` these
             are expanded to columns.
 
-            .. versionadded:: 0.23.0
+            .. versionadded:: 0.23.0.
 
         args : tuple
             Positional arguments to pass to function in addition to the
-            array/series
-        Additional keyword arguments will be passed as keywords to the function
+            array/series.
+        kwds :
+            Additional keyword arguments to pass as keywords to the function.
 
         Notes
         -----
@@ -4941,6 +4957,7 @@ class DataFrame(NDFrame):
         3    [1, 2]
         4    [1, 2]
         5    [1, 2]
+        dtype: object
 
         Passing result_type='expand' will expand list-like results
         to columns of a Dataframe
@@ -4958,7 +4975,7 @@ class DataFrame(NDFrame):
         ``result_type='expand'``. The resulting column names
         will be the Series index.
 
-        >>> df.apply(lambda x: Series([1, 2], index=['foo', 'bar']), axis=1)
+        >>> df.apply(lambda x: pd.Series([1, 2], index=['foo', 'bar']), axis=1)
            foo  bar
         0    1    2
         1    1    2

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -4822,11 +4822,10 @@ class DataFrame(NDFrame):
         Apply a function along an axis of the DataFrame.
 
         Objects passed to the function are Series objects whose index is
-        either the DataFrame's index (``axis=0``)
-        or the DataFrame's columns (``axis=1``).
-        If ``result_type is None``, the final return type is the return
-        type of the applied function.
-        Otherwise, it depends on the `result_type` argument.
+        either the DataFrame's index (``axis=0``) or the DataFrame's columns
+        (``axis=1``). If ``result_type is None``, the final return type is the
+        return type of the applied function. Otherwise, it depends on the
+        `result_type` argument.
 
         Parameters
         ----------

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -4824,7 +4824,7 @@ class DataFrame(NDFrame):
         Objects passed to the function are Series objects having as index
         either the DataFrame's index (``axis=0``)
         or the DataFrame's columns (``axis=1``).
-        If `result_type` is None, the final return type is the return
+        If ``result_type is None``, the final return type is the return
         type of the applied function.
         Otherwise, it depends on the `result_type` argument.
 
@@ -4857,10 +4857,10 @@ class DataFrame(NDFrame):
               instead.
             If you are just applying a NumPy reduction function this will
             achieve much better performance.
-        reduce : boolean or None, default None
+        reduce : boolean or `None`, default `None`
             Try to apply reduction procedures. If the `DataFrame` is empty,
             :meth:`apply` will use reduce to determine whether the result
-            should be a Series or a `DataFrame`. If reduce is None (the
+            should be a Series or a `DataFrame`. If ``reduce is None`` (the
             default), :meth:`apply`'s return value will be guessed by calling
             func on an empty Series
             (note: while guessing, exceptions raised by `func` will be
@@ -4872,7 +4872,7 @@ class DataFrame(NDFrame):
                This argument will be removed in a future version, replaced
                by result_type='reduce'.
 
-        result_type : {'expand', 'reduce', 'broadcast', None}
+        result_type : {'expand', 'reduce', 'broadcast', `None`}
             These only act when ``axis=1`` (columns):
 
             * 'expand' : list-like results will be turned into columns.

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -4851,7 +4851,7 @@ class DataFrame(NDFrame):
                by result_type='broadcast'.
 
         raw : boolean, default False
-            * `False` : passes each row or column into a Series to the
+            * `False` : passes each row or column as a Series to the
               function.
             * `True` : the passed function will receive ndarray objects
               instead.

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -4856,7 +4856,7 @@ class DataFrame(NDFrame):
               instead.
               If you are just applying a NumPy reduction function this will
               achieve much better performance.
-        reduce : bool or `None`, default `None`
+        reduce : bool or None, default None
             Try to apply reduction procedures. If the DataFrame is empty,
             `apply` will use `reduce` to determine whether the result
             should be a Series or a DataFrame. If ``reduce=None`` (the

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -4906,46 +4906,33 @@ class DataFrame(NDFrame):
         Examples
         --------
 
-        We use this DataFrame to illustrate
-
-        >>> df = pd.DataFrame(np.tile(np.arange(3), 6).reshape(6, -1) + 1,
-        ...                   columns=['A', 'B', 'C'])
+        >>> df = pd.DataFrame([[4, 9],] * 3, columns=['A', 'B'])
         >>> df
-           A  B  C
-        0  1  2  3
-        1  1  2  3
-        2  1  2  3
-        3  1  2  3
-        4  1  2  3
-        5  1  2  3
+           A  B
+        0  4  9
+        1  4  9
+        2  4  9
 
         Using a numpy universal function (in this case the same as
         ``np.sqrt(df)``):
 
         >>> df.apply(np.sqrt)
-             A         B         C
-        0  1.0  1.414214  1.732051
-        1  1.0  1.414214  1.732051
-        2  1.0  1.414214  1.732051
-        3  1.0  1.414214  1.732051
-        4  1.0  1.414214  1.732051
-        5  1.0  1.414214  1.732051
+             A    B
+        0  2.0  3.0
+        1  2.0  3.0
+        2  2.0  3.0
 
         Using a reducing function on either axis
 
         >>> df.apply(np.sum, axis=0)
-        A     6
-        B    12
-        C    18
+        A    12
+        B    27
         dtype: int64
 
         >>> df.apply(np.sum, axis=1)
-        0    6
-        1    6
-        2    6
-        3    6
-        4    6
-        5    6
+        0    13
+        1    13
+        2    13
         dtype: int64
 
         Retuning a list-like will result in a Series
@@ -4954,9 +4941,12 @@ class DataFrame(NDFrame):
         0    [1, 2]
         1    [1, 2]
         2    [1, 2]
-        3    [1, 2]
-        4    [1, 2]
-        5    [1, 2]
+        dtype: object
+
+        >>> df.apply(lambda x: [1,], axis=1)
+        0    [1]
+        1    [1]
+        2    [1]
         dtype: object
 
         Passing result_type='expand' will expand list-like results
@@ -4967,9 +4957,6 @@ class DataFrame(NDFrame):
         0  1  2
         1  1  2
         2  1  2
-        3  1  2
-        4  1  2
-        5  1  2
 
         Returning a Series inside the function is similar to passing
         ``result_type='expand'``. The resulting column names
@@ -4980,23 +4967,17 @@ class DataFrame(NDFrame):
         0    1    2
         1    1    2
         2    1    2
-        3    1    2
-        4    1    2
-        5    1    2
 
         Passing ``result_type='broadcast'`` will ensure the same shape
         result, whether list-like or scalar is returned by the function,
         and broadcast it along the axis. The resulting column names will
         be the originals.
 
-        >>> df.apply(lambda x: [1, 2, 3], axis=1, result_type='broadcast')
-           A  B  C
-        0  1  2  3
-        1  1  2  3
-        2  1  2  3
-        3  1  2  3
-        4  1  2  3
-        5  1  2  3
+        >>> df.apply(lambda x: [1, 2], axis=1, result_type='broadcast')
+           A  B
+        0  1  2
+        1  1  2
+        2  1  2
 
         See also
         --------

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -4903,6 +4903,12 @@ class DataFrame(NDFrame):
         side-effects, as they will take effect twice for the first
         column/row.
 
+        See also
+        --------
+        DataFrame.applymap: For elementwise operations
+        DataFrame.aggregate: only perform aggregating type operations
+        DataFrame.transform: only perform transformating type operations
+
         Examples
         --------
 
@@ -4972,12 +4978,6 @@ class DataFrame(NDFrame):
         0  1  2
         1  1  2
         2  1  2
-
-        See also
-        --------
-        DataFrame.applymap: For elementwise operations
-        DataFrame.aggregate: only perform aggregating type operations
-        DataFrame.transform: only perform transformating type operations
 
         Returns
         -------

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -4837,7 +4837,7 @@ class DataFrame(NDFrame):
 
             * 0 or 'index': apply function to each column.
             * 1 or 'columns': apply function to each row.
-        broadcast : boolean, optional
+        broadcast : bool, optional
             Only relevant for aggregation functions:
 
             * `False` or `None` : returns a Series whose length is the length
@@ -4850,14 +4850,14 @@ class DataFrame(NDFrame):
                This argument will be removed in a future version, replaced
                by result_type='broadcast'.
 
-        raw : boolean, default False
+        raw : bool, default False
             * `False` : passes each row or column as a Series to the
               function.
             * `True` : the passed function will receive ndarray objects
               instead.
             If you are just applying a NumPy reduction function this will
             achieve much better performance.
-        reduce : boolean or `None`, default `None`
+        reduce : bool or `None`, default `None`
             Try to apply reduction procedures. If the `DataFrame` is empty,
             :meth:`apply` will use reduce to determine whether the result
             should be a Series or a `DataFrame`. If ``reduce is None`` (the

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -4943,12 +4943,6 @@ class DataFrame(NDFrame):
         2    [1, 2]
         dtype: object
 
-        >>> df.apply(lambda x: [1,], axis=1)
-        0    [1]
-        1    [1]
-        2    [1]
-        dtype: object
-
         Passing result_type='expand' will expand list-like results
         to columns of a Dataframe
 

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -4839,9 +4839,9 @@ class DataFrame(NDFrame):
         broadcast : bool, optional
             Only relevant for aggregation functions:
 
-            * ``False`` or ``None`` : returns a Series whose length is the length
-              of the index or the number of columns (based on the `axis`
-              parameter)
+            * ``False`` or ``None`` : returns a Series whose length is the
+              length of the index or the number of columns (based on the
+              `axis` parameter)
             * ``True`` : results will be broadcast to the original shape
               of the frame, the original index and columns will be retained.
 


### PR DESCRIPTION
Checklist for the pandas documentation sprint (ignore this if you are doing
an unrelated PR):

- [x] PR title is "DOC: update the <your-function-or-method> docstring"
- [x] The validation script passes: `scripts/validate_docstrings.py <your-function-or-method>`
- [x] The PEP8 style check passes: `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] The html version looks good: `python doc/make.py --single <your-function-or-method>`
- [x] It has been proofread on language by another sprint participant

Please include the output of the validation script below between the "```" ticks:

```
################################################################################
###################### Docstring (pandas.DataFrame.apply) ######################
################################################################################

Apply a function along an axis of the `Series`.

Objects passed to the function are `Series` objects having as index
either the DataFrame's index (`axis=0`)
or the DataFrame's columns (`axis=1`).
If `result_type` is None, the final return type is the return
type of the applied function.
Otherwise, it depends on the `result_type` argument.

Parameters
----------
func : function
    Function to apply to each column or row.
axis : {0 or 'index', 1 or 'columns'}, default 0
    Axis along which the function is applied:

    * 0 or 'index': apply function to each column.
    * 1 or 'columns': apply function to each row.
broadcast : boolean, optional
    Only relevant for aggregation functions:

    * `False` or `None` : returns a `Series` whose length is the length
      of the index or the number of columns (based on the `axis`
      parameter)
    * `True` : results will be broadcast to the original shape
      of the frame, the original index and columns will be retained.

    .. deprecated:: 0.23.0
       This argument will be removed in a future version, replaced
       by result_type='broadcast'.

raw : boolean, default False
    * `False` : passes each row or column into a `Series` to the
      function.
    * `True` : the passed function will receive ndarray objects
      instead.
    If you are just applying a NumPy reduction function this will
    achieve much better performance.
reduce : boolean or None, default None
    Try to apply reduction procedures. If the `DataFrame` is empty,
    :meth:`apply` will use reduce to determine whether the result
    should be a `Series` or a `DataFrame`. If reduce is None (the
    default), :meth:`apply`'s return value will be guessed by calling
    func on an empty `Series`
    (note: while guessing, exceptions raised by `func` will be
    ignored).
    If reduce is True a `Series` will always be returned, and if
    `False` a `DataFrame` will always be returned.

    .. deprecated:: 0.23.0.
       This argument will be removed in a future version, replaced
       by result_type='reduce'.

result_type : {'expand', 'reduce', 'broadcast', None}
    These only act when `axis=1` (columns):

    * 'expand' : list-like results will be turned into columns.
    * 'reduce' : returns a `Series` if possible rather than expanding
      list-like results. This is the opposite of 'expand'.
    * 'broadcast' : results will be broadcast to the original shape
      of the `DataFrame`, the original index and columns will be
      retained.

    The default behaviour (`None`) depends on the return value of the
    applied function: list-like results will be returned as a `Series`
    of those. However if the apply function returns a `Series` these
    are expanded to columns.

    .. versionadded:: 0.23.0.

args : tuple
    Positional arguments to pass to function in addition to the
    array/series.
kwds :
    Additional keyword arguments to pass as keywords to the function.

Notes
-----
In the current implementation apply calls func twice on the
first column/row to decide whether it can take a fast or slow
code path. This can lead to unexpected behavior if func has
side-effects, as they will take effect twice for the first
column/row.

Examples
--------

We use this DataFrame to illustrate

>>> df = pd.DataFrame(np.tile(np.arange(3), 6).reshape(6, -1) + 1,
...                   columns=['A', 'B', 'C'])
>>> df
   A  B  C
0  1  2  3
1  1  2  3
2  1  2  3
3  1  2  3
4  1  2  3
5  1  2  3

Using a numpy universal function (in this case the same as
``np.sqrt(df)``):

>>> df.apply(np.sqrt)
     A         B         C
0  1.0  1.414214  1.732051
1  1.0  1.414214  1.732051
2  1.0  1.414214  1.732051
3  1.0  1.414214  1.732051
4  1.0  1.414214  1.732051
5  1.0  1.414214  1.732051

Using a reducing function on either axis

>>> df.apply(np.sum, axis=0)
A     6
B    12
C    18
dtype: int64

>>> df.apply(np.sum, axis=1)
0    6
1    6
2    6
3    6
4    6
5    6
dtype: int64

Retuning a list-like will result in a Series

>>> df.apply(lambda x: [1, 2], axis=1)
0    [1, 2]
1    [1, 2]
2    [1, 2]
3    [1, 2]
4    [1, 2]
5    [1, 2]
dtype: object

Passing result_type='expand' will expand list-like results
to columns of a Dataframe

>>> df.apply(lambda x: [1, 2], axis=1, result_type='expand')
   0  1
0  1  2
1  1  2
2  1  2
3  1  2
4  1  2
5  1  2

Returning a Series inside the function is similar to passing
``result_type='expand'``. The resulting column names
will be the Series index.

>>> df.apply(lambda x: pd.Series([1, 2], index=['foo', 'bar']), axis=1)
   foo  bar
0    1    2
1    1    2
2    1    2
3    1    2
4    1    2
5    1    2

Passing ``result_type='broadcast'`` will ensure the same shape
result, whether list-like or scalar is returned by the function,
and broadcast it along the axis. The resulting column names will
be the originals.

>>> df.apply(lambda x: [1, 2, 3], axis=1, result_type='broadcast')
   A  B  C
0  1  2  3
1  1  2  3
2  1  2  3
3  1  2  3
4  1  2  3
5  1  2  3

See also
--------
DataFrame.applymap: For elementwise operations
DataFrame.aggregate: only perform aggregating type operations
DataFrame.transform: only perform transformating type operations

Returns
-------
applied : Series or DataFrame

################################################################################
################################## Validation ##################################
################################################################################

Errors found:
	Errors in parameters section
		Parameters {'kwds'} not documented
		Unknown parameters {'kwds :'}
		Parameter "raw" description should start with capital letter
		Parameter "kwds :" has no type
```

If the validation script still gives errors, but you think there is a good reason
to deviate in this case (and there are certainly such cases), please state this
explicitly.
