### PR TITLE
DEPR: Warn on empty Series dtype inference

### DIFF
--- a/asv_bench/benchmarks/indexing.py
+++ b/asv_bench/benchmarks/indexing.py
@@ -249,7 +249,7 @@ class MethodLookup(object):
     goal_time = 0.2
 
     def setup_cache(self):
-        s = Series()
+        s = Series(dtype='float64')
         return s
 
     def time_lookup_iloc(self, s):

--- a/doc/source/missing_data.rst
+++ b/doc/source/missing_data.rst
@@ -196,17 +196,17 @@ The sum of an empty or all-NA Series or column of a DataFrame is 0.
 
 .. ipython:: python
 
-   pd.Series([np.nan]).sum()
-   
-   pd.Series([]).sum()
+   pd.Series([np.nan], dtype='float').sum()
+
+   pd.Series([], dtype='float').sum()
 
 The product of an empty or all-NA Series or column of a DataFrame is 1.
 
 .. ipython:: python
 
-   pd.Series([np.nan]).prod()
-   
-   pd.Series([]).prod()
+   pd.Series([np.nan], dtype='float').prod()
+
+   pd.Series([], dtype='float').prod()
 
 
 NA values in GroupBy

--- a/doc/source/whatsnew/v0.19.0.txt
+++ b/doc/source/whatsnew/v0.19.0.txt
@@ -705,7 +705,7 @@ A ``Series`` will now correctly promote its dtype for assignment with incompat v
 
 .. ipython:: python
 
-   s = pd.Series()
+   s = pd.Series(dtype='float')
 
 **Previous behavior**:
 

--- a/doc/source/whatsnew/v0.21.0.txt
+++ b/doc/source/whatsnew/v0.21.0.txt
@@ -411,14 +411,14 @@ Note that this also changes the sum of an empty ``Series``. Previously this alwa
 
 .. code-block:: ipython
 
-   In [1]: pd.Series([]).sum()
+   In [1]: pd.Series([], dtype='float').sum()
    Out[1]: 0
 
 but for consistency with the all-NaN case, this was changed to return NaN as well:
 
 .. ipython:: python
 
-   pd.Series([]).sum()
+   pd.Series([], dtype='float').sum()
 
 
 .. _whatsnew_0210.api_breaking.loc:

--- a/doc/source/whatsnew/v0.22.0.txt
+++ b/doc/source/whatsnew/v0.22.0.txt
@@ -38,7 +38,7 @@ The default sum for empty or all-*NA* ``Series`` is now ``0``.
 
 .. code-block:: ipython
 
-   In [1]: pd.Series([]).sum()
+   In [1]: pd.Series([], dtype='float').sum()
    Out[1]: nan
 
    In [2]: pd.Series([np.nan]).sum()
@@ -48,7 +48,7 @@ The default sum for empty or all-*NA* ``Series`` is now ``0``.
 
 .. ipython:: python
 
-   pd.Series([]).sum()
+   pd.Series([], dtype='float').sum()
    pd.Series([np.nan]).sum()
 
 The default behavior is the same as pandas 0.20.3 with bottleneck installed. It
@@ -60,7 +60,7 @@ keyword.
 
 .. ipython:: python
 
-   pd.Series([]).sum(min_count=1)
+   pd.Series([], dtype='float').sum(min_count=1)
 
 Thanks to the ``skipna`` parameter, the ``.sum`` on an all-*NA*
 series is conceptually the same as the ``.sum`` of an empty one with
@@ -78,9 +78,9 @@ returning ``1`` instead.
 
 .. ipython:: python
 
-   pd.Series([]).prod()
+   pd.Series([], dtype='float').prod()
    pd.Series([np.nan]).prod()
-   pd.Series([]).prod(min_count=1)
+   pd.Series([], dtype='float').prod(min_count=1)
 
 These changes affect :meth:`DataFrame.sum` and :meth:`DataFrame.prod` as well.
 Finally, a few less obvious places in pandas are affected by this change.

--- a/doc/source/whatsnew/v0.23.0.txt
+++ b/doc/source/whatsnew/v0.23.0.txt
@@ -862,6 +862,7 @@ Other API Changes
 Deprecations
 ~~~~~~~~~~~~
 
+- The inferred dtype for an empty Series will change from ``float`` to ``object`` (:issue:`17261`).
 - ``Series.from_array`` and ``SparseSeries.from_array`` are deprecated. Use the normal constructor ``Series(..)`` and ``SparseSeries(..)`` instead (:issue:`18213`).
 - ``DataFrame.as_matrix`` is deprecated. Use ``DataFrame.values`` instead (:issue:`18458`).
 - ``Series.asobject``, ``DatetimeIndex.asobject``, ``PeriodIndex.asobject`` and ``TimeDeltaIndex.asobject`` have been deprecated. Use ``.astype(object)`` instead (:issue:`18572`)

--- a/pandas/core/arrays/categorical.py
+++ b/pandas/core/arrays/categorical.py
@@ -324,6 +324,11 @@ class Categorical(ExtensionArray, PandasObject):
                 null_mask = isna(values)
                 if null_mask.any():
                     values = [values[idx] for idx in np.where(~null_mask)[0]]
+                    if len(values) == 0:
+                        # This avoids the FutureWarning in sanitize_array about
+                        # inferring float -> object. I suppose that float is
+                        # the correct dtype to infer for an all NaN array.
+                        sanitize_dtype = 'float'
                 values = _sanitize_array(values, None, dtype=sanitize_dtype)
 
         if dtype.categories is None:

--- a/pandas/core/base.py
+++ b/pandas/core/base.py
@@ -954,7 +954,11 @@ class IndexOpsMixin(object):
                 # we specify the keys here to handle the
                 # possibility that they are tuples
                 from pandas import Series
-                mapper = Series(mapper)
+                if len(mapper) == 0:
+                    mapper_dtype = 'float'
+                else:
+                    mapper_dtype = None
+                mapper = Series(mapper, dtype=mapper_dtype)
 
         if isinstance(mapper, ABCSeries):
             # Since values were input this means we came from either

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -5399,7 +5399,11 @@ class NDFrame(PandasObject, SelectionMixin):
             if self.ndim == 1:
                 if isinstance(value, (dict, ABCSeries)):
                     from pandas import Series
-                    value = Series(value)
+                    if len(value) == 0:
+                        series_dtype = 'float'
+                    else:
+                        series_dtype = None
+                    value = Series(value, dtype=series_dtype)
                 elif not is_list_like(value):
                     pass
                 else:
@@ -9376,13 +9380,13 @@ Examples
 --------
 By default, the sum of an empty or all-NA Series is ``0``.
 
->>> pd.Series([]).sum()  # min_count=0 is the default
+>>> pd.Series([], dtype='float').sum()  # min_count=0 is the default
 0.0
 
 This can be controlled with the ``min_count`` parameter. For example, if
 you'd like the sum of an empty series to be NaN, pass ``min_count=1``.
 
->>> pd.Series([]).sum(min_count=1)
+>>> pd.Series([], dtype='float').sum(min_count=1)
 nan
 
 Thanks to the ``skipna`` parameter, ``min_count`` handles all-NA and
@@ -9400,12 +9404,12 @@ Examples
 --------
 By default, the product of an empty or all-NA Series is ``1``
 
->>> pd.Series([]).prod()
+>>> pd.Series([], dtype='float').prod()
 1.0
 
 This can be controlled with the ``min_count`` parameter
 
->>> pd.Series([]).prod(min_count=1)
+>>> pd.Series([], dtype='float').prod(min_count=1)
 nan
 
 Thanks to the ``skipna`` parameter, ``min_count`` handles all-NA and

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -42,7 +42,6 @@ from pandas.core.dtypes.common import (
     is_datetime64_any_dtype,
     is_datetime64tz_dtype,
     is_timedelta64_dtype,
-    is_hashable,
     needs_i8_conversion,
     is_iterator, is_list_like,
     is_scalar)
@@ -1313,33 +1312,9 @@ class Index(IndexOpsMixin, PandasObject):
         return FrozenList((self.name, ))
 
     def _set_names(self, values, level=None):
-        """
-        Set new names on index. Each name has to be a hashable type.
-
-        Parameters
-        ----------
-        values : str or sequence
-            name(s) to set
-        level : int, level name, or sequence of int/level names (default None)
-            If the index is a MultiIndex (hierarchical), level(s) to set (None
-            for all levels).  Otherwise level must be None
-
-        Raises
-        ------
-        TypeError if each name is not hashable.
-        """
-        if not is_list_like(values):
-            raise ValueError('Names must be a list-like')
         if len(values) != 1:
             raise ValueError('Length of new names must be 1, got %d' %
                              len(values))
-
-        # GH 20527
-        # All items in 'name' need to be hashable:
-        for name in values:
-            if not is_hashable(name):
-                raise TypeError('{}.name must be a hashable type'
-                                .format(self.__class__.__name__))
         self.name = values[0]
 
     names = property(fset=_set_names, fget=_get_names)
@@ -1365,9 +1340,9 @@ class Index(IndexOpsMixin, PandasObject):
         Examples
         --------
         >>> Index([1, 2, 3, 4]).set_names('foo')
-        Int64Index([1, 2, 3, 4], dtype='int64', name='foo')
+        Int64Index([1, 2, 3, 4], dtype='int64')
         >>> Index([1, 2, 3, 4]).set_names(['foo'])
-        Int64Index([1, 2, 3, 4], dtype='int64', name='foo')
+        Int64Index([1, 2, 3, 4], dtype='int64')
         >>> idx = MultiIndex.from_tuples([(1, u'one'), (1, u'two'),
                                           (2, u'one'), (2, u'two')],
                                           names=['foo', 'bar'])
@@ -1380,7 +1355,6 @@ class Index(IndexOpsMixin, PandasObject):
                    labels=[[0, 0, 1, 1], [0, 1, 0, 1]],
                    names=[u'baz', u'bar'])
         """
-
         if level is not None and self.nlevels == 1:
             raise ValueError('Level must be None for non-MultiIndex')
 

--- a/pandas/core/indexes/multi.py
+++ b/pandas/core/indexes/multi.py
@@ -16,7 +16,6 @@ from pandas.core.dtypes.common import (
     _ensure_platform_int,
     is_categorical_dtype,
     is_object_dtype,
-    is_hashable,
     is_iterator,
     is_list_like,
     pandas_dtype,
@@ -635,29 +634,12 @@ class MultiIndex(Index):
 
     def _set_names(self, names, level=None, validate=True):
         """
-        Set new names on index. Each name has to be a hashable type.
-
-        Parameters
-        ----------
-        values : str or sequence
-            name(s) to set
-        level : int, level name, or sequence of int/level names (default None)
-            If the index is a MultiIndex (hierarchical), level(s) to set (None
-            for all levels).  Otherwise level must be None
-        validate : boolean, default True
-            validate that the names match level lengths
-
-        Raises
-        ------
-        TypeError if each name is not hashable.
-
-        Notes
-        -----
         sets names on levels. WARNING: mutates!
 
         Note that you generally want to set this *after* changing levels, so
         that it only acts on copies
         """
+
         # GH 15110
         # Don't allow a single string for names in a MultiIndex
         if names is not None and not is_list_like(names):
@@ -680,20 +662,10 @@ class MultiIndex(Index):
 
         # set the name
         for l, name in zip(level, names):
-            if name is not None:
-
-                # GH 20527
-                # All items in 'names' need to be hashable:
-                if not is_hashable(name):
-                    raise TypeError('{}.name must be a hashable type'
-                                    .format(self.__class__.__name__))
-
-                if name in used:
-                    raise ValueError(
-                        'Duplicated level name: "{}", assigned to '
-                        'level {}, is already used for level '
-                        '{}.'.format(name, l, used[name]))
-
+            if name is not None and name in used:
+                raise ValueError('Duplicated level name: "{}", assigned to '
+                                 'level {}, is already used for level '
+                                 '{}.'.format(name, l, used[name]))
             self.levels[l].rename(name, inplace=True)
             used[name] = l
 

--- a/pandas/core/tools/datetimes.py
+++ b/pandas/core/tools/datetimes.py
@@ -58,7 +58,7 @@ def _maybe_cache(arg, format, cache, tz, convert_listlike):
         Cache of converted, unique dates. Can be empty
     """
     from pandas import Series
-    cache_array = Series()
+    cache_array = Series(dtype='float')
     if cache:
         # Perform a quicker unique check
         from pandas import Index

--- a/pandas/plotting/_core.py
+++ b/pandas/plotting/_core.py
@@ -1656,7 +1656,7 @@ class BoxPlot(LinePlot):
     def _make_plot(self):
         if self.subplots:
             from pandas.core.series import Series
-            self._return_obj = Series()
+            self._return_obj = Series(dtype='float')
 
             for i, (label, y) in enumerate(self._iter_data()):
                 ax = self._get_ax(i)
@@ -2603,7 +2603,7 @@ def boxplot_frame_groupby(grouped, subplots=True, column=None, fontsize=None,
         axes = _flatten(axes)
 
         from pandas.core.series import Series
-        ret = Series()
+        ret = Series(dtype='float')
         for (key, group), ax in zip(grouped, axes):
             d = group.boxplot(ax=ax, column=column, fontsize=fontsize,
                               rot=rot, grid=grid, **kwds)

--- a/pandas/tests/dtypes/test_inference.py
+++ b/pandas/tests/dtypes/test_inference.py
@@ -1173,7 +1173,7 @@ class TestIsScalar(object):
         assert is_scalar(DateOffset(days=1))
 
     def test_is_scalar_pandas_containers(self):
-        assert not is_scalar(Series())
+        assert not is_scalar(Series(dtype='float'))
         assert not is_scalar(Series([1]))
         assert not is_scalar(DataFrame())
         assert not is_scalar(DataFrame([[1]]))

--- a/pandas/tests/frame/test_analytics.py
+++ b/pandas/tests/frame/test_analytics.py
@@ -1252,7 +1252,8 @@ class TestDataFrameAnalytics(TestData):
         expected = DataFrame([df.loc[s].isin(other) for s in df.index])
         tm.assert_frame_equal(result, expected)
 
-    @pytest.mark.parametrize("empty", [[], Series(), np.array([])])
+    @pytest.mark.parametrize("empty", [[], Series(dtype='float'),
+                             np.array([])])
     def test_isin_empty(self, empty):
         # see gh-16991
         df = DataFrame({'A': ['a', 'b', 'c'], 'B': ['a', 'e', 'f']})

--- a/pandas/tests/frame/test_indexing.py
+++ b/pandas/tests/frame/test_indexing.py
@@ -125,12 +125,12 @@ class TestDataFrameIndexing(TestData):
         # tuples
         df = DataFrame(randn(8, 3),
                        columns=Index([('foo', 'bar'), ('baz', 'qux'),
-                                      ('peek', 'aboo')], name=('sth', 'sth2')))
+                                      ('peek', 'aboo')], name=['sth', 'sth2']))
 
         result = df[[('foo', 'bar'), ('baz', 'qux')]]
         expected = df.iloc[:, :2]
         assert_frame_equal(result, expected)
-        assert result.columns.names == ('sth', 'sth2')
+        assert result.columns.names == ['sth', 'sth2']
 
     def test_getitem_callable(self):
         # GH 12533

--- a/pandas/tests/frame/test_operators.py
+++ b/pandas/tests/frame/test_operators.py
@@ -421,7 +421,7 @@ class TestDataFrameOperators(TestData):
     def test_arith_flex_zero_len_raises(self):
         # GH#19522 passing fill_value to frame flex arith methods should
         # raise even in the zero-length special cases
-        ser_len0 = pd.Series([])
+        ser_len0 = pd.Series([], dtype='float')
         df_len0 = pd.DataFrame([], columns=['A', 'B'])
         df = pd.DataFrame([[1, 2], [3, 4]], columns=['A', 'B'])
 

--- a/pandas/tests/generic/test_series.py
+++ b/pandas/tests/generic/test_series.py
@@ -226,4 +226,4 @@ class TestSeries(Generic):
     def test_valid_deprecated(self):
         # GH18800
         with tm.assert_produces_warning(FutureWarning):
-            pd.Series([]).valid()
+            pd.Series([], dtype='float').valid()

--- a/pandas/tests/groupby/test_counting.py
+++ b/pandas/tests/groupby/test_counting.py
@@ -24,7 +24,7 @@ class TestCounting(object):
 
     def test_cumcount_empty(self):
         ge = DataFrame().groupby(level=0)
-        se = Series().groupby(level=0)
+        se = Series(dtype='float').groupby(level=0)
 
         # edge case, as this is usually considered float
         e = Series(dtype='int64')
@@ -98,7 +98,7 @@ class TestCounting(object):
 
     def test_ngroup_empty(self):
         ge = DataFrame().groupby(level=0)
-        se = Series().groupby(level=0)
+        se = Series(dtype='float').groupby(level=0)
 
         # edge case, as this is usually considered float
         e = Series(dtype='int64')

--- a/pandas/tests/indexes/test_base.py
+++ b/pandas/tests/indexes/test_base.py
@@ -435,24 +435,6 @@ class TestIndex(Base):
         assert isinstance(empty, MultiIndex)
         assert not len(empty)
 
-    def test_constructor_nonhashable_name(self, indices):
-        # GH 20527
-
-        if isinstance(indices, MultiIndex):
-            pytest.skip("multiindex handled in test_multi.py")
-
-        name = ['0']
-        message = "Index.name must be a hashable type"
-        tm.assert_raises_regex(TypeError, message, name=name)
-
-        # With .rename()
-        renamed = [['1']]
-        tm.assert_raises_regex(TypeError, message,
-                               indices.rename, name=renamed)
-        # With .set_names()
-        tm.assert_raises_regex(TypeError, message,
-                               indices.set_names, names=renamed)
-
     def test_view_with_args(self):
 
         restricted = ['unicodeIndex', 'strIndex', 'catIndex', 'boolIndex',
@@ -1642,7 +1624,8 @@ class TestIndex(Base):
         # Float64Index overrides isin, so must be checked separately
         check_idx(Float64Index([1.0, 2.0, 3.0, 4.0]))
 
-    @pytest.mark.parametrize("empty", [[], Series(), np.array([])])
+    @pytest.mark.parametrize("empty", [[], Series(dtype='float'),
+                             np.array([])])
     def test_isin_empty(self, empty):
         # see gh-16991
         idx = Index(["a", "b"])

--- a/pandas/tests/indexes/test_multi.py
+++ b/pandas/tests/indexes/test_multi.py
@@ -615,27 +615,8 @@ class TestMultiIndex(Base):
         with tm.assert_raises_regex(ValueError, label_error):
             self.index.copy().set_labels([[0, 0, 0, 0], [0, 0]])
 
-    def test_constructor_nonhashable_names(self):
-        # GH 20527
-        levels = [[1, 2], [u'one', u'two']]
-        labels = [[0, 0, 1, 1], [0, 1, 0, 1]]
-        names = ((['foo'], ['bar']))
-        message = "MultiIndex.name must be a hashable type"
-        tm.assert_raises_regex(TypeError, message,
-                               MultiIndex, levels=levels,
-                               labels=labels, names=names)
-
-        # With .rename()
-        mi = MultiIndex(levels=[[1, 2], [u'one', u'two']],
-                        labels=[[0, 0, 1, 1], [0, 1, 0, 1]],
-                        names=('foo', 'bar'))
-        renamed = [['foor'], ['barr']]
-        tm.assert_raises_regex(TypeError, message, mi.rename, names=renamed)
-        # With .set_names()
-        tm.assert_raises_regex(TypeError, message, mi.set_names, names=renamed)
-
-    @pytest.mark.parametrize('names', [['a', 'b', 'a'], ['1', '1', '2'],
-                                       ['1', 'a', '1']])
+    @pytest.mark.parametrize('names', [['a', 'b', 'a'], [1, 1, 2],
+                                       [1, 'a', 1]])
     def test_duplicate_level_names(self, names):
         # GH18872
         pytest.raises(ValueError, pd.MultiIndex.from_product,

--- a/pandas/tests/indexing/test_loc.py
+++ b/pandas/tests/indexing/test_loc.py
@@ -253,7 +253,7 @@ class TestLoc(Base):
         # GH  7496
         # loc should not fallback
 
-        s = Series()
+        s = Series(dtype='float')
         s.loc[1] = 1
         s.loc['a'] = 2
 

--- a/pandas/tests/indexing/test_partial.py
+++ b/pandas/tests/indexing/test_partial.py
@@ -450,19 +450,19 @@ class TestPartialSetting(object):
         # GH5226
 
         # partially set with an empty object series
-        s = Series()
+        s = Series(dtype='float')
         s.loc[1] = 1
         tm.assert_series_equal(s, Series([1], index=[1]))
         s.loc[3] = 3
         tm.assert_series_equal(s, Series([1, 3], index=[1, 3]))
 
-        s = Series()
+        s = Series(dtype='float')
         s.loc[1] = 1.
         tm.assert_series_equal(s, Series([1.], index=[1]))
         s.loc[3] = 3.
         tm.assert_series_equal(s, Series([1., 3.], index=[1, 3]))
 
-        s = Series()
+        s = Series(dtype='float')
         s.loc['foo'] = 1
         tm.assert_series_equal(s, Series([1], index=['foo']))
         s.loc['bar'] = 3
@@ -604,11 +604,11 @@ class TestPartialSetting(object):
     def test_partial_set_empty_frame_set_series(self):
         # GH 5756
         # setting with empty Series
-        df = DataFrame(Series())
-        tm.assert_frame_equal(df, DataFrame({0: Series()}))
+        df = DataFrame(Series(dtype='float'))
+        tm.assert_frame_equal(df, DataFrame({0: Series(dtype='float')}))
 
         df = DataFrame(Series(name='foo'))
-        tm.assert_frame_equal(df, DataFrame({'foo': Series()}))
+        tm.assert_frame_equal(df, DataFrame({'foo': Series(dtype='float')}))
 
     def test_partial_set_empty_frame_empty_copy_assignment(self):
         # GH 5932

--- a/pandas/tests/io/formats/test_format.py
+++ b/pandas/tests/io/formats/test_format.py
@@ -746,7 +746,7 @@ class TestDataFrameFormatting(object):
     def test_to_string_buffer_all_unicode(self):
         buf = StringIO()
 
-        empty = DataFrame({u('c/\u03c3'): Series()})
+        empty = DataFrame({u('c/\u03c3'): Series(dtype='float')})
         nonempty = DataFrame({u('c/\u03c3'): Series([1, 2, 3])})
 
         print(empty, file=buf)

--- a/pandas/tests/io/test_pytables.py
+++ b/pandas/tests/io/test_pytables.py
@@ -2780,7 +2780,7 @@ class TestHDFStore(Base):
         self._check_roundtrip(df[:0], tm.assert_frame_equal)
 
     def test_empty_series_frame(self):
-        s0 = Series()
+        s0 = Series(dtype='float')
         s1 = Series(name='myseries')
         df0 = DataFrame()
         df1 = DataFrame(index=['a', 'b', 'c'])

--- a/pandas/tests/reshape/test_concat.py
+++ b/pandas/tests/reshape/test_concat.py
@@ -2245,7 +2245,7 @@ def test_concat_empty_and_non_empty_frame_regression():
 def test_concat_empty_and_non_empty_series_regression():
     # GH 18187 regression test
     s1 = pd.Series([1])
-    s2 = pd.Series([])
+    s2 = pd.Series([], dtype='float')
     expected = s1
     result = pd.concat([s1, s2])
     tm.assert_series_equal(result, expected)

--- a/pandas/tests/series/common.py
+++ b/pandas/tests/series/common.py
@@ -27,4 +27,4 @@ class TestData(object):
 
     @cache_readonly
     def empty(self):
-        return pd.Series([], index=[])
+        return pd.Series([], index=[], dtype='float')

--- a/pandas/tests/series/indexing/test_datetime.py
+++ b/pandas/tests/series/indexing/test_datetime.py
@@ -97,7 +97,7 @@ def test_series_set_value():
 
     with tm.assert_produces_warning(FutureWarning,
                                     check_stacklevel=False):
-        s = Series().set_value(dates[0], 1.)
+        s = Series(dtype='float').set_value(dates[0], 1.)
     with tm.assert_produces_warning(FutureWarning,
                                     check_stacklevel=False):
         s2 = s.set_value(dates[1], np.nan)

--- a/pandas/tests/series/indexing/test_indexing.py
+++ b/pandas/tests/series/indexing/test_indexing.py
@@ -109,7 +109,8 @@ def test_getitem_get(test_data):
 
     # None
     # GH 5652
-    for s in [Series(), Series(index=list('abc'))]:
+    for s in [Series(dtype='float'),
+              Series(index=list('abc'), dtype='float')]:
         result = s.get(None)
         assert result is None
 
@@ -134,7 +135,7 @@ def test_getitem_generator(test_data):
 
 def test_type_promotion():
     # GH12599
-    s = pd.Series()
+    s = pd.Series(dtype='float')
     s["a"] = pd.Timestamp("2016-01-01")
     s["b"] = 3.0
     s["c"] = "foo"
@@ -169,7 +170,7 @@ def test_getitem_out_of_bounds(test_data):
     pytest.raises(IndexError, test_data.ts.__getitem__, len(test_data.ts))
 
     # GH #917
-    s = Series([])
+    s = Series([], dtype='float')
     pytest.raises(IndexError, s.__getitem__, -1)
 
 
@@ -281,12 +282,12 @@ def test_setitem(test_data):
 
     # Test for issue #10193
     key = pd.Timestamp('2012-01-01')
-    series = pd.Series()
+    series = pd.Series(dtype='float')
     series[key] = 47
     expected = pd.Series(47, [key])
     assert_series_equal(series, expected)
 
-    series = pd.Series([], pd.DatetimeIndex([], freq='D'))
+    series = pd.Series([], pd.DatetimeIndex([], freq='D'), dtype='float')
     series[key] = 47
     expected = pd.Series(47, pd.DatetimeIndex([key], freq='D'))
     assert_series_equal(series, expected)
@@ -562,7 +563,7 @@ def test_setitem_na():
 
 def test_timedelta_assignment():
     # GH 8209
-    s = Series([])
+    s = Series([], dtype='float')
     s.loc['B'] = timedelta(1)
     tm.assert_series_equal(s, Series(Timedelta('1 days'), index=['B']))
 

--- a/pandas/tests/series/indexing/test_numeric.py
+++ b/pandas/tests/series/indexing/test_numeric.py
@@ -81,7 +81,7 @@ def test_delitem():
     assert_series_equal(s, expected)
 
     # empty
-    s = Series()
+    s = Series(dtype='float')
 
     def f():
         del s[0]

--- a/pandas/tests/series/test_analytics.py
+++ b/pandas/tests/series/test_analytics.py
@@ -38,7 +38,7 @@ class TestSeriesAnalytics(TestData):
         with pd.option_context("use_bottleneck", use_bottleneck):
             # GH 9422 / 18921
             # Entirely empty
-            s = Series([])
+            s = Series([], dtype='float')
             # NA by default
             result = getattr(s, method)()
             assert result == unit
@@ -228,7 +228,7 @@ class TestSeriesAnalytics(TestData):
     def test_mode(self):
         # No mode should be found.
         exp = Series([], dtype=np.float64)
-        tm.assert_series_equal(Series([]).mode(), exp)
+        tm.assert_series_equal(Series([], dtype='float').mode(), exp)
 
         exp = Series([1], dtype=np.int64)
         tm.assert_series_equal(Series([1]).mode(), exp)
@@ -1292,7 +1292,8 @@ class TestSeriesAnalytics(TestData):
         result = s.isin(s[0:2])
         assert_series_equal(result, expected)
 
-    @pytest.mark.parametrize("empty", [[], Series(), np.array([])])
+    @pytest.mark.parametrize("empty", [[], Series(dtype='float'),
+                             np.array([])])
     def test_isin_empty(self, empty):
         # see gh-16991
         s = Series(["a", "b"])

--- a/pandas/tests/series/test_api.py
+++ b/pandas/tests/series/test_api.py
@@ -269,7 +269,7 @@ class TestSeriesMisc(TestData, SharedWithSparse):
         pd.MultiIndex.from_tuples(lzip([0, 1, 2, 3], 'EFGH')), ])
     def test_index_tab_completion(self, index):
         # dir contains string-like values of the Index.
-        s = pd.Series(index=index)
+        s = pd.Series(index=index, dtype='float')
         dir_s = dir(s)
         for i, x in enumerate(s.index.unique(level=0)):
             if i < 100:
@@ -279,7 +279,7 @@ class TestSeriesMisc(TestData, SharedWithSparse):
                 assert x not in dir_s
 
     def test_not_hashable(self):
-        s_empty = Series()
+        s_empty = Series(dtype='float')
         s = Series([1])
         pytest.raises(TypeError, hash, s_empty)
         pytest.raises(TypeError, hash, s)
@@ -456,10 +456,11 @@ class TestSeriesMisc(TestData, SharedWithSparse):
             s.str.repeat(2)
 
     def test_empty_method(self):
-        s_empty = pd.Series()
+        s_empty = pd.Series(dtype='float')
         assert s_empty.empty
 
-        for full_series in [pd.Series([1]), pd.Series(index=[1])]:
+        for full_series in [pd.Series([1]),
+                            pd.Series(index=[1], dtype='float')]:
             assert not full_series.empty
 
     def test_tab_complete_warning(self, ip):
@@ -467,7 +468,7 @@ class TestSeriesMisc(TestData, SharedWithSparse):
         pytest.importorskip('IPython', minversion="6.0.0")
         from IPython.core.completer import provisionalcompleter
 
-        code = "import pandas as pd; s = pd.Series()"
+        code = "import pandas as pd; s = pd.Series(dtype='float')"
         ip.run_code(code)
         with tm.assert_produces_warning(None):
             with provisionalcompleter('ignore'):

--- a/pandas/tests/series/test_apply.py
+++ b/pandas/tests/series/test_apply.py
@@ -39,7 +39,7 @@ class TestSeriesApply(TestData):
         assert s.name == rs.name
 
         # index but no data
-        s = Series(index=[1, 2, 3])
+        s = Series(index=[1, 2, 3], dtype='float')
         rs = s.apply(lambda x: x)
         tm.assert_series_equal(s, rs)
 
@@ -388,10 +388,14 @@ class TestSeriesMap(TestData):
 
     @pytest.mark.parametrize("index", tm.all_index_generator(10))
     def test_map_empty(self, index):
-        s = Series(index)
+        if len(index) == 0:
+            dtype = 'float'
+        else:
+            dtype = None
+        s = Series(index, dtype=dtype)
         result = s.map({})
 
-        expected = pd.Series(np.nan, index=s.index)
+        expected = pd.Series(np.nan, index=s.index, dtype='float')
         tm.assert_series_equal(result, expected)
 
     def test_map_compat(self):

--- a/pandas/tests/series/test_combine_concat.py
+++ b/pandas/tests/series/test_combine_concat.py
@@ -92,7 +92,7 @@ class TestSeriesCombine(TestData):
 
         # corner case
         s = Series([1., 2, 3], index=[0, 1, 2])
-        result = s.combine_first(Series([], index=[]))
+        result = s.combine_first(Series([], index=[], dtype='float'))
         assert_series_equal(s, result)
 
     def test_update(self):

--- a/pandas/tests/series/test_constructors.py
+++ b/pandas/tests/series/test_constructors.py
@@ -115,6 +115,10 @@ class TestSeriesConstructors(TestData):
             empty2 = Series('', index=range(3))
             assert_series_equal(empty, empty2)
 
+    def test_constructor_empty_warns(self):
+        # https://github.com/pandas-dev/pandas/issues/17261
+        with tm.assert_produces_warning(FutureWarning):
+            pd.Series([])
     @pytest.mark.parametrize('input_arg', [np.nan, float('nan')])
     def test_constructor_nan(self, input_arg):
         empty = Series(dtype='float64', index=lrange(10))

--- a/pandas/tests/series/test_dtypes.py
+++ b/pandas/tests/series/test_dtypes.py
@@ -230,7 +230,9 @@ class TestSeriesDtypes(TestData):
 
         # GH16717
         # if dtypes provided is empty, it should error
-        dt5 = dtype_class({})
+        with warnings.catch_warnings(record=True):
+            # ignore empty series dtype warning
+            dt5 = dtype_class({})
         with pytest.raises(KeyError):
             s.astype(dt5)
 

--- a/pandas/tests/series/test_missing.py
+++ b/pandas/tests/series/test_missing.py
@@ -57,7 +57,7 @@ class TestSeriesMissingData(TestData):
     def test_remove_na_deprecation(self):
         # see gh-16971
         with tm.assert_produces_warning(FutureWarning):
-            remove_na(Series([]))
+            remove_na(Series([], dtype='float'))
 
     def test_timedelta_fillna(self):
         # GH 3371
@@ -516,7 +516,7 @@ class TestSeriesMissingData(TestData):
         assert_series_equal(result, expected)
         result = s1.fillna({})
         assert_series_equal(result, s1)
-        result = s1.fillna(Series(()))
+        result = s1.fillna(Series((), dtype='float'))
         assert_series_equal(result, s1)
         result = s2.fillna(s1)
         assert_series_equal(result, s2)
@@ -637,7 +637,7 @@ class TestSeriesMissingData(TestData):
         #     assert_series_equal(selector, expected)
 
     def test_dropna_empty(self):
-        s = Series([])
+        s = Series([], dtype='float')
         assert len(s.dropna()) == 0
         s.dropna(inplace=True)
         assert len(s) == 0
@@ -916,7 +916,7 @@ class TestSeriesInterpolateData(TestData):
         s = Series([np.nan, np.nan])
         assert_series_equal(s.interpolate(**kwargs), s)
 
-        s = Series([]).interpolate()
+        s = Series([], dtype='float').interpolate()
         assert_series_equal(s.interpolate(**kwargs), s)
 
     def test_interpolate_index_values(self):

--- a/pandas/tests/series/test_operators.py
+++ b/pandas/tests/series/test_operators.py
@@ -406,11 +406,11 @@ class TestSeriesComparisons(object):
         # filling
 
         # vs empty
-        result = a & Series([])
+        result = a & Series([], dtype='float')
         expected = Series([False, False, False], list('bca'))
         assert_series_equal(result, expected)
 
-        result = a | Series([])
+        result = a | Series([], dtype='float')
         expected = Series([True, False, True], list('bca'))
         assert_series_equal(result, expected)
 
@@ -425,7 +425,7 @@ class TestSeriesComparisons(object):
 
         # identity
         # we would like s[s|e] == s to hold for any e, whether empty or not
-        for e in [Series([]), Series([1], ['z']),
+        for e in [Series([], dtype='float'), Series([1], ['z']),
                   Series(np.nan, b.index), Series(np.nan, a.index)]:
             result = a[a | e]
             assert_series_equal(result, a[a])
@@ -1403,7 +1403,7 @@ class TestSeriesOperators(TestData):
         s_tft = Series([True, False, True], index=index)
         s_fff = Series([False, False, False], index=index)
         s_tff = Series([True, False, False], index=index)
-        s_empty = Series([])
+        s_empty = Series([], dtype='float')
 
         # TODO: unused
         # s_0101 = Series([0, 1, 0, 1])
@@ -1538,12 +1538,12 @@ class TestSeriesOperators(TestData):
     def test_operators_corner(self):
         series = self.ts
 
-        empty = Series([], index=Index([]))
+        empty = Series([], index=Index([]), dtype='float')
 
         result = series + empty
         assert np.isnan(result).all()
 
-        result = empty + Series([], index=Index([]))
+        result = empty + Series([], index=Index([]), dtype='float')
         assert len(result) == 0
 
         # TODO: this returned NotImplemented earlier, what to do?
@@ -1685,7 +1685,7 @@ class TestSeriesOperators(TestData):
     @pytest.mark.parametrize(
         "test_input,error_type",
         [
-            (pd.Series([]), ValueError),
+            (pd.Series([], dtype='float'), ValueError),
 
             # For strings, or any Series with dtype 'O'
             (pd.Series(['foo', 'bar', 'baz']), TypeError),

--- a/pandas/tests/series/test_quantile.py
+++ b/pandas/tests/series/test_quantile.py
@@ -64,7 +64,7 @@ class TestSeriesQuantile(TestData):
 
         result = self.ts.quantile([])
         expected = pd.Series([], name=self.ts.name, index=Index(
-            [], dtype=float))
+            [], dtype=float), dtype=float)
         tm.assert_series_equal(result, expected)
 
     def test_quantile_interpolation(self):
@@ -100,7 +100,7 @@ class TestSeriesQuantile(TestData):
         assert result == expected
 
         # all nan/empty
-        cases = [Series([]), Series([np.nan, np.nan])]
+        cases = [Series([], dtype='float'), Series([np.nan, np.nan])]
 
         for s in cases:
             res = s.quantile(0.5)

--- a/pandas/tests/series/test_replace.py
+++ b/pandas/tests/series/test_replace.py
@@ -227,7 +227,7 @@ class TestSeriesReplace(TestData):
         # GH 15289
         s = pd.Series(list('abcd'))
         tm.assert_series_equal(s, s.replace(dict()))
-        tm.assert_series_equal(s, s.replace(pd.Series([])))
+        tm.assert_series_equal(s, s.replace(pd.Series([], dtype='float')))
 
     def test_replace_string_with_number(self):
         # GH 15743

--- a/pandas/tests/series/test_repr.py
+++ b/pandas/tests/series/test_repr.py
@@ -56,7 +56,8 @@ class TestSeriesRepr(TestData):
         s.name = None
         assert "Name:" not in repr(s)
 
-        s = Series(index=date_range('20010101', '20020101'), name='test')
+        s = Series(index=date_range('20010101', '20020101'), name='test',
+                   dtype='float')
         assert "Name: test" in repr(s)
 
     def test_repr(self):

--- a/pandas/tests/series/test_sorting.py
+++ b/pandas/tests/series/test_sorting.py
@@ -158,8 +158,8 @@ class TestSeriesSorting(TestData):
 
     def test_sort_index_kind(self):
         # GH #14444 & #13589:  Add support for sort algo choosing
-        series = Series(index=[3, 2, 1, 4, 3])
-        expected_series = Series(index=[1, 2, 3, 3, 4])
+        series = Series(index=[3, 2, 1, 4, 3], dtype='float')
+        expected_series = Series(index=[1, 2, 3, 3, 4], dtype='float')
 
         index_sorted_series = series.sort_index(kind='mergesort')
         assert_series_equal(expected_series, index_sorted_series)
@@ -171,13 +171,15 @@ class TestSeriesSorting(TestData):
         assert_series_equal(expected_series, index_sorted_series)
 
     def test_sort_index_na_position(self):
-        series = Series(index=[3, 2, 1, 4, 3, np.nan])
+        series = Series(index=[3, 2, 1, 4, 3, np.nan], dtype='float')
 
-        expected_series_first = Series(index=[np.nan, 1, 2, 3, 3, 4])
+        expected_series_first = Series(index=[np.nan, 1, 2, 3, 3, 4],
+                                       dtype='float')
         index_sorted_series = series.sort_index(na_position='first')
         assert_series_equal(expected_series_first, index_sorted_series)
 
-        expected_series_last = Series(index=[1, 2, 3, 3, 4, np.nan])
+        expected_series_last = Series(index=[1, 2, 3, 3, 4, np.nan],
+                                      dtype='float')
         index_sorted_series = series.sort_index(na_position='last')
         assert_series_equal(expected_series_last, index_sorted_series)
 

--- a/pandas/tests/series/test_timeseries.py
+++ b/pandas/tests/series/test_timeseries.py
@@ -284,7 +284,7 @@ class TestTimeSeries(TestData):
     def test_asfreq_datetimeindex_empty_series(self):
         # GH 14320
         expected = Series(index=pd.DatetimeIndex(
-            ["2016-09-29 11:00"])).asfreq('H')
+            ["2016-09-29 11:00"]), dtype='float').asfreq('H')
         result = Series(index=pd.DatetimeIndex(["2016-09-29 11:00"]),
                         data=[3]).asfreq('H')
         tm.assert_index_equal(expected.index, result.index)
@@ -372,7 +372,7 @@ class TestTimeSeries(TestData):
                                         limit=limit)
         assert_series_equal(rs_freq, rs_periods)
 
-        empty_ts = Series(index=self.ts.index)
+        empty_ts = Series(index=self.ts.index, dtype='float')
         rs_freq = empty_ts.pct_change(freq=freq,
                                       fill_method=fill_method,
                                       limit=limit)
@@ -423,12 +423,12 @@ class TestTimeSeries(TestData):
         assert ts.last_valid_index() is None
         assert ts.first_valid_index() is None
 
-        ser = Series([], index=[])
+        ser = Series([], index=[], dtype='float')
         assert ser.last_valid_index() is None
         assert ser.first_valid_index() is None
 
         # GH12800
-        empty = Series()
+        empty = Series(dtype='float')
         assert empty.last_valid_index() is None
         assert empty.first_valid_index() is None
 

--- a/pandas/tests/series/test_timezones.py
+++ b/pandas/tests/series/test_timezones.py
@@ -64,7 +64,7 @@ class TestSeriesTimezones(object):
     @pytest.mark.parametrize('tzstr', ['US/Eastern', 'dateutil/US/Eastern'])
     def test_series_tz_localize_empty(self, tzstr):
         # GH#2248
-        ser = Series()
+        ser = Series(dtype='float')
 
         ser2 = ser.tz_localize('utc')
         assert ser2.index.tz == pytz.utc

--- a/pandas/tests/test_algos.py
+++ b/pandas/tests/test_algos.py
@@ -585,7 +585,8 @@ class TestIsin(object):
         result = algos.isin(Sd, St)
         tm.assert_numpy_array_equal(expected, result)
 
-    @pytest.mark.parametrize("empty", [[], Series(), np.array([])])
+    @pytest.mark.parametrize("empty", [[], Series(dtype='float'),
+                             np.array([])])
     def test_empty(self, empty):
         # see gh-16991
         vals = Index(["a", "b"])

--- a/pandas/tests/test_multilevel.py
+++ b/pandas/tests/test_multilevel.py
@@ -1979,7 +1979,7 @@ Thur,Lunch,Yes,51.51,17"""
         s2 = Series([
             1, 2, 3, 4
         ], index=MultiIndex.from_tuples([(1, 2), (1, 3), (3, 2), (3, 4)]))
-        s3 = Series()
+        s3 = Series(dtype='float')
 
         # it works!
         DataFrame({'foo': s1, 'bar': s2, 'baz': s3})

--- a/pandas/tests/test_register_accessor.py
+++ b/pandas/tests/test_register_accessor.py
@@ -86,4 +86,4 @@ def test_raises_attribute_error():
                 raise AttributeError("whoops")
 
         with tm.assert_raises_regex(AttributeError, "whoops"):
-            pd.Series([]).bad
+            pd.Series([], dtype='float').bad

--- a/pandas/tests/test_window.py
+++ b/pandas/tests/test_window.py
@@ -933,7 +933,7 @@ class TestMoments(Base):
         assert np.isnan(result).all()
 
         # empty
-        vals = pd.Series([])
+        vals = pd.Series([], dtype='float')
         result = vals.rolling(5, center=True, win_type='boxcar').mean()
         assert len(result) == 0
 
@@ -1663,9 +1663,10 @@ class TestMoments(Base):
                 assert not result[11:].isna().any()
 
             # check series of length 0
-            result = getattr(Series().ewm(com=50, min_periods=min_periods),
-                             name)()
-            tm.assert_series_equal(result, Series())
+            result = getattr(
+                Series(dtype='float').ewm(com=50, min_periods=min_periods),
+                name)()
+            tm.assert_series_equal(result, Series(dtype='float'))
 
             # check series of length 1
             result = getattr(Series([1.]).ewm(50, min_periods=min_periods),
@@ -1842,7 +1843,7 @@ class TestPairwise(object):
 # create the data only once as we are not setting it
 def _create_consistency_data():
     def create_series():
-        return [Series(),
+        return [Series(dtype='float'),
                 Series([np.nan]),
                 Series([np.nan, np.nan]),
                 Series([3.]),
@@ -2667,7 +2668,7 @@ class TestMomentsConsistency(Base):
 
     def test_moment_functions_zero_length(self):
         # GH 8056
-        s = Series()
+        s = Series(dtype='float')
         s_expected = s
         df1 = DataFrame()
         df1_expected = df1

--- a/pandas/tests/util/test_hashing.py
+++ b/pandas/tests/util/test_hashing.py
@@ -152,7 +152,7 @@ class TestHashing(object):
                     Series(['a', np.nan, 'c']),
                     Series(['a', None, 'c']),
                     Series([True, False, True]),
-                    Series(),
+                    Series(dtype='float'),
                     Index([1, 2, 3]),
                     Index([True, False, True]),
                     DataFrame({'x': ['a', 'b', 'c'], 'y': [1, 2, 3]}),


### PR DESCRIPTION
We're changing `Series([])` to be `object` instead of `float`. This does the warning

- [x] xref https://github.com/pandas-dev/pandas/issues/17261 (leave open till we make the change)
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry
