### PR TITLE
DOC: update the pd.Index.asof docstring

### DIFF
--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -2397,32 +2397,37 @@ class Index(IndexOpsMixin, PandasObject):
 
         See Also
         --------
+        Series.asof : Return the latest value in a Series up to the
+            passed index.
+        merge_asof : Perform an asof merge (similar to left join but it
+            matches on nearest key rather than equal key).
         Index.get_loc : `asof` is a thin wrapper around `get_loc`
             with method='pad'.
 
         Examples
         --------
-        The method returns the latest index label up to the passed label.
+        `Index.asof` returns the latest index label up to the passed label.
 
-        >>> idx = pd.Index([13, 18, 20])
-        >>> idx.asof(14)
-        13
+        >>> idx = pd.Index(['2013-12-31', '2014-01-02', '2014-01-03'])
+        >>> idx.asof('2014-01-01')
+        '2013-12-31'
 
         If the label is in the index, the method returns the passed label.
 
-        >>> idx.asof(18)
-        18
+        >>> idx.asof('2014-01-02')
+        '2014-01-02'
 
         If all of the labels in the index are later than the passed label,
         NaN is returned.
 
-        >>> idx.asof(1)
+        >>> idx.asof('1999-01-02')
         nan
 
         If the index is not sorted, an error is raised.
 
-        >>> idx_not_sorted = pd.Index([13, 20, 18])
-        >>> idx_not_sorted.asof(18)
+        >>> idx_not_sorted = pd.Index(['2013-12-31', '2015-01-02',
+        ...                            '2014-01-03'])
+        >>> idx_not_sorted.asof('2013-12-31')
         Traceback (most recent call last):
         ValueError: index must be monotonic increasing or decreasing
         """

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -2378,10 +2378,11 @@ class Index(IndexOpsMixin, PandasObject):
 
     def asof(self, label):
         """
-        Return the latest index label up to and including the passed label.
+        Return the label from the index, or, if not present, the previous one.
 
-        For sorted indexes, return the index label that is the latest among
-        the labels that are not later than the passed index label.
+        Assuming that the index is sorted, return the passed index label if it
+        is in the index, or return the previous index label if the passed one
+        is not in the index.
 
         Parameters
         ----------
@@ -2390,10 +2391,11 @@ class Index(IndexOpsMixin, PandasObject):
 
         Returns
         -------
-        object : The index label that is the latest as of the passed label,
-            or NaN if there is no such label.
+        object : The passed label if it is in the index. The previous label
+            if the passed label is not in the sorted index, or NaN if there
+            is no such label.
 
-        See also
+        See Also
         --------
         Index.get_loc : `asof` is a thin wrapper around `get_loc`
             with method='pad'.
@@ -2402,23 +2404,25 @@ class Index(IndexOpsMixin, PandasObject):
         --------
         The method returns the latest index label up to the passed label.
 
-        >>> pd.Index([13, 18, 20]).asof(14)
+        >>> idx = pd.Index([13, 18, 20])
+        >>> idx.asof(14)
         13
 
         If the label is in the index, the method returns the passed label.
 
-        >>> pd.Index([13, 18, 20]).asof(18)
+        >>> idx.asof(18)
         18
 
         If all of the labels in the index are later than the passed label,
         NaN is returned.
 
-        >>> pd.Index([13, 18, 20]).asof(1)
+        >>> idx.asof(1)
         nan
 
         If the index is not sorted, an error is raised.
 
-        >>> pd.Index([13, 20, 18]).asof(18)
+        >>> idx_not_sorted = pd.Index([13, 20, 18])
+        >>> idx_not_sorted.asof(18)
         Traceback (most recent call last):
         ValueError: index must be monotonic increasing or decreasing
         """

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -2391,9 +2391,10 @@ class Index(IndexOpsMixin, PandasObject):
 
         Returns
         -------
-        object : The passed label if it is in the index. The previous label
-            if the passed label is not in the sorted index, or NaN if there
-            is no such label.
+        object
+            The passed label if it is in the index. The previous label if the
+            passed label is not in the sorted index or `NaN` if there is no
+            such label.
 
         See Also
         --------

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -2378,12 +2378,49 @@ class Index(IndexOpsMixin, PandasObject):
 
     def asof(self, label):
         """
-        For a sorted index, return the most recent label up to and including
-        the passed label. Return NaN if not found.
+        Return the latest index label up to and including the passed label.
+
+        For sorted indexes, return the index label that is the latest among
+        the labels that are not later than the passed index label.
+
+        Parameters
+        ----------
+        label : object
+            The label up to which the method returns the latest index label.
+
+        Returns
+        -------
+        object : The index label that is the latest as of the passed label,
+            or NaN if there is no such label.
 
         See also
         --------
-        get_loc : asof is a thin wrapper around get_loc with method='pad'
+        Index.get_loc : `asof` is a thin wrapper around `get_loc`
+            with method='pad'.
+
+        Examples
+        --------
+        The method returns the latest index label up to the passed label.
+
+        >>> pd.Index([13, 18, 20]).asof(14)
+        13
+
+        If the label is in the index, the method returns the passed label.
+
+        >>> pd.Index([13, 18, 20]).asof(18)
+        18
+
+        If all of the labels in the index are later than the passed label,
+        NaN is returned.
+
+        >>> pd.Index([13, 18, 20]).asof(1)
+        nan
+
+        If the index is not sorted, an error is raised.
+
+        >>> pd.Index([13, 20, 18]).asof(18)
+        Traceback (most recent call last):
+        ValueError: index must be monotonic increasing or decreasing
         """
         try:
             loc = self.get_loc(label, method='pad')


### PR DESCRIPTION
Checklist for the pandas documentation sprint (ignore this if you are doing
an unrelated PR):

- [x] PR title is "DOC: update the <your-function-or-method> docstring"
- [x] The validation script passes: `scripts/validate_docstrings.py <your-function-or-method>`
- [x] The PEP8 style check passes: `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] The html version looks good: `python doc/make.py --single <your-function-or-method>`
- [x] It has been proofread on language by another sprint participant

Please include the output of the validation script below between the "```" ticks:

```
################################################################################
######################## Docstring (pandas.Index.asof)  ########################
################################################################################

Return the latest index label up to and including the passed label.

For sorted indexes, return the index label that is the latest among
the labels that are not later than the passed index label.

Parameters
----------
label : object
    The label up to which the method returns the latest index label.

Returns
-------
object : The index label that is the latest as of the passed label,
    or NaN if there is no such label.

See also
--------
Index.get_loc : `asof` is a thin wrapper around `get_loc`
    with method='pad'.

Examples
--------
13 is the latest index label up to 14.

>>> pd.Index([13, 18, 20]).asof(14)
13

If the label is in the index, the method returns the passed label.

>>> pd.Index([13, 18, 20]).asof(18)
18

If all of the labels in the index are later than the passed label,
NaN is returned.

>>> pd.Index([13, 18, 20]).asof(1)
nan

If the index is not sorted, an error is raised.

>>> pd.Index([13, 20, 18]).asof(18)
Traceback (most recent call last):
ValueError: index must be monotonic increasing or decreasing

################################################################################
################################## Validation ##################################
################################################################################

Docstring for "pandas.Index.asof" correct. :)

```

If the validation script still gives errors, but you think there is a good reason
to deviate in this case (and there are certainly such cases), please state this
explicitly.

