### PR TITLE
PKG: remove pyproject.toml for now

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,9 +1,0 @@
-[build-system]
-requires = [
-    "wheel",
-    "setuptools",
-    "Cython",  # required for VCS build, optional for released source
-    "numpy==1.9.3; python_version=='3.5'",
-    "numpy==1.12.1; python_version=='3.6'",
-    "numpy==1.13.1; python_version>='3.7'",
-]


### PR DESCRIPTION
Since this gives problems, it might be better to remove this until support in pip is better? 
Eg I also have errors on the geopandas CI when installing pandas master with pip due to this.

Scipy did something similar: https://github.com/scipy/scipy/pull/8735