### PR TITLE
Prevent Unlimited Agg Recursion with Duplicate Col Names

### DIFF
--- a/doc/source/whatsnew/v0.23.1.txt
+++ b/doc/source/whatsnew/v0.23.1.txt
@@ -43,7 +43,10 @@ Documentation Changes
 Bug Fixes
 ~~~~~~~~~
 
--
+Groupby/Resample/Rolling
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+- Bug in :func:`DataFrame.agg` where applying multiple aggregation functions to a :class:`DataFrame` with duplicated column names would cause a stack overflow (:issue:`21063`)
 -
 
 Conversion

--- a/pandas/core/base.py
+++ b/pandas/core/base.py
@@ -590,9 +590,9 @@ class SelectionMixin(object):
 
         # multiples
         else:
-            for col in obj:
+            for index, col in enumerate(obj):
                 try:
-                    colg = self._gotitem(col, ndim=1, subset=obj[col])
+                    colg = self._gotitem(col, ndim=1, subset=obj.iloc[:, [index]])
                     results.append(colg.aggregate(arg))
                     keys.append(col)
                 except (TypeError, DataError):
@@ -675,7 +675,6 @@ class GroupByMixin(object):
         subset : object, default None
             subset to act on
         """
-
         # create a new object to prevent aliasing
         if subset is None:
             subset = self.obj

--- a/pandas/core/base.py
+++ b/pandas/core/base.py
@@ -593,7 +593,7 @@ class SelectionMixin(object):
             for index, col in enumerate(obj):
                 try:
                     colg = self._gotitem(col, ndim=1,
-                                         subset=obj.iloc[:, [index]])
+                                         subset=obj.iloc[:, index])
                     results.append(colg.aggregate(arg))
                     keys.append(col)
                 except (TypeError, DataError):

--- a/pandas/core/base.py
+++ b/pandas/core/base.py
@@ -592,7 +592,8 @@ class SelectionMixin(object):
         else:
             for index, col in enumerate(obj):
                 try:
-                    colg = self._gotitem(col, ndim=1, subset=obj.iloc[:, [index]])
+                    colg = self._gotitem(col, ndim=1,
+                                         subset=obj.iloc[:, [index]])
                     results.append(colg.aggregate(arg))
                     keys.append(col)
                 except (TypeError, DataError):

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -5731,7 +5731,12 @@ class DataFrame(NDFrame):
     # ----------------------------------------------------------------------
     # Function application
 
-    def _gotitem(self, key, ndim, subset=None):
+    def _gotitem(self,
+                 key,           # type: Union[str, List[str]]
+                 ndim,          # type: int
+                 subset=None    # type: Union[Series, DataFrame, None]
+                 ):
+        # type: (...) -> Union[Series, DataFrame]
         """
         sub-classes to define
         return a sliced object

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -5746,6 +5746,8 @@ class DataFrame(NDFrame):
         """
         if subset is None:
             subset = self
+        elif subset.ndim == 1:
+            subset = self._constructor(subset)
 
         # TODO: _shallow_copy(subset)?
         return subset[key]

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -5748,7 +5748,7 @@ class DataFrame(NDFrame):
             subset = self
 
         # TODO: _shallow_copy(subset)?
-        return self[key]
+        return subset[key]
 
     _agg_doc = dedent("""
     The aggregation operations are always performed over an axis, either the

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -5751,8 +5751,8 @@ class DataFrame(NDFrame):
         """
         if subset is None:
             subset = self
-        elif subset.ndim == 1:
-            subset = self._constructor(subset)
+        elif subset.ndim == 1:  # is Series
+            return subset
 
         # TODO: _shallow_copy(subset)?
         return subset[key]

--- a/pandas/tests/frame/test_apply.py
+++ b/pandas/tests/frame/test_apply.py
@@ -554,6 +554,14 @@ class TestDataFrameApply(TestData):
         result = df.apply(lambda x: x)
         assert_frame_equal(result, df)
 
+    def test_apply_dup_names_multi_agg(self):
+        # GH 21063
+        df = pd.DataFrame([[0, 1], [2, 3]], columns=['a', 'a'])
+        expected = pd.DataFrame([[0, 1]], columns=['a', 'a'], index=['min'])
+        result = df.agg(['min'])
+
+        tm.assert_frame_equal(result, expected)
+
 
 class TestInferOutputShape(object):
     # the user has supplied an opaque UDF where


### PR DESCRIPTION
- [X] closes #21063
- [X] tests added / passed
- [X] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry

The `_gotitem` implementation for `DataFrame` seems a little strange so there may be a more comprehensive approach, but this should prevent the issue for the time being

Didn't add whatsnew yet since none existed for 0.23.1. Happy to add if we are OK with this fix