### PR TITLE
BUG: Ignore versionadded directive when checking for periods at docstring end

### DIFF
--- a/pandas/tests/scripts/test_validate_docstrings.py
+++ b/pandas/tests/scripts/test_validate_docstrings.py
@@ -193,6 +193,44 @@ class GoodDocStrings(object):
         """
         pass
 
+    def mode(self, axis=0, numeric_only=False, dropna=True):
+        """
+        Get the mode(s) of each element along the axis selected. Adds a row
+        for each mode per label, fills in gaps with nan.
+
+        Note that there could be multiple values returned for the selected
+        axis (when more than one item share the maximum frequency), which is
+        the reason why a dataframe is returned. If you want to impute missing
+        values with the mode in a dataframe ``df``, you can just do this:
+        ``df.fillna(df.mode().iloc[0])``
+
+        Parameters
+        ----------
+        axis : {0 or 'index', 1 or 'columns'}, default 0
+            Describe axis.
+        numeric_only : boolean, default False
+            Describes numeric_only.
+        dropna : boolean, default True
+            This param tests that the versionadded directive doesn't break the
+            checks for the ending period.
+            Don't consider counts of NaN/NaT.
+
+            .. versionadded:: 0.24.0
+
+        Returns
+        -------
+        modes : DataFrame (sorted)
+
+        Examples
+        --------
+        >>> df = pd.DataFrame({'A': [1, 2, 1, 2, 1, 2, 3]})
+        >>> df.mode()
+           A
+        0  1
+        1  2
+        """
+        pass
+
 
 class BadGenericDocStrings(object):
     """Everything here has a bad docstring
@@ -374,6 +412,18 @@ class BadParameters(object):
            Doesn't end with a dot
         """
 
+    def no_description_period_with_version_added(self, kind):
+        """
+        Forgets to add a period, and also includes a directive.
+
+        Parameters
+        ----------
+        kind : str
+           Doesn't end with a dot
+
+           .. versionadded:: 0.00.0
+        """
+
     def parameter_capitalization(self, kind):
         """
         Forgets to capitalize the description.
@@ -495,7 +545,7 @@ class TestValidator(object):
 
     @pytest.mark.parametrize("func", [
         'plot', 'sample', 'random_letters', 'sample_values', 'head', 'head1',
-        'contains'])
+        'contains', 'mode'])
     def test_good_functions(self, func):
         assert validate_one(self._import_path(   # noqa: F821
             klass='GoodDocStrings', func=func)) == 0
@@ -530,6 +580,8 @@ class TestValidator(object):
           'Unknown parameters {kind: str}',
           'Parameter "kind: str" has no type')),
         ('BadParameters', 'no_description_period',
+         ('Parameter "kind" description should finish with "."',)),
+        ('BadParameters', 'no_description_period_with_version_added',
          ('Parameter "kind" description should finish with "."',)),
         ('BadParameters', 'parameter_capitalization',
          ('Parameter "kind" description should start with a capital letter',)),

--- a/pandas/tests/scripts/test_validate_docstrings.py
+++ b/pandas/tests/scripts/test_validate_docstrings.py
@@ -198,6 +198,8 @@ class GoodDocStrings(object):
         Get the mode(s) of each element along the axis selected. Adds a row
         for each mode per label, fills in gaps with nan.
 
+        This test is to ensure that directives don't affect the tests for
+        periods at the end of parameters.
         Note that there could be multiple values returned for the selected
         axis (when more than one item share the maximum frequency), which is
         the reason why a dataframe is returned. If you want to impute missing
@@ -208,8 +210,15 @@ class GoodDocStrings(object):
         ----------
         axis : {0 or 'index', 1 or 'columns'}, default 0
             Describe axis.
+
+            .. versionchanged:: 0.1.2
+
         numeric_only : boolean, default False
             Describes numeric_only.
+
+            .. versionadded:: 0.1.2
+            .. deprecated:: 0.00.0
+
         dropna : boolean, default True
             This param tests that the versionadded directive doesn't break the
             checks for the ending period.
@@ -412,7 +421,7 @@ class BadParameters(object):
            Doesn't end with a dot
         """
 
-    def no_description_period_with_version_added(self, kind):
+    def no_description_period_with_directive(self, kind):
         """
         Forgets to add a period, and also includes a directive.
 
@@ -422,6 +431,19 @@ class BadParameters(object):
            Doesn't end with a dot
 
            .. versionadded:: 0.00.0
+        """
+
+    def no_description_period_with_directives(self, kind):
+        """
+        Forgets to add a period, and also includes multiple directives.
+
+        Parameters
+        ----------
+        kind : str
+           Doesn't end with a dot
+
+           .. versionchanged:: 0.00.0
+           .. deprecated:: 0.00.0
         """
 
     def parameter_capitalization(self, kind):
@@ -581,7 +603,7 @@ class TestValidator(object):
           'Parameter "kind: str" has no type')),
         ('BadParameters', 'no_description_period',
          ('Parameter "kind" description should finish with "."',)),
-        ('BadParameters', 'no_description_period_with_version_added',
+        ('BadParameters', 'no_description_period_with_directive',
          ('Parameter "kind" description should finish with "."',)),
         ('BadParameters', 'parameter_capitalization',
          ('Parameter "kind" description should start with a capital letter',)),

--- a/pandas/tests/scripts/test_validate_docstrings.py
+++ b/pandas/tests/scripts/test_validate_docstrings.py
@@ -193,50 +193,22 @@ class GoodDocStrings(object):
         """
         pass
 
-    def mode(self, axis=0, numeric_only=False, dropna=True):
+    def mode(self, axis, numeric_only):
         """
-        Get the mode(s) of each element along the axis selected. Adds a row
-        for each mode per label, fills in gaps with nan.
-
-        This test is to ensure that directives don't affect the tests for
-        periods at the end of parameters.
-        Note that there could be multiple values returned for the selected
-        axis (when more than one item share the maximum frequency), which is
-        the reason why a dataframe is returned. If you want to impute missing
-        values with the mode in a dataframe ``df``, you can just do this:
-        ``df.fillna(df.mode().iloc[0])``
+        Ensure sphinx directives don't affect checks for trailing periods.
 
         Parameters
         ----------
-        axis : {0 or 'index', 1 or 'columns'}, default 0
-            Describe axis.
+        axis : str
+            Sentence ending in period, followed by single directive.
 
             .. versionchanged:: 0.1.2
 
-        numeric_only : boolean, default False
-            Describes numeric_only.
+        numeric_only : boolean
+            Sentence ending in period, followed by multiple directives.
 
             .. versionadded:: 0.1.2
             .. deprecated:: 0.00.0
-
-        dropna : boolean, default True
-            This param tests that the versionadded directive doesn't break the
-            checks for the ending period.
-            Don't consider counts of NaN/NaT.
-
-            .. versionadded:: 0.24.0
-
-        Returns
-        -------
-        modes : DataFrame (sorted)
-
-        Examples
-        --------
-        >>> df = pd.DataFrame({'A': [1, 2, 1, 2, 1, 2, 3]})
-        >>> df.mode()
-           A
-        0  1
-        1  2
         """
         pass
 

--- a/pandas/tests/scripts/test_validate_docstrings.py
+++ b/pandas/tests/scripts/test_validate_docstrings.py
@@ -209,6 +209,8 @@ class GoodDocStrings(object):
 
             .. versionadded:: 0.1.2
             .. deprecated:: 0.00.0
+                A multiline description,
+                which spans another line.
         """
         pass
 

--- a/scripts/validate_docstrings.py
+++ b/scripts/validate_docstrings.py
@@ -465,7 +465,15 @@ def validate_one(func_name):
                 param_errs.append('Parameter "{}" description '
                                   'should start with a '
                                   'capital letter'.format(param))
-            if doc.parameter_desc(param)[-1] != '.':
+
+            if '.. versionadded::' in doc.parameter_desc(param):
+                index = doc.parameter_desc(param).index('.. versionadded::')
+                # Check for periods at the end of the description before the
+                # versionadded directive
+                period_check_index = index - 1
+            else:
+                period_check_index = -1
+            if doc.parameter_desc(param)[period_check_index] != '.':
                 param_errs.append('Parameter "{}" description '
                                   'should finish with "."'.format(param))
     if param_errs:

--- a/scripts/validate_docstrings.py
+++ b/scripts/validate_docstrings.py
@@ -234,11 +234,12 @@ class Docstring(object):
     def parameter_type(self, param):
         return self.doc_parameters[param][0]
 
-    def parameter_desc(self, param):
+    def raw_parameter_desc(self, param):
         return self.doc_parameters[param][1]
 
-    def parameter_desc_without_directives(self, param):
-        desc = self.parameter_desc(param)
+    def parameter_desc(self, param):
+        desc = self.raw_parameter_desc(param)
+        # Find and strip out any sphinx directives
         for directive in DIRECTIVES:
             full_directive = '.. {}'.format(directive)
             if full_directive in desc:
@@ -475,7 +476,7 @@ def validate_one(func_name):
                 param_errs.append('Parameter "{}" description '
                                   'should start with a '
                                   'capital letter'.format(param))
-            if doc.parameter_desc_without_directives(param)[-1] != '.':
+            if doc.parameter_desc(param)[-1] != '.':
                 param_errs.append('Parameter "{}" description '
                                   'should finish with "."'.format(param))
     if param_errs:

--- a/scripts/validate_docstrings.py
+++ b/scripts/validate_docstrings.py
@@ -42,7 +42,7 @@ from pandas.io.formats.printing import pprint_thing
 
 
 PRIVATE_CLASSES = ['NDFrame', 'IndexOpsMixin']
-DIRECTIVES = ['.. versionadded', '.. versionchanged', '.. deprecated']
+DIRECTIVES = ['versionadded', 'versionchanged', 'deprecated']
 
 
 def _load_obj(obj_name):
@@ -236,6 +236,15 @@ class Docstring(object):
 
     def parameter_desc(self, param):
         return self.doc_parameters[param][1]
+
+    def parameter_desc_without_directives(self, param):
+        desc = self.parameter_desc(param)
+        for directive in DIRECTIVES:
+            full_directive = '.. {}'.format(directive)
+            if full_directive in desc:
+                # Only retain any description before the directive
+                desc = desc[:desc.index(full_directive)]
+        return desc
 
     @property
     def see_also(self):
@@ -466,17 +475,7 @@ def validate_one(func_name):
                 param_errs.append('Parameter "{}" description '
                                   'should start with a '
                                   'capital letter'.format(param))
-
-            period_check_index = -1
-            for directive in DIRECTIVES:
-                if directive in doc.parameter_desc(param):
-                    # Get index of character before start of directive
-                    index = doc.parameter_desc(param).index(directive) - 1
-                    # If this directive is closest to the description, use it.
-                    if index < period_check_index or period_check_index is -1:
-                        period_check_index = index
-
-            if doc.parameter_desc(param)[period_check_index] != '.':
+            if doc.parameter_desc_without_directives(param)[-1] != '.':
                 param_errs.append('Parameter "{}" description '
                                   'should finish with "."'.format(param))
     if param_errs:

--- a/scripts/validate_docstrings.py
+++ b/scripts/validate_docstrings.py
@@ -234,11 +234,8 @@ class Docstring(object):
     def parameter_type(self, param):
         return self.doc_parameters[param][0]
 
-    def raw_parameter_desc(self, param):
-        return self.doc_parameters[param][1]
-
     def parameter_desc(self, param):
-        desc = self.raw_parameter_desc(param)
+        desc = self.doc_parameters[param][1]
         # Find and strip out any sphinx directives
         for directive in DIRECTIVES:
             full_directive = '.. {}'.format(directive)

--- a/scripts/validate_docstrings.py
+++ b/scripts/validate_docstrings.py
@@ -42,6 +42,7 @@ from pandas.io.formats.printing import pprint_thing
 
 
 PRIVATE_CLASSES = ['NDFrame', 'IndexOpsMixin']
+DIRECTIVES = ['.. versionadded', '.. versionchanged', '.. deprecated']
 
 
 def _load_obj(obj_name):
@@ -466,13 +467,15 @@ def validate_one(func_name):
                                   'should start with a '
                                   'capital letter'.format(param))
 
-            if '.. versionadded::' in doc.parameter_desc(param):
-                index = doc.parameter_desc(param).index('.. versionadded::')
-                # Check for periods at the end of the description before the
-                # versionadded directive
-                period_check_index = index - 1
-            else:
-                period_check_index = -1
+            period_check_index = -1
+            for directive in DIRECTIVES:
+                if directive in doc.parameter_desc(param):
+                    # Get index of character before start of directive
+                    index = doc.parameter_desc(param).index(directive) - 1
+                    # If this directive is closest to the description, use it.
+                    if index < period_check_index or period_check_index is -1:
+                        period_check_index = index
+
             if doc.parameter_desc(param)[period_check_index] != '.':
                 param_errs.append('Parameter "{}" description '
                                   'should finish with "."'.format(param))


### PR DESCRIPTION
Will ignore the `versionadded` directive when checking for `'.'` at the end of descriptions.  

- [x] closes #22405
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
