### PR TITLE
parameterize tests in scalar/timedelta

### DIFF
--- a/pandas/tests/scalar/timedelta/test_construction.py
+++ b/pandas/tests/scalar/timedelta/test_construction.py
@@ -195,17 +195,13 @@ def test_iso_constructor_raises(fmt):
         Timedelta(fmt)
 
 
-@pytest.mark.parametrize('constructed_td, conversion',
-                         [(Timedelta(nanoseconds=100), '100ns'),
-                          (Timedelta(days=1, hours=1, minutes=1, weeks=1,
-                                     seconds=1, milliseconds=1, microseconds=1,
-                                     nanoseconds=1), 694861001001001),
-                          (Timedelta(microseconds=1) +
-                           Timedelta(nanoseconds=1), '1us1ns'),
-                          (Timedelta(microseconds=1) -
-                           Timedelta(nanoseconds=1), '999ns'),
-                          (Timedelta(microseconds=1) +
-                           5 * Timedelta(nanoseconds=-2), '990ns')])
+@pytest.mark.parametrize('constructed_td, conversion', [
+    (Timedelta(nanoseconds=100), '100ns'),
+    (Timedelta(days=1, hours=1, minutes=1, weeks=1, seconds=1, milliseconds=1,
+               microseconds=1, nanoseconds=1), 694861001001001),
+    (Timedelta(microseconds=1) + Timedelta(nanoseconds=1), '1us1ns'),
+    (Timedelta(microseconds=1) - Timedelta(nanoseconds=1), '999ns'),
+    (Timedelta(microseconds=1) + 5 * Timedelta(nanoseconds=-2), '990ns')])
 def test_td_constructor_on_nanoseconds(constructed_td, conversion):
     # GH#9273
     assert constructed_td == Timedelta(conversion)

--- a/pandas/tests/scalar/timedelta/test_construction.py
+++ b/pandas/tests/scalar/timedelta/test_construction.py
@@ -210,5 +210,7 @@ def test_td_constructor_on_nanoseconds(constructed_td, conversion):
     # GH#9273
     assert constructed_td == Timedelta(conversion)
 
+
+def test_td_constructor_value_error():
     with pytest.raises(TypeError):
         Timedelta(nanoseconds='abc')

--- a/pandas/tests/scalar/timedelta/test_construction.py
+++ b/pandas/tests/scalar/timedelta/test_construction.py
@@ -195,28 +195,20 @@ def test_iso_constructor_raises(fmt):
         Timedelta(fmt)
 
 
-def test_td_constructor_on_nanoseconds():
+@pytest.mark.parametrize('constructed_td, conversion',
+                         [(Timedelta(nanoseconds=100), '100ns'),
+                          (Timedelta(days=1, hours=1, minutes=1, weeks=1,
+                                     seconds=1, milliseconds=1, microseconds=1,
+                                     nanoseconds=1), 694861001001001),
+                          (Timedelta(microseconds=1) +
+                           Timedelta(nanoseconds=1), '1us1ns'),
+                          (Timedelta(microseconds=1) -
+                           Timedelta(nanoseconds=1), '999ns'),
+                          (Timedelta(microseconds=1) +
+                           5 * Timedelta(nanoseconds=-2), '990ns')])
+def test_td_constructor_on_nanoseconds(constructed_td, conversion):
     # GH#9273
-    result = Timedelta(nanoseconds=100)
-    expected = Timedelta('100ns')
-    assert result == expected
-
-    result = Timedelta(days=1, hours=1, minutes=1, weeks=1, seconds=1,
-                       milliseconds=1, microseconds=1, nanoseconds=1)
-    expected = Timedelta(694861001001001)
-    assert result == expected
-
-    result = Timedelta(microseconds=1) + Timedelta(nanoseconds=1)
-    expected = Timedelta('1us1ns')
-    assert result == expected
-
-    result = Timedelta(microseconds=1) - Timedelta(nanoseconds=1)
-    expected = Timedelta('999ns')
-    assert result == expected
-
-    result = Timedelta(microseconds=1) + 5 * Timedelta(nanoseconds=-2)
-    expected = Timedelta('990ns')
-    assert result == expected
+    assert constructed_td == Timedelta(conversion)
 
     with pytest.raises(TypeError):
         Timedelta(nanoseconds='abc')

--- a/pandas/tests/scalar/timedelta/test_formats.py
+++ b/pandas/tests/scalar/timedelta/test_formats.py
@@ -1,48 +1,39 @@
 # -*- coding: utf-8 -*-
+import pytest
+
 from pandas import Timedelta
 
 
-def test_repr():
-    assert (repr(Timedelta(10, unit='d')) ==
-            "Timedelta('10 days 00:00:00')")
-    assert (repr(Timedelta(10, unit='s')) ==
-            "Timedelta('0 days 00:00:10')")
-    assert (repr(Timedelta(10, unit='ms')) ==
-            "Timedelta('0 days 00:00:00.010000')")
-    assert (repr(Timedelta(-10, unit='ms')) ==
-            "Timedelta('-1 days +23:59:59.990000')")
+@pytest.mark.parametrize('td, expected_repr',
+                         [(Timedelta(10, unit='d'),
+                           "Timedelta('10 days 00:00:00')"),
+                          (Timedelta(10, unit='s'),
+                           "Timedelta('0 days 00:00:10')"),
+                          (Timedelta(10, unit='ms'),
+                           "Timedelta('0 days 00:00:00.010000')"),
+                          (Timedelta(-10, unit='ms'),
+                           "Timedelta('-1 days +23:59:59.990000')")])
+def test_repr(td, expected_repr):
+    assert repr(td) == expected_repr
 
 
-def test_isoformat():
-    td = Timedelta(days=6, minutes=50, seconds=3,
-                   milliseconds=10, microseconds=10, nanoseconds=12)
-    expected = 'P6DT0H50M3.010010012S'
-    result = td.isoformat()
-    assert result == expected
-
-    td = Timedelta(days=4, hours=12, minutes=30, seconds=5)
-    result = td.isoformat()
-    expected = 'P4DT12H30M5S'
-    assert result == expected
-
-    td = Timedelta(nanoseconds=123)
-    result = td.isoformat()
-    expected = 'P0DT0H0M0.000000123S'
-    assert result == expected
-
-    # trim nano
-    td = Timedelta(microseconds=10)
-    result = td.isoformat()
-    expected = 'P0DT0H0M0.00001S'
-    assert result == expected
-
-    # trim micro
-    td = Timedelta(milliseconds=1)
-    result = td.isoformat()
-    expected = 'P0DT0H0M0.001S'
-    assert result == expected
-
-    # don't strip every 0
-    result = Timedelta(minutes=1).isoformat()
-    expected = 'P0DT0H1M0S'
-    assert result == expected
+@pytest.mark.parametrize('td, expected_iso',
+                         [(Timedelta(days=6, minutes=50, seconds=3,
+                                     milliseconds=10, microseconds=10,
+                                     nanoseconds=12),
+                           'P6DT0H50M3.010010012S'),
+                          (Timedelta(days=4, hours=12, minutes=30, seconds=5),
+                           'P4DT12H30M5S'),
+                          (Timedelta(nanoseconds=123),
+                           'P0DT0H0M0.000000123S'),
+                          # trim nano
+                          (Timedelta(microseconds=10),
+                           'P0DT0H0M0.00001S'),
+                          # trim micro
+                          (Timedelta(milliseconds=1),
+                           'P0DT0H0M0.001S'),
+                          # don't strip every 0
+                          (Timedelta(minutes=1),
+                           'P0DT0H1M0S')])
+def test_isoformat(td, expected_iso):
+    assert td.isoformat() == expected_iso

--- a/pandas/tests/scalar/timedelta/test_formats.py
+++ b/pandas/tests/scalar/timedelta/test_formats.py
@@ -4,36 +4,25 @@ import pytest
 from pandas import Timedelta
 
 
-@pytest.mark.parametrize('td, expected_repr',
-                         [(Timedelta(10, unit='d'),
-                           "Timedelta('10 days 00:00:00')"),
-                          (Timedelta(10, unit='s'),
-                           "Timedelta('0 days 00:00:10')"),
-                          (Timedelta(10, unit='ms'),
-                           "Timedelta('0 days 00:00:00.010000')"),
-                          (Timedelta(-10, unit='ms'),
-                           "Timedelta('-1 days +23:59:59.990000')")])
+@pytest.mark.parametrize('td, expected_repr', [
+    (Timedelta(10, unit='d'), "Timedelta('10 days 00:00:00')"),
+    (Timedelta(10, unit='s'), "Timedelta('0 days 00:00:10')"),
+    (Timedelta(10, unit='ms'), "Timedelta('0 days 00:00:00.010000')"),
+    (Timedelta(-10, unit='ms'), "Timedelta('-1 days +23:59:59.990000')")])
 def test_repr(td, expected_repr):
     assert repr(td) == expected_repr
 
 
-@pytest.mark.parametrize('td, expected_iso',
-                         [(Timedelta(days=6, minutes=50, seconds=3,
-                                     milliseconds=10, microseconds=10,
-                                     nanoseconds=12),
-                           'P6DT0H50M3.010010012S'),
-                          (Timedelta(days=4, hours=12, minutes=30, seconds=5),
-                           'P4DT12H30M5S'),
-                          (Timedelta(nanoseconds=123),
-                           'P0DT0H0M0.000000123S'),
-                          # trim nano
-                          (Timedelta(microseconds=10),
-                           'P0DT0H0M0.00001S'),
-                          # trim micro
-                          (Timedelta(milliseconds=1),
-                           'P0DT0H0M0.001S'),
-                          # don't strip every 0
-                          (Timedelta(minutes=1),
-                           'P0DT0H1M0S')])
+@pytest.mark.parametrize('td, expected_iso', [
+    (Timedelta(days=6, minutes=50, seconds=3, milliseconds=10, microseconds=10,
+               nanoseconds=12), 'P6DT0H50M3.010010012S'),
+    (Timedelta(days=4, hours=12, minutes=30, seconds=5), 'P4DT12H30M5S'),
+    (Timedelta(nanoseconds=123), 'P0DT0H0M0.000000123S'),
+    # trim nano
+    (Timedelta(microseconds=10), 'P0DT0H0M0.00001S'),
+    # trim micro
+    (Timedelta(milliseconds=1), 'P0DT0H0M0.001S'),
+    # don't strip every 0
+    (Timedelta(minutes=1), 'P0DT0H1M0S')])
 def test_isoformat(td, expected_iso):
     assert td.isoformat() == expected_iso


### PR DESCRIPTION
- [x] closes https://github.com/pandas-dev/pandas/issues/20426
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
