### PR TITLE
TST: fixturize series/test_alter_axes.py

### DIFF
--- a/pandas/tests/series/conftest.py
+++ b/pandas/tests/series/conftest.py
@@ -6,26 +6,44 @@ from pandas import Series
 
 
 @pytest.fixture
-def ts():
-    ts = tm.makeTimeSeries()
-    ts.name = 'ts'
-    return ts
+def datetime_series():
+    """
+    Fixture for Series of floats with DatetimeIndex
+
+    See pandas.util.testing.makeTimeSeries
+    """
+    s = tm.makeTimeSeries()
+    s.name = 'ts'
+    return s
 
 
 @pytest.fixture
-def series():
-    series = tm.makeStringSeries()
-    series.name = 'series'
-    return series
+def string_series():
+    """
+    Fixture for Series of floats with Index of unique strings
+
+    See pandas.util.testing.makeStringSeries
+    """
+    s = tm.makeStringSeries()
+    s.name = 'series'
+    return s
 
 
 @pytest.fixture
-def objSeries():
-    objSeries = tm.makeObjectSeries()
-    objSeries.name = 'objects'
-    return objSeries
+def object_series():
+    """
+    Fixture for Series of dtype datetime64[ns] with Index of unique strings
+
+    See pandas.util.testing.makeObjectSeries
+    """
+    s = tm.makeObjectSeries()
+    s.name = 'objects'
+    return s
 
 
 @pytest.fixture
-def empty():
+def empty_series():
+    """
+    Fixture for empty Series
+    """
     return Series([], index=[])

--- a/pandas/tests/series/conftest.py
+++ b/pandas/tests/series/conftest.py
@@ -9,8 +9,6 @@ from pandas import Series
 def datetime_series():
     """
     Fixture for Series of floats with DatetimeIndex
-
-    See pandas.util.testing.makeTimeSeries
     """
     s = tm.makeTimeSeries()
     s.name = 'ts'
@@ -21,8 +19,6 @@ def datetime_series():
 def string_series():
     """
     Fixture for Series of floats with Index of unique strings
-
-    See pandas.util.testing.makeStringSeries
     """
     s = tm.makeStringSeries()
     s.name = 'series'
@@ -33,8 +29,6 @@ def string_series():
 def object_series():
     """
     Fixture for Series of dtype datetime64[ns] with Index of unique strings
-
-    See pandas.util.testing.makeObjectSeries
     """
     s = tm.makeObjectSeries()
     s.name = 'objects'

--- a/pandas/tests/series/conftest.py
+++ b/pandas/tests/series/conftest.py
@@ -1,0 +1,31 @@
+import pytest
+
+import pandas.util.testing as tm
+
+from pandas import Series
+
+
+@pytest.fixture
+def ts():
+    ts = tm.makeTimeSeries()
+    ts.name = 'ts'
+    return ts
+
+
+@pytest.fixture
+def series():
+    series = tm.makeStringSeries()
+    series.name = 'series'
+    return series
+
+
+@pytest.fixture
+def objSeries():
+    objSeries = tm.makeObjectSeries()
+    objSeries.name = 'objects'
+    return objSeries
+
+
+@pytest.fixture
+def empty():
+    return Series([], index=[])

--- a/pandas/tests/series/test_alter_axes.py
+++ b/pandas/tests/series/test_alter_axes.py
@@ -13,23 +13,24 @@ from pandas.compat import lrange, range, zip
 import pandas.util.testing as tm
 
 
-class TestSeriesAlterAxes():
+class TestSeriesAlterAxes(object):
 
-    def test_setindex(self, series):
+    def test_setindex(self, string_series):
         # wrong type
-        pytest.raises(TypeError, setattr, series, 'index', None)
+        pytest.raises(TypeError, setattr, string_series, 'index', None)
 
         # wrong length
-        pytest.raises(Exception, setattr, series, 'index',
-                      np.arange(len(series) - 1))
+        pytest.raises(Exception, setattr, string_series, 'index',
+                      np.arange(len(string_series) - 1))
 
         # works
-        series.index = np.arange(len(series))
-        assert isinstance(series.index, Index)
+        string_series.index = np.arange(len(string_series))
+        assert isinstance(string_series.index, Index)
 
     # Renaming
 
-    def test_rename(self, ts):
+    def test_rename(self, datetime_series):
+        ts = datetime_series
         renamer = lambda x: x.strftime('%Y%m%d')
         renamed = ts.rename(renamer)
         assert renamed.index[0] == renamer(ts.index[0])
@@ -99,12 +100,12 @@ class TestSeriesAlterAxes():
         assert s.name is None
         assert s is not s2
 
-    def test_rename_inplace(self, ts):
+    def test_rename_inplace(self, datetime_series):
         renamer = lambda x: x.strftime('%Y%m%d')
-        expected = renamer(ts.index[0])
+        expected = renamer(datetime_series.index[0])
 
-        ts.rename(renamer, inplace=True)
-        assert ts.index[0] == expected
+        datetime_series.rename(renamer, inplace=True)
+        assert datetime_series.index[0] == expected
 
     def test_set_index_makes_timeseries(self):
         idx = tm.makeDateIndex(10)
@@ -221,11 +222,10 @@ class TestSeriesAlterAxes():
         expected = Series(np.arange(6), index=e_idx)
         tm.assert_series_equal(result, expected)
 
-    def test_rename_axis_inplace(self, ts):
+    def test_rename_axis_inplace(self, datetime_series):
         # GH 15704
-        series = ts.copy()
-        expected = series.rename_axis('foo')
-        result = series.copy()
+        expected = datetime_series.rename_axis('foo')
+        result = datetime_series
         no_return = result.rename_axis('foo', inplace=True)
 
         assert no_return is None


### PR DESCRIPTION
- [x] prep for #22225, in the sense that it preempts (and splits off) the test-related changes that have been required on the DataFrame-side of the PR (see  #22236)
- [x] tests modified / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`

In particular, it takes the fixture-like attributes of `tests/series/common.TestData` and transforms them into fixtures in `tests/series/conftest.py`, with the eventual goal of replacing all the `TestData`-attributes in the Series tests, similar to #22471 (I can also open a sister issue to that for the Series tests).