### PR TITLE
BLD: Use relative path in setup.py for pxd includes

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -450,7 +450,7 @@ common_include = ['pandas/_libs/src/klib', 'pandas/_libs/src']
 
 
 def pxd(name):
-    return os.path.abspath(pjoin('pandas', name + '.pxd'))
+    return pjoin('pandas', name + '.pxd')
 
 
 # args to ignore warnings


### PR DESCRIPTION
This caused failures on the conda-forge build

xref https://github.com/conda-forge/pandas-feedstock/pull/41