### PR TITLE
fix for TypeError: unorderable types" in when using set_index with multiple column names

### DIFF
--- a/doc/source/whatsnew/v0.24.0.txt
+++ b/doc/source/whatsnew/v0.24.0.txt
@@ -626,7 +626,7 @@ MultiIndex
 
 - Removed compatibility for :class:`MultiIndex` pickles prior to version 0.8.0; compatibility with :class:`MultiIndex` pickles from version 0.13 forward is maintained (:issue:`21654`)
 - :meth:`MultiIndex.get_loc_level` (and as a consequence, ``.loc`` on a :class:``MultiIndex``ed object) will now raise a ``KeyError``, rather than returning an empty ``slice``, if asked a label which is present in the ``levels`` but is unused (:issue:`22221`)
-- Fix `TypeError` in Python 3 when creating :class: `MultiIndex` in which some levels have mixed types. If (for instance) all labels are tuples of ints, there is no problem (:issue:`15457`)
+- Fix `TypeError` in Python 3 when creating :class: `MultiIndex` in which some levels have mixed types, e.g. when some labels are tuples (:issue:`15457`)
 
 I/O
 ^^^

--- a/doc/source/whatsnew/v0.24.0.txt
+++ b/doc/source/whatsnew/v0.24.0.txt
@@ -626,7 +626,7 @@ MultiIndex
 
 - Removed compatibility for :class:`MultiIndex` pickles prior to version 0.8.0; compatibility with :class:`MultiIndex` pickles from version 0.13 forward is maintained (:issue:`21654`)
 - :meth:`MultiIndex.get_loc_level` (and as a consequence, ``.loc`` on a :class:``MultiIndex``ed object) will now raise a ``KeyError``, rather than returning an empty ``slice``, if asked a label which is present in the ``levels`` but is unused (:issue:`22221`)
-- Fix issue when creating :class:`MultiIndex` from mixed type arrays including tuples. In some cases df.set_index(['A','B']) raised a ``TypeError unorderable types`` when trying to set multiple columns as indices. (:issue:'15457')
+- Fix `TypeError` in Python 3 when creating `MultiIndex` in which some columns are of object type, e.g. when labels are tuples  (:issue:'15457')
 
 I/O
 ^^^

--- a/doc/source/whatsnew/v0.24.0.txt
+++ b/doc/source/whatsnew/v0.24.0.txt
@@ -626,7 +626,7 @@ MultiIndex
 
 - Removed compatibility for :class:`MultiIndex` pickles prior to version 0.8.0; compatibility with :class:`MultiIndex` pickles from version 0.13 forward is maintained (:issue:`21654`)
 - :meth:`MultiIndex.get_loc_level` (and as a consequence, ``.loc`` on a :class:``MultiIndex``ed object) will now raise a ``KeyError``, rather than returning an empty ``slice``, if asked a label which is present in the ``levels`` but is unused (:issue:`22221`)
-- Fix `TypeError` in Python 3 when creating :class: `MultiIndex` in which some levels have mixed types, e.g. when labels are tuples (:issue:`15457`)
+- Fix `TypeError` in Python 3 when creating :class: `MultiIndex` in which some levels have mixed types, e.g. when some labels are tuples (:issue:`15457`)
 
 I/O
 ^^^

--- a/doc/source/whatsnew/v0.24.0.txt
+++ b/doc/source/whatsnew/v0.24.0.txt
@@ -626,7 +626,7 @@ MultiIndex
 
 - Removed compatibility for :class:`MultiIndex` pickles prior to version 0.8.0; compatibility with :class:`MultiIndex` pickles from version 0.13 forward is maintained (:issue:`21654`)
 - :meth:`MultiIndex.get_loc_level` (and as a consequence, ``.loc`` on a :class:``MultiIndex``ed object) will now raise a ``KeyError``, rather than returning an empty ``slice``, if asked a label which is present in the ``levels`` but is unused (:issue:`22221`)
-- Fix `TypeError` in Python 3 when creating `MultiIndex` in which some columns are of object type, e.g. when labels are tuples  (:issue:'15457')
+- Fix `TypeError` in Python 3 when creating :class: `MultiIndex` in which some columns are of object type, e.g. when labels are tuples  (:issue:`15457`)
 
 I/O
 ^^^

--- a/doc/source/whatsnew/v0.24.0.txt
+++ b/doc/source/whatsnew/v0.24.0.txt
@@ -626,7 +626,7 @@ MultiIndex
 
 - Removed compatibility for :class:`MultiIndex` pickles prior to version 0.8.0; compatibility with :class:`MultiIndex` pickles from version 0.13 forward is maintained (:issue:`21654`)
 - :meth:`MultiIndex.get_loc_level` (and as a consequence, ``.loc`` on a :class:``MultiIndex``ed object) will now raise a ``KeyError``, rather than returning an empty ``slice``, if asked a label which is present in the ``levels`` but is unused (:issue:`22221`)
-- Fix `TypeError` in Python 3 when creating :class: `MultiIndex` in which some columns are of object type, e.g. when labels are tuples  (:issue:`15457`)
+- Fix `TypeError` in Python 3 when creating :class: `MultiIndex` in which some levels have mixed types, e.g. when labels are tuples (:issue:`15457`)
 
 I/O
 ^^^

--- a/doc/source/whatsnew/v0.24.0.txt
+++ b/doc/source/whatsnew/v0.24.0.txt
@@ -626,7 +626,7 @@ MultiIndex
 
 - Removed compatibility for :class:`MultiIndex` pickles prior to version 0.8.0; compatibility with :class:`MultiIndex` pickles from version 0.13 forward is maintained (:issue:`21654`)
 - :meth:`MultiIndex.get_loc_level` (and as a consequence, ``.loc`` on a :class:``MultiIndex``ed object) will now raise a ``KeyError``, rather than returning an empty ``slice``, if asked a label which is present in the ``levels`` but is unused (:issue:`22221`)
-- Fix `TypeError` in Python 3 when creating :class: `MultiIndex` in which some levels have mixed types, e.g. when some labels are tuples (:issue:`15457`)
+- Fix ``TypeError`` in Python 3 when creating :class:`MultiIndex` in which some levels have mixed types, e.g. when some labels are tuples (:issue:`15457`)
 
 I/O
 ^^^

--- a/doc/source/whatsnew/v0.24.0.txt
+++ b/doc/source/whatsnew/v0.24.0.txt
@@ -626,7 +626,7 @@ MultiIndex
 
 - Removed compatibility for :class:`MultiIndex` pickles prior to version 0.8.0; compatibility with :class:`MultiIndex` pickles from version 0.13 forward is maintained (:issue:`21654`)
 - :meth:`MultiIndex.get_loc_level` (and as a consequence, ``.loc`` on a :class:``MultiIndex``ed object) will now raise a ``KeyError``, rather than returning an empty ``slice``, if asked a label which is present in the ``levels`` but is unused (:issue:`22221`)
--
+- Fix issue when creating :class:`MultiIndex` from mixed type arrays including tuples. In some cases df.set_index(['A','B']) raised a ``TypeError unorderable types`` when trying to set multiple columns as indices. (:issue:'15457')
 
 I/O
 ^^^

--- a/doc/source/whatsnew/v0.24.0.txt
+++ b/doc/source/whatsnew/v0.24.0.txt
@@ -626,7 +626,7 @@ MultiIndex
 
 - Removed compatibility for :class:`MultiIndex` pickles prior to version 0.8.0; compatibility with :class:`MultiIndex` pickles from version 0.13 forward is maintained (:issue:`21654`)
 - :meth:`MultiIndex.get_loc_level` (and as a consequence, ``.loc`` on a :class:``MultiIndex``ed object) will now raise a ``KeyError``, rather than returning an empty ``slice``, if asked a label which is present in the ``levels`` but is unused (:issue:`22221`)
-- Fix `TypeError` in Python 3 when creating :class: `MultiIndex` in which some levels have mixed types, e.g. when some labels are tuples (:issue:`15457`)
+- Fix `TypeError` in Python 3 when creating :class: `MultiIndex` in which some levels have mixed types. If (for instance) all labels are tuples of ints, there is no problem (:issue:`15457`)
 
 I/O
 ^^^

--- a/pandas/core/arrays/categorical.py
+++ b/pandas/core/arrays/categorical.py
@@ -2538,7 +2538,10 @@ def _factorize_from_iterable(values):
                                       ordered=values.ordered)
         codes = values.codes
     else:
-        cat = Categorical(values, ordered=True)
+        # The value of ordered is irrelevant since we don't use cat as such,
+        # but only the resulting categories, the order of which is independent
+        # from ordered. Set ordered to False as default due to issue #15457
+        cat = Categorical(values, ordered=False)
         categories = cat.categories
         codes = cat.codes
     return codes, categories

--- a/pandas/core/arrays/categorical.py
+++ b/pandas/core/arrays/categorical.py
@@ -2540,7 +2540,7 @@ def _factorize_from_iterable(values):
     else:
         # The value of ordered is irrelevant since we don't use cat as such,
         # but only the resulting categories, the order of which is independent
-        # from ordered. Set ordered to False as default due to issue #15457
+        # from ordered. Set ordered to False as default. See GH #15457"
         cat = Categorical(values, ordered=False)
         categories = cat.categories
         codes = cat.codes

--- a/pandas/core/arrays/categorical.py
+++ b/pandas/core/arrays/categorical.py
@@ -2540,7 +2540,7 @@ def _factorize_from_iterable(values):
     else:
         # The value of ordered is irrelevant since we don't use cat as such,
         # but only the resulting categories, the order of which is independent
-        # from ordered. Set ordered to False as default. See GH #15457"
+        # from ordered. Set ordered to False as default. See GH #15457
         cat = Categorical(values, ordered=False)
         categories = cat.categories
         codes = cat.codes

--- a/pandas/tests/frame/test_alter_axes.py
+++ b/pandas/tests/frame/test_alter_axes.py
@@ -261,7 +261,7 @@ class TestDataFrameAlterAxes(TestData):
         comp = comp.tz_localize(None)
         tm.assert_numpy_array_equal(result.values, comp.values)
 
-        # list of datetimes with a tzg
+        # list of datetimes with a tz
         df['D'] = i.to_pydatetime()
         result = df['D']
         assert_series_equal(result, expected, check_names=False)

--- a/pandas/tests/frame/test_alter_axes.py
+++ b/pandas/tests/frame/test_alter_axes.py
@@ -394,8 +394,9 @@ class TestDataFrameAlterAxes(TestData):
 
     def test_set_index_tuple(self):
         # test for fix of issue #15457, where the following raised a TypeError
-        df = DataFrame([[2, 1, 2], [4, (1, 2), 3]]).set_index([0, 1])
-        assert df.to_dict() == {2: {(2, 1): 2, (4, (1, 2)): 3}}
+        expected = pd.DataFrame([[2, 1], [4, (1, 2)]]).set_index([0, 1]).index
+        result = pd.MultiIndex.from_tuples([(2, 1), (4, (1, 2))], names=(0, 1))
+        tm.assert_index_equal(expected, result)
 
     # Renaming
 

--- a/pandas/tests/frame/test_alter_axes.py
+++ b/pandas/tests/frame/test_alter_axes.py
@@ -392,6 +392,11 @@ class TestDataFrameAlterAxes(TestData):
 
         assert new_index.freq == index.freq
 
+    def test_set_index_tuple(self):
+        # test for fix of issue #15457, where the following raised a TypeError
+        df = DataFrame([[2, 1, 2], [4, (1, 2), 3]]).set_index([0, 1])
+        assert df.to_dict() == {2: {(2, 1): 2, (4, (1, 2)): 3}}
+
     # Renaming
 
     def test_rename(self):

--- a/pandas/tests/frame/test_alter_axes.py
+++ b/pandas/tests/frame/test_alter_axes.py
@@ -261,7 +261,7 @@ class TestDataFrameAlterAxes(TestData):
         comp = comp.tz_localize(None)
         tm.assert_numpy_array_equal(result.values, comp.values)
 
-        # list of datetimes with a tz
+        # list of datetimes with a tzg
         df['D'] = i.to_pydatetime()
         result = df['D']
         assert_series_equal(result, expected, check_names=False)
@@ -391,12 +391,6 @@ class TestDataFrameAlterAxes(TestData):
         result = df.set_index(new_index)  # noqa
 
         assert new_index.freq == index.freq
-
-    def test_set_index_tuple(self):
-        # test for fix of issue #15457, where the following raised a TypeError
-        expected = pd.DataFrame([[2, 1], [4, (1, 2)]]).set_index([0, 1]).index
-        result = pd.MultiIndex.from_tuples([(2, 1), (4, (1, 2))], names=(0, 1))
-        tm.assert_index_equal(expected, result)
 
     # Renaming
 

--- a/pandas/tests/indexes/multi/test_constructor.py
+++ b/pandas/tests/indexes/multi/test_constructor.py
@@ -3,12 +3,11 @@
 import re
 
 import numpy as np
-import pytest
-from pandas._libs.tslib import Timestamp
-
 import pandas as pd
 import pandas.util.testing as tm
+import pytest
 from pandas import Index, MultiIndex, date_range
+from pandas._libs.tslib import Timestamp
 from pandas.compat import lrange, range
 from pandas.core.dtypes.cast import construct_1d_object_array_from_listlike
 
@@ -24,7 +23,7 @@ def test_constructor_single_level():
 
 def test_constructor_no_levels():
     tm.assert_raises_regex(ValueError, "non-zero number "
-                                       "of levels/labels",
+                           "of levels/labels",
                            MultiIndex, levels=[], labels=[])
     both_re = re.compile('Must pass both levels and labels')
     with tm.assert_raises_regex(TypeError, both_re):
@@ -57,7 +56,7 @@ def test_constructor_mismatched_label_levels(idx):
     labels = [np.array([1]), np.array([2]), np.array([3])]
     levels = ["a"]
     tm.assert_raises_regex(ValueError, "Length of levels and labels "
-                                       "must be the same", MultiIndex,
+                           "must be the same", MultiIndex,
                            levels=levels, labels=labels)
     length_error = re.compile('>= length of level')
     label_error = re.compile(r'Unequal label lengths: \[4, 2\]')
@@ -260,13 +259,13 @@ def test_from_arrays_invalid_input(invalid_array):
 def test_from_arrays_different_lengths(idx1, idx2):
     # see gh-13599
     tm.assert_raises_regex(ValueError, '^all arrays must '
-                                       'be same length$',
+                           'be same length$',
                            MultiIndex.from_arrays, [idx1, idx2])
 
 
 def test_from_tuples():
     tm.assert_raises_regex(TypeError, 'Cannot infer number of levels '
-                                      'from empty list',
+                           'from empty list',
                            MultiIndex.from_tuples, [])
 
     expected = MultiIndex(levels=[[1, 3], [2, 4]],
@@ -391,6 +390,7 @@ def test_from_product_index_series_categorical(ordered, f):
 
 
 def test_from_product():
+
     first = ['foo', 'bar', 'buz']
     second = ['a', 'b', 'c']
     names = ['first', 'second']
@@ -425,6 +425,7 @@ def test_from_product_iterator():
 
 
 def test_create_index_existing_name(idx):
+
     # GH11193, when an existing index is passed, and a new name is not
     # specified, the new index should inherit the previous object name
     index = idx
@@ -463,9 +464,8 @@ def test_tuples_with_name_string():
     with pytest.raises(ValueError):
         pd.Index(li, name='a')
 
-
 def test_from_tuples_with_tuple_label():
-    # test for fix of issue #15457, where the following raised a TypeError
+    # GH 15457
     expected = pd.DataFrame([[2, 1, 2], [4, (1, 2), 3]], columns=['a', 'b', 'c']).set_index(['a', 'b'])
     idx = pd.MultiIndex.from_tuples([(2, 1), (4, (1, 2))], names=('a', 'b'))
     result = pd.DataFrame([2, 3], columns=['c'], index=idx)

--- a/pandas/tests/indexes/multi/test_constructor.py
+++ b/pandas/tests/indexes/multi/test_constructor.py
@@ -3,11 +3,12 @@
 import re
 
 import numpy as np
+import pytest
+from pandas._libs.tslib import Timestamp
+
 import pandas as pd
 import pandas.util.testing as tm
-import pytest
 from pandas import Index, MultiIndex, date_range
-from pandas._libs.tslib import Timestamp
 from pandas.compat import lrange, range
 from pandas.core.dtypes.cast import construct_1d_object_array_from_listlike
 
@@ -23,7 +24,7 @@ def test_constructor_single_level():
 
 def test_constructor_no_levels():
     tm.assert_raises_regex(ValueError, "non-zero number "
-                           "of levels/labels",
+                                       "of levels/labels",
                            MultiIndex, levels=[], labels=[])
     both_re = re.compile('Must pass both levels and labels')
     with tm.assert_raises_regex(TypeError, both_re):
@@ -56,7 +57,7 @@ def test_constructor_mismatched_label_levels(idx):
     labels = [np.array([1]), np.array([2]), np.array([3])]
     levels = ["a"]
     tm.assert_raises_regex(ValueError, "Length of levels and labels "
-                           "must be the same", MultiIndex,
+                                       "must be the same", MultiIndex,
                            levels=levels, labels=labels)
     length_error = re.compile('>= length of level')
     label_error = re.compile(r'Unequal label lengths: \[4, 2\]')
@@ -259,13 +260,13 @@ def test_from_arrays_invalid_input(invalid_array):
 def test_from_arrays_different_lengths(idx1, idx2):
     # see gh-13599
     tm.assert_raises_regex(ValueError, '^all arrays must '
-                           'be same length$',
+                                       'be same length$',
                            MultiIndex.from_arrays, [idx1, idx2])
 
 
 def test_from_tuples():
     tm.assert_raises_regex(TypeError, 'Cannot infer number of levels '
-                           'from empty list',
+                                      'from empty list',
                            MultiIndex.from_tuples, [])
 
     expected = MultiIndex(levels=[[1, 3], [2, 4]],
@@ -390,7 +391,6 @@ def test_from_product_index_series_categorical(ordered, f):
 
 
 def test_from_product():
-
     first = ['foo', 'bar', 'buz']
     second = ['a', 'b', 'c']
     names = ['first', 'second']
@@ -425,7 +425,6 @@ def test_from_product_iterator():
 
 
 def test_create_index_existing_name(idx):
-
     # GH11193, when an existing index is passed, and a new name is not
     # specified, the new index should inherit the previous object name
     index = idx
@@ -463,3 +462,11 @@ def test_tuples_with_name_string():
         pd.Index(li, name='abc')
     with pytest.raises(ValueError):
         pd.Index(li, name='a')
+
+
+def test_from_tuples_with_tuple_label():
+    # test for fix of issue #15457, where the following raised a TypeError
+    expected = pd.DataFrame([[2, 1, 2], [4, (1, 2), 3]], columns=['a', 'b', 'c']).set_index(['a', 'b'])
+    idx = pd.MultiIndex.from_tuples([(2, 1), (4, (1, 2))], names=('a', 'b'))
+    result = pd.DataFrame([2, 3], columns=['c'], index=idx)
+    tm.assert_frame_equal(expected, result)

--- a/pandas/tests/indexes/multi/test_constructor.py
+++ b/pandas/tests/indexes/multi/test_constructor.py
@@ -464,9 +464,11 @@ def test_tuples_with_name_string():
     with pytest.raises(ValueError):
         pd.Index(li, name='a')
 
+
 def test_from_tuples_with_tuple_label():
     # GH 15457
-    expected = pd.DataFrame([[2, 1, 2], [4, (1, 2), 3]], columns=['a', 'b', 'c']).set_index(['a', 'b'])
+    expected = pd.DataFrame([[2, 1, 2], [4, (1, 2), 3]],
+                            columns=['a', 'b', 'c']).set_index(['a', 'b'])
     idx = pd.MultiIndex.from_tuples([(2, 1), (4, (1, 2))], names=('a', 'b'))
     result = pd.DataFrame([2, 3], columns=['c'], index=idx)
     tm.assert_frame_equal(expected, result)

--- a/pandas/tests/indexes/multi/test_constructor.py
+++ b/pandas/tests/indexes/multi/test_constructor.py
@@ -463,4 +463,3 @@ def test_tuples_with_name_string():
         pd.Index(li, name='abc')
     with pytest.raises(ValueError):
         pd.Index(li, name='a')
-

--- a/pandas/tests/indexes/multi/test_constructor.py
+++ b/pandas/tests/indexes/multi/test_constructor.py
@@ -313,13 +313,6 @@ def test_from_product_empty_zero_levels():
         MultiIndex.from_product([])
 
 
-def test_set_index_tuple():
-    # test for fix of issue #15457, where the following raised a TypeError
-    result = pd.MultiIndex.from_arrays([[2, 4], [1, (1, 2)]])
-    expected = pd.MultiIndex.from_tuples([(2, 4), (1, (1, 2))])
-    assert result == expected
-
-
 def test_from_product_empty_one_level():
     result = MultiIndex.from_product([[]], names=['A'])
     expected = pd.Index([], name='A')
@@ -470,3 +463,4 @@ def test_tuples_with_name_string():
         pd.Index(li, name='abc')
     with pytest.raises(ValueError):
         pd.Index(li, name='a')
+

--- a/pandas/tests/indexes/multi/test_constructor.py
+++ b/pandas/tests/indexes/multi/test_constructor.py
@@ -313,6 +313,13 @@ def test_from_product_empty_zero_levels():
         MultiIndex.from_product([])
 
 
+def test_set_index_tuple():
+    # test for fix of issue #15457, where the following raised a TypeError
+    result = pd.MultiIndex.from_arrays([[2, 4], [1, (1, 2)]])
+    expected = pd.MultiIndex.from_tuples([(2, 4), (1, (1, 2))])
+    assert result == expected
+
+
 def test_from_product_empty_one_level():
     result = MultiIndex.from_product([[]], names=['A'])
     expected = pd.Index([], name='A')


### PR DESCRIPTION
- closes #15457