### PR TITLE
DOC: update Rolling.std docstring

### DIFF
--- a/pandas/core/window.py
+++ b/pandas/core/window.py
@@ -885,10 +885,10 @@ class _Rolling_and_Expanding(_Rolling):
 
     Notes
     -----
-    The default `ddof` of 1 used in Series.var is different than the default
-    `ddof` of 0 in numpy.var.
+    The default `ddof` of 1 used in Series.std is different than the default
+    `ddof` of 0 in numpy.std.
 
-    A minimum of 1 periods is required for the rolling calculation.
+    A minimum of one period is required for the rolling calculation.
 
     Examples
     --------

--- a/pandas/core/window.py
+++ b/pandas/core/window.py
@@ -867,15 +867,13 @@ class _Rolling_and_Expanding(_Rolling):
     ddof : int, default 1
         Delta Degrees of Freedom.  The divisor used in calculations
         is ``N - ddof``, where ``N`` represents the number of elements.
-    *args
-        Under Review.
-    **kwargs
-        Under Review.
+    *args, **kwargs
+        For NumPy compatibility. No additional arguments are used.
 
     Returns
     -------
-    Returns the same object type as determined by the caller of the %(name)s
-    calculation.
+    Series or DataFrame
+        Returns the same object type as the caller of the %(name)s calculation.
 
     See Also
     --------
@@ -887,38 +885,32 @@ class _Rolling_and_Expanding(_Rolling):
 
     Notes
     -----
+    The default `ddof` of 1 used in Series.var is different than the default
+    `ddof` of 0 in numpy.var.
+
     A minimum of 1 periods is required for the rolling calculation.
 
     Examples
     --------
-    >>> s = pd.Series((5, 5, 5, 5, 6, 7, 9, 10, 5, 5, 5, 5))
+    >>> s = pd.Series([5, 5, 6, 7, 5, 5, 5])
     >>> s.rolling(3).std()
-    0          NaN
-    1          NaN
-    2     0.000000
-    3     0.000000
-    4     0.577350
-    5     1.000000
-    6     1.527525
-    7     1.527525
-    8     2.645751
-    9     2.886751
-    10    0.000000
-    11    0.000000
+    0         NaN
+    1         NaN
+    2    0.577350
+    3    1.000000
+    4    1.000000
+    5    1.154701
+    6    0.000000
     dtype: float64
+
     >>> s.expanding(3).std()
-    0          NaN
-    1          NaN
-    2     0.000000
-    3     0.000000
-    4     0.447214
-    5     0.836660
-    6     1.527525
-    7     2.000000
-    8     1.936492
-    9     1.873796
-    10    1.814086
-    11    1.758098
+    0         NaN
+    1         NaN
+    2    0.577350
+    3    0.957427
+    4    0.894427
+    5    0.836660
+    6    0.786796
     dtype: float64
     """)
 

--- a/pandas/core/window.py
+++ b/pandas/core/window.py
@@ -859,23 +859,23 @@ class _Rolling_and_Expanding(_Rolling):
     _shared_docs['std'] = dedent("""
     Calculate %(name)s standard deviation.
 
-    Normalized by N-1 by default. This can be changed using the ddof argument.
+    Normalized by N-1 by default. This can be changed using the `ddof`
+    argument.
 
     Parameters
     ----------
     ddof : int, default 1
         Delta Degrees of Freedom.  The divisor used in calculations
         is ``N - ddof``, where ``N`` represents the number of elements.
-    args
+    *args
         Under Review.
-    kwargs
+    **kwargs
         Under Review.
 
     Returns
     -------
-    Series or DataFrame
-        Returned object type is determined by the caller of the %(name)s
-        calculation
+    Returns the same object type as determined by the caller of the %(name)s
+    calculation.
 
     See Also
     --------
@@ -891,10 +891,8 @@ class _Rolling_and_Expanding(_Rolling):
 
     Examples
     --------
-    The below example will show a rolling example
-
-    >>> s = pd.Series((5,5,5,5,6,7,9,10,5,5,5,5))
-    >>> s.rolling(3).std(1)
+    >>> s = pd.Series((5, 5, 5, 5, 6, 7, 9, 10, 5, 5, 5, 5))
+    >>> s.rolling(3).std()
     0          NaN
     1          NaN
     2     0.000000
@@ -907,6 +905,20 @@ class _Rolling_and_Expanding(_Rolling):
     9     2.886751
     10    0.000000
     11    0.000000
+    dtype: float64
+    >>> s.expanding(3).std()
+    0          NaN
+    1          NaN
+    2     0.000000
+    3     0.000000
+    4     0.447214
+    5     0.836660
+    6     1.527525
+    7     2.000000
+    8     1.936492
+    9     1.873796
+    10    1.814086
+    11    1.758098
     dtype: float64
     """)
 

--- a/pandas/core/window.py
+++ b/pandas/core/window.py
@@ -857,13 +857,58 @@ class _Rolling_and_Expanding(_Rolling):
         return self._apply('roll_median_c', 'median', **kwargs)
 
     _shared_docs['std'] = dedent("""
-    %(name)s standard deviation
+    Calculate %(name)s standard deviation.
+
+    Normalized by N-1 by default. This can be changed using the ddof argument.
 
     Parameters
     ----------
     ddof : int, default 1
         Delta Degrees of Freedom.  The divisor used in calculations
-        is ``N - ddof``, where ``N`` represents the number of elements.""")
+        is ``N - ddof``, where ``N`` represents the number of elements.
+    args
+        Under Review.
+    kwargs
+        Under Review.
+
+    Returns
+    -------
+    Series or DataFrame
+        Returned object type is determined by the caller of the %(name)s
+        calculation
+
+    See Also
+    --------
+    Series.%(name)s : Calling object with Series data
+    DataFrame.%(name)s : Calling object with DataFrames
+    Series.std : Equivalent method for Series
+    DataFrame.std : Equivalent method for DataFrame
+    numpy.std : Equivalent method for Numpy array
+
+    Notes
+    -----
+    A minimum of 1 periods is required for the rolling calculation.
+
+    Examples
+    --------
+    The below example will show a rolling example
+
+    >>> s = pd.Series((5,5,5,5,6,7,9,10,5,5,5,5))
+    >>> s.rolling(3).std(1)
+    0          NaN
+    1          NaN
+    2     0.000000
+    3     0.000000
+    4     0.577350
+    5     1.000000
+    6     1.527525
+    7     1.527525
+    8     2.645751
+    9     2.886751
+    10    0.000000
+    11    0.000000
+    dtype: float64
+    """)
 
     def std(self, ddof=1, *args, **kwargs):
         nv.validate_window_func('std', args, kwargs)
@@ -1250,7 +1295,6 @@ class Rolling(_Rolling_and_Expanding):
         return super(Rolling, self).median(**kwargs)
 
     @Substitution(name='rolling')
-    @Appender(_doc_template)
     @Appender(_shared_docs['std'])
     def std(self, ddof=1, *args, **kwargs):
         nv.validate_rolling_func('std', args, kwargs)
@@ -1489,7 +1533,6 @@ class Expanding(_Rolling_and_Expanding):
         return super(Expanding, self).median(**kwargs)
 
     @Substitution(name='expanding')
-    @Appender(_doc_template)
     @Appender(_shared_docs['std'])
     def std(self, ddof=1, *args, **kwargs):
         nv.validate_expanding_func('std', args, kwargs)


### PR DESCRIPTION
Checklist for the pandas documentation sprint (ignore this if you are doing
an unrelated PR):

- [x] PR title is "DOC: update the <your-function-or-method> docstring"
- [x] The validation script passes: `scripts/validate_docstrings.py <your-function-or-method>`
- [x] The PEP8 style check passes: `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] The html version looks good: `python doc/make.py --single <your-function-or-method>`
- [x] It has been proofread on language by another sprint participant

Please include the output of the validation script below between the "```" ticks:

```
################################################################################
################## Docstring (pandas.core.window.Rolling.std) ##################
################################################################################

Calculate rolling standard deviation.

Normalized by N-1 by default. This can be changed using the ddof argument.

Parameters
----------
ddof : int, default 1
    Delta Degrees of Freedom.  The divisor used in calculations
    is ``N - ddof``, where ``N`` represents the number of elements.
args
    Under Review.
kwargs
    Under Review.

Returns
-------
Series or DataFrame
    Returned object type is determined by the caller of the rolling
    calculation

See Also
--------
Series.rolling : Calling object with Series data
DataFrame.rolling : Calling object with DataFrames
Series.std : Equivalent method for Series
DataFrame.std : Equivalent method for DataFrame
numpy.std : Equivalent method for Numpy array

Notes
-----
A minimum of 1 periods is required for the rolling calculation.

Examples
--------
The below example will show a rolling example

>>> s = pd.Series((5,5,5,5,6,7,9,10,5,5,5,5))
>>> s.rolling(3).std(1)
0          NaN
1          NaN
2     0.000000
3     0.000000
4     0.577350
5     1.000000
6     1.527525
7     1.527525
8     2.645751
9     2.886751
10    0.000000
11    0.000000
dtype: float64

################################################################################
################################## Validation ##################################
################################################################################

Errors found:
        Errors in parameters section
                Parameter "args" has no type
                Parameter "kwargs" has no type

################################################################################
################# Docstring (pandas.core.window.Expanding.std) #################
################################################################################

Calculate expanding standard deviation.

Normalized by N-1 by default. This can be changed using the ddof argument.

Parameters
----------
ddof : int, default 1
    Delta Degrees of Freedom.  The divisor used in calculations
    is ``N - ddof``, where ``N`` represents the number of elements.
args
    Under Review.
kwargs
    Under Review.

Returns
-------
Series or DataFrame
    Returned object type is determined by the caller of the expanding
    calculation

See Also
--------
Series.expanding : Calling object with Series data
DataFrame.expanding : Calling object with DataFrames
Series.std : Equivalent method for Series
DataFrame.std : Equivalent method for DataFrame
numpy.std : Equivalent method for Numpy array

Notes
-----
A minimum of 1 periods is required for the rolling calculation.

Examples
--------
The below example will show a rolling example

>>> s = pd.Series((5,5,5,5,6,7,9,10,5,5,5,5))
>>> s.rolling(3).std(1)
0          NaN
1          NaN
2     0.000000
3     0.000000
4     0.577350
5     1.000000
6     1.527525
7     1.527525
8     2.645751
9     2.886751
10    0.000000
11    0.000000
dtype: float64

################################################################################
################################## Validation ##################################
################################################################################

Errors found:
        Errors in parameters section
                Parameter "args" has no type
                Parameter "kwargs" has no type
```

If the validation script still gives errors, but you think there is a good reason
to deviate in this case (and there are certainly such cases), please state this
explicitly.
