### PR TITLE
CLN: Old helper functions

### DIFF
--- a/pandas/core/reshape/util.py
+++ b/pandas/core/reshape/util.py
@@ -3,14 +3,7 @@ import numpy as np
 from pandas.core.dtypes.common import is_list_like
 
 from pandas.compat import reduce
-from pandas.core.index import Index
 from pandas.core import common as com
-
-
-def match(needles, haystack):
-    haystack = Index(haystack)
-    needles = Index(needles)
-    return haystack.get_indexer(needles)
 
 
 def cartesian_product(X):

--- a/pandas/core/tools/datetimes.py
+++ b/pandas/core/tools/datetimes.py
@@ -1,5 +1,5 @@
 from functools import partial
-from datetime import datetime, timedelta, time
+from datetime import datetime, time
 from collections import MutableMapping
 
 import numpy as np
@@ -850,24 +850,3 @@ def to_time(arg, format=None, infer_time_format=False, errors='raise'):
         return _convert_listlike(arg, format)
 
     return _convert_listlike(np.array([arg]), format)[0]
-
-
-def format(dt):
-    """Returns date in YYYYMMDD format."""
-    return dt.strftime('%Y%m%d')
-
-
-OLE_TIME_ZERO = datetime(1899, 12, 30, 0, 0, 0)
-
-
-def ole2datetime(oledt):
-    """function for converting excel date to normal date format"""
-    val = float(oledt)
-
-    # Excel has a bug where it thinks the date 2/29/1900 exists
-    # we just reject any date before 3/1/1900.
-    if val < 61:
-        msg = "Value is outside of acceptable range: {value}".format(value=val)
-        raise ValueError(msg)
-
-    return OLE_TIME_ZERO + timedelta(days=val)

--- a/pandas/tests/io/test_sql.py
+++ b/pandas/tests/io/test_sql.py
@@ -36,7 +36,6 @@ from pandas import DataFrame, Series, Index, MultiIndex, isna, concat
 from pandas import date_range, to_datetime, to_timedelta, Timestamp
 import pandas.compat as compat
 from pandas.compat import range, lrange, string_types, PY36
-from pandas.core.tools.datetimes import format as date_format
 
 import pandas.io.sql as sql
 from pandas.io.sql import read_sql_table, read_sql_query
@@ -2092,6 +2091,11 @@ class TestSQLiteFallback(SQLiteMixIn, PandasSQLTest):
 
 # -----------------------------------------------------------------------------
 # -- Old tests from 0.13.1 (before refactor using sqlalchemy)
+
+
+def date_format(dt):
+    """Returns date in YYYYMMDD format."""
+    return dt.strftime('%Y%m%d')
 
 
 _formatters = {

--- a/pandas/tests/tseries/offsets/test_offsets.py
+++ b/pandas/tests/tseries/offsets/test_offsets.py
@@ -29,7 +29,6 @@ from pandas.tseries.offsets import (BDay, CDay, BQuarterEnd, BMonthEnd,
                                     QuarterEnd, BusinessMonthEnd, FY5253,
                                     Nano, Easter, FY5253Quarter,
                                     LastWeekOfMonth, Tick)
-from pandas.core.tools.datetimes import format, ole2datetime
 import pandas.tseries.offsets as offsets
 from pandas.io.pickle import read_pickle
 from pandas._libs.tslibs import timezones
@@ -43,19 +42,6 @@ from .common import assert_offset_equal, assert_onOffset
 ####
 # Misc function tests
 ####
-
-
-def test_format():
-    actual = format(datetime(2008, 1, 15))
-    assert actual == '20080115'
-
-
-def test_ole2datetime():
-    actual = ole2datetime(60000)
-    assert actual == datetime(2064, 4, 8)
-
-    with pytest.raises(ValueError):
-        ole2datetime(60)
 
 
 def test_to_m8():


### PR DESCRIPTION
- [x] closes #21838
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`

It appears that these functions were helpers at one point in the past, but they don't appear anywhere in the codebase now (and are not publicly documented).

I _think_ they are safe to blow away, although they exist the public namespace. 