### PR TITLE
Fix for issue #21150, using a simple lock to prevent an issue with multiple threads accessing an Index

### DIFF
--- a/ci/azure-windows-27.yaml
+++ b/ci/azure-windows-27.yaml
@@ -6,6 +6,7 @@ dependencies:
   - beautifulsoup4
   - bottleneck
   - dateutil
+  - futures
   - gcsfs
   - html5lib
   - jinja2=2.8

--- a/ci/circle-27-compat.yaml
+++ b/ci/circle-27-compat.yaml
@@ -5,6 +5,7 @@ channels:
 dependencies:
   - bottleneck=1.0.0
   - cython=0.28.2
+  - futures
   - jinja2=2.8
   - numexpr=2.4.4 # we test that we correctly don't use an unsupported numexpr
   - numpy=1.9.3

--- a/ci/travis-27-locale.yaml
+++ b/ci/travis-27-locale.yaml
@@ -5,6 +5,7 @@ channels:
 dependencies:
   - bottleneck=1.0.0
   - cython=0.28.2
+  - futures
   - lxml
   - matplotlib=1.4.3
   - numpy=1.9.3

--- a/ci/travis-27.yaml
+++ b/ci/travis-27.yaml
@@ -8,6 +8,7 @@ dependencies:
   - cython=0.28.2
   - fastparquet
   - feather-format
+  - futures
   - gcsfs
   - html5lib
   - ipython


### PR DESCRIPTION
Hi,

First time working with Cython, and after uni did very little C/C++, so feel free to be a bit more serious about reviewing this pull request.

I am trying to practice more Python, and learn more about the code base of projects like Panda, and found the issue #21150, which happens a lot in Java (my main language), so decided to see how I'd go about fixing it.

Used the same approach found in `strptime.pyx`, to add a lock to prevent two threads of accessing the `mapping` Hashtable in the `_ensure_mapping_populated` method.

The problem occurred when two threads accessed the method around the same time, then one would create the `mapping` Hashtable instance, preventing the other from entering the `if` statement which also sets the `unique` flag to `true/1`.

I didn't find any other part that could cause an obvious issue due to this lock, or another thread-safety issue. However, I can imagine that moving the logic maybe to the constructor so that we immediately know whether the index is unique or not, could fix it too, and remove the need of the lock, at the expense of changing the current design (I believe the index is not tightly coupled with the values passed... later, after certain calls, the mapping hashtable gets populated, which gives better performance I believe).

Or, if core devs prefer to ask users to use a lock in their code base instead of implementing in Pandas, I'd be keen to close this PR and open a new one for the documentation with some note about it.

Feel free to suggest any changes or even leave comments to educate me :-) The documentation for setting up the development environment and for contributing was super easy to follow, I hope I didn't forget anything.

Thank you!
Bruno

- [ ] closes #21150
- [ ] tests added / passed
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
