### PR TITLE
BUG: Fix wrong khash method definition

### DIFF
--- a/doc/source/whatsnew/v0.23.0.txt
+++ b/doc/source/whatsnew/v0.23.0.txt
@@ -1246,6 +1246,7 @@ Indexing
 - Bug in ``Series.is_unique`` where extraneous output in stderr is shown if Series contains objects with ``__ne__`` defined (:issue:`20661`)
 - Bug in ``.loc`` assignment with a single-element list-like incorrectly assigns as a list (:issue:`19474`)
 - Bug in partial string indexing on a ``Series/DataFrame`` with a monotonic decreasing ``DatetimeIndex`` (:issue:`19362`)
+- Bug in ``.loc``, which cannot handle ``uint64`` input (:issue:`20722`)
 
 MultiIndex
 ^^^^^^^^^^

--- a/doc/source/whatsnew/v0.23.0.txt
+++ b/doc/source/whatsnew/v0.23.0.txt
@@ -1254,7 +1254,7 @@ Indexing
 - Bug in ``.loc`` assignment with a single-element list-like incorrectly assigns as a list (:issue:`19474`)
 - Bug in partial string indexing on a ``Series/DataFrame`` with a monotonic decreasing ``DatetimeIndex`` (:issue:`19362`)
 - Bug in :meth:`IntervalIndex.get_loc` and :meth:`IntervalIndex.get_indexer` when used with an :class:`IntervalIndex` containing a single interval (:issue:`17284`, :issue:`20921`)
-- Bug in ``.loc``, which cannot handle ``uint64`` input (:issue:`20722`)
+- Bug in ``.loc`` with a ``uint64`` indexer (:issue:`20722`)
 
 MultiIndex
 ^^^^^^^^^^

--- a/pandas/_libs/khash.pxd
+++ b/pandas/_libs/khash.pxd
@@ -84,9 +84,9 @@ cdef extern from "khash_python.h":
     kh_uint64_t* kh_init_uint64() nogil
     void kh_destroy_uint64(kh_uint64_t*) nogil
     void kh_clear_uint64(kh_uint64_t*) nogil
-    khint_t kh_get_uint64(kh_uint64_t*, int64_t) nogil
+    khint_t kh_get_uint64(kh_uint64_t*, uint64_t) nogil
     void kh_resize_uint64(kh_uint64_t*, khint_t) nogil
-    khint_t kh_put_uint64(kh_uint64_t*, int64_t, int*) nogil
+    khint_t kh_put_uint64(kh_uint64_t*, uint64_t, int*) nogil
     void kh_del_uint64(kh_uint64_t*, khint_t) nogil
 
     bint kh_exist_uint64(kh_uint64_t*, khiter_t) nogil

--- a/pandas/tests/indexing/test_loc.py
+++ b/pandas/tests/indexing/test_loc.py
@@ -784,3 +784,32 @@ Region_1,Site_2,3977723089,A,5/20/2015 8:33,5/20/2015 9:09,Yes,No"""
             index=pd.MultiIndex.from_product(keys))
 
         tm.assert_series_equal(result, expected)
+
+    def test_loc_uint64(self):
+        # GH20722
+        # Test whether loc accept uint64 max value as index.
+        s = pd.Series(
+            [1, 2],
+            index=[
+                np.iinfo('uint64').max - 1,
+                np.iinfo('uint64').max
+            ]
+        )
+        exp1 = pd.Series(
+            [1],
+            index=[
+                18446744073709551614
+            ]
+        )
+        exp2 = pd.Series(
+            [2],
+            index=[
+                18446744073709551615
+            ]
+        )
+
+        tm.assert_series_equal(s.loc[[np.iinfo('uint64').max - 1]], exp1)
+        assert 1 == s.loc[np.iinfo('uint64').max - 1]
+
+        tm.assert_series_equal(s.loc[[np.iinfo('uint64').max]], exp2)
+        assert 2 == s.loc[np.iinfo('uint64').max]

--- a/pandas/tests/indexing/test_loc.py
+++ b/pandas/tests/indexing/test_loc.py
@@ -788,28 +788,18 @@ Region_1,Site_2,3977723089,A,5/20/2015 8:33,5/20/2015 9:09,Yes,No"""
     def test_loc_uint64(self):
         # GH20722
         # Test whether loc accept uint64 max value as index.
-        s = pd.Series(
-            [1, 2],
-            index=[
-                np.iinfo('uint64').max - 1,
-                np.iinfo('uint64').max
-            ]
-        )
-        exp1 = pd.Series(
-            [1],
-            index=[
-                18446744073709551614
-            ]
-        )
-        exp2 = pd.Series(
-            [2],
-            index=[
-                18446744073709551615
-            ]
-        )
+        s = pd.Series([1, 2],
+                      index=[np.iinfo('uint64').max - 1,
+                             np.iinfo('uint64').max])
 
-        tm.assert_series_equal(s.loc[[np.iinfo('uint64').max - 1]], exp1)
-        assert 1 == s.loc[np.iinfo('uint64').max - 1]
+        result = s.loc[np.iinfo('uint64').max - 1]
+        expected = s.iloc[0]
+        assert result == expected
 
-        tm.assert_series_equal(s.loc[[np.iinfo('uint64').max]], exp2)
-        assert 2 == s.loc[np.iinfo('uint64').max]
+        result = s.loc[[np.iinfo('uint64').max - 1]]
+        expected = s.iloc[[0]]
+        tm.assert_series_equal(result, expected)
+
+        result = s.loc[[np.iinfo('uint64').max - 1,
+                       np.iinfo('uint64').max]]
+        tm.assert_series_equal(result, s)


### PR DESCRIPTION
- [x] closes #20722
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry
