### PR TITLE
clarifying regex pipe behavior

### DIFF
--- a/pandas/core/strings.py
+++ b/pandas/core/strings.py
@@ -335,11 +335,11 @@ def str_contains(arr, pat, case=True, flags=0, na=np.nan, regex=True):
     4    False
     dtype: bool
 
-    Returning 'house' and 'parrot' within same string.
+    Returning 'house' or 'dog' when either expression occurs in a string.
 
-    >>> s1.str.contains('house|parrot', regex=True)
+    >>> s1.str.contains('house|dog', regex=True)
     0    False
-    1    False
+    1     True
     2     True
     3    False
     4      NaN


### PR DESCRIPTION
[Current documentation for `pandas.Series.str.contains()`](https://pandas.pydata.org/pandas-docs/stable/generated/pandas.Series.str.contains.html) states that the `|` acts as a regex **and** operator ("Returning ‘house’ and ‘parrot’ within same string."), while I believe it is actually an **or** operator. I've updated the phrase and example to demonstrate this behavior in what I think is a clearer way, though I'm definitely open to suggestions to improve it further.

- [ ] closes #xxxx
- [ ] tests added / passed
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
