### PR TITLE
Use the Agg backend for docs builds

### DIFF
--- a/doc/make.py
+++ b/doc/make.py
@@ -363,6 +363,10 @@ def main():
     sys.path.append(args.python_path)
     globals()['pandas'] = importlib.import_module('pandas')
 
+    # Set the matplotlib backend to the non-interactive Agg backend for all
+    # child processes.
+    os.environ['MPLBACKEND'] = 'module://matplotlib.backends.backend_agg'
+
     builder = DocBuilder(args.num_jobs, not args.no_api, args.single,
                          args.verbosity)
     getattr(builder, args.command)()

--- a/doc/source/matplotlibrc
+++ b/doc/source/matplotlibrc
@@ -1,1 +1,0 @@
-backend: Agg

--- a/doc/source/matplotlibrc
+++ b/doc/source/matplotlibrc
@@ -1,0 +1,1 @@
+backend: Agg


### PR DESCRIPTION
This uses a non-interactive Agg matplotlib backend to build docs, which avoids trying to use the default MacOS backend, which can fail in some environments.

Closes #21913.