### PR TITLE
CLN: Remove duplicate Categorical subsection from 0.23.1 whatsnew

### DIFF
--- a/doc/source/whatsnew/v0.23.1.txt
+++ b/doc/source/whatsnew/v0.23.1.txt
@@ -97,8 +97,3 @@ Reshaping
 
 - Bug in :func:`concat` where error was raised in concatenating :class:`Series` with numpy scalar and tuple names (:issue:`21015`)
 -
-
-Categorical
-^^^^^^^^^^^
-
--


### PR DESCRIPTION
Unless I'm misreading, it looks like there are two Categorical subsections under the Bug Fixes section, with the first subsection starting on line 65.