### PR TITLE
BUG: type aliasing is not allowed to be compared using isinstance()

### DIFF
--- a/doc/source/whatsnew/v0.23.1.txt
+++ b/doc/source/whatsnew/v0.23.1.txt
@@ -48,6 +48,11 @@ Groupby/Resample/Rolling
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
 - Bug in :func:`DataFrame.agg` where applying multiple aggregation functions to a :class:`DataFrame` with duplicated column names would cause a stack overflow (:issue:`21063`)
+
+Strings
+^^^^^^^
+
+- Bug in :meth:`Series.str.replace()` where the method throws `TypeError` on Python 3.5.2
 -
 
 Conversion

--- a/doc/source/whatsnew/v0.23.1.txt
+++ b/doc/source/whatsnew/v0.23.1.txt
@@ -52,7 +52,7 @@ Groupby/Resample/Rolling
 Strings
 ^^^^^^^
 
-- Bug in :meth:`Series.str.replace()` where the method throws `TypeError` on Python 3.5.2
+- Bug in :meth:`Series.str.replace()` where the method throws `TypeError` on Python 3.5.2 (:issue: `21078`)
 -
 
 Conversion

--- a/pandas/compat/__init__.py
+++ b/pandas/compat/__init__.py
@@ -425,7 +425,7 @@ parse_date = _date_parser.parse
 
 # In Python 3.7, the private re._pattern_type is removed.
 # Python 3.5+ have typing.re.Pattern
-if PY35:
+if sys.version_info >= (3, 5, 4):
     import typing
     re_type = typing.re.Pattern
 else:

--- a/pandas/compat/__init__.py
+++ b/pandas/compat/__init__.py
@@ -425,7 +425,7 @@ parse_date = _date_parser.parse
 
 # In Python 3.7, the private re._pattern_type is removed.
 # Python 3.5+ have typing.re.Pattern
-if sys.version_info >= (3, 5, 4):
+if PY36:
     import typing
     re_type = typing.re.Pattern
 else:

--- a/pandas/tests/test_compat.py
+++ b/pandas/tests/test_compat.py
@@ -6,7 +6,7 @@ Testing that functions from compat work as expected
 import pytest
 from pandas.compat import (range, zip, map, filter, lrange, lzip, lmap,
                            lfilter, builtins, iterkeys, itervalues, iteritems,
-                           next, get_range_parameters, PY2)
+                           next, get_range_parameters, PY2, re_type)
 
 
 class TestBuiltinIterators(object):
@@ -89,3 +89,8 @@ class TestCompatFunctions(object):
         assert start_result == start_expected
         assert stop_result == stop_expected
         assert step_result == step_expected
+
+
+def test_re_type():
+    import re
+    assert isinstance(re.compile(''), re_type)

--- a/pandas/tests/test_compat.py
+++ b/pandas/tests/test_compat.py
@@ -4,6 +4,7 @@ Testing that functions from compat work as expected
 """
 
 import pytest
+import re
 from pandas.compat import (range, zip, map, filter, lrange, lzip, lmap,
                            lfilter, builtins, iterkeys, itervalues, iteritems,
                            next, get_range_parameters, PY2, re_type)
@@ -92,5 +93,4 @@ class TestCompatFunctions(object):
 
 
 def test_re_type():
-    import re
     assert isinstance(re.compile(''), re_type)


### PR DESCRIPTION
- [X] closes #21078
- [ ] tests added / passed
- [X] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

As raised in #21078, Python 3.5.4 supports the using `isinstance()` with `typing.re.Pattern` But it does not support the same method in 3.5.2.

``` Python
Python 3.5.2 (default, Nov 23 2017, 16:37:01)
[GCC 5.4.0 20160609] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import re
>>> import typing
>>> isinstance(re.compile(''), typing.re.Pattern)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/lib/python3.5/typing.py", line 260, in __instancecheck__
    raise TypeError("Type aliases cannot be used with isinstance().")
TypeError: Type aliases cannot be used with isinstance().
```

This Bugfix PR is to revert the `re_type` to be back to what it used to be before the update with the new release.
