### PR TITLE
Add Featuretools to Pandas Ecosystem Page

### DIFF
--- a/doc/source/ecosystem.rst
+++ b/doc/source/ecosystem.rst
@@ -38,7 +38,10 @@ Statsmodels leverages pandas objects as the underlying data container for comput
 Use pandas DataFrames in your `scikit-learn <http://scikit-learn.org/>`__
 ML pipeline.
 
+`Featuretools <https://github.com/featuretools/featuretools/>`__
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+Featuretools is a Python library for automated feature engineering built on top of pandas. It excels at transforming transactional and relational datasets into feature matrices for machine learning using reusable feature engineering "primitives". Users can contribute their own primitives in python and share them with the rest of the community. 
 
 .. _ecosystem.visualization:
 

--- a/doc/source/ecosystem.rst
+++ b/doc/source/ecosystem.rst
@@ -41,7 +41,7 @@ ML pipeline.
 `Featuretools <https://github.com/featuretools/featuretools/>`__
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Featuretools is a Python library for automated feature engineering built on top of pandas. It excels at transforming transactional and relational datasets into feature matrices for machine learning using reusable feature engineering "primitives". Users can contribute their own primitives in python and share them with the rest of the community. 
+Featuretools is a Python library for automated feature engineering built on top of pandas. It excels at transforming temporal and relational datasets into feature matrices for machine learning using reusable feature engineering "primitives". Users can contribute their own primitives in Python and share them with the rest of the community. 
 
 .. _ecosystem.visualization:
 


### PR DESCRIPTION
Adding a library for automated feature engineering that is built on top of Pandas that I think would be very relevant to users of pandas. 

More info on our website (https://www.featuretools.com/) and GitHub (https://github.com/featuretools/featuretools/).