### PR TITLE
Replaces Exceptions with ValueError in MultiIndex, closes #21770

### DIFF
--- a/doc/source/whatsnew/v0.24.0.txt
+++ b/doc/source/whatsnew/v0.24.0.txt
@@ -190,6 +190,8 @@ Other API Changes
 
 .. _whatsnew_0240.api.incompatibilities:
 
+- Trying to reindex a ``DataFrame`` with a non unique ``MultiIndex`` now raises a ``ValueError`` instead of an ``Exception`` (:issue:`21770`)
+
 Series and Index Data-Dtype Incompatibilities
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/pandas/core/indexes/multi.py
+++ b/pandas/core/indexes/multi.py
@@ -1958,7 +1958,7 @@ class MultiIndex(Index):
                                                           tolerance=tolerance)
 
         if not self.is_unique:
-            raise Exception('Reindexing only valid with uniquely valued Index '
+            raise ValueError('Reindexing only valid with uniquely valued Index '
                             'objects')
 
         if method == 'pad' or method == 'backfill':
@@ -2023,7 +2023,7 @@ class MultiIndex(Index):
                                                limit=limit,
                                                tolerance=tolerance)
                 else:
-                    raise Exception("cannot handle a non-unique multi-index!")
+                    raise ValueError("cannot handle a non-unique multi-index!")
 
         if not isinstance(target, MultiIndex):
             if indexer is None:

--- a/pandas/core/indexes/multi.py
+++ b/pandas/core/indexes/multi.py
@@ -1958,8 +1958,8 @@ class MultiIndex(Index):
                                                           tolerance=tolerance)
 
         if not self.is_unique:
-            raise ValueError('Reindexing only valid with uniquely valued Index '
-                            'objects')
+            raise ValueError('Reindexing only valid with uniquely valued '
+                             'Index objects')
 
         if method == 'pad' or method == 'backfill':
             if tolerance is not None:

--- a/pandas/tests/indexes/multi/test_reindex.py
+++ b/pandas/tests/indexes/multi/test_reindex.py
@@ -97,3 +97,11 @@ def test_reindex_base(idx):
 
     with tm.assert_raises_regex(ValueError, 'Invalid fill method'):
         idx.get_indexer(idx, method='invalid')
+
+
+def test_reindex_non_unique():
+    idx = pd.MultiIndex.from_tuples([(0, 0), (1, 1), (1, 1), (2, 2)])
+    a = pd.Series(np.arange(4), index=idx)
+    new_idx = pd.MultiIndex.from_tuples([(0, 0), (1, 1), (2, 2)])
+    with tm.assert_raises_regex(ValueError, 'cannot handle a non-unique multi-index!'):
+        a.reindex(new_idx)

--- a/pandas/tests/indexes/multi/test_reindex.py
+++ b/pandas/tests/indexes/multi/test_reindex.py
@@ -103,5 +103,6 @@ def test_reindex_non_unique():
     idx = pd.MultiIndex.from_tuples([(0, 0), (1, 1), (1, 1), (2, 2)])
     a = pd.Series(np.arange(4), index=idx)
     new_idx = pd.MultiIndex.from_tuples([(0, 0), (1, 1), (2, 2)])
-    with tm.assert_raises_regex(ValueError, 'cannot handle a non-unique multi-index!'):
+    with tm.assert_raises_regex(ValueError,
+                                'cannot handle a non-unique multi-index!'):
         a.reindex(new_idx)


### PR DESCRIPTION
- [X] closes #21770 
- [X] tests added / passed
- [X] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [X] whatsnew entry