### PR TITLE
PERF: remove useless overrides

### DIFF
--- a/doc/source/whatsnew/v0.23.2.txt
+++ b/doc/source/whatsnew/v0.23.2.txt
@@ -27,6 +27,7 @@ Performance Improvements
 - Improved performance of membership checks in :class:`CategoricalIndex`
   (i.e. ``x in ci``-style checks are much faster). :meth:`CategoricalIndex.contains`
   is likewise much faster (:issue:`21369`)
+- Improved performance of :meth:`MultiIndex.is_unique` (:issue:`21522`)
 -
 
 Documentation Changes

--- a/pandas/core/indexes/multi.py
+++ b/pandas/core/indexes/multi.py
@@ -853,14 +853,6 @@ class MultiIndex(Index):
         return True
 
     @cache_readonly
-    def is_monotonic(self):
-        """
-        return if the index is monotonic increasing (only equal or
-        increasing) values.
-        """
-        return self.is_monotonic_increasing
-
-    @cache_readonly
     def is_monotonic_increasing(self):
         """
         return if the index is monotonic increasing (only equal or
@@ -886,10 +878,6 @@ class MultiIndex(Index):
         """
         # monotonic decreasing if and only if reverse is monotonic increasing
         return self[::-1].is_monotonic_increasing
-
-    @cache_readonly
-    def is_unique(self):
-        return not self.duplicated().any()
 
     @cache_readonly
     def _have_mixed_levels(self):


### PR DESCRIPTION
- [x] closes #21522
- [x] tests passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry

Asv run:

```
       before           after         ratio
     [9e982e18]       [705f0e3b]
-         243±7ms          186±4ms     0.77  multiindex_object.GetLoc.time_large_get_loc_warm
-       220±0.9ms          151±3ms     0.69  multiindex_object.GetLoc.time_large_get_loc
-         173±1ms          101±2ms     0.59  multiindex_object.Integer.time_get_indexer

SOME BENCHMARKS HAVE CHANGED SIGNIFICANTLY.
```

Notice that as of now the same _cannot_ be done for ``.is_monotonic_increasing`` and friends, because the sortedness of the ``MultiIndex`` corresponds to the sortedness of the underlying int index only if levels are themselves sorted.