### PR TITLE
BUG: bug in GroupBy.count where arg minlength passed to np.bincount must be None for np<1.13

### DIFF
--- a/doc/source/whatsnew/v0.23.4.txt
+++ b/doc/source/whatsnew/v0.23.4.txt
@@ -32,7 +32,6 @@ Bug Fixes
 
 - Bug where calling :func:`DataFrameGroupBy.agg` with a list of functions including ``ohlc`` as the non-initial element would raise a ``ValueError`` (:issue:`21716`)
 - Bug in ``roll_quantile`` caused a memory leak when calling ``.rolling(...).quantile(q)`` with ``q`` in (0,1) (:issue:`21965`)
-- Bug in :func:`pandas.core.groupby.SeriesGroupBy.count` when using numpy < 1.13 and ngroups=0 (:issue:`21956`).
 -
 
 **Conversion**

--- a/doc/source/whatsnew/v0.23.4.txt
+++ b/doc/source/whatsnew/v0.23.4.txt
@@ -32,6 +32,7 @@ Bug Fixes
 
 - Bug where calling :func:`DataFrameGroupBy.agg` with a list of functions including ``ohlc`` as the non-initial element would raise a ``ValueError`` (:issue:`21716`)
 - Bug in ``roll_quantile`` caused a memory leak when calling ``.rolling(...).quantile(q)`` with ``q`` in (0,1) (:issue:`21965`)
+- Bug in :func:`pandas.core.groupby.SeriesGroupBy.count` when using numpy < 1.13 and ngroups=0 (:issue:`21956`).
 -
 
 **Conversion**

--- a/doc/source/whatsnew/v0.24.0.txt
+++ b/doc/source/whatsnew/v0.24.0.txt
@@ -536,11 +536,11 @@ Groupby/Resample/Rolling
 
 - Bug in :func:`pandas.core.groupby.GroupBy.first` and :func:`pandas.core.groupby.GroupBy.last` with ``as_index=False`` leading to the loss of timezone information (:issue:`15884`)
 - Bug in :meth:`DatetimeIndex.resample` when downsampling across a DST boundary (:issue:`8531`)
--
--
-
+- Bug where ``ValueError`` is wrongly raised when calling :func:`~pandas.core.groupby.SeriesGroupBy.count` method of a
+  ``SeriesGroupBy`` when the grouping variable only contains NaNs and numpy version < 1.13 (:issue:`21956`).
 - Multiple bugs in :func:`pandas.core.Rolling.min` with ``closed='left'` and a
   datetime-like index leading to incorrect results and also segfault. (:issue:`21704`)
+-
 
 Sparse
 ^^^^^^

--- a/pandas/core/groupby/generic.py
+++ b/pandas/core/groupby/generic.py
@@ -46,7 +46,6 @@ from pandas.core.base import SpecificationError, DataError
 from pandas.core.index import Index, MultiIndex, CategoricalIndex
 from pandas.core.arrays.categorical import Categorical
 from pandas.core.internals import BlockManager, make_block
-from pandas.compat.numpy import _np_version_under1p13
 
 from pandas.plotting._core import boxplot_frame_groupby
 
@@ -1208,10 +1207,7 @@ class SeriesGroupBy(GroupBy):
 
         mask = (ids != -1) & ~isna(val)
         ids = ensure_platform_int(ids)
-        minlength = ngroups or 0
-        if _np_version_under1p13 and minlength == 0:
-            minlength = None
-        out = np.bincount(ids[mask], minlength=minlength)
+        out = np.bincount(ids[mask], minlength=ngroups or None)
 
         return Series(out,
                       index=self.grouper.result_index,

--- a/pandas/core/groupby/generic.py
+++ b/pandas/core/groupby/generic.py
@@ -46,6 +46,7 @@ from pandas.core.base import SpecificationError, DataError
 from pandas.core.index import Index, MultiIndex, CategoricalIndex
 from pandas.core.arrays.categorical import Categorical
 from pandas.core.internals import BlockManager, make_block
+from pandas.compat.numpy import _np_version_under1p13
 
 from pandas.plotting._core import boxplot_frame_groupby
 
@@ -1207,7 +1208,10 @@ class SeriesGroupBy(GroupBy):
 
         mask = (ids != -1) & ~isna(val)
         ids = ensure_platform_int(ids)
-        out = np.bincount(ids[mask], minlength=ngroups or 0)
+        minlength = ngroups or 0
+        if _np_version_under1p13 and minlength == 0:
+            minlength = None
+        out = np.bincount(ids[mask], minlength=minlength)
 
         return Series(out,
                       index=self.grouper.result_index,

--- a/pandas/tests/groupby/test_counting.py
+++ b/pandas/tests/groupby/test_counting.py
@@ -212,3 +212,13 @@ class TestCounting(object):
         expected = DataFrame({'y': [2, 1]}, index=['a', 'b'])
         expected.index.name = "x"
         assert_frame_equal(expected, res)
+
+    def test_count_with_only_nans_in_first_group(self):
+        # GH21956
+        df = DataFrame({'A': [np.nan, np.nan], 'B': ['a', 'b'], 'C': [1, 2]})
+        result = df.groupby(['A', 'B']).C.count()
+        mi = MultiIndex(levels=[[], ['a', 'b']],
+                        labels=[[], []],
+                        names=['A', 'B'])
+        expected = Series([], index=mi, dtype=np.int64, name='C')
+        assert_series_equal(result, expected, check_index_type=False)


### PR DESCRIPTION
- [x] closes #21956
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry

See #21956 for details.