### PR TITLE
Fix and test scalar extension dtype op corner case

### DIFF
--- a/pandas/core/ops.py
+++ b/pandas/core/ops.py
@@ -1229,7 +1229,7 @@ def _arith_method_SERIES(cls, op, special):
 
         elif (is_extension_array_dtype(left) or
                 (is_extension_array_dtype(right) and not is_scalar(right))):
-            # disallow scalar to exclude e.g. "category", "Int64"
+            # GH#22378 disallow scalar to exclude e.g. "category", "Int64"
             return dispatch_to_extension_op(op, left, right)
 
         elif is_datetime64_dtype(left) or is_datetime64tz_dtype(left):

--- a/pandas/core/ops.py
+++ b/pandas/core/ops.py
@@ -1228,8 +1228,8 @@ def _arith_method_SERIES(cls, op, special):
                             "{op}".format(typ=type(left).__name__, op=str_rep))
 
         elif (is_extension_array_dtype(left) or
-                is_extension_array_dtype(right)):
-            # TODO: should this include `not is_scalar(right)`?
+                (is_extension_array_dtype(right) and not is_scalar(right))):
+            # disallow scalar to exclude e.g. "category", "Int64"
             return dispatch_to_extension_op(op, left, right)
 
         elif is_datetime64_dtype(left) or is_datetime64tz_dtype(left):

--- a/pandas/tests/arithmetic/test_object.py
+++ b/pandas/tests/arithmetic/test_object.py
@@ -73,6 +73,25 @@ class TestObjectComparisons(object):
 
 class TestArithmetic(object):
 
+    def test_add_extension_scalar(self, box):
+        # Check that scalars satisfying is_extension_array_dtype(obj)
+        # do not incorrectly try to dispatch to an ExtensionArray operation
+
+        arr = pd.Series(['a', 'b', 'c'])
+        arr = tm.box_expected(arr, box)
+
+        expected = pd.Series(['acategory', 'bcategory', 'ccategory'])
+        expected = tm.box_expected(expected, box)
+
+        result = arr + "category"
+        tm.assert_equal(result, expected)
+
+        expected = pd.Series(['aInt64', 'bInt64', 'cInt64'])
+        expected = tm.box_expected(expected, box)
+
+        result = arr + "Int64"
+        tm.assert_equal(result, expected)
+
     @pytest.mark.parametrize('box', [
         pytest.param(pd.Index,
                      marks=pytest.mark.xfail(reason="Does not mask nulls",

--- a/pandas/tests/arithmetic/test_object.py
+++ b/pandas/tests/arithmetic/test_object.py
@@ -73,23 +73,19 @@ class TestObjectComparisons(object):
 
 class TestArithmetic(object):
 
-    def test_add_extension_scalar(self, box):
+    @pytest.mark.parametrize("op", [operator.add, ops.radd])
+    @pytest.mark.parametrize("other", ["category", "Int64"])
+    def test_add_extension_scalar(self, other, box, op):
         # Check that scalars satisfying is_extension_array_dtype(obj)
         # do not incorrectly try to dispatch to an ExtensionArray operation
 
         arr = pd.Series(['a', 'b', 'c'])
+        expected = pd.Series([op(x, other) for x in arr])
+
         arr = tm.box_expected(arr, box)
-
-        expected = pd.Series(['acategory', 'bcategory', 'ccategory'])
         expected = tm.box_expected(expected, box)
 
-        result = arr + "category"
-        tm.assert_equal(result, expected)
-
-        expected = pd.Series(['aInt64', 'bInt64', 'cInt64'])
-        expected = tm.box_expected(expected, box)
-
-        result = arr + "Int64"
+        result = op(arr, other)
         tm.assert_equal(result, expected)
 
     @pytest.mark.parametrize('box', [

--- a/pandas/tests/arithmetic/test_object.py
+++ b/pandas/tests/arithmetic/test_object.py
@@ -76,6 +76,7 @@ class TestArithmetic(object):
     @pytest.mark.parametrize("op", [operator.add, ops.radd])
     @pytest.mark.parametrize("other", ["category", "Int64"])
     def test_add_extension_scalar(self, other, box, op):
+        # GH#22378
         # Check that scalars satisfying is_extension_array_dtype(obj)
         # do not incorrectly try to dispatch to an ExtensionArray operation
 


### PR DESCRIPTION
Fixes the following behavior in master:

```
ser = pd.Series(['a', 'b', 'c'])

>>> ser + "category"
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "pandas/core/ops.py", line 1233, in wrapper
    return dispatch_to_extension_op(op, left, right)
  File "pandas/core/ops.py", line 1163, in dispatch_to_extension_op
    res_values = op(new_left, new_right)
TypeError: can only concatenate list (not "str") to list


>>> ser + "Int64"
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "pandas/core/ops.py", line 1233, in wrapper
    return dispatch_to_extension_op(op, left, right)
  File "pandas/core/ops.py", line 1163, in dispatch_to_extension_op
    res_values = op(new_left, new_right)
TypeError: can only concatenate list (not "str") to list
```

and the same for the reversed ops.