### PR TITLE
BUG: DecimalArray and JSONArray that are empty return incorrect results for isna()

### DIFF
--- a/pandas/tests/extension/base/missing.py
+++ b/pandas/tests/extension/base/missing.py
@@ -18,6 +18,11 @@ class BaseMissingTests(BaseExtensionTests):
         expected = pd.Series(expected)
         self.assert_series_equal(result, expected)
 
+        # GH 21189
+        result = pd.Series(data_missing).drop([0, 1]).isna()
+        expected = pd.Series([], dtype=bool)
+        self.assert_series_equal(result, expected)
+
     def test_dropna_series(self, data_missing):
         ser = pd.Series(data_missing)
         result = ser.dropna()

--- a/pandas/tests/extension/decimal/array.py
+++ b/pandas/tests/extension/decimal/array.py
@@ -90,7 +90,7 @@ class DecimalArray(ExtensionArray):
         return 0
 
     def isna(self):
-        return np.array([x.is_nan() for x in self._data])
+        return np.array([x.is_nan() for x in self._data], dtype=bool)
 
     @property
     def _na_value(self):

--- a/pandas/tests/extension/json/array.py
+++ b/pandas/tests/extension/json/array.py
@@ -108,7 +108,8 @@ class JSONArray(ExtensionArray):
         return sys.getsizeof(self.data)
 
     def isna(self):
-        return np.array([x == self.dtype.na_value for x in self.data])
+        return np.array([x == self.dtype.na_value for x in self.data],
+                        dtype=bool)
 
     def take(self, indexer, allow_fill=False, fill_value=None):
         # re-implement here, since NumPy has trouble setting


### PR DESCRIPTION

- [x] closes #21189
- [x] tests added / passed
  - Modified tests/extension/base/missing.py to test when arrays are empty
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
  - Did not put anything here because it's internal code

Probably for @TomAugspurger to review.
