### PR TITLE
Fix test_info_repr #21746

### DIFF
--- a/pandas/tests/io/formats/test_format.py
+++ b/pandas/tests/io/formats/test_format.py
@@ -1586,8 +1586,12 @@ c  10  11  12  13  14\
             assert '...' in df._repr_html_()
 
     def test_info_repr(self):
+        # GH#21746 For tests inside a terminal (i.e. not CI) we need to detect
+        # the terminal size to ensure that we try to print something "too big"
+        term_width, term_height = get_terminal_size()
+
         max_rows = 60
-        max_cols = 20
+        max_cols = 20 + (max(term_width, 80) - 80) // 4
         # Long
         h, w = max_rows + 1, max_cols - 1
         df = DataFrame({k: np.arange(1, 1 + h) for k in np.arange(w)})


### PR DESCRIPTION
Fixes test that fails locally in py27 when run in a terminal window wider than 80 characters.

- [x] closes #21746
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
