### PR TITLE
DOC: Do no use 'type' as first word when specifying a return type (#21622)

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -4675,7 +4675,7 @@ class DataFrame(NDFrame):
 
         Returns
         -------
-        swapped : type of caller (new object)
+        swapped : same type as caller (new object)
 
         .. versionchanged:: 0.18.1
 

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -800,7 +800,7 @@ class NDFrame(PandasObject, SelectionMixin):
 
         Returns
         -------
-        swapped : type of caller (new object)
+        swapped : same type as caller (new object)
 
         .. versionchanged:: 0.18.1
 
@@ -1073,7 +1073,7 @@ class NDFrame(PandasObject, SelectionMixin):
 
         Returns
         -------
-        renamed : type of caller or None if inplace=True
+        renamed : same type as caller or None if inplace=True
 
         See Also
         --------
@@ -2468,7 +2468,7 @@ class NDFrame(PandasObject, SelectionMixin):
 
         Returns
         -------
-        value : type of items contained in object
+        value : same type as items contained in object
         """
         try:
             return self[key]
@@ -2768,7 +2768,7 @@ class NDFrame(PandasObject, SelectionMixin):
 
         Returns
         -------
-        taken : type of caller
+        taken : same type as caller
             An array-like containing the elements taken from the object.
 
         See Also
@@ -2824,7 +2824,7 @@ class NDFrame(PandasObject, SelectionMixin):
 
         Returns
         -------
-        taken : type of caller
+        taken : same type as caller
             An array-like containing the elements taken from the object.
 
         See Also
@@ -3033,7 +3033,7 @@ class NDFrame(PandasObject, SelectionMixin):
 
         Returns
         -------
-        selection : type of caller
+        selection : same type as caller
         """
         warnings.warn("'select' is deprecated and will be removed in a "
                       "future release. You can use "
@@ -3924,7 +3924,7 @@ class NDFrame(PandasObject, SelectionMixin):
 
         Returns
         -------
-        obj_head : type of caller
+        obj_head : same type as caller
             The first `n` rows of the caller object.
 
         See Also
@@ -4447,7 +4447,7 @@ class NDFrame(PandasObject, SelectionMixin):
 
         Returns
         -------
-        consolidated : type of caller
+        consolidated : same type as caller
         """
         inplace = validate_bool_kwarg(inplace, 'inplace')
         if inplace:
@@ -4916,7 +4916,7 @@ class NDFrame(PandasObject, SelectionMixin):
 
         Returns
         -------
-        casted : type of caller
+        casted : same type as caller
 
         Examples
         --------
@@ -6691,7 +6691,7 @@ class NDFrame(PandasObject, SelectionMixin):
 
         Returns
         -------
-        converted : type of caller
+        converted : same type as caller
 
         Examples
         --------
@@ -6772,7 +6772,7 @@ class NDFrame(PandasObject, SelectionMixin):
 
         Returns
         -------
-        values_at_time : type of caller
+        values_at_time : same type as caller
 
         Examples
         --------
@@ -6826,7 +6826,7 @@ class NDFrame(PandasObject, SelectionMixin):
 
         Returns
         -------
-        values_between_time : type of caller
+        values_between_time : same type as caller
 
         Examples
         --------
@@ -7145,7 +7145,7 @@ class NDFrame(PandasObject, SelectionMixin):
 
         Returns
         -------
-        subset : type of caller
+        subset : same type as caller
 
         See Also
         --------
@@ -7209,7 +7209,7 @@ class NDFrame(PandasObject, SelectionMixin):
 
         Returns
         -------
-        subset : type of caller
+        subset : same type as caller
 
         See Also
         --------

--- a/pandas/core/groupby/groupby.py
+++ b/pandas/core/groupby/groupby.py
@@ -867,7 +867,7 @@ b  2""")
 
         Returns
         -------
-        group : type of obj
+        group : same type as obj
         """
         if obj is None:
             obj = self._selected_obj

--- a/pandas/core/sparse/series.py
+++ b/pandas/core/sparse/series.py
@@ -398,7 +398,7 @@ class SparseSeries(Series):
 
         Returns
         -------
-        abs: type of caller
+        abs: same type as caller
         """
         return self._constructor(np.abs(self.values),
                                  index=self.index).__finalize__(self)

--- a/pandas/core/window.py
+++ b/pandas/core/window.py
@@ -665,7 +665,7 @@ class Window(_Window):
 
         Returns
         -------
-        y : type of input argument
+        y : same type as input argument
 
         """
         window = self._prep_window(**kwargs)
@@ -2139,7 +2139,7 @@ class EWM(_Rolling):
 
         Returns
         -------
-        y : type of input argument
+        y : same type as input argument
 
         """
         blocks, obj, index = self._create_blocks()

--- a/pandas/io/packers.py
+++ b/pandas/io/packers.py
@@ -178,7 +178,7 @@ def read_msgpack(path_or_buf, encoding='utf-8', iterator=False, **kwargs):
 
     Returns
     -------
-    obj : type of object stored in file
+    obj : same type as object stored in file
 
     """
     path_or_buf, _, _, should_close = get_filepath_or_buffer(path_or_buf)

--- a/pandas/io/pickle.py
+++ b/pandas/io/pickle.py
@@ -103,7 +103,7 @@ def read_pickle(path, compression='infer'):
 
     Returns
     -------
-    unpickled : type of object stored in file
+    unpickled : same type as object stored in file
 
     See Also
     --------

--- a/pandas/io/pytables.py
+++ b/pandas/io/pytables.py
@@ -687,7 +687,7 @@ class HDFStore(StringMixin):
 
         Returns
         -------
-        obj : type of object stored in file
+        obj : same type as object stored in file
         """
         group = self.get_node(key)
         if group is None:


### PR DESCRIPTION
Pycharm is otherwise confused and expects objects of type
'type' to be returned.

- [x] closes #21622 
- [x] tests added / passed (no code changes)
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry (not needed I guess)
