### PR TITLE
ENH: Change DatetimeIndex.time to also return timezone info

### DIFF
--- a/doc/source/timeseries.rst
+++ b/doc/source/timeseries.rst
@@ -723,7 +723,7 @@ There are several time/date properties that one can access from ``Timestamp`` or
     microsecond,"The microseconds of the datetime"
     nanosecond,"The nanoseconds of the datetime"
     date,"Returns datetime.date (does not contain timezone information)"
-    time,"Returns datetime.time (does not contain timezone information)"
+    time,"Returns datetime.time (contains timezone information)"
     dayofyear,"The ordinal day of year"
     weekofyear,"The week ordinal of the year"
     week,"The week ordinal of the year"

--- a/doc/source/whatsnew/v0.24.0.txt
+++ b/doc/source/whatsnew/v0.24.0.txt
@@ -84,7 +84,7 @@ Other Enhancements
 - :meth:`Series.nlargest`, :meth:`Series.nsmallest`, :meth:`DataFrame.nlargest`, and :meth:`DataFrame.nsmallest` now accept the value ``"all"`` for the ``keep`` argument. This keeps all ties for the nth largest/smallest value (:issue:`16818`)
 - :class:`IntervalIndex` has gained the :meth:`~IntervalIndex.set_closed` method to change the existing ``closed`` value (:issue:`21670`)
 - :func:`~DataFrame.to_csv` and :func:`~DataFrame.to_json` now support ``compression='infer'`` to infer compression based on filename (:issue:`15008`)
--
+- Changed DatetimeIndex.time to also return timezone information. Mainly undid changes from :issue:`21821. (:issue:`21358)
 
 .. _whatsnew_0240.api_breaking:
 

--- a/doc/source/whatsnew/v0.24.0.txt
+++ b/doc/source/whatsnew/v0.24.0.txt
@@ -84,7 +84,7 @@ Other Enhancements
 - :meth:`Series.nlargest`, :meth:`Series.nsmallest`, :meth:`DataFrame.nlargest`, and :meth:`DataFrame.nsmallest` now accept the value ``"all"`` for the ``keep`` argument. This keeps all ties for the nth largest/smallest value (:issue:`16818`)
 - :class:`IntervalIndex` has gained the :meth:`~IntervalIndex.set_closed` method to change the existing ``closed`` value (:issue:`21670`)
 - :func:`~DataFrame.to_csv` and :func:`~DataFrame.to_json` now support ``compression='infer'`` to infer compression based on filename (:issue:`15008`)
-- Changed DatetimeIndex.time to also return timezone information. Mainly undid changes from :issue:`21821. (:issue:`21358)
+- Changed DatetimeIndex.time to also return timezone information. (:issue:`21358)
 
 .. _whatsnew_0240.api_breaking:
 

--- a/doc/source/whatsnew/v0.24.0.txt
+++ b/doc/source/whatsnew/v0.24.0.txt
@@ -84,7 +84,7 @@ Other Enhancements
 - :meth:`Series.nlargest`, :meth:`Series.nsmallest`, :meth:`DataFrame.nlargest`, and :meth:`DataFrame.nsmallest` now accept the value ``"all"`` for the ``keep`` argument. This keeps all ties for the nth largest/smallest value (:issue:`16818`)
 - :class:`IntervalIndex` has gained the :meth:`~IntervalIndex.set_closed` method to change the existing ``closed`` value (:issue:`21670`)
 - :func:`~DataFrame.to_csv` and :func:`~DataFrame.to_json` now support ``compression='infer'`` to infer compression based on filename (:issue:`15008`)
-- Changed DatetimeIndex.time to also return timezone information. (:issue:`21358)
+- :attr:`DatetimeIndex.time` now also returns timezone information. (:issue:`21358`)
 
 .. _whatsnew_0240.api_breaking:
 

--- a/pandas/_libs/tslib.pyx
+++ b/pandas/_libs/tslib.pyx
@@ -74,7 +74,7 @@ cdef inline object create_time_from_ts(
         int64_t value, pandas_datetimestruct dts,
         object tz, object freq):
     """ convenience routine to construct a datetime.time from its parts """
-    return time(dts.hour, dts.min, dts.sec, dts.us)
+    return time(dts.hour, dts.min, dts.sec, dts.us, tz)
 
 
 def ints_to_pydatetime(ndarray[int64_t] arr, tz=None, freq=None,

--- a/pandas/core/arrays/datetimes.py
+++ b/pandas/core/arrays/datetimes.py
@@ -576,8 +576,7 @@ class DatetimeArrayMixin(DatetimeLikeArrayMixin):
     def time(self):
         """
         Returns numpy array of datetime.time. The time part of the Timestamps.
-        Time returned is in local time, and contains associated timezone
-        information.
+        Time returned is in local time with associated timezone information.
         """
         return tslib.ints_to_pydatetime(self.asi8, self.tz, box="time")
 

--- a/pandas/core/arrays/datetimes.py
+++ b/pandas/core/arrays/datetimes.py
@@ -576,6 +576,8 @@ class DatetimeArrayMixin(DatetimeLikeArrayMixin):
     def time(self):
         """
         Returns numpy array of datetime.time. The time part of the Timestamps.
+        Time returned is in local time, and contains associated timezone
+        information.
         """
         return tslib.ints_to_pydatetime(self.asi8, self.tz, box="time")
 

--- a/pandas/core/arrays/datetimes.py
+++ b/pandas/core/arrays/datetimes.py
@@ -577,15 +577,7 @@ class DatetimeArrayMixin(DatetimeLikeArrayMixin):
         """
         Returns numpy array of datetime.time. The time part of the Timestamps.
         """
-        # If the Timestamps have a timezone that is not UTC,
-        # convert them into their i8 representation while
-        # keeping their timezone and not using UTC
-        if self.tz is not None and self.tz is not utc:
-            timestamps = self._local_timestamps()
-        else:
-            timestamps = self.asi8
-
-        return tslib.ints_to_pydatetime(timestamps, box="time")
+        return tslib.ints_to_pydatetime(self.asi8, self.tz, box="time")
 
     @property
     def date(self):

--- a/pandas/tests/indexes/datetimes/test_timezones.py
+++ b/pandas/tests/indexes/datetimes/test_timezones.py
@@ -718,15 +718,15 @@ class TestDatetimeIndexTimezones(object):
 
         tm.assert_numpy_array_equal(result, expected)
 
-    @pytest.mark.parametrize("dtype", [
-        None, 'datetime64[ns, CET]',
-        'datetime64[ns, EST]', 'datetime64[ns, UTC]'
+    @pytest.mark.parametrize("tz", [
+        None, pytz.timezone('CET'), pytz.timezone('EST'), 
+        pytz.timezone('UTC')
     ])
-    def test_time_accessor(self, dtype):
+    def test_time_accessor(self, tz):
         # Regression test for GH#21267
-        expected = np.array([time(10, 20, 30), pd.NaT])
+        expected = np.array([time(10, 20, 30, tzinfo=tz), pd.NaT])
 
-        index = DatetimeIndex(['2018-06-04 10:20:30', pd.NaT], dtype=dtype)
+        index = DatetimeIndex(['2018-06-04 10:20:30', pd.NaT], tz=tz)
         result = index.time
 
         tm.assert_numpy_array_equal(result, expected)

--- a/pandas/tests/indexes/datetimes/test_timezones.py
+++ b/pandas/tests/indexes/datetimes/test_timezones.py
@@ -724,6 +724,7 @@ class TestDatetimeIndexTimezones(object):
     ])
     def test_time_accessor(self, tz):
         # Regression test for GH#21267
+        # Changed test to account for GH#21358
         expected = np.array([time(10, 20, 30, tzinfo=tz), pd.NaT])
 
         index = DatetimeIndex(['2018-06-04 10:20:30', pd.NaT], tz=tz)

--- a/pandas/tests/indexes/datetimes/test_timezones.py
+++ b/pandas/tests/indexes/datetimes/test_timezones.py
@@ -719,7 +719,7 @@ class TestDatetimeIndexTimezones(object):
         tm.assert_numpy_array_equal(result, expected)
 
     @pytest.mark.parametrize("tz", [
-        None, pytz.timezone('CET'), pytz.timezone('EST'), 
+        None, pytz.timezone('CET'), pytz.timezone('EST'),
         pytz.timezone('UTC')
     ])
     def test_time_accessor(self, tz):


### PR DESCRIPTION
- [ ] closes #21358
- [ ] tests added / passed
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

Mainly just reverted changes from GH#21281 and updated docs. Also had to change one test added in GH#21281.