### PR TITLE
Set pd.options.display.max_rows = 20 by default

### DIFF
--- a/doc/source/options.rst
+++ b/doc/source/options.rst
@@ -352,7 +352,7 @@ display.max_info_rows                   1690785      df.info() will usually show
                                                      and max_info_cols limit this null
                                                      check only to frames with smaller
                                                      dimensions then specified.
-display.max_rows                        60           This sets the maximum number of rows
+display.max_rows                        20           This sets the maximum number of rows
                                                      pandas should output when printing
                                                      out various output. For example,
                                                      this value determines whether the

--- a/doc/source/whatsnew/v0.23.0.txt
+++ b/doc/source/whatsnew/v0.23.0.txt
@@ -687,6 +687,11 @@ yourself. To revert to the old setting, you can run this line:
 
   pd.options.display.max_columns = 20
 
+Furthermore, the default value for the maximum number of displayed rows is now
+20 (instead of 60) (``pd.options.display.max_rows=20``) (:issue:`20514`). This
+makes it easier to get an overview of a large dataframe in most standard
+terminal windows.
+
 .. _whatsnew_0230.api.datetimelike:
 
 Datetimelike API Changes

--- a/pandas/core/config_init.py
+++ b/pandas/core/config_init.py
@@ -310,7 +310,7 @@ with cf.config_prefix('display'):
     cf.register_option('column_space', 12, validator=is_int)
     cf.register_option('max_info_rows', 1690785, pc_max_info_rows_doc,
                        validator=is_instance_factory((int, type(None))))
-    cf.register_option('max_rows', 60, pc_max_rows_doc,
+    cf.register_option('max_rows', 20, pc_max_rows_doc,
                        validator=is_instance_factory([type(None), int]))
     cf.register_option('max_categories', 8, pc_max_categories_doc,
                        validator=is_int)


### PR DESCRIPTION
As a follow-up to #17023, I propose to change the default number of displayed rows to 20.

- [ ] closes #xxxx
- [x] tests added / passed
- [X] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry
