### PR TITLE
core: fix DatetimeBlock operated with timedelta

### DIFF
--- a/doc/source/whatsnew/v0.24.0.txt
+++ b/doc/source/whatsnew/v0.24.0.txt
@@ -443,7 +443,7 @@ Datetimelike
 Timedelta
 ^^^^^^^^^
 
-- Bug in :class:`DataFrame` with ``dtype='datetime64[ns]'`` when adding :class:`Timedelta` (:issue:`22007`)
+- Bug in :class:`DataFrame` with ``dtype='datetime64[ns]'`` when adding :class:`Timedelta` (:issue:`22005`)
 -
 -
 

--- a/doc/source/whatsnew/v0.24.0.txt
+++ b/doc/source/whatsnew/v0.24.0.txt
@@ -443,7 +443,7 @@ Datetimelike
 Timedelta
 ^^^^^^^^^
 
--
+- Bug in :class:`DataFrame` with ``dtype='datetime64[ns]'`` when adding :class:`Timedelta` (:issue:`22007`)
 -
 -
 

--- a/pandas/core/internals/blocks.py
+++ b/pandas/core/internals/blocks.py
@@ -2713,6 +2713,11 @@ class DatetimeBlock(DatetimeLikeBlockMixin, Block):
                                 "naive Block")
             other_mask = isna(other)
             other = other.asm8.view('i8')
+        elif isinstance(other, (timedelta, np.timedelta64)):
+            if not isinstance(other, Timedelta):
+                other = Timedelta(other)
+            other_mask = isna(other)
+            other = other.asm8.view('i8')
         elif hasattr(other, 'dtype') and is_datetime64_dtype(other):
             other_mask = isna(other)
             other = other.astype('i8', copy=False).view('i8')

--- a/pandas/tests/frame/test_arithmetic.py
+++ b/pandas/tests/frame/test_arithmetic.py
@@ -219,8 +219,12 @@ class TestFrameArithmetic(object):
         np.timedelta64(1, 'D')
     ])
     def test_timestamp_df_add_timedelta(self, other):
+        # GH 22005
         expected = pd.DataFrame([pd.Timestamp('2018-01-02')])
         result = pd.DataFrame([pd.Timestamp('2018-01-01')]) + other
+        tm.assert_frame_equal(result, expected)
+
+        result = pd.DataFrame([pd.Timestamp('2018-01-03')]) - other
         tm.assert_frame_equal(result, expected)
 
         result = other + pd.DataFrame([pd.Timestamp('2018-01-01')])

--- a/pandas/tests/frame/test_arithmetic.py
+++ b/pandas/tests/frame/test_arithmetic.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+import datetime
+
 import pytest
 import numpy as np
 
@@ -210,6 +212,19 @@ class TestFrameArithmetic(object):
         expected = pd.DataFrame([pd.Timedelta(days=0), pd.Timedelta(days=1),
                                  pd.Timedelta(days=2)])
         tm.assert_frame_equal(res, expected)
+
+    @pytest.mark.parametrize('other', [
+        pd.Timedelta('1d'),
+        datetime.timedelta(days=1),
+        np.timedelta64(1, 'D')
+    ])
+    def test_timestamp_df_add_timedelta(self, other):
+        expected = pd.DataFrame([pd.Timestamp('2018-01-02')])
+        result = pd.DataFrame([pd.Timestamp('2018-01-01')]) + other
+        tm.assert_frame_equal(result, expected)
+
+        result = other + pd.DataFrame([pd.Timestamp('2018-01-01')])
+        tm.assert_frame_equal(result, expected)
 
     @pytest.mark.parametrize('data', [
         [1, 2, 3],


### PR DESCRIPTION
- [X] closes #22005
- [X] tests added / passed
- [X] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry
