### PR TITLE
PERF: improve performance of NDFrame.describe

### DIFF
--- a/asv_bench/benchmarks/frame_methods.py
+++ b/asv_bench/benchmarks/frame_methods.py
@@ -519,7 +519,6 @@ class Describe(object):
     goal_time = 0.2
 
     def setup(self):
-        np.random.seed(123)
         self.df = DataFrame({
             'a': np.random.randint(0, 100, int(1e6)),
             'b': np.random.randint(0, 100, int(1e6)),

--- a/asv_bench/benchmarks/frame_methods.py
+++ b/asv_bench/benchmarks/frame_methods.py
@@ -513,6 +513,7 @@ class NSort(object):
     def time_nsmallest(self, keep):
         self.df.nsmallest(100, 'A', keep=keep)
 
+
 class Describe(object):
 
     goal_time = 0.2

--- a/asv_bench/benchmarks/frame_methods.py
+++ b/asv_bench/benchmarks/frame_methods.py
@@ -512,3 +512,21 @@ class NSort(object):
 
     def time_nsmallest(self, keep):
         self.df.nsmallest(100, 'A', keep=keep)
+
+class Describe(object):
+
+    goal_time = 0.2
+
+    def setup(self):
+        np.random.seed(123)
+        self.df = DataFrame({
+            'a': np.random.randint(0, 100, int(1e6)),
+            'b': np.random.randint(0, 100, int(1e6)),
+            'c': np.random.randint(0, 100, int(1e6))
+        })
+
+    def time_series_describe(self):
+        self.df['a'].describe()
+
+    def time_dataframe_describe(self):
+        self.df.describe()

--- a/doc/source/whatsnew/v0.24.0.txt
+++ b/doc/source/whatsnew/v0.24.0.txt
@@ -63,7 +63,7 @@ Removal of prior version deprecations/changes
 Performance Improvements
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
-- Improved performance of :func:`Series.describe` in case of numeric dtpyes
+- Improved performance of :func:`Series.describe` in case of numeric dtpyes (:issue:`21274`)
 -
 
 .. _whatsnew_0240.docs:

--- a/doc/source/whatsnew/v0.24.0.txt
+++ b/doc/source/whatsnew/v0.24.0.txt
@@ -63,8 +63,7 @@ Removal of prior version deprecations/changes
 Performance Improvements
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
--
--
+- Improved performance of :func:`Series.describe` in case of numeric dtpyes
 -
 
 .. _whatsnew_0240.docs:

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -8519,7 +8519,7 @@ class NDFrame(PandasObject, SelectionMixin):
             stat_index = (['count', 'mean', 'std', 'min'] +
                           formatted_percentiles + ['max'])
             d = ([series.count(), series.mean(), series.std(), series.min()] +
-                 [series.quantile(x) for x in percentiles] + [series.max()])
+                 series.quantile(percentiles).tolist() + [series.max()])
             return pd.Series(d, index=stat_index, name=series.name)
 
         def describe_categorical_1d(data):


### PR DESCRIPTION
A one-line change that enables to calculate the percentiles in `describe` more efficiently. The point is that calculating percentiles in one pass is faster than separately.

`describe` (with default `percentiles` argument) becomes 25-30% faster than before for numerical Series and DataFrames.

### Setup 
```
import timeit

setup = '''
import numpy as np
import pandas as pd
np.random.seed(123)
s = pd.Series(np.random.randint(0, 100, 1000000))
'''
```

### Benchmark
```
min(timeit.Timer('s.describe()', setup=setup).repeat(100, 1))
```

### Results
On master:
```
0.06349272100487724
```

With this change:
```
0.04745814300258644
```

Results are similar for DataFrames.

- [ ] closes #xxxx
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
