### PR TITLE
DOC: update DataFrame.dropna's axis argument docs

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -4186,6 +4186,7 @@ class DataFrame(NDFrame):
 
             .. deprecated:: 0.23.0
                 Pass tuple or list to drop on multiple axes.
+                Only a single axis is allowed.
 
         how : {'any', 'all'}, default 'any'
             Determine if row or column is removed from DataFrame, when we have


### PR DESCRIPTION
Make `DataFrame.dropna`'s axis argument type deprecated warning in documentation easier to understand.