### PR TITLE
DOC: Fixing 'a la' confusion in series.quantile documentation

### DIFF
--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -1837,7 +1837,7 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
 
     def quantile(self, q=0.5, interpolation='linear'):
         """
-        Return value at the given quantile, a la numpy.percentile.
+        Return value at the given quantile, (you can also see numpy.percentile, much similar like series.quantile).
 
         Parameters
         ----------

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -1839,7 +1839,7 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
         """
         Return value at the given quantile
         (you can also see numpy.percentile, much similar like series.quantile).
- 
+
         Parameters
         ----------
         q : float or array-like, default 0.5 (50% quantile)

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -1837,8 +1837,7 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
 
     def quantile(self, q=0.5, interpolation='linear'):
         """
-        Return value at the given quantile
-        (you can also see numpy.percentile, much similar like series.quantile).
+        Return value at the given quantile.
 
         Parameters
         ----------
@@ -1877,6 +1876,7 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
         See Also
         --------
         pandas.core.window.Rolling.quantile
+        numpy.percentile
         """
 
         self._check_percentile(q)

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -1837,8 +1837,9 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
 
     def quantile(self, q=0.5, interpolation='linear'):
         """
-        Return value at the given quantile, (you can also see numpy.percentile, much similar like series.quantile).
-
+        Return value at the given quantile
+        (you can also see numpy.percentile, much similar like series.quantile).
+ 
         Parameters
         ----------
         q : float or array-like, default 0.5 (50% quantile)


### PR DESCRIPTION
Just stating that numpy.percentile also offers something similar to this

- [x] closes #21292
- [ ] tests added / passed
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] Just clarified quantile doc a bit
