### PR TITLE
[CLN] update and clean up imports

### DIFF
--- a/pandas/_libs/parsers.pyx
+++ b/pandas/_libs/parsers.pyx
@@ -53,7 +53,7 @@ from pandas.core.dtypes.common import (
     pandas_dtype)
 from pandas.core.arrays import Categorical
 from pandas.core.dtypes.concat import union_categoricals
-import pandas.io.common as com
+import pandas.io.common as iocom
 
 from pandas.errors import (ParserError, DtypeWarning,
                            EmptyDataError, ParserWarning)
@@ -665,7 +665,8 @@ cdef class TextReader:
             if b'utf-16' in (self.encoding or b''):
                 # we need to read utf-16 through UTF8Recoder.
                 # if source is utf-16, convert source to utf-8 by UTF8Recoder.
-                source = com.UTF8Recoder(source, self.encoding.decode('utf-8'))
+                source = iocom.UTF8Recoder(source,
+                                           self.encoding.decode('utf-8'))
                 self.encoding = b'utf-8'
                 self.c_encoding = <char*> self.encoding
 
@@ -1356,7 +1357,7 @@ cdef asbytes(object o):
 # common NA values
 # no longer excluding inf representations
 # '1.#INF','-1.#INF', '1.#INF000000',
-_NA_VALUES = _ensure_encoded(list(com._NA_VALUES))
+_NA_VALUES = _ensure_encoded(list(iocom._NA_VALUES))
 
 
 def _maybe_upcast(arr):

--- a/pandas/io/clipboards.py
+++ b/pandas/io/clipboards.py
@@ -1,10 +1,11 @@
 """ io on the clipboard """
 import warnings
 
+from pandas import compat
 from pandas.compat import StringIO, PY2, PY3
 
 from pandas.core.dtypes.generic import ABCDataFrame
-from pandas import compat, get_option, option_context
+from pandas import get_option, option_context
 
 
 def read_clipboard(sep=r'\s+', **kwargs):  # pragma: no cover

--- a/pandas/io/common.py
+++ b/pandas/io/common.py
@@ -7,15 +7,17 @@ import mmap
 from contextlib import contextmanager, closing
 import zipfile
 
-from pandas.compat import StringIO, BytesIO, string_types, text_type
-from pandas import compat
-from pandas.io.formats.printing import pprint_thing
-import pandas.core.common as com
-from pandas.core.dtypes.common import is_number, is_file_like
-
 # compat
 from pandas.errors import (ParserError, DtypeWarning,  # noqa
-                           EmptyDataError, ParserWarning)
+                           EmptyDataError, ParserWarning, AbstractMethodError)
+
+from pandas.compat import StringIO, BytesIO, string_types, text_type
+from pandas import compat
+
+from pandas.core.dtypes.common import is_number, is_file_like
+
+from pandas.io.formats.printing import pprint_thing
+
 
 # gh-12665: Alias for now and remove later.
 CParserError = ParserError
@@ -67,7 +69,7 @@ class BaseIterator(object):
         return self
 
     def __next__(self):
-        raise com.AbstractMethodError(self)
+        raise AbstractMethodError(self)
 
 
 if not compat.PY3:

--- a/pandas/io/feather_format.py
+++ b/pandas/io/feather_format.py
@@ -1,8 +1,11 @@
 """ feather-format compat """
 
 from distutils.version import LooseVersion
-from pandas import DataFrame, RangeIndex, Int64Index
 from pandas.compat import range
+
+from pandas.core.dtypes.generic import ABCDataFrame, ABCInt64Index
+from pandas import RangeIndex
+
 from pandas.io.common import _stringify_path
 
 
@@ -45,7 +48,7 @@ def to_feather(df, path):
 
     """
     path = _stringify_path(path)
-    if not isinstance(df, DataFrame):
+    if not isinstance(df, ABCDataFrame):
         raise ValueError("feather only support IO with DataFrames")
 
     feather = _try_import()
@@ -57,7 +60,7 @@ def to_feather(df, path):
     # validate that we have only a default index
     # raise on anything else as we don't serialize the index
 
-    if not isinstance(df.index, Int64Index):
+    if not isinstance(df.index, ABCInt64Index):
         raise ValueError("feather does not support serializing {} "
                          "for the index; you can .reset_index()"
                          "to make the index into column(s)".format(

--- a/pandas/io/formats/style.py
+++ b/pandas/io/formats/style.py
@@ -14,22 +14,23 @@ try:
         PackageLoader, Environment, ChoiceLoader, FileSystemLoader
     )
 except ImportError:
-    msg = "pandas.Styler requires jinja2. "\
-          "Please install with `conda install Jinja2`\n"\
-          "or `pip install Jinja2`"
+    msg = ("pandas.Styler requires jinja2. "
+           "Please install with `conda install Jinja2`\n"
+           "or `pip install Jinja2`")
     raise ImportError(msg)
 
-from pandas.core.dtypes.common import is_float, is_string_like
-
 import numpy as np
-import pandas as pd
-from pandas.api.types import is_list_like
+
+from pandas.util._decorators import Appender
 from pandas.compat import range
+
+from pandas.core.dtypes.common import is_float, is_string_like, is_list_like
+
+import pandas as pd
 from pandas.core.config import get_option
 from pandas.core.generic import _shared_docs
 import pandas.core.common as com
 from pandas.core.indexing import _maybe_numeric_slice, _non_reducing_slice
-from pandas.util._decorators import Appender
 try:
     import matplotlib.pyplot as plt
     from matplotlib import colors

--- a/pandas/io/html.py
+++ b/pandas/io/html.py
@@ -10,15 +10,17 @@ import collections
 
 from distutils.version import LooseVersion
 
-from pandas.core.dtypes.common import is_list_like
-from pandas.errors import EmptyDataError
-from pandas.io.common import _is_url, urlopen, _validate_header_arg
-from pandas.io.parsers import TextParser
+from pandas.errors import AbstractMethodError, EmptyDataError
+
 from pandas.compat import (lrange, lmap, u, string_types, iteritems,
                            raise_with_traceback, binary_type)
+
+from pandas.core.dtypes.common import is_list_like
 from pandas import Series
-import pandas.core.common as com
+
 from pandas.io.formats.printing import pprint_thing
+from pandas.io.common import _is_url, urlopen, _validate_header_arg
+from pandas.io.parsers import TextParser
 
 _IMPORTS = False
 _HAS_BS4 = False
@@ -253,7 +255,7 @@ class _HtmlFrameParser(object):
         text : str or unicode
             The text from an individual DOM node.
         """
-        raise com.AbstractMethodError(self)
+        raise AbstractMethodError(self)
 
     def _parse_td(self, obj):
         """Return the td elements from a row element.
@@ -268,7 +270,7 @@ class _HtmlFrameParser(object):
         list of node-like
             These are the elements of each row, i.e., the columns.
         """
-        raise com.AbstractMethodError(self)
+        raise AbstractMethodError(self)
 
     def _parse_thead_tr(self, table):
         """
@@ -283,7 +285,7 @@ class _HtmlFrameParser(object):
         list of node-like
             These are the <tr> row elements of a table.
         """
-        raise com.AbstractMethodError(self)
+        raise AbstractMethodError(self)
 
     def _parse_tbody_tr(self, table):
         """
@@ -302,7 +304,7 @@ class _HtmlFrameParser(object):
         list of node-like
             These are the <tr> row elements of a table.
         """
-        raise com.AbstractMethodError(self)
+        raise AbstractMethodError(self)
 
     def _parse_tfoot_tr(self, table):
         """
@@ -317,7 +319,7 @@ class _HtmlFrameParser(object):
         list of node-like
             These are the <tr> row elements of a table.
         """
-        raise com.AbstractMethodError(self)
+        raise AbstractMethodError(self)
 
     def _parse_tables(self, doc, match, attrs):
         """
@@ -343,7 +345,7 @@ class _HtmlFrameParser(object):
         list of node-like
             HTML <table> elements to be parsed into raw data.
         """
-        raise com.AbstractMethodError(self)
+        raise AbstractMethodError(self)
 
     def _equals_tag(self, obj, tag):
         """
@@ -362,7 +364,7 @@ class _HtmlFrameParser(object):
         boolean
             Whether `obj`'s tag name is `tag`
         """
-        raise com.AbstractMethodError(self)
+        raise AbstractMethodError(self)
 
     def _build_doc(self):
         """
@@ -373,7 +375,7 @@ class _HtmlFrameParser(object):
         node-like
             The DOM from which to parse the table element.
         """
-        raise com.AbstractMethodError(self)
+        raise AbstractMethodError(self)
 
     def _parse_thead_tbody_tfoot(self, table_html):
         """

--- a/pandas/io/json/json.py
+++ b/pandas/io/json/json.py
@@ -1,23 +1,30 @@
 # pylint: disable-msg=E1101,W0613,W0603
 from itertools import islice
 import os
+
 import numpy as np
 
 import pandas._libs.json as json
 from pandas._libs.tslibs import iNaT
+
+from pandas.errors import AbstractMethodError
+
+from pandas import compat
 from pandas.compat import StringIO, long, u, to_str
-from pandas import compat, isna
-from pandas import Series, DataFrame, to_datetime, MultiIndex
+
+from pandas.core.dtypes.common import is_period_dtype
+from pandas.core.dtypes.generic import ABCMultiIndex
+
+from pandas import Series, DataFrame, to_datetime, isna, concat
+
 from pandas.io.common import (get_filepath_or_buffer, _get_handle,
                               _infer_compression, _stringify_path,
                               BaseIterator)
-from pandas.io.parsers import _validate_integer
-import pandas.core.common as com
-from pandas.core.reshape.concat import concat
 from pandas.io.formats.printing import pprint_thing
+from pandas.io.parsers import _validate_integer
+
 from .normalize import _convert_to_line_delimits
 from .table_schema import build_table_schema, parse_table_schema
-from pandas.core.dtypes.common import is_period_dtype
 
 loads = json.loads
 dumps = json.dumps
@@ -93,7 +100,7 @@ class Writer(object):
         self._format_axes()
 
     def _format_axes(self):
-        raise com.AbstractMethodError(self)
+        raise AbstractMethodError(self)
 
     def write(self):
         return self._write(self.obj, self.orient, self.double_precision,
@@ -181,7 +188,7 @@ class JSONTableWriter(FrameWriter):
         self.schema = build_table_schema(obj, index=self.index)
 
         # NotImplementd on a column MultiIndex
-        if obj.ndim == 2 and isinstance(obj.columns, MultiIndex):
+        if obj.ndim == 2 and isinstance(obj.columns, ABCMultiIndex):
             raise NotImplementedError(
                 "orient='table' is not supported for MultiIndex")
 
@@ -654,7 +661,7 @@ class Parser(object):
                 setattr(self.obj, axis, new_axis)
 
     def _try_convert_types(self):
-        raise com.AbstractMethodError(self)
+        raise AbstractMethodError(self)
 
     def _try_convert_data(self, name, data, use_dtypes=True,
                           convert_dates=True):
@@ -767,7 +774,7 @@ class Parser(object):
         return data, False
 
     def _try_convert_dates(self):
-        raise com.AbstractMethodError(self)
+        raise AbstractMethodError(self)
 
 
 class SeriesParser(Parser):

--- a/pandas/io/packers.py
+++ b/pandas/io/packers.py
@@ -39,12 +39,20 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 """
 
 from datetime import datetime, date, timedelta
-from dateutil.parser import parse
 import os
 from textwrap import dedent
 import warnings
 
 import numpy as np
+from dateutil.parser import parse
+
+from pandas.util._move import (
+    BadMove as _BadMove,
+    move_into_mutable_buffer as _move_into_mutable_buffer,
+)
+
+from pandas.errors import PerformanceWarning
+
 from pandas import compat
 from pandas.compat import u, u_safe
 
@@ -61,16 +69,11 @@ from pandas.core.arrays import IntervalArray
 from pandas.core.sparse.api import SparseSeries, SparseDataFrame
 from pandas.core.sparse.array import BlockIndex, IntIndex
 from pandas.core.generic import NDFrame
-from pandas.errors import PerformanceWarning
-from pandas.io.common import get_filepath_or_buffer, _stringify_path
 from pandas.core.internals import BlockManager, make_block, _safe_reshape
 import pandas.core.internals as internals
 
+from pandas.io.common import get_filepath_or_buffer, _stringify_path
 from pandas.io.msgpack import Unpacker as _Unpacker, Packer as _Packer, ExtType
-from pandas.util._move import (
-    BadMove as _BadMove,
-    move_into_mutable_buffer as _move_into_mutable_buffer,
-)
 
 # check which compression libs we have installed
 try:

--- a/pandas/io/parquet.py
+++ b/pandas/io/parquet.py
@@ -2,9 +2,13 @@
 
 from warnings import catch_warnings
 from distutils.version import LooseVersion
-from pandas import DataFrame, RangeIndex, Int64Index, get_option
+
+import pandas.core.dtypes.generic as gt
+
+from pandas import RangeIndex, get_option
 from pandas.compat import string_types
 import pandas.core.common as com
+
 from pandas.io.common import get_filepath_or_buffer, is_s3_url
 
 
@@ -47,7 +51,7 @@ class BaseImpl(object):
     @staticmethod
     def validate_dataframe(df):
 
-        if not isinstance(df, DataFrame):
+        if not isinstance(df, gt.ABCDataFrame):
             raise ValueError("to_parquet only supports IO with DataFrames")
 
         # must have value column names (strings only)
@@ -140,15 +144,14 @@ class PyArrowImpl(BaseImpl):
     def _validate_write_lt_070(self, df):
         # Compatibility shim for pyarrow < 0.7.0
         # TODO: Remove in pandas 0.23.0
-        from pandas.core.indexes.multi import MultiIndex
-        if isinstance(df.index, MultiIndex):
+        if isinstance(df.index, gt.ABCMultiIndex):
             msg = (
                 "Multi-index DataFrames are only supported "
                 "with pyarrow >= 0.7.0"
             )
             raise ValueError(msg)
         # Validate index
-        if not isinstance(df.index, Int64Index):
+        if not isinstance(df.index, gt.ABCInt64Index):
             msg = (
                 "pyarrow < 0.7.0 does not support serializing {} for the "
                 "index; you can .reset_index() to make the index into "

--- a/pandas/io/parsers.py
+++ b/pandas/io/parsers.py
@@ -12,9 +12,16 @@ from textwrap import fill
 
 import numpy as np
 
+from pandas._libs import lib, parsers, ops as libops
+from pandas._libs.tslibs import parsing
+
+from pandas.util._decorators import Appender
+from pandas.errors import ParserWarning, ParserError, EmptyDataError
+
 from pandas import compat
 from pandas.compat import (range, lrange, PY3, StringIO, lzip,
                            zip, string_types, map, u)
+
 from pandas.core.dtypes.common import (
     is_integer, ensure_object,
     is_list_like, is_integer_dtype,
@@ -24,6 +31,7 @@ from pandas.core.dtypes.common import (
 from pandas.core.dtypes.dtypes import CategoricalDtype
 from pandas.core.dtypes.missing import isna
 from pandas.core.dtypes.cast import astype_nansafe
+
 from pandas.core.index import (Index, MultiIndex, RangeIndex,
                                ensure_index_from_sequences)
 from pandas.core.series import Series
@@ -31,20 +39,14 @@ from pandas.core.frame import DataFrame
 from pandas.core.arrays import Categorical
 from pandas.core import algorithms
 import pandas.core.common as com
+from pandas.core.tools import datetimes as tools
+
 from pandas.io.date_converters import generic_parser
-from pandas.errors import ParserWarning, ParserError, EmptyDataError
 from pandas.io.common import (get_filepath_or_buffer, is_file_like,
                               _validate_header_arg, _get_handle,
                               UnicodeReader, UTF8Recoder, _NA_VALUES,
                               BaseIterator, _infer_compression)
-from pandas.core.tools import datetimes as tools
 
-from pandas.util._decorators import Appender
-
-import pandas._libs.lib as lib
-import pandas._libs.parsers as parsers
-import pandas._libs.ops as libops
-from pandas._libs.tslibs import parsing
 
 # BOM character (byte order mark)
 # This exists at the beginning of a file to indicate endianness

--- a/pandas/io/sql.py
+++ b/pandas/io/sql.py
@@ -6,25 +6,27 @@ retrieval and to reduce dependency on DB-specific API.
 
 from __future__ import print_function, division
 from datetime import datetime, date, time
-
+from contextlib import contextmanager
 import warnings
 import re
+
 import numpy as np
 
 import pandas._libs.lib as lib
+
+from pandas.compat import (map, zip, raise_with_traceback,
+                           string_types, text_type)
+
+from pandas.core.dtypes.generic import ABCSeries
 from pandas.core.dtypes.missing import isna
 from pandas.core.dtypes.dtypes import DatetimeTZDtype
 from pandas.core.dtypes.common import (
     is_list_like, is_dict_like,
     is_datetime64tz_dtype)
 
-from pandas.compat import (map, zip, raise_with_traceback,
-                           string_types, text_type)
-from pandas.core.api import DataFrame, Series
+from pandas.core.api import DataFrame
 from pandas.core.base import PandasObject
 from pandas.core.tools.datetimes import to_datetime
-
-from contextlib import contextmanager
 
 
 class SQLAlchemyRequired(ImportError):
@@ -439,7 +441,7 @@ def to_sql(frame, name, con, schema=None, if_exists='fail', index=True,
 
     pandas_sql = pandasSQL_builder(con, schema=schema)
 
-    if isinstance(frame, Series):
+    if isinstance(frame, ABCSeries):
         frame = frame.to_frame()
     elif not isinstance(frame, DataFrame):
         raise NotImplementedError("'frame' argument should be either a "

--- a/pandas/plotting/_timeseries.py
+++ b/pandas/plotting/_timeseries.py
@@ -8,9 +8,9 @@ from matplotlib import pylab
 from pandas._libs.tslibs.period import Period
 
 from pandas.core.dtypes.generic import (
-    ABCPeriodIndex, ABCDatetimeIndex, ABCTimedeltaIndex)
+    ABCPeriodIndex, ABCDatetimeIndex, ABCTimedeltaIndex,
+    ABCDateOffset)
 
-from pandas.tseries.offsets import DateOffset
 import pandas.tseries.frequencies as frequencies
 
 from pandas.io.formats.printing import pprint_thing
@@ -209,7 +209,7 @@ def _get_freq(ax, series):
         freq = ax_freq
 
     # get the period frequency
-    if isinstance(freq, DateOffset):
+    if isinstance(freq, ABCDateOffset):
         freq = freq.rule_code
     else:
         freq = frequencies.get_base_alias(freq)
@@ -231,7 +231,7 @@ def _use_dynamic_x(ax, data):
     if freq is None:
         return False
 
-    if isinstance(freq, DateOffset):
+    if isinstance(freq, ABCDateOffset):
         freq = freq.rule_code
     else:
         freq = frequencies.get_base_alias(freq)
@@ -269,7 +269,7 @@ def _maybe_convert_index(ax, data):
 
         if freq is None:
             freq = getattr(data.index, 'inferred_freq', None)
-        if isinstance(freq, DateOffset):
+        if isinstance(freq, ABCDateOffset):
             freq = freq.rule_code
 
         if freq is None:

--- a/pandas/tseries/holiday.py
+++ b/pandas/tseries/holiday.py
@@ -1,11 +1,13 @@
+from datetime import datetime, timedelta
 import warnings
 
-from pandas import DateOffset, DatetimeIndex, Series, Timestamp
-from pandas.compat import add_metaclass
-from datetime import datetime, timedelta
-from dateutil.relativedelta import MO, TU, WE, TH, FR, SA, SU  # noqa
-from pandas.tseries.offsets import Easter, Day
 import numpy as np
+from dateutil.relativedelta import MO, TU, WE, TH, FR, SA, SU  # noqa
+
+from pandas.compat import add_metaclass
+
+from pandas import DatetimeIndex, Series, Timestamp
+from pandas.tseries.offsets import Easter, Day, DateOffset
 
 
 def next_monday(dt):


### PR DESCRIPTION
Use ABCFoo classes in cases where doing so allow us to avoid a heavier import.

Change a few cases of `com.AbstractMethodError` to import from `pandas.errors`

Otherwise mostly just rearranging imports in encouraged order.
