### PR TITLE
BUG: DatetimeIndex._data should return an ndarray

### DIFF
--- a/doc/source/whatsnew/v0.23.0.txt
+++ b/doc/source/whatsnew/v0.23.0.txt
@@ -996,7 +996,6 @@ Other API Changes
 - :func:`DataFrame.to_dict` with ``orient='index'`` no longer casts int columns to float for a DataFrame with only int and float columns (:issue:`18580`)
 - A user-defined-function that is passed to :func:`Series.rolling().aggregate() <pandas.core.window.Rolling.aggregate>`, :func:`DataFrame.rolling().aggregate() <pandas.core.window.Rolling.aggregate>`, or its expanding cousins, will now *always* be passed a ``Series``, rather than a ``np.array``; ``.apply()`` only has the ``raw`` keyword, see :ref:`here <whatsnew_0230.enhancements.window_raw>`. This is consistent with the signatures of ``.aggregate()`` across pandas (:issue:`20584`)
 - Rolling and Expanding types raise ``NotImplementedError`` upon iteration (:issue:`11704`).
-- ``DatetimeIndex._data`` now returns a numpy array in all cases (:issue:`20810`)
 
 .. _whatsnew_0230.deprecations:
 

--- a/doc/source/whatsnew/v0.23.0.txt
+++ b/doc/source/whatsnew/v0.23.0.txt
@@ -996,6 +996,7 @@ Other API Changes
 - :func:`DataFrame.to_dict` with ``orient='index'`` no longer casts int columns to float for a DataFrame with only int and float columns (:issue:`18580`)
 - A user-defined-function that is passed to :func:`Series.rolling().aggregate() <pandas.core.window.Rolling.aggregate>`, :func:`DataFrame.rolling().aggregate() <pandas.core.window.Rolling.aggregate>`, or its expanding cousins, will now *always* be passed a ``Series``, rather than a ``np.array``; ``.apply()`` only has the ``raw`` keyword, see :ref:`here <whatsnew_0230.enhancements.window_raw>`. This is consistent with the signatures of ``.aggregate()`` across pandas (:issue:`20584`)
 - Rolling and Expanding types raise ``NotImplementedError`` upon iteration (:issue:`11704`).
+- ``DatetimeIndex._data`` now returns a numpy array in all cases (:issue:`20810`)
 
 .. _whatsnew_0230.deprecations:
 

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -506,6 +506,9 @@ class Index(IndexOpsMixin, PandasObject):
         attributes.update(kwargs)
         if not len(values) and 'dtype' not in kwargs:
             attributes['dtype'] = self.dtype
+        from pandas import DatetimeIndex
+        if isinstance(values, DatetimeIndex):
+            values = values.values
         return self._simple_new(values, **attributes)
 
     def _shallow_copy_with_infer(self, values=None, **kwargs):

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -41,7 +41,6 @@ from pandas.core.dtypes.common import (
     is_signed_integer_dtype,
     is_unsigned_integer_dtype,
     is_integer_dtype, is_float_dtype,
-    is_datetime64_dtype,
     is_datetime64_any_dtype,
     is_datetime64tz_dtype,
     is_timedelta64_dtype,

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -41,6 +41,7 @@ from pandas.core.dtypes.common import (
     is_signed_integer_dtype,
     is_unsigned_integer_dtype,
     is_integer_dtype, is_float_dtype,
+    is_datetime64_dtype,
     is_datetime64_any_dtype,
     is_datetime64tz_dtype,
     is_timedelta64_dtype,
@@ -509,6 +510,7 @@ class Index(IndexOpsMixin, PandasObject):
 
         # _simple_new expects an ndarray
         values = getattr(values, 'values', values)
+
         return self._simple_new(values, **attributes)
 
     def _shallow_copy_with_infer(self, values=None, **kwargs):

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -506,9 +506,9 @@ class Index(IndexOpsMixin, PandasObject):
         attributes.update(kwargs)
         if not len(values) and 'dtype' not in kwargs:
             attributes['dtype'] = self.dtype
-        from pandas import DatetimeIndex
-        if isinstance(values, DatetimeIndex):
-            values = values.values
+
+        # _simple_new expects an ndarray
+        values = getattr(values, 'values', values)
         return self._simple_new(values, **attributes)
 
     def _shallow_copy_with_infer(self, values=None, **kwargs):

--- a/pandas/core/indexes/datetimes.py
+++ b/pandas/core/indexes/datetimes.py
@@ -525,7 +525,6 @@ class DatetimeIndex(DatetimeArrayMixin, DatelikeOps, TimelikeOps,
                                           freq=freq, name=name)
             else:
                 index = _generate_regular_range(start, end, periods, freq)
-
         else:
 
             if tz is not None:
@@ -549,12 +548,13 @@ class DatetimeIndex(DatetimeArrayMixin, DatelikeOps, TimelikeOps,
                                               freq=freq, name=name)
                 else:
                     index = _generate_regular_range(start, end, periods, freq)
-
                 if tz is not None and getattr(index, 'tz', None) is None:
-                    index = conversion.tz_localize_to_utc(_ensure_int64(index),
-                                                          tz,
-                                                          ambiguous=ambiguous)
-                    index = index.view(_NS_DTYPE)
+                    arr = conversion.tz_localize_to_utc(_ensure_int64(index),
+                                                        tz,
+                                                        ambiguous=ambiguous)
+
+                    arr = arr.view(_NS_DTYPE)
+                    index = DatetimeIndex(arr)
 
                     # index is localized datetime64 array -> have to convert
                     # start/end as well to compare
@@ -575,7 +575,9 @@ class DatetimeIndex(DatetimeArrayMixin, DatelikeOps, TimelikeOps,
             index = index[1:]
         if not right_closed and len(index) and index[-1] == end:
             index = index[:-1]
-        index = cls._simple_new(index, name=name, freq=freq, tz=tz)
+
+        index = cls._simple_new(index.values, name=name, freq=freq, tz=tz)
+
         return index
 
     def _convert_for_op(self, value):
@@ -597,9 +599,6 @@ class DatetimeIndex(DatetimeArrayMixin, DatelikeOps, TimelikeOps,
         we require the we have a dtype compat for the values
         if we are passed a non-dtype compat, then coerce using the constructor
         """
-
-        if isinstance(values, DatetimeIndex):
-            values = values.values
 
         if getattr(values, 'dtype', None) is None:
             # empty, but with dtype compat

--- a/pandas/core/indexes/datetimes.py
+++ b/pandas/core/indexes/datetimes.py
@@ -525,6 +525,7 @@ class DatetimeIndex(DatetimeArrayMixin, DatelikeOps, TimelikeOps,
                                           freq=freq, name=name)
             else:
                 index = _generate_regular_range(start, end, periods, freq)
+
         else:
 
             if tz is not None:
@@ -548,6 +549,7 @@ class DatetimeIndex(DatetimeArrayMixin, DatelikeOps, TimelikeOps,
                                               freq=freq, name=name)
                 else:
                     index = _generate_regular_range(start, end, periods, freq)
+
                 if tz is not None and getattr(index, 'tz', None) is None:
                     arr = conversion.tz_localize_to_utc(_ensure_int64(index),
                                                         tz,
@@ -607,6 +609,8 @@ class DatetimeIndex(DatetimeArrayMixin, DatelikeOps, TimelikeOps,
                 return cls(values, name=name, freq=freq, tz=tz,
                            dtype=dtype, **kwargs)
             values = np.array(values, copy=False)
+
+        assert isinstance(values, np.ndarray)
 
         if is_object_dtype(values):
             return cls(values, name=name, freq=freq, tz=tz,
@@ -1002,7 +1006,7 @@ class DatetimeIndex(DatetimeArrayMixin, DatelikeOps, TimelikeOps,
         else:
             naive = self
         result = super(DatetimeIndex, naive).unique(level=level)
-        return self._simple_new(result, name=self.name, tz=self.tz,
+        return self._simple_new(result.values, name=self.name, tz=self.tz,
                                 freq=self.freq)
 
     def union(self, other):

--- a/pandas/core/indexes/datetimes.py
+++ b/pandas/core/indexes/datetimes.py
@@ -12,7 +12,6 @@ from pandas.core.base import _shared_docs
 from pandas.core.dtypes.common import (
     _INT64_DTYPE,
     _NS_DTYPE,
-    is_object_dtype,
     is_datetime64_dtype,
     is_datetimetz,
     is_dtype_equal,
@@ -556,7 +555,6 @@ class DatetimeIndex(DatetimeArrayMixin, DatelikeOps, TimelikeOps,
                                                         ambiguous=ambiguous)
 
                     index = DatetimeIndex(arr)
-
 
                     # index is localized datetime64 array -> have to convert
                     # start/end as well to compare

--- a/pandas/core/indexes/datetimes.py
+++ b/pandas/core/indexes/datetimes.py
@@ -610,6 +610,7 @@ class DatetimeIndex(DatetimeArrayMixin, DatelikeOps, TimelikeOps,
                            dtype=dtype, **kwargs)
             values = np.array(values, copy=False)
 
+        # values should be a numpy array
         assert isinstance(values, np.ndarray)
 
         if is_object_dtype(values):

--- a/pandas/core/indexes/datetimes.py
+++ b/pandas/core/indexes/datetimes.py
@@ -598,6 +598,9 @@ class DatetimeIndex(DatetimeArrayMixin, DatelikeOps, TimelikeOps,
         if we are passed a non-dtype compat, then coerce using the constructor
         """
 
+        if isinstance(values, DatetimeIndex):
+            values = values.values
+
         if getattr(values, 'dtype', None) is None:
             # empty, but with dtype compat
             if values is None:

--- a/pandas/core/indexes/datetimes.py
+++ b/pandas/core/indexes/datetimes.py
@@ -613,6 +613,8 @@ class DatetimeIndex(DatetimeArrayMixin, DatelikeOps, TimelikeOps,
         if not is_datetime64_dtype(values):
             values = _ensure_int64(values).view(_NS_DTYPE)
 
+        values = getattr(values, 'values', values)
+
         assert isinstance(values, np.ndarray), "values is not an np.ndarray"
         assert is_datetime64_dtype(values)
 

--- a/pandas/core/indexes/datetimes.py
+++ b/pandas/core/indexes/datetimes.py
@@ -610,14 +610,11 @@ class DatetimeIndex(DatetimeArrayMixin, DatelikeOps, TimelikeOps,
                            dtype=dtype, **kwargs)
             values = np.array(values, copy=False)
 
+        if not is_datetime64_dtype(values):
+            values = _ensure_int64(values).view(_NS_DTYPE)
+
         assert isinstance(values, np.ndarray), "values is not an np.ndarray"
         assert is_datetime64_dtype(values)
-
-        if is_object_dtype(values):
-            return cls(values, name=name, freq=freq, tz=tz,
-                       dtype=dtype, **kwargs).values
-        elif not is_datetime64_dtype(values):
-            values = _ensure_int64(values).view(_NS_DTYPE)
 
         result = super(DatetimeIndex, cls)._simple_new(values, freq, tz,
                                                        **kwargs)
@@ -1862,9 +1859,7 @@ def _generate_regular_range(start, end, periods, freq):
                              "if a 'period' is given.")
 
         data = np.arange(b, e, stride, dtype=np.int64)
-
-        # _simple_new is getting an array of int64 here
-        data = DatetimeIndex._simple_new(data, None, tz=tz)
+        data = DatetimeIndex._simple_new(data.view(_NS_DTYPE), None, tz=tz)
     else:
         if isinstance(start, Timestamp):
             start = start.to_pydatetime()

--- a/pandas/core/indexes/datetimes.py
+++ b/pandas/core/indexes/datetimes.py
@@ -555,8 +555,8 @@ class DatetimeIndex(DatetimeArrayMixin, DatelikeOps, TimelikeOps,
                                                         tz,
                                                         ambiguous=ambiguous)
 
-                    arr = arr.view(_NS_DTYPE)
                     index = DatetimeIndex(arr)
+
 
                     # index is localized datetime64 array -> have to convert
                     # start/end as well to compare
@@ -610,8 +610,8 @@ class DatetimeIndex(DatetimeArrayMixin, DatelikeOps, TimelikeOps,
                            dtype=dtype, **kwargs)
             values = np.array(values, copy=False)
 
-        # values should be a numpy array
-        assert isinstance(values, np.ndarray)
+        assert isinstance(values, np.ndarray), "values is not an np.ndarray"
+        assert is_datetime64_dtype(values)
 
         if is_object_dtype(values):
             return cls(values, name=name, freq=freq, tz=tz,
@@ -1862,6 +1862,8 @@ def _generate_regular_range(start, end, periods, freq):
                              "if a 'period' is given.")
 
         data = np.arange(b, e, stride, dtype=np.int64)
+
+        # _simple_new is getting an array of int64 here
         data = DatetimeIndex._simple_new(data, None, tz=tz)
     else:
         if isinstance(start, Timestamp):

--- a/pandas/io/pytables.py
+++ b/pandas/io/pytables.py
@@ -2472,7 +2472,8 @@ class GenericFixed(Fixed):
         if klass == DatetimeIndex:
             def f(values, freq=None, tz=None):
                 # data are already in UTC, localize and convert if tz present
-                result = DatetimeIndex._simple_new(values, None, freq=freq)
+                result = DatetimeIndex._simple_new(values.values, None,
+                                                   freq=freq)
                 if tz is not None:
                     result = result.tz_localize('UTC').tz_convert(tz)
                 return result

--- a/pandas/tests/indexes/test_base.py
+++ b/pandas/tests/indexes/test_base.py
@@ -329,7 +329,7 @@ class TestIndex(Base):
     ])
     def test_constructor_simple_new(self, vals, dtype):
         index = Index(vals, name=dtype)
-        result = index._simple_new(index, dtype)
+        result = index._simple_new(index.values, dtype)
         tm.assert_index_equal(result, index)
 
     @pytest.mark.parametrize("vals", [


### PR DESCRIPTION
- [x] closes #20810
- [ ] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry

The change I made seems to fix the case in the original issue without breaking any tests. 

On my branch:
```
In [1]: idx1 = pd.DatetimeIndex(start="2012-01-01", periods=3, freq='D') # date_range kind of construction

In [2]: idx1._data
array(['2012-01-01T00:00:00.000000000', '2012-01-02T00:00:00.000000000',
       '2012-01-03T00:00:00.000000000'], dtype='datetime64[ns]')

In [3]: idx2 = pd.DatetimeIndex(idx1)

In [4]: idx2._data
Out[4]: 
array(['2012-01-01T00:00:00.000000000', '2012-01-02T00:00:00.000000000',
       '2012-01-03T00:00:00.000000000'], dtype='datetime64[ns]')
```

But is the solution too simple or is something more sophisticated required?

And do we need tests for this issue?