### PR TITLE
Add unit test for #12813

### DIFF
--- a/doc/source/whatsnew/v0.24.0.txt
+++ b/doc/source/whatsnew/v0.24.0.txt
@@ -331,6 +331,7 @@ Numeric
 ^^^^^^^
 
 - Bug in :class:`Series` ``__rmatmul__`` doesn't support matrix vector multiplication (:issue:`21530`)
+- Bug in :func:`factorize` fails with read-only array (:issue:`12813`)
 -
 -
 

--- a/pandas/tests/test_algos.py
+++ b/pandas/tests/test_algos.py
@@ -231,8 +231,9 @@ class TestFactorize(object):
 
         pytest.raises(TypeError, algos.factorize, x17[::-1], sort=True)
 
-    def test_uint64_factorize(self):
+    def test_uint64_factorize(self, writable):
         data = np.array([2**63, 1, 2**63], dtype=np.uint64)
+        data.setflags(write=writable)
         exp_labels = np.array([0, 1, 0], dtype=np.intp)
         exp_uniques = np.array([2**63, 1], dtype=np.uint64)
 


### PR DESCRIPTION
- [x] closes #12813
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry

The bug was already fixed with my previous PR but this adds a fixture to a unit test to also test read-only arrays as factorize input.