### PR TITLE
DOC: Update link and description of the Spyder IDE in Ecosystem docs

### DIFF
--- a/doc/source/ecosystem.rst
+++ b/doc/source/ecosystem.rst
@@ -168,8 +168,8 @@ or the clipboard into a new pandas DataFrame via a sophisticated import wizard.
 
 Most pandas classes, methods and data attributes can be autocompleted in
 Spyder's `Editor <https://docs.spyder-ide.org/editor.html>`__ and
-`IPython Console <https://docs.spyder-ide.org/ipythonconsole.html>__,
-and Spyder's `Help pane<https://docs.spyder-ide.org/help.html>__ can retrieve
+`IPython Console <https://docs.spyder-ide.org/ipythonconsole.html>`__,
+and Spyder's `Help pane<https://docs.spyder-ide.org/help.html>`__ can retrieve
 and render Numpydoc documentation on pandas objects in rich text with Sphinx
 both automatically and on-demand.
 

--- a/doc/source/ecosystem.rst
+++ b/doc/source/ecosystem.rst
@@ -149,8 +149,8 @@ for pandas ``display.`` settings.
 qgrid is "an interactive grid for sorting and filtering
 DataFrames in IPython Notebook" built with SlickGrid.
 
-`Spyder <https://github.com/spyder-ide/spyder/>`__
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+`Spyder <https://www.spyder-ide.org/>`__
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Spyder is a cross-platform Qt-based open-source Python IDE with
 editing, testing, debugging, and introspection features.

--- a/doc/source/ecosystem.rst
+++ b/doc/source/ecosystem.rst
@@ -158,8 +158,8 @@ data exploration, interactive execution, deep inspection and rich visualization
 capabilities of a scientific environment like MATLAB or Rstudio.
 
 Its `Variable Explorer <https://docs.spyder-ide.org/variableexplorer.html>`__
-allows users to view, manipulate and edit pandas Index, DateTimeIndex, Series,
-TimeSeries and DataFrame objects with a full GUI, including the ability to
+allows users to view, manipulate and edit pandas Index, DatetimeIndex, Series,
+and DataFrame objects with a full GUI, including the ability to
 sort by column, copy and modify individual values, display a "heatmap"
 per-column or globally, convert column data types and more, all with user- or
 automatically-adjustable column-widths and display formatting.

--- a/doc/source/ecosystem.rst
+++ b/doc/source/ecosystem.rst
@@ -14,7 +14,7 @@ development to remain focused around it's original requirements.
 
 This is an inexhaustive list of projects that build on pandas in order to provide
 tools in the PyData space. For a list of projects that depend on pandas,
-see the 
+see the
 `libraries.io usage page for pandas <https://libraries.io/pypi/pandas/usage>`_
 or `search pypi for pandas <https://pypi.org/search/?q=pandas>`_.
 
@@ -44,7 +44,7 @@ ML pipeline.
 `Featuretools <https://github.com/featuretools/featuretools/>`__
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Featuretools is a Python library for automated feature engineering built on top of pandas. It excels at transforming temporal and relational datasets into feature matrices for machine learning using reusable feature engineering "primitives". Users can contribute their own primitives in Python and share them with the rest of the community. 
+Featuretools is a Python library for automated feature engineering built on top of pandas. It excels at transforming temporal and relational datasets into feature matrices for machine learning using reusable feature engineering "primitives". Users can contribute their own primitives in Python and share them with the rest of the community.
 
 .. _ecosystem.visualization:
 
@@ -228,12 +228,12 @@ This package requires valid credentials for this API (non free).
 pandaSDMX is a library to retrieve and acquire statistical data
 and metadata disseminated in
 `SDMX <http://www.sdmx.org>`_ 2.1, an ISO-standard
-widely used by institutions such as statistics offices, central banks,   
-and international organisations. pandaSDMX can expose datasets and related 
+widely used by institutions such as statistics offices, central banks,
+and international organisations. pandaSDMX can expose datasets and related
 structural metadata including data flows, code-lists,
 and data structure definitions as pandas Series
 or MultiIndexed DataFrames.
-   
+
 `fredapi <https://github.com/mortada/fredapi>`__
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 fredapi is a Python interface to the `Federal Reserve Economic Data (FRED) <http://research.stlouisfed.org/fred2/>`__

--- a/doc/source/ecosystem.rst
+++ b/doc/source/ecosystem.rst
@@ -158,19 +158,13 @@ data exploration, interactive execution, deep inspection and rich visualization
 capabilities of a scientific environment like MATLAB or Rstudio.
 
 Its `Variable Explorer <https://docs.spyder-ide.org/variableexplorer.html>`__
-allows users to view, manipulate and edit pandas Index, DatetimeIndex, Series,
-and DataFrame objects with a full GUI, including the ability to
-sort by column, copy and modify individual values, display a "heatmap"
-per-column or globally, convert column data types and more, all with user- or
-automatically-adjustable column-widths and display formatting.
-The Variable Explorer also allows renaming and duplicating pandas objects,
-adding new columns, copying them to the clipboard as plain text (TSV), pasting
-them into  different Spyder/IPython sessions, and saving and loading
-one or multiple in a session to and from a file in lossless native format.
-Spyder can import data from a variety of plain text and binary files
-or the clipboard into a new pandas DataFrame, via a sophisticated import wizard
-offering options to handle column and row separators, skipping rows, and
-comments, and the ability to transpose, type-convert and preview the results.
+allows users to view, manipulate and edit pandas ``Index``, ``Series``,
+and ``DataFrame`` objects like a "spreadsheet", including copying and modifying
+values, sorting, displaying a "heatmap", converting data types and more.
+Pandas objects can also be renamed, duplicated, new columns added,
+copyed/pasted to/from the clipboard (as TSV), and saved/loaded to/from a file.
+Spyder can also import data from a variety of plain text and binary files
+or the clipboard into a new pandas DataFrame via a sophisticated import wizard.
 
 Most pandas classes, methods and data attributes can be autocompleted in
 Spyder's `Editor <https://docs.spyder-ide.org/editor.html>`__ and

--- a/doc/source/ecosystem.rst
+++ b/doc/source/ecosystem.rst
@@ -152,10 +152,33 @@ DataFrames in IPython Notebook" built with SlickGrid.
 `Spyder <https://www.spyder-ide.org/>`__
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Spyder is a cross-platform Qt-based open-source Python IDE with
-editing, testing, debugging, and introspection features.
-Spyder can now introspect and display Pandas DataFrames and show
-both "column wise min/max and global min/max coloring."
+Spyder is a cross-platform PyQt-based IDE combining the editing, analysis,
+debugging and profiling functionality of a software development tool with the
+data exploration, interactive execution, deep inspection and rich visualization
+capabilities of a scientific environment like MATLAB or Rstudio.
+
+Its `Variable Explorer <https://docs.spyder-ide.org/variableexplorer.html>`__
+allows users to view, manipulate and edit pandas Index, DateTimeIndex, Series,
+TimeSeries and DataFrame objects with a full GUI, including the ability to
+sort by column, copy and modify individual values, display a "heatmap"
+per-column or globally, convert column data types and more, all with user- or
+automatically-adjustable column-widths and display formatting.
+The Variable Explorer also allows renaming and duplicating pandas objects,
+adding new columns, copying them to the clipboard as plain text (TSV), pasting
+them into  different Spyder/IPython sessions, and saving and loading
+one or multiple in a session to and from a file in lossless native format.
+Spyder can import data from a variety of plain text and binary files
+or the clipboard into a new pandas DataFrame, via a sophisticated import wizard
+offering options to handle column and row separators, skipping rows, and
+comments, and the ability to transpose, type-convert and preview the results.
+
+Most pandas classes, methods and data attributes can be autocompleted in
+Spyder's `Editor <https://docs.spyder-ide.org/editor.html>`__ and
+`IPython Console <https://docs.spyder-ide.org/ipythonconsole.html>__,
+and Spyder's `Help pane<https://docs.spyder-ide.org/help.html>__ can retrieve
+and render Numpydoc documentation on pandas objects in rich text with Sphinx
+both automatically and on-demand.
+
 
 .. _ecosystem.api:
 


### PR DESCRIPTION
Over the past few years, [Spyder](https://docs.spyder-ide.org/), a PyQt-based open source Python IDE focused on data science (comparable to MATLAB and Rstudio, but developed by community volunteers instead of a for-profit company), has incorporated a deep swath of ``pandas``-specific features and integration. We've also set up a new, modern website for the project, and a new documentation site as well explaining these, which should be linked to instead of the current one.

Accordingly, this PR does a few simple things, split into separate commits to make it easy to modify or revert any of the changes if undesired:

* It updates the Spyder URL to point to our new main website, in HTTPS
* It uses a more up to date one-liner description of Spyder itself, and principally focuses on a greatly expanded list of ways Spyder directly interacts with pandas and offers tools for working with Series and DataFrame objects.
    * As part of this, it embeds links to our new modern, online documentation that describes how these features work, for users to easily reference
* It also cleans up a few stray trailing spaces present in the Ecosystem docs (I can revert this if undesired)

I included a fair amount of detail in the different distinct ways Spyder interacts with pandas objects and the specific features it offers when working with such, but if you think its too long I can cut down the central paragraph accordingly; just let me know and I'll do it promptly.

Thanks!