### PR TITLE
DOC: Update pandas.Series.copy docstring

### DIFF
--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -4508,21 +4508,21 @@ class NDFrame(PandasObject, SelectionMixin):
         """
         Make a copy of this object's indices and data.
 
-        When `deep=True` (default), a new object will be created with a
+        When ``deep=True`` (default), a new object will be created with a
         copy of the calling object's data and indices. Modifications to
         the data or indices of the copy will not be reflected in the
         original object (see notes below).
 
-        When `deep=False`, a new object will be created without copying
+        When ``deep=False``, a new object will be created without copying
         the calling object's data or index (only references to the data
         and index are copied). Any changes to the data of the original
         will be reflected in the shallow copy (and vice versa).
 
         Parameters
         ----------
-        deep : boolean or str, default `True`
+        deep : bool, default True
             Make a deep copy, including a copy of the data and the indices.
-            With `deep=False` neither the indices nor the data are copied.
+            With ``deep=False`` neither the indices nor the data are copied.
 
         Returns
         -------

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -4516,8 +4516,7 @@ class NDFrame(PandasObject, SelectionMixin):
         When `deep=False`, a new object will be created without copying
         the calling object's data or index (only references to the data
         and index are copied). Any changes to the data of the original
-        will be reflected in the shallow copy (and vice versa). Changes
-        to the index will result in a new index as indices are immutable.
+        will be reflected in the shallow copy (and vice versa).
 
         Parameters
         ----------
@@ -4532,10 +4531,15 @@ class NDFrame(PandasObject, SelectionMixin):
 
         Notes
         -----
-        When `deep=True`, data is copied but actual Python objects
+        When ``deep=True``, data is copied but actual Python objects
         will not be copied recursively, only the reference to the object.
         This is in contrast to `copy.deepcopy` in the Standard Library,
         which recursively copies object data (see examples below).
+
+        While ``Index`` objects are copied when ``deep=True``, the underlying
+        numpy array is not copied for performance reasons. Since ``Index`` is
+        immutable, the underlying data can be safely shared and a copy
+        is not needed.
 
         Examples
         --------
@@ -4589,9 +4593,9 @@ class NDFrame(PandasObject, SelectionMixin):
         b    2
         dtype: int64
 
-        When copying an object containing Python objects, a deep copy will
-        copy the data, but will not do so recursively. Updating a nested data
-        object will be reflected in the deep copy.
+        Note that when copying an object containing Python objects, a deep copy
+        will copy the data, but will not do so recursively. Updating a nested
+        data object will be reflected in the deep copy.
 
         >>> s = pd.Series([[1, 2], [3, 4]])
         >>> deep = s.copy()

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -4506,61 +4506,60 @@ class NDFrame(PandasObject, SelectionMixin):
 
     def copy(self, deep=True):
         """
-        Make a copy of this objects indices and data.
+        Make a copy of this object's indices and data.
 
-        Deep copy (default) will create a new object with a copy of the objects
-        data and indices. Modifications to the data or indices of the copy
-        will not be reflected in the original object.
+        When `deep=True` (default), a new object will be created with a
+        copy of the calling object's data and indices. Modifications to
+        the data or indices of the copy will not be reflected in the
+        original object (see notes below).
 
-        Shallow copy (``deep=False``) will create a new object without copying
-        the data or indices. Any changes to the index or data of the original
-        will be reflected in the shallow copy (and vice versa).
+        When `deep=False`, a new object will be created without copying
+        the calling object's data (only a reference to the data is
+        copied). Any changes to the data of the original will be reflected
+        in the shallow copy (and vice versa).
 
         Parameters
         ----------
         deep : boolean or string, default True
             Make a deep copy, including a copy of the data and the indices.
-            With ``deep=False`` neither the indices or the data are copied.
-
-            Note that when ``deep=True`` data is copied, actual python objects
-            will not be copied recursively, only the reference to the object.
-            This is in contrast to ``copy.deepcopy`` in the Standard Library,
-            which recursively copies object data.
+            With `deep=False` neither the indices or the data are copied.
 
         Returns
         -------
         copy : type of caller
 
+        Notes
+        -----
+        When `deep=True`, data is copied but actual python objects
+        will not be copied recursively, only the reference to the object.
+        This is in contrast to `copy.deepcopy` in the Standard Library,
+        which recursively copies object data.  (See examples below).
+
         Examples
         --------
-        >>> s = pd.Series([1,2], dtype="int32", index=["a", "b"])
+        >>> s = pd.Series([1, 2], index=["a", "b"])
         >>> s
         a    1
         b    2
-        dtype: int32
+        dtype: int64
         >>> s_copy = s.copy()
         >>> s_copy
         a    1
         b    2
-        dtype: int32
+        dtype: int64
 
         Shallow copy versus default (deep) copy:
 
-        In a shallow copy the index and data is a reference to the original
-        objects'.
+        In a shallow copy, the data is shared with the original object.
 
-        >>> s = pd.Series([1,2], dtype="int32", index=["a", "b"])
+        >>> s = pd.Series([1,2], index=["a", "b"])
         >>> deep_copy = s.copy()
         >>> shallow_copy = s.copy(deep=False)
         >>> id(s) == id(shallow_copy)
         False
-        >>> id(s.index) == id(shallow_copy.index)
-        True
         >>> id(s.values) == id(shallow_copy.values)
         True
         >>> id(s) == id(deep_copy)
-        False
-        >>> id(s.index) == id(deep_copy.index)
         False
         >>> id(s.values) == id(deep_copy.values)
         False
@@ -4568,58 +4567,43 @@ class NDFrame(PandasObject, SelectionMixin):
         >>> s
         a    3
         b    2
-        dtype: int32
+        dtype: int64
         >>> shallow_copy
         a    3
         b    2
-        dtype: int32
+        dtype: int64
         >>> deep_copy
         a    1
         b    2
-        dtype: int32
+        dtype: int64
         >>> shallow_copy[0] = 4
         >>> s
         a    4
         b    2
-        dtype: int32
+        dtype: int64
         >>> shallow_copy
         a    4
         b    2
-        dtype: int32
+        dtype: int64
         >>> deep_copy
         a    1
         b    2
-        dtype: int32
+        dtype: int64
 
-        When copying object containing python objects, deep copy will
-        copy the indices and data but will not do so recursively.
+        When copying an object containing python objects, deep copy will
+        copy the data, but will not do so recursively.
 
-        >>> class Point(object):
-        ...     def __init__(self, x, y):
-        ...         self.x = x
-        ...         self.y = y
-        ...     def __repr__(self):
-        ...         return "Point(%d,%d)" % (self.x, self.y)
-        ...
-        >>> p1 = Point(0, 1)
-        >>> s = pd.Series([p1], dtype="object")
-        >>> s
-        0    Point(0,1)
-        dtype: object
+        >>> s = pd.Series([[1, 2], [3, 4]])
         >>> s_copy = s.copy()
-        >>> s_copy
-        0    Point(0,1)
-        dtype: object
-        >>> id(s[0]) == id(s_copy[0])
-        True
-        >>> p1.x = 1
+        >>> s[0][0] = 10
         >>> s
-        0    Point(1,1)
+        0    [10, 2]
+        1     [3, 4]
         dtype: object
         >>> s_copy
-        0    Point(1,1)
+        0    [10, 2]
+        1     [3, 4]
         dtype: object
-        >>>
 
         For deep-copying python objects, the following can be used:
 

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -4527,7 +4527,7 @@ class NDFrame(PandasObject, SelectionMixin):
 
         Returns
         -------
-        copy : type of caller
+        copy : Series, DataFrame or Panel
             Object type matches caller.
 
         Notes


### PR DESCRIPTION
Closes https://github.com/pandas-dev/pandas/issues/19505

- Add extended summary
- Add examples

Checklist for the pandas documentation sprint (ignore this if you are doing
an unrelated PR):

- [X] PR title is "DOC: update the <your-function-or-method> docstring"
- [X] The validation script passes: `scripts/validate_docstrings.py <your-function-or-method>`
- [X] The PEP8 style check passes: `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [X] The html version looks good: `python doc/make.py --single <your-function-or-method>`
- [X] It has been proofread on language by another sprint participant

Please include the output of the validation script below between the "```" ticks:

```

################################################################################
######################## Docstring (pandas.Series.copy) ########################
################################################################################

Make a copy of this objects indices and data.

Deep copy (default) will create a new object with a copy of the objects
data and indices. Modifications to the data or indices of the copy
will not be reflected in the original object.

Shallow copy (``deep=False``) will create a new object without copying
the data or indices. Any changes to the index or data of the original
will be reflected in the shallow copy (and vice versa).

Parameters
----------
deep : boolean or string, default True
    Make a deep copy, including a copy of the data and the indices.
    With ``deep=False`` neither the indices or the data are copied.

    Note that when ``deep=True`` data is copied, actual python objects
    will not be copied recursively, only the reference to the object.
    This is in contrast to ``copy.deepcopy`` in the Standard Library,
    which recursively copies object data.

Returns
-------
copy : type of caller

Examples
--------
>>> s = pd.Series([1,2], dtype="int32", index=["a", "b"])
>>> s
a    1
b    2
dtype: int32
>>> s_copy = s.copy()
>>> s_copy
a    1
b    2
dtype: int32

Shallow copy versus default (deep) copy:

In a shallow copy the index and data is a reference to the original
objects'.

>>> s = pd.Series([1,2], dtype="int32", index=["a", "b"])
>>> deep_copy = s.copy()
>>> shallow_copy = s.copy(deep=False)
>>> id(s) == id(shallow_copy)
False
>>> id(s.index) == id(shallow_copy.index)
True
>>> id(s.values) == id(shallow_copy.values)
True
>>> id(s) == id(deep_copy)
False
>>> id(s.index) == id(deep_copy.index)
False
>>> id(s.values) == id(deep_copy.values)
False
>>> s[0] = 3
>>> s
a    3
b    2
dtype: int32
>>> shallow_copy
a    3
b    2
dtype: int32
>>> deep_copy
a    1
b    2
dtype: int32
>>> shallow_copy[0] = 4
>>> s
a    4
b    2
dtype: int32
>>> shallow_copy
a    4
b    2
dtype: int32
>>> deep_copy
a    1
b    2
dtype: int32

When copying object containing python objects, deep copy will
copy the indices and data but will not do so recursively.

>>> class Point(object):
...     def __init__(self, x, y):
...         self.x = x
...         self.y = y
...     def __repr__(self):
...         return "Point(%d,%d)" % (self.x, self.y)
...
>>> p1 = Point(0, 1)
>>> s = pd.Series([p1], dtype="object")
>>> s
0    Point(0,1)
dtype: object
>>> s_copy = s.copy()
>>> s_copy
0    Point(0,1)
dtype: object
>>> id(s[0]) == id(s_copy[0])
True
>>> p1.x = 1
>>> s
0    Point(1,1)
dtype: object
>>> s_copy
0    Point(1,1)
dtype: object
>>>

For deep-copying python objects, the following can be used:

>>> import copy
>>> deep_deep_copy = pd.Series(copy.deepcopy(s.values),
...                            index=copy.deepcopy(s.index))

################################################################################
################################## Validation ##################################
################################################################################

Errors found:
        See Also section not found

```

If the validation script still gives errors, but you think there is a good reason
to deviate in this case (and there are certainly such cases), please state this
explicitly.

Not sure if anything should be added to the See Also section