### PR TITLE
DOC: update the Series.str.join docstring

### DIFF
--- a/pandas/core/strings.py
+++ b/pandas/core/strings.py
@@ -969,40 +969,23 @@ def str_join(arr, sep):
     Examples
     --------
 
-    >>> df = pd.Series({1: ['dog', 'cat', 'fish'],
-    ...                 2: ['lion', 'elephant', 'zebra'],
-    ...                 3: ['cow', 'pig', 'chicken']})
-    >>> df
-    1           [dog, cat, fish]
-    2    [lion, elephant, zebra]
-    3        [cow, pig, chicken]
-    dtype: object
-
-    Join all lists using '_'.
-
-    >>> df.str.join('_')
-    1           dog_cat_fish
-    2    lion_elephant_zebra
-    3        cow_pig_chicken
-    dtype: object
-
     Example with a list that contains non-string elements.
 
-    >>> df = pd.Series({1: [1.1, 2.2, 3.3],
-    ...                 2: ['lion', 'elephant', 'zebra'],
-    ...                 3: ['cow', 'pig', 'chicken']})
-    >>> df
-    1            [1.1, 2.2, 3.3]
-    2    [lion, elephant, zebra]
-    3        [cow, pig, chicken]
+    >>> s = pd.Series({1: ['lion', 'elephant', 'zebra'],
+    ...                2: [1.1, 2.2, 3.3],
+    ...                3: [np.nan, np.nan, np.nan]})
+    >>> s
+    1    [lion, elephant, zebra]
+    2            [1.1, 2.2, 3.3]
+    3            [nan, nan, nan]
     dtype: object
 
     Join all lists using an '-', the list of floats will become a NaN.
 
-    >>> df.str.join('-')
-    1                    NaN
-    2    lion-elephant-zebra
-    3        cow-pig-chicken
+    >>> s.str.join('-')
+    1    lion-elephant-zebra
+    2                    NaN
+    3                    NaN
     dtype: object
     """
     return _na_map(sep.join, arr)

--- a/pandas/core/strings.py
+++ b/pandas/core/strings.py
@@ -941,13 +941,14 @@ def str_get_dummies(arr, sep='|'):
 
 def str_join(arr, sep):
     """
-    Join lists contained as elements in the Series/Index with
-    passed delimiter. Equivalent to :meth:`str.join`.
+    Join lists contained as elements in the Series/Index with passed delimiter.
+
+    This function is an equivalent to :meth:`str.join`.
 
     Parameters
     ----------
     sep : string
-        Delimiter
+        Delimiter to use between list entries.
 
     Returns
     -------
@@ -958,16 +959,23 @@ def str_join(arr, sep):
     If any of the lists does not contain string objects the result of the join
     will be `NaN`.
 
+    See Also
+    --------
+    split: Split strings around given separator/delimiter.
+
     Examples
     --------
 
     >>> df = pd.Series({1: ["foo", "bar", "foobar"],
-                        2: ['test', 'test2', 'test3'],
-                        3: ['ham', 'eggs', 'chicken']})
+    ...    2: ['test', 'test2', 'test3'],
+    ...    3: ['ham', 'eggs', 'chicken']})
+    >>> df
     1      [foo, bar, foobar]
     2    [test, test2, test3]
     3    [ham, eggs, chicken]
     dtype: object
+
+    Join all lists using "_".
 
     >>> df.str.join("_")
     1      foo_bar_foobar
@@ -975,13 +983,18 @@ def str_join(arr, sep):
     3    ham_eggs_chicken
     dtype: object
 
+    Example with a list that contains non-string elements.
+
     >>> df = pd.Series({1: [1.1, 2.2, 3.3],
-                        2: ['test', 'test2', 'test3'],
-                        3: ['ham', 'eggs', 'chicken']})
+    ...    2: ['test', 'test2', 'test3'],
+    ...    3: ['ham', 'eggs', 'chicken']})
+    >>> df
     1         [1.1, 2.2, 3.3]
     2    [test, test2, test3]
     3    [ham, eggs, chicken]
     dtype: object
+
+    Join all lists using an "-", the list of floats will become a NaN.
 
     >>> df.str.join("-")
     1                 NaN

--- a/pandas/core/strings.py
+++ b/pandas/core/strings.py
@@ -954,7 +954,7 @@ def str_join(arr, sep):
 
     Returns
     -------
-    Series/Index of objects
+    Series/Index: object
 
     Notes
     -----
@@ -971,21 +971,28 @@ def str_join(arr, sep):
 
     Example with a list that contains non-string elements.
 
-    >>> s = pd.Series({1: ['lion', 'elephant', 'zebra'],
-    ...                2: [1.1, 2.2, 3.3],
-    ...                3: [np.nan, np.nan, np.nan]})
+    >>> s = pd.Series([['lion', 'elephant', 'zebra'],
+    ...                [1.1, 2.2, 3.3],
+    ...                ['cat', np.nan, 'dog'],
+    ...                ['cow', 4.5, 'goat']
+    ...                ['duck', ['swan', 'fish'], 'guppy']])
     >>> s
-    1    [lion, elephant, zebra]
-    2            [1.1, 2.2, 3.3]
-    3            [nan, nan, nan]
+    0        [lion, elephant, zebra]
+    1                [1.1, 2.2, 3.3]
+    2                [cat, nan, dog]
+    3               [cow, 4.5, goat]
+    4    [duck, [swan, fish], guppy]
     dtype: object
 
-    Join all lists using an '-', the list of floats will become a NaN.
+    Join all lists using an '-', the lists containing object(s) of types other
+    than str will become a NaN.
 
     >>> s.str.join('-')
-    1    lion-elephant-zebra
+    0    lion-elephant-zebra
+    1                    NaN
     2                    NaN
     3                    NaN
+    4                    NaN
     dtype: object
     """
     return _na_map(sep.join, arr)

--- a/pandas/core/strings.py
+++ b/pandas/core/strings.py
@@ -943,16 +943,18 @@ def str_join(arr, sep):
     """
     Join lists contained as elements in the Series/Index with passed delimiter.
 
+    If the elements of a Series are lists themselves, join the content of these
+    lists using the delimiter passed to the function.
     This function is an equivalent to :meth:`str.join`.
 
     Parameters
     ----------
-    sep : string
+    sep : str
         Delimiter to use between list entries.
 
     Returns
     -------
-    joined : Series/Index of objects
+    Series/Index of objects
 
     Notes
     -----
@@ -961,45 +963,46 @@ def str_join(arr, sep):
 
     See Also
     --------
-    split: Split strings around given separator/delimiter.
+    str.join : Standard library version of this method.
+    Series.str.split : Split strings around given separator/delimiter.
 
     Examples
     --------
 
-    >>> df = pd.Series({1: ["foo", "bar", "foobar"],
-    ...    2: ['test', 'test2', 'test3'],
-    ...    3: ['ham', 'eggs', 'chicken']})
+    >>> df = pd.Series({1: ['dog', 'cat', 'fish'],
+    ...                 2: ['lion', 'elephant', 'zebra'],
+    ...                 3: ['cow', 'pig', 'chicken']})
     >>> df
-    1      [foo, bar, foobar]
-    2    [test, test2, test3]
-    3    [ham, eggs, chicken]
+    1           [dog, cat, fish]
+    2    [lion, elephant, zebra]
+    3        [cow, pig, chicken]
     dtype: object
 
-    Join all lists using "_".
+    Join all lists using '_'.
 
-    >>> df.str.join("_")
-    1      foo_bar_foobar
-    2    test_test2_test3
-    3    ham_eggs_chicken
+    >>> df.str.join('_')
+    1           dog_cat_fish
+    2    lion_elephant_zebra
+    3        cow_pig_chicken
     dtype: object
 
     Example with a list that contains non-string elements.
 
     >>> df = pd.Series({1: [1.1, 2.2, 3.3],
-    ...    2: ['test', 'test2', 'test3'],
-    ...    3: ['ham', 'eggs', 'chicken']})
+    ...                 2: ['lion', 'elephant', 'zebra'],
+    ...                 3: ['cow', 'pig', 'chicken']})
     >>> df
-    1         [1.1, 2.2, 3.3]
-    2    [test, test2, test3]
-    3    [ham, eggs, chicken]
+    1            [1.1, 2.2, 3.3]
+    2    [lion, elephant, zebra]
+    3        [cow, pig, chicken]
     dtype: object
 
-    Join all lists using an "-", the list of floats will become a NaN.
+    Join all lists using an '-', the list of floats will become a NaN.
 
-    >>> df.str.join("-")
-    1                 NaN
-    2    test-test2-test3
-    3    ham-eggs-chicken
+    >>> df.str.join('-')
+    1                    NaN
+    2    lion-elephant-zebra
+    3        cow-pig-chicken
     dtype: object
     """
     return _na_map(sep.join, arr)

--- a/pandas/core/strings.py
+++ b/pandas/core/strings.py
@@ -952,6 +952,42 @@ def str_join(arr, sep):
     Returns
     -------
     joined : Series/Index of objects
+
+    Notes
+    -----
+    If any of the lists does not contain string objects the result of the join
+    will be `NaN`.
+
+    Examples
+    --------
+
+    >>> df = pd.Series({1: ["foo", "bar", "foobar"],
+                        2: ['test', 'test2', 'test3'],
+                        3: ['ham', 'eggs', 'chicken']})
+    1      [foo, bar, foobar]
+    2    [test, test2, test3]
+    3    [ham, eggs, chicken]
+    dtype: object
+
+    >>> df.str.join("_")
+    1      foo_bar_foobar
+    2    test_test2_test3
+    3    ham_eggs_chicken
+    dtype: object
+
+    >>> df = pd.Series({1: [1.1, 2.2, 3.3],
+                        2: ['test', 'test2', 'test3'],
+                        3: ['ham', 'eggs', 'chicken']})
+    1         [1.1, 2.2, 3.3]
+    2    [test, test2, test3]
+    3    [ham, eggs, chicken]
+    dtype: object
+
+    >>> df.str.join("-")
+    1                 NaN
+    2    test-test2-test3
+    3    ham-eggs-chicken
+    dtype: object
     """
     return _na_map(sep.join, arr)
 


### PR DESCRIPTION
Checklist for the pandas documentation sprint (ignore this if you are doing
an unrelated PR):

- [x] PR title is "DOC: update the <your-function-or-method> docstring"
- [x] The validation script passes: `scripts/validate_docstrings.py <your-function-or-method>`
- [x] The PEP8 style check passes: `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] The html version looks good: `python doc/make.py --single <your-function-or-method>`
- [x] It has been proofread on language by another sprint participant

Please include the output of the validation script below between the "```" ticks:

```
################################################################################
###################### Docstring (pandas.Series.str.join) ######################
################################################################################

Join lists contained as elements in the Series/Index with passed delimiter.

If the elements of a Series are lists themselves, join the content of these
lists using the delimiter passed to the function.
This function is an equivalent to :meth:`str.join`.

Parameters
----------
sep : str
    Delimiter to use between list entries.

Returns
-------
Series/Index of objects

Notes
-----
If any of the lists does not contain string objects the result of the join
will be `NaN`.

See Also
--------
str.join : Standard library version of this method.
Series.str.split : Split strings around given separator/delimiter.

Examples
--------

Example with a list that contains non-string elements.

>>> s = pd.Series([['lion', 'elephant', 'zebra'],
...                [1.1, 2.2, 3.3],
...                ["cat", np.nan, "dog"],
...                ["cow", 4.5, "goat"]])
>>> s
0    [lion, elephant, zebra]
1            [1.1, 2.2, 3.3]
2            [cat, nan, dog]
3           [cow, 4.5, goat]
dtype: object

Join all lists using an '-', the list of floats will become a NaN.

>>> s.str.join('-')
0    lion-elephant-zebra
1                    NaN
2                    NaN
3                    NaN
dtype: object

################################################################################
################################## Validation ##################################
################################################################################

Docstring for "pandas.Series.str.join" correct. :)

```

If the validation script still gives errors, but you think there is a good reason
to deviate in this case (and there are certainly such cases), please state this
explicitly.


