### PR TITLE
ERR: Consistent errors for non-numeric ranking. (#19560)

### DIFF
--- a/doc/source/whatsnew/v0.23.0.txt
+++ b/doc/source/whatsnew/v0.23.0.txt
@@ -418,6 +418,8 @@ Other Enhancements
 Backwards incompatible API changes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+- Using :func:`DataFrame.rank` on a data frame with non-numeric entries other than ordered categoricals will raise a ValueError.
+
 .. _whatsnew_0230.api_breaking.deps:
 
 Dependencies have increased minimum versions

--- a/pandas/core/algorithms.py
+++ b/pandas/core/algorithms.py
@@ -859,6 +859,17 @@ def rank(values, axis=0, method='average', na_option='keep',
         Whether or not to the display the returned rankings in integer form
         (e.g. 1, 2, 3) or in percentile form (e.g. 0.333..., 0.666..., 1).
     """
+    if is_object_dtype(values):
+        def raise_non_numeric_error():
+            raise ValueError("pandas.core.algorithms.rank "
+                             "not supported for unordered "
+                             "non-numeric data")
+        if is_categorical_dtype(values):
+            if not values.ordered:
+                raise_non_numeric_error()
+        else:
+            raise_non_numeric_error()
+
     if values.ndim == 1:
         f, values = _get_data_algo(values, _rank1d_functions)
         ranks = f(values, ties_method=method, ascending=ascending,


### PR DESCRIPTION
- [ ] closes #19560 
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry

*This is only partial solution to issue #19560. 
*There were some errors with the tests, but I guess they are unrelated to these changes since I also
have them with master.
*I modified some tests so that they don't contradict with the update "don't allow objects to be ranked unless they are ordered categorials" that was suggested in #19560.