### PR TITLE
DOC: fill in class names for rename methods

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -3720,7 +3720,7 @@ class DataFrame(NDFrame):
         copy : boolean, default True
             Also copy underlying data
         inplace : boolean, default False
-            Whether to return a new %(klass)s. If True then value of copy is
+            Whether to return a new DataFrame. If True then value of copy is
             ignored.
         level : int or level name, default None
             In case of a MultiIndex, only rename labels in the specified

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -3269,7 +3269,7 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
         copy : boolean, default True
             Also copy underlying data
         inplace : boolean, default False
-            Whether to return a new %(klass)s. If True then value of copy is
+            Whether to return a new Series. If True then value of copy is
             ignored.
         level : int or level name, default None
             In case of a MultiIndex, only rename labels in the specified


### PR DESCRIPTION
The documentation for the `inplace` parameter has the `%(klass)` placeholder from the original NDFrame. This fills in the appropriate values in the following places:

* http://pandas.pydata.org/pandas-docs/version/0.23/generated/pandas.DataFrame.rename.html
* http://pandas.pydata.org/pandas-docs/version/0.23/generated/pandas.Series.rename.html