### PR TITLE
Fix tests fragile to PATH

### DIFF
--- a/pandas/tests/plotting/test_converter.py
+++ b/pandas/tests/plotting/test_converter.py
@@ -1,4 +1,5 @@
 import subprocess
+import sys
 import pytest
 from datetime import datetime, date
 
@@ -27,7 +28,7 @@ class TestRegistration(object):
                 "import pandas as pd; "
                 "units = dict(matplotlib.units.registry); "
                 "assert pd.Timestamp in units)'")
-        call = ['python', '-c', code]
+        call = [sys.executable, '-c', code]
         assert subprocess.check_call(call) == 0
 
     def test_warns(self):

--- a/pandas/tests/test_downstream.py
+++ b/pandas/tests/test_downstream.py
@@ -3,6 +3,7 @@
 Testing that we work in the downstream packages
 """
 import subprocess
+import sys
 
 import pytest
 import numpy as np  # noqa
@@ -57,7 +58,7 @@ def test_xarray(df):
 
 def test_oo_optimizable():
     # GH 21071
-    subprocess.check_call(["python", "-OO", "-c", "import pandas"])
+    subprocess.check_call([sys.executable, "-OO", "-c", "import pandas"])
 
 
 @tm.network


### PR DESCRIPTION
Closes #21450

Get path of current python interpreter running opposed to one on users path.
