### PR TITLE
ENH GH20601 raise error when pivot table's number of levels > int32

### DIFF
--- a/doc/source/whatsnew/v0.24.0.txt
+++ b/doc/source/whatsnew/v0.24.0.txt
@@ -615,7 +615,7 @@ Reshaping
 - Bug in :meth:`Series.combine_first` with ``datetime64[ns, tz]`` dtype which would return tz-naive result (:issue:`21469`)
 - Bug in :meth:`Series.where` and :meth:`DataFrame.where` with ``datetime64[ns, tz]`` dtype (:issue:`21546`)
 - Bug in :meth:`Series.mask` and :meth:`DataFrame.mask` with ``list`` conditionals (:issue:`21891`)
--
+- Bug in :func:`pandas.pivot_table` when the number of unique index combination exceeds int32 (:issue:`20601`)
 -
 
 Build Changes

--- a/pandas/core/reshape/pivot.py
+++ b/pandas/core/reshape/pivot.py
@@ -31,6 +31,11 @@ def pivot_table(data, values=None, index=None, columns=None, aggfunc='mean',
     index = _convert_by(index)
     columns = _convert_by(columns)
 
+    num_rows = data.reindex(index, axis='columns').shape[0]
+    num_columns = data.reindex(columns, axis='columns').shape[0]
+    if num_rows * num_columns > (2 ** 31 - 1):
+        raise ValueError('Pivot table is too big, causing int32 overflow')
+
     if isinstance(aggfunc, list):
         pieces = []
         keys = []

--- a/pandas/core/reshape/pivot.py
+++ b/pandas/core/reshape/pivot.py
@@ -31,11 +31,6 @@ def pivot_table(data, values=None, index=None, columns=None, aggfunc='mean',
     index = _convert_by(index)
     columns = _convert_by(columns)
 
-    num_rows = data.reindex(index, axis='columns').shape[0]
-    num_columns = data.reindex(columns, axis='columns').shape[0]
-    if num_rows * num_columns > (2 ** 31 - 1):
-        raise ValueError('Pivot table is too big, causing int32 overflow')
-
     if isinstance(aggfunc, list):
         pieces = []
         keys = []
@@ -86,9 +81,14 @@ def pivot_table(data, values=None, index=None, columns=None, aggfunc='mean',
                 pass
         values = list(values)
 
-    # group by the cartesian product of the grouper
-    # if we have a categorical
-    grouped = data.groupby(keys, observed=False)
+    num_rows = (data.reindex(columns=index).drop_duplicates().shape[0]
+                if index else 1)
+    num_cols = (data.reindex(columns=columns).drop_duplicates().shape[0]
+                if columns else 1)
+    if num_rows * num_cols * len(values) > (2 ** 31 - 1):
+        raise ValueError('Pivot table is too big, causing int32 overflow')
+
+    grouped = data.groupby(keys)
     agged = grouped.agg(aggfunc)
     if dropna and isinstance(agged, ABCDataFrame) and len(agged.columns):
         agged = agged.dropna(how='all')

--- a/pandas/core/reshape/pivot.py
+++ b/pandas/core/reshape/pivot.py
@@ -81,13 +81,6 @@ def pivot_table(data, values=None, index=None, columns=None, aggfunc='mean',
                 pass
         values = list(values)
 
-    num_rows = (data.reindex(columns=index).drop_duplicates().shape[0]
-                if index else 1)
-    num_cols = (data.reindex(columns=columns).drop_duplicates().shape[0]
-                if columns else 1)
-    if num_rows * num_cols * len(values) > (2 ** 31 - 1):
-        raise ValueError('Pivot table is too big, causing int32 overflow')
-
     grouped = data.groupby(keys)
     agged = grouped.agg(aggfunc)
     if dropna and isinstance(agged, ABCDataFrame) and len(agged.columns):

--- a/pandas/core/reshape/reshape.py
+++ b/pandas/core/reshape/reshape.py
@@ -126,10 +126,12 @@ class _Unstacker(object):
         self.removed_level = self.new_index_levels.pop(self.level)
         self.removed_level_full = index.levels[self.level]
 
-        num_rows = np.max([index_level.size for index_level in self.new_index_levels])
+        num_rows = np.max([index_level.size for index_level
+                           in self.new_index_levels])
         num_columns = self.removed_level.size
         if num_rows * num_columns > (2 ** 31 - 1):
-            raise ValueError('Unstacked data frame is too big, causing int32 overflow')
+            raise ValueError('Unstacked DataFrame is too big, '
+                             'causing int32 overflow')
 
         self._make_sorted_values_labels()
         self._make_selectors()

--- a/pandas/core/reshape/reshape.py
+++ b/pandas/core/reshape/reshape.py
@@ -126,6 +126,11 @@ class _Unstacker(object):
         self.removed_level = self.new_index_levels.pop(self.level)
         self.removed_level_full = index.levels[self.level]
 
+        num_rows = np.max([index_level.size for index_level in self.new_index_levels])
+        num_columns = self.removed_level.size
+        if num_rows * num_columns > (2 ** 31 - 1):
+            raise ValueError('Unstacked data frame is too big, causing int32 overflow')
+
         self._make_sorted_values_labels()
         self._make_selectors()
 
@@ -161,8 +166,6 @@ class _Unstacker(object):
         self.full_shape = ngroups, stride
 
         selector = self.sorted_labels[-1] + stride * comp_index + self.lift
-        if np.prod(self.full_shape) > (2 ** 31 - 1):
-            raise ValueError('Pivot table is too big, causing int32 overflow')
         mask = np.zeros(np.prod(self.full_shape), dtype=bool)
         mask.put(selector, True)
 

--- a/pandas/core/reshape/reshape.py
+++ b/pandas/core/reshape/reshape.py
@@ -126,6 +126,10 @@ class _Unstacker(object):
         self.removed_level = self.new_index_levels.pop(self.level)
         self.removed_level_full = index.levels[self.level]
 
+        # Bug fix GH 20601
+        # If the data frame is too big,
+        # the number of unique index combination will cause int32 overflow
+        # We want to check and raise an error before this happens
         num_rows = np.max([index_level.size for index_level
                            in self.new_index_levels])
         num_columns = self.removed_level.size

--- a/pandas/core/reshape/reshape.py
+++ b/pandas/core/reshape/reshape.py
@@ -161,6 +161,8 @@ class _Unstacker(object):
         self.full_shape = ngroups, stride
 
         selector = self.sorted_labels[-1] + stride * comp_index + self.lift
+        if np.prod(self.full_shape) > (2 ** 31 - 1):
+            raise ValueError('Pivot table is too big, causing int32 overflow')
         mask = np.zeros(np.prod(self.full_shape), dtype=bool)
         mask.put(selector, True)
 

--- a/pandas/tests/reshape/test_pivot.py
+++ b/pandas/tests/reshape/test_pivot.py
@@ -1279,9 +1279,11 @@ class TestPivotTable(object):
     def test_pivot_number_of_levels_larger_than_int32(self):
         # GH 20601
         data = DataFrame({'ind1': list(range(1337600)) * 2,
-                          'ind2': list(range(3040)) * 2 * 440, 'count': [1] * 2 * 1337600})
+                          'ind2': list(range(3040)) * 2 * 440,
+                          'count': [1] * 2 * 1337600})
         with tm.assert_raises_regex(ValueError, 'int32 overflow'):
-            data.pivot_table(index='ind1', columns='ind2', values='count', aggfunc='count')
+            data.pivot_table(index='ind1', columns='ind2',
+                             values='count', aggfunc='count')
 
 
 class TestCrosstab(object):

--- a/pandas/tests/reshape/test_pivot.py
+++ b/pandas/tests/reshape/test_pivot.py
@@ -1278,11 +1278,11 @@ class TestPivotTable(object):
     @pytest.mark.slow
     def test_pivot_number_of_levels_larger_than_int32(self):
         # GH 20601
-        data = DataFrame({'ind1': list(range(1337600)) * 2,
-                          'ind2': list(range(3040)) * 2 * 440,
-                          'count': [1] * 2 * 1337600})
+        df = DataFrame({'ind1': np.arange(2 ** 16),
+                          'ind2': np.arange(2 ** 16),
+                          'count': np.arange(2 ** 16)})
         with tm.assert_raises_regex(ValueError, 'int32 overflow'):
-            data.pivot_table(index='ind1', columns='ind2',
+            df.pivot_table(index='ind1', columns='ind2',
                              values='count', aggfunc='count')
 
 

--- a/pandas/tests/reshape/test_pivot.py
+++ b/pandas/tests/reshape/test_pivot.py
@@ -1279,11 +1279,11 @@ class TestPivotTable(object):
     def test_pivot_number_of_levels_larger_than_int32(self):
         # GH 20601
         df = DataFrame({'ind1': np.arange(2 ** 16),
-                          'ind2': np.arange(2 ** 16),
-                          'count': np.arange(2 ** 16)})
+                        'ind2': np.arange(2 ** 16),
+                        'count': np.arange(2 ** 16)})
         with tm.assert_raises_regex(ValueError, 'int32 overflow'):
             df.pivot_table(index='ind1', columns='ind2',
-                             values='count', aggfunc='count')
+                           values='count', aggfunc='count')
 
 
 class TestCrosstab(object):

--- a/pandas/tests/reshape/test_pivot.py
+++ b/pandas/tests/reshape/test_pivot.py
@@ -1275,6 +1275,14 @@ class TestPivotTable(object):
                                aggfunc=f_numpy)
         tm.assert_frame_equal(result, expected)
 
+    @pytest.mark.slow
+    def test_pivot_number_of_levels_larger_than_int32(self):
+        # GH 20601
+        data = DataFrame({'ind1': list(range(1337600)) * 2,
+                          'ind2': list(range(3040)) * 2 * 440, 'count': [1] * 2 * 1337600})
+        with tm.assert_raises_regex(ValueError, 'int32 overflow'):
+            data.pivot_table(index='ind1', columns='ind2', values='count', aggfunc='count')
+
 
 class TestCrosstab(object):
 

--- a/pandas/tests/test_multilevel.py
+++ b/pandas/tests/test_multilevel.py
@@ -1195,6 +1195,13 @@ Thur,Lunch,Yes,51.51,17"""
         recons = result.stack()
         tm.assert_frame_equal(recons, df)
 
+    @pytest.mark.slow
+    def test_unstack_number_of_levels_larger_than_int32(self):
+        # GH 20601
+        df = DataFrame(np.random.randn(2 ** 16, 2), index=[np.arange(2 ** 16), np.arange(2 ** 16)])
+        with tm.assert_raises_regex(ValueError, 'int32 overflow'):
+            df.unstack()
+
     def test_stack_order_with_unsorted_levels(self):
         # GH 16323
 

--- a/pandas/tests/test_multilevel.py
+++ b/pandas/tests/test_multilevel.py
@@ -1198,7 +1198,8 @@ Thur,Lunch,Yes,51.51,17"""
     @pytest.mark.slow
     def test_unstack_number_of_levels_larger_than_int32(self):
         # GH 20601
-        df = DataFrame(np.random.randn(2 ** 16, 2), index=[np.arange(2 ** 16), np.arange(2 ** 16)])
+        df = DataFrame(np.random.randn(2 ** 16, 2),
+                       index=[np.arange(2 ** 16), np.arange(2 ** 16)])
         with tm.assert_raises_regex(ValueError, 'int32 overflow'):
             df.unstack()
 


### PR DESCRIPTION
Because the error of number of levels exceeding int32 can happen both in `pivot_table` and `unstack`, I catch the error as early as possible in both places.

Arguments for and against catching the error in `pivot_table`:
- For: `pivot_table` does aggregation before calling `unstack`, so it takes a while before the error is raised
- Against: `pivot_table` ultimately calls `unstack`, so it's not worth it to check for the error in both places

I'm happy to go with either way as you prefer.

- [X ] closes #20601
- [X ] tests added / passed
- [X ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [X ] whatsnew entry
