### PR TITLE
BUG: CategoricalIndex.searchsorted doesn't return a scalar if input was scalar

### DIFF
--- a/doc/source/whatsnew/v0.23.0.txt
+++ b/doc/source/whatsnew/v0.23.0.txt
@@ -1289,9 +1289,6 @@ Indexing
 - Bug in performing in-place operations on a ``DataFrame`` with a duplicate ``Index`` (:issue:`17105`)
 - Bug in :meth:`IntervalIndex.get_loc` and :meth:`IntervalIndex.get_indexer` when used with an :class:`IntervalIndex` containing a single interval (:issue:`17284`, :issue:`20921`)
 - Bug in ``.loc`` with a ``uint64`` indexer (:issue:`20722`)
-- Bug in :func:`CategoricalIndex.searchsorted` where the method did not return a scalar when the input values was scalar (:issue:`21019`)
-- Bug in :class:`CategoricalIndex` where slicing beyond the range of the data raised a KeyError (:issue:`21019`)
-
 
 MultiIndex
 ^^^^^^^^^^

--- a/doc/source/whatsnew/v0.23.0.txt
+++ b/doc/source/whatsnew/v0.23.0.txt
@@ -1289,6 +1289,9 @@ Indexing
 - Bug in performing in-place operations on a ``DataFrame`` with a duplicate ``Index`` (:issue:`17105`)
 - Bug in :meth:`IntervalIndex.get_loc` and :meth:`IntervalIndex.get_indexer` when used with an :class:`IntervalIndex` containing a single interval (:issue:`17284`, :issue:`20921`)
 - Bug in ``.loc`` with a ``uint64`` indexer (:issue:`20722`)
+- Bug in ``CategoricalIndex.searchsorted`` where the method didn't return a scalar when the input values was scalar (:issue:`21019`)
+- Bug in ``CategoricalIndex`` where slicing beyond the range of the data raised a KeyError (:issue:`21019`)
+
 
 MultiIndex
 ^^^^^^^^^^

--- a/doc/source/whatsnew/v0.23.0.txt
+++ b/doc/source/whatsnew/v0.23.0.txt
@@ -1289,8 +1289,8 @@ Indexing
 - Bug in performing in-place operations on a ``DataFrame`` with a duplicate ``Index`` (:issue:`17105`)
 - Bug in :meth:`IntervalIndex.get_loc` and :meth:`IntervalIndex.get_indexer` when used with an :class:`IntervalIndex` containing a single interval (:issue:`17284`, :issue:`20921`)
 - Bug in ``.loc`` with a ``uint64`` indexer (:issue:`20722`)
-- Bug in ``CategoricalIndex.searchsorted`` where the method didn't return a scalar when the input values was scalar (:issue:`21019`)
-- Bug in ``CategoricalIndex`` where slicing beyond the range of the data raised a KeyError (:issue:`21019`)
+- Bug in :func:`CategoricalIndex.searchsorted` where the method did not return a scalar when the input values was scalar (:issue:`21019`)
+- Bug in :class:`CategoricalIndex` where slicing beyond the range of the data raised a KeyError (:issue:`21019`)
 
 
 MultiIndex

--- a/doc/source/whatsnew/v0.23.1.txt
+++ b/doc/source/whatsnew/v0.23.1.txt
@@ -89,8 +89,7 @@ Indexing
 - Bug in :class:`IntervalIndex` constructors where creating an ``IntervalIndex`` from categorical data was not fully supported (:issue:`21243`, issue:`21253`)
 - Bug in :meth:`MultiIndex.sort_index` which was not guaranteed to sort correctly with ``level=1``; this was also causing data misalignment in particular :meth:`DataFrame.stack` operations (:issue:`20994`, :issue:`20945`, :issue:`21052`)
 - Bug in :func:`CategoricalIndex.searchsorted` where the method did not return a scalar when the input values was scalar (:issue:`21019`)
-- Bug in :class:`CategoricalIndex` where slicing beyond the range of the data raised a KeyError (:issue:`21019`)
--
+- Bug in :class:`CategoricalIndex` where slicing beyond the range of the data raised a ``KeyError`` (:issue:`21019`)
 
 I/O
 ^^^

--- a/doc/source/whatsnew/v0.23.1.txt
+++ b/doc/source/whatsnew/v0.23.1.txt
@@ -88,6 +88,8 @@ Indexing
 - Bug in :meth:`MultiIndex.set_names` where error raised for a ``MultiIndex`` with ``nlevels == 1`` (:issue:`21149`)
 - Bug in :class:`IntervalIndex` constructors where creating an ``IntervalIndex`` from categorical data was not fully supported (:issue:`21243`, issue:`21253`)
 - Bug in :meth:`MultiIndex.sort_index` which was not guaranteed to sort correctly with ``level=1``; this was also causing data misalignment in particular :meth:`DataFrame.stack` operations (:issue:`20994`, :issue:`20945`, :issue:`21052`)
+- Bug in :func:`CategoricalIndex.searchsorted` where the method did not return a scalar when the input values was scalar (:issue:`21019`)
+- Bug in :class:`CategoricalIndex` where slicing beyond the range of the data raised a KeyError (:issue:`21019`)
 -
 
 I/O

--- a/pandas/core/arrays/categorical.py
+++ b/pandas/core/arrays/categorical.py
@@ -1343,7 +1343,7 @@ class Categorical(ExtensionArray, PandasObject):
         if -1 in values_as_codes:
             raise ValueError("Value(s) to be inserted must be in categories.")
         if is_scalar(value):
-            values_as_codes = np.asscalar(values_as_codes)
+            values_as_codes = values_as_codes.item()
 
         return self.codes.searchsorted(values_as_codes, side=side,
                                        sorter=sorter)

--- a/pandas/core/arrays/categorical.py
+++ b/pandas/core/arrays/categorical.py
@@ -1342,6 +1342,8 @@ class Categorical(ExtensionArray, PandasObject):
 
         if -1 in values_as_codes:
             raise ValueError("Value(s) to be inserted must be in categories.")
+        if is_scalar(value):
+            values_as_codes = np.asscalar(values_as_codes)
 
         return self.codes.searchsorted(values_as_codes, side=side,
                                        sorter=sorter)

--- a/pandas/core/indexes/category.py
+++ b/pandas/core/indexes/category.py
@@ -432,13 +432,14 @@ class CategoricalIndex(Index, accessor.PandasDelegate):
         >>> monotonic_index.get_loc('b')
         slice(1, 3, None)
 
-        >>> non_monotonic_index = p.dCategoricalIndex(list('abcb'))
+        >>> non_monotonic_index = pd.CategoricalIndex(list('abcb'))
         >>> non_monotonic_index.get_loc('b')
         array([False,  True, False,  True], dtype=bool)
         """
-        codes = self.categories.get_loc(key)
-        if (codes == -1):
-            raise KeyError(key)
+        try:
+            codes = self.categories.get_loc(key)
+        except KeyError:
+            raise KeyError("Category `{}` unknown".format(key))
         return self._engine.get_loc(codes)
 
     def get_value(self, series, key):

--- a/pandas/core/indexes/category.py
+++ b/pandas/core/indexes/category.py
@@ -436,10 +436,10 @@ class CategoricalIndex(Index, accessor.PandasDelegate):
         >>> non_monotonic_index.get_loc('b')
         array([False,  True, False,  True], dtype=bool)
         """
-        try:
-            codes = self.categories.get_loc(key)
-        except KeyError:
-            raise KeyError("Category `{}` unknown".format(key))
+        codes = self.categories.get_loc(key)
+        if (codes == -1):
+            raise KeyError(key)
+
         return self._engine.get_loc(codes)
 
     def get_value(self, series, key):

--- a/pandas/tests/categorical/test_analytics.py
+++ b/pandas/tests/categorical/test_analytics.py
@@ -86,9 +86,9 @@ class TestCategoricalAnalytics(object):
         # Searching for single item argument, side='left' (default)
         res_cat = c1.searchsorted('apple')
         res_ser = s1.searchsorted('apple')
-        exp = np.array([2], dtype=np.intp)
-        tm.assert_numpy_array_equal(res_cat, exp)
-        tm.assert_numpy_array_equal(res_ser, exp)
+        exp = np.int64(2)
+        assert res_cat == exp
+        assert res_ser == exp
 
         # Searching for single item array, side='left' (default)
         res_cat = c1.searchsorted(['bread'])

--- a/pandas/tests/categorical/test_analytics.py
+++ b/pandas/tests/categorical/test_analytics.py
@@ -86,7 +86,7 @@ class TestCategoricalAnalytics(object):
         # Searching for single item argument, side='left' (default)
         res_cat = c1.searchsorted('apple')
         res_ser = s1.searchsorted('apple')
-        exp = np.int64(2)
+        exp = np.intp(2)
         assert res_cat == exp
         assert res_ser == exp
 


### PR DESCRIPTION
`CategoricalIndex.searchsorted` returns the wrong shape for scalar input. Numpy arrays and all other index types return a scalar if the input is a scalar, but the `CategoricalIndex` does not

For example
```
>>> import numpy as np
>>> np.array([1, 2, 3]).searchsorted(1)
0
>>> np.array([1, 2, 3]).searchsorted([1])
array([0])
>>> import pandas as pd
>>> pd.Index([1, 2, 3]).searchsorted(1)
0
>>> pd.Index([1, 2, 3]).searchsorted([1])
array([0])
```

This issue also affects slicing on sorted/ordered categoricals, which is why I've written another test for the slicing.


- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry
- [ ] example in categoricals.rst