### PR TITLE
BUG: dropna() on single column timezone-aware values (#13407)

### DIFF
--- a/doc/source/whatsnew/v0.23.0.txt
+++ b/doc/source/whatsnew/v0.23.0.txt
@@ -903,11 +903,12 @@ Timezones
 - :func:`Timestamp.replace` will now handle Daylight Savings transitions gracefully (:issue:`18319`)
 - Bug in tz-aware :class:`DatetimeIndex` where addition/subtraction with a :class:`TimedeltaIndex` or array with ``dtype='timedelta64[ns]'`` was incorrect (:issue:`17558`)
 - Bug in :func:`DatetimeIndex.insert` where inserting ``NaT`` into a timezone-aware index incorrectly raised (:issue:`16357`)
-- Bug in the :class:`DataFrame` constructor, where tz-aware Datetimeindex and a given column name will result in an empty ``DataFrame`` (:issue:`19157`)
+- Bug in :class:`DataFrame` constructor, where tz-aware Datetimeindex and a given column name will result in an empty ``DataFrame`` (:issue:`19157`)
 - Bug in :func:`Timestamp.tz_localize` where localizing a timestamp near the minimum or maximum valid values could overflow and return a timestamp with an incorrect nanosecond value (:issue:`12677`)
 - Bug when iterating over :class:`DatetimeIndex` that was localized with fixed timezone offset that rounded nanosecond precision to microseconds (:issue:`19603`)
 - Bug in :func:`DataFrame.diff` that raised an ``IndexError`` with tz-aware values (:issue:`18578`)
 - Bug in :func:`melt` that converted tz-aware dtypes to tz-naive (:issue:`15785`)
+- Bug in :func:`Dataframe.count` that raised an ``ValueError`` if .dropna() method is invoked for single column timezone-aware values. (:issue:`13407`)
 
 Offsets
 ^^^^^^^

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -6578,7 +6578,9 @@ class DataFrame(NDFrame):
                 # column frames with an extension array
                 result = notna(frame).sum(axis=axis)
             else:
-                counts = notna(frame.values).sum(axis=axis)
+                # GH13407
+                series_counts = notna(frame).sum(axis=axis)
+                counts = series_counts.values
                 result = Series(counts, index=frame._get_agg_axis(axis))
 
         return result.astype('int64')

--- a/pandas/tests/frame/test_missing.py
+++ b/pandas/tests/frame/test_missing.py
@@ -8,6 +8,9 @@ from distutils.version import LooseVersion
 from numpy import nan, random
 import numpy as np
 
+import datetime
+import dateutil
+
 from pandas.compat import lrange
 from pandas import (DataFrame, Series, Timestamp,
                     date_range, Categorical)
@@ -182,6 +185,26 @@ class TestDataFrameMissingData(TestData):
         inp = df.copy()
         inp.dropna(how='all', axis=(0, 1), inplace=True)
         assert_frame_equal(inp, expected)
+
+    def test_dropna_tz_aware_datetime(self):
+        # GH13407
+        df = DataFrame()
+        dt1 = datetime.datetime(2015, 1, 1,
+                                tzinfo=dateutil.tz.tzutc())
+        dt2 = datetime.datetime(2015, 2, 2,
+                                tzinfo=dateutil.tz.tzutc())
+        df['Time'] = [dt1]
+        result = df.dropna(axis=0)
+        expected = DataFrame({'Time': [dt1]})
+        assert_frame_equal(result, expected)
+
+        # Ex2
+        df = DataFrame({'Time': [dt1, None, np.nan, dt2]})
+        result = df.dropna(axis=0)
+        expected = DataFrame([dt1, dt2],
+                             columns=['Time'],
+                             index=[0, 3])
+        assert_frame_equal(result, expected)
 
     def test_fillna(self):
         tf = self.tsframe


### PR DESCRIPTION
- [x] closes #13407
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry

As mentioned by the title of #13407, DataFrame.values not a 2D-array when constructed from timezone-aware datetimes. Hence, ``notna(frame.values)`` raises ``ValueErorr: 'axis' entry is out of bounds`` because user tries to apply ``dropna`` on a 1D-array.

I mainly include the example mentioned by the original author of #13407. Let me know if further test examples are required for this issue. Thanks.

Edit: I add additional test example to demonstrate the dropping of np.nan and None from the Series having timezone-ware datetimes.