### PR TITLE
CLN: Remove variable assignment on CI script

### DIFF
--- a/ci/print_skipped.py
+++ b/ci/print_skipped.py
@@ -24,7 +24,9 @@ def parse_results(filename):
             out = ''
             if old_class != current_class:
                 ndigits = int(math.log(i, 10) + 1)
-                out += ('-' * (len(name + msg) + 4 + ndigits) + '\n')  # 4 for : + space + # + space
+
+                # 4 for : + space + # + space
+                out += ('-' * (len(name + msg) + 4 + ndigits) + '\n')
             out += '#{i} {name}: {msg}'.format(i=i, name=name, msg=msg)
             skipped.append(out)
             i += 1

--- a/ci/print_skipped.py
+++ b/ci/print_skipped.py
@@ -10,7 +10,7 @@ def parse_results(filename):
     root = tree.getroot()
     skipped = []
 
-    current_class = old_class = ''
+    current_class = ''
     i = 1
     assert i - 1 == len(skipped)
     for el in root.findall('testcase'):
@@ -24,7 +24,7 @@ def parse_results(filename):
             out = ''
             if old_class != current_class:
                 ndigits = int(math.log(i, 10) + 1)
-                out += ('-' * (len(name + msg) + 4 + ndigits) + '\n') # 4 for : + space + # + space
+                out += ('-' * (len(name + msg) + 4 + ndigits) + '\n')  # 4 for : + space + # + space
             out += '#{i} {name}: {msg}'.format(i=i, name=name, msg=msg)
             skipped.append(out)
             i += 1


### PR DESCRIPTION
Looks to me like this variable assignment is not required since on line 19 `old_class = current_class`