### PR TITLE
CLN: removed unused "convert" parameter to _take

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -2641,7 +2641,7 @@ class DataFrame(NDFrame):
                 return self.loc[:, lab_slice]
             else:
                 if isinstance(label, Index):
-                    return self._take(i, axis=1, convert=True)
+                    return self._take(i, axis=1)
 
                 index_len = len(self.index)
 
@@ -2720,10 +2720,10 @@ class DataFrame(NDFrame):
             # be reindexed to match DataFrame rows
             key = check_bool_indexer(self.index, key)
             indexer = key.nonzero()[0]
-            return self._take(indexer, axis=0, convert=False)
+            return self._take(indexer, axis=0)
         else:
             indexer = self.loc._convert_to_indexer(key, axis=1)
-            return self._take(indexer, axis=1, convert=True)
+            return self._take(indexer, axis=1)
 
     def _getitem_multilevel(self, key):
         loc = self.columns.get_loc(key)
@@ -4292,7 +4292,7 @@ class DataFrame(NDFrame):
                 else:
                     raise TypeError('must specify how or thresh')
 
-            result = self._take(mask.nonzero()[0], axis=axis, convert=False)
+            result = self._take(mask.nonzero()[0], axis=axis)
 
         if inplace:
             self._update_inplace(result)

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -37,7 +37,6 @@ from pandas.core.base import PandasObject, SelectionMixin
 from pandas.core.index import (Index, MultiIndex, _ensure_index,
                                InvalidIndexError, RangeIndex)
 import pandas.core.indexing as indexing
-from pandas.core.indexing import maybe_convert_indices
 from pandas.core.indexes.datetimes import DatetimeIndex
 from pandas.core.indexes.period import PeriodIndex, Period
 from pandas.core.internals import BlockManager

--- a/pandas/core/groupby/groupby.py
+++ b/pandas/core/groupby/groupby.py
@@ -508,8 +508,7 @@ class Grouper(object):
             # use stable sort to support first, last, nth
             indexer = self.indexer = ax.argsort(kind='mergesort')
             ax = ax.take(indexer)
-            obj = obj._take(indexer, axis=self.axis,
-                            convert=False, is_copy=False)
+            obj = obj._take(indexer, axis=self.axis, is_copy=False)
 
         self.obj = obj
         self.grouper = ax
@@ -860,7 +859,7 @@ b  2""")
         if not len(inds):
             raise KeyError(name)
 
-        return obj._take(inds, axis=self.axis, convert=False)
+        return obj._take(inds, axis=self.axis)
 
     def __iter__(self):
         """
@@ -1437,9 +1436,9 @@ class GroupBy(_GroupBy):
         cls.min = groupby_function('min', 'min', np.min, numeric_only=False)
         cls.max = groupby_function('max', 'max', np.max, numeric_only=False)
         cls.first = groupby_function('first', 'first', first_compat,
-                                     numeric_only=False, _convert=True)
+                                     numeric_only=False)
         cls.last = groupby_function('last', 'last', last_compat,
-                                    numeric_only=False, _convert=True)
+                                    numeric_only=False)
 
     @Substitution(name='groupby')
     @Appender(_doc_template)
@@ -2653,7 +2652,7 @@ class BaseGrouper(object):
         # avoids object / Series creation overhead
         dummy = obj._get_values(slice(None, 0)).to_dense()
         indexer = get_group_index_sorter(group_index, ngroups)
-        obj = obj._take(indexer, convert=False).to_dense()
+        obj = obj._take(indexer).to_dense()
         group_index = algorithms.take_nd(
             group_index, indexer, allow_fill=False)
         grouper = reduction.SeriesGrouper(obj, func, group_index, ngroups,
@@ -5032,7 +5031,7 @@ class DataSplitter(object):
             yield i, self._chop(sdata, slice(start, end))
 
     def _get_sorted_data(self):
-        return self.data._take(self.sort_idx, axis=self.axis, convert=False)
+        return self.data._take(self.sort_idx, axis=self.axis)
 
     def _chop(self, sdata, slice_obj):
         return sdata.iloc[slice_obj]

--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -1126,7 +1126,7 @@ class _NDFrameIndexer(_NDFrameIndexerBase):
         if com.is_bool_indexer(key):
             key = check_bool_indexer(labels, key)
             inds, = key.nonzero()
-            return self.obj._take(inds, axis=axis, convert=False)
+            return self.obj._take(inds, axis=axis)
         else:
             # Have the index compute an indexer or return None
             # if it cannot handle; we only act on all found values
@@ -1158,8 +1158,7 @@ class _NDFrameIndexer(_NDFrameIndexerBase):
                     keyarr)
 
                 if new_indexer is not None:
-                    result = self.obj._take(indexer[indexer != -1], axis=axis,
-                                            convert=False)
+                    result = self.obj._take(indexer[indexer != -1], axis=axis)
 
                     self._validate_read_indexer(key, new_indexer, axis)
                     result = result._reindex_with_indexers(
@@ -1356,7 +1355,7 @@ class _NDFrameIndexer(_NDFrameIndexerBase):
         if isinstance(indexer, slice):
             return self._slice(indexer, axis=axis, kind='iloc')
         else:
-            return self.obj._take(indexer, axis=axis, convert=False)
+            return self.obj._take(indexer, axis=axis)
 
 
 class _IXIndexer(_NDFrameIndexer):
@@ -1494,7 +1493,7 @@ class _LocationIndexer(_NDFrameIndexer):
         key = check_bool_indexer(labels, key)
         inds, = key.nonzero()
         try:
-            return self.obj._take(inds, axis=axis, convert=False)
+            return self.obj._take(inds, axis=axis)
         except Exception as detail:
             raise self._exception(detail)
 
@@ -1514,7 +1513,7 @@ class _LocationIndexer(_NDFrameIndexer):
         if isinstance(indexer, slice):
             return self._slice(indexer, axis=axis, kind='iloc')
         else:
-            return self.obj._take(indexer, axis=axis, convert=False)
+            return self.obj._take(indexer, axis=axis)
 
 
 class _LocIndexer(_LocationIndexer):
@@ -2050,7 +2049,7 @@ class _iLocIndexer(_LocationIndexer):
         if isinstance(slice_obj, slice):
             return self._slice(slice_obj, axis=axis, kind='iloc')
         else:
-            return self.obj._take(slice_obj, axis=axis, convert=False)
+            return self.obj._take(slice_obj, axis=axis)
 
     def _get_list_axis(self, key, axis=None):
         """
@@ -2068,7 +2067,7 @@ class _iLocIndexer(_LocationIndexer):
         if axis is None:
             axis = self.axis or 0
         try:
-            return self.obj._take(key, axis=axis, convert=False)
+            return self.obj._take(key, axis=axis)
         except IndexError:
             # re-raise with different error message
             raise IndexError("positional indexers are out-of-bounds")

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -3504,9 +3504,7 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
         return v
 
     @Appender(generic._shared_docs['_take'])
-    def _take(self, indices, axis=0, convert=True, is_copy=False):
-        if convert:
-            indices = maybe_convert_indices(indices, len(self._get_axis(axis)))
+    def _take(self, indices, axis=0, is_copy=False):
 
         indices = _ensure_platform_int(indices)
         new_index = self.index.take(indices)
@@ -3514,6 +3512,7 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
         if is_categorical_dtype(self):
             # https://github.com/pandas-dev/pandas/issues/20664
             # TODO: remove when the default Categorical.take behavior changes
+            indices = maybe_convert_indices(indices, len(self._get_axis(axis)))
             kwargs = {'allow_fill': False}
         else:
             kwargs = {}


### PR DESCRIPTION
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`

Followup to #20841: the ``convert`` parameter to ``_take`` is irrelevant: the conversion of negative to positive indices is required only for ``Categorical``s (and only until we normalize their ``take`` behavior with negative indices).