### PR TITLE
DOC: Fix dateutil link in install instructions

### DIFF
--- a/doc/source/install.rst
+++ b/doc/source/install.rst
@@ -225,7 +225,7 @@ Dependencies
 
 * `setuptools <https://setuptools.readthedocs.io/en/latest/>`__: 24.2.0 or higher
 * `NumPy <http://www.numpy.org>`__: 1.9.0 or higher
-* `python-dateutil <//https://dateutil.readthedocs.io/en/stable/>`__: 2.5.0 or higher
+* `python-dateutil <https://dateutil.readthedocs.io/en/stable/>`__: 2.5.0 or higher
 * `pytz <http://pytz.sourceforge.net/>`__
 
 .. _install.recommended_dependencies:


### PR DESCRIPTION
This should be a rather straightforward review. :) Some errant slashes were preventing the python-dateutil link from working.