### PR TITLE
DOC: update the DataFrame.at[] docstring

### DIFF
--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -1888,11 +1888,49 @@ class _ScalarAccessIndexer(_NDFrameIndexer):
 
 
 class _AtIndexer(_ScalarAccessIndexer):
-    """Fast label-based scalar accessor
+    """
+    Access a single value for a row/column label pair.
 
-    Similarly to ``loc``, ``at`` provides **label** based scalar lookups.
-    You can also set using these indexers.
+    Similar to ``loc``, in that both provide label-based lookups. Use
+    ``at`` if you only need to get or set a single value in a DataFrame
+    or Series.
 
+    See Also
+    --------
+    DataFrame.iat : Access a single value for a row/column pair by integer position
+    DataFrame.loc : Access a group of rows and columns by label(s)
+    Series.at : Access a single value using a label
+
+    Examples
+    --------
+    >>> df = pd.DataFrame([[0, 2, 3], [0, 4, 1], [10, 20, 30]],
+    ...                   index=[4, 5, 6], columns=['A', 'B', 'C'])
+    >>> df
+        A   B   C
+    4   0   2   3
+    5   0   4   1
+    6  10  20  30
+
+    Get value at specified row/column pair
+
+    >>> df.at[4, 'B']
+    2
+
+    Set value at specified row/column pair
+
+    >>> df.at[4, 'B'] = 10
+    >>> df.at[4, 'B']
+    10
+
+    Get value within a series
+
+    >>> df.loc[5].at['B']
+    4
+
+    Raises
+    ------
+    KeyError
+        When label does not exist in DataFrame
     """
 
     _takeable = False

--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -1897,12 +1897,10 @@ class _AtIndexer(_ScalarAccessIndexer):
 
     See Also
     --------
-    DataFrame.iat
-        Access a single value for a row/column pair by integer position
-    DataFrame.loc
-        Access a group of rows and columns by label(s)
-    Series.at
-        Access a single value using a label
+    DataFrame.iat : Access a single value for a row/column pair by integer
+                    position
+    DataFrame.loc : Access a group of rows and columns by label(s)
+    Series.at : Access a single value using a label
 
     Examples
     --------
@@ -1925,7 +1923,7 @@ class _AtIndexer(_ScalarAccessIndexer):
     >>> df.at[4, 'B']
     10
 
-    Get value within a series
+    Get value within a Series
 
     >>> df.loc[5].at['B']
     4

--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -1897,9 +1897,12 @@ class _AtIndexer(_ScalarAccessIndexer):
 
     See Also
     --------
-    DataFrame.iat : Access a single value for a row/column pair by integer position
-    DataFrame.loc : Access a group of rows and columns by label(s)
-    Series.at : Access a single value using a label
+    DataFrame.iat
+        Access a single value for a row/column pair by integer position
+    DataFrame.loc
+        Access a group of rows and columns by label(s)
+    Series.at
+        Access a single value using a label
 
     Examples
     --------

--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -1898,7 +1898,7 @@ class _AtIndexer(_ScalarAccessIndexer):
     See Also
     --------
     DataFrame.iat : Access a single value for a row/column pair by integer
-                    position
+        position
     DataFrame.loc : Access a group of rows and columns by label(s)
     Series.at : Access a single value using a label
 


### PR DESCRIPTION
Checklist for the pandas documentation sprint (ignore this if you are doing
an unrelated PR):

- [x] PR title is "DOC: update the <your-function-or-method> docstring"
- [x] The validation script passes: `scripts/validate_docstrings.py <your-function-or-method>`
- [x] The PEP8 style check passes: `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] The html version looks good: `python doc/make.py --single <your-function-or-method>`
- [x] It has been proofread on language by another sprint participant

Please include the output of the validation script below between the "```" ticks:

```
# paste output of "scripts/validate_docstrings.py <your-function-or-method>" here
# between the "```" (remove this comment, but keep the "```")
################################################################################
####################### Docstring (pandas.DataFrame.at)  #######################
################################################################################

Access a single value for a row/column label pair.

Similar to ``loc``, in that both provide label-based lookups. Use
``at`` if you only need to get or set a single value in a DataFrame
or Series.

See Also
--------
DataFrame.iat : Access a single value for a row/column pair by integer position
DataFrame.loc : Access a group of rows and columns by label(s)
Series.at : Access a single value using a label

Examples
--------
>>> df = pd.DataFrame([[0, 2, 3], [0, 4, 1], [10, 20, 30]],
...                   index=[4, 5, 6], columns=['A', 'B', 'C'])
>>> df
    A   B   C
4   0   2   3
5   0   4   1
6  10  20  30

Get value at specified row/column pair

>>> df.at[4, 'B']
2

Set value at specified row/column pair

>>> df.at[4, 'B'] = 10
>>> df.at[4, 'B']
10

Get value within a series

>>> df.loc[5].at['B']
4

Raises
------
KeyError
    When label does not exist in DataFrame

################################################################################
################################## Validation ##################################
################################################################################

Errors found:
	No returns section found

```

If the validation script still gives errors, but you think there is a good reason
to deviate in this case (and there are certainly such cases), please state this
explicitly.