### PR TITLE
REF: multi_take is now able to tackle all list-like (non-bool) cases

### DIFF
--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -902,6 +902,20 @@ class _NDFrameIndexer(_NDFrameIndexerBase):
         return retval
 
     def _multi_take_opportunity(self, tup):
+        """
+        Check whether there is the possibility to use ``_multi_take``.
+        Currently the limit is that all axes being indexed must be indexed with
+        list-likes.
+
+        Parameters
+        ----------
+        tup : tuple
+            Tuple of indexers, one per axis
+
+        Returns
+        -------
+        boolean: Whether the current indexing can be passed through _multi_take
+        """
         if not all(is_list_like_indexer(x) for x in tup):
             return False
 
@@ -912,9 +926,21 @@ class _NDFrameIndexer(_NDFrameIndexerBase):
         return True
 
     def _multi_take(self, tup):
-        """ create the reindex map for our objects, raise the _exception if we
-        can't create the indexer
         """
+        Create the indexers for the passed tuple of keys, and execute the take
+        operation. This allows the take operation to be executed all at once -
+        rather than once for each dimension - improving efficiency.
+
+        Parameters
+        ----------
+        tup : tuple
+            Tuple of indexers, one per axis
+
+        Returns
+        -------
+        values: same type as the object being indexed
+        """
+        # GH 836
         o = self.obj
         d = {axis: self._get_listlike_indexer(key, axis)
              for (key, axis) in zip(tup, o._AXIS_ORDERS)}

--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -902,23 +902,12 @@ class _NDFrameIndexer(_NDFrameIndexerBase):
         return retval
 
     def _multi_take_opportunity(self, tup):
-        from pandas.core.generic import NDFrame
-
-        # ugly hack for GH #836
-        if not isinstance(self.obj, NDFrame):
-            return False
-
         if not all(is_list_like_indexer(x) for x in tup):
             return False
 
         # just too complicated
-        for indexer, ax in zip(tup, self.obj._data.axes):
-            if isinstance(ax, MultiIndex):
-                return False
-            elif com.is_bool_indexer(indexer):
-                return False
-            elif not ax.is_unique:
-                return False
+        if any(com.is_bool_indexer(x) for x in tup):
+            return False
 
         return True
 


### PR DESCRIPTION
- [x] tests passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`

This is basically a consequence of #21503 - the code path for indexing when ``key`` is a collection is now the same for multi_take and for single take.

(Next step will be to merge the other code paths too, and approach with multi_take _all_ cases in which mutiple axes are being indexed, in whatever fashion)