### PR TITLE
CLN: remove Index.__inv__ , add Index.__invert__

### DIFF
--- a/doc/source/whatsnew/v0.24.0.txt
+++ b/doc/source/whatsnew/v0.24.0.txt
@@ -614,6 +614,8 @@ Indexing
 - Fixed ``DataFrame[np.nan]`` when columns are non-unique (:issue:`21428`)
 - Bug when indexing :class:`DatetimeIndex` with nanosecond resolution dates and timezones (:issue:`11679`)
 - Bug where indexing with a Numpy array containing negative values would mutate the indexer (:issue:`21867`)
+- Method :meth:`Index.__inv__` was suppressed, as it provided the same functionality as :meth:`Index.__neg__` rather than what its name suggested; :meth:`Index.__invert__` was added instead, and the ``~`` operator now works (analogously as for :class:`Series`) (:issue:`21688`)
+-
 
 Missing
 ^^^^^^^
@@ -686,6 +688,5 @@ Other
 - :meth: `~pandas.io.formats.style.Styler.background_gradient` now takes a ``text_color_threshold`` parameter to automatically lighten the text color based on the luminance of the background color. This improves readability with dark background colors without the need to limit the background colormap range. (:issue:`21258`)
 - Require at least 0.28.2 version of ``cython`` to support read-only memoryviews (:issue:`21688`)
 - :meth: `~pandas.io.formats.style.Styler.background_gradient` now also supports tablewise application (in addition to rowwise and columnwise) with ``axis=None`` (:issue:`15204`)
--
 -
 -

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -4689,7 +4689,7 @@ class Index(IndexOpsMixin, PandasObject):
         cls.__neg__ = make_invalid_op('__neg__')
         cls.__pos__ = make_invalid_op('__pos__')
         cls.__abs__ = make_invalid_op('__abs__')
-        cls.__inv__ = make_invalid_op('__inv__')
+        cls.__invert__ = make_invalid_op('__invert__')
 
     def _maybe_update_attributes(self, attrs):
         """ Update Index attributes (e.g. freq) depending on op """
@@ -4786,7 +4786,7 @@ class Index(IndexOpsMixin, PandasObject):
         cls.__neg__ = _make_evaluate_unary(operator.neg, '__neg__')
         cls.__pos__ = _make_evaluate_unary(operator.pos, '__pos__')
         cls.__abs__ = _make_evaluate_unary(np.abs, '__abs__')
-        cls.__inv__ = _make_evaluate_unary(lambda x: -x, '__inv__')
+        cls.__invert__ = _make_evaluate_unary(np.invert, '__invert__')
 
     @classmethod
     def _add_numeric_methods(cls):


### PR DESCRIPTION
- [x] closes #22335
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry

@jreback @jorisvandenbossche suggestions on where to put a test (``pandas/tests/test_arithmetic.py`` would seem the right place, except it only contains tests involving datetimelike) and which version to target (not sure 0.23.5 is OK)?