### PR TITLE
BUG: Fix `json_normalize` when calling with list `record_path` (#21605)

### DIFF
--- a/doc/source/whatsnew/v0.23.2.txt
+++ b/doc/source/whatsnew/v0.23.2.txt
@@ -72,6 +72,7 @@ Bug Fixes
 
 - Bug in :func:`read_csv` that caused it to incorrectly raise an error when ``nrows=0``, ``low_memory=True``, and ``index_col`` was not ``None`` (:issue:`21141`)
 - Bug in :func:`json_normalize` when formatting the ``record_prefix`` with integer columns (:issue:`21536`)
+- Bug in :func:`json_normalize` when calling with list ``record_path`` (:issue:`21605`)
 -
 
 **Plotting**

--- a/pandas/io/json/normalize.py
+++ b/pandas/io/json/normalize.py
@@ -224,7 +224,7 @@ def json_normalize(data, record_path=None, meta=None,
         sep = str(sep)
     meta_keys = [sep.join(val) for val in meta]
 
-    def _recursive_extract_dict(obj, key, seen_meta, level):
+    def _extract(obj, key, seen_meta, level):
         recs = _pull_field(obj, key)
 
         # For repeating the metadata later
@@ -260,9 +260,9 @@ def json_normalize(data, record_path=None, meta=None,
                                    seen_meta, level=level + 1)
         elif isinstance(data, list):
             for obj in data:
-                _recursive_extract_dict(obj, path[0], seen_meta, level)
+                _extract(obj, path[0], seen_meta, level)
         else:
-            _recursive_extract_dict(data, path[0], seen_meta, level)
+            _extract(data, path[0], seen_meta, level)
 
     _recursive_extract(data, record_path, {}, level=0)
 

--- a/pandas/io/json/normalize.py
+++ b/pandas/io/json/normalize.py
@@ -224,6 +224,31 @@ def json_normalize(data, record_path=None, meta=None,
         sep = str(sep)
     meta_keys = [sep.join(val) for val in meta]
 
+    def _recursive_extract_dict(obj, key, seen_meta, level):
+        recs = _pull_field(obj, key)
+
+        # For repeating the metadata later
+        lengths.append(len(recs))
+
+        for val, key in zip(meta, meta_keys):
+            if level + 1 > len(val):
+                meta_val = seen_meta[key]
+            else:
+                try:
+                    meta_val = _pull_field(obj, val[level:])
+                except KeyError as e:
+                    if errors == 'ignore':
+                        meta_val = np.nan
+                    else:
+                        raise \
+                            KeyError("Try running with "
+                                     "errors='ignore' as key "
+                                     "{err} is not always present"
+                                     .format(err=e))
+            meta_vals[key].append(meta_val)
+
+        records.extend(recs)
+
     def _recursive_extract(data, path, seen_meta, level=0):
         if len(path) > 1:
             for obj in data:
@@ -233,31 +258,11 @@ def json_normalize(data, record_path=None, meta=None,
 
                 _recursive_extract(obj[path[0]], path[1:],
                                    seen_meta, level=level + 1)
-        else:
+        elif isinstance(data, list):
             for obj in data:
-                recs = _pull_field(obj, path[0])
-
-                # For repeating the metadata later
-                lengths.append(len(recs))
-
-                for val, key in zip(meta, meta_keys):
-                    if level + 1 > len(val):
-                        meta_val = seen_meta[key]
-                    else:
-                        try:
-                            meta_val = _pull_field(obj, val[level:])
-                        except KeyError as e:
-                            if errors == 'ignore':
-                                meta_val = np.nan
-                            else:
-                                raise \
-                                    KeyError("Try running with "
-                                             "errors='ignore' as key "
-                                             "{err} is not always present"
-                                             .format(err=e))
-                    meta_vals[key].append(meta_val)
-
-                records.extend(recs)
+                _recursive_extract_dict(obj, path[0], seen_meta, level)
+        else:
+            _recursive_extract_dict(data, path[0], seen_meta, level)
 
     _recursive_extract(data, record_path, {}, level=0)
 

--- a/pandas/tests/io/json/test_normalize.py
+++ b/pandas/tests/io/json/test_normalize.py
@@ -129,6 +129,12 @@ class TestJSONNormalize(object):
         expected = DataFrame([[1], [2]], columns=['Prefix.0'])
         tm.assert_frame_equal(result, expected)
 
+    def test_list_record_path(self):
+        # GH 21605
+        result = json_normalize({'A': {'B': [1, 2]}}, ['A', 'B'])
+        expected = DataFrame([[1], [2]], columns=['0'])
+        tm.assert_frame_equal(result, expected)
+
     def test_more_deeply_nested(self, deep_nested):
 
         result = json_normalize(deep_nested, ['states', 'cities'],

--- a/pandas/tests/io/json/test_normalize.py
+++ b/pandas/tests/io/json/test_normalize.py
@@ -131,8 +131,8 @@ class TestJSONNormalize(object):
 
     def test_list_record_path(self):
         # GH 21605
-        result = json_normalize({'A': {'B': [1, 2]}}, ['A', 'B'])
-        expected = DataFrame([[1], [2]], columns=['0'])
+        result = json_normalize({'A': {'B': [{'X': 1, 'Y': 2}, {'X': 3, 'Y': 4}]}}, ['A', 'B'])
+        expected = DataFrame([[1, 2], [3, 4]], columns=['X', 'Y'])
         tm.assert_frame_equal(result, expected)
 
     def test_more_deeply_nested(self, deep_nested):

--- a/pandas/tests/io/json/test_normalize.py
+++ b/pandas/tests/io/json/test_normalize.py
@@ -131,7 +131,8 @@ class TestJSONNormalize(object):
 
     def test_list_record_path(self):
         # GH 21605
-        result = json_normalize({'A': {'B': [{'X': 1, 'Y': 2}, {'X': 3, 'Y': 4}]}}, ['A', 'B'])
+        result = json_normalize(
+            {'A': {'B': [{'X': 1, 'Y': 2}, {'X': 3, 'Y': 4}]}}, ['A', 'B'])
         expected = DataFrame([[1, 2], [3, 4]], columns=['X', 'Y'])
         tm.assert_frame_equal(result, expected)
 


### PR DESCRIPTION
This PR fixes the bug that caused `json_normalize` to throw `TypeError` when calling with a list `record_path`.

- [x] closes #21605
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry
