### PR TITLE
CLN: Remove unused method

### DIFF
--- a/pandas/core/indexes/multi.py
+++ b/pandas/core/indexes/multi.py
@@ -752,11 +752,6 @@ class MultiIndex(Index):
     def inferred_type(self):
         return 'mixed'
 
-    @staticmethod
-    def _from_elements(values, labels=None, levels=None, names=None,
-                       sortorder=None):
-        return MultiIndex(levels, labels, names, sortorder=sortorder)
-
     def _get_level_number(self, level):
         count = self.names.count(level)
         if (count > 1) and not is_integer(level):


### PR DESCRIPTION
- [y] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`

This method isn't used anywhere in the codebase, good to delete?