### PR TITLE
BUG: cant modify df with duplicate index (#17105)

### DIFF
--- a/doc/source/whatsnew/v0.23.0.txt
+++ b/doc/source/whatsnew/v0.23.0.txt
@@ -1243,6 +1243,7 @@ Indexing
 - Bug in ``Series.is_unique`` where extraneous output in stderr is shown if Series contains objects with ``__ne__`` defined (:issue:`20661`)
 - Bug in ``.loc`` assignment with a single-element list-like incorrectly assigns as a list (:issue:`19474`)
 - Bug in partial string indexing on a ``Series/DataFrame`` with a monotonic decreasing ``DatetimeIndex`` (:issue:`19362`)
+- Bug in performing in-place operations on a DataFrame with a duplicate Index (:issue:`17105`)
 
 MultiIndex
 ^^^^^^^^^^

--- a/doc/source/whatsnew/v0.23.0.txt
+++ b/doc/source/whatsnew/v0.23.0.txt
@@ -1245,7 +1245,7 @@ Indexing
 - Bug in ``Series.is_unique`` where extraneous output in stderr is shown if Series contains objects with ``__ne__`` defined (:issue:`20661`)
 - Bug in ``.loc`` assignment with a single-element list-like incorrectly assigns as a list (:issue:`19474`)
 - Bug in partial string indexing on a ``Series/DataFrame`` with a monotonic decreasing ``DatetimeIndex`` (:issue:`19362`)
-- Bug in performing in-place operations on a DataFrame with a duplicate Index (:issue:`17105`)
+- Bug in performing in-place operations on a ``DataFrame`` with a duplicate ``Index`` (:issue:`17105`)
 
 MultiIndex
 ^^^^^^^^^^

--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -1319,7 +1319,7 @@ class _NDFrameIndexer(_NDFrameIndexerBase):
                     (indexer,
                      missing) = labels.get_indexer_non_unique(objarr)
                     # 'indexer' has dupes, create 'check' using 'missing'
-                    check = np.zeros_like(objarr)
+                    check = np.zeros(len(objarr))
                     check[missing] = -1
 
                 mask = check == -1

--- a/pandas/tests/indexing/test_loc.py
+++ b/pandas/tests/indexing/test_loc.py
@@ -786,45 +786,27 @@ Region_1,Site_2,3977723089,A,5/20/2015 8:33,5/20/2015 9:09,Yes,No"""
         tm.assert_series_equal(result, expected)
 
     def test_modify_with_duplicate_index_assigning(self):
-        """ see issue #17105 """
+        # gh-17105
 
+        # insert a duplicate element to the index
         trange = pd.date_range(start=pd.Timestamp(year=2017, month=1, day=1),
                                end=pd.Timestamp(year=2017, month=1, day=5))
 
-        # insert a duplicate element to the index
         trange = trange.insert(loc=5,
                                item=pd.Timestamp(year=2017, month=1, day=5))
 
         df = pd.DataFrame(0, index=trange, columns=["A", "B"])
         bool_idx = np.array([False, False, False, False, False, True])
 
-        # modify the value for the duplicate index entry
+        # assignment
         df.loc[trange[bool_idx], "A"] = 6
 
         expected = pd.DataFrame({'A': [0, 0, 0, 0, 6, 6],
                                  'B': [0, 0, 0, 0, 0, 0]},
                                 index=trange)
-
         tm.assert_frame_equal(df, expected)
 
-    def test_modify_with_duplicate_index_adding(self):
-        """ see issue #17105 """
-
-        trange = pd.date_range(start=pd.Timestamp(year=2017, month=1, day=1),
-                               end=pd.Timestamp(year=2017, month=1, day=5))
-
-        # insert a duplicate element to the index
-        trange = trange.insert(loc=5,
-                               item=pd.Timestamp(year=2017, month=1, day=5))
-
+        # in-place
         df = pd.DataFrame(0, index=trange, columns=["A", "B"])
-        bool_idx = np.array([False, False, False, False, False, True])
-
-        # modify the value for the duplicate index entry
-        df.loc[trange[bool_idx], "A"] += 7
-
-        expected = pd.DataFrame({'A': [0, 0, 0, 0, 7, 7],
-                                 'B': [0, 0, 0, 0, 0, 0]},
-                                index=trange)
-
+        df.loc[trange[bool_idx], "A"] += 6
         tm.assert_frame_equal(df, expected)

--- a/pandas/tests/indexing/test_loc.py
+++ b/pandas/tests/indexing/test_loc.py
@@ -784,29 +784,3 @@ Region_1,Site_2,3977723089,A,5/20/2015 8:33,5/20/2015 9:09,Yes,No"""
             index=pd.MultiIndex.from_product(keys))
 
         tm.assert_series_equal(result, expected)
-
-    def test_modify_with_duplicate_index_assigning(self):
-        # gh-17105
-
-        # insert a duplicate element to the index
-        trange = pd.date_range(start=pd.Timestamp(year=2017, month=1, day=1),
-                               end=pd.Timestamp(year=2017, month=1, day=5))
-
-        trange = trange.insert(loc=5,
-                               item=pd.Timestamp(year=2017, month=1, day=5))
-
-        df = pd.DataFrame(0, index=trange, columns=["A", "B"])
-        bool_idx = np.array([False, False, False, False, False, True])
-
-        # assignment
-        df.loc[trange[bool_idx], "A"] = 6
-
-        expected = pd.DataFrame({'A': [0, 0, 0, 0, 6, 6],
-                                 'B': [0, 0, 0, 0, 0, 0]},
-                                index=trange)
-        tm.assert_frame_equal(df, expected)
-
-        # in-place
-        df = pd.DataFrame(0, index=trange, columns=["A", "B"])
-        df.loc[trange[bool_idx], "A"] += 6
-        tm.assert_frame_equal(df, expected)

--- a/pandas/tests/indexing/test_loc.py
+++ b/pandas/tests/indexing/test_loc.py
@@ -784,3 +784,47 @@ Region_1,Site_2,3977723089,A,5/20/2015 8:33,5/20/2015 9:09,Yes,No"""
             index=pd.MultiIndex.from_product(keys))
 
         tm.assert_series_equal(result, expected)
+
+    def test_modify_with_duplicate_index_assigning(self):
+        """ see issue #17105 """
+
+        trange = pd.date_range(start=pd.Timestamp(year=2017, month=1, day=1),
+                               end=pd.Timestamp(year=2017, month=1, day=5))
+
+        # insert a duplicate element to the index
+        trange = trange.insert(loc=5,
+                               item=pd.Timestamp(year=2017, month=1, day=5))
+
+        df = pd.DataFrame(0, index=trange, columns=["A", "B"])
+        bool_idx = np.array([False, False, False, False, False, True])
+
+        # modify the value for the duplicate index entry
+        df.loc[trange[bool_idx], "A"] = 6
+
+        expected = pd.DataFrame({'A': [0, 0, 0, 0, 6, 6],
+                                 'B': [0, 0, 0, 0, 0, 0]},
+                                index=trange)
+
+        tm.assert_frame_equal(df, expected)
+
+    def test_modify_with_duplicate_index_adding(self):
+        """ see issue #17105 """
+
+        trange = pd.date_range(start=pd.Timestamp(year=2017, month=1, day=1),
+                               end=pd.Timestamp(year=2017, month=1, day=5))
+
+        # insert a duplicate element to the index
+        trange = trange.insert(loc=5,
+                               item=pd.Timestamp(year=2017, month=1, day=5))
+
+        df = pd.DataFrame(0, index=trange, columns=["A", "B"])
+        bool_idx = np.array([False, False, False, False, False, True])
+
+        # modify the value for the duplicate index entry
+        df.loc[trange[bool_idx], "A"] += 7
+
+        expected = pd.DataFrame({'A': [0, 0, 0, 0, 7, 7],
+                                 'B': [0, 0, 0, 0, 0, 0]},
+                                index=trange)
+
+        tm.assert_frame_equal(df, expected)


### PR DESCRIPTION
- [x] closes #17105
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry

Fixing to allow the modification of DataFrames that have duplicate elements in the index. Previously it would fail with

```
AttributeError: 'bool' object has no attribute 'any'
```
See #17105 for a code snippet.

Replacing `zeros_like(objarray)` with `zeros()` because the first unnecessarily returns an array of zeros with the same types as `objarray`. We only want the zeros, not the type, to be able to later compare against -1 and get an array as a result:

The result of `zeros_like()` with dates gives a boolean after comparison
```
>>> myarr_fromindex = np.zeros_like(pd.DatetimeIndex([2,3]))
>>> myarr_fromindex
array(['1970-01-01T00:00:00.000000000', '1970-01-01T00:00:00.000000000'],
      dtype='datetime64[ns]')
>>> 
>>> type(myarr_fromindex)
<type 'numpy.ndarray'>
>>>
>>> myarr_fromindex == -1
False
```

The result of `zeros_like()` with numbers gives an array after comparison
```
>>> 
>>> 
>>> myarr_fromarr = np.zeros_like([2,3])
>>> myarr_fromarr
array([0, 0])
>>> type(myarr_fromarr)
<type 'numpy.ndarray'>
>>> myarr_fromarr == -1
array([False, False])
>>> 
```




