### PR TITLE
DOC: Fix versionadded directive typos in IntervalIndex

### DIFF
--- a/pandas/core/indexes/interval.py
+++ b/pandas/core/indexes/interval.py
@@ -160,7 +160,7 @@ class IntervalIndex(IntervalMixin, Index):
     dtype : dtype or None, default None
         If None, dtype will be inferred
 
-        ..versionadded:: 0.23.0
+        .. versionadded:: 0.23.0
 
     Attributes
     ----------
@@ -438,7 +438,7 @@ class IntervalIndex(IntervalMixin, Index):
         dtype : dtype or None, default None
             If None, dtype will be inferred
 
-            ..versionadded:: 0.23.0
+            .. versionadded:: 0.23.0
 
         Examples
         --------
@@ -568,7 +568,7 @@ class IntervalIndex(IntervalMixin, Index):
         dtype : dtype or None, default None
             If None, dtype will be inferred
 
-            ..versionadded:: 0.23.0
+            .. versionadded:: 0.23.0
 
         Examples
         --------
@@ -619,7 +619,7 @@ class IntervalIndex(IntervalMixin, Index):
         dtype : dtype or None, default None
             If None, dtype will be inferred
 
-            ..versionadded:: 0.23.0
+            .. versionadded:: 0.23.0
 
         Examples
         --------
@@ -671,7 +671,7 @@ class IntervalIndex(IntervalMixin, Index):
             Returns NA as a tuple if True, ``(nan, nan)``, or just as the NA
             value itself if False, ``nan``.
 
-            ..versionadded:: 0.23.0
+            .. versionadded:: 0.23.0
 
         Examples
         --------


### PR DESCRIPTION
There needs to be a space between the `..` and `versionadded::`.  Currently being rendered as plaintext, which doesn't look too great:

![image](https://user-images.githubusercontent.com/5332445/41943354-50072132-7960-11e8-814e-5fd8ef559a86.png)

Couldn't find any other instances of this in the codebase for `versionadded` or any other commonly used directives.  Pretty minor so tagging this as 0.23.2.
