### PR TITLE
API: str.cat will align on Series

### DIFF
--- a/doc/source/text.rst
+++ b/doc/source/text.rst
@@ -305,18 +305,20 @@ The same alignment can be used when ``others`` is a ``DataFrame``:
 Concatenating a Series and many objects into a Series
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-All list-likes (including iterators, ``dict``-views, etc.) can be arbitrarily combined in a list-like container:
+All one-dimensional list-likes can be arbitrarily combined in a list-like container (including iterators, ``dict``-views, etc.):
 
 .. ipython:: python
 
-    s.str.cat([u, t.values, ['A', 'B', 'C', 'D'], d.values, f], na_rep='-')
+    s
+    u
+    s.str.cat([u, pd.Index(u.values), ['A', 'B', 'C', 'D']], na_rep='-')
 
-All elements must match in length to the calling ``Series``, except those having an index if ``join`` is not None:
+All elements must match in length to the calling ``Series`` (or ``Index``), except those having an index if ``join`` is not None:
 
 .. ipython:: python
 
-    s.str.cat([u, v, ['A', 'B', 'C', 'D'], d.values, f.loc[[1]]],
-               join='outer', na_rep='-')
+    v
+    s.str.cat([u, v, ['A', 'B', 'C', 'D']], join='outer', na_rep='-')
 
 If using ``join='right'`` on a list of ``others`` that contains different indexes,
 the union of these indexes will be used as the basis for the final concatenation:

--- a/doc/source/text.rst
+++ b/doc/source/text.rst
@@ -257,6 +257,7 @@ The parameter ``others`` can also be two-dimensional. In this case, the number o
 .. ipython:: python
 
     d = pd.concat([t, s], axis=1)
+    s
     d
     s.str.cat(d, na_rep='-')
     
@@ -271,6 +272,8 @@ the ``join``-keyword, which controls the manner of alignment.
 .. ipython:: python
 
     u = pd.Series(['b', 'd', 'a', 'c'], index=[1, 3, 0, 2])
+    s
+    u
     s.str.cat(u)
     s.str.cat(u, join='left')
 
@@ -285,6 +288,8 @@ In particular, alignment also means that the different lengths do not need to co
 .. ipython:: python
 
     v = pd.Series(['z', 'a', 'b', 'd', 'e'], index=[-1, 0, 1, 3, 4])
+    s
+    v
     s.str.cat(v, join='left', na_rep='-')
     s.str.cat(v, join='outer', na_rep='-')
 
@@ -293,13 +298,14 @@ The same alignment can be used when ``others`` is a ``DataFrame``:
 .. ipython:: python
     
     f = d.loc[[3, 2, 1, 0], :]
+    s
     f
     s.str.cat(f, join='left', na_rep='-')
 
 Concatenating a Series and many objects into a Series
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-All list-likes (as well as ``DataFrame`` and two-dimensional ``ndarray``) can be arbitrarily combined in a list-like container:
+All list-likes (including iterators,  ``dict``-views, etc.) can be arbitrarily combined in a list-like container:
 
 .. ipython:: python
 
@@ -317,14 +323,9 @@ the union of these indexes will be used as the basis for the final concatenation
 
 .. ipython:: python
 
+    u.loc[[3]]
+    v.loc[[-1, 0]]
     s.str.cat([u.loc[[3]], v.loc[[-1, 0]]], join='right', na_rep='-')
-
-Finally, the surrounding container can also be an :obj:`Iterable` other than a ``list`` (e.g. an iterator, or a ``dict``-view, etc.):
-
-.. ipython:: python
-    
-    from collections import OrderedDict
-    s.str.cat(d.to_dict('series', into=OrderedDict).values(), na_rep='-')
 
 Indexing with ``.str``
 ----------------------

--- a/doc/source/text.rst
+++ b/doc/source/text.rst
@@ -247,27 +247,84 @@ Missing values on either side will result in missing values in the result as wel
     s.str.cat(t)
     s.str.cat(t, na_rep='-')
 
-Series are *not* aligned on their index before concatenation:
+Concatenating a Series and something array-like into a Series
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. versionadded:: 0.23.0
+
+The parameter ``others`` can also be two-dimensional. In this case, the number or rows must match the lengths of the calling ``Series`` (or ``Index``).
 
 .. ipython:: python
 
-    u = pd.Series(['b', 'd', 'e', 'c'], index=[1, 3, 4, 2])
-    # without alignment
+    d = pd.concat([t, s], axis=1)
+    d
+    s.str.cat(d, na_rep='-')
+    
+Concatenating a Series and an indexed object into a Series, with alignment
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. versionadded:: 0.23.0
+
+For concatenation with a ``Series`` or ``DataFrame``, it is possible to align the respective indexes before concatenation by setting
+the ``join``-keyword, which controls the manner of alignment.
+
+.. ipython:: python
+
+    u = pd.Series(['b', 'd', 'a', 'c'], index=[1, 3, 0, 2])
     s.str.cat(u)
-    # with separate alignment
-    v, w = s.align(u)
-    v.str.cat(w, na_rep='-')
+    s.str.cat(u, join='left')
+
+.. warning::
+
+    If the ``join`` keyword is not passed, the method :meth:`~Series.str.cat` will currently fall back to the behavior before version 0.23.0 (i.e. no alignment),
+    but a ``FutureWarning`` will be raised, since this default will change to ``join='left'`` in a future version.
+
+To usual options are available for ``join`` (one of ``'left', 'outer', 'inner', 'right'``).
+In particular, alignment also means that the different lengths do not need to coincide anymore.
+
+.. ipython:: python
+
+    v = pd.Series(['z', 'a', 'b', 'd', 'e'], index=[-1, 0, 1, 3, 4])
+    s.str.cat(v, join='left', na_rep='-')
+    s.str.cat(v, join='outer', na_rep='-')
+
+The same alignment can be used when ``others`` is a ``DataFrame``:
+
+.. ipython:: python
+    
+    f = d.loc[[3, 2, 1, 0], :]
+    f
+    s.str.cat(f, join='left', na_rep='-')
 
 Concatenating a Series and many objects into a Series
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-List-likes (excluding iterators, ``dict``-views, etc.) can be arbitrarily combined in a list.
-All elements of the list must match in length to the calling ``Series`` (resp. ``Index``):
+All list-likes (as well as ``DataFrame`` and two-dimensional ``ndarray``) can be arbitrarily combined in a list-like container:
 
 .. ipython:: python
 
-    x = pd.Series([1, 2, 3, 4], index=['A', 'B', 'C', 'D'])
-    s.str.cat([['A', 'B', 'C', 'D'], s, s.values, x.index])
+    s.str.cat([u, t.values, ['A', 'B', 'C', 'D'], d.values, f], na_rep='-')
+
+All elements must match in length to the calling ``Series``, except those having an index if ``join`` is not None:
+
+.. ipython:: python
+
+    s.str.cat([u, v, ['A', 'B', 'C', 'D'], d.values, f.loc[[1]]],
+               join='outer', na_rep='-')
+
+If using ``join='right'`` on a list of ``others`` that contains different indexes,
+the union of these indexes will be used as the basis for the final concatenation:
+
+.. ipython:: python
+
+    s.str.cat([u.loc[[3]], v.loc[[-1, 0]]], join='right', na_rep='-')
+
+Finally, the surrounding container can also be an :obj:`Iterable` other than a ``list`` (e.g. an iterator, or a ``dict``-view, etc.):
+
+.. ipython:: python
+    
+    from collections import OrderedDict
+    s.str.cat(d.to_dict('series', into=OrderedDict).values(), na_rep='-')
 
 Indexing with ``.str``
 ----------------------

--- a/doc/source/text.rst
+++ b/doc/source/text.rst
@@ -311,7 +311,7 @@ All one-dimensional list-likes can be arbitrarily combined in a list-like contai
 
     s
     u
-    s.str.cat([u, pd.Index(u.values), ['A', 'B', 'C', 'D']], na_rep='-')
+    s.str.cat([u, pd.Index(u.values), ['A', 'B', 'C', 'D'], map(int, u.index)], na_rep='-')
 
 All elements must match in length to the calling ``Series`` (or ``Index``), except those having an index if ``join`` is not None:
 

--- a/doc/source/text.rst
+++ b/doc/source/text.rst
@@ -266,8 +266,8 @@ Concatenating a Series and an indexed object into a Series, with alignment
 
 .. versionadded:: 0.23.0
 
-For concatenation with a ``Series`` or ``DataFrame``, it is possible to align the respective indexes before concatenation by setting
-the ``join``-keyword, which controls the manner of alignment.
+For concatenation with a ``Series`` or ``DataFrame``, it is possible to align the indexes before concatenation by setting
+the ``join``-keyword.
 
 .. ipython:: python
 
@@ -282,7 +282,7 @@ the ``join``-keyword, which controls the manner of alignment.
     If the ``join`` keyword is not passed, the method :meth:`~Series.str.cat` will currently fall back to the behavior before version 0.23.0 (i.e. no alignment),
     but a ``FutureWarning`` will be raised if any of the involved indexes differ, since this default will change to ``join='left'`` in a future version.
 
-To usual options are available for ``join`` (one of ``'left', 'outer', 'inner', 'right'``).
+The usual options are available for ``join`` (one of ``'left', 'outer', 'inner', 'right'``).
 In particular, alignment also means that the different lengths do not need to coincide anymore.
 
 .. ipython:: python

--- a/doc/source/text.rst
+++ b/doc/source/text.rst
@@ -280,7 +280,7 @@ the ``join``-keyword, which controls the manner of alignment.
 .. warning::
 
     If the ``join`` keyword is not passed, the method :meth:`~Series.str.cat` will currently fall back to the behavior before version 0.23.0 (i.e. no alignment),
-    but a ``FutureWarning`` will be raised, since this default will change to ``join='left'`` in a future version.
+    but a ``FutureWarning`` will be raised if any of the involved indexes differ, since this default will change to ``join='left'`` in a future version.
 
 To usual options are available for ``join`` (one of ``'left', 'outer', 'inner', 'right'``).
 In particular, alignment also means that the different lengths do not need to coincide anymore.
@@ -305,7 +305,7 @@ The same alignment can be used when ``others`` is a ``DataFrame``:
 Concatenating a Series and many objects into a Series
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-All list-likes (including iterators,  ``dict``-views, etc.) can be arbitrarily combined in a list-like container:
+All list-likes (including iterators, ``dict``-views, etc.) can be arbitrarily combined in a list-like container:
 
 .. ipython:: python
 

--- a/doc/source/whatsnew/v0.23.0.txt
+++ b/doc/source/whatsnew/v0.23.0.txt
@@ -326,17 +326,6 @@ to ``'left'`` in a future version of pandas.
 
 In particular, ``others`` does not need to be of the same length as the calling ``Series`` (if both have an index and ``join is not None``).
 For more examples, see :ref:`here <text.concatenate>`.
-
-Additionally, ``str.cat`` now allows ``others`` to be a ``DataFrame`` or two-dimensional ``np.ndarray``.
-
-.. ipython:: python
-    
-    u = pd.Series(['b', 'd', 'a', 'c'], index=[1, 3, 0, 2])
-    d = pd.concat([s, u], axis=1)
-    t.str.cat(d.values)
-    s.str.cat(d, join='left', na_rep='-')
-
-Furthermore, any combination of "concatenateable" arguments can be passed in a list-like container (e.g. an iterator).
     
 For categorical data, it is now possible to call :meth:`Series.str.cat` for ``CategoricalIndex`` as well (previously raised a ``ValueError``).
 Finally, if ``others is not None``, the resulting ``Series``/``Index`` will now remain categorical if the calling

--- a/doc/source/whatsnew/v0.23.0.txt
+++ b/doc/source/whatsnew/v0.23.0.txt
@@ -308,6 +308,39 @@ The :func:`DataFrame.assign` now accepts dependent keyword arguments for python 
 
       df.assign(A=df.A+1, C= lambda df: df.A* -1)
 
+.. _whatsnew_0230.enhancements.str_cat_align:
+
+``Series.str.cat`` has gained the ``join`` kwarg
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Previously, :meth:`Series.str.cat` did not -- in contrast to most of ``pandas`` -- align :class:`Series` on their index before concatenation (see :issue:`18657`).
+The method has now gained a keyword ``join`` to control the manner of alignment. In v.0.23 it will default to None (meaning no alignment), but this default will change
+to ``'left'`` in a future version of pandas.
+
+.. ipython:: python
+
+    s = pd.Series(['a', 'b', 'c', 'd'])
+    t = pd.Series(['b', 'd', 'e', 'c'], index=[1, 3, 4, 2])
+    s.str.cat(t)
+    s.str.cat(t, join='left', na_rep='-')
+
+In particular, ``others`` does not need to be of the same length as the calling ``Series`` (if both have an index and ``join is not None``).
+For more examples, see :ref:`here <text.concatenate>`.
+
+Additionally, ``str.cat`` now allows ``others`` to be a ``DataFrame`` or two-dimensional ``np.ndarray``.
+
+.. ipython:: python
+    
+    u = pd.Series(['b', 'd', 'a', 'c'], index=[1, 3, 0, 2])
+    d = pd.concat([s, u], axis=1)
+    t.str.cat(d.values)
+    s.str.cat(d, join='left', na_rep='-')
+
+Furthermore, any combination of "concatenateable" arguments can be passed in a list-like container (e.g. an iterator).
+    
+For categorical data, it is now possible to call :meth:`Series.str.cat` for ``CategoricalIndex`` as well (previously raised a ``ValueError``).
+Finally, if ``others is not None``, the resulting ``Series``/``Index`` will now remain categorical if the calling
+``Series``/``Index`` is categorical.
 
 .. _whatsnew_0230.enhancements.astype_category:
 

--- a/doc/source/whatsnew/v0.23.0.txt
+++ b/doc/source/whatsnew/v0.23.0.txt
@@ -314,8 +314,9 @@ The :func:`DataFrame.assign` now accepts dependent keyword arguments for python 
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Previously, :meth:`Series.str.cat` did not -- in contrast to most of ``pandas`` -- align :class:`Series` on their index before concatenation (see :issue:`18657`).
-The method has now gained a keyword ``join`` to control the manner of alignment. In v.0.23 it will default to None (meaning no alignment), but this default will change
-to ``'left'`` in a future version of pandas.
+The method has now gained a keyword ``join`` to control the manner of alignment, see examples below and in :ref:`here <text.concatenate>`.
+
+In v.0.23 `join` will default to None (meaning no alignment), but this default will change to ``'left'`` in a future version of pandas.
 
 .. ipython:: python
 
@@ -324,12 +325,9 @@ to ``'left'`` in a future version of pandas.
     s.str.cat(t)
     s.str.cat(t, join='left', na_rep='-')
 
-In particular, ``others`` does not need to be of the same length as the calling ``Series`` (if both have an index and ``join is not None``).
-For more examples, see :ref:`here <text.concatenate>`.
-    
-For categorical data, it is now possible to call :meth:`Series.str.cat` for ``CategoricalIndex`` as well (previously raised a ``ValueError``).
-Finally, if ``others is not None``, the resulting ``Series``/``Index`` will now remain categorical if the calling
-``Series``/``Index`` is categorical.
+Furthermore:
+- meth:`Series.str.cat` now works as well for ``CategoricalIndex`` as well (previously raised a ``ValueError``; see :issue:`20842`)
+- If concatenating with something (i.e. `others is not None`) the resulting ``Series``/``Index`` will now remain categorical if the calling ``Series``/``Index`` is categorical (see :issue:`20843`)
 
 .. _whatsnew_0230.enhancements.astype_category:
 

--- a/doc/source/whatsnew/v0.23.0.txt
+++ b/doc/source/whatsnew/v0.23.0.txt
@@ -325,9 +325,7 @@ In v.0.23 `join` will default to None (meaning no alignment), but this default w
     s.str.cat(t)
     s.str.cat(t, join='left', na_rep='-')
 
-Furthermore:
-- meth:`Series.str.cat` now works as well for ``CategoricalIndex`` as well (previously raised a ``ValueError``; see :issue:`20842`)
-- If concatenating with something (i.e. `others is not None`) the resulting ``Series``/``Index`` will now remain categorical if the calling ``Series``/``Index`` is categorical (see :issue:`20843`)
+Furthermore, meth:`Series.str.cat` now works for ``CategoricalIndex`` as well (previously raised a ``ValueError``; see :issue:`20842`).
 
 .. _whatsnew_0230.enhancements.astype_category:
 

--- a/pandas/core/strings.py
+++ b/pandas/core/strings.py
@@ -2217,11 +2217,10 @@ class StringMethods(NoNewAttributesMixin):
         # str_cat discards index
         res = str_cat(data, others=others, sep=sep, na_rep=na_rep)
 
-        dtype = 'category' if self._is_categorical else None
         if isinstance(self._orig, Index):
-            res = Index(res, dtype=dtype)
+            res = Index(res)
         else:  # Series
-            res = Series(res, index=data.index, dtype=dtype)
+            res = Series(res, index=data.index)
         return res
 
     @copy(str_split)

--- a/pandas/core/strings.py
+++ b/pandas/core/strings.py
@@ -141,7 +141,7 @@ def _length_check(others):
             elif len(x) != n:
                 raise ValueError('All arrays must be same length')
         except TypeError:
-            raise ValueError("Did you mean to supply a `sep` keyword?")
+            raise ValueError('Must pass arrays containing strings to str_cat')
     return n
 
 
@@ -2003,7 +2003,6 @@ class StringMethods(NoNewAttributesMixin):
                     # strings/NaN/None. Need to robustify check against
                     # x in nxt being list-like (otherwise ambiguous boolean).
                     is_legal = all((isinstance(x, compat.string_types)
-                                    or (is_list_like(x) and any(isnull(x)))
                                     or (not is_list_like(x) and isnull(x))
                                     or x is None)
                                    for x in nxt)
@@ -2184,10 +2183,10 @@ class StringMethods(NoNewAttributesMixin):
             # turn anything in "others" into lists of Series
             tmp = self._get_series_list(others, ignore_index=(join is None))
             others, fut_warn = tmp
-        except ValueError:  # let TypeError raised by _get_series_list pass
+        except ValueError:  # do not catch TypeError raised by _get_series_list
             if join is None:
-                # legacy warning
-                raise ValueError('All arrays must be same length')
+                raise ValueError('All arrays must be same length, except '
+                                 'those having an index if `join` is not None')
             else:
                 raise ValueError('If `others` contains arrays or lists (or '
                                  'other list-likes without an index), these '

--- a/pandas/core/strings.py
+++ b/pandas/core/strings.py
@@ -65,7 +65,7 @@ def _get_array_list(arr, others):
 
 def str_cat(arr, others=None, sep=None, na_rep=None):
     """
-    Concatenate strings in the Series/Index with given separator.
+    Auxiliary function for :meth:`str.cat`
 
     If `others` is specified, this function concatenates the Series/Index
     and elements of `others` element-wise.
@@ -84,42 +84,9 @@ def str_cat(arr, others=None, sep=None, na_rep=None):
 
     Returns
     -------
-    concat : Series/Index of objects or str
-
-    See Also
-    --------
-    split : Split each string in the Series/Index
-
-    Examples
-    --------
-    When not passing `other`, all values are concatenated into a single
-    string:
-
-    >>> s = pd.Series(['a', 'b', np.nan, 'c'])
-    >>> s.str.cat(sep=' ')
-    'a b c'
-
-    By default, NA values in the Series are ignored. Using `na_rep`, they
-    can be given a representation:
-
-    >>> pd.Series(['a', 'b', np.nan, 'c']).str.cat(sep=' ', na_rep='?')
-    'a b ? c'
-
-    If `others` is specified, corresponding values are
-    concatenated with the separator. Result will be a Series of strings.
-
-    >>> pd.Series(['a', 'b', 'c']).str.cat(['A', 'B', 'C'], sep=',')
-    0    a,A
-    1    b,B
-    2    c,C
-    dtype: object
-
-    Also, you can pass a list of list-likes.
-
-    >>> pd.Series(['a', 'b']).str.cat([['x', 'y'], ['1', '2']], sep=',')
-    0    a,x,1
-    1    b,y,2
-    dtype: object
+    concat
+        ndarray containing concatenated results (if `others is not None`)
+        or str (if `others is None`)
     """
     if sep is None:
         sep = ''
@@ -1833,7 +1800,8 @@ class StringMethods(NoNewAttributesMixin):
     def __init__(self, data):
         self._validate(data)
         self._is_categorical = is_categorical_dtype(data)
-        self._data = data.cat.categories if self._is_categorical else data
+        # .values.categories works for both Series/Index
+        self._data = data.values.categories if self._is_categorical else data
         # save orig to blow up categoricals to the right type
         self._orig = data
         self._freeze()
@@ -1859,7 +1827,11 @@ class StringMethods(NoNewAttributesMixin):
 
             # see src/inference.pyx which can contain string values
             allowed_types = ('string', 'unicode', 'mixed', 'mixed-integer')
-            if data.inferred_type not in allowed_types:
+            if is_categorical_dtype(data.dtype):
+                inf_type = data.categories.inferred_type
+            else:
+                inf_type = data.inferred_type
+            if inf_type not in allowed_types:
                 message = ("Can only use .str accessor with string values "
                            "(i.e. inferred_type is 'string', 'unicode' or "
                            "'mixed')")
@@ -1962,11 +1934,269 @@ class StringMethods(NoNewAttributesMixin):
                 cons = self._orig._constructor
                 return cons(result, name=name, index=index)
 
-    @copy(str_cat)
-    def cat(self, others=None, sep=None, na_rep=None):
-        data = self._orig if self._is_categorical else self._data
-        result = str_cat(data, others=others, sep=sep, na_rep=na_rep)
-        return self._wrap_result(result, use_codes=(not self._is_categorical))
+    def _str_cat_los(self, input, ignore_index=False):
+        """
+        Auxiliary function for :meth:`str.cat`. Turn potentially mixed input
+        into list of Series (elements without an index must match the length of
+        the calling Series/Index).
+
+        Parameters
+        ----------
+        input : Series, DataFrame, np.ndarrary, list-like or list-like of those
+        ignore_index : Boolean
+            Determines whether to forcefully align with index of the caller
+
+        Returns
+        -------
+        tuple : first element: input transformed into list of Series
+            second element: Boolean whether FutureWarning should be raised
+        """
+
+        # once str.cat defaults to alignment, this function can be simplified;
+        # will not need `ignore_index` and the second boolean output anymore
+
+        from pandas.core.index import Index
+        from pandas.core.series import Series
+        from pandas.core.frame import DataFrame
+
+        # self._orig is either Series or Index
+        idx = self._orig if isinstance(self._orig, Index) else self._orig.index
+
+        if isinstance(input, Series):
+            los = [Series(input.values, index=idx) if ignore_index else input]
+            return (los, True)
+        elif isinstance(input, Index):
+            los = [Series(input.values,
+                          index=(idx if ignore_index else input))]
+            return (los, True)
+        elif isinstance(input, DataFrame):
+            if ignore_index:
+                # without copy, this could change (the corresponding list
+                # element of) "others" that was passed to str.cat
+                input = input.copy()
+                input.index = idx
+            return ([input[x] for x in input], True)
+        elif isinstance(input, np.ndarray) and input.ndim == 2:
+            input = DataFrame(input, index=idx)
+            return ([input[x] for x in input], False)
+        elif is_list_like(input):
+            input = list(input)  # ensure iterators do not get read twice, etc.
+            if all(is_list_like(x) for x in input):
+                los = []
+                fuwa = False
+                while input:
+                    tmp = self._str_cat_los(input.pop(0),
+                                            ignore_index=ignore_index)
+                    los = los + tmp[0]
+                    fuwa = fuwa or tmp[1]
+                return (los, fuwa)
+            else:
+                return ([Series(input, index=idx)], False)
+        else:
+            raise ValueError('input must be Series, Index, DataFrame, '
+                             'np.ndarrary or list-like')
+
+    def cat(self, others=None, sep=None, na_rep=None, join=None):
+        """
+        Concatenate strings in the Series/Index with given separator.
+
+        If `others` is specified, this function concatenates the Series/Index
+        and elements of `others` element-wise.
+        If `others` is not passed, then all values in the Series/Index are
+        concatenated into a single string with a given `sep`.
+
+        Parameters
+        ----------
+        others : Series, Index, DataFrame, np.ndarrary or list-like
+            Series, Index, DataFrame, np.ndarray (one- or two-dimensional) and
+            other list-likes of strings must have the same length as the
+            calling Series/Index, with the exception of indexed objects (i.e.
+            Series/Index/DataFrame) if `join` is not None.
+
+            If others is a list-like that contains an arbitrary combination of
+            the above, then all elements will be unpacked and must satisfy the
+            above criteria individually.
+
+            If others is None, the method returns the concatenation of all
+            strings in the calling Series/Index.
+        sep : string or None, default None
+            If None, concatenates without any separator.
+        na_rep : string or None, default None
+            Representation that is inserted for all missing values:
+
+            - If `na_rep` is None, and `others` is None, missing values in the
+              Series/Index are omitted from the result.
+            - If `na_rep` is None, and `others` is not None, a row containing a
+              missing value in any of the columns (before concatenation) will
+              have a missing value in the result.
+        join : {'left', 'right', 'outer', 'inner'}, default None
+            Determines the join-style between the calling Series/Index and any
+            Series/Index/DataFrame in `others` (objects without an index need
+            to match the length of the calling Series/Index). If None,
+            alignment is disabled, but this option will be removed in a future
+            version of pandas and replaced with a default of `'left'`. To
+            disable alignment, use `.values` on any Series/Index/DataFrame in
+            `others`.
+
+            .. versionadded:: 0.23.0
+
+        Returns
+        -------
+        concat : str if `other is None`, Series/Index of objects if `others is
+            not None`. In the latter case, the result will remain categorical
+            if the calling Series/Index is categorical.
+
+        See Also
+        --------
+        split : Split each string in the Series/Index
+
+        Examples
+        --------
+        When not passing `others`, all values are concatenated into a single
+        string:
+
+        >>> s = pd.Series(['a', 'b', np.nan, 'd'])
+        >>> s.str.cat(sep=' ')
+        'a b d'
+
+        By default, NA values in the Series are ignored. Using `na_rep`, they
+        can be given a representation:
+
+        >>> s.str.cat(sep=' ', na_rep='?')
+        'a b ? d'
+
+        If `others` is specified, corresponding values are concatenated with
+        the separator. Result will be a Series of strings.
+
+        >>> s.str.cat(['A', 'B', 'C', 'D'], sep=',')
+        0    a,A
+        1    b,B
+        2    NaN
+        3    d,D
+        dtype: object
+
+        Missing values will remain missing in the result, but can again be
+        represented using `na_rep`
+
+        >>> s.str.cat(['A', 'B', 'C', 'D'], sep=',', na_rep='-')
+        0    a,A
+        1    b,B
+        2    -,C
+        3    d,D
+        dtype: object
+
+        If `sep` is not specified, the values are concatenated without
+        separation.
+
+        >>> s.str.cat(['A', 'B', 'C', 'D'], na_rep='-')
+        0    aA
+        1    bB
+        2    -C
+        3    dD
+        dtype: object
+
+        Series with different indexes can be aligned before concatenation. The
+        `join`-keyword works as in other methods.
+
+        >>> t = pd.Series(['d', 'a', 'e', 'c'], index=[3, 0, 4, 2])
+        >>> s.str.cat(t, join=None, na_rep='-')
+        0    ad
+        1    ba
+        2    -e
+        3    dc
+        dtype: object
+        >>>
+        >>> s.str.cat(t, join='left', na_rep='-')
+        0    aa
+        1    b-
+        2    -c
+        3    dd
+        dtype: object
+        >>>
+        >>> s.str.cat(t, join='outer', na_rep='-')
+        0    aa
+        1    b-
+        2    -c
+        3    dd
+        4    -e
+        dtype: object
+        >>>
+        >>> s.str.cat(t, join='inner', na_rep='-')
+        0    aa
+        2    -c
+        3    dd
+        dtype: object
+        >>>
+        >>> s.str.cat(t, join='right', na_rep='-')
+        3    dd
+        0    aa
+        4    -e
+        2    -c
+        dtype: object
+
+        For more examples, see :ref:`here <text.concatenate>`.
+        """
+        from pandas.core.index import Index
+        from pandas.core.series import Series
+        from pandas.core.reshape.concat import concat
+
+        if isinstance(others, str):
+            raise ValueError("Did you mean to supply a `sep` keyword?")
+
+        if isinstance(self._orig, Index):
+            data = Series(self._orig, index=self._orig)
+        else:  # Series
+            data = self._orig
+
+        # concatenate Series into itself if no "others"
+        if others is None:
+            result = str_cat(data, others=others, sep=sep, na_rep=na_rep)
+            return self._wrap_result(result,
+                                     use_codes=(not self._is_categorical))
+
+        try:
+            # turn anything in "others" into lists of Series
+            others, fuwa = self._str_cat_los(others,
+                                             ignore_index=(join is None))
+        except ValueError:
+            if join is None:
+                # legacy warning
+                raise ValueError('All arrays must be same length')
+            else:
+                raise ValueError('If `others` contains arrays or lists (or '
+                                 'other list-likes without an index), these '
+                                 'must all be of the same length as the '
+                                 'calling Series/Index.')
+
+        if join is None and fuwa:
+            warnings.warn("A future version of pandas will perform index "
+                          "alignment when `others` is a Series/Index/"
+                          "DataFrame (or a list-like containing one). To "
+                          "disable alignment (the behavior before v.0.23) and "
+                          "silence this warning, use `.values` on any Series/"
+                          "Index/DataFrame in `others`. To enable alignment "
+                          "and silence this warning, pass `join='left'|"
+                          "'outer'|'inner'|'right'`. The future default will "
+                          "be `join='left'`.", FutureWarning, stacklevel=2)
+
+        # align if required
+        if join is not None:
+            # Need to add keys for uniqueness in case of duplicate columns
+            others = concat(others, axis=1,
+                            join=(join if join == 'inner' else 'outer'),
+                            keys=range(len(others)))
+            data, others = data.align(others, join=join)
+            others = [others[x] for x in others]  # again list of Series
+
+        # str_cat discards index
+        res = str_cat(data, others=others, sep=sep, na_rep=na_rep)
+
+        dtype = 'category' if self._is_categorical else None
+        if isinstance(self._orig, Index):
+            res = Index(res, dtype=dtype)
+        else:  # Series
+            res = Series(res, index=data.index, dtype=dtype)
+        return res
 
     @copy(str_split)
     def split(self, pat=None, n=-1, expand=False):

--- a/pandas/tests/series/test_api.py
+++ b/pandas/tests/series/test_api.py
@@ -608,6 +608,7 @@ class TestCategoricalSeries(object):
 
         # str functions, which need special arguments
         special_func_defs = [
+            ('cat', (list("zyxw"),), {"sep": ","}),
             ('center', (10,), {}),
             ('contains', ("a",), {}),
             ('count', ("a",), {}),
@@ -643,12 +644,11 @@ class TestCategoricalSeries(object):
         ]
         _special_func_names = [f[0] for f in special_func_defs]
 
-        # * cat tested extensively with categorical data in test_strings.py
         # * get, join: they need a individual elements of type lists, but
         #   we can't make a categorical with lists as individual categories.
         #   -> `s.str.split(" ").astype("category")` will error!
         # * `translate` has different interfaces for py2 vs. py3
-        _ignore_names = ["cat", "get", "join", "translate"]
+        _ignore_names = ["get", "join", "translate"]
 
         str_func_names = [f for f in dir(s.str) if not (
             f.startswith("_") or

--- a/pandas/tests/series/test_api.py
+++ b/pandas/tests/series/test_api.py
@@ -608,7 +608,6 @@ class TestCategoricalSeries(object):
 
         # str functions, which need special arguments
         special_func_defs = [
-            ('cat', (list("zyxw"),), {"sep": ","}),
             ('center', (10,), {}),
             ('contains', ("a",), {}),
             ('count', ("a",), {}),
@@ -644,11 +643,12 @@ class TestCategoricalSeries(object):
         ]
         _special_func_names = [f[0] for f in special_func_defs]
 
+        # * cat tested extensively with categorical data in test_strings.py
         # * get, join: they need a individual elements of type lists, but
         #   we can't make a categorical with lists as individual categories.
         #   -> `s.str.split(" ").astype("category")` will error!
         # * `translate` has different interfaces for py2 vs. py3
-        _ignore_names = ["get", "join", "translate"]
+        _ignore_names = ["cat", "get", "join", "translate"]
 
         str_func_names = [f for f in dir(s.str) if not (
             f.startswith("_") or

--- a/pandas/tests/test_strings.py
+++ b/pandas/tests/test_strings.py
@@ -228,7 +228,7 @@ class TestStringMethods(object):
             s = Series(s)
         t = Index(['b', 'a', 'b', 'c'], dtype=dtype_target)
 
-        exp = Index(['ab', 'aa', 'bb', 'ac'], dtype=dtype_caller)
+        exp = Index(['ab', 'aa', 'bb', 'ac'])
         if series_or_index == 'series':
             exp = Series(exp)
 

--- a/pandas/tests/test_strings.py
+++ b/pandas/tests/test_strings.py
@@ -19,7 +19,7 @@ import pandas.util.testing as tm
 import pandas.core.strings as strings
 
 
-def assert_series_or_index_equal(left, right, expect_warn=False):
+def assert_series_or_index_equal(left, right):
     if isinstance(left, Series):
         assert_series_equal(left, right)
     else:  # Index

--- a/pandas/tests/test_strings.py
+++ b/pandas/tests/test_strings.py
@@ -351,22 +351,24 @@ class TestStringMethods(object):
 
         # errors for incorrect arguments in list-like
         rgx = 'others must be Series, Index, DataFrame,.*'
+        # make sure None/Nan also work as string-replacements
+        u = Series(['a', np.nan, 'c', None])
 
         # mix of string and Series
         with tm.assert_raises_regex(TypeError, rgx):
-            s.str.cat([s, 's'])
+            s.str.cat([u, 'u'])
 
         # DataFrame in list
         with tm.assert_raises_regex(TypeError, rgx):
-            s.str.cat([s, d])
+            s.str.cat([u, d])
 
         # 2-dim ndarray in list
         with tm.assert_raises_regex(TypeError, rgx):
-            s.str.cat([s, d.values])
+            s.str.cat([u, d.values])
 
         # nested lists
         with tm.assert_raises_regex(TypeError, rgx):
-            s.str.cat([s, [s, d]])
+            s.str.cat([u, [u, d]])
 
         # forbidden input type, e.g. int
         with tm.assert_raises_regex(TypeError, rgx):

--- a/pandas/tests/test_strings.py
+++ b/pandas/tests/test_strings.py
@@ -132,6 +132,18 @@ class TestStringMethods(object):
         exp = np.array(['aa', NA, 'bb', 'bd', 'cfoo', NA], dtype=np.object_)
         tm.assert_almost_equal(result, exp)
 
+        # error for incorrect lengths
+        rgx = 'All arrays must be same length'
+        three = Series(['1', '2', '3'])
+
+        with tm.assert_raises_regex(ValueError, rgx):
+            strings.str_cat(one, three)
+
+        # error for incorrect type
+        rgx = "Must pass arrays containing strings to str_cat"
+        with tm.assert_raises_regex(ValueError, rgx):
+            strings.str_cat(one, 'three')
+
     @pytest.mark.parametrize('series_or_index', ['series', 'index'])
     def test_str_cat(self, series_or_index):
         # test_cat above tests "str_cat" from ndarray to ndarray;
@@ -183,7 +195,7 @@ class TestStringMethods(object):
         assert_series_or_index_equal(s.str.cat(list(t), na_rep='-'), exp)
 
         # errors for incorrect lengths
-        rgx = 'All arrays must be same length'
+        rgx = 'All arrays must be same length, except.*'
         z = Series(['1', '2', '3'])
 
         with tm.assert_raises_regex(ValueError, rgx):
@@ -305,7 +317,7 @@ class TestStringMethods(object):
         assert_series_or_index_equal(s.str.cat(iter([t.values, list(s)])), exp)
 
         # errors for incorrect lengths
-        rgx = 'All arrays must be same length'
+        rgx = 'All arrays must be same length, except.*'
         z = Series(['1', '2', '3'])
         e = concat([z, z], axis=1)
 
@@ -331,7 +343,7 @@ class TestStringMethods(object):
 
         # errors for incorrect arguments in list-like
         rgx = 'others must be Series, Index, DataFrame,.*'
-        # make sure None/Nan also work as string-replacements
+        # make sure None/NaN do not crash checks in _get_series_list
         u = Series(['a', np.nan, 'c', None])
 
         # mix of string and Series

--- a/pandas/tests/test_strings.py
+++ b/pandas/tests/test_strings.py
@@ -11,12 +11,19 @@ from numpy.random import randint
 
 from pandas.compat import range, u
 import pandas.compat as compat
-from pandas import Index, Series, DataFrame, isna, MultiIndex, notna
+from pandas import Index, Series, DataFrame, isna, MultiIndex, notna, concat
 
-from pandas.util.testing import assert_series_equal
+from pandas.util.testing import assert_series_equal, assert_index_equal
 import pandas.util.testing as tm
 
 import pandas.core.strings as strings
+
+
+def assert_series_or_index_equal(left, right):
+    if isinstance(left, Series):
+        assert_series_equal(left, right)
+    else:
+        assert_index_equal(left, right)
 
 
 class TestStringMethods(object):
@@ -124,6 +131,263 @@ class TestStringMethods(object):
         result = strings.str_cat(one, two)
         exp = np.array(['aa', NA, 'bb', 'bd', 'cfoo', NA], dtype=np.object_)
         tm.assert_almost_equal(result, exp)
+
+    @pytest.mark.parametrize('ser_or_ind', ['series', 'index'])
+    def test_str_cat(self, ser_or_ind):
+        # test_cat above tests "str_cat" from ndarray to ndarray;
+        # here testing "str.cat" from Series/Index to Series/Index/ndarray/list
+        s = Index(['a', 'a', 'b', 'b', 'c', np.nan])
+        if ser_or_ind == 'series':
+            s = Series(s)
+        t = Index(['a', np.nan, 'b', 'd', 'foo', np.nan])
+
+        # single array
+        result = s.str.cat()
+        exp = 'aabbc'
+        assert result == exp
+
+        result = s.str.cat(na_rep='-')
+        exp = 'aabbc-'
+        assert result == exp
+
+        result = s.str.cat(sep='_', na_rep='NA')
+        exp = 'a_a_b_b_c_NA'
+        assert result == exp
+
+        # Series/Index with Index
+        exp = Index(['aa', 'a-', 'bb', 'bd', 'cfoo', '--'])
+        if ser_or_ind == 'series':
+            exp = Series(exp)
+        with tm.assert_produces_warning(expected_warning=FutureWarning):
+            # FutureWarning to switch to alignment by default
+            assert_series_or_index_equal(s.str.cat(t, na_rep='-'), exp)
+
+        # Series/Index with Series
+        t = Series(t)
+        with tm.assert_produces_warning(expected_warning=FutureWarning):
+            # FutureWarning to switch to alignment by default
+            assert_series_or_index_equal(s.str.cat(t, na_rep='-'), exp)
+
+        # Series/Index with array (no warning necessary)
+        assert_series_or_index_equal(s.str.cat(t.values, na_rep='-'), exp)
+
+        # Series/Index with list (no warning necessary)
+        assert_series_or_index_equal(s.str.cat(list(t), na_rep='-'), exp)
+
+        # errors for incorrect lengths
+        rgx = 'All arrays must be same length'
+        z = Series(['1', '2', '3'])
+
+        with tm.assert_raises_regex(ValueError, rgx):
+            s.str.cat(z)
+
+        with tm.assert_raises_regex(ValueError, rgx):
+            s.str.cat(z.values)
+
+        with tm.assert_raises_regex(ValueError, rgx):
+            s.str.cat(list(z))
+
+    @pytest.mark.parametrize('ser_or_ind', ['series', 'index'])
+    def test_str_cat_raises_intuitive_error(self, ser_or_ind):
+        # https://github.com/pandas-dev/pandas/issues/11334
+        s = Index(['a', 'b', 'c', 'd'])
+        if ser_or_ind == 'series':
+            s = Series(s)
+        message = "Did you mean to supply a `sep` keyword?"
+        with tm.assert_raises_regex(ValueError, message):
+            s.str.cat('|')
+        with tm.assert_raises_regex(ValueError, message):
+            s.str.cat('    ')
+
+    @pytest.mark.parametrize('ser_or_ind, dtype_caller, dtype_target', [
+        ('series', 'object', 'object'),
+        ('series', 'object', 'category'),
+        ('series', 'category', 'object'),
+        ('series', 'category', 'category'),
+        ('index', 'object', 'object'),
+        ('index', 'object', 'category'),
+        ('index', 'category', 'object'),
+        ('index', 'category', 'category')
+    ])
+    def test_str_cat_categorical(self, ser_or_ind, dtype_caller, dtype_target):
+        s = Index(['a', 'a', 'b', 'a'], dtype=dtype_caller)
+        if ser_or_ind == 'series':
+            s = Series(s)
+        t = Index(['b', 'a', 'b', 'c'], dtype=dtype_target)
+
+        exp = Index(['ab', 'aa', 'bb', 'ac'], dtype=dtype_caller)
+        if ser_or_ind == 'series':
+            exp = Series(exp)
+        # Series/Index with Index
+        with tm.assert_produces_warning(expected_warning=FutureWarning):
+            # FutureWarning to switch to alignment by default
+            assert_series_or_index_equal(s.str.cat(t), exp)
+
+        # Series/Index with Series
+        with tm.assert_produces_warning(expected_warning=FutureWarning):
+            # FutureWarning to switch to alignment by default
+            assert_series_or_index_equal(s.str.cat(Series(t)), exp)
+
+    @pytest.mark.parametrize('ser_or_ind', ['series', 'index'])
+    def test_str_cat_mixed_inputs(self, ser_or_ind):
+        s = Index(['a', 'b', 'c', 'd'])
+        if ser_or_ind == 'series':
+            s = Series(s)
+        t = Series(['A', 'B', 'C', 'D'])
+        d = concat([t, Series(s)], axis=1)
+
+        exp = Index(['aAa', 'bBb', 'cCc', 'dDd'])
+        if ser_or_ind == 'series':
+            exp = Series(exp)
+        # Series/Index with DataFrame
+        with tm.assert_produces_warning(expected_warning=FutureWarning):
+            # FutureWarning to switch to alignment by default
+            assert_series_or_index_equal(s.str.cat(d), exp)
+
+        # Series/Index with two-dimensional ndarray (no warning necessary)
+        assert_series_or_index_equal(s.str.cat(d.values), exp)
+
+        # Series/Index with list of Series
+        with tm.assert_produces_warning(expected_warning=FutureWarning):
+            # FutureWarning to switch to alignment by default
+            assert_series_or_index_equal(s.str.cat([t, s]), exp)
+
+        # Series/Index with list of list-likes (no warning necessary)
+        assert_series_or_index_equal(s.str.cat([t.values, list(s)]), exp)
+
+        # Series/Index with mixed list of Series/list-like
+        with tm.assert_produces_warning(expected_warning=FutureWarning):
+            # FutureWarning to switch to alignment by default
+            assert_series_or_index_equal(s.str.cat([t.values, s]), exp)
+
+        # Series/Index with iterator of list-likes (no warning necessary)
+        assert_series_or_index_equal(s.str.cat(iter([t.values, list(s)])), exp)
+
+        # errors for incorrect lengths
+        rgx = 'All arrays must be same length'
+        z = Series(['1', '2', '3'])
+        e = concat([z, z], axis=1)
+
+        # DataFrame
+        with tm.assert_raises_regex(ValueError, rgx):
+            s.str.cat(e)
+
+        # two-dimensional ndarray
+        with tm.assert_raises_regex(ValueError, rgx):
+            s.str.cat(e.values)
+
+        # list of Series
+        with tm.assert_raises_regex(ValueError, rgx):
+            s.str.cat([z, s])
+
+        # list of list-likes
+        with tm.assert_raises_regex(ValueError, rgx):
+            s.str.cat([z.values, list(s)])
+
+        # mixed list of Series/list-like
+        with tm.assert_raises_regex(ValueError, rgx):
+            s.str.cat([z, list(s)])
+
+    @pytest.mark.parametrize('ser_or_ind, join', [
+        ('series', 'left'), ('series', 'outer'),
+        ('series', 'inner'), ('series', 'right'),
+        ('index', 'left'), ('index', 'outer'),
+        ('index', 'inner'), ('index', 'right')
+    ])
+    def test_str_cat_align_indexed(self, ser_or_ind, join):
+        # https://github.com/pandas-dev/pandas/issues/18657
+        s = Series(['a', 'b', 'c', 'd'], index=['a', 'b', 'c', 'd'])
+        t = Series(['D', 'A', 'E', 'B'], index=['d', 'a', 'e', 'b'])
+        sa, ta = s.align(t, join=join)
+        if ser_or_ind == 'index':
+            s = Index(s)
+            sa = Index(sa)
+
+        with tm.assert_produces_warning(expected_warning=FutureWarning):
+            # result of mamnual alignmnent of inputs
+            exp = sa.str.cat(ta, na_rep='-')
+
+        assert_series_or_index_equal(s.str.cat(t, join=join, na_rep='-'), exp)
+
+    @pytest.mark.parametrize('join', ['left', 'outer', 'inner', 'right'])
+    def test_str_cat_align_mixed_inputs(self, join):
+        s = Series(['a', 'b', 'c', 'd'])
+        t = Series(['d', 'a', 'e', 'b'], index=[3, 0, 4, 1])
+        d = concat([t, t], axis=1)
+
+        exp_outer = Series(['aaa', 'bbb', 'c--', 'ddd', '-ee'])
+        sa, ta = s.align(t, join=join)
+        exp = exp_outer.loc[ta.index]
+
+        # list of Series
+        tm.assert_series_equal(s.str.cat([t, t], join=join, na_rep='-'), exp)
+
+        # DataFrame
+        tm.assert_series_equal(s.str.cat(d, join=join, na_rep='-'), exp)
+
+        # mixed list of indexed/unindexed
+        u = ['A', 'B', 'C', 'D']
+        exp_outer = Series(['aaA', 'bbB', 'c-C', 'ddD', '-e-'])
+        e = concat([t, s], axis=1, join=(join if join == 'inner' else 'outer'))
+        sa, ea = s.align(e, join=join)
+        exp = exp_outer.loc[ea.index]
+        tm.assert_series_equal(s.str.cat([t, u], join=join, na_rep='-'), exp)
+
+        # errors for incorrect lengths
+        rgx = 'If `others` contains arrays or lists.*'
+        z = ['1', '2', '3']
+
+        # unindexed object of wrong length
+        with tm.assert_raises_regex(ValueError, rgx):
+            s.str.cat(z, join=join)
+
+        # unindexed object of wrong length in list
+        with tm.assert_raises_regex(ValueError, rgx):
+            s.str.cat([t, z], join=join)
+
+    def test_str_cat_special_cases(self):
+        s = Series(['a', 'b', 'c', 'd'])
+        t = Series(['d', 'a', 'e', 'b'], index=[3, 0, 4, 1])
+        d = concat([t, t], axis=1)
+
+        # lists of elements with different types - unaligned
+        mix = [t, t.values, ['A', 'B', 'C', 'D'], d, d.values]
+        exp = Series(['addAdddd', 'baaBaaaa', 'ceeCeeee', 'dbbDbbbb'])
+        with tm.assert_produces_warning(expected_warning=FutureWarning):
+            tm.assert_series_equal(s.str.cat(mix, join=None), exp)
+
+        # lists of elements with different types - aligned with na_rep
+        exp = Series(['aadAaadd', 'bbaBbbaa', 'c-eC--ee', 'ddbDddbb'])
+        tm.assert_series_equal(s.str.cat(mix, join='left', na_rep='-'), exp)
+
+        # iterator of elements with different types
+        exp = Series(['aadAaadd', 'bbaBbbaa', 'c-eC--ee',
+                      'ddbDddbb', '-e--ee--'])
+        tm.assert_series_equal(s.str.cat(iter(mix), join='outer', na_rep='-'),
+                               exp)
+
+        # right-align with different indexes in other
+        exp = Series(['aa--', 'd-dd'], index=[0, 3])
+        tm.assert_series_equal(s.str.cat([t.loc[[0]], d.loc[[3]]],
+                                         join='right', na_rep='-'), exp)
+
+    def test_cat_on_filtered_index(self):
+        df = DataFrame(index=MultiIndex.from_product(
+            [[2011, 2012], [1, 2, 3]], names=['year', 'month']))
+
+        df = df.reset_index()
+        df = df[df.month > 1]
+
+        str_year = df.year.astype('str')
+        str_month = df.month.astype('str')
+        str_both = str_year.str.cat(str_month, sep=' ', join='left')
+
+        assert str_both.loc[1] == '2011 2'
+
+        str_multiple = str_year.str.cat([str_month, str_month],
+                                        sep=' ', join='left')
+
+        assert str_multiple.loc[1] == '2011 2 2'
 
     def test_count(self):
         values = np.array(['foo', 'foofoo', NA, 'foooofooofommmfoo'],
@@ -1263,7 +1527,7 @@ class TestStringMethods(object):
         # GH7241
         # (extract) on empty series
 
-        tm.assert_series_equal(empty_str, empty.str.cat(empty))
+        tm.assert_series_equal(empty_str, empty.str.cat(empty, join='left'))
         assert '' == empty.str.cat()
         tm.assert_series_equal(empty_str, empty.str.title())
         tm.assert_series_equal(empty_int, empty.str.count('a'))
@@ -2772,32 +3036,6 @@ class TestStringMethods(object):
         result = s.str.normalize('NFKC')
         tm.assert_index_equal(result, expected)
 
-    def test_cat_on_filtered_index(self):
-        df = DataFrame(index=MultiIndex.from_product(
-            [[2011, 2012], [1, 2, 3]], names=['year', 'month']))
-
-        df = df.reset_index()
-        df = df[df.month > 1]
-
-        str_year = df.year.astype('str')
-        str_month = df.month.astype('str')
-        str_both = str_year.str.cat(str_month, sep=' ')
-
-        assert str_both.loc[1] == '2011 2'
-
-        str_multiple = str_year.str.cat([str_month, str_month], sep=' ')
-
-        assert str_multiple.loc[1] == '2011 2 2'
-
-    def test_str_cat_raises_intuitive_error(self):
-        # https://github.com/pandas-dev/pandas/issues/11334
-        s = Series(['a', 'b', 'c', 'd'])
-        message = "Did you mean to supply a `sep` keyword?"
-        with tm.assert_raises_regex(ValueError, message):
-            s.str.cat('|')
-        with tm.assert_raises_regex(ValueError, message):
-            s.str.cat('    ')
-
     def test_index_str_accessor_visibility(self):
         from pandas.core.strings import StringMethods
 
@@ -2857,9 +3095,9 @@ class TestStringMethods(object):
         lhs = Series(np.array(list('abc'), 'S1').astype(object))
         rhs = Series(np.array(list('def'), 'S1').astype(object))
         if compat.PY3:
-            pytest.raises(TypeError, lhs.str.cat, rhs)
+            pytest.raises(TypeError, lhs.str.cat, rhs, join='left')
         else:
-            result = lhs.str.cat(rhs)
+            result = lhs.str.cat(rhs, join='left')
             expected = Series(np.array(
                 ['ad', 'be', 'cf'], 'S2').astype(object))
             tm.assert_series_equal(result, expected)

--- a/pandas/tests/test_strings.py
+++ b/pandas/tests/test_strings.py
@@ -166,13 +166,9 @@ class TestStringMethods(object):
         # Series/Index with Series
         t = Series(t)
         # s as Series has same index as t -> no warning
-        # s as Index is different from t.index -> warning
+        # s as Index is different from t.index -> warning (tested below)
         if series_or_index == 'series':
             assert_series_equal(s.str.cat(t, na_rep='-'), exp)
-        else:
-            with tm.assert_produces_warning(expected_warning=FutureWarning):
-                # FutureWarning to switch to alignment by default
-                assert_series_or_index_equal(s.str.cat(t, na_rep='-'), exp)
 
         # Series/Index with Series: warning if different indexes
         t.index = t.index + 1
@@ -241,13 +237,9 @@ class TestStringMethods(object):
         # Series/Index with Series
         t = Series(t)
         # s as Series has same index as t -> no warning
-        # s as Index is different from t.index -> warning
+        # s as Index is different from t.index -> warning (tested below)
         if series_or_index == 'series':
             assert_series_equal(s.str.cat(t), exp)
-        else:
-            with tm.assert_produces_warning(expected_warning=FutureWarning):
-                # FutureWarning to switch to alignment by default
-                assert_series_or_index_equal(s.str.cat(t), exp)
 
         # Series/Index with Series: warning if different indexes
         t.index = t.index + 1
@@ -269,13 +261,9 @@ class TestStringMethods(object):
 
         # Series/Index with DataFrame
         # s as Series has same index as d -> no warning
-        # s as Index is different from d.index -> warning
+        # s as Index is different from d.index -> warning (tested below)
         if series_or_index == 'series':
             assert_series_equal(s.str.cat(d), exp)
-        else:
-            with tm.assert_produces_warning(expected_warning=FutureWarning):
-                # FutureWarning to switch to alignment by default
-                assert_series_or_index_equal(s.str.cat(d), exp)
 
         # Series/Index with DataFrame: warning if different indexes
         d.index = d.index + 1
@@ -288,13 +276,9 @@ class TestStringMethods(object):
 
         # Series/Index with list of Series
         # s as Series has same index as t, s -> no warning
-        # s as Index is different from t.index -> warning
+        # s as Index is different from t.index -> warning (tested below)
         if series_or_index == 'series':
             assert_series_equal(s.str.cat([t, s]), exp)
-        else:
-            with tm.assert_produces_warning(expected_warning=FutureWarning):
-                # FutureWarning to switch to alignment by default
-                assert_series_or_index_equal(s.str.cat([t, s]), exp)
 
         # Series/Index with list of Series: warning if different indexes
         tt = t.copy()
@@ -308,13 +292,9 @@ class TestStringMethods(object):
 
         # Series/Index with mixed list of Series/list-like
         # s as Series has same index as t -> no warning
-        # s as Index is different from t.index -> warning
+        # s as Index is different from t.index -> warning (tested below)
         if series_or_index == 'series':
             assert_series_equal(s.str.cat([t, s.values]), exp)
-        else:
-            with tm.assert_produces_warning(expected_warning=FutureWarning):
-                # FutureWarning to switch to alignment by default
-                assert_series_or_index_equal(s.str.cat([t, s.values]), exp)
 
         # Series/Index with mixed list: warning if different indexes
         with tm.assert_produces_warning(expected_warning=FutureWarning):

--- a/pandas/tests/test_strings.py
+++ b/pandas/tests/test_strings.py
@@ -132,12 +132,12 @@ class TestStringMethods(object):
         exp = np.array(['aa', NA, 'bb', 'bd', 'cfoo', NA], dtype=np.object_)
         tm.assert_almost_equal(result, exp)
 
-    @pytest.mark.parametrize('ser_or_ind', ['series', 'index'])
-    def test_str_cat(self, ser_or_ind):
+    @pytest.mark.parametrize('series_or_index', ['series', 'index'])
+    def test_str_cat(self, series_or_index):
         # test_cat above tests "str_cat" from ndarray to ndarray;
         # here testing "str.cat" from Series/Index to Series/Index/ndarray/list
         s = Index(['a', 'a', 'b', 'b', 'c', np.nan])
-        if ser_or_ind == 'series':
+        if series_or_index == 'series':
             s = Series(s)
         t = Index(['a', np.nan, 'b', 'd', 'foo', np.nan])
 
@@ -156,7 +156,7 @@ class TestStringMethods(object):
 
         # Series/Index with Index
         exp = Index(['aa', 'a-', 'bb', 'bd', 'cfoo', '--'])
-        if ser_or_ind == 'series':
+        if series_or_index == 'series':
             exp = Series(exp)
         with tm.assert_produces_warning(expected_warning=FutureWarning):
             # FutureWarning to switch to alignment by default
@@ -187,11 +187,11 @@ class TestStringMethods(object):
         with tm.assert_raises_regex(ValueError, rgx):
             s.str.cat(list(z))
 
-    @pytest.mark.parametrize('ser_or_ind', ['series', 'index'])
-    def test_str_cat_raises_intuitive_error(self, ser_or_ind):
+    @pytest.mark.parametrize('series_or_index', ['series', 'index'])
+    def test_str_cat_raises_intuitive_error(self, series_or_index):
         # https://github.com/pandas-dev/pandas/issues/11334
         s = Index(['a', 'b', 'c', 'd'])
-        if ser_or_ind == 'series':
+        if series_or_index == 'series':
             s = Series(s)
         message = "Did you mean to supply a `sep` keyword?"
         with tm.assert_raises_regex(ValueError, message):
@@ -199,7 +199,7 @@ class TestStringMethods(object):
         with tm.assert_raises_regex(ValueError, message):
             s.str.cat('    ')
 
-    @pytest.mark.parametrize('ser_or_ind, dtype_caller, dtype_target', [
+    @pytest.mark.parametrize('series_or_index, dtype_caller, dtype_target', [
         ('series', 'object', 'object'),
         ('series', 'object', 'category'),
         ('series', 'category', 'object'),
@@ -209,14 +209,15 @@ class TestStringMethods(object):
         ('index', 'category', 'object'),
         ('index', 'category', 'category')
     ])
-    def test_str_cat_categorical(self, ser_or_ind, dtype_caller, dtype_target):
+    def test_str_cat_categorical(self, series_or_index,
+                                 dtype_caller, dtype_target):
         s = Index(['a', 'a', 'b', 'a'], dtype=dtype_caller)
-        if ser_or_ind == 'series':
+        if series_or_index == 'series':
             s = Series(s)
         t = Index(['b', 'a', 'b', 'c'], dtype=dtype_target)
 
         exp = Index(['ab', 'aa', 'bb', 'ac'], dtype=dtype_caller)
-        if ser_or_ind == 'series':
+        if series_or_index == 'series':
             exp = Series(exp)
         # Series/Index with Index
         with tm.assert_produces_warning(expected_warning=FutureWarning):
@@ -228,16 +229,16 @@ class TestStringMethods(object):
             # FutureWarning to switch to alignment by default
             assert_series_or_index_equal(s.str.cat(Series(t)), exp)
 
-    @pytest.mark.parametrize('ser_or_ind', ['series', 'index'])
-    def test_str_cat_mixed_inputs(self, ser_or_ind):
+    @pytest.mark.parametrize('series_or_index', ['series', 'index'])
+    def test_str_cat_mixed_inputs(self, series_or_index):
         s = Index(['a', 'b', 'c', 'd'])
-        if ser_or_ind == 'series':
+        if series_or_index == 'series':
             s = Series(s)
         t = Series(['A', 'B', 'C', 'D'])
         d = concat([t, Series(s)], axis=1)
 
         exp = Index(['aAa', 'bBb', 'cCc', 'dDd'])
-        if ser_or_ind == 'series':
+        if series_or_index == 'series':
             exp = Series(exp)
         # Series/Index with DataFrame
         with tm.assert_produces_warning(expected_warning=FutureWarning):
@@ -288,18 +289,18 @@ class TestStringMethods(object):
         with tm.assert_raises_regex(ValueError, rgx):
             s.str.cat([z, list(s)])
 
-    @pytest.mark.parametrize('ser_or_ind, join', [
+    @pytest.mark.parametrize('series_or_index, join', [
         ('series', 'left'), ('series', 'outer'),
         ('series', 'inner'), ('series', 'right'),
         ('index', 'left'), ('index', 'outer'),
         ('index', 'inner'), ('index', 'right')
     ])
-    def test_str_cat_align_indexed(self, ser_or_ind, join):
+    def test_str_cat_align_indexed(self, series_or_index, join):
         # https://github.com/pandas-dev/pandas/issues/18657
         s = Series(['a', 'b', 'c', 'd'], index=['a', 'b', 'c', 'd'])
         t = Series(['D', 'A', 'E', 'B'], index=['d', 'a', 'e', 'b'])
         sa, ta = s.align(t, join=join)
-        if ser_or_ind == 'index':
+        if series_or_index == 'index':
             s = Index(s)
             sa = Index(sa)
 


### PR DESCRIPTION
Fixes issue #18657, fixed existing tests, added new test; all pass.

After I pushed everything and thought about it some more, I realised that one may argue about the default alignment-behavior, and whether it should be changed to `join=outer`. The behavior as implemented is compatible with the current requirement that everything be of the same length. To me, it is more intuitive that the concatenated `other` is added to the current series without enlarging it, but I can also see the argument why that restriction is unnecessary.

PS. This is my first PR, tried to follow all the rules. Sorry if I overlooked something.

Edit: Also fixes #20842 