### PR TITLE
CLN: Use new-style classes instead of old-style classes

### DIFF
--- a/ci/lint.sh
+++ b/ci/lint.sh
@@ -165,6 +165,14 @@ if [ "$LINT" ]; then
         RET=1
     fi
     echo "Check for deprecated messages without sphinx directive DONE"
+
+    echo "Check for old-style classes"
+    grep -R --include="*.py" -E "class\s\S*[^)]:" pandas scripts
+
+    if [ $? = "0" ]; then
+        RET=1
+    fi
+    echo "Check for old-style classes DONE"
     
 else
     echo "NOT Linting"

--- a/pandas/_version.py
+++ b/pandas/_version.py
@@ -25,7 +25,7 @@ def get_keywords():
     return keywords
 
 
-class VersioneerConfig:
+class VersioneerConfig(object):
     pass
 
 

--- a/pandas/io/common.py
+++ b/pandas/io/common.py
@@ -534,7 +534,7 @@ else:
             row = next(self.reader)
             return [compat.text_type(s, "utf-8") for s in row]
 
-    class UnicodeWriter:
+    class UnicodeWriter(object):
 
         """
         A CSV writer which will write rows to CSV file "f",

--- a/pandas/io/sas/sas7bdat.py
+++ b/pandas/io/sas/sas7bdat.py
@@ -321,7 +321,7 @@ class SAS7BDATReader(BaseIterator):
                   (compression == 0))
             f2 = (ptype == const.compressed_subheader_type)
             if (self.compression != "") and f1 and f2:
-                index = const.index.dataSubheaderIndex
+                index = const.SASIndex.data_subheader_index
             else:
                 self.close()
                 raise ValueError("Unknown subheader signature")
@@ -360,23 +360,23 @@ class SAS7BDATReader(BaseIterator):
         offset = pointer.offset
         length = pointer.length
 
-        if subheader_index == const.index.rowSizeIndex:
+        if subheader_index == const.SASIndex.row_size_index:
             processor = self._process_rowsize_subheader
-        elif subheader_index == const.index.columnSizeIndex:
+        elif subheader_index == const.SASIndex.column_size_index:
             processor = self._process_columnsize_subheader
-        elif subheader_index == const.index.columnTextIndex:
+        elif subheader_index == const.SASIndex.column_text_index:
             processor = self._process_columntext_subheader
-        elif subheader_index == const.index.columnNameIndex:
+        elif subheader_index == const.SASIndex.column_name_index:
             processor = self._process_columnname_subheader
-        elif subheader_index == const.index.columnAttributesIndex:
+        elif subheader_index == const.SASIndex.column_attributes_index:
             processor = self._process_columnattributes_subheader
-        elif subheader_index == const.index.formatAndLabelIndex:
+        elif subheader_index == const.SASIndex.format_and_label_index:
             processor = self._process_format_subheader
-        elif subheader_index == const.index.columnListIndex:
+        elif subheader_index == const.SASIndex.column_list_index:
             processor = self._process_columnlist_subheader
-        elif subheader_index == const.index.subheaderCountsIndex:
+        elif subheader_index == const.SASIndex.subheader_counts_index:
             processor = self._process_subheader_counts
-        elif subheader_index == const.index.dataSubheaderIndex:
+        elif subheader_index == const.SASIndex.data_subheader_index:
             self._current_page_data_subheader_pointers.append(pointer)
             return
         else:

--- a/pandas/io/sas/sas_constants.py
+++ b/pandas/io/sas/sas_constants.py
@@ -102,7 +102,7 @@ encoding_names = {29: "latin1", 20: "utf-8", 33: "cyrillic", 60: "wlatin2",
                   61: "wcyrillic", 62: "wlatin1", 90: "ebcdic870"}
 
 
-class index:
+class index(object):
     rowSizeIndex = 0
     columnSizeIndex = 1
     subheaderCountsIndex = 2

--- a/pandas/io/sas/sas_constants.py
+++ b/pandas/io/sas/sas_constants.py
@@ -102,49 +102,49 @@ encoding_names = {29: "latin1", 20: "utf-8", 33: "cyrillic", 60: "wlatin2",
                   61: "wcyrillic", 62: "wlatin1", 90: "ebcdic870"}
 
 
-class index(object):
-    rowSizeIndex = 0
-    columnSizeIndex = 1
-    subheaderCountsIndex = 2
-    columnTextIndex = 3
-    columnNameIndex = 4
-    columnAttributesIndex = 5
-    formatAndLabelIndex = 6
-    columnListIndex = 7
-    dataSubheaderIndex = 8
+class SASIndex(object):
+    row_size_index = 0
+    column_size_index = 1
+    subheader_counts_index = 2
+    column_text_index = 3
+    column_name_index = 4
+    column_attributes_index = 5
+    format_and_label_index = 6
+    column_list_index = 7
+    data_subheader_index = 8
 
 
 subheader_signature_to_index = {
-    b"\xF7\xF7\xF7\xF7": index.rowSizeIndex,
-    b"\x00\x00\x00\x00\xF7\xF7\xF7\xF7": index.rowSizeIndex,
-    b"\xF7\xF7\xF7\xF7\x00\x00\x00\x00": index.rowSizeIndex,
-    b"\xF7\xF7\xF7\xF7\xFF\xFF\xFB\xFE": index.rowSizeIndex,
-    b"\xF6\xF6\xF6\xF6": index.columnSizeIndex,
-    b"\x00\x00\x00\x00\xF6\xF6\xF6\xF6": index.columnSizeIndex,
-    b"\xF6\xF6\xF6\xF6\x00\x00\x00\x00": index.columnSizeIndex,
-    b"\xF6\xF6\xF6\xF6\xFF\xFF\xFB\xFE": index.columnSizeIndex,
-    b"\x00\xFC\xFF\xFF": index.subheaderCountsIndex,
-    b"\xFF\xFF\xFC\x00": index.subheaderCountsIndex,
-    b"\x00\xFC\xFF\xFF\xFF\xFF\xFF\xFF": index.subheaderCountsIndex,
-    b"\xFF\xFF\xFF\xFF\xFF\xFF\xFC\x00": index.subheaderCountsIndex,
-    b"\xFD\xFF\xFF\xFF": index.columnTextIndex,
-    b"\xFF\xFF\xFF\xFD": index.columnTextIndex,
-    b"\xFD\xFF\xFF\xFF\xFF\xFF\xFF\xFF": index.columnTextIndex,
-    b"\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFD": index.columnTextIndex,
-    b"\xFF\xFF\xFF\xFF": index.columnNameIndex,
-    b"\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF": index.columnNameIndex,
-    b"\xFC\xFF\xFF\xFF": index.columnAttributesIndex,
-    b"\xFF\xFF\xFF\xFC": index.columnAttributesIndex,
-    b"\xFC\xFF\xFF\xFF\xFF\xFF\xFF\xFF": index.columnAttributesIndex,
-    b"\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFC": index.columnAttributesIndex,
-    b"\xFE\xFB\xFF\xFF": index.formatAndLabelIndex,
-    b"\xFF\xFF\xFB\xFE": index.formatAndLabelIndex,
-    b"\xFE\xFB\xFF\xFF\xFF\xFF\xFF\xFF": index.formatAndLabelIndex,
-    b"\xFF\xFF\xFF\xFF\xFF\xFF\xFB\xFE": index.formatAndLabelIndex,
-    b"\xFE\xFF\xFF\xFF": index.columnListIndex,
-    b"\xFF\xFF\xFF\xFE": index.columnListIndex,
-    b"\xFE\xFF\xFF\xFF\xFF\xFF\xFF\xFF": index.columnListIndex,
-    b"\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFE": index.columnListIndex}
+    b"\xF7\xF7\xF7\xF7": SASIndex.row_size_index,
+    b"\x00\x00\x00\x00\xF7\xF7\xF7\xF7": SASIndex.row_size_index,
+    b"\xF7\xF7\xF7\xF7\x00\x00\x00\x00": SASIndex.row_size_index,
+    b"\xF7\xF7\xF7\xF7\xFF\xFF\xFB\xFE": SASIndex.row_size_index,
+    b"\xF6\xF6\xF6\xF6": SASIndex.column_size_index,
+    b"\x00\x00\x00\x00\xF6\xF6\xF6\xF6": SASIndex.column_size_index,
+    b"\xF6\xF6\xF6\xF6\x00\x00\x00\x00": SASIndex.column_size_index,
+    b"\xF6\xF6\xF6\xF6\xFF\xFF\xFB\xFE": SASIndex.column_size_index,
+    b"\x00\xFC\xFF\xFF": SASIndex.subheader_counts_index,
+    b"\xFF\xFF\xFC\x00": SASIndex.subheader_counts_index,
+    b"\x00\xFC\xFF\xFF\xFF\xFF\xFF\xFF": SASIndex.subheader_counts_index,
+    b"\xFF\xFF\xFF\xFF\xFF\xFF\xFC\x00": SASIndex.subheader_counts_index,
+    b"\xFD\xFF\xFF\xFF": SASIndex.column_text_index,
+    b"\xFF\xFF\xFF\xFD": SASIndex.column_text_index,
+    b"\xFD\xFF\xFF\xFF\xFF\xFF\xFF\xFF": SASIndex.column_text_index,
+    b"\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFD": SASIndex.column_text_index,
+    b"\xFF\xFF\xFF\xFF": SASIndex.column_name_index,
+    b"\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF": SASIndex.column_name_index,
+    b"\xFC\xFF\xFF\xFF": SASIndex.column_attributes_index,
+    b"\xFF\xFF\xFF\xFC": SASIndex.column_attributes_index,
+    b"\xFC\xFF\xFF\xFF\xFF\xFF\xFF\xFF": SASIndex.column_attributes_index,
+    b"\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFC": SASIndex.column_attributes_index,
+    b"\xFE\xFB\xFF\xFF": SASIndex.format_and_label_index,
+    b"\xFF\xFF\xFB\xFE": SASIndex.format_and_label_index,
+    b"\xFE\xFB\xFF\xFF\xFF\xFF\xFF\xFF": SASIndex.format_and_label_index,
+    b"\xFF\xFF\xFF\xFF\xFF\xFF\xFB\xFE": SASIndex.format_and_label_index,
+    b"\xFE\xFF\xFF\xFF": SASIndex.column_list_index,
+    b"\xFF\xFF\xFF\xFE": SASIndex.column_list_index,
+    b"\xFE\xFF\xFF\xFF\xFF\xFF\xFF\xFF": SASIndex.column_list_index,
+    b"\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFE": SASIndex.column_list_index}
 
 
 # List of frequently used SAS date and datetime formats

--- a/pandas/tests/frame/test_analytics.py
+++ b/pandas/tests/frame/test_analytics.py
@@ -1215,7 +1215,7 @@ class TestDataFrameAnalytics(TestData):
         getattr(mixed, name)(axis=0)
         getattr(mixed, name)(axis=1)
 
-        class NonzeroFail:
+        class NonzeroFail(object):
 
             def __nonzero__(self):
                 raise ValueError

--- a/pandas/tests/indexing/test_panel.py
+++ b/pandas/tests/indexing/test_panel.py
@@ -149,7 +149,7 @@ class TestPanel(object):
 
             # with an object-like
             # GH 9140
-            class TestObject:
+            class TestObject(object):
 
                 def __str__(self):
                     return "TestObject"

--- a/pandas/tests/io/formats/test_format.py
+++ b/pandas/tests/io/formats/test_format.py
@@ -1621,7 +1621,7 @@ c  10  11  12  13  14\
         If the test fails, it at least won't hang.
         """
 
-        class A:
+        class A(object):
             def __getitem__(self, key):
                 return 3  # obviously simplified
 

--- a/pandas/tests/io/json/test_ujson.py
+++ b/pandas/tests/io/json/test_ujson.py
@@ -460,11 +460,11 @@ class TestUltraJSONTests(object):
     def test_encodeRecursionMax(self):
         # 8 is the max recursion depth
 
-        class O2:
+        class O2(object):
             member = 0
             pass
 
-        class O1:
+        class O1(object):
             member = 0
             pass
 
@@ -772,7 +772,7 @@ class TestUltraJSONTests(object):
         assert "[1,2,3]" == f.getvalue()
 
     def test_dumpToFileLikeObject(self):
-        class filelike:
+        class filelike(object):
 
             def __init__(self):
                 self.bytes = ''
@@ -800,7 +800,7 @@ class TestUltraJSONTests(object):
             np.array([1, 2, 3, 4]), ujson.load(f, numpy=True))
 
     def test_loadFileLikeObject(self):
-        class filelike:
+        class filelike(object):
 
             def read(self):
                 try:
@@ -837,7 +837,7 @@ class TestUltraJSONTests(object):
 
     def test_encodeNumericOverflowNested(self):
         for n in range(0, 100):
-            class Nested:
+            class Nested(object):
                 x = 12839128391289382193812939
 
             nested = Nested()
@@ -886,7 +886,7 @@ class TestUltraJSONTests(object):
     def test_toDict(self):
         d = {u("key"): 31337}
 
-        class DictTest:
+        class DictTest(object):
 
             def toDict(self):
                 return d

--- a/pandas/tests/io/json/test_ujson.py
+++ b/pandas/tests/io/json/test_ujson.py
@@ -772,14 +772,14 @@ class TestUltraJSONTests(object):
         assert "[1,2,3]" == f.getvalue()
 
     def test_dumpToFileLikeObject(self):
-        class filelike(object):
+        class FileLike(object):
 
             def __init__(self):
                 self.bytes = ''
 
             def write(self, bytes):
                 self.bytes += bytes
-        f = filelike()
+        f = FileLike()
         ujson.dump([1, 2, 3], f)
         assert "[1,2,3]" == f.bytes
 
@@ -800,7 +800,7 @@ class TestUltraJSONTests(object):
             np.array([1, 2, 3, 4]), ujson.load(f, numpy=True))
 
     def test_loadFileLikeObject(self):
-        class filelike(object):
+        class FileLike(object):
 
             def read(self):
                 try:
@@ -808,10 +808,10 @@ class TestUltraJSONTests(object):
                 except AttributeError:
                     self.end = True
                     return "[1,2,3,4]"
-        f = filelike()
+        f = FileLike()
         assert [1, 2, 3, 4] == ujson.load(f)
 
-        f = filelike()
+        f = FileLike()
         tm.assert_numpy_array_equal(
             np.array([1, 2, 3, 4]), ujson.load(f, numpy=True))
 

--- a/pandas/tests/scalar/timedelta/test_timedelta.py
+++ b/pandas/tests/scalar/timedelta/test_timedelta.py
@@ -37,7 +37,7 @@ class TestTimedeltaArithmetic(object):
             assert left != right
 
     def test_ops_notimplemented(self):
-        class Other:
+        class Other(object):
             pass
 
         other = Other()

--- a/pandas/tests/sparse/frame/test_frame.py
+++ b/pandas/tests/sparse/frame/test_frame.py
@@ -227,7 +227,7 @@ class TestSparseDataFrame(SharedWithSparse):
 
     def test_constructor_from_unknown_type(self):
         # GH 19393
-        class Unknown:
+        class Unknown(object):
             pass
         with pytest.raises(TypeError,
                            message='SparseDataFrame called with unknown type '

--- a/pandas/tests/test_errors.py
+++ b/pandas/tests/test_errors.py
@@ -54,7 +54,7 @@ def test_error_rename():
             pass
 
 
-class Foo:
+class Foo(object):
     @classmethod
     def classmethod(cls):
         raise AbstractMethodError(cls, methodtype='classmethod')

--- a/pandas/tests/test_resample.py
+++ b/pandas/tests/test_resample.py
@@ -1082,7 +1082,7 @@ class TestDatetimeIndex(Base):
         def fn(x, a=1):
             return str(type(x))
 
-        class fn_class(object):
+        class FnClass(object):
 
             def __call__(self, x):
                 return str(type(x))
@@ -1091,7 +1091,7 @@ class TestDatetimeIndex(Base):
         df_lambda = df.resample("M").apply(lambda x: str(type(x)))
         df_partial = df.resample("M").apply(partial(fn))
         df_partial2 = df.resample("M").apply(partial(fn, a=2))
-        df_class = df.resample("M").apply(fn_class())
+        df_class = df.resample("M").apply(FnClass())
 
         assert_frame_equal(df_standard, df_lambda)
         assert_frame_equal(df_standard, df_partial)

--- a/pandas/tests/test_resample.py
+++ b/pandas/tests/test_resample.py
@@ -1082,7 +1082,7 @@ class TestDatetimeIndex(Base):
         def fn(x, a=1):
             return str(type(x))
 
-        class fn_class:
+        class fn_class(object):
 
             def __call__(self, x):
                 return str(type(x))

--- a/scripts/validate_docstrings.py
+++ b/scripts/validate_docstrings.py
@@ -94,7 +94,7 @@ def _output_header(title, width=80, char='#'):
         full_line=full_line, title_line=title_line)
 
 
-class Docstring:
+class Docstring(object):
     def __init__(self, method_name, method_obj):
         self.method_name = method_name
         self.method_obj = method_obj

--- a/versioneer.py
+++ b/versioneer.py
@@ -352,7 +352,7 @@ import subprocess
 import sys
 
 
-class VersioneerConfig:
+class VersioneerConfig(object):
     pass
 
 


### PR DESCRIPTION
Noticed some [lgtm.com alerts](https://lgtm.com/projects/g/pydata/pandas/snapshot/f85a69a8fdaed49747c4db61f5177a296cf290eb/files/scripts/validate_docstrings.py?sort=name&dir=ASC&mode=heatmap&showExcluded=false#L108) about the [`@property` decorator not working in old-style classes](https://lgtm.com/rules/10030086/) in `scripts/validate_docstrings.py`.  I don't think this actually causes any undesired behavior in that script though.

Figured this would be a good time to enforce new-style classes throughout the codebase:
  - Converted old-style classes to new-style classes
      - Basically just inserted `(object)`.
  - Added a check to `lint.sh` for old-style classes, since `flake8` doesn't look to be catching it.
      - Maybe there's a way to enforce this in `flake8` instead?
  - Didn't hit the Cython code; not exactly sure what the new-style vs. old-style conventions are there.