### PR TITLE
DOC: update the Series.view docstring

### DIFF
--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -555,10 +555,6 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
         type. The new data type must preserve the same size in bytes as to not
         cause index misalignment.
 
-        Series are instantiated with `dtype=float64` by default, so unlike
-        `numpy.array.view()` this function will not try to preserve the current
-        Series data type.
-
         Parameters
         ----------
         dtype : data type
@@ -571,7 +567,15 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
 
         See Also
         --------
-        numpy.ndarray.view : Return a new view of the same data in memory.
+        numpy.ndarray.view : Equivalent numpy function to create a new view of
+            the same data in memory.
+
+        Notes
+        -----
+        Series are instantiated with `dtype=float64` by default. While
+        `numpy.ndarray.view()` will return a view with the same data type as
+        the original array, Series.view() will try using `float64` and may fail
+        if the original data type size in bytes is not the same.
 
         Examples
         --------
@@ -584,7 +588,7 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
         4    2
         dtype: int8
 
-        The 8 bit signed integer representation of `-1` is `0b10000001`, but
+        The 8 bit signed integer representation of `-1` is `0b11111111`, but
         the same bytes represent 255 if read as an 8 bit unsigned integer:
 
         >>> us = s.view('uint8')

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -572,10 +572,11 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
 
         Notes
         -----
-        Series are instantiated with `dtype=float64` by default. While
-        `numpy.ndarray.view()` will return a view with the same data type as
-        the original array, Series.view() will try using `float64` and may fail
-        if the original data type size in bytes is not the same.
+        Series are instantiated with ``dtype=float64`` by default. While
+        ``numpy.ndarray.view()`` will return a view with the same data type as
+        the original array, ``Series.view()`` (without specified dtype)
+        will try using ``float64`` and may fail if the original data type size
+        in bytes is not the same.
 
         Examples
         --------

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -547,6 +547,66 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
         return len(self._data)
 
     def view(self, dtype=None):
+        """
+        Create a new view of the Series.
+
+        This function will return a new Series with a view of the same
+        underlying values in memory, optionally reinterpreted with a new data
+        type. The new data type must preserve the same size in bytes as to not
+        cause index misalignment.
+
+        Series are instantiated with `dtype=float64` by default, so unlike
+        `numpy.array.view()` this function will not try to preserve the current
+        Series data type.
+
+        Parameters
+        ----------
+        dtype : data type
+            Data type object or one of their string representations.
+
+        Returns
+        -------
+        Series
+            A new Series object as a view of the same data in memory.
+
+        See Also
+        --------
+        numpy.ndarray.view : Return a new view of the same data in memory.
+
+        Examples
+        --------
+        >>> s = pd.Series([-2, -1, 0, 1, 2], dtype='int8')
+        >>> s
+        0   -2
+        1   -1
+        2    0
+        3    1
+        4    2
+        dtype: int8
+
+        The 8 bit signed integer representation of `-1` is `0b10000001`, but
+        the same bytes represent 255 if read as an 8 bit unsigned integer:
+
+        >>> us = s.view('uint8')
+        >>> us
+        0    254
+        1    255
+        2      0
+        3      1
+        4      2
+        dtype: uint8
+
+        The views share the same underlying values:
+
+        >>> us[0] = 128
+        >>> s
+        0   -128
+        1     -1
+        2      0
+        3      1
+        4      2
+        dtype: int8
+        """
         return self._constructor(self._values.view(dtype),
                                  index=self.index).__finalize__(self)
 


### PR DESCRIPTION
- [X] PR title is "DOC: update the <your-function-or-method> docstring"
- [X] The validation script passes: `scripts/validate_docstrings.py <your-function-or-method>`
- [X] The PEP8 style check passes: `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [X] The html version looks good: `python doc/make.py --single <your-function-or-method>`
- [X] It has been proofread on language by another sprint participant

```
################################################################################
######################## Docstring (pandas.Series.view) ########################
################################################################################

Create a new view of the Series.

This function will return a new Series with a view of the same
underlying values in memory, optionally reinterpreted with a new data
type. The new data type must preserve the same size in bytes as to not
cause index misalignment.

Parameters
----------
dtype : data type
    Data type object or one of their string representations.

Returns
-------
Series
    A new Series object as a view of the same data in memory.

See Also
--------
numpy.ndarray.view : Equivalent numpy function to create a new view of
    the same data in memory.

Notes
-----
Series are instantiated with `dtype=float64` by default. While
`numpy.ndarray.view()` will return a view with the same data type as
the original array, Series.view() will try using `float64` and may fail
if the original data type size in bytes is not the same.

Examples
--------
>>> s = pd.Series([-2, -1, 0, 1, 2], dtype='int8')
>>> s
0   -2
1   -1
2    0
3    1
4    2
dtype: int8

The 8 bit signed integer representation of `-1` is `0b11111111`, but
the same bytes represent 255 if read as an 8 bit unsigned integer:

>>> us = s.view('uint8')
>>> us
0    254
1    255
2      0
3      1
4      2
dtype: uint8

The views share the same underlying values:

>>> us[0] = 128
>>> s
0   -128
1     -1
2      0
3      1
4      2
dtype: int8

################################################################################
################################## Validation ##################################
################################################################################

Docstring for "pandas.Series.view" correct. :)
```