### PR TITLE
BUG: to_records() fails for MultiIndex DF (#21064)

### DIFF
--- a/doc/source/whatsnew/v0.24.0.txt
+++ b/doc/source/whatsnew/v0.24.0.txt
@@ -131,7 +131,7 @@ Indexing
 MultiIndex
 ^^^^^^^^^^
 
--
+- Bug :func:`to_records` fails for empty MultiIndex DF (:issue:`21064`)
 -
 -
 

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -1392,7 +1392,13 @@ class DataFrame(NDFrame):
             else:
                 if isinstance(self.index, MultiIndex):
                     # array of tuples to numpy cols. copy copy copy
-                    ix_vals = lmap(np.array, zip(*self.index.values))
+                    tuples = self.index.values
+                    if len(tuples):
+                        ix_vals = lmap(np.array, zip(*tuples))
+                    else:
+                        # empty MultiIndex DF
+                        ix_vals = [np.array([], dtype=lev.dtype)
+                                   for lev in self.index.levels]
                 else:
                     ix_vals = [self.index.values]
 


### PR DESCRIPTION
- [x] closes #21064
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry

This fixes the bug that prevents using `to_records` on an empty dataframe that has a MultiIndex

`self.index.values` returns an empty array (no tuples) for an empty MultiIndex DF and that would be used for `ix_values`. Instead, `ix_values should have an array of empty arrays, each one with the correct dtype according to the MultiIndex level/column.