### PR TITLE
DOC: update the pandas.Series.str.split docstring

### DIFF
--- a/pandas/core/strings.py
+++ b/pandas/core/strings.py
@@ -1122,9 +1122,12 @@ def str_split(arr, pat=None, n=None):
 
     Notes
     -----
-    - If n >= default splits, makes all splits
-    - If n < default splits, makes first n splits only
-    - Appends `None` for padding if ``expand=True``
+    The handling of the `n` keyword depends on the number of found splits:
+
+    - If found splits > `n`,  make first `n` splits only
+    - If found splits <= `n`, make all splits
+    - If for a certain row the number of found splits < `n`,
+      append `None` for padding up to `n` if ``expand=True``
 
     Examples
     --------

--- a/pandas/core/strings.py
+++ b/pandas/core/strings.py
@@ -1116,9 +1116,9 @@ def str_split(arr, pat=None, n=None):
 
     Returns
     -------
-    Type matches caller unless `expand=True` (return type is `DataFrame` or
-    `MultiIndex`)
     split : Series/Index or DataFrame/MultiIndex of objects
+        Type matches caller unless `expand=True` (return type is `DataFrame` or
+    `MultiIndex`)
 
     Notes
     -----

--- a/pandas/core/strings.py
+++ b/pandas/core/strings.py
@@ -1104,27 +1104,27 @@ def str_split(arr, pat=None, n=None):
     ----------
     pat : str, optional
         String or regular expression to split on.
-        If `None`, split on whitespace.
+        If not specified, split on whitespace.
     n : int, default -1 (all)
         Limit number of splits in output.
-        `None`, 0 and -1 will be interpreted as return all splits.
+        ``None``, 0 and -1 will be interpreted as return all splits.
     expand : bool, default False
         Expand the splitted strings into separate columns.
 
-        * If `True`, return DataFrame/MultiIndex expanding dimensionality.
-        * If `False`, return Series/Index, containing lists of strings.
+        * If ``True``, return DataFrame/MultiIndex expanding dimensionality.
+        * If ``False``, return Series/Index, containing lists of strings.
 
     Returns
     -------
     split : Series/Index or DataFrame/MultiIndex of objects
-        Type matches caller unless `expand=True` (return type is `DataFrame` or
-    `MultiIndex`)
+        Type matches caller unless ``expand=True`` (return type is DataFrame or
+    MultiIndex)
 
     Notes
     -----
     - If n >= default splits, makes all splits
     - If n < default splits, makes first n splits only
-    - Appends `None` for padding if `expand=True`
+    - Appends `None` for padding if ``expand=True``
 
     Examples
     --------
@@ -1142,7 +1142,7 @@ def str_split(arr, pat=None, n=None):
     1    [but this is even better]
     dtype: object
 
-    When using `expand=True`, the split elements will
+    When using ``expand=True``, the split elements will
     expand out into separate columns.
 
     >>> s.str.split(expand=True)


### PR DESCRIPTION
Checklist for the pandas documentation sprint (ignore this if you are doing
an unrelated PR):

- [x] PR title is "DOC: update the <your-function-or-method> docstring"
- [x] The validation script passes: `scripts/validate_docstrings.py <your-function-or-method>`
- [x] The PEP8 style check passes: `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] The html version looks good: `python doc/make.py --single <your-function-or-method>`
- [x] It has been proofread on language by another sprint participant

```
################################################################################
##################### Docstring (pandas.Series.str.split)  #####################
################################################################################

Split strings around given separator/delimiter.

Split each str in the caller's values by given
pattern, propagating NaN values. Equivalent to :meth:`str.split`.

Parameters
----------
pat : string, default None
    String or regular expression to split on.
    If `None`, split on whitespace.
n : int, default -1 (all)
    Vary dimensionality of output.

    * `None`, 0 and -1 will be interpreted as return all splits
expand : bool, default False
    Expand the split strings into separate columns.

    * If `True`, return DataFrame/MultiIndex expanding dimensionality.
    * If `False`, return Series/Index.

Returns
-------
Type matches caller unless `expand=True` (return type is `DataFrame`)
split : Series/Index or DataFrame/MultiIndex of objects

Notes
-----
If `expand` parameter is `True` and:
  - If n >= default splits, makes all splits
  - If n < default splits, makes first n splits only
  - Appends `None` for padding.

Examples
--------
>>> s = pd.Series(["this is good text", "but this is even better"])

By default, split will return an object of the same size
having lists containing the split elements

>>> s.str.split()
0           [this, is, good, text]
1    [but, this, is, even, better]
dtype: object
>>> s.str.split("random")
0          [this is good text]
1    [but this is even better]
dtype: object

When using `expand=True`, the split elements will
expand out into separate columns.

>>> s.str.split(expand=True)
      0     1     2     3       4
0  this    is  good  text    None
1   but  this    is  even  better
>>> s.str.split(" is ", expand=True)
          0            1
0      this    good text
1  but this  even better

Parameter `n` can be used to limit the number of columns in
expansion of output.

>>> s.str.split("is", n=1, expand=True)
        0                1
0      th     is good text
1  but th   is even better

If NaN is present, it is propagated throughout the columns
during the split.

>>> s = pd.Series(["this is good text", "but this is even better", np.nan])
>>> s.str.split(n=3, expand=True)
      0     1     2            3
0  this    is  good         text
1   but  this    is  even better
2   NaN   NaN   NaN          NaN

################################################################################
################################## Validation ##################################
################################################################################

Errors found:
	Errors in parameters section
		Parameter "n" description should finish with "."
	See Also section not found
```