### PR TITLE
Bug: Allow np.timedelta64 objects to index TimedeltaIndex

### DIFF
--- a/doc/source/whatsnew/v0.23.0.txt
+++ b/doc/source/whatsnew/v0.23.0.txt
@@ -871,6 +871,7 @@ Datetimelike
 - Bug in :func:`to_datetime` where passing an out-of-bounds datetime with ``errors='coerce'`` and ``utc=True`` would raise ``OutOfBoundsDatetime`` instead of parsing to ``NaT`` (:issue:`19612`)
 - Bug in :class:`DatetimeIndex` and :class:`TimedeltaIndex` addition and subtraction where name of the returned object was not always set consistently. (:issue:`19744`)
 - Bug in :class:`DatetimeIndex` and :class:`TimedeltaIndex` addition and subtraction where operations with numpy arrays raised ``TypeError`` (:issue:`19847`)
+- Bug in :class:`TimedeltaIndex` when slicing with a ``np.timedelta64`` object would raise a ``TypeError`` (:issue:`20393`)
 
 Timedelta
 ^^^^^^^^^

--- a/doc/source/whatsnew/v0.23.0.txt
+++ b/doc/source/whatsnew/v0.23.0.txt
@@ -871,7 +871,7 @@ Datetimelike
 - Bug in :func:`to_datetime` where passing an out-of-bounds datetime with ``errors='coerce'`` and ``utc=True`` would raise ``OutOfBoundsDatetime`` instead of parsing to ``NaT`` (:issue:`19612`)
 - Bug in :class:`DatetimeIndex` and :class:`TimedeltaIndex` addition and subtraction where name of the returned object was not always set consistently. (:issue:`19744`)
 - Bug in :class:`DatetimeIndex` and :class:`TimedeltaIndex` addition and subtraction where operations with numpy arrays raised ``TypeError`` (:issue:`19847`)
-- Bug in :class:`TimedeltaIndex` when slicing with a ``np.timedelta64`` object would raise a ``TypeError`` (:issue:`20393`)
+- Bug in :class:`TimedeltaIndex` when indexing with a ``np.timedelta64`` object would raise a ``TypeError`` (:issue:`20393`)
 
 Timedelta
 ^^^^^^^^^

--- a/doc/source/whatsnew/v0.23.0.txt
+++ b/doc/source/whatsnew/v0.23.0.txt
@@ -871,7 +871,6 @@ Datetimelike
 - Bug in :func:`to_datetime` where passing an out-of-bounds datetime with ``errors='coerce'`` and ``utc=True`` would raise ``OutOfBoundsDatetime`` instead of parsing to ``NaT`` (:issue:`19612`)
 - Bug in :class:`DatetimeIndex` and :class:`TimedeltaIndex` addition and subtraction where name of the returned object was not always set consistently. (:issue:`19744`)
 - Bug in :class:`DatetimeIndex` and :class:`TimedeltaIndex` addition and subtraction where operations with numpy arrays raised ``TypeError`` (:issue:`19847`)
-- Bug in :class:`TimedeltaIndex` when indexing with a ``np.timedelta64`` object would raise a ``TypeError`` (:issue:`20393`)
 
 Timedelta
 ^^^^^^^^^
@@ -888,7 +887,8 @@ Timedelta
 - Bug in :func:`Timedelta.total_seconds()` causing precision errors i.e. ``Timedelta('30S').total_seconds()==30.000000000000004`` (:issue:`19458`)
 - Bug in :func: `Timedelta.__rmod__` where operating with a ``numpy.timedelta64`` returned a ``timedelta64`` object instead of a ``Timedelta`` (:issue:`19820`)
 - Multiplication of :class:`TimedeltaIndex` by ``TimedeltaIndex`` will now raise ``TypeError`` instead of raising ``ValueError`` in cases of length mis-match (:issue`19333`)
--
+- Bug in indexing a :class:`TimedeltaIndex` with a ``np.timedelta64`` object which was raising a ``TypeError`` (:issue:`20393`)
+
 
 Timezones
 ^^^^^^^^^

--- a/pandas/core/indexes/timedeltas.py
+++ b/pandas/core/indexes/timedeltas.py
@@ -819,6 +819,7 @@ class TimedeltaIndex(DatetimeIndexOpsMixin, TimelikeOps, Int64Index):
         label :  object
 
         """
+
         assert kind in ['ix', 'loc', 'getitem', None]
 
         if isinstance(label, compat.string_types):
@@ -829,7 +830,8 @@ class TimedeltaIndex(DatetimeIndexOpsMixin, TimelikeOps, Int64Index):
             else:
                 return (lbound + to_offset(parsed.resolution) -
                         Timedelta(1, 'ns'))
-        elif is_integer(label) or is_float(label):
+        elif ((is_integer(label) or is_float(label)) and
+              not is_timedelta64_dtype(label)):
             self._invalid_indexer('slice', label)
 
         return label

--- a/pandas/core/indexes/timedeltas.py
+++ b/pandas/core/indexes/timedeltas.py
@@ -819,7 +819,6 @@ class TimedeltaIndex(DatetimeIndexOpsMixin, TimelikeOps, Int64Index):
         label :  object
 
         """
-
         assert kind in ['ix', 'loc', 'getitem', None]
 
         if isinstance(label, compat.string_types):

--- a/pandas/tests/indexing/test_timedelta.py
+++ b/pandas/tests/indexing/test_timedelta.py
@@ -68,3 +68,15 @@ class TestTimedeltaIndexing(object):
         series.iloc[0] = value
         expected = pd.Series([pd.NaT, 1, 2], dtype='timedelta64[ns]')
         tm.assert_series_equal(series, expected)
+
+    @pytest.mark.parametrize('start,stop, expected_slice', [
+        [np.timedelta64(0, 'ns'), None, slice(0, 11)],
+        [np.timedelta64(1, 'D'), np.timedelta64(6, 'D'), slice(1, 7)],
+        [None, np.timedelta64(4, 'D'), slice(0, 5)]])
+    def test_numpy_timedelta_scalar_indexing(self, start, stop,
+                                             expected_slice):
+        # GH 20393
+        s = pd.Series(range(11), pd.timedelta_range('0 days', '10 days'))
+        result = s.loc[slice(start, stop)]
+        expected = s.iloc[expected_slice]
+        tm.assert_series_equal(result, expected)


### PR DESCRIPTION
- [x] closes #20393
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry

`is_integer(label)` would catch `np.timedelta64` objects due to https://github.com/numpy/numpy/issues/10685 (I believe), so ensure that the label is also not a timedelta64 dtype