### PR TITLE
CLN: make CategoricalIndex._create_categorical a classmethod

### DIFF
--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -1130,7 +1130,8 @@ class Index(IndexOpsMixin, PandasObject):
         """
 
         from pandas import DataFrame
-        result = DataFrame(self._shallow_copy(), columns=[self.name or 0])
+        name = self.name or 0
+        result = DataFrame({name: self.values.copy()})
 
         if index:
             result.index = self

--- a/pandas/core/indexes/category.py
+++ b/pandas/core/indexes/category.py
@@ -85,11 +85,11 @@ class CategoricalIndex(Index, accessor.PandasDelegate):
             name = data.name
 
         if isinstance(data, ABCCategorical):
-            data = cls._create_categorical(cls, data, categories, ordered,
+            data = cls._create_categorical(data, categories, ordered,
                                            dtype)
         elif isinstance(data, CategoricalIndex):
             data = data._data
-            data = cls._create_categorical(cls, data, categories, ordered,
+            data = cls._create_categorical(data, categories, ordered,
                                            dtype)
         else:
 
@@ -99,7 +99,7 @@ class CategoricalIndex(Index, accessor.PandasDelegate):
                 if data is not None or categories is None:
                     cls._scalar_data_error(data)
                 data = []
-            data = cls._create_categorical(cls, data, categories, ordered,
+            data = cls._create_categorical(data, categories, ordered,
                                            dtype)
 
         if copy:
@@ -136,8 +136,8 @@ class CategoricalIndex(Index, accessor.PandasDelegate):
                                      ordered=self.ordered)
         return CategoricalIndex(cat, name=name)
 
-    @staticmethod
-    def _create_categorical(self, data, categories=None, ordered=None,
+    @classmethod
+    def _create_categorical(cls, data, categories=None, ordered=None,
                             dtype=None):
         """
         *this is an internal non-public method*
@@ -155,7 +155,7 @@ class CategoricalIndex(Index, accessor.PandasDelegate):
         -------
         Categorical
         """
-        if (isinstance(data, (ABCSeries, type(self))) and
+        if (isinstance(data, (cls, ABCSeries)) and
                 is_categorical_dtype(data)):
             data = data.values
 
@@ -179,7 +179,7 @@ class CategoricalIndex(Index, accessor.PandasDelegate):
                     dtype=None, **kwargs):
         result = object.__new__(cls)
 
-        values = cls._create_categorical(cls, values, categories, ordered,
+        values = cls._create_categorical(values, categories, ordered,
                                          dtype=dtype)
         result._data = values
         result.name = name
@@ -236,7 +236,7 @@ class CategoricalIndex(Index, accessor.PandasDelegate):
             if not is_list_like(values):
                 values = [values]
             other = CategoricalIndex(self._create_categorical(
-                self, other, categories=self.categories, ordered=self.ordered))
+                other, categories=self.categories, ordered=self.ordered))
             if not other.isin(values).all():
                 raise TypeError("cannot append a non-category item to a "
                                 "CategoricalIndex")
@@ -798,7 +798,7 @@ class CategoricalIndex(Index, accessor.PandasDelegate):
                     other = other._values
                 elif isinstance(other, Index):
                     other = self._create_categorical(
-                        self, other._values, categories=self.categories,
+                        other._values, categories=self.categories,
                         ordered=self.ordered)
 
                 if isinstance(other, (ABCCategorical, np.ndarray,


### PR DESCRIPTION
Currently, ``CategoricalIndex._create_categorical`` is a staticmethod, and is being called internally using *either* instances or classes as its first argument, e.g.:
* in ``_is_dtype_compat`` *an instance* is supplied as the first argument,
* in ``__new__`` *a class* is supplied as the first argument.

This is confusing and makes the code paths different depending on how the method is called. It makes it difficult to reason about the precise output of the method.

This PR cleans this up by making ``_create_categorical`` a classmethod. This simplifies stuff, and we can also remove the method's first parameter when calling it.

Calling ``_create_categorical`` unneccesarily is one reason for the slowness of #20395. After this cleanup PR I will do another that should get #20395 come down to 1.6 ms as well as give some other related performance improvements.