### PR TITLE
DOC: update the DataFrame.iat[] docstring

### DIFF
--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -1921,27 +1921,30 @@ class _AtIndexer(_ScalarAccessIndexer):
 
 class _iAtIndexer(_ScalarAccessIndexer):
     """
-    Selects a single value for a row/column pair by integer position.
+    Access a single value for a row/column pair by integer position.
 
-    Useful if performance is a major concern and you only need to
-    get or set a value at a particular row/column.
+    Similar to ``iloc``, in that both provided integer-based lookups. Use
+    ``iat`` if you only need to get or set a single value in a DataFrame.
 
     See Also
     --------
-    at : Selects a single value for a row/column label pair
-    loc : Selects a group of rows and columns by label(s)
-    iloc : Selects group of rows and columns by integer position(s)
+    DataFrame.at : Access a single value for a row/column label pair
+    DataFrame.loc : Access a group of rows and columns by label(s)
+    DataFrame.iloc : Access a group of rows and columns by integer position(s)
 
     Examples
     --------
-    >>> df = pd.DataFrame([[0, 2, 3], [0, 4, 1], [10, 20, 30]])
+    >>> df = pd.DataFrame([[0, 2, 3], [0, 4, 1], [10, 20, 30]],
+    ...      columns=['A', 'B', 'C'])
     >>> df
-        0   1   2
+        A   B   C
     0   0   2   3
     1   0   4   1
     2  10  20  30
+
     >>> df.iat[1, 2]
     1
+
     >>> df.iat[1, 2] = 10
     >>> df.iat[1, 2]
     10

--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -1924,7 +1924,8 @@ class _iAtIndexer(_ScalarAccessIndexer):
     Access a single value for a row/column pair by integer position.
 
     Similar to ``iloc``, in that both provide integer-based lookups. Use
-    ``iat`` if you only need to get or set a single value in a DataFrame.
+    ``iat`` if you only need to get or set a single value in a ``DataFrame``
+    or ``Series``.
 
     See Also
     --------
@@ -1942,12 +1943,26 @@ class _iAtIndexer(_ScalarAccessIndexer):
     1   0   4   1
     2  10  20  30
 
+    Get value at specified row/column pair
+
     >>> df.iat[1, 2]
     1
+
+    Set value at specified row/column pair
 
     >>> df.iat[1, 2] = 10
     >>> df.iat[1, 2]
     10
+
+    Get value within a series
+
+    >>> df.loc[0].iat[1]
+    2
+
+    Raises
+    ------
+    IndexError
+        When integer position is out of bounds
     """
 
     _takeable = True

--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -1920,11 +1920,35 @@ class _AtIndexer(_ScalarAccessIndexer):
 
 
 class _iAtIndexer(_ScalarAccessIndexer):
-    """Fast integer location scalar accessor.
+    """
+    Selects a single value for a row/column pair by integer position.
 
-    Similarly to ``iloc``, ``iat`` provides **integer** based lookups.
-    You can also set using these indexers.
+    Useful if performance is a major concern and you only need to
+    get or set a value at a particular row/column.
 
+    See Also
+    --------
+    at : Selects a single value for a row/column label pair
+    loc : Selects a group of rows and columns by label(s)
+    iloc : Selects group of rows and columns by integer position(s)
+
+    Returns
+    -------
+        None
+
+    Examples
+    --------
+    >>> df = pd.DataFrame([[0,2,3], [0,4,1], [10,20,30]])
+    >>> df
+        0   1   2
+    0   0   2   3
+    1   0   4   1
+    2  10  20  30
+    >>> df.iat[1, 2]
+    1
+    >>> df.iat[1, 2] = 10
+    >>> df.iat[1, 2]
+    10
     """
 
     _takeable = True

--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -1936,7 +1936,7 @@ class _iAtIndexer(_ScalarAccessIndexer):
     Examples
     --------
     >>> df = pd.DataFrame([[0, 2, 3], [0, 4, 1], [10, 20, 30]],
-    ...      columns=['A', 'B', 'C'])
+    ...                   columns=['A', 'B', 'C'])
     >>> df
         A   B   C
     0   0   2   3

--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -1923,7 +1923,7 @@ class _iAtIndexer(_ScalarAccessIndexer):
     """
     Access a single value for a row/column pair by integer position.
 
-    Similar to ``iloc``, in that both provided integer-based lookups. Use
+    Similar to ``iloc``, in that both provide integer-based lookups. Use
     ``iat`` if you only need to get or set a single value in a DataFrame.
 
     See Also

--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -1932,13 +1932,9 @@ class _iAtIndexer(_ScalarAccessIndexer):
     loc : Selects a group of rows and columns by label(s)
     iloc : Selects group of rows and columns by integer position(s)
 
-    Returns
-    -------
-        None
-
     Examples
     --------
-    >>> df = pd.DataFrame([[0,2,3], [0,4,1], [10,20,30]])
+    >>> df = pd.DataFrame([[0, 2, 3], [0, 4, 1], [10, 20, 30]])
     >>> df
         0   1   2
     0   0   2   3

--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -1924,8 +1924,8 @@ class _iAtIndexer(_ScalarAccessIndexer):
     Access a single value for a row/column pair by integer position.
 
     Similar to ``iloc``, in that both provide integer-based lookups. Use
-    ``iat`` if you only need to get or set a single value in a ``DataFrame``
-    or ``Series``.
+    ``iat`` if you only need to get or set a single value in a DataFrame
+    or Series.
 
     See Also
     --------


### PR DESCRIPTION
Checklist for the pandas documentation sprint (ignore this if you are doing
an unrelated PR):

- [x] PR title is "DOC: update the <your-function-or-method> docstring"
- [x] The validation script passes: `scripts/validate_docstrings.py <your-function-or-method>`
- [x] The PEP8 style check passes: `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] The html version looks good: `python doc/make.py --single <your-function-or-method>`
- [x] It has been proofread on language by another sprint participant

Please include the output of the validation script below between the "```" ticks:

```
# paste output of "scripts/validate_docstrings.py <your-function-or-method>" here
# between the "```" (remove this comment, but keep the "```")

################################################################################
####################### Docstring (pandas.DataFrame.iat) #######################
################################################################################

Selects a single value for a row/column pair by integer position.

Useful if performance is a major concern and you only need to
get or set a value at a particular row/column.

See Also
--------
at : Selects a single value for a row/column label pair
loc : Selects a group of rows and columns by label(s)
iloc : Selects group of rows and columns by integer position(s)

Returns
-------
    None

Examples
--------
>>> df = pd.DataFrame([[0,2,3], [0,4,1], [10,20,30]])
>>> df
    0   1   2
0   0   2   3
1   0   4   1
2  10  20  30
>>> df.iat[1, 2]
1
>>> df.iat[1, 2] = 10
>>> df.iat[1, 2]
10

################################################################################
################################## Validation ##################################
################################################################################

Docstring for "pandas.DataFrame.iat" correct. :)

```

If the validation script still gives errors, but you think there is a good reason
to deviate in this case (and there are certainly such cases), please state this
explicitly.