### PR TITLE
Adding test_map_missing_mixed to test_apply.py in pandas test suite series

### DIFF
--- a/pandas/tests/series/test_apply.py
+++ b/pandas/tests/series/test_apply.py
@@ -579,7 +579,7 @@ class TestSeriesMap(TestData):
 
     @pytest.mark.parametrize("mapping,exp", [
         ({np.nan: 'not NaN'}, pd.Series(['not NaN'])),
-        ({'string': 'another string' }, pd.Series(['another string'])),
+        ({'string': 'another string'}, pd.Series(['another string'])),
         ({42: 'the answer'}, pd.Series(['the answer']))])
     def test_map_missing_mixed(self, mapping, exp):
         s = pd.Series(list(mapping.keys())[0])

--- a/pandas/tests/series/test_apply.py
+++ b/pandas/tests/series/test_apply.py
@@ -582,6 +582,7 @@ class TestSeriesMap(TestData):
         (list('abc'), {'a': 'a letter'}, ['a letter'] + [np.nan] * 3),
         (list(range(3)), {0: 42}, [42] + [np.nan] * 3)])
     def test_map_missing_mixed(self, vals, mapping, exp):
+        # GH20495
         s = pd.Series(vals + [np.nan])
         result = s.map(mapping)
 

--- a/pandas/tests/series/test_apply.py
+++ b/pandas/tests/series/test_apply.py
@@ -578,11 +578,11 @@ class TestSeriesMap(TestData):
         tm.assert_series_equal(result, exp)
 
     @pytest.mark.parametrize("vals,mapping,exp", [
-        (list('abc'), {np.nan: 'not NaN'}, pd.Series(['not NaN'])),
-        (list('abc'), {'string': 'another string'}, pd.Series(['another string'])),
-        (list(range(3)), {42: 'the answer'}, pd.Series(['the answer']))])
+        (list('abc'), {np.nan: 'not NaN'}, ['not NaN']),
+        (list('abc'), {'string': 'another string'}, ['another string']),
+        (list(range(3)), {42: 'the answer'}, ['the answer'])])
     def test_map_missing_mixed(self, vals, mapping, exp):
         s = pd.Series(vals + [list(mapping.keys())[0]])
         result = s.map(mapping)
 
-        tm.assert_series_equal(result[-1:].reset_index(drop=True), exp)
+        tm.assert_series_equal(result[-1:].reset_index(drop=True), pd.Series(exp))

--- a/pandas/tests/series/test_apply.py
+++ b/pandas/tests/series/test_apply.py
@@ -577,10 +577,12 @@ class TestSeriesMap(TestData):
         exp = pd.Series(['Asia/Tokyo'] * 25, name='XX')
         tm.assert_series_equal(result, exp)
 
-    def test_map_missing_mixed(self):
-        s = pd.Series(list('abc') + [np.nan])
+    @pytest.mark.parametrize("mapping,exp", [
+        ({np.nan: 'not NaN'}, pd.Series(['not NaN'])),
+        ({'string': 'another string' }, pd.Series(['another string'])),
+        ({42: 'the answer'}, pd.Series(['the answer']))])
+    def test_map_missing_mixed(self, mapping, exp):
+        s = pd.Series(list(mapping.keys())[0])
+        result = s.map(mapping)
 
-        result = s.map({np.nan: 'not NaN'})
-        result2 = s.map({'a': 42, np.nan: 'not NaN'})
-
-        tm.assert_series_equal(result[-1:], result2[-1:])
+        tm.assert_series_equal(result, exp)

--- a/pandas/tests/series/test_apply.py
+++ b/pandas/tests/series/test_apply.py
@@ -577,12 +577,12 @@ class TestSeriesMap(TestData):
         exp = pd.Series(['Asia/Tokyo'] * 25, name='XX')
         tm.assert_series_equal(result, exp)
 
-    @pytest.mark.parametrize("mapping,exp", [
-        ({np.nan: 'not NaN'}, pd.Series(['not NaN'])),
-        ({'string': 'another string'}, pd.Series(['another string'])),
-        ({42: 'the answer'}, pd.Series(['the answer']))])
-    def test_map_missing_mixed(self, mapping, exp):
-        s = pd.Series(list(mapping.keys())[0])
+    @pytest.mark.parametrize("vals,mapping,exp", [
+        (list('abc'), {np.nan: 'not NaN'}, pd.Series(['not NaN'])),
+        (list('abc'), {'string': 'another string'}, pd.Series(['another string'])),
+        (list(range(3)), {42: 'the answer'}, pd.Series(['the answer']))])
+    def test_map_missing_mixed(self, vals, mapping, exp):
+        s = pd.Series(vals + [list(mapping.keys())[0]])
         result = s.map(mapping)
 
-        tm.assert_series_equal(result, exp)
+        tm.assert_series_equal(result[-1:].reset_index(drop=True), exp)

--- a/pandas/tests/series/test_apply.py
+++ b/pandas/tests/series/test_apply.py
@@ -583,4 +583,4 @@ class TestSeriesMap(TestData):
         result = s.map({np.nan: 'not NaN'})
         result2 = s.map({'a': 42, np.nan: 'not NaN'})
 
-        tm.assert_series_equal(result, result2)
+        tm.assert_series_equal(result[-1:], result2[-1:])

--- a/pandas/tests/series/test_apply.py
+++ b/pandas/tests/series/test_apply.py
@@ -579,7 +579,7 @@ class TestSeriesMap(TestData):
 
     def test_map_missing_mixed(self):
         s = pd.Series(list('abc') + [np.nan])
-        
+
         result = s.map({np.nan: 'not NaN'})
         result2 = s.map({'a': 42, np.nan: 'not NaN'})
 

--- a/pandas/tests/series/test_apply.py
+++ b/pandas/tests/series/test_apply.py
@@ -576,3 +576,11 @@ class TestSeriesMap(TestData):
         result = s.map(f)
         exp = pd.Series(['Asia/Tokyo'] * 25, name='XX')
         tm.assert_series_equal(result, exp)
+
+    def test_map_missing_mixed(self):
+        s = pd.Series(list('abc') + [np.nan])
+        
+        result = s.map({np.nan: 'not NaN'})
+        result2 = s.map({'a': 42, np.nan: 'not NaN'})
+
+        tm.assert_series_equal(result, result2)

--- a/pandas/tests/series/test_apply.py
+++ b/pandas/tests/series/test_apply.py
@@ -578,11 +578,11 @@ class TestSeriesMap(TestData):
         tm.assert_series_equal(result, exp)
 
     @pytest.mark.parametrize("vals,mapping,exp", [
-        (list('abc'), {np.nan: 'not NaN'}, ['not NaN']),
-        (list('abc'), {'string': 'another string'}, ['another string']),
-        (list(range(3)), {42: 'the answer'}, ['the answer'])])
+        (list('abc'), {np.nan: 'not NaN'}, [np.nan] * 3 + ['not NaN']),
+        (list('abc'), {'a': 'a letter'}, ['a letter'] + [np.nan] * 3),
+        (list(range(3)), {0: 42}, [42] + [np.nan] * 3)])
     def test_map_missing_mixed(self, vals, mapping, exp):
-        s = pd.Series(vals + [list(mapping.keys())[0]])
+        s = pd.Series(vals + [np.nan])
         result = s.map(mapping)
 
-        tm.assert_series_equal(result[-1:].reset_index(drop=True), pd.Series(exp))
+        tm.assert_series_equal(result, pd.Series(exp))


### PR DESCRIPTION
Checklist for other PRs (remove this part if you are doing a PR for the pandas documentation sprint):

- [x] closes #20495
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry (n/a)
