### PR TITLE
BUG #21374: Fix divison with complex numbers in eval() method

### DIFF
--- a/pandas/core/computation/ops.py
+++ b/pandas/core/computation/ops.py
@@ -465,8 +465,9 @@ class Div(BinOp):
                                                       rhs.return_type))
 
         if truediv or PY3:
-            # do not upcast float32s to float64 un-necessarily
-            acceptable_dtypes = [np.float32, np.float_]
+            # do not upcast float32s to float64 un-necessarily 
+            acceptable_dtypes = [np.float32, np.float_,
+                                 np.complex64, np.complex_]
             _cast_inplace(com.flatten(self), acceptable_dtypes, np.float_)
 
 

--- a/pandas/core/computation/ops.py
+++ b/pandas/core/computation/ops.py
@@ -465,7 +465,7 @@ class Div(BinOp):
                                                       rhs.return_type))
 
         if truediv or PY3:
-            # do not upcast float32s to float64 un-necessarily 
+            # do not upcast float32s to float64 un-necessarily
             acceptable_dtypes = [np.float32, np.float_,
                                  np.complex64, np.complex_]
             _cast_inplace(com.flatten(self), acceptable_dtypes, np.float_)


### PR DESCRIPTION
- [ ] closes #21374 
- [ ] tests added / passed
```python
data = {"a": [1 + 2j], "b": [1 + 1j]}
df = pd.DataFrame(data = data)
df.eval("a/b")
```
Expected output:
```python
df["a"]/df["b"]

0    (1.5+0.5j)
dtype: complex128
```
New result:
```python
df.eval("a/b")

0    (1.5+0.5j)
dtype: complex128
```
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
