### PR TITLE
[BUG][BLD] revert DEF component of #21878

### DIFF
--- a/pandas/_libs/src/numpy_helper.h
+++ b/pandas/_libs/src/numpy_helper.h
@@ -30,6 +30,23 @@ PANDAS_INLINE PyObject* get_value_1d(PyArrayObject* ap, Py_ssize_t i) {
     return PyArray_Scalar(item, PyArray_DESCR(ap), (PyObject*)ap);
 }
 
+// returns ASCII or UTF8 (py3) view on python str
+// python object owns memory, should not be freed
+PANDAS_INLINE const char* get_c_string(PyObject* obj) {
+#if PY_VERSION_HEX >= 0x03000000
+    return PyUnicode_AsUTF8(obj);
+#else
+    return PyString_AsString(obj);
+#endif
+}
+
+PANDAS_INLINE PyObject* char_to_string(const char* data) {
+#if PY_VERSION_HEX >= 0x03000000
+    return PyUnicode_FromString(data);
+#else
+    return PyString_FromString(data);
+#endif
+}
 
 void set_array_not_contiguous(PyArrayObject* ao) {
     ao->flags &= ~(NPY_ARRAY_C_CONTIGUOUS | NPY_ARRAY_F_CONTIGUOUS);

--- a/pandas/_libs/src/util.pxd
+++ b/pandas/_libs/src/util.pxd
@@ -4,9 +4,7 @@ cnp.import_array()
 
 cimport cpython
 from cpython cimport PyTypeObject
-from cpython.string cimport PyString_FromString, PyString_AsString
 
-DEF PY3 = bytes != str
 
 cdef extern from "Python.h":
     # Note: importing extern-style allows us to declare these as nogil
@@ -17,8 +15,6 @@ cdef extern from "Python.h":
     bint PyFloat_Check(object obj) nogil
     bint PyComplex_Check(object obj) nogil
     bint PyObject_TypeCheck(object obj, PyTypeObject* type) nogil
-    char* PyUnicode_AsUTF8(object unicode)
-    object PyUnicode_FromString(const char* u) nogil
 
 
 cdef extern from "numpy/arrayobject.h":
@@ -74,6 +70,8 @@ cdef extern from "numpy_helper.h":
     int assign_value_1d(ndarray, Py_ssize_t, object) except -1
     cnp.int64_t get_nat()
     object get_value_1d(ndarray, Py_ssize_t)
+    char *get_c_string(object) except NULL
+    object char_to_string(char*)
 
 ctypedef fused numeric:
     cnp.int8_t
@@ -102,26 +100,6 @@ cdef extern from "headers/stdint.h":
     enum: INT32_MIN
     enum: INT64_MAX
     enum: INT64_MIN
-
-
-cdef inline const char* get_c_string(object obj) except NULL:
-    """
-    returns ASCII or UTF8 (py3) view on python str
-    python object owns memory, should not be freed
-    """
-    # TODO: this docstring is copied verbatim from version that was
-    # directly in numpy_helper.C; is it still accurate?
-    IF PY3:
-        return PyUnicode_AsUTF8(obj)
-    ELSE:
-        return PyString_AsString(obj)
-
-
-cdef inline object char_to_string(const char* data):
-    IF PY3:
-        return PyUnicode_FromString(data)
-    ELSE:
-        return PyString_FromString(data)
 
 
 cdef inline object get_value_at(ndarray arr, object loc):

--- a/pandas/_libs/tslib.pyx
+++ b/pandas/_libs/tslib.pyx
@@ -53,7 +53,7 @@ from tslibs.timestamps cimport (create_timestamp_from_ts,
 from tslibs.timestamps import Timestamp
 
 
-DEF PY2 = str == bytes
+cdef bint PY2 = str == bytes
 
 
 cdef inline object create_datetime_from_ts(
@@ -555,9 +555,8 @@ cpdef array_to_datetime(ndarray[object] values, errors='raise',
                 if len(val) == 0 or val in nat_strings:
                     iresult[i] = NPY_NAT
                     continue
-                if PY2:
-                    if PyUnicode_Check(val):
-                        val = val.encode('utf-8')
+                if PyUnicode_Check(val) and PY2:
+                    val = val.encode('utf-8')
 
                 try:
                     _string_to_dts(val, &dts, &out_local, &out_tzoffset)

--- a/pandas/_libs/tslibs/period.pyx
+++ b/pandas/_libs/tslibs/period.pyx
@@ -52,7 +52,7 @@ from nattype cimport _nat_scalar_rules, NPY_NAT, is_null_datetimelike
 from offsets cimport to_offset
 from offsets import _Tick
 
-DEF PY2 = str == bytes
+cdef bint PY2 = str == bytes
 
 
 cdef extern from "period_helper.h":
@@ -728,7 +728,7 @@ cdef object _period_strftime(int64_t value, int freq, object fmt):
 
             result = result.replace(str_extra_fmts[i], repl)
 
-    IF PY2:
+    if PY2:
         result = result.decode('utf-8', 'ignore')
 
     return result


### PR DESCRIPTION
#21878 introduced a subtle build problem that is not caught by the CI.  Running `python setup.py build_ext --inplace` followed by `python3 setup.py build_ext --inplace` causes compile-time errors in py3 (or if running these in the opposite order, errors in py2).  These are fixed by running `python setup.py clean` in between.

This reverts the relevant changes.

For anyone curious: cython supports syntax:

```
DEF foo = [...]

IF foo:
    [...]
ELSE:
    [...]
```

and these IF/ELSE conditions get evaluated at compile-time.  #21878 incorrectly assumed that "compile-time" in this context meant ".c -> .so" time, not ".pyx -> .c" time.  In this we used:

```
DEF PY2 = str == bytes

IF PY2:
    [...]
ELSE:
    [...]
```

so after running `setup.py build_ext --inplace` in py2, the ".c" file we end up with has already gotten rid of the PY3 branches.  When we run `python3 setup.py build_ext --inplace` cython uses the existing .c file, tries to compile it to .so, and breaks.