### PR TITLE
DOC: update Series.sort_values docstring

### DIFF
--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -1885,7 +1885,6 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
     # ----------------------------------------------------------------------
     # Reindexing, sorting
 
-    #@Appender(generic._shared_docs['sort_values'] % _shared_doc_kwargs)
     def sort_values(self, axis=0, ascending=True, inplace=False,
                     kind='quicksort', na_position='last'):
         """
@@ -1938,7 +1937,7 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
 
         **Sort values ascending order**
 
-        >>> s.sort_values(ascending= True)
+        >>> s.sort_values(ascending=True)
         1      1.0
         4      1.0
         5      2.0
@@ -1951,7 +1950,7 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
 
         **Sort values descending order**
 
-        >>> s.sort_values(ascending= False)
+        >>> s.sort_values(ascending=False)
         3    323.0
         2    232.0
         7     45.0
@@ -1964,7 +1963,7 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
 
         **Sort values inplace**
 
-        >>> s.sort_values(ascending= False, inplace= True)
+        >>> s.sort_values(ascending=False, inplace=True)
         >>> s
         3    323.0
         2    232.0
@@ -1978,7 +1977,7 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
 
         **Sort values putting NAs first**
 
-        >>> s.sort_values(na_position= 'first')
+        >>> s.sort_values(na_position='first')
         0      NaN
         4      1.0
         1      1.0

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -1888,9 +1888,9 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
     def sort_values(self, axis=0, ascending=True, inplace=False,
                     kind='quicksort', na_position='last'):
         """
-        Sort by the Series values.
+        Sort by the values.
 
-        Sort (or order) a Series in ascending or descending order by some
+        Sort a Series in ascending or descending order by some
         criterion.
 
         Parameters

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -1895,18 +1895,18 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
 
         Parameters
         ----------
-        axis : {0 or ‘index’}, default 0
-            Axis to direct sorting. The value `index` is accepted for
+        axis : {0 or 'index'}, default 0
+            Axis to direct sorting. The value 'index' is accepted for
             compatibility with DataFrame.sort_values.
         ascending : bool, default True
-            If  `True` sort values in ascending order, otherwise descending.
+            If  True sort values in ascending order, otherwise descending.
         inplace : bool, default False
             If True, perform operation in-place.
-        kind : {‘quicksort’, ‘mergesort’ or ‘heapsort’}, default ‘quicksort’
-            Choice of sorting algorithm. See also :func:`np.sort` for more
-             information. `mergesort` is the only stable  algorithm.
+        kind : {'quicksort', 'mergesort' or 'heapsort'}, default 'quicksort'
+            Choice of sorting algorithm. See also :func:'numpy.sort' for more
+            information. 'mergesort' is the only stable  algorithm.
         na_position : {'first' or 'last'}, default 'last'
-             Argument `first` puts NaNs at the beginning, `last` puts NaNs at
+             Argument 'first' puts NaNs at the beginning, 'last' puts NaNs at
              the end.
 
         Returns

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -1897,7 +1897,7 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
         axis : {0 or ‘index’}, default 0
             Axis to direct sorting.
         ascending : bool, default True
-            Sort ascending (True) or descending (False).
+            Sort ascending (`True`) or descending (`False`).
         inplace : bool, default False
             If True, perform operation in-place.
         kind : {‘quicksort’, ‘mergesort’ or ‘heapsort’}, default ‘quicksort’
@@ -1908,7 +1908,7 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
 
         Returns
         -------
-        sorted_obj : Series
+        Series
             Series ordered by values.
 
         See Also
@@ -1935,7 +1935,7 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
         7     45.0
         dtype: float64
 
-        **Sort values ascending order**
+        Sort values ascending order
 
         >>> s.sort_values(ascending=True)
         1      1.0
@@ -1948,7 +1948,7 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
         0      NaN
         dtype: float64
 
-        **Sort values descending order**
+        Sort values descending order
 
         >>> s.sort_values(ascending=False)
         3    323.0
@@ -1961,7 +1961,7 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
         0      NaN
         dtype: float64
 
-        **Sort values inplace**
+        Sort values inplace
 
         >>> s.sort_values(ascending=False, inplace=True)
         >>> s
@@ -1975,7 +1975,7 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
         0      NaN
         dtype: float64
 
-        **Sort values putting NAs first**
+        Sort values putting NAs first
 
         >>> s.sort_values(na_position='first')
         0      NaN

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -1922,13 +1922,13 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
 
         Examples
         --------
-        >>> s = pd.Series([np.nan, 1, 3, 5, 10])
+        >>> s = pd.Series([np.nan, 1, 3, 10, 5])
         >>> s
         0     NaN
         1     1.0
         2     3.0
-        3     5.0
-        4    10.0
+        3     10.0
+        4     5.0
         dtype: float64
 
         Sort values ascending order (default behaviour)
@@ -1936,16 +1936,16 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
         >>> s.sort_values(ascending=True)
         1     1.0
         2     3.0
-        3     5.0
-        4    10.0
+        4     5.0
+        3    10.0
         0     NaN
         dtype: float64
 
         Sort values descending order
 
         >>> s.sort_values(ascending=False)
-        4    10.0
-        3     5.0
+        3    10.0
+        4     5.0
         2     3.0
         1     1.0
         0     NaN
@@ -1955,8 +1955,8 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
 
         >>> s.sort_values(ascending=False, inplace=True)
         >>> s
-        4    10.0
-        3     5.0
+        3    10.0
+        4     5.0
         2     3.0
         1     1.0
         0     NaN
@@ -1968,8 +1968,8 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
         0     NaN
         1     1.0
         2     3.0
-        3     5.0
-        4    10.0
+        4     5.0
+        3    10.0
         dtype: float64
 
         Sort a series of strings

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -76,7 +76,7 @@ import pandas.plotting._core as gfx
 __all__ = ['Series']
 
 _shared_doc_kwargs = dict(
-    axes='index', klass='Series', axes_single_arg="{0, 'index'}",
+    axes='index', klass='Series', axes_single_arg="{0 or 'index'}",
     inplace="""inplace : boolean, default False
         If True, performs operation inplace and returns None.""",
     unique='np.ndarray', duplicated='Series',
@@ -1885,10 +1885,110 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
     # ----------------------------------------------------------------------
     # Reindexing, sorting
 
-    @Appender(generic._shared_docs['sort_values'] % _shared_doc_kwargs)
+    #@Appender(generic._shared_docs['sort_values'] % _shared_doc_kwargs)
     def sort_values(self, axis=0, ascending=True, inplace=False,
                     kind='quicksort', na_position='last'):
+        """
+        Sort by the Series values.
 
+        Sort (or order) a Series into ascending or descending order by some criterion.
+
+        Parameters
+        ----------
+        axis : {0 or ‘index’}, default 0
+            Axis to direct sorting.
+        ascending : bool, default True
+            Sort ascending (True) or descending (False).
+        inplace : bool, default False
+            If True, perform operation in-place.
+        kind : {‘quicksort’, ‘mergesort’ or ‘heapsort’}, default ‘quicksort’
+            Choice of sorting algorithm. See also ndarray.np.sort [1]_ for more information. `mergesort` is the only stable
+            algorithm.
+        na_position : {'first' or 'last'}, default 'last'
+             Argument `first` puts NaNs at the beginning, `last` puts NaNs at the end.
+
+        Returns
+        -------
+        sorted_obj : Series
+            Series ordered by values.
+
+        See Also
+        --------
+        Series.sort_index : Sort by the Series indices.
+        DataFrame.sort_index : Sort DataFrame by indices.
+        DataFrame.sort_values : Sort by the values along either axis.
+
+        References
+        ----------
+        .. [1] https://docs.scipy.org/doc/numpy/reference/generated/numpy.sort.html
+
+        Examples
+        --------
+        >>> s = pd.Series([np.nan, 1, 232, 323, 1, 2, 3, 45])
+        >>> s
+        0      NaN
+        1      1.0
+        2    232.0
+        3    323.0
+        4      1.0
+        5      2.0
+        6      3.0
+        7     45.0
+        dtype: float64
+
+        **Sort values ascending order**
+
+        >>> s.sort_values(ascending= True)
+        1      1.0
+        4      1.0
+        5      2.0
+        6      3.0
+        7     45.0
+        2    232.0
+        3    323.0
+        0      NaN
+        dtype: float64
+
+        **Sort values descending order**
+
+        >>> s.sort_values(ascending= False)
+        3    323.0
+        2    232.0
+        7     45.0
+        6      3.0
+        5      2.0
+        4      1.0
+        1      1.0
+        0      NaN
+        dtype: float64
+
+        **Sort values inplace**
+
+        >>> s.sort_values(ascending= False, inplace= True)
+        >>> s
+        3    323.0
+        2    232.0
+        7     45.0
+        6      3.0
+        5      2.0
+        4      1.0
+        1      1.0
+        0      NaN
+        dtype: float64
+
+        **Sort values putting NAs first**
+
+        >>> s.sort_values(na_position= 'first')
+        0      NaN
+        4      1.0
+        1      1.0
+        5      2.0
+        6      3.0
+        7     45.0
+        2    232.0
+        3    323.0
+        dtype: float64
+        """
         inplace = validate_bool_kwarg(inplace, 'inplace')
         axis = self._get_axis_number(axis)
 

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -1897,7 +1897,7 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
         axis : {0 or ‘index’}, default 0
             Axis to direct sorting.
         ascending : bool, default True
-            Sort ascending (`True`) or descending (`False`).
+            If  `True` sort values into ascending order, otherwise descending.
         inplace : bool, default False
             If True, perform operation in-place.
         kind : {‘quicksort’, ‘mergesort’ or ‘heapsort’}, default ‘quicksort’

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -1890,21 +1890,24 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
         """
         Sort by the Series values.
 
-        Sort (or order) a Series into ascending or descending order by some criterion.
+        Sort (or order) a Series in ascending or descending order by some
+        criterion.
 
         Parameters
         ----------
         axis : {0 or ‘index’}, default 0
-            Axis to direct sorting.
+            Axis to direct sorting. The value `index` is accepted for
+            compatibility with DataFrame.sort_values.
         ascending : bool, default True
-            If  `True` sort values into ascending order, otherwise descending.
+            If  `True` sort values in ascending order, otherwise descending.
         inplace : bool, default False
             If True, perform operation in-place.
         kind : {‘quicksort’, ‘mergesort’ or ‘heapsort’}, default ‘quicksort’
-            Choice of sorting algorithm. See also ndarray.np.sort [1]_ for more information. `mergesort` is the only stable
-            algorithm.
+            Choice of sorting algorithm. See also :func:`np.sort` for more
+             information. `mergesort` is the only stable  algorithm.
         na_position : {'first' or 'last'}, default 'last'
-             Argument `first` puts NaNs at the beginning, `last` puts NaNs at the end.
+             Argument `first` puts NaNs at the beginning, `last` puts NaNs at
+             the end.
 
         Returns
         -------
@@ -1917,76 +1920,76 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
         DataFrame.sort_index : Sort DataFrame by indices.
         DataFrame.sort_values : Sort by the values along either axis.
 
-        References
-        ----------
-        .. [1] https://docs.scipy.org/doc/numpy/reference/generated/numpy.sort.html
-
         Examples
         --------
-        >>> s = pd.Series([np.nan, 1, 232, 323, 1, 2, 3, 45])
+        >>> s = pd.Series([np.nan, 1, 3, 5, 10])
         >>> s
-        0      NaN
-        1      1.0
-        2    232.0
-        3    323.0
-        4      1.0
-        5      2.0
-        6      3.0
-        7     45.0
+        0     NaN
+        1     1.0
+        2     3.0
+        3     5.0
+        4    10.0
         dtype: float64
 
-        Sort values ascending order
+        Sort values ascending order (default behaviour)
 
         >>> s.sort_values(ascending=True)
-        1      1.0
-        4      1.0
-        5      2.0
-        6      3.0
-        7     45.0
-        2    232.0
-        3    323.0
-        0      NaN
+        1     1.0
+        2     3.0
+        3     5.0
+        4    10.0
+        0     NaN
         dtype: float64
 
         Sort values descending order
 
         >>> s.sort_values(ascending=False)
-        3    323.0
-        2    232.0
-        7     45.0
-        6      3.0
-        5      2.0
-        4      1.0
-        1      1.0
-        0      NaN
+        4    10.0
+        3     5.0
+        2     3.0
+        1     1.0
+        0     NaN
         dtype: float64
 
         Sort values inplace
 
         >>> s.sort_values(ascending=False, inplace=True)
         >>> s
-        3    323.0
-        2    232.0
-        7     45.0
-        6      3.0
-        5      2.0
-        4      1.0
-        1      1.0
-        0      NaN
+        4    10.0
+        3     5.0
+        2     3.0
+        1     1.0
+        0     NaN
         dtype: float64
 
         Sort values putting NAs first
 
         >>> s.sort_values(na_position='first')
-        0      NaN
-        4      1.0
-        1      1.0
-        5      2.0
-        6      3.0
-        7     45.0
-        2    232.0
-        3    323.0
+        0     NaN
+        1     1.0
+        2     3.0
+        3     5.0
+        4    10.0
         dtype: float64
+
+        Sort a series of strings
+
+        >>> s = pd.Series(['z', 'b', 'd', 'a', 'c'])
+        >>> s
+        0    z
+        1    b
+        2    d
+        3    a
+        4    c
+        dtype: object
+
+        >>> s.sort_values()
+        3    a
+        1    b
+        4    c
+        2    d
+        0    z
+        dtype: object
         """
         inplace = validate_bool_kwarg(inplace, 'inplace')
         axis = self._get_axis_number(axis)

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -1906,8 +1906,8 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
             Choice of sorting algorithm. See also :func:'numpy.sort' for more
             information. 'mergesort' is the only stable  algorithm.
         na_position : {'first' or 'last'}, default 'last'
-             Argument 'first' puts NaNs at the beginning, 'last' puts NaNs at
-             the end.
+            Argument 'first' puts NaNs at the beginning, 'last' puts NaNs at
+            the end.
 
         Returns
         -------

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -1899,11 +1899,11 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
             Axis to direct sorting. The value 'index' is accepted for
             compatibility with DataFrame.sort_values.
         ascending : bool, default True
-            If  True sort values in ascending order, otherwise descending.
+            If True, sort values in ascending order, otherwise descending.
         inplace : bool, default False
             If True, perform operation in-place.
         kind : {'quicksort', 'mergesort' or 'heapsort'}, default 'quicksort'
-            Choice of sorting algorithm. See also :func:'numpy.sort' for more
+            Choice of sorting algorithm. See also :func:`numpy.sort` for more
             information. 'mergesort' is the only stable  algorithm.
         na_position : {'first' or 'last'}, default 'last'
             Argument 'first' puts NaNs at the beginning, 'last' puts NaNs at
@@ -1917,8 +1917,8 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
         See Also
         --------
         Series.sort_index : Sort by the Series indices.
+        DataFrame.sort_values : Sort DataFrame by the values along either axis.
         DataFrame.sort_index : Sort DataFrame by indices.
-        DataFrame.sort_values : Sort by the values along either axis.
 
         Examples
         --------


### PR DESCRIPTION
Co-authored-by: @marielen

Checklist for the pandas documentation sprint (ignore this if you are doing
an unrelated PR):

- [x] PR title is "DOC: update the <your-function-or-method> docstring"
- [x] The validation script passes: `scripts/validate_docstrings.py <your-function-or-method>`
- [x] The PEP8 style check passes: `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] The html version looks good: `python doc/make.py --single <your-function-or-method>`
- [x] It has been proofread on language by another sprint participant

Please include the output of the validation script below between the "```" ticks:

```
################################################################################
############## Docstring (pandas.core.series.Series.sort_values)  ##############
################################################################################

Sort by the values.

Sort a Series in ascending or descending order by some
criterion.

Parameters
----------
axis : {0 or 'index'}, default 0
    Axis to direct sorting. The value 'index' is accepted for
    compatibility with DataFrame.sort_values.
ascending : bool, default True
    If  True sort values in ascending order, otherwise descending.
inplace : bool, default False
    If True, perform operation in-place.
kind : {'quicksort', 'mergesort' or 'heapsort'}, default 'quicksort'
    Choice of sorting algorithm. See also :func:'numpy.sort' for more
    information. 'mergesort' is the only stable  algorithm.
na_position : {'first' or 'last'}, default 'last'
    Argument 'first' puts NaNs at the beginning, 'last' puts NaNs at
    the end.

Returns
-------
Series
    Series ordered by values.

See Also
--------
Series.sort_index : Sort by the Series indices.
DataFrame.sort_index : Sort DataFrame by indices.
DataFrame.sort_values : Sort by the values along either axis.

Examples
--------
>>> s = pd.Series([np.nan, 1, 3, 10, 5])
>>> s
0     NaN
1     1.0
2     3.0
3     10.0
4     5.0
dtype: float64

Sort values ascending order (default behaviour)

>>> s.sort_values(ascending=True)
1     1.0
2     3.0
4     5.0
3    10.0
0     NaN
dtype: float64

Sort values descending order

>>> s.sort_values(ascending=False)
3    10.0
4     5.0
2     3.0
1     1.0
0     NaN
dtype: float64

Sort values inplace

>>> s.sort_values(ascending=False, inplace=True)
>>> s
3    10.0
4     5.0
2     3.0
1     1.0
0     NaN
dtype: float64

Sort values putting NAs first

>>> s.sort_values(na_position='first')
0     NaN
1     1.0
2     3.0
4     5.0
3    10.0
dtype: float64

Sort a series of strings

>>> s = pd.Series(['z', 'b', 'd', 'a', 'c'])
>>> s
0    z
1    b
2    d
3    a
4    c
dtype: object

>>> s.sort_values()
3    a
1    b
4    c
2    d
0    z
dtype: object

################################################################################
################################## Validation ##################################
################################################################################

Docstring for "pandas.core.series.Series.sort_values" correct. :)

```

If the validation script still gives errors, but you think there is a good reason
to deviate in this case (and there are certainly such cases), please state this
explicitly.
