### PR TITLE
remove daytime attr, move getstate and setstate to base class

### DIFF
--- a/pandas/tseries/offsets.py
+++ b/pandas/tseries/offsets.py
@@ -423,30 +423,6 @@ class DateOffset(BaseOffset):
     def nanos(self):
         raise ValueError("{name} is a non-fixed frequency".format(name=self))
 
-    def __setstate__(self, state):
-        """Reconstruct an instance from a pickled state"""
-        if 'offset' in state:
-            # Older (<0.22.0) versions have offset attribute instead of _offset
-            if '_offset' in state:  # pragma: no cover
-                raise AssertionError('Unexpected key `_offset`')
-            state['_offset'] = state.pop('offset')
-            state['kwds']['offset'] = state['_offset']
-
-        if '_offset' in state and not isinstance(state['_offset'], timedelta):
-            # relativedelta, we need to populate using its kwds
-            offset = state['_offset']
-            odict = offset.__dict__
-            kwds = {key: odict[key] for key in odict if odict[key]}
-            state.update(kwds)
-
-        self.__dict__ = state
-        if 'weekmask' in state and 'holidays' in state:
-            calendar, holidays = _get_calendar(weekmask=self.weekmask,
-                                               holidays=self.holidays,
-                                               calendar=None)
-            self.calendar = calendar
-            self.holidays = holidays
-
 
 class SingleConstructorOffset(DateOffset):
     @classmethod
@@ -493,21 +469,6 @@ class BusinessMixin(object):
         if attrs:
             out += ': ' + ', '.join(attrs)
         return out
-
-    def __getstate__(self):
-        """Return a pickleable state"""
-        state = self.__dict__.copy()
-
-        # we don't want to actually pickle the calendar object
-        # as its a np.busyday; we recreate on deserilization
-        if 'calendar' in state:
-            del state['calendar']
-        try:
-            state['kwds'].pop('calendar')
-        except KeyError:
-            pass
-
-        return state
 
 
 class BusinessDay(BusinessMixin, SingleConstructorOffset):
@@ -690,7 +651,6 @@ class BusinessHourMixin(BusinessMixin):
             until = datetime(2014, 4, 1, self.end.hour, self.end.minute)
             return (until - dtstart).total_seconds()
         else:
-            self.daytime = False
             dtstart = datetime(2014, 4, 1, self.start.hour, self.start.minute)
             until = datetime(2014, 4, 2, self.end.hour, self.end.minute)
             return (until - dtstart).total_seconds()


### PR DESCRIPTION
If/when #18224 is revived to make `_BaseOffset` a `cdef class`, we'll need to move `__getstate__` and `__setstate__` into the base class (and then make some changes).  This moves the two methods pre-emptively so that we'll have a smaller diff for the next steps.

Also removes an attr `self.daytime` that is not used anywhere else.