### PR TITLE
Fix Series construction with dtype=str

### DIFF
--- a/doc/source/whatsnew/v0.23.0.txt
+++ b/doc/source/whatsnew/v0.23.0.txt
@@ -714,7 +714,6 @@ Other API Changes
 - ``pd.to_datetime('today')`` now returns a datetime, consistent with ``pd.Timestamp('today')``; previously ``pd.to_datetime('today')`` returned a ``.normalized()`` datetime (:issue:`19935`)
 - :func:`Series.str.replace` now takes an optional `regex` keyword which, when set to ``False``, uses literal string replacement rather than regex replacement (:issue:`16808`)
 - :func:`DatetimeIndex.strftime` and :func:`PeriodIndex.strftime` now return an ``Index`` instead of a numpy array to be consistent with similar accessors (:issue:`20127`)
-``Series`` construction with a ``string``, ``dtype=str`` specified, and ``index`` specified will now return an ``object`` dtyped ``Series``, previously this would raise an AttributeError (:issue:`19853`)
 
 .. _whatsnew_0230.deprecations:
 
@@ -1033,6 +1032,7 @@ Reshaping
 - Bug in :class:`Series` constructor with ``Categorical`` where a ```ValueError`` is not raised when an index of different length is given (:issue:`19342`)
 - Bug in :meth:`DataFrame.astype` where column metadata is lost when converting to categorical or a dictionary of dtypes (:issue:`19920`)
 - Bug in :func:`cut` and :func:`qcut` where timezone information was dropped (:issue:`19872`)
+- Bug in :class:`Series` constructor with a ``dtype=str``, previously raised in some cases (:issue:`19853`)
 
 Other
 ^^^^^

--- a/doc/source/whatsnew/v0.23.0.txt
+++ b/doc/source/whatsnew/v0.23.0.txt
@@ -714,6 +714,7 @@ Other API Changes
 - ``pd.to_datetime('today')`` now returns a datetime, consistent with ``pd.Timestamp('today')``; previously ``pd.to_datetime('today')`` returned a ``.normalized()`` datetime (:issue:`19935`)
 - :func:`Series.str.replace` now takes an optional `regex` keyword which, when set to ``False``, uses literal string replacement rather than regex replacement (:issue:`16808`)
 - :func:`DatetimeIndex.strftime` and :func:`PeriodIndex.strftime` now return an ``Index`` instead of a numpy array to be consistent with similar accessors (:issue:`20127`)
+``Series`` construction with a ``string``, ``dtype=str`` specified, and ``index`` specified will now return an ``object`` dtyped ``Series``, previously this would raise an AttributeError (:issue:`19853`)
 
 .. _whatsnew_0230.deprecations:
 

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -4059,9 +4059,14 @@ def _sanitize_array(data, index, dtype=None, copy=False,
     if issubclass(subarr.dtype.type, compat.string_types):
         # GH 16605
         # If not empty convert the data to dtype
-        if not isna(data).all():
-            data = np.array(data, dtype=dtype, copy=False)
-
-        subarr = np.array(data, dtype=object, copy=copy)
+        try:
+            all_elements_na = isna(data).all()
+        except AttributeError:
+            # GH 19853: If data is a scalar, subarr has already the result
+            pass
+        else:
+            if not all_elements_na:
+                data = np.array(data, dtype=dtype, copy=False)
+            subarr = np.array(data, dtype=object, copy=copy)
 
     return subarr

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -4060,7 +4060,7 @@ def _sanitize_array(data, index, dtype=None, copy=False,
         # GH 16605
         # If not empty convert the data to dtype
         # GH 19853: If data is a scalar, subarr has already the result
-        if not np.isscalar(data):
+        if not is_scalar(data):
             if not np.all(isna(data)):
                 data = np.array(data, dtype=dtype, copy=False)
             subarr = np.array(data, dtype=object, copy=copy)

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -4059,13 +4059,9 @@ def _sanitize_array(data, index, dtype=None, copy=False,
     if issubclass(subarr.dtype.type, compat.string_types):
         # GH 16605
         # If not empty convert the data to dtype
-        try:
-            all_elements_na = isna(data).all()
-        except AttributeError:
-            # GH 19853: If data is a scalar, subarr has already the result
-            pass
-        else:
-            if not all_elements_na:
+        # GH 19853: If data is a scalar, subarr has already the result
+        if not np.isscalar(data):
+            if not np.all(isna(data)):
                 data = np.array(data, dtype=dtype, copy=False)
             subarr = np.array(data, dtype=object, copy=copy)
 

--- a/pandas/tests/series/test_constructors.py
+++ b/pandas/tests/series/test_constructors.py
@@ -110,6 +110,11 @@ class TestSeriesConstructors(TestData):
             empty2 = Series(input_class(), index=lrange(10), dtype='float64')
             assert_series_equal(empty, empty2)
 
+            # GH 19853 : with empty string, index and dtype str
+            empty = Series('', dtype='str', index=range(3))
+            assert empty.all() == ''
+            assert (empty == Series('', index=range(3))).all()
+
     @pytest.mark.parametrize('input_arg', [np.nan, float('nan')])
     def test_constructor_nan(self, input_arg):
         empty = Series(dtype='float64', index=lrange(10))

--- a/pandas/tests/series/test_constructors.py
+++ b/pandas/tests/series/test_constructors.py
@@ -111,9 +111,9 @@ class TestSeriesConstructors(TestData):
             assert_series_equal(empty, empty2)
 
             # GH 19853 : with empty string, index and dtype str
-            empty = Series('', dtype='str', index=range(3))
-            assert empty.all() == ''
-            assert (empty == Series('', index=range(3))).all()
+            empty = Series('', dtype=str, index=range(3))
+            empty2 = Series('', index=range(3))
+            assert_series_equal(empty, empty2)
 
     @pytest.mark.parametrize('input_arg', [np.nan, float('nan')])
     def test_constructor_nan(self, input_arg):


### PR DESCRIPTION
TST: Added test for construction Series with dtype=str 
BUG: Handles case where data is scalar 
DOC: added changes to whatsnew/v0.23.0.txt

Checklist for other PRs (remove this part if you are doing a PR for the pandas documentation sprint):

- [x] closes #19853
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry
