### PR TITLE
BUG: Categorical.__setitem__ allows for tuple assignment

### DIFF
--- a/doc/source/whatsnew/v0.23.1.txt
+++ b/doc/source/whatsnew/v0.23.1.txt
@@ -100,6 +100,7 @@ Bug Fixes
 - Bug in :meth:`Series.str.replace()` where the method throws `TypeError` on Python 3.5.2 (:issue: `21078`)
 - Bug in :class:`Timedelta`: where passing a float with a unit would prematurely round the float precision (:issue: `14156`)
 - Bug in :func:`pandas.testing.assert_index_equal` which raised ``AssertionError`` incorrectly, when comparing two :class:`CategoricalIndex` objects with param ``check_categorical=False`` (:issue:`19776`)
+- Bug in :meth:`Categorical.__setitem__` where error was raised when trying to change value for Categorical objects containing tuples (:issue:`20439`)
 
 **Sparse**
 

--- a/doc/source/whatsnew/v0.23.1.txt
+++ b/doc/source/whatsnew/v0.23.1.txt
@@ -100,7 +100,7 @@ Bug Fixes
 - Bug in :meth:`Series.str.replace()` where the method throws `TypeError` on Python 3.5.2 (:issue: `21078`)
 - Bug in :class:`Timedelta`: where passing a float with a unit would prematurely round the float precision (:issue: `14156`)
 - Bug in :func:`pandas.testing.assert_index_equal` which raised ``AssertionError`` incorrectly, when comparing two :class:`CategoricalIndex` objects with param ``check_categorical=False`` (:issue:`19776`)
-- Bug in :meth:`Categorical.__setitem__` where error was raised when trying to change value for Categorical objects containing tuples (:issue:`20439`)
+- Bug in :meth:`Categorical.__setitem__` where error was raised when trying to set value to a tuple (:issue:`20439`)
 
 **Sparse**
 

--- a/doc/source/whatsnew/v0.23.1.txt
+++ b/doc/source/whatsnew/v0.23.1.txt
@@ -100,7 +100,6 @@ Bug Fixes
 - Bug in :meth:`Series.str.replace()` where the method throws `TypeError` on Python 3.5.2 (:issue: `21078`)
 - Bug in :class:`Timedelta`: where passing a float with a unit would prematurely round the float precision (:issue: `14156`)
 - Bug in :func:`pandas.testing.assert_index_equal` which raised ``AssertionError`` incorrectly, when comparing two :class:`CategoricalIndex` objects with param ``check_categorical=False`` (:issue:`19776`)
-- Bug in :meth:`Categorical.__setitem__` where error was raised when trying to set value to a tuple (:issue:`20439`)
 
 **Sparse**
 

--- a/doc/source/whatsnew/v0.23.2.txt
+++ b/doc/source/whatsnew/v0.23.2.txt
@@ -43,8 +43,11 @@ Bug Fixes
 -
 -
 
-**Conversion**
+**Data-type specific**
 
+- Bug in :meth:`Categorical.__setitem__` where error was raised when trying to set value to a tuple (:issue:`20439`)
+
+**Conversion**
 
 -
 -

--- a/pandas/core/arrays/categorical.py
+++ b/pandas/core/arrays/categorical.py
@@ -1971,10 +1971,16 @@ class Categorical(ExtensionArray, PandasObject):
                 raise ValueError("Cannot set a Categorical with another, "
                                  "without identical categories")
 
-        rvalue = value if is_list_like(value) else [value]
-
+        # is the new value one of the defined categories?
         from pandas import Index
-        to_add = Index(rvalue).difference(self.categories)
+        if isinstance(value, tuple):
+            rvalue = [value]
+            to_add = Index(rvalue,
+                           tupleize_cols=False).difference(self.categories)
+        else:
+            if not is_list_like(value):
+                rvalue = [value]
+            to_add = Index(rvalue).difference(self.categories)
 
         # no assignments of values not in categories, but it's always ok to set
         # something to np.nan

--- a/pandas/core/arrays/categorical.py
+++ b/pandas/core/arrays/categorical.py
@@ -1978,8 +1978,7 @@ class Categorical(ExtensionArray, PandasObject):
             to_add = Index(rvalue,
                            tupleize_cols=False).difference(self.categories)
         else:
-            if not is_list_like(value):
-                rvalue = [value]
+            rvalue = value if is_list_like(value) else [value]
             to_add = Index(rvalue).difference(self.categories)
 
         # no assignments of values not in categories, but it's always ok to set

--- a/pandas/core/arrays/categorical.py
+++ b/pandas/core/arrays/categorical.py
@@ -1971,7 +1971,6 @@ class Categorical(ExtensionArray, PandasObject):
                 raise ValueError("Cannot set a Categorical with another, "
                                  "without identical categories")
 
-        # is the new value one of the defined categories?
         from pandas import Index
         if isinstance(value, tuple):
             rvalue = [value]

--- a/pandas/tests/categorical/test_indexing.py
+++ b/pandas/tests/categorical/test_indexing.py
@@ -103,3 +103,23 @@ class TestCategoricalIndexing(object):
             s.categories = [1, 2]
 
         pytest.raises(ValueError, f)
+
+    def test_setitem_with_tuple_categories(self):
+        # changing element of categorical of tuples
+        s = Categorical([('a', 'a'), ('a', 'b'), ('b', 'a'), ('b', 'b')])
+        s[0] = ('b', 'b')
+
+        expected = Categorical(
+            [('b', 'b'), ('a', 'b'), ('b', 'a'), ('b', 'b')],
+            categories=[('a', 'a'), ('a', 'b'), ('b', 'a'), ('b', 'b')]
+        )
+        tm.assert_categorical_equal(s, expected)
+
+        # changing element to use new category
+        msg = ''.join([
+            "Cannot setitem on a Categorical with a new category, set the ",
+            "categories first"
+        ])
+        with tm.assert_raises_regex(ValueError, msg):
+            s = Categorical([('a', 'a'), ('a', 'b'), ('b', 'a'), ('b', 'b')])
+            s[0] = ('c', 'c')

--- a/pandas/tests/categorical/test_indexing.py
+++ b/pandas/tests/categorical/test_indexing.py
@@ -105,17 +105,18 @@ class TestCategoricalIndexing(object):
         pytest.raises(ValueError, f)
 
     def test_setitem_with_tuple_categories(self):
-        # changing element of categorical of tuples
+        # GH 20439
+
+        # change element in Categorical of tuples
         s = Categorical([('a', 'a'), ('a', 'b'), ('b', 'a'), ('b', 'b')])
         s[0] = ('b', 'b')
-
         expected = Categorical(
             [('b', 'b'), ('a', 'b'), ('b', 'a'), ('b', 'b')],
             categories=[('a', 'a'), ('a', 'b'), ('b', 'a'), ('b', 'b')]
         )
         tm.assert_categorical_equal(s, expected)
 
-        # changing element to use new category
+        # change element in Categorical to use new category
         msg = ("Cannot setitem on a Categorical with a new category, set the "
                "categories first")
         with tm.assert_raises_regex(ValueError, msg):

--- a/pandas/tests/categorical/test_indexing.py
+++ b/pandas/tests/categorical/test_indexing.py
@@ -116,10 +116,8 @@ class TestCategoricalIndexing(object):
         tm.assert_categorical_equal(s, expected)
 
         # changing element to use new category
-        msg = ''.join([
-            "Cannot setitem on a Categorical with a new category, set the ",
-            "categories first"
-        ])
+        msg = ("Cannot setitem on a Categorical with a new category, set the "
+               "categories first")
         with tm.assert_raises_regex(ValueError, msg):
             s = Categorical([('a', 'a'), ('a', 'b'), ('b', 'a'), ('b', 'b')])
             s[0] = ('c', 'c')


### PR DESCRIPTION
- [x] closes #20439 
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry

Pretty straightforward fix in the `__setitem__` method

While I was looking into this, I discovered a bug that does not allow for the creation of mixed-dtype Categoricals, if the first element is not a tuple. Should I create an issue?

```console
In [20]: s = pd.Categorical([('a', 'a'), ('a', 'b'), ('b', 'a'), 'c'])

In [21]: s
Out[21]:
[(a, a), (a, b), (b, a), c]
Categories (4, object): [(a, a), (a, b), (b, a), c]

In [22]: s = pd.Categorical(['c', ('a', 'b'), ('b', 'a'), 'c'])
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
<ipython-input-22-0f4b5f338532> in <module>()
----> 1 s = pd.Categorical(['c', ('a', 'b'), ('b', 'a'), 'c'])

~/Documents/siv-dev/projects/open-source/pandas/pandas/core/arrays/categorical.py in __init__(self, values, categories, ordered, dtype, fastpath)
    328             # _sanitize_array coerces np.nan to a string under certain versions
    329             # of numpy
--> 330             values = maybe_infer_to_datetimelike(values, convert_dates=True)
    331             if not isinstance(values, np.ndarray):
    332                 values = _convert_to_list_like(values)

~/Documents/siv-dev/projects/open-source/pandas/pandas/core/dtypes/cast.py in maybe_infer_to_datetimelike(value, convert_dates)
    893     if not is_list_like(v):
    894         v = [v]
--> 895     v = np.array(v, copy=False)
    896
    897     # we only care about object dtypes

ValueError: setting an array element with a sequence
```