### PR TITLE
DOC: update the Period.dayofyear docstring

### DIFF
--- a/pandas/_libs/tslibs/period.pyx
+++ b/pandas/_libs/tslibs/period.pyx
@@ -1269,8 +1269,8 @@ cdef class _Period(object):
 
         See Also
         --------
+        Period.day : Return the day of the month.
         Period.dayofweek : Return the day of week.
-        Period.daysinmonth : Return the days in that month.
         PeriodIndex.dayofyear : Return the day of year of all indexes.
 
         Examples

--- a/pandas/_libs/tslibs/period.pyx
+++ b/pandas/_libs/tslibs/period.pyx
@@ -1255,6 +1255,36 @@ cdef class _Period(object):
 
     @property
     def dayofyear(self):
+        """
+        Return the day of the year.
+
+        This attribute returns the day of the year on which the particular
+        date occurs. The return value ranges between 1 to 365 for regular
+        years and 1 to 366 for leap years.
+
+        Returns
+        -------
+        int
+            The day of year.
+
+        See Also
+        --------
+        Period.dayofweek : Return the day of week.
+        Period.daysinmonth : Return the days in that month.
+        PeriodIndex.dayofyear : Return the day of year of all indexes.
+
+        Examples
+        --------
+        >>> period = pd.Period("2015-10-23", freq='H')
+        >>> period.dayofyear
+        296
+        >>> period = pd.Period("2012-12-31", freq='D')
+        >>> period.dayofyear
+        366
+        >>> period = pd.Period("2013-01-01", freq='D')
+        >>> period.dayofyear
+        1
+        """
         base, mult = get_freq_code(self.freq)
         return pday_of_year(self.ordinal, base)
 


### PR DESCRIPTION
Signed-off-by: Tushar Mittal <chiragmittal.mittal@gmail.com>

Checklist for the pandas documentation sprint (ignore this if you are doing
an unrelated PR):

- [x] PR title is "DOC: update the <your-function-or-method> docstring"
- [x] The validation script passes: `scripts/validate_docstrings.py <your-function-or-method>`
- [x] The PEP8 style check passes: `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] The html version looks good: `python doc/make.py --single <your-function-or-method>`
- [x] It has been proofread on language by another sprint participant

Please include the output of the validation script below between the "```" ticks:

```
################################################################################
##################### Docstring (pandas.Period.dayofyear)  #####################
################################################################################

Return the day of the year.

This attribute returns the day of the year on which the particular
date occurs. The return value ranges between 1 to 365 for regular
years and 1 to 366 for leap years.

Returns
-------
int
    The day of year.

See Also
--------
Period.dayofweek : Return the day of week.
Period.daysinmonth : Return the days in that month.
PeriodIndex.dayofyear : Return the day of year of all indexes. 

Examples
--------
>>> period = pd.Period("2015-10-23", freq='H')
>>> period.dayofyear
296
>>> period = pd.Period("2012-12-31", freq='D')
>>> period.dayofyear
366
>>> period = pd.Period("2013-01-01", freq='D')
>>> period.dayofyear
1

################################################################################
################################## Validation ##################################
################################################################################

Docstring for "pandas.Period.dayofyear" correct. :)
```

If the validation script still gives errors, but you think there is a good reason
to deviate in this case (and there are certainly such cases), please state this
explicitly.
