### PR TITLE
BUG: Keep original name in str.cat

### DIFF
--- a/pandas/core/strings.py
+++ b/pandas/core/strings.py
@@ -2320,9 +2320,9 @@ class StringMethods(NoNewAttributesMixin):
         res = str_cat(data, others=others, sep=sep, na_rep=na_rep)
 
         if isinstance(self._orig, Index):
-            res = Index(res)
+            res = Index(res, name=self._orig.name)
         else:  # Series
-            res = Series(res, index=data.index)
+            res = Series(res, index=data.index, name=self._orig.name)
         return res
 
     @copy(str_split)

--- a/pandas/tests/test_strings.py
+++ b/pandas/tests/test_strings.py
@@ -144,6 +144,19 @@ class TestStringMethods(object):
         with tm.assert_raises_regex(ValueError, rgx):
             strings.str_cat(one, 'three')
 
+    @pytest.mark.parametrize('container', [Series, Index])
+    @pytest.mark.parametrize('other', [None, Series, Index])
+    def test_str_cat_name(self, container, other):
+        # https://github.com/pandas-dev/pandas/issues/21053
+        values = ['a', 'b']
+        if other:
+            other = other(values)
+        else:
+            other = values
+        result = container(values, name='name').str.cat(other, sep=',',
+                                                        join='left')
+        assert result.name == 'name'
+
     @pytest.mark.parametrize('series_or_index', ['series', 'index'])
     def test_str_cat(self, series_or_index):
         # test_cat above tests "str_cat" from ndarray to ndarray;


### PR DESCRIPTION
Closes https://github.com/pandas-dev/pandas/issues/21053

cc @jreback @jorisvandenbossche @h-vetinari for a quick check if you have a chance.