### PR TITLE
[REF] Move constructor helpers to EA Mixin classes

### DIFF
--- a/pandas/core/arrays/datetimelike.py
+++ b/pandas/core/arrays/datetimelike.py
@@ -403,7 +403,7 @@ class DatetimeLikeArrayMixin(AttributesMixin):
             td = Timedelta(self.freq)
             return op(self, td * other)
 
-        # We should only get here with DatetimeIndex; dispatch
+        # We should only get here with Datetime Array/Index; dispatch
         # to _addsub_offset_array
         assert not is_timedelta64_dtype(self)
         return op(self, np.array(other) * self.freq)

--- a/pandas/core/arrays/datetimes.py
+++ b/pandas/core/arrays/datetimes.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from datetime import timedelta
+from datetime import datetime, timedelta
 import warnings
 
 import numpy as np
@@ -21,6 +21,8 @@ from pandas.core.dtypes.common import (
     is_timedelta64_dtype,
     _ensure_int64)
 from pandas.core.dtypes.dtypes import DatetimeTZDtype
+
+from pandas.core.algorithms import checked_add_with_arr
 
 from pandas.tseries.frequencies import to_offset, DateOffset
 from pandas.tseries.offsets import Tick
@@ -250,8 +252,41 @@ class DatetimeArrayMixin(DatetimeLikeArrayMixin):
     # -----------------------------------------------------------------
     # Arithmetic Methods
 
+    def _sub_datelike(self, other):
+        # subtract a datetime from myself, yielding a ndarray[timedelta64[ns]]
+        if isinstance(other, (DatetimeArrayMixin, np.ndarray)):
+            if isinstance(other, np.ndarray):
+                # if other is an ndarray, we assume it is datetime64-dtype
+                other = type(self)(other)
+            # require tz compat
+            if not self._has_same_tz(other):
+                raise TypeError("{cls} subtraction must have the same "
+                                "timezones or no timezones"
+                                .format(cls=type(self).__name__))
+            result = self._sub_datelike_dti(other)
+        elif isinstance(other, (datetime, np.datetime64)):
+            assert other is not NaT
+            other = Timestamp(other)
+            if other is NaT:
+                return self - NaT
+            elif not self._has_same_tz(other):
+                # require tz compat
+                raise TypeError("Timestamp subtraction must have the same "
+                                "timezones or no timezones")
+            else:
+                i8 = self.asi8
+                result = checked_add_with_arr(i8, -other.value,
+                                              arr_mask=self._isnan)
+                result = self._maybe_mask_results(result,
+                                                  fill_value=iNaT)
+        else:
+            raise TypeError("cannot subtract {cls} and {typ}"
+                            .format(cls=type(self).__name__,
+                                    typ=type(other).__name__))
+        return result.view('timedelta64[ns]')
+
     def _sub_datelike_dti(self, other):
-        """subtraction of two DatetimeIndexes"""
+        """subtraction of two Datetime Arrays/Indexes"""
         if not len(self) == len(other):
             raise ValueError("cannot add indices of unequal length")
 
@@ -516,6 +551,48 @@ class DatetimeArrayMixin(DatetimeLikeArrayMixin):
         datetimes : ndarray
         """
         return tslib.ints_to_pydatetime(self.asi8, tz=self.tz)
+
+    def normalize(self):
+        """
+        Convert times to midnight.
+
+        The time component of the date-time is converted to midnight i.e.
+        00:00:00. This is useful in cases, when the time does not matter.
+        Length is unaltered. The timezones are unaffected.
+
+        This method is available on Series with datetime values under
+        the ``.dt`` accessor, and directly on DatetimeIndex.
+
+        Returns
+        -------
+        DatetimeArray, DatetimeIndex or Series
+            The same type as the original data. Series will have the same
+            name and index. DatetimeIndex will have the same name.
+
+        See Also
+        --------
+        floor : Floor the datetimes to the specified freq.
+        ceil : Ceil the datetimes to the specified freq.
+        round : Round the datetimes to the specified freq.
+
+        Examples
+        --------
+        >>> idx = pd.DatetimeIndex(start='2014-08-01 10:00', freq='H',
+        ...                        periods=3, tz='Asia/Calcutta')
+        >>> idx
+        DatetimeIndex(['2014-08-01 10:00:00+05:30',
+                       '2014-08-01 11:00:00+05:30',
+                       '2014-08-01 12:00:00+05:30'],
+                        dtype='datetime64[ns, Asia/Calcutta]', freq='H')
+        >>> idx.normalize()
+        DatetimeIndex(['2014-08-01 00:00:00+05:30',
+                       '2014-08-01 00:00:00+05:30',
+                       '2014-08-01 00:00:00+05:30'],
+                       dtype='datetime64[ns, Asia/Calcutta]', freq=None)
+        """
+        new_values = conversion.normalize_i8_timestamps(self.asi8, self.tz)
+        return type(self)(new_values,
+                          freq='infer').tz_localize(self.tz)
 
     # -----------------------------------------------------------------
     # Properties - Vectorized Timestamp Properties/Methods

--- a/pandas/core/arrays/period.py
+++ b/pandas/core/arrays/period.py
@@ -5,20 +5,25 @@ import warnings
 import numpy as np
 
 from pandas._libs import lib
-from pandas._libs.tslib import NaT, iNaT
 from pandas._libs.tslibs.period import (
     Period, IncompatibleFrequency, DIFFERENT_FREQ_INDEX,
     get_period_field_arr, period_asfreq_arr)
-from pandas._libs.tslibs import period as libperiod
-from pandas._libs.tslibs.timedeltas import delta_to_nanoseconds
+from pandas._libs.tslibs import (
+    NaT, iNaT,
+    delta_to_nanoseconds,
+    period as libperiod)
 from pandas._libs.tslibs.fields import isleapyear_arr
 
 from pandas import compat
+from pandas.compat import zip
 from pandas.util._decorators import cache_readonly
 
 from pandas.core.dtypes.common import (
     is_integer_dtype, is_float_dtype, is_period_dtype)
 from pandas.core.dtypes.dtypes import PeriodDtype
+from pandas.core.dtypes.generic import ABCSeries
+
+import pandas.core.common as com
 
 from pandas.tseries import frequencies
 from pandas.tseries.offsets import Tick, DateOffset
@@ -156,6 +161,25 @@ class PeriodArrayMixin(DatetimeLikeArrayMixin):
             raise ValueError('freq is not specified and cannot be inferred')
         result._freq = Period._maybe_convert_freq(freq)
         return result
+
+    @classmethod
+    def _generate_range(cls, start, end, periods, freq, fields):
+        if freq is not None:
+            freq = Period._maybe_convert_freq(freq)
+
+        field_count = len(fields)
+        if com._count_not_none(start, end) > 0:
+            if field_count > 0:
+                raise ValueError('Can either instantiate from fields '
+                                 'or endpoints, but not both')
+            subarr, freq = _get_ordinal_range(start, end, periods, freq)
+        elif field_count > 0:
+            subarr, freq = _range_from_fields(freq=freq, **fields)
+        else:
+            raise ValueError('Not enough parameters to construct '
+                             'Period range')
+
+        return subarr, freq
 
     # --------------------------------------------------------------------
     # Vectorized analogues of Period properties
@@ -371,3 +395,102 @@ class PeriodArrayMixin(DatetimeLikeArrayMixin):
 
 
 PeriodArrayMixin._add_comparison_methods()
+
+
+# -----------------------------------------------------------------
+# Constructor Helpers
+
+def _get_ordinal_range(start, end, periods, freq, mult=1):
+    if com._count_not_none(start, end, periods) != 2:
+        raise ValueError('Of the three parameters: start, end, and periods, '
+                         'exactly two must be specified')
+
+    if freq is not None:
+        _, mult = frequencies.get_freq_code(freq)
+
+    if start is not None:
+        start = Period(start, freq)
+    if end is not None:
+        end = Period(end, freq)
+
+    is_start_per = isinstance(start, Period)
+    is_end_per = isinstance(end, Period)
+
+    if is_start_per and is_end_per and start.freq != end.freq:
+        raise ValueError('start and end must have same freq')
+    if (start is NaT or end is NaT):
+        raise ValueError('start and end must not be NaT')
+
+    if freq is None:
+        if is_start_per:
+            freq = start.freq
+        elif is_end_per:
+            freq = end.freq
+        else:  # pragma: no cover
+            raise ValueError('Could not infer freq from start/end')
+
+    if periods is not None:
+        periods = periods * mult
+        if start is None:
+            data = np.arange(end.ordinal - periods + mult,
+                             end.ordinal + 1, mult,
+                             dtype=np.int64)
+        else:
+            data = np.arange(start.ordinal, start.ordinal + periods, mult,
+                             dtype=np.int64)
+    else:
+        data = np.arange(start.ordinal, end.ordinal + 1, mult, dtype=np.int64)
+
+    return data, freq
+
+
+def _range_from_fields(year=None, month=None, quarter=None, day=None,
+                       hour=None, minute=None, second=None, freq=None):
+    if hour is None:
+        hour = 0
+    if minute is None:
+        minute = 0
+    if second is None:
+        second = 0
+    if day is None:
+        day = 1
+
+    ordinals = []
+
+    if quarter is not None:
+        if freq is None:
+            freq = 'Q'
+            base = frequencies.FreqGroup.FR_QTR
+        else:
+            base, mult = frequencies.get_freq_code(freq)
+            if base != frequencies.FreqGroup.FR_QTR:
+                raise AssertionError("base must equal FR_QTR")
+
+        year, quarter = _make_field_arrays(year, quarter)
+        for y, q in zip(year, quarter):
+            y, m = libperiod._quarter_to_myear(y, q, freq)
+            val = libperiod.period_ordinal(y, m, 1, 1, 1, 1, 0, 0, base)
+            ordinals.append(val)
+    else:
+        base, mult = frequencies.get_freq_code(freq)
+        arrays = _make_field_arrays(year, month, day, hour, minute, second)
+        for y, mth, d, h, mn, s in zip(*arrays):
+            ordinals.append(libperiod.period_ordinal(
+                y, mth, d, h, mn, s, 0, 0, base))
+
+    return np.array(ordinals, dtype=np.int64), freq
+
+
+def _make_field_arrays(*fields):
+    length = None
+    for x in fields:
+        if isinstance(x, (list, np.ndarray, ABCSeries)):
+            if length is not None and len(x) != length:
+                raise ValueError('Mismatched Period array lengths')
+            elif length is None:
+                length = len(x)
+
+    arrays = [np.asarray(x) if isinstance(x, (np.ndarray, list, ABCSeries))
+              else np.repeat(x, length) for x in fields]
+
+    return arrays

--- a/pandas/core/indexes/datetimes.py
+++ b/pandas/core/indexes/datetimes.py
@@ -32,7 +32,6 @@ from pandas.core.dtypes.dtypes import DatetimeTZDtype
 from pandas.core.dtypes.missing import isna
 
 import pandas.core.dtypes.concat as _concat
-from pandas.core.algorithms import checked_add_with_arr
 from pandas.core.arrays.datetimes import DatetimeArrayMixin
 
 from pandas.core.indexes.base import Index, _index_shared_docs
@@ -781,38 +780,6 @@ class DatetimeIndex(DatetimeArrayMixin, DatelikeOps, TimelikeOps,
         else:
             raise Exception("invalid pickle state")
     _unpickle_compat = __setstate__
-
-    def _sub_datelike(self, other):
-        # subtract a datetime from myself, yielding a ndarray[timedelta64[ns]]
-        if isinstance(other, (DatetimeIndex, np.ndarray)):
-            # if other is an ndarray, we assume it is datetime64-dtype
-            other = DatetimeIndex(other)
-            # require tz compat
-            if not self._has_same_tz(other):
-                raise TypeError("{cls} subtraction must have the same "
-                                "timezones or no timezones"
-                                .format(cls=type(self).__name__))
-            result = self._sub_datelike_dti(other)
-        elif isinstance(other, (datetime, np.datetime64)):
-            assert other is not tslibs.NaT
-            other = Timestamp(other)
-            if other is tslibs.NaT:
-                return self - tslibs.NaT
-            # require tz compat
-            elif not self._has_same_tz(other):
-                raise TypeError("Timestamp subtraction must have the same "
-                                "timezones or no timezones")
-            else:
-                i8 = self.asi8
-                result = checked_add_with_arr(i8, -other.value,
-                                              arr_mask=self._isnan)
-                result = self._maybe_mask_results(result,
-                                                  fill_value=tslibs.iNaT)
-        else:
-            raise TypeError("cannot subtract {cls} and {typ}"
-                            .format(cls=type(self).__name__,
-                                    typ=type(other).__name__))
-        return result.view('timedelta64[ns]')
 
     def _maybe_update_attributes(self, attrs):
         """ Update Index attributes (e.g. freq) depending on op """
@@ -1581,48 +1548,11 @@ class DatetimeIndex(DatetimeArrayMixin, DatelikeOps, TimelikeOps,
     is_year_end = _wrap_field_accessor('is_year_end')
     is_leap_year = _wrap_field_accessor('is_leap_year')
 
+    @Appender(DatetimeArrayMixin.normalize.__doc__)
     def normalize(self):
-        """
-        Convert times to midnight.
-
-        The time component of the date-time is converted to midnight i.e.
-        00:00:00. This is useful in cases, when the time does not matter.
-        Length is unaltered. The timezones are unaffected.
-
-        This method is available on Series with datetime values under
-        the ``.dt`` accessor, and directly on DatetimeIndex.
-
-        Returns
-        -------
-        DatetimeIndex or Series
-            The same type as the original data. Series will have the same
-            name and index. DatetimeIndex will have the same name.
-
-        See Also
-        --------
-        floor : Floor the datetimes to the specified freq.
-        ceil : Ceil the datetimes to the specified freq.
-        round : Round the datetimes to the specified freq.
-
-        Examples
-        --------
-        >>> idx = pd.DatetimeIndex(start='2014-08-01 10:00', freq='H',
-        ...                        periods=3, tz='Asia/Calcutta')
-        >>> idx
-        DatetimeIndex(['2014-08-01 10:00:00+05:30',
-                       '2014-08-01 11:00:00+05:30',
-                       '2014-08-01 12:00:00+05:30'],
-                        dtype='datetime64[ns, Asia/Calcutta]', freq='H')
-        >>> idx.normalize()
-        DatetimeIndex(['2014-08-01 00:00:00+05:30',
-                       '2014-08-01 00:00:00+05:30',
-                       '2014-08-01 00:00:00+05:30'],
-                       dtype='datetime64[ns, Asia/Calcutta]', freq=None)
-        """
-        new_values = conversion.normalize_i8_timestamps(self.asi8, self.tz)
-        return DatetimeIndex(new_values,
-                             freq='infer',
-                             name=self.name).tz_localize(self.tz)
+        res = DatetimeArrayMixin.normalize(self)
+        res.name = self.name
+        return res
 
     @Substitution(klass='DatetimeIndex')
     @Appender(_shared_docs['searchsorted'])

--- a/pandas/core/indexes/period.py
+++ b/pandas/core/indexes/period.py
@@ -16,7 +16,6 @@ from pandas.core.dtypes.common import (
     is_bool_dtype,
     pandas_dtype,
     _ensure_object)
-from pandas.core.dtypes.generic import ABCSeries
 
 import pandas.tseries.frequencies as frequencies
 from pandas.tseries.frequencies import get_freq_code as _gfc
@@ -29,7 +28,7 @@ from pandas._libs.lib import infer_dtype
 from pandas._libs import tslib, index as libindex
 from pandas._libs.tslibs.period import (Period, IncompatibleFrequency,
                                         DIFFERENT_FREQ_INDEX,
-                                        _validate_end_alias, _quarter_to_myear)
+                                        _validate_end_alias)
 from pandas._libs.tslibs import resolution, period
 
 from pandas.core.arrays.period import PeriodArrayMixin
@@ -39,7 +38,6 @@ from pandas.core.indexes.base import _index_shared_docs, _ensure_index
 from pandas import compat
 from pandas.util._decorators import (Appender, Substitution, cache_readonly,
                                      deprecate_kwarg)
-from pandas.compat import zip
 
 import pandas.core.indexes.base as ibase
 _index_doc_kwargs = dict(ibase._index_doc_kwargs)
@@ -265,25 +263,6 @@ class PeriodIndex(PeriodArrayMixin, DatelikeOps, DatetimeIndexOpsMixin,
     @cache_readonly
     def _engine(self):
         return self._engine_type(lambda: self, len(self))
-
-    @classmethod
-    def _generate_range(cls, start, end, periods, freq, fields):
-        if freq is not None:
-            freq = Period._maybe_convert_freq(freq)
-
-        field_count = len(fields)
-        if com._count_not_none(start, end) > 0:
-            if field_count > 0:
-                raise ValueError('Can either instantiate from fields '
-                                 'or endpoints, but not both')
-            subarr, freq = _get_ordinal_range(start, end, periods, freq)
-        elif field_count > 0:
-            subarr, freq = _range_from_fields(freq=freq, **fields)
-        else:
-            raise ValueError('Not enough parameters to construct '
-                             'Period range')
-
-        return subarr, freq
 
     @classmethod
     def _simple_new(cls, values, name=None, freq=None, **kwargs):
@@ -875,102 +854,6 @@ PeriodIndex._add_comparison_methods()
 PeriodIndex._add_numeric_methods_disabled()
 PeriodIndex._add_logical_methods_disabled()
 PeriodIndex._add_datetimelike_methods()
-
-
-def _get_ordinal_range(start, end, periods, freq, mult=1):
-    if com._count_not_none(start, end, periods) != 2:
-        raise ValueError('Of the three parameters: start, end, and periods, '
-                         'exactly two must be specified')
-
-    if freq is not None:
-        _, mult = _gfc(freq)
-
-    if start is not None:
-        start = Period(start, freq)
-    if end is not None:
-        end = Period(end, freq)
-
-    is_start_per = isinstance(start, Period)
-    is_end_per = isinstance(end, Period)
-
-    if is_start_per and is_end_per and start.freq != end.freq:
-        raise ValueError('start and end must have same freq')
-    if (start is tslib.NaT or end is tslib.NaT):
-        raise ValueError('start and end must not be NaT')
-
-    if freq is None:
-        if is_start_per:
-            freq = start.freq
-        elif is_end_per:
-            freq = end.freq
-        else:  # pragma: no cover
-            raise ValueError('Could not infer freq from start/end')
-
-    if periods is not None:
-        periods = periods * mult
-        if start is None:
-            data = np.arange(end.ordinal - periods + mult,
-                             end.ordinal + 1, mult,
-                             dtype=np.int64)
-        else:
-            data = np.arange(start.ordinal, start.ordinal + periods, mult,
-                             dtype=np.int64)
-    else:
-        data = np.arange(start.ordinal, end.ordinal + 1, mult, dtype=np.int64)
-
-    return data, freq
-
-
-def _range_from_fields(year=None, month=None, quarter=None, day=None,
-                       hour=None, minute=None, second=None, freq=None):
-    if hour is None:
-        hour = 0
-    if minute is None:
-        minute = 0
-    if second is None:
-        second = 0
-    if day is None:
-        day = 1
-
-    ordinals = []
-
-    if quarter is not None:
-        if freq is None:
-            freq = 'Q'
-            base = frequencies.FreqGroup.FR_QTR
-        else:
-            base, mult = _gfc(freq)
-            if base != frequencies.FreqGroup.FR_QTR:
-                raise AssertionError("base must equal FR_QTR")
-
-        year, quarter = _make_field_arrays(year, quarter)
-        for y, q in zip(year, quarter):
-            y, m = _quarter_to_myear(y, q, freq)
-            val = period.period_ordinal(y, m, 1, 1, 1, 1, 0, 0, base)
-            ordinals.append(val)
-    else:
-        base, mult = _gfc(freq)
-        arrays = _make_field_arrays(year, month, day, hour, minute, second)
-        for y, mth, d, h, mn, s in zip(*arrays):
-            ordinals.append(period.period_ordinal(
-                y, mth, d, h, mn, s, 0, 0, base))
-
-    return np.array(ordinals, dtype=np.int64), freq
-
-
-def _make_field_arrays(*fields):
-    length = None
-    for x in fields:
-        if isinstance(x, (list, np.ndarray, ABCSeries)):
-            if length is not None and len(x) != length:
-                raise ValueError('Mismatched Period array lengths')
-            elif length is None:
-                length = len(x)
-
-    arrays = [np.asarray(x) if isinstance(x, (np.ndarray, list, ABCSeries))
-              else np.repeat(x, length) for x in fields]
-
-    return arrays
 
 
 def pnow(freq=None):


### PR DESCRIPTION
After this:

- Tests
- Comparisons
- Tests
- Deal with the fact that DatetimeIndex caches ranges, only feasible because of immutability
- Tests!
- formatting/`__repr__` methods
- Teeeeeests
- Double-check docstring accuracy
