### PR TITLE
DOC: update the pandas.DataFrame.pct_change docstring

### DIFF
--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -7520,13 +7520,13 @@ class NDFrame(PandasObject, SelectionMixin):
         Parameters
         ----------
         periods : int, default 1
-            Periods to shift for forming percent change
+            Periods to shift for forming percent change.
         fill_method : str, default 'pad'
-            How to handle NAs before computing percent changes
+            How to handle NAs before computing percent changes.
         limit : int, default None
-            The number of consecutive NAs to fill before stopping
+            The number of consecutive NAs to fill before stopping.
         freq : DateOffset, timedelta, or offset alias string, optional
-            Increment to use from time series API (e.g. 'M' or BDay())
+            Increment to use from time series API (e.g. 'M' or BDay()).
 
         Returns
         -------

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -7573,8 +7573,8 @@ class NDFrame(PandasObject, SelectionMixin):
         >>> s.pct_change(fill_method='ffill')
         0         NaN
         1    0.011111
-        2   -0.065934
-        3    0.000000
+        2    0.000000
+        3   -0.065934
         dtype: float64
 
         Percentage change in French franc, Deutsche Mark, and Italian lira from

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -7531,11 +7531,12 @@ class NDFrame(PandasObject, SelectionMixin):
         freq : DateOffset, timedelta, or offset alias string, optional
             Increment to use from time series API (e.g. 'M' or BDay()).
         kwargs : mapping, optional
-            A dictionary of keyword arguments passed into ``%(klass)s.shift``.
+            A dictionary of keyword arguments passed into
+            ``DataFrame.shift``/``Series.shift``.
 
         Returns
         -------
-        chg : %(klass)s
+        chg : Series or DataFrame, same type as the input
 
         Notes
         -----
@@ -7566,7 +7567,8 @@ class NDFrame(PandasObject, SelectionMixin):
 
         See Also
         --------
-        pandas.%(klass)s.diff : see the difference of two columns
+        pandas.DataFrame.diff : see the difference of two columns
+        pandas.Series.diff : see the difference of two columns
         """
 
     @Appender(_shared_docs['pct_change'] % _shared_doc_kwargs)

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -7530,19 +7530,38 @@ class NDFrame(PandasObject, SelectionMixin):
             The number of consecutive NAs to fill before stopping.
         freq : DateOffset, timedelta, or offset alias string, optional
             Increment to use from time series API (e.g. 'M' or BDay()).
-        kwargs : mapping, optional
-            A dictionary of keyword arguments passed into
+        **kwargs : mapping, optional
+            Additional keyword arguments are passed into
             ``DataFrame.shift``/``Series.shift``.
 
         Returns
         -------
-        chg : Series or DataFrame, same type as the input
+        chg : Series or DataFrame, same type as the calling object
 
         Notes
         -----
         By default, the percentage change is calculated along the stat
         axis: 0, or ``Index``, for ``DataFrame`` and 1, or ``minor`` for
         ``Panel``. You can change this with the ``axis`` keyword argument.
+
+        Percentage change in French franc, Deutsche Mark, and Italian lira from
+        1 January 1980 to 1 March 1980.
+
+        >>> df = pd.DataFrame({
+        ...     'FR': [4.0405, 4.0963, 4.3149],
+        ...     'GR': [1.7246, 1.7482, 1.8519],
+        ...     'IT': [804.74, 810.01, 860.13]},
+        ...     index=['1980-01-01', '1980-02-01', '1980-03-01'])
+        >>> df
+                        FR      GR      IT
+        1980-01-01  4.0405  1.7246  804.74
+        1980-02-01  4.0963  1.7482  810.01
+        1980-03-01  4.3149  1.8519  860.13
+        >>> df.pct_change()
+                          FR        GR        IT
+        1980-01-01       NaN       NaN       NaN
+        1980-02-01  0.013810  0.013684  0.006549
+        1980-03-01  0.053365  0.059318  0.061876
 
         Examples
         --------
@@ -7576,25 +7595,6 @@ class NDFrame(PandasObject, SelectionMixin):
         2    0.000000
         3   -0.065934
         dtype: float64
-
-        Percentage change in French franc, Deutsche Mark, and Italian lira from
-        1 January 1980 to 1 March 1980.
-
-        >>> df = pd.DataFrame({
-        ...     'FR': [4.0405, 4.0963, 4.3149],
-        ...     'GR': [1.7246, 1.7482, 1.8519],
-        ...     'IT': [804.74, 810.01, 860.13]},
-        ...     index=['1980-01-01', '1980-02-01', '1980-03-01'])
-        >>> df
-                        FR      GR      IT
-        1980-01-01  4.0405  1.7246  804.74
-        1980-02-01  4.0963  1.7482  810.01
-        1980-03-01  4.3149  1.8519  860.13
-        >>> df.pct_change()
-                          FR        GR        IT
-        1980-01-01       NaN       NaN       NaN
-        1980-02-01  0.013810  0.013684  0.006549
-        1980-03-01  0.053365  0.059318  0.061876
 
         See Also
         --------

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -7546,6 +7546,37 @@ class NDFrame(PandasObject, SelectionMixin):
 
         Examples
         --------
+        See the percentage change in a Series.
+
+        >>> s = pd.Series([90, 91, 85])
+        >>> s
+        0    90
+        1    91
+        2    85
+        dtype: int64
+        >>> s.pct_change()
+        0         NaN
+        1    0.011111
+        2   -0.065934
+        dtype: float64
+
+        See the percentage change in a Series where filling NAs with last
+        valid observation forward to next valid.
+
+        >>> s = pd.Series([90, 91, None, 85])
+        >>> s
+        0    90.0
+        1    91.0
+        2     NaN
+        3    85.0
+        dtype: float64
+        >>> s.pct_change(fill_method='ffill')
+        0         NaN
+        1    0.011111
+        2   -0.065934
+        3    0.000000
+        dtype: float64
+
         Percentage change in French franc, Deutsche Mark, and Italian lira from
         1 January 1980 to 1 March 1980.
 

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -7515,7 +7515,10 @@ class NDFrame(PandasObject, SelectionMixin):
         return q
 
     _shared_docs['pct_change'] = """
-        Percent change over given number of periods.
+        Percentage change between the current and previous element.
+
+        This is useful in comparing the percentage of change in a time series
+        of elements.
 
         Parameters
         ----------
@@ -7536,13 +7539,15 @@ class NDFrame(PandasObject, SelectionMixin):
 
         Notes
         -----
-
         By default, the percentage change is calculated along the stat
         axis: 0, or ``Index``, for ``DataFrame`` and 1, or ``minor`` for
         ``Panel``. You can change this with the ``axis`` keyword argument.
 
         Examples
         --------
+        Percentage change in French franc, Deutsche Mark, and Italian lira from
+        1 January 1980 to 1 March 1980.
+
         >>> df = pd.DataFrame({
         ...     'FR': [4.0405, 4.0963, 4.3149],
         ...     'GR': [1.7246, 1.7482, 1.8519],
@@ -7558,6 +7563,10 @@ class NDFrame(PandasObject, SelectionMixin):
         1980-01-01       NaN       NaN       NaN
         1980-02-01  0.013810  0.013684  0.006549
         1980-03-01  0.053365  0.059318  0.061876
+
+        See Also
+        --------
+        pandas.%(klass)s.diff : see the difference of two columns
         """
 
     @Appender(_shared_docs['pct_change'] % _shared_doc_kwargs)

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -7532,36 +7532,12 @@ class NDFrame(PandasObject, SelectionMixin):
             Increment to use from time series API (e.g. 'M' or BDay()).
         **kwargs : mapping, optional
             Additional keyword arguments are passed into
-            ``DataFrame.shift``/``Series.shift``.
+            `DataFrame.shift` or `Series.shift`.
 
         Returns
         -------
-        chg : Series or DataFrame, same type as the calling object
-
-        Notes
-        -----
-        By default, the percentage change is calculated along the stat
-        axis: 0, or ``Index``, for ``DataFrame`` and 1, or ``minor`` for
-        ``Panel``. You can change this with the ``axis`` keyword argument.
-
-        Percentage change in French franc, Deutsche Mark, and Italian lira from
-        1 January 1980 to 1 March 1980.
-
-        >>> df = pd.DataFrame({
-        ...     'FR': [4.0405, 4.0963, 4.3149],
-        ...     'GR': [1.7246, 1.7482, 1.8519],
-        ...     'IT': [804.74, 810.01, 860.13]},
-        ...     index=['1980-01-01', '1980-02-01', '1980-03-01'])
-        >>> df
-                        FR      GR      IT
-        1980-01-01  4.0405  1.7246  804.74
-        1980-02-01  4.0963  1.7482  810.01
-        1980-03-01  4.3149  1.8519  860.13
-        >>> df.pct_change()
-                          FR        GR        IT
-        1980-01-01       NaN       NaN       NaN
-        1980-02-01  0.013810  0.013684  0.006549
-        1980-03-01  0.053365  0.059318  0.061876
+        chg : Series or DataFrame
+            The same type as the calling object.
 
         Examples
         --------
@@ -7596,10 +7572,45 @@ class NDFrame(PandasObject, SelectionMixin):
         3   -0.065934
         dtype: float64
 
+        Percentage change in French franc, Deutsche Mark, and Italian lira from
+        1 January 1980 to 1 March 1980.
+
+        >>> df = pd.DataFrame({
+        ...     'FR': [4.0405, 4.0963, 4.3149],
+        ...     'GR': [1.7246, 1.7482, 1.8519],
+        ...     'IT': [804.74, 810.01, 860.13]},
+        ...     index=['1980-01-01', '1980-02-01', '1980-03-01'])
+        >>> df
+                        FR      GR      IT
+        1980-01-01  4.0405  1.7246  804.74
+        1980-02-01  4.0963  1.7482  810.01
+        1980-03-01  4.3149  1.8519  860.13
+        >>> df.pct_change()
+                          FR        GR        IT
+        1980-01-01       NaN       NaN       NaN
+        1980-02-01  0.013810  0.013684  0.006549
+        1980-03-01  0.053365  0.059318  0.061876
+
+        Percentage of change in GOOG and APPL stock volume.
+
+        >>> df = pd.DataFrame({
+        ...     '2016': [1769950, 30586265],
+        ...     '2015': [1500923, 40912316],
+        ...     '2014': [1371819, 41403351]},
+        ...     index=['GOOG', 'APPL'])
+        >>> df
+                  2016      2015      2014
+        GOOG   1769950   1500923   1371819
+        APPL  30586265  40912316  41403351
+        >>> df.pct_change(axis='columns')
+              2016      2015      2014
+        GOOG   NaN -0.151997 -0.086016
+        APPL   NaN  0.337604  0.012002
+
         See Also
         --------
-        pandas.DataFrame.diff : see the difference of two columns
-        pandas.Series.diff : see the difference of two columns
+        DataFrame.diff : see the difference of two columns
+        Series.diff : see the difference of two columns
         """
 
     @Appender(_shared_docs['pct_change'] % _shared_doc_kwargs)

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -7515,10 +7515,11 @@ class NDFrame(PandasObject, SelectionMixin):
         return q
 
     _shared_docs['pct_change'] = """
-        Percentage change between the current and previous element.
+        Percentage change between the current and a prior element.
 
-        This is useful in comparing the percentage of change in a time series
-        of elements.
+        Computes the percentage change from the immediately previous row by
+        default. This is useful in comparing the percentage of change in a time
+        series of elements.
 
         Parameters
         ----------
@@ -7530,7 +7531,7 @@ class NDFrame(PandasObject, SelectionMixin):
             The number of consecutive NAs to fill before stopping.
         freq : DateOffset, timedelta, or offset alias string, optional
             Increment to use from time series API (e.g. 'M' or BDay()).
-        **kwargs : mapping, optional
+        **kwargs
             Additional keyword arguments are passed into
             `DataFrame.shift` or `Series.shift`.
 
@@ -7539,9 +7540,16 @@ class NDFrame(PandasObject, SelectionMixin):
         chg : Series or DataFrame
             The same type as the calling object.
 
+        See Also
+        --------
+        Series.diff : Compute the difference of two elements in a Series.
+        DataFrame.diff : Compute the difference of two elements in a DataFrame.
+        Series.shift : Shift the index by some number of periods.
+        DataFrame.shift : Shift the index by some number of periods.
+
         Examples
         --------
-        See the percentage change in a Series.
+        **Series**
 
         >>> s = pd.Series([90, 91, 85])
         >>> s
@@ -7549,10 +7557,17 @@ class NDFrame(PandasObject, SelectionMixin):
         1    91
         2    85
         dtype: int64
+
         >>> s.pct_change()
         0         NaN
         1    0.011111
         2   -0.065934
+        dtype: float64
+
+        >>> s.pct_change(periods=2)
+        0         NaN
+        1         NaN
+        2   -0.055556
         dtype: float64
 
         See the percentage change in a Series where filling NAs with last
@@ -7565,6 +7580,7 @@ class NDFrame(PandasObject, SelectionMixin):
         2     NaN
         3    85.0
         dtype: float64
+
         >>> s.pct_change(fill_method='ffill')
         0         NaN
         1    0.011111
@@ -7572,8 +7588,10 @@ class NDFrame(PandasObject, SelectionMixin):
         3   -0.065934
         dtype: float64
 
+        **DataFrame**
+
         Percentage change in French franc, Deutsche Mark, and Italian lira from
-        1 January 1980 to 1 March 1980.
+        1980-01-01 to 1980-03-01.
 
         >>> df = pd.DataFrame({
         ...     'FR': [4.0405, 4.0963, 4.3149],
@@ -7585,13 +7603,15 @@ class NDFrame(PandasObject, SelectionMixin):
         1980-01-01  4.0405  1.7246  804.74
         1980-02-01  4.0963  1.7482  810.01
         1980-03-01  4.3149  1.8519  860.13
+
         >>> df.pct_change()
                           FR        GR        IT
         1980-01-01       NaN       NaN       NaN
         1980-02-01  0.013810  0.013684  0.006549
         1980-03-01  0.053365  0.059318  0.061876
 
-        Percentage of change in GOOG and APPL stock volume.
+        Percentage of change in GOOG and APPL stock volume. Shows computing
+        the percentage change between columns.
 
         >>> df = pd.DataFrame({
         ...     '2016': [1769950, 30586265],
@@ -7602,15 +7622,11 @@ class NDFrame(PandasObject, SelectionMixin):
                   2016      2015      2014
         GOOG   1769950   1500923   1371819
         APPL  30586265  40912316  41403351
+
         >>> df.pct_change(axis='columns')
               2016      2015      2014
         GOOG   NaN -0.151997 -0.086016
         APPL   NaN  0.337604  0.012002
-
-        See Also
-        --------
-        DataFrame.diff : see the difference of two columns
-        Series.diff : see the difference of two columns
         """
 
     @Appender(_shared_docs['pct_change'] % _shared_doc_kwargs)

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -7527,6 +7527,8 @@ class NDFrame(PandasObject, SelectionMixin):
             The number of consecutive NAs to fill before stopping.
         freq : DateOffset, timedelta, or offset alias string, optional
             Increment to use from time series API (e.g. 'M' or BDay()).
+        kwargs : mapping, optional
+            A dictionary of keyword arguments passed into ``%(klass)s.shift``.
 
         Returns
         -------
@@ -7538,6 +7540,24 @@ class NDFrame(PandasObject, SelectionMixin):
         By default, the percentage change is calculated along the stat
         axis: 0, or ``Index``, for ``DataFrame`` and 1, or ``minor`` for
         ``Panel``. You can change this with the ``axis`` keyword argument.
+
+        Examples
+        --------
+        >>> df = pd.DataFrame({
+        ...     'FR': [4.0405, 4.0963, 4.3149],
+        ...     'GR': [1.7246, 1.7482, 1.8519],
+        ...     'IT': [804.74, 810.01, 860.13]},
+        ...     index=['1980-01-01', '1980-02-01', '1980-03-01'])
+        >>> df
+                        FR      GR      IT
+        1980-01-01  4.0405  1.7246  804.74
+        1980-02-01  4.0963  1.7482  810.01
+        1980-03-01  4.3149  1.8519  860.13
+        >>> df.pct_change()
+                          FR        GR        IT
+        1980-01-01       NaN       NaN       NaN
+        1980-02-01  0.013810  0.013684  0.006549
+        1980-03-01  0.053365  0.059318  0.061876
         """
 
     @Appender(_shared_docs['pct_change'] % _shared_doc_kwargs)


### PR DESCRIPTION
Checklist for the pandas documentation sprint (ignore this if you are doing
an unrelated PR):

- [x] PR title is "DOC: update the <your-function-or-method> docstring"
- [x] The validation script passes: `scripts/validate_docstrings.py <your-function-or-method>`
- [x] The PEP8 style check passes: `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] The html version looks good: `python doc/make.py --single <your-function-or-method>`
- [ ] It has been proofread on language by another sprint participant

Please include the output of the validation script below between the "```" ticks:

```
################################################################################
################### Docstring (pandas.DataFrame.pct_change)  ###################
################################################################################

Percentage change between the current and previous element.

This is useful in comparing the percentage of change in a time series
of elements.

Parameters
----------
periods : int, default 1
    Periods to shift for forming percent change.
fill_method : str, default 'pad'
    How to handle NAs before computing percent changes.
limit : int, default None
    The number of consecutive NAs to fill before stopping.
freq : DateOffset, timedelta, or offset alias string, optional
    Increment to use from time series API (e.g. 'M' or BDay()).
**kwargs : mapping, optional
    Additional keyword arguments are passed into
    `DataFrame.shift` or `Series.shift`.

Returns
-------
chg : Series or DataFrame
    The same type as the calling object.

Examples
--------
See the percentage change in a Series.

>>> s = pd.Series([90, 91, 85])
>>> s
0    90
1    91
2    85
dtype: int64
>>> s.pct_change()
0         NaN
1    0.011111
2   -0.065934
dtype: float64

See the percentage change in a Series where filling NAs with last
valid observation forward to next valid.

>>> s = pd.Series([90, 91, None, 85])
>>> s
0    90.0
1    91.0
2     NaN
3    85.0
dtype: float64
>>> s.pct_change(fill_method='ffill')
0         NaN
1    0.011111
2    0.000000
3   -0.065934
dtype: float64

Percentage change in French franc, Deutsche Mark, and Italian lira from
1 January 1980 to 1 March 1980.

>>> df = pd.DataFrame({
...     'FR': [4.0405, 4.0963, 4.3149],
...     'GR': [1.7246, 1.7482, 1.8519],
...     'IT': [804.74, 810.01, 860.13]},
...     index=['1980-01-01', '1980-02-01', '1980-03-01'])
>>> df
                FR      GR      IT
1980-01-01  4.0405  1.7246  804.74
1980-02-01  4.0963  1.7482  810.01
1980-03-01  4.3149  1.8519  860.13
>>> df.pct_change()
                  FR        GR        IT
1980-01-01       NaN       NaN       NaN
1980-02-01  0.013810  0.013684  0.006549
1980-03-01  0.053365  0.059318  0.061876

Percentage of change in GOOG and APPL stock volume.

>>> df = pd.DataFrame({
...     '2016': [1769950, 30586265],
...     '2015': [1500923, 40912316],
...     '2014': [1371819, 41403351]},
...     index=['GOOG', 'APPL'])
>>> df
          2016      2015      2014
GOOG   1769950   1500923   1371819
APPL  30586265  40912316  41403351
>>> df.pct_change(axis='columns')
      2016      2015      2014
GOOG   NaN -0.151997 -0.086016
APPL   NaN  0.337604  0.012002

See Also
--------
DataFrame.diff : see the difference of two columns
Series.diff : see the difference of two columns

################################################################################
################################## Validation ##################################
################################################################################

Errors found:
	Errors in parameters section
		Parameters {'kwargs'} not documented
		Unknown parameters {'**kwargs'}
```