### PR TITLE
BUG: DataFrame.replace with out of bound datetime causing RecursionError

### DIFF
--- a/doc/source/whatsnew/v0.24.0.txt
+++ b/doc/source/whatsnew/v0.24.0.txt
@@ -558,7 +558,7 @@ Reshaping
 - Bug in :meth:`Series.combine_first` with ``datetime64[ns, tz]`` dtype which would return tz-naive result (:issue:`21469`)
 - Bug in :meth:`Series.where` and :meth:`DataFrame.where` with ``datetime64[ns, tz]`` dtype (:issue:`21546`)
 - Bug in :meth:`Series.mask` and :meth:`DataFrame.mask` with ``list`` conditionals (:issue:`21891`)
--
+- Bug in :meth:`DataFrame.replace` raises RecursionError when converting OutOfBounds ``datetime64[ns, tz]`` (:issue:`20380`)
 -
 
 Build Changes

--- a/pandas/core/dtypes/cast.py
+++ b/pandas/core/dtypes/cast.py
@@ -838,7 +838,12 @@ def soft_convert_objects(values, datetime=True, numeric=True, timedelta=True,
 
     # Soft conversions
     if datetime:
-        values = lib.maybe_convert_objects(values, convert_datetime=datetime)
+        # GH 20380
+        try:
+            values = lib.maybe_convert_objects(values,
+                                               convert_datetime=datetime)
+        except ValueError:
+            pass
 
     if timedelta and is_object_dtype(values.dtype):
         # Object check to ensure only run if previous did not convert

--- a/pandas/core/dtypes/cast.py
+++ b/pandas/core/dtypes/cast.py
@@ -6,7 +6,7 @@ import numpy as np
 import warnings
 
 from pandas._libs import tslib, lib, tslibs
-from pandas._libs.tslibs import iNaT
+from pandas._libs.tslibs import iNaT, OutOfBoundsDatetime
 from pandas.compat import string_types, text_type, PY3
 from .common import (ensure_object, is_bool, is_integer, is_float,
                      is_complex, is_datetimetz, is_categorical_dtype,
@@ -838,11 +838,12 @@ def soft_convert_objects(values, datetime=True, numeric=True, timedelta=True,
 
     # Soft conversions
     if datetime:
-        # GH 20380
+        # GH 20380, when datetime is beyond year 2262, hence outside
+        # bound of nanosecond-resolution 64-bit integers.
         try:
             values = lib.maybe_convert_objects(values,
                                                convert_datetime=datetime)
-        except ValueError:
+        except OutOfBoundsDatetime:
             pass
 
     if timedelta and is_object_dtype(values.dtype):

--- a/pandas/core/internals/blocks.py
+++ b/pandas/core/internals/blocks.py
@@ -802,12 +802,15 @@ class Block(PandasObject):
                                     copy=not inplace) for b in blocks]
             return blocks
         except (TypeError, ValueError):
-
             # try again with a compatible block
             block = self.astype(object)
-            return block.replace(
-                to_replace=original_to_replace, value=value, inplace=inplace,
-                filter=filter, regex=regex, convert=convert)
+            return block.replace(to_replace=original_to_replace,
+                                 value=value,
+                                 inplace=inplace,
+                                 filter=filter,
+                                 regex=regex,
+                                 # GH 20380 without convert
+                                 convert=False)
 
     def _replace_single(self, *args, **kwargs):
         """ no-op on a non-ObjectBlock """

--- a/pandas/core/internals/blocks.py
+++ b/pandas/core/internals/blocks.py
@@ -809,8 +809,7 @@ class Block(PandasObject):
                                  inplace=inplace,
                                  filter=filter,
                                  regex=regex,
-                                 # GH 20380 without convert
-                                 convert=False)
+                                 convert=convert)
 
     def _replace_single(self, *args, **kwargs):
         """ no-op on a non-ObjectBlock """

--- a/pandas/tests/frame/test_replace.py
+++ b/pandas/tests/frame/test_replace.py
@@ -757,40 +757,29 @@ class TestDataFrameReplace(TestData):
         result = tsframe.fillna(method='bfill')
         assert_frame_equal(result, tsframe.fillna(method='bfill'))
 
-    def test_replace_dtypes(self):
-        # int
-        df = DataFrame({'ints': [1, 2, 3]})
-        result = df.replace(1, 0)
-        expected = DataFrame({'ints': [0, 2, 3]})
-        assert_frame_equal(result, expected)
-
-        df = DataFrame({'ints': [1, 2, 3]}, dtype=np.int32)
-        result = df.replace(1, 0)
-        expected = DataFrame({'ints': [0, 2, 3]}, dtype=np.int32)
-        assert_frame_equal(result, expected)
-
-        df = DataFrame({'ints': [1, 2, 3]}, dtype=np.int16)
-        result = df.replace(1, 0)
-        expected = DataFrame({'ints': [0, 2, 3]}, dtype=np.int16)
-        assert_frame_equal(result, expected)
-
-        # bools
-        df = DataFrame({'bools': [True, False, True]})
-        result = df.replace(False, True)
-        assert result.values.all()
-
-        # complex blocks
-        df = DataFrame({'complex': [1j, 2j, 3j]})
-        result = df.replace(1j, 0j)
-        expected = DataFrame({'complex': [0j, 2j, 3j]})
-        assert_frame_equal(result, expected)
-
-        # datetime blocks
-        prev = datetime.today()
-        now = datetime.today()
-        df = DataFrame({'datetime64': Index([prev, now, prev])})
-        result = df.replace(prev, now)
-        expected = DataFrame({'datetime64': Index([now] * 3)})
+    @pytest.mark.parametrize('frame, to_replace, value, expected', [
+        (DataFrame({'ints': [1, 2, 3]}), 1, 0,
+         DataFrame({'ints': [0, 2, 3]})),
+        (DataFrame({'ints': [1, 2, 3]}, dtype=np.int32), 1, 0,
+         DataFrame({'ints': [0, 2, 3]}, dtype=np.int32)),
+        (DataFrame({'ints': [1, 2, 3]}, dtype=np.int16), 1, 0,
+         DataFrame({'ints': [0, 2, 3]}, dtype=np.int16)),
+        (DataFrame({'bools': [True, False, True]}), False, True,
+         DataFrame({'bools': [True, True, True]})),
+        (DataFrame({'complex': [1j, 2j, 3j]}), 1j, 0,
+         DataFrame({'complex': [0j, 2j, 3j]})),
+        (DataFrame({'datetime64': Index([datetime(2018, 5, 28),
+                                         datetime(2018, 7, 28),
+                                         datetime(2018, 5, 28)])}),
+         datetime(2018, 5, 28), datetime(2018, 7, 28),
+         DataFrame({'datetime64': Index([datetime(2018, 7, 28)] * 3)})),
+        # GH 20380
+        (DataFrame({'dt': [datetime(3017, 12, 20)], 'str': ['foo']}),
+         'foo', 'bar',
+         DataFrame({'dt': [datetime(3017, 12, 20)], 'str': ['bar']}))
+    ])
+    def test_replace_dtypes(self, frame, to_replace, value, expected):
+        result = getattr(frame, 'replace')(to_replace, value)
         assert_frame_equal(result, expected)
 
     def test_replace_input_formats_listlike(self):

--- a/pandas/tests/frame/test_replace.py
+++ b/pandas/tests/frame/test_replace.py
@@ -776,7 +776,15 @@ class TestDataFrameReplace(TestData):
         # GH 20380
         (DataFrame({'dt': [datetime(3017, 12, 20)], 'str': ['foo']}),
          'foo', 'bar',
-         DataFrame({'dt': [datetime(3017, 12, 20)], 'str': ['bar']}))
+         DataFrame({'dt': [datetime(3017, 12, 20)], 'str': ['bar']})),
+        (DataFrame({'A': date_range('20130101', periods=3, tz='US/Eastern'),
+                    'B': [0, np.nan, 2]}),
+         Timestamp('20130102', tz='US/Eastern'),
+         Timestamp('20130104', tz='US/Eastern'),
+         DataFrame({'A': [Timestamp('20130101', tz='US/Eastern'),
+                          Timestamp('20130104', tz='US/Eastern'),
+                          Timestamp('20130103', tz='US/Eastern')],
+                    'B': [0, np.nan, 2]}))
     ])
     def test_replace_dtypes(self, frame, to_replace, value, expected):
         result = getattr(frame, 'replace')(to_replace, value)


### PR DESCRIPTION
- [x] closes #20380
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry

By default, keyword convert=True for replace method for Block and ObjectBlock. When trying to replace dataframe, blocks are operated on separately, during which conversion happens if convert=True. OutOfBoundsDatetime(inherited from ValueError) raised by lib.maybe_convert_objects caused Block.replace, ObjectBlock.replace to form infinite recursive loop.

As mentioned in #20380, setting convert=False (private and not available to public) solves the issue at hand, but there appear to be other uses cases that expect it to be True by default. Right now, simply wrap a try...except block around the lib.maybe_convert_objects in cast module. Downside is it catches all ValueError in maybe_convert_objects silently.