### PR TITLE
DOC: update the pandas.core.window.x.mean docstring

### DIFF
--- a/pandas/core/window.py
+++ b/pandas/core/window.py
@@ -323,7 +323,47 @@ class _Window(PandasObject, SelectionMixin):
     %(name)s sum""")
 
     _shared_docs['mean'] = dedent("""
-    %(name)s mean""")
+    Calculate the %(name)s mean of the values.
+
+    Parameters
+    ----------
+    *args
+        Under Review.
+    **kwargs
+        Under Review.
+
+    Returns
+    -------
+    Series or DataFrame
+        Returned object type is determined by the caller of the %(name)s
+        calculation.
+
+    See Also
+    --------
+    Series.%(name)s : Calling object with Series data
+    DataFrame.%(name)s : Calling object with DataFrames
+    Series.mean : Equivalent method for Series
+    DataFrame.mean : Equivalent method for DataFrame
+
+    Examples
+    --------
+    The below example will show rolling mean calculations with window sizes of
+    two and three, respectively.
+
+    >>> s = pd.Series([1, 2, 3, 4])
+    >>> s.rolling(2).mean()
+    0    NaN
+    1    1.5
+    2    2.5
+    3    3.5
+    dtype: float64
+    >>> s.rolling(3).mean()
+    0    NaN
+    1    NaN
+    2    2.0
+    3    3.0
+    dtype: float64
+    """)
 
 
 class Window(_Window):
@@ -646,7 +686,6 @@ class Window(_Window):
         return self._apply_window(mean=False, **kwargs)
 
     @Substitution(name='window')
-    @Appender(_doc_template)
     @Appender(_shared_docs['mean'])
     def mean(self, *args, **kwargs):
         nv.validate_window_func('mean', args, kwargs)
@@ -1237,7 +1276,6 @@ class Rolling(_Rolling_and_Expanding):
         return super(Rolling, self).min(*args, **kwargs)
 
     @Substitution(name='rolling')
-    @Appender(_doc_template)
     @Appender(_shared_docs['mean'])
     def mean(self, *args, **kwargs):
         nv.validate_rolling_func('mean', args, kwargs)
@@ -1476,7 +1514,6 @@ class Expanding(_Rolling_and_Expanding):
         return super(Expanding, self).min(*args, **kwargs)
 
     @Substitution(name='expanding')
-    @Appender(_doc_template)
     @Appender(_shared_docs['mean'])
     def mean(self, *args, **kwargs):
         nv.validate_expanding_func('mean', args, kwargs)

--- a/pandas/core/window.py
+++ b/pandas/core/window.py
@@ -347,7 +347,7 @@ class _Window(PandasObject, SelectionMixin):
 
     Examples
     --------
-    The below example will show rolling mean calculations with window sizes of
+    The below examples will show rolling mean calculations with window sizes of
     two and three, respectively.
 
     >>> s = pd.Series([1, 2, 3, 4])
@@ -357,6 +357,7 @@ class _Window(PandasObject, SelectionMixin):
     2    2.5
     3    3.5
     dtype: float64
+    
     >>> s.rolling(3).mean()
     0    NaN
     1    NaN

--- a/pandas/core/window.py
+++ b/pandas/core/window.py
@@ -357,7 +357,7 @@ class _Window(PandasObject, SelectionMixin):
     2    2.5
     3    3.5
     dtype: float64
-    
+
     >>> s.rolling(3).mean()
     0    NaN
     1    NaN


### PR DESCRIPTION
Checklist for the pandas documentation sprint (ignore this if you are doing
an unrelated PR):

- [X] PR title is "DOC: update the <your-function-or-method> docstring"
- [X] The validation script passes: `scripts/validate_docstrings.py <your-function-or-method>`
- [X] The PEP8 style check passes: `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [X] The html version looks good: `python doc/make.py --single <your-function-or-method>`
- [X] It has been proofread on language by another sprint participant

Please include the output of the validation script below between the "```" ticks:

```
(pandas_dev) lilcrawford:pandas $ python scripts/validate_docstrings.py pandas.core.window.Window.mean

################################################################################
################## Docstring (pandas.core.window.Window.mean) ##################
################################################################################

Calculate the window mean of the values.

Parameters
----------
*args
    Under Review.
**kwargs
    Under Review.

Returns
-------
Series or DataFrame
    Returned object type is determined by the caller of the window
    calculation.

See Also
--------
Series.window : Calling object with Series data
DataFrame.window : Calling object with DataFrames
Series.mean : Equivalent method for Series
DataFrame.mean : Equivalent method for DataFrame

Examples
--------
The below example will show rolling mean calculations with window sizes of
two and three, respectively.

>>> s = pd.Series([1, 2, 3, 4])
>>> s.rolling(2).mean()
0    NaN
1    1.5
2    2.5
3    3.5
dtype: float64
>>> s.rolling(3).mean()
0    NaN
1    NaN
2    2.0
3    3.0
dtype: float64

################################################################################
################################## Validation ##################################
################################################################################

Errors found:
	No extended summary found
	Errors in parameters section
		Parameters {'args', 'kwargs'} not documented
		Unknown parameters {'**kwargs', '*args'}
		Parameter "*args" has no type
		Parameter "**kwargs" has no type

(pandas_dev) lilcrawford:pandas $ python scripts/validate_docstrings.py pandas.core.window.Rolling.mean

################################################################################
################# Docstring (pandas.core.window.Rolling.mean)  #################
################################################################################

Calculate the rolling mean of the values.

Parameters
----------
*args
    Under Review.
**kwargs
    Under Review.

Returns
-------
Series or DataFrame
    Returned object type is determined by the caller of the rolling
    calculation.

See Also
--------
Series.rolling : Calling object with Series data
DataFrame.rolling : Calling object with DataFrames
Series.mean : Equivalent method for Series
DataFrame.mean : Equivalent method for DataFrame

Examples
--------
The below example will show rolling mean calculations with window sizes of
two and three, respectively.

>>> s = pd.Series([1, 2, 3, 4])
>>> s.rolling(2).mean()
0    NaN
1    1.5
2    2.5
3    3.5
dtype: float64
>>> s.rolling(3).mean()
0    NaN
1    NaN
2    2.0
3    3.0
dtype: float64

################################################################################
################################## Validation ##################################
################################################################################

Errors found:
	No extended summary found
	Errors in parameters section
		Parameters {'args', 'kwargs'} not documented
		Unknown parameters {'**kwargs', '*args'}
		Parameter "*args" has no type
		Parameter "**kwargs" has no type

(pandas_dev) lilcrawford:pandas $ python scripts/validate_docstrings.py pandas.core.window.Expanding.mean

################################################################################
################ Docstring (pandas.core.window.Expanding.mean)  ################
################################################################################

Calculate the expanding mean of the values.

Parameters
----------
*args
    Under Review.
**kwargs
    Under Review.

Returns
-------
Series or DataFrame
    Returned object type is determined by the caller of the expanding
    calculation.

See Also
--------
Series.expanding : Calling object with Series data
DataFrame.expanding : Calling object with DataFrames
Series.mean : Equivalent method for Series
DataFrame.mean : Equivalent method for DataFrame

Examples
--------
The below example will show rolling mean calculations with window sizes of
two and three, respectively.

>>> s = pd.Series([1, 2, 3, 4])
>>> s.rolling(2).mean()
0    NaN
1    1.5
2    2.5
3    3.5
dtype: float64
>>> s.rolling(3).mean()
0    NaN
1    NaN
2    2.0
3    3.0
dtype: float64

################################################################################
################################## Validation ##################################
################################################################################

Errors found:
	No extended summary found
	Errors in parameters section
		Parameters {'args', 'kwargs'} not documented
		Unknown parameters {'**kwargs', '*args'}
		Parameter "*args" has no type
		Parameter "**kwargs" has no type
```

If the validation script still gives errors, but you think there is a good reason
to deviate in this case (and there are certainly such cases), please state this
explicitly.