### PR TITLE
DOC: update the pandas.Series.add_suffix docstring

### DIFF
--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -2978,15 +2978,37 @@ class NDFrame(PandasObject, SelectionMixin):
 
     def add_suffix(self, suffix):
         """
-        Concatenate suffix string with panel items names.
+        Add a suffix string to panel items names.
 
         Parameters
         ----------
-        suffix : string
+        suffix : str
+            The string to add after each item name.
 
         Returns
         -------
-        with_suffix : type of caller
+        Series
+            Original Series with updated item names.
+
+        See Also
+        --------
+        pandas.Series.add_prefix: Concatenate prefix string with panel items names.
+
+        Examples
+        --------
+        >>> s = pd.Series([1,2,3,4])
+        >>> s
+        0    1
+        1    2
+        2    3
+        3    4
+        dtype: int64
+        >>> s.add_suffix('_item')
+        0_item    1
+        1_item    2
+        2_item    3
+        3_item    4
+        dtype: int64
         """
         new_data = self._data.add_suffix(suffix)
         return self._constructor(new_data).__finalize__(self)

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -2978,7 +2978,7 @@ class NDFrame(PandasObject, SelectionMixin):
 
     def add_suffix(self, suffix):
         """
-        Add a suffix string to panel items names.
+        Add a suffix string to Series items names.
 
         Parameters
         ----------
@@ -2992,11 +2992,11 @@ class NDFrame(PandasObject, SelectionMixin):
 
         See Also
         --------
-        pandas.Series.add_prefix: Concatenate prefix string with panel items names.
+        Series.add_prefix: Concatenate prefix string with Series items names.
 
         Examples
         --------
-        >>> s = pd.Series([1,2,3,4])
+        >>> s = pd.Series([1, 2, 3, 4])
         >>> s
         0    1
         1    2

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -2951,7 +2951,8 @@ class NDFrame(PandasObject, SelectionMixin):
 
         See Also
         --------
-        Series.add_suffix: Suffix labels with string `suffix`.
+        Series.add_suffix: Suffix row labels with string `suffix`.
+        DataFrame.add_suffix: Suffix column labels with string `suffix`.
 
         Examples
         --------
@@ -3007,7 +3008,8 @@ class NDFrame(PandasObject, SelectionMixin):
 
         See Also
         --------
-        Series.add_prefix: Prefix labels with string `prefix`.
+        Series.add_prefix: Prefix row labels with string `prefix`.
+        DataFrame.add_prefix: Prefix column labels with string `prefix`.
 
         Examples
         --------
@@ -3018,6 +3020,7 @@ class NDFrame(PandasObject, SelectionMixin):
         2    3
         3    4
         dtype: int64
+
         >>> s.add_suffix('_item')
         0_item    1
         1_item    2
@@ -3032,8 +3035,9 @@ class NDFrame(PandasObject, SelectionMixin):
         1  2  4
         2  3  5
         3  4  6
+
         >>> df.add_suffix('_col')
-           A_col  B_col
+             A_col  B_col
         0       1       3
         1       2       4
         2       3       5

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -2978,21 +2978,24 @@ class NDFrame(PandasObject, SelectionMixin):
 
     def add_suffix(self, suffix):
         """
-        Add a suffix string to Series items names.
+        Suffix labels with string `suffix`.
+
+        For Series, the row labels are suffixed.
+        For DataFrame, the column labels are suffixed.
 
         Parameters
         ----------
         suffix : str
-            The string to add after each item name.
+            The string to add after each label.
 
         Returns
         -------
-        Series
-            Original Series with updated item names.
+        Series or DataFrame
+            New Series or DataFrame with updated labels.
 
         See Also
         --------
-        Series.add_prefix: Concatenate prefix string with Series items names.
+        Series.add_prefix: Prefix labels with string `prefix`.
 
         Examples
         --------
@@ -3009,6 +3012,20 @@ class NDFrame(PandasObject, SelectionMixin):
         2_item    3
         3_item    4
         dtype: int64
+
+        >>> df = pd.DataFrame({'A': [1, 2, 3, 4],  'B': [3, 4, 5, 6]})
+        >>> df
+           A  B
+        0  1  3
+        1  2  4
+        2  3  5
+        3  4  6
+        >>> df.add_suffix('_col')
+           A_col  B_col
+        0       1       3
+        1       2       4
+        2       3       5
+        3       4       6
         """
         new_data = self._data.add_suffix(suffix)
         return self._constructor(new_data).__finalize__(self)


### PR DESCRIPTION
Checklist for the pandas documentation sprint (ignore this if you are doing
an unrelated PR):

- [x] PR title is "DOC: update the <your-function-or-method> docstring"
- [x] The validation script passes: `scripts/validate_docstrings.py <your-function-or-method>`
- [x] The PEP8 style check passes: `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] The html version looks good: `python doc/make.py --single <your-function-or-method>`
- [x] It has been proofread on language by another sprint participant

Please include the output of the validation script below between the "```" ticks:

```
################################################################################
##################### Docstring (pandas.Series.add_suffix) #####################
################################################################################

Add a suffix string to panel items names.

Parameters
----------
suffix : str
    The string to add after each item name.

Returns
-------
Series
    Original Series with updated item names.

See Also
--------
pandas.Series.add_prefix: Concatenate prefix string with panel items names.

Examples
--------
>>> s = pd.Series([1,2,3,4])
>>> s
0    1
1    2
2    3
3    4
dtype: int64
>>> s.add_suffix('_item')
0_item    1
1_item    2
2_item    3
3_item    4
dtype: int64

################################################################################
################################## Validation ##################################
################################################################################

Errors found:
	No extended summary found
```

If the validation script still gives errors, but you think there is a good reason
to deviate in this case (and there are certainly such cases), please state this
explicitly.