### PR TITLE
ENH/BUG: Add is_dst method to DatetimeIndex and Timestamp to solve AmbiguousTimeError

### DIFF
--- a/doc/source/api.rst
+++ b/doc/source/api.rst
@@ -582,6 +582,7 @@ These can be accessed like ``Series.dt.<property>``.
    Series.dt.to_pydatetime
    Series.dt.tz_localize
    Series.dt.tz_convert
+   Series.dt.is_dst
    Series.dt.normalize
    Series.dt.strftime
    Series.dt.round
@@ -1778,6 +1779,7 @@ Time-specific operations
    DatetimeIndex.snap
    DatetimeIndex.tz_convert
    DatetimeIndex.tz_localize
+   DatetimeIndex.is_dst
    DatetimeIndex.round
    DatetimeIndex.floor
    DatetimeIndex.ceil

--- a/doc/source/api.rst
+++ b/doc/source/api.rst
@@ -1987,6 +1987,7 @@ Methods
     Timestamp.isocalendar
     Timestamp.isoformat
     Timestamp.isoweekday
+    Timestamp.is_dst
     Timestamp.month_name
     Timestamp.normalize
     Timestamp.now

--- a/doc/source/whatsnew/v0.24.0.txt
+++ b/doc/source/whatsnew/v0.24.0.txt
@@ -184,7 +184,7 @@ Other Enhancements
 - :class:`DatetimeIndex` gained :attr:`DatetimeIndex.timetz` attribute. Returns local time with timezone information. (:issue:`21358`)
 - :class:`Resampler` now is iterable like :class:`GroupBy` (:issue:`15314`).
 - :ref:`Series.resample` and :ref:`DataFrame.resample` have gained the :meth:`Resampler.quantile` (:issue:`15023`).
-- :class:`DatetimeIndex` has gained a ``is_dst`` method (:issue:`18885`, :issue:`18946`)
+- :class:`DatetimeIndex` and :class:`Timestamp` have gained a ``is_dst`` method (:issue:`18885`, :issue:`18946`)
 
 .. _whatsnew_0240.api_breaking:
 

--- a/doc/source/whatsnew/v0.24.0.txt
+++ b/doc/source/whatsnew/v0.24.0.txt
@@ -184,7 +184,7 @@ Other Enhancements
 - :class:`DatetimeIndex` gained :attr:`DatetimeIndex.timetz` attribute. Returns local time with timezone information. (:issue:`21358`)
 - :class:`Resampler` now is iterable like :class:`GroupBy` (:issue:`15314`).
 - :ref:`Series.resample` and :ref:`DataFrame.resample` have gained the :meth:`Resampler.quantile` (:issue:`15023`).
-- :class:`DatetimeIndex` and :class:`Timestamp` have gained a ``is_dst`` method (:issue:`18885`, :issue:`18946`)
+- :class:`DatetimeIndex` and :class:`Timestamp` have gained an ``is_dst`` method (:issue:`18885`, :issue:`18946`)
 
 .. _whatsnew_0240.api_breaking:
 

--- a/doc/source/whatsnew/v0.24.0.txt
+++ b/doc/source/whatsnew/v0.24.0.txt
@@ -184,6 +184,7 @@ Other Enhancements
 - :class:`DatetimeIndex` gained :attr:`DatetimeIndex.timetz` attribute. Returns local time with timezone information. (:issue:`21358`)
 - :class:`Resampler` now is iterable like :class:`GroupBy` (:issue:`15314`).
 - :ref:`Series.resample` and :ref:`DataFrame.resample` have gained the :meth:`Resampler.quantile` (:issue:`15023`).
+- :class:`DatetimeIndex` has gained a `is_dst` method.
 
 .. _whatsnew_0240.api_breaking:
 

--- a/doc/source/whatsnew/v0.24.0.txt
+++ b/doc/source/whatsnew/v0.24.0.txt
@@ -184,7 +184,7 @@ Other Enhancements
 - :class:`DatetimeIndex` gained :attr:`DatetimeIndex.timetz` attribute. Returns local time with timezone information. (:issue:`21358`)
 - :class:`Resampler` now is iterable like :class:`GroupBy` (:issue:`15314`).
 - :ref:`Series.resample` and :ref:`DataFrame.resample` have gained the :meth:`Resampler.quantile` (:issue:`15023`).
-- :class:`DatetimeIndex` has gained a `is_dst` method.
+- :class:`DatetimeIndex` has gained a ``is_dst`` method (:issue:`18885`, :issue:`18946`)
 
 .. _whatsnew_0240.api_breaking:
 
@@ -616,6 +616,8 @@ Timezones
 - Bug when setting a new value with :meth:`DataFrame.loc` with a :class:`DatetimeIndex` with a DST transition (:issue:`18308`, :issue:`20724`)
 - Bug in :meth:`DatetimeIndex.unique` that did not re-localize tz-aware dates correctly (:issue:`21737`)
 - Bug when indexing a :class:`Series` with a DST transition (:issue:`21846`)
+- Bug in :meth:`DatetimeIndex.floor` that raised an ``AmbiguousTimeError`` during a DST transition (:issue:`18946`)
+- Bug in :func:`merge` when merging ``datetime64[ns, tz]`` data that contained a DST transition (:issue:`18885`)
 
 Offsets
 ^^^^^^^

--- a/pandas/_libs/tslib.pyx
+++ b/pandas/_libs/tslib.pyx
@@ -146,7 +146,7 @@ def ints_to_pydatetime(int64_t[:] arr, tz=None, freq=None, box="datetime"):
                 dt64_to_dtstruct(local_value, &dts)
                 result[i] = func_create(value, dts, tz, freq)
     else:
-        trans, deltas, typ = get_dst_info(tz)
+        trans, deltas, typ = get_dst_info(tz, False)
 
         if typ not in ['pytz', 'dateutil']:
             # static/fixed; in this case we know that len(delta) == 1

--- a/pandas/_libs/tslibs/nattype.pyx
+++ b/pandas/_libs/tslibs/nattype.pyx
@@ -260,6 +260,20 @@ class NaTType(_NaT):
     def is_year_end(self):
         return False
 
+    def is_dst(self):
+        """
+        Returns a boolean indicating if the Timestamp is in daylight savings
+        time. Naive timestamps are considered not to be in daylight savings
+        time.
+
+        Returns
+        -------
+        Boolean
+            True if the Timestamp is in daylight savings time
+            False if the Timestamp is naive or not in daylight savings time
+        """
+        return False
+
     def __rdiv__(self, other):
         return _nat_rdivide_op(self, other)
 
@@ -353,6 +367,7 @@ class NaTType(_NaT):
     strptime = _make_error_func('strptime', datetime)
     strftime = _make_error_func('strftime', datetime)
     isocalendar = _make_error_func('isocalendar', datetime)
+    dst = _make_error_func('dst', datetime)
     ctime = _make_error_func('ctime', datetime)
     time = _make_error_func('time', datetime)
     toordinal = _make_error_func('toordinal', datetime)

--- a/pandas/_libs/tslibs/nattype.pyx
+++ b/pandas/_libs/tslibs/nattype.pyx
@@ -353,7 +353,6 @@ class NaTType(_NaT):
     strptime = _make_error_func('strptime', datetime)
     strftime = _make_error_func('strftime', datetime)
     isocalendar = _make_error_func('isocalendar', datetime)
-    dst = _make_error_func('dst', datetime)
     ctime = _make_error_func('ctime', datetime)
     time = _make_error_func('time', datetime)
     toordinal = _make_error_func('toordinal', datetime)

--- a/pandas/_libs/tslibs/period.pyx
+++ b/pandas/_libs/tslibs/period.pyx
@@ -1516,7 +1516,7 @@ cdef int64_t[:] localize_dt64arr_to_period(int64_t[:] stamps,
             result[i] = get_period_ordinal(&dts, freq)
     else:
         # Adjust datetime64 timestamp, recompute datetimestruct
-        trans, deltas, typ = get_dst_info(tz)
+        trans, deltas, typ = get_dst_info(tz, False)
 
         if typ not in ['pytz', 'dateutil']:
             # static/fixed; in this case we know that len(delta) == 1

--- a/pandas/_libs/tslibs/resolution.pyx
+++ b/pandas/_libs/tslibs/resolution.pyx
@@ -68,7 +68,7 @@ cdef _reso_local(int64_t[:] stamps, object tz):
                 reso = curr_reso
     else:
         # Adjust datetime64 timestamp, recompute datetimestruct
-        trans, deltas, typ = get_dst_info(tz)
+        trans, deltas, typ = get_dst_info(tz, False)
 
         if typ not in ['pytz', 'dateutil']:
             # static/fixed; in this case we know that len(delta) == 1

--- a/pandas/_libs/tslibs/timestamps.pyx
+++ b/pandas/_libs/tslibs/timestamps.pyx
@@ -722,6 +722,20 @@ class Timestamp(_Timestamp):
         raise AttributeError("Cannot directly set timezone. Use tz_localize() "
                              "or tz_convert() as appropriate")
 
+    def is_dst(self):
+        """
+        Returns a boolean indicating if the Timestamp is in daylight savings
+        time. Naive timestamps are considered not to be in daylight savings
+        time.
+
+        Returns
+        -------
+        Boolean
+            True if the Timestamp is in daylight savings time
+            False if the Timestamp is naive or not in daylight savings time
+        """
+        return bool(self.dst())
+
     def __setstate__(self, state):
         self.value = state[0]
         self.freq = state[1]

--- a/pandas/_libs/tslibs/timezones.pxd
+++ b/pandas/_libs/tslibs/timezones.pxd
@@ -13,4 +13,4 @@ cpdef object maybe_get_tz(object tz)
 cdef get_utcoffset(tzinfo, obj)
 cdef bint is_fixed_offset(object tz)
 
-cdef object get_dst_info(object tz, dst)
+cdef object get_dst_info(object tz, bint dst)

--- a/pandas/_libs/tslibs/timezones.pxd
+++ b/pandas/_libs/tslibs/timezones.pxd
@@ -13,4 +13,4 @@ cpdef object maybe_get_tz(object tz)
 cdef get_utcoffset(tzinfo, obj)
 cdef bint is_fixed_offset(object tz)
 
-cdef object get_dst_info(object tz)
+cdef object get_dst_info(object tz, dst)

--- a/pandas/_libs/tslibs/timezones.pyx
+++ b/pandas/_libs/tslibs/timezones.pyx
@@ -305,9 +305,8 @@ cdef object get_dst_info(object tz, dst):
 
 def _is_dst(int64_t[:] values, object tz):
     """
-    Return a boolean array where True indicates a value that lies in
-    daylight savings time and False indicates a value that does not lie in
-    daylight savings time
+    Return a boolean array indicating whether each epoch timestamp is in
+    daylight savings time with respect with the passed timezone.
 
     Parameters
     ----------
@@ -318,8 +317,8 @@ def _is_dst(int64_t[:] values, object tz):
 
     Returns
     -------
-    ndarray
-        Booleans
+    ndarray of booleans
+        True indicates daylight savings time
     """
     cdef:
         Py_ssize_t n = len(values)

--- a/pandas/core/indexes/datetimelike.py
+++ b/pandas/core/indexes/datetimelike.py
@@ -284,7 +284,7 @@ class DatetimeIndexOpsMixin(DatetimeLikeArrayMixin):
         if getattr(self, 'tz', None) is not None:
             if not isinstance(result, ABCIndexClass):
                 result = self._simple_new(result)
-            result = result.tz_localize(self.tz)
+            result = result.tz_localize(self.tz, ambiguous=self.is_dst())
         return result
 
     def _box_values_as_index(self):

--- a/pandas/core/indexes/datetimes.py
+++ b/pandas/core/indexes/datetimes.py
@@ -266,7 +266,7 @@ class DatetimeIndex(DatetimeArrayMixin, DatelikeOps, TimelikeOps,
     _datetimelike_methods = ['to_period', 'tz_localize',
                              'tz_convert',
                              'normalize', 'strftime', 'round', 'floor',
-                             'ceil', 'month_name', 'day_name']
+                             'ceil', 'month_name', 'day_name', 'is_dst']
 
     _is_numeric_dtype = False
     _infer_as_myclass = True
@@ -442,6 +442,38 @@ class DatetimeIndex(DatetimeArrayMixin, DatelikeOps, TimelikeOps,
         # GH 3746: Prevent localizing or converting the index by setting tz
         raise AttributeError("Cannot directly set timezone. Use tz_localize() "
                              "or tz_convert() as appropriate")
+
+    def is_dst(self):
+        """
+        Returns an Index of booleans indicating if each corresponding timestamp
+        is in daylight savings time.
+
+        If the DatetimeIndex does not have a timezone, returns an Index
+        who's values are all False.
+
+        Returns
+        -------
+        Index
+            True if the timestamp is in daylight savings time else False
+
+        Example
+        -------
+        >>> dti = pd.date_range('2018-11-04', periods=4, freq='H',
+                                tz='US/Pacific')
+
+        >>> dti
+        DatetimeIndex(['2018-11-04 00:00:00-07:00',
+                       '2018-11-04 01:00:00-07:00',
+                       '2018-11-04 01:00:00-08:00',
+                       '2018-11-04 02:00:00-08:00'],
+                      dtype='datetime64[ns, US/Pacific]', freq='H')
+
+        >>> dti.is_dst()
+        Index([True, True, False, False], dtype='object')
+        """
+        if self.tz is None:
+            return Index([False] * len(self))
+        return Index([bool(ts.dst()) for ts in self])
 
     @property
     def size(self):

--- a/pandas/core/indexes/datetimes.py
+++ b/pandas/core/indexes/datetimes.py
@@ -471,7 +471,7 @@ class DatetimeIndex(DatetimeArrayMixin, DatelikeOps, TimelikeOps,
         >>> dti.is_dst()
         Index([True, True, False, False], dtype='object')
         """
-        return Index(timezones._is_dst(self.asi8, self.tz))
+        return Index(timezones.is_dst(self.asi8, self.tz))
 
     @property
     def size(self):

--- a/pandas/core/indexes/datetimes.py
+++ b/pandas/core/indexes/datetimes.py
@@ -471,9 +471,7 @@ class DatetimeIndex(DatetimeArrayMixin, DatelikeOps, TimelikeOps,
         >>> dti.is_dst()
         Index([True, True, False, False], dtype='object')
         """
-        if self.tz is None:
-            return Index([False] * len(self))
-        return Index([bool(ts.dst()) for ts in self])
+        return Index(timezones._is_dst(self.asi8, self.tz))
 
     @property
     def size(self):

--- a/pandas/tests/indexes/datetimes/test_timezones.py
+++ b/pandas/tests/indexes/datetimes/test_timezones.py
@@ -1012,6 +1012,17 @@ class TestDatetimeIndexTimezones(object):
         for i, ts in enumerate(index):
             assert ts == index[i]
 
+    def test_is_dst(self):
+        dti = pd.date_range('2018-11-04', periods=4, freq='H', tz='US/Pacific')
+        result = dti.is_dst()
+        expected = Index([True, True, False, False])
+        tm.assert_index_equal(result, expected)
+
+        dti_naive = dti.tz_localize(None)
+        result = dti_naive.is_dst()
+        expected = Index([False] * 4)
+        tm.assert_index_equal(result, expected)
+
 
 class TestDateRange(object):
     """Tests for date_range with timezones"""

--- a/pandas/tests/indexes/datetimes/test_timezones.py
+++ b/pandas/tests/indexes/datetimes/test_timezones.py
@@ -1028,6 +1028,11 @@ class TestDatetimeIndexTimezones(object):
         expected = Index([False] * 4)
         tm.assert_index_equal(result, expected)
 
+        dti_fixed = dti.tz_localize(pytz.FixedOffset(300))
+        result = dti_fixed.is_dst()
+        expected = Index([False] * 4)
+        tm.assert_index_equal(result, expected)
+
         dti_nat = pd.DatetimeIndex([pd.NaT])
         result = dti_nat.is_dst()
         expected = Index([False])

--- a/pandas/tests/indexes/datetimes/test_timezones.py
+++ b/pandas/tests/indexes/datetimes/test_timezones.py
@@ -1012,30 +1012,20 @@ class TestDatetimeIndexTimezones(object):
         for i, ts in enumerate(index):
             assert ts == index[i]
 
-    def test_is_dst(self):
-        dti = DatetimeIndex([])
+    @pytest.mark.parametrize('arg, expected_arg', [
+        [[], []],
+        [date_range('2018-11-04', periods=4, freq='H', tz='US/Pacific'),
+         [True, True, False, False]],
+        [date_range('2018-11-04', periods=4, freq='H'),
+         [False] * 4],
+        [date_range('2018-11-04', periods=4, freq='H', tz=pytz.FixedOffset(3)),
+         [False] * 4],
+        [[pd.NaT], [False]]
+    ])
+    def test_is_dst(self, arg, expected_arg):
+        dti = DatetimeIndex(arg)
         result = dti.is_dst()
-        expected = Index([])
-        tm.assert_index_equal(result, expected)
-
-        dti = date_range('2018-11-04', periods=4, freq='H', tz='US/Pacific')
-        result = dti.is_dst()
-        expected = Index([True, True, False, False])
-        tm.assert_index_equal(result, expected)
-
-        dti_naive = dti.tz_localize(None)
-        result = dti_naive.is_dst()
-        expected = Index([False] * 4)
-        tm.assert_index_equal(result, expected)
-
-        dti_fixed = dti.tz_localize(pytz.FixedOffset(300))
-        result = dti_fixed.is_dst()
-        expected = Index([False] * 4)
-        tm.assert_index_equal(result, expected)
-
-        dti_nat = pd.DatetimeIndex([pd.NaT])
-        result = dti_nat.is_dst()
-        expected = Index([False])
+        expected = Index(expected_arg)
         tm.assert_index_equal(result, expected)
 
 

--- a/pandas/tests/indexes/datetimes/test_timezones.py
+++ b/pandas/tests/indexes/datetimes/test_timezones.py
@@ -1013,7 +1013,12 @@ class TestDatetimeIndexTimezones(object):
             assert ts == index[i]
 
     def test_is_dst(self):
-        dti = pd.date_range('2018-11-04', periods=4, freq='H', tz='US/Pacific')
+        dti = DatetimeIndex([])
+        result = dti.is_dst()
+        expected = Index([])
+        tm.assert_index_equal(result, expected)
+
+        dti = date_range('2018-11-04', periods=4, freq='H', tz='US/Pacific')
         result = dti.is_dst()
         expected = Index([True, True, False, False])
         tm.assert_index_equal(result, expected)

--- a/pandas/tests/indexes/datetimes/test_timezones.py
+++ b/pandas/tests/indexes/datetimes/test_timezones.py
@@ -1023,6 +1023,11 @@ class TestDatetimeIndexTimezones(object):
         expected = Index([False] * 4)
         tm.assert_index_equal(result, expected)
 
+        dti_nat = pd.DatetimeIndex([pd.NaT])
+        result = dti_nat.is_dst()
+        expected = Index([False])
+        tm.assert_index_equal(result, expected)
+
 
 class TestDateRange(object):
     """Tests for date_range with timezones"""

--- a/pandas/tests/scalar/test_nat.py
+++ b/pandas/tests/scalar/test_nat.py
@@ -330,3 +330,7 @@ def test_nat_arithmetic_td64_vector(box, assert_func):
 def test_nat_pinned_docstrings():
     # GH17327
     assert NaT.ctime.__doc__ == datetime.ctime.__doc__
+
+
+def test_is_dst():
+    assert NaT.is_dst() is False

--- a/pandas/tests/scalar/timestamp/test_timezones.py
+++ b/pandas/tests/scalar/timestamp/test_timezones.py
@@ -308,13 +308,14 @@ class TestTimestampTZOperations(object):
 
         assert result == expected
 
-    def test_timestamp_is_dst(self):
+    @pytest.mark.parametrize('tz', ['US/Pacific', 'dateutil/US/Pacific'])
+    def test_timestamp_is_dst(self, tz):
         ts_naive = Timestamp('2018-11-04')
         assert ts_naive.is_dst() is False
 
-        ts_aware = ts_naive.tz_localize('US/Pacific')
+        ts_aware = ts_naive.tz_localize(tz)
         assert ts_aware.is_dst() is True
 
         # DST transition at 2am
-        ts_aware = Timestamp('2018-11-04 04:00').tz_localize('US/Pacific')
+        ts_aware = Timestamp('2018-11-04 04:00').tz_localize(tz)
         assert ts_aware.is_dst() is False

--- a/pandas/tests/scalar/timestamp/test_timezones.py
+++ b/pandas/tests/scalar/timestamp/test_timezones.py
@@ -307,3 +307,14 @@ class TestTimestampTZOperations(object):
         expected = _datetime.timetz()
 
         assert result == expected
+
+    def test_timestamp_is_dst(self):
+        ts_naive = Timestamp('2018-11-04')
+        assert ts_naive.is_dst() is False
+
+        ts_aware = ts_naive.tz_localize('US/Pacific')
+        assert ts_aware.is_dst() is True
+
+        # DST transition at 2am
+        ts_aware = Timestamp('2018-11-04 04:00').tz_localize('US/Pacific')
+        assert ts_aware.is_dst() is False

--- a/pandas/tests/series/test_datetime_values.py
+++ b/pandas/tests/series/test_datetime_values.py
@@ -37,7 +37,8 @@ class TestSeriesDatetimeValues(TestData):
         ok_for_dt = DatetimeIndex._datetimelike_ops
         ok_for_dt_methods = ['to_period', 'to_pydatetime', 'tz_localize',
                              'tz_convert', 'normalize', 'strftime', 'round',
-                             'floor', 'ceil', 'day_name', 'month_name']
+                             'floor', 'ceil', 'day_name', 'month_name',
+                             'is_dst']
         ok_for_td = TimedeltaIndex._datetimelike_ops
         ok_for_td_methods = ['components', 'to_pytimedelta', 'total_seconds',
                              'round', 'floor', 'ceil']


### PR DESCRIPTION
- [x] closes #18885
- [x] closes #18946
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry

The issues above required a new method to keep track if each timestamp in the `DatetimeIndex` was previously in daylight savings time in order to pass into `tz_localize(..., ambiguous=...)`

Therefore, added a `is_dst` method to `DatetimeIndex` and `Timestamp`.