### PR TITLE
DOC: Improve the docstring of pandas.core.window.Rolling.median

### DIFF
--- a/pandas/core/window.py
+++ b/pandas/core/window.py
@@ -861,7 +861,7 @@ class _Rolling_and_Expanding(_Rolling):
     -------
     Series or DataFrame
         Returned object type is determined by the caller of the %(name)s
-        calculation
+        object.
 
     See Also
     --------

--- a/pandas/core/window.py
+++ b/pandas/core/window.py
@@ -872,12 +872,9 @@ class _Rolling_and_Expanding(_Rolling):
 
     Examples
     --------
-    The below example will show a rolling calculation with a window size of
-    three.
+    Compute the rolling mean of a series with a window size of 3.
 
-    >>> import pandas as pd
-    >>> import numpy as np
-    >>> s = pd.Series(np.arange(5))
+    >>> s = pd.Series([0, 1, 2, 3, 4])
     >>> s.rolling(3).median()
     0    NaN
     1    NaN

--- a/pandas/core/window.py
+++ b/pandas/core/window.py
@@ -872,7 +872,7 @@ class _Rolling_and_Expanding(_Rolling):
 
     Examples
     --------
-    Compute the rolling mean of a series with a window size of 3.
+    Compute the rolling median of a series with a window size of 3.
 
     >>> s = pd.Series([0, 1, 2, 3, 4])
     >>> s.rolling(3).median()

--- a/pandas/core/window.py
+++ b/pandas/core/window.py
@@ -850,7 +850,50 @@ class _Rolling_and_Expanding(_Rolling):
         return self._apply('roll_mean', 'mean', **kwargs)
 
     _shared_docs['median'] = dedent("""
-    %(name)s median
+    Calculate the %(name)s median.
+
+    Parameters
+    ----------
+    **kwargs
+        Under Review.
+
+    Returns
+    -------
+    Series or DataFrame
+        Returned object type is determined by the caller of the %(name)s
+        calculation
+
+    See Also
+    --------
+    Series.%(name)s : Calling object with Series data
+    DataFrame.%(name)s : Calling object with DataFrames
+    Series.median : Equivalent method for Series
+    DataFrame.median : Equivalent method for DataFrame
+
+    Examples
+    --------
+    The below example will show a rolling calculation with a window size of
+    three.
+
+    >>> import pandas as pd
+    >>> import numpy as np
+
+    >>> df = pd.DataFrame({
+    ...     'a': np.random.randn(10)
+    ... })
+
+    >>> df.rolling(3).median()
+        a
+    0 	NaN
+    1 	NaN
+    2 	0.447664
+    3 	0.896537
+    4 	0.896537
+    5 	0.896537
+    6 	0.387809
+    7 	-0.067098
+    8 	-0.209795
+    9 	-0.618871
     """)
 
     def median(self, **kwargs):

--- a/pandas/core/window.py
+++ b/pandas/core/window.py
@@ -861,7 +861,7 @@ class _Rolling_and_Expanding(_Rolling):
     Returns
     -------
     Series or DataFrame
-        Returned type the same as the caller.
+        Returned type is the same as the original object.
 
     See Also
     --------

--- a/pandas/core/window.py
+++ b/pandas/core/window.py
@@ -855,13 +855,13 @@ class _Rolling_and_Expanding(_Rolling):
     Parameters
     ----------
     **kwargs
-        Under Review.
+        For compatibility with other %(name)s methods. Has no effect
+        on the computed median.
 
     Returns
     -------
     Series or DataFrame
-        Returned object type is determined by the caller of the %(name)s
-        object.
+        Returned type the same as the caller.
 
     See Also
     --------

--- a/pandas/core/window.py
+++ b/pandas/core/window.py
@@ -878,22 +878,15 @@ class _Rolling_and_Expanding(_Rolling):
     >>> import pandas as pd
     >>> import numpy as np
 
-    >>> df = pd.DataFrame({
-    ...     'a': np.random.randn(10)
-    ... })
+    >>> s = pd.Series(np.arange(5))
 
-    >>> df.rolling(3).median()
-        a
-    0 	NaN
-    1 	NaN
-    2 	0.447664
-    3 	0.896537
-    4 	0.896537
-    5 	0.896537
-    6 	0.387809
-    7 	-0.067098
-    8 	-0.209795
-    9 	-0.618871
+    >>> s.rolling(3).median()
+    0    NaN
+    1    NaN
+    2    1.0
+    3    2.0
+    4    3.0
+    dtype: float64
     """)
 
     def median(self, **kwargs):

--- a/pandas/core/window.py
+++ b/pandas/core/window.py
@@ -877,9 +877,7 @@ class _Rolling_and_Expanding(_Rolling):
 
     >>> import pandas as pd
     >>> import numpy as np
-
     >>> s = pd.Series(np.arange(5))
-
     >>> s.rolling(3).median()
     0    NaN
     1    NaN
@@ -1280,7 +1278,6 @@ class Rolling(_Rolling_and_Expanding):
         return super(Rolling, self).mean(*args, **kwargs)
 
     @Substitution(name='rolling')
-    @Appender(_doc_template)
     @Appender(_shared_docs['median'])
     def median(self, **kwargs):
         return super(Rolling, self).median(**kwargs)
@@ -1519,7 +1516,6 @@ class Expanding(_Rolling_and_Expanding):
         return super(Expanding, self).mean(*args, **kwargs)
 
     @Substitution(name='expanding')
-    @Appender(_doc_template)
     @Appender(_shared_docs['median'])
     def median(self, **kwargs):
         return super(Expanding, self).median(**kwargs)


### PR DESCRIPTION
Checklist for the pandas documentation sprint (ignore this if you are doing
an unrelated PR):

- [x] PR title is "DOC: update the <your-function-or-method> docstring"
- [x] The validation script passes: `scripts/validate_docstrings.py <your-function-or-method>`
- [x] The PEP8 style check passes: `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] The html version looks good: `python doc/make.py --single <your-function-or-method>`
- [x] It has been proofread on language by another sprint participant

Please include the output of the validation script below between the "```" ticks:

```
# paste output of "scripts/validate_docstrings.py <your-function-or-method>" here
# between the "```" (remove this comment, but keep the "```")

```
Errors found:
        No extended summary found
        Errors in parameters section
                Parameters {'kwargs'} not documented
                Unknown parameters {'**kwargs'}
                Parameter "**kwargs" has no type

If the validation script still gives errors, but you think there is a good reason
to deviate in this case (and there are certainly such cases), please state this
explicitly.

Median is pretty straightforward. Maybe an extended summary is not really necessary? Kwargs needs further review.