### PR TITLE
Stable Sorting Algorithm for Fillna Indexer

### DIFF
--- a/doc/source/whatsnew/v0.23.1.txt
+++ b/doc/source/whatsnew/v0.23.1.txt
@@ -52,6 +52,7 @@ Groupby/Resample/Rolling
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
 - Bug in :func:`DataFrame.agg` where applying multiple aggregation functions to a :class:`DataFrame` with duplicated column names would cause a stack overflow (:issue:`21063`)
+- Bug in :func:`pandas.core.groupby.GroupBy.ffill` and :func:`pandas.core.groupby.GroupBy.bfill` where the fill within a grouping would not always be applied as intended due to the implementations' use of a non-stable sort (:issue:`21207`)
 
 Strings
 ^^^^^^^

--- a/pandas/_libs/groupby.pyx
+++ b/pandas/_libs/groupby.pyx
@@ -297,7 +297,8 @@ def group_fillna_indexer(ndarray[int64_t] out, ndarray[int64_t] labels,
     # Make sure all arrays are the same size
     assert N == len(labels) == len(mask)
 
-    sorted_labels = np.argsort(labels).astype(np.int64, copy=False)
+    sorted_labels = np.argsort(labels, kind='mergesort').astype(
+        np.int64, copy=False)
     if direction == 'bfill':
         sorted_labels = sorted_labels[::-1]
 

--- a/pandas/tests/groupby/test_transform.py
+++ b/pandas/tests/groupby/test_transform.py
@@ -720,6 +720,7 @@ def test_group_fill_methods(mix_groupings, as_series, val1, val2,
         exp = DataFrame({'key': keys, 'val': _exp_vals})
         assert_frame_equal(result, exp)
 
+
 @pytest.mark.parametrize("fill_method", ['ffill', 'bfill'])
 def test_pad_stable_sorting(fill_method):
     # GH 21207

--- a/pandas/tests/groupby/test_transform.py
+++ b/pandas/tests/groupby/test_transform.py
@@ -720,6 +720,22 @@ def test_group_fill_methods(mix_groupings, as_series, val1, val2,
         exp = DataFrame({'key': keys, 'val': _exp_vals})
         assert_frame_equal(result, exp)
 
+@pytest.mark.parametrize("fill_method", ['ffill', 'bfill'])
+def test_pad_stable_sorting(fill_method):
+    # GH 21207
+    x = [0] * 20
+    y = [np.nan] * 10 + [1] * 10
+
+    if fill_method == 'bfill':
+        y = y[::-1]
+
+    df = pd.DataFrame({'x': x, 'y': y})
+    expected = df.copy()
+
+    result = getattr(df.groupby('x'), fill_method)()
+
+    tm.assert_frame_equal(result, expected)
+
 
 @pytest.mark.parametrize("test_series", [True, False])
 @pytest.mark.parametrize("periods,fill_method,limit", [


### PR DESCRIPTION
- [X] closes #21207
- [X] tests added / passed
- [X] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry

Haven't added a whatsnew yet if only because I need to think through the best way to phrase this / investigate where it doesn't work. I have a feeling the default `kind` argument has a bug in it back in NumPy, but `mergesort` is guaranteed as a stable sort so may be preferable anyway in spite of the performance hit.

https://docs.scipy.org/doc/numpy/reference/generated/numpy.sort.html#numpy.sort

Will post ASVs later as well - let me know of feedback in the interim