### PR TITLE
DOC: Improving the docstring of Series.str.upper and related

### DIFF
--- a/pandas/core/strings.py
+++ b/pandas/core/strings.py
@@ -2172,7 +2172,7 @@ class StringMethods(NoNewAttributesMixin):
     2    this is a SentEnce
     3          The is Paris
     dtype: object
-    
+
     >>> s.str.lower()
     0                 lower
     1              capitals

--- a/pandas/core/strings.py
+++ b/pandas/core/strings.py
@@ -2154,18 +2154,25 @@ class StringMethods(NoNewAttributesMixin):
 
     See Also
     --------
-    Series.str.lower : Converts all characters to lower case.
-    Series.str.upper : Converts all characters to upper case.
-    Series.str.title : Converts first character of each word to upper case and
-        remaining to lower case.
-    Series.str.capitalize : Converts first character to upper case and
-        remaining to lower case.
-    Series.str.swapcase : Converts upper case to lower case and lower case to
-        upper case.
+    Series.str.lower : Converts all characters to lowercase.
+    Series.str.upper : Converts all characters to uppercase.
+    Series.str.title : Converts first character of each word to uppercase and
+        remaining to lowercase.
+    Series.str.capitalize : Converts first character to uppercase and
+        remaining to lowercase.
+    Series.str.swapcase : Converts uppercase to lowercase and lowercase to
+        uppercase.
 
     Examples
     --------
     >>> s = pd.Series(['lower', 'CAPITALS', 'this is a sentence', 'SwApCaSe'])
+    >>> s
+    0                 lower
+    1              CAPITALS
+    2    this is a SentEnce
+    3          The is Paris
+    dtype: object
+    
     >>> s.str.lower()
     0                 lower
     1              capitals

--- a/pandas/core/strings.py
+++ b/pandas/core/strings.py
@@ -2169,8 +2169,8 @@ class StringMethods(NoNewAttributesMixin):
     >>> s
     0                 lower
     1              CAPITALS
-    2    this is a SentEnce
-    3          The is Paris
+    2    this is a sentence
+    3              SwApCaSe
     dtype: object
 
     >>> s.str.lower()

--- a/pandas/core/strings.py
+++ b/pandas/core/strings.py
@@ -2145,11 +2145,61 @@ class StringMethods(NoNewAttributesMixin):
 
     _shared_docs['casemethods'] = ("""
     Convert strings in the Series/Index to %(type)s.
+
     Equivalent to :meth:`str.%(method)s`.
 
     Returns
     -------
-    converted : Series/Index of objects
+    Series/Index of objects
+
+    See Also
+    --------
+    Series.str.lower : Converts all characters to lower case.
+    Series.str.upper : Converts all characters to upper case.
+    Series.str.title : Converts first character of each word to upper case and
+        remaining to lower case.
+    Series.str.capitalize : Converts first character to upper case and
+        remaining to lower case.
+    Series.str.swapcase : Converts upper case to lower case and lower case to
+        upper case.
+
+    Examples
+    --------
+    >>> s = pd.Series(['lower', 'CAPITALS', 'this is a sentence', 'SwApCaSe'])
+    >>> s.str.lower()
+    0                 lower
+    1              capitals
+    2    this is a sentence
+    3              swapcase
+    dtype: object
+
+    >>> s.str.upper()
+    0                 LOWER
+    1              CAPITALS
+    2    THIS IS A SENTENCE
+    3              SWAPCASE
+    dtype: object
+
+    >>> s.str.title()
+    0                 Lower
+    1              Capitals
+    2    This Is A Sentence
+    3              Swapcase
+    dtype: object
+
+    >>> s.str.capitalize()
+    0                 Lower
+    1              Capitals
+    2    This is a sentence
+    3              Swapcase
+    dtype: object
+
+    >>> s.str.swapcase()
+    0                 LOWER
+    1              capitals
+    2    THIS IS A SENTENCE
+    3              sWaPcAsE
+    dtype: object
     """)
     _shared_docs['lower'] = dict(type='lowercase', method='lower')
     _shared_docs['upper'] = dict(type='uppercase', method='upper')


### PR DESCRIPTION
Checklist for the pandas documentation sprint (ignore this if you are doing
an unrelated PR):

- [X] PR title is "DOC: update the <your-function-or-method> docstring"
- [X] The validation script passes: `scripts/validate_docstrings.py <your-function-or-method>`
- [X] The PEP8 style check passes: `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] The html version looks good: `python doc/make.py --single <your-function-or-method>`
- [X] It has been proofread on language by another sprint participant

Please include the output of the validation script below between the "```" ticks:

```
################################################################################
##################### Docstring (pandas.Series.str.upper)  #####################
################################################################################

Convert strings in the Series/Index to uppercase.

Equivalent to :meth:`str.upper`.

Returns
-------
Series/Index of objects

See Also
--------
Series.str.lower : Converts all characters to lower case.
Series.str.upper : Converts all characters to upper case.
Series.str.title : Converts first character of each word to upper case and
    remaining to lower case.
Series.str.capitalize : Converts first character to upper case and
    remaining to lower case.
Series.str.swapcase : Converts upper case to lower case and lower case to
    upper case.

Examples
--------
>>> s = pd.Series(['lower', 'CAPITALS', 'this is a sentence', 'SwApCaSe'])
>>> s.str.lower()
0                 lower
1              capitals
2    this is a sentence
3              swapcase
dtype: object

>>> s.str.upper()
0                 LOWER
1              CAPITALS
2    THIS IS A SENTENCE
3              SWAPCASE
dtype: object

>>> s.str.title()
0                 Lower
1              Capitals
2    This Is A Sentence
3              Swapcase
dtype: object

>>> s.str.capitalize()
0                 Lower
1              Capitals
2    This is a sentence
3              Swapcase
dtype: object

>>> s.str.swapcase()
0                 LOWER
1              capitals
2    THIS IS A SENTENCE
3              sWaPcAsE
dtype: object

################################################################################
################################## Validation ##################################
################################################################################

Docstring for "pandas.Series.str.upper" correct. :)

```

If the validation script still gives errors, but you think there is a good reason
to deviate in this case (and there are certainly such cases), please state this
explicitly.


Checklist for other PRs (remove this part if you are doing a PR for the pandas documentation sprint):

- [ ] closes #xxxx
- [ ] tests added / passed
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
