### PR TITLE
COMPAT: Ascii example

### DIFF
--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -1534,10 +1534,10 @@ class Index(IndexOpsMixin, PandasObject):
         >>> idx.is_categorical()
         False
 
-        >>> s = pd.Series(["Peter", "Víctor", "Elisabeth", "Mar"])
+        >>> s = pd.Series(["Peter", "Victor", "Elisabeth", "Mar"])
         >>> s
         0        Peter
-        1       Víctor
+        1       Victor
         2    Elisabeth
         3          Mar
         dtype: object


### PR DESCRIPTION
Py2 issues:

```
pytest -m single -r xX --junitxml=/tmp/single.xml --strict --only-slow --skip-network pandas
Traceback (most recent call last):
  File "/home/travis/miniconda3/envs/pandas/lib/python2.7/site-packages/_pytest/config.py", line 366, in _importconftest
    mod = conftestpath.pyimport()
  File "/home/travis/miniconda3/envs/pandas/lib/python2.7/site-packages/py/_path/local.py", line 668, in pyimport
    __import__(modname)
  File "/home/travis/build/pandas-dev/pandas/pandas/__init__.py", line 45, in <module>
    from pandas.core.api import *
  File "/home/travis/build/pandas-dev/pandas/pandas/core/api.py", line 10, in <module>
    from pandas.core.groupby import Grouper
  File "/home/travis/build/pandas-dev/pandas/pandas/core/groupby.py", line 45, in <module>
    from pandas.core.index import (Index, MultiIndex,
  File "/home/travis/build/pandas-dev/pandas/pandas/core/index.py", line 2, in <module>
    from pandas.core.indexes.api import *
  File "/home/travis/build/pandas-dev/pandas/pandas/core/indexes/api.py", line 1, in <module>
    from pandas.core.indexes.base import (Index,
  File "/home/travis/build/pandas-dev/pandas/pandas/core/indexes/base.py", line 1537
SyntaxError: Non-ASCII character '\xc3' in file /home/travis/build/pandas-dev/pandas/pandas/core/indexes/base.py on line 1538, but no encoding declared; see http://python.org/dev/peps/pep-0263/ for details
ERROR: could not load /home/travis/build/pandas-dev/pandas/pandas/conftest.py
```

