### PR TITLE
DOC: Deleted 'replaced' from Returns docstring

### DIFF
--- a/pandas/core/strings.py
+++ b/pandas/core/strings.py
@@ -558,7 +558,7 @@ def str_replace(arr, pat, repl, n=-1, case=None, flags=0, regex=True):
 
     Returns
     -------
-    replaced : Series/Index of objects
+    Series/Index of objects
 
     Raises
     ------

--- a/pandas/core/strings.py
+++ b/pandas/core/strings.py
@@ -558,7 +558,10 @@ def str_replace(arr, pat, repl, n=-1, case=None, flags=0, regex=True):
 
     Returns
     -------
-    Series/Index of objects
+    Series or Index of object
+        A copy of the object with all matching occurrences of `pat` replaced by
+        `repl`.
+
 
     Raises
     ------


### PR DESCRIPTION
Deleted the word 'replaced' from the Returns section of the docstring, since it is an unnecessary local variable name. 