### PR TITLE
PERF: removed coercion to int64 for arrays of ints in Categorical.from_codes

### DIFF
--- a/asv_bench/benchmarks/categoricals.py
+++ b/asv_bench/benchmarks/categoricals.py
@@ -51,6 +51,7 @@ class Constructor(object):
 
         self.values_some_nan = list(np.tile(self.categories + [np.nan], N))
         self.values_all_nan = [np.nan] * len(self.values)
+        self.values_all_int8 = np.ones(N, 'int8')
 
     def time_regular(self):
         pd.Categorical(self.values, self.categories)
@@ -69,6 +70,9 @@ class Constructor(object):
 
     def time_all_nan(self):
         pd.Categorical(self.values_all_nan)
+
+    def time_from_codes_all_int8(self):
+        pd.Categorical.from_codes(self.values_all_int8, self.categories)
 
 
 class ValueCounts(object):

--- a/doc/source/whatsnew/v0.23.0.txt
+++ b/doc/source/whatsnew/v0.23.0.txt
@@ -1079,6 +1079,7 @@ Performance Improvements
 - Improved performance of :func:`Series.isin` in the case of categorical dtypes (:issue:`20003`)
 - Improved performance of ``getattr(Series, attr)`` when the Series has certain index types. This manifiested in slow printing of large Series with a ``DatetimeIndex`` (:issue:`19764`)
 - Fixed a performance regression for :func:`GroupBy.nth` and :func:`GroupBy.last` with some object columns (:issue:`19283`)
+- Improved performance of :func:`pandas.core.arrays.Categorical.from_codes` (:issue:`18501`)
 
 .. _whatsnew_0230.docs:
 

--- a/pandas/core/arrays/categorical.py
+++ b/pandas/core/arrays/categorical.py
@@ -578,11 +578,7 @@ class Categorical(ExtensionArray, PandasObject):
             unordered.
         """
         try:
-            if (type(codes) == np.ndarray
-                    and np.issubdtype(codes.dtype, np.integer)):
-                codes = np.asarray(codes)
-            else:
-                codes = np.asarray(codes, np.int64)
+            codes = coerce_indexer_dtype(np.asarray(codes), categories)
         except (ValueError, TypeError):
             raise ValueError(
                 "codes need to be convertible to an arrays of integers")

--- a/pandas/core/arrays/categorical.py
+++ b/pandas/core/arrays/categorical.py
@@ -578,7 +578,11 @@ class Categorical(ExtensionArray, PandasObject):
             unordered.
         """
         try:
-            codes = np.asarray(codes, np.int64)
+            if (type(codes) == np.ndarray
+                    and np.issubdtype(codes.dtype, np.integer)):
+                codes = np.asarray(codes)
+            else:
+                codes = np.asarray(codes, np.int64)
         except (ValueError, TypeError):
             raise ValueError(
                 "codes need to be convertible to an arrays of integers")


### PR DESCRIPTION
- [x] closes #18501
- [ ] tests added / **passed**
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry
```
In [3]: arr = np.ones(10000000,dtype='int8')

# master
In [4]: %timeit pd.Categorical.from_codes(arr, ['foo', 'bar'])
44.2 ms ± 545 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)

# after patch
In [4]: %timeit pd.Categorical.from_codes(arr, ['foo', 'bar'])
9 ms ± 54.2 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)
```

```
       before           after         ratio
     [6d5d7015]       [fb1f7b84]
         9.24±1ms       9.94±0.6ms     1.08  categoricals.Concat.time_concat
       5.52±0.1ms      5.41±0.05ms     0.98  categoricals.Concat.time_union
       32.0±0.3ms       32.3±0.3ms     1.01  categoricals.Constructor.time_all_nan
      1.32±0.02ms      1.28±0.01ms     0.97  categoricals.Constructor.time_datetimes
      1.26±0.01ms      1.29±0.02ms     1.02  categoricals.Constructor.time_datetimes_with_nat
          354±3μs          349±7μs     0.99  categoricals.Constructor.time_fastpath
      20.0±0.08ms       20.1±0.3ms     1.01  categoricals.Constructor.time_regular
          185±1ms        186±0.6ms     1.01  categoricals.Constructor.time_with_nan
           10.1ms           10.1ms     0.99  categoricals.Isin.time_isin_categorical('int64')
      10.7±0.08ms      10.8±0.07ms     1.00  categoricals.Isin.time_isin_categorical('object')
       9.11±0.1ms       9.04±0.2ms     0.99  categoricals.Rank.time_rank_int
       9.33±0.1ms       9.37±0.1ms     1.00  categoricals.Rank.time_rank_int_cat
       9.13±0.1ms      8.97±0.05ms     0.98  categoricals.Rank.time_rank_int_cat_ordered
        141±0.9ms          136±1ms     0.97  categoricals.Rank.time_rank_string
       11.2±0.2ms       11.1±0.1ms     0.99  categoricals.Rank.time_rank_string_cat
       9.04±0.1ms       9.23±0.1ms     1.02  categoricals.Rank.time_rank_string_cat_ordered
          592±5μs          586±3μs     0.99  categoricals.Repr.time_rendering
         32.8±2ms       28.4±0.6ms    ~0.86  categoricals.SetCategories.time_set_categories
         31.8±2ms       29.6±0.1ms     0.93  categoricals.ValueCounts.time_value_counts(False)
       30.7±0.1ms       29.3±0.2ms     0.96  categoricals.ValueCounts.time_value_counts(True)
```





