### PR TITLE
BUG: HDFStore failures on timezone-aware data

### DIFF
--- a/doc/source/whatsnew/v0.23.0.txt
+++ b/doc/source/whatsnew/v0.23.0.txt
@@ -1099,6 +1099,7 @@ I/O
 - Bug in :meth:`pandas.io.json.json_normalize` where subrecords are not properly normalized if any subrecords values are NoneType (:issue:`20030`)
 - Bug in ``usecols`` parameter in :func:`pandas.io.read_csv` and :func:`pandas.io.read_table` where error is not raised correctly when passing a string. (:issue:`20529`)
 - Bug in :func:`HDFStore.keys` when reading a file with a softlink causes exception (:issue:`20523`)
+- Bug in :class:`HDFStore` for Series and empty DataFrames with timezone-aware data (:issue:`20594`)
 
 Plotting
 ^^^^^^^^

--- a/doc/source/whatsnew/v0.23.0.txt
+++ b/doc/source/whatsnew/v0.23.0.txt
@@ -1099,7 +1099,7 @@ I/O
 - Bug in :meth:`pandas.io.json.json_normalize` where subrecords are not properly normalized if any subrecords values are NoneType (:issue:`20030`)
 - Bug in ``usecols`` parameter in :func:`pandas.io.read_csv` and :func:`pandas.io.read_table` where error is not raised correctly when passing a string. (:issue:`20529`)
 - Bug in :func:`HDFStore.keys` when reading a file with a softlink causes exception (:issue:`20523`)
-- Bug in :class:`HDFStore` for Series and empty DataFrames with timezone-aware data (:issue:`20594`)
+- Bug in :class:`HDFStore` export of a :class:`Series` or an empty :class:`DataFrame` with timezone-aware data in fixed format (:issue:`20594`)
 
 Plotting
 ^^^^^^^^

--- a/pandas/io/pytables.py
+++ b/pandas/io/pytables.py
@@ -2766,7 +2766,7 @@ class SeriesFixed(GenericFixed):
         super(SeriesFixed, self).write(obj, **kwargs)
         self.write_index('index', obj.index)
         if is_datetime64tz_dtype(obj.dtype):
-            values = obj._data.blocks[0].values
+            values = obj.dt._get_values()
         else:
             values = obj.values
         self.write_array('values', values)

--- a/pandas/tests/io/test_pytables.py
+++ b/pandas/tests/io/test_pytables.py
@@ -2792,11 +2792,13 @@ class TestHDFStore(Base):
         self._check_roundtrip(df1, tm.assert_frame_equal)
         self._check_roundtrip(df2, tm.assert_frame_equal)
 
-    def test_empty_series(self):
-        for dtype in [np.int64, np.float64, np.object, 'm8[ns]', 'M8[ns]',
-                      'datetime64[ns, UTC]']:
-            s = Series(dtype=dtype)
-            self._check_roundtrip(s, tm.assert_series_equal)
+    @pytest.mark.parametrize('dtype', [
+        np.int64, np.float64, np.object, 'm8[ns]', 'M8[ns]',
+        'datetime64[ns, UTC]'
+    ])
+    def test_empty_series(self, dtype):
+        s = Series(dtype=dtype)
+        self._check_roundtrip(s, tm.assert_series_equal)
 
     def test_series_timezone(self):
         s = Series([0], dtype='datetime64[ns, UTC]')

--- a/pandas/tests/io/test_pytables.py
+++ b/pandas/tests/io/test_pytables.py
@@ -2794,18 +2794,24 @@ class TestHDFStore(Base):
 
     @pytest.mark.parametrize('dtype', [
         np.int64, np.float64, np.object, 'm8[ns]', 'M8[ns]',
-        'datetime64[ns, UTC]'
+        'datetime64[ns, UTC]', 'datetime64[ns, US/Eastern]'
     ])
     def test_empty_series(self, dtype):
         s = Series(dtype=dtype)
         self._check_roundtrip(s, tm.assert_series_equal)
 
-    def test_series_timezone(self):
-        s = Series([0], dtype='datetime64[ns, UTC]')
+    @pytest.mark.parametrize('dtype', [
+        'datetime64[ns, UTC]', 'datetime64[ns, US/Eastern]'
+    ])
+    def test_series_timezone(self, dtype):
+        s = Series([0], dtype=dtype)
         self._check_roundtrip(s, tm.assert_series_equal)
 
-    def test_empty_frame_timezone(self):
-        s = Series(dtype='datetime64[ns, UTC]')
+    @pytest.mark.parametrize('dtype', [
+        'datetime64[ns, UTC]', 'datetime64[ns, US/Eastern]'
+    ])
+    def test_empty_frame_timezone(self, dtype):
+        s = Series(dtype=dtype)
         df = DataFrame({'A': s})
         self._check_roundtrip(df, tm.assert_frame_equal)
 

--- a/pandas/tests/io/test_pytables.py
+++ b/pandas/tests/io/test_pytables.py
@@ -2793,9 +2793,19 @@ class TestHDFStore(Base):
         self._check_roundtrip(df2, tm.assert_frame_equal)
 
     def test_empty_series(self):
-        for dtype in [np.int64, np.float64, np.object, 'm8[ns]', 'M8[ns]']:
+        for dtype in [np.int64, np.float64, np.object, 'm8[ns]', 'M8[ns]',
+                      'datetime64[ns, UTC]']:
             s = Series(dtype=dtype)
             self._check_roundtrip(s, tm.assert_series_equal)
+
+    def test_series_timezone(self):
+        s = Series([0], dtype='datetime64[ns, UTC]')
+        self._check_roundtrip(s, tm.assert_series_equal)
+
+    def test_empty_frame_timezone(self):
+        s = Series(dtype='datetime64[ns, UTC]')
+        df = DataFrame({'A': s})
+        self._check_roundtrip(df, tm.assert_frame_equal)
 
     def test_can_serialize_dates(self):
 


### PR DESCRIPTION
- [x] closes #20594
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry
