### PR TITLE
Emit warning for missing labels in Multiindex.loc[[...]] (and more)

### DIFF
--- a/doc/source/whatsnew/v0.23.0.txt
+++ b/doc/source/whatsnew/v0.23.0.txt
@@ -873,6 +873,7 @@ Deprecations
 - The ``is_copy`` attribute is deprecated and will be removed in a future version (:issue:`18801`).
 - ``IntervalIndex.from_intervals`` is deprecated in favor of the :class:`IntervalIndex` constructor (:issue:`19263`)
 - ``DataFrame.from_items`` is deprecated. Use :func:`DataFrame.from_dict` instead, or ``DataFrame.from_dict(OrderedDict())`` if you wish to preserve the key order (:issue:`17320`, :issue:`17312`)
+- Indexing a ``MultiIndex`` or a ``FloatIndex`` with a list containing some missing keys will now show a ``FutureWarning``, consistently with other types of indexes (:issue:`17758`).
 
 - The ``broadcast`` parameter of ``.apply()`` is deprecated in favor of ``result_type='broadcast'`` (:issue:`18577`)
 - The ``reduce`` parameter of ``.apply()`` is deprecated in favor of ``result_type='reduce'`` (:issue:`18577`)
@@ -1107,6 +1108,8 @@ Indexing
 - :func:`Index.to_series` now accepts ``index`` and ``name`` kwargs (:issue:`18699`)
 - :func:`DatetimeIndex.to_series` now accepts ``index`` and ``name`` kwargs (:issue:`18699`)
 - Bug in indexing non-scalar value from ``Series`` having non-unique ``Index`` will return value flattened (:issue:`17610`)
+- Bug in indexing with iterator containing only missing keys, which raised no error (:issue:`20748`)
+- Fixed inconsistency in ``.ix`` between list and scalar keys when index has integer dtype and does not include desired key(s) (:issue:`20753`)
 - Bug in ``__setitem__`` when indexing a :class:`DataFrame` with a 2-d boolean ndarray (:issue:`18582`)
 - Bug in ``str.extractall`` when there were no matches empty :class:`Index` was returned instead of appropriate :class:`MultiIndex` (:issue:`19034`)
 - Bug in :class:`IntervalIndex` where empty and purely NA data was constructed inconsistently depending on the construction method (:issue:`18421`)

--- a/doc/source/whatsnew/v0.23.0.txt
+++ b/doc/source/whatsnew/v0.23.0.txt
@@ -873,7 +873,7 @@ Deprecations
 - The ``is_copy`` attribute is deprecated and will be removed in a future version (:issue:`18801`).
 - ``IntervalIndex.from_intervals`` is deprecated in favor of the :class:`IntervalIndex` constructor (:issue:`19263`)
 - ``DataFrame.from_items`` is deprecated. Use :func:`DataFrame.from_dict` instead, or ``DataFrame.from_dict(OrderedDict())`` if you wish to preserve the key order (:issue:`17320`, :issue:`17312`)
-- Indexing a ``MultiIndex`` or a ``FloatIndex`` with a list containing some missing keys will now show a ``FutureWarning``, consistently with other types of indexes (:issue:`17758`).
+- Indexing a :class:`MultiIndex` or a :class:`FloatIndex` with a list containing some missing keys will now show a :class:`FutureWarning`, which is consistent with other types of indexes (:issue:`17758`).
 
 - The ``broadcast`` parameter of ``.apply()`` is deprecated in favor of ``result_type='broadcast'`` (:issue:`18577`)
 - The ``reduce`` parameter of ``.apply()`` is deprecated in favor of ``result_type='reduce'`` (:issue:`18577`)
@@ -1109,7 +1109,7 @@ Indexing
 - :func:`DatetimeIndex.to_series` now accepts ``index`` and ``name`` kwargs (:issue:`18699`)
 - Bug in indexing non-scalar value from ``Series`` having non-unique ``Index`` will return value flattened (:issue:`17610`)
 - Bug in indexing with iterator containing only missing keys, which raised no error (:issue:`20748`)
-- Fixed inconsistency in ``.ix`` between list and scalar keys when index has integer dtype and does not include desired key(s) (:issue:`20753`)
+- Fixed inconsistency in ``.ix`` between list and scalar keys when the index has integer dtype and does not include the desired keys (:issue:`20753`)
 - Bug in ``__setitem__`` when indexing a :class:`DataFrame` with a 2-d boolean ndarray (:issue:`18582`)
 - Bug in ``str.extractall`` when there were no matches empty :class:`Index` was returned instead of appropriate :class:`MultiIndex` (:issue:`19034`)
 - Bug in :class:`IntervalIndex` where empty and purely NA data was constructed inconsistently depending on the construction method (:issue:`18421`)

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -4881,6 +4881,9 @@ def _ensure_index(index_like, copy=False):
     if hasattr(index_like, 'name'):
         return Index(index_like, name=index_like.name, copy=copy)
 
+    if is_iterator(index_like):
+        index_like = list(index_like)
+
     # must check for exactly list here because of strict type
     # check in clean_index_list
     if isinstance(index_like, list):

--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -1112,9 +1112,10 @@ class _NDFrameIndexer(_NDFrameIndexerBase):
             ax = self.obj._get_axis(axis)
             # existing labels are unique and indexer are unique
             if labels.is_unique and Index(keyarr).is_unique:
-                self._validate_read_indexer(key, ax.get_indexer_for(key), axis)
+                indexer = ax.get_indexer_for(key)
+                self._validate_read_indexer(key, indexer, axis)
 
-                d = {axis: [ax.reindex(keyarr)[0], ax.get_indexer_for(key)]}
+                d = {axis: [ax.reindex(keyarr)[0], indexer]}
                 return self.obj._reindex_with_indexers(d, copy=True,
                                                        allow_dups=True)
 

--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -200,10 +200,6 @@ class _NDFrameIndexer(_NDFrameIndexerBase):
         axis : int
             Dimension on which the indexing is being made
 
-        Returns:
-        --------
-        None
-
         Raises
         ------
         TypeError
@@ -945,7 +941,7 @@ class _NDFrameIndexer(_NDFrameIndexerBase):
                                             o._get_axis_number(axis))
                 d[axis] = (keyarr, indexer)
             return o._reindex_with_indexers(d, copy=True, allow_dups=True)
-        except(KeyError, IndexingError) as detail:
+        except (KeyError, IndexingError) as detail:
             raise self._exception(detail)
 
     def _convert_for_reindex(self, key, axis=None):
@@ -1189,10 +1185,6 @@ class _NDFrameIndexer(_NDFrameIndexerBase):
             Indices corresponding to the key (with -1 indicating not found)
         axis: int
             Dimension on which the indexing is being made
-
-        Returns
-        -------
-        None
 
         Raises
         ------

--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -16,6 +16,8 @@ from pandas.core.dtypes.common import (
     _is_unorderable_exception,
     _ensure_platform_int)
 from pandas.core.dtypes.missing import isna, _infer_fill_value
+from pandas.errors import AbstractMethodError
+from pandas.util._decorators import Appender
 
 from pandas.core.index import Index, MultiIndex
 
@@ -186,8 +188,34 @@ class _NDFrameIndexer(_NDFrameIndexerBase):
         indexer = self._get_setitem_indexer(key)
         self._setitem_with_indexer(indexer, value)
 
-    def _validate_key(self, k, axis):
-        raise NotImplementedError()
+    def _validate_key(self, key, axis):
+        """
+        Ensure that key is valid for current indexer.
+
+        Parameters
+        ----------
+        key : scalar, slice or list-like
+            The key requested
+
+        axis : int
+            Dimension on which the indexing is being made
+
+        Returns:
+        --------
+        None
+
+        Raises
+        ------
+        TypeError
+            If the key (or some element of it) has wrong type
+
+        IndexError
+            If the key (or some element of it) is out of bounds
+
+        KeyError
+            If the key was not found
+        """
+        raise AbstractMethodError()
 
     def _has_valid_tuple(self, key):
         """ check the key for valid keys across my indexer """
@@ -1377,6 +1405,7 @@ class _IXIndexer(_NDFrameIndexer):
                       DeprecationWarning, stacklevel=2)
         super(_IXIndexer, self).__init__(name, obj)
 
+    @Appender(_NDFrameIndexer._validate_key.__doc__)
     def _validate_key(self, key, axis):
         if isinstance(key, slice):
             return True
@@ -1739,6 +1768,7 @@ class _LocIndexer(_LocationIndexer):
                     "index is integers), listlike of labels, boolean")
     _exception = KeyError
 
+    @Appender(_NDFrameIndexer._validate_key.__doc__)
     def _validate_key(self, key, axis):
         ax = self.obj._get_axis(axis)
 

--- a/pandas/core/sparse/frame.py
+++ b/pandas/core/sparse/frame.py
@@ -715,6 +715,9 @@ class SparseDataFrame(DataFrame):
         if fill_value is None:
             fill_value = np.nan
 
+        reindexers = {self._get_axis_number(a): val
+                      for (a, val) in compat.iteritems(reindexers)}
+
         index, row_indexer = reindexers.get(0, (None, None))
         columns, col_indexer = reindexers.get(1, (None, None))
 

--- a/pandas/tests/frame/test_indexing.py
+++ b/pandas/tests/frame/test_indexing.py
@@ -396,8 +396,12 @@ class TestDataFrameIndexing(TestData):
         assert (self.frame['D'] == 0).all()
 
         df = DataFrame(np.random.randn(8, 4))
-        with catch_warnings(record=True):
-            assert isna(df.ix[:, [-1]].values).all()
+        # ix does label-based indexing when having an integer index
+        with pytest.raises(KeyError):
+            df.ix[[-1]]
+
+        with pytest.raises(KeyError):
+            df.ix[:, [-1]]
 
         # #1942
         a = DataFrame(randn(20, 2), index=[chr(x + 65) for x in range(20)])

--- a/pandas/tests/indexing/common.py
+++ b/pandas/tests/indexing/common.py
@@ -1,7 +1,7 @@
 """ common utilities """
 
 import itertools
-from warnings import catch_warnings
+from warnings import catch_warnings, filterwarnings
 import numpy as np
 
 from pandas.compat import lrange
@@ -300,7 +300,8 @@ class Base(object):
 
                     # Panel deprecations
                     if isinstance(obj, Panel):
-                        with catch_warnings(record=True):
+                        with catch_warnings():
+                            filterwarnings("ignore", "\nPanel*", FutureWarning)
                             _call()
                     else:
                         _call()

--- a/pandas/tests/indexing/common.py
+++ b/pandas/tests/indexing/common.py
@@ -6,7 +6,8 @@ import numpy as np
 
 from pandas.compat import lrange
 from pandas.core.dtypes.common import is_scalar
-from pandas import Series, DataFrame, Panel, date_range, UInt64Index
+from pandas import (Series, DataFrame, Panel, date_range, UInt64Index,
+                    Float64Index, MultiIndex)
 from pandas.util import testing as tm
 from pandas.io.formats.printing import pprint_thing
 
@@ -29,7 +30,7 @@ class Base(object):
 
     _objs = set(['series', 'frame', 'panel'])
     _typs = set(['ints', 'uints', 'labels', 'mixed',
-                 'ts', 'floats', 'empty', 'ts_rev'])
+                 'ts', 'floats', 'empty', 'ts_rev', 'multi'])
 
     def setup_method(self, method):
 
@@ -53,6 +54,32 @@ class Base(object):
                                      items=UInt64Index(lrange(0, 8, 2)),
                                      major_axis=UInt64Index(lrange(0, 12, 3)),
                                      minor_axis=UInt64Index(lrange(0, 16, 4)))
+
+        self.series_floats = Series(np.random.rand(4),
+                                    index=Float64Index(range(0, 8, 2)))
+        self.frame_floats = DataFrame(np.random.randn(4, 4),
+                                      index=Float64Index(range(0, 8, 2)),
+                                      columns=Float64Index(range(0, 12, 3)))
+        with catch_warnings(record=True):
+            self.panel_floats = Panel(np.random.rand(4, 4, 4),
+                                      items=Float64Index(range(0, 8, 2)),
+                                      major_axis=Float64Index(range(0, 12, 3)),
+                                      minor_axis=Float64Index(range(0, 16, 4)))
+
+        m_idces = [MultiIndex.from_product([[1, 2], [3, 4]]),
+                   MultiIndex.from_product([[5, 6], [7, 8]]),
+                   MultiIndex.from_product([[9, 10], [11, 12]])]
+
+        self.series_multi = Series(np.random.rand(4),
+                                   index=m_idces[0])
+        self.frame_multi = DataFrame(np.random.randn(4, 4),
+                                     index=m_idces[0],
+                                     columns=m_idces[1])
+        with catch_warnings(record=True):
+            self.panel_multi = Panel(np.random.rand(4, 4, 4),
+                                     items=m_idces[0],
+                                     major_axis=m_idces[1],
+                                     minor_axis=m_idces[2])
 
         self.series_labels = Series(np.random.randn(4), index=list('abcd'))
         self.frame_labels = DataFrame(np.random.randn(4, 4),

--- a/pandas/tests/indexing/test_floats.py
+++ b/pandas/tests/indexing/test_floats.py
@@ -685,17 +685,23 @@ class TestFloatIndexers(object):
         assert_series_equal(result1, result3)
         assert_series_equal(result1, result4)
 
-        result1 = s[[1.6, 5, 10]]
-        result2 = s.loc[[1.6, 5, 10]]
-        result3 = s.loc[[1.6, 5, 10]]
+        with tm.assert_produces_warning(FutureWarning, check_stacklevel=False):
+            result1 = s[[1.6, 5, 10]]
+        with tm.assert_produces_warning(FutureWarning, check_stacklevel=False):
+            result2 = s.loc[[1.6, 5, 10]]
+        with tm.assert_produces_warning(FutureWarning, check_stacklevel=False):
+            result3 = s.loc[[1.6, 5, 10]]
         assert_series_equal(result1, result2)
         assert_series_equal(result1, result3)
         assert_series_equal(result1, Series(
             [np.nan, 2, 4], index=[1.6, 5, 10]))
 
-        result1 = s[[0, 1, 2]]
-        result2 = s.loc[[0, 1, 2]]
-        result3 = s.loc[[0, 1, 2]]
+        with tm.assert_produces_warning(FutureWarning, check_stacklevel=False):
+            result1 = s[[0, 1, 2]]
+        with tm.assert_produces_warning(FutureWarning, check_stacklevel=False):
+            result2 = s.loc[[0, 1, 2]]
+        with tm.assert_produces_warning(FutureWarning, check_stacklevel=False):
+            result3 = s.loc[[0, 1, 2]]
         assert_series_equal(result1, result2)
         assert_series_equal(result1, result3)
         assert_series_equal(result1, Series(

--- a/pandas/tests/indexing/test_indexing.py
+++ b/pandas/tests/indexing/test_indexing.py
@@ -221,10 +221,9 @@ class TestFancy(Base):
             result = df.loc[['A', 'A', 'E']]
         tm.assert_frame_equal(result, expected)
 
-        if PY2:
-            # Catching warnings unreliable with Python 2 (GH #20770)
-            pytest.skip()
-
+    @pytest.mark.skipif(PY2,
+                        reason="GH-20770. Py2 unreliable warnings catching.")
+    def test_dups_fancy_indexing2(self):
         # GH 5835
         # dups on index and missing values
         df = DataFrame(

--- a/pandas/tests/indexing/test_indexing.py
+++ b/pandas/tests/indexing/test_indexing.py
@@ -192,15 +192,9 @@ class TestFancy(Base):
             result = df.loc[rows]
         tm.assert_frame_equal(result, expected)
 
-        # inconsistent returns for unique/duplicate indices when values are
-        # missing
-        df = DataFrame(np.random.randn(4, 3), index=list('ABCD'))
-        expected = df.reindex(['E'])
-
         dfnu = DataFrame(np.random.randn(5, 3), index=list('AABCD'))
-        with catch_warnings(record=True):
-            result = dfnu.ix[['E']]
-        tm.assert_frame_equal(result, expected)
+        with pytest.raises(KeyError):
+            dfnu.ix[['E']]
 
         # ToDo: check_index_type can be True after GH 11497
 

--- a/pandas/tests/indexing/test_indexing.py
+++ b/pandas/tests/indexing/test_indexing.py
@@ -19,6 +19,7 @@ import pandas as pd
 from pandas.core.indexing import _non_reducing_slice, _maybe_numeric_slice
 from pandas import NaT, DataFrame, Index, Series, MultiIndex
 import pandas.util.testing as tm
+from pandas.compat import PY2
 
 from pandas.tests.indexing.common import Base, _mklbl
 
@@ -131,6 +132,8 @@ class TestFancy(Base):
         assert is_float_dtype(left['foo'])
         assert is_float_dtype(left['baz'])
 
+    @pytest.mark.skipif(PY2, reason=("Catching warnings unreliable with "
+                                     "Python 2 (GH #20770)"))
     def test_dups_fancy_indexing(self):
 
         # GH 3455
@@ -192,6 +195,7 @@ class TestFancy(Base):
             result = df.loc[rows]
         tm.assert_frame_equal(result, expected)
 
+        # List containing only missing label
         dfnu = DataFrame(np.random.randn(5, 3), index=list('AABCD'))
         with pytest.raises(KeyError):
             dfnu.ix[['E']]

--- a/pandas/tests/indexing/test_indexing.py
+++ b/pandas/tests/indexing/test_indexing.py
@@ -132,8 +132,6 @@ class TestFancy(Base):
         assert is_float_dtype(left['foo'])
         assert is_float_dtype(left['baz'])
 
-    @pytest.mark.skipif(PY2, reason=("Catching warnings unreliable with "
-                                     "Python 2 (GH #20770)"))
     def test_dups_fancy_indexing(self):
 
         # GH 3455
@@ -222,6 +220,10 @@ class TestFancy(Base):
         with tm.assert_produces_warning(FutureWarning, check_stacklevel=False):
             result = df.loc[['A', 'A', 'E']]
         tm.assert_frame_equal(result, expected)
+
+        if PY2:
+            # Catching warnings unreliable with Python 2 (GH #20770)
+            pytest.skip()
 
         # GH 5835
         # dups on index and missing values

--- a/pandas/tests/indexing/test_loc.py
+++ b/pandas/tests/indexing/test_loc.py
@@ -12,6 +12,7 @@ from pandas import Series, DataFrame, Timestamp, date_range, MultiIndex, Index
 from pandas.util import testing as tm
 from pandas.tests.indexing.common import Base
 from pandas.api.types import is_scalar
+from pandas.compat import PY2
 
 
 class TestLoc(Base):
@@ -152,6 +153,8 @@ class TestLoc(Base):
                           [Timestamp('20130102'), Timestamp('20130103')],
                           typs=['ts'], axes=0)
 
+    @pytest.mark.skipif(PY2, reason=("Catching warnings unreliable with "
+                                     "Python 2 (GH #20770)"))
     def test_loc_getitem_label_list_with_missing(self):
         self.check_result('list lbl', 'loc', [0, 1, 2], 'indexer', [0, 1, 2],
                           typs=['empty'], fails=KeyError)

--- a/pandas/tests/indexing/test_loc.py
+++ b/pandas/tests/indexing/test_loc.py
@@ -167,9 +167,11 @@ class TestLoc(Base):
             self.check_result('list lbl', 'loc', [3, 6, 7], 'ix', [3, 6, 7],
                               typs=['ints', 'uints', 'floats'],
                               axes=1, fails=KeyError)
-        self.check_result('list lbl', 'loc', [4, 8, 10], 'ix', [4, 8, 10],
-                          typs=['ints', 'uints', 'floats'],
-                          axes=2, fails=KeyError)
+
+        with tm.assert_produces_warning(FutureWarning, check_stacklevel=False):
+            self.check_result('list lbl', 'loc', [4, 8, 10], 'ix', [4, 8, 10],
+                              typs=['ints', 'uints', 'floats'],
+                              axes=2, fails=KeyError)
 
         # GH 17758 - MultiIndex and missing keys
         with tm.assert_produces_warning(FutureWarning, check_stacklevel=False):

--- a/pandas/tests/indexing/test_loc.py
+++ b/pandas/tests/indexing/test_loc.py
@@ -120,7 +120,7 @@ class TestLoc(Base):
                           typs=['ints', 'uints', 'labels', 'mixed', 'ts'],
                           fails=KeyError)
         self.check_result('label range', 'loc', 'f', 'ix', 'f',
-                          typs=['floats'], fails=TypeError)
+                          typs=['floats'], fails=KeyError)
         self.check_result('label range', 'loc', 20, 'ix', 20,
                           typs=['ints', 'uints', 'mixed'], fails=KeyError)
         self.check_result('label range', 'loc', 20, 'ix', 20,
@@ -128,7 +128,7 @@ class TestLoc(Base):
         self.check_result('label range', 'loc', 20, 'ix', 20, typs=['ts'],
                           axes=0, fails=TypeError)
         self.check_result('label range', 'loc', 20, 'ix', 20, typs=['floats'],
-                          axes=0, fails=TypeError)
+                          axes=0, fails=KeyError)
 
     def test_loc_getitem_label_list(self):
 
@@ -156,13 +156,24 @@ class TestLoc(Base):
         self.check_result('list lbl', 'loc', [0, 1, 2], 'indexer', [0, 1, 2],
                           typs=['empty'], fails=KeyError)
         with tm.assert_produces_warning(FutureWarning, check_stacklevel=False):
-            self.check_result('list lbl', 'loc', [0, 2, 3], 'ix', [0, 2, 3],
-                              typs=['ints', 'uints'], axes=0, fails=KeyError)
+            self.check_result('list lbl', 'loc', [0, 2, 10], 'ix', [0, 2, 10],
+                              typs=['ints', 'uints', 'floats'],
+                              axes=0, fails=KeyError)
+
         with tm.assert_produces_warning(FutureWarning, check_stacklevel=False):
             self.check_result('list lbl', 'loc', [3, 6, 7], 'ix', [3, 6, 7],
-                              typs=['ints', 'uints'], axes=1, fails=KeyError)
+                              typs=['ints', 'uints', 'floats'],
+                              axes=1, fails=KeyError)
         self.check_result('list lbl', 'loc', [4, 8, 10], 'ix', [4, 8, 10],
-                          typs=['ints', 'uints'], axes=2, fails=KeyError)
+                          typs=['ints', 'uints', 'floats'],
+                          axes=2, fails=KeyError)
+
+        # GH 17758 - MultiIndex and missing keys
+        with tm.assert_produces_warning(FutureWarning, check_stacklevel=False):
+            self.check_result('list lbl', 'loc', [(1, 3), (1, 4), (2, 5)],
+                              'ix', [(1, 3), (1, 4), (2, 5)],
+                              typs=['multi'],
+                              axes=0)
 
     def test_getitem_label_list_with_missing(self):
         s = Series(range(3), index=['a', 'b', 'c'])

--- a/pandas/tests/series/indexing/test_numeric.py
+++ b/pandas/tests/series/indexing/test_numeric.py
@@ -57,14 +57,29 @@ def test_get_nan():
     assert s.get(np.nan) is None
     assert s.get(np.nan, default='Missing') == 'Missing'
 
-    # ensure that fixing the above hasn't broken get
+
+def test_get_nan_multiple():
+    # GH 8569
+    # ensure that fixing "test_get_nan" above hasn't broken get
     # with multiple elements
+    s = pd.Float64Index(range(10)).to_series()
+
+    idx = [2, 30]
+    with tm.assert_produces_warning(FutureWarning, check_stacklevel=False):
+        assert_series_equal(s.get(idx),
+                            Series([2, np.nan], index=idx))
+
+    idx = [2, np.nan]
+    with tm.assert_produces_warning(FutureWarning, check_stacklevel=False):
+        assert_series_equal(s.get(idx),
+                            Series([2, np.nan], index=idx))
+
+    # GH 17295 - all missing keys
     idx = [20, 30]
-    assert_series_equal(s.get(idx),
-                        Series([np.nan] * 2, index=idx))
+    assert(s.get(idx) is None)
+
     idx = [np.nan, np.nan]
-    assert_series_equal(s.get(idx),
-                        Series([np.nan] * 2, index=idx))
+    assert(s.get(idx) is None)
 
 
 def test_delitem():


### PR DESCRIPTION
- [x] closes #17758
- [x] closes #20748
- [x] closes #20753
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry

Main changes:
- the presence of at least one key (and of all of them, for the temporary warning) is now checked _after_ building the indexer, using the indexer itself, in a unique place
- for this to be possible, ``obj.reindex`` was replaced with ``obj._reindex_with_indexers``
- ``_multi_take`` is uglier than before... but it's ugly anyway, and must be removed in a future refactoring (in which first indexers are built in all possible code paths, _then_ values are extracted)
- ``_has_valid_type`` was mostly used in "assertion mode" (without looking at its return value), so I changed it to ``_validate_key`` and now it is _only_ used in "assertion mode"

Asv (``--bench indexing``) give
```
       before           after         ratio
     [3a2e9e6c]       [25711d3d]
+       162±0.2ms          273±5ms     1.68  indexing.NumericSeriesIndexing.time_getitem_array(<class 'pandas.core.indexes.numeric.Float64Index'>)
+         162±1ms        269±0.7ms     1.66  indexing.NumericSeriesIndexing.time_loc_array(<class 'pandas.core.indexes.numeric.Float64Index'>)
+       162±0.6ms          267±1ms     1.65  indexing.NumericSeriesIndexing.time_ix_list_like(<class 'pandas.core.indexes.numeric.Float64Index'>)
+         164±2ms          270±1ms     1.64  indexing.NumericSeriesIndexing.time_ix_array(<class 'pandas.core.indexes.numeric.Float64Index'>)
+       166±0.6ms        273±0.6ms     1.64  indexing.NumericSeriesIndexing.time_getitem_lists(<class 'pandas.core.indexes.numeric.Float64Index'>)
+       163±0.5ms        267±0.8ms     1.64  indexing.NumericSeriesIndexing.time_getitem_list_like(<class 'pandas.core.indexes.numeric.Float64Index'>)
+         163±3ms        267±0.4ms     1.64  indexing.NumericSeriesIndexing.time_loc_list_like(<class 'pandas.core.indexes.numeric.Float64Index'>)
+         412±3μs          664±4μs     1.61  indexing.NumericSeriesIndexing.time_ix_list_like(<class 'pandas.core.indexes.numeric.Int64Index'>)
+        1.08±0ms      1.42±0.05ms     1.32  indexing.NumericSeriesIndexing.time_ix_array(<class 'pandas.core.indexes.numeric.Int64Index'>)
+     1.14±0.01ms      1.31±0.02ms     1.15  indexing.PanelIndexing.time_subset
-       133±0.2ms        121±0.4ms     0.91  frame_methods.Iteration.time_iteritems_indexing
-         442±2ns          399±2ns     0.90  indexing.MethodLookup.time_lookup_iloc
-       145±0.8μs        130±0.8μs     0.90  indexing.IntervalIndexing.time_getitem_list
-         151±2μs          134±1μs     0.89  indexing.AssignTimeseriesIndex.time_frame_assign_timeseries_index
-      48.5±0.8μs       41.2±0.1μs     0.85  indexing.IntervalIndexing.time_getitem_scalar
-        44.3±1μs       35.6±0.1μs     0.80  indexing.NumericSeriesIndexing.time_iloc_list_like(<class 'pandas.core.indexes.numeric.Float64Index'>)
-     3.81±0.02ms      2.06±0.02ms     0.54  indexing.DataFrameNumericIndexing.time_loc_dups

SOME BENCHMARKS HAVE CHANGED SIGNIFICANTLY.

```

notice that ``FloatIndex`` was _not_ being checked at all (i.e. #17758 applied to it too), now it is.

In any case, as I wrote above, there are several improvements still to be made, but I want to go gradually because the complexity of this PR is already pretty high for me.