### PR TITLE
PERF/REF: improve performance of Series.searchsorted, PandasArray.searchsorted, collect functionality

### DIFF
--- a/asv_bench/benchmarks/series_methods.py
+++ b/asv_bench/benchmarks/series_methods.py
@@ -124,6 +124,25 @@ class Dropna(object):
         self.s.dropna()
 
 
+class SearchSorted(object):
+
+    goal_time = 0.2
+    params = ['int8', 'int16', 'int32', 'int64',
+              'uint8', 'uint16', 'uint32', 'uint64',
+              'float16', 'float32', 'float64',
+              'str']
+    param_names = ['dtype']
+
+    def setup(self, dtype):
+        N = 10**5
+        data = np.array([1] * N + [2] * N + [3] * N).astype(dtype)
+        self.s = Series(data)
+
+    def time_searchsorted(self, dtype):
+        key = '2' if dtype == 'str' else 2
+        self.s.searchsorted(key)
+
+
 class Map(object):
 
     params = ['dict', 'Series']

--- a/doc/source/whatsnew/v0.25.0.rst
+++ b/doc/source/whatsnew/v0.25.0.rst
@@ -64,7 +64,8 @@ Performance Improvements
 
 - Significant speedup in `SparseArray` initialization that benefits most operations, fixing performance regression introduced in v0.20.0 (:issue:`24985`)
 - `DataFrame.to_stata()` is now faster when outputting data with any string or non-native endian columns (:issue:`25045`)
--
+- Improved performance of :meth:`Series.searchsorted`. The speedup is especially large when the dtype is int8/int16/int32 and the searched key is within
+  the integer bounds for the dtype(:issue:`22034`)
 
 
 .. _whatsnew_0250.bug_fixes:

--- a/doc/source/whatsnew/v0.25.0.rst
+++ b/doc/source/whatsnew/v0.25.0.rst
@@ -65,7 +65,7 @@ Performance Improvements
 - Significant speedup in `SparseArray` initialization that benefits most operations, fixing performance regression introduced in v0.20.0 (:issue:`24985`)
 - `DataFrame.to_stata()` is now faster when outputting data with any string or non-native endian columns (:issue:`25045`)
 - Improved performance of :meth:`Series.searchsorted`. The speedup is especially large when the dtype is
-  int8/int16/int32 and the searched key is within the integer bounds for the dtype(:issue:`22034`)
+  int8/int16/int32 and the searched key is within the integer bounds for the dtype (:issue:`22034`)
 
 
 .. _whatsnew_0250.bug_fixes:

--- a/doc/source/whatsnew/v0.25.0.rst
+++ b/doc/source/whatsnew/v0.25.0.rst
@@ -64,8 +64,8 @@ Performance Improvements
 
 - Significant speedup in `SparseArray` initialization that benefits most operations, fixing performance regression introduced in v0.20.0 (:issue:`24985`)
 - `DataFrame.to_stata()` is now faster when outputting data with any string or non-native endian columns (:issue:`25045`)
-- Improved performance of :meth:`Series.searchsorted`. The speedup is especially large when the dtype is int8/int16/int32 and the searched key is within
-  the integer bounds for the dtype(:issue:`22034`)
+- Improved performance of :meth:`Series.searchsorted`. The speedup is especially large when the dtype is
+  int8/int16/int32 and the searched key is within the integer bounds for the dtype(:issue:`22034`)
 
 
 .. _whatsnew_0250.bug_fixes:

--- a/pandas/core/algorithms.py
+++ b/pandas/core/algorithms.py
@@ -1734,24 +1734,25 @@ def searchsorted(arr, value, side="left", sorter=None):
 
     .. versionadded:: 0.25.0
 
-    Find the indices into a sorted array `self` (a) such that, if the
+    Find the indices into a sorted array `arr` (a) such that, if the
     corresponding elements in `value` were inserted before the indices,
-    the order of `self` would be preserved.
+    the order of `arr` would be preserved.
 
-    Assuming that `self` is sorted:
+    Assuming that `arr` is sorted:
 
     ======  ================================
     `side`  returned index `i` satisfies
     ======  ================================
-    left    ``self[i-1] < value <= self[i]``
-    right   ``self[i-1] <= value < self[i]``
+    left    ``arr[i-1] < value <= self[i]``
+    right   ``arr[i-1] <= value < self[i]``
     ======  ================================
 
     Parameters
     ----------
-    arr: numpy.array or ExtensionArray
-        array to search in. Cannot be Index, Series or PandasArray, as that
-        would cause a RecursionError.
+    arr: array-like
+        Input array. If `sorter` is None, then it must be sorted in
+        ascending order, otherwise `sorter` must be an array of indices
+        that sort it.
     value : array_like
         Values to insert into `arr`.
     side : {'left', 'right'}, optional

--- a/pandas/core/algorithms.py
+++ b/pandas/core/algorithms.py
@@ -19,7 +19,7 @@ from pandas.core.dtypes.common import (
     ensure_float64, ensure_int64, ensure_object, ensure_platform_int,
     ensure_uint64, is_array_like, is_bool_dtype, is_categorical_dtype,
     is_complex_dtype, is_datetime64_any_dtype, is_datetime64tz_dtype,
-    is_datetimelike, is_extension_array_dtype, is_float_dtype,
+    is_datetimelike, is_extension_array_dtype, is_float_dtype, is_integer,
     is_integer_dtype, is_interval_dtype, is_list_like, is_numeric_dtype,
     is_object_dtype, is_period_dtype, is_scalar, is_signed_integer_dtype,
     is_sparse, is_timedelta64_dtype, is_unsigned_integer_dtype,
@@ -1722,6 +1722,88 @@ def take_2d_multi(arr, indexer, out=None, fill_value=np.nan, mask_info=None,
 
     func(arr, indexer, out=out, fill_value=fill_value)
     return out
+
+
+# ---- #
+# searchsorted #
+# ---- #
+
+def searchsorted(arr, value, side="left", sorter=None):
+    """
+    Find indices where elements should be inserted to maintain order.
+
+    .. versionadded:: 0.25.0
+
+    Find the indices into a sorted array `self` (a) such that, if the
+    corresponding elements in `value` were inserted before the indices,
+    the order of `self` would be preserved.
+
+    Assuming that `self` is sorted:
+
+    ======  ================================
+    `side`  returned index `i` satisfies
+    ======  ================================
+    left    ``self[i-1] < value <= self[i]``
+    right   ``self[i-1] <= value < self[i]``
+    ======  ================================
+
+    Parameters
+    ----------
+    arr: numpy.array or ExtensionArray
+        array to search in. Cannot be Index, Series or PandasArray, as that
+        would cause a RecursionError.
+    value : array_like
+        Values to insert into `arr`.
+    side : {'left', 'right'}, optional
+        If 'left', the index of the first suitable location found is given.
+        If 'right', return the last such index.  If there is no suitable
+        index, return either 0 or N (where N is the length of `self`).
+    sorter : 1-D array_like, optional
+        Optional array of integer indices that sort array a into ascending
+        order. They are typically the result of argsort.
+
+    Returns
+    -------
+    array of ints
+        Array of insertion points with the same shape as `value`.
+
+    See Also
+    --------
+    numpy.searchsorted : Similar method from NumPy.
+    """
+    if sorter is not None:
+        sorter = ensure_platform_int(sorter)
+
+    if is_integer_dtype(arr) and (
+            is_integer(value) or is_integer_dtype(value)):
+        from .arrays.array_ import array
+        # if `arr` and `value` have different dtypes, `arr` would be
+        # recast by numpy, causing a slow search.
+        # Before searching below, we therefore try to give `value` the
+        # same dtype as `arr`, while guarding against integer overflows.
+        iinfo = np.iinfo(arr.dtype.type)
+        value_arr = np.array([value]) if is_scalar(value) else np.array(value)
+        if (value_arr >= iinfo.min).all() and (value_arr <= iinfo.max).all():
+            # value within bounds, so no overflow, so can convert value dtype
+            # to dtype of arr
+            dtype = arr.dtype
+        else:
+            dtype = value_arr.dtype
+
+        if is_scalar(value):
+            value = dtype.type(value)
+        else:
+            value = array(value, dtype=dtype)
+    elif not (is_object_dtype(arr) or is_numeric_dtype(arr) or
+              is_categorical_dtype(arr)):
+        from pandas.core.series import Series
+        # E.g. if `arr` is an array with dtype='datetime64[ns]'
+        # and `value` is a pd.Timestamp, we may need to convert value
+        value_ser = Series(value)._values
+        value = value_ser[0] if is_scalar(value) else value_ser
+
+    result = arr.searchsorted(value, side=side, sorter=sorter)
+    return result
 
 
 # ---- #

--- a/pandas/core/algorithms.py
+++ b/pandas/core/algorithms.py
@@ -1724,9 +1724,9 @@ def take_2d_multi(arr, indexer, out=None, fill_value=np.nan, mask_info=None,
     return out
 
 
-# ---- #
+# ------------ #
 # searchsorted #
-# ---- #
+# ------------ #
 
 def searchsorted(arr, value, side="left", sorter=None):
     """
@@ -1774,7 +1774,7 @@ def searchsorted(arr, value, side="left", sorter=None):
     if sorter is not None:
         sorter = ensure_platform_int(sorter)
 
-    if is_integer_dtype(arr) and (
+    if isinstance(arr, np.ndarray) and is_integer_dtype(arr) and (
             is_integer(value) or is_integer_dtype(value)):
         from .arrays.array_ import array
         # if `arr` and `value` have different dtypes, `arr` would be

--- a/pandas/core/arrays/base.py
+++ b/pandas/core/arrays/base.py
@@ -555,17 +555,17 @@ class ExtensionArray(object):
         .. versionadded:: 0.24.0
 
         Find the indices into a sorted array `self` (a) such that, if the
-        corresponding elements in `v` were inserted before the indices, the
-        order of `self` would be preserved.
+        corresponding elements in `value` were inserted before the indices,
+        the order of `self` would be preserved.
 
-        Assuming that `a` is sorted:
+        Assuming that `self` is sorted:
 
-        ======  ============================
+        ======  ================================
         `side`  returned index `i` satisfies
-        ======  ============================
-        left    ``self[i-1] < v <= self[i]``
-        right   ``self[i-1] <= v < self[i]``
-        ======  ============================
+        ======  ================================
+        left    ``self[i-1] < value <= self[i]``
+        right   ``self[i-1] <= value < self[i]``
+        ======  ================================
 
         Parameters
         ----------
@@ -581,7 +581,7 @@ class ExtensionArray(object):
 
         Returns
         -------
-        indices : array of ints
+        array of ints
             Array of insertion points with the same shape as `value`.
 
         See Also

--- a/pandas/core/arrays/numpy_.py
+++ b/pandas/core/arrays/numpy_.py
@@ -4,6 +4,7 @@ import numpy as np
 
 from pandas._libs import lib
 from pandas.compat.numpy import function as nv
+from pandas.util._decorators import Appender
 from pandas.util._validators import validate_fillna_kwargs
 
 from pandas.core.dtypes.dtypes import ExtensionDtype
@@ -11,7 +12,7 @@ from pandas.core.dtypes.generic import ABCIndexClass, ABCSeries
 from pandas.core.dtypes.inference import is_array_like, is_list_like
 
 from pandas import compat
-from pandas.core import nanops
+from pandas.core import common as com, nanops
 from pandas.core.missing import backfill_1d, pad_1d
 
 from .base import ExtensionArray, ExtensionOpsMixin
@@ -422,6 +423,11 @@ class PandasArray(ExtensionArray, ExtensionOpsMixin, NDArrayOperatorsMixin):
             result = result.copy()
 
         return result
+
+    @Appender(ExtensionArray.searchsorted.__doc__)
+    def searchsorted(self, value, side='left', sorter=None):
+        return com.searchsorted(self.to_numpy(), value,
+                                side=side, sorter=sorter)
 
     # ------------------------------------------------------------------------
     # Ops

--- a/pandas/core/arrays/numpy_.py
+++ b/pandas/core/arrays/numpy_.py
@@ -12,7 +12,8 @@ from pandas.core.dtypes.generic import ABCIndexClass, ABCSeries
 from pandas.core.dtypes.inference import is_array_like, is_list_like
 
 from pandas import compat
-from pandas.core import common as com, nanops
+from pandas.core import nanops
+from pandas.core.algorithms import searchsorted
 from pandas.core.missing import backfill_1d, pad_1d
 
 from .base import ExtensionArray, ExtensionOpsMixin
@@ -426,8 +427,8 @@ class PandasArray(ExtensionArray, ExtensionOpsMixin, NDArrayOperatorsMixin):
 
     @Appender(ExtensionArray.searchsorted.__doc__)
     def searchsorted(self, value, side='left', sorter=None):
-        return com.searchsorted(self.to_numpy(), value,
-                                side=side, sorter=sorter)
+        return searchsorted(self.to_numpy(), value,
+                            side=side, sorter=sorter)
 
     # ------------------------------------------------------------------------
     # Ops

--- a/pandas/core/base.py
+++ b/pandas/core/base.py
@@ -1525,8 +1525,8 @@ class IndexOpsMixin(object):
     @Substitution(klass='Index')
     @Appender(_shared_docs['searchsorted'])
     def searchsorted(self, value, side='left', sorter=None):
-        return com.searchsorted(self._values, value,
-                                side=side, sorter=sorter)
+        return algorithms.searchsorted(self._values, value,
+                                       side=side, sorter=sorter)
 
     def drop_duplicates(self, keep='first', inplace=False):
         inplace = validate_bool_kwarg(inplace, 'inplace')

--- a/pandas/core/base.py
+++ b/pandas/core/base.py
@@ -1522,15 +1522,11 @@ class IndexOpsMixin(object):
         array([3])
         """)
 
-    @Substitution(klass='IndexOpsMixin')
+    @Substitution(klass='Index')
     @Appender(_shared_docs['searchsorted'])
     def searchsorted(self, value, side='left', sorter=None):
-        result = com.searchsorted(self._values, value,
-                                  side=side, sorter=sorter)
-
-        if is_scalar(value):
-            return result if is_scalar(result) else result[0]
-        return result
+        return com.searchsorted(self._values, value,
+                                side=side, sorter=sorter)
 
     def drop_duplicates(self, keep='first', inplace=False):
         inplace = validate_bool_kwarg(inplace, 'inplace')

--- a/pandas/core/base.py
+++ b/pandas/core/base.py
@@ -1525,8 +1525,12 @@ class IndexOpsMixin(object):
     @Substitution(klass='IndexOpsMixin')
     @Appender(_shared_docs['searchsorted'])
     def searchsorted(self, value, side='left', sorter=None):
-        # needs coercion on the key (DatetimeIndex does already)
-        return self._values.searchsorted(value, side=side, sorter=sorter)
+        result = com.searchsorted(self._values, value,
+                                  side=side, sorter=sorter)
+
+        if is_scalar(value):
+            return result if is_scalar(result) else result[0]
+        return result
 
     def drop_duplicates(self, keep='first', inplace=False):
         inplace = validate_bool_kwarg(inplace, 'inplace')

--- a/pandas/core/common.py
+++ b/pandas/core/common.py
@@ -13,7 +13,8 @@ import inspect
 import numpy as np
 
 from pandas._libs import lib, tslibs
-from pandas.compat import PY36, OrderedDict, iteritems
+import pandas.compat as compat
+from pandas.compat import PY36, iteritems
 
 from pandas.core.dtypes.cast import construct_1d_object_array_from_listlike
 from pandas.core.dtypes.common import (
@@ -21,8 +22,6 @@ from pandas.core.dtypes.common import (
 from pandas.core.dtypes.generic import ABCIndex, ABCIndexClass, ABCSeries
 from pandas.core.dtypes.inference import _iterable_not_string
 from pandas.core.dtypes.missing import isna, isnull, notnull  # noqa
-
-from pandas import compat
 
 
 class SettingWithCopyError(ValueError):

--- a/pandas/core/common.py
+++ b/pandas/core/common.py
@@ -511,6 +511,7 @@ def searchsorted_integer(arr, value, side="left", sorter=None):
     int or numpy.array
         The locations(s) of `value` in `arr`.
     """
+    from .arrays.array_ import array
     if sorter is not None:
         sorter = ensure_platform_int(sorter)
 
@@ -518,12 +519,16 @@ def searchsorted_integer(arr, value, side="left", sorter=None):
     # against integer overflows. If the value of `value` is outside of the
     # bound of `arr`, `arr` would be recast by numpy, causing a slower search.
     value_arr = np.array([value]) if is_scalar(value) else np.array(value)
-    iinfo = np.iinfo(arr.dtype)
+    iinfo = np.iinfo(arr.dtype.type)
     if (value_arr >= iinfo.min).all() and (value_arr <= iinfo.max).all():
         dtype = arr.dtype
     else:
         dtype = value_arr.dtype
-    value = np.asarray(value, dtype=dtype)
+
+    if is_scalar(value):
+        value = dtype.type(value)
+    else:
+        value = array(value, dtype=dtype)
 
     return arr.searchsorted(value, side=side, sorter=sorter)
 

--- a/pandas/core/common.py
+++ b/pandas/core/common.py
@@ -17,9 +17,7 @@ from pandas.compat import PY36, OrderedDict, iteritems
 
 from pandas.core.dtypes.cast import construct_1d_object_array_from_listlike
 from pandas.core.dtypes.common import (
-    ensure_platform_int, is_array_like, is_bool_dtype, is_categorical_dtype,
-    is_extension_array_dtype, is_integer, is_integer_dtype, is_numeric_dtype,
-    is_object_dtype, is_scalar)
+    is_array_like, is_bool_dtype, is_extension_array_dtype, is_integer)
 from pandas.core.dtypes.generic import ABCIndex, ABCIndexClass, ABCSeries
 from pandas.core.dtypes.inference import _iterable_not_string
 from pandas.core.dtypes.missing import isna, isnull, notnull  # noqa
@@ -485,81 +483,3 @@ def _get_rename_function(mapper):
         f = mapper
 
     return f
-
-
-def searchsorted(arr, value, side="left", sorter=None):
-    """
-    Find indices where elements should be inserted to maintain order.
-
-    .. versionadded:: 0.25.0
-
-    Find the indices into a sorted array `self` (a) such that, if the
-    corresponding elements in `value` were inserted before the indices,
-    the order of `self` would be preserved.
-
-    Assuming that `self` is sorted:
-
-    ======  ================================
-    `side`  returned index `i` satisfies
-    ======  ================================
-    left    ``self[i-1] < value <= self[i]``
-    right   ``self[i-1] <= value < self[i]``
-    ======  ================================
-
-    Parameters
-    ----------
-    arr: numpy.array or ExtensionArray
-        array to search in. Cannot be Index, Series or PandasArray, as that
-        would cause a RecursionError.
-    value : array_like
-        Values to insert into `arr`.
-    side : {'left', 'right'}, optional
-        If 'left', the index of the first suitable location found is given.
-        If 'right', return the last such index.  If there is no suitable
-        index, return either 0 or N (where N is the length of `self`).
-    sorter : 1-D array_like, optional
-        Optional array of integer indices that sort array a into ascending
-        order. They are typically the result of argsort.
-
-    Returns
-    -------
-    array of ints
-        Array of insertion points with the same shape as `value`.
-
-    See Also
-    --------
-    numpy.searchsorted : Similar method from NumPy.
-    """
-    if sorter is not None:
-        sorter = ensure_platform_int(sorter)
-
-    if is_integer_dtype(arr) and (
-            is_integer(value) or is_integer_dtype(value)):
-        from .arrays.array_ import array
-        # if `arr` and `value` have different dtypes, `arr` would be
-        # recast by numpy, causing a slow search.
-        # Before searching below, we therefore try to give `value` the
-        # same dtype as `arr`, while guarding against integer overflows.
-        iinfo = np.iinfo(arr.dtype.type)
-        value_arr = np.array([value]) if is_scalar(value) else np.array(value)
-        if (value_arr >= iinfo.min).all() and (value_arr <= iinfo.max).all():
-            # value within bounds, so no overflow, so can convert value dtype
-            # to dtype of arr
-            dtype = arr.dtype
-        else:
-            dtype = value_arr.dtype
-
-        if is_scalar(value):
-            value = dtype.type(value)
-        else:
-            value = array(value, dtype=dtype)
-    elif not (is_object_dtype(arr) or is_numeric_dtype(arr) or
-              is_categorical_dtype(arr)):
-        from pandas.core.series import Series
-        # E.g. if `arr` is an array with dtype='datetime64[ns]'
-        # and `value` is a pd.Timestamp, we may need to convert value
-        value_ser = Series(value)._values
-        value = value_ser[0] if is_scalar(value) else value_ser
-
-    result = arr.searchsorted(value, side=side, sorter=sorter)
-    return result

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -2392,17 +2392,12 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
     @Substitution(klass='Series')
     @Appender(base._shared_docs['searchsorted'])
     def searchsorted(self, value, side='left', sorter=None):
-        if sorter is not None:
-            sorter = ensure_platform_int(sorter)
-        if not is_extension_type(self._values):
-            # numpy searchsorted is only fast if value is of same dtype as the
-            # searched array. Below we ensure that value has the right dtype,
-            # and is not 0-dimensional.
-            value = np.asarray(value, dtype=self._values.dtype)
-            value = value[..., np.newaxis] if value.ndim == 0 else value
+        result = com.searchsorted(self._values, value,
+                                  side=side, sorter=sorter)
 
-        result = self._values.searchsorted(value, side=side, sorter=sorter)
-        return result[0] if is_scalar(value) else result
+        if is_scalar(value):
+            return result if is_scalar(result) else result[0]
+        return result
 
     # -------------------------------------------------------------------
     # Combination

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -2394,9 +2394,11 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
     def searchsorted(self, value, side='left', sorter=None):
         if sorter is not None:
             sorter = ensure_platform_int(sorter)
-        result = self._values.searchsorted(Series(value)._values,
-                                           side=side, sorter=sorter)
+        if not is_extension_type(self._values):
+            value = np.asarray(value, dtype=self._values.dtype)
+            value = value[..., np.newaxis] if value.ndim == 0 else value
 
+        result = self._values.searchsorted(value, side=side, sorter=sorter)
         return result[0] if is_scalar(value) else result
 
     # -------------------------------------------------------------------

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -2395,6 +2395,9 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
         if sorter is not None:
             sorter = ensure_platform_int(sorter)
         if not is_extension_type(self._values):
+            # numpy searchsorted is only fast if value is of same dtype as the
+            # searched array. Below we ensure that value has the right dtype,
+            # and is not 0-dimensional.
             value = np.asarray(value, dtype=self._values.dtype)
             value = value[..., np.newaxis] if value.ndim == 0 else value
 

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -2392,12 +2392,8 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
     @Substitution(klass='Series')
     @Appender(base._shared_docs['searchsorted'])
     def searchsorted(self, value, side='left', sorter=None):
-        result = com.searchsorted(self._values, value,
-                                  side=side, sorter=sorter)
-
-        if is_scalar(value):
-            return result if is_scalar(result) else result[0]
-        return result
+        return com.searchsorted(self._values, value,
+                                side=side, sorter=sorter)
 
     # -------------------------------------------------------------------
     # Combination

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -2392,8 +2392,8 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
     @Substitution(klass='Series')
     @Appender(base._shared_docs['searchsorted'])
     def searchsorted(self, value, side='left', sorter=None):
-        return com.searchsorted(self._values, value,
-                                side=side, sorter=sorter)
+        return algorithms.searchsorted(self._values, value,
+                                       side=side, sorter=sorter)
 
     # -------------------------------------------------------------------
     # Combination

--- a/pandas/tests/arrays/test_array.py
+++ b/pandas/tests/arrays/test_array.py
@@ -285,9 +285,15 @@ class TestArrayAnalytics(object):
         expected = np.array([1, 2], dtype=np.intp)
         tm.assert_numpy_array_equal(result, expected)
 
-    def test_search_sorted_datetime64_scalar(self):
-        arr = pd.array(pd.date_range('20120101', periods=10, freq='2D'))
-        val = pd.Timestamp('20120102')
+    @pytest.mark.parametrize('arr, val', [
+        [pd.date_range('20120101', periods=10, freq='2D'),
+         pd.Timestamp('20120102')],
+        [pd.date_range('20120101', periods=10, freq='2D', tz='Asia/Hong_Kong'),
+         pd.Timestamp('20120102', tz='Asia/Hong_Kong')],
+        [pd.timedelta_range(start='1 day', end='10 days', periods=10),
+         pd.Timedelta('2 days')]])
+    def test_search_sorted_datetime64_scalar(self, arr, val):
+        arr = pd.array(arr)
         result = arr.searchsorted(val)
         assert is_scalar(result)
         assert result == 1


### PR DESCRIPTION
- [x] closes #14565
- [x] ASV's added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry

Numpy's searchsorted doesn't like being given values to search for that aren't of the same type as the array being searched. By ensuring that the input value has the same dtype as the underlying array, the search is sped up significantly.

```python
>>> n = 1_000_000
>>> s = pd.Series(([1] * n + [2] * n + [3] * n), dtype='int8')
>>> %timeit s.searchsorted(1)  # python int
15.2 ms  # master
9.75 µs  # this PR
```

## ASV results

```
      before           after         ratio
     [b9754556]       [fd6c117b]
-        93.9±9μs         10.9±0μs     0.12  series_methods.SearchSorted.time_searchsorted('int64')
-        95.4±0μs         10.9±2μs     0.11  series_methods.SearchSorted.time_searchsorted('float64')
-        140±10μs       10.7±0.4μs     0.08  series_methods.SearchSorted.time_searchsorted('str')
-      1.34±0.1ms       10.8±0.3μs     0.01  series_methods.SearchSorted.time_searchsorted('uint16')
-     1.52±0.03ms         10.7±0μs     0.01  series_methods.SearchSorted.time_searchsorted('int16')
-      1.79±0.1ms         12.5±2μs     0.01  series_methods.SearchSorted.time_searchsorted('int8')
-      1.46±0.1ms       10.2±0.8μs     0.01  series_methods.SearchSorted.time_searchsorted('int32')
-        1.46±0ms         9.54±1μs     0.01  series_methods.SearchSorted.time_searchsorted('uint8')
-      1.46±0.1ms         9.38±2μs     0.01  series_methods.SearchSorted.time_searchsorted('float32')
-      1.71±0.2ms       10.4±0.9μs     0.01  series_methods.SearchSorted.time_searchsorted('uint32')
-      1.82±0.1ms         10.7±0μs     0.01  series_methods.SearchSorted.time_searchsorted('uint64')
-     2.14±0.04ms         10.7±0μs     0.00  series_methods.SearchSorted.time_searchsorted('float16')

SOME BENCHMARKS HAVE CHANGED SIGNIFICANTLY.
```

The improventents are largest when the dtype  isn't int64 or float64, but for those cases the improvement is also significant (10x).
