### PR TITLE
DOC: Adding clarification on return dtype of to_numeric

### DIFF
--- a/pandas/core/tools/numeric.py
+++ b/pandas/core/tools/numeric.py
@@ -43,6 +43,10 @@ def to_numeric(arg, errors='raise', downcast=None):
         checked satisfy that specification, no downcasting will be
         performed on the data.
 
+        Also Note that the default return dtype is `float64` or `int64`
+        depending on the data supplied.`downcast` for `float` or `int`
+        should only be used if output desired is `float32` or `int32`
+
         .. versionadded:: 0.19.0
 
     Returns

--- a/pandas/core/tools/numeric.py
+++ b/pandas/core/tools/numeric.py
@@ -16,6 +16,9 @@ def to_numeric(arg, errors='raise', downcast=None):
     """
     Convert argument to a numeric type.
 
+    The default return dtype is `float64` or `int64` depending on the data supplied. 
+    Use the `downcast` parameter to obtain other dtypes.
+
     Parameters
     ----------
     arg : list, tuple, 1-d array, or Series
@@ -42,10 +45,6 @@ def to_numeric(arg, errors='raise', downcast=None):
         the dtype it is to be cast to, so if none of the dtypes
         checked satisfy that specification, no downcasting will be
         performed on the data.
-
-        Also Note that the default return dtype is `float64` or `int64`
-        depending on the data supplied.`downcast` for `float` or `int`
-        should only be used if output desired is `float32` or `int32`
 
         .. versionadded:: 0.19.0
 

--- a/pandas/core/tools/numeric.py
+++ b/pandas/core/tools/numeric.py
@@ -17,7 +17,7 @@ def to_numeric(arg, errors='raise', downcast=None):
     Convert argument to a numeric type.
 
     The default return dtype is `float64` or `int64`
-    depending on the data supplied.Use the `downcast` parameter
+    depending on the data supplied. Use the `downcast` parameter
     to obtain other dtypes.
 
     Parameters

--- a/pandas/core/tools/numeric.py
+++ b/pandas/core/tools/numeric.py
@@ -16,8 +16,9 @@ def to_numeric(arg, errors='raise', downcast=None):
     """
     Convert argument to a numeric type.
 
-    The default return dtype is `float64` or `int64` depending on the data supplied. 
-    Use the `downcast` parameter to obtain other dtypes.
+    The default return dtype is `float64` or `int64`
+    depending on the data supplied.Use the `downcast` parameter
+    to obtain other dtypes.
 
     Parameters
     ----------


### PR DESCRIPTION
Specifying the default return types for `to_numeric` in case of no downcast

- [x] closes #21551
- [ ] tests added / passed
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
