### PR TITLE
Add link to "Craft Minimal Bug Report" blogpost

### DIFF
--- a/doc/source/contributing.rst
+++ b/doc/source/contributing.rst
@@ -32,8 +32,9 @@ Bug reports and enhancement requests
 
 Bug reports are an important part of making *pandas* more stable. Having a complete bug report
 will allow others to reproduce the bug and provide insight into fixing. See
-`this stackoverflow article <https://stackoverflow.com/help/mcve>`_ for tips on
-writing a good bug report.
+`this stackoverflow article <https://stackoverflow.com/help/mcve>`_ and
+`this blogpost <http://matthewrocklin.com/blog/work/2018/02/28/minimal-bug-reports>`_
+for tips on writing a good bug report.
 
 Trying the bug-producing code out on the *master* branch is often a worthwhile exercise
 to confirm the bug still exists. It is also worth searching existing bug reports and pull requests


### PR DESCRIPTION
As requested in https://twitter.com/jreback/status/976242019864588294

This blogpost extends the MCVE documentation currently linked to in this
docpage with some do's and don'ts counter-examples.