### PR TITLE
BUG: _cython_table bug fix

### DIFF
--- a/pandas/conftest.py
+++ b/pandas/conftest.py
@@ -126,7 +126,7 @@ def all_arithmetic_operators(request):
 # use sorted as dicts in py<3.6 have random order, which xdist doesn't like
 _cython_table = sorted(((key, value) for key, value in
                         pd.core.base.SelectionMixin._cython_table.items()),
-                       key=lambda x: x[0].__class__.__name__)
+                       key=lambda x: x[0].__name__)
 
 
 @pytest.fixture(params=_cython_table)


### PR DESCRIPTION
#21224 introduced a bug, where the ``conftest._cython_table`` isn't sorted by the function's name, but by the functions class name (i.e. "function"). This can make the sorting indeterministic and make the build fail on Python 2.7 and 3.5 at times.

This PR makes the sort order follow the functions names again and therefore be deterministic.