### PR TITLE
[CLN] [BLD] Fix many compiler warnings

### DIFF
--- a/pandas/_libs/hashtable_class_helper.pxi.in
+++ b/pandas/_libs/hashtable_class_helper.pxi.in
@@ -29,7 +29,7 @@ dtypes = [('Float64', 'float64', 'float64_t'),
 
 ctypedef struct {{name}}VectorData:
     {{arg}} *data
-    size_t n, m
+    Py_ssize_t n, m
 
 {{endif}}
 
@@ -147,7 +147,7 @@ cdef class StringVector:
     cdef resize(self):
         cdef:
             char **orig_data
-            size_t i, m
+            Py_ssize_t i, m
 
         m = self.data.m
         self.data.m = max(self.data.m * 4, _INIT_VEC_CAP)
@@ -172,7 +172,7 @@ cdef class StringVector:
     def to_array(self):
         cdef:
             ndarray ao
-            size_t n
+            Py_ssize_t n
             object val
 
         ao = np.empty(self.data.n, dtype=np.object)
@@ -198,7 +198,7 @@ cdef class ObjectVector:
 
     cdef:
         PyObject **data
-        size_t n, m
+        Py_ssize_t n, m
         ndarray ao
         bint external_view_exists
 
@@ -281,7 +281,7 @@ cdef class {{name}}HashTable(HashTable):
     def sizeof(self, deep=False):
         """ return the size of my table in bytes """
         return self.table.n_buckets * (sizeof({{dtype}}_t) + # keys
-                                       sizeof(size_t) + # vals
+                                       sizeof(Py_ssize_t) + # vals
                                        sizeof(uint32_t)) # flags
 
     cpdef get_item(self, {{dtype}}_t val):
@@ -522,13 +522,13 @@ cdef class StringHashTable(HashTable):
     def sizeof(self, deep=False):
         """ return the size of my table in bytes """
         return self.table.n_buckets * (sizeof(char *) + # keys
-                                       sizeof(size_t) + # vals
+                                       sizeof(Py_ssize_t) + # vals
                                        sizeof(uint32_t)) # flags
 
     cpdef get_item(self, object val):
         cdef:
             khiter_t k
-            char *v
+            const char *v
         v = util.get_c_string(val)
 
         k = kh_get_str(self.table, v)
@@ -541,7 +541,7 @@ cdef class StringHashTable(HashTable):
         cdef:
             khiter_t k
             int ret = 0
-            char *v
+            const char *v
 
         v = util.get_c_string(val)
 
@@ -560,10 +560,10 @@ cdef class StringHashTable(HashTable):
             int64_t *resbuf = <int64_t*> labels.data
             khiter_t k
             kh_str_t *table = self.table
-            char *v
-            char **vecs
+            const char *v
+            const char **vecs
 
-        vecs = <char **> malloc(n * sizeof(char *))
+        vecs = <const char **> malloc(n * sizeof(char *))
         for i in range(n):
             val = values[i]
             v = util.get_c_string(val)
@@ -589,10 +589,10 @@ cdef class StringHashTable(HashTable):
             object val
             ObjectVector uniques
             khiter_t k
-            char *v
-            char **vecs
+            const char *v
+            const char **vecs
 
-        vecs = <char **> malloc(n * sizeof(char *))
+        vecs = <const char **> malloc(n * sizeof(char *))
         uindexer = np.empty(n, dtype=np.int64)
         for i in range(n):
             val = values[i]
@@ -627,7 +627,7 @@ cdef class StringHashTable(HashTable):
             Py_ssize_t i, n = len(values)
             int ret = 0
             object val
-            char *v
+            const char *v
             khiter_t k
             int64_t[:] locs = np.empty(n, dtype=np.int64)
 
@@ -660,12 +660,12 @@ cdef class StringHashTable(HashTable):
             Py_ssize_t i, n = len(values)
             int ret = 0
             object val
-            char *v
-            char **vecs
+            const char *v
+            const char **vecs
             khiter_t k
 
         # these by-definition *must* be strings
-        vecs = <char **> malloc(n * sizeof(char *))
+        vecs = <const char **> malloc(n * sizeof(char *))
         for i in range(n):
             val = values[i]
 
@@ -693,8 +693,8 @@ cdef class StringHashTable(HashTable):
             Py_ssize_t idx, count = count_prior
             int ret = 0
             object val
-            char *v
-            char **vecs
+            const char *v
+            const char **vecs
             khiter_t k
             bint use_na_value
 
@@ -705,7 +705,7 @@ cdef class StringHashTable(HashTable):
 
         # pre-filter out missing
         # and assign pointers
-        vecs = <char **> malloc(n * sizeof(char *))
+        vecs = <const char **> malloc(n * sizeof(char *))
         for i in range(n):
             val = values[i]
 
@@ -769,7 +769,7 @@ cdef class PyObjectHashTable(HashTable):
     def sizeof(self, deep=False):
         """ return the size of my table in bytes """
         return self.table.n_buckets * (sizeof(PyObject *) + # keys
-                                       sizeof(size_t) + # vals
+                                       sizeof(Py_ssize_t) + # vals
                                        sizeof(uint32_t)) # flags
 
     cpdef get_item(self, object val):

--- a/pandas/_libs/intervaltree.pxi.in
+++ b/pandas/_libs/intervaltree.pxi.in
@@ -262,7 +262,7 @@ cdef class {{dtype_title}}Closed{{closed_title}}IntervalNode:
             self.min_left = 0
             self.max_right = 0
 
-        if <int64_t>self.n_elements <= leaf_size:
+        if self.n_elements <= leaf_size:
             # make this a terminal (leaf) node
             self.is_leaf_node = True
             self.left = left
@@ -343,29 +343,28 @@ cdef class {{dtype_title}}Closed{{closed_title}}IntervalNode:
             # continue the binary tree structure. Instead, we use linear
             # search.
             for i in range(self.n_elements):
-                if (self.left[i] {{cmp_left}}
-                        <{{dtype}}_t>point {{cmp_right}} self.right[i]):
+                if self.left[i] {{cmp_left}} point {{cmp_right}} self.right[i]:
                     result.append(self.indices[i])
         else:
             # There are child nodes. Based on comparing our query to the pivot,
             # look at the center values, then go to the relevant child.
-            if <{{dtype}}_t>point < self.pivot:
+            if point < self.pivot:
                 values = self.center_left_values
                 indices = self.center_left_indices
                 for i in range(self.n_center):
-                    if not values[i] {{cmp_left}} <{{dtype}}_t>point:
+                    if not values[i] {{cmp_left}} point:
                         break
                     result.append(indices[i])
-                if <{{dtype}}_t>point {{cmp_right}} self.left_node.max_right:
+                if point {{cmp_right}} self.left_node.max_right:
                     self.left_node.query(result, point)
-            elif <{{dtype}}_t>point > self.pivot:
+            elif point > self.pivot:
                 values = self.center_right_values
                 indices = self.center_right_indices
                 for i in range(self.n_center - 1, -1, -1):
-                    if not <{{dtype}}_t>point {{cmp_right}} values[i]:
+                    if not point {{cmp_right}} values[i]:
                         break
                     result.append(indices[i])
-                if self.right_node.min_left {{cmp_left}} <{{dtype}}_t>point:
+                if self.right_node.min_left {{cmp_left}} point:
                     self.right_node.query(result, point)
             else:
                 result.extend(self.center_left_indices)

--- a/pandas/_libs/intervaltree.pxi.in
+++ b/pandas/_libs/intervaltree.pxi.in
@@ -262,7 +262,7 @@ cdef class {{dtype_title}}Closed{{closed_title}}IntervalNode:
             self.min_left = 0
             self.max_right = 0
 
-        if self.n_elements <= leaf_size:
+        if <int64_t>self.n_elements <= leaf_size:
             # make this a terminal (leaf) node
             self.is_leaf_node = True
             self.left = left
@@ -343,28 +343,29 @@ cdef class {{dtype_title}}Closed{{closed_title}}IntervalNode:
             # continue the binary tree structure. Instead, we use linear
             # search.
             for i in range(self.n_elements):
-                if self.left[i] {{cmp_left}} point {{cmp_right}} self.right[i]:
+                if (self.left[i] {{cmp_left}}
+                        <{{dtype}}_t>point {{cmp_right}} self.right[i]):
                     result.append(self.indices[i])
         else:
             # There are child nodes. Based on comparing our query to the pivot,
             # look at the center values, then go to the relevant child.
-            if point < self.pivot:
+            if <{{dtype}}_t>point < self.pivot:
                 values = self.center_left_values
                 indices = self.center_left_indices
                 for i in range(self.n_center):
-                    if not values[i] {{cmp_left}} point:
+                    if not values[i] {{cmp_left}} <{{dtype}}_t>point:
                         break
                     result.append(indices[i])
-                if point {{cmp_right}} self.left_node.max_right:
+                if <{{dtype}}_t>point {{cmp_right}} self.left_node.max_right:
                     self.left_node.query(result, point)
-            elif point > self.pivot:
+            elif <{{dtype}}_t>point > self.pivot:
                 values = self.center_right_values
                 indices = self.center_right_indices
                 for i in range(self.n_center - 1, -1, -1):
-                    if not point {{cmp_right}} values[i]:
+                    if not <{{dtype}}_t>point {{cmp_right}} values[i]:
                         break
                     result.append(indices[i])
-                if self.right_node.min_left {{cmp_left}} point:
+                if self.right_node.min_left {{cmp_left}} <{{dtype}}_t>point:
                     self.right_node.query(result, point)
             else:
                 result.extend(self.center_left_indices)

--- a/pandas/_libs/src/datetime/np_datetime.c
+++ b/pandas/_libs/src/datetime/np_datetime.c
@@ -329,10 +329,11 @@ int cmp_npy_datetimestruct(const npy_datetimestruct *a,
  * Returns -1 on error, 0 on success, and 1 (with no error set)
  * if obj doesn't have the needed date or datetime attributes.
  */
-int convert_pydatetime_to_datetimestruct(PyDateTime_Date *obj,
+int convert_pydatetime_to_datetimestruct(PyDateTime_Date *dtobj,
                                          npy_datetimestruct *out) {
     // Assumes that obj is a valid datetime object
     PyObject *tmp;
+    PyObject *obj = (PyObject*)dtobj;
 
     /* Initialize the output to all zeros */
     memset(out, 0, sizeof(npy_datetimestruct));

--- a/pandas/_libs/src/datetime/np_datetime.h
+++ b/pandas/_libs/src/datetime/np_datetime.h
@@ -31,7 +31,7 @@ extern const npy_datetimestruct _NS_MAX_DTS;
 // stuff pandas needs
 // ----------------------------------------------------------------------------
 
-int convert_pydatetime_to_datetimestruct(PyDateTime_Date *obj,
+int convert_pydatetime_to_datetimestruct(PyDateTime_Date *dtobj,
                                          npy_datetimestruct *out);
 
 npy_datetime npy_datetimestruct_to_datetime(NPY_DATETIMEUNIT base,

--- a/pandas/_libs/src/parser/tokenizer.c
+++ b/pandas/_libs/src/parser/tokenizer.c
@@ -262,7 +262,7 @@ static int make_stream_space(parser_t *self, size_t nbytes) {
         ("\n\nmake_stream_space: nbytes = %zu.  grow_buffer(self->stream...)\n",
          nbytes))
     self->stream = (char *)grow_buffer((void *)self->stream, self->stream_len,
-                                       (size_t*)&self->stream_cap, nbytes * 2,
+                                       (int64_t*)&self->stream_cap, nbytes * 2,
                                        sizeof(char), &status);
     TRACE(
         ("make_stream_space: self->stream=%p, self->stream_len = %zu, "
@@ -289,7 +289,7 @@ static int make_stream_space(parser_t *self, size_t nbytes) {
     cap = self->words_cap;
     self->words =
         (char **)grow_buffer((void *)self->words, self->words_len,
-                             (size_t*)&self->words_cap, nbytes,
+                             (int64_t*)&self->words_cap, nbytes,
                              sizeof(char *), &status);
     TRACE(
         ("make_stream_space: grow_buffer(self->self->words, %zu, %zu, %zu, "
@@ -320,7 +320,7 @@ static int make_stream_space(parser_t *self, size_t nbytes) {
     cap = self->lines_cap;
     self->line_start =
         (int64_t *)grow_buffer((void *)self->line_start, self->lines + 1,
-                           (size_t*)&self->lines_cap, nbytes,
+                           (int64_t*)&self->lines_cap, nbytes,
                            sizeof(int64_t), &status);
     TRACE((
         "make_stream_space: grow_buffer(self->line_start, %zu, %zu, %zu, %d)\n",

--- a/pandas/_libs/src/ujson/python/objToJSON.c
+++ b/pandas/_libs/src/ujson/python/objToJSON.c
@@ -427,7 +427,7 @@ static void *PyUnicodeToUTF8(JSOBJ _obj, JSONTypeContext *tc, void *outValue,
 #if (PY_VERSION_HEX >= 0x03030000)
     if (PyUnicode_IS_COMPACT_ASCII(obj)) {
         Py_ssize_t len;
-        char *data = PyUnicode_AsUTF8AndSize(obj, &len);
+        char *data = (char*)PyUnicode_AsUTF8AndSize(obj, &len);
         *_outLen = len;
         return data;
     }

--- a/pandas/_libs/tslibs/period.pyx
+++ b/pandas/_libs/tslibs/period.pyx
@@ -927,7 +927,8 @@ def extract_freq(ndarray[object] values):
 # -----------------------------------------------------------------------
 # period helpers
 
-
+@cython.wraparound(False)
+@cython.boundscheck(False)
 cdef ndarray[int64_t] localize_dt64arr_to_period(ndarray[int64_t] stamps,
                                                  int freq, object tz):
     cdef:

--- a/pandas/_libs/tslibs/util.pxd
+++ b/pandas/_libs/tslibs/util.pxd
@@ -70,7 +70,7 @@ cdef extern from "../src/numpy_helper.h":
     int assign_value_1d(ndarray, Py_ssize_t, object) except -1
     cnp.int64_t get_nat()
     object get_value_1d(ndarray, Py_ssize_t)
-    char *get_c_string(object) except NULL
+    const char *get_c_string(object) except NULL
     object char_to_string(char*)
 
 ctypedef fused numeric:

--- a/pandas/io/sas/sas.pyx
+++ b/pandas/io/sas/sas.pyx
@@ -104,7 +104,8 @@ cdef ndarray[uint8_t, ndim=1] rle_decompress(
             raise ValueError("unknown control byte: {byte}"
                              .format(byte=control_byte))
 
-    if len(result) != result_length:
+    # In py37 cython/clang sees `len(outbuff)` as size_t and not Py_ssize_t
+    if <Py_ssize_t>len(result) != <Py_ssize_t>result_length:
         raise ValueError("RLE: {got} != {expect}".format(got=len(result),
                                                          expect=result_length))
 
@@ -186,11 +187,13 @@ cdef ndarray[uint8_t, ndim=1] rdc_decompress(
         else:
             raise ValueError("unknown RDC command")
 
-    if len(outbuff) != result_length:
+    # In py37 cython/clang sees `len(outbuff)` as size_t and not Py_ssize_t
+    if <Py_ssize_t>len(outbuff) != <Py_ssize_t>result_length:
         raise ValueError("RDC: {got} != {expect}\n"
                          .format(got=len(outbuff), expect=result_length))
 
     return np.asarray(outbuff)
+
 
 cdef enum ColumnTypes:
     column_type_decimal = 1
@@ -203,6 +206,7 @@ cdef int page_mix_types_0 = const.page_mix_types[0]
 cdef int page_mix_types_1 = const.page_mix_types[1]
 cdef int page_data_type = const.page_data_type
 cdef int subheader_pointers_offset = const.subheader_pointers_offset
+
 
 cdef class Parser(object):
 

--- a/setup.py
+++ b/setup.py
@@ -491,7 +491,6 @@ def srcpath(name=None, suffix='.pyx', subdir='src'):
 if suffix == '.pyx':
     lib_depends = [srcpath(f, suffix='.pyx', subdir='_libs/src')
                    for f in lib_depends]
-    lib_depends.append('pandas/_libs/util.pxd')
 else:
     lib_depends = []
 
@@ -507,7 +506,7 @@ np_datetime_headers = ['pandas/_libs/src/datetime/np_datetime.h',
 np_datetime_sources = ['pandas/_libs/src/datetime/np_datetime.c',
                        'pandas/_libs/src/datetime/np_datetime_strings.c']
 
-tseries_depends = np_datetime_headers + ['pandas/_libs/tslibs/np_datetime.pxd']
+tseries_depends = np_datetime_headers
 
 
 ext_data = {


### PR DESCRIPTION
Checked in OSX in 2.7 and 3.7, on Ubuntu on 2.7 and 3.5, this fixes just about all the warnings that are fixable at my pay-grade.

The ones that are left:

- Ubiquitous `NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION` --> I expect there is a compiler flag that can be set in setup.py to silence this (and only this) warning, haven't figured it out.
- In Py3.7:
```
pandas/_libs/src/ujson/python/objToJSON.c:430:15: warning: initializing 'char *' with an expression of type 'const char *' discards qualifiers
      [-Wincompatible-pointer-types-discards-qualifiers]
        char *data = PyUnicode_AsUTF8AndSize(obj, &len);
              ^      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
pandas/_libs/src/ujson/python/objToJSON.c:436:14: warning: 'PyUnicode_EncodeUTF8' is deprecated [-Wdeprecated-declarations]
    newObj = PyUnicode_EncodeUTF8(PyUnicode_AS_UNICODE(obj),
             ^
/usr/local/Cellar/python/3.7.0/Frameworks/Python.framework/Versions/3.7/include/python3.7m/unicodeobject.h:1324:7: note: 'PyUnicode_EncodeUTF8' has been
      explicitly marked deprecated here
    ) Py_DEPRECATED(3.3);
      ^
/usr/local/Cellar/python/3.7.0/Frameworks/Python.framework/Versions/3.7/include/python3.7m/pyport.h:493:54: note: expanded from macro 'Py_DEPRECATED'
#define Py_DEPRECATED(VERSION_UNUSED) __attribute__((__deprecated__))
                                                     ^
3 warnings generated.
```
- On Linux:
```
In file included from pandas/_libs/src/datetime/np_datetime.h:21:0,
                 from pandas/_libs/src/datetime/np_datetime_strings.c:33:
/usr/include/python3.5m/datetime.h:191:25: warning: ‘PyDateTimeAPI’ defined but not used [-Wunused-variable]
 static PyDateTime_CAPI *PyDateTimeAPI = NULL;
```
- Also on Linux a bunch of "this may be unitialized" warnings.