### PR TITLE
CLN: remove redundant call to ensure_index

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -7616,7 +7616,7 @@ def _arrays_to_mgr(arrays, arr_names, index, columns, dtype=None):
     arrays = _homogenize(arrays, index, dtype)
 
     # from BlockManager perspective
-    axes = [ensure_index(columns), ensure_index(index)]
+    axes = [ensure_index(columns), index]
 
     return create_block_manager_from_arrays(arrays, arr_names, axes)
 


### PR DESCRIPTION
- [x] tests passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`

Small followup to #22232
