### PR TITLE
BUG: xtick labels didn't work some times 

### DIFF
--- a/pandas/plotting/_core.py
+++ b/pandas/plotting/_core.py
@@ -390,7 +390,7 @@ class MPLPlot(object):
 
         if self.orientation == 'vertical' or self.orientation is None:
             if self._need_to_set_index:
-                xticklabels = [get_label(x) for x in ax.get_xticks()]
+                xticklabels = [get_label(x) for x in self._get_xticks()]
                 ax.set_xticklabels(xticklabels)
             self._apply_axis_properties(ax.xaxis, rot=self.rot,
                                         fontsize=self.fontsize)


### PR DESCRIPTION
use locally defined self._get_xticks instead of matplotlib default ax.get_xticks() 

actually fixes #18755  the other is unrelated
