### PR TITLE
DOC: update the pd.Index.contains docstring

### DIFF
--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -1832,15 +1832,31 @@ class Index(IndexOpsMixin, PandasObject):
             return False
 
     _index_shared_docs['contains'] = """
-        return a boolean if this key is IN the index
+        Return a boolean if key is in the index.
+
+        This function returns True if key is in the index and
+        returns False if key is not in index.
 
         Parameters
         ----------
-        key : object
+        key : immutable object
+            Key to be searched.
 
         Returns
         -------
-        boolean
+        bool
+            Result of the key search.
+
+        Notes
+        -----
+            CategoricalIndex is a sub-class of Index.
+
+        Examples
+        --------
+        >>> pd.CategoricalIndex([2000, 2001, 2012]).contains(2001)
+        True
+        >>> pd.CategoricalIndex([2000, 2001, 2012]).contains(2222)
+        False
         """
 
     @Appender(_index_shared_docs['contains'] % _index_doc_kwargs)


### PR DESCRIPTION
Checklist for the pandas documentation sprint (ignore this if you are doing
an unrelated PR):

- [X] PR title is "DOC: update the <your-function-or-method> docstring"
- [ ] The validation script passes: `scripts/validate_docstrings.py <your-function-or-method>`
- [X] The PEP8 style check passes: `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [X] The html version looks good: `python doc/make.py --single <your-function-or-method>`
- [X] It has been proofread on language by another sprint participant

Please include the output of the validation script below between the "```" ticks:

```

################################################################################
###################### Docstring (pandas.Index.contains)  ######################
################################################################################

Return a boolean if key is in the index.

This function returns True if key is in the index and
returns False if key is not in index.

Parameters
----------
key : immutable object
    Key to be searched.

Returns
-------
bool
    Result of the key search.

Notes
-----
    CategoricalIndex is a sub-class of Index.

Examples
--------
>>> pd.CategoricalIndex([2000, 2001, 2012]).contains(2001)
True
>>> pd.CategoricalIndex([2000, 2001, 2012]).contains(2222)
False

################################################################################
################################## Validation ##################################
################################################################################

Errors found:
        See Also section not found
```

If the validation script still gives errors, but you think there is a good reason
to deviate in this case (and there are certainly such cases), please state this
explicitly.

See Also missing because we haven't found similar functions

Checklist for other PRs (remove this part if you are doing a PR for the pandas documentation sprint):

- [ ] closes #xxxx
- [ ] tests added / passed
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
