### PR TITLE
BUG: Fix IntervalIndex.get_loc/get_indexer for IntervalIndex of length one

### DIFF
--- a/doc/source/api.rst
+++ b/doc/source/api.rst
@@ -1632,6 +1632,8 @@ IntervalIndex Components
    IntervalIndex.length
    IntervalIndex.values
    IntervalIndex.is_non_overlapping_monotonic
+   IntervalIndex.get_loc
+   IntervalIndex.get_indexer
 
 
 .. _api.multiindex:

--- a/doc/source/whatsnew/v0.23.0.txt
+++ b/doc/source/whatsnew/v0.23.0.txt
@@ -1245,6 +1245,7 @@ Indexing
 - Bug in ``Series.is_unique`` where extraneous output in stderr is shown if Series contains objects with ``__ne__`` defined (:issue:`20661`)
 - Bug in ``.loc`` assignment with a single-element list-like incorrectly assigns as a list (:issue:`19474`)
 - Bug in partial string indexing on a ``Series/DataFrame`` with a monotonic decreasing ``DatetimeIndex`` (:issue:`19362`)
+- Bug in ``IntervalIndex.get_loc()`` and ``IntervalIndex.get_indexer()`` when used with an :class:`IntervalIndex` containing a single interval (:issue:`17284`, :issue:`20921`)
 
 MultiIndex
 ^^^^^^^^^^

--- a/doc/source/whatsnew/v0.23.0.txt
+++ b/doc/source/whatsnew/v0.23.0.txt
@@ -1245,7 +1245,7 @@ Indexing
 - Bug in ``Series.is_unique`` where extraneous output in stderr is shown if Series contains objects with ``__ne__`` defined (:issue:`20661`)
 - Bug in ``.loc`` assignment with a single-element list-like incorrectly assigns as a list (:issue:`19474`)
 - Bug in partial string indexing on a ``Series/DataFrame`` with a monotonic decreasing ``DatetimeIndex`` (:issue:`19362`)
-- Bug in ``IntervalIndex.get_loc()`` and ``IntervalIndex.get_indexer()`` when used with an :class:`IntervalIndex` containing a single interval (:issue:`17284`, :issue:`20921`)
+- Bug in :meth:`IntervalIndex.get_loc` and :meth:`IntervalIndex.get_indexer` when used with an :class:`IntervalIndex` containing a single interval (:issue:`17284`, :issue:`20921`)
 
 MultiIndex
 ^^^^^^^^^^

--- a/pandas/core/indexes/interval.py
+++ b/pandas/core/indexes/interval.py
@@ -159,20 +159,22 @@ class IntervalIndex(IntervalMixin, Index):
 
     Attributes
     ----------
-    left
-    right
     closed
-    mid
-    length
-    values
     is_non_overlapping_monotonic
+    left
+    length
+    mid
+    right
+    values
 
     Methods
     -------
-    from_arrays
-    from_tuples
-    from_breaks
     contains
+    from_arrays
+    from_breaks
+    from_tuples
+    get_indexer
+    get_loc
 
     Examples
     ---------

--- a/pandas/core/indexes/interval.py
+++ b/pandas/core/indexes/interval.py
@@ -938,8 +938,11 @@ class IntervalIndex(IntervalMixin, Index):
         if isinstance(label, IntervalMixin):
             raise NotImplementedError
 
+        # GH 20921: "not is_monotonic_increasing" for the second condition
+        # instead of "is_monotonic_decreasing" to account for single element
+        # indexes being both increasing and decreasing
         if ((side == 'left' and self.left.is_monotonic_increasing) or
-                (side == 'right' and self.left.is_monotonic_decreasing)):
+                (side == 'right' and not self.left.is_monotonic_increasing)):
             sub_idx = self.right
             if self.open_right or exclude_label:
                 label = _get_next_label(label)

--- a/pandas/tests/indexes/interval/test_interval.py
+++ b/pandas/tests/indexes/interval/test_interval.py
@@ -497,6 +497,14 @@ class TestIntervalIndex(Base):
         pytest.raises(KeyError, self.index.get_loc,
                       Interval(-1, 0, 'left'))
 
+    # Make consistent with test_interval_new.py (see #16316, #16386)
+    @pytest.mark.parametrize('item', [3, Interval(1, 4)])
+    def test_get_loc_length_one(self, item, closed):
+        # GH 20921
+        index = IntervalIndex.from_tuples([(0, 5)], closed=closed)
+        result = index.get_loc(item)
+        assert result == 0
+
     # To be removed, replaced by test_interval_new.py (see #16316, #16386)
     def test_get_indexer(self):
         actual = self.index.get_indexer([-1, 0, 0.5, 1, 1.5, 2, 3])
@@ -543,6 +551,16 @@ class TestIntervalIndex(Base):
         actual = self.index.get_indexer(target)
         expected = np.array([0, 0, 0], dtype='intp')
         tm.assert_numpy_array_equal(actual, expected)
+
+    # Make consistent with test_interval_new.py (see #16316, #16386)
+    @pytest.mark.parametrize('item', [
+        [3], np.arange(1, 5), [Interval(1, 4)], interval_range(1, 4)])
+    def test_get_indexer_length_one(self, item, closed):
+        # GH 17284
+        index = IntervalIndex.from_tuples([(0, 5)], closed=closed)
+        result = index.get_indexer(item)
+        expected = np.array([0] * len(item), dtype='intp')
+        tm.assert_numpy_array_equal(result, expected)
 
     # To be removed, replaced by test_interval_new.py (see #16316, #16386)
     def test_contains(self):


### PR DESCRIPTION
- [X] closes #17284
- [X] closes #20921
- [X] tests added / passed
- [X] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [X] whatsnew entry
