### PR TITLE
CLN: Remove deprecated method

### DIFF
--- a/doc/source/timeseries.rst
+++ b/doc/source/timeseries.rst
@@ -426,10 +426,11 @@ Custom Frequency Ranges
 .. warning::
 
    This functionality was originally exclusive to ``cdate_range``, which is
-   deprecated as of version 0.21.0 in favor of ``bdate_range``.  Note that
-   ``cdate_range`` only utilizes the ``weekmask`` and ``holidays`` parameters
-   when custom business day, 'C', is passed as the frequency string. Support has 
-   been expanded with ``bdate_range`` to work with any custom frequency string.
+   deprecated as of version 0.21.0 (deleted in 0.24.0) in favor of
+   ``bdate_range``. Note that ``cdate_range`` only utilizes the ``weekmask``
+   and ``holidays`` parameters when custom business day, 'C', is passed
+   as the frequency string. Support has been expanded with ``bdate_range``
+   to work with any custom frequency string.
 
 .. versionadded:: 0.21.0
 

--- a/doc/source/timeseries.rst
+++ b/doc/source/timeseries.rst
@@ -423,15 +423,6 @@ resulting ``DatetimeIndex``:
 Custom Frequency Ranges
 ~~~~~~~~~~~~~~~~~~~~~~~
 
-.. warning::
-
-   This functionality was originally exclusive to ``cdate_range``, which is
-   deprecated as of version 0.21.0 (deleted in 0.24.0) in favor of
-   ``bdate_range``. Note that ``cdate_range`` only utilizes the ``weekmask``
-   and ``holidays`` parameters when custom business day, 'C', is passed
-   as the frequency string. Support has been expanded with ``bdate_range``
-   to work with any custom frequency string.
-
 .. versionadded:: 0.21.0
 
 ``bdate_range`` can also generate a range of custom frequency dates by using

--- a/pandas/core/indexes/datetimes.py
+++ b/pandas/core/indexes/datetimes.py
@@ -1790,60 +1790,6 @@ def bdate_range(start=None, end=None, periods=None, freq='B', tz=None,
                          closed=closed, **kwargs)
 
 
-def cdate_range(start=None, end=None, periods=None, freq='C', tz=None,
-                normalize=True, name=None, closed=None, **kwargs):
-    """
-    Return a fixed frequency DatetimeIndex, with CustomBusinessDay as the
-    default frequency
-
-    .. deprecated:: 0.21.0
-
-    Parameters
-    ----------
-    start : string or datetime-like, default None
-        Left bound for generating dates
-    end : string or datetime-like, default None
-        Right bound for generating dates
-    periods : integer, default None
-        Number of periods to generate
-    freq : string or DateOffset, default 'C' (CustomBusinessDay)
-        Frequency strings can have multiples, e.g. '5H'
-    tz : string, default None
-        Time zone name for returning localized DatetimeIndex, for example
-        Asia/Beijing
-    normalize : bool, default False
-        Normalize start/end dates to midnight before generating date range
-    name : string, default None
-        Name of the resulting DatetimeIndex
-    closed : string, default None
-        Make the interval closed with respect to the given frequency to
-        the 'left', 'right', or both sides (None)
-
-    Notes
-    -----
-    Of the three parameters: ``start``, ``end``, and ``periods``, exactly two
-    must be specified.
-
-    To learn more about the frequency strings, please see `this link
-    <http://pandas.pydata.org/pandas-docs/stable/timeseries.html#offset-aliases>`__.
-
-    Returns
-    -------
-    rng : DatetimeIndex
-    """
-    warnings.warn("cdate_range is deprecated and will be removed in a future "
-                  "version, instead use pd.bdate_range(..., freq='{freq}')"
-                  .format(freq=freq), FutureWarning, stacklevel=2)
-
-    if freq == 'C':
-        holidays = kwargs.pop('holidays', [])
-        weekmask = kwargs.pop('weekmask', 'Mon Tue Wed Thu Fri')
-        freq = CDay(holidays=holidays, weekmask=weekmask)
-    return DatetimeIndex(start=start, end=end, periods=periods, freq=freq,
-                         tz=tz, normalize=normalize, name=name,
-                         closed=closed, **kwargs)
-
-
 _CACHE_START = Timestamp(datetime(1950, 1, 1))
 _CACHE_END = Timestamp(datetime(2030, 1, 1))
 

--- a/pandas/core/indexes/datetimes.py
+++ b/pandas/core/indexes/datetimes.py
@@ -1815,11 +1815,6 @@ def cdate_range(start=None, end=None, periods=None, freq='C', tz=None,
         Normalize start/end dates to midnight before generating date range
     name : string, default None
         Name of the resulting DatetimeIndex
-    weekmask : string, Default 'Mon Tue Wed Thu Fri'
-        weekmask of valid business days, passed to ``numpy.busdaycalendar``
-    holidays : list
-        list/array of dates to exclude from the set of valid business days,
-        passed to ``numpy.busdaycalendar``
     closed : string, default None
         Make the interval closed with respect to the given frequency to
         the 'left', 'right', or both sides (None)

--- a/pandas/tests/api/test_api.py
+++ b/pandas/tests/api/test_api.py
@@ -215,16 +215,6 @@ class TestTypes(object):
                 ignore_order=True)
 
 
-class TestCDateRange(object):
-
-    def test_deprecation_cdaterange(self):
-        # GH17596
-        from pandas.core.indexes.datetimes import cdate_range
-        with tm.assert_produces_warning(FutureWarning,
-                                        check_stacklevel=False):
-            cdate_range('2017-01-01', '2017-12-31')
-
-
 class TestCategoricalMove(object):
 
     def test_categorical_move(self):


### PR DESCRIPTION
These params are no longer in the method, therefore can remove the docs strings
