### PR TITLE
BUG: Fixed concat warning message

### DIFF
--- a/doc/source/whatsnew/v0.23.1.txt
+++ b/doc/source/whatsnew/v0.23.1.txt
@@ -112,7 +112,7 @@ Reshaping
 ^^^^^^^^^
 
 - Bug in :func:`concat` where error was raised in concatenating :class:`Series` with numpy scalar and tuple names (:issue:`21015`)
--
+- Bug in :func:`concat` warning message providing the wrong guidance for future behavior (:issue:`21101`)
 
 Other
 ^^^^^

--- a/pandas/core/indexes/api.py
+++ b/pandas/core/indexes/api.py
@@ -24,9 +24,9 @@ _sort_msg = textwrap.dedent("""\
 Sorting because non-concatenation axis is not aligned. A future version
 of pandas will change to not sort by default.
 
-To accept the future behavior, pass 'sort=True'.
+To accept the future behavior, pass 'sort=False'.
 
-To retain the current behavior and silence the warning, pass sort=False
+To retain the current behavior and silence the warning, pass 'sort=True'.
 """)
 
 


### PR DESCRIPTION
- [x] closes #21101
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry
