### PR TITLE
BUG: Avoid splitting string with list() (#20592)

### DIFF
--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -951,7 +951,10 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
 
             if not isinstance(key, (list, Series, np.ndarray, Series)):
                 try:
-                    key = list(key)
+                    if isinstance(key, compat.string_types):
+                        key = [key]
+                    else:
+                        key = list(key)
                 except Exception:
                     key = [key]
 


### PR DESCRIPTION
 Solves #20592 and I doubt that there are any cases when a key string should be split by `list()`