### PR TITLE
DEPR: DataFrame dropna accepting multiple axes

### DIFF
--- a/doc/source/whatsnew/v0.23.0.txt
+++ b/doc/source/whatsnew/v0.23.0.txt
@@ -1005,7 +1005,7 @@ Deprecations
 - Setting ``PeriodIndex.freq`` (which was not guaranteed to work correctly) is deprecated. Use :meth:`PeriodIndex.asfreq` instead (:issue:`20678`)
 - ``Index.get_duplicates()`` is deprecated and will be removed in a future version (:issue:`20239`)
 - The previous default behavior of negative indices in ``Categorical.take`` is deprecated. In a future version it will change from meaning missing values to meaning positional indices from the right. The future behavior is consistent with :meth:`Series.take` (:issue:`20664`).
-- Passing multiple axes to the ``axis`` parameter in :func: `DataFrame.dropna` has been deprecated and will not be supported in a future version (:issue:`20987`)
+- Passing multiple axes to the ``axis`` parameter in :func:`DataFrame.dropna` has been deprecated and will be removed in a future version (:issue:`20987`)
 
 
 .. _whatsnew_0230.prior_deprecations:

--- a/doc/source/whatsnew/v0.23.0.txt
+++ b/doc/source/whatsnew/v0.23.0.txt
@@ -1005,7 +1005,7 @@ Deprecations
 - Setting ``PeriodIndex.freq`` (which was not guaranteed to work correctly) is deprecated. Use :meth:`PeriodIndex.asfreq` instead (:issue:`20678`)
 - ``Index.get_duplicates()`` is deprecated and will be removed in a future version (:issue:`20239`)
 - The previous default behavior of negative indices in ``Categorical.take`` is deprecated. In a future version it will change from meaning missing values to meaning positional indices from the right. The future behavior is consistent with :meth:`Series.take` (:issue:`20664`).
-- Passing multiple axes to the ``axis`` parameter in :func: `DataFrame.dropna` has been deprecated and will not be suppoted in a future version (:issue:`20987`)
+- Passing multiple axes to the ``axis`` parameter in :func: `DataFrame.dropna` has been deprecated and will not be supported in a future version (:issue:`20987`)
 
 
 .. _whatsnew_0230.prior_deprecations:

--- a/doc/source/whatsnew/v0.23.0.txt
+++ b/doc/source/whatsnew/v0.23.0.txt
@@ -1005,6 +1005,7 @@ Deprecations
 - Setting ``PeriodIndex.freq`` (which was not guaranteed to work correctly) is deprecated. Use :meth:`PeriodIndex.asfreq` instead (:issue:`20678`)
 - ``Index.get_duplicates()`` is deprecated and will be removed in a future version (:issue:`20239`)
 - The previous default behavior of negative indices in ``Categorical.take`` is deprecated. In a future version it will change from meaning missing values to meaning positional indices from the right. The future behavior is consistent with :meth:`Series.take` (:issue:`20664`).
+- Passing multiple axes to the ``axis`` parameter in :func: `DataFrame.dropna` has been deprecated and will not be suppoted in a future version (:issue:`20987`)
 
 
 .. _whatsnew_0230.prior_deprecations:

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -4168,7 +4168,7 @@ class DataFrame(NDFrame):
 
         Parameters
         ----------
-        axis : {0 or 'index', 1 or 'columns'}
+        axis : {0 or 'index', 1 or 'columns'}, default 0
             Determine if rows or columns which contain missing values are
             removed.
 

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -4175,7 +4175,8 @@ class DataFrame(NDFrame):
             * 0, or 'index' : Drop rows which contain missing values.
             * 1, or 'columns' : Drop columns which contain missing value.
 
-            deprecated:: 0.23.0: Pass tuple or list to drop on multiple axes.
+            .. deprecated:: 0.23.0: Pass tuple or list to drop on multiple
+            axes.
         how : {'any', 'all'}, default 'any'
             Determine if row or column is removed from DataFrame, when we have
             at least one NA or all NA.

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -4168,14 +4168,14 @@ class DataFrame(NDFrame):
 
         Parameters
         ----------
-        axis : {0 or 'index', 1 or 'columns'}, or tuple/list thereof
+        axis : {0 or 'index', 1 or 'columns'}
             Determine if rows or columns which contain missing values are
             removed.
 
             * 0, or 'index' : Drop rows which contain missing values.
             * 1, or 'columns' : Drop columns which contain missing value.
 
-            Pass tuple or list to drop on multiple axes.
+            deprecated:: 0.23.0: Pass tuple or list to drop on multiple axes.
         how : {'any', 'all'}, default 'any'
             Determine if row or column is removed from DataFrame, when we have
             at least one NA or all NA.
@@ -4259,6 +4259,11 @@ class DataFrame(NDFrame):
         """
         inplace = validate_bool_kwarg(inplace, 'inplace')
         if isinstance(axis, (tuple, list)):
+            # GH20987
+            msg = ("supplying multiple axes to axis is deprecated and "
+                   "will be removed in a future version.")
+            warnings.warn(msg, FutureWarning, stacklevel=2)
+
             result = self
             for ax in axis:
                 result = result.dropna(how=how, thresh=thresh, subset=subset,

--- a/pandas/tests/frame/test_missing.py
+++ b/pandas/tests/frame/test_missing.py
@@ -174,8 +174,12 @@ class TestDataFrameMissingData(TestData):
                         [np.nan, np.nan, np.nan, np.nan],
                         [7, np.nan, 8, 9]])
         cp = df.copy()
-        result = df.dropna(how='all', axis=[0, 1])
-        result2 = df.dropna(how='all', axis=(0, 1))
+
+        # GH20987
+        with tm.assert_produces_warning(FutureWarning):
+            result = df.dropna(how='all', axis=[0, 1])
+        with tm.assert_produces_warning(FutureWarning):
+            result2 = df.dropna(how='all', axis=(0, 1))
         expected = df.dropna(how='all').dropna(how='all', axis=1)
 
         assert_frame_equal(result, expected)
@@ -183,7 +187,8 @@ class TestDataFrameMissingData(TestData):
         assert_frame_equal(df, cp)
 
         inp = df.copy()
-        inp.dropna(how='all', axis=(0, 1), inplace=True)
+        with tm.assert_produces_warning(FutureWarning):
+            inp.dropna(how='all', axis=(0, 1), inplace=True)
         assert_frame_equal(inp, expected)
 
     def test_dropna_tz_aware_datetime(self):


### PR DESCRIPTION
Deprecates multiple axes passing to `dropna`.

I added the whatsnew to 0.23.0 for now, I can move this to 0.24.0 later if preferred once the whatsnew doc is created.

- [x] closes #20987
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry
