### PR TITLE
DEPR: Add deprecated index attribute names to deprecation list

### DIFF
--- a/doc/source/whatsnew/v0.23.1.txt
+++ b/doc/source/whatsnew/v0.23.1.txt
@@ -30,6 +30,7 @@ Performance Improvements
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
 - Improved performance of :meth:`CategoricalIndex.is_monotonic_increasing`, :meth:`CategoricalIndex.is_monotonic_decreasing` and :meth:`CategoricalIndex.is_monotonic` (:issue:`21025`)
+- Improved performance of :meth:`CategoricalIndex.is_unique` (:issue:`21107`)
 -
 -
 

--- a/pandas/core/accessor.py
+++ b/pandas/core/accessor.py
@@ -12,7 +12,8 @@ from pandas.util._decorators import Appender
 
 class DirNamesMixin(object):
     _accessors = frozenset([])
-    _deprecations = frozenset(['asobject'])
+    _deprecations = frozenset(
+        ['asobject', 'base', 'data', 'flags', 'itemsize', 'strides'])
 
     def _dir_deletions(self):
         """ delete unwanted __dir__ for this object """

--- a/pandas/core/indexes/category.py
+++ b/pandas/core/indexes/category.py
@@ -378,7 +378,7 @@ class CategoricalIndex(Index, accessor.PandasDelegate):
     # introspection
     @cache_readonly
     def is_unique(self):
-        return not self.duplicated().any()
+        return self._engine.is_unique
 
     @property
     def is_monotonic_increasing(self):

--- a/pandas/tests/indexes/test_category.py
+++ b/pandas/tests/indexes/test_category.py
@@ -581,6 +581,15 @@ class TestCategoricalIndex(Base):
         assert c.is_monotonic_increasing
         assert not c.is_monotonic_decreasing
 
+    @pytest.mark.parametrize('values, expected', [
+        ([1, 2, 3], True),
+        ([1, 3, 1], False),
+        (list('abc'), True),
+        (list('aba'), False)])
+    def test_is_unique(self, values, expected):
+        ci = CategoricalIndex(values)
+        assert ci.is_unique is expected
+
     def test_duplicates(self):
 
         idx = CategoricalIndex([0, 0, 0], name='foo')


### PR DESCRIPTION
In ipython, when you press tab (e.g. ``idx.<tab>`` a long list of deprecations shows up:

```
C:\Users\TP\Miniconda3\envs\pandas-dev\lib\site-packages\jedi\evaluate\compiled\__init__.py:328: FutureWarning: Int64Index.base is deprecated and will be removed in a future version
  getattr(obj, name)
C:\Users\TP\Miniconda3\envs\pandas-dev\lib\site-packages\jedi\evaluate\compiled\__init__.py:328: FutureWarning: Int64Index.data is deprecated and will be removed in a future version
  getattr(obj, name)
C:\Users\TP\Miniconda3\envs\pandas-dev\lib\site-packages\jedi\evaluate\compiled\__init__.py:328: FutureWarning: Int64Index.flags is deprecated and will be removed in a future version
  getattr(obj, name)
C:\Users\TP\Miniconda3\envs\pandas-dev\lib\site-packages\jedi\evaluate\compiled\__init__.py:328: FutureWarning: Int64Index.itemsize is deprecated and will be removed in a future version
  getattr(obj, name)
C:\Users\TP\Miniconda3\envs\pandas-dev\lib\site-packages\jedi\evaluate\compiled\__init__.py:328: FutureWarning: Int64Index.strides is deprecated and will be removed in a future version
  getattr(obj, name)
```

This PR we avoid getting that list of deprecations in iPython. I'm not sure if/whre this should go in the whatsnew document.