### PR TITLE
Fix Inconsistent MultiIndex Sorting

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -4685,7 +4685,6 @@ class DataFrame(NDFrame):
             result.index = result.index.swaplevel(i, j)
         else:
             result.columns = result.columns.swaplevel(i, j)
-
         return result
 
     def reorder_levels(self, order, axis=0):

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -4454,7 +4454,10 @@ class DataFrame(NDFrame):
         axis = self._get_axis_number(axis)
         labels = self._get_axis(axis)
 
-        if level:
+        # make sure that the axis is lexsorted to start
+        # if not we need to reconstruct to get the correct indexer
+        labels = labels._sort_levels_monotonic()
+        if level is not None:
 
             new_axis, indexer = labels.sortlevel(level, ascending=ascending,
                                                  sort_remaining=sort_remaining)
@@ -4462,9 +4465,6 @@ class DataFrame(NDFrame):
         elif isinstance(labels, MultiIndex):
             from pandas.core.sorting import lexsort_indexer
 
-            # make sure that the axis is lexsorted to start
-            # if not we need to reconstruct to get the correct indexer
-            labels = labels._sort_levels_monotonic()
             indexer = lexsort_indexer(labels._get_labels_for_sorting(),
                                       orders=ascending,
                                       na_position=na_position)
@@ -4685,6 +4685,7 @@ class DataFrame(NDFrame):
             result.index = result.index.swaplevel(i, j)
         else:
             result.columns = result.columns.swaplevel(i, j)
+
         return result
 
     def reorder_levels(self, order, axis=0):

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -2616,7 +2616,7 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
         axis = self._get_axis_number(axis)
         index = self.index
 
-        if level:
+        if level is not None:
             new_index, indexer = index.sortlevel(level, ascending=ascending,
                                                  sort_remaining=sort_remaining)
         elif isinstance(index, MultiIndex):

--- a/pandas/tests/frame/test_reshape.py
+++ b/pandas/tests/frame/test_reshape.py
@@ -871,7 +871,7 @@ class TestDataFrameReshape(TestData):
 
         expected = pd.DataFrame([
             [3, 1, 2, 0]], columns=pd.MultiIndex.from_tuples([
-                ('c', 'A'), ('c', 'B'),('d', 'A'), ('d', 'B')], names=[
+                ('c', 'A'), ('c', 'B'), ('d', 'A'), ('d', 'B')], names=[
                     'baz', 'foo']))
         expected.index.name = 'bar'
 

--- a/pandas/tests/frame/test_reshape.py
+++ b/pandas/tests/frame/test_reshape.py
@@ -861,6 +861,23 @@ class TestDataFrameReshape(TestData):
 
                 tm.assert_series_equal(result, expected)
 
+    @pytest.mark.parametrize("level", [0, 'baz'])
+    def test_unstack_swaplevel(self, level):
+        # GH 20994
+        mi = pd.MultiIndex.from_product([[0], ['d', 'c']],
+                                        names=['bar', 'baz'])
+        df = pd.DataFrame([[0, 2], [1, 3]], index=mi, columns=['B', 'A'])
+        df.columns.name = 'foo'
+
+        expected = pd.DataFrame([
+            [3, 1, 2, 0]], columns=pd.MultiIndex.from_tuples([
+                ('c', 'A'), ('c', 'B'),('d', 'A'), ('d', 'B')], names=[
+                    'baz', 'foo']))
+        expected.index.name = 'bar'
+
+        result = df.unstack().swaplevel(axis=1).sort_index(axis=1, level=level)
+        tm.assert_frame_equal(result, expected)
+
 
 def test_unstack_fill_frame_object():
     # GH12815 Test unstacking with object.

--- a/pandas/tests/frame/test_reshape.py
+++ b/pandas/tests/frame/test_reshape.py
@@ -862,7 +862,7 @@ class TestDataFrameReshape(TestData):
                 tm.assert_series_equal(result, expected)
 
     @pytest.mark.parametrize("level", [0, 'baz'])
-    def test_unstack_swaplevel(self, level):
+    def test_unstack_swaplevel_sortlevel(self, level):
         # GH 20994
         mi = pd.MultiIndex.from_product([[0], ['d', 'c']],
                                         names=['bar', 'baz'])

--- a/pandas/tests/frame/test_sorting.py
+++ b/pandas/tests/frame/test_sorting.py
@@ -550,18 +550,36 @@ class TestDataFrameSortIndexKinds(TestData):
         expected = frame.iloc[:, ::-1]
         assert_frame_equal(result, expected)
 
-    def test_sort_index_multiindex(self):
+    @pytest.mark.parametrize("level", ['A', 0])  # GH 21052
+    def test_sort_index_multiindex(self, level):
         # GH13496
 
         # sort rows by specified level of multi-index
-        mi = MultiIndex.from_tuples([[2, 1, 3], [1, 1, 1]], names=list('ABC'))
-        df = DataFrame([[1, 2], [3, 4]], mi)
+        mi = MultiIndex.from_tuples([
+            [2, 1, 3], [2, 1, 2], [1, 1, 1]], names=list('ABC'))
+        df = DataFrame([[1, 2], [3, 4], [5, 6]], index=mi)
 
-        # MI sort, but no level: sort_level has no effect
-        mi = MultiIndex.from_tuples([[1, 1, 3], [1, 1, 1]], names=list('ABC'))
-        df = DataFrame([[1, 2], [3, 4]], mi)
-        result = df.sort_index(sort_remaining=False)
-        expected = df.sort_index()
+        expected_mi = MultiIndex.from_tuples([
+            [1, 1, 1],
+            [2, 1, 2],
+            [2, 1, 3]], names=list('ABC'))
+        expected = pd.DataFrame([
+            [5, 6],
+            [3, 4],
+            [1, 2]], index=expected_mi)
+        result = df.sort_index(level=level)
+        assert_frame_equal(result, expected)
+
+        # sort_remaining=False
+        expected_mi = MultiIndex.from_tuples([
+            [1, 1, 1],
+            [2, 1, 3],
+            [2, 1, 2]], names=list('ABC'))
+        expected = pd.DataFrame([
+            [5, 6],
+            [1, 2],
+            [3, 4]], index=expected_mi)
+        result = df.sort_index(level=level, sort_remaining=False)
         assert_frame_equal(result, expected)
 
     def test_sort_index_intervalindex(self):

--- a/pandas/tests/series/test_sorting.py
+++ b/pandas/tests/series/test_sorting.py
@@ -141,19 +141,20 @@ class TestSeriesSorting(TestData):
         assert result is None
         tm.assert_series_equal(random_order, self.ts)
 
-    def test_sort_index_multiindex(self):
+    @pytest.mark.parametrize("level", ['A', 0])  # GH 21052
+    def test_sort_index_multiindex(self, level):
 
         mi = MultiIndex.from_tuples([[1, 1, 3], [1, 1, 1]], names=list('ABC'))
         s = Series([1, 2], mi)
         backwards = s.iloc[[1, 0]]
 
         # implicit sort_remaining=True
-        res = s.sort_index(level='A')
+        res = s.sort_index(level=level)
         assert_series_equal(backwards, res)
 
         # GH13496
-        # rows share same level='A': sort has no effect without remaining lvls
-        res = s.sort_index(level='A', sort_remaining=False)
+        # sort has no effect without remaining lvls
+        res = s.sort_index(level=level, sort_remaining=False)
         assert_series_equal(s, res)
 
     def test_sort_index_kind(self):


### PR DESCRIPTION
closes #20994
closes #20945
closes #21052
- [X] tests added / passed
- [X] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

This is a pretty dark corner and I'll admit that I don't fully understand all of the elements in play. That said, the first problem I noticed with the first referenced issue was an errant conditional that was causing `level=0` and `level='foo'` to go down two different branches, even if the name of the first level was in fact 'foo'.

After uncovering that, the subsequent ordering of the returned index then was incorrect regardless of the argument. I moved a monotonic sort around to fix this, though I feel like:

 - There may be a more general purpose solution to fix this AND
 - There may be more expressive tests to add here

Feedback appreciated