### PR TITLE
Catch IntervalIndex.itemsize deprecation warning in tests and remove IntervalArray.itemsize

### DIFF
--- a/pandas/core/arrays/interval.py
+++ b/pandas/core/arrays/interval.py
@@ -688,10 +688,6 @@ class IntervalArray(IntervalMixin, ExtensionArray):
     def shape(self):
         return self.left.shape
 
-    @property
-    def itemsize(self):
-        return self.left.itemsize + self.right.itemsize
-
     def take(self, indices, allow_fill=False, fill_value=None, axis=None,
              **kwargs):
         """

--- a/pandas/core/indexes/interval.py
+++ b/pandas/core/indexes/interval.py
@@ -369,8 +369,14 @@ class IntervalIndex(IntervalMixin, Index):
 
     @property
     def itemsize(self):
-        # Avoid materializing ndarray[Interval]
-        return self._data.itemsize
+        msg = ('IntervalIndex.itemsize is deprecated and will be removed in '
+               'a future version')
+        warnings.warn(msg, FutureWarning, stacklevel=2)
+
+        # supress the warning from the underlying left/right itemsize
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore')
+            return self.left.itemsize + self.right.itemsize
 
     def __len__(self):
         return len(self.left)

--- a/pandas/tests/indexes/interval/test_interval.py
+++ b/pandas/tests/indexes/interval/test_interval.py
@@ -989,9 +989,11 @@ class TestIntervalIndex(Base):
         # GH 19209
         left = np.arange(0, 4, dtype='i8')
         right = np.arange(1, 5, dtype='i8')
-
-        result = IntervalIndex.from_arrays(left, right).itemsize
         expected = 16  # 8 * 2
+
+        with tm.assert_produces_warning(FutureWarning, check_stacklevel=False):
+            result = IntervalIndex.from_arrays(left, right).itemsize
+
         assert result == expected
 
     @pytest.mark.parametrize('new_closed', [


### PR DESCRIPTION
- [X] closes #22049
- [X] tests added / passed
- [X] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`

I don't think a whatsnew entry is needed.  This was already deprecated for `IntervalIndex`, but wasn't being caught in the tests, and was displaying the name from the underlying `left`/`right` values.  Likewise, `IntervalArray` was created after the deprecation, so no reason to even add it.
