### PR TITLE
CLN: Fix typo in deprecation warning - "strudes" --> "strides"

### DIFF
--- a/pandas/core/base.py
+++ b/pandas/core/base.py
@@ -758,7 +758,7 @@ class IndexOpsMixin(object):
     @property
     def strides(self):
         """ return the strides of the underlying data """
-        warnings.warn("{obj}.strudes is deprecated and will be removed "
+        warnings.warn("{obj}.strides is deprecated and will be removed "
                       "in a future version".format(obj=type(self).__name__),
                       FutureWarning, stacklevel=2)
         return self._ndarray_values.strides


### PR DESCRIPTION
xref #20721

Minor typo, but might be nice to fix prior to the official 0.23.0 release.