### PR TITLE
API: Added axis to take

### DIFF
--- a/pandas/core/algorithms.py
+++ b/pandas/core/algorithms.py
@@ -1448,7 +1448,7 @@ def _get_take_nd_function(ndim, arr_dtype, out_dtype, axis=0, mask_info=None):
     return func
 
 
-def take(arr, indices, allow_fill=False, fill_value=None):
+def take(arr, indices, axis=0, allow_fill=False, fill_value=None):
     """
     Take elements from an array.
 
@@ -1461,6 +1461,8 @@ def take(arr, indices, allow_fill=False, fill_value=None):
         to an ndarray.
     indices : sequence of integers
         Indices to be taken.
+    axis : int, default 0
+        The axis over which to select values.
     allow_fill : bool, default False
         How to handle negative values in `indices`.
 
@@ -1475,6 +1477,9 @@ def take(arr, indices, allow_fill=False, fill_value=None):
         Fill value to use for NA-indices when `allow_fill` is True.
         This may be ``None``, in which case the default NA value for
         the type (``self.dtype.na_value``) is used.
+
+        For multi-dimensional `arr`, each *element* is filled with
+        `fill_value`.
 
     Returns
     -------
@@ -1529,10 +1534,11 @@ def take(arr, indices, allow_fill=False, fill_value=None):
     if allow_fill:
         # Pandas style, -1 means NA
         validate_indices(indices, len(arr))
-        result = take_1d(arr, indices, allow_fill=True, fill_value=fill_value)
+        result = take_1d(arr, indices, axis=axis, allow_fill=True,
+                         fill_value=fill_value)
     else:
         # NumPy style
-        result = arr.take(indices)
+        result = arr.take(indices, axis=axis)
     return result
 
 

--- a/pandas/tests/test_take.py
+++ b/pandas/tests/test_take.py
@@ -447,6 +447,29 @@ class TestTake(object):
         expected[:, [2, 4]] = datetime(2007, 1, 1)
         tm.assert_almost_equal(result, expected)
 
+    def test_take_axis_0(self):
+        arr = np.arange(12).reshape(4, 3)
+        result = algos.take(arr, [0, -1])
+        expected = np.array([[0, 1, 2], [9, 10, 11]])
+        tm.assert_numpy_array_equal(result, expected)
+
+        # allow_fill=True
+        result = algos.take(arr, [0, -1], allow_fill=True, fill_value=0)
+        expected = np.array([[0, 1, 2], [0, 0, 0]])
+        tm.assert_numpy_array_equal(result, expected)
+
+    def test_take_axis_1(self):
+        arr = np.arange(12).reshape(4, 3)
+        result = algos.take(arr, [0, -1], axis=1)
+        expected = np.array([[0, 2], [3, 5], [6, 8], [9, 11]])
+        tm.assert_numpy_array_equal(result, expected)
+
+        # allow_fill=True
+        result = algos.take(arr, [0, -1], axis=1, allow_fill=True,
+                            fill_value=0)
+        expected = np.array([[0, 0], [3, 0], [6, 0], [9, 0]])
+        tm.assert_numpy_array_equal(result, expected)
+
 
 class TestExtensionTake(object):
     # The take method found in pd.api.extensions


### PR DESCRIPTION
- [x] closes #20932 
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`

One thing that's worrisome here: for N-D arrays, the `fill_value` argument is set for each element. In the case of IPArray, this is fine, since my storage NA-value is (0, 0), so I would pass `fill_value=0`. But in general, when people are using an N-D array to back a 1-D column, that won't necessarily work. But at that point, maybe we recommend people implement take on their own.