### PR TITLE
BUG: invalid rolling window on empty input

### DIFF
--- a/doc/source/whatsnew/v0.23.1.txt
+++ b/doc/source/whatsnew/v0.23.1.txt
@@ -52,7 +52,8 @@ Groupby/Resample/Rolling
 - Bug in :func:`DataFrame.agg` where applying multiple aggregation functions to a :class:`DataFrame` with duplicated column names would cause a stack overflow (:issue:`21063`)
 - Bug in :func:`pandas.core.groupby.GroupBy.ffill` and :func:`pandas.core.groupby.GroupBy.bfill` where the fill within a grouping would not always be applied as intended due to the implementations' use of a non-stable sort (:issue:`21207`)
 - Bug in :func:`pandas.core.groupby.GroupBy.rank` where results did not scale to 100% when specifying ``method='dense'`` and ``pct=True``
--Bug in :func:`pandas.DataFrame.rolling` and :func:`pandas.Series.rolling` which incorrectly accepted a 0 window size rather than raising (:issue:`21286`)
+- Bug in :func:`pandas.DataFrame.rolling` and :func:`pandas.Series.rolling` which incorrectly accepted a 0 window size rather than raising (:issue:`21286`)
+
 Strings
 ^^^^^^^
 

--- a/doc/source/whatsnew/v0.23.1.txt
+++ b/doc/source/whatsnew/v0.23.1.txt
@@ -52,6 +52,7 @@ Groupby/Resample/Rolling
 - Bug in :func:`DataFrame.agg` where applying multiple aggregation functions to a :class:`DataFrame` with duplicated column names would cause a stack overflow (:issue:`21063`)
 - Bug in :func:`pandas.core.groupby.GroupBy.ffill` and :func:`pandas.core.groupby.GroupBy.bfill` where the fill within a grouping would not always be applied as intended due to the implementations' use of a non-stable sort (:issue:`21207`)
 - Bug in :func:`pandas.core.groupby.GroupBy.rank` where results did not scale to 100% when specifying ``method='dense'`` and ``pct=True``
+- Bug in :func:`pandas.core.windows.Windows.validate` where windows parameter was accpeting a numeric value of 0 (:issue:`21286`) 
 
 Strings
 ^^^^^^^

--- a/doc/source/whatsnew/v0.23.1.txt
+++ b/doc/source/whatsnew/v0.23.1.txt
@@ -52,8 +52,7 @@ Groupby/Resample/Rolling
 - Bug in :func:`DataFrame.agg` where applying multiple aggregation functions to a :class:`DataFrame` with duplicated column names would cause a stack overflow (:issue:`21063`)
 - Bug in :func:`pandas.core.groupby.GroupBy.ffill` and :func:`pandas.core.groupby.GroupBy.bfill` where the fill within a grouping would not always be applied as intended due to the implementations' use of a non-stable sort (:issue:`21207`)
 - Bug in :func:`pandas.core.groupby.GroupBy.rank` where results did not scale to 100% when specifying ``method='dense'`` and ``pct=True``
-- Bug in :func:`pandas.core.windows.Windows.validate` where windows parameter was accpeting a numeric value of 0 (:issue:`21286`) 
-
+-Bug in :func:`pandas.DataFrame.rolling` and :func:`pandas.Series.rolling` which incorrectly accepted a 0 window size rather than raising (:issue:`21286`)
 Strings
 ^^^^^^^
 

--- a/pandas/core/window.py
+++ b/pandas/core/window.py
@@ -603,7 +603,7 @@ class Window(_Window):
             pass
         elif is_integer(window):
             if window <= 0:
-                raise ValueError("please enter a positive window")
+                raise ValueError("window must be > 0 ")
             try:
                 import scipy.signal as sig
             except ImportError:

--- a/pandas/core/window.py
+++ b/pandas/core/window.py
@@ -96,8 +96,6 @@ class _Window(PandasObject, SelectionMixin):
         return self.win_type == 'freq'
 
     def validate(self):
-        if self.window <= 0:
-            raise ValueError("please enter a positive window")
         if self.center is not None and not is_bool(self.center):
             raise ValueError("center must be a boolean")
         if self.min_periods is not None and not \
@@ -604,6 +602,8 @@ class Window(_Window):
         if isinstance(window, (list, tuple, np.ndarray)):
             pass
         elif is_integer(window):
+            if window <= 0:
+                raise ValueError("please enter a positive window")
             try:
                 import scipy.signal as sig
             except ImportError:

--- a/pandas/core/window.py
+++ b/pandas/core/window.py
@@ -96,7 +96,7 @@ class _Window(PandasObject, SelectionMixin):
         return self.win_type == 'freq'
 
     def validate(self):
-        if self.window==0:
+        if self.window == 0:
             raise ValueError("Please Enter a window other than 0")
         if self.center is not None and not is_bool(self.center):
             raise ValueError("center must be a boolean")

--- a/pandas/core/window.py
+++ b/pandas/core/window.py
@@ -604,10 +604,8 @@ class Window(_Window):
         if isinstance(window, (list, tuple, np.ndarray)):
             pass
         elif is_integer(window):
-            if window == 0:
-                raise ValueError("window must not be zero")
-            if window < 0:
-                raise ValueError("window must be non-negative")
+            if window <= 0:
+                raise ValueError("window must be positive")
             try:
                 import scipy.signal as sig
             except ImportError:

--- a/pandas/core/window.py
+++ b/pandas/core/window.py
@@ -604,6 +604,8 @@ class Window(_Window):
         if isinstance(window, (list, tuple, np.ndarray)):
             pass
         elif is_integer(window):
+            if window == 0:
+                raise ValueError("window must not be zero")
             if window < 0:
                 raise ValueError("window must be non-negative")
             try:

--- a/pandas/core/window.py
+++ b/pandas/core/window.py
@@ -96,6 +96,8 @@ class _Window(PandasObject, SelectionMixin):
         return self.win_type == 'freq'
 
     def validate(self):
+        if self.window==0:
+            raise ValueError("Please Enter a window other than 0")
         if self.center is not None and not is_bool(self.center):
             raise ValueError("center must be a boolean")
         if self.min_periods is not None and not \

--- a/pandas/core/window.py
+++ b/pandas/core/window.py
@@ -604,8 +604,6 @@ class Window(_Window):
         if isinstance(window, (list, tuple, np.ndarray)):
             pass
         elif is_integer(window):
-            if window <= 0:
-                raise ValueError("window must be positive")
             try:
                 import scipy.signal as sig
             except ImportError:

--- a/pandas/core/window.py
+++ b/pandas/core/window.py
@@ -96,8 +96,8 @@ class _Window(PandasObject, SelectionMixin):
         return self.win_type == 'freq'
 
     def validate(self):
-        if self.window == 0:
-            raise ValueError("Please Enter a window other than 0")
+        if self.window <= 0:
+            raise ValueError("please enter a positive window")
         if self.center is not None and not is_bool(self.center):
             raise ValueError("center must be a boolean")
         if self.min_periods is not None and not \

--- a/pandas/tests/test_window.py
+++ b/pandas/tests/test_window.py
@@ -389,9 +389,10 @@ class TestRolling(Base):
         c(window=2, min_periods=1, center=False)
 
         # GH 13383
-        c(0)
+
         with pytest.raises(ValueError):
             c(-1)
+            c(0)
 
         # not valid
         for w in [2., 'foo', np.array([2])]:
@@ -409,9 +410,9 @@ class TestRolling(Base):
         # GH 13383
         o = getattr(self, which)
         c = o.rolling
-        c(0, win_type='boxcar')
         with pytest.raises(ValueError):
             c(-1, win_type='boxcar')
+            c(0, win_type='boxcar')
 
     @pytest.mark.parametrize(
         'window', [timedelta(days=3), pd.Timedelta(days=3)])

--- a/pandas/tests/test_window.py
+++ b/pandas/tests/test_window.py
@@ -402,7 +402,6 @@ class TestRolling(Base):
             with pytest.raises(ValueError):
                 c(window=2, min_periods=1, center=w)
 
-    # these tests seems unnecessary here 21291
     @td.skip_if_no_scipy
     @pytest.mark.parametrize(
         'which', ['series', 'frame'])
@@ -412,7 +411,6 @@ class TestRolling(Base):
         c = o.rolling
         with pytest.raises(ValueError):
             c(-1, win_type='boxcar')
-            
 
     @pytest.mark.parametrize(
         'window', [timedelta(days=3), pd.Timedelta(days=3)])

--- a/pandas/tests/test_window.py
+++ b/pandas/tests/test_window.py
@@ -389,10 +389,9 @@ class TestRolling(Base):
         c(window=2, min_periods=1, center=False)
 
         # GH 13383
-
         with pytest.raises(ValueError):
-            c(-1)
             c(0)
+            c(-1)
 
         # not valid
         for w in [2., 'foo', np.array([2])]:
@@ -403,6 +402,7 @@ class TestRolling(Base):
             with pytest.raises(ValueError):
                 c(window=2, min_periods=1, center=w)
 
+    # these tests seems unnecessary here 21291
     @td.skip_if_no_scipy
     @pytest.mark.parametrize(
         'which', ['series', 'frame'])
@@ -412,7 +412,7 @@ class TestRolling(Base):
         c = o.rolling
         with pytest.raises(ValueError):
             c(-1, win_type='boxcar')
-            c(0, win_type='boxcar')
+            
 
     @pytest.mark.parametrize(
         'window', [timedelta(days=3), pd.Timedelta(days=3)])


### PR DESCRIPTION
Added a raise Value Error for the case when window==0, Kindly refer to issue #21286 for the same

- [x] closes #21286 
- [x] tests added / passed
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] A simple except cases added
