### PR TITLE
Series.describe returns first and last for tz-aware datetimes

### DIFF
--- a/doc/source/whatsnew/v0.24.0.txt
+++ b/doc/source/whatsnew/v0.24.0.txt
@@ -295,8 +295,6 @@ Datetimelike
 ^^^^^^^^^^^^
 
 - Fixed bug where two :class:`DateOffset` objects with different ``normalize`` attributes could evaluate as equal (:issue:`21404`)
-- Bug in :class:`Index` with ``datetime64[ns, tz]`` dtype that did not localize integer data correctly (:issue:`20964`)
-- Fixed bug where :meth:`DataFrame.describe` and :meth:`Series.describe` on tz-aware datetimes did not show `first` and `last` result (:issue:`21328`)
 
 Timedelta
 ^^^^^^^^^
@@ -318,6 +316,7 @@ Timezones
 - Bug in :class:`Series` constructor which would coerce tz-aware and tz-naive :class:`Timestamp`s to tz-aware (:issue:`13051`)
 - Bug in :class:`Index` with ``datetime64[ns, tz]`` dtype that did not localize integer data correctly (:issue:`20964`)
 - Bug in :class:`DatetimeIndex` where constructing with an integer and tz would not localize correctly (:issue:`12619`)
+- Fixed bug where :meth:`DataFrame.describe` and :meth:`Series.describe` on tz-aware datetimes did not show `first` and `last` result (:issue:`21328`)
 
 Offsets
 ^^^^^^^

--- a/doc/source/whatsnew/v0.24.0.txt
+++ b/doc/source/whatsnew/v0.24.0.txt
@@ -295,6 +295,8 @@ Datetimelike
 ^^^^^^^^^^^^
 
 - Fixed bug where two :class:`DateOffset` objects with different ``normalize`` attributes could evaluate as equal (:issue:`21404`)
+- Bug in :class:`Index` with ``datetime64[ns, tz]`` dtype that did not localize integer data correctly (:issue:`20964`)
+- Fixed bug where `describe` method on tz-aware datetimes did not show `first` and `last` result (:issue:`21328`)
 
 Timedelta
 ^^^^^^^^^

--- a/doc/source/whatsnew/v0.24.0.txt
+++ b/doc/source/whatsnew/v0.24.0.txt
@@ -296,7 +296,7 @@ Datetimelike
 
 - Fixed bug where two :class:`DateOffset` objects with different ``normalize`` attributes could evaluate as equal (:issue:`21404`)
 - Bug in :class:`Index` with ``datetime64[ns, tz]`` dtype that did not localize integer data correctly (:issue:`20964`)
-- Fixed bug where `describe` method on tz-aware datetimes did not show `first` and `last` result (:issue:`21328`)
+- Fixed bug where :meth:`DataFrame.describe` and :meth:`Series.describe` on tz-aware datetimes did not show `first` and `last` result (:issue:`21328`)
 
 Timedelta
 ^^^^^^^^^

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -20,7 +20,7 @@ from pandas.core.dtypes.common import (
     is_bool_dtype,
     is_categorical_dtype,
     is_numeric_dtype,
-    is_datetime64_dtype,
+    is_datetime64_any_dtype,
     is_timedelta64_dtype,
     is_datetime64tz_dtype,
     is_list_like,
@@ -8531,12 +8531,13 @@ class NDFrame(PandasObject, SelectionMixin):
             if result[1] > 0:
                 top, freq = objcounts.index[0], objcounts.iloc[0]
 
-                if is_datetime64_dtype(data):
+                if is_datetime64_any_dtype(data):
+                    tz = data.dt.tz
                     asint = data.dropna().values.view('i8')
                     names += ['top', 'freq', 'first', 'last']
-                    result += [tslib.Timestamp(top), freq,
-                               tslib.Timestamp(asint.min()),
-                               tslib.Timestamp(asint.max())]
+                    result += [tslib.Timestamp(top, tz=tz), freq,
+                               tslib.Timestamp(asint.min(), tz=tz),
+                               tslib.Timestamp(asint.max(), tz=tz)]
                 else:
                     names += ['top', 'freq']
                     result += [top, freq]

--- a/pandas/tests/frame/test_analytics.py
+++ b/pandas/tests/frame/test_analytics.py
@@ -417,6 +417,27 @@ class TestDataFrameAnalytics(TestData):
                     "max           5 days 00:00:00         0 days 05:00:00")
         assert repr(res) == exp_repr
 
+    def test_describe_tz_values(self, tz_naive_fixture):
+        tz = tz_naive_fixture
+        s1 = Series(range(5))
+        start = Timestamp(2018, 1, 1)
+        end = Timestamp(2018, 1, 5)
+        s2 = Series(date_range(start, end, tz=tz))
+        df = pd.DataFrame({'s1': s1, 's2': s2})
+
+        expected = DataFrame({'s1': [5, np.nan, np.nan, np.nan, np.nan, np.nan,
+                                     2, 1.581139, 0, 1, 2, 3, 4],
+                              's2': [5, 5, s2.value_counts().index[0], 1,
+                                     start.tz_localize(tz),
+                                     end.tz_localize(tz), np.nan, np.nan,
+                                     np.nan, np.nan, np.nan, np.nan, np.nan]},
+                             index=['count', 'unique', 'top', 'freq', 'first',
+                                    'last', 'mean', 'std', 'min', '25%', '50%',
+                                    '75%', 'max']
+                             )
+        res = df.describe(include='all')
+        tm.assert_frame_equal(res, expected)
+
     def test_reduce_mixed_frame(self):
         # GH 6806
         df = DataFrame({

--- a/pandas/tests/frame/test_analytics.py
+++ b/pandas/tests/frame/test_analytics.py
@@ -418,6 +418,7 @@ class TestDataFrameAnalytics(TestData):
         assert repr(res) == exp_repr
 
     def test_describe_tz_values(self, tz_naive_fixture):
+        # GH 21332
         tz = tz_naive_fixture
         s1 = Series(range(5))
         start = Timestamp(2018, 1, 1)

--- a/pandas/tests/series/test_analytics.py
+++ b/pandas/tests/series/test_analytics.py
@@ -336,17 +336,15 @@ class TestSeriesAnalytics(TestData):
                           index=['count', 'unique', 'top', 'freq'])
         tm.assert_series_equal(result, expected)
 
-    @pytest.mark.parametrize("tz, name", [
-        (None, "tz-naive"),
-        ("US/Eastern", "tz-aware")
-    ])
-    def test_describe_dt(self, tz, name):
+    def test_describe_with_tz(self, tz_naive_fixture):
+        tz = tz_naive_fixture
+        name = tz_naive_fixture
         start = Timestamp(2018, 1, 1)
         end = Timestamp(2018, 1, 5)
         s = Series(date_range(start, end, tz=tz), name=name)
         result = s.describe()
         expected = Series(
-            [5, 5, start.tz_localize(tz), 1, start.tz_localize(tz),
+            [5, 5, s.value_counts().index[0], 1, start.tz_localize(tz),
              end.tz_localize(tz)
              ],
             name=name,

--- a/pandas/tests/series/test_analytics.py
+++ b/pandas/tests/series/test_analytics.py
@@ -336,12 +336,11 @@ class TestSeriesAnalytics(TestData):
                           index=['count', 'unique', 'top', 'freq'])
         tm.assert_series_equal(result, expected)
 
-    @pytest.mark.parametrize("tz", [None, "US/Eastern"])
-    def test_describe_dt(self, tz):
-        if tz is None:
-            name = "tz-naive"
-        else:
-            name = "tz-aware"
+    @pytest.mark.parametrize("tz, name", [
+        (None, "tz-naive"),
+        ("US/Eastern", "tz-aware")
+    ])
+    def test_describe_dt(self, tz, name):
         start = Timestamp(2018, 1, 1)
         end = Timestamp(2018, 1, 5)
         s = Series(date_range(start, end, tz=tz), name=name)

--- a/pandas/tests/series/test_analytics.py
+++ b/pandas/tests/series/test_analytics.py
@@ -336,27 +336,21 @@ class TestSeriesAnalytics(TestData):
                           index=['count', 'unique', 'top', 'freq'])
         tm.assert_series_equal(result, expected)
 
+    @pytest.mark.parametrize("tz", [None, "US/Eastern"])
+    def test_describe_dt(self, tz):
+        if tz is None:
+            name = "tz-naive"
+        else:
+            name = "tz-aware"
         start = Timestamp(2018, 1, 1)
         end = Timestamp(2018, 1, 5)
-        s = Series(date_range(start, end), name="tz-naive")
-        result = s.describe()
-        expected = Series(
-            [5, 5, start, 1, start, end],
-            name="tz-naive",
-            index=['count', 'unique', 'top', 'freq', 'first', 'last']
-        )
-        tm.assert_series_equal(result, expected)
-
-        start = Timestamp(2018, 1, 1)
-        end = Timestamp(2018, 1, 5)
-        tz = "US/Eastern"
-        s = Series(date_range(start, end, tz=tz), name="tz-aware")
+        s = Series(date_range(start, end, tz=tz), name=name)
         result = s.describe()
         expected = Series(
             [5, 5, start.tz_localize(tz), 1, start.tz_localize(tz),
              end.tz_localize(tz)
              ],
-            name="tz-aware",
+            name=name,
             index=['count', 'unique', 'top', 'freq', 'first', 'last']
         )
         tm.assert_series_equal(result, expected)

--- a/pandas/tests/series/test_analytics.py
+++ b/pandas/tests/series/test_analytics.py
@@ -336,6 +336,31 @@ class TestSeriesAnalytics(TestData):
                           index=['count', 'unique', 'top', 'freq'])
         tm.assert_series_equal(result, expected)
 
+        start = Timestamp(2018, 1, 1)
+        end = Timestamp(2018, 1, 5)
+        s = Series(date_range(start, end), name="tz-naive")
+        result = s.describe()
+        expected = Series(
+            [5, 5, start, 1, start, end],
+            name="tz-naive",
+            index=['count', 'unique', 'top', 'freq', 'first', 'last']
+        )
+        tm.assert_series_equal(result, expected)
+
+        start = Timestamp(2018, 1, 1)
+        end = Timestamp(2018, 1, 5)
+        tz = "US/Eastern"
+        s = Series(date_range(start, end, tz=tz), name="tz-aware")
+        result = s.describe()
+        expected = Series(
+            [5, 5, start.tz_localize(tz), 1, start.tz_localize(tz),
+             end.tz_localize(tz)
+             ],
+            name="tz-aware",
+            index=['count', 'unique', 'top', 'freq', 'first', 'last']
+        )
+        tm.assert_series_equal(result, expected)
+
     def test_argsort(self):
         self._check_accum_op('argsort', check_dtype=False)
         argsorted = self.ts.argsort()

--- a/pandas/tests/series/test_analytics.py
+++ b/pandas/tests/series/test_analytics.py
@@ -337,6 +337,7 @@ class TestSeriesAnalytics(TestData):
         tm.assert_series_equal(result, expected)
 
     def test_describe_with_tz(self, tz_naive_fixture):
+        # GH 21332
         tz = tz_naive_fixture
         name = tz_naive_fixture
         start = Timestamp(2018, 1, 1)


### PR DESCRIPTION
GH issue 21328

- [x] closes #21328 
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
