### PR TITLE
API/REGR: (re-)allow neg/pos unary operation on object dtype

### DIFF
--- a/doc/source/whatsnew/v0.23.2.txt
+++ b/doc/source/whatsnew/v0.23.2.txt
@@ -18,7 +18,7 @@ Fixed Regressions
 
 - Fixed regression in :meth:`to_csv` when handling file-like object incorrectly (:issue:`21471`)
 - Bug in both :meth:`DataFrame.first_valid_index` and :meth:`Series.first_valid_index` raised for a row index having duplicate values (:issue:`21441`)
--
+- Fixed regression in unary negative operations with object dtype (:issue:`21380`)
 
 .. _whatsnew_0232.performance:
 

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -1118,11 +1118,8 @@ class NDFrame(PandasObject, SelectionMixin):
         values = com._values_from_object(self)
         if is_bool_dtype(values):
             arr = operator.inv(values)
-        elif is_numeric_dtype(values) or is_timedelta64_dtype(values):
-            arr = operator.neg(values)
-        elif (is_object_dtype(values) and
-              lib.infer_dtype(values) not in ['string', 'bytes', 'unicode']):
-            # explicity allow object dtypes that are not strings, gh-21380
+        elif (is_numeric_dtype(values) or is_timedelta64_dtype(values)
+                or is_object_dtype(values)):
             arr = operator.neg(values)
         else:
             raise TypeError("Unary negative expects numeric dtype, not {}"
@@ -1133,11 +1130,8 @@ class NDFrame(PandasObject, SelectionMixin):
         values = com._values_from_object(self)
         if (is_bool_dtype(values) or is_period_arraylike(values)):
             arr = values
-        elif is_numeric_dtype(values) or is_timedelta64_dtype(values):
-            arr = operator.pos(values)
-        elif (is_object_dtype(values) and
-              lib.infer_dtype(values) not in ['string', 'bytes', 'unicode']):
-            # explicity allow object dtypes that are not strings, gh-21380
+        elif (is_numeric_dtype(values) or is_timedelta64_dtype(values)
+                or is_object_dtype(values)):
             arr = operator.pos(values)
         else:
             raise TypeError("Unary plus expects numeric dtype, not {}"

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -1117,22 +1117,16 @@ class NDFrame(PandasObject, SelectionMixin):
         values = com._values_from_object(self)
         if is_bool_dtype(values):
             arr = operator.inv(values)
-        elif (is_numeric_dtype(values) or is_timedelta64_dtype(values)):
-            arr = operator.neg(values)
         else:
-            raise TypeError("Unary negative expects numeric dtype, not {}"
-                            .format(values.dtype))
+            arr = operator.neg(values)
         return self.__array_wrap__(arr)
 
     def __pos__(self):
         values = com._values_from_object(self)
         if (is_bool_dtype(values) or is_period_arraylike(values)):
             arr = values
-        elif (is_numeric_dtype(values) or is_timedelta64_dtype(values)):
-            arr = operator.pos(values)
         else:
-            raise TypeError("Unary plus expects numeric dtype, not {}"
-                            .format(values.dtype))
+            arr = operator.pos(values)
         return self.__array_wrap__(arr)
 
     def __invert__(self):

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -10,7 +10,7 @@ import json
 import numpy as np
 import pandas as pd
 
-from pandas._libs import tslib, properties, lib
+from pandas._libs import tslib, properties
 from pandas.core.dtypes.common import (
     _ensure_int64,
     _ensure_object,

--- a/pandas/tests/frame/test_operators.py
+++ b/pandas/tests/frame/test_operators.py
@@ -3,6 +3,7 @@
 from __future__ import print_function
 from collections import deque
 from datetime import datetime
+from decimal import Decimal
 import operator
 
 import pytest
@@ -282,6 +283,17 @@ class TestDataFrameOperators(TestData):
         assert_frame_equal(-df, expected)
         assert_series_equal(-df['a'], expected['a'])
 
+    @pytest.mark.parametrize('df, expected', [
+        (np.array([1, 2], dtype=object), np.array([-1, -2], dtype=object)),
+        ([Decimal('1.0'), Decimal('2.0')], [Decimal('-1.0'), Decimal('-2.0')]),
+    ])
+    def test_neg_object(self, df, expected):
+        # GH 21380
+        df = pd.DataFrame({'a': df})
+        expected = pd.DataFrame({'a': expected})
+        assert_frame_equal(-df, expected)
+        assert_series_equal(-df['a'], expected['a'])
+
     @pytest.mark.parametrize('df', [
         pd.DataFrame({'a': ['a', 'b']}),
         pd.DataFrame({'a': pd.to_datetime(['2017-01-22', '1970-01-01'])}),
@@ -302,6 +314,15 @@ class TestDataFrameOperators(TestData):
     ])
     def test_pos_numeric(self, df):
         # GH 16073
+        assert_frame_equal(+df, df)
+        assert_series_equal(+df['a'], df['a'])
+
+    @pytest.mark.parametrize('df', [
+        pd.DataFrame({'a': np.array([-1, 2], dtype=object)}),
+        pd.DataFrame({'a': [Decimal('-1.0'), Decimal('2.0')]}),
+    ])
+    def test_pos_object(self, df):
+        # GH 21380
         assert_frame_equal(+df, df)
         assert_series_equal(+df['a'], df['a'])
 

--- a/pandas/tests/frame/test_operators.py
+++ b/pandas/tests/frame/test_operators.py
@@ -318,6 +318,7 @@ class TestDataFrameOperators(TestData):
         assert_series_equal(+df['a'], df['a'])
 
     @pytest.mark.parametrize('df', [
+        pd.DataFrame({'a': ['a', 'b']}),
         pd.DataFrame({'a': np.array([-1, 2], dtype=object)}),
         pd.DataFrame({'a': [Decimal('-1.0'), Decimal('2.0')]}),
     ])
@@ -327,7 +328,6 @@ class TestDataFrameOperators(TestData):
         assert_series_equal(+df['a'], df['a'])
 
     @pytest.mark.parametrize('df', [
-        pd.DataFrame({'a': ['a', 'b']}),
         pd.DataFrame({'a': pd.to_datetime(['2017-01-22', '1970-01-01'])}),
     ])
     def test_pos_raises(self, df):


### PR DESCRIPTION
closes #21380

This is an easy fix to simply be more forgiveable and just try the operation:

- For object dtype, this is IMO the better way: simply let the scalar values decide if it can do those operations or not. 
  The scalar values (eg strings) already raise an informative error message. Eg for a series with string you get `TypeError: bad operand type for unary -: 'str'` for unary negative operation.
- But with two caveats to discuss:
  - For datetime64 data, the error message is not as user friendly as our custom one: "TypeError: ufunc 'negative' did not contain a loop with signature matching types dtype('<M8[ns]') dtype('<M8[ns]')"
  - For the unary positive operation, numpy has apparently different rules: it does allow datetime64 data and returns itself (the same for object string data). Because of this, the current tests fail (it expects TypeError for `+s_string`)

<details>
<summary>Details with examples</summary>

```
In [14]: s_string = pd.Series(['a', 'b'])

In [15]: -s_string
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
<ipython-input-15-91308cf04ad2> in <module>()
----> 1 -s_string

~/scipy/pandas/pandas/core/generic.py in __neg__(self)
   1119             arr = operator.inv(values)
   1120         else:
-> 1121             arr = operator.neg(values)
   1122         return self.__array_wrap__(arr)
   1123 

TypeError: bad operand type for unary -: 'str'

In [16]: +s_string
Out[16]: 
0    a
1    b
dtype: object

In [17]: s_datetime = pd.Series(pd.date_range('2012', periods=3))

In [18]: -s_datetime
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
<ipython-input-18-b460860ba74c> in <module>()
----> 1 -s_datetime

~/scipy/pandas/pandas/core/generic.py in __neg__(self)
   1119             arr = operator.inv(values)
   1120         else:
-> 1121             arr = operator.neg(values)
   1122         return self.__array_wrap__(arr)
   1123 

TypeError: ufunc 'negative' did not contain a loop with signature matching types dtype('<M8[ns]') dtype('<M8[ns]')

In [19]: +s_datetime
Out[19]: 
0   2012-01-01
1   2012-01-02
2   2012-01-03
dtype: datetime64[ns]

In [20]: 

In [20]: from decimal import Decimal
    ...: s_decimal = pd.Series([Decimal(1)])

In [21]: -s_decimal
Out[21]: 
0    -1
dtype: object

In [22]: +s_decimal
Out[22]: 
0    1
dtype: object


```
</details>