### PR TITLE
BUG: group with multiple named results

### DIFF
--- a/pandas/core/groupby/groupby.py
+++ b/pandas/core/groupby/groupby.py
@@ -2300,14 +2300,14 @@ class BaseGrouper(object):
     def names(self):
         # GH 19029
         # add suffix to level name in case they contain duplicates (GH 19029):
-        orig_names =  [ping.name for ping in self.groupings]
-        # if no names were assigned return the original names 
+        orig_names = [ping.name for ping in self.groupings]
+        # if no names were assigned return the original names
         if all(x is None for x in orig_names):
             return orig_names
         # in case duplicates are contained rename all of them
         if len(set(orig_names)) < len(orig_names):
-            orig_names = [''.join([str(x),str(i)])
-                                for i,x in enumerate(orig_names)]
+            orig_names = [''.join([str(x), str(i)])
+                          for i, x in enumerate(orig_names)]
 
         return orig_names
 

--- a/pandas/core/groupby/groupby.py
+++ b/pandas/core/groupby/groupby.py
@@ -2298,7 +2298,18 @@ class BaseGrouper(object):
 
     @property
     def names(self):
-        return [ping.name for ping in self.groupings]
+        # GH 19029
+        # add suffix to level name in case they contain duplicates (GH 19029):
+        orig_names =  [ping.name for ping in self.groupings]
+        # if no names were assigned return the original names 
+        if all(x is None for x in orig_names):
+            return orig_names
+        # in case duplicates are contained rename all of them
+        if len(set(orig_names)) < len(orig_names):
+            orig_names = [''.join([str(x),str(i)])
+                                for i,x in enumerate(orig_names)]
+
+        return orig_names
 
     def size(self):
         """

--- a/pandas/core/groupby/groupby.py
+++ b/pandas/core/groupby/groupby.py
@@ -2298,18 +2298,28 @@ class BaseGrouper(object):
 
     @property
     def names(self):
-        # GH 19029
         # add suffix to level name in case they contain duplicates (GH 19029):
         orig_names = [ping.name for ping in self.groupings]
         # if no names were assigned return the original names
         if all(x is None for x in orig_names):
             return orig_names
-        # in case duplicates are contained rename all of them
-        if len(set(orig_names)) < len(orig_names):
-            orig_names = [''.join([str(x), str(i)])
-                          for i, x in enumerate(orig_names)]
 
-        return orig_names
+        suffixes = collections.defaultdict(int)
+        dups = {n: count for n, count in
+                collections.Counter(orig_names).items() if count > 1}
+        new_names = []
+        for name in orig_names:
+            if name not in dups:
+                new_names.append(name)
+            else:
+                if name is not None:
+                    new_name = '{0}_{1}'.format(name, suffixes[name])
+                else:
+                    new_name = '{0}'.format(suffixes[name])
+                suffixes[name] += 1
+                new_names.append(new_name)
+
+        return new_names
 
     def size(self):
         """

--- a/pandas/tests/groupby/test_categorical.py
+++ b/pandas/tests/groupby/test_categorical.py
@@ -558,14 +558,6 @@ def test_as_index():
     result = df.groupby(['cat', s], as_index=False, observed=True).sum()
     tm.assert_frame_equal(result, expected)
 
-    # GH 19029: conflicitng names should not raise a value error anymore
-    raised = False
-    try:
-        df.groupby(['cat', s.rename('cat')], observed=True).sum()
-    except ValueError:
-        raised = True
-    assert raised is False
-
     # is original index dropped?
     group_columns = ['cat', 'A']
     expected = DataFrame(

--- a/pandas/tests/groupby/test_categorical.py
+++ b/pandas/tests/groupby/test_categorical.py
@@ -559,14 +559,12 @@ def test_as_index():
     tm.assert_frame_equal(result, expected)
 
     # GH 19029: conflicitng names should not raise a value error anymore
-    raised=False
+    raised = False
     try:
         df.groupby(['cat', s.rename('cat')], observed=True).sum()
-    except ValueError as e:
+    except ValueError:
         raised = True
-    assert raised == False
-        
-         
+    assert raised is False
 
     # is original index dropped?
     group_columns = ['cat', 'A']

--- a/pandas/tests/groupby/test_categorical.py
+++ b/pandas/tests/groupby/test_categorical.py
@@ -558,9 +558,15 @@ def test_as_index():
     result = df.groupby(['cat', s], as_index=False, observed=True).sum()
     tm.assert_frame_equal(result, expected)
 
-    # GH18872: conflicting names in desired index
-    with pytest.raises(ValueError):
+    # GH 19029: conflicitng names should not raise a value error anymore
+    raised=False
+    try:
         df.groupby(['cat', s.rename('cat')], observed=True).sum()
+    except ValueError as e:
+        raised = True
+    assert raised == False
+        
+         
 
     # is original index dropped?
     group_columns = ['cat', 'A']

--- a/pandas/tests/groupby/test_groupby.py
+++ b/pandas/tests/groupby/test_groupby.py
@@ -1677,9 +1677,9 @@ def test_tuple_correct_keyerror():
 
 
 def test_dup_index_names():
-    # duplicated index names in groupby operations should be renamed (GH 19029):
-    df = pd.DataFrame(data={'date': list(pd.date_range('5.1.2018', '5.3.2018')),
-                            'vals': list(range(3))})
+    # dup. index names in groupby operations should be renamed (GH 19029):
+    df = pd.DataFrame({'date': list(pd.date_range('5.1.2018', '5.3.2018')),
+                       'vals': list(range(3))})
 
     mi = pd.MultiIndex.from_product([[5], [1, 2, 3]], names=['date0', 'date1'])
     expected = pd.Series(data=list(range(3)), index=mi, name='vals')
@@ -1687,18 +1687,18 @@ def test_dup_index_names():
     failed = False
     try:
         result = df.groupby([df.date.dt.month, df.date.dt.day])['vals'].sum()
-    except ValueError as e:
+    except ValueError:
         failed = True
 
-    assert failed == False
+    assert failed is False
 
-    tm.assert_series_equal(result,expected)
+    tm.assert_series_equal(result, expected)
 
 
 def test_empty_index_names():
     # don't rename frames in case no names were assigned (GH 19029)
-    df = pd.DataFrame(data={'date': list(pd.date_range('5.1.2018', '5.3.2018')),
-                            'vals': list(range(3))})
+    df = pd.DataFrame({'date': list(pd.date_range('5.1.2018', '5.3.2018')),
+                       'vals': list(range(3))})
 
     mi = pd.MultiIndex.from_product([[5], [1, 2, 3]])
     expected = pd.Series(data=list(range(3)), index=mi, name='vals')
@@ -1706,11 +1706,10 @@ def test_empty_index_names():
     failed = False
     try:
         result = df.groupby([df.date.dt.month.rename(None),
-                        df.date.dt.day.rename(None)])['vals'].sum()
-    except ValueError as e:
+                             df.date.dt.day.rename(None)])['vals'].sum()
+    except ValueError:
         failed = True
 
-    assert failed == False
+    assert failed is False
 
-    tm.assert_series_equal(result,expected)
-
+    tm.assert_series_equal(result, expected)

--- a/pandas/tests/reshape/test_pivot.py
+++ b/pandas/tests/reshape/test_pivot.py
@@ -1709,16 +1709,17 @@ class TestCrosstab(object):
         s = pd.Series(range(3), name='foo')
         failed = False
         try:
-           result=pd.crosstab(s,s)
-        except ValueError as e:
+            result = pd.crosstab(s, s)
+        except ValueError:
             failed = True
 
-        assert failed == False
+        assert failed is False
 
-        s0 = pd.Series(range(3),name='foo0')
-        s1 = pd.Series(range(3),name='foo1')
-        expected = pd.DataFrame(data=np.diag(np.ones(3,dtype='int64')), index=s0, columns=s1)
-        tm.assert_frame_equal(result,expected)
+        s0 = pd.Series(range(3), name='foo0')
+        s1 = pd.Series(range(3), name='foo1')
+        expected = pd.DataFrame(np.diag(np.ones(3, dtype='int64')),
+                                index=s0, columns=s1)
+        tm.assert_frame_equal(result, expected)
 
     @pytest.mark.parametrize("names", [['a', ('b', 'c')],
                                        [('a', 'b'), 'c']])

--- a/pandas/tests/reshape/test_pivot.py
+++ b/pandas/tests/reshape/test_pivot.py
@@ -1705,9 +1705,20 @@ class TestCrosstab(object):
         tm.assert_frame_equal(result, expected)
 
     def test_crosstab_dup_index_names(self):
-        # GH 13279, GH 18872
+        # duplicated index name should get renamed (GH 19029)
         s = pd.Series(range(3), name='foo')
-        pytest.raises(ValueError, pd.crosstab, s, s)
+        failed = False
+        try:
+           result=pd.crosstab(s,s)
+        except ValueError as e:
+            failed = True
+
+        assert failed == False
+
+        s0 = pd.Series(range(3),name='foo0')
+        s1 = pd.Series(range(3),name='foo1')
+        expected = pd.DataFrame(data=np.diag(np.ones(3,dtype='int64')), index=s0, columns=s1)
+        tm.assert_frame_equal(result,expected)
 
     @pytest.mark.parametrize("names", [['a', ('b', 'c')],
                                        [('a', 'b'), 'c']])


### PR DESCRIPTION
- [x] closes #19029 
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

This bugfix gets rid of duplicated names that can be the result of groupby operations (#19029).
I opted to implement one of the ideas proposed by [toobaz](https://github.com/pandas-dev/pandas/issues/19029#issuecomment-354684340): duplicated names get suffixed by their corresponding position, i.e. ['name','name'] gets transformed into ['name0', 'name1'].

* A few testcases have been added.
* One particular testcase had to be changed ([test_crosstab_dup_index_names](https://github.com/pandas-dev/pandas/blob/master/pandas/tests/reshape/test_pivot.py))
  - This is because with the new bugfix crosstab does not yield a ValueError anymore.
