### PR TITLE
BUG: Fix json_normalize throwing AttributeError (#21608)

### DIFF
--- a/doc/source/whatsnew/v0.23.2.txt
+++ b/doc/source/whatsnew/v0.23.2.txt
@@ -72,7 +72,7 @@ Bug Fixes
 
 - Bug in :func:`read_csv` that caused it to incorrectly raise an error when ``nrows=0``, ``low_memory=True``, and ``index_col`` was not ``None`` (:issue:`21141`)
 - Bug in :func:`json_normalize` when formatting the ``record_prefix`` with integer columns (:issue:`21536`)
-- Bug in :func:`json_normalize` when flattening an array of values (:issue:`21536`)
+- Bug in :func:`json_normalize` when flattening an array of values (:issue:`21608`)
 -
 
 **Plotting**

--- a/doc/source/whatsnew/v0.23.2.txt
+++ b/doc/source/whatsnew/v0.23.2.txt
@@ -72,6 +72,7 @@ Bug Fixes
 
 - Bug in :func:`read_csv` that caused it to incorrectly raise an error when ``nrows=0``, ``low_memory=True``, and ``index_col`` was not ``None`` (:issue:`21141`)
 - Bug in :func:`json_normalize` when formatting the ``record_prefix`` with integer columns (:issue:`21536`)
+- Bug in :func:`json_normalize` when flattening an array of values (:issue:`21536`)
 -
 
 **Plotting**

--- a/pandas/io/json/normalize.py
+++ b/pandas/io/json/normalize.py
@@ -186,9 +186,13 @@ def json_normalize(data, record_path=None, meta=None,
 
         return result
 
-    if isinstance(data, list) and not data:
-        return DataFrame()
-
+    if isinstance(data, list):
+        if not data:
+            return DataFrame()
+        elif any([not isinstance(x, list) and not isinstance(x, dict)
+                  for x in data]):
+            return DataFrame(data, columns=['0'])
+            
     # A bit of a hackjob
     if isinstance(data, dict):
         data = [data]

--- a/pandas/io/json/normalize.py
+++ b/pandas/io/json/normalize.py
@@ -192,7 +192,7 @@ def json_normalize(data, record_path=None, meta=None,
         elif any([not isinstance(x, list) and not isinstance(x, dict)
                   for x in data]):
             return DataFrame(data, columns=['0'])
-            
+
     # A bit of a hackjob
     if isinstance(data, dict):
         data = [data]

--- a/pandas/tests/io/json/test_normalize.py
+++ b/pandas/tests/io/json/test_normalize.py
@@ -129,6 +129,12 @@ class TestJSONNormalize(object):
         expected = DataFrame([[1], [2]], columns=['Prefix.0'])
         tm.assert_frame_equal(result, expected)
 
+    def test_value_array(self):
+        # GH 21608
+        result = json_normalize([1, 2])
+        expected = DataFrame([[1], [2]], columns=['0'])
+        tm.assert_frame_equal(result, expected)
+
     def test_more_deeply_nested(self, deep_nested):
 
         result = json_normalize(deep_nested, ['states', 'cities'],


### PR DESCRIPTION
This PR fixes the bug in `json_normalize` that causes it to throw `AttributeError` when flattening an array of values.
- [ ] closes #21608 
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry
