### PR TITLE
PERF: improve speed of nans in CategoricalIndex

### DIFF
--- a/pandas/core/indexes/category.py
+++ b/pandas/core/indexes/category.py
@@ -326,7 +326,7 @@ class CategoricalIndex(Index, accessor.PandasDelegate):
         hash(key)
 
         if isna(key):  # if key is a NaN, check if any NaN is in self.
-            return self.isna().any()
+            return self.hasnans
 
         # is key in self.categories? Then get its location.
         # If not (i.e. KeyError), it logically can't be in self either


### PR DESCRIPTION
This is a minor follow-up to #21369.

```python
>>> n = 100_000
>>> ci = pd.CategoricalIndex(['a']*n + ['b']*n + ['c']*n + [np.nan])
>>> np.nan in ci
19.5 us  # master
114 ns  # this PR
```

Using ``self.hasnans`` to check for nans is faster than ``self.isna().any()`` because  it's cached.
