### PR TITLE
update the pandas.Series.str.repeat docstring

### DIFF
--- a/pandas/core/strings.py
+++ b/pandas/core/strings.py
@@ -678,17 +678,45 @@ def str_replace(arr, pat, repl, n=-1, case=None, flags=0, regex=True):
 
 def str_repeat(arr, repeats):
     """
-    Duplicate each string in the Series/Index by indicated number
-    of times.
+    Duplicate each string repeated by indicated number of times.
+
+    Duplicate each string in the Series/Index by indicated number of times.
+    A passed value of zero or negative integer will return an empty string.
 
     Parameters
     ----------
-    repeats : int or array
-        Same value for all (int) or different value per (array)
+    repeats : int or array-like
+        Same value for all (int) or different value per (array).
 
     Returns
     -------
-    repeated : Series/Index of objects
+    Series or Index
+        Series or Index of repeated string objects specified by
+        input parameter repeats.
+
+    Examples
+    --------
+    >>> s = pd.Series(['a', 'b', 'c', 'd', 'e'])
+
+    Using same value for all:
+
+    >>> s.str.repeat(repeats=4)
+    0    aaaa
+    1    bbbb
+    2    cccc
+    3    dddd
+    4    eeee
+    dtype: object
+
+    Using different value per element:
+
+    >>> s.str.repeat(repeats=[-2, -1, 0, 1, 2])
+    0
+    1
+    2
+    3     d
+    4    ee
+    dtype: object
     """
     if is_scalar(repeats):
 


### PR DESCRIPTION
Checklist for the pandas documentation sprint (ignore this if you are doing
an unrelated PR):

- [x] PR title is "DOC: update the <your-function-or-method> docstring"
- [x] The validation script passes: `scripts/validate_docstrings.py <your-function-or-method>`
- [x] The PEP8 style check passes: `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] The html version looks good: `python doc/make.py --single <your-function-or-method>`
- [x] It has been proofread on language by another sprint participant

```
################################################################################
##################### Docstring (pandas.Series.str.repeat) #####################
################################################################################

Duplicate each string repeated by indicated number of times.

Parameters
----------
repeats : int or array
    Same value for all (int) or different value per (array).

Returns
-------
repeated : Series/Index of objects
    Same type as the original object

Examples
--------
>>> s = pd.Series(['a', 'b', 'c', 'd', 'e'])

Using same value for all:

>>> s.str.repeat(4)
0    aaaa
1    bbbb
2    cccc
3    dddd
4    eeee
dtype: object

Using different value per element:

>>> s.str.repeat([3, 2, 5, 1, 4])
0      aaa
1       bb
2    ccccc
3        d
4     eeee
dtype: object

Passing zero or negative integer will return an empty string

>>> s.str.repeat([0, 0, -2, -1, 0])
0
1
2
3
4
dtype: object

Notes
--------
A passed value of zero or negative integer will return an empty string.

See also
--------
numpy.ndarray.repeat: Repeat elements of an array.

################################################################################
################################## Validation ##################################
################################################################################

Errors found:
	No extended summary found
```

If the validation script still gives errors, but you think there is a good reason
to deviate in this case (and there are certainly such cases), please state this
explicitly.


Checklist for other PRs (remove this part if you are doing a PR for the pandas documentation sprint):

- [ ] closes #xxxx
- [ ] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
