### PR TITLE
BUG: Series construction sharing data with DTI

### DIFF
--- a/doc/source/whatsnew/v0.24.0.rst
+++ b/doc/source/whatsnew/v0.24.0.rst
@@ -1304,6 +1304,7 @@ Indexing
 - Bug in :func:`Index.union` and :func:`Index.intersection` where name of the ``Index`` of the result was not computed correctly for certain cases (:issue:`9943`, :issue:`9862`)
 - Bug in :class:`Index` slicing with boolean :class:`Index` may raise ``TypeError`` (:issue:`22533`)
 - Bug when :class:`Series` was created from :class:`DatetimeIndex`, the series shares the same underneath data with that index (:issue:`21907`)
+- Bug when :class:`Series` was created from :class:`DatetimeIndex`, the series shares the same data with that index (:issue:`21907`)
 
 Missing
 ^^^^^^^

--- a/doc/source/whatsnew/v0.24.0.rst
+++ b/doc/source/whatsnew/v0.24.0.rst
@@ -1303,6 +1303,7 @@ Indexing
 - Bug where setting a timedelta column by ``Index`` causes it to be casted to double, and therefore lose precision (:issue:`23511`)
 - Bug in :func:`Index.union` and :func:`Index.intersection` where name of the ``Index`` of the result was not computed correctly for certain cases (:issue:`9943`, :issue:`9862`)
 - Bug in :class:`Index` slicing with boolean :class:`Index` may raise ``TypeError`` (:issue:`22533`)
+- Bug when :class:`Series` was created from :class:`DatetimeIndex`, the series shares the same underneath data with that index (:issue:`21907`)
 
 Missing
 ^^^^^^^

--- a/doc/source/whatsnew/v0.24.0.rst
+++ b/doc/source/whatsnew/v0.24.0.rst
@@ -1303,7 +1303,6 @@ Indexing
 - Bug where setting a timedelta column by ``Index`` causes it to be casted to double, and therefore lose precision (:issue:`23511`)
 - Bug in :func:`Index.union` and :func:`Index.intersection` where name of the ``Index`` of the result was not computed correctly for certain cases (:issue:`9943`, :issue:`9862`)
 - Bug in :class:`Index` slicing with boolean :class:`Index` may raise ``TypeError`` (:issue:`22533`)
-- Bug when :class:`Series` was created from :class:`DatetimeIndex`, the series shares the same underneath data with that index (:issue:`21907`)
 - Bug when :class:`Series` was created from :class:`DatetimeIndex`, the series shares the same data with that index (:issue:`21907`)
 
 Missing

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -182,7 +182,11 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
                     data = data.astype(dtype)
                 else:
                     # need to copy to avoid aliasing issues
-                    data = data._values.copy()
+                    # GH21907
+                    if isinstance(data, DatetimeIndex):
+                        data = data.copy(deep=True)
+                    else:
+                        data = data._values.copy()
                 copy = False
 
             elif isinstance(data, np.ndarray):

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -181,9 +181,8 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
                     # astype copies
                     data = data.astype(dtype)
                 else:
-                    # need to copy to avoid aliasing issues
                     # GH21907
-                    if isinstance(data, DatetimeIndex):
+                    if isinstance(data._values, DatetimeIndex):
                         data = data.copy(deep=True)
                     else:
                         data = data._values.copy()

--- a/pandas/tests/series/test_constructors.py
+++ b/pandas/tests/series/test_constructors.py
@@ -985,6 +985,7 @@ class TestSeriesConstructors():
         expected = src.copy(deep=True)
         prod = Series(src)
         prod[::3] = NaT
+        assert expected[0] is not NaT
         tm.assert_index_equal(src, expected)
 
     # https://github.com/pandas-dev/pandas/issues/22698

--- a/pandas/tests/series/test_constructors.py
+++ b/pandas/tests/series/test_constructors.py
@@ -970,6 +970,23 @@ class TestSeriesConstructors():
         values = frozenset(values)
         pytest.raises(TypeError, Series, values)
 
+    @pytest.mark.parametrize(
+        "src",
+        [pd.date_range('2016-01-01', periods=10, tz='US/Pacific'),
+         pd.timedelta_range('1 day', periods=10),
+         pd.period_range('2012Q1', periods=3, freq='Q'),
+         pd.Index(list('abcdefghij')),
+         pd.Int64Index(np.arange(10)),
+         pd.RangeIndex(0, 10)])
+    def test_fromIndex(self, src):
+        # GH21907
+        # When constructing a series from an index,
+        # the series does not share data with that index
+        expected = src.copy(deep=True)
+        prod = Series(src)
+        prod[::3] = NaT
+        tm.assert_index_equal(src, expected)
+
     # https://github.com/pandas-dev/pandas/issues/22698
     @pytest.mark.filterwarnings("ignore:elementwise comparison:FutureWarning")
     def test_fromDict(self):


### PR DESCRIPTION
add a type check for DatetimeIndex and then pass a deep copy to create a Series object


closes #21907 