### PR TITLE
DOC: update the Period.days_in_month docstring

### DIFF
--- a/pandas/_libs/tslibs/period.pyx
+++ b/pandas/_libs/tslibs/period.pyx
@@ -1270,6 +1270,36 @@ cdef class _Period(object):
 
     @property
     def days_in_month(self):
+        """
+        Get the total number of days in the month that this period falls on.
+
+        Returns
+        -------
+        int
+
+        See Also
+        --------
+        Period.daysinmonth : Returns the number of days in the month.
+        DatetimeIndex.daysinmonth : Return the number of days in the month.
+        calendar.monthrange : Return a tuple containing weekday
+            (0-6 ~ Mon-Sun) and number of days (28-31).
+
+        Examples
+        --------
+        >>> p= pd.Period('2018-2-17')
+        >>> p.days_in_month
+        28
+
+        >>> import datetime
+        >>> pd.Period(datetime.datetime.today(), freq= 'B').days_in_month
+        31
+
+        Handles the leap year case as well:
+
+        >>> p= pd.Period('2016-2-17')
+        >>> p.days_in_month
+        29
+        """
         base, mult = get_freq_code(self.freq)
         return pdays_in_month(self.ordinal, base)
 

--- a/pandas/_libs/tslibs/period.pyx
+++ b/pandas/_libs/tslibs/period.pyx
@@ -1286,17 +1286,16 @@ cdef class _Period(object):
 
         Examples
         --------
-        >>> p= pd.Period('2018-2-17')
+        >>> p = pd.Period('2018-2-17')
         >>> p.days_in_month
         28
 
-        >>> import datetime
-        >>> pd.Period(datetime.datetime.today(), freq= 'B').days_in_month
+        >>> pd.Period('2018-03-01').days_in_month
         31
 
         Handles the leap year case as well:
 
-        >>> p= pd.Period('2016-2-17')
+        >>> p = pd.Period('2016-2-17')
         >>> p.days_in_month
         29
         """

--- a/pandas/_libs/tslibs/period.pyx
+++ b/pandas/_libs/tslibs/period.pyx
@@ -1279,9 +1279,9 @@ cdef class _Period(object):
 
         See Also
         --------
-        Period.daysinmonth : Returns the number of days in the month.
-        DatetimeIndex.daysinmonth : Return the number of days in the month.
-        calendar.monthrange : Return a tuple containing weekday
+        Period.daysinmonth : Gets the number of days in the month.
+        DatetimeIndex.daysinmonth : Gets the number of days in the month.
+        calendar.monthrange : Returns a tuple containing weekday
             (0-6 ~ Mon-Sun) and number of days (28-31).
 
         Examples


### PR DESCRIPTION
- [x] PR title is "DOC: update the <your-function-or-method> docstring"
- [x] The validation script passes: `scripts/validate_docstrings.py <your-function-or-method>`
- [x] The PEP8 style check passes: `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] The html version looks good: `python doc/make.py --single <your-function-or-method>`
- [ ] It has been proofread on language by another sprint participant

```
################################################################################
################### Docstring (pandas.Period.days_in_month)  ###################
################################################################################

Get the total number of days in the month that this period falls on.

Returns
-------
int

See Also
--------
Period.daysinmonth : Returns the number of days in the month.
DatetimeIndex.daysinmonth : Return the number of days in the month.
calendar.monthrange : Return a tuple containing weekday
    (0-6 ~ Mon-Sun) and number of days (28-31).

Examples
--------
>>> p= pd.Period('2018-2-17')
>>> p.days_in_month
28

>>> import datetime
>>> pd.Period(datetime.datetime.today(), freq= 'B').days_in_month
31

Handles the leap year case as well:

>>> p= pd.Period('2016-2-17')
>>> p.days_in_month
29

################################################################################
################################## Validation ##################################
################################################################################

Errors found:
	No extended summary found
```

* Short summary summarises pretty much all the characteristics of this attribute.
