### PR TITLE
DOC: update the docstring of pandas.DataFrame.from_dict

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -901,7 +901,7 @@ class DataFrame(NDFrame):
         columns : list, default None
             Column labels to use when ``orient='index'``. Raises a ValueError
             if used with ``orient='columns'``.
-            
+
             .. versionadded:: 0.23.0
 
         Returns
@@ -910,8 +910,8 @@ class DataFrame(NDFrame):
 
         See Also
         --------
-        pandas.DataFrame.from_records : DataFrame from ndarray (structured dtype),
-            list of tuples, dict, or DataFrame
+        pandas.DataFrame.from_records : DataFrame from ndarray (structured
+            dtype), list of tuples, dict, or DataFrame
         pandas.DataFrame: DataFrame object creation using constructor
 
         Examples

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -899,8 +899,8 @@ class DataFrame(NDFrame):
         dtype : dtype, default None
             Data type to force, otherwise infer.
         columns : list, default None
-            Column labels to use when orient='index'. Raises a ValueError
-            if used with orient='columns'.
+            Column labels to use when ``orient='index'``. Raises a ValueError
+            if used with ``orient='columns'``.
             .. versionadded:: 0.23.0
 
         See Also
@@ -915,6 +915,8 @@ class DataFrame(NDFrame):
 
         Examples
         --------
+        By default the keys of the dict become the DataFrame columns:
+
         >>> data = {'col_1': [3, 2, 1, 0], 'col_2': ['a', 'b', 'c', 'd']}
         >>> pd.DataFrame.from_dict(data)
            col_1 col_2
@@ -922,6 +924,9 @@ class DataFrame(NDFrame):
         1      2     b
         2      1     c
         3      0     d
+
+        Specify ``orient='index'`` to create the DataFrame using dictionary
+        keys as rows:
 
         >>> data = {'row_1': [3, 2, 1, 0], 'row_2': ['a', 'b', 'c', 'd']}
         >>> pd.DataFrame.from_dict(data, orient='index')

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -883,27 +883,51 @@ class DataFrame(NDFrame):
     @classmethod
     def from_dict(cls, data, orient='columns', dtype=None, columns=None):
         """
-        Construct DataFrame from dict of array-like or dicts
+        Construct DataFrame from dict of array-like or dicts.
+
+        Creates DataFrame object from dictionary by columns or by index
+        allowing dtype specification.
 
         Parameters
         ----------
         data : dict
-            {field : array-like} or {field : dict}
+            Of the form {field : array-like} or {field : dict}.
         orient : {'columns', 'index'}, default 'columns'
             The "orientation" of the data. If the keys of the passed dict
             should be the columns of the resulting DataFrame, pass 'columns'
             (default). Otherwise if the keys should be rows, pass 'index'.
         dtype : dtype, default None
-            Data type to force, otherwise infer
-        columns: list, default None
+            Data type to force, otherwise infer.
+        columns : list, default None
             Column labels to use when orient='index'. Raises a ValueError
-            if used with orient='columns'
-
+            if used with orient='columns'.
             .. versionadded:: 0.23.0
+
+        See Also
+        --------
+        pandas.DataFrame.from_records : DataFrame from ndarray (structured dtype),
+                                        list of tuples, dict, or DataFrame
+        pandas.DataFrame: DataFrame object creation using constructor
 
         Returns
         -------
-        DataFrame
+        pandas.DataFrame
+
+        Examples
+        --------
+        >>> data = {'col_1': [3, 2, 1, 0], 'col_2': ['a', 'b', 'c', 'd']}
+        >>> pd.DataFrame.from_dict(data)
+           col_1 col_2
+        0      3     a
+        1      2     b
+        2      1     c
+        3      0     d
+
+        >>> data = {'row_1': [3, 2, 1, 0], 'row_2': ['a', 'b', 'c', 'd']}
+        >>> pd.DataFrame.from_dict(data, orient='index')
+               0  1  2  3
+        row_1  3  2  1  0
+        row_2  a  b  c  d
         """
         index = None
         orient = orient.lower()

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -906,7 +906,7 @@ class DataFrame(NDFrame):
         See Also
         --------
         pandas.DataFrame.from_records : DataFrame from ndarray (structured dtype),
-                                        list of tuples, dict, or DataFrame
+            list of tuples, dict, or DataFrame
         pandas.DataFrame: DataFrame object creation using constructor
 
         Returns

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -910,9 +910,9 @@ class DataFrame(NDFrame):
 
         See Also
         --------
-        pandas.DataFrame.from_records : DataFrame from ndarray (structured
+        DataFrame.from_records : DataFrame from ndarray (structured
             dtype), list of tuples, dict, or DataFrame
-        pandas.DataFrame: DataFrame object creation using constructor
+        DataFrame : DataFrame object creation using constructor
 
         Examples
         --------
@@ -934,10 +934,10 @@ class DataFrame(NDFrame):
                0  1  2  3
         row_1  3  2  1  0
         row_2  a  b  c  d
-        
+
         When using the 'index' orientation, the column names can be
         specified manually:
-        
+
         >>> pd.DataFrame.from_dict(data, orient='index',
         ...                        columns=['A', 'B', 'C', 'D'])
                A  B  C  D

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -904,15 +904,15 @@ class DataFrame(NDFrame):
             
             .. versionadded:: 0.23.0
 
+        Returns
+        -------
+        pandas.DataFrame
+
         See Also
         --------
         pandas.DataFrame.from_records : DataFrame from ndarray (structured dtype),
             list of tuples, dict, or DataFrame
         pandas.DataFrame: DataFrame object creation using constructor
-
-        Returns
-        -------
-        pandas.DataFrame
 
         Examples
         --------
@@ -932,6 +932,15 @@ class DataFrame(NDFrame):
         >>> data = {'row_1': [3, 2, 1, 0], 'row_2': ['a', 'b', 'c', 'd']}
         >>> pd.DataFrame.from_dict(data, orient='index')
                0  1  2  3
+        row_1  3  2  1  0
+        row_2  a  b  c  d
+        
+        When using the 'index' orientation, the column names can be
+        specified manually:
+        
+        >>> pd.DataFrame.from_dict(data, orient='index',
+        ...                        columns=['A', 'B', 'C', 'D'])
+               A  B  C  D
         row_1  3  2  1  0
         row_2  a  b  c  d
         """

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -901,6 +901,7 @@ class DataFrame(NDFrame):
         columns : list, default None
             Column labels to use when ``orient='index'``. Raises a ValueError
             if used with ``orient='columns'``.
+            
             .. versionadded:: 0.23.0
 
         See Also


### PR DESCRIPTION
Checklist for the pandas documentation sprint (ignore this if you are doing
an unrelated PR):

- [x] PR title is "DOC: update the <your-function-or-method> docstring"
- [x] The validation script passes: `scripts/validate_docstrings.py <your-function-or-method>`
- [x] The PEP8 style check passes: `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] The html version looks good: `python doc/make.py --single <your-function-or-method>`
- [ ] It has been proofread on language by another sprint participant

Please include the output of the validation script below between the "```" ticks:

```
(pandas_dev) david@david-TM1604:~/repos/pandas$ python scripts/validate_docstrings.py pandas.DataFrame.from_dict

################################################################################
#################### Docstring (pandas.DataFrame.from_dict) ####################
################################################################################

Construct DataFrame from dict of array-like or dicts.

Creates DataFrame object from dictionary by columns or by index
allowing dtype specification.

Parameters
----------
data : dict
    Of the form {field : array-like} or {field : dict}.
orient : {'columns', 'index'}, default 'columns'
    The "orientation" of the data. If the keys of the passed dict
    should be the columns of the resulting DataFrame, pass 'columns'
    (default). Otherwise if the keys should be rows, pass 'index'.
dtype : dtype, default None
    Data type to force, otherwise infer.
columns : list, default None
    Column labels to use when orient='index'. Raises a ValueError
    if used with orient='columns'.
    .. versionadded:: 0.23.0

See Also
--------
pandas.DataFrame.from_records : DataFrame from ndarray (structured dtype),
                                list of tuples, dict, or DataFrame
pandas.DataFrame: DataFrame object creation using constructor

Returns
-------
pandas.DataFrame

Examples
--------
>>> data = {'col_1': [3, 2, 1, 0], 'col_2': ['a', 'b', 'c', 'd']}
>>> pd.DataFrame.from_dict(data)
   col_1 col_2
0      3     a
1      2     b
2      1     c
3      0     d

>>> data = {'row_1': [3, 2, 1, 0], 'row_2': ['a', 'b', 'c', 'd']}
>>> pd.DataFrame.from_dict(data, orient='index')
       0  1  2  3
row_1  3  2  1  0
row_2  a  b  c  d

################################################################################
################################## Validation ##################################
################################################################################

Errors found:
	Errors in parameters section
		Parameter "columns" description should finish with "."
```

If the validation script still gives errors, but you think there is a good reason
to deviate in this case (and there are certainly such cases), please state this
explicitly.


Checklist for other PRs (remove this part if you are doing a PR for the pandas documentation sprint):

- [ ] closes #xxxx
- [ ] tests added / passed
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
