### PR TITLE
TST: Add failing tests for minute rounding

### DIFF
--- a/pandas/tests/scalar/timestamp/test_unary_ops.py
+++ b/pandas/tests/scalar/timestamp/test_unary_ops.py
@@ -118,6 +118,25 @@ class TestTimestampUnaryOps(object):
             expected = Timestamp(expected)
             assert result == expected
 
+    @pytest.mark.parametrize('test_input, freq, expected', [
+        ('2018-01-01 00:02:00', '2T', '2018-01-01 00:02:00'),
+        ('2018-01-01 00:04:00', '4T', '2018-01-01 00:04:00'),
+        ('2018-01-01 00:15:00', '15T', '2018-01-01 00:15:00'),
+        ('2018-01-01 00:20:00', '20T', '2018-01-01 00:20:00'),
+    ])
+    def test_round_minute_freq(self, test_input, freq, expected):
+        # ensure timestamps that shouldn't round don't
+        # GH#21262
+        dt = Timestamp(test_input)
+        expected = Timestamp(expected)
+        
+        result_ceil = dt.ceil(freq)
+        assert result_ceil == expected
+        result_floor = dt.floor(freq)
+        assert result_floor == expected
+        result_round = dt.round(freq)
+        assert result_round == expected
+
     def test_ceil(self):
         dt = Timestamp('20130101 09:10:11')
         result = dt.ceil('D')


### PR DESCRIPTION
For some minute frequencies, `.ceil()` will round up even if it should not.

- [ ] closes #21262
- [x] tests added
- [ ] tests passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
