### PR TITLE
DOC: update the pandas.Series.shift docstring

### DIFF
--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -8372,19 +8372,13 @@ class NDFrame(PandasObject, SelectionMixin):
         ----------
         periods : int
             Number of periods to shift. Can be positive or negative.
-        freq : DateOffset, timedelta, or str, optional
+        freq : DateOffset, tseries.offsets, timedelta, or str, optional
             Offset to use from the tseries module or time rule (e.g. 'EOM').
             If `freq` is specified then the index values are shifted but the
             data is not realigned. That is, use `freq` if you would like to
             extend the index when shifting and preserve the original data.
-        axis : {0 or ‘index’, 1 or ‘columns’, None}, default None
+        axis : {0 or 'index', 1 or 'columns', None}, default None
             Shift direction.
-
-        Notes
-        -----
-        If freq is specified then the index values are shifted but the data
-        is not realigned. That is, use freq if you would like to extend the
-        index when shifting and preserve the original data.
 
         Returns
         -------

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -8390,7 +8390,7 @@ class NDFrame(PandasObject, SelectionMixin):
         Index.shift : Shift values of Index.
         DatetimeIndex.shift : Shift values of DatetimeIndex.
         PeriodIndex.shift : Shift values of PeriodIndex.
-        tshift : Shift the time index, using the index’s frequency if
+        tshift : Shift the time index, using the index's frequency if
             available.
 
         Examples

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -8361,22 +8361,24 @@ class NDFrame(PandasObject, SelectionMixin):
                           errors=errors)
 
     _shared_docs['shift'] = ("""
-        Shift index by desired number of periods with an optional time freq
+        Shift index by desired number of periods with an optional time `freq`.
+
+        When `freq` is not passed, shift the index without realigning the data.
+        If `freq` is passed (in this case, the index must be date or datetime,
+        or it will raises a `NotImplementedError`), the index will be
+        increased using the periods and the `freq`.
 
         Parameters
         ----------
         periods : int
-            Number of periods to move, can be positive or negative.
+            Number of periods to shift; can be positive or negative.
         freq : DateOffset, timedelta, or time rule string, optional
             Increment to use from the tseries module or time rule (e.g. 'EOM').
-            See Notes.
-        axis : %(axes_single_arg)s
-
-        See Also
-        --------
-        Index.shift : Shift values of Index.
-        DatetimeIndex.shift : Shift values of DatetimeIndex.
-        PeriodIndex.shift : Shift values of PeriodIndex.
+            If `freq` is specified then the index values are shifted but the
+            data is not realigned. That is, use `freq` if you would like to
+            extend the index when shifting and preserve the original data.
+        axis : {0 or ‘index’, 1 or ‘columns’, None}, default None
+            Shift direction.
 
         Notes
         -----
@@ -8386,7 +8388,75 @@ class NDFrame(PandasObject, SelectionMixin):
 
         Returns
         -------
-        shifted : %(klass)s
+        %(klass)s
+            Copy of input object, shifted.
+
+        See Also
+        --------
+        Index.shift : Shift values of Index.
+        DatetimeIndex.shift : Shift values of DatetimeIndex.
+        PeriodIndex.shift : Shift values of PeriodIndex.
+        tshift : Shift the time index, using the index’s frequency if
+            available.
+
+        Examples
+        --------
+        >>> df = pd.DataFrame({'Col1': [10, 20, 15, 30, 45],
+        ...                    'Col2': [13, 23, 18, 33, 48],
+        ...                    'Col3': [17, 27, 22, 37, 52]})
+
+        >>> df.shift(periods=3)
+           Col1  Col2  Col3
+        0   NaN   NaN   NaN
+        1   NaN   NaN   NaN
+        2   NaN   NaN   NaN
+        3  10.0  13.0  17.0
+        4  20.0  23.0  27.0
+
+        >>> df.shift(periods=1, axis=1)
+           Col1  Col2  Col3
+        0   NaN  10.0  13.0
+        1   NaN  20.0  23.0
+        2   NaN  15.0  18.0
+        3   NaN  30.0  33.0
+        4   NaN  45.0  48.0
+
+        **freq parameter**
+
+        When using the freq parameter with a :class:pandas.DateTimeIndex
+        the index values are shifted but the data is not realigned.
+
+        >>> names = ['Joaquim', 'Maria', 'Emanuel', 'Jussara', 'Geraldo']
+        >>> dates = pd.date_range(start='2018-03-05 11:15:00',
+        ...                       freq='5D', periods=5)
+        >>> df = pd.DataFrame(data={'names': names}, index=dates)
+        >>> df
+                               names
+        2018-03-05 11:15:00  Joaquim
+        2018-03-10 11:15:00    Maria
+        2018-03-15 11:15:00  Emanuel
+        2018-03-20 11:15:00  Jussara
+        2018-03-25 11:15:00  Geraldo
+
+        Shift the index by 2 days (offset-alias 'D').
+
+        >>> df.shift(periods=2, freq='D')
+                               names
+        2018-03-07 11:15:00  Joaquim
+        2018-03-12 11:15:00    Maria
+        2018-03-17 11:15:00  Emanuel
+        2018-03-22 11:15:00  Jussara
+        2018-03-27 11:15:00  Geraldo
+
+        Shift the index by 75 minutes (offset-alias 'min').
+
+        >>> df.shift(periods=75, freq='min')
+                               names
+        2018-03-05 12:30:00  Joaquim
+        2018-03-10 12:30:00    Maria
+        2018-03-15 12:30:00  Emanuel
+        2018-03-20 12:30:00  Jussara
+        2018-03-25 12:30:00  Geraldo
     """)
 
     @Appender(_shared_docs['shift'] % _shared_doc_kwargs)

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -8365,15 +8365,15 @@ class NDFrame(PandasObject, SelectionMixin):
 
         When `freq` is not passed, shift the index without realigning the data.
         If `freq` is passed (in this case, the index must be date or datetime,
-        or it will raises a `NotImplementedError`), the index will be
+        or it will raise a `NotImplementedError`), the index will be
         increased using the periods and the `freq`.
 
         Parameters
         ----------
         periods : int
-            Number of periods to shift; can be positive or negative.
-        freq : DateOffset, timedelta, or time rule string, optional
-            Increment to use from the tseries module or time rule (e.g. 'EOM').
+            Number of periods to shift. Can be positive or negative.
+        freq : DateOffset, timedelta, or str, optional
+            Offset to use from the tseries module or time rule (e.g. 'EOM').
             If `freq` is specified then the index values are shifted but the
             data is not realigned. That is, use `freq` if you would like to
             extend the index when shifting and preserve the original data.
@@ -8413,50 +8413,13 @@ class NDFrame(PandasObject, SelectionMixin):
         3  10.0  13.0  17.0
         4  20.0  23.0  27.0
 
-        >>> df.shift(periods=1, axis=1)
+        >>> df.shift(periods=1, axis='columns')
            Col1  Col2  Col3
         0   NaN  10.0  13.0
         1   NaN  20.0  23.0
         2   NaN  15.0  18.0
         3   NaN  30.0  33.0
         4   NaN  45.0  48.0
-
-        **freq parameter**
-
-        When using the freq parameter with a :class:pandas.DateTimeIndex
-        the index values are shifted but the data is not realigned.
-
-        >>> names = ['Joaquim', 'Maria', 'Emanuel', 'Jussara', 'Geraldo']
-        >>> dates = pd.date_range(start='2018-03-05 11:15:00',
-        ...                       freq='5D', periods=5)
-        >>> df = pd.DataFrame(data={'names': names}, index=dates)
-        >>> df
-                               names
-        2018-03-05 11:15:00  Joaquim
-        2018-03-10 11:15:00    Maria
-        2018-03-15 11:15:00  Emanuel
-        2018-03-20 11:15:00  Jussara
-        2018-03-25 11:15:00  Geraldo
-
-        Shift the index by 2 days (offset-alias 'D').
-
-        >>> df.shift(periods=2, freq='D')
-                               names
-        2018-03-07 11:15:00  Joaquim
-        2018-03-12 11:15:00    Maria
-        2018-03-17 11:15:00  Emanuel
-        2018-03-22 11:15:00  Jussara
-        2018-03-27 11:15:00  Geraldo
-
-        Shift the index by 75 minutes (offset-alias 'min').
-
-        >>> df.shift(periods=75, freq='min')
-                               names
-        2018-03-05 12:30:00  Joaquim
-        2018-03-10 12:30:00    Maria
-        2018-03-15 12:30:00  Emanuel
-        2018-03-20 12:30:00  Jussara
-        2018-03-25 12:30:00  Geraldo
     """)
 
     @Appender(_shared_docs['shift'] % _shared_doc_kwargs)


### PR DESCRIPTION
Checklist for the pandas documentation sprint (ignore this if you are doing an unrelated PR):

- [x] PR title is "DOC: update the <your-function-or-method> docstring"
- [x] The validation script passes: `scripts/validate_docstrings.py <your-function-or-method>`
- [x] The PEP8 style check passes: `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] The html version looks good: `python doc/make.py --single <your-function-or-method>`
- [x] It has been proofread on language by another sprint participant

Please include the output of the validation script below between the "```" ticks:

```
################################################################################
####################### Docstring (pandas.Series.shift)  #######################
################################################################################

Shift index by desired number of periods with an optional time freq.

When freq is not passed, shift the index without realign the data.
If freq is passed (in this case, the index must be date or datetime),
the index will be increased using the periods and the freq.

Parameters
----------
periods : int
    Number of periods to move, can be positive or negative.
freq : DateOffset, timedelta, or time rule string, optional
    Increment to use from the tseries module or time rule (e.g. 'EOM').
    See Notes.
axis : int or str
    Shift direction. {0, 'index'}.

Notes
-----
If freq is specified then the index values are shifted but the data
is not realigned. That is, use freq if you would like to extend the
index when shifting and preserve the original data.

Returns
-------
shifted : Series

Examples
--------
>>> df = pd.DataFrame({'Col1': [10, 20, 30, 20, 15, 30, 45],
...                    'Col2': [13, 23, 33, 23, 18, 33, 48],
...                    'Col3': [17, 27, 37, 27, 22, 37, 52]})
>>> print(df)
   Col1  Col2  Col3
0    10    13    17
1    20    23    27
2    30    33    37
3    20    23    27
4    15    18    22
5    30    33    37
6    45    48    52

>>> df.shift(periods=3)
   Col1  Col2  Col3
0   NaN   NaN   NaN
1   NaN   NaN   NaN
2   NaN   NaN   NaN
3  10.0  13.0  17.0
4  20.0  23.0  27.0
5  30.0  33.0  37.0
6  20.0  23.0  27.0

>>> df.shift(periods=1, axis=1)
   Col1  Col2  Col3
0   NaN  10.0  13.0
1   NaN  20.0  23.0
2   NaN  30.0  33.0
3   NaN  20.0  23.0
4   NaN  15.0  18.0
5   NaN  30.0  33.0
6   NaN  45.0  48.0

>>> import datetime
>>> names = ['João', 'Maria', 'Emanuel', 'Jussara', 'José']
>>> dates = [datetime.datetime(2018, 3, 1, 11, 15),
...          datetime.datetime(2018, 3, 5, 11, 15),
...          datetime.datetime(2018, 3, 10, 11, 15),
...          datetime.datetime(2018, 3, 15, 11, 15),
...          datetime.datetime(2018, 3, 20, 11, 15)]
>>> df = pd.DataFrame(data={'names': names}, index=dates)
>>> print(df)
                       names
2018-03-01 11:15:00     João
2018-03-05 11:15:00    Maria
2018-03-10 11:15:00  Emanuel
2018-03-15 11:15:00  Jussara
2018-03-20 11:15:00     José

>>> df.shift(periods=2, freq='D')
                       names
2018-03-03 11:15:00     João
2018-03-07 11:15:00    Maria
2018-03-12 11:15:00  Emanuel
2018-03-17 11:15:00  Jussara
2018-03-22 11:15:00     José

>>> df.shift(periods=75, freq='min')
                       names
2018-03-01 12:30:00     João
2018-03-05 12:30:00    Maria
2018-03-10 12:30:00  Emanuel
2018-03-15 12:30:00  Jussara
2018-03-20 12:30:00     José

See Also
--------
slice_shift: Equivalent to shift without copying data.
tshift: Shift the time index, using the index’s frequency if available.

################################################################################
################################## Validation ##################################
################################################################################

Docstring for "pandas.Series.shift" correct. :)
```