### PR TITLE
Np Any/All Transformation Bug

### DIFF
--- a/doc/source/whatsnew/v0.23.0.txt
+++ b/doc/source/whatsnew/v0.23.0.txt
@@ -1130,6 +1130,7 @@ Groupby/Resample/Rolling
 - Fixed a performance regression for ``GroupBy.nth`` and ``GroupBy.last`` with some object columns (:issue:`19283`)
 - Bug in :func:`DataFrameGroupBy.cumsum` and :func:`DataFrameGroupBy.cumprod` when ``skipna`` was passed (:issue:`19806`)
 - Bug in :func:`Dataframe.resample` that dropped timezone information (:issue:`13238`)
+- Bug in :func:`DataFrame.groupby` where transformations using ``np.all`` and ``np.any`` were raising a ``ValueError`` (:issue:`20653`)
 
 Sparse
 ^^^^^^

--- a/pandas/core/base.py
+++ b/pandas/core/base.py
@@ -188,6 +188,8 @@ class SelectionMixin(object):
         builtins.sum: 'sum',
         builtins.max: 'max',
         builtins.min: 'min',
+        np.all: 'all',
+        np.any: 'any',
         np.sum: 'sum',
         np.mean: 'mean',
         np.prod: 'prod',

--- a/pandas/tests/groupby/test_transform.py
+++ b/pandas/tests/groupby/test_transform.py
@@ -723,3 +723,15 @@ class TestGroupBy(MixIn):
             exp = DataFrame({'vals': exp_vals * 2})
             result = get_result(grp)
             tm.assert_frame_equal(result, exp)
+
+    @pytest.mark.parametrize("func", [np.any, np.all])
+    def test_any_all_np_func(self, func):
+        # GH 20653
+        df = pd.DataFrame([['foo', True],
+                           [np.nan, True],
+                           ['foo', True]], columns=['key', 'val'])
+
+        exp = pd.Series([True, np.nan, True], name='val')
+
+        res = df.groupby('key')['val'].transform(func)
+        tm.assert_series_equal(res, exp)


### PR DESCRIPTION
- [X] closes #20653
- [X] tests added / passed
- [X] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [X] whatsnew entry

I believe this can be added to the whitelist of Cython functions as a result of #19722. I did similar changes with other agg funcs and will review separately to see if we should be adding more to this dict