### PR TITLE
style.bar: add support for axis=None (tablewise application instead of rowwise or columnwise)

### DIFF
--- a/doc/source/whatsnew/v0.24.0.txt
+++ b/doc/source/whatsnew/v0.24.0.txt
@@ -728,6 +728,7 @@ Other
 - :meth: `~pandas.io.formats.style.Styler.background_gradient` now takes a ``text_color_threshold`` parameter to automatically lighten the text color based on the luminance of the background color. This improves readability with dark background colors without the need to limit the background colormap range. (:issue:`21258`)
 - Require at least 0.28.2 version of ``cython`` to support read-only memoryviews (:issue:`21688`)
 - :meth: `~pandas.io.formats.style.Styler.background_gradient` now also supports tablewise application (in addition to rowwise and columnwise) with ``axis=None`` (:issue:`15204`)
+- :meth: `~pandas.io.formats.style.Styler.bar` now also supports tablewise application (in addition to rowwise and columnwise) with ``axis=None``
 -
 -
 -

--- a/doc/source/whatsnew/v0.24.0.txt
+++ b/doc/source/whatsnew/v0.24.0.txt
@@ -725,10 +725,10 @@ Build Changes
 Other
 ^^^^^
 
-- :meth: `~pandas.io.formats.style.Styler.background_gradient` now takes a ``text_color_threshold`` parameter to automatically lighten the text color based on the luminance of the background color. This improves readability with dark background colors without the need to limit the background colormap range. (:issue:`21258`)
+- :meth:`~pandas.io.formats.style.Styler.background_gradient` now takes a ``text_color_threshold`` parameter to automatically lighten the text color based on the luminance of the background color. This improves readability with dark background colors without the need to limit the background colormap range. (:issue:`21258`)
 - Require at least 0.28.2 version of ``cython`` to support read-only memoryviews (:issue:`21688`)
-- :meth: `~pandas.io.formats.style.Styler.background_gradient` now also supports tablewise application (in addition to rowwise and columnwise) with ``axis=None`` (:issue:`15204`)
-- :meth: `~pandas.io.formats.style.Styler.bar` now also supports tablewise application (in addition to rowwise and columnwise) with ``axis=None``
+- :meth:`~pandas.io.formats.style.Styler.background_gradient` now also supports tablewise application (in addition to rowwise and columnwise) with ``axis=None`` (:issue:`15204`)
+- :meth:`~pandas.io.formats.style.Styler.bar` now also supports tablewise application (in addition to rowwise and columnwise) with ``axis=None`` and setting clipping range with ``vmin`` and ``vmax`` (:issue:`21548` and :issue:`21526`)
 -
 -
 -

--- a/doc/source/whatsnew/v0.24.0.txt
+++ b/doc/source/whatsnew/v0.24.0.txt
@@ -728,7 +728,7 @@ Other
 - :meth:`~pandas.io.formats.style.Styler.background_gradient` now takes a ``text_color_threshold`` parameter to automatically lighten the text color based on the luminance of the background color. This improves readability with dark background colors without the need to limit the background colormap range. (:issue:`21258`)
 - Require at least 0.28.2 version of ``cython`` to support read-only memoryviews (:issue:`21688`)
 - :meth:`~pandas.io.formats.style.Styler.background_gradient` now also supports tablewise application (in addition to rowwise and columnwise) with ``axis=None`` (:issue:`15204`)
-- :meth:`~pandas.io.formats.style.Styler.bar` now also supports tablewise application (in addition to rowwise and columnwise) with ``axis=None`` and setting clipping range with ``vmin`` and ``vmax`` (:issue:`21548` and :issue:`21526`)
+- :meth:`~pandas.io.formats.style.Styler.bar` now also supports tablewise application (in addition to rowwise and columnwise) with ``axis=None`` and setting clipping range with ``vmin`` and ``vmax`` (:issue:`21548` and :issue:`21526`). ``NaN`` values are also handled properly.
 -
 -
 -

--- a/pandas/io/formats/style.py
+++ b/pandas/io/formats/style.py
@@ -1053,36 +1053,40 @@ class Styler(object):
 
         Parameters
         ----------
-        subset: IndexSlice, optional
-            a valid slice for ``data`` to limit the style application to
-        axis: int, default 0, meaning column-wise
-        color: str or 2-tuple/list
+        subset : IndexSlice, optional
+            A valid slice for `data` to limit the style application to.
+        axis : int, str or None, default 0
+            Apply to each column (`axis=0` or `'index'`)
+            or to each row (`axis=1` or `'columns'`) or
+            to the entire DataFrame at once with `axis=None`.
+        color : str or 2-tuple/list
             If a str is passed, the color is the same for both
             negative and positive numbers. If 2-tuple/list is used, the
             first element is the color_negative and the second is the
-            color_positive (eg: ['#d65f5f', '#5fba7d'])
-        width: float, default 100
-            A number between 0 or 100. The largest value will cover ``width``
-            percent of the cell's width
+            color_positive (eg: ['#d65f5f', '#5fba7d']).
+        width : float, default 100
+            A number between 0 or 100. The largest value will cover `width`
+            percent of the cell's width.
         align : {'left', 'zero',' mid'}, default 'left'
-            - 'left' : the min value starts at the left of the cell
-            - 'zero' : a value of zero is located at the center of the cell
+            How to align the bars with the cells.
+            - 'left' : the min value starts at the left of the cell.
+            - 'zero' : a value of zero is located at the center of the cell.
             - 'mid' : the center of the cell is at (max-min)/2, or
               if values are all negative (positive) the zero is aligned
-              at the right (left) of the cell
+              at the right (left) of the cell.
 
               .. versionadded:: 0.20.0
 
-        vmin: float, optional
-            minimum bar value, defining the left hand limit
-            of the bar drawing range, lower values are clipped to ``vmin``.
+        vmin : float, optional
+            Minimum bar value, defining the left hand limit
+            of the bar drawing range, lower values are clipped to `vmin`.
             When None (default): the minimum value of the data will be used.
 
             .. versionadded:: 0.24.0
 
-        vmax: float, optional
-            maximum bar value, defining the right hand limit
-            of the bar drawing range, higher values are clipped to ``vmax``.
+        vmax : float, optional
+            Maximum bar value, defining the right hand limit
+            of the bar drawing range, higher values are clipped to `vmax`.
             When None (default): the maximum value of the data will be used.
 
             .. versionadded:: 0.24.0

--- a/pandas/io/formats/style.py
+++ b/pandas/io/formats/style.py
@@ -993,12 +993,12 @@ class Styler(object):
         return self.applymap(f, subset=subset)
 
     @staticmethod
-    def _bar(s, align, colors, width=100):
+    def _bar(s, align, colors, width=100, vmin=None, vmax=None):
         """Draw bar chart in dataframe cells"""
 
         # Get input value range.
-        smin = s.values.min()
-        smax = s.values.max()
+        smin = s.values.min() if vmin is None else vmin
+        smax = s.values.max() if vmax is None else vmax
         if align == 'mid':
             smin = min(0, smin)
             smax = max(0, smax)
@@ -1020,7 +1020,7 @@ class Styler(object):
                         s=start, c=color
                     )
                 css += '{c} {e:.1f}%, transparent {e:.1f}%)'.format(
-                    e=end, c=color,
+                    e=min(end, width), c=color,
                 )
             return css
 
@@ -1039,7 +1039,7 @@ class Styler(object):
             )
 
     def bar(self, subset=None, axis=0, color='#d65f5f', width=100,
-            align='left'):
+            align='left', vmin=None, vmax=None):
         """
         Draw bar chart in the cell backgrounds.
 
@@ -1065,6 +1065,21 @@ class Styler(object):
 
               .. versionadded:: 0.20.0
 
+        vmin: float, optional
+            minimum bar value, defining the left hand limit
+            of the bar drawing range, lower values are clipped to ``vmin``.
+            When None (default): the minimum value of the data will be used.
+
+            .. versionadded:: 0.24.0
+
+        vmax: float, optional
+            maximum bar value, defining the right hand limit
+            of the bar drawing range, higher values are clipped to ``vmax``.
+            When None (default): the maximum value of the data will be used.
+
+            .. versionadded:: 0.24.0
+
+
         Returns
         -------
         self : Styler
@@ -1084,7 +1099,8 @@ class Styler(object):
         subset = _maybe_numeric_slice(self.data, subset)
         subset = _non_reducing_slice(subset)
         self.apply(self._bar, subset=subset, axis=axis,
-                   align=align, colors=color, width=width)
+                   align=align, colors=color, width=width,
+                   vmin=vmin, vmax=vmax)
 
         return self
 

--- a/pandas/io/formats/style.py
+++ b/pandas/io/formats/style.py
@@ -30,6 +30,8 @@ from pandas.core.generic import _shared_docs
 import pandas.core.common as com
 from pandas.core.indexing import _maybe_numeric_slice, _non_reducing_slice
 from pandas.util._decorators import Appender
+from pandas.core.dtypes.generic import ABCSeries
+
 try:
     import matplotlib.pyplot as plt
     from matplotlib import colors
@@ -997,8 +999,12 @@ class Styler(object):
         """Draw bar chart in dataframe cells"""
 
         # Get input value range.
-        smin = s.values.min() if vmin is None else vmin
-        smax = s.values.max() if vmax is None else vmax
+        smin = s.min() if vmin is None else vmin
+        if isinstance(smin, ABCSeries):
+            smin = smin.min()
+        smax = s.max() if vmax is None else vmax
+        if isinstance(smax, ABCSeries):
+            smax = smax.max()
         if align == 'mid':
             smin = min(0, smin)
             smax = max(0, smax)
@@ -1025,6 +1031,8 @@ class Styler(object):
             return css
 
         def css(x):
+            if pd.isna(x):
+                return ''
             if align == 'left':
                 return css_bar(0, x, colors[x > zero])
             else:

--- a/pandas/tests/io/formats/test_style.py
+++ b/pandas/tests/io/formats/test_style.py
@@ -349,10 +349,10 @@ class TestStyler(object):
             (0, 0): ['width: 10em', ' height: 80%'],
             (1, 0): ['width: 10em', ' height: 80%',
                      'background: linear-gradient('
-                     '90deg,#d65f5f 50.0%, transparent 0%)'],
+                     '90deg,#d65f5f 50.0%, transparent 50.0%)'],
             (2, 0): ['width: 10em', ' height: 80%',
                      'background: linear-gradient('
-                     '90deg,#d65f5f 100.0%, transparent 0%)']
+                     '90deg,#d65f5f 100.0%, transparent 100.0%)']
         }
         assert result == expected
 
@@ -361,10 +361,10 @@ class TestStyler(object):
             (0, 0): ['width: 10em', ' height: 80%'],
             (1, 0): ['width: 10em', ' height: 80%',
                      'background: linear-gradient('
-                     '90deg,red 25.0%, transparent 0%)'],
+                     '90deg,red 25.0%, transparent 25.0%)'],
             (2, 0): ['width: 10em', ' height: 80%',
                      'background: linear-gradient('
-                     '90deg,red 50.0%, transparent 0%)']
+                     '90deg,red 50.0%, transparent 50.0%)']
         }
         assert result == expected
 
@@ -383,46 +383,46 @@ class TestStyler(object):
                     (0, 2): ['width: 10em', ' height: 80%'],
                     (1, 0): ['width: 10em', ' height: 80%',
                              'background: linear-gradient(90deg,#d65f5f 50.0%,'
-                             ' transparent 0%)'],
+                             ' transparent 50.0%)'],
                     (1, 1): ['width: 10em', ' height: 80%',
                              'background: linear-gradient(90deg,#d65f5f 50.0%,'
-                             ' transparent 0%)'],
+                             ' transparent 50.0%)'],
                     (1, 2): ['width: 10em', ' height: 80%',
                              'background: linear-gradient(90deg,#d65f5f 50.0%,'
-                             ' transparent 0%)'],
+                             ' transparent 50.0%)'],
                     (2, 0): ['width: 10em', ' height: 80%',
                              'background: linear-gradient(90deg,#d65f5f 100.0%'
-                             ', transparent 0%)'],
+                             ', transparent 100.0%)'],
                     (2, 1): ['width: 10em', ' height: 80%',
                              'background: linear-gradient(90deg,#d65f5f 100.0%'
-                             ', transparent 0%)'],
+                             ', transparent 100.0%)'],
                     (2, 2): ['width: 10em', ' height: 80%',
                              'background: linear-gradient(90deg,#d65f5f 100.0%'
-                             ', transparent 0%)']}
+                             ', transparent 100.0%)']}
         assert result == expected
 
         result = df.style.bar(axis=1)._compute().ctx
         expected = {(0, 0): ['width: 10em', ' height: 80%'],
                     (0, 1): ['width: 10em', ' height: 80%',
                              'background: linear-gradient(90deg,#d65f5f 50.0%,'
-                             ' transparent 0%)'],
+                             ' transparent 50.0%)'],
                     (0, 2): ['width: 10em', ' height: 80%',
                              'background: linear-gradient(90deg,#d65f5f 100.0%'
-                             ', transparent 0%)'],
+                             ', transparent 100.0%)'],
                     (1, 0): ['width: 10em', ' height: 80%'],
                     (1, 1): ['width: 10em', ' height: 80%',
                              'background: linear-gradient(90deg,#d65f5f 50.0%'
-                             ', transparent 0%)'],
+                             ', transparent 50.0%)'],
                     (1, 2): ['width: 10em', ' height: 80%',
                              'background: linear-gradient(90deg,#d65f5f 100.0%'
-                             ', transparent 0%)'],
+                             ', transparent 100.0%)'],
                     (2, 0): ['width: 10em', ' height: 80%'],
                     (2, 1): ['width: 10em', ' height: 80%',
                              'background: linear-gradient(90deg,#d65f5f 50.0%'
-                             ', transparent 0%)'],
+                             ', transparent 50.0%)'],
                     (2, 2): ['width: 10em', ' height: 80%',
                              'background: linear-gradient(90deg,#d65f5f 100.0%'
-                             ', transparent 0%)']}
+                             ', transparent 100.0%)']}
         assert result == expected
 
     def test_bar_align_mid_pos_and_neg(self):
@@ -432,21 +432,16 @@ class TestStyler(object):
                               '#d65f5f', '#5fba7d'])._compute().ctx
 
         expected = {(0, 0): ['width: 10em', ' height: 80%',
-                             'background: linear-gradient(90deg, '
-                             'transparent 0%, transparent 0.0%, #d65f5f 0.0%, '
+                             'background: linear-gradient(90deg,'
                              '#d65f5f 10.0%, transparent 10.0%)'],
-                    (1, 0): ['width: 10em', ' height: 80%',
-                             'background: linear-gradient(90deg, '
-                             'transparent 0%, transparent 10.0%, '
-                             '#d65f5f 10.0%, #d65f5f 10.0%, '
-                             'transparent 10.0%)'],
+                    (1, 0): ['width: 10em', ' height: 80%', ],
                     (2, 0): ['width: 10em', ' height: 80%',
                              'background: linear-gradient(90deg, '
-                             'transparent 0%, transparent 10.0%, #5fba7d 10.0%'
+                             'transparent 10.0%, #5fba7d 10.0%'
                              ', #5fba7d 30.0%, transparent 30.0%)'],
                     (3, 0): ['width: 10em', ' height: 80%',
                              'background: linear-gradient(90deg, '
-                             'transparent 0%, transparent 10.0%, '
+                             'transparent 10.0%, '
                              '#5fba7d 10.0%, #5fba7d 100.0%, '
                              'transparent 100.0%)']}
 
@@ -459,20 +454,16 @@ class TestStyler(object):
                               '#d65f5f', '#5fba7d'])._compute().ctx
 
         expected = {(0, 0): ['width: 10em', ' height: 80%',
-                             'background: linear-gradient(90deg, '
-                             'transparent 0%, transparent 0.0%, #5fba7d 0.0%, '
+                             'background: linear-gradient(90deg,'
                              '#5fba7d 10.0%, transparent 10.0%)'],
                     (1, 0): ['width: 10em', ' height: 80%',
-                             'background: linear-gradient(90deg, '
-                             'transparent 0%, transparent 0.0%, #5fba7d 0.0%, '
+                             'background: linear-gradient(90deg,'
                              '#5fba7d 20.0%, transparent 20.0%)'],
                     (2, 0): ['width: 10em', ' height: 80%',
-                             'background: linear-gradient(90deg, '
-                             'transparent 0%, transparent 0.0%, #5fba7d 0.0%, '
+                             'background: linear-gradient(90deg,'
                              '#5fba7d 50.0%, transparent 50.0%)'],
                     (3, 0): ['width: 10em', ' height: 80%',
-                             'background: linear-gradient(90deg, '
-                             'transparent 0%, transparent 0.0%, #5fba7d 0.0%, '
+                             'background: linear-gradient(90deg,'
                              '#5fba7d 100.0%, transparent 100.0%)']}
 
         assert result == expected
@@ -484,23 +475,21 @@ class TestStyler(object):
                               '#d65f5f', '#5fba7d'])._compute().ctx
 
         expected = {(0, 0): ['width: 10em', ' height: 80%',
-                             'background: linear-gradient(90deg, '
-                             'transparent 0%, transparent 0.0%, '
-                             '#d65f5f 0.0%, #d65f5f 100.0%, '
-                             'transparent 100.0%)'],
+                             'background: linear-gradient(90deg,'
+                             '#d65f5f 100.0%, transparent 100.0%)'],
                     (1, 0): ['width: 10em', ' height: 80%',
                              'background: linear-gradient(90deg, '
-                             'transparent 0%, transparent 40.0%, '
+                             'transparent 40.0%, '
                              '#d65f5f 40.0%, #d65f5f 100.0%, '
                              'transparent 100.0%)'],
                     (2, 0): ['width: 10em', ' height: 80%',
                              'background: linear-gradient(90deg, '
-                             'transparent 0%, transparent 70.0%, '
+                             'transparent 70.0%, '
                              '#d65f5f 70.0%, #d65f5f 100.0%, '
                              'transparent 100.0%)'],
                     (3, 0): ['width: 10em', ' height: 80%',
                              'background: linear-gradient(90deg, '
-                             'transparent 0%, transparent 80.0%, '
+                             'transparent 80.0%, '
                              '#d65f5f 80.0%, #d65f5f 100.0%, '
                              'transparent 100.0%)']}
         assert result == expected
@@ -511,25 +500,75 @@ class TestStyler(object):
 
         result = df.style.bar(align='zero', color=[
                               '#d65f5f', '#5fba7d'], width=90)._compute().ctx
-
         expected = {(0, 0): ['width: 10em', ' height: 80%',
                              'background: linear-gradient(90deg, '
-                             'transparent 0%, transparent 45.0%, '
-                             '#d65f5f 45.0%, #d65f5f 50%, '
-                             'transparent 50%)'],
-                    (1, 0): ['width: 10em', ' height: 80%',
-                             'background: linear-gradient(90deg, '
-                             'transparent 0%, transparent 50%, '
-                             '#5fba7d 50%, #5fba7d 50.0%, '
-                             'transparent 50.0%)'],
+                             'transparent 40.0%, #d65f5f 40.0%, '
+                             '#d65f5f 45.0%, transparent 45.0%)'],
+                    (1, 0): ['width: 10em', ' height: 80%'],
                     (2, 0): ['width: 10em', ' height: 80%',
                              'background: linear-gradient(90deg, '
-                             'transparent 0%, transparent 50%, #5fba7d 50%, '
-                             '#5fba7d 60.0%, transparent 60.0%)'],
+                             'transparent 45.0%, #5fba7d 45.0%, '
+                             '#5fba7d 55.0%, transparent 55.0%)'],
                     (3, 0): ['width: 10em', ' height: 80%',
                              'background: linear-gradient(90deg, '
-                             'transparent 0%, transparent 50%, #5fba7d 50%, '
-                             '#5fba7d 95.0%, transparent 95.0%)']}
+                             'transparent 45.0%, #5fba7d 45.0%, '
+                             '#5fba7d 90.0%, transparent 90.0%)']}
+        assert result == expected
+
+    def test_bar_align_left_axis_none(self):
+        df = pd.DataFrame({'A': [0, 1], 'B': [2, 4]})
+        result = df.style.bar(axis=None)._compute().ctx
+        expected = {
+            (0, 0): ['width: 10em', ' height: 80%'],
+            (1, 0): ['width: 10em', ' height: 80%',
+                     'background: linear-gradient(90deg,'
+                     '#d65f5f 25.0%, transparent 25.0%)'],
+            (0, 1): ['width: 10em', ' height: 80%',
+                     'background: linear-gradient(90deg,'
+                     '#d65f5f 50.0%, transparent 50.0%)'],
+            (1, 1): ['width: 10em', ' height: 80%',
+                     'background: linear-gradient(90deg,'
+                     '#d65f5f 100.0%, transparent 100.0%)']
+        }
+        assert result == expected
+
+    def test_bar_align_zero_axis_none(self):
+        df = pd.DataFrame({'A': [0, 1], 'B': [-2, 4]})
+        result = df.style.bar(align='zero', axis=None)._compute().ctx
+        expected = {
+            (0, 0): ['width: 10em', ' height: 80%'],
+            (1, 0): ['width: 10em', ' height: 80%',
+                     'background: linear-gradient(90deg, '
+                     'transparent 50.0%, #d65f5f 50.0%, '
+                     '#d65f5f 62.5%, transparent 62.5%)'],
+            (0, 1): ['width: 10em', ' height: 80%',
+                     'background: linear-gradient(90deg, '
+                     'transparent 25.0%, #d65f5f 25.0%, '
+                     '#d65f5f 50.0%, transparent 50.0%)'],
+            (1, 1): ['width: 10em', ' height: 80%',
+                     'background: linear-gradient(90deg, '
+                     'transparent 50.0%, #d65f5f 50.0%, '
+                     '#d65f5f 100.0%, transparent 100.0%)']
+        }
+        assert result == expected
+
+    def test_bar_align_mid_axis_none(self):
+        df = pd.DataFrame({'A': [0, 1], 'B': [-2, 4]})
+        result = df.style.bar(align='mid', axis=None)._compute().ctx
+        expected = {
+            (0, 0): ['width: 10em', ' height: 80%'],
+            (1, 0): ['width: 10em', ' height: 80%',
+                     'background: linear-gradient(90deg, '
+                     'transparent 33.3%, #d65f5f 33.3%, '
+                     '#d65f5f 50.0%, transparent 50.0%)'],
+            (0, 1): ['width: 10em', ' height: 80%',
+                     'background: linear-gradient(90deg,'
+                     '#d65f5f 33.3%, transparent 33.3%)'],
+            (1, 1): ['width: 10em', ' height: 80%',
+                     'background: linear-gradient(90deg, '
+                     'transparent 33.3%, #d65f5f 33.3%, '
+                     '#d65f5f 100.0%, transparent 100.0%)']
+        }
         assert result == expected
 
     def test_bar_bad_align_raises(self):

--- a/pandas/tests/io/formats/test_style.py
+++ b/pandas/tests/io/formats/test_style.py
@@ -651,6 +651,45 @@ class TestStyler(object):
         }
         assert result == expected
 
+    def test_bar_align_mid_nans(self):
+        df = pd.DataFrame({'A': [1, None], 'B': [-1, 3]})
+        result = df.style.bar(align='mid', axis=None)._compute().ctx
+        expected = {
+            (0, 0): ['width: 10em', ' height: 80%',
+                     'background: linear-gradient(90deg, '
+                     'transparent 25.0%, #d65f5f 25.0%, '
+                     '#d65f5f 50.0%, transparent 50.0%)'],
+            (1, 0): [''],
+            (0, 1): ['width: 10em', ' height: 80%',
+                     'background: linear-gradient(90deg,'
+                     '#d65f5f 25.0%, transparent 25.0%)'],
+            (1, 1): ['width: 10em', ' height: 80%',
+                     'background: linear-gradient(90deg, '
+                     'transparent 25.0%, #d65f5f 25.0%, '
+                     '#d65f5f 100.0%, transparent 100.0%)']
+        }
+        assert result == expected
+
+    def test_bar_align_zero_nans(self):
+        df = pd.DataFrame({'A': [1, None], 'B': [-1, 2]})
+        result = df.style.bar(align='zero', axis=None)._compute().ctx
+        expected = {
+            (0, 0): ['width: 10em', ' height: 80%',
+                     'background: linear-gradient(90deg, '
+                     'transparent 50.0%, #d65f5f 50.0%, '
+                     '#d65f5f 75.0%, transparent 75.0%)'],
+            (1, 0): [''],
+            (0, 1): ['width: 10em', ' height: 80%',
+                     'background: linear-gradient(90deg, '
+                     'transparent 25.0%, #d65f5f 25.0%, '
+                     '#d65f5f 50.0%, transparent 50.0%)'],
+            (1, 1): ['width: 10em', ' height: 80%',
+                     'background: linear-gradient(90deg, '
+                     'transparent 50.0%, #d65f5f 50.0%, '
+                     '#d65f5f 100.0%, transparent 100.0%)']
+        }
+        assert result == expected
+
     def test_bar_bad_align_raises(self):
         df = pd.DataFrame({'A': [-100, -60, -30, -20]})
         with pytest.raises(ValueError):

--- a/pandas/tests/io/formats/test_style.py
+++ b/pandas/tests/io/formats/test_style.py
@@ -571,6 +571,86 @@ class TestStyler(object):
         }
         assert result == expected
 
+    def test_bar_align_mid_vmin(self):
+        df = pd.DataFrame({'A': [0, 1], 'B': [-2, 4]})
+        result = df.style.bar(align='mid', axis=None, vmin=-6)._compute().ctx
+        expected = {
+            (0, 0): ['width: 10em', ' height: 80%'],
+            (1, 0): ['width: 10em', ' height: 80%',
+                     'background: linear-gradient(90deg, '
+                     'transparent 60.0%, #d65f5f 60.0%, '
+                     '#d65f5f 70.0%, transparent 70.0%)'],
+            (0, 1): ['width: 10em', ' height: 80%',
+                     'background: linear-gradient(90deg, '
+                     'transparent 40.0%, #d65f5f 40.0%, '
+                     '#d65f5f 60.0%, transparent 60.0%)'],
+            (1, 1): ['width: 10em', ' height: 80%',
+                     'background: linear-gradient(90deg, '
+                     'transparent 60.0%, #d65f5f 60.0%, '
+                     '#d65f5f 100.0%, transparent 100.0%)']
+        }
+        assert result == expected
+
+    def test_bar_align_mid_vmax(self):
+        df = pd.DataFrame({'A': [0, 1], 'B': [-2, 4]})
+        result = df.style.bar(align='mid', axis=None, vmax=8)._compute().ctx
+        expected = {
+            (0, 0): ['width: 10em', ' height: 80%'],
+            (1, 0): ['width: 10em', ' height: 80%',
+                     'background: linear-gradient(90deg, '
+                     'transparent 20.0%, #d65f5f 20.0%, '
+                     '#d65f5f 30.0%, transparent 30.0%)'],
+            (0, 1): ['width: 10em', ' height: 80%',
+                     'background: linear-gradient(90deg,'
+                     '#d65f5f 20.0%, transparent 20.0%)'],
+            (1, 1): ['width: 10em', ' height: 80%',
+                     'background: linear-gradient(90deg, '
+                     'transparent 20.0%, #d65f5f 20.0%, '
+                     '#d65f5f 60.0%, transparent 60.0%)']
+        }
+        assert result == expected
+
+    def test_bar_align_mid_vmin_vmax_wide(self):
+        df = pd.DataFrame({'A': [0, 1], 'B': [-2, 4]})
+        result = df.style.bar(align='mid', axis=None,
+                              vmin=-3, vmax=7)._compute().ctx
+        expected = {
+            (0, 0): ['width: 10em', ' height: 80%'],
+            (1, 0): ['width: 10em', ' height: 80%',
+                     'background: linear-gradient(90deg, '
+                     'transparent 30.0%, #d65f5f 30.0%, '
+                     '#d65f5f 40.0%, transparent 40.0%)'],
+            (0, 1): ['width: 10em', ' height: 80%',
+                     'background: linear-gradient(90deg, '
+                     'transparent 10.0%, #d65f5f 10.0%, '
+                     '#d65f5f 30.0%, transparent 30.0%)'],
+            (1, 1): ['width: 10em', ' height: 80%',
+                     'background: linear-gradient(90deg, '
+                     'transparent 30.0%, #d65f5f 30.0%, '
+                     '#d65f5f 70.0%, transparent 70.0%)']
+        }
+        assert result == expected
+
+    def test_bar_align_mid_vmin_vmax_clipping(self):
+        df = pd.DataFrame({'A': [0, 1], 'B': [-2, 4]})
+        result = df.style.bar(align='mid', axis=None,
+                              vmin=-1, vmax=3)._compute().ctx
+        expected = {
+            (0, 0): ['width: 10em', ' height: 80%'],
+            (1, 0): ['width: 10em', ' height: 80%',
+                     'background: linear-gradient(90deg, '
+                     'transparent 25.0%, #d65f5f 25.0%, '
+                     '#d65f5f 50.0%, transparent 50.0%)'],
+            (0, 1): ['width: 10em', ' height: 80%',
+                     'background: linear-gradient(90deg,'
+                     '#d65f5f 25.0%, transparent 25.0%)'],
+            (1, 1): ['width: 10em', ' height: 80%',
+                     'background: linear-gradient(90deg, '
+                     'transparent 25.0%, #d65f5f 25.0%, '
+                     '#d65f5f 100.0%, transparent 100.0%)']
+        }
+        assert result == expected
+
     def test_bar_bad_align_raises(self):
         df = pd.DataFrame({'A': [-100, -60, -30, -20]})
         with pytest.raises(ValueError):


### PR DESCRIPTION
- eliminate code duplication related to style.bar with different align modes
- add support for axis=None
- fix minor bug with align 'zero' and width < 100
- make generated CSS gradients more compact

- [x] Closes #21525
- [x] tests added / passed
- [x] passes `git diff origin/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry
