### PR TITLE
CLN: Use pandas.compat instead of sys.version_info for Python version checks

### DIFF
--- a/pandas/_version.py
+++ b/pandas/_version.py
@@ -12,6 +12,7 @@ import os
 import re
 import subprocess
 import sys
+from pandas.compat import PY3
 
 
 def get_keywords():
@@ -83,7 +84,7 @@ def run_command(commands, args, cwd=None, verbose=False, hide_stderr=False):
             print("unable to find command, tried %s" % (commands,))
         return None
     stdout = p.communicate()[0].strip()
-    if sys.version_info[0] >= 3:
+    if PY3:
         stdout = stdout.decode()
     if p.returncode != 0:
         if verbose:

--- a/pandas/compat/__init__.py
+++ b/pandas/compat/__init__.py
@@ -369,7 +369,7 @@ except NameError:
         return any("__call__" in klass.__dict__ for klass in type(obj).__mro__)
 
 
-if sys.version_info[0] < 3:
+if PY2:
     # In PY2 functools.wraps doesn't provide metadata pytest needs to generate
     # decorated tests using parametrization. See pytest GH issue #2782
     def wraps(wrapped, assigned=functools.WRAPPER_ASSIGNMENTS,

--- a/pandas/io/clipboard/clipboards.py
+++ b/pandas/io/clipboard/clipboards.py
@@ -1,12 +1,10 @@
-import sys
 import subprocess
 from .exceptions import PyperclipException
+from pandas.compat import PY2, text_type
 
 EXCEPT_MSG = """
     Pyperclip could not find a copy/paste mechanism for your system.
     For more information, please visit https://pyperclip.readthedocs.org """
-PY2 = sys.version_info[0] == 2
-text_type = unicode if PY2 else str  # noqa
 
 
 def init_osx_clipboard():

--- a/pandas/io/formats/terminal.py
+++ b/pandas/io/formats/terminal.py
@@ -14,8 +14,9 @@ on linux, os x, windows and cygwin (windows).
 from __future__ import print_function
 
 import os
-import sys
 import shutil
+from pandas.compat import PY3
+
 
 __all__ = ['get_terminal_size', 'is_terminal']
 
@@ -29,7 +30,7 @@ def get_terminal_size():
     """
     import platform
 
-    if sys.version_info[0] >= 3:
+    if PY3:
         return shutil.get_terminal_size()
 
     current_os = platform.system()

--- a/pandas/tests/frame/test_analytics.py
+++ b/pandas/tests/frame/test_analytics.py
@@ -4,9 +4,7 @@ from __future__ import print_function
 
 import warnings
 from datetime import timedelta
-from distutils.version import LooseVersion
 import operator
-import sys
 import pytest
 
 from string import ascii_lowercase
@@ -1857,13 +1855,8 @@ class TestDataFrameAnalytics(TestData):
             'col1': [1.123, 2.123, 3.123],
             'col2': [1.2, 2.2, 3.2]})
 
-        if LooseVersion(sys.version) < LooseVersion('2.7'):
-            # Rounding with decimal is a ValueError in Python < 2.7
-            with pytest.raises(ValueError):
-                df.round(nan_round_Series)
-        else:
-            with pytest.raises(TypeError):
-                df.round(nan_round_Series)
+        with pytest.raises(TypeError):
+            df.round(nan_round_Series)
 
         # Make sure this doesn't break existing Series.round
         tm.assert_series_equal(df['col1'].round(1), expected_rounded['col1'])

--- a/pandas/tests/frame/test_api.py
+++ b/pandas/tests/frame/test_api.py
@@ -7,8 +7,6 @@ import pytest
 # pylint: disable-msg=W0612,E1101
 from copy import deepcopy
 import pydoc
-import sys
-from distutils.version import LooseVersion
 
 from pandas.compat import range, lrange, long
 from pandas import compat
@@ -253,18 +251,14 @@ class SharedWithSparse(object):
                     '[(0, 1, 4), (1, 2, 5), (2, 3, 6)]')
 
         tup = next(df.itertuples(name='TestName'))
-
-        if LooseVersion(sys.version) >= LooseVersion('2.7'):
-            assert tup._fields == ('Index', 'a', 'b')
-            assert (tup.Index, tup.a, tup.b) == tup
-            assert type(tup).__name__ == 'TestName'
+        assert tup._fields == ('Index', 'a', 'b')
+        assert (tup.Index, tup.a, tup.b) == tup
+        assert type(tup).__name__ == 'TestName'
 
         df.columns = ['def', 'return']
         tup2 = next(df.itertuples(name='TestName'))
         assert tup2 == (0, 1, 4)
-
-        if LooseVersion(sys.version) >= LooseVersion('2.7'):
-            assert tup2._fields == ('Index', '_1', '_2')
+        assert tup2._fields == ('Index', '_1', '_2')
 
         df3 = DataFrame({'f' + str(i): [i] for i in range(1024)})
         # will raise SyntaxError if trying to create namedtuple

--- a/pandas/tests/indexes/datetimes/test_tools.py
+++ b/pandas/tests/indexes/datetimes/test_tools.py
@@ -1,6 +1,5 @@
 """ test to_datetime """
 
-import sys
 import pytz
 import pytest
 import locale
@@ -149,9 +148,6 @@ class TestTimeConversionFormats(object):
         # GH 10834
         # 8904
         # exact kw
-        if sys.version_info < (2, 7):
-            pytest.skip('on python version < 2.7')
-
         s = Series(['19MAY11', 'foobar19MAY11', '19MAY11:00:00:00',
                     '19MAY11 00:00:00Z'])
         result = to_datetime(s, format='%d%b%y', exact=False, cache=cache)

--- a/pandas/tests/io/formats/test_format.py
+++ b/pandas/tests/io/formats/test_format.py
@@ -1256,8 +1256,6 @@ class TestDataFrameFormatting(object):
 
         df_s = df.to_string()
 
-        # Python 2.5 just wants me to be sad. And debian 32-bit
-        # sys.version_info[0] == 2 and sys.version_info[1] < 6:
         if _three_digit_exp():
             expected = ('              x\n0  0.00000e+000\n1  2.50000e-001\n'
                         '2  3.45600e+003\n3  1.20000e+046\n4  1.64000e+006\n'
@@ -1281,8 +1279,7 @@ class TestDataFrameFormatting(object):
 
         df = DataFrame({'x': [1e9, 0.2512]})
         df_s = df.to_string()
-        # Python 2.5 just wants me to be sad. And debian 32-bit
-        # sys.version_info[0] == 2 and sys.version_info[1] < 6:
+
         if _three_digit_exp():
             expected = ('               x\n'
                         '0  1.000000e+009\n'

--- a/pandas/tests/io/parser/common.py
+++ b/pandas/tests/io/parser/common.py
@@ -1275,9 +1275,8 @@ eight,1,2,3"""
         else:  # Python engine
             assert output == 'Filled 1 NA values in column a\n'
 
+    @pytest.mark.skipif(PY3, reason="won't work in Python 3")
     def test_iteration_open_handle(self):
-        if PY3:
-            pytest.skip("won't work in Python 3")
 
         with tm.ensure_clean() as path:
             with open(path, 'wb') as f:

--- a/pandas/tests/io/parser/common.py
+++ b/pandas/tests/io/parser/common.py
@@ -1277,8 +1277,7 @@ eight,1,2,3"""
 
     def test_iteration_open_handle(self):
         if PY3:
-            pytest.skip(
-                "won't work in Python 3 {0}".format(sys.version_info))
+            pytest.skip("won't work in Python 3")
 
         with tm.ensure_clean() as path:
             with open(path, 'wb') as f:

--- a/pandas/tests/io/test_excel.py
+++ b/pandas/tests/io/test_excel.py
@@ -1,6 +1,5 @@
 # pylint: disable=E1101
 import os
-import sys
 import warnings
 from datetime import datetime, date, time, timedelta
 from distutils.version import LooseVersion
@@ -16,7 +15,7 @@ import pandas as pd
 import pandas.util.testing as tm
 import pandas.util._test_decorators as td
 from pandas import DataFrame, Index, MultiIndex
-from pandas.compat import u, range, map, BytesIO, iteritems
+from pandas.compat import u, range, map, BytesIO, iteritems, PY36
 from pandas.core.config import set_option, get_option
 from pandas.io.common import URLError
 from pandas.io.excel import (
@@ -585,9 +584,6 @@ class TestXlrdReader(ReadingTestsBase):
     def test_read_from_file_url(self, ext):
 
         # FILE
-        if sys.version_info[:2] < (2, 6):
-            pytest.skip("file:// not supported with Python < 2.6")
-
         localtable = os.path.join(self.dirpath, 'test1' + ext)
         local_table = read_excel(localtable)
 
@@ -2314,9 +2310,9 @@ def test_styler_to_excel(engine):
 
 
 @td.skip_if_no('openpyxl')
+@pytest.mark.skipif(not PY36, reason='requires fspath')
 class TestFSPath(object):
 
-    @pytest.mark.skipif(sys.version_info < (3, 6), reason='requires fspath')
     def test_excelfile_fspath(self):
         with tm.ensure_clean('foo.xlsx') as path:
             df = DataFrame({"A": [1, 2]})
@@ -2325,8 +2321,6 @@ class TestFSPath(object):
             result = os.fspath(xl)
             assert result == path
 
-    @pytest.mark.skipif(sys.version_info < (3, 6), reason='requires fspath')
-    # @pytest.mark.xfail
     def test_excelwriter_fspath(self):
         with tm.ensure_clean('foo.xlsx') as path:
             writer = ExcelWriter(path)

--- a/pandas/tests/io/test_packers.py
+++ b/pandas/tests/io/test_packers.py
@@ -4,7 +4,6 @@ from warnings import catch_warnings
 import os
 import datetime
 import numpy as np
-import sys
 from distutils.version import LooseVersion
 
 from pandas import compat
@@ -297,11 +296,6 @@ class TestBasic(TestPackers):
         assert NaT is nat_rec
 
     def test_datetimes(self):
-
-        # fails under 2.6/win32 (np.datetime64 seems broken)
-
-        if LooseVersion(sys.version) < LooseVersion('2.7'):
-            pytest.skip('2.6 with np.datetime64 is broken')
 
         for i in [datetime.datetime(2013, 1, 1),
                   datetime.datetime(2013, 1, 1, 5, 1),

--- a/pandas/tests/io/test_pickle.py
+++ b/pandas/tests/io/test_pickle.py
@@ -20,13 +20,12 @@ import os
 from distutils.version import LooseVersion
 import pandas as pd
 from pandas import Index
-from pandas.compat import is_platform_little_endian
+from pandas.compat import is_platform_little_endian, PY3
 import pandas
 import pandas.util.testing as tm
 import pandas.util._test_decorators as td
 from pandas.tseries.offsets import Day, MonthEnd
 import shutil
-import sys
 
 
 @pytest.fixture(scope='module')
@@ -474,21 +473,12 @@ class TestProtocol(object):
             tm.assert_frame_equal(df, df2)
 
     @pytest.mark.parametrize('protocol', [3, 4])
-    @pytest.mark.skipif(sys.version_info[:2] >= (3, 4),
-                        reason="Testing invalid parameters for "
-                               "Python 2.x and 3.y (y < 4).")
+    @pytest.mark.skipif(PY3, reason="Testing invalid parameters for Python 2")
     def test_read_bad_versions(self, protocol, get_random_path):
-        # For Python 2.x (respectively 3.y with y < 4), [expected]
-        # HIGHEST_PROTOCOL should be 2 (respectively 3). Hence, the protocol
-        # parameter should not exceed 2 (respectively 3).
-        if sys.version_info[:2] < (3, 0):
-            expect_hp = 2
-        else:
-            expect_hp = 3
-        with tm.assert_raises_regex(ValueError,
-                                    "pickle protocol %d asked for; the highest"
-                                    " available protocol is %d" % (protocol,
-                                                                   expect_hp)):
+        # For Python 2, HIGHEST_PROTOCOL should be 2.
+        msg = ("pickle protocol {protocol} asked for; the highest available "
+               "protocol is 2").format(protocol=protocol)
+        with tm.assert_raises_regex(ValueError, msg):
             with tm.ensure_clean(get_random_path) as path:
                 df = tm.makeDataFrame()
                 df.to_pickle(path, protocol=protocol)

--- a/pandas/tests/io/test_stata.py
+++ b/pandas/tests/io/test_stata.py
@@ -4,10 +4,8 @@
 import datetime as dt
 import os
 import struct
-import sys
 import warnings
 from datetime import datetime
-from distutils.version import LooseVersion
 from collections import OrderedDict
 
 import numpy as np
@@ -144,8 +142,6 @@ class TestStata(object):
         tm.assert_frame_equal(parsed, expected)
 
     def test_read_dta2(self):
-        if LooseVersion(sys.version) < LooseVersion('2.7'):
-            pytest.skip('datetime interp under 2.6 is faulty')
 
         expected = DataFrame.from_records(
             [

--- a/pandas/tests/scalar/timestamp/test_comparisons.py
+++ b/pandas/tests/scalar/timestamp/test_comparisons.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-import sys
 from datetime import datetime
 import operator
 
@@ -9,7 +8,7 @@ import numpy as np
 from dateutil.tz import tzutc
 from pytz import utc
 
-from pandas.compat import long
+from pandas.compat import long, PY2
 from pandas import Timestamp
 
 
@@ -104,7 +103,7 @@ class TestTimestampComparison(object):
         pytest.raises(Exception, b.__lt__, a)
         pytest.raises(Exception, b.__gt__, a)
 
-        if sys.version_info < (3, 3):
+        if PY2:
             pytest.raises(Exception, a.__eq__, b.to_pydatetime())
             pytest.raises(Exception, a.to_pydatetime().__eq__, b)
         else:
@@ -125,7 +124,7 @@ class TestTimestampComparison(object):
         pytest.raises(Exception, b.__lt__, a)
         pytest.raises(Exception, b.__gt__, a)
 
-        if sys.version_info < (3, 3):
+        if PY2:
             pytest.raises(Exception, a.__eq__, b.to_pydatetime())
             pytest.raises(Exception, a.to_pydatetime().__eq__, b)
         else:
@@ -146,7 +145,7 @@ class TestTimestampComparison(object):
         pytest.raises(Exception, b.__lt__, a)
         pytest.raises(Exception, b.__gt__, a)
 
-        if sys.version_info < (3, 3):
+        if PY2:
             pytest.raises(Exception, a.__eq__, b.to_pydatetime())
             pytest.raises(Exception, a.to_pydatetime().__eq__, b)
         else:

--- a/pandas/tests/util/test_util.py
+++ b/pandas/tests/util/test_util.py
@@ -7,7 +7,7 @@ from uuid import uuid4
 from collections import OrderedDict
 
 import pytest
-from pandas.compat import intern
+from pandas.compat import intern, PY3
 import pandas.core.common as com
 from pandas.util._move import move_into_mutable_buffer, BadMove, stolenbuf
 from pandas.util._decorators import deprecate_kwarg, make_signature
@@ -374,10 +374,7 @@ class TestMove(object):
         # materialize as bytearray to show that it is mutable
         assert bytearray(as_stolen_buf) == b'test'
 
-    @pytest.mark.skipif(
-        sys.version_info[0] > 2,
-        reason='bytes objects cannot be interned in py3',
-    )
+    @pytest.mark.skipif(PY3, reason='bytes objects cannot be interned in py3')
     def test_interned(self):
         salt = uuid4().hex
 

--- a/pandas/util/testing.py
+++ b/pandas/util/testing.py
@@ -2088,7 +2088,7 @@ _network_errno_vals = (
 # and conditionally raise on these exception types
 _network_error_classes = (IOError, httplib.HTTPException)
 
-if sys.version_info >= (3, 3):
+if PY3:
     _network_error_classes += (TimeoutError,)  # noqa
 
 


### PR DESCRIPTION
Hopefully this will make code changes related to dropping support for specific versions of Python slightly easier to identify.

Summary:
  - Replaced instances `sys.version_info` with equivalent checks from `pandas.compat`
  - Removed code blocks specific to unsupported versions of Python (<2.7, 3.0-3.4)

<br />
There were some very specific examples that I left as-is:

https://github.com/pandas-dev/pandas/blob/c4b4a81f56205082ec7f12bf77766e3b74d27c37/pandas/tests/io/formats/test_to_csv.py#L13

Didn't change any Cython related code, as it appears that we want to avoid imports from outside `_libs`:
https://github.com/pandas-dev/pandas/blob/c4b4a81f56205082ec7f12bf77766e3b74d27c37/pandas/_libs/tslibs/parsing.pyx#L25-L26