### PR TITLE
Added capture_stderr decorator to test_validate_docstrings

### DIFF
--- a/pandas/tests/scripts/test_validate_docstrings.py
+++ b/pandas/tests/scripts/test_validate_docstrings.py
@@ -4,6 +4,8 @@ import sys
 import numpy as np
 import pytest
 
+from pandas.util.testing import capture_stderr
+
 
 class GoodDocStrings(object):
     """
@@ -553,10 +555,12 @@ class TestValidator(object):
 
         return base_path
 
+    @capture_stderr
     def test_good_class(self):
         assert validate_one(self._import_path(  # noqa: F821
             klass='GoodDocStrings')) == 0
 
+    @capture_stderr
     @pytest.mark.parametrize("func", [
         'plot', 'sample', 'random_letters', 'sample_values', 'head', 'head1',
         'contains', 'mode'])
@@ -564,10 +568,12 @@ class TestValidator(object):
         assert validate_one(self._import_path(   # noqa: F821
             klass='GoodDocStrings', func=func)) == 0
 
+    @capture_stderr
     def test_bad_class(self):
         assert validate_one(self._import_path(  # noqa: F821
             klass='BadGenericDocStrings')) > 0
 
+    @capture_stderr
     @pytest.mark.parametrize("func", [
         'func', 'astype', 'astype1', 'astype2', 'astype3', 'plot', 'method'])
     def test_bad_generic_functions(self, func):

--- a/pandas/util/testing.py
+++ b/pandas/util/testing.py
@@ -673,7 +673,7 @@ def capture_stderr(f):
     AssertionError: assert 'foo\n' == 'bar\n'
     """
 
-    @wraps(f)
+    @compat.wraps(f)
     def wrapper(*args, **kwargs):
         try:
             sys.stderr = StringIO()


### PR DESCRIPTION
- [X] closes #22483
- [X] tests added / passed
- [X] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

Originally thought it would be nice to have this as a class decorator, but usage of this conflicts with the `capsys` fixture used by `test_bad_examples` so had to pick and choose where to apply. Additionally the decorator doesn't work out of the box to wrap classes, so it would take a decent amount more code.

cc @gfyoung will present minor merge conflicts with your work in #22531