### PR TITLE
DOC: Updated docstring DatetimeIndex.ceil

### DIFF
--- a/pandas/core/indexes/datetimelike.py
+++ b/pandas/core/indexes/datetimelike.py
@@ -122,20 +122,21 @@ class TimelikeOps(object):
     @Appender(_round_doc % "ceil")
     def ceil(self, freq):
         """
-        Ceil the index to the specified freq.
+        Floor the index to the specified freq.
 
-        Links to the available `frequency strings <http://pandas.
-        pydata.org/pandas-docs/stable/timeseries.html#offset-aliases>`_
-        and `frequency objects <http://pandas.pydata.org/pandas-docs/
-        stable/timeseries.html#dateoffset-objects>`_ .
+        Links to the available [frequency strings](http://pandas.
+        pydata.org/pandas-docs/stable/timeseries.html#offset-aliases)
+        and [frequency objects](http://pandas.pydata.org/pandas-docs/
+        stable/timeseries.html#dateoffset-objects).
 
         Parameters
         ----------
-        freq : freq string/object
+        freq : str, object
+            String or object specifying the frequency to round down to.
 
         Returns
         -------
-        ceil : DatetimeIndex
+        index of same type
 
         See Also
         --------
@@ -145,17 +146,16 @@ class TimelikeOps(object):
         Examples
         --------
 
-        In [2]: df = pd.DatetimeIndex(start='2014-08-01 09:23:41.321211',
+        >>> dti = pd.DatetimeIndex(start='2014-08-01 09:23:41.321211',
         freq = 'H', periods = 3)
 
-        In [3]: df
-
-        Out[3]: DatetimeIndex(['2014-08-01 09:23:41.321211',
+        >>> dti
+        DatetimeIndex(['2014-08-01 09:23:41.321211',
         '2014-08-01 10:23:41.321211', '2014-08-01 11:23:41.321211'],
         dtype='datetime64[ns]', freq='H')
 
-        In [4]: df.ceil('H')
-        Out[4]: DatetimeIndex(['2014-08-01 10:00:00', '2014-08-01 11:00:00',
+        >>> dti.ceil('H')
+        DatetimeIndex(['2014-08-01 10:00:00', '2014-08-01 11:00:00',
                '2014-08-01 12:00:00'],
               dtype='datetime64[ns]', freq=None)
 

--- a/pandas/core/indexes/datetimelike.py
+++ b/pandas/core/indexes/datetimelike.py
@@ -132,11 +132,12 @@ class TimelikeOps(object):
         Parameters
         ----------
         freq : str, object
-            String or object specifying the frequency to round down to.
+			String or object specifying the frequency to round down to.
 
         Returns
         -------
-        index of same type
+        DatetimeIndex
+            Index of the same time is rounded off.
 
         See Also
         --------
@@ -147,18 +148,40 @@ class TimelikeOps(object):
         --------
 
         >>> dti = pd.DatetimeIndex(start='2014-08-01 09:23:41.321211',
-        freq = 'H', periods = 3)
-
+		...							freq='H', periods=3)
         >>> dti
         DatetimeIndex(['2014-08-01 09:23:41.321211',
         '2014-08-01 10:23:41.321211', '2014-08-01 11:23:41.321211'],
         dtype='datetime64[ns]', freq='H')
 
         >>> dti.ceil('H')
-        DatetimeIndex(['2014-08-01 10:00:00', '2014-08-01 11:00:00',
-               '2014-08-01 12:00:00'],
-              dtype='datetime64[ns]', freq=None)
-
+        DatetimeIndex(['2014-08-01 10:00:00', '2014-08-01 11:00:00','2014-08-01 12:00:00'],dtype='datetime64[ns]', freq=None)
+        >>> dti = pd.DatetimeIndex(start='2014-08-01 09:15:41.321211',freq = 'None' , periods = 3)
+		Traceback (most recent call last):
+		File "/usr/local/lib/python3.6/dist-packages/pandas/tseries/frequencies.py", line 552, in get_offset
+		klass = prefix_mapping[split[0]]
+		KeyError: 'NONE'
+		
+		During handling of the above exception, another exception occurred:
+		
+		Traceback (most recent call last):
+		File "/usr/local/lib/python3.6/dist-packages/pandas/tseries/frequencies.py", line 475, in to_offset
+		offset = get_offset(name)
+		File "/usr/local/lib/python3.6/dist-packages/pandas/tseries/frequencies.py", line 558, in get_offset
+		raise ValueError(_INVALID_FREQ_ERROR.format(name))
+		ValueError: Invalid frequency: NONE
+		During handling of the above exception, another exception occurred:
+		Traceback (most recent call last):
+		File "<stdin>", line 1, in <module>
+		File "/usr/local/lib/python3.6/dist-packages/pandas/util/decorators.py", line 91, in wrapper
+		return func(*args, **kwargs)
+		File "/usr/local/lib/python3.6/dist-packages/pandas/tseries/index.py", line 269, in __new__
+		freq = to_offset(freq)
+		File "/usr/local/lib/python3.6/dist-packages/pandas/util/decorators.py", line 91, in wrapper
+		return func(*args, **kwargs)
+		File "/usr/local/lib/python3.6/dist-packages/pandas/tseries/frequencies.py", line 487, in to_offset
+		raise ValueError(_INVALID_FREQ_ERROR.format(freq))
+		ValueError: Invalid frequency: None
         """
         return self._round(freq, np.ceil)
 

--- a/pandas/core/indexes/datetimelike.py
+++ b/pandas/core/indexes/datetimelike.py
@@ -121,67 +121,64 @@ class TimelikeOps(object):
 
     @Appender(_round_doc % "ceil")
     def ceil(self, freq):
-        """
-        Floor the index to the specified freq.
-
-        Links to the available [frequency strings](http://pandas.
-        pydata.org/pandas-docs/stable/timeseries.html#offset-aliases)
-        and [frequency objects](http://pandas.pydata.org/pandas-docs/
-        stable/timeseries.html#dateoffset-objects).
-
-        Parameters
-        ----------
-        freq : str, object
-			String or object specifying the frequency to round down to.
-
-        Returns
-        -------
-        DatetimeIndex
-            Index of the same time is rounded off.
-
-        See Also
-        --------
-        DatetimeIndex.floor : Floor the DatetimeIndex to the specified freq.
-        DatetimeIndex.round : Round the DatetimeIndex to the specified freq.
-
-        Examples
-        --------
-
-        >>> dti = pd.DatetimeIndex(start='2014-08-01 09:23:41.321211',
-		...							freq='H', periods=3)
-        >>> dti
-        DatetimeIndex(['2014-08-01 09:23:41.321211',
-        '2014-08-01 10:23:41.321211', '2014-08-01 11:23:41.321211'],
-        dtype='datetime64[ns]', freq='H')
-
-        >>> dti.ceil('H')
-        DatetimeIndex(['2014-08-01 10:00:00', '2014-08-01 11:00:00','2014-08-01 12:00:00'],dtype='datetime64[ns]', freq=None)
-        >>> dti = pd.DatetimeIndex(start='2014-08-01 09:15:41.321211',freq = 'None' , periods = 3)
-		Traceback (most recent call last):
-		File "/usr/local/lib/python3.6/dist-packages/pandas/tseries/frequencies.py", line 552, in get_offset
-		klass = prefix_mapping[split[0]]
-		KeyError: 'NONE'
-		
-		During handling of the above exception, another exception occurred:
-		
-		Traceback (most recent call last):
-		File "/usr/local/lib/python3.6/dist-packages/pandas/tseries/frequencies.py", line 475, in to_offset
-		offset = get_offset(name)
-		File "/usr/local/lib/python3.6/dist-packages/pandas/tseries/frequencies.py", line 558, in get_offset
-		raise ValueError(_INVALID_FREQ_ERROR.format(name))
-		ValueError: Invalid frequency: NONE
-		During handling of the above exception, another exception occurred:
-		Traceback (most recent call last):
-		File "<stdin>", line 1, in <module>
-		File "/usr/local/lib/python3.6/dist-packages/pandas/util/decorators.py", line 91, in wrapper
-		return func(*args, **kwargs)
-		File "/usr/local/lib/python3.6/dist-packages/pandas/tseries/index.py", line 269, in __new__
-		freq = to_offset(freq)
-		File "/usr/local/lib/python3.6/dist-packages/pandas/util/decorators.py", line 91, in wrapper
-		return func(*args, **kwargs)
-		File "/usr/local/lib/python3.6/dist-packages/pandas/tseries/frequencies.py", line 487, in to_offset
-		raise ValueError(_INVALID_FREQ_ERROR.format(freq))
-		ValueError: Invalid frequency: None
+	"""
+	Floor the index to the specified freq.
+	Links to the available [frequency strings](http://pandas.
+	pydata.org/pandas-docs/stable/timeseries.html#offset-aliases)
+	and [frequency objects](http://pandas.pydata.org/pandas-docs/
+	stable/timeseries.html#dateoffset-objects).
+	
+	Parameters
+	----------
+	freq : str, object
+		String or object specifying the frequency to round down to.
+	
+	Returns
+	-------
+	DatetimeIndex
+		Index of the same type is rounded off.
+	
+	See Also
+	--------
+	DatetimeIndex.floor : Floor the DatetimeIndex to the specified freq.
+	DatetimeIndex.round : Round the DatetimeIndex to the specified freq.
+	
+	Examples
+	--------
+	
+	>>> dti = pd.DatetimeIndex(start='2014-08-01 09:23:41.321211',
+	...				freq='H', periods=3)
+	>>> dti
+	DatetimeIndex(['2014-08-01 09:23:41.321211',
+	'2014-08-01 10:23:41.321211', '2014-08-01 11:23:41.321211'],
+	dtype='datetime64[ns]', freq='H')
+	
+	>>> dti.ceil('H')
+	DatetimeIndex(['2014-08-01 10:00:00', '2014-08-01 11:00:00','2014-08-01 12:00:00'],dtype='datetime64[ns]', freq=None)
+	>>> dti = pd.DatetimeIndex(start='2014-08-01 09:15:41.321211',freq = 'None' , periods = 3)
+	Traceback (most recent call last):
+	File "/usr/local/lib/python3.6/dist-packages/pandas/tseries/frequencies.py", line 552, in get_offset
+	klass = prefix_mapping[split[0]]
+	KeyError: 'NONE'
+	During handling of the above exception, another exception occurred:
+	Traceback (most recent call last):
+	File "/usr/local/lib/python3.6/dist-packages/pandas/tseries/frequencies.py", line 475, in to_offset
+	offset = get_offset(name)
+	File "/usr/local/lib/python3.6/dist-packages/pandas/tseries/frequencies.py", line 558, in get_offset
+	raise ValueError(_INVALID_FREQ_ERROR.format(name))
+	ValueError: Invalid frequency: NONE
+	During handling of the above exception, another exception occurred:
+	Traceback (most recent call last):
+	File "<stdin>", line 1, in <module>
+	File "/usr/local/lib/python3.6/dist-packages/pandas/util/decorators.py", line 91, in wrapper
+	return func(*args, **kwargs)
+	File "/usr/local/lib/python3.6/dist-packages/pandas/tseries/index.py", line 269, in __new__
+	freq = to_offset(freq)
+	File "/usr/local/lib/python3.6/dist-packages/pandas/util/decorators.py", line 91, in wrapper
+	return func(*args, **kwargs)
+	File "/usr/local/lib/python3.6/dist-packages/pandas/tseries/frequencies.py", line 487, in to_offset
+	raise ValueError(_INVALID_FREQ_ERROR.format(freq))
+	ValueError: Invalid frequency: None
         """
         return self._round(freq, np.ceil)
 

--- a/pandas/core/indexes/datetimelike.py
+++ b/pandas/core/indexes/datetimelike.py
@@ -159,12 +159,6 @@ class TimelikeOps(object):
                '2014-08-01 12:00:00'],
               dtype='datetime64[ns]', freq=None)
 
-
-        Raises
-        ------
-        TypeError
-            If the DatetimeIndex is tz-aware and tz is not None.
-
         """
         return self._round(freq, np.ceil)
 

--- a/pandas/core/indexes/datetimelike.py
+++ b/pandas/core/indexes/datetimelike.py
@@ -122,64 +122,45 @@ class TimelikeOps(object):
     @Appender(_round_doc % "ceil")
     def ceil(self, freq):
 	"""
-	Floor the index to the specified freq.
-	Links to the available [frequency strings](http://pandas.
-	pydata.org/pandas-docs/stable/timeseries.html#offset-aliases)
-	and [frequency objects](http://pandas.pydata.org/pandas-docs/
-	stable/timeseries.html#dateoffset-objects).
-	
-	Parameters
-	----------
-	freq : str, object
-		String or object specifying the frequency to round down to.
-	
-	Returns
-	-------
-	DatetimeIndex
-		Index of the same type is rounded off.
-	
-	See Also
-	--------
-	DatetimeIndex.floor : Floor the DatetimeIndex to the specified freq.
-	DatetimeIndex.round : Round the DatetimeIndex to the specified freq.
-	
-	Examples
-	--------
-	
-	>>> dti = pd.DatetimeIndex(start='2014-08-01 09:23:41.321211',
-	...				freq='H', periods=3)
-	>>> dti
-	DatetimeIndex(['2014-08-01 09:23:41.321211',
-	'2014-08-01 10:23:41.321211', '2014-08-01 11:23:41.321211'],
-	dtype='datetime64[ns]', freq='H')
-	
-	>>> dti.ceil('H')
-	DatetimeIndex(['2014-08-01 10:00:00', '2014-08-01 11:00:00','2014-08-01 12:00:00'],dtype='datetime64[ns]', freq=None)
-	>>> dti = pd.DatetimeIndex(start='2014-08-01 09:15:41.321211',freq = 'None' , periods = 3)
-	Traceback (most recent call last):
-	File "/usr/local/lib/python3.6/dist-packages/pandas/tseries/frequencies.py", line 552, in get_offset
-	klass = prefix_mapping[split[0]]
-	KeyError: 'NONE'
-	During handling of the above exception, another exception occurred:
-	Traceback (most recent call last):
-	File "/usr/local/lib/python3.6/dist-packages/pandas/tseries/frequencies.py", line 475, in to_offset
-	offset = get_offset(name)
-	File "/usr/local/lib/python3.6/dist-packages/pandas/tseries/frequencies.py", line 558, in get_offset
-	raise ValueError(_INVALID_FREQ_ERROR.format(name))
-	ValueError: Invalid frequency: NONE
-	During handling of the above exception, another exception occurred:
-	Traceback (most recent call last):
-	File "<stdin>", line 1, in <module>
-	File "/usr/local/lib/python3.6/dist-packages/pandas/util/decorators.py", line 91, in wrapper
-	return func(*args, **kwargs)
-	File "/usr/local/lib/python3.6/dist-packages/pandas/tseries/index.py", line 269, in __new__
-	freq = to_offset(freq)
-	File "/usr/local/lib/python3.6/dist-packages/pandas/util/decorators.py", line 91, in wrapper
-	return func(*args, **kwargs)
-	File "/usr/local/lib/python3.6/dist-packages/pandas/tseries/frequencies.py", line 487, in to_offset
-	raise ValueError(_INVALID_FREQ_ERROR.format(freq))
-	ValueError: Invalid frequency: None
-        """
+        Floor the index to the specified freq.
+
+        Links to the available [frequency strings](http://pandas.
+        pydata.org/pandas-docs/stable/timeseries.html#offset-aliases)
+        and [frequency objects](http://pandas.pydata.org/pandas-docs/
+        stable/timeseries.html#dateoffset-objects).
+
+        Parameters
+        ----------
+        freq : str, object
+        String or object specifying the frequency to round down to.
+
+        Returns
+        -------
+        DatetimeIndex
+            Index of the same time is rounded off.
+
+        See Also
+        --------
+        DatetimeIndex.floor : Floor the DatetimeIndex to the specified freq.
+        DatetimeIndex.round : Round the DatetimeIndex to the specified freq.
+
+        Examples
+        --------
+
+        >>> dti = pd.DatetimeIndex(start='2014-08-01 09:23:41.321211',
+        ...         freq='H', periods=3)
+
+        >>> dti
+        DatetimeIndex(['2014-08-01 09:23:41.321211',
+        '2014-08-01 10:23:41.321211',
+               '2014-08-01 11:23:41.321211'],
+              dtype='datetime64[ns]', freq='H')
+        
+        >>> dti.ceil('H')
+        DatetimeIndex(['2014-08-01 10:00:00', '2014-08-01 11:00:00',
+               '2014-08-01 12:00:00'],
+              dtype='datetime64[ns]', freq=None)  
+	"""
         return self._round(freq, np.ceil)
 
 

--- a/pandas/core/indexes/datetimelike.py
+++ b/pandas/core/indexes/datetimelike.py
@@ -121,6 +121,51 @@ class TimelikeOps(object):
 
     @Appender(_round_doc % "ceil")
     def ceil(self, freq):
+        """
+        Ceil the index to the specified freq.
+
+        Links to the available `frequency strings <http://pandas.
+        pydata.org/pandas-docs/stable/timeseries.html#offset-aliases>`_
+        and `frequency objects <http://pandas.pydata.org/pandas-docs/
+        stable/timeseries.html#dateoffset-objects>`_ .
+
+        Parameters
+        ----------
+        freq : freq string/object
+
+        Returns
+        -------
+        ceil : DatetimeIndex
+
+        See Also
+        --------
+        DatetimeIndex.floor : Floor the DatetimeIndex to the specified freq.
+        DatetimeIndex.round : Round the DatetimeIndex to the specified freq.
+
+        Examples
+        --------
+
+        In [2]: df = pd.DatetimeIndex(start='2014-08-01 09:23:41.321211',
+        freq = 'H', periods = 3)
+
+        In [3]: df
+
+        Out[3]: DatetimeIndex(['2014-08-01 09:23:41.321211',
+        '2014-08-01 10:23:41.321211', '2014-08-01 11:23:41.321211'],
+        dtype='datetime64[ns]', freq='H')
+
+        In [4]: df.ceil('H')
+        Out[4]: DatetimeIndex(['2014-08-01 10:00:00', '2014-08-01 11:00:00',
+               '2014-08-01 12:00:00'],
+              dtype='datetime64[ns]', freq=None)
+
+
+        Raises
+        ------
+        TypeError
+            If the DatetimeIndex is tz-aware and tz is not None.
+
+        """
         return self._round(freq, np.ceil)
 
 


### PR DESCRIPTION
completed the DatetimeIndex.ceil Docstring.

Checklist for the pandas documentation sprint (ignore this if you are doing
an unrelated PR):

- [ ] PR title is "DOC: update the <your-function-or-method> docstring"
- [ ] The validation script passes: `scripts/validate_docstrings.py <your-function-or-method>`
- [ ] The PEP8 style check passes: `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] The html version looks good: `python doc/make.py --single <your-function-or-method>`
- [ ] It has been proofread on language by another sprint participant

Please include the output of the validation script below between the "```" ticks:

```
# paste output of "scripts/validate_docstrings.py <your-function-or-method>" here
# between the "```" (remove this comment, but keep the "```")

```

If the validation script still gives errors, but you think there is a good reason
to deviate in this case (and there are certainly such cases), please state this
explicitly.


Checklist for other PRs (remove this part if you are doing a PR for the pandas documentation sprint):

- [ ] closes #xxxx
- [ ] tests added / passed
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
