### PR TITLE
BUG : read_json with table='orient' causes unexpected type coercion 

### DIFF
--- a/pandas/io/json/json.py
+++ b/pandas/io/json/json.py
@@ -706,12 +706,12 @@ class Parser(object):
                 except (TypeError, ValueError):
                     pass
 
-        # do't coerce 0-len data
+        # don't coerce 0-len data
         if len(data) and (data.dtype == 'float' or data.dtype == 'object'):
 
-            # coerce ints if we can
+            # coerce float if we can
             try:
-                new_data = data.astype('int64')
+                new_data = data.astype('float64')
                 if (new_data == data).all():
                     data = new_data
                     result = True
@@ -721,7 +721,7 @@ class Parser(object):
         # coerce ints to 64
         if data.dtype == 'int':
 
-            # coerce floats to 64
+            # coerce ints to 64
             try:
                 data = data.astype('int64')
                 result = True

--- a/pandas/io/json/json.py
+++ b/pandas/io/json/json.py
@@ -707,11 +707,11 @@ class Parser(object):
                     pass
 
         # don't coerce 0-len data
-        if len(data) and (data.dtype == 'float' or data.dtype == 'object'):
+        if len(data) and (data.dtype == 'object'):
 
-            # coerce float if we can
+            # coerce int if we can
             try:
-                new_data = data.astype('float64')
+                new_data = data.astype('int64')
                 if (new_data == data).all():
                     data = new_data
                     result = True
@@ -724,6 +724,16 @@ class Parser(object):
             # coerce ints to 64
             try:
                 data = data.astype('int64')
+                result = True
+            except (TypeError, ValueError):
+                pass
+
+        # coerce floats to 64
+        if data.dtype == 'float':
+
+            # coerce floats to 64
+            try:
+                data = data.astype('float64')
                 result = True
             except (TypeError, ValueError):
                 pass


### PR DESCRIPTION
BUG : read_json with table='orient' causes unexpected type coercion #21345

- [x] closes #21345
- [ ] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

Changed `.astype` parameters according to the comments. Should work now
