### PR TITLE
DOC: Updated the docstring of pandas.Series.str.get

### DIFF
--- a/pandas/core/strings.py
+++ b/pandas/core/strings.py
@@ -1651,17 +1651,36 @@ def str_translate(arr, table, deletechars=None):
 
 def str_get(arr, i):
     """
+    Extract element from each component at specified position.
+
     Extract element from lists, tuples, or strings in each element in the
     Series/Index.
 
     Parameters
     ----------
     i : int
-        Integer index (location)
+        Position of element to extract.
 
     Returns
     -------
     items : Series/Index of objects
+
+    Examples
+    --------
+    >>> s = pd.Series(["String", (1, 2, 3), ["a", "b", "c"], 123])
+    >>> s
+    0       String
+    1    (1, 2, 3)
+    2    [a, b, c]
+    3          123
+    dtype: object
+
+    >>> s.str.get(1)
+    0      t
+    1      2
+    2      b
+    3    NaN
+    dtype: object
     """
     f = lambda x: x[i] if len(x) > i >= -len(x) else np.nan
     return _na_map(f, arr)

--- a/pandas/core/strings.py
+++ b/pandas/core/strings.py
@@ -1667,19 +1667,36 @@ def str_get(arr, i):
 
     Examples
     --------
-    >>> s = pd.Series(["String", (1, 2, 3), ["a", "b", "c"], 123])
+    >>> s = pd.Series(["String", 
+               (1, 2, 3), 
+               ["a", "b", "c"], 
+               123, -456, 
+               {1:"Hello", "2":"World"}])
     >>> s
-    0       String
-    1    (1, 2, 3)
-    2    [a, b, c]
-    3          123
+    0                        String
+    1                     (1, 2, 3)
+    2                     [a, b, c]
+    3                           123
+    4                          -456
+    5    {1: 'Hello', '2': 'World'}
     dtype: object
-
+    
     >>> s.str.get(1)
-    0      t
-    1      2
-    2      b
+    0        t
+    1        2
+    2        b
+    3      NaN
+    4      NaN
+    5    Hello
+    dtype: object
+    
+    >>> s.str.get(-1)
+    0      g
+    1      3
+    2      c
     3    NaN
+    4    NaN
+    5    NaN
     dtype: object
     """
     f = lambda x: x[i] if len(x) > i >= -len(x) else np.nan

--- a/pandas/core/strings.py
+++ b/pandas/core/strings.py
@@ -1667,10 +1667,10 @@ def str_get(arr, i):
 
     Examples
     --------
-    >>> s = pd.Series(["String", 
-               (1, 2, 3), 
-               ["a", "b", "c"], 
-               123, -456, 
+    >>> s = pd.Series(["String",
+               (1, 2, 3),
+               ["a", "b", "c"],
+               123, -456,
                {1:"Hello", "2":"World"}])
     >>> s
     0                        String
@@ -1680,7 +1680,7 @@ def str_get(arr, i):
     4                          -456
     5    {1: 'Hello', '2': 'World'}
     dtype: object
-    
+
     >>> s.str.get(1)
     0        t
     1        2
@@ -1689,7 +1689,7 @@ def str_get(arr, i):
     4      NaN
     5    Hello
     dtype: object
-    
+
     >>> s.str.get(-1)
     0      g
     1      3


### PR DESCRIPTION
Checklist for the pandas documentation sprint (ignore this if you are doing
an unrelated PR):

- [x] PR title is "DOC: update the <your-function-or-method> docstring"
- [x] The validation script passes: `scripts/validate_docstrings.py <your-function-or-method>`
- [x] The PEP8 style check passes: `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] The html version looks good: `python doc/make.py --single <your-function-or-method>`
- [x] It has been proofread on language by another sprint participant

Please include the output of the validation script below between the "```" ticks:

```
################################################################################
###################### Docstring (pandas.Series.str.get)  ######################
################################################################################

Extract the element from each component at the specified position.

Extract element from lists, tuples, or strings in each element in the
Series/Index.

Parameters
----------
i : int
    Position of the element to extract.

Returns
-------
items : Series/Index of objects

Examples
--------
>>> s = pd.Series(["String", (1, 2, 3), ["a", "b", "c"], 123])
>>> s
0       String
1    (1, 2, 3)
2    [a, b, c]
3          123
dtype: object

>>> s.str.get(1)
0      t
1      2
2      b
3    NaN
dtype: object

################################################################################
################################## Validation ##################################
################################################################################

Errors found:
	See Also section not found

```