### PR TITLE
EHN: allow zip compression in `to_pickle`, `to_json`, `to_csv`

### DIFF
--- a/doc/source/whatsnew/v0.23.0.txt
+++ b/doc/source/whatsnew/v0.23.0.txt
@@ -344,6 +344,7 @@ Other Enhancements
 - :meth:`DataFrame.to_sql` now performs a multivalue insert if the underlying connection supports itk rather than inserting row by row.
   ``SQLAlchemy`` dialects supporting multivalue inserts include: ``mysql``, ``postgresql``, ``sqlite`` and any dialect with ``supports_multivalues_insert``. (:issue:`14315`, :issue:`8953`)
 - :func:`read_html` now accepts a ``displayed_only`` keyword argument to controls whether or not hidden elements are parsed (``True`` by default) (:issue:`20027`)
+- zip compression is supported via ``compression=zip`` in :func:`DataFrame.to_pickle`, :func:`Series.to_pickle`, :func:`DataFrame.to_csv`, :func:`Series.to_csv`, :func:`DataFrame.to_json`, :func:`Series.to_json`. (:issue:`17778`)
 
 .. _whatsnew_0230.api_breaking:
 

--- a/doc/source/whatsnew/v0.23.0.txt
+++ b/doc/source/whatsnew/v0.23.0.txt
@@ -344,7 +344,7 @@ Other Enhancements
 - :meth:`DataFrame.to_sql` now performs a multivalue insert if the underlying connection supports itk rather than inserting row by row.
   ``SQLAlchemy`` dialects supporting multivalue inserts include: ``mysql``, ``postgresql``, ``sqlite`` and any dialect with ``supports_multivalues_insert``. (:issue:`14315`, :issue:`8953`)
 - :func:`read_html` now accepts a ``displayed_only`` keyword argument to controls whether or not hidden elements are parsed (``True`` by default) (:issue:`20027`)
-- zip compression is supported via ``compression=zip`` for python >= 3 in :func:`DataFrame.to_pickle`, :func:`Series.to_pickle`, :func:`DataFrame.to_csv`, :func:`Series.to_csv`, :func:`DataFrame.to_json`, :func:`Series.to_json`. (:issue:`17778`)
+- zip compression is supported via ``compression=zip`` in :func:`DataFrame.to_pickle`, :func:`Series.to_pickle`, :func:`DataFrame.to_csv`, :func:`Series.to_csv`, :func:`DataFrame.to_json`, :func:`Series.to_json`. (:issue:`17778`)
 
 .. _whatsnew_0230.api_breaking:
 

--- a/doc/source/whatsnew/v0.23.0.txt
+++ b/doc/source/whatsnew/v0.23.0.txt
@@ -344,7 +344,7 @@ Other Enhancements
 - :meth:`DataFrame.to_sql` now performs a multivalue insert if the underlying connection supports itk rather than inserting row by row.
   ``SQLAlchemy`` dialects supporting multivalue inserts include: ``mysql``, ``postgresql``, ``sqlite`` and any dialect with ``supports_multivalues_insert``. (:issue:`14315`, :issue:`8953`)
 - :func:`read_html` now accepts a ``displayed_only`` keyword argument to controls whether or not hidden elements are parsed (``True`` by default) (:issue:`20027`)
-- zip compression is supported via ``compression=zip`` in :func:`DataFrame.to_pickle`, :func:`Series.to_pickle`, :func:`DataFrame.to_csv`, :func:`Series.to_csv`, :func:`DataFrame.to_json`, :func:`Series.to_json`. (:issue:`17778`)
+- zip compression is supported via ``compression=zip`` for python >= 3 in :func:`DataFrame.to_pickle`, :func:`Series.to_pickle`, :func:`DataFrame.to_csv`, :func:`Series.to_csv`, :func:`DataFrame.to_json`, :func:`Series.to_json`. (:issue:`17778`)
 
 .. _whatsnew_0230.api_breaking:
 

--- a/pandas/conftest.py
+++ b/pandas/conftest.py
@@ -75,16 +75,6 @@ def compression(request):
     return request.param
 
 
-@pytest.fixture(params=[None, 'gzip', 'bz2',
-                        pytest.param('xz', marks=td.skip_if_no_lzma)])
-def compression_no_zip(request):
-    """
-    Fixture for trying common compression types in compression tests
-    except zip
-    """
-    return request.param
-
-
 @pytest.fixture(scope='module')
 def datetime_tz_utc():
     from datetime import timezone

--- a/pandas/conftest.py
+++ b/pandas/conftest.py
@@ -3,7 +3,7 @@ import pytest
 import numpy
 import pandas
 import pandas.util._test_decorators as td
-from compat import PY2
+from pandas.compat import PY2
 
 
 def pytest_addoption(parser):

--- a/pandas/conftest.py
+++ b/pandas/conftest.py
@@ -3,6 +3,7 @@ import pytest
 import numpy
 import pandas
 import pandas.util._test_decorators as td
+from compat import PY2
 
 
 def pytest_addoption(parser):
@@ -66,7 +67,11 @@ def ip():
     return InteractiveShell()
 
 
-@pytest.fixture(params=[None, 'gzip', 'bz2', 'zip',
+@pytest.fixture(params=[None,
+                        'gzip',
+                        'bz2',
+                        pytest.mark.skipif(PY2, reason='zip compression not'
+                                           ' supported in Python 2.')('zip'),
                         pytest.param('xz', marks=td.skip_if_no_lzma)])
 def compression(request):
     """

--- a/pandas/conftest.py
+++ b/pandas/conftest.py
@@ -3,7 +3,6 @@ import pytest
 import numpy
 import pandas
 import pandas.util._test_decorators as td
-from pandas.compat import PY2
 
 
 def pytest_addoption(parser):
@@ -67,11 +66,7 @@ def ip():
     return InteractiveShell()
 
 
-@pytest.fixture(params=[None,
-                        'gzip',
-                        'bz2',
-                        pytest.mark.skipif(PY2, reason='zip compression not'
-                                           ' supported in Python 2.')('zip'),
+@pytest.fixture(params=[None, 'gzip', 'bz2', 'zip',
                         pytest.param('xz', marks=td.skip_if_no_lzma)])
 def compression(request):
     """

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -1654,9 +1654,9 @@ class DataFrame(NDFrame):
             A string representing the encoding to use in the output file,
             defaults to 'ascii' on Python 2 and 'utf-8' on Python 3.
         compression : string, optional
-            a string representing the compression to use in the output file,
-            allowed values are 'gzip', 'bz2', 'zip', 'xz', only used when the
-            first argument is a filename.
+            A string representing the compression to use in the output file.
+            Allowed values are 'gzip', 'bz2', 'zip', 'xz'. This input is only
+            used when the first argument is a filename.
         line_terminator : string, default ``'\n'``
             The newline character or character sequence to use in the output
             file

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -1655,8 +1655,9 @@ class DataFrame(NDFrame):
             defaults to 'ascii' on Python 2 and 'utf-8' on Python 3.
         compression : string, optional
             a string representing the compression to use in the output file,
-            allowed values are 'gzip', 'bz2', 'zip', 'xz',
-            only used when the first argument is a filename
+            allowed values are 'gzip', 'bz2', 'zip', 'xz', 'zip' only
+            supported with Python>=3.0, only used when the first argument is a
+            filename.
         line_terminator : string, default ``'\n'``
             The newline character or character sequence to use in the output
             file

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -1655,7 +1655,7 @@ class DataFrame(NDFrame):
             defaults to 'ascii' on Python 2 and 'utf-8' on Python 3.
         compression : string, optional
             a string representing the compression to use in the output file,
-            allowed values are 'gzip', 'bz2', 'xz',
+            allowed values are 'gzip', 'bz2', 'zip', 'xz',
             only used when the first argument is a filename
         line_terminator : string, default ``'\n'``
             The newline character or character sequence to use in the output

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -1655,9 +1655,8 @@ class DataFrame(NDFrame):
             defaults to 'ascii' on Python 2 and 'utf-8' on Python 3.
         compression : string, optional
             a string representing the compression to use in the output file,
-            allowed values are 'gzip', 'bz2', 'zip', 'xz', 'zip' only
-            supported with Python>=3.0, only used when the first argument is a
-            filename.
+            allowed values are 'gzip', 'bz2', 'zip', 'xz', only used when the
+            first argument is a filename.
         line_terminator : string, default ``'\n'``
             The newline character or character sequence to use in the output
             file

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -2089,7 +2089,8 @@ class NDFrame(PandasObject, SelectionMixin):
         compression : {'infer', 'gzip', 'bz2', 'zip', 'xz', None}, \
         default 'infer'
             A string representing the compression to use in the output file. By
-            default, infers from the file extension in specified path.
+            default, infers from the file extension in specified path. 'zip'
+            only supported with Python>=3.0
 
             .. versionadded:: 0.20.0
         protocol : int

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -2130,6 +2130,7 @@ class NDFrame(PandasObject, SelectionMixin):
         2    2    7
         3    3    8
         4    4    9
+
         >>> import os
         >>> os.remove("./dummy.pkl")
         """

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -1816,8 +1816,7 @@ class NDFrame(PandasObject, SelectionMixin):
 
         compression : {None, 'gzip', 'bz2', 'zip', 'xz'}
             A string representing the compression to use in the output file,
-            'zip' only supported with Python>=3.0, only used when the first
-            argument is a filename.
+            only used when the first argument is a filename.
 
             .. versionadded:: 0.21.0
 
@@ -2089,8 +2088,7 @@ class NDFrame(PandasObject, SelectionMixin):
         compression : {'infer', 'gzip', 'bz2', 'zip', 'xz', None}, \
         default 'infer'
             A string representing the compression to use in the output file. By
-            default, infers from the file extension in specified path. 'zip'
-            only supported with Python>=3.0
+            default, infers from the file extension in specified path.
 
             .. versionadded:: 0.20.0
         protocol : int

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -2085,7 +2085,8 @@ class NDFrame(PandasObject, SelectionMixin):
         ----------
         path : str
             File path where the pickled object will be stored.
-        compression : {'infer', 'gzip', 'bz2', 'xz', None}, default 'infer'
+        compression : {'infer', 'gzip', 'bz2', 'xz', 'zip', None},
+                default 'infer'
             A string representing the compression to use in the output file. By
             default, infers from the file extension in specified path.
 

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -1816,7 +1816,8 @@ class NDFrame(PandasObject, SelectionMixin):
 
         compression : {None, 'gzip', 'bz2', 'zip', 'xz'}
             A string representing the compression to use in the output file,
-            only used when the first argument is a filename
+            'zip' only supported with Python>=3.0, only used when the first
+            argument is a filename.
 
             .. versionadded:: 0.21.0
 
@@ -2130,7 +2131,6 @@ class NDFrame(PandasObject, SelectionMixin):
         2    2    7
         3    3    8
         4    4    9
-
         >>> import os
         >>> os.remove("./dummy.pkl")
         """

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -1814,7 +1814,7 @@ class NDFrame(PandasObject, SelectionMixin):
 
             .. versionadded:: 0.19.0
 
-        compression : {None, 'gzip', 'bz2', 'xz'}
+        compression : {None, 'gzip', 'bz2', 'zip', 'xz'}
             A string representing the compression to use in the output file,
             only used when the first argument is a filename
 
@@ -2085,8 +2085,8 @@ class NDFrame(PandasObject, SelectionMixin):
         ----------
         path : str
             File path where the pickled object will be stored.
-        compression : {'infer', 'gzip', 'bz2', 'xz', 'zip', None},
-                default 'infer'
+        compression : {'infer', 'gzip', 'bz2', 'zip', 'xz', None}, \
+        default 'infer'
             A string representing the compression to use in the output file. By
             default, infers from the file extension in specified path.
 

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -3633,8 +3633,8 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
             non-ascii, for python versions prior to 3
         compression : string, optional
             a string representing the compression to use in the output file,
-            allowed values are 'gzip', 'bz2', 'xz', only used when the first
-            argument is a filename
+            allowed values are 'gzip', 'bz2', 'zip', 'xz', only used when the
+            first argument is a filename
         date_format: string, default None
             Format string for datetime objects.
         decimal: string, default '.'

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -3632,9 +3632,9 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
             a string representing the encoding to use if the contents are
             non-ascii, for python versions prior to 3
         compression : string, optional
-            a string representing the compression to use in the output file,
-            allowed values are 'gzip', 'bz2', 'zip', 'xz', only used when the
-            first argument is a filename
+            A string representing the compression to use in the output file.
+            Allowed values are 'gzip', 'bz2', 'zip', 'xz'. This input is only
+            used when the first argument is a filename.
         date_format: string, default None
             Format string for datetime objects.
         decimal: string, default '.'

--- a/pandas/io/common.py
+++ b/pandas/io/common.py
@@ -429,7 +429,13 @@ def _get_handle(path_or_buf, mode, encoding=None, compression=None,
 
 
 class BytesZipFile(ZipFile, BytesIO):
-    """override write method with writestr to accept bytes."""
+    """
+    Wrapper for standard library class ZipFile and allow the returned file-like
+    handle to accept byte strings via `write` method.
+
+    BytesIO provides attributes of file-like object and ZipFile.writestr writes
+    bytes strings into a member of the archive.
+    """
     # GH 17778
     def __init__(self, file, mode='r', **kwargs):
         if mode in ['wb', 'rb']:

--- a/pandas/io/common.py
+++ b/pandas/io/common.py
@@ -366,11 +366,7 @@ def _get_handle(path_or_buf, mode, encoding=None, compression=None,
         elif compression == 'zip':
             zf = BytesZipFile(path_or_buf, mode)
             if zf.mode == 'w':
-                if compat.PY3:
-                    f = zf
-                elif compat.PY2:
-                    raise NotImplementedError('Writing zip compression is not'
-                                              ' supported in Python 2.')
+                f = zf
             elif zf.mode == 'r':
                 zip_names = zf.namelist()
                 if len(zip_names) == 1:

--- a/pandas/io/common.py
+++ b/pandas/io/common.py
@@ -439,12 +439,6 @@ class BytesZipFile(ZipFile, BytesIO):
     def write(self, data):
         super(BytesZipFile, self).writestr(self.filename, data)
 
-    def writable(self):
-        return self.mode == 'w'
-
-    def readable(self):
-        return self.mode == 'r'
-
 
 class MMapWrapper(BaseIterator):
     """

--- a/pandas/io/common.py
+++ b/pandas/io/common.py
@@ -437,7 +437,8 @@ class BytesZipFile(ZipFile, BytesIO):
         super(BytesZipFile, self).__init__(file, mode, **kwargs)
 
     def write(self, data):
-        super(BytesZipFile, self).writestr(self.filename, data)
+        if self.filename not in self.nameslist():
+            super(BytesZipFile, self).writestr(self.filename, data)
 
 
 class MMapWrapper(BaseIterator):

--- a/pandas/io/common.py
+++ b/pandas/io/common.py
@@ -6,7 +6,7 @@ import codecs
 import mmap
 from contextlib import contextmanager, closing
 from zipfile import ZipFile
-from io import BufferedIOBase
+
 from pandas.compat import StringIO, BytesIO, string_types, text_type
 from pandas import compat
 from pandas.io.formats.printing import pprint_thing
@@ -428,7 +428,7 @@ def _get_handle(path_or_buf, mode, encoding=None, compression=None,
     return f, handles
 
 
-class BytesZipFile(ZipFile, BufferedIOBase):
+class BytesZipFile(ZipFile, BytesIO):
     """override write method with writestr to accept bytes."""
     # GH 17778
     def __init__(self, file, mode='r', **kwargs):

--- a/pandas/io/common.py
+++ b/pandas/io/common.py
@@ -437,7 +437,7 @@ class BytesZipFile(ZipFile, BytesIO):
         super(BytesZipFile, self).__init__(file, mode, **kwargs)
 
     def write(self, data):
-        if self.filename not in self.nameslist():
+        if self.filename not in self.namelist():
             super(BytesZipFile, self).writestr(self.filename, data)
 
 

--- a/pandas/io/common.py
+++ b/pandas/io/common.py
@@ -366,7 +366,11 @@ def _get_handle(path_or_buf, mode, encoding=None, compression=None,
         elif compression == 'zip':
             zf = BytesZipFile(path_or_buf, mode)
             if zf.mode == 'w':
-                f = zf
+                if compat.PY3:
+                    f = zf
+                elif compat.PY2:
+                    raise NotImplementedError('Writing zip compression is not'
+                                              ' supported in Python 2.')
             elif zf.mode == 'r':
                 zip_names = zf.namelist()
                 if len(zip_names) == 1:

--- a/pandas/io/common.py
+++ b/pandas/io/common.py
@@ -437,8 +437,7 @@ class BytesZipFile(ZipFile, BytesIO):
         super(BytesZipFile, self).__init__(file, mode, **kwargs)
 
     def write(self, data):
-        if self.filename not in self.namelist():
-            super(BytesZipFile, self).writestr(self.filename, data)
+        super(BytesZipFile, self).writestr(self.filename, data)
 
 
 class MMapWrapper(BaseIterator):

--- a/pandas/io/formats/csvs.py
+++ b/pandas/io/formats/csvs.py
@@ -133,8 +133,8 @@ class CSVFormatter(object):
         else:
             f, handles = _get_handle(self.path_or_buf, self.mode,
                                      encoding=encoding,
-                                     compression=self.compression)
-            close = True
+                                     compression=None)
+            close = True if self.compression is None else False
 
         try:
             writer_kwargs = dict(lineterminator=self.line_terminator,
@@ -150,6 +150,16 @@ class CSVFormatter(object):
 
             self._save()
 
+            # GH 17778 handles compression for byte strings.
+            if not close and self.compression:
+                f.close()
+                with open(self.path_or_buf, 'r') as f:
+                    data = f.read()
+                f, handles = _get_handle(self.path_or_buf, self.mode,
+                                         encoding=encoding,
+                                         compression=self.compression)
+                f.write(data)
+                close = True
         finally:
             if close:
                 f.close()

--- a/pandas/io/formats/csvs.py
+++ b/pandas/io/formats/csvs.py
@@ -150,6 +150,7 @@ class CSVFormatter(object):
 
             self._save()
 
+        finally:
             # GH 17778 handles compression for byte strings.
             if not close and self.compression:
                 f.close()
@@ -160,7 +161,6 @@ class CSVFormatter(object):
                                          compression=self.compression)
                 f.write(data)
                 close = True
-        finally:
             if close:
                 f.close()
 

--- a/pandas/io/pickle.py
+++ b/pandas/io/pickle.py
@@ -62,6 +62,7 @@ def to_pickle(obj, path, compression='infer', protocol=pkl.HIGHEST_PROTOCOL):
     2    2    7
     3    3    8
     4    4    9
+
     >>> import os
     >>> os.remove("./dummy.pkl")
     """
@@ -132,6 +133,7 @@ def read_pickle(path, compression='infer'):
     2    2    7
     3    3    8
     4    4    9
+
     >>> import os
     >>> os.remove("./dummy.pkl")
     """

--- a/pandas/io/pickle.py
+++ b/pandas/io/pickle.py
@@ -18,7 +18,7 @@ def to_pickle(obj, path, compression='infer', protocol=pkl.HIGHEST_PROTOCOL):
         Any python object.
     path : str
         File path where the pickled object will be stored.
-    compression : {'infer', 'gzip', 'bz2', 'xz', 'zip', None}, default 'infer'
+    compression : {'infer', 'gzip', 'bz2', 'zip', 'xz', None}, default 'infer'
         A string representing the compression to use in the output file. By
         default, infers from the file extension in specified path.
 
@@ -93,7 +93,7 @@ def read_pickle(path, compression='infer'):
     ----------
     path : str
         File path where the pickled object will be loaded.
-    compression : {'infer', 'gzip', 'bz2', 'xz', 'zip', None}, default 'infer'
+    compression : {'infer', 'gzip', 'bz2', 'zip', 'xz', None}, default 'infer'
         For on-the-fly decompression of on-disk data. If 'infer', then use
         gzip, bz2, xz or zip if path ends in '.gz', '.bz2', '.xz',
         or '.zip' respectively, and no decompression otherwise.

--- a/pandas/io/pickle.py
+++ b/pandas/io/pickle.py
@@ -20,7 +20,8 @@ def to_pickle(obj, path, compression='infer', protocol=pkl.HIGHEST_PROTOCOL):
         File path where the pickled object will be stored.
     compression : {'infer', 'gzip', 'bz2', 'zip', 'xz', None}, default 'infer'
         A string representing the compression to use in the output file. By
-        default, infers from the file extension in specified path.
+        default, infers from the file extension in specified path. 'zip' only
+        supported with Python>=3.0
 
         .. versionadded:: 0.20.0
     protocol : int
@@ -62,7 +63,6 @@ def to_pickle(obj, path, compression='infer', protocol=pkl.HIGHEST_PROTOCOL):
     2    2    7
     3    3    8
     4    4    9
-
     >>> import os
     >>> os.remove("./dummy.pkl")
     """
@@ -133,7 +133,6 @@ def read_pickle(path, compression='infer'):
     2    2    7
     3    3    8
     4    4    9
-
     >>> import os
     >>> os.remove("./dummy.pkl")
     """

--- a/pandas/io/pickle.py
+++ b/pandas/io/pickle.py
@@ -74,7 +74,7 @@ def to_pickle(obj, path, compression='infer', protocol=pkl.HIGHEST_PROTOCOL):
     if protocol < 0:
         protocol = pkl.HIGHEST_PROTOCOL
     try:
-        pkl.dump(obj, f, protocol=protocol)
+        f.write(pkl.dumps(obj, protocol=protocol))
     finally:
         for _f in fh:
             _f.close()

--- a/pandas/io/pickle.py
+++ b/pandas/io/pickle.py
@@ -20,8 +20,7 @@ def to_pickle(obj, path, compression='infer', protocol=pkl.HIGHEST_PROTOCOL):
         File path where the pickled object will be stored.
     compression : {'infer', 'gzip', 'bz2', 'zip', 'xz', None}, default 'infer'
         A string representing the compression to use in the output file. By
-        default, infers from the file extension in specified path. 'zip' only
-        supported with Python>=3.0
+        default, infers from the file extension in specified path.
 
         .. versionadded:: 0.20.0
     protocol : int

--- a/pandas/io/pickle.py
+++ b/pandas/io/pickle.py
@@ -18,7 +18,7 @@ def to_pickle(obj, path, compression='infer', protocol=pkl.HIGHEST_PROTOCOL):
         Any python object.
     path : str
         File path where the pickled object will be stored.
-    compression : {'infer', 'gzip', 'bz2', 'xz', None}, default 'infer'
+    compression : {'infer', 'gzip', 'bz2', 'xz', 'zip', None}, default 'infer'
         A string representing the compression to use in the output file. By
         default, infers from the file extension in specified path.
 

--- a/pandas/tests/frame/test_to_csv.py
+++ b/pandas/tests/frame/test_to_csv.py
@@ -943,20 +943,6 @@ class TestDataFrameToCSV(TestData):
             with tm.decompress_file(filename, compression) as fh:
                 assert_frame_equal(df, read_csv(fh, index_col=0))
 
-    @pytest.mark.xfail(reason='zip compression is now supported for csv.')
-    def test_to_csv_compression_value_error(self):
-        # GH7615
-        # use the compression kw in to_csv
-        df = DataFrame([[0.123456, 0.234567, 0.567567],
-                        [12.32112, 123123.2, 321321.2]],
-                       index=['A', 'B'], columns=['X', 'Y', 'Z'])
-
-        with ensure_clean() as filename:
-            # zip compression is not supported and should raise ValueError
-            import zipfile
-            pytest.raises(zipfile.BadZipfile, df.to_csv,
-                          filename, compression="zip")
-
     def test_to_csv_date_format(self):
         with ensure_clean('__tmp_to_csv_date_format__') as path:
             dt_index = self.tsframe.index

--- a/pandas/tests/frame/test_to_csv.py
+++ b/pandas/tests/frame/test_to_csv.py
@@ -919,7 +919,7 @@ class TestDataFrameToCSV(TestData):
         recons = pd.read_csv(StringIO(csv_str), index_col=0)
         assert_frame_equal(self.frame, recons)
 
-    def test_to_csv_compression(self, compression_no_zip):
+    def test_to_csv_compression(self, compression):
 
         df = DataFrame([[0.123456, 0.234567, 0.567567],
                         [12.32112, 123123.2, 321321.2]],
@@ -927,22 +927,23 @@ class TestDataFrameToCSV(TestData):
 
         with ensure_clean() as filename:
 
-            df.to_csv(filename, compression=compression_no_zip)
+            df.to_csv(filename, compression=compression)
 
             # test the round trip - to_csv -> read_csv
-            rs = read_csv(filename, compression=compression_no_zip,
+            rs = read_csv(filename, compression=compression,
                           index_col=0)
             assert_frame_equal(df, rs)
 
             # explicitly make sure file is compressed
-            with tm.decompress_file(filename, compression_no_zip) as fh:
+            with tm.decompress_file(filename, compression) as fh:
                 text = fh.read().decode('utf8')
                 for col in df.columns:
                     assert col in text
 
-            with tm.decompress_file(filename, compression_no_zip) as fh:
+            with tm.decompress_file(filename, compression) as fh:
                 assert_frame_equal(df, read_csv(fh, index_col=0))
 
+    @pytest.mark.xfail(reason='zip compression is now supported for csv.')
     def test_to_csv_compression_value_error(self):
         # GH7615
         # use the compression kw in to_csv

--- a/pandas/tests/frame/test_to_csv.py
+++ b/pandas/tests/frame/test_to_csv.py
@@ -8,7 +8,7 @@ import pytest
 from numpy import nan
 import numpy as np
 
-from pandas.compat import (lmap, range, lrange, StringIO, u)
+from pandas.compat import (lmap, range, lrange, StringIO, u, PY2)
 import pandas.core.common as com
 from pandas.errors import ParserError
 from pandas import (DataFrame, Index, Series, MultiIndex, Timestamp,
@@ -924,6 +924,9 @@ class TestDataFrameToCSV(TestData):
         df = DataFrame([[0.123456, 0.234567, 0.567567],
                         [12.32112, 123123.2, 321321.2]],
                        index=['A', 'B'], columns=['X', 'Y', 'Z'])
+
+        if PY2 and compression == 'zip':
+            pytest.xfail(reason='zip compression not supported in Python 2.')
 
         with ensure_clean() as filename:
 

--- a/pandas/tests/frame/test_to_csv.py
+++ b/pandas/tests/frame/test_to_csv.py
@@ -8,7 +8,7 @@ import pytest
 from numpy import nan
 import numpy as np
 
-from pandas.compat import (lmap, range, lrange, StringIO, u, PY2)
+from pandas.compat import (lmap, range, lrange, StringIO, u)
 import pandas.core.common as com
 from pandas.errors import ParserError
 from pandas import (DataFrame, Index, Series, MultiIndex, Timestamp,
@@ -924,10 +924,6 @@ class TestDataFrameToCSV(TestData):
         df = DataFrame([[0.123456, 0.234567, 0.567567],
                         [12.32112, 123123.2, 321321.2]],
                        index=['A', 'B'], columns=['X', 'Y', 'Z'])
-
-        if PY2 and compression == 'zip':
-            pytest.xfail(reason='zip compression for csv not suppported in'
-                                'Python 2')
 
         with ensure_clean() as filename:
 

--- a/pandas/tests/frame/test_to_csv.py
+++ b/pandas/tests/frame/test_to_csv.py
@@ -8,7 +8,7 @@ import pytest
 from numpy import nan
 import numpy as np
 
-from pandas.compat import (lmap, range, lrange, StringIO, u, PY2)
+from pandas.compat import (lmap, range, lrange, StringIO, u)
 import pandas.core.common as com
 from pandas.errors import ParserError
 from pandas import (DataFrame, Index, Series, MultiIndex, Timestamp,
@@ -924,9 +924,6 @@ class TestDataFrameToCSV(TestData):
         df = DataFrame([[0.123456, 0.234567, 0.567567],
                         [12.32112, 123123.2, 321321.2]],
                        index=['A', 'B'], columns=['X', 'Y', 'Z'])
-
-        if PY2 and compression == 'zip':
-            pytest.xfail(reason='zip compression not supported in Python 2.')
 
         with ensure_clean() as filename:
 

--- a/pandas/tests/frame/test_to_csv.py
+++ b/pandas/tests/frame/test_to_csv.py
@@ -8,7 +8,7 @@ import pytest
 from numpy import nan
 import numpy as np
 
-from pandas.compat import (lmap, range, lrange, StringIO, u)
+from pandas.compat import (lmap, range, lrange, StringIO, u, PY2)
 import pandas.core.common as com
 from pandas.errors import ParserError
 from pandas import (DataFrame, Index, Series, MultiIndex, Timestamp,
@@ -924,6 +924,10 @@ class TestDataFrameToCSV(TestData):
         df = DataFrame([[0.123456, 0.234567, 0.567567],
                         [12.32112, 123123.2, 321321.2]],
                        index=['A', 'B'], columns=['X', 'Y', 'Z'])
+
+        if PY2 and compression == 'zip':
+            pytest.xfail(reason='zip compression for csv not suppported in'
+                                'Python 2')
 
         with ensure_clean() as filename:
 

--- a/pandas/tests/io/json/test_compression.py
+++ b/pandas/tests/io/json/test_compression.py
@@ -21,14 +21,15 @@ def test_compression_roundtrip(compression_no_zip):
         assert_frame_equal(df, pd.read_json(result))
 
 
+@pytest.mark.xfail(reason='zip compression is now supported for json.')
 def test_compress_zip_value_error():
     df = pd.DataFrame([[0.123456, 0.234567, 0.567567],
                        [12.32112, 123123.2, 321321.2]],
                       index=['A', 'B'], columns=['X', 'Y', 'Z'])
 
     with tm.ensure_clean() as path:
-        import zipfile
-        pytest.raises(zipfile.BadZipfile, df.to_json, path, compression="zip")
+        from zipfile import BadZipfile
+        pytest.raises(BadZipfile, df.to_json, path, compression="zip")
 
 
 def test_read_zipped_json():

--- a/pandas/tests/io/json/test_compression.py
+++ b/pandas/tests/io/json/test_compression.py
@@ -21,17 +21,6 @@ def test_compression_roundtrip(compression):
         assert_frame_equal(df, pd.read_json(result))
 
 
-@pytest.mark.xfail(reason='zip compression is now supported for json.')
-def test_compress_zip_value_error():
-    df = pd.DataFrame([[0.123456, 0.234567, 0.567567],
-                       [12.32112, 123123.2, 321321.2]],
-                      index=['A', 'B'], columns=['X', 'Y', 'Z'])
-
-    with tm.ensure_clean() as path:
-        import zipfile
-        pytest.raises(zipfile.BadZipfile, df.to_json, path, compression="zip")
-
-
 def test_read_zipped_json():
     uncompressed_path = tm.get_data_path("tsframe_v012.json")
     uncompressed_df = pd.read_json(uncompressed_path)

--- a/pandas/tests/io/json/test_compression.py
+++ b/pandas/tests/io/json/test_compression.py
@@ -5,18 +5,18 @@ import pandas.util.testing as tm
 from pandas.util.testing import assert_frame_equal, assert_raises_regex
 
 
-def test_compression_roundtrip(compression_no_zip):
+def test_compression_roundtrip(compression):
     df = pd.DataFrame([[0.123456, 0.234567, 0.567567],
                        [12.32112, 123123.2, 321321.2]],
                       index=['A', 'B'], columns=['X', 'Y', 'Z'])
 
     with tm.ensure_clean() as path:
-        df.to_json(path, compression=compression_no_zip)
+        df.to_json(path, compression=compression)
         assert_frame_equal(df, pd.read_json(path,
-                                            compression=compression_no_zip))
+                                            compression=compression))
 
         # explicitly ensure file was compressed.
-        with tm.decompress_file(path, compression_no_zip) as fh:
+        with tm.decompress_file(path, compression) as fh:
             result = fh.read().decode('utf8')
         assert_frame_equal(df, pd.read_json(result))
 
@@ -42,7 +42,7 @@ def test_read_zipped_json():
     assert_frame_equal(uncompressed_df, compressed_df)
 
 
-def test_with_s3_url(compression_no_zip):
+def test_with_s3_url(compression):
     boto3 = pytest.importorskip('boto3')
     pytest.importorskip('s3fs')
     moto = pytest.importorskip('moto')
@@ -53,35 +53,35 @@ def test_with_s3_url(compression_no_zip):
         bucket = conn.create_bucket(Bucket="pandas-test")
 
         with tm.ensure_clean() as path:
-            df.to_json(path, compression=compression_no_zip)
+            df.to_json(path, compression=compression)
             with open(path, 'rb') as f:
                 bucket.put_object(Key='test-1', Body=f)
 
         roundtripped_df = pd.read_json('s3://pandas-test/test-1',
-                                       compression=compression_no_zip)
+                                       compression=compression)
         assert_frame_equal(df, roundtripped_df)
 
 
-def test_lines_with_compression(compression_no_zip):
+def test_lines_with_compression(compression):
 
     with tm.ensure_clean() as path:
         df = pd.read_json('{"a": [1, 2, 3], "b": [4, 5, 6]}')
         df.to_json(path, orient='records', lines=True,
-                   compression=compression_no_zip)
+                   compression=compression)
         roundtripped_df = pd.read_json(path, lines=True,
-                                       compression=compression_no_zip)
+                                       compression=compression)
         assert_frame_equal(df, roundtripped_df)
 
 
-def test_chunksize_with_compression(compression_no_zip):
+def test_chunksize_with_compression(compression):
 
     with tm.ensure_clean() as path:
         df = pd.read_json('{"a": ["foo", "bar", "baz"], "b": [4, 5, 6]}')
         df.to_json(path, orient='records', lines=True,
-                   compression=compression_no_zip)
+                   compression=compression)
 
         res = pd.read_json(path, lines=True, chunksize=1,
-                           compression=compression_no_zip)
+                           compression=compression)
         roundtripped_df = pd.concat(res)
         assert_frame_equal(df, roundtripped_df)
 

--- a/pandas/tests/io/json/test_compression.py
+++ b/pandas/tests/io/json/test_compression.py
@@ -28,8 +28,8 @@ def test_compress_zip_value_error():
                       index=['A', 'B'], columns=['X', 'Y', 'Z'])
 
     with tm.ensure_clean() as path:
-        from zipfile import BadZipfile
-        pytest.raises(BadZipfile, df.to_json, path, compression="zip")
+        import zipfile
+        pytest.raises(zipfile.BadZipfile, df.to_json, path, compression="zip")
 
 
 def test_read_zipped_json():

--- a/pandas/tests/io/test_pickle.py
+++ b/pandas/tests/io/test_pickle.py
@@ -352,7 +352,7 @@ class TestCompression(object):
                 f.write(fh.read())
             f.close()
 
-    def test_write_explicit(self, compression_no_zip, get_random_path):
+    def test_write_explicit(self, compression, get_random_path):
         base = get_random_path
         path1 = base + ".compressed"
         path2 = base + ".raw"
@@ -361,10 +361,10 @@ class TestCompression(object):
             df = tm.makeDataFrame()
 
             # write to compressed file
-            df.to_pickle(p1, compression=compression_no_zip)
+            df.to_pickle(p1, compression=compression)
 
             # decompress
-            with tm.decompress_file(p1, compression=compression_no_zip) as f:
+            with tm.decompress_file(p1, compression=compression) as f:
                 with open(p2, "wb") as fh:
                     fh.write(f.read())
 

--- a/pandas/tests/io/test_pickle.py
+++ b/pandas/tests/io/test_pickle.py
@@ -20,7 +20,7 @@ import os
 from distutils.version import LooseVersion
 import pandas as pd
 from pandas import Index
-from pandas.compat import is_platform_little_endian, PY2
+from pandas.compat import is_platform_little_endian
 import pandas
 import pandas.util.testing as tm
 import pandas.util._test_decorators as td
@@ -356,9 +356,6 @@ class TestCompression(object):
         base = get_random_path
         path1 = base + ".compressed"
         path2 = base + ".raw"
-
-        if PY2 and compression == 'zip':
-            pytest.xfail(reason='zip compression not supported in Python 2.')
 
         with tm.ensure_clean(path1) as p1, tm.ensure_clean(path2) as p2:
             df = tm.makeDataFrame()

--- a/pandas/tests/io/test_pickle.py
+++ b/pandas/tests/io/test_pickle.py
@@ -20,7 +20,7 @@ import os
 from distutils.version import LooseVersion
 import pandas as pd
 from pandas import Index
-from pandas.compat import is_platform_little_endian
+from pandas.compat import is_platform_little_endian, PY2
 import pandas
 import pandas.util.testing as tm
 import pandas.util._test_decorators as td
@@ -415,6 +415,9 @@ class TestCompression(object):
         base = get_random_path
         path1 = base + ".raw"
         path2 = base + ".compressed"
+
+        if PY2 and compression == 'zip':
+            pytest.xfail(reason='zip compression not supported in Python 2.')
 
         with tm.ensure_clean(path1) as p1, tm.ensure_clean(path2) as p2:
             df = tm.makeDataFrame()

--- a/pandas/tests/io/test_pickle.py
+++ b/pandas/tests/io/test_pickle.py
@@ -357,6 +357,9 @@ class TestCompression(object):
         path1 = base + ".compressed"
         path2 = base + ".raw"
 
+        if PY2 and compression == 'zip':
+            pytest.xfail(reason='zip compression not supported in Python 2.')
+
         with tm.ensure_clean(path1) as p1, tm.ensure_clean(path2) as p2:
             df = tm.makeDataFrame()
 
@@ -415,9 +418,6 @@ class TestCompression(object):
         base = get_random_path
         path1 = base + ".raw"
         path2 = base + ".compressed"
-
-        if PY2 and compression == 'zip':
-            pytest.xfail(reason='zip compression not supported in Python 2.')
 
         with tm.ensure_clean(path1) as p1, tm.ensure_clean(path2) as p2:
             df = tm.makeDataFrame()

--- a/pandas/tests/series/test_io.py
+++ b/pandas/tests/series/test_io.py
@@ -138,26 +138,26 @@ class TestSeriesToCSV(TestData):
         csv_str = s.to_csv(path=None)
         assert isinstance(csv_str, str)
 
-    def test_to_csv_compression(self, compression_no_zip):
+    def test_to_csv_compression(self, compression):
 
         s = Series([0.123456, 0.234567, 0.567567], index=['A', 'B', 'C'],
                    name='X')
 
         with ensure_clean() as filename:
 
-            s.to_csv(filename, compression=compression_no_zip, header=True)
+            s.to_csv(filename, compression=compression, header=True)
 
             # test the round trip - to_csv -> read_csv
-            rs = pd.read_csv(filename, compression=compression_no_zip,
+            rs = pd.read_csv(filename, compression=compression,
                              index_col=0, squeeze=True)
             assert_series_equal(s, rs)
 
             # explicitly ensure file was compressed
-            with tm.decompress_file(filename, compression_no_zip) as fh:
+            with tm.decompress_file(filename, compression) as fh:
                 text = fh.read().decode('utf8')
                 assert s.name in text
 
-            with tm.decompress_file(filename, compression_no_zip) as fh:
+            with tm.decompress_file(filename, compression) as fh:
                 assert_series_equal(s, pd.read_csv(fh,
                                                    index_col=0,
                                                    squeeze=True))

--- a/pandas/tests/series/test_io.py
+++ b/pandas/tests/series/test_io.py
@@ -10,7 +10,7 @@ import pandas as pd
 
 from pandas import Series, DataFrame
 
-from pandas.compat import StringIO, u
+from pandas.compat import StringIO, u, PY2
 from pandas.util.testing import (assert_series_equal, assert_almost_equal,
                                  assert_frame_equal, ensure_clean)
 import pandas.util.testing as tm
@@ -142,6 +142,10 @@ class TestSeriesToCSV(TestData):
 
         s = Series([0.123456, 0.234567, 0.567567], index=['A', 'B', 'C'],
                    name='X')
+
+        if PY2 and compression == 'zip':
+            pytest.xfail(reason='zip compression for csv not suppported in'
+                                'Python 2')
 
         with ensure_clean() as filename:
 

--- a/pandas/tests/series/test_io.py
+++ b/pandas/tests/series/test_io.py
@@ -10,7 +10,7 @@ import pandas as pd
 
 from pandas import Series, DataFrame
 
-from pandas.compat import StringIO, u
+from pandas.compat import StringIO, u, PY2
 from pandas.util.testing import (assert_series_equal, assert_almost_equal,
                                  assert_frame_equal, ensure_clean)
 import pandas.util.testing as tm
@@ -142,6 +142,9 @@ class TestSeriesToCSV(TestData):
 
         s = Series([0.123456, 0.234567, 0.567567], index=['A', 'B', 'C'],
                    name='X')
+
+        if PY2 and compression == 'zip':
+            pytest.xfail(reason='zip compression not supported in Python 2.')
 
         with ensure_clean() as filename:
 

--- a/pandas/tests/series/test_io.py
+++ b/pandas/tests/series/test_io.py
@@ -10,7 +10,7 @@ import pandas as pd
 
 from pandas import Series, DataFrame
 
-from pandas.compat import StringIO, u, PY2
+from pandas.compat import StringIO, u
 from pandas.util.testing import (assert_series_equal, assert_almost_equal,
                                  assert_frame_equal, ensure_clean)
 import pandas.util.testing as tm
@@ -142,10 +142,6 @@ class TestSeriesToCSV(TestData):
 
         s = Series([0.123456, 0.234567, 0.567567], index=['A', 'B', 'C'],
                    name='X')
-
-        if PY2 and compression == 'zip':
-            pytest.xfail(reason='zip compression for csv not suppported in'
-                                'Python 2')
 
         with ensure_clean() as filename:
 

--- a/pandas/tests/series/test_io.py
+++ b/pandas/tests/series/test_io.py
@@ -10,7 +10,7 @@ import pandas as pd
 
 from pandas import Series, DataFrame
 
-from pandas.compat import StringIO, u, PY2
+from pandas.compat import StringIO, u
 from pandas.util.testing import (assert_series_equal, assert_almost_equal,
                                  assert_frame_equal, ensure_clean)
 import pandas.util.testing as tm
@@ -142,9 +142,6 @@ class TestSeriesToCSV(TestData):
 
         s = Series([0.123456, 0.234567, 0.567567], index=['A', 'B', 'C'],
                    name='X')
-
-        if PY2 and compression == 'zip':
-            pytest.xfail(reason='zip compression not supported in Python 2.')
 
         with ensure_clean() as filename:
 

--- a/pandas/util/testing.py
+++ b/pandas/util/testing.py
@@ -172,7 +172,7 @@ def decompress_file(path, compression):
     path : str
         The path where the file is read from
 
-    compression : {'gzip', 'bz2', 'xz', None}
+    compression : {'gzip', 'bz2', 'zip', 'xz', None}
         Name of the decompression to use
 
     Returns


### PR DESCRIPTION
- [x] closes https://github.com/pandas-dev/pandas/issues/17778
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry

Currently, `to_pickle` doesn't support compression='zip' whereas `read_pickle` is able to unpickle zip compressed file. The same applies to `to_json`, `to_csv` methods under generic, frame, series. 

Standard library ZipFile class default write method requires a filename but pickle.dump(obj, f, protocol) requires f being a file-like object (i.e. file handle) which offers writing bytes. Create a new BytesZipFile class that allows pickle.dump to write bytes into zip file handle. 

Now zip compressed objects (pickle, json, csv) are roundtripable with `read_pickle`, `read_json`, `read_csv`.

Need suggestion as to where to put BytesZipFile class which overrides `write` method with `writestr`. Other comments welcome.