### PR TITLE
TST: Use multiple instances of parametrize instead of product in tests

### DIFF
--- a/pandas/tests/dtypes/test_dtypes.py
+++ b/pandas/tests/dtypes/test_dtypes.py
@@ -2,8 +2,6 @@
 import re
 import pytest
 
-from itertools import product
-
 import numpy as np
 import pandas as pd
 from pandas import (
@@ -233,12 +231,14 @@ class TestDatetimeTZDtype(Base):
         assert is_datetimetz(s2)
         assert s1.dtype == s2.dtype
 
-    def test_parser(self):
+    @pytest.mark.parametrize('tz', ['UTC', 'US/Eastern'])
+    @pytest.mark.parametrize('constructor', ['M8', 'datetime64'])
+    def test_parser(self, tz, constructor):
         # pr #11245
-        for tz, constructor in product(('UTC', 'US/Eastern'),
-                                       ('M8', 'datetime64')):
-            assert (DatetimeTZDtype('%s[ns, %s]' % (constructor, tz)) ==
-                    DatetimeTZDtype('ns', tz))
+        dtz_str = '{con}[ns, {tz}]'.format(con=constructor, tz=tz)
+        result = DatetimeTZDtype(dtz_str)
+        expected = DatetimeTZDtype('ns', tz)
+        assert result == expected
 
     def test_empty(self):
         dt = DatetimeTZDtype()

--- a/pandas/tests/frame/test_rank.py
+++ b/pandas/tests/frame/test_rank.py
@@ -10,7 +10,6 @@ from numpy import nan
 from pandas.util.testing import assert_frame_equal
 from pandas.tests.frame.common import TestData
 from pandas import Series, DataFrame
-from pandas.compat import product
 
 
 class TestRank(TestData):
@@ -25,6 +24,13 @@ class TestRank(TestData):
         'first': np.array([1, 5, 7, 3, nan, 4, 2, 8, nan, 6]),
         'dense': np.array([1, 3, 4, 2, nan, 2, 1, 5, nan, 3]),
     }
+
+    @pytest.fixture(params=['average', 'min', 'max', 'first', 'dense'])
+    def method(self, request):
+        """
+        Fixture for trying all rank methods
+        """
+        return request.param
 
     def test_rank(self):
         rankdata = pytest.importorskip('scipy.stats.rankdata')
@@ -217,34 +223,35 @@ class TestRank(TestData):
                         expected = expected.astype('float64')
                     tm.assert_frame_equal(result, expected)
 
-    def test_rank_descending(self):
-        dtypes = ['O', 'f8', 'i8']
+    @pytest.mark.parametrize('dtype', ['O', 'f8', 'i8'])
+    def test_rank_descending(self, method, dtype):
 
-        for dtype, method in product(dtypes, self.results):
-            if 'i' in dtype:
-                df = self.df.dropna()
-            else:
-                df = self.df.astype(dtype)
+        if 'i' in dtype:
+            df = self.df.dropna()
+        else:
+            df = self.df.astype(dtype)
 
-            res = df.rank(ascending=False)
-            expected = (df.max() - df).rank()
-            assert_frame_equal(res, expected)
+        res = df.rank(ascending=False)
+        expected = (df.max() - df).rank()
+        assert_frame_equal(res, expected)
 
-            if method == 'first' and dtype == 'O':
-                continue
+        if method == 'first' and dtype == 'O':
+            return
 
-            expected = (df.max() - df).rank(method=method)
+        expected = (df.max() - df).rank(method=method)
 
-            if dtype != 'O':
-                res2 = df.rank(method=method, ascending=False,
-                               numeric_only=True)
-                assert_frame_equal(res2, expected)
+        if dtype != 'O':
+            res2 = df.rank(method=method, ascending=False,
+                           numeric_only=True)
+            assert_frame_equal(res2, expected)
 
-            res3 = df.rank(method=method, ascending=False,
-                           numeric_only=False)
-            assert_frame_equal(res3, expected)
+        res3 = df.rank(method=method, ascending=False,
+                       numeric_only=False)
+        assert_frame_equal(res3, expected)
 
-    def test_rank_2d_tie_methods(self):
+    @pytest.mark.parametrize('axis', [0, 1])
+    @pytest.mark.parametrize('dtype', [None, object])
+    def test_rank_2d_tie_methods(self, method, axis, dtype):
         df = self.df
 
         def _check2d(df, expected, method='average', axis=0):
@@ -257,43 +264,38 @@ class TestRank(TestData):
             result = df.rank(method=method, axis=axis)
             assert_frame_equal(result, exp_df)
 
-        dtypes = [None, object]
         disabled = set([(object, 'first')])
-        results = self.results
+        if (dtype, method) in disabled:
+            return
+        frame = df if dtype is None else df.astype(dtype)
+        _check2d(frame, self.results[method], method=method, axis=axis)
 
-        for method, axis, dtype in product(results, [0, 1], dtypes):
-            if (dtype, method) in disabled:
-                continue
-            frame = df if dtype is None else df.astype(dtype)
-            _check2d(frame, results[method], method=method, axis=axis)
+    @pytest.mark.parametrize(
+        "method,exp", [("dense",
+                        [[1., 1., 1.],
+                         [1., 0.5, 2. / 3],
+                         [1., 0.5, 1. / 3]]),
+                       ("min",
+                        [[1. / 3, 1., 1.],
+                         [1. / 3, 1. / 3, 2. / 3],
+                         [1. / 3, 1. / 3, 1. / 3]]),
+                       ("max",
+                        [[1., 1., 1.],
+                         [1., 2. / 3, 2. / 3],
+                         [1., 2. / 3, 1. / 3]]),
+                       ("average",
+                        [[2. / 3, 1., 1.],
+                         [2. / 3, 0.5, 2. / 3],
+                         [2. / 3, 0.5, 1. / 3]]),
+                       ("first",
+                        [[1. / 3, 1., 1.],
+                         [2. / 3, 1. / 3, 2. / 3],
+                         [3. / 3, 2. / 3, 1. / 3]])])
+    def test_rank_pct_true(self, method, exp):
+        # see gh-15630.
 
+        df = DataFrame([[2012, 66, 3], [2012, 65, 2], [2012, 65, 1]])
+        result = df.rank(method=method, pct=True)
 
-@pytest.mark.parametrize(
-    "method,exp", [("dense",
-                    [[1., 1., 1.],
-                     [1., 0.5, 2. / 3],
-                     [1., 0.5, 1. / 3]]),
-                   ("min",
-                    [[1. / 3, 1., 1.],
-                     [1. / 3, 1. / 3, 2. / 3],
-                     [1. / 3, 1. / 3, 1. / 3]]),
-                   ("max",
-                    [[1., 1., 1.],
-                     [1., 2. / 3, 2. / 3],
-                     [1., 2. / 3, 1. / 3]]),
-                   ("average",
-                    [[2. / 3, 1., 1.],
-                     [2. / 3, 0.5, 2. / 3],
-                     [2. / 3, 0.5, 1. / 3]]),
-                   ("first",
-                    [[1. / 3, 1., 1.],
-                     [2. / 3, 1. / 3, 2. / 3],
-                     [3. / 3, 2. / 3, 1. / 3]])])
-def test_rank_pct_true(method, exp):
-    # see gh-15630.
-
-    df = DataFrame([[2012, 66, 3], [2012, 65, 2], [2012, 65, 1]])
-    result = df.rank(method=method, pct=True)
-
-    expected = DataFrame(exp)
-    tm.assert_frame_equal(result, expected)
+        expected = DataFrame(exp)
+        tm.assert_frame_equal(result, expected)

--- a/pandas/tests/groupby/test_function.py
+++ b/pandas/tests/groupby/test_function.py
@@ -778,9 +778,10 @@ def test_frame_describe_unstacked_format():
 # nunique
 # --------------------------------
 
-@pytest.mark.parametrize("n, m", cart_product(10 ** np.arange(2, 6),
-                                              (10, 100, 1000)))
-@pytest.mark.parametrize("sort, dropna", cart_product((False, True), repeat=2))
+@pytest.mark.parametrize('n', 10 ** np.arange(2, 6))
+@pytest.mark.parametrize('m', [10, 100, 1000])
+@pytest.mark.parametrize('sort', [False, True])
+@pytest.mark.parametrize('dropna', [False, True])
 def test_series_groupby_nunique(n, m, sort, dropna):
 
     def check_nunique(df, keys, as_index=True):

--- a/pandas/tests/groupby/test_whitelist.py
+++ b/pandas/tests/groupby/test_whitelist.py
@@ -8,7 +8,6 @@ from string import ascii_lowercase
 import numpy as np
 from pandas import DataFrame, Series, compat, date_range, Index, MultiIndex
 from pandas.util import testing as tm
-from pandas.compat import lrange, product
 
 AGG_FUNCTIONS = ['sum', 'prod', 'min', 'max', 'median', 'mean', 'skew',
                  'mad', 'std', 'var', 'sem']
@@ -175,12 +174,11 @@ def raw_frame():
     return raw_frame
 
 
-@pytest.mark.parametrize(
-    "op, level, axis, skipna, sort",
-    product(AGG_FUNCTIONS,
-            lrange(2), lrange(2),
-            [True, False],
-            [True, False]))
+@pytest.mark.parametrize('op', AGG_FUNCTIONS)
+@pytest.mark.parametrize('level', [0, 1])
+@pytest.mark.parametrize('axis', [0, 1])
+@pytest.mark.parametrize('skipna', [True, False])
+@pytest.mark.parametrize('sort', [True, False])
 def test_regression_whitelist_methods(
         raw_frame, op, level,
         axis, skipna, sort):

--- a/pandas/tests/reshape/test_concat.py
+++ b/pandas/tests/reshape/test_concat.py
@@ -1,5 +1,5 @@
 from warnings import catch_warnings
-from itertools import combinations, product
+from itertools import combinations
 
 import datetime as dt
 import dateutil
@@ -941,10 +941,11 @@ class TestAppend(ConcatenateBase):
                                 columns=combined_columns)
         assert_frame_equal(result, expected)
 
-    @pytest.mark.parametrize(
-        "index_can_append, index_cannot_append_with_other",
-        product(indexes_can_append, indexes_cannot_append_with_other),
-        ids=lambda x: x.__class__.__name__)
+    @pytest.mark.parametrize('index_can_append', indexes_can_append,
+                             ids=lambda x: x.__class__.__name__)
+    @pytest.mark.parametrize('index_cannot_append_with_other',
+                             indexes_cannot_append_with_other,
+                             ids=lambda x: x.__class__.__name__)
     def test_append_different_columns_types_raises(
             self, index_can_append, index_cannot_append_with_other):
         # GH18359

--- a/pandas/tests/sparse/series/test_series.py
+++ b/pandas/tests/sparse/series/test_series.py
@@ -23,8 +23,6 @@ from pandas._libs.sparse import BlockIndex, IntIndex
 from pandas.core.sparse.api import SparseSeries
 from pandas.tests.series.test_api import SharedWithSparse
 
-from itertools import product
-
 
 def _test_data1():
     # nan-based
@@ -985,16 +983,16 @@ class TestSparseSeries(SharedWithSparse):
         tm.assert_sp_series_equal(result, result2)
         tm.assert_sp_series_equal(result, expected)
 
-    @pytest.mark.parametrize('deep,fill_values', [([True, False],
-                                                   [0, 1, np.nan, None])])
-    def test_memory_usage_deep(self, deep, fill_values):
-        for deep, fill_value in product(deep, fill_values):
-            sparse_series = SparseSeries(fill_values, fill_value=fill_value)
-            dense_series = Series(fill_values)
-            sparse_usage = sparse_series.memory_usage(deep=deep)
-            dense_usage = dense_series.memory_usage(deep=deep)
+    @pytest.mark.parametrize('deep', [True, False])
+    @pytest.mark.parametrize('fill_value', [0, 1, np.nan, None])
+    def test_memory_usage_deep(self, deep, fill_value):
+        values = [0, 1, np.nan, None]
+        sparse_series = SparseSeries(values, fill_value=fill_value)
+        dense_series = Series(values)
+        sparse_usage = sparse_series.memory_usage(deep=deep)
+        dense_usage = dense_series.memory_usage(deep=deep)
 
-            assert sparse_usage < dense_usage
+        assert sparse_usage < dense_usage
 
 
 class TestSparseHandlingMultiIndexes(object):

--- a/pandas/tests/test_window.py
+++ b/pandas/tests/test_window.py
@@ -2105,10 +2105,9 @@ class TestMomentsConsistency(Base):
                                              (mean_x * mean_y))
 
     @pytest.mark.slow
-    @pytest.mark.parametrize(
-        'min_periods, adjust, ignore_na', product([0, 1, 2, 3, 4],
-                                                  [True, False],
-                                                  [False, True]))
+    @pytest.mark.parametrize('min_periods', [0, 1, 2, 3, 4])
+    @pytest.mark.parametrize('adjust', [True, False])
+    @pytest.mark.parametrize('ignore_na', [True, False])
     def test_ewm_consistency(self, min_periods, adjust, ignore_na):
         def _weights(s, com, adjust, ignore_na):
             if isinstance(s, DataFrame):


### PR DESCRIPTION

- All instances `product` being used inside a `@pytest.mark.parametrize` have been converted to separate instances of `@pytest.mark.parametrize`
- Extracted `product` from within tests where it was straightforward
- There are still multiple instances of `product` being used within tests for looping purporses
   - Most of the ones left do not appear to be trivial to extract
   - Some instances we might not want to remove/are clearer as-is
   - Could maybe open an issue for some of the more obvious ones?