### PR TITLE
TST: Parametrize dtypes tests - test_common.py and test_concat.py

### DIFF
--- a/pandas/tests/dtypes/test_common.py
+++ b/pandas/tests/dtypes/test_common.py
@@ -16,44 +16,46 @@ class TestPandasDtype(object):
 
     # Passing invalid dtype, both as a string or object, must raise TypeError
     # Per issue GH15520
-    def test_invalid_dtype_error(self):
-        msg = 'not understood'
-        invalid_list = [pd.Timestamp, 'pd.Timestamp', list]
-        for dtype in invalid_list:
-            with tm.assert_raises_regex(TypeError, msg):
-                com.pandas_dtype(dtype)
-
-        valid_list = [object, 'float64', np.object_, np.dtype('object'), 'O',
-                      np.float64, float, np.dtype('float64')]
-        for dtype in valid_list:
+    @pytest.mark.parametrize('dtype', [pd.Timestamp, 'pd.Timestamp', list])
+    def test_invalid_dtype_error(self, dtype):
+        with tm.assert_raises_regex(TypeError, 'not understood'):
             com.pandas_dtype(dtype)
 
-    def test_numpy_dtype(self):
-        for dtype in ['M8[ns]', 'm8[ns]', 'object', 'float64', 'int64']:
-            assert com.pandas_dtype(dtype) == np.dtype(dtype)
+    @pytest.mark.parametrize('dtype', [
+        object, 'float64', np.object_, np.dtype('object'), 'O',
+        np.float64, float, np.dtype('float64')])
+    def test_pandas_dtype_valid(self, dtype):
+        assert com.pandas_dtype(dtype) == dtype
+
+    @pytest.mark.parametrize('dtype', [
+        'M8[ns]', 'm8[ns]', 'object', 'float64', 'int64'])
+    def test_numpy_dtype(self, dtype):
+        assert com.pandas_dtype(dtype) == np.dtype(dtype)
 
     def test_numpy_string_dtype(self):
         # do not parse freq-like string as period dtype
         assert com.pandas_dtype('U') == np.dtype('U')
         assert com.pandas_dtype('S') == np.dtype('S')
 
-    def test_datetimetz_dtype(self):
-        for dtype in ['datetime64[ns, US/Eastern]',
-                      'datetime64[ns, Asia/Tokyo]',
-                      'datetime64[ns, UTC]']:
-            assert com.pandas_dtype(dtype) is DatetimeTZDtype(dtype)
-            assert com.pandas_dtype(dtype) == DatetimeTZDtype(dtype)
-            assert com.pandas_dtype(dtype) == dtype
+    @pytest.mark.parametrize('dtype', [
+        'datetime64[ns, US/Eastern]',
+        'datetime64[ns, Asia/Tokyo]',
+        'datetime64[ns, UTC]'])
+    def test_datetimetz_dtype(self, dtype):
+        assert com.pandas_dtype(dtype) is DatetimeTZDtype(dtype)
+        assert com.pandas_dtype(dtype) == DatetimeTZDtype(dtype)
+        assert com.pandas_dtype(dtype) == dtype
 
     def test_categorical_dtype(self):
         assert com.pandas_dtype('category') == CategoricalDtype()
 
-    def test_period_dtype(self):
-        for dtype in ['period[D]', 'period[3M]', 'period[U]',
-                      'Period[D]', 'Period[3M]', 'Period[U]']:
-            assert com.pandas_dtype(dtype) is PeriodDtype(dtype)
-            assert com.pandas_dtype(dtype) == PeriodDtype(dtype)
-            assert com.pandas_dtype(dtype) == dtype
+    @pytest.mark.parametrize('dtype', [
+        'period[D]', 'period[3M]', 'period[U]',
+        'Period[D]', 'Period[3M]', 'Period[U]'])
+    def test_period_dtype(self, dtype):
+        assert com.pandas_dtype(dtype) is PeriodDtype(dtype)
+        assert com.pandas_dtype(dtype) == PeriodDtype(dtype)
+        assert com.pandas_dtype(dtype) == dtype
 
 
 dtypes = dict(datetime_tz=com.pandas_dtype('datetime64[ns, US/Eastern]'),

--- a/pandas/tests/dtypes/test_common.py
+++ b/pandas/tests/dtypes/test_common.py
@@ -16,10 +16,10 @@ class TestPandasDtype(object):
 
     # Passing invalid dtype, both as a string or object, must raise TypeError
     # Per issue GH15520
-    @pytest.mark.parametrize('dtype', [pd.Timestamp, 'pd.Timestamp', list])
-    def test_invalid_dtype_error(self, dtype):
+    @pytest.mark.parametrize('box', [pd.Timestamp, 'pd.Timestamp', list])
+    def test_invalid_dtype_error(self, box):
         with tm.assert_raises_regex(TypeError, 'not understood'):
-            com.pandas_dtype(dtype)
+            com.pandas_dtype(box)
 
     @pytest.mark.parametrize('dtype', [
         object, 'float64', np.object_, np.dtype('object'), 'O',

--- a/pandas/tests/dtypes/test_concat.py
+++ b/pandas/tests/dtypes/test_concat.py
@@ -6,8 +6,7 @@ from pandas import (
     Index, DatetimeIndex, PeriodIndex, TimedeltaIndex, Series, Period)
 
 
-# test cases of the form (to_concat, expected)
-test_cases_standard = [
+@pytest.mark.parametrize('to_concat, expected', [
     # int/float/str
     ([['a'], [1, 2]], ['i', 'object']),
     ([[3, 4], [1, 2]], ['i']),
@@ -30,19 +29,15 @@ test_cases_standard = [
      ['timedelta']),
     ([DatetimeIndex(['2011-01-01'], tz='Asia/Tokyo'),
       TimedeltaIndex(['1 days'])],
-     ['datetime64[ns, Asia/Tokyo]', 'timedelta'])]
-
-
+     ['datetime64[ns, Asia/Tokyo]', 'timedelta'])])
 @pytest.mark.parametrize('klass', [Index, Series])
-@pytest.mark.parametrize('to_concat, expected', test_cases_standard)
 def test_get_dtype_kinds(klass, to_concat, expected):
     to_concat_klass = [klass(c) for c in to_concat]
     result = _concat.get_dtype_kinds(to_concat_klass)
     assert result == set(expected)
 
 
-# test cases of the form (to_concat, expected)
-test_cases_period = [
+@pytest.mark.parametrize('to_concat, expected', [
     # because we don't have Period dtype (yet),
     # Series results in object dtype
     ([PeriodIndex(['2011-01'], freq='M'),
@@ -52,10 +47,7 @@ test_cases_period = [
     ([PeriodIndex(['2011-01'], freq='M'),
       PeriodIndex(['2011-01'], freq='D')], ['period[M]', 'period[D]']),
     ([Series([Period('2011-01', freq='M')]),
-      Series([Period('2011-02', freq='D')])], ['object'])]
-
-
-@pytest.mark.parametrize('to_concat, expected', test_cases_period)
+      Series([Period('2011-02', freq='D')])], ['object'])])
 def test_get_dtype_kinds_period(to_concat, expected):
     result = _concat.get_dtype_kinds(to_concat)
     assert result == set(expected)

--- a/pandas/tests/dtypes/test_concat.py
+++ b/pandas/tests/dtypes/test_concat.py
@@ -1,77 +1,61 @@
 # -*- coding: utf-8 -*-
 
-import pandas as pd
+import pytest
 import pandas.core.dtypes.concat as _concat
+from pandas import (
+    Index, DatetimeIndex, PeriodIndex, TimedeltaIndex, Series, Period)
 
 
-class TestConcatCompat(object):
+# test cases of the form (to_concat, expected)
+test_cases_standard = [
+    # int/float/str
+    ([['a'], [1, 2]], ['i', 'object']),
+    ([[3, 4], [1, 2]], ['i']),
+    ([[3, 4], [1, 2.1]], ['i', 'f']),
 
-    def check_concat(self, to_concat, exp):
-        for klass in [pd.Index, pd.Series]:
-            to_concat_klass = [klass(c) for c in to_concat]
-            res = _concat.get_dtype_kinds(to_concat_klass)
-            assert res == set(exp)
+    # datetimelike
+    ([DatetimeIndex(['2011-01-01']), DatetimeIndex(['2011-01-02'])],
+     ['datetime']),
+    ([TimedeltaIndex(['1 days']), TimedeltaIndex(['2 days'])],
+     ['timedelta']),
 
-    def test_get_dtype_kinds(self):
-        to_concat = [['a'], [1, 2]]
-        self.check_concat(to_concat, ['i', 'object'])
+    # datetimelike object
+    ([DatetimeIndex(['2011-01-01']),
+      DatetimeIndex(['2011-01-02'], tz='US/Eastern')],
+     ['datetime', 'datetime64[ns, US/Eastern]']),
+    ([DatetimeIndex(['2011-01-01'], tz='Asia/Tokyo'),
+      DatetimeIndex(['2011-01-02'], tz='US/Eastern')],
+     ['datetime64[ns, Asia/Tokyo]', 'datetime64[ns, US/Eastern]']),
+    ([TimedeltaIndex(['1 days']), TimedeltaIndex(['2 hours'])],
+     ['timedelta']),
+    ([DatetimeIndex(['2011-01-01'], tz='Asia/Tokyo'),
+      TimedeltaIndex(['1 days'])],
+     ['datetime64[ns, Asia/Tokyo]', 'timedelta'])]
 
-        to_concat = [[3, 4], [1, 2]]
-        self.check_concat(to_concat, ['i'])
 
-        to_concat = [[3, 4], [1, 2.1]]
-        self.check_concat(to_concat, ['i', 'f'])
+@pytest.mark.parametrize('klass', [Index, Series])
+@pytest.mark.parametrize('to_concat, expected', test_cases_standard)
+def test_get_dtype_kinds(klass, to_concat, expected):
+    to_concat_klass = [klass(c) for c in to_concat]
+    result = _concat.get_dtype_kinds(to_concat_klass)
+    assert result == set(expected)
 
-    def test_get_dtype_kinds_datetimelike(self):
-        to_concat = [pd.DatetimeIndex(['2011-01-01']),
-                     pd.DatetimeIndex(['2011-01-02'])]
-        self.check_concat(to_concat, ['datetime'])
 
-        to_concat = [pd.TimedeltaIndex(['1 days']),
-                     pd.TimedeltaIndex(['2 days'])]
-        self.check_concat(to_concat, ['timedelta'])
+# test cases of the form (to_concat, expected)
+test_cases_period = [
+    # because we don't have Period dtype (yet),
+    # Series results in object dtype
+    ([PeriodIndex(['2011-01'], freq='M'),
+      PeriodIndex(['2011-01'], freq='M')], ['period[M]']),
+    ([Series([Period('2011-01', freq='M')]),
+      Series([Period('2011-02', freq='M')])], ['object']),
+    ([PeriodIndex(['2011-01'], freq='M'),
+      PeriodIndex(['2011-01'], freq='D')], ['period[M]', 'period[D]']),
+    ([Series([Period('2011-01', freq='M')]),
+      Series([Period('2011-02', freq='D')])], ['object'])]
 
-    def test_get_dtype_kinds_datetimelike_object(self):
-        to_concat = [pd.DatetimeIndex(['2011-01-01']),
-                     pd.DatetimeIndex(['2011-01-02'], tz='US/Eastern')]
-        self.check_concat(to_concat,
-                          ['datetime', 'datetime64[ns, US/Eastern]'])
 
-        to_concat = [pd.DatetimeIndex(['2011-01-01'], tz='Asia/Tokyo'),
-                     pd.DatetimeIndex(['2011-01-02'], tz='US/Eastern')]
-        self.check_concat(to_concat,
-                          ['datetime64[ns, Asia/Tokyo]',
-                           'datetime64[ns, US/Eastern]'])
-
-        # timedelta has single type
-        to_concat = [pd.TimedeltaIndex(['1 days']),
-                     pd.TimedeltaIndex(['2 hours'])]
-        self.check_concat(to_concat, ['timedelta'])
-
-        to_concat = [pd.DatetimeIndex(['2011-01-01'], tz='Asia/Tokyo'),
-                     pd.TimedeltaIndex(['1 days'])]
-        self.check_concat(to_concat,
-                          ['datetime64[ns, Asia/Tokyo]', 'timedelta'])
-
-    def test_get_dtype_kinds_period(self):
-        # because we don't have Period dtype (yet),
-        # Series results in object dtype
-        to_concat = [pd.PeriodIndex(['2011-01'], freq='M'),
-                     pd.PeriodIndex(['2011-01'], freq='M')]
-        res = _concat.get_dtype_kinds(to_concat)
-        assert res == set(['period[M]'])
-
-        to_concat = [pd.Series([pd.Period('2011-01', freq='M')]),
-                     pd.Series([pd.Period('2011-02', freq='M')])]
-        res = _concat.get_dtype_kinds(to_concat)
-        assert res == set(['object'])
-
-        to_concat = [pd.PeriodIndex(['2011-01'], freq='M'),
-                     pd.PeriodIndex(['2011-01'], freq='D')]
-        res = _concat.get_dtype_kinds(to_concat)
-        assert res == set(['period[M]', 'period[D]'])
-
-        to_concat = [pd.Series([pd.Period('2011-01', freq='M')]),
-                     pd.Series([pd.Period('2011-02', freq='D')])]
-        res = _concat.get_dtype_kinds(to_concat)
-        assert res == set(['object'])
+@pytest.mark.parametrize('to_concat, expected', test_cases_period)
+def test_get_dtype_kinds_period(to_concat, expected):
+    result = _concat.get_dtype_kinds(to_concat)
+    assert result == set(expected)


### PR DESCRIPTION
Parametrized some straightforward dtypes related tests.

Relatively minor changes to `test_common.py`:
  - mostly just extracted `for` loops
  - split one test into two separate tests (see code comment)

Made larger changes to `test_concat.py`:
  - removed the test class in favor of plain functions, since there was only one class in the file
  - combined a few different tests into a single test, since they were all using test procedure
      - removed the `check_concat` validation function since it's only called once now
      - further parametrized over a `for` loop previously in the  `check_concat` validation function
  - removed the `import pandas as pd` in favor of directly importing the necessary classes
      
