### PR TITLE
Implement _tz_convert_tzlocal_utc for de-duplication

### DIFF
--- a/pandas/_libs/tslibs/conversion.pyx
+++ b/pandas/_libs/tslibs/conversion.pyx
@@ -791,7 +791,7 @@ def tz_convert(ndarray[int64_t] vals, object tz1, object tz2):
         return result
 
     # if all NaT, return all NaT
-    tt = utc_dates[utc_dates!=NPY_NAT]
+    tt = utc_dates[utc_dates != NPY_NAT]
     if not len(tt):
         return utc_dates
 


### PR DESCRIPTION
There is a bunch of code in conversion (and a bit in resolution, period, and tslib) that can be de-duplicated.  This is one part of ~5 steps in that process.