### PR TITLE
BUG/PERF: Fixed IntervalIndex.nbytes and itemsize

### DIFF
--- a/doc/source/whatsnew/v0.23.0.txt
+++ b/doc/source/whatsnew/v0.23.0.txt
@@ -896,6 +896,7 @@ Performance Improvements
 - Improved performance of :func:`pandas.core.groupby.GroupBy.ffill` and :func:`pandas.core.groupby.GroupBy.bfill` (:issue:`11296`)
 - Improved performance of :func:`pandas.core.groupby.GroupBy.any` and :func:`pandas.core.groupby.GroupBy.all` (:issue:`15435`)
 - Improved performance of :func:`pandas.core.groupby.GroupBy.pct_change` (:issue:`19165`)
+- Improved performance of ``IntervalIndex.nbytes`` and ``IntervalIndex.itemsize`` (:issue:`19209`)
 
 .. _whatsnew_0230.docs:
 
@@ -1062,6 +1063,7 @@ Indexing
 - Bug in ``Index`` subclasses constructors that ignore unexpected keyword arguments (:issue:`19348`)
 - Bug in :meth:`Index.difference` when taking difference of an ``Index`` with itself (:issue:`20040`)
 - Bug in :meth:`DataFrame.first_valid_index` and :meth:`DataFrame.last_valid_index` in presence of entire rows of NaNs in the middle of values (:issue:`20499`).
+- Bug in ``IntervalIndex.nbytes`` and ``IntervalIndex.itemsize`` underreporting memory usage (:issues:`19209`).
 
 MultiIndex
 ^^^^^^^^^^

--- a/pandas/core/indexes/interval.py
+++ b/pandas/core/indexes/interval.py
@@ -729,6 +729,14 @@ class IntervalIndex(IntervalMixin, Index):
         return self.left.size
 
     @property
+    def nbytes(self):
+        return self.left.nbytes + self.right.nbytes
+
+    @property
+    def itemsize(self):
+        return self.left.itemsize + self.right.itemsize
+
+    @property
     def shape(self):
         # Avoid materializing self.values
         return self.left.shape

--- a/pandas/tests/indexes/interval/test_interval.py
+++ b/pandas/tests/indexes/interval/test_interval.py
@@ -24,6 +24,7 @@ def name(request):
 
 class TestIntervalIndex(Base):
     _holder = IntervalIndex
+    _compat_props = ['shape', 'ndim', 'size']
 
     def setup_method(self, method):
         self.index = IntervalIndex.from_arrays([0, 1], [1, 2])
@@ -964,3 +965,21 @@ class TestIntervalIndex(Base):
             assert all(isna(x) for x in result_na)
         else:
             assert isna(result_na)
+
+    def test_nbytes(self):
+        # GH 19209
+        left = np.arange(0, 4, dtype='i8')
+        right = np.arange(1, 5, dtype='i8')
+
+        result = IntervalIndex.from_arrays(left, right).nbytes
+        expected = 64  # 4 * 8 * 2
+        assert result == expected
+
+    def test_itemsize(self):
+        # GH 19209
+        left = np.arange(0, 4, dtype='i8')
+        right = np.arange(1, 5, dtype='i8')
+
+        result = IntervalIndex.from_arrays(left, right).itemsize
+        expected = 16  # 8 * 2
+        assert result == expected


### PR DESCRIPTION
Avoid materializing the ndarray of Intervals. Just get from left and right
instead.

Closes https://github.com/pandas-dev/pandas/issues/19209