### PR TITLE
DOC: update the DataFrame.count docstring

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -5592,22 +5592,58 @@ class DataFrame(NDFrame):
 
     def count(self, axis=0, level=None, numeric_only=False):
         """
-        Return Series with number of non-NA/null observations over requested
-        axis. Works with non-floating point data as well (detects NaN and None)
+        Count non-NA cells for each column or row.
+
+        Return Series with number of non-NA observations over requested
+        axis. Works with non-floating point data as well (detects `NaN` and
+        `None`)
 
         Parameters
         ----------
         axis : {0 or 'index', 1 or 'columns'}, default 0
-            0 or 'index' for row-wise, 1 or 'columns' for column-wise
-        level : int or level name, default None
-            If the axis is a MultiIndex (hierarchical), count along a
-            particular level, collapsing into a DataFrame
+            If equal 0 or 'index' counts are generated for each column.
+            If equal 1 or 'columns' counts are generated for each row.
+        level : int or str, optional
+            If the axis is a `MultiIndex` (hierarchical), count along a
+            particular level, collapsing into a `DataFrame`.
+            A `str` specifies the level name.
         numeric_only : boolean, default False
-            Include only float, int, boolean data
+            Include only `float`, `int` or `boolean` data.
 
         Returns
         -------
-        count : Series (or DataFrame if level specified)
+        Series or DataFrame
+            For each column/row the number of non-NA/null entries.
+            If level is specified returns a `DataFrame`.
+
+        See Also
+        --------
+        Series.count: number of non-NA elements in a Series
+        DataFrame.shape: number of DataFrame rows and columns (including NA
+            elements)
+        DataFrame.isnull: boolean same-sized DataFrame showing places of NA
+            elements
+
+        Examples
+        --------
+        >>> df=pd.DataFrame({ "Person":["John","Myla",None],
+        ...                   "Age":[24.,np.nan,21.],
+        ...                   "Single":[False,True,True]     })
+        >>> df
+           Person   Age  Single
+        0    John  24.0   False
+        1    Myla   NaN    True
+        2    None  21.0    True
+        >>> df.count()
+        Person    2
+        Age       2
+        Single    3
+        dtype: int64
+        >>> df.count(axis=1)
+        0    3
+        1    2
+        2    2
+        dtype: int64
         """
         axis = self._get_axis_number(axis)
         if level is not None:

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -5594,9 +5594,8 @@ class DataFrame(NDFrame):
         """
         Count non-NA cells for each column or row.
 
-        Return Series with number of non-NA observations over requested
-        axis. Works with non-floating point data as well (detects `None`,
-        `NaN` and `NaT`).
+        The values `None`, `NaN`, `NaT`, and optionally `numpy.inf` (depending
+        on `pandas.options.mode.use_inf_as_na`) are considered NA.
 
         Parameters
         ----------

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -5602,7 +5602,7 @@ class DataFrame(NDFrame):
         ----------
         axis : {0 or 'index', 1 or 'columns'}, default 0
             If 0 or 'index' counts are generated for each column.
-            If 1 or 'columns' counts are generated for each row.
+            If 1 or 'columns' counts are generated for each **row**.
         level : int or str, optional
             If the axis is a `MultiIndex` (hierarchical), count along a
             particular level, collapsing into a `DataFrame`.
@@ -5621,11 +5621,13 @@ class DataFrame(NDFrame):
         Series.count: number of non-NA elements in a Series
         DataFrame.shape: number of DataFrame rows and columns (including NA
             elements)
-        DataFrame.isnull: boolean same-sized DataFrame showing places of NA
+        DataFrame.isna: boolean same-sized DataFrame showing places of NA
             elements
 
         Examples
         --------
+        Constructing DataFrame from a dictionary:
+
         >>> df = pd.DataFrame({"Person":
         ...                    ["John", "Myla", None, "John", "Myla"],
         ...                    "Age": [24., np.nan, 21., 33, 26],
@@ -5637,18 +5639,27 @@ class DataFrame(NDFrame):
         2    None  21.0    True
         3    John  33.0    True
         4    Myla  26.0   False
+
+        Notice the uncounted NA values:
+
         >>> df.count()
         Person    4
         Age       4
         Single    5
         dtype: int64
-        >>> df.count(axis=1)
+
+        Counts for each **row**:
+
+        >>> df.count(axis='columns')
         0    3
         1    2
         2    2
         3    3
         4    3
         dtype: int64
+
+        Counts for one level of a `MultiIndex`:
+
         >>> df.set_index(["Person", "Single"]).count(level="Person")
                 Age
         Person

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -5595,14 +5595,14 @@ class DataFrame(NDFrame):
         Count non-NA cells for each column or row.
 
         Return Series with number of non-NA observations over requested
-        axis. Works with non-floating point data as well (detects `NaN` and
-        `None`)
+        axis. Works with non-floating point data as well (detects `None`,
+        `NaN` and `NaT`)
 
         Parameters
         ----------
         axis : {0 or 'index', 1 or 'columns'}, default 0
-            If equal 0 or 'index' counts are generated for each column.
-            If equal 1 or 'columns' counts are generated for each row.
+            If 0 or 'index' counts are generated for each column.
+            If 1 or 'columns' counts are generated for each row.
         level : int or str, optional
             If the axis is a `MultiIndex` (hierarchical), count along a
             particular level, collapsing into a `DataFrame`.
@@ -5626,24 +5626,34 @@ class DataFrame(NDFrame):
 
         Examples
         --------
-        >>> df=pd.DataFrame({ "Person":["John","Myla",None],
-        ...                   "Age":[24.,np.nan,21.],
-        ...                   "Single":[False,True,True]     })
+        >>> df = pd.DataFrame({"Person":
+        ...                    ["John", "Myla", None, "John", "Myla"],
+        ...                    "Age": [24., np.nan, 21., 33, 26],
+        ...                    "Single": [False, True, True, True, False]})
         >>> df
            Person   Age  Single
         0    John  24.0   False
         1    Myla   NaN    True
         2    None  21.0    True
+        3    John  33.0    True
+        4    Myla  26.0   False
         >>> df.count()
-        Person    2
-        Age       2
-        Single    3
+        Person    4
+        Age       4
+        Single    5
         dtype: int64
         >>> df.count(axis=1)
         0    3
         1    2
         2    2
+        3    3
+        4    3
         dtype: int64
+        >>> df.set_index(["Person", "Single"]).count(level="Person")
+                Age
+        Person
+        John      2
+        Myla      1
         """
         axis = self._get_axis_number(axis)
         if level is not None:

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -5596,7 +5596,7 @@ class DataFrame(NDFrame):
 
         Return Series with number of non-NA observations over requested
         axis. Works with non-floating point data as well (detects `None`,
-        `NaN` and `NaT`)
+        `NaN` and `NaT`).
 
         Parameters
         ----------
@@ -5605,7 +5605,7 @@ class DataFrame(NDFrame):
             If 1 or 'columns' counts are generated for each **row**.
         level : int or str, optional
             If the axis is a `MultiIndex` (hierarchical), count along a
-            particular level, collapsing into a `DataFrame`.
+            particular `level`, collapsing into a `DataFrame`.
             A `str` specifies the level name.
         numeric_only : boolean, default False
             Include only `float`, `int` or `boolean` data.
@@ -5614,7 +5614,7 @@ class DataFrame(NDFrame):
         -------
         Series or DataFrame
             For each column/row the number of non-NA/null entries.
-            If level is specified returns a `DataFrame`.
+            If `level` is specified returns a `DataFrame`.
 
         See Also
         --------


### PR DESCRIPTION
Checklist for the pandas documentation sprint (ignore this if you are doing
an unrelated PR):

- [x] PR title is "DOC: update the <your-function-or-method> docstring"
- [x] The validation script passes: `scripts/validate_docstrings.py <your-function-or-method>`
- [x] The PEP8 style check passes: `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] The html version looks good: `python doc/make.py --single <your-function-or-method>`
- [x] It has been proofread on language by another sprint participant

Please include the output of the validation script below between the "```" ticks:

```
################################################################################
###################### Docstring (pandas.DataFrame.count) ######################
################################################################################

Count non-NA cells for each column or row.

Return Series with number of non-NA observations over requested
axis. Works with non-floating point data as well (detects `NaN` and
`None`)

Parameters
----------
axis : {0 or 'index', 1 or 'columns'}, default 0
    If equal 0 or 'index' counts are generated for each column.
    If equal 1 or 'columns' counts are generated for each row.
level : int or str, optional
    If the axis is a `MultiIndex` (hierarchical), count along a
    particular level, collapsing into a `DataFrame`.
    A `str` specifies the level name.
numeric_only : boolean, default False
    Include only `float`, `int` or `boolean` data.

Returns
-------
Series or DataFrame
    For each column/row the number of non-NA/null entries.
    If level is specified returns a `DataFrame`.

See Also
--------
Series.count: number of non-NA elements in a Series
DataFrame.shape: number of DataFrame rows and columns (including NA
    elements)
DataFrame.isnull: boolean same-sized DataFrame showing places of NA
    elements

Examples
--------
>>> df=pd.DataFrame({ "Person":["John","Myla",None],
...                   "Age":[24.,np.nan,21.],
...                   "Single":[False,True,True]     })
>>> df
   Person   Age  Single
0    John  24.0   False
1    Myla   NaN    True
2    None  21.0    True
>>> df.count()
Person    2
Age       2
Single    3
dtype: int64
>>> df.count(axis=1)
0    3
1    2
2    2
dtype: int64

################################################################################
################################## Validation ##################################
################################################################################

Docstring for "pandas.DataFrame.count" correct. :)
```

If the validation script still gives errors, but you think there is a good reason
to deviate in this case (and there are certainly such cases), please state this
explicitly.
