### PR TITLE
BUG: unexpected assign by a single-element list (GH19474)

### DIFF
--- a/doc/source/whatsnew/v0.23.0.txt
+++ b/doc/source/whatsnew/v0.23.0.txt
@@ -1111,6 +1111,7 @@ Indexing
 - Bug in :meth:`DataFrame.first_valid_index` and :meth:`DataFrame.last_valid_index` in presence of entire rows of NaNs in the middle of values (:issue:`20499`).
 - Bug in :class:`IntervalIndex` where some indexing operations were not supported for overlapping or non-monotonic ``uint64`` data (:issue:`20636`)
 - Bug in ``Series.is_unique`` where extraneous output in stderr is shown if Series contains objects with ``__ne__`` defined (:issue:`20661`)
+- Bug in ``.loc`` assignment with a single-element list-like incorrectly assigns as a list (:issue:`19474`)
 
 MultiIndex
 ^^^^^^^^^^

--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -532,7 +532,8 @@ class _NDFrameIndexer(_NDFrameIndexerBase):
 
             def can_do_equal_len():
                 """ return True if we have an equal len settable """
-                if not len(labels) == 1 or not np.iterable(value):
+                if (not len(labels) == 1 or not np.iterable(value) or
+                        is_scalar(plane_indexer[0])):
                     return False
 
                 l = len(value)

--- a/pandas/tests/indexing/test_iloc.py
+++ b/pandas/tests/indexing/test_iloc.py
@@ -10,6 +10,7 @@ from pandas.compat import lrange, lmap
 from pandas import Series, DataFrame, date_range, concat, isna
 from pandas.util import testing as tm
 from pandas.tests.indexing.common import Base
+from pandas.api.types import is_scalar
 
 
 class TestiLoc(Base):
@@ -525,6 +526,21 @@ class TestiLoc(Base):
         expected = DataFrame(dict(A=['a', 'b', 'x', 'y', 'e'],
                                   B=[5, 6, 11, 13, 9]))
         tm.assert_frame_equal(df, expected)
+
+    @pytest.mark.parametrize(
+        'indexer', [[0], slice(None, 1, None), np.array([0])])
+    @pytest.mark.parametrize(
+        'value', [['Z'], np.array(['Z'])])
+    def test_iloc_setitem_with_scalar_index(self, indexer, value):
+        # GH #19474
+        # assigning like "df.iloc[0, [0]] = ['Z']" should be evaluated
+        # elementwisely, not using "setter('A', ['Z'])".
+
+        df = pd.DataFrame([[1, 2], [3, 4]], columns=['A', 'B'])
+        df.iloc[0, indexer] = value
+        result = df.iloc[0, 0]
+
+        assert is_scalar(result) and result == 'Z'
 
     def test_iloc_mask(self):
 


### PR DESCRIPTION
- [x] closes #19474
- [x] tests added / passed (some failed independently of my changes)
- [x] passes `git diff master --name-only -- "*.py" | flake8`
- [x] whatsnew entry

I thought it is a straightforward way to evaluate all of `df.loc[0, ['A']] = ['X']`, `df.loc[0, ['A', 'B']] = ['X', 'Y']`, ...(more-columns case) the same way in `else` block at line 590 of pandas/core/indexing.py.

Please let me know bad or ungrammatical points.