### PR TITLE
DOC: update the aggregate docstring

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -107,6 +107,10 @@ from pandas.core.config import get_option
 _shared_doc_kwargs = dict(
     axes='index, columns', klass='DataFrame',
     axes_single_arg="{0 or 'index', 1 or 'columns'}",
+    axis="""
+    axis : {0 or 'index', 1 or 'columns'}, default 0
+        - 0 or 'index': apply function to each column.
+        - 1 or 'columns': apply function to each row.""",
     optional_by="""
         by : str or list of str
             Name or list of names to sort by.

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -4463,10 +4463,10 @@ class DataFrame(NDFrame):
         Return reshaped DataFrame organized by given index / column values.
 
         Reshape data (produce a "pivot" table) based on column values. Uses
-        unique values from specified `index` / `columns` to form axes of the resulting
-        DataFrame. This function does not support data aggregation, multiple
-        values will result in a MultiIndex in the columns. See the
-        :ref:`User Guide <reshaping>` for more on reshaping.
+        unique values from specified `index` / `columns` to form axes of the
+        resulting DataFrame. This function does not support data
+        aggregation, multiple values will result in a MultiIndex in the
+        columns. See the :ref:`User Guide <reshaping>` for more on reshaping.
 
         Parameters
         ----------

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -4764,36 +4764,49 @@ class DataFrame(NDFrame):
         return self[key]
 
     _agg_doc = dedent("""
+    Notes
+    -----
+    The default behavior of aggregating over the axis 0 is different from
+    `numpy` functions `mean`/`median`/`prod`/`sum`/`std`/`var`, where the
+    default is to compute the aggregation of the flattened array (e.g.,
+    `numpy.mean(arr_2d)` as opposed to `numpy.mean(arr_2d, axis=0)`).
+
+    `agg` is an alias for `aggregate`. Use the alias.
+
     Examples
     --------
 
-    >>> df = pd.DataFrame(np.random.randn(10, 3), columns=['A', 'B', 'C'],
-    ...                   index=pd.date_range('1/1/2000', periods=10))
-    >>> df.iloc[3:7] = np.nan
+    >>> df = df = pd.DataFrame([[1,2,3],
+    ...                         [4,5,6],
+    ...                         [7,8,9],
+    ...                         [np.nan, np.nan, np.nan]],
+    ...                        columns=['A', 'B', 'C'])
 
     Aggregate these functions across all columns
 
-    >>> df.agg(['sum', 'min'])
-                A         B         C
-    sum -0.182253 -0.614014 -2.909534
-    min -1.916563 -1.460076 -1.568297
+    >>> df.aggregate(['sum', 'min'])
+            A     B     C
+    sum  12.0  15.0  18.0
+    min   1.0   2.0   3.0
 
     Different aggregations per column
 
-    >>> df.agg({'A' : ['sum', 'min'], 'B' : ['min', 'max']})
-                A         B
-    max       NaN  1.514318
-    min -1.916563 -1.460076
-    sum -0.182253       NaN
+    >>> df.aggregate({'A' : ['sum', 'min'], 'B' : ['min', 'max']})
+            A    B
+    max   NaN  8.0
+    min   1.0  2.0
+    sum  12.0  NaN
 
     See also
     --------
-    pandas.DataFrame.apply
-    pandas.DataFrame.transform
-    pandas.DataFrame.groupby.aggregate
-    pandas.DataFrame.resample.aggregate
-    pandas.DataFrame.rolling.aggregate
-
+    pandas.DataFrame.apply : Perform any type of operations.
+    pandas.DataFrame.transform : Perform transformation type operations.
+    pandas.DataFrame.groupby.aggregate : Perform aggregation type operations
+        over groups.
+    pandas.DataFrame.resample.aggregate : Perform aggregation type operations
+        over resampled bins.
+    pandas.DataFrame.rolling.aggregate : Perform aggregation type operations
+        over rolling window.
     """)
 
     @Appender(_agg_doc)

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -4997,27 +4997,35 @@ class DataFrame(NDFrame):
 
     Examples
     --------
-
-    >>> df = pd.DataFrame([[1,2,3],
-    ...                    [4,5,6],
-    ...                    [7,8,9],
+    >>> df = pd.DataFrame([[1, 2, 3],
+    ...                    [4, 5, 6],
+    ...                    [7, 8, 9],
     ...                    [np.nan, np.nan, np.nan]],
     ...                   columns=['A', 'B', 'C'])
 
-    Aggregate these functions across all columns
+    Aggregate these functions over the rows.
 
     >>> df.agg(['sum', 'min'])
             A     B     C
     sum  12.0  15.0  18.0
     min   1.0   2.0   3.0
 
-    Different aggregations per column
+    Different aggregations per column.
 
     >>> df.agg({'A' : ['sum', 'min'], 'B' : ['min', 'max']})
             A    B
     max   NaN  8.0
     min   1.0  2.0
     sum  12.0  NaN
+
+    Aggregate over the columns.
+
+    >>> df.agg("mean", axis="columns")
+    0    2.0
+    1    5.0
+    2    8.0
+    3    NaN
+    dtype: float64
 
     See also
     --------

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -4770,32 +4770,34 @@ class DataFrame(NDFrame):
     _agg_doc = dedent("""
     Notes
     -----
-    The default behavior of aggregating over the axis 0 is different from
-    `numpy` functions `mean`/`median`/`prod`/`sum`/`std`/`var`, where the
-    default is to compute the aggregation of the flattened array (e.g.,
-    `numpy.mean(arr_2d)` as opposed to `numpy.mean(arr_2d, axis=0)`).
+    The aggregation operations are always performed over an axis, either the
+    index (default) or the column axis. This behavior is different from
+    `numpy` aggregation functions (`mean`, `median`, `prod`, `sum`, `std`,
+    `var`), where the default is to compute the aggregation of the flattened
+    array, e.g., ``numpy.mean(arr_2d)`` as opposed to ``numpy.mean(arr_2d,
+    axis=0)``.
 
     `agg` is an alias for `aggregate`. Use the alias.
 
     Examples
     --------
 
-    >>> df = df = pd.DataFrame([[1,2,3],
-    ...                         [4,5,6],
-    ...                         [7,8,9],
-    ...                         [np.nan, np.nan, np.nan]],
-    ...                        columns=['A', 'B', 'C'])
+    >>> df = pd.DataFrame([[1,2,3],
+    ...                    [4,5,6],
+    ...                    [7,8,9],
+    ...                    [np.nan, np.nan, np.nan]],
+    ...                   columns=['A', 'B', 'C'])
 
     Aggregate these functions across all columns
 
-    >>> df.aggregate(['sum', 'min'])
+    >>> df.agg(['sum', 'min'])
             A     B     C
     sum  12.0  15.0  18.0
     min   1.0   2.0   3.0
 
     Different aggregations per column
 
-    >>> df.aggregate({'A' : ['sum', 'min'], 'B' : ['min', 'max']})
+    >>> df.agg({'A' : ['sum', 'min'], 'B' : ['min', 'max']})
             A    B
     max   NaN  8.0
     min   1.0  2.0
@@ -4803,14 +4805,14 @@ class DataFrame(NDFrame):
 
     See also
     --------
-    pandas.DataFrame.apply : Perform any type of operations.
-    pandas.DataFrame.transform : Perform transformation type operations.
-    pandas.DataFrame.groupby.aggregate : Perform aggregation type operations
-        over groups.
-    pandas.DataFrame.resample.aggregate : Perform aggregation type operations
-        over resampled bins.
-    pandas.DataFrame.rolling.aggregate : Perform aggregation type operations
-        over rolling window.
+    DataFrame.apply : Perform any type of operations.
+    DataFrame.transform : Perform transformation type operations.
+    pandas.core.groupby.GroupBy : Perform operations over groups.
+    pandas.core.resample.Resampler : Perform operations over resampled bins.
+    pandas.core.window.Rolling : Perform operations over rolling window.
+    pandas.core.window.Expanding : Perform operations over expanding window.
+    pandas.core.window.EWM : Perform operation over exponential weighted
+        window.
     """)
 
     @Appender(_agg_doc)

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -3946,9 +3946,7 @@ class NDFrame(PandasObject, SelectionMixin):
         - function.
         - list of functions.
         - dict of column names -> functions (or list of functions).
-    axis : {0 or 'index', 1 or 'columns'}, default 0
-        - 0 or 'index': apply function to each column.
-        - 1 or 'columns': apply function to each row.
+    %(axis)s
     args
         Optional positional arguments to pass to the function.
     kwargs

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -3929,7 +3929,7 @@ class NDFrame(PandasObject, SelectionMixin):
         return com._pipe(self, func, *args, **kwargs)
 
     _shared_docs['aggregate'] = ("""
-    Aggregate using one or multiple operations along the specified axis.
+    Aggregate using one or more operations over the specified axis.
 
     %(versionadded)s
 
@@ -3947,10 +3947,10 @@ class NDFrame(PandasObject, SelectionMixin):
         - list of functions.
         - dict of column names -> functions (or list of functions).
     %(axis)s
-    args
-        Optional positional arguments to pass to the function.
-    kwargs
-        Optional keyword arguments to pass to the function.
+    *args
+        Positional arguments to pass to the function.
+    **kwargs
+        Keyword arguments to pass to the function.
 
     Returns
     -------

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -3929,36 +3929,38 @@ class NDFrame(PandasObject, SelectionMixin):
         return com._pipe(self, func, *args, **kwargs)
 
     _shared_docs['aggregate'] = ("""
-    Aggregate using callable, string, dict, or list of string/callables
+    Aggregate using one or multiple operations along the specified axis.
 
     %(versionadded)s
 
     Parameters
     ----------
-    func : callable, string, dictionary, or list of string/callables
+    func : function, string, dictionary, or list of string/functions
         Function to use for aggregating the data. If a function, must either
         work when passed a %(klass)s or when passed to %(klass)s.apply. For
         a DataFrame, can pass a dict, if the keys are DataFrame column names.
 
-        Accepted Combinations are:
+        Accepted combinations are:
 
-        - string function name
-        - function
-        - list of functions
-        - dict of column names -> functions (or list of functions)
-
-    Notes
-    -----
-    Numpy functions mean/median/prod/sum/std/var are special cased so the
-    default behavior is applying the function along axis=0
-    (e.g., np.mean(arr_2d, axis=0)) as opposed to
-    mimicking the default Numpy behavior (e.g., np.mean(arr_2d)).
-
-    `agg` is an alias for `aggregate`. Use the alias.
+        - string function name.
+        - function.
+        - list of functions.
+        - dict of column names -> functions (or list of functions).
+    axis : {0 or 'index', 1 or 'columns'}, default 0
+        - 0 or 'index': apply function to each column.
+        - 1 or 'columns': apply function to each row.
+    args
+        Optional positional arguments to pass to the function.
+    kwargs
+        Optional keyword arguments to pass to the function.
 
     Returns
     -------
     aggregated : %(klass)s
+
+    Notes
+    -----
+    `agg` is an alias for `aggregate`. Use the alias.
     """)
 
     _shared_docs['transform'] = ("""
@@ -4006,7 +4008,6 @@ class NDFrame(PandasObject, SelectionMixin):
     --------
     pandas.%(klass)s.aggregate
     pandas.%(klass)s.apply
-
     """)
 
     # ----------------------------------------------------------------------

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -3954,11 +3954,12 @@ class NDFrame(PandasObject, SelectionMixin):
         - function.
         - list of functions.
         - dict of column names -> functions (or list of functions).
+
     %(axis)s
     *args
-        Positional arguments to pass to the function.
+        Positional arguments to pass to `func`.
     **kwargs
-        Keyword arguments to pass to the function.
+        Keyword arguments to pass to `func`.
 
     Returns
     -------

--- a/pandas/core/groupby.py
+++ b/pandas/core/groupby.py
@@ -3431,7 +3431,8 @@ class SeriesGroupBy(GroupBy):
     @Appender(_agg_doc)
     @Appender(_shared_docs['aggregate'] % dict(
         klass='Series',
-        versionadded=''))
+        versionadded='',
+        axis=''))
     def aggregate(self, func_or_funcs, *args, **kwargs):
         _level = kwargs.pop('_level', None)
         if isinstance(func_or_funcs, compat.string_types):
@@ -4610,7 +4611,8 @@ class DataFrameGroupBy(NDFrameGroupBy):
     @Appender(_agg_doc)
     @Appender(_shared_docs['aggregate'] % dict(
         klass='DataFrame',
-        versionadded=''))
+        versionadded='',
+        axis=''))
     def aggregate(self, arg, *args, **kwargs):
         return super(DataFrameGroupBy, self).aggregate(arg, *args, **kwargs)
 

--- a/pandas/core/resample.py
+++ b/pandas/core/resample.py
@@ -334,7 +334,8 @@ one pass, you can do
     @Appender(_agg_doc)
     @Appender(_shared_docs['aggregate'] % dict(
         klass='DataFrame',
-        versionadded=''))
+        versionadded='',
+        axis=''))
     def aggregate(self, arg, *args, **kwargs):
 
         self._set_binner()

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -77,6 +77,10 @@ __all__ = ['Series']
 
 _shared_doc_kwargs = dict(
     axes='index', klass='Series', axes_single_arg="{0, 'index'}",
+    axis="""
+    axis : {0 or 'index'}
+        Parameter needed for compatibility.
+    """,
     inplace="""inplace : boolean, default False
         If True, performs operation inplace and returns None.""",
     unique='np.ndarray', duplicated='Series',
@@ -2353,13 +2357,6 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
         return self
 
     _agg_doc = dedent("""
-    Notes
-    -----
-    The only possible value for axis is 0 or 'index' because
-    :class:`~pandas.Series` has only one axis.
-
-    `agg` is an alias for `aggregate`. Use the alias.
-
     Examples
     --------
 

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -79,7 +79,7 @@ _shared_doc_kwargs = dict(
     axes='index', klass='Series', axes_single_arg="{0 or 'index'}",
     axis="""
     axis : {0 or 'index'}
-        Parameter needed for compatibility.
+        Parameter needed for compatibility with DataFrame.
     """,
     inplace="""inplace : boolean, default False
         If True, performs operation inplace and returns None.""",

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -2353,6 +2353,13 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
         return self
 
     _agg_doc = dedent("""
+    Notes
+    -----
+    The only possible value for axis is 0 or 'index' because
+    :class:`~pandas.Series` has only one axis.
+
+    `agg` is an alias for `aggregate`. Use the alias.
+
     Examples
     --------
 

--- a/pandas/core/window.py
+++ b/pandas/core/window.py
@@ -626,7 +626,8 @@ class Window(_Window):
     @Appender(_agg_doc)
     @Appender(_shared_docs['aggregate'] % dict(
         versionadded='',
-        klass='Series/DataFrame'))
+        klass='Series/DataFrame',
+        axis=''))
     def aggregate(self, arg, *args, **kwargs):
         result, how = self._aggregate(arg, *args, **kwargs)
         if result is None:
@@ -1192,7 +1193,8 @@ class Rolling(_Rolling_and_Expanding):
     @Appender(_agg_doc)
     @Appender(_shared_docs['aggregate'] % dict(
         versionadded='',
-        klass='Series/DataFrame'))
+        klass='Series/DataFrame',
+        axis=''))
     def aggregate(self, arg, *args, **kwargs):
         return super(Rolling, self).aggregate(arg, *args, **kwargs)
 
@@ -1436,7 +1438,8 @@ class Expanding(_Rolling_and_Expanding):
     @Appender(_agg_doc)
     @Appender(_shared_docs['aggregate'] % dict(
         versionadded='',
-        klass='Series/DataFrame'))
+        klass='Series/DataFrame',
+        axis=''))
     def aggregate(self, arg, *args, **kwargs):
         return super(Expanding, self).aggregate(arg, *args, **kwargs)
 
@@ -1717,7 +1720,8 @@ class EWM(_Rolling):
     @Appender(_agg_doc)
     @Appender(_shared_docs['aggregate'] % dict(
         versionadded='',
-        klass='Series/DataFrame'))
+        klass='Series/DataFrame',
+        axis=''))
     def aggregate(self, arg, *args, **kwargs):
         return super(EWM, self).aggregate(arg, *args, **kwargs)
 


### PR DESCRIPTION
Checklist for the pandas documentation sprint (ignore this if you are doing
an unrelated PR):

- [X] PR title is "DOC: update the <your-function-or-method> docstring"
- [ ] The validation script passes: `scripts/validate_docstrings.py <your-function-or-method>`
- [X] The PEP8 style check passes: `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [X] The html version looks good: `python doc/make.py --single <your-function-or-method>`
- [ ] It has been proofread on language by another sprint participant

Please include the output of the validation script below between the "```" ticks:

```
################################################################################
#################### Docstring (pandas.DataFrame.aggregate) ####################
################################################################################

Aggregate using one or multiple operations along the specified axis.

.. versionadded:: 0.20.0

Parameters
----------
func : function, string, dictionary, or list of string/functions
    Function to use for aggregating the data. If a function, must either
    work when passed a DataFrame or when passed to DataFrame.apply. For
    a DataFrame, can pass a dict, if the keys are DataFrame column names.

    Accepted combinations are:

    - string function name.
    - function.
    - list of functions.
    - dict of column names -> functions (or list of functions).
axis : {0 or 'index', 1 or 'columns'}, default 0
    - 0 or 'index': apply function to each column.
    - 1 or 'columns': apply function to each row.
args
    Optional positional arguments to pass to the function.
kwargs
    Optional keyword arguments to pass to the function.

Returns
-------
aggregated : DataFrame

Notes
-----
`agg` is an alias for `aggregate`. Use the alias.

Notes
-----
The default behavior of aggregating over the axis 0 is different from
`numpy` functions `mean`/`median`/`prod`/`sum`/`std`/`var`, where the
default is to compute the aggregation of the flattened array (e.g.,
`numpy.mean(arr_2d)` as opposed to `numpy.mean(arr_2d, axis=0)`).

`agg` is an alias for `aggregate`. Use the alias.

Examples
--------

>>> df = df = pd.DataFrame([[1,2,3],
...                         [4,5,6],
...                         [7,8,9],
...                         [np.nan, np.nan, np.nan]],
...                        columns=['A', 'B', 'C'])

Aggregate these functions across all columns

>>> df.aggregate(['sum', 'min'])
        A     B     C
sum  12.0  15.0  18.0
min   1.0   2.0   3.0

Different aggregations per column

>>> df.aggregate({'A' : ['sum', 'min'], 'B' : ['min', 'max']})
        A    B
max   NaN  8.0
min   1.0  2.0
sum  12.0  NaN

See also
--------
pandas.DataFrame.apply : Perform any type of operations.
pandas.DataFrame.transform : Perform transformation type operations.
pandas.DataFrame.groupby.aggregate : Perform aggregation type operations
    over groups.
pandas.DataFrame.resample.aggregate : Perform aggregation type operations
    over resampled bins.
pandas.DataFrame.rolling.aggregate : Perform aggregation type operations
    over rolling window.

################################################################################
################################## Validation ##################################
################################################################################

Errors found:
	Errors in parameters section
		Parameter "axis" description should start with capital letter
		Parameter "args" has no type
		Parameter "kwargs" has no type

```

If the validation script still gives errors, but you think there is a good reason
to deviate in this case (and there are certainly such cases), please state this
explicitly.

- args and kwargs have no type
- axis : {0 or 'index', 1 or 'columns'}, default 0

This PR has been made in collaboration with @rochamatcomp

Question to reviewers: we have added to the docstring the parameter `axis` because this is appropriate for DataFrame. However this dosctring is generic (shared with Series, groupby, window and resample) and the parameter `axis` is wrong for them (for Series the parameter has only one possible value). What should be the right way to fix this?
