### PR TITLE
DOC: update the pandas.DataFrame.replace docstring

### DIFF
--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -4957,7 +4957,7 @@ class NDFrame(PandasObject, SelectionMixin):
 
         See Also
         --------
-        %(klass)s.fillna : Fill `NaN` values
+        %(klass)s.fillna : Fill NA values
         %(klass)s.where : Replace values based on boolean condition
         Series.str.replace : Simple string replacement.
 

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -4953,7 +4953,8 @@ class NDFrame(PandasObject, SelectionMixin):
             .. versionchanged:: 0.23.0
                 Added to DataFrame.
         axis : None
-            Deprecated.
+            .. deprecated:: 0.13.0
+               Has no effect and will be removed.
 
         See Also
         --------

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -4867,34 +4867,33 @@ class NDFrame(PandasObject, SelectionMixin):
                            limit=limit, downcast=downcast)
 
     _shared_docs['replace'] = ("""
-        Replace values given in 'to_replace' with 'value'.
+        Replace values given in `to_replace` with `value`.
 
-        Values of the DataFrame or a Series are being replaced with
-        other values in a dynamic way. Instead of replacing values in a
-        specific cell (row/column combination), this method allows for more
-        flexibility with replacements. For instance, values can be replaced
-        by specifying lists of values and replacements separately or
-        with a dynamic set of inputs like dicts.
+        Values of the %(klass)s are replaced with other values dynamically.
+        This differs from updating with ``.loc`` or ``.iloc``, which require
+        you to specify a location to update with some value.
 
         Parameters
         ----------
         to_replace : str, regex, list, dict, Series, int, float, or None
+            How to find the values that will be replaced.
+
             * numeric, str or regex:
 
-                - numeric: numeric values equal to ``to_replace`` will be
-                  replaced with ``value``
-                - str: string exactly matching ``to_replace`` will be replaced
-                  with ``value``
-                - regex: regexs matching ``to_replace`` will be replaced with
-                  ``value``
+                - numeric: numeric values equal to `to_replace` will be
+                  replaced with `value`
+                - str: string exactly matching `to_replace` will be replaced
+                  with `value`
+                - regex: regexs matching `to_replace` will be replaced with
+                  `value`
 
             * list of str, regex, or numeric:
 
-                - First, if ``to_replace`` and ``value`` are both lists, they
+                - First, if `to_replace` and `value` are both lists, they
                   **must** be the same length.
                 - Second, if ``regex=True`` then all of the strings in **both**
                   lists will be interpreted as regexs otherwise they will match
-                  directly. This doesn't matter much for ``value`` since there
+                  directly. This doesn't matter much for `value` since there
                   are only a few possible substitution regexes you can use.
                 - str, regex and numeric rules apply as above.
 
@@ -4902,20 +4901,20 @@ class NDFrame(PandasObject, SelectionMixin):
 
                 - Dicts can be used to specify different replacement values
                   for different existing values. For example,
-                  {'a': 'b', 'y': 'z'} replaces the value 'a' with 'b' and
-                  'y' with 'z'. To use a dict in this way the ``value``
-                  parameter should be ``None``.
+                  ``{'a': 'b', 'y': 'z'}`` replaces the value 'a' with 'b' and
+                  'y' with 'z'. To use a dict in this way the `value`
+                  parameter should be `None`.
                 - For a DataFrame a dict can specify that different values
                   should be replaced in different columns. For example,
-                  {'a': 1, 'b': 'z'} looks for the value 1 in column 'a' and
-                  the value 'z' in column 'b' and replaces these values with
-                  whatever is specified in ``value``. The ``value`` parameter
+                  ``{'a': 1, 'b': 'z'}`` looks for the value 1 in column 'a'
+                  and the value 'z' in column 'b' and replaces these values
+                  with whatever is specified in `value`. The `value` parameter
                   should not be ``None`` in this case. You can treat this as a
                   special case of passing two lists except that you are
                   specifying the column to search in.
                 - For a DataFrame nested dictionaries, e.g.,
-                  {'a': {'b': np.nan}}, are read as follows: look in column
-                  'a' for the value 'b' and replace it with NaN. The ``value``
+                  ``{'a': {'b': np.nan}}``, are read as follows: look in column
+                  'a' for the value 'b' and replace it with NaN. The `value`
                   parameter should be ``None`` to use a nested dict in this
                   way. You can nest regular expressions as well. Note that
                   column names (the top-level dictionary keys in a nested
@@ -4923,14 +4922,14 @@ class NDFrame(PandasObject, SelectionMixin):
 
             * None:
 
-                - This means that the ``regex`` argument must be a string,
+                - This means that the `regex` argument must be a string,
                   compiled regular expression, or list, dict, ndarray or
-                  Series of such elements. If ``value`` is also ``None`` then
-                  this **must** be a nested dictionary or ``Series``.
+                  Series of such elements. If `value` is also ``None`` then
+                  this **must** be a nested dictionary or Series.
 
             See the examples section for examples of each of these.
         value : scalar, dict, list, str, regex, default None
-            Value to replace any values matching ``to_replace`` with.
+            Value to replace any values matching `to_replace` with.
             For a DataFrame a dict of values can be used to specify which
             value to use for each column (columns not in the dict will not be
             filled). Regular expressions, strings and lists or dicts of such
@@ -4941,15 +4940,15 @@ class NDFrame(PandasObject, SelectionMixin):
             Returns the caller if this is True.
         limit : int, default None
             Maximum size gap to forward or backward fill.
-        regex : bool or same types as ``to_replace``, default False
-            Whether to interpret ``to_replace`` and/or ``value`` as regular
-            expressions. If this is ``True`` then ``to_replace`` *must* be a
+        regex : bool or same types as `to_replace`, default False
+            Whether to interpret `to_replace` and/or `value` as regular
+            expressions. If this is ``True`` then `to_replace` *must* be a
             string. Alternatively, this could be a regular expression or a
             list, dict, or array of regular expressions in which case
-            ``to_replace`` must be ``None``.
+            `to_replace` must be ``None``.
         method : {'pad', 'ffill', 'bfill', `None`}
-            The method to use when for replacement, when ``to_replace`` is a
-            scalar, list or tuple and ``value`` is `None`.
+            The method to use when for replacement, when `to_replace` is a
+            scalar, list or tuple and `value` is ``None``.
 
             .. versionchanged:: 0.23.0
                 Added to DataFrame.
@@ -4960,6 +4959,7 @@ class NDFrame(PandasObject, SelectionMixin):
         --------
         %(klass)s.fillna : Fill `NaN` values
         %(klass)s.where : Replace values based on boolean condition
+        Series.str.replace : Simple string replacement.
 
         Returns
         -------
@@ -4969,19 +4969,19 @@ class NDFrame(PandasObject, SelectionMixin):
         Raises
         ------
         AssertionError
-            * If ``regex`` is not a ``bool`` and ``to_replace`` is not
+            * If `regex` is not a ``bool`` and `to_replace` is not
               ``None``.
         TypeError
-            * If ``to_replace`` is a ``dict`` and ``value`` is not a ``list``,
+            * If `to_replace` is a ``dict`` and `value` is not a ``list``,
               ``dict``, ``ndarray``, or ``Series``
-            * If ``to_replace`` is ``None`` and ``regex`` is not compilable
+            * If `to_replace` is ``None`` and `regex` is not compilable
               into a regular expression or is a list, dict, ndarray, or
               Series.
             * When replacing multiple ``bool`` or ``datetime64`` objects and
-              the arguments to ``to_replace`` does not match the type of the
+              the arguments to `to_replace` does not match the type of the
               value being replaced
         ValueError
-            * If a ``list`` or an ``ndarray`` is passed to ``to_replace`` and
+            * If a ``list`` or an ``ndarray`` is passed to `to_replace` and
               `value` but they are not the same length.
 
         Notes
@@ -4995,12 +4995,14 @@ class NDFrame(PandasObject, SelectionMixin):
           numbers *are* strings, then you can do this.
         * This method has *a lot* of options. You are encouraged to experiment
           and play with this method to gain intuition about how it works.
-        * When dict is used as the ``to_replace`` value, it is like
+        * When dict is used as the `to_replace` value, it is like
           key(s) in the dict are the to_replace part and
           value(s) in the dict are the value parameter.
 
         Examples
         --------
+
+        **Scalar `to_replace` and `value`**
 
         >>> s = pd.Series([0, 1, 2, 3, 4])
         >>> s.replace(0, 5)
@@ -5010,6 +5012,7 @@ class NDFrame(PandasObject, SelectionMixin):
         3    3
         4    4
         dtype: int64
+
         >>> df = pd.DataFrame({'A': [0, 1, 2, 3, 4],
         ...                    'B': [5, 6, 7, 8, 9],
         ...                    'C': ['a', 'b', 'c', 'd', 'e']})
@@ -5021,6 +5024,8 @@ class NDFrame(PandasObject, SelectionMixin):
         3  3  8  d
         4  4  9  e
 
+        **List-like `to_replace`**
+
         >>> df.replace([0, 1, 2, 3], 4)
            A  B  C
         0  4  5  a
@@ -5028,6 +5033,7 @@ class NDFrame(PandasObject, SelectionMixin):
         2  4  7  c
         3  4  8  d
         4  4  9  e
+
         >>> df.replace([0, 1, 2, 3], [4, 3, 2, 1])
            A  B  C
         0  4  5  a
@@ -5035,6 +5041,7 @@ class NDFrame(PandasObject, SelectionMixin):
         2  2  7  c
         3  1  8  d
         4  4  9  e
+
         >>> s.replace([1, 2], method='bfill')
         0    0
         1    3
@@ -5043,6 +5050,8 @@ class NDFrame(PandasObject, SelectionMixin):
         4    4
         dtype: int64
 
+        **dict-like `to_replace`**
+
         >>> df.replace({0: 10, 1: 100})
              A  B  C
         0   10  5  a
@@ -5050,6 +5059,7 @@ class NDFrame(PandasObject, SelectionMixin):
         2    2  7  c
         3    3  8  d
         4    4  9  e
+
         >>> df.replace({'A': 0, 'B': 5}, 100)
              A    B  C
         0  100  100  a
@@ -5057,6 +5067,7 @@ class NDFrame(PandasObject, SelectionMixin):
         2    2    7  c
         3    3    8  d
         4    4    9  e
+
         >>> df.replace({'A': {0: 100, 4: 400}})
              A  B  C
         0  100  5  a
@@ -5065,6 +5076,8 @@ class NDFrame(PandasObject, SelectionMixin):
         3    3  8  d
         4  400  9  e
 
+        **Regular expression `to_replace`**
+
         >>> df = pd.DataFrame({'A': ['bat', 'foo', 'bait'],
         ...                    'B': ['abc', 'bar', 'xyz']})
         >>> df.replace(to_replace=r'^ba.$', value='new', regex=True)
@@ -5072,21 +5085,25 @@ class NDFrame(PandasObject, SelectionMixin):
         0   new  abc
         1   foo  new
         2  bait  xyz
+
         >>> df.replace({'A': r'^ba.$'}, {'A': 'new'}, regex=True)
               A    B
         0   new  abc
         1   foo  bar
         2  bait  xyz
+
         >>> df.replace(regex=r'^ba.$', value='new')
               A    B
         0   new  abc
         1   foo  new
         2  bait  xyz
+
         >>> df.replace(regex={r'^ba.$':'new', 'foo':'xyz'})
               A    B
         0   new  abc
         1   xyz  new
         2  bait  xyz
+
         >>> df.replace(regex=[r'^ba.$', 'foo'], value='new')
               A    B
         0   new  abc
@@ -5094,12 +5111,14 @@ class NDFrame(PandasObject, SelectionMixin):
         2  bait  xyz
 
         Note that when replacing multiple ``bool`` or ``datetime64`` objects,
-        the data types in the ``to_replace`` parameter must match the data
+        the data types in the `to_replace` parameter must match the data
         type of the value being replaced:
 
         >>> df = pd.DataFrame({'A': [True, False, True],
         ...                    'B': [False, True, False]})
         >>> df.replace({'a string': 'new value', True: False})  # raises
+        Traceback (most recent call last):
+            ...
         TypeError: Cannot compare types 'ndarray(dtype=bool)' and 'str'
 
         This raises a ``TypeError`` because one of the ``dict`` keys is not of
@@ -5107,16 +5126,15 @@ class NDFrame(PandasObject, SelectionMixin):
 
         Compare the behavior of ``s.replace({'a': None})`` and
         ``s.replace('a', None)`` to understand the pecularities
-        of the ``to_replace`` parameter:
+        of the `to_replace` parameter:
 
         >>> s = pd.Series([10, 'a', 'a', 'b', 'a'])
 
-        When one uses a dict as the ``to_replace`` value, it is like the
-        value(s) in the dict are equal to the value parameter.
+        When one uses a dict as the `to_replace` value, it is like the
+        value(s) in the dict are equal to the `value` parameter.
         ``s.replace({'a': None})`` is equivalent to
         ``s.replace(to_replace={'a': None}, value=None, method=None)``:
 
-        >>> #s.replace(to_replace={'a': None}, value=None, method=None)
         >>> s.replace({'a': None})
         0      10
         1    None
@@ -5125,14 +5143,13 @@ class NDFrame(PandasObject, SelectionMixin):
         4    None
         dtype: object
 
-        When ``value=None`` and ``to_replace`` are a scalar, list or
-        tuple, ``replace`` uses the method parameter (default 'pad') to do the
+        When ``value=None`` and `to_replace` is a scalar, list or
+        tuple, `replace` uses the method parameter (default 'pad') to do the
         replacement. So this is why the 'a' values are being replaced by 10
         in rows 1 and 2 and 'b' in row 4 in this case.
         The command ``s.replace('a', None)`` is actually equivalent to
         ``s.replace(to_replace='a', value=None, method='pad')``:
 
-        >>> #s.replace(to_replace='a', value=None, method='pad')
         >>> s.replace('a', None)
         0    10
         1    10

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -4870,7 +4870,8 @@ class NDFrame(PandasObject, SelectionMixin):
         Replace values given in 'to_replace' with 'value'.
 
         Values of the DataFrame or a Series are being replaced with
-        other values.
+        other values. One or several values can be replaced with one
+        or several values.
 
         Parameters
         ----------
@@ -4960,7 +4961,8 @@ class NDFrame(PandasObject, SelectionMixin):
 
         Returns
         -------
-        filled : %(klass)s
+        %(klass)s
+            Some values have been substituted for new values.
 
         Raises
         ------

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -4878,7 +4878,7 @@ class NDFrame(PandasObject, SelectionMixin):
 
         Parameters
         ----------
-        to_replace : str, regex, list, dict, Series, numeric, or None
+        to_replace : str, regex, list, dict, Series, int, float, or None
             * numeric, str or regex:
 
                 - numeric: numeric values equal to ``to_replace`` will be

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -4950,6 +4950,7 @@ class NDFrame(PandasObject, SelectionMixin):
         method : {'pad', 'ffill', 'bfill', `None`}
             The method to use when for replacement, when ``to_replace`` is a
             scalar, list or tuple and ``value`` is `None`.
+
             .. versionchanged:: 0.23.0
                 Added to DataFrame.
         axis : None
@@ -5104,7 +5105,7 @@ class NDFrame(PandasObject, SelectionMixin):
         This raises a ``TypeError`` because one of the ``dict`` keys is not of
         the correct type for replacement.
 
-        Compare the behavior of` `s.replace({'a': None})`` and
+        Compare the behavior of ``s.replace({'a': None})`` and
         ``s.replace('a', None)`` to understand the pecularities
         of the ``to_replace`` parameter:
 
@@ -5115,6 +5116,7 @@ class NDFrame(PandasObject, SelectionMixin):
         ``s.replace({'a': None})`` is equivalent to
         ``s.replace(to_replace={'a': None}, value=None, method=None)``:
 
+        >>> #s.replace(to_replace={'a': None}, value=None, method=None)
         >>> s.replace({'a': None})
         0      10
         1    None
@@ -5130,6 +5132,7 @@ class NDFrame(PandasObject, SelectionMixin):
         The command ``s.replace('a', None)`` is actually equivalent to
         ``s.replace(to_replace='a', value=None, method='pad')``:
 
+        >>> #s.replace(to_replace='a', value=None, method='pad')
         >>> s.replace('a', None)
         0    10
         1    10


### PR DESCRIPTION
- [x] PR title is "DOC: update the <your-function-or-method> docstring"
- [ ] The validation script passes: `scripts/validate_docstrings.py <your-function-or-method>`
- [x] The PEP8 style check passes: `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] The html version looks good: `python doc/make.py --single <your-function-or-method>`
- [ ] It has been proofread on language by another sprint participant

**Note:** Just did a minor improvement, not a full change!

Still a few verification errors:
- Errors in parameters section
  - Parameter "to_replace" description should start with capital letter
  - Parameter "axis" description should finish with "."
- Examples do not pass tests

```
################################################################################
##################### Docstring (pandas.DataFrame.replace) #####################
################################################################################

Replace values given in 'to_replace' with 'value'.

Values of the DataFrame or a Series are being replaced with
other values. One or several values can be replaced with one
or several values.

Parameters
----------
to_replace : str, regex, list, dict, Series, numeric, or None

    * numeric, str or regex:

        - numeric: numeric values equal to ``to_replace`` will be
          replaced with ``value``
        - str: string exactly matching ``to_replace`` will be replaced
          with ``value``
        - regex: regexs matching ``to_replace`` will be replaced with
          ``value``

    * list of str, regex, or numeric:

        - First, if ``to_replace`` and ``value`` are both lists, they
          **must** be the same length.
        - Second, if ``regex=True`` then all of the strings in **both**
          lists will be interpreted as regexs otherwise they will match
          directly. This doesn't matter much for ``value`` since there
          are only a few possible substitution regexes you can use.
        - str, regex and numeric rules apply as above.

    * dict:

        - Dicts can be used to specify different replacement values
          for different existing values. For example,
          {'a': 'b', 'y': 'z'} replaces the value 'a' with 'b' and
          'y' with 'z'. To use a dict in this way the ``value``
          parameter should be ``None``.
        - For a DataFrame a dict can specify that different values
          should be replaced in different columns. For example,
          {'a': 1, 'b': 'z'} looks for the value 1 in column 'a' and
          the value 'z' in column 'b' and replaces these values with
          whatever is specified in ``value``. The ``value`` parameter
          should not be ``None`` in this case. You can treat this as a
          special case of passing two lists except that you are
          specifying the column to search in.
        - For a DataFrame nested dictionaries, e.g.,
          {'a': {'b': np.nan}}, are read as follows: look in column 'a'
          for the value 'b' and replace it with NaN. The ``value``
          parameter should be ``None`` to use a nested dict in this
          way. You can nest regular expressions as well. Note that
          column names (the top-level dictionary keys in a nested
          dictionary) **cannot** be regular expressions.

    * None:

        - This means that the ``regex`` argument must be a string,
          compiled regular expression, or list, dict, ndarray or Series
          of such elements. If ``value`` is also ``None`` then this
          **must** be a nested dictionary or ``Series``.

    See the examples section for examples of each of these.
value : scalar, dict, list, str, regex, default None
    Value to replace any values matching ``to_replace`` with.
    For a DataFrame a dict of values can be used to specify which
    value to use for each column (columns not in the dict will not be
    filled). Regular expressions, strings and lists or dicts of such
    objects are also allowed.
inplace : boolean, default False
    If True, in place. Note: this will modify any
    other views on this object (e.g. a column from a DataFrame).
    Returns the caller if this is True.
limit : int, default None
    Maximum size gap to forward or backward fill.
regex : bool or same types as ``to_replace``, default False
    Whether to interpret ``to_replace`` and/or ``value`` as regular
    expressions. If this is ``True`` then ``to_replace`` *must* be a
    string. Alternatively, this could be a regular expression or a
    list, dict, or array of regular expressions in which case
    ``to_replace`` must be ``None``.
method : string, optional, {'pad', 'ffill', 'bfill'}, default is 'pad'
    The method to use when for replacement, when ``to_replace`` is a
    scalar, list or tuple and ``value`` is None.
axis : None
    Deprecated.

    .. versionchanged:: 0.23.0
        Added to DataFrame

See Also
--------
DataFrame.fillna : Fill NA/NaN values
DataFrame.where : Replace values based on boolean condition

Returns
-------
DataFrame
    Some values have been substituted for new values.

Raises
------
AssertionError
    * If ``regex`` is not a ``bool`` and ``to_replace`` is not
      ``None``.
TypeError
    * If ``to_replace`` is a ``dict`` and ``value`` is not a ``list``,
      ``dict``, ``ndarray``, or ``Series``
    * If ``to_replace`` is ``None`` and ``regex`` is not compilable
      into a regular expression or is a list, dict, ndarray, or
      Series.
    * When replacing multiple ``bool`` or ``datetime64`` objects and
      the arguments to ``to_replace`` does not match the type of the
      value being replaced
ValueError
    * If a ``list`` or an ``ndarray`` is passed to ``to_replace`` and
      `value` but they are not the same length.

Notes
-----
* Regex substitution is performed under the hood with ``re.sub``. The
  rules for substitution for ``re.sub`` are the same.
* Regular expressions will only substitute on strings, meaning you
  cannot provide, for example, a regular expression matching floating
  point numbers and expect the columns in your frame that have a
  numeric dtype to be matched. However, if those floating point
  numbers *are* strings, then you can do this.
* This method has *a lot* of options. You are encouraged to experiment
  and play with this method to gain intuition about how it works.

Examples
--------

>>> s = pd.Series([0, 1, 2, 3, 4])
>>> s.replace(0, 5)
0    5
1    1
2    2
3    3
4    4
dtype: int64
>>> df = pd.DataFrame({'A': [0, 1, 2, 3, 4],
...                    'B': [5, 6, 7, 8, 9],
...                    'C': ['a', 'b', 'c', 'd', 'e']})
>>> df.replace(0, 5)
   A  B  C
0  5  5  a
1  1  6  b
2  2  7  c
3  3  8  d
4  4  9  e

>>> df.replace([0, 1, 2, 3], 4)
   A  B  C
0  4  5  a
1  4  6  b
2  4  7  c
3  4  8  d
4  4  9  e
>>> df.replace([0, 1, 2, 3], [4, 3, 2, 1])
   A  B  C
0  4  5  a
1  3  6  b
2  2  7  c
3  1  8  d
4  4  9  e
>>> s.replace([1, 2], method='bfill')
0    0
1    3
2    3
3    3
4    4
dtype: int64

>>> df.replace({0: 10, 1: 100})
     A  B  C
0   10  5  a
1  100  6  b
2    2  7  c
3    3  8  d
4    4  9  e
>>> df.replace({'A': 0, 'B': 5}, 100)
     A    B  C
0  100  100  a
1    1    6  b
2    2    7  c
3    3    8  d
4    4    9  e
>>> df.replace({'A': {0: 100, 4: 400}})
     A  B  C
0  100  5  a
1    1  6  b
2    2  7  c
3    3  8  d
4  400  9  e

>>> df = pd.DataFrame({'A': ['bat', 'foo', 'bait'],
...                    'B': ['abc', 'bar', 'xyz']})
>>> df.replace(to_replace=r'^ba.$', value='new', regex=True)
      A    B
0   new  abc
1   foo  new
2  bait  xyz
>>> df.replace({'A': r'^ba.$'}, {'A': 'new'}, regex=True)
      A    B
0   new  abc
1   foo  bar
2  bait  xyz
>>> df.replace(regex=r'^ba.$', value='new')
      A    B
0   new  abc
1   foo  new
2  bait  xyz
>>> df.replace(regex={r'^ba.$':'new', 'foo':'xyz'})
      A    B
0   new  abc
1   xyz  new
2  bait  xyz
>>> df.replace(regex=[r'^ba.$', 'foo'], value='new')
      A    B
0   new  abc
1   new  new
2  bait  xyz

Note that when replacing multiple ``bool`` or ``datetime64`` objects,
the data types in the ``to_replace`` parameter must match the data
type of the value being replaced:

>>> df = pd.DataFrame({'A': [True, False, True],
...                    'B': [False, True, False]})
>>> df.replace({'a string': 'new value', True: False})  # raises
TypeError: Cannot compare types 'ndarray(dtype=bool)' and 'str'

This raises a ``TypeError`` because one of the ``dict`` keys is not of
the correct type for replacement.

Compare the behavior of
``s.replace('a', None)`` and ``s.replace({'a': None})`` to understand
the pecularities of the ``to_replace`` parameter.
``s.replace('a', None)`` is actually equivalent to
``s.replace(to_replace='a', value=None, method='pad')``,
because when ``value=None`` and ``to_replace`` is a scalar, list or
tuple, ``replace`` uses the method parameter to do the replacement.
So this is why the 'a' values are being replaced by 30 in rows 3 and 4
and 'b' in row 6 in this case. However, this behaviour does not occur
when you use a dict as the ``to_replace`` value. In this case, it is
like the value(s) in the dict are equal to the value parameter.

>>> s = pd.Series([10, 20, 30, 'a', 'a', 'b', 'a'])
>>> print(s)
0    10
1    20
2    30
3     a
4     a
5     b
6     a
dtype: object
>>> print(s.replace('a', None))
0    10
1    20
2    30
3    30
4    30
5     b
6     b
dtype: object
>>> print(s.replace({'a': None}))
0      10
1      20
2      30
3    None
4    None
5       b
6    None
dtype: object

################################################################################
################################## Validation ##################################
################################################################################

Errors found:
        Errors in parameters section
                Parameter "to_replace" description should start with capital letter
                Parameter "axis" description should finish with "."
        Examples do not pass tests

################################################################################
################################### Doctests ###################################
################################################################################

**********************************************************************
Line 229, in pandas.DataFrame.replace
Failed example:
    df.replace({'a string': 'new value', True: False})  # raises
Exception raised:
    Traceback (most recent call last):
      File "C:\Users\thisi\AppData\Local\conda\conda\envs\pandas_dev\lib\doctest.py", line 1330, in __run
        compileflags, 1), test.globs)
      File "<doctest pandas.DataFrame.replace[17]>", line 1, in <module>
        df.replace({'a string': 'new value', True: False})  # raises
      File "C:\Users\thisi\Documents\GitHub\pandas\pandas\core\frame.py", line 3136, in replace
        method=method, axis=axis)
      File "C:\Users\thisi\Documents\GitHub\pandas\pandas\core\generic.py", line 5208, in replace
        limit=limit, regex=regex)
      File "C:\Users\thisi\Documents\GitHub\pandas\pandas\core\frame.py", line 3136, in replace
        method=method, axis=axis)
      File "C:\Users\thisi\Documents\GitHub\pandas\pandas\core\generic.py", line 5257, in replace
        regex=regex)
      File "C:\Users\thisi\Documents\GitHub\pandas\pandas\core\internals.py", line 3696, in replace_list
        masks = [comp(s) for i, s in enumerate(src_list)]
      File "C:\Users\thisi\Documents\GitHub\pandas\pandas\core\internals.py", line 3696, in <listcomp>
        masks = [comp(s) for i, s in enumerate(src_list)]
      File "C:\Users\thisi\Documents\GitHub\pandas\pandas\core\internals.py", line 3694, in comp
        return _maybe_compare(values, getattr(s, 'asm8', s), operator.eq)
      File "C:\Users\thisi\Documents\GitHub\pandas\pandas\core\internals.py", line 5122, in _maybe_compare
        b=type_names[1]))
    TypeError: Cannot compare types 'ndarray(dtype=bool)' and 'str'
```
