### PR TITLE
Replaced open with Context Mgrs in Parser Tests

### DIFF
--- a/pandas/tests/io/parser/common.py
+++ b/pandas/tests/io/parser/common.py
@@ -54,20 +54,22 @@ bar2,12,13,14,15
         # and C engine will raise UnicodeDecodeError instead of
         # c engine raising ParserError and swallowing exception
         # that caused read to fail.
-        handle = open(self.csv_shiftjs, "rb")
         codec = codecs.lookup("utf-8")
         utf8 = codecs.lookup('utf-8')
-        # stream must be binary UTF8
-        stream = codecs.StreamRecoder(
-            handle, utf8.encode, utf8.decode, codec.streamreader,
-            codec.streamwriter)
+
         if compat.PY3:
             msg = "'utf-8' codec can't decode byte"
         else:
             msg = "'utf8' codec can't decode byte"
-        with tm.assert_raises_regex(UnicodeDecodeError, msg):
-            self.read_csv(stream)
-        stream.close()
+
+        # stream must be binary UTF8
+        with open(self.csv_shiftjs, "rb") as handle, codecs.StreamRecoder(
+                handle, utf8.encode, utf8.decode, codec.streamreader,
+                codec.streamwriter) as stream:
+
+            with tm.assert_raises_regex(UnicodeDecodeError, msg):
+                self.read_csv(stream)
+
 
     def test_read_csv(self):
         if not compat.PY3:

--- a/pandas/tests/io/parser/common.py
+++ b/pandas/tests/io/parser/common.py
@@ -70,7 +70,6 @@ bar2,12,13,14,15
             with tm.assert_raises_regex(UnicodeDecodeError, msg):
                 self.read_csv(stream)
 
-
     def test_read_csv(self):
         if not compat.PY3:
             if compat.is_platform_windows():

--- a/pandas/tests/io/parser/compression.py
+++ b/pandas/tests/io/parser/compression.py
@@ -110,16 +110,15 @@ class CompressionTests(object):
         # see gh-9770
         expected = self.read_csv(self.csv1, index_col=0, parse_dates=True)
 
-        inputs = [self.csv1, self.csv1 + '.gz',
-                  self.csv1 + '.bz2', open(self.csv1)]
+        with open(self.csv1) as f:
+            inputs = [self.csv1, self.csv1 + '.gz',
+                      self.csv1 + '.bz2', f]
 
-        for f in inputs:
-            df = self.read_csv(f, index_col=0, parse_dates=True,
-                               compression='infer')
+            for inp in inputs:
+                df = self.read_csv(inp, index_col=0, parse_dates=True,
+                                   compression='infer')
 
-            tm.assert_frame_equal(expected, df)
-
-        inputs[3].close()
+                tm.assert_frame_equal(expected, df)
 
     def test_read_csv_compressed_utf16_example(self):
         # GH18071

--- a/pandas/tests/io/parser/test_textreader.py
+++ b/pandas/tests/io/parser/test_textreader.py
@@ -35,24 +35,18 @@ class TestTextReader(object):
         self.xls1 = os.path.join(self.dirpath, 'test.xls')
 
     def test_file_handle(self):
-        try:
-            f = open(self.csv1, 'rb')
+        with open(self.csv1, 'rb') as f:
             reader = TextReader(f)
-            result = reader.read()  # noqa
-        finally:
-            f.close()
+            reader.read()
 
     def test_string_filename(self):
         reader = TextReader(self.csv1, header=None)
         reader.read()
 
     def test_file_handle_mmap(self):
-        try:
-            f = open(self.csv1, 'rb')
+        with open(self.csv1, 'rb') as f:
             reader = TextReader(f, memory_map=True, header=None)
             reader.read()
-        finally:
-            f.close()
 
     def test_StringIO(self):
         with open(self.csv1, 'rb') as f:


### PR DESCRIPTION
Maybe closes #21102 and #19984, though if not should still work as a general cleanup