### PR TITLE
TST: adding join_types fixture

### DIFF
--- a/pandas/conftest.py
+++ b/pandas/conftest.py
@@ -89,3 +89,11 @@ def compression_no_zip(request):
 def datetime_tz_utc():
     from datetime import timezone
     return timezone.utc
+
+
+@pytest.fixture(params=['inner', 'outer', 'left', 'right'])
+def join_type(request):
+    """
+    Fixture for trying all types of join operations
+    """
+    return request.param

--- a/pandas/tests/indexes/common.py
+++ b/pandas/tests/indexes/common.py
@@ -978,11 +978,10 @@ class Base(object):
         assert not index.empty
         assert index[:0].empty
 
-    @pytest.mark.parametrize('how', ['outer', 'inner', 'left', 'right'])
-    def test_join_self_unique(self, how):
+    def test_join_self_unique(self, join_type):
         index = self.create_index()
         if index.is_unique:
-            joined = index.join(index, how=how)
+            joined = index.join(index, how=join_type)
             assert (index == joined).all()
 
     def test_searchsorted_monotonic(self, indices):

--- a/pandas/tests/indexes/datetimes/test_datetime.py
+++ b/pandas/tests/indexes/datetimes/test_datetime.py
@@ -250,10 +250,9 @@ class TestDatetimeIndex(object):
         assert cols.dtype == joined.dtype
         tm.assert_numpy_array_equal(cols.values, joined.values)
 
-    @pytest.mark.parametrize('how', ['outer', 'inner', 'left', 'right'])
-    def test_join_self(self, how):
+    def test_join_self(self, join_type):
         index = date_range('1/1/2000', periods=10)
-        joined = index.join(index, how=how)
+        joined = index.join(index, how=join_type)
         assert index is joined
 
     def assert_index_parameters(self, index):
@@ -274,8 +273,7 @@ class TestDatetimeIndex(object):
                                      freq=index.freq)
         self.assert_index_parameters(new_index)
 
-    @pytest.mark.parametrize('how', ['left', 'right', 'inner', 'outer'])
-    def test_join_with_period_index(self, how):
+    def test_join_with_period_index(self, join_type):
         df = tm.makeCustomDataframe(
             10, 10, data_gen_f=lambda *args: np.random.randint(2),
             c_idx_type='p', r_idx_type='dt')
@@ -284,7 +282,7 @@ class TestDatetimeIndex(object):
         with tm.assert_raises_regex(ValueError,
                                     'can only call with other '
                                     'PeriodIndex-ed objects'):
-            df.columns.join(s.index, how=how)
+            df.columns.join(s.index, how=join_type)
 
     def test_factorize(self):
         idx1 = DatetimeIndex(['2014-01', '2014-01', '2014-02', '2014-02',

--- a/pandas/tests/indexes/datetimes/test_timezones.py
+++ b/pandas/tests/indexes/datetimes/test_timezones.py
@@ -700,18 +700,17 @@ class TestDatetimeIndexTimezones(object):
     # -------------------------------------------------------------
     # Unsorted
 
-    @pytest.mark.parametrize('how', ['inner', 'outer', 'left', 'right'])
-    def test_join_utc_convert(self, how):
+    def test_join_utc_convert(self, join_type):
         rng = date_range('1/1/2011', periods=100, freq='H', tz='utc')
 
         left = rng.tz_convert('US/Eastern')
         right = rng.tz_convert('Europe/Berlin')
 
-        result = left.join(left[:-5], how=how)
+        result = left.join(left[:-5], how=join_type)
         assert isinstance(result, DatetimeIndex)
         assert result.tz == left.tz
 
-        result = left.join(right[:-5], how=how)
+        result = left.join(right[:-5], how=join_type)
         assert isinstance(result, DatetimeIndex)
         assert result.tz.zone == 'UTC'
 

--- a/pandas/tests/indexes/period/test_period.py
+++ b/pandas/tests/indexes/period/test_period.py
@@ -532,10 +532,9 @@ class TestPeriodIndex(DatetimeLike):
         exp = Index([x.ordinal for x in index])
         tm.assert_index_equal(result, exp)
 
-    @pytest.mark.parametrize('how', ['outer', 'inner', 'left', 'right'])
-    def test_join_self(self, how):
+    def test_join_self(self, join_type):
         index = period_range('1/1/2000', periods=10)
-        joined = index.join(index, how=how)
+        joined = index.join(index, how=join_type)
         assert index is joined
 
     def test_insert(self):

--- a/pandas/tests/indexes/period/test_setops.py
+++ b/pandas/tests/indexes/period/test_setops.py
@@ -14,20 +14,18 @@ def _permute(obj):
 
 class TestPeriodIndex(object):
 
-    @pytest.mark.parametrize('kind', ['inner', 'outer', 'left', 'right'])
-    def test_joins(self, kind):
+    def test_joins(self, join_type):
         index = period_range('1/1/2000', '1/20/2000', freq='D')
 
-        joined = index.join(index[:-5], how=kind)
+        joined = index.join(index[:-5], how=join_type)
 
         assert isinstance(joined, PeriodIndex)
         assert joined.freq == index.freq
 
-    @pytest.mark.parametrize('kind', ['inner', 'outer', 'left', 'right'])
-    def test_join_self(self, kind):
+    def test_join_self(self, join_type):
         index = period_range('1/1/2000', '1/20/2000', freq='D')
 
-        res = index.join(index, how=kind)
+        res = index.join(index, how=join_type)
         assert index is res
 
     def test_join_does_not_recur(self):

--- a/pandas/tests/indexes/test_base.py
+++ b/pandas/tests/indexes/test_base.py
@@ -1599,16 +1599,15 @@ class TestIndex(Base):
         idx = Index(['a', 'b'], name='asdf')
         assert idx.name == idx[1:].name
 
-    def test_join_self(self):
-        # instance attributes of the form self.<name>Index
-        indices = 'unicode', 'str', 'date', 'int', 'float'
-        kinds = 'outer', 'inner', 'left', 'right'
-        for index_kind in indices:
-            res = getattr(self, '{0}Index'.format(index_kind))
+    # instance attributes of the form self.<name>Index
+    @pytest.mark.parametrize('index_kind',
+                             ['unicode', 'str', 'date', 'int', 'float'])
+    def test_join_self(self, join_type, index_kind):
 
-            for kind in kinds:
-                joined = res.join(res, how=kind)
-                assert res is joined
+        res = getattr(self, '{0}Index'.format(index_kind))
+
+        joined = res.join(res, how=join_type)
+        assert res is joined
 
     def test_str_attribute(self):
         # GH9068

--- a/pandas/tests/indexes/test_multi.py
+++ b/pandas/tests/indexes/test_multi.py
@@ -450,11 +450,11 @@ class TestMultiIndex(Base):
 
         # Make sure label setting works too
         labels2 = [[0, 0, 0, 0, 0, 0], [0, 0, 0, 0, 0, 0]]
-        exp_values = np.empty((6, ), dtype=object)
+        exp_values = np.empty((6,), dtype=object)
         exp_values[:] = [(long(1), 'a')] * 6
 
         # Must be 1d array of tuples
-        assert exp_values.shape == (6, )
+        assert exp_values.shape == (6,)
         new_values = mi2.set_labels(labels2).values
 
         # Not inplace shouldn't change
@@ -583,7 +583,7 @@ class TestMultiIndex(Base):
 
     def test_constructor_no_levels(self):
         tm.assert_raises_regex(ValueError, "non-zero number "
-                               "of levels/labels",
+                                           "of levels/labels",
                                MultiIndex, levels=[], labels=[])
         both_re = re.compile('Must pass both levels and labels')
         with tm.assert_raises_regex(TypeError, both_re):
@@ -595,7 +595,7 @@ class TestMultiIndex(Base):
         labels = [np.array([1]), np.array([2]), np.array([3])]
         levels = ["a"]
         tm.assert_raises_regex(ValueError, "Length of levels and labels "
-                               "must be the same", MultiIndex,
+                                           "must be the same", MultiIndex,
                                levels=levels, labels=labels)
         length_error = re.compile('>= length of level')
         label_error = re.compile(r'Unequal label lengths: \[4, 2\]')
@@ -844,19 +844,19 @@ class TestMultiIndex(Base):
         idx1 = [1, 2, 3]
         idx2 = ['a', 'b']
         tm.assert_raises_regex(ValueError, '^all arrays must '
-                               'be same length$',
+                                           'be same length$',
                                MultiIndex.from_arrays, [idx1, idx2])
 
         idx1 = []
         idx2 = ['a', 'b']
         tm.assert_raises_regex(ValueError, '^all arrays must '
-                               'be same length$',
+                                           'be same length$',
                                MultiIndex.from_arrays, [idx1, idx2])
 
         idx1 = [1, 2, 3]
         idx2 = []
         tm.assert_raises_regex(ValueError, '^all arrays must '
-                               'be same length$',
+                                           'be same length$',
                                MultiIndex.from_arrays, [idx1, idx2])
 
     def test_from_product(self):
@@ -964,7 +964,7 @@ class TestMultiIndex(Base):
 
     def test_values_multiindex_datetimeindex(self):
         # Test to ensure we hit the boxing / nobox part of MI.values
-        ints = np.arange(10**18, 10**18 + 5)
+        ints = np.arange(10 ** 18, 10 ** 18 + 5)
         naive = pd.DatetimeIndex(ints)
         aware = pd.DatetimeIndex(ints, tz='US/Central')
 
@@ -1023,7 +1023,7 @@ class TestMultiIndex(Base):
 
     def test_append_mixed_dtypes(self):
         # GH 13660
-        dti = date_range('2011-01-01', freq='M', periods=3,)
+        dti = date_range('2011-01-01', freq='M', periods=3, )
         dti_tz = date_range('2011-01-01', freq='M', periods=3, tz='US/Eastern')
         pi = period_range('2011-01', freq='M', periods=3)
 
@@ -1067,9 +1067,12 @@ class TestMultiIndex(Base):
         tm.assert_index_equal(result, expected)
 
         # GH 10460
-        index = MultiIndex(levels=[CategoricalIndex(
-            ['A', 'B']), CategoricalIndex([1, 2, 3])], labels=[np.array(
-                [0, 0, 0, 1, 1, 1]), np.array([0, 1, 2, 0, 1, 2])])
+        index = MultiIndex(
+            levels=[CategoricalIndex(['A', 'B']),
+                    CategoricalIndex([1, 2, 3])],
+            labels=[np.array([0, 0, 0, 1, 1, 1]),
+                    np.array([0, 1, 2, 0, 1, 2])])
+
         exp = CategoricalIndex(['A', 'A', 'A', 'B', 'B', 'B'])
         tm.assert_index_equal(index.get_level_values(0), exp)
         exp = CategoricalIndex([1, 2, 3, 1, 2, 3])
@@ -1397,7 +1400,7 @@ class TestMultiIndex(Base):
                 [0, 1, 0, 0, 0, 1, 0, 1]), np.array([1, 0, 1, 1, 0, 0, 1, 0])])
 
         tm.assert_raises_regex(KeyError, "[Kk]ey length.*greater than "
-                               "MultiIndex lexsort depth",
+                                         "MultiIndex lexsort depth",
                                index.slice_locs, (1, 0, 1), (2, 1, 0))
 
         # works
@@ -1887,12 +1890,12 @@ class TestMultiIndex(Base):
         expected.names = first.names
         assert first.names == result.names
         tm.assert_raises_regex(TypeError, "other must be a MultiIndex "
-                               "or a list of tuples",
+                                          "or a list of tuples",
                                first.difference, [1, 2, 3, 4, 5])
 
     def test_from_tuples(self):
         tm.assert_raises_regex(TypeError, 'Cannot infer number of levels '
-                               'from empty list',
+                                          'from empty list',
                                MultiIndex.from_tuples, [])
 
         expected = MultiIndex(levels=[[1, 3], [2, 4]],
@@ -2039,8 +2042,9 @@ class TestMultiIndex(Base):
         dropped = index.droplevel(0)
         assert dropped.name == 'second'
 
-        index = MultiIndex(levels=[Index(lrange(4)), Index(lrange(4)), Index(
-            lrange(4))], labels=[np.array([0, 0, 1, 2, 2, 2, 3, 3]), np.array(
+        index = MultiIndex(
+            levels=[Index(lrange(4)), Index(lrange(4)), Index(lrange(4))],
+            labels=[np.array([0, 0, 1, 2, 2, 2, 3, 3]), np.array(
                 [0, 1, 0, 0, 0, 1, 0, 1]), np.array([1, 0, 1, 1, 0, 0, 1, 0])],
             names=['one', 'two', 'three'])
         dropped = index.droplevel(0)
@@ -2051,8 +2055,9 @@ class TestMultiIndex(Base):
         assert dropped.equals(expected)
 
     def test_droplevel_multiple(self):
-        index = MultiIndex(levels=[Index(lrange(4)), Index(lrange(4)), Index(
-            lrange(4))], labels=[np.array([0, 0, 1, 2, 2, 2, 3, 3]), np.array(
+        index = MultiIndex(
+            levels=[Index(lrange(4)), Index(lrange(4)), Index(lrange(4))],
+            labels=[np.array([0, 0, 1, 2, 2, 2, 3, 3]), np.array(
                 [0, 1, 0, 0, 0, 1, 0, 1]), np.array([1, 0, 1, 1, 0, 0, 1, 0])],
             names=['one', 'two', 'three'])
 
@@ -2101,7 +2106,7 @@ class TestMultiIndex(Base):
         # key wrong length
         msg = "Item must have length equal to number of levels"
         with tm.assert_raises_regex(ValueError, msg):
-            self.index.insert(0, ('foo2', ))
+            self.index.insert(0, ('foo2',))
 
         left = pd.DataFrame([['a', 'b', 0], ['b', 'd', 1]],
                             columns=['1st', '2nd', '3rd'])
@@ -2134,8 +2139,8 @@ class TestMultiIndex(Base):
 
         # GH9250
         idx = [('test1', i) for i in range(5)] + \
-            [('test2', i) for i in range(6)] + \
-            [('test', 17), ('test', 18)]
+              [('test2', i) for i in range(6)] + \
+              [('test', 17), ('test', 18)]
 
         left = pd.Series(np.linspace(0, 10, 11),
                          pd.MultiIndex.from_tuples(idx[:-2]))
@@ -2210,42 +2215,36 @@ class TestMultiIndex(Base):
         tm.assert_raises_regex(ValueError, msg, idx.take,
                                indices, mode='clip')
 
-    def test_join_level(self):
-        def _check_how(other, how):
-            join_index, lidx, ridx = other.join(self.index, how=how,
-                                                level='second',
-                                                return_indexers=True)
+    @pytest.mark.parametrize('other',
+                             [Index(['three', 'one', 'two']),
+                              Index(['one']),
+                              Index(['one', 'three'])])
+    def test_join_level(self, other, join_type):
+        join_index, lidx, ridx = other.join(self.index, how=join_type,
+                                            level='second',
+                                            return_indexers=True)
 
-            exp_level = other.join(self.index.levels[1], how=how)
-            assert join_index.levels[0].equals(self.index.levels[0])
-            assert join_index.levels[1].equals(exp_level)
+        exp_level = other.join(self.index.levels[1], how=join_type)
+        assert join_index.levels[0].equals(self.index.levels[0])
+        assert join_index.levels[1].equals(exp_level)
 
-            # pare down levels
-            mask = np.array(
-                [x[1] in exp_level for x in self.index], dtype=bool)
-            exp_values = self.index.values[mask]
-            tm.assert_numpy_array_equal(join_index.values, exp_values)
+        # pare down levels
+        mask = np.array(
+            [x[1] in exp_level for x in self.index], dtype=bool)
+        exp_values = self.index.values[mask]
+        tm.assert_numpy_array_equal(join_index.values, exp_values)
 
-            if how in ('outer', 'inner'):
-                join_index2, ridx2, lidx2 = \
-                    self.index.join(other, how=how, level='second',
-                                    return_indexers=True)
+        if join_type in ('outer', 'inner'):
+            join_index2, ridx2, lidx2 = \
+                self.index.join(other, how=join_type, level='second',
+                                return_indexers=True)
 
-                assert join_index.equals(join_index2)
-                tm.assert_numpy_array_equal(lidx, lidx2)
-                tm.assert_numpy_array_equal(ridx, ridx2)
-                tm.assert_numpy_array_equal(join_index2.values, exp_values)
+            assert join_index.equals(join_index2)
+            tm.assert_numpy_array_equal(lidx, lidx2)
+            tm.assert_numpy_array_equal(ridx, ridx2)
+            tm.assert_numpy_array_equal(join_index2.values, exp_values)
 
-        def _check_all(other):
-            _check_how(other, 'outer')
-            _check_how(other, 'inner')
-            _check_how(other, 'left')
-            _check_how(other, 'right')
-
-        _check_all(Index(['three', 'one', 'two']))
-        _check_all(Index(['one']))
-        _check_all(Index(['one', 'three']))
-
+    def test_join_level_corner_case(self):
         # some corner cases
         idx = Index(['three', 'one', 'two'])
         result = idx.join(self.index, level='second')
@@ -2254,12 +2253,10 @@ class TestMultiIndex(Base):
         tm.assert_raises_regex(TypeError, "Join.*MultiIndex.*ambiguous",
                                self.index.join, self.index, level=1)
 
-    def test_join_self(self):
-        kinds = 'outer', 'inner', 'left', 'right'
-        for kind in kinds:
-            res = self.index
-            joined = res.join(res, how=kind)
-            assert res is joined
+    def test_join_self(self, join_type):
+        res = self.index
+        joined = res.join(res, how=join_type)
+        assert res is joined
 
     def test_join_multi(self):
         # GH 10665
@@ -2335,7 +2332,7 @@ class TestMultiIndex(Base):
         assert self.index.append(self.index).has_duplicates
 
         index = MultiIndex(levels=[[0, 1], [0, 1, 2]], labels=[
-                           [0, 0, 0, 0, 1, 1, 1], [0, 1, 2, 0, 0, 1, 2]])
+            [0, 0, 0, 0, 1, 1, 1], [0, 1, 2, 0, 0, 1, 2]])
         assert index.has_duplicates
 
         # GH 9075
@@ -2434,8 +2431,11 @@ class TestMultiIndex(Base):
 
     def test_duplicate_meta_data(self):
         # GH 10115
-        index = MultiIndex(levels=[[0, 1], [0, 1, 2]], labels=[
-                           [0, 0, 0, 0, 1, 1, 1], [0, 1, 2, 0, 0, 1, 2]])
+        index = MultiIndex(
+            levels=[[0, 1], [0, 1, 2]],
+            labels=[[0, 0, 0, 0, 1, 1, 1],
+                    [0, 1, 2, 0, 0, 1, 2]])
+
         for idx in [index,
                     index.set_names([None, None]),
                     index.set_names([None, 'Num']),

--- a/pandas/tests/indexes/timedeltas/test_timedelta.py
+++ b/pandas/tests/indexes/timedeltas/test_timedelta.py
@@ -102,10 +102,9 @@ class TestTimedeltaIndex(DatetimeLike):
         tm.assert_numpy_array_equal(arr, exp_arr)
         tm.assert_index_equal(idx, idx3)
 
-    @pytest.mark.parametrize('kind', ['outer', 'inner', 'left', 'right'])
-    def test_join_self(self, kind):
+    def test_join_self(self, join_type):
         index = timedelta_range('1 day', periods=10)
-        joined = index.join(index, how=kind)
+        joined = index.join(index, how=join_type)
         tm.assert_index_equal(index, joined)
 
     def test_does_not_convert_mixed_integer(self):

--- a/pandas/tests/reshape/merge/test_join.py
+++ b/pandas/tests/reshape/merge/test_join.py
@@ -297,7 +297,25 @@ class TestJoin(object):
                               'b': [2, 2]}, index=df.index)
         tm.assert_frame_equal(result, expected)
 
-    def test_join_index_mixed(self):
+    def test_join_index_mixed(self, join_type):
+        # no overlapping blocks
+        df1 = DataFrame(index=np.arange(10))
+        df1['bool'] = True
+        df1['string'] = 'foo'
+
+        df2 = DataFrame(index=np.arange(5, 15))
+        df2['int'] = 1
+        df2['float'] = 1.
+
+        joined = df1.join(df2, how=join_type)
+        expected = _join_by_hand(df1, df2, how=join_type)
+        assert_frame_equal(joined, expected)
+
+        joined = df2.join(df1, how=join_type)
+        expected = _join_by_hand(df2, df1, how=join_type)
+        assert_frame_equal(joined, expected)
+
+    def test_join_index_mixed_overlap(self):
         df1 = DataFrame({'A': 1., 'B': 2, 'C': 'foo', 'D': True},
                         index=np.arange(10),
                         columns=['A', 'B', 'C', 'D'])
@@ -316,25 +334,6 @@ class TestJoin(object):
         df2.columns = expected_columns[4:]
         expected = _join_by_hand(df1, df2)
         assert_frame_equal(joined, expected)
-
-        # no overlapping blocks
-        df1 = DataFrame(index=np.arange(10))
-        df1['bool'] = True
-        df1['string'] = 'foo'
-
-        df2 = DataFrame(index=np.arange(5, 15))
-        df2['int'] = 1
-        df2['float'] = 1.
-
-        for kind in ['inner', 'outer', 'left', 'right']:
-
-            joined = df1.join(df2, how=kind)
-            expected = _join_by_hand(df1, df2, how=kind)
-            assert_frame_equal(joined, expected)
-
-            joined = df2.join(df1, how=kind)
-            expected = _join_by_hand(df2, df1, how=kind)
-            assert_frame_equal(joined, expected)
 
     def test_join_empty_bug(self):
         # generated an exception in 0.4.3

--- a/pandas/tests/reshape/merge/test_merge_index_as_string.py
+++ b/pandas/tests/reshape/merge/test_merge_index_as_string.py
@@ -157,9 +157,7 @@ def test_merge_indexes_and_columns_lefton_righton(
 
 @pytest.mark.parametrize('left_index',
                          ['inner', ['inner', 'outer']])
-@pytest.mark.parametrize('how',
-                         ['inner', 'left', 'right', 'outer'])
-def test_join_indexes_and_columns_on(df1, df2, left_index, how):
+def test_join_indexes_and_columns_on(df1, df2, left_index, join_type):
 
     # Construct left_df
     left_df = df1.set_index(left_index)
@@ -169,12 +167,12 @@ def test_join_indexes_and_columns_on(df1, df2, left_index, how):
 
     # Result
     expected = (left_df.reset_index()
-                .join(right_df, on=['outer', 'inner'], how=how,
+                .join(right_df, on=['outer', 'inner'], how=join_type,
                       lsuffix='_x', rsuffix='_y')
                 .set_index(left_index))
 
     # Perform join
-    result = left_df.join(right_df, on=['outer', 'inner'], how=how,
+    result = left_df.join(right_df, on=['outer', 'inner'], how=join_type,
                           lsuffix='_x', rsuffix='_y')
 
     assert_frame_equal(result, expected, check_like=True)

--- a/pandas/tests/series/indexing/test_alter_index.py
+++ b/pandas/tests/series/indexing/test_alter_index.py
@@ -18,8 +18,6 @@ from pandas.compat import lrange, range
 from pandas.util.testing import (assert_series_equal)
 import pandas.util.testing as tm
 
-JOIN_TYPES = ['inner', 'outer', 'left', 'right']
-
 
 @pytest.mark.parametrize(
     'first_slice,second_slice', [
@@ -28,7 +26,6 @@ JOIN_TYPES = ['inner', 'outer', 'left', 'right']
         [[None, -5], [None, 0]],
         [[None, 0], [None, 0]]
     ])
-@pytest.mark.parametrize('join_type', JOIN_TYPES)
 @pytest.mark.parametrize('fill', [None, -1])
 def test_align(test_data, first_slice, second_slice, join_type, fill):
     a = test_data.ts[slice(*first_slice)]
@@ -67,7 +64,6 @@ def test_align(test_data, first_slice, second_slice, join_type, fill):
         [[None, -5], [None, 0]],
         [[None, 0], [None, 0]]
     ])
-@pytest.mark.parametrize('join_type', JOIN_TYPES)
 @pytest.mark.parametrize('method', ['pad', 'bfill'])
 @pytest.mark.parametrize('limit', [None, 1])
 def test_align_fill_method(test_data,

--- a/pandas/tests/series/indexing/test_boolean.py
+++ b/pandas/tests/series/indexing/test_boolean.py
@@ -16,8 +16,6 @@ from pandas.tseries.offsets import BDay
 from pandas.util.testing import (assert_series_equal)
 import pandas.util.testing as tm
 
-JOIN_TYPES = ['inner', 'outer', 'left', 'right']
-
 
 def test_getitem_boolean(test_data):
     s = test_data.series

--- a/pandas/tests/series/indexing/test_datetime.py
+++ b/pandas/tests/series/indexing/test_datetime.py
@@ -20,7 +20,6 @@ import pandas.util.testing as tm
 import pandas._libs.index as _index
 from pandas._libs import tslib
 
-JOIN_TYPES = ['inner', 'outer', 'left', 'right']
 
 """
 Also test support for datetime64[ns] in Series / DataFrame

--- a/pandas/tests/series/test_period.py
+++ b/pandas/tests/series/test_period.py
@@ -117,7 +117,7 @@ class TestSeriesPeriod(object):
         result = df.values.squeeze()
         assert (result[:, 0] == expected.values).all()
 
-    def test_align_series(self):
+    def test_add_series(self):
         rng = period_range('1/1/2000', '1/1/2010', freq='A')
         ts = Series(np.random.randn(len(rng)), index=rng)
 
@@ -129,12 +129,15 @@ class TestSeriesPeriod(object):
         result = ts + _permute(ts[::2])
         tm.assert_series_equal(result, expected)
 
-        # it works!
-        for kind in ['inner', 'outer', 'left', 'right']:
-            ts.align(ts[::2], join=kind)
         msg = "Input has different freq=D from PeriodIndex\\(freq=A-DEC\\)"
         with tm.assert_raises_regex(period.IncompatibleFrequency, msg):
             ts + ts.asfreq('D', how="end")
+
+    def test_align_series(self, join_type):
+        rng = period_range('1/1/2000', '1/1/2010', freq='A')
+        ts = Series(np.random.randn(len(rng)), index=rng)
+
+        ts.align(ts[::2], join=join_type)
 
     def test_truncate(self):
         # GH 17717


### PR DESCRIPTION
follow up for PR #20059

Extracting join types to a fixture

- [ ] tests added / passed
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
