### PR TITLE
PERF: add method Categorical.__contains__

### DIFF
--- a/asv_bench/benchmarks/categoricals.py
+++ b/asv_bench/benchmarks/categoricals.py
@@ -202,7 +202,11 @@ class Contains(object):
     def setup(self):
         N = 10**5
         self.ci = tm.makeCategoricalIndex(N)
-        self.cat = self.ci.categories[0]
+        self.c = self.ci.values
+        self.key = self.ci.categories[0]
 
-    def time_contains(self):
-        self.cat in self.ci
+    def time_categorical_index_contains(self):
+        self.key in self.ci
+
+    def time_categorical_contains(self):
+        self.key in self.c

--- a/doc/source/whatsnew/v0.23.2.txt
+++ b/doc/source/whatsnew/v0.23.2.txt
@@ -26,7 +26,7 @@ Performance Improvements
 
 - Improved performance of membership checks in :class:`CategoricalIndex`
   (i.e. ``x in ci``-style checks are much faster). :meth:`CategoricalIndex.contains`
-  is likewise much faster (:issue:`21369`)
+  is likewise much faster (:issue:`21369`, :issue:`21508`)
 - Improved performance of :meth:`MultiIndex.is_unique` (:issue:`21522`)
 -
 

--- a/pandas/core/arrays/categorical.py
+++ b/pandas/core/arrays/categorical.py
@@ -1848,11 +1848,35 @@ class Categorical(ExtensionArray, PandasObject):
 
     @staticmethod
     def _contains(key, categories, container):
-        """Returns True if `key` is in `categories` and the
-        location of `key` in `categories` is in `container`.
+        """
+        Helper for membership check for ``key``.
 
-        This is a helper method used in :method:`Categorical.__contains__`
+        This helper method is used in :method:`Categorical.__contains__`
         and in :class:`CategoricalIndex.__contains__`.
+
+        Returns True if ``key`` is in ``categories`` and the
+        location of ``key`` in ``categories`` is in ``container``.
+
+        Parameters
+        ----------
+        key : a hashable object
+            The key to check membership for.
+        categories : Sequence
+            The possible values for ``key``. The location for ``key``
+            in ``categories`` is also its value in ``container``
+        container : Container (e.g. list-like or mapping)
+            The container to check for membership in.
+
+        Returns
+        -------
+        is_in : bool
+            True if ``key`` is in ``categories`` and location of
+            ``key`` in ``categories`` is in ``container``, else False.
+
+        Notes
+        -----
+        This method does not check for Nan values. Do that separately
+        before calling this method.
         """
 
         # is key in categories? Then get its location in categories.

--- a/pandas/core/arrays/categorical.py
+++ b/pandas/core/arrays/categorical.py
@@ -183,9 +183,11 @@ def contains(cat, key, container):
 
     Notes
     -----
-    This method does not check for Nan values. Do that separately
+    This method does not check for NaN values. Do that separately
     before calling this method.
     """
+    hash(key)
+
     # get location of key in categories.
     # If a KeyError, the key isn't in categories, so logically
     #  can't be in container either.
@@ -1897,9 +1899,8 @@ class Categorical(ExtensionArray, PandasObject):
 
     def __contains__(self, key):
         """Returns True if `key` is in this Categorical."""
-        hash(key)
-
-        if isna(key):  # if key is a NaN, check if any NaN is in self.
+        # if key is a NaN, check if any NaN is in self.
+        if isna(key):
             return self.isna().any()
 
         return contains(self, key, container=self._codes)

--- a/pandas/core/indexes/category.py
+++ b/pandas/core/indexes/category.py
@@ -24,6 +24,7 @@ from pandas.core import accessor
 import pandas.core.common as com
 import pandas.core.missing as missing
 import pandas.core.indexes.base as ibase
+from pandas.core.arrays import Categorical
 
 _index_doc_kwargs = dict(ibase._index_doc_kwargs)
 _index_doc_kwargs.update(dict(target_klass='CategoricalIndex'))
@@ -125,7 +126,6 @@ class CategoricalIndex(Index, accessor.PandasDelegate):
         CategoricalIndex
         """
 
-        from pandas.core.arrays import Categorical
         if categories is None:
             categories = self.categories
         if ordered is None:
@@ -162,7 +162,6 @@ class CategoricalIndex(Index, accessor.PandasDelegate):
         if not isinstance(data, ABCCategorical):
             if ordered is None and dtype is None:
                 ordered = False
-            from pandas.core.arrays import Categorical
             data = Categorical(data, categories=categories, ordered=ordered,
                                dtype=dtype)
         else:
@@ -328,23 +327,8 @@ class CategoricalIndex(Index, accessor.PandasDelegate):
         if isna(key):  # if key is a NaN, check if any NaN is in self.
             return self.hasnans
 
-        # is key in self.categories? Then get its location.
-        # If not (i.e. KeyError), it logically can't be in self either
-        try:
-            loc = self.categories.get_loc(key)
-        except KeyError:
-            return False
-
-        # loc is the location of key in self.categories, but also the value
-        # for key in self.codes and in self._engine. key may be in categories,
-        # but still not in self, check this. Example:
-        # 'b' in CategoricalIndex(['a'], categories=['a', 'b']) #  False
-        if is_scalar(loc):
-            return loc in self._engine
-        else:
-            # if self.categories is IntervalIndex, loc is an array
-            # check if any scalar of the array is in self._engine
-            return any(loc_ in self._engine for loc_ in loc)
+        return Categorical._contains(key, categories=self.categories,
+                                     container=self._engine)
 
     @Appender(_index_shared_docs['contains'] % _index_doc_kwargs)
     def contains(self, key):
@@ -479,7 +463,6 @@ class CategoricalIndex(Index, accessor.PandasDelegate):
             other = self._na_value
         values = np.where(cond, self.values, other)
 
-        from pandas.core.arrays import Categorical
         cat = Categorical(values,
                           categories=self.categories,
                           ordered=self.ordered)
@@ -862,7 +845,6 @@ class CategoricalIndex(Index, accessor.PandasDelegate):
     def _add_accessors(cls):
         """ add in Categorical accessor methods """
 
-        from pandas.core.arrays import Categorical
         CategoricalIndex._add_delegate_accessors(
             delegate=Categorical, accessors=["rename_categories",
                                              "reorder_categories",

--- a/pandas/core/indexes/category.py
+++ b/pandas/core/indexes/category.py
@@ -24,7 +24,7 @@ from pandas.core import accessor
 import pandas.core.common as com
 import pandas.core.missing as missing
 import pandas.core.indexes.base as ibase
-from pandas.core.arrays import Categorical
+from pandas.core.arrays.categorical import Categorical, contains
 
 _index_doc_kwargs = dict(ibase._index_doc_kwargs)
 _index_doc_kwargs.update(dict(target_klass='CategoricalIndex'))
@@ -327,8 +327,7 @@ class CategoricalIndex(Index, accessor.PandasDelegate):
         if isna(key):  # if key is a NaN, check if any NaN is in self.
             return self.hasnans
 
-        return Categorical._contains(key, categories=self.categories,
-                                     container=self._engine)
+        return contains(self, key, container=self._engine)
 
     @Appender(_index_shared_docs['contains'] % _index_doc_kwargs)
     def contains(self, key):

--- a/pandas/core/indexes/category.py
+++ b/pandas/core/indexes/category.py
@@ -322,16 +322,14 @@ class CategoricalIndex(Index, accessor.PandasDelegate):
 
     @Appender(_index_shared_docs['__contains__'] % _index_doc_kwargs)
     def __contains__(self, key):
-        hash(key)
-
-        if isna(key):  # if key is a NaN, check if any NaN is in self.
+        # if key is a NaN, check if any NaN is in self.
+        if isna(key):
             return self.hasnans
 
         return contains(self, key, container=self._engine)
 
     @Appender(_index_shared_docs['contains'] % _index_doc_kwargs)
     def contains(self, key):
-        hash(key)
         return key in self
 
     def __array__(self, dtype=None):

--- a/pandas/tests/categorical/test_algos.py
+++ b/pandas/tests/categorical/test_algos.py
@@ -71,6 +71,23 @@ def test_isin_empty(empty):
     tm.assert_numpy_array_equal(expected, result)
 
 
+def test_contains():
+
+    c = pd.Categorical(list('aabbca'), categories=list('cab'))
+
+    assert 'b' in c
+    assert 'z' not in c
+    assert np.nan not in c
+
+    # assert codes NOT in index
+    assert 0 not in c
+    assert 1 not in c
+
+    c = pd.Categorical(list('aabbca') + [np.nan], categories=list('cab'))
+
+    assert np.nan in c
+
+
 class TestTake(object):
     # https://github.com/pandas-dev/pandas/issues/20664
 

--- a/pandas/tests/categorical/test_algos.py
+++ b/pandas/tests/categorical/test_algos.py
@@ -72,7 +72,7 @@ def test_isin_empty(empty):
 
 
 def test_contains():
-
+    # GH21508
     c = pd.Categorical(list('aabbca'), categories=list('cab'))
 
     assert 'b' in c
@@ -84,7 +84,6 @@ def test_contains():
     assert 1 not in c
 
     c = pd.Categorical(list('aabbca') + [np.nan], categories=list('cab'))
-
     assert np.nan in c
 
 

--- a/pandas/tests/categorical/test_algos.py
+++ b/pandas/tests/categorical/test_algos.py
@@ -71,22 +71,6 @@ def test_isin_empty(empty):
     tm.assert_numpy_array_equal(expected, result)
 
 
-def test_contains():
-    # GH21508
-    c = pd.Categorical(list('aabbca'), categories=list('cab'))
-
-    assert 'b' in c
-    assert 'z' not in c
-    assert np.nan not in c
-
-    # assert codes NOT in index
-    assert 0 not in c
-    assert 1 not in c
-
-    c = pd.Categorical(list('aabbca') + [np.nan], categories=list('cab'))
-    assert np.nan in c
-
-
 class TestTake(object):
     # https://github.com/pandas-dev/pandas/issues/20664
 

--- a/pandas/tests/categorical/test_operators.py
+++ b/pandas/tests/categorical/test_operators.py
@@ -291,3 +291,20 @@ class TestCategoricalOps(object):
 
         # invalid ufunc
         pytest.raises(TypeError, lambda: np.log(s))
+
+    def test_contains(self):
+        # GH21508
+        c = pd.Categorical(list('aabbca'), categories=list('cab'))
+
+        assert 'b' in c
+        assert 'z' not in c
+        assert np.nan not in c
+        with pytest.raises(TypeError):
+            assert [1] in c
+
+        # assert codes NOT in index
+        assert 0 not in c
+        assert 1 not in c
+
+        c = pd.Categorical(list('aabbca') + [np.nan], categories=list('cab'))
+        assert np.nan in c


### PR DESCRIPTION
- [x] closes #21022 
- [x] xref #21369
- [x] tests added / passed
- [x] benchmark added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry

Currently, membership checks in ``Categorical`` is very slow as explained by @fjetter in #21022. This PR fixes the issue. See also #21369 which fixed the similar issue for ``CategoricalIndex``.

Tests didn't exist beforehand and have been added.

ASV:

```
      before           after         ratio
     [9e982e18]       [28461f0c]
-      4.26±0.7ms         134±20μs     0.03  categoricals.Contains.time_categorical_contains

SOME BENCHMARKS HAVE CHANGED SIGNIFICANTLY.
```