### PR TITLE
Consistent Return Structure for Rolling Apply

### DIFF
--- a/doc/source/whatsnew/v0.23.0.txt
+++ b/doc/source/whatsnew/v0.23.0.txt
@@ -1328,6 +1328,7 @@ Groupby/Resample/Rolling
 - Bug in :func:`DataFrame.groupby` where transformations using ``np.all`` and ``np.any`` were raising a ``ValueError`` (:issue:`20653`)
 - Bug in :func:`DataFrame.resample` where ``ffill``, ``bfill``, ``pad``, ``backfill``, ``fillna``, ``interpolate``, and ``asfreq`` were ignoring ``loffset``. (:issue:`20744`)
 - Bug in :func:`DataFrame.groupby` when applying a function that has mixed data types and the user supplied function can fail on the grouping column (:issue:`20949`)
+- Bug in :func:`DataFrameGroupBy.rolling().apply() <pandas.core.window.Rolling.apply>` where operations performed against the associated :class:`DataFrameGroupBy` object could impact the inclusion of the grouped item(s) in the result (:issue:`14013`)
 
 Sparse
 ^^^^^^

--- a/pandas/core/window.py
+++ b/pandas/core/window.py
@@ -791,6 +791,7 @@ class _GroupByMixin(GroupByMixin):
 
         def f(x, name=name, *args):
             x = self._shallow_copy(x)
+
             if isinstance(name, compat.string_types):
                 return getattr(x, name)(*args, **kwargs)
 

--- a/pandas/core/window.py
+++ b/pandas/core/window.py
@@ -796,7 +796,6 @@ class _GroupByMixin(GroupByMixin):
 
             return x.apply(name, *args, **kwargs)
 
-
         return self._groupby.apply(f)
 
 

--- a/pandas/core/window.py
+++ b/pandas/core/window.py
@@ -791,11 +791,11 @@ class _GroupByMixin(GroupByMixin):
 
         def f(x, name=name, *args):
             x = self._shallow_copy(x)
-
             if isinstance(name, compat.string_types):
                 return getattr(x, name)(*args, **kwargs)
 
             return x.apply(name, *args, **kwargs)
+
 
         return self._groupby.apply(f)
 
@@ -837,11 +837,7 @@ class _Rolling(_Window):
         index, indexi = self._get_index(index=index)
         results = []
         for b in blocks:
-            try:
-                values = self._prep_values(b.values)
-            except TypeError:
-                results.append(b.values.copy())
-                continue
+            values = self._prep_values(b.values)
 
             if values.size == 0:
                 results.append(values.copy())

--- a/pandas/tests/test_window.py
+++ b/pandas/tests/test_window.py
@@ -105,7 +105,6 @@ class TestApi(Base):
     def tests_skip_nuisance(self):
 
         df = DataFrame({'A': range(5), 'B': range(5, 10), 'C': 'foo'})
-
         r = df.rolling(window=3)
         result = r[['A', 'B']].sum()
         expected = DataFrame({'A': [np.nan, np.nan, 3, 6, 9],
@@ -113,9 +112,13 @@ class TestApi(Base):
                              columns=list('AB'))
         tm.assert_frame_equal(result, expected)
 
+    def test_skip_sum_object_raises(self):
+        df = DataFrame({'A': range(5), 'B': range(5, 10), 'C': 'foo'})
+        r = df.rolling(window=3)
         expected = concat([r[['A', 'B']].sum(), df[['C']]], axis=1)
-        result = r.sum()
-        tm.assert_frame_equal(result, expected, check_like=True)
+
+        with tm.assert_raises_regex(TypeError, 'cannot handle this type'):
+            result = r.sum()
 
     def test_agg(self):
         df = DataFrame({'A': range(5), 'B': range(0, 10, 2)})

--- a/pandas/tests/test_window.py
+++ b/pandas/tests/test_window.py
@@ -115,10 +115,9 @@ class TestApi(Base):
     def test_skip_sum_object_raises(self):
         df = DataFrame({'A': range(5), 'B': range(5, 10), 'C': 'foo'})
         r = df.rolling(window=3)
-        expected = concat([r[['A', 'B']].sum(), df[['C']]], axis=1)
 
         with tm.assert_raises_regex(TypeError, 'cannot handle this type'):
-            result = r.sum()
+            r.sum()
 
     def test_agg(self):
         df = DataFrame({'A': range(5), 'B': range(0, 10, 2)})

--- a/pandas/tests/test_window.py
+++ b/pandas/tests/test_window.py
@@ -3181,11 +3181,11 @@ class TestGrouperGrouping(object):
         df = pd.DataFrame({'A': ['foo'] * 3 + ['bar'] * 3, 'B': [1] * 6})
         g = df.groupby('A')
 
-        # First ensure that the grouped column is not part of the output
         mi = pd.MultiIndex.from_tuples([('bar', 3), ('bar', 4), ('bar', 5),
                                         ('foo', 0), ('foo', 1), ('foo', 2)])
 
         mi.names = ['A', None]
+        # Grouped column should not be a part of the output
         expected = pd.DataFrame([np.nan, 2., 2.] * 2, columns=['B'], index=mi)
 
         result = g.rolling(window=2).sum()


### PR DESCRIPTION
- [X] closes #14013
- [X] tests added / passed
- [X] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry

With the changes made in #20949 it appears possible to fix this bug by suppressing a `catch` block that was internal to Rolling's `_apply`. I'm not sure what the purpose of this catch as it essentially allows values to bypass the applied function...Only one test broke on removal which looked wrong anyway, so I updated it as such
