### PR TITLE
DOC: updated docstring for nanoseconds function per doc guidelines

### DIFF
--- a/pandas/_libs/tslibs/timedeltas.pyx
+++ b/pandas/_libs/tslibs/timedeltas.pyx
@@ -803,7 +803,6 @@ cdef class _Timedelta(timedelta):
         Timedelta.components : Return all attributes with assigned values (i.e.
             days, hours, minutes, seconds, milliseconds, microseconds, nanoseconds).
 
-
         Examples
         --------
         **Using string input**
@@ -812,12 +811,11 @@ cdef class _Timedelta(timedelta):
         >>> td.nanoseconds
         42
 
-        **Using integer inputs**
+        **Using integer input**
 
         >>> td = pd.Timedelta(42, unit='ns')
         >>> td.nanoseconds
         42 
-
         """
         self._ensure_components()
         return self._ns

--- a/pandas/_libs/tslibs/timedeltas.pyx
+++ b/pandas/_libs/tslibs/timedeltas.pyx
@@ -800,8 +800,9 @@ cdef class _Timedelta(timedelta):
 
         See Also
         --------
-        Timedelta.components : Return all attributes with assigned values (i.e.
-            days, hours, minutes, seconds, milliseconds, microseconds, nanoseconds).
+        Timedelta.components : Return all attributes with assigned values
+            (i.e. days, hours, minutes, seconds, milliseconds, microseconds,
+            nanoseconds).
 
         Examples
         --------
@@ -815,7 +816,7 @@ cdef class _Timedelta(timedelta):
 
         >>> td = pd.Timedelta(42, unit='ns')
         >>> td.nanoseconds
-        42 
+        42
         """
         self._ensure_components()
         return self._ns

--- a/pandas/_libs/tslibs/timedeltas.pyx
+++ b/pandas/_libs/tslibs/timedeltas.pyx
@@ -795,12 +795,27 @@ cdef class _Timedelta(timedelta):
         
         Returns
         -------
-        int : Number of nanoseconds
+        int
+            Number of nanoseconds.
 
         See Also
         --------
         Timedelta.components : Return all attributes with assigned values (i.e.
-            days, seconds, microseconds, nanoseconds)
+            days, hours, minutes, seconds, milliseconds, microseconds, nanoseconds).
+
+
+        Examples
+        --------
+        >>> td = pd.Timedelta('1 days 2 min 3 us 42 ns')
+        >>> td.nanoseconds
+        42
+
+        **Using integer inputs**
+
+        >>> td = pd.Timedelta(42, unit='ns')
+        >>> td.nanoseconds
+        42 
+
         """
         self._ensure_components()
         return self._ns

--- a/pandas/_libs/tslibs/timedeltas.pyx
+++ b/pandas/_libs/tslibs/timedeltas.pyx
@@ -795,8 +795,7 @@ cdef class _Timedelta(timedelta):
         
         Returns
         -------
-        int
-            Number of nanoseconds
+        int : Number of nanoseconds
 
         See Also
         --------

--- a/pandas/_libs/tslibs/timedeltas.pyx
+++ b/pandas/_libs/tslibs/timedeltas.pyx
@@ -789,9 +789,17 @@ cdef class _Timedelta(timedelta):
     @property
     def nanoseconds(self):
         """
-        Number of nanoseconds (>= 0 and less than 1 microsecond).
+        Return the number of nanoseconds (n), where 0 <= n < 1 microsecond.
+        
+        Returns
+        -------
+        int
+            Number of nanoseconds
 
-        .components will return the shown components
+        See Also
+        --------
+        Timedelta.components : Return all attributes with assigned values (i.e.
+            days, seconds, microseconds, nanoseconds)
         """
         self._ensure_components()
         return self._ns

--- a/pandas/_libs/tslibs/timedeltas.pyx
+++ b/pandas/_libs/tslibs/timedeltas.pyx
@@ -806,6 +806,7 @@ cdef class _Timedelta(timedelta):
 
         Examples
         --------
+        **Using string input**
         >>> td = pd.Timedelta('1 days 2 min 3 us 42 ns')
         >>> td.nanoseconds
         42

--- a/pandas/_libs/tslibs/timedeltas.pyx
+++ b/pandas/_libs/tslibs/timedeltas.pyx
@@ -807,6 +807,7 @@ cdef class _Timedelta(timedelta):
         Examples
         --------
         **Using string input**
+
         >>> td = pd.Timedelta('1 days 2 min 3 us 42 ns')
         >>> td.nanoseconds
         42

--- a/pandas/_libs/tslibs/timedeltas.pyx
+++ b/pandas/_libs/tslibs/timedeltas.pyx
@@ -792,7 +792,7 @@ cdef class _Timedelta(timedelta):
     def nanoseconds(self):
         """
         Return the number of nanoseconds (n), where 0 <= n < 1 microsecond.
-        
+       
         Returns
         -------
         int


### PR DESCRIPTION
- [ ] closes #xxxx
- [ ] tests added / passed
- [X] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

```
################################################################################
################### Docstring (pandas.Timedelta.nanoseconds) ###################
################################################################################

Return the number of nanoseconds (n), where 0 <= n < 1 microsecond.

Returns
-------
int : Number of nanoseconds

See Also
--------
Timedelta.components : Return all attributes with assigned values (i.e.
    days, seconds, microseconds, nanoseconds)

################################################################################
################################## Validation ##################################
################################################################################

Errors found:
	No extended summary found
	No examples section found
```