### PR TITLE
BENCH: asv csv reading benchmarks now rewind StringIO objects

### DIFF
--- a/asv_bench/benchmarks/io/csv.py
+++ b/asv_bench/benchmarks/io/csv.py
@@ -54,7 +54,14 @@ class ToCSVDatetime(BaseIO):
         self.data.to_csv(self.fname, date_format='%Y%m%d')
 
 
-class ReadCSVDInferDatetimeFormat(object):
+class StringIORewind(object):
+
+    def data(self, stringio_object):
+        stringio_object.seek(0)
+        return stringio_object
+
+
+class ReadCSVDInferDatetimeFormat(StringIORewind):
 
     goal_time = 0.2
     params = ([True, False], ['custom', 'iso8601', 'ymd'])
@@ -66,10 +73,12 @@ class ReadCSVDInferDatetimeFormat(object):
                    'iso8601': '%Y-%m-%d %H:%M:%S',
                    'ymd': '%Y%m%d'}
         dt_format = formats[format]
-        self.data = StringIO('\n'.join(rng.strftime(dt_format).tolist()))
+        self.StringIO_input = StringIO('\n'.join(
+                                       rng.strftime(dt_format).tolist()))
 
     def time_read_csv(self, infer_datetime_format, format):
-        read_csv(self.data, header=None, names=['foo'], parse_dates=['foo'],
+        read_csv(self.data(self.StringIO_input),
+                 header=None, names=['foo'], parse_dates=['foo'],
                  infer_datetime_format=infer_datetime_format)
 
 
@@ -95,7 +104,7 @@ class ReadCSVSkipRows(BaseIO):
         read_csv(self.fname, skiprows=skiprows)
 
 
-class ReadUint64Integers(object):
+class ReadUint64Integers(StringIORewind):
 
     goal_time = 0.2
 
@@ -108,13 +117,13 @@ class ReadUint64Integers(object):
         self.data2 = StringIO('\n'.join(arr.astype(str).tolist()))
 
     def time_read_uint64(self):
-        read_csv(self.data1, header=None, names=['foo'])
+        read_csv(self.data(self.data1), header=None, names=['foo'])
 
     def time_read_uint64_neg_values(self):
-        read_csv(self.data2, header=None, names=['foo'])
+        read_csv(self.data(self.data2), header=None, names=['foo'])
 
     def time_read_uint64_na_values(self):
-        read_csv(self.data1, header=None, names=['foo'],
+        read_csv(self.data(self.data1), header=None, names=['foo'],
                  na_values=self.na_values)
 
 
@@ -140,19 +149,20 @@ class ReadCSVThousands(BaseIO):
         read_csv(self.fname, sep=sep, thousands=thousands)
 
 
-class ReadCSVComment(object):
+class ReadCSVComment(StringIORewind):
 
     goal_time = 0.2
 
     def setup(self):
         data = ['A,B,C'] + (['1,2,3 # comment'] * 100000)
-        self.s_data = StringIO('\n'.join(data))
+        self.StringIO_input = StringIO('\n'.join(data))
 
     def time_comment(self):
-        read_csv(self.s_data, comment='#', header=None, names=list('abc'))
+        read_csv(self.data(self.StringIO_input), comment='#',
+                 header=None, names=list('abc'))
 
 
-class ReadCSVFloatPrecision(object):
+class ReadCSVFloatPrecision(StringIORewind):
 
     goal_time = 0.2
     params = ([',', ';'], ['.', '_'], [None, 'high', 'round_trip'])
@@ -164,14 +174,14 @@ class ReadCSVFloatPrecision(object):
         rows = sep.join(['0{}'.format(decimal) + '{}'] * 3) + '\n'
         data = rows * 5
         data = data.format(*floats) * 200  # 1000 x 3 strings csv
-        self.s_data = StringIO(data)
+        self.StringIO_input = StringIO(data)
 
     def time_read_csv(self, sep, decimal, float_precision):
-        read_csv(self.s_data, sep=sep, header=None, names=list('abc'),
-                 float_precision=float_precision)
+        read_csv(self.data(self.StringIO_input), sep=sep, header=None,
+                 names=list('abc'), float_precision=float_precision)
 
     def time_read_csv_python_engine(self, sep, decimal, float_precision):
-        read_csv(self.s_data, sep=sep, header=None, engine='python',
+        read_csv(self.data(self.StringIO_input), sep=sep, header=None, engine='python',
                  float_precision=None, names=list('abc'))
 
 
@@ -193,7 +203,7 @@ class ReadCSVCategorical(BaseIO):
         read_csv(self.fname, dtype='category')
 
 
-class ReadCSVParseDates(object):
+class ReadCSVParseDates(StringIORewind):
 
     goal_time = 0.2
 
@@ -206,12 +216,14 @@ class ReadCSVParseDates(object):
                """
         two_cols = ['KORD,19990127'] * 5
         data = data.format(*two_cols)
-        self.s_data = StringIO(data)
+        self.StringIO_input = StringIO(data)
 
     def time_multiple_date(self):
-        read_csv(self.s_data, sep=',', header=None,
-                 names=list(string.digits[:9]), parse_dates=[[1, 2], [1, 3]])
+        read_csv(self.data(self.StringIO_input), sep=',', header=None,
+                 names=list(string.digits[:9]),
+                 parse_dates=[[1, 2], [1, 3]])
 
     def time_baseline(self):
-        read_csv(self.s_data, sep=',', header=None, parse_dates=[1],
+        read_csv(self.data(self.StringIO_input), sep=',', header=None,
+                 parse_dates=[1],
                  names=list(string.digits[:9]))


### PR DESCRIPTION
In short, the `asv` benchmarks used for timing `read_csv` are actually reading in empty file-like objects most of the time at the moment. This is because the `setup()` method of the benchmarks is only called between **repeats** and not between **iterations** of repeats--see [writing benchmarks docs](http://asv.readthedocs.io/en/latest/writing_benchmarks.html#timing).

You can confirm this by simply printing the `size` of the dataframes you get from `read_csv` in any StringIO-dependent benchmarks--the **first** iteration of a repeat should have the correct size, but the rest will all be 0. You could also just print the memory address (StringIO object)--they'll all be the same after the first iteration of a repeat. I did this with @stefanv and @mattip in the NumPy context.

This can be quite confusing--a bit different than the paradigm you might expect in i.e, a unit test context--for more gory details see [my related comment in NumPy loadtxt() asv benchmarks](https://github.com/numpy/numpy/pull/11422#issuecomment-403247951). As noted there, one could probably avoid this by using an actual file object instead / if preferred, but realistically this just boils down to [how timeit works](https://stackoverflow.com/questions/8220801/how-to-use-timeit-module#comment11535453_8220943). Confounding the results with the seek is unfortunate, so working with file objects may be preferred if dumping files in the bench env is acceptable.
