### PR TITLE
Fix DataFrame.to_string() justification (2)

### DIFF
--- a/doc/source/whatsnew/v0.23.5.txt
+++ b/doc/source/whatsnew/v0.23.5.txt
@@ -52,5 +52,3 @@ Bug Fixes
 **I/O**
 
 - Bug in :func:`read_csv` that caused it to raise ``OverflowError`` when trying to use 'inf' as ``na_value`` with integer index column (:issue:`17128`)
-- Bug in :func:`to_string(index=False)` that broke column alignment (:issue:`16839`, :issue:`13032`)
--

--- a/doc/source/whatsnew/v0.23.5.txt
+++ b/doc/source/whatsnew/v0.23.5.txt
@@ -52,3 +52,5 @@ Bug Fixes
 **I/O**
 
 - Bug in :func:`read_csv` that caused it to raise ``OverflowError`` when trying to use 'inf' as ``na_value`` with integer index column (:issue:`17128`)
+- Bug in :func:`to_string(index=False)` that broke column alignment (:issue:`16839`, :issue:`13032`)
+-

--- a/doc/source/whatsnew/v0.24.0.txt
+++ b/doc/source/whatsnew/v0.24.0.txt
@@ -762,6 +762,7 @@ I/O
 - :func:`read_sas()` will correctly parse sas7bdat files with many columns (:issue:`22628`)
 - :func:`read_sas()` will correctly parse sas7bdat files with data page types having also bit 7 set (so page type is 128 + 256 = 384) (:issue:`16615`)
 - Bug in :meth:`detect_client_encoding` where potential ``IOError`` goes unhandled when importing in a mod_wsgi process due to restricted access to stdout. (:issue:`21552`)
+- Bug in :func:`to_string()` that broke column alignment when ``index=False`` and width of first column's values is greater than the width of first column's header (:issue:`16839`, :issue:`13032`)
 
 Plotting
 ^^^^^^^^

--- a/pandas/io/formats/format.py
+++ b/pandas/io/formats/format.py
@@ -650,8 +650,6 @@ class DataFrameFormatter(TableFormatter):
                 self._chk_truncate()
                 strcols = self._to_str_columns()
                 text = self.adj.adjoin(1, *strcols)
-        if not self.index:
-            text = text.replace('\n ', '\n').strip()
         self.buf.writelines(text)
 
         if self.should_show_dimensions:

--- a/pandas/io/formats/format.py
+++ b/pandas/io/formats/format.py
@@ -288,8 +288,7 @@ class SeriesFormatter(object):
         if self.index:
             result = self.adj.adjoin(3, *[fmt_index[1:], fmt_values])
         else:
-            result = self.adj.adjoin(3, fmt_values).replace('\n ',
-                                                            '\n').strip()
+            result = self.adj.adjoin(3, fmt_values)
 
         if self.header and have_header:
             result = fmt_index[0] + '\n' + result

--- a/pandas/tests/io/formats/test_format.py
+++ b/pandas/tests/io/formats/test_format.py
@@ -1274,7 +1274,7 @@ class TestDataFrameFormatting(object):
 
         df_s = df.to_string(index=False)
         # Leading space is expected for positive numbers.
-        expected = ("  x   y    z\n
+        expected = ("  x   y    z\n"
                     " 11  33  AAA\n"
                     " 22 -44     ")
         assert df_s == expected

--- a/pandas/tests/io/formats/test_format.py
+++ b/pandas/tests/io/formats/test_format.py
@@ -1270,39 +1270,20 @@ class TestDataFrameFormatting(object):
 
     def test_to_string_no_index(self):
 
-        dfs = [
+        df = DataFrame({'x': [11, 22], 'y': [33, -44], 'z': ['AAA', '   ']})
 
-            # ints
-            DataFrame({'x': [1, 2, 3], 'y': [4, 5, 6]}),
-            DataFrame({'x': [11, 22, 33], 'y': [4, 5, 6]}),
-            DataFrame({'x': [11, 22, -33], 'y': [4, 5, 6]}),
-            DataFrame({'x': [11, 22, -33], 'y': [4, 5, -6]}),
-            DataFrame({'x': [11, 22, -33], 'y': [44, 55, -66]}),
+        df_s = df.to_string(index=False)
+        # Leading space is expected for positive numbers.
+        expected = ("  x   y    z\n
+                    " 11  33  AAA\n"
+                    " 22 -44     ")
+        assert df_s == expected
 
-            # floats
-            DataFrame({'x': [0.1, 0.2, -0.3], 'y': [4, 5, 6]}),
-            DataFrame({'x': [0.1, 0.2, -0.3], 'y': [0.4, 0.5, 0.6]}),
-            DataFrame({'x': [0.1, 0.2, -0.3], 'y': [0.4, 0.5, -0.6]}),
-        ]
-
-        exs = [
-
-            # ints
-            " x  y\n 1  4\n 2  5\n 3  6",
-            "  x  y\n 11  4\n 22  5\n 33  6",
-            "  x  y\n 11  4\n 22  5\n-33  6",
-            "  x  y\n 11  4\n 22  5\n-33 -6",
-            "  x   y\n 11  44\n 22  55\n-33 -66",
-
-            # floats
-            "   x  y\n 0.1  4\n 0.2  5\n-0.3  6",
-            "   x    y\n 0.1  0.4\n 0.2  0.5\n-0.3  0.6",
-            "   x    y\n 0.1  0.4\n 0.2  0.5\n-0.3 -0.6",
-        ]
-
-        for df, expected in zip(dfs, exs):
-            df_s = df.to_string(index=False)
-            assert df_s == expected
+        df_s = df[['y', 'x', 'z']].to_string(index=False)
+        expected = ("  y   x    z\n"
+                    " 33  11  AAA\n"
+                    "-44  22     ")
+        assert df_s == expected
 
     def test_to_string_line_width_no_index(self):
         df = DataFrame({'x': [1, 2, 3], 'y': [4, 5, 6]})

--- a/pandas/tests/io/formats/test_format.py
+++ b/pandas/tests/io/formats/test_format.py
@@ -1835,7 +1835,7 @@ class TestSeriesFormatting(object):
         # GH 11729 Test index=False option
         s = Series([1, 2, 3, 4])
         result = s.to_string(index=False)
-        expected = (u('1\n') + '2\n' + '3\n' + '4')
+        expected = (u(' 1\n') + ' 2\n' + ' 3\n' + ' 4')
         assert result == expected
 
     def test_unicode_name_in_footer(self):

--- a/pandas/tests/io/formats/test_format.py
+++ b/pandas/tests/io/formats/test_format.py
@@ -1269,19 +1269,40 @@ class TestDataFrameFormatting(object):
             df.to_string(header=['X'])
 
     def test_to_string_no_index(self):
-        df = DataFrame({'x': [1, 2, 3], 'y': [4, 5, 6]})
 
-        df_s = df.to_string(index=False)
-        expected = " x  y\n 1  4\n 2  5\n 3  6"
+        dfs = [
 
-        assert df_s == expected
+            # ints
+            DataFrame({'x': [1, 2, 3], 'y': [4, 5, 6]}),
+            DataFrame({'x': [11, 22, 33], 'y': [4, 5, 6]}),
+            DataFrame({'x': [11, 22, -33], 'y': [4, 5, 6]}),
+            DataFrame({'x': [11, 22, -33], 'y': [4, 5, -6]}),
+            DataFrame({'x': [11, 22, -33], 'y': [44, 55, -66]}),
 
-        df = DataFrame({'x': [1, 2, -3], 'y': [4, 5, -6]})
+            # floats
+            DataFrame({'x': [0.1, 0.2, -0.3], 'y': [4, 5, 6]}),
+            DataFrame({'x': [0.1, 0.2, -0.3], 'y': [0.4, 0.5, 0.6]}),
+            DataFrame({'x': [0.1, 0.2, -0.3], 'y': [0.4, 0.5, -0.6]}),
+        ]
 
-        df_s = df.to_string(index=False)
-        expected = " x  y\n 1  4\n 2  5\n-3 -6"
+        exs = [
 
-        assert df_s == expected
+            # ints
+            " x  y\n 1  4\n 2  5\n 3  6",
+            "  x  y\n 11  4\n 22  5\n 33  6",
+            "  x  y\n 11  4\n 22  5\n-33  6",
+            "  x  y\n 11  4\n 22  5\n-33 -6",
+            "  x   y\n 11  44\n 22  55\n-33 -66",
+
+            # floats
+            "   x  y\n 0.1  4\n 0.2  5\n-0.3  6",
+            "   x    y\n 0.1  0.4\n 0.2  0.5\n-0.3  0.6",
+            "   x    y\n 0.1  0.4\n 0.2  0.5\n-0.3 -0.6",
+        ]
+
+        for df, expected in zip(dfs, exs):
+            df_s = df.to_string(index=False)
+            assert df_s == expected
 
     def test_to_string_line_width_no_index(self):
         df = DataFrame({'x': [1, 2, 3], 'y': [4, 5, 6]})
@@ -1291,10 +1312,17 @@ class TestDataFrameFormatting(object):
 
         assert df_s == expected
 
-        df = DataFrame({'x': [1, 2, -3], 'y': [4, 5, -6]})
+        df = DataFrame({'x': [11, 22, 33], 'y': [4, 5, 6]})
 
         df_s = df.to_string(line_width=1, index=False)
-        expected = " x  \\\n 1   \n 2   \n-3   \n\n y  \n 4  \n 5  \n-6  "
+        expected = "  x  \\\n 11   \n 22   \n 33   \n\n y  \n 4  \n 5  \n 6  "
+
+        assert df_s == expected
+
+        df = DataFrame({'x': [11, 22, -33], 'y': [4, 5, -6]})
+
+        df_s = df.to_string(line_width=1, index=False)
+        expected = "  x  \\\n 11   \n 22   \n-33   \n\n y  \n 4  \n 5  \n-6  "
 
         assert df_s == expected
 

--- a/pandas/tests/io/formats/test_format.py
+++ b/pandas/tests/io/formats/test_format.py
@@ -1272,7 +1272,14 @@ class TestDataFrameFormatting(object):
         df = DataFrame({'x': [1, 2, 3], 'y': [4, 5, 6]})
 
         df_s = df.to_string(index=False)
-        expected = "x  y\n1  4\n2  5\n3  6"
+        expected = " x  y\n 1  4\n 2  5\n 3  6"
+
+        assert df_s == expected
+
+        df = DataFrame({'x': [1, 2, -3], 'y': [4, 5, -6]})
+
+        df_s = df.to_string(index=False)
+        expected = " x  y\n 1  4\n 2  5\n-3 -6"
 
         assert df_s == expected
 
@@ -1280,7 +1287,14 @@ class TestDataFrameFormatting(object):
         df = DataFrame({'x': [1, 2, 3], 'y': [4, 5, 6]})
 
         df_s = df.to_string(line_width=1, index=False)
-        expected = "x  \\\n1   \n2   \n3   \n\ny  \n4  \n5  \n6"
+        expected = " x  \\\n 1   \n 2   \n 3   \n\n y  \n 4  \n 5  \n 6  "
+
+        assert df_s == expected
+
+        df = DataFrame({'x': [1, 2, -3], 'y': [4, 5, -6]})
+
+        df_s = df.to_string(line_width=1, index=False)
+        expected = " x  \\\n 1   \n 2   \n-3   \n\n y  \n 4  \n 5  \n-6  "
 
         assert df_s == expected
 

--- a/pandas/tests/io/formats/test_format.py
+++ b/pandas/tests/io/formats/test_format.py
@@ -1269,7 +1269,7 @@ class TestDataFrameFormatting(object):
             df.to_string(header=['X'])
 
     def test_to_string_no_index(self):
-
+        # GH 16839, GH 13032
         df = DataFrame({'x': [11, 22], 'y': [33, -44], 'z': ['AAA', '   ']})
 
         df_s = df.to_string(index=False)
@@ -1286,6 +1286,7 @@ class TestDataFrameFormatting(object):
         assert df_s == expected
 
     def test_to_string_line_width_no_index(self):
+        # GH 13998, GH 22505
         df = DataFrame({'x': [1, 2, 3], 'y': [4, 5, 6]})
 
         df_s = df.to_string(line_width=1, index=False)


### PR DESCRIPTION
- [x] closes #16839, 
closes #13032
- [ ] tests added / passed
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

'Competes' with #22437 which attempts to revert `% d` to `%d` as suggested here: https://github.com/pandas-dev/pandas/issues/13032#issue-151973347 That turned out to affect a lot of tests, which in hindsight is expected; the `% d` has been around since at least 2012 (106fe994cb0eb2701).

Instead, this PR reverts parts of #11942 and embraces the leading space even when `index=False`. `df.to_string(index=False)` will print the leading space when the first column is positive only, as well as preserve leading/trailing spaces on first/last lines.

With the following code:
```python
import pandas as pd
def wrap_to_string(df, **kwargs):
    s = df.to_string(**kwargs)
    print(str(kwargs).center(25, '-'))
    for i, line in enumerate(s.split('\n')):
        print(f'^{line}$-{i}')
    print()
df = pd.DataFrame({'w': [1, 2], 'x': [3, -4], 'y': [555, 666],
                   'z': [777, -888], 'a': ['AAA', '   ']})
cols_ = list(map(list, ['wxyza', 'xyzaw', 'yzawx', 'zawxy', 'awxyz']))
for cols in cols_:
    wrap_to_string(df[cols], index=False)
```
Output with master:

```python
-----{'index': False}----  # last cell (three spaces) disappeared
^w  x    y    z    a$-0
^1  3  555  777  AAA$-1
^2 -4  666 -888$-2

-----{'index': False}----  # misaligned
^x    y    z    a  w$-0
^3  555  777  AAA  1$-1
^-4  666 -888       2$-2

-----{'index': False}----  # misaligned
^y    z    a  w  x$-0
^555  777  AAA  1  3$-1
^666 -888       2 -4$-2

-----{'index': False}----  # misaligned
^z    a  w  x    y$-0
^777  AAA  1  3  555$-1
^-888       2 -4  666$-2

-----{'index': False}----  # misaligned
^a  w  x    y    z$-0
^AAA  1  3  555  777$-1
^     2 -4  666 -888$-2
```

Output with this PR:

```python
-----{'index': False}----
^ w  x    y    z    a$-0
^ 1  3  555  777  AAA$-1
^ 2 -4  666 -888     $-2

-----{'index': False}----
^ x    y    z    a  w$-0
^ 3  555  777  AAA  1$-1
^-4  666 -888       2$-2

-----{'index': False}----
^   y    z    a  w  x$-0
^ 555  777  AAA  1  3$-1
^ 666 -888       2 -4$-2

-----{'index': False}----
^   z    a  w  x    y$-0
^ 777  AAA  1  3  555$-1
^-888       2 -4  666$-2

-----{'index': False}----
^   a  w  x    y    z$-0
^ AAA  1  3  555  777$-1
^      2 -4  666 -888$-2
```

Similar effect on Series as well.
