### PR TITLE
Added links to useful discussions of groupby and SettingWithCopyWarning

### DIFF
--- a/doc/source/groupby.rst
+++ b/doc/source/groupby.rst
@@ -1366,3 +1366,6 @@ column index name will be used as the name of the inserted column:
    result
 
    result.stack()
+
+Additional discussion can be found at `https://pythonforbiologists.com/when-to-use-aggregatefiltertransform-in-pandas/
+<https://pythonforbiologists.com/when-to-use-aggregatefiltertransform-in-pandas/>`_.

--- a/doc/source/indexing.rst
+++ b/doc/source/indexing.rst
@@ -1919,3 +1919,6 @@ This will **not** work at all, and so should be avoided:
    The chained assignment warnings / exceptions are aiming to inform the user of a possibly invalid
    assignment. There may be false positives; situations where a chained assignment is inadvertently
    reported.
+
+For additional discussion and explanation, see `https://www.dataquest.io/blog/settingwithcopywarning/
+<https://www.dataquest.io/blog/settingwithcopywarning/>`_.


### PR DESCRIPTION
Added links to useful discussions of `groupby` and `SettingWithCopyWarning`.

Did not run tests as only docs changed, but `python make.py --single groupby` and `python make.py --single indexing` successfully create the respective html files.

- [x] closes #17505
- [ ] tests added / passed
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
