### PR TITLE
DOC: update the pandas.DataFrame.clip docstring

### DIFF
--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -5629,6 +5629,12 @@ class NDFrame(PandasObject, SelectionMixin):
             Original input with those values above/below the
             `upper`/`lower` thresholds set to the threshold values.
 
+        Notes
+        -----
+
+        .. [1] Tukey, John W. "The future of data analysis." The annals of
+            mathematical statistics 33.1 (1962): 1-67.
+
         See Also
         --------
         DataFrame.clip : Trim values at input threshold(s).
@@ -5650,13 +5656,13 @@ class NDFrame(PandasObject, SelectionMixin):
         ...                    'b': [1, 2, 100]},
         ...                    index=['foo', 'bar', 'foobar'])
         >>> df
-            a   b
+             a  b
         foo -1  1
         bar -2  2
         foobar  -100    100
 
         >>> df.clip(lower=-10, upper=10)
-            a   b
+             a  b
         foo -1  1
         bar -2  2
         foobar  -10 10
@@ -5667,7 +5673,7 @@ class NDFrame(PandasObject, SelectionMixin):
 
         >>> col_thresh = pd.Series({'a': -5, 'b': 5})
         >>> df.clip(lower=col_thresh, axis='columns')
-            a   b
+             a  b
         foo -1  5
         bar -2  5
         foobar  -5  100
@@ -5681,15 +5687,14 @@ class NDFrame(PandasObject, SelectionMixin):
         bar 1   2
         foobar  10  100
 
-        `Winsorizing <https://en.wikipedia.org/wiki/Winsorizing>`__ is a
-        related method, whereby the data are clipped at
+        Winsorizing [1]_ is a related method, whereby the data are clipped at
         the 5th and 95th percentiles. The ``DataFrame.quantile`` method returns
         a ``Series`` with column names as index and the quantiles as values.
         Use ``axis='columns'`` to apply clipping to columns.
 
         >>> lower, upper = df.quantile(0.05), df.quantile(0.95)
         >>> df.clip(lower=lower, upper=upper, axis='columns')
-            a   b
+             a  b
         foo -1.1    1.1
         bar -2.0    2.0
         foobar  -90.2   90.2

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -5601,6 +5601,9 @@ class NDFrame(PandasObject, SelectionMixin):
         """
         Trim values at input threshold(s).
 
+        Elements above the upper threshold will be changed to upper threshold.
+        Elements below the lower threshold will be changed to lower threshold.
+
         Parameters
         ----------
         lower : float or array_like, default None
@@ -5609,53 +5612,69 @@ class NDFrame(PandasObject, SelectionMixin):
             Align object with lower and upper along the given axis.
         inplace : boolean, default False
             Whether to perform the operation in place on the data
-                .. versionadded:: 0.21.0
+                .. versionadded:: 0.21.0.
 
         Returns
         -------
         clipped : Series
 
+        Notes
+        -----
+        Clipping data is a method for dealing with dubious elements.
+        If some elements are too large or too small, clipping is one way to
+        transform the data into a reasonable range.
+
+        See Also
+        --------
+        pandas.DataFrame.clip_upper : Return copy of input with values
+            above given value(s) truncated.
+        pandas.DataFrame.clip_lower : Return copy of input with values
+            below given value(s) truncated.
+
         Examples
         --------
+        >>> df = pd.DataFrame({'a':[1, 2, 3], 'b':[4, 5, 6], 'c':[7, 8, 9001]})
         >>> df
             a   b   c
         0   1   4   7
         1   2   5   8
         2   3   6   9001
 
-
-        >>> df.clip( lower = 1 , upper = 9 )
+        >>> df.clip(lower = 1, upper = 9)
             a   b   c
         0   1   4   7
         1   2   5   8
         2   3   6   9
 
-        
-        You can clip each column with different thresholds by passing a Series to the lower/upper argument.
+        You can clip each column with different thresholds by passing
+        a Series to the lower/upper argument.
 
+        >>> some_data = {'A':[-19, 12, -5],'B':[1, 100, -5]}
+        >>> df = pd.DataFrame(data = some_data, index = ['foo', 'bar', 'bizz'])
         >>> df
               A   B
         foo  -19  1
         bar   12 100
         bizz -5  -5
-        
-        >>> df.clip( lower = pd.Series({'A': -10, 'B': 10}) , axis = 1 )
 
+        Use the axis argument to clip by column or rows.  Clip column A with
+        lower threshold of -10 and column B has lower threshold of 10.
+
+        >>> df.clip(lower = pd.Series({'A':-10, 'B':10}), axis = 1)
               A   B
         foo  -10 10
         bar   12 100
         bizz -5  10
 
-        Use the axis argument to clip by column or rows.
+        Clip the foo, bar, and bizz rows with lower thresholds -10, 0, and 10.
 
-        >>> df.clip( lower = pd.Series({'foo':-10,'bar':0, 'bizz':10}) , axis = 0 )
+        >>> row_thresh = pd.Series({'foo':-10, 'bar':0, 'bizz':10})
+        >>> df.clip(lower = row_thresh ,axis = 0)
              A   B
         foo  -10 1
         bar   12 100
         bizz  10 10
-
         """
-        
         if isinstance(self, ABCPanel):
             raise NotImplementedError("clip is not supported yet for panels")
 

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -5613,7 +5613,7 @@ class NDFrame(PandasObject, SelectionMixin):
             Upper threshold for clipping.  Values larger than `upper` will be
             converted to `upper`.
         axis : {0 or 'index', 1 or 'columns', None}, default None
-            Align object with lower and upper along the given axis.
+            Apply clip by index (i.e. by rows) or columns.
         inplace : boolean, default False
             Whether to perform the operation in place on the data
                 .. versionadded:: 0.21.0.

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -5631,11 +5631,18 @@ class NDFrame(PandasObject, SelectionMixin):
 
         See Also
         --------
+        DataFrame.clip : Trim values at input threshold(s).
         Series.clip : Trim values at input threshold(s).
-        DataFrame.clip_upper : Return copy of input with values above given
+        Series.clip_lower : Return copy of the input with values below given
+            value(s) truncated.
+        Series.clip_upper : Return copy of input with values above given
             value(s) truncated.
         DataFrame.clip_lower : Return copy of the input with values below given
             value(s) truncated.
+        DataFrame.clip_upper : Return copy of input with values above given
+            value(s) truncated.
+        DataFrame.quantile : Return values at the given quantile over requested
+            axis, a la numpy.percentile.
 
         Examples
         --------

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -5617,6 +5617,8 @@ class NDFrame(PandasObject, SelectionMixin):
         Returns
         -------
         clipped : DataFrame/Series
+            Elements above or below the upper and lower thresholds converted to
+            threshold values.
 
         Notes
         -----

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -5635,7 +5635,7 @@ class NDFrame(PandasObject, SelectionMixin):
         Examples
         --------
         >>> some_data = {'a': [1, 2, 3], 'b': [4, 5, 6], 'c': [7, 8, 9001]}
-        >>> df = pd.DataFrame(some_data, index = ['foo','bar','foobar'])
+        >>> df = pd.DataFrame(some_data, index = ['foo', 'bar', 'foobar'])
         >>> df
             a   b   c
         foo 1   4   7

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -5629,9 +5629,8 @@ class NDFrame(PandasObject, SelectionMixin):
             Original input with those values above/below the
             `upper`/`lower` thresholds set to the threshold values.
 
-        Notes
+        References
         -----
-
         .. [1] Tukey, John W. "The future of data analysis." The annals of
             mathematical statistics 33.1 (1962): 1-67.
 

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -5602,7 +5602,9 @@ class NDFrame(PandasObject, SelectionMixin):
         Trim values at input threshold(s).
 
         Elements above/below the upper/lower thresholds will be changed to
-        upper/lower thresholds.
+        upper/lower thresholds. Clipping data is a method for dealing with
+        out-of-range elements. If some elements are too large or too small,
+        clipping is one way to transform the data into a reasonable range.
 
         Parameters
         ----------
@@ -5617,67 +5619,70 @@ class NDFrame(PandasObject, SelectionMixin):
         inplace : boolean, default False
             Whether to perform the operation in place on the data
                 .. versionadded:: 0.21.0.
-        *args : Additional keywords have no effect but might be accepted
-            for compatibility with numpy.
-        **kwargs : Additional keywords have no effect but might be accepted
+        *args, **kwargs
+            Additional keywords have no effect but might be accepted
             for compatibility with numpy.
 
         Returns
         -------
         `Series` or `DataFrame`.
-            DataFrame is returned with those values above/below the
+            Original input with those values above/below the
             `upper`/`'lower` thresholds set to the threshold values.
 
         See Also
         --------
-        pandas.Series.clip : Trim values at input threshold(s).
+        Series.clip : Trim values at input threshold(s).
+        DataFrame.clip_upper : Return copy of input with values above given
+            value(s) truncated.
+        DataFrame.clip_lower : Return copy of the input with values below given
+            value(s) truncated.
 
         Examples
         --------
-        >>> some_data = {'a': [1, 2, 3], 'b': [4, 5, 6], 'c': [7, 8, 9001]}
-        >>> df = pd.DataFrame(some_data, index = ['foo', 'bar', 'foobar'])
+        >>> some_data = {'a': [-1, -2, -100], 'b': [1, 2, 100]}
+        >>> df=pd.DataFrame(some_data, index = ['foo', 'bar', 'foobar'])
         >>> df
-            a   b   c
-        foo 1   4   7
-        bar 2   5   8
-        foobar  3   6   9001
+            a   b
+        foo -1  1
+        bar -2  2
+        foobar  -100    100
 
-        >>> df.clip(lower=1, upper=9)
-            a   b   c
-        foo 1   4   7
-        bar 2   5   8
-        foobar  3   6   9
+        >>> df.clip(lower=-10, upper=10)
+            a   b
+        foo -1  1
+        bar -2  2
+        foobar  -10 10
 
         You can clip each column or row with different thresholds by passing
         a ``Series`` to the lower/upper argument. Use the axis argument to clip
         by column or rows.
 
-        >>> col_thresh = pd.Series({'a':4, 'b':5, 'c':6})
+        >>> col_thresh=pd.Series({'a':-5, 'b':5})
         >>> df.clip(lower=col_thresh, axis='columns')
-            a   b   c
-        foo 4   5   7
-        bar 4   5   8
-        foobar  4   6   9001
+            a   b
+        foo -1  5
+        bar -2  5
+        foobar  -5  100
 
         Clip the foo, bar, and foobar rows with lower thresholds 5, 7, and 10.
 
-        >>> row_thresh = pd.Series({'foo': 5, 'bar': 7, 'foobar': 10})
+        >>> row_thresh=pd.Series({'foo': 0, 'bar': 1, 'foobar': 10})
         >>> df.clip(lower=row_thresh, axis='index')
-            a   b   c
-        foo 5   5   7
-        bar 7   7   8
-        foobar  10  10  9001
+            a   b
+        foo 0   1
+        bar 1   2
+        foobar  10  100
 
-        Clipping data is a method for dealing with out-of-range elements.
-        If some elements are too large or too small, clipping is one way to
-        transform the data into a reasonable range.
         `Winsorizing <https://en.wikipedia.org/wiki/Winsorizing>`__ is a
         related method, whereby the data are clipped at
         the 5th and 95th percentiles.
 
-        >>> lwr_thresh = df.quantile(0.05)
-        >>> upr_thresh = df.quantile(0.95)
-        >>> dfw = df.clip(lower=lwr_thresh, upper=upr_thresh, axis='columns')
+        >>> lower, upper = df.quantile(0.05), df.quantile(0.95)
+        >>> df.clip(lower=lower, upper=upper, axis='columns')
+            a   b
+        foo -1.1    1.1
+        bar -2.0    2.0
+        foobar  -90.2   90.2
         """
         if isinstance(self, ABCPanel):
             raise NotImplementedError("clip is not supported yet for panels")

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -5692,7 +5692,7 @@ class NDFrame(PandasObject, SelectionMixin):
         >>> x = np.random.normal(size=(1000,3))
         >>> U = df.quantile(0.95)
         >>> L = df.quantile(0.5)
-        >>> winsorized_df = df.clip(lower=L, upper=U, axis = 1)
+        >>> winsorized_df = df.clip(lower=L, upper=U, axis=1)
         """
         if isinstance(self, ABCPanel):
             raise NotImplementedError("clip is not supported yet for panels")

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -5639,7 +5639,7 @@ class NDFrame(PandasObject, SelectionMixin):
 
         Examples
         --------
-        >>> some_data = {'a': [-1, -2, -100], 'b': [1, 2, 100]}
+        >>> some_data={'a': [-1, -2, -100], 'b': [1, 2, 100]}
         >>> df=pd.DataFrame(some_data, index = ['foo', 'bar', 'foobar'])
         >>> df
             a   b

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -5627,7 +5627,7 @@ class NDFrame(PandasObject, SelectionMixin):
         -------
         `Series` or `DataFrame`.
             Original input with those values above/below the
-            `upper`/`'lower` thresholds set to the threshold values.
+            `upper`/`lower` thresholds set to the threshold values.
 
         See Also
         --------

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -5619,81 +5619,64 @@ class NDFrame(PandasObject, SelectionMixin):
                 .. versionadded:: 0.21.0.
         *args : Additional keywords have no effect but might be accepted
             for compatibility with numpy.
-        **kwargs :  Additional keywords have no effect but might be accepted
+        **kwargs : Additional keywords have no effect but might be accepted
             for compatibility with numpy.
+
         Returns
         -------
-        clipped : `Series` or `DataFrame`.
-            Elements above or below the upper and lower thresholds converted to
-            threshold values.
-
-        Notes
-        -----
-        Clipping data is a method for dealing with out-of-range elements.
-        If some elements are too large or too small, clipping is one way to
-        transform the data into a reasonable range.
+        `Series` or `DataFrame`.
+            DataFrame is returned with those values above/below the 
+            `upper`/`'lower` thresholds set to the threshold values.
 
         See Also
         --------
-        pandas.DataFrame.clip_upper : Return copy of input with values
-            above given value(s) truncated.
-        pandas.DataFrame.clip_lower : Return copy of input with values
-            below given value(s) truncated.
         pandas.Series.clip : Trim values at input threshold(s).
 
         Examples
         --------
         >>> some_data = {'a': [1, 2, 3], 'b': [4, 5, 6], 'c': [7, 8, 9001]}
-        >>> df = pd.DataFrame(some_data)
+        >>> df = pd.DataFrame(some_data, index = ['foo','bar','foobar'])
         >>> df
             a   b   c
-        0   1   4   7
-        1   2   5   8
-        2   3   6   9001
+        foo 1   4   7
+        bar 2   5   8
+        foobar  3   6   9001
 
         >>> df.clip(lower=1, upper=9)
             a   b   c
-        0   1   4   7
-        1   2   5   8
-        2   3   6   9
+        foo 1   4   7
+        bar 2   5   8
+        foobar  3   6   9
 
         You can clip each column or row with different thresholds by passing
-        a ``Series`` to the lower/upper argument.
+        a ``Series`` to the lower/upper argument. Use the axis argument to clip 
+        by column or rows.
 
-        >>> some_data = {'A': [-19, 12, -5], 'B': [1, 100, -5]}
-        >>> df = pd.DataFrame(data=some_data, index=['foo', 'bar', 'bizz'])
-        >>> df
-              A   B
-        foo  -19  1
-        bar   12 100
-        bizz -5  -5
+        >>> col_thresh = pd.Series({'a':4, 'b':5, 'c':6})
+        >>> df.clip(lower=col_thresh, axis='columns')
+            a   b   c
+        foo 4   5   7
+        bar 4   5   8
+        foobar  4   6   9001
 
-        Use the axis argument to clip by column or rows.  Clip column A with
-        lower threshold of -10 and column B has lower threshold of 10.
+        Clip the foo, bar, and foobar rows with lower thresholds 5, 7, and 10.
 
-        >>> df.clip(lower=pd.Series({'A': -10, 'B': 10}), axis=1)
-              A   B
-        foo  -10 10
-        bar   12 100
-        bizz -5  10
+        >>> row_thresh = pd.Series({'foo': 5, 'bar': 7, 'foobar': 10})
+        >>> df.clip(lower=row_thresh, axis='index')
+            a   b   c
+        foo 5   5   7
+        bar 7   7   8
+        foobar  10  10  9001
 
-        Clip the foo, bar, and bizz rows with lower thresholds -10, 0, and 10.
+        Clipping data is a method for dealing with out-of-range elements.
+        If some elements are too large or too small, clipping is one way to
+        transform the data into a reasonable range.
+        `Winsorizing <https://en.wikipedia.org/wiki/Winsorizing>`__ is a related
+        method, whereby the data are clipped at the 5th and 95th percentiles.
 
-        >>> row_thresh = pd.Series({'foo': -10, 'bar': 0, 'bizz': 10})
-        >>> df.clip(lower=row_thresh, axis=0)
-             A   B
-        foo  -10 1
-        bar   12 100
-        bizz  10 10
-
-        `Winsorizing <https://en.wikipedia.org/wiki/Winsorizing>`__ is a way
-        of removing outliers from data.  Columns of a DataFrame can be
-        winsorized at 5th and 95th percentile by using clip.
-
-        >>> x = np.random.normal(size=(1000,3))
-        >>> U = df.quantile(0.95)
-        >>> L = df.quantile(0.5)
-        >>> winsorized_df = df.clip(lower=L, upper=U, axis=1)
+        >>> lwr_thresh = df.quantile(0.05)
+        >>> upr_thresh = df.quantile(0.95)
+        >>> df_win = df.clip(lower=lwr_thresh, upper=upr_thresh, axis='columns')
         """
         if isinstance(self, ABCPanel):
             raise NotImplementedError("clip is not supported yet for panels")

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -5617,6 +5617,8 @@ class NDFrame(PandasObject, SelectionMixin):
         inplace : boolean, default False
             Whether to perform the operation in place on the data
                 .. versionadded:: 0.21.0.
+        args : dictionary of arguments arguments passed to pandas.compat.numpy
+        kwargs : dictionary of keyword arguments passed to pandas.compat.numpy
 
         Returns
         -------

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -5607,7 +5607,11 @@ class NDFrame(PandasObject, SelectionMixin):
         Parameters
         ----------
         lower : float or array_like, default None
+            Lower threshold for clipping.  Values smaller than upper will be
+            converted to lower.
         upper : float or array_like, default None
+            Upper threshold for clipping.  Values larger than upper will be
+            converted to upper.
         axis : int or string axis name, optional
             Align object with lower and upper along the given axis.
         inplace : boolean, default False

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -5616,7 +5616,7 @@ class NDFrame(PandasObject, SelectionMixin):
 
         Returns
         -------
-        clipped : Series
+        clipped : DataFrame/Series
 
         Notes
         -----
@@ -5640,17 +5640,17 @@ class NDFrame(PandasObject, SelectionMixin):
         1   2   5   8
         2   3   6   9001
 
-        >>> df.clip(lower = 1, upper = 9)
+        >>> df.clip(lower=1, upper=9)
             a   b   c
         0   1   4   7
         1   2   5   8
         2   3   6   9
 
         You can clip each column with different thresholds by passing
-        a Series to the lower/upper argument.
+        a ``Series`` to the lower/upper argument.
 
         >>> some_data = {'A':[-19, 12, -5],'B':[1, 100, -5]}
-        >>> df = pd.DataFrame(data = some_data, index = ['foo', 'bar', 'bizz'])
+        >>> df = pd.DataFrame(data=some_data, index=['foo', 'bar', 'bizz'])
         >>> df
               A   B
         foo  -19  1
@@ -5660,7 +5660,7 @@ class NDFrame(PandasObject, SelectionMixin):
         Use the axis argument to clip by column or rows.  Clip column A with
         lower threshold of -10 and column B has lower threshold of 10.
 
-        >>> df.clip(lower = pd.Series({'A':-10, 'B':10}), axis = 1)
+        >>> df.clip(lower=pd.Series({'A':-10, 'B':10}), axis=1)
               A   B
         foo  -10 10
         bar   12 100
@@ -5668,8 +5668,8 @@ class NDFrame(PandasObject, SelectionMixin):
 
         Clip the foo, bar, and bizz rows with lower thresholds -10, 0, and 10.
 
-        >>> row_thresh = pd.Series({'foo':-10, 'bar':0, 'bizz':10})
-        >>> df.clip(lower = row_thresh ,axis = 0)
+        >>> row_thresh=pd.Series({'foo':-10, 'bar':0, 'bizz':10})
+        >>> df.clip(lower=row_thresh, axis=0)
              A   B
         foo  -10 1
         bar   12 100

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -5601,34 +5601,34 @@ class NDFrame(PandasObject, SelectionMixin):
         """
         Trim values at input threshold(s).
 
-        Elements above the upper threshold will be changed to upper threshold.
-        Elements below the lower threshold will be changed to lower threshold.
+        Elements above/below the upper'lower thresholds will be changed to
+        upper/lower thresholds.
 
         Parameters
         ----------
-        lower : float or array_like, default None
-            Lower threshold for clipping.  Values smaller than upper will be
-            converted to lower.
-        upper : float or array_like, default None
-            Upper threshold for clipping.  Values larger than upper will be
-            converted to upper.
-        axis : int or string axis name, optional
+        lower : float, array-like or None, default None
+            Lower threshold for clipping.  Values smaller than `lower` will be
+            converted to `lower`.
+        upper : float, array-like or None, default None
+            Upper threshold for clipping.  Values larger than `upper` will be
+            converted to `upper`.
+        axis : {0 or 'index', 1 or 'columns', None}, default None
             Align object with lower and upper along the given axis.
         inplace : boolean, default False
             Whether to perform the operation in place on the data
                 .. versionadded:: 0.21.0.
-        args : dictionary of arguments arguments passed to pandas.compat.numpy
-        kwargs : dictionary of keyword arguments passed to pandas.compat.numpy
+        *args : arguments passed to pandas.compat.numpy
+        **kwargs : keyword arguments passed to pandas.compat.numpy
 
         Returns
         -------
-        clipped : DataFrame/Series
+        clipped : `Series` or `DataFrame`.
             Elements above or below the upper and lower thresholds converted to
             threshold values.
 
         Notes
         -----
-        Clipping data is a method for dealing with dubious elements.
+        Clipping data is a method for dealing with out-of-range elements.
         If some elements are too large or too small, clipping is one way to
         transform the data into a reasonable range.
 
@@ -5638,10 +5638,12 @@ class NDFrame(PandasObject, SelectionMixin):
             above given value(s) truncated.
         pandas.DataFrame.clip_lower : Return copy of input with values
             below given value(s) truncated.
+        pandas.Series.clip : Trim values at input threshold(s).
 
         Examples
         --------
-        >>> df=pd.DataFrame({'a':[1, 2, 3], 'b':[4, 5, 6], 'c':[7, 8, 9001]})
+        >>> some_data = {'a': [1, 2, 3], 'b': [4, 5, 6], 'c': [7, 8, 9001]}
+        >>> df = pd.DataFrame(some_data)
         >>> df
             a   b   c
         0   1   4   7
@@ -5657,8 +5659,8 @@ class NDFrame(PandasObject, SelectionMixin):
         You can clip each column or row with different thresholds by passing
         a ``Series`` to the lower/upper argument.
 
-        >>> some_data={'A':[-19, 12, -5],'B':[1, 100, -5]}
-        >>> df=pd.DataFrame(data=some_data, index=['foo', 'bar', 'bizz'])
+        >>> some_data = {'A': [-19, 12, -5], 'B': [1, 100, -5]}
+        >>> df = pd.DataFrame(data=some_data, index=['foo', 'bar', 'bizz'])
         >>> df
               A   B
         foo  -19  1
@@ -5668,7 +5670,7 @@ class NDFrame(PandasObject, SelectionMixin):
         Use the axis argument to clip by column or rows.  Clip column A with
         lower threshold of -10 and column B has lower threshold of 10.
 
-        >>> df.clip(lower=pd.Series({'A':-10, 'B':10}), axis=1)
+        >>> df.clip(lower=pd.Series({'A': -10, 'B': 10}), axis=1)
               A   B
         foo  -10 10
         bar   12 100
@@ -5676,7 +5678,7 @@ class NDFrame(PandasObject, SelectionMixin):
 
         Clip the foo, bar, and bizz rows with lower thresholds -10, 0, and 10.
 
-        >>> row_thresh=pd.Series({'foo':-10, 'bar':0, 'bizz':10})
+        >>> row_thresh = pd.Series({'foo': -10, 'bar': 0, 'bizz': 10})
         >>> df.clip(lower=row_thresh, axis=0)
              A   B
         foo  -10 1
@@ -5685,15 +5687,12 @@ class NDFrame(PandasObject, SelectionMixin):
 
         `Winsorizing <https://en.wikipedia.org/wiki/Winsorizing>`__ is a way
         of removing outliers from data.  Columns of a DataFrame can be
-        winsorized by using clip.
+        winsorized at 5th and 95th percentile by using clip.
 
-        >>> import numpy as np
-        >>> x=np.random.normal(size=(1000,3))
-        >>> df=pd.DataFrame(x, columns=['a','b','c'])
-        >>> #Winsorize columns at 5% and 95%
-        >>> U=df.quantile(0.95)
-        >>> L=df.quantile(0.5)
-        >>> winsorized_df=df.clip(lower=L, upper=U, axis = 1)
+        >>> x = np.random.normal(size=(1000,3))
+        >>> U = df.quantile(0.95)
+        >>> L = df.quantile(0.5)
+        >>> winsorized_df = df.clip(lower=L, upper=U, axis = 1)
         """
         if isinstance(self, ABCPanel):
             raise NotImplementedError("clip is not supported yet for panels")

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -5633,7 +5633,7 @@ class NDFrame(PandasObject, SelectionMixin):
 
         Examples
         --------
-        >>> df = pd.DataFrame({'a':[1, 2, 3], 'b':[4, 5, 6], 'c':[7, 8, 9001]})
+        >>> df=pd.DataFrame({'a':[1, 2, 3], 'b':[4, 5, 6], 'c':[7, 8, 9001]})
         >>> df
             a   b   c
         0   1   4   7
@@ -5646,11 +5646,11 @@ class NDFrame(PandasObject, SelectionMixin):
         1   2   5   8
         2   3   6   9
 
-        You can clip each column with different thresholds by passing
+        You can clip each column or row with different thresholds by passing
         a ``Series`` to the lower/upper argument.
 
         >>> some_data = {'A':[-19, 12, -5],'B':[1, 100, -5]}
-        >>> df = pd.DataFrame(data=some_data, index=['foo', 'bar', 'bizz'])
+        >>> df=pd.DataFrame(data=some_data, index=['foo', 'bar', 'bizz'])
         >>> df
               A   B
         foo  -19  1
@@ -5674,6 +5674,18 @@ class NDFrame(PandasObject, SelectionMixin):
         foo  -10 1
         bar   12 100
         bizz  10 10
+
+        `Winsorizing <https://en.wikipedia.org/wiki/Winsorizing>`__ is a way
+        of removing outliers from data.  Columns of a DataFrame can be
+        winsorized by using clip.
+
+        >>> import numpy as np
+        >>> x=np.random.normal(size=(1000,3))
+        >>> df=pd.DataFrame(x, columns=['a','b','c'])
+        >>> #Winsorize columns at 5% and 95%
+        >>> U=df.quantile(0.95)
+        >>> L=df.quantile(0.5)
+        >>> winsorized_df=df.clip(lower=L, upper=U, axis = 1)
         """
         if isinstance(self, ABCPanel):
             raise NotImplementedError("clip is not supported yet for panels")

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -5649,7 +5649,7 @@ class NDFrame(PandasObject, SelectionMixin):
         You can clip each column or row with different thresholds by passing
         a ``Series`` to the lower/upper argument.
 
-        >>> some_data = {'A':[-19, 12, -5],'B':[1, 100, -5]}
+        >>> some_data={'A':[-19, 12, -5],'B':[1, 100, -5]}
         >>> df=pd.DataFrame(data=some_data, index=['foo', 'bar', 'bizz'])
         >>> df
               A   B

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -5601,7 +5601,7 @@ class NDFrame(PandasObject, SelectionMixin):
         """
         Trim values at input threshold(s).
 
-        Elements above/below the upper'lower thresholds will be changed to
+        Elements above/below the upper/lower thresholds will be changed to
         upper/lower thresholds.
 
         Parameters

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -5617,9 +5617,10 @@ class NDFrame(PandasObject, SelectionMixin):
         inplace : boolean, default False
             Whether to perform the operation in place on the data
                 .. versionadded:: 0.21.0.
-        *args : arguments passed to pandas.compat.numpy
-        **kwargs : keyword arguments passed to pandas.compat.numpy
-
+        *args : Additional keywords have no effect but might be accepted
+            for compatibility with numpy.
+        **kwargs :  Additional keywords have no effect but might be accepted
+            for compatibility with numpy.
         Returns
         -------
         clipped : `Series` or `DataFrame`.

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -5639,8 +5639,8 @@ class NDFrame(PandasObject, SelectionMixin):
 
         Examples
         --------
-        >>> some_data={'a': [-1, -2, -100], 'b': [1, 2, 100]}
-        >>> df=pd.DataFrame(some_data, index = ['foo', 'bar', 'foobar'])
+        >>> some_data = {'a': [-1, -2, -100], 'b': [1, 2, 100]}
+        >>> df = pd.DataFrame(some_data, index = ['foo', 'bar', 'foobar'])
         >>> df
             a   b
         foo -1  1
@@ -5657,7 +5657,7 @@ class NDFrame(PandasObject, SelectionMixin):
         a ``Series`` to the lower/upper argument. Use the axis argument to clip
         by column or rows.
 
-        >>> col_thresh=pd.Series({'a':-5, 'b':5})
+        >>> col_thresh = pd.Series({'a': -5, 'b': 5})
         >>> df.clip(lower=col_thresh, axis='columns')
             a   b
         foo -1  5
@@ -5666,7 +5666,7 @@ class NDFrame(PandasObject, SelectionMixin):
 
         Clip the foo, bar, and foobar rows with lower thresholds 5, 7, and 10.
 
-        >>> row_thresh=pd.Series({'foo': 0, 'bar': 1, 'foobar': 10})
+        >>> row_thresh = pd.Series({'foo': 0, 'bar': 1, 'foobar': 10})
         >>> df.clip(lower=row_thresh, axis='index')
             a   b
         foo 0   1

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -5646,8 +5646,9 @@ class NDFrame(PandasObject, SelectionMixin):
 
         Examples
         --------
-        >>> some_data = {'a': [-1, -2, -100], 'b': [1, 2, 100]}
-        >>> df = pd.DataFrame(some_data, index = ['foo', 'bar', 'foobar'])
+        >>> df = pd.DataFrame({'a': [-1, -2, -100],
+        ...                    'b': [1, 2, 100]},
+        ...                    index=['foo', 'bar', 'foobar'])
         >>> df
             a   b
         foo -1  1
@@ -5682,7 +5683,9 @@ class NDFrame(PandasObject, SelectionMixin):
 
         `Winsorizing <https://en.wikipedia.org/wiki/Winsorizing>`__ is a
         related method, whereby the data are clipped at
-        the 5th and 95th percentiles.
+        the 5th and 95th percentiles. The ``DataFrame.quantile`` method returns
+        a ``Series`` with column names as index and the quantiles as values.
+        Use ``axis='columns'`` to apply clipping to columns.
 
         >>> lower, upper = df.quantile(0.05), df.quantile(0.95)
         >>> df.clip(lower=lower, upper=upper, axis='columns')

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -5625,7 +5625,7 @@ class NDFrame(PandasObject, SelectionMixin):
         Returns
         -------
         `Series` or `DataFrame`.
-            DataFrame is returned with those values above/below the 
+            DataFrame is returned with those values above/below the
             `upper`/`'lower` thresholds set to the threshold values.
 
         See Also
@@ -5649,7 +5649,7 @@ class NDFrame(PandasObject, SelectionMixin):
         foobar  3   6   9
 
         You can clip each column or row with different thresholds by passing
-        a ``Series`` to the lower/upper argument. Use the axis argument to clip 
+        a ``Series`` to the lower/upper argument. Use the axis argument to clip
         by column or rows.
 
         >>> col_thresh = pd.Series({'a':4, 'b':5, 'c':6})
@@ -5671,12 +5671,13 @@ class NDFrame(PandasObject, SelectionMixin):
         Clipping data is a method for dealing with out-of-range elements.
         If some elements are too large or too small, clipping is one way to
         transform the data into a reasonable range.
-        `Winsorizing <https://en.wikipedia.org/wiki/Winsorizing>`__ is a related
-        method, whereby the data are clipped at the 5th and 95th percentiles.
+        `Winsorizing <https://en.wikipedia.org/wiki/Winsorizing>`__ is a
+        related method, whereby the data are clipped at
+        the 5th and 95th percentiles.
 
         >>> lwr_thresh = df.quantile(0.05)
         >>> upr_thresh = df.quantile(0.95)
-        >>> df_win = df.clip(lower=lwr_thresh, upper=upr_thresh, axis='columns')
+        >>> dfw = df.clip(lower=lwr_thresh, upper=upr_thresh, axis='columns')
         """
         if isinstance(self, ABCPanel):
             raise NotImplementedError("clip is not supported yet for panels")

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -5618,36 +5618,42 @@ class NDFrame(PandasObject, SelectionMixin):
         Examples
         --------
         >>> df
-                  0         1
-        0  0.335232 -1.256177
-        1 -1.367855  0.746646
-        2  0.027753 -1.176076
-        3  0.230930 -0.679613
-        4  1.261967  0.570967
+            a   b   c
+        0   1   4   7
+        1   2   5   8
+        2   3   6   9001
 
-        >>> df.clip(-1.0, 0.5)
-                  0         1
-        0  0.335232 -1.000000
-        1 -1.000000  0.500000
-        2  0.027753 -1.000000
-        3  0.230930 -0.679613
-        4  0.500000  0.500000
 
-        >>> t
-        0   -0.3
-        1   -0.2
-        2   -0.1
-        3    0.0
-        4    0.1
-        dtype: float64
+        >>> df.clip( lower = 1 , upper = 9 )
+            a   b   c
+        0   1   4   7
+        1   2   5   8
+        2   3   6   9
 
-        >>> df.clip(t, t + 1, axis=0)
-                  0         1
-        0  0.335232 -0.300000
-        1 -0.200000  0.746646
-        2  0.027753 -0.100000
-        3  0.230930  0.000000
-        4  1.100000  0.570967
+        
+        You can clip each column with different thresholds by passing a Series to the lower/upper argument.
+
+        >>> df
+              A   B
+        foo  -19  1
+        bar   12 100
+        bizz -5  -5
+        
+        >>> df.clip( lower = pd.Series({'A': -10, 'B': 10}) , axis = 1 )
+
+              A   B
+        foo  -10 10
+        bar   12 100
+        bizz -5  10
+
+        Use the axis argument to clip by column or rows.
+
+        >>> df.clip( lower = pd.Series({'foo':-10,'bar':0, 'bizz':10}) , axis = 0 )
+             A   B
+        foo  -10 1
+        bar   12 100
+        bizz  10 10
+
         """
         if isinstance(self, ABCPanel):
             raise NotImplementedError("clip is not supported yet for panels")

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -5655,6 +5655,7 @@ class NDFrame(PandasObject, SelectionMixin):
         bizz  10 10
 
         """
+        
         if isinstance(self, ABCPanel):
             raise NotImplementedError("clip is not supported yet for panels")
 


### PR DESCRIPTION
Checklist for the pandas documentation sprint (ignore this if you are doing
an unrelated PR):

- [x] PR title is "DOC: update the <your-function-or-method> docstring"
- [x] The validation script passes: `scripts/validate_docstrings.py <your-function-or-method>`
- [x] The PEP8 style check passes: `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] The html version looks good: `python doc/make.py --single <your-function-or-method>`
- [x] It has been proofread on language by another sprint participant

Please include the output of the validation script below between the "```" ticks:

```
################################################################################
################################## Validation ##################################
################################################################################

Errors found:
	Errors in parameters section
		Parameters {'kwargs', 'args'} not documented
		Unknown parameters {'*args, **kwargs'}
		Parameter "*args, **kwargs" has no type
(pandas_dev) Demetris-Retina-MacBook-Pro:pandas demetri$ git diff upstream/master -u -- "*.py" | flake8 --diff
(pandas_dev) Demetris-Retina-MacBook-Pro:pandas demetri$ python scripts/validate_docstrings.py pandas.DataFrame.clip

################################################################################
###################### Docstring (pandas.DataFrame.clip)  ######################
################################################################################

Trim values at input threshold(s).

Elements above/below the upper/lower thresholds will be changed to
upper/lower thresholds. Clipping data is a method for dealing with
out-of-range elements. If some elements are too large or too small,
clipping is one way to transform the data into a reasonable range.

Parameters
----------
lower : float, array-like or None, default None
    Lower threshold for clipping.  Values smaller than `lower` will be
    converted to `lower`.
upper : float, array-like or None, default None
    Upper threshold for clipping.  Values larger than `upper` will be
    converted to `upper`.
axis : {0 or 'index', 1 or 'columns', None}, default None
    Apply clip by index (i.e. by rows) or columns.
inplace : boolean, default False
    Whether to perform the operation in place on the data
        .. versionadded:: 0.21.0.
*args, **kwargs
    Additional keywords have no effect but might be accepted
    for compatibility with numpy.

Returns
-------
`Series` or `DataFrame`.
    Original input with those values above/below the
    `upper`/`lower` thresholds set to the threshold values.

References
-----
.. [1] Tukey, John W. "The future of data analysis." The annals of
    mathematical statistics 33.1 (1962): 1-67.

See Also
--------
DataFrame.clip : Trim values at input threshold(s).
Series.clip : Trim values at input threshold(s).
Series.clip_lower : Return copy of the input with values below given
    value(s) truncated.
Series.clip_upper : Return copy of input with values above given
    value(s) truncated.
DataFrame.clip_lower : Return copy of the input with values below given
    value(s) truncated.
DataFrame.clip_upper : Return copy of input with values above given
    value(s) truncated.
DataFrame.quantile : Return values at the given quantile over requested
    axis, a la numpy.percentile.

Examples
--------
>>> df = pd.DataFrame({'a': [-1, -2, -100],
...                    'b': [1, 2, 100]},
...                    index=['foo', 'bar', 'foobar'])
>>> df
     a  b
foo -1  1
bar -2  2
foobar  -100    100

>>> df.clip(lower=-10, upper=10)
     a  b
foo -1  1
bar -2  2
foobar  -10 10

You can clip each column or row with different thresholds by passing
a ``Series`` to the lower/upper argument. Use the axis argument to clip
by column or rows.

>>> col_thresh = pd.Series({'a': -5, 'b': 5})
>>> df.clip(lower=col_thresh, axis='columns')
     a  b
foo -1  5
bar -2  5
foobar  -5  100

Clip the foo, bar, and foobar rows with lower thresholds 5, 7, and 10.

>>> row_thresh = pd.Series({'foo': 0, 'bar': 1, 'foobar': 10})
>>> df.clip(lower=row_thresh, axis='index')
    a   b
foo 0   1
bar 1   2
foobar  10  100

Winsorizing [1]_ is a related method, whereby the data are clipped at
the 5th and 95th percentiles. The ``DataFrame.quantile`` method returns
a ``Series`` with column names as index and the quantiles as values.
Use ``axis='columns'`` to apply clipping to columns.

>>> lower, upper = df.quantile(0.05), df.quantile(0.95)
>>> df.clip(lower=lower, upper=upper, axis='columns')
     a  b
foo -1.1    1.1
bar -2.0    2.0
foobar  -90.2   90.2

################################################################################
################################## Validation ##################################
################################################################################

Errors found:
	Errors in parameters section
		Parameters {'kwargs', 'args'} not documented
		Unknown parameters {'*args, **kwargs'}
		Parameter "*args, **kwargs" has no type
```



Changes:

* `*args` and `**kwargs` description taken from #20256 in the name of consistency