### PR TITLE
ENH: Raise useful error when iterating a Window

### DIFF
--- a/doc/source/whatsnew/v0.23.0.txt
+++ b/doc/source/whatsnew/v0.23.0.txt
@@ -966,7 +966,7 @@ Other API Changes
 - Constructing a Series from a list of length 1 no longer broadcasts this list when a longer index is specified (:issue:`19714`, :issue:`20391`).
 - :func:`DataFrame.to_dict` with ``orient='index'`` no longer casts int columns to float for a DataFrame with only int and float columns (:issue:`18580`)
 - A user-defined-function that is passed to :func:`Series.rolling().aggregate() <pandas.core.window.Rolling.aggregate>`, :func:`DataFrame.rolling().aggregate() <pandas.core.window.Rolling.aggregate>`, or its expanding cousins, will now *always* be passed a ``Series``, rather than a ``np.array``; ``.apply()`` only has the ``raw`` keyword, see :ref:`here <whatsnew_0230.enhancements.window_raw>`. This is consistent with the signatures of ``.aggregate()`` across pandas (:issue:`20584`)
-- Window types, such as Rolling and Expanding, raise `NotImplementedError` upon iteration. This will ideally be replaced by mimicking the (key, group) iteration of GroupBy (:issue:`11704`).
+- Rolling and Expanding types raise ``NotImplementedError`` upon iteration (:issue:`11704`).
 
 .. _whatsnew_0230.deprecations:
 

--- a/doc/source/whatsnew/v0.23.0.txt
+++ b/doc/source/whatsnew/v0.23.0.txt
@@ -966,6 +966,7 @@ Other API Changes
 - Constructing a Series from a list of length 1 no longer broadcasts this list when a longer index is specified (:issue:`19714`, :issue:`20391`).
 - :func:`DataFrame.to_dict` with ``orient='index'`` no longer casts int columns to float for a DataFrame with only int and float columns (:issue:`18580`)
 - A user-defined-function that is passed to :func:`Series.rolling().aggregate() <pandas.core.window.Rolling.aggregate>`, :func:`DataFrame.rolling().aggregate() <pandas.core.window.Rolling.aggregate>`, or its expanding cousins, will now *always* be passed a ``Series``, rather than a ``np.array``; ``.apply()`` only has the ``raw`` keyword, see :ref:`here <whatsnew_0230.enhancements.window_raw>`. This is consistent with the signatures of ``.aggregate()`` across pandas (:issue:`20584`)
+- Window types, such as Rolling and Expanding, raise `NotImplementedError` upon iteration. This will ideally be replaced by mimicking the (key, group) iteration of GroupBy (:issue:`11704`).
 
 .. _whatsnew_0230.deprecations:
 

--- a/pandas/core/window.py
+++ b/pandas/core/window.py
@@ -183,7 +183,7 @@ class _Window(PandasObject, SelectionMixin):
 
     def __iter__(self):
         url = 'https://github.com/pandas-dev/pandas/issues/11704'
-        raise NotImplementedError('See issue #11704 %s' % (url,))
+        raise NotImplementedError('See issue #11704 {url}'.format(url=url))
 
     def _get_index(self, index=None):
         """

--- a/pandas/core/window.py
+++ b/pandas/core/window.py
@@ -181,6 +181,10 @@ class _Window(PandasObject, SelectionMixin):
         return "{klass} [{attrs}]".format(klass=self._window_type,
                                           attrs=','.join(attrs))
 
+    def __iter__(self):
+        url = 'https://github.com/pandas-dev/pandas/issues/11704'
+        raise NotImplementedError('See issue #11704 %s' % (url,))
+
     def _get_index(self, index=None):
         """
         Return index as ndarrays

--- a/pandas/tests/test_window.py
+++ b/pandas/tests/test_window.py
@@ -512,11 +512,11 @@ class TestRolling(Base):
         tm.assert_index_equal(result.columns, df.columns)
         assert result.index.names == [None, '1', '2']
 
-    @pytest.mark.parametrize('cls', [pd.Series, pd.DataFrame])
-    def test_iter_raises(self, cls):
+    @pytest.mark.parametrize('klass', [pd.Series, pd.DataFrame])
+    def test_iter_raises(self, klass):
         # https://github.com/pandas-dev/pandas/issues/11704
         # Iteration over a Window
-        obj = cls([1, 2, 3, 4])
+        obj = klass([1, 2, 3, 4])
         with pytest.raises(NotImplementedError):
             iter(obj.rolling(2))
 
@@ -598,11 +598,11 @@ class TestExpanding(Base):
         expected = pd.Series([np.nan])
         tm.assert_series_equal(result, expected)
 
-    @pytest.mark.parametrize('cls', [pd.Series, pd.DataFrame])
-    def test_iter_raises(self, cls):
+    @pytest.mark.parametrize('klass', [pd.Series, pd.DataFrame])
+    def test_iter_raises(self, klass):
         # https://github.com/pandas-dev/pandas/issues/11704
         # Iteration over a Window
-        obj = cls([1, 2, 3, 4])
+        obj = klass([1, 2, 3, 4])
         with pytest.raises(NotImplementedError):
             iter(obj.expanding(2))
 

--- a/pandas/tests/test_window.py
+++ b/pandas/tests/test_window.py
@@ -513,7 +513,7 @@ class TestRolling(Base):
         assert result.index.names == [None, '1', '2']
 
     @pytest.mark.parametrize('cls', [pd.Series, pd.DataFrame])
-    def test_iter_raises(cls):
+    def test_iter_raises(self, cls):
         # https://github.com/pandas-dev/pandas/issues/11704
         # Iteration over a Window
         obj = cls([1, 2, 3, 4])
@@ -599,7 +599,7 @@ class TestExpanding(Base):
         tm.assert_series_equal(result, expected)
 
     @pytest.mark.parametrize('cls', [pd.Series, pd.DataFrame])
-    def test_iter_raises(cls):
+    def test_iter_raises(self, cls):
         # https://github.com/pandas-dev/pandas/issues/11704
         # Iteration over a Window
         obj = cls([1, 2, 3, 4])

--- a/pandas/tests/test_window.py
+++ b/pandas/tests/test_window.py
@@ -46,6 +46,27 @@ def win_types_special(request):
     return request.param
 
 
+# Issue 11704: Iteration over a Window
+
+@pytest.fixture
+def series():
+    return pd.Series([1, 2, 3, 4])
+
+@pytest.fixture
+def frame():
+    return pd.DataFrame({'a': [1, 2, 3, 4], 'b': [10, 20, 30, 40]})
+
+@pytest.mark.parametrize('which', [series(), frame()])
+def test_rolling_iterator(which):
+    with pytest.raises(NotImplementedError):
+        iter(which.rolling(2))
+
+@pytest.mark.parametrize('which', [series(), frame()])
+def test_expanding_iterator(which):
+    with pytest.raises(NotImplementedError):
+        iter(which.expanding())
+
+
 class Base(object):
 
     _nan_locs = np.arange(20, 40)


### PR DESCRIPTION
Until Issue #11704 is completed, raise a NotImplementedError to provide
a more clear error message when attempting to iterate over a Rolling
or Expanding window.