### PR TITLE
BUG: first/last lose timezone in groupby with as_index=False

### DIFF
--- a/doc/source/whatsnew/v0.24.0.txt
+++ b/doc/source/whatsnew/v0.24.0.txt
@@ -225,7 +225,7 @@ Plotting
 Groupby/Resample/Rolling
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
--
+- Bug in :func:`pandas.core.groupby.first` and :func:`pandas.core.groupby.last` with ``as_index=False`` leading to the loss of timezone information (:issue:`15884`)
 -
 -
 

--- a/doc/source/whatsnew/v0.24.0.txt
+++ b/doc/source/whatsnew/v0.24.0.txt
@@ -225,7 +225,7 @@ Plotting
 Groupby/Resample/Rolling
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
-- Bug in :func:`pandas.core.groupby.first` and :func:`pandas.core.groupby.last` with ``as_index=False`` leading to the loss of timezone information (:issue:`15884`)
+- Bug in :func:`pandas.core.groupby.GroupBy.first` and :func:`pandas.core.groupby.GroupBy.last` with ``as_index=False`` leading to the loss of timezone information (:issue:`15884`)
 -
 -
 

--- a/pandas/core/groupby/groupby.py
+++ b/pandas/core/groupby/groupby.py
@@ -4740,10 +4740,7 @@ class DataFrameGroupBy(NDFrameGroupBy):
 
     def _wrap_agged_blocks(self, items, blocks):
         if not self.as_index:
-            if blocks[0].values.ndim > 1:
-                index = np.arange(blocks[0].values.shape[1])
-            else:
-                index = np.arange(blocks[0].values.shape[0])
+            index = np.arange(blocks[0].values.shape[-1])
             mgr = BlockManager(blocks, [items, index])
             result = DataFrame(mgr)
 

--- a/pandas/core/groupby/groupby.py
+++ b/pandas/core/groupby/groupby.py
@@ -4740,7 +4740,10 @@ class DataFrameGroupBy(NDFrameGroupBy):
 
     def _wrap_agged_blocks(self, items, blocks):
         if not self.as_index:
-            index = np.arange(blocks[0].values.shape[1])
+            if blocks[0].values.ndim > 1:
+                index = np.arange(blocks[0].values.shape[1])
+            else:
+                index = np.arange(blocks[0].values.shape[0])
             mgr = BlockManager(blocks, [items, index])
             result = DataFrame(mgr)
 

--- a/pandas/tests/groupby/test_nth.py
+++ b/pandas/tests/groupby/test_nth.py
@@ -221,15 +221,15 @@ def test_nth_multi_index(three_group):
 
 
 @pytest.mark.parametrize('data, expected_first, expected_last', [
-    ({'id': ['A'], 
+    ({'id': ['A'],
       'time': Timestamp('2012-02-01 14:00:00',
                         tz='US/Central'),
       'foo': [1]},
-     {'id': ['A'], 
+     {'id': ['A'],
       'time': Timestamp('2012-02-01 14:00:00',
                         tz='US/Central'),
       'foo': [1]},
-     {'id': ['A'],  
+     {'id': ['A'],
       'time': Timestamp('2012-02-01 14:00:00',
                         tz='US/Central'),
       'foo': [1]}),
@@ -276,6 +276,7 @@ def test_first_last_tz(data, expected_first, expected_last):
 
     result = df.groupby('id', as_index=False)['time'].last()
     assert_frame_equal(result, expected[['id', 'time']])
+
 
 def test_nth_multi_index_as_expected():
     # PR 9090, related to issue 8979

--- a/pandas/tests/groupby/test_nth.py
+++ b/pandas/tests/groupby/test_nth.py
@@ -221,29 +221,38 @@ def test_nth_multi_index(three_group):
 
 
 @pytest.mark.parametrize('data, expected_first, expected_last', [
-    ({'id': ['A'], 'time': Timestamp('2012-02-01 14:00:00',
-                                     tz='US/Central')},
-     {'id': ['A'], 'time': Timestamp('2012-02-01 14:00:00',
-                                     tz='US/Central')},
-     {'id': ['A'], 'time': Timestamp('2012-02-01 14:00:00',
-                                     tz='US/Central')}),
+    ({'id': ['A'], 
+      'time': Timestamp('2012-02-01 14:00:00',
+                        tz='US/Central'),
+      'foo': [1]},
+     {'id': ['A'], 
+      'time': Timestamp('2012-02-01 14:00:00',
+                        tz='US/Central'),
+      'foo': [1]},
+     {'id': ['A'],  
+      'time': Timestamp('2012-02-01 14:00:00',
+                        tz='US/Central'),
+      'foo': [1]}),
     ({'id': ['A', 'B', 'A'],
       'time': [Timestamp('2012-01-01 13:00:00',
                          tz='America/New_York'),
                Timestamp('2012-02-01 14:00:00',
                          tz='US/Central'),
                Timestamp('2012-03-01 12:00:00',
-                         tz='Europe/London')]},
+                         tz='Europe/London')],
+      'foo': [1, 2, 3]},
      {'id': ['A', 'B'],
       'time': [Timestamp('2012-01-01 13:00:00',
                          tz='America/New_York'),
                Timestamp('2012-02-01 14:00:00',
-                         tz='US/Central')]},
+                         tz='US/Central')],
+      'foo': [1, 2]},
      {'id': ['A', 'B'],
       'time': [Timestamp('2012-03-01 12:00:00',
                          tz='Europe/London'),
                Timestamp('2012-02-01 14:00:00',
-                         tz='US/Central')]})
+                         tz='US/Central')],
+      'foo': [3, 2]})
 ])
 def test_first_last_tz(data, expected_first, expected_last):
     # GH15884
@@ -254,12 +263,19 @@ def test_first_last_tz(data, expected_first, expected_last):
 
     result = df.groupby('id', as_index=False).first()
     expected = DataFrame(expected_first)
-    assert_frame_equal(result, expected)
+    cols = ['id', 'time', 'foo']
+    assert_frame_equal(result[cols], expected[cols])
+
+    result = df.groupby('id', as_index=False)['time'].first()
+    assert_frame_equal(result, expected[['id', 'time']])
 
     result = df.groupby('id', as_index=False).last()
     expected = DataFrame(expected_last)
-    assert_frame_equal(result, expected)
+    cols = ['id', 'time', 'foo']
+    assert_frame_equal(result[cols], expected[cols])
 
+    result = df.groupby('id', as_index=False)['time'].last()
+    assert_frame_equal(result, expected[['id', 'time']])
 
 def test_nth_multi_index_as_expected():
     # PR 9090, related to issue 8979


### PR DESCRIPTION
- [ ] closes #15884
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry
