### PR TITLE
TST/CLN: Old timezone issues PT3

### DIFF
--- a/doc/source/whatsnew/v0.24.0.txt
+++ b/doc/source/whatsnew/v0.24.0.txt
@@ -248,6 +248,8 @@ Timezones
 - Bug in :meth:`Series.truncate` with a tz-aware :class:`DatetimeIndex` which would cause a core dump (:issue:`9243`)
 - Bug in :class:`Series` constructor which would coerce tz-aware and tz-naive :class:`Timestamp`s to tz-aware (:issue:`13051`)
 - Bug in :class:`Index` with ``datetime64[ns, tz]`` dtype that did not localize integer data correctly (:issue:`20964`)
+- Bug in :class:`DatetimeIndex` where constructing with an integer and tz would not localize correctly (:issue:`12619`)
+- Bug in :func:`DataFrame.fillna` where a ``ValueError`` would raise when one column contained a ``datetime64[ns, tz]`` dtype (:issue:`15522`)
 
 Offsets
 ^^^^^^^
@@ -326,7 +328,7 @@ Sparse
 Reshaping
 ^^^^^^^^^
 
--
+- Bug in :func:`pandas.concat` when joining resampled DataFrames with timezone aware index (:issue:`13783`)
 -
 -
 

--- a/pandas/tests/frame/test_missing.py
+++ b/pandas/tests/frame/test_missing.py
@@ -300,6 +300,17 @@ class TestDataFrameMissingData(TestData):
                                   pd.Timestamp('2012-11-11 00:00:00+01:00')]})
         assert_frame_equal(df.fillna(method='bfill'), exp)
 
+        # with timezone in another column
+        # GH 15522
+        df = pd.DataFrame({'A': pd.date_range('20130101', periods=4,
+                                              tz='US/Eastern'),
+                           'B': [1, 2, np.nan, np.nan]})
+        result = df.fillna(method='pad')
+        expected = pd.DataFrame({'A': pd.date_range('20130101', periods=4,
+                                                    tz='US/Eastern'),
+                                 'B': [1., 2., 2., 2.]})
+        assert_frame_equal(result, expected)
+
     def test_na_actions_categorical(self):
 
         cat = Categorical([1, 2, 3, np.nan], categories=[1, 2, 3])

--- a/pandas/tests/indexes/datetimes/test_construction.py
+++ b/pandas/tests/indexes/datetimes/test_construction.py
@@ -496,6 +496,13 @@ class TestDatetimeIndex(object):
         expected = klass([ts])
         assert result == expected
 
+    def test_construction_int_rountrip(self, tz_naive_fixture):
+        # GH 12619
+        tz = tz_naive_fixture
+        result = 1293858000000000000
+        expected = DatetimeIndex([1293858000000000000], tz=tz).asi8[0]
+        assert result == expected
+
 
 class TestTimeSeries(object):
 

--- a/pandas/tests/reshape/test_concat.py
+++ b/pandas/tests/reshape/test_concat.py
@@ -2351,6 +2351,15 @@ bar2,12,13,14,15
 
         tm.assert_frame_equal(result, expected)
 
+        # GH 13783: Concat after resample
+        with catch_warnings(record=True):
+            result = pd.concat([df1.resample('H').mean(),
+                                df2.resample('H').mean()])
+            expected = pd.DataFrame({'a': [1, 2, 3] + [np.nan] * 3,
+                                     'b': [np.nan] * 3 + [1, 2, 3]},
+                                    index=idx1.append(idx1))
+            tm.assert_frame_equal(result, expected)
+
 
 @pytest.mark.parametrize('pdt', [pd.Series, pd.DataFrame, pd.Panel])
 @pytest.mark.parametrize('dt', np.sctypes['float'])


### PR DESCRIPTION
- [x] closes #13783
- [x] closes #12619
- [x] closes #15522
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry

xref #21612 and #21491, last of the cleanup of older timezone issues
