### PR TITLE
DOC: update the docstring of pandas.DataFrame.from_dict

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -883,27 +883,53 @@ class DataFrame(NDFrame):
     @classmethod
     def from_dict(cls, data, orient='columns', dtype=None, columns=None):
         """
-        Construct DataFrame from dict of array-like or dicts
+        Construct DataFrame from dict of array-like or dicts.
+
+        Creates DataFrame object from dictionary by columns or by index
+        allowing dtype specification.
 
         Parameters
         ----------
         data : dict
-            {field : array-like} or {field : dict}
+            Of the form {field : array-like} or {field : dict}.
         orient : {'columns', 'index'}, default 'columns'
             The "orientation" of the data. If the keys of the passed dict
             should be the columns of the resulting DataFrame, pass 'columns'
             (default). Otherwise if the keys should be rows, pass 'index'.
         dtype : dtype, default None
-            Data type to force, otherwise infer
-        columns: list, default None
+            Data type to force, otherwise infer.
+        columns : list, default None
             Column labels to use when orient='index'. Raises a ValueError
             if used with orient='columns'
+            .. versionadded:: 0.23.0.
 
-            .. versionadded:: 0.23.0
+        See Also
+        --------
+        DataFrame.from_records : Create DataFrame from ndarray (structured dtype),
+                                 list of tuples, dict, or DataFrame
+        DataFrame.from_items : Create DataFrame from sequence of (key, value) pairs.
 
         Returns
         -------
         DataFrame
+
+        Examples
+        --------
+        >>> data = {'col_1': [3, 2, 1, 0], 'col_2': ['a', 'b', 'c', 'd']}
+        >>> data
+        {'col_1': [3, 2, 1, 0], 'col_2': ['a', 'b', 'c', 'd']}
+
+        >>> pd.DataFrame.from_dict(data)
+           col_1 col_2
+        0      3     a
+        1      2     b
+        2      1     c
+        3      0     d
+
+        >>> pd.DataFrame.from_dict(data, orient='index')
+               0  1  2  3
+        col_1  3  2  1  0
+        col_2  a  b  c  d
         """
         index = None
         orient = orient.lower()

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -905,9 +905,9 @@ class DataFrame(NDFrame):
 
         See Also
         --------
-        DataFrame.from_records : Create DataFrame from ndarray (structured dtype),
+        DataFrame.from_records : DataFrame from ndarray (structured dtype),
                                  list of tuples, dict, or DataFrame
-        DataFrame.from_items : Create DataFrame from sequence of (key, value) pairs.
+        DataFrame.from_items : DataFrame from sequence of (key, value) pairs.
 
         Returns
         -------

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -5582,23 +5582,24 @@ class NDFrame(PandasObject, SelectionMixin):
 
         Examples
         --------
-        >>> data = {'0': [9, -3, 0, -1, 5], '1': [-2, -7, 6, 8, -5]}
+        >>> data = {'col_0': [9, -3, 0, -1, 5], 'col_1': [-2, -7, 6, 8, -5]}
         >>> df = pd.DataFrame(data)
         >>> df
-            0 	1
-        0 	9 	-2
-        1 	-3 	-7
-        2 	0 	6
-        3 	-1 	8
-        4 	5 	-5
+           col_0  col_1
+        0      9     -2
+        1     -3     -7
+        2      0      6
+        3     -1      8
+        4      5     -5
+
 
         >>> df.clip(-4, 6)
-            0 	1
-        0 	6 	-2
-        1 	-3 	-4
-        2 	0 	6
-        3 	-1 	6
-        4 	5 	-4
+           col_0  col_1
+        0      6     -2
+        1     -3     -4
+        2      0      6
+        3     -1      6
+        4      5     -4
 
         >>> t = pd.Series([2, -4, -1, 6, 3])
         >>> t
@@ -5610,12 +5611,13 @@ class NDFrame(PandasObject, SelectionMixin):
         dtype: int64
 
         >>> df.clip(t, t + 4, axis=0)
-            0 	1
-        0 	6 	2
-        1 	-3 	-4
-        2 	0 	3
-        3  	6 	8
-        4 	5 	3
+           col_0  col_1
+        0      6      2
+        1     -3     -4
+        2      0      3
+        3      6      8
+        4      5      3
+
         """
         if isinstance(self, ABCPanel):
             raise NotImplementedError("clip is not supported yet for panels")

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -5548,8 +5548,8 @@ class NDFrame(PandasObject, SelectionMixin):
         """
         Trim values at input threshold(s).
 
-	    Truncates values below and above specified thresholds.
-	    Thresholds can be singular values or array like, and in
+        Truncates values below and above specified thresholds.
+        Thresholds can be singular values or array like, and in
         the latter case the truncation is performed element-wise
         in the specified axis.
 
@@ -5559,7 +5559,7 @@ class NDFrame(PandasObject, SelectionMixin):
             Minimum threshold value. All values below this
             threshold will be set to it.
         upper : float or array_like, default None
-            Maximum threshold value. All values above this 
+            Maximum threshold value. All values above this
             threshold will be set to it.
         axis : int or string axis name, optional
             Align object with lower and upper along the given axis.
@@ -5573,8 +5573,8 @@ class NDFrame(PandasObject, SelectionMixin):
 
         See Also
         --------
-        clip_lower : Return copy of the input with values below given value(s) truncated.
-        clip_upper : Return copy of the input with values above given value(s) truncated.
+        clip_lower : Clips values below specified threshold(s).
+        clip_upper : Clips values above specified threshold(s).
 
         Returns
         -------
@@ -5585,7 +5585,7 @@ class NDFrame(PandasObject, SelectionMixin):
         >>> data = {'0': [9, -3, 0, -1, 5], '1': [-2, -7, 6, 8, -5]}
         >>> df = pd.DataFrame(data)
         >>> df
-         	0 	1
+            0 	1
         0 	9 	-2
         1 	-3 	-7
         2 	0 	6
@@ -5610,7 +5610,7 @@ class NDFrame(PandasObject, SelectionMixin):
         dtype: int64
 
         >>> df.clip(t, t + 4, axis=0)
- 	        0 	1
+            0 	1
         0 	6 	2
         1 	-3 	-4
         2 	0 	3

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -5548,10 +5548,11 @@ class NDFrame(PandasObject, SelectionMixin):
         """
         Trim values at input threshold(s).
 
-        Truncates values below and above specified thresholds.
-        Thresholds can be singular values or array like, and in
-        the latter case the truncation is performed element-wise
-        in the specified axis.
+        Values outside specified boundary are re-assigned
+        to the closest boundary value. Thresholds can be
+        singular values or array like, and in the latter
+        case the clipping is performed element-wise in
+        the specified axis.
 
         Parameters
         ----------
@@ -5566,19 +5567,19 @@ class NDFrame(PandasObject, SelectionMixin):
         inplace : boolean, default False
             Whether to perform the operation in place on the data
                 .. versionadded:: 0.21.0.
-        args : iterable, optional
-            Arguments to pass to the function.
-        kwargs : mapping, optional
-            Keyworded arguments to pass to the function.
+        *args, **kwargs
+            Additional keywords have no effect but might be accepted
+            for compatibility with numpy.
 
         See Also
         --------
-        clip_lower : Clips values below specified threshold(s).
-        clip_upper : Clips values above specified threshold(s).
+        clip_lower : Clip values below specified threshold(s).
+        clip_upper : Clip values above specified threshold(s).
 
         Returns
         -------
-        clipped : Series
+        'pandas.Series'
+            Series with the values outside the clip boundaries replaced
 
         Examples
         --------

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -5548,15 +5548,33 @@ class NDFrame(PandasObject, SelectionMixin):
         """
         Trim values at input threshold(s).
 
+	    Truncates values below and above specified thresholds.
+	    Thresholds can be singular values or array like, and in
+        the latter case the truncation is performed element-wise
+        in the specified axis.
+
         Parameters
         ----------
         lower : float or array_like, default None
+            Minimum threshold value. All values below this
+            threshold will be set to it.
         upper : float or array_like, default None
+            Maximum threshold value. All values above this 
+            threshold will be set to it.
         axis : int or string axis name, optional
             Align object with lower and upper along the given axis.
         inplace : boolean, default False
             Whether to perform the operation in place on the data
-                .. versionadded:: 0.21.0
+                .. versionadded:: 0.21.0.
+        args : iterable, optional
+            Arguments to pass to the function.
+        kwargs : mapping, optional
+            Keyworded arguments to pass to the function.
+
+        See Also
+        --------
+        clip_lower : Return copy of the input with values below given value(s) truncated.
+        clip_upper : Return copy of the input with values above given value(s) truncated.
 
         Returns
         -------
@@ -5564,37 +5582,40 @@ class NDFrame(PandasObject, SelectionMixin):
 
         Examples
         --------
+        >>> data = {'0': [9, -3, 0, -1, 5], '1': [-2, -7, 6, 8, -5]}
+        >>> df = pd.DataFrame(data)
         >>> df
-                  0         1
-        0  0.335232 -1.256177
-        1 -1.367855  0.746646
-        2  0.027753 -1.176076
-        3  0.230930 -0.679613
-        4  1.261967  0.570967
+         	0 	1
+        0 	9 	-2
+        1 	-3 	-7
+        2 	0 	6
+        3 	-1 	8
+        4 	5 	-5
 
-        >>> df.clip(-1.0, 0.5)
-                  0         1
-        0  0.335232 -1.000000
-        1 -1.000000  0.500000
-        2  0.027753 -1.000000
-        3  0.230930 -0.679613
-        4  0.500000  0.500000
+        >>> df.clip(-4, 6)
+            0 	1
+        0 	6 	-2
+        1 	-3 	-4
+        2 	0 	6
+        3 	-1 	6
+        4 	5 	-4
 
+        >>> t = pd.Series([2, -4, -1, 6, 3])
         >>> t
-        0   -0.3
-        1   -0.2
-        2   -0.1
-        3    0.0
-        4    0.1
-        dtype: float64
+        0    2
+        1   -4
+        2   -1
+        3    6
+        4    3
+        dtype: int64
 
-        >>> df.clip(t, t + 1, axis=0)
-                  0         1
-        0  0.335232 -0.300000
-        1 -0.200000  0.746646
-        2  0.027753 -0.100000
-        3  0.230930  0.000000
-        4  1.100000  0.570967
+        >>> df.clip(t, t + 4, axis=0)
+ 	        0 	1
+        0 	6 	2
+        1 	-3 	-4
+        2 	0 	3
+        3  	6 	8
+        4 	5 	3
         """
         if isinstance(self, ABCPanel):
             raise NotImplementedError("clip is not supported yet for panels")


### PR DESCRIPTION
```
################################################################################
#################### Docstring (pandas.DataFrame.from_dict) ####################
################################################################################

Construct DataFrame from dict of array-like or dicts.

Creates DataFrame object from dictionary by columns or by index
allowing dtype specification.

Parameters
----------
data : dict
    Of the form {field : array-like} or {field : dict}.
orient : {'columns', 'index'}, default 'columns'
    The "orientation" of the data. If the keys of the passed dict
    should be the columns of the resulting DataFrame, pass 'columns'
    (default). Otherwise if the keys should be rows, pass 'index'.
dtype : dtype, default None
    Data type to force, otherwise infer.
columns : list, default None
    Column labels to use when orient='index'. Raises a ValueError
    if used with orient='columns'
    .. versionadded:: 0.23.0.

See Also
--------
DataFrame.from_records : Create DataFrame from ndarray (structured dtype),
                         list of tuples, dict, or DataFrame
DataFrame.from_items : Create DataFrame from sequence of (key, value) pairs.

Returns
-------
DataFrame

Examples
--------
>>> data = {'col_1': [3, 2, 1, 0], 'col_2': ['a', 'b', 'c', 'd']}
>>> data
{'col_1': [3, 2, 1, 0], 'col_2': ['a', 'b', 'c', 'd']}

>>> pd.DataFrame.from_dict(data)
   col_1 col_2
0      3     a
1      2     b
2      1     c
3      0     d

>>> pd.DataFrame.from_dict(data, orient='index')
       0  1  2  3
col_1  3  2  1  0
col_2  a  b  c  d

################################################################################
################################## Validation ##################################
################################################################################

Docstring for "pandas.DataFrame.from_dict" correct. :)
```