### PR TITLE
TST: remove skip for values/index length mismatch in ExtensionArray tests

### DIFF
--- a/pandas/tests/extension/base/constructors.py
+++ b/pandas/tests/extension/base/constructors.py
@@ -41,10 +41,7 @@ class BaseConstructorsTests(BaseExtensionTests):
         assert result.shape == (len(data), 1)
         assert isinstance(result._data.blocks[0], ExtensionBlock)
 
-    @pytest.mark.xfail(reason="GH-19342")
     def test_series_given_mismatched_index_raises(self, data):
-        msg = 'Wrong number of items passed 3, placement implies 4'
-        with tm.assert_raises_regex(ValueError, None) as m:
+        msg = 'Length of passed values is 3, index implies 5'
+        with tm.assert_raises_regex(ValueError, msg):
             pd.Series(data[:3], index=[0, 1, 2, 3, 4])
-
-        assert m.match(msg)


### PR DESCRIPTION
https://github.com/pandas-dev/pandas/issues/19342 is fixed in the meantime