### PR TITLE
DOC/TST: Added NORMALIZE_WHITESPACE flag

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -32,3 +32,4 @@ markers =
     slow: mark a test as slow
     network: mark a test as network
     high_memory: mark a test as a high-memory only
+doctest_optionflags= NORMALIZE_WHITESPACE

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,4 +32,4 @@ markers =
     slow: mark a test as slow
     network: mark a test as network
     high_memory: mark a test as a high-memory only
-doctest_optionflags= NORMALIZE_WHITESPACE
+doctest_optionflags= NORMALIZE_WHITESPACE IGNORE_EXCEPTION_DETAIL


### PR DESCRIPTION
I think we want this to be always on. You can disable it with

```
doctest: -NORMALIZE_WHITESPACE
```