### PR TITLE
BUG: Patch for skipping seek() when loading Excel files from url

### DIFF
--- a/pandas/io/excel.py
+++ b/pandas/io/excel.py
@@ -10,6 +10,7 @@ import os
 import abc
 import warnings
 import numpy as np
+from io import UnsupportedOperation
 
 from pandas.core.dtypes.common import (
     is_integer, is_float,
@@ -388,8 +389,13 @@ class ExcelFile(object):
         elif not isinstance(io, xlrd.Book) and hasattr(io, "read"):
             # N.B. xlrd.Book has a read attribute too
             if hasattr(io, 'seek'):
-                # GH 19779
-                io.seek(0)
+                try:
+                    # GH 19779
+                    io.seek(0)
+                except UnsupportedOperation:
+                    # HTTPResponse does not support seek()
+                    # GH 20434
+                    pass
 
             data = io.read()
             self.book = xlrd.open_workbook(file_contents=data)


### PR DESCRIPTION
- [x] closes #20434
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry

This is my first PR and I tried to follow the guideline. Sorry, if I overlooked something.
I don't have to add anything in whatsnew, because the bug isn't present in the current stable version 0.22, correct?