### PR TITLE
BUG: assert_index_equal does not raise error for check_categorical=False when comparing 2 CategoricalIndex objects

### DIFF
--- a/doc/source/whatsnew/v0.23.1.txt
+++ b/doc/source/whatsnew/v0.23.1.txt
@@ -49,7 +49,7 @@ Bug Fixes
 Categorical
 ^^^^^^^^^^^
 
-- Bug in :func:`pandas.util.testing.assert_index_equal` raised ``AssertionError`` if comparing two :class:`CategoricalIndex` objects when ``check_categorical=False`` (:issue:`19776`)
+- Bug in :func:`pandas.util.testing.assert_index_equal` which raised ``AssertionError`` incorrectly, when comparing two :class:`CategoricalIndex` objects with param ``check_categorical=False`` (:issue:`19776`)
 
 Conversion
 ^^^^^^^^^^

--- a/doc/source/whatsnew/v0.23.1.txt
+++ b/doc/source/whatsnew/v0.23.1.txt
@@ -46,6 +46,11 @@ Bug Fixes
 -
 -
 
+Categorical
+^^^^^^^^^^^
+
+- Bug in :func:`pandas.util.testing.assert_index_equal` raised ``AssertionError`` if comparing two :class:`CategoricalIndex` objects when ``check_categorical=False`` (:issue:`19776`)
+
 Conversion
 ^^^^^^^^^^
 

--- a/doc/source/whatsnew/v0.24.0.txt
+++ b/doc/source/whatsnew/v0.24.0.txt
@@ -76,7 +76,7 @@ Bug Fixes
 Categorical
 ^^^^^^^^^^^
 
-- Bug in :func:`pandas.util.testing.assert_index_equal` raised ``AssertionError`` when comparing two :class:`CategoricalIndex` objects when ``check_categorical=False`` (:issue:`19776`)
+- Bug in :func:`pandas.util.testing.assert_index_equal` raised ``AssertionError`` if comparing two :class:`CategoricalIndex` objects when ``check_categorical=False`` (:issue:`19776`)
 -
 -
 

--- a/doc/source/whatsnew/v0.24.0.txt
+++ b/doc/source/whatsnew/v0.24.0.txt
@@ -76,7 +76,7 @@ Bug Fixes
 Categorical
 ^^^^^^^^^^^
 
-- Bug in :func:`pandas.util.testing.assert_index_equal` raised ``AssertionError`` if comparing two :class:`CategoricalIndex` objects when ``check_categorical=False`` (:issue:`19776`)
+-
 -
 -
 

--- a/doc/source/whatsnew/v0.24.0.txt
+++ b/doc/source/whatsnew/v0.24.0.txt
@@ -76,7 +76,7 @@ Bug Fixes
 Categorical
 ^^^^^^^^^^^
 
--
+- Bug in :func:`pandas.util.testing.assert_index_equal` raised ``AssertionError`` when comparing two :class:`CategoricalIndex` objects when ``check_categorical=False`` (:issue:`19776`)
 -
 -
 

--- a/pandas/tests/util/test_testing.py
+++ b/pandas/tests/util/test_testing.py
@@ -508,7 +508,8 @@ Attribute "names" are different
 
 Attribute "dtype" are different
 \\[left\\]:  CategoricalDtype\\(categories=\\[u?'a', u?'b'\\], ordered=False\\)
-\\[right\\]: CategoricalDtype\\(categories=\\[u?'a', u?'b', u?'c'\\], ordered=False\\)"""  # noqa
+\\[right\\]: CategoricalDtype\\(categories=\\[u?'a', u?'b', u?'c'\\], \
+ordered=False\\)"""
 
         with tm.assert_raises_regex(AssertionError, expected):
             assert_index_equal(pd.Index(pd.Categorical(['a', 'b'])),
@@ -623,7 +624,8 @@ Series values are different \\(33\\.33333 %\\)
 
 Attribute "dtype" are different
 \\[left\\]:  CategoricalDtype\\(categories=\\[u?'a', u?'b'\\], ordered=False\\)
-\\[right\\]: CategoricalDtype\\(categories=\\[u?'a', u?'b', u?'c'\\], ordered=False\\)"""  # noqa
+\\[right\\]: CategoricalDtype\\(categories=\\[u?'a', u?'b', u?'c'\\], \
+ordered=False\\)"""
 
         with tm.assert_raises_regex(AssertionError, expected):
             assert_series_equal(pd.Series(pd.Categorical(['a', 'b'])),

--- a/pandas/tests/util/test_testing.py
+++ b/pandas/tests/util/test_testing.py
@@ -507,8 +507,8 @@ Attribute "names" are different
         expected = """Index are different
 
 Attribute "dtype" are different
-\\[left\\]:  CategoricalDtype\\(categories=\\['a', 'b'\\], ordered=False\\)
-\\[right\\]: CategoricalDtype\\(categories=\\['a', 'b', 'c'\\], ordered=False\\)"""  # noqa
+\\[left\\]:  CategoricalDtype\\(categories=\\[u'a', u'b'\\], ordered=False\\)
+\\[right\\]: CategoricalDtype\\(categories=\\[u'a', u'b', u'c'\\], ordered=False\\)"""  # noqa
 
         with tm.assert_raises_regex(AssertionError, expected):
             assert_index_equal(pd.Index(pd.Categorical(['a', 'b'])),
@@ -622,8 +622,8 @@ Series values are different \\(33\\.33333 %\\)
         expected = """Attributes are different
 
 Attribute "dtype" are different
-\\[left\\]:  CategoricalDtype\\(categories=\\['a', 'b'\\], ordered=False\\)
-\\[right\\]: CategoricalDtype\\(categories=\\['a', 'b', 'c'\\], ordered=False\\)"""  # noqa
+\\[left\\]:  CategoricalDtype\\(categories=\\[u'a', u'b'\\], ordered=False\\)
+\\[right\\]: CategoricalDtype\\(categories=\\[u'a', u'b', u'c'\\], ordered=False\\)"""  # noqa
 
         with tm.assert_raises_regex(AssertionError, expected):
             assert_series_equal(pd.Series(pd.Categorical(['a', 'b'])),

--- a/pandas/tests/util/test_testing.py
+++ b/pandas/tests/util/test_testing.py
@@ -507,8 +507,8 @@ Attribute "names" are different
         expected = """Index are different
 
 Attribute "dtype" are different
-\\[left\\]:  CategoricalDtype\\(categories=\\[u'a', u'b'\\], ordered=False\\)
-\\[right\\]: CategoricalDtype\\(categories=\\[u'a', u'b', u'c'\\], ordered=False\\)"""  # noqa
+\\[left\\]:  CategoricalDtype\\(categories=\\[u?'a', u?'b'\\], ordered=False\\)
+\\[right\\]: CategoricalDtype\\(categories=\\[u?'a', u?'b', u?'c'\\], ordered=False\\)"""  # noqa
 
         with tm.assert_raises_regex(AssertionError, expected):
             assert_index_equal(pd.Index(pd.Categorical(['a', 'b'])),
@@ -622,8 +622,8 @@ Series values are different \\(33\\.33333 %\\)
         expected = """Attributes are different
 
 Attribute "dtype" are different
-\\[left\\]:  CategoricalDtype\\(categories=\\[u'a', u'b'\\], ordered=False\\)
-\\[right\\]: CategoricalDtype\\(categories=\\[u'a', u'b', u'c'\\], ordered=False\\)"""  # noqa
+\\[left\\]:  CategoricalDtype\\(categories=\\[u?'a', u?'b'\\], ordered=False\\)
+\\[right\\]: CategoricalDtype\\(categories=\\[u?'a', u?'b', u?'c'\\], ordered=False\\)"""  # noqa
 
         with tm.assert_raises_regex(AssertionError, expected):
             assert_series_equal(pd.Series(pd.Categorical(['a', 'b'])),

--- a/pandas/tests/util/test_testing.py
+++ b/pandas/tests/util/test_testing.py
@@ -508,7 +508,7 @@ Attribute "names" are different
 
 Attribute "dtype" are different
 \\[left\\]:  CategoricalDtype\\(categories=\\['a', 'b'\\], ordered=False\\)
-\\[right\\]: CategoricalDtype\\(categories=\\['a', 'b', 'c'\\], ordered=False\\)""" # noqa
+\\[right\\]: CategoricalDtype\\(categories=\\['a', 'b', 'c'\\], ordered=False\\)"""  # noqa
 
         with tm.assert_raises_regex(AssertionError, expected):
             assert_index_equal(pd.Index(pd.Categorical(['a', 'b'])),
@@ -623,7 +623,7 @@ Series values are different \\(33\\.33333 %\\)
 
 Attribute "dtype" are different
 \\[left\\]:  CategoricalDtype\\(categories=\\['a', 'b'\\], ordered=False\\)
-\\[right\\]: CategoricalDtype\\(categories=\\['a', 'b', 'c'\\], ordered=False\\)""" # noqa
+\\[right\\]: CategoricalDtype\\(categories=\\['a', 'b', 'c'\\], ordered=False\\)"""  # noqa
 
         with tm.assert_raises_regex(AssertionError, expected):
             assert_series_equal(pd.Series(pd.Categorical(['a', 'b'])),

--- a/pandas/tests/util/test_testing.py
+++ b/pandas/tests/util/test_testing.py
@@ -503,6 +503,24 @@ Attribute "names" are different
         with tm.assert_raises_regex(AssertionError, expected):
             assert_index_equal(idx1, idx2)
 
+    def test_categorical_index_equality(self):
+        expected = """Index are different
+
+Attribute "dtype" are different
+\\[left\\]:  CategoricalDtype\\(categories=\\['a', 'b'\\], ordered=False\\)
+\\[right\\]: CategoricalDtype\\(categories=\\['a', 'b', 'c'\\], ordered=False\\)""" # noqa
+
+        with tm.assert_raises_regex(AssertionError, expected):
+            assert_index_equal(pd.Index(pd.Categorical(['a', 'b'])),
+                               pd.Index(pd.Categorical(['a', 'b'],
+                                        categories=['a', 'b', 'c'])))
+
+    def test_categorical_index_equality_relax_categories_check(self):
+        assert_index_equal(pd.Index(pd.Categorical(['a', 'b'])),
+                           pd.Index(pd.Categorical(['a', 'b'],
+                                    categories=['a', 'b', 'c'])),
+                           check_categorical=False)
+
 
 class TestAssertSeriesEqual(object):
 
@@ -599,6 +617,24 @@ Series values are different \\(33\\.33333 %\\)
         with tm.assert_raises_regex(AssertionError, expected):
             assert_series_equal(pd.Series([1, 2, 3]), pd.Series([1, 2, 4]),
                                 check_less_precise=True)
+
+    def test_categorical_series_equality(self):
+        expected = """Attributes are different
+
+Attribute "dtype" are different
+\\[left\\]:  CategoricalDtype\\(categories=\\['a', 'b'\\], ordered=False\\)
+\\[right\\]: CategoricalDtype\\(categories=\\['a', 'b', 'c'\\], ordered=False\\)""" # noqa
+
+        with tm.assert_raises_regex(AssertionError, expected):
+            assert_series_equal(pd.Series(pd.Categorical(['a', 'b'])),
+                                pd.Series(pd.Categorical(['a', 'b'],
+                                          categories=['a', 'b', 'c'])))
+
+    def test_categorical_series_equality_relax_categories_check(self):
+        assert_series_equal(pd.Series(pd.Categorical(['a', 'b'])),
+                            pd.Series(pd.Categorical(['a', 'b'],
+                                      categories=['a', 'b', 'c'])),
+                            check_categorical=False)
 
 
 class TestAssertFrameEqual(object):

--- a/pandas/util/testing.py
+++ b/pandas/util/testing.py
@@ -964,14 +964,14 @@ def assert_categorical_equal(left, right, check_dtype=True,
     right : Categorical
     check_dtype : bool, default True
         Check that integer dtype of the codes are the same
-    obj : str, default 'Categorical'
-        Specify object name being compared, internally used to show appropriate
-        assertion message
     check_category_order : bool, default True
         Whether the order of the categories should be compared, which
         implies identical integer codes.  If False, only the resulting
         values are compared.  The ordered attribute is
         checked regardless.
+    obj : str, default 'Categorical'
+        Specify object name being compared, internally used to show appropriate
+        assertion message
     """
     _check_isinstance(left, right, Categorical)
 

--- a/pandas/util/testing.py
+++ b/pandas/util/testing.py
@@ -1025,7 +1025,7 @@ def raise_assert_detail(obj, message, left, right, diff=None):
 
 def assert_numpy_array_equal(left, right, strict_nan=False,
                              check_dtype=True, err_msg=None,
-                             obj='numpy array', check_same=None):
+                             check_same=None, obj='numpy array'):
     """ Checks that 'np.ndarray' is equivalent
 
     Parameters
@@ -1038,11 +1038,11 @@ def assert_numpy_array_equal(left, right, strict_nan=False,
         check dtype if both a and b are np.ndarray
     err_msg : str, default None
         If provided, used as assertion message
+    check_same : None|'copy'|'same', default None
+        Ensure left and right refer/do not refer to the same memory area
     obj : str, default 'numpy array'
         Specify object name being compared, internally used to show appropriate
         assertion message
-    check_same : None|'copy'|'same', default None
-        Ensure left and right refer/do not refer to the same memory area
     """
 
     # instance validation

--- a/pandas/util/testing.py
+++ b/pandas/util/testing.py
@@ -778,8 +778,12 @@ def assert_index_equal(left, right, exact='equiv', check_names=True,
 
     def _check_types(l, r, obj='Index'):
         if exact:
-            assert_class_equal(left, right, exact=exact, obj=obj)
-            assert_attr_equal('dtype', l, r, obj=obj)
+            assert_class_equal(l, r, exact=exact, obj=obj)
+
+            # Skip exact dtype checking with `check_categorical` is False
+            if check_categorical:
+                assert_attr_equal('dtype', l, r, obj=obj)
+
             # allow string-like to have different inferred_types
             if l.inferred_type in ('string', 'unicode'):
                 assert r.inferred_type in ('string', 'unicode')
@@ -829,7 +833,8 @@ def assert_index_equal(left, right, exact='equiv', check_names=True,
             # get_level_values may change dtype
             _check_types(left.levels[level], right.levels[level], obj=obj)
 
-    if check_exact:
+    # skip exact index checking when `check_categorical` is False
+    if check_exact and check_categorical:
         if not left.equals(right):
             diff = np.sum((left.values != right.values)
                           .astype(int)) * 100.0 / len(left)

--- a/pandas/util/testing.py
+++ b/pandas/util/testing.py
@@ -780,7 +780,7 @@ def assert_index_equal(left, right, exact='equiv', check_names=True,
         if exact:
             assert_class_equal(l, r, exact=exact, obj=obj)
 
-            # Skip exact dtype checking with `check_categorical` is False
+            # Skip exact dtype checking when `check_categorical` is False
             if check_categorical:
                 assert_attr_equal('dtype', l, r, obj=obj)
 
@@ -833,8 +833,8 @@ def assert_index_equal(left, right, exact='equiv', check_names=True,
             # get_level_values may change dtype
             _check_types(left.levels[level], right.levels[level], obj=obj)
 
-    run_exact_index_check = check_exact and check_categorical
-    if run_exact_index_check:
+    # skip exact index checking when `check_categorical` is False
+    if check_exact and check_categorical:
         if not left.equals(right):
             diff = np.sum((left.values != right.values)
                           .astype(int)) * 100.0 / len(left)

--- a/pandas/util/testing.py
+++ b/pandas/util/testing.py
@@ -833,8 +833,8 @@ def assert_index_equal(left, right, exact='equiv', check_names=True,
             # get_level_values may change dtype
             _check_types(left.levels[level], right.levels[level], obj=obj)
 
-    # skip exact index checking when `check_categorical` is False
-    if check_exact and check_categorical:
+    run_exact_index_check = check_exact and check_categorical
+    if run_exact_index_check:
         if not left.equals(right):
             diff = np.sum((left.values != right.values)
                           .astype(int)) * 100.0 / len(left)

--- a/pandas/util/testing.py
+++ b/pandas/util/testing.py
@@ -955,13 +955,13 @@ def is_sorted(seq):
 
 
 def assert_categorical_equal(left, right, check_dtype=True,
-                             obj='Categorical', check_category_order=True):
+                             check_category_order=True, obj='Categorical'):
     """Test that Categoricals are equivalent.
 
     Parameters
     ----------
-    left, right : Categorical
-        Categoricals to compare
+    left : Categorical
+    right : Categorical
     check_dtype : bool, default True
         Check that integer dtype of the codes are the same
     obj : str, default 'Categorical'


### PR DESCRIPTION
- [x] closes #19776 
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry

* tests added for `check_categorical` parameter in `assert_series_equal`
* cleaned up `assert_categorical_equal` parameter order and docstring to match other functions (`obj` at the end)

Thanks to all maintainers who helped answer questions on Gitter during the informal PyCon sprint!