### PR TITLE
BUG: Fixed exception when Series.str.get is used with dict values and the index is not an existing key (#20671)

### DIFF
--- a/doc/source/whatsnew/v0.23.0.txt
+++ b/doc/source/whatsnew/v0.23.0.txt
@@ -1053,6 +1053,10 @@ Numeric
 - Bug in :meth:`Series.rank` and :meth:`DataFrame.rank` when ``ascending='False'`` failed to return correct ranks for infinity if ``NaN`` were present (:issue:`19538`)
 - Bug where ``NaN`` was returned instead of 0 by :func:`Series.pct_change` and :func:`DataFrame.pct_change` when ``fill_method`` is not ``None`` (:issue:`19873`)
 
+Strings
+^^^^^^^
+- Bug in :func:`Series.str.get` with a dictionary in the values and the index not in the keys, raising `KeyError` (:issue:`20671`)
+
 
 Indexing
 ^^^^^^^^

--- a/pandas/core/strings.py
+++ b/pandas/core/strings.py
@@ -1663,7 +1663,12 @@ def str_get(arr, i):
     -------
     items : Series/Index of objects
     """
-    f = lambda x: x[i] if len(x) > i >= -len(x) else np.nan
+    def f(x):
+        if isinstance(x, dict):
+            return x.get(i)
+        elif len(x) > i >= -len(x):
+            return x[i]
+        return np.nan
     return _na_map(f, arr)
 
 

--- a/pandas/tests/test_strings.py
+++ b/pandas/tests/test_strings.py
@@ -2581,16 +2581,17 @@ class TestStringMethods(object):
         expected = Series([3, 3, np.nan, np.nan])
         tm.assert_series_equal(result, expected)
 
-        for to_type in tuple, list, np.array:
-            values = Series([to_type([to_type([1, 2])])])
+    @pytest.mark.parametrize('to_type', [tuple, list, np.array])
+    def test_get_complex_nested(self, to_type):
+        values = Series([to_type([to_type([1, 2])])])
 
-            result = values.str.get(0)
-            expected = Series([to_type([1, 2])])
-            tm.assert_series_equal(result, expected)
+        result = values.str.get(0)
+        expected = Series([to_type([1, 2])])
+        tm.assert_series_equal(result, expected)
 
-            result = values.str.get(1)
-            expected = Series([np.nan])
-            tm.assert_series_equal(result, expected)
+        result = values.str.get(1)
+        expected = Series([np.nan])
+        tm.assert_series_equal(result, expected)
 
     def test_more_contains(self):
         # PR #1179

--- a/pandas/tests/test_strings.py
+++ b/pandas/tests/test_strings.py
@@ -2568,6 +2568,30 @@ class TestStringMethods(object):
         expected = Series(['3', '8', np.nan])
         tm.assert_series_equal(result, expected)
 
+    def test_get_complex(self):
+        # GH 20671, getting value not in dict raising `KeyError`
+        values = Series([(1, 2, 3), [1, 2, 3], {1, 2, 3},
+                         {1: 'a', 2: 'b', 3: 'c'}])
+
+        result = values.str.get(1)
+        expected = Series([2, 2, np.nan, 'a'])
+        tm.assert_series_equal(result, expected)
+
+        result = values.str.get(-1)
+        expected = Series([3, 3, np.nan, np.nan])
+        tm.assert_series_equal(result, expected)
+
+        for to_type in tuple, list, np.array:
+            values = Series([to_type([to_type([1, 2])])])
+
+            result = values.str.get(0)
+            expected = Series([to_type([1, 2])])
+            tm.assert_series_equal(result, expected)
+
+            result = values.str.get(1)
+            expected = Series([np.nan])
+            tm.assert_series_equal(result, expected)
+
     def test_more_contains(self):
         # PR #1179
         s = Series(['A', 'B', 'C', 'Aaba', 'Baca', '', NA,


### PR DESCRIPTION
- [X] closes #20671
- [X] tests added / passed (* unrelated tests failed, with locale problems, not sure if caused by something on my system or something on pandas)
- [X] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [X] whatsnew entry
