### PR TITLE
BUG: Let IntervalIndex constructor override inferred closed

### DIFF
--- a/doc/source/whatsnew/v0.24.0.txt
+++ b/doc/source/whatsnew/v0.24.0.txt
@@ -194,6 +194,13 @@ Strings
 -
 -
 
+Interval
+^^^^^^^^
+
+- Bug in the :class:`IntervalIndex` constructor where the ``closed`` parameter did not always override the inferred ``closed`` (:issue:`19370`)
+-
+-
+
 Indexing
 ^^^^^^^^
 

--- a/pandas/core/indexes/interval.py
+++ b/pandas/core/indexes/interval.py
@@ -233,7 +233,7 @@ class IntervalIndex(IntervalMixin, Index):
         if isinstance(data, IntervalIndex):
             left = data.left
             right = data.right
-            closed = data.closed
+            closed = closed or data.closed
         else:
 
             # don't allow scalars
@@ -241,16 +241,8 @@ class IntervalIndex(IntervalMixin, Index):
                 cls._scalar_data_error(data)
 
             data = maybe_convert_platform_interval(data)
-            left, right, infer_closed = intervals_to_interval_bounds(data)
-
-            if (com._all_not_none(closed, infer_closed) and
-                    closed != infer_closed):
-                # GH 18421
-                msg = ("conflicting values for closed: constructor got "
-                       "'{closed}', inferred from data '{infer_closed}'"
-                       .format(closed=closed, infer_closed=infer_closed))
-                raise ValueError(msg)
-
+            left, right, infer_closed = intervals_to_interval_bounds(
+                data, validate_closed=closed is None)
             closed = closed or infer_closed
 
         return cls._simple_new(left, right, closed, name, copy=copy,

--- a/pandas/tests/indexes/interval/test_construction.py
+++ b/pandas/tests/indexes/interval/test_construction.py
@@ -317,13 +317,7 @@ class TestClassConstructors(Base):
         pass
 
     def test_constructor_errors(self, constructor):
-        # mismatched closed inferred from intervals vs constructor.
-        ivs = [Interval(0, 1, closed='both'), Interval(1, 2, closed='both')]
-        msg = 'conflicting values for closed'
-        with tm.assert_raises_regex(ValueError, msg):
-            constructor(ivs, closed='neither')
-
-        # mismatched closed within intervals
+        # mismatched closed within intervals with no constructor override
         ivs = [Interval(0, 1, closed='right'), Interval(2, 3, closed='left')]
         msg = 'intervals must all be closed on the same side'
         with tm.assert_raises_regex(ValueError, msg):
@@ -340,6 +334,24 @@ class TestClassConstructors(Base):
                "is not an interval")
         with tm.assert_raises_regex(TypeError, msg):
             constructor([0, 1])
+
+    @pytest.mark.parametrize('data, closed', [
+        ([], 'both'),
+        ([np.nan, np.nan], 'neither'),
+        ([Interval(0, 3, closed='neither'),
+          Interval(2, 5, closed='neither')], 'left'),
+        ([Interval(0, 3, closed='left'),
+          Interval(2, 5, closed='right')], 'neither'),
+        (IntervalIndex.from_breaks(range(5), closed='both'), 'right')])
+    def test_override_inferred_closed(self, constructor, data, closed):
+        # GH 19370
+        if isinstance(data, IntervalIndex):
+            tuples = data.to_tuples()
+        else:
+            tuples = [(iv.left, iv.right) if notna(iv) else iv for iv in data]
+        expected = IntervalIndex.from_tuples(tuples, closed=closed)
+        result = constructor(data, closed=closed)
+        tm.assert_index_equal(result, expected)
 
 
 class TestFromIntervals(TestClassConstructors):


### PR DESCRIPTION
- [X] closes #19370
- [X] tests added / passed
- [X] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [X] whatsnew entry

Makes `IntervalIndex` constructor behavior consistent: the `closed` parameter, if specified, takes priority over the inferred `closed`.

Comments:
- Modified the `intervals_to_interval_bounds` function to optionally raise if mixed values of `closed` are  encountered instead of automatically raising.
   - Allow creating an `IntervalIndex` from mixed closed lists, e.g.`[Interval(0, 1, closed='left'), Interval(2, 3, closed='right')]`, only if `closed` is specified during construction.
  -  The above will still raise if `closed` is not passed to the constructor.
   - This appears to only be called in the constructor currently.
- Added an Interval subsection to the Bug Fixes section of the 0.24.0 whatsnew, since I anticipate that there will be a non-negligible number of interval related fixes.