### PR TITLE
DOC: consistent docstring for compression kwarg

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -1750,9 +1750,9 @@ class DataFrame(NDFrame):
         encoding : string, optional
             A string representing the encoding to use in the output file,
             defaults to 'ascii' on Python 2 and 'utf-8' on Python 3.
-        compression : {'infer', 'gzip', 'bz2', 'xz', None}, default None
+        compression : {'infer', 'gzip', 'bz2', 'zip', 'xz', None}, default None
             If 'infer' and `path_or_buf` is path-like, then detect compression
-            from the following extensions: '.gz', '.bz2' or '.xz'
+            from the following extensions: '.gz', '.bz2', '.zip' or '.xz'
             (otherwise no compression).
         line_terminator : string, default ``'\n'``
             The newline character or character sequence to use in the output

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -1999,7 +1999,7 @@ class NDFrame(PandasObject, SelectionMixin):
 
             .. versionadded:: 0.19.0
 
-        compression : {'infer', 'gzip', 'bz2', 'xz', None}, default None
+        compression : {'infer', 'gzip', 'bz2', 'zip', 'xz', None}, default None
             A string representing the compression to use in the output file,
             only used when the first argument is a filename.
 


### PR DESCRIPTION
- [x] closes #17900
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`

https://github.com/pandas-dev/pandas/pull/17900#discussion_r147927074 removed zip from docstring. But the support to write zip compression was added during March and April this year (mainly https://github.com/pandas-dev/pandas/pull/20394 and a few patches) and now in functional and in production. 

Because #17900 started when there is no zip writing and merged after zip writing support is added, it appears to have inadvertently changed docstring. This PR disambiguates and reflects production.

```
import os
import pandas as pd

a = pd.DataFrame(10000 * [[123, 234, 435]], columns=['A', 'B', 'C'])
a.to_csv('test_compressed', index=False, compression='zip')
b = pd.read_csv('test_compressed', compression='zip')

assert a.equals(b)
os.remove('test_compressed')

>>> pd.__version__
'0.23.3'
```