### PR TITLE
BUG to_clipboard passes the wrong sep to to_csv

### DIFF
--- a/doc/source/whatsnew/v0.24.0.txt
+++ b/doc/source/whatsnew/v0.24.0.txt
@@ -147,7 +147,7 @@ MultiIndex
 I/O
 ^^^
 
--
+- Bug in :func:`to_clipboard` which passes r'\t' instead of '\t' to to_csv (:issue:`21385`)
 -
 -
 

--- a/pandas/io/clipboards.py
+++ b/pandas/io/clipboards.py
@@ -99,7 +99,7 @@ def to_clipboard(obj, excel=True, sep=None, **kwargs):  # pragma: no cover
     if excel:
         try:
             if sep is None:
-                sep = r'\t'
+                sep = '\t'
             buf = StringIO()
             # clipboard_set (pyperclip) expects unicode
             obj.to_csv(buf, sep=sep, encoding='utf-8', **kwargs)


### PR DESCRIPTION
Originally, the sep is `\t` as to_csv expects. A commit changes the sep to `r'\t',` causing an exception (because `csv.writer` expects the delimiter to be a one-character string). The exception is suppressed (with `pass` in the `except` block), causing the data frame to be passed to `to_string` downstream (even though it should be handled by `to_csv`)

Changing `r't'` back to `\t` is a quick fix, but just `pass` in the `except` block seems like the more problematic root cause (that I'm not handling here). 

- [x ] closes #21385
- [ ] tests added / passed
- [x ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x ] whatsnew entry
