### PR TITLE
fix Error Indexing DafaFrame with a 0-d array

### DIFF
--- a/doc/source/whatsnew/v0.24.0.txt
+++ b/doc/source/whatsnew/v0.24.0.txt
@@ -501,6 +501,7 @@ Indexing
 - Fixed ``DataFrame[np.nan]`` when columns are non-unique (:issue:`21428`)
 - Bug when indexing :class:`DatetimeIndex` with nanosecond resolution dates and timezones (:issue:`11679`)
 - Bug where indexing with a Numpy array containing negative values would mutate the indexer (:issue:`21867`)
+- Bug where indexing with a 0-dimensional array would error with an unhelpful stack trace (:issue: `21946`)
 
 Missing
 ^^^^^^^

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -4178,6 +4178,8 @@ class Index(IndexOpsMixin, PandasObject):
             pass
         elif is_integer(key):
             pass
+        elif np.array(key).ndim == 0:
+            self._invalid_indexer(form, key)
         elif kind in ['iloc', 'getitem']:
             self._invalid_indexer(form, key)
         return key

--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -2692,8 +2692,9 @@ def is_nested_tuple(tup, labels):
 
 def is_list_like_indexer(key):
     # allow a list_like, but exclude NamedTuples which can be indexers
-    return is_list_like(key) and not (isinstance(key, tuple) and
-                                      type(key) is not tuple)
+    return (is_list_like(key)
+            and not (isinstance(key, tuple) and type(key) is not tuple)
+            and not np.array(key).ndim == 0)
 
 
 def is_label_like(key):

--- a/pandas/tests/indexing/test_indexing.py
+++ b/pandas/tests/indexing/test_indexing.py
@@ -890,6 +890,13 @@ class TestMisc(Base):
         del df
         assert wr() is None
 
+    def test_zero_index_iloc_raises(self):
+        df = pd.DataFrame([[1, 2], [3, 4]], columns=['a', 'b'])
+        ar = np.array(0)
+        msg = 'Cannot index by location index with a non-integer key'
+        with assert_raises_regex(TypeError, msg):
+            df.iloc[ar]
+
 
 class TestSeriesNoneCoercion(object):
     EXPECTED_RESULTS = [


### PR DESCRIPTION
closes #21946

- [x ] closes #xxxx
- [x ] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x ] whatsnew entry
