### PR TITLE
DEPR: Add deprecated index attribute names to deprecation list

### DIFF
--- a/doc/source/whatsnew/v0.23.1.txt
+++ b/doc/source/whatsnew/v0.23.1.txt
@@ -44,6 +44,8 @@ Documentation Changes
 Bug Fixes
 ~~~~~~~~~
 
+- tab completion on :class:`Index` in IPython no longer outputs deprecation warnings (:issue:`21125`)
+
 Groupby/Resample/Rolling
 ^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/pandas/core/accessor.py
+++ b/pandas/core/accessor.py
@@ -12,7 +12,8 @@ from pandas.util._decorators import Appender
 
 class DirNamesMixin(object):
     _accessors = frozenset([])
-    _deprecations = frozenset(['asobject'])
+    _deprecations = frozenset(
+        ['asobject', 'base', 'data', 'flags', 'itemsize', 'strides'])
 
     def _dir_deletions(self):
         """ delete unwanted __dir__ for this object """

--- a/pandas/tests/indexes/test_base.py
+++ b/pandas/tests/indexes/test_base.py
@@ -2088,6 +2088,17 @@ Index([u'a', u'bb', u'ccc', u'a', u'bb', u'ccc', u'a', u'bb', u'ccc', u'a',
         with tm.assert_produces_warning(FutureWarning):
             index.get_duplicates()
 
+    def test_tab_complete_warning(self, ip):
+        # https://github.com/pandas-dev/pandas/issues/16409
+        pytest.importorskip('IPython', minversion="6.0.0")
+        from IPython.core.completer import provisionalcompleter
+
+        code = "import pandas as pd; idx = pd.Index([1, 2])"
+        ip.run_code(code)
+        with tm.assert_produces_warning(None):
+            with provisionalcompleter('ignore'):
+                list(ip.Completer.completions('idx.', 4))
+
 
 class TestMixedIntIndex(Base):
     # Mostly the tests from common.py for which the results differ


### PR DESCRIPTION
In ipython, when you press tab (e.g. ``idx.<tab>``) a long list of deprecations shows up:

```
C:\Users\TP\Miniconda3\envs\pandas-dev\lib\site-packages\jedi\evaluate\compiled\__init__.py:328: FutureWarning: Int64Index.base is deprecated and will be removed in a future version
  getattr(obj, name)
C:\Users\TP\Miniconda3\envs\pandas-dev\lib\site-packages\jedi\evaluate\compiled\__init__.py:328: FutureWarning: Int64Index.data is deprecated and will be removed in a future version
  getattr(obj, name)
C:\Users\TP\Miniconda3\envs\pandas-dev\lib\site-packages\jedi\evaluate\compiled\__init__.py:328: FutureWarning: Int64Index.flags is deprecated and will be removed in a future version
  getattr(obj, name)
C:\Users\TP\Miniconda3\envs\pandas-dev\lib\site-packages\jedi\evaluate\compiled\__init__.py:328: FutureWarning: Int64Index.itemsize is deprecated and will be removed in a future version
  getattr(obj, name)
C:\Users\TP\Miniconda3\envs\pandas-dev\lib\site-packages\jedi\evaluate\compiled\__init__.py:328: FutureWarning: Int64Index.strides is deprecated and will be removed in a future version
  getattr(obj, name)
```

With this PR we avoid getting that list of deprecations in iPython.

I'm not sure if/where this should go in the whatsnew document.