### PR TITLE
DOC: move whatsnew on performance from 0.23.2 to 0.24.0

### DIFF
--- a/doc/source/whatsnew/v0.23.2.txt
+++ b/doc/source/whatsnew/v0.23.2.txt
@@ -59,19 +59,6 @@ Fixed Regressions
 - Bug in :meth:`Timestamp.ceil` and :meth:`Timestamp.floor` when timestamp is a multiple of the rounding frequency (:issue:`21262`)
 - Fixed regression in :func:`to_clipboard` that defaulted to copying dataframes with space delimited instead of tab delimited (:issue:`21104`)
 
-.. _whatsnew_0232.performance:
-
-Performance Improvements
-~~~~~~~~~~~~~~~~~~~~~~~~
-
-- Improved performance of membership checks in :class:`Categorical` and :class:`CategoricalIndex`
-  (i.e. ``x in cat``-style checks are much faster). :meth:`CategoricalIndex.contains`
-  is likewise much faster (:issue:`21369`, :issue:`21508`)
-- Improved performance of :meth:`HDFStore.groups` (and dependent functions like
-  :meth:`~HDFStore.keys`.  (i.e. ``x in store`` checks are much faster)
-  (:issue:`21372`)
-- Improved performance of :meth:`MultiIndex.is_unique` (:issue:`21522`)
--
 
 Documentation Changes
 ~~~~~~~~~~~~~~~~~~~~~

--- a/doc/source/whatsnew/v0.24.0.txt
+++ b/doc/source/whatsnew/v0.24.0.txt
@@ -201,6 +201,12 @@ Performance Improvements
 - Improved performance of :func:`Series.describe` in case of numeric dtpyes (:issue:`21274`)
 - Improved performance of :func:`pandas.core.groupby.GroupBy.rank` when dealing with tied rankings (:issue:`21237`)
 - Improved performance of :func:`DataFrame.set_index` with columns consisting of :class:`Period` objects (:issue:`21582`,:issue:`21606`)
+- Improved performance of membership checks in :class:`Categorical` and :class:`CategoricalIndex`
+  (i.e. ``x in cat``-style checks are much faster). :meth:`CategoricalIndex.contains`
+  is likewise much faster (:issue:`21369`, :issue:`21508`)
+- Improved performance of :meth:`HDFStore.groups` (and dependent functions like
+  :meth:`~HDFStore.keys`.  (i.e. ``x in store`` checks are much faster)
+  (:issue:`21372`)
 -
 
 .. _whatsnew_0240.docs:


### PR DESCRIPTION
I did not backport the performance improvements in my backporting PRs for now, so this moves that section to 0.24.0.txt. 
(my rationale: let's be conservative for bug fix releases, performance improvements (if they are not fixing severe performance regressions) are not strictly needed in a bug fix release).

