### PR TITLE
Color text based on background color when using `_background_gradient()`

### DIFF
--- a/doc/source/whatsnew/v0.24.0.txt
+++ b/doc/source/whatsnew/v0.24.0.txt
@@ -181,7 +181,7 @@ Reshaping
 Other
 ^^^^^
 
-- :meth: `~pandas.io.formats.style.Styler.background_gradient` now takes a ``text_color_threshold`` parameter to automatically lighten the text color based on the luminance of the background color. This improves readability with dark background colors without the need to limit the background colormap range. (:issue:`21258`, :issue:`21269`)
+- :meth: `~pandas.io.formats.style.Styler.background_gradient` now takes a ``text_color_threshold`` parameter to automatically lighten the text color based on the luminance of the background color. This improves readability with dark background colors without the need to limit the background colormap range. (:issue:`21258`)
 -
 -
 

--- a/doc/source/whatsnew/v0.24.0.txt
+++ b/doc/source/whatsnew/v0.24.0.txt
@@ -181,7 +181,7 @@ Reshaping
 Other
 ^^^^^
 
--
+- :meth: `~pandas.io.formats.style.Styler.background_gradient` now takes a ``text_color_threshold`` parameter to automatically lighten the text color based on the luminance of the background color. This improves readability with dark background colors without the need to limit the background colormap range. (:issue:`21258`, :issue:`21269`)
 -
 -
 

--- a/pandas/io/formats/style.py
+++ b/pandas/io/formats/style.py
@@ -863,7 +863,7 @@ class Styler(object):
         return self
 
     def background_gradient(self, cmap='PuBu', low=0, high=0, axis=0,
-                            subset=None, text_color=0.2):
+                            subset=None, text_color=0.408):
         """
         Color the background in a gradient according to
         the data in each column (optionally row).
@@ -902,7 +902,7 @@ class Styler(object):
         return self
 
     @staticmethod
-    def _background_gradient(s, cmap='PuBu', low=0, high=0, text_color=0.2):
+    def _background_gradient(s, cmap='PuBu', low=0, high=0, text_color=0.408):
         """Color background in a range according to the data."""
         with _mpl(Styler.background_gradient) as (plt, colors):
             rng = s.max() - s.min()

--- a/pandas/io/formats/style.py
+++ b/pandas/io/formats/style.py
@@ -863,7 +863,7 @@ class Styler(object):
         return self
 
     def background_gradient(self, cmap='PuBu', low=0, high=0, axis=0,
-                            subset=None, text_color=0.408):
+                            subset=None, text_color_threshold=0.408):
         """
         Color the background in a gradient according to
         the data in each column (optionally row).
@@ -879,7 +879,7 @@ class Styler(object):
             1 or 'columns' for columnwise, 0 or 'index' for rowwise
         subset: IndexSlice
             a valid slice for ``data`` to limit the style application to
-        text_color: float or int
+        text_color_threshold: float or int
             luminance threshold for determining text color. Facilitates text
             visibility across varying background colors. From 0 to 1.
             0 = all text is dark colored, 1 = all text is light colored.
@@ -892,19 +892,21 @@ class Styler(object):
 
         Notes
         -----
-        Set ``text_color`` or tune ``low`` and ``high`` to keep the text
-        legible by not using the entire range of the color map. The range of
-        the data is extended by ``low * (x.max() - x.min())`` and ``high *
+        Set ``text_color_threshold`` or tune ``low`` and ``high`` to keep the
+        text legible by not using the entire range of the color map. The range
+        of the data is extended by ``low * (x.max() - x.min())`` and ``high *
         (x.max() - x.min())`` before normalizing.
         """
         subset = _maybe_numeric_slice(self.data, subset)
         subset = _non_reducing_slice(subset)
         self.apply(self._background_gradient, cmap=cmap, subset=subset,
-                   axis=axis, low=low, high=high, text_color=text_color)
+                   axis=axis, low=low, high=high,
+                   text_color_threshold=text_color_threshold)
         return self
 
     @staticmethod
-    def _background_gradient(s, cmap='PuBu', low=0, high=0, text_color=0.408):
+    def _background_gradient(s, cmap='PuBu', low=0, high=0,
+                             text_color_threshold=0.408):
         """Color background in a range according to the data."""
         with _mpl(Styler.background_gradient) as (plt, colors):
             rng = s.max() - s.min()
@@ -915,9 +917,9 @@ class Styler(object):
             # https://github.com/matplotlib/matplotlib/issues/5427
             normed = norm(s.values)
             c = [colors.rgb2hex(x) for x in plt.cm.get_cmap(cmap)(normed)]
-            if (not isinstance(text_color, (float, int)) or
-                    not 0 <= text_color <= 1):
-                msg = "`text_color` must be a value from 0 to 1."
+            if (not isinstance(text_color_threshold, (float, int)) or
+                    not 0 <= text_color_threshold <= 1):
+                msg = "`text_color_threshold` must be a value from 0 to 1."
                 raise ValueError(msg)
 
             def relative_luminance(color):
@@ -943,8 +945,8 @@ class Styler(object):
                 lum = rgb.dot([.2126, .7152, .0722])
                 return lum.item()
 
-            text_colors = ['#f1f1f1' if relative_luminance(x) < text_color
-                           else '#000000' for x in c]
+            text_colors = ['#f1f1f1' if relative_luminance(x) <
+                           text_color_threshold else '#000000' for x in c]
 
             return ['background-color: {color};color: {tc}'.format(
                     color=color, tc=tc) for color, tc in zip(c, text_colors)]

--- a/pandas/io/formats/style.py
+++ b/pandas/io/formats/style.py
@@ -884,6 +884,8 @@ class Styler(object):
             visibility across varying background colors. From 0 to 1.
             0 = all text is dark colored, 1 = all text is light colored.
 
+            .. versionadded:: 0.24.0
+
         Returns
         -------
         self : Styler

--- a/pandas/io/formats/style.py
+++ b/pandas/io/formats/style.py
@@ -919,15 +919,21 @@ class Styler(object):
                 raise ValueError(msg)
 
             def relative_luminance(color):
-                """Calculate the relative luminance of a color according to W3C
-                standards, https://www.w3.org/WAI/GL/wiki/Relative_luminance
+                """
+                Calculate relative luminance of a color.
+
+                The calculation adheres to the W3C standards
+                (https://www.w3.org/WAI/GL/wiki/Relative_luminance)
+
                 Parameters
                 ----------
-                color : matplotlib color. Hex code, rgb-tuple, or
-                HTML color name.
+                color : matplotlib color
+                    Hex code, rgb-tuple, or HTML color name.
+
                 Returns
                 -------
-                luminance : float between 0 and 1
+                float
+                    The relative luminance as a value from 0 to 1
                 """
                 rgb = colors.colorConverter.to_rgba_array(color)[:, :3]
                 rgb = np.where(rgb <= .03928, rgb / 12.92,

--- a/pandas/io/formats/style.py
+++ b/pandas/io/formats/style.py
@@ -896,6 +896,11 @@ class Styler(object):
         text legible by not using the entire range of the color map. The range
         of the data is extended by ``low * (x.max() - x.min())`` and ``high *
         (x.max() - x.min())`` before normalizing.
+
+        Raises
+        ------
+        ValueError
+            If ``text_color_threshold`` is not a value from 0 to 1.
         """
         subset = _maybe_numeric_slice(self.data, subset)
         subset = _non_reducing_slice(subset)

--- a/pandas/tests/io/formats/test_style.py
+++ b/pandas/tests/io/formats/test_style.py
@@ -1064,7 +1064,7 @@ class TestStylerMatplotlibDep(object):
         msg = "`text_color_threshold` must be a value from 0 to 1."
         with tm.assert_raises_regex(ValueError, msg):
             df.style.background_gradient(
-                text_color_threshold=text_color_threshold)
+                text_color_threshold=text_color_threshold)._compute()
 
 
 def test_block_names():

--- a/pandas/tests/io/formats/test_style.py
+++ b/pandas/tests/io/formats/test_style.py
@@ -1028,11 +1028,6 @@ class TestStylerMatplotlibDep(object):
             assert all("#" in x[0] for x in result.values())
             assert result[(0, 0)] == result[(0, 1)]
             assert result[(1, 0)] == result[(1, 1)]
-            for res in result:
-                if result[res][0].split(' ')[1] in ['#fde725', '#ffffcc']:
-                    assert result[(res)][1].split(' ')[1] == '#000000'
-                elif result[res][0].split(' ')[1] in ['#800026', '#440154']:
-                    assert result[(res)][1].split(' ')[1] == '#f1f1f1'
 
         result = df.style.background_gradient(
             subset=pd.IndexSlice[1, 'A'])._compute().ctx
@@ -1043,10 +1038,25 @@ class TestStylerMatplotlibDep(object):
     @td.skip_if_no_mpl
     def test_text_color_threshold(self):
         df = pd.DataFrame([[1, 2], [2, 4]], columns=['A', 'B'])
-        for text_color_threshold in [1.1, '1', -1, [2, 2]]:
-            with pytest.raises(ValueError):
-                df.style.background_gradient(
-                    text_color_threshold=text_color_threshold)
+        for c_map in [None, 'YlOrRd']:
+            result = df.style.background_gradient(cmap=c_map)._compute().ctx
+            for res in result:
+                bg_color = result[res][0].split(' ')[1]
+                assert bg_color in ['#fde725', '#ffffcc',
+                                    '#800026', '#440154'], (
+                    "Unexpected background color returned from "
+                    "`style.background_gradient()`")
+                text_color = result[(res)][1].split(' ')[1]
+                if bg_color in ['#fde725', '#ffffcc']:
+                    assert text_color == '#000000'
+                elif bg_color in ['#800026', '#440154']:
+                    assert text_color == '#f1f1f1'
+            for res in result:
+                if result[res][0].split(' ')[1] in ['#fde725', '#ffffcc']:
+                    assert result[(res)][1].split(' ')[1] == '#000000'
+                elif result[res][0].split(' ')[1] in ['#800026', '#440154']:
+                    assert result[(res)][1].split(' ')[1] == '#f1f1f1'
+
 
 
 def test_block_names():

--- a/pandas/tests/io/formats/test_style.py
+++ b/pandas/tests/io/formats/test_style.py
@@ -1028,6 +1028,11 @@ class TestStylerMatplotlibDep(object):
             assert all("#" in x[0] for x in result.values())
             assert result[(0, 0)] == result[(0, 1)]
             assert result[(1, 0)] == result[(1, 1)]
+            for res in result:
+                if result[res][0].split(' ')[1] in ['#fde725', '#ffffcc']:
+                    assert result[(res)][1].split(' ')[1] == '#000000'
+                elif result[res][0].split(' ')[1] in ['#800026', '#440154']:
+                    assert result[(res)][1].split(' ')[1] == '#f1f1f1'
 
         result = df.style.background_gradient(
             subset=pd.IndexSlice[1, 'A'])._compute().ctx

--- a/pandas/tests/io/formats/test_style.py
+++ b/pandas/tests/io/formats/test_style.py
@@ -1036,24 +1036,19 @@ class TestStylerMatplotlibDep(object):
                                   'color: #000000']
 
     @td.skip_if_no_mpl
-    @pytest.mark.parametrize("c_map", [None, 'YlOrRd'])
-    def test_text_color_threshold(self, c_map):
+    @pytest.mark.parametrize(
+        'c_map,expected', [
+            (None, [
+                ['background-color: #440154', 'color: #f1f1f1'],
+                ['background-color: #fde725', 'color: #000000']]),
+            ('YlOrRd', [
+                ['background-color: #ffffcc', 'color: #000000'],
+                ['background-color: #800026', 'color: #f1f1f1']])])
+    def test_text_color_threshold(self, c_map, expected):
         df = pd.DataFrame([[1, 2], [2, 4]], columns=['A', 'B'])
         result = df.style.background_gradient(cmap=c_map)._compute().ctx
-        test_colors = {None: {(0, 0): ('#440154', '#f1f1f1'),
-                              (1, 0): ('#fde725', '#000000')},
-                       'YlOrRd': {(0, 0): ('#ffffcc', '#000000'),
-                                  (1, 0): ('#800026', '#f1f1f1')}}
-        # Light text on dark background
-        assert result[0, 0][0].split(' ')[1] == test_colors[c_map][0, 0][0], (
-            'Unexpected background color returned from '
-            '`style.background_gradient()`')
-        assert result[0, 0][1].split(' ')[1] == test_colors[c_map][0, 0][1]
-        # Dark text on light background
-        assert result[1, 0][0].split(' ')[1] == test_colors[c_map][1, 0][0], (
-            'Unexpected background color returned from '
-            '`style.background_gradient()`')
-        assert result[1, 0][1].split(' ')[1] == test_colors[c_map][1, 0][1]
+        assert result[0, 0] == expected[0]
+        assert result[1, 0] == expected[1]
 
     @td.skip_if_no_mpl
     @pytest.mark.parametrize("text_color_threshold", [1.1, '1', -1, [2, 2]])

--- a/pandas/tests/io/formats/test_style.py
+++ b/pandas/tests/io/formats/test_style.py
@@ -1036,26 +1036,24 @@ class TestStylerMatplotlibDep(object):
                                   'color: #000000']
 
     @td.skip_if_no_mpl
-    def test_text_color_threshold(self):
+    @pytest.mark.parametrize("c_map", [None, 'YlOrRd'])
+    def test_text_color_threshold(self, c_map):
         df = pd.DataFrame([[1, 2], [2, 4]], columns=['A', 'B'])
-        for c_map in [None, 'YlOrRd']:
-            result = df.style.background_gradient(cmap=c_map)._compute().ctx
-            for res in result:
-                bg_color = result[res][0].split(' ')[1]
-                assert bg_color in ['#fde725', '#ffffcc',
-                                    '#800026', '#440154'], (
-                    "Unexpected background color returned from "
-                    "`style.background_gradient()`")
-                text_color = result[(res)][1].split(' ')[1]
-                if bg_color in ['#fde725', '#ffffcc']:
-                    assert text_color == '#000000'
-                elif bg_color in ['#800026', '#440154']:
-                    assert text_color == '#f1f1f1'
-            for res in result:
-                if result[res][0].split(' ')[1] in ['#fde725', '#ffffcc']:
-                    assert result[(res)][1].split(' ')[1] == '#000000'
-                elif result[res][0].split(' ')[1] in ['#800026', '#440154']:
-                    assert result[(res)][1].split(' ')[1] == '#f1f1f1'
+        result = df.style.background_gradient(cmap=c_map)._compute().ctx
+        test_colors = {None: {(0, 0): ('#440154', '#f1f1f1'),
+                              (1, 0): ('#fde725', '#000000')},
+                       'YlOrRd': {(0, 0): ('#ffffcc', '#000000'),
+                                  (1, 0): ('#800026', '#f1f1f1')}}
+        # Light text on dark background
+        assert result[0, 0][0].split(' ')[1] == test_colors[c_map][0, 0][0], (
+            'Unexpected background color returned from '
+            '`style.background_gradient()`')
+        assert result[0, 0][1].split(' ')[1] == test_colors[c_map][0, 0][1]
+        # Dark text on light background
+        assert result[1, 0][0].split(' ')[1] == test_colors[c_map][1, 0][0], (
+            'Unexpected background color returned from '
+            '`style.background_gradient()`')
+        assert result[1, 0][1].split(' ')[1] == test_colors[c_map][1, 0][1]
 
     @td.skip_if_no_mpl
     @pytest.mark.parametrize("text_color_threshold", [1.1, '1', -1, [2, 2]])

--- a/pandas/tests/io/formats/test_style.py
+++ b/pandas/tests/io/formats/test_style.py
@@ -1031,7 +1031,9 @@ class TestStylerMatplotlibDep(object):
 
         result = df.style.background_gradient(
             subset=pd.IndexSlice[1, 'A'])._compute().ctx
-        assert result[(1, 0)] == ['background-color: #fff7fb']
+
+        assert result[(1, 0)] == ['background-color: #fff7fb',
+                                  'color: #000000']
 
 
 def test_block_names():

--- a/pandas/tests/io/formats/test_style.py
+++ b/pandas/tests/io/formats/test_style.py
@@ -1038,17 +1038,16 @@ class TestStylerMatplotlibDep(object):
     @td.skip_if_no_mpl
     @pytest.mark.parametrize(
         'c_map,expected', [
-            (None, [
-                ['background-color: #440154', 'color: #f1f1f1'],
-                ['background-color: #fde725', 'color: #000000']]),
-            ('YlOrRd', [
-                ['background-color: #ffffcc', 'color: #000000'],
-                ['background-color: #800026', 'color: #f1f1f1']])])
+            (None, {
+                (0, 0): ['background-color: #440154', 'color: #f1f1f1'],
+                (1, 0): ['background-color: #fde725', 'color: #000000']}),
+            ('YlOrRd', {
+                (0, 0): ['background-color: #ffffcc', 'color: #000000'],
+                (1, 0): ['background-color: #800026', 'color: #f1f1f1']})])
     def test_text_color_threshold(self, c_map, expected):
-        df = pd.DataFrame([[1, 2], [2, 4]], columns=['A', 'B'])
+        df = pd.DataFrame([1, 2], columns=['A'])
         result = df.style.background_gradient(cmap=c_map)._compute().ctx
-        assert result[0, 0] == expected[0]
-        assert result[1, 0] == expected[1]
+        assert result == expected
 
     @td.skip_if_no_mpl
     @pytest.mark.parametrize("text_color_threshold", [1.1, '1', -1, [2, 2]])

--- a/pandas/tests/io/formats/test_style.py
+++ b/pandas/tests/io/formats/test_style.py
@@ -1017,9 +1017,9 @@ class TestStyler(object):
         assert ctx['body'][1][2]['display_value'] == 3
 
 
+@td.skip_if_no_mpl
 class TestStylerMatplotlibDep(object):
 
-    @td.skip_if_no_mpl
     def test_background_gradient(self):
         df = pd.DataFrame([[1, 2], [2, 4]], columns=['A', 'B'])
 
@@ -1035,7 +1035,6 @@ class TestStylerMatplotlibDep(object):
         assert result[(1, 0)] == ['background-color: #fff7fb',
                                   'color: #000000']
 
-    @td.skip_if_no_mpl
     @pytest.mark.parametrize(
         'c_map,expected', [
             (None, {
@@ -1049,7 +1048,6 @@ class TestStylerMatplotlibDep(object):
         result = df.style.background_gradient(cmap=c_map)._compute().ctx
         assert result == expected
 
-    @td.skip_if_no_mpl
     @pytest.mark.parametrize("text_color_threshold", [1.1, '1', -1, [2, 2]])
     def test_text_color_threshold_raises(self, text_color_threshold):
         df = pd.DataFrame([[1, 2], [2, 4]], columns=['A', 'B'])

--- a/pandas/tests/io/formats/test_style.py
+++ b/pandas/tests/io/formats/test_style.py
@@ -1057,6 +1057,14 @@ class TestStylerMatplotlibDep(object):
                 elif result[res][0].split(' ')[1] in ['#800026', '#440154']:
                     assert result[(res)][1].split(' ')[1] == '#f1f1f1'
 
+    @td.skip_if_no_mpl
+    @pytest.mark.parametrize("text_color_threshold", [1.1, '1', -1, [2, 2]])
+    def test_text_color_threshold_raises(self, text_color_threshold):
+        df = pd.DataFrame([[1, 2], [2, 4]], columns=['A', 'B'])
+        msg = "`text_color_threshold` must be a value from 0 to 1."
+        with tm.assert_raises_regex(ValueError, msg):
+            df.style.background_gradient(
+                text_color_threshold=text_color_threshold)
 
 
 def test_block_names():

--- a/pandas/tests/io/formats/test_style.py
+++ b/pandas/tests/io/formats/test_style.py
@@ -1040,6 +1040,14 @@ class TestStylerMatplotlibDep(object):
         assert result[(1, 0)] == ['background-color: #fff7fb',
                                   'color: #000000']
 
+    @td.skip_if_no_mpl
+    def test_text_color_threshold(self):
+        df = pd.DataFrame([[1, 2], [2, 4]], columns=['A', 'B'])
+        for text_color_threshold in [1.1, '1', -1, [2, 2]]:
+            with pytest.raises(ValueError):
+                df.style.background_gradient(
+                    text_color_threshold=text_color_threshold)
+
 
 def test_block_names():
     # catch accidental removal of a block


### PR DESCRIPTION
The purpose of this PR is to automatically color text dark or light based on the background color of the HTML table:

================`old behavior` ===========================`new behavior`========
![image](https://user-images.githubusercontent.com/4560057/40745876-b43b17ca-6426-11e8-892c-7f27598789de.png) ![image](https://user-images.githubusercontent.com/4560057/40744927-0e2796a8-6424-11e8-9837-53566d53bef6.png)

As described in #21258, I use the luminance-based approach from `seaborn`'s annotated heatmaps. Tagging @WillAyd who commented on that issue. A few comments on this PR

1. Initially, I was not sure if defining the `relative_luminance()` method within `_background_gradient()` was the right way to go, but I opted for this since I saw the same approach elsewhere in the file. Let me know if you prefer a different approach.

2. I am not sure how intuitive it is that a parameter named `text_color` takes a numeric argument and not a color, but I think it is a good name for discoverability. Naming it `luminance_threshold` or similar might be confusing for users looking for a way to change the text color.

3. I opted to make the light text not completely white. The focus should be the background color so the text should not pop out too much. Thoughts?


================`#ffffff` ============================`#f1f1f1` (current choice)===
![image](https://user-images.githubusercontent.com/4560057/40744958-25ba1ac0-6424-11e8-9b51-afaf0a1d05c8.png) ![image](https://user-images.githubusercontent.com/4560057/40744927-0e2796a8-6424-11e8-9837-53566d53bef6.png)

![image](https://user-images.githubusercontent.com/4560057/40745533-b2b81c46-6425-11e8-8bdd-e743441a5b18.png) ![image](https://user-images.githubusercontent.com/4560057/40745507-a54dd0e6-6425-11e8-8e92-50afbd986c57.png)


4. I think 0.2 is a good default threshold value for `text_color` based on my own qualitative assessment, feel free to disagree. The seaborn default of 0.4 makes too much text white in my opinion. Since colors and contrast can be quite subjective, I thought I would include some comparisons.

============`text_color=0.4` ======================`text_color=0.2` (current choice)===
![image](https://user-images.githubusercontent.com/4560057/40745779-6620b1ee-6426-11e8-830a-6517239c8305.png) ![image](https://user-images.githubusercontent.com/4560057/40745632-f692805a-6425-11e8-8f1f-9ff00b81965f.png)
![image](https://user-images.githubusercontent.com/4560057/40745801-7332014e-6426-11e8-88b5-75b34ecfd6ca.png) ![image](https://user-images.githubusercontent.com/4560057/40745647-0653f08c-6426-11e8-995f-b69e6dd1c85c.png)
![image](https://user-images.githubusercontent.com/4560057/40745756-4fd3ef5a-6426-11e8-9335-855a09c2ec56.png) ![image](https://user-images.githubusercontent.com/4560057/40745721-3d98f48e-6426-11e8-9511-a3a9d4b52225.png)


This is my first PR, apologies if I have misunderstood something. 

- [x] closes #21258 
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry
