### PR TITLE
misplaced scatter/hexbin subplot colorbars

### DIFF
--- a/doc/source/whatsnew/v0.24.0.txt
+++ b/doc/source/whatsnew/v0.24.0.txt
@@ -336,8 +336,7 @@ I/O
 Plotting
 ^^^^^^^^
 
-- Bug in :func:'DataFrame.plot.scatter' and :func:'DataFrame.plot.hexbin' caused x-axis label and ticklabels to disappear when colorbar was on in IPython inline backend (:issue:`10611` and :issue:`10678`)
-- Bug in :func:'DataFrame.plot.scatter' and :func:'DataFrame.plot.hexbin' resulted in misplaced colorbars when subplot was used (related to :issue:`20455`)
+- Bug in :func:'DataFrame.plot.scatter' and :func:'DataFrame.plot.hexbin' caused x-axis label and ticklabels to disappear when colorbar was on in IPython inline backend (:issue:`10611`, :issue:`10678`, and :issue:`20455`)
 -
 
 Groupby/Resample/Rolling

--- a/doc/source/whatsnew/v0.24.0.txt
+++ b/doc/source/whatsnew/v0.24.0.txt
@@ -337,7 +337,7 @@ Plotting
 ^^^^^^^^
 
 - Bug in :func:'DataFrame.plot.scatter' and :func:'DataFrame.plot.hexbin' caused x-axis label and ticklabels to disappear when colorbar was on in IPython inline backend (:issue:`10611` and :issue:`10678`)
--
+- Bug in :func:'DataFrame.plot.scatter' and :func:'DataFrame.plot.hexbin' resulted in misplaced colorbars when subplot was used (related to :issue:`20455`)
 -
 
 Groupby/Resample/Rolling

--- a/pandas/plotting/_core.py
+++ b/pandas/plotting/_core.py
@@ -847,7 +847,7 @@ class PlanePlot(MPLPlot):
         # https://github.com/ipython/ipython/issues/11215
 
         img = ax.collections[0]
-        cbar = self.fig.colorbar(img, **kwds)
+        cbar = self.fig.colorbar(img, ax=ax, **kwds)
         points = ax.get_position().get_points()
         cbar_points = cbar.ax.get_position().get_points()
         cbar.ax.set_position([cbar_points[0, 0],

--- a/pandas/tests/plotting/test_frame.py
+++ b/pandas/tests/plotting/test_frame.py
@@ -1133,7 +1133,7 @@ class TestDataFramePlots(TestPlotBase):
         assert ax.xaxis.get_label().get_visible()
 
     @pytest.mark.slow
-    def test_if_scatterplot_colorbars_are_next_to_parent_axes():
+    def test_if_scatterplot_colorbars_are_next_to_parent_axes(self):
         import matplotlib.pyplot as plt
         random_array = np.random.random((1000, 3))
         df = pd.DataFrame(random_array,
@@ -1144,11 +1144,13 @@ class TestDataFramePlots(TestPlotBase):
         df.plot.scatter('A label', 'B label', c='C label', ax=axes[1])
         plt.tight_layout()
 
-        points = np.array([ax.get_position().get_points() for ax in fig.axes])
+        points = np.array([ax.get_position().get_points()
+                           for ax in fig.axes])
         axes_x_coords = points[:, :, 0]
         parent_distance = axes_x_coords[1, :] - axes_x_coords[0, :]
         colorbar_distance = axes_x_coords[3, :] - axes_x_coords[2, :]
-        assert np.isclose(parent_distance, colorbar_distance).all()
+        np.testing.assert_almost_equal(
+            parent_distance, colorbar_distance, decimal=7)
 
     @pytest.mark.slow
     def test_plot_scatter_with_categorical_data(self):

--- a/pandas/tests/plotting/test_frame.py
+++ b/pandas/tests/plotting/test_frame.py
@@ -1149,8 +1149,8 @@ class TestDataFramePlots(TestPlotBase):
         axes_x_coords = points[:, :, 0]
         parent_distance = axes_x_coords[1, :] - axes_x_coords[0, :]
         colorbar_distance = axes_x_coords[3, :] - axes_x_coords[2, :]
-        np.testing.assert_almost_equal(
-            parent_distance, colorbar_distance, decimal=7)
+        assert np.isclose(parent_distance,
+                          colorbar_distance, atol=1e-7).all()
 
     @pytest.mark.slow
     def test_plot_scatter_with_categorical_data(self):

--- a/pandas/tests/plotting/test_frame.py
+++ b/pandas/tests/plotting/test_frame.py
@@ -1133,6 +1133,24 @@ class TestDataFramePlots(TestPlotBase):
         assert ax.xaxis.get_label().get_visible()
 
     @pytest.mark.slow
+    def test_if_scatterplot_colorbars_are_next_to_parent_axes():
+        import matplotlib.pyplot as plt
+        random_array = np.random.random((1000, 3))
+        df = pd.DataFrame(random_array,
+                          columns=['A label', 'B label', 'C label'])
+
+        fig, axes = plt.subplots(1, 2)
+        df.plot.scatter('A label', 'B label', c='C label', ax=axes[0])
+        df.plot.scatter('A label', 'B label', c='C label', ax=axes[1])
+        plt.tight_layout()
+
+        points = np.array([ax.get_position().get_points() for ax in fig.axes])
+        axes_x_coords = points[:, :, 0]
+        parent_distance = axes_x_coords[1, :] - axes_x_coords[0, :]
+        colorbar_distance = axes_x_coords[3, :] - axes_x_coords[2, :]
+        assert np.isclose(parent_distance, colorbar_distance).all()
+
+    @pytest.mark.slow
     def test_plot_scatter_with_categorical_data(self):
         # GH 16199
         df = pd.DataFrame({'x': [1, 2, 3, 4],


### PR DESCRIPTION
- [x] closes #20455
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry

NOTE: I have tested the following in Jupyter lab.

When I run:

```python
%matplotlib inline
import matplotlib.pyplot as plt
import numpy as np
import pandas as pd
random_array = np.random.random((1000,3))
df = pd.DataFrame(random_array,columns=['A label','B label','C label'])

fig, axes = plt.subplots(1, 2)
df.plot.scatter('A label','B label', c='C label', ax=axes[0])
df.plot.scatter('A label','B label', c='C label', ax=axes[1])
plt.tight_layout()
```
I get:

![image](https://user-images.githubusercontent.com/26352146/42286164-eaa6ad96-7f7f-11e8-9bb5-cbe03d9820b7.png)

This PR fixes the issue with colorbars. After the PR the output is:

![image](https://user-images.githubusercontent.com/26352146/42286213-213375ba-7f80-11e8-964c-a0d4bdd79526.png)

This also fixes similar issue with hexbin plot. To explore different configurations try the following function:

```python
%matplotlib inline
import matplotlib.pyplot as plt
import numpy as np
import pandas as pd

def make_multiplots(numrows=2,numcols=2,sharey=True,sharex=True, is_scatter = True):
    fig, axes = plt.subplots(numrows, numcols, sharey=sharey, sharex=sharex )
    for i in range(axes.shape[0]):
        for j in range(axes.shape[1]):
            random_array = np.random.random((1000,3))
            df = pd.DataFrame(random_array,columns=['A label','B label','C label'])
            if is_scatter:
                df.plot.scatter('A label', 'B label', c='C label', ax=axes[i,j]);
            else:
                df.plot.hexbin('A label', 'B label', gridsize=20, ax=axes[i,j]);

make_multiplots(numrows=2,numcols=3,sharey=False, sharex=False, is_scatter=False)
plt.tight_layout()
```
![image](https://user-images.githubusercontent.com/26352146/42286309-6bbba0c6-7f80-11e8-9327-b17cf31ecb07.png)

