### PR TITLE
Continue Collecting Arithmetic Tests

### DIFF
--- a/pandas/tests/arithmetic/test_datetime64.py
+++ b/pandas/tests/arithmetic/test_datetime64.py
@@ -65,6 +65,32 @@ class TestDatetime64DataFrameComparison(object):
 
 
 class TestDatetime64SeriesComparison(object):
+    # TODO: moved from tests.series.test_operators; needs cleanup
+    def test_comparison_invalid(self):
+        # GH#4968
+        # invalid date/int comparisons
+        ser = Series(range(5))
+        ser2 = Series(pd.date_range('20010101', periods=5))
+
+        for (x, y) in [(ser, ser2), (ser2, ser)]:
+
+            result = x == y
+            expected = Series([False] * 5)
+            tm.assert_series_equal(result, expected)
+
+            result = x != y
+            expected = Series([True] * 5)
+            tm.assert_series_equal(result, expected)
+
+            with pytest.raises(TypeError):
+                x >= y
+            with pytest.raises(TypeError):
+                x > y
+            with pytest.raises(TypeError):
+                x < y
+            with pytest.raises(TypeError):
+                x <= y
+
     @pytest.mark.parametrize('data', [
         [Timestamp('2011-01-01'), NaT, Timestamp('2011-01-03')],
         [Timedelta('1 days'), NaT, Timedelta('3 days')],

--- a/pandas/tests/arithmetic/test_datetime64.py
+++ b/pandas/tests/arithmetic/test_datetime64.py
@@ -5,6 +5,7 @@
 import operator
 from datetime import datetime, timedelta
 import warnings
+from itertools import product, starmap
 
 import numpy as np
 import pytest
@@ -1360,7 +1361,95 @@ class TestDatetimeIndexArithmetic(object):
         with pytest.raises(TypeError):
             op(dti, pi)
 
-    # -------------------------------------------------------------
+    # -------------------------------------------------------------------
+    # TODO: Most of this block is moved from series or frame tests, needs
+    # cleanup, box-parametrization, and de-duplication
+
+    @pytest.mark.parametrize('op', [operator.add, operator.sub])
+    def test_timedelta64_equal_timedelta_supported_ops(self, op):
+        ser = Series([Timestamp('20130301'),
+                      Timestamp('20130228 23:00:00'),
+                      Timestamp('20130228 22:00:00'),
+                      Timestamp('20130228 21:00:00')])
+
+        intervals = ['D', 'h', 'm', 's', 'us']
+
+        # TODO: unused
+        # npy16_mappings = {'D': 24 * 60 * 60 * 1000000,
+        #                   'h': 60 * 60 * 1000000,
+        #                   'm': 60 * 1000000,
+        #                   's': 1000000,
+        #                   'us': 1}
+
+        def timedelta64(*args):
+            return sum(starmap(np.timedelta64, zip(args, intervals)))
+
+        for d, h, m, s, us in product(*([range(2)] * 5)):
+            nptd = timedelta64(d, h, m, s, us)
+            pytd = timedelta(days=d, hours=h, minutes=m, seconds=s,
+                             microseconds=us)
+            lhs = op(ser, nptd)
+            rhs = op(ser, pytd)
+
+            tm.assert_series_equal(lhs, rhs)
+
+    def test_ops_nat_mixed_datetime64_timedelta64(self):
+        # GH#11349
+        timedelta_series = Series([NaT, Timedelta('1s')])
+        datetime_series = Series([NaT, Timestamp('19900315')])
+        nat_series_dtype_timedelta = Series([NaT, NaT],
+                                            dtype='timedelta64[ns]')
+        nat_series_dtype_timestamp = Series([NaT, NaT], dtype='datetime64[ns]')
+        single_nat_dtype_datetime = Series([NaT], dtype='datetime64[ns]')
+        single_nat_dtype_timedelta = Series([NaT], dtype='timedelta64[ns]')
+
+        # subtraction
+        tm.assert_series_equal(datetime_series - single_nat_dtype_datetime,
+                               nat_series_dtype_timedelta)
+
+        tm.assert_series_equal(datetime_series - single_nat_dtype_timedelta,
+                               nat_series_dtype_timestamp)
+        tm.assert_series_equal(-single_nat_dtype_timedelta + datetime_series,
+                               nat_series_dtype_timestamp)
+
+        # without a Series wrapping the NaT, it is ambiguous
+        # whether it is a datetime64 or timedelta64
+        # defaults to interpreting it as timedelta64
+        tm.assert_series_equal(nat_series_dtype_timestamp -
+                               single_nat_dtype_datetime,
+                               nat_series_dtype_timedelta)
+
+        tm.assert_series_equal(nat_series_dtype_timestamp -
+                               single_nat_dtype_timedelta,
+                               nat_series_dtype_timestamp)
+        tm.assert_series_equal(-single_nat_dtype_timedelta +
+                               nat_series_dtype_timestamp,
+                               nat_series_dtype_timestamp)
+
+        with pytest.raises(TypeError):
+            timedelta_series - single_nat_dtype_datetime
+
+        # addition
+        tm.assert_series_equal(nat_series_dtype_timestamp +
+                               single_nat_dtype_timedelta,
+                               nat_series_dtype_timestamp)
+        tm.assert_series_equal(single_nat_dtype_timedelta +
+                               nat_series_dtype_timestamp,
+                               nat_series_dtype_timestamp)
+
+        tm.assert_series_equal(nat_series_dtype_timestamp +
+                               single_nat_dtype_timedelta,
+                               nat_series_dtype_timestamp)
+        tm.assert_series_equal(single_nat_dtype_timedelta +
+                               nat_series_dtype_timestamp,
+                               nat_series_dtype_timestamp)
+
+        tm.assert_series_equal(nat_series_dtype_timedelta +
+                               single_nat_dtype_datetime,
+                               nat_series_dtype_timestamp)
+        tm.assert_series_equal(single_nat_dtype_datetime +
+                               nat_series_dtype_timedelta,
+                               nat_series_dtype_timestamp)
 
     def test_ufunc_coercions(self):
         idx = date_range('2011-01-01', periods=3, freq='2D', name='x')

--- a/pandas/tests/arithmetic/test_numeric.py
+++ b/pandas/tests/arithmetic/test_numeric.py
@@ -714,7 +714,7 @@ class TestAdditionSubtraction(object):
 
         tser = tm.makeTimeSeries().rename('ts')
         check(tser, tser * 2)
-        check(self.ts, tser * 0)
+        check(tser, tser * 0)
         check(tser, tser[::2])
         check(tser, 5)
 

--- a/pandas/tests/arithmetic/test_object.py
+++ b/pandas/tests/arithmetic/test_object.py
@@ -19,6 +19,18 @@ from pandas import Series, Timestamp
 
 class TestObjectComparisons(object):
 
+    def test_comparison_object_numeric_nas(self):
+        ser = Series(np.random.randn(10), dtype=object)
+        shifted = ser.shift(2)
+
+        ops = ['lt', 'le', 'gt', 'ge', 'eq', 'ne']
+        for op in ops:
+            func = getattr(operator, op)
+
+            result = func(ser, shifted)
+            expected = func(ser.astype(float), shifted.astype(float))
+            tm.assert_series_equal(result, expected)
+
     def test_object_comparisons(self):
         ser = Series(['a', 'b', np.nan, 'c', 'a'])
 

--- a/pandas/tests/arithmetic/test_object.py
+++ b/pandas/tests/arithmetic/test_object.py
@@ -2,12 +2,14 @@
 # Arithmetc tests for DataFrame/Series/Index/Array classes that should
 # behave identically.
 # Specifically for object dtype
+import operator
 
 import pytest
 import numpy as np
 
 import pandas as pd
 import pandas.util.testing as tm
+from pandas.core import ops
 
 from pandas import Series, Timestamp
 
@@ -58,32 +60,40 @@ class TestObjectComparisons(object):
 # Arithmetic
 
 class TestArithmetic(object):
-    def test_df_radd_str(self):
-        df = pd.DataFrame(['x', np.nan, 'x'])
 
-        expected = pd.DataFrame(['ax', np.nan, 'ax'])
-        result = 'a' + df
-        tm.assert_frame_equal(result, expected)
-
-        expected = pd.DataFrame(['xa', np.nan, 'xa'])
-        result = df + 'a'
-        tm.assert_frame_equal(result, expected)
-
-    def test_series_radd_str(self):
+    @pytest.mark.parametrize('box', [
+        pytest.param(pd.Index,
+                     marks=pytest.mark.xfail(reason="Does not mask nulls",
+                                             strict=True, raises=TypeError)),
+        pd.Series,
+        pd.DataFrame
+    ], ids=lambda x: x.__name__)
+    def test_objarr_add_str(self, box):
         ser = pd.Series(['x', np.nan, 'x'])
-        tm.assert_series_equal('a' + ser, pd.Series(['ax', np.nan, 'ax']))
-        tm.assert_series_equal(ser + 'a', pd.Series(['xa', np.nan, 'xa']))
+        expected = pd.Series(['xa', np.nan, 'xa'])
 
-    @pytest.mark.parametrize('data', [
-        [1, 2, 3],
-        [1.1, 2.2, 3.3],
-        [pd.Timestamp('2011-01-01'), pd.Timestamp('2011-01-02'), pd.NaT],
-        ['x', 'y', 1]])
-    @pytest.mark.parametrize('dtype', [None, object])
-    def test_df_radd_str_invalid(self, dtype, data):
-        df = pd.DataFrame(data, dtype=dtype)
-        with pytest.raises(TypeError):
-            'foo_' + df
+        ser = tm.box_expected(ser, box)
+        expected = tm.box_expected(expected, box)
+
+        result = ser + 'a'
+        tm.assert_equal(result, expected)
+
+    @pytest.mark.parametrize('box', [
+        pytest.param(pd.Index,
+                     marks=pytest.mark.xfail(reason="Does not mask nulls",
+                                             strict=True, raises=TypeError)),
+        pd.Series,
+        pd.DataFrame
+    ], ids=lambda x: x.__name__)
+    def test_objarr_radd_str(self, box):
+        ser = pd.Series(['x', np.nan, 'x'])
+        expected = pd.Series(['ax', np.nan, 'ax'])
+
+        ser = tm.box_expected(ser, box)
+        expected = tm.box_expected(expected, box)
+
+        result = 'a' + ser
+        tm.assert_equal(result, expected)
 
     @pytest.mark.parametrize('data', [
         [1, 2, 3],
@@ -91,21 +101,26 @@ class TestArithmetic(object):
         [Timestamp('2011-01-01'), Timestamp('2011-01-02'), pd.NaT],
         ['x', 'y', 1]])
     @pytest.mark.parametrize('dtype', [None, object])
-    def test_series_radd_str_invalid(self, dtype, data):
+    def test_objarr_radd_str_invalid(self, dtype, data, box):
         ser = Series(data, dtype=dtype)
+
+        ser = tm.box_expected(ser, box)
         with pytest.raises(TypeError):
             'foo_' + ser
 
-    # TODO: parametrize, better name
-    def test_object_ser_add_invalid(self):
+    @pytest.mark.parametrize('op', [operator.add, ops.radd,
+                                    operator.sub, ops.rsub])
+    def test_objarr_add_invalid(self, op, box):
         # invalid ops
+        if box is pd.DataFrame and op is ops.radd:
+            pytest.xfail(reason="DataFrame op incorrectly casts the np.array"
+                                "case to M8[ns]")
+
         obj_ser = tm.makeObjectSeries()
         obj_ser.name = 'objects'
+
+        obj_ser = tm.box_expected(obj_ser, box)
         with pytest.raises(Exception):
-            obj_ser + 1
+            op(obj_ser, 1)
         with pytest.raises(Exception):
-            obj_ser + np.array(1, dtype=np.int64)
-        with pytest.raises(Exception):
-            obj_ser - 1
-        with pytest.raises(Exception):
-            obj_ser - np.array(1, dtype=np.int64)
+            op(obj_ser, np.array(1, dtype=np.int64))

--- a/pandas/tests/arithmetic/test_object.py
+++ b/pandas/tests/arithmetic/test_object.py
@@ -124,3 +124,31 @@ class TestArithmetic(object):
             op(obj_ser, 1)
         with pytest.raises(Exception):
             op(obj_ser, np.array(1, dtype=np.int64))
+
+    # TODO: Moved from tests.series.test_operators; needs cleanup
+    def test_operators_na_handling(self):
+        ser = Series(['foo', 'bar', 'baz', np.nan])
+        result = 'prefix_' + ser
+        expected = pd.Series(['prefix_foo', 'prefix_bar',
+                              'prefix_baz', np.nan])
+        tm.assert_series_equal(result, expected)
+
+        result = ser + '_suffix'
+        expected = pd.Series(['foo_suffix', 'bar_suffix',
+                              'baz_suffix', np.nan])
+        tm.assert_series_equal(result, expected)
+
+    # TODO: parametrize over box
+    @pytest.mark.parametrize('dtype', [None, object])
+    def test_series_with_dtype_radd_timedelta(self, dtype):
+        # note this test is _not_ aimed at timedelta64-dtyped Series
+        ser = pd.Series([pd.Timedelta('1 days'), pd.Timedelta('2 days'),
+                         pd.Timedelta('3 days')], dtype=dtype)
+        expected = pd.Series([pd.Timedelta('4 days'), pd.Timedelta('5 days'),
+                              pd.Timedelta('6 days')])
+
+        result = pd.Timedelta('3 days') + ser
+        tm.assert_series_equal(result, expected)
+
+        result = ser + pd.Timedelta('3 days')
+        tm.assert_series_equal(result, expected)

--- a/pandas/tests/frame/test_arithmetic.py
+++ b/pandas/tests/frame/test_arithmetic.py
@@ -1,11 +1,16 @@
 # -*- coding: utf-8 -*-
+import operator
+
 import pytest
 import numpy as np
 
-from pandas.compat import range
+from pandas.compat import range, PY3
+import pandas.io.formats.printing as printing
 
 import pandas as pd
 import pandas.util.testing as tm
+
+from pandas.tests.frame.common import _check_mixed_float, _check_mixed_int
 
 
 # -------------------------------------------------------------------
@@ -78,3 +83,171 @@ class TestFrameFlexArithmetic(object):
                             dtype='datetime64[ns]'),
              'B': ser * 2})
         tm.assert_frame_equal(result, expected)
+
+    def test_arith_flex_frame(self):
+        seriesd = tm.getSeriesData()
+        frame = pd.DataFrame(seriesd).copy()
+
+        mixed_float = pd.DataFrame({'A': frame['A'].copy().astype('float32'),
+                                    'B': frame['B'].copy().astype('float32'),
+                                    'C': frame['C'].copy().astype('float16'),
+                                    'D': frame['D'].copy().astype('float64')})
+
+        intframe = pd.DataFrame({k: v.astype(int)
+                                 for k, v in seriesd.items()})
+        mixed_int = pd.DataFrame({'A': intframe['A'].copy().astype('int32'),
+                                  'B': np.ones(len(intframe), dtype='uint64'),
+                                  'C': intframe['C'].copy().astype('uint8'),
+                                  'D': intframe['D'].copy().astype('int64')})
+
+        # force these all to int64 to avoid platform testing issues
+        intframe = pd.DataFrame({c: s for c, s in intframe.items()},
+                                dtype=np.int64)
+
+        ops = ['add', 'sub', 'mul', 'div', 'truediv', 'pow', 'floordiv', 'mod']
+        if not PY3:
+            aliases = {}
+        else:
+            aliases = {'div': 'truediv'}
+
+        for op in ops:
+            try:
+                alias = aliases.get(op, op)
+                f = getattr(operator, alias)
+                result = getattr(frame, op)(2 * frame)
+                exp = f(frame, 2 * frame)
+                tm.assert_frame_equal(result, exp)
+
+                # vs mix float
+                result = getattr(mixed_float, op)(2 * mixed_float)
+                exp = f(mixed_float, 2 * mixed_float)
+                tm.assert_frame_equal(result, exp)
+                _check_mixed_float(result, dtype=dict(C=None))
+
+                # vs mix int
+                if op in ['add', 'sub', 'mul']:
+                    result = getattr(mixed_int, op)(2 + mixed_int)
+                    exp = f(mixed_int, 2 + mixed_int)
+
+                    # no overflow in the uint
+                    dtype = None
+                    if op in ['sub']:
+                        dtype = dict(B='uint64', C=None)
+                    elif op in ['add', 'mul']:
+                        dtype = dict(C=None)
+                    tm.assert_frame_equal(result, exp)
+                    _check_mixed_int(result, dtype=dtype)
+
+                    # rops
+                    r_f = lambda x, y: f(y, x)
+                    result = getattr(frame, 'r' + op)(2 * frame)
+                    exp = r_f(frame, 2 * frame)
+                    tm.assert_frame_equal(result, exp)
+
+                    # vs mix float
+                    result = getattr(mixed_float, op)(2 * mixed_float)
+                    exp = f(mixed_float, 2 * mixed_float)
+                    tm.assert_frame_equal(result, exp)
+                    _check_mixed_float(result, dtype=dict(C=None))
+
+                    result = getattr(intframe, op)(2 * intframe)
+                    exp = f(intframe, 2 * intframe)
+                    tm.assert_frame_equal(result, exp)
+
+                    # vs mix int
+                    if op in ['add', 'sub', 'mul']:
+                        result = getattr(mixed_int, op)(2 + mixed_int)
+                        exp = f(mixed_int, 2 + mixed_int)
+
+                        # no overflow in the uint
+                        dtype = None
+                        if op in ['sub']:
+                            dtype = dict(B='uint64', C=None)
+                        elif op in ['add', 'mul']:
+                            dtype = dict(C=None)
+                        tm.assert_frame_equal(result, exp)
+                        _check_mixed_int(result, dtype=dtype)
+            except:
+                printing.pprint_thing("Failing operation %r" % op)
+                raise
+
+            # ndim >= 3
+            ndim_5 = np.ones(frame.shape + (3, 4, 5))
+            msg = "Unable to coerce to Series/DataFrame"
+            with tm.assert_raises_regex(ValueError, msg):
+                f(frame, ndim_5)
+
+            with tm.assert_raises_regex(ValueError, msg):
+                getattr(frame, op)(ndim_5)
+
+        # res_add = frame.add(frame)
+        # res_sub = frame.sub(frame)
+        # res_mul = frame.mul(frame)
+        # res_div = frame.div(2 * frame)
+
+        # tm.assert_frame_equal(res_add, frame + frame)
+        # tm.assert_frame_equal(res_sub, frame - frame)
+        # tm.assert_frame_equal(res_mul, frame * frame)
+        # tm.assert_frame_equal(res_div, frame / (2 * frame))
+
+        const_add = frame.add(1)
+        tm.assert_frame_equal(const_add, frame + 1)
+
+        # corner cases
+        result = frame.add(frame[:0])
+        tm.assert_frame_equal(result, frame * np.nan)
+
+        result = frame[:0].add(frame)
+        tm.assert_frame_equal(result, frame * np.nan)
+        with tm.assert_raises_regex(NotImplementedError, 'fill_value'):
+            frame.add(frame.iloc[0], fill_value=3)
+        with tm.assert_raises_regex(NotImplementedError, 'fill_value'):
+            frame.add(frame.iloc[0], axis='index', fill_value=3)
+
+    def test_arith_flex_series(self):
+        arr = np.array([[1., 2., 3.],
+                        [4., 5., 6.],
+                        [7., 8., 9.]])
+        df = pd.DataFrame(arr, columns=['one', 'two', 'three'],
+                          index=['a', 'b', 'c'])
+
+        row = df.xs('a')
+        col = df['two']
+        # after arithmetic refactor, add truediv here
+        ops = ['add', 'sub', 'mul', 'mod']
+        for op in ops:
+            f = getattr(df, op)
+            op = getattr(operator, op)
+            tm.assert_frame_equal(f(row), op(df, row))
+            tm.assert_frame_equal(f(col, axis=0), op(df.T, col).T)
+
+        # special case for some reason
+        tm.assert_frame_equal(df.add(row, axis=None), df + row)
+
+        # cases which will be refactored after big arithmetic refactor
+        tm.assert_frame_equal(df.div(row), df / row)
+        tm.assert_frame_equal(df.div(col, axis=0), (df.T / col).T)
+
+        # broadcasting issue in GH#7325
+        df = pd.DataFrame(np.arange(3 * 2).reshape((3, 2)), dtype='int64')
+        expected = pd.DataFrame([[np.nan, np.inf], [1.0, 1.5], [1.0, 1.25]])
+        result = df.div(df[0], axis='index')
+        tm.assert_frame_equal(result, expected)
+
+        df = pd.DataFrame(np.arange(3 * 2).reshape((3, 2)), dtype='float64')
+        expected = pd.DataFrame([[np.nan, np.inf], [1.0, 1.5], [1.0, 1.25]])
+        result = df.div(df[0], axis='index')
+        tm.assert_frame_equal(result, expected)
+
+    def test_arith_flex_zero_len_raises(self):
+        # GH#19522 passing fill_value to frame flex arith methods should
+        # raise even in the zero-length special cases
+        ser_len0 = pd.Series([])
+        df_len0 = pd.DataFrame([], columns=['A', 'B'])
+        df = pd.DataFrame([[1, 2], [3, 4]], columns=['A', 'B'])
+
+        with tm.assert_raises_regex(NotImplementedError, 'fill_value'):
+            df.add(ser_len0, fill_value='E')
+
+        with tm.assert_raises_regex(NotImplementedError, 'fill_value'):
+            df_len0.sub(df['A'], axis=None, fill_value=3)

--- a/pandas/tests/frame/test_operators.py
+++ b/pandas/tests/frame/test_operators.py
@@ -8,7 +8,7 @@ import operator
 
 import pytest
 
-from numpy import nan, random
+from numpy import nan
 import numpy as np
 
 from pandas.compat import range
@@ -30,60 +30,6 @@ from pandas.tests.frame.common import (TestData, _check_mixed_float,
 
 
 class TestDataFrameOperators(TestData):
-
-    def test_operators(self):
-        garbage = random.random(4)
-        colSeries = Series(garbage, index=np.array(self.frame.columns))
-
-        idSum = self.frame + self.frame
-        seriesSum = self.frame + colSeries
-
-        for col, series in compat.iteritems(idSum):
-            for idx, val in compat.iteritems(series):
-                origVal = self.frame[col][idx] * 2
-                if not np.isnan(val):
-                    assert val == origVal
-                else:
-                    assert np.isnan(origVal)
-
-        for col, series in compat.iteritems(seriesSum):
-            for idx, val in compat.iteritems(series):
-                origVal = self.frame[col][idx] + colSeries[col]
-                if not np.isnan(val):
-                    assert val == origVal
-                else:
-                    assert np.isnan(origVal)
-
-        added = self.frame2 + self.frame2
-        expected = self.frame2 * 2
-        assert_frame_equal(added, expected)
-
-        df = DataFrame({'a': ['a', None, 'b']})
-        assert_frame_equal(df + df, DataFrame({'a': ['aa', np.nan, 'bb']}))
-
-        # Test for issue #10181
-        for dtype in ('float', 'int64'):
-            frames = [
-                DataFrame(dtype=dtype),
-                DataFrame(columns=['A'], dtype=dtype),
-                DataFrame(index=[0], dtype=dtype),
-            ]
-            for df in frames:
-                assert (df + df).equals(df)
-                assert_frame_equal(df + df, df)
-
-    @pytest.mark.parametrize('other', [nan, 7, -23, 2.718, -3.14, np.inf])
-    def test_ops_np_scalar(self, other):
-        vals = np.random.randn(5, 3)
-        f = lambda x: DataFrame(x, index=list('ABCDE'),
-                                columns=['jim', 'joe', 'jolie'])
-
-        df = f(vals)
-
-        assert_frame_equal(df / np.array(other), f(vals / other))
-        assert_frame_equal(np.array(other) * df, f(vals * other))
-        assert_frame_equal(df + np.array(other), f(vals + other))
-        assert_frame_equal(np.array(other) - df, f(other - vals))
 
     def test_operators_boolean(self):
 

--- a/pandas/tests/series/test_arithmetic.py
+++ b/pandas/tests/series/test_arithmetic.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from datetime import timedelta
 import operator
 
 import numpy as np
@@ -75,33 +74,3 @@ class TestSeriesComparison(object):
             ser = Series(cidx).rename(names[1])
             result = op(ser, cidx)
             assert result.name == names[2]
-
-
-class TestTimedeltaSeriesComparisons(object):
-    def test_compare_timedelta_series(self):
-        # regresssion test for GH5963
-        s = pd.Series([timedelta(days=1), timedelta(days=2)])
-        actual = s > timedelta(days=1)
-        expected = pd.Series([False, True])
-        tm.assert_series_equal(actual, expected)
-
-
-# ------------------------------------------------------------------
-# Arithmetic
-
-class TestSeriesArithmetic(object):
-    # Standard, numeric, or otherwise not-Timestamp/Timedelta/Period dtypes
-
-    @pytest.mark.parametrize('dtype', [None, object])
-    def test_series_with_dtype_radd_timedelta(self, dtype):
-        # note this test is _not_ aimed at timedelta64-dtyped Series
-        ser = pd.Series([pd.Timedelta('1 days'), pd.Timedelta('2 days'),
-                         pd.Timedelta('3 days')], dtype=dtype)
-        expected = pd.Series([pd.Timedelta('4 days'), pd.Timedelta('5 days'),
-                              pd.Timedelta('6 days')])
-
-        result = pd.Timedelta('3 days') + ser
-        tm.assert_series_equal(result, expected)
-
-        result = ser + pd.Timedelta('3 days')
-        tm.assert_series_equal(result, expected)

--- a/pandas/tests/series/test_operators.py
+++ b/pandas/tests/series/test_operators.py
@@ -179,39 +179,6 @@ class TestSeriesComparisons(object):
         expected[mask] = False
         assert_series_equal(result, expected)
 
-    def test_comparison_object_numeric_nas(self):
-        ser = Series(np.random.randn(10), dtype=object)
-        shifted = ser.shift(2)
-
-        ops = ['lt', 'le', 'gt', 'ge', 'eq', 'ne']
-        for op in ops:
-            func = getattr(operator, op)
-
-            result = func(ser, shifted)
-            expected = func(ser.astype(float), shifted.astype(float))
-            assert_series_equal(result, expected)
-
-    def test_comparison_invalid(self):
-        # GH4968
-        # invalid date/int comparisons
-        s = Series(range(5))
-        s2 = Series(date_range('20010101', periods=5))
-
-        for (x, y) in [(s, s2), (s2, s)]:
-
-            result = x == y
-            expected = Series([False] * 5)
-            assert_series_equal(result, expected)
-
-            result = x != y
-            expected = Series([True] * 5)
-            assert_series_equal(result, expected)
-
-            pytest.raises(TypeError, lambda: x >= y)
-            pytest.raises(TypeError, lambda: x > y)
-            pytest.raises(TypeError, lambda: x < y)
-            pytest.raises(TypeError, lambda: x <= y)
-
     def test_unequal_categorical_comparison_raises_type_error(self):
         # unequal comparison should raise for unordered cats
         cat = Series(Categorical(list("abc")))

--- a/pandas/tests/series/test_operators.py
+++ b/pandas/tests/series/test_operators.py
@@ -3,10 +3,8 @@
 
 import pytest
 
-from collections import Iterable
 from datetime import datetime, timedelta
 import operator
-from itertools import product, starmap
 
 from numpy import nan
 import numpy as np
@@ -15,13 +13,12 @@ import pandas as pd
 from pandas import (Index, Series, DataFrame, isna, bdate_range,
                     NaT, date_range, timedelta_range, Categorical)
 from pandas.core.indexes.datetimes import Timestamp
-from pandas.core.indexes.timedeltas import Timedelta
 import pandas.core.nanops as nanops
 
-from pandas.compat import range, zip
+from pandas.compat import range
 from pandas import compat
 from pandas.util.testing import (assert_series_equal, assert_almost_equal,
-                                 assert_frame_equal, assert_index_equal)
+                                 assert_frame_equal)
 import pandas.util.testing as tm
 
 from .common import TestData
@@ -498,158 +495,6 @@ class TestSeriesComparisons(object):
                 left.to_frame() < right.to_frame()
 
 
-class TestTimedeltaSeriesArithmetic(object):
-
-    def test_operators_timedelta64(self):
-        # series ops
-        v1 = date_range('2012-1-1', periods=3, freq='D')
-        v2 = date_range('2012-1-2', periods=3, freq='D')
-        rs = Series(v2) - Series(v1)
-        xp = Series(1e9 * 3600 * 24,
-                    rs.index).astype('int64').astype('timedelta64[ns]')
-        assert_series_equal(rs, xp)
-        assert rs.dtype == 'timedelta64[ns]'
-
-        df = DataFrame(dict(A=v1))
-        td = Series([timedelta(days=i) for i in range(3)])
-        assert td.dtype == 'timedelta64[ns]'
-
-        # series on the rhs
-        result = df['A'] - df['A'].shift()
-        assert result.dtype == 'timedelta64[ns]'
-
-        result = df['A'] + td
-        assert result.dtype == 'M8[ns]'
-
-        # scalar Timestamp on rhs
-        maxa = df['A'].max()
-        assert isinstance(maxa, Timestamp)
-
-        resultb = df['A'] - df['A'].max()
-        assert resultb.dtype == 'timedelta64[ns]'
-
-        # timestamp on lhs
-        result = resultb + df['A']
-        values = [Timestamp('20111230'), Timestamp('20120101'),
-                  Timestamp('20120103')]
-        expected = Series(values, name='A')
-        assert_series_equal(result, expected)
-
-        # datetimes on rhs
-        result = df['A'] - datetime(2001, 1, 1)
-        expected = Series(
-            [timedelta(days=4017 + i) for i in range(3)], name='A')
-        assert_series_equal(result, expected)
-        assert result.dtype == 'm8[ns]'
-
-        d = datetime(2001, 1, 1, 3, 4)
-        resulta = df['A'] - d
-        assert resulta.dtype == 'm8[ns]'
-
-        # roundtrip
-        resultb = resulta + d
-        assert_series_equal(df['A'], resultb)
-
-        # timedeltas on rhs
-        td = timedelta(days=1)
-        resulta = df['A'] + td
-        resultb = resulta - td
-        assert_series_equal(resultb, df['A'])
-        assert resultb.dtype == 'M8[ns]'
-
-        # roundtrip
-        td = timedelta(minutes=5, seconds=3)
-        resulta = df['A'] + td
-        resultb = resulta - td
-        assert_series_equal(df['A'], resultb)
-        assert resultb.dtype == 'M8[ns]'
-
-        # inplace
-        value = rs[2] + np.timedelta64(timedelta(minutes=5, seconds=1))
-        rs[2] += np.timedelta64(timedelta(minutes=5, seconds=1))
-        assert rs[2] == value
-
-    def test_timedelta64_ops_nat(self):
-        # GH 11349
-        timedelta_series = Series([NaT, Timedelta('1s')])
-        nat_series_dtype_timedelta = Series([NaT, NaT],
-                                            dtype='timedelta64[ns]')
-        single_nat_dtype_timedelta = Series([NaT], dtype='timedelta64[ns]')
-
-        # subtraction
-        assert_series_equal(timedelta_series - NaT,
-                            nat_series_dtype_timedelta)
-        assert_series_equal(-NaT + timedelta_series,
-                            nat_series_dtype_timedelta)
-
-        assert_series_equal(timedelta_series - single_nat_dtype_timedelta,
-                            nat_series_dtype_timedelta)
-        assert_series_equal(-single_nat_dtype_timedelta + timedelta_series,
-                            nat_series_dtype_timedelta)
-
-        # addition
-        assert_series_equal(nat_series_dtype_timedelta + NaT,
-                            nat_series_dtype_timedelta)
-        assert_series_equal(NaT + nat_series_dtype_timedelta,
-                            nat_series_dtype_timedelta)
-
-        assert_series_equal(nat_series_dtype_timedelta +
-                            single_nat_dtype_timedelta,
-                            nat_series_dtype_timedelta)
-        assert_series_equal(single_nat_dtype_timedelta +
-                            nat_series_dtype_timedelta,
-                            nat_series_dtype_timedelta)
-
-        assert_series_equal(timedelta_series + NaT,
-                            nat_series_dtype_timedelta)
-        assert_series_equal(NaT + timedelta_series,
-                            nat_series_dtype_timedelta)
-
-        assert_series_equal(timedelta_series + single_nat_dtype_timedelta,
-                            nat_series_dtype_timedelta)
-        assert_series_equal(single_nat_dtype_timedelta + timedelta_series,
-                            nat_series_dtype_timedelta)
-
-        assert_series_equal(nat_series_dtype_timedelta + NaT,
-                            nat_series_dtype_timedelta)
-        assert_series_equal(NaT + nat_series_dtype_timedelta,
-                            nat_series_dtype_timedelta)
-
-        assert_series_equal(nat_series_dtype_timedelta +
-                            single_nat_dtype_timedelta,
-                            nat_series_dtype_timedelta)
-        assert_series_equal(single_nat_dtype_timedelta +
-                            nat_series_dtype_timedelta,
-                            nat_series_dtype_timedelta)
-
-        # multiplication
-        assert_series_equal(nat_series_dtype_timedelta * 1.0,
-                            nat_series_dtype_timedelta)
-        assert_series_equal(1.0 * nat_series_dtype_timedelta,
-                            nat_series_dtype_timedelta)
-
-        assert_series_equal(timedelta_series * 1, timedelta_series)
-        assert_series_equal(1 * timedelta_series, timedelta_series)
-
-        assert_series_equal(timedelta_series * 1.5,
-                            Series([NaT, Timedelta('1.5s')]))
-        assert_series_equal(1.5 * timedelta_series,
-                            Series([NaT, Timedelta('1.5s')]))
-
-        assert_series_equal(timedelta_series * nan,
-                            nat_series_dtype_timedelta)
-        assert_series_equal(nan * timedelta_series,
-                            nat_series_dtype_timedelta)
-
-        # division
-        assert_series_equal(timedelta_series / 2,
-                            Series([NaT, Timedelta('0.5s')]))
-        assert_series_equal(timedelta_series / 2.0,
-                            Series([NaT, Timedelta('0.5s')]))
-        assert_series_equal(timedelta_series / nan,
-                            nat_series_dtype_timedelta)
-
-
 class TestDatetimeSeriesArithmetic(object):
 
     def test_operators_datetimelike_invalid(self, all_arithmetic_operators):
@@ -739,8 +584,10 @@ class TestSeriesOperators(TestData):
                                         'truediv', 'div', 'pow'])
     def test_op_method(self, opname, ts):
         # check that Series.{opname} behaves like Series.__{opname}__,
-        series = ts[0](self.ts)
-        other = ts[1](self.ts)
+        tser = tm.makeTimeSeries().rename('ts')
+
+        series = ts[0](tser)
+        other = ts[1](tser)
         check_reverse = ts[2]
 
         if opname == 'div' and compat.PY3:
@@ -768,187 +615,10 @@ class TestSeriesOperators(TestData):
     def test_invert(self):
         assert_series_equal(-(self.series < 0), ~(self.series < 0))
 
-    def test_operators(self):
-        def _check_op(series, other, op, pos_only=False,
-                      check_dtype=True):
-            left = np.abs(series) if pos_only else series
-            right = np.abs(other) if pos_only else other
-
-            cython_or_numpy = op(left, right)
-            python = left.combine(right, op)
-            assert_series_equal(cython_or_numpy, python,
-                                check_dtype=check_dtype)
-
-        def check(series, other):
-            simple_ops = ['add', 'sub', 'mul', 'truediv', 'floordiv', 'mod']
-
-            for opname in simple_ops:
-                _check_op(series, other, getattr(operator, opname))
-
-            _check_op(series, other, operator.pow, pos_only=True)
-
-            _check_op(series, other, lambda x, y: operator.add(y, x))
-            _check_op(series, other, lambda x, y: operator.sub(y, x))
-            _check_op(series, other, lambda x, y: operator.truediv(y, x))
-            _check_op(series, other, lambda x, y: operator.floordiv(y, x))
-            _check_op(series, other, lambda x, y: operator.mul(y, x))
-            _check_op(series, other, lambda x, y: operator.pow(y, x),
-                      pos_only=True)
-            _check_op(series, other, lambda x, y: operator.mod(y, x))
-
-        check(self.ts, self.ts * 2)
-        check(self.ts, self.ts * 0)
-        check(self.ts, self.ts[::2])
-        check(self.ts, 5)
-
-        def check_comparators(series, other, check_dtype=True):
-            _check_op(series, other, operator.gt, check_dtype=check_dtype)
-            _check_op(series, other, operator.ge, check_dtype=check_dtype)
-            _check_op(series, other, operator.eq, check_dtype=check_dtype)
-            _check_op(series, other, operator.lt, check_dtype=check_dtype)
-            _check_op(series, other, operator.le, check_dtype=check_dtype)
-
-        check_comparators(self.ts, 5)
-        check_comparators(self.ts, self.ts + 1, check_dtype=False)
-
-    def test_divmod(self):
-        def check(series, other):
-            results = divmod(series, other)
-            if isinstance(other, Iterable) and len(series) != len(other):
-                # if the lengths don't match, this is the test where we use
-                # `self.ts[::2]`. Pad every other value in `other_np` with nan.
-                other_np = []
-                for n in other:
-                    other_np.append(n)
-                    other_np.append(np.nan)
-            else:
-                other_np = other
-            other_np = np.asarray(other_np)
-            with np.errstate(all='ignore'):
-                expecteds = divmod(series.values, np.asarray(other_np))
-
-            for result, expected in zip(results, expecteds):
-                # check the values, name, and index separately
-                assert_almost_equal(np.asarray(result), expected)
-
-                assert result.name == series.name
-                assert_index_equal(result.index, series.index)
-
-        check(self.ts, self.ts * 2)
-        check(self.ts, self.ts * 0)
-        check(self.ts, self.ts[::2])
-        check(self.ts, 5)
-
     def test_operators_empty_int_corner(self):
         s1 = Series([], [], dtype=np.int32)
         s2 = Series({'x': 0.})
         assert_series_equal(s1 * s2, Series([np.nan], index=['x']))
-
-    @pytest.mark.parametrize("m", [1, 3, 10])
-    @pytest.mark.parametrize("unit", ['D', 'h', 'm', 's', 'ms', 'us', 'ns'])
-    def test_timedelta64_conversions(self, m, unit):
-
-        startdate = Series(date_range('2013-01-01', '2013-01-03'))
-        enddate = Series(date_range('2013-03-01', '2013-03-03'))
-
-        s1 = enddate - startdate
-        s1[2] = np.nan
-
-        # op
-        expected = s1.apply(lambda x: x / np.timedelta64(m, unit))
-        result = s1 / np.timedelta64(m, unit)
-        assert_series_equal(result, expected)
-
-        # reverse op
-        expected = s1.apply(
-            lambda x: Timedelta(np.timedelta64(m, unit)) / x)
-        result = np.timedelta64(m, unit) / s1
-        assert_series_equal(result, expected)
-
-    @pytest.mark.parametrize('op', [operator.add, operator.sub])
-    def test_timedelta64_equal_timedelta_supported_ops(self, op):
-        ser = Series([Timestamp('20130301'), Timestamp('20130228 23:00:00'),
-                      Timestamp('20130228 22:00:00'),
-                      Timestamp('20130228 21:00:00')])
-
-        intervals = 'D', 'h', 'm', 's', 'us'
-
-        # TODO: unused
-        # npy16_mappings = {'D': 24 * 60 * 60 * 1000000,
-        #                   'h': 60 * 60 * 1000000,
-        #                   'm': 60 * 1000000,
-        #                   's': 1000000,
-        #                   'us': 1}
-
-        def timedelta64(*args):
-            return sum(starmap(np.timedelta64, zip(args, intervals)))
-
-        for d, h, m, s, us in product(*([range(2)] * 5)):
-            nptd = timedelta64(d, h, m, s, us)
-            pytd = timedelta(days=d, hours=h, minutes=m, seconds=s,
-                             microseconds=us)
-            lhs = op(ser, nptd)
-            rhs = op(ser, pytd)
-
-            assert_series_equal(lhs, rhs)
-
-    def test_ops_nat_mixed_datetime64_timedelta64(self):
-        # GH 11349
-        timedelta_series = Series([NaT, Timedelta('1s')])
-        datetime_series = Series([NaT, Timestamp('19900315')])
-        nat_series_dtype_timedelta = Series([NaT, NaT],
-                                            dtype='timedelta64[ns]')
-        nat_series_dtype_timestamp = Series([NaT, NaT], dtype='datetime64[ns]')
-        single_nat_dtype_datetime = Series([NaT], dtype='datetime64[ns]')
-        single_nat_dtype_timedelta = Series([NaT], dtype='timedelta64[ns]')
-
-        # subtraction
-        assert_series_equal(datetime_series - single_nat_dtype_datetime,
-                            nat_series_dtype_timedelta)
-
-        assert_series_equal(datetime_series - single_nat_dtype_timedelta,
-                            nat_series_dtype_timestamp)
-        assert_series_equal(-single_nat_dtype_timedelta + datetime_series,
-                            nat_series_dtype_timestamp)
-
-        # without a Series wrapping the NaT, it is ambiguous
-        # whether it is a datetime64 or timedelta64
-        # defaults to interpreting it as timedelta64
-        assert_series_equal(nat_series_dtype_timestamp -
-                            single_nat_dtype_datetime,
-                            nat_series_dtype_timedelta)
-
-        assert_series_equal(nat_series_dtype_timestamp -
-                            single_nat_dtype_timedelta,
-                            nat_series_dtype_timestamp)
-        assert_series_equal(-single_nat_dtype_timedelta +
-                            nat_series_dtype_timestamp,
-                            nat_series_dtype_timestamp)
-
-        with pytest.raises(TypeError):
-            timedelta_series - single_nat_dtype_datetime
-
-        # addition
-        assert_series_equal(nat_series_dtype_timestamp +
-                            single_nat_dtype_timedelta,
-                            nat_series_dtype_timestamp)
-        assert_series_equal(single_nat_dtype_timedelta +
-                            nat_series_dtype_timestamp,
-                            nat_series_dtype_timestamp)
-
-        assert_series_equal(nat_series_dtype_timestamp +
-                            single_nat_dtype_timedelta,
-                            nat_series_dtype_timestamp)
-        assert_series_equal(single_nat_dtype_timedelta +
-                            nat_series_dtype_timestamp,
-                            nat_series_dtype_timestamp)
-
-        assert_series_equal(nat_series_dtype_timedelta +
-                            single_nat_dtype_datetime,
-                            nat_series_dtype_timestamp)
-        assert_series_equal(single_nat_dtype_datetime +
-                            nat_series_dtype_timedelta,
-                            nat_series_dtype_timestamp)
 
     def test_ops_datetimelike_align(self):
         # GH 7500
@@ -1136,16 +806,6 @@ class TestSeriesOperators(TestData):
                           index=self.ts.index[:-5], name='ts')
         tm.assert_series_equal(added[:-5], expected)
 
-    @pytest.mark.parametrize('op', [operator.add, operator.sub, operator.mul,
-                                    operator.truediv, operator.floordiv])
-    def test_operators_reverse_object(self, op):
-        # GH 56
-        arr = Series(np.random.randn(10), index=np.arange(10), dtype=object)
-
-        result = op(1., arr)
-        expected = op(1., arr.astype(float))
-        assert_series_equal(result.astype(float), expected)
-
     pairings = []
     for op in ['add', 'sub', 'mul', 'pow', 'truediv', 'floordiv']:
         fv = 0
@@ -1214,41 +874,6 @@ class TestSeriesOperators(TestData):
         assert isna(result[0])
         assert isna(result2[0])
 
-        s = Series(['foo', 'bar', 'baz', np.nan])
-        result = 'prefix_' + s
-        expected = Series(['prefix_foo', 'prefix_bar', 'prefix_baz', np.nan])
-        assert_series_equal(result, expected)
-
-        result = s + '_suffix'
-        expected = Series(['foo_suffix', 'bar_suffix', 'baz_suffix', np.nan])
-        assert_series_equal(result, expected)
-
-    def test_datetime64_with_index(self):
-        # arithmetic integer ops with an index
-        ser = Series(np.random.randn(5))
-        expected = ser - ser.index.to_series()
-        result = ser - ser.index
-        assert_series_equal(result, expected)
-
-        # GH 4629
-        # arithmetic datetime64 ops with an index
-        ser = Series(date_range('20130101', periods=5),
-                     index=date_range('20130101', periods=5))
-        expected = ser - ser.index.to_series()
-        result = ser - ser.index
-        assert_series_equal(result, expected)
-
-        with pytest.raises(TypeError):
-            # GH#18850
-            result = ser - ser.index.to_period()
-
-        df = DataFrame(np.random.randn(5, 2),
-                       index=date_range('20130101', periods=5))
-        df['date'] = Timestamp('20130102')
-        df['expected'] = df['date'] - df.index.to_series()
-        df['result'] = df['date'] - df.index
-        assert_series_equal(df['result'], df['expected'], check_names=False)
-
     def test_op_duplicate_index(self):
         # GH14227
         s1 = Series([1, 2], index=[1, 1])
@@ -1306,43 +931,6 @@ class TestSeriesOperators(TestData):
 
 
 class TestSeriesOperationsDataFrameCompat(object):
-    def test_operators_frame(self):
-        # rpow does not work with DataFrame
-        ts = tm.makeTimeSeries()
-        ts.name = 'ts'
-
-        df = DataFrame({'A': ts})
-
-        assert_series_equal(ts + ts, ts + df['A'],
-                            check_names=False)
-        assert_series_equal(ts ** ts, ts ** df['A'],
-                            check_names=False)
-        assert_series_equal(ts < ts, ts < df['A'],
-                            check_names=False)
-        assert_series_equal(ts / ts, ts / df['A'],
-                            check_names=False)
-
-    def test_series_frame_radd_bug(self):
-        # GH#353
-        vals = Series(tm.rands_array(5, 10))
-        result = 'foo_' + vals
-        expected = vals.map(lambda x: 'foo_' + x)
-        assert_series_equal(result, expected)
-
-        frame = DataFrame({'vals': vals})
-        result = 'foo_' + frame
-        expected = DataFrame({'vals': vals.map(lambda x: 'foo_' + x)})
-        assert_frame_equal(result, expected)
-
-        ts = tm.makeTimeSeries()
-        ts.name = 'ts'
-
-        # really raise this time
-        with pytest.raises(TypeError):
-            datetime.now() + ts
-
-        with pytest.raises(TypeError):
-            ts + datetime.now()
 
     def test_bool_ops_df_compat(self):
         # GH 1134
@@ -1401,32 +989,3 @@ class TestSeriesOperationsDataFrameCompat(object):
                            index=list('ABCD'))
         assert_frame_equal(s3.to_frame() | s4.to_frame(), exp)
         assert_frame_equal(s4.to_frame() | s3.to_frame(), exp)
-
-    def test_arith_ops_df_compat(self):
-        # GH#1134
-        s1 = pd.Series([1, 2, 3], index=list('ABC'), name='x')
-        s2 = pd.Series([2, 2, 2], index=list('ABD'), name='x')
-
-        exp = pd.Series([3.0, 4.0, np.nan, np.nan],
-                        index=list('ABCD'), name='x')
-        assert_series_equal(s1 + s2, exp)
-        assert_series_equal(s2 + s1, exp)
-
-        exp = pd.DataFrame({'x': [3.0, 4.0, np.nan, np.nan]},
-                           index=list('ABCD'))
-        assert_frame_equal(s1.to_frame() + s2.to_frame(), exp)
-        assert_frame_equal(s2.to_frame() + s1.to_frame(), exp)
-
-        # different length
-        s3 = pd.Series([1, 2, 3], index=list('ABC'), name='x')
-        s4 = pd.Series([2, 2, 2, 2], index=list('ABCD'), name='x')
-
-        exp = pd.Series([3, 4, 5, np.nan],
-                        index=list('ABCD'), name='x')
-        assert_series_equal(s3 + s4, exp)
-        assert_series_equal(s4 + s3, exp)
-
-        exp = pd.DataFrame({'x': [3, 4, 5, np.nan]},
-                           index=list('ABCD'))
-        assert_frame_equal(s3.to_frame() + s4.to_frame(), exp)
-        assert_frame_equal(s4.to_frame() + s3.to_frame(), exp)


### PR DESCRIPTION
A small amount of cleanup/parametrization, but mostly moving tests ~unchanged.

A few tests in tests.frame.test_operators are moved to tests.frame.test_arithmetic.

In a bunch of cases I'm trying to not move things that will cause merge conflicts with #22163; will get those in an upcoming pass.