### PR TITLE
DOC: Fix renaming categories section

### DIFF
--- a/doc/source/categorical.rst
+++ b/doc/source/categorical.rst
@@ -358,10 +358,10 @@ Renaming categories is done by assigning new values to the
     s
     s.cat.categories = ["Group %s" % g for g in s.cat.categories]
     s
-    s.cat.rename_categories([1,2,3])
+    s = s.cat.rename_categories([1,2,3])
     s
     # You can also pass a dict-like object to map the renaming
-    s.cat.rename_categories({1: 'x', 2: 'y', 3: 'z'})
+    s = s.cat.rename_categories({1: 'x', 2: 'y', 3: 'z'})
     s
 
 .. note::


### PR DESCRIPTION
The categories were not correctly saved so that the renaming using the
dict-like object had no effect.
