### PR TITLE
Update ecosystem.rst to include Pint

### DIFF
--- a/doc/source/ecosystem.rst
+++ b/doc/source/ecosystem.rst
@@ -338,6 +338,16 @@ found in NumPy or pandas, which work well with pandas' data containers.
 Cyberpandas provides an extension type for storing arrays of IP Addresses. These
 arrays can be stored inside pandas' Series and DataFrame.
 
+`pint`_
+~~~~~~~
+
+`Pint <https://pint.readthedocs.io/en/latest/>` provides an extension type for
+storing numeric arrays with units. These arrays can be stored inside pandas'
+Series and DataFrame. Operations between Series and DataFrame columns which
+use pint's extension array are then units aware.
+
+Note that this feature requires Pint v0.9 or higher.
+
 .. _ecosystem.accessors:
 
 Accessors
@@ -352,7 +362,9 @@ Library        Accessor   Classes
 ============== ========== =========================
 `cyberpandas`_ ``ip``     ``Series``
 `pdvega`_      ``vgplot`` ``Series``, ``DataFrame``
+`pint`_        ``pint``   ``Series``, ``DataFrame``
 ============== ========== =========================
 
 .. _cyberpandas: https://cyberpandas.readthedocs.io/en/latest
 .. _pdvega: https://jakevdp.github.io/pdvega/
+.. _pint: https://github.com/hgrecco/pint


### PR DESCRIPTION
We are working on upgrading pint to be compatible with pandas, see https://github.com/hgrecco/pint/pull/684

I am guessing that the line in the docs,

> If you’re building a library that implements the interface, please publicize it on Extension Data Types.

meant something like this pull request. If that's completely wrong, apologies.

- [x] closes #xxxx (N/A as not directly related to an issue, but makes progress towards #10349 )
- [x] (N/A) tests added / passed 
- [x] (N/A) passes `git diff upstream/master -u -- "*.py" | flake8 --diff` *
- [x] whatsnew entry
