### PR TITLE
Fix plot column against itself

### DIFF
--- a/pandas/plotting/_core.py
+++ b/pandas/plotting/_core.py
@@ -1805,8 +1805,10 @@ def _plot(data, x=None, y=None, subplots=False,
                         except (IndexError, KeyError, TypeError):
                             pass
 
-                if y == x:
-                    data[y] = data.index
+                if type(y) == type(x):
+                    if y == x:
+                        data[y] = data.index
+
                 # don't overwrite
                 data = data[y].copy()
 

--- a/pandas/plotting/_core.py
+++ b/pandas/plotting/_core.py
@@ -1805,6 +1805,8 @@ def _plot(data, x=None, y=None, subplots=False,
                         except (IndexError, KeyError, TypeError):
                             pass
 
+                if y == x:
+                    data[y] = data.index
                 # don't overwrite
                 data = data[y].copy()
 

--- a/pandas/plotting/_core.py
+++ b/pandas/plotting/_core.py
@@ -1786,7 +1786,11 @@ def _plot(data, x=None, y=None, subplots=False,
                     x = data_cols[x]
                 elif not isinstance(data[x], ABCSeries):
                     raise ValueError("x must be a label or position")
-                data = data.set_index(x)
+                if y is not None:
+                    if x in y:
+                        data = data.set_index(x, drop=False)
+                else:
+                    data = data.set_index(x)
 
             if y is not None:
                 # check if we have y as int or list of ints
@@ -1804,10 +1808,6 @@ def _plot(data, x=None, y=None, subplots=False,
                             kwds[kw] = data[kwds[kw]]
                         except (IndexError, KeyError, TypeError):
                             pass
-
-                if type(y) == type(x):
-                    if y == x:
-                        data[y] = data.index
 
                 # don't overwrite
                 data = data[y].copy()


### PR DESCRIPTION
My first ever open source PR, be gentle.

- [x] closes #22088
- [x] plotting tests passed 
(310 passed, 4 skipped, 2 xfailed, 4 xpassed, 39 warnings)
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
I ran this command and it returned nothing.

This allows for plotting of where `x` and `y` are the same column. I had to add the type check because otherwise it failed a check where `y` is a numpy array.
