### PR TITLE
Resampling with NaT in TimedeltaIndex raises MemoryError

### DIFF
--- a/doc/source/whatsnew/v0.23.5.txt
+++ b/doc/source/whatsnew/v0.23.5.txt
@@ -33,7 +33,7 @@ Bug Fixes
 
 **Groupby/Resample/Rolling**
 
--
+- Bug in :meth:`DataFrame.resample` when resampling ``NaT`` in ``TimeDeltaIndex`` (:issue:`13223`).
 -
 
 **Missing**

--- a/pandas/core/resample.py
+++ b/pandas/core/resample.py
@@ -1383,8 +1383,7 @@ class TimeGrouper(Grouper):
                 data=[], freq=self.freq, name=ax.name)
             return binner, [], labels
 
-        start = ax[0]
-        end = ax[-1]
+        start, end = ax.min(), ax.max()
         labels = binner = TimedeltaIndex(start=start,
                                          end=end,
                                          freq=self.freq,

--- a/pandas/tests/test_resample.py
+++ b/pandas/tests/test_resample.py
@@ -2887,6 +2887,16 @@ class TestTimedeltaIndex(Base):
                                                    freq='1T'))
         assert_frame_equal(result, expected)
 
+    def test_resample_with_nat(self):
+        # GH 13223
+        index = pd.to_timedelta(['0s', pd.NaT, '2s'])
+        result = DataFrame({'value': [2, 3, 5]}, index).resample('1s').mean()
+        expected = DataFrame({'value': [2.5, np.nan, 5.0]},
+                             index=timedelta_range('0 day',
+                                                   periods=3,
+                                                   freq='1S'))
+        assert_frame_equal(result, expected)
+
 
 class TestResamplerGrouper(object):
 


### PR DESCRIPTION
- [x] closes #13223
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry
