### PR TITLE
Safely raise errors when object contains unicode

### DIFF
--- a/doc/source/whatsnew/v0.23.0.txt
+++ b/doc/source/whatsnew/v0.23.0.txt
@@ -1165,3 +1165,4 @@ Other
 
 - Improved error message when attempting to use a Python keyword as an identifier in a ``numexpr`` backed query (:issue:`18221`)
 - Bug in accessing a :func:`pandas.get_option`, which raised ``KeyError`` rather than ``OptionError`` when looking up a non-existant option key in some cases (:issue:`19789`)
+- Bug in :func:`raise_assert_detail` for Series and DataFrames with differing unicode data (:issue:`20503`)

--- a/doc/source/whatsnew/v0.23.0.txt
+++ b/doc/source/whatsnew/v0.23.0.txt
@@ -1165,4 +1165,4 @@ Other
 
 - Improved error message when attempting to use a Python keyword as an identifier in a ``numexpr`` backed query (:issue:`18221`)
 - Bug in accessing a :func:`pandas.get_option`, which raised ``KeyError`` rather than ``OptionError`` when looking up a non-existant option key in some cases (:issue:`19789`)
-- Bug in :func:`raise_assert_detail` for Series and DataFrames with differing unicode data (:issue:`20503`)
+- Bug in :func:`assert_series_equal` and :func:`assert_frame_equal` for Series or DataFrames with differing unicode data (:issue:`20503`)

--- a/pandas/tests/util/test_testing.py
+++ b/pandas/tests/util/test_testing.py
@@ -283,11 +283,11 @@ numpy array values are different \\(33\\.33333 %\\)
 \\[right\\]: \\[á, à, å\\]"""
 
         with tm.assert_raises_regex(AssertionError, expected):
-            assert_numpy_array_equal(np.array([u"á", u"à", u"ä"]),
-                                     np.array([u"á", u"à", u"å"]))
+            assert_numpy_array_equal(np.array([u'á', u'à', u'ä']),
+                                     np.array([u'á', u'à', u'å']))
         with tm.assert_raises_regex(AssertionError, expected):
-            assert_almost_equal(np.array([u"á", u"à", u"ä"]),
-                                np.array([u"á", u"à", u"å"]))
+            assert_almost_equal(np.array([u'á', u'à', u'ä']),
+                                np.array([u'á', u'à', u'å']))
 
         # allow to overwrite message
         expected = """Index are different
@@ -700,12 +700,16 @@ DataFrame\\.iloc\\[:, 1\\] values are different \\(33\\.33333 %\\)
 \\[right\\]: \\[é, è, e̊\\]"""
 
         with tm.assert_raises_regex(AssertionError, expected):
-            assert_frame_equal(pd.DataFrame({'A': [u"á", u"à", u"ä"], 'E': [u"é", u"è", u"ë"]}),
-                               pd.DataFrame({'A': [u"á", u"à", u"ä"], 'E': [u"é", u"è", u"e̊"]}))
+            assert_frame_equal(pd.DataFrame({'A': [u'á', u'à', u'ä'],
+                                             'E': [u'é', u'è', u'ë']}),
+                               pd.DataFrame({'A': [u'á', u'à', u'ä'],
+                                             'E': [u'é', u'è', u'e̊']}))
 
         with tm.assert_raises_regex(AssertionError, expected):
-            assert_frame_equal(pd.DataFrame({'A': [u"á", u"à", u"ä"], 'E': [u"é", u"è", u"ë"]}),
-                               pd.DataFrame({'A': [u"á", u"à", u"ä"], 'E': [u"é", u"è", u"e̊"]}),
+            assert_frame_equal(pd.DataFrame({'A': [u'á', u'à', u'ä'],
+                                             'E': [u'é', u'è', u'ë']}),
+                               pd.DataFrame({'A': [u'á', u'à', u'ä'],
+                                             'E': [u'é', u'è', u'e̊']}),
                                by_blocks=True)
 
 

--- a/pandas/tests/util/test_testing.py
+++ b/pandas/tests/util/test_testing.py
@@ -276,19 +276,6 @@ numpy array values are different \\(25\\.0 %\\)
             assert_almost_equal(np.array([[1, 2], [3, 4]]),
                                 np.array([[1, 3], [3, 4]]))
 
-        expected = """numpy array are different
-
-numpy array values are different \\(33\\.33333 %\\)
-\\[left\\]:  \\[á, à, ä\\]
-\\[right\\]: \\[á, à, å\\]"""
-
-        with tm.assert_raises_regex(AssertionError, expected):
-            assert_numpy_array_equal(np.array([u'á', u'à', u'ä']),
-                                     np.array([u'á', u'à', u'å']))
-        with tm.assert_raises_regex(AssertionError, expected):
-            assert_almost_equal(np.array([u'á', u'à', u'ä']),
-                                np.array([u'á', u'à', u'å']))
-
         # allow to overwrite message
         expected = """Index are different
 
@@ -302,6 +289,24 @@ Index shapes are different
         with tm.assert_raises_regex(AssertionError, expected):
             assert_almost_equal(np.array([1, 2]), np.array([3, 4, 5]),
                                 obj='Index')
+
+    def test_numpy_array_equal_unicode_message(self):
+        # Test ensures that `assert_numpy_array_equals` raises the right
+        # exception when comparing np.arrays containing differing
+        # unicode objects (#20503)
+
+        expected = """numpy array are different
+
+numpy array values are different \\(33\\.33333 %\\)
+\\[left\\]:  \\[á, à, ä\\]
+\\[right\\]: \\[á, à, å\\]"""
+
+        with tm.assert_raises_regex(AssertionError, expected):
+            assert_numpy_array_equal(np.array([u'á', u'à', u'ä']),
+                                     np.array([u'á', u'à', u'å']))
+        with tm.assert_raises_regex(AssertionError, expected):
+            assert_almost_equal(np.array([u'á', u'à', u'ä']),
+                                np.array([u'á', u'à', u'å']))
 
     @td.skip_if_windows
     def test_numpy_array_equal_object_message(self):
@@ -692,6 +697,11 @@ DataFrame\\.iloc\\[:, 1\\] values are different \\(33\\.33333 %\\)
             assert_frame_equal(pd.DataFrame({'A': [1, 2, 3], 'B': [4, 5, 6]}),
                                pd.DataFrame({'A': [1, 2, 3], 'B': [4, 5, 7]}),
                                by_blocks=True)
+
+    def test_frame_equal_message_unicode(self):
+        # Test ensures that `assert_frame_equals` raises the right
+        # exception when comparing DataFrames containing differing
+        # unicode objects (#20503)
 
         expected = """DataFrame\\.iloc\\[:, 1\\] are different
 

--- a/pandas/tests/util/test_testing.py
+++ b/pandas/tests/util/test_testing.py
@@ -523,6 +523,7 @@ class TestAssertSeriesEqual(object):
         self._assert_not_equal(Series(range(3)), Series(range(3)) + 1)
         self._assert_not_equal(Series(list('abc')), Series(list('xyz')))
         self._assert_not_equal(Series(list(u'áàä')), Series(list(u'éèë')))
+        self._assert_not_equal(Series(list(u'áàä')), Series(list(b'aaa')))
         self._assert_not_equal(Series(range(3)), Series(range(4)))
         self._assert_not_equal(
             Series(range(3)), Series(
@@ -720,6 +721,25 @@ DataFrame\\.iloc\\[:, 1\\] values are different \\(33\\.33333 %\\)
                                              'E': [u'é', u'è', u'ë']}),
                                pd.DataFrame({'A': [u'á', u'à', u'ä'],
                                              'E': [u'é', u'è', u'e̊']}),
+                               by_blocks=True)
+
+        expected = """DataFrame\\.iloc\\[:, 0\\] are different
+
+DataFrame\\.iloc\\[:, 0\\] values are different \\(100\\.0 %\\)
+\\[left\\]:  \\[á, à, ä\\]
+\\[right\\]: \\[a, a, a\\]"""
+
+        with tm.assert_raises_regex(AssertionError, expected):
+            assert_frame_equal(pd.DataFrame({'A': [u'á', u'à', u'ä'],
+                                             'E': [u'é', u'è', u'ë']}),
+                               pd.DataFrame({'A': ['a', 'a', 'a'],
+                                             'E': ['e', 'e', 'e']}))
+
+        with tm.assert_raises_regex(AssertionError, expected):
+            assert_frame_equal(pd.DataFrame({'A': [u'á', u'à', u'ä'],
+                                             'E': [u'é', u'è', u'ë']}),
+                               pd.DataFrame({'A': ['a', 'a', 'a'],
+                                             'E': ['e', 'e', 'e']}),
                                by_blocks=True)
 
 

--- a/pandas/tests/util/test_testing.py
+++ b/pandas/tests/util/test_testing.py
@@ -276,6 +276,19 @@ numpy array values are different \\(25\\.0 %\\)
             assert_almost_equal(np.array([[1, 2], [3, 4]]),
                                 np.array([[1, 3], [3, 4]]))
 
+        expected = """numpy array are different
+
+numpy array values are different \\(33\\.33333 %\\)
+\\[left\\]:  \\[á, à, ä\\]
+\\[right\\]: \\[á, à, å\\]"""
+
+        with tm.assert_raises_regex(AssertionError, expected):
+            assert_numpy_array_equal(np.array([u"á", u"à", u"ä"]),
+                                     np.array([u"á", u"à", u"å"]))
+        with tm.assert_raises_regex(AssertionError, expected):
+            assert_almost_equal(np.array([u"á", u"à", u"ä"]),
+                                np.array([u"á", u"à", u"å"]))
+
         # allow to overwrite message
         expected = """Index are different
 
@@ -499,10 +512,12 @@ class TestAssertSeriesEqual(object):
     def test_equal(self):
         self._assert_equal(Series(range(3)), Series(range(3)))
         self._assert_equal(Series(list('abc')), Series(list('abc')))
+        self._assert_equal(Series(list(u'áàä')), Series(list(u'áàä')))
 
     def test_not_equal(self):
         self._assert_not_equal(Series(range(3)), Series(range(3)) + 1)
         self._assert_not_equal(Series(list('abc')), Series(list('xyz')))
+        self._assert_not_equal(Series(list(u'áàä')), Series(list(u'éèë')))
         self._assert_not_equal(Series(range(3)), Series(range(4)))
         self._assert_not_equal(
             Series(range(3)), Series(
@@ -676,6 +691,21 @@ DataFrame\\.iloc\\[:, 1\\] values are different \\(33\\.33333 %\\)
         with tm.assert_raises_regex(AssertionError, expected):
             assert_frame_equal(pd.DataFrame({'A': [1, 2, 3], 'B': [4, 5, 6]}),
                                pd.DataFrame({'A': [1, 2, 3], 'B': [4, 5, 7]}),
+                               by_blocks=True)
+
+        expected = """DataFrame\\.iloc\\[:, 1\\] are different
+
+DataFrame\\.iloc\\[:, 1\\] values are different \\(33\\.33333 %\\)
+\\[left\\]:  \\[é, è, ë\\]
+\\[right\\]: \\[é, è, e̊\\]"""
+
+        with tm.assert_raises_regex(AssertionError, expected):
+            assert_frame_equal(pd.DataFrame({'A': [u"á", u"à", u"ä"], 'E': [u"é", u"è", u"ë"]}),
+                               pd.DataFrame({'A': [u"á", u"à", u"ä"], 'E': [u"é", u"è", u"e̊"]}))
+
+        with tm.assert_raises_regex(AssertionError, expected):
+            assert_frame_equal(pd.DataFrame({'A': [u"á", u"à", u"ä"], 'E': [u"é", u"è", u"ë"]}),
+                               pd.DataFrame({'A': [u"á", u"à", u"ä"], 'E': [u"é", u"è", u"e̊"]}),
                                by_blocks=True)
 
 

--- a/pandas/util/testing.py
+++ b/pandas/util/testing.py
@@ -31,7 +31,7 @@ from pandas.core.dtypes.common import (
     is_interval_dtype,
     is_sequence,
     is_list_like)
-from pandas.io.formats.printing import pprint_thing
+from pandas.io.formats.printing import pprint_thing_encoded
 from pandas.core.algorithms import take_1d
 import pandas.core.common as com
 
@@ -989,11 +989,11 @@ def assert_categorical_equal(left, right, check_dtype=True,
 
 def raise_assert_detail(obj, message, left, right, diff=None):
     if isinstance(left, np.ndarray):
-        left = repr(pprint_thing(left))
+        left = pprint_thing_encoded(left, encoding=pd.options.display.encoding)
     elif is_categorical_dtype(left):
         left = repr(left)
     if isinstance(right, np.ndarray):
-        right = repr(pprint_thing(right))
+        right = pprint_thing_encoded(right, encoding=pd.options.display.encoding)
     elif is_categorical_dtype(right):
         right = repr(right)
 

--- a/pandas/util/testing.py
+++ b/pandas/util/testing.py
@@ -31,7 +31,7 @@ from pandas.core.dtypes.common import (
     is_interval_dtype,
     is_sequence,
     is_list_like)
-from pandas.io.formats.printing import pprint_thing_encoded
+from pandas.io.formats.printing import pprint_thing
 from pandas.core.algorithms import take_1d
 import pandas.core.common as com
 
@@ -989,15 +989,20 @@ def assert_categorical_equal(left, right, check_dtype=True,
 
 def raise_assert_detail(obj, message, left, right, diff=None):
     if isinstance(left, np.ndarray):
-        left = pprint_thing_encoded(left,
-                                    encoding=pd.options.display.encoding)
+        left = pprint_thing(left)
     elif is_categorical_dtype(left):
         left = repr(left)
+
+    if compat.PY2 and isinstance(left, compat.string_types):
+        left = left.encode('utf-8')
+
     if isinstance(right, np.ndarray):
-        right = pprint_thing_encoded(right,
-                                     encoding=pd.options.display.encoding)
+        right = pprint_thing(right)
     elif is_categorical_dtype(right):
         right = repr(right)
+
+    if compat.PY2 and isinstance(right, compat.string_types):
+        right = right.encode('utf-8')
 
     msg = """{obj} are different
 

--- a/pandas/util/testing.py
+++ b/pandas/util/testing.py
@@ -994,6 +994,7 @@ def raise_assert_detail(obj, message, left, right, diff=None):
         left = repr(left)
 
     if PY2 and isinstance(left, string_types):
+        # left needs to be printable in native text type in python2
         left = left.encode('utf-8')
 
     if isinstance(right, np.ndarray):
@@ -1002,6 +1003,7 @@ def raise_assert_detail(obj, message, left, right, diff=None):
         right = repr(right)
 
     if PY2 and isinstance(right, string_types):
+        # right needs to be printable in native text type in python2
         right = right.encode('utf-8')
 
     msg = """{obj} are different

--- a/pandas/util/testing.py
+++ b/pandas/util/testing.py
@@ -989,11 +989,11 @@ def assert_categorical_equal(left, right, check_dtype=True,
 
 def raise_assert_detail(obj, message, left, right, diff=None):
     if isinstance(left, np.ndarray):
-        left = pprint_thing(left)
+        left = repr(pprint_thing(left))
     elif is_categorical_dtype(left):
         left = repr(left)
     if isinstance(right, np.ndarray):
-        right = pprint_thing(right)
+        right = repr(pprint_thing(right))
     elif is_categorical_dtype(right):
         right = repr(right)
 

--- a/pandas/util/testing.py
+++ b/pandas/util/testing.py
@@ -38,7 +38,7 @@ import pandas.core.common as com
 import pandas.compat as compat
 from pandas.compat import (
     filter, map, zip, range, unichr, lrange, lmap, lzip, u, callable, Counter,
-    raise_with_traceback, httplib, StringIO, PY3)
+    raise_with_traceback, httplib, StringIO, string_types, PY3, PY2)
 
 from pandas import (bdate_range, CategoricalIndex, Categorical, IntervalIndex,
                     DatetimeIndex, TimedeltaIndex, PeriodIndex, RangeIndex,
@@ -993,7 +993,7 @@ def raise_assert_detail(obj, message, left, right, diff=None):
     elif is_categorical_dtype(left):
         left = repr(left)
 
-    if compat.PY2 and isinstance(left, compat.string_types):
+    if PY2 and isinstance(left, string_types):
         left = left.encode('utf-8')
 
     if isinstance(right, np.ndarray):
@@ -1001,7 +1001,7 @@ def raise_assert_detail(obj, message, left, right, diff=None):
     elif is_categorical_dtype(right):
         right = repr(right)
 
-    if compat.PY2 and isinstance(right, compat.string_types):
+    if PY2 and isinstance(right, string_types):
         right = right.encode('utf-8')
 
     msg = """{obj} are different

--- a/pandas/util/testing.py
+++ b/pandas/util/testing.py
@@ -989,11 +989,13 @@ def assert_categorical_equal(left, right, check_dtype=True,
 
 def raise_assert_detail(obj, message, left, right, diff=None):
     if isinstance(left, np.ndarray):
-        left = pprint_thing_encoded(left, encoding=pd.options.display.encoding)
+        left = pprint_thing_encoded(left,
+                                    encoding=pd.options.display.encoding)
     elif is_categorical_dtype(left):
         left = repr(left)
     if isinstance(right, np.ndarray):
-        right = pprint_thing_encoded(right, encoding=pd.options.display.encoding)
+        right = pprint_thing_encoded(right,
+                                     encoding=pd.options.display.encoding)
     elif is_categorical_dtype(right):
         right = repr(right)
 


### PR DESCRIPTION
This safely turns nd.array objects that contain unicode into a
representation that can be printed

Checklist for other PRs (remove this part if you are doing a PR for the pandas documentation sprint):

- [x] closes #20503
- [ ] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry
