### PR TITLE
CLN/DEPR: removed deprecated as_indexer arg from str.match()

### DIFF
--- a/doc/source/whatsnew/v0.24.0.txt
+++ b/doc/source/whatsnew/v0.24.0.txt
@@ -630,7 +630,7 @@ Numeric
 Strings
 ^^^^^^^
 
--
+- Removed as_indexer(deprecated of 0.21.0) keyword completely from str.match() (:issue:`22356`,:issue:`6581`)
 -
 -
 

--- a/doc/source/whatsnew/v0.24.0.txt
+++ b/doc/source/whatsnew/v0.24.0.txt
@@ -518,7 +518,7 @@ Removal of prior version deprecations/changes
 - The ``LongPanel`` and ``WidePanel`` classes have been removed (:issue:`10892`)
 - Several private functions were removed from the (non-public) module ``pandas.core.common`` (:issue:`22001`)
 - Removal of the previously deprecated module ``pandas.core.datetools`` (:issue:`14105`, :issue:`14094`)
--
+- Removal of the previously deprecated as_indexer keyword completely from ``str.match()`` (:issue:`22356`,:issue:`6581`)
 
 .. _whatsnew_0240.performance:
 
@@ -630,7 +630,7 @@ Numeric
 Strings
 ^^^^^^^
 
-- Removed as_indexer(deprecated of 0.21.0) keyword completely from str.match() (:issue:`22356`,:issue:`6581`)
+-
 -
 -
 

--- a/pandas/core/strings.py
+++ b/pandas/core/strings.py
@@ -2456,9 +2456,8 @@ class StringMethods(NoNewAttributesMixin):
         return self._wrap_result(result)
 
     @copy(str_match)
-    def match(self, pat, case=True, flags=0, na=np.nan, as_indexer=None):
-        result = str_match(self._parent, pat, case=case, flags=flags, na=na,
-                           as_indexer=as_indexer)
+    def match(self, pat, case=True, flags=0, na=np.nan):
+        result = str_match(self._parent, pat, case=case, flags=flags, na=na)
         return self._wrap_result(result)
 
     @copy(str_replace)

--- a/pandas/core/strings.py
+++ b/pandas/core/strings.py
@@ -709,7 +709,7 @@ def str_repeat(arr, repeats):
         return result
 
 
-def str_match(arr, pat, case=True, flags=0, na=np.nan, as_indexer=None):
+def str_match(arr, pat, case=True, flags=0, na=np.nan):
     """
     Determine if each string matches a regular expression.
 
@@ -722,8 +722,6 @@ def str_match(arr, pat, case=True, flags=0, na=np.nan, as_indexer=None):
     flags : int, default 0 (no flags)
         re module flags, e.g. re.IGNORECASE
     na : default NaN, fill value for missing values.
-    as_indexer
-        .. deprecated:: 0.21.0
 
     Returns
     -------
@@ -740,17 +738,6 @@ def str_match(arr, pat, case=True, flags=0, na=np.nan, as_indexer=None):
         flags |= re.IGNORECASE
 
     regex = re.compile(pat, flags=flags)
-
-    if (as_indexer is False) and (regex.groups > 0):
-        raise ValueError("as_indexer=False with a pattern with groups is no "
-                         "longer supported. Use '.str.extract(pat)' instead")
-    elif as_indexer is not None:
-        # Previously, this keyword was used for changing the default but
-        # deprecated behaviour. This keyword is now no longer needed.
-        warnings.warn("'as_indexer' keyword was specified but is ignored "
-                      "(match now returns a boolean indexer by default), "
-                      "and will be removed in a future version.",
-                      FutureWarning, stacklevel=3)
 
     dtype = bool
     f = lambda x: bool(regex.match(x))

--- a/pandas/tests/test_strings.py
+++ b/pandas/tests/test_strings.py
@@ -942,7 +942,7 @@ class TestStringMethods(object):
         values = Series(['fooBAD__barBAD', NA, 'foo'])
         exp = Series([True, NA, False])
         with tm.assert_raises_regex(TypeError,
-                                    "str_match() got an "
+                                    "match() got an "
                                     "unexpected keyword "
                                     "argument 'as_indexer'"):
             result = values.str.match('.*BAD[_]+.*BAD', as_indexer=True)

--- a/pandas/tests/test_strings.py
+++ b/pandas/tests/test_strings.py
@@ -942,8 +942,9 @@ class TestStringMethods(object):
         values = Series(['fooBAD__barBAD', NA, 'foo'])
         exp = Series([True, NA, False])
         with tm.assert_raises_regex(TypeError,
-                                    "match() got an unexpected "
-                                    "keyword argument 'as_indexer'"):
+                                    "got an unexpected "
+                                    "keyword argument "
+                                    "'as_indexer'"):
             result = values.str.match('.*BAD[_]+.*BAD', as_indexer=True)
 
         # mixed

--- a/pandas/tests/test_strings.py
+++ b/pandas/tests/test_strings.py
@@ -946,16 +946,6 @@ class TestStringMethods(object):
                                     "unexpected keyword "
                                     "argument 'as_indexer'"):
             result = values.str.match('.*BAD[_]+.*BAD', as_indexer=True)
-        with tm.assert_raises_regex(TypeError,
-                                    "str_match() got an "
-                                    "unexpected keyword "
-                                    "argument 'as_indexer'"):
-            result = values.str.match('.*BAD[_]+.*BAD', as_indexer=False)
-        with tm.assert_raises_regex(TypeError,
-                                    "str_match() got an "
-                                    "unexpected keyword "
-                                    "argument 'as_indexer'"):
-            result = values.str.match('.*(BAD[_]+).*(BAD)', as_indexer=True)
 
         # mixed
         mixed = Series(['aBAD_BAD', NA, 'BAD_b_BAD', True, datetime.today(),

--- a/pandas/tests/test_strings.py
+++ b/pandas/tests/test_strings.py
@@ -938,15 +938,6 @@ class TestStringMethods(object):
         exp = Series([True, NA, False])
         tm.assert_series_equal(result, exp)
 
-        # GH 22316 test the removal of as_indexer from match
-        values = Series(['fooBAD__barBAD', NA, 'foo'])
-        exp = Series([True, NA, False])
-        with tm.assert_raises_regex(TypeError,
-                                    "got an unexpected "
-                                    "keyword argument "
-                                    "'as_indexer'"):
-            result = values.str.match('.*BAD[_]+.*BAD', as_indexer=True)
-
         # mixed
         mixed = Series(['aBAD_BAD', NA, 'BAD_b_BAD', True, datetime.today(),
                         'foo', None, 1, 2.])

--- a/pandas/tests/test_strings.py
+++ b/pandas/tests/test_strings.py
@@ -942,9 +942,8 @@ class TestStringMethods(object):
         values = Series(['fooBAD__barBAD', NA, 'foo'])
         exp = Series([True, NA, False])
         with tm.assert_raises_regex(TypeError,
-                                    "match() got an "
-                                    "unexpected keyword "
-                                    "argument 'as_indexer'"):
+                                    "match() got an unexpected "
+                                    "keyword argument 'as_indexer'"):
             result = values.str.match('.*BAD[_]+.*BAD', as_indexer=True)
 
         # mixed

--- a/pandas/tests/test_strings.py
+++ b/pandas/tests/test_strings.py
@@ -938,20 +938,24 @@ class TestStringMethods(object):
         exp = Series([True, NA, False])
         tm.assert_series_equal(result, exp)
 
-        # test passing as_indexer still works but is ignored
+        # GH 22316 test the removal of as_indexer from match
         values = Series(['fooBAD__barBAD', NA, 'foo'])
         exp = Series([True, NA, False])
-        with tm.assert_produces_warning(FutureWarning):
+        with tm.assert_raises_regex(TypeError,
+                                    "str_match() got an "
+                                    "unexpected keyword "
+                                    "argument 'as_indexer'"):
             result = values.str.match('.*BAD[_]+.*BAD', as_indexer=True)
-        tm.assert_series_equal(result, exp)
-        with tm.assert_produces_warning(FutureWarning):
+        with tm.assert_raises_regex(TypeError,
+                                    "str_match() got an "
+                                    "unexpected keyword "
+                                    "argument 'as_indexer'"):
             result = values.str.match('.*BAD[_]+.*BAD', as_indexer=False)
-        tm.assert_series_equal(result, exp)
-        with tm.assert_produces_warning(FutureWarning):
+        with tm.assert_raises_regex(TypeError,
+                                    "str_match() got an "
+                                    "unexpected keyword "
+                                    "argument 'as_indexer'"):
             result = values.str.match('.*(BAD[_]+).*(BAD)', as_indexer=True)
-        tm.assert_series_equal(result, exp)
-        pytest.raises(ValueError, values.str.match, '.*(BAD[_]+).*(BAD)',
-                      as_indexer=False)
 
         # mixed
         mixed = Series(['aBAD_BAD', NA, 'BAD_b_BAD', True, datetime.today(),


### PR DESCRIPTION
- [x] closes #22316 
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry

removed as_indexer(deprecated of 0.20.0) arg completely from str.match. 