### PR TITLE
DOC" update the Pandas core window rolling count docstring"

### DIFF
--- a/pandas/core/window.py
+++ b/pandas/core/window.py
@@ -781,17 +781,19 @@ class _Rolling(_Window):
 class _Rolling_and_Expanding(_Rolling):
 
     _shared_docs['count'] = dedent(r"""
-    The %(name)s count of any non-Nan observations inside the window.
+    The %(name)s count of any non-NaN observations inside the window.
 
     Returns
     -------
-    Returned object type is determined by the caller of the %(name)s
-    calculation.
+    Series or DataFrame
+        Returned object type is determined by the caller of the %(name)s
+        calculation.
 
     See Also
     --------
     pandas.Series.%(name)s : Calling object with Series data
     pandas.DataFrame.%(name)s : Calling object with DataFrames
+    pandas.DataFrame.count : Count of the full DataFrame
 
     Examples
     --------
@@ -1475,7 +1477,6 @@ class Expanding(_Rolling_and_Expanding):
     agg = aggregate
 
     @Substitution(name='expanding')
-    @Appender(_doc_template)
     @Appender(_shared_docs['count'])
     def count(self, **kwargs):
         return super(Expanding, self).count(**kwargs)

--- a/pandas/core/window.py
+++ b/pandas/core/window.py
@@ -781,17 +781,17 @@ class _Rolling(_Window):
 class _Rolling_and_Expanding(_Rolling):
 
     _shared_docs['count'] = dedent(r"""
-    The %(name)'s count of any non-Nan values inside the window.  
+    The %(name)s count of any non-Nan observations inside the window.
 
     Returns
     -------
-    Series or Dataframe
-        Returned object type is determined by the caller of %(name)
+    Returned object type is determined by the caller of the %(name)s
+    calculation.
 
     See Also
     --------
-    pandas.Series.%(name)
-    pandas.DataFrame.%(name)
+    pandas.Series.%(name)s : Calling object with Series data
+    pandas.DataFrame.%(name)s : Calling object with DataFrames
 
     Examples
     --------

--- a/pandas/core/window.py
+++ b/pandas/core/window.py
@@ -781,21 +781,21 @@ class _Rolling(_Window):
 class _Rolling_and_Expanding(_Rolling):
 
     _shared_docs['count'] = dedent(r"""
-    The %(name)s sum if it is a non-Nan value inside the window.
+    The %(name)'s count of any non-Nan values inside the window.  
 
     Returns
     -------
-    Returns the object type with the sum of the window values
-    in the current row.
+    Series or Dataframe
+        Returned object type is determined by the caller of %(name)
 
     See Also
     --------
-    Series.%(name)s : Calling object with Series data
-    DataFrame.%(name)s : Calling object with DataFrames
+    pandas.Series.%(name)s
+    pandas.DataFrame.%(name)s
 
     Examples
     --------
-    >>> s = pd.Series([2, 3, np.nan, 'values'])
+    >>> s = pd.Series([2, 3, np.nan, 10])
     >>> s.rolling(2).count()
     0    1.0
     1    2.0

--- a/pandas/core/window.py
+++ b/pandas/core/window.py
@@ -790,8 +790,8 @@ class _Rolling_and_Expanding(_Rolling):
 
     See Also
     --------
-    pandas.Series.%(name)s
-    pandas.DataFrame.%(name)s
+    pandas.Series.%(name)
+    pandas.DataFrame.%(name)
 
     Examples
     --------

--- a/pandas/core/window.py
+++ b/pandas/core/window.py
@@ -780,9 +780,41 @@ class _Rolling(_Window):
 
 class _Rolling_and_Expanding(_Rolling):
 
-    _shared_docs['count'] = """%(name)s count of number of non-NaN
-    observations inside provided window."""
 
+    _shared_docs['count'] = dedent(r"""
+    The %(name)s sum if it is a non-Nan value inside the window.
+
+    Returns
+    -------
+    Returns the object type with the sum of the window values in the current row.
+
+    See Also
+    --------
+    Series.%(name)s : Calling object with Series data
+    DataFrame.%(name)s : Calling object with DataFrames 
+
+    Examples
+    -------- 
+    >>> s = pd.Series([2, 3, np.nan, 'values'])
+    >>> s.rolling(2).count()
+    0    1.0
+    1    2.0
+    2    1.0
+    3    1.0
+    dtype: float64
+    >>> s.rolling(3).count()
+    0    1.0
+    1    2.0
+    2    2.0
+    3    2.0
+    dtype: float64
+    >>> s.rolling(4).count()
+    0    1.0
+    1    2.0
+    2    2.0
+    3    3.0
+    dtype: float64
+    """)
     def count(self):
 
         blocks, obj, index = self._create_blocks()
@@ -1199,7 +1231,6 @@ class Rolling(_Rolling_and_Expanding):
     agg = aggregate
 
     @Substitution(name='rolling')
-    @Appender(_doc_template)
     @Appender(_shared_docs['count'])
     def count(self):
 

--- a/pandas/core/window.py
+++ b/pandas/core/window.py
@@ -780,21 +780,21 @@ class _Rolling(_Window):
 
 class _Rolling_and_Expanding(_Rolling):
 
-
     _shared_docs['count'] = dedent(r"""
     The %(name)s sum if it is a non-Nan value inside the window.
 
     Returns
     -------
-    Returns the object type with the sum of the window values in the current row.
+    Returns the object type with the sum of the window values
+    in the current row.
 
     See Also
     --------
     Series.%(name)s : Calling object with Series data
-    DataFrame.%(name)s : Calling object with DataFrames 
+    DataFrame.%(name)s : Calling object with DataFrames
 
     Examples
-    -------- 
+    --------
     >>> s = pd.Series([2, 3, np.nan, 'values'])
     >>> s.rolling(2).count()
     0    1.0
@@ -815,6 +815,7 @@ class _Rolling_and_Expanding(_Rolling):
     3    3.0
     dtype: float64
     """)
+
     def count(self):
 
         blocks, obj, index = self._create_blocks()


### PR DESCRIPTION
Checklist for the pandas documentation sprint (ignore this if you are doing
an unrelated PR):

- [ ] PR title is "DOC: update the <your-function-or-method> docstring"
- [ ] The validation script passes: `scripts/validate_docstrings.py <your-function-or-method>`
- [ ] The PEP8 style check passes: `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] The html version looks good: `python doc/make.py --single <your-function-or-method>`
- [ ] It has been proofread on language by another sprint participant

Please include the output of the validation script below between the "```" ticks:

```
################################################################################
################# Docstring (pandas.core.window.Rolling.count) #################
################################################################################

The rolling sum if it is a non-Nan value inside the window.

Returns
-------
Returns the object type with the sum of the window values
in the current row.

See Also
--------
Series.rolling : Calling object with Series data
DataFrame.rolling : Calling object with DataFrames

Examples
--------
>>> s = pd.Series([2, 3, np.nan, 'values'])
>>> s.rolling(2).count()
0    1.0
1    2.0
2    1.0
3    1.0
dtype: float64
>>> s.rolling(3).count()
0    1.0
1    2.0
2    2.0
3    2.0
dtype: float64
>>> s.rolling(4).count()
0    1.0
1    2.0
2    2.0
3    3.0
dtype: float64

################################################################################
################################## Validation ##################################
################################################################################

Errors found:
	No extended summary found

```

If the validation script still gives errors, but you think there is a good reason
to deviate in this case (and there are certainly such cases), please state this
explicitly.


Checklist for other PRs (remove this part if you are doing a PR for the pandas documentation sprint):

- [ ] closes #xxxx
- [ ] tests added / passed
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
