### PR TITLE
CI: Fix Travis failures due to lint.sh on pandas/core/strings.py

### DIFF
--- a/pandas/core/strings.py
+++ b/pandas/core/strings.py
@@ -293,7 +293,8 @@ def str_contains(arr, pat, case=True, flags=0, na=np.nan, regex=True):
     See Also
     --------
     match : analogous, but stricter, relying on re.match instead of re.search
-    Series.str.startswith : Test if the start of each string element matches a pattern.
+    Series.str.startswith : Test if the start of each string element matches a
+        pattern.
     Series.str.endswith : Same as startswith, but tests the end of string.
 
     Examples


### PR DESCRIPTION
Travis builds are failing since `lint.sh` is catching a line that's too long in `pandas/core/strings.py`, e.g. https://travis-ci.org/pandas-dev/pandas/jobs/411505206