### PR TITLE
Grab timezones appropriately in timetz test

### DIFF
--- a/pandas/tests/series/test_datetime_values.py
+++ b/pandas/tests/series/test_datetime_values.py
@@ -15,8 +15,7 @@ from pandas import (Index, Series, DataFrame, bdate_range,
                     date_range, period_range, timedelta_range,
                     PeriodIndex, DatetimeIndex, TimedeltaIndex)
 import pandas.core.common as com
-
-import dateutil
+from pandas._libs.tslibs.timezones import maybe_get_tz
 
 from pandas.util.testing import assert_series_equal
 import pandas.util.testing as tm
@@ -464,10 +463,7 @@ class TestSeriesDatetimeValues(TestData):
 
     def test_dt_timetz_accessor(self, tz_naive_fixture):
         # GH21358
-        if tz_naive_fixture is not None:
-            tz = dateutil.tz.gettz(tz_naive_fixture)
-        else:
-            tz = None
+        tz = maybe_get_tz(tz_naive_fixture)
 
         dtindex = pd.DatetimeIndex(['2014-04-04 23:56', '2014-07-18 21:24',
                                     '2015-11-22 22:14'], tz=tz)


### PR DESCRIPTION
- [x] closes #22337
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`