### PR TITLE
[DOC]: To remove extra `` to match :class: rendering requirements

### DIFF
--- a/doc/source/whatsnew/v0.24.0.txt
+++ b/doc/source/whatsnew/v0.24.0.txt
@@ -31,8 +31,8 @@ Backwards incompatible API changes
 Tick DateOffset Normalize Restrictions
 --------------------------------------
 
-Creating a ``Tick`` object (:class:``Day``, :class:``Hour``, :class:``Minute``,
-:class:``Second``, :class:``Milli``, :class:``Micro``, :class:``Nano``) with
+Creating a ``Tick`` object (:class:`Day`, :class:`Hour`, :class:`Minute`,
+:class:`Second`, :class:`Milli`, :class:`Micro`, :class:`Nano`) with
 `normalize=True` is no longer supported.  This prevents unexpected behavior
 where addition could fail to be monotone or associative.  (:issue:`21427`)
 


### PR DESCRIPTION
Removing extra `` to solve rendering issues

- [x] xref #21564
- [ ] tests added / passed
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

@TomAugspurger , I am not really much acquainted to :class: reference. Do tell me If I am wrong in the inference of the issue.
I guessed that the parameters should be enclosed in `` not `` `` by looking at the following:
https://github.com/pandas-dev/pandas/blob/f1ffc5fae06a7294dc831887b0d76177aec9b708/doc/source/whatsnew/v0.24.0.txt#L66-L70