### PR TITLE
TST: Remove invalid dtype test

### DIFF
--- a/pandas/tests/extension/base/interface.py
+++ b/pandas/tests/extension/base/interface.py
@@ -32,9 +32,6 @@ class BaseInterfaceTests(BaseExtensionTests):
         result = np.array(data)
         assert result[0] == data[0]
 
-    def test_as_ndarray_with_dtype_kind(self, data):
-        np.array(data, dtype=data.dtype.kind)
-
     def test_repr(self, data):
         ser = pd.Series(data)
         assert data.dtype.name in repr(ser)


### PR DESCRIPTION
This test was not valid. Not every dtype kind is a valid dtype.
For example, the dtype may be 'uint64', but the kind is 'u'.