### PR TITLE
parametrize tests, unify repeated tests

### DIFF
--- a/pandas/tests/tseries/offsets/test_offsets.py
+++ b/pandas/tests/tseries/offsets/test_offsets.py
@@ -159,18 +159,23 @@ class Base(object):
         assert offset1 == offset2
 
     def test_rsub(self):
-        if self._offset is None:
-            # i.e. skip for TestCommon
+        if self._offset is None or not hasattr(self, "offset2"):
+            # i.e. skip for TestCommon and YQM subclasses that do not have
+            # offset2 attr
             return
         assert self.d - self.offset2 == (-self.offset2).apply(self.d)
 
     def test_radd(self):
-        if self._offset is None:
+        if self._offset is None or not hasattr(self, "offset2"):
+            # i.e. skip for TestCommon and YQM subclasses that do not have
+            # offset2 attr
             return
         assert self.d + self.offset2 == self.offset2 + self.d
 
     def test_sub(self):
-        if self._offset is None:
+        if self._offset is None or not hasattr(self, "offset2"):
+            # i.e. skip for TestCommon and YQM subclasses that do not have
+            # offset2 attr
             return
         off = self.offset2
         with pytest.raises(Exception):
@@ -181,7 +186,9 @@ class Base(object):
         assert self.d - self.offset2 == self.d - (2 * off - off)
 
     def testMult1(self):
-        if self._offset is None:
+        if self._offset is None or not hasattr(self, "offset1"):
+            # i.e. skip for TestCommon and YQM subclasses that do not have
+            # offset1 attr
             return
         assert self.d + 10 * self.offset1 == self.d + self._offset(10)
         assert self.d + 5 * self.offset1 == self.d + self._offset(5)

--- a/pandas/tests/tseries/offsets/test_offsets.py
+++ b/pandas/tests/tseries/offsets/test_offsets.py
@@ -41,12 +41,6 @@ from pandas.tseries.holiday import USFederalHolidayCalendar
 from .common import assert_offset_equal, assert_onOffset
 
 
-def test_monthrange():
-    import calendar
-    for y in range(2000, 2013):
-        for m in range(1, 13):
-            assert tslib.monthrange(y, m) == calendar.monthrange(y, m)
-
 ####
 # Misc function tests
 ####
@@ -147,6 +141,50 @@ class Base(object):
             # we are creating an invalid offset
             # so ignore
             pass
+
+    def test_offsets_compare_equal(self):
+        # root cause of GH#456
+        if self._offset is None:
+            return
+        offset1 = self._offset()
+        offset2 = self._offset()
+        assert not offset1 != offset2
+        assert offset1 == offset2
+
+    def test_rsub(self):
+        if self._offset is None or not hasattr(self, 'd'):
+            # TODO: define `d` for classes where it is missing?
+            return
+        assert self.d - self.offset2 == (-self.offset2).apply(self.d)
+
+    def test_radd(self):
+        if self._offset is None or not hasattr(self, 'd'):
+            # TODO: define `d` for classes where it is missing?
+            return
+        assert self.d + self.offset2 == self.offset2 + self.d
+
+    def test_sub(self):
+        if self._offset is None or not hasattr(self, 'd'):
+            return
+        off = self.offset2
+        with pytest.raises(Exception):
+            off - self.d
+
+        assert 2 * off - off == off
+        assert self.d - self.offset2 == self.d + self._offset(-2)
+        assert self.d - self.offset2 == self.d - (2 * off - off)
+
+    def testMult1(self):
+        if self._offset is None or not hasattr(self, 'd'):
+            return
+        assert self.d + 10 * self.offset1 == self.d + self._offset(10)
+        assert self.d + 5 * self.offset1 == self.d + self._offset(5)
+
+    def testMult2(self):
+        if self._offset is None or not hasattr(self, 'd'):
+            return
+        assert self.d + (-5 * self._offset(-10)) == self.d + self._offset(50)
+        assert self.d + (-3 * self._offset(-2)) == self.d + self._offset(6)
 
 
 class TestCommon(Base):
@@ -515,6 +553,7 @@ class TestBusinessDay(Base):
         self.d = datetime(2008, 1, 1)
 
         self.offset = BDay()
+        self.offset1 = self.offset
         self.offset2 = BDay(2)
 
     def test_different_normalize_equals(self):
@@ -536,7 +575,7 @@ class TestBusinessDay(Base):
 
         assert (self.d + offset) == datetime(2008, 1, 2, 2)
 
-    def testEQ(self):
+    def test_eq(self):
         assert self.offset2 == self.offset2
 
     def test_mul(self):
@@ -545,27 +584,8 @@ class TestBusinessDay(Base):
     def test_hash(self):
         assert hash(self.offset2) == hash(self.offset2)
 
-    def testCall(self):
+    def test_call(self):
         assert self.offset2(self.d) == datetime(2008, 1, 3)
-
-    def testRAdd(self):
-        assert self.d + self.offset2 == self.offset2 + self.d
-
-    def testSub(self):
-        off = self.offset2
-        pytest.raises(Exception, off.__sub__, self.d)
-        assert 2 * off - off == off
-
-        assert self.d - self.offset2 == self.d + BDay(-2)
-
-    def testRSub(self):
-        assert self.d - self.offset2 == (-self.offset2).apply(self.d)
-
-    def testMult1(self):
-        assert self.d + 10 * self.offset == self.d + BDay(10)
-
-    def testMult2(self):
-        assert self.d + (-5 * BDay(-10)) == self.d + BDay(50)
 
     def testRollback1(self):
         assert BDay(10).rollback(self.d) == self.d
@@ -678,12 +698,6 @@ class TestBusinessDay(Base):
     def test_apply_corner(self):
         pytest.raises(TypeError, BDay().apply, BMonthEnd())
 
-    def test_offsets_compare_equal(self):
-        # root cause of #456
-        offset1 = BDay()
-        offset2 = BDay()
-        assert not offset1 != offset2
-
 
 class TestBusinessHour(Base):
     _offset = BusinessHour
@@ -735,7 +749,7 @@ class TestBusinessHour(Base):
         assert self.d + BusinessHour() * 3 == expected
         assert self.d + BusinessHour(n=3) == expected
 
-    def testEQ(self):
+    def test_eq(self):
         for offset in [self.offset1, self.offset2, self.offset3, self.offset4]:
             assert offset == offset
 
@@ -749,30 +763,21 @@ class TestBusinessHour(Base):
         for offset in [self.offset1, self.offset2, self.offset3, self.offset4]:
             assert hash(offset) == hash(offset)
 
-    def testCall(self):
+    def test_call(self):
         assert self.offset1(self.d) == datetime(2014, 7, 1, 11)
         assert self.offset2(self.d) == datetime(2014, 7, 1, 13)
         assert self.offset3(self.d) == datetime(2014, 6, 30, 17)
         assert self.offset4(self.d) == datetime(2014, 6, 30, 14)
 
-    def testRAdd(self):
-        assert self.d + self.offset2 == self.offset2 + self.d
-
-    def testSub(self):
+    def test_sub(self):
+        # we have to override test_sub here becasue self.offset2 is not
+        # defined as self._offset(2)
         off = self.offset2
-        pytest.raises(Exception, off.__sub__, self.d)
+        with pytest.raises(Exception):
+            off - self.d
         assert 2 * off - off == off
 
         assert self.d - self.offset2 == self.d + self._offset(-3)
-
-    def testRSub(self):
-        assert self.d - self.offset2 == (-self.offset2).apply(self.d)
-
-    def testMult1(self):
-        assert self.d + 5 * self.offset1 == self.d + self._offset(5)
-
-    def testMult2(self):
-        assert self.d + (-3 * self._offset(-2)) == self.d + self._offset(6)
 
     def testRollback1(self):
         assert self.offset1.rollback(self.d) == self.d
@@ -1323,12 +1328,6 @@ class TestBusinessHour(Base):
             for base, expected in compat.iteritems(cases):
                 assert_offset_equal(offset, base, expected)
 
-    def test_offsets_compare_equal(self):
-        # root cause of #456
-        offset1 = self._offset()
-        offset2 = self._offset()
-        assert not offset1 != offset2
-
     def test_datetimeindex(self):
         idx1 = DatetimeIndex(start='2014-07-04 15:00', end='2014-07-08 10:00',
                              freq='BH')
@@ -1367,6 +1366,8 @@ class TestBusinessHour(Base):
 
 class TestCustomBusinessHour(Base):
     _offset = CustomBusinessHour
+    holidays = ['2014-06-27', datetime(2014, 6, 30),
+                np.datetime64('2014-07-02')]
 
     def setup_method(self, method):
         # 2014 Calendar to check custom holidays
@@ -1377,8 +1378,6 @@ class TestCustomBusinessHour(Base):
         self.d = datetime(2014, 7, 1, 10, 00)
         self.offset1 = CustomBusinessHour(weekmask='Tue Wed Thu Fri')
 
-        self.holidays = ['2014-06-27', datetime(2014, 6, 30),
-                         np.datetime64('2014-07-02')]
         self.offset2 = CustomBusinessHour(holidays=self.holidays)
 
     def test_constructor_errors(self):
@@ -1407,7 +1406,7 @@ class TestCustomBusinessHour(Base):
         assert self.d + CustomBusinessHour() * 3 == expected
         assert self.d + CustomBusinessHour(n=3) == expected
 
-    def testEQ(self):
+    def test_eq(self):
         for offset in [self.offset1, self.offset2]:
             assert offset == offset
 
@@ -1424,32 +1423,17 @@ class TestCustomBusinessHour(Base):
         assert (CustomBusinessHour(holidays=['2014-06-27']) !=
                 CustomBusinessHour(holidays=['2014-06-28']))
 
+    def test_sub(self):
+        # override Base implementation
+        pass
+
     def test_hash(self):
         assert hash(self.offset1) == hash(self.offset1)
         assert hash(self.offset2) == hash(self.offset2)
 
-    def testCall(self):
+    def test_call(self):
         assert self.offset1(self.d) == datetime(2014, 7, 1, 11)
         assert self.offset2(self.d) == datetime(2014, 7, 1, 11)
-
-    def testRAdd(self):
-        assert self.d + self.offset2 == self.offset2 + self.d
-
-    def testSub(self):
-        off = self.offset2
-        pytest.raises(Exception, off.__sub__, self.d)
-        assert 2 * off - off == off
-
-        assert self.d - self.offset2 == self.d - (2 * off - off)
-
-    def testRSub(self):
-        assert self.d - self.offset2 == (-self.offset2).apply(self.d)
-
-    def testMult1(self):
-        assert self.d + 5 * self.offset1 == self.d + self._offset(5)
-
-    def testMult2(self):
-        assert self.d + (-3 * self._offset(-2)) == self.d + self._offset(6)
 
     def testRollback1(self):
         assert self.offset1.rollback(self.d) == self.d
@@ -1490,49 +1474,51 @@ class TestCustomBusinessHour(Base):
         result = offset.rollforward(dt)
         assert result == datetime(2014, 7, 7, 9)
 
-    def test_normalize(self):
-        tests = []
+    normalize_cases = []
+    normalize_cases.append((
+        CustomBusinessHour(normalize=True, holidays=holidays),
+        {datetime(2014, 7, 1, 8): datetime(2014, 7, 1),
+         datetime(2014, 7, 1, 17): datetime(2014, 7, 3),
+         datetime(2014, 7, 1, 16): datetime(2014, 7, 3),
+         datetime(2014, 7, 1, 23): datetime(2014, 7, 3),
+         datetime(2014, 7, 1, 0): datetime(2014, 7, 1),
+         datetime(2014, 7, 4, 15): datetime(2014, 7, 4),
+         datetime(2014, 7, 4, 15, 59): datetime(2014, 7, 4),
+         datetime(2014, 7, 4, 16, 30): datetime(2014, 7, 7),
+         datetime(2014, 7, 5, 23): datetime(2014, 7, 7),
+         datetime(2014, 7, 6, 10): datetime(2014, 7, 7)}))
 
-        tests.append((CustomBusinessHour(normalize=True,
-                                         holidays=self.holidays),
-                      {datetime(2014, 7, 1, 8): datetime(2014, 7, 1),
-                       datetime(2014, 7, 1, 17): datetime(2014, 7, 3),
-                       datetime(2014, 7, 1, 16): datetime(2014, 7, 3),
-                       datetime(2014, 7, 1, 23): datetime(2014, 7, 3),
-                       datetime(2014, 7, 1, 0): datetime(2014, 7, 1),
-                       datetime(2014, 7, 4, 15): datetime(2014, 7, 4),
-                       datetime(2014, 7, 4, 15, 59): datetime(2014, 7, 4),
-                       datetime(2014, 7, 4, 16, 30): datetime(2014, 7, 7),
-                       datetime(2014, 7, 5, 23): datetime(2014, 7, 7),
-                       datetime(2014, 7, 6, 10): datetime(2014, 7, 7)}))
+    normalize_cases.append((
+        CustomBusinessHour(-1, normalize=True, holidays=holidays),
+        {datetime(2014, 7, 1, 8): datetime(2014, 6, 26),
+         datetime(2014, 7, 1, 17): datetime(2014, 7, 1),
+         datetime(2014, 7, 1, 16): datetime(2014, 7, 1),
+         datetime(2014, 7, 1, 10): datetime(2014, 6, 26),
+         datetime(2014, 7, 1, 0): datetime(2014, 6, 26),
+         datetime(2014, 7, 7, 10): datetime(2014, 7, 4),
+         datetime(2014, 7, 7, 10, 1): datetime(2014, 7, 7),
+         datetime(2014, 7, 5, 23): datetime(2014, 7, 4),
+         datetime(2014, 7, 6, 10): datetime(2014, 7, 4)}))
 
-        tests.append((CustomBusinessHour(-1, normalize=True,
-                                         holidays=self.holidays),
-                      {datetime(2014, 7, 1, 8): datetime(2014, 6, 26),
-                       datetime(2014, 7, 1, 17): datetime(2014, 7, 1),
-                       datetime(2014, 7, 1, 16): datetime(2014, 7, 1),
-                       datetime(2014, 7, 1, 10): datetime(2014, 6, 26),
-                       datetime(2014, 7, 1, 0): datetime(2014, 6, 26),
-                       datetime(2014, 7, 7, 10): datetime(2014, 7, 4),
-                       datetime(2014, 7, 7, 10, 1): datetime(2014, 7, 7),
-                       datetime(2014, 7, 5, 23): datetime(2014, 7, 4),
-                       datetime(2014, 7, 6, 10): datetime(2014, 7, 4)}))
+    normalize_cases.append((
+        CustomBusinessHour(1, normalize=True,
+                           start='17:00', end='04:00',
+                           holidays=holidays),
+        {datetime(2014, 7, 1, 8): datetime(2014, 7, 1),
+         datetime(2014, 7, 1, 17): datetime(2014, 7, 1),
+         datetime(2014, 7, 1, 23): datetime(2014, 7, 2),
+         datetime(2014, 7, 2, 2): datetime(2014, 7, 2),
+         datetime(2014, 7, 2, 3): datetime(2014, 7, 3),
+         datetime(2014, 7, 4, 23): datetime(2014, 7, 5),
+         datetime(2014, 7, 5, 2): datetime(2014, 7, 5),
+         datetime(2014, 7, 7, 2): datetime(2014, 7, 7),
+         datetime(2014, 7, 7, 17): datetime(2014, 7, 7)}))
 
-        tests.append((CustomBusinessHour(1, normalize=True, start='17:00',
-                                         end='04:00', holidays=self.holidays),
-                      {datetime(2014, 7, 1, 8): datetime(2014, 7, 1),
-                       datetime(2014, 7, 1, 17): datetime(2014, 7, 1),
-                       datetime(2014, 7, 1, 23): datetime(2014, 7, 2),
-                       datetime(2014, 7, 2, 2): datetime(2014, 7, 2),
-                       datetime(2014, 7, 2, 3): datetime(2014, 7, 3),
-                       datetime(2014, 7, 4, 23): datetime(2014, 7, 5),
-                       datetime(2014, 7, 5, 2): datetime(2014, 7, 5),
-                       datetime(2014, 7, 7, 2): datetime(2014, 7, 7),
-                       datetime(2014, 7, 7, 17): datetime(2014, 7, 7)}))
-
-        for offset, cases in tests:
-            for dt, expected in compat.iteritems(cases):
-                assert offset.apply(dt) == expected
+    @pytest.mark.parametrize('norm_cases', normalize_cases)
+    def test_normalize(self, norm_cases):
+        offset, cases = norm_cases
+        for dt, expected in compat.iteritems(cases):
+            assert offset.apply(dt) == expected
 
     def test_onOffset(self):
         tests = []
@@ -1550,75 +1536,75 @@ class TestCustomBusinessHour(Base):
             for dt, expected in compat.iteritems(cases):
                 assert offset.onOffset(dt) == expected
 
-    def test_apply(self):
-        tests = []
+    apply_cases = []
+    apply_cases.append((
+        CustomBusinessHour(holidays=holidays),
+        {datetime(2014, 7, 1, 11): datetime(2014, 7, 1, 12),
+         datetime(2014, 7, 1, 13): datetime(2014, 7, 1, 14),
+         datetime(2014, 7, 1, 15): datetime(2014, 7, 1, 16),
+         datetime(2014, 7, 1, 19): datetime(2014, 7, 3, 10),
+         datetime(2014, 7, 1, 16): datetime(2014, 7, 3, 9),
+         datetime(2014, 7, 1, 16, 30, 15): datetime(2014, 7, 3, 9, 30, 15),
+         datetime(2014, 7, 1, 17): datetime(2014, 7, 3, 10),
+         datetime(2014, 7, 2, 11): datetime(2014, 7, 3, 10),
+         # out of business hours
+         datetime(2014, 7, 2, 8): datetime(2014, 7, 3, 10),
+         datetime(2014, 7, 2, 19): datetime(2014, 7, 3, 10),
+         datetime(2014, 7, 2, 23): datetime(2014, 7, 3, 10),
+         datetime(2014, 7, 3, 0): datetime(2014, 7, 3, 10),
+         # saturday
+         datetime(2014, 7, 5, 15): datetime(2014, 7, 7, 10),
+         datetime(2014, 7, 4, 17): datetime(2014, 7, 7, 10),
+         datetime(2014, 7, 4, 16, 30): datetime(2014, 7, 7, 9, 30),
+         datetime(2014, 7, 4, 16, 30, 30): datetime(2014, 7, 7, 9, 30, 30)}))
 
-        tests.append((
-            CustomBusinessHour(holidays=self.holidays),
-            {datetime(2014, 7, 1, 11): datetime(2014, 7, 1, 12),
-             datetime(2014, 7, 1, 13): datetime(2014, 7, 1, 14),
-             datetime(2014, 7, 1, 15): datetime(2014, 7, 1, 16),
-             datetime(2014, 7, 1, 19): datetime(2014, 7, 3, 10),
-             datetime(2014, 7, 1, 16): datetime(2014, 7, 3, 9),
-             datetime(2014, 7, 1, 16, 30, 15): datetime(2014, 7, 3, 9, 30, 15),
-             datetime(2014, 7, 1, 17): datetime(2014, 7, 3, 10),
-             datetime(2014, 7, 2, 11): datetime(2014, 7, 3, 10),
-             # out of business hours
-             datetime(2014, 7, 2, 8): datetime(2014, 7, 3, 10),
-             datetime(2014, 7, 2, 19): datetime(2014, 7, 3, 10),
-             datetime(2014, 7, 2, 23): datetime(2014, 7, 3, 10),
-             datetime(2014, 7, 3, 0): datetime(2014, 7, 3, 10),
-             # saturday
-             datetime(2014, 7, 5, 15): datetime(2014, 7, 7, 10),
-             datetime(2014, 7, 4, 17): datetime(2014, 7, 7, 10),
-             datetime(2014, 7, 4, 16, 30): datetime(2014, 7, 7, 9, 30),
-             datetime(2014, 7, 4, 16, 30, 30): datetime(2014, 7, 7, 9, 30,
-                                                        30)}))
+    apply_cases.append((
+        CustomBusinessHour(4, holidays=holidays),
+        {datetime(2014, 7, 1, 11): datetime(2014, 7, 1, 15),
+         datetime(2014, 7, 1, 13): datetime(2014, 7, 3, 9),
+         datetime(2014, 7, 1, 15): datetime(2014, 7, 3, 11),
+         datetime(2014, 7, 1, 16): datetime(2014, 7, 3, 12),
+         datetime(2014, 7, 1, 17): datetime(2014, 7, 3, 13),
+         datetime(2014, 7, 2, 11): datetime(2014, 7, 3, 13),
+         datetime(2014, 7, 2, 8): datetime(2014, 7, 3, 13),
+         datetime(2014, 7, 2, 19): datetime(2014, 7, 3, 13),
+         datetime(2014, 7, 2, 23): datetime(2014, 7, 3, 13),
+         datetime(2014, 7, 3, 0): datetime(2014, 7, 3, 13),
+         datetime(2014, 7, 5, 15): datetime(2014, 7, 7, 13),
+         datetime(2014, 7, 4, 17): datetime(2014, 7, 7, 13),
+         datetime(2014, 7, 4, 16, 30): datetime(2014, 7, 7, 12, 30),
+         datetime(2014, 7, 4, 16, 30, 30): datetime(2014, 7, 7, 12, 30, 30)}))
 
-        tests.append((
-            CustomBusinessHour(4, holidays=self.holidays),
-            {datetime(2014, 7, 1, 11): datetime(2014, 7, 1, 15),
-             datetime(2014, 7, 1, 13): datetime(2014, 7, 3, 9),
-             datetime(2014, 7, 1, 15): datetime(2014, 7, 3, 11),
-             datetime(2014, 7, 1, 16): datetime(2014, 7, 3, 12),
-             datetime(2014, 7, 1, 17): datetime(2014, 7, 3, 13),
-             datetime(2014, 7, 2, 11): datetime(2014, 7, 3, 13),
-             datetime(2014, 7, 2, 8): datetime(2014, 7, 3, 13),
-             datetime(2014, 7, 2, 19): datetime(2014, 7, 3, 13),
-             datetime(2014, 7, 2, 23): datetime(2014, 7, 3, 13),
-             datetime(2014, 7, 3, 0): datetime(2014, 7, 3, 13),
-             datetime(2014, 7, 5, 15): datetime(2014, 7, 7, 13),
-             datetime(2014, 7, 4, 17): datetime(2014, 7, 7, 13),
-             datetime(2014, 7, 4, 16, 30): datetime(2014, 7, 7, 12, 30),
-             datetime(2014, 7, 4, 16, 30, 30): datetime(2014, 7, 7, 12, 30,
-                                                        30)}))
+    @pytest.mark.parametrize('apply_case', apply_cases)
+    def test_apply(self, apply_case):
+        offset, cases = apply_case
+        for base, expected in compat.iteritems(cases):
+            assert_offset_equal(offset, base, expected)
 
-        for offset, cases in tests:
-            for base, expected in compat.iteritems(cases):
-                assert_offset_equal(offset, base, expected)
+    nano_cases = []
+    nano_cases.append(
+        (CustomBusinessHour(holidays=holidays),
+         {Timestamp('2014-07-01 15:00') + Nano(5):
+            Timestamp('2014-07-01 16:00') + Nano(5),
+          Timestamp('2014-07-01 16:00') + Nano(5):
+            Timestamp('2014-07-03 09:00') + Nano(5),
+          Timestamp('2014-07-01 16:00') - Nano(5):
+            Timestamp('2014-07-01 17:00') - Nano(5)}))
 
-    def test_apply_nanoseconds(self):
-        tests = []
+    nano_cases.append(
+        (CustomBusinessHour(-1, holidays=holidays),
+         {Timestamp('2014-07-01 15:00') + Nano(5):
+            Timestamp('2014-07-01 14:00') + Nano(5),
+          Timestamp('2014-07-01 10:00') + Nano(5):
+            Timestamp('2014-07-01 09:00') + Nano(5),
+          Timestamp('2014-07-01 10:00') - Nano(5):
+            Timestamp('2014-06-26 17:00') - Nano(5)}))
 
-        tests.append((CustomBusinessHour(holidays=self.holidays),
-                      {Timestamp('2014-07-01 15:00') + Nano(5): Timestamp(
-                          '2014-07-01 16:00') + Nano(5),
-                       Timestamp('2014-07-01 16:00') + Nano(5): Timestamp(
-                           '2014-07-03 09:00') + Nano(5),
-                       Timestamp('2014-07-01 16:00') - Nano(5): Timestamp(
-                           '2014-07-01 17:00') - Nano(5)}))
-
-        tests.append((CustomBusinessHour(-1, holidays=self.holidays),
-                      {Timestamp('2014-07-01 15:00') + Nano(5): Timestamp(
-                          '2014-07-01 14:00') + Nano(5),
-                       Timestamp('2014-07-01 10:00') + Nano(5): Timestamp(
-                           '2014-07-01 09:00') + Nano(5),
-                       Timestamp('2014-07-01 10:00') - Nano(5): Timestamp(
-                           '2014-06-26 17:00') - Nano(5), }))
-
-        for offset, cases in tests:
-            for base, expected in compat.iteritems(cases):
-                assert_offset_equal(offset, base, expected)
+    @pytest.mark.parametrize('nano_case', nano_cases)
+    def test_apply_nanoseconds(self, nano_case):
+        offset, cases = nano_case
+        for base, expected in compat.iteritems(cases):
+            assert_offset_equal(offset, base, expected)
 
 
 class TestCustomBusinessDay(Base):
@@ -1629,6 +1615,7 @@ class TestCustomBusinessDay(Base):
         self.nd = np_datetime64_compat('2008-01-01 00:00:00Z')
 
         self.offset = CDay()
+        self.offset1 = self.offset
         self.offset2 = CDay(2)
 
     def test_different_normalize_equals(self):
@@ -1650,7 +1637,7 @@ class TestCustomBusinessDay(Base):
 
         assert (self.d + offset) == datetime(2008, 1, 2, 2)
 
-    def testEQ(self):
+    def test_eq(self):
         assert self.offset2 == self.offset2
 
     def test_mul(self):
@@ -1659,28 +1646,9 @@ class TestCustomBusinessDay(Base):
     def test_hash(self):
         assert hash(self.offset2) == hash(self.offset2)
 
-    def testCall(self):
+    def test_call(self):
         assert self.offset2(self.d) == datetime(2008, 1, 3)
         assert self.offset2(self.nd) == datetime(2008, 1, 3)
-
-    def testRAdd(self):
-        assert self.d + self.offset2 == self.offset2 + self.d
-
-    def testSub(self):
-        off = self.offset2
-        pytest.raises(Exception, off.__sub__, self.d)
-        assert 2 * off - off == off
-
-        assert self.d - self.offset2 == self.d + CDay(-2)
-
-    def testRSub(self):
-        assert self.d - self.offset2 == (-self.offset2).apply(self.d)
-
-    def testMult1(self):
-        assert self.d + 10 * self.offset == self.d + CDay(10)
-
-    def testMult2(self):
-        assert self.d + (-5 * CDay(-10)) == self.d + CDay(50)
 
     def testRollback1(self):
         assert CDay(10).rollback(self.d) == self.d
@@ -1789,12 +1757,6 @@ class TestCustomBusinessDay(Base):
     def test_apply_corner(self):
         pytest.raises(Exception, CDay().apply, BMonthEnd())
 
-    def test_offsets_compare_equal(self):
-        # root cause of #456
-        offset1 = CDay()
-        offset2 = CDay()
-        assert not offset1 != offset2
-
     def test_holidays(self):
         # Define a TradingDay offset
         holidays = ['2012-05-01', datetime(2013, 5, 1),
@@ -1863,10 +1825,11 @@ class CustomBusinessMonthBase(object):
     def setup_method(self, method):
         self.d = datetime(2008, 1, 1)
 
-        self.offset = self._object()
-        self.offset2 = self._object(2)
+        self.offset = self._offset()
+        self.offset1 = self.offset
+        self.offset2 = self._offset(2)
 
-    def testEQ(self):
+    def test_eq(self):
         assert self.offset2 == self.offset2
 
     def test_mul(self):
@@ -1875,47 +1838,23 @@ class CustomBusinessMonthBase(object):
     def test_hash(self):
         assert hash(self.offset2) == hash(self.offset2)
 
-    def testRAdd(self):
-        assert self.d + self.offset2 == self.offset2 + self.d
-
-    def testSub(self):
-        off = self.offset2
-        pytest.raises(Exception, off.__sub__, self.d)
-        assert 2 * off - off == off
-
-        assert self.d - self.offset2 == self.d + self._object(-2)
-
-    def testRSub(self):
-        assert self.d - self.offset2 == (-self.offset2).apply(self.d)
-
-    def testMult1(self):
-        assert self.d + 10 * self.offset == self.d + self._object(10)
-
-    def testMult2(self):
-        assert self.d + (-5 * self._object(-10)) == self.d + self._object(50)
-
-    def test_offsets_compare_equal(self):
-        offset1 = self._object()
-        offset2 = self._object()
-        assert not offset1 != offset2
-
     def test_roundtrip_pickle(self):
         def _check_roundtrip(obj):
             unpickled = tm.round_trip_pickle(obj)
             assert unpickled == obj
 
-        _check_roundtrip(self._object())
-        _check_roundtrip(self._object(2))
-        _check_roundtrip(self._object() * 2)
+        _check_roundtrip(self._offset())
+        _check_roundtrip(self._offset(2))
+        _check_roundtrip(self._offset() * 2)
 
     def test_copy(self):
         # GH 17452
-        off = self._object(weekmask='Mon Wed Fri')
+        off = self._offset(weekmask='Mon Wed Fri')
         assert off == off.copy()
 
 
 class TestCustomBusinessMonthEnd(CustomBusinessMonthBase, Base):
-    _object = CBMonthEnd
+    _offset = CBMonthEnd
 
     def test_different_normalize_equals(self):
         # equivalent in this special case
@@ -2032,7 +1971,7 @@ class TestCustomBusinessMonthEnd(CustomBusinessMonthBase, Base):
 
 
 class TestCustomBusinessMonthBegin(CustomBusinessMonthBase, Base):
-    _object = CBMonthBegin
+    _offset = CBMonthBegin
 
     def test_different_normalize_equals(self):
         # equivalent in this special case
@@ -2157,9 +2096,11 @@ class TestWeek(Base):
         assert repr(Week(n=-2, weekday=0)) == "<-2 * Weeks: weekday=0>"
 
     def test_corner(self):
-        pytest.raises(ValueError, Week, weekday=7)
-        tm.assert_raises_regex(
-            ValueError, "Day must be", Week, weekday=-1)
+        with pytest.raises(ValueError):
+            Week(weekday=7)
+
+        with pytest.raises(ValueError, match="Day must be"):
+            Week(weekday=-1)
 
     def test_isAnchored(self):
         assert Week(weekday=0).isAnchored()
@@ -2204,38 +2145,35 @@ class TestWeek(Base):
         for base, expected in compat.iteritems(cases):
             assert_offset_equal(offset, base, expected)
 
-    def test_onOffset(self):
-        for weekday in range(7):
-            offset = Week(weekday=weekday)
+    @pytest.mark.parametrize('weekday', range(7))
+    def test_onOffset(self, weekday):
+        offset = Week(weekday=weekday)
 
-            for day in range(1, 8):
-                date = datetime(2008, 1, day)
+        for day in range(1, 8):
+            date = datetime(2008, 1, day)
 
-                if day % 7 == weekday:
-                    expected = True
-                else:
-                    expected = False
-            assert_onOffset(offset, date, expected)
-
-    def test_offsets_compare_equal(self):
-        # root cause of #456
-        offset1 = Week()
-        offset2 = Week()
-        assert not offset1 != offset2
+            if day % 7 == weekday:
+                expected = True
+            else:
+                expected = False
+        assert_onOffset(offset, date, expected)
 
 
 class TestWeekOfMonth(Base):
     _offset = WeekOfMonth
 
     def test_constructor(self):
-        tm.assert_raises_regex(ValueError, "^Week", WeekOfMonth,
-                               n=1, week=4, weekday=0)
-        tm.assert_raises_regex(ValueError, "^Week", WeekOfMonth,
-                               n=1, week=-1, weekday=0)
-        tm.assert_raises_regex(ValueError, "^Day", WeekOfMonth,
-                               n=1, week=0, weekday=-1)
-        tm.assert_raises_regex(ValueError, "^Day", WeekOfMonth,
-                               n=1, week=0, weekday=7)
+        with pytest.raises(ValueError, match="^Week"):
+            WeekOfMonth(n=1, week=4, weekday=0)
+
+        with pytest.raises(ValueError, match="^Week"):
+            WeekOfMonth(n=1, week=-1, weekday=0)
+
+        with pytest.raises(ValueError, match="^Day"):
+            WeekOfMonth(n=1, week=0, weekday=-1)
+
+        with pytest.raises(ValueError, match="^Day"):
+            WeekOfMonth(n=1, week=0, weekday=-7)
 
     def test_repr(self):
         assert (repr(WeekOfMonth(weekday=1, week=2)) ==
@@ -2324,13 +2262,14 @@ class TestLastWeekOfMonth(Base):
     _offset = LastWeekOfMonth
 
     def test_constructor(self):
-        tm.assert_raises_regex(ValueError, "^N cannot be 0",
-                               LastWeekOfMonth, n=0, weekday=1)
+        with pytest.raises(ValueError, match="^N cannot be 0"):
+            LastWeekOfMonth(n=0, weekday=1)
 
-        tm.assert_raises_regex(ValueError, "^Day", LastWeekOfMonth, n=1,
-                               weekday=-1)
-        tm.assert_raises_regex(
-            ValueError, "^Day", LastWeekOfMonth, n=1, weekday=7)
+        with pytest.raises(ValueError, match="^Day"):
+            LastWeekOfMonth(n=1, weekday=-1)
+
+        with pytest.raises(ValueError, match="^Day"):
+            LastWeekOfMonth(n=1, weekday=7)
 
     def test_offset(self):
         # Saturday
@@ -2773,9 +2712,9 @@ class TestOffsetNames(object):
 
 
 def test_get_offset():
-    with tm.assert_raises_regex(ValueError, _INVALID_FREQ_ERROR):
+    with pytest.raises(ValueError, match=_INVALID_FREQ_ERROR):
         get_offset('gibberish')
-    with tm.assert_raises_regex(ValueError, _INVALID_FREQ_ERROR):
+    with pytest.raises(ValueError, match=_INVALID_FREQ_ERROR):
         get_offset('QS-JAN-B')
 
     pairs = [
@@ -2793,7 +2732,7 @@ def test_get_offset():
 def test_get_offset_legacy():
     pairs = [('w@Sat', Week(weekday=5))]
     for name, expected in pairs:
-        with tm.assert_raises_regex(ValueError, _INVALID_FREQ_ERROR):
+        with pytest.raises(ValueError, match=_INVALID_FREQ_ERROR):
             get_offset(name)
 
 

--- a/pandas/tests/tseries/offsets/test_offsets.py
+++ b/pandas/tests/tseries/offsets/test_offsets.py
@@ -41,6 +41,12 @@ from pandas.tseries.holiday import USFederalHolidayCalendar
 from .common import assert_offset_equal, assert_onOffset
 
 
+def test_monthrange():
+    import calendar
+    for y in range(2000, 2013):
+        for m in range(1, 13):
+            assert tslib.monthrange(y, m) == calendar.monthrange(y, m)
+
 ####
 # Misc function tests
 ####

--- a/pandas/tests/tslibs/test_ccalendar.py
+++ b/pandas/tests/tslibs/test_ccalendar.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-import calendar
 from datetime import datetime
 
 import numpy as np
@@ -17,9 +16,3 @@ def test_get_day_of_year():
     result = ccalendar.get_day_of_year(dt.year, dt.month, dt.day)
     expected = (dt - dt.replace(month=1, day=1)).days + 1
     assert result == expected
-
-
-def test_monthrange():
-    for y in range(2000, 2013):
-        for m in range(1, 13):
-            assert ccalendar.monthrange(y, m) == calendar.monthrange(y, m)

--- a/pandas/tests/tslibs/test_ccalendar.py
+++ b/pandas/tests/tslibs/test_ccalendar.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+import calendar
 from datetime import datetime
 
 import numpy as np
@@ -16,3 +17,9 @@ def test_get_day_of_year():
     result = ccalendar.get_day_of_year(dt.year, dt.month, dt.day)
     expected = (dt - dt.replace(month=1, day=1)).days + 1
     assert result == expected
+
+
+def test_monthrange():
+    for y in range(2000, 2013):
+        for m in range(1, 13):
+            assert ccalendar.monthrange(y, m) == calendar.monthrange(y, m)


### PR DESCRIPTION
There's more to do, but the diff is already pretty big as it is.

There are a handful of test methods that are defined in 5-6 test classes.  By moving those to the base class we a) get rid of duplicate code and b) run the tests for all (well, most) `DateOffset` subclasses.