### PR TITLE
DOC: update the pandas.Series.str.split docstring

### DIFF
--- a/pandas/core/strings.py
+++ b/pandas/core/strings.py
@@ -1117,7 +1117,7 @@ def str_split(arr, pat=None, n=None):
     Returns
     -------
     Series, Index, DataFrame or MultiIndex
-        Type matches caller unless ``expand=True`` (see Notes)
+        Type matches caller unless ``expand=True`` (see Notes).
 
     Notes
     -----
@@ -1130,6 +1130,13 @@ def str_split(arr, pat=None, n=None):
 
     If using ``expand=True``, Series and Index callers return DataFrame and
     MultiIndex objects, respectively.
+
+    See Also
+    --------
+    str.split : Standard library version of this method.
+    Series.str.get_dummies : Split each string into dummy variables.
+    Series.str.partition : Split string on a separator, returning
+        the before, separator, and after components.
 
     Examples
     --------

--- a/pandas/core/strings.py
+++ b/pandas/core/strings.py
@@ -1116,9 +1116,8 @@ def str_split(arr, pat=None, n=None):
 
     Returns
     -------
-    split : Series/Index or DataFrame/MultiIndex of objects
-        Type matches caller unless ``expand=True`` (return type is DataFrame or
-    MultiIndex)
+    Series, Index, DataFrame or MultiIndex
+        Type matches caller unless ``expand=True`` (see Notes)
 
     Notes
     -----
@@ -1128,6 +1127,9 @@ def str_split(arr, pat=None, n=None):
     - If found splits <= `n`, make all splits
     - If for a certain row the number of found splits < `n`,
       append `None` for padding up to `n` if ``expand=True``
+
+    If using ``expand=True``, Series and Index callers return DataFrame and
+    MultiIndex objects, respectively.
 
     Examples
     --------
@@ -1145,8 +1147,10 @@ def str_split(arr, pat=None, n=None):
     1    [but this is even better]
     dtype: object
 
-    When using ``expand=True``, the split elements will
-    expand out into separate columns.
+    When using ``expand=True``, the split elements will expand out into
+    separate columns.
+
+    For Series object, output return type is DataFrame.
 
     >>> s.str.split(expand=True)
           0     1     2     3       4
@@ -1156,6 +1160,13 @@ def str_split(arr, pat=None, n=None):
               0            1
     0      this    good text
     1  but this  even better
+
+    For Index object, output return type is MultiIndex.
+
+    >>> i = pd.Index(["ba 100 001", "ba 101 002", "ba 102 003"])
+    >>> i.str.split(expand=True)
+    MultiIndex(levels=[['ba'], ['100', '101', '102'], ['001', '002', '003']],
+           labels=[[0, 0, 0], [0, 1, 2], [0, 1, 2]])
 
     Parameter `n` can be used to limit the number of splits in the output.
 


### PR DESCRIPTION
Following up from discussion on #20282 

- [x] PR title is "DOC: update the pandas.Series.str.split docstring"
- [x] The validation script passes: `scripts/validate_docstrings.py pandas.Series.str.split docstring`
- [x] The PEP8 style check passes: `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] The html version looks good: `python doc/make.py --single pandas.Series.str.split docstring`

```
################################################################################
##################### Docstring (pandas.Series.str.split)  #####################
################################################################################

Split strings around given separator/delimiter.

Split each string in the caller's values by given
pattern, propagating NaN values. Equivalent to :meth:`str.split`.

Parameters
----------
pat : str, optional
    String or regular expression to split on.
    If not specified, split on whitespace.
n : int, default -1 (all)
    Limit number of splits in output.
    ``None``, 0 and -1 will be interpreted as return all splits.
expand : bool, default False
    Expand the splitted strings into separate columns.

    * If ``True``, return DataFrame/MultiIndex expanding dimensionality.
    * If ``False``, return Series/Index, containing lists of strings.

Returns
-------
split : Series/Index or DataFrame/MultiIndex of objects
    Type matches caller unless ``expand=True`` (return type is DataFrame or
MultiIndex)

Notes
-----
The handling of the `n` keyword depends on the number of found splits:

- If found splits > `n`,  make first `n` splits only
- If found splits <= `n`, make all splits
- If for a certain row the number of found splits < `n`,
  append `None` for padding up to `n` if ``expand=True``

Examples
--------
>>> s = pd.Series(["this is good text", "but this is even better"])

By default, split will return an object of the same size
having lists containing the split elements

>>> s.str.split()
0           [this, is, good, text]
1    [but, this, is, even, better]
dtype: object
>>> s.str.split("random")
0          [this is good text]
1    [but this is even better]
dtype: object

When using ``expand=True``, the split elements will expand out into
separate columns.

For Series object, output return type is DataFrame.

>>> s.str.split(expand=True)
      0     1     2     3       4
0  this    is  good  text    None
1   but  this    is  even  better
>>> s.str.split(" is ", expand=True)
          0            1
0      this    good text
1  but this  even better

For Index object, output return type is MultiIndex.

>>> i = pd.Index(["ba 100 001", "ba 101 002", "ba 102 003"])
>>> i.str.split(expand=True)
MultiIndex(levels=[['ba'], ['100', '101', '102'], ['001', '002', '003']],
       labels=[[0, 0, 0], [0, 1, 2], [0, 1, 2]])

Parameter `n` can be used to limit the number of splits in the output.

>>> s.str.split("is", n=1)
0          [th,  is good text]
1    [but th,  is even better]
dtype: object
>>> s.str.split("is", n=1, expand=True)
        0                1
0      th     is good text
1  but th   is even better

If NaN is present, it is propagated throughout the columns
during the split.

>>> s = pd.Series(["this is good text", "but this is even better", np.nan])
>>> s.str.split(n=3, expand=True)
      0     1     2            3
0  this    is  good         text
1   but  this    is  even better
2   NaN   NaN   NaN          NaN

################################################################################
################################## Validation ##################################
################################################################################

Errors found:
	See Also section not found
```

@jorisvandenbossche @WillAyd 