### PR TITLE
BUG: Series dot product __rmatmul__ doesn't allow matrix vector multiplication

### DIFF
--- a/doc/source/whatsnew/v0.24.0.txt
+++ b/doc/source/whatsnew/v0.24.0.txt
@@ -183,7 +183,7 @@ Offsets
 Numeric
 ^^^^^^^
 
--
+- Bug in :class:`Series` ``__rmatmul__`` doesn't support matrix vector multiplication (:issue:`21530`)
 -
 -
 

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -2066,7 +2066,7 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
 
     def __rmatmul__(self, other):
         """ Matrix multiplication using binary `@` operator in Python>=3.5 """
-        return self.dot(other)
+        return self.dot(np.transpose(other)).T
 
     @Substitution(klass='Series')
     @Appender(base._shared_docs['searchsorted'])

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -2066,7 +2066,7 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
 
     def __rmatmul__(self, other):
         """ Matrix multiplication using binary `@` operator in Python>=3.5 """
-        return self.dot(np.transpose(other)).T
+        return self.dot(np.transpose(other))
 
     @Substitution(klass='Series')
     @Appender(base._shared_docs['searchsorted'])

--- a/pandas/tests/series/test_analytics.py
+++ b/pandas/tests/series/test_analytics.py
@@ -854,6 +854,7 @@ class TestSeriesAnalytics(TestData):
         expected = np.dot(a.values, a.values)
         assert_almost_equal(result, expected)
 
+        # GH 21530
         # np.array (matrix) @ Series (__rmatmul__)
         result = operator.matmul(b.T.values, a)
         expected = np.dot(b.T.values, a.values)

--- a/pandas/tests/series/test_analytics.py
+++ b/pandas/tests/series/test_analytics.py
@@ -857,7 +857,7 @@ class TestSeriesAnalytics(TestData):
 
         # GH 21530
         # vector (1D list) @ Series (__rmatmul__)
-        result = operator.matmul(a.tolist(), a)
+        result = operator.matmul(a.values.tolist(), a)
         expected = np.dot(a.values, a.values)
         assert_almost_equal(result, expected)
 
@@ -869,7 +869,7 @@ class TestSeriesAnalytics(TestData):
 
         # GH 21530
         # matrix (2D nested lists) @ Series (__rmatmul__)
-        result = operator.matmul(b.T.tolist(), a)
+        result = operator.matmul(b.T.values.tolist(), a)
         expected = np.dot(b.T.values, a.values)
         assert_almost_equal(result, expected)
 

--- a/pandas/tests/series/test_analytics.py
+++ b/pandas/tests/series/test_analytics.py
@@ -854,6 +854,11 @@ class TestSeriesAnalytics(TestData):
         expected = np.dot(a.values, a.values)
         assert_almost_equal(result, expected)
 
+        # np.array (matrix) @ Series (__rmatmul__)
+        result = operator.matmul(b.T.values, a)
+        expected = np.dot(b.T.values, a.values)
+        assert_almost_equal(result, expected)
+
         # mixed dtype DataFrame @ Series
         a['p'] = int(a.p)
         result = operator.matmul(b.T, a)

--- a/pandas/tests/series/test_analytics.py
+++ b/pandas/tests/series/test_analytics.py
@@ -849,14 +849,27 @@ class TestSeriesAnalytics(TestData):
         expected = np.dot(a.values, a.values)
         assert_almost_equal(result, expected)
 
-        # np.array @ Series (__rmatmul__)
+        # GH 21530
+        # vector (1D np.array) @ Series (__rmatmul__)
         result = operator.matmul(a.values, a)
         expected = np.dot(a.values, a.values)
         assert_almost_equal(result, expected)
 
         # GH 21530
-        # np.array (matrix) @ Series (__rmatmul__)
+        # vector (1D list) @ Series (__rmatmul__)
+        result = operator.matmul(a.tolist(), a)
+        expected = np.dot(a.values, a.values)
+        assert_almost_equal(result, expected)
+
+        # GH 21530
+        # matrix (2D np.array) @ Series (__rmatmul__)
         result = operator.matmul(b.T.values, a)
+        expected = np.dot(b.T.values, a.values)
+        assert_almost_equal(result, expected)
+
+        # GH 21530
+        # matrix (2D nested lists) @ Series (__rmatmul__)
+        result = operator.matmul(b.T.tolist(), a)
         expected = np.dot(b.T.values, a.values)
         assert_almost_equal(result, expected)
 


### PR DESCRIPTION
- [x] closes #21530 
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry

the new `__rmatmul__` implementation in Series seems to be missing matrix vector multiplication case as raised in the issue in question. Only inner product of two vectors was supported in `__rmatmul__` method.

This PR uses the same implementation in DataFrame to add support in Series and test case.

matmul operator (`@`, `@=`) was added in python 3.5 in https://www.python.org/dev/peps/pep-0465/

```python
class A(object):
    def __matmul__(self, other):
        print('__matmul__ is called in A.')

class B(object):
    def __rmatmul__(self, other):
        print('__rmatmul__ is called in B.')

A() @ B()
B() @ A()
del A.__matmul__
A() @ B()

>>> A() @ B()
__matmul__ is called in A.
>>> B() @ A()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: unsupported operand type(s) for @: 'B' and 'A'
>>> del A.__matmul__
>>> A() @ B()
__rmatmul__ is called in B.
```