### PR TITLE
CLN: remove deprecated infer_dst keyword

### DIFF
--- a/asv_bench/benchmarks/timeseries.py
+++ b/asv_bench/benchmarks/timeseries.py
@@ -75,8 +75,7 @@ class TzLocalize(object):
                                                   freq='S'))
 
     def time_infer_dst(self):
-        with warnings.catch_warnings(record=True):
-            self.index.tz_localize('US/Eastern', infer_dst=True)
+        self.index.tz_localize('US/Eastern', ambiguous='infer')
 
 
 class ResetIndex(object):

--- a/doc/source/timeseries.rst
+++ b/doc/source/timeseries.rst
@@ -2191,10 +2191,9 @@ Ambiguous Times when Localizing
 
 In some cases, localize cannot determine the DST and non-DST hours when there are
 duplicates.  This often happens when reading files or database records that simply
-duplicate the hours.  Passing ``ambiguous='infer'`` (``infer_dst`` argument in prior
-releases) into ``tz_localize`` will attempt to determine the right offset.  Below
-the top example will fail as it contains ambiguous times and the bottom will
-infer the right offset.
+duplicate the hours.  Passing ``ambiguous='infer'`` into ``tz_localize`` will
+attempt to determine the right offset.  Below the top example will fail as it
+contains ambiguous times and the bottom will infer the right offset.
 
 .. ipython:: python
 

--- a/doc/source/whatsnew/v0.23.0.txt
+++ b/doc/source/whatsnew/v0.23.0.txt
@@ -777,6 +777,10 @@ Removal of prior version deprecations/changes
 - The top-level functions ``pd.rolling_*``, ``pd.expanding_*`` and ``pd.ewm*`` have been removed (Deprecated since v0.18).
   Instead, use the DataFrame/Series methods :attr:`~DataFrame.rolling`, :attr:`~DataFrame.expanding` and :attr:`~DataFrame.ewm` (:issue:`18723`)
 - Imports from ``pandas.core.common`` for functions such as ``is_datetime64_dtype`` are now removed. These are located in ``pandas.api.types``. (:issue:`13634`, :issue:`19769`)
+- The ``infer_dst`` keyword in :meth:`Series.tz_localize`, :meth:`DatetimeIndex.tz_localize`
+  and :class:`DatetimeIndex` have been removed. ``infer_dst=True`` is equivalent to
+  ``ambiguous='infer'``, and ``infer_dst=False`` to ``ambiguous='raise'`` (:issue:`7963`).
+
 
 .. _whatsnew_0230.performance:
 

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -7937,9 +7937,6 @@ class NDFrame(PandasObject, SelectionMixin):
         result.set_axis(ax, axis=axis, inplace=True)
         return result.__finalize__(self)
 
-    @deprecate_kwarg(old_arg_name='infer_dst', new_arg_name='ambiguous',
-                     mapping={True: 'infer',
-                              False: 'raise'})
     def tz_localize(self, tz, axis=0, level=None, copy=True,
                     ambiguous='raise'):
         """
@@ -7963,9 +7960,6 @@ class NDFrame(PandasObject, SelectionMixin):
             - 'NaT' will return NaT where there are ambiguous times
             - 'raise' will raise an AmbiguousTimeError if there are ambiguous
               times
-        infer_dst : boolean, default False
-            .. deprecated:: 0.15.0
-               Attempt to infer fall dst-transition hours based on order
 
         Returns
         -------

--- a/pandas/core/indexes/datetimes.py
+++ b/pandas/core/indexes/datetimes.py
@@ -208,9 +208,6 @@ class DatetimeIndex(DatelikeOps, TimelikeOps, DatetimeIndexOpsMixin,
           times)
         - 'NaT' will return NaT where there are ambiguous times
         - 'raise' will raise an AmbiguousTimeError if there are ambiguous times
-    infer_dst : boolean, default False
-        .. deprecated:: 0.15.0
-           Attempt to infer fall dst-transition hours based on order
     name : object
         Name to be stored in the index
     dayfirst : bool, default False
@@ -329,8 +326,6 @@ class DatetimeIndex(DatelikeOps, TimelikeOps, DatetimeIndexOpsMixin,
     _is_numeric_dtype = False
     _infer_as_myclass = True
 
-    @deprecate_kwarg(old_arg_name='infer_dst', new_arg_name='ambiguous',
-                     mapping={True: 'infer', False: 'raise'})
     def __new__(cls, data=None,
                 freq=None, start=None, end=None, periods=None, tz=None,
                 normalize=False, closed=None, ambiguous='raise',
@@ -2270,8 +2265,6 @@ class DatetimeIndex(DatelikeOps, TimelikeOps, DatetimeIndexOpsMixin,
         # No conversion since timestamps are all UTC to begin with
         return self._shallow_copy(tz=tz)
 
-    @deprecate_kwarg(old_arg_name='infer_dst', new_arg_name='ambiguous',
-                     mapping={True: 'infer', False: 'raise'})
     def tz_localize(self, tz, ambiguous='raise', errors='raise'):
         """
         Localize tz-naive DatetimeIndex to tz-aware DatetimeIndex.
@@ -2305,10 +2298,6 @@ default 'raise'
               to the specified time zone
 
             .. versionadded:: 0.19.0
-
-        infer_dst : boolean, default False
-            .. deprecated:: 0.15.0
-               Attempt to infer fall dst-transition hours based on order
 
         Returns
         -------

--- a/pandas/core/indexes/period.py
+++ b/pandas/core/indexes/period.py
@@ -1095,7 +1095,7 @@ class PeriodIndex(DatelikeOps, DatetimeIndexOpsMixin, Int64Index):
         """
         raise NotImplementedError("Not yet implemented for PeriodIndex")
 
-    def tz_localize(self, tz, infer_dst=False):
+    def tz_localize(self, tz, ambiguous='raise'):
         """
         Localize tz-naive DatetimeIndex to given time zone (using
         pytz/dateutil), or remove timezone from tz-aware DatetimeIndex
@@ -1106,8 +1106,6 @@ class PeriodIndex(DatelikeOps, DatetimeIndexOpsMixin, Int64Index):
             Time zone for time. Corresponding timestamps would be converted to
             time zone of the TimeSeries.
             None will remove timezone holding local time.
-        infer_dst : boolean, default False
-            Attempt to infer fall dst-transition hours based on order
 
         Returns
         -------

--- a/pandas/tests/indexes/datetimes/test_timezones.py
+++ b/pandas/tests/indexes/datetimes/test_timezones.py
@@ -341,9 +341,6 @@ class TestDatetimeIndexTimezones(object):
         di = DatetimeIndex(times)
         localized = di.tz_localize(tz, ambiguous='infer')
         tm.assert_index_equal(dr, localized)
-        with tm.assert_produces_warning(FutureWarning):
-            localized_old = di.tz_localize(tz, infer_dst=True)
-        tm.assert_index_equal(dr, localized_old)
         tm.assert_index_equal(dr, DatetimeIndex(times, tz=tz,
                                                 ambiguous='infer'))
 
@@ -353,9 +350,6 @@ class TestDatetimeIndexTimezones(object):
         localized = dr.tz_localize(tz)
         localized_infer = dr.tz_localize(tz, ambiguous='infer')
         tm.assert_index_equal(localized, localized_infer)
-        with tm.assert_produces_warning(FutureWarning):
-            localized_infer_old = dr.tz_localize(tz, infer_dst=True)
-        tm.assert_index_equal(localized, localized_infer_old)
 
     @pytest.mark.parametrize('tz', [pytz.timezone('US/Eastern'),
                                     gettz('US/Eastern')])
@@ -525,7 +519,7 @@ class TestDatetimeIndexTimezones(object):
         localized = DatetimeIndex(times, tz=tz, ambiguous=is_dst)
         tm.assert_index_equal(dr, localized)
 
-        # Test duplicate times where infer_dst fails
+        # Test duplicate times where inferring the dst fails
         times += times
         di = DatetimeIndex(times)
 


### PR DESCRIPTION
This has come up a few times during the docstring improvements: we still had the `infer_dst` deprecations left over (deprecated in 0.15)