### PR TITLE
BUG: raise error when setting cached properties

### DIFF
--- a/pandas/_libs/properties.pyx
+++ b/pandas/_libs/properties.pyx
@@ -37,6 +37,9 @@ cdef class CachedProperty(object):
             PyDict_SetItem(cache, self.name, val)
         return val
 
+    def __set__(self, obj, value):
+        raise AttributeError("Can't set attribute")
+
 
 cache_readonly = CachedProperty
 

--- a/pandas/tests/indexes/test_base.py
+++ b/pandas/tests/indexes/test_base.py
@@ -2056,6 +2056,11 @@ Index([u'a', u'bb', u'ccc', u'a', u'bb', u'ccc', u'a', u'bb', u'ccc', u'a',
         ser.index -= 1
         assert ser.index.name == "foo"
 
+    def test_cached_properties_not_settable(self):
+        idx = pd.Index([1, 2, 3])
+        with tm.assert_raises_regex(AttributeError, "Can't set attribute"):
+            idx.is_unique = False
+
 
 class TestMixedIntIndex(Base):
     # Mostly the tests from common.py for which the results differ


### PR DESCRIPTION
A bug I introduced myself some time ago in https://github.com/pandas-dev/pandas/pull/19991. Apparently the object needs to explicitly raise in the `__set__` method, otherwise the property is assumed to be settable:

```
In [6]: idx = pd.Index([1, 2, 3])

In [7]: idx.is_unique
Out[7]: True

In [8]: idx.is_unique = False

In [9]: idx.is_unique
Out[9]: False

In [10]: idx.is_monotonic
Out[10]: True

In [11]: idx.is_monotonic = False
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
<ipython-input-11-b2a74ac7466c> in <module>()
----> 1 idx.is_monotonic = False

AttributeError: can't set attribute
```

`is_unique` is a cached property, didn't raise anymore on master (see above), in contrast to normal property `is_monotonic`.

This patch ensures also cached properties have the same error.