### PR TITLE
MAINT: refactor from_items() using from_dict()

### DIFF
--- a/doc/source/whatsnew/v0.24.0.txt
+++ b/doc/source/whatsnew/v0.24.0.txt
@@ -391,6 +391,7 @@ Removal of prior version deprecations/changes
 
 - The ``LongPanel`` and ``WidePanel`` classes have been removed (:issue:`10892`)
 - Several private functions were removed from the (non-public) module ``pandas.core.common`` (:issue:`22001`)
+- :meth: `~pandas.DataFrame.from_items` has been refactored and the deprecation warning from v0.23.0 has been removed (i.e. it is no longer deprecated)
 -
 -
 

--- a/pandas/tests/frame/test_constructors.py
+++ b/pandas/tests/frame/test_constructors.py
@@ -1283,35 +1283,27 @@ class TestDataFrameConstructors(TestData):
 
     def test_constructor_from_items(self):
         items = [(c, self.frame[c]) for c in self.frame.columns]
-        with tm.assert_produces_warning(FutureWarning,
-                                        check_stacklevel=False):
-            recons = DataFrame.from_items(items)
+        recons = DataFrame.from_items(items)
         tm.assert_frame_equal(recons, self.frame)
 
         # pass some columns
-        with tm.assert_produces_warning(FutureWarning,
-                                        check_stacklevel=False):
-            recons = DataFrame.from_items(items, columns=['C', 'B', 'A'])
+        recons = DataFrame.from_items(items, columns=['C', 'B', 'A'])
         tm.assert_frame_equal(recons, self.frame.loc[:, ['C', 'B', 'A']])
 
         # orient='index'
 
         row_items = [(idx, self.mixed_frame.xs(idx))
                      for idx in self.mixed_frame.index]
-        with tm.assert_produces_warning(FutureWarning,
-                                        check_stacklevel=False):
-            recons = DataFrame.from_items(row_items,
-                                          columns=self.mixed_frame.columns,
-                                          orient='index')
+        recons = DataFrame.from_items(row_items,
+                                      columns=self.mixed_frame.columns,
+                                      orient='index')
         tm.assert_frame_equal(recons, self.mixed_frame)
         assert recons['A'].dtype == np.float64
 
         with tm.assert_raises_regex(TypeError,
                                     "Must pass columns with "
                                     "orient='index'"):
-            with tm.assert_produces_warning(FutureWarning,
-                                            check_stacklevel=False):
-                DataFrame.from_items(row_items, orient='index')
+            DataFrame.from_items(row_items, orient='index')
 
         # orient='index', but thar be tuples
         arr = construct_1d_object_array_from_listlike(
@@ -1319,19 +1311,15 @@ class TestDataFrameConstructors(TestData):
         self.mixed_frame['foo'] = arr
         row_items = [(idx, list(self.mixed_frame.xs(idx)))
                      for idx in self.mixed_frame.index]
-        with tm.assert_produces_warning(FutureWarning,
-                                        check_stacklevel=False):
-            recons = DataFrame.from_items(row_items,
-                                          columns=self.mixed_frame.columns,
-                                          orient='index')
+        recons = DataFrame.from_items(row_items,
+                                      columns=self.mixed_frame.columns,
+                                      orient='index')
         tm.assert_frame_equal(recons, self.mixed_frame)
         assert isinstance(recons['foo'][0], tuple)
 
-        with tm.assert_produces_warning(FutureWarning,
-                                        check_stacklevel=False):
-            rs = DataFrame.from_items([('A', [1, 2, 3]), ('B', [4, 5, 6])],
-                                      orient='index',
-                                      columns=['one', 'two', 'three'])
+        rs = DataFrame.from_items([('A', [1, 2, 3]), ('B', [4, 5, 6])],
+                                  orient='index',
+                                  columns=['one', 'two', 'three'])
         xp = DataFrame([[1, 2, 3], [4, 5, 6]], index=['A', 'B'],
                        columns=['one', 'two', 'three'])
         tm.assert_frame_equal(rs, xp)
@@ -1339,31 +1327,12 @@ class TestDataFrameConstructors(TestData):
     def test_constructor_from_items_scalars(self):
         # GH 17312
         with tm.assert_raises_regex(ValueError,
-                                    r'The value in each \(key, value\) '
-                                    'pair must be an array, Series, or dict'):
-            with tm.assert_produces_warning(FutureWarning,
-                                            check_stacklevel=False):
-                DataFrame.from_items([('A', 1), ('B', 4)])
+                                    r'If using all scalar values, '
+                                    'you must pass an index'):
+            DataFrame.from_items([('A', 1), ('B', 4)])
 
-        with tm.assert_raises_regex(ValueError,
-                                    r'The value in each \(key, value\) '
-                                    'pair must be an array, Series, or dict'):
-            with tm.assert_produces_warning(FutureWarning,
-                                            check_stacklevel=False):
-                DataFrame.from_items([('A', 1), ('B', 2)], columns=['col1'],
-                                     orient='index')
-
-    def test_from_items_deprecation(self):
-        # GH 17320
-        with tm.assert_produces_warning(FutureWarning,
-                                        check_stacklevel=False):
-            DataFrame.from_items([('A', [1, 2, 3]), ('B', [4, 5, 6])])
-
-        with tm.assert_produces_warning(FutureWarning,
-                                        check_stacklevel=False):
-            DataFrame.from_items([('A', [1, 2, 3]), ('B', [4, 5, 6])],
-                                 columns=['col1', 'col2', 'col3'],
-                                 orient='index')
+        DataFrame.from_items([('A', 1), ('B', 2)], columns=['col1'],
+                             orient='index')
 
     def test_constructor_mix_series_nonseries(self):
         df = DataFrame({'A': self.frame['A'],


### PR DESCRIPTION
This removes the deprecation warnings introduced in #18262,
by reimplementing `DataFrame.from_items()` in the recommended
way using `DataFrame.from_dict()` and `collections.OrderedDict`.

This eliminates the maintenance burden of separate code for
`from_items()`, while allowing existing uses to keep working.

A small cleanup can be done once #8425 is fixed.

- [x] closes #21850
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry
