### PR TITLE
CLN: Simplify read_csv tz offset parsing

### DIFF
--- a/pandas/io/parsers.py
+++ b/pandas/io/parsers.py
@@ -1632,19 +1632,17 @@ class ParserBase(object):
 
         if try_num_bool:
             try:
-                result = lib.maybe_convert_numeric(np.asarray(values),
-                                                   na_values, False)
+                result = lib.maybe_convert_numeric(values, na_values, False)
                 na_count = isna(result).sum()
             except Exception:
                 result = values
                 if values.dtype == np.object_:
-                    na_count = parsers.sanitize_objects(np.asarray(result),
+                    na_count = parsers.sanitize_objects(result,
                                                         na_values, False)
         else:
             result = values
             if values.dtype == np.object_:
-                na_count = parsers.sanitize_objects(np.asarray(values),
-                                                    na_values, False)
+                na_count = parsers.sanitize_objects(values, na_values, False)
 
         if result.dtype == np.object_ and try_num_bool:
             result = libops.maybe_convert_bool(np.asarray(values),
@@ -3034,7 +3032,7 @@ def _make_date_converter(date_parser=None, dayfirst=False,
                 return tools.to_datetime(
                     ensure_object(strs),
                     utc=None,
-                    box=True,
+                    box=False,
                     dayfirst=dayfirst,
                     errors='ignore',
                     infer_datetime_format=infer_datetime_format


### PR DESCRIPTION
I _think_ after  #22457  we do not need the `np.asarray` calls that were introduced in #22380