### PR TITLE
CI: Bump to NumPy compat to 1.9.3

### DIFF
--- a/ci/circle-27-compat.yaml
+++ b/ci/circle-27-compat.yaml
@@ -7,7 +7,7 @@ dependencies:
   - cython=0.28.2
   - jinja2=2.8
   - numexpr=2.4.4 # we test that we correctly don't use an unsupported numexpr
-  - numpy=1.9.2
+  - numpy=1.9.3
   - openpyxl
   - psycopg2
   - pytables=3.2.2

--- a/ci/travis-27-locale.yaml
+++ b/ci/travis-27-locale.yaml
@@ -7,7 +7,7 @@ dependencies:
   - cython=0.28.2
   - lxml
   - matplotlib=1.4.3
-  - numpy=1.9.2
+  - numpy=1.9.3
   - openpyxl=2.4.0
   - python-dateutil
   - python-blosc


### PR DESCRIPTION
1.9.2 doesn't seem to be available in `/pkgs/main`. We're seeing errors like

```
ImportError: libgfortran.so.1: cannot open shared object file: No such file or directory
```

when importing numpy.

Switching to 1.9.3 (which is available in main) solves that for me locally.