### PR TITLE
BUG: Iteration over DatetimeIndex stops at chunksize (GH21012)

### DIFF
--- a/pandas/core/indexes/datetimes.py
+++ b/pandas/core/indexes/datetimes.py
@@ -1365,7 +1365,8 @@ class DatetimeIndex(DatelikeOps, TimelikeOps, DatetimeIndexOpsMixin,
             converted = libts.ints_to_pydatetime(data[start_i:end_i],
                                                  tz=self.tz, freq=self.freq,
                                                  box="timestamp")
-            return iter(converted)
+            for v in converted:
+                yield v
 
     def _wrap_union_result(self, other, result):
         name = self.name if self.name == other.name else None

--- a/pandas/tests/indexes/datetimes/test_datetime.py
+++ b/pandas/tests/indexes/datetimes/test_datetime.py
@@ -153,6 +153,17 @@ class TestDatetimeIndex(object):
             assert result._repr_base == expected._repr_base
             assert result == expected
 
+    @pytest.mark.parametrize('periods', [0, 9999, 10000, 10001])
+    def test_iteration_over_chunksize(self, periods):
+        # GH21012
+
+        index = date_range('2000-01-01 00:00:00', periods=periods, freq='min')
+        num = 0
+        for stamp in index:
+            assert index[num] == stamp
+            num += 1
+        assert num == len(index)
+
     def test_misc_coverage(self):
         rng = date_range('1/1/2000', periods=5)
         result = rng.groupby(rng.day)


### PR DESCRIPTION
- [x] closes #21012
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

avoided using `yield` and changing DatetimeIndex itself into a iterator. @cbertinato 's advice was helpful.