### PR TITLE
[BUG] Fix interpolation for datetimelike dtypes

### DIFF
--- a/doc/source/whatsnew/v0.24.0.txt
+++ b/doc/source/whatsnew/v0.24.0.txt
@@ -371,7 +371,7 @@ Datetimelike
 
 - Fixed bug where two :class:`DateOffset` objects with different ``normalize`` attributes could evaluate as equal (:issue:`21404`)
 - Fixed bug where :meth:`Timestamp.resolution` incorrectly returned 1-microsecond ``timedelta`` instead of 1-nanosecond :class:`Timedelta` (:issue:`21336`,:issue:`21365`)
-- Fixed bug in :meth:`DataFrame.interpolate` and :meth:`Series.interpolate` where null values were not filled for dtypes of ``datetime64[ns]``, ``datetime64[ns, tz]``, ``timedelta64[ns]`` (:issue:`????`)
+- Fixed bug in :meth:`DataFrame.interpolate` and :meth:`Series.interpolate` where null values were not filled for dtypes of ``datetime64[ns]``, ``datetime64[ns, tz]``, ``timedelta64[ns]`` (:issue:`21915`)
 
 Timedelta
 ^^^^^^^^^

--- a/doc/source/whatsnew/v0.24.0.txt
+++ b/doc/source/whatsnew/v0.24.0.txt
@@ -371,6 +371,7 @@ Datetimelike
 
 - Fixed bug where two :class:`DateOffset` objects with different ``normalize`` attributes could evaluate as equal (:issue:`21404`)
 - Fixed bug where :meth:`Timestamp.resolution` incorrectly returned 1-microsecond ``timedelta`` instead of 1-nanosecond :class:`Timedelta` (:issue:`21336`,:issue:`21365`)
+- Fixed bug in :meth:`DataFrame.interpolate` and :meth:`Series.interpolate` where null values were not filled for dtypes of ``datetime64[ns]``, ``datetime64[ns, tz]``, ``timedelta64[ns]`` (:issue:`????`)
 
 Timedelta
 ^^^^^^^^^

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -684,8 +684,6 @@ class NDFrame(PandasObject, SelectionMixin):
         new_axes = self._construct_axes_dict_from(self, [self._get_axis(x)
                                                          for x in axes_names])
         new_values = self.values.transpose(axes_numbers)
-
-        new_values = values.transpose(axes_numbers)
         if kwargs.pop('copy', None) or (len(args) and args[-1]):
             new_values = new_values.copy()
 

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -683,10 +683,8 @@ class NDFrame(PandasObject, SelectionMixin):
 
         new_axes = self._construct_axes_dict_from(self, [self._get_axis(x)
                                                          for x in axes_names])
-        values = self.values
-        if isinstance(values, DatetimeIndex):
-            # kludge for tz-aware case.  See GH#19198
-            values = values.astype('O').values.reshape(self.shape)
+        new_values = self.values.transpose(axes_numbers)
+
         new_values = values.transpose(axes_numbers)
         if kwargs.pop('copy', None) or (len(args) and args[-1]):
             new_values = new_values.copy()

--- a/pandas/tests/frame/test_missing.py
+++ b/pandas/tests/frame/test_missing.py
@@ -862,6 +862,7 @@ class TestDataFrameInterpolate(TestData):
     @pytest.mark.parametrize('use_idx', [True, False])
     @pytest.mark.parametrize('tz', [None, 'US/Central'])
     def test_interpolate_dt64_values(self, tz, use_idx):
+        # GH#21915
         dti = pd.date_range('2016-01-01', periods=10, tz=tz)
         index = dti if use_idx else None
 
@@ -881,6 +882,7 @@ class TestDataFrameInterpolate(TestData):
 
     @pytest.mark.parametrize('use_idx', [True, False])
     def test_interpolate_td64_values(self, use_idx):
+        # GH#21915
         tdi = pd.timedelta_range('1D', periods=10)
         index = tdi if use_idx else None
 
@@ -899,6 +901,7 @@ class TestDataFrameInterpolate(TestData):
 
     @pytest.mark.parametrize('use_idx', [True, False])
     def test_interpolate_datetimelike_and_object(self, use_idx):
+        # GH#21915
         # Check that dt64/td64 with more than one column doesn't get
         # screwed up by .transpose() with an object column present.
         dti_tz = pd.date_range('2016-01-01', periods=10, tz='US/Central')

--- a/pandas/tests/series/test_missing.py
+++ b/pandas/tests/series/test_missing.py
@@ -1322,6 +1322,7 @@ class TestSeriesInterpolateData(TestData):
     @pytest.mark.parametrize('use_idx', [True, False])
     @pytest.mark.parametrize('tz', [None, 'US/Central'])
     def test_interpolate_dt64_values(self, tz, use_idx):
+        # GH#21915
         dti = pd.date_range('2016-01-01', periods=10, tz=tz)
         index = dti if use_idx else None
 
@@ -1338,6 +1339,7 @@ class TestSeriesInterpolateData(TestData):
 
     @pytest.mark.parametrize('use_idx', [True, False])
     def test_interpolate_td64_values(self, use_idx):
+        # GH#21915
         tdi = pd.timedelta_range('1D', periods=10)
         index = tdi if use_idx else None
 


### PR DESCRIPTION
- [x] closes #11312, #11701, #19199,
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry

Two bugs here, one fixed, one avoided.  First is in `Block._interpolate` where datetimelike values were not cast correctly.  Second is that `DataFrame.transpose` will raise in some conditions (see #19198, also motivated #21908).

This adds dtype-handling code in `Block._interpolate`.  An alternative would be to override `_interpolate` in subclasses.  Either way works for me.

NB: This is only implemented for `method='linear'`.  I made that explicit in the tests as a reminder to follow-up with others.

(#19199 is marked as  a duplicate but it includes a bug report for the TZ-aware case that is separate bug.)