### PR TITLE
BUG: Retain tz-aware dtypes with melt (#15785)

### DIFF
--- a/doc/source/whatsnew/v0.23.0.txt
+++ b/doc/source/whatsnew/v0.23.0.txt
@@ -896,6 +896,7 @@ Timezones
 - Bug in :func:`Timestamp.tz_localize` where localizing a timestamp near the minimum or maximum valid values could overflow and return a timestamp with an incorrect nanosecond value (:issue:`12677`)
 - Bug when iterating over :class:`DatetimeIndex` that was localized with fixed timezone offset that rounded nanosecond precision to microseconds (:issue:`19603`)
 - Bug in :func:`DataFrame.diff` that raised an ``IndexError`` with tz-aware values (:issue:`18578`)
+- Bug in :func:`melt` that coverted tz-aware dtypes to tz-naive (:issue:`15785`)
 
 Offsets
 ^^^^^^^

--- a/doc/source/whatsnew/v0.23.0.txt
+++ b/doc/source/whatsnew/v0.23.0.txt
@@ -896,7 +896,7 @@ Timezones
 - Bug in :func:`Timestamp.tz_localize` where localizing a timestamp near the minimum or maximum valid values could overflow and return a timestamp with an incorrect nanosecond value (:issue:`12677`)
 - Bug when iterating over :class:`DatetimeIndex` that was localized with fixed timezone offset that rounded nanosecond precision to microseconds (:issue:`19603`)
 - Bug in :func:`DataFrame.diff` that raised an ``IndexError`` with tz-aware values (:issue:`18578`)
-- Bug in :func:`melt` that coverted tz-aware dtypes to tz-naive (:issue:`15785`)
+- Bug in :func:`melt` that converted tz-aware dtypes to tz-naive (:issue:`15785`)
 
 Offsets
 ^^^^^^^

--- a/pandas/core/reshape/melt.py
+++ b/pandas/core/reshape/melt.py
@@ -13,7 +13,9 @@ from pandas.util._decorators import Appender
 
 import re
 from pandas.core.dtypes.missing import notna
+from pandas.core.dtypes.common import is_extension_type
 from pandas.core.tools.numeric import to_numeric
+from pandas.core.reshape.concat import concat
 
 
 @Appender(_shared_docs['melt'] %
@@ -70,7 +72,13 @@ def melt(frame, id_vars=None, value_vars=None, var_name=None,
 
     mdata = {}
     for col in id_vars:
-        mdata[col] = np.tile(frame.pop(col).values, K)
+        id_data = frame.pop(col)
+        if is_extension_type(id_data):
+            # Preserve pandas dtype by not converting to a numpy array
+            id_data = concat([id_data] * K, ignore_index=True)
+        else:
+            id_data = np.tile(id_data.values, K)
+        mdata[col] = id_data
 
     mcolumns = id_vars + var_name + [value_name]
 

--- a/pandas/core/reshape/melt.py
+++ b/pandas/core/reshape/melt.py
@@ -74,7 +74,6 @@ def melt(frame, id_vars=None, value_vars=None, var_name=None,
     for col in id_vars:
         id_data = frame.pop(col)
         if is_extension_type(id_data):
-            # Preserve pandas dtype by not converting to a numpy array
             id_data = concat([id_data] * K, ignore_index=True)
         else:
             id_data = np.tile(id_data.values, K)

--- a/pandas/tests/reshape/test_melt.py
+++ b/pandas/tests/reshape/test_melt.py
@@ -214,22 +214,16 @@ class TestMelt(object):
 
     @pytest.mark.parametrize("col", [
         pd.Series(pd.date_range('2010', periods=5, tz='US/Pacific')),
-        pd.Series(["a", "b", "c", "a", "d"], dtype="category")])
-    @pytest.mark.parametrize("pandas_dtype_value", [True, False])
-    def test_pandas_dtypes_id_var(self, col, pandas_dtype_value):
+        pd.Series(["a", "b", "c", "a", "d"], dtype="category"),
+        pd.Series([0, 1, 0, 0, 0])])
+    def test_pandas_dtypes(self, col):
         # GH 15785
-        # Pandas dtype in the id
         df = DataFrame({'klass': range(5),
                         'col': col,
-                        'attr1': [1, 0, 0, 0, 0]})
-        if pandas_dtype_value:
-            # Pandas dtype in the value as well
-            df['attr2'] = col
-            expected_value = pd.concat([pd.Series([1, 0, 0, 0, 0]), col],
-                                       ignore_index=True)
-        else:
-            df['attr2'] = [0, 1, 0, 0, 0]
-            expected_value = [1, 0, 0, 0, 0] + [0, 1, 0, 0, 0]
+                        'attr1': [1, 0, 0, 0, 0],
+                        'attr2': col})
+        expected_value = pd.concat([pd.Series([1, 0, 0, 0, 0]), col],
+                                   ignore_index=True)
         result = melt(df, id_vars=['klass', 'col'], var_name='attribute',
                       value_name='value')
         expected = DataFrame({0: list(range(5)) * 2,

--- a/pandas/tests/reshape/test_melt.py
+++ b/pandas/tests/reshape/test_melt.py
@@ -215,33 +215,28 @@ class TestMelt(object):
     @pytest.mark.parametrize("col", [
         pd.Series(pd.date_range('2010', periods=5, tz='US/Pacific')),
         pd.Series(["a", "b", "c", "a", "d"], dtype="category")])
-    def test_pandas_dtypes_id_var(self, col):
+    @pytest.mark.parametrize("pandas_dtype_value", [True, False])
+    def test_pandas_dtypes_id_var(self, col, pandas_dtype_value):
         # GH 15785
         # Pandas dtype in the id
         df = DataFrame({'klass': range(5),
                         'col': col,
-                        'attr1': [1, 0, 0, 0, 0],
-                        'attr2': [0, 1, 0, 0, 0]})
+                        'attr1': [1, 0, 0, 0, 0]})
+        if pandas_dtype_value:
+            # Pandas dtype in the value as well
+            df['attr2'] = col
+            expected_value = pd.concat([pd.Series([1, 0, 0, 0, 0]), col],
+                                       ignore_index=True)
+        else:
+            df['attr2'] = [0, 1, 0, 0, 0]
+            expected_value = [1, 0, 0, 0, 0] + [0, 1, 0, 0, 0]
         result = melt(df, id_vars=['klass', 'col'], var_name='attribute',
                       value_name='value')
-        expected = DataFrame({'klass': list(range(5)) * 2,
-                              'col': pd.concat([col] * 2, ignore_index=True),
-                              'attribute': ['attr1'] * 5 + ['attr2'] * 5,
-                              'value': [1, 0, 0, 0, 0] + [0, 1, 0, 0, 0]})
-        tm.assert_frame_equal(result, expected)
-
-        # Pandas dtype in the value
-        df = DataFrame({'klass': range(5),
-                        'col': col,
-                        'attr1': [1, 0, 0, 0, 0],
-                        'attr2': col})
-        result = melt(df, id_vars=['klass', 'col'], var_name='attribute',
-                      value_name='value')
-        expected = DataFrame({'klass': list(range(5)) * 2,
-                              'col': pd.concat([col] * 2, ignore_index=True),
-                              'attribute': ['attr1'] * 5 + ['attr2'] * 5,
-                              'value': pd.concat([pd.Series([1, 0, 0, 0, 0]),
-                                                  col], ignore_index=True)})
+        expected = DataFrame({0: list(range(5)) * 2,
+                              1: pd.concat([col] * 2, ignore_index=True),
+                              2: ['attr1'] * 5 + ['attr2'] * 5,
+                              3: expected_value})
+        expected.columns = ['klass', 'col', 'attribute', 'value']
         tm.assert_frame_equal(result, expected)
 
 

--- a/pandas/tests/reshape/test_melt.py
+++ b/pandas/tests/reshape/test_melt.py
@@ -230,7 +230,7 @@ class TestMelt(object):
                               'value': [1, 0, 0, 0, 0] + [0, 1, 0, 0, 0]})
         tm.assert_frame_equal(result, expected)
 
-        # Pandas dtype in the column
+        # Pandas dtype in the value
         df = DataFrame({'klass': range(5),
                         'col': col,
                         'attr1': [1, 0, 0, 0, 0],


### PR DESCRIPTION
- [x] closes #15785
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry

`.values` call was converting tz aware data to tz naive data (by casting to a numpy array). Added an additional test for Categorical data as well.