### PR TITLE
REF: No need to delegate to index check of whether an int is an int

### DIFF
--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -2124,7 +2124,25 @@ class _iLocIndexer(_LocationIndexer):
         return values
 
     def _validate_integer(self, key, axis):
-        # return a boolean if we have a valid integer indexer
+        """
+        Check that 'key' is a valid position in the desired axis.
+
+        Parameters
+        ----------
+        key : int
+            Requested position
+        axis : int
+            Desired axis
+
+        Returns
+        -------
+        None
+
+        Raises
+        ------
+        IndexError
+            If 'key' is not a valid position in axis 'axis'
+        """
 
         ax = self.obj._get_axis(axis)
         l = len(ax)
@@ -2215,8 +2233,6 @@ class _iLocIndexer(_LocationIndexer):
 
         # a single integer
         else:
-            key = self._convert_scalar_indexer(key, axis)
-
             if not is_integer(key):
                 raise TypeError("Cannot index by location index with a "
                                 "non-integer key")

--- a/pandas/tests/indexing/test_floats.py
+++ b/pandas/tests/indexing/test_floats.py
@@ -50,7 +50,7 @@ class TestFloatIndexers(object):
             def f():
                 s.iloc[3.0]
             tm.assert_raises_regex(TypeError,
-                                   'cannot do positional indexing',
+                                   'Cannot index by location index',
                                    f)
 
             def f():

--- a/pandas/tests/indexing/test_iloc.py
+++ b/pandas/tests/indexing/test_iloc.py
@@ -126,6 +126,18 @@ class TestiLoc(Base):
                           typs=['labels', 'mixed', 'ts', 'floats', 'empty'],
                           fails=IndexError)
 
+    @pytest.mark.parametrize('dims', [1, 2])
+    def test_iloc_getitem_invalid_scalar(self, dims):
+        # GH 21982
+
+        if dims == 1:
+            s = Series(np.arange(10))
+        else:
+            s = DataFrame(np.arange(100).reshape(10, 10))
+
+        tm.assert_raises_regex(TypeError, 'Cannot index by location index',
+                               lambda: s.iloc['a'])
+
     def test_iloc_array_not_mutating_negative_indices(self):
 
         # GH 21867


### PR DESCRIPTION
- [x] tests passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry

Just fixing the following nonsensical error:

``` python
In [2]: pd.Series(range(10)).iloc['a']
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
<ipython-input-2-4a32011255fe> in <module>()
----> 1 pd.Series(range(10)).iloc['a']
[...]
TypeError: cannot do positional indexing on <class 'pandas.core.indexes.range.RangeIndex'> with these indexers [a] of <class 'str'>
```

(you just cannot do positional indexing with a ``str``, regardless of the index)

... and adding a docstring while I was at it.