### PR TITLE
DOC/DEPR: clarify argmin/argmax deprecation message

### DIFF
--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -1807,7 +1807,8 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
     argmin = deprecate(
         'argmin', idxmin, '0.21.0',
         msg=dedent("""\
-        the behaviour of 'Series.argmin' is deprecated, use 'idxmin' instead.
+        The current behaviour of 'Series.argmin' is deprecated, use 'idxmin'
+        instead.
         The behavior of 'argmin' will be corrected to return the positional
         minimum in the future. For now, use 'series.values.argmin' or
         'np.argmin(np.array(values))' to get the position of the minimum
@@ -1816,7 +1817,8 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
     argmax = deprecate(
         'argmax', idxmax, '0.21.0',
         msg=dedent("""\
-        the behaviour of 'Series.argmax' is deprecated, use 'idxmax' instead.
+        The current behaviour of 'Series.argmax' is deprecated, use 'idxmax'
+        instead.
         The behavior of 'argmax' will be corrected to return the positional
         maximum in the future. For now, use 'series.values.argmax' or
         'np.argmax(np.array(values))' to get the position of the maximum

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -1807,16 +1807,20 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
     argmin = deprecate(
         'argmin', idxmin, '0.21.0',
         msg=dedent("""\
-        'argmin' is deprecated, use 'idxmin' instead. The behavior of 'argmin'
-        will be corrected to return the positional minimum in the future.
-        Use 'series.values.argmin' to get the position of the minimum row.""")
+        the behaviour of 'Series.argmin' is deprecated, use 'idxmin' instead.
+        The behavior of 'argmin' will be corrected to return the positional
+        minimum in the future. For now, use 'series.values.argmin' or
+        'np.argmin(np.array(values))' to get the position of the minimum
+        row.""")
     )
     argmax = deprecate(
         'argmax', idxmax, '0.21.0',
         msg=dedent("""\
-        'argmax' is deprecated, use 'idxmax' instead. The behavior of 'argmax'
-        will be corrected to return the positional maximum in the future.
-        Use 'series.values.argmax' to get the position of the maximum row.""")
+        the behaviour of 'Series.argmax' is deprecated, use 'idxmax' instead.
+        The behavior of 'argmax' will be corrected to return the positional
+        maximum in the future. For now, use 'series.values.argmax' or
+        'np.argmax(np.array(values))' to get the position of the maximum
+        row.""")
     )
 
     def round(self, decimals=0, *args, **kwargs):


### PR DESCRIPTION
Attempt to better phrase the message, xref https://github.com/pandas-dev/pandas/issues/16830#issuecomment-412211029