### PR TITLE
BUG: fix raise of TypeError when subtracting timedelta array

### DIFF
--- a/doc/source/whatsnew/v0.24.0.txt
+++ b/doc/source/whatsnew/v0.24.0.txt
@@ -642,6 +642,7 @@ Timedelta
 - Bug in :class:`Series` with numeric dtype when adding or subtracting an an array or ``Series`` with ``timedelta64`` dtype (:issue:`22390`)
 - Bug in :class:`Index` with numeric dtype when multiplying or dividing an array with dtype ``timedelta64`` (:issue:`22390`)
 - Bug in :class:`TimedeltaIndex` incorrectly allowing indexing with ``Timestamp`` object (:issue:`20464`)
+- Fixed bug where subtracting :class:`Timedelta` from an object-dtyped array would raise ``TypeError`` (:issue:`21980`)
 -
 -
 

--- a/pandas/_libs/tslibs/timedeltas.pyx
+++ b/pandas/_libs/tslibs/timedeltas.pyx
@@ -541,10 +541,12 @@ def _binary_op_method_timedeltalike(op, name):
 
         elif hasattr(other, 'dtype'):
             # nd-array like
-            if other.dtype.kind not in ['m', 'M']:
-                # raise rathering than letting numpy return wrong answer
+            if other.dtype.kind in ['m', 'M']:
+                return op(self.to_timedelta64(), other)
+            elif other.dtype.kind == 'O':
+                return np.array([op(self, x) for x in other])
+            else:
                 return NotImplemented
-            return op(self.to_timedelta64(), other)
 
         elif not _validate_ops_compat(other):
             return NotImplemented


### PR DESCRIPTION
closes #21980

- [x] closes #xxxx
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry
