### PR TITLE
Replaced PANDAS_DATETIMEUNIT with NPY_DATETIMEUNIT

### DIFF
--- a/pandas/_libs/src/datetime/np_datetime.c
+++ b/pandas/_libs/src/datetime/np_datetime.c
@@ -21,6 +21,7 @@ This file is derived from NumPy 1.7. See NUMPY_LICENSE.txt
 
 #include <numpy/arrayobject.h>
 #include <numpy/arrayscalars.h>
+#include <numpy/ndarraytypes.h>
 #include "np_datetime.h"
 
 #if PY_MAJOR_VERSION >= 3
@@ -511,21 +512,21 @@ invalid_time:
     return -1;
 }
 
-npy_datetime pandas_datetimestruct_to_datetime(PANDAS_DATETIMEUNIT fr,
+npy_datetime pandas_datetimestruct_to_datetime(NPY_DATETIMEUNIT fr,
                                                pandas_datetimestruct *d) {
-    npy_datetime result = PANDAS_DATETIME_NAT;
+    npy_datetime result = NPY_DATETIME_NAT;
 
     convert_datetimestruct_to_datetime(fr, d, &result);
     return result;
 }
 
-void pandas_datetime_to_datetimestruct(npy_datetime val, PANDAS_DATETIMEUNIT fr,
+void pandas_datetime_to_datetimestruct(npy_datetime val, NPY_DATETIMEUNIT fr,
                                        pandas_datetimestruct *result) {
     convert_datetime_to_datetimestruct(fr, val, result);
 }
 
 void pandas_timedelta_to_timedeltastruct(npy_timedelta val,
-                                         PANDAS_DATETIMEUNIT fr,
+                                         NPY_DATETIMEUNIT fr,
                                          pandas_timedeltastruct *result) {
     convert_timedelta_to_timedeltastruct(fr, val, result);
 }
@@ -537,15 +538,15 @@ void pandas_timedelta_to_timedeltastruct(npy_timedelta val,
  *
  * Returns 0 on success, -1 on failure.
  */
-int convert_datetimestruct_to_datetime(PANDAS_DATETIMEUNIT base,
+int convert_datetimestruct_to_datetime(NPY_DATETIMEUNIT base,
                                        const pandas_datetimestruct *dts,
                                        npy_datetime *out) {
     npy_datetime ret;
 
-    if (base == PANDAS_FR_Y) {
+    if (base == NPY_FR_Y) {
         /* Truncate to the year */
         ret = dts->year - 1970;
-    } else if (base == PANDAS_FR_M) {
+    } else if (base == NPY_FR_M) {
         /* Truncate to the month */
         ret = 12 * (dts->year - 1970) + (dts->month - 1);
     } else {
@@ -553,7 +554,7 @@ int convert_datetimestruct_to_datetime(PANDAS_DATETIMEUNIT base,
         npy_int64 days = get_datetimestruct_days(dts);
 
         switch (base) {
-            case PANDAS_FR_W:
+            case NPY_FR_W:
                 /* Truncate to weeks */
                 if (days >= 0) {
                     ret = days / 7;
@@ -561,31 +562,31 @@ int convert_datetimestruct_to_datetime(PANDAS_DATETIMEUNIT base,
                     ret = (days - 6) / 7;
                 }
                 break;
-            case PANDAS_FR_D:
+            case NPY_FR_D:
                 ret = days;
                 break;
-            case PANDAS_FR_h:
+            case NPY_FR_h:
                 ret = days * 24 + dts->hour;
                 break;
-            case PANDAS_FR_m:
+            case NPY_FR_m:
                 ret = (days * 24 + dts->hour) * 60 + dts->min;
                 break;
-            case PANDAS_FR_s:
+            case NPY_FR_s:
                 ret = ((days * 24 + dts->hour) * 60 + dts->min) * 60 + dts->sec;
                 break;
-            case PANDAS_FR_ms:
+            case NPY_FR_ms:
                 ret = (((days * 24 + dts->hour) * 60 + dts->min) * 60 +
                        dts->sec) *
                           1000 +
                       dts->us / 1000;
                 break;
-            case PANDAS_FR_us:
+            case NPY_FR_us:
                 ret = (((days * 24 + dts->hour) * 60 + dts->min) * 60 +
                        dts->sec) *
                           1000000 +
                       dts->us;
                 break;
-            case PANDAS_FR_ns:
+            case NPY_FR_ns:
                 ret = ((((days * 24 + dts->hour) * 60 + dts->min) * 60 +
                         dts->sec) *
                            1000000 +
@@ -593,7 +594,7 @@ int convert_datetimestruct_to_datetime(PANDAS_DATETIMEUNIT base,
                           1000 +
                       dts->ps / 1000;
                 break;
-            case PANDAS_FR_ps:
+            case NPY_FR_ps:
                 ret = ((((days * 24 + dts->hour) * 60 + dts->min) * 60 +
                         dts->sec) *
                            1000000 +
@@ -601,7 +602,7 @@ int convert_datetimestruct_to_datetime(PANDAS_DATETIMEUNIT base,
                           1000000 +
                       dts->ps;
                 break;
-            case PANDAS_FR_fs:
+            case NPY_FR_fs:
                 /* only 2.6 hours */
                 ret = (((((days * 24 + dts->hour) * 60 + dts->min) * 60 +
                          dts->sec) *
@@ -612,7 +613,7 @@ int convert_datetimestruct_to_datetime(PANDAS_DATETIMEUNIT base,
                           1000 +
                       dts->as / 1000;
                 break;
-            case PANDAS_FR_as:
+            case NPY_FR_as:
                 /* only 9.2 secs */
                 ret = (((((days * 24 + dts->hour) * 60 + dts->min) * 60 +
                          dts->sec) *
@@ -640,7 +641,7 @@ int convert_datetimestruct_to_datetime(PANDAS_DATETIMEUNIT base,
 /*
  * Converts a datetime based on the given metadata into a datetimestruct
  */
-int convert_datetime_to_datetimestruct(PANDAS_DATETIMEUNIT base,
+int convert_datetime_to_datetimestruct(NPY_DATETIMEUNIT base,
                                        npy_datetime dt,
                                        pandas_datetimestruct *out) {
     npy_int64 perday;
@@ -656,11 +657,11 @@ int convert_datetime_to_datetimestruct(PANDAS_DATETIMEUNIT base,
      * for negative values.
      */
     switch (base) {
-        case PANDAS_FR_Y:
+        case NPY_FR_Y:
             out->year = 1970 + dt;
             break;
 
-        case PANDAS_FR_M:
+        case NPY_FR_M:
             if (dt >= 0) {
                 out->year = 1970 + dt / 12;
                 out->month = dt % 12 + 1;
@@ -670,16 +671,16 @@ int convert_datetime_to_datetimestruct(PANDAS_DATETIMEUNIT base,
             }
             break;
 
-        case PANDAS_FR_W:
+        case NPY_FR_W:
             /* A week is 7 days */
             set_datetimestruct_days(dt * 7, out);
             break;
 
-        case PANDAS_FR_D:
+        case NPY_FR_D:
             set_datetimestruct_days(dt, out);
             break;
 
-        case PANDAS_FR_h:
+        case NPY_FR_h:
             perday = 24LL;
 
             if (dt >= 0) {
@@ -693,7 +694,7 @@ int convert_datetime_to_datetimestruct(PANDAS_DATETIMEUNIT base,
             out->hour = dt;
             break;
 
-        case PANDAS_FR_m:
+        case NPY_FR_m:
             perday = 24LL * 60;
 
             if (dt >= 0) {
@@ -708,7 +709,7 @@ int convert_datetime_to_datetimestruct(PANDAS_DATETIMEUNIT base,
             out->min = dt % 60;
             break;
 
-        case PANDAS_FR_s:
+        case NPY_FR_s:
             perday = 24LL * 60 * 60;
 
             if (dt >= 0) {
@@ -724,7 +725,7 @@ int convert_datetime_to_datetimestruct(PANDAS_DATETIMEUNIT base,
             out->sec = dt % 60;
             break;
 
-        case PANDAS_FR_ms:
+        case NPY_FR_ms:
             perday = 24LL * 60 * 60 * 1000;
 
             if (dt >= 0) {
@@ -741,7 +742,7 @@ int convert_datetime_to_datetimestruct(PANDAS_DATETIMEUNIT base,
             out->us = (dt % 1000LL) * 1000;
             break;
 
-        case PANDAS_FR_us:
+        case NPY_FR_us:
             perday = 24LL * 60LL * 60LL * 1000LL * 1000LL;
 
             if (dt >= 0) {
@@ -758,7 +759,7 @@ int convert_datetime_to_datetimestruct(PANDAS_DATETIMEUNIT base,
             out->us = dt % 1000000LL;
             break;
 
-        case PANDAS_FR_ns:
+        case NPY_FR_ns:
             perday = 24LL * 60LL * 60LL * 1000LL * 1000LL * 1000LL;
 
             if (dt >= 0) {
@@ -776,7 +777,7 @@ int convert_datetime_to_datetimestruct(PANDAS_DATETIMEUNIT base,
             out->ps = (dt % 1000LL) * 1000;
             break;
 
-        case PANDAS_FR_ps:
+        case NPY_FR_ps:
             perday = 24LL * 60 * 60 * 1000 * 1000 * 1000 * 1000;
 
             if (dt >= 0) {
@@ -794,7 +795,7 @@ int convert_datetime_to_datetimestruct(PANDAS_DATETIMEUNIT base,
             out->ps = dt % 1000000LL;
             break;
 
-        case PANDAS_FR_fs:
+        case NPY_FR_fs:
             /* entire range is only +- 2.6 hours */
             if (dt >= 0) {
                 out->hour = dt / (60 * 60 * 1000000000000000LL);
@@ -821,7 +822,7 @@ int convert_datetime_to_datetimestruct(PANDAS_DATETIMEUNIT base,
             }
             break;
 
-        case PANDAS_FR_as:
+        case NPY_FR_as:
             /* entire range is only +- 9.2 seconds */
             if (dt >= 0) {
                 out->sec = (dt / 1000000000000000000LL) % 60;
@@ -861,7 +862,7 @@ int convert_datetime_to_datetimestruct(PANDAS_DATETIMEUNIT base,
  *
  * Returns 0 on success, -1 on failure.
  */
-int convert_timedelta_to_timedeltastruct(PANDAS_DATETIMEUNIT base,
+int convert_timedelta_to_timedeltastruct(NPY_DATETIMEUNIT base,
                                          npy_timedelta td,
                                          pandas_timedeltastruct *out) {
     npy_int64 frac;
@@ -874,7 +875,7 @@ int convert_timedelta_to_timedeltastruct(PANDAS_DATETIMEUNIT base,
     memset(out, 0, sizeof(pandas_timedeltastruct));
 
     switch (base) {
-        case PANDAS_FR_ns:
+        case NPY_FR_ns:
 
         // put frac in seconds
         if (td < 0 && td % (1000LL * 1000LL * 1000LL) != 0)

--- a/pandas/_libs/src/datetime/np_datetime.h
+++ b/pandas/_libs/src/datetime/np_datetime.h
@@ -19,29 +19,6 @@ This file is derived from NumPy 1.7. See NUMPY_LICENSE.txt
 
 #include <numpy/ndarraytypes.h>
 
-typedef enum {
-        PANDAS_FR_Y = 0,  // Years
-        PANDAS_FR_M = 1,  // Months
-        PANDAS_FR_W = 2,  // Weeks
-        // Gap where NPY_FR_B was
-        PANDAS_FR_D = 4,  // Days
-        PANDAS_FR_h = 5,  // hours
-        PANDAS_FR_m = 6,  // minutes
-        PANDAS_FR_s = 7,  // seconds
-        PANDAS_FR_ms = 8,  // milliseconds
-        PANDAS_FR_us = 9,  // microseconds
-        PANDAS_FR_ns = 10,  // nanoseconds
-        PANDAS_FR_ps = 11,  // picoseconds
-        PANDAS_FR_fs = 12,  // femtoseconds
-        PANDAS_FR_as = 13,  // attoseconds
-        PANDAS_FR_GENERIC = 14  // Generic, unbound units, can
-                                // convert to anything
-} PANDAS_DATETIMEUNIT;
-
-#define PANDAS_DATETIME_NUMUNITS 13
-
-#define PANDAS_DATETIME_NAT NPY_MIN_INT64
-
 typedef struct {
         npy_int64 year;
         npy_int32 month, day, hour, min, sec, us, ps, as;
@@ -61,14 +38,14 @@ extern const pandas_datetimestruct _NS_MAX_DTS;
 int convert_pydatetime_to_datetimestruct(PyObject *obj,
                                          pandas_datetimestruct *out);
 
-npy_datetime pandas_datetimestruct_to_datetime(PANDAS_DATETIMEUNIT fr,
+npy_datetime pandas_datetimestruct_to_datetime(NPY_DATETIMEUNIT fr,
                                                pandas_datetimestruct *d);
 
-void pandas_datetime_to_datetimestruct(npy_datetime val, PANDAS_DATETIMEUNIT fr,
+void pandas_datetime_to_datetimestruct(npy_datetime val, NPY_DATETIMEUNIT fr,
                                        pandas_datetimestruct *result);
 
 void pandas_timedelta_to_timedeltastruct(npy_timedelta val,
-                                         PANDAS_DATETIMEUNIT fr,
+                                         NPY_DATETIMEUNIT fr,
                                          pandas_timedeltastruct *result);
 
 int dayofweek(int y, int m, int d);
@@ -103,7 +80,7 @@ add_minutes_to_datetimestruct(pandas_datetimestruct *dts, int minutes);
 
 
 int
-convert_datetime_to_datetimestruct(PANDAS_DATETIMEUNIT base,
+convert_datetime_to_datetimestruct(NPY_DATETIMEUNIT base,
                                    npy_datetime dt,
                                    pandas_datetimestruct *out);
 

--- a/pandas/_libs/src/datetime/np_datetime_strings.c
+++ b/pandas/_libs/src/datetime/np_datetime_strings.c
@@ -28,6 +28,7 @@ This file implements string parsing and creation for NumPy datetime.
 
 #include <numpy/arrayobject.h>
 #include "numpy/arrayscalars.h"
+#include <numpy/ndarraytypes.h>
 
 #include "np_datetime.h"
 #include "np_datetime_strings.h"
@@ -514,37 +515,36 @@ error:
  * Provides a string length to use for converting datetime
  * objects with the given local and unit settings.
  */
-int get_datetime_iso_8601_strlen(int local, PANDAS_DATETIMEUNIT base) {
+int get_datetime_iso_8601_strlen(int local, NPY_DATETIMEUNIT base) {
     int len = 0;
 
     switch (base) {
         /* Generic units can only be used to represent NaT */
-        /*case PANDAS_FR_GENERIC:*/
         /*    return 4;*/
-        case PANDAS_FR_as:
+        case NPY_FR_as:
             len += 3; /* "###" */
-        case PANDAS_FR_fs:
+        case NPY_FR_fs:
             len += 3; /* "###" */
-        case PANDAS_FR_ps:
+        case NPY_FR_ps:
             len += 3; /* "###" */
-        case PANDAS_FR_ns:
+        case NPY_FR_ns:
             len += 3; /* "###" */
-        case PANDAS_FR_us:
+        case NPY_FR_us:
             len += 3; /* "###" */
-        case PANDAS_FR_ms:
+        case NPY_FR_ms:
             len += 4; /* ".###" */
-        case PANDAS_FR_s:
+        case NPY_FR_s:
             len += 3; /* ":##" */
-        case PANDAS_FR_m:
+        case NPY_FR_m:
             len += 3; /* ":##" */
-        case PANDAS_FR_h:
+        case NPY_FR_h:
             len += 3; /* "T##" */
-        case PANDAS_FR_D:
-        case PANDAS_FR_W:
+        case NPY_FR_D:
+        case NPY_FR_W:
             len += 3; /* "-##" */
-        case PANDAS_FR_M:
+        case NPY_FR_M:
             len += 3; /* "-##" */
-        case PANDAS_FR_Y:
+        case NPY_FR_Y:
             len += 21; /* 64-bit year */
             break;
         default:
@@ -552,7 +552,7 @@ int get_datetime_iso_8601_strlen(int local, PANDAS_DATETIMEUNIT base) {
             break;
     }
 
-    if (base >= PANDAS_FR_h) {
+    if (base >= NPY_FR_h) {
         if (local) {
             len += 5; /* "+####" or "-####" */
         } else {
@@ -581,7 +581,7 @@ int get_datetime_iso_8601_strlen(int local, PANDAS_DATETIMEUNIT base) {
  *  string was too short).
  */
 int make_iso_8601_datetime(pandas_datetimestruct *dts, char *outstr, int outlen,
-                           PANDAS_DATETIMEUNIT base) {
+                           NPY_DATETIMEUNIT base) {
     char *substr = outstr, sublen = outlen;
     int tmplen;
 
@@ -591,8 +591,8 @@ int make_iso_8601_datetime(pandas_datetimestruct *dts, char *outstr, int outlen,
      * TODO: Could print weeks with YYYY-Www format if the week
      *       epoch is a Monday.
      */
-    if (base == PANDAS_FR_W) {
-        base = PANDAS_FR_D;
+    if (base == NPY_FR_W) {
+        base = NPY_FR_D;
     }
 
 /* YEAR */
@@ -614,7 +614,7 @@ int make_iso_8601_datetime(pandas_datetimestruct *dts, char *outstr, int outlen,
     sublen -= tmplen;
 
     /* Stop if the unit is years */
-    if (base == PANDAS_FR_Y) {
+    if (base == NPY_FR_Y) {
         if (sublen > 0) {
             *substr = '\0';
         }
@@ -638,7 +638,7 @@ int make_iso_8601_datetime(pandas_datetimestruct *dts, char *outstr, int outlen,
     sublen -= 3;
 
     /* Stop if the unit is months */
-    if (base == PANDAS_FR_M) {
+    if (base == NPY_FR_M) {
         if (sublen > 0) {
             *substr = '\0';
         }
@@ -662,7 +662,7 @@ int make_iso_8601_datetime(pandas_datetimestruct *dts, char *outstr, int outlen,
     sublen -= 3;
 
     /* Stop if the unit is days */
-    if (base == PANDAS_FR_D) {
+    if (base == NPY_FR_D) {
         if (sublen > 0) {
             *substr = '\0';
         }
@@ -686,7 +686,7 @@ int make_iso_8601_datetime(pandas_datetimestruct *dts, char *outstr, int outlen,
     sublen -= 3;
 
     /* Stop if the unit is hours */
-    if (base == PANDAS_FR_h) {
+    if (base == NPY_FR_h) {
         goto add_time_zone;
     }
 
@@ -707,7 +707,7 @@ int make_iso_8601_datetime(pandas_datetimestruct *dts, char *outstr, int outlen,
     sublen -= 3;
 
     /* Stop if the unit is minutes */
-    if (base == PANDAS_FR_m) {
+    if (base == NPY_FR_m) {
         goto add_time_zone;
     }
 
@@ -728,7 +728,7 @@ int make_iso_8601_datetime(pandas_datetimestruct *dts, char *outstr, int outlen,
     sublen -= 3;
 
     /* Stop if the unit is seconds */
-    if (base == PANDAS_FR_s) {
+    if (base == NPY_FR_s) {
         goto add_time_zone;
     }
 
@@ -753,7 +753,7 @@ int make_iso_8601_datetime(pandas_datetimestruct *dts, char *outstr, int outlen,
     sublen -= 4;
 
     /* Stop if the unit is milliseconds */
-    if (base == PANDAS_FR_ms) {
+    if (base == NPY_FR_ms) {
         goto add_time_zone;
     }
 
@@ -774,7 +774,7 @@ int make_iso_8601_datetime(pandas_datetimestruct *dts, char *outstr, int outlen,
     sublen -= 3;
 
     /* Stop if the unit is microseconds */
-    if (base == PANDAS_FR_us) {
+    if (base == NPY_FR_us) {
         goto add_time_zone;
     }
 
@@ -795,7 +795,7 @@ int make_iso_8601_datetime(pandas_datetimestruct *dts, char *outstr, int outlen,
     sublen -= 3;
 
     /* Stop if the unit is nanoseconds */
-    if (base == PANDAS_FR_ns) {
+    if (base == NPY_FR_ns) {
         goto add_time_zone;
     }
 
@@ -816,7 +816,7 @@ int make_iso_8601_datetime(pandas_datetimestruct *dts, char *outstr, int outlen,
     sublen -= 3;
 
     /* Stop if the unit is picoseconds */
-    if (base == PANDAS_FR_ps) {
+    if (base == NPY_FR_ps) {
         goto add_time_zone;
     }
 
@@ -837,7 +837,7 @@ int make_iso_8601_datetime(pandas_datetimestruct *dts, char *outstr, int outlen,
     sublen -= 3;
 
     /* Stop if the unit is femtoseconds */
-    if (base == PANDAS_FR_fs) {
+    if (base == NPY_FR_fs) {
         goto add_time_zone;
     }
 

--- a/pandas/_libs/src/datetime/np_datetime_strings.c
+++ b/pandas/_libs/src/datetime/np_datetime_strings.c
@@ -27,7 +27,7 @@ This file implements string parsing and creation for NumPy datetime.
 #include <time.h>
 
 #include <numpy/arrayobject.h>
-#include "numpy/arrayscalars.h"
+#include <numpy/arrayscalars.h>
 #include <numpy/ndarraytypes.h>
 
 #include "np_datetime.h"

--- a/pandas/_libs/src/datetime/np_datetime_strings.h
+++ b/pandas/_libs/src/datetime/np_datetime_strings.h
@@ -60,7 +60,7 @@ parse_iso_8601_datetime(char *str, int len,
  * objects with the given local and unit settings.
  */
 int
-get_datetime_iso_8601_strlen(int local, PANDAS_DATETIMEUNIT base);
+get_datetime_iso_8601_strlen(int local, NPY_DATETIMEUNIT base);
 
 /*
  * Converts an pandas_datetimestruct to an (almost) ISO 8601
@@ -74,6 +74,6 @@ get_datetime_iso_8601_strlen(int local, PANDAS_DATETIMEUNIT base);
  */
 int
 make_iso_8601_datetime(pandas_datetimestruct *dts, char *outstr, int outlen,
-                       PANDAS_DATETIMEUNIT base);
+                       NPY_DATETIMEUNIT base);
 
 #endif  // PANDAS__LIBS_SRC_DATETIME_NP_DATETIME_STRINGS_H_

--- a/pandas/_libs/src/period_helper.c
+++ b/pandas/_libs/src/period_helper.c
@@ -54,7 +54,7 @@ npy_int64 unix_date_from_ymd(int year, int month, int day) {
     dts.year = year;
     dts.month = month;
     dts.day = day;
-    unix_date = pandas_datetimestruct_to_datetime(PANDAS_FR_D, &dts);
+    unix_date = pandas_datetimestruct_to_datetime(NPY_FR_D, &dts);
     return unix_date;
 }
 
@@ -151,7 +151,7 @@ static npy_int64 DtoB(pandas_datetimestruct *dts,
 static npy_int64 asfreq_DTtoA(npy_int64 ordinal, asfreq_info *af_info) {
     pandas_datetimestruct dts;
     ordinal = downsample_daytime(ordinal, af_info);
-    pandas_datetime_to_datetimestruct(ordinal, PANDAS_FR_D, &dts);
+    pandas_datetime_to_datetimestruct(ordinal, NPY_FR_D, &dts);
     if (dts.month > af_info->to_end) {
         return (npy_int64)(dts.year + 1 - 1970);
     } else {
@@ -163,7 +163,7 @@ static int DtoQ_yq(npy_int64 ordinal, asfreq_info *af_info, int *year) {
     pandas_datetimestruct dts;
     int quarter;
 
-    pandas_datetime_to_datetimestruct(ordinal, PANDAS_FR_D, &dts);
+    pandas_datetime_to_datetimestruct(ordinal, NPY_FR_D, &dts);
     if (af_info->to_end != 12) {
         dts.month -= af_info->to_end;
         if (dts.month <= 0) {
@@ -192,7 +192,7 @@ static npy_int64 asfreq_DTtoM(npy_int64 ordinal, asfreq_info *af_info) {
 
     ordinal = downsample_daytime(ordinal, af_info);
 
-    pandas_datetime_to_datetimestruct(ordinal, PANDAS_FR_D, &dts);
+    pandas_datetime_to_datetimestruct(ordinal, NPY_FR_D, &dts);
     return (npy_int64)((dts.year - 1970) * 12 + dts.month - 1);
 }
 
@@ -205,7 +205,7 @@ static npy_int64 asfreq_DTtoB(npy_int64 ordinal, asfreq_info *af_info) {
     int roll_back;
     pandas_datetimestruct dts;
     npy_int64 unix_date = downsample_daytime(ordinal, af_info);
-    pandas_datetime_to_datetimestruct(unix_date, PANDAS_FR_D, &dts);
+    pandas_datetime_to_datetimestruct(unix_date, NPY_FR_D, &dts);
 
     // This usage defines roll_back the opposite way from the others
     roll_back = 1 - af_info->is_end;
@@ -265,7 +265,7 @@ static npy_int64 asfreq_WtoB(npy_int64 ordinal, asfreq_info *af_info) {
     pandas_datetimestruct dts;
     npy_int64 unix_date = asfreq_WtoDT(ordinal, af_info);
 
-    pandas_datetime_to_datetimestruct(unix_date, PANDAS_FR_D, &dts);
+    pandas_datetime_to_datetimestruct(unix_date, NPY_FR_D, &dts);
     roll_back = af_info->is_end;
     return DtoB(&dts, roll_back, unix_date);
 }
@@ -305,7 +305,7 @@ static npy_int64 asfreq_MtoB(npy_int64 ordinal, asfreq_info *af_info) {
     pandas_datetimestruct dts;
     npy_int64 unix_date = asfreq_MtoDT(ordinal, af_info);
 
-    pandas_datetime_to_datetimestruct(unix_date, PANDAS_FR_D, &dts);
+    pandas_datetime_to_datetimestruct(unix_date, NPY_FR_D, &dts);
     roll_back = af_info->is_end;
     return DtoB(&dts, roll_back, unix_date);
 }
@@ -360,7 +360,7 @@ static npy_int64 asfreq_QtoB(npy_int64 ordinal, asfreq_info *af_info) {
     pandas_datetimestruct dts;
     npy_int64 unix_date = asfreq_QtoDT(ordinal, af_info);
 
-    pandas_datetime_to_datetimestruct(unix_date, PANDAS_FR_D, &dts);
+    pandas_datetime_to_datetimestruct(unix_date, NPY_FR_D, &dts);
     roll_back = af_info->is_end;
     return DtoB(&dts, roll_back, unix_date);
 }
@@ -417,7 +417,7 @@ static npy_int64 asfreq_AtoB(npy_int64 ordinal, asfreq_info *af_info) {
     pandas_datetimestruct dts;
     npy_int64 unix_date = asfreq_AtoDT(ordinal, af_info);
 
-    pandas_datetime_to_datetimestruct(unix_date, PANDAS_FR_D, &dts);
+    pandas_datetime_to_datetimestruct(unix_date, NPY_FR_D, &dts);
     roll_back = af_info->is_end;
     return DtoB(&dts, roll_back, unix_date);
 }

--- a/pandas/_libs/src/ujson/python/objToJSON.c
+++ b/pandas/_libs/src/ujson/python/objToJSON.c
@@ -43,6 +43,7 @@ http://www.opensource.apple.com/source/tcl/tcl-14/tcl/license.terms
 #include <math.h>                 // NOLINT(build/include_order)
 #include <numpy/arrayobject.h>    // NOLINT(build/include_order)
 #include <numpy/arrayscalars.h>   // NOLINT(build/include_order)
+#include <numpy/ndarraytypes.h>   // NOLINT(build/include_order)
 #include <numpy/npy_math.h>       // NOLINT(build/include_order)
 #include <stdio.h>                // NOLINT(build/include_order)
 #include <ultrajson.h>            // NOLINT(build/include_order)
@@ -138,7 +139,7 @@ typedef struct __PyObjectEncoder {
     TypeContext basicTypeContext;
 
     int datetimeIso;
-    PANDAS_DATETIMEUNIT datetimeUnit;
+    NPY_DATETIMEUNIT datetimeUnit;
 
     // output format style for pandas data types
     int outputFormat;
@@ -444,7 +445,7 @@ static void *PyUnicodeToUTF8(JSOBJ _obj, JSONTypeContext *tc, void *outValue,
 static void *PandasDateTimeStructToJSON(pandas_datetimestruct *dts,
                                         JSONTypeContext *tc, void *outValue,
                                         size_t *_outLen) {
-    PANDAS_DATETIMEUNIT base = ((PyObjectEncoder *)tc->encoder)->datetimeUnit;
+    NPY_DATETIMEUNIT base = ((PyObjectEncoder *)tc->encoder)->datetimeUnit;
 
     if (((PyObjectEncoder *)tc->encoder)->datetimeIso) {
         PRINTMARK();
@@ -482,7 +483,7 @@ static void *NpyDateTimeScalarToJSON(JSOBJ _obj, JSONTypeContext *tc,
     PRINTMARK();
 
     pandas_datetime_to_datetimestruct(
-        obj->obval, (PANDAS_DATETIMEUNIT)obj->obmeta.base, &dts);
+        obj->obval, (NPY_DATETIMEUNIT)obj->obmeta.base, &dts);
     return PandasDateTimeStructToJSON(&dts, tc, outValue, _outLen);
 }
 
@@ -512,7 +513,7 @@ static void *NpyDatetime64ToJSON(JSOBJ _obj, JSONTypeContext *tc,
     PRINTMARK();
 
     pandas_datetime_to_datetimestruct((npy_datetime)GET_TC(tc)->longValue,
-                                      PANDAS_FR_ns, &dts);
+                                      NPY_FR_ns, &dts);
     return PandasDateTimeStructToJSON(&dts, tc, outValue, _outLen);
 }
 
@@ -1864,15 +1865,15 @@ void Object_beginTypeContext(JSOBJ _obj, JSONTypeContext *tc) {
 
         base = ((PyObjectEncoder *)tc->encoder)->datetimeUnit;
         switch (base) {
-            case PANDAS_FR_ns:
+            case NPY_FR_ns:
                 break;
-            case PANDAS_FR_us:
+            case NPY_FR_us:
                 value /= 1000LL;
                 break;
-            case PANDAS_FR_ms:
+            case NPY_FR_ms:
                 value /= 1000000LL;
                 break;
-            case PANDAS_FR_s:
+            case NPY_FR_s:
                 value /= 1000000000LL;
                 break;
         }
@@ -2358,7 +2359,7 @@ PyObject *objToJSON(PyObject *self, PyObject *args, PyObject *kwargs) {
     pyEncoder.npyType = -1;
     pyEncoder.npyValue = NULL;
     pyEncoder.datetimeIso = 0;
-    pyEncoder.datetimeUnit = PANDAS_FR_ms;
+    pyEncoder.datetimeUnit = NPY_FR_ms;
     pyEncoder.outputFormat = COLUMNS;
     pyEncoder.defaultHandler = 0;
     pyEncoder.basicTypeContext.newObj = NULL;
@@ -2416,13 +2417,13 @@ PyObject *objToJSON(PyObject *self, PyObject *args, PyObject *kwargs) {
 
     if (sdateFormat != NULL) {
         if (strcmp(sdateFormat, "s") == 0) {
-            pyEncoder.datetimeUnit = PANDAS_FR_s;
+            pyEncoder.datetimeUnit = NPY_FR_s;
         } else if (strcmp(sdateFormat, "ms") == 0) {
-            pyEncoder.datetimeUnit = PANDAS_FR_ms;
+            pyEncoder.datetimeUnit = NPY_FR_ms;
         } else if (strcmp(sdateFormat, "us") == 0) {
-            pyEncoder.datetimeUnit = PANDAS_FR_us;
+            pyEncoder.datetimeUnit = NPY_FR_us;
         } else if (strcmp(sdateFormat, "ns") == 0) {
-            pyEncoder.datetimeUnit = PANDAS_FR_ns;
+            pyEncoder.datetimeUnit = NPY_FR_ns;
         } else {
             PyErr_Format(PyExc_ValueError,
                          "Invalid value '%s' for option 'date_unit'",

--- a/pandas/_libs/tslibs/conversion.pxd
+++ b/pandas/_libs/tslibs/conversion.pxd
@@ -32,21 +32,3 @@ cdef maybe_datetimelike_to_i8(object val)
 cdef int64_t tz_convert_utc_to_tzlocal(int64_t utc_val, tzinfo tz)
 
 cpdef datetime localize_pydatetime(datetime dt, object tz)
-
-cdef extern from "numpy/ndarraytypes.h":
-    ctypedef enum NPY_DATETIMEUNIT:
-        NPY_FR_ERROR
-        NPY_FR_Y
-        NPY_FR_M
-        NPY_FR_W
-        NPY_FR_D
-        NPY_FR_h
-        NPY_FR_m
-        NPY_FR_s
-        NPY_FR_ms
-        NPY_FR_us
-        NPY_FR_ns
-        NPY_FR_ps
-        NPY_FR_fs
-        NPY_FR_as
-        NPY_FR_GENERIC

--- a/pandas/_libs/tslibs/conversion.pxd
+++ b/pandas/_libs/tslibs/conversion.pxd
@@ -7,6 +7,7 @@ from numpy cimport int64_t, int32_t
 
 from np_datetime cimport pandas_datetimestruct
 
+
 cdef class _TSObject:
     cdef:
         pandas_datetimestruct dts      # pandas_datetimestruct

--- a/pandas/_libs/tslibs/conversion.pxd
+++ b/pandas/_libs/tslibs/conversion.pxd
@@ -7,7 +7,6 @@ from numpy cimport int64_t, int32_t
 
 from np_datetime cimport pandas_datetimestruct
 
-
 cdef class _TSObject:
     cdef:
         pandas_datetimestruct dts      # pandas_datetimestruct
@@ -33,3 +32,21 @@ cdef maybe_datetimelike_to_i8(object val)
 cdef int64_t tz_convert_utc_to_tzlocal(int64_t utc_val, tzinfo tz)
 
 cpdef datetime localize_pydatetime(datetime dt, object tz)
+
+cdef extern from "numpy/ndarraytypes.h":
+    ctypedef enum NPY_DATETIMEUNIT:
+        NPY_FR_ERROR
+        NPY_FR_Y
+        NPY_FR_M
+        NPY_FR_W
+        NPY_FR_D
+        NPY_FR_h
+        NPY_FR_m
+        NPY_FR_s
+        NPY_FR_ms
+        NPY_FR_us
+        NPY_FR_ns
+        NPY_FR_ps
+        NPY_FR_fs
+        NPY_FR_as
+        NPY_FR_GENERIC

--- a/pandas/_libs/tslibs/conversion.pyx
+++ b/pandas/_libs/tslibs/conversion.pyx
@@ -21,7 +21,6 @@ PyDateTime_IMPORT
 from np_datetime cimport (check_dts_bounds,
                           pandas_datetimestruct,
                           pandas_datetime_to_datetimestruct, _string_to_dts,
-                          PANDAS_DATETIMEUNIT, PANDAS_FR_ns,
                           npy_datetime,
                           dt64_to_dtstruct, dtstruct_to_dt64,
                           get_datetime64_unit, get_datetime64_value,
@@ -62,13 +61,13 @@ cdef inline int64_t get_datetime64_nanos(object val) except? -1:
     """
     cdef:
         pandas_datetimestruct dts
-        PANDAS_DATETIMEUNIT unit
+        NPY_DATETIMEUNIT unit
         npy_datetime ival
 
     unit = get_datetime64_unit(val)
     ival = get_datetime64_value(val)
 
-    if unit != PANDAS_FR_ns:
+    if unit != NPY_FR_ns:
         pandas_datetime_to_datetimestruct(ival, unit, &dts)
         check_dts_bounds(&dts)
         ival = dtstruct_to_dt64(&dts)
@@ -93,7 +92,7 @@ def ensure_datetime64ns(ndarray arr, copy=True):
     cdef:
         Py_ssize_t i, n = arr.size
         ndarray[int64_t] ivalues, iresult
-        PANDAS_DATETIMEUNIT unit
+        NPY_DATETIMEUNIT unit
         pandas_datetimestruct dts
 
     shape = (<object> arr).shape
@@ -107,7 +106,7 @@ def ensure_datetime64ns(ndarray arr, copy=True):
         return result
 
     unit = get_datetime64_unit(arr.flat[0])
-    if unit == PANDAS_FR_ns:
+    if unit == NPY_FR_ns:
         if copy:
             arr = arr.copy()
         result = arr

--- a/pandas/_libs/tslibs/conversion.pyx
+++ b/pandas/_libs/tslibs/conversion.pyx
@@ -24,7 +24,7 @@ from np_datetime cimport (check_dts_bounds,
                           npy_datetime,
                           dt64_to_dtstruct, dtstruct_to_dt64,
                           get_datetime64_unit, get_datetime64_value,
-                          pydatetime_to_dt64)
+                          pydatetime_to_dt64, NPY_DATETIMEUNIT, NPY_FR_ns)
 from np_datetime import OutOfBoundsDatetime
 
 from util cimport (is_string_object,

--- a/pandas/_libs/tslibs/np_datetime.pxd
+++ b/pandas/_libs/tslibs/np_datetime.pxd
@@ -11,7 +11,7 @@ cdef extern from "numpy/ndarrayobject.h":
 
 cdef extern from "numpy/ndarraytypes.h":
     ctypedef struct PyArray_DatetimeMetaData:
-        PANDAS_DATETIMEUNIT base
+        NPY_DATETIMEUNIT base
         int64_t num
 
 cdef extern from "numpy/arrayscalars.h":
@@ -34,24 +34,24 @@ cdef extern from "../src/datetime/np_datetime.h":
         int64_t days
         int32_t hrs, min, sec, ms, us, ns, seconds, microseconds, nanoseconds
 
-    ctypedef enum PANDAS_DATETIMEUNIT:
-        PANDAS_FR_Y
-        PANDAS_FR_M
-        PANDAS_FR_W
-        PANDAS_FR_D
-        PANDAS_FR_B
-        PANDAS_FR_h
-        PANDAS_FR_m
-        PANDAS_FR_s
-        PANDAS_FR_ms
-        PANDAS_FR_us
-        PANDAS_FR_ns
-        PANDAS_FR_ps
-        PANDAS_FR_fs
-        PANDAS_FR_as
+    ctypedef enum NPY_DATETIMEUNIT:
+        NPY_FR_Y
+        NPY_FR_M
+        NPY_FR_W
+        NPY_FR_D
+        NPY_FR_B
+        NPY_FR_h
+        NPY_FR_m
+        NPY_FR_s
+        NPY_FR_ms
+        NPY_FR_us
+        NPY_FR_ns
+        NPY_FR_ps
+        NPY_FR_fs
+        NPY_FR_as
 
     void pandas_datetime_to_datetimestruct(npy_datetime val,
-                                           PANDAS_DATETIMEUNIT fr,
+                                           NPY_DATETIMEUNIT fr,
                                            pandas_datetimestruct *result) nogil
 
 
@@ -70,7 +70,7 @@ cdef int64_t pydate_to_dt64(date val, pandas_datetimestruct *dts)
 
 cdef npy_datetime get_datetime64_value(object obj) nogil
 cdef npy_timedelta get_timedelta64_value(object obj) nogil
-cdef PANDAS_DATETIMEUNIT get_datetime64_unit(object obj) nogil
+cdef NPY_DATETIMEUNIT get_datetime64_unit(object obj) nogil
 
 cdef int _string_to_dts(object val, pandas_datetimestruct* dts,
                         int* out_local, int* out_tzoffset) except? -1

--- a/pandas/_libs/tslibs/np_datetime.pyx
+++ b/pandas/_libs/tslibs/np_datetime.pyx
@@ -19,16 +19,16 @@ cdef extern from "../src/datetime/np_datetime.h":
     int cmp_pandas_datetimestruct(pandas_datetimestruct *a,
                                   pandas_datetimestruct *b)
 
-    npy_datetime pandas_datetimestruct_to_datetime(PANDAS_DATETIMEUNIT fr,
+    npy_datetime pandas_datetimestruct_to_datetime(NPY_DATETIMEUNIT fr,
                                                    pandas_datetimestruct *d
                                                    ) nogil
 
     void pandas_datetime_to_datetimestruct(npy_datetime val,
-                                           PANDAS_DATETIMEUNIT fr,
+                                           NPY_DATETIMEUNIT fr,
                                            pandas_datetimestruct *result) nogil
 
     void pandas_timedelta_to_timedeltastruct(npy_timedelta val,
-                                             PANDAS_DATETIMEUNIT fr,
+                                             NPY_DATETIMEUNIT fr,
                                              pandas_timedeltastruct *result
                                             ) nogil
 
@@ -59,11 +59,11 @@ cdef inline npy_timedelta get_timedelta64_value(object obj) nogil:
     return (<PyTimedeltaScalarObject*>obj).obval
 
 
-cdef inline PANDAS_DATETIMEUNIT get_datetime64_unit(object obj) nogil:
+cdef inline NPY_DATETIMEUNIT get_datetime64_unit(object obj) nogil:
     """
     returns the unit part of the dtype for a numpy datetime64 object.
     """
-    return <PANDAS_DATETIMEUNIT>(<PyDatetimeScalarObject*>obj).obmeta.base
+    return <NPY_DATETIMEUNIT>(<PyDatetimeScalarObject*>obj).obmeta.base
 
 # ----------------------------------------------------------------------
 # Comparison
@@ -127,22 +127,22 @@ cdef inline check_dts_bounds(pandas_datetimestruct *dts):
 
 cdef inline int64_t dtstruct_to_dt64(pandas_datetimestruct* dts) nogil:
     """Convenience function to call pandas_datetimestruct_to_datetime
-    with the by-far-most-common frequency PANDAS_FR_ns"""
-    return pandas_datetimestruct_to_datetime(PANDAS_FR_ns, dts)
+    with the by-far-most-common frequency NPY_FR_ns"""
+    return pandas_datetimestruct_to_datetime(NPY_FR_ns, dts)
 
 
 cdef inline void dt64_to_dtstruct(int64_t dt64,
                                   pandas_datetimestruct* out) nogil:
     """Convenience function to call pandas_datetime_to_datetimestruct
-    with the by-far-most-common frequency PANDAS_FR_ns"""
-    pandas_datetime_to_datetimestruct(dt64, PANDAS_FR_ns, out)
+    with the by-far-most-common frequency NPY_FR_ns"""
+    pandas_datetime_to_datetimestruct(dt64, NPY_FR_ns, out)
     return
 
 cdef inline void td64_to_tdstruct(int64_t td64,
                                   pandas_timedeltastruct* out) nogil:
     """Convenience function to call pandas_timedelta_to_timedeltastruct
-    with the by-far-most-common frequency PANDAS_FR_ns"""
-    pandas_timedelta_to_timedeltastruct(td64, PANDAS_FR_ns, out)
+    with the by-far-most-common frequency NPY_FR_ns"""
+    pandas_timedelta_to_timedeltastruct(td64, NPY_FR_ns, out)
     return
 
 

--- a/pandas/_libs/tslibs/period.pyx
+++ b/pandas/_libs/tslibs/period.pyx
@@ -24,25 +24,8 @@ PyDateTime_IMPORT
 
 from np_datetime cimport (pandas_datetimestruct, dtstruct_to_dt64,
                           dt64_to_dtstruct,
-                          pandas_datetime_to_datetimestruct)
-
-cdef extern from "numpy/ndarraytypes.h":
-    ctypedef enum NPY_DATETIMEUNIT:
-        NPY_FR_ERROR
-        NPY_FR_Y
-        NPY_FR_M
-        NPY_FR_W
-        NPY_FR_D
-        NPY_FR_h
-        NPY_FR_m
-        NPY_FR_s
-        NPY_FR_ms
-        NPY_FR_us
-        NPY_FR_ns
-        NPY_FR_ps
-        NPY_FR_fs
-        NPY_FR_as
-        NPY_FR_GENERIC
+                          pandas_datetime_to_datetimestruct,
+                          NPY_DATETIMEUNIT, NPY_FR_D)
 
 cdef extern from "../src/datetime/np_datetime.h":
     int64_t pandas_datetimestruct_to_datetime(NPY_DATETIMEUNIT fr,

--- a/pandas/_libs/tslibs/period.pyx
+++ b/pandas/_libs/tslibs/period.pyx
@@ -24,12 +24,28 @@ PyDateTime_IMPORT
 
 from np_datetime cimport (pandas_datetimestruct, dtstruct_to_dt64,
                           dt64_to_dtstruct,
-                          PANDAS_FR_D,
-                          pandas_datetime_to_datetimestruct,
-                          PANDAS_DATETIMEUNIT)
+                          pandas_datetime_to_datetimestruct)
+
+cdef extern from "numpy/ndarraytypes.h":
+    ctypedef enum NPY_DATETIMEUNIT:
+        NPY_FR_ERROR
+        NPY_FR_Y
+        NPY_FR_M
+        NPY_FR_W
+        NPY_FR_D
+        NPY_FR_h
+        NPY_FR_m
+        NPY_FR_s
+        NPY_FR_ms
+        NPY_FR_us
+        NPY_FR_ns
+        NPY_FR_ps
+        NPY_FR_fs
+        NPY_FR_as
+        NPY_FR_GENERIC
 
 cdef extern from "../src/datetime/np_datetime.h":
-    int64_t pandas_datetimestruct_to_datetime(PANDAS_DATETIMEUNIT fr,
+    int64_t pandas_datetimestruct_to_datetime(NPY_DATETIMEUNIT fr,
                                               pandas_datetimestruct *d
                                               ) nogil
 
@@ -188,7 +204,7 @@ cdef int64_t get_period_ordinal(pandas_datetimestruct *dts, int freq) nogil:
     elif freq == FR_MTH:
         return (dts.year - 1970) * 12 + dts.month - 1
 
-    unix_date = pandas_datetimestruct_to_datetime(PANDAS_FR_D, dts)
+    unix_date = pandas_datetimestruct_to_datetime(NPY_FR_D, dts)
 
     if freq >= FR_SEC:
         seconds = unix_date * 86400 + dts.hour * 3600 + dts.min * 60 + dts.sec
@@ -315,7 +331,7 @@ cdef void date_info_from_days_and_time(pandas_datetimestruct *dts,
     # abstime >= 0.0 and abstime <= 86400
 
     # Calculate the date
-    pandas_datetime_to_datetimestruct(unix_date, PANDAS_FR_D, dts)
+    pandas_datetime_to_datetimestruct(unix_date, NPY_FR_D, dts)
 
     # Calculate the time
     inttime = <int>abstime


### PR DESCRIPTION
progress towards #21852

- [X] tests added / passed
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

Working on my C-fu as well. There may be a better way to do this (ex: even adding NPY_DATETIMEUNIT to Cython/includes) but figured I'd offer this up for review

@jbrockmendel 