### PR TITLE
CLN: use 'codes' rather than 'values' internally in Categorical

### DIFF
--- a/pandas/core/arrays/categorical.py
+++ b/pandas/core/arrays/categorical.py
@@ -1736,7 +1736,7 @@ class Categorical(ExtensionArray, PandasObject):
             raise NotImplementedError("specifying a limit for fillna has not "
                                       "been implemented yet")
 
-        values = self._codes
+        codes = self._codes
 
         # pad / bfill
         if method is not None:
@@ -1744,7 +1744,7 @@ class Categorical(ExtensionArray, PandasObject):
             values = self.to_dense().reshape(-1, len(self))
             values = interpolate_2d(values, method, 0, None,
                                     value).astype(self.categories.dtype)[0]
-            values = _get_codes_for_values(values, self.categories)
+            codes = _get_codes_for_values(values, self.categories)
 
         else:
 
@@ -1756,27 +1756,27 @@ class Categorical(ExtensionArray, PandasObject):
 
                 values_codes = _get_codes_for_values(value, self.categories)
                 indexer = np.where(values_codes != -1)
-                values[indexer] = values_codes[values_codes != -1]
+                codes[indexer] = values_codes[values_codes != -1]
 
             # If value is not a dict or Series it should be a scalar
             elif is_hashable(value):
                 if not isna(value) and value not in self.categories:
                     raise ValueError("fill value must be in categories")
 
-                mask = values == -1
+                mask = codes == -1
                 if mask.any():
-                    values = values.copy()
+                    codes = codes.copy()
                     if isna(value):
-                        values[mask] = -1
+                        codes[mask] = -1
                     else:
-                        values[mask] = self.categories.get_loc(value)
+                        codes[mask] = self.categories.get_loc(value)
 
             else:
                 raise TypeError('"value" parameter must be a scalar, dict '
                                 'or Series, but you passed a '
                                 '"{0}"'.format(type(value).__name__))
 
-        return self._constructor(values, dtype=self.dtype, fastpath=True)
+        return self._constructor(codes, dtype=self.dtype, fastpath=True)
 
     def take_nd(self, indexer, allow_fill=None, fill_value=None):
         """
@@ -2148,14 +2148,12 @@ class Categorical(ExtensionArray, PandasObject):
         """
 
         import pandas._libs.hashtable as htable
-        values = self._codes
+        codes = self._codes
         if dropna:
             good = self._codes != -1
-            values = self._codes[good]
-        values = sorted(htable.mode_int64(ensure_int64(values), dropna))
-        result = self._constructor(values=values, dtype=self.dtype,
-                                   fastpath=True)
-        return result
+            codes = self._codes[good]
+        codes = sorted(htable.mode_int64(ensure_int64(codes), dropna))
+        return self._constructor(values=codes, dtype=self.dtype, fastpath=True)
 
     def unique(self):
         """

--- a/pandas/core/indexes/category.py
+++ b/pandas/core/indexes/category.py
@@ -460,9 +460,7 @@ class CategoricalIndex(Index, accessor.PandasDelegate):
             other = self._na_value
         values = np.where(cond, self.values, other)
 
-        cat = Categorical(values,
-                          categories=self.categories,
-                          ordered=self.ordered)
+        cat = Categorical(values, dtype=self.dtype)
         return self._shallow_copy(cat, **self._get_attributes_dict())
 
     def reindex(self, target, method=None, level=None, limit=None,


### PR DESCRIPTION
In some places a variable has the name ``values``, where ``codes`` would be more logical, as we're dealing with codes.

This makes it a bit easier to understand what we're looking at when reading IMO,