### PR TITLE
remove cnp usage from sas.pyx

### DIFF
--- a/pandas/io/sas/sas.pyx
+++ b/pandas/io/sas/sas.pyx
@@ -2,20 +2,22 @@
 # cython: boundscheck=False, initializedcheck=False
 
 import numpy as np
-cimport numpy as cnp
-from numpy cimport uint8_t, uint16_t, int8_t, int64_t, ndarray
 import sas_constants as const
+
+ctypedef signed long long   int64_t
+ctypedef unsigned char      uint8_t
+ctypedef unsigned short     uint16_t
 
 # rle_decompress decompresses data using a Run Length Encoding
 # algorithm.  It is partially documented here:
 #
 # https://cran.r-project.org/web/packages/sas7bdat/vignettes/sas7bdat.pdf
-cdef ndarray[uint8_t, ndim=1] rle_decompress(
-        int result_length, ndarray[uint8_t, ndim=1] inbuff):
+cdef const uint8_t[:] rle_decompress(int result_length,
+                                     const uint8_t[:] inbuff):
 
     cdef:
         uint8_t control_byte, x
-        uint8_t [:] result = np.zeros(result_length, np.uint8)
+        uint8_t[:] result = np.zeros(result_length, np.uint8)
         int rpos = 0, ipos = 0, length = len(inbuff)
         int i, nbytes, end_of_first_byte
 
@@ -115,14 +117,14 @@ cdef ndarray[uint8_t, ndim=1] rle_decompress(
 # rdc_decompress decompresses data using the Ross Data Compression algorithm:
 #
 # http://collaboration.cmc.ec.gc.ca/science/rpn/biblio/ddj/Website/articles/CUJ/1992/9210/ross/ross.htm
-cdef ndarray[uint8_t, ndim=1] rdc_decompress(
-        int result_length, ndarray[uint8_t, ndim=1] inbuff):
+cdef const uint8_t[:] rdc_decompress(int result_length,
+                                     const uint8_t[:] inbuff):
 
     cdef:
         uint8_t cmd
         uint16_t ctrl_bits, ctrl_mask = 0, ofs, cnt
         int ipos = 0, rpos = 0, k
-        uint8_t [:] outbuff = np.zeros(result_length, dtype=np.uint8)
+        uint8_t[:] outbuff = np.zeros(result_length, dtype=np.uint8)
 
     ii = -1
 
@@ -230,8 +232,7 @@ cdef class Parser(object):
         int subheader_pointer_length
         int current_page_type
         bint is_little_endian
-        ndarray[uint8_t, ndim=1] (*decompress)(
-            int result_length, ndarray[uint8_t, ndim=1] inbuff)
+        const uint8_t[:] (*decompress)(int result_length, const uint8_t[:] inbuff)
         object parser
 
     def __init__(self, object parser):
@@ -395,7 +396,7 @@ cdef class Parser(object):
             Py_ssize_t j
             int s, k, m, jb, js, current_row
             int64_t lngt, start, ct
-            ndarray[uint8_t, ndim=1] source
+            const uint8_t[:] source
             int64_t[:] column_types
             int64_t[:] lengths
             int64_t[:] offsets
@@ -434,8 +435,8 @@ cdef class Parser(object):
                 jb += 1
             elif column_types[j] == column_type_string:
                 # string
-                string_chunk[js, current_row] = source[start:(
-                    start + lngt)].tostring().rstrip()
+                string_chunk[js, current_row] = np.array(source[start:(
+                    start + lngt)]).tostring().rstrip()
                 js += 1
 
         self.current_row_on_page_index += 1

--- a/pandas/io/sas/sas.pyx
+++ b/pandas/io/sas/sas.pyx
@@ -232,7 +232,8 @@ cdef class Parser(object):
         int subheader_pointer_length
         int current_page_type
         bint is_little_endian
-        const uint8_t[:] (*decompress)(int result_length, const uint8_t[:] inbuff)
+        const uint8_t[:] (*decompress)(int result_length,
+                                       const uint8_t[:] inbuff)
         object parser
 
     def __init__(self, object parser):


### PR DESCRIPTION
Building this particular file will no longer emit the numpy 1.7 deprecation warning.