### PR TITLE
BUG: Fix #20744. loffset ignored in resample ffill

### DIFF
--- a/doc/source/whatsnew/v0.23.0.txt
+++ b/doc/source/whatsnew/v0.23.0.txt
@@ -1203,6 +1203,7 @@ Groupby/Resample/Rolling
 - Bug in :func:`DataFrameGroupBy.cumsum` and :func:`DataFrameGroupBy.cumprod` when ``skipna`` was passed (:issue:`19806`)
 - Bug in :func:`DataFrame.resample` that dropped timezone information (:issue:`13238`)
 - Bug in :func:`DataFrame.groupby` where transformations using ``np.all`` and ``np.any`` were raising a ``ValueError`` (:issue:`20653`)
+- Bug in :func:`DataFrame.resample` where ``ffill``, ``bfill``, ``pad``, ``backfill``, ``fillna``, ``interpolate``, and ``asfreq`` were ignoring ``loffset``. (:issue:`20744`)
 
 Sparse
 ^^^^^^

--- a/pandas/core/resample.py
+++ b/pandas/core/resample.py
@@ -967,6 +967,7 @@ class DatetimeIndexResampler(Resampler):
             result = obj.reindex(res_index, method=method,
                                  limit=limit, fill_value=fill_value)
 
+        result = self._apply_loffset(result)
         return self._wrap_result(result)
 
     def _wrap_result(self, result):

--- a/pandas/tests/test_resample.py
+++ b/pandas/tests/test_resample.py
@@ -1182,6 +1182,19 @@ class TestDatetimeIndex(Base):
         expected = ser.resample('w-sun', loffset=-bday).last()
         assert result.index[0] - bday == expected.index[0]
 
+    def test_resample_loffset_upsample(self):
+        # GH 20744
+        rng = date_range('1/1/2000 00:00:00', '1/1/2000 00:13:00', freq='min')
+        s = Series(np.random.randn(14), index=rng)
+
+        result = s.resample('5min', closed='right', label='right',
+                            loffset=timedelta(minutes=1)).ffill()
+        idx = date_range('1/1/2000', periods=4, freq='5min')
+        expected = Series([s[0], s[5], s[10], s[-1]],
+                          index=idx + timedelta(minutes=1))
+
+        assert_series_equal(result, expected)
+
     def test_resample_loffset_count(self):
         # GH 12725
         start_time = '1/1/2000 00:00:00'


### PR DESCRIPTION
- [x] closes #20744 
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry

This replaces pull request #20867 