### PR TITLE
TST/CLN: correctly skip in indexes/common; add test for duplicated

### DIFF
--- a/pandas/tests/indexes/common.py
+++ b/pandas/tests/indexes/common.py
@@ -35,10 +35,6 @@ class Base(object):
         assert indices.equals(unpickled)
 
     def test_pickle_compat_construction(self):
-        # this is testing for pickle compat
-        if self._holder is None:
-            pytest.skip('Skip check for uncertain type')
-
         # need an object to create with
         pytest.raises(TypeError, self._holder)
 

--- a/pandas/tests/indexes/common.py
+++ b/pandas/tests/indexes/common.py
@@ -366,10 +366,12 @@ class Base(object):
 
         idx = self._holder(indices)
         if idx.has_duplicates:
-            # We need to be able to control creation of duplicates here
-            # This is slightly circular, as drop_duplicates depends on
-            # duplicated, but in the end, it all works out because we
-            # cross-check with Series.duplicated
+            # We are testing the duplicated-method here, so we need to know
+            # exactly which indices are duplicate and how (for the result).
+            # This is not possible if "idx" has duplicates already, which we
+            # therefore remove. This is seemingly circular, as drop_duplicates
+            # invokes duplicated, but in the end, it all works out because we
+            # cross-check with Series.duplicated, which is tested separately.
             idx = idx.drop_duplicates()
 
         n, k = len(idx), 10

--- a/pandas/tests/indexes/common.py
+++ b/pandas/tests/indexes/common.py
@@ -343,7 +343,7 @@ class Base(object):
         new_copy = indices.copy(deep=True, name="banana")
         assert new_copy.name == "banana"
 
-    def test_duplicates(self, indices):
+    def test_has_duplicates(self, indices):
         if type(indices) is not self._holder:
             pytest.skip('Can only check if we have the correct type')
         if not len(indices) or isinstance(indices, MultiIndex):

--- a/pandas/tests/indexes/test_category.py
+++ b/pandas/tests/indexes/test_category.py
@@ -590,12 +590,15 @@ class TestCategoricalIndex(Base):
         ci = CategoricalIndex(values)
         assert ci.is_unique is expected
 
-    def test_duplicates(self):
+    def test_has_duplicates(self):
 
         idx = CategoricalIndex([0, 0, 0], name='foo')
         assert not idx.is_unique
         assert idx.has_duplicates
 
+    def test_drop_duplicates(self):
+
+        idx = CategoricalIndex([0, 0, 0], name='foo')
         expected = CategoricalIndex([0], name='foo')
         tm.assert_index_equal(idx.drop_duplicates(), expected)
         tm.assert_index_equal(idx.unique(), expected)

--- a/pandas/tests/indexes/test_range.py
+++ b/pandas/tests/indexes/test_range.py
@@ -806,7 +806,7 @@ class TestRangeIndex(Numeric):
         result = a - fidx
         tm.assert_index_equal(result, expected)
 
-    def test_duplicates(self):
+    def test_has_duplicates(self):
         for ind in self.indices:
             if not len(ind):
                 continue


### PR DESCRIPTION
Splitting up #21645 

* Added tests for `duplicated`
* Following https://github.com/pandas-dev/pandas/pull/21645#discussion_r202192191, turned several blank `return` statements (which falsely pass the test)  into `pytest.skip`.
