### PR TITLE
DOC add Python 2.7 warning to recent whatsnew; include 23.3

### DIFF
--- a/doc/source/whatsnew.rst
+++ b/doc/source/whatsnew.rst
@@ -20,6 +20,8 @@ These are new features and improvements of note in each release.
 
 .. include:: whatsnew/v0.24.0.txt
 
+.. include:: whatsnew/v0.23.3.txt
+
 .. include:: whatsnew/v0.23.2.txt
 
 .. include:: whatsnew/v0.23.1.txt

--- a/doc/source/whatsnew/v0.23.1.txt
+++ b/doc/source/whatsnew/v0.23.1.txt
@@ -6,6 +6,11 @@ v0.23.1 (June 12, 2018)
 This is a minor bug-fix release in the 0.23.x series and includes some small regression fixes
 and bug fixes. We recommend that all users upgrade to this version.
 
+.. warning::
+
+   Starting January 1, 2019, pandas feature releases will support Python 3 only.
+   See :ref:`install.dropping-27` for more.
+
 .. contents:: What's new in v0.23.1
     :local:
     :backlinks: none

--- a/doc/source/whatsnew/v0.23.2.txt
+++ b/doc/source/whatsnew/v0.23.2.txt
@@ -11,6 +11,10 @@ and bug fixes. We recommend that all users upgrade to this version.
    Pandas 0.23.2 is first pandas release that's compatible with
    Python 3.7 (:issue:`20552`)
 
+.. warning::
+
+   Starting January 1, 2019, pandas feature releases will support Python 3 only.
+   See :ref:`install.dropping-27` for more.
 
 .. contents:: What's new in v0.23.2
     :local:

--- a/doc/source/whatsnew/v0.23.4.txt
+++ b/doc/source/whatsnew/v0.23.4.txt
@@ -6,6 +6,10 @@ v0.23.4
 This is a minor bug-fix release in the 0.23.x series and includes some small regression fixes
 and bug fixes. We recommend that all users upgrade to this version.
 
+.. warning::
+
+   Starting January 1, 2019, pandas feature releases will support Python 3 only.
+   See :ref:`install.dropping-27` for more.
 
 .. contents:: What's new in v0.23.4
     :local:

--- a/doc/source/whatsnew/v0.24.0.txt
+++ b/doc/source/whatsnew/v0.24.0.txt
@@ -3,6 +3,11 @@
 v0.24.0 (Month XX, 2018)
 ------------------------
 
+.. warning::
+
+   Starting January 1, 2019, pandas feature releases will support Python 3 only.
+   See :ref:`install.dropping-27` for more.
+
 .. _whatsnew_0240.enhancements:
 
 New features


### PR DESCRIPTION
#18894 laid out:
> We should add a big note on the top of each whatsnew that we are planning on dropping 2.7 support as of the end of 2018.

So far, this warning only appeared in v0.23.0, and can be easily missed these days. This PR adds them to the recent whatsnews, and also includes v0.23.3 in `whatsnew.rst`
