### PR TITLE
Revert change to comparison op with datetime.date objects

### DIFF
--- a/doc/source/whatsnew/v0.23.1.txt
+++ b/doc/source/whatsnew/v0.23.1.txt
@@ -10,8 +10,6 @@ and bug fixes. We recommend that all users upgrade to this version.
     :local:
     :backlinks: none
 
-.. _whatsnew_0231.enhancements:
-
 .. _whatsnew_0231.fixed_regressions:
 
 Fixed Regressions

--- a/doc/source/whatsnew/v0.23.1.txt
+++ b/doc/source/whatsnew/v0.23.1.txt
@@ -55,22 +55,6 @@ To summarize, here's the behavior in 0.22.0, 0.23.0, 0.23.1:
 
 In addition, ordering comparisons will raise a ``TypeError`` in the future.
 
-  .. code-block:: python
-
-     >>> pd.Series(pd.date_range('2017', periods=2)) > datetime.date(2017, 1, 1)
-     /bin/python:1: FutureWarning: Comparing Series of datetimes with 'datetime.date'.  Currently, the
-     'datetime.date' is coerced to a datetime. In the future pandas will
-     not coerce, and a TypeError will be raised. To retain the current
-     behavior, convert the 'datetime.date' to a datetime with
-     'pd.Timestamp'.
-       #!/bin/python3
-     Out[6]:
-     0    False
-     1     True
-     dtype: bool
-   
-In the future, the 0.23.0 behavior of not coercing will be restored.
-
 **Other Fixes**
 
 - Reverted the ability of :func:`~DataFrame.to_sql` to perform multivalue

--- a/doc/source/whatsnew/v0.23.1.txt
+++ b/doc/source/whatsnew/v0.23.1.txt
@@ -10,6 +10,66 @@ and bug fixes. We recommend that all users upgrade to this version.
     :local:
     :backlinks: none
 
+.. _whatsnew_0231.fixed_regressions:
+
+Fixed Regressions
+~~~~~~~~~~~~~~~~~
+
+Comparing Series with datetime.date
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+We've reverted a 0.23.0 change to comparing a :class:`Series` holding datetimes and a ``datetime.date`` object (:issue:`21152`).
+In pandas 0.22 and earlier, comparing a Series holding datetimes and ``datetime.date`` objects would coerce the ``datetime.date`` to a datetime before comapring.
+This was inconsistent with Python, NumPy, and :class:`DatetimeIndex`, which never consider a datetime and ``datetime.date`` equal.
+In 0.23.0, we unified operations between DatetimeIndex and Series, and in the process changed comparisons between a Series of datetimes and ``datetime.date`` without warning.
+We've temporarily restored the 0.22.0 behavior, so datetimes and dates may again compare equal, but restore the 0.23.0 behavior in a future release.
+
+To summarize, here's the behavior in 0.22.0, 0.23.0, 0.23.1:
+
+.. code-block:: python
+
+   # 0.22.0... Silently coerce the datetime.date
+   >>> Series(pd.date_range('2017', periods=2)) == datetime.date(2017, 1, 1)
+   0     True
+   1    False
+   dtype: bool
+
+   # 0.23.0... Do not coerce the datetime.date
+   >>> Series(pd.date_range('2017', periods=2)) == datetime.date(2017, 1, 1)
+   0    False
+   1    False
+   dtype: bool
+
+   # 0.23.1... Coerce the datetime.date with a warning
+   >>> Series(pd.date_range('2017', periods=2)) == datetime.date(2017, 1, 1)
+   /bin/python:1: FutureWarning: Comparing Series of datetimes with 'datetime.date'.  Currently, the
+   'datetime.date' is coerced to a datetime. In the future pandas will
+   not coerce, and the values not compare equal to the 'datetime.date'.
+   To retain the current behavior, convert the 'datetime.date' to a
+   datetime with 'pd.Timestamp'.
+     #!/bin/python3
+   0     True
+   1    False
+   dtype: bool
+
+In addition, ordering comparisons will raise a ``TypeError`` in the future.
+
+  .. code-block:: python
+
+     >>> pd.Series(pd.date_range('2017', periods=2)) > datetime.date(2017, 1, 1)
+     /bin/python:1: FutureWarning: Comparing Series of datetimes with 'datetime.date'.  Currently, the
+     'datetime.date' is coerced to a datetime. In the future pandas will
+     not coerce, and a TypeError will be raised. To retain the current
+     behavior, convert the 'datetime.date' to a datetime with
+     'pd.Timestamp'.
+       #!/bin/python3
+     Out[6]:
+     0    False
+     1     True
+     dtype: bool
+   
+In the future, the 0.23.0 behavior of not coercing will be restored.
+
 .. _whatsnew_0231.enhancements:
 
 New features

--- a/pandas/core/ops.py
+++ b/pandas/core/ops.py
@@ -5,7 +5,10 @@ This is not a public API.
 """
 # necessary to enforce truediv in Python 2.X
 from __future__ import division
+import datetime
 import operator
+import textwrap
+import warnings
 
 import numpy as np
 import pandas as pd
@@ -1197,8 +1200,35 @@ def _comp_method_SERIES(cls, op, special):
         if is_datetime64_dtype(self) or is_datetime64tz_dtype(self):
             # Dispatch to DatetimeIndex to ensure identical
             # Series/Index behavior
+            if (isinstance(other, datetime.date) and
+                    not isinstance(other, datetime.datetime)):
+                # https://github.com/pandas-dev/pandas/issues/21152
+                # Compatibility for difference between Series comparison w/
+                # datetime and date
+                msg = (
+                    "Comparing Series of datetimes with 'datetime.date'.  "
+                    "Currently, the 'datetime.date' is coerced to a "
+                    "datetime. In the future pandas will not coerce, "
+                    "and {future}. "
+                    "To retain the current behavior, "
+                    "convert the 'datetime.date' to a datetime with "
+                    "'pd.Timestamp'."
+                )
+
+                if op in {operator.lt, operator.le, operator.gt, operator.ge}:
+                    future = "a TypeError will be raised"
+                else:
+                    future = (
+                        "'the values will not compare equal to the "
+                        "'datetime.date'"
+                    )
+                msg = '\n'.join(textwrap.wrap(msg.format(future=future)))
+                warnings.warn(msg, FutureWarning, stacklevel=2)
+                other = pd.Timestamp(other)
+
             res_values = dispatch_to_index_op(op, self, other,
                                               pd.DatetimeIndex)
+
             return self._constructor(res_values, index=self.index,
                                      name=res_name)
 


### PR DESCRIPTION
- [x] closes #21152
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry

cc @jbrockmendel, @innominate227

FYI, @jorisvandenbossche the whatsnew will conflict with your other PR