### PR TITLE
BUG: df.agg, df.transform and df.apply use different methods when axis=1 than when axis=0

### DIFF
--- a/doc/source/whatsnew/v0.24.0.txt
+++ b/doc/source/whatsnew/v0.24.0.txt
@@ -475,11 +475,9 @@ Numeric
 - Bug in :class:`Series` ``__rmatmul__`` doesn't support matrix vector multiplication (:issue:`21530`)
 - Bug in :func:`factorize` fails with read-only array (:issue:`12813`)
 - Fixed bug in :func:`unique` handled signed zeros inconsistently: for some inputs 0.0 and -0.0 were treated as equal and for some inputs as different. Now they are treated as equal for all inputs (:issue:`21866`)
-- Bug in :meth:`DataFrame.agg`, :meth:`DataFrame.transform` and :meth:`DataFrame.apply` when ``axis=1``.
-  Using ``apply`` with a list of functions and axis=1 (e.g. ``df.apply(['abs'], axis=1)``)
-  previously gave a TypeError. This fixes that issue.
-  As ``agg`` and ``transform`` in some cases delegate to ``apply``, this also
-  fixed this issue for them (:issue:`16679`).
+- Bug in :meth:`DataFrame.agg`, :meth:`DataFrame.transform` and :meth:`DataFrame.apply` where,
+  when supplied with a list of functions and ``axis=1`` (e.g. ``df.apply(['sum', 'mean'], axis=1)``),
+  a ``TypeError`` was wrongly raised. For all three methods such calculation are now done correctly. (:issue:`16679`).
 -
 
 Strings

--- a/doc/source/whatsnew/v0.24.0.txt
+++ b/doc/source/whatsnew/v0.24.0.txt
@@ -475,7 +475,11 @@ Numeric
 - Bug in :class:`Series` ``__rmatmul__`` doesn't support matrix vector multiplication (:issue:`21530`)
 - Bug in :func:`factorize` fails with read-only array (:issue:`12813`)
 - Fixed bug in :func:`unique` handled signed zeros inconsistently: for some inputs 0.0 and -0.0 were treated as equal and for some inputs as different. Now they are treated as equal for all inputs (:issue:`21866`)
--
+- Bug in :meth:`DataFrame.agg`, :meth:`DataFrame.transform` and :meth:`DataFrame.apply` when ``axis=1``.
+  Using ``apply`` with a list of functions and axis=1 (e.g. ``df.apply(['abs'], axis=1)``)
+  previously gave a TypeError. This fixes that issue.
+  As ``agg`` and ``transform`` in some cases delegate to ``apply``, this also
+  fixed this issue for them (:issue:`16679`).
 -
 
 Strings

--- a/pandas/conftest.py
+++ b/pandas/conftest.py
@@ -6,7 +6,7 @@ import pytest
 import pandas
 import numpy as np
 import pandas as pd
-from pandas.compat import PY3
+from pandas.compat import PY3, PY36
 import pandas.util._test_decorators as td
 
 
@@ -64,7 +64,7 @@ def spmatrix(request):
                 ids=lambda x: "axis {!r}".format(x))
 def axis(request):
     """
-     Fixture for returning the axis numbers of a dataframe.
+     Fixture for returning the axis numbers of a DataFrame.
      """
     return request.param
 
@@ -72,7 +72,7 @@ def axis(request):
 @pytest.fixture(params=[0, 'index'], ids=lambda x: "axis {!r}".format(x))
 def axis_series(request):
     """
-     Fixture for returning the axis numbers of a series.
+     Fixture for returning the axis numbers of a Series.
      """
     return request.param
 
@@ -117,6 +117,18 @@ def all_arithmetic_operators(request):
     """
     Fixture for dunder names for common arithmetic operations
     """
+    return request.param
+
+
+_cython_table = list(pd.core.base.SelectionMixin._cython_table.items())
+if not PY36:
+    # dicts have random order in Python<3.6, which xdist doesn't like
+    _cython_table = sorted(((key, value) for key, value in _cython_table),
+                           key=lambda x: x[0].__class__.__name__)
+
+
+@pytest.fixture(params=_cython_table)
+def cython_table_items(request):
     return request.param
 
 

--- a/pandas/conftest.py
+++ b/pandas/conftest.py
@@ -60,8 +60,8 @@ def spmatrix(request):
     return getattr(sparse, request.param + '_matrix')
 
 
-@pytest.fixture(params=[0, 1],
-                ids=lambda x: "axis {}".format(x))
+@pytest.fixture(params=[0, 1, 'index', 'columns'],
+                ids=lambda x: "axis {!r}".format(x))
 def axis(request):
     """
      Fixture for returning the axis numbers of a dataframe.
@@ -69,7 +69,7 @@ def axis(request):
     return request.param
 
 
-@pytest.fixture(params=[0], ids=lambda x: "axis {}".format(x))
+@pytest.fixture(params=[0, 'index'], ids=lambda x: "axis {!r}".format(x))
 def axis_series(request):
     """
      Fixture for returning the axis numbers of a series.

--- a/pandas/conftest.py
+++ b/pandas/conftest.py
@@ -60,6 +60,23 @@ def spmatrix(request):
     return getattr(sparse, request.param + '_matrix')
 
 
+@pytest.fixture(params=[0, 1],
+                ids=lambda x: "axis {}".format(x))
+def axis(request):
+    """
+     Fixture for returning the axis numbers of a dataframe.
+     """
+    return request.param
+
+
+@pytest.fixture(params=[0], ids=lambda x: "axis {}".format(x))
+def axis_series(request):
+    """
+     Fixture for returning the axis numbers of a series.
+     """
+    return request.param
+
+
 @pytest.fixture
 def ip():
     """

--- a/pandas/core/apply.py
+++ b/pandas/core/apply.py
@@ -5,6 +5,8 @@ from pandas._libs import reduction
 from pandas.core.dtypes.generic import ABCSeries
 from pandas.core.dtypes.common import (
     is_extension_type,
+    is_dict_like,
+    is_list_like,
     is_sequence)
 from pandas.util._decorators import cache_readonly
 
@@ -106,7 +108,7 @@ class FrameApply(object):
         """ compute the results """
 
         # dispatch to agg
-        if isinstance(self.f, (list, dict)):
+        if is_list_like(self.f) or is_dict_like(self.f):
             return self.obj.aggregate(self.f, axis=self.axis,
                                       *self.args, **self.kwds)
 

--- a/pandas/core/apply.py
+++ b/pandas/core/apply.py
@@ -105,6 +105,11 @@ class FrameApply(object):
     def get_result(self):
         """ compute the results """
 
+        # dispatch to agg
+        if isinstance(self.f, (list, dict)):
+            return self.obj.aggregate(self.f, axis=self.axis,
+                                      *self.args, **self.kwds)
+
         # all empty
         if len(self.columns) == 0 and len(self.index) == 0:
             return self.apply_empty_result()
@@ -307,15 +312,6 @@ class FrameApply(object):
 
 class FrameRowApply(FrameApply):
     axis = 0
-
-    def get_result(self):
-
-        # dispatch to agg
-        if isinstance(self.f, (list, dict)):
-            return self.obj.aggregate(self.f, axis=self.axis,
-                                      *self.args, **self.kwds)
-
-        return super(FrameRowApply, self).get_result()
 
     def apply_broadcast(self):
         return super(FrameRowApply, self).apply_broadcast(self.obj)

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -6080,7 +6080,7 @@ class DataFrame(NDFrame):
         return result
 
     def _aggregate(self, arg, axis=0, *args, **kwargs):
-        if axis == 1:
+        if axis in {1, 'columns'}:
             result, how = (super(DataFrame, self.T)
                            ._aggregate(arg, *args, **kwargs))
             result = result.T if result is not None else result
@@ -6090,7 +6090,7 @@ class DataFrame(NDFrame):
     agg = aggregate
 
     def transform(self, func, axis=0, *args, **kwargs):
-        if axis == 1:
+        if axis in {1, 'columns'}:
             return super(DataFrame, self.T).transform(func, *args, **kwargs).T
         return super(DataFrame, self).transform(func, *args, **kwargs)
 

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -6080,7 +6080,8 @@ class DataFrame(NDFrame):
         return result
 
     def _aggregate(self, arg, axis=0, *args, **kwargs):
-        if axis in {1, 'columns'}:
+        axis = self._get_axis_number(axis)
+        if axis == 1:
             result, how = (super(DataFrame, self.T)
                            ._aggregate(arg, *args, **kwargs))
             result = result.T if result is not None else result
@@ -6090,7 +6091,8 @@ class DataFrame(NDFrame):
     agg = aggregate
 
     def transform(self, func, axis=0, *args, **kwargs):
-        if axis in {1, 'columns'}:
+        axis = self._get_axis_number(axis)
+        if axis == 1:
             return super(DataFrame, self.T).transform(func, *args, **kwargs).T
         return super(DataFrame, self).transform(func, *args, **kwargs)
 

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -6070,16 +6070,19 @@ class DataFrame(NDFrame):
     def aggregate(self, func, axis=0, *args, **kwargs):
         axis = self._get_axis_number(axis)
 
-        # TODO: flipped axis
         result = None
-        if axis == 0:
-            try:
-                result, how = self._aggregate(func, axis=0, *args, **kwargs)
-            except TypeError:
-                pass
+        try:
+            result, how = self._aggregate(func, axis=axis, *args, **kwargs)
+        except TypeError:
+            pass
         if result is None:
             return self.apply(func, axis=axis, args=args, **kwargs)
         return result
+
+    @Appender(NDFrame._aggregate.__doc__, indents=2)
+    def _aggregate(self, arg, axis=0, *args, **kwargs):
+        obj = self.T if axis == 1 else self
+        return super(DataFrame, obj)._aggregate(arg, *args, **kwargs)
 
     agg = aggregate
 

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -6080,10 +6080,19 @@ class DataFrame(NDFrame):
         return result
 
     def _aggregate(self, arg, axis=0, *args, **kwargs):
-        obj = self.T if axis == 1 else self
-        return super(DataFrame, obj)._aggregate(arg, *args, **kwargs)
+        if axis == 1:
+            result, how = (super(DataFrame, self.T)
+                           ._aggregate(arg, *args, **kwargs))
+            result = result.T if result is not None else result
+            return result, how
+        return super(DataFrame, self)._aggregate(arg, *args, **kwargs)
 
     agg = aggregate
+
+    def transform(self, func, axis=0, *args, **kwargs):
+        if axis == 1:
+            return super(DataFrame, self.T).transform(func, *args, **kwargs).T
+        return super(DataFrame, self).transform(func, *args, **kwargs)
 
     def apply(self, func, axis=0, broadcast=None, raw=False, reduce=None,
               result_type=None, args=(), **kwds):

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -6080,8 +6080,9 @@ class DataFrame(NDFrame):
         return result
 
     def _aggregate(self, arg, axis=0, *args, **kwargs):
-        axis = self._get_axis_number(axis)
         if axis == 1:
+            # NDFrame.aggregate returns a tuple, and we need to transpose
+            # only result
             result, how = (super(DataFrame, self.T)
                            ._aggregate(arg, *args, **kwargs))
             result = result.T if result is not None else result
@@ -6090,6 +6091,7 @@ class DataFrame(NDFrame):
 
     agg = aggregate
 
+    @Appender(_shared_docs['transform'] % _shared_doc_kwargs)
     def transform(self, func, axis=0, *args, **kwargs):
         axis = self._get_axis_number(axis)
         if axis == 1:

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -6079,7 +6079,6 @@ class DataFrame(NDFrame):
             return self.apply(func, axis=axis, args=args, **kwargs)
         return result
 
-    @Appender(NDFrame._aggregate.__doc__, indents=2)
     def _aggregate(self, arg, axis=0, *args, **kwargs):
         obj = self.T if axis == 1 else self
         return super(DataFrame, obj)._aggregate(arg, *args, **kwargs)

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -9193,16 +9193,14 @@ class NDFrame(PandasObject, SelectionMixin):
 
         cls.ewm = ewm
 
-        @Appender(_shared_docs['transform'] % _shared_doc_kwargs)
-        def transform(self, func, *args, **kwargs):
-            result = self.agg(func, *args, **kwargs)
-            if is_scalar(result) or len(result) != len(self):
-                raise ValueError("transforms cannot produce "
-                                 "aggregated results")
+    @Appender(_shared_docs['transform'] % _shared_doc_kwargs)
+    def transform(self, func, *args, **kwargs):
+        result = self.agg(func, *args, **kwargs)
+        if is_scalar(result) or len(result) != len(self):
+            raise ValueError("transforms cannot produce "
+                             "aggregated results")
 
-            return result
-
-        cls.transform = transform
+        return result
 
     # ----------------------------------------------------------------------
     # Misc methods

--- a/pandas/tests/frame/test_apply.py
+++ b/pandas/tests/frame/test_apply.py
@@ -20,33 +20,8 @@ from pandas.core.apply import frame_apply
 from pandas.util.testing import (assert_series_equal,
                                  assert_frame_equal)
 import pandas.util.testing as tm
+from pandas.conftest import _get_cython_table_params
 from pandas.tests.frame.common import TestData
-
-
-def _get_cython_table_params(frame, func_names_and_expected):
-    """combine frame, functions from SelectionMixin._cython_table
-    keys and expected result.
-
-    Parameters
-    ----------
-    frame : DataFrame
-        A symmetrical DataFrame
-    func_names_and_expected : Sequence of two items
-        The first item is a name of a NDFrame method ('sum', 'prod') etc.
-        The second item is the expected return value
-
-    Returns
-    -------
-    results : list
-        List of three items (DataFrame, function, expected result)
-    """
-    from pandas.conftest import _cython_table
-    results = []
-    for func_name, expected in func_names_and_expected:
-        results.append((frame, func_name, expected))
-        results += [(frame, func, expected) for func, name in _cython_table
-                    if name == func_name]
-    return results
 
 
 class TestDataFrameApply(TestData):

--- a/pandas/tests/frame/test_apply.py
+++ b/pandas/tests/frame/test_apply.py
@@ -40,18 +40,12 @@ def _get_cython_table_params(frame, func_names_and_expected):
     results : list
         List of three items (DataFrame, function, expected result)
     """
-    table = pd.core.base.SelectionMixin._cython_table
-    if compat.PY36:
-        table = list(table.items())
-    else:  # dicts have random order in Python<3.6, which xdist doesn't like
-        table = sorted(((key, value) for key, value in table.items()),
-                       key=lambda x: x[0].__class__.__name__)
+    from pandas.conftest import _cython_table
     results = []
     for func_name, expected in func_names_and_expected:
         results.append((frame, func_name, expected))
-        results += [
-            (frame, func, expected) for func, name in table
-            if name == func_name]
+        results += [(frame, func, expected) for func, name in _cython_table
+                    if name == func_name]
     return results
 
 

--- a/pandas/tests/frame/test_apply.py
+++ b/pandas/tests/frame/test_apply.py
@@ -946,7 +946,7 @@ class TestDataFrameAggregate(TestData):
         df = pd.DataFrame({'A': range(5), 'B': 5})
 
         # nested renaming
-        with tm.assert_produces_warning(FutureWarning):
+        with tm.assert_produces_warning(FutureWarning, check_stacklevel=False):
             df.agg({'A': {'foo': 'min'},
                     'B': {'bar': 'max'}})
 
@@ -1056,3 +1056,73 @@ class TestDataFrameAggregate(TestData):
         expected = df.size
 
         assert result == expected
+
+    @pytest.mark.parametrize("frame, expected_dict", [
+        [DataFrame(), {
+            'sum': Series(),
+            'max': Series(),
+            'min': Series(),
+            'all': Series(dtype=bool),
+            'any': Series(dtype=bool),
+            'mean': Series(),
+            'prod': Series(),
+            'std': Series(),
+            'var': Series(),
+            'median': Series(),
+            'cumprod': DataFrame(),
+            'cumsum': DataFrame(),
+        }],
+        [DataFrame([[np.nan, 1], [1, 2]]), {
+            'sum': Series([1., 3]),
+            'max': Series([1., 2]),
+            'min': Series([1., 1]),
+            'all': Series([True, True]),
+            'any': Series([True, True]),
+            'mean': Series([1, 1.5]),
+            'prod': Series([1., 2]),
+            'std': Series([np.nan, 0.707107]),
+            'var': Series([np.nan, 0.5]),
+            'median': Series([1, 1.5]),
+            'cumprod': DataFrame([[np.nan, 1], [1., 2.]]),
+            'cumsum': DataFrame([[np.nan, 1], [1., 3.]]),
+        }],
+        [DataFrame([['a', 'b'], ['b', 'a']]), {
+            'sum': Series(['ab', 'ba']),
+            'max': Series(['b', 'b']),
+            'min': Series(['a', 'a']),
+            'all': Series([True, True]),
+            'any': Series([True, True]),
+            'mean': Series([], index=pd.Index([], dtype='int64')),
+            'prod': Series([], index=pd.Index([], dtype='int64')),
+            'std': Series([], index=pd.Index([], dtype='int64')),
+            'var': Series([], index=pd.Index([], dtype='int64')),
+            'median': Series([], index=pd.Index([], dtype='int64')),
+            'cumprod': TypeError,
+            'cumsum': DataFrame([['a', 'b'], ['ab', 'ba']]),
+        }],
+    ])
+    @pytest.mark.parametrize("axis", [0, 1], ids=lambda x: "axis {}".format(x))
+    def test_agg_cython_table(self, cython_table_items,
+                              frame, expected_dict, axis):
+        # GH21224
+        # test if using items in pandas.core.base.SelectionMixin._cython_table
+        # in agg gives correct results
+        np_func, str_func = cython_table_items
+        expected = expected_dict[str_func]
+
+        if isinstance(expected, type) and issubclass(expected, Exception):
+            with pytest.raises(expected):
+                # e.g. DataFrame(['a b'.split()]).cumprod() will raise
+                frame.agg(np_func, axis=axis)
+            with pytest.raises(expected):
+                frame.agg(str_func, axis=axis)
+            return
+
+        result = frame.agg(np_func, axis=axis)
+        result_str_func = frame.agg(str_func, axis=axis)
+        if str_func in ('cumprod', 'cumsum'):
+            tm.assert_frame_equal(result, expected)
+            tm.assert_frame_equal(result_str_func, expected)
+        else:
+            tm.assert_series_equal(result, expected)
+            tm.assert_series_equal(result_str_func, expected)

--- a/pandas/tests/frame/test_apply.py
+++ b/pandas/tests/frame/test_apply.py
@@ -869,7 +869,7 @@ def zip_frames(frames, axis=1):
 class TestDataFrameAggregate(TestData):
 
     def test_agg_transform(self, axis):
-        other_axis = abs(axis - 1)
+        other_axis = 1 if axis in {0, 'index'} else 0
 
         with np.errstate(all='ignore'):
 
@@ -890,7 +890,7 @@ class TestDataFrameAggregate(TestData):
             # list-like
             result = self.frame.apply([np.sqrt], axis=axis)
             expected = f_sqrt.copy()
-            if axis == 0:
+            if axis in {0, 'index'}:
                 expected.columns = pd.MultiIndex.from_product(
                     [self.frame.columns, ['sqrt']])
             else:
@@ -906,7 +906,7 @@ class TestDataFrameAggregate(TestData):
             # functions per series and then concatting
             result = self.frame.apply([np.abs, np.sqrt], axis=axis)
             expected = zip_frames([f_abs, f_sqrt], axis=other_axis)
-            if axis == 0:
+            if axis in {0, 'index'}:
                 expected.columns = pd.MultiIndex.from_product(
                     [self.frame.columns, ['absolute', 'sqrt']])
             else:
@@ -1001,7 +1001,7 @@ class TestDataFrameAggregate(TestData):
                     'B': {'bar': 'max'}})
 
     def test_agg_reduce(self, axis):
-        other_axis = abs(axis - 1)
+        other_axis = 1 if axis in {0, 'index'} else 0
         name1, name2 = self.frame.axes[other_axis].unique()[:2].sort_values()
 
         # all reducers
@@ -1010,7 +1010,7 @@ class TestDataFrameAggregate(TestData):
                               self.frame.sum(axis=axis),
                               ], axis=1)
         expected.columns = ['mean', 'max', 'sum']
-        expected = expected.T if axis == 0 else expected
+        expected = expected.T if axis in {0, 'index'} else expected
 
         result = self.frame.agg(['mean', 'max', 'sum'], axis=axis)
         assert_frame_equal(result, expected)
@@ -1031,7 +1031,7 @@ class TestDataFrameAggregate(TestData):
                           index=['mean']),
             name2: Series([self.frame.loc(other_axis)[name2].sum()],
                           index=['sum'])})
-        expected = expected.T if axis == 1 else expected
+        expected = expected.T if axis in {1, 'columns'} else expected
         assert_frame_equal(result, expected)
 
         # dict input with lists with multiple
@@ -1045,7 +1045,7 @@ class TestDataFrameAggregate(TestData):
                            self.frame.loc(other_axis)[name2].max()],
                            index=['sum', 'max'])),
         ]))
-        expected = expected.T if axis == 1 else expected
+        expected = expected.T if axis in {1, 'columns'} else expected
         assert_frame_equal(result, expected)
 
     def test_nuiscance_columns(self):

--- a/pandas/tests/generic/test_label_or_level_utils.py
+++ b/pandas/tests/generic/test_label_or_level_utils.py
@@ -82,7 +82,7 @@ def test_is_level_or_label_reference_df_simple(df_levels, axis):
     expected_labels, expected_levels = get_labels_levels(df_levels)
 
     # Transpose frame if axis == 1
-    if axis == 1:
+    if axis in {1, 'columns'}:
         df_levels = df_levels.T
 
     # Perform checks
@@ -93,7 +93,7 @@ def test_is_level_or_label_reference_df_simple(df_levels, axis):
 def test_is_level_reference_df_ambig(df_ambig, axis):
 
     # Transpose frame if axis == 1
-    if axis == 1:
+    if axis in {1, 'columns'}:
         df_ambig = df_ambig.T
 
     # df has both an on-axis level and off-axis label named L1
@@ -166,7 +166,7 @@ def test_is_label_or_level_reference_panel_error(panel):
 def test_check_label_or_level_ambiguity_df(df_ambig, axis):
 
     # Transpose frame if axis == 1
-    if axis == 1:
+    if axis in {1, 'columns'}:
         df_ambig = df_ambig.T
 
     # df_ambig has both an on-axis level and off-axis label named L1
@@ -176,7 +176,7 @@ def test_check_label_or_level_ambiguity_df(df_ambig, axis):
 
         assert df_ambig._check_label_or_level_ambiguity('L1', axis=axis)
         warning_msg = w[0].message.args[0]
-        if axis == 0:
+        if axis in {0, 'index'}:
             assert warning_msg.startswith("'L1' is both an index level "
                                           "and a column label")
         else:
@@ -236,7 +236,7 @@ def test_check_label_or_level_ambiguity_panel_error(panel):
 # ===============================
 def assert_label_values(frame, labels, axis):
     for label in labels:
-        if axis == 0:
+        if axis in {0, 'index'}:
             expected = frame[label]._values
         else:
             expected = frame.loc[label]._values
@@ -248,7 +248,7 @@ def assert_label_values(frame, labels, axis):
 
 def assert_level_values(frame, levels, axis):
     for level in levels:
-        if axis == 0:
+        if axis in {0, 'index'}:
             expected = frame.index.get_level_values(level=level)._values
         else:
             expected = (frame.columns
@@ -267,7 +267,7 @@ def test_get_label_or_level_values_df_simple(df_levels, axis):
     expected_labels, expected_levels = get_labels_levels(df_levels)
 
     # Transpose frame if axis == 1
-    if axis == 1:
+    if axis in {1, 'columns'}:
         df_levels = df_levels.T
 
     # Perform checks
@@ -278,7 +278,7 @@ def test_get_label_or_level_values_df_simple(df_levels, axis):
 def test_get_label_or_level_values_df_ambig(df_ambig, axis):
 
     # Transpose frame if axis == 1
-    if axis == 1:
+    if axis in {1, 'columns'}:
         df_ambig = df_ambig.T
 
     # df has both an on-axis level and off-axis label named L1
@@ -298,7 +298,7 @@ def test_get_label_or_level_values_df_ambig(df_ambig, axis):
 def test_get_label_or_level_values_df_duplabels(df_duplabels, axis):
 
     # Transpose frame if axis == 1
-    if axis == 1:
+    if axis in {1, 'columns'}:
         df_duplabels = df_duplabels.T
 
     # df has unambiguous level 'L1'
@@ -308,7 +308,7 @@ def test_get_label_or_level_values_df_duplabels(df_duplabels, axis):
     assert_label_values(df_duplabels, ['L3'], axis=axis)
 
     # df has duplicate labels 'L2'
-    if axis == 0:
+    if axis in {0, 'index'}:
         expected_msg = "The column label 'L2' is not unique"
     else:
         expected_msg = "The index label 'L2' is not unique"
@@ -355,7 +355,7 @@ def assert_labels_dropped(frame, labels, axis):
     for label in labels:
         df_dropped = frame._drop_labels_or_levels(label, axis=axis)
 
-        if axis == 0:
+        if axis in {0, 'index'}:
             assert label in frame.columns
             assert label not in df_dropped.columns
         else:
@@ -367,7 +367,7 @@ def assert_levels_dropped(frame, levels, axis):
     for level in levels:
         df_dropped = frame._drop_labels_or_levels(level, axis=axis)
 
-        if axis == 0:
+        if axis in {0, 'index'}:
             assert level in frame.index.names
             assert level not in df_dropped.index.names
         else:
@@ -383,7 +383,7 @@ def test_drop_labels_or_levels_df(df_levels, axis):
     expected_labels, expected_levels = get_labels_levels(df_levels)
 
     # Transpose frame if axis == 1
-    if axis == 1:
+    if axis in {1, 'columns'}:
         df_levels = df_levels.T
 
     # Perform checks

--- a/pandas/tests/generic/test_label_or_level_utils.py
+++ b/pandas/tests/generic/test_label_or_level_utils.py
@@ -76,7 +76,6 @@ def assert_level_reference(frame, levels, axis):
 
 # DataFrame
 # ---------
-@pytest.mark.parametrize('axis', [0, 1])
 def test_is_level_or_label_reference_df_simple(df_levels, axis):
 
     # Compute expected labels and levels
@@ -91,7 +90,6 @@ def test_is_level_or_label_reference_df_simple(df_levels, axis):
     assert_label_reference(df_levels, expected_labels, axis=axis)
 
 
-@pytest.mark.parametrize('axis', [0, 1])
 def test_is_level_reference_df_ambig(df_ambig, axis):
 
     # Transpose frame if axis == 1
@@ -165,7 +163,6 @@ def test_is_label_or_level_reference_panel_error(panel):
 
 # DataFrame
 # ---------
-@pytest.mark.parametrize('axis', [0, 1])
 def test_check_label_or_level_ambiguity_df(df_ambig, axis):
 
     # Transpose frame if axis == 1
@@ -264,7 +261,6 @@ def assert_level_values(frame, levels, axis):
 
 # DataFrame
 # ---------
-@pytest.mark.parametrize('axis', [0, 1])
 def test_get_label_or_level_values_df_simple(df_levels, axis):
 
     # Compute expected labels and levels
@@ -279,7 +275,6 @@ def test_get_label_or_level_values_df_simple(df_levels, axis):
     assert_level_values(df_levels, expected_levels, axis=axis)
 
 
-@pytest.mark.parametrize('axis', [0, 1])
 def test_get_label_or_level_values_df_ambig(df_ambig, axis):
 
     # Transpose frame if axis == 1
@@ -300,7 +295,6 @@ def test_get_label_or_level_values_df_ambig(df_ambig, axis):
         assert_label_values(df_ambig, ['L3'], axis=axis)
 
 
-@pytest.mark.parametrize('axis', [0, 1])
 def test_get_label_or_level_values_df_duplabels(df_duplabels, axis):
 
     # Transpose frame if axis == 1
@@ -383,7 +377,6 @@ def assert_levels_dropped(frame, levels, axis):
 
 # DataFrame
 # ---------
-@pytest.mark.parametrize('axis', [0, 1])
 def test_drop_labels_or_levels_df(df_levels, axis):
 
     # Compute expected labels and levels

--- a/pandas/tests/series/test_apply.py
+++ b/pandas/tests/series/test_apply.py
@@ -35,17 +35,12 @@ def _get_cython_table_params(series, func_names_and_expected):
     results : list
         List of three items (Series, function, expected result)
     """
-    table = pd.core.base.SelectionMixin._cython_table
-    if compat.PY36:
-        table = list(table.items())
-    else:  # dicts have random order in Python<3.6, which xdist doesn't like
-        table = sorted(((key, value) for key, value in table.items()),
-                       key=lambda x: x[0].__class__.__name__)
+    from pandas.conftest import _cython_table
     results = []
     for func_name, expected in func_names_and_expected:
         results.append((series, func_name, expected))
         results += [
-            (series, func, expected) for func, name in table
+            (series, func, expected) for func, name in _cython_table
             if name == func_name]
     return results
 

--- a/pandas/tests/series/test_apply.py
+++ b/pandas/tests/series/test_apply.py
@@ -331,6 +331,78 @@ class TestSeriesAggregate(TestData):
                                        ('mean', 1.5)]))
         assert_series_equal(result[expected.index], expected)
 
+    @pytest.mark.parametrize("series, expected_dict", [
+        [Series(), {
+            'sum': 0,
+            'max': np.nan,
+            'min': np.nan,
+            'all': True,
+            'any': False,
+            'mean': np.nan,
+            'prod': 1,
+            'std': np.nan,
+            'var': np.nan,
+            'median': np.nan,
+            'cumprod': Series([], Index([])),
+            'cumsum': Series([], Index([])),
+        }],
+        [Series([np.nan, 1, 2, 3]), {
+            'sum': 6,
+            'max': 3,
+            'min': 1,
+            'all': True,
+            'any': True,
+            'mean': 2,
+            'prod': 6,
+            'std': 1,
+            'var': 1,
+            'median': 2,
+            'cumprod': Series([np.nan, 1, 2, 6]),
+            'cumsum': Series([np.nan, 1, 3, 6]),
+        }],
+        [Series('a b c'.split()), {
+            'sum': 'abc',
+            'max': 'c',
+            'min': 'a',
+            'all': 'c',  # see GH12863
+            'any': 'a',
+            'mean': TypeError,  # mean raises TypeError
+            'prod': TypeError,
+            'std': TypeError,
+            'var': TypeError,
+            'median': TypeError,
+            'cumprod': TypeError,
+            'cumsum': Series(['a', 'ab', 'abc']),
+        }],
+    ])
+    def test_agg_cython_table(self, cython_table_items,
+                              series, expected_dict):
+        # GH21224
+        # test if using items in pandas.core.base.SelectionMixin._cython_table
+        # in agg gives correct results
+        np_func, str_func = cython_table_items
+        expected = expected_dict[str_func]
+
+        if isinstance(expected, type) and issubclass(expected, Exception):
+            with pytest.raises(expected):
+                # e.g. Series('a b'.split()).cumprod() will raise
+                series.agg(np_func)
+            with pytest.raises(expected):
+                series.agg(str_func)
+            return
+
+        result = series.agg(np_func)
+        result_str_func = series.agg(str_func)
+        if str_func in ('cumprod', 'cumsum'):
+            tm.assert_series_equal(result, expected)
+            tm.assert_series_equal(result_str_func, expected)
+        elif tm.is_number(expected):
+            assert np.isclose(result, expected, equal_nan=True)
+            assert np.isclose(result_str_func, expected, equal_nan=True)
+        else:
+            assert result == expected
+            assert result_str_func == expected
+
 
 class TestSeriesMap(TestData):
 

--- a/pandas/tests/series/test_apply.py
+++ b/pandas/tests/series/test_apply.py
@@ -12,37 +12,12 @@ import pandas as pd
 from pandas import (Index, Series, DataFrame, isna)
 from pandas.compat import lrange
 from pandas import compat
-from pandas.util.testing import assert_series_equal, assert_frame_equal
+from pandas.util.testing import (assert_series_equal,
+                                 assert_frame_equal)
 import pandas.util.testing as tm
+from pandas.conftest import _get_cython_table_params
 
 from .common import TestData
-
-
-def _get_cython_table_params(series, func_names_and_expected):
-    """combine series, functions from SelectionMixin._cython_table
-    keys and expected result.
-
-    Parameters
-    ----------
-    series : Series
-        A Series
-    func_names_and_expected : Sequence of two items
-        The first item is a name of a NDFrame method ('sum', 'prod') etc.
-        The second item is the expected return value
-
-    Returns
-    -------
-    results : list
-        List of three items (Series, function, expected result)
-    """
-    from pandas.conftest import _cython_table
-    results = []
-    for func_name, expected in func_names_and_expected:
-        results.append((series, func_name, expected))
-        results += [
-            (series, func, expected) for func, name in _cython_table
-            if name == func_name]
-    return results
 
 
 class TestSeriesApply(TestData):


### PR DESCRIPTION
- [x] closes #16679
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry

This is a splitoff from #21123, to only fix #16679. #19629 will be fixed in a separate PR afterwards.

Passing functions to ``df.agg``, ``df.transform`` and ``df.apply`` may use different methods when ``axis=1``, than when,``axis=0``, and give different results when NaNs are supplied.

Explanation
-------------
Passing the functions in ``SelectionMixin._cython_table`` to ``df.agg`` should defer to use the relevant cython functions. This currently works as expected when ``axis=0``, but not when ``axis=1``.

The reason for this difference is that ``df.aggregate`` currently defers to ``df._aggregate`` when ``axis=0``, but defers to ``df.apply``, when ``axis=1``, and these may give different result when passed functions and the series/frame contains Nan values. I've solved this by transposing df in ``DataFrame._aggragate`` when ``axis=1``, and passing the possibly transposed on to the super method.

Also, ``df.apply`` delegates back to ``df.agg``, when given lists or dicts as inputs, but only works when axis=0. This PR fixes this, so axis=1 works the as axis=0.

The tests have been heavily parametrized, helping ensure that various ways to call the methods now give correct results for both axes.

@WillAyd @jreback (reviewers of #21123)