### PR TITLE
Inconsistent behaviour when apply() used on categorical with NaN values

### DIFF
--- a/pandas/core/arrays/categorical.py
+++ b/pandas/core/arrays/categorical.py
@@ -1198,7 +1198,7 @@ class Categorical(ExtensionArray, PandasObject):
                                    categories=new_categories,
                                    ordered=self.ordered)
         except ValueError:
-            return np.take(new_categories, self._codes)
+            return take_1d(new_categories, self._codes)
 
     __eq__ = _cat_compare_op('__eq__')
     __ne__ = _cat_compare_op('__ne__')

--- a/pandas/tests/series/test_apply.py
+++ b/pandas/tests/series/test_apply.py
@@ -164,6 +164,15 @@ class TestSeriesApply(TestData):
         with tm.assert_produces_warning(FutureWarning):
             tsdf.A.agg({'foo': ['sum', 'mean']})
 
+    def test_apply_categorical_with_nan_values(self):
+        # GH 20714
+        s1 = pd.Series(['1-1', '1-1', np.NaN], dtype='category')
+        s1 = s1.apply(lambda x: x.split('-')[0])
+
+        s2 = pd.Series(['1', '1', np.NaN], dtype='category')
+
+        tm.assert_series_equal(s1, s2, check_dtype=False)
+
 
 class TestSeriesAggregate(TestData):
 


### PR DESCRIPTION

- [x] closes #20714 
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
