### PR TITLE
Concatenation of series of differing types should lead to object

### DIFF
--- a/doc/source/whatsnew/v0.24.0.txt
+++ b/doc/source/whatsnew/v0.24.0.txt
@@ -257,6 +257,7 @@ ExtensionType Changes
 - Bug in :meth:`Series.get` for ``Series`` using ``ExtensionArray`` and integer index (:issue:`21257`)
 - :meth:`Series.combine()` works correctly with :class:`~pandas.api.extensions.ExtensionArray` inside of :class:`Series` (:issue:`20825`)
 - :meth:`Series.combine()` with scalar argument now works for any function type (:issue:`21248`)
+- Bug in :func:`concat` that lead to inconsistent behaviour for ExtensionArrays where the scalar representation was int or float (:issue:`21792`)
 -
 
 .. _whatsnew_0240.api.incompatibilities:

--- a/pandas/core/dtypes/concat.py
+++ b/pandas/core/dtypes/concat.py
@@ -180,6 +180,8 @@ def _concat_compat(to_concat, axis=0):
     extensions = [is_extension_array_dtype(x) for x in to_concat]
     if any(extensions) and axis == 1:
         to_concat = [np.atleast_2d(x.astype('object')) for x in to_concat]
+    elif any(extensions):
+        to_concat = [x.astype('object') for x in to_concat]
 
     if not nonempty:
         # we have all empties, but may need to coerce the result dtype to


### PR DESCRIPTION
- [x] closes #21792
- [ ] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry
 
I see no simple solution on how to make a test for this without introducing a whole new ExtensionArray class that is actually of scalar type `'i'`.

cc @jreback I'm wondering a bit why this has not yet been a problem for https://github.com/pandas-dev/pandas/pull/21160 

I have check that this fixes the problems I'm seeing in `fletcher` on `int` and `float` dtypes.