### PR TITLE
DOC: update `pandas/core/ops.py` docstring with examples for pandas.DataFrame.gt and .ge methods

### DIFF
--- a/pandas/core/ops.py
+++ b/pandas/core/ops.py
@@ -370,6 +370,66 @@ d  1.0  NaN
 e  NaN  2.0
 """
 
+_gt_example_FRAME = """
+>>> df1 = pd.DataFrame({'num1': range(1,6),
+                        'num2': range(2,11,2),
+                        'num3': range(1,20,4)})
+>>> df1
+   num1  num2  num3
+0     1     2     1
+1     2     4     5
+2     3     6     9
+3     4     8    13
+4     5    10    17
+>>> df2 = pd.DataFrame({'num1': range(6,11),
+                        'num2': range(1,10,2),
+                        'num3': range(1,20,4)})
+>>> df2
+   num1  num2  num3
+0     6     1     1
+1     7     3     5
+2     8     5     9
+3     9     7    13
+4    10     9    17
+>>> df1.gt(df2)
+    num1  num2   num3
+0  False  True  False
+1  False  True  False
+2  False  True  False
+3  False  True  False
+4  False  True  False
+"""
+
+_ge_example_FRAME = """
+>>> df1 = pd.DataFrame({'num1': range(1,6),
+                        'num2': range(2,11,2),
+                        'num3': range(1,20,4)})
+>>> df1
+   num1  num2  num3
+0     1     2     1
+1     2     4     5
+2     3     6     9
+3     4     8    13
+4     5    10    17
+>>> df2 = pd.DataFrame({'num1': range(6,11),
+                        'num2': range(1,10,2),
+                        'num3': range(1,20,4)})
+>>> df2
+   num1  num2  num3
+0     6     1     1
+1     7     3     5
+2     8     5     9
+3     9     7    13
+4    10     9    17
+>>> df1.ge(df2)
+    num1  num2   num3
+0  False  True   True
+1  False  True   True
+2  False  True   True
+3  False  True   True
+4  False  True   True
+"""
+
 _op_descriptions = {
     # Arithmetic Operators
     'add': {'op': '+',
@@ -425,11 +485,11 @@ _op_descriptions = {
     'gt': {'op': '>',
            'desc': 'Greater than',
            'reverse': None,
-           'df_examples': None},
+           'df_examples': _gt_example_FRAME},
     'ge': {'op': '>=',
            'desc': 'Greater than or equal to',
            'reverse': None,
-           'df_examples': None}}
+           'df_examples': _ge_example_FRAME}}
 
 _op_names = list(_op_descriptions.keys())
 for key in _op_names:


### PR DESCRIPTION
Checklist for the pandas documentation sprint:

- [X] PR title is "DOC: update the <your-function-or-method> docstring"
- [ ] The validation script passes: `scripts/validate_docstrings.py <your-function-or-method>`
- [X] The PEP8 style check passes: `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [X] The html version looks good: `python doc/make.py --single <your-function-or-method>`
- [X] It has been proofread on language by another sprint participant

Please include the output of the validation script below between the "```" ticks:

```
################################################################################
####################### Docstring (pandas.DataFrame.gt)  #######################
################################################################################

Wrapper for flexible comparison methods gt

################################################################################
################################## Validation ##################################
################################################################################

Errors found:
	Docstring text (summary) should start in the line immediately after the opening quotes (not in the same line, or leaving a blank line in between)
	Closing quotes should be placed in the line after the last text in the docstring (do not close the quotes in the same line as the text, or leave a blank line between the last text and the quotes)
	Summary does not end with dot
	No extended summary found
	Errors in parameters section
		Parameters {'axis', 'level', 'other'} not documented
	No returns section found
	See Also section not found
	No examples section found

################################################################################
####################### Docstring (pandas.DataFrame.ge)  #######################
################################################################################

Wrapper for flexible comparison methods ge

################################################################################
################################## Validation ##################################
################################################################################

Errors found:
	Docstring text (summary) should start in the line immediately after the opening quotes (not in the same line, or leaving a blank line in between)
	Closing quotes should be placed in the line after the last text in the docstring (do not close the quotes in the same line as the text, or leave a blank line between the last text and the quotes)
	Summary does not end with dot
	No extended summary found
	Errors in parameters section
		Parameters {'level', 'other', 'axis'} not documented
	No returns section found
	See Also section not found
	No examples section found

```

If the validation script still gives errors, but you think there is a good reason
to deviate in this case (and there are certainly such cases), please state this
explicitly.

Comparison methods in `ops.py` including `.gt()` and `.ge()` do not have standard docstring like other methods. They use a generalized wrapper summary line. This pull request simply adds examples in line with recent merge for `.add()` method: https://github.com/pandas-dev/pandas/pull/20246/files