### PR TITLE
Remove unused param/method

### DIFF
--- a/ci/print_skipped.py
+++ b/ci/print_skipped.py
@@ -10,7 +10,7 @@ def parse_results(filename):
     root = tree.getroot()
     skipped = []
 
-    current_class = old_class = ''
+    current_class = ''
     i = 1
     assert i - 1 == len(skipped)
     for el in root.findall('testcase'):
@@ -24,7 +24,8 @@ def parse_results(filename):
             out = ''
             if old_class != current_class:
                 ndigits = int(math.log(i, 10) + 1)
-                out += ('-' * (len(name + msg) + 4 + ndigits) + '\n') # 4 for : + space + # + space
+                #  4 for : + space + # + space
+                out += ('-' * (len(name + msg) + 4 + ndigits) + '\n')
             out += '#{i} {name}: {msg}'.format(i=i, name=name, msg=msg)
             skipped.append(out)
             i += 1

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -4695,7 +4695,7 @@ class Index(IndexOpsMixin, PandasObject):
         """ Update Index attributes (e.g. freq) depending on op """
         return attrs
 
-    def _validate_for_numeric_unaryop(self, op, opstr):
+    def _validate_for_numeric_unaryop(self, opstr):
         """ validate if we can perform a numeric unary operation """
 
         if not self._is_numeric_dtype:
@@ -4776,7 +4776,7 @@ class Index(IndexOpsMixin, PandasObject):
 
             def _evaluate_numeric_unary(self):
 
-                self._validate_for_numeric_unaryop(op, opstr)
+                self._validate_for_numeric_unaryop(opstr)
                 attrs = self._get_attributes_dict()
                 attrs = self._maybe_update_attributes(attrs)
                 return Index(op(self.values), **attrs)

--- a/pandas/core/indexes/datetimes.py
+++ b/pandas/core/indexes/datetimes.py
@@ -1815,11 +1815,6 @@ def cdate_range(start=None, end=None, periods=None, freq='C', tz=None,
         Normalize start/end dates to midnight before generating date range
     name : string, default None
         Name of the resulting DatetimeIndex
-    weekmask : string, Default 'Mon Tue Wed Thu Fri'
-        weekmask of valid business days, passed to ``numpy.busdaycalendar``
-    holidays : list
-        list/array of dates to exclude from the set of valid business days,
-        passed to ``numpy.busdaycalendar``
     closed : string, default None
         Make the interval closed with respect to the given frequency to
         the 'left', 'right', or both sides (None)

--- a/pandas/core/indexes/multi.py
+++ b/pandas/core/indexes/multi.py
@@ -752,11 +752,6 @@ class MultiIndex(Index):
     def inferred_type(self):
         return 'mixed'
 
-    @staticmethod
-    def _from_elements(values, labels=None, levels=None, names=None,
-                       sortorder=None):
-        return MultiIndex(levels, labels, names, sortorder=sortorder)
-
     def _get_level_number(self, level):
         count = self.names.count(level)
         if (count > 1) and not is_integer(level):


### PR DESCRIPTION
- [y] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`

-Remove unused param "op" in `_validate_for_numeric_unaryop`. ( Param remove from single call of function)

-Static method `_from_element` appears to be unused
