### PR TITLE
BUG: resample with TimedeltaIndex, fenceposts are off

### DIFF
--- a/doc/source/whatsnew/v0.24.0.txt
+++ b/doc/source/whatsnew/v0.24.0.txt
@@ -709,6 +709,7 @@ Groupby/Resample/Rolling
   datetime-like index leading to incorrect results and also segfault. (:issue:`21704`)
 - Bug in :meth:`Resampler.apply` when passing postiional arguments to applied func (:issue:`14615`).
 - Bug in :meth:`Series.resample` when passing ``numpy.timedelta64`` to `loffset` kwarg (:issue:`7687`).
+- Bug in :meth:`Resampler.asfreq` when frequency of ``TimedeltaIndex`` is a subperiod of a new frequency (:issue:`13022`).
 
 Sparse
 ^^^^^^

--- a/pandas/core/resample.py
+++ b/pandas/core/resample.py
@@ -1157,16 +1157,6 @@ class TimedeltaIndexResampler(DatetimeIndexResampler):
 
     def _adjust_binner_for_upsample(self, binner):
         """ adjust our binner when upsampling """
-        ax = self.ax
-
-        if is_subperiod(ax.freq, self.freq):
-            # We are actually downsampling
-            # but are in the asfreq path
-            # GH 12926
-            if self.closed == 'right':
-                binner = binner[1:]
-            else:
-                binner = binner[:-1]
         return binner
 
 

--- a/pandas/core/resample.py
+++ b/pandas/core/resample.py
@@ -963,7 +963,10 @@ class DatetimeIndexResampler(Resampler):
         return self._wrap_result(result)
 
     def _adjust_binner_for_upsample(self, binner):
-        """ adjust our binner when upsampling """
+        """
+        Adjust our binner when upsampling.
+        The range of a new index should not be outside specified range
+        """
         if self.closed == 'right':
             binner = binner[1:]
         else:
@@ -1156,7 +1159,11 @@ class TimedeltaIndexResampler(DatetimeIndexResampler):
         return self.groupby._get_time_delta_bins(self.ax)
 
     def _adjust_binner_for_upsample(self, binner):
-        """ adjust our binner when upsampling """
+        """
+        Adjust our binner when upsampling.
+        The range of a new index is allowed to be greater than original range
+        so we don't need to change the length of a binner, GH 13022
+        """
         return binner
 
 

--- a/pandas/tests/test_resample.py
+++ b/pandas/tests/test_resample.py
@@ -26,7 +26,6 @@ from pandas import (Series, DataFrame, Panel, Index, isna,
 from pandas.compat import range, lrange, zip, OrderedDict
 from pandas.errors import UnsupportedFunctionCall
 import pandas.tseries.offsets as offsets
-from pandas.tseries.frequencies import to_offset
 from pandas.tseries.offsets import Minute, BDay
 
 from pandas.core.groupby.groupby import DataError

--- a/pandas/tests/test_resample.py
+++ b/pandas/tests/test_resample.py
@@ -626,12 +626,7 @@ class Base(object):
         obj = series_and_frame
 
         result = obj.resample(freq).asfreq()
-        if freq == '2D':
-            new_index = obj.index.take(np.arange(0, len(obj.index), 2))
-            new_index.freq = to_offset('2D')
-        else:
-            new_index = self.create_index(obj.index[0], obj.index[-1],
-                                          freq=freq)
+        new_index = self.create_index(obj.index[0], obj.index[-1], freq=freq)
         expected = obj.reindex(new_index)
         assert_almost_equal(result, expected)
 
@@ -2931,6 +2926,17 @@ class TestTimedeltaIndex(Base):
                                                    periods=3,
                                                    freq='1S'))
         assert_frame_equal(result, expected)
+
+    def test_resample_as_freq_with_subperiod(self):
+        # GH 13022
+        index = timedelta_range('00:00:00', '00:10:00', freq='5T')
+        df = DataFrame(data={'value': [1, 5, 10]}, index=index)
+        result = df.resample('2T').asfreq()
+        expected_data = {'value': [1, np.nan, np.nan, np.nan, np.nan, 10]}
+        expected = DataFrame(data=expected_data,
+                             index=timedelta_range('00:00:00',
+                                                   '00:10:00', freq='2T'))
+        tm.assert_frame_equal(result, expected)
 
 
 class TestResamplerGrouper(object):


### PR DESCRIPTION
- [x] closes #13022
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry
