### PR TITLE
DOC: update the PeriodIndex docstring

### DIFF
--- a/pandas/core/indexes/period.py
+++ b/pandas/core/indexes/period.py
@@ -148,12 +148,26 @@ class PeriodIndex(DatelikeOps, DatetimeIndexOpsMixin, Int64Index):
         If periods is none, generated index will extend to first conforming
         period on or just past end argument
     year : int, array, or Series, default None
+        If not None requires a freq to be specified and either
+        month or quarter to be specified
     month : int, array, or Series, default None
+        If not None requires a freq and year to be specified
     quarter : int, array, or Series, default None
+        If quarter is not None the freq is required to be
+        quarterly Q or Q-DEC. it will be set to Q-DEC if not specified.
+        day, hour, minute, second are not used
     day : int, array, or Series, default None
+        If not None requires a freq, month, and year to be specified.
+        day defaults to 1 if year and month specified
     hour : int, array, or Series, default None
+        If not None requires a freq, month, and year to be specified.
+        hour will default to 0 if year and month specified
     minute : int, array, or Series, default None
+        If not None requires a freq, month, and year to be specified.
+        minute will default to 0 if year and month specified
     second : int, array, or Series, default None
+        If not None requires a freq, month, and year to be specified.
+        second will default to 0 if year and month specified
     tz : object, default None
         Timezone for converting datetime64 data to Periods
     dtype : str or PeriodDtype, default None
@@ -194,6 +208,8 @@ class PeriodIndex(DatelikeOps, DatetimeIndexOpsMixin, Int64Index):
     >>> idx = PeriodIndex(year=year_arr, quarter=q_arr)
 
     >>> idx2 = PeriodIndex(start='2000', end='2010', freq='A')
+
+    >>> idx3 = PeriodIndex(year=[2000, 2001], month=[1, 2], second=[1, 2], freq='S')
 
     See Also
     ---------

--- a/pandas/core/indexes/period.py
+++ b/pandas/core/indexes/period.py
@@ -133,43 +133,43 @@ class PeriodIndex(DatelikeOps, DatetimeIndexOpsMixin, Int64Index):
     Parameters
     ----------
     data : array-like (1-dimensional), optional
-        Optional period-like data to construct index with
+        Optional period-like data to construct index with.
     copy : bool
-        Make a copy of input ndarray
+        Make a copy of input ndarray.
     freq : string or period object, optional
-        One of pandas period strings or corresponding objects
+        One of pandas period strings or corresponding objects.
     start : starting value, period-like, optional
         If data is None, used as the start point in generating regular
         period data.
     periods : int, optional, > 0
         Number of periods to generate, if generating index. Takes precedence
-        over end argument
+        over end argument.
     end : end value, period-like, optional
         If periods is none, generated index will extend to first conforming
-        period on or just past end argument
+        period on or just past end argument.
     year : int, array, or Series, default None
         If not None requires a freq to be specified and either
-        month or quarter to be specified
+        month or quarter to be specified.
     month : int, array, or Series, default None
-        If not None requires a freq and year to be specified
+        If not None requires a freq and year to be specified.
     quarter : int, array, or Series, default None
         If quarter is not None the freq is required to be
         quarterly Q or Q-DEC. it will be set to Q-DEC if not specified.
-        day, hour, minute, second are not used
+        day, hour, minute, second are not used.
     day : int, array, or Series, default None
         If not None requires a freq, month, and year to be specified.
-        day defaults to 1 if year and month specified
+        day defaults to 1 if year and month specified.
     hour : int, array, or Series, default None
         If not None requires a freq, month, and year to be specified.
-        hour will default to 0 if year and month specified
+        hour will default to 0 if year and month specified.
     minute : int, array, or Series, default None
         If not None requires a freq, month, and year to be specified.
-        minute will default to 0 if year and month specified
+        minute will default to 0 if year and month specified.
     second : int, array, or Series, default None
         If not None requires a freq, month, and year to be specified.
-        second will default to 0 if year and month specified
+        second will default to 0 if year and month specified.
     tz : object, default None
-        Timezone for converting datetime64 data to Periods
+        Timezone for converting datetime64 data to Periods.
     dtype : str or PeriodDtype, default None
 
     Attributes
@@ -205,11 +205,11 @@ class PeriodIndex(DatelikeOps, DatetimeIndexOpsMixin, Int64Index):
 
     Examples
     --------
-    >>> idx = PeriodIndex(year=year_arr, quarter=q_arr)
+    >>> idx = pd.PeriodIndex(year=[2000, 2001, 2002], quarter=[1, 2, 1])
 
-    >>> idx2 = PeriodIndex(start='2000', end='2010', freq='A')
+    >>> idx2 = pd.PeriodIndex(start='2000', end='2010', freq='A')
 
-    >>> idx3 = PeriodIndex(year=[2000, 2001], month=[1, 2], second=[1, 2], freq='S')
+    >>> idx3 = pd.PeriodIndex(year=[2000, 2001], month=[1, 2], second=[1, 2], freq='S')
 
     See Also
     ---------


### PR DESCRIPTION
year, month, quarter, day, hour, minute, second documentation
improved. Detailed in depth the requirements of each parameter.

Documentation is still confusing for allowable freq arguments

Checklist for the pandas documentation sprint (ignore this if you are doing
an unrelated PR):

- [X] PR title is "DOC: update the <your-function-or-method> docstring"
- [X] The validation script passes: `scripts/validate_docstrings.py <your-function-or-method>`
- [X] The PEP8 style check passes: `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [X] The html version looks good: `python doc/make.py --single <your-function-or-method>`
- [X] It has been proofread on language by another sprint participant

```
################################################################################
################################## Validation ##################################
################################################################################

Errors found:
	Errors in parameters section
		Parameters {'fields', 'name', 'ordinal'} not documented
		Unknown parameters {'second', 'month', 'year', 'minute', 'quarter', 'day', 'hour'}
		Parameter "dtype" has no description
	No returns section found
```

A few errors are still reported but are outside of the scope of the doc sprint (fields, name, ordinal).
