### PR TITLE
BUG: Fix json_normalize throwing TypeError (#21536)

### DIFF
--- a/doc/source/whatsnew/v0.23.2.txt
+++ b/doc/source/whatsnew/v0.23.2.txt
@@ -64,7 +64,7 @@ Bug Fixes
 
 **I/O**
 
--
+- Bug in :meth:`json_normalize` where passing an array of values and a `record_prefix` would raise a `TypeError` (:issue:`21536`)
 -
 
 **Plotting**

--- a/doc/source/whatsnew/v0.23.2.txt
+++ b/doc/source/whatsnew/v0.23.2.txt
@@ -65,7 +65,7 @@ Bug Fixes
 **I/O**
 
 - Bug in :func:`read_csv` that caused it to incorrectly raise an error when ``nrows=0``, ``low_memory=True``, and ``index_col`` was not ``None`` (:issue:`21141`)
-- Bug in :func:`json_normalize` where passing an array of values and a `record_prefix` would raise a `TypeError` (:issue:`21536`)
+- Bug in :func:`json_normalize` when formatting the ``record_prefix`` with integer columns (:issue:`21536`)
 -
 
 **Plotting**

--- a/pandas/io/json/normalize.py
+++ b/pandas/io/json/normalize.py
@@ -170,6 +170,11 @@ def json_normalize(data, record_path=None, meta=None,
     3      Summit        1234   John Kasich     Ohio        OH
     4    Cuyahoga        1337   John Kasich     Ohio        OH
 
+    >>> data = {'A': [1, 2]}
+    >>> json_normalize(data, 'A', record_prefix='Prefix.')
+        Prefix.0
+    0          1
+    1          2
     """
     def _pull_field(js, spec):
         result = js

--- a/pandas/io/json/normalize.py
+++ b/pandas/io/json/normalize.py
@@ -259,8 +259,8 @@ def json_normalize(data, record_path=None, meta=None,
     result = DataFrame(records)
 
     if record_prefix is not None:
-        result.rename(columns=lambda x: "{p}{c}".format(p=record_prefix, c=x),
-                      inplace=True)
+        result = result.rename(
+            columns=lambda x: "{p}{c}".format(p=record_prefix, c=x))
 
     # Data types, a problem
     for k, v in compat.iteritems(meta_vals):

--- a/pandas/io/json/normalize.py
+++ b/pandas/io/json/normalize.py
@@ -259,7 +259,8 @@ def json_normalize(data, record_path=None, meta=None,
     result = DataFrame(records)
 
     if record_prefix is not None:
-        result.rename(columns=lambda x: record_prefix + x, inplace=True)
+        result.rename(columns=lambda x: "{p}{c}".format(p=record_prefix, c=x),
+                      inplace=True)
 
     # Data types, a problem
     for k, v in compat.iteritems(meta_vals):

--- a/pandas/tests/io/json/test_normalize.py
+++ b/pandas/tests/io/json/test_normalize.py
@@ -127,7 +127,7 @@ class TestJSONNormalize(object):
         # GH 21536
         result = json_normalize({'A': [1, 2]}, 'A', record_prefix='Prefix.')
         expected = DataFrame([[1], [2]], columns=['Prefix.0'])
-        tm.assert_frame_equal(result.reindex_like(expected), expected)
+        tm.assert_frame_equal(result, expected)
 
     def test_more_deeply_nested(self, deep_nested):
 

--- a/pandas/tests/io/json/test_normalize.py
+++ b/pandas/tests/io/json/test_normalize.py
@@ -123,6 +123,12 @@ class TestJSONNormalize(object):
                           'country', 'states_name']).sort_values()
         assert result.columns.sort_values().equals(expected)
 
+    def test_value_array_record_prefix(self):
+        # GH 21536
+        result = json_normalize({'A': [1, 2]}, 'A', record_prefix='Prefix.')
+        expected = DataFrame([[1], [2]], columns=['Prefix.0'])
+        tm.assert_frame_equal(result.reindex_like(expected), expected)
+
     def test_more_deeply_nested(self, deep_nested):
 
         result = json_normalize(deep_nested, ['states', 'cities'],


### PR DESCRIPTION
Fix json_normalize throwing TypeError with array of values and record_prefix (#21536)

- [x] closes #21536
- [x] tests added / passed
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry
