### PR TITLE
BUG: make conftest._cython_table deterministic for Python<3.6

### DIFF
--- a/pandas/conftest.py
+++ b/pandas/conftest.py
@@ -123,13 +123,10 @@ def all_arithmetic_operators(request):
     return request.param
 
 
-# use sorted as dicts in py<3.6 have random order, which xdist doesn't like
-_cython_table = sorted(((key, value) for key, value in
-                        pd.core.base.SelectionMixin._cython_table.items()),
-                       key=lambda x: x[0].__name__)
+_cython_table = pd.core.base.SelectionMixin._cython_table.items()
 
 
-@pytest.fixture(params=_cython_table)
+@pytest.fixture(params=list(_cython_table))
 def cython_table_items(request):
     return request.param
 

--- a/pandas/core/base.py
+++ b/pandas/core/base.py
@@ -23,7 +23,7 @@ from pandas.core import common as com, algorithms
 import pandas.core.nanops as nanops
 import pandas._libs.lib as lib
 from pandas.compat.numpy import function as nv
-from pandas.compat import PYPY
+from pandas.compat import PYPY, OrderedDict
 from pandas.util._decorators import (Appender, cache_readonly,
                                      deprecate_kwarg, Substitution)
 
@@ -179,28 +179,28 @@ class SelectionMixin(object):
     _selection = None
     _internal_names = ['_cache', '__setstate__']
     _internal_names_set = set(_internal_names)
-    _builtin_table = {
-        builtins.sum: np.sum,
-        builtins.max: np.max,
-        builtins.min: np.min
-    }
-    _cython_table = {
-        builtins.sum: 'sum',
-        builtins.max: 'max',
-        builtins.min: 'min',
-        np.all: 'all',
-        np.any: 'any',
-        np.sum: 'sum',
-        np.mean: 'mean',
-        np.prod: 'prod',
-        np.std: 'std',
-        np.var: 'var',
-        np.median: 'median',
-        np.max: 'max',
-        np.min: 'min',
-        np.cumprod: 'cumprod',
-        np.cumsum: 'cumsum'
-    }
+    _builtin_table = OrderedDict((
+        (builtins.sum, np.sum),
+        (builtins.max, np.max),
+        (builtins.min, np.min),
+    ))
+    _cython_table = OrderedDict((
+        (builtins.sum, 'sum'),
+        (builtins.max, 'max'),
+        (builtins.min, 'min'),
+        (np.all, 'all'),
+        (np.any, 'any'),
+        (np.sum, 'sum'),
+        (np.mean, 'mean'),
+        (np.prod, 'prod'),
+        (np.std, 'std'),
+        (np.var, 'var'),
+        (np.median, 'median'),
+        (np.max, 'max'),
+        (np.min, 'min'),
+        (np.cumprod, 'cumprod'),
+        (np.cumsum, 'cumsum'),
+    ))
 
     @property
     def _selection_name(self):


### PR DESCRIPTION
Closes a bug for Python < 3.6 where xdist gets non-deterministic input because of random dict ordering for Python < 3.6.

See #22156 for details.