### PR TITLE
CI: builds docs on every commit

### DIFF
--- a/ci/build_docs.sh
+++ b/ci/build_docs.sh
@@ -10,11 +10,11 @@ echo "inside $0"
 
 git show --pretty="format:" --name-only HEAD~5.. --first-parent | grep -P "rst|txt|doc"
 
-if [ "$?" != "0" ]; then
-    echo "Skipping doc build, none were modified"
-    # nope, skip docs build
-    exit 0
-fi
+# if [ "$?" != "0" ]; then
+#     echo "Skipping doc build, none were modified"
+#     # nope, skip docs build
+#     exit 0
+# fi
 
 
 if [ "$DOC" ]; then


### PR DESCRIPTION
As I refer to the dev docs on PRs, let's build them for each commit temporarily. 
Will clean it up when I update https://github.com/pandas-dev/pandas/pull/19952