### PR TITLE
DOC: Correct the date of whatsnew v0.23 #21067

### DIFF
--- a/doc/source/whatsnew/v0.23.0.txt
+++ b/doc/source/whatsnew/v0.23.0.txt
@@ -1,6 +1,6 @@
 .. _whatsnew_0230:
 
-v0.23.0 (May 15, 2017)
+v0.23.0 (May 15, 2018)
 ----------------------
 
 This is a major release from 0.22.0 and includes a number of API changes,


### PR DESCRIPTION
- [x] closes #21067
- [x] tests added / passed (NA, just the DOC)
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry
