### PR TITLE
DOC: Fix spaces and brackets in ValueError message for option_context.

### DIFF
--- a/pandas/core/config.py
+++ b/pandas/core/config.py
@@ -390,8 +390,8 @@ class option_context(object):
 
     def __init__(self, *args):
         if not (len(args) % 2 == 0 and len(args) >= 2):
-            raise ValueError('Need to invoke as'
-                             'option_context(pat, val, [(pat, val), ...)).')
+            raise ValueError('Need to invoke as '
+                             'option_context(pat, val, [(pat, val), ...]).')
 
         self.ops = list(zip(args[::2], args[1::2]))
 

--- a/pandas/core/config.py
+++ b/pandas/core/config.py
@@ -390,8 +390,8 @@ class option_context(object):
 
     def __init__(self, *args):
         if not (len(args) % 2 == 0 and len(args) >= 2):
-            raise ValueError('Need to invoke as '
-                             'option_context(pat, val, [(pat, val), ...]).')
+            raise ValueError('Need to invoke as'
+                             ' option_context(pat, val, [(pat, val), ...]).')
 
         self.ops = list(zip(args[::2], args[1::2]))
 


### PR DESCRIPTION
Add a missing space and changed a parenthesis to a bracket in the message of the ValueError raised whenever  the `args` in `option_context(*args)` don't meet requirements.
'Need to invoke asoption_context(pat, val, [(pat, val), ...)).'
->
'Need to invoke as option_context(pat, val, [(pat, val), ...]).'

- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
