### PR TITLE
Move Unchanged arith methods to EA mixins

### DIFF
--- a/pandas/core/arrays/datetimelike.py
+++ b/pandas/core/arrays/datetimelike.py
@@ -167,3 +167,15 @@ class DatetimeLikeArrayMixin(object):
             mask = (self._isnan) | (other._isnan)
             new_values[mask] = iNaT
         return new_values.view('i8')
+
+    def _sub_nat(self):
+        """Subtract pd.NaT from self"""
+        # GH#19124 Timedelta - datetime is not in general well-defined.
+        # We make an exception for pd.NaT, which in this case quacks
+        # like a timedelta.
+        # For datetime64 dtypes by convention we treat NaT as a datetime, so
+        # this subtraction returns a timedelta64 dtype.
+        # For period dtype, timedelta64 is a close-enough return dtype.
+        result = np.zeros(len(self), dtype=np.int64)
+        result.fill(iNaT)
+        return result.view('timedelta64[ns]')

--- a/pandas/core/arrays/period.py
+++ b/pandas/core/arrays/period.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+from pandas._libs.tslib import NaT
 from pandas._libs.tslibs.period import Period
 
 from pandas.util._decorators import cache_readonly
@@ -26,3 +27,10 @@ class PeriodArrayMixin(DatetimeLikeArrayMixin):
     @property
     def asi8(self):
         return self._ndarray_values.view('i8')
+
+    # ------------------------------------------------------------------
+    # Arithmetic Methods
+
+    def _sub_datelike(self, other):
+        assert other is not NaT
+        return NotImplemented

--- a/pandas/core/arrays/timedelta.py
+++ b/pandas/core/arrays/timedelta.py
@@ -1,8 +1,10 @@
 # -*- coding: utf-8 -*-
 
-from pandas._libs.tslib import Timedelta
+from pandas._libs.tslib import Timedelta, NaT
 
 from pandas.core.dtypes.common import _TD_DTYPE
+
+from pandas.tseries.offsets import Tick
 
 from .datetimelike import DatetimeLikeArrayMixin
 
@@ -15,3 +17,17 @@ class TimedeltaArrayMixin(DatetimeLikeArrayMixin):
     @property
     def dtype(self):
         return _TD_DTYPE
+
+    # ----------------------------------------------------------------
+    # Arithmetic Methods
+
+    def _add_offset(self, other):
+        assert not isinstance(other, Tick)
+        raise TypeError("cannot add the type {typ} to a {cls}"
+                        .format(typ=type(other).__name__,
+                                cls=type(self).__name__))
+
+    def _sub_datelike(self, other):
+        assert other is not NaT
+        raise TypeError("cannot subtract a datelike from a {cls}"
+                        .format(cls=type(self).__name__))

--- a/pandas/core/indexes/datetimelike.py
+++ b/pandas/core/indexes/datetimelike.py
@@ -696,17 +696,6 @@ class DatetimeIndexOpsMixin(DatetimeLikeArrayMixin):
         # and datetime dtypes
         return self._nat_new(box=True)
 
-    def _sub_nat(self):
-        """Subtract pd.NaT from self"""
-        # GH#19124 Timedelta - datetime is not in general well-defined.
-        # We make an exception for pd.NaT, which in this case quacks
-        # like a timedelta.
-        # For datetime64 dtypes by convention we treat NaT as a datetime, so
-        # this subtraction returns a timedelta64 dtype.
-        # For period dtype, timedelta64 is a close-enough return dtype.
-        result = self._nat_new(box=False)
-        return result.view('timedelta64[ns]')
-
     def _sub_period_array(self, other):
         """
         Subtract one PeriodIndex from another.  This is only valid if they

--- a/pandas/core/indexes/datetimelike.py
+++ b/pandas/core/indexes/datetimelike.py
@@ -707,9 +707,6 @@ class DatetimeIndexOpsMixin(DatetimeLikeArrayMixin):
         result = self._nat_new(box=False)
         return result.view('timedelta64[ns]')
 
-    def _sub_period(self, other):
-        return NotImplemented
-
     def _sub_period_array(self, other):
         """
         Subtract one PeriodIndex from another.  This is only valid if they
@@ -744,9 +741,6 @@ class DatetimeIndexOpsMixin(DatetimeLikeArrayMixin):
             mask = (self._isnan) | (other._isnan)
             new_values[mask] = NaT
         return new_values
-
-    def _add_offset(self, offset):
-        raise com.AbstractMethodError(self)
 
     def _addsub_offset_array(self, other, op):
         """

--- a/pandas/core/indexes/period.py
+++ b/pandas/core/indexes/period.py
@@ -763,6 +763,7 @@ class PeriodIndex(PeriodArrayMixin, DatelikeOps, DatetimeIndexOpsMixin,
         if self.hasnans:
             new_data[self._isnan] = tslib.NaT
 
+        # TODO: Should name=self.name be passed here?
         return Index(new_data)
 
     def shift(self, n):

--- a/pandas/core/indexes/period.py
+++ b/pandas/core/indexes/period.py
@@ -745,10 +745,6 @@ class PeriodIndex(PeriodArrayMixin, DatelikeOps, DatetimeIndexOpsMixin,
         ordinal_delta = self._maybe_convert_timedelta(other)
         return self.shift(ordinal_delta)
 
-    def _sub_datelike(self, other):
-        assert other is not tslib.NaT
-        return NotImplemented
-
     def _sub_period(self, other):
         # If the operation is well-defined, we return an object-Index
         # of DateOffsets.  Null entries are filled with pd.NaT

--- a/pandas/core/indexes/timedeltas.py
+++ b/pandas/core/indexes/timedeltas.py
@@ -349,12 +349,6 @@ class TimedeltaIndex(TimedeltaArrayMixin, DatetimeIndexOpsMixin,
             attrs['freq'] = 'infer'
         return attrs
 
-    def _add_offset(self, other):
-        assert not isinstance(other, Tick)
-        raise TypeError("cannot add the type {typ} to a {cls}"
-                        .format(typ=type(other).__name__,
-                                cls=type(self).__name__))
-
     def _add_delta(self, delta):
         """
         Add a timedelta-like, Tick, or TimedeltaIndex-like object
@@ -429,11 +423,6 @@ class TimedeltaIndex(TimedeltaArrayMixin, DatetimeIndexOpsMixin,
                                           arr_mask=self._isnan)
             result = self._maybe_mask_results(result, fill_value=iNaT)
             return DatetimeIndex(result)
-
-    def _sub_datelike(self, other):
-        assert other is not NaT
-        raise TypeError("cannot subtract a datelike from a {cls}"
-                        .format(cls=type(self).__name__))
 
     def _addsub_offset_array(self, other, op):
         # Add or subtract Array-like of DateOffset objects


### PR DESCRIPTION
Next steps after #19902.  Breaking these up into smaller pieces than usual because I don't know what bits will prove controversial.

All this PR does is take a few of the easiest no-changes-needed methods and moved them to the EA mixins.
