### PR TITLE
BUG: Fixed NDFrame.transform('abs')

### DIFF
--- a/pandas/core/apply.py
+++ b/pandas/core/apply.py
@@ -111,6 +111,9 @@ class FrameApply(object):
 
         # string dispatch
         if isinstance(self.f, compat.string_types):
+            # Support for `frame.transform('method')`
+            # Some methods (shift, etc.) require the axis argument, others
+            # don't, so inspect and insert if nescessary.
             func = getattr(self.obj, self.f)
             sig = compat.signature(func)
             if 'axis' in sig.args:

--- a/pandas/core/apply.py
+++ b/pandas/core/apply.py
@@ -111,7 +111,9 @@ class FrameApply(object):
 
         # string dispatch
         if isinstance(self.f, compat.string_types):
-            self.kwds['axis'] = self.axis
+            if self.f not in {'abs'}:
+                # Not all transform functions take an axis keyword.
+                self.kwds['axis'] = self.axis
             return getattr(self.obj, self.f)(*self.args, **self.kwds)
 
         # ufunc

--- a/pandas/core/apply.py
+++ b/pandas/core/apply.py
@@ -111,10 +111,11 @@ class FrameApply(object):
 
         # string dispatch
         if isinstance(self.f, compat.string_types):
-            if self.f not in {'abs'}:
-                # Not all transform functions take an axis keyword.
+            func = getattr(self.obj, self.f)
+            sig = compat.signature(func)
+            if 'axis' in sig.args:
                 self.kwds['axis'] = self.axis
-            return getattr(self.obj, self.f)(*self.args, **self.kwds)
+            return func(*self.args, **self.kwds)
 
         # ufunc
         elif isinstance(self.f, np.ufunc):

--- a/pandas/tests/frame/test_apply.py
+++ b/pandas/tests/frame/test_apply.py
@@ -880,6 +880,13 @@ class TestDataFrameAggregate(TestData):
             with np.errstate(all='ignore'):
                 df.agg({'A': ['abs', 'sum'], 'B': ['mean', 'max']})
 
+    def test_transform_abs_name(self):
+        # https://github.com/pandas-dev/pandas/issues/19760
+        df = pd.DataFrame({"A": [-1, 2]})
+        result = df.transform('abs')
+        expected = pd.DataFrame({"A": [1, 2]})
+        tm.assert_frame_equal(result, expected)
+
     def test_demo(self):
         # demonstration tests
         df = pd.DataFrame({'A': range(5), 'B': 5})

--- a/pandas/tests/frame/test_apply.py
+++ b/pandas/tests/frame/test_apply.py
@@ -4,6 +4,7 @@ from __future__ import print_function
 
 import pytest
 
+import operator
 from datetime import datetime
 
 import warnings
@@ -880,11 +881,14 @@ class TestDataFrameAggregate(TestData):
             with np.errstate(all='ignore'):
                 df.agg({'A': ['abs', 'sum'], 'B': ['mean', 'max']})
 
-    def test_transform_abs_name(self):
+    @pytest.mark.parametrize('method', [
+        'abs', 'shift', 'pct_change', 'cumsum', 'rank',
+    ])
+    def test_transform_method_name(self, method):
         # https://github.com/pandas-dev/pandas/issues/19760
         df = pd.DataFrame({"A": [-1, 2]})
-        result = df.transform('abs')
-        expected = pd.DataFrame({"A": [1, 2]})
+        result = df.transform(method)
+        expected = operator.methodcaller(method)(df)
         tm.assert_frame_equal(result, expected)
 
     def test_demo(self):


### PR DESCRIPTION
Closes https://github.com/pandas-dev/pandas/issues/19760

So this is a hacky workaround. I think we would ideally whitelist a set of valid NDFrame.transform methods, but I don't want to break things. What would that list include?

- abs
- pct_change
- shift
- tshift
- cum*