### PR TITLE
Add missing period to pandas.Series.interpolate docstring

### DIFF
--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -6098,7 +6098,7 @@ class NDFrame(PandasObject, SelectionMixin):
             * 'index', 'values': use the actual numerical values of the index
             * 'nearest', 'zero', 'slinear', 'quadratic', 'cubic',
               'barycentric', 'polynomial' is passed to
-              :func:`scipy.interpolate.interp1d`. Both 'polynomial' and
+              :class:`scipy.interpolate.interp1d`. Both 'polynomial' and
               'spline' require that you also specify an `order` (int),
               e.g. ``df.interpolate(method='polynomial', order=4)``.
               These use the actual numerical values of the index.
@@ -6111,7 +6111,7 @@ class NDFrame(PandasObject, SelectionMixin):
               and `tutorial documentation
               <http://docs.scipy.org/doc/scipy/reference/tutorial/interpolate.html>`__
             * 'from_derivatives' refers to
-              :func:`scipy.interpolate.BPoly.from_derivatives` which
+              :meth:`scipy.interpolate.BPoly.from_derivatives` which
               replaces 'piecewise_polynomial' interpolation method in
               scipy 0.18
 

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -6110,13 +6110,13 @@ class NDFrame(PandasObject, SelectionMixin):
               <http://docs.scipy.org/doc/scipy/reference/interpolate.html#univariate-interpolation>`__
               and `tutorial documentation
               <http://docs.scipy.org/doc/scipy/reference/tutorial/interpolate.html>`__
-            * 'from_derivatives' refers to BPoly.from_derivatives which
+            * 'from_derivatives' refers to ``BPoly.from_derivatives`` which
               replaces 'piecewise_polynomial' interpolation method in
               scipy 0.18
 
             .. versionadded:: 0.18.1
 
-               Added support for the 'akima' method
+               Added support for the 'akima' method.
                Added interpolate method 'from_derivatives' which replaces
                'piecewise_polynomial' in scipy 0.18; backwards-compatible with
                scipy < 0.18

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -6098,7 +6098,7 @@ class NDFrame(PandasObject, SelectionMixin):
             * 'index', 'values': use the actual numerical values of the index
             * 'nearest', 'zero', 'slinear', 'quadratic', 'cubic',
               'barycentric', 'polynomial' is passed to
-              :py:func:`scipy.interpolate.interp1d`. Both 'polynomial' and
+              :func:`scipy.interpolate.interp1d`. Both 'polynomial' and
               'spline' require that you also specify an `order` (int),
               e.g. ``df.interpolate(method='polynomial', order=4)``.
               These use the actual numerical values of the index.
@@ -6111,7 +6111,7 @@ class NDFrame(PandasObject, SelectionMixin):
               and `tutorial documentation
               <http://docs.scipy.org/doc/scipy/reference/tutorial/interpolate.html>`__
             * 'from_derivatives' refers to
-              :py:func:`scipy.interpolate.BPoly.from_derivatives` which
+              :func:`scipy.interpolate.BPoly.from_derivatives` which
               replaces 'piecewise_polynomial' interpolation method in
               scipy 0.18
 

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -6098,9 +6098,9 @@ class NDFrame(PandasObject, SelectionMixin):
             * 'index', 'values': use the actual numerical values of the index
             * 'nearest', 'zero', 'slinear', 'quadratic', 'cubic',
               'barycentric', 'polynomial' is passed to
-              ``scipy.interpolate.interp1d``. Both 'polynomial' and 'spline'
-              require that you also specify an `order` (int),
-              e.g. df.interpolate(method='polynomial', order=4).
+              :py:func:`scipy.interpolate.interp1d`. Both 'polynomial' and
+              'spline' require that you also specify an `order` (int),
+              e.g. ``df.interpolate(method='polynomial', order=4)``.
               These use the actual numerical values of the index.
             * 'krogh', 'piecewise_polynomial', 'spline', 'pchip' and 'akima'
               are all wrappers around the scipy interpolation methods of
@@ -6110,7 +6110,8 @@ class NDFrame(PandasObject, SelectionMixin):
               <http://docs.scipy.org/doc/scipy/reference/interpolate.html#univariate-interpolation>`__
               and `tutorial documentation
               <http://docs.scipy.org/doc/scipy/reference/tutorial/interpolate.html>`__
-            * 'from_derivatives' refers to ``BPoly.from_derivatives`` which
+            * 'from_derivatives' refers to
+              :py:func:`scipy.interpolate.BPoly.from_derivatives` which
               replaces 'piecewise_polynomial' interpolation method in
               scipy 0.18
 


### PR DESCRIPTION
Previously, the _new in version_ message seemed like a run-on sentence:
https://pandas.pydata.org/pandas-docs/stable/generated/pandas.Series.interpolate.html

Also added code formatting for `BPoly.from_derivatives` reference.