### PR TITLE
DOC: update the DataFrame.pivot	docstring

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -4346,7 +4346,8 @@ class DataFrame(NDFrame):
         Reshape data (produce a "pivot" table) based on column values. Uses
         unique values from specified `index` / `columns` to form axes of the resulting
         DataFrame. This function does not support data aggregation, multiple
-        values will result in a MultiIndex in the columns.
+        values will result in a MultiIndex in the columns. See the
+        :ref:`User Guide <reshaping>` for more on reshaping.
 
         Parameters
         ----------

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -4345,7 +4345,7 @@ class DataFrame(NDFrame):
 
         Reshape data (produce a "pivot" table) based on column values. Uses
         unique values from index / columns to form axes of the resulting
-        DataFrame. This function don't support data aggregation, multiple
+        DataFrame. This function does not support data aggregation, multiple
         values will result in hierarchically indexed columns.
 
         Parameters

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -4341,27 +4341,31 @@ class DataFrame(NDFrame):
 
     def pivot(self, index=None, columns=None, values=None):
         """
+        Return reshaped DataFrame summarized by given index / column values.
+
         Reshape data (produce a "pivot" table) based on column values. Uses
         unique values from index / columns to form axes of the resulting
-        DataFrame.
+        DataFrame. This function don't support data aggregation, multiple
+        values will result in hierarchically indexed columns.
 
         Parameters
         ----------
         index : string or object, optional
             Column name to use to make new frame's index. If None, uses
             existing index.
-        columns : string or object
-            Column name to use to make new frame's columns
+        columns : string or object, optional
+            Column name to use to make new frame's columns.
         values : string or object, optional
             Column name to use for populating new frame's values. If not
             specified, all remaining columns will be used and the result will
-            have hierarchically indexed columns
+            have hierarchically indexed columns.
 
         Returns
         -------
-        pivoted : DataFrame
+        DataFrame
+            Returns reshaped DataFrame.
 
-        See also
+        See Also
         --------
         DataFrame.pivot_table : generalization of pivot that can handle
             duplicate values for one index/column pair
@@ -4377,8 +4381,8 @@ class DataFrame(NDFrame):
         --------
 
         >>> df = pd.DataFrame({'foo': ['one','one','one','two','two','two'],
-                               'bar': ['A', 'B', 'C', 'A', 'B', 'C'],
-                               'baz': [1, 2, 3, 4, 5, 6]})
+        ...                    'bar': ['A', 'B', 'C', 'A', 'B', 'C'],
+        ...                    'baz': [1, 2, 3, 4, 5, 6]})
         >>> df
             foo   bar  baz
         0   one   A    1
@@ -4389,16 +4393,16 @@ class DataFrame(NDFrame):
         5   two   C    6
 
         >>> df.pivot(index='foo', columns='bar', values='baz')
-             A   B   C
+        bar  A   B   C
+        foo
         one  1   2   3
         two  4   5   6
 
         >>> df.pivot(index='foo', columns='bar')['baz']
-             A   B   C
+        bar  A   B   C
+        foo
         one  1   2   3
         two  4   5   6
-
-
         """
         from pandas.core.reshape.reshape import pivot
         return pivot(self, index=index, columns=columns, values=values)

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -4369,7 +4369,7 @@ class DataFrame(NDFrame):
         ------
         ValueError:
             When there are any `index`, `columns` combinations with multiple
-            values.
+            values. `DataFrame.pivot_table` when you need to aggregate.
 
         See Also
         --------

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -4413,10 +4413,10 @@ class DataFrame(NDFrame):
 
         A ValueError is raised if there are any duplicates.
 
-        >>> af = pd.DataFrame({"foo": ['one', 'one', 'two', 'two'],
+        >>> df = pd.DataFrame({"foo": ['one', 'one', 'two', 'two'],
         ...                    "bar": ['A', 'A', 'B', 'C'],
         ...                    "baz": [1, 2, 3, 4]})
-        >>> af
+        >>> df
            foo bar  baz
         0  one   A    1
         1  one   A    2
@@ -4426,7 +4426,7 @@ class DataFrame(NDFrame):
         Notice that the first two rows are the same for our `index`
         and `columns` arguments.
 
-        >>> af.pivot(index='foo', columns='bar', values='baz')
+        >>> df.pivot(index='foo', columns='bar', values='baz')
         Traceback (most recent call last):
            ...
         ValueError: Index contains duplicate entries, cannot reshape

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -4346,7 +4346,7 @@ class DataFrame(NDFrame):
         Reshape data (produce a "pivot" table) based on column values. Uses
         unique values from specified `index` / `columns` to form axes of the resulting
         DataFrame. This function does not support data aggregation, multiple
-        values will result in hierarchically indexed columns.
+        values will result in a MultiIndex in the columns.
 
         Parameters
         ----------
@@ -4365,6 +4365,12 @@ class DataFrame(NDFrame):
         DataFrame
             Returns reshaped DataFrame.
 
+        Raises
+        ------
+        ValueError:
+            When there are any `index`, `columns` combinations with multiple
+            values.
+
         See Also
         --------
         DataFrame.pivot_table : generalization of pivot that can handle
@@ -4379,8 +4385,8 @@ class DataFrame(NDFrame):
 
         Examples
         --------
-
-        >>> df = pd.DataFrame({'foo': ['one','one','one','two','two','two'],
+        >>> df = pd.DataFrame({'foo': ['one', 'one', 'one', 'two', 'two',
+        ...                            'two'],
         ...                    'bar': ['A', 'B', 'C', 'A', 'B', 'C'],
         ...                    'baz': [1, 2, 3, 4, 5, 6]})
         >>> df
@@ -4403,6 +4409,26 @@ class DataFrame(NDFrame):
         foo
         one  1   2   3
         two  4   5   6
+
+        A ValueError is raised if there are any duplicates.
+
+        >>> af = pd.DataFrame({"foo": ['one', 'one', 'two', 'two'],
+        ...                    "bar": ['A', 'A', 'B', 'C'],
+        ...                    "baz": [1, 2, 3, 4]})
+        >>> af
+           foo bar  baz
+        0  one   A    1
+        1  one   A    2
+        2  two   B    3
+        3  two   C    4
+
+        Notice that the first two rows are the same for our `index`
+        and `columns` arguments.
+
+        >>> af.pivot(index='foo', columns='bar', values='baz')
+        Traceback (most recent call last):
+           ...
+        ValueError: Index contains duplicate entries, cannot reshape
         """
         from pandas.core.reshape.reshape import pivot
         return pivot(self, index=index, columns=columns, values=values)

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -4341,22 +4341,22 @@ class DataFrame(NDFrame):
 
     def pivot(self, index=None, columns=None, values=None):
         """
-        Return reshaped DataFrame summarized by given index / column values.
+        Return reshaped DataFrame organized by given index / column values.
 
         Reshape data (produce a "pivot" table) based on column values. Uses
-        unique values from index / columns to form axes of the resulting
+        unique values from specified `index` / `columns` to form axes of the resulting
         DataFrame. This function does not support data aggregation, multiple
         values will result in hierarchically indexed columns.
 
         Parameters
         ----------
         index : string or object, optional
-            Column name to use to make new frame's index. If None, uses
+            Column to use to make new frame's index. If None, uses
             existing index.
-        columns : string or object, optional
-            Column name to use to make new frame's columns.
+        columns : string or object
+            Column to use to make new frame's columns.
         values : string or object, optional
-            Column name to use for populating new frame's values. If not
+            Column to use for populating new frame's values. If not
             specified, all remaining columns will be used and the result will
             have hierarchically indexed columns.
 
@@ -4368,14 +4368,14 @@ class DataFrame(NDFrame):
         See Also
         --------
         DataFrame.pivot_table : generalization of pivot that can handle
-            duplicate values for one index/column pair
+            duplicate values for one index/column pair.
         DataFrame.unstack : pivot based on the index values instead of a
-            column
+            column.
 
         Notes
         -----
         For finer-tuned control, see hierarchical indexing documentation along
-        with the related stack/unstack methods
+        with the related stack/unstack methods.
 
         Examples
         --------


### PR DESCRIPTION
Checklist for the pandas documentation sprint (ignore this if you are doing
an unrelated PR):

- [x] PR title is "DOC: update the <your-function-or-method> docstring"
- [x] The validation script passes: `scripts/validate_docstrings.py <your-function-or-method>`
- [x] The PEP8 style check passes: `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] The html version looks good: `python doc/make.py --single <your-function-or-method>`
- [x] It has been proofread on language by another sprint participant

Please include the output of the validation script below between the "```" ticks:

```
################################################################################
###################### Docstring (pandas.DataFrame.pivot) ######################
################################################################################

Return reshaped DataFrame summarized by given index / column values.

Reshape data (produce a "pivot" table) based on column values. Uses
unique values from index / columns to form axes of the resulting
DataFrame. This function does not support data aggregation, multiple
values will result in hierarchically indexed columns.

Parameters
----------
index : string or object, optional
    Column name to use to make new frame's index. If None, uses
    existing index.
columns : string or object, optional
    Column name to use to make new frame's columns.
values : string or object, optional
    Column name to use for populating new frame's values. If not
    specified, all remaining columns will be used and the result will
    have hierarchically indexed columns.

Returns
-------
DataFrame
    Returns reshaped DataFrame.

See Also
--------
DataFrame.pivot_table : generalization of pivot that can handle
    duplicate values for one index/column pair
DataFrame.unstack : pivot based on the index values instead of a
    column

Notes
-----
For finer-tuned control, see hierarchical indexing documentation along
with the related stack/unstack methods

Examples
--------

>>> df = pd.DataFrame({'foo': ['one','one','one','two','two','two'],
...                    'bar': ['A', 'B', 'C', 'A', 'B', 'C'],
...                    'baz': [1, 2, 3, 4, 5, 6]})
>>> df
    foo   bar  baz
0   one   A    1
1   one   B    2
2   one   C    3
3   two   A    4
4   two   B    5
5   two   C    6

>>> df.pivot(index='foo', columns='bar', values='baz')
bar  A   B   C
foo
one  1   2   3
two  4   5   6

>>> df.pivot(index='foo', columns='bar')['baz']
bar  A   B   C
foo
one  1   2   3
two  4   5   6

################################################################################
################################## Validation ##################################
################################################################################

Docstring for "pandas.DataFrame.pivot" correct. :)
```

If the validation script still gives errors, but you think there is a good reason
to deviate in this case (and there are certainly such cases), please state this
explicitly.
