### PR TITLE
PERF: do not check for label presence preventively

### DIFF
--- a/doc/source/whatsnew/v0.24.0.txt
+++ b/doc/source/whatsnew/v0.24.0.txt
@@ -17,7 +17,7 @@ Other Enhancements
 - :func:`to_datetime` now supports the ``%Z`` and ``%z`` directive when passed into ``format`` (:issue:`13486`)
 - :func:`Series.mode` and :func:`DataFrame.mode` now support the ``dropna`` parameter which can be used to specify whether NaN/NaT values should be considered (:issue:`17534`)
 - :func:`to_csv` now supports ``compression`` keyword when a file handle is passed. (:issue:`21227`)
-- :meth:`Index.droplevel` is now implemented also for flat indexes, for compatibility with MultiIndex (:issue:`21115`)
+- :meth:`Index.droplevel` is now implemented also for flat indexes, for compatibility with :class:`MultiIndex` (:issue:`21115`)
 
 
 .. _whatsnew_0240.api_breaking:

--- a/doc/source/whatsnew/v0.24.0.txt
+++ b/doc/source/whatsnew/v0.24.0.txt
@@ -199,6 +199,7 @@ Indexing
 ^^^^^^^^
 
 - The traceback from a ``KeyError`` when asking ``.loc`` for a single missing label is now shorter and more clear (:issue:`21557`)
+- When ``.ix`` is asked for a missing integer label in a :class:`MultiIndex` with a first level of integer type, it now raises a ``KeyError`` - consistently with the case of a flat :class:`Int64Index` - rather than falling back to positional indexing (:issue:`21593`)
 -
 -
 

--- a/pandas/tests/indexes/datetimes/test_partial_slicing.py
+++ b/pandas/tests/indexes/datetimes/test_partial_slicing.py
@@ -11,6 +11,7 @@ from pandas import (DatetimeIndex, Series, DataFrame,
                     date_range, Index, Timedelta, Timestamp)
 from pandas.util import testing as tm
 
+from pandas.core.indexing import IndexingError
 
 class TestSlicing(object):
     def test_dti_slicing(self):
@@ -313,12 +314,12 @@ class TestSlicing(object):
         result = df_multi.loc[('2013-06-19 09:30:00', 'ACCT1', 'ABC')]
         tm.assert_series_equal(result, expected)
 
-        # this is a KeyError as we don't do partial string selection on
-        # multi-levels
+        # this is an IndexingError as we don't do partial string selection on
+        # multi-levels.
         def f():
             df_multi.loc[('2013-06-19', 'ACCT1', 'ABC')]
 
-        pytest.raises(KeyError, f)
+        pytest.raises(IndexingError, f)
 
         # GH 4294
         # partial slice on a series mi

--- a/pandas/tests/indexes/datetimes/test_partial_slicing.py
+++ b/pandas/tests/indexes/datetimes/test_partial_slicing.py
@@ -13,6 +13,7 @@ from pandas.util import testing as tm
 
 from pandas.core.indexing import IndexingError
 
+
 class TestSlicing(object):
     def test_dti_slicing(self):
         dti = DatetimeIndex(start='1/1/2005', end='12/1/2005', freq='M')

--- a/pandas/tests/indexing/test_multiindex.py
+++ b/pandas/tests/indexing/test_multiindex.py
@@ -230,7 +230,8 @@ class TestMultiIndexBasic(object):
         # corner column
         rs = mi_int.iloc[2, 2]
         with catch_warnings(record=True):
-            xp = mi_int.ix[:, 2].ix[2]
+            # First level is int - so use .loc rather than .ix (GH 21593)
+            xp = mi_int.loc[(8, 12), (4, 10)]
         assert rs == xp
 
         # this is basically regular indexing
@@ -277,6 +278,12 @@ class TestMultiIndexBasic(object):
         with catch_warnings(record=True):
             xp = mi_int.ix[4]
         tm.assert_frame_equal(rs, xp)
+
+        # missing label
+        pytest.raises(KeyError, lambda: mi_int.loc[2])
+        with catch_warnings(record=True):
+            # GH 21593
+            pytest.raises(KeyError, lambda: mi_int.ix[2])
 
     def test_getitem_partial_int(self):
         # GH 12416


### PR DESCRIPTION
- [x] closes #21593
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry

ASV run:

```
       before           after         ratio
     [f1ffc5fa]       [0af738b0]
-         433±7μs          390±5μs     0.90  indexing.MultiIndexing.time_series_ix
-      79.0±0.9μs       53.1±0.8μs     0.67  indexing.IntervalIndexing.time_loc_scalar
-      66.3±0.8μs         42.7±2μs     0.64  indexing.NumericSeriesIndexing.time_loc_scalar(<class 'pandas.core.indexes.numeric.Int64Index'>)
-      86.9±0.4μs       54.7±0.2μs     0.63  indexing.NumericSeriesIndexing.time_loc_scalar(<class 'pandas.core.indexes.numeric.Float64Index'>)

SOME BENCHMARKS HAVE CHANGED SIGNIFICANTLY.
```

We don't check anymore if errors raised in indexing have to do with ordering different types (in Python 3)... but I can't think of any possible case (and none is present in the tests) in which looking for a single label could create a sorting problem.