### PR TITLE
DOC: improve the shared docstring of Series.str.strip()

### DIFF
--- a/pandas/core/strings.py
+++ b/pandas/core/strings.py
@@ -2151,12 +2151,49 @@ class StringMethods(NoNewAttributesMixin):
         return self._wrap_result(result)
 
     _shared_docs['str_strip'] = ("""
-    Strip whitespace (including newlines) from each string in the
-    Series/Index from %(side)s. Equivalent to :meth:`str.%(method)s`.
+    Strip combinations of characters from the %(side)s of strings.
+
+    Operates on each element in the given String/Index, and is equivalent to
+    :meth:`str.%(method)s`.
+
+    Parameters
+    ----------
+    to_strip : str or unicode, optional
+        String or unicode specifying the set of characters to be removed from
+        the %(side)s. If omitted or None, the strip method defaults to removing
+        whitespace and newlines.
 
     Returns
     -------
     stripped : Series/Index of objects
+
+    See Also
+    --------
+    Series.str.strip : Removes defined characters from both sides
+    Series.str.lstrip : Removes defined characters from the left side
+    Series.str.rstrip : Removes defined characters from the right side
+
+    Examples
+    --------
+    >>> s = pd.Series(data=['   spacious   ', '__-left_foo',
+    ...                     '-__center_foo__-', 'right_foo-__'])
+    >>> s.str.strip()[0]
+    'spacious'
+
+    Rather than string matching, all combinations of the `to_strip` parameter's
+    characters are removed.
+
+    >>> s.str.lstrip("-_")[1:]
+    1         left_foo
+    2    center_foo__-
+    3     right_foo-__
+    dtype: object
+
+    >>> s.str.rstrip("-_")[1:]
+    1      __-left_foo
+    2    -__center_foo
+    3        right_foo
+    dtype: object
     """)
 
     @Appender(_shared_docs['str_strip'] % dict(side='left and right sides',


### PR DESCRIPTION
- [ ] closes #xxxx
- [ ] tests added / passed
- [X] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

Docstring written with @jalammar as part of the pandas sprint at PyData London 2018, guided by @datapythonista. Wasn't too sure of the "Return" definition, so we defaulted to the one written for str_strip. Docstring is shared by the strip, lstrip, and rstrip methods, and validate_docstrings.py script output for the "script" variant is included below: 

################################################################################
##################### Docstring (pandas.Series.str.strip)  #####################
################################################################################

Strip combinations of characters from the left and right sides of strings.

Operates on each element in the given String/Index, and is equivalent to
:meth:`str.strip`.

Parameters
----------
to_strip : str or unicode, optional
    String or unicode specifying the set of characters to be removed from
    the left and right sides. If omitted or None, the strip method defaults to removing
    whitespace and newlines.

Returns
-------
stripped : Series/Index of objects

See Also
--------
Series.str.strip : Removes defined characters from both sides
Series.str.lstrip : Removes defined characters from the left side
Series.str.rstrip : Removes defined characters from the right side

Examples
--------
>>> s = pd.Series(data=['   spacious   ', '__-left_foo',
...                     '-__center_foo__-', 'right_foo-__'])
>>> s.str.strip()[0]
'spacious'

Rather than string matching, all combinations of the `to_strip` parameter's
characters are removed.

>>> s.str.lstrip("-_")[1:]
1         left_foo
2    center_foo__-
3     right_foo-__
dtype: object

>>> s.str.rstrip("-_")[1:]
1      __-left_foo
2    -__center_foo
3        right_foo
dtype: object

################################################################################
################################## Validation ##################################
################################################################################

Docstring for "pandas.Series.str.strip" correct. :)





