### PR TITLE
DOC: Formatting for DtypeWarning Docstring [ci skip]

### DIFF
--- a/pandas/errors/__init__.py
+++ b/pandas/errors/__init__.py
@@ -68,8 +68,7 @@ class DtypeWarning(Warning):
     ...                    'b': ['b'] * 300000})
     >>> df.to_csv('test.csv', index=False)
     >>> df2 = pd.read_csv('test.csv')
-
-        DtypeWarning: Columns (0) have mixed types
+    ... # DtypeWarning: Columns (0) have mixed types
 
     Important to notice that ``df2`` will contain both `str` and `int` for the
     same input, '1'.


### PR DESCRIPTION
xref : https://github.com/pandas-dev/pandas/pull/20208

![fireshot capture 002 - pandas errors dtypewarning pandas 0_ - file____users_taugspurger_sandbox_](https://user-images.githubusercontent.com/1312546/37349929-958f175e-26a5-11e8-8c1e-872c2261c64f.png)

cc @jorisvandenbossche @hissashirocha