### PR TITLE
DOC: update the pandas.Series.str.startswith docstring

### DIFF
--- a/pandas/core/strings.py
+++ b/pandas/core/strings.py
@@ -330,40 +330,41 @@ def str_startswith(arr, pat, na=np.nan):
     """
     Test if the start of each string element matches a pattern.
 
-    Return a Series of booleans indicating whether the given pattern matches
-    the start of each string element.
-    Equivalent to :meth: `str.startswith`.
+    Equivalent to :meth:`str.startswith`.
 
     Parameters
     ----------
-    pat : string
-        Character sequence.
+    pat : str
+        Character sequence. Regular expressions are not accepted.
     na : object, default NaN
-        Character sequence shown if element tested is not a string.
+        Object shown if element tested is not a string.
 
     Returns
     -------
-    startswith : Series/array of boolean values
-
-    Examples
-    --------
-    >>> s = pd.Series(['bat', 'bear', 'cat'])
-    >>> s.str.startswith('b')
-    0     True
-    1     True
-    2    False
-    dtype: bool
-    >>> s = pd.Series(['bat', 'bear', 'cat', np.nan])
-    >>> s.str.startswith('b', na='not_a_string')
-    0            True
-    1            True
-    2           False
-    3    not_a_string
-    dtype: object
+    startswith : Series or array-like of bool
+        A Series of booleans indicating whether the given pattern matches
+        the start of each string element.
 
     See Also
     --------
-    endswith : same as startswith, but tests the end of string
+    str_endswith : Same as startswith, but tests the end of string.
+    str.startswith : Python standard library string method.
+
+    Examples
+    --------
+    >>> s = pd.Series(['bat', 'Bear', 'cat', np.nan])
+    >>> s.str.startswith('b')
+    0     True
+    1    False
+    2    False
+    3      NaN
+    dtype: object
+    >>> s.str.startswith('b', na=False)
+    0     True
+    1    False
+    2    False
+    3    False
+    dtype: bool
     """
     f = lambda x: x.startswith(pat)
     return _na_map(f, arr, na, dtype=bool)

--- a/pandas/core/strings.py
+++ b/pandas/core/strings.py
@@ -341,7 +341,7 @@ def str_startswith(arr, pat, na=np.nan):
 
     Returns
     -------
-    startswith : Series or array-like of bool
+    Series or Index of bool
         A Series of booleans indicating whether the given pattern matches
         the start of each string element.
 
@@ -360,6 +360,10 @@ def str_startswith(arr, pat, na=np.nan):
     2    False
     3      NaN
     dtype: object
+
+    Specifying `na` to be `False` instead of `NaN`.
+
+    >>> s = pd.Series(['bat', 'Bear', 'cat', np.nan])
     >>> s.str.startswith('b', na=False)
     0     True
     1    False

--- a/pandas/core/strings.py
+++ b/pandas/core/strings.py
@@ -328,19 +328,42 @@ def str_contains(arr, pat, case=True, flags=0, na=np.nan, regex=True):
 
 def str_startswith(arr, pat, na=np.nan):
     """
-    Return boolean Series/``array`` indicating whether each string in the
-    Series/Index starts with passed pattern. Equivalent to
-    :meth:`str.startswith`.
+    Test if the start of each string element matches a pattern.
+
+    Return a Series of booleans indicating whether the given pattern matches
+    the start of each string element.
+    Equivalent to :meth: `str.startswith`.
 
     Parameters
     ----------
     pat : string
-        Character sequence
-    na : bool, default NaN
+        Character sequence.
+    na : object, default NaN
+        Character sequence shown if element tested is not a string.
 
     Returns
     -------
     startswith : Series/array of boolean values
+
+    Examples
+    --------
+    >>> s = pd.Series(['bat', 'bear', 'cat'])
+    >>> s.str.startswith('b')
+    0     True
+    1     True
+    2    False
+    dtype: bool
+    >>> s = pd.Series(['bat', 'bear', 'cat', np.nan])
+    >>> s.str.startswith('b', na='not_a_string')
+    0            True
+    1            True
+    2           False
+    3    not_a_string
+    dtype: object
+
+    See Also
+    --------
+    endswith : same as startswith, but tests the end of string
     """
     f = lambda x: x.startswith(pat)
     return _na_map(f, arr, na, dtype=bool)

--- a/pandas/core/strings.py
+++ b/pandas/core/strings.py
@@ -347,8 +347,9 @@ def str_startswith(arr, pat, na=np.nan):
 
     See Also
     --------
-    str_endswith : Same as startswith, but tests the end of string.
     str.startswith : Python standard library string method.
+    Series.str.endswith : Same as startswith, but tests the end of string.
+    Series.str.contains : Tests if string element contains a pattern.
 
     Examples
     --------

--- a/pandas/core/strings.py
+++ b/pandas/core/strings.py
@@ -354,6 +354,13 @@ def str_startswith(arr, pat, na=np.nan):
     Examples
     --------
     >>> s = pd.Series(['bat', 'Bear', 'cat', np.nan])
+    >>> s
+    0     bat
+    1    Bear
+    2     cat
+    3     NaN
+    dtype: object
+
     >>> s.str.startswith('b')
     0     True
     1    False
@@ -363,7 +370,6 @@ def str_startswith(arr, pat, na=np.nan):
 
     Specifying `na` to be `False` instead of `NaN`.
 
-    >>> s = pd.Series(['bat', 'Bear', 'cat', np.nan])
     >>> s.str.startswith('b', na=False)
     0     True
     1    False


### PR DESCRIPTION
Checklist for the pandas documentation sprint (ignore this if you are doing
an unrelated PR):

- [X] PR title is "DOC: update the <your-function-or-method> docstring"
- [X] The validation script passes: `scripts/validate_docstrings.py <your-function-or-method>`
- [X] The PEP8 style check passes: `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [X] The html version looks good: `python doc/make.py --single <your-function-or-method>`
- [X] It has been proofread on language by another sprint participant

Please include the output of the validation script below between the "```" ticks:

```
################################################################################
################### Docstring (pandas.Series.str.startswith) ###################
################################################################################

Test if the start of each string element matches a pattern.

Return a Series of booleans indicating whether the given pattern matches
the start of each string element.
Equivalent to :meth: `str.startswith`.

Parameters
----------
pat : string
    Character sequence.
na : object, default NaN
    Character sequence shown if element tested is not a string.

Returns
-------
startswith : Series/array of boolean values

Examples
--------
>>> s = pd.Series(['bat', 'bear', 'cat'])
>>> s.str.startswith('b')
0     True
1     True
2    False
dtype: bool
>>> s = pd.Series(['bat', 'bear', 'cat', np.nan])
>>> s.str.startswith('b', na='not_a_string')
0            True
1            True
2           False
3    not_a_string
dtype: object

See Also
--------
endswith : same as startswith, but tests the end of string

################################################################################
################################## Validation ##################################
################################################################################
```

If the validation script still gives errors, but you think there is a good reason
to deviate in this case (and there are certainly such cases), please state this
explicitly.
