### PR TITLE
BUG: fix get_indexer_non_unique with CategoricalIndex key

### DIFF
--- a/doc/source/whatsnew/v0.23.2.txt
+++ b/doc/source/whatsnew/v0.23.2.txt
@@ -55,7 +55,7 @@ Conversion
 Indexing
 ^^^^^^^^
 
--
+- Bug in :meth:`Index.get_indexer_non_unique` with categorical key (:issue:`21448`)
 -
 
 I/O

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -31,6 +31,7 @@ from pandas.core.dtypes.common import (
     is_dtype_equal,
     is_dtype_union_equal,
     is_object_dtype,
+    is_categorical,
     is_categorical_dtype,
     is_interval_dtype,
     is_period_dtype,
@@ -3300,6 +3301,8 @@ class Index(IndexOpsMixin, PandasObject):
     @Appender(_index_shared_docs['get_indexer_non_unique'] % _index_doc_kwargs)
     def get_indexer_non_unique(self, target):
         target = _ensure_index(target)
+        if is_categorical(target):
+            target = target.astype(target.dtype.categories.dtype)
         pself, ptarget = self._maybe_promote(target)
         if pself is not self or ptarget is not target:
             return pself.get_indexer_non_unique(ptarget)

--- a/pandas/core/indexes/category.py
+++ b/pandas/core/indexes/category.py
@@ -598,7 +598,12 @@ class CategoricalIndex(Index, accessor.PandasDelegate):
         target = ibase._ensure_index(target)
 
         if isinstance(target, CategoricalIndex):
-            target = target.categories
+            # Indexing on codes is more efficient if categories are the same:
+            if target.categories is self.categories:
+                target = target.codes
+                indexer, missing = self._engine.get_indexer_non_unique(target)
+                return _ensure_platform_int(indexer), missing
+            target = target.values
 
         codes = self.categories.get_indexer(target)
         indexer, missing = self._engine.get_indexer_non_unique(codes)


### PR DESCRIPTION
- [x] closes #21448
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry
