### PR TITLE
BUG: Fix inconsistency between the shape properties of SparseSeries and SparseArray (#21126)

### DIFF
--- a/doc/source/whatsnew/v0.23.1.txt
+++ b/doc/source/whatsnew/v0.23.1.txt
@@ -67,6 +67,11 @@ Categorical
 
 - Bug in :func:`pandas.util.testing.assert_index_equal` which raised ``AssertionError`` incorrectly, when comparing two :class:`CategoricalIndex` objects with param ``check_categorical=False`` (:issue:`19776`)
 
+Sparse
+^^^^^^
+
+- Bug in :attr:`SparseArray.shape` ignores ``fill_values`` (:issue:`21126`)
+
 Conversion
 ^^^^^^^^^^
 

--- a/doc/source/whatsnew/v0.23.1.txt
+++ b/doc/source/whatsnew/v0.23.1.txt
@@ -70,7 +70,7 @@ Categorical
 Sparse
 ^^^^^^
 
-- Bug in :attr:`SparseArray.shape` ignores ``fill_values`` (:issue:`21126`)
+- Bug in :attr:`SparseArray.shape` which previously only returned the shape :attr:`SparseArray.sp_values` (:issue:`21126`)
 
 Conversion
 ^^^^^^^^^^

--- a/pandas/core/sparse/array.py
+++ b/pandas/core/sparse/array.py
@@ -290,7 +290,9 @@ class SparseArray(PandasObject, np.ndarray):
         """Necessary for making this object picklable"""
         object_state = list(np.ndarray.__reduce__(self))
         subclass_state = self.fill_value, self.sp_index
-        object_state[2] = (object_state[2], subclass_state)
+        object_state[2] = list(object_state[2])
+        object_state[2][1] = super(SparseArray, self).shape
+        object_state[2] = (tuple(object_state[2]), subclass_state)
         return tuple(object_state)
 
     def __setstate__(self, state):
@@ -338,6 +340,10 @@ class SparseArray(PandasObject, np.ndarray):
         output.fill(self.fill_value)
         output.put(int_index.indices, self)
         return output
+
+    @property
+    def shape(self):
+        return (len(self),)
 
     @property
     def sp_values(self):

--- a/pandas/core/sparse/array.py
+++ b/pandas/core/sparse/array.py
@@ -290,9 +290,8 @@ class SparseArray(PandasObject, np.ndarray):
         """Necessary for making this object picklable"""
         object_state = list(np.ndarray.__reduce__(self))
         subclass_state = self.fill_value, self.sp_index
-        object_state[2] = list(object_state[2])
-        object_state[2][1] = super(SparseArray, self).shape
-        object_state[2] = (tuple(object_state[2]), subclass_state)
+        object_state[2] = self.sp_values.__reduce__()[2]
+        object_state[2] = (object_state[2], subclass_state)
         return tuple(object_state)
 
     def __setstate__(self, state):

--- a/pandas/tests/sparse/test_array.py
+++ b/pandas/tests/sparse/test_array.py
@@ -454,6 +454,16 @@ class TestSparseArray(object):
         assert_almost_equal(self.arr.to_dense(), self.arr_data)
         assert_almost_equal(self.arr.sp_values, np.asarray(self.arr))
 
+    def test_shape(self):
+        out = SparseArray([0, 0, 0, 0, 0])
+        assert out.shape == (5,)
+
+        out = SparseArray([])
+        assert out.shape == (0,)
+
+        out = SparseArray([0])
+        assert out.shape == (1,)
+
     def test_to_dense(self):
         vals = np.array([1, np.nan, np.nan, 3, np.nan])
         res = SparseArray(vals).to_dense()

--- a/pandas/tests/sparse/test_array.py
+++ b/pandas/tests/sparse/test_array.py
@@ -454,16 +454,16 @@ class TestSparseArray(object):
         assert_almost_equal(self.arr.to_dense(), self.arr_data)
         assert_almost_equal(self.arr.sp_values, np.asarray(self.arr))
 
-    def test_shape(self):
+    @pytest.mark.parametrize('data,shape,dtype', [
+        ([0, 0, 0, 0, 0], (5,), None),
+        ([], (0,), None),
+        ([0], (1,), None),
+        (['A', 'A', np.nan, 'B'], (4,), np.object)
+    ])
+    def test_shape(self, data, shape, dtype):
         # GH 21126
-        out = SparseArray([0, 0, 0, 0, 0])
-        assert out.shape == (5,)
-
-        out = SparseArray([])
-        assert out.shape == (0,)
-
-        out = SparseArray([0])
-        assert out.shape == (1,)
+        out = SparseArray(data, dtype=dtype)
+        assert out.shape == shape
 
     def test_to_dense(self):
         vals = np.array([1, np.nan, np.nan, 3, np.nan])

--- a/pandas/tests/sparse/test_array.py
+++ b/pandas/tests/sparse/test_array.py
@@ -455,6 +455,7 @@ class TestSparseArray(object):
         assert_almost_equal(self.arr.sp_values, np.asarray(self.arr))
 
     def test_shape(self):
+        # GH 21126
         out = SparseArray([0, 0, 0, 0, 0])
         assert out.shape == (5,)
 


### PR DESCRIPTION
- [x] closes #21126 
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry
