### PR TITLE
DOC: update the str_replace docstring

### DIFF
--- a/pandas/core/strings.py
+++ b/pandas/core/strings.py
@@ -439,8 +439,7 @@ def str_endswith(arr, pat, na=np.nan):
 def str_replace(arr, pat, repl, n=-1, case=None, flags=0, regex=True):
     r"""
     Replace occurrences of pattern/regex in the Series/Index with
-    some other string. Equivalent to :meth:`str.replace` or
-    :func:`re.sub`.
+    some other string. Equivalent to :func:`re.sub`.
 
     Parameters
     ----------


### PR DESCRIPTION
Remove claim in `str_replace` docstring of equivalence to base Python `str.replace` -- the former does regex parsing while the latter does not.