### PR TITLE
TST: Fixed version comparison

### DIFF
--- a/pandas/tests/extension/json/test_json.py
+++ b/pandas/tests/extension/json/test_json.py
@@ -1,16 +1,14 @@
 import operator
-import sys
 
 import pytest
 
 
-from pandas.compat import PY36
+from pandas.compat import PY2, PY36
 from pandas.tests.extension import base
 
 from .array import JSONArray, JSONDtype, make_data
 
-pytestmark = pytest.mark.skipif(sys.version_info[0] == 2,
-                                reason="Py2 doesn't have a UserDict")
+pytestmark = pytest.mark.skipif(PY2, reason="Py2 doesn't have a UserDict")
 
 
 @pytest.fixture

--- a/pandas/tests/extension/json/test_json.py
+++ b/pandas/tests/extension/json/test_json.py
@@ -4,6 +4,7 @@ import sys
 import pytest
 
 
+from pandas.compat import PY36
 from pandas.tests.extension import base
 
 from .array import JSONArray, JSONDtype, make_data
@@ -81,7 +82,7 @@ class TestMissing(base.BaseMissingTests):
 
 class TestMethods(base.BaseMethodsTests):
     unhashable = pytest.mark.skip(reason="Unhashable")
-    unstable = pytest.mark.skipif(sys.version_info < (3, 6),
+    unstable = pytest.mark.skipif(not PY36,  # 3.6 or higher
                                   reason="Dictionary order unstable")
 
     @unhashable

--- a/pandas/tests/extension/json/test_json.py
+++ b/pandas/tests/extension/json/test_json.py
@@ -81,7 +81,7 @@ class TestMissing(base.BaseMissingTests):
 
 class TestMethods(base.BaseMethodsTests):
     unhashable = pytest.mark.skip(reason="Unhashable")
-    unstable = pytest.mark.skipif(sys.version_info <= (3, 5),
+    unstable = pytest.mark.skipif(sys.version_info < (3, 6),
                                   reason="Dictionary order unstable")
 
     @unhashable


### PR DESCRIPTION
This failed to skip for 3.5.x because the micro component made it False.


closes https://github.com/pandas-dev/pandas/issues/20468