### PR TITLE
fixes #22085 (int type pandas.series.index contains float type key bug)

### DIFF
--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -1949,7 +1949,7 @@ class Index(IndexOpsMixin, PandasObject):
     def __contains__(self, key):
         hash(key)
         try:
-            if type(key) == float and self.dtype == int:
+            if is_float(key) and is_integer_dtype(self.dtype):
                 if key != int(key):
                     return False
             return key in self._engine

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -1948,11 +1948,11 @@ class Index(IndexOpsMixin, PandasObject):
     @Appender(_index_shared_docs['__contains__'] % _index_doc_kwargs)
     def __contains__(self, key):
         hash(key)
-        try:
-            if is_float(key) and is_integer_dtype(self.dtype):
+        if is_float(key) and is_integer_dtype(self.dtype):
                 if key != int(key):
                     return False
-            return key in self._engine
+        try:
+          return key in self._engine
         except (OverflowError, TypeError, ValueError):
             return False
 

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -1949,6 +1949,9 @@ class Index(IndexOpsMixin, PandasObject):
     def __contains__(self, key):
         hash(key)
         try:
+            if type(key) == float and self.dtype == int:
+                if key != int(key):
+                    return False
             return key in self._engine
         except (OverflowError, TypeError, ValueError):
             return False

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -1952,7 +1952,7 @@ class Index(IndexOpsMixin, PandasObject):
                 if key != int(key):
                     return False
         try:
-          return key in self._engine
+            return key in self._engine
         except (OverflowError, TypeError, ValueError):
             return False
 


### PR DESCRIPTION
- [x] closes #22085 
- [ ] tests added / passed
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry
checks for type using is_float, is_integer_dtype and if key is a float that does not resolve to an equivalent int and Index is int, returns false. 