### PR TITLE
BUG: Fix group index calculation to prevent hitting maximum recursion depth (#21524)

### DIFF
--- a/doc/source/whatsnew/v0.23.2.txt
+++ b/doc/source/whatsnew/v0.23.2.txt
@@ -60,6 +60,7 @@ Bug Fixes
 
 - Bug in :meth:`Index.get_indexer_non_unique` with categorical key (:issue:`21448`)
 - Bug in comparison operations for :class:`MultiIndex` where error was raised on equality / inequality comparison involving a MultiIndex with ``nlevels == 1`` (:issue:`21149`)
+- Bug in calculation of group index causing "maximum recursion depth exceeded" errors during ``DataFrame.duplicated`` calls  (:issue:`21524`).
 -
 
 **I/O**

--- a/doc/source/whatsnew/v0.23.2.txt
+++ b/doc/source/whatsnew/v0.23.2.txt
@@ -60,7 +60,7 @@ Bug Fixes
 
 - Bug in :meth:`Index.get_indexer_non_unique` with categorical key (:issue:`21448`)
 - Bug in comparison operations for :class:`MultiIndex` where error was raised on equality / inequality comparison involving a MultiIndex with ``nlevels == 1`` (:issue:`21149`)
-- Bug in calculation of group index causing "maximum recursion depth exceeded" errors during ``DataFrame.duplicated`` calls  (:issue:`21524`).
+- Bug in :func:`DataFrame.duplicated` with a large number of columns causing a 'maximum recursion depth exceeded' (:issue:`21524`).
 -
 
 **I/O**

--- a/pandas/core/sorting.py
+++ b/pandas/core/sorting.py
@@ -52,7 +52,8 @@ def get_group_index(labels, shape, sort, xnull):
                 return i
         return len(shape)
 
-    def maybe_lift(lab, size):  # pormote nan values
+    def maybe_lift(lab, size):
+        # promote nan values (assigned to -1 here) so that all values are non-negative
         return (lab + 1, size + 1) if (lab == -1).any() else (lab, size)
 
     labels = map(_ensure_int64, labels)
@@ -62,6 +63,8 @@ def get_group_index(labels, shape, sort, xnull):
     labels = list(labels)
     shape = list(shape)
 
+    # Iteratively process all the labels in chunks sized so less than _INT64_MAX unique int ids
+    # will be required for each chunk
     while True:
         # how many levels can be done without overflow:
         nlev = _int64_cut_off(shape)

--- a/pandas/core/sorting.py
+++ b/pandas/core/sorting.py
@@ -53,8 +53,8 @@ def get_group_index(labels, shape, sort, xnull):
         return len(shape)
 
     def maybe_lift(lab, size):
-        # promote nan values (assigned to -1 here)
-        # so that all values are non-negative
+        # promote nan values (assigned -1 label in lab array)
+        # so that all output values are non-negative
         return (lab + 1, size + 1) if (lab == -1).any() else (lab, size)
 
     labels = map(_ensure_int64, labels)

--- a/pandas/core/sorting.py
+++ b/pandas/core/sorting.py
@@ -53,7 +53,8 @@ def get_group_index(labels, shape, sort, xnull):
         return len(shape)
 
     def maybe_lift(lab, size):
-        # promote nan values (assigned to -1 here) so that all values are non-negative
+        # promote nan values (assigned to -1 here)
+        # so that all values are non-negative
         return (lab + 1, size + 1) if (lab == -1).any() else (lab, size)
 
     labels = map(_ensure_int64, labels)
@@ -63,8 +64,8 @@ def get_group_index(labels, shape, sort, xnull):
     labels = list(labels)
     shape = list(shape)
 
-    # Iteratively process all the labels in chunks sized so less than _INT64_MAX unique int ids
-    # will be required for each chunk
+    # Iteratively process all the labels in chunks sized so less
+    # than _INT64_MAX unique int ids will be required for each chunk
     while True:
         # how many levels can be done without overflow:
         nlev = _int64_cut_off(shape)

--- a/pandas/tests/frame/test_analytics.py
+++ b/pandas/tests/frame/test_analytics.py
@@ -1527,6 +1527,7 @@ class TestDataFrameAnalytics(TestData):
         with pytest.raises(KeyError):
             df.drop_duplicates(subset)
 
+    @pytest.mark.slow
     def test_duplicated_do_not_fail_on_wide_dataframes(self):
         # Given the wide dataframe with a lot of columns
         # with different (important!) values

--- a/pandas/tests/frame/test_analytics.py
+++ b/pandas/tests/frame/test_analytics.py
@@ -1528,15 +1528,18 @@ class TestDataFrameAnalytics(TestData):
             df.drop_duplicates(subset)
 
     def test_duplicated_do_not_fail_on_wide_dataframes(self):
-        # Given the wide dataframe with a lot of columns with different (important!) values
+        # Given the wide dataframe with a lot of columns
+        # with different (important!) values
         data = {}
         for i in range(100):
             data['col_{0:02d}'.format(i)] = np.random.randint(0, 1000, 30000)
         df = pd.DataFrame(data).T
         # When we request to calculate duplicates
         dupes = df.duplicated()
-        # Then we get the bool pd.Series as a result (don't fail during calculation)
-        # Actual values doesn't matter here, though usually it's all False in this case
+        # Then we get the bool pd.Series as a result
+        # and don't fail during calculation.
+        # Actual values doesn't matter here, though usually
+        # it's all False in this case
         assert isinstance(dupes, pd.Series)
         assert dupes.dtype == np.bool
 

--- a/pandas/tests/frame/test_analytics.py
+++ b/pandas/tests/frame/test_analytics.py
@@ -1531,18 +1531,16 @@ class TestDataFrameAnalytics(TestData):
     def test_duplicated_do_not_fail_on_wide_dataframes(self):
         # Given the wide dataframe with a lot of columns
         # with different (important!) values
-        data = {}
-        for i in range(100):
-            data['col_{0:02d}'.format(i)] = np.random.randint(0, 1000, 30000)
+        data = {'col_{0:02d}'.format(i): np.random.randint(0, 1000, 30000)
+                for i in range(100)}
         df = pd.DataFrame(data).T
-        # When we request to calculate duplicates
-        dupes = df.duplicated()
-        # Then we get the bool pd.Series as a result
+        result = df.duplicated()
+        # Then duplicates produce the bool pd.Series as a result
         # and don't fail during calculation.
         # Actual values doesn't matter here, though usually
         # it's all False in this case
-        assert isinstance(dupes, pd.Series)
-        assert dupes.dtype == np.bool
+        assert isinstance(result, pd.Series)
+        assert result.dtype == np.bool
 
     def test_drop_duplicates_with_duplicate_column_names(self):
         # GH17836

--- a/pandas/tests/frame/test_analytics.py
+++ b/pandas/tests/frame/test_analytics.py
@@ -1527,6 +1527,19 @@ class TestDataFrameAnalytics(TestData):
         with pytest.raises(KeyError):
             df.drop_duplicates(subset)
 
+    def test_duplicated_do_not_fail_on_wide_dataframes(self):
+        # Given the wide dataframe with a lot of columns with different (important!) values
+        data = {}
+        for i in range(100):
+            data['col_{0:02d}'.format(i)] = np.random.randint(0, 1000, 30000)
+        df = pd.DataFrame(data).T
+        # When we request to calculate duplicates
+        dupes = df.duplicated()
+        # Then we get the bool pd.Series as a result (don't fail during calculation)
+        # Actual values doesn't matter here, though usually it's all False in this case
+        assert isinstance(dupes, pd.Series)
+        assert dupes.dtype == np.bool
+
     def test_drop_duplicates_with_duplicate_column_names(self):
         # GH17836
         df = DataFrame([

--- a/pandas/tests/frame/test_analytics.py
+++ b/pandas/tests/frame/test_analytics.py
@@ -1529,12 +1529,14 @@ class TestDataFrameAnalytics(TestData):
 
     @pytest.mark.slow
     def test_duplicated_do_not_fail_on_wide_dataframes(self):
+        # gh-21524
         # Given the wide dataframe with a lot of columns
         # with different (important!) values
         data = {'col_{0:02d}'.format(i): np.random.randint(0, 1000, 30000)
                 for i in range(100)}
         df = pd.DataFrame(data).T
         result = df.duplicated()
+
         # Then duplicates produce the bool pd.Series as a result
         # and don't fail during calculation.
         # Actual values doesn't matter here, though usually


### PR DESCRIPTION
This just replaces tail recursion call with a simple loop. It should have no effect whatsoever on a performance but prevent hitting recursion limits on some input data ( See example in my issue here: https://github.com/pandas-dev/pandas/issues/21524 )

- [x] closes #21524 
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry
