### PR TITLE
PERF: Add __contains__ to CategoricalIndex

### DIFF
--- a/asv_bench/benchmarks/categoricals.py
+++ b/asv_bench/benchmarks/categoricals.py
@@ -193,3 +193,16 @@ class IsMonotonic(object):
 
     def time_categorical_series_is_monotonic_decreasing(self):
         self.s.is_monotonic_decreasing
+
+
+class Contains(object):
+
+    goal_time = 0.2
+
+    def setup(self):
+        N = 10**5
+        self.ci = tm.makeCategoricalIndex(N)
+        self.cat = self.ci.categories[0]
+
+    def time_contains(self):
+        self.cat in self.ci

--- a/doc/source/whatsnew/v0.23.2.txt
+++ b/doc/source/whatsnew/v0.23.2.txt
@@ -24,7 +24,9 @@ Fixed Regressions
 Performance Improvements
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
--
+- Improved performance of membership checks in :class:`CategoricalIndex`
+  (i.e. ``x in ci``-style checks are much faster). :meth:`CategoricalIndex.contains`
+  is likewise much faster (:issue:`21369`)
 -
 
 Documentation Changes

--- a/doc/source/whatsnew/v0.24.0.txt
+++ b/doc/source/whatsnew/v0.24.0.txt
@@ -65,7 +65,9 @@ Performance Improvements
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
 - Improved performance of :func:`Series.describe` in case of numeric dtpyes (:issue:`21274`)
--
+- Improved performance of membership checks in :class:`CategoricalIndex`
+  (i.e. ``x in ci``-style checks are much faster). :meth:`CategoricalIndex.contains`
+  is likewise much faster (:issue:`21369`)
 
 .. _whatsnew_0240.docs:
 

--- a/doc/source/whatsnew/v0.24.0.txt
+++ b/doc/source/whatsnew/v0.24.0.txt
@@ -65,9 +65,7 @@ Performance Improvements
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
 - Improved performance of :func:`Series.describe` in case of numeric dtpyes (:issue:`21274`)
-- Improved performance of membership checks in :class:`CategoricalIndex`
-  (i.e. ``x in ci``-style checks are much faster). :meth:`CategoricalIndex.contains`
-  is likewise much faster (:issue:`21369`)
+-
 
 .. _whatsnew_0240.docs:
 

--- a/pandas/core/indexes/category.py
+++ b/pandas/core/indexes/category.py
@@ -324,20 +324,19 @@ class CategoricalIndex(Index, accessor.PandasDelegate):
     @Appender(_index_shared_docs['__contains__'] % _index_doc_kwargs)
     def __contains__(self, key):
         hash(key)
-
-        if self.categories._defer_to_indexing:
-            return key in self.categories
-
-        return key in self.values
+        if isna(key):
+            return self.isna().any()
+        elif self.categories._defer_to_indexing:  # e.g. Interval values
+            loc = self.categories.get_loc(key)
+            return np.isin(self.codes, loc).any()
+        elif key in self.categories:
+            return self.categories.get_loc(key) in self._engine
+        else:
+            return False
 
     @Appender(_index_shared_docs['contains'] % _index_doc_kwargs)
     def contains(self, key):
-        hash(key)
-
-        if self.categories._defer_to_indexing:
-            return self.categories.contains(key)
-
-        return key in self.values
+        return key in self
 
     def __array__(self, dtype=None):
         """ the array interface, return my values """


### PR DESCRIPTION
- [x] progress towards #20395
- [x] xref #21022
- [ ] tests added / passed
- [x] benchmark added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry

Currently, membership checks in ``CategoricalIndex`` is very slow as explained in #21022. This PR fixes the issue for ``CategoricalIndex``, while #21022 contains the fix for ``Categorical``. The difference between the two cases is the use of ``_engine`` for ``CategoricalIndex``, which makes this even faster than the ``Catagorical`` solution in #21022.

Tests exist already and can be found in ``tests/indexes/test_category.py::TestCategoricalIndex::test_contains``.

ASV:

```
      before           after         ratio
     [0c65c57a]       [986779ab]
-      2.49±0.2ms       3.26±0.2μs     0.00  categoricals.Contains.time_contains

SOME BENCHMARKS HAVE CHANGED SIGNIFICANTLY.
```