### PR TITLE
BUG: Support to create DataFrame from list subclasses

### DIFF
--- a/asv_bench/benchmarks/frame_ctor.py
+++ b/asv_bench/benchmarks/frame_ctor.py
@@ -91,4 +91,17 @@ class FromNDArray(object):
         self.df = DataFrame(self.data)
 
 
+class FromLists(object):
+
+    goal_time = 0.2
+
+    def setup(self):
+        N = 1000
+        M = 100
+        self.data = [[j for j in range(M)] for i in range(N)]
+
+    def time_frame_from_lists(self):
+        self.df = DataFrame(self.data)
+
+
 from .pandas_vb_common import setup  # noqa: F401

--- a/doc/source/whatsnew/v0.24.0.rst
+++ b/doc/source/whatsnew/v0.24.0.rst
@@ -1606,6 +1606,7 @@ Other
 - Bug in :meth:`DataFrame.combine_first` in which column types were unexpectedly converted to float (:issue:`20699`)
 - Bug where C variables were declared with external linkage causing import errors if certain other C libraries were imported before Pandas. (:issue:`24113`)
 - Constructing a DataFrame with an index argument that wasn't already an instance of :class:`~pandas.core.Index` was broken in `4efb39f <https://github.com/pandas-dev/pandas/commit/4efb39f01f5880122fa38d91e12d217ef70fad9e>`_ (:issue:`22227`).
+- Bug in :func:`to_object_array` prevented list subclasses to be used to create :class:`DataFrame` (:issue:`21226`)
 
 .. _whatsnew_0.24.0.contributors:
 

--- a/pandas/_libs/lib.pyx
+++ b/pandas/_libs/lib.pyx
@@ -2208,7 +2208,7 @@ def map_infer(ndarray arr, object f, bint convert=1):
     return result
 
 
-def to_object_array(rows: list, min_width: int=0):
+def to_object_array(rows: object, int min_width=0):
     """
     Convert a list of lists into an object array.
 
@@ -2229,20 +2229,22 @@ def to_object_array(rows: list, min_width: int=0):
     cdef:
         Py_ssize_t i, j, n, k, tmp
         ndarray[object, ndim=2] result
+        list input_rows
         list row
 
-    n = len(rows)
+    input_rows = <list>rows
+    n = len(input_rows)
 
     k = min_width
     for i in range(n):
-        tmp = len(rows[i])
+        tmp = len(input_rows[i])
         if tmp > k:
             k = tmp
 
     result = np.empty((n, k), dtype=object)
 
     for i in range(n):
-        row = rows[i]
+        row = <list>input_rows[i]
 
         for j in range(len(row)):
             result[i, j] = row[j]

--- a/pandas/tests/frame/test_constructors.py
+++ b/pandas/tests/frame/test_constructors.py
@@ -2165,6 +2165,15 @@ class TestDataFrameConstructors(TestData):
         result = DataFrame({'A': range(5)}, dtype=dtype)
         tm.assert_frame_equal(result, expected)
 
+    def test_frame_from_list_subclass(self):
+        # GH21226
+        class List(list):
+            pass
+
+        expected = DataFrame([[1, 2, 3], [4, 5, 6]])
+        result = DataFrame(List([List([1, 2, 3]), List([4, 5, 6])]))
+        tm.assert_frame_equal(result, expected)
+
 
 class TestDataFrameConstructorWithDatetimeTZ(TestData):
 


### PR DESCRIPTION
- [x] closes #21226
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry

Alternative fix could be that instead of doing `isinstance` check in frame's `_to_arrays` method:

```
if isinstance(data[0], (list, tuple)):
```

We would do:

```
if type(data[0]) in (list, tuple):
```

This would then assure that `to_object_array` is called really just with exactly lists. But currently there is a mismatch, `if` checks with subtypes, while `to_object_array` does not support them. I think it is better to support them so this merge request adds support for subtypes/subclasses of list.