### PR TITLE
BUG/REG: file-handle object handled incorrectly in to_csv

### DIFF
--- a/doc/source/whatsnew/v0.23.2.txt
+++ b/doc/source/whatsnew/v0.23.2.txt
@@ -56,7 +56,7 @@ Bug Fixes
 
 **I/O**
 
--
+- Bug in :meth:`to_csv` when handling file-like object incorrectly (:issue:`21471`)
 -
 
 **Plotting**

--- a/doc/source/whatsnew/v0.23.2.txt
+++ b/doc/source/whatsnew/v0.23.2.txt
@@ -16,7 +16,7 @@ and bug fixes. We recommend that all users upgrade to this version.
 Fixed Regressions
 ~~~~~~~~~~~~~~~~~
 
--
+- Fixed Regression in :meth:`to_csv` when handling file-like object incorrectly (:issue:`21471`)
 -
 
 .. _whatsnew_0232.performance:
@@ -56,7 +56,7 @@ Bug Fixes
 
 **I/O**
 
-- Bug in :meth:`to_csv` when handling file-like object incorrectly (:issue:`21471`)
+-
 -
 
 **Plotting**

--- a/doc/source/whatsnew/v0.23.2.txt
+++ b/doc/source/whatsnew/v0.23.2.txt
@@ -16,7 +16,7 @@ and bug fixes. We recommend that all users upgrade to this version.
 Fixed Regressions
 ~~~~~~~~~~~~~~~~~
 
-- Fixed Regression in :meth:`to_csv` when handling file-like object incorrectly (:issue:`21471`)
+- Fixed regression in :meth:`to_csv` when handling file-like object incorrectly (:issue:`21471`)
 -
 
 .. _whatsnew_0232.performance:

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -1690,7 +1690,8 @@ class DataFrame(NDFrame):
             defaults to 'ascii' on Python 2 and 'utf-8' on Python 3.
         compression : string, optional
             A string representing the compression to use in the output file.
-            Allowed values are 'gzip', 'bz2', 'zip', 'xz'.
+            Allowed values are 'gzip', 'bz2', 'zip', 'xz'. This input is only
+            used when the first argument is a filename.
         line_terminator : string, default ``'\n'``
             The newline character or character sequence to use in the output
             file

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -3790,7 +3790,8 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
             non-ascii, for python versions prior to 3
         compression : string, optional
             A string representing the compression to use in the output file.
-            Allowed values are 'gzip', 'bz2', 'zip', 'xz'.
+            Allowed values are 'gzip', 'bz2', 'zip', 'xz'. This input is only
+            used when the first argument is a filename.
         date_format: string, default None
             Format string for datetime objects.
         decimal: string, default '.'

--- a/pandas/io/common.py
+++ b/pandas/io/common.py
@@ -447,10 +447,7 @@ class BytesZipFile(zipfile.ZipFile, BytesIO):
 
     @property
     def closed(self):
-        if compat.PY2:
-            return self.fp is None
-        else:
-            return super(BytesZipFile, self).closed
+        return self.fp is None
 
 
 class MMapWrapper(BaseIterator):

--- a/pandas/io/common.py
+++ b/pandas/io/common.py
@@ -445,6 +445,13 @@ class BytesZipFile(zipfile.ZipFile, BytesIO):
     def write(self, data):
         super(BytesZipFile, self).writestr(self.filename, data)
 
+    @property
+    def closed(self):
+        if compat.PY2:
+            return self.fp is None
+        else:
+            return super(BytesZipFile, self).closed
+
 
 class MMapWrapper(BaseIterator):
     """

--- a/pandas/io/formats/csvs.py
+++ b/pandas/io/formats/csvs.py
@@ -174,10 +174,9 @@ class CSVFormatter(object):
             if is_zip:
                 # GH 17778 handles zip compression separately.
                 buf = f.getvalue()
-                try:
+                if hasattr(self.path_or_buf, 'write'):
                     self.path_or_buf.write(buf)
-                except AttributeError:
-                    # when path_or_buf is not file-like, create handle.
+                else:
                     f, handles = _get_handle(self.path_or_buf, self.mode,
                                              encoding=encoding,
                                              compression=self.compression)

--- a/pandas/io/formats/csvs.py
+++ b/pandas/io/formats/csvs.py
@@ -142,6 +142,11 @@ class CSVFormatter(object):
         elif hasattr(self.path_or_buf, 'write'):
             f = self.path_or_buf
             close = False
+            if self.compression:
+                import warnings
+                msg = ("compression has no effect when passing file-like "
+                       "object as input.")
+                warnings.warn(msg, RuntimeWarning, stacklevel=2)
         else:
             f, handles = _get_handle(self.path_or_buf, self.mode,
                                      encoding=encoding,
@@ -178,19 +183,6 @@ class CSVFormatter(object):
                 f.close()
                 for _fh in handles:
                     _fh.close()
-
-            # GH 17778 handles zip compression for byte strings separately.
-            # if path is not None:
-            #     buf = f.getvalue()
-            #     f, handles = _get_handle(path, self.mode,
-            #                              encoding=encoding,
-            #                              compression=self.compression)
-            #     f.write(buf)
-            #
-            #     if not py2zip:
-            #         f.close()
-            #         for _fh in handles:
-            #             _fh.close()
 
     def _save_header(self):
 

--- a/pandas/io/formats/csvs.py
+++ b/pandas/io/formats/csvs.py
@@ -130,17 +130,16 @@ class CSVFormatter(object):
         else:
             encoding = self.encoding
 
+        # GH 21227 internal compression is not used when file-like passed.
         if self.compression and hasattr(self.path_or_buf, 'write'):
             msg = ("compression has no effect when passing file-like "
                    "object as input.")
             warnings.warn(msg, RuntimeWarning, stacklevel=2)
 
-        if isinstance(self.path_or_buf, ZipFile) or (
-                not hasattr(self.path_or_buf, 'write')
-                and self.compression == 'zip'):
-            is_zip = True
-        else:
-            is_zip = False
+        # when zip compression is called.
+        is_zip = isinstance(self.path_or_buf, ZipFile) or (
+                    not hasattr(self.path_or_buf, 'write')
+                    and self.compression == 'zip')
 
         if is_zip:
             # zipfile doesn't support writing string to archive. uses string
@@ -178,6 +177,7 @@ class CSVFormatter(object):
                 try:
                     self.path_or_buf.write(buf)
                 except AttributeError:
+                    # when path_or_buf is not file-like, create handle.
                     f, handles = _get_handle(self.path_or_buf, self.mode,
                                              encoding=encoding,
                                              compression=self.compression)

--- a/pandas/io/formats/csvs.py
+++ b/pandas/io/formats/csvs.py
@@ -138,8 +138,8 @@ class CSVFormatter(object):
 
         # when zip compression is called.
         is_zip = isinstance(self.path_or_buf, ZipFile) or (
-                    not hasattr(self.path_or_buf, 'write')
-                    and self.compression == 'zip')
+            not hasattr(self.path_or_buf, 'write')
+            and self.compression == 'zip')
 
         if is_zip:
             # zipfile doesn't support writing string to archive. uses string

--- a/pandas/io/formats/csvs.py
+++ b/pandas/io/formats/csvs.py
@@ -6,6 +6,7 @@ Module for formatting output data into CSV files.
 from __future__ import print_function
 
 import csv as csvlib
+from zipfile import ZipFile
 import numpy as np
 
 from pandas.core.dtypes.missing import notna
@@ -127,7 +128,7 @@ class CSVFormatter(object):
         else:
             encoding = self.encoding
 
-        if (not hasattr(self.path_or_buf, 'write') and
+        if (isinstance(self.path_or_buf, ZipFile) or
                 self.compression == 'zip'):
             is_zip = True
         else:

--- a/pandas/io/formats/csvs.py
+++ b/pandas/io/formats/csvs.py
@@ -134,8 +134,9 @@ class CSVFormatter(object):
                    "object as input.")
             warnings.warn(msg, RuntimeWarning, stacklevel=2)
 
-        if (isinstance(self.path_or_buf, ZipFile) or
-                self.compression == 'zip'):
+        if isinstance(self.path_or_buf, ZipFile) or (
+                not hasattr(self.path_or_buf, 'write')
+                and self.compression == 'zip'):
             is_zip = True
         else:
             is_zip = False

--- a/pandas/io/formats/csvs.py
+++ b/pandas/io/formats/csvs.py
@@ -128,6 +128,12 @@ class CSVFormatter(object):
         else:
             encoding = self.encoding
 
+        if self.compression and hasattr(self.path_or_buf, 'write'):
+            import warnings
+            msg = ("compression has no effect when passing file-like "
+                   "object as input.")
+            warnings.warn(msg, RuntimeWarning, stacklevel=2)
+
         if (isinstance(self.path_or_buf, ZipFile) or
                 self.compression == 'zip'):
             is_zip = True
@@ -143,11 +149,6 @@ class CSVFormatter(object):
         elif hasattr(self.path_or_buf, 'write'):
             f = self.path_or_buf
             close = False
-            if self.compression:
-                import warnings
-                msg = ("compression has no effect when passing file-like "
-                       "object as input.")
-                warnings.warn(msg, RuntimeWarning, stacklevel=2)
         else:
             f, handles = _get_handle(self.path_or_buf, self.mode,
                                      encoding=encoding,

--- a/pandas/io/formats/csvs.py
+++ b/pandas/io/formats/csvs.py
@@ -5,6 +5,8 @@ Module for formatting output data into CSV files.
 
 from __future__ import print_function
 
+import warnings
+
 import csv as csvlib
 from zipfile import ZipFile
 import numpy as np
@@ -129,7 +131,6 @@ class CSVFormatter(object):
             encoding = self.encoding
 
         if self.compression and hasattr(self.path_or_buf, 'write'):
-            import warnings
             msg = ("compression has no effect when passing file-like "
                    "object as input.")
             warnings.warn(msg, RuntimeWarning, stacklevel=2)

--- a/pandas/tests/frame/test_to_csv.py
+++ b/pandas/tests/frame/test_to_csv.py
@@ -946,10 +946,9 @@ class TestDataFrameToCSV(TestData):
                                       encoding=encoding)
             with f:
                 df.to_csv(f, encoding=encoding)
-            result_fh = pd.read_csv(filename, compression=compression,
-                                    encoding=encoding, index_col=0,
-                                    squeeze=True)
-            assert_frame_equal(df, result_fh)
+            result = pd.read_csv(filename, compression=compression,
+                                 encoding=encoding, index_col=0, squeeze=True)
+            assert_frame_equal(df, result)
 
             # explicitly make sure file is compressed
             with tm.decompress_file(filename, compression) as fh:

--- a/pandas/tests/frame/test_to_csv.py
+++ b/pandas/tests/frame/test_to_csv.py
@@ -9,6 +9,7 @@ from numpy import nan
 import numpy as np
 
 from pandas.compat import (lmap, range, lrange, StringIO, u)
+from pandas.io.common import _get_handle
 import pandas.core.common as com
 from pandas.errors import ParserError
 from pandas import (DataFrame, Index, Series, MultiIndex, Timestamp,
@@ -935,17 +936,19 @@ class TestDataFrameToCSV(TestData):
         with ensure_clean() as filename:
 
             df.to_csv(filename, compression=compression, encoding=encoding)
-
             # test the round trip - to_csv -> read_csv
             result = read_csv(filename, compression=compression,
                               index_col=0, encoding=encoding)
-
-            with open(filename, 'w') as fh:
-                df.to_csv(fh, compression=compression, encoding=encoding)
-
-            result_fh = read_csv(filename, compression=compression,
-                                 index_col=0, encoding=encoding)
             assert_frame_equal(df, result)
+
+            # test the round trip using file handle - to_csv -> read_csv
+            f, _handles = _get_handle(filename, 'w', compression=compression,
+                                      encoding=encoding)
+            with f:
+                df.to_csv(f, encoding=encoding)
+            result_fh = pd.read_csv(filename, compression=compression,
+                                    encoding=encoding, index_col=0,
+                                    squeeze=True)
             assert_frame_equal(df, result_fh)
 
             # explicitly make sure file is compressed

--- a/pandas/tests/series/test_io.py
+++ b/pandas/tests/series/test_io.py
@@ -11,6 +11,7 @@ import pandas as pd
 from pandas import Series, DataFrame
 
 from pandas.compat import StringIO, u
+from pandas.io.common import _get_handle
 from pandas.util.testing import (assert_series_equal, assert_almost_equal,
                                  assert_frame_equal, ensure_clean)
 import pandas.util.testing as tm
@@ -151,19 +152,19 @@ class TestSeriesToCSV(TestData):
 
             s.to_csv(filename, compression=compression, encoding=encoding,
                      header=True)
-
             # test the round trip - to_csv -> read_csv
             result = pd.read_csv(filename, compression=compression,
                                  encoding=encoding, index_col=0, squeeze=True)
+            assert_series_equal(s, result)
 
-            with open(filename, 'w') as fh:
-                s.to_csv(fh, compression=compression, encoding=encoding,
-                         header=True)
-
+            # test the round trip using file handle - to_csv -> read_csv
+            f, _handles = _get_handle(filename, 'w', compression=compression,
+                                      encoding=encoding)
+            with f:
+                s.to_csv(f, encoding=encoding, header=True)
             result_fh = pd.read_csv(filename, compression=compression,
                                     encoding=encoding, index_col=0,
                                     squeeze=True)
-            assert_series_equal(s, result)
             assert_series_equal(s, result_fh)
 
             # explicitly ensure file was compressed

--- a/pandas/tests/series/test_io.py
+++ b/pandas/tests/series/test_io.py
@@ -162,10 +162,9 @@ class TestSeriesToCSV(TestData):
                                       encoding=encoding)
             with f:
                 s.to_csv(f, encoding=encoding, header=True)
-            result_fh = pd.read_csv(filename, compression=compression,
-                                    encoding=encoding, index_col=0,
-                                    squeeze=True)
-            assert_series_equal(s, result_fh)
+            result = pd.read_csv(filename, compression=compression,
+                                 encoding=encoding, index_col=0, squeeze=True)
+            assert_series_equal(s, result)
 
             # explicitly ensure file was compressed
             with tm.decompress_file(filename, compression) as fh:

--- a/pandas/tests/test_common.py
+++ b/pandas/tests/test_common.py
@@ -263,3 +263,15 @@ def test_compression_size_fh(obj, method, compression_only):
             assert not f.closed
         uncompressed = os.path.getsize(filename)
         assert uncompressed > compressed
+
+
+def test_compression_warning(compression_only):
+    df = DataFrame(100 * [[0.123456, 0.234567, 0.567567],
+                          [12.32112, 123123.2, 321321.2]],
+                   columns=['X', 'Y', 'Z'])
+    with tm.ensure_clean() as filename:
+        f, _handles = _get_handle(filename, 'w', compression=compression_only)
+        with tm.assert_produces_warning(RuntimeWarning,
+                                        check_stacklevel=False):
+            with f:
+                df.to_csv(f, compression=compression_only)

--- a/pandas/tests/test_common.py
+++ b/pandas/tests/test_common.py
@@ -255,12 +255,14 @@ def test_compression_size_fh(obj, method, compression_only):
         with f:
             getattr(obj, method)(f)
             assert not f.closed
+        assert f.closed
         compressed = os.path.getsize(filename)
     with tm.ensure_clean() as filename:
         f, _handles = _get_handle(filename, 'w', compression=None)
         with f:
             getattr(obj, method)(f)
             assert not f.closed
+        assert f.closed
         uncompressed = os.path.getsize(filename)
         assert uncompressed > compressed
 

--- a/pandas/tests/test_common.py
+++ b/pandas/tests/test_common.py
@@ -265,6 +265,7 @@ def test_compression_size_fh(obj, method, compression_only):
         assert uncompressed > compressed
 
 
+# GH 21227
 def test_compression_warning(compression_only):
     df = DataFrame(100 * [[0.123456, 0.234567, 0.567567],
                           [12.32112, 123123.2, 321321.2]],


### PR DESCRIPTION
- [x] closes #https://github.com/pandas-dev/pandas/issues/21471
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry

This error related to PR #21249 and https://github.com/pandas-dev/pandas/issues/21227. This is never supported use case and to use file-handle in to_csv with compression, the file-object itself should be a compression archive such as:
```
with gzip.open('test.txt.gz', 'wt') as f:
    pd.DataFrame([0,1],index=['a','b'], columns=['c']).to_csv(f, sep='\t')
```

Regressed to 0.22 to_csv with support for zipfile. zipfile doesn't support writing csv strings to a zip archive using a file-handle. So buffer is used to catch the writing and dump into zip archive in one go. The other scenarios remain unchanged.