### PR TITLE
TEST: groupby(as_index=False, sort=False).aggregate formerly (?) gave unexpected results with a list-like function

### DIFF
--- a/pandas/tests/groupby/aggregate/test_other.py
+++ b/pandas/tests/groupby/aggregate/test_other.py
@@ -512,3 +512,14 @@ def test_agg_category_nansum(observed):
     if observed:
         expected = expected[expected != 0]
     tm.assert_series_equal(result, expected)
+
+
+def test_agg_list_like_func():
+    # GH 18473
+    df = pd.DataFrame({'A': [str(x) for x in range(3)],
+                       'B': [str(x) for x in range(3)]})
+    grouped = df.groupby('A', as_index=False, sort=False)
+    result = grouped.agg({'B': lambda x: list(x)})
+    expected = pd.DataFrame({'A': [str(x) for x in range(3)],
+                             'B': [[str(x)] for x in range(3)]})
+    tm.assert_frame_equal(result, expected)


### PR DESCRIPTION
- [x] closes #18473
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
