### PR TITLE
ENH: dtype('bool') ndarray or Series coerced to dtype('int') in qcut GH20303

### DIFF
--- a/doc/source/whatsnew/v0.23.0.txt
+++ b/doc/source/whatsnew/v0.23.0.txt
@@ -344,6 +344,7 @@ Other Enhancements
 - :meth:`DataFrame.to_sql` now performs a multivalue insert if the underlying connection supports itk rather than inserting row by row.
   ``SQLAlchemy`` dialects supporting multivalue inserts include: ``mysql``, ``postgresql``, ``sqlite`` and any dialect with ``supports_multivalues_insert``. (:issue:`14315`, :issue:`8953`)
 - :func:`read_html` now accepts a ``displayed_only`` keyword argument to controls whether or not hidden elements are parsed (``True`` by default) (:issue:`20027`)
+- :func:`qcut` now coerces ``dtype='bool'`` `ndarrays` and `Series` to int (equal to `.astype` method) (:issue:`20303`)
 
 .. _whatsnew_0230.api_breaking:
 

--- a/doc/source/whatsnew/v0.23.0.txt
+++ b/doc/source/whatsnew/v0.23.0.txt
@@ -345,10 +345,7 @@ Other Enhancements
   ``SQLAlchemy`` dialects supporting multivalue inserts include: ``mysql``, ``postgresql``, ``sqlite`` and any dialect with ``supports_multivalues_insert``. (:issue:`14315`, :issue:`8953`)
 - :func:`read_html` now accepts a ``displayed_only`` keyword argument to controls whether or not hidden elements are parsed (``True`` by default) (:issue:`20027`)
 - zip compression is supported via ``compression=zip`` in :func:`DataFrame.to_pickle`, :func:`Series.to_pickle`, :func:`DataFrame.to_csv`, :func:`Series.to_csv`, :func:`DataFrame.to_json`, :func:`Series.to_json`. (:issue:`17778`)
-<<<<<<< HEAD
 - :func:`qcut` now coerces ``dtype='bool'`` `ndarrays` and `Series` to int (equal to `.astype` method) (:issue:`20303`)
-=======
->>>>>>> upstream/master
 
 .. _whatsnew_0230.api_breaking:
 

--- a/doc/source/whatsnew/v0.23.0.txt
+++ b/doc/source/whatsnew/v0.23.0.txt
@@ -344,7 +344,7 @@ Other Enhancements
 - :meth:`DataFrame.to_sql` now performs a multivalue insert if the underlying connection supports itk rather than inserting row by row.
   ``SQLAlchemy`` dialects supporting multivalue inserts include: ``mysql``, ``postgresql``, ``sqlite`` and any dialect with ``supports_multivalues_insert``. (:issue:`14315`, :issue:`8953`)
 - :func:`read_html` now accepts a ``displayed_only`` keyword argument to controls whether or not hidden elements are parsed (``True`` by default) (:issue:`20027`)
-- :func:`qcut` now coerces ``dtype='bool'`` `ndarrays` and `Series` to int (equal to `.astype` method) (:issue:`20303`)
+- :func:`qcut` now handles boolean ``ndarray`` and ``Series`` (:issue:`20303`)
 
 .. _whatsnew_0230.api_breaking:
 

--- a/doc/source/whatsnew/v0.23.0.txt
+++ b/doc/source/whatsnew/v0.23.0.txt
@@ -344,7 +344,8 @@ Other Enhancements
 - :meth:`DataFrame.to_sql` now performs a multivalue insert if the underlying connection supports itk rather than inserting row by row.
   ``SQLAlchemy`` dialects supporting multivalue inserts include: ``mysql``, ``postgresql``, ``sqlite`` and any dialect with ``supports_multivalues_insert``. (:issue:`14315`, :issue:`8953`)
 - :func:`read_html` now accepts a ``displayed_only`` keyword argument to controls whether or not hidden elements are parsed (``True`` by default) (:issue:`20027`)
-- :func:`qcut` now handles boolean ``ndarray`` and ``Series`` (:issue:`20303`)
+- zip compression is supported via ``compression=zip`` in :func:`DataFrame.to_pickle`, :func:`Series.to_pickle`, :func:`DataFrame.to_csv`, :func:`Series.to_csv`, :func:`DataFrame.to_json`, :func:`Series.to_json`. (:issue:`17778`)
+- :func:`qcut` now coerces ``dtype='bool'`` `ndarrays` and `Series` to int (equal to `.astype` method) (:issue:`20303`)
 
 .. _whatsnew_0230.api_breaking:
 
@@ -715,6 +716,7 @@ Other API Changes
 - ``pd.to_datetime('today')`` now returns a datetime, consistent with ``pd.Timestamp('today')``; previously ``pd.to_datetime('today')`` returned a ``.normalized()`` datetime (:issue:`19935`)
 - :func:`Series.str.replace` now takes an optional `regex` keyword which, when set to ``False``, uses literal string replacement rather than regex replacement (:issue:`16808`)
 - :func:`DatetimeIndex.strftime` and :func:`PeriodIndex.strftime` now return an ``Index`` instead of a numpy array to be consistent with similar accessors (:issue:`20127`)
+- Constructing a Series from a list of length 1 no longer broadcasts this list when a longer index is specified (:issue:`19714`, :issue:`20391`).
 
 .. _whatsnew_0230.deprecations:
 
@@ -844,6 +846,7 @@ Categorical
   ``self`` but in a different order (:issue:`19551`)
 - Bug in :meth:`Index.astype` with a categorical dtype where the resultant index is not converted to a :class:`CategoricalIndex` for all types of index (:issue:`18630`)
 - Bug in :meth:`Series.astype` and ``Categorical.astype()`` where an existing categorical data does not get updated (:issue:`10696`, :issue:`18593`)
+- Bug in :meth:`Series.str.split` with ``expand=True`` incorrectly raising an IndexError on empty strings (:issue:`20002`).
 - Bug in :class:`Index` constructor with ``dtype=CategoricalDtype(...)`` where ``categories`` and ``ordered`` are not maintained (issue:`19032`)
 - Bug in :class:`Series` constructor with scalar and ``dtype=CategoricalDtype(...)`` where ``categories`` and ``ordered`` are not maintained (issue:`19565`)
 - Bug in ``Categorical.__iter__`` not converting to Python types (:issue:`19909`)
@@ -887,7 +890,8 @@ Timedelta
 - Bug in :func:`Timedelta.total_seconds()` causing precision errors i.e. ``Timedelta('30S').total_seconds()==30.000000000000004`` (:issue:`19458`)
 - Bug in :func: `Timedelta.__rmod__` where operating with a ``numpy.timedelta64`` returned a ``timedelta64`` object instead of a ``Timedelta`` (:issue:`19820`)
 - Multiplication of :class:`TimedeltaIndex` by ``TimedeltaIndex`` will now raise ``TypeError`` instead of raising ``ValueError`` in cases of length mis-match (:issue`19333`)
--
+- Bug in indexing a :class:`TimedeltaIndex` with a ``np.timedelta64`` object which was raising a ``TypeError`` (:issue:`20393`)
+
 
 Timezones
 ^^^^^^^^^
@@ -979,11 +983,13 @@ I/O
 - :class:`Timedelta` now supported in :func:`DataFrame.to_excel` for all Excel file types (:issue:`19242`, :issue:`9155`, :issue:`19900`)
 - Bug in :meth:`pandas.io.stata.StataReader.value_labels` raising an ``AttributeError`` when called on very old files. Now returns an empty dict (:issue:`19417`)
 - Bug in :func:`read_pickle` when unpickling objects with :class:`TimedeltaIndex` or :class:`Float64Index` created with pandas prior to version 0.20 (:issue:`19939`)
+- Bug in :meth:`pandas.io.json.json_normalize` where subrecords are not properly normalized if any subrecords values are NoneType (:issue:`20030`)
 
 Plotting
 ^^^^^^^^
 
 - :func:`DataFrame.plot` now raises a ``ValueError`` when the ``x`` or ``y`` argument is improperly formed (:issue:`18671`)
+- Bug in :func:`DataFrame.plot` when ``x`` and ``y`` arguments given as positions caused incorrect referenced columns for line, bar and area plots (:issue:`20056`)
 - Bug in formatting tick labels with ``datetime.time()`` and fractional seconds (:issue:`18478`).
 - :meth:`Series.plot.kde` has exposed the args ``ind`` and ``bw_method`` in the docstring (:issue:`18461`). The argument ``ind`` may now also be an integer (number of sample points).
 
@@ -1039,3 +1045,4 @@ Other
 
 - Improved error message when attempting to use a Python keyword as an identifier in a ``numexpr`` backed query (:issue:`18221`)
 - Bug in accessing a :func:`pandas.get_option`, which raised ``KeyError`` rather than ``OptionError`` when looking up a non-existant option key in some cases (:issue:`19789`)
+- :func:`DataFrame.plot` now supports multiple columns to the ``y`` argument (:issue:`19699`)

--- a/pandas/core/reshape/tile.py
+++ b/pandas/core/reshape/tile.py
@@ -351,7 +351,7 @@ def _coerce_to_type(x):
     handle it
     """
     dtype = None
-    
+
     if is_datetime64tz_dtype(x):
         dtype = x.dtype
     elif is_datetime64_dtype(x):
@@ -362,10 +362,10 @@ def _coerce_to_type(x):
         dtype = np.timedelta64
     elif is_bool_dtype(x):
         dtype = x.dtype
-    
+
     if dtype is not None:
         if is_bool_dtype(x):
-            # GH 20303: coerce bool to int 
+            # GH 20303: coerce bool to int
             x = np.where(np.isnan(x), np.nan, x.astype(int))
         else:
             # GH 19768: force NaT to NaN during integer conversion

--- a/pandas/core/reshape/tile.py
+++ b/pandas/core/reshape/tile.py
@@ -361,7 +361,7 @@ def _coerce_to_type(x):
         x = to_timedelta(x)
         dtype = np.timedelta64
     elif is_bool_dtype(x):
-        # GH 20303: coerce bool dtype to int 
+        # GH 20303: coerce bool dtype to int
         x = x.astype(np.int64)
         dtype = np.bool_
 

--- a/pandas/core/reshape/tile.py
+++ b/pandas/core/reshape/tile.py
@@ -17,7 +17,7 @@ from pandas.core.dtypes.common import (
 import pandas.core.algorithms as algos
 import pandas.core.nanops as nanops
 from pandas._libs.lib import infer_dtype
-from pandas import (to_timedelta, to_datetime,
+from pandas import (to_timedelta, to_datetime, notna,
                     Categorical, Timestamp, Timedelta,
                     Series, Interval, IntervalIndex)
 
@@ -361,15 +361,13 @@ def _coerce_to_type(x):
         x = to_timedelta(x)
         dtype = np.timedelta64
     elif is_bool_dtype(x):
-        dtype = x.dtype
+        # GH 20303: coerce bool dtype to int 
+        x = x.astype(np.int64)
+        dtype = np.bool_
 
     if dtype is not None:
-        if is_bool_dtype(x):
-            # GH 20303: coerce bool to int
-            x = np.where(np.isnan(x), np.nan, x.astype(int))
-        else:
-            # GH 19768: force NaT to NaN during integer conversion
-            x = np.where(x.notna(), x.view(np.int64), np.nan)
+        # GH 19768: force NaT to NaN during integer conversion
+        x = np.where(notna(x), x.view(np.int64), np.nan)
 
     return x, dtype
 

--- a/pandas/tests/reshape/test_tile.py
+++ b/pandas/tests/reshape/test_tile.py
@@ -263,15 +263,26 @@ class TestCut(object):
         expected = Categorical(intervals, ordered=True)
         tm.assert_categorical_equal(result, expected)
 
-    def test_qcut_bool_coercion_to_int(self):
-        # issue 20303
-        arr = np.random.randint(2, size=100)
-        bool_arr = arr.astype(bool)
+    def test_qcut_bool_array_to_int(self):
+        # GH 20303
+        arr = Series(np.random.randint(2, size=100))
         bins = 6
 
-        exp = qcut(arr, bins, duplicates='drop')
-        result = qcut(bool_arr, bins, duplicates='drop')
-        tm.assert_categorical_equal(result, exp)
+        expected = qcut(arr, bins, duplicates='drop')
+
+        data = arr.astype(bool)
+        result = qcut(data, bins, duplicates='drop')
+        tm.assert_series_equal(result, expected)
+
+    def test_qcut_bool_series_to_int(self):
+        arr = np.random.randint(2, size=100)
+        bins = 6
+
+        expected = qcut(arr, bins, duplicates='drop')
+
+        data = arr.astype(bool)
+        result = qcut(data, bins, duplicates='drop')
+        tm.assert_categorical_equal(result, expected)
 
     def test_round_frac(self):
         # it works

--- a/pandas/tests/reshape/test_tile.py
+++ b/pandas/tests/reshape/test_tile.py
@@ -263,24 +263,24 @@ class TestCut(object):
         expected = Categorical(intervals, ordered=True)
         tm.assert_categorical_equal(result, expected)
 
-    def test_qcut_bool_array_to_int(self):
+    def test_qcut_bool_series_to_int(self):
         # GH 20303
-        arr = Series(np.random.randint(2, size=100))
+        x = Series(np.random.randint(2, size=100))
         bins = 6
 
-        expected = qcut(arr, bins, duplicates='drop')
+        expected = qcut(x, bins, duplicates='drop')
 
-        data = arr.astype(bool)
+        data = x.astype(bool)
         result = qcut(data, bins, duplicates='drop')
         tm.assert_series_equal(result, expected)
 
-    def test_qcut_bool_series_to_int(self):
-        arr = np.random.randint(2, size=100)
+    def test_qcut_bool_array_to_int(self):
+        x = np.random.randint(2, size=100)
         bins = 6
 
         expected = qcut(arr, bins, duplicates='drop')
 
-        data = arr.astype(bool)
+        data = x.astype(bool)
         result = qcut(data, bins, duplicates='drop')
         tm.assert_categorical_equal(result, expected)
 

--- a/pandas/tests/reshape/test_tile.py
+++ b/pandas/tests/reshape/test_tile.py
@@ -263,6 +263,16 @@ class TestCut(object):
         expected = Categorical(intervals, ordered=True)
         tm.assert_categorical_equal(result, expected)
 
+    def test_qcut_bool_coercion_to_int(self):
+        # issue 20303
+        arr = np.random.randint(2, size=100) 
+        bool_arr = arr.astype(bool)
+        bins = 6
+
+        exp = qcut(arr, bins, duplicates='drop')
+        result = qcut(bool_arr, bins, duplicates='drop')
+        tm.assert_categorical_equal(result, exp)
+
     def test_round_frac(self):
         # it works
         result = cut(np.arange(11.), 2)

--- a/pandas/tests/reshape/test_tile.py
+++ b/pandas/tests/reshape/test_tile.py
@@ -265,7 +265,7 @@ class TestCut(object):
 
     def test_qcut_bool_coercion_to_int(self):
         # issue 20303
-        arr = np.random.randint(2, size=100) 
+        arr = np.random.randint(2, size=100)
         bool_arr = arr.astype(bool)
         bins = 6
 


### PR DESCRIPTION

- [x] closes #20303 
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry

Currently, passing a `dtype('bool')` `ndarray` or `Series` as argument to `qcut` raises a `TypeError`.  As was suggested in #20303, now `_coerce_to_type` also coerces `bool` types to `int`. 