### PR TITLE
TST : Adding new test case for pivot_table() with Categorical data

### DIFF
--- a/pandas/tests/reshape/test_pivot.py
+++ b/pandas/tests/reshape/test_pivot.py
@@ -153,12 +153,12 @@ class TestPivotTable(object):
         result = df.pivot_table(index="In", columns="Col", values="Val",
                                 dropna=dropna)
         expected = pd.DataFrame(
-          {'A': [np.nan, 5], 'B': [1, np.nan], 'C': [3.0, 3.0]},
-          index=pd.Index(
-                         pd.Categorical.from_codes([0, 1],
-                                                   categories=['low', 'high'],
-                                                   ordered=True),
-                         name='In'))
+            {'A': [np.nan, 5], 'B': [1, np.nan], 'C': [3.0, 3.0]},
+            index=pd.Index(
+                pd.Categorical.from_codes([0, 1],
+                                          categories=['low', 'high'],
+                                          ordered=True),
+                name='In'))
         tm.assert_frame_equal(result, expected)
 
     def test_pivot_with_non_observable_dropna(self, dropna):

--- a/pandas/tests/reshape/test_pivot.py
+++ b/pandas/tests/reshape/test_pivot.py
@@ -155,10 +155,10 @@ class TestPivotTable(object):
         expected = pd.DataFrame(
           {'A': [np.nan, 5], 'B': [1, np.nan], 'C': [3.0, 3.0]},
           index=pd.Index(
-            pd.Categorical.from_codes([0, 1],
-                                      categories=['low', 'high'],
-                                      ordered=True),
-            name='In'))
+                         pd.Categorical.from_codes([0, 1],
+                                                   categories=['low', 'high'],
+                                                   ordered=True),
+                         name='In'))
         tm.assert_frame_equal(result, expected)
 
     def test_pivot_with_non_observable_dropna(self, dropna):

--- a/pandas/tests/reshape/test_pivot.py
+++ b/pandas/tests/reshape/test_pivot.py
@@ -145,22 +145,22 @@ class TestPivotTable(object):
     def test_pivot_with_non_observable_dropna_civ(self, dropna):
         # gh-21370
         arr = [np.nan, 'low', 'high', 'low', 'high', 'high', np.nan]
-        df = pd.DataFrame(
-         {"In": pd.Categorical(arr,
-         categories=['low', 'high'], ordered=True),
-          "Col": ["A", "B", "C", "C", "C", "A", "B"],
-          "Val": range(7)})
+        df = pd.DataFrame({"In": pd.Categorical(arr,
+                                                categories=['low', 'high'],
+                          ordered=True), "Col": ["A",
+                                                 "B", "C", "C", "C", "A", "B"],
+                          "Val": range(7)})
         result = df.pivot_table(index="In", columns="Col", values="Val",
-        dropna=dropna)
+                                dropna=dropna)
         expected = pd.DataFrame(
           {'A': [np.nan, 5], 'B': [1, np.nan], 'C': [3.0, 3.0]},
           index=pd.Index(
-            pd.Categorical.from_codes([0,1],
+            pd.Categorical.from_codes([0, 1],
                                       categories=['low', 'high'],
                                       ordered=True),
             name='In'))
-        tm.assert_frame_equal(result,expected) 
-    
+        tm.assert_frame_equal(result, expected)
+
     def test_pivot_with_non_observable_dropna(self, dropna):
         # gh-21133
         df = pd.DataFrame(

--- a/pandas/tests/reshape/test_pivot.py
+++ b/pandas/tests/reshape/test_pivot.py
@@ -145,23 +145,24 @@ class TestPivotTable(object):
     def test_pivot_with_non_observable_dropna_civ(self, dropna):
         # gh-21370
         arr = [np.nan, 'low', 'high', 'low', np.nan]
-        df = pd.DataFrame(
-            {"In": pd.Categorical(arr,
-                                  categories=['low', 'high'],
-                                  ordered=True),
-             "Col": ["A", "B", "C", "A", "B"],
-             "Val": range(1, 6)})
+        df = pd.DataFrame({
+            "In": pd.Categorical(arr,
+                                 categories=['low', 'high'],
+                                 ordered=True),
+            "Col": ["A", "B", "C", "A", "B"],
+            "Val": range(1, 6)
+        })
         result = df.pivot_table(index="In", columns="Col", values="Val",
                                 dropna=dropna)
-        expected = pd.DataFrame(
-            {
-                'A': [4.0, np.nan],
-                'B': [2.0, np.nan],
-                'C': [np.nan, 3.0]},
+        expected = pd.DataFrame({
+            'A': [4.0, np.nan],
+            'B': [2.0, np.nan],
+            'C': [np.nan, 3.0]},
             index=pd.Index(
-                pd.Categorical.from_codes([0, 1],
-                                          categories=['low', 'high'],
-                                          ordered=True),
+                pd.Categorical.from_codes(
+                    [0, 1],
+                    categories=['low', 'high'],
+                    ordered=True),
                 name='In'))
         tm.assert_frame_equal(result, expected)
 

--- a/pandas/tests/reshape/test_pivot.py
+++ b/pandas/tests/reshape/test_pivot.py
@@ -143,21 +143,23 @@ class TestPivotTable(object):
         tm.assert_frame_equal(result, expected)
 
     def test_pivot_with_non_observable_dropna_civ(self, dropna):
-      # gh-21370
-       df=pd.DataFrame(
-         {"In":pd.Categorical([np.nan,'low','high','low','high','high',np.nan],
-                              categories=['low','high'],ordered=True),
-          "Col":["A","B","C","C","C","A","B"],
-          "Val":range(7)})
-        result=df.pivot_table(index="In",columns="Col",values="Val",dropna=dropna)
-        expected=pd.DataFrame(
-          {'A':[np.nan,5],'B':[1,np.nan],'C':[3.0,3.0]},
+        # gh-21370
+        arr = [np.nan, 'low', 'high', 'low', 'high', 'high', np.nan]
+        df = pd.DataFrame(
+         {"In": pd.Categorical(arr,
+         categories=['low', 'high'], ordered=True),
+          "Col": ["A", "B", "C", "C", "C", "A", "B"],
+          "Val": range(7)})
+        result = df.pivot_table(index="In", columns="Col", values="Val",
+        dropna=dropna)
+        expected = pd.DataFrame(
+          {'A': [np.nan, 5], 'B': [1, np.nan], 'C': [3.0, 3.0]},
           index=pd.Index(
             pd.Categorical.from_codes([0,1],
-                                      categories=['low','high'],
+                                      categories=['low', 'high'],
                                       ordered=True),
             name='In'))
-       tm.assert_frame_equal(result,expected) 
+        tm.assert_frame_equal(result,expected) 
     
     def test_pivot_with_non_observable_dropna(self, dropna):
         # gh-21133

--- a/pandas/tests/reshape/test_pivot.py
+++ b/pandas/tests/reshape/test_pivot.py
@@ -144,16 +144,20 @@ class TestPivotTable(object):
 
     def test_pivot_with_non_observable_dropna_civ(self, dropna):
         # gh-21370
-        arr = [np.nan, 'low', 'high', 'low', 'high', 'high', np.nan]
-        df = pd.DataFrame({"In": pd.Categorical(arr,
-                                                categories=['low', 'high'],
-                          ordered=True), "Col": ["A",
-                                                 "B", "C", "C", "C", "A", "B"],
-                          "Val": range(7)})
+        arr = [np.nan, 'low', 'high', 'low', np.nan]
+        df = pd.DataFrame(
+            {"In": pd.Categorical(arr,
+                                  categories=['low', 'high'],
+                                  ordered=True),
+             "Col": ["A", "B", "C", "A", "B"],
+             "Val": range(1, 6)})
         result = df.pivot_table(index="In", columns="Col", values="Val",
                                 dropna=dropna)
         expected = pd.DataFrame(
-            {'A': [np.nan, 5], 'B': [1, np.nan], 'C': [3.0, 3.0]},
+            {
+                'A': [4.0, np.nan],
+                'B': [2.0, np.nan],
+                'C': [np.nan, 3.0]},
             index=pd.Index(
                 pd.Categorical.from_codes([0, 1],
                                           categories=['low', 'high'],

--- a/pandas/tests/reshape/test_pivot.py
+++ b/pandas/tests/reshape/test_pivot.py
@@ -142,6 +142,23 @@ class TestPivotTable(object):
 
         tm.assert_frame_equal(result, expected)
 
+    def test_pivot_with_non_observable_dropna_civ(self, dropna):
+      # gh-21370
+       df=pd.DataFrame(
+         {"In":pd.Categorical([np.nan,'low','high','low','high','high',np.nan],
+                              categories=['low','high'],ordered=True),
+          "Col":["A","B","C","C","C","A","B"],
+          "Val":range(7)})
+        result=df.pivot_table(index="In",columns="Col",values="Val",dropna=dropna)
+        expected=pd.DataFrame(
+          {'A':[np.nan,5],'B':[1,np.nan],'C':[3.0,3.0]},
+          index=pd.Index(
+            pd.Categorical.from_codes([0,1],
+                                      categories=['low','high'],
+                                      ordered=True),
+            name='In'))
+       tm.assert_frame_equal(result,expected) 
+    
     def test_pivot_with_non_observable_dropna(self, dropna):
         # gh-21133
         df = pd.DataFrame(


### PR DESCRIPTION
TST: add additional test cases for pivot_table with categorical data #21370

- [x] closes #21370
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

Added a new test case for checking ```index/column/value``` workability as per the patch offered by PR #21252 

**Note** : the _civ means Column,Index and Value in the test name (wasn't being very creative here)