### PR TITLE
ENH: pivot/groupby index with nan (GH3729)

### DIFF
--- a/doc/source/whatsnew/v0.24.0.txt
+++ b/doc/source/whatsnew/v0.24.0.txt
@@ -9,6 +9,7 @@ New features
 ~~~~~~~~~~~~
 
 - ``ExcelWriter`` now accepts ``mode`` as a keyword argument, enabling append to existing workbooks when using the ``openpyxl`` engine (:issue:`3441`)
+- ``groupby`` now accepts ``group_nas`` as a keyword argument, enabling the `np.nan` as a grouping label (:issue:`3729`)
 
 .. _whatsnew_0240.enhancements.other:
 

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -6584,7 +6584,8 @@ class NDFrame(PandasObject, SelectionMixin):
                                          axis=axis, inplace=inplace)
 
     def groupby(self, by=None, axis=0, level=None, as_index=True, sort=True,
-                group_keys=True, squeeze=False, observed=False, **kwargs):
+                group_keys=True, squeeze=False, observed=False,
+                group_nas=False, **kwargs):
         """
         Group series using mapper (dict or key function, apply given function
         to group, return result as series) or by a series of columns.
@@ -6621,6 +6622,8 @@ class NDFrame(PandasObject, SelectionMixin):
             This only applies if any of the groupers are Categoricals
             If True: only show observed values for categorical groupers.
             If False: show all values for categorical groupers.
+        group_nas : boolean, default False
+            Group the NaNs as normal values
 
             .. versionadded:: 0.23.0
 
@@ -6656,7 +6659,7 @@ class NDFrame(PandasObject, SelectionMixin):
         axis = self._get_axis_number(axis)
         return groupby(self, by=by, axis=axis, level=level, as_index=as_index,
                        sort=sort, group_keys=group_keys, squeeze=squeeze,
-                       observed=observed, **kwargs)
+                       observed=observed, group_nas=group_nas, **kwargs)
 
     def asfreq(self, freq, method=None, how=None, normalize=False,
                fill_value=None):

--- a/pandas/tests/groupby/test_groupby.py
+++ b/pandas/tests/groupby/test_groupby.py
@@ -276,6 +276,12 @@ def test_with_na_groups(dtype):
 
     assert_series_equal(agged, expected, check_dtype=False)
 
+    grouped_na = values.groupby(labels, group_nas=True)
+    agged_na = grouped_na.agg(len)
+    expected_na = Series([4, 2, 4], index=['bar', 'foo', np.nan])
+
+    assert_series_equal(agged_na, expected_na, check_dtype=False)
+
     # assert issubclass(agged.dtype.type, np.integer)
 
     # explicitly return a float from my function
@@ -287,6 +293,28 @@ def test_with_na_groups(dtype):
 
     assert_series_equal(agged, expected, check_dtype=False)
     assert issubclass(agged.dtype.type, np.dtype(dtype).type)
+
+    agged_na = grouped_na.agg(f)
+    expected_na = Series([4, 2, 4], index=['bar', 'foo', np.nan])
+
+    assert_series_equal(agged_na, expected_na, check_dtype=False)
+    assert issubclass(agged_na.dtype.type, np.dtype(dtype).type)
+
+    # Check the data frame groupby interface also handles NaNs correctly
+    df = pd.DataFrame({"Vals": values, "Labs": labels})
+
+    agged = df.groupby("Labs")["Vals"].sum()
+    expected = Series(
+        [4, 2], index=Index(['bar', 'foo'], name='Labs'), name='Vals'
+    )
+    assert_series_equal(agged, expected, check_dtype=False)
+
+    agged_na = df.groupby("Labs", group_nas=True)["Vals"].sum()
+    expected_na = Series(
+        [4, 2, 4], index=Index(['bar', 'foo', np.nan], name='Labs'),
+        name='Vals'
+    )
+    assert_series_equal(agged_na, expected_na, check_dtype=False)
 
 
 def test_indices_concatenation_order():


### PR DESCRIPTION
Adds the ability to use NaN as a grouping variable. Required allowing NA as a factorisation variable in `factorize()`.

- [x] closes #3729
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry
