### PR TITLE
[CLN] Collect __repr__ and rendering methods together

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -587,6 +587,9 @@ class DataFrame(NDFrame):
         """
         return len(self.index), len(self.columns)
 
+    # ----------------------------------------------------------------------
+    # Rendering Methods
+
     def _repr_fits_vertical_(self):
         """
         Check length against max_rows.
@@ -722,6 +725,59 @@ class DataFrame(NDFrame):
         """
         from pandas.io.formats.style import Styler
         return Styler(self)
+
+    @Substitution(header='Write out the column names. If a list of strings '
+                         'is given, it is assumed to be aliases for the '
+                         'column names')
+    @Substitution(shared_params=fmt.common_docstring,
+                  returns=fmt.return_docstring)
+    def to_string(self, buf=None, columns=None, col_space=None, header=True,
+                  index=True, na_rep='NaN', formatters=None, float_format=None,
+                  sparsify=None, index_names=True, justify=None,
+                  line_width=None, max_rows=None, max_cols=None,
+                  show_dimensions=False):
+        """
+        Render a DataFrame to a console-friendly tabular output.
+
+        %(shared_params)s
+        line_width : int, optional
+            Width to wrap a line in characters.
+
+        %(returns)s
+
+        See Also
+        --------
+        to_html : Convert DataFrame to HTML.
+
+        Examples
+        --------
+        >>> d = {'col1' : [1, 2, 3], 'col2' : [4, 5, 6]}
+        >>> df = pd.DataFrame(d)
+        >>> print(df.to_string())
+           col1  col2
+        0     1     4
+        1     2     5
+        2     3     6
+        """
+
+        formatter = fmt.DataFrameFormatter(self, buf=buf, columns=columns,
+                                           col_space=col_space, na_rep=na_rep,
+                                           formatters=formatters,
+                                           float_format=float_format,
+                                           sparsify=sparsify, justify=justify,
+                                           index_names=index_names,
+                                           header=header, index=index,
+                                           line_width=line_width,
+                                           max_rows=max_rows,
+                                           max_cols=max_cols,
+                                           show_dimensions=show_dimensions)
+        formatter.to_string()
+
+        if buf is None:
+            result = formatter.buf.getvalue()
+            return result
+
+    # ----------------------------------------------------------------------
 
     def iteritems(self):
         """
@@ -2004,57 +2060,6 @@ class DataFrame(NDFrame):
         from pandas.io.parquet import to_parquet
         to_parquet(self, fname, engine,
                    compression=compression, **kwargs)
-
-    @Substitution(header='Write out the column names. If a list of strings '
-                         'is given, it is assumed to be aliases for the '
-                         'column names')
-    @Substitution(shared_params=fmt.common_docstring,
-                  returns=fmt.return_docstring)
-    def to_string(self, buf=None, columns=None, col_space=None, header=True,
-                  index=True, na_rep='NaN', formatters=None, float_format=None,
-                  sparsify=None, index_names=True, justify=None,
-                  line_width=None, max_rows=None, max_cols=None,
-                  show_dimensions=False):
-        """
-        Render a DataFrame to a console-friendly tabular output.
-
-        %(shared_params)s
-        line_width : int, optional
-            Width to wrap a line in characters.
-
-        %(returns)s
-
-        See Also
-        --------
-        to_html : Convert DataFrame to HTML.
-
-        Examples
-        --------
-        >>> d = {'col1' : [1, 2, 3], 'col2' : [4, 5, 6]}
-        >>> df = pd.DataFrame(d)
-        >>> print(df.to_string())
-           col1  col2
-        0     1     4
-        1     2     5
-        2     3     6
-        """
-
-        formatter = fmt.DataFrameFormatter(self, buf=buf, columns=columns,
-                                           col_space=col_space, na_rep=na_rep,
-                                           formatters=formatters,
-                                           float_format=float_format,
-                                           sparsify=sparsify, justify=justify,
-                                           index_names=index_names,
-                                           header=header, index=index,
-                                           line_width=line_width,
-                                           max_rows=max_rows,
-                                           max_cols=max_cols,
-                                           show_dimensions=show_dimensions)
-        formatter.to_string()
-
-        if buf is None:
-            result = formatter.buf.getvalue()
-            return result
 
     @Substitution(header='whether to print column labels, default True')
     @Substitution(shared_params=fmt.common_docstring,

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -778,6 +778,7 @@ class DataFrame(NDFrame):
             return result
 
     # ----------------------------------------------------------------------
+    # Iteration
 
     def iteritems(self):
         """
@@ -909,6 +910,8 @@ class DataFrame(NDFrame):
         return zip(*arrays)
 
     items = iteritems
+
+    # ----------------------------------------------------------------------
 
     def __len__(self):
         """Returns length of info axis, but here we use the index """

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -1590,15 +1590,11 @@ class NDFrame(PandasObject, SelectionMixin):
     # ----------------------------------------------------------------------
     # Iteration
 
-    def __hash__(self):
-        raise TypeError('{0!r} objects are mutable, thus they cannot be'
-                        ' hashed'.format(self.__class__.__name__))
-
     def __iter__(self):
         """Iterate over infor axis"""
         return iter(self._info_axis)
 
-    # can we get a better explanation of this?
+    # TODO: can we get a better explanation of this?
     def keys(self):
         """Get the 'info axis' (see Indexing for more)
 
@@ -1615,6 +1611,12 @@ class NDFrame(PandasObject, SelectionMixin):
         """
         for h in self._info_axis:
             yield h, self[h]
+
+    # ----------------------------------------------------------------------
+
+    def __hash__(self):
+        raise TypeError('{0!r} objects are mutable, thus they cannot be'
+                        ' hashed'.format(self.__class__.__name__))
 
     def __len__(self):
         """Returns length of info axis"""

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -150,17 +150,6 @@ class NDFrame(PandasObject, SelectionMixin):
                       "in a future version.", FutureWarning, stacklevel=2)
         self._is_copy = msg
 
-    def _repr_data_resource_(self):
-        """
-        Not a real Jupyter special repr method, but we use the same
-        naming convention.
-        """
-        if config.get_option("display.html.table_schema"):
-            data = self.head(config.get_option('display.max_rows'))
-            payload = json.loads(data.to_json(orient='table'),
-                                 object_pairs_hook=collections.OrderedDict)
-            return payload
-
     def _validate_dtype(self, dtype):
         """ validate the passed dtype """
 
@@ -202,12 +191,6 @@ class NDFrame(PandasObject, SelectionMixin):
         """
         raise com.AbstractMethodError(self)
 
-    def __unicode__(self):
-        # unicode representation based upon iterating over self
-        # (since, by definition, `PandasContainers` are iterable)
-        prepr = '[%s]' % ','.join(map(pprint_thing, self))
-        return '%s(%s)' % (self.__class__.__name__, prepr)
-
     def _dir_additions(self):
         """ add the string-like attributes from the info_axis.
         If info_axis is a MultiIndex, it's first level values are used.
@@ -229,6 +212,36 @@ class NDFrame(PandasObject, SelectionMixin):
         original, such as Series.to_frame() and DataFrame.to_panel()
         """
         raise NotImplementedError
+
+    # ----------------------------------------------------------------------
+    # Rendering Methods
+
+    def __unicode__(self):
+        # unicode representation based upon iterating over self
+        # (since, by definition, `PandasContainers` are iterable)
+        prepr = '[%s]' % ','.join(map(pprint_thing, self))
+        return '%s(%s)' % (self.__class__.__name__, prepr)
+
+    def _repr_data_resource_(self):
+        """
+        Not a real Jupyter special repr method, but we use the same
+        naming convention.
+        """
+        if config.get_option("display.html.table_schema"):
+            data = self.head(config.get_option('display.max_rows'))
+            payload = json.loads(data.to_json(orient='table'),
+                                 object_pairs_hook=collections.OrderedDict)
+            return payload
+
+    def _repr_latex_(self):
+        """
+        Returns a LaTeX representation for a particular object.
+        Mainly for use with nbconvert (jupyter notebook conversion to pdf).
+        """
+        if config.get_option('display.latex.repr'):
+            return self.to_latex()
+        else:
+            return None
 
     # ----------------------------------------------------------------------
     # Axis
@@ -1758,19 +1771,6 @@ class NDFrame(PandasObject, SelectionMixin):
             self._unpickle_matrix_compat(state)
 
         self._item_cache = {}
-
-    # ----------------------------------------------------------------------
-    # IO
-
-    def _repr_latex_(self):
-        """
-        Returns a LaTeX representation for a particular object.
-        Mainly for use with nbconvert (jupyter notebook conversion to pdf).
-        """
-        if config.get_option('display.latex.repr'):
-            return self.to_latex()
-        else:
-            return None
 
     # ----------------------------------------------------------------------
     # I/O Methods

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -1120,6 +1120,32 @@ class Index(IndexOpsMixin, PandasObject):
         values[mask] = na_rep
         return values
 
+    def to_native_types(self, slicer=None, **kwargs):
+        """
+        Format specified values of `self` and return them.
+
+        Parameters
+        ----------
+        slicer : int, array-like
+            An indexer into `self` that specifies which values
+            are used in the formatting process.
+        kwargs : dict
+            Options for specifying how the values should be formatted.
+            These options include the following:
+
+            1) na_rep : str
+                The value that serves as a placeholder for NULL values
+            2) quoting : bool or None
+                Whether or not there are quoted values in `self`
+            3) date_format : str
+                The format used to represent date-like values
+        """
+
+        values = self
+        if slicer is not None:
+            values = values[slicer]
+        return values._format_native_types(**kwargs)
+
     # ----------------------------------------------------------------------
 
     def to_series(self, index=None, name=None):
@@ -2310,32 +2336,6 @@ class Index(IndexOpsMixin, PandasObject):
 
             # coerces to object
             return self.astype(object).putmask(mask, value)
-
-    def to_native_types(self, slicer=None, **kwargs):
-        """
-        Format specified values of `self` and return them.
-
-        Parameters
-        ----------
-        slicer : int, array-like
-            An indexer into `self` that specifies which values
-            are used in the formatting process.
-        kwargs : dict
-            Options for specifying how the values should be formatted.
-            These options include the following:
-
-            1) na_rep : str
-                The value that serves as a placeholder for NULL values
-            2) quoting : bool or None
-                Whether or not there are quoted values in `self`
-            3) date_format : str
-                The format used to represent date-like values
-        """
-
-        values = self
-        if slicer is not None:
-            values = values[slicer]
-        return values._format_native_types(**kwargs)
 
     def equals(self, other):
         """

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -1952,6 +1952,9 @@ class Index(IndexOpsMixin, PandasObject):
             return False
         return is_datetime_array(ensure_object(self.values))
 
+    # ----------------------------------------------------------------------
+    # Picklability
+
     def __reduce__(self):
         d = dict(data=self._data)
         d.update(self._get_attributes_dict())
@@ -1983,6 +1986,8 @@ class Index(IndexOpsMixin, PandasObject):
             raise Exception("invalid pickle state")
 
     _unpickle_compat = __setstate__
+
+    # ----------------------------------------------------------------------
 
     def __nonzero__(self):
         raise ValueError("The truth value of a {0} is ambiguous. "

--- a/pandas/core/indexes/category.py
+++ b/pandas/core/indexes/category.py
@@ -261,6 +261,9 @@ class CategoricalIndex(Index, accessor.PandasDelegate):
 
         return False
 
+    # ----------------------------------------------------------------------
+    # Rendering Methods
+
     @property
     def _formatter_func(self):
         return self.categories._formatter_func
@@ -283,6 +286,8 @@ class CategoricalIndex(Index, accessor.PandasDelegate):
         if len(self) > max_seq_items:
             attrs.append(('length', len(self)))
         return attrs
+
+    # ----------------------------------------------------------------------
 
     @property
     def inferred_type(self):

--- a/pandas/core/indexes/datetimes.py
+++ b/pandas/core/indexes/datetimes.py
@@ -711,6 +711,7 @@ class DatetimeIndex(DatetimeArrayMixin, DatelikeOps, TimelikeOps,
         return lambda x: "'%s'" % formatter(x, tz=self.tz)
 
     # ----------------------------------------------------------------------
+    # Pickling Methods
 
     def __reduce__(self):
 
@@ -753,6 +754,8 @@ class DatetimeIndex(DatetimeArrayMixin, DatelikeOps, TimelikeOps,
         else:
             raise Exception("invalid pickle state")
     _unpickle_compat = __setstate__
+
+    # ----------------------------------------------------------------------
 
     def _maybe_update_attributes(self, attrs):
         """ Update Index attributes (e.g. freq) depending on op """

--- a/pandas/core/indexes/datetimes.py
+++ b/pandas/core/indexes/datetimes.py
@@ -711,7 +711,7 @@ class DatetimeIndex(DatetimeArrayMixin, DatelikeOps, TimelikeOps,
         return lambda x: "'%s'" % formatter(x, tz=self.tz)
 
     # ----------------------------------------------------------------------
-    # Pickling Methods
+    # Picklability
 
     def __reduce__(self):
 

--- a/pandas/core/indexes/datetimes.py
+++ b/pandas/core/indexes/datetimes.py
@@ -682,6 +682,18 @@ class DatetimeIndex(DatetimeArrayMixin, DatelikeOps, TimelikeOps,
 
         return indexSlice
 
+    # ----------------------------------------------------------------------
+    # Rendering Methods
+
+    def _format_native_types(self, na_rep='NaT', date_format=None, **kwargs):
+        from pandas.io.formats.format import _get_format_datetime64_from_values
+        format = _get_format_datetime64_from_values(self, date_format)
+
+        return libts.format_array_from_datetime(self.asi8,
+                                                tz=self.tz,
+                                                format=format,
+                                                na_rep=na_rep)
+
     def _mpl_repr(self):
         # how to represent ourselves to matplotlib
         return libts.ints_to_pydatetime(self.asi8, self.tz)
@@ -697,6 +709,8 @@ class DatetimeIndex(DatetimeArrayMixin, DatelikeOps, TimelikeOps,
         from pandas.io.formats.format import _get_format_datetime64
         formatter = _get_format_datetime64(is_dates_only=self._is_dates_only)
         return lambda x: "'%s'" % formatter(x, tz=self.tz)
+
+    # ----------------------------------------------------------------------
 
     def __reduce__(self):
 
@@ -747,15 +761,6 @@ class DatetimeIndex(DatetimeArrayMixin, DatelikeOps, TimelikeOps,
             # no need to infer if freq is None
             attrs['freq'] = 'infer'
         return attrs
-
-    def _format_native_types(self, na_rep='NaT', date_format=None, **kwargs):
-        from pandas.io.formats.format import _get_format_datetime64_from_values
-        format = _get_format_datetime64_from_values(self, date_format)
-
-        return libts.format_array_from_datetime(self.asi8,
-                                                tz=self.tz,
-                                                format=format,
-                                                na_rep=na_rep)
 
     @Appender(_index_shared_docs['astype'])
     def astype(self, dtype, copy=True):

--- a/pandas/core/indexes/interval.py
+++ b/pandas/core/indexes/interval.py
@@ -899,7 +899,8 @@ class IntervalIndex(IntervalMixin, Index):
 
         return self._shallow_copy(left, right)
 
-    # __repr__ associated methods are based on MultiIndex
+    # ----------------------------------------------------------------------
+    # Rendering Methods
 
     def _format_with_header(self, header, **kwargs):
         return header + list(self._format_native_types(**kwargs))
@@ -955,6 +956,8 @@ class IntervalIndex(IntervalMixin, Index):
     def _format_space(self):
         space = ' ' * (len(self.__class__.__name__) + 1)
         return "\n{space}".format(space=space)
+
+    # ----------------------------------------------------------------------
 
     def argsort(self, *args, **kwargs):
         return np.lexsort((self.right, self.left))

--- a/pandas/core/indexes/multi.py
+++ b/pandas/core/indexes/multi.py
@@ -1540,6 +1540,9 @@ class MultiIndex(Index):
         """A tuple with the length of each level."""
         return tuple(len(x) for x in self.levels)
 
+    # ----------------------------------------------------------------------
+    # Picklability
+
     def __reduce__(self):
         """Necessary for making this object picklable"""
         d = dict(levels=[lev for lev in self.levels],
@@ -1567,6 +1570,8 @@ class MultiIndex(Index):
         self.sortorder = sortorder
         self._verify_integrity()
         self._reset_identity()
+
+    # ----------------------------------------------------------------------
 
     def __getitem__(self, key):
         if is_scalar(key):

--- a/pandas/core/indexes/multi.py
+++ b/pandas/core/indexes/multi.py
@@ -607,6 +607,69 @@ class MultiIndex(Index):
         result += self._engine.sizeof(deep=deep)
         return result
 
+    # ----------------------------------------------------------------------
+    # Rendering Methods
+
+    def format(self, space=2, sparsify=None, adjoin=True, names=False,
+               na_rep=None, formatter=None):
+        if len(self) == 0:
+            return []
+
+        stringified_levels = []
+        for lev, lab in zip(self.levels, self.labels):
+            na = na_rep if na_rep is not None else _get_na_rep(lev.dtype.type)
+
+            if len(lev) > 0:
+
+                formatted = lev.take(lab).format(formatter=formatter)
+
+                # we have some NA
+                mask = lab == -1
+                if mask.any():
+                    formatted = np.array(formatted, dtype=object)
+                    formatted[mask] = na
+                    formatted = formatted.tolist()
+
+            else:
+                # weird all NA case
+                formatted = [pprint_thing(na if isna(x) else x,
+                                          escape_chars=('\t', '\r', '\n'))
+                             for x in algos.take_1d(lev._values, lab)]
+            stringified_levels.append(formatted)
+
+        result_levels = []
+        for lev, name in zip(stringified_levels, self.names):
+            level = []
+
+            if names:
+                level.append(pprint_thing(name,
+                                          escape_chars=('\t', '\r', '\n'))
+                             if name is not None else '')
+
+            level.extend(np.array(lev, dtype=object))
+            result_levels.append(level)
+
+        if sparsify is None:
+            sparsify = get_option("display.multi_sparse")
+
+        if sparsify:
+            sentinel = ''
+            # GH3547
+            # use value of sparsify as sentinel,  unless it's an obvious
+            # "Truthey" value
+            if sparsify not in [True, 1]:
+                sentinel = sparsify
+            # little bit of a kludge job for #1217
+            result_levels = _sparsify(result_levels, start=int(names),
+                                      sentinel=sentinel)
+
+        if adjoin:
+            from pandas.io.formats.format import _get_adjustment
+            adj = _get_adjustment()
+            return adj.adjoin(space, *result_levels).split('\n')
+        else:
+            return result_levels
+
     def _format_attrs(self):
         """
         Return a list of tuples of the (attr,formatted_value)
@@ -628,6 +691,31 @@ class MultiIndex(Index):
     def _format_data(self, name=None):
         # we are formatting thru the attributes
         return None
+
+    def _format_native_types(self, na_rep='nan', **kwargs):
+        new_levels = []
+        new_labels = []
+
+        # go through the levels and format them
+        for level, label in zip(self.levels, self.labels):
+            level = level._format_native_types(na_rep=na_rep, **kwargs)
+            # add nan values, if there are any
+            mask = (label == -1)
+            if mask.any():
+                nan_index = len(level)
+                level = np.append(level, na_rep)
+                label = label.values()
+                label[mask] = nan_index
+            new_levels.append(level)
+            new_labels.append(label)
+
+        # reconstruct the multi-index
+        mi = MultiIndex(levels=new_levels, labels=new_labels, names=self.names,
+                        sortorder=self.sortorder, verify_integrity=False)
+
+        return mi.values
+
+    # ----------------------------------------------------------------------
 
     def __len__(self):
         return len(self.labels[0])
@@ -689,29 +777,6 @@ class MultiIndex(Index):
 
     names = property(fset=_set_names, fget=_get_names,
                      doc="Names of levels in MultiIndex")
-
-    def _format_native_types(self, na_rep='nan', **kwargs):
-        new_levels = []
-        new_labels = []
-
-        # go through the levels and format them
-        for level, label in zip(self.levels, self.labels):
-            level = level._format_native_types(na_rep=na_rep, **kwargs)
-            # add nan values, if there are any
-            mask = (label == -1)
-            if mask.any():
-                nan_index = len(level)
-                level = np.append(level, na_rep)
-                label = label.values()
-                label[mask] = nan_index
-            new_levels.append(level)
-            new_labels.append(label)
-
-        # reconstruct the multi-index
-        mi = MultiIndex(levels=new_levels, labels=new_labels, names=self.names,
-                        sortorder=self.sortorder, verify_integrity=False)
-
-        return mi.values
 
     @Appender(_index_shared_docs['_get_grouper_for_level'])
     def _get_grouper_for_level(self, mapper, level):
@@ -1075,66 +1140,6 @@ class MultiIndex(Index):
         else:
             level = self._get_level_number(level)
             return self._get_level_values(level=level, unique=True)
-
-    def format(self, space=2, sparsify=None, adjoin=True, names=False,
-               na_rep=None, formatter=None):
-        if len(self) == 0:
-            return []
-
-        stringified_levels = []
-        for lev, lab in zip(self.levels, self.labels):
-            na = na_rep if na_rep is not None else _get_na_rep(lev.dtype.type)
-
-            if len(lev) > 0:
-
-                formatted = lev.take(lab).format(formatter=formatter)
-
-                # we have some NA
-                mask = lab == -1
-                if mask.any():
-                    formatted = np.array(formatted, dtype=object)
-                    formatted[mask] = na
-                    formatted = formatted.tolist()
-
-            else:
-                # weird all NA case
-                formatted = [pprint_thing(na if isna(x) else x,
-                                          escape_chars=('\t', '\r', '\n'))
-                             for x in algos.take_1d(lev._values, lab)]
-            stringified_levels.append(formatted)
-
-        result_levels = []
-        for lev, name in zip(stringified_levels, self.names):
-            level = []
-
-            if names:
-                level.append(pprint_thing(name,
-                                          escape_chars=('\t', '\r', '\n'))
-                             if name is not None else '')
-
-            level.extend(np.array(lev, dtype=object))
-            result_levels.append(level)
-
-        if sparsify is None:
-            sparsify = get_option("display.multi_sparse")
-
-        if sparsify:
-            sentinel = ''
-            # GH3547
-            # use value of sparsify as sentinel,  unless it's an obvious
-            # "Truthey" value
-            if sparsify not in [True, 1]:
-                sentinel = sparsify
-            # little bit of a kludge job for #1217
-            result_levels = _sparsify(result_levels, start=int(names),
-                                      sentinel=sentinel)
-
-        if adjoin:
-            from pandas.io.formats.format import _get_adjustment
-            adj = _get_adjustment()
-            return adj.adjoin(space, *result_levels).split('\n')
-        else:
-            return result_levels
 
     def _to_safe_for_reshape(self):
         """ convert to object if we are a categorical """

--- a/pandas/core/indexes/range.py
+++ b/pandas/core/indexes/range.py
@@ -185,6 +185,9 @@ class RangeIndex(Int64Index):
         d.update(dict(self._get_data_as_items()))
         return ibase._new_Index, (self.__class__, d), None
 
+    # ----------------------------------------------------------------------
+    # Rendering Methods
+
     def _format_attrs(self):
         """
         Return a list of tuples of the (attr, formatted_value)
@@ -197,6 +200,8 @@ class RangeIndex(Int64Index):
     def _format_data(self, name=None):
         # we are formatting thru the attributes
         return None
+
+    # ----------------------------------------------------------------------
 
     @cache_readonly
     def nbytes(self):

--- a/pandas/core/indexes/timedeltas.py
+++ b/pandas/core/indexes/timedeltas.py
@@ -246,10 +246,21 @@ class TimedeltaIndex(TimedeltaArrayMixin, DatetimeIndexOpsMixin,
         result._reset_identity()
         return result
 
+    # ----------------------------------------------------------------------
+    # Rendering Methods
+
     @property
     def _formatter_func(self):
         from pandas.io.formats.format import _get_format_timedelta64
         return _get_format_timedelta64(self, box=True)
+
+    def _format_native_types(self, na_rep=u'NaT', date_format=None, **kwargs):
+        from pandas.io.formats.format import Timedelta64Formatter
+        return Timedelta64Formatter(values=self,
+                                    nat_rep=na_rep,
+                                    justify='all').get_result()
+
+    # ----------------------------------------------------------------------
 
     def __setstate__(self, state):
         """Necessary for making this object picklable"""
@@ -301,12 +312,6 @@ class TimedeltaIndex(TimedeltaArrayMixin, DatetimeIndexOpsMixin,
         except AttributeError:
             raise TypeError("Cannot add/subtract non-tick DateOffset to {cls}"
                             .format(cls=type(self).__name__))
-
-    def _format_native_types(self, na_rep=u'NaT', date_format=None, **kwargs):
-        from pandas.io.formats.format import Timedelta64Formatter
-        return Timedelta64Formatter(values=self,
-                                    nat_rep=na_rep,
-                                    justify='all').get_result()
 
     days = _wrap_field_accessor("days")
     seconds = _wrap_field_accessor("seconds")

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -476,12 +476,6 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
         """ return the internal repr of this data """
         return self._data.internal_values()
 
-    def _formatting_values(self):
-        """Return the values that can be formatted (used by SeriesFormatter
-        and DataFrameFormatter)
-        """
-        return self._data.formatting_values()
-
     def get_values(self):
         """ same as values (but handles sparseness conversions); is a view """
         return self._data.get_values()
@@ -1226,6 +1220,9 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
             df = self.to_frame(name)
             return df.reset_index(level=level, drop=drop)
 
+    # ----------------------------------------------------------------------
+    # Rendering Methods
+
     def __unicode__(self):
         """
         Return a string representation for a particular DataFrame
@@ -1300,6 +1297,14 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
             except AttributeError:
                 with open(buf, 'w') as f:
                     f.write(result)
+
+    def _formatting_values(self):
+        """Return the values that can be formatted (used by SeriesFormatter
+        and DataFrameFormatter)
+        """
+        return self._data.formatting_values()
+
+    # ----------------------------------------------------------------------
 
     def iteritems(self):
         """

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -1305,6 +1305,7 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
         return self._data.formatting_values()
 
     # ----------------------------------------------------------------------
+    # Iteration
 
     def iteritems(self):
         """
@@ -1314,12 +1315,12 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
 
     items = iteritems
 
-    # ----------------------------------------------------------------------
-    # Misc public methods
-
     def keys(self):
         """Alias for index"""
         return self.index
+
+    # ----------------------------------------------------------------------
+    # Misc public methods
 
     def to_dict(self, into=dict):
         """


### PR DESCRIPTION
Motivation here is in looking at options for rendering EA subclasses.

There's a decent argument to be made that `to_html` and/or `to_latex` should be included in "rendering methods", in large part because they both call `fmt.Formatter`.  Holding off on that pending feedback.