### PR TITLE
PERF: improved performance of CategoricalIndex.is_monotonic*

### DIFF
--- a/asv_bench/benchmarks/categoricals.py
+++ b/asv_bench/benchmarks/categoricals.py
@@ -173,3 +173,23 @@ class Isin(object):
 
     def time_isin_categorical(self, dtype):
         self.series.isin(self.sample)
+
+
+class IsMonotonic(object):
+
+    def setup(self):
+        N = 1000
+        self.c = pd.CategoricalIndex(list('a' * N + 'b' * N + 'c' * N))
+        self.s = pd.Series(self.c)
+
+    def time_categorical_index_is_monotonic_increasing(self):
+        self.c.is_monotonic_increasing
+
+    def time_categorical_index_is_monotonic_decreasing(self):
+        self.c.is_monotonic_decreasing
+
+    def time_categorical_series_is_monotonic_increasing(self):
+        self.s.is_monotonic_increasing
+
+    def time_categorical_series_is_monotonic_decreasing(self):
+        self.s.is_monotonic_decreasing

--- a/doc/source/whatsnew/v0.23.1.txt
+++ b/doc/source/whatsnew/v0.23.1.txt
@@ -29,6 +29,7 @@ Deprecations
 Performance Improvements
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
+- Improved performance of :meth:`CategoricalIndex.is_monotonic_increasing`, :meth:`CategoricalIndex.is_monotonic_decreasing` and :meth:`CategoricalIndex.is_monotonic` (:issue:`21025`)
 -
 -
 

--- a/pandas/core/indexes/category.py
+++ b/pandas/core/indexes/category.py
@@ -382,11 +382,11 @@ class CategoricalIndex(Index, accessor.PandasDelegate):
 
     @property
     def is_monotonic_increasing(self):
-        return Index(self.codes).is_monotonic_increasing
+        return self._engine.is_monotonic_increasing
 
     @property
     def is_monotonic_decreasing(self):
-        return Index(self.codes).is_monotonic_decreasing
+        return self._engine.is_monotonic_decreasing
 
     @Appender(_index_shared_docs['index_unique'] % _index_doc_kwargs)
     def unique(self, level=None):

--- a/pandas/tests/indexes/test_category.py
+++ b/pandas/tests/indexes/test_category.py
@@ -543,35 +543,41 @@ class TestCategoricalIndex(Base):
         tm.assert_numpy_array_equal(indexer,
                                     np.array([-1, -1], dtype=np.intp))
 
-    def test_is_monotonic(self):
-        c = CategoricalIndex([1, 2, 3])
+    @pytest.mark.parametrize('data, non_lexsorted_data', [
+        [[1, 2, 3], [9, 0, 1, 2, 3]],
+        [list('abc'), list('fabcd')],
+    ])
+    def test_is_monotonic(self, data, non_lexsorted_data):
+        c = CategoricalIndex(data)
         assert c.is_monotonic_increasing
         assert not c.is_monotonic_decreasing
 
-        c = CategoricalIndex([1, 2, 3], ordered=True)
+        c = CategoricalIndex(data, ordered=True)
         assert c.is_monotonic_increasing
         assert not c.is_monotonic_decreasing
 
-        c = CategoricalIndex([1, 2, 3], categories=[3, 2, 1])
+        c = CategoricalIndex(data, categories=reversed(data))
         assert not c.is_monotonic_increasing
         assert c.is_monotonic_decreasing
 
-        c = CategoricalIndex([1, 3, 2], categories=[3, 2, 1])
+        c = CategoricalIndex(data, categories=reversed(data), ordered=True)
+        assert not c.is_monotonic_increasing
+        assert c.is_monotonic_decreasing
+
+        # test when data is neither monotonic increasing nor decreasing
+        reordered_data = [data[0], data[2], data[1]]
+        c = CategoricalIndex(reordered_data, categories=reversed(data))
         assert not c.is_monotonic_increasing
         assert not c.is_monotonic_decreasing
-
-        c = CategoricalIndex([1, 2, 3], categories=[3, 2, 1], ordered=True)
-        assert not c.is_monotonic_increasing
-        assert c.is_monotonic_decreasing
 
         # non lexsorted categories
-        categories = [9, 0, 1, 2, 3]
+        categories = non_lexsorted_data
 
-        c = CategoricalIndex([9, 0], categories=categories)
+        c = CategoricalIndex(categories[:2], categories=categories)
         assert c.is_monotonic_increasing
         assert not c.is_monotonic_decreasing
 
-        c = CategoricalIndex([0, 1], categories=categories)
+        c = CategoricalIndex(categories[1:3], categories=categories)
         assert c.is_monotonic_increasing
         assert not c.is_monotonic_decreasing
 


### PR DESCRIPTION
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry

```python
>>> n = 1000000
>>> ci = pd.CategoricalIndex(list('a' * n + 'b' * n + 'c' * n))
>>> %t ci.is_monotonic_increasing
22 ms # v0.22 and master
227 ns  # this commit
```

There seem to be a few more like this, where ``CategoricalIndex`` should use ``self._engine`` but doesn't. 

@TomAugspurger?