### PR TITLE
DOC: docstring to series.unique

### DIFF
--- a/pandas/core/base.py
+++ b/pandas/core/base.py
@@ -1020,30 +1020,6 @@ class IndexOpsMixin(object):
                               normalize=normalize, bins=bins, dropna=dropna)
         return result
 
-    _shared_docs['unique'] = (
-        """
-        Return unique values in the object. Uniques are returned in order
-        of appearance, this does NOT sort. Hash table-based unique.
-
-        Parameters
-        ----------
-        values : 1d array-like
-
-        Returns
-        -------
-        unique values.
-          - If the input is an Index, the return is an Index
-          - If the input is a Categorical dtype, the return is a Categorical
-          - If the input is a Series/ndarray, the return will be an ndarray
-
-        See Also
-        --------
-        unique
-        Index.unique
-        Series.unique
-        """)
-
-    @Appender(_shared_docs['unique'] % _indexops_doc_kwargs)
     def unique(self):
         values = self._values
 

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -1438,7 +1438,7 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
 
         Returns
         -------
-        unique values : ndarray or Categorical
+        ndarray or Categorical
             The unique values returned as a NumPy array. In case of categorical
             data type, returned as a Categorical.
 
@@ -1452,13 +1452,10 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
         >>> pd.Series([2, 1, 3, 3], name='A').unique()
         array([2, 1, 3])
 
-        >>> pd.Series([2] + [1] * 5).unique()
-        array([2, 1])
-
-        >>> pd.Series([pd.Timestamp('20160101') for _ in range(3)]).unique()
+        >>> pd.Series([pd.Timestamp('2016-01-01') for _ in range(3)]).unique()
         array(['2016-01-01T00:00:00.000000000'], dtype='datetime64[ns]')
 
-        >>> pd.Series([pd.Timestamp('20160101', tz='US/Eastern')
+        >>> pd.Series([pd.Timestamp('2016-01-01', tz='US/Eastern')
         ...            for _ in range(3)]).unique()
         array([Timestamp('2016-01-01 00:00:00-0500', tz='US/Eastern')],
               dtype=object)

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -1459,8 +1459,8 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
         >>> pd.Series([pd.Timestamp('20160101') for _ in range(3)]).unique()
         array(['2016-01-01T00:00:00.000000000'], dtype='datetime64[ns]')
 
-        >>> pd.Series([pd.Timestamp('20160101', tz='US/Eastern') \
-                       for _ in range(3)]).unique()
+        >>> pd.Series([pd.Timestamp('20160101', tz='US/Eastern')
+        ...            for _ in range(3)]).unique()
         array([Timestamp('2016-01-01 00:00:00-0500', tz='US/Eastern')],
               dtype=object)
 
@@ -1473,8 +1473,8 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
 
         An ordered Categorical preserves the category ordering.
 
-        >>> pd.Series(pd.Categorical(list('baabc'), categories=list('abc'), \
-                                     ordered=True)).unique()
+        >>> pd.Series(pd.Categorical(list('baabc'), categories=list('abc'),
+        ...                          ordered=True)).unique()
         [b, a, c]
         Categories (3, object): [a < b < c]
         """

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -1445,8 +1445,8 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
 
         See Also
         --------
-        unique
-        Index.unique
+        unique : return unique values of 1d array-like objects.
+        Index.unique : return Index with unique values from an Index object.
 
         Examples
         --------

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -1438,7 +1438,9 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
 
         Returns
         -------
-        unique values : Series or Categorical
+        unique values : ndarray or Categorical
+            The unique values returned as a NumPy array. In case of categorical
+            data type, returned as a Categorical.
 
         See Also
         --------

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -1459,7 +1459,7 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
         >>> pd.Series([pd.Timestamp('20160101') for _ in range(3)]).unique()
         array(['2016-01-01T00:00:00.000000000'], dtype='datetime64[ns]')
 
-        >>> pd.Series([pd.Timestamp('20160101', tz='US/Eastern')
+        >>> pd.Series([pd.Timestamp('20160101', tz='US/Eastern') \
                        for _ in range(3)]).unique()
         array([Timestamp('2016-01-01 00:00:00-0500', tz='US/Eastern')],
               dtype=object)
@@ -1473,7 +1473,7 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
 
         An ordered Categorical preserves the category ordering.
 
-        >>> pd.Series(pd.Categorical(list('baabc'), categories=list('abc'),
+        >>> pd.Series(pd.Categorical(list('baabc'), categories=list('abc'), \
                                      ordered=True)).unique()
         [b, a, c]
         Categories (3, object): [a < b < c]

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -1438,10 +1438,7 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
 
         Returns
         -------
-        unique values.
-          - If the input is an Index, the return is an Index
-          - If the input is a Categorical dtype, the return is a Categorical
-          - If the input is a Series/ndarray, the return will be an ndarray
+        unique values : Series or Categorical
 
         See Also
         --------

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -1429,8 +1429,28 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
         # TODO: Add option for bins like value_counts()
         return algorithms.mode(self)
 
-    @Appender(base._shared_docs['unique'] % _shared_doc_kwargs)
     def unique(self):
+        """
+        Return unique values in the object. Uniques are returned in order
+        of appearance, this does NOT sort. Hash table-based unique.
+
+        Parameters
+        ----------
+        values : 1d array-like
+
+        Returns
+        -------
+        unique values.
+          - If the input is an Index, the return is an Index
+          - If the input is a Categorical dtype, the return is a Categorical
+          - If the input is a Series/ndarray, the return will be an ndarray
+
+        See Also
+        --------
+        unique
+        Index.unique
+        Series.unique
+        """
         result = super(Series, self).unique()
 
         if is_datetime64tz_dtype(self.dtype):

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -1445,7 +1445,7 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
 
         See Also
         --------
-        unique : return unique values of 1d array-like objects.
+        pandas.unique : top-level unique method for any 1-d array-like object.
         Index.unique : return Index with unique values from an Index object.
 
         Examples

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -1431,12 +1431,10 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
 
     def unique(self):
         """
-        Return unique values in the object. Uniques are returned in order
-        of appearance, this does NOT sort. Hash table-based unique.
+        Return unique values in the Series.
 
-        Parameters
-        ----------
-        values : 1d array-like
+        Uniques are returned in order of appearance. Hash table-based unique,
+        therefore does NOT sort.
 
         Returns
         -------
@@ -1449,7 +1447,36 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
         --------
         unique
         Index.unique
-        Series.unique
+
+        Examples
+        --------
+        >>> pd.Series([2, 1, 3, 3], name='A').unique()
+        array([2, 1, 3])
+
+        >>> pd.Series([2] + [1] * 5).unique()
+        array([2, 1])
+
+        >>> pd.Series([pd.Timestamp('20160101') for _ in range(3)]).unique()
+        array(['2016-01-01T00:00:00.000000000'], dtype='datetime64[ns]')
+
+        >>> pd.Series([pd.Timestamp('20160101', tz='US/Eastern')
+                       for _ in range(3)]).unique()
+        array([Timestamp('2016-01-01 00:00:00-0500', tz='US/Eastern')],
+              dtype=object)
+
+        An unordered Categorical will return categories in the order of
+        appearance.
+
+        >>> pd.Series(pd.Categorical(list('baabc'))).unique()
+        [b, a, c]
+        Categories (3, object): [b, a, c]
+
+        An ordered Categorical preserves the category ordering.
+
+        >>> pd.Series(pd.Categorical(list('baabc'), categories=list('abc'),
+                                     ordered=True)).unique()
+        [b, a, c]
+        Categories (3, object): [a < b < c]
         """
         result = super(Series, self).unique()
 

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -1431,7 +1431,7 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
 
     def unique(self):
         """
-        Return unique values in the Series.
+        Return unique values of Series object.
 
         Uniques are returned in order of appearance. Hash table-based unique,
         therefore does NOT sort.


### PR DESCRIPTION
- [x] closes #20075 
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

seems that no one has picked this up. moving _shared_doc['unique'] used by Series.unique() only to Series.unique.
```
################################################################################
####################### Docstring (pandas.Series.unique) #######################
################################################################################

Return unique values of Series object.

Uniques are returned in order of appearance. Hash table-based unique,
therefore does NOT sort.

Returns
-------
unique values.
  - If the input is an Index, the return is an Index
  - If the input is a Categorical dtype, the return is a Categorical
  - If the input is a Series/ndarray, the return will be an ndarray

See Also
--------
unique : return unique values of 1d array-like objects.
Index.unique : return Index with unique values from an Index object.

Examples
--------
>>> pd.Series([2, 1, 3, 3], name='A').unique()
array([2, 1, 3])

>>> pd.Series([2] + [1] * 5).unique()
array([2, 1])

>>> pd.Series([pd.Timestamp('20160101') for _ in range(3)]).unique()
array(['2016-01-01T00:00:00.000000000'], dtype='datetime64[ns]')

>>> pd.Series([pd.Timestamp('20160101', tz='US/Eastern')                        for _ in range(3)]).unique()
array([Timestamp('2016-01-01 00:00:00-0500', tz='US/Eastern')],
      dtype=object)

An unordered Categorical will return categories in the order of
appearance.

>>> pd.Series(pd.Categorical(list('baabc'))).unique()
[b, a, c]
Categories (3, object): [b, a, c]

An ordered Categorical preserves the category ordering.

>>> pd.Series(pd.Categorical(list('baabc'), categories=list('abc'),                                      ordered=True)).unique()
[b, a, c]
Categories (3, object): [a < b < c]

################################################################################
################################## Validation ##################################
################################################################################

Docstring for "pandas.Series.unique" correct. :)
```