### PR TITLE
PERF: Fixed regression in Series(index=idx) constructor

### DIFF
--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -318,7 +318,9 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
         # Now we just make sure the order is respected, if any
         if data and index is not None:
             s = s.reindex(index, copy=False)
-        elif not PY36 and not isinstance(data, OrderedDict):
+        elif not PY36 and not isinstance(data, OrderedDict) and data:
+            # Need the `and data` to avoid sorting Series(None, index=[...])
+            # since that isn't really dict-like
             try:
                 s = s.sort_index()
             except TypeError:

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -41,7 +41,11 @@ from pandas.core.dtypes.cast import (
     maybe_cast_to_datetime, maybe_castable,
     construct_1d_arraylike_from_scalar,
     construct_1d_object_array_from_listlike)
-from pandas.core.dtypes.missing import isna, notna, remove_na_arraylike
+from pandas.core.dtypes.missing import (
+    isna,
+    notna,
+    remove_na_arraylike,
+    na_value_for_dtype)
 
 from pandas.core.index import (Index, MultiIndex, InvalidIndexError,
                                Float64Index, _ensure_index)
@@ -219,7 +223,7 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
             elif isinstance(data, dict):
                 # Same as previous block, but special cased for data=None,
                 # for performance when creating empty arrays.
-                data = np.nan
+                data = na_value_for_dtype(dtype)
 
             elif isinstance(data, SingleBlockManager):
                 if index is None:

--- a/pandas/tests/series/test_constructors.py
+++ b/pandas/tests/series/test_constructors.py
@@ -133,6 +133,10 @@ class TestSeriesConstructors(TestData):
         assert result.dtype == dtype
         assert len(result) == 0
 
+    def test_constructor_no_data_index_order(self):
+        result = pd.Series(index=['b', 'a', 'c'])
+        assert result.index.tolist() == ['b', 'a', 'c']
+
     def test_constructor_series(self):
         index1 = ['d', 'b', 'a', 'c']
         index2 = sorted(index1)

--- a/pandas/tests/series/test_constructors.py
+++ b/pandas/tests/series/test_constructors.py
@@ -122,6 +122,17 @@ class TestSeriesConstructors(TestData):
 
         assert_series_equal(empty, empty2, check_index_type=False)
 
+    @pytest.mark.parametrize('dtype', [
+        'f8', 'i8', 'M8[ns]', 'm8[ns]', 'category', 'object',
+        'datetime64[ns, UTC]',
+    ])
+    @pytest.mark.parametrize('index', [None, pd.Index([])])
+    def test_constructor_dtype_only(self, dtype, index):
+        # GH-20865
+        result = pd.Series(dtype=dtype, index=index)
+        assert result.dtype == dtype
+        assert len(result) == 0
+
     def test_constructor_series(self):
         index1 = ['d', 'b', 'a', 'c']
         index2 = sorted(index1)


### PR DESCRIPTION
From https://github.com/pandas-dev/pandas/pull/18496/

Special cases empty series construction, since the reindex is not necessary.

xref https://github.com/pandas-dev/pandas/issues/18532#issuecomment-385190350

Setup

```python
data = None
idx = date_range(start=datetime(2015, 10, 26),
                              end=datetime(2016, 1, 1),
                              freq='50s')
dict_data = dict(zip(idx, range(len(idx))))
data = None if data is None else dict_data
```

benchmark

```
%timeit out = Series(data, index=idx)
```

HEAD:

```
113 µs ± 6.22 µs per loop (mean ± std. dev. of 7 runs, 10000 loops each)
```

0.21.0

```
96.5 µs ± 6.05 µs per loop (mean ± std. dev. of 7 runs, 10000 loops each)
```

Master

```
320 ms ± 11.3 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
```