### PR TITLE
CLN: Remove try-except in parse_dates test

### DIFF
--- a/pandas/tests/io/parser/parse_dates.py
+++ b/pandas/tests/io/parser/parse_dates.py
@@ -8,15 +8,15 @@ parsers defined in parsers.py
 from distutils.version import LooseVersion
 from datetime import datetime, date
 
+import pytz
 import pytest
 import numpy as np
 from pandas._libs.tslibs import parsing
 from pandas._libs.tslib import Timestamp
 
 import pandas as pd
-import pandas.io.parsers as parsers
-import pandas.core.tools.datetimes as tools
 import pandas.util.testing as tm
+import pandas.io.parsers as parsers
 
 import pandas.io.date_converters as conv
 from pandas import DataFrame, Series, Index, DatetimeIndex, MultiIndex
@@ -356,21 +356,13 @@ KORD6,19990127, 23:00:00, 22:56:00, -0.5900, 1.7100, 4.6000, 0.0000, 280.0000"""
 
     def test_parse_tz_aware(self):
         # See gh-1693
-        import pytz
         data = StringIO("Date,x\n2012-06-13T01:39:00Z,0.5")
 
         # it works
         result = self.read_csv(data, index_col=0, parse_dates=True)
         stamp = result.index[0]
         assert stamp.minute == 39
-        try:
-            assert result.index.tz is pytz.utc
-        except AssertionError:
-            arr = result.index.to_pydatetime()
-            result = tools.to_datetime(arr, utc=True)[0]
-            assert stamp.minute == result.minute
-            assert stamp.hour == result.hour
-            assert stamp.day == result.day
+        assert result.index.tz is pytz.utc
 
     def test_multiple_date_cols_index(self):
         data = """


### PR DESCRIPTION
Follow-up to https://github.com/pandas-dev/pandas/pull/22418#pullrequestreview-147454897