### PR TITLE
Cleanup clipboard tests

### DIFF
--- a/pandas/tests/io/test_clipboard.py
+++ b/pandas/tests/io/test_clipboard.py
@@ -115,7 +115,7 @@ class TestClipboard(object):
         (None, None),
         ('\t', 'default'),
         (None, 'default')
-        ])
+    ])
     def test_clipboard_copy_tabs_default(self, sep, excel):
         for dt in self.data_types:
             data = self.data[dt]
@@ -126,7 +126,7 @@ class TestClipboard(object):
     @pytest.mark.parametrize('sep, excel', [
         (',', True),
         ('|', True)
-        ])
+    ])
     def test_clipboard_copy_delim(self, sep, excel):
         for dt in self.data_types:
             data = self.data[dt]
@@ -138,7 +138,7 @@ class TestClipboard(object):
         ('\t', False),
         (None, False),
         ('default', False)
-        ])
+    ])
     def test_clipboard_copy_strings(self, sep, excel):
         for dt in self.data_types:
             data = self.data[dt]

--- a/pandas/tests/io/test_clipboard.py
+++ b/pandas/tests/io/test_clipboard.py
@@ -29,7 +29,6 @@ class TestClipboard(object):
 
     @classmethod
     def setup_class(cls):
-        np.random.seed(0)
         cls.data = {}
         cls.data['string'] = mkdf(5, 3, c_idx_type='s', r_idx_type='i',
                                   c_idx_names=[None], r_idx_names=[None])
@@ -65,7 +64,6 @@ class TestClipboard(object):
         cls.data['delim_symbols'] = pd.DataFrame({'a': ['"a,\t"b|c', 'd\tef´'],
                                                   'b': ['hi\'j', 'k\'\'lm']})
         cls.data_types = list(cls.data.keys())
-        cls.data_expected = {}
 
     @classmethod
     def teardown_class(cls):
@@ -101,6 +99,14 @@ class TestClipboard(object):
         with tm.assert_produces_warning():
             self.data['string'].to_clipboard(excel=True, sep=r'\t')
 
+    def build_kwargs(self, sep, excel):
+        kwargs = {}
+        if excel != 'default':
+            kwargs['excel'] = excel
+        if sep != 'default':
+            kwargs['sep'] = sep
+        return kwargs
+
     @pytest.mark.parametrize('sep, excel', [
         ('\t', True),
         (None, True),
@@ -113,11 +119,7 @@ class TestClipboard(object):
     def test_clipboard_copy_tabs_default(self, sep, excel):
         for dt in self.data_types:
             data = self.data[dt]
-            kwargs = {}
-            if excel != 'default':
-                kwargs['excel'] = excel
-            if sep != 'default':
-                kwargs['sep'] = sep
+            kwargs = self.build_kwargs(sep, excel)
             data.to_clipboard(**kwargs)
             assert clipboard_get() == data.to_csv(sep='\t')
 
@@ -128,11 +130,7 @@ class TestClipboard(object):
     def test_clipboard_copy_delim(self, sep, excel):
         for dt in self.data_types:
             data = self.data[dt]
-            kwargs = {}
-            if excel != 'default':
-                kwargs['excel'] = excel
-            if sep != 'default':
-                kwargs['sep'] = sep
+            kwargs = self.build_kwargs(sep, excel)
             data.to_clipboard(**kwargs)
             assert clipboard_get() == data.to_csv(sep=sep)
 
@@ -144,11 +142,7 @@ class TestClipboard(object):
     def test_clipboard_copy_strings(self, sep, excel):
         for dt in self.data_types:
             data = self.data[dt]
-            kwargs = {}
-            if excel != 'default':
-                kwargs['excel'] = excel
-            if sep != 'default':
-                kwargs['sep'] = sep
+            kwargs = self.build_kwargs(sep, excel)
             data.to_clipboard(**kwargs)
             result = read_clipboard(sep=r'\s+')
             assert result.to_string() == data.to_string()

--- a/pandas/tests/io/test_clipboard.py
+++ b/pandas/tests/io/test_clipboard.py
@@ -89,9 +89,8 @@ class TestClipboard(object):
         tm.assert_frame_equal(data, result, check_dtype=False)
 
     # Test that default arguments copy as tab delimited
-    # Fails because to_clipboard defaults to space delim.
-    # Issue in #21104, Fixed in #21111
-    @pytest.mark.xfail
+    @pytest.mark.xfail(reason='to_clipboard defaults to space delim. '
+                       'Issue in #21104, Fixed in #21111')
     def test_round_trip_frame(self, df):
         self.check_round_trip_frame(df)
 
@@ -101,10 +100,10 @@ class TestClipboard(object):
         self.check_round_trip_frame(df, sep=sep)
 
     # Test white space separator
-    # Fails on 'delims' df because quote escapes aren't handled correctly
-    # in default c engine. Fixed in #21111 by defaulting to python engine
-    # for whitespace separator
-    @pytest.mark.xfail
+    @pytest.mark.xfail(reason="Fails on 'delims' df because quote escapes "
+                       "aren't handled correctly in default c engine. Fixed "
+                       "in #21111 by defaulting to python engine for "
+                       "whitespace separator")
     def test_round_trip_frame_string(self, df):
         df.to_clipboard(excel=False, sep=None)
         result = read_clipboard()
@@ -113,8 +112,7 @@ class TestClipboard(object):
 
     # Two character separator is not supported in to_clipboard
     # Test that multi-character separators are not silently passed
-    # Fails, Fixed in #21111
-    @pytest.mark.xfail
+    @pytest.mark.xfail(reason="Not yet implemented.  Fixed in #21111")
     def test_excel_sep_warning(self):
         with tm.assert_produces_warning():
             gen_df('string').to_clipboard(excel=True, sep=r'\t')
@@ -128,26 +126,25 @@ class TestClipboard(object):
 
     # Tests that the default behavior of to_clipboard is tab
     # delimited and excel="True"
-    # Fails because to_clipboard defaults to space delim.
-    # Issue in #21104, Fixed in #21111
-    @pytest.mark.xfail
+    @pytest.mark.xfail(reason="to_clipboard defaults to space delim. Issue in "
+                       "#21104, Fixed in #21111")
     @pytest.mark.parametrize('sep', ['\t', None, 'default'])
     @pytest.mark.parametrize('excel', [True, None, 'default'])
     def test_clipboard_copy_tabs_default(self, sep, excel, df):
         kwargs = build_kwargs(sep, excel)
         df.to_clipboard(**kwargs)
         if PY2:
-            # to_clipboard copies unicode, to_csv produces bytes. This is 
+            # to_clipboard copies unicode, to_csv produces bytes. This is
             # expected behavior
             assert clipboard_get().encode('utf-8') == df.to_csv(sep='\t')
         else:
             assert clipboard_get() == df.to_csv(sep='\t')
 
     # Tests reading of white space separated tables
-    # Fails on 'delims' df because quote escapes aren't handled correctly
-    # in default c engine. Fixed in #21111 by defaulting to python engine
-    # for whitespace separator
-    @pytest.mark.xfail
+    @pytest.mark.xfail(reason="Fails on 'delims' df because quote escapes "
+                       "aren't handled correctly. in default c engine. Fixed "
+                       "in #21111 by defaulting to python engine for "
+                       "whitespace separator")
     @pytest.mark.parametrize('sep', [None, 'default'])
     @pytest.mark.parametrize('excel', [False])
     def test_clipboard_copy_strings(self, sep, excel, df):
@@ -199,9 +196,8 @@ class TestClipboard(object):
         with pytest.raises(NotImplementedError):
             pd.read_clipboard(encoding='ascii')
 
-    # Fails because to_clipboard defaults to space delim.
-    # Issue in #21104, Fixed in #21111
-    @pytest.mark.xfail
+    @pytest.mark.xfail(reason='to_clipboard defaults to space delim. '
+                       'Issue in #21104, Fixed in #21111')
     @pytest.mark.parametrize('enc', ['UTF-8', 'utf-8', 'utf8'])
     def test_round_trip_valid_encodings(self, enc, df):
         self.check_round_trip_frame(df, encoding=enc)

--- a/pandas/tests/io/test_clipboard.py
+++ b/pandas/tests/io/test_clipboard.py
@@ -22,131 +22,118 @@ except (PyperclipException, RuntimeError):
     _DEPS_INSTALLED = 0
 
 
+def build_kwargs(sep, excel):
+    kwargs = {}
+    if excel != 'default':
+        kwargs['excel'] = excel
+    if sep != 'default':
+        kwargs['sep'] = sep
+    return kwargs
+
+
+def gen_df(data_type):
+    if data_type == 'delims':
+        return pd.DataFrame({'a': ['"a,\t"b|c', 'd\tef´'],
+                             'b': ['hi\'j', 'k\'\'lm']})
+    elif data_type == 'utf8':
+        return pd.DataFrame({'a': ['µasd', 'Ωœ∑´'],
+                             'b': ['øπ∆˚¬', 'œ∑´®']})
+    elif data_type == 'string':
+        return mkdf(5, 3, c_idx_type='s', r_idx_type='i',
+                    c_idx_names=[None], r_idx_names=[None])
+    elif data_type == 'long':
+        max_rows = get_option('display.max_rows')
+        return mkdf(max_rows + 1, 3,
+                    data_gen_f=lambda *args: randint(2),
+                    c_idx_type='s', r_idx_type='i',
+                    c_idx_names=[None], r_idx_names=[None])
+    elif data_type == 'nonascii':
+        return pd.DataFrame({'en': 'in English'.split(),
+                             'es': 'en español'.split()})
+    elif data_type == 'colwidth':
+        _cw = get_option('display.max_colwidth') + 1
+        return mkdf(5, 3, data_gen_f=lambda *args: 'x' * _cw,
+                    c_idx_type='s', r_idx_type='i',
+                    c_idx_names=[None], r_idx_names=[None])
+    elif data_type == 'mixed':
+        return DataFrame({'a': np.arange(1.0, 6.0) + 0.01,
+                          'b': np.arange(1, 6),
+                          'c': list('abcde')})
+    elif data_type == 'float':
+        return mkdf(5, 3, data_gen_f=lambda r, c: float(r) + 0.01,
+                    c_idx_type='s', r_idx_type='i',
+                    c_idx_names=[None], r_idx_names=[None])
+
+    elif data_type == 'int':
+        return mkdf(5, 3, data_gen_f=lambda *args: randint(2),
+                    c_idx_type='s', r_idx_type='i',
+                    c_idx_names=[None], r_idx_names=[None])
+
+
+@pytest.fixture(params=['delims', 'utf8', 'string', 'long', 'nonascii',
+                        'colwidth', 'mixed', 'float', 'int'])
+def df(request):
+    return gen_df(request.param)
+
+
 @pytest.mark.single
 @pytest.mark.skipif(not _DEPS_INSTALLED,
                     reason="clipboard primitives not installed")
 class TestClipboard(object):
 
-    @classmethod
-    def setup_class(cls):
-        cls.data = {}
-        cls.data['string'] = mkdf(5, 3, c_idx_type='s', r_idx_type='i',
-                                  c_idx_names=[None], r_idx_names=[None])
-        cls.data['int'] = mkdf(5, 3, data_gen_f=lambda *args: randint(2),
-                               c_idx_type='s', r_idx_type='i',
-                               c_idx_names=[None], r_idx_names=[None])
-        cls.data['float'] = mkdf(5, 3,
-                                 data_gen_f=lambda r, c: float(r) + 0.01,
-                                 c_idx_type='s', r_idx_type='i',
-                                 c_idx_names=[None], r_idx_names=[None])
-        cls.data['mixed'] = DataFrame({'a': np.arange(1.0, 6.0) + 0.01,
-                                       'b': np.arange(1, 6),
-                                       'c': list('abcde')})
-
-        # Test columns exceeding "max_colwidth" (GH8305)
-        _cw = get_option('display.max_colwidth') + 1
-        cls.data['colwidth'] = mkdf(5, 3, data_gen_f=lambda *args: 'x' * _cw,
-                                    c_idx_type='s', r_idx_type='i',
-                                    c_idx_names=[None], r_idx_names=[None])
-        # Test GH-5346
-        max_rows = get_option('display.max_rows')
-        cls.data['longdf'] = mkdf(max_rows + 1, 3,
-                                  data_gen_f=lambda *args: randint(2),
-                                  c_idx_type='s', r_idx_type='i',
-                                  c_idx_names=[None], r_idx_names=[None])
-        # Test for non-ascii text: GH9263
-        cls.data['nonascii'] = pd.DataFrame({'en': 'in English'.split(),
-                                             'es': 'en español'.split()})
-        # unicode round trip test for GH 13747, GH 12529
-        cls.data['utf8'] = pd.DataFrame({'a': ['µasd', 'Ωœ∑´'],
-                                         'b': ['øπ∆˚¬', 'œ∑´®']})
-        # Test for quotes and common delimiters in text
-        cls.data['delim_symbols'] = pd.DataFrame({'a': ['"a,\t"b|c', 'd\tef´'],
-                                                  'b': ['hi\'j', 'k\'\'lm']})
-        cls.data_types = list(cls.data.keys())
-
-    @classmethod
-    def teardown_class(cls):
-        del cls.data_types, cls.data
-
-    def check_round_trip_frame(self, data_type, excel=None, sep=None,
+    def check_round_trip_frame(self, data, excel=None, sep=None,
                                encoding=None):
-        data = self.data[data_type]
         data.to_clipboard(excel=excel, sep=sep, encoding=encoding)
         result = read_clipboard(sep=sep or '\t', index_col=0,
                                 encoding=encoding)
         tm.assert_frame_equal(data, result, check_dtype=False)
 
-    def test_round_trip_frame(self):
-        for dt in self.data_types:
-            self.check_round_trip_frame(dt)
+    @pytest.mark.xfail
+    def test_round_trip_frame(self, df):
+        self.check_round_trip_frame(df)
 
-    def test_round_trip_frame_sep(self):
-        for dt in self.data_types:
-            self.check_round_trip_frame(dt, sep=',')
-            self.check_round_trip_frame(dt, sep='|')
-            self.check_round_trip_frame(dt, sep='\t')
+    def test_round_trip_frame_sep(self, df):
+        self.check_round_trip_frame(df, sep=',')
+        self.check_round_trip_frame(df, sep='|')
+        self.check_round_trip_frame(df, sep='\t')
 
-    def test_round_trip_frame_string(self):
-        for dt in self.data_types:
-            data = self.data[dt]
-            data.to_clipboard(excel=False, sep=None)
-            result = read_clipboard()
-            assert data.to_string() == result.to_string()
-            assert data.shape == result.shape
+    @pytest.mark.xfail
+    def test_round_trip_frame_string(self, df):
+        df.to_clipboard(excel=False, sep=None)
+        result = read_clipboard()
+        assert df.to_string() == result.to_string()
+        assert df.shape == result.shape
 
+    @pytest.mark.xfail
     def test_excel_sep_warning(self):
         with tm.assert_produces_warning():
-            self.data['string'].to_clipboard(excel=True, sep=r'\t')
+            gen_df('string').to_clipboard(excel=True, sep=r'\t')
 
-    def build_kwargs(self, sep, excel):
-        kwargs = {}
-        if excel != 'default':
-            kwargs['excel'] = excel
-        if sep != 'default':
-            kwargs['sep'] = sep
-        return kwargs
+    @pytest.mark.xfail
+    @pytest.mark.parametrize('sep', ['\t', None, 'default'])
+    @pytest.mark.parametrize('excel', [True, None, 'default'])
+    def test_clipboard_copy_tabs_default(self, sep, excel, df):
+        kwargs = build_kwargs(sep, excel)
+        df.to_clipboard(**kwargs)
+        assert clipboard_get() == df.to_csv(sep='\t')
 
-    @pytest.mark.parametrize('sep, excel', [
-        ('\t', True),
-        (None, True),
-        ('default', True),
-        ('\t', None),
-        (None, None),
-        ('\t', 'default'),
-        (None, 'default')
-    ])
-    def test_clipboard_copy_tabs_default(self, sep, excel):
-        for dt in self.data_types:
-            data = self.data[dt]
-            kwargs = self.build_kwargs(sep, excel)
-            data.to_clipboard(**kwargs)
-            assert clipboard_get() == data.to_csv(sep='\t')
+    @pytest.mark.xfail
+    @pytest.mark.parametrize('sep', [',', '|'])
+    @pytest.mark.parametrize('excel', [True])
+    def test_clipboard_copy_delim(self, sep, excel, df):
+        kwargs = build_kwargs(sep, excel)
+        df.to_clipboard(**kwargs)
+        assert clipboard_get() == df.to_csv(sep=sep)
 
-    @pytest.mark.parametrize('sep, excel', [
-        (',', True),
-        ('|', True)
-    ])
-    def test_clipboard_copy_delim(self, sep, excel):
-        for dt in self.data_types:
-            data = self.data[dt]
-            kwargs = self.build_kwargs(sep, excel)
-            data.to_clipboard(**kwargs)
-            assert clipboard_get() == data.to_csv(sep=sep)
-
-    @pytest.mark.parametrize('sep, excel', [
-        ('\t', False),
-        (None, False),
-        ('default', False)
-    ])
-    def test_clipboard_copy_strings(self, sep, excel):
-        for dt in self.data_types:
-            data = self.data[dt]
-            kwargs = self.build_kwargs(sep, excel)
-            data.to_clipboard(**kwargs)
-            result = read_clipboard(sep=r'\s+')
-            assert result.to_string() == data.to_string()
-            assert data.shape == result.shape
+    @pytest.mark.xfail
+    @pytest.mark.parametrize('sep', ['\t', None, 'default'])
+    @pytest.mark.parametrize('excel', [False])
+    def test_clipboard_copy_strings(self, sep, excel, df):
+        kwargs = build_kwargs(sep, excel)
+        df.to_clipboard(**kwargs)
+        result = read_clipboard(sep=r'\s+')
+        assert result.to_string() == df.to_string()
+        assert df.shape == result.shape
 
     def test_read_clipboard_infer_excel(self):
         # gh-19010: avoid warnings
@@ -184,13 +171,13 @@ class TestClipboard(object):
 
     def test_invalid_encoding(self):
         # test case for testing invalid encoding
-        data = self.data['string']
+        df = gen_df('string')
         with pytest.raises(ValueError):
-            data.to_clipboard(encoding='ascii')
+            df.to_clipboard(encoding='ascii')
         with pytest.raises(NotImplementedError):
             pd.read_clipboard(encoding='ascii')
 
-    def test_round_trip_valid_encodings(self):
-        for enc in ['UTF-8', 'utf-8', 'utf8']:
-            for dt in self.data_types:
-                self.check_round_trip_frame(dt, encoding=enc)
+    @pytest.mark.xfail
+    @pytest.mark.parametrize('enc', ['UTF-8', 'utf-8', 'utf8'])
+    def test_round_trip_valid_encodings(self, enc, df):
+        self.check_round_trip_frame(df, encoding=enc)


### PR DESCRIPTION
As requested in #21111, I've refactored the original clipboard tests as well as adding my own.  The set of tests have been improved to include testing of:

- failure of tab delimited tables (#21104)
- errors relating to copying and reading space-delimited tables
- copy and pasting tables where the text contains quotes or delimiters

As a result, these tests will fail on the current master branch, but should succeed on the commit in #21111

@WillAyd