### PR TITLE
Named objs in asserts messages.

### DIFF
--- a/pandas/_libs/testing.pyx
+++ b/pandas/_libs/testing.pyx
@@ -156,8 +156,8 @@ cpdef assert_almost_equal(a, b,
             else:
                 r = None
 
-            raise_assert_detail(obj, '{0} length are different'.format(join_obj(obj)),
-                                na, nb, r)
+            raise_assert_detail(obj, '{0} length are different'.format(
+                join_obj(obj)), na, nb, r)
 
         for i in xrange(len(a)):
             try:
@@ -169,8 +169,6 @@ cpdef assert_almost_equal(a, b,
 
         if is_unequal:
             from pandas.util.testing import raise_assert_detail, join_obj
-
-
 
             msg = '{0} values are different ({1} %)'.format(
                 join_obj(obj), np.round(diff * 100.0 / na, 5))

--- a/pandas/_libs/testing.pyx
+++ b/pandas/_libs/testing.pyx
@@ -3,6 +3,7 @@ import numpy as np
 from pandas import compat
 from pandas.core.dtypes.missing import isna, array_equivalent
 from pandas.core.dtypes.common import is_dtype_equal
+from pandas.core.common import _maybe_make_list
 
 cdef NUMERIC_TYPES = (
     bool,
@@ -129,9 +130,9 @@ cpdef assert_almost_equal(a, b,
         if a_is_ndarray and b_is_ndarray:
             na, nb = a.size, b.size
             if a.shape != b.shape:
-                from pandas.util.testing import raise_assert_detail
+                from pandas.util.testing import raise_assert_detail, join_obj
                 raise_assert_detail(
-                    obj, '{0} shapes are different'.format(obj),
+                    obj, '{0} shapes are different'.format(join_obj(obj)),
                     a.shape, b.shape)
 
             if check_dtype and not is_dtype_equal(a, b):
@@ -147,7 +148,7 @@ cpdef assert_almost_equal(a, b,
             na, nb = len(a), len(b)
 
         if na != nb:
-            from pandas.util.testing import raise_assert_detail
+            from pandas.util.testing import raise_assert_detail, join_obj
 
             # if we have a small diff set, print it
             if abs(na - nb) < 10:
@@ -155,7 +156,7 @@ cpdef assert_almost_equal(a, b,
             else:
                 r = None
 
-            raise_assert_detail(obj, '{0} length are different'.format(obj),
+            raise_assert_detail(obj, '{0} length are different'.format(join_obj(obj)),
                                 na, nb, r)
 
         for i in xrange(len(a)):
@@ -167,9 +168,12 @@ cpdef assert_almost_equal(a, b,
                 diff += 1
 
         if is_unequal:
-            from pandas.util.testing import raise_assert_detail
+            from pandas.util.testing import raise_assert_detail, join_obj
+
+
+
             msg = '{0} values are different ({1} %)'.format(
-                obj, np.round(diff * 100.0 / na, 5))
+                join_obj(obj), np.round(diff * 100.0 / na, 5))
             raise_assert_detail(obj, msg, lobj, robj)
 
         return True

--- a/pandas/tests/util/test_testing.py
+++ b/pandas/tests/util/test_testing.py
@@ -616,7 +616,8 @@ The Holy Grail and The Life of Brian values are different \\(33.33333 %\\)
 \\[The Life of Brian\\]: \\[0, 2, 3\\]"""
 
         with tm.assert_raises_regex(AssertionError, expected):
-            assert_series_equal(pd.Series([1, 2, 3]), pd.Series([0, 2, 3]), obj=('The Holy Grail', 'The Life of Brian'))
+            assert_series_equal(pd.Series([1, 2, 3]), pd.Series([0, 2, 3]),
+                                obj=('The Holy Grail', 'The Life of Brian'))
 
 
 class TestAssertFrameEqual(object):
@@ -730,7 +731,6 @@ DataFrame\\.blocks\\.iloc\\[:, 1\\] values are different \\(33\\.33333 %\\)
 Potato and Mushroom shape mismatch
 \\[Potato\\]:   \\(3, 2\\)
 \\[Mushroom\\]: \\(3, 1\\)"""
-
 
         with tm.assert_raises_regex(AssertionError, expected):
             assert_frame_equal(pd.DataFrame({'A': [1, 2, 3], 'B': [4, 5, 6]}),

--- a/pandas/tests/util/test_testing.py
+++ b/pandas/tests/util/test_testing.py
@@ -338,6 +338,19 @@ Iterable values are different \\(50\\.0 %\\)
         with tm.assert_raises_regex(AssertionError, expected):
             assert_almost_equal([1, 2], [1, 3])
 
+    def test_numpy_array_equal_message_named(self):
+        a = np.array([1, 2, 3])
+        b = np.array([0, 2, 3])
+
+        expected = """a and bee are different
+
+a and bee values are different \\(33.33333 %\\)
+\\[a\\]:   \\[1, 2, 3\\]
+\\[bee\\]: \\[0, 2, 3\\]"""
+
+        with tm.assert_raises_regex(AssertionError, expected):
+            assert_numpy_array_equal(a, b, obj=('a', 'bee'))
+
 
 class TestAssertIndexEqual(object):
 
@@ -487,6 +500,19 @@ Attribute "names" are different
         with tm.assert_raises_regex(AssertionError, expected):
             assert_index_equal(idx1, idx2)
 
+    def test_index_equal_message_named(self):
+
+        expected = """Index1 and Idx2 are different
+
+Index1 and Idx2 values are different \\(33.33333 %\\)
+\\[Index1\\]: Int64Index\\(\\[1, 2, 3\\], dtype='int64'\\)
+\\[Idx2\\]:   Int64Index\\(\\[0, 2, 3\\], dtype='int64'\\)"""
+
+        idx1 = pd.Index([1, 2, 3])
+        idx2 = pd.Index([0, 2, 3])
+        with tm.assert_raises_regex(AssertionError, expected):
+            assert_index_equal(idx1, idx2, obj=('Index1', 'Idx2'))
+
 
 class TestAssertSeriesEqual(object):
 
@@ -580,6 +606,17 @@ Series values are different \\(33\\.33333 %\\)
         with tm.assert_raises_regex(AssertionError, expected):
             assert_series_equal(pd.Series([1, 2, 3]), pd.Series([1, 2, 4]),
                                 check_less_precise=True)
+
+    def test_series_equal_message_named(self):
+
+        expected = """The Holy Grail and The Life of Brian are different
+
+The Holy Grail and The Life of Brian values are different \\(33.33333 %\\)
+\\[The Holy Grail\\]:    \\[1, 2, 3\\]
+\\[The Life of Brian\\]: \\[0, 2, 3\\]"""
+
+        with tm.assert_raises_regex(AssertionError, expected):
+            assert_series_equal(pd.Series([1, 2, 3]), pd.Series([0, 2, 3]), obj=('The Holy Grail', 'The Life of Brian'))
 
 
 class TestAssertFrameEqual(object):
@@ -686,6 +723,20 @@ DataFrame\\.blocks\\.iloc\\[:, 1\\] values are different \\(33\\.33333 %\\)
                                pd.DataFrame({'A': [1, 2, 3], 'B': [4, 5, 7]}),
                                by_blocks=True)
 
+    def test_frame_equal_message_named(self):
+
+        expected = """Potato and Mushroom are different
+
+Potato and Mushroom shape mismatch
+\\[Potato\\]:   \\(3, 2\\)
+\\[Mushroom\\]: \\(3, 1\\)"""
+
+
+        with tm.assert_raises_regex(AssertionError, expected):
+            assert_frame_equal(pd.DataFrame({'A': [1, 2, 3], 'B': [4, 5, 6]}),
+                               pd.DataFrame({'A': [1, 2, 3]}),
+                               obj=('Potato', 'Mushroom'))
+
 
 class TestAssertCategoricalEqual(object):
 
@@ -723,6 +774,19 @@ Attribute "ordered" are different
         b = pd.Categorical([1, 2, 3, 4], ordered=True)
         with tm.assert_raises_regex(AssertionError, expected):
             tm.assert_categorical_equal(a, b)
+
+    def test_categorical_equal_message_named(self):
+
+        expected = """Blue.categories and Red.categories are different
+
+Blue.categories and Red.categories values are different \\(25.0 %\\)
+\\[Blue.categories\\]: Int64Index\\(\\[1, 2, 3, 4\\], dtype='int64'\\)
+\\[Red.categories\\]:  Int64Index\\(\\[1, 2, 3, 5\\], dtype='int64'\\)"""
+
+        a = pd.Categorical([1, 2, 3, 4])
+        b = pd.Categorical([1, 2, 3, 5])
+        with tm.assert_raises_regex(AssertionError, expected):
+            tm.assert_categorical_equal(a, b, obj=('Blue', 'Red'))
 
 
 class TestRNGContext(object):

--- a/pandas/tests/util/test_testing.py
+++ b/pandas/tests/util/test_testing.py
@@ -356,9 +356,9 @@ Index levels are different
         with tm.assert_raises_regex(AssertionError, expected):
             assert_index_equal(idx1, idx2, exact=False)
 
-        expected = """MultiIndex level \\[1\\] are different
+        expected = """Index MultiIndex level \\[1\\] are different
 
-MultiIndex level \\[1\\] values are different \\(25\\.0 %\\)
+Index MultiIndex level \\[1\\] values are different \\(25\\.0 %\\)
 \\[left\\]:  Int64Index\\(\\[2, 2, 3, 4\\], dtype='int64'\\)
 \\[right\\]: Int64Index\\(\\[1, 2, 3, 4\\], dtype='int64'\\)"""
 
@@ -366,8 +366,10 @@ MultiIndex level \\[1\\] values are different \\(25\\.0 %\\)
                                           ('B', 3), ('B', 4)])
         idx2 = pd.MultiIndex.from_tuples([('A', 1), ('A', 2),
                                           ('B', 3), ('B', 4)])
+
         with tm.assert_raises_regex(AssertionError, expected):
             assert_index_equal(idx1, idx2)
+
         with tm.assert_raises_regex(AssertionError, expected):
             assert_index_equal(idx1, idx2, check_exact=False)
 
@@ -440,9 +442,9 @@ Index values are different \\(33\\.33333 %\\)
         with tm.assert_raises_regex(AssertionError, expected):
             assert_index_equal(idx1, idx2, check_less_precise=True)
 
-        expected = """MultiIndex level \\[1\\] are different
+        expected = """Index MultiIndex level \\[1\\] are different
 
-MultiIndex level \\[1\\] values are different \\(25\\.0 %\\)
+Index MultiIndex level \\[1\\] values are different \\(25\\.0 %\\)
 \\[left\\]:  Int64Index\\(\\[2, 2, 3, 4\\], dtype='int64'\\)
 \\[right\\]: Int64Index\\(\\[1, 2, 3, 4\\], dtype='int64'\\)"""
 

--- a/pandas/tests/util/test_testing.py
+++ b/pandas/tests/util/test_testing.py
@@ -673,6 +673,12 @@ DataFrame\\.iloc\\[:, 1\\] values are different \\(33\\.33333 %\\)
             assert_frame_equal(pd.DataFrame({'A': [1, 2, 3], 'B': [4, 5, 6]}),
                                pd.DataFrame({'A': [1, 2, 3], 'B': [4, 5, 7]}))
 
+        expected = """DataFrame\\.blocks\\.iloc\\[:, 1\\] are different
+
+DataFrame\\.blocks\\.iloc\\[:, 1\\] values are different \\(33\\.33333 %\\)
+\\[left\\]:  \\[4, 5, 6\\]
+\\[right\\]: \\[4, 5, 7\\]"""
+
         with tm.assert_raises_regex(AssertionError, expected):
             assert_frame_equal(pd.DataFrame({'A': [1, 2, 3], 'B': [4, 5, 6]}),
                                pd.DataFrame({'A': [1, 2, 3], 'B': [4, 5, 7]}),

--- a/pandas/util/testing.py
+++ b/pandas/util/testing.py
@@ -1305,7 +1305,7 @@ def assert_frame_equal(left, right, check_dtype=True,
     # shape comparison
     if left.shape != right.shape:
         raise_assert_detail(obj,
-                            'DataFrame shape mismatch',
+                            '{obj} shape mismatch'.format(obj=join_obj(obj)),
                             '{shape!r}'.format(shape=left.shape),
                             '{shape!r}'.format(shape=right.shape))
 

--- a/pandas/util/testing.py
+++ b/pandas/util/testing.py
@@ -47,7 +47,6 @@ from pandas import (bdate_range, CategoricalIndex, Categorical, IntervalIndex,
 from pandas._libs import testing as _testing
 from pandas.io.common import urlopen
 
-
 N = 30
 K = 4
 _RAISE_NETWORK_ERROR_DEFAULT = False
@@ -297,7 +296,6 @@ def _check_isinstance(left, right, cls):
 
 
 def assert_dict_equal(left, right, compare_keys=True):
-
     _check_isinstance(left, right, dict)
     return _testing.assert_dict_equal(left, right, compare_keys=compare_keys)
 
@@ -464,7 +462,7 @@ def get_locales(prefix=None, normalize=True,
         return _valid_locales(out_locales, normalize)
 
     found = re.compile('{prefix}.*'.format(prefix=prefix)) \
-              .findall('\n'.join(out_locales))
+        .findall('\n'.join(out_locales))
     return _valid_locales(found, normalize)
 
 
@@ -547,6 +545,7 @@ def _valid_locales(locales, normalize):
         normalizer = lambda x: x.strip()
 
     return list(filter(_can_set_locale, map(normalizer, locales)))
+
 
 # -----------------------------------------------------------------------------
 # Stdout / stderr decorators
@@ -647,6 +646,7 @@ def capture_stderr(f):
 
     return wrapper
 
+
 # -----------------------------------------------------------------------------
 # Console debugging tools
 
@@ -675,6 +675,7 @@ def set_trace():
     except Exception:
         from pdb import Pdb as OldPdb
         OldPdb().set_trace(sys._getframe().f_back)
+
 
 # -----------------------------------------------------------------------------
 # contextmanager to ensure the file cleanup
@@ -736,6 +737,7 @@ def get_data_path(f=''):
     _, filename, _, _, _, _ = inspect.getouterframes(inspect.currentframe())[1]
     base_dir = os.path.abspath(os.path.dirname(filename))
     return os.path.join(base_dir, 'data', f)
+
 
 # -----------------------------------------------------------------------------
 # Comparators
@@ -822,7 +824,8 @@ def assert_index_equal(left, right, exact='equiv', check_names=True,
             llevel = _get_ilevel_values(left, level)
             rlevel = _get_ilevel_values(right, level)
 
-            lobj = map_obj('{obj} MultiIndex level [{level}]', obj, level=level)
+            lobj = map_obj('{obj} MultiIndex level [{level}]', obj,
+                           level=level)
             assert_index_equal(llevel, rlevel,
                                exact=exact, check_names=check_names,
                                check_less_precise=check_less_precise,
@@ -889,7 +892,8 @@ def assert_class_equal(left, right, exact=True, obj='Input'):
             # allow equivalence of Int64Index/RangeIndex
             types = set([type(left).__name__, type(right).__name__])
             if len(types - set(['Int64Index', 'RangeIndex'])):
-                msg = '{obj} classes are not equivalent'.format(obj=join_obj(obj))
+                msg = '{obj} classes are not equivalent'.format(
+                    obj=join_obj(obj))
                 raise_assert_detail(obj, msg, repr_class(left),
                                     repr_class(right))
     elif exact:
@@ -962,7 +966,8 @@ def is_sorted(seq, obj='seq'):
     if isinstance(seq, (Index, Series)):
         seq = seq.values
     # sorting does not change precisions
-    return assert_numpy_array_equal(seq, np.sort(np.array(seq)), obj=(obj, 'sorted({})'.format(obj)))
+    return assert_numpy_array_equal(seq, np.sort(np.array(seq)),
+                                    obj=(obj, 'sorted({})'.format(obj)))
 
 
 def assert_categorical_equal(left, right, check_dtype=True,
@@ -1011,7 +1016,6 @@ def assert_categorical_equal(left, right, check_dtype=True,
 
 
 def raise_assert_detail(obj, message, left, right, diff=None):
-
     obj = com._maybe_make_list(obj)
 
     if len(obj) >= 2:
@@ -1021,7 +1025,6 @@ def raise_assert_detail(obj, message, left, right, diff=None):
 
     names_formatted = list(map(lambda x: '[{}]:'.format(x), names))
     max_len = max(map(len, names_formatted))
-
 
     if isinstance(left, np.ndarray):
         left = pprint_thing(left)
@@ -1036,7 +1039,9 @@ def raise_assert_detail(obj, message, left, right, diff=None):
 
 {message}
 {names[0]:<{max_len}} {left}
-{names[1]:<{max_len}} {right}""".format(obj=join_obj(obj), message=message, left=left, right=right, names=names_formatted, max_len=max_len)
+{names[1]:<{max_len}} {right}""".format(obj=join_obj(obj), message=message,
+                                        left=left, right=right,
+                                        names=names_formatted, max_len=max_len)
 
     if diff is not None:
         msg += "\n[diff]: {diff}".format(diff=diff)
@@ -1095,7 +1100,8 @@ def assert_numpy_array_equal(left, right, strict_nan=False,
         if err_msg is None:
             if left.shape != right.shape:
                 raise_assert_detail(obj, '{obj} shapes are different'
-                                    .format(obj=join_obj(obj)), left.shape, right.shape)
+                                    .format(obj=join_obj(obj)), left.shape,
+                                    right.shape)
 
             diff = 0
             for l, r in zip(left, right):
@@ -1199,14 +1205,14 @@ def assert_series_equal(left, right, check_dtype=True,
     if check_exact:
         assert_numpy_array_equal(left.get_values(), right.get_values(),
                                  check_dtype=check_dtype,
-                                 obj=map_obj('{obj}', obj),)
+                                 obj=map_obj('{obj}', obj), )
     elif check_datetimelike_compat:
         # we want to check only if we have compat dtypes
         # e.g. integer and M|m are NOT compat, but we can simply check
         # the values in that case
         if (is_datetimelike_v_numeric(left, right) or
-            is_datetimelike_v_object(left, right) or
-            needs_i8_conversion(left) or
+                is_datetimelike_v_object(left, right) or
+                needs_i8_conversion(left) or
                 needs_i8_conversion(right)):
 
             # datetimelike may have different objects (e.g. datetime.datetime
@@ -1336,7 +1342,8 @@ def assert_frame_equal(left, right, check_dtype=True,
             assert dtype in lblocks
             assert dtype in rblocks
             assert_frame_equal(lblocks[dtype], rblocks[dtype],
-                               check_dtype=check_dtype, obj=map_obj('{obj}.blocks', obj))
+                               check_dtype=check_dtype,
+                               obj=map_obj('{obj}.blocks', obj))
 
     # compare by columns
     else:
@@ -1546,6 +1553,7 @@ def assert_sp_frame_equal(left, right, check_dtype=True, exact_indices=True,
     for col in right:
         assert (col in left)
 
+
 # -----------------------------------------------------------------------------
 # Others
 
@@ -1614,7 +1622,7 @@ def makeIntIndex(k=10, name=None):
 
 
 def makeUIntIndex(k=10, name=None):
-    return Index([2**63 + i for i in lrange(k)], name=name)
+    return Index([2 ** 63 + i for i in lrange(k)], name=name)
 
 
 def makeRangeIndex(k=10, name=None, **kwargs):
@@ -2099,8 +2107,8 @@ _network_errno_vals = (
     111,  # Connection refused
     110,  # Connection timed out
     104,  # Connection reset Error
-    54,   # Connection reset by peer
-    60,   # urllib.error.URLError: [Errno 60] Connection timed out
+    54,  # Connection reset by peer
+    60,  # urllib.error.URLError: [Errno 60] Connection timed out
 )
 
 # Both of the above shouldn't mask real issues such as 404's
@@ -2273,7 +2281,6 @@ with_connectivity_check = network
 
 
 class SimpleMock(object):
-
     """
     Poor man's mocking object
 
@@ -2289,7 +2296,7 @@ class SimpleMock(object):
     """
 
     def __init__(self, obj, *args, **kwds):
-        assert(len(args) % 2 == 0)
+        assert (len(args) % 2 == 0)
         attrs = kwds.get("attrs", {})
         for k, v in zip(args[::2], args[1::2]):
             # dict comprehensions break 2.6
@@ -2575,12 +2582,10 @@ class RNGContext(object):
         self.seed = seed
 
     def __enter__(self):
-
         self.start_state = np.random.get_state()
         np.random.seed(self.seed)
 
     def __exit__(self, exc_type, exc_value, traceback):
-
         np.random.set_state(self.start_state)
 
 
@@ -2642,7 +2647,9 @@ def test_parallel(num_threads=2, kwargs_list=None):
                 thread.start()
             for thread in threads:
                 thread.join()
+
         return inner
+
     return wrapper
 
 

--- a/pandas/util/testing.py
+++ b/pandas/util/testing.py
@@ -770,8 +770,8 @@ def assert_index_equal(left, right, exact='equiv', check_names=True,
         Whether to compare number exactly.
     check_categorical : bool, default True
         Whether to compare internal Categorical exactly.
-    obj : str, default 'Index'
-        Specify object name being compared, internally used to show appropriate
+    obj : str or 2-length sequence (tuple, list, ...), default 'Index'
+        Specify object(s) name(s) being compared, used to show appropriate
         assertion message
     """
 
@@ -908,8 +908,8 @@ def assert_attr_equal(attr, left, right, obj='Attributes'):
         Attribute name being compared.
     left : object
     right : object
-    obj : str, default 'Attributes'
-        Specify object name being compared, internally used to show appropriate
+    obj : str or 2-length sequence (tuple, list, ...), default 'Attributes'
+        Specify object(s) name(s) being compared, used to show appropriate
         assertion message
     """
 
@@ -975,8 +975,8 @@ def assert_categorical_equal(left, right, check_dtype=True,
         Categoricals to compare
     check_dtype : bool, default True
         Check that integer dtype of the codes are the same
-    obj : str, default 'Categorical'
-        Specify object name being compared, internally used to show appropriate
+    obj : str or 2-length sequence (tuple, list, ...), default 'Categorical'
+        Specify object(s) name(s) being compared, used to show appropriate
         assertion message
     check_category_order : bool, default True
         Whether the order of the categories should be compared, which
@@ -1059,8 +1059,8 @@ def assert_numpy_array_equal(left, right, strict_nan=False,
         check dtype if both a and b are np.ndarray
     err_msg : str, default None
         If provided, used as assertion message
-    obj : str, default 'numpy array'
-        Specify object name being compared, internally used to show appropriate
+    obj : str or 2-length sequence (tuple, list, ...), default 'numpy array'
+        Specify object(s) name(s) being compared, used to show appropriate
         assertion message
     check_same : None|'copy'|'same', default None
         Ensure left and right refer/do not refer to the same memory area
@@ -1156,8 +1156,8 @@ def assert_series_equal(left, right, check_dtype=True,
         Compare datetime-like which is comparable ignoring dtype.
     check_categorical : bool, default True
         Whether to compare internal Categorical exactly.
-    obj : str, default 'Series'
-        Specify object name being compared, internally used to show appropriate
+    obj : str or 2-length sequence (tuple, list, ...), default 'Series'
+        Specify object(s) name(s) being compared, used to show appropriate
         assertion message
     """
 
@@ -1286,8 +1286,8 @@ def assert_frame_equal(left, right, check_dtype=True,
         Whether to compare internal Categorical exactly.
     check_like : bool, default False
         If true, ignore the order of rows & columns
-    obj : str, default 'DataFrame'
-        Specify object name being compared, internally used to show appropriate
+    obj : str or 2-length sequence (tuple, list, ...), default 'DataFrame'
+        Specify object(s) name(s) being compared, used to show appropriate
         assertion message
     """
 

--- a/pandas/util/testing.py
+++ b/pandas/util/testing.py
@@ -822,7 +822,7 @@ def assert_index_equal(left, right, exact='equiv', check_names=True,
             llevel = _get_ilevel_values(left, level)
             rlevel = _get_ilevel_values(right, level)
 
-            lobj = 'MultiIndex level [{level}]'.format(level=level)
+            lobj = map_obj('{obj} MultiIndex level [{level}]', obj, level=level)
             assert_index_equal(llevel, rlevel,
                                exact=exact, check_names=check_names,
                                check_less_precise=check_less_precise,
@@ -1012,7 +1012,7 @@ def assert_categorical_equal(left, right, check_dtype=True,
 
 def raise_assert_detail(obj, message, left, right, diff=None):
 
-    # obj = com._maybe_make_list(obj)
+    obj = com._maybe_make_list(obj)
 
     if len(obj) >= 2:
         names = obj[:2]


### PR DESCRIPTION

### Feature
---

Ability to name objects being passed into `pandas.util.testing.assert_<type>_equal()` statements to allow for more helpful error messages Via the `obj` parameter.

#### Example:

```python
a = pd.Index([1, 2, 3, 4])
b = pd.Index([1, 2, 3, 5])

testing.assert_index_equal(a, b, obj=('Red', 'Blue'))
```
#### Output:
```diff
- AssertionError: Red and Blue are different
- 
- Red and Blue values are different (25.0 %)
- [Red]:  Int64Index([1, 2, 3, 4], dtype='int64')
- [Blue]: Int64Index([1, 2, 3, 5], dtype='int64')
```
---
However, messages & are still kept in tact.  For instance if I do a equal on two Dataframes with different values & pass in the names it will still append `.iloc[:, <idx>]` as shown:

#### Example:
```python
df1 = pd.DataFrame({'A': [1, 2, 3], 'B': [4, 5, 6]}, index=['a', 'b', 'c'])
df2 = pd.DataFrame({'A': [1, 2, 3], 'B': [6, 5, 4]}, index=['a', 'b', 'c'])

testing.assert_frame_equal(df1, df2, obj=('df1', 'df2'))
```
#### Output:
```diff
- AssertionError: df1.iloc[:, 1] and df2.iloc[:, 1] are different
- 
- df1.iloc[:, 1] and df2.iloc[:, 1] values are different (66.66667 %)
- [df1.iloc[:, 1]]: [4, 5, 6]
- [df2.iloc[:, 1]]: [6, 5, 4]
```
---
But, if this is undesired or unneeded, the default names, `('left', 'right')`, still persists.  As shown:

#### Example:
```python
testing.assert_index_equal(a, b)
```
#### Output:
```diff
- AssertionError: Index are different
- 
- Index values are different (25.0 %)
- [left]:  Int64Index([1, 2, 3, 4], dtype='int64')
- [right]: Int64Index([1, 2, 3, 5], dtype='int64')
```

It should be noted where were a _few_ cases where I had to change the default messages due to some hard-coded messages, I've updated the tests for those specific cases.  **but** if for some reason someone has something that relies on those messages being exactly what they were they will now break.

---
Checklist for other PRs:

- [x] closes #xxxx (N/A)
- [x] tests added / passed*
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

\* There were 4 unrelated tests that were failing on upstream/master & those 4 still fail, but all the tests related to the files I edit still pass.