### PR TITLE
Accepts integer/float string with units and raises when unit is ambiguous

### DIFF
--- a/doc/source/whatsnew/v0.24.0.txt
+++ b/doc/source/whatsnew/v0.24.0.txt
@@ -665,8 +665,7 @@ Timedelta
 - Bug in :class:`Index` with numeric dtype when multiplying or dividing an array with dtype ``timedelta64`` (:issue:`22390`)
 - Bug in :class:`TimedeltaIndex` incorrectly allowing indexing with ``Timestamp`` object (:issue:`20464`)
 - Fixed bug where subtracting :class:`Timedelta` from an object-dtyped array would raise ``TypeError`` (:issue:`21980`)
--
--
+- Bug in :class:`Timedelta`: where passing a string of a pure number would not take unit into account. Also raises for ambiguous/duplicate unit specification (:issue: `12136`)
 
 Timezones
 ^^^^^^^^^

--- a/pandas/_libs/tslibs/timedeltas.pxd
+++ b/pandas/_libs/tslibs/timedeltas.pxd
@@ -3,7 +3,7 @@
 from numpy cimport int64_t
 
 # Exposed for tslib, not intended for outside use.
-cdef parse_timedelta_string(object ts, specified_unit=*)
+cdef parse_timedelta_string(object ts, object specified_unit=None)
 cpdef int64_t cast_from_unit(object ts, object unit) except? -1
 cpdef int64_t delta_to_nanoseconds(delta) except? -1
 cpdef convert_to_timedelta64(object ts, object unit)

--- a/pandas/_libs/tslibs/timedeltas.pxd
+++ b/pandas/_libs/tslibs/timedeltas.pxd
@@ -3,7 +3,7 @@
 from numpy cimport int64_t
 
 # Exposed for tslib, not intended for outside use.
-cdef parse_timedelta_string(object ts)
+cdef parse_timedelta_string(object ts, object specified_unit=None)
 cpdef int64_t cast_from_unit(object ts, object unit) except? -1
 cpdef int64_t delta_to_nanoseconds(delta) except? -1
 cpdef convert_to_timedelta64(object ts, object unit)

--- a/pandas/_libs/tslibs/timedeltas.pxd
+++ b/pandas/_libs/tslibs/timedeltas.pxd
@@ -3,7 +3,7 @@
 from numpy cimport int64_t
 
 # Exposed for tslib, not intended for outside use.
-cdef parse_timedelta_string(object ts, object specified_unit=None)
+cdef parse_timedelta_string(object ts, specified_unit=*)
 cpdef int64_t cast_from_unit(object ts, object unit) except? -1
 cpdef int64_t delta_to_nanoseconds(delta) except? -1
 cpdef convert_to_timedelta64(object ts, object unit)

--- a/pandas/_libs/tslibs/timedeltas.pxd
+++ b/pandas/_libs/tslibs/timedeltas.pxd
@@ -3,7 +3,7 @@
 from numpy cimport int64_t
 
 # Exposed for tslib, not intended for outside use.
-cdef parse_timedelta_string(object ts, specified_unit=*)
+cdef parse_timedelta_string(object ts)
 cpdef int64_t cast_from_unit(object ts, object unit) except? -1
 cpdef int64_t delta_to_nanoseconds(delta) except? -1
 cpdef convert_to_timedelta64(object ts, object unit)

--- a/pandas/_libs/tslibs/timedeltas.pyx
+++ b/pandas/_libs/tslibs/timedeltas.pyx
@@ -1021,6 +1021,8 @@ class Timedelta(_Timedelta):
                 try:
                     value = float(value)
                 except ValueError:
+                    if unit is not None:
+                        raise ValueError("Unit cannot be defined for strings other than pure integer/floats.")
                     value = parse_timedelta_string(value)
                     value = np.timedelta64(value)
                 else:

--- a/pandas/_libs/tslibs/timedeltas.pyx
+++ b/pandas/_libs/tslibs/timedeltas.pyx
@@ -1019,15 +1019,18 @@ class Timedelta(_Timedelta):
                 value = parse_iso_format_string(value)
             else:
                 try:
+                    orig_value = value
                     value = float(value)
                 except ValueError:
                     if unit is not None:
-                        raise ValueError("Unit cannot be defined for strings other than pure integer/floats.")
+                        raise ValueError("Unit cannot be defined for strings other than pure integer/floats."
+                        " Value: {} Unit: {}".format(value, unit))
                     value = parse_timedelta_string(value)
                     value = np.timedelta64(value)
                 else:
                     if unit is None:
-                        raise ValueError("Cannot convert float string without unit.")
+                        raise ValueError("Cannot convert float string without unit."
+                        " Value: {} Type: {}".format(orig_value, type(orig_value)))
                     value = convert_to_timedelta64(value, unit)
         elif PyDelta_Check(value):
             value = convert_to_timedelta64(value, 'ns')

--- a/pandas/_libs/tslibs/timedeltas.pyx
+++ b/pandas/_libs/tslibs/timedeltas.pyx
@@ -969,7 +969,7 @@ class Timedelta(_Timedelta):
     ----------
     value : Timedelta, timedelta, np.timedelta64, string, or integer
     unit : string, {'ns', 'us', 'ms', 's', 'm', 'h', 'D'}, optional
-        Denote the unit of the input, if input is an integer. Default 'ns'.
+        Denote the unit of the input, if input is an integer/float. Default 'ns'.
     days, seconds, microseconds,
     milliseconds, minutes, hours, weeks : numeric, optional
         Values for construction in compat with datetime.timedelta.
@@ -1018,8 +1018,15 @@ class Timedelta(_Timedelta):
             elif len(value) > 0 and value[0] == 'P':
                 value = parse_iso_format_string(value)
             else:
-                value = parse_timedelta_string(value, unit)
-            value = np.timedelta64(value)
+                try:
+                    value = float(value)
+                except ValueError:
+                    value = parse_timedelta_string(value)
+                    value = np.timedelta64(value)
+                else:
+                    if unit is None:
+                        raise ValueError("Cannot convert float string without unit.")
+                    value = convert_to_timedelta64(value, unit)
         elif PyDelta_Check(value):
             value = convert_to_timedelta64(value, 'ns')
         elif is_timedelta64_object(value):

--- a/pandas/_libs/tslibs/timedeltas.pyx
+++ b/pandas/_libs/tslibs/timedeltas.pyx
@@ -1001,7 +1001,6 @@ class Timedelta(_Timedelta):
                                  "[weeks, days, hours, minutes, seconds, "
                                  "milliseconds, microseconds, nanoseconds]")
 
-
         if isinstance(value, Timedelta):
             value = value.value
         elif is_string_object(value):

--- a/pandas/tests/scalar/timedelta/test_construction.py
+++ b/pandas/tests/scalar/timedelta/test_construction.py
@@ -85,10 +85,6 @@ def test_construction():
     with pytest.raises(ValueError):
         Timedelta('10 days -1 h 1.5m 1s 3us')
 
-    # no units specified
-    with pytest.raises(ValueError):
-        Timedelta('3.1415')
-
     # invalid construction
     tm.assert_raises_regex(ValueError, "cannot construct a Timedelta",
                            lambda: Timedelta())
@@ -223,17 +219,14 @@ class not_raises(object):
 @pytest.mark.parametrize("redundant_unit, expectation", [
     ("", not_raises()),
     ("d", pytest.raises(ValueError)),
-    ("us", pytest.raises(ValueError)),
-])
+    ("us", pytest.raises(ValueError))])
 @pytest.mark.parametrize("unit", [
-   "d", "m", "s", "us"
-])
+    "d", "m", "s", "us"])
 @pytest.mark.parametrize("sign", [
-   +1, -1
-])
+    +1, -1])
 @pytest.mark.parametrize("num", [
-    0.001, 1, 10
-])
+    0.001, 1, 10])
 def test_string_with_unit(num, sign, unit, redundant_unit, expectation):
     with expectation:
-        assert Timedelta(str(sign*num)+redundant_unit, unit=unit) == Timedelta(sign*num, unit=unit)
+        assert Timedelta(str(sign * num) + redundant_unit, unit=unit) \
+        == Timedelta(sign * num, unit=unit)

--- a/pandas/tests/scalar/timedelta/test_construction.py
+++ b/pandas/tests/scalar/timedelta/test_construction.py
@@ -223,17 +223,14 @@ class not_raises(object):
 @pytest.mark.parametrize("redundant_unit, expectation", [
     ("", not_raises()),
     ("d", pytest.raises(ValueError)),
-    ("us", pytest.raises(ValueError)),
-])
+    ("us", pytest.raises(ValueError))])
 @pytest.mark.parametrize("unit", [
-   "d", "m", "s", "us"
-])
+   "d", "m", "s", "us"])
 @pytest.mark.parametrize("sign", [
-   +1, -1
-])
+   +1, -1])
 @pytest.mark.parametrize("num", [
-    0.001, 1, 10
-])
+    0.001, 1, 10])
 def test_string_with_unit(num, sign, unit, redundant_unit, expectation):
     with expectation:
-        assert Timedelta(str(sign*num)+redundant_unit, unit=unit) == Timedelta(sign*num, unit=unit)
+        assert Timedelta(str(sign * num) + redundant_unit, unit=unit) \
+               == Timedelta(sign * num, unit=unit)

--- a/pandas/tests/scalar/timedelta/test_construction.py
+++ b/pandas/tests/scalar/timedelta/test_construction.py
@@ -8,6 +8,12 @@ import pandas as pd
 import pandas.util.testing as tm
 from pandas import Timedelta
 
+import sys
+if sys.version_info >= (3, 3):
+    from contextlib import ExitStack as do_not_raise
+else:
+    from contextlib2 import ExitStack as do_not_raise
+
 
 def test_construction():
     expected = np.timedelta64(10, 'D').astype('m8[ns]').view('i8')
@@ -212,16 +218,8 @@ def test_td_constructor_value_error():
         Timedelta(nanoseconds='abc')
 
 
-class not_raises(object):
-    def __enter__(self):
-        pass
-
-    def __exit__(self, exc_type, exc_val, exc_tb):
-        pass
-
-
 @pytest.mark.parametrize("redundant_unit, expectation", [
-    ("", not_raises()),
+    ("", do_not_raise()),
     ("d", pytest.raises(ValueError)),
     ("us", pytest.raises(ValueError))])
 @pytest.mark.parametrize("unit", [

--- a/pandas/tests/scalar/timedelta/test_construction.py
+++ b/pandas/tests/scalar/timedelta/test_construction.py
@@ -228,5 +228,6 @@ class not_raises(object):
     0.001, 1, 10])
 def test_string_with_unit(num, sign, unit, redundant_unit, expectation):
     with expectation:
-        assert Timedelta(str(sign * num) + redundant_unit, unit=unit)\
-            == Timedelta(sign * num, unit=unit)
+        val = sign * num
+        val_str = str(val) + redundant_unit
+        assert Timedelta(val_str, unit=unit) == Timedelta(val, unit=unit)

--- a/pandas/tests/scalar/timedelta/test_construction.py
+++ b/pandas/tests/scalar/timedelta/test_construction.py
@@ -212,17 +212,13 @@ def test_td_constructor_value_error():
         Timedelta(nanoseconds='abc')
 
 
-@pytest.mark.parametrize("redundant_unit, expectation", [
-    ("", tm.do_not_raise),
-    ("d", pytest.raises(ValueError)),
-    ("us", pytest.raises(ValueError))])
-@pytest.mark.parametrize("unit", [
-    "d", "m", "s", "us"])
-@pytest.mark.parametrize("sign", [
-    +1, -1])
-@pytest.mark.parametrize("num", [
-    0.001, 1, 10])
-def test_string_with_unit(num, sign, unit, redundant_unit, expectation):
+@pytest.mark.parametrize("str_unit, unit, expectation", [
+    ("", "s", tm.do_not_raise),
+    ("s", "s", pytest.raises(ValueError)),
+    ("", None, pytest.raises(ValueError)),
+    ("s", "d", pytest.raises(ValueError)),])
+def test_string_with_unit(str_unit, unit, expectation):
     with expectation:
-        assert Timedelta(str(sign * num) + redundant_unit, unit=unit) \
-        == Timedelta(sign * num, unit=unit)
+        val_str = "10{}".format(str_unit)
+        assert Timedelta(val_str, unit=unit) == Timedelta(10, unit=unit)
+        assert pd.to_timedelta(val_str, unit=unit) == Timedelta(10, unit=unit)

--- a/pandas/tests/scalar/timedelta/test_construction.py
+++ b/pandas/tests/scalar/timedelta/test_construction.py
@@ -85,10 +85,6 @@ def test_construction():
     with pytest.raises(ValueError):
         Timedelta('10 days -1 h 1.5m 1s 3us')
 
-    # no units specified
-    with pytest.raises(ValueError):
-        Timedelta('3.1415')
-
     # invalid construction
     tm.assert_raises_regex(ValueError, "cannot construct a Timedelta",
                            lambda: Timedelta())
@@ -225,12 +221,12 @@ class not_raises(object):
     ("d", pytest.raises(ValueError)),
     ("us", pytest.raises(ValueError))])
 @pytest.mark.parametrize("unit", [
-   "d", "m", "s", "us"])
+    "d", "m", "s", "us"])
 @pytest.mark.parametrize("sign", [
-   +1, -1])
+    +1, -1])
 @pytest.mark.parametrize("num", [
     0.001, 1, 10])
 def test_string_with_unit(num, sign, unit, redundant_unit, expectation):
     with expectation:
         assert Timedelta(str(sign * num) + redundant_unit, unit=unit) \
-               == Timedelta(sign * num, unit=unit)
+        == Timedelta(sign * num, unit=unit)

--- a/pandas/tests/scalar/timedelta/test_construction.py
+++ b/pandas/tests/scalar/timedelta/test_construction.py
@@ -8,12 +8,6 @@ import pandas as pd
 import pandas.util.testing as tm
 from pandas import Timedelta
 
-import sys
-if sys.version_info >= (3, 3):
-    from contextlib import ExitStack as do_not_raise
-else:
-    from contextlib2 import ExitStack as do_not_raise
-
 
 def test_construction():
     expected = np.timedelta64(10, 'D').astype('m8[ns]').view('i8')
@@ -219,7 +213,7 @@ def test_td_constructor_value_error():
 
 
 @pytest.mark.parametrize("redundant_unit, expectation", [
-    ("", do_not_raise()),
+    ("", tm.do_not_raise),
     ("d", pytest.raises(ValueError)),
     ("us", pytest.raises(ValueError))])
 @pytest.mark.parametrize("unit", [

--- a/pandas/tests/scalar/timedelta/test_construction.py
+++ b/pandas/tests/scalar/timedelta/test_construction.py
@@ -210,3 +210,30 @@ def test_td_constructor_on_nanoseconds(constructed_td, conversion):
 def test_td_constructor_value_error():
     with pytest.raises(TypeError):
         Timedelta(nanoseconds='abc')
+
+
+class not_raises(object):
+    def __enter__(self):
+        pass
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        pass
+
+
+@pytest.mark.parametrize("redundant_unit, expectation", [
+    ("", not_raises()),
+    ("d", pytest.raises(ValueError)),
+    ("us", pytest.raises(ValueError)),
+])
+@pytest.mark.parametrize("unit", [
+   "d", "m", "s", "us"
+])
+@pytest.mark.parametrize("sign", [
+   +1, -1
+])
+@pytest.mark.parametrize("num", [
+    0.001, 1, 10
+])
+def test_string_with_unit(num, sign, unit, redundant_unit, expectation):
+    with expectation:
+        assert Timedelta(str(sign*num)+redundant_unit, unit=unit) == Timedelta(sign*num, unit=unit)

--- a/pandas/tests/scalar/timedelta/test_construction.py
+++ b/pandas/tests/scalar/timedelta/test_construction.py
@@ -85,6 +85,10 @@ def test_construction():
     with pytest.raises(ValueError):
         Timedelta('10 days -1 h 1.5m 1s 3us')
 
+    # no units specified
+    with pytest.raises(ValueError):
+        Timedelta('3.1415')
+
     # invalid construction
     tm.assert_raises_regex(ValueError, "cannot construct a Timedelta",
                            lambda: Timedelta())
@@ -219,15 +223,17 @@ class not_raises(object):
 @pytest.mark.parametrize("redundant_unit, expectation", [
     ("", not_raises()),
     ("d", pytest.raises(ValueError)),
-    ("us", pytest.raises(ValueError))])
+    ("us", pytest.raises(ValueError)),
+])
 @pytest.mark.parametrize("unit", [
-    "d", "m", "s", "us"])
+   "d", "m", "s", "us"
+])
 @pytest.mark.parametrize("sign", [
-    +1, -1])
+   +1, -1
+])
 @pytest.mark.parametrize("num", [
-    0.001, 1, 10])
+    0.001, 1, 10
+])
 def test_string_with_unit(num, sign, unit, redundant_unit, expectation):
     with expectation:
-        val = sign * num
-        val_str = str(val) + redundant_unit
-        assert Timedelta(val_str, unit=unit) == Timedelta(val, unit=unit)
+        assert Timedelta(str(sign*num)+redundant_unit, unit=unit) == Timedelta(sign*num, unit=unit)

--- a/pandas/tests/scalar/timedelta/test_construction.py
+++ b/pandas/tests/scalar/timedelta/test_construction.py
@@ -89,6 +89,9 @@ def test_construction():
     with pytest.raises(ValueError):
         Timedelta('3.1415')
 
+    with pytest.raises(ValueError):
+        Timedelta('2000')
+
     # invalid construction
     tm.assert_raises_regex(ValueError, "cannot construct a Timedelta",
                            lambda: Timedelta())
@@ -213,10 +216,11 @@ def test_td_constructor_value_error():
 
 
 @pytest.mark.parametrize("str_unit, unit, expectation", [
-    ("", "s", tm.do_not_raise),
-    ("s", "s", pytest.raises(ValueError)),
-    ("", None, pytest.raises(ValueError)),
-    ("s", "d", pytest.raises(ValueError)),])
+    ("", "s", tm.do_not_raise),              # Expected case
+    ("s", "s", pytest.raises(ValueError)),   # Units doubly defined
+    ("s", "d", pytest.raises(ValueError)),
+    ("", None, pytest.raises(ValueError)),   # No units
+])
 def test_string_with_unit(str_unit, unit, expectation):
     with expectation:
         val_str = "10{}".format(str_unit)

--- a/pandas/tests/scalar/timedelta/test_construction.py
+++ b/pandas/tests/scalar/timedelta/test_construction.py
@@ -228,5 +228,5 @@ class not_raises(object):
     0.001, 1, 10])
 def test_string_with_unit(num, sign, unit, redundant_unit, expectation):
     with expectation:
-        assert Timedelta(str(sign * num) + redundant_unit, unit=unit) \
-        == Timedelta(sign * num, unit=unit)
+        assert Timedelta(str(sign * num) + redundant_unit, unit=unit)\
+            == Timedelta(sign * num, unit=unit)

--- a/pandas/tests/scalar/timedelta/test_construction.py
+++ b/pandas/tests/scalar/timedelta/test_construction.py
@@ -85,6 +85,10 @@ def test_construction():
     with pytest.raises(ValueError):
         Timedelta('10 days -1 h 1.5m 1s 3us')
 
+    # no units specified
+    with pytest.raises(ValueError):
+        Timedelta('3.1415')
+
     # invalid construction
     tm.assert_raises_regex(ValueError, "cannot construct a Timedelta",
                            lambda: Timedelta())

--- a/pandas/util/testing.py
+++ b/pandas/util/testing.py
@@ -48,6 +48,14 @@ from pandas import (bdate_range, CategoricalIndex, Categorical, IntervalIndex,
 from pandas._libs import testing as _testing
 from pandas.io.common import urlopen
 
+if sys.version_info >= (3, 3):
+    from contextlib import ExitStack as nullcontext
+else:
+    from contextlib2 import ExitStack as nullcontext
+
+
+do_not_raise = nullcontext()
+
 
 N = 30
 K = 4

--- a/pandas/util/testing.py
+++ b/pandas/util/testing.py
@@ -48,13 +48,17 @@ from pandas import (bdate_range, CategoricalIndex, Categorical, IntervalIndex,
 from pandas._libs import testing as _testing
 from pandas.io.common import urlopen
 
-if sys.version_info >= (3, 3):
-    from contextlib import ExitStack as nullcontext
-else:
-    from contextlib2 import ExitStack as nullcontext
+
+class NullContextManager(object):
+    def __init__(self, dummy_resource=None):
+        self.dummy_resource = dummy_resource
+    def __enter__(self):
+        return self.dummy_resource
+    def __exit__(self, *args):
+        pass
 
 
-do_not_raise = nullcontext()
+do_not_raise = NullContextManager()
 
 
 N = 30


### PR DESCRIPTION
I couldn't get tests to run on my machine so I will see if it passes on the CI servers.

- [x] closes #12136
- [ ] tests added / passed
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry
