### PR TITLE
DOC: update docstring of pandas.Series.add_prefix docstring

### DIFF
--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -2963,21 +2963,23 @@ class NDFrame(PandasObject, SelectionMixin):
 
     def add_prefix(self, prefix):
         """
-        Concatenate prefix string with Series items names.
+        Prefix labels with string `prefix`.
+
+        For Series, the row labels are prefixed. For DataFrame, the column labels are prefixed.
 
         Parameters
         ----------
         prefix : str
-            The string to add before each item name.
+            The string to add before each label.
 
         Returns
         -------
-        Series
-            Original Series with updated item names.
+        Series or DataFrame
+            Original Series or DataFrame with updated labels.
 
         See Also
         --------
-        Series.add_suffix: Add a suffix string to Series items names.
+        Series.add_suffix: Suffix labels with string `suffix`.
 
         Examples
         --------
@@ -2994,6 +2996,20 @@ class NDFrame(PandasObject, SelectionMixin):
         item_2    3
         item_3    4
         dtype: int64
+
+        >>> df = pd.DataFrame({'A': [1, 2, 3, 4],  'B': [3, 4, 5, 6]})
+        >>> df
+           A  B
+        0  1  3
+        1  2  4
+        2  3  5
+        3  4  6
+        >>> df.add_suffix('_item')
+           A_item  B_item
+        0       1       3
+        1       2       4
+        2       3       5
+        3       4       6
         """
         new_data = self._data.add_prefix(prefix)
         return self._constructor(new_data).__finalize__(self)

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -2976,7 +2976,7 @@ class NDFrame(PandasObject, SelectionMixin):
         Returns
         -------
         Series or DataFrame
-            Original Series or DataFrame with updated labels.
+            New Series or DataFrame with updated labels.
 
         See Also
         --------
@@ -3005,8 +3005,8 @@ class NDFrame(PandasObject, SelectionMixin):
         1  2  4
         2  3  5
         3  4  6
-        >>> df.add_suffix('_item')
-           A_item  B_item
+        >>> df.add_prefix('col_')
+           col_A  col_B
         0       1       3
         1       2       4
         2       3       5

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -2977,7 +2977,7 @@ class NDFrame(PandasObject, SelectionMixin):
 
         See Also
         --------
-        Series.add_suffix: Add a suffix string to panel items names.
+        Series.add_suffix: Add a suffix string to Series items names.
 
         Examples
         --------

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -2965,7 +2965,7 @@ class NDFrame(PandasObject, SelectionMixin):
         """
         Prefix labels with string `prefix`.
 
-        For Series, the row labels are prefixed.  
+        For Series, the row labels are prefixed.
         For DataFrame, the column labels are prefixed.
 
         Parameters

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -2965,7 +2965,8 @@ class NDFrame(PandasObject, SelectionMixin):
         """
         Prefix labels with string `prefix`.
 
-        For Series, the row labels are prefixed. For DataFrame, the column labels are prefixed.
+        For Series, the row labels are prefixed.  
+        For DataFrame, the column labels are prefixed.
 
         Parameters
         ----------

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -2991,6 +2991,7 @@ class NDFrame(PandasObject, SelectionMixin):
         2    3
         3    4
         dtype: int64
+
         >>> s.add_prefix('item_')
         item_0    1
         item_1    2
@@ -3005,8 +3006,9 @@ class NDFrame(PandasObject, SelectionMixin):
         1  2  4
         2  3  5
         3  4  6
+
         >>> df.add_prefix('col_')
-           col_A  col_B
+             col_A  col_B
         0       1       3
         1       2       4
         2       3       5

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -2963,7 +2963,7 @@ class NDFrame(PandasObject, SelectionMixin):
 
     def add_prefix(self, prefix):
         """
-        Concatenate prefix string with panel items names.
+        Concatenate prefix string with Series items names.
 
         Parameters
         ----------
@@ -2977,11 +2977,11 @@ class NDFrame(PandasObject, SelectionMixin):
 
         See Also
         --------
-        pandas.Series.add_suffix: Add a suffix string to panel items names.
+        Series.add_suffix: Add a suffix string to panel items names.
 
         Examples
         --------
-        >>> s = pd.Series([1,2,3,4])
+        >>> s = pd.Series([1, 2, 3, 4])
         >>> s
         0    1
         1    2

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -2967,11 +2967,33 @@ class NDFrame(PandasObject, SelectionMixin):
 
         Parameters
         ----------
-        prefix : string
+        prefix : str
+            The string to add before each item name.
 
         Returns
         -------
-        with_prefix : type of caller
+        Series
+            Original Series with updated item names.
+
+        See Also
+        --------
+        pandas.Series.add_suffix: Add a suffix string to panel items names.
+
+        Examples
+        --------
+        >>> s = pd.Series([1,2,3,4])
+        >>> s
+        0    1
+        1    2
+        2    3
+        3    4
+        dtype: int64
+        >>> s.add_prefix('item_')
+        item_0    1
+        item_1    2
+        item_2    3
+        item_3    4
+        dtype: int64
         """
         new_data = self._data.add_prefix(prefix)
         return self._constructor(new_data).__finalize__(self)


### PR DESCRIPTION
Checklist for the pandas documentation sprint (ignore this if you are doing
an unrelated PR):

- [x] PR title is "DOC: update the <your-function-or-method> docstring"
- [x] The validation script passes: `scripts/validate_docstrings.py <your-function-or-method>`
- [x] The PEP8 style check passes: `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] The html version looks good: `python doc/make.py --single <your-function-or-method>`
- [x] It has been proofread on language by another sprint participant

Please include the output of the validation script below between the "```" ticks:

```
################################################################################
##################### Docstring (pandas.Series.add_prefix) #####################
################################################################################

Concatenate prefix string with panel items names.

Parameters
----------
prefix : str
    The string to add before each item name.

Returns
-------
Series
    Original Series with updated item names.

See Also
--------
pandas.Series.add_suffix: Add a suffix string to panel items names.

Examples
--------
>>> s = pd.Series([1,2,3,4])
>>> s
0    1
1    2
2    3
3    4
dtype: int64
>>> s.add_prefix('item_')
item_0    1
item_1    2
item_2    3
item_3    4
dtype: int64

################################################################################
################################## Validation ##################################
################################################################################

Errors found:
	No extended summary found
```

If the validation script still gives errors, but you think there is a good reason
to deviate in this case (and there are certainly such cases), please state this
explicitly.