### PR TITLE
CI: add missing tzlocal dependency (rpy2, doc build)

### DIFF
--- a/ci/travis-36-doc.yaml
+++ b/ci/travis-36-doc.yaml
@@ -36,6 +36,7 @@ dependencies:
   - sphinx
   - sqlalchemy
   - statsmodels
+  - tzlocal
   - xarray
   - xlrd
   - xlsxwriter


### PR DESCRIPTION
- [x] closes #22412
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry
