### PR TITLE
removed not necessary bn switch decorator on nansum

### DIFF
--- a/pandas/core/nanops.py
+++ b/pandas/core/nanops.py
@@ -326,7 +326,6 @@ def nanall(values, axis=None, skipna=True):
 
 
 @disallow('M8')
-@bottleneck_switch()
 def nansum(values, axis=None, skipna=True, min_count=0):
     values, mask, dtype, dtype_max = _get_values(values, skipna, 0)
     dtype_sum = dtype_max


### PR DESCRIPTION
Removed not necessary bottleneck_switch decorator on nansum function like nanprod.