### PR TITLE
BUG: Retain timezone information in to_datetime if box=False

### DIFF
--- a/doc/source/whatsnew/v0.24.0.txt
+++ b/doc/source/whatsnew/v0.24.0.txt
@@ -237,7 +237,7 @@ without timezone localization. This is inconsistent from parsing the same
 datetime string with :class:`Timestamp` which would preserve the UTC
 offset in the ``tz`` attribute. Now, :func:`to_datetime` preserves the UTC
 offset in the ``tz`` attribute when all the datetime strings have the same
-UTC offset (:issue:`17697`, :issue:`11736`)
+UTC offset (:issue:`17697`, :issue:`11736`, :issue:`22457`)
 
 *Previous Behavior*:
 

--- a/pandas/core/tools/datetimes.py
+++ b/pandas/core/tools/datetimes.py
@@ -277,17 +277,23 @@ def _convert_listlike_datetimes(arg, box, format, name=None, tz=None,
             )
             if tz_parsed is not None:
                 if box:
+                    # We can take a shortcut since the datetime64 numpy array
+                    # is in UTC
                     return DatetimeIndex._simple_new(result, name=name,
                                                      tz=tz_parsed)
                 else:
+                    # Convert the datetime64 numpy array to an numpy array
+                    # of datetime objects
                     result = [Timestamp(ts, tz=tz_parsed).to_pydatetime()
                               for ts in result]
                     return np.array(result, dtype=object)
 
         if box:
+            # Ensure we return an Index in all cases where box=True
             if is_datetime64_dtype(result):
                 return DatetimeIndex(result, tz=tz, name=name)
             elif is_object_dtype(result):
+                # e.g. an Index of datetime objects
                 from pandas import Index
                 return Index(result, name=name)
         return result

--- a/pandas/core/tools/datetimes.py
+++ b/pandas/core/tools/datetimes.py
@@ -275,9 +275,14 @@ def _convert_listlike_datetimes(arg, box, format, name=None, tz=None,
                 yearfirst=yearfirst,
                 require_iso8601=require_iso8601
             )
-            if tz_parsed is not None and box:
-                return DatetimeIndex._simple_new(result, name=name,
-                                                 tz=tz_parsed)
+            if tz_parsed is not None:
+                if box:
+                    return DatetimeIndex._simple_new(result, name=name,
+                                                     tz=tz_parsed)
+                else:
+                    result = [Timestamp(ts, tz=tz_parsed).to_pydatetime()
+                              for ts in result]
+                    return np.array(result, dtype=object)
 
         if box:
             if is_datetime64_dtype(result):

--- a/pandas/tests/indexes/datetimes/test_tools.py
+++ b/pandas/tests/indexes/datetimes/test_tools.py
@@ -592,6 +592,17 @@ class TestToDatetime(object):
         result = DatetimeIndex([ts_str] * 2)
         tm.assert_index_equal(result, expected)
 
+    def test_iso_8601_strings_same_offset_no_box(self):
+        # GH 22446
+        data = ['2018-01-04 09:01:00+09:00', '2018-01-04 09:02:00+09:00']
+        result = pd.to_datetime(data, box=False)
+        expected = np.array([
+            datetime(2018, 1, 4, 9, 1, tzinfo=pytz.FixedOffset(540)),
+            datetime(2018, 1, 4, 9, 2, tzinfo=pytz.FixedOffset(540))
+        ],
+            dtype=object)
+        tm.assert_numpy_array_equal(result, expected)
+
     def test_iso_8601_strings_with_different_offsets(self):
         # GH 17697, 11736
         ts_strings = ["2015-11-18 15:30:00+05:30",

--- a/pandas/tests/test_algos.py
+++ b/pandas/tests/test_algos.py
@@ -330,10 +330,9 @@ class TestUnique(object):
              '2015-01-01T00:00:00.000000000+0000'],
             dtype='M8[ns]')
 
-        dt_index = pd.to_datetime(['2015-01-03T00:00:00.000000000+0000',
-                                   '2015-01-01T00:00:00.000000000+0000',
-                                   '2015-01-01T00:00:00.000000000+0000'],
-                                  box=False)
+        dt_index = pd.to_datetime(['2015-01-03T00:00:00.000000000',
+                                   '2015-01-01T00:00:00.000000000',
+                                   '2015-01-01T00:00:00.000000000'])
         result = algos.unique(dt_index)
         tm.assert_numpy_array_equal(result, expected)
         assert result.dtype == expected.dtype


### PR DESCRIPTION
- [x] closes #22446
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`

Don't think this requires a whatsnew entry since this was introduced in (and part of) #21822 which is slated for v0.24.0