### PR TITLE
DOC: Improve the docstring of Timedelta.delta redux

### DIFF
--- a/pandas/_libs/tslibs/timedeltas.pyx
+++ b/pandas/_libs/tslibs/timedeltas.pyx
@@ -760,7 +760,32 @@ cdef class _Timedelta(timedelta):
 
     @property
     def delta(self):
-        """ return out delta in ns (for internal compat) """
+        """
+        Return the timedelta in nanoseconds (ns), for internal compatibility.
+
+        Returns
+        -------
+        int
+            Timedelta in nanoseconds.
+
+        Examples
+        --------
+        >>> td = pd.Timedelta('1 days 42 ns')
+        >>> td.delta
+        86400000000042
+
+        >>> td = pd.Timedelta('3 s')
+        >>> td.delta
+        3000000000
+
+        >>> td = pd.Timedelta('3 ms 5 us')
+        >>> td.delta
+        3005000
+
+        >>> td = pd.Timedelta(42, unit='ns')
+        >>> td.delta
+        42 
+        """
         return self.value
 
     @property

--- a/pandas/_libs/tslibs/timedeltas.pyx
+++ b/pandas/_libs/tslibs/timedeltas.pyx
@@ -784,7 +784,7 @@ cdef class _Timedelta(timedelta):
 
         >>> td = pd.Timedelta(42, unit='ns')
         >>> td.delta
-        42 
+        42
         """
         return self.value
 


### PR DESCRIPTION
- [ ] closes #xxxx
- [ ] tests added / passed
- [X] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

rather than trying to pick and choose items from my previous PR #21135 (which somehow had a number of other items sucked into it) ...
gonna start from scratch here and close out the old PR.

tried to incorporate changes noted in previous conversations with @WillAyd and @jreback (thanks for the guidance!)

```
################################################################################
###################### Docstring (pandas.Timedelta.delta) ######################
################################################################################

Return the timedelta in nanoseconds (ns), for internal compatibility.

Returns
-------
int
    Timedelta in nanoseconds.

Examples
--------
>>> td = pd.Timedelta('1 days 42 ns')
>>> td.delta
86400000000042

>>> td = pd.Timedelta('3 s')
>>> td.delta
3000000000

>>> td = pd.Timedelta('3 ms 5 us')
>>> td.delta
3005000

>>> td = pd.Timedelta(42, unit='ns')
>>> td.delta
42

################################################################################
################################## Validation ##################################
################################################################################
```
 