### PR TITLE
DOC: update the pandas.Series.sort_index docstring

### DIFF
--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -2021,8 +2021,8 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
         """
         Sort Series by index labels.
 
-        Returns a new Series sorted by label if `inplace` argument is `False`,
-        otherwise updates the original series and returns `null`.
+        Returns a new Series sorted by label if `inplace` argument is
+        ``False``, otherwise updates the original series and returns None.
 
         Parameters
         ----------

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -2016,10 +2016,124 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
         else:
             return result.__finalize__(self)
 
-    @Appender(generic._shared_docs['sort_index'] % _shared_doc_kwargs)
     def sort_index(self, axis=0, level=None, ascending=True, inplace=False,
                    kind='quicksort', na_position='last', sort_remaining=True):
+        """
+        Sort object by labels.
 
+        Returns a new Series sorted by label if `inplace` argument is `False`,
+        otherwise updates the original series and returns `null`.
+
+        Parameters
+        ----------
+        axis : int, default 0
+            Axis to direct sorting.
+        level : int, default None
+            If not None, sort on values in specified index level(s).
+        ascending : boolean, default true
+            Sort ascending vs. descending.
+        inplace : bool, default False
+            If True, perform operation in-place.
+        kind : {'quicksort', 'mergesort', 'heapsort'}, default 'quicksort'
+            Choice of sorting algorithm. See also ndarray.np.sort for more
+            information.  `mergesort` is the only stable algorithm. For
+            DataFrames, this option is only applied when sorting on a single
+            column or label.
+        na_position : {'first', 'last'}, default 'last'
+            If `first` puts NaNs at the beginning, `last` puts NaNs at the end.
+            Not implemented for MultiIndex.
+        sort_remaining : bool, default True
+            If true and sorting by level and index is multilevel, sort by other
+            levels too (in order) after sorting by specified level.
+
+        Returns
+        -------
+        sorted_obj : Series
+
+        See Also
+        --------
+        sort_values : Sort by the value
+
+        Examples
+        --------
+        >>> s = pd.Series(['a', 'b', 'c', 'd'], index=[3,2,1,4])
+        >>> s.sort_index()
+        1    c
+        2    b
+        3    a
+        4    d
+        dtype: object
+
+        Sort Descending
+
+        >>> s = pd.Series(['a', 'b', 'c', 'd'], index=[3,2,1,4])
+        >>> s.sort_index(ascending=False)
+        4    d
+        3    a
+        2    b
+        1    c
+        dtype: object
+
+        Sort Inplace
+
+        >>> s = pd.Series(['a', 'b', 'c', 'd'], index=[3,2,1,4])
+        >>> s.sort_index(inplace=True)
+        >>> s
+        1    c
+        2    b
+        3    a
+        4    d
+        dtype: object
+
+        Sort placing NaNs at first
+
+        >>> s = pd.Series(['a', 'b', 'c', 'd'], index=[3,2,1,np.nan])
+        >>> s.sort_index(na_position='first')
+        NaN     d
+         1.0    c
+         2.0    b
+         3.0    a
+        dtype: object
+
+        Specify index level to sort
+
+        >>> import numpy as np
+        >>> arrays = [np.array(['qux', 'qux', 'foo', 'foo',\
+                                'baz', 'baz', 'bar', 'bar']),
+        ...           np.array(['two', 'one', 'two', 'one',\
+                                'two', 'one', 'two', 'one'])]
+        >>> s = pd.Series([1, 2, 3, 4, 5, 6, 7, 8], index=arrays)
+        >>> s.sort_index(level=1)
+        bar  one    8
+        baz  one    6
+        foo  one    4
+        qux  one    2
+        bar  two    7
+        baz  two    5
+        foo  two    3
+        qux  two    1
+        dtype: int64
+
+        Does not sort by remaining levels when sorting by levels
+
+        >>> import numpy as np
+        >>> arrays = [np.array(['qux', 'qux', 'foo', 'foo',\
+                                'baz', 'baz', 'bar', 'bar']),
+        ...           np.array(['two', 'one', 'two', 'one',\
+                                'two', 'one', 'two', 'one'])]
+        >>> s = pd.Series([1, 2, 3, 4, 5, 6, 7, 8], index=arrays)
+        >>> s.sort_index(level=1, sort_remaining=False)
+        qux  one    2
+        foo  one    4
+        baz  one    6
+        bar  one    8
+        qux  two    1
+        foo  two    3
+        baz  two    5
+        bar  two    7
+        dtype: int64
+        """
+        
         # TODO: this can be combined with DataFrame.sort_index impl as
         # almost identical
         inplace = validate_bool_kwarg(inplace, 'inplace')

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -2019,7 +2019,7 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
     def sort_index(self, axis=0, level=None, ascending=True, inplace=False,
                    kind='quicksort', na_position='last', sort_remaining=True):
         """
-        Sort object by labels.
+        Sort Series by index labels.
 
         Returns a new Series sorted by label if `inplace` argument is `False`,
         otherwise updates the original series and returns `null`.
@@ -2027,20 +2027,20 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
         Parameters
         ----------
         axis : int, default 0
-            Axis to direct sorting.
-        level : int, default None
+            Axis to direct sorting. This can only be 0 for Series.
+        level : int, optional
             If not None, sort on values in specified index level(s).
-        ascending : boolean, default true
+        ascending : bool, default true
             Sort ascending vs. descending.
         inplace : bool, default False
             If True, perform operation in-place.
         kind : {'quicksort', 'mergesort', 'heapsort'}, default 'quicksort'
-            Choice of sorting algorithm. See also ndarray.np.sort for more
-            information.  `mergesort` is the only stable algorithm. For
+            Choice of sorting algorithm. See also :func:`numpy.sort` for more
+            information.  'mergesort' is the only stable algorithm. For
             DataFrames, this option is only applied when sorting on a single
             column or label.
         na_position : {'first', 'last'}, default 'last'
-            If `first` puts NaNs at the beginning, `last` puts NaNs at the end.
+            If `first` puts NaNs at the beginning, 'last' puts NaNs at the end.
             Not implemented for MultiIndex.
         sort_remaining : bool, default True
             If true and sorting by level and index is multilevel, sort by other
@@ -2053,11 +2053,13 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
 
         See Also
         --------
-        sort_values : Sort by the value
+        DataFrame.sort_index: Sort DataFrame by the index
+        DataFrame.sort_values: Sort DataFrame by the value
+        Series.sort_values : Sort Series by the value
 
         Examples
         --------
-        >>> s = pd.Series(['a', 'b', 'c', 'd'], index=[3,2,1,4])
+        >>> s = pd.Series(['a','b','c','d'], index=[3,2,1,4])
         >>> s.sort_index()
         1    c
         2    b
@@ -2067,7 +2069,7 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
 
         Sort Descending
 
-        >>> s = pd.Series(['a', 'b', 'c', 'd'], index=[3,2,1,4])
+        >>> s = pd.Series(['a','b','c','d'], index=[3,2,1,4])
         >>> s.sort_index(ascending=False)
         4    d
         3    a
@@ -2077,7 +2079,7 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
 
         Sort Inplace
 
-        >>> s = pd.Series(['a', 'b', 'c', 'd'], index=[3,2,1,4])
+        >>> s = pd.Series(['a','b','c','d'], index=[3,2,1,4])
         >>> s.sort_index(inplace=True)
         >>> s
         1    c
@@ -2088,7 +2090,7 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
 
         Sort placing NaNs at first
 
-        >>> s = pd.Series(['a', 'b', 'c', 'd'], index=[3,2,1,np.nan])
+        >>> s = pd.Series(['a','b','c','d'], index=[3,2,1,np.nan])
         >>> s.sort_index(na_position='first')
         NaN     d
          1.0    c
@@ -2098,12 +2100,11 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
 
         Specify index level to sort
 
-        >>> import numpy as np
-        >>> arrays = [np.array(['qux', 'qux', 'foo', 'foo',
-        ...                     'baz', 'baz', 'bar', 'bar']),
-        ...           np.array(['two', 'one', 'two', 'one',
-        ...                     'two', 'one', 'two', 'one'])]
-        >>> s = pd.Series([1, 2, 3, 4, 5, 6, 7, 8], index=arrays)
+        >>> arrays = [np.array(['qux','qux','foo','foo',
+        ...                     'baz','baz','bar','bar']),
+        ...           np.array(['two','one','two','one',
+        ...                     'two','one','two','one'])]
+        >>> s = pd.Series([1,2,3,4,5,6,7,8], index=arrays)
         >>> s.sort_index(level=1)
         bar  one    8
         baz  one    6
@@ -2117,12 +2118,11 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
 
         Does not sort by remaining levels when sorting by levels
 
-        >>> import numpy as np
-        >>> arrays = [np.array(['qux', 'qux', 'foo', 'foo',
-        ...                     'baz', 'baz', 'bar', 'bar']),
-        ...           np.array(['two', 'one', 'two', 'one',
-        ...                     'two', 'one', 'two', 'one'])]
-        >>> s = pd.Series([1, 2, 3, 4, 5, 6, 7, 8], index=arrays)
+        >>> arrays = [np.array(['qux','qux','foo','foo',
+        ...                     'baz','baz','bar','bar']),
+        ...           np.array(['two','one','two','one',
+        ...                     'two','one','two','one'])]
+        >>> s = pd.Series([1,2,3,4,5,6,7,8], index=arrays)
         >>> s.sort_index(level=1, sort_remaining=False)
         qux  one    2
         foo  one    4

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -2040,7 +2040,7 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
             DataFrames, this option is only applied when sorting on a single
             column or label.
         na_position : {'first', 'last'}, default 'last'
-            If `first` puts NaNs at the beginning, 'last' puts NaNs at the end.
+            If 'first' puts NaNs at the beginning, 'last' puts NaNs at the end.
             Not implemented for MultiIndex.
         sort_remaining : bool, default True
             If true and sorting by level and index is multilevel, sort by other
@@ -2059,7 +2059,7 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
 
         Examples
         --------
-        >>> s = pd.Series(['a','b','c','d'], index=[3,2,1,4])
+        >>> s = pd.Series(['a', 'b', 'c', 'd'], index=[3, 2, 1, 4])
         >>> s.sort_index()
         1    c
         2    b
@@ -2069,7 +2069,6 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
 
         Sort Descending
 
-        >>> s = pd.Series(['a','b','c','d'], index=[3,2,1,4])
         >>> s.sort_index(ascending=False)
         4    d
         3    a
@@ -2079,7 +2078,6 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
 
         Sort Inplace
 
-        >>> s = pd.Series(['a','b','c','d'], index=[3,2,1,4])
         >>> s.sort_index(inplace=True)
         >>> s
         1    c
@@ -2088,9 +2086,10 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
         4    d
         dtype: object
 
-        Sort placing NaNs at first
+        By default NaNs are put at the end, but use `na_position` to place
+        them at the beginning
 
-        >>> s = pd.Series(['a','b','c','d'], index=[3,2,1,np.nan])
+        >>> s = pd.Series(['a', 'b', 'c', 'd'], index=[3, 2, 1, np.nan])
         >>> s.sort_index(na_position='first')
         NaN     d
          1.0    c
@@ -2100,11 +2099,11 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
 
         Specify index level to sort
 
-        >>> arrays = [np.array(['qux','qux','foo','foo',
-        ...                     'baz','baz','bar','bar']),
-        ...           np.array(['two','one','two','one',
-        ...                     'two','one','two','one'])]
-        >>> s = pd.Series([1,2,3,4,5,6,7,8], index=arrays)
+        >>> arrays = [np.array(['qux', 'qux', 'foo', 'foo',
+        ...                     'baz', 'baz', 'bar', 'bar']),
+        ...           np.array(['two', 'one', 'two', 'one',
+        ...                     'two', 'one', 'two', 'one'])]
+        >>> s = pd.Series([1, 2, 3, 4, 5, 6, 7, 8], index=arrays)
         >>> s.sort_index(level=1)
         bar  one    8
         baz  one    6
@@ -2118,11 +2117,6 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
 
         Does not sort by remaining levels when sorting by levels
 
-        >>> arrays = [np.array(['qux','qux','foo','foo',
-        ...                     'baz','baz','bar','bar']),
-        ...           np.array(['two','one','two','one',
-        ...                     'two','one','two','one'])]
-        >>> s = pd.Series([1,2,3,4,5,6,7,8], index=arrays)
         >>> s.sort_index(level=1, sort_remaining=False)
         qux  one    2
         foo  one    4

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -2048,7 +2048,8 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
 
         Returns
         -------
-        sorted_obj : Series
+        pandas.Series
+            The original Series sorted by the labels
 
         See Also
         --------
@@ -2098,10 +2099,10 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
         Specify index level to sort
 
         >>> import numpy as np
-        >>> arrays = [np.array(['qux', 'qux', 'foo', 'foo',\
-                                'baz', 'baz', 'bar', 'bar']),
-        ...           np.array(['two', 'one', 'two', 'one',\
-                                'two', 'one', 'two', 'one'])]
+        >>> arrays = [np.array(['qux', 'qux', 'foo', 'foo',
+        ...                     'baz', 'baz', 'bar', 'bar']),
+        ...           np.array(['two', 'one', 'two', 'one',
+        ...                     'two', 'one', 'two', 'one'])]
         >>> s = pd.Series([1, 2, 3, 4, 5, 6, 7, 8], index=arrays)
         >>> s.sort_index(level=1)
         bar  one    8
@@ -2117,10 +2118,10 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
         Does not sort by remaining levels when sorting by levels
 
         >>> import numpy as np
-        >>> arrays = [np.array(['qux', 'qux', 'foo', 'foo',\
-                                'baz', 'baz', 'bar', 'bar']),
-        ...           np.array(['two', 'one', 'two', 'one',\
-                                'two', 'one', 'two', 'one'])]
+        >>> arrays = [np.array(['qux', 'qux', 'foo', 'foo',
+        ...                     'baz', 'baz', 'bar', 'bar']),
+        ...           np.array(['two', 'one', 'two', 'one',
+        ...                     'two', 'one', 'two', 'one'])]
         >>> s = pd.Series([1, 2, 3, 4, 5, 6, 7, 8], index=arrays)
         >>> s.sort_index(level=1, sort_remaining=False)
         qux  one    2
@@ -2133,7 +2134,6 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
         bar  two    7
         dtype: int64
         """
-        
         # TODO: this can be combined with DataFrame.sort_index impl as
         # almost identical
         inplace = validate_bool_kwarg(inplace, 'inplace')


### PR DESCRIPTION
Checklist for the pandas documentation sprint (ignore this if you are doing
an unrelated PR):

- [x] PR title is "DOC: update the <your-function-or-method> docstring"
- [x] The validation script passes: `scripts/validate_docstrings.py <your-function-or-method>`
- [x] The PEP8 style check passes: `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] The html version looks good: `python doc/make.py --single <your-function-or-method>`
- [x] It has been proofread on language by another sprint participant

Please include the output of the validation script below between the "```" ticks:

```
################################################################################
##################### Docstring (pandas.Series.sort_index) #####################
################################################################################

Sort Series by index labels.

Returns a new Series sorted by label if `inplace` argument is `False`,
otherwise updates the original series and returns `null`.

Parameters
----------
axis : int, default 0
    Axis to direct sorting. This can only be 0 for Series.
level : int, optional
    If not None, sort on values in specified index level(s).
ascending : bool, default true
    Sort ascending vs. descending.
inplace : bool, default False
    If True, perform operation in-place.
kind : {'quicksort', 'mergesort', 'heapsort'}, default 'quicksort'
    Choice of sorting algorithm. See also :func:`numpy.sort` for more
    information.  'mergesort' is the only stable algorithm. For
    DataFrames, this option is only applied when sorting on a single
    column or label.
na_position : {'first', 'last'}, default 'last'
    If 'first' puts NaNs at the beginning, 'last' puts NaNs at the end.
    Not implemented for MultiIndex.
sort_remaining : bool, default True
    If true and sorting by level and index is multilevel, sort by other
    levels too (in order) after sorting by specified level.

Returns
-------
pandas.Series
    The original Series sorted by the labels

See Also
--------
DataFrame.sort_index: Sort DataFrame by the index
DataFrame.sort_values: Sort DataFrame by the value
Series.sort_values : Sort Series by the value

Examples
--------
>>> s = pd.Series(['a', 'b', 'c', 'd'], index=[3, 2, 1, 4])
>>> s.sort_index()
1    c
2    b
3    a
4    d
dtype: object

Sort Descending

>>> s.sort_index(ascending=False)
4    d
3    a
2    b
1    c
dtype: object

Sort Inplace

>>> s.sort_index(inplace=True)
>>> s
1    c
2    b
3    a
4    d
dtype: object

By default NaNs are put at the end, but use `na_position` to place
them at the beginning

>>> s = pd.Series(['a', 'b', 'c', 'd'], index=[3, 2, 1, np.nan])
>>> s.sort_index(na_position='first')
NaN     d
 1.0    c
 2.0    b
 3.0    a
dtype: object

Specify index level to sort

>>> arrays = [np.array(['qux', 'qux', 'foo', 'foo',
...                     'baz', 'baz', 'bar', 'bar']),
...           np.array(['two', 'one', 'two', 'one',
...                     'two', 'one', 'two', 'one'])]
>>> s = pd.Series([1, 2, 3, 4, 5, 6, 7, 8], index=arrays)
>>> s.sort_index(level=1)
bar  one    8
baz  one    6
foo  one    4
qux  one    2
bar  two    7
baz  two    5
foo  two    3
qux  two    1
dtype: int64

Does not sort by remaining levels when sorting by levels

>>> s.sort_index(level=1, sort_remaining=False)
qux  one    2
foo  one    4
baz  one    6
bar  one    8
qux  two    1
foo  two    3
baz  two    5
bar  two    7
dtype: int64

################################################################################
################################## Validation ##################################
################################################################################

Docstring for "pandas.Series.sort_index" correct. :)
```