### PR TITLE
TST: tests for inconsistent indexing with datetimes

### DIFF
--- a/pandas/tests/frame/test_indexing.py
+++ b/pandas/tests/frame/test_indexing.py
@@ -1548,6 +1548,14 @@ class TestDataFrameIndexing(TestData):
         # pytest.raises(
         #    Exception, df.loc.__setitem__, ('d', 'timestamp'), [nan])
 
+    def test_setitem_mixed_datetime(self):
+        # GH 9336
+        expected = DataFrame({'date': [1, 'a', 'b']})
+        df = DataFrame({'date': Series(pd.NaT, range(3))})
+        df.loc[0, 'date'] = 1
+        df.loc[1:2, 'date'] = 'a', 'b'
+        tm.assert_frame_equal(df, expected)
+
     def test_setitem_frame(self):
         piece = self.frame.loc[self.frame.index[:2], ['A', 'B']]
         self.frame.loc[self.frame.index[-2]:, ['A', 'B']] = piece.values

--- a/pandas/tests/frame/test_indexing.py
+++ b/pandas/tests/frame/test_indexing.py
@@ -1557,14 +1557,14 @@ class TestDataFrameIndexing(TestData):
                                     'y',
                                     pd.datetime(2013, 1, 1),
                                     pd.datetime(2014, 1, 1)]})
-        df = pd.DataFrame(np.zeros((6, 2), dtype=int), columns=['a', 'b'])
+        df = pd.DataFrame(0, columns=list('ab'), index=range(6))
         df['b'] = pd.NaT
         df.loc[0, 'b'] = pd.datetime(2012, 1, 1)
         df.loc[1, 'b'] = 1
         df.loc[[2, 3], 'b'] = 'x', 'y'
-        A = pd.DataFrame([[13, pd.datetime(2013, 1, 1)],
-                          [14, pd.datetime(2014, 1, 1)]])
-        df.loc[[4, 5], ['a', 'b']] = A.values
+        A = np.array([[13, pd.datetime(2013, 1, 1)],
+                      [14, pd.datetime(2014, 1, 1)]])
+        df.loc[[4, 5], ['a', 'b']] = A
         assert_frame_equal(df, expected)
 
     def test_setitem_frame(self):

--- a/pandas/tests/frame/test_indexing.py
+++ b/pandas/tests/frame/test_indexing.py
@@ -1562,8 +1562,8 @@ class TestDataFrameIndexing(TestData):
         df.loc[0, 'b'] = pd.datetime(2012, 1, 1)
         df.loc[1, 'b'] = 1
         df.loc[[2, 3], 'b'] = 'x', 'y'
-        A = np.array([[13, pd.datetime(2013, 1, 1)],
-                      [14, pd.datetime(2014, 1, 1)]])
+        A = np.array([[13, np.datetime64('2013-01-01T00:00:00')],
+                      [14, np.datetime64('2014-01-01T00:00:00')]])
         df.loc[[4, 5], ['a', 'b']] = A
         assert_frame_equal(df, expected)
 

--- a/pandas/tests/frame/test_indexing.py
+++ b/pandas/tests/frame/test_indexing.py
@@ -1550,11 +1550,22 @@ class TestDataFrameIndexing(TestData):
 
     def test_setitem_mixed_datetime(self):
         # GH 9336
-        expected = DataFrame({'date': [1, 'a', 'b']})
-        df = DataFrame({'date': Series(pd.NaT, range(3))})
-        df.loc[0, 'date'] = 1
-        df.loc[1:2, 'date'] = 'a', 'b'
-        tm.assert_frame_equal(df, expected)
+        expected = DataFrame({'a': [0, 0, 0, 0, 13, 14],
+                              'b': [pd.datetime(2012, 1, 1),
+                                    1,
+                                    'x',
+                                    'y',
+                                    pd.datetime(2013, 1, 1),
+                                    pd.datetime(2014, 1, 1)]})
+        df = pd.DataFrame(np.zeros((6, 2), dtype=int), columns=['a', 'b'])
+        df['b'] = pd.NaT
+        df.loc[0, 'b'] = pd.datetime(2012, 1, 1)
+        df.loc[1, 'b'] = 1
+        df.loc[[2, 3], 'b'] = 'x', 'y'
+        A = pd.DataFrame([[13, pd.datetime(2013, 1, 1)],
+                          [14, pd.datetime(2014, 1, 1)]])
+        df.loc[[4, 5], ['a', 'b']] = A.values
+        assert_frame_equal(df, expected)
 
     def test_setitem_frame(self):
         piece = self.frame.loc[self.frame.index[:2], ['A', 'B']]

--- a/pandas/tests/indexing/test_loc.py
+++ b/pandas/tests/indexing/test_loc.py
@@ -444,13 +444,6 @@ class TestLoc(Base):
         expected = DataFrame({'date': Series(['string'])})
         tm.assert_frame_equal(df, expected)
 
-        # GH 9336
-        expected = DataFrame({'date': [1, 'a', 'b']})
-        df = DataFrame({'date': Series(pd.NaT, range(3))})
-        df.loc[0, 'date'] = 1
-        df.loc[1:2, 'date'] = 'a', 'b'
-        tm.assert_frame_equal(df, expected)
-
     def test_loc_setitem_consistency_empty(self):
         # empty (essentially noops)
         expected = DataFrame(columns=['x', 'y'])

--- a/pandas/tests/indexing/test_loc.py
+++ b/pandas/tests/indexing/test_loc.py
@@ -444,6 +444,13 @@ class TestLoc(Base):
         expected = DataFrame({'date': Series(['string'])})
         tm.assert_frame_equal(df, expected)
 
+        # GH 9336
+        expected = DataFrame({'date': [1, 'a', 'b']})
+        df = DataFrame({'date': Series(pd.NaT, range(3))})
+        df.loc[0, 'date'] = 1
+        df.loc[1:2, 'date'] = 'a', 'b'
+        tm.assert_frame_equal(df, expected)
+
     def test_loc_setitem_consistency_empty(self):
         # empty (essentially noops)
         expected = DataFrame(columns=['x', 'y'])


### PR DESCRIPTION

- [X] closes #9336
- [X] tests added / passed
- [X] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry