### PR TITLE
Feature-Request: Allow user defined categories in get_dummies()

### DIFF
--- a/pandas/core/arrays/categorical.py
+++ b/pandas/core/arrays/categorical.py
@@ -2489,7 +2489,7 @@ def _convert_to_list_like(list_like):
         return [list_like]
 
 
-def _factorize_from_iterable(values):
+def _factorize_from_iterable(values, categories=None):
     """
     Factorize an input `values` into `categories` and `codes`. Preserves
     categorical dtype in `categories`.
@@ -2520,7 +2520,7 @@ def _factorize_from_iterable(values):
                                       ordered=values.ordered)
         codes = values.codes
     else:
-        cat = Categorical(values, ordered=True)
+        cat = Categorical(values, ordered=True, categories=categories)
         categories = cat.categories
         codes = cat.codes
     return codes, categories

--- a/pandas/core/reshape/reshape.py
+++ b/pandas/core/reshape/reshape.py
@@ -875,7 +875,7 @@ def get_dummies(data, prefix=None, prefix_sep='_', dummy_na=False,
             with_dummies = [data.select_dtypes(exclude=dtypes_to_encode)]
 
         for (col, pre, sep, cat) in zip(data_to_encode.iteritems(), prefix,
-                                   prefix_sep, categories):
+                                        prefix_sep, categories):
             # col is (column_name, column), use just column data here
             dummy = _get_dummies_1d(col[1], prefix=pre, prefix_sep=sep,
                                     dummy_na=dummy_na, sparse=sparse,


### PR DESCRIPTION
- [ ] closes #22078
- [ ] tests added / passed
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

Allow user to provide his own set of labels for `get_dummies()`. Useful if one has multiple dataframes and not all categories are present in some of them.
Just wanted to get some general feedback if this is a good idea.
Will do docs, tests, etc. if this is considered a useful feature. Below some examples on how it works.

```python
In [26]: df
Out[26]: 
  var_1  var_2  y
0     a      1  1
1     b      1  2
2     c      1  3
3     a      0  4
4     a      0  5

# current state remains unaffected
In [27]: pd.get_dummies(df, columns=['var_1'])
Out[27]: 
   var_2  y  var_1_a  var_1_b  var_1_c
0      1  1        1        0        0
1      1  2        0        1        0
2      1  3        0        0        1
3      0  4        1        0        0
4      0  5        1        0        0

# if categories are provided, use those.
In [28]: pd.get_dummies(df, columns=['var_1'], categories=[['a','c','f','b']])
Out[28]: 
   var_2  y  var_1_a  var_1_c  var_1_f  var_1_b
0      1  1        1        0        0        0
1      1  2        0        0        0        1
2      1  3        0        1        0        0
3      0  4        1        0        0        0
4      0  5        1        0        0        0

# works with multiple columns
In [29]: pd.get_dummies(df, columns=['var_1', 'var_2'], categories=[['a','c','f','b'], [2,1,0]])
Out[29]: 
   y  var_1_a  var_1_c  var_1_f  var_1_b  var_2_2  var_2_1  var_2_0
0  1        1        0        0        0        0        1        0
1  2        0        0        0        1        0        1        0
2  3        0        1        0        0        0        1        0
3  4        1        0        0        0        0        0        1
4  5        1        0        0        0        0        0        1

# None has to be provided if default is wanted (which seems unnecessary, but showing it works)
In [30]: pd.get_dummies(df, columns=['var_1', 'var_2'], categories=[['a','c','f','b'], None])
Out[30]: 
   y  var_1_a  var_1_c  var_1_f  var_1_b  var_2_0  var_2_1
0  1        1        0        0        0        0        1
1  2        0        0        0        1        0        1
2  3        0        1        0        0        0        1
3  4        1        0        0        0        1        0
4  5        1        0        0        0        1        0
```