### PR TITLE
add unit test for writing to already open file

### DIFF
--- a/pandas/tests/io/formats/test_to_csv.py
+++ b/pandas/tests/io/formats/test_to_csv.py
@@ -302,6 +302,7 @@ $1$,$2$
         assert not sys.stdout.closed
 
     def test_to_csv_write_to_open_file(self):
+        # GH 21696
         df = pd.DataFrame({'a': ['x', 'y', 'z']})
         expected = '''\
 manual header

--- a/pandas/tests/io/formats/test_to_csv.py
+++ b/pandas/tests/io/formats/test_to_csv.py
@@ -300,3 +300,18 @@ $1$,$2$
         output = sys.stdout.getvalue()
         assert output == expected_ascii
         assert not sys.stdout.closed
+
+    def test_to_csv_write_to_open_file(self):
+        df = pd.DataFrame({'a': ['x', 'y', 'z']})
+        expected = '''\
+manual header
+x
+y
+z
+'''
+        with tm.ensure_clean('test.txt') as path:
+            with open(path, 'w') as f:
+                f.write('manual header\n')
+                df.to_csv(f, header=None, index=None)
+            with open(path, 'r') as f:
+                assert f.read() == expected


### PR DESCRIPTION
- [ ] closes
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

closes #21577 
The added unit test will pass for `0.23.0`, fails for `0.23.1`, passes for `master`.