### PR TITLE
DOC: update the Series.between docstring

### DIFF
--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -3528,11 +3528,19 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
 
         Returns
         -------
-        is_between : Series
+        Series of bool
+
+        Notes
+        -----
+        This function is equivalent to `(left <= series) & (series <= right)`
+
+        See Also
+        --------
+        pandas.Series.gt : Greater than of series and other
+        pandas.Series.lt : Less than of series and other
 
         Examples
         --------
-
         >>> s = pd.Series([2, 0, 4, 8, np.nan])
 
         Boundary values are included by default:
@@ -3564,11 +3572,6 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
         2     True
         3    False
         dtype: bool
-
-        See Also
-        --------
-        DataFrame.query : Query the columns of a frame with a boolean
-            expression.
         """
         if inclusive:
             lmask = self >= left

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -3528,11 +3528,12 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
 
         Returns
         -------
-        Series of bool
+        Series
+            Each element will be a boolean.
 
         Notes
         -----
-        This function is equivalent to `(left <= series) & (series <= right)`
+        This function is equivalent to ``(left <= ser) & (ser <= right)``
 
         See Also
         --------
@@ -3553,7 +3554,7 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
         4    False
         dtype: bool
 
-        With `inclusive` set to `False` boundary values are excluded:
+        With `inclusive` set to ``False`` boundary values are excluded:
 
         >>> s.between(1, 4, inclusive=False)
         0     True

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -3511,19 +3511,64 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
 
     def between(self, left, right, inclusive=True):
         """
-        Return boolean Series equivalent to left <= series <= right. NA values
-        will be treated as False
+        Return boolean Series equivalent to left <= series <= right.
+
+        This function returns a boolean vector containing `True` wherever the
+        corresponding Series element is between the boundary values `left` and
+        `right`. NA values are treated as `False`.
 
         Parameters
         ----------
         left : scalar
-            Left boundary
+            Left boundary.
         right : scalar
-            Right boundary
+            Right boundary.
+        inclusive : bool, default True
+            Include boundaries.
 
         Returns
         -------
         is_between : Series
+
+        Examples
+        --------
+
+        >>> s = pd.Series([2, 0, 4, 8, np.nan])
+
+        Boundary values are included by default:
+
+        >>> s.between(1, 4)
+        0     True
+        1    False
+        2     True
+        3    False
+        4    False
+        dtype: bool
+
+        With `inclusive` set to `False` boundary values are excluded:
+
+        >>> s.between(1, 4, inclusive=False)
+        0     True
+        1    False
+        2    False
+        3    False
+        4    False
+        dtype: bool
+
+        `left` and `right` can be any scalar value:
+
+        >>> s = pd.Series(['Alice', 'Bob', 'Carol', 'Eve'])
+        >>> s.between('Anna', 'Daniel')
+        0    False
+        1     True
+        2     True
+        3    False
+        dtype: bool
+
+        See Also
+        --------
+        DataFrame.query : Query the columns of a frame with a boolean
+            expression.
         """
         if inclusive:
             lmask = self >= left


### PR DESCRIPTION
Checklist for the pandas documentation sprint (ignore this if you are doing
an unrelated PR):

- [x] PR title is "DOC: update the <your-function-or-method> docstring"
- [x] The validation script passes: `scripts/validate_docstrings.py <your-function-or-method>`
- [x] The PEP8 style check passes: `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] The html version looks good: `python doc/make.py --single <your-function-or-method>`
- [x] It has been proofread on language by another sprint participant

Please include the output of the validation script below between the "```" ticks:

```
################################################################################
###################### Docstring (pandas.Series.between)  ######################
################################################################################

Return boolean Series equivalent to left <= series <= right.

This function returns a boolean vector containing `True` wherever the
corresponding Series element is between the boundary values `left` and
`right`. NA values are treated as `False`.

Parameters
----------
left : scalar
    Left boundary.
right : scalar
    Right boundary.
inclusive : bool, default True
    Include boundaries.

Returns
-------
is_between : Series

Examples
--------

>>> s = pd.Series([2, 0, 4, 8, np.nan])

Boundary values are included by default:

>>> s.between(1, 4)
0     True
1    False
2     True
3    False
4    False
dtype: bool

With `inclusive` set to `False` boundary values are excluded:

>>> s.between(1, 4, inclusive=False)
0     True
1    False
2    False
3    False
4    False
dtype: bool

`left` and `right` can be any scalar value:

>>> s = pd.Series(['Alice', 'Bob', 'Carol', 'Eve'])
>>> s.between('Anna', 'Daniel')
0    False
1     True
2     True
3    False
dtype: bool

See Also
--------
DataFrame.query : Query the columns of a frame with a boolean
    expression.

################################################################################
################################## Validation ##################################
################################################################################

Docstring for "pandas.Series.between" correct. :)
```