### PR TITLE
BUG: encoding error in to_csv compression

### DIFF
--- a/doc/source/whatsnew/v0.23.1.txt
+++ b/doc/source/whatsnew/v0.23.1.txt
@@ -92,7 +92,7 @@ I/O
 
 - Bug in IO methods specifying ``compression='zip'`` which produced uncompressed zip archives (:issue:`17778`, :issue:`21144`)
 - Bug in :meth:`DataFrame.to_stata` which prevented exporting DataFrames to buffers and most file-like objects (:issue:`21041`)
-- Bug in :meth:`DataFrame.to_csv` using compression causes encoding error (:issue:`21241`)
+- Bug in :meth:`DataFrame.to_csv` and :meth:`Series.to_csv` using compression causes encoding error (:issue:`21241`, :issue:`21118`)
 -
 
 Plotting

--- a/doc/source/whatsnew/v0.23.1.txt
+++ b/doc/source/whatsnew/v0.23.1.txt
@@ -92,6 +92,7 @@ I/O
 
 - Bug in IO methods specifying ``compression='zip'`` which produced uncompressed zip archives (:issue:`17778`, :issue:`21144`)
 - Bug in :meth:`DataFrame.to_stata` which prevented exporting DataFrames to buffers and most file-like objects (:issue:`21041`)
+- Bug in :meth:`DataFrame.to_csv` using compression causes encoding error (:issue:`21241`)
 -
 
 Plotting

--- a/doc/source/whatsnew/v0.23.1.txt
+++ b/doc/source/whatsnew/v0.23.1.txt
@@ -92,7 +92,7 @@ I/O
 
 - Bug in IO methods specifying ``compression='zip'`` which produced uncompressed zip archives (:issue:`17778`, :issue:`21144`)
 - Bug in :meth:`DataFrame.to_stata` which prevented exporting DataFrames to buffers and most file-like objects (:issue:`21041`)
-- Bug in :meth:`DataFrame.to_csv` and :meth:`Series.to_csv` using compression causes encoding error (:issue:`21241`, :issue:`21118`)
+- Bug in :meth:`DataFrame.to_csv` and :meth:`Series.to_csv` causes encoding error when compression and encoding are specified (:issue:`21241`, :issue:`21118`)
 -
 
 Plotting

--- a/pandas/io/formats/csvs.py
+++ b/pandas/io/formats/csvs.py
@@ -131,7 +131,6 @@ class CSVFormatter(object):
         # PR 21300 uses string buffer to receive csv writing and dump into
         # file-like output with compression as option. GH 21241, 21118
         f = StringIO()
-        close = True
         if not is_file_like(self.path_or_buf):
             # path_or_buf is path
             path_or_buf = self.path_or_buf
@@ -141,7 +140,7 @@ class CSVFormatter(object):
         else:
             # path_or_buf is file-like IO objects.
             f = self.path_or_buf
-            close = False
+            path_or_buf = None
 
         try:
             writer_kwargs = dict(lineterminator=self.line_terminator,
@@ -160,7 +159,7 @@ class CSVFormatter(object):
         finally:
             # GH 17778 handles zip compression for byte strings separately.
             buf = f.getvalue()
-            if close:
+            if path_or_buf:
                 f, handles = _get_handle(path_or_buf, self.mode,
                                          encoding=encoding,
                                          compression=self.compression)

--- a/pandas/io/formats/csvs.py
+++ b/pandas/io/formats/csvs.py
@@ -133,10 +133,13 @@ class CSVFormatter(object):
         f = StringIO()
         close = True
         if not is_file_like(self.path_or_buf):
+            # path_or_buf is path
             path_or_buf = self.path_or_buf
         elif hasattr(self.path_or_buf, 'name'):
+            # path_or_buf is file handle
             path_or_buf = self.path_or_buf.name
         else:
+            # path_or_buf is file-like IO objects.
             f = self.path_or_buf
             close = False
 

--- a/pandas/io/formats/csvs.py
+++ b/pandas/io/formats/csvs.py
@@ -152,11 +152,15 @@ class CSVFormatter(object):
 
         finally:
             # GH 17778 handles zip compression for byte strings separately to
-            # support Python 2
+            # support Python 2, also allow compression file handle
             if not close and self.compression:
                 f.close()
-                with open(f.name, 'rb') as f:
-                    data = f.read().decode(encoding)
+                if compat.PY2:
+                    _fh = open(f.name, 'r')
+                else:
+                    _fh = open(f.name, 'r', encoding=encoding)
+                with _fh:
+                    data = _fh.read()
                 f, handles = _get_handle(f.name, self.mode,
                                          encoding=encoding,
                                          compression=self.compression)

--- a/pandas/io/formats/csvs.py
+++ b/pandas/io/formats/csvs.py
@@ -154,8 +154,8 @@ class CSVFormatter(object):
             # GH 17778 handles compression for byte strings.
             if not close and self.compression:
                 f.close()
-                with open(f.name, 'r') as f:
-                    data = f.read()
+                with open(f.name, 'rb') as f:
+                    data = f.read().decode(encoding)
                 f, handles = _get_handle(f.name, self.mode,
                                          encoding=encoding,
                                          compression=self.compression)

--- a/pandas/io/formats/csvs.py
+++ b/pandas/io/formats/csvs.py
@@ -155,12 +155,10 @@ class CSVFormatter(object):
             # support Python 2, also allow compression file handle
             if not close and self.compression:
                 f.close()
-                if compat.PY2:
-                    _fh = open(f.name, 'r')
-                else:
-                    _fh = open(f.name, 'r', encoding=encoding)
-                with _fh:
-                    data = _fh.read()
+                with open(f.name, 'rb') as f:
+                    data = f.read()
+                if not compat.PY2:
+                    data = data.decode(encoding)
                 f, handles = _get_handle(f.name, self.mode,
                                          encoding=encoding,
                                          compression=self.compression)

--- a/pandas/io/formats/csvs.py
+++ b/pandas/io/formats/csvs.py
@@ -151,7 +151,8 @@ class CSVFormatter(object):
             self._save()
 
         finally:
-            # GH 17778 handles compression for byte strings.
+            # GH 17778 handles zip compression for byte strings separately to
+            # support Python 2
             if not close and self.compression:
                 f.close()
                 with open(f.name, 'rb') as f:

--- a/pandas/io/formats/csvs.py
+++ b/pandas/io/formats/csvs.py
@@ -9,6 +9,7 @@ import csv as csvlib
 import numpy as np
 
 from pandas.core.dtypes.missing import notna
+from pandas.core.dtypes.inference import is_file_like
 from pandas.core.index import Index, MultiIndex
 from pandas import compat
 from pandas.compat import (StringIO, range, zip)
@@ -129,16 +130,17 @@ class CSVFormatter(object):
 
         # PR 21300 uses string buffer to receive csv writing and dump into
         # file-like output with compression as option.
-        if hasattr(self.path_or_buf, 'name'):
-            path_or_buf = self.path_or_buf.name
-            f = StringIO()
-        elif isinstance(self.path_or_buf, compat.string_types):
+        if not is_file_like(self.path_or_buf):
             path_or_buf = self.path_or_buf
             f = StringIO()
+            close = True
+        elif hasattr(self.path_or_buf, 'name'):
+            path_or_buf = self.path_or_buf.name
+            f = StringIO()
+            close = True
         else:
             f = self.path_or_buf
-
-        close = f != self.path_or_buf
+            close = False
 
         try:
             writer_kwargs = dict(lineterminator=self.line_terminator,

--- a/pandas/io/formats/csvs.py
+++ b/pandas/io/formats/csvs.py
@@ -129,15 +129,13 @@ class CSVFormatter(object):
             encoding = self.encoding
 
         # PR 21300 uses string buffer to receive csv writing and dump into
-        # file-like output with compression as option.
+        # file-like output with compression as option. GH 21241, 21118
+        f = StringIO()
+        close = True
         if not is_file_like(self.path_or_buf):
             path_or_buf = self.path_or_buf
-            f = StringIO()
-            close = True
         elif hasattr(self.path_or_buf, 'name'):
             path_or_buf = self.path_or_buf.name
-            f = StringIO()
-            close = True
         else:
             f = self.path_or_buf
             close = False

--- a/pandas/tests/frame/test_to_csv.py
+++ b/pandas/tests/frame/test_to_csv.py
@@ -923,6 +923,7 @@ class TestDataFrameToCSV(TestData):
         (DataFrame([[0.123456, 0.234567, 0.567567],
                     [12.32112, 123123.2, 321321.2]],
                    index=['A', 'B'], columns=['X', 'Y', 'Z']), None),
+        # GH 21241, 21118
         (DataFrame([['abc', 'def', 'ghi']], columns=['X', 'Y', 'Z']), 'ascii'),
         (DataFrame(5 * [[123, u"你好", u"世界"]],
                    columns=['X', 'Y', 'Z']), 'gb2312'),

--- a/pandas/tests/frame/test_to_csv.py
+++ b/pandas/tests/frame/test_to_csv.py
@@ -922,7 +922,7 @@ class TestDataFrameToCSV(TestData):
     @pytest.mark.parametrize('frame, encoding', [
         (DataFrame([[0.123456, 0.234567, 0.567567],
                     [12.32112, 123123.2, 321321.2]],
-                   index=['A', 'B'], columns=['X', 'Y', 'Z']), 'utf-8'),
+                   index=['A', 'B'], columns=['X', 'Y', 'Z']), None),
         (DataFrame([['abc', 'def', 'ghi']], columns=['X', 'Y', 'Z']), 'ascii'),
         (DataFrame(5 * [[123, u"你好", u"世界"]],
                    columns=['X', 'Y', 'Z']), 'gb2312'),
@@ -942,7 +942,7 @@ class TestDataFrameToCSV(TestData):
 
             # explicitly make sure file is compressed
             with tm.decompress_file(filename, compression) as fh:
-                text = fh.read().decode(encoding)
+                text = fh.read().decode(encoding or 'utf8')
                 for col in frame.columns:
                     assert col in text
 

--- a/pandas/tests/frame/test_to_csv.py
+++ b/pandas/tests/frame/test_to_csv.py
@@ -919,7 +919,7 @@ class TestDataFrameToCSV(TestData):
         recons = pd.read_csv(StringIO(csv_str), index_col=0)
         assert_frame_equal(self.frame, recons)
 
-    @pytest.mark.parametrize('frame, encoding', [
+    @pytest.mark.parametrize('df,encoding', [
         (DataFrame([[0.123456, 0.234567, 0.567567],
                     [12.32112, 123123.2, 321321.2]],
                    index=['A', 'B'], columns=['X', 'Y', 'Z']), None),
@@ -929,27 +929,27 @@ class TestDataFrameToCSV(TestData):
         (DataFrame(5 * [[123, u"Γειά σου", u"Κόσμε"]],
                    columns=['X', 'Y', 'Z']), 'cp737')
     ])
-    def test_to_csv_compression(self, frame, encoding, compression):
+    def test_to_csv_compression(self, df, encoding, compression):
 
         with ensure_clean() as filename:
 
-            frame.to_csv(filename, compression=compression, encoding=encoding)
+            df.to_csv(filename, compression=compression, encoding=encoding)
 
             # test the round trip - to_csv -> read_csv
-            rs = read_csv(filename, compression=compression,
-                          index_col=0, encoding=encoding)
-            assert_frame_equal(frame, rs)
+            result = read_csv(filename, compression=compression,
+                              index_col=0, encoding=encoding)
+            assert_frame_equal(df, result)
 
             # explicitly make sure file is compressed
             with tm.decompress_file(filename, compression) as fh:
                 text = fh.read().decode(encoding or 'utf8')
-                for col in frame.columns:
+                for col in df.columns:
                     assert col in text
 
             with tm.decompress_file(filename, compression) as fh:
-                assert_frame_equal(frame, read_csv(fh,
-                                                   index_col=0,
-                                                   encoding=encoding))
+                assert_frame_equal(df, read_csv(fh,
+                                                index_col=0,
+                                                encoding=encoding))
 
     def test_to_csv_date_format(self):
         with ensure_clean('__tmp_to_csv_date_format__') as path:

--- a/pandas/tests/frame/test_to_csv.py
+++ b/pandas/tests/frame/test_to_csv.py
@@ -939,7 +939,14 @@ class TestDataFrameToCSV(TestData):
             # test the round trip - to_csv -> read_csv
             result = read_csv(filename, compression=compression,
                               index_col=0, encoding=encoding)
+
+            with open(filename, 'w') as fh:
+                df.to_csv(fh, compression=compression, encoding=encoding)
+
+            result_fh = read_csv(filename, compression=compression,
+                                 index_col=0, encoding=encoding)
             assert_frame_equal(df, result)
+            assert_frame_equal(df, result_fh)
 
             # explicitly make sure file is compressed
             with tm.decompress_file(filename, compression) as fh:

--- a/pandas/tests/series/test_io.py
+++ b/pandas/tests/series/test_io.py
@@ -139,7 +139,7 @@ class TestSeriesToCSV(TestData):
 
     @pytest.mark.parametrize('s, encoding', [
         (Series([0.123456, 0.234567, 0.567567], index=['A', 'B', 'C'],
-                name='X'), 'utf-8'),
+                name='X'), None),
         (Series(['abc', 'def', 'ghi'], name='X'), 'ascii'),
         (Series(["123", u"你好", u"世界"], name=u"中文"), 'gb2312'),
         (Series(["123", u"Γειά σου", u"Κόσμε"], name=u"Ελληνικά"), 'cp737')
@@ -158,7 +158,7 @@ class TestSeriesToCSV(TestData):
 
             # explicitly ensure file was compressed
             with tm.decompress_file(filename, compression) as fh:
-                text = fh.read().decode(encoding)
+                text = fh.read().decode(encoding or 'utf8')
                 assert s.name in text
 
             with tm.decompress_file(filename, compression) as fh:

--- a/pandas/tests/series/test_io.py
+++ b/pandas/tests/series/test_io.py
@@ -140,6 +140,7 @@ class TestSeriesToCSV(TestData):
     @pytest.mark.parametrize('s,encoding', [
         (Series([0.123456, 0.234567, 0.567567], index=['A', 'B', 'C'],
                 name='X'), None),
+        # GH 21241, 21118
         (Series(['abc', 'def', 'ghi'], name='X'), 'ascii'),
         (Series(["123", u"你好", u"世界"], name=u"中文"), 'gb2312'),
         (Series(["123", u"Γειά σου", u"Κόσμε"], name=u"Ελληνικά"), 'cp737')

--- a/pandas/tests/series/test_io.py
+++ b/pandas/tests/series/test_io.py
@@ -137,7 +137,7 @@ class TestSeriesToCSV(TestData):
         csv_str = s.to_csv(path=None)
         assert isinstance(csv_str, str)
 
-    @pytest.mark.parametrize('s, encoding', [
+    @pytest.mark.parametrize('s,encoding', [
         (Series([0.123456, 0.234567, 0.567567], index=['A', 'B', 'C'],
                 name='X'), None),
         (Series(['abc', 'def', 'ghi'], name='X'), 'ascii'),
@@ -152,9 +152,9 @@ class TestSeriesToCSV(TestData):
                      header=True)
 
             # test the round trip - to_csv -> read_csv
-            rs = pd.read_csv(filename, compression=compression,
-                             encoding=encoding, index_col=0, squeeze=True)
-            assert_series_equal(s, rs)
+            result = pd.read_csv(filename, compression=compression,
+                                 encoding=encoding, index_col=0, squeeze=True)
+            assert_series_equal(s, result)
 
             # explicitly ensure file was compressed
             with tm.decompress_file(filename, compression) as fh:

--- a/pandas/tests/series/test_io.py
+++ b/pandas/tests/series/test_io.py
@@ -10,7 +10,7 @@ import pandas as pd
 
 from pandas import Series, DataFrame
 
-from pandas.compat import StringIO, u, PY2
+from pandas.compat import StringIO, u
 from pandas.util.testing import (assert_series_equal, assert_almost_equal,
                                  assert_frame_equal, ensure_clean)
 import pandas.util.testing as tm

--- a/pandas/tests/series/test_io.py
+++ b/pandas/tests/series/test_io.py
@@ -155,7 +155,16 @@ class TestSeriesToCSV(TestData):
             # test the round trip - to_csv -> read_csv
             result = pd.read_csv(filename, compression=compression,
                                  encoding=encoding, index_col=0, squeeze=True)
+
+            with open(filename, 'w') as fh:
+                s.to_csv(fh, compression=compression, encoding=encoding,
+                         header=True)
+
+            result_fh = pd.read_csv(filename, compression=compression,
+                                    encoding=encoding, index_col=0,
+                                    squeeze=True)
             assert_series_equal(s, result)
+            assert_series_equal(s, result_fh)
 
             # explicitly ensure file was compressed
             with tm.decompress_file(filename, compression) as fh:

--- a/pandas/tests/series/test_io.py
+++ b/pandas/tests/series/test_io.py
@@ -10,7 +10,7 @@ import pandas as pd
 
 from pandas import Series, DataFrame
 
-from pandas.compat import StringIO, u
+from pandas.compat import StringIO, u, PY2
 from pandas.util.testing import (assert_series_equal, assert_almost_equal,
                                  assert_frame_equal, ensure_clean)
 import pandas.util.testing as tm
@@ -137,29 +137,35 @@ class TestSeriesToCSV(TestData):
         csv_str = s.to_csv(path=None)
         assert isinstance(csv_str, str)
 
-    def test_to_csv_compression(self, compression):
-
-        s = Series([0.123456, 0.234567, 0.567567], index=['A', 'B', 'C'],
-                   name='X')
+    @pytest.mark.parametrize('s, encoding', [
+        (Series([0.123456, 0.234567, 0.567567], index=['A', 'B', 'C'],
+                name='X'), 'utf-8'),
+        (Series(['abc', 'def', 'ghi'], name='X'), 'ascii'),
+        (Series(["123", u"你好", u"世界"], name=u"中文"), 'gb2312'),
+        (Series(["123", u"Γειά σου", u"Κόσμε"], name=u"Ελληνικά"), 'cp737')
+    ])
+    def test_to_csv_compression(self, s, encoding, compression):
 
         with ensure_clean() as filename:
 
-            s.to_csv(filename, compression=compression, header=True)
+            s.to_csv(filename, compression=compression, encoding=encoding,
+                     header=True)
 
             # test the round trip - to_csv -> read_csv
             rs = pd.read_csv(filename, compression=compression,
-                             index_col=0, squeeze=True)
+                             encoding=encoding, index_col=0, squeeze=True)
             assert_series_equal(s, rs)
 
             # explicitly ensure file was compressed
             with tm.decompress_file(filename, compression) as fh:
-                text = fh.read().decode('utf8')
+                text = fh.read().decode(encoding)
                 assert s.name in text
 
             with tm.decompress_file(filename, compression) as fh:
                 assert_series_equal(s, pd.read_csv(fh,
                                                    index_col=0,
-                                                   squeeze=True))
+                                                   squeeze=True,
+                                                   encoding=encoding))
 
 
 class TestSeriesIO(TestData):

--- a/pandas/tests/test_common.py
+++ b/pandas/tests/test_common.py
@@ -252,12 +252,13 @@ def test_compression_size_fh(obj, method, compression_only):
     with tm.ensure_clean() as filename:
         with open(filename, 'w') as fh:
             getattr(obj, method)(fh, compression=compression_only)
-            # GH 17778
-            assert fh.closed
+            assert not fh.closed
+        assert fh.closed
         compressed = os.path.getsize(filename)
     with tm.ensure_clean() as filename:
         with open(filename, 'w') as fh:
             getattr(obj, method)(fh, compression=None)
             assert not fh.closed
+        assert fh.closed
         uncompressed = os.path.getsize(filename)
         assert uncompressed > compressed


### PR DESCRIPTION
- [x] closes #21241 
closes #21118
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry

Fix a problem where encoding wasn't handled properly in to_csv compression in Python 3. It was caused by dumping uncompressed csv on disk and reading it back to memory without passing specified encoding. Then platform tried to decode using default locale encoding which may or may not succeed. 

This PR added tests for non-ascii data with csv compression. Also, by using string buffer, this PR removed repeated disk roundtrip and redundant encoding/decoding which caused UnicodeDecodeError. There is performance improvement compared to 0.22 and 0.23. It also supports file-like object as input path_or_buf. 

Before this PR:
```
>>> df = DataFrame(100 * [[123, "abc", u"样本1", u"样本2"]], columns=['A', 'B', 'C', 'D'])
>>>
>>> def test_to_csv(df):
...     df.to_csv(
...         path_or_buf='test',
...         encoding='utf8',
...         compression='zip',
...         quoting=1,
...         sep='\t',
...         index=False)
...
>>> timeit(lambda: test_to_csv(df), number=5000)
11.856349980007508
```
After this PR:

```
>>> df = DataFrame(100 * [[123, "abc", u"样本1", u"样本2"]], columns=['A', 'B', 'C', 'D'])
>>>
>>> def test_to_csv(df):
...     df.to_csv(
...         path_or_buf='test',
...         encoding='utf8',
...         compression='zip',
...         quoting=1,
...         sep='\t',
...         index=False)
...
>>> timeit(lambda: test_to_csv(df), number=5000)
5.459916951993364
```