### PR TITLE
wrap urlopen with requests

### DIFF
--- a/pandas/io/common.py
+++ b/pandas/io/common.py
@@ -104,7 +104,7 @@ def _urlopen(url, session=None):
             r = session.get(url)
         else:
             r = requests.get(url)
-        r.raise_for_status
+        r.raise_for_status()
         content = r.content
     except ImportError:
         r = urlopen(url)

--- a/pandas/io/common.py
+++ b/pandas/io/common.py
@@ -215,6 +215,14 @@ def get_filepath_or_buffer(filepath_or_buffer, encoding=None,
                          or buffer
     encoding : the encoding to use to decode py3 bytes, default is 'utf-8'
     mode : str, optional
+    compression : {'infer', 'gzip', 'bz2', 'zip', 'xz', None}, default 'infer'
+        For on-the-fly decompression of on-disk data. If 'infer' and
+        `filepath_or_buffer` is path-like, then detect compression from the
+        following extensions: '.gz', '.bz2', '.zip', or '.xz' (otherwise no
+        decompression). If using 'zip', the ZIP file must contain only one data
+        file to be read in. Set to None for no decompression.
+
+    .. versionadded:: 0.18.1 support for 'zip' and 'xz' compression.
 
     Returns
     -------

--- a/pandas/io/common.py
+++ b/pandas/io/common.py
@@ -106,11 +106,11 @@ def _urlopen(url, session=None):
             r = requests.get(url)
         r.raise_for_status()
         content = r.content
+        r.close()
     except ImportError:
-        r = urlopen(url)
-        content = r.read()
-        content_encoding = r.headers.get('Content-Encoding', None)
-    r.close()
+        with urlopen(url) as r:
+            content = r.read()
+            content_encoding = r.headers.get('Content-Encoding', None)
     if content_encoding == 'gzip':
         # Override compression based on Content-Encoding header.
         compression = 'gzip'

--- a/pandas/io/excel.py
+++ b/pandas/io/excel.py
@@ -332,7 +332,8 @@ def read_excel(io,
                         "`sheet`")
 
     if not isinstance(io, ExcelFile):
-        io = ExcelFile(io, engine=engine)
+        session = kwds.get('session', None)
+        io = ExcelFile(io, engine=engine, session=session)
 
     return io.parse(
         sheet_name=sheet_name,
@@ -396,10 +397,11 @@ class ExcelFile(object):
         if engine is not None and engine != 'xlrd':
             raise ValueError("Unknown engine: {engine}".format(engine=engine))
 
+        session = kwds.pop('session', None)
         # If io is a url, want to keep the data as bytes so can't pass
         # to get_filepath_or_buffer()
         if _is_url(self._io):
-            io = _urlopen(self._io)
+            io, _ = _urlopen(self._io, session=session)
         elif not isinstance(self.io, (ExcelFile, xlrd.Book)):
             io, _, _, _ = get_filepath_or_buffer(self._io)
 

--- a/pandas/io/html.py
+++ b/pandas/io/html.py
@@ -201,7 +201,8 @@ class _HtmlFrameParser(object):
     functionality.
     """
 
-    def __init__(self, io, match, attrs, encoding, displayed_only, session=None):
+    def __init__(self, io, match, attrs, encoding, displayed_only,
+                 session=None):
         self.io = io
         self.match = match
         self.attrs = attrs
@@ -892,7 +893,8 @@ def _parse(flavor, io, match, attrs, encoding, displayed_only, **kwargs):
     session = kwargs.get('session', None)
     for flav in flavor:
         parser = _parser_dispatch(flav)
-        p = parser(io, compiled_match, attrs, encoding, displayed_only, session)
+        p = parser(io, compiled_match, attrs, encoding, displayed_only,
+                   session)
 
         try:
             tables = p.parse_tables()

--- a/pandas/io/json/json.py
+++ b/pandas/io/json/json.py
@@ -228,7 +228,7 @@ class JSONTableWriter(FrameWriter):
 def read_json(path_or_buf=None, orient=None, typ='frame', dtype=True,
               convert_axes=True, convert_dates=True, keep_default_dates=True,
               numpy=False, precise_float=False, date_unit=None, encoding=None,
-              lines=False, chunksize=None, compression='infer'):
+              lines=False, chunksize=None, compression='infer', session=None):
     """
     Convert a JSON string to pandas object
 
@@ -410,6 +410,7 @@ def read_json(path_or_buf=None, orient=None, typ='frame', dtype=True,
     compression = _infer_compression(path_or_buf, compression)
     filepath_or_buffer, _, compression, should_close = get_filepath_or_buffer(
         path_or_buf, encoding=encoding, compression=compression,
+        session=session,
     )
 
     json_reader = JsonReader(

--- a/pandas/io/parsers.py
+++ b/pandas/io/parsers.py
@@ -319,6 +319,9 @@ float_precision : str, optional
     values. The options are `None` for the ordinary converter,
     `high` for the high-precision converter, and `round_trip` for the
     round-trip converter.
+session : requests.Session
+    object with the a requests session configuration for remote file.
+    (requires the requests library)
 
 Returns
 -------
@@ -401,10 +404,11 @@ def _read(filepath_or_buffer, kwds):
         encoding = re.sub('_', '-', encoding).lower()
         kwds['encoding'] = encoding
 
+    session = kwds.get('session', None)
     compression = kwds.get('compression')
     compression = _infer_compression(filepath_or_buffer, compression)
     filepath_or_buffer, _, compression, should_close = get_filepath_or_buffer(
-        filepath_or_buffer, encoding, compression)
+        filepath_or_buffer, encoding, compression, session=session)
     kwds['compression'] = compression
 
     if kwds.get('date_parser', None) is not None:
@@ -590,7 +594,8 @@ def _make_parser_function(name, default_sep=','):
                  delim_whitespace=False,
                  low_memory=_c_parser_defaults['low_memory'],
                  memory_map=False,
-                 float_precision=None):
+                 float_precision=None,
+                 session=None):
 
         # deprecate read_table GH21948
         if name == "read_table":
@@ -690,7 +695,8 @@ def _make_parser_function(name, default_sep=','):
                     mangle_dupe_cols=mangle_dupe_cols,
                     tupleize_cols=tupleize_cols,
                     infer_datetime_format=infer_datetime_format,
-                    skip_blank_lines=skip_blank_lines)
+                    skip_blank_lines=skip_blank_lines,
+                    session=session)
 
         return _read(filepath_or_buffer, kwds)
 


### PR DESCRIPTION
- [X] closes #16716
- [ ] tests added / passed
- [X] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry


Alternative to https://github.com/pandas-dev/pandas/pull/17087

I'll write the whatsnew entry, tests, and the session option for `html`, `json`, and `excel` if this path is OK with the devs.

Ping @skynss who is the original author of #17087 and @gfyoung who reviewed it.

Note that the main difference in this approach is that I made the option slightly simpler by allowing only the `session` instead of `http_params`.

You can see an example of this in action in:

http://nbviewer.jupyter.org/urls/gist.githubusercontent.com/ocefpaf/d6e9ab2c3569ff8fa181fc7885b6524d/raw/5d868fd4cbe2b81f84ccab7760b80251ef6e4651/pandas_test.ipynb