### PR TITLE
Run tests in conda build [ci skip]

### DIFF
--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -29,8 +29,13 @@ requirements:
     - pytz
 
 test:
+  requirements:
+    - pytest
   imports:
     - pandas
+  commands:
+    - python -c "import pandas; pandas.test()"
+
 
 about:
   home: http://pandas.pydata.org

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -29,10 +29,8 @@ requirements:
     - pytz
 
 test:
-  requirements:
+  requires:
     - pytest
-  imports:
-    - pandas
   commands:
     - python -c "import pandas; pandas.test()"
 


### PR DESCRIPTION
[ci skip]

This is to aid in the release process. Easiest to let conda-build run the tests by default, and disable them where we don't want to run them.
