### PR TITLE
DOC: update the series.dt.weekofyear docstring

### DIFF
--- a/pandas/core/indexes/datetimes.py
+++ b/pandas/core/indexes/datetimes.py
@@ -1705,7 +1705,64 @@ class DatetimeIndex(DatelikeOps, TimelikeOps, DatetimeIndexOpsMixin,
     nanosecond = _field_accessor('nanosecond', 'ns',
                                  "The nanoseconds of the datetime")
     weekofyear = _field_accessor('weekofyear', 'woy',
-                                 "The week ordinal of the year")
+    """
+    The week ordinal of the year.
+
+    Return the week ordinal of the year. Note that there can be 
+    counter intuitive edge cases around the yearchange. For example, 
+    the first of january could be in week 52 of the previous year. 
+    Monday indicates the start of a new week. 
+    
+    See Also
+    --------
+    pandas.Series.dt.week : Identical method.
+    pandas.Series.dt.weekofyear : Identical method.
+    
+    Returns
+    -------
+    ndarray of formatted strings
+    
+    Examples
+    --------
+    >>> dates = pd.date_range("2016-12-31", "2017-01-08", freq="D")
+    >>> s = pd.Series(dates)
+    >>> pd.DataFrame({'date':s, 'week':s.dt.weekofyear, 'day':s.dt.strftime("%A")})
+            date  week        day
+    0 2016-12-31    52   Saturday
+    1 2017-01-01    52     Sunday
+    2 2017-01-02     1     Monday
+    3 2017-01-03     1    Tuesday
+    4 2017-01-04     1  Wednesday
+    5 2017-01-05     1   Thursday
+    6 2017-01-06     1     Friday
+    7 2017-01-07     1   Saturday
+    8 2017-01-08     1     Sunday
+    
+    Note what `series.dt.week` and `series.dt.weekofyear` are the same.
+    
+    >>> s.dt.week
+    0    52
+    1    52
+    2     1
+    3     1
+    4     1
+    5     1
+    6     1
+    7     1
+    8     1
+    dtype: int64
+    >>> s.dt.weekofyear
+    0    52
+    1    52
+    2     1
+    3     1
+    4     1
+    5     1
+    6     1
+    7     1
+    8     1
+    dtype: int64
+    """)
     week = weekofyear
     dayofweek = _field_accessor('dayofweek', 'dow',
                                 "The day of the week with Monday=0, Sunday=6")

--- a/pandas/core/indexes/datetimes.py
+++ b/pandas/core/indexes/datetimes.py
@@ -1722,7 +1722,7 @@ class DatetimeIndex(DatelikeOps, TimelikeOps, DatetimeIndexOpsMixin,
 
     Returns
     -------
-    ndarray of formatted strings
+    ndarray of integers indicating week
 
     Examples
     --------

--- a/pandas/core/indexes/datetimes.py
+++ b/pandas/core/indexes/datetimes.py
@@ -1714,16 +1714,16 @@ class DatetimeIndex(DatelikeOps, TimelikeOps, DatetimeIndexOpsMixin,
     counter intuitive edge cases around the yearchange. For example, 
     the first of january could be in week 52 of the previous year.
     Monday indicates the start of a new week.
-    
+
     See Also
     --------
     pandas.Series.dt.week : Identical method.
     pandas.Series.dt.weekofyear : Identical method.
-    
+
     Returns
     -------
     ndarray of formatted strings
-    
+
     Examples
     --------
     >>> dates = pd.date_range("2016-12-31", "2017-01-08", freq="D")

--- a/pandas/core/indexes/datetimes.py
+++ b/pandas/core/indexes/datetimes.py
@@ -1716,8 +1716,9 @@ class DatetimeIndex(DatelikeOps, TimelikeOps, DatetimeIndexOpsMixin,
 
     Returns
     -------
-    ndarray of integers indicating the week number
-    
+    Series
+        Containing integers indicating the week number.
+
     See Also
     --------
     pandas.Series.dt.week : Identical method.
@@ -1739,7 +1740,7 @@ class DatetimeIndex(DatelikeOps, TimelikeOps, DatetimeIndexOpsMixin,
     7 2017-01-07     1   Saturday
     8 2017-01-08     1     Sunday
 
-    Note that `series.dt.week` and `series.dt.weekofyear` are the same.
+    Note `pandas.Series.dt.week`/`pandas.Series.dt.weekofyear` are the same.
 
     >>> s.dt.week
     0    52

--- a/pandas/core/indexes/datetimes.py
+++ b/pandas/core/indexes/datetimes.py
@@ -1706,8 +1706,7 @@ class DatetimeIndex(DatelikeOps, TimelikeOps, DatetimeIndexOpsMixin,
                                   "The microseconds of the datetime")
     nanosecond = _field_accessor('nanosecond', 'ns',
                                  "The nanoseconds of the datetime")
-    weekofyear = _field_accessor('weekofyear', 'woy',
-    """
+    _weekofyear_doc = """
     The week ordinal of the year.
 
     Return the week ordinal of the year. Note that there can be
@@ -1715,21 +1714,21 @@ class DatetimeIndex(DatelikeOps, TimelikeOps, DatetimeIndexOpsMixin,
     the first of january could be in week 52 of the previous year.
     Monday indicates the start of a new week.
 
+    Returns
+    -------
+    ndarray of integers indicating the week number
+    
     See Also
     --------
     pandas.Series.dt.week : Identical method.
     pandas.Series.dt.weekofyear : Identical method.
 
-    Returns
-    -------
-    ndarray of integers indicating week
-
     Examples
     --------
     >>> dates = pd.date_range("2016-12-31", "2017-01-08", freq="D")
     >>> s = pd.Series(dates)
-    >>> pd.DataFrame({'date':s, 'week':s.dt.week, 'day':s.dt.strftime("%A")})
-            date  week        day
+    >>> pd.DataFrame({'dt': s, 'week': s.dt.week, 'day': s.dt.strftime("%A")})
+              dt  week        day
     0 2016-12-31    52   Saturday
     1 2017-01-01    52     Sunday
     2 2017-01-02     1     Monday
@@ -1764,8 +1763,10 @@ class DatetimeIndex(DatelikeOps, TimelikeOps, DatetimeIndexOpsMixin,
     7     1
     8     1
     dtype: int64
-    """)
+    """
+    weekofyear = _field_accessor('weekofyear', 'woy', _weekofyear_doc)
     week = weekofyear
+
     dayofweek = _field_accessor('dayofweek', 'dow',
                                 "The day of the week with Monday=0, Sunday=6")
     weekday = dayofweek

--- a/pandas/core/indexes/datetimes.py
+++ b/pandas/core/indexes/datetimes.py
@@ -1712,11 +1712,12 @@ class DatetimeIndex(DatelikeOps, TimelikeOps, DatetimeIndexOpsMixin,
     Return the week ordinal of the year. Note that there can be
     counter intuitive edge cases around a year change. For example
     the first of january could be in week 52 of the previous year.
-    Monday indicates the start of a new week.
+    Monday indicates the start of a new week. This method is available
+    on both Series with datetime values or DatetimeIndex.
 
     Returns
     -------
-    Series
+    ndarry
         Containing integers indicating the week number.
 
     See Also

--- a/pandas/core/indexes/datetimes.py
+++ b/pandas/core/indexes/datetimes.py
@@ -1710,8 +1710,8 @@ class DatetimeIndex(DatelikeOps, TimelikeOps, DatetimeIndexOpsMixin,
     """
     The week ordinal of the year.
 
-    Return the week ordinal of the year. Note that there can be 
-    counter intuitive edge cases around the yearchange. For example, 
+    Return the week ordinal of the year. Note that there can be
+    counter intuitive edge cases around the yearchange. For example
     the first of january could be in week 52 of the previous year.
     Monday indicates the start of a new week.
 
@@ -1739,9 +1739,9 @@ class DatetimeIndex(DatelikeOps, TimelikeOps, DatetimeIndexOpsMixin,
     6 2017-01-06     1     Friday
     7 2017-01-07     1   Saturday
     8 2017-01-08     1     Sunday
-    
+
     Note what `series.dt.week` and `series.dt.weekofyear` are the same.
-    
+
     >>> s.dt.week
     0    52
     1    52

--- a/pandas/core/indexes/datetimes.py
+++ b/pandas/core/indexes/datetimes.py
@@ -1710,7 +1710,7 @@ class DatetimeIndex(DatelikeOps, TimelikeOps, DatetimeIndexOpsMixin,
     The week ordinal of the year.
 
     Return the week ordinal of the year. Note that there can be
-    counter intuitive edge cases around the yearchange. For example
+    counter intuitive edge cases around a year change. For example
     the first of january could be in week 52 of the previous year.
     Monday indicates the start of a new week.
 
@@ -1739,7 +1739,7 @@ class DatetimeIndex(DatelikeOps, TimelikeOps, DatetimeIndexOpsMixin,
     7 2017-01-07     1   Saturday
     8 2017-01-08     1     Sunday
 
-    Note what `series.dt.week` and `series.dt.weekofyear` are the same.
+    Note that `series.dt.week` and `series.dt.weekofyear` are the same.
 
     >>> s.dt.week
     0    52

--- a/pandas/core/indexes/datetimes.py
+++ b/pandas/core/indexes/datetimes.py
@@ -1712,8 +1712,8 @@ class DatetimeIndex(DatelikeOps, TimelikeOps, DatetimeIndexOpsMixin,
 
     Return the week ordinal of the year. Note that there can be 
     counter intuitive edge cases around the yearchange. For example, 
-    the first of january could be in week 52 of the previous year. 
-    Monday indicates the start of a new week. 
+    the first of january could be in week 52 of the previous year.
+    Monday indicates the start of a new week.
     
     See Also
     --------
@@ -1728,7 +1728,7 @@ class DatetimeIndex(DatelikeOps, TimelikeOps, DatetimeIndexOpsMixin,
     --------
     >>> dates = pd.date_range("2016-12-31", "2017-01-08", freq="D")
     >>> s = pd.Series(dates)
-    >>> pd.DataFrame({'date':s, 'week':s.dt.weekofyear, 'day':s.dt.strftime("%A")})
+    >>> pd.DataFrame({'date':s, 'week':s.dt.week, 'day':s.dt.strftime("%A")})
             date  week        day
     0 2016-12-31    52   Saturday
     1 2017-01-01    52     Sunday


### PR DESCRIPTION
Checklist for the pandas documentation sprint (ignore this if you are doing
an unrelated PR):

- [x] PR title is "DOC: update the <your-function-or-method> docstring"
- [x] The validation script passes: `scripts/validate_docstrings.py <your-function-or-method>`
- [x] The PEP8 style check passes: `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] The html version looks good: `python doc/make.py --single <your-function-or-method>`
- [x] It has been proofread on language by another sprint participant

Please include the output of the validation script below between the "```" ticks:

```
################################################################################
###################### Docstring (pandas.Series.dt.week)  ######################
################################################################################

The week ordinal of the year.

Return the week ordinal of the year. Note that there can be
counter intuitive edge cases around the yearchange. For example
the first of january could be in week 52 of the previous year.
Monday indicates the start of a new week.

See Also
--------
pandas.Series.dt.week : Identical method.
pandas.Series.dt.weekofyear : Identical method.

Returns
-------
ndarray of integers indicating week

Examples
--------
>>> dates = pd.date_range("2016-12-31", "2017-01-08", freq="D")
>>> s = pd.Series(dates)
>>> pd.DataFrame({'date':s, 'week':s.dt.week, 'day':s.dt.strftime("%A")})
        date  week        day
0 2016-12-31    52   Saturday
1 2017-01-01    52     Sunday
2 2017-01-02     1     Monday
3 2017-01-03     1    Tuesday
4 2017-01-04     1  Wednesday
5 2017-01-05     1   Thursday
6 2017-01-06     1     Friday
7 2017-01-07     1   Saturday
8 2017-01-08     1     Sunday

Note what `series.dt.week` and `series.dt.weekofyear` are the same.

>>> s.dt.week
0    52
1    52
2     1
3     1
4     1
5     1
6     1
7     1
8     1
dtype: int64
>>> s.dt.weekofyear
0    52
1    52
2     1
3     1
4     1
5     1
6     1
7     1
8     1
dtype: int64

################################################################################
################################## Validation ##################################
################################################################################

Docstring for "pandas.Series.dt.week" correct. :)
```

If the validation script still gives errors, but you think there is a good reason
to deviate in this case (and there are certainly such cases), please state this
explicitly.