### PR TITLE
update tslibs imports

### DIFF
--- a/pandas/_libs/__init__.py
+++ b/pandas/_libs/__init__.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # flake8: noqa
 
-from .tslib import iNaT, NaT, Timestamp, Timedelta, OutOfBoundsDatetime
+from .tslibs import iNaT, NaT, Timestamp, Timedelta, OutOfBoundsDatetime
 
 # TODO
 # period is directly dependent on tslib and imports python

--- a/pandas/_libs/index.pyx
+++ b/pandas/_libs/index.pyx
@@ -25,8 +25,7 @@ from tslibs.conversion cimport maybe_datetimelike_to_i8
 from hashtable cimport HashTable
 
 from pandas._libs import algos, hashtable as _hash
-from pandas._libs.tslibs import period as periodlib
-from pandas._libs.tslib import Timestamp, Timedelta
+from pandas._libs.tslibs import Timestamp, Timedelta, period as periodlib
 from pandas._libs.missing import checknull
 
 cdef int64_t iNaT = util.get_nat()

--- a/pandas/_libs/interval.pyx
+++ b/pandas/_libs/interval.pyx
@@ -5,7 +5,7 @@ cimport util
 cimport cython
 import cython
 from numpy cimport ndarray
-from tslib import Timestamp
+from tslibs import Timestamp
 from tslibs.timezones cimport tz_compare
 
 from cpython.object cimport (Py_EQ, Py_NE, Py_GT, Py_LT, Py_GE, Py_LE,

--- a/pandas/_libs/lib.pyx
+++ b/pandas/_libs/lib.pyx
@@ -1,6 +1,5 @@
+# -*- coding: utf-8 -*-
 # cython: profile=False
-import operator
-
 cimport cython
 from cython cimport Py_ssize_t
 

--- a/pandas/_libs/missing.pyx
+++ b/pandas/_libs/missing.pyx
@@ -15,7 +15,6 @@ cimport util
 
 from tslibs.np_datetime cimport get_timedelta64_value, get_datetime64_value
 from tslibs.nattype import NaT
-from tslibs.nattype cimport is_null_datetimelike
 
 cdef double INF = <double> np.inf
 cdef double NEGINF = -INF

--- a/pandas/_libs/reshape.pyx
+++ b/pandas/_libs/reshape.pyx
@@ -4,11 +4,9 @@ cimport cython
 from cython cimport Py_ssize_t
 
 import numpy as np
-cimport numpy as cnp
 from numpy cimport (ndarray,
                     int8_t, int16_t, int32_t, int64_t, uint8_t, uint16_t,
                     uint32_t, uint64_t, float32_t, float64_t)
-cnp.import_array()
 
 
 cdef double NaN = <double> np.NaN

--- a/pandas/_libs/src/util.pxd
+++ b/pandas/_libs/src/util.pxd
@@ -100,6 +100,7 @@ cdef extern from "headers/stdint.h":
     enum: INT64_MAX
     enum: INT64_MIN
 
+
 cdef inline object get_value_at(ndarray arr, object loc):
     cdef:
         Py_ssize_t i, sz
@@ -118,6 +119,7 @@ cdef inline object get_value_at(ndarray arr, object loc):
         raise IndexError('index out of bounds')
 
     return get_value_1d(arr, i)
+
 
 cdef inline set_value_at_unsafe(ndarray arr, object loc, object value):
     """Sets a value into the array without checking the writeable flag.
@@ -153,11 +155,13 @@ cdef inline set_value_at(ndarray arr, object loc, object value):
 cdef inline is_array(object o):
     return cnp.PyArray_Check(o)
 
+
 cdef inline bint _checknull(object val):
     try:
         return val is None or (cpython.PyFloat_Check(val) and val != val)
     except ValueError:
         return False
+
 
 cdef inline bint is_period_object(object val):
     return getattr(val, '_typ', '_typ') == 'period'

--- a/pandas/_libs/tslib.pyx
+++ b/pandas/_libs/tslib.pyx
@@ -38,14 +38,12 @@ import pytz
 
 
 from tslibs.timedeltas cimport cast_from_unit
-from tslibs.timedeltas import Timedelta, ints_to_pytimedelta  # noqa:F841
 from tslibs.timezones cimport (is_utc, is_tzlocal, is_fixed_offset,
                                treat_tz_as_pytz, get_dst_info)
 from tslibs.conversion cimport (tz_convert_single, _TSObject,
                                 convert_datetime_to_tsobject,
                                 get_datetime64_nanos,
                                 tz_convert_utc_to_tzlocal)
-from tslibs.conversion import tz_convert_single, normalize_date  # noqa:F841
 
 from tslibs.nattype import NaT, nat_strings, iNaT
 from tslibs.nattype cimport checknull_with_nat, NPY_NAT

--- a/pandas/_libs/tslibs/frequencies.pyx
+++ b/pandas/_libs/tslibs/frequencies.pyx
@@ -5,7 +5,6 @@ import re
 cimport cython
 
 cimport numpy as cnp
-from numpy cimport int64_t
 cnp.import_array()
 
 from util cimport is_integer_object, is_string_object

--- a/pandas/_libs/tslibs/offsets.pyx
+++ b/pandas/_libs/tslibs/offsets.pyx
@@ -11,7 +11,6 @@ from cpython.datetime cimport (PyDateTime_IMPORT, PyDateTime_CheckExact,
 PyDateTime_IMPORT
 
 from dateutil.relativedelta import relativedelta
-from pytz import UTC
 
 import numpy as np
 cimport numpy as cnp
@@ -24,7 +23,6 @@ from util cimport is_string_object, is_integer_object
 from ccalendar import MONTHS, DAYS
 from ccalendar cimport get_days_in_month, dayofweek
 from conversion cimport tz_convert_single, pydt_to_i8, localize_pydatetime
-from frequencies cimport get_freq_code
 from nattype cimport NPY_NAT
 from np_datetime cimport (pandas_datetimestruct,
                           dtstruct_to_dt64, dt64_to_dtstruct)

--- a/pandas/_libs/tslibs/parsing.pyx
+++ b/pandas/_libs/tslibs/parsing.pyx
@@ -6,10 +6,6 @@ Parsing functions for datetime and datetime-like strings.
 import sys
 import re
 
-from cpython cimport PyString_Check, PyUnicode_Check
-
-from libc.stdlib cimport free
-
 cimport cython
 from cython cimport Py_ssize_t
 
@@ -34,7 +30,6 @@ else:
 # dateutil compat
 from dateutil.tz import (tzoffset,
                          tzlocal as _dateutil_tzlocal,
-                         tzfile as _dateutil_tzfile,
                          tzutc as _dateutil_tzutc,
                          tzstr as _dateutil_tzstr)
 from dateutil.relativedelta import relativedelta

--- a/pandas/_libs/tslibs/period.pyx
+++ b/pandas/_libs/tslibs/period.pyx
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # cython: profile=False
-from datetime import datetime, date, timedelta
+from datetime import datetime, date
 
 from cpython cimport (
     PyUnicode_Check,
@@ -37,7 +37,7 @@ cimport util
 from util cimport is_period_object, is_string_object, INT32_MIN
 
 from timestamps import Timestamp
-from timezones cimport is_utc, is_tzlocal, get_utcoffset, get_dst_info
+from timezones cimport is_utc, is_tzlocal, get_dst_info
 from timedeltas cimport delta_to_nanoseconds
 
 cimport ccalendar

--- a/pandas/_libs/tslibs/resolution.pyx
+++ b/pandas/_libs/tslibs/resolution.pyx
@@ -15,12 +15,10 @@ from pandas._libs.khash cimport (khiter_t,
                                  kh_init_int64, kh_int64_t,
                                  kh_resize_int64, kh_get_int64)
 
-from cpython.datetime cimport datetime
-
 from np_datetime cimport pandas_datetimestruct, dt64_to_dtstruct
 from frequencies cimport get_freq_code
 from timezones cimport (is_utc, is_tzlocal,
-                        maybe_get_tz, get_dst_info, get_utcoffset)
+                        maybe_get_tz, get_dst_info)
 from fields import build_field_sarray
 from conversion import tz_convert
 from conversion cimport tz_convert_utc_to_tzlocal

--- a/pandas/_libs/tslibs/strptime.pyx
+++ b/pandas/_libs/tslibs/strptime.pyx
@@ -31,7 +31,6 @@ import numpy as np
 from numpy cimport ndarray, int64_t
 
 from datetime import date as datetime_date
-from cpython.datetime cimport datetime
 
 from np_datetime cimport (check_dts_bounds,
                           dtstruct_to_dt64, pandas_datetimestruct)

--- a/pandas/_libs/window.pyx
+++ b/pandas/_libs/window.pyx
@@ -20,8 +20,7 @@ cdef extern from "../src/headers/cmath" namespace "std":
 cimport util
 from util cimport numeric
 
-from skiplist cimport (IndexableSkiplist,
-                       node_t, skiplist_t,
+from skiplist cimport (skiplist_t,
                        skiplist_init, skiplist_destroy,
                        skiplist_get, skiplist_insert, skiplist_remove)
 

--- a/pandas/core/arrays/timedelta.py
+++ b/pandas/core/arrays/timedelta.py
@@ -3,8 +3,8 @@ from datetime import timedelta
 
 import numpy as np
 
-from pandas._libs import tslib
-from pandas._libs.tslib import Timedelta, NaT
+from pandas._libs import tslibs
+from pandas._libs.tslibs import Timedelta, NaT
 from pandas._libs.tslibs.fields import get_timedelta_field
 from pandas._libs.tslibs.timedeltas import array_to_timedelta64
 
@@ -148,7 +148,7 @@ class TimedeltaArrayMixin(DatetimeLikeArrayMixin):
         -------
         datetimes : ndarray
         """
-        return tslib.ints_to_pytimedelta(self.asi8)
+        return tslibs.ints_to_pytimedelta(self.asi8)
 
     days = _field_accessor("days", "days",
                            " Number of days for each element. ")

--- a/pandas/core/common.py
+++ b/pandas/core/common.py
@@ -8,7 +8,7 @@ import inspect
 import collections
 
 import numpy as np
-from pandas._libs import lib, tslib
+from pandas._libs import lib, tslibs
 
 from pandas import compat
 from pandas.compat import long, zip, iteritems, PY36, OrderedDict
@@ -87,9 +87,9 @@ def _maybe_box_datetimelike(value):
     # turn a datetime like into a Timestamp/timedelta as needed
 
     if isinstance(value, (np.datetime64, datetime)):
-        value = tslib.Timestamp(value)
+        value = tslibs.Timestamp(value)
     elif isinstance(value, (np.timedelta64, timedelta)):
-        value = tslib.Timedelta(value)
+        value = tslibs.Timedelta(value)
 
     return value
 

--- a/pandas/core/dtypes/cast.py
+++ b/pandas/core/dtypes/cast.py
@@ -5,8 +5,8 @@ from datetime import datetime, timedelta
 import numpy as np
 import warnings
 
-from pandas._libs import tslib, lib
-from pandas._libs.tslib import iNaT
+from pandas._libs import tslib, lib, tslibs
+from pandas._libs.tslibs import iNaT
 from pandas.compat import string_types, text_type, PY3
 from .common import (_ensure_object, is_bool, is_integer, is_float,
                      is_complex, is_datetimetz, is_categorical_dtype,
@@ -278,14 +278,14 @@ def maybe_promote(dtype, fill_value=np.nan):
         else:
             if issubclass(dtype.type, np.datetime64):
                 try:
-                    fill_value = tslib.Timestamp(fill_value).value
+                    fill_value = tslibs.Timestamp(fill_value).value
                 except Exception:
                     # the proper thing to do here would probably be to upcast
                     # to object (but numpy 1.6.1 doesn't do this properly)
                     fill_value = iNaT
             elif issubclass(dtype.type, np.timedelta64):
                 try:
-                    fill_value = tslib.Timedelta(fill_value).value
+                    fill_value = tslibs.Timedelta(fill_value).value
                 except Exception:
                     # as for datetimes, cannot upcast to object
                     fill_value = iNaT
@@ -393,8 +393,8 @@ def infer_dtype_from_scalar(val, pandas_dtype=False):
         dtype = np.object_
 
     elif isinstance(val, (np.datetime64, datetime)):
-        val = tslib.Timestamp(val)
-        if val is tslib.NaT or val.tz is None:
+        val = tslibs.Timestamp(val)
+        if val is tslibs.NaT or val.tz is None:
             dtype = np.dtype('M8[ns]')
         else:
             if pandas_dtype:
@@ -405,7 +405,7 @@ def infer_dtype_from_scalar(val, pandas_dtype=False):
         val = val.value
 
     elif isinstance(val, (np.timedelta64, timedelta)):
-        val = tslib.Timedelta(val).value
+        val = tslibs.Timedelta(val).value
         dtype = np.dtype('m8[ns]')
 
     elif is_bool(val):
@@ -625,7 +625,7 @@ def coerce_to_dtypes(result, dtypes):
             if isna(r):
                 pass
             elif dtype == _NS_DTYPE:
-                r = tslib.Timestamp(r)
+                r = tslibs.Timestamp(r)
             elif dtype == _TD_DTYPE:
                 r = _coerce_scalar_to_timedelta_type(r)
             elif dtype == np.bool_:
@@ -679,7 +679,7 @@ def astype_nansafe(arr, dtype, copy=True):
 
     elif is_timedelta64_dtype(arr):
         if is_object_dtype(dtype):
-            return tslib.ints_to_pytimedelta(arr.view(np.int64))
+            return tslibs.ints_to_pytimedelta(arr.view(np.int64))
         elif dtype == np.int64:
             return arr.view(dtype)
 

--- a/pandas/core/dtypes/concat.py
+++ b/pandas/core/dtypes/concat.py
@@ -3,7 +3,7 @@ Utility functions related to concat
 """
 
 import numpy as np
-import pandas._libs.tslib as tslib
+from pandas._libs import tslib, tslibs
 from pandas import compat
 from pandas.core.dtypes.common import (
     is_categorical_dtype,
@@ -486,7 +486,7 @@ def _convert_datetimelike_to_object(x):
 
     elif x.dtype == _TD_DTYPE:
         shape = x.shape
-        x = tslib.ints_to_pytimedelta(x.view(np.int64).ravel(), box=True)
+        x = tslibs.ints_to_pytimedelta(x.view(np.int64).ravel(), box=True)
         x = x.reshape(shape)
 
     return x

--- a/pandas/core/dtypes/missing.py
+++ b/pandas/core/dtypes/missing.py
@@ -3,7 +3,7 @@ missing types & inference
 """
 import numpy as np
 from pandas._libs import lib, missing as libmissing
-from pandas._libs.tslib import NaT, iNaT
+from pandas._libs.tslibs import NaT, iNaT
 from .generic import (ABCMultiIndex, ABCSeries,
                       ABCIndexClass, ABCGeneric,
                       ABCExtensionArray)

--- a/pandas/core/indexes/api.py
+++ b/pandas/core/indexes/api.py
@@ -17,8 +17,7 @@ from pandas.core.indexes.period import PeriodIndex
 from pandas.core.indexes.datetimes import DatetimeIndex
 
 import pandas.core.common as com
-from pandas._libs import lib
-from pandas._libs.tslib import NaT
+from pandas._libs import lib, NaT
 
 _sort_msg = textwrap.dedent("""\
 Sorting because non-concatenation axis is not aligned. A future version

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -4,7 +4,7 @@ import operator
 from textwrap import dedent
 
 import numpy as np
-from pandas._libs import (lib, index as libindex, tslib as libts,
+from pandas._libs import (lib, index as libindex, tslibs,
                           algos as libalgos, join as libjoin,
                           Timedelta)
 from pandas._libs.lib import is_datetime_array
@@ -407,7 +407,7 @@ class Index(IndexOpsMixin, PandasObject):
                             try:
                                 return DatetimeIndex(subarr, copy=copy,
                                                      name=name, **kwargs)
-                            except libts.OutOfBoundsDatetime:
+                            except tslibs.OutOfBoundsDatetime:
                                 pass
 
                     elif inferred.startswith('timedelta'):

--- a/pandas/core/indexes/datetimes.py
+++ b/pandas/core/indexes/datetimes.py
@@ -53,7 +53,7 @@ import pandas.core.common as com
 import pandas.tseries.offsets as offsets
 import pandas.core.tools.datetimes as tools
 
-from pandas._libs import (lib, index as libindex, tslib as libts,
+from pandas._libs import (lib, index as libindex, tslibs, tslib as libts,
                           join as libjoin, Timestamp)
 from pandas._libs.tslibs import (timezones, conversion, fields, parsing,
                                  ccalendar)
@@ -494,14 +494,14 @@ class DatetimeIndex(DatetimeArrayMixin, DatelikeOps, TimelikeOps,
 
         if start is not None:
             if normalize:
-                start = libts.normalize_date(start)
+                start = tslibs.normalize_date(start)
                 _normalized = True
             else:
                 _normalized = _normalized and start.time() == _midnight
 
         if end is not None:
             if normalize:
-                end = libts.normalize_date(end)
+                end = tslibs.normalize_date(end)
                 _normalized = True
             else:
                 _normalized = _normalized and end.time() == _midnight
@@ -796,10 +796,10 @@ class DatetimeIndex(DatetimeArrayMixin, DatelikeOps, TimelikeOps,
                                 .format(cls=type(self).__name__))
             result = self._sub_datelike_dti(other)
         elif isinstance(other, (datetime, np.datetime64)):
-            assert other is not libts.NaT
+            assert other is not tslibs.NaT
             other = Timestamp(other)
-            if other is libts.NaT:
-                return self - libts.NaT
+            if other is tslibs.NaT:
+                return self - tslibs.NaT
             # require tz compat
             elif not self._has_same_tz(other):
                 raise TypeError("Timestamp subtraction must have the same "
@@ -809,7 +809,7 @@ class DatetimeIndex(DatetimeArrayMixin, DatelikeOps, TimelikeOps,
                 result = checked_add_with_arr(i8, -other.value,
                                               arr_mask=self._isnan)
                 result = self._maybe_mask_results(result,
-                                                  fill_value=libts.iNaT)
+                                                  fill_value=tslibs.iNaT)
         else:
             raise TypeError("cannot subtract {cls} and {typ}"
                             .format(cls=type(self).__name__,

--- a/pandas/core/internals.py
+++ b/pandas/core/internals.py
@@ -74,10 +74,9 @@ from pandas.io.formats.printing import pprint_thing
 
 import pandas.core.missing as missing
 from pandas.core.sparse.array import _maybe_to_sparse, SparseArray
-from pandas._libs import lib, tslib
-from pandas._libs.tslib import Timedelta
+from pandas._libs import lib, tslib, tslibs
+from pandas._libs.tslibs import conversion, Timedelta
 from pandas._libs.internals import BlockPlacement
-from pandas._libs.tslibs import conversion
 
 from pandas.util._decorators import cache_readonly
 from pandas.util._validators import validate_bool_kwarg
@@ -2140,11 +2139,11 @@ class DatetimeLikeBlockMixin(object):
 
     @property
     def _na_value(self):
-        return tslib.NaT
+        return tslibs.NaT
 
     @property
     def fill_value(self):
-        return tslib.iNaT
+        return tslibs.iNaT
 
     def get_values(self, dtype=None):
         """
@@ -2175,7 +2174,7 @@ class TimeDeltaBlock(DatetimeLikeBlockMixin, IntBlock):
 
     @property
     def _box_func(self):
-        return lambda x: tslib.Timedelta(x, unit='ns')
+        return lambda x: Timedelta(x, unit='ns')
 
     def _can_hold_element(self, element):
         tipo = maybe_infer_dtype_type(element)
@@ -2214,7 +2213,7 @@ class TimeDeltaBlock(DatetimeLikeBlockMixin, IntBlock):
         if isinstance(other, bool):
             raise TypeError
         elif is_null_datelike_scalar(other):
-            other = tslib.iNaT
+            other = tslibs.iNaT
             other_mask = True
         elif isinstance(other, Timedelta):
             other_mask = isna(other)
@@ -2240,7 +2239,7 @@ class TimeDeltaBlock(DatetimeLikeBlockMixin, IntBlock):
             mask = isna(result)
             if result.dtype.kind in ['i', 'f', 'O']:
                 result = result.astype('m8[ns]')
-            result[mask] = tslib.iNaT
+            result[mask] = tslibs.iNaT
         elif isinstance(result, (np.integer, np.float)):
             result = self._box_func(result)
         return result
@@ -2714,7 +2713,7 @@ class DatetimeBlock(DatetimeLikeBlockMixin, Block):
         if isinstance(other, bool):
             raise TypeError
         elif is_null_datelike_scalar(other):
-            other = tslib.iNaT
+            other = tslibs.iNaT
             other_mask = True
         elif isinstance(other, (datetime, np.datetime64, date)):
             other = self._box_func(other)
@@ -2747,7 +2746,7 @@ class DatetimeBlock(DatetimeLikeBlockMixin, Block):
 
     @property
     def _box_func(self):
-        return tslib.Timestamp
+        return tslibs.Timestamp
 
     def to_native_types(self, slicer=None, na_rep=None, date_format=None,
                         quoting=None, **kwargs):
@@ -2892,7 +2891,7 @@ class DatetimeTZBlock(NonConsolidatableMixIn, DatetimeBlock):
             raise TypeError
         elif (is_null_datelike_scalar(other) or
               (is_scalar(other) and isna(other))):
-            other = tslib.iNaT
+            other = tslibs.iNaT
             other_mask = True
         elif isinstance(other, self._holder):
             if other.tz != self.values.tz:
@@ -2900,7 +2899,7 @@ class DatetimeTZBlock(NonConsolidatableMixIn, DatetimeBlock):
             other_mask = _block_shape(isna(other), ndim=self.ndim)
             other = _block_shape(other.asi8, ndim=self.ndim)
         elif isinstance(other, (np.datetime64, datetime, date)):
-            other = tslib.Timestamp(other)
+            other = tslibs.Timestamp(other)
             tz = getattr(other, 'tz', None)
 
             # test we can have an equal time zone
@@ -2919,7 +2918,7 @@ class DatetimeTZBlock(NonConsolidatableMixIn, DatetimeBlock):
             if result.dtype.kind in ['i', 'f', 'O']:
                 result = result.astype('M8[ns]')
         elif isinstance(result, (np.integer, np.float, np.datetime64)):
-            result = tslib.Timestamp(result, tz=self.values.tz)
+            result = tslibs.Timestamp(result, tz=self.values.tz)
         if isinstance(result, np.ndarray):
             # allow passing of > 1dim if its trivial
             if result.ndim > 1:
@@ -2930,7 +2929,7 @@ class DatetimeTZBlock(NonConsolidatableMixIn, DatetimeBlock):
 
     @property
     def _box_func(self):
-        return lambda x: tslib.Timestamp(x, tz=self.dtype.tz)
+        return lambda x: tslibs.Timestamp(x, tz=self.dtype.tz)
 
     def shift(self, periods, axis=0, mgr=None):
         """ shift the block by periods """
@@ -2948,9 +2947,9 @@ class DatetimeTZBlock(NonConsolidatableMixIn, DatetimeBlock):
         new_values = self.values.asi8.take(indexer)
 
         if periods > 0:
-            new_values[:periods] = tslib.iNaT
+            new_values[:periods] = tslibs.iNaT
         else:
-            new_values[periods:] = tslib.iNaT
+            new_values[periods:] = tslibs.iNaT
 
         new_values = self.values._shallow_copy(new_values)
         return [self.make_block_same_class(new_values,
@@ -5540,11 +5539,11 @@ def get_empty_dtype_and_na(join_units):
         return np.dtype(np.object_), np.nan
     elif 'datetimetz' in upcast_classes:
         dtype = upcast_classes['datetimetz']
-        return dtype[0], tslib.iNaT
+        return dtype[0], tslibs.iNaT
     elif 'datetime' in upcast_classes:
-        return np.dtype('M8[ns]'), tslib.iNaT
+        return np.dtype('M8[ns]'), tslibs.iNaT
     elif 'timedelta' in upcast_classes:
-        return np.dtype('m8[ns]'), tslib.iNaT
+        return np.dtype('m8[ns]'), tslibs.iNaT
     else:  # pragma
         g = np.find_common_type(upcast_classes, [])
         if is_float_dtype(g):

--- a/pandas/core/nanops.py
+++ b/pandas/core/nanops.py
@@ -6,7 +6,7 @@ from distutils.version import LooseVersion
 
 import numpy as np
 from pandas import compat
-from pandas._libs import tslib, lib
+from pandas._libs import tslibs, lib
 from pandas.core.dtypes.common import (
     _get_dtype,
     is_float, is_scalar,
@@ -190,13 +190,13 @@ def _get_fill_value(dtype, fill_value=None, fill_value_typ=None):
                 return -np.inf
     else:
         if fill_value_typ is None:
-            return tslib.iNaT
+            return tslibs.iNaT
         else:
             if fill_value_typ == '+inf':
                 # need the max int here
                 return _int64_max
             else:
-                return tslib.iNaT
+                return tslibs.iNaT
 
 
 def _get_values(values, skipna, fill_value=None, fill_value_typ=None,
@@ -268,7 +268,7 @@ def _wrap_results(result, dtype):
 
     if is_datetime64_dtype(dtype):
         if not isinstance(result, np.ndarray):
-            result = tslib.Timestamp(result)
+            result = tslibs.Timestamp(result)
         else:
             result = result.view(dtype)
     elif is_timedelta64_dtype(dtype):
@@ -278,7 +278,7 @@ def _wrap_results(result, dtype):
             if np.fabs(result) > _int64_max:
                 raise ValueError("overflow in timedelta operation")
 
-            result = tslib.Timedelta(result, unit='ns')
+            result = tslibs.Timedelta(result, unit='ns')
         else:
             result = result.astype('i8').view(dtype)
 
@@ -722,7 +722,7 @@ def _maybe_null_out(result, axis, mask, min_count=1):
             else:
                 # GH12941, use None to auto cast null
                 result[null_mask] = None
-    elif result is not tslib.NaT:
+    elif result is not tslibs.NaT:
         null_mask = mask.size - mask.sum()
         if null_mask < min_count:
             result = np.nan

--- a/pandas/core/resample.py
+++ b/pandas/core/resample.py
@@ -24,7 +24,7 @@ from pandas.core.dtypes.generic import ABCDataFrame, ABCSeries
 import pandas.compat as compat
 from pandas.compat.numpy import function as nv
 
-from pandas._libs import lib, tslib
+from pandas._libs import lib
 from pandas._libs.tslibs import Timestamp, NaT
 from pandas._libs.tslibs.period import IncompatibleFrequency
 

--- a/pandas/core/resample.py
+++ b/pandas/core/resample.py
@@ -25,7 +25,7 @@ import pandas.compat as compat
 from pandas.compat.numpy import function as nv
 
 from pandas._libs import lib, tslib
-from pandas._libs.tslib import Timestamp
+from pandas._libs.tslibs import Timestamp, NaT
 from pandas._libs.tslibs.period import IncompatibleFrequency
 
 from pandas.util._decorators import Appender, Substitution
@@ -1345,8 +1345,8 @@ class TimeGrouper(Grouper):
                 labels = labels[:-1]
 
         if ax.hasnans:
-            binner = binner.insert(0, tslib.NaT)
-            labels = labels.insert(0, tslib.NaT)
+            binner = binner.insert(0, NaT)
+            labels = labels.insert(0, NaT)
 
         # if we end up with more labels than bins
         # adjust the labels
@@ -1461,8 +1461,8 @@ class TimeGrouper(Grouper):
             # shift bins by the number of NaT
             bins += nat_count
             bins = np.insert(bins, 0, nat_count)
-            binner = binner.insert(0, tslib.NaT)
-            labels = labels.insert(0, tslib.NaT)
+            binner = binner.insert(0, NaT)
+            labels = labels.insert(0, NaT)
 
         return binner, bins, labels
 

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -76,7 +76,7 @@ from pandas.util._decorators import (
     Appender, deprecate, deprecate_kwarg, Substitution)
 from pandas.util._validators import validate_bool_kwarg
 
-from pandas._libs import index as libindex, tslib as libts, lib, iNaT
+from pandas._libs import index as libindex, tslibs, lib, iNaT
 from pandas.core.config import get_option
 from pandas.core.strings import StringMethods
 from pandas.core.tools.datetimes import to_datetime
@@ -380,7 +380,7 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
                     # need to set here because we changed the index
                     if fastpath:
                         self._data.set_axis(axis, labels)
-                except (libts.OutOfBoundsDatetime, ValueError):
+                except (tslibs.OutOfBoundsDatetime, ValueError):
                     # labels may exceeds datetime bounds,
                     # or not be a DatetimeIndex
                     pass

--- a/pandas/core/tools/datetimes.py
+++ b/pandas/core/tools/datetimes.py
@@ -4,9 +4,9 @@ from collections import MutableMapping
 
 import numpy as np
 
-from pandas._libs import tslib
+from pandas._libs import tslib, tslibs
 from pandas._libs.tslibs.strptime import array_strptime
-from pandas._libs.tslibs import parsing, conversion
+from pandas._libs.tslibs import parsing, conversion, Timestamp
 from pandas._libs.tslibs.parsing import (  # noqa
     parse_time_string,
     DateParseError,
@@ -131,7 +131,7 @@ def _return_parsed_timezone_results(result, timezones, box, tz):
         raise ValueError("Cannot pass a tz argument when "
                          "parsing strings with timezone "
                          "information.")
-    tz_results = np.array([tslib.Timestamp(res).tz_localize(zone) for res, zone
+    tz_results = np.array([Timestamp(res).tz_localize(zone) for res, zone
                            in zip(result, timezones)])
     if box:
         from pandas import Index
@@ -252,7 +252,7 @@ def _convert_listlike_datetimes(arg, box, format, name=None, tz=None,
                     if '%Z' in format or '%z' in format:
                         return _return_parsed_timezone_results(
                             result, timezones, box, tz)
-                except tslib.OutOfBoundsDatetime:
+                except tslibs.OutOfBoundsDatetime:
                     if errors == 'raise':
                         raise
                     result = arg
@@ -307,7 +307,7 @@ def _adjust_to_origin(arg, origin, unit):
     """
     if origin == 'julian':
         original = arg
-        j0 = tslib.Timestamp(0).to_julian_date()
+        j0 = Timestamp(0).to_julian_date()
         if unit != 'D':
             raise ValueError("unit must be 'D' for origin='julian'")
         try:
@@ -317,10 +317,10 @@ def _adjust_to_origin(arg, origin, unit):
                              "'origin'='julian'")
 
         # premptively check this for a nice range
-        j_max = tslib.Timestamp.max.to_julian_date() - j0
-        j_min = tslib.Timestamp.min.to_julian_date() - j0
+        j_max = Timestamp.max.to_julian_date() - j0
+        j_min = Timestamp.min.to_julian_date() - j0
         if np.any(arg > j_max) or np.any(arg < j_min):
-            raise tslib.OutOfBoundsDatetime(
+            raise tslibs.OutOfBoundsDatetime(
                 "{original} is Out of Bounds for "
                 "origin='julian'".format(original=original))
     else:
@@ -335,9 +335,9 @@ def _adjust_to_origin(arg, origin, unit):
 
         # we are going to offset back to unix / epoch time
         try:
-            offset = tslib.Timestamp(origin)
-        except tslib.OutOfBoundsDatetime:
-            raise tslib.OutOfBoundsDatetime(
+            offset = Timestamp(origin)
+        except tslibs.OutOfBoundsDatetime:
+            raise tslibs.OutOfBoundsDatetime(
                 "origin {origin} is Out of Bounds".format(origin=origin))
         except ValueError:
             raise ValueError("origin {origin} cannot be converted "
@@ -346,11 +346,11 @@ def _adjust_to_origin(arg, origin, unit):
         if offset.tz is not None:
             raise ValueError(
                 "origin offset {} must be tz-naive".format(offset))
-        offset -= tslib.Timestamp(0)
+        offset -= Timestamp(0)
 
         # convert the offset to the unit of the arg
         # this should be lossless in terms of precision
-        offset = offset // tslib.Timedelta(1, unit=unit)
+        offset = offset // tslibs.Timedelta(1, unit=unit)
 
         # scalars & ndarray-like can handle the addition
         if is_list_like(arg) and not isinstance(
@@ -538,7 +538,7 @@ def to_datetime(arg, errors='raise', dayfirst=False, yearfirst=False,
                                errors=errors, exact=exact,
                                infer_datetime_format=infer_datetime_format)
 
-    if isinstance(arg, tslib.Timestamp):
+    if isinstance(arg, Timestamp):
         result = arg
     elif isinstance(arg, ABCSeries):
         cache_array = _maybe_cache(arg, format, cache, convert_listlike)
@@ -701,7 +701,7 @@ def _attempt_YYYYMMDD(arg, errors):
     def calc_with_mask(carg, mask):
         result = np.empty(carg.shape, dtype='M8[ns]')
         iresult = result.view('i8')
-        iresult[~mask] = tslib.iNaT
+        iresult[~mask] = tslibs.iNaT
         result[mask] = calc(carg[mask].astype(np.float64).astype(np.int64)). \
             astype('M8[ns]')
         return result

--- a/pandas/core/tools/timedeltas.py
+++ b/pandas/core/tools/timedeltas.py
@@ -4,7 +4,7 @@ timedelta support tools
 
 import numpy as np
 import pandas as pd
-import pandas._libs.tslib as tslib
+from pandas._libs import tslibs
 from pandas._libs.tslibs.timedeltas import (convert_to_timedelta64,
                                             array_to_timedelta64)
 
@@ -153,7 +153,7 @@ def _coerce_scalar_to_timedelta_type(r, unit='ns', box=True, errors='raise'):
         result = pd.NaT
 
     if box:
-        result = tslib.Timedelta(result)
+        result = tslibs.Timedelta(result)
     return result
 
 

--- a/pandas/core/util/hashing.py
+++ b/pandas/core/util/hashing.py
@@ -4,7 +4,7 @@ data hash pandas / numpy objects
 import itertools
 
 import numpy as np
-from pandas._libs import hashing, tslib
+from pandas._libs import hashing, tslibs
 from pandas.core.dtypes.generic import (
     ABCMultiIndex,
     ABCIndexClass,
@@ -321,8 +321,8 @@ def _hash_scalar(val, encoding='utf8', hash_key=None):
         # for tz-aware datetimes, we need the underlying naive UTC value and
         # not the tz aware object or pd extension type (as
         # infer_dtype_from_scalar would do)
-        if not isinstance(val, tslib.Timestamp):
-            val = tslib.Timestamp(val)
+        if not isinstance(val, tslibs.Timestamp):
+            val = tslibs.Timestamp(val)
         val = val.tz_convert(None)
 
     dtype, val = infer_dtype_from_scalar(val)

--- a/pandas/errors/__init__.py
+++ b/pandas/errors/__init__.py
@@ -4,7 +4,7 @@
 Expose public exceptions & warnings
 """
 
-from pandas._libs.tslib import OutOfBoundsDatetime
+from pandas._libs.tslibs import OutOfBoundsDatetime
 
 
 class PerformanceWarning(Warning):

--- a/pandas/io/formats/format.py
+++ b/pandas/io/formats/format.py
@@ -7,6 +7,17 @@ and latex files. This module also applies to display formatting.
 from __future__ import print_function
 # pylint: disable=W0141
 
+from functools import partial
+
+import numpy as np
+
+from pandas._libs import lib
+from pandas._libs.tslibs import iNaT, Timestamp, Timedelta
+from pandas._libs.tslib import format_array_from_datetime
+
+from pandas import compat
+from pandas.compat import StringIO, lzip, map, zip, u
+
 from pandas.core.dtypes.missing import isna, notna
 from pandas.core.dtypes.common import (
     is_categorical_dtype,
@@ -26,23 +37,16 @@ from pandas.core.dtypes.generic import ABCSparseArray
 from pandas.core.base import PandasObject
 import pandas.core.common as com
 from pandas.core.index import Index, MultiIndex, _ensure_index
-from pandas import compat
-from pandas.compat import (StringIO, lzip, map, zip, u)
-
-from pandas.io.formats.terminal import get_terminal_size
 from pandas.core.config import get_option, set_option
-from pandas.io.common import (_expand_user, _stringify_path)
-from pandas.io.formats.printing import adjoin, justify, pprint_thing
-from pandas._libs import lib
-
-from pandas._libs.tslib import (iNaT, Timestamp, Timedelta,
-                                format_array_from_datetime)
 from pandas.core.indexes.datetimes import DatetimeIndex
 from pandas.core.indexes.period import PeriodIndex
-import pandas as pd
-import numpy as np
 
-from functools import partial
+from pandas.io.formats.terminal import get_terminal_size
+from pandas.io.common import (_expand_user, _stringify_path)
+from pandas.io.formats.printing import adjoin, justify, pprint_thing
+
+import pandas as pd
+
 
 common_docstring = """
     Parameters

--- a/pandas/io/json/json.py
+++ b/pandas/io/json/json.py
@@ -4,7 +4,7 @@ import os
 import numpy as np
 
 import pandas._libs.json as json
-from pandas._libs.tslib import iNaT
+from pandas._libs.tslibs import iNaT
 from pandas.compat import StringIO, long, u, to_str
 from pandas import compat, isna
 from pandas import Series, DataFrame, to_datetime, MultiIndex

--- a/pandas/io/stata.py
+++ b/pandas/io/stata.py
@@ -18,7 +18,7 @@ from collections import OrderedDict
 import numpy as np
 from dateutil.relativedelta import relativedelta
 from pandas._libs.lib import infer_dtype
-from pandas._libs.tslib import NaT, Timestamp
+from pandas._libs.tslibs import NaT, Timestamp
 from pandas._libs.writers import max_len_string_array
 
 import pandas as pd

--- a/pandas/plotting/_converter.py
+++ b/pandas/plotting/_converter.py
@@ -23,7 +23,7 @@ from pandas.core.dtypes.generic import ABCSeries
 
 from pandas.compat import lrange
 import pandas.compat as compat
-from pandas._libs import tslib
+from pandas._libs import tslibs
 import pandas.core.common as com
 from pandas.core.index import Index
 
@@ -52,7 +52,7 @@ _mpl_units = {}  # Cache for units overwritten by us
 
 def get_pairs():
     pairs = [
-        (tslib.Timestamp, DatetimeConverter),
+        (tslibs.Timestamp, DatetimeConverter),
         (Period, PeriodConverter),
         (pydt.datetime, DatetimeConverter),
         (pydt.date, DatetimeConverter),
@@ -312,7 +312,7 @@ class DatetimeConverter(dates.DateConverter):
         if isinstance(values, (datetime, pydt.date)):
             return _dt_to_float_ordinal(values)
         elif isinstance(values, np.datetime64):
-            return _dt_to_float_ordinal(tslib.Timestamp(values))
+            return _dt_to_float_ordinal(tslibs.Timestamp(values))
         elif isinstance(values, pydt.time):
             return dates.date2num(values)
         elif (is_integer(values) or is_float(values)):

--- a/pandas/tests/indexes/test_numeric.py
+++ b/pandas/tests/indexes/test_numeric.py
@@ -13,7 +13,7 @@ from pandas import (date_range, Series, Index, Float64Index,
 import pandas.util.testing as tm
 
 import pandas as pd
-from pandas._libs.tslib import Timestamp, Timedelta
+from pandas._libs.tslibs import Timestamp, Timedelta
 
 from pandas.tests.indexes.common import Base
 

--- a/pandas/tests/tslibs/test_tslib.py
+++ b/pandas/tests/tslibs/test_tslib.py
@@ -3,21 +3,21 @@
 
 from datetime import datetime, date
 
-from pandas._libs import tslib
+from pandas._libs import tslibs
 
 
 def test_normalize_date():
     value = date(2012, 9, 7)
 
-    result = tslib.normalize_date(value)
+    result = tslibs.normalize_date(value)
     assert (result == datetime(2012, 9, 7))
 
     value = datetime(2012, 9, 7, 12)
 
-    result = tslib.normalize_date(value)
+    result = tslibs.normalize_date(value)
     assert (result == datetime(2012, 9, 7))
 
     value = datetime(2007, 10, 1, 1, 12, 5, 10)
 
-    actual = tslib.normalize_date(value)
+    actual = tslibs.normalize_date(value)
     assert actual == datetime(2007, 10, 1)

--- a/pandas/tseries/frequencies.py
+++ b/pandas/tseries/frequencies.py
@@ -14,7 +14,7 @@ from pandas.core.dtypes.common import (
 
 from pandas.tseries.offsets import DateOffset
 
-from pandas._libs.tslib import Timedelta
+from pandas._libs.tslibs import Timedelta
 
 import pandas._libs.tslibs.frequencies as libfreqs
 from pandas._libs.tslibs.frequencies import (  # noqa, semi-public API

--- a/pandas/tseries/offsets.py
+++ b/pandas/tseries/offsets.py
@@ -13,7 +13,7 @@ import pandas.core.common as com
 
 # import after tools, dateutil check
 from dateutil.easter import easter
-from pandas._libs import tslib, Timestamp, OutOfBoundsDatetime, Timedelta
+from pandas._libs import tslibs, Timestamp, OutOfBoundsDatetime, Timedelta
 from pandas.util._decorators import cache_readonly
 
 from pandas._libs.tslibs import (
@@ -60,8 +60,8 @@ def as_timestamp(obj):
 def apply_wraps(func):
     @functools.wraps(func)
     def wrapper(self, other):
-        if other is tslib.NaT:
-            return tslib.NaT
+        if other is tslibs.NaT:
+            return tslibs.NaT
         elif isinstance(other, (timedelta, Tick, DateOffset)):
             # timedelta path
             return func(self, other)
@@ -89,7 +89,7 @@ def apply_wraps(func):
                 if not isinstance(self, Nano) and result.nanosecond != nano:
                     if result.tz is not None:
                         # convert to UTC
-                        value = tslib.tz_convert_single(
+                        value = conversion.tz_convert_single(
                             result.value, 'UTC', result.tz)
                     else:
                         value = result.value
@@ -103,7 +103,7 @@ def apply_wraps(func):
 
             if self.normalize:
                 # normalize_date returns normal datetime
-                result = tslib.normalize_date(result)
+                result = tslibs.normalize_date(result)
 
             if tz is not None and result.tzinfo is None:
                 result = conversion.localize_pydatetime(result, tz)

--- a/pandas/tslib.py
+++ b/pandas/tslib.py
@@ -3,5 +3,5 @@
 import warnings
 warnings.warn("The pandas.tslib module is deprecated and will be "
               "removed in a future version.", FutureWarning, stacklevel=2)
-from pandas._libs.tslib import Timestamp, Timedelta, OutOfBoundsDatetime
+from pandas._libs.tslibs import Timestamp, Timedelta, OutOfBoundsDatetime
 from pandas._libs.tslibs.nattype import NaT, NaTType


### PR DESCRIPTION
Another try at #21802.  Removing `Timedelta` from the `tslib` namespace broke a ton of imports, so this goes through and updates all of them.