### PR TITLE
Add interpolation options to rolling quantile

### DIFF
--- a/asv_bench/benchmarks/rolling.py
+++ b/asv_bench/benchmarks/rolling.py
@@ -65,25 +65,15 @@ class Quantile(object):
     params = (['DataFrame', 'Series'],
               [10, 1000],
               ['int', 'float'],
-              [0, 0.5, 1])
+              [0, 0.5, 1],
+              ['linear', 'nearest', 'lower', 'higher', 'midpoint'])
     param_names = ['constructor', 'window', 'dtype', 'percentile']
 
-    def setup(self, constructor, window, dtype, percentile):
+    def setup(self, constructor, window, dtype, percentile, interpolation):
         N = 10 ** 5
         arr = np.random.random(N).astype(dtype)
         self.roll = getattr(pd, constructor)(arr).rolling(window)
 
-    def time_quantile(self, constructor, window, dtype, percentile):
-        self.roll.quantile(percentile)
-
-    def time_quantile_nearest(self, constructor, window, dtype, percentile):
-        self.roll.quantile(percentile, interpolation='nearest')
-
-    def time_quantile_lower(self, constructor, window, dtype, percentile):
-        self.roll.quantile(percentile, interpolation='lower')
-
-    def time_quantile_higher(self, constructor, window, dtype, percentile):
-        self.roll.quantile(percentile, interpolation='higher')
-
-    def time_quantile_midpoint(self, constructor, window, dtype, percentile):
-        self.roll.quantile(percentile, interpolation='midpoint')
+    def time_quantile(self, constructor, window, dtype, percentile,
+                      interpolation):
+        self.roll.quantile(percentile, interpolation=interpolation)

--- a/asv_bench/benchmarks/rolling.py
+++ b/asv_bench/benchmarks/rolling.py
@@ -22,6 +22,7 @@ class Methods(object):
     def time_rolling(self, constructor, window, dtype, method):
         getattr(self.roll, method)()
 
+
 class VariableWindowMethods(Methods):
     sample_time = 0.2
     params = (['DataFrame', 'Series'],
@@ -36,6 +37,7 @@ class VariableWindowMethods(Methods):
         arr = (100 * np.random.random(N)).astype(dtype)
         index = pd.date_range('2017-01-01', periods=N, freq='5s')
         self.roll = getattr(pd, constructor)(arr, index=index).rolling(window)
+
 
 class Pairwise(object):
 
@@ -59,7 +61,6 @@ class Pairwise(object):
 
 
 class Quantile(object):
-
     sample_time = 0.2
     params = (['DataFrame', 'Series'],
               [10, 1000],
@@ -68,9 +69,21 @@ class Quantile(object):
     param_names = ['constructor', 'window', 'dtype', 'percentile']
 
     def setup(self, constructor, window, dtype, percentile):
-        N = 10**5
+        N = 10 ** 5
         arr = np.random.random(N).astype(dtype)
         self.roll = getattr(pd, constructor)(arr).rolling(window)
 
     def time_quantile(self, constructor, window, dtype, percentile):
         self.roll.quantile(percentile)
+
+    def time_quantile_nearest(self, constructor, window, dtype, percentile):
+        self.roll.quantile(percentile, interpolation='nearest')
+
+    def time_quantile_lower(self, constructor, window, dtype, percentile):
+        self.roll.quantile(percentile, interpolation='lower')
+
+    def time_quantile_higher(self, constructor, window, dtype, percentile):
+        self.roll.quantile(percentile, interpolation='higher')
+
+    def time_quantile_midpoint(self, constructor, window, dtype, percentile):
+        self.roll.quantile(percentile, interpolation='midpoint')

--- a/doc/source/whatsnew/v0.23.0.txt
+++ b/doc/source/whatsnew/v0.23.0.txt
@@ -443,6 +443,7 @@ Other Enhancements
 - :meth:`DataFrame.to_sql` now performs a multivalue insert if the underlying connection supports itk rather than inserting row by row.
   ``SQLAlchemy`` dialects supporting multivalue inserts include: ``mysql``, ``postgresql``, ``sqlite`` and any dialect with ``supports_multivalues_insert``. (:issue:`14315`, :issue:`8953`)
 - :func:`read_html` now accepts a ``displayed_only`` keyword argument to controls whether or not hidden elements are parsed (``True`` by default) (:issue:`20027`)
+- :meth:`Rolling.quantile` and :meth:`Expanding.quantile` now accept ``interpolation`` keyword (``linear`` by default) (:issue:`20497`)
 - zip compression is supported via ``compression=zip`` in :func:`DataFrame.to_pickle`, :func:`Series.to_pickle`, :func:`DataFrame.to_csv`, :func:`Series.to_csv`, :func:`DataFrame.to_json`, :func:`Series.to_json`. (:issue:`17778`)
 - :class:`WeekOfMonth` constructor now supports ``n=0`` (:issue:`20517`).
 - :class:`DataFrame` and :class:`Series` now support matrix multiplication (```@```) operator (:issue:`10259`) for Python>=3.5

--- a/doc/source/whatsnew/v0.23.0.txt
+++ b/doc/source/whatsnew/v0.23.0.txt
@@ -449,6 +449,7 @@ Other Enhancements
 - Updated ``to_gbq`` and ``read_gbq`` signature and documentation to reflect changes from
   the Pandas-GBQ library version 0.4.0. Adds intersphinx mapping to Pandas-GBQ
   library. (:issue:`20564`)
+- :meth:`Rolling.quantile` and :meth:`Expanding.quantile` now accept ``interpolation`` keyword
 
 .. _whatsnew_0230.api_breaking:
 

--- a/doc/source/whatsnew/v0.23.0.txt
+++ b/doc/source/whatsnew/v0.23.0.txt
@@ -443,14 +443,13 @@ Other Enhancements
 - :meth:`DataFrame.to_sql` now performs a multivalue insert if the underlying connection supports itk rather than inserting row by row.
   ``SQLAlchemy`` dialects supporting multivalue inserts include: ``mysql``, ``postgresql``, ``sqlite`` and any dialect with ``supports_multivalues_insert``. (:issue:`14315`, :issue:`8953`)
 - :func:`read_html` now accepts a ``displayed_only`` keyword argument to controls whether or not hidden elements are parsed (``True`` by default) (:issue:`20027`)
-- :meth:`Rolling.quantile` and :meth:`Expanding.quantile` now accept ``interpolation`` keyword (``linear`` by default) (:issue:`20497`)
+- :meth:`Rolling.quantile` and :meth:`Expanding.quantile` now accept the ``interpolation`` keyword, ``linear`` by default (:issue:`20497`)
 - zip compression is supported via ``compression=zip`` in :func:`DataFrame.to_pickle`, :func:`Series.to_pickle`, :func:`DataFrame.to_csv`, :func:`Series.to_csv`, :func:`DataFrame.to_json`, :func:`Series.to_json`. (:issue:`17778`)
 - :class:`WeekOfMonth` constructor now supports ``n=0`` (:issue:`20517`).
 - :class:`DataFrame` and :class:`Series` now support matrix multiplication (```@```) operator (:issue:`10259`) for Python>=3.5
 - Updated ``to_gbq`` and ``read_gbq`` signature and documentation to reflect changes from
   the Pandas-GBQ library version 0.4.0. Adds intersphinx mapping to Pandas-GBQ
   library. (:issue:`20564`)
-- :meth:`Rolling.quantile` and :meth:`Expanding.quantile` now accept ``interpolation`` keyword
 
 .. _whatsnew_0230.api_breaking:
 

--- a/pandas/_libs/window.pyx
+++ b/pandas/_libs/window.pyx
@@ -1356,6 +1356,7 @@ cdef _roll_min_max(ndarray[numeric] input, int64_t win, int64_t minp,
     # print("output: {0}".format(output))
     return output
 
+
 def _get_interpolation_id(str interpolation):
     """
     Converts string to interpolation id
@@ -1452,7 +1453,7 @@ def roll_quantile(ndarray[float64_t, cast=True] input, int64_t win,
                     vlow = skiplist.get(idx)
                     vhigh = skiplist.get(idx + 1)
                     output[i] = ((vlow + (vhigh - vlow) *
-                        (idx_with_fraction - idx)))
+                                  (idx_with_fraction - idx)))
                 elif interpolation_id == 1:  # lower
                     output[i] = skiplist.get(idx)
                 elif interpolation_id == 2:  # higher

--- a/pandas/_libs/window.pyx
+++ b/pandas/_libs/window.pyx
@@ -1398,7 +1398,7 @@ def roll_quantile(ndarray[float64_t, cast=True] input, int64_t win,
     try:
         interpolation_type = interpolation_types[interpolation]
     except KeyError:
-        raise ValueError("Interpolation {} is not supported"
+        raise ValueError("Interpolation '{}' is not supported"
                          .format(interpolation))
 
     # we use the Fixed/Variable Indexer here as the

--- a/pandas/_libs/window.pyx
+++ b/pandas/_libs/window.pyx
@@ -1396,7 +1396,7 @@ def roll_quantile(ndarray[float64_t, cast=True] input, int64_t win,
 
     try:
         interpolation_type = interpolation_types[interpolation]
-    except ValueError:
+    except KeyError:
         raise ValueError("Interpolation {} is not supported"
                          .format(interpolation))
 
@@ -1442,7 +1442,7 @@ def roll_quantile(ndarray[float64_t, cast=True] input, int64_t win,
                 # Single value in skip list
                 output[i] = skiplist.get(0)
             else:
-                idx_with_fraction = quantile * <double> (nobs - 1)
+                idx_with_fraction = quantile * (nobs - 1)
                 idx = int(idx_with_fraction)
 
                 if interpolation_type == LINEAR:
@@ -1455,10 +1455,7 @@ def roll_quantile(ndarray[float64_t, cast=True] input, int64_t win,
                 elif interpolation_type == HIGHER:
                     output[i] = skiplist.get(idx + 1)
                 elif interpolation_type == NEAREST:
-                    if idx_with_fraction - idx < 0.5:
-                        output[i] = skiplist.get(idx)
-                    else:
-                        output[i] = skiplist.get(idx + 1)
+                    output[i] = skiplist.get(round(idx_with_fraction))
                 elif interpolation_type == MIDPOINT:
                     vlow = skiplist.get(idx)
                     vhigh = skiplist.get(idx + 1)

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -7079,6 +7079,10 @@ class DataFrame(NDFrame):
                a     b
         0.1  1.3   3.7
         0.5  2.5  55.0
+
+        See Also
+        --------
+        pandas.core.window.Rolling.quantile
         """
         self._check_percentile(q)
 

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -1855,6 +1855,9 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
         0.75    3.25
         dtype: float64
 
+        See Also
+        --------
+        pandas.core.window.Rolling.quantile
         """
 
         self._check_percentile(q)

--- a/pandas/core/window.py
+++ b/pandas/core/window.py
@@ -1287,7 +1287,8 @@ class _Rolling_and_Expanding(_Rolling):
               fractional part of the index surrounded by `i` and `j`.
             * lower: `i`.
             * higher: `j`.
-            * nearest: `i` or `j` whichever is nearest.
+            * nearest: `i` or `j` whichever is nearest. Implementation uses
+              round() built-in.
             * midpoint: (`i` + `j`) / 2.
 
     Returns
@@ -1305,6 +1306,7 @@ class _Rolling_and_Expanding(_Rolling):
     2    2.0
     3    3.0
     dtype: float64
+
     >>> s.rolling(2).quantile(.4, interpolation='midpoint')
     0    NaN
     1    1.5
@@ -1316,7 +1318,7 @@ class _Rolling_and_Expanding(_Rolling):
     --------
     pandas.Series.quantile
     pandas.DataFrame.quantile
-    
+
     """)
 
     def quantile(self, quantile, interpolation='linear', **kwargs):
@@ -1655,7 +1657,7 @@ class Rolling(_Rolling_and_Expanding):
     @Substitution(name='rolling')
     @Appender(_doc_template)
     @Appender(_shared_docs['quantile'])
-    def quantile(self, quantile, interpolation='linear', **kwargs):  # here
+    def quantile(self, quantile, interpolation='linear', **kwargs):
         return super(Rolling, self).quantile(quantile=quantile,
                                              interpolation=interpolation,
                                              **kwargs)
@@ -1916,8 +1918,10 @@ class Expanding(_Rolling_and_Expanding):
     @Substitution(name='expanding')
     @Appender(_doc_template)
     @Appender(_shared_docs['quantile'])
-    def quantile(self, quantile, **kwargs):
-        return super(Expanding, self).quantile(quantile=quantile, **kwargs)
+    def quantile(self, quantile, interpolation='linear', **kwargs,):
+        return super(Expanding, self).quantile(quantile=quantile,
+                                               interpolation=interpolation,
+                                               **kwargs)
 
     @Substitution(name='expanding')
     @Appender(_doc_template)

--- a/pandas/core/window.py
+++ b/pandas/core/window.py
@@ -1287,15 +1287,14 @@ class _Rolling_and_Expanding(_Rolling):
               fractional part of the index surrounded by `i` and `j`.
             * lower: `i`.
             * higher: `j`.
-            * nearest: `i` or `j` whichever is nearest. Implementation uses
-              round() built-in.
+            * nearest: `i` or `j` whichever is nearest.
             * midpoint: (`i` + `j`) / 2.
 
     Returns
     -------
     Series or DataFrame
         Returned object type is determined by the caller of the %(name)s
-        calculation
+        calculation.
 
     Examples
     --------
@@ -1316,8 +1315,10 @@ class _Rolling_and_Expanding(_Rolling):
 
     See Also
     --------
-    pandas.Series.quantile
-    pandas.DataFrame.quantile
+    pandas.Series.quantile : Computes value at the given quantile over all data
+        in Series.
+    pandas.DataFrame.quantile : Computes values at the given quantile over
+        requested axis in DataFrame.
 
     """)
 

--- a/pandas/core/window.py
+++ b/pandas/core/window.py
@@ -1288,7 +1288,36 @@ class _Rolling_and_Expanding(_Rolling):
             * lower: `i`.
             * higher: `j`.
             * nearest: `i` or `j` whichever is nearest.
-            * midpoint: (`i` + `j`) / 2.""")
+            * midpoint: (`i` + `j`) / 2.
+
+    Returns
+    -------
+    Series or DataFrame
+        Returned object type is determined by the caller of the %(name)s
+        calculation
+
+    Examples
+    --------
+    >>> s = Series([1, 2, 3, 4])
+    >>> s.rolling(2).quantile(.4, interpolation='lower')
+    0    NaN
+    1    1.0
+    2    2.0
+    3    3.0
+    dtype: float64
+    >>> s.rolling(2).quantile(.4, interpolation='midpoint')
+    0    NaN
+    1    1.5
+    2    2.5
+    3    3.5
+    dtype: float64
+
+    See Also
+    --------
+    pandas.Series.quantile
+    pandas.DataFrame.quantile
+    
+    """)
 
     def quantile(self, quantile, interpolation='linear', **kwargs):
         window = self._get_window()

--- a/pandas/core/window.py
+++ b/pandas/core/window.py
@@ -1276,9 +1276,21 @@ class _Rolling_and_Expanding(_Rolling):
     Parameters
     ----------
     quantile : float
-        0 <= quantile <= 1""")
+        0 <= quantile <= 1
+    interpolation : {'linear', 'lower', 'higher', 'midpoint', 'nearest'}
+        .. versionadded:: 0.23.0
 
-    def quantile(self, quantile, **kwargs):
+        This optional parameter specifies the interpolation method to use,
+        when the desired quantile lies between two data points `i` and `j`:
+
+            * linear: `i + (j - i) * fraction`, where `fraction` is the
+              fractional part of the index surrounded by `i` and `j`.
+            * lower: `i`.
+            * higher: `j`.
+            * nearest: `i` or `j` whichever is nearest.
+            * midpoint: (`i` + `j`) / 2.""")
+
+    def quantile(self, quantile, interpolation='linear', **kwargs):
         window = self._get_window()
         index, indexi = self._get_index()
 
@@ -1292,7 +1304,8 @@ class _Rolling_and_Expanding(_Rolling):
                                         self.closed)
             else:
                 return _window.roll_quantile(arg, window, minp, indexi,
-                                             self.closed, quantile)
+                                             self.closed, quantile,
+                                             interpolation)
 
         return self._apply(f, 'quantile', quantile=quantile,
                            **kwargs)
@@ -1613,8 +1626,10 @@ class Rolling(_Rolling_and_Expanding):
     @Substitution(name='rolling')
     @Appender(_doc_template)
     @Appender(_shared_docs['quantile'])
-    def quantile(self, quantile, **kwargs):
-        return super(Rolling, self).quantile(quantile=quantile, **kwargs)
+    def quantile(self, quantile, interpolation='linear', **kwargs):  # here
+        return super(Rolling, self).quantile(quantile=quantile,
+                                             interpolation=interpolation,
+                                             **kwargs)
 
     @Substitution(name='rolling')
     @Appender(_doc_template)

--- a/pandas/core/window.py
+++ b/pandas/core/window.py
@@ -1918,7 +1918,7 @@ class Expanding(_Rolling_and_Expanding):
     @Substitution(name='expanding')
     @Appender(_doc_template)
     @Appender(_shared_docs['quantile'])
-    def quantile(self, quantile, interpolation='linear', **kwargs,):
+    def quantile(self, quantile, interpolation='linear', **kwargs):
         return super(Expanding, self).quantile(quantile=quantile,
                                                interpolation=interpolation,
                                                **kwargs)

--- a/pandas/tests/test_window.py
+++ b/pandas/tests/test_window.py
@@ -1168,7 +1168,7 @@ class TestMoments(Base):
 
     def test_rolling_quantile_series(self):
         # #16211: Tests that rolling window's quantile default behavior
-        # is analogus to Series' quantile
+        # is analogous to Series' quantile
         arr = np.arange(100)
         s = Series(arr)
         q1 = s.quantile(0.1)
@@ -1177,16 +1177,29 @@ class TestMoments(Base):
         tm.assert_almost_equal(q1, q2)
 
     @pytest.mark.parametrize('quantile', [0.0, 0.1, 0.45, 0.5, 1])
+    @pytest.mark.parametrize('na_probability', [0.0, 0.3])
     @pytest.mark.parametrize('interpolation', ['linear', 'lower', 'higher',
                                                'nearest', 'midpoint'])
     def test_rolling_quantile_interpolation_options(self, quantile,
+                                                    na_probability,
                                                     interpolation):
-        # Tests that rolling window's quantile behavior is analogus to
+        # Tests that rolling window's quantile behavior is analogous to
         # Series' quantile for each interpolation option
         size = 100
-        s = Series(np.arange(size))
+        s = Series(np.random.rand(size))
+
+        # set NaN values
+        na_count = 0
+        na_total = int(size * na_probability)
+        while na_count < na_total:
+            index = np.random.randint(0, size)
+            if not np.isnan(s[index]):
+                s[index] = np.NaN
+                na_count += 1
+
         q1 = s.quantile(quantile, interpolation)
-        q2 = s.rolling(size).quantile(quantile, interpolation).iloc[-1]
+        q2 = s.rolling(size, min_periods=1).quantile(
+            quantile, interpolation).iloc[-1]
 
         tm.assert_almost_equal(q1, q2)
 

--- a/pandas/tests/test_window.py
+++ b/pandas/tests/test_window.py
@@ -1167,16 +1167,6 @@ class TestMoments(Base):
 
         tm.assert_almost_equal(df_quantile.values, np.array(np_percentile))
 
-    def test_rolling_quantile_series(self):
-        # #16211: Tests that rolling window's quantile default behavior
-        # is analogous to Series' quantile
-        arr = np.arange(100)
-        s = Series(arr)
-        q1 = s.quantile(0.1)
-        q2 = s.rolling(100).quantile(0.1).iloc[-1]
-
-        tm.assert_almost_equal(q1, q2)
-
     @pytest.mark.skipif(_np_version_under1p12,
                         reason='numpy midpoint interpolation is broken')
     @pytest.mark.parametrize('quantile', [0.0, 0.1, 0.45, 0.5, 1])
@@ -1187,7 +1177,7 @@ class TestMoments(Base):
                                       [0., np.nan, 0.2, np.nan, 0.4],
                                       [np.nan, np.nan, np.nan, np.nan],
                                       [np.nan, 0.1, np.nan, 0.3, 0.4, 0.5],
-                                      [0.5], [np.nan, 0.7, 0.5]])
+                                      [0.5], [np.nan, 0.7, 0.6]])
     def test_rolling_quantile_interpolation_options(self, quantile,
                                                     interpolation, data):
         # Tests that rolling window's quantile behavior is analogous to
@@ -1201,13 +1191,13 @@ class TestMoments(Base):
         if np.isnan(q1):
             assert np.isnan(q2)
         else:
-            assert round(q1, 15) == round(q2, 15)
+            assert q1 == q2
 
     def test_invalid_quantile_value(self):
         data = np.arange(5)
         s = Series(data)
 
-        with pytest.raises(ValueError, match="Interpolation invalid"
+        with pytest.raises(ValueError, match="Interpolation 'invalid'"
                                              " is not supported"):
             s.rolling(len(data), min_periods=1).quantile(
                 0.5, interpolation='invalid')

--- a/pandas/tests/test_window.py
+++ b/pandas/tests/test_window.py
@@ -1173,22 +1173,21 @@ class TestMoments(Base):
         s = Series(arr)
         q1 = s.quantile(0.1)
         q2 = s.rolling(100).quantile(0.1).iloc[-1]
+
         tm.assert_almost_equal(q1, q2)
 
-        q1 = s.quantile(0.1, interpolation='lower')
-        q2 = s.rolling(100).quantile(0.1, interpolation='lower').iloc[-1]
-        tm.assert_almost_equal(q1, q2)
+    @pytest.mark.parametrize('quantile', [0.0, 0.1, 0.45, 0.5, 1])
+    @pytest.mark.parametrize('interpolation', ['linear', 'lower', 'higher',
+                                               'nearest', 'midpoint'])
+    def test_rolling_quantile_interpolation_options(self, quantile,
+                                                    interpolation):
+        # Tests that rolling window's quantile behavior is analogus to
+        # Series' quantile for each interpolation option
+        size = 100
+        s = Series(np.arange(size))
+        q1 = s.quantile(quantile, interpolation)
+        q2 = s.rolling(size).quantile(quantile, interpolation).iloc[-1]
 
-        q1 = s.quantile(0.1, interpolation='higher')
-        q2 = s.rolling(100).quantile(0.1, interpolation='higher').iloc[-1]
-        tm.assert_almost_equal(q1, q2)
-
-        q1 = s.quantile(0.1, interpolation='nearest')
-        q2 = s.rolling(100).quantile(0.1, interpolation='nearest').iloc[-1]
-        tm.assert_almost_equal(q1, q2)
-
-        q1 = s.quantile(0.1, interpolation='midpoint')
-        q2 = s.rolling(100).quantile(0.1, interpolation='midpoint').iloc[-1]
         tm.assert_almost_equal(q1, q2)
 
     def test_rolling_quantile_param(self):

--- a/pandas/tests/test_window.py
+++ b/pandas/tests/test_window.py
@@ -1173,7 +1173,22 @@ class TestMoments(Base):
         s = Series(arr)
         q1 = s.quantile(0.1)
         q2 = s.rolling(100).quantile(0.1).iloc[-1]
+        tm.assert_almost_equal(q1, q2)
 
+        q1 = s.quantile(0.1, interpolation='lower')
+        q2 = s.rolling(100).quantile(0.1, interpolation='lower').iloc[-1]
+        tm.assert_almost_equal(q1, q2)
+
+        q1 = s.quantile(0.1, interpolation='higher')
+        q2 = s.rolling(100).quantile(0.1, interpolation='higher').iloc[-1]
+        tm.assert_almost_equal(q1, q2)
+
+        q1 = s.quantile(0.1, interpolation='nearest')
+        q2 = s.rolling(100).quantile(0.1, interpolation='nearest').iloc[-1]
+        tm.assert_almost_equal(q1, q2)
+
+        q1 = s.quantile(0.1, interpolation='midpoint')
+        q2 = s.rolling(100).quantile(0.1, interpolation='midpoint').iloc[-1]
         tm.assert_almost_equal(q1, q2)
 
     def test_rolling_quantile_param(self):

--- a/pandas/tests/test_window.py
+++ b/pandas/tests/test_window.py
@@ -1178,14 +1178,14 @@ class TestMoments(Base):
                                       [np.nan, np.nan, np.nan, np.nan],
                                       [np.nan, 0.1, np.nan, 0.3, 0.4, 0.5],
                                       [0.5], [np.nan, 0.7, 0.6]])
-    def test_rolling_quantile_interpolation_options(self, quantile,
-                                                    interpolation, data):
+    def test_moving_quantile_interpolation_options(self, quantile,
+                                                   interpolation, data):
         # Tests that rolling window's quantile behavior is analogous to
         # Series' quantile for each interpolation option
         s = Series(data)
 
         q1 = s.quantile(quantile, interpolation)
-        q2 = s.rolling(len(data), min_periods=1).quantile(
+        q2 = s.expanding(min_periods=1).quantile(
             quantile, interpolation).iloc[-1]
 
         if np.isnan(q1):
@@ -1202,7 +1202,7 @@ class TestMoments(Base):
             s.rolling(len(data), min_periods=1).quantile(
                 0.5, interpolation='invalid')
 
-    def test_rolling_quantile_param(self):
+    def test_moving_quantile_param(self):
         ser = Series([0.0, .1, .5, .9, 1.0])
 
         with pytest.raises(ValueError):

--- a/pandas/tests/test_window.py
+++ b/pandas/tests/test_window.py
@@ -6,7 +6,7 @@ from warnings import catch_warnings
 from datetime import datetime, timedelta
 from numpy.random import randn
 import numpy as np
-from scipy._lib._version import NumpyVersion
+from pandas import _np_version_under1p12
 
 import pandas as pd
 from pandas import (Series, DataFrame, bdate_range,
@@ -1177,7 +1177,7 @@ class TestMoments(Base):
 
         tm.assert_almost_equal(q1, q2)
 
-    @pytest.mark.skipif(NumpyVersion(np.__version__) < '1.12.0',
+    @pytest.mark.skipif(_np_version_under1p12,
                         reason='numpy midpoint interpolation is broken')
     @pytest.mark.parametrize('quantile', [0.0, 0.1, 0.45, 0.5, 1])
     @pytest.mark.parametrize('interpolation', ['linear', 'lower', 'higher',

--- a/pandas/tests/test_window.py
+++ b/pandas/tests/test_window.py
@@ -6,6 +6,7 @@ from warnings import catch_warnings
 from datetime import datetime, timedelta
 from numpy.random import randn
 import numpy as np
+from scipy._lib._version import NumpyVersion
 
 import pandas as pd
 from pandas import (Series, DataFrame, bdate_range,
@@ -1176,6 +1177,8 @@ class TestMoments(Base):
 
         tm.assert_almost_equal(q1, q2)
 
+    @pytest.mark.skipif(NumpyVersion(np.__version__) < '1.12.0',
+                        reason='numpy midpoint interpolation is broken')
     @pytest.mark.parametrize('quantile', [0.0, 0.1, 0.45, 0.5, 1])
     @pytest.mark.parametrize('interpolation', ['linear', 'lower', 'higher',
                                                'nearest', 'midpoint'])

--- a/pandas/tests/test_window.py
+++ b/pandas/tests/test_window.py
@@ -1178,8 +1178,8 @@ class TestMoments(Base):
                                       [np.nan, np.nan, np.nan, np.nan],
                                       [np.nan, 0.1, np.nan, 0.3, 0.4, 0.5],
                                       [0.5], [np.nan, 0.7, 0.6]])
-    def test_moving_quantile_interpolation_options(self, quantile,
-                                                   interpolation, data):
+    def test_rolling_quantile_interpolation_options(self, quantile,
+                                                    interpolation, data):
         # Tests that rolling window's quantile behavior is analogous to
         # Series' quantile for each interpolation option
         s = Series(data)
@@ -1202,7 +1202,7 @@ class TestMoments(Base):
             s.rolling(len(data), min_periods=1).quantile(
                 0.5, interpolation='invalid')
 
-    def test_moving_quantile_param(self):
+    def test_rolling_quantile_param(self):
         ser = Series([0.0, .1, .5, .9, 1.0])
 
         with pytest.raises(ValueError):


### PR DESCRIPTION
It version 0.21.0 rolling quantile started to use linear interpolation, it broke backward compatibility.

Regular (not rolling) quantile supports these interpolation options: `linear`, `lower`, `higher`, `nearest` and `midpoint`.
This commit adds the same options to moving quantile.

Performance issues of this commit (note: I re-run benchmarks, see message below) 
This code has 15% worse performance on benchmarks with small values of window (`window=10`). This is because loop inside `roll_quantile` now contains switch.
I tried to replace switch with callback but it led to even worse performance. Even if I move some of the code to new function (without any change in logic) it still makes performance much worse.
How bad is it? Could you please give me an advice on how to arrange the code such that it has the same performance?

- [ ] closes #xxxx
- [ ] tests added / passed
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
