### PR TITLE
[TST] make xfails strict

### DIFF
--- a/pandas/tests/arrays/categorical/test_constructors.py
+++ b/pandas/tests/arrays/categorical/test_constructors.py
@@ -511,7 +511,8 @@ class TestCategoricalConstructors(object):
         cat = Categorical([0, 1, 2], ordered=True)
         assert cat.ordered
 
-    @pytest.mark.xfail(reason="Imaginary values not supported in Categorical")
+    @pytest.mark.xfail(reason="Imaginary values not supported in Categorical",
+                       strict=True)
     def test_constructor_imaginary(self):
         values = [1, 2, 3 + 1j]
         c1 = Categorical(values)

--- a/pandas/tests/extension/base/setitem.py
+++ b/pandas/tests/extension/base/setitem.py
@@ -159,7 +159,8 @@ class BaseSetitemTests(BaseExtensionTests):
         with tm.assert_raises_regex(ValueError, xpr):
             df['B'] = data[:5]
 
-    @pytest.mark.xfail(reason="GH-20441: setitem on extension types.")
+    @pytest.mark.xfail(reason="GH#20441: setitem on extension types.",
+                       strict=True)
     def test_setitem_tuple_index(self, data):
         s = pd.Series(data[:2], index=[(0, 0), (0, 1)])
         expected = pd.Series(data.take([1, 1]), index=s.index)

--- a/pandas/tests/extension/integer/test_integer.py
+++ b/pandas/tests/extension/integer/test_integer.py
@@ -599,13 +599,17 @@ class TestCasting(BaseInteger, base.BaseCastingTests):
 
 class TestGroupby(BaseInteger, base.BaseGroupbyTests):
 
-    @pytest.mark.xfail(reason="groupby not working")
+    @pytest.mark.xfail(reason="groupby not working", strict=True)
     def test_groupby_extension_no_sort(self, data_for_grouping):
         super(TestGroupby, self).test_groupby_extension_no_sort(
             data_for_grouping)
 
-    @pytest.mark.xfail(reason="groupby not working")
-    @pytest.mark.parametrize('as_index', [True, False])
+    @pytest.mark.parametrize('as_index', [
+        pytest.param(True,
+                     marks=pytest.mark.xfail(reason="groupby not working",
+                                             strict=True)),
+        False
+    ])
     def test_groupby_extension_agg(self, as_index, data_for_grouping):
         super(TestGroupby, self).test_groupby_extension_agg(
             as_index, data_for_grouping)

--- a/pandas/tests/extension/json/test_json.py
+++ b/pandas/tests/extension/json/test_json.py
@@ -142,6 +142,7 @@ class TestInterface(BaseJSON, base.BaseInterfaceTests):
 
 class TestConstructors(BaseJSON, base.BaseConstructorsTests):
 
+    # TODO: Should this be pytest.mark.skip?
     @pytest.mark.xfail(reason="not implemented constructor from dtype")
     def test_from_dtype(self, data):
         # construct from our dtype & string dtype
@@ -157,10 +158,12 @@ class TestGetitem(BaseJSON, base.BaseGetitemTests):
 
 
 class TestMissing(BaseJSON, base.BaseMissingTests):
+    # TODO: Should this be pytest.mark.skip?
     @pytest.mark.xfail(reason="Setting a dict as a scalar")
     def test_fillna_series(self):
         """We treat dictionaries as a mapping in fillna, not a scalar."""
 
+    # TODO: Should this be pytest.mark.skip?
     @pytest.mark.xfail(reason="Setting a dict as a scalar")
     def test_fillna_frame(self):
         """We treat dictionaries as a mapping in fillna, not a scalar."""
@@ -212,7 +215,7 @@ class TestMethods(BaseJSON, base.BaseMethodsTests):
 
 
 class TestCasting(BaseJSON, base.BaseCastingTests):
-
+    # TODO: Should this be pytest.mark.skip?
     @pytest.mark.xfail(reason="failing on np.array(self, dtype=str)")
     def test_astype_str(self):
         """This currently fails in NumPy on np.array(self, dtype=str) with

--- a/pandas/tests/frame/test_arithmetic.py
+++ b/pandas/tests/frame/test_arithmetic.py
@@ -201,7 +201,8 @@ class TestFrameMulDiv(object):
 
 class TestFrameArithmetic(object):
 
-    @pytest.mark.xfail(reason='GH#7996 datetime64 units not converted to nano')
+    @pytest.mark.xfail(reason='GH#7996 datetime64 units not converted to nano',
+                       strict=True)
     def test_df_sub_datetime64_not_ns(self):
         df = pd.DataFrame(pd.date_range('20130101', periods=3))
         dt64 = np.datetime64('2013-01-01')

--- a/pandas/tests/frame/test_duplicates.py
+++ b/pandas/tests/frame/test_duplicates.py
@@ -55,7 +55,8 @@ def test_duplicated_keep(keep, expected):
     tm.assert_series_equal(result, expected)
 
 
-@pytest.mark.xfail(reason="GH21720; nan/None falsely considered equal")
+@pytest.mark.xfail(reason="GH#21720; nan/None falsely considered equal",
+                   strict=True)
 @pytest.mark.parametrize('keep, expected', [
     ('first', Series([False, False, True, False, True])),
     ('last', Series([True, True, False, False, False])),

--- a/pandas/tests/groupby/aggregate/test_other.py
+++ b/pandas/tests/groupby/aggregate/test_other.py
@@ -487,7 +487,17 @@ def test_agg_structs_series(structure, expected):
     tm.assert_series_equal(result, expected)
 
 
-@pytest.mark.xfail(reason="GH-18869: agg func not called on empty groups.")
+@pytest.mark.parametrize('observed', [
+    True,
+    pytest.param(False,
+                 marks=pytest.mark.xfail(reason="GH#18869: agg func not "
+                                                "called on empty groups.",
+                                         strict=True)),
+    pytest.param(None,
+                 marks=pytest.mark.xfail(reason="GH#18869: agg func not "
+                                                "called on empty groups.",
+                                         strict=True))
+])
 def test_agg_category_nansum(observed):
     categories = ['a', 'b', 'c']
     df = pd.DataFrame({"A": pd.Categorical(['a', 'a', 'b'],

--- a/pandas/tests/groupby/test_apply.py
+++ b/pandas/tests/groupby/test_apply.py
@@ -58,9 +58,10 @@ def test_apply_trivial():
     tm.assert_frame_equal(result, expected)
 
 
-@pytest.mark.xfail(reason=("GH 20066; function passed into apply "
-                           "returns a DataFrame with the same index "
-                           "as the one to create GroupBy object."))
+@pytest.mark.xfail(reason="GH#20066; function passed into apply "
+                          "returns a DataFrame with the same index "
+                          "as the one to create GroupBy object.",
+                   strict=True)
 def test_apply_trivial_fail():
     # GH 20066
     # trivial apply fails if the constant dataframe has the same index

--- a/pandas/tests/indexes/interval/test_astype.py
+++ b/pandas/tests/indexes/interval/test_astype.py
@@ -95,7 +95,7 @@ class TestIntSubtype(Base):
                                              closed=index.closed)
         tm.assert_index_equal(result, expected)
 
-    @pytest.mark.xfail(reason='GH 15832')
+    @pytest.mark.xfail(reason='GH#15832', strict=True)
     def test_subtype_integer_errors(self):
         # int64 -> uint64 fails with negative values
         index = interval_range(-10, 10)
@@ -133,7 +133,7 @@ class TestFloatSubtype(Base):
         with tm.assert_raises_regex(ValueError, msg):
             index.insert(0, np.nan).astype(dtype)
 
-    @pytest.mark.xfail(reason='GH 15832')
+    @pytest.mark.xfail(reason='GH#15832', strict=True)
     def test_subtype_integer_errors(self):
         # float64 -> uint64 fails with negative values
         index = interval_range(-10.0, 10.0)

--- a/pandas/tests/indexes/multi/test_missing.py
+++ b/pandas/tests/indexes/multi/test_missing.py
@@ -83,7 +83,7 @@ def test_nulls(idx):
         idx.isna()
 
 
-@pytest.mark.xfail
+@pytest.mark.xfail(strict=True)
 def test_hasnans_isnans(idx):
     # GH 11343, added tests for hasnans / isnans
     index = idx.copy()

--- a/pandas/tests/indexes/period/test_arithmetic.py
+++ b/pandas/tests/indexes/period/test_arithmetic.py
@@ -356,7 +356,8 @@ class TestPeriodIndexArithmetic(object):
         with pytest.raises(period.IncompatibleFrequency):
             tdarr - rng
 
-    @pytest.mark.xfail(reason='op with TimedeltaIndex raises, with ndarray OK')
+    @pytest.mark.xfail(reason='op with TimedeltaIndex raises, with ndarray OK',
+                       strict=True)
     def test_pi_add_sub_td64_array_tick(self):
         rng = pd.period_range('1/1/2000', freq='Q', periods=3)
         dti = pd.date_range('2016-01-01', periods=3)

--- a/pandas/tests/indexes/test_base.py
+++ b/pandas/tests/indexes/test_base.py
@@ -491,8 +491,9 @@ class TestIndex(Base):
         with tm.assert_raises_regex(OverflowError, msg):
             Index([np.iinfo(np.uint64).max - 1], dtype="int64")
 
-    @pytest.mark.xfail(reason="see gh-21311: Index "
-                              "doesn't enforce dtype argument")
+    @pytest.mark.xfail(reason="see GH#21311: Index "
+                              "doesn't enforce dtype argument",
+                       strict=True)
     def test_constructor_cast(self):
         msg = "could not convert string to float"
         with tm.assert_raises_regex(ValueError, msg):
@@ -1455,7 +1456,8 @@ class TestIndex(Base):
         assert index2.slice_locs(8.5, 1.5) == (2, 6)
         assert index2.slice_locs(10.5, -1) == (0, n)
 
-    @pytest.mark.xfail(reason="Assertions were not correct - see GH 20915")
+    @pytest.mark.xfail(reason="Assertions were not correct - see GH#20915",
+                       strict=True)
     def test_slice_ints_with_floats_raises(self):
         # int slicing with floats
         # GH 4892, these are all TypeErrors

--- a/pandas/tests/indexes/test_numeric.py
+++ b/pandas/tests/indexes/test_numeric.py
@@ -150,7 +150,8 @@ class Numeric(Base):
         result = 2.0**idx
         tm.assert_index_equal(result, expected)
 
-    @pytest.mark.xfail(reason='GH#19252 Series has no __rdivmod__')
+    @pytest.mark.xfail(reason='GH#19252 Series has no __rdivmod__',
+                       strict=True)
     def test_divmod_series(self):
         idx = self.create_index()
 

--- a/pandas/tests/io/formats/test_to_csv.py
+++ b/pandas/tests/io/formats/test_to_csv.py
@@ -274,7 +274,7 @@ $1$,$2$
             with open(path, 'r') as f:
                 assert f.read() == expected_ascii
 
-    @pytest.mark.xfail
+    @pytest.mark.xfail(strict=True)
     def test_to_csv_string_array_utf8(self):
         # GH 10813
         str_array = [{'names': ['foo', 'bar']}, {'names': ['baz', 'qux']}]

--- a/pandas/tests/io/json/test_json_table_schema.py
+++ b/pandas/tests/io/json/test_json_table_schema.py
@@ -495,7 +495,10 @@ class TestTableOrient(object):
 class TestTableOrientReader(object):
 
     @pytest.mark.parametrize("index_nm", [
-        None, "idx", pytest.param("index", marks=pytest.mark.xfail),
+        None,
+        "idx",
+        pytest.param("index",
+                     marks=pytest.mark.xfail(strict=True)),
         'level_0'])
     @pytest.mark.parametrize("vals", [
         {'ints': [1, 2, 3, 4]},
@@ -504,7 +507,8 @@ class TestTableOrientReader(object):
         {'categoricals': pd.Series(pd.Categorical(['a', 'b', 'c', 'c']))},
         {'ordered_cats': pd.Series(pd.Categorical(['a', 'b', 'c', 'c'],
                                                   ordered=True))},
-        pytest.param({'floats': [1., 2., 3., 4.]}, marks=pytest.mark.xfail),
+        pytest.param({'floats': [1., 2., 3., 4.]},
+                     marks=pytest.mark.xfail(strict=True)),
         {'floats': [1.1, 2.2, 3.3, 4.4]},
         {'bools': [True, False, False, True]}])
     def test_read_json_table_orient(self, index_nm, vals, recwarn):
@@ -562,7 +566,9 @@ class TestTableOrientReader(object):
         tm.assert_frame_equal(df, result)
 
     @pytest.mark.parametrize("strict_check", [
-        pytest.param(True, marks=pytest.mark.xfail), False])
+        pytest.param(True, marks=pytest.mark.xfail(strict=True)),
+        False
+    ])
     def test_empty_frame_roundtrip(self, strict_check):
         # GH 21287
         df = pd.DataFrame([], columns=['a', 'b', 'c'])

--- a/pandas/tests/io/test_excel.py
+++ b/pandas/tests/io/test_excel.py
@@ -2227,7 +2227,8 @@ class TestExcelWriterEngineTests(object):
     pytest.param('xlwt',
                  marks=pytest.mark.xfail(reason='xlwt does not support '
                                                 'openpyxl-compatible '
-                                                'style dicts')),
+                                                'style dicts',
+                                         strict=True)),
     'xlsxwriter',
     'openpyxl',
 ])

--- a/pandas/tests/io/test_parquet.py
+++ b/pandas/tests/io/test_parquet.py
@@ -216,7 +216,8 @@ def test_options_get_engine(fp, pa):
 
 
 @pytest.mark.xfail(is_platform_windows() or is_platform_mac(),
-                   reason="reading pa metadata failing on Windows/mac")
+                   reason="reading pa metadata failing on Windows/mac",
+                   strict=True)
 def test_cross_engine_pa_fp(df_cross_compat, pa, fp):
     # cross-compat with differing reading/writing engines
 
@@ -383,7 +384,8 @@ class TestParquetPyArrow(Base):
 
         check_round_trip(df, pa)
 
-    @pytest.mark.xfail(reason="pyarrow fails on this (ARROW-1883)")
+    @pytest.mark.xfail(reason="pyarrow fails on this (ARROW-1883)",
+                       strict=True)
     def test_basic_subset_columns(self, pa, df_full):
         # GH18628
 

--- a/pandas/tests/io/test_parquet.py
+++ b/pandas/tests/io/test_parquet.py
@@ -384,8 +384,8 @@ class TestParquetPyArrow(Base):
 
         check_round_trip(df, pa)
 
-    @pytest.mark.xfail(reason="pyarrow fails on this (ARROW-1883)",
-                       strict=True)
+    # TODO: This doesn't fail on all systems; track down which
+    @pytest.mark.xfail(reason="pyarrow fails on this (ARROW-1883)")
     def test_basic_subset_columns(self, pa, df_full):
         # GH18628
 

--- a/pandas/tests/plotting/test_frame.py
+++ b/pandas/tests/plotting/test_frame.py
@@ -496,7 +496,8 @@ class TestDataFramePlots(TestPlotBase):
             testdata.plot(y="text")
 
     @pytest.mark.xfail(reason='not support for period, categorical, '
-                       'datetime_mixed_tz')
+                              'datetime_mixed_tz',
+                       strict=True)
     def test_subplots_timeseries_y_axis_not_supported(self):
         """
         This test will fail for:

--- a/pandas/tests/plotting/test_misc.py
+++ b/pandas/tests/plotting/test_misc.py
@@ -212,7 +212,6 @@ class TestDataFramePlots(TestPlotBase):
         with tm.assert_produces_warning(FutureWarning):
             parallel_coordinates(df, 'Name', colors=colors)
 
-    @pytest.mark.xfail(reason="unreliable test")
     def test_parallel_coordinates_with_sorted_labels(self):
         """ For #15908 """
         from pandas.plotting import parallel_coordinates

--- a/pandas/tests/reshape/test_pivot.py
+++ b/pandas/tests/reshape/test_pivot.py
@@ -458,7 +458,8 @@ class TestPivotTable(object):
         tm.assert_frame_equal(result, expected)
 
     @pytest.mark.xfail(reason='MultiIndexed unstack with tuple names fails'
-                              'with KeyError #19966')
+                              'with KeyError GH#19966',
+                       strict=True)
     def test_pivot_with_multiindex(self):
         # issue #17160
         index = Index(data=[0, 1, 2, 3, 4, 5])
@@ -617,8 +618,9 @@ class TestPivotTable(object):
 
         tm.assert_frame_equal(expected, result)
 
-    @pytest.mark.xfail(reason='GH 17035 (len of floats is casted back to '
-                              'floats)')
+    @pytest.mark.xfail(reason='GH#17035 (len of floats is casted back to '
+                              'floats)',
+                       strict=True)
     def test_margins_dtype_len(self):
         mi_val = list(product(['bar', 'foo'], ['one', 'two'])) + [('All', '')]
         mi = MultiIndex.from_tuples(mi_val, names=('A', 'B'))
@@ -1102,8 +1104,9 @@ class TestPivotTable(object):
         expected = pd.DataFrame(table.values, index=ix, columns=cols)
         tm.assert_frame_equal(table, expected)
 
-    @pytest.mark.xfail(reason='GH 17035 (np.mean of ints is casted back to '
-                              'ints)')
+    @pytest.mark.xfail(reason='GH#17035 (np.mean of ints is casted back to '
+                              'ints)',
+                       strict=True)
     def test_categorical_margins(self, observed):
         # GH 10989
         df = pd.DataFrame({'x': np.arange(8),
@@ -1117,8 +1120,9 @@ class TestPivotTable(object):
         table = df.pivot_table('x', 'y', 'z', dropna=observed, margins=True)
         tm.assert_frame_equal(table, expected)
 
-    @pytest.mark.xfail(reason='GH 17035 (np.mean of ints is casted back to '
-                              'ints)')
+    @pytest.mark.xfail(reason='GH#17035 (np.mean of ints is casted back to '
+                              'ints)',
+                       strict=True)
     def test_categorical_margins_category(self, observed):
         df = pd.DataFrame({'x': np.arange(8),
                            'y': np.arange(8) // 4,

--- a/pandas/tests/scalar/period/test_asfreq.py
+++ b/pandas/tests/scalar/period/test_asfreq.py
@@ -32,7 +32,8 @@ class TestFreqConversion(object):
         assert week2.asfreq('D', 'S') <= per2
 
     @pytest.mark.xfail(reason='GH#19643 period_helper asfreq functions fail '
-                              'to check for overflows')
+                              'to check for overflows',
+                       strict=True)
     def test_to_timestamp_out_of_bounds(self):
         # GH#19643, currently gives Timestamp('1754-08-30 22:43:41.128654848')
         per = Period('0001-01-01', freq='B')

--- a/pandas/tests/scalar/period/test_period.py
+++ b/pandas/tests/scalar/period/test_period.py
@@ -1443,6 +1443,8 @@ def test_period_immutable():
         per.freq = 2 * freq
 
 
+# TODO: This doesn't fail on all systems; track down which
+@pytest.mark.xfail(reason="Parses as Jan 1, 0007 on some systems")
 def test_small_year_parsing():
     per1 = Period('0001-01-07', 'D')
     assert per1.year == 1

--- a/pandas/tests/scalar/period/test_period.py
+++ b/pandas/tests/scalar/period/test_period.py
@@ -1443,7 +1443,6 @@ def test_period_immutable():
         per.freq = 2 * freq
 
 
-@pytest.mark.xfail(reason='GH#19834 Period parsing error')
 def test_small_year_parsing():
     per1 = Period('0001-01-07', 'D')
     assert per1.year == 1

--- a/pandas/tests/series/test_analytics.py
+++ b/pandas/tests/series/test_analytics.py
@@ -2070,7 +2070,7 @@ class TestCategoricalSeriesAnalytics(object):
         "dtype",
         ["int_", "uint", "float_", "unicode_", "timedelta64[h]",
          pytest.param("datetime64[D]",
-                      marks=pytest.mark.xfail(reason="issue7996"))]
+                      marks=pytest.mark.xfail(reason="GH#7996", strict=True))]
     )
     @pytest.mark.parametrize("is_ordered", [True, False])
     def test_drop_duplicates_categorical_non_bool(self, dtype, is_ordered):

--- a/pandas/tests/series/test_rank.py
+++ b/pandas/tests/series/test_rank.py
@@ -223,7 +223,8 @@ class TestSeriesRank(TestData):
                      'int64',
                      marks=pytest.mark.xfail(
                          reason="iNaT is equivalent to minimum value of dtype"
-                         "int64 pending issue #16674")),
+                                "int64 pending issue GH#16674",
+                         strict=True)),
         ([NegInfinity(), '1', 'A', 'BA', 'Ba', 'C', Infinity()],
          'object')
     ])

--- a/pandas/tests/sparse/frame/test_analytics.py
+++ b/pandas/tests/sparse/frame/test_analytics.py
@@ -4,8 +4,8 @@ from pandas import SparseDataFrame, DataFrame, SparseSeries
 from pandas.util import testing as tm
 
 
-@pytest.mark.xfail(reason='Wrong SparseBlock initialization '
-                   '(GH 17386)')
+@pytest.mark.xfail(reason='Wrong SparseBlock initialization (GH#17386)',
+                   strict=True)
 def test_quantile():
     # GH 17386
     data = [[1, 1], [2, 10], [3, 100], [np.nan, np.nan]]
@@ -22,8 +22,8 @@ def test_quantile():
     tm.assert_sp_series_equal(result, sparse_expected)
 
 
-@pytest.mark.xfail(reason='Wrong SparseBlock initialization '
-                   '(GH 17386)')
+@pytest.mark.xfail(reason='Wrong SparseBlock initialization (GH#17386)',
+                   strict=True)
 def test_quantile_multi():
     # GH 17386
     data = [[1, 1], [2, 10], [3, 100], [np.nan, np.nan]]

--- a/pandas/tests/sparse/frame/test_frame.py
+++ b/pandas/tests/sparse/frame/test_frame.py
@@ -1131,7 +1131,8 @@ class TestSparseDataFrame(SharedWithSparse):
         tm.assert_frame_equal(df_blocks['float64'], df)
 
     @pytest.mark.xfail(reason='nan column names in _init_dict problematic '
-                              '(GH 16894)')
+                              '(GH#16894)',
+                       strict=True)
     def test_nan_columnname(self):
         # GH 8822
         nan_colname = DataFrame(Series(1.0, index=[0]), columns=[nan])
@@ -1257,8 +1258,8 @@ class TestSparseDataFrameAnalytics(object):
         for func in funcs:
             getattr(np, func)(self.frame)
 
-    @pytest.mark.xfail(reason='Wrong SparseBlock initialization '
-                              '(GH 17386)')
+    @pytest.mark.xfail(reason='Wrong SparseBlock initialization (GH#17386)',
+                       strict=True)
     def test_quantile(self):
         # GH 17386
         data = [[1, 1], [2, 10], [3, 100], [nan, nan]]
@@ -1274,8 +1275,8 @@ class TestSparseDataFrameAnalytics(object):
         tm.assert_series_equal(result, dense_expected)
         tm.assert_sp_series_equal(result, sparse_expected)
 
-    @pytest.mark.xfail(reason='Wrong SparseBlock initialization '
-                              '(GH 17386)')
+    @pytest.mark.xfail(reason='Wrong SparseBlock initialization (GH#17386)',
+                       strict=True)
     def test_quantile_multi(self):
         # GH 17386
         data = [[1, 1], [2, 10], [3, 100], [nan, nan]]

--- a/pandas/tests/sparse/frame/test_indexing.py
+++ b/pandas/tests/sparse/frame/test_indexing.py
@@ -18,8 +18,8 @@ pytestmark = pytest.mark.skip("Wrong SparseBlock initialization (GH 17386)")
         [np.nan, np.nan]
     ]
 ])
-@pytest.mark.xfail(reason='Wrong SparseBlock initialization '
-                          '(GH 17386)')
+@pytest.mark.xfail(reason='Wrong SparseBlock initialization (GH#17386)',
+                   strict=True)
 def test_where_with_numeric_data(data):
     # GH 17386
     lower_bound = 1.5
@@ -52,8 +52,8 @@ def test_where_with_numeric_data(data):
     0.1,
     100.0 + 100.0j
 ])
-@pytest.mark.xfail(reason='Wrong SparseBlock initialization '
-                          '(GH 17386)')
+@pytest.mark.xfail(reason='Wrong SparseBlock initialization (GH#17386)',
+                   strict=True)
 def test_where_with_numeric_data_and_other(data, other):
     # GH 17386
     lower_bound = 1.5
@@ -70,8 +70,8 @@ def test_where_with_numeric_data_and_other(data, other):
     tm.assert_sp_frame_equal(result, sparse_expected)
 
 
-@pytest.mark.xfail(reason='Wrong SparseBlock initialization '
-                          '(GH 17386)')
+@pytest.mark.xfail(reason='Wrong SparseBlock initialization (GH#17386)',
+                   strict=True)
 def test_where_with_bool_data():
     # GH 17386
     data = [[False, False], [True, True], [False, False]]
@@ -94,8 +94,8 @@ def test_where_with_bool_data():
     0.1,
     100.0 + 100.0j
 ])
-@pytest.mark.xfail(reason='Wrong SparseBlock initialization '
-                          '(GH 17386)')
+@pytest.mark.xfail(reason='Wrong SparseBlock initialization (GH#17386)',
+                   strict=True)
 def test_where_with_bool_data_and_other(other):
     # GH 17386
     data = [[False, False], [True, True], [False, False]]

--- a/pandas/tests/sparse/series/test_indexing.py
+++ b/pandas/tests/sparse/series/test_indexing.py
@@ -18,8 +18,8 @@ pytestmark = pytest.mark.skip("Wrong SparseBlock initialization (GH 17386)")
         np.nan, np.nan
     ]
 ])
-@pytest.mark.xfail(reason='Wrong SparseBlock initialization '
-                          '(GH 17386)')
+@pytest.mark.xfail(reason='Wrong SparseBlock initialization (GH#17386)',
+                   strict=True)
 def test_where_with_numeric_data(data):
     # GH 17386
     lower_bound = 1.5
@@ -70,8 +70,8 @@ def test_where_with_numeric_data_and_other(data, other):
     tm.assert_sp_series_equal(result, sparse_expected)
 
 
-@pytest.mark.xfail(reason='Wrong SparseBlock initialization '
-                          '(GH 17386)')
+@pytest.mark.xfail(reason='Wrong SparseBlock initialization (GH#17386)',
+                   strict=True)
 def test_where_with_bool_data():
     # GH 17386
     data = [False, False, True, True, False, False]

--- a/pandas/tests/test_algos.py
+++ b/pandas/tests/test_algos.py
@@ -858,10 +858,8 @@ class TestDuplicated(object):
                   2, 4, 1, 5, 6]),
         np.array([1.1, 2.2, 1.1, np.nan, 3.3,
                   2.2, 4.4, 1.1, np.nan, 6.6]),
-        pytest.param(np.array([1 + 1j, 2 + 2j, 1 + 1j, 5 + 5j, 3 + 3j,
-                               2 + 2j, 4 + 4j, 1 + 1j, 5 + 5j, 6 + 6j]),
-                     marks=pytest.mark.xfail(reason="Complex bug. GH 16399")
-                     ),
+        np.array([1 + 1j, 2 + 2j, 1 + 1j, 5 + 5j, 3 + 3j,
+                  2 + 2j, 4 + 4j, 1 + 1j, 5 + 5j, 6 + 6j]),
         np.array(['a', 'b', 'a', 'e', 'c',
                   'b', 'd', 'a', 'e', 'f'], dtype=object),
         np.array([1, 2**63, 1, 3**5, 10, 2**63, 39, 1, 3**5, 7],

--- a/pandas/tests/test_base.py
+++ b/pandas/tests/test_base.py
@@ -1235,7 +1235,8 @@ def test_values_consistent(array, expected_type, dtype):
     pytest.param(
         pd.PeriodIndex(['2017', '2018'], freq='D'),
         np.array([17167, 17532]),
-        marks=pytest.mark.xfail(reason="PeriodArray Not implemented")
+        marks=pytest.mark.xfail(reason="PeriodArray Not implemented",
+                                strict=True)
     ),
 ])
 def test_ndarray_values(array, expected):

--- a/pandas/tests/test_downstream.py
+++ b/pandas/tests/test_downstream.py
@@ -95,7 +95,7 @@ def test_pandas_gbq(df):
     pandas_gbq = import_module('pandas_gbq')  # noqa
 
 
-@pytest.mark.xfail(reason="0.7.0 pending")
+@pytest.mark.xfail(reason="0.7.0 pending", strict=True)
 @tm.network
 def test_pandas_datareader():
 

--- a/pandas/tests/test_window.py
+++ b/pandas/tests/test_window.py
@@ -621,8 +621,9 @@ class TestExpanding(Base):
     @pytest.mark.parametrize(
         'expander',
         [1, pytest.param('ls', marks=pytest.mark.xfail(
-                         reason='GH 16425 expanding with '
-                                'offset not supported'))])
+                         reason='GH#16425 expanding with '
+                                'offset not supported',
+                         strict=True))])
     def test_empty_df_expanding(self, expander):
         # GH 15819 Verifies that datetime and integer expanding windows can be
         # applied to empty DataFrames


### PR DESCRIPTION
This leaves untouched xfails with reasons like "flaky on 3.7" and a few where the test itself is just a `pass`.

In the process a handful of previously xfailed cases are no longer xfailed.