### PR TITLE
DOC: update the pandas.Series.dt.is_year_start docstring

### DIFF
--- a/pandas/core/indexes/datetimes.py
+++ b/pandas/core/indexes/datetimes.py
@@ -1764,7 +1764,7 @@ class DatetimeIndex(DatelikeOps, TimelikeOps, DatetimeIndexOpsMixin,
         1   2017-12-31
         2   2018-01-01
         dtype: datetime64[ns]
-        >>> dates.dt.is_year_end
+        >>> dates.dt.is_year_start
         0    False
         1    False
         2    True

--- a/pandas/core/indexes/datetimes.py
+++ b/pandas/core/indexes/datetimes.py
@@ -1744,31 +1744,44 @@ class DatetimeIndex(DatelikeOps, TimelikeOps, DatetimeIndexOpsMixin,
         'is_year_start',
         'is_year_start',
         """
-        Return a boolean indicating whether the date is the first day of the
-        year.
+        Indicate whether the date is the first day of a year.
 
         Returns
         -------
-        is_year_start : Series of boolean.
+        Series or DatetimeIndex
+            The same type as the original data with boolean values. Series will
+            have the same name and index. DatetimeIndex will have the same
+            name.
 
         See Also
         --------
-        is_year_end : Return a boolean indicating whether the date is the
-            last day of the year.
+        is_year_end : Similar method indicating the last day of the year.
 
         Examples
         --------
+        This method is available on Series with datetime values under
+        the ``.dt`` accessor, and directly on DatetimeIndex.
+
         >>> dates = pd.Series(pd.date_range("2017-12-30", periods=3))
         >>> dates
         0   2017-12-30
         1   2017-12-31
         2   2018-01-01
         dtype: datetime64[ns]
+
         >>> dates.dt.is_year_start
         0    False
         1    False
         2    True
         dtype: bool
+
+        >>> idx = pd.date_range("2017-12-30", periods=3)
+        >>> idx
+        DatetimeIndex(['2017-12-30', '2017-12-31', '2018-01-01'],
+                      dtype='datetime64[ns]', freq='D')
+
+        >>> idx.is_year_start
+        array([False, False,  True])
         """)
     is_year_end = _field_accessor(
         'is_year_end',

--- a/pandas/core/indexes/datetimes.py
+++ b/pandas/core/indexes/datetimes.py
@@ -1743,7 +1743,33 @@ class DatetimeIndex(DatelikeOps, TimelikeOps, DatetimeIndexOpsMixin,
     is_year_start = _field_accessor(
         'is_year_start',
         'is_year_start',
-        "Logical indicating if first day of year (defined by frequency)")
+        """
+        Return a boolean indicating whether the date is the first day of the
+        year.
+
+        Returns
+        -------
+        is_year_start : Series of boolean.
+
+        See Also
+        --------
+        is_year_end : Return a boolean indicating whether the date is the
+            last day of the year.
+
+        Examples
+        --------
+        >>> dates = pd.Series(pd.date_range("2017-12-30", periods=3))
+        >>> dates
+        0   2017-12-30
+        1   2017-12-31
+        2   2018-01-01
+        dtype: datetime64[ns]
+        >>> dates.dt.is_year_end
+        0    False
+        1    False
+        2    True
+        dtype: bool
+        """)
     is_year_end = _field_accessor(
         'is_year_end',
         'is_year_end',


### PR DESCRIPTION
Checklist for the pandas documentation sprint (ignore this if you are doing
an unrelated PR):

- [X] PR title is "DOC: update the <your-function-or-method> docstring"
- [X] The validation script passes: `scripts/validate_docstrings.py <your-function-or-method>`
- [X] The PEP8 style check passes: `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [X] The html version looks good: `python doc/make.py --single <your-function-or-method>`
- [X] It has been proofread on language by another sprint participant

Please include the output of the validation script below between the "```" ticks:

```
################################################################################
################## Docstring (pandas.Series.dt.is_year_start) ##################
################################################################################

Return a boolean indicating whether the date is the first day of the
year.

Returns
-------
is_year_start : Series of boolean.

See Also
--------
is_year_end : Return a boolean indicating whether the date is the
    last day of the year.

Examples
--------
>>> dates = pd.Series(pd.date_range("2017-12-30", periods=3))
>>> dates
0   2017-12-30
1   2017-12-31
2   2018-01-01
dtype: datetime64[ns]
>>> dates.dt.is_year_start
0    False
1    False
2    True
dtype: bool

################################################################################
################################## Validation ##################################
################################################################################

Errors found:
    No summary found (a short summary in a single line should be present at the beginning of the docstring)

```

If the validation script still gives errors, but you think there is a good reason
to deviate in this case (and there are certainly such cases), please state this
explicitly.

* short summary exceeds one line by one word, hope that is ok
