### PR TITLE
API: dispatch to EA.astype

### DIFF
--- a/doc/source/whatsnew/v0.24.0.txt
+++ b/doc/source/whatsnew/v0.24.0.txt
@@ -446,7 +446,7 @@ ExtensionType Changes
 - Bug in :meth:`Series.get` for ``Series`` using ``ExtensionArray`` and integer index (:issue:`21257`)
 - :meth:`Series.combine()` works correctly with :class:`~pandas.api.extensions.ExtensionArray` inside of :class:`Series` (:issue:`20825`)
 - :meth:`Series.combine()` with scalar argument now works for any function type (:issue:`21248`)
--
+- :meth:`Series.astype` and :meth:`DataFrame.astype` now dispatch to :meth:`ExtensionArray.astype` (:issue:`21185:`).
 
 .. _whatsnew_0240.api.incompatibilities:
 

--- a/pandas/core/arrays/integer.py
+++ b/pandas/core/arrays/integer.py
@@ -8,6 +8,7 @@ from pandas.util._decorators import cache_readonly
 from pandas.compat import u, range
 from pandas.compat import set_function_name
 
+from pandas.core.dtypes.cast import astype_nansafe
 from pandas.core.dtypes.generic import ABCSeries, ABCIndexClass
 from pandas.core.dtypes.common import (
     is_integer, is_scalar, is_float,
@@ -391,7 +392,7 @@ class IntegerArray(ExtensionArray, ExtensionOpsMixin):
 
         # coerce
         data = self._coerce_to_ndarray()
-        return data.astype(dtype=dtype, copy=False)
+        return astype_nansafe(data, dtype, copy=None)
 
     @property
     def _ndarray_values(self):

--- a/pandas/core/dtypes/cast.py
+++ b/pandas/core/dtypes/cast.py
@@ -647,7 +647,17 @@ def coerce_to_dtypes(result, dtypes):
 
 def astype_nansafe(arr, dtype, copy=True):
     """ return a view if copy is False, but
-        need to be very careful as the result shape could change! """
+        need to be very careful as the result shape could change!
+
+    Parameters
+    ----------
+    arr : ndarray
+    dtype : np.dtype
+    copy : bool or None, default True
+        Whether to copy during the `.astype` (True) or
+        just return a view (False). Passing `copy=None` will
+        attempt to return a view, but will copy if necessary.
+    """
 
     # dispatch on extension dtype if needed
     if is_extension_array_dtype(dtype):
@@ -735,7 +745,16 @@ def astype_nansafe(arr, dtype, copy=True):
 
     if copy:
         return arr.astype(dtype, copy=True)
-    return arr.view(dtype)
+    else:
+        try:
+            return arr.view(dtype)
+        except TypeError:
+            if copy is None:
+                # allowed to copy if necessary (e.g. object)
+                return arr.astype(dtype, copy=True)
+            else:
+                raise
+
 
 
 def maybe_convert_objects(values, convert_dates=True, convert_numeric=True,

--- a/pandas/core/dtypes/cast.py
+++ b/pandas/core/dtypes/cast.py
@@ -653,10 +653,6 @@ def astype_nansafe(arr, dtype, copy=True):
     ----------
     arr : ndarray
     dtype : np.dtype
-    copy : bool or None, default True
-        Whether to copy during the `.astype` (True) or
-        just return a view (False). Passing `copy=None` will
-        attempt to return a view, but will copy if necessary.
     """
 
     # dispatch on extension dtype if needed
@@ -745,15 +741,7 @@ def astype_nansafe(arr, dtype, copy=True):
 
     if copy:
         return arr.astype(dtype, copy=True)
-    else:
-        try:
-            return arr.view(dtype)
-        except TypeError:
-            if copy is None:
-                # allowed to copy if necessary (e.g. object)
-                return arr.astype(dtype, copy=True)
-            else:
-                raise
+    return arr.view(dtype)
 
 
 def maybe_convert_objects(values, convert_dates=True, convert_numeric=True,

--- a/pandas/core/dtypes/cast.py
+++ b/pandas/core/dtypes/cast.py
@@ -653,6 +653,7 @@ def astype_nansafe(arr, dtype, copy=True):
     ----------
     arr : ndarray
     dtype : np.dtype
+    copy : bool, default True
     """
 
     # dispatch on extension dtype if needed

--- a/pandas/core/dtypes/cast.py
+++ b/pandas/core/dtypes/cast.py
@@ -654,6 +654,8 @@ def astype_nansafe(arr, dtype, copy=True):
     arr : ndarray
     dtype : np.dtype
     copy : bool, default True
+        If False, a view will be attempted but may fail, if
+        e.g. the itemsizes don't align.
     """
 
     # dispatch on extension dtype if needed

--- a/pandas/core/dtypes/cast.py
+++ b/pandas/core/dtypes/cast.py
@@ -739,8 +739,10 @@ def astype_nansafe(arr, dtype, copy=True):
                       FutureWarning, stacklevel=5)
         dtype = np.dtype(dtype.name + "[ns]")
 
-    if copy:
+    if copy or is_object_dtype(arr) or is_object_dtype(dtype):
+        # Explicit copy, or required since NumPy can't view from / to object.
         return arr.astype(dtype, copy=True)
+
     return arr.view(dtype)
 
 

--- a/pandas/core/dtypes/cast.py
+++ b/pandas/core/dtypes/cast.py
@@ -756,7 +756,6 @@ def astype_nansafe(arr, dtype, copy=True):
                 raise
 
 
-
 def maybe_convert_objects(values, convert_dates=True, convert_numeric=True,
                           convert_timedeltas=True, copy=True):
     """ if we have an object dtype, try to coerce dates and/or numbers """

--- a/pandas/core/internals/blocks.py
+++ b/pandas/core/internals/blocks.py
@@ -637,22 +637,25 @@ class Block(PandasObject):
             # force the copy here
             if values is None:
 
-                if issubclass(dtype.type,
-                              (compat.text_type, compat.string_types)):
-
-                    # use native type formatting for datetime/tz/timedelta
-                    if self.is_datelike:
-                        values = self.to_native_types()
-
-                    # astype formatting
-                    else:
-                        values = self.get_values()
-
+                if self.is_extension:
+                    values = self.values.astype(dtype)
                 else:
-                    values = self.get_values(dtype=dtype)
+                    if issubclass(dtype.type,
+                                  (compat.text_type, compat.string_types)):
 
-                # _astype_nansafe works fine with 1-d only
-                values = astype_nansafe(values.ravel(), dtype, copy=True)
+                        # use native type formatting for datetime/tz/timedelta
+                        if self.is_datelike:
+                            values = self.to_native_types()
+
+                        # astype formatting
+                        else:
+                            values = self.get_values()
+
+                    else:
+                        values = self.get_values(dtype=dtype)
+
+                    # _astype_nansafe works fine with 1-d only
+                    values = astype_nansafe(values.ravel(), dtype, copy=True)
 
                 # TODO(extension)
                 # should we make this attribute?

--- a/pandas/tests/extension/decimal/array.py
+++ b/pandas/tests/extension/decimal/array.py
@@ -15,6 +15,17 @@ class DecimalDtype(ExtensionDtype):
     name = 'decimal'
     na_value = decimal.Decimal('NaN')
 
+    def __init__(self, context=None):
+        self.context = context or decimal.getcontext()
+
+    def __eq__(self, other):
+        if isinstance(other, type(self)):
+            return self.context == other.context
+        return super(DecimalDtype, self).__eq__(other)
+
+    def __repr__(self):
+        return 'DecimalDtype(context={})'.format(self.context)
+
     @classmethod
     def construct_array_type(cls):
         """Return the array type associated with this dtype
@@ -35,13 +46,12 @@ class DecimalDtype(ExtensionDtype):
 
 
 class DecimalArray(ExtensionArray, ExtensionScalarOpsMixin):
-    dtype = DecimalDtype()
 
-    def __init__(self, values, dtype=None, copy=False):
+    def __init__(self, values, dtype=None, copy=False, context=None):
         for val in values:
-            if not isinstance(val, self.dtype.type):
+            if not isinstance(val, decimal.Decimal):
                 raise TypeError("All values must be of type " +
-                                str(self.dtype.type))
+                                str(decimal.Decimal))
         values = np.asarray(values, dtype=object)
 
         self._data = values
@@ -51,6 +61,11 @@ class DecimalArray(ExtensionArray, ExtensionScalarOpsMixin):
         # those aliases are currently not working due to assumptions
         # in internal code (GH-20735)
         # self._values = self.values = self.data
+        self._dtype = DecimalDtype(context)
+
+    @property
+    def dtype(self):
+        return self._dtype
 
     @classmethod
     def _from_sequence(cls, scalars, dtype=None, copy=False):
@@ -81,6 +96,11 @@ class DecimalArray(ExtensionArray, ExtensionScalarOpsMixin):
         if deep:
             return type(self)(self._data.copy())
         return type(self)(self)
+
+    def astype(self, dtype, copy=True):
+        if isinstance(dtype, type(self.dtype)):
+            return type(self)(self._data, context=dtype.context)
+        return super().astype(dtype, copy)
 
     def __setitem__(self, key, value):
         if pd.api.types.is_list_like(value):

--- a/pandas/tests/extension/decimal/array.py
+++ b/pandas/tests/extension/decimal/array.py
@@ -100,7 +100,7 @@ class DecimalArray(ExtensionArray, ExtensionScalarOpsMixin):
     def astype(self, dtype, copy=True):
         if isinstance(dtype, type(self.dtype)):
             return type(self)(self._data, context=dtype.context)
-        return super().astype(dtype, copy)
+        return super(DecimalArray, self).astype(dtype, copy)
 
     def __setitem__(self, key, value):
         if pd.api.types.is_list_like(value):

--- a/pandas/tests/extension/decimal/test_decimal.py
+++ b/pandas/tests/extension/decimal/test_decimal.py
@@ -226,7 +226,6 @@ def test_astype_dispatches(frame):
     assert result.dtype.context.prec == ctx.prec
 
 
-
 class TestArithmeticOps(BaseDecimal, base.BaseArithmeticOpsTests):
 
     def check_opname(self, s, op_name, other, exc=None):

--- a/pandas/tests/extension/decimal/test_decimal.py
+++ b/pandas/tests/extension/decimal/test_decimal.py
@@ -207,6 +207,10 @@ def test_dataframe_constructor_with_dtype():
 
 @pytest.mark.parametrize("frame", [True, False])
 def test_astype_dispatches(frame):
+    # This is a dtype-specific test that ensures Series[decimal].astype
+    # gets all the way through to ExtensionArray.astype
+    # Designing a reliable smoke test that works for arbitrary data types
+    # is difficult.
     data = pd.Series(DecimalArray([decimal.Decimal(2)]), name='a')
     ctx = decimal.Context()
     ctx.prec = 5

--- a/pandas/tests/extension/decimal/test_decimal.py
+++ b/pandas/tests/extension/decimal/test_decimal.py
@@ -205,6 +205,24 @@ def test_dataframe_constructor_with_dtype():
     tm.assert_frame_equal(result, expected)
 
 
+@pytest.mark.parametrize("frame", [True, False])
+def test_astype_dispatches(frame):
+    data = pd.Series(DecimalArray([decimal.Decimal(2)]), name='a')
+    ctx = decimal.Context()
+    ctx.prec = 5
+
+    if frame:
+        data = data.to_frame()
+
+    result = data.astype(DecimalDtype(ctx))
+
+    if frame:
+        result = result['a']
+
+    assert result.dtype.context.prec == ctx.prec
+
+
+
 class TestArithmeticOps(BaseDecimal, base.BaseArithmeticOpsTests):
 
     def check_opname(self, s, op_name, other, exc=None):

--- a/pandas/tests/extension/integer/test_integer.py
+++ b/pandas/tests/extension/integer/test_integer.py
@@ -567,6 +567,14 @@ class TestCasting(BaseInteger, base.BaseCastingTests):
         expected = pd.Series(np.asarray(mixed))
         tm.assert_series_equal(result, expected)
 
+    def test_astype_nansafe(self):
+        # https://github.com/pandas-dev/pandas/pull/22343
+        arr = IntegerArray([np.nan, 1, 2], dtype="Int8")
+
+        with tm.assert_raises_regex(
+                ValueError, 'cannot convert float NaN to integer'):
+            arr.astype('uint32')
+
     @pytest.mark.parametrize('dtype', [Int8Dtype(), 'Int8'])
     def test_astype_specific_casting(self, dtype):
         s = pd.Series([1, 2, 3], dtype='Int64')

--- a/pandas/tests/extension/integer/test_integer.py
+++ b/pandas/tests/extension/integer/test_integer.py
@@ -567,14 +567,6 @@ class TestCasting(BaseInteger, base.BaseCastingTests):
         expected = pd.Series(np.asarray(mixed))
         tm.assert_series_equal(result, expected)
 
-    def test_astype_nansafe(self):
-        # https://github.com/pandas-dev/pandas/pull/22343
-        arr = IntegerArray([np.nan, 1, 2], dtype="Int8")
-
-        with tm.assert_raises_regex(
-                ValueError, 'cannot convert float NaN to integer'):
-            arr.astype('uint32')
-
     @pytest.mark.parametrize('dtype', [Int8Dtype(), 'Int8'])
     def test_astype_specific_casting(self, dtype):
         s = pd.Series([1, 2, 3], dtype='Int64')
@@ -703,6 +695,15 @@ def test_cross_type_arithmetic():
     result = df.A + df.B
     expected = pd.Series([2, np.nan, np.nan], dtype='Int64')
     tm.assert_series_equal(result, expected)
+
+
+def test_astype_nansafe():
+    # https://github.com/pandas-dev/pandas/pull/22343
+    arr = IntegerArray([np.nan, 1, 2], dtype="Int8")
+
+    with tm.assert_raises_regex(
+            ValueError, 'cannot convert float NaN to integer'):
+        arr.astype('uint32')
 
 
 # TODO(jreback) - these need testing / are broken


### PR DESCRIPTION
Closes https://github.com/pandas-dev/pandas/issues/21296

split from https://github.com/pandas-dev/pandas/pull/22325

Note that this is just a partial fix to get sparse working. We have some issues:

for better or worse, categorical is still special cased. `Series[EA].astype('category')` will not yet dispatch to `EA.astype`. That's good non-pandas EAs won't have to worry about specially handling categorical. It's bad, since it's a special case.

And that's the second issue, in general, how should we handle astyping from EA1 -> EA2? In principle, we always have `ndarray[object]` as the lowest common denominator. So something like `EA2(EA.astype(object))` may work. But that won't necessarily be efficient. I'm not sure what's best here.

cc @xhochy 