### PR TITLE
Fix string format in test runner

### DIFF
--- a/pandas/util/testing.py
+++ b/pandas/util/testing.py
@@ -2394,7 +2394,7 @@ def network(t, url="http://www.google.com",
                 raise
             else:
                 skip("Skipping test due to lack of connectivity"
-                     " and error {error}".format(e))
+                     " and error {error}".format(error=e))
 
     return wrapper
 


### PR DESCRIPTION
`.format()` was expecting keyword arguments. Updated to match other skips nearby.
