### PR TITLE
CLN: dedent else part of Series._get_with

### DIFF
--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -855,20 +855,20 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
                 return self._get_values(key)
         elif key_type == 'boolean':
             return self._get_values(key)
-        else:
-            try:
-                # handle the dup indexing case (GH 4246)
-                if isinstance(key, (list, tuple)):
-                    return self.loc[key]
 
-                return self.reindex(key)
-            except Exception:
-                # [slice(0, 5, None)] will break if you convert to ndarray,
-                # e.g. as requested by np.median
-                # hack
-                if isinstance(key[0], slice):
-                    return self._get_values(key)
-                raise
+        try:
+            # handle the dup indexing case (GH 4246)
+            if isinstance(key, (list, tuple)):
+                return self.loc[key]
+
+            return self.reindex(key)
+        except Exception:
+            # [slice(0, 5, None)] will break if you convert to ndarray,
+            # e.g. as requested by np.median
+            # hack
+            if isinstance(key[0], slice):
+                return self._get_values(key)
+            raise
 
     def _get_values_tuple(self, key):
         # mpl hackaround

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -829,47 +829,46 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
         elif isinstance(key, ABCDataFrame):
             raise TypeError('Indexing a Series with DataFrame is not '
                             'supported, use the appropriate DataFrame column')
-        else:
-            if isinstance(key, tuple):
-                try:
-                    return self._get_values_tuple(key)
-                except Exception:
-                    if len(key) == 1:
-                        key = key[0]
-                        if isinstance(key, slice):
-                            return self._get_values(key)
-                    raise
-
-            # pragma: no cover
-            if not isinstance(key, (list, np.ndarray, Series, Index)):
-                key = list(key)
-
-            if isinstance(key, Index):
-                key_type = key.inferred_type
-            else:
-                key_type = lib.infer_dtype(key)
-
-            if key_type == 'integer':
-                if self.index.is_integer() or self.index.is_floating():
-                    return self.loc[key]
-                else:
-                    return self._get_values(key)
-            elif key_type == 'boolean':
-                return self._get_values(key)
-            else:
-                try:
-                    # handle the dup indexing case (GH 4246)
-                    if isinstance(key, (list, tuple)):
-                        return self.loc[key]
-
-                    return self.reindex(key)
-                except Exception:
-                    # [slice(0, 5, None)] will break if you convert to ndarray,
-                    # e.g. as requested by np.median
-                    # hack
-                    if isinstance(key[0], slice):
+        elif isinstance(key, tuple):
+            try:
+                return self._get_values_tuple(key)
+            except Exception:
+                if len(key) == 1:
+                    key = key[0]
+                    if isinstance(key, slice):
                         return self._get_values(key)
-                    raise
+                raise
+
+        # pragma: no cover
+        if not isinstance(key, (list, np.ndarray, Series, Index)):
+            key = list(key)
+
+        if isinstance(key, Index):
+            key_type = key.inferred_type
+        else:
+            key_type = lib.infer_dtype(key)
+
+        if key_type == 'integer':
+            if self.index.is_integer() or self.index.is_floating():
+                return self.loc[key]
+            else:
+                return self._get_values(key)
+        elif key_type == 'boolean':
+            return self._get_values(key)
+        else:
+            try:
+                # handle the dup indexing case (GH 4246)
+                if isinstance(key, (list, tuple)):
+                    return self.loc[key]
+
+                return self.reindex(key)
+            except Exception:
+                # [slice(0, 5, None)] will break if you convert to ndarray,
+                # e.g. as requested by np.median
+                # hack
+                if isinstance(key[0], slice):
+                    return self._get_values(key)
+                raise
 
     def _get_values_tuple(self, key):
         # mpl hackaround


### PR DESCRIPTION
- [X] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`

There is a gigantic and unneeded ``else`` clause in ``Series._get_with`` and it makes the code hard to read.

This PR removes the else clause and dedents its content one level. This helps readability.
