### PR TITLE
BUG: raise KeyError if MultiIndex.get_loc_level is asked unused label

### DIFF
--- a/doc/source/whatsnew/v0.24.0.txt
+++ b/doc/source/whatsnew/v0.24.0.txt
@@ -622,8 +622,8 @@ Missing
 MultiIndex
 ^^^^^^^^^^
 
-- Removed compatibility for MultiIndex pickles prior to version 0.8.0; compatibility with MultiIndex pickles from version 0.13 forward is maintained (:issue:`21654`)
--
+- Removed compatibility for :class:`MultiIndex` pickles prior to version 0.8.0; compatibility with :class:`MultiIndex` pickles from version 0.13 forward is maintained (:issue:`21654`)
+- :meth:`MultiIndex.get_loc_level` (and as a consequence, ``.loc`` on a :class:``MultiIndex``ed object) will now raise a ``KeyError``, rather than returning an empty ``slice``, if asked a label which is present in the ``levels`` but is unused (:issue:`22221`)
 -
 
 I/O

--- a/pandas/tests/groupby/test_apply.py
+++ b/pandas/tests/groupby/test_apply.py
@@ -518,6 +518,19 @@ def test_groupby_apply_none_first():
     tm.assert_frame_equal(result2, expected2)
 
 
+def test_groupby_apply_return_empty_chunk():
+    # GH 22221: apply filter which returns some empty groups
+    df = pd.DataFrame(dict(value=[0, 1], group=['filled', 'empty']))
+    groups = df.groupby('group')
+    result = groups.apply(lambda group: group[group.value != 1]['value'])
+    expected = pd.Series([0], name='value',
+                         index=MultiIndex.from_product([['empty', 'filled'],
+                                                        [0]],
+                                                       names=['group', None]
+                                                       ).drop('empty'))
+    tm.assert_series_equal(result, expected)
+
+
 def test_apply_with_mixed_types():
     # gh-20949
     df = pd.DataFrame({'A': 'a a b'.split(), 'B': [1, 2, 3], 'C': [4, 6, 5]})

--- a/pandas/tests/groupby/test_apply.py
+++ b/pandas/tests/groupby/test_apply.py
@@ -271,10 +271,7 @@ def test_apply_chunk_view():
     df = DataFrame({'key': [1, 1, 1, 2, 2, 2, 3, 3, 3],
                     'value': compat.lrange(9)})
 
-    # return view
-    f = lambda x: x[:2]
-
-    result = df.groupby('key', group_keys=False).apply(f)
+    result = df.groupby('key', group_keys=False).apply(lambda x: x[:2])
     expected = df.take([0, 1, 3, 4, 6, 7])
     tm.assert_frame_equal(result, expected)
 

--- a/pandas/tests/indexes/multi/test_indexing.py
+++ b/pandas/tests/indexes/multi/test_indexing.py
@@ -271,6 +271,10 @@ def test_get_loc_level():
     assert new_index is None
 
     pytest.raises(KeyError, index.get_loc_level, (2, 2))
+    # GH 22221: unused label
+    pytest.raises(KeyError, index.drop(2).get_loc_level, 2)
+    # Unused label on unsorted level:
+    pytest.raises(KeyError, index.drop(1, level=2).get_loc_level, 2, 2)
 
     index = MultiIndex(levels=[[2000], lrange(4)], labels=[np.array(
         [0, 0, 0, 0]), np.array([0, 1, 2, 3])])


### PR DESCRIPTION
- [x] closes #22221
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry
