### PR TITLE
REF: Move most remaining arith helpers to datetimelike mixins

### DIFF
--- a/pandas/core/arrays/timedelta.py
+++ b/pandas/core/arrays/timedelta.py
@@ -10,7 +10,8 @@ from pandas._libs.tslibs.timedeltas import array_to_timedelta64
 
 from pandas import compat
 
-from pandas.core.dtypes.common import _TD_DTYPE, _ensure_int64
+from pandas.core.dtypes.common import (
+    _TD_DTYPE, _ensure_int64, is_timedelta64_dtype)
 from pandas.core.dtypes.generic import ABCSeries
 from pandas.core.dtypes.missing import isna
 
@@ -58,7 +59,11 @@ class TimedeltaArrayMixin(DatetimeLikeArrayMixin):
         if values.dtype == np.object_:
             values = array_to_timedelta64(values)
         if values.dtype != _TD_DTYPE:
-            values = _ensure_int64(values).view(_TD_DTYPE)
+            if is_timedelta64_dtype(values):
+                # non-nano unit
+                values = values.astype(_TD_DTYPE)
+            else:
+                values = _ensure_int64(values).view(_TD_DTYPE)
 
         result = object.__new__(cls)
         result._data = values
@@ -91,6 +96,38 @@ class TimedeltaArrayMixin(DatetimeLikeArrayMixin):
         assert other is not NaT
         raise TypeError("cannot subtract a datelike from a {cls}"
                         .format(cls=type(self).__name__))
+
+    def _add_delta(self, delta):
+        """
+        Add a timedelta-like, Tick, or TimedeltaIndex-like object
+        to self.
+
+        Parameters
+        ----------
+        delta : timedelta, np.timedelta64, Tick, TimedeltaArray, TimedeltaIndex
+
+        Returns
+        -------
+        result : same type as self
+
+        Notes
+        -----
+        The result's name is set outside of _add_delta by the calling
+        method (__add__ or __sub__)
+        """
+        if isinstance(delta, (Tick, timedelta, np.timedelta64)):
+            new_values = self._add_delta_td(delta)
+        elif isinstance(delta, TimedeltaArrayMixin):
+            new_values = self._add_delta_tdi(delta)
+        elif is_timedelta64_dtype(delta):
+            # ndarray[timedelta64] --> wrap in TimedeltaArray/Index
+            delta = type(self)(delta)
+            new_values = self._add_delta_tdi(delta)
+        else:
+            raise TypeError("cannot add the type {0} to a TimedeltaIndex"
+                            .format(type(delta)))
+
+        return type(self)(new_values, freq='infer')
 
     def _evaluate_with_timedelta_like(self, other, op):
         if isinstance(other, ABCSeries):

--- a/pandas/core/indexes/datetimelike.py
+++ b/pandas/core/indexes/datetimelike.py
@@ -41,7 +41,7 @@ from pandas.core.dtypes.generic import (
 from pandas.core.dtypes.missing import isna
 from pandas.core import common as com, algorithms, ops
 
-from pandas.errors import NullFrequencyError, PerformanceWarning
+from pandas.errors import NullFrequencyError
 import pandas.io.formats.printing as printing
 
 from pandas.core.arrays.datetimelike import DatetimeLikeArrayMixin
@@ -598,34 +598,6 @@ class DatetimeIndexOpsMixin(DatetimeLikeArrayMixin):
 
         return (super(DatetimeIndexOpsMixin, self)
                 ._convert_scalar_indexer(key, kind=kind))
-
-    def _addsub_offset_array(self, other, op):
-        """
-        Add or subtract array-like of DateOffset objects
-
-        Parameters
-        ----------
-        other : Index, np.ndarray
-            object-dtype containing pd.DateOffset objects
-        op : {operator.add, operator.sub}
-
-        Returns
-        -------
-        result : same class as self
-        """
-        assert op in [operator.add, operator.sub]
-        if len(other) == 1:
-            return op(self, other[0])
-
-        warnings.warn("Adding/subtracting array of DateOffsets to "
-                      "{cls} not vectorized"
-                      .format(cls=type(self).__name__), PerformanceWarning)
-
-        res_values = op(self.astype('O').values, np.array(other))
-        kwargs = {}
-        if not is_period_dtype(self):
-            kwargs['freq'] = 'infer'
-        return type(self)(res_values, **kwargs)
 
     @classmethod
     def _add_datetimelike_methods(cls):

--- a/pandas/core/indexes/period.py
+++ b/pandas/core/indexes/period.py
@@ -480,66 +480,6 @@ class PeriodIndex(PeriodArrayMixin, DatelikeOps, DatetimeIndexOpsMixin,
         values = self.asi8
         return ((values[1:] - values[:-1]) < 2).all()
 
-    def asfreq(self, freq=None, how='E'):
-        """
-        Convert the PeriodIndex to the specified frequency `freq`.
-
-        Parameters
-        ----------
-
-        freq : str
-            a frequency
-        how : str {'E', 'S'}
-            'E', 'END', or 'FINISH' for end,
-            'S', 'START', or 'BEGIN' for start.
-            Whether the elements should be aligned to the end
-            or start within pa period. January 31st ('END') vs.
-            January 1st ('START') for example.
-
-        Returns
-        -------
-        new : PeriodIndex with the new frequency
-
-        Examples
-        --------
-        >>> pidx = pd.period_range('2010-01-01', '2015-01-01', freq='A')
-        >>> pidx
-        <class 'pandas.core.indexes.period.PeriodIndex'>
-        [2010, ..., 2015]
-        Length: 6, Freq: A-DEC
-
-        >>> pidx.asfreq('M')
-        <class 'pandas.core.indexes.period.PeriodIndex'>
-        [2010-12, ..., 2015-12]
-        Length: 6, Freq: M
-
-        >>> pidx.asfreq('M', how='S')
-        <class 'pandas.core.indexes.period.PeriodIndex'>
-        [2010-01, ..., 2015-01]
-        Length: 6, Freq: M
-        """
-        how = _validate_end_alias(how)
-
-        freq = Period._maybe_convert_freq(freq)
-
-        base1, mult1 = _gfc(self.freq)
-        base2, mult2 = _gfc(freq)
-
-        asi8 = self.asi8
-        # mult1 can't be negative or 0
-        end = how == 'E'
-        if end:
-            ordinal = asi8 + mult1 - 1
-        else:
-            ordinal = asi8
-
-        new_data = period.period_asfreq_arr(ordinal, base1, base2, end)
-
-        if self.hasnans:
-            new_data[self._isnan] = tslib.iNaT
-
-        return self._simple_new(new_data, self.name, freq=freq)
-
     year = _wrap_field_accessor('year')
     month = _wrap_field_accessor('month')
     day = _wrap_field_accessor('day')

--- a/pandas/core/indexes/timedeltas.py
+++ b/pandas/core/indexes/timedeltas.py
@@ -337,38 +337,6 @@ class TimedeltaIndex(TimedeltaArrayMixin, DatetimeIndexOpsMixin,
             attrs['freq'] = 'infer'
         return attrs
 
-    def _add_delta(self, delta):
-        """
-        Add a timedelta-like, Tick, or TimedeltaIndex-like object
-        to self.
-
-        Parameters
-        ----------
-        delta : {timedelta, np.timedelta64, Tick, TimedeltaIndex}
-
-        Returns
-        -------
-        result : TimedeltaIndex
-
-        Notes
-        -----
-        The result's name is set outside of _add_delta by the calling
-        method (__add__ or __sub__)
-        """
-        if isinstance(delta, (Tick, timedelta, np.timedelta64)):
-            new_values = self._add_delta_td(delta)
-        elif isinstance(delta, TimedeltaIndex):
-            new_values = self._add_delta_tdi(delta)
-        elif is_timedelta64_dtype(delta):
-            # ndarray[timedelta64] --> wrap in TimedeltaIndex
-            delta = TimedeltaIndex(delta)
-            new_values = self._add_delta_tdi(delta)
-        else:
-            raise TypeError("cannot add the type {0} to a TimedeltaIndex"
-                            .format(type(delta)))
-
-        return TimedeltaIndex(new_values, freq='infer')
-
     def _evaluate_with_timedelta_like(self, other, op):
         result = TimedeltaArrayMixin._evaluate_with_timedelta_like(self, other,
                                                                    op)

--- a/pandas/tests/arrays/test_datetimelike.py
+++ b/pandas/tests/arrays/test_datetimelike.py
@@ -1,0 +1,57 @@
+# -*- coding: utf-8 -*-
+import numpy as np
+
+import pandas as pd
+
+from pandas.core.arrays.datetimes import DatetimeArrayMixin
+from pandas.core.arrays.timedelta import TimedeltaArrayMixin
+from pandas.core.arrays.period import PeriodArrayMixin
+
+
+class TestDatetimeArray(object):
+
+    def test_from_dti(self, tz_naive_fixture):
+        tz = tz_naive_fixture
+        dti = pd.date_range('2016-01-01', periods=3, tz=tz)
+        arr = DatetimeArrayMixin(dti)
+        assert list(dti) == list(arr)
+
+    def test_astype_object(self, tz_naive_fixture):
+        tz = tz_naive_fixture
+        dti = pd.date_range('2016-01-01', periods=3, tz=tz)
+        arr = DatetimeArrayMixin(dti)
+        asobj = arr.astype('O')
+        assert isinstance(asobj, np.ndarray)
+        assert asobj.dtype == 'O'
+        assert list(asobj) == list(dti)
+
+
+class TestTimedeltaArray(object):
+    def test_from_tdi(self):
+        tdi = pd.TimedeltaIndex(['1 Day', '3 Hours'])
+        arr = TimedeltaArrayMixin(tdi)
+        assert list(arr) == list(tdi)
+
+    def test_astype_object(self):
+        tdi = pd.TimedeltaIndex(['1 Day', '3 Hours'])
+        arr = TimedeltaArrayMixin(tdi)
+        asobj = arr.astype('O')
+        assert isinstance(asobj, np.ndarray)
+        assert asobj.dtype == 'O'
+        assert list(asobj) == list(tdi)
+
+
+class TestPeriodArray(object):
+
+    def test_from_pi(self):
+        pi = pd.period_range('2016', freq='Q', periods=3)
+        arr = PeriodArrayMixin(pi)
+        assert list(arr) == list(pi)
+
+    def test_astype_object(self):
+        pi = pd.period_range('2016', freq='Q', periods=3)
+        arr = PeriodArrayMixin(pi)
+        asobj = arr.astype('O')
+        assert isinstance(asobj, np.ndarray)
+        assert asobj.dtype == 'O'
+        assert list(asobj) == list(pi)


### PR DESCRIPTION
Before we can finally move over `_add_datetimelike_methods` and be done with this, some more work needs to go into the `__new__` methods.  This gets another big chunk through, starts implementing tests.