### PR TITLE
BUG: Fix interval_range when start/periods or end/periods are specified with float start/end

### DIFF
--- a/doc/source/whatsnew/v0.23.1.txt
+++ b/doc/source/whatsnew/v0.23.1.txt
@@ -77,6 +77,7 @@ Indexing
 ^^^^^^^^
 
 - Bug in :meth:`Series.reset_index` where appropriate error was not raised with an invalid level name (:issue:`20925`)
+- Bug in :func:`interval_range` when ``start``/``periods`` or ``end``/``periods`` are specified with float ``start`` or ``end`` (:issue:`21161`)
 -
 
 I/O

--- a/pandas/core/indexes/interval.py
+++ b/pandas/core/indexes/interval.py
@@ -1572,6 +1572,10 @@ def interval_range(start=None, end=None, periods=None, freq=None,
         periods += 1
 
     if is_number(endpoint):
+        # force consistency between start/end/freq (lower end if freq skips it)
+        if com._all_not_none(start, end, freq):
+            end -= (end - start) % freq
+
         # compute the period/start/end if unspecified (at most one)
         if periods is None:
             periods = int((end - start) // freq) + 1
@@ -1579,10 +1583,6 @@ def interval_range(start=None, end=None, periods=None, freq=None,
             start = end - (periods - 1) * freq
         elif end is None:
             end = start + (periods - 1) * freq
-
-        # force end to be consistent with freq (lower if freq skips end)
-        if freq is not None:
-            end -= end % freq
 
         breaks = np.linspace(start, end, periods)
         if all(is_integer(x) for x in com._not_none(start, end, freq)):

--- a/pandas/tests/indexes/interval/test_interval_range.py
+++ b/pandas/tests/indexes/interval/test_interval_range.py
@@ -110,6 +110,8 @@ class TestIntervalRange(object):
 
     @pytest.mark.parametrize('start, end, freq, expected_endpoint', [
         (0, 10, 3, 9),
+        (0, 10, 1.5, 9),
+        (0.5, 10, 3, 9.5),
         (Timedelta('0D'), Timedelta('10D'), '2D4H', Timedelta('8D16H')),
         (Timestamp('2018-01-01'),
          Timestamp('2018-02-09'),
@@ -124,6 +126,22 @@ class TestIntervalRange(object):
         result = interval_range(start=start, end=end, freq=freq)
         result_endpoint = result.right[-1]
         assert result_endpoint == expected_endpoint
+
+    @pytest.mark.parametrize('start, end, freq', [
+        (0.5, None, None),
+        (None, 4.5, None),
+        (0.5, None, 1.5),
+        (None, 6.5, 1.5)])
+    def test_no_invalid_float_truncation(self, start, end, freq):
+        # GH 21161
+        if freq is None:
+            breaks = [0.5, 1.5, 2.5, 3.5, 4.5]
+        else:
+            breaks = [0.5, 2.0, 3.5, 5.0, 6.5]
+        expected = IntervalIndex.from_breaks(breaks)
+
+        result = interval_range(start=start, end=end, periods=4, freq=freq)
+        tm.assert_index_equal(result, expected)
 
     @pytest.mark.parametrize('start, mid, end', [
         (Timestamp('2018-03-10', tz='US/Eastern'),


### PR DESCRIPTION
- [X] closes #21161
- [X] tests added / passed
- [X] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [X] whatsnew entry

Should be good for 0.23.1; the code changes only hit the `interval_range` function, which is outside the `IntervalIndex` class, so should be independent of any enhancements related to `IntervalIndex` that we might want to push to 0.24.0.