### PR TITLE
DOC: Improve docstring of Timedelta.delta

### DIFF
--- a/pandas/_libs/tslibs/timedeltas.pyx
+++ b/pandas/_libs/tslibs/timedeltas.pyx
@@ -803,7 +803,6 @@ cdef class _Timedelta(timedelta):
         Timedelta.components : Return all attributes with assigned values (i.e.
             days, hours, minutes, seconds, milliseconds, microseconds, nanoseconds).
 
-
         Examples
         --------
         **Using string input**
@@ -812,12 +811,11 @@ cdef class _Timedelta(timedelta):
         >>> td.nanoseconds
         42
 
-        **Using integer inputs**
+        **Using integer input**
 
         >>> td = pd.Timedelta(42, unit='ns')
         >>> td.nanoseconds
         42 
-
         """
         self._ensure_components()
         return self._ns

--- a/pandas/_libs/tslibs/timedeltas.pyx
+++ b/pandas/_libs/tslibs/timedeltas.pyx
@@ -800,8 +800,9 @@ cdef class _Timedelta(timedelta):
 
         See Also
         --------
-        Timedelta.components : Return all attributes with assigned values (i.e.
-            days, hours, minutes, seconds, milliseconds, microseconds, nanoseconds).
+        Timedelta.components : Return all attributes with assigned values
+            (i.e. days, hours, minutes, seconds, milliseconds, microseconds,
+            nanoseconds).
 
         Examples
         --------
@@ -815,7 +816,7 @@ cdef class _Timedelta(timedelta):
 
         >>> td = pd.Timedelta(42, unit='ns')
         >>> td.nanoseconds
-        42 
+        42
         """
         self._ensure_components()
         return self._ns

--- a/pandas/_libs/tslibs/timedeltas.pyx
+++ b/pandas/_libs/tslibs/timedeltas.pyx
@@ -770,7 +770,48 @@ cdef class _Timedelta(timedelta):
 
     @property
     def resolution(self):
-        """ return a string representing the lowest resolution that we have """
+        """
+        Return a string representing the lowest (i.e. smallest) time resolution.
+
+        Each timedelta has a defined resolution that represents the lowest OR 
+        most granular level of precision. Each level of resolution is 
+        represented by a short string as defined below:
+
+          - Days:         'D'
+          - Hours:        'H'
+          - Minutes:      'T'
+          - Seconds:      'S'
+          - Milliseconds: 'L'
+          - Microseconds: 'U'
+          - Nanoseconds:  'N'
+
+        Returns
+        -------
+        str
+            Time resolution.
+
+        Examples
+        --------
+        **Using string input**
+
+        >>> td = pd.Timedelta('1 days 2 min 3 us 42 ns')
+        >>> td.resolution
+        'N'
+
+        >>> td = pd.Timedelta('1 days 2 min 3 us')
+        >>> td.resolution
+        'U'
+
+        >>> td = pd.Timedelta('2 min 3 s')
+        >>> td.resolution
+        'S'
+
+        **Using integer input**
+
+        >>> td = pd.Timedelta(36, unit='us')
+        >>> td.resolution
+        'U'
+        """ 
 
         self._ensure_components()
         if self._ns:

--- a/pandas/_libs/tslibs/timedeltas.pyx
+++ b/pandas/_libs/tslibs/timedeltas.pyx
@@ -795,12 +795,27 @@ cdef class _Timedelta(timedelta):
         
         Returns
         -------
-        int : Number of nanoseconds
+        int
+            Number of nanoseconds.
 
         See Also
         --------
         Timedelta.components : Return all attributes with assigned values (i.e.
-            days, seconds, microseconds, nanoseconds)
+            days, hours, minutes, seconds, milliseconds, microseconds, nanoseconds).
+
+
+        Examples
+        --------
+        >>> td = pd.Timedelta('1 days 2 min 3 us 42 ns')
+        >>> td.nanoseconds
+        42
+
+        **Using integer inputs**
+
+        >>> td = pd.Timedelta(42, unit='ns')
+        >>> td.nanoseconds
+        42 
+
         """
         self._ensure_components()
         return self._ns

--- a/pandas/_libs/tslibs/timedeltas.pyx
+++ b/pandas/_libs/tslibs/timedeltas.pyx
@@ -760,7 +760,36 @@ cdef class _Timedelta(timedelta):
 
     @property
     def delta(self):
-        """ return out delta in ns (for internal compat) """
+        """
+        Return the timedelta in nanoseconds (ns), for internal compatibility.
+
+        Returns
+        -------
+        int
+            Timedelta in nanoseconds.
+
+        Examples
+        --------
+        **Using string input**
+
+        >>> td = pd.Timedelta('1 days 42 ns')
+        >>> td.delta
+        86400000000042
+
+        >>> td = pd.Timedelta('3 s')
+        >>> td.delta
+        3000000000
+
+        >>> td = pd.Timedelta('3 ms 5 us')
+        >>> td.delta
+        3005000
+
+        **Using integer input**
+
+        >>> td = pd.Timedelta(42, unit='ns')
+        >>> td.delta
+        42
+        """
         return self.value
 
     @property

--- a/pandas/_libs/tslibs/timedeltas.pyx
+++ b/pandas/_libs/tslibs/timedeltas.pyx
@@ -795,8 +795,7 @@ cdef class _Timedelta(timedelta):
         
         Returns
         -------
-        int
-            Number of nanoseconds
+        int : Number of nanoseconds
 
         See Also
         --------

--- a/pandas/_libs/tslibs/timedeltas.pyx
+++ b/pandas/_libs/tslibs/timedeltas.pyx
@@ -789,9 +789,17 @@ cdef class _Timedelta(timedelta):
     @property
     def nanoseconds(self):
         """
-        Number of nanoseconds (>= 0 and less than 1 microsecond).
+        Return the number of nanoseconds (n), where 0 <= n < 1 microsecond.
+        
+        Returns
+        -------
+        int
+            Number of nanoseconds
 
-        .components will return the shown components
+        See Also
+        --------
+        Timedelta.components : Return all attributes with assigned values (i.e.
+            days, seconds, microseconds, nanoseconds)
         """
         self._ensure_components()
         return self._ns

--- a/pandas/_libs/tslibs/timedeltas.pyx
+++ b/pandas/_libs/tslibs/timedeltas.pyx
@@ -806,6 +806,7 @@ cdef class _Timedelta(timedelta):
 
         Examples
         --------
+        **Using string input**
         >>> td = pd.Timedelta('1 days 2 min 3 us 42 ns')
         >>> td.nanoseconds
         42

--- a/pandas/_libs/tslibs/timedeltas.pyx
+++ b/pandas/_libs/tslibs/timedeltas.pyx
@@ -807,6 +807,7 @@ cdef class _Timedelta(timedelta):
         Examples
         --------
         **Using string input**
+
         >>> td = pd.Timedelta('1 days 2 min 3 us 42 ns')
         >>> td.nanoseconds
         42

--- a/pandas/_libs/tslibs/timedeltas.pyx
+++ b/pandas/_libs/tslibs/timedeltas.pyx
@@ -792,7 +792,7 @@ cdef class _Timedelta(timedelta):
     def nanoseconds(self):
         """
         Return the number of nanoseconds (n), where 0 <= n < 1 microsecond.
-        
+       
         Returns
         -------
         int


### PR DESCRIPTION
- [ ] closes #xxxx
- [ ] tests added / passed
- [X] passes `git diff upstream/master -u -- "*.pyx" | flake8 --diff`
- [ ] whatsnew entry

```
################################################################################
###################### Docstring (pandas.Timedelta.delta) ######################
################################################################################

Return the timedelta in nanoseconds (ns), for internal compatibility.

Returns
-------
int
    Timedelta in nanoseconds.

Examples
--------
**Using string input**

>>> td = pd.Timedelta('1 days 42 ns')
>>> td.delta
86400000000042

>>> td = pd.Timedelta('3 s')
>>> td.delta
3000000000

>>> td = pd.Timedelta('3 ms 5 us')
>>> td.delta
3005000

**Using integer input**

>>> td = pd.Timedelta(42, unit='ns')
>>> td.delta
42

################################################################################
################################## Validation ##################################
################################################################################

Errors found:
	No extended summary found
	See Also section not found
```