### PR TITLE
[BLD] Fix remaining compile-time warnings

### DIFF
--- a/pandas/_libs/groupby.pyx
+++ b/pandas/_libs/groupby.pyx
@@ -13,7 +13,7 @@ from numpy cimport (ndarray,
                     uint32_t, uint64_t, float32_t, float64_t)
 
 
-from util cimport numeric, get_nat
+from util cimport numeric, get_nat, npy_isnan
 
 from algos cimport (swap, TiebreakEnumType, TIEBREAK_AVERAGE, TIEBREAK_MIN,
                     TIEBREAK_MAX, TIEBREAK_FIRST, TIEBREAK_DENSE)
@@ -35,7 +35,7 @@ cdef inline float64_t median_linear(float64_t* a, int n) nogil:
 
     # count NAs
     for i in range(n):
-        if a[i] != a[i]:
+        if npy_isnan(a[i]):
             na_count += 1
 
     if na_count:
@@ -46,7 +46,7 @@ cdef inline float64_t median_linear(float64_t* a, int n) nogil:
 
         j = 0
         for i in range(n):
-            if a[i] == a[i]:
+            if not npy_isnan(a[i]):
                 tmp[j] = a[i]
                 j += 1
 
@@ -160,7 +160,7 @@ def group_cumprod_float64(float64_t[:, :] out,
                 continue
             for j in range(K):
                 val = values[i, j]
-                if val == val:
+                if not npy_isnan(val):
                     accum[lab, j] *= val
                     out[i, j] = accum[lab, j]
                 else:
@@ -199,7 +199,7 @@ def group_cumsum(numeric[:, :] out,
                 val = values[i, j]
 
                 if numeric == float32_t or numeric == float64_t:
-                    if val == val:
+                    if not npy_isnan(val):
                         accum[lab, j] += val
                         out[i, j] = accum[lab, j]
                     else:

--- a/pandas/_libs/groupby.pyx
+++ b/pandas/_libs/groupby.pyx
@@ -12,8 +12,13 @@ from numpy cimport (ndarray,
                     int8_t, int16_t, int32_t, int64_t, uint8_t, uint16_t,
                     uint32_t, uint64_t, float32_t, float64_t)
 
+cdef extern from "numpy/npy_math.h":
+    # Note: apparently npy_isnan has better windows-compat than
+    # the libc.math.isnan implementation
+    # See discussion: https://github.com/cython/cython/issues/550
+    bint npy_isnan(double x) nogil
 
-from util cimport numeric, get_nat, npy_isnan
+from util cimport numeric, get_nat
 
 from algos cimport (swap, TiebreakEnumType, TIEBREAK_AVERAGE, TIEBREAK_MIN,
                     TIEBREAK_MAX, TIEBREAK_FIRST, TIEBREAK_DENSE)

--- a/pandas/_libs/groupby_helper.pxi.in
+++ b/pandas/_libs/groupby_helper.pxi.in
@@ -340,7 +340,11 @@ def group_last_{{name}}(ndarray[{{dest_type2}}, ndim=2] out,
                 val = values[i, j]
 
                 # not nan
+                {{if c_type.startswith('float')}}
                 if not npy_isnan(val) and val != {{nan_val}}:
+                {{else}}
+                if val == val and val != {{nan_val}}:
+                {{endif}}
                     nobs[lab, j] += 1
                     resx[lab, j] = val
 
@@ -396,7 +400,11 @@ def group_nth_{{name}}(ndarray[{{dest_type2}}, ndim=2] out,
                 val = values[i, j]
 
                 # not nan
+                {{if c_type.startswith('float')}}
                 if not npy_isnan(val) and val != {{nan_val}}:
+                {{else}}
+                if val == val and val != {{nan_val}}:
+                {{endif}}
                     nobs[lab, j] += 1
                     if nobs[lab, j] == rank:
                         resx[lab, j] = val

--- a/pandas/_libs/groupby_helper.pxi.in
+++ b/pandas/_libs/groupby_helper.pxi.in
@@ -66,7 +66,7 @@ def group_add_{{name}}(ndarray[{{dest_type2}}, ndim=2] out,
                 val = values[i, j]
 
                 # not nan
-                if val == val:
+                if not npy_isnan(val):
                     nobs[lab, j] += 1
                     sumx[lab, j] += val
 
@@ -112,7 +112,7 @@ def group_prod_{{name}}(ndarray[{{dest_type2}}, ndim=2] out,
                 val = values[i, j]
 
                 # not nan
-                if val == val:
+                if not npy_isnan(val):
                     nobs[lab, j] += 1
                     prodx[lab, j] *= val
 
@@ -161,7 +161,7 @@ def group_var_{{name}}(ndarray[{{dest_type2}}, ndim=2] out,
                 val = values[i, j]
 
                 # not nan
-                if val == val:
+                if not npy_isnan(val):
                     nobs[lab, j] += 1
                     oldmean = mean[lab, j]
                     mean[lab, j] += (val - oldmean) / nobs[lab, j]
@@ -209,7 +209,7 @@ def group_mean_{{name}}(ndarray[{{dest_type2}}, ndim=2] out,
             for j in range(K):
                 val = values[i, j]
                 # not nan
-                if val == val:
+                if not npy_isnan(val):
                     nobs[lab, j] += 1
                     sumx[lab, j] += val
 
@@ -260,10 +260,10 @@ def group_ohlc_{{name}}(ndarray[{{dest_type2}}, ndim=2] out,
 
             counts[lab] += 1
             val = values[i, 0]
-            if val != val:
+            if npy_isnan(val):
                 continue
 
-            if out[lab, 0] != out[lab, 0]:
+            if npy_isnan(out[lab, 0]):
                 out[lab, 0] = out[lab, 1] = out[lab, 2] = out[lab, 3] = val
             else:
                 out[lab, 1] = max(out[lab, 1], val)
@@ -340,7 +340,7 @@ def group_last_{{name}}(ndarray[{{dest_type2}}, ndim=2] out,
                 val = values[i, j]
 
                 # not nan
-                if val == val and val != {{nan_val}}:
+                if not npy_isnan(val) and val != {{nan_val}}:
                     nobs[lab, j] += 1
                     resx[lab, j] = val
 
@@ -396,7 +396,7 @@ def group_nth_{{name}}(ndarray[{{dest_type2}}, ndim=2] out,
                 val = values[i, j]
 
                 # not nan
-                if val == val and val != {{nan_val}}:
+                if not npy_isnan(val) and val != {{nan_val}}:
                     nobs[lab, j] += 1
                     if nobs[lab, j] == rank:
                         resx[lab, j] = val
@@ -651,7 +651,7 @@ def group_max_{{name}}(ndarray[{{dest_type2}}, ndim=2] out,
                 {{if name == 'int64'}}
                 if val != {{nan_val}}:
                 {{else}}
-                if val == val and val != {{nan_val}}:
+                if not npy_isnan(val) and val != {{nan_val}}:
                 {{endif}}
                     nobs[lab, j] += 1
                     if val > maxx[lab, j]:
@@ -706,7 +706,7 @@ def group_min_{{name}}(ndarray[{{dest_type2}}, ndim=2] out,
                 {{if name == 'int64'}}
                 if val != {{nan_val}}:
                 {{else}}
-                if val == val and val != {{nan_val}}:
+                if not npy_isnan(val) and val != {{nan_val}}:
                 {{endif}}
                     nobs[lab, j] += 1
                     if val < minx[lab, j]:
@@ -754,7 +754,7 @@ def group_cummin_{{name}}(ndarray[{{dest_type2}}, ndim=2] out,
                     out[i, j] = {{nan_val}}
                 else:
                 {{else}}
-                if val == val:
+                if not npy_isnan(val):
                 {{endif}}
                     mval = accum[lab, j]
                     if val < mval:
@@ -795,7 +795,7 @@ def group_cummax_{{name}}(ndarray[{{dest_type2}}, ndim=2] out,
                     out[i, j] = {{nan_val}}
                 else:
                 {{else}}
-                if val == val:
+                if not npy_isnan(val):
                 {{endif}}
                     mval = accum[lab, j]
                     if val > mval:

--- a/pandas/_libs/hashtable.pyx
+++ b/pandas/_libs/hashtable.pyx
@@ -16,6 +16,7 @@ cnp.import_array()
 
 cdef extern from "numpy/npy_math.h":
     double NAN "NPY_NAN"
+    bint npy_isnan(double x) nogil
 
 
 from khash cimport (

--- a/pandas/_libs/hashtable_class_helper.pxi.in
+++ b/pandas/_libs/hashtable_class_helper.pxi.in
@@ -389,7 +389,7 @@ cdef class {{name}}HashTable(HashTable):
             for i in range(n):
                 val = values[i]
 
-                if val != val or (use_na_value and val == na_value2):
+                if npy_isnan(val) or (use_na_value and val == na_value2):
                     labels[i] = na_sentinel
                     continue
 
@@ -528,7 +528,7 @@ cdef class StringHashTable(HashTable):
     cpdef get_item(self, object val):
         cdef:
             khiter_t k
-            char *v
+            const char *v
         v = util.get_c_string(val)
 
         k = kh_get_str(self.table, v)
@@ -541,7 +541,7 @@ cdef class StringHashTable(HashTable):
         cdef:
             khiter_t k
             int ret = 0
-            char *v
+            const char *v
 
         v = util.get_c_string(val)
 
@@ -560,10 +560,10 @@ cdef class StringHashTable(HashTable):
             int64_t *resbuf = <int64_t*> labels.data
             khiter_t k
             kh_str_t *table = self.table
-            char *v
-            char **vecs
+            const char *v
+            const char **vecs
 
-        vecs = <char **> malloc(n * sizeof(char *))
+        vecs = <const char **> malloc(n * sizeof(char *))
         for i in range(n):
             val = values[i]
             v = util.get_c_string(val)
@@ -589,10 +589,10 @@ cdef class StringHashTable(HashTable):
             object val
             ObjectVector uniques
             khiter_t k
-            char *v
-            char **vecs
+            const char *v
+            const char **vecs
 
-        vecs = <char **> malloc(n * sizeof(char *))
+        vecs = <const char **> malloc(n * sizeof(char *))
         uindexer = np.empty(n, dtype=np.int64)
         for i in range(n):
             val = values[i]
@@ -627,12 +627,12 @@ cdef class StringHashTable(HashTable):
             Py_ssize_t i, n = len(values)
             int ret = 0
             object val
-            char *v
+            const char *v
             khiter_t k
             int64_t[:] locs = np.empty(n, dtype=np.int64)
 
         # these by-definition *must* be strings
-        vecs = <char **> malloc(n * sizeof(char *))
+        vecs = <const char**> malloc(n * sizeof(char *))
         for i in range(n):
             val = values[i]
 
@@ -660,12 +660,12 @@ cdef class StringHashTable(HashTable):
             Py_ssize_t i, n = len(values)
             int ret = 0
             object val
-            char *v
-            char **vecs
+            const char *v
+            const char**vecs
             khiter_t k
 
         # these by-definition *must* be strings
-        vecs = <char **> malloc(n * sizeof(char *))
+        vecs = <const char**> malloc(n * sizeof(char *))
         for i in range(n):
             val = values[i]
 
@@ -693,8 +693,8 @@ cdef class StringHashTable(HashTable):
             Py_ssize_t idx, count = count_prior
             int ret = 0
             object val
-            char *v
-            char **vecs
+            const char *v
+            const char**vecs
             khiter_t k
             bint use_na_value
 
@@ -705,7 +705,7 @@ cdef class StringHashTable(HashTable):
 
         # pre-filter out missing
         # and assign pointers
-        vecs = <char **> malloc(n * sizeof(char *))
+        vecs = <const char**> malloc(n * sizeof(char *))
         for i in range(n):
             val = values[i]
 

--- a/pandas/_libs/hashtable_class_helper.pxi.in
+++ b/pandas/_libs/hashtable_class_helper.pxi.in
@@ -389,7 +389,11 @@ cdef class {{name}}HashTable(HashTable):
             for i in range(n):
                 val = values[i]
 
+                {{if dtype == 'float64'}}
                 if npy_isnan(val) or (use_na_value and val == na_value2):
+                {{else}}
+                if val != val or (use_na_value and val == na_value2):
+                {{endif}}
                     labels[i] = na_sentinel
                     continue
 

--- a/pandas/_libs/hashtable_class_helper.pxi.in
+++ b/pandas/_libs/hashtable_class_helper.pxi.in
@@ -29,7 +29,7 @@ dtypes = [('Float64', 'float64', 'float64_t'),
 
 ctypedef struct {{name}}VectorData:
     {{arg}} *data
-    size_t n, m
+    Py_ssize_t n, m
 
 {{endif}}
 
@@ -147,7 +147,7 @@ cdef class StringVector:
     cdef resize(self):
         cdef:
             char **orig_data
-            size_t i, m
+            Py_ssize_t i, m
 
         m = self.data.m
         self.data.m = max(self.data.m * 4, _INIT_VEC_CAP)
@@ -172,7 +172,7 @@ cdef class StringVector:
     def to_array(self):
         cdef:
             ndarray ao
-            size_t n
+            Py_ssize_t n
             object val
 
         ao = np.empty(self.data.n, dtype=np.object)
@@ -198,7 +198,7 @@ cdef class ObjectVector:
 
     cdef:
         PyObject **data
-        size_t n, m
+        Py_ssize_t n, m
         ndarray ao
         bint external_view_exists
 
@@ -281,7 +281,7 @@ cdef class {{name}}HashTable(HashTable):
     def sizeof(self, deep=False):
         """ return the size of my table in bytes """
         return self.table.n_buckets * (sizeof({{dtype}}_t) + # keys
-                                       sizeof(size_t) + # vals
+                                       sizeof(Py_ssize_t) + # vals
                                        sizeof(uint32_t)) # flags
 
     cpdef get_item(self, {{dtype}}_t val):
@@ -522,7 +522,7 @@ cdef class StringHashTable(HashTable):
     def sizeof(self, deep=False):
         """ return the size of my table in bytes """
         return self.table.n_buckets * (sizeof(char *) + # keys
-                                       sizeof(size_t) + # vals
+                                       sizeof(Py_ssize_t) + # vals
                                        sizeof(uint32_t)) # flags
 
     cpdef get_item(self, object val):
@@ -769,7 +769,7 @@ cdef class PyObjectHashTable(HashTable):
     def sizeof(self, deep=False):
         """ return the size of my table in bytes """
         return self.table.n_buckets * (sizeof(PyObject *) + # keys
-                                       sizeof(size_t) + # vals
+                                       sizeof(Py_ssize_t) + # vals
                                        sizeof(uint32_t)) # flags
 
     cpdef get_item(self, object val):

--- a/pandas/_libs/hashtable_func_helper.pxi.in
+++ b/pandas/_libs/hashtable_func_helper.pxi.in
@@ -271,7 +271,12 @@ def ismember_{{dtype}}({{scalar}}[:] arr, {{scalar}}[:] values, bint hasnans=0):
             if k != table.n_buckets:
                 result[i] = 1
             else:
+                {{if dtype == 'float64'}}
                 result[i] = hasnans and npy_isnan(val)
+                {{else}}
+                result[i] = hasnans and val != val
+                {{endif}}
+
     {{endif}}
 
     kh_destroy_{{ttype}}(table)

--- a/pandas/_libs/hashtable_func_helper.pxi.in
+++ b/pandas/_libs/hashtable_func_helper.pxi.in
@@ -271,7 +271,7 @@ def ismember_{{dtype}}({{scalar}}[:] arr, {{scalar}}[:] values, bint hasnans=0):
             if k != table.n_buckets:
                 result[i] = 1
             else:
-                result[i] = hasnans and val != val
+                result[i] = hasnans and npy_isnan(val)
     {{endif}}
 
     kh_destroy_{{ttype}}(table)

--- a/pandas/_libs/src/datetime/np_datetime.c
+++ b/pandas/_libs/src/datetime/np_datetime.c
@@ -28,6 +28,15 @@ This file is derived from NumPy 1.7. See NUMPY_LICENSE.txt
 #define PyInt_AsLong PyLong_AsLong
 #endif
 
+// Silence "implicit declaration of function" warnings
+int convert_datetimestruct_to_datetime(NPY_DATETIMEUNIT base,
+                                       const npy_datetimestruct *dts,
+                                       npy_datetime *out);
+int convert_timedelta_to_timedeltastruct(NPY_DATETIMEUNIT base,
+                                         npy_timedelta td,
+                                         pandas_timedeltastruct *out);
+
+
 const npy_datetimestruct _NS_MIN_DTS = {
     1677, 9, 21, 0, 12, 43, 145225, 0, 0};
 const npy_datetimestruct _NS_MAX_DTS = {

--- a/pandas/_libs/src/parser/tokenizer.c
+++ b/pandas/_libs/src/parser/tokenizer.c
@@ -262,7 +262,7 @@ static int make_stream_space(parser_t *self, size_t nbytes) {
         ("\n\nmake_stream_space: nbytes = %zu.  grow_buffer(self->stream...)\n",
          nbytes))
     self->stream = (char *)grow_buffer((void *)self->stream, self->stream_len,
-                                       (size_t*)&self->stream_cap, nbytes * 2,
+                                       (int64_t*)&self->stream_cap, nbytes * 2,
                                        sizeof(char), &status);
     TRACE(
         ("make_stream_space: self->stream=%p, self->stream_len = %zu, "
@@ -289,7 +289,7 @@ static int make_stream_space(parser_t *self, size_t nbytes) {
     cap = self->words_cap;
     self->words =
         (char **)grow_buffer((void *)self->words, self->words_len,
-                             (size_t*)&self->words_cap, nbytes,
+                             (int64_t*)&self->words_cap, nbytes,
                              sizeof(char *), &status);
     TRACE(
         ("make_stream_space: grow_buffer(self->self->words, %zu, %zu, %zu, "
@@ -320,7 +320,7 @@ static int make_stream_space(parser_t *self, size_t nbytes) {
     cap = self->lines_cap;
     self->line_start =
         (int64_t *)grow_buffer((void *)self->line_start, self->lines + 1,
-                           (size_t*)&self->lines_cap, nbytes,
+                           (int64_t*)&self->lines_cap, nbytes,
                            sizeof(int64_t), &status);
     TRACE((
         "make_stream_space: grow_buffer(self->line_start, %zu, %zu, %zu, %d)\n",

--- a/pandas/_libs/src/util.pxd
+++ b/pandas/_libs/src/util.pxd
@@ -29,12 +29,6 @@ cdef extern from "numpy/ndarrayobject.h":
     bint PyArray_IsIntegerScalar(obj) nogil
     bint PyArray_Check(obj) nogil
 
-cdef extern from "numpy/npy_math.h":
-    # Note: apparently npy_isnan has better windows-compat than
-    # the libc.math.isnan implementation
-    # See discussion: https://github.com/cython/cython/issues/550
-    bint npy_isnan(double x) nogil
-
 # --------------------------------------------------------------------
 # Type Checking
 
@@ -165,7 +159,7 @@ cdef inline is_array(object o):
 
 cdef inline bint _checknull(object val):
     try:
-        return val is None or (cpython.PyFloat_Check(val) and npy_isnan(val))
+        return val is None or (cpython.PyFloat_Check(val) and val != val)
     except ValueError:
         return False
 

--- a/pandas/_libs/src/util.pxd
+++ b/pandas/_libs/src/util.pxd
@@ -32,6 +32,7 @@ cdef extern from "numpy/ndarrayobject.h":
 cdef extern from "numpy/npy_math.h":
     # Note: apparently npy_isnan has better windows-compat than
     # the libc.math.isnan implementation
+    # See discussion: https://github.com/cython/cython/issues/550
     bint npy_isnan(double x) nogil
 
 # --------------------------------------------------------------------
@@ -75,7 +76,7 @@ cdef extern from "numpy_helper.h":
     int assign_value_1d(ndarray, Py_ssize_t, object) except -1
     cnp.int64_t get_nat()
     object get_value_1d(ndarray, Py_ssize_t)
-    char *get_c_string(object) except NULL
+    const char *get_c_string(object) except NULL
     object char_to_string(char*)
 
 ctypedef fused numeric:

--- a/pandas/_libs/src/util.pxd
+++ b/pandas/_libs/src/util.pxd
@@ -29,6 +29,11 @@ cdef extern from "numpy/ndarrayobject.h":
     bint PyArray_IsIntegerScalar(obj) nogil
     bint PyArray_Check(obj) nogil
 
+cdef extern from "numpy/npy_math.h":
+    # Note: apparently npy_isnan has better windows-compat than
+    # the libc.math.isnan implementation
+    bint npy_isnan(double x) nogil
+
 # --------------------------------------------------------------------
 # Type Checking
 
@@ -159,7 +164,7 @@ cdef inline is_array(object o):
 
 cdef inline bint _checknull(object val):
     try:
-        return val is None or (cpython.PyFloat_Check(val) and val != val)
+        return val is None or (cpython.PyFloat_Check(val) and npy_isnan(val))
     except ValueError:
         return False
 

--- a/pandas/io/msgpack/_unpacker.pyx
+++ b/pandas/io/msgpack/_unpacker.pyx
@@ -139,7 +139,7 @@ def unpackb(object packed, object object_hook=None, object list_hook=None,
     ret = unpack_construct(&ctx, buf, buf_len, &off)
     if ret == 1:
         obj = unpack_data(&ctx)
-        if off < buf_len:
+        if <Py_ssize_t>off < buf_len:
             raise ExtraData(obj, PyBytes_FromStringAndSize(
                 buf + off, buf_len - off))
         return obj
@@ -367,9 +367,11 @@ cdef class Unpacker(object):
         self.buf_tail = tail + _buf_len
 
     cdef read_from_file(self):
+        # Assume self.max_buffer_size - (self.buf_tail - self.buf_head) >= 0
         next_bytes = self.file_like_read(
             min(self.read_size,
-                self.max_buffer_size - (self.buf_tail - self.buf_head)))
+                <Py_ssize_t>(self.max_buffer_size -
+                             (self.buf_tail - self.buf_head))))
         if next_bytes:
             self.append_buffer(PyBytes_AsString(next_bytes),
                                PyBytes_Size(next_bytes))
@@ -417,7 +419,9 @@ cdef class Unpacker(object):
     def read_bytes(self, Py_ssize_t nbytes):
         """Read a specified number of raw bytes from the stream"""
         cdef size_t nread
-        nread = min(self.buf_tail - self.buf_head, nbytes)
+
+        # Assume that self.buf_tail - self.buf_head >= 0
+        nread = min(<Py_ssize_t>(self.buf_tail - self.buf_head), nbytes)
         ret = PyBytes_FromStringAndSize(self.buf + self.buf_head, nread)
         self.buf_head += nread
         if len(ret) < nbytes and self.file_like is not None:


### PR DESCRIPTION
With the exception of Numpy-Deprecated-API-1.7 warnings that _any_ cython code produces, this fixes all remaining compiler warnings (... on py27, there's still a whole mess of them in py37).

Based on a little bit of profiling it looked like `npy_isnan(x)` gives a 40% perf improvement over `x != x`.  But profiling is hard, so who knows.  In the comment where npy_nan is imported there is a link to a discussion about it.