### PR TITLE
ENH: Number formatting support for excel styles

### DIFF
--- a/doc/source/style.ipynb
+++ b/doc/source/style.ipynb
@@ -985,7 +985,10 @@
     "- `vertical-align`\n",
     "- `white-space: nowrap`\n",
     "\n",
-    "Only CSS2 named colors and hex colors of the form `#rgb` or `#rrggbb` are currently supported."
+    "Only CSS2 named colors and hex colors of the form `#rgb` or `#rrggbb` are currently supported.\n",
+    "\n",
+    "The following pseudo CSS properties are also available to set excel specific style properties:\n",
+    "- `number-format`\n"
    ]
   },
   {

--- a/doc/source/whatsnew/v0.24.0.txt
+++ b/doc/source/whatsnew/v0.24.0.txt
@@ -372,7 +372,7 @@ Other API Changes
 - Trying to reindex a ``DataFrame`` with a non unique ``MultiIndex`` now raises a ``ValueError`` instead of an ``Exception`` (:issue:`21770`)
 - :meth:`PeriodIndex.tz_convert` and :meth:`PeriodIndex.tz_localize` have been removed (:issue:`21781`)
 - :class:`Index` subtraction will attempt to operate element-wise instead of raising ``TypeError`` (:issue:`19369`)
-- :class:`pandas.io.formats.style.Styler` supports a ``number-format`` property when using :meth:`~pandas.io.formats.style.Styler.to_excel`
+- :class:`pandas.io.formats.style.Styler` supports a ``number-format`` property when using :meth:`~pandas.io.formats.style.Styler.to_excel` (:issue:`22015`)
 
 .. _whatsnew_0240.deprecations:
 

--- a/doc/source/whatsnew/v0.24.0.txt
+++ b/doc/source/whatsnew/v0.24.0.txt
@@ -372,6 +372,7 @@ Other API Changes
 - Trying to reindex a ``DataFrame`` with a non unique ``MultiIndex`` now raises a ``ValueError`` instead of an ``Exception`` (:issue:`21770`)
 - :meth:`PeriodIndex.tz_convert` and :meth:`PeriodIndex.tz_localize` have been removed (:issue:`21781`)
 - :class:`Index` subtraction will attempt to operate element-wise instead of raising ``TypeError`` (:issue:`19369`)
+- :class:`pandas.io.formats.style.Styler` supports a ``number-format`` property when using :meth:`~pandas.io.formats.style.Styler.to_excel`
 
 .. _whatsnew_0240.deprecations:
 

--- a/pandas/io/formats/excel.py
+++ b/pandas/io/formats/excel.py
@@ -98,8 +98,8 @@ class CSSToExcelConverter(object):
             'border': self.build_border(props),
             'fill': self.build_fill(props),
             'font': self.build_font(props),
+            'number_format': self.build_number_format(props),
         }
-        # TODO: support number format
         # TODO: handle cell width and height: needs support in pandas.io.excel
 
         def remove_none(d):
@@ -313,6 +313,9 @@ class CSSToExcelConverter(object):
         except KeyError:
             warnings.warn('Unhandled color format: {val!r}'.format(val=val),
                           CSSWarning)
+
+    def build_number_format(self, props):
+        return {'format_code': props.get('number-format')}
 
 
 class ExcelFormatter(object):

--- a/pandas/tests/io/formats/test_to_excel.py
+++ b/pandas/tests/io/formats/test_to_excel.py
@@ -172,6 +172,9 @@ from pandas.io.formats.excel import CSSToExcelConverter
      {'alignment': {'wrap_text': False}}),
     ('white-space: normal',
      {'alignment': {'wrap_text': True}}),
+    # NUMBER FORMAT
+    ('number-format: 0%',
+     {'number_format': {'format_code': '0%'}}),
 ])
 def test_css_to_excel(css, expected):
     convert = CSSToExcelConverter()

--- a/pandas/tests/io/test_excel.py
+++ b/pandas/tests/io/test_excel.py
@@ -2241,6 +2241,7 @@ def test_styler_to_excel(engine):
                           ['', 'font-style: italic', ''],
                           ['', '', 'text-align: right'],
                           ['background-color: red', '', ''],
+                          ['number-format: 0%', '', ''],
                           ['', '', ''],
                           ['', '', ''],
                           ['', '', '']],
@@ -2266,7 +2267,7 @@ def test_styler_to_excel(engine):
 
     # Prepare spreadsheets
 
-    df = DataFrame(np.random.randn(10, 3))
+    df = DataFrame(np.random.randn(11, 3))
     with ensure_clean('.xlsx' if engine != 'xlwt' else '.xls') as path:
         writer = ExcelWriter(path, engine=engine)
         df.to_excel(writer, sheet_name='frame')
@@ -2294,7 +2295,7 @@ def test_styler_to_excel(engine):
                 n_cells += 1
 
         # ensure iteration actually happened:
-        assert n_cells == (10 + 1) * (3 + 1)
+        assert n_cells == (11 + 1) * (3 + 1)
 
         # (2) check styling with default converter
 
@@ -2344,13 +2345,16 @@ def test_styler_to_excel(engine):
                     assert cell1.fill.patternType != cell2.fill.patternType
                     assert cell2.fill.fgColor.rgb == alpha + 'FF0000'
                     assert cell2.fill.patternType == 'solid'
+                elif ref == 'B9':
+                    assert cell1.number_format == 'General'
+                    assert cell2.number_format == '0%'
                 else:
                     assert_equal_style(cell1, cell2)
 
                 assert cell1.value == cell2.value
                 n_cells += 1
 
-        assert n_cells == (10 + 1) * (3 + 1)
+        assert n_cells == (11 + 1) * (3 + 1)
 
         # (3) check styling with custom converter
         n_cells = 0
@@ -2359,7 +2363,7 @@ def test_styler_to_excel(engine):
             assert len(col1) == len(col2)
             for cell1, cell2 in zip(col1, col2):
                 ref = '%s%d' % (cell2.column, cell2.row)
-                if ref in ('B2', 'C3', 'D4', 'B5', 'C6', 'D7', 'B8'):
+                if ref in ('B2', 'C3', 'D4', 'B5', 'C6', 'D7', 'B8', 'B9'):
                     assert not cell1.font.bold
                     assert cell2.font.bold
                 else:
@@ -2368,7 +2372,7 @@ def test_styler_to_excel(engine):
                 assert cell1.value == cell2.value
                 n_cells += 1
 
-        assert n_cells == (10 + 1) * (3 + 1)
+        assert n_cells == (11 + 1) * (3 + 1)
 
 
 @td.skip_if_no('openpyxl')


### PR DESCRIPTION
- [x] closes #22027 
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry

Add number formatting support to the excel styles using a fake css entry. 

```css
number-format: 0%;
```

Added new tests, updated docs, and manually verified outputs using both excel output engines that support styling. 