### PR TITLE
Option_context Dictionary argument

### DIFF
--- a/pandas/core/config.py
+++ b/pandas/core/config.py
@@ -379,6 +379,8 @@ class option_context(object):
     Context manager to temporarily set options in the `with` statement context.
 
     You need to invoke as ``option_context(pat, val, [(pat, val), ...])``.
+    You may also invoke using a dictionary of (pat, val) pairs:
+    ``option_context(options={pat:val})``
 
     Examples
     --------
@@ -388,12 +390,14 @@ class option_context(object):
 
     """
 
-    def __init__(self, *args):
-        if not (len(args) % 2 == 0 and len(args) >= 2):
+    def __init__(self, *args, options={}):
+        if not (len(args) % 2 == 0 and (len(args) >= 2 or len(options))):
             raise ValueError('Need to invoke as'
                              'option_context(pat, val, [(pat, val), ...)).')
 
-        self.ops = list(zip(args[::2], args[1::2]))
+        self.ops = list(zip(args[::2], args[1::2])) + [
+            [key, val] for key, val in options.items()
+        ]
 
     def __enter__(self):
         undo = []

--- a/pandas/tests/test_config.py
+++ b/pandas/tests/test_config.py
@@ -370,6 +370,9 @@ class TestConfig(object):
                 eq(25)
             eq(15)
         eq(0)
+        with self.cf.option_context(options={"a": 15}):
+            eq(15)
+        eq(0)
 
         self.cf.set_option("a", 17)
         eq(17)


### PR DESCRIPTION
Checklist for the pandas documentation sprint (ignore this if you are doing
an unrelated PR):

Not a documentation sprint participant

Please include the output of the validation script below between the "```" ticks:

```
root@dfb9f788ea02:/pandas# scripts/validate_docstrings.py pandas.option_context

################################################################################
###################### Docstring (pandas.option_context)  ######################
################################################################################

Context manager to temporarily set options in the `with` statement context.

You need to invoke as ``option_context(pat, val, [(pat, val), ...])``.
You may also invoke using a dictionary of (pat, val) pairs:
``option_context(options={pat:val})``

Examples
--------

>>> with option_context('display.max_rows', 10, 'display.max_columns', 5):
        ...
Traceback (most recent call last):
  File "scripts/validate_docstrings.py", line 505, in <module>
    sys.exit(main(args.function))
  File "scripts/validate_docstrings.py", line 491, in main
    return validate_one(function)
  File "scripts/validate_docstrings.py", line 468, in validate_one
    examples_errs = doc.examples_errors
  File "scripts/validate_docstrings.py", line 265, in examples_errors
    for test in finder.find(self.raw_doc, self.method_name, globs=context):
  File "/usr/lib/python3.5/doctest.py", line 924, in find
    self._find(tests, obj, name, module, source_lines, globs, {})
  File "/usr/lib/python3.5/doctest.py", line 974, in _find
    test = self._get_test(obj, name, module, globs, source_lines)
  File "/usr/lib/python3.5/doctest.py", line 1058, in _get_test
    filename, lineno)
  File "/usr/lib/python3.5/doctest.py", line 660, in get_doctest
    return DocTest(self.get_examples(string, name), globs,
  File "/usr/lib/python3.5/doctest.py", line 674, in get_examples
    return [x for x in self.parse(string, name)
  File "/usr/lib/python3.5/doctest.py", line 636, in parse
    self._parse_example(m, name, lineno)
  File "/usr/lib/python3.5/doctest.py", line 695, in _parse_example
    self._check_prefix(source_lines[1:], ' '*indent + '.', name, lineno)
  File "/usr/lib/python3.5/doctest.py", line 792, in _check_prefix
    (lineno+i+1, name, line))
ValueError: line 11 of the docstring for pandas.option_context has inconsistent leading whitespace: '        ...'
```

If the validation script still gives errors, but you think there is a good reason
to deviate in this case (and there are certainly such cases), please state this
explicitly.

Two reasons to ignore the error with the whitespace:
1) It was there in the original, unmodified docstring
2) It appears to be an indication of the indentation following entering a `with` context block

Checklist for other PRs (remove this part if you are doing a PR for the pandas documentation sprint):

- [x] No related issue. Added to resolve a personal pet peeve (the original `option_context` api is extremely un-pythonic)
- [x] tests added & passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry (Not sure what to add or to which specific whatsnew file)
