### PR TITLE
WIP: Make weekday_name field in DatetimeIndex categorical

### DIFF
--- a/pandas/core/indexes/datetimes.py
+++ b/pandas/core/indexes/datetimes.py
@@ -42,6 +42,7 @@ import pandas.compat as compat
 from pandas.tseries.frequencies import to_offset, get_period_alias, Resolution
 from pandas.core.indexes.datetimelike import (
     DatelikeOps, TimelikeOps, DatetimeIndexOpsMixin)
+from pandas.core.indexes.category import CategoricalIndex
 from pandas.tseries.offsets import (
     DateOffset, generate_range, Tick, CDay, prefix_mapping)
 
@@ -55,8 +56,7 @@ import pandas.core.tools.datetimes as tools
 from pandas._libs import (lib, index as libindex, tslib as libts,
                           join as libjoin, Timestamp)
 from pandas._libs.tslibs import (timezones, conversion, fields, parsing,
-                                 ccalendar,
-                                 resolution as libresolution)
+                                 resolution as libresolution, ccalendar)
 
 # -------- some conversion wrapper functions
 
@@ -2511,7 +2511,9 @@ default 'raise'
         result = fields.get_date_name_field(values, 'month_name',
                                             locale=locale)
         result = self._maybe_mask_results(result)
-        return Index(result, name=self.name)
+        return CategoricalIndex(result, ordered=True,
+                                categories=ccalendar.MONTHS_FULL[1:],
+                                name=self.name)
 
     def day_name(self, locale=None):
         """
@@ -2537,7 +2539,8 @@ default 'raise'
         result = fields.get_date_name_field(values, 'day_name',
                                             locale=locale)
         result = self._maybe_mask_results(result)
-        return Index(result, name=self.name)
+        return CategoricalIndex(result, ordered=True, name=self.name,
+                                categories=ccalendar.DAYS_FULL)
 
 
 DatetimeIndex._add_comparison_methods()

--- a/pandas/tests/indexes/datetimes/test_misc.py
+++ b/pandas/tests/indexes/datetimes/test_misc.py
@@ -7,7 +7,7 @@ import numpy as np
 import pandas as pd
 import pandas.util.testing as tm
 from pandas import (Index, DatetimeIndex, datetime, offsets,
-                    date_range, Timestamp)
+                    date_range, Timestamp, CategoricalIndex)
 
 
 class TestTimeSeries(object):
@@ -283,7 +283,9 @@ class TestDatetime64(object):
         # GH 12805
         dti = DatetimeIndex(freq='M', start='2012', end='2013')
         result = dti.month_name(locale=time_locale)
-        expected = Index([month.capitalize() for month in expected_months])
+        expected = CategoricalIndex(
+            [month.capitalize() for month in expected_months],
+            ordered=True, categories=expected_months)
         tm.assert_index_equal(result, expected)
         for date, expected in zip(dti, expected_months):
             result = date.month_name(locale=time_locale)

--- a/pandas/tests/series/test_datetime_values.py
+++ b/pandas/tests/series/test_datetime_values.py
@@ -308,7 +308,8 @@ class TestSeriesDatetimeValues(TestData):
 
         s = Series(DatetimeIndex(freq='M', start='2012', end='2013'))
         result = s.dt.month_name(locale=time_locale)
-        expected = Series([month.capitalize() for month in expected_months])
+        expected = Series([month.capitalize() for month in expected_months])\
+            .astype('category', ordered=True, categories=expected_months)
         tm.assert_series_equal(result, expected)
         for s_date, expected in zip(s, expected_months):
             result = s_date.month_name(locale=time_locale)


### PR DESCRIPTION
- [x] closes #12993 
- [ ] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
Work in progress. `DatetimeIndex` `CategoricalIndex` for `weekday_name` but accessing it from  `dt.weekday_name` still returns an `object` dtype