### PR TITLE
Bug: exporting data frames to excel using xlsxwriter with option cons…

### DIFF
--- a/doc/source/whatsnew/v0.24.0.txt
+++ b/doc/source/whatsnew/v0.24.0.txt
@@ -671,7 +671,7 @@ Missing
 - Bug in :func:`DataFrame.fillna` where a ``ValueError`` would raise when one column contained a ``datetime64[ns, tz]`` dtype (:issue:`15522`)
 - Bug in :func:`Series.hasnans` that could be incorrectly cached and return incorrect answers if null elements are introduced after an initial call (:issue:`19700`)
 - :func:`Series.isin` now treats all nans as equal also for `np.object`-dtype. This behavior is consistent with the behavior for float64 (:issue:`22119`)
-- Bug in: class:`ExcelWriter` where exporting data frames to excel using xlsxwriter with option constant_memory set to true, most of the cells are empty. Now raises NotImlementedError. (:issue:`15392`)
+- Bug in: class:`ExcelWriter` where exporting `DataFrames` to Excel using ``xlsxwriter`` with option `constant_memory` set to True, most of the cells are empty. Now raises ``NotImlementedError``. (:issue:`15392`)
 
 MultiIndex
 ^^^^^^^^^^

--- a/doc/source/whatsnew/v0.24.0.txt
+++ b/doc/source/whatsnew/v0.24.0.txt
@@ -671,6 +671,7 @@ Missing
 - Bug in :func:`DataFrame.fillna` where a ``ValueError`` would raise when one column contained a ``datetime64[ns, tz]`` dtype (:issue:`15522`)
 - Bug in :func:`Series.hasnans` that could be incorrectly cached and return incorrect answers if null elements are introduced after an initial call (:issue:`19700`)
 - :func:`Series.isin` now treats all nans as equal also for `np.object`-dtype. This behavior is consistent with the behavior for float64 (:issue:`22119`)
+- Bug in: class:`ExcelWriter` where exporting data frames to excel using xlsxwriter with option constant_memory set to true, most of the cells are empty. Now raises NotImlementedError. (:issue:`15392`)
 
 MultiIndex
 ^^^^^^^^^^

--- a/pandas/io/excel.py
+++ b/pandas/io/excel.py
@@ -916,6 +916,14 @@ class ExcelWriter(object):
     def __init__(self, path, engine=None,
                  date_format=None, datetime_format=None, mode='w',
                  **engine_kwargs):
+
+        # check for contant_memory option
+        options = engine_kwargs.get('options', {})
+        constant_memory = options.get('constant_memory', None)
+        if constant_memory:
+            raise NotImplementedError('The option constant_memory=True is '
+                                      'not supported.')
+
         # validate that this engine can handle the extension
         if isinstance(path, string_types):
             ext = os.path.splitext(path)[-1]

--- a/pandas/tests/io/test_excel.py
+++ b/pandas/tests/io/test_excel.py
@@ -1831,9 +1831,11 @@ class TestExcelWriter(_WriterBase):
         result = read_excel(self.path, 'test_c', comment='#')
         tm.assert_frame_equal(result, expected)
 
+    # RE issue # 15392
     def test_constant_memory_option_raises_NotImplementedError(self, engine):
         df = DataFrame({'a': ['1', '2'], 'b': ['2', '3']})
-        with pytest.raises(NotImplementedError):
+        msg = 'The option constant_memory=True is not supported.'
+        with tm.assert_raises_regex(NotImplementedError, msg):
             xlw = pd.ExcelWriter(self.path, engine=engine,
                                  options=dict(constant_memory=True))
             df.to_excel(xlw)

--- a/pandas/tests/io/test_excel.py
+++ b/pandas/tests/io/test_excel.py
@@ -1831,8 +1831,9 @@ class TestExcelWriter(_WriterBase):
         result = read_excel(self.path, 'test_c', comment='#')
         tm.assert_frame_equal(result, expected)
 
-    # RE issue # 15392
     def test_constant_memory_option_raises_NotImplementedError(self, engine):
+        # Re issue # 15392
+        # Test ExcelWriter with constant_memory=True raises NotImplementedError
         df = DataFrame({'a': ['1', '2'], 'b': ['2', '3']})
         msg = 'The option constant_memory=True is not supported.'
         with tm.assert_raises_regex(NotImplementedError, msg):

--- a/pandas/tests/io/test_excel.py
+++ b/pandas/tests/io/test_excel.py
@@ -1831,6 +1831,13 @@ class TestExcelWriter(_WriterBase):
         result = read_excel(self.path, 'test_c', comment='#')
         tm.assert_frame_equal(result, expected)
 
+    def test_constant_memory_option_raises_NotImplementedError(self, engine):
+        df = DataFrame({'a': ['1', '2'], 'b': ['2', '3']})
+        with pytest.raises(NotImplementedError):
+            xlw = pd.ExcelWriter(self.path, engine=engine,
+                                 options=dict(constant_memory=True))
+            df.to_excel(xlw)
+
     def test_comment_emptyline(self, merge_cells, engine, ext):
         # Re issue #18735
         # Test that read_excel ignores commented lines at the end of file


### PR DESCRIPTION
…tant_memory set to true, most of the cells are empty. Now raises NotImlementedError. #15392

- [x] closes #15392
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry
