### PR TITLE
DOC: Mention both series and dataframe mirror methods

### DIFF
--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -7827,7 +7827,7 @@ class NDFrame(PandasObject, SelectionMixin):
 
         Returns
         -------
-        wh : same type as caller
+        Series or DataFrame
 
         Notes
         -----
@@ -7836,9 +7836,9 @@ class NDFrame(PandasObject, SelectionMixin):
         element is used; otherwise the corresponding element from
         ``other`` is used.
 
-        The signature for :func:`DataFrame.where` or
-        :func:`DataFrame.where` differs from :func:`numpy.where`.s
-        Roughly ``df1.where(m, df2)`` is equivalent to
+        The signature for :func:`Series.where` or
+        :func:`DataFrame.where` differs from :func:`numpy.where`.
+        Roughly ``DataFrame.where(m, df2)`` is equivalent to
         ``np.where(m, df1, df2)``.
 
         For further details and examples see the ``%(name)s`` documentation in
@@ -7847,9 +7847,9 @@ class NDFrame(PandasObject, SelectionMixin):
         See Also
         --------
         :func:`DataFrame.%(name_other)s` : Return an object of same shape as
-            caller
+            caller.
         :func:`Series.%(name_other)s` : Return an object of same shape as
-            caller
+            caller.
 
         Examples
         --------

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -7832,12 +7832,13 @@ class NDFrame(PandasObject, SelectionMixin):
         Notes
         -----
         The %(name)s method is an application of the if-then idiom. For each
-        element in the calling DataFrame, if ``cond`` is ``%(cond)s`` the
-        element is used; otherwise the corresponding element from the DataFrame
+        element in the caller, if ``cond`` is ``%(cond)s`` the
+        element is used; otherwise the corresponding element from
         ``other`` is used.
 
-        The signature for :func:`DataFrame.where` differs from
-        :func:`numpy.where`. Roughly ``df1.where(m, df2)`` is equivalent to
+        The signature for :func:`DataFrame.where` or
+        :func:`DataFrame.where` differs from :func:`numpy.where`.s
+        Roughly ``df1.where(m, df2)`` is equivalent to
         ``np.where(m, df1, df2)``.
 
         For further details and examples see the ``%(name)s`` documentation in
@@ -7846,9 +7847,9 @@ class NDFrame(PandasObject, SelectionMixin):
         See Also
         --------
         :func:`DataFrame.%(name_other)s` : Return an object of same shape as
-            self
+            caller
         :func:`Series.%(name_other)s` : Return an object of same shape as
-            self
+            caller
 
         Examples
         --------

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -7847,6 +7847,8 @@ class NDFrame(PandasObject, SelectionMixin):
         --------
         :func:`DataFrame.%(name_other)s` : Return an object of same shape as
             self
+        :func:`Series.%(name_other)s` : Return an object of same shape as
+            self
 
         Examples
         --------


### PR DESCRIPTION
- [x] closes #21825

Now the automatically-generated doc features both `Series` and `Dataframe` in the _See also:_ section.
