### PR TITLE
DOC: update the pandas.DataFrame.all docstring

### DIFF
--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -7869,7 +7869,7 @@ _all_doc = """\
 Return whether all elements are True over series or dataframe axis.
 
 Returns True if all elements within a series or along a dataframe
-axis or are non-zero, not-empty or not-False."""
+axis are non-zero, not-empty or not-False."""
 
 _all_examples = """\
 Examples
@@ -7909,8 +7909,8 @@ dtype: bool
 _all_see_also = """\
 See also
 --------
-pandas.Series.all : Return if all elements are True
-pandas.DataFrame.any : Return if one (or more) elements are True
+pandas.Series.all : Return True if all elements are True
+pandas.DataFrame.any : Return True if one (or more) elements are True
 """
 
 _cnum_doc = """

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -4295,7 +4295,7 @@ class NDFrame(PandasObject, SelectionMixin):
 
         e.g. If the dtypes are float16 and float32, dtype will be upcast to
         float32.  If dtypes are int32 and uint8, dtype will be upcast to
-        int32. By By :func:`numpy.find_common_type` convention, mixing int64
+        int32. By :func:`numpy.find_common_type` convention, mixing int64
         and uint64 will result in a float64 dtype.
 
         See Also

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -7802,7 +7802,7 @@ bool_only : boolean, default None
     Include only boolean columns. If None, will attempt to use everything,
     then use only boolean data. Not implemented for Series.
 **kwargs : any, default None
-    Additional keywords have no fect but might be accepted for
+    Additional keywords have no affect but might be accepted for
     compatibility with numpy.
 
 Returns
@@ -7813,42 +7813,50 @@ Returns
 %(see_also)s"""
 
 _all_doc = """\
-Return whether all elements are True over requested axis.
+Return whether all elements are True over series or dataframe axis.
 
-Returns True if all elements along a dataframe
-axis are non-zero, not-empty or not-False.
-Also note that a series consisting of different data
-types returns the first occurence of the non-zero, not-empty
-or not-False element."""
+Returns True if all elements within a series or along a dataframe
+axis or are non-zero, not-empty or not-False."""
 
 _all_examples = """\
 Examples
 --------
-First create a pandas dataframe::
-    >>> d = {'col1': [True, True], 'col2': [True, False]}
-    >>> df = pd.DataFrame(data=d)
-    >>> df
-       col1   col2
-    0  True   True
-    1  True  False
+Series
 
-Default behaviour checks if column-wise values all return True
-    >>> df.all()
-    col1     True
-    col2    False
-    dtype: bool
+>>> pd.Series([True, True]).all()
+True
+>>> pd.Series([True, False]).all()
+False
 
-Adding axis=1 will check row-wise values
-    >>> df.all(axis=1)
-    0     True
-    1    False
-    dtype: bool
+Dataframes
+
+Create a dataframe from a dictionary.
+
+>>> df = pd.DataFrame({'col1': [True, True], 'col2': [True, False]})
+>>> df
+   col1   col2
+0  True   True
+1  True  False
+
+Default behaviour checks if column-wise values all return True.
+
+>>> df.all()
+col1     True
+col2    False
+dtype: bool
+
+Adding axis=1 argument will check if row-wise values all return True.
+
+>>> df.all(axis=1)
+0     True
+1    False
+dtype: bool
 """
 
 _all_see_also = """\
 See also
 --------
-pandas.DataFrame.any : Checks if one (or more) items return True
+pandas.DataFrame.any : Return if one (or more) elements are True
 """
 
 _cnum_doc = """

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -7787,7 +7787,9 @@ _bool_doc = """
 
 Parameters
 ----------
-axis : %(axis_descr)s
+axis : int, default 0
+    Select the axis that you would like to analyze. For column-wise
+    (axis=0), for row-wise (axis=1).
 skipna : boolean, default True
     Exclude NA/null values. If an entire row/column is NA, the result
     will be NA.

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -7810,7 +7810,7 @@ Return whether all elements are True over requested axis.
 
 Returns True if all elements along a dataframe
 axis are non-zero, not-empty or not-False.
-Also note that a series consisting of different data 
+Also note that a series consisting of different data
 types returns the first occurence of the non-zero, not-empty
 or not-False element."""
 
@@ -7824,7 +7824,7 @@ First create a pandas dataframe::
        col1   col2
     0  True   True
     1  True  False
-    
+
 Default behaviour checks if column-wise values all return True
     >>> df.all()
     col1     True
@@ -8025,7 +8025,8 @@ def _make_cum_function(cls, name, name1, name2, axis_descr, desc,
     return set_function_name(cum_func, name, cls)
 
 
-def _make_logical_function(cls, name, name1, name2, axis_descr, desc, f, examples, see_also):
+def _make_logical_function(cls, name, name1, name2, axis_descr, desc, f,
+                           examples, see_also):
     @Substitution(outname=name, desc=desc, name1=name1, name2=name2,
                   axis_descr=axis_descr, examples=examples, see_also=see_also)
     @Appender(_bool_doc)

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -7787,9 +7787,7 @@ _bool_doc = """
 
 Parameters
 ----------
-axis : int, default 0
-    Select the axis that you would like to analyze. For column-wise
-    (axis=0), for row-wise (axis=1).
+axis : %(axis_descr)s
 skipna : boolean, default True
     Exclude NA/null values. If an entire row/column is NA, the result
     will be NA.
@@ -7799,6 +7797,9 @@ level : int or level name, default None
 bool_only : boolean, default None
     Include only boolean columns. If None, will attempt to use everything,
     then use only boolean data. Not implemented for Series.
+**kwargs : any, default None
+    Additional keywords have no fect but might be accepted for
+    compatibility with numpy.
 
 Returns
 -------

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -7523,11 +7523,10 @@ class NDFrame(PandasObject, SelectionMixin):
         cls.any = _make_logical_function(
             cls, 'any', name, name2, axis_descr,
             'Return whether any element is True over requested axis',
-            nanops.nanany)
+            nanops.nanany, '', '')
         cls.all = _make_logical_function(
-            cls, 'all', name, name2, axis_descr,
-            'Return whether all elements are True over requested axis',
-            nanops.nanall)
+            cls, 'all', name, name2, axis_descr, _all_doc,
+            nanops.nanall, _all_examples, _all_see_also)
 
         @Substitution(outname='mad',
                       desc="Return the mean absolute deviation of the values "
@@ -7784,7 +7783,6 @@ Returns
 %(outname)s : %(name1)s or %(name2)s (if level specified)\n"""
 
 _bool_doc = """
-
 %(desc)s
 
 Parameters
@@ -7792,17 +7790,58 @@ Parameters
 axis : %(axis_descr)s
 skipna : boolean, default True
     Exclude NA/null values. If an entire row/column is NA, the result
-    will be NA
+    will be NA.
 level : int or level name, default None
     If the axis is a MultiIndex (hierarchical), count along a
-    particular level, collapsing into a %(name1)s
+    particular level, collapsing into a %(name1)s.
 bool_only : boolean, default None
     Include only boolean columns. If None, will attempt to use everything,
     then use only boolean data. Not implemented for Series.
 
 Returns
 -------
-%(outname)s : %(name1)s or %(name2)s (if level specified)\n"""
+%(outname)s : %(name1)s or %(name2)s (if level specified)
+
+%(examples)s
+%(see_also)s"""
+
+_all_doc = """\
+Return whether all elements are True over requested axis.
+
+Returns True if all elements along a dataframe
+axis are non-zero, not-empty or not-False.
+Also note that a series consisting of different data 
+types returns the first occurence of the non-zero, not-empty
+or not-False element."""
+
+_all_examples = """\
+Examples
+--------
+First create a pandas dataframe::
+    >>> d = {'col1': [True, True], 'col2': [True, False]}
+    >>> df = pd.DataFrame(data=d)
+    >>> df
+       col1   col2
+    0  True   True
+    1  True  False
+Default behaviour checks if column-wise values all return True
+    >>> df.all()
+    col1     True
+    col2    False
+    dtype: bool
+
+Adding axis=1 will check row-wise values
+    >>> df.all(axis=1)
+    0     True
+    1    False
+    dtype: bool
+"""
+
+_all_see_also = """\
+See also
+--------
+pandas.DataFrame.any : Checks if one (or more) items return True
+"""
 
 _cnum_doc = """
 
@@ -7985,9 +8024,9 @@ def _make_cum_function(cls, name, name1, name2, axis_descr, desc,
     return set_function_name(cum_func, name, cls)
 
 
-def _make_logical_function(cls, name, name1, name2, axis_descr, desc, f):
+def _make_logical_function(cls, name, name1, name2, axis_descr, desc, f, examples, see_also):
     @Substitution(outname=name, desc=desc, name1=name1, name2=name2,
-                  axis_descr=axis_descr)
+                  axis_descr=axis_descr, examples=examples, see_also=see_also)
     @Appender(_bool_doc)
     def logical_func(self, axis=None, bool_only=None, skipna=None, level=None,
                      **kwargs):

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -3673,12 +3673,12 @@ class NDFrame(PandasObject, SelectionMixin):
 
         Returns
         -------
-        obj_tail : type of caller
-            The last n rows of the caller object.
+        type of caller
+            The last `n` rows of the caller object.
 
         See Also
         --------
-        pandas.DataFrame.head
+        pandas.DataFrame.head : The first `n` rows of the caller object.
 
         Examples
         --------
@@ -4236,7 +4236,55 @@ class NDFrame(PandasObject, SelectionMixin):
 
     @property
     def values(self):
-        """Numpy representation of NDFrame
+        """
+        Return a Numpy representation of the DataFrame.
+
+        Only the values in the DataFrame will be returned, the axes labels
+        will be removed.
+
+        Returns
+        -------
+        numpy.ndarray
+            The values of the DataFrame.
+
+        Examples
+        --------
+        A DataFrame where all columns are the same type (e.g., int64) results
+        in an array of the same type.
+
+        >>> df = pd.DataFrame({'age':    [ 3,  29],
+        ...                    'height': [94, 170],
+        ...                    'weight': [31, 115]})
+        >>> df
+           age  height  weight
+        0    3      94      31
+        1   29     170     115
+        >>> df.dtypes
+        age       int64
+        height    int64
+        weight    int64
+        dtype: object
+        >>> df.values
+        array([[  3,  94,  31],
+               [ 29, 170, 115]], dtype=int64)
+
+        A DataFrame with mixed type columns(e.g., str/object, int64, float32)
+        results in an ndarray of the broadest type that accommodates these
+        mixed types (e.g., object).
+
+        >>> df2 = pd.DataFrame([('parrot',   24.0, 'second'),
+        ...                     ('lion',     80.5, 1),
+        ...                     ('monkey', np.nan, None)],
+        ...                   columns=('name', 'max_speed', 'rank'))
+        >>> df2.dtypes
+        name          object
+        max_speed    float64
+        rank          object
+        dtype: object
+        >>> df2.values
+        array([['parrot', 24.0, 'second'],
+               ['lion', 80.5, 1],
+               ['monkey', nan, None]], dtype=object)
 
         Notes
         -----
@@ -4247,8 +4295,13 @@ class NDFrame(PandasObject, SelectionMixin):
 
         e.g. If the dtypes are float16 and float32, dtype will be upcast to
         float32.  If dtypes are int32 and uint8, dtype will be upcast to
-        int32. By numpy.find_common_type convention, mixing int64 and uint64
-        will result in a flot64 dtype.
+        int32. By By :func:`numpy.find_common_type` convention, mixing int64
+        and uint64 will result in a float64 dtype.
+
+        See Also
+        --------
+        pandas.DataFrame.index : Retrievie the index labels
+        pandas.DataFrame.columns : Retrieving the column names
         """
         self._consolidate_inplace()
         return self._data.as_array(transpose=self._AXIS_REVERSED)

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -7909,6 +7909,7 @@ dtype: bool
 _all_see_also = """\
 See also
 --------
+pandas.Series.all : Return if all elements are True
 pandas.DataFrame.any : Return if one (or more) elements are True
 """
 

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -3669,12 +3669,12 @@ class NDFrame(PandasObject, SelectionMixin):
 
         Returns
         -------
-        type of caller
-            The last `n` rows of the caller object.
+        obj_tail : type of caller
+            The last n rows of the caller object.
 
         See Also
         --------
-        pandas.DataFrame.head : The first `n` rows of the caller object.
+        pandas.DataFrame.head
 
         Examples
         --------
@@ -4232,55 +4232,7 @@ class NDFrame(PandasObject, SelectionMixin):
 
     @property
     def values(self):
-        """
-        Return a Numpy representation of the DataFrame.
-
-        Only the values in the DataFrame will be returned, the axes labels
-        will be removed.
-
-        Returns
-        -------
-        numpy.ndarray
-            The values of the DataFrame.
-
-        Examples
-        --------
-        A DataFrame where all columns are the same type (e.g., int64) results
-        in an array of the same type.
-
-        >>> df = pd.DataFrame({'age':    [ 3,  29],
-        ...                    'height': [94, 170],
-        ...                    'weight': [31, 115]})
-        >>> df
-           age  height  weight
-        0    3      94      31
-        1   29     170     115
-        >>> df.dtypes
-        age       int64
-        height    int64
-        weight    int64
-        dtype: object
-        >>> df.values
-        array([[  3,  94,  31],
-               [ 29, 170, 115]], dtype=int64)
-
-        A DataFrame with mixed type columns(e.g., str/object, int64, float32)
-        results in an ndarray of the broadest type that accommodates these
-        mixed types (e.g., object).
-
-        >>> df2 = pd.DataFrame([('parrot',   24.0, 'second'),
-        ...                     ('lion',     80.5, 1),
-        ...                     ('monkey', np.nan, None)],
-        ...                   columns=('name', 'max_speed', 'rank'))
-        >>> df2.dtypes
-        name          object
-        max_speed    float64
-        rank          object
-        dtype: object
-        >>> df2.values
-        array([['parrot', 24.0, 'second'],
-               ['lion', 80.5, 1],
-               ['monkey', nan, None]], dtype=object)
+        """Numpy representation of NDFrame
 
         Notes
         -----
@@ -4291,13 +4243,8 @@ class NDFrame(PandasObject, SelectionMixin):
 
         e.g. If the dtypes are float16 and float32, dtype will be upcast to
         float32.  If dtypes are int32 and uint8, dtype will be upcast to
-        int32. By :func:`numpy.find_common_type` convention, mixing int64
-        and uint64 will result in a float64 dtype.
-
-        See Also
-        --------
-        pandas.DataFrame.index : Retrievie the index labels
-        pandas.DataFrame.columns : Retrieving the column names
+        int32. By numpy.find_common_type convention, mixing int64 and uint64
+        will result in a flot64 dtype.
         """
         self._consolidate_inplace()
         return self._data.as_array(transpose=self._AXIS_REVERSED)
@@ -7877,6 +7824,7 @@ First create a pandas dataframe::
        col1   col2
     0  True   True
     1  True  False
+    
 Default behaviour checks if column-wise values all return True
     >>> df.all()
     col1     True


### PR DESCRIPTION
Checklist for the pandas documentation sprint (ignore this if you are doing
an unrelated PR):

- [x] PR title is "DOC: update the <your-function-or-method> docstring"
- [x] The validation script passes: `scripts/validate_docstrings.py <your-function-or-method>`
- [x] The PEP8 style check passes: `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] The html version looks good: `python doc/make.py --single <your-function-or-method>`
- [x] It has been proofread on language by another sprint participant

Please include the output of the validation script below between the "```" ticks:

```
################################################################################
####################### Docstring (pandas.DataFrame.all) #######################
################################################################################

Return whether all elements are True over requested axis.

Returns True if all elements along a dataframe
axis are non-zero, not-empty or not-False.
Also note that a series consisting of different data
types returns the first occurence of the non-zero, not-empty
or not-False element.

Parameters
----------
axis : {index (0), columns (1)}
skipna : boolean, default True
    Exclude NA/null values. If an entire row/column is NA, the result
    will be NA.
level : int or level name, default None
    If the axis is a MultiIndex (hierarchical), count along a
    particular level, collapsing into a Series.
bool_only : boolean, default None
    Include only boolean columns. If None, will attempt to use everything,
    then use only boolean data. Not implemented for Series.
**kwargs : any, default None
    Additional keywords have no fect but might be accepted for
    compatibility with numpy.

Returns
-------
all : Series or DataFrame (if level specified)

Examples
--------
First create a pandas dataframe::
    >>> d = {'col1': [True, True], 'col2': [True, False]}
    >>> df = pd.DataFrame(data=d)
    >>> df
       col1   col2
    0  True   True
    1  True  False

Default behaviour checks if column-wise values all return True
    >>> df.all()
    col1     True
    col2    False
    dtype: bool

Adding axis=1 will check row-wise values
    >>> df.all(axis=1)
    0     True
    1    False
    dtype: bool

See also
--------
pandas.DataFrame.any : Checks if one (or more) items return True

################################################################################
################################## Validation ##################################
################################################################################

Errors found:
	Errors in parameters section
		Parameters {'kwargs'} not documented
		Unknown parameters {'**kwargs'}
		Parameter "axis" has no description

```

If the validation script still gives errors, but you think there is a good reason
to deviate in this case (and there are certainly such cases), please state this
explicitly.
The axis description is a bug in the string interpollation of %(axis_descr)s
The **kwargs error is a bug in the parameter evaluation 
