### PR TITLE
DOC: general docstring formatting fixes

### DIFF
--- a/pandas/core/base.py
+++ b/pandas/core/base.py
@@ -855,6 +855,7 @@ class IndexOpsMixin(object):
         'a'
 
         For a MultiIndex, the minimum is determined lexicographically.
+
         >>> idx = pd.MultiIndex.from_product([('a', 'b'), (2, 1)])
         >>> idx.min()
         ('a', 1)

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -5465,8 +5465,6 @@ class DataFrame(NDFrame):
         return self[key]
 
     _agg_doc = dedent("""
-    Notes
-    -----
     The aggregation operations are always performed over an axis, either the
     index (default) or the column axis. This behavior is different from
     `numpy` aggregation functions (`mean`, `median`, `prod`, `sum`, `std`,

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -1910,20 +1910,20 @@ class NDFrame(PandasObject, SelectionMixin):
             Identifier for the group in the store.
         mode : {'a', 'w', 'r+'}, default 'a'
             Mode to open file:
-            
+
             - 'w': write, a new file is created (an existing file with
-            the same name would be deleted).
+              the same name would be deleted).
             - 'a': append, an existing file is opened for reading and
-            writing, and if the file does not exist it is created.
+              writing, and if the file does not exist it is created.
             - 'r+': similar to 'a', but the file must already exist.
         format : {'fixed', 'table'}, default 'fixed'
             Possible values:
-            
+
             - 'fixed': Fixed format. Fast writing/reading. Not-appendable,
-            nor searchable.
+              nor searchable.
             - 'table': Table format. Write as a PyTables Table structure
-            which may perform worse but allow more flexible operations
-            like searching / selecting subsets of the data.
+              which may perform worse but allow more flexible operations
+              like searching / selecting subsets of the data.
         append : bool, default False
             For Table formats, append the input data to the existing.
         data_columns :  list of columns or True, optional
@@ -5795,10 +5795,11 @@ class NDFrame(PandasObject, SelectionMixin):
             * None: (default) no fill restriction
             * 'inside' Only fill NaNs surrounded by valid values (interpolate).
             * 'outside' Only fill NaNs outside valid values (extrapolate).
-            .. versionadded:: 0.21.0
 
             If limit is specified, consecutive NaNs will be filled in this
             direction.
+
+            .. versionadded:: 0.21.0
         inplace : bool, default False
             Update the NDFrame in place if possible.
         downcast : optional, 'infer' or None, defaults to None
@@ -7717,6 +7718,7 @@ class NDFrame(PandasObject, SelectionMixin):
 
         The index values in ``truncate`` can be datetimes or string
         dates.
+
         >>> dates = pd.date_range('2016-01-01', '2016-02-01', freq='s')
         >>> df = pd.DataFrame(index=dates, data={'A': 1})
         >>> df.tail()
@@ -7960,7 +7962,7 @@ class NDFrame(PandasObject, SelectionMixin):
         0   1 days
         dtype: timedelta64[ns]
 
-        Select rows with data closest to certian value using argsort (from
+        Select rows with data closest to certain value using argsort (from
         `StackOverflow <https://stackoverflow.com/a/17758115>`__).
 
         >>> df = pd.DataFrame({

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -1,6 +1,7 @@
 from datetime import datetime, timedelta
 import warnings
 import operator
+from textwrap import dedent
 
 import numpy as np
 from pandas._libs import (lib, index as libindex, tslib as libts,
@@ -2183,7 +2184,7 @@ class Index(IndexOpsMixin, PandasObject):
         mapped to ``True`` values.
         Everything else get mapped to ``False`` values. Characters such as
         empty strings `''` or :attr:`numpy.inf` are not considered NA values
-        (unless you set :attr:`pandas.options.mode.use_inf_as_na` `= True`).
+        (unless you set ``pandas.options.mode.use_inf_as_na = True``).
 
         .. versionadded:: 0.20.0
 
@@ -4700,7 +4701,7 @@ class Index(IndexOpsMixin, PandasObject):
         %(outname)s : bool or array_like (if axis is specified)
             A single element array_like may be converted to bool."""
 
-        _index_shared_docs['index_all'] = """
+        _index_shared_docs['index_all'] = dedent("""
 
         See Also
         --------
@@ -4738,9 +4739,9 @@ class Index(IndexOpsMixin, PandasObject):
 
         >>> pd.Index([0, 0, 0]).any()
         False
-        """
+        """)
 
-        _index_shared_docs['index_any'] = """
+        _index_shared_docs['index_any'] = dedent("""
 
         See Also
         --------
@@ -4761,7 +4762,7 @@ class Index(IndexOpsMixin, PandasObject):
         >>> index = pd.Index([0, 0, 0])
         >>> index.any()
         False
-        """
+        """)
 
         def _make_logical_function(name, desc, f):
             @Substitution(outname=name, desc=desc)

--- a/pandas/core/indexes/datetimelike.py
+++ b/pandas/core/indexes/datetimelike.py
@@ -87,15 +87,12 @@ class DatelikeOps(object):
     Examples
     --------
     >>> import datetime
-    >>> data = pd.date_range(datetime.datetime(2018,3,10,19,27,52),
-    ...                      periods=4, freq='B')
-    >>> df = pd.DataFrame(data, columns=['date'])
-    >>> df.date[1]
-    Timestamp('2018-03-13 19:27:52')
-    >>> df.date[1].strftime('%d-%m-%Y')
-    '13-03-2018'
-    >>> df.date[1].strftime('%B %d, %Y, %r')
-    'March 13, 2018, 07:27:52 PM'
+    >>> rng = pd.date_range(pd.Timestamp("2018-03-10 09:00"),
+    ...                     periods=3, freq='s')
+    >>> rng.strftime('%B %d, %Y, %r')
+    Index(['March 10, 2018, 09:00:00 AM', 'March 10, 2018, 09:00:01 AM',
+           'March 10, 2018, 09:00:02 AM'],
+          dtype='object')
     """.format("https://docs.python.org/3/library/datetime.html"
                "#strftime-and-strptime-behavior")
 

--- a/pandas/core/indexes/datetimelike.py
+++ b/pandas/core/indexes/datetimelike.py
@@ -86,7 +86,6 @@ class DatelikeOps(object):
 
     Examples
     --------
-    >>> import datetime
     >>> rng = pd.date_range(pd.Timestamp("2018-03-10 09:00"),
     ...                     periods=3, freq='s')
     >>> rng.strftime('%B %d, %Y, %r')

--- a/pandas/core/reshape/tile.py
+++ b/pandas/core/reshape/tile.py
@@ -51,7 +51,7 @@ def cut(x, bins, right=True, labels=None, retbins=False, precision=3,
     right : bool, default True
         Indicates whether `bins` includes the rightmost edge or not. If
         ``right == True`` (the default), then the `bins` ``[1, 2, 3, 4]``
-         indicate (1,2], (2,3], (3,4]. This argument is ignored when
+        indicate (1,2], (2,3], (3,4]. This argument is ignored when
         `bins` is an IntervalIndex.
     labels : array or bool, optional
         Specifies the labels for the returned bins. Must be the same length as


### PR DESCRIPTION
Some general formatting fixes (+ fix example in DatetimeIndex.strftime to actually use that method and not Timestamp.strftime). 

Merging directly as it contains some PEP8 issues I merged in master.