### PR TITLE
Fix DataFrame.to_string() justification

### DIFF
--- a/pandas/io/formats/format.py
+++ b/pandas/io/formats/format.py
@@ -680,7 +680,7 @@ class DataFrameFormatter(TableFormatter):
         for i, ed in enumerate(col_bins):
             row = strcols[st:ed]
             if i > 0 and not self.index:
-                has_leading_sp = all([e[0] == ' ' for e in row[0]])
+                has_leading_sp = all(e[0] == ' ' for e in row[0])
                 if has_leading_sp:
                     row[0] = [e[1:] for e in row[0]]
             if self.index:
@@ -792,7 +792,7 @@ class DataFrameFormatter(TableFormatter):
             dtypes = self.frame.dtypes
             need_leadsp = dict(zip(fmt_columns, map(is_numeric_dtype, dtypes)))
             str_columns = [[' ' + x if not self._get_formatter(i) and
-                            need_leadsp[x] and (self.index or i>0) else x]
+                            need_leadsp[x] and (self.index or i > 0) else x]
                            for i, (col, x) in enumerate(zip(columns,
                                                             fmt_columns))]
 

--- a/pandas/io/formats/format.py
+++ b/pandas/io/formats/format.py
@@ -650,8 +650,6 @@ class DataFrameFormatter(TableFormatter):
                 self._chk_truncate()
                 strcols = self._to_str_columns()
                 text = self.adj.adjoin(1, *strcols)
-        if not self.index:
-            text = text.replace('\n ', '\n').strip()
         self.buf.writelines(text)
 
         if self.should_show_dimensions:
@@ -681,6 +679,10 @@ class DataFrameFormatter(TableFormatter):
         st = 0
         for i, ed in enumerate(col_bins):
             row = strcols[st:ed]
+            if i > 0 and not self.index:
+                has_leading_sp = all([e[0] == ' ' for e in row[0]])
+                if has_leading_sp:
+                    row[0] = [e[1:] for e in row[0]]
             if self.index:
                 row.insert(0, idx)
             if nbins > 1:
@@ -790,7 +792,7 @@ class DataFrameFormatter(TableFormatter):
             dtypes = self.frame.dtypes
             need_leadsp = dict(zip(fmt_columns, map(is_numeric_dtype, dtypes)))
             str_columns = [[' ' + x if not self._get_formatter(i) and
-                            need_leadsp[x] else x]
+                            need_leadsp[x] and (self.index or i>0) else x]
                            for i, (col, x) in enumerate(zip(columns,
                                                             fmt_columns))]
 
@@ -1106,7 +1108,7 @@ class FloatArrayFormatter(GenericArrayFormatter):
 class IntArrayFormatter(GenericArrayFormatter):
 
     def _format_strings(self):
-        formatter = self.formatter or (lambda x: '{x: d}'.format(x=x))
+        formatter = self.formatter or (lambda x: '{x:d}'.format(x=x))
         fmt_values = [formatter(x) for x in self.values]
         return fmt_values
 

--- a/pandas/tests/arrays/categorical/test_repr.py
+++ b/pandas/tests/arrays/categorical/test_repr.py
@@ -52,7 +52,7 @@ class TestCategoricalRepr(object):
     def test_print_none_width(self):
         # GH10087
         a = Series(Categorical([1, 2, 3, 4]))
-        exp = u("0    1\n1    2\n2    3\n3    4\n" +
+        exp = u("0   1\n1   2\n2   3\n3   4\n" +
                 "dtype: category\nCategories (4, int64): [1, 2, 3, 4]")
 
         with option_context("display.width", None):

--- a/pandas/tests/io/formats/test_format.py
+++ b/pandas/tests/io/formats/test_format.py
@@ -553,18 +553,18 @@ class TestDataFrameFormatting(object):
         df = DataFrame({'a': [u'あ', u'いいい', u'う', u'ええええええ'],
                         'b': [1, 222, 33333, 4]},
                        index=['a', 'bb', 'c', 'ddd'])
-        expected = (u"          a      b\na         あ      1\n"
-                    u"bb      いいい    222\nc         う  33333\n"
-                    u"ddd  ええええええ      4")
+        expected = (u"          a     b\na         あ     1\n"
+                    u"bb      いいい   222\nc         う 33333\n"
+                    u"ddd  ええええええ     4")
         assert _rep(df) == expected
 
         # last col
         df = DataFrame({'a': [1, 222, 33333, 4],
                         'b': [u'あ', u'いいい', u'う', u'ええええええ']},
                        index=['a', 'bb', 'c', 'ddd'])
-        expected = (u"         a       b\na        1       あ\n"
-                    u"bb     222     いいい\nc    33333       う\n"
-                    u"ddd      4  ええええええ")
+        expected = (u"        a       b\na       1       あ\n"
+                    u"bb    222     いいい\nc   33333       う\n"
+                    u"ddd     4  ええええええ")
         assert _rep(df) == expected
 
         # all col
@@ -659,18 +659,18 @@ class TestDataFrameFormatting(object):
             df = DataFrame({'a': [u'あ', u'いいい', u'う', u'ええええええ'],
                             'b': [1, 222, 33333, 4]},
                            index=['a', 'bb', 'c', 'ddd'])
-            expected = (u"                a      b\na              あ      1\n"
-                        u"bb         いいい    222\nc              う  33333\n"
-                        u"ddd  ええええええ      4")
+            expected = (u"                a     b\na              あ     1\n"
+                        u"bb         いいい   222\nc              う 33333\n"
+                        u"ddd  ええええええ     4")
             assert _rep(df) == expected
 
             # last col
             df = DataFrame({'a': [1, 222, 33333, 4],
                             'b': [u'あ', u'いいい', u'う', u'ええええええ']},
                            index=['a', 'bb', 'c', 'ddd'])
-            expected = (u"         a             b\na        1            あ\n"
-                        u"bb     222        いいい\nc    33333            う\n"
-                        u"ddd      4  ええええええ")
+            expected = (u"        a             b\na       1            あ\n"
+                        u"bb    222        いいい\nc   33333            う\n"
+                        u"ddd     4  ええええええ")
             assert _rep(df) == expected
 
             # all col
@@ -885,12 +885,12 @@ class TestDataFrameFormatting(object):
         df = pd.DataFrame({"dt": dts,
                            "x": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]})
         with option_context('display.max_rows', 5):
-            expected = ('                          dt   x\n'
-                        '0  2011-01-01 00:00:00-05:00   1\n'
-                        '1  2011-01-01 00:00:00-05:00   2\n'
-                        '..                       ...  ..\n'
-                        '8                        NaT   9\n'
-                        '9                        NaT  10\n\n'
+            expected = ('                          dt  x\n'
+                        '0  2011-01-01 00:00:00-05:00  1\n'
+                        '1  2011-01-01 00:00:00-05:00  2\n'
+                        '..                       ... ..\n'
+                        '8                        NaT  9\n'
+                        '9                        NaT 10\n\n'
                         '[10 rows x 2 columns]')
             assert repr(df) == expected
 
@@ -898,12 +898,12 @@ class TestDataFrameFormatting(object):
         df = pd.DataFrame({"dt": dts,
                            "x": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]})
         with option_context('display.max_rows', 5):
-            expected = ('                          dt   x\n'
-                        '0                        NaT   1\n'
-                        '1                        NaT   2\n'
-                        '..                       ...  ..\n'
-                        '8  2011-01-01 00:00:00-05:00   9\n'
-                        '9  2011-01-01 00:00:00-05:00  10\n\n'
+            expected = ('                          dt  x\n'
+                        '0                        NaT  1\n'
+                        '1                        NaT  2\n'
+                        '..                       ... ..\n'
+                        '8  2011-01-01 00:00:00-05:00  9\n'
+                        '9  2011-01-01 00:00:00-05:00 10\n\n'
                         '[10 rows x 2 columns]')
             assert repr(df) == expected
 
@@ -912,12 +912,12 @@ class TestDataFrameFormatting(object):
         df = pd.DataFrame({"dt": dts,
                            "x": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]})
         with option_context('display.max_rows', 5):
-            expected = ('                           dt   x\n'
-                        '0   2011-01-01 00:00:00+09:00   1\n'
-                        '1   2011-01-01 00:00:00+09:00   2\n'
-                        '..                        ...  ..\n'
-                        '8   2011-01-01 00:00:00-05:00   9\n'
-                        '9   2011-01-01 00:00:00-05:00  10\n\n'
+            expected = ('                           dt  x\n'
+                        '0   2011-01-01 00:00:00+09:00  1\n'
+                        '1   2011-01-01 00:00:00+09:00  2\n'
+                        '..                        ... ..\n'
+                        '8   2011-01-01 00:00:00-05:00  9\n'
+                        '9   2011-01-01 00:00:00-05:00 10\n\n'
                         '[10 rows x 2 columns]')
             assert repr(df) == expected
 
@@ -1253,7 +1253,7 @@ class TestDataFrameFormatting(object):
         df = DataFrame({'x': [1, 2, 3], 'y': [4, 5, 6]})
 
         df_s = df.to_string(header=False)
-        expected = "0  1  4\n1  2  5\n2  3  6"
+        expected = "0 1 4\n1 2 5\n2 3 6"
 
         assert df_s == expected
 
@@ -1261,7 +1261,7 @@ class TestDataFrameFormatting(object):
         df = DataFrame({'x': [1, 2, 3], 'y': [4, 5, 6]})
 
         df_s = df.to_string(header=['X', 'Y'])
-        expected = '   X  Y\n0  1  4\n1  2  5\n2  3  6'
+        expected = '  X Y\n0 1 4\n1 2 5\n2 3 6'
 
         assert df_s == expected
 
@@ -1428,10 +1428,10 @@ class TestDataFrameFormatting(object):
         rs = df.to_string(formatters={'__index__': lambda x: 'abc' [x]})
 
         xp = """\
-    0   1   2   3   4
-a   0   1   2   3   4
-b   5   6   7   8   9
-c  10  11  12  13  14\
+   0  1  2  3  4
+a  0  1  2  3  4
+b  5  6  7  8  9
+c 10 11 12 13 14\
 """
 
         assert rs == xp
@@ -1470,9 +1470,9 @@ c  10  11  12  13  14\
         assert result == expected
 
     def test_to_string_line_width(self):
-        df = DataFrame(123, lrange(10, 15), lrange(30))
+        df = DataFrame(123, lrange(10, 15), lrange(35))
         s = df.to_string(line_width=80)
-        assert max(len(l) for l in s.split('\n')) == 80
+        assert max(len(l) for l in s.split('\n')) <= 80
 
     def test_show_dimensions(self):
         df = DataFrame(123, lrange(10, 15), lrange(30))
@@ -1883,25 +1883,25 @@ class TestSeriesFormatting(object):
         idx = pd.MultiIndex.from_tuples([(u'あ', u'いい'), (u'う', u'え'), (
             u'おおお', u'かかかか'), (u'き', u'くく')])
         s = Series([1, 22, 3333, 44444], index=idx)
-        expected = (u"あ    いい          1\n"
-                    u"う    え          22\n"
-                    u"おおお  かかかか     3333\n"
-                    u"き    くく      44444\ndtype: int64")
+        expected = (u"あ    いい         1\n"
+                    u"う    え         22\n"
+                    u"おおお  かかかか    3333\n"
+                    u"き    くく     44444\ndtype: int64")
         assert _rep(s) == expected
 
         # object dtype, shorter than unicode repr
         s = Series([1, 22, 3333, 44444], index=[1, 'AB', np.nan, u'あああ'])
-        expected = (u"1          1\nAB        22\nNaN     3333\n"
-                    u"あああ    44444\ndtype: int64")
+        expected = (u"1         1\nAB       22\nNaN    3333\n"
+                    u"あああ   44444\ndtype: int64")
         assert _rep(s) == expected
 
         # object dtype, longer than unicode repr
         s = Series([1, 22, 3333, 44444],
                    index=[1, 'AB', pd.Timestamp('2011-01-01'), u'あああ'])
-        expected = (u"1                          1\n"
-                    u"AB                        22\n"
-                    u"2011-01-01 00:00:00     3333\n"
-                    u"あああ                    44444\ndtype: int64")
+        expected = (u"1                         1\n"
+                    u"AB                       22\n"
+                    u"2011-01-01 00:00:00    3333\n"
+                    u"あああ                   44444\ndtype: int64")
         assert _rep(s) == expected
 
         # truncate
@@ -1961,26 +1961,26 @@ class TestSeriesFormatting(object):
             idx = pd.MultiIndex.from_tuples([(u'あ', u'いい'), (u'う', u'え'), (
                 u'おおお', u'かかかか'), (u'き', u'くく')])
             s = Series([1, 22, 3333, 44444], index=idx)
-            expected = (u"あ      いい            1\n"
-                        u"う      え             22\n"
-                        u"おおお  かかかか     3333\n"
-                        u"き      くく        44444\n"
+            expected = (u"あ      いい           1\n"
+                        u"う      え            22\n"
+                        u"おおお  かかかか    3333\n"
+                        u"き      くく       44444\n"
                         u"dtype: int64")
             assert _rep(s) == expected
 
             # object dtype, shorter than unicode repr
             s = Series([1, 22, 3333, 44444], index=[1, 'AB', np.nan, u'あああ'])
-            expected = (u"1             1\nAB           22\nNaN        3333\n"
-                        u"あああ    44444\ndtype: int64")
+            expected = (u"1            1\nAB          22\nNaN       3333\n"
+                        u"あああ   44444\ndtype: int64")
             assert _rep(s) == expected
 
             # object dtype, longer than unicode repr
             s = Series([1, 22, 3333, 44444],
                        index=[1, 'AB', pd.Timestamp('2011-01-01'), u'あああ'])
-            expected = (u"1                          1\n"
-                        u"AB                        22\n"
-                        u"2011-01-01 00:00:00     3333\n"
-                        u"あああ                 44444\ndtype: int64")
+            expected = (u"1                         1\n"
+                        u"AB                       22\n"
+                        u"2011-01-01 00:00:00    3333\n"
+                        u"あああ                44444\ndtype: int64")
             assert _rep(s) == expected
 
             # truncate
@@ -2128,8 +2128,8 @@ class TestSeriesFormatting(object):
         # GH 12615
         index = pd.period_range('2013-01', periods=6, freq='M')
         s = Series(np.arange(6, dtype='int64'), index=index)
-        exp = ("2013-01    0\n2013-02    1\n2013-03    2\n2013-04    3\n"
-               "2013-05    4\n2013-06    5\nFreq: M, dtype: int64")
+        exp = ("2013-01   0\n2013-02   1\n2013-03   2\n2013-04   3\n"
+               "2013-05   4\n2013-06   5\nFreq: M, dtype: int64")
         assert str(s) == exp
 
         s = Series(index)
@@ -2251,7 +2251,7 @@ class TestSeriesFormatting(object):
         s = Series([0, 100, 200, 400])
         with option_context("display.max_rows", 2):
             strrepr = repr(s).replace('\n', '')
-        assert getndots(strrepr) == 3
+        assert getndots(strrepr) == 2
 
     def test_show_dimensions(self):
         # gh-7117
@@ -2273,25 +2273,25 @@ class TestSeriesFormatting(object):
         s = Series(range(100), dtype='int64')
         s.name = 'myser'
         res = s.to_string(max_rows=2, name=True)
-        exp = '0      0\n      ..\n99    99\nName: myser'
+        exp = '0     0\n     ..\n99   99\nName: myser'
         assert res == exp
         res = s.to_string(max_rows=2, name=False)
-        exp = '0      0\n      ..\n99    99'
+        exp = '0     0\n     ..\n99   99'
         assert res == exp
 
     def test_to_string_dtype(self):
         s = Series(range(100), dtype='int64')
         res = s.to_string(max_rows=2, dtype=True)
-        exp = '0      0\n      ..\n99    99\ndtype: int64'
+        exp = '0     0\n     ..\n99   99\ndtype: int64'
         assert res == exp
         res = s.to_string(max_rows=2, dtype=False)
-        exp = '0      0\n      ..\n99    99'
+        exp = '0     0\n     ..\n99   99'
         assert res == exp
 
     def test_to_string_length(self):
         s = Series(range(100), dtype='int64')
         res = s.to_string(max_rows=2, length=True)
-        exp = '0      0\n      ..\n99    99\nLength: 100'
+        exp = '0     0\n     ..\n99   99\nLength: 100'
         assert res == exp
 
     def test_to_string_na_rep(self):
@@ -2311,10 +2311,10 @@ class TestSeriesFormatting(object):
         s = pd.Series(range(10), dtype='int64')
         s.index.name = 'foo'
         res = s.to_string(header=True, max_rows=2)
-        exp = 'foo\n0    0\n    ..\n9    9'
+        exp = 'foo\n0   0 \n    ..\n9   9 '
         assert res == exp
         res = s.to_string(header=False, max_rows=2)
-        exp = '0    0\n    ..\n9    9'
+        exp = '0   0 \n    ..\n9   9 '
         assert res == exp
 
 

--- a/pandas/tests/io/formats/test_format.py
+++ b/pandas/tests/io/formats/test_format.py
@@ -1269,18 +1269,60 @@ class TestDataFrameFormatting(object):
             df.to_string(header=['X'])
 
     def test_to_string_no_index(self):
-        df = DataFrame({'x': [1, 2, 3], 'y': [4, 5, 6]})
 
-        df_s = df.to_string(index=False)
-        expected = "x  y\n1  4\n2  5\n3  6"
+        dfs = [
 
-        assert df_s == expected
+            # ints
+            DataFrame({'x': [1, 2, 3], 'y': [4, 5, 6]}),
+            DataFrame({'x': [11, 22, 33], 'y': [4, 5, 6]}),
+            DataFrame({'x': [11, 22, -33], 'y': [4, 5, 6]}),
+            DataFrame({'x': [11, 22, -33], 'y': [4, 5, -6]}),
+            DataFrame({'x': [11, 22, -33], 'y': [44, 55, -66]}),
+
+            # floats
+            DataFrame({'x': [0.1, 0.2, -0.3], 'y': [4, 5, 6]}),
+            DataFrame({'x': [0.1, 0.2, -0.3], 'y': [0.4, 0.5, 0.6]}),
+            DataFrame({'x': [0.1, 0.2, -0.3], 'y': [0.4, 0.5, -0.6]}),
+        ]
+
+        exs = [
+
+            # ints
+            "x  y\n1  4\n2  5\n3  6",
+            " x  y\n11  4\n22  5\n33  6",
+            "  x  y\n 11  4\n 22  5\n-33  6",
+            "  x  y\n 11  4\n 22  5\n-33 -6",
+            "  x   y\n 11  44\n 22  55\n-33 -66",
+
+            # floats
+            "   x  y\n 0.1  4\n 0.2  5\n-0.3  6",
+            "   x    y\n 0.1  0.4\n 0.2  0.5\n-0.3  0.6",
+            "   x    y\n 0.1  0.4\n 0.2  0.5\n-0.3 -0.6",
+        ]
+
+        for df, expected in zip(dfs, exs):
+            df_s = df.to_string(index=False)
+            assert df_s == expected
 
     def test_to_string_line_width_no_index(self):
         df = DataFrame({'x': [1, 2, 3], 'y': [4, 5, 6]})
 
         df_s = df.to_string(line_width=1, index=False)
-        expected = "x  \\\n1   \n2   \n3   \n\ny  \n4  \n5  \n6"
+        expected = "x  \\\n1   \n2   \n3   \n\ny  \n4  \n5  \n6  "
+
+        assert df_s == expected
+
+        df = DataFrame({'x': [11, 22, 33], 'y': [4, 5, 6]})
+
+        df_s = df.to_string(line_width=1, index=False)
+        expected = " x  \\\n11   \n22   \n33   \n\ny  \n4  \n5  \n6  "
+
+        assert df_s == expected
+
+        df = DataFrame({'x': [11, 22, -33], 'y': [4, 5, -6]})
+
+        df_s = df.to_string(line_width=1, index=False)
+        expected = "  x  \\\n 11   \n 22   \n-33   \n\n y  \n 4  \n 5  \n-6  "
 
         assert df_s == expected
 

--- a/pandas/tests/io/formats/test_to_latex.py
+++ b/pandas/tests/io/formats/test_to_latex.py
@@ -63,10 +63,10 @@ class TestToLatex(object):
         withoutindex_result = df.to_latex(index=False)
         withoutindex_expected = r"""\begin{tabular}{rl}
 \toprule
- a &   b \\
+a &   b \\
 \midrule
- 1 &  b1 \\
- 2 &  b2 \\
+1 &  b1 \\
+2 &  b2 \\
 \bottomrule
 \end{tabular}
 """
@@ -199,12 +199,12 @@ c3 & 0 &  0 &  1 &  2 &  3 \\
         expected = r"""\begin{tabular}{lrrrrr}
 \toprule
 a & \multicolumn{2}{l}{c1} & \multicolumn{2}{l}{c2} & c3 \\
-b &  0 &  1 &  0 &  1 &  0 \\
+b &  0 & 1 &  0 & 1 &  0 \\
 \midrule
-0 &  0 &  4 &  0 &  4 &  0 \\
-1 &  1 &  5 &  1 &  5 &  1 \\
-2 &  2 &  6 &  2 &  6 &  2 \\
-3 &  3 &  7 &  3 &  7 &  3 \\
+0 &  0 & 4 &  0 & 4 &  0 \\
+1 &  1 & 5 &  1 & 5 &  1 \\
+2 &  2 & 6 &  2 & 6 &  2 \\
+3 &  3 & 7 &  3 & 7 &  3 \\
 \bottomrule
 \end{tabular}
 """
@@ -279,13 +279,13 @@ B & c &  NaN \\
         expected = r"""\begin{tabular}{lrrrrr}
 \toprule
 {} & \multicolumn{2}{l}{c1} & \multicolumn{2}{l}{c2} & c3 \\
-{} &  0 &  1 &  0 &  1 &  0 \\
+{} &  0 & 1 &  0 & 1 &  0 \\
 \midrule
-0 &  0 &  5 &  0 &  5 &  0 \\
-1 &  1 &  6 &  1 &  6 &  1 \\
-2 &  2 &  7 &  2 &  7 &  2 \\
-3 &  3 &  8 &  3 &  8 &  3 \\
-4 &  4 &  9 &  4 &  9 &  4 \\
+0 &  0 & 5 &  0 & 5 &  0 \\
+1 &  1 & 6 &  1 & 6 &  1 \\
+2 &  2 & 7 &  2 & 7 &  2 \\
+3 &  3 & 8 &  3 & 8 &  3 \\
+4 &  4 & 9 &  4 & 9 &  4 \\
 \bottomrule
 \end{tabular}
 """
@@ -294,14 +294,14 @@ B & c &  NaN \\
         result = df.to_latex(multicolumn=False)
         expected = r"""\begin{tabular}{lrrrrr}
 \toprule
-{} & c1 &    & c2 &    & c3 \\
-{} &  0 &  1 &  0 &  1 &  0 \\
+{} & c1 &   & c2 &   & c3 \\
+{} &  0 & 1 &  0 & 1 &  0 \\
 \midrule
-0 &  0 &  5 &  0 &  5 &  0 \\
-1 &  1 &  6 &  1 &  6 &  1 \\
-2 &  2 &  7 &  2 &  7 &  2 \\
-3 &  3 &  8 &  3 &  8 &  3 \\
-4 &  4 &  9 &  4 &  9 &  4 \\
+0 &  0 & 5 &  0 & 5 &  0 \\
+1 &  1 & 6 &  1 & 6 &  1 \\
+2 &  2 & 7 &  2 & 7 &  2 \\
+3 &  3 & 8 &  3 & 8 &  3 \\
+4 &  4 & 9 &  4 & 9 &  4 \\
 \bottomrule
 \end{tabular}
 """
@@ -330,15 +330,15 @@ c3 & 0 &  0 &  1 &  2 &  3 &  4 \\
         expected = r"""\begin{tabular}{llrrrrr}
 \toprule
    &   & \multicolumn{2}{c}{c1} & \multicolumn{2}{c}{c2} & c3 \\
-   &   &  0 &  1 &  0 &  1 &  0 \\
+   &   &  0 & 1 &  0 & 1 &  0 \\
 \midrule
-\multirow{2}{*}{c1} & 0 &  0 &  1 &  2 &  3 &  4 \\
-   & 1 &  5 &  6 &  7 &  8 &  9 \\
+\multirow{2}{*}{c1} & 0 &  0 & 1 &  2 & 3 &  4 \\
+   & 1 &  5 & 6 &  7 & 8 &  9 \\
 \cline{1-7}
-\multirow{2}{*}{c2} & 0 &  0 &  1 &  2 &  3 &  4 \\
-   & 1 &  5 &  6 &  7 &  8 &  9 \\
+\multirow{2}{*}{c2} & 0 &  0 & 1 &  2 & 3 &  4 \\
+   & 1 &  5 & 6 &  7 & 8 &  9 \\
 \cline{1-7}
-c3 & 0 &  0 &  1 &  2 &  3 &  4 \\
+c3 & 0 &  0 & 1 &  2 & 3 &  4 \\
 \bottomrule
 \end{tabular}
 """
@@ -422,7 +422,7 @@ b &       b &     b \\
         withoutindex_result = df.to_latex(index=False, longtable=True)
         withoutindex_expected = r"""\begin{longtable}{rl}
 \toprule
- a &   b \\
+a &   b \\
 \midrule
 \endhead
 \midrule
@@ -432,8 +432,8 @@ b &       b &     b \\
 
 \bottomrule
 \endlastfoot
- 1 &  b1 \\
- 2 &  b2 \\
+1 &  b1 \\
+2 &  b2 \\
 \end{longtable}
 """
 
@@ -478,8 +478,8 @@ b &       b &     b \\
         withindex_result = df.to_latex(header=False)
         withindex_expected = r"""\begin{tabular}{lrl}
 \toprule
-0 &  1 &  b1 \\
-1 &  2 &  b2 \\
+0 & 1 &  b1 \\
+1 & 2 &  b2 \\
 \bottomrule
 \end{tabular}
 """
@@ -489,8 +489,8 @@ b &       b &     b \\
         withoutindex_result = df.to_latex(index=False, header=False)
         withoutindex_expected = r"""\begin{tabular}{rl}
 \toprule
- 1 &  b1 \\
- 2 &  b2 \\
+1 &  b1 \\
+2 &  b2 \\
 \bottomrule
 \end{tabular}
 """

--- a/pandas/tests/series/test_repr.py
+++ b/pandas/tests/series/test_repr.py
@@ -29,12 +29,12 @@ class TestSeriesRepr(TestData):
                                    [0, 1, 2, 0, 1, 1, 2, 0, 1, 2]],
                            names=['first', 'second'])
         s = Series(lrange(0, len(index)), index=index, name='sth')
-        expected = ["first  second", "foo    one       0",
-                    "       two       1", "       three     2",
-                    "bar    one       3", "       two       4",
-                    "baz    two       5", "       three     6",
-                    "qux    one       7", "       two       8",
-                    "       three     9", "Name: sth, dtype: int64"]
+        expected = ["first  second", "foo    one      0",
+                    "       two      1", "       three    2",
+                    "bar    one      3", "       two      4",
+                    "baz    two      5", "       three    6",
+                    "qux    one      7", "       two      8",
+                    "       three    9", "Name: sth, dtype: int64"]
         expected = "\n".join(expected)
         assert repr(s) == expected
 
@@ -234,7 +234,7 @@ class TestCategoricalRepr(object):
 
     def test_categorical_repr(self):
         a = Series(Categorical([1, 2, 3, 4]))
-        exp = u("0    1\n1    2\n2    3\n3    4\n" +
+        exp = u("0   1\n1   2\n2   3\n3   4\n" +
                 "dtype: category\nCategories (4, int64): [1, 2, 3, 4]")
 
         assert exp == a.__unicode__()
@@ -253,25 +253,25 @@ class TestCategoricalRepr(object):
 
     def test_categorical_series_repr(self):
         s = Series(Categorical([1, 2, 3]))
-        exp = """0    1
-1    2
-2    3
+        exp = """0   1
+1   2
+2   3
 dtype: category
 Categories (3, int64): [1, 2, 3]"""
 
         assert repr(s) == exp
 
         s = Series(Categorical(np.arange(10)))
-        exp = """0    0
-1    1
-2    2
-3    3
-4    4
-5    5
-6    6
-7    7
-8    8
-9    9
+        exp = """0   0
+1   1
+2   2
+3   3
+4   4
+5   5
+6   6
+7   7
+8   8
+9   9
 dtype: category
 Categories (10, int64): [0, 1, 2, 3, ..., 6, 7, 8, 9]"""
 
@@ -279,25 +279,25 @@ Categories (10, int64): [0, 1, 2, 3, ..., 6, 7, 8, 9]"""
 
     def test_categorical_series_repr_ordered(self):
         s = Series(Categorical([1, 2, 3], ordered=True))
-        exp = """0    1
-1    2
-2    3
+        exp = """0   1
+1   2
+2   3
 dtype: category
 Categories (3, int64): [1 < 2 < 3]"""
 
         assert repr(s) == exp
 
         s = Series(Categorical(np.arange(10), ordered=True))
-        exp = """0    0
-1    1
-2    2
-3    3
-4    4
-5    5
-6    6
-7    7
-8    8
-9    9
+        exp = """0   0
+1   1
+2   2
+3   3
+4   4
+5   5
+6   6
+7   7
+8   8
+9   9
 dtype: category
 Categories (10, int64): [0 < 1 < 2 < 3 ... 6 < 7 < 8 < 9]"""
 

--- a/pandas/tests/sparse/test_format.py
+++ b/pandas/tests/sparse/test_format.py
@@ -89,8 +89,8 @@ class TestSparseSeriesFormatting(object):
 
         result = repr(s)
         dtype = '' if use_32bit_repr else ', dtype=int32'
-        exp = ("0    0\n1    1\n2    0\n3    0\n4    1\n"
-               "5    0\ndtype: int64\nBlockIndex\n"
+        exp = ("0   0\n1   1\n2   0\n3   0\n4   1\n"
+               "5   0\ndtype: int64\nBlockIndex\n"
                "Block locations: array([1, 4]{0})\n"
                "Block lengths: array([1, 1]{0})".format(dtype))
         assert result == exp
@@ -98,7 +98,7 @@ class TestSparseSeriesFormatting(object):
         with option_context("display.max_rows", 3,
                             "display.show_dimensions", False):
             result = repr(s)
-            exp = ("0    0\n    ..\n5    0\n"
+            exp = ("0   0 \n    ..\n5   0 \n"
                    "dtype: int64\nBlockIndex\n"
                    "Block locations: array([1, 4]{0})\n"
                    "Block lengths: array([1, 1]{0})".format(dtype))


### PR DESCRIPTION
- [ ] closes #16839, #13032
- [ ] tests added / passed
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

Fixes justification with `DataFrame.to_string(index=False)`, but breaks other tests :-(

There are two side-effects of this PR, which will likely make it unacceptable, but wanted to get suggestions if possible.

1. It changes the expected behavior with trailing spaces as shown below.

```
import pandas as pd
def wrap_to_string(df, **kwargs):
    s = df.to_string(**kwargs)
    print(str(kwargs).center(40, '='))
    for i, line in enumerate(s.split('\n')):
        print(f'^{line}$-{i}')
    print('~' * 40)
df = pd.DataFrame({'x': [11, -22], 'y': ['aaa', ' ']})
wrap_to_string(df)
wrap_to_string(df, line_width=1)
wrap_to_string(df, index=False)
wrap_to_string(df, index=False, line_width=1)
```

Current output with `master`
```
==================={}===================  # Looks good
^    x    y$-0
^0  11  aaa$-1
^1 -22     $-2
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
==========={'line_width': 1}============  # Looks good (to me anyways) but has trailing spaces
^    x  \$-0
^0  11   $-1
^1 -22   $-2
^$-3
^     y  $-4
^0  aaa  $-5
^1       $-6
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
============{'index': False}============  # broken justification (this is what I want to fix)
^x    y$-0
^11  aaa$-1
^-22$-2                                   # the last value (space) disappeared completely
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
==={'index': False, 'line_width': 1}====  # still broken
^x  \$-0
^11   $-1
^-22   $-2
^$-3
^  y  $-4
^aaa$-5                                   # the last value (space) disappeared completely
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

Output with this PR

```
==================={}===================  # No change from master
^    x    y$-0
^0  11  aaa$-1
^1 -22     $-2
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
==========={'line_width': 1}============  # No change from master
^    x  \$-0
^0  11   $-1
^1 -22   $-2
^$-3
^     y  $-4
^0  aaa  $-5
^1       $-6
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
============{'index': False}============  # Justification is fixed
^  x    y$-0
^ 11  aaa$-1
^-22     $-2
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
==={'index': False, 'line_width': 1}====  # Justification is fixed
^  x  \$-0
^ 11   $-1
^-22   $-2
^$-3
^  y  $-4
^aaa  $-5
^     $-6
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```




2. It breaks a bunch of other tests that use 
`IntArrayFormatter._format_strings` because the formatting changed from `'{x: d}'` which adds a leading space for positive values, to `'{x:d}'`. My impression is that this PR eliminates an arguably unnecessary extra space for positive integers, but I haven't looked at those tests in too much detail (eg I've never used to_latex).

The tests that break and an example is shown below.

```
pandas/tests/arrays/categorical/test_repr.py::TestCategoricalRepr::test_print_none_width FAILED                                                                                                                  [  4%]
pandas/tests/io/formats/test_format.py::TestDataFrameFormatting::test_east_asian_unicode_frame FAILED                                                                                                            [  8%] 
pandas/tests/io/formats/test_format.py::TestDataFrameFormatting::test_datetimelike_frame FAILED                                                                                                                  [ 12%]
pandas/tests/io/formats/test_format.py::TestDataFrameFormatting::test_to_string_no_header FAILED                                                                                                                 [ 16%]
pandas/tests/io/formats/test_format.py::TestDataFrameFormatting::test_to_string_specified_header FAILED                                                                                                          [ 20%]
pandas/tests/io/formats/test_format.py::TestDataFrameFormatting::test_to_string_index_formatter FAILED                                                                                                           [ 25%]
pandas/tests/io/formats/test_format.py::TestDataFrameFormatting::test_to_string_line_width FAILED                                                                                                                [ 29%] 
pandas/tests/io/formats/test_format.py::TestSeriesFormatting::test_east_asian_unicode_series FAILED                                                                                                              [ 33%] 
pandas/tests/io/formats/test_format.py::TestSeriesFormatting::test_period FAILED                                                                                                                                 [ 37%]
pandas/tests/io/formats/test_format.py::TestSeriesFormatting::test_truncate_ndots FAILED                                                                                                                         [ 41%] 
pandas/tests/io/formats/test_format.py::TestSeriesFormatting::test_to_string_name FAILED                                                                                                                         [ 45%] 
pandas/tests/io/formats/test_format.py::TestSeriesFormatting::test_to_string_dtype FAILED                                                                                                                        [ 50%]
pandas/tests/io/formats/test_format.py::TestSeriesFormatting::test_to_string_length FAILED                                                                                                                       [ 54%]
pandas/tests/io/formats/test_format.py::TestSeriesFormatting::test_to_string_header FAILED                                                                                                                       [ 58%]
pandas/tests/io/formats/test_to_latex.py::TestToLatex::test_to_latex FAILED                                                                                                                                      [ 62%] 
pandas/tests/io/formats/test_to_latex.py::TestToLatex::test_to_latex_multiindex FAILED                                                                                                                           [ 66%] 
pandas/tests/io/formats/test_to_latex.py::TestToLatex::test_to_latex_multicolumnrow FAILED                                                                                                                       [ 70%] 
pandas/tests/io/formats/test_to_latex.py::TestToLatex::test_to_latex_longtable FAILED                                                                                                                            [ 75%] 
pandas/tests/io/formats/test_to_latex.py::TestToLatex::test_to_latex_no_header FAILED                                                                                                                            [ 79%] 
pandas/tests/series/test_repr.py::TestSeriesRepr::test_multilevel_name_print FAILED                                                                                                                              [ 83%]
pandas/tests/series/test_repr.py::TestCategoricalRepr::test_categorical_repr FAILED                                                                                                                              [ 87%]
pandas/tests/series/test_repr.py::TestCategoricalRepr::test_categorical_series_repr FAILED                                                                                                                       [ 91%] 
pandas/tests/series/test_repr.py::TestCategoricalRepr::test_categorical_series_repr_ordered FAILED                                                                                                               [ 95%]
pandas/tests/sparse/test_format.py::TestSparseSeriesFormatting::test_sparse_int FAILED                                                                                                                           [100%] 
```

```
______________________________________________________________________________________ TestCategoricalRepr.test_print_none_width _______________________________________________________________________________________
                                                                                                                                                                                                                        
self = <pandas.tests.arrays.categorical.test_repr.TestCategoricalRepr object at 0x12892def0>                                                                                                                            
                                                                                                                                                                                                                        
    def test_print_none_width(self):                                                                                                                                                                                    
        # GH10087                                                                                                                                                                                                       
        a = Series(Categorical([1, 2, 3, 4]))                                                                                                                                                                           
        exp = u("0    1\n1    2\n2    3\n3    4\n" +                                                                                                                                                                    
                "dtype: category\nCategories (4, int64): [1, 2, 3, 4]")                                                                                                                                                 
                                                                                                                                                                                                                        
        with option_context("display.width", None):                                                                                                                                                                    
>           assert exp == repr(a)                                                                                                                                                                                      
E           AssertionError: assert '0    1\n1   ... [1, 2, 3, 4]' == '0   1\n1   2\... [1, 2, 3, 4]'                                                                                                                   
E             - 0    1                                                                                                                                                                                                 
E             ?  -                                                                                                                                                                                                      
E             + 0   1                                                                                                                                                                                                   
E             - 1    2                                                                                                                                                                                                 
E             ?  -                                                                                                                                                                                                      
E             + 1   2                                                                                                                                                                                                   
E             - 2    3                                                                                                                                                                                                 
E             ?  -                                                                                                                                                                                                     
E             + 2   3                                                                                                                                                                                                  
E             - 3    4                                                                                                                                                                                                  
E             ?  -                                                                                                                                                                                                      
E             + 3   4                                                                                                                                                                                                   
E               dtype: category                                                                                                                                                                                         
E               Categories (4, int64): [1, 2, 3, 4]                                                                                                                                                                     
                                                                                                                                                                                                                       
pandas/tests/arrays/categorical/test_repr.py:59: AssertionError
```

The root issue, I think, is that we have `'{x: d}'.format(x=x)`, but the current tests don't want the leading space for a simple `pd.DataFrame({'x': [0, 1], 'y': [2, 3]}).to_string(index=False)`.

I have [another attempt](https://github.com/gshiba/pandas/commit/05592c74c56f997fc19d1a332f16914ebb22b6e9) at this issue, which explicitly expects the leading space, but may not be palatable to some...

Thanks.