### PR TITLE
BUG: #19497 FIX. Add tupleize_cols option to internals._transform_index()

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -3642,6 +3642,10 @@ class DataFrame(NDFrame):
         level : int or level name, default None
             In case of a MultiIndex, only rename labels in the specified
             level.
+        tupleize_cols : boolean, default False
+            In case of an Index, when True, create MultiIndex if possible.
+            False ensures that an Index will not be converted to a
+            MultiIndex if labels are 'rename'd.
 
         Returns
         -------

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -933,6 +933,7 @@ class NDFrame(PandasObject, SelectionMixin):
         inplace = kwargs.pop('inplace', False)
         level = kwargs.pop('level', None)
         axis = kwargs.pop('axis', None)
+        tupleize_cols = kwargs.pop('tupleize_cols', False)
         if axis is not None:
             axis = self._get_axis_number(axis)
 
@@ -971,7 +972,7 @@ class NDFrame(PandasObject, SelectionMixin):
             if level is not None:
                 level = self.axes[axis]._get_level_number(level)
             result._data = result._data.rename_axis(f, axis=baxis, copy=copy,
-                                                    level=level)
+                                                    level=level, tupleize_cols=tupleize_cols)
             result._clear_item_cache()
 
         if inplace:

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -971,8 +971,10 @@ class NDFrame(PandasObject, SelectionMixin):
             baxis = self._get_block_manager_axis(axis)
             if level is not None:
                 level = self.axes[axis]._get_level_number(level)
-            result._data = result._data.rename_axis(f, axis=baxis, copy=copy,
-                                                    level=level, tupleize_cols=tupleize_cols)
+            result._data = \
+                result._data.rename_axis(f, axis=baxis, copy=copy,
+                                         level=level,
+                                         tupleize_cols=tupleize_cols)
             result._clear_item_cache()
 
         if inplace:

--- a/pandas/core/internals.py
+++ b/pandas/core/internals.py
@@ -3294,7 +3294,8 @@ class BlockManager(PandasObject):
 
         """
         obj = self.copy(deep=copy)
-        obj.set_axis(axis, _transform_index(self.axes[axis], mapper, level, tupleize_cols=tupleize_cols))
+        obj.set_axis(axis, _transform_index(self.axes[axis], mapper, level,
+                                            tupleize_cols=tupleize_cols))
         return obj
 
     def add_prefix(self, prefix):

--- a/pandas/core/internals.py
+++ b/pandas/core/internals.py
@@ -3280,7 +3280,8 @@ class BlockManager(PandasObject):
 
         self.axes[axis] = new_labels
 
-    def rename_axis(self, mapper, axis, copy=True, level=None):
+    def rename_axis(self, mapper, axis, copy=True, level=None,
+                    tupleize_cols=False):
         """
         Rename one of axes.
 
@@ -3293,7 +3294,7 @@ class BlockManager(PandasObject):
 
         """
         obj = self.copy(deep=copy)
-        obj.set_axis(axis, _transform_index(self.axes[axis], mapper, level))
+        obj.set_axis(axis, _transform_index(self.axes[axis], mapper, level, tupleize_cols=tupleize_cols))
         return obj
 
     def add_prefix(self, prefix):
@@ -5234,7 +5235,7 @@ def _safe_reshape(arr, new_shape):
     return arr
 
 
-def _transform_index(index, func, level=None):
+def _transform_index(index, func, level=None, tupleize_cols=True):
     """
     Apply function to all values found in index.
 
@@ -5251,7 +5252,7 @@ def _transform_index(index, func, level=None):
         return MultiIndex.from_tuples(items, names=index.names)
     else:
         items = [func(x) for x in index]
-        return Index(items, name=index.name)
+        return Index(items, name=index.name, tupleize_cols=tupleize_cols)
 
 
 def _putmask_smart(v, m, n):


### PR DESCRIPTION
- Closes #19497
- NO TESTS have been added/passed. Currently experiencing issues getting pandas conda environment installed so unable to do this myself. Very simple alteration however...
- Code passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- Implements tupleize_cols option for pandas.core.internals_transform_index(), and provides the capability to manipulate this option using pandas.DataFrame.rename(). 
**NOTE**: for renaming, the keyword argument default is False, because as suggested [here](https://github.com/pandas-dev/pandas/issues/19497), this is unintuitive and unexepected. The keyword argument for the _transform_index() is True however, which is consistent with default pandas.Index() creation behaviour.
