### PR TITLE
DOC: update the pandas.errors.DtypeWarning docstring

### DIFF
--- a/pandas/errors/__init__.py
+++ b/pandas/errors/__init__.py
@@ -63,7 +63,6 @@ class DtypeWarning(Warning):
     This example creates and reads a large CSV file with a column that contains
     `int` and `str`.
 
-    >>> import os
     >>> df = pd.DataFrame({'a': (['1'] * 100000 + ['X'] * 100000 +
     ...                          ['1'] * 100000),
     ...                    'b': ['b'] * 300000})
@@ -91,6 +90,7 @@ class DtypeWarning(Warning):
 
     No warning was issued.
 
+    >>> import os
     >>> os.remove('test.csv')
     """
 

--- a/pandas/errors/__init__.py
+++ b/pandas/errors/__init__.py
@@ -13,12 +13,14 @@ class PerformanceWarning(Warning):
     performance impact.
     """
 
+
 class UnsupportedFunctionCall(ValueError):
     """
     Exception raised when attempting to call a numpy function
     on a pandas object, but that function is not supported by
     the object e.g. ``np.cumsum(groupby_object)``.
     """
+
 
 class UnsortedIndexError(KeyError):
     """
@@ -38,9 +40,53 @@ class ParserError(ValueError):
 
 class DtypeWarning(Warning):
     """
-    Warning that is raised for a dtype incompatibility. This
-    can happen whenever `pd.read_csv` encounters non-
-    uniform dtypes in a column(s) of a given CSV file.
+    Warning raised when importing different dtypes in a column from a file.
+
+    Raised for a dtype incompatibility. This can happen whenever `pd.read_csv`
+    or `pd.read_table` encounter non-uniform dtypes in a column(s) of a given
+    CSV file.
+
+    It only happens when dealing with larger files.
+
+    See Also
+    --------
+    pd.read_csv : Read CSV (comma-separated) file into a DataFrame.
+    pd.read_table : Read general delimited file into a DataFrame.
+
+    Notes
+    -----
+    Despite the warning, the CSV file is imported with mixed types in a single
+    column. See the examples below to better understand this issue.
+
+    Examples
+    --------
+    This example creates and reads a large CSV file with a column that contains
+    `int` and `str`.
+
+    >>> df = pd.DataFrame({'a':['1']*100000 + ['X']*100000 + ['1']*100000,
+    ...                    'b':['b']*300000})
+    >>> df.to_csv('test', sep='\t', index=False, na_rep='NA')
+    >>> df2 = pd.read_csv('test', sep='\t')
+    Traceback (most recent call last):
+    ...
+    DtypeWarning: Columns (0) have mixed types...
+
+    Important to notice that df2 will contain both `str` and `int` for the
+    same input, '1'.
+
+    >>> df2.iloc[262140,0]
+    '1'
+    >>> type(df2.iloc[262140,0])
+    <class 'str'>
+    >>> df2.iloc[262150,0]
+    1
+    >>> type(df2.iloc[262150,0])
+    <class 'int'>
+
+    One way to solve this issue is using the parameter `converters` in the
+    `read_csv` and `read_table` functions to explicit the conversion:
+
+    >>> df2 = pd.read_csv('test', sep='\t', converters={'a': str})
     """
 
 

--- a/pandas/errors/__init__.py
+++ b/pandas/errors/__init__.py
@@ -13,14 +13,12 @@ class PerformanceWarning(Warning):
     performance impact.
     """
 
-
 class UnsupportedFunctionCall(ValueError):
     """
     Exception raised when attempting to call a numpy function
     on a pandas object, but that function is not supported by
     the object e.g. ``np.cumsum(groupby_object)``.
     """
-
 
 class UnsortedIndexError(KeyError):
     """

--- a/pandas/errors/__init__.py
+++ b/pandas/errors/__init__.py
@@ -67,7 +67,6 @@ class DtypeWarning(Warning):
     ...                    'b':['b']*300000})
     >>> df.to_csv('test', sep='\t', index=False, na_rep='NA')
     >>> df2 = pd.read_csv('test', sep='\t')
-    Traceback (most recent call last):
     ...
     DtypeWarning: Columns (0) have mixed types...
 

--- a/pandas/errors/__init__.py
+++ b/pandas/errors/__init__.py
@@ -63,13 +63,16 @@ class DtypeWarning(Warning):
     This example creates and reads a large CSV file with a column that contains
     `int` and `str`.
 
-    >>> df = pd.DataFrame({'a':['1']*100000 + ['X']*100000 + ['1']*100000,
-    ...                    'b':['b']*300000})
+    >>> import os
+    >>> df = pd.DataFrame({'a': (['1'] * 100000 + ['X'] * 100000 +
+    ...                          ['1'] * 100000),
+    ...                    'b': ['b'] * 300000})
     >>> df.to_csv('test.csv', index=False)
     >>> df2 = pd.read_csv('test.csv')
-    >>> DtypeWarning: Columns (0) have mixed types... # doctest: +SKIP
 
-    Important to notice that df2 will contain both `str` and `int` for the
+        DtypeWarning: Columns (0) have mixed types
+
+    Important to notice that ``df2`` will contain both `str` and `int` for the
     same input, '1'.
 
     >>> df2.iloc[262140, 0]
@@ -81,10 +84,14 @@ class DtypeWarning(Warning):
     >>> type(df2.iloc[262150, 0])
     <class 'int'>
 
-    One way to solve this issue is using the parameter `converters` in the
+    One way to solve this issue is using the `dtype` parameter in the
     `read_csv` and `read_table` functions to explicit the conversion:
 
-    >>> df2 = pd.read_csv('test', sep='\t', converters={'a': str})
+    >>> df2 = pd.read_csv('test.csv', sep=',', dtype={'a': str})
+
+    No warning was issued.
+
+    >>> os.remove('test.csv')
     """
 
 

--- a/pandas/errors/__init__.py
+++ b/pandas/errors/__init__.py
@@ -38,23 +38,25 @@ class ParserError(ValueError):
 
 class DtypeWarning(Warning):
     """
-    Warning raised when importing different dtypes in a column from a file.
+    Warning raised when reading different dtypes in a column from a file.
 
-    Raised for a dtype incompatibility. This can happen whenever `pd.read_csv`
-    or `pd.read_table` encounter non-uniform dtypes in a column(s) of a given
+    Raised for a dtype incompatibility. This can happen whenever `read_csv`
+    or `read_table` encounter non-uniform dtypes in a column(s) of a given
     CSV file.
-
-    It only happens when dealing with larger files.
 
     See Also
     --------
-    pd.read_csv : Read CSV (comma-separated) file into a DataFrame.
-    pd.read_table : Read general delimited file into a DataFrame.
+    pandas.read_csv : Read CSV (comma-separated) file into a DataFrame.
+    pandas.read_table : Read general delimited file into a DataFrame.
 
     Notes
     -----
-    Despite the warning, the CSV file is imported with mixed types in a single
-    column. See the examples below to better understand this issue.
+    This warning is issued when dealing with larger files because the dtype
+    checking happens per chunk read.
+
+    Despite the warning, the CSV file is read with mixed types in a single
+    column which will be an object type. See the examples below to better
+    understand this issue.
 
     Examples
     --------
@@ -63,22 +65,20 @@ class DtypeWarning(Warning):
 
     >>> df = pd.DataFrame({'a':['1']*100000 + ['X']*100000 + ['1']*100000,
     ...                    'b':['b']*300000})
-    >>> df.to_csv('test', sep='\t', index=False, na_rep='NA')
-    >>> df2 = pd.read_csv('test', sep='\t')
-    Traceback (most recent call last):
-    ...
-    DtypeWarning: Columns (0) have mixed types...
+    >>> df.to_csv('test.csv', index=False)
+    >>> df2 = pd.read_csv('test.csv')
+    >>> DtypeWarning: Columns (0) have mixed types... # doctest: +SKIP
 
     Important to notice that df2 will contain both `str` and `int` for the
     same input, '1'.
 
-    >>> df2.iloc[262140,0]
+    >>> df2.iloc[262140, 0]
     '1'
-    >>> type(df2.iloc[262140,0])
+    >>> type(df2.iloc[262140, 0])
     <class 'str'>
-    >>> df2.iloc[262150,0]
+    >>> df2.iloc[262150, 0]
     1
-    >>> type(df2.iloc[262150,0])
+    >>> type(df2.iloc[262150, 0])
     <class 'int'>
 
     One way to solve this issue is using the parameter `converters` in the

--- a/pandas/errors/__init__.py
+++ b/pandas/errors/__init__.py
@@ -67,6 +67,7 @@ class DtypeWarning(Warning):
     ...                    'b':['b']*300000})
     >>> df.to_csv('test', sep='\t', index=False, na_rep='NA')
     >>> df2 = pd.read_csv('test', sep='\t')
+    Traceback (most recent call last):
     ...
     DtypeWarning: Columns (0) have mixed types...
 


### PR DESCRIPTION
Checklist for the pandas documentation sprint (ignore this if you are doing
an unrelated PR):

- [X] PR title is "DOC: update the <your-function-or-method> docstring"
- [X] The validation script passes: `scripts/validate_docstrings.py <your-function-or-method>`
- [X] The PEP8 style check passes: `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [X] The html version looks good: `python doc/make.py --single <your-function-or-method>`
- [X] It has been proofread on language by another sprint participant

Please include the output of the validation script below between the "```" ticks:

```
################################################################################
#################### Docstring (pandas.errors.DtypeWarning) ####################
################################################################################

Warning raised when reading different dtypes in a column from a file.

Raised for a dtype incompatibility. This can happen whenever `read_csv`
or `read_table` encounter non-uniform dtypes in a column(s) of a given
CSV file.

See Also
--------
pandas.read_csv : Read CSV (comma-separated) file into a DataFrame.
pandas.read_table : Read general delimited file into a DataFrame.

Notes
-----
This warning is issued when dealing with larger files because the dtype
checking happens per chunk read.

Despite the warning, the CSV file is read with mixed types in a single
column which will be an object type. See the examples below to better
understand this issue.

Examples
--------
This example creates and reads a large CSV file with a column that contains
`int` and `str`.

>>> df = pd.DataFrame({'a':['1']*100000 + ['X']*100000 + ['1']*100000,
...                    'b':['b']*300000})
>>> df.to_csv('test.csv', index=False)
>>> df2 = pd.read_csv('test.csv')
>>> DtypeWarning: Columns (0) have mixed types... # doctest: +SKIP

Important to notice that df2 will contain both `str` and `int` for the
same input, '1'.

>>> df2.iloc[262140, 0]
'1'
>>> type(df2.iloc[262140, 0])
<class 'str'>
>>> df2.iloc[262150, 0]
1
>>> type(df2.iloc[262150, 0])
<class 'int'>

One way to solve this issue is using the parameter `converters` in the
`read_csv` and `read_table` functions to explicit the conversion:

>>> df2 = pd.read_csv('test', sep=' ', converters={'a': str})
scripts/validate_docstrings.py:268: DtypeWarning: Columns (0) have mixed types. Specify dtype option on import or set low_memory=False.
  runner.run(test)

################################################################################
################################## Validation ##################################
################################################################################

Errors found:
	No returns section found
```
