### PR TITLE
[ENH] pull in warning for dialect change from pandas-gbq

### DIFF
--- a/doc/source/whatsnew/v0.24.0.txt
+++ b/doc/source/whatsnew/v0.24.0.txt
@@ -170,9 +170,9 @@ Other Enhancements
 - :meth:`Series.droplevel` and :meth:`DataFrame.droplevel` are now implemented (:issue:`20342`)
 - Added support for reading from Google Cloud Storage via the ``gcsfs`` library (:issue:`19454`)
 - :func:`to_gbq` and :func:`read_gbq` signature and documentation updated to
-  reflect changes from the `Pandas-GBQ library version 0.5.0
-  <https://pandas-gbq.readthedocs.io/en/latest/changelog.html#changelog-0-5-0>`__.
-  (:issue:`21627`)
+  reflect changes from the `Pandas-GBQ library version 0.6.0
+  <https://pandas-gbq.readthedocs.io/en/latest/changelog.html#changelog-0-6-0>`__.
+  (:issue:`21627`, :issue:`22557`)
 - New method :meth:`HDFStore.walk` will recursively walk the group hierarchy of an HDF5 file (:issue:`10932`)
 - :func:`read_html` copies cell data across ``colspan`` and ``rowspan``, and it treats all-``th`` table rows as headers if ``header`` kwarg is not given and there is no ``thead`` (:issue:`17054`)
 - :meth:`Series.nlargest`, :meth:`Series.nsmallest`, :meth:`DataFrame.nlargest`, and :meth:`DataFrame.nsmallest` now accept the value ``"all"`` for the ``keep`` argument. This keeps all ties for the nth largest/smallest value (:issue:`16818`)

--- a/pandas/io/gbq.py
+++ b/pandas/io/gbq.py
@@ -1,5 +1,7 @@
 """ Google BigQuery support """
 
+import warnings
+
 
 def _try_import():
     # since pandas is a dependency of pandas-gbq
@@ -23,7 +25,7 @@ def _try_import():
 
 def read_gbq(query, project_id=None, index_col=None, col_order=None,
              reauth=False, private_key=None, auth_local_webserver=False,
-             dialect='legacy', location=None, configuration=None,
+             dialect=None, location=None, configuration=None,
              verbose=None):
     """
     Load data from Google BigQuery.
@@ -65,6 +67,8 @@ def read_gbq(query, project_id=None, index_col=None, col_order=None,
 
         *New in version 0.2.0 of pandas-gbq*.
     dialect : str, default 'legacy'
+        Note: The default value is changing to 'standard' in a future verion.
+
         SQL syntax dialect to use. Value can be one of:
 
         ``'legacy'``
@@ -76,6 +80,8 @@ def read_gbq(query, project_id=None, index_col=None, col_order=None,
             compliant with the SQL 2011 standard. For more information
             see `BigQuery Standard SQL Reference
             <https://cloud.google.com/bigquery/docs/reference/standard-sql/>`__.
+
+        .. versionchanged:: 0.24.0
     location : str, optional
         Location where the query job should run. See the `BigQuery locations
         documentation
@@ -108,6 +114,17 @@ def read_gbq(query, project_id=None, index_col=None, col_order=None,
     pandas.DataFrame.to_gbq : Write a DataFrame to Google BigQuery.
     """
     pandas_gbq = _try_import()
+
+    if dialect is None:
+        dialect = "legacy"
+        warnings.warn(
+            'The default value for dialect is changing to "standard" in a '
+            'future version of pandas-gbq. Pass in dialect="legacy" to '
+            "disable this warning.",
+            FutureWarning,
+            stacklevel=2,
+        )
+
     return pandas_gbq.read_gbq(
         query, project_id=project_id, index_col=index_col,
         col_order=col_order, reauth=reauth, verbose=verbose,

--- a/pandas/tests/io/test_gbq.py
+++ b/pandas/tests/io/test_gbq.py
@@ -4,11 +4,17 @@ import pytz
 import platform
 import os
 
+try:
+    from unittest import mock
+except ImportError:
+    mock = pytest.importorskip("mock")
+
 import numpy as np
 import pandas as pd
 from pandas import compat, DataFrame
-
 from pandas.compat import range
+import pandas.util.testing as tm
+
 
 pandas_gbq = pytest.importorskip('pandas_gbq')
 
@@ -91,6 +97,16 @@ def make_mixed_dataframe_v2(test_size):
                       'strs': strs[0],
                       'times': times[0]},
                      index=range(test_size))
+
+
+def test_read_gbq_without_dialect_warns_future_change(monkeypatch):
+    # Default dialect is changing to standard SQL. See:
+    # https://github.com/pydata/pandas-gbq/issues/195
+    mock_read_gbq = mock.Mock()
+    mock_read_gbq.return_value = DataFrame([[1.0]])
+    monkeypatch.setattr(pandas_gbq, 'read_gbq', mock_read_gbq)
+    with tm.assert_produces_warning(FutureWarning):
+        pd.read_gbq("SELECT 1")
 
 
 @pytest.mark.single


### PR DESCRIPTION
- [x] ~closes~ towards https://github.com/pydata/pandas-gbq/issues/195
- [x] tests added / passed (N/A)
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry
