### PR TITLE
Fix Python2 test failures in certain locales

### DIFF
--- a/pandas/tests/util/test_util.py
+++ b/pandas/tests/util/test_util.py
@@ -418,6 +418,32 @@ def test_numpy_errstate_is_default():
 
 
 @td.skip_if_windows
+def test_can_set_locale_valid_set():
+    # Setting the default locale should return True
+    assert tm.can_set_locale('') is True
+
+
+@td.skip_if_windows
+def test_can_set_locale_invalid_set():
+    # Setting an invalid locale should return False
+    assert tm.can_set_locale('non-existent_locale') is False
+
+
+@td.skip_if_windows
+def test_can_set_locale_invalid_get(monkeypatch):
+    # In some cases, an invalid locale can be set,
+    # but a subsequent getlocale() raises a ValueError
+    # See GH 22129
+
+    def mockgetlocale():
+        raise ValueError()
+
+    with monkeypatch.context() as m:
+        m.setattr(locale, 'getlocale', mockgetlocale)
+        assert tm.can_set_locale('') is False
+
+
+@td.skip_if_windows
 class TestLocaleUtils(object):
 
     @classmethod

--- a/pandas/tests/util/test_util.py
+++ b/pandas/tests/util/test_util.py
@@ -418,32 +418,6 @@ def test_numpy_errstate_is_default():
 
 
 @td.skip_if_windows
-def test_can_set_locale_valid_set():
-    # Setting the default locale should return True
-    assert tm.can_set_locale('') is True
-
-
-@td.skip_if_windows
-def test_can_set_locale_invalid_set():
-    # Setting an invalid locale should return False
-    assert tm.can_set_locale('non-existent_locale') is False
-
-
-@td.skip_if_windows
-def test_can_set_locale_invalid_get(monkeypatch):
-    # In some cases, an invalid locale can be set,
-    # but a subsequent getlocale() raises a ValueError
-    # See GH 22129
-
-    def mockgetlocale():
-        raise ValueError()
-
-    with monkeypatch.context() as m:
-        m.setattr(locale, 'getlocale', mockgetlocale)
-        assert tm.can_set_locale('') is False
-
-
-@td.skip_if_windows
 class TestLocaleUtils(object):
 
     @classmethod
@@ -458,6 +432,26 @@ class TestLocaleUtils(object):
     def teardown_class(cls):
         del cls.locales
         del cls.current_locale
+
+    def test_can_set_locale_valid_set(self):
+        # Setting the default locale should return True
+        assert tm.can_set_locale('') is True
+
+    def test_can_set_locale_invalid_set(self):
+        # Setting an invalid locale should return False
+        assert tm.can_set_locale('non-existent_locale') is False
+
+    def test_can_set_locale_invalid_get(self, monkeypatch):
+        # In some cases, an invalid locale can be set,
+        # but a subsequent getlocale() raises a ValueError
+        # See GH 22129
+
+        def mockgetlocale():
+            raise ValueError()
+
+        with monkeypatch.context() as m:
+            m.setattr(locale, 'getlocale', mockgetlocale)
+            assert tm.can_set_locale('') is False
 
     def test_get_locales(self):
         # all systems should have at least a single locale

--- a/pandas/util/testing.py
+++ b/pandas/util/testing.py
@@ -504,23 +504,19 @@ def set_locale(new_locale, lc_var=locale.LC_ALL):
 
     try:
         locale.setlocale(lc_var, new_locale)
-
-        try:
-            normalized_locale = locale.getlocale()
-        except ValueError:
-            yield new_locale
+        normalized_locale = locale.getlocale()
+        if com._all_not_none(*normalized_locale):
+            yield '.'.join(normalized_locale)
         else:
-            if com._all_not_none(*normalized_locale):
-                yield '.'.join(normalized_locale)
-            else:
-                yield new_locale
+            yield new_locale
     finally:
         locale.setlocale(lc_var, current_locale)
 
 
 def can_set_locale(lc, lc_var=locale.LC_ALL):
     """
-    Check to see if we can set a locale without raising an Exception.
+    Check to see if we can set a locale, and subsequently get the locale,
+    without raising an Exception.
 
     Parameters
     ----------
@@ -538,7 +534,8 @@ def can_set_locale(lc, lc_var=locale.LC_ALL):
     try:
         with set_locale(lc, lc_var=lc_var):
             pass
-    except locale.Error:  # horrible name for a Exception subclass
+    except (ValueError,
+            locale.Error):  # horrible name for a Exception subclass
         return False
     else:
         return True


### PR DESCRIPTION
Check that we can also get the locale, after setting it, without raising an Exception.

- [x] closes #22129
- [x] tests added / passed
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
