### PR TITLE
DOC: Loading sphinxcontrib.spelling to sphinx only if it's available (#21396)

### DIFF
--- a/ci/environment-dev.yaml
+++ b/ci/environment-dev.yaml
@@ -13,3 +13,4 @@ dependencies:
   - pytz
   - setuptools>=24.2.0
   - sphinx
+  - sphinxcontrib-spelling

--- a/ci/requirements_dev.txt
+++ b/ci/requirements_dev.txt
@@ -9,3 +9,4 @@ python-dateutil>=2.5.0
 pytz
 setuptools>=24.2.0
 sphinx
+sphinxcontrib-spelling

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -16,9 +16,11 @@ import os
 import re
 import inspect
 import importlib
-from sphinx.ext.autosummary import _import_by_name
+import logging
 import warnings
+from sphinx.ext.autosummary import _import_by_name
 
+logger = logging.getLogger(__name__)
 
 try:
     raw_input          # Python 2
@@ -73,8 +75,15 @@ extensions = ['sphinx.ext.autodoc',
               'sphinx.ext.ifconfig',
               'sphinx.ext.linkcode',
               'nbsphinx',
-              'sphinxcontrib.spelling'
               ]
+
+try:
+    import sphinxcontrib.spelling
+except ImportError as err:
+    logger.warn(('sphinxcontrib.spelling failed to import with error "{}". '
+                '`spellcheck` command is not available.'.format(err)))
+else:
+    extensions.append('sphinxcontrib.spelling')
 
 exclude_patterns = ['**.ipynb_checkpoints']
 


### PR DESCRIPTION
- [X] closes #21396
- [ ] tests added / passed
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

I think the optional dependencies go directly into the `.txt` files for pip and conda, and not into the yaml file. Please correct me if I'm wrong.

Seems like besides `sphinxcontrib-spelling`, a binary program `enchant` is required, and it's not available in conda for what I've seen. Not sure what's the right approach for it.