### PR TITLE
Wrong error message in HDFStore.append

### DIFF
--- a/pandas/io/pytables.py
+++ b/pandas/io/pytables.py
@@ -1732,10 +1732,11 @@ class IndexCol(StringMixin):
                     itemsize = self.itemsize
                 if c.itemsize < itemsize:
                     raise ValueError(
-                        "Trying to store a string with len [%s] in [%s] "
-                        "column but\nthis column has a limit of [%s]!\n"
+                        "Trying to store a string with len [%s] in the "
+                        "column [%s], but\nthis column has a limit of [%s]!\n"
                         "Consider using min_itemsize to preset the sizes on "
-                        "these columns" % (itemsize, self.cname, c.itemsize))
+                        "these columns" % (itemsize, self.values[0],
+                                           c.itemsize))
                 return c.itemsize
 
         return None


### PR DESCRIPTION
Updated pytables.py to clarify error message when appending dataframe with None item in previously string-only column

- [ ] closes #16300
- [ ] tests passed
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
