### PR TITLE
move ndarray-returning functions to EA mixin classes

### DIFF
--- a/pandas/core/arrays/datetimelike.py
+++ b/pandas/core/arrays/datetimelike.py
@@ -185,12 +185,13 @@ class DatetimeLikeArrayMixin(object):
 
     def _sub_period_array(self, other):
         """
-        Subtract one PeriodIndex from another.  This is only valid if they
+        Subtract a Period Array/Index from self.  This is only valid if self
+        is itself a Period Array/Index, raises otherwise.  Both objects must
         have the same frequency.
 
         Parameters
         ----------
-        other : PeriodIndex
+        other : PeriodIndex or PeriodArray
 
         Returns
         -------
@@ -203,7 +204,8 @@ class DatetimeLikeArrayMixin(object):
                                     cls=type(self).__name__))
 
         if not len(self) == len(other):
-            raise ValueError("cannot subtract indices of unequal length")
+            raise ValueError("cannot subtract arrays/indices of "
+                             "unequal length")
         if self.freq != other.freq:
             msg = DIFFERENT_FREQ_INDEX.format(self.freqstr, other.freqstr)
             raise IncompatibleFrequency(msg)

--- a/pandas/core/arrays/datetimes.py
+++ b/pandas/core/arrays/datetimes.py
@@ -3,6 +3,7 @@ import warnings
 
 import numpy as np
 
+from pandas._libs import tslib
 from pandas._libs.tslib import Timestamp, NaT, iNaT
 from pandas._libs.tslibs import timezones
 
@@ -108,3 +109,17 @@ class DatetimeArrayMixin(DatetimeLikeArrayMixin):
             mask = (self._isnan) | (other._isnan)
             new_values[mask] = iNaT
         return new_values.view('timedelta64[ns]')
+
+    # ----------------------------------------------------------------
+    # Conversion Methods - Vectorized analogues of Timedelta methods
+
+    def to_pydatetime(self):
+        """
+        Return Datetime Array/Index as object ndarray of datetime.datetime
+        objects
+
+        Returns
+        -------
+        datetimes : ndarray
+        """
+        return tslib.ints_to_pydatetime(self.asi8, tz=self.tz)

--- a/pandas/core/arrays/period.py
+++ b/pandas/core/arrays/period.py
@@ -1,11 +1,21 @@
 # -*- coding: utf-8 -*-
+from datetime import timedelta
+import warnings
 
+import numpy as np
+
+from pandas._libs import lib
 from pandas._libs.tslib import NaT
-from pandas._libs.tslibs.period import Period
+from pandas._libs.tslibs.period import (
+    Period, IncompatibleFrequency, DIFFERENT_FREQ_INDEX)
+from pandas._libs.tslibs.timedeltas import delta_to_nanoseconds
 
 from pandas.util._decorators import cache_readonly
 
 from pandas.core.dtypes.dtypes import PeriodDtype
+
+from pandas.tseries import frequencies
+from pandas.tseries.offsets import Tick, DateOffset
 
 from .datetimelike import DatetimeLikeArrayMixin
 
@@ -28,9 +38,52 @@ class PeriodArrayMixin(DatetimeLikeArrayMixin):
     def asi8(self):
         return self._ndarray_values.view('i8')
 
+    @property
+    def freq(self):
+        """Return the frequency object if it is set, otherwise None"""
+        return self._freq
+
+    @freq.setter
+    def freq(self, value):
+        msg = ('Setting PeriodIndex.freq has been deprecated and will be '
+               'removed in a future version; use PeriodIndex.asfreq instead. '
+               'The PeriodIndex.freq setter is not guaranteed to work.')
+        warnings.warn(msg, FutureWarning, stacklevel=2)
+        self._freq = value
+
     # ------------------------------------------------------------------
     # Arithmetic Methods
 
     def _sub_datelike(self, other):
         assert other is not NaT
         return NotImplemented
+
+    def _maybe_convert_timedelta(self, other):
+        if isinstance(
+                other, (timedelta, np.timedelta64, Tick, np.ndarray)):
+            offset = frequencies.to_offset(self.freq.rule_code)
+            if isinstance(offset, Tick):
+                if isinstance(other, np.ndarray):
+                    nanos = np.vectorize(delta_to_nanoseconds)(other)
+                else:
+                    nanos = delta_to_nanoseconds(other)
+                offset_nanos = delta_to_nanoseconds(offset)
+                check = np.all(nanos % offset_nanos == 0)
+                if check:
+                    return nanos // offset_nanos
+        elif isinstance(other, DateOffset):
+            freqstr = other.rule_code
+            base = frequencies.get_base_alias(freqstr)
+            if base == self.freq.rule_code:
+                return other.n
+            msg = DIFFERENT_FREQ_INDEX.format(self.freqstr, other.freqstr)
+            raise IncompatibleFrequency(msg)
+        elif lib.is_integer(other):
+            # integer is passed to .shift via
+            # _add_datetimelike_methods basically
+            # but ufunc may pass integer to _add_delta
+            return other
+
+        # raise when input doesn't have freq
+        msg = "Input has different freq from PeriodIndex(freq={0})"
+        raise IncompatibleFrequency(msg.format(self.freqstr))

--- a/pandas/core/arrays/period.py
+++ b/pandas/core/arrays/period.py
@@ -60,6 +60,22 @@ class PeriodArrayMixin(DatetimeLikeArrayMixin):
         return NotImplemented
 
     def _maybe_convert_timedelta(self, other):
+        """
+        Convert timedelta-like input to an integer multiple of self.freq
+
+        Parameters
+        ----------
+        other : timedelta, np.timedelta64, DateOffset, int, np.ndarray
+
+        Returns
+        -------
+        converted : int, np.ndarray[int64]
+
+        Raises
+        ------
+        IncompatibleFrequency : if the input cannot be written as a multiple
+            of self.freq.  Note IncompatibleFrequency subclasses ValueError.
+        """
         if isinstance(
                 other, (timedelta, np.timedelta64, Tick, np.ndarray)):
             offset = frequencies.to_offset(self.freq.rule_code)

--- a/pandas/core/arrays/period.py
+++ b/pandas/core/arrays/period.py
@@ -45,10 +45,11 @@ class PeriodArrayMixin(DatetimeLikeArrayMixin):
 
     @freq.setter
     def freq(self, value):
-        msg = ('Setting PeriodIndex.freq has been deprecated and will be '
+        msg = ('Setting {cls}.freq has been deprecated and will be '
                'removed in a future version; use PeriodIndex.asfreq instead. '
-               'The PeriodIndex.freq setter is not guaranteed to work.')
-        warnings.warn(msg, FutureWarning, stacklevel=2)
+               'The {cls}.freq setter is not guaranteed to work.')
+        warnings.warn(msg.format(cls=type(self).__name__,
+                      FutureWarning, stacklevel=2)
         self._freq = value
 
     # ------------------------------------------------------------------
@@ -85,5 +86,6 @@ class PeriodArrayMixin(DatetimeLikeArrayMixin):
             return other
 
         # raise when input doesn't have freq
-        msg = "Input has different freq from PeriodIndex(freq={0})"
-        raise IncompatibleFrequency(msg.format(self.freqstr))
+        msg = "Input has different freq from {cls}(freq={freqstr})"
+        raise IncompatibleFrequency(msg.format(cls=type(self).__name__,
+                                               freqstr=self.freqstr))

--- a/pandas/core/arrays/period.py
+++ b/pandas/core/arrays/period.py
@@ -48,7 +48,7 @@ class PeriodArrayMixin(DatetimeLikeArrayMixin):
         msg = ('Setting {cls}.freq has been deprecated and will be '
                'removed in a future version; use PeriodIndex.asfreq instead. '
                'The {cls}.freq setter is not guaranteed to work.')
-        warnings.warn(msg.format(cls=type(self).__name__,
+        warnings.warn(msg.format(cls=type(self).__name__),
                       FutureWarning, stacklevel=2)
         self._freq = value
 

--- a/pandas/core/arrays/timedelta.py
+++ b/pandas/core/arrays/timedelta.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+from pandas._libs import tslib
 from pandas._libs.tslib import Timedelta, NaT
 
 from pandas.core.dtypes.common import _TD_DTYPE
@@ -31,3 +32,17 @@ class TimedeltaArrayMixin(DatetimeLikeArrayMixin):
         assert other is not NaT
         raise TypeError("cannot subtract a datelike from a {cls}"
                         .format(cls=type(self).__name__))
+
+    # ----------------------------------------------------------------
+    # Conversion Methods - Vectorized analogues of Timedelta methods
+
+    def to_pytimedelta(self):
+        """
+        Return Timedelta Array/Index as object ndarray of datetime.timedelta
+        objects
+
+        Returns
+        -------
+        datetimes : ndarray
+        """
+        return tslib.ints_to_pytimedelta(self.asi8)

--- a/pandas/core/indexes/datetimelike.py
+++ b/pandas/core/indexes/datetimelike.py
@@ -13,8 +13,7 @@ from pandas.core.tools.timedeltas import to_timedelta
 import numpy as np
 
 from pandas._libs import lib, iNaT, NaT, Timedelta
-from pandas._libs.tslibs.period import (Period, IncompatibleFrequency,
-                                        DIFFERENT_FREQ_INDEX)
+from pandas._libs.tslibs.period import Period
 from pandas._libs.tslibs.timestamps import round_ns
 
 from pandas.core.dtypes.common import (
@@ -695,41 +694,6 @@ class DatetimeIndexOpsMixin(DatetimeLikeArrayMixin):
         # GH#19124 pd.NaT is treated like a timedelta for both timedelta
         # and datetime dtypes
         return self._nat_new(box=True)
-
-    def _sub_period_array(self, other):
-        """
-        Subtract one PeriodIndex from another.  This is only valid if they
-        have the same frequency.
-
-        Parameters
-        ----------
-        other : PeriodIndex
-
-        Returns
-        -------
-        result : np.ndarray[object]
-            Array of DateOffset objects; nulls represented by NaT
-        """
-        if not is_period_dtype(self):
-            raise TypeError("cannot subtract {dtype}-dtype to {cls}"
-                            .format(dtype=other.dtype,
-                                    cls=type(self).__name__))
-
-        if not len(self) == len(other):
-            raise ValueError("cannot subtract indices of unequal length")
-        if self.freq != other.freq:
-            msg = DIFFERENT_FREQ_INDEX.format(self.freqstr, other.freqstr)
-            raise IncompatibleFrequency(msg)
-
-        new_values = checked_add_with_arr(self.asi8, -other.asi8,
-                                          arr_mask=self._isnan,
-                                          b_mask=other._isnan)
-
-        new_values = np.array([self.freq * x for x in new_values])
-        if self.hasnans or other.hasnans:
-            mask = (self._isnan) | (other._isnan)
-            new_values[mask] = NaT
-        return new_values
 
     def _addsub_offset_array(self, other, op):
         """

--- a/pandas/core/indexes/datetimes.py
+++ b/pandas/core/indexes/datetimes.py
@@ -987,16 +987,6 @@ class DatetimeIndex(DatetimeArrayMixin, DatelikeOps, TimelikeOps,
 
         return self.values.copy()
 
-    def to_pydatetime(self):
-        """
-        Return DatetimeIndex as object ndarray of datetime.datetime objects
-
-        Returns
-        -------
-        datetimes : ndarray
-        """
-        return libts.ints_to_pydatetime(self.asi8, tz=self.tz)
-
     def to_period(self, freq=None):
         """
         Cast to PeriodIndex at a particular frequency.

--- a/pandas/core/indexes/timedeltas.py
+++ b/pandas/core/indexes/timedeltas.py
@@ -34,7 +34,7 @@ from pandas.core.indexes.datetimelike import (
 from pandas.core.tools.timedeltas import (
     to_timedelta, _coerce_scalar_to_timedelta_type)
 from pandas.tseries.offsets import Tick, DateOffset
-from pandas._libs import (lib, index as libindex, tslib as libts,
+from pandas._libs import (lib, index as libindex,
                           join as libjoin, Timedelta, NaT, iNaT)
 from pandas._libs.tslibs.timedeltas import array_to_timedelta64
 from pandas._libs.tslibs.fields import get_timedelta_field
@@ -540,16 +540,6 @@ class TimedeltaIndex(TimedeltaArrayMixin, DatetimeIndexOpsMixin,
         """
         return Index(self._maybe_mask_results(1e-9 * self.asi8),
                      name=self.name)
-
-    def to_pytimedelta(self):
-        """
-        Return TimedeltaIndex as object ndarray of datetime.timedelta objects
-
-        Returns
-        -------
-        datetimes : ndarray
-        """
-        return libts.ints_to_pytimedelta(self.asi8)
 
     @Appender(_index_shared_docs['astype'])
     def astype(self, dtype, copy=True):


### PR DESCRIPTION
Orthogonal to other EAMixin PRs.

The methods this moves are unchanged.  Docstrings changed e.g. "DatetimeIndex" to "Datetime Array/Index".  I'm open to suggestions for better wording.

The error message in `PeriodArrayMixin._maybe_convert_timedelta` is changed to use `type(self).__name__` instead of hardcoding `PeriodIndex`.  Ditto the warning issued by `PeriodArrayMixin.freq.setter`.