### PR TITLE
DOC: fix mistake in Series.str.cat

### DIFF
--- a/pandas/core/strings.py
+++ b/pandas/core/strings.py
@@ -2172,9 +2172,9 @@ class StringMethods(NoNewAttributesMixin):
 
         Returns
         -------
-        concat : str if `other is None`, Series/Index of objects if `others is
-            not None`. In the latter case, the result will remain categorical
-            if the calling Series/Index is categorical.
+        concat :
+            str if `others` is None, Series/Index of objects if `others` is not
+            None.
 
         See Also
         --------

--- a/pandas/core/strings.py
+++ b/pandas/core/strings.py
@@ -2172,9 +2172,9 @@ class StringMethods(NoNewAttributesMixin):
 
         Returns
         -------
-        concat :
-            str if `others` is None, Series/Index of objects if `others` is not
-            None.
+        concat : str or Series/Index of objects
+            If `others` is None, `str` is returned, otherwise a `Series/Index`
+            (same type as caller) of objects is returned.
 
         See Also
         --------


### PR DESCRIPTION
Fix error in API-docstring that was introduced at the end of #20347 due to timepressure for the v.0.23-cutoff: removed functionality that categorical callers get categorical output, but forgot to adapt doc-string.

Unfortunately, this survived both #20347 and the follow-up, but since v.0.23.1 is coming soon, I didn't wanna let this opportunity pass.