### PR TITLE
BUG: read_excel return empty dataframe when using usecols

### DIFF
--- a/doc/source/io.rst
+++ b/doc/source/io.rst
@@ -2852,23 +2852,46 @@ Parsing Specific Columns
 
 It is often the case that users will insert columns to do temporary computations
 in Excel and you may not want to read in those columns. ``read_excel`` takes
-a ``usecols`` keyword to allow you to specify a subset of columns to parse.
+either a ``usecols`` or ``usecols_excel`` keyword to allow you to specify a
+subset of columns to parse. Note that you can not use both ``usecols`` and
+``usecols_excel`` named arguments at the same time.
 
-If ``usecols`` is an integer, then it is assumed to indicate the last column
-to be parsed.
-
-.. code-block:: python
-
-   read_excel('path_to_file.xls', 'Sheet1', usecols=2)
-
-If `usecols` is a list of integers, then it is assumed to be the file column
-indices to be parsed.
+If ``usecols_excel`` is supplied, then it is assumed that indicates a comma
+separated list of Excel column letters and column ranges to be parsed.
 
 .. code-block:: python
 
-   read_excel('path_to_file.xls', 'Sheet1', usecols=[0, 2, 3])
+   read_excel('path_to_file.xls', 'Sheet1', usecols_excel='A:E')
+   read_excel('path_to_file.xls', 'Sheet1', usecols_excel='A,C,E:F')
 
-Element order is ignored, so ``usecols=[0, 1]`` is the same as ``[1, 0]``.
+If ``usecols`` is a list of integers, then it is assumed to be the file
+column indices to be parsed.
+
+.. code-block:: python
+
+   read_excel('path_to_file.xls', 'Sheet1', usecols=[1, 3, 5])
+
+Element order is ignored, so ``usecols_excel=[0, 1]`` is the same as ``[1, 0]``.
+
+If ``usecols`` is a list of strings, then it is assumed that each string
+correspond to column names provided either by the user in `names` or
+inferred from the document header row(s) and those strings define which columns
+will be parsed.
+
+.. code-block:: python
+
+   read_excel('path_to_file.xls', 'Sheet1', usecols=['foo', 'bar'])
+
+Element order is ignored, so ``usecols=['baz', 'joe']`` is the same as
+``['joe', 'baz']``.
+
+If ``usecols`` is callable, the callable function will be evaluated against the
+column names, returning names where the callable function evaluates to True.
+
+.. code-block:: python
+
+   read_excel('path_to_file.xls', 'Sheet1', usecols=lambda x: x.isalpha())
+
 
 Parsing Dates
 +++++++++++++

--- a/doc/source/whatsnew/v0.24.0.txt
+++ b/doc/source/whatsnew/v0.24.0.txt
@@ -36,7 +36,7 @@ Datetimelike API Changes
 Other API Changes
 ^^^^^^^^^^^^^^^^^
 
--
+- :func:`read_excel` has gained the keyword argument ``usecols_excel`` that receives a string containing comma separated Excel ranges and columns. The ``usecols`` keyword argument at :func:`read_excel` had removed support for a string containing comma separated Excel ranges and columns and for an int indicating the first j columns to be read in a ``DataFrame``. Also, the ``usecols`` keyword argument at :func:`read_excel` had added support for receiving a list of strings containing column labels and a callable. (:issue:`18273`)
 -
 -
 
@@ -148,7 +148,7 @@ I/O
 ^^^
 
 -
--
+- Bug in :func:`read_excel` where ``usecols`` keyword argument as a list of strings were returning a empty ``DataFrame`` (:issue:`18273`)
 -
 
 Plotting


### PR DESCRIPTION
- [x] closes #18273
- [x] tests added / passed
- [x] passes git diff master --name-only -- "*.py" | grep "pandas/" | xargs -r flake8
- [x] whatsnew entry

As mentioned read_excel returns an empty DataFrame when usecols argument is a list of strings.
Now lists of strings are correctly interpreted by read_excel function.