### PR TITLE
DOC: update the IntervalIndex.from_array docstring

### DIFF
--- a/pandas/core/indexes/interval.py
+++ b/pandas/core/indexes/interval.py
@@ -461,8 +461,7 @@ class IntervalIndex(IntervalMixin, Index):
     def from_arrays(cls, left, right, closed='right', name=None, copy=False,
                     dtype=None):
         """
-        Construct an IntervalIndex from a given element in a left
-        and right array.
+        Construct from two arrays defining the left and right bounds.
 
         Parameters
         ----------
@@ -477,14 +476,37 @@ class IntervalIndex(IntervalMixin, Index):
             Name to be stored in the index.
         copy : boolean, default False
             Copy the data.
-        dtype : dtype or None, default None
+        dtype : dtype, optional
             If None, dtype will be inferred.
 
-            .. versionadded:: 0.23.0.
+            .. versionadded:: 0.23.0
 
         Returns
         -------
         index : IntervalIndex
+
+        Notes
+        -----
+        Each element of `left` must be less than or equal to the `right`
+        element at the same position. If an element is missing, it must be
+        missing in both `left` and `right`. A TypeError is raised when
+        using an unsupported type for `left` or `right`. At the moment,
+        'category', 'object', and 'string' subtypes are not supported.
+
+        Raises
+        ------
+        ValueError
+            When a value is missing in only one of `left` or `right`.
+            When a value in `left` is greater than the corresponding value
+            in `right`.
+
+        See Also
+        --------
+        interval_range : Function to create a fixed frequency IntervalIndex.
+        IntervalIndex.from_breaks : Construct an IntervalIndex from an array of
+            splits.
+        IntervalIndex.from_tuples : Construct an IntervalIndex from a
+            list/array of tuples.
 
         Examples
         --------
@@ -500,27 +522,14 @@ class IntervalIndex(IntervalMixin, Index):
         ...                                     [2, 13, 19], closed='left')
         >>> ages
         IntervalIndex([[0, 2), [2, 13), [13, 19)]
-              closed='left',
-              dtype='interval[int64]')
+                      closed='left',
+                      dtype='interval[int64]')
         >>> s = pd.Series(['baby', 'kid', 'teen'], ages)
         >>> s
         [0, 2)      baby
         [2, 13)      kid
         [13, 19)    teen
         dtype: object
-
-        Notes
-        -----
-        Each element of `left` must be smaller or equal to the `right` element
-        at the same position, ie, ``left[i] <= right[i]``.
-
-        See Also
-        --------
-        interval_range : Function to create a fixed frequency IntervalIndex.
-        IntervalIndex.from_breaks : Construct an IntervalIndex from an array of
-                                    splits.
-        IntervalIndex.from_tuples : Construct an IntervalIndex from a
-                                    list/array of tuples.
         """
         left = maybe_convert_platform_interval(left)
         right = maybe_convert_platform_interval(right)

--- a/pandas/core/indexes/interval.py
+++ b/pandas/core/indexes/interval.py
@@ -148,13 +148,17 @@ class IntervalIndex(IntervalMixin, Index):
     closed : {'left', 'right', 'both', 'neither'}, default 'right'
         Whether the intervals are closed on the left-side, right-side, both or
         neither.
-    name : object, optional
-        Name to be stored in the index.
-    copy : boolean, default False
-        Copy the meta-data.
     dtype : dtype or None, default None
         If None, dtype will be inferred.
-
+    copy : boolean, default False
+        Copy the meta-data.
+    name : object, optional
+        Name to be stored in the index.
+    fastpath : boolean, default False
+        Create IntervalIndex without verifying integrity.
+    verify_integrity : boolean, default True
+        Verify that the IntervalIndex is valid.
+        
         ..versionadded:: 0.23.0.
 
     Attributes

--- a/pandas/core/indexes/interval.py
+++ b/pandas/core/indexes/interval.py
@@ -148,16 +148,12 @@ class IntervalIndex(IntervalMixin, Index):
     closed : {'left', 'right', 'both', 'neither'}, default 'right'
         Whether the intervals are closed on the left-side, right-side, both or
         neither.
+    name : object, optional
+        Name to be stored in the index.
     copy : boolean, default False
         Copy the meta-data
     dtype : dtype or None, default None
         If None, dtype will be inferred
-    name : object, optional
-        Name to be stored in the index.
-    fastpath : boolean, default False
-        Create IntervalIndex without verifying integrity.
-    verify_integrity : boolean, default True
-        Verify that the IntervalIndex is valid.
 
         ..versionadded:: 0.23.0
 

--- a/pandas/core/indexes/interval.py
+++ b/pandas/core/indexes/interval.py
@@ -158,7 +158,7 @@ class IntervalIndex(IntervalMixin, Index):
         Create IntervalIndex without verifying integrity.
     verify_integrity : boolean, default True
         Verify that the IntervalIndex is valid.
-        
+
         ..versionadded:: 0.23.0.
 
     Attributes
@@ -461,7 +461,8 @@ class IntervalIndex(IntervalMixin, Index):
     def from_arrays(cls, left, right, closed='right', name=None, copy=False,
                     dtype=None):
         """
-        Construct an IntervalIndex from a a left and right array
+        Construct an IntervalIndex from a given element in a left
+        and right array.
 
         Parameters
         ----------
@@ -475,11 +476,15 @@ class IntervalIndex(IntervalMixin, Index):
         name : object, optional
             Name to be stored in the index.
         copy : boolean, default False
-            copy the data
+            Copy the data.
         dtype : dtype or None, default None
-            If None, dtype will be inferred
+            If None, dtype will be inferred.
 
-            ..versionadded:: 0.23.0
+            .. versionadded:: 0.23.0.
+
+        Returns
+        -------
+        index : IntervalIndex
 
         Examples
         --------
@@ -488,13 +493,34 @@ class IntervalIndex(IntervalMixin, Index):
                       closed='right',
                       dtype='interval[int64]')
 
+        If you want to segment different groups of people based on
+        ages, you can apply the method as follows:
+
+        >>> ages = pd.IntervalIndex.from_arrays([0, 2, 13],
+        ...                                     [2, 13, 19], closed='left')
+        >>> ages
+        IntervalIndex([[0, 2), [2, 13), [13, 19)]
+              closed='left',
+              dtype='interval[int64]')
+        >>> s = pd.Series(['baby', 'kid', 'teen'], ages)
+        >>> s
+        [0, 2)      baby
+        [2, 13)      kid
+        [13, 19)    teen
+        dtype: object
+
+        Notes
+        -----
+        Each element of `left` must be smaller or equal to the `right` element
+        at the same position, ie, ``left[i] <= right[i]``.
+
         See Also
         --------
-        interval_range : Function to create a fixed frequency IntervalIndex
+        interval_range : Function to create a fixed frequency IntervalIndex.
         IntervalIndex.from_breaks : Construct an IntervalIndex from an array of
-                                    splits
+                                    splits.
         IntervalIndex.from_tuples : Construct an IntervalIndex from a
-                                    list/array of tuples
+                                    list/array of tuples.
         """
         left = maybe_convert_platform_interval(left)
         right = maybe_convert_platform_interval(right)

--- a/pandas/core/indexes/interval.py
+++ b/pandas/core/indexes/interval.py
@@ -526,6 +526,14 @@ class IntervalIndex(IntervalMixin, Index):
         [2, 13)      kid
         [13, 19)    teen
         dtype: object
+
+        Values may be missing, but they must be missing in both arrays.
+
+        >>> pd.IntervalIndex.from_arrays([0, np.nan, 13],
+        ...                              [2, np.nan, 19])
+        IntervalIndex([(0.0, 2.0], nan, (13.0, 19.0]]
+                      closed='right',
+                      dtype='interval[float64]')
         """
         left = maybe_convert_platform_interval(left)
         right = maybe_convert_platform_interval(right)

--- a/pandas/core/indexes/interval.py
+++ b/pandas/core/indexes/interval.py
@@ -142,20 +142,20 @@ class IntervalIndex(IntervalMixin, Index):
 
     Parameters
     ----------
-    data : array-like (1-dimensional)
+    data : array-Like (1-dimensional)
         Array-like containing Interval objects from which to build the
-        IntervalIndex
+        IntervalIndex.
     closed : {'left', 'right', 'both', 'neither'}, default 'right'
         Whether the intervals are closed on the left-side, right-side, both or
         neither.
     name : object, optional
         Name to be stored in the index.
     copy : boolean, default False
-        Copy the meta-data
+        Copy the meta-data.
     dtype : dtype or None, default None
-        If None, dtype will be inferred
+        If None, dtype will be inferred.
 
-        ..versionadded:: 0.23.0
+        ..versionadded:: 0.23.0.
 
     Attributes
     ----------
@@ -198,11 +198,11 @@ class IntervalIndex(IntervalMixin, Index):
 
     See Also
     --------
-    Index : The base pandas Index type
-    Interval : A bounded slice-like interval; the elements of an IntervalIndex
-    interval_range : Function to create a fixed frequency IntervalIndex
-    cut, qcut : Convert arrays of continuous data into Categoricals/Series of
-                Intervals
+    Index : The base pandas Index type.
+    Interval : A bounded slice-like interval; the elements of an IntervalIndex.
+    qcut : Quantile-based discretization function.
+    cut : Return indices of half-open bins to which each value of x belongs.
+    interval_range : Function to create a fixed frequency IntervalIndex.
     """
     _typ = 'intervalindex'
     _comparables = ['name']

--- a/pandas/core/indexes/interval.py
+++ b/pandas/core/indexes/interval.py
@@ -142,16 +142,16 @@ class IntervalIndex(IntervalMixin, Index):
 
     Parameters
     ----------
-    data : array-Like (1-dimensional)
+    data : array-like (1-dimensional)
         Array-like containing Interval objects from which to build the
-        IntervalIndex.
+        IntervalIndex
     closed : {'left', 'right', 'both', 'neither'}, default 'right'
         Whether the intervals are closed on the left-side, right-side, both or
         neither.
-    dtype : dtype or None, default None
-        If None, dtype will be inferred.
     copy : boolean, default False
-        Copy the meta-data.
+        Copy the meta-data
+    dtype : dtype or None, default None
+        If None, dtype will be inferred
     name : object, optional
         Name to be stored in the index.
     fastpath : boolean, default False
@@ -159,7 +159,7 @@ class IntervalIndex(IntervalMixin, Index):
     verify_integrity : boolean, default True
         Verify that the IntervalIndex is valid.
 
-        ..versionadded:: 0.23.0.
+        ..versionadded:: 0.23.0
 
     Attributes
     ----------
@@ -202,11 +202,11 @@ class IntervalIndex(IntervalMixin, Index):
 
     See Also
     --------
-    Index : The base pandas Index type.
-    Interval : A bounded slice-like interval; the elements of an IntervalIndex.
-    qcut : Quantile-based discretization function.
-    cut : Return indices of half-open bins to which each value of x belongs.
-    interval_range : Function to create a fixed frequency IntervalIndex.
+    Index : The base pandas Index type
+    Interval : A bounded slice-like interval; the elements of an IntervalIndex
+    interval_range : Function to create a fixed frequency IntervalIndex
+    cut, qcut : Convert arrays of continuous data into Categoricals/Series of
+                Intervals
     """
     _typ = 'intervalindex'
     _comparables = ['name']


### PR DESCRIPTION
Checklist for the pandas documentation sprint (ignore this if you are doing
an unrelated PR):

- [x] PR title is "DOC: update the <your-function-or-method> docstring"
- [x] The validation script passes: `scripts/validate_docstrings.py <your-function-or-method>`
- [x] The PEP8 style check passes: `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] The html version looks good: `python doc/make.py --single <your-function-or-method>`
- [x] It has been proofread on language by another sprint participant

```

################################################################################
################# Docstring (pandas.IntervalIndex.from_arrays) #################
################################################################################

Construct an IntervalIndex from a given element in a left
and right array.

Parameters
----------
left : array-like (1-dimensional)
    Left bounds for each interval.
right : array-like (1-dimensional)
    Right bounds for each interval.
closed : {'left', 'right', 'both', 'neither'}, default 'right'
    Whether the intervals are closed on the left-side, right-side, both
    or neither.
name : object, optional
    Name to be stored in the index.
copy : boolean, default False
    Copy the data.
dtype : dtype or None, default None
    If None, dtype will be inferred.

    .. versionadded:: 0.23.0.

Returns
-------
index : IntervalIndex

Examples
--------
>>> pd.IntervalIndex.from_arrays([0, 1, 2], [1, 2, 3])
IntervalIndex([(0, 1], (1, 2], (2, 3]]
              closed='right',
              dtype='interval[int64]')

If you want to segment different groups of people based on
ages, you can apply the method as follows:

>>> ages = pd.IntervalIndex.from_arrays([0, 2, 13],
...                                     [2, 13, 19], closed='left')
>>> ages
IntervalIndex([[0, 2), [2, 13), [13, 19)]
      closed='left',
      dtype='interval[int64]')
>>> s = pd.Series(['baby', 'kid', 'teen'], ages)
>>> s
[0, 2)      baby
[2, 13)      kid
[13, 19)    teen
dtype: object

Notes
-----
Each element of `left` must be smaller or equal to the `right` element
at the same position, ie, ``left[i] <= right[i]``.

See Also
--------
interval_range : Function to create a fixed frequency IntervalIndex.
IntervalIndex.from_breaks : Construct an IntervalIndex from an array of
                            splits.
IntervalIndex.from_tuples : Construct an IntervalIndex from a
                            list/array of tuples.

################################################################################
################################## Validation ##################################
################################################################################

Errors found:
	No summary found (a short summary in a single line should be present at the beginning of the docstring)

```