### PR TITLE
Parametrized NA sentinel for factorize

### DIFF
--- a/pandas/_libs/hashtable.pxd
+++ b/pandas/_libs/hashtable.pxd
@@ -10,8 +10,6 @@ cdef class HashTable:
 cdef class UInt64HashTable(HashTable):
     cdef:
         kh_uint64_t *table
-        uint64_t na_value
-        bint use_na_value
 
     cpdef get_item(self, uint64_t val)
     cpdef set_item(self, uint64_t key, Py_ssize_t val)
@@ -19,8 +17,6 @@ cdef class UInt64HashTable(HashTable):
 cdef class Int64HashTable(HashTable):
     cdef:
         kh_int64_t *table
-        int64_t na_value
-        bint use_na_value
 
     cpdef get_item(self, int64_t val)
     cpdef set_item(self, int64_t key, Py_ssize_t val)
@@ -28,8 +24,6 @@ cdef class Int64HashTable(HashTable):
 cdef class Float64HashTable(HashTable):
     cdef:
         kh_float64_t *table
-        float64_t na_value
-        bint use_na_value
 
     cpdef get_item(self, float64_t val)
     cpdef set_item(self, float64_t key, Py_ssize_t val)
@@ -37,8 +31,6 @@ cdef class Float64HashTable(HashTable):
 cdef class PyObjectHashTable(HashTable):
     cdef:
         kh_pymap_t *table
-        object na_value
-        bint use_na_value
 
     cpdef get_item(self, object val)
     cpdef set_item(self, object key, Py_ssize_t val)
@@ -47,8 +39,6 @@ cdef class PyObjectHashTable(HashTable):
 cdef class StringHashTable(HashTable):
     cdef:
         kh_str_t *table
-        object na_value
-        bint use_na_value
 
     cpdef get_item(self, object val)
     cpdef set_item(self, object key, Py_ssize_t val)

--- a/pandas/_libs/hashtable.pxd
+++ b/pandas/_libs/hashtable.pxd
@@ -8,32 +8,47 @@ cdef class HashTable:
     pass
 
 cdef class UInt64HashTable(HashTable):
-    cdef kh_uint64_t *table
+    cdef:
+        kh_uint64_t *table
+        uint64_t na_value
+        bint use_na_value
 
     cpdef get_item(self, uint64_t val)
     cpdef set_item(self, uint64_t key, Py_ssize_t val)
 
 cdef class Int64HashTable(HashTable):
-    cdef kh_int64_t *table
+    cdef:
+        kh_int64_t *table
+        int64_t na_value
+        bint use_na_value
 
     cpdef get_item(self, int64_t val)
     cpdef set_item(self, int64_t key, Py_ssize_t val)
 
 cdef class Float64HashTable(HashTable):
-    cdef kh_float64_t *table
+    cdef:
+        kh_float64_t *table
+        float64_t na_value
+        bint use_na_value
 
     cpdef get_item(self, float64_t val)
     cpdef set_item(self, float64_t key, Py_ssize_t val)
 
 cdef class PyObjectHashTable(HashTable):
-    cdef kh_pymap_t *table
+    cdef:
+        kh_pymap_t *table
+        object na_value
+        bint use_na_value
 
     cpdef get_item(self, object val)
     cpdef set_item(self, object key, Py_ssize_t val)
 
 
 cdef class StringHashTable(HashTable):
-    cdef kh_str_t *table
+    cdef:
+        kh_str_t *table
+        object na_value
+        bint use_na_value
 
     cpdef get_item(self, object val)
     cpdef set_item(self, object key, Py_ssize_t val)

--- a/pandas/_libs/hashtable.pxd
+++ b/pandas/_libs/hashtable.pxd
@@ -8,37 +8,32 @@ cdef class HashTable:
     pass
 
 cdef class UInt64HashTable(HashTable):
-    cdef:
-        kh_uint64_t *table
+    cdef kh_uint64_t *table
 
     cpdef get_item(self, uint64_t val)
     cpdef set_item(self, uint64_t key, Py_ssize_t val)
 
 cdef class Int64HashTable(HashTable):
-    cdef:
-        kh_int64_t *table
+    cdef kh_int64_t *table
 
     cpdef get_item(self, int64_t val)
     cpdef set_item(self, int64_t key, Py_ssize_t val)
 
 cdef class Float64HashTable(HashTable):
-    cdef:
-        kh_float64_t *table
+    cdef kh_float64_t *table
 
     cpdef get_item(self, float64_t val)
     cpdef set_item(self, float64_t key, Py_ssize_t val)
 
 cdef class PyObjectHashTable(HashTable):
-    cdef:
-        kh_pymap_t *table
+    cdef kh_pymap_t *table
 
     cpdef get_item(self, object val)
     cpdef set_item(self, object key, Py_ssize_t val)
 
 
 cdef class StringHashTable(HashTable):
-    cdef:
-        kh_str_t *table
+    cdef kh_str_t *table
 
     cpdef get_item(self, object val)
     cpdef set_item(self, object key, Py_ssize_t val)

--- a/pandas/_libs/hashtable.pyx
+++ b/pandas/_libs/hashtable.pyx
@@ -70,7 +70,7 @@ cdef class Factorizer:
         return self.count
 
     def factorize(self, ndarray[object] values, sort=False, na_sentinel=-1,
-                  check_null=True):
+                  na_value=None):
         """
         Factorize values with nans replaced by na_sentinel
         >>> factorize(np.array([1,2,np.nan], dtype='O'), na_sentinel=20)
@@ -81,7 +81,7 @@ cdef class Factorizer:
             uniques.extend(self.uniques.to_array())
             self.uniques = uniques
         labels = self.table.get_labels(values, self.uniques,
-                                       self.count, na_sentinel, check_null)
+                                       self.count, na_sentinel, na_value)
         mask = (labels == na_sentinel)
         # sort on
         if sort:
@@ -114,7 +114,7 @@ cdef class Int64Factorizer:
         return self.count
 
     def factorize(self, int64_t[:] values, sort=False,
-                  na_sentinel=-1, check_null=True):
+                  na_sentinel=-1, na_value=None):
         """
         Factorize values with nans replaced by na_sentinel
         >>> factorize(np.array([1,2,np.nan], dtype='O'), na_sentinel=20)
@@ -126,7 +126,7 @@ cdef class Int64Factorizer:
             self.uniques = uniques
         labels = self.table.get_labels(values, self.uniques,
                                        self.count, na_sentinel,
-                                       check_null)
+                                       na_value=na_value)
 
         # sort on
         if sort:

--- a/pandas/_libs/hashtable_class_helper.pxi.in
+++ b/pandas/_libs/hashtable_class_helper.pxi.in
@@ -308,11 +308,8 @@ def get_dispatch(dtypes):
 
 cdef class {{name}}HashTable(HashTable):
 
-    def __cinit__(self, size_hint=1, {{dtype}}_t na_value={{default_na_value}},
-                  bint use_na_value=False):
+    def __cinit__(self, size_hint=1):
         self.table = kh_init_{{dtype}}()
-        self.na_value = na_value
-        self.use_na_value = use_na_value
         if size_hint is not None:
             kh_resize_{{dtype}}(self.table, size_hint)
 
@@ -411,21 +408,20 @@ cdef class {{name}}HashTable(HashTable):
     @cython.boundscheck(False)
     def get_labels(self, {{dtype}}_t[:] values, {{name}}Vector uniques,
                    Py_ssize_t count_prior, Py_ssize_t na_sentinel,
-                   bint check_null=True):
+                   bint check_null=True,
+                   {{dtype}}_t na_value={{default_na_value}},
+                   bint use_na_value=False):
         cdef:
             Py_ssize_t i, n = len(values)
             int64_t[:] labels
             Py_ssize_t idx, count = count_prior
             int ret = 0
-            {{dtype}}_t val, na_value
+            {{dtype}}_t val
             khiter_t k
             {{name}}VectorData *ud
-            bint use_na_value
 
         labels = np.empty(n, dtype=np.int64)
         ud = uniques.data
-        na_value = self.na_value
-        use_na_value = self.use_na_value
 
         with nogil:
             for i in range(n):
@@ -526,11 +522,8 @@ cdef class StringHashTable(HashTable):
     # or a sentinel np.nan / None missing value
     na_string_sentinel = '__nan__'
 
-    def __init__(self, int size_hint=1, object na_value=na_string_sentinel,
-                 bint use_na_value=False):
+    def __init__(self, int size_hint=1):
         self.table = kh_init_str()
-        self.na_value = na_value
-        self.use_na_value = use_na_value
         if size_hint is not None:
             kh_resize_str(self.table, size_hint)
 
@@ -705,7 +698,9 @@ cdef class StringHashTable(HashTable):
     @cython.boundscheck(False)
     def get_labels(self, ndarray[object] values, ObjectVector uniques,
                    Py_ssize_t count_prior, int64_t na_sentinel,
-                   bint check_null=1):
+                   bint check_null=1,
+                   object na_value=na_string_sentinel,
+                   bint use_na_value=False):
         cdef:
             Py_ssize_t i, n = len(values)
             int64_t[:] labels
@@ -716,14 +711,10 @@ cdef class StringHashTable(HashTable):
             char *v
             char **vecs
             khiter_t k
-            bint use_na_value
 
         # these by-definition *must* be strings
         labels = np.zeros(n, dtype=np.int64)
         uindexer = np.empty(n, dtype=np.int64)
-
-        na_value = self.na_value
-        use_na_value = self.use_na_value
 
         # pre-filter out missing
         # and assign pointers
@@ -768,11 +759,8 @@ na_sentinel = object
 
 cdef class PyObjectHashTable(HashTable):
 
-    def __init__(self, size_hint=1, object na_value=na_sentinel,
-                 bint use_na_value=False):
+    def __init__(self, size_hint=1):
         self.table = kh_init_pymap()
-        self.na_value = na_value
-        self.use_na_value = use_na_value
         kh_resize_pymap(self.table, size_hint)
 
     def __dealloc__(self):
@@ -886,7 +874,9 @@ cdef class PyObjectHashTable(HashTable):
 
     def get_labels(self, ndarray[object] values, ObjectVector uniques,
                    Py_ssize_t count_prior, int64_t na_sentinel,
-                   bint check_null=True):
+                   bint check_null=True,
+                   object na_value=na_sentinel,
+                   bint use_na_value=False):
         cdef:
             Py_ssize_t i, n = len(values)
             int64_t[:] labels
@@ -894,11 +884,8 @@ cdef class PyObjectHashTable(HashTable):
             int ret = 0
             object val
             khiter_t k
-            bint use_na_value
 
         labels = np.empty(n, dtype=np.int64)
-        na_value = self.na_value
-        use_na_value = self.use_na_value
 
         for i in range(n):
             val = values[i]

--- a/pandas/_libs/hashtable_class_helper.pxi.in
+++ b/pandas/_libs/hashtable_class_helper.pxi.in
@@ -716,7 +716,7 @@ cdef class StringHashTable(HashTable):
             int64_t[:] uindexer
             Py_ssize_t idx, count = count_prior
             int ret = 0
-            object val, na_value2
+            object val
             char *v
             char **vecs
             khiter_t k

--- a/pandas/_libs/hashtable_class_helper.pxi.in
+++ b/pandas/_libs/hashtable_class_helper.pxi.in
@@ -409,26 +409,37 @@ cdef class {{name}}HashTable(HashTable):
     def get_labels(self, {{dtype}}_t[:] values, {{name}}Vector uniques,
                    Py_ssize_t count_prior, Py_ssize_t na_sentinel,
                    bint check_null=True,
-                   {{dtype}}_t na_value={{default_na_value}},
-                   bint use_na_value=False):
+                   object na_value=None):
         cdef:
             Py_ssize_t i, n = len(values)
             int64_t[:] labels
             Py_ssize_t idx, count = count_prior
             int ret = 0
-            {{dtype}}_t val
+            {{dtype}}_t val, na_value2
             khiter_t k
             {{name}}VectorData *ud
+            bint use_na_value
 
         labels = np.empty(n, dtype=np.int64)
         ud = uniques.data
+        use_na_value = na_value is not None
+
+        if use_na_value:
+            # We need this na_value2 because we want to allow users
+            # to *optionally* specify an NA sentinel *of the correct* type.
+            # We use None, to make it optional, which requires `object` type
+            # for the parameter. To please the compiler, we use na_value2,
+            # which is only used if it's *specified*.
+            na_value2 = <{{dtype}}_t>na_value
+        else:
+            na_value2 = {{default_na_value}}
 
         with nogil:
             for i in range(n):
                 val = values[i]
 
                 if ((check_null and {{null_condition}}) or
-                        (use_na_value and val == na_value)):
+                        (use_na_value and val == na_value2)):
                     labels[i] = na_sentinel
                     continue
 
@@ -699,22 +710,23 @@ cdef class StringHashTable(HashTable):
     def get_labels(self, ndarray[object] values, ObjectVector uniques,
                    Py_ssize_t count_prior, int64_t na_sentinel,
                    bint check_null=1,
-                   object na_value=na_string_sentinel,
-                   bint use_na_value=False):
+                   object na_value=None):
         cdef:
             Py_ssize_t i, n = len(values)
             int64_t[:] labels
             int64_t[:] uindexer
             Py_ssize_t idx, count = count_prior
             int ret = 0
-            object val
+            object val, na_value2
             char *v
             char **vecs
             khiter_t k
+            bint use_na_value
 
         # these by-definition *must* be strings
         labels = np.zeros(n, dtype=np.int64)
         uindexer = np.empty(n, dtype=np.int64)
+        use_na_value = na_value is not None
 
         # pre-filter out missing
         # and assign pointers
@@ -875,8 +887,7 @@ cdef class PyObjectHashTable(HashTable):
     def get_labels(self, ndarray[object] values, ObjectVector uniques,
                    Py_ssize_t count_prior, int64_t na_sentinel,
                    bint check_null=True,
-                   object na_value=na_sentinel,
-                   bint use_na_value=False):
+                   object na_value=None):
         cdef:
             Py_ssize_t i, n = len(values)
             int64_t[:] labels
@@ -884,8 +895,10 @@ cdef class PyObjectHashTable(HashTable):
             int ret = 0
             object val
             khiter_t k
+            bint use_na_value
 
         labels = np.empty(n, dtype=np.int64)
+        use_na_value = na_value is not None
 
         for i in range(n):
             val = values[i]

--- a/pandas/_libs/hashtable_class_helper.pxi.in
+++ b/pandas/_libs/hashtable_class_helper.pxi.in
@@ -250,13 +250,13 @@ cdef class HashTable:
 
 {{py:
 
-# name, dtype, null_condition, float_group, default_na_value
-dtypes = [('Float64', 'float64', 'val != val', True, 'nan'),
-          ('UInt64', 'uint64', 'False', False, 0),
-          ('Int64', 'int64', 'val == iNaT', False, 'iNaT')]
+# name, dtype, float_group, default_na_value
+dtypes = [('Float64', 'float64', True, 'nan'),
+          ('UInt64', 'uint64', False, 0),
+          ('Int64', 'int64', False, 'iNaT')]
 
 def get_dispatch(dtypes):
-  for (name, dtype, null_condition, float_group, default_na_value) in dtypes:
+  for (name, dtype, float_group, default_na_value) in dtypes:
     unique_template = """\
         cdef:
            Py_ssize_t i, n = len(values)
@@ -298,13 +298,13 @@ def get_dispatch(dtypes):
         return uniques.to_array()
       """
 
-    unique_template = unique_template.format(name=name, dtype=dtype, null_condition=null_condition, float_group=float_group)
+    unique_template = unique_template.format(name=name, dtype=dtype, float_group=float_group)
 
-    yield (name, dtype, null_condition, float_group, default_na_value, unique_template)
+    yield (name, dtype, float_group, default_na_value, unique_template)
 }}
 
 
-{{for name, dtype, null_condition, float_group, default_na_value, unique_template in get_dispatch(dtypes)}}
+{{for name, dtype, float_group, default_na_value, unique_template in get_dispatch(dtypes)}}
 
 cdef class {{name}}HashTable(HashTable):
 
@@ -438,8 +438,7 @@ cdef class {{name}}HashTable(HashTable):
             for i in range(n):
                 val = values[i]
 
-                if ((check_null and {{null_condition}}) or
-                        (use_na_value and val == na_value2)):
+                if check_null and (val != val or val == na_value2):
                     labels[i] = na_sentinel
                     continue
 

--- a/pandas/_libs/hashtable_class_helper.pxi.in
+++ b/pandas/_libs/hashtable_class_helper.pxi.in
@@ -250,13 +250,13 @@ cdef class HashTable:
 
 {{py:
 
-# name, dtype, null_condition, float_group
-dtypes = [('Float64', 'float64', 'val != val', True),
-          ('UInt64', 'uint64', 'False', False),
-          ('Int64', 'int64', 'val == iNaT', False)]
+# name, dtype, null_condition, float_group, default_na_value
+dtypes = [('Float64', 'float64', 'val != val', True, 'nan'),
+          ('UInt64', 'uint64', 'False', False, 0),
+          ('Int64', 'int64', 'val == iNaT', False, 'iNaT')]
 
 def get_dispatch(dtypes):
-  for (name, dtype, null_condition, float_group) in dtypes:
+  for (name, dtype, null_condition, float_group, default_na_value) in dtypes:
     unique_template = """\
         cdef:
            Py_ssize_t i, n = len(values)
@@ -300,16 +300,19 @@ def get_dispatch(dtypes):
 
     unique_template = unique_template.format(name=name, dtype=dtype, null_condition=null_condition, float_group=float_group)
 
-    yield (name, dtype, null_condition, float_group, unique_template)
+    yield (name, dtype, null_condition, float_group, default_na_value, unique_template)
 }}
 
 
-{{for name, dtype, null_condition, float_group, unique_template in get_dispatch(dtypes)}}
+{{for name, dtype, null_condition, float_group, default_na_value, unique_template in get_dispatch(dtypes)}}
 
 cdef class {{name}}HashTable(HashTable):
 
-    def __cinit__(self, size_hint=1):
+    def __cinit__(self, size_hint=1, {{dtype}}_t na_value={{default_na_value}},
+                  bint use_na_value=False):
         self.table = kh_init_{{dtype}}()
+        self.na_value = na_value
+        self.use_na_value = use_na_value
         if size_hint is not None:
             kh_resize_{{dtype}}(self.table, size_hint)
 
@@ -414,18 +417,22 @@ cdef class {{name}}HashTable(HashTable):
             int64_t[:] labels
             Py_ssize_t idx, count = count_prior
             int ret = 0
-            {{dtype}}_t val
+            {{dtype}}_t val, na_value
             khiter_t k
             {{name}}VectorData *ud
+            bint use_na_value
 
         labels = np.empty(n, dtype=np.int64)
         ud = uniques.data
+        na_value = self.na_value
+        use_na_value = self.use_na_value
 
         with nogil:
             for i in range(n):
                 val = values[i]
 
-                if check_null and {{null_condition}}:
+                if ((check_null and {{null_condition}}) or
+                        (use_na_value and val == na_value)):
                     labels[i] = na_sentinel
                     continue
 
@@ -519,8 +526,11 @@ cdef class StringHashTable(HashTable):
     # or a sentinel np.nan / None missing value
     na_string_sentinel = '__nan__'
 
-    def __init__(self, int size_hint=1):
+    def __init__(self, int size_hint=1, object na_value=na_string_sentinel,
+                 bint use_na_value=False):
         self.table = kh_init_str()
+        self.na_value = na_value
+        self.use_na_value = use_na_value
         if size_hint is not None:
             kh_resize_str(self.table, size_hint)
 
@@ -706,10 +716,14 @@ cdef class StringHashTable(HashTable):
             char *v
             char **vecs
             khiter_t k
+            bint use_na_value
 
         # these by-definition *must* be strings
         labels = np.zeros(n, dtype=np.int64)
         uindexer = np.empty(n, dtype=np.int64)
+
+        na_value = self.na_value
+        use_na_value = self.use_na_value
 
         # pre-filter out missing
         # and assign pointers
@@ -717,7 +731,8 @@ cdef class StringHashTable(HashTable):
         for i in range(n):
             val = values[i]
 
-            if PyUnicode_Check(val) or PyString_Check(val):
+            if ((PyUnicode_Check(val) or PyString_Check(val)) and
+                    not (use_na_value and val == na_value)):
                 v = util.get_c_string(val)
                 vecs[i] = v
             else:
@@ -753,8 +768,11 @@ na_sentinel = object
 
 cdef class PyObjectHashTable(HashTable):
 
-    def __init__(self, size_hint=1):
+    def __init__(self, size_hint=1, object na_value=na_sentinel,
+                 bint use_na_value=False):
         self.table = kh_init_pymap()
+        self.na_value = na_value
+        self.use_na_value = use_na_value
         kh_resize_pymap(self.table, size_hint)
 
     def __dealloc__(self):
@@ -876,14 +894,18 @@ cdef class PyObjectHashTable(HashTable):
             int ret = 0
             object val
             khiter_t k
+            bint use_na_value
 
         labels = np.empty(n, dtype=np.int64)
+        na_value = self.na_value
+        use_na_value = self.use_na_value
 
         for i in range(n):
             val = values[i]
             hash(val)
 
-            if check_null and val != val or val is None:
+            if ((check_null and val != val or val is None) or
+                    (use_na_value and val == na_value)):
                 labels[i] = na_sentinel
                 continue
 

--- a/pandas/_libs/hashtable_class_helper.pxi.in
+++ b/pandas/_libs/hashtable_class_helper.pxi.in
@@ -408,7 +408,6 @@ cdef class {{name}}HashTable(HashTable):
     @cython.boundscheck(False)
     def get_labels(self, {{dtype}}_t[:] values, {{name}}Vector uniques,
                    Py_ssize_t count_prior, Py_ssize_t na_sentinel,
-                   bint check_null=True,
                    object na_value=None):
         cdef:
             Py_ssize_t i, n = len(values)
@@ -438,7 +437,7 @@ cdef class {{name}}HashTable(HashTable):
             for i in range(n):
                 val = values[i]
 
-                if check_null and (val != val or val == na_value2):
+                if val != val or (use_na_value and val == na_value2):
                     labels[i] = na_sentinel
                     continue
 
@@ -708,7 +707,6 @@ cdef class StringHashTable(HashTable):
     @cython.boundscheck(False)
     def get_labels(self, ndarray[object] values, ObjectVector uniques,
                    Py_ssize_t count_prior, int64_t na_sentinel,
-                   bint check_null=1,
                    object na_value=None):
         cdef:
             Py_ssize_t i, n = len(values)
@@ -885,7 +883,6 @@ cdef class PyObjectHashTable(HashTable):
 
     def get_labels(self, ndarray[object] values, ObjectVector uniques,
                    Py_ssize_t count_prior, int64_t na_sentinel,
-                   bint check_null=True,
                    object na_value=None):
         cdef:
             Py_ssize_t i, n = len(values)
@@ -903,7 +900,7 @@ cdef class PyObjectHashTable(HashTable):
             val = values[i]
             hash(val)
 
-            if ((check_null and val != val or val is None) or
+            if ((val != val or val is None) or
                     (use_na_value and val == na_value)):
                 labels[i] = na_sentinel
                 continue

--- a/pandas/core/algorithms.py
+++ b/pandas/core/algorithms.py
@@ -515,7 +515,8 @@ def factorize(values, sort=False, order=None, na_sentinel=-1, size_hint=None):
         values, dtype, _ = _ensure_data(values)
 
         if (is_datetime64_any_dtype(original) or
-                is_timedelta64_dtype(original)):
+                is_timedelta64_dtype(original) or
+                is_period_dtype(original)):
             na_value = iNaT
         else:
             na_value = None

--- a/pandas/core/algorithms.py
+++ b/pandas/core/algorithms.py
@@ -29,7 +29,7 @@ from pandas.core.dtypes.common import (
     _ensure_float64, _ensure_uint64,
     _ensure_int64)
 from pandas.compat.numpy import _np_version_under1p10
-from pandas.core.dtypes.missing import isna
+from pandas.core.dtypes.missing import isna, na_value_for_dtype
 
 from pandas.core import common as com
 from pandas._libs import algos, lib, hashtable as htable
@@ -517,7 +517,7 @@ def factorize(values, sort=False, order=None, na_sentinel=-1, size_hint=None):
         if (is_datetime64_any_dtype(original) or
                 is_timedelta64_dtype(original) or
                 is_period_dtype(original)):
-            na_value = iNaT
+            na_value = na_value_for_dtype(original.dtype)
         else:
             na_value = None
 

--- a/pandas/core/algorithms.py
+++ b/pandas/core/algorithms.py
@@ -462,9 +462,10 @@ def _factorize_array(values, check_nulls, na_sentinel=-1, size_hint=None,
     if use_na_value:
         kwargs['na_value'] = na_value
 
-    table = hash_klass(size_hint or len(values), **kwargs)
+    table = hash_klass(size_hint or len(values))
     uniques = vec_klass()
-    labels = table.get_labels(values, uniques, 0, na_sentinel, check_nulls)
+    labels = table.get_labels(values, uniques, 0, na_sentinel, check_nulls,
+                              **kwargs)
 
     labels = _ensure_platform_int(labels)
     uniques = uniques.to_array()

--- a/pandas/core/algorithms.py
+++ b/pandas/core/algorithms.py
@@ -517,7 +517,8 @@ def factorize(values, sort=False, order=None, na_sentinel=-1, size_hint=None):
         dtype = original.dtype
     else:
         values, dtype, _ = _ensure_data(values)
-        check_nulls = not is_integer_dtype(original)
+        check_nulls = (not is_integer_dtype(original) and
+                       not is_bool_dtype(original))
 
         labels, uniques = _factorize_array(values, check_nulls,
                                            na_sentinel=na_sentinel,

--- a/pandas/core/algorithms.py
+++ b/pandas/core/algorithms.py
@@ -513,7 +513,7 @@ def factorize(values, sort=False, order=None, na_sentinel=-1, size_hint=None,
         dtype = original.dtype
     else:
         values, dtype, _ = _ensure_data(values)
-        check_nulls = not is_integer_dtype(original)
+        check_nulls = na_value is not None or not is_integer_dtype(original)
 
         labels, uniques = _factorize_array(values, check_nulls,
                                            na_sentinel=na_sentinel,

--- a/pandas/core/algorithms.py
+++ b/pandas/core/algorithms.py
@@ -456,16 +456,10 @@ def _factorize_array(values, check_nulls, na_sentinel=-1, size_hint=None,
     """
     (hash_klass, vec_klass), values = _get_data_algo(values, _hashtables)
 
-    use_na_value = na_value is not None
-    kwargs = dict(use_na_value=use_na_value)
-
-    if use_na_value:
-        kwargs['na_value'] = na_value
-
     table = hash_klass(size_hint or len(values))
     uniques = vec_klass()
     labels = table.get_labels(values, uniques, 0, na_sentinel, check_nulls,
-                              **kwargs)
+                              na_value=na_value)
 
     labels = _ensure_platform_int(labels)
     uniques = uniques.to_array()

--- a/pandas/core/arrays/categorical.py
+++ b/pandas/core/arrays/categorical.py
@@ -7,7 +7,6 @@ import types
 from pandas import compat
 from pandas.compat import u, lzip
 from pandas._libs import lib, algos as libalgos
-from pandas._libs.tslib import iNaT
 
 from pandas.core.dtypes.generic import (
     ABCSeries, ABCIndexClass, ABCCategoricalIndex)

--- a/pandas/core/arrays/categorical.py
+++ b/pandas/core/arrays/categorical.py
@@ -2164,8 +2164,7 @@ class Categorical(ExtensionArray, PandasObject):
         codes = self.codes.astype('int64')
         # We set missing codes, normally -1, to iNaT so that the
         # Int64HashTable treats them as missing values.
-        labels, uniques = _factorize_array(codes, check_nulls=True,
-                                           na_sentinel=na_sentinel,
+        labels, uniques = _factorize_array(codes, na_sentinel=na_sentinel,
                                            na_value=-1)
         uniques = self._constructor(self.categories.take(uniques),
                                     categories=self.categories,

--- a/pandas/core/arrays/categorical.py
+++ b/pandas/core/arrays/categorical.py
@@ -2163,11 +2163,11 @@ class Categorical(ExtensionArray, PandasObject):
         from pandas.core.algorithms import _factorize_array
 
         codes = self.codes.astype('int64')
-        codes[codes == -1] = iNaT
         # We set missing codes, normally -1, to iNaT so that the
         # Int64HashTable treats them as missing values.
         labels, uniques = _factorize_array(codes, check_nulls=True,
-                                           na_sentinel=na_sentinel)
+                                           na_sentinel=na_sentinel,
+                                           na_value=-1)
         uniques = self._constructor(self.categories.take(uniques),
                                     categories=self.categories,
                                     ordered=self.ordered)

--- a/pandas/core/dtypes/missing.py
+++ b/pandas/core/dtypes/missing.py
@@ -11,6 +11,7 @@ from .common import (is_string_dtype, is_datetimelike,
                      is_datetimelike_v_numeric, is_float_dtype,
                      is_datetime64_dtype, is_datetime64tz_dtype,
                      is_timedelta64_dtype, is_interval_dtype,
+                     is_period_dtype,
                      is_complex_dtype,
                      is_string_like_dtype, is_bool_dtype,
                      is_integer_dtype, is_dtype_equal,
@@ -393,7 +394,7 @@ def na_value_for_dtype(dtype, compat=True):
     dtype = pandas_dtype(dtype)
 
     if (is_datetime64_dtype(dtype) or is_datetime64tz_dtype(dtype) or
-            is_timedelta64_dtype(dtype)):
+            is_timedelta64_dtype(dtype) or is_period_dtype(dtype)):
         return NaT
     elif is_float_dtype(dtype):
         return np.nan

--- a/pandas/tests/dtypes/test_missing.py
+++ b/pandas/tests/dtypes/test_missing.py
@@ -15,7 +15,8 @@ from pandas._libs.tslib import iNaT
 from pandas import (NaT, Float64Index, Series,
                     DatetimeIndex, TimedeltaIndex, date_range)
 from pandas.core.dtypes.common import is_scalar
-from pandas.core.dtypes.dtypes import DatetimeTZDtype
+from pandas.core.dtypes.dtypes import (
+    DatetimeTZDtype, PeriodDtype, IntervalDtype)
 from pandas.core.dtypes.missing import (
     array_equivalent, isna, notna, isnull, notnull,
     na_value_for_dtype)
@@ -311,23 +312,27 @@ def test_array_equivalent_str():
                                     np.array(['A', 'X'], dtype=dtype))
 
 
-def test_na_value_for_dtype():
-    for dtype in [np.dtype('M8[ns]'), np.dtype('m8[ns]'),
-                  DatetimeTZDtype('datetime64[ns, US/Eastern]')]:
-        assert na_value_for_dtype(dtype) is NaT
-
-    for dtype in ['u1', 'u2', 'u4', 'u8',
-                  'i1', 'i2', 'i4', 'i8']:
-        assert na_value_for_dtype(np.dtype(dtype)) == 0
-
-    for dtype in ['bool']:
-        assert na_value_for_dtype(np.dtype(dtype)) is False
-
-    for dtype in ['f2', 'f4', 'f8']:
-        assert np.isnan(na_value_for_dtype(np.dtype(dtype)))
-
-    for dtype in ['O']:
-        assert np.isnan(na_value_for_dtype(np.dtype(dtype)))
+@pytest.mark.parametrize('dtype, na_value', [
+    # Datetime-like
+    (np.dtype("M8[ns]"), NaT),
+    (np.dtype("m8[ns]"), NaT),
+    (DatetimeTZDtype('datetime64[ns, US/Eastern]'), NaT),
+    (PeriodDtype("M"), NaT),
+    # Integer
+    ('u1', 0), ('u2', 0), ('u4', 0), ('u8', 0),
+    ('i1', 0), ('i2', 0), ('i4', 0), ('i8', 0),
+    # Bool
+    ('bool', False),
+    # Float
+    ('f2', np.nan), ('f4', np.nan), ('f8', np.nan),
+    # Object
+    ('O', np.nan),
+    # Interval
+    (IntervalDtype(), np.nan),
+])
+def test_na_value_for_dtype(dtype, na_value):
+    result = na_value_for_dtype(dtype)
+    assert result is na_value
 
 
 class TestNAObj(object):

--- a/pandas/tests/test_algos.py
+++ b/pandas/tests/test_algos.py
@@ -275,7 +275,10 @@ class TestFactorize(object):
         (np.array([1, 0, 1, 2], dtype='u8'), 1),
         (np.array([-2**63, 1, -2**63, 0], dtype='i8'), -2**63),
         (np.array([1, -2**63, 1, 0], dtype='i8'), 1),
-        (np.array(['a', '', 'a', 'b'], dtype=object), 'a')
+        (np.array(['a', '', 'a', 'b'], dtype=object), 'a'),
+        (np.array([(), ('a', 1), (), ('a', 2)], dtype=object), ()),
+        (np.array([('a', 1), (), ('a', 1), ('a', 2)], dtype=object),
+         ('a', 1)),
     ])
     def test_parametrized_factorize_na_value(self, data, na_value):
         l, u = algos._factorize_array(data, check_nulls=True,

--- a/pandas/tests/test_algos.py
+++ b/pandas/tests/test_algos.py
@@ -281,8 +281,7 @@ class TestFactorize(object):
          ('a', 1)),
     ])
     def test_parametrized_factorize_na_value(self, data, na_value):
-        l, u = algos._factorize_array(data, check_nulls=True,
-                                      na_value=na_value)
+        l, u = algos._factorize_array(data, na_value=na_value)
         expected_uniques = data[[1, 3]]
         expected_labels = np.array([-1, 0, -1, 1], dtype='i8')
         tm.assert_numpy_array_equal(l, expected_labels)

--- a/pandas/tests/test_algos.py
+++ b/pandas/tests/test_algos.py
@@ -266,7 +266,7 @@ class TestFactorize(object):
         # arrays that include the NA default for that type, but isn't used.
         l, u = algos.factorize(data)
         expected_uniques = data[[0, 1]]
-        expected_labels = np.array([0, 1, 0])
+        expected_labels = np.array([0, 1, 0], dtype='i8')
         tm.assert_numpy_array_equal(l, expected_labels)
         tm.assert_numpy_array_equal(u, expected_uniques)
 
@@ -281,7 +281,7 @@ class TestFactorize(object):
         l, u = algos._factorize_array(data, check_nulls=True,
                                       na_value=na_value)
         expected_uniques = data[[1, 3]]
-        expected_labels = np.array([-1, 0, -1, 1])
+        expected_labels = np.array([-1, 0, -1, 1], dtype='i8')
         tm.assert_numpy_array_equal(l, expected_labels)
         tm.assert_numpy_array_equal(u, expected_uniques)
 

--- a/pandas/tests/test_algos.py
+++ b/pandas/tests/test_algos.py
@@ -272,8 +272,10 @@ class TestFactorize(object):
 
     @pytest.mark.parametrize('data, na_value', [
         (np.array([0, 1, 0, 2], dtype='u8'), 0),
+        (np.array([1, 0, 1, 2], dtype='u8'), 1),
         (np.array([-2**63, 1, -2**63, 0], dtype='i8'), -2**63),
-        (np.array(['', 'a', '', 'b'], dtype=object), '')
+        (np.array([1, -2**63, 1, 0], dtype='i8'), 1),
+        (np.array(['a', '', 'a', 'b'], dtype=object), 'a')
     ])
     def test_parametrized_factorize_na_value(self, data, na_value):
         l, u = pd.factorize(data, na_value=na_value)

--- a/pandas/tests/test_algos.py
+++ b/pandas/tests/test_algos.py
@@ -257,6 +257,31 @@ class TestFactorize(object):
         with tm.assert_produces_warning(False):
             algos.factorize(data)
 
+    @pytest.mark.parametrize('data', [
+        np.array([0, 1, 0], dtype='u8'),
+        np.array([-2**63, 1, -2**63], dtype='i8'),
+        np.array(['__nan__', 'foo', '__nan__'], dtype='object'),
+    ])
+    def test_parametrized_factorize_na_value_default(self, data):
+        # arrays that include the NA default for that type, but isn't used.
+        l, u = pd.factorize(data)
+        expected_uniques = data[[0, 1]]
+        expected_labels = np.array([0, 1, 0])
+        tm.assert_numpy_array_equal(l, expected_labels)
+        tm.assert_numpy_array_equal(u, expected_uniques)
+
+    @pytest.mark.parametrize('data, na_value', [
+        (np.array([0, 1, 0, 2], dtype='u8'), 0),
+        (np.array([-2**63, 1, -2**63, 0], dtype='i8'), -2**63),
+        (np.array(['', 'a', '', 'b'], dtype=object), '')
+    ])
+    def test_parametrized_factorize_na_value(self, data, na_value):
+        l, u = pd.factorize(data, na_value=na_value)
+        expected_uniques = data[[1, 3]]
+        expected_labels = np.array([-1, 0, -1, 1])
+        tm.assert_numpy_array_equal(l, expected_labels)
+        tm.assert_numpy_array_equal(u, expected_uniques)
+
 
 class TestUnique(object):
 

--- a/pandas/tests/test_algos.py
+++ b/pandas/tests/test_algos.py
@@ -264,7 +264,7 @@ class TestFactorize(object):
     ])
     def test_parametrized_factorize_na_value_default(self, data):
         # arrays that include the NA default for that type, but isn't used.
-        l, u = pd.factorize(data)
+        l, u = algos.factorize(data)
         expected_uniques = data[[0, 1]]
         expected_labels = np.array([0, 1, 0])
         tm.assert_numpy_array_equal(l, expected_labels)
@@ -278,7 +278,8 @@ class TestFactorize(object):
         (np.array(['a', '', 'a', 'b'], dtype=object), 'a')
     ])
     def test_parametrized_factorize_na_value(self, data, na_value):
-        l, u = pd.factorize(data, na_value=na_value)
+        l, u = algos._factorize_array(data, check_nulls=True,
+                                      na_value=na_value)
         expected_uniques = data[[1, 3]]
         expected_labels = np.array([-1, 0, -1, 1])
         tm.assert_numpy_array_equal(l, expected_labels)


### PR DESCRIPTION
Adds a new keyword `na_value` to control the NA sentinel inside the factorize
routine.

```python
In [3]: arr = np.array([0, 1, 0, 2], dtype='u8')

In [4]: pd.factorize(arr)
Out[4]: (array([0, 1, 0, 2]), array([0, 1, 2], dtype=uint64))

In [5]: pd.factorize(arr, na_value=0)
Out[5]: (array([-1,  0, -1,  1]), array([1, 2], dtype=uint64))
```

The basic idea is that our hashtables now have two "modes" for detecting NA values

1. The previous way, based on the templated na_condition
2. Equality to a user-specified NA value.

Note: specifying NA value does not "turn off" the old way of checking NAs.

```python
In [2]: pd.factorize(np.array([0.0, np.nan, 1.0]), na_value=0.0)
Out[2]: (array([-1, -1,  0]), array([1.]))
```

I'm sure the implementation can be cleaned up, but I wanted to put this up for feedback. Hopefully someone can tell me how to avoid the `use_default_na` nonsense :)

cc @WillAyd

closes https://github.com/pandas-dev/pandas/issues/20328