### PR TITLE
DOC: update the pandas.Series.dt.is_quarter_end docstring

### DIFF
--- a/pandas/core/indexes/datetimes.py
+++ b/pandas/core/indexes/datetimes.py
@@ -1740,31 +1740,42 @@ class DatetimeIndex(DatelikeOps, TimelikeOps, DatetimeIndexOpsMixin,
         'is_quarter_end',
         'is_quarter_end',
         """
-        Return a boolean indicating whether the date is the last day of a
-        quarter.
+        Indicator for whether the date is the last day of a quarter.
 
         Returns
         -------
-        is_quarter_end : Series of boolean.
+        is_quarter_end : Series or DatetimeIndex
+            The same type as the original data with boolean values. Series will
+            have the same name and index. DatetimeIndex will have the same
+            name.
 
         See Also
         --------
         quarter : Return the quarter of the date.
-
-        is_quarter_start : Return a boolean indicating whether the date is the
-            first day of the quarter.
+        is_quarter_start : Similar method indicating the quarter start.
 
         Examples
         --------
+        This method is available on Series with datetime values under
+        the ``.dt`` accessor, and directly on DatetimeIndex.
+
         >>> df = pd.DataFrame({'dates': pd.date_range("2017-03-30",
-        ...                   periods=4)})
-        >>> df.assign(quarter = df.dates.dt.quarter,
-        ...          is_quarter_end = df.dates.dt.is_quarter_end)
+        ...                    periods=4)})
+        >>> df.assign(quarter=df.dates.dt.quarter,
+        ...           is_quarter_end=df.dates.dt.is_quarter_end)
                dates  quarter    is_quarter_end
         0 2017-03-30        1             False
         1 2017-03-31        1              True
         2 2017-04-01        2             False
         3 2017-04-02        2             False
+
+        >>> idx = pd.date_range('2017-03-30', periods=4)
+        >>> idx
+        DatetimeIndex(['2017-03-30', '2017-03-31', '2017-04-01', '2017-04-02'],
+                      dtype='datetime64[ns]', freq='D')
+
+        >>> idx.is_quarter_end
+        array([False,  True, False, False])
         """)
     is_year_start = _field_accessor(
         'is_year_start',

--- a/pandas/core/indexes/datetimes.py
+++ b/pandas/core/indexes/datetimes.py
@@ -1739,7 +1739,33 @@ class DatetimeIndex(DatelikeOps, TimelikeOps, DatetimeIndexOpsMixin,
     is_quarter_end = _field_accessor(
         'is_quarter_end',
         'is_quarter_end',
-        "Logical indicating if last day of quarter (defined by frequency)")
+        """
+        Return a boolean indicating whether the date is the last day of a
+        quarter.
+
+        Returns
+        -------
+        is_quarter_end : Series of boolean.
+
+        See Also
+        --------
+        quarter : Return the quarter of the date.
+
+        is_quarter_start : Return a boolean indicating whether the date is the
+            first day of the quarter.
+
+        Examples
+        --------
+        >>> df = pd.DataFrame({'dates': pd.date_range("2017-03-30",
+        ...                   periods=4)})
+        >>> df.assign(quarter = df.dates.dt.quarter,
+        ...          is_quarter_end = df.dates.dt.is_quarter_end)
+               dates  quarter    is_quarter_end
+        0 2017-03-30        1             False
+        1 2017-03-31        1              True
+        2 2017-04-01        2             False
+        3 2017-04-02        2             False
+        """)
     is_year_start = _field_accessor(
         'is_year_start',
         'is_year_start',


### PR DESCRIPTION
Checklist for the pandas documentation sprint (ignore this if you are doing
an unrelated PR):

- [X] PR title is "DOC: update the <your-function-or-method> docstring"
- [X] The validation script passes: `scripts/validate_docstrings.py <your-function-or-method>`
- [X] The PEP8 style check passes: `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [X] The html version looks good: `python doc/make.py --single <your-function-or-method>`
- [X] It has been proofread on language by another sprint participant

Please include the output of the validation script below between the "```" ticks:

```
################################################################################
################# Docstring (pandas.Series.dt.is_quarter_end)  #################
################################################################################

Return a boolean indicating whether the date is the last day of a
quarter.

Returns
-------
is_quarter_end : Series of boolean.

See Also
--------
quarter : Return the quarter of the date.

is_quarter_start : Return a boolean indicating whether the date is the
    first day of the quarter.

Examples
--------
>>> df = pd.DataFrame({'dates': pd.date_range("2017-03-30",
...                   periods=4)})
>>> df.assign(quarter = df.dates.dt.quarter,
...          is_quarter_end = df.dates.dt.is_quarter_end)
       dates  quarter    is_quarter_end
0 2017-03-30        1             False
1 2017-03-31        1              True
2 2017-04-01        2             False
3 2017-04-02        2             False

################################################################################
################################## Validation ##################################
################################################################################

Errors found:
	No summary found (a short summary in a single line should be present at the beginning of the docstring)

```

If the validation script still gives errors, but you think there is a good reason
to deviate in this case (and there are certainly such cases), please state this
explicitly.

* No extended summary required.
* Short summary exceeds one line by one word, hope that is ok
