### PR TITLE
remove cnp cimports where possible

### DIFF
--- a/pandas/_libs/hashing.pyx
+++ b/pandas/_libs/hashing.pyx
@@ -3,14 +3,15 @@
 # at https://github.com/veorq/SipHash
 
 import cython
-cimport numpy as cnp
+from cpython cimport PyBytes_Check, PyUnicode_Check
+
+from libc.stdlib cimport malloc, free
+from libc.stdint cimport uint8_t, uint32_t, uint64_t
+
 import numpy as np
-from numpy cimport ndarray, uint8_t, uint32_t, uint64_t
+from numpy cimport ndarray
 
 from util cimport _checknull
-from cpython cimport (PyBytes_Check,
-                      PyUnicode_Check)
-from libc.stdlib cimport malloc, free
 
 DEF cROUNDS = 2
 DEF dROUNDS = 4

--- a/pandas/_libs/internals.pyx
+++ b/pandas/_libs/internals.pyx
@@ -3,6 +3,8 @@
 cimport cython
 from cython cimport Py_ssize_t
 
+from libc.stdint cimport int64_t
+
 from cpython cimport PyObject
 from cpython.slice cimport PySlice_Check
 
@@ -10,7 +12,6 @@ cdef extern from "Python.h":
     Py_ssize_t PY_SSIZE_T_MAX
 
 import numpy as np
-from numpy cimport int64_t
 
 cdef extern from "compat_helper.h":
     cdef int slice_get_indices(PyObject* s, Py_ssize_t length,

--- a/pandas/_libs/join.pyx
+++ b/pandas/_libs/join.pyx
@@ -4,11 +4,9 @@ cimport cython
 from cython cimport Py_ssize_t
 
 import numpy as np
-cimport numpy as cnp
 from numpy cimport (ndarray,
                     int8_t, int16_t, int32_t, int64_t, uint8_t, uint16_t,
                     uint32_t, uint64_t, float32_t, float64_t)
-cnp.import_array()
 
 
 cdef double NaN = <double> np.NaN

--- a/pandas/_libs/tslibs/ccalendar.pxd
+++ b/pandas/_libs/tslibs/ccalendar.pxd
@@ -2,8 +2,7 @@
 # cython: profile=False
 
 from cython cimport Py_ssize_t
-
-from numpy cimport int64_t, int32_t
+from libc.stdint cimport int64_t, int32_t
 
 
 cdef int dayofweek(int y, int m, int d) nogil

--- a/pandas/_libs/tslibs/ccalendar.pyx
+++ b/pandas/_libs/tslibs/ccalendar.pyx
@@ -7,8 +7,7 @@ Cython implementations of functions resembling the stdlib calendar module
 
 cimport cython
 from cython cimport Py_ssize_t
-
-from numpy cimport int64_t, int32_t
+from libc.stdint cimport int64_t, int32_t
 
 from locale import LC_TIME
 from strptime import LocaleTime

--- a/pandas/_libs/tslibs/fields.pyx
+++ b/pandas/_libs/tslibs/fields.pyx
@@ -9,9 +9,7 @@ cimport cython
 from cython cimport Py_ssize_t
 
 import numpy as np
-cimport numpy as cnp
 from numpy cimport ndarray, int64_t, int32_t, int8_t
-cnp.import_array()
 
 from ccalendar import get_locale_names, MONTHS_FULL, DAYS_FULL
 from ccalendar cimport (get_days_in_month, is_leapyear, dayofweek,

--- a/pandas/_libs/tslibs/parsing.pyx
+++ b/pandas/_libs/tslibs/parsing.pyx
@@ -8,15 +8,13 @@ import re
 
 cimport cython
 from cython cimport Py_ssize_t
-
+from libc.stdint cimport int64_t
 
 from cpython.datetime cimport datetime
 import time
 
 import numpy as np
-cimport numpy as cnp
-from numpy cimport int64_t, ndarray
-cnp.import_array()
+from numpy cimport ndarray
 
 # Avoid import from outside _libs
 if sys.version_info.major == 2:


### PR DESCRIPTION
Not sure what it will take to get avoid the 1.7 deprecation warnings, will see if this helps.

Also curious whether cimporting from libc.stdint works on Appveyor.