### PR TITLE
ENH: add np.nan funcs to _cython_table

### DIFF
--- a/doc/source/whatsnew/v0.23.1.txt
+++ b/doc/source/whatsnew/v0.23.1.txt
@@ -94,3 +94,8 @@ Categorical
 ^^^^^^^^^^^
 
 -
+
+Numeric
+^^^^^^^
+
+- :meth:`~DataFrame.agg` now correctly handles numpy NaN-aware methods like :meth:`numpy.nansum` (:issue:`19629`)

--- a/doc/source/whatsnew/v0.23.1.txt
+++ b/doc/source/whatsnew/v0.23.1.txt
@@ -99,3 +99,4 @@ Numeric
 ^^^^^^^
 
 - :meth:`~DataFrame.agg` now correctly handles numpy NaN-aware methods like :meth:`numpy.nansum` (:issue:`19629`)
+- :meth:`~DataFrame.agg` now correctly handles built-in methods like ``sum`` when axis=1 (:issue:`21134`)

--- a/pandas/conftest.py
+++ b/pandas/conftest.py
@@ -149,3 +149,20 @@ def tz_aware_fixture(request):
     Fixture for trying explicit timezones: {0}
     """
     return request.param
+
+
+@pytest.fixture(
+    # params: Python 3.5 randomizes dict access and xdist doesn't like that
+    # in fixtures. In order to get predetermined values we need to sort
+    # the list deterministically
+    # GH 21123
+    params=list(sorted(pd.core.base.SelectionMixin._cython_table.items(),
+                       key=lambda x: x[0].__name__)),
+    ids=lambda x: "({}-{!r})".format(x[0].__name__, x[1]),
+)
+def cython_table_items(request):
+    """
+    Fixture for returning the items in
+    pandas.core.base.SelectionMixin._cython_table
+    """
+    return request.param

--- a/pandas/conftest.py
+++ b/pandas/conftest.py
@@ -158,7 +158,7 @@ def tz_aware_fixture(request):
     # GH 21123
     params=list(sorted(pd.core.base.SelectionMixin._cython_table.items(),
                        key=lambda x: x[0].__name__)),
-    ids=lambda x: "({}-{!r})".format(x[0].__name__, x[1]),
+    ids=lambda x: "({}-{!r})_fixture".format(x[0].__name__, x[1]),
 )
 def cython_table_items(request):
     """

--- a/pandas/core/base.py
+++ b/pandas/core/base.py
@@ -22,7 +22,8 @@ from pandas.errors import AbstractMethodError
 from pandas.core import common as com, algorithms
 import pandas.core.nanops as nanops
 import pandas._libs.lib as lib
-from pandas.compat.numpy import function as nv
+from pandas.compat.numpy import (function as nv, _np_version_under1p10,
+                                 _np_version_under1p12)
 from pandas.compat import PYPY
 from pandas.util._decorators import (Appender, cache_readonly,
                                      deprecate_kwarg, Substitution)
@@ -191,16 +192,30 @@ class SelectionMixin(object):
         np.all: 'all',
         np.any: 'any',
         np.sum: 'sum',
+        np.nansum: 'sum',
         np.mean: 'mean',
+        np.nanmean: 'mean',
         np.prod: 'prod',
         np.std: 'std',
+        np.nanstd: 'std',
         np.var: 'var',
+        np.nanvar: 'var',
         np.median: 'median',
+        np.nanmedian: 'median',
         np.max: 'max',
+        np.nanmax: 'max',
         np.min: 'min',
+        np.nanmin: 'min',
         np.cumprod: 'cumprod',
-        np.cumsum: 'cumsum'
+        np.cumsum: 'cumsum',
     }
+
+    if not _np_version_under1p10:
+        _cython_table[np.nanprod] = 'prod'
+
+    if not _np_version_under1p12:
+        _cython_table[np.nancumprod] = 'cumprod'
+        _cython_table[np.nancumsum] = 'cumsum'
 
     @property
     def _selection_name(self):
@@ -553,8 +568,8 @@ class SelectionMixin(object):
             result = None
 
         f = self._is_cython_func(arg)
-        if f and not args and not kwargs:
-            return getattr(self, f)(), None
+        if f:
+            return getattr(self, f)(*args, **kwargs), None
 
         # caller can react
         return result, True

--- a/pandas/core/base.py
+++ b/pandas/core/base.py
@@ -568,7 +568,7 @@ class SelectionMixin(object):
             result = None
 
         f = self._is_cython_func(arg)
-        if f:
+        if f is not None:
             return getattr(self, f)(*args, **kwargs), None
 
         # caller can react

--- a/pandas/core/base.py
+++ b/pandas/core/base.py
@@ -331,13 +331,14 @@ class SelectionMixin(object):
 
         raise ValueError("{arg} is an unknown string function".format(arg=arg))
 
-    def _aggregate(self, arg, *args, **kwargs):
+    def _aggregate(self, arg, axis=0, *args, **kwargs):
         """
         provide an implementation for the aggregators
 
         Parameters
         ----------
         arg : string, dict, function
+        axis : int
         *args : args to pass on to the function
         **kwargs : kwargs to pass on to the function
 
@@ -350,17 +351,18 @@ class SelectionMixin(object):
         how can be a string describe the required post-processing, or
         None if not required
         """
+        obj = self if axis == 0 else self.T
         is_aggregator = lambda x: isinstance(x, (list, tuple, dict))
         is_nested_renamer = False
 
         _axis = kwargs.pop('_axis', None)
         if _axis is None:
-            _axis = getattr(self, 'axis', 0)
+            _axis = getattr(obj, 'axis', 0)
         _level = kwargs.pop('_level', None)
 
         if isinstance(arg, compat.string_types):
-            return self._try_aggregate_string_function(arg, *args,
-                                                       **kwargs), None
+            return obj._try_aggregate_string_function(arg, *args,
+                                                      **kwargs), None
 
         if isinstance(arg, dict):
 
@@ -368,7 +370,7 @@ class SelectionMixin(object):
             if _axis != 0:  # pragma: no cover
                 raise ValueError('Can only pass dict with axis=0')
 
-            obj = self._selected_obj
+            selected_obj = obj._selected_obj
 
             def nested_renaming_depr(level=4):
                 # deprecation of nested renaming
@@ -403,16 +405,16 @@ class SelectionMixin(object):
                     if isinstance(v, dict):
                         is_nested_renamer = True
 
-                        if k not in obj.columns:
+                        if k not in selected_obj.columns:
                             msg = ('cannot perform renaming for {key} with a '
                                    'nested dictionary').format(key=k)
                             raise SpecificationError(msg)
                         nested_renaming_depr(4 + (_level or 0))
 
-                    elif isinstance(obj, ABCSeries):
+                    elif isinstance(selected_obj, ABCSeries):
                         nested_renaming_depr()
-                    elif isinstance(obj, ABCDataFrame) and \
-                            k not in obj.columns:
+                    elif isinstance(selected_obj, ABCDataFrame) and \
+                            k not in selected_obj.columns:
                         raise KeyError(
                             "Column '{col}' does not exist!".format(col=k))
 
@@ -422,8 +424,8 @@ class SelectionMixin(object):
                 # deprecation of renaming keys
                 # GH 15931
                 keys = list(compat.iterkeys(arg))
-                if (isinstance(obj, ABCDataFrame) and
-                        len(obj.columns.intersection(keys)) != len(keys)):
+                if (isinstance(selected_obj, ABCDataFrame) and len(
+                        selected_obj.columns.intersection(keys)) != len(keys)):
                     nested_renaming_depr()
 
             from pandas.core.reshape.concat import concat
@@ -432,7 +434,7 @@ class SelectionMixin(object):
                 """
                 aggregate a 1-dim with how
                 """
-                colg = self._gotitem(name, ndim=1, subset=subset)
+                colg = obj._gotitem(name, ndim=1, subset=subset)
                 if colg.ndim != 1:
                     raise SpecificationError("nested dictionary is ambiguous "
                                              "in aggregation")
@@ -442,8 +444,8 @@ class SelectionMixin(object):
                 """
                 aggregate a 2-dim with how
                 """
-                colg = self._gotitem(self._selection, ndim=2,
-                                     subset=obj)
+                colg = obj._gotitem(obj._selection, ndim=2,
+                                    subset=selected_obj)
                 return colg.aggregate(how, _level=None)
 
             def _agg(arg, func):
@@ -473,20 +475,22 @@ class SelectionMixin(object):
 
                 else:
 
-                    if self._selection is not None:
+                    if obj._selection is not None:
                         keys = None
 
             # some selection on the object
-            elif self._selection is not None:
+            elif obj._selection is not None:
 
-                sl = set(self._selection_list)
+                sl = set(obj._selection_list)
 
                 # we are a Series like object,
                 # but may have multiple aggregations
                 if len(sl) == 1:
 
-                    result = _agg(arg, lambda fname,
-                                  agg_how: _agg_1dim(self._selection, agg_how))
+                    result = _agg(
+                        arg,
+                        lambda fname, agg_how: _agg_1dim(
+                            obj._selection, agg_how))
 
                 # we are selecting the same set as we are aggregating
                 elif not len(sl - set(keys)):
@@ -531,7 +535,7 @@ class SelectionMixin(object):
                 return concat([result[k] for k in keys],
                               keys=keys, axis=1), True
 
-            elif isinstance(self, ABCSeries) and is_any_series():
+            elif isinstance(obj, ABCSeries) and is_any_series():
 
                 # we have a dict of Series
                 # return a MI Series
@@ -556,20 +560,20 @@ class SelectionMixin(object):
 
                 # we have a dict of scalars
                 result = Series(result,
-                                name=getattr(self, 'name', None))
+                                name=getattr(obj, 'name', None))
 
             return result, True
         elif is_list_like(arg) and arg not in compat.string_types:
             # we require a list, but not an 'str'
-            return self._aggregate_multiple_funcs(arg,
-                                                  _level=_level,
-                                                  _axis=_axis), None
+            return obj._aggregate_multiple_funcs(arg,
+                                                 _level=_level,
+                                                 _axis=_axis), None
         else:
             result = None
 
-        f = self._is_cython_func(arg)
+        f = obj._is_cython_func(arg)
         if f is not None:
-            return getattr(self, f)(*args, **kwargs), None
+            return getattr(obj, f)(*args, **kwargs), None
 
         # caller can react
         return result, True

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -5818,13 +5818,11 @@ class DataFrame(NDFrame):
     def aggregate(self, func, axis=0, *args, **kwargs):
         axis = self._get_axis_number(axis)
 
-        # TODO: flipped axis
         result = None
-        if axis == 0:
-            try:
-                result, how = self._aggregate(func, axis=0, *args, **kwargs)
-            except TypeError:
-                pass
+        try:
+            result, how = self._aggregate(func, axis=axis, *args, **kwargs)
+        except TypeError:
+            pass
         if result is None:
             return self.apply(func, axis=axis, args=args, **kwargs)
         return result

--- a/pandas/core/groupby/groupby.py
+++ b/pandas/core/groupby/groupby.py
@@ -4086,7 +4086,10 @@ class NDFrameGroupBy(GroupBy):
     def aggregate(self, arg, *args, **kwargs):
 
         _level = kwargs.pop('_level', None)
-        result, how = self._aggregate(arg, _level=_level, *args, **kwargs)
+        _agg_kwargs = kwargs.copy()
+        axis = _agg_kwargs.pop('axis', 0)
+        result, how = self._aggregate(arg, axis, _level=_level,
+                                      *args, **_agg_kwargs)
         if how is None:
             return result
 

--- a/pandas/tests/frame/test_apply.py
+++ b/pandas/tests/frame/test_apply.py
@@ -1072,10 +1072,11 @@ class TestDataFrameAggregate(TestData):
         # etc.
         # GH21123
         np_func, str_func = cython_table_items
-
-        tm.assert_almost_equal(df.agg(np_func),
-                               df.agg(str_func),
-                               )
-        tm.assert_almost_equal(df.agg(np_func, axis=1),
-                               df.agg(str_func, axis=1),
-                               )
+        if str_func in ('cumprod', 'cumsum'):
+            tm.assert_frame_equal(df.agg(np_func), df.agg(str_func))
+            tm.assert_frame_equal(df.agg(np_func, axis=1),
+                                  df.agg(str_func, axis=1))
+        else:
+            tm.assert_series_equal(df.agg(np_func), df.agg(str_func))
+            tm.assert_series_equal(df.agg(np_func, axis=1),
+                                   df.agg(str_func, axis=1))

--- a/pandas/tests/frame/test_apply.py
+++ b/pandas/tests/frame/test_apply.py
@@ -1112,10 +1112,15 @@ class TestDataFrameAggregate(TestData):
             with pytest.raises(expected):
                 # e.g. DataFrame(['a b'.split()]).cumprod() will raise
                 df.agg(np_func, axis=axis)
+            with pytest.raises(expected):
                 df.agg(str_func, axis=axis)
-        elif str_func in ('cumprod', 'cumsum'):
-            tm.assert_frame_equal(df.agg(np_func, axis=axis), expected)
-            tm.assert_frame_equal(df.agg(str_func, axis=axis), expected)
+            return
+
+        result = df.agg(np_func, axis=axis)
+        result_str_func = df.agg(str_func, axis=axis)
+        if str_func in ('cumprod', 'cumsum'):
+            tm.assert_frame_equal(result, expected)
+            tm.assert_frame_equal(result_str_func, expected)
         else:
-            tm.assert_series_equal(df.agg(np_func, axis=axis), expected)
-            tm.assert_series_equal(df.agg(str_func, axis=axis), expected)
+            tm.assert_series_equal(result, expected)
+            tm.assert_series_equal(result_str_func, expected)

--- a/pandas/tests/frame/test_apply.py
+++ b/pandas/tests/frame/test_apply.py
@@ -1056,3 +1056,26 @@ class TestDataFrameAggregate(TestData):
         expected = df.size
 
         assert result == expected
+
+    @pytest.mark.parametrize("df", [
+        pd.DataFrame([[1, 2], [3, 4]]),
+        pd.DataFrame([[np.nan, 2], [3, 4]]),
+        pd.DataFrame(),
+    ])
+    def test_agg_function_input(self, df, cython_table_items):
+        # test whether the functions (keys) in
+        # pd.core.base.SelectionMixin._cython_table give the same result
+        # as the related strings (values) when used in df.agg. Examples:
+        # - ``df.agg(np.nansum)`` should give the same result as
+        #   ``df.agg('sum')``
+        # - ``df.agg(sum)`` should give the same result as ``df.agg('sum')``
+        # etc.
+        # GH21123
+        np_func, str_func = cython_table_items
+
+        tm.assert_almost_equal(df.agg(np_func),
+                               df.agg(str_func),
+                               )
+        tm.assert_almost_equal(df.agg(np_func, axis=1),
+                               df.agg(str_func, axis=1),
+                               )

--- a/pandas/tests/series/test_apply.py
+++ b/pandas/tests/series/test_apply.py
@@ -604,6 +604,7 @@ class TestSeriesMap(TestData):
         # GH21123
         np_func, str_func = cython_table_items
 
-        tm.assert_almost_equal(series.agg(np_func),
-                               series.agg(str_func),
-                               )
+        if str_func in ('cumprod', 'cumsum'):
+            tm.assert_series_equal(series.agg(np_func), series.agg(str_func))
+        else:
+            tm.assert_almost_equal(series.agg(np_func), series.agg(str_func))

--- a/pandas/tests/series/test_apply.py
+++ b/pandas/tests/series/test_apply.py
@@ -587,3 +587,23 @@ class TestSeriesMap(TestData):
         result = s.map(mapping)
 
         tm.assert_series_equal(result, pd.Series(exp))
+
+    @pytest.mark.parametrize("series", [
+        pd.Series([1, 2, 3, 4]),
+        pd.Series([np.nan, 2, 3, 4]),
+        pd.Series(),
+    ])
+    def test_agg_function_input(self, series, cython_table_items):
+        # test whether the functions (keys) in
+        # pd.core.base.SelectionMixin._cython_table give the same result
+        # as the related strings (values), when used in ser.agg. Examples:
+        # - ``ser.agg(np.nansum)`` should give the same result as
+        #   ``ser.agg('sum')``
+        # - ``ser.agg(sum)`` should give the same result as ``ser.agg('sum')``
+        # etc.
+        # GH21123
+        np_func, str_func = cython_table_items
+
+        tm.assert_almost_equal(series.agg(np_func),
+                               series.agg(str_func),
+                               )

--- a/pandas/tests/series/test_apply.py
+++ b/pandas/tests/series/test_apply.py
@@ -384,13 +384,21 @@ class TestSeriesAggregate(TestData):
         if isinstance(expected, type) and issubclass(expected, Exception):
             with pytest.raises(expected):
                 series.agg(np_func)
+            with pytest.raises(expected):
                 series.agg(str_func)
-        elif str_func in ('cumprod', 'cumsum'):
-            tm.assert_series_equal(series.agg(np_func), expected)
-            tm.assert_series_equal(series.agg(str_func), expected)
+            return
+
+        result = series.agg(np_func)
+        result_str_func = series.agg(str_func)
+        if str_func in ('cumprod', 'cumsum'):
+            tm.assert_series_equal(result, expected)
+            tm.assert_series_equal(result_str_func, expected)
+        elif tm.is_number(expected):
+            assert np.isclose(result, expected, equal_nan=True)
+            assert np.isclose(result_str_func, expected, equal_nan=True)
         else:
-            tm.assert_almost_equal(series.agg(np_func), expected)
-            tm.assert_almost_equal(series.agg(str_func), expected)
+            assert result == expected
+            assert result_str_func == expected
 
 
 class TestSeriesMap(TestData):

--- a/pandas/tests/test_nanops.py
+++ b/pandas/tests/test_nanops.py
@@ -994,6 +994,49 @@ class TestNankurtFixedValues(object):
         return np.random.RandomState(1234)
 
 
+@pytest.fixture(params=[
+    pd.Series([1, 2, 3, 4, 5, 6]),
+    pd.DataFrame([[1, 2, 3], [4, 5, 6]])
+])
+def nan_test_object(request):
+    return request.param
+
+
+@pytest.mark.parametrize("standard, nan_method", [
+    (np.sum, np.nansum),
+    (np.mean, np.nanmean),
+    (np.std, np.nanstd),
+    (np.var, np.nanvar),
+    (np.median, np.nanmedian),
+    (np.max, np.nanmax),
+    (np.min, np.nanmin),
+])
+def test_np_nan_functions(standard, nan_method, nan_test_object):
+    tm.assert_almost_equal(nan_test_object.agg(standard),
+                           nan_test_object.agg(nan_method),
+                           check_exact=True)
+
+
+@td.skip_if_no("numpy", min_version="1.10.0")
+def test_np_nanprod(nan_test_object):
+    tm.assert_almost_equal(nan_test_object.agg(np.prod),
+                           nan_test_object.agg(np.nanprod),
+                           check_exact=True)
+
+
+@td.skip_if_no("numpy", min_version="1.12.0")
+def test_np_nancumprod(nan_test_object):
+    # Not using pytest params for methods as will fail at build time
+    methods = [
+        (np.cumprod, np.nancumprod),
+        (np.cumsum, np.nancumsum)
+    ]
+    for standard, nan_method in methods:
+        tm.assert_almost_equal(nan_test_object.agg(standard),
+                               nan_test_object.agg(nan_method),
+                               check_exact=True)
+
+
 def test_use_bottleneck():
 
     if nanops._BOTTLENECK_INSTALLED:

--- a/pandas/tests/test_nanops.py
+++ b/pandas/tests/test_nanops.py
@@ -13,8 +13,7 @@ from pandas.core.dtypes.common import is_integer_dtype
 import pandas.core.nanops as nanops
 import pandas.util.testing as tm
 import pandas.util._test_decorators as td
-from pandas.compat.numpy import (_np_version_under1p13, _np_version_under1p10,
-                                 _np_version_under1p12)
+from pandas.compat.numpy import _np_version_under1p13
 
 use_bn = nanops._USE_BOTTLENECK
 
@@ -993,52 +992,6 @@ class TestNankurtFixedValues(object):
     @property
     def prng(self):
         return np.random.RandomState(1234)
-
-
-@pytest.fixture(params=[
-    pd.Series([1, 2, 3, 4]),
-    pd.DataFrame([[1, 2], [3, 4]]),
-    pd.Series([np.nan, 2, 3, 4]),
-    pd.DataFrame([[np.nan, 2], [3, 4]]),
-    pd.Series(),
-    pd.DataFrame(),
-    pd.Series([np.nan]),
-    pd.DataFrame([[np.nan]]),
-])
-def series_or_frame(request):
-    return request.param
-
-
-@pytest.mark.parametrize("standard, nan_method", [
-    (np.sum, np.nansum),
-    (np.mean, np.nanmean),
-    (np.std, np.nanstd),
-    (np.var, np.nanvar),
-    (np.median, np.nanmedian),
-    (np.max, np.nanmax),
-    (np.min, np.nanmin),
-], ids=lambda x: x.__name__)
-def test_np_nan_functions(standard, nan_method, series_or_frame):
-    tm.assert_almost_equal(series_or_frame.agg(standard),
-                           series_or_frame.agg(nan_method),
-                           check_exact=True)
-
-
-@pytest.mark.skipif(_np_version_under1p10, reason="requires numpy>=1.10")
-def test_np_nanprod(series_or_frame):
-    tm.assert_almost_equal(series_or_frame.agg(np.prod),
-                           series_or_frame.agg(np.nanprod),
-                           check_exact=True)
-
-
-@pytest.mark.skipif(_np_version_under1p12, reason="requires numpy>=1.12")
-def test_np_nancumprod(series_or_frame):
-    funcs = [(np.cumprod, np.nancumprod),
-             (np.cumsum, np.nancumsum)]
-    for standard, nan_method in funcs:
-        tm.assert_almost_equal(series_or_frame.agg(standard),
-                               series_or_frame.agg(nan_method),
-                               check_exact=True)
 
 
 def test_use_bottleneck():


### PR DESCRIPTION
closes #19629 
closes #21134
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry

This started as a copy of #19670 by @AaronCritchley, but has solved two bugs that the tests surfaced along the way.

Bug 1:
there is currently a bug in ``df.aggregate``, where the method incorrectly defers to ``df.apply`` in a corner case. This only shows up in the result when using numpy < 1.13 and passing np.nan* functions to ``df.aggregate``. This is the reason for the change in ``base.py`` line 571. (see #8383 for further details on the bug in numpy<1.13 and how it affects pandas.)

Bug 2:
Passing builtins to ``df.aggregate`` is ok when ``axis=0``, but gives wrong result,when ``axis=1`` (#21134). The reason for this difference is that ``df.aggregate`` defers to ``df._aggregate`` when ``axis=0,`` but defers to ``df.apply``, when ``axis=1``, and these give different result when passed funcions  and the series/frame contains Nan values. This can be solved by transposing df and defering the transposed frame to its ``_aggragate`` method when ``axis=1``.

The added tests have been heavily parametrized (this helped unearth the bugs above). Thet have been placed in ``series/test_apply.py`` and ``frame/test_apply``, as a lot of other tests for ser/df.aggregate were already there. 