### PR TITLE
core: try coerce result back to DatetimeBlock

### DIFF
--- a/doc/source/whatsnew/v0.24.0.txt
+++ b/doc/source/whatsnew/v0.24.0.txt
@@ -436,6 +436,7 @@ Datetimelike
 
 - Fixed bug where two :class:`DateOffset` objects with different ``normalize`` attributes could evaluate as equal (:issue:`21404`)
 - Fixed bug where :meth:`Timestamp.resolution` incorrectly returned 1-microsecond ``timedelta`` instead of 1-nanosecond :class:`Timedelta` (:issue:`21336`,:issue:`21365`)
+- Fixed bug where :class:`DataFrame` with ``dtype='datetime64[ns]'`` operating with :class:`DateOffset` could cast to ``dtype='object'`` (:issue:`21610`)
 
 Timedelta
 ^^^^^^^^^

--- a/pandas/core/internals/__init__.py
+++ b/pandas/core/internals/__init__.py
@@ -2788,10 +2788,10 @@ class DatetimeBlock(DatetimeLikeBlockMixin, Block):
         self.values[locs] = values
 
     def eval(self, func, other, try_cast=False, **kwargs):
-        block = super().eval(func, other, try_cast=try_cast, **kwargs)[0]
+        block = super(DatetimeBlock, self).eval(func, other, try_cast=try_cast,
+                                                **kwargs)[0]
         if try_cast:
-            if isinstance(other,
-                          (tslibs.Timestamp, np.datetime64, datetime, date)):
+            if isinstance(other, (np.datetime64, date)):
                 block = TimeDeltaBlock(block.values, block.mgr_locs,
                                        ndim=block.ndim)
             elif isinstance(other, ABCDateOffset):

--- a/pandas/tests/frame/test_arithmetic.py
+++ b/pandas/tests/frame/test_arithmetic.py
@@ -211,6 +211,16 @@ class TestFrameArithmetic(object):
                                  pd.Timedelta(days=2)])
         tm.assert_frame_equal(res, expected)
 
+    def test_timestamp_df_add_dateoffset(self):
+        expected = pd.DataFrame([pd.Timestamp('2019')])
+        result = pd.DataFrame([pd.Timestamp('2018')]) + pd.DateOffset(years=1)
+        tm.assert_frame_equal(expected, result)
+
+        expected = pd.DataFrame([pd.Timestamp('2019', tz='Asia/Shanghai')])
+        result = (pd.DataFrame([pd.Timestamp('2018', tz='Asia/Shanghai')])
+                  + pd.DateOffset(years=1))
+        tm.assert_frame_equal(expected, result)
+
     @pytest.mark.parametrize('data', [
         [1, 2, 3],
         [1.1, 2.2, 3.3],

--- a/pandas/tests/frame/test_arithmetic.py
+++ b/pandas/tests/frame/test_arithmetic.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+import datetime
 import pytest
 import numpy as np
 
@@ -219,6 +220,17 @@ class TestFrameArithmetic(object):
         expected = pd.DataFrame([pd.Timestamp('2019', tz='Asia/Shanghai')])
         result = (pd.DataFrame([pd.Timestamp('2018', tz='Asia/Shanghai')])
                   + pd.DateOffset(years=1))
+        tm.assert_frame_equal(expected, result)
+
+    @pytest.mark.parametrize('other', [
+        pd.Timestamp('2017'),
+        np.datetime64('2017'),
+        datetime.datetime(2017, 1, 1),
+        datetime.date(2017, 1, 1),
+    ])
+    def test_timestamp_df_sub_timestamp(self, other):
+        expected = pd.DataFrame([pd.Timedelta('365d')])
+        result = pd.DataFrame([pd.Timestamp('2018')]) - other
         tm.assert_frame_equal(expected, result)
 
     @pytest.mark.parametrize('data', [

--- a/pandas/tests/frame/test_arithmetic.py
+++ b/pandas/tests/frame/test_arithmetic.py
@@ -213,6 +213,7 @@ class TestFrameArithmetic(object):
         tm.assert_frame_equal(res, expected)
 
     def test_timestamp_df_add_dateoffset(self):
+        # GH 21610
         expected = pd.DataFrame([pd.Timestamp('2019')])
         result = pd.DataFrame([pd.Timestamp('2018')]) + pd.DateOffset(years=1)
         tm.assert_frame_equal(expected, result)
@@ -229,6 +230,7 @@ class TestFrameArithmetic(object):
         datetime.date(2017, 1, 1),
     ])
     def test_timestamp_df_sub_timestamp(self, other):
+        # GH 8554 12437
         expected = pd.DataFrame([pd.Timedelta('365d')])
         result = pd.DataFrame([pd.Timestamp('2018')]) - other
         tm.assert_frame_equal(expected, result)

--- a/pandas/tests/internals/test_internals.py
+++ b/pandas/tests/internals/test_internals.py
@@ -1238,7 +1238,6 @@ class TestCanHoldElement(object):
         (2**63, 'complex128'),
         (True, 'bool'),
         (np.timedelta64(20, 'ns'), '<m8[ns]'),
-        (np.datetime64(20, 'ns'), '<M8[ns]'),
     ])
     @pytest.mark.parametrize('op', [
         operator.add,
@@ -1249,15 +1248,16 @@ class TestCanHoldElement(object):
         operator.pow,
     ], ids=lambda x: x.__name__)
     def test_binop_other(self, op, value, dtype):
-        skip = {(operator.add, 'bool'),
-                (operator.sub, 'bool'),
-                (operator.mul, 'bool'),
-                (operator.truediv, 'bool'),
-                (operator.mod, 'i8'),
-                (operator.mod, 'complex128'),
-                (operator.mod, '<M8[ns]'),
-                (operator.mod, '<m8[ns]'),
-                (operator.pow, 'bool')}
+        skip = {
+            (operator.add, 'bool'),
+            (operator.sub, 'bool'),
+            (operator.mul, 'bool'),
+            (operator.truediv, 'bool'),
+            (operator.mod, 'i8'),
+            (operator.mod, 'complex128'),
+            (operator.mod, '<m8[ns]'),
+            (operator.pow, 'bool'),
+        }
         if (op, dtype) in skip:
             pytest.skip("Invalid combination {},{}".format(op, dtype))
         e = DummyElement(value, dtype)

--- a/pandas/tests/internals/test_internals.py
+++ b/pandas/tests/internals/test_internals.py
@@ -1248,16 +1248,14 @@ class TestCanHoldElement(object):
         operator.pow,
     ], ids=lambda x: x.__name__)
     def test_binop_other(self, op, value, dtype):
-        skip = {
-            (operator.add, 'bool'),
-            (operator.sub, 'bool'),
-            (operator.mul, 'bool'),
-            (operator.truediv, 'bool'),
-            (operator.mod, 'i8'),
-            (operator.mod, 'complex128'),
-            (operator.mod, '<m8[ns]'),
-            (operator.pow, 'bool'),
-        }
+        skip = {(operator.add, 'bool'),
+                (operator.sub, 'bool'),
+                (operator.mul, 'bool'),
+                (operator.truediv, 'bool'),
+                (operator.mod, 'i8'),
+                (operator.mod, 'complex128'),
+                (operator.mod, '<m8[ns]'),
+                (operator.pow, 'bool')}
         if (op, dtype) in skip:
             pytest.skip("Invalid combination {},{}".format(op, dtype))
         e = DummyElement(value, dtype)


### PR DESCRIPTION
- [x] closes #21610 #8554 #12437
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry
---
Hang up until `Block.eval` reformed.