### PR TITLE
Fix whatsnew dates

### DIFF
--- a/doc/source/whatsnew/v0.23.1.txt
+++ b/doc/source/whatsnew/v0.23.1.txt
@@ -1,7 +1,7 @@
 .. _whatsnew_0231:
 
-v0.23.1
--------
+v0.23.1 (June 12, 2018)
+-----------------------
 
 This is a minor bug-fix release in the 0.23.x series and includes some small regression fixes
 and bug fixes. We recommend that all users upgrade to this version.

--- a/doc/source/whatsnew/v0.23.2.txt
+++ b/doc/source/whatsnew/v0.23.2.txt
@@ -1,7 +1,7 @@
 .. _whatsnew_0232:
 
-v0.23.2
--------
+v0.23.2 (July 5, 2018)
+----------------------
 
 This is a minor bug-fix release in the 0.23.x series and includes some small regression fixes
 and bug fixes. We recommend that all users upgrade to this version.

--- a/doc/source/whatsnew/v0.24.0.txt
+++ b/doc/source/whatsnew/v0.24.0.txt
@@ -1,7 +1,7 @@
 .. _whatsnew_0240:
 
-v0.24.0
--------
+v0.24.0 (Month XX, 2018)
+------------------------
 
 .. _whatsnew_0240.enhancements:
 


### PR DESCRIPTION
Up to v0.23.0, there's always a date in the whatsnew-entries. This adds them back to v0.23.1 & v0.23.2, as well as a blank template for v0.24.0.
