### PR TITLE
CLN: display.notebook_repr_html -> display.html.notebook (GH11784)

### DIFF
--- a/doc/source/options.rst
+++ b/doc/source/options.rst
@@ -372,7 +372,7 @@ display.memory_usage                    True         This specifies if the memor
 display.multi_sparse                    True         "Sparsify" MultiIndex display (don't
                                                      display repeated elements in outer
                                                      levels within groups)
-display.notebook_repr_html              True         When True, IPython notebook will
+display.html.notebook                   True         When True, IPython notebook will
                                                      use html representation for
                                                      pandas objects (if it is available).
 display.pprint_nest_depth               3            Controls the number of nested levels

--- a/doc/source/whatsnew/v0.23.0.txt
+++ b/doc/source/whatsnew/v0.23.0.txt
@@ -740,6 +740,7 @@ Deprecations
 
 - ``pandas.tseries.plotting.tsplot`` is deprecated. Use :func:`Series.plot` instead (:issue:`18627`)
 - ``Index.summary()`` is deprecated and will be removed in a future version (:issue:`18217`)
+- ``pd.options.display.notebook_repr_html`` is deprecated in favor of ``pd.options.display.html.notebook`` (:issue:`11784`)
 
 .. _whatsnew_0230.prior_deprecations:
 

--- a/pandas/core/config_init.py
+++ b/pandas/core/config_init.py
@@ -107,6 +107,11 @@ pc_nb_repr_h_doc = """
     pandas objects (if it is available).
 """
 
+pc_nb_repr_h_deprecation_warning = """
+display.notebook_repr_html has been deprecated,
+use display.html.notebook instead
+"""
+
 pc_date_dayfirst_doc = """
 : boolean
     When True, prints and parses dates with the day first, eg 20/01/2005
@@ -366,6 +371,8 @@ with cf.config_prefix('display'):
                        validator=is_int)
     cf.register_option('html.use_mathjax', True, pc_html_use_mathjax_doc,
                        validator=is_bool)
+    cf.register_option('html.notebook', True, pc_nb_repr_h_doc,
+                       validator=is_bool)
 
 with cf.config_prefix('html'):
     cf.register_option('border', 1, pc_html_border_doc,
@@ -374,6 +381,9 @@ with cf.config_prefix('html'):
 cf.deprecate_option('html.border', msg=pc_html_border_deprecation_warning,
                     rkey='display.html.border')
 
+cf.deprecate_option('display.notebook_repr_html',
+                    msg=pc_nb_repr_h_deprecation_warning,
+                    rkey='display.html.notebook')
 
 tc_sim_interactive_doc = """
 : boolean

--- a/pandas/core/config_init.py
+++ b/pandas/core/config_init.py
@@ -101,7 +101,7 @@ pc_max_info_cols_doc = """
     per column information will be printed.
 """
 
-pc_nb_repr_h_doc = """
+html_notebook_doc = """
 : boolean
     When True, IPython notebook will use html representation for
     pandas objects (if it is available).
@@ -327,7 +327,7 @@ with cf.config_prefix('display'):
                        validator=is_int)
     cf.register_option('colheader_justify', 'right', colheader_justify_doc,
                        validator=is_text)
-    cf.register_option('notebook_repr_html', True, pc_nb_repr_h_doc,
+    cf.register_option('notebook_repr_html', True, html_notebook_doc,
                        validator=is_bool)
     cf.register_option('date_dayfirst', False, pc_date_dayfirst_doc,
                        validator=is_bool)
@@ -371,7 +371,7 @@ with cf.config_prefix('display'):
                        validator=is_int)
     cf.register_option('html.use_mathjax', True, pc_html_use_mathjax_doc,
                        validator=is_bool)
-    cf.register_option('html.notebook', True, pc_nb_repr_h_doc,
+    cf.register_option('html.notebook', True, html_notebook_doc,
                        validator=is_bool)
 
 with cf.config_prefix('html'):

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -703,7 +703,7 @@ class DataFrame(NDFrame):
             val = val.replace('>', r'&gt;', 1)
             return '<pre>' + val + '</pre>'
 
-        if get_option("display.notebook_repr_html"):
+        if get_option("display.html.notebook"):
             max_rows = get_option("display.max_rows")
             max_cols = get_option("display.max_columns")
             show_dimensions = get_option("display.show_dimensions")

--- a/pandas/tests/io/formats/test_format.py
+++ b/pandas/tests/io/formats/test_format.py
@@ -1243,7 +1243,7 @@ class TestDataFrameFormatting(object):
     def test_to_string_float_formatting(self):
         tm.reset_display_options()
         fmt.set_option('display.precision', 5, 'display.column_space', 12,
-                       'display.notebook_repr_html', False)
+                       'display.html.notebook', False)
 
         df = DataFrame({'x': [0, 0.25, 3456.000, 12e+45, 1.64e+6, 1.7e+8,
                               1.253456, np.pi, -1e6]})
@@ -1421,7 +1421,7 @@ c  10  11  12  13  14\
         fmt.set_option('display.max_rows', 1, 'display.max_columns', 1)
         self.frame._repr_html_()
 
-        fmt.set_option('display.notebook_repr_html', False)
+        fmt.set_option('display.html.notebook', False)
         self.frame._repr_html_()
 
         tm.reset_display_options()
@@ -1650,6 +1650,12 @@ c  10  11  12  13  14\
                "1 2013-02       2011-02-01  b\n2 2013-03 2011-03-01 09:00  c\n"
                "3 2013-04          2011-04  d")
         assert str(df) == exp
+
+    @tm.capture_stdout
+    def test_option_notebook_repr_html_deprecated(self):
+        with tm.assert_produces_warning(FutureWarning,
+                                        check_stacklevel=False):
+            pd.options.display.notebook_repr_html
 
 
 def gen_series_formatting():

--- a/pandas/tests/io/formats/test_format.py
+++ b/pandas/tests/io/formats/test_format.py
@@ -1653,6 +1653,7 @@ c  10  11  12  13  14\
 
     @tm.capture_stdout
     def test_option_notebook_repr_html_deprecated(self):
+        # GH11784
         with tm.assert_produces_warning(FutureWarning,
                                         check_stacklevel=False):
             pd.options.display.notebook_repr_html


### PR DESCRIPTION
Deprecate display.notebook_repr_html option and move it to
display.html.notebook

- [X] closes #11784
- [X] tests added / passed
- [X] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [X] whatsnew entry