### PR TITLE
Fix zillion deprecation warnings in core.dtypes.common

### DIFF
--- a/pandas/core/dtypes/common.py
+++ b/pandas/core/dtypes/common.py
@@ -2023,7 +2023,9 @@ def pandas_dtype(dtype):
     # also catch some valid dtypes such as object, np.object_ and 'object'
     # which we safeguard against by catching them earlier and returning
     # np.dtype(valid_dtype) before this condition is evaluated.
-    if dtype in [object, np.object_, 'object', 'O']:
+    if  hashable(dtype) and dtype in [object, np.object_, 'object', 'O']:
+        # check hashability to avoid errors/DeprecationWarning when we get
+        # here and `dtype` is an array
         return npdtype
     elif npdtype.kind == 'O':
         raise TypeError("dtype '{}' not understood".format(dtype))

--- a/pandas/core/dtypes/common.py
+++ b/pandas/core/dtypes/common.py
@@ -2023,7 +2023,7 @@ def pandas_dtype(dtype):
     # also catch some valid dtypes such as object, np.object_ and 'object'
     # which we safeguard against by catching them earlier and returning
     # np.dtype(valid_dtype) before this condition is evaluated.
-    if  hashable(dtype) and dtype in [object, np.object_, 'object', 'O']:
+    if hashable(dtype) and dtype in [object, np.object_, 'object', 'O']:
         # check hashability to avoid errors/DeprecationWarning when we get
         # here and `dtype` is an array
         return npdtype

--- a/pandas/core/dtypes/common.py
+++ b/pandas/core/dtypes/common.py
@@ -2023,7 +2023,7 @@ def pandas_dtype(dtype):
     # also catch some valid dtypes such as object, np.object_ and 'object'
     # which we safeguard against by catching them earlier and returning
     # np.dtype(valid_dtype) before this condition is evaluated.
-    if hashable(dtype) and dtype in [object, np.object_, 'object', 'O']:
+    if is_hashable(dtype) and dtype in [object, np.object_, 'object', 'O']:
         # check hashability to avoid errors/DeprecationWarning when we get
         # here and `dtype` is an array
         return npdtype


### PR DESCRIPTION
Looking through a recent Travis log I see tons of these:

```
  /home/travis/build/pandas-dev/pandas/pandas/core/dtypes/common.py:2026: DeprecationWarning: elementwise == comparison failed; this will raise an error in the future.
    if dtype in [object, np.object_, 'object', 'O']:
```

This is driven by (probably not desired) cases where `dtype` is array-like at this point (also showed up in #22092).  Easily avoided by checking for hashability before checking for inclusion.