### PR TITLE
DOC: update the Rolling.var docstring

### DIFF
--- a/pandas/core/window.py
+++ b/pandas/core/window.py
@@ -879,13 +879,58 @@ class _Rolling_and_Expanding(_Rolling):
                            ddof=ddof, **kwargs)
 
     _shared_docs['var'] = dedent("""
-    %(name)s variance
-
+    Calculate unbiased %(name)s variance.
+    
+    Normalized by N-1 by default. This can be changed using the ddof argument.
+    
     Parameters
     ----------
     ddof : int, default 1
         Delta Degrees of Freedom.  The divisor used in calculations
-        is ``N - ddof``, where ``N`` represents the number of elements.""")
+        is ``N - ddof``, where ``N`` represents the number of elements.
+    args
+        Under Review.
+    kwargs
+        Under Review.
+      
+    Returns
+    -------
+    Series or DataFrame
+        Returned object type is determined by the caller of the %(name)s
+        calculation
+        
+    See Also
+    --------
+    Series.%(name)s : Calling object with Series data
+    DataFrame.%(name)s : Calling object with DataFrames
+    Series.var : Equivalent method for Series
+    DataFrame.var : Equivalent method for DataFrame
+    numpy.var : Equivalent method for Numpy array
+    
+    Notes
+    -----
+    A minimum of 1 periods is required for the rolling calculation.
+      
+    Examples
+    --------
+    The below example will show a rolling example 
+    
+    >>> s = pd.Series((5,5,5,5,6,7,9,10,5,5,5,5))
+    >>> s.rolling(3).var(1)
+    0          NaN
+    1          NaN
+    2     0.000000
+    3     0.000000
+    4     0.333333
+    5     1.000000
+    6     2.333333
+    7     2.333333
+    8     7.000000
+    9     8.333333
+    10    0.000000
+    11    0.000000
+    dtype: float64
+    """)
 
     def var(self, ddof=1, *args, **kwargs):
         nv.validate_window_func('var', args, kwargs)
@@ -1257,7 +1302,6 @@ class Rolling(_Rolling_and_Expanding):
         return super(Rolling, self).std(ddof=ddof, **kwargs)
 
     @Substitution(name='rolling')
-    @Appender(_doc_template)
     @Appender(_shared_docs['var'])
     def var(self, ddof=1, *args, **kwargs):
         nv.validate_rolling_func('var', args, kwargs)
@@ -1496,7 +1540,6 @@ class Expanding(_Rolling_and_Expanding):
         return super(Expanding, self).std(ddof=ddof, **kwargs)
 
     @Substitution(name='expanding')
-    @Appender(_doc_template)
     @Appender(_shared_docs['var'])
     def var(self, ddof=1, *args, **kwargs):
         nv.validate_expanding_func('var', args, kwargs)

--- a/pandas/core/window.py
+++ b/pandas/core/window.py
@@ -881,23 +881,23 @@ class _Rolling_and_Expanding(_Rolling):
     _shared_docs['var'] = dedent("""
     Calculate unbiased %(name)s variance.
 
-    Normalized by N-1 by default. This can be changed using the ddof argument.
+    Normalized by N-1 by default. This can be changed using the `ddof`
+    argument.
 
     Parameters
     ----------
     ddof : int, default 1
         Delta Degrees of Freedom.  The divisor used in calculations
         is ``N - ddof``, where ``N`` represents the number of elements.
-    args
+    *args
         Under Review.
-    kwargs
+    **kwargs
         Under Review.
 
     Returns
     -------
-    Series or DataFrame
-        Returned object type is determined by the caller of the %(name)s
-        calculation
+    Returns the same object type as determined by the caller of the %(name)s
+    calculation.
 
     See Also
     --------
@@ -913,9 +913,7 @@ class _Rolling_and_Expanding(_Rolling):
 
     Examples
     --------
-    The below example will show a rolling example
-
-    >>> s = pd.Series((5,5,5,5,6,7,9,10,5,5,5,5))
+    >>> s = pd.Series((5, 5, 5, 5, 6, 7, 9, 10, 5, 5, 5, 5))
     >>> s.rolling(3).var(1)
     0          NaN
     1          NaN
@@ -929,6 +927,20 @@ class _Rolling_and_Expanding(_Rolling):
     9     8.333333
     10    0.000000
     11    0.000000
+    dtype: float64
+    >>> s.expanding(3).var(1)
+    0          NaN
+    1          NaN
+    2     0.000000
+    3     0.000000
+    4     0.200000
+    5     0.700000
+    6     2.333333
+    7     4.000000
+    8     3.750000
+    9     3.511111
+    10    3.290909
+    11    3.090909
     dtype: float64
     """)
 

--- a/pandas/core/window.py
+++ b/pandas/core/window.py
@@ -880,9 +880,9 @@ class _Rolling_and_Expanding(_Rolling):
 
     _shared_docs['var'] = dedent("""
     Calculate unbiased %(name)s variance.
-    
+
     Normalized by N-1 by default. This can be changed using the ddof argument.
-    
+
     Parameters
     ----------
     ddof : int, default 1
@@ -892,13 +892,13 @@ class _Rolling_and_Expanding(_Rolling):
         Under Review.
     kwargs
         Under Review.
-      
+
     Returns
     -------
     Series or DataFrame
         Returned object type is determined by the caller of the %(name)s
         calculation
-        
+
     See Also
     --------
     Series.%(name)s : Calling object with Series data
@@ -906,15 +906,15 @@ class _Rolling_and_Expanding(_Rolling):
     Series.var : Equivalent method for Series
     DataFrame.var : Equivalent method for DataFrame
     numpy.var : Equivalent method for Numpy array
-    
+
     Notes
     -----
     A minimum of 1 periods is required for the rolling calculation.
-      
+
     Examples
     --------
-    The below example will show a rolling example 
-    
+    The below example will show a rolling example
+
     >>> s = pd.Series((5,5,5,5,6,7,9,10,5,5,5,5))
     >>> s.rolling(3).var(1)
     0          NaN

--- a/pandas/core/window.py
+++ b/pandas/core/window.py
@@ -889,10 +889,8 @@ class _Rolling_and_Expanding(_Rolling):
     ddof : int, default 1
         Delta Degrees of Freedom.  The divisor used in calculations
         is ``N - ddof``, where ``N`` represents the number of elements.
-    *args
-        Under Review.
-    **kwargs
-        Under Review.
+    *args, **kwargs
+        For NumPy compatibility. No additional arguments are used.
 
     Returns
     -------
@@ -909,10 +907,10 @@ class _Rolling_and_Expanding(_Rolling):
 
     Notes
     -----
-    The default `ddof` of 1 used in Series.var is different than the default
-    `ddof` of 0 in numpy.var.
+    The default `ddof` of 1 used in :meth:`Series.var` is different than the
+    default `ddof` of 0 in :func:`numpy.var`.
 
-    A minimum of 1 periods is required for the rolling calculation.
+    A minimum of 1 period is required for the rolling calculation.
 
     Examples
     --------

--- a/pandas/core/window.py
+++ b/pandas/core/window.py
@@ -896,8 +896,8 @@ class _Rolling_and_Expanding(_Rolling):
 
     Returns
     -------
-    Returns the same object type as determined by the caller of the %(name)s
-    calculation.
+    Series or DataFrame
+        Returns the same object type as the caller of the %(name)s calculation.
 
     See Also
     --------
@@ -909,38 +909,32 @@ class _Rolling_and_Expanding(_Rolling):
 
     Notes
     -----
+    The default `ddof` of 1 used in Series.var is different than the default
+    `ddof` of 0 in numpy.var.
+
     A minimum of 1 periods is required for the rolling calculation.
 
     Examples
     --------
-    >>> s = pd.Series((5, 5, 5, 5, 6, 7, 9, 10, 5, 5, 5, 5))
-    >>> s.rolling(3).var(1)
-    0          NaN
-    1          NaN
-    2     0.000000
-    3     0.000000
-    4     0.333333
-    5     1.000000
-    6     2.333333
-    7     2.333333
-    8     7.000000
-    9     8.333333
-    10    0.000000
-    11    0.000000
+    >>> s = pd.Series([5, 5, 6, 7, 5, 5, 5])
+    >>> s.rolling(3).var()
+    0         NaN
+    1         NaN
+    2    0.333333
+    3    1.000000
+    4    1.000000
+    5    1.333333
+    6    0.000000
     dtype: float64
-    >>> s.expanding(3).var(1)
-    0          NaN
-    1          NaN
-    2     0.000000
-    3     0.000000
-    4     0.200000
-    5     0.700000
-    6     2.333333
-    7     4.000000
-    8     3.750000
-    9     3.511111
-    10    3.290909
-    11    3.090909
+
+    >>> s.expanding(3).var()
+    0         NaN
+    1         NaN
+    2    0.333333
+    3    0.916667
+    4    0.800000
+    5    0.700000
+    6    0.619048
     dtype: float64
     """)
 


### PR DESCRIPTION
Checklist for the pandas documentation sprint (ignore this if you are doing
an unrelated PR):

- [x] PR title is "DOC: update the <your-function-or-method> docstring"
- [x] The validation script passes: `scripts/validate_docstrings.py <your-function-or-method>`
- [x] The PEP8 style check passes: `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] The html version looks good: `python doc/make.py --single <your-function-or-method>`
- [x] It has been proofread on language by another sprint participant

Please include the output of the validation script below between the "```" ticks:

```
################################################################################
################## Docstring (pandas.core.window.Rolling.var) ##################
################################################################################

Calculate unbiased rolling variance.

Normalized by N-1 by default. This can be changed using the ddof argument.

Parameters
----------
ddof : int, default 1
    Delta Degrees of Freedom.  The divisor used in calculations
    is ``N - ddof``, where ``N`` represents the number of elements.
args
    Under Review.
kwargs
    Under Review.

Returns
-------
Series or DataFrame
    Returned object type is determined by the caller of the rolling
    calculation

See Also
--------
Series.rolling : Calling object with Series data
DataFrame.rolling : Calling object with DataFrames
Series.var : Equivalent method for Series
DataFrame.var : Equivalent method for DataFrame
numpy.var : Equivalent method for Numpy array

Notes
-----
A minimum of 1 periods is required for the rolling calculation.

Examples
--------
The below example will show a rolling example

>>> s = pd.Series((5,5,5,5,6,7,9,10,5,5,5,5))
>>> s.rolling(3).var(1)
0          NaN
1          NaN
2     0.000000
3     0.000000
4     0.333333
5     1.000000
6     2.333333
7     2.333333
8     7.000000
9     8.333333
10    0.000000
11    0.000000
dtype: float64

################################################################################
################################## Validation ##################################
################################################################################

Errors found:
        Errors in parameters section
                Parameter "args" has no type
                Parameter "kwargs" has no type


################################################################################
################# Docstring (pandas.core.window.Expanding.var) #################
################################################################################

Calculate unbiased expanding variance.

Normalized by N-1 by default. This can be changed using the ddof argument.

Parameters
----------
ddof : int, default 1
    Delta Degrees of Freedom.  The divisor used in calculations
    is ``N - ddof``, where ``N`` represents the number of elements.
args
    Under Review.
kwargs
    Under Review.

Returns
-------
Series or DataFrame
    Returned object type is determined by the caller of the expanding
    calculation

See Also
--------
Series.expanding : Calling object with Series data
DataFrame.expanding : Calling object with DataFrames
Series.var : Equivalent method for Series
DataFrame.var : Equivalent method for DataFrame
numpy.var : Equivalent method for Numpy array

Notes
-----
A minimum of 1 periods is required for the rolling calculation.

Examples
--------
The below example will show a rolling example

>>> s = pd.Series((5,5,5,5,6,7,9,10,5,5,5,5))
>>> s.rolling(3).var(1)
0          NaN
1          NaN
2     0.000000
3     0.000000
4     0.333333
5     1.000000
6     2.333333
7     2.333333
8     7.000000
9     8.333333
10    0.000000
11    0.000000
dtype: float64

################################################################################
################################## Validation ##################################
################################################################################

Errors found:
        Errors in parameters section
                Parameter "args" has no type
                Parameter "kwargs" has no type
```

If the validation script still gives errors, but you think there is a good reason
to deviate in this case (and there are certainly such cases), please state this
explicitly.