### PR TITLE
DOC: add docstring for Index.get_duplicates

### DIFF
--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -1710,6 +1710,42 @@ class Index(IndexOpsMixin, PandasObject):
                             kind=type(key)))
 
     def get_duplicates(self):
+        """
+        Extract duplicated index elements.
+
+        This function returns a sorted list of index elements which appear more
+        than once in the index.
+
+        Returns
+        -------
+        array-like
+            List of duplicated indices.
+
+        See Also
+        --------
+        :meth:`Index.duplicated` : Return boolean array denoting duplicate values.
+        :meth:`Index.drop_duplicates` : Return Index with duplicate values removed.
+
+        Examples
+        --------
+        >>> pd.Index([1, 2, 3, 4]).get_duplicates()
+        []
+        >>> pd.Index([1, 2, 2, 3, 3, 3, 4]).get_duplicates()
+        [2, 3]
+        >>> pd.Index([1, 2, 3, 2, 3, 4, 3]).get_duplicates()
+        [2, 3]
+        >>> pd.Index(['a', 'b', 'b', 'c', 'c', 'c', 'd']).get_duplicates()
+        ['b', 'c']
+        >>> dates = pd.to_datetime(['2018-01-01', '2018-01-02',
+        ...                         '2018-01-03', '2018-01-03'],
+        ...                        format='%Y-%m-%d')
+        >>> pd.Index(pd.to_datetime(dates, format='%Y-%m-%d')).get_duplicates()
+        DatetimeIndex(['2018-01-03'], dtype='datetime64[ns]', freq=None)
+
+        Notes
+        -----
+        Returns empty list in case all index elements are unique.
+        """
         from collections import defaultdict
         counter = defaultdict(lambda: 0)
         for k in self.values:

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -1723,8 +1723,8 @@ class Index(IndexOpsMixin, PandasObject):
 
         See Also
         --------
-        :meth:`Index.duplicated` : Return boolean array denoting duplicate values.
-        :meth:`Index.drop_duplicates` : Return Index with duplicate values removed.
+        :meth:`Index.duplicated` : Return boolean array denoting duplicates.
+        :meth:`Index.drop_duplicates` : Return Index with duplicates removed.
 
         Examples
         --------

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -1713,38 +1713,55 @@ class Index(IndexOpsMixin, PandasObject):
         """
         Extract duplicated index elements.
 
-        This function returns a sorted list of index elements which appear more
-        than once in the index.
+        Returns a sorted list of index elements which appear more than once in
+        the index.
 
         Returns
         -------
         array-like
-            List of duplicated indices.
+            List of duplicated indexes.
 
         See Also
         --------
-        :meth:`Index.duplicated` : Return boolean array denoting duplicates.
-        :meth:`Index.drop_duplicates` : Return Index with duplicates removed.
+        Index.duplicated : Return boolean array denoting duplicates.
+        Index.drop_duplicates : Return Index with duplicates removed.
 
         Examples
         --------
-        >>> pd.Index([1, 2, 3, 4]).get_duplicates()
-        []
+
+        Works on different Index of types.
+
         >>> pd.Index([1, 2, 2, 3, 3, 3, 4]).get_duplicates()
         [2, 3]
-        >>> pd.Index([1, 2, 3, 2, 3, 4, 3]).get_duplicates()
-        [2, 3]
+        >>> pd.Index([1., 2., 2., 3., 3., 3., 4.]).get_duplicates()
+        [2.0, 3.0]
         >>> pd.Index(['a', 'b', 'b', 'c', 'c', 'c', 'd']).get_duplicates()
         ['b', 'c']
-        >>> dates = pd.to_datetime(['2018-01-01', '2018-01-02',
-        ...                         '2018-01-03', '2018-01-03'],
+        >>> dates = pd.to_datetime(['2018-01-01', '2018-01-02', '2018-01-03',
+        ...                         '2018-01-03', '2018-01-04', '2018-01-04'],
         ...                        format='%Y-%m-%d')
-        >>> pd.Index(pd.to_datetime(dates, format='%Y-%m-%d')).get_duplicates()
-        DatetimeIndex(['2018-01-03'], dtype='datetime64[ns]', freq=None)
+        >>> pd.Index(dates).get_duplicates()
+        DatetimeIndex(['2018-01-03', '2018-01-04'],
+                      dtype='datetime64[ns]', freq=None)
+
+        Sorts duplicated elements even when indexes are unordered.
+
+        >>> pd.Index([1, 2, 3, 2, 3, 4, 3]).get_duplicates()
+        [2, 3]
+
+        Return empty array-like structure when all elements are unique.
+
+        >>> pd.Index([1, 2, 3, 4]).get_duplicates()
+        []
+        >>> dates = pd.to_datetime(['2018-01-01', '2018-01-02', '2018-01-03'],
+        ...                        format='%Y-%m-%d')
+        >>> pd.Index(dates).get_duplicates()
+        DatetimeIndex([], dtype='datetime64[ns]', freq=None)
 
         Notes
         -----
-        Returns empty list in case all index elements are unique.
+        In case of datetime-like indexes, the function is overridden where the
+        result is converted to DatetimeIndex.
         """
         from collections import defaultdict
         counter = defaultdict(lambda: 0)


### PR DESCRIPTION
Checklist for the pandas documentation sprint (ignore this if you are doing
an unrelated PR):

- [x] PR title is "DOC: update the <your-function-or-method> docstring"
- [x] The validation script passes: `scripts/validate_docstrings.py <your-function-or-method>`
- [x] The PEP8 style check passes: `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] The html version looks good: `python doc/make.py --single <your-function-or-method>`
- [x] It has been proofread on language by another sprint participant

Please include the output of the validation script below between the "```" ticks:

```

################################################################################
################### Docstring (pandas.Index.get_duplicates)  ###################
################################################################################

        Extract duplicated index elements.

        Returns a sorted list of index elements which appear more than once in
        the index.

        Returns
        -------
        array-like
            List of duplicated indexes.

        See Also
        --------
        Index.duplicated : Return boolean array denoting duplicates.
        Index.drop_duplicates : Return Index with duplicates removed.

        Examples
        --------

        Works on different Index of types.

        >>> pd.Index([1, 2, 2, 3, 3, 3, 4]).get_duplicates()
        [2, 3]
        >>> pd.Index([1., 2., 2., 3., 3., 3., 4.]).get_duplicates()
        [2.0, 3.0]
        >>> pd.Index(['a', 'b', 'b', 'c', 'c', 'c', 'd']).get_duplicates()
        ['b', 'c']
        >>> dates = pd.to_datetime(['2018-01-01', '2018-01-02', '2018-01-03',
        ...                         '2018-01-03', '2018-01-04', '2018-01-04'],
        ...                        format='%Y-%m-%d')
        >>> pd.Index(dates).get_duplicates()
        DatetimeIndex(['2018-01-03', '2018-01-04'],
                      dtype='datetime64[ns]', freq=None)

        Sorts duplicated elements even when indexes are unordered.

        >>> pd.Index([1, 2, 3, 2, 3, 4, 3]).get_duplicates()
        [2, 3]

        Return empty array-like structure when all elements are unique.

        >>> pd.Index([1, 2, 3, 4]).get_duplicates()
        []
        >>> dates = pd.to_datetime(['2018-01-01', '2018-01-02', '2018-01-03'],
        ...                        format='%Y-%m-%d')
        >>> pd.Index(dates).get_duplicates()
        DatetimeIndex([], dtype='datetime64[ns]', freq=None)

        Notes
        -----
        In case of datetime-like indexes, the function is overridden where the
        result is converted to DatetimeIndex.

################################################################################
################################## Validation ##################################
################################################################################

Docstring for "pandas.Index.get_duplicates" correct. :)

```

If the validation script still gives errors, but you think there is a good reason
to deviate in this case (and there are certainly such cases), please state this
explicitly.


Checklist for other PRs (remove this part if you are doing a PR for the pandas documentation sprint):

- [ ] closes #xxxx
- [ ] tests added / passed
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
