### PR TITLE
DOC: update the pandas.Series.str.strip docstring

### DIFF
--- a/pandas/core/strings.py
+++ b/pandas/core/strings.py
@@ -2094,8 +2094,46 @@ class StringMethods(NoNewAttributesMixin):
         return self._wrap_result(result)
 
     _shared_docs['str_strip'] = ("""
-    Strip whitespace (including newlines) from each string in the
-    Series/Index from %(side)s. Equivalent to :meth:`str.%(method)s`.
+    Strip whitespaces from string in Series.
+
+    Strip whitespace (including newlines) or given string from
+    each string in the Series/Index from %(side)s. Equivalent to
+    :meth:`str.%(method)s`.
+
+    Parameters
+    ----------
+    to_strip : str or unicode
+        String or unicode to strip in the given string.
+
+    Examples
+    --------
+    >>> # strip method
+    >>> s = pd.Series(['   This is a Test 1  '])
+    >>> s
+    0    This is a Test 1
+    dtype: object
+    >>> s = s.str.strip()
+    >>> s
+    0    This is a Test 1
+    dtype: object
+    >>> # lstrip method
+    >>> s1 = pd.Series(['This is another Test'])
+    >>> s1
+    0    This is another Test
+    dtype: object
+    >>> s1 = s1.str.lstrip('This')
+    >>> s1
+    0     is another Test
+    dtype: object
+    >>> # rstrip method
+    >>> s2 = pd.Series(['This is the last test'])
+    >>> s2
+    0    This is the last test
+    dtype: object
+    >>> s2 = s2.str.rstrip('test')
+    >>> s2
+    0     This is the last
+    dtype: object
 
     Returns
     -------


### PR DESCRIPTION
Checklist for the pandas documentation sprint (ignore this if you are doing
an unrelated PR):

- [x] PR title is "DOC: update the <your-function-or-method> docstring"
- [x] The validation script passes: `scripts/validate_docstrings.py <your-function-or-method>`
- [x] The PEP8 style check passes: `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] The html version looks good: `python doc/make.py --single <your-function-or-method>`
- [x] It has been proofread on language by another sprint participant

Please include the output of the validation script below between the "```" ticks:

```
################################################################################
##################### Docstring (pandas.Series.str.strip)  #####################
################################################################################

Strip whitespaces from string in Series.

Strip whitespace (including newlines) or given string from
each string in the Series/Index from left and right sides. Equivalent to
:meth:`str.strip`.

Parameters
----------
to_strip : str or unicode
    String or unicode to strip in the given string.

Examples
--------
>>> # strip method
>>> s = pd.Series(['   This is a Test 1  '])
>>> s
0    This is a Test 1
dtype: object
>>> s = s.str.strip()
>>> s
0    This is a Test 1
dtype: object
>>> # lstrip method
>>> s1 = pd.Series(['This is another Test'])
>>> s1
0    This is another Test
dtype: object
>>> s1 = s1.str.lstrip('This')
>>> s1
0     is another Test
dtype: object
>>> # rstrip method
>>> s2 = pd.Series(['This is the last test'])
>>> s2
0    This is the last test
dtype: object
>>> s2 = s2.str.rstrip('test')
>>> s2
0     This is the last
dtype: object

Returns
-------
stripped : Series/Index of objects

################################################################################
################################## Validation ##################################
################################################################################

Errors found:
	See Also section not found


```