### PR TITLE
Preserve Alignment Between Index and Values for Non-Monotonic Stack

### DIFF
--- a/pandas/core/reshape/reshape.py
+++ b/pandas/core/reshape/reshape.py
@@ -653,7 +653,13 @@ def _stack_multi_columns(frame, level_num=-1, dropna=True):
     # time to ravel the values
     new_data = {}
     level_vals = this.columns.levels[-1]
-    level_labels = sorted(set(this.columns.labels[-1]))
+    level_labels = list()
+    for label in this.columns.labels[-1]:
+        # GH 20945 if labels are not monotonic we were mangling
+        # alignment when moving to index; ensure we preserve order
+        if label not in level_labels:
+            level_labels.append(label)
+
     level_vals_used = level_vals[level_labels]
     levsize = len(level_labels)
     drop_cols = []

--- a/pandas/tests/frame/test_reshape.py
+++ b/pandas/tests/frame/test_reshape.py
@@ -414,6 +414,22 @@ class TestDataFrameReshape(TestData):
         assert_frame_equal(df3.stack(level=['animal', 0]),
                            animal_hair_stacked, check_names=False)
 
+    def test_stack_retains_index_order(self):
+        # GH 20945
+        col_index = pd.MultiIndex.from_product([
+            ['c', 'b', 'a', 'd'],
+            ['A', 'B']
+        ])
+
+        df = pd.DataFrame([[1, 11, 2, 22, 3, 33, 4, 44]], columns=col_index)
+
+        expected_mi = pd.MultiIndex.from_product([[0], ['c', 'b', 'a', 'd']])
+        expected = pd.DataFrame([[1, 11], [2, 22], [3, 33], [4, 44]],
+                                index=expected_mi, columns=['A', 'B'])
+
+        result = df.stack(level=0)
+        tm.assert_frame_equal(result, expected)
+
     def test_stack_int_level_names(self):
         columns = MultiIndex.from_tuples(
             [('A', 'cat', 'long'), ('B', 'cat', 'long'),


### PR DESCRIPTION
- [X] closes #20945
- [X] tests added / passed
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

Not overly familiar with this code so submitting for review as there's probably a better way of going about it. The root cause of the referenced issue IIUC is that the index labels of the caller are non-monotonic. `stack` essentially takes values and labels from the level that is getting pushed down into the rows with an implicit assumption that both are monotonic, hence the index/values get misaligned.

This breaks at least one other test so not ready to merge, but looking for feedback on:

 - If there's a better way to align the values with the labels in this function AND/OR
 - If we make any guarantees about the order of the labels for the level(s) being moved in this function