### PR TITLE
DOC: update the pandas.core.resample.Resampler.fillna docstring

### DIFF
--- a/pandas/core/resample.py
+++ b/pandas/core/resample.py
@@ -624,18 +624,134 @@ one pass, you can do
 
     def fillna(self, method, limit=None):
         """
-        Fill missing values
+        Fill the new missing values in the resampled data using different
+        methods.
+
+        In statistics, imputation is the process of replacing missing data with
+        substituted values [1]_. When resampling data, missing values may
+        appear (e.g., when the resampling frequency is higher than the original
+        frequency).
+
+        The backward fill ('bfill') will replace NaN values that appeared in
+        the resampled data with the next value in the original sequence. The
+        forward fill ('ffill'), on the other hand, will replace NaN values
+        that appeared in the resampled data with the previous value in the
+        original sequence. Missing values that existed in the orginal data will
+        not be modified.
 
         Parameters
         ----------
         method : str, method of resampling ('ffill', 'bfill')
+            Method to use for filling holes in resampled data
+                * ffill: use previous valid observation to fill gap (forward
+                  fill).
+                * bfill: use next valid observation to fill gap (backward
+                  fill).
         limit : integer, optional
-            limit of how many values to fill
+            Limit of how many values to fill.
+
+        Returns
+        -------
+        Series, DataFrame
+            An upsampled Series or DataFrame with backward or forwards filled
+            NaN values.
+
+        Examples
+        --------
+
+        Resampling a Series:
+
+        >>> s = pd.Series([1, 2, 3],
+        ...               index=pd.date_range('20180101', periods=3, freq='h'))
+        >>> s
+        2018-01-01 00:00:00    1
+        2018-01-01 01:00:00    2
+        2018-01-01 02:00:00    3
+        Freq: H, dtype: int64
+
+        >>> s.resample('30min').fillna("bfill")
+        2018-01-01 00:00:00    1
+        2018-01-01 00:30:00    2
+        2018-01-01 01:00:00    2
+        2018-01-01 01:30:00    3
+        2018-01-01 02:00:00    3
+        Freq: 30T, dtype: int64
+
+        >>> s.resample('15min').fillna("bfill", limit=2)
+        2018-01-01 00:00:00    1.0
+        2018-01-01 00:15:00    NaN
+        2018-01-01 00:30:00    2.0
+        2018-01-01 00:45:00    2.0
+        2018-01-01 01:00:00    2.0
+        2018-01-01 01:15:00    NaN
+        2018-01-01 01:30:00    3.0
+        2018-01-01 01:45:00    3.0
+        2018-01-01 02:00:00    3.0
+        Freq: 15T, dtype: float64
+
+        >>> s.resample('30min').fillna("ffill")
+        2018-01-01 00:00:00    1
+        2018-01-01 00:30:00    1
+        2018-01-01 01:00:00    2
+        2018-01-01 01:30:00    2
+        2018-01-01 02:00:00    3
+        Freq: 30T, dtype: int64
+
+        Resampling a DataFrame that has missing values:
+
+        >>> df = pd.DataFrame({'a': [2, np.nan, 6], 'b': [1, 3, 5]},
+        ...                   index=pd.date_range('20180101', periods=3,
+        ...                                       freq='h'))
+        >>> df
+                               a  b
+        2018-01-01 00:00:00  2.0  1
+        2018-01-01 01:00:00  NaN  3
+        2018-01-01 02:00:00  6.0  5
+
+        >>> df.resample('30min').fillna("bfill")
+                               a  b
+        2018-01-01 00:00:00  2.0  1
+        2018-01-01 00:30:00  NaN  3
+        2018-01-01 01:00:00  NaN  3
+        2018-01-01 01:30:00  6.0  5
+        2018-01-01 02:00:00  6.0  5
+
+        >>> df.resample('15min').fillna("bfill", limit=2)
+                               a    b
+        2018-01-01 00:00:00  2.0  1.0
+        2018-01-01 00:15:00  NaN  NaN
+        2018-01-01 00:30:00  NaN  3.0
+        2018-01-01 00:45:00  NaN  3.0
+        2018-01-01 01:00:00  NaN  3.0
+        2018-01-01 01:15:00  NaN  NaN
+        2018-01-01 01:30:00  6.0  5.0
+        2018-01-01 01:45:00  6.0  5.0
+        2018-01-01 02:00:00  6.0  5.0
+
+        >>> df.resample('30min').fillna("ffill")
+                              a	b
+        2018-01-01 00:00:00	2.0	1
+        2018-01-01 00:30:00	2.0	1
+        2018-01-01 01:00:00	NaN	3
+        2018-01-01 01:30:00	NaN	3
+        2018-01-01 02:00:00	6.0	5
 
         See Also
         --------
-        Series.fillna
-        DataFrame.fillna
+        backfill : Backward fill NaN values in the resampled data.
+        pad : Forward fill NaN values in the resampled data.
+        bfill : Alias of backfill.
+        ffill: Alias of pad.
+        nearest : Fill NaN values in the resampled data
+            with nearest neighbor starting from center.
+        pandas.Series.fillna : Fill NaN values in the Series using the
+            specified method, which can be 'bfill' and 'ffill'.
+        pandas.DataFrame.fillna : Fill NaN values in the DataFrame using the
+            specified method, which can be 'bfill' and 'ffill'.
+
+        References
+        ----------
+        .. [1] https://en.wikipedia.org/wiki/Imputation_(statistics)
         """
         return self._upsample(method, limit=limit)
 

--- a/pandas/core/resample.py
+++ b/pandas/core/resample.py
@@ -639,24 +639,32 @@ one pass, you can do
         method : {'pad', 'backfill', 'ffill', 'bfill', 'nearest'}
             Method to use for filling holes in resampled data
 
-            * 'pad': use previous valid observation to fill gap (forward
-              fill).
-            * 'backfill': use next valid observation to fill gap.
+            * 'pad' or 'ffill': use previous valid observation to fill gap
+              (forward fill).
+            * 'backfill' or 'bfill': use next valid observation to fill gap.
             * 'nearest': use nearest valid observation to fill gap.
-            * 'ffill': same as 'pad'.
-            * 'bfill': same as 'backfill'.
+
         limit : integer, optional
-            Limit of how many consecutive values to fill.
+            Limit of how many consecutive missing values to fill.
 
         Returns
         -------
         Series or DataFrame
-            An upsampled Series or DataFrame with backward or forwards filled
-            NaN values.
+            An upsampled Series or DataFrame with missing values filled.
+
+        See Also
+        --------
+        backfill : Backward fill NaN values in the resampled data.
+        pad : Forward fill NaN values in the resampled data.
+        nearest : Fill NaN values in the resampled data
+            with nearest neighbor starting from center.
+        pandas.Series.fillna : Fill NaN values in the Series using the
+            specified method, which can be 'bfill' and 'ffill'.
+        pandas.DataFrame.fillna : Fill NaN values in the DataFrame using the
+            specified method, which can be 'bfill' and 'ffill'.
 
         Examples
         --------
-
         Resampling a Series:
 
         >>> s = pd.Series([1, 2, 3],
@@ -713,7 +721,7 @@ one pass, you can do
         2018-01-01 02:00:00    3
         Freq: 30T, dtype: int64
 
-        Resamping a Series that has missing values:
+        Missing values present before the upsampling are not affected.
 
         >>> sm = pd.Series([1, None, 3],
         ...               index=pd.date_range('20180101', periods=3, freq='h'))
@@ -747,8 +755,8 @@ one pass, you can do
         2018-01-01 02:00:00    3.0
         Freq: 30T, dtype: float64
 
-        Resampling a DataFrame that has missing values works similar as for
-        Series column-by-column:
+        DataFrame resampling is done column-wise. All the same options are
+        available.
 
         >>> df = pd.DataFrame({'a': [2, np.nan, 6], 'b': [1, 3, 5]},
         ...                   index=pd.date_range('20180101', periods=3,
@@ -766,29 +774,6 @@ one pass, you can do
         2018-01-01 01:00:00  NaN  3
         2018-01-01 01:30:00  6.0  5
         2018-01-01 02:00:00  6.0  5
-
-        >>> df.resample('15min').fillna("bfill", limit=2)
-                               a    b
-        2018-01-01 00:00:00  2.0  1.0
-        2018-01-01 00:15:00  NaN  NaN
-        2018-01-01 00:30:00  NaN  3.0
-        2018-01-01 00:45:00  NaN  3.0
-        2018-01-01 01:00:00  NaN  3.0
-        2018-01-01 01:15:00  NaN  NaN
-        2018-01-01 01:30:00  6.0  5.0
-        2018-01-01 01:45:00  6.0  5.0
-        2018-01-01 02:00:00  6.0  5.0
-
-        See Also
-        --------
-        backfill : Backward fill NaN values in the resampled data.
-        pad : Forward fill NaN values in the resampled data.
-        nearest : Fill NaN values in the resampled data
-            with nearest neighbor starting from center.
-        pandas.Series.fillna : Fill NaN values in the Series using the
-            specified method, which can be 'bfill' and 'ffill'.
-        pandas.DataFrame.fillna : Fill NaN values in the DataFrame using the
-            specified method, which can be 'bfill' and 'ffill'.
 
         References
         ----------


### PR DESCRIPTION
- [x] PR title is "DOC: update the pandas.core.resample.Resampler.fillna docstring"
- [x] The validation script passes: `scripts/validate_docstrings.py pandas.core.resample.Resampler.fillna`
- [x] The PEP8 style check passes: `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] The html version looks good: `python doc/make.py --single pandas.core.resample.Resampler.fillna`
- [x] It has been proofread on language by another sprint participant

Please include the output of the validation script below between the "```" ticks:

```

################################################################################
############## Docstring (pandas.core.resample.Resampler.fillna)  ##############
################################################################################

Fill the new missing values in the resampled data using different
methods.

In statistics, imputation is the process of replacing missing data with
substituted values [1]_. When resampling data, missing values may
appear (e.g., when the resampling frequency is higher than the original
frequency).

The backward fill ('bfill') will replace NaN values that appeared in
the resampled data with the next value in the original sequence. The
forward fill ('ffill'), on the other hand, will replace NaN values
that appeared in the resampled data with the previous value in the
original sequence. Missing values that existed in the orginal data will
not be modified.

Parameters
----------
method : str, method of resampling ('ffill', 'bfill')
    Method to use for filling holes in resampled data
        * ffill: use previous valid observation to fill gap (forward
          fill).
        * bfill: use next valid observation to fill gap (backward
          fill).
limit : integer, optional
    Limit of how many values to fill.

Returns
-------
Series, DataFrame
    An upsampled Series or DataFrame with backward or forwards filled
    NaN values.

Examples
--------

Resampling a Series:

>>> s = pd.Series([1, 2, 3],
...               index=pd.date_range('20180101', periods=3, freq='h'))
>>> s
2018-01-01 00:00:00    1
2018-01-01 01:00:00    2
2018-01-01 02:00:00    3
Freq: H, dtype: int64

>>> s.resample('30min').fillna("bfill")
2018-01-01 00:00:00    1
2018-01-01 00:30:00    2
2018-01-01 01:00:00    2
2018-01-01 01:30:00    3
2018-01-01 02:00:00    3
Freq: 30T, dtype: int64

>>> s.resample('15min').fillna("bfill", limit=2)
2018-01-01 00:00:00    1.0
2018-01-01 00:15:00    NaN
2018-01-01 00:30:00    2.0
2018-01-01 00:45:00    2.0
2018-01-01 01:00:00    2.0
2018-01-01 01:15:00    NaN
2018-01-01 01:30:00    3.0
2018-01-01 01:45:00    3.0
2018-01-01 02:00:00    3.0
Freq: 15T, dtype: float64

>>> s.resample('30min').fillna("ffill")
2018-01-01 00:00:00    1
2018-01-01 00:30:00    1
2018-01-01 01:00:00    2
2018-01-01 01:30:00    2
2018-01-01 02:00:00    3
Freq: 30T, dtype: int64

Resampling a DataFrame that has missing values:

>>> df = pd.DataFrame({'a': [2, np.nan, 6], 'b': [1, 3, 5]},
...                   index=pd.date_range('20180101', periods=3,
...                                       freq='h'))
>>> df
                       a  b
2018-01-01 00:00:00  2.0  1
2018-01-01 01:00:00  NaN  3
2018-01-01 02:00:00  6.0  5

>>> df.resample('30min').fillna("bfill")
                       a  b
2018-01-01 00:00:00  2.0  1
2018-01-01 00:30:00  NaN  3
2018-01-01 01:00:00  NaN  3
2018-01-01 01:30:00  6.0  5
2018-01-01 02:00:00  6.0  5

>>> df.resample('15min').fillna("bfill", limit=2)
                       a    b
2018-01-01 00:00:00  2.0  1.0
2018-01-01 00:15:00  NaN  NaN
2018-01-01 00:30:00  NaN  3.0
2018-01-01 00:45:00  NaN  3.0
2018-01-01 01:00:00  NaN  3.0
2018-01-01 01:15:00  NaN  NaN
2018-01-01 01:30:00  6.0  5.0
2018-01-01 01:45:00  6.0  5.0
2018-01-01 02:00:00  6.0  5.0

>>> df.resample('30min').fillna("ffill")
                      a b
2018-01-01 00:00:00     2.0     1
2018-01-01 00:30:00     2.0     1
2018-01-01 01:00:00     NaN     3
2018-01-01 01:30:00     NaN     3
2018-01-01 02:00:00     6.0     5

See Also
--------
backfill : Backward fill NaN values in the resampled data.
pad : Forward fill NaN values in the resampled data.
bfill : Alias of backfill.
ffill: Alias of pad.
nearest : Fill NaN values in the resampled data
    with nearest neighbor starting from center.
pandas.Series.fillna : Fill NaN values in the Series using the
    specified method, which can be 'bfill' and 'ffill'.
pandas.DataFrame.fillna : Fill NaN values in the DataFrame using the
    specified method, which can be 'bfill' and 'ffill'.

References
----------
.. [1] https://en.wikipedia.org/wiki/Imputation_(statistics)

################################################################################
################################## Validation ##################################
################################################################################

Docstring for "pandas.core.resample.Resampler.fillna" correct. :)
```