### PR TITLE
[CLN] cleanup import reverse-dependencies

### DIFF
--- a/pandas/io/clipboards.py
+++ b/pandas/io/clipboards.py
@@ -1,7 +1,10 @@
 """ io on the clipboard """
-from pandas import compat, get_option, option_context, DataFrame
-from pandas.compat import StringIO, PY2, PY3
 import warnings
+
+from pandas.compat import StringIO, PY2, PY3
+
+from pandas.core.dtypes.generic import ABCDataFrame
+from pandas import compat, get_option, option_context
 
 
 def read_clipboard(sep=r'\s+', **kwargs):  # pragma: no cover
@@ -131,7 +134,7 @@ def to_clipboard(obj, excel=True, sep=None, **kwargs):  # pragma: no cover
     elif sep is not None:
         warnings.warn('to_clipboard with excel=False ignores the sep argument')
 
-    if isinstance(obj, DataFrame):
+    if isinstance(obj, ABCDataFrame):
         # str(df) has various unhelpful defaults, like truncation
         with option_context('display.max_colwidth', 999999):
             objstr = obj.to_string(**kwargs)

--- a/pandas/io/excel.py
+++ b/pandas/io/excel.py
@@ -9,29 +9,32 @@ from datetime import datetime, date, time, MINYEAR, timedelta
 import os
 import abc
 import warnings
-import numpy as np
+from textwrap import fill
 from io import UnsupportedOperation
+from distutils.version import LooseVersion
+
+import numpy as np
+
+import pandas._libs.json as json
+from pandas.util._decorators import Appender, deprecate_kwarg
+from pandas.errors import EmptyDataError
+
+import pandas.compat as compat
+from pandas.compat import (map, zip, reduce, range, lrange, u, add_metaclass,
+                           string_types, OrderedDict)
 
 from pandas.core.dtypes.common import (
     is_integer, is_float,
     is_bool, is_list_like)
 
+from pandas.core import config
 from pandas.core.frame import DataFrame
+
 from pandas.io.parsers import TextParser
-from pandas.errors import EmptyDataError
 from pandas.io.common import (_is_url, _urlopen, _validate_header_arg,
                               get_filepath_or_buffer, _NA_VALUES,
                               _stringify_path)
-import pandas._libs.json as json
-from pandas.compat import (map, zip, reduce, range, lrange, u, add_metaclass,
-                           string_types, OrderedDict)
-from pandas.core import config
 from pandas.io.formats.printing import pprint_thing
-import pandas.compat as compat
-from warnings import warn
-from distutils.version import LooseVersion
-from pandas.util._decorators import Appender, deprecate_kwarg
-from textwrap import fill
 
 __all__ = ["read_excel", "ExcelWriter", "ExcelFile"]
 
@@ -527,8 +530,8 @@ class ExcelFile(object):
                                       "is not implemented")
 
         if parse_dates is True and index_col is None:
-            warn("The 'parse_dates=True' keyword of read_excel was provided"
-                 " without an 'index_col' keyword value.")
+            warnings.warn("The 'parse_dates=True' keyword of read_excel was "
+                          "provided without an 'index_col' keyword value.")
 
         import xlrd
         from xlrd import (xldate, XL_CELL_DATE,

--- a/pandas/io/formats/excel.py
+++ b/pandas/io/formats/excel.py
@@ -8,12 +8,15 @@ import itertools
 import numpy as np
 
 from pandas.compat import reduce
-from pandas.io.formats.css import CSSResolver, CSSWarning
-from pandas.io.formats.printing import pprint_thing
 import pandas.core.common as com
+
 from pandas.core.dtypes.common import is_float, is_scalar
 from pandas.core.dtypes import missing
-from pandas import Index, MultiIndex, PeriodIndex
+from pandas.core.dtypes.generic import ABCMultiIndex, ABCPeriodIndex
+from pandas import Index
+
+from pandas.io.formats.css import CSSResolver, CSSWarning
+from pandas.io.formats.printing import pprint_thing
 from pandas.io.formats.format import get_level_lengths
 
 
@@ -414,7 +417,7 @@ class ExcelFormatter(object):
         coloffset = 0
         lnum = 0
 
-        if self.index and isinstance(self.df.index, MultiIndex):
+        if self.index and isinstance(self.df.index, ABCMultiIndex):
             coloffset = len(self.df.index[0]) - 1
 
         if self.merge_cells:
@@ -449,7 +452,7 @@ class ExcelFormatter(object):
 
             if self.index:
                 coloffset = 1
-                if isinstance(self.df.index, MultiIndex):
+                if isinstance(self.df.index, ABCMultiIndex):
                     coloffset = len(self.df.index[0])
 
             colnames = self.columns
@@ -466,7 +469,7 @@ class ExcelFormatter(object):
                                 header_style)
 
     def _format_header(self):
-        if isinstance(self.columns, MultiIndex):
+        if isinstance(self.columns, ABCMultiIndex):
             gen = self._format_header_mi()
         else:
             gen = self._format_header_regular()
@@ -483,7 +486,7 @@ class ExcelFormatter(object):
 
     def _format_body(self):
 
-        if isinstance(self.df.index, MultiIndex):
+        if isinstance(self.df.index, ABCMultiIndex):
             return self._format_hierarchical_rows()
         else:
             return self._format_regular_rows()
@@ -507,7 +510,7 @@ class ExcelFormatter(object):
             else:
                 index_label = self.df.index.names[0]
 
-            if isinstance(self.columns, MultiIndex):
+            if isinstance(self.columns, ABCMultiIndex):
                 self.rowcounter += 1
 
             if index_label and self.header is not False:
@@ -516,7 +519,7 @@ class ExcelFormatter(object):
 
             # write index_values
             index_values = self.df.index
-            if isinstance(self.df.index, PeriodIndex):
+            if isinstance(self.df.index, ABCPeriodIndex):
                 index_values = self.df.index.to_timestamp()
 
             for idx, idxval in enumerate(index_values):
@@ -548,7 +551,7 @@ class ExcelFormatter(object):
             # with index names (blank if None) for
             # unambigous round-trip, unless not merging,
             # in which case the names all go on one row Issue #11328
-            if isinstance(self.columns, MultiIndex) and self.merge_cells:
+            if isinstance(self.columns, ABCMultiIndex) and self.merge_cells:
                 self.rowcounter += 1
 
             # if index labels are not empty go ahead and dump

--- a/pandas/io/formats/format.py
+++ b/pandas/io/formats/format.py
@@ -12,7 +12,7 @@ from functools import partial
 import numpy as np
 
 from pandas._libs import lib
-from pandas._libs.tslibs import iNaT, Timestamp, Timedelta
+from pandas._libs.tslibs import NaT, iNaT, Timestamp, Timedelta
 from pandas._libs.tslib import format_array_from_datetime
 
 from pandas import compat
@@ -33,19 +33,17 @@ from pandas.core.dtypes.common import (
     is_datetime64_dtype,
     is_timedelta64_dtype,
     is_list_like)
-from pandas.core.dtypes.generic import ABCSparseArray
+from pandas.core.dtypes.generic import ABCSparseArray, ABCMultiIndex
 from pandas.core.base import PandasObject
 import pandas.core.common as com
-from pandas.core.index import Index, MultiIndex, _ensure_index
+from pandas.core.index import Index, _ensure_index
 from pandas.core.config import get_option, set_option
 from pandas.core.indexes.datetimes import DatetimeIndex
 from pandas.core.indexes.period import PeriodIndex
 
 from pandas.io.formats.terminal import get_terminal_size
-from pandas.io.common import (_expand_user, _stringify_path)
+from pandas.io.common import _expand_user, _stringify_path
 from pandas.io.formats.printing import adjoin, justify, pprint_thing
-
-import pandas as pd
 
 
 common_docstring = """
@@ -248,7 +246,7 @@ class SeriesFormatter(object):
 
     def _get_formatted_index(self):
         index = self.tr_series.index
-        is_multi = isinstance(index, MultiIndex)
+        is_multi = isinstance(index, ABCMultiIndex)
 
         if is_multi:
             have_header = any(name for name in index.names)
@@ -768,7 +766,7 @@ class DataFrameFormatter(TableFormatter):
 
         columns = frame.columns
 
-        if isinstance(columns, MultiIndex):
+        if isinstance(columns, ABCMultiIndex):
             fmt_columns = columns.format(sparsify=False, adjoin=False)
             fmt_columns = lzip(*fmt_columns)
             dtypes = self.frame.dtypes._values
@@ -824,7 +822,7 @@ class DataFrameFormatter(TableFormatter):
 
         fmt = self._get_formatter('__index__')
 
-        if isinstance(index, MultiIndex):
+        if isinstance(index, ABCMultiIndex):
             fmt_index = index.format(sparsify=self.sparsify, adjoin=False,
                                      names=show_index_names, formatter=fmt)
         else:
@@ -850,7 +848,7 @@ class DataFrameFormatter(TableFormatter):
     def _get_column_name_list(self):
         names = []
         columns = self.frame.columns
-        if isinstance(columns, MultiIndex):
+        if isinstance(columns, ABCMultiIndex):
             names.extend('' if name is None else name
                          for name in columns.names)
         else:
@@ -937,7 +935,7 @@ class GenericArrayFormatter(object):
             if self.na_rep is not None and is_scalar(x) and isna(x):
                 if x is None:
                     return 'None'
-                elif x is pd.NaT:
+                elif x is NaT:
                     return 'NaT'
                 return self.na_rep
             elif isinstance(x, PandasObject):
@@ -1415,7 +1413,7 @@ def _trim_zeros(str_floats, na_rep='NaN'):
 
 
 def _has_names(index):
-    if isinstance(index, MultiIndex):
+    if isinstance(index, ABCMultiIndex):
         return com._any_not_none(*index.names)
     else:
         return index.name is not None

--- a/pandas/io/formats/html.py
+++ b/pandas/io/formats/html.py
@@ -8,12 +8,14 @@ from distutils.version import LooseVersion
 
 from textwrap import dedent
 
-import pandas.core.common as com
-from pandas.core.index import MultiIndex
 from pandas import compat
 from pandas.compat import (lzip, range, map, zip, u,
                            OrderedDict, unichr)
+
+import pandas.core.common as com
+from pandas.core.dtypes.generic import ABCMultiIndex
 from pandas.core.config import get_option
+
 from pandas.io.formats.printing import pprint_thing
 from pandas.io.formats.format import (get_level_lengths,
                                       buffer_put_lines)
@@ -117,7 +119,7 @@ class HTMLFormatter(TableFormatter):
                          ('tbody tr th',
                           'vertical-align',
                           'top')]
-        if isinstance(self.columns, MultiIndex):
+        if isinstance(self.columns, ABCMultiIndex):
             element_props.append(('thead tr th',
                                   'text-align',
                                   'left'))
@@ -205,7 +207,7 @@ class HTMLFormatter(TableFormatter):
             else:
                 row = []
 
-            if isinstance(self.columns, MultiIndex):
+            if isinstance(self.columns, ABCMultiIndex):
                 if self.fmt.has_column_names and self.fmt.index:
                     row.append(single_column_table(self.columns.names))
                 else:
@@ -224,7 +226,7 @@ class HTMLFormatter(TableFormatter):
 
         indent += self.indent_delta
 
-        if isinstance(self.columns, MultiIndex):
+        if isinstance(self.columns, ABCMultiIndex):
             template = 'colspan="{span:d}" halign="left"'
 
             if self.fmt.sparsify:
@@ -337,7 +339,7 @@ class HTMLFormatter(TableFormatter):
 
         # write values
         if self.fmt.index:
-            if isinstance(self.frame.index, MultiIndex):
+            if isinstance(self.frame.index, ABCMultiIndex):
                 self._write_hierarchical_rows(fmt_values, indent)
             else:
                 self._write_regular_rows(fmt_values, indent)

--- a/pandas/io/formats/latex.py
+++ b/pandas/io/formats/latex.py
@@ -2,14 +2,16 @@
 """
 Module for formatting output data in Latex.
 """
-
 from __future__ import print_function
 
-from pandas.core.index import MultiIndex
+import numpy as np
+
 from pandas import compat
 from pandas.compat import range, map, zip, u
+
+from pandas.core.dtypes.generic import ABCMultiIndex
+
 from pandas.io.formats.format import TableFormatter
-import numpy as np
 
 
 class LatexFormatter(TableFormatter):
@@ -63,7 +65,7 @@ class LatexFormatter(TableFormatter):
                 return 'l'
 
         # reestablish the MultiIndex that has been joined by _to_str_column
-        if self.fmt.index and isinstance(self.frame.index, MultiIndex):
+        if self.fmt.index and isinstance(self.frame.index, ABCMultiIndex):
             out = self.frame.index.format(
                 adjoin=False, sparsify=self.fmt.sparsify,
                 names=self.fmt.has_index_names, na_rep=self.fmt.na_rep

--- a/pandas/io/pytables.py
+++ b/pandas/io/pytables.py
@@ -11,6 +11,16 @@ import copy
 import itertools
 import warnings
 import os
+from distutils.version import LooseVersion
+
+import numpy as np
+
+from pandas._libs import algos, lib, writers as libwriters
+from pandas._libs.tslibs import timezones
+
+from pandas.errors import PerformanceWarning
+from pandas import compat
+from pandas.compat import u_safe as u, PY3, range, lrange, string_types, filter
 
 from pandas.core.dtypes.common import (
     is_list_like,
@@ -23,17 +33,10 @@ from pandas.core.dtypes.common import (
     _ensure_platform_int)
 from pandas.core.dtypes.missing import array_equivalent
 
-import numpy as np
-from pandas import (Series, DataFrame, Panel, Index,
-                    MultiIndex, Int64Index, isna, concat, to_datetime,
-                    SparseSeries, SparseDataFrame, PeriodIndex,
-                    DatetimeIndex, TimedeltaIndex)
 from pandas.core import config
-from pandas.io.common import _stringify_path
+from pandas.core.config import get_option
 from pandas.core.sparse.array import BlockIndex, IntIndex
 from pandas.core.base import StringMixin
-from pandas.io.formats.printing import adjoin, pprint_thing
-from pandas.errors import PerformanceWarning
 import pandas.core.common as com
 from pandas.core.algorithms import match, unique
 from pandas.core.arrays.categorical import (Categorical,
@@ -42,15 +45,15 @@ from pandas.core.internals import (BlockManager, make_block,
                                    _block2d_to_blocknd,
                                    _factor_indexer, _block_shape)
 from pandas.core.index import _ensure_index
-from pandas import compat
-from pandas.compat import u_safe as u, PY3, range, lrange, string_types, filter
-from pandas.core.config import get_option
 from pandas.core.computation.pytables import Expr, maybe_expression
 
-from pandas._libs import algos, lib, writers as libwriters
-from pandas._libs.tslibs import timezones
+from pandas.io.common import _stringify_path
+from pandas.io.formats.printing import adjoin, pprint_thing
 
-from distutils.version import LooseVersion
+from pandas import (Series, DataFrame, Panel, Index,
+                    MultiIndex, Int64Index, isna, concat, to_datetime,
+                    SparseSeries, SparseDataFrame, PeriodIndex,
+                    DatetimeIndex, TimedeltaIndex)
 
 # versioning attribute
 _version = '0.15.2'

--- a/pandas/io/sas/sas7bdat.py
+++ b/pandas/io/sas/sas7bdat.py
@@ -13,15 +13,19 @@ Partial documentation of the file format:
 Reference for binary data compression:
   http://collaboration.cmc.ec.gc.ca/science/rpn/biblio/ddj/Website/articles/CUJ/1992/9210/ross/ross.htm
 """
-
-import pandas as pd
-from pandas import compat
-from pandas.io.common import get_filepath_or_buffer, BaseIterator
-from pandas.errors import EmptyDataError
-import numpy as np
+from datetime import datetime
 import struct
+
+import numpy as np
+
+from pandas import compat
+from pandas.errors import EmptyDataError
+
+from pandas.io.common import get_filepath_or_buffer, BaseIterator
 import pandas.io.sas.sas_constants as const
 from pandas.io.sas._sas import Parser
+
+import pandas as pd
 
 
 class _subheader_pointer(object):
@@ -169,7 +173,7 @@ class SAS7BDATReader(BaseIterator):
                 self.encoding or self.default_encoding)
 
         # Timestamp is epoch 01/01/1960
-        epoch = pd.datetime(1960, 1, 1)
+        epoch = datetime(1960, 1, 1)
         x = self._read_float(const.date_created_offset + align1,
                              const.date_created_length)
         self.date_created = epoch + pd.to_timedelta(x, unit='s')

--- a/pandas/io/sas/sas_xport.py
+++ b/pandas/io/sas/sas_xport.py
@@ -9,13 +9,16 @@ https://support.sas.com/techsup/technote/ts140.pdf
 """
 
 from datetime import datetime
-import pandas as pd
-from pandas.io.common import get_filepath_or_buffer, BaseIterator
-from pandas import compat
 import struct
-import numpy as np
-from pandas.util._decorators import Appender
 import warnings
+
+import numpy as np
+
+from pandas.util._decorators import Appender
+from pandas import compat
+
+from pandas.io.common import get_filepath_or_buffer, BaseIterator
+import pandas as pd
 
 _correct_line1 = ("HEADER RECORD*******LIBRARY HEADER RECORD!!!!!!!"
                   "000000000000000000000000000000  ")

--- a/pandas/io/stata.py
+++ b/pandas/io/stata.py
@@ -14,14 +14,15 @@ import datetime
 import struct
 import sys
 from collections import OrderedDict
+import warnings
 
 import numpy as np
 from dateutil.relativedelta import relativedelta
+
 from pandas._libs.lib import infer_dtype
 from pandas._libs.tslibs import NaT, Timestamp
 from pandas._libs.writers import max_len_string_array
 
-import pandas as pd
 from pandas import compat, to_timedelta, to_datetime, isna, DatetimeIndex
 from pandas.compat import (lrange, lmap, lzip, text_type, string_types, range,
                            zip, BytesIO)
@@ -317,12 +318,12 @@ def _stata_elapsed_date_to_datetime_vec(dates, fmt):
         ms = dates
         conv_dates = convert_delta_safe(base, ms, 'ms')
     elif fmt.startswith(("%tC", "tC")):
-        from warnings import warn
 
-        warn("Encountered %tC format. Leaving in Stata Internal Format.")
+        warnings.warn("Encountered %tC format. Leaving in Stata "
+                      "Internal Format.")
         conv_dates = Series(dates, dtype=np.object)
         if has_bad_values:
-            conv_dates[bad_locs] = pd.NaT
+            conv_dates[bad_locs] = NaT
         return conv_dates
     # Delta days relative to base
     elif fmt.startswith(("%td", "td", "%d", "d")):
@@ -425,8 +426,7 @@ def _datetime_to_stata_elapsed_vec(dates, fmt):
         d = parse_dates_safe(dates, delta=True)
         conv_dates = d.delta / 1000
     elif fmt in ["%tC", "tC"]:
-        from warnings import warn
-        warn("Stata Internal Format tC not supported.")
+        warnings.warn("Stata Internal Format tC not supported.")
         conv_dates = dates
     elif fmt in ["%td", "td"]:
         d = parse_dates_safe(dates, delta=True)
@@ -580,8 +580,6 @@ def _cast_to_stata_types(data):
                     raise ValueError(msg.format(col, value, float64_max))
 
     if ws:
-        import warnings
-
         warnings.warn(ws, PossiblePrecisionLoss)
 
     return data
@@ -627,7 +625,6 @@ class StataValueLabel(object):
             category = vl[1]
             if not isinstance(category, string_types):
                 category = str(category)
-                import warnings
                 warnings.warn(value_label_mismatch_doc.format(catarray.name),
                               ValueLabelTypeMismatch)
 
@@ -1425,7 +1422,6 @@ class StataReader(StataParser, BaseIterator):
     @Appender(_data_method_doc)
     def data(self, **kwargs):
 
-        import warnings
         warnings.warn("'data' is deprecated, use 'read' instead")
 
         if self._data_read:
@@ -2105,7 +2101,6 @@ class StataWriter(StataParser):
                     del self._convert_dates[o]
 
         if converted_names:
-            import warnings
             conversion_warning = []
             for orig_name, name in converted_names.items():
                 # need to possibly encode the orig name if its unicode

--- a/pandas/plotting/_converter.py
+++ b/pandas/plotting/_converter.py
@@ -11,6 +11,9 @@ import matplotlib.dates as dates
 from matplotlib.ticker import Formatter, AutoLocator, Locator
 from matplotlib.transforms import nonsingular
 
+from pandas._libs import tslibs
+from pandas._libs.tslibs import resolution
+
 from pandas.core.dtypes.common import (
     is_float, is_integer,
     is_integer_dtype,
@@ -23,13 +26,11 @@ from pandas.core.dtypes.generic import ABCSeries
 
 from pandas.compat import lrange
 import pandas.compat as compat
-from pandas._libs import tslibs
 import pandas.core.common as com
 from pandas.core.index import Index
 
 from pandas.core.indexes.datetimes import date_range
 import pandas.core.tools.datetimes as tools
-from pandas._libs.tslibs import resolution
 import pandas.tseries.frequencies as frequencies
 from pandas.tseries.frequencies import FreqGroup
 from pandas.core.indexes.period import Period, PeriodIndex

--- a/pandas/plotting/_core.py
+++ b/pandas/plotting/_core.py
@@ -9,10 +9,15 @@ from distutils.version import LooseVersion
 
 import numpy as np
 
-from pandas.util._decorators import cache_readonly
+from pandas.util._decorators import cache_readonly, Appender
+from pandas.compat import range, lrange, map, zip, string_types
+import pandas.compat as compat
+
 import pandas.core.common as com
 from pandas.core.base import PandasObject
 from pandas.core.config import get_option
+from pandas.core.generic import _shared_docs, _shared_doc_kwargs
+
 from pandas.core.dtypes.missing import isna, notna, remove_na_arraylike
 from pandas.core.dtypes.common import (
     is_list_like,
@@ -20,16 +25,10 @@ from pandas.core.dtypes.common import (
     is_number,
     is_hashable,
     is_iterator)
-from pandas.core.dtypes.generic import ABCSeries, ABCDataFrame
+from pandas.core.dtypes.generic import (
+    ABCSeries, ABCDataFrame, ABCPeriodIndex, ABCMultiIndex, ABCIndexClass)
 
-from pandas.core.generic import _shared_docs, _shared_doc_kwargs
-from pandas.core.index import Index, MultiIndex
-
-from pandas.core.indexes.period import PeriodIndex
-from pandas.compat import range, lrange, map, zip, string_types
-import pandas.compat as compat
 from pandas.io.formats.printing import pprint_thing
-from pandas.util._decorators import Appender
 
 from pandas.plotting._compat import (_mpl_ge_1_3_1,
                                      _mpl_ge_1_5_0,
@@ -170,7 +169,8 @@ class MPLPlot(object):
         for kw, err in zip(['xerr', 'yerr'], [xerr, yerr]):
             self.errors[kw] = self._parse_errorbars(kw, err)
 
-        if not isinstance(secondary_y, (bool, tuple, list, np.ndarray, Index)):
+        if not isinstance(secondary_y, (bool, tuple, list,
+                                        np.ndarray, ABCIndexClass)):
             secondary_y = [secondary_y]
         self.secondary_y = secondary_y
 
@@ -484,7 +484,7 @@ class MPLPlot(object):
 
     @property
     def legend_title(self):
-        if not isinstance(self.data.columns, MultiIndex):
+        if not isinstance(self.data.columns, ABCMultiIndex):
             name = self.data.columns.name
             if name is not None:
                 name = pprint_thing(name)
@@ -566,7 +566,7 @@ class MPLPlot(object):
                                               'datetime64', 'time')
 
         if self.use_index:
-            if convert_period and isinstance(index, PeriodIndex):
+            if convert_period and isinstance(index, ABCPeriodIndex):
                 self.data = self.data.reindex(index=index.sort_values())
                 x = self.data.index.to_timestamp()._mpl_repr()
             elif index.is_numeric():
@@ -596,7 +596,7 @@ class MPLPlot(object):
             y = np.ma.array(y)
             y = np.ma.masked_where(mask, y)
 
-        if isinstance(x, Index):
+        if isinstance(x, ABCIndexClass):
             x = x._mpl_repr()
 
         if is_errorbar:
@@ -615,7 +615,7 @@ class MPLPlot(object):
             return ax.plot(*args, **kwds)
 
     def _get_index_name(self):
-        if isinstance(self.data.index, MultiIndex):
+        if isinstance(self.data.index, ABCMultiIndex):
             name = self.data.index.names
             if com._any_not_none(*name):
                 name = ','.join(pprint_thing(x) for x in name)
@@ -653,7 +653,8 @@ class MPLPlot(object):
         if isinstance(self.secondary_y, bool):
             return self.secondary_y
 
-        if isinstance(self.secondary_y, (tuple, list, np.ndarray, Index)):
+        if isinstance(self.secondary_y, (tuple, list,
+                                         np.ndarray, ABCIndexClass)):
             return self.data.columns[i] in self.secondary_y
 
     def _apply_style_colors(self, colors, kwds, col_num, label):
@@ -704,14 +705,12 @@ class MPLPlot(object):
         if err is None:
             return None
 
-        from pandas import DataFrame, Series
-
         def match_labels(data, e):
             e = e.reindex(data.index)
             return e
 
         # key-matched DataFrame
-        if isinstance(err, DataFrame):
+        if isinstance(err, ABCDataFrame):
 
             err = match_labels(self.data, err)
         # key-matched dict
@@ -719,7 +718,7 @@ class MPLPlot(object):
             pass
 
         # Series of error values
-        elif isinstance(err, Series):
+        elif isinstance(err, ABCSeries):
             # broadcast error series across data
             err = match_labels(self.data, err)
             err = np.atleast_2d(err)
@@ -765,14 +764,13 @@ class MPLPlot(object):
         return err
 
     def _get_errorbars(self, label=None, index=None, xerr=True, yerr=True):
-        from pandas import DataFrame
         errors = {}
 
         for kw, flag in zip(['xerr', 'yerr'], [xerr, yerr]):
             if flag:
                 err = self.errors[kw]
                 # user provided label-matched dataframe of errors
-                if isinstance(err, (DataFrame, dict)):
+                if isinstance(err, (ABCDataFrame, dict)):
                     if label is not None and label in err.keys():
                         err = err[label]
                     else:
@@ -2196,9 +2194,8 @@ def boxplot(data, column=None, by=None, ax=None, fontsize=None,
     if return_type not in BoxPlot._valid_return_types:
         raise ValueError("return_type must be {'axes', 'dict', 'both'}")
 
-    from pandas import Series, DataFrame
-    if isinstance(data, Series):
-        data = DataFrame({'x': data})
+    if isinstance(data, ABCSeries):
+        data = data.to_frame('x')
         column = 'x'
 
     def _get_colors():
@@ -2420,7 +2417,7 @@ def hist_frame(data, column=None, by=None, grid=True, xlabelsize=None,
         return axes
 
     if column is not None:
-        if not isinstance(column, (list, np.ndarray, Index)):
+        if not isinstance(column, (list, np.ndarray, ABCIndexClass)):
             column = [column]
         data = data[column]
     data = data._get_numeric_data()
@@ -2658,7 +2655,6 @@ def boxplot_frame_groupby(grouped, subplots=True, column=None, fontsize=None,
 def _grouped_plot(plotf, data, column=None, by=None, numeric_only=True,
                   figsize=None, sharex=True, sharey=True, layout=None,
                   rot=0, ax=None, **kwargs):
-    from pandas import DataFrame
 
     if figsize == 'default':
         # allowed to specify mpl default with 'default'
@@ -2679,7 +2675,7 @@ def _grouped_plot(plotf, data, column=None, by=None, numeric_only=True,
 
     for i, (key, group) in enumerate(grouped):
         ax = _axes[i]
-        if numeric_only and isinstance(group, DataFrame):
+        if numeric_only and isinstance(group, ABCDataFrame):
             group = group._get_numeric_data()
         plotf(group, ax, **kwargs)
         ax.set_title(pprint_thing(key))

--- a/pandas/plotting/_timeseries.py
+++ b/pandas/plotting/_timeseries.py
@@ -3,14 +3,16 @@
 import functools
 
 import numpy as np
-
 from matplotlib import pylab
-from pandas.core.indexes.period import Period
+
+from pandas._libs.tslibs.period import Period
+
+from pandas.core.dtypes.generic import (
+    ABCPeriodIndex, ABCDatetimeIndex, ABCTimedeltaIndex)
+
 from pandas.tseries.offsets import DateOffset
 import pandas.tseries.frequencies as frequencies
-from pandas.core.indexes.datetimes import DatetimeIndex
-from pandas.core.indexes.period import PeriodIndex
-from pandas.core.indexes.timedeltas import TimedeltaIndex
+
 from pandas.io.formats.printing import pprint_thing
 import pandas.compat as compat
 
@@ -69,7 +71,7 @@ def _maybe_resample(series, ax, kwargs):
         raise ValueError('Cannot use dynamic axis without frequency info')
 
     # Convert DatetimeIndex to PeriodIndex
-    if isinstance(series.index, DatetimeIndex):
+    if isinstance(series.index, ABCDatetimeIndex):
         series = series.to_period(freq=freq)
 
     if ax_freq is not None and freq != ax_freq:
@@ -239,7 +241,7 @@ def _use_dynamic_x(ax, data):
         return False
 
     # hack this for 0.10.1, creating more technical debt...sigh
-    if isinstance(data.index, DatetimeIndex):
+    if isinstance(data.index, ABCDatetimeIndex):
         base = frequencies.get_freq(freq)
         x = data.index
         if (base <= frequencies.FreqGroup.FR_DAY):
@@ -262,7 +264,7 @@ def _get_index_freq(data):
 def _maybe_convert_index(ax, data):
     # tsplot converts automatically, but don't want to convert index
     # over and over for DataFrames
-    if isinstance(data.index, DatetimeIndex):
+    if isinstance(data.index, ABCDatetimeIndex):
         freq = getattr(data.index, 'freq', None)
 
         if freq is None:
@@ -320,7 +322,7 @@ def format_dateaxis(subplot, freq, index):
     # handle index specific formatting
     # Note: DatetimeIndex does not use this
     # interface. DatetimeIndex uses matplotlib.date directly
-    if isinstance(index, PeriodIndex):
+    if isinstance(index, ABCPeriodIndex):
 
         majlocator = TimeSeries_DateLocator(freq, dynamic_mode=True,
                                             minor_locator=False,
@@ -343,7 +345,7 @@ def format_dateaxis(subplot, freq, index):
         # x and y coord info
         subplot.format_coord = functools.partial(_format_coord, freq)
 
-    elif isinstance(index, TimedeltaIndex):
+    elif isinstance(index, ABCTimedeltaIndex):
         subplot.xaxis.set_major_formatter(
             TimeSeries_TimedeltaFormatter())
     else:

--- a/pandas/plotting/_tools.py
+++ b/pandas/plotting/_tools.py
@@ -8,8 +8,7 @@ from math import ceil
 import numpy as np
 
 from pandas.core.dtypes.common import is_list_like
-from pandas.core.dtypes.generic import ABCSeries
-from pandas.core.index import Index
+from pandas.core.dtypes.generic import ABCSeries, ABCIndexClass, ABCDataFrame
 from pandas.compat import range
 
 
@@ -43,10 +42,9 @@ def table(ax, data, rowLabels=None, colLabels=None, **kwargs):
     -------
     matplotlib table object
     """
-    from pandas import DataFrame
     if isinstance(data, ABCSeries):
-        data = DataFrame(data, columns=[data.name])
-    elif isinstance(data, DataFrame):
+        data = data.to_frame()
+    elif isinstance(data, ABCDataFrame):
         pass
     else:
         raise ValueError('Input data must be DataFrame or Series')
@@ -341,7 +339,7 @@ def _handle_shared_axes(axarr, nplots, naxes, nrows, ncols, sharex, sharey):
 def _flatten(axes):
     if not is_list_like(axes):
         return np.array([axes])
-    elif isinstance(axes, (np.ndarray, Index)):
+    elif isinstance(axes, (np.ndarray, ABCIndexClass)):
         return axes.ravel()
     return np.array(axes)
 


### PR DESCRIPTION
Parts of the code are made more difficult to reason about by depending on `pandas.io.formats`, which has dependencies all over the code.

This PR starts in on this by replacing `import Foo` with `import ABCFoo` where possible.  Along the way it cleans up import order.