### PR TITLE
BUG: Fix MI repr with long names

### DIFF
--- a/doc/source/whatsnew/v0.23.2.txt
+++ b/doc/source/whatsnew/v0.23.2.txt
@@ -54,7 +54,7 @@ Fixed Regressions
 
 - Fixed regression in :meth:`to_csv` when handling file-like object incorrectly (:issue:`21471`)
 - Bug in both :meth:`DataFrame.first_valid_index` and :meth:`Series.first_valid_index` raised for a row index having duplicate values (:issue:`21441`)
--
+- Fixed printing of DataFrames with hierarchical columns with long names (:issue:`21180`)
 
 .. _whatsnew_0232.performance:
 

--- a/pandas/io/formats/format.py
+++ b/pandas/io/formats/format.py
@@ -636,10 +636,12 @@ class DataFrameFormatter(TableFormatter):
                     mid = int(round(n_cols / 2.))
                     mid_ix = col_lens.index[mid]
                     col_len = col_lens[mid_ix]
-                    adj_dif -= (col_len + 1)  # adjoin adds one
+                    # adjoin adds one
+                    adj_dif -= (col_len + 1)
                     col_lens = col_lens.drop(mid_ix)
                     n_cols = len(col_lens)
-                max_cols_adj = n_cols - self.index  # subtract index column
+                # subtract index column
+                max_cols_adj = n_cols - self.index
                 # GH-21180. Ensure that we print at least two.
                 max_cols_adj = max(max_cols_adj, 2)
                 self.max_cols_adj = max_cols_adj

--- a/pandas/io/formats/format.py
+++ b/pandas/io/formats/format.py
@@ -640,6 +640,8 @@ class DataFrameFormatter(TableFormatter):
                     col_lens = col_lens.drop(mid_ix)
                     n_cols = len(col_lens)
                 max_cols_adj = n_cols - self.index  # subtract index column
+                # GH-21180. Ensure that we print at least two.
+                max_cols_adj = max(max_cols_adj, 2)
                 self.max_cols_adj = max_cols_adj
 
                 # Call again _chk_truncate to cut frame appropriately

--- a/pandas/io/formats/format.py
+++ b/pandas/io/formats/format.py
@@ -778,7 +778,7 @@ class DataFrameFormatter(TableFormatter):
 
             str_columns = list(zip(*[[space_format(x, y) for y in x]
                                      for x in fmt_columns]))
-            if self.sparsify:
+            if self.sparsify and len(str_columns):
                 str_columns = _sparsify(str_columns)
 
             str_columns = [list(x) for x in zip(*str_columns)]

--- a/pandas/tests/io/formats/test_format.py
+++ b/pandas/tests/io/formats/test_format.py
@@ -305,7 +305,7 @@ class TestDataFrameFormatting(object):
             assert not has_truncated_repr(df)
             assert not has_expanded_repr(df)
 
-    def test_repr_multiindex(self):
+    def test_repr_truncates_terminal_size(self):
         # https://github.com/pandas-dev/pandas/issues/21180
         # TODO: use mock fixutre.
         # This is being backported, so doing it directly here.
@@ -328,11 +328,20 @@ class TestDataFrameFormatting(object):
         df = pd.DataFrame(1, index=index, columns=columns)
 
         with p1, p2:
-            result = repr(df.head())
+            result = repr(df)
 
-        # This assert will hopefully be replaced by something better in
-        # the future
-        assert result.split('\n')[0][-3:] == '...'
+        h1, h2 = result.split('\n')[:2]
+        assert 'long' in h1
+        assert 'loooooonger' in h1
+        assert 'cat' in h2
+        assert 'dog' in h2
+
+        # regular columns
+        df2 = pd.DataFrame({"A" * 41: [1, 2], 'B' * 41: [1, 2]})
+        with p1, p2:
+            result = repr(df2)
+
+        assert df2.columns[0] in result.split('\n')[0]
 
     def test_repr_max_columns_max_rows(self):
         term_width, term_height = get_terminal_size()

--- a/pandas/tests/io/formats/test_format.py
+++ b/pandas/tests/io/formats/test_format.py
@@ -314,7 +314,7 @@ class TestDataFrameFormatting(object):
         except ImportError:
             mock = pytest.importorskip("mock")
 
-        terminal_size = os.terminal_size((118, 96))
+        terminal_size = (118, 96)
         p1 = mock.patch('pandas.io.formats.console.get_terminal_size',
                         return_value=terminal_size)
         p2 = mock.patch('pandas.io.formats.format.get_terminal_size',


### PR DESCRIPTION
Closes #21180 

```python
In [4]:         try:
   ...:             from unittest import mock
   ...:         except ImportError:
   ...:             mock = pytest.importorskip("mock")
   ...:
   ...:         terminal_size = os.terminal_size((118, 96))
   ...:         p1 = mock.patch('pandas.io.formats.console.get_terminal_size',
   ...:                         return_value=terminal_size)
   ...:         p2 = mock.patch('pandas.io.formats.format.get_terminal_size',
   ...:                         return_value=terminal_size)
   ...:
   ...:         index = range(5)
   ...:         columns = pd.MultiIndex.from_tuples([
   ...:             ('This is a long title with > 37 chars.', 'cat'),
   ...:             ('This is a loooooonger title with > 43 chars.', 'dog'),
   ...:         ])
   ...:         df = pd.DataFrame(1, index=index, columns=columns)
   ...:
   ...:

In [5]: with p1, p2:
   ...:     print('-' * 80)
   ...:     print(repr(df))
   ...:     print('-' * 80)
   ...:
```

output:

```
--------------------------------------------------------------------------------
  ...
  ...
0 ...
1 ...
2 ...
3 ...
4 ...

[5 rows x 2 columns]
--------------------------------------------------------------------------------
```

This matches the repr for non-hierarchical

```python
In [6]: s = pd.DataFrame({"A" * 41: [1, 2], 'B' * 41: [1, 2]})

In [7]: with p1, p2:
   ...:     print('-' * 80)
   ...:     print(repr(s))
   ...:     print('-' * 80)
   ...:
```

output:

```
--------------------------------------------------------------------------------
  ...
0 ...
1 ...

[2 rows x 2 columns]
--------------------------------------------------------------------------------
```

These can certainly be improved, though I'm not sure we'll (I'll) get to it for 0.23.2.