### PR TITLE
CLN: Revert "Return Python integers" (not needed after #20989)

### DIFF
--- a/pandas/_libs/index.pyx
+++ b/pandas/_libs/index.pyx
@@ -195,7 +195,7 @@ cdef class IndexEngine:
         if count > 1:
             return indexer
         if count == 1:
-            return int(found[0])
+            return found[0]
 
         raise KeyError(val)
 

--- a/pandas/_libs/index_class_helper.pxi.in
+++ b/pandas/_libs/index_class_helper.pxi.in
@@ -74,7 +74,7 @@ cdef class {{name}}Engine(IndexEngine):
         if count > 1:
             return indexer
         if count == 1:
-            return int(found[0])
+            return found[0]
 
         raise KeyError(val)
 


### PR DESCRIPTION
This reverts commit 8e3d4d08501dc83d4c2302686c8342e7448c78e5.

- [x] tests passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`

I had introduced the explicit casting to solve broken tests on Windows, but @jreback's #20989 is the correct way to do it, so these are now redundant.
