### PR TITLE
BUG: silent overflow in DateTimeArray subtraction

### DIFF
--- a/doc/source/whatsnew/v0.24.0.txt
+++ b/doc/source/whatsnew/v0.24.0.txt
@@ -582,6 +582,7 @@ Datetimelike
 - Bug in :class:`DataFrame` comparisons against ``Timestamp``-like objects failing to raise ``TypeError`` for inequality checks with mismatched types (:issue:`8932`,:issue:`22163`)
 - Bug in :class:`DataFrame` with mixed dtypes including ``datetime64[ns]`` incorrectly raising ``TypeError`` on equality comparisons (:issue:`13128`,:issue:`22163`)
 - Bug in :meth:`DataFrame.eq` comparison against ``NaT`` incorrectly returning ``True`` or ``NaN`` (:issue:`15697`,:issue:`22163`)
+- Bug in :class:`DatetimeIndex` subtraction that incorrectly failed to raise `OverflowError` (:issue:22492, :issue:22508)
 
 Timedelta
 ^^^^^^^^^

--- a/doc/source/whatsnew/v0.24.0.txt
+++ b/doc/source/whatsnew/v0.24.0.txt
@@ -582,7 +582,7 @@ Datetimelike
 - Bug in :class:`DataFrame` comparisons against ``Timestamp``-like objects failing to raise ``TypeError`` for inequality checks with mismatched types (:issue:`8932`,:issue:`22163`)
 - Bug in :class:`DataFrame` with mixed dtypes including ``datetime64[ns]`` incorrectly raising ``TypeError`` on equality comparisons (:issue:`13128`,:issue:`22163`)
 - Bug in :meth:`DataFrame.eq` comparison against ``NaT`` incorrectly returning ``True`` or ``NaN`` (:issue:`15697`,:issue:`22163`)
-- Bug in :class:`DatetimeIndex` subtraction that incorrectly failed to raise `OverflowError` (:issue:22492, :issue:22508)
+- Bug in :class:`DatetimeIndex` subtraction that incorrectly failed to raise `OverflowError` when the difference between :class:`Timestamp`s (a :class:`Timedelta` object) exceeds `int64` limit (:issue:`22492`, :issue:`22508`)
 
 Timedelta
 ^^^^^^^^^

--- a/doc/source/whatsnew/v0.24.0.txt
+++ b/doc/source/whatsnew/v0.24.0.txt
@@ -582,7 +582,7 @@ Datetimelike
 - Bug in :class:`DataFrame` comparisons against ``Timestamp``-like objects failing to raise ``TypeError`` for inequality checks with mismatched types (:issue:`8932`,:issue:`22163`)
 - Bug in :class:`DataFrame` with mixed dtypes including ``datetime64[ns]`` incorrectly raising ``TypeError`` on equality comparisons (:issue:`13128`,:issue:`22163`)
 - Bug in :meth:`DataFrame.eq` comparison against ``NaT`` incorrectly returning ``True`` or ``NaN`` (:issue:`15697`,:issue:`22163`)
-- Bug in :class:`DatetimeIndex` subtraction that incorrectly failed to raise `OverflowError` when the difference between :class:`Timestamp`s (a :class:`Timedelta` object) exceeds `int64` limit (:issue:`22492`, :issue:`22508`)
+- Bug in :class:`DatetimeIndex` subtraction that incorrectly failed to raise `OverflowError` (:issue:`22492`, :issue:`22508`)
 
 Timedelta
 ^^^^^^^^^

--- a/pandas/core/arrays/datetimes.py
+++ b/pandas/core/arrays/datetimes.py
@@ -459,7 +459,8 @@ class DatetimeArrayMixin(dtl.DatetimeLikeArrayMixin):
 
         self_i8 = self.asi8
         other_i8 = other.asi8
-        new_values = self_i8 - other_i8
+        new_values = checked_add_with_arr(self_i8, -other_i8,
+                                          arr_mask=self._isnan)
         if self.hasnans or other.hasnans:
             mask = (self._isnan) | (other._isnan)
             new_values[mask] = iNaT

--- a/pandas/tests/arithmetic/test_datetime64.py
+++ b/pandas/tests/arithmetic/test_datetime64.py
@@ -1578,20 +1578,22 @@ class TestDatetimeIndexArithmetic(object):
         ts_neg = pd.to_datetime(['1950-01-01', '1950-01-01'])
         ts_pos = pd.to_datetime(['1980-01-01', '1980-01-01'])
 
-        with pytest.raises(OverflowError):
-            dtimax - ts_neg
-
+        # General tests
         expected = pd.Timestamp.max.value - ts_pos[1].value
-        res = dtimax - ts_pos
-        assert res[1].value == expected
+        result = dtimax - ts_pos
+        assert result[1].value == expected
 
         expected = pd.Timestamp.min.value - ts_neg[1].value
-        res = dtimin - ts_neg
-        assert res[1].value == expected
+        result = dtimin - ts_neg
+        assert result[1].value == expected
+
+        with pytest.raises(OverflowError):
+            dtimax - ts_neg
 
         with pytest.raises(OverflowError):
             dtimin - ts_pos
 
+        # Edge cases
         tmin = pd.to_datetime([pd.Timestamp.min])
         t1 = tmin + pd.Timedelta.max + pd.Timedelta('1us')
         with pytest.raises(OverflowError):

--- a/pandas/tests/arithmetic/test_datetime64.py
+++ b/pandas/tests/arithmetic/test_datetime64.py
@@ -1571,6 +1571,7 @@ class TestDatetimeIndexArithmetic(object):
                 dtimin - variant
 
     def test_datetimeindex_sub_datetimeindex_overflow(self):
+        # GH#22492, GH#22508
         dtimax = pd.to_datetime(['now', pd.Timestamp.max])
         dtimin = pd.to_datetime(['now', pd.Timestamp.min])
 
@@ -1590,6 +1591,16 @@ class TestDatetimeIndexArithmetic(object):
 
         with pytest.raises(OverflowError):
             dtimin - ts_pos
+
+        tmin = pd.to_datetime([pd.Timestamp.min])
+        t1 = tmin + pd.Timedelta.max + pd.Timedelta('1us')
+        with pytest.raises(OverflowError):
+            t1 - tmin
+
+        tmax = pd.to_datetime([pd.Timestamp.max])
+        t2 = tmax + pd.Timedelta.min - pd.Timedelta('1us')
+        with pytest.raises(OverflowError):
+            tmax - t2
 
     @pytest.mark.parametrize('names', [('foo', None, None),
                                        ('baz', 'bar', None),

--- a/pandas/tests/arithmetic/test_datetime64.py
+++ b/pandas/tests/arithmetic/test_datetime64.py
@@ -1570,6 +1570,27 @@ class TestDatetimeIndexArithmetic(object):
             with pytest.raises(OverflowError):
                 dtimin - variant
 
+    def test_datetimeindex_sub_datetimeindex_overflow(self):
+        dtimax = pd.to_datetime(['now', pd.Timestamp.max])
+        dtimin = pd.to_datetime(['now', pd.Timestamp.min])
+
+        ts_neg = pd.to_datetime(['1950-01-01', '1950-01-01'])
+        ts_pos = pd.to_datetime(['1980-01-01', '1980-01-01'])
+
+        with pytest.raises(OverflowError):
+            dtimax - ts_neg
+
+        expected = pd.Timestamp.max.value - ts_pos[1].value
+        res = dtimax - ts_pos
+        assert res[1].value == expected
+
+        expected = pd.Timestamp.min.value - ts_neg[1].value
+        res = dtimin - ts_neg
+        assert res[1].value == expected
+
+        with pytest.raises(OverflowError):
+            dtimin - ts_pos
+    
     @pytest.mark.parametrize('names', [('foo', None, None),
                                        ('baz', 'bar', None),
                                        ('bar', 'bar', 'bar')])

--- a/pandas/tests/arithmetic/test_datetime64.py
+++ b/pandas/tests/arithmetic/test_datetime64.py
@@ -1590,7 +1590,7 @@ class TestDatetimeIndexArithmetic(object):
 
         with pytest.raises(OverflowError):
             dtimin - ts_pos
-    
+
     @pytest.mark.parametrize('names', [('foo', None, None),
                                        ('baz', 'bar', None),
                                        ('bar', 'bar', 'bar')])


### PR DESCRIPTION
- [x] closes #22492
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry
