### PR TITLE
Maintain Dict Ordering with Concat

### DIFF
--- a/doc/source/whatsnew/v0.23.2.txt
+++ b/doc/source/whatsnew/v0.23.2.txt
@@ -83,5 +83,5 @@ Bug Fixes
 **Other**
 
 - Bug in :meth:`Series.nlargest` for signed and unsigned integer dtypes when the minimum value is present (:issue:`21426`)
-- Bug in :class:`_Concatenator` should not sort Ordered Dictionaries (:issue:`21510`)
+- Bug in :class:`_Concatenator` should maintain dict ordering when :meth:`concat` is called (:issue:`2151`)
 -

--- a/doc/source/whatsnew/v0.23.2.txt
+++ b/doc/source/whatsnew/v0.23.2.txt
@@ -83,5 +83,5 @@ Bug Fixes
 **Other**
 
 - Bug in :meth:`Series.nlargest` for signed and unsigned integer dtypes when the minimum value is present (:issue:`21426`)
-- Bug in :class:`_Concatenator` should maintain dict ordering when :meth:`concat` is called (:issue:`2151`)
+- Bug in :meth:`concat` should maintain dict ordering when :meth:`concat` is called (:issue:`2151`)
 -

--- a/doc/source/whatsnew/v0.23.2.txt
+++ b/doc/source/whatsnew/v0.23.2.txt
@@ -83,4 +83,5 @@ Bug Fixes
 **Other**
 
 - Bug in :meth:`Series.nlargest` for signed and unsigned integer dtypes when the minimum value is present (:issue:`21426`)
+- Bug in :class:`_Concatenator` should not sort Ordered Dictionaries (:issue:21510`)
 -

--- a/doc/source/whatsnew/v0.23.2.txt
+++ b/doc/source/whatsnew/v0.23.2.txt
@@ -83,5 +83,5 @@ Bug Fixes
 **Other**
 
 - Bug in :meth:`Series.nlargest` for signed and unsigned integer dtypes when the minimum value is present (:issue:`21426`)
-- Bug in :class:`_Concatenator` should not sort Ordered Dictionaries (:issue:21510`)
+- Bug in :class:`_Concatenator` should not sort Ordered Dictionaries (:issue:`21510`)
 -

--- a/doc/source/whatsnew/v0.24.0.txt
+++ b/doc/source/whatsnew/v0.24.0.txt
@@ -255,6 +255,6 @@ Other
 ^^^^^
 
 - :meth: `~pandas.io.formats.style.Styler.background_gradient` now takes a ``text_color_threshold`` parameter to automatically lighten the text color based on the luminance of the background color. This improves readability with dark background colors without the need to limit the background colormap range. (:issue:`21258`)
--
+- Bug in :meth:`concat` should maintain dict order when :meth:`concat` is called (:issue:`2151`)
 -
 -

--- a/pandas/core/reshape/concat.py
+++ b/pandas/core/reshape/concat.py
@@ -1,7 +1,7 @@
 """
 concat routines
 """
-
+from collections import OrderedDict
 import numpy as np
 from pandas import compat, DataFrame, Series, Index, MultiIndex
 from pandas.core.index import (_get_objs_combined_axis,
@@ -250,7 +250,10 @@ class _Concatenator(object):
 
         if isinstance(objs, dict):
             if keys is None:
-                keys = sorted(objs)
+                if not isinstance(objs,OrderedDict):
+                    keys = sorted(objs)
+                else:
+                    keys = objs
             objs = [objs[k] for k in keys]
         else:
             objs = list(objs)

--- a/pandas/core/reshape/concat.py
+++ b/pandas/core/reshape/concat.py
@@ -250,7 +250,7 @@ class _Concatenator(object):
 
         if isinstance(objs, dict):
             if keys is None:
-                if not isinstance(objs,OrderedDict):
+                if not isinstance(objs, OrderedDict):
                     keys = sorted(objs)
                 else:
                     keys = objs

--- a/pandas/tests/reshape/test_concat.py
+++ b/pandas/tests/reshape/test_concat.py
@@ -1297,13 +1297,14 @@ class TestConcatenate(ConcatenateBase):
 
     def test_concat_with_ordered_dict(self):
         # GH 21510
-        ps = pd.concat(OrderedDict([('First', pd.Series(range(3))),
-                                    ('Another', pd.Series(range(4)))]))
-        ps_list = list(ps.keys())
-        exp_list = [('First', 0), ('First', 1), ('First', 2),
-                    ('Another', 0), ('Another', 1),
-                    ('Another', 2), ('Another', 3)]
-        assert ps_list == exp_list
+        result = pd.concat(OrderedDict([('First', pd.Series(range(3))),
+                                        ('Another', pd.Series(range(4)))]))
+        a = pd.Series(range(3), range(3))
+        b = pd.Series(range(4), range(4))
+        a.index = pd.MultiIndex.from_tuples([('First', v) for v in a.index])
+        b.index = pd.MultiIndex.from_tuples([('Another', v) for v in b.index])
+        expected = a.append(b)
+        tm.assert_series_equal(result, expected)
 
     def test_crossed_dtypes_weird_corner(self):
         columns = ['A', 'B', 'C', 'D']

--- a/pandas/tests/reshape/test_concat.py
+++ b/pandas/tests/reshape/test_concat.py
@@ -1300,9 +1300,10 @@ class TestConcatenate(ConcatenateBase):
         result = pd.concat(OrderedDict([('First', pd.Series(range(3))),
                                         ('Another', pd.Series(range(4)))]))
         index = MultiIndex(levels=[['First', 'Another'], [0, 1, 2, 3]],
-                           labels=[[0, 0, 0, 1, 1, 1, 1], [0, 1, 2, 0, 1, 2, 3]])
+                           labels=[[0, 0, 0, 1, 1, 1, 1],
+                                   [0, 1, 2, 0, 1, 2, 3]])
         data = list(range(3)) + list(range(4))
-        expected = pd.Series(data,index=index)
+        expected = pd.Series(data, index=index)
         tm.assert_series_equal(result, expected)
 
     def test_crossed_dtypes_weird_corner(self):

--- a/pandas/tests/reshape/test_concat.py
+++ b/pandas/tests/reshape/test_concat.py
@@ -1299,11 +1299,10 @@ class TestConcatenate(ConcatenateBase):
         # GH 21510
         result = pd.concat(OrderedDict([('First', pd.Series(range(3))),
                                         ('Another', pd.Series(range(4)))]))
-        a = pd.Series(range(3), range(3))
-        b = pd.Series(range(4), range(4))
-        a.index = pd.MultiIndex.from_tuples([('First', v) for v in a.index])
-        b.index = pd.MultiIndex.from_tuples([('Another', v) for v in b.index])
-        expected = a.append(b)
+        index = MultiIndex(levels=[['First', 'Another'], [0, 1, 2, 3]],
+                           labels=[[0, 0, 0, 1, 1, 1, 1], [0, 1, 2, 0, 1, 2, 3]])
+        data = list(range(3)) + list(range(4))
+        expected = pd.Series(data,index=index)
         tm.assert_series_equal(result, expected)
 
     def test_crossed_dtypes_weird_corner(self):

--- a/pandas/tests/reshape/test_concat.py
+++ b/pandas/tests/reshape/test_concat.py
@@ -1,3 +1,4 @@
+from collections import OrderedDict
 from warnings import catch_warnings
 from itertools import combinations, product
 
@@ -1293,6 +1294,16 @@ class TestConcatenate(ConcatenateBase):
 
         tm.assert_frame_equal(result, exp)
         assert result.index.names == exp.index.names
+
+    def test_concat_with_ordered_dict(self):
+        # GH 21510
+        ps = pd.concat(OrderedDict([('First', pd.Series(range(3))),
+                                    ('Another', pd.Series(range(4)))]))
+        ps_list = list(ps.keys())
+        exp_list = [('First', 0), ('First', 1), ('First', 2),
+                    ('Another', 0), ('Another', 1),
+                    ('Another', 2), ('Another', 3)]
+        assert ps_list == exp_list
 
     def test_crossed_dtypes_weird_corner(self):
         columns = ['A', 'B', 'C', 'D']


### PR DESCRIPTION
- [x] closes #21510
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry

although the set is instance of dict, it should not sort if it is also instance of OrderedDict