### PR TITLE
DOC: update the Index.isin docstring

### DIFF
--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -3396,8 +3396,11 @@ class Index(IndexOpsMixin, PandasObject):
 
     def isin(self, values, level=None):
         """
+        Boolean array on existence of index values in `values`.
+
         Compute boolean array of whether each index value is found in the
-        passed set of values.
+        passed set of values. Length of the returned boolean array matches
+        the length of the index.
 
         Parameters
         ----------
@@ -3406,11 +3409,25 @@ class Index(IndexOpsMixin, PandasObject):
 
             .. versionadded:: 0.18.1
 
-            Support for values as a set
+            Support for values as a set.
 
-        level : str or int, optional
+        level : str or int, optional in the case of Index, compulsory on
+            MultiIndex
             Name or position of the index level to use (if the index is a
             MultiIndex).
+
+        Returns
+        -------
+        is_contained : ndarray (boolean dtype)
+
+        See also
+        --------
+        DatetimeIndex.isin : an Index of :class:`Datetime` s
+        TimedeltaIndex : an Index of :class:`Timedelta` s
+        PeriodIndex : an Index of :class:`Period` s
+        MultiIndex.isin : Same for `MultiIndex`
+        NumericIndex.isin : Same for `Int64Index`, `UInt64Index`,
+                            `Float64Index`
 
         Notes
         -----
@@ -3419,10 +3436,40 @@ class Index(IndexOpsMixin, PandasObject):
         - if it is the name of one *and only one* index level, use that level;
         - otherwise it should be a number indicating level position.
 
-        Returns
-        -------
-        is_contained : ndarray (boolean dtype)
+        Examples
+        --------
+        >>> idx = pd.Index([1,2,3])
+        >>> idx
+        Int64Index([1, 2, 3], dtype='int64')
 
+        Check whether a value is in the Index:
+        >>> idx.isin([1])
+        array([ True, False, False])
+
+        >>> midx = pd.MultiIndex.from_arrays([[1,2,3],
+        ...                                    ['red','blue','green']],
+        ...                                    names=('number', 'color'))
+        >>> midx
+        MultiIndex(levels=[[1, 2, 3], ['blue', 'green', 'red']],\
+ labels=[[0, 1, 2], [2, 0, 1]],\
+ names=['number', 'color'])
+
+        Check whether a string index value is in the 'color' level of the
+        MultiIndex:
+
+        >>> midx.isin(['red'],'color')
+        array([ True, False, False])
+
+        >>> dates = ['3/11/2000', '3/12/2000', '3/13/2000']
+        >>> dti = pd.to_datetime(dates)
+        >>> dti
+        DatetimeIndex(['2000-03-11', '2000-03-12', '2000-03-13'],\
+ dtype='datetime64[ns]', freq=None)
+
+        Check whether a datetime index value is in the DatetimeIndex:
+
+        >>> dti.isin(['3/11/2000'])
+        array([ True, False, False])
         """
         if level is not None:
             self._validate_index_level(level)

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -3396,10 +3396,10 @@ class Index(IndexOpsMixin, PandasObject):
 
     def isin(self, values, level=None):
         """
-        Boolean array on existence of index values in `values`.
+        Return a boolean array where the index values are in `values`.
 
         Compute boolean array of whether each index value is found in the
-        passed set of values. Length of the returned boolean array matches
+        passed set of values. The length of the returned boolean array matches
         the length of the index.
 
         Parameters
@@ -3411,10 +3411,9 @@ class Index(IndexOpsMixin, PandasObject):
 
             Support for values as a set.
 
-        level : str or int, optional in the case of Index, compulsory on
-            MultiIndex
+        level : str or int, optional
             Name or position of the index level to use (if the index is a
-            MultiIndex).
+            `MultiIndex`).
 
         Returns
         -------
@@ -3422,15 +3421,15 @@ class Index(IndexOpsMixin, PandasObject):
 
         See also
         --------
-        DatetimeIndex.isin : an Index of :class:`Datetime` s
-        TimedeltaIndex : an Index of :class:`Timedelta` s
-        PeriodIndex : an Index of :class:`Period` s
-        MultiIndex.isin : Same for `MultiIndex`
-        NumericIndex.isin : Same for `Int64Index`, `UInt64Index`,
-                            `Float64Index`
+        Series.isin: same for :class:`~pandas.Series`
 
         Notes
         -----
+        In the case of `MultiIndex` you must either specify `values` as a
+        list-like object containing tuples that are the same length as the
+        number of levels, or specify `level`. Otherwise it will raise
+        `ValueError`.
+
         If `level` is specified:
 
         - if it is the name of one *and only one* index level, use that level;
@@ -3450,21 +3449,26 @@ class Index(IndexOpsMixin, PandasObject):
         ...                                    ['red','blue','green']],
         ...                                    names=('number', 'color'))
         >>> midx
-        MultiIndex(levels=[[1, 2, 3], ['blue', 'green', 'red']],\
- labels=[[0, 1, 2], [2, 0, 1]],\
- names=['number', 'color'])
+        MultiIndex(levels=[[1, 2, 3], ['blue', 'green', 'red']],
+        labels=[[0, 1, 2], [2, 0, 1]],
+        names=['number', 'color'])
 
         Check whether a string index value is in the 'color' level of the
         MultiIndex:
 
-        >>> midx.isin(['red'],'color')
+        >>> midx.isin(['red'], level='color')
+        array([ True, False, False])
+
+        Check whether a pair of indexes is in the MultiIndex:
+
+        >>> midx.isin([(1, 'red'), (3, 'red')])
         array([ True, False, False])
 
         >>> dates = ['3/11/2000', '3/12/2000', '3/13/2000']
         >>> dti = pd.to_datetime(dates)
         >>> dti
-        DatetimeIndex(['2000-03-11', '2000-03-12', '2000-03-13'],\
- dtype='datetime64[ns]', freq=None)
+        DatetimeIndex(['2000-03-11', '2000-03-12', '2000-03-13'],
+        dtype='datetime64[ns]', freq=None)
 
         Check whether a datetime index value is in the DatetimeIndex:
 

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -3446,8 +3446,8 @@ class Index(IndexOpsMixin, PandasObject):
         array([ True, False, False])
 
         >>> midx = pd.MultiIndex.from_arrays([[1,2,3],
-        ...                                    ['red','blue','green']],
-        ...                                    names=('number', 'color'))
+        ...                                  ['red','blue','green']],
+        ...                                  names=('number', 'color'))
         >>> midx
         MultiIndex(levels=[[1, 2, 3], ['blue', 'green', 'red']],
         labels=[[0, 1, 2], [2, 0, 1]],

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -3409,7 +3409,7 @@ class Index(IndexOpsMixin, PandasObject):
 
             .. versionadded:: 0.18.1
 
-            Support for values as a set.
+               Support for values as a set.
 
         level : str or int, optional
             Name or position of the index level to use (if the index is a
@@ -3417,18 +3417,20 @@ class Index(IndexOpsMixin, PandasObject):
 
         Returns
         -------
-        is_contained : ndarray (boolean dtype)
+        is_contained : ndarray
+            NumPy array of boolean values.
 
         See also
         --------
-        Series.isin: same for :class:`~pandas.Series`
+        Series.isin : Same for Series.
+        DataFrame.isin : Same method for DataFrames.
 
         Notes
         -----
         In the case of `MultiIndex` you must either specify `values` as a
         list-like object containing tuples that are the same length as the
-        number of levels, or specify `level`. Otherwise it will raise
-        `ValueError`.
+        number of levels, or specify `level`. Otherwise it will raise a
+        ``ValueError``.
 
         If `level` is specified:
 
@@ -3441,38 +3443,39 @@ class Index(IndexOpsMixin, PandasObject):
         >>> idx
         Int64Index([1, 2, 3], dtype='int64')
 
-        Check whether a value is in the Index:
-        >>> idx.isin([1])
+        Check whether each index value in a list of values.
+        >>> idx.isin([1, 4])
         array([ True, False, False])
 
         >>> midx = pd.MultiIndex.from_arrays([[1,2,3],
-        ...                                  ['red','blue','green']],
+        ...                                  ['red', 'blue', 'green']],
         ...                                  names=('number', 'color'))
         >>> midx
         MultiIndex(levels=[[1, 2, 3], ['blue', 'green', 'red']],
-        labels=[[0, 1, 2], [2, 0, 1]],
-        names=['number', 'color'])
+                   labels=[[0, 1, 2], [2, 0, 1]],
+                   names=['number', 'color'])
 
-        Check whether a string index value is in the 'color' level of the
-        MultiIndex:
+        Check whether the strings in the 'color' level of the MultiIndex
+        are in a list of colors.
 
-        >>> midx.isin(['red'], level='color')
+        >>> midx.isin(['red', 'orange', 'yellow'], level='color')
         array([ True, False, False])
 
-        Check whether a pair of indexes is in the MultiIndex:
+        To check across the levels of a MultiIndex, pass a list of tuples:
 
         >>> midx.isin([(1, 'red'), (3, 'red')])
         array([ True, False, False])
 
-        >>> dates = ['3/11/2000', '3/12/2000', '3/13/2000']
+        For a DatetimeIndex, string values in `values` are converted to
+        Timestamps.
+
+        >>> dates = ['2000-03-11', '2000-03-12', '2000-03-13']
         >>> dti = pd.to_datetime(dates)
         >>> dti
         DatetimeIndex(['2000-03-11', '2000-03-12', '2000-03-13'],
         dtype='datetime64[ns]', freq=None)
 
-        Check whether a datetime index value is in the DatetimeIndex:
-
-        >>> dti.isin(['3/11/2000'])
+        >>> dti.isin(['2000-03-11'])
         array([ True, False, False])
         """
         if level is not None:


### PR DESCRIPTION
Checklist for the pandas documentation sprint (ignore this if you are doing
an unrelated PR):

- [x] PR title is "DOC: update the <your-function-or-method> docstring"
- [x] The validation script passes: `scripts/validate_docstrings.py <your-function-or-method>`
- [x] The PEP8 style check passes: `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] The html version looks good: `python doc/make.py --single <your-function-or-method>`
- [x] It has been proofread on language by another sprint participant

Please include the output of the validation script below between the "```" ticks:

```

################################################################################
######################## Docstring (pandas.Index.isin)  ########################
################################################################################

Boolean array on existence of index values in `values`.

Compute boolean array of whether each index value is found in the
passed set of values. Length of the returned boolean array matches
the length of the index.

Parameters
----------
values : set or list-like
    Sought values.

    .. versionadded:: 0.18.1

    Support for values as a set.

level : str or int, optional in the case of Index, compulsory on
    MultiIndex
    Name or position of the index level to use (if the index is a
    MultiIndex).

Returns
-------
is_contained : ndarray (boolean dtype)

See also
--------
DatetimeIndex.isin : an Index of :class:`Datetime` s
TimedeltaIndex : an Index of :class:`Timedelta` s
PeriodIndex : an Index of :class:`Period` s
MultiIndex.isin : Same for `MultiIndex`
NumericIndex.isin : Same for `Int64Index`, `UInt64Index`,
                    `Float64Index`

Notes
-----
If `level` is specified:

- if it is the name of one *and only one* index level, use that level;
- otherwise it should be a number indicating level position.

Examples
--------
>>> idx = pd.Index([1,2,3])
>>> idx
Int64Index([1, 2, 3], dtype='int64')

Check whether a value is in the Index:
>>> idx.isin([1])
array([ True, False, False])

>>> midx = pd.MultiIndex.from_arrays([[1,2,3],
...                                    ['red','blue','green']],
...                                    names=('number', 'color'))
>>> midx
MultiIndex(levels=[[1, 2, 3], ['blue', 'green', 'red']], labels=[[0, 1, 2], [2, 0, 1]], names=['number', 'color'])

Check whether a string index value is in the 'color' level of the
MultiIndex:

>>> midx.isin(['red'],'color')
array([ True, False, False])

>>> dates = ['3/11/2000', '3/12/2000', '3/13/2000']
>>> dti = pd.to_datetime(dates)
>>> dti
DatetimeIndex(['2000-03-11', '2000-03-12', '2000-03-13'], dtype='datetime64[ns]', freq=None)

Check whether a datetime index value is in the DatetimeIndex:

>>> dti.isin(['3/11/2000'])
array([ True, False, False])

################################################################################
################################## Validation ##################################
################################################################################

Docstring for "pandas.Index.isin" correct. :)
```

If the validation script still gives errors, but you think there is a good reason
to deviate in this case (and there are certainly such cases), please state this
explicitly.
