### PR TITLE
BUG: Coerce to object for mixed concat

### DIFF
--- a/pandas/core/dtypes/concat.py
+++ b/pandas/core/dtypes/concat.py
@@ -8,6 +8,7 @@ from pandas import compat
 from pandas.core.dtypes.common import (
     is_categorical_dtype,
     is_sparse,
+    is_extension_array_dtype,
     is_datetimetz,
     is_datetime64_dtype,
     is_timedelta64_dtype,
@@ -172,6 +173,11 @@ def _concat_compat(to_concat, axis=0):
     # these are mandated to handle empties as well
     elif 'sparse' in typs:
         return _concat_sparse(to_concat, axis=axis, typs=typs)
+
+    extensions = [is_extension_array_dtype(x) for x in to_concat]
+    if any(extensions) and not all(extensions):
+        to_concat = [np.atleast_2d(x.astype('object')) for x in to_concat]
+        # convert non extensions to objects
 
     if not nonempty:
         # we have all empties, but may need to coerce the result dtype to

--- a/pandas/core/dtypes/concat.py
+++ b/pandas/core/dtypes/concat.py
@@ -177,7 +177,6 @@ def _concat_compat(to_concat, axis=0):
     extensions = [is_extension_array_dtype(x) for x in to_concat]
     if any(extensions) and not all(extensions):
         to_concat = [np.atleast_2d(x.astype('object')) for x in to_concat]
-        # convert non extensions to objects
 
     if not nonempty:
         # we have all empties, but may need to coerce the result dtype to
@@ -216,7 +215,7 @@ def _concat_categorical(to_concat, axis=0):
 
     def _concat_asobject(to_concat):
         to_concat = [x.get_values() if is_categorical_dtype(x.dtype)
-                     else x.ravel() for x in to_concat]
+                     else np.asarray(x).ravel() for x in to_concat]
         res = _concat_compat(to_concat)
         if axis == 1:
             return res.reshape(1, len(res))
@@ -554,6 +553,8 @@ def _concat_sparse(to_concat, axis=0, typs=None):
         # coerce to native type
         if isinstance(x, SparseArray):
             x = x.get_values()
+        else:
+            x = np.asarray(x)
         x = x.ravel()
         if axis > 0:
             x = np.atleast_2d(x)

--- a/pandas/core/dtypes/concat.py
+++ b/pandas/core/dtypes/concat.py
@@ -175,7 +175,7 @@ def _concat_compat(to_concat, axis=0):
         return _concat_sparse(to_concat, axis=axis, typs=typs)
 
     extensions = [is_extension_array_dtype(x) for x in to_concat]
-    if any(extensions) and not all(extensions):
+    if any(extensions):
         to_concat = [np.atleast_2d(x.astype('object')) for x in to_concat]
 
     if not nonempty:

--- a/pandas/tests/extension/base/reshaping.py
+++ b/pandas/tests/extension/base/reshaping.py
@@ -45,9 +45,21 @@ class BaseReshapingTests(BaseExtensionTests):
         # https://github.com/pandas-dev/pandas/issues/20762
         df1 = pd.DataFrame({'A': data[:3]})
         df2 = pd.DataFrame({"A": [1, 2, 3]})
+        df3 = pd.DataFrame({"A": ['a', 'b', 'c']}).astype('category')
+        df4 = pd.DataFrame({"A": pd.SparseArray([1, 2, 3])})
+        dfs = [df1, df2, df3, df4]
 
+        result = pd.concat(dfs)
+        expected = pd.concat([x.astype(object) for x in dfs])
+        self.assert_frame_equal(result, expected)
+
+        result = pd.concat([x['A'] for x in dfs])
+        expected = pd.concat([x['A'].astype(object) for x in dfs])
+        self.assert_series_equal(result, expected)
+
+        # simple test for just EA and one other
         result = pd.concat([df1, df2])
-        expected = pd.concat([df1.astype(object), df2.astype(object)])
+        expected = pd.concat([df1.astype('object'), df2.astype('object')])
         self.assert_frame_equal(result, expected)
 
     def test_align(self, data, na_value):

--- a/pandas/tests/extension/base/reshaping.py
+++ b/pandas/tests/extension/base/reshaping.py
@@ -41,6 +41,15 @@ class BaseReshapingTests(BaseExtensionTests):
             expected = pd.Series(data_missing.take([1, 1, 0, 0]))
             self.assert_series_equal(result, expected)
 
+    def test_concat_with_other_dtype_coerces(self, data):
+        # https://github.com/pandas-dev/pandas/issues/20762
+        df1 = pd.DataFrame({'A': data[:3]})
+        df2 = pd.DataFrame({"A": [1, 2, 3]})
+
+        result = pd.concat([df1, df2])
+        expected = pd.concat([df1.astype(object), df2.astype(object)])
+        self.assert_frame_equal(result, expected)
+
     def test_align(self, data, na_value):
         a = data[:3]
         b = data[2:5]

--- a/pandas/tests/extension/base/reshaping.py
+++ b/pandas/tests/extension/base/reshaping.py
@@ -41,7 +41,7 @@ class BaseReshapingTests(BaseExtensionTests):
             expected = pd.Series(data_missing.take([1, 1, 0, 0]))
             self.assert_series_equal(result, expected)
 
-    def test_concat_with_other_dtype_coerces(self, data):
+    def test_concat_mixed_dtypes(self, data):
         # https://github.com/pandas-dev/pandas/issues/20762
         df1 = pd.DataFrame({'A': data[:3]})
         df2 = pd.DataFrame({"A": [1, 2, 3]})
@@ -49,10 +49,12 @@ class BaseReshapingTests(BaseExtensionTests):
         df4 = pd.DataFrame({"A": pd.SparseArray([1, 2, 3])})
         dfs = [df1, df2, df3, df4]
 
+        # dataframes
         result = pd.concat(dfs)
         expected = pd.concat([x.astype(object) for x in dfs])
         self.assert_frame_equal(result, expected)
 
+        # series
         result = pd.concat([x['A'] for x in dfs])
         expected = pd.concat([x['A'].astype(object) for x in dfs])
         self.assert_series_equal(result, expected)


### PR DESCRIPTION
- [x] closes #20762
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
