### PR TITLE
CLN: Refactor open into context manager in io tests

### DIFF
--- a/pandas/tests/io/test_packers.py
+++ b/pandas/tests/io/test_packers.py
@@ -128,9 +128,8 @@ class TestAPI(TestPackers):
         with ensure_clean(self.path) as p:
 
             s = df.to_msgpack()
-            fh = open(p, 'wb')
-            fh.write(s)
-            fh.close()
+            with open(p, 'wb') as fh:
+                fh.write(s)
             result = read_msgpack(p)
             tm.assert_frame_equal(result, df)
 

--- a/pandas/tests/series/test_io.py
+++ b/pandas/tests/series/test_io.py
@@ -75,9 +75,8 @@ class TestSeriesToCSV(TestData):
             series_h = self.read_csv(path, header=0)
             assert series_h.name == "series"
 
-            outfile = open(path, "w")
-            outfile.write("1998-01-01|1.0\n1999-01-01|2.0")
-            outfile.close()
+            with open(path, "w") as outfile:
+                outfile.write("1998-01-01|1.0\n1999-01-01|2.0")
 
             series = self.read_csv(path, sep="|")
             check_series = Series({datetime(1998, 1, 1): 1.0,


### PR DESCRIPTION
- [ ] closes #xxxx
- [ ] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

Building on #21105 by @WillAyd, I cleaned up some more `open` statements.