### PR TITLE
DOC: Whatsnew for string coercion fix [ci skip]

### DIFF
--- a/doc/source/whatsnew/v0.23.1.txt
+++ b/doc/source/whatsnew/v0.23.1.txt
@@ -100,6 +100,8 @@ Bug Fixes
 - Bug in :meth:`Series.str.replace()` where the method throws `TypeError` on Python 3.5.2 (:issue: `21078`)
 - Bug in :class:`Timedelta`: where passing a float with a unit would prematurely round the float precision (:issue: `14156`)
 - Bug in :func:`pandas.testing.assert_index_equal` which raised ``AssertionError`` incorrectly, when comparing two :class:`CategoricalIndex` objects with param ``check_categorical=False`` (:issue:`19776`)
+- Bug in :class:`DataFrame` and :class:`Series` constructors not coercing values to strings when ``dtype=str`` is passed (:issue:`21083`)
+
 
 **Sparse**
 


### PR DESCRIPTION
xref https://github.com/pandas-dev/pandas/pull/21366/files/a94d3995160a07a09693a883ceb0641e82ca7bdd#r194103331

That PR had
tests (https://github.com/pandas-dev/pandas/pull/21366/files/a94d3995160a07a09693a883ceb0641e82ca7bdd#diff-10e7ab03eb0363417c9b042860d3ba73R814)
but no release note for this specifically, since I didn't know it was a bug.

[ci skip]