### PR TITLE
TST: Add interval closed fixture to top-level conftest

### DIFF
--- a/pandas/conftest.py
+++ b/pandas/conftest.py
@@ -137,6 +137,14 @@ def nselect_method(request):
     return request.param
 
 
+@pytest.fixture(params=['left', 'right', 'both', 'neither'])
+def closed(request):
+    """
+    Fixture for trying all interval closed parameters
+    """
+    return request.param
+
+
 @pytest.fixture(params=[None, np.nan, pd.NaT, float('nan'), np.float('NaN')])
 def nulls_fixture(request):
     """

--- a/pandas/tests/indexes/interval/test_construction.py
+++ b/pandas/tests/indexes/interval/test_construction.py
@@ -14,11 +14,6 @@ import pandas.core.common as com
 import pandas.util.testing as tm
 
 
-@pytest.fixture(params=['left', 'right', 'both', 'neither'])
-def closed(request):
-    return request.param
-
-
 @pytest.fixture(params=[None, 'foo'])
 def name(request):
     return request.param

--- a/pandas/tests/indexes/interval/test_interval.py
+++ b/pandas/tests/indexes/interval/test_interval.py
@@ -12,11 +12,6 @@ import pandas.util.testing as tm
 import pandas as pd
 
 
-@pytest.fixture(scope='class', params=['left', 'right', 'both', 'neither'])
-def closed(request):
-    return request.param
-
-
 @pytest.fixture(scope='class', params=[None, 'foo'])
 def name(request):
     return request.param

--- a/pandas/tests/indexes/interval/test_interval_range.py
+++ b/pandas/tests/indexes/interval/test_interval_range.py
@@ -11,11 +11,6 @@ from pandas.tseries.offsets import Day
 import pandas.util.testing as tm
 
 
-@pytest.fixture(scope='class', params=['left', 'right', 'both', 'neither'])
-def closed(request):
-    return request.param
-
-
 @pytest.fixture(scope='class', params=[None, 'foo'])
 def name(request):
     return request.param

--- a/pandas/tests/indexes/interval/test_interval_tree.py
+++ b/pandas/tests/indexes/interval/test_interval_tree.py
@@ -7,11 +7,6 @@ from pandas._libs.interval import IntervalTree
 import pandas.util.testing as tm
 
 
-@pytest.fixture(scope='class', params=['left', 'right', 'both', 'neither'])
-def closed(request):
-    return request.param
-
-
 @pytest.fixture(
     scope='class', params=['int32', 'int64', 'float32', 'float64', 'uint64'])
 def dtype(request):

--- a/pandas/tests/indexing/interval/test_interval.py
+++ b/pandas/tests/indexing/interval/test_interval.py
@@ -3,7 +3,6 @@ import numpy as np
 import pandas as pd
 
 from pandas import Series, DataFrame, IntervalIndex, Interval
-from pandas.compat import product
 import pandas.util.testing as tm
 
 
@@ -51,9 +50,7 @@ class TestIntervalIndex(object):
         tm.assert_series_equal(expected, s[s >= 2])
 
     # TODO: check this behavior is consistent with test_interval_new.py
-    @pytest.mark.parametrize('direction, closed',
-                             product(('increasing', 'decreasing'),
-                                     ('left', 'right', 'neither', 'both')))
+    @pytest.mark.parametrize('direction', ['increasing', 'decreasing'])
     def test_nonoverlapping_monotonic(self, direction, closed):
         tpls = [(0, 1), (2, 3), (4, 5)]
         if direction == 'decreasing':


### PR DESCRIPTION
Noticed identical copies of this fixture in multiple places, so seemed reasonable to dedupe and move to the top-level `conftest.py`.  I think I removed all instances of such a fixture/parametrize being used, but could have missed one.  I imagine this fixture will be used in more places in the future when interval related tests are expanded.