### PR TITLE
Drop redundant TestLocale

### DIFF
--- a/pandas/tests/util/test_testing.py
+++ b/pandas/tests/util/test_testing.py
@@ -848,18 +848,6 @@ class TestRNGContext(object):
             assert np.random.randn() == expected0
 
 
-class TestLocale(object):
-
-    def test_locale(self):
-        if sys.platform == 'win32':
-            pytest.skip(
-                "skipping on win platforms as locale not available")
-
-        # GH9744
-        locales = tm.get_locales()
-        assert len(locales) >= 1
-
-
 def test_datapath_missing(datapath, request):
     if not request.config.getoption("--strict-data-files"):
         pytest.skip("Need to set '--strict-data-files'")

--- a/pandas/tests/util/test_util.py
+++ b/pandas/tests/util/test_util.py
@@ -455,6 +455,7 @@ class TestLocaleUtils(object):
 
     def test_get_locales(self):
         # all systems should have at least a single locale
+        # GH9744
         assert len(tm.get_locales()) > 0
 
     def test_get_locales_prefix(self):


### PR DESCRIPTION
We have the `TestLocaleUtils` class in `tests/util/test_util.py`
https://github.com/pandas-dev/pandas/blob/master/pandas/tests/util/test_util.py#L421
which is more comprehensive and includes `test_get_locales` which is functionally identical.

- [ ] closes #xxxx
- [ ] tests added / passed
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
