### PR TITLE
DOC: update the Index.get_values docstring

### DIFF
--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -684,22 +684,16 @@ class Index(IndexOpsMixin, PandasObject):
         """
         Return `Index` data as an `numpy.ndarray`.
 
-        In its functionality it is the same as `Series.get_values`,
-        but because it refers only to `Index` values, it does not need
-        the additional sparse transformation work.
-
-        It is a getter wrapper around `Index.values`. Getters are
-        often considered non-pythonic and, therefore, should be avoided if are
-        not explicitly aimed for.
+        It is a getter wrapper around `Index.values`.
 
         Returns
         -------
         numpy.ndarray
-            A one-dimensional `numpy array` of the indexes.
+            A one-dimensional numpy array of the indexes.
 
         See Also
         --------
-        Index.values : The original function around which `get_values` wraps.
+        Index.values : The original function around which get_values wraps.
 
         Examples
         --------

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -681,7 +681,44 @@ class Index(IndexOpsMixin, PandasObject):
         return self.values
 
     def get_values(self):
-        """ return the underlying data as an ndarray """
+        """
+        Return `Index` data as an `ndarray`.
+
+        Because this is a wrapper function around Index.values, it is useful
+        when one explicitly wants to use a getter.
+
+        Returns
+        -------
+        numpy.ndarray
+            A one-dimensional numpy `array` of the indexes.
+
+        See Also
+        --------
+        Index
+            The basic object storing axis labels for all pandas objects.
+        Index.values
+            The original function around which `get_values` creates a wrapper.
+
+        Examples
+        --------
+        Getting the `Index` values of a `DataFrame`:
+
+        >>> df = pd.DataFrame([[1, 2, 3], [4, 5, 6], [7, 8, 9]],
+        ...                    index=['a', 'b', 'c'], columns=['A', 'B', 'C'])
+        >>> df
+           A  B  C
+        a  1  2  3
+        b  4  5  6
+        c  7  8  9
+        >>> df.index.get_values()
+        array(['a', 'b', 'c'], dtype=object)
+
+        Standalone `Index` values:
+
+        >>> idx = pd.Index(['1', '2', '3'])
+        >>> idx.get_values()
+        array(['1', '2', '3'], dtype=object)
+        """
         return self.values
 
     @Appender(IndexOpsMixin.memory_usage.__doc__)

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -684,12 +684,10 @@ class Index(IndexOpsMixin, PandasObject):
         """
         Return `Index` data as an `numpy.ndarray`.
 
-        It is a getter wrapper around `Index.values`.
-
         Returns
         -------
         numpy.ndarray
-            A one-dimensional numpy array of the indexes.
+            A one-dimensional numpy array of the `Index` values.
 
         See Also
         --------
@@ -718,7 +716,9 @@ class Index(IndexOpsMixin, PandasObject):
         `MultiIndex` arrays also have only one dimension:
 
         >>> midx = pd.MultiIndex.from_arrays([[1, 2, 3], ['a', 'b', 'c']],
-        ...                                  names =  ('number', 'letter'))
+        ...                                  names=('number', 'letter'))
+        >>> midx.get_values()
+        array([(1, 'a'), (2, 'b'), (3, 'c')], dtype=object)
         >>> midx.ndim
         1
         """

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -682,22 +682,24 @@ class Index(IndexOpsMixin, PandasObject):
 
     def get_values(self):
         """
-        Return `Index` data as an `ndarray`.
+        Return `Index` data as an `numpy.ndarray`.
 
-        Because this is a wrapper function around Index.values, it is useful
-        when one explicitly wants to use a getter.
+        In its functionality it is the same as `Series.get_values`,
+        but because it refers only to `Index` values, it does not need
+        the additional sparse transformation work.
+
+        It is a getter wrapper around `Index.values`. Getters are
+        often considered non-pythonic and, therefore, should be avoided if are
+        not explicitly aimed for.
 
         Returns
         -------
         numpy.ndarray
-            A one-dimensional numpy `array` of the indexes.
+            A one-dimensional `numpy array` of the indexes.
 
         See Also
         --------
-        Index
-            The basic object storing axis labels for all pandas objects.
-        Index.values
-            The original function around which `get_values` creates a wrapper.
+        Index.values : The original function around which `get_values` wraps.
 
         Examples
         --------
@@ -718,6 +720,13 @@ class Index(IndexOpsMixin, PandasObject):
         >>> idx = pd.Index(['1', '2', '3'])
         >>> idx.get_values()
         array(['1', '2', '3'], dtype=object)
+
+        `MultiIndex` arrays also have only one dimension:
+
+        >>> midx = pd.MultiIndex.from_arrays([[1, 2, 3], ['a', 'b', 'c']],
+        ...                                  names =  ('number', 'letter'))
+        >>> midx.ndim
+        1
         """
         return self.values
 

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -691,7 +691,7 @@ class Index(IndexOpsMixin, PandasObject):
 
         See Also
         --------
-        Index.values : The original function around which get_values wraps.
+        Index.values : The attribute that get_values wraps.
 
         Examples
         --------

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -719,7 +719,7 @@ class Index(IndexOpsMixin, PandasObject):
         ...                                  names=('number', 'letter'))
         >>> midx.get_values()
         array([(1, 'a'), (2, 'b'), (3, 'c')], dtype=object)
-        >>> midx.ndim
+        >>> midx.get_values().ndim
         1
         """
         return self.values


### PR DESCRIPTION
Checklist for the pandas documentation sprint (ignore this if you are doing
an unrelated PR):

- [X] PR title is "DOC: update the <your-function-or-method> docstring"
- [X] The validation script passes: `scripts/validate_docstrings.py <your-function-or-method>`
- [X] The PEP8 style check passes: `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [X] The html version looks good: `python doc/make.py --single <your-function-or-method>`
- [X] It has been proofread on language by another sprint participant

Please include the output of the validation script below between the "```" ticks:

```
################################################################################
##################### Docstring (pandas.Index.get_values)  #####################
################################################################################

Return `Index` data as an `ndarray`.

Because this is a wrapper function around Index.values, it is useful
when one explicitly wants to use a getter.

Returns
-------
numpy.ndarray
    A one-dimensional numpy `array` of the indexes.

See Also
--------
Index
    The basic object storing axis labels for all pandas objects.
Index.values
    The original function around which `get_values` creates a wrapper.

Examples
--------
Getting the `Index` values of a `DataFrame`:

>>> df = pd.DataFrame([[1, 2, 3], [4, 5, 6], [7, 8, 9]],
...                    index=['a', 'b', 'c'], columns=['A', 'B', 'C'])
>>> df
   A  B  C
a  1  2  3
b  4  5  6
c  7  8  9
>>> df.index.get_values()
array(['a', 'b', 'c'], dtype=object)

Standalone `Index` values:

>>> idx = pd.Index(['1', '2', '3'])
>>> idx.get_values()
array(['1', '2', '3'], dtype=object)

################################################################################
################################## Validation ##################################
################################################################################

Docstring for "pandas.Index.get_values" correct. :)
```

If the validation script still gives errors, but you think there is a good reason
to deviate in this case (and there are certainly such cases), please state this
explicitly.
