### PR TITLE
move _add__ and __sub__ to liboffsets, implement _Tick

### DIFF
--- a/pandas/_libs/tslibs/offsets.pyx
+++ b/pandas/_libs/tslibs/offsets.pyx
@@ -378,8 +378,8 @@ class _BaseOffset(object):
         if isinstance(other, datetime):
             raise TypeError('Cannot subtract datetime from offset.')
         elif type(other) == type(self):
-            return self.__class__(self.n - other.n, normalize=self.normalize,
-                                  **self.kwds)
+            return type(self)(self.n - other.n, normalize=self.normalize,
+                              **self.kwds)
         else:  # pragma: no cover
             return NotImplemented
 
@@ -387,8 +387,8 @@ class _BaseOffset(object):
         return self.apply(other)
 
     def __mul__(self, other):
-        return self.__class__(n=other * self.n, normalize=self.normalize,
-                              **self.kwds)
+        return type(self)(n=other * self.n, normalize=self.normalize,
+                          **self.kwds)
 
     def __neg__(self):
         # Note: we are defering directly to __mul__ instead of __rmul__, as

--- a/pandas/_libs/tslibs/offsets.pyx
+++ b/pandas/_libs/tslibs/offsets.pyx
@@ -511,8 +511,10 @@ class BaseOffset(_BaseOffset):
 
 
 class _Tick(object):
-    # dummy class to mix into tseries.Tick so that in tslibs.period we can
-    # do isinstance checks on _Tick and avoid importing tseries.offsets
+    """
+    dummy class to mix into tseries.offsets.Tick so that in tslibs.period we
+    can do isinstance checks on _Tick and avoid importing tseries.offsets
+    """
     pass
 
 

--- a/pandas/_libs/tslibs/offsets.pyx
+++ b/pandas/_libs/tslibs/offsets.pyx
@@ -364,6 +364,24 @@ class _BaseOffset(object):
                 if name not in ['n', 'normalize']}
         return {name: kwds[name] for name in kwds if kwds[name] is not None}
 
+    def __add__(self, other):
+        if getattr(other, "_typ", None) in ["datetimeindex",
+                                            "series", "period"]:
+            # defer to the other class's implementation
+        try:
+            return self.apply(other)
+        except ApplyTypeError:
+            return NotImplemented
+
+    def __sub__(self, other):
+        if isinstance(other, datetime):
+            raise TypeError('Cannot subtract datetime from offset.')
+        elif type(other) == type(self):
+            return self.__class__(self.n - other.n, normalize=self.normalize,
+                                  **self.kwds)
+        else:  # pragma: no cover
+            return NotImplemented
+
     def __call__(self, other):
         return self.apply(other)
 
@@ -489,6 +507,12 @@ class BaseOffset(_BaseOffset):
             # i.e. isinstance(other, (ABCDatetimeIndex, ABCSeries))
             return other - self
         return -self + other
+
+
+class _Tick(object):
+    # dummy class to mix into tseries.Tick so that in tslibs.period we can
+    # do isinstance checks on _Tick and avoid importing tseries.offsets
+    pass
 
 
 # ----------------------------------------------------------------------

--- a/pandas/_libs/tslibs/offsets.pyx
+++ b/pandas/_libs/tslibs/offsets.pyx
@@ -368,6 +368,7 @@ class _BaseOffset(object):
         if getattr(other, "_typ", None) in ["datetimeindex",
                                             "series", "period"]:
             # defer to the other class's implementation
+            return other + self
         try:
             return self.apply(other)
         except ApplyTypeError:

--- a/pandas/_libs/tslibs/period.pyx
+++ b/pandas/_libs/tslibs/period.pyx
@@ -55,8 +55,8 @@ from parsing import parse_time_string, NAT_SENTINEL
 from resolution import Resolution
 from nattype import nat_strings, NaT, iNaT
 from nattype cimport _nat_scalar_rules, NPY_NAT
+from offsets import _Tick
 
-from pandas.tseries import offsets
 from pandas.tseries import frequencies
 
 
@@ -1062,9 +1062,9 @@ cdef class _Period(object):
             int64_t nanos, offset_nanos
 
         if (PyDelta_Check(other) or util.is_timedelta64_object(other) or
-                isinstance(other, offsets.Tick)):
+                isinstance(other, _Tick)):
             offset = frequencies.to_offset(self.freq.rule_code)
-            if isinstance(offset, offsets.Tick):
+            if isinstance(offset, _Tick):
                 nanos = delta_to_nanoseconds(other)
                 offset_nanos = delta_to_nanoseconds(offset)
                 if nanos % offset_nanos == 0:

--- a/pandas/tseries/offsets.py
+++ b/pandas/tseries/offsets.py
@@ -7,7 +7,7 @@ from pandas.compat import range
 from pandas import compat
 import numpy as np
 
-from pandas.core.dtypes.generic import ABCSeries, ABCDatetimeIndex, ABCPeriod
+from pandas.core.dtypes.generic import ABCPeriod
 from pandas.core.tools.datetimes import to_datetime
 import pandas.core.common as com
 

--- a/pandas/tseries/offsets.py
+++ b/pandas/tseries/offsets.py
@@ -311,25 +311,6 @@ class DateOffset(BaseOffset):
     def name(self):
         return self.rule_code
 
-    def __add__(self, other):
-        if isinstance(other, (ABCDatetimeIndex, ABCSeries)):
-            return other + self
-        elif isinstance(other, ABCPeriod):
-            return other + self
-        try:
-            return self.apply(other)
-        except ApplyTypeError:
-            return NotImplemented
-
-    def __sub__(self, other):
-        if isinstance(other, datetime):
-            raise TypeError('Cannot subtract datetime from offset.')
-        elif type(other) == type(self):
-            return self.__class__(self.n - other.n, normalize=self.normalize,
-                                  **self.kwds)
-        else:  # pragma: no cover
-            return NotImplemented
-
     def rollback(self, dt):
         """Roll provided date backward to next offset only if not on offset"""
         dt = as_timestamp(dt)
@@ -2129,7 +2110,7 @@ def _tick_comp(op):
     return f
 
 
-class Tick(SingleConstructorOffset):
+class Tick(liboffsets._Tick, SingleConstructorOffset):
     _inc = Timedelta(microseconds=1000)
     _prefix = 'undefined'
     _attributes = frozenset(['n', 'normalize'])


### PR DESCRIPTION
Last one for now.

Moving `__add__` and `__sub__` to liboffsets has been viable for a while now, just getting around to it.

Implements a dummy `_Tick` class that gets mixed in to `Tick`.  Then in `tslibs.period` we can replace `isinstance(obj, offsets.Tick)` checks with `isinstnace(obj, _Tick)`, obviating the need for the import of `tseries.offsets`.  This moves us closer to being able to import `Period` directly in `_libs.__init__`, which has been a long-time goal (see the comment there).  In conjunction with #21693 and #21690, I think that gets us the rest of the way there.