### PR TITLE
DOC: Fix find_undoc_args script to use getfullargspec()

### DIFF
--- a/scripts/find_undoc_args.py
+++ b/scripts/find_undoc_args.py
@@ -62,7 +62,7 @@ def cmp_docstring_sig(f):
         path = f.__code__.co_filename.split(args.path, 1)[-1][1:]
         return dict(path=path, lnum=f.__code__.co_firstlineno)
 
-    sig_names = set(inspect.getargspec(f).args)
+    sig_names = set(inspect.getfullargspec(f).args)
     # XXX numpydoc can be used to get the list of parameters
     doc = f.__doc__.lower()
     doc = re.split('^\s*parameters\s*', doc, 1, re.M)[-1]


### PR DESCRIPTION
Use [getfullargspec](https://docs.python.org/3/library/inspect.html#inspect.getfullargspec) instead of [getargspec](https://docs.python.org/3/library/inspect.html#inspect.getargspec) to fix the find_undoc_args.py script

