### PR TITLE
DOC: Link to new PyPI instead of legacy PyPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 <tr>
   <td>Latest Release</td>
   <td>
-    <a href="https://pypi.python.org/pypi/pandas/">
+    <a href="https://pypi.org/project/pandas/">
     <img src="https://img.shields.io/pypi/v/pandas.svg" alt="latest release" />
     </a>
   </td>
@@ -25,7 +25,7 @@
 <tr>
   <td>Package Status</td>
   <td>
-		<a href="https://pypi.python.org/pypi/pandas/">
+		<a href="https://pypi.org/project/pandas/">
 		<img src="https://img.shields.io/pypi/status/pandas.svg" alt="status" /></td>
 		</a>
 </tr>
@@ -158,7 +158,7 @@ The source code is currently hosted on GitHub at:
 https://github.com/pandas-dev/pandas
 
 Binary installers for the latest released version are available at the [Python
-package index](https://pypi.python.org/pypi/pandas) and on conda.
+package index](https://pypi.org/project/pandas) and on conda.
 
 ```sh
 # conda

--- a/doc/source/contributing.rst
+++ b/doc/source/contributing.rst
@@ -473,7 +473,7 @@ Here are *some* of the more common ``cpplint`` issues:
   - every header file must include a header guard to avoid name collisions if re-included
 
 :ref:`Continuous Integration <contributing.ci>` will run the
-`cpplint <https://pypi.python.org/pypi/cpplint>`_ tool
+`cpplint <https://pypi.org/project/cpplint>`_ tool
 and report any stylistic errors in your code. Therefore, it is helpful before
 submitting code to run the check yourself::
 
@@ -521,7 +521,7 @@ the more common ``PEP8`` issues:
   - passing arguments should have spaces after commas, e.g. ``foo(arg1, arg2, kw1='bar')``
 
 :ref:`Continuous Integration <contributing.ci>` will run
-the `flake8 <http://pypi.python.org/pypi/flake8>`_ tool
+the `flake8 <https://pypi.org/project/flake8>`_ tool
 and report any stylistic errors in your code. Therefore, it is helpful before
 submitting code to run the check yourself on the diff::
 
@@ -798,7 +798,7 @@ Or with one of the following constructs::
     pytest pandas/tests/[test-module].py::[TestClass]
     pytest pandas/tests/[test-module].py::[TestClass]::[test_method]
 
-Using `pytest-xdist <https://pypi.python.org/pypi/pytest-xdist>`_, one can
+Using `pytest-xdist <https://pypi.org/project/pytest-xdist>`_, one can
 speed up local testing on multicore machines. To use this feature, you will
 need to install `pytest-xdist` via::
 

--- a/doc/source/index.rst.template
+++ b/doc/source/index.rst.template
@@ -12,7 +12,7 @@ pandas: powerful Python data analysis toolkit
 
 **Date**: |today| **Version**: |version|
 
-**Binary Installers:** http://pypi.python.org/pypi/pandas
+**Binary Installers:** https://pypi.org/project/pandas
 
 **Source Repository:** http://github.com/pandas-dev/pandas
 

--- a/doc/source/install.rst
+++ b/doc/source/install.rst
@@ -12,7 +12,7 @@ cross platform distribution for data analysis and scientific computing.
 This is the recommended installation method for most users.
 
 Instructions for installing from source,
-`PyPI <http://pypi.python.org/pypi/pandas>`__, `ActivePython <https://www.activestate.com/activepython/downloads>`__, various Linux distributions, or a
+`PyPI <https://pypi.org/project/pandas>`__, `ActivePython <https://www.activestate.com/activepython/downloads>`__, various Linux distributions, or a
 `development version <http://github.com/pandas-dev/pandas>`__ are also provided.
 
 .. _install.dropping-27:
@@ -153,7 +153,7 @@ Installing from PyPI
 ~~~~~~~~~~~~~~~~~~~~
 
 pandas can be installed via pip from
-`PyPI <http://pypi.python.org/pypi/pandas>`__.
+`PyPI <https://pypi.org/project/pandas>`__.
 
 ::
 
@@ -258,7 +258,7 @@ Optional Dependencies
 * `xarray <http://xarray.pydata.org>`__: pandas like handling for > 2 dims, needed for converting Panels to xarray objects. Version 0.7.0 or higher is recommended.
 * `PyTables <http://www.pytables.org>`__: necessary for HDF5-based storage. Version 3.0.0 or higher required, Version 3.2.1 or higher highly recommended.
 * `Feather Format <https://github.com/wesm/feather>`__: necessary for feather-based storage, version 0.3.1 or higher.
-* `Apache Parquet <https://parquet.apache.org/>`__, either `pyarrow <http://arrow.apache.org/docs/python/>`__ (>= 0.4.1) or `fastparquet <https://fastparquet.readthedocs.io/en/latest>`__ (>= 0.0.6) for parquet-based storage. The `snappy <https://pypi.python.org/pypi/python-snappy>`__ and `brotli <https://pypi.python.org/pypi/brotlipy>`__ are available for compression support.
+* `Apache Parquet <https://parquet.apache.org/>`__, either `pyarrow <http://arrow.apache.org/docs/python/>`__ (>= 0.4.1) or `fastparquet <https://fastparquet.readthedocs.io/en/latest>`__ (>= 0.0.6) for parquet-based storage. The `snappy <https://pypi.org/project/python-snappy>`__ and `brotli <https://pypi.org/project/brotlipy>`__ are available for compression support.
 * `SQLAlchemy <http://www.sqlalchemy.org>`__: for SQL database support. Version 0.8.1 or higher recommended. Besides SQLAlchemy, you also need a database specific driver. You can find an overview of supported drivers for each SQL dialect in the `SQLAlchemy docs <http://docs.sqlalchemy.org/en/latest/dialects/index.html>`__. Some common drivers are:
 
   * `psycopg2 <http://initd.org/psycopg/>`__: for PostgreSQL
@@ -271,11 +271,11 @@ Optional Dependencies
   * `xlrd/xlwt <http://www.python-excel.org/>`__: Excel reading (xlrd) and writing (xlwt)
   * `openpyxl <http://https://openpyxl.readthedocs.io/en/default/>`__: openpyxl version 2.4.0
     for writing .xlsx files (xlrd >= 0.9.0)
-  * `XlsxWriter <https://pypi.python.org/pypi/XlsxWriter>`__: Alternative Excel writer
+  * `XlsxWriter <https://pypi.org/project/XlsxWriter>`__: Alternative Excel writer
 
 * `Jinja2 <http://jinja.pocoo.org/>`__: Template engine for conditional HTML formatting.
 * `s3fs <http://s3fs.readthedocs.io/>`__: necessary for Amazon S3 access (s3fs >= 0.0.7).
-* `blosc <https://pypi.python.org/pypi/blosc>`__: for msgpack compression using ``blosc``
+* `blosc <https://pypi.org/project/blosc>`__: for msgpack compression using ``blosc``
 * One of
   `qtpy  <https://github.com/spyder-ide/qtpy>`__ (requires PyQt or PySide),
   `PyQt5 <https://www.riverbankcomputing.com/software/pyqt/download5>`__,
@@ -287,7 +287,7 @@ Optional Dependencies
 * `pandas-gbq <https://pandas-gbq.readthedocs.io/en/latest/install.html#dependencies>`__: for Google BigQuery I/O.
 
 
-* `Backports.lzma <https://pypi.python.org/pypi/backports.lzma/>`__: Only for Python 2, for writing to and/or reading from an xz compressed DataFrame in CSV; Python 3 support is built into the standard library.
+* `Backports.lzma <https://pypi.org/project/backports.lzma/>`__: Only for Python 2, for writing to and/or reading from an xz compressed DataFrame in CSV; Python 3 support is built into the standard library.
 * One of the following combinations of libraries is needed to use the
   top-level :func:`~pandas.read_html` function:
 

--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -34,7 +34,7 @@ analysis / manipulation tool available in any language.
 **Where to get it**
 
 * Source code: http://github.com/pandas-dev/pandas
-* Binary installers on PyPI: http://pypi.python.org/pypi/pandas
+* Binary installers on PyPI: https://pypi.org/project/pandas
 * Documentation: http://pandas.pydata.org
 
 pandas 0.22.0

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -1892,7 +1892,7 @@ class DataFrame(NDFrame):
         Notes
         -----
         This function requires either the `fastparquet
-        <https://pypi.python.org/pypi/fastparquet>`_ or `pyarrow
+        <https://pypi.org/project/fastparquet>`_ or `pyarrow
         <https://arrow.apache.org/docs/python/>`_ library.
 
         Examples

--- a/pandas/io/clipboard/__init__.py
+++ b/pandas/io/clipboard/__init__.py
@@ -71,7 +71,7 @@ def determine_clipboard():
         try:
             # qtpy is a small abstraction layer that lets you write
             # applications using a single api call to either PyQt or PySide
-            # https://pypi.python.org/pypi/QtPy
+            # https://pypi.org/project/QtPy
             import qtpy  # noqa
         except ImportError:
             # If qtpy isn't installed, fall back on importing PyQt5, or PyQt5

--- a/versioneer.py
+++ b/versioneer.py
@@ -12,7 +12,7 @@ The Versioneer
 * Compatible With: python2.6, 2.7, 3.2, 3.3, 3.4, and pypy
 * [![Latest Version]
 (https://pypip.in/version/versioneer/badge.svg?style=flat)
-](https://pypi.python.org/pypi/versioneer/)
+](https://pypi.org/project/versioneer/)
 * [![Build Status]
 (https://travis-ci.org/warner/python-versioneer.png?branch=master)
 ](https://travis-ci.org/warner/python-versioneer)


### PR DESCRIPTION
The new PyPI site has [officially launched](https://pythoninsider.blogspot.ca/2018/04/new-pypi-launched-legacy-pypi-shutting.html), and they've recommended [linking to the new site](https://warehouse.readthedocs.io/api-reference/integration-guide/#migrating-to-the-new-pypi).

Links to the legacy site are currently redirecting to the new site, so the content of what users will actually see isn't different than with the existing links, but seems best to avoid the redirect.
