### PR TITLE
DOC: update the pd.Index.argsort docstring

### DIFF
--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -2334,7 +2334,7 @@ class Index(IndexOpsMixin, PandasObject):
         See also
         --------
         numpy.argsort : Similar method for NumPy arrays.
-        Index.sort_values : Return sorted copy of Index
+        Index.sort_values : Return sorted copy of Index.
 
         Examples
         --------

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -2316,7 +2316,7 @@ class Index(IndexOpsMixin, PandasObject):
 
     def argsort(self, *args, **kwargs):
         """
-        Return the order of the indices that would sort the index.
+        Return the integer indicies that would sort the index.
 
         Parameters
         ----------
@@ -2328,7 +2328,7 @@ class Index(IndexOpsMixin, PandasObject):
         Returns
         -------
         numpy.ndarray
-            indicies that would sort the index if used as
+            Integer indicies that would sort the index if used as
             an indexer.
 
         See also

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -2328,24 +2328,26 @@ class Index(IndexOpsMixin, PandasObject):
         Returns
         -------
         numpy.ndarray
-            Argsorted indices of the index
+            indicies that would sort the index if used as
+            an indexer.
 
         See also
         --------
-        numpy.ndarray.argsort : Similar method for NumPy arrays.
-        pd.Index.sort_values : Return sorted copy of Index
+        numpy.argsort : Similar method for NumPy arrays.
+        Index.sort_values : Return sorted copy of Index
 
         Examples
         --------
-        >>> pd.Index(['b','a','d','c']).argsort()
-        array([1, 0, 3, 2], dtype=int64)
+        >>> idx = pd.Index(['b', 'a', 'd', 'c'])
+        >>> idx
+        Index(['b', 'a', 'd', 'c'], dtype='object')
 
-        When applying argsort to a Series object then the result won't
-        be affected by Series values only by Series index.
+        >>> order = idx.argsort()
+        >>> order
+        array([1, 0, 3, 2])
 
-        >>> s = pd.Series(data=[4, 3, 2, 1], index=['c', 'b', 'a', 'd'])
-        >>> s.index.argsort()
-        array([2, 1, 0, 3], dtype=int64)
+        >>> idx[order]
+        Index(['a', 'b', 'c', 'd'], dtype='object')
         """
         result = self.asi8
         if result is None:

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -2316,16 +2316,36 @@ class Index(IndexOpsMixin, PandasObject):
 
     def argsort(self, *args, **kwargs):
         """
-        Returns the indices that would sort the index and its
-        underlying data.
+        Return the order of the indices that would sort the index.
+
+        Parameters
+        ----------
+        *args
+            Passed to `numpy.ndarray.argsort`.
+        **kwargs
+            Passed to `numpy.ndarray.argsort`.
 
         Returns
         -------
-        argsorted : numpy array
+        numpy.ndarray
+            Argsorted indices of the index
 
         See also
         --------
-        numpy.ndarray.argsort
+        numpy.ndarray.argsort : Similar method for NumPy arrays.
+        pd.Index.sort_values : Return sorted copy of Index
+
+        Examples
+        --------
+        >>> pd.Index(['b','a','d','c']).argsort()
+        array([1, 0, 3, 2], dtype=int64)
+
+        When applying argsort to a Series object then the result won't
+        be affected by Series values only by Series index.
+
+        >>> s = pd.Series(data=[4, 3, 2, 1], index=['c', 'b', 'a', 'd'])
+        >>> s.index.argsort()
+        array([2, 1, 0, 3], dtype=int64)
         """
         result = self.asi8
         if result is None:


### PR DESCRIPTION
Checklist for the pandas documentation sprint (ignore this if you are doing
an unrelated PR):

- [X] PR title is "DOC: update the <your-function-or-method> docstring"
- [ ] The validation script passes: `scripts/validate_docstrings.py <your-function-or-method>`
- [X] The PEP8 style check passes: `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [X] The html version looks good: `python doc/make.py --single <your-function-or-method>`
- [X] It has been proofread on language by another sprint participant

Please include the output of the validation script below between the "```" ticks:

```
################################################################################
####################### Docstring (pandas.Index.argsort) #######################
################################################################################

Return the order of the indices.

We have an object with values and index. Using argsort method
returns a series of indices that would sort the index.

Parameters
----------
*args
    Passed to `numpy.ndarray.argsort`.
**kwargs
    Passed to `numpy.ndarray.argsort`.

Returns
-------
numpy.ndarray : Argsorted indices of the index

See also
--------
numpy.ndarray.argsort : Returns the indices that would sort this array.

Examples
--------
>>> s = pd.Series(data=[4,3,2,1],index=['c','b','a','d'])
>>> s.index.argsort()
array([2, 1, 0, 3], dtype=int64)

################################################################################
################################## Validation ##################################
################################################################################

Errors found:
        Errors in parameters section
                Parameters {'args', 'kwargs'} not documented
                Unknown parameters {'**kwargs', '*args'}
                Parameter "*args" has no type
                Parameter "**kwargs" has no type
```

If the validation script still gives errors, but you think there is a good reason
to deviate in this case (and there are certainly such cases), please state this
explicitly.

We did our best to explain *args and **kwargs

Checklist for other PRs (remove this part if you are doing a PR for the pandas documentation sprint):

- [ ] closes #xxxx
- [ ] tests added / passed
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
