### PR TITLE
EA.values warning test

### DIFF
--- a/pandas/core/arrays/base.py
+++ b/pandas/core/arrays/base.py
@@ -5,6 +5,19 @@
    This is an experimental API and subject to breaking changes
    without warning.
 """
+# Some notes, just for implementors.
+#
+# * Avoid a `.values` attribute
+#   There are corners in pandas that assume assume array.values is an ndarray,
+#   and does ndarray things like ge the dtype. If you have a non-ndarray
+#   `.values` attribute, things may break. We're working to fix these.
+# * Reference the default implementations, but avoid using private methods.
+#   Some default implementations (e.g. `factorize`) use pandas' internal
+#   methods. If possible, avoid using those methods when overriding the default
+#   implementation. If that isn't possible, raise an issue to discuss adding
+#   those to the public API.
+
+
 import numpy as np
 
 from pandas.errors import AbstractMethodError

--- a/pandas/tests/extension/base/interface.py
+++ b/pandas/tests/extension/base/interface.py
@@ -50,3 +50,10 @@ class BaseInterfaceTests(BaseExtensionTests):
         assert is_extension_array_dtype(data.dtype)
         assert is_extension_array_dtype(pd.Series(data))
         assert isinstance(data.dtype, ExtensionDtype)
+
+    def test_no_values_attribute(self, data):
+        if hasattr(data, 'values') and not hasattr(data.values, 'dtype'):
+            msg = ("ExtensionArray contains a 'values' attribute that does "
+                   "not have a dtype attribute. This may cause issues in "
+                   "pandas' internals.")
+            raise ValueError(msg)

--- a/pandas/tests/extension/base/interface.py
+++ b/pandas/tests/extension/base/interface.py
@@ -52,6 +52,11 @@ class BaseInterfaceTests(BaseExtensionTests):
         assert isinstance(data.dtype, ExtensionDtype)
 
     def test_no_values_attribute(self, data):
+        # GH-20735
+        # Currently, pandas has places where we accepts Union[ndarray, EA]
+        # but in practice expect an ndarray, since we get `data.values.dtype`.
+        # This warns users to avoid using a `.values` attribute that is not
+        # an ndarray-like
         if hasattr(data, 'values') and not hasattr(data.values, 'dtype'):
             msg = ("ExtensionArray contains a 'values' attribute that does "
                    "not have a dtype attribute. This may cause issues in "

--- a/pandas/tests/extension/test_values.py
+++ b/pandas/tests/extension/test_values.py
@@ -1,0 +1,23 @@
+import pytest
+
+from pandas.tests.extension.base import BaseInterfaceTests
+from pandas.tests.extension.json.array import JSONArray
+
+
+class JSONArray2(JSONArray):
+    @property
+    def values(self):
+        return self.data
+
+
+@pytest.fixture
+def data():
+    return JSONArray2([{"A": [1, 2], "B": [3, 4]}])
+
+
+class TestBaseInterfaceTests(BaseInterfaceTests):
+    def test_no_values_attribute(self, data):
+        # GH-20735
+        with pytest.raises(ValueError) as m:
+            super(TestBaseInterfaceTests, self).test_no_values_attribute(data)
+        assert m.match("ExtensionArray contains")


### PR DESCRIPTION
xref #20735 (doesn't close)

Here's a local "test" for it.

```
pytest pandas/tests/extension/test_values.py -k test_no_values
==================================================================== test session starts ====================================================================
platform darwin -- Python 3.7.0b3, pytest-3.5.0, py-1.5.3, pluggy-0.6.0
rootdir: /Users/taugspurger/sandbox/pandas, inifile: setup.cfg
plugins: xdist-1.22.2, forked-0.2, cov-2.5.1
collected 9 items / 8 deselected

pandas/tests/extension/test_values.py F                                                                                                               [100%]

========================================================================= FAILURES ==========================================================================
______________________________________________________ TestBaseInterfaceTests.test_no_values_attribute ______________________________________________________

self = <pandas.tests.extension.test_values.TestBaseInterfaceTests object at 0x112ed4748>, data = JSONArary([{'A': [1, 2], 'B': [3, 4]}])

    def test_no_values_attribute(self, data):
        # GH-20735
        # Currently, pandas has places where we accepts Union[ndarray, EA]
        # but in practice expect an ndarray, since we get `data.values.dtype`.
        # This warns users to avoid using a `.values` attribute that is not
        # an ndarray-like
        if hasattr(data, 'values') and not hasattr(data.values, 'dtype'):
            msg = ("ExtensionArray contains a 'values' attribute that does "
                   "not have a dtype attribute. This may cause issues in "
                   "pandas' internals.")
>           raise ValueError(msg)
E           ValueError: ExtensionArray contains a 'values' attribute that does not have a dtype attribute. This may cause issues in pandas' internals.

pandas/tests/extension/base/interface.py:64: ValueError
========================================================== 1 failed, 8 deselected in 0.12 seconds ===========================================================
```

What, if anything, should we include in pandas to test this? I'm fine with the current PR (no tests), since it's just test code.

Edit: ignore what I said about testing. Added one that calls `super()` inside a `raises` context manager. It's not too bad.