### PR TITLE
PERF: __contains__ method for Categorical

### DIFF
--- a/asv_bench/benchmarks/categoricals.py
+++ b/asv_bench/benchmarks/categoricals.py
@@ -193,3 +193,47 @@ class IsMonotonic(object):
 
     def time_categorical_series_is_monotonic_decreasing(self):
         self.s.is_monotonic_decreasing
+
+
+class Contains(object):
+
+    params = (["a", "c", "d", "z", np.nan], [True, False])
+    param_names = ["value", "has_nan"]
+
+    def setup(self, value, has_nan):
+        n = 1 * 10 ** 4
+        obj_values = list("a" * n + "b" * n + "c" * n)
+        if has_nan:
+            obj_values = [np.nan] + obj_values[:-2] + [np.nan]
+
+        self.ci = pd.CategoricalIndex(obj_values, categories=list("abcd"))
+        self.cat = pd.Categorical(obj_values, categories=list("abcd"))
+
+    def time_contains_index(self, value, has_nan):
+        value in self.ci
+
+    def time_cat_isin(self, value, has_nan):
+        value in self.cat
+
+
+class Indexing(object):
+
+    params = (["a", "c"], [True, False])
+    param_names = ["value", "has_nan"]
+
+    def setup(self, value, has_nan):
+        n = 1 * 10 ** 4
+        obj_values = list("a" * n + "b" * n + "c" * n)
+        if has_nan:
+            obj_values = [np.nan] + obj_values[:-2] + [np.nan]
+
+        self.ci = pd.CategoricalIndex(obj_values, categories=list("abcd"))
+        self.cat = pd.Categorical(obj_values, categories=list("abcd"))
+        self.df = pd.DataFrame(dict(A=range(n * 3)), index=self.ci)
+        self.ser = pd.Series(range(n * 3), index=self.ci)
+
+    def time_loc_df(self, value, has_nan):
+        self.df.loc[value]
+
+    def time_loc_ser(self, value, has_nan):
+        self.ser.loc[value]

--- a/asv_bench/benchmarks/categoricals.py
+++ b/asv_bench/benchmarks/categoricals.py
@@ -197,7 +197,14 @@ class IsMonotonic(object):
 
 class Contains(object):
 
-    params = (["a", "c", "d", "z", np.nan], [True, False])
+    params = ([
+        "b",  # in array
+        "d",  # in categories but not in codes
+        "z",  # nowhere
+        np.nan,
+    ],
+        [True, False],
+    )
     param_names = ["value", "has_nan"]
 
     def setup(self, value, has_nan):
@@ -227,10 +234,9 @@ class Indexing(object):
         if has_nan:
             obj_values = [np.nan] + obj_values[:-2] + [np.nan]
 
-        self.ci = pd.CategoricalIndex(obj_values, categories=list("abcd"))
-        self.cat = pd.Categorical(obj_values, categories=list("abcd"))
-        self.df = pd.DataFrame(dict(A=range(n * 3)), index=self.ci)
-        self.ser = pd.Series(range(n * 3), index=self.ci)
+        ci = pd.CategoricalIndex(obj_values, categories=list("abcd"))
+        self.df = pd.DataFrame(dict(A=range(n * 3)), index=ci)
+        self.ser = pd.Series(range(n * 3), index=ci)
 
     def time_loc_df(self, value, has_nan):
         self.df.loc[value]

--- a/doc/source/whatsnew/v0.24.0.txt
+++ b/doc/source/whatsnew/v0.24.0.txt
@@ -64,7 +64,7 @@ Performance Improvements
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
 - Improved performance of :func:`Series.describe` in case of numeric dtpyes (:issue:`21274`)
-- Improved performance of indexing on a Series/DataFrame with a CategoricalIndex
+- Improved performance of indexing on a Series/DataFrame with a ``CategoricalIndex`` (:issue:`21022`)
 
 .. _whatsnew_0240.docs:
 

--- a/doc/source/whatsnew/v0.24.0.txt
+++ b/doc/source/whatsnew/v0.24.0.txt
@@ -83,7 +83,7 @@ Bug Fixes
 Categorical
 ^^^^^^^^^^^
 
--
+- Fixed an issue where membership checks on ``CategoricalIndex`` with interval values may return false positive (:issue:`21022`)
 -
 -
 

--- a/doc/source/whatsnew/v0.24.0.txt
+++ b/doc/source/whatsnew/v0.24.0.txt
@@ -64,7 +64,7 @@ Performance Improvements
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
 - Improved performance of :func:`Series.describe` in case of numeric dtpyes (:issue:`21274`)
--
+- Improved performance of indexing on a Series/DataFrame with a CategoricalIndex
 
 .. _whatsnew_0240.docs:
 

--- a/pandas/core/arrays/categorical.py
+++ b/pandas/core/arrays/categorical.py
@@ -1847,6 +1847,13 @@ class Categorical(ExtensionArray, PandasObject):
         """Returns an Iterator over the values of this Categorical."""
         return iter(self.get_values().tolist())
 
+    def __contains__(self, key):
+        """Returns True if `key` is in this Categorical."""
+        if key in self.categories:
+            return self.categories.get_loc(key) in self.codes
+        else:
+            return False
+
     def _tidy_repr(self, max_vals=10, footer=True):
         """ a short repr displaying only max_vals and an optional (but default
         footer)

--- a/pandas/core/arrays/categorical.py
+++ b/pandas/core/arrays/categorical.py
@@ -1849,10 +1849,14 @@ class Categorical(ExtensionArray, PandasObject):
 
     def __contains__(self, key):
         """Returns True if `key` is in this Categorical."""
-        if key in self.categories:
-            return self.categories.get_loc(key) in self.codes
-        elif isna(key) and self.isna().any():
-            return True
+        hash(key)
+        if isna(key):
+            return self.isna().any()
+        elif self.categories._defer_to_indexing:  # e.g. Interval values
+            loc = self.categories.get_loc(key)
+            return np.isin(self.codes, loc).any()
+        elif key in self.categories:
+            return self.categories.get_loc(key) in self._codes
         else:
             return False
 

--- a/pandas/core/arrays/categorical.py
+++ b/pandas/core/arrays/categorical.py
@@ -1851,6 +1851,8 @@ class Categorical(ExtensionArray, PandasObject):
         """Returns True if `key` is in this Categorical."""
         if key in self.categories:
             return self.categories.get_loc(key) in self.codes
+        elif isna(key) and self.isna().any():
+            return True
         else:
             return False
 

--- a/pandas/core/indexes/category.py
+++ b/pandas/core/indexes/category.py
@@ -323,20 +323,10 @@ class CategoricalIndex(Index, accessor.PandasDelegate):
 
     @Appender(_index_shared_docs['__contains__'] % _index_doc_kwargs)
     def __contains__(self, key):
-        hash(key)
-
-        if self.categories._defer_to_indexing:
-            return key in self.categories
-
         return key in self.values
 
     @Appender(_index_shared_docs['contains'] % _index_doc_kwargs)
     def contains(self, key):
-        hash(key)
-
-        if self.categories._defer_to_indexing:
-            return self.categories.contains(key)
-
         return key in self.values
 
     def __array__(self, dtype=None):

--- a/pandas/tests/indexes/test_category.py
+++ b/pandas/tests/indexes/test_category.py
@@ -244,6 +244,10 @@ class TestCategoricalIndex(Base):
             list('aabbca') + [np.nan], categories=list('cabdef'))
         assert np.nan in ci
 
+        ci = CategoricalIndex(
+            list('aaa'), categories=list('cabdef'))
+        assert 'f' not in ci
+
     def test_min_max(self):
 
         ci = self.create_index(ordered=False)

--- a/pandas/tests/indexes/test_category.py
+++ b/pandas/tests/indexes/test_category.py
@@ -248,6 +248,13 @@ class TestCategoricalIndex(Base):
             list('aaa'), categories=list('cabdef'))
         assert 'f' not in ci
 
+    def test_containst_defer_to_indexing(self):
+        intervals = pd.interval_range(1, 4)
+        cat = pd.CategoricalIndex(list(intervals[:-1]), categories=intervals)
+        assert intervals[0] in cat
+        assert intervals[1] in cat
+        assert intervals[2] not in cat
+
     def test_min_max(self):
 
         ci = self.create_index(ordered=False)


### PR DESCRIPTION
Calling `key in Categorical(...)` trivially falls back to calling `__iter__` and then forces a full construction of the array by invoking `get_values`. 
This implementation is faster in best case situations than using .e.g.`any(Categorical.isin(key))` since we do not care about the complete array. Not sure if I need to handle any edge cases, though.

This obviously can't reach the performance of a simple Index but is a bit faster than before

before:
```
· Discovering benchmarks
· Running 1 total benchmarks (1 commits * 1 environments * 1 benchmarks)
[  0.00%] ·· Building for existing-py_Users_fjetter_miniconda2_envs_pandas-dev_bin_python
[  0.00%] ·· Benchmarking existing-py_Users_fjetter_miniconda2_envs_pandas-dev_bin_python
[100.00%] ··· Running categoricals.Slicing.time_loc_categorical                                         2.04ms
```
after
```
· Discovering benchmarks
· Running 1 total benchmarks (1 commits * 1 environments * 1 benchmarks)
[  0.00%] ·· Building for existing-py_Users_fjetter_miniconda2_envs_pandas-dev_bin_python
[  0.00%] ·· Benchmarking existing-py_Users_fjetter_miniconda2_envs_pandas-dev_bin_python
[100.00%] ··· Running categoricals.Slicing.time_loc_categorical                                       852.58μs
```

- [x] closes #20395
- [x] benchmark added
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry

cc @topper-123 