### PR TITLE
PERF: avoid unnecessary recoding in CategoricalIndex._create_categorical

### DIFF
--- a/pandas/core/indexes/category.py
+++ b/pandas/core/indexes/category.py
@@ -172,7 +172,10 @@ class CategoricalIndex(Index, accessor.PandasDelegate):
                 data = data.set_ordered(ordered)
             if isinstance(dtype, CategoricalDtype):
                 # we want to silently ignore dtype='category'
-                data = data._set_dtype(dtype)
+                if dtype != data.dtype:
+                    data = data._set_dtype(dtype)
+                else:
+                    data = data.copy()
         return data
 
     @classmethod


### PR DESCRIPTION
- [x] progress towards #20395
- [x] xref #21369
- [ ] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`

This issue was found when looking for a solution to #20395. I've found that ``CategoricalIndex._create_categorical`` makes an unnecessary call to ``Categorical._set_dtype`` when passed a dtype that is equal to self.dtype:

```python
>>> n = 100_000
>>> ci = pd.CategoricalIndex(list('a'*n + 'b'*n + 'c'*n))
>>> %timeit ci._create_categorical(ci, ci)
197 µs  # master and this PR
>>> %timeit ci._create_categorical(ci, ci, dtype=ci.dtype)
1.92 ms  # master
197 µs  # this PR
```

Internally, some operations in Pandas pass self.dtype to ``CategoricalIndex._create_categorical`` and onwards to ``_set_dtype``, which is a very slow code path.

By avoiding calling ``_set_dtype`` unnecessarily, some operations become faster. For example:

```python
>>> df = pd.DataFrame(dict(A=range(n*3)), index=ci)
>>> %timeit df.loc['b']
3.55 ms # master
2.14 ms  # this PR
```

As ``Categoricalndex._create_categorical`` is called directly or indirectly by various methods (e.g. ``CategoricalIndex._shallow_copy``), there are probably other places where this speedup is relevant also.