### PR TITLE
PROPOSAL: use datetime64 and timedelta64 to eval

### DIFF
--- a/pandas/compat/numpy/__init__.py
+++ b/pandas/compat/numpy/__init__.py
@@ -68,6 +68,22 @@ def np_array_datetime64_compat(arr, *args, **kwargs):
     return np.array(arr, *args, **kwargs)
 
 
+# np.percentile should support datetime64 in upsteam. numpy/numpy#11620
+# TODO: change the version if the bug fixed
+if _nlv >= '99.99.99':
+    np_percentile_compat = np.percentile
+else:
+    def np_percentile_compat(values, q, **kw):
+        '''
+        provide compat for np.percentile supporting datetime64
+        '''
+        if values.dtype.kind == 'M':
+            result = np.percentile(values.view('i8'), q, **kw)
+            return result.astype(values.dtype)
+        else:
+            return np.percentile(values, q, **kw)
+
+
 __all__ = ['np',
            '_np_version_under1p10',
            '_np_version_under1p11',

--- a/pandas/core/common.py
+++ b/pandas/core/common.py
@@ -431,11 +431,3 @@ def _pipe(obj, func, *args, **kwargs):
         return func(*args, **kwargs)
     else:
         return func(obj, *args, **kwargs)
-
-
-# TODO: np.percentile not support datetime64, should be fixed in upsteam.
-def percentile(values, q, **kw):
-    if values.dtype.kind == 'M':
-        return np.percentile(values.view('i8'), q, **kw).astype(values.dtype)
-    else:
-        return np.percentile(values, q, **kw)

--- a/pandas/core/common.py
+++ b/pandas/core/common.py
@@ -431,3 +431,11 @@ def _pipe(obj, func, *args, **kwargs):
         return func(*args, **kwargs)
     else:
         return func(obj, *args, **kwargs)
+
+
+# TODO: np.percentile not support datetime64, should be fixed in upsteam.
+def percentile(values, q, **kw):
+    if values.dtype.kind == 'M':
+        return np.percentile(values.view('i8'), q, **kw).astype(values.dtype)
+    else:
+        return np.percentile(values, q, **kw)

--- a/pandas/core/internals/blocks.py
+++ b/pandas/core/internals/blocks.py
@@ -11,6 +11,7 @@ from pandas._libs.tslibs import conversion, Timedelta
 
 from pandas import compat
 from pandas.compat import range, zip
+from pandas.compat.numpy import np_percentile_compat
 
 from pandas.util._validators import validate_bool_kwarg
 
@@ -1601,7 +1602,7 @@ class Block(PandasObject):
                     return np.array([self.fill_value] * len(q),
                                     dtype=values.dtype)
 
-            return com.percentile(values, q, **kw)
+            return np_percentile_compat(values, q, **kw)
 
         def _nanpercentile(values, q, axis, **kw):
 
@@ -1621,7 +1622,7 @@ class Block(PandasObject):
                     result = np.array(result, dtype=values.dtype, copy=False).T
                     return result
             else:
-                return com.percentile(values, q, axis=axis, **kw)
+                return np_percentile_compat(values, q, axis=axis, **kw)
 
         from pandas import Float64Index
         is_empty = values.shape[axis] == 0

--- a/pandas/core/internals/managers.py
+++ b/pandas/core/internals/managers.py
@@ -1772,6 +1772,7 @@ def form_blocks(arrays, names, axes):
         blocks.extend(datetime_blocks)
 
     if len(items_dict['DatetimeTZBlock']):
+        # TODO: same tz can share one block
         dttz_blocks = [make_block(array,
                                   klass=DatetimeTZBlock,
                                   placement=[i])

--- a/pandas/tests/internals/test_internals.py
+++ b/pandas/tests/internals/test_internals.py
@@ -308,7 +308,7 @@ class TestDatetimeBlock(object):
                 date(2010, 10, 10))
         for val in vals:
             coerced = block._try_coerce_args(block.values, val)[2]
-            assert np.int64 == type(coerced)
+            assert np.datetime64 == type(coerced)
             assert pd.Timestamp('2010-10-10') == pd.Timestamp(coerced)
 
 
@@ -1250,14 +1250,20 @@ class TestCanHoldElement(object):
     ], ids=lambda x: x.__name__)
     def test_binop_other(self, op, value, dtype):
         skip = {(operator.add, 'bool'),
+                (operator.add, '<M8[ns]'),
                 (operator.sub, 'bool'),
                 (operator.mul, 'bool'),
+                (operator.mul, '<m8[ns]'),
+                (operator.mul, '<M8[ns]'),
                 (operator.truediv, 'bool'),
+                (operator.truediv, '<M8[ns]'),
                 (operator.mod, 'i8'),
                 (operator.mod, 'complex128'),
                 (operator.mod, '<M8[ns]'),
                 (operator.mod, '<m8[ns]'),
-                (operator.pow, 'bool')}
+                (operator.pow, 'bool'),
+                (operator.pow, '<m8[ns]'),
+                (operator.pow, '<M8[ns]')}
         if (op, dtype) in skip:
             pytest.skip("Invalid combination {},{}".format(op, dtype))
         e = DummyElement(value, dtype)

--- a/pandas/tests/internals/test_internals.py
+++ b/pandas/tests/internals/test_internals.py
@@ -300,14 +300,14 @@ class TestDatetimeBlock(object):
         block = create_block('datetime', [0])
 
         # coerce None
-        none_coerced = block._try_coerce_args(block.values, None)[2]
+        _, none_coerced = block._try_coerce_args(block.values, None)
         assert pd.Timestamp(none_coerced) is pd.NaT
 
         # coerce different types of date bojects
         vals = (np.datetime64('2010-10-10'), datetime(2010, 10, 10),
                 date(2010, 10, 10))
         for val in vals:
-            coerced = block._try_coerce_args(block.values, val)[2]
+            _, coerced = block._try_coerce_args(block.values, val)
             assert np.datetime64 == type(coerced)
             assert pd.Timestamp('2010-10-10') == pd.Timestamp(coerced)
 


### PR DESCRIPTION
This PR aims to use datetime64 and timedelta64 in evaluation directly, instead of casting to integer and then casting back. 

Benefits:
1. `values` is saved in `ndarray[datetime64]`, casting to `int` to eval is non-intuitive. It seems back to the time before numpy 1.7 which implements `datetime64`.
2. `numpy.ufunc` can handle all the `dtype` change, e.g.  `datetime64 - datetime64 = timedelta64`. Additonally, nonsense operations are prohibited, e.g. `datetime64 + datetime64`.
3. numpy implements `datetime64('NaT')`, seems `values_mask` and `other_mask` are no longer needed for `nan`s.
4. `Series` can share the same call path with `DataFrame` in `Block`. Now `Series` is using `dispatch_to_index_op` to wrap as `Index`, but `Index` is 1d-array while `DataFrame` is 2d-array, so `DataFrame` can't use the same wrapper. `ndarray([Index])` is `dtype='O'` so can't be benefited from `numpy.ufunc`.

This commit has passed `tests/{internals,frame,dtypes}` , but not `tests/series`, because `dispatch_to_index_op` breaks it.