### PR TITLE
ENH: fill_value argument for shift #15486

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -3619,9 +3619,9 @@ class DataFrame(NDFrame):
                                               method=method, axis=axis)
 
     @Appender(_shared_docs['shift'] % _shared_doc_kwargs)
-    def shift(self, periods=1, freq=None, axis=0):
+    def shift(self, periods=1, freq=None, axis=0, fill_value=np.nan):
         return super(DataFrame, self).shift(periods=periods, freq=freq,
-                                            axis=axis)
+                                            axis=axis, fill_value=fill_value)
 
     def set_index(self, keys, drop=True, append=False, inplace=False,
                   verify_integrity=False):

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -5145,36 +5145,51 @@ class DataFrame(NDFrame):
 
     def stack(self, level=-1, dropna=True):
         """
-        Pivot a level of the (possibly hierarchical) column labels, returning a
-        DataFrame (or Series in the case of an object with a single level of
-        column labels) having a hierarchical index with a new inner-most level
-        of row labels.
-        The level involved will automatically get sorted.
+        Stack the prescribed level(s) from the column axis onto the index
+        axis.
+
+        Return a reshaped DataFrame or Series having a multi-level
+        index with one or more new inner-most levels compared to the current
+        dataframe. The new inner-most levels are created by pivoting the
+        columns of the current dataframe:
+
+          - if the columns have a single level, the output is a Series;
+          - if the columns have multiple levels, the new index level
+            is taken from the prescribed level(s) and the output is a
+            DataFrame.
+
+        The new index levels are sorted.
 
         Parameters
         ----------
-        level : int, string, or list of these, default last level
-            Level(s) to stack, can pass level name
+        level : int, string, list, default last level
+            Level(s) to stack from the column axis, defined as
+            integers or strings.
         dropna : boolean, default True
-            Whether to drop rows in the resulting Frame/Series with no valid
-            values
+            Whether to drop rows in the resulting Frame/Series with no
+            valid values.
 
         Examples
         ----------
+        >>> s = pd.DataFrame([[0, 1], [2, 3]], index=['one', 'two'], columns=['a', 'b'])
         >>> s
              a   b
-        one  1.  2.
-        two  3.  4.
-
+        one  0   1
+        two  2   3
         >>> s.stack()
-        one a    1
-            b    2
-        two a    3
-            b    4
+        one  a    0
+             b    1
+        two  a    2
+             b    3
+        dtype: int64
 
         Returns
         -------
         stacked : DataFrame or Series
+
+        See Also
+        --------
+        pandas.DataFrame.unstack: unstack prescribed level(s) from index axis onto column axis.
         """
         from pandas.core.reshape.reshape import stack, stack_multiple
 

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -5145,51 +5145,32 @@ class DataFrame(NDFrame):
 
     def stack(self, level=-1, dropna=True):
         """
-        Stack the prescribed level(s) from the column axis onto the index
-        axis.
-
-        Return a reshaped DataFrame or Series having a multi-level
-        index with one or more new inner-most levels compared to the current
-        dataframe. The new inner-most levels are created by pivoting the
-        columns of the current dataframe:
-
-          - if the columns have a single level, the output is a Series;
-          - if the columns have multiple levels, the new index level
-            is taken from the prescribed level(s) and the output is a
-            DataFrame.
-
-        The new index levels are sorted.
-
+        Pivot a level of the (possibly hierarchical) column labels, returning a
+        DataFrame (or Series in the case of an object with a single level of
+        column labels) having a hierarchical index with a new inner-most level
+        of row labels.
+        The level involved will automatically get sorted.
         Parameters
         ----------
-        level : int, string, list, default last level
-            Level(s) to stack from the column axis, defined as
-            integers or strings.
+        level : int, string, or list of these, default last level
+            Level(s) to stack, can pass level name
         dropna : boolean, default True
-            Whether to drop rows in the resulting Frame/Series with no
-            valid values.
-
+            Whether to drop rows in the resulting Frame/Series with no valid
+            values
         Examples
         ----------
-        >>> s = pd.DataFrame([[0, 1], [2, 3]], index=['one', 'two'], columns=['a', 'b'])
         >>> s
              a   b
-        one  0   1
-        two  2   3
+        one  1.  2.
+        two  3.  4.
         >>> s.stack()
-        one  a    0
-             b    1
-        two  a    2
-             b    3
-        dtype: int64
-
+        one a    1
+            b    2
+        two a    3
+            b    4
         Returns
         -------
         stacked : DataFrame or Series
-
-        See Also
-        --------
-        pandas.DataFrame.unstack: unstack prescribed level(s) from index axis onto column axis.
         """
         from pandas.core.reshape.reshape import stack, stack_multiple
 

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -5150,6 +5150,7 @@ class DataFrame(NDFrame):
         column labels) having a hierarchical index with a new inner-most level
         of row labels.
         The level involved will automatically get sorted.
+
         Parameters
         ----------
         level : int, string, or list of these, default last level
@@ -5157,17 +5158,20 @@ class DataFrame(NDFrame):
         dropna : boolean, default True
             Whether to drop rows in the resulting Frame/Series with no valid
             values
+
         Examples
         ----------
         >>> s
              a   b
         one  1.  2.
         two  3.  4.
+
         >>> s.stack()
         one a    1
             b    2
         two a    3
             b    4
+
         Returns
         -------
         stacked : DataFrame or Series

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -7545,7 +7545,8 @@ class NDFrame(PandasObject, SelectionMixin):
 
         block_axis = self._get_block_manager_axis(axis)
         if freq is None:
-            new_data = self._data.shift(periods=periods, axis=block_axis, fill_value=fill_value)
+            new_data = self._data.shift(periods=periods, axis=block_axis,
+                                        fill_value=fill_value)
         else:
             return self.tshift(periods, freq, fill_value)
 

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -7544,9 +7544,11 @@ class NDFrame(PandasObject, SelectionMixin):
             return self
 
         block_axis = self._get_block_manager_axis(axis)
+        shift_kwargs = {'periods': periods, 'axis': block_axis}
+        if not is_categorical_dtype(self):
+            shift_kwargs['fill_value'] = fill_value
         if freq is None:
-            new_data = self._data.shift(periods=periods, axis=block_axis,
-                                        fill_value=fill_value)
+                new_data = self._data.shift(**shift_kwargs)
         else:
             return self.tshift(periods, freq, fill_value)
 

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -7550,7 +7550,10 @@ class NDFrame(PandasObject, SelectionMixin):
         if freq is None:
                 new_data = self._data.shift(**shift_kwargs)
         else:
-            return self.tshift(periods, freq, fill_value)
+            tshift_kwargs = {'periods': periods, 'freq': freq}
+            if not is_categorical_dtype(self):
+                tshift_kwargs['fill_value'] = fill_value
+            return self.tshift(**tshift_kwargs)
 
         return self._constructor(new_data).__finalize__(self)
 

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -7539,15 +7539,15 @@ class NDFrame(PandasObject, SelectionMixin):
     """)
 
     @Appender(_shared_docs['shift'] % _shared_doc_kwargs)
-    def shift(self, periods=1, freq=None, axis=0):
+    def shift(self, periods=1, freq=None, axis=0, fill_value=np.nan):
         if periods == 0:
             return self
 
         block_axis = self._get_block_manager_axis(axis)
         if freq is None:
-            new_data = self._data.shift(periods=periods, axis=block_axis)
+            new_data = self._data.shift(periods=periods, axis=block_axis, fill_value=fill_value)
         else:
-            return self.tshift(periods, freq)
+            return self.tshift(periods, freq, fill_value)
 
         return self._constructor(new_data).__finalize__(self)
 
@@ -7587,18 +7587,20 @@ class NDFrame(PandasObject, SelectionMixin):
 
         return new_obj.__finalize__(self)
 
-    def tshift(self, periods=1, freq=None, axis=0):
+    def tshift(self, periods=1, freq=None, axis=0, fill_value=np.nan):
         """
         Shift the time index, using the index's frequency if available.
 
         Parameters
         ----------
         periods : int
-            Number of periods to move, can be positive or negative
+            Number of periods to move, can be positive or negative.
         freq : DateOffset, timedelta, or time rule string, default None
-            Increment to use from the tseries module or time rule (e.g. 'EOM')
+            Increment to use from the tseries module or time rule (e.g. 'EOM').
         axis : int or basestring
-            Corresponds to the axis that contains the Index
+            Corresponds to the axis that contains the Index.
+        fill_value :
+            Value to use to cover missing values.
 
         Notes
         -----

--- a/pandas/core/internals.py
+++ b/pandas/core/internals.py
@@ -1279,12 +1279,12 @@ class Block(PandasObject):
         new_values = algos.diff(self.values, n, axis=axis)
         return [self.make_block(values=new_values)]
 
-    def shift(self, periods, axis=0, mgr=None):
+    def shift(self, periods, axis=0, mgr=None, fill_value=np.nan):
         """ shift the block by periods, possibly upcast """
 
         # convert integer to float if necessary. need to do a lot more than
         # that, handle boolean etc also
-        new_values, fill_value = maybe_upcast(self.values)
+        new_values, fill_value = maybe_upcast(self.values, fill_value)
 
         # make sure array sent to np.roll is c_contiguous
         f_ordered = new_values.flags.f_contiguous

--- a/pandas/core/internals.py
+++ b/pandas/core/internals.py
@@ -2541,7 +2541,7 @@ class CategoricalBlock(ExtensionBlock):
 
         return result
 
-    def shift(self, periods, axis=0, mgr=None):
+    def shift(self, periods, axis=0, mgr=None, fill_value=np.nan):
         return self.make_block_same_class(values=self.values.shift(periods),
                                           placement=self.mgr_locs)
 
@@ -2879,7 +2879,7 @@ class DatetimeTZBlock(NonConsolidatableMixIn, DatetimeBlock):
     def _box_func(self):
         return lambda x: tslib.Timestamp(x, tz=self.dtype.tz)
 
-    def shift(self, periods, axis=0, mgr=None):
+    def shift(self, periods, axis=0, mgr=None, fill_value=np.nan):
         """ shift the block by periods """
 
         # think about moving this to the DatetimeIndex. This is a non-freq
@@ -3072,7 +3072,7 @@ class SparseBlock(NonConsolidatableMixIn, Block):
         return [self.make_block_same_class(values=values,
                                            placement=self.mgr_locs)]
 
-    def shift(self, periods, axis=0, mgr=None):
+    def shift(self, periods, axis=0, mgr=None, fill_value=np.nan):
         """ shift the block by periods """
         N = len(self.values.T)
         indexer = np.zeros(N, dtype=int)

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -3358,8 +3358,9 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
                                            axis=axis)
 
     @Appender(generic._shared_docs['shift'] % _shared_doc_kwargs)
-    def shift(self, periods=1, freq=None, axis=0):
-        return super(Series, self).shift(periods=periods, freq=freq, axis=axis)
+    def shift(self, periods=1, freq=None, axis=0, fill_value=np.nan):
+        return super(Series, self).shift(periods=periods, freq=freq, axis=axis,
+                                         fill_value=fill_value)
 
     def reindex_axis(self, labels, axis=0, **kwargs):
         """Conform Series to new index with optional filling logic.

--- a/pandas/tests/frame/test_timeseries.py
+++ b/pandas/tests/frame/test_timeseries.py
@@ -308,6 +308,14 @@ class TestDataFrameTimeSeriesMethods(TestData):
                        columns=['high', 'low'])
         assert_frame_equal(rs, xp)
 
+    def test_shift_bool_fillna(self):
+        df = DataFrame({'high': [True, False],
+                        'low': [False, False]})
+        rs = df.shift(1, fill_value=True)
+        xp = DataFrame({'high': [True, True],
+                        'low': [True, False]})
+        assert_frame_equal(rs, xp)
+
     def test_shift_categorical(self):
         # GH 9416
         s1 = pd.Series(['a', 'b', 'c'], dtype='category')

--- a/pandas/tests/series/test_analytics.py
+++ b/pandas/tests/series/test_analytics.py
@@ -1607,6 +1607,17 @@ class TestSeriesAnalytics(TestData):
         expected = ts.astype(float).shift(1)
         assert_series_equal(shifted, expected)
 
+    def test_shift_fillna(self):
+        # ENH 15486
+        ts = self.ts.astype(int)
+        fillval = 0
+        shifted = ts.shift(1, fill_value=fillval)
+        # default behaviour adds nan so converts to floats
+        default = ts.shift(1)
+        default.iloc[0] = fillval
+        expected = default.astype(int)
+        assert_series_equal(shifted, expected)
+
     def test_shift_categorical(self):
         # GH 9416
         s = pd.Series(['a', 'b', 'c', 'd'], dtype='category')


### PR DESCRIPTION
This is a work in progress. 

Checklist for other PRs (remove this part if you are doing a PR for the pandas documentation sprint):

- [X] closes #15486 
- [ ] tests added / passed
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
