### PR TITLE
DOC: Updating str_pad docstring

### DIFF
--- a/pandas/core/strings.py
+++ b/pandas/core/strings.py
@@ -1321,14 +1321,16 @@ def str_pad(arr, width, side='left', fillchar=' '):
     ----------
     width : int
         Minimum width of resulting string; additional characters will be filled
-        with spaces
+        with character defined in fillchar
     side : {'left', 'right', 'both'}, default 'left'
+        Side from which to fill resulting string
     fillchar : str, default ' '
         Additional character for filling, default is whitespace
 
     Returns
     -------
-    Series or Index of objects
+    Series or Index of object
+        Returns Series or Index with minimum number of char in object
 
     Examples
     --------
@@ -1337,15 +1339,15 @@ def str_pad(arr, width, side='left', fillchar=' '):
     0    panda
     1      fox
 
-    >>> s.str.pad(10)
+    >>> s.str.pad(width=10)
     0         panda
     1           fox
 
-    >>> s.str.pad(10, 'right', '-')
+    >>> s.str.pad(width=10, side='right', fillchar='-')
     0    panda-----
     1    fox-------
 
-    >>> s.str.pad(10, 'both', '-')
+    >>> s.str.pad(width=10, side='both', fillchar='-')
     0    --panda---
     1    ---fox----
     """

--- a/pandas/core/strings.py
+++ b/pandas/core/strings.py
@@ -1314,8 +1314,8 @@ def str_index(arr, sub, start=0, end=None, side='left'):
 
 def str_pad(arr, width, side='left', fillchar=' '):
     """
-    Pad strings in the Series/Index with an additional character to
-    specified side.
+    Pad strings in the Series/Index with additional characters on
+    specified side to fill up to specified width.
 
     Parameters
     ----------
@@ -1323,12 +1323,32 @@ def str_pad(arr, width, side='left', fillchar=' '):
         Minimum width of resulting string; additional characters will be filled
         with spaces
     side : {'left', 'right', 'both'}, default 'left'
-    fillchar : str
+    fillchar : str, default ' '
         Additional character for filling, default is whitespace
 
     Returns
     -------
-    padded : Series/Index of objects
+    Series or Index of objects
+
+    Examples
+    --------
+    >>> s = pd.Series(["panda", "fox"])
+    >>> s
+    0    panda
+    1      fox
+    
+    >>> s.str.pad(10)
+    0         panda
+    1           fox
+
+    >>> s.str.pad(10, 'right')
+    0    panda     
+    1    fox       
+
+    >>> s.str.pad(10, 'both', '-')
+    0    --panda---
+    1    ---fox----
+
     """
 
     if not isinstance(fillchar, compat.string_types):

--- a/pandas/core/strings.py
+++ b/pandas/core/strings.py
@@ -1336,7 +1336,7 @@ def str_pad(arr, width, side='left', fillchar=' '):
     >>> s
     0    panda
     1      fox
-    
+
     >>> s.str.pad(10)
     0         panda
     1           fox
@@ -1348,7 +1348,6 @@ def str_pad(arr, width, side='left', fillchar=' '):
     >>> s.str.pad(10, 'both', '-')
     0    --panda---
     1    ---fox----
-
     """
 
     if not isinstance(fillchar, compat.string_types):

--- a/pandas/core/strings.py
+++ b/pandas/core/strings.py
@@ -1341,9 +1341,9 @@ def str_pad(arr, width, side='left', fillchar=' '):
     0         panda
     1           fox
 
-    >>> s.str.pad(10, 'right')
-    0    panda     
-    1    fox       
+    >>> s.str.pad(10, 'right', '-')
+    0    panda-----
+    1    fox-------
 
     >>> s.str.pad(10, 'both', '-')
     0    --panda---


### PR DESCRIPTION
- [x ] tests added / passed
- [ x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`

Pad documentation was describing a different behaviour, so I fixed it and added examples.
