### PR TITLE
PERF: CategoricalIndex.get_loc should avoid expensive cast of .codes to int64

### DIFF
--- a/asv_bench/benchmarks/indexing.py
+++ b/asv_bench/benchmarks/indexing.py
@@ -2,7 +2,8 @@ import warnings
 
 import numpy as np
 import pandas.util.testing as tm
-from pandas import (Series, DataFrame, MultiIndex, Int64Index, Float64Index,
+from pandas import (Series, DataFrame, MultiIndex,
+                    Int64Index, UInt64Index, Float64Index,
                     IntervalIndex, CategoricalIndex,
                     IndexSlice, concat, date_range)
 from .pandas_vb_common import setup, Panel  # noqa
@@ -11,7 +12,7 @@ from .pandas_vb_common import setup, Panel  # noqa
 class NumericSeriesIndexing(object):
 
     goal_time = 0.2
-    params = [Int64Index, Float64Index]
+    params = [Int64Index, UInt64Index, Float64Index]
     param = ['index']
 
     def setup(self, index):

--- a/asv_bench/benchmarks/indexing_engines.py
+++ b/asv_bench/benchmarks/indexing_engines.py
@@ -1,6 +1,5 @@
 import numpy as np
 
-import pandas.util.testing as tm
 from pandas._libs.index import (Int64Engine, Int32Engine,
                                 Int16Engine, Int8Engine,
                                 UInt64Engine, UInt32Engine,
@@ -32,10 +31,9 @@ class NumericEngineIndexing(object):
         }[index_type]
 
         self.data = engine(lambda: array_, len(array_))
-        self.int_scalar = 2
 
     def time_get_loc(self, engine, index_type):
-        self.data.get_loc(self.int_scalar)
+        self.data.get_loc(2)
 
 
 class ObjectEngineIndexing(object):
@@ -57,7 +55,6 @@ class ObjectEngineIndexing(object):
         }[index_type]
 
         self.data = engine(lambda: array_, len(array_))
-        self.int_scalar = 'b'
 
     def time_get_loc(self, engine, index_type):
-        self.data.get_loc(self.int_scalar)
+        self.data.get_loc(2)

--- a/asv_bench/benchmarks/indexing_engines.py
+++ b/asv_bench/benchmarks/indexing_engines.py
@@ -1,0 +1,63 @@
+import numpy as np
+
+import pandas.util.testing as tm
+from pandas._libs.index import (Int64Engine, Int32Engine,
+                                Int16Engine, Int8Engine,
+                                UInt64Engine, UInt32Engine,
+                                UInt16Engine, UInt8Engine,
+                                Float64Engine, Float32Engine,
+                                ObjectEngine,
+                                )
+
+
+class NumericEngineIndexing(object):
+
+    goal_time = 0.2
+    params = [[Int64Engine, Int32Engine, Int16Engine, Int8Engine,
+               UInt64Engine, UInt32Engine, UInt16Engine, UInt8Engine,
+               Float64Engine, Float32Engine,
+               ],
+              ['monotonic_incr', 'monotonic_decr', 'non_monotonic']
+              ]
+    param_names = ['engine', 'index_type']
+
+    def setup(self, engine, index_type):
+        N = 10**5
+        values = list([1] * N + [2] * N + [3] * N)
+        array_ = {
+            'monotonic_incr': np.array(values, dtype=engine._dtype),
+            'monotonic_decr': np.array(list(reversed(values)),
+                                       dtype=engine._dtype),
+            'non_monotonic': np.array([1, 2, 3] * N, dtype=engine._dtype),
+        }[index_type]
+
+        self.data = engine(lambda: array_, len(array_))
+        self.int_scalar = 2
+
+    def time_get_loc(self, engine, index_type):
+        self.data.get_loc(self.int_scalar)
+
+
+class ObjectEngineIndexing(object):
+
+    goal_time = 0.2
+    params = [[ObjectEngine],
+              ['monotonic_incr', 'monotonic_decr', 'non_monotonic']
+              ]
+    param_names = ['engine', 'index_type']
+
+    def setup(self, engine, index_type):
+        N = 10**5
+        values = list('a' * N + 'b' * N + 'c' * N)
+        array_ = {
+            'monotonic_incr': np.array(values, dtype=engine._dtype),
+            'monotonic_decr': np.array(list(reversed(values)),
+                                       dtype=engine._dtype),
+            'non_monotonic': np.array(list('abc') * N, dtype=engine._dtype),
+        }[index_type]
+
+        self.data = engine(lambda: array_, len(array_))
+        self.int_scalar = 'b'
+
+    def time_get_loc(self, engine, index_type):
+        self.data.get_loc(self.int_scalar)

--- a/doc/source/whatsnew/v0.24.0.txt
+++ b/doc/source/whatsnew/v0.24.0.txt
@@ -591,9 +591,10 @@ Removal of prior version deprecations/changes
 Performance Improvements
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
-- Very large improvement in performance of slicing when the index is a :class:`CategoricalIndex`,
-  both when indexing by label (using .loc) and position(.iloc).
-  Likewise, slicing a ``CategoricalIndex`` itself (i.e. ``ci[100:200]``) shows similar speed improvements (:issue:`21659`)
+- Slicing Series and Dataframe with an monotonically increasing :class:`CategoricalIndex`
+  is now very fast and has speed comparable to slicing with an ``Int64Index``.
+  The speed increase is both when indexing by label (using .loc) and position(.iloc) (:issue:`20395`)
+- Slicing a ``CategoricalIndex`` itself (i.e. ``ci[1000:2000]``) shows similar speed improvements as above (:issue:`21659`)
 - Improved performance of :func:`Series.describe` in case of numeric dtpyes (:issue:`21274`)
 - Improved performance of :func:`pandas.core.groupby.GroupBy.rank` when dealing with tied rankings (:issue:`21237`)
 - Improved performance of :func:`DataFrame.set_index` with columns consisting of :class:`Period` objects (:issue:`21582`, :issue:`21606`)

--- a/pandas/_libs/algos.pyx
+++ b/pandas/_libs/algos.pyx
@@ -10,11 +10,13 @@ from libc.math cimport fabs, sqrt
 import numpy as np
 cimport numpy as cnp
 from numpy cimport (ndarray,
-                    NPY_INT64, NPY_UINT64, NPY_INT32, NPY_INT16, NPY_INT8,
-                    NPY_FLOAT32, NPY_FLOAT64,
+                    NPY_INT64, NPY_INT32, NPY_INT16, NPY_INT8,
+                    NPY_UINT64, NPY_UINT32, NPY_UINT16, NPY_UINT8,
+                    NPY_FLOAT64, NPY_FLOAT32,
                     NPY_OBJECT,
-                    int8_t, int16_t, int32_t, int64_t, uint8_t, uint16_t,
-                    uint32_t, uint64_t, float32_t, float64_t,
+                    int64_t, int32_t, int16_t, int8_t,
+                    uint64_t, uint32_t, uint16_t, uint8_t,
+                    float64_t, float32_t,
                     double_t)
 cnp.import_array()
 

--- a/pandas/_libs/algos.pyx
+++ b/pandas/_libs/algos.pyx
@@ -361,9 +361,13 @@ ctypedef fused algos_t:
     float64_t
     float32_t
     object
-    int32_t
     int64_t
+    int32_t
+    int16_t
+    int8_t
     uint64_t
+    uint32_t
+    uint16_t
     uint8_t
 
 

--- a/pandas/_libs/algos_common_helper.pxi.in
+++ b/pandas/_libs/algos_common_helper.pxi.in
@@ -133,11 +133,14 @@ def ensure_object(object arr):
 # name, c_type, dtype
 dtypes = [('float64', 'FLOAT64', 'float64'),
           ('float32', 'FLOAT32', 'float32'),
-          ('int8', 'INT8', 'int8'),
-          ('int16', 'INT16', 'int16'),
-          ('int32', 'INT32', 'int32'),
           ('int64', 'INT64', 'int64'),
+          ('int32', 'INT32', 'int32'),
+          ('int16', 'INT16', 'int16'),
+          ('int8', 'INT8', 'int8'),
           ('uint64', 'UINT64', 'uint64'),
+          ('uint32', 'UINT32', 'uint32'),
+          ('uint16', 'UINT16', 'uint16'),
+          ('uint8', 'UINT8', 'uint8'),
           # ('platform_int', 'INT', 'int_'),
           # ('object', 'OBJECT', 'object_'),
 ]

--- a/pandas/_libs/index.pyx
+++ b/pandas/_libs/index.pyx
@@ -5,9 +5,10 @@ import cython
 
 import numpy as np
 cimport numpy as cnp
-from numpy cimport (ndarray, float64_t, int32_t,
-                    int8_t, int16_t, int32_t, int64_t,
-                    uint8_t, uint64_t,
+from numpy cimport (ndarray,
+                    float64_t, float32_t,
+                    int64_t,int32_t, int16_t, int8_t,
+                    uint64_t, uint32_t, uint16_t, uint8_t,
                     intp_t,
                     # Note: NPY_DATETIME, NPY_TIMEDELTA are only available
                     # for cimport in cython>=0.27.3
@@ -244,8 +245,6 @@ cdef class IndexEngine:
         if not self.is_mapping_populated:
 
             values = self._get_index_values()
-            if values.dtype in {'int8', 'int16', 'int32'}:
-                values = algos.ensure_int64(values)
             self.mapping = self._make_hash_table(len(values))
             self._call_map_locations(values)
 

--- a/pandas/_libs/index.pyx
+++ b/pandas/_libs/index.pyx
@@ -6,7 +6,9 @@ import cython
 import numpy as np
 cimport numpy as cnp
 from numpy cimport (ndarray, float64_t, int32_t,
-                    int64_t, uint8_t, uint64_t, intp_t,
+                    int8_t, int16_t, int32_t, int64_t,
+                    uint8_t, uint64_t,
+                    intp_t,
                     # Note: NPY_DATETIME, NPY_TIMEDELTA are only available
                     # for cimport in cython>=0.27.3
                     NPY_DATETIME, NPY_TIMEDELTA)
@@ -242,6 +244,8 @@ cdef class IndexEngine:
         if not self.is_mapping_populated:
 
             values = self._get_index_values()
+            if values.dtype in {'int8', 'int16', 'int32'}:
+                values = algos.ensure_int64(values)
             self.mapping = self._make_hash_table(len(values))
             self._call_map_locations(values)
 

--- a/pandas/_libs/index.pyx
+++ b/pandas/_libs/index.pyx
@@ -7,7 +7,7 @@ import numpy as np
 cimport numpy as cnp
 from numpy cimport (ndarray,
                     float64_t, float32_t,
-                    int64_t,int32_t, int16_t, int8_t,
+                    int64_t, int32_t, int16_t, int8_t,
                     uint64_t, uint32_t, uint16_t, uint8_t,
                     intp_t,
                     # Note: NPY_DATETIME, NPY_TIMEDELTA are only available

--- a/pandas/_libs/index_class_helper.pxi.in
+++ b/pandas/_libs/index_class_helper.pxi.in
@@ -12,11 +12,15 @@ WARNING: DO NOT edit .pxi FILE directly, .pxi is generated from .pxi.in
 
 # name, dtype, ctype
 dtypes = [('Float64', 'float64', 'float64_t'),
+          ('Float32', 'float32', 'float32_t'),
           ('Int64', 'int64', 'int64_t'),
           ('Int32', 'int32', 'int32_t'),
           ('Int16', 'int16', 'int16_t'),
           ('Int8', 'int8', 'int8_t'),
           ('UInt64', 'uint64', 'uint64_t'),
+          ('UInt32', 'uint32', 'uint32_t'),
+          ('UInt16', 'uint16', 'uint16_t'),
+          ('UInt8', 'uint8', 'uint8_t'),
           ('Object', 'object', 'object'),
           ]
 }}
@@ -41,10 +45,23 @@ cdef class {{name}}Engine(IndexEngine):
         {{if name == 'Object'}}
         return _hash.PyObjectHashTable(n)
         {{elif name in {'Int8', 'Int16', 'Int32'} }}
+        # {{name}}HashTable is not available, so we use Int64HashTable
         return _hash.Int64HashTable(n)
+        {{elif name in {'UInt8', 'UInt16', 'UInt32'} }}
+        # {{name}}HashTable is not available, so we use UInt64HashTable
+        return _hash.UInt64HashTable(n)
+        {{elif name in {'Float32'} }}
+        # {{name}}HashTable is not available, so we use Float64HashTable
+        return _hash.Float64HashTable(n)
         {{else}}
         return _hash.{{name}}HashTable(n)
         {{endif}}
+
+    {{if name in {'Int8', 'Int16', 'Int32'} }}
+    cpdef _call_map_locations(self, values):
+        # self.mapping is of type Int64HashTable, so convert dtype of values
+        self.mapping.map_locations(algos.ensure_int64(values))
+    {{endif}}
 
     {{if name != 'Float64' and name != 'Object'}}
     cdef _check_type(self, object val):

--- a/pandas/_libs/index_class_helper.pxi.in
+++ b/pandas/_libs/index_class_helper.pxi.in
@@ -33,7 +33,7 @@ cdef class {{name}}Engine(IndexEngine):
     _dtype = '{{dtype}}'
 
     def _call_monotonic(self, values):
-        return algos.is_monotonic_{{dtype}}(values, timelike=False)
+        return algos.is_monotonic(values, timelike=False)
 
     def get_backfill_indexer(self, other, limit=None):
         return algos.backfill_{{dtype}}(self._get_index_values(),

--- a/pandas/_libs/index_class_helper.pxi.in
+++ b/pandas/_libs/index_class_helper.pxi.in
@@ -30,6 +30,8 @@ dtypes = [('Float64', 'float64', 'float64_t'),
 
 cdef class {{name}}Engine(IndexEngine):
 
+    _dtype = '{{dtype}}'
+
     def _call_monotonic(self, values):
         return algos.is_monotonic_{{dtype}}(values, timelike=False)
 
@@ -61,6 +63,14 @@ cdef class {{name}}Engine(IndexEngine):
     cpdef _call_map_locations(self, values):
         # self.mapping is of type Int64HashTable, so convert dtype of values
         self.mapping.map_locations(algos.ensure_int64(values))
+    {{elif name in {'UInt8', 'UInt16', 'UInt32'} }}
+    cpdef _call_map_locations(self, values):
+        # self.mapping is of type UInt64HashTable, so convert dtype of values
+        self.mapping.map_locations(algos.ensure_uint64(values))
+    {{elif name in {'Float32'} }}
+    cpdef _call_map_locations(self, values):
+        # self.mapping is of type Float64HashTable, so convert dtype of values
+        self.mapping.map_locations(algos.ensure_float64(values))
     {{endif}}
 
     {{if name != 'Float64' and name != 'Object'}}
@@ -83,7 +93,7 @@ cdef class {{name}}Engine(IndexEngine):
             ndarray[{{ctype}}] values
             int count = 0
 
-        {{if name != 'Float64'}}
+        {{if name not in {'Float64', 'Float32'} }}
         if not util.is_integer_object(val):
             raise KeyError(val)
         {{endif}}

--- a/pandas/_libs/index_class_helper.pxi.in
+++ b/pandas/_libs/index_class_helper.pxi.in
@@ -12,9 +12,13 @@ WARNING: DO NOT edit .pxi FILE directly, .pxi is generated from .pxi.in
 
 # name, dtype, ctype
 dtypes = [('Float64', 'float64', 'float64_t'),
-          ('UInt64', 'uint64', 'uint64_t'),
           ('Int64', 'int64', 'int64_t'),
-          ('Object', 'object', 'object')]
+          ('Int32', 'int32', 'int32_t'),
+          ('Int16', 'int16', 'int16_t'),
+          ('Int8', 'int8', 'int8_t'),
+          ('UInt64', 'uint64', 'uint64_t'),
+          ('Object', 'object', 'object'),
+          ]
 }}
 
 {{for name, dtype, ctype in dtypes}}

--- a/pandas/_libs/index_class_helper.pxi.in
+++ b/pandas/_libs/index_class_helper.pxi.in
@@ -40,6 +40,8 @@ cdef class {{name}}Engine(IndexEngine):
     cdef _make_hash_table(self, n):
         {{if name == 'Object'}}
         return _hash.PyObjectHashTable(n)
+        {{elif name in {'Int8', 'Int16', 'Int32'} }}
+        return _hash.Int64HashTable(n)
         {{else}}
         return _hash.{{name}}HashTable(n)
         {{endif}}

--- a/pandas/conftest.py
+++ b/pandas/conftest.py
@@ -102,14 +102,29 @@ def ip():
 
 
 @pytest.fixture(params=[True, False, None])
-def observed(request):
+def _true_false_none(request):
+    """
+    Base fixture for fixtures that return True, False and None.
+    """
+    return request.param
+
+
+@pytest.fixture
+def observed(_true_false_none):
     """ pass in the observed keyword to groupby for [True, False]
     This indicates whether categoricals should return values for
     values which are not in the grouper [False / None], or only values which
     appear in the grouper [True]. [None] is supported for future compatiblity
     if we decide to change the default (and would need to warn if this
     parameter is not passed)"""
-    return request.param
+    return _true_false_none
+
+
+@pytest.fixture
+def ordered(_true_false_none):
+    """Return the allowed parameters for Categorical/CategoricalIndex.ordered.
+    """
+    return _true_false_none
 
 
 _all_arithmetic_operators = ['__add__', '__radd__',

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -3085,6 +3085,10 @@ class Index(IndexOpsMixin, PandasObject):
         -------
         loc : int if unique index, slice if monotonic index, else mask
 
+        Raises
+        ------
+        KeyError : If key is not in self
+
         Examples
         ---------
         >>> unique_index = pd.Index(list('abc'))

--- a/pandas/core/indexes/category.py
+++ b/pandas/core/indexes/category.py
@@ -448,18 +448,12 @@ class CategoricalIndex(Index, accessor.PandasDelegate):
         >>> non_monotonic_index.get_loc('b')
         array([False,  True, False,  True], dtype=bool)
         """
-        codes = self.categories.get_loc(key)
-        if (codes == -1):
-            raise KeyError(key)
+        code = self.categories.get_loc(key)
 
-        if self.is_monotonic_increasing and not self.is_unique:
-            if codes not in self._engine:
-                raise KeyError(key)
-            codes = self.codes.dtype.type(codes)
-            lhs = self.codes.searchsorted(codes, side='left')
-            rhs = self.codes.searchsorted(codes, side='right')
-            return slice(lhs, rhs)
-        return self._engine.get_loc(codes)
+        # dtype must be same as dtype for self.codes else searchsorted is slow
+        code = self.codes.dtype.type(code)
+
+        return self._engine.get_loc(code)
 
     def get_value(self, series, key):
         """

--- a/pandas/core/indexes/category.py
+++ b/pandas/core/indexes/category.py
@@ -86,8 +86,10 @@ class CategoricalIndex(Index, accessor.PandasDelegate):
 
     @property
     def _engine_type(self):
-        type_name = self.codes.dtype.name.capitalize()
-        return getattr(libindex, "{}Engine".format(type_name))
+        # self.codes can have dtype int8, int16, int 32 or int64, so we need
+        # to return the corresponding engine type (libindex.Int8Engine, etc.).
+        engine_name = "{}Engine".format(self.codes.dtype.name.capitalize())
+        return getattr(libindex, engine_name)
     _attributes = ['name']
 
     def __new__(cls, data=None, categories=None, ordered=None, dtype=None,

--- a/pandas/core/indexes/category.py
+++ b/pandas/core/indexes/category.py
@@ -426,6 +426,10 @@ class CategoricalIndex(Index, accessor.PandasDelegate):
         -------
         loc : int if unique index, slice if monotonic index, else mask
 
+        Raises
+        ------
+        KeyError : If key is not in self
+
         Examples
         ---------
         >>> unique_index = pd.CategoricalIndex(list('abc'))
@@ -443,6 +447,14 @@ class CategoricalIndex(Index, accessor.PandasDelegate):
         codes = self.categories.get_loc(key)
         if (codes == -1):
             raise KeyError(key)
+
+        if self.is_monotonic_increasing and not self.is_unique:
+            if codes not in self._engine:
+                raise KeyError(key)
+            codes = self.codes.dtype.type(codes)
+            lhs = self.codes.searchsorted(codes, side='left')
+            rhs = self.codes.searchsorted(codes, side='right')
+            return slice(lhs, rhs)
         return self._engine.get_loc(codes)
 
     def get_value(self, series, key):

--- a/pandas/core/indexes/category.py
+++ b/pandas/core/indexes/category.py
@@ -83,7 +83,11 @@ class CategoricalIndex(Index, accessor.PandasDelegate):
     """
 
     _typ = 'categoricalindex'
-    _engine_type = libindex.Int64Engine
+
+    @property
+    def _engine_type(self):
+        type_name = self.codes.dtype.name.capitalize()
+        return getattr(libindex, "{}Engine".format(type_name))
     _attributes = ['name']
 
     def __new__(cls, data=None, categories=None, ordered=None, dtype=None,
@@ -377,7 +381,7 @@ class CategoricalIndex(Index, accessor.PandasDelegate):
     def _engine(self):
 
         # we are going to look things up with the codes themselves
-        return self._engine_type(lambda: self.codes.astype('i8'), len(self))
+        return self._engine_type(lambda: self.codes, len(self))
 
     # introspection
     @cache_readonly

--- a/pandas/tests/indexes/conftest.py
+++ b/pandas/tests/indexes/conftest.py
@@ -4,6 +4,7 @@ import pandas as pd
 
 import pandas.util.testing as tm
 from pandas.core.indexes.api import Index, MultiIndex
+from pandas._libs import index as li
 from pandas.compat import lzip, long
 
 
@@ -45,3 +46,15 @@ def zero(request):
     # For testing division by (or of) zero for Index with length 5, this
     # gives several scalar-zeros and length-5 vector-zeros
     return request.param
+
+
+@pytest.fixture(
+    params=[
+        'Int64', 'Int32', 'Int16', 'Int8',
+        'UInt64', 'UInt32', 'UInt16', 'UInt8',
+        'Float64', 'Float32',
+    ])
+def num_engine(request):
+    """Return the various numeric engines in pd._libs.index
+    """
+    return getattr(li, "{}Engine".format(request.param))

--- a/pandas/tests/indexes/conftest.py
+++ b/pandas/tests/indexes/conftest.py
@@ -54,7 +54,7 @@ def zero(request):
         'UInt64', 'UInt32', 'UInt16', 'UInt8',
         'Float64', 'Float32',
     ])
-def num_engine(request):
-    """Return the various numeric engines in pd._libs.index
+def numeric_indexing_engine(request):
+    """Return the various numeric indexing engines in pd._libs.index
     """
     return getattr(li, "{}Engine".format(request.param))

--- a/pandas/tests/indexes/test_category.py
+++ b/pandas/tests/indexes/test_category.py
@@ -14,6 +14,7 @@ import numpy as np
 from pandas import Categorical, IntervalIndex, compat
 from pandas.util.testing import assert_almost_equal
 import pandas.core.config as cf
+from pandas._libs import index as li
 import pandas as pd
 
 if PY3:
@@ -1117,3 +1118,27 @@ class TestCategoricalIndex(Base):
         msg = "the 'mode' parameter is not supported"
         tm.assert_raises_regex(ValueError, msg, idx.take,
                                indices, mode='clip')
+
+
+class TestCategoricalIndexEngine(object):
+
+    @pytest.mark.parametrize('nbits', [8, 16, 32, 64])
+    def test_engine_type(self, nbits):
+        """Check that a CategoricalIndex has the correct engine type.
+        """
+        if nbits < 64:
+            ncategories = int(2 ** (nbits / 2) / 2)  # 128 for nbits==16 etc
+            index = CategoricalIndex(range(ncategories))
+        else:
+            index = CategoricalIndex(['a', 'b', 'c'])
+            # having actual 2 ** (64 / 2) / 2 categories is too
+            # memory-intensive, so we set codes.dtype manually
+            index._values._codes = index._values._codes.astype('int64')
+
+        dtype = {8: np.int8, 16: np.int16,
+                 32: np.int32, 64: np.int64}[nbits]
+        engine = {8: li.Int8Engine, 16: li.Int16Engine,
+                  32: li.Int32Engine, 64: li.Int64Engine}[nbits]
+
+        assert isinstance(index._engine, engine)
+        assert issubclass(index.codes.dtype.type, dtype)

--- a/pandas/tests/indexes/test_category.py
+++ b/pandas/tests/indexes/test_category.py
@@ -14,7 +14,7 @@ import numpy as np
 from pandas import Categorical, IntervalIndex, compat
 from pandas.util.testing import assert_almost_equal
 import pandas.core.config as cf
-from pandas._libs import index as li
+from pandas._libs import index as libindex
 import pandas as pd
 
 if PY3:
@@ -1127,18 +1127,18 @@ class TestCategoricalIndexEngine(object):
         """Check that a CategoricalIndex has the correct engine type.
         """
         if nbits < 64:
-            ncategories = int(2 ** (nbits / 2) / 2)  # 128 for nbits==16 etc
+            ncategories = int(2 ** (nbits / 2) / 2 + 1)  # 129 if nbits==16 etc
             index = CategoricalIndex(range(ncategories))
         else:
             index = CategoricalIndex(['a', 'b', 'c'])
-            # having actual 2 ** (64 / 2) / 2 categories is too
+            # having actual 2 ** (64 / 2) / 2 + 1 categories is too
             # memory-intensive, so we set codes.dtype manually
             index._values._codes = index._values._codes.astype('int64')
 
         dtype = {8: np.int8, 16: np.int16,
                  32: np.int32, 64: np.int64}[nbits]
-        engine = {8: li.Int8Engine, 16: li.Int16Engine,
-                  32: li.Int32Engine, 64: li.Int64Engine}[nbits]
+        engine = {8: libindex.Int8Engine, 16: libindex.Int16Engine,
+                  32: libindex.Int32Engine, 64: libindex.Int64Engine}[nbits]
 
         assert isinstance(index._engine, engine)
         assert issubclass(index.codes.dtype.type, dtype)

--- a/pandas/tests/indexes/test_engine.py
+++ b/pandas/tests/indexes/test_engine.py
@@ -1,0 +1,94 @@
+# -*- coding: utf-8 -*-
+
+import numpy as np
+import pytest
+
+import pandas as pd
+from pandas._libs.index import (Int64Engine, UInt64Engine,
+                                Float64Engine, ObjectEngine)
+
+
+class TestNumericEngine(object):
+
+    @pytest.mark.parametrize('data', [[0, 1, 2]])
+    def test_engine_type(self, data, num_engine):
+        index = pd.Index(data, dtype=num_engine._dtype)
+        if issubclass(index.dtype.type, np.signedinteger):
+            assert isinstance(index._engine, Int64Engine)
+        elif issubclass(index.dtype.type, np.unsignedinteger):
+            assert isinstance(index._engine, UInt64Engine)
+        elif issubclass(index.dtype.type, np.floating):
+            assert isinstance(index._engine, Float64Engine)
+        else:
+            raise TypeError("unexpected dtype {}".format(index.dtype))
+
+    @pytest.mark.parametrize('data', [[0, 1, 2]])
+    def test_is_monotonic_ordered(self, data, num_engine):
+        codes = np.array(data, dtype=num_engine._dtype)
+        e = num_engine(lambda: codes, len(codes))
+        assert e.is_monotonic_increasing
+        assert not e.is_monotonic_decreasing
+
+        # reverse sort order
+        codes = np.array(list(reversed(data)), dtype=num_engine._dtype)
+        e = num_engine(lambda: codes, len(codes))
+        assert not e.is_monotonic_increasing
+        assert e.is_monotonic_decreasing
+
+    @pytest.mark.parametrize('data', [[1, 0, 2]])
+    def test_is_not_monotonic_ordered(self, data, num_engine):
+        codes = np.array(data, dtype=num_engine._dtype)
+        e = num_engine(lambda: codes, len(codes))
+        assert not e.is_monotonic_increasing
+        assert not e.is_monotonic_decreasing
+
+    @pytest.mark.parametrize('values, expected', [
+        ([1, 2, 3], True),
+        ([1, 1, 2], False),
+    ])
+    def test_is_unique(self, values, expected, num_engine):
+
+        codes = np.array(values, dtype=num_engine._dtype)
+        e = num_engine(lambda: codes, len(codes))
+        assert e.is_unique is expected
+
+
+class TestObjectEngine(object):
+
+    def setup_class(cls):
+        cls.Engine = ObjectEngine
+        cls.dtype = object
+
+    @pytest.mark.parametrize('data', [['a', 'b', 'c']])
+    def test_engine_type(self, data):
+        index = pd.Index(data)
+        assert isinstance(index._engine, self.Engine)
+
+    @pytest.mark.parametrize('data', [['a', 'b', 'c']])
+    def test_is_monotonic_ordered(self, data):
+        codes = np.array(data, dtype=self.dtype)
+        e = self.Engine(lambda: codes, len(codes))
+        assert e.is_monotonic_increasing
+        assert not e.is_monotonic_decreasing
+
+        # reverse sort order
+        codes = np.array(list(reversed(data)), dtype=self.dtype)
+        e = self.Engine(lambda: codes, len(codes))
+        assert not e.is_monotonic_increasing
+        assert e.is_monotonic_decreasing
+
+    @pytest.mark.parametrize('data', [['a', 'c', 'b']])
+    def test_is_not_monotonic_ordered(self, data):
+        codes = np.array(data, dtype=self.dtype)
+        e = self.Engine(lambda: codes, len(codes))
+        assert not e.is_monotonic_increasing
+        assert not e.is_monotonic_decreasing
+
+    @pytest.mark.parametrize('values, expected', [
+        (['a', 'b', 'c'], True),
+        (['a', 'a', 'b'], False),
+    ])
+    def test_is_unique(self, values, expected):
+        codes = np.array(values, dtype=self.dtype)
+        e = self.Engine(lambda: codes, len(codes))
+        assert e.is_unique is expected

--- a/pandas/tests/indexes/test_engine.py
+++ b/pandas/tests/indexes/test_engine.py
@@ -10,9 +10,11 @@ from pandas._libs.index import (Int64Engine, UInt64Engine,
 
 class TestNumericEngine(object):
 
-    @pytest.mark.parametrize('data', [[0, 1, 2]])
-    def test_engine_type(self, data, num_engine):
-        index = pd.Index(data, dtype=num_engine._dtype)
+    def setup_class(cls):
+        cls.data = [1, 2, 3]
+
+    def test_engine_type(self, numeric_indexing_engine):
+        index = pd.Index(self.data, dtype=numeric_indexing_engine._dtype)
         if issubclass(index.dtype.type, np.signedinteger):
             assert isinstance(index._engine, Int64Engine)
         elif issubclass(index.dtype.type, np.unsignedinteger):
@@ -22,23 +24,26 @@ class TestNumericEngine(object):
         else:
             raise TypeError("unexpected dtype {}".format(index.dtype))
 
-    @pytest.mark.parametrize('data', [[0, 1, 2]])
-    def test_is_monotonic_ordered(self, data, num_engine):
-        codes = np.array(data, dtype=num_engine._dtype)
-        e = num_engine(lambda: codes, len(codes))
+    def test_is_monotonic_ordered(self, numeric_indexing_engine):
+        codes = np.array(self.data, dtype=numeric_indexing_engine._dtype)
+        e = numeric_indexing_engine(lambda: codes, len(codes))
+
         assert e.is_monotonic_increasing
         assert not e.is_monotonic_decreasing
 
         # reverse sort order
-        codes = np.array(list(reversed(data)), dtype=num_engine._dtype)
-        e = num_engine(lambda: codes, len(codes))
+        reversed_data = list(reversed(self.data))
+        codes = np.array(reversed_data, dtype=numeric_indexing_engine._dtype)
+        e = numeric_indexing_engine(lambda: codes, len(codes))
+
         assert not e.is_monotonic_increasing
         assert e.is_monotonic_decreasing
 
-    @pytest.mark.parametrize('data', [[1, 0, 2]])
-    def test_is_not_monotonic_ordered(self, data, num_engine):
-        codes = np.array(data, dtype=num_engine._dtype)
-        e = num_engine(lambda: codes, len(codes))
+    def test_is_not_monotonic_ordered(self, numeric_indexing_engine):
+        data = [1, 0, 2]
+        codes = np.array(data, dtype=numeric_indexing_engine._dtype)
+        e = numeric_indexing_engine(lambda: codes, len(codes))
+
         assert not e.is_monotonic_increasing
         assert not e.is_monotonic_decreasing
 
@@ -46,10 +51,10 @@ class TestNumericEngine(object):
         ([1, 2, 3], True),
         ([1, 1, 2], False),
     ])
-    def test_is_unique(self, values, expected, num_engine):
+    def test_is_unique(self, values, expected, numeric_indexing_engine):
+        codes = np.array(values, dtype=numeric_indexing_engine._dtype)
+        e = numeric_indexing_engine(lambda: codes, len(codes))
 
-        codes = np.array(values, dtype=num_engine._dtype)
-        e = num_engine(lambda: codes, len(codes))
         assert e.is_unique is expected
 
     @pytest.mark.parametrize('values, value, expected', [
@@ -59,9 +64,9 @@ class TestNumericEngine(object):
         ([1, 2, 2, 1], 2, np.array([False, True, True, False])),
         ([1, 3, 2], 2, 2),
     ])
-    def test_get_loc(self, values, value, expected, num_engine):
-        codes = np.array(values, dtype=num_engine._dtype)
-        e = num_engine(lambda: codes, len(codes))
+    def test_get_loc(self, values, value, expected, numeric_indexing_engine):
+        codes = np.array(values, dtype=numeric_indexing_engine._dtype)
+        e = numeric_indexing_engine(lambda: codes, len(codes))
         result = e.get_loc(value)
 
         if isinstance(expected, np.ndarray):
@@ -73,9 +78,10 @@ class TestNumericEngine(object):
         ([1, 2, 3], 4, KeyError),
         ([1, 2, 3], '4', KeyError),
     ])
-    def test_get_loc_raises(self, values, value, error, num_engine):
-        codes = np.array(values, dtype=num_engine._dtype)
-        e = num_engine(lambda: codes, len(codes))
+    def test_get_loc_raises(self, values, value, error,
+                            numeric_indexing_engine):
+        codes = np.array(values, dtype=numeric_indexing_engine._dtype)
+        e = numeric_indexing_engine(lambda: codes, len(codes))
         with pytest.raises(error):
             e.get_loc(value)
 
@@ -83,41 +89,44 @@ class TestNumericEngine(object):
 class TestObjectEngine(object):
 
     def setup_class(cls):
+        cls.data = list('abc')
         cls.dtype = object
         cls.Engine = ObjectEngine
 
-    @pytest.mark.parametrize('data', [['a', 'b', 'c']])
-    def test_engine_type(self, data):
-        index = pd.Index(data)
+    def test_engine_type(self):
+        index = pd.Index(self.data)
         assert isinstance(index._engine, self.Engine)
 
-    @pytest.mark.parametrize('data', [['a', 'b', 'c']])
-    def test_is_monotonic_ordered(self, data):
-        codes = np.array(data, dtype=self.dtype)
+    def test_is_monotonic_ordered(self):
+        codes = np.array(self.data, dtype=self.dtype)
         e = self.Engine(lambda: codes, len(codes))
+
         assert e.is_monotonic_increasing
         assert not e.is_monotonic_decreasing
 
         # reverse sort order
-        codes = np.array(list(reversed(data)), dtype=self.dtype)
+        reversed_data = list(reversed(self.data))
+        codes = np.array(reversed_data, dtype=self.dtype)
         e = self.Engine(lambda: codes, len(codes))
+
         assert not e.is_monotonic_increasing
         assert e.is_monotonic_decreasing
 
-    @pytest.mark.parametrize('data', [['a', 'c', 'b']])
-    def test_is_not_monotonic_ordered(self, data):
-        codes = np.array(data, dtype=self.dtype)
+    def test_is_not_monotonic_ordered(self):
+        codes = np.array(list('cab'), dtype=self.dtype)
         e = self.Engine(lambda: codes, len(codes))
+
         assert not e.is_monotonic_increasing
         assert not e.is_monotonic_decreasing
 
     @pytest.mark.parametrize('values, expected', [
-        (['a', 'b', 'c'], True),
-        (['a', 'a', 'b'], False),
+        (list('abc'), True),
+        (list('aab'), False),
     ])
     def test_is_unique(self, values, expected):
         codes = np.array(values, dtype=self.dtype)
         e = self.Engine(lambda: codes, len(codes))
+
         assert e.is_unique is expected
 
     @pytest.mark.parametrize('values, value, expected', [

--- a/pandas/tests/indexes/test_engine.py
+++ b/pandas/tests/indexes/test_engine.py
@@ -6,8 +6,6 @@ import pytest
 import pandas as pd
 from pandas._libs.index import (Int64Engine, UInt64Engine,
                                 Float64Engine, ObjectEngine)
-from pandas._libs.lib import is_scalar
-import pandas.util.testing as tm
 
 
 class TestNumericEngine(object):
@@ -57,8 +55,8 @@ class TestNumericEngine(object):
     @pytest.mark.parametrize('values, value, expected', [
         ([1, 2, 3], 2, 1),
         ([1, 2, 2, 3], 2, slice(1, 3)),
-        ([3, 2, 2, 1], 2, np.array([False,  True,  True, False])),
-        ([1, 2, 2, 1], 2, np.array([False,  True,  True, False])),
+        ([3, 2, 2, 1], 2, np.array([False, True, True, False])),
+        ([1, 2, 2, 1], 2, np.array([False, True, True, False])),
         ([1, 3, 2], 2, 2),
     ])
     def test_get_loc(self, values, value, expected, num_engine):
@@ -125,8 +123,8 @@ class TestObjectEngine(object):
     @pytest.mark.parametrize('values, value, expected', [
         (list('abc'), 'b', 1),
         (list('abbc'), 'b', slice(1, 3)),
-        (list('cbba'), 'b', np.array([False,  True,  True, False])),
-        (list('abba'), 'b', np.array([False,  True,  True, False])),
+        (list('cbba'), 'b', np.array([False, True, True, False])),
+        (list('abba'), 'b', np.array([False, True, True, False])),
         (list('acb'), 'b', 2),
     ])
     def test_get_loc(self, values, value, expected):

--- a/pandas/tests/indexes/test_engine.py
+++ b/pandas/tests/indexes/test_engine.py
@@ -6,6 +6,8 @@ import pytest
 import pandas as pd
 from pandas._libs.index import (Int64Engine, UInt64Engine,
                                 Float64Engine, ObjectEngine)
+from pandas._libs.lib import is_scalar
+import pandas.util.testing as tm
 
 
 class TestNumericEngine(object):
@@ -52,12 +54,39 @@ class TestNumericEngine(object):
         e = num_engine(lambda: codes, len(codes))
         assert e.is_unique is expected
 
+    @pytest.mark.parametrize('values, value, expected', [
+        ([1, 2, 3], 2, 1),
+        ([1, 2, 2, 3], 2, slice(1, 3)),
+        ([3, 2, 2, 1], 2, np.array([False,  True,  True, False])),
+        ([1, 2, 2, 1], 2, np.array([False,  True,  True, False])),
+        ([1, 3, 2], 2, 2),
+    ])
+    def test_get_loc(self, values, value, expected, num_engine):
+        codes = np.array(values, dtype=num_engine._dtype)
+        e = num_engine(lambda: codes, len(codes))
+        result = e.get_loc(value)
+
+        if isinstance(expected, np.ndarray):
+            assert (result == expected).all()
+        else:
+            assert result == expected
+
+    @pytest.mark.parametrize('values, value, error', [
+        ([1, 2, 3], 4, KeyError),
+        ([1, 2, 3], '4', KeyError),
+    ])
+    def test_get_loc_raises(self, values, value, error, num_engine):
+        codes = np.array(values, dtype=num_engine._dtype)
+        e = num_engine(lambda: codes, len(codes))
+        with pytest.raises(error):
+            e.get_loc(value)
+
 
 class TestObjectEngine(object):
 
     def setup_class(cls):
-        cls.Engine = ObjectEngine
         cls.dtype = object
+        cls.Engine = ObjectEngine
 
     @pytest.mark.parametrize('data', [['a', 'b', 'c']])
     def test_engine_type(self, data):
@@ -92,3 +121,30 @@ class TestObjectEngine(object):
         codes = np.array(values, dtype=self.dtype)
         e = self.Engine(lambda: codes, len(codes))
         assert e.is_unique is expected
+
+    @pytest.mark.parametrize('values, value, expected', [
+        (list('abc'), 'b', 1),
+        (list('abbc'), 'b', slice(1, 3)),
+        (list('cbba'), 'b', np.array([False,  True,  True, False])),
+        (list('abba'), 'b', np.array([False,  True,  True, False])),
+        (list('acb'), 'b', 2),
+    ])
+    def test_get_loc(self, values, value, expected):
+        codes = np.array(values, dtype=self.dtype)
+        e = self.Engine(lambda: codes, len(codes))
+        result = e.get_loc(value)
+
+        if isinstance(expected, np.ndarray):
+            assert (result == expected).all()
+        else:
+            assert result == expected
+
+    @pytest.mark.parametrize('values, value, error', [
+        (list('abc'), 'd', KeyError),
+        (list('abc'), 4, KeyError),
+    ])
+    def test_get_loc_raises(self, values, value, error):
+        codes = np.array(values, dtype=self.dtype)
+        e = self.Engine(lambda: codes, len(codes))
+        with pytest.raises(error):
+            e.get_loc(value)


### PR DESCRIPTION
- [x] closes #20395
- [ ] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

This is the the final puzzle for #20395.

The problem with the current implementation is that ``CategoricalIndex._engine`` constantly recodes int8 arrays to int64 arrays:

https://github.com/pandas-dev/pandas/blob/dc45fbafef172e357cb5decdeab22de67160f5b7/pandas/core/indexes/category.py#L365-L369

Notice the ``lambda: self.codes.astype('i8')`` part, which means that every time ``_engine.vgetter`` is called, an int64-array is created. This is very expensive and we would ideally want to just use the original array dtype (int8, int16 or whatever) always and avoid this conversion.

A complicating issue is that it is *not* enough to just avoid the int64 transformation, as ``array.searchsorted`` apparantly needs a dtype-compatible input or else it is *also* very slow:

```python
>>> n = 1_000_000
>>> ci = pd.CategoricalIndex(list('a' * n + 'b' * n + 'c' * n))
>>> %timeit ci.codes.searchsorted(1)  # search for left location of 'b'
7.38 ms   # slow
>>> code = np.int8(1)
>>> %timeit ci.codes.searchsorted(code)
2.57 µs  # fast
```

### Solution options

As CategoricalIndex.codes may be int8, int16, etc, the solution must be to (1) have an indexing engine for each integer dtype or an indexing engine that accepts all int types, not just int64 *and* (2) that the key must be translated into the same dtype as the codes array before calling searchsorted. So either:
1. Change Int64Engine to be a IntEngine (i.e. accept all integer dtypes)
2. Make new IntEngine classes, with the appropriate flexibility for accepting all integer dtypes, but defers to Int64 version if/when needed (e.g. if codes is int8, but we only have ``algos.is_monotonic_int64`` for checking monotonicity)
3. Do everything in Python.

I assume option 1 is not desired, and option 3 assumedly likewise. In the updated PR I've made a proposal in Cython, that attains the needed speed.

Benchmarks from ``asv_bench/indexing.py``

```
      before           after         ratio
     [dc45fbaf]       [bc03b8bd]
-     1.54±0.02ms         9.80±0μs     0.01  indexing.CategoricalIndexIndexing.time_get_loc_scalar('monotonic_incr')

SOME BENCHMARKS HAVE CHANGED SIGNIFICANTLY.
```
