### PR TITLE
DOC: remove incorrect example from __add__ et al docstring

### DIFF
--- a/pandas/core/ops.py
+++ b/pandas/core/ops.py
@@ -516,33 +516,6 @@ Mismatched indices will be unioned together
 Returns
 -------
 result : DataFrame
-
-Examples
---------
->>> a = pd.DataFrame([1, 1, 1, np.nan], index=['a', 'b', 'c', 'd'],
-                     columns=['one'])
->>> a
-   one
-a  1.0
-b  1.0
-c  1.0
-d  NaN
->>> b = pd.DataFrame(dict(one=[1, np.nan, 1, np.nan],
-                          two=[np.nan, 2, np.nan, 2]),
-                     index=['a', 'b', 'd', 'e'])
->>> b
-   one  two
-a  1.0  NaN
-b  NaN  2.0
-d  1.0  NaN
-e  NaN  2.0
->>> a.add(b, fill_value=0)
-   one  two
-a  2.0  NaN
-b  1.0  2.0
-c  1.0  NaN
-d  1.0  NaN
-e  NaN  2.0
 """
 
 _flex_doc_FRAME = """


### PR DESCRIPTION
Notices while reviewing the doc PRs. We add a similar example to the `__add__` and similar docstrings (based on ``_arith_doc_FRAME`` template) than to `add` (which use the `_flex_doc_FRAME` template), so the example is incorrect, and also not needed for that docstring I think (nobody should directly use `__add__`?) 
So remove it to have less code to maintain.


