### PR TITLE
TST: fix shebang typo

### DIFF
--- a/pandas/tests/io/generate_legacy_storage_files.py
+++ b/pandas/tests/io/generate_legacy_storage_files.py
@@ -1,4 +1,4 @@
-#!/usr/env/bin python
+#!/usr/bin/env python
 
 """
 self-contained to write legacy storage (pickle/msgpack) files


### PR DESCRIPTION
Fix shebang typo in generate_legacy_storage_files.py

- [x] closes #21306