### PR TITLE
Add pip 9.0.3 to conda environment to avoid numpy 1.9.3 error 

### DIFF
--- a/ci/environment-dev.yaml
+++ b/ci/environment-dev.yaml
@@ -12,3 +12,4 @@ dependencies:
   - pytz
   - setuptools
   - sphinx
+  - pip==9.0.3


### PR DESCRIPTION
I obtain this error:
'No matching distribution found for numpy==1.9.3'.
See #20952 for more details. This change works for me. Closes #20952 .

- [ ] closes #xxxx
- [ ] tests added / passed
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry