### PR TITLE
DOC: update the Period.start_time attribute docstring

### DIFF
--- a/pandas/_libs/tslibs/period.pyx
+++ b/pandas/_libs/tslibs/period.pyx
@@ -1164,6 +1164,36 @@ cdef class _Period(object):
 
     @property
     def start_time(self):
+        """
+        Return the Timestamp.
+
+        This attribute returns the timestamp of the particular
+        starting date for the given period.
+
+        See also
+        --------
+        Period.dayofyear
+            Return the day of year.
+        Period.daysinmonth
+            Return the days in that month.
+        Period.dayofweek
+            Return the day of the week.
+
+        Returns
+        -------
+        Timestamp
+
+        Examples
+        --------
+        >>> period = pd.Period('2012-1-1', freq='D')
+        >>> period
+        Period('2012-01-01', 'D')
+
+        >>> period.start_time
+        Timestamp('2012-01-01 00:00:00')
+        >>> period.end_time
+        Timestamp('2012-01-01 23:59:59.999999999')
+        """
         return self.to_timestamp(how='S')
 
     @property

--- a/pandas/_libs/tslibs/period.pyx
+++ b/pandas/_libs/tslibs/period.pyx
@@ -1255,7 +1255,7 @@ cdef class _Period(object):
         Returns
         -------
         Int
-            Range of 0 to 6
+            Range from 0 to 6(included).
 
         See also
         --------

--- a/pandas/_libs/tslibs/period.pyx
+++ b/pandas/_libs/tslibs/period.pyx
@@ -1246,6 +1246,37 @@ cdef class _Period(object):
 
     @property
     def dayofweek(self):
+        """
+        Return the day of the week.
+
+        This attribute returns the day of the week on which the particular
+        date occurs with Monady=0, Sunday=6.
+
+        Returns
+        -------
+        Int:Range of 0 to 6
+
+        See also
+        --------
+        Period.dayofyear
+            Return the day of year.
+        Period.daysinmonth
+            Return the days in that month.
+
+        Examples
+        --------
+        >>> p=pd.Period('2012-1-1 19:00', freq='H')
+        >>> p
+        Period('2012-01-01 19:00', 'H')
+        >>> p.dayofweek
+        6
+
+        >>> q=pd.Period('2013-1-9 11:00', freq='H')
+        >>> q
+        Period('2013-01-09 11:00', 'H')
+        >>> q.dayofweek
+        2
+        """
         base, mult = get_freq_code(self.freq)
         return pweekday(self.ordinal, base)
 

--- a/pandas/_libs/tslibs/period.pyx
+++ b/pandas/_libs/tslibs/period.pyx
@@ -1250,11 +1250,12 @@ cdef class _Period(object):
         Return the day of the week.
 
         This attribute returns the day of the week on which the particular
-        date occurs with Monady=0, Sunday=6.
+        starting date for the given period occurs with Monday=0, Sunday=6.
 
         Returns
         -------
-        Int:Range of 0 to 6
+        Int
+            Range of 0 to 6
 
         See also
         --------
@@ -1265,16 +1266,16 @@ cdef class _Period(object):
 
         Examples
         --------
-        >>> p=pd.Period('2012-1-1 19:00', freq='H')
-        >>> p
+        >>> period1 = pd.Period('2012-1-1 19:00', freq='H')
+        >>> period1
         Period('2012-01-01 19:00', 'H')
-        >>> p.dayofweek
+        >>> period1.dayofweek
         6
 
-        >>> q=pd.Period('2013-1-9 11:00', freq='H')
-        >>> q
+        >>> period2 = pd.Period('2013-1-9 11:00', freq='H')
+        >>> period2
         Period('2013-01-09 11:00', 'H')
-        >>> q.dayofweek
+        >>> period2.dayofweek
         2
         """
         base, mult = get_freq_code(self.freq)


### PR DESCRIPTION
Checklist for the pandas documentation sprint (ignore this if you are doing
an unrelated PR):

- [x] PR title is "DOC: update the <your-function-or-method> docstring"
- [x] The validation script passes: `scripts/validate_docstrings.py <your-function-or-method>`
- [x] The PEP8 style check passes: `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] The html version looks good: `python doc/make.py --single <your-function-or-method>`
- [ ] It has been proofread on language by another sprint participant

Please include the output of the validation script below between the "```" ticks:

```
(pandas_dev) root@kalih:~/pythonpanda/pandas# python scripts/validate_docstrings.py pandas.Period.start_time

################################################################################
##################### Docstring (pandas.Period.start_time) #####################
################################################################################

Return the Timestamp.

This attribute returns the timestamp of the particular
starting date for the given period.

See also
--------
Period.dayofyear
    Return the day of year.
Period.daysinmonth
    Return the days in that month.
Period.dayofweek
    Return the day of the week.

Returns
-------
Timestamp

Examples
--------
>>> period = pd.Period('2012-1-1', freq='D')
>>> period
Period('2012-01-01', 'D')

>>> period.start_time
Timestamp('2012-01-01 00:00:00')
>>> period.end_time
Timestamp('2012-01-01 23:59:59.999999999')

################################################################################
################################## Validation ##################################
################################################################################

Docstring for "pandas.Period.start_time" correct. :)
```

If the validation script still gives errors, but you think there is a good reason
to deviate in this case (and there are certainly such cases), please state this
explicitly.

