### PR TITLE
DOC: Formatting in Series.str.extractall

### DIFF
--- a/pandas/core/strings.py
+++ b/pandas/core/strings.py
@@ -942,19 +942,20 @@ def str_extractall(arr, pat, flags=0):
 
     Parameters
     ----------
-    pat : string
-        Regular expression pattern with capturing groups
+    pat : str
+        Regular expression pattern with capturing groups.
     flags : int, default 0 (no flags)
-        re module flags, e.g. re.IGNORECASE
+        re module flags, e.g. re.IGNORECASE.
 
     Returns
     -------
-    A DataFrame with one row for each match, and one column for each
-    group. Its rows have a MultiIndex with first levels that come from
-    the subject Series. The last level is named 'match' and indicates
-    the order in the subject. Any capture group names in regular
-    expression pat will be used for column names; otherwise capture
-    group numbers will be used.
+    DataFrame
+        A DataFrame with one row for each match, and one column for each
+        group. Its rows have a MultiIndex with first levels that come from
+        the subject Series. The last level is named 'match' and indexes the
+        matches in each item of the Series. Any capture group names in regular
+        expression pat will be used for column names; otherwise capture
+        group numbers will be used.
 
     See Also
     --------

--- a/pandas/core/strings.py
+++ b/pandas/core/strings.py
@@ -945,15 +945,18 @@ def str_extractall(arr, pat, flags=0):
     pat : str
         Regular expression pattern with capturing groups.
     flags : int, default 0 (no flags)
-        re module flags, e.g. re.IGNORECASE.
+        A ``re`` module flag, for example ``re.IGNORECASE``. These allow
+        to modify regular expression matching for things like case, spaces, etc.
+        Multiple flags can be combined with the bitwise OR operator,
+        for example ``re.IGNORECASE | re.MULTILINE``.
 
     Returns
     -------
     DataFrame
-        A DataFrame with one row for each match, and one column for each
-        group. Its rows have a MultiIndex with first levels that come from
-        the subject Series. The last level is named 'match' and indexes the
-        matches in each item of the Series. Any capture group names in regular
+        A ``DataFrame`` with one row for each match, and one column for each
+        group. Its rows have a ``MultiIndex`` with first levels that come from
+        the subject ``Series``. The last level is named 'match' and indexes the
+        matches in each item of the ``Series``. Any capture group names in regular
         expression pat will be used for column names; otherwise capture
         group numbers will be used.
 
@@ -1001,7 +1004,6 @@ def str_extractall(arr, pat, flags=0):
       1          a     2
     B 0          b     1
     C 0        NaN     1
-
     """
 
     regex = re.compile(pat, flags=flags)

--- a/pandas/core/strings.py
+++ b/pandas/core/strings.py
@@ -946,8 +946,8 @@ def str_extractall(arr, pat, flags=0):
         Regular expression pattern with capturing groups.
     flags : int, default 0 (no flags)
         A ``re`` module flag, for example ``re.IGNORECASE``. These allow
-        to modify regular expression matching for things like case, spaces, etc.
-        Multiple flags can be combined with the bitwise OR operator,
+        to modify regular expression matching for things like case, spaces,
+        etc. Multiple flags can be combined with the bitwise OR operator,
         for example ``re.IGNORECASE | re.MULTILINE``.
 
     Returns
@@ -956,8 +956,8 @@ def str_extractall(arr, pat, flags=0):
         A ``DataFrame`` with one row for each match, and one column for each
         group. Its rows have a ``MultiIndex`` with first levels that come from
         the subject ``Series``. The last level is named 'match' and indexes the
-        matches in each item of the ``Series``. Any capture group names in regular
-        expression pat will be used for column names; otherwise capture
+        matches in each item of the ``Series``. Any capture group names in
+        regular expression pat will be used for column names; otherwise capture
         group numbers will be used.
 
     See Also


### PR DESCRIPTION
In Series.str.extractall, corrected the formatting in the return value and added a period at the end of the parameter descriptions. Can also clarify descriptions if useful.

- [ ] closes #xxxx
- [ ] tests added / passed
- [X] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

```
################################################################################
################### Docstring (pandas.Series.str.extractall) ###################
################################################################################

For each subject string in the Series, extract groups from all
matches of regular expression pat. When each subject string in the
Series has exactly one match, extractall(pat).xs(0, level='match')
is the same as extract(pat).

.. versionadded:: 0.18.0

Parameters
----------
pat : str
    Regular expression pattern with capturing groups.
flags : int, default 0 (no flags)
    re module flags, e.g. re.IGNORECASE.

Returns
-------
DataFrame
    A DataFrame with one row for each match, and one column for each
    group. Its rows have a MultiIndex with first levels that come from
    the subject Series. The last level is named 'match' and indexes the
    matches in each item of the Series. Any capture group names in regular
    expression pat will be used for column names; otherwise capture
    group numbers will be used.

See Also
--------
extract : returns first match only (not all matches)

Examples
--------
A pattern with one group will return a DataFrame with one column.
Indices with no matches will not appear in the result.

>>> s = pd.Series(["a1a2", "b1", "c1"], index=["A", "B", "C"])
>>> s.str.extractall(r"[ab](\d)")
         0
  match
A 0      1
  1      2
B 0      1

Capture group names are used for column names of the result.

>>> s.str.extractall(r"[ab](?P<digit>\d)")
        digit
  match
A 0         1
  1         2
B 0         1

A pattern with two groups will return a DataFrame with two columns.

>>> s.str.extractall(r"(?P<letter>[ab])(?P<digit>\d)")
        letter digit
  match
A 0          a     1
  1          a     2
B 0          b     1

Optional groups that do not match are NaN in the result.

>>> s.str.extractall(r"(?P<letter>[ab])?(?P<digit>\d)")
        letter digit
  match
A 0          a     1
  1          a     2
B 0          b     1
C 0        NaN     1

################################################################################
################################## Validation ##################################
################################################################################

Errors found:
	Closing quotes should be placed in the line after the last text in the docstring (do not close the quotes in the same line as the text, or leave a blank line between the last text and the quotes)
	Use only one blank line to separate sections or paragraphs
	Errors in parameters section
		Parameter "flags" description should start with a capital letter
```