### PR TITLE
BUG: fix failing DataFrame.loc when indexing with an IntervalIndex

### DIFF
--- a/doc/source/whatsnew/v0.24.0.txt
+++ b/doc/source/whatsnew/v0.24.0.txt
@@ -669,6 +669,7 @@ Indexing
 - Bug where indexing with a Numpy array containing negative values would mutate the indexer (:issue:`21867`)
 - Bug where mixed indexes wouldn't allow integers for ``.at`` (:issue:`19860`)
 - ``Float64Index.get_loc`` now raises ``KeyError`` when boolean key passed. (:issue:`19087`)
+- Bug when asking ``.loc`` for :class:`DataFrame` with :class:`IntervalIndex` index. (:issue:`19977`)
 
 Missing
 ^^^^^^^

--- a/doc/source/whatsnew/v0.24.0.txt
+++ b/doc/source/whatsnew/v0.24.0.txt
@@ -669,7 +669,7 @@ Indexing
 - Bug where indexing with a Numpy array containing negative values would mutate the indexer (:issue:`21867`)
 - Bug where mixed indexes wouldn't allow integers for ``.at`` (:issue:`19860`)
 - ``Float64Index.get_loc`` now raises ``KeyError`` when boolean key passed. (:issue:`19087`)
-- Bug when asking ``.loc`` for :class:`DataFrame` with :class:`IntervalIndex` index. (:issue:`19977`)
+- Bug in :meth:`DataFrame.loc` when indexing with an :class:`IntervalIndex` (:issue:`19977`)
 
 Missing
 ^^^^^^^

--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -1491,7 +1491,7 @@ class _LocationIndexer(_NDFrameIndexer):
             try:
                 if self._is_scalar_access(key):
                     return self._getitem_scalar(key)
-            except (KeyError, IndexError):
+            except (KeyError, IndexError, AttributeError):
                 pass
             return self._getitem_tuple(key)
         else:

--- a/pandas/tests/frame/test_indexing.py
+++ b/pandas/tests/frame/test_indexing.py
@@ -3100,6 +3100,7 @@ class TestDataFrameIndexing(TestData):
         assert_series_equal(result, expected)
 
     def test_interval_index(self):
+        # GH 19977
         index = pd.interval_range(start=0, periods=3)
         df = pd.DataFrame([[1, 2, 3], [4, 5, 6], [7, 8, 9]],
                           index=index,

--- a/pandas/tests/frame/test_indexing.py
+++ b/pandas/tests/frame/test_indexing.py
@@ -3114,7 +3114,8 @@ class TestDataFrameIndexing(TestData):
                           index=index,
                           columns=['A', 'B', 'C'])
 
-        index_exp = pd.interval_range(start=0, periods=2, freq=1, closed='both')
+        index_exp = pd.interval_range(start=0, periods=2,
+                                      freq=1, closed='both')
         expected = pd.Series([1, 4], index=index_exp, name='A')
         result = df.loc[1, 'A']
         assert_series_equal(result, expected)

--- a/pandas/tests/frame/test_indexing.py
+++ b/pandas/tests/frame/test_indexing.py
@@ -3099,6 +3099,26 @@ class TestDataFrameIndexing(TestData):
         result = dg['x', 0]
         assert_series_equal(result, expected)
 
+    def test_interval_index(self):
+        index = pd.interval_range(start=0, periods=3)
+        df = pd.DataFrame([[1, 2, 3], [4, 5, 6], [7, 8, 9]],
+                          index=index,
+                          columns=['A', 'B', 'C'])
+
+        expected = 1
+        result = df.loc[0.5, 'A']
+        assert_almost_equal(result, expected)
+
+        index = pd.interval_range(start=0, periods=3, closed='both')
+        df = pd.DataFrame([[1, 2, 3], [4, 5, 6], [7, 8, 9]],
+                          index=index,
+                          columns=['A', 'B', 'C'])
+
+        index_exp = pd.interval_range(start=0, periods=2, freq=1, closed='both')
+        expected = pd.Series([1, 4], index=index_exp, name='A')
+        result = df.loc[1, 'A']
+        assert_series_equal(result, expected)
+
 
 class TestDataFrameIndexingDatetimeWithTZ(TestData):
 


### PR DESCRIPTION
- [x] closes #19977
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry
