### PR TITLE
DOC: update the pandas.Series.dt.is_quarter_start docstring

### DIFF
--- a/pandas/core/indexes/datetimes.py
+++ b/pandas/core/indexes/datetimes.py
@@ -1736,31 +1736,42 @@ class DatetimeIndex(DatelikeOps, TimelikeOps, DatetimeIndexOpsMixin,
         'is_quarter_start',
         'is_quarter_start',
         """
-        Return a boolean indicating whether the date is the first day of a
-        quarter.
+        Indicator for whether the date is the first day of a quarter.
 
         Returns
         -------
-        is_quarter_start : Series of boolean.
+        is_quarter_start : Series or DatetimeIndex
+            The same type as the original data with boolean values. Series will
+            have the same name and index. DatetimeIndex will have the same
+            name.
 
         See Also
         --------
         quarter : Return the quarter of the date.
-
-        is_quarter_end : Return a boolean indicating whether the date is the
-            last day of the quarter.
+        is_quarter_end : Similar method for indicating the start of a quarter.
 
         Examples
         --------
+        This method is available on Series with datetime values under
+        the ``.dt`` accessor, and directly on DatetimeIndex.
+
         >>> df = pd.DataFrame({'dates': pd.date_range("2017-03-30",
         ...                   periods=4)})
         >>> df.assign(quarter = df.dates.dt.quarter,
-        ...          is_quarter_start = df.dates.dt.is_quarter_start)
+        ...           is_quarter_start=df.dates.dt.is_quarter_start)
                dates  quarter  is_quarter_start
         0 2017-03-30        1             False
         1 2017-03-31        1             False
         2 2017-04-01        2              True
         3 2017-04-02        2             False
+
+        >>> idx = pd.date_range('2017-03-30', periods=4)
+        >>> idx
+        DatetimeIndex(['2017-03-30', '2017-03-31', '2017-04-01', '2017-04-02'],
+                      dtype='datetime64[ns]', freq='D')
+
+        >>> idx.is_quarter_start
+        array([False, False,  True, False])
         """)
     is_quarter_end = _field_accessor(
         'is_quarter_end',

--- a/pandas/core/indexes/datetimes.py
+++ b/pandas/core/indexes/datetimes.py
@@ -1753,7 +1753,7 @@ class DatetimeIndex(DatelikeOps, TimelikeOps, DatetimeIndexOpsMixin,
         Examples
         --------
         >>> df = pd.DataFrame({'dates': pd.date_range("2017-03-30",
-            periods=4)})
+        ...                   periods=4)})
         >>> df.assign(quarter = df.dates.dt.quarter,
         ...          is_quarter_start = df.dates.dt.is_quarter_start)
                dates  quarter  is_quarter_start

--- a/pandas/core/indexes/datetimes.py
+++ b/pandas/core/indexes/datetimes.py
@@ -1752,8 +1752,7 @@ class DatetimeIndex(DatelikeOps, TimelikeOps, DatetimeIndexOpsMixin,
 
         Examples
         --------
-        >>> df = pd.DataFrame({'dates': pd.date_range("2017-03-30",
-            periods=4)})
+        >>> df = pd.DataFrame({'dates': pd.date_range("2017-03-30", periods=4)})
         >>> df.assign(quarter = df.dates.dt.quarter,
         ...          is_quarter_start = df.dates.dt.is_quarter_start)
                dates  quarter  is_quarter_start

--- a/pandas/core/indexes/datetimes.py
+++ b/pandas/core/indexes/datetimes.py
@@ -1735,7 +1735,32 @@ class DatetimeIndex(DatelikeOps, TimelikeOps, DatetimeIndexOpsMixin,
     is_quarter_start = _field_accessor(
         'is_quarter_start',
         'is_quarter_start',
-        "Logical indicating if first day of quarter (defined by frequency)")
+        """
+        Return a boolean indicating whether the date is the first day of a
+        quarter.
+
+        Returns
+        -------
+        is_quarter_start : Series of boolean.
+
+        See Also
+        --------
+        quarter : Return the quarter of the date.
+
+        is_quarter_end : Return a boolean indicating whether the date is the
+            last day of the quarter.
+
+        Examples
+        --------
+        >>> df = pd.DataFrame({'dates': pd.date_range("2017-03-30", periods=4)})
+        >>> df.assign(quarter = df.dates.dt.quarter,
+        ...          is_quarter_start = df.dates.dt.is_quarter_start)
+               dates  quarter  is_quarter_start
+        0 2017-03-30        1             False
+        1 2017-03-31        1             False
+        2 2017-04-01        2              True
+        3 2017-04-02        2             False
+        """)
     is_quarter_end = _field_accessor(
         'is_quarter_end',
         'is_quarter_end',

--- a/pandas/core/indexes/datetimes.py
+++ b/pandas/core/indexes/datetimes.py
@@ -1757,7 +1757,7 @@ class DatetimeIndex(DatelikeOps, TimelikeOps, DatetimeIndexOpsMixin,
 
         >>> df = pd.DataFrame({'dates': pd.date_range("2017-03-30",
         ...                   periods=4)})
-        >>> df.assign(quarter = df.dates.dt.quarter,
+        >>> df.assign(quarter=df.dates.dt.quarter,
         ...           is_quarter_start=df.dates.dt.is_quarter_start)
                dates  quarter  is_quarter_start
         0 2017-03-30        1             False

--- a/pandas/core/indexes/datetimes.py
+++ b/pandas/core/indexes/datetimes.py
@@ -1752,7 +1752,8 @@ class DatetimeIndex(DatelikeOps, TimelikeOps, DatetimeIndexOpsMixin,
 
         Examples
         --------
-        >>> df = pd.DataFrame({'dates': pd.date_range("2017-03-30", periods=4)})
+        >>> df = pd.DataFrame({'dates': pd.date_range("2017-03-30",
+            periods=4)})
         >>> df.assign(quarter = df.dates.dt.quarter,
         ...          is_quarter_start = df.dates.dt.is_quarter_start)
                dates  quarter  is_quarter_start


### PR DESCRIPTION
Checklist for the pandas documentation sprint (ignore this if you are doing
an unrelated PR):

- [X] PR title is "DOC: update the <your-function-or-method> docstring"
- [X] The validation script passes: `scripts/validate_docstrings.py <your-function-or-method>`
- [X] The PEP8 style check passes: `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [X] The html version looks good: `python doc/make.py --single <your-function-or-method>`
- [X] It has been proofread on language by another sprint participant

Please include the output of the validation script below between the "```" ticks:

```
################################################################################
################ Docstring (pandas.Series.dt.is_quarter_start)  ################
################################################################################

Return a boolean indicating whether the date is the first day of a
quarter.

Returns
-------
is_quarter_start : Series of boolean.

See Also
--------
quarter : Return the quarter of the date.

is_quarter_end : Return a boolean indicating whether the date is the
    last day of the quarter.

Examples
--------
>>> df = pd.DataFrame({'dates': pd.date_range("2017-03-30", periods=4)})
>>> df.assign(quarter = df.dates.dt.quarter,
...          is_quarter_start = df.dates.dt.is_quarter_start)
       dates  quarter  is_quarter_start
0 2017-03-30        1             False
1 2017-03-31        1             False
2 2017-04-01        2              True
3 2017-04-02        2             False

################################################################################
################################## Validation ##################################
################################################################################

Errors found:
	No summary found (a short summary in a single line should be present at the beginning of the docstring)

```

If the validation script still gives errors, but you think there is a good reason
to deviate in this case (and there are certainly such cases), please state this
explicitly.

* Short summary exceeds single line by one word, hope that is ok.