### PR TITLE
Implement delegate_names to allow decorating delegated attributes

### DIFF
--- a/pandas/core/accessor.py
+++ b/pandas/core/accessor.py
@@ -105,6 +105,38 @@ class PandasDelegate(object):
                 setattr(cls, name, f)
 
 
+def delegate_names(delegate, accessors, typ, overwrite=False):
+    """
+    Add delegated names to a class using a class decorator.  This provides
+    an alternative usage to directly calling `_add_delegate_accessors`
+    below a class definition.
+
+    Parameters
+    ----------
+    delegate : the class to get methods/properties & doc-strings
+    acccessors : string list of accessors to add
+    typ : 'property' or 'method'
+    overwrite : boolean, default False
+       overwrite the method/property in the target class if it exists
+
+    Returns
+    -------
+    decorator
+
+    Examples
+    --------
+    @delegate_names(Categorical, ["categories", "ordered"], "property")
+    class CategoricalAccessor(PandasDelegate):
+        [...]
+    """
+    def add_delegate_accessors(cls):
+        cls._add_delegate_accessors(delegate, accessors, typ,
+                                    overwrite=overwrite)
+        return cls
+
+    return add_delegate_accessors
+
+
 # Ported with modifications from xarray
 # https://github.com/pydata/xarray/blob/master/xarray/core/extensions.py
 # 1. We don't need to catch and re-raise AttributeErrors as RuntimeErrors

--- a/pandas/core/arrays/categorical.py
+++ b/pandas/core/arrays/categorical.py
@@ -34,7 +34,7 @@ from pandas.core.dtypes.common import (
     is_dict_like)
 
 from pandas.core.algorithms import factorize, take_1d, unique1d, take
-from pandas.core.accessor import PandasDelegate
+from pandas.core.accessor import PandasDelegate, delegate_names
 from pandas.core.base import (PandasObject,
                               NoNewAttributesMixin, _shared_docs)
 import pandas.core.common as com
@@ -2365,6 +2365,15 @@ class Categorical(ExtensionArray, PandasObject):
 # The Series.cat accessor
 
 
+@delegate_names(delegate=Categorical,
+                accessors=["categories", "ordered"],
+                typ="property")
+@delegate_names(delegate=Categorical,
+                accessors=["rename_categories", "reorder_categories",
+                           "add_categories", "remove_categories",
+                           "remove_unused_categories", "set_categories",
+                           "as_ordered", "as_unordered"],
+                typ="method")
 class CategoricalAccessor(PandasDelegate, PandasObject, NoNewAttributesMixin):
     """
     Accessor object for categorical properties of the Series values.
@@ -2423,15 +2432,6 @@ class CategoricalAccessor(PandasDelegate, PandasObject, NoNewAttributesMixin):
         if res is not None:
             return Series(res, index=self.index, name=self.name)
 
-
-CategoricalAccessor._add_delegate_accessors(delegate=Categorical,
-                                            accessors=["categories",
-                                                       "ordered"],
-                                            typ='property')
-CategoricalAccessor._add_delegate_accessors(delegate=Categorical, accessors=[
-    "rename_categories", "reorder_categories", "add_categories",
-    "remove_categories", "remove_unused_categories", "set_categories",
-    "as_ordered", "as_unordered"], typ='method')
 
 # utility routines
 

--- a/pandas/core/indexes/accessors.py
+++ b/pandas/core/indexes/accessors.py
@@ -12,7 +12,7 @@ from pandas.core.dtypes.common import (
     is_timedelta64_dtype, is_categorical_dtype,
     is_list_like)
 
-from pandas.core.accessor import PandasDelegate
+from pandas.core.accessor import PandasDelegate, delegate_names
 from pandas.core.base import NoNewAttributesMixin, PandasObject
 from pandas.core.indexes.datetimes import DatetimeIndex
 from pandas.core.indexes.period import PeriodIndex
@@ -110,6 +110,12 @@ class Properties(PandasDelegate, PandasObject, NoNewAttributesMixin):
         return result
 
 
+@delegate_names(delegate=DatetimeIndex,
+                accessors=DatetimeIndex._datetimelike_ops,
+                typ="property")
+@delegate_names(delegate=DatetimeIndex,
+                accessors=DatetimeIndex._datetimelike_methods,
+                typ="method")
 class DatetimeProperties(Properties):
     """
     Accessor object for datetimelike properties of the Series values.
@@ -175,16 +181,12 @@ class DatetimeProperties(Properties):
         return self._get_values().inferred_freq
 
 
-DatetimeProperties._add_delegate_accessors(
-    delegate=DatetimeIndex,
-    accessors=DatetimeIndex._datetimelike_ops,
-    typ='property')
-DatetimeProperties._add_delegate_accessors(
-    delegate=DatetimeIndex,
-    accessors=DatetimeIndex._datetimelike_methods,
-    typ='method')
-
-
+@delegate_names(delegate=TimedeltaIndex,
+                accessors=TimedeltaIndex._datetimelike_ops,
+                typ="property")
+@delegate_names(delegate=TimedeltaIndex,
+                accessors=TimedeltaIndex._datetimelike_methods,
+                typ="method")
 class TimedeltaProperties(Properties):
     """
     Accessor object for datetimelike properties of the Series values.
@@ -268,16 +270,12 @@ class TimedeltaProperties(Properties):
         return self._get_values().inferred_freq
 
 
-TimedeltaProperties._add_delegate_accessors(
-    delegate=TimedeltaIndex,
-    accessors=TimedeltaIndex._datetimelike_ops,
-    typ='property')
-TimedeltaProperties._add_delegate_accessors(
-    delegate=TimedeltaIndex,
-    accessors=TimedeltaIndex._datetimelike_methods,
-    typ='method')
-
-
+@delegate_names(delegate=PeriodIndex,
+                accessors=PeriodIndex._datetimelike_ops,
+                typ="property")
+@delegate_names(delegate=PeriodIndex,
+                accessors=PeriodIndex._datetimelike_methods,
+                typ="method")
 class PeriodProperties(Properties):
     """
     Accessor object for datetimelike properties of the Series values.
@@ -291,16 +289,6 @@ class PeriodProperties(Properties):
     Returns a Series indexed like the original Series.
     Raises TypeError if the Series does not contain datetimelike values.
     """
-
-
-PeriodProperties._add_delegate_accessors(
-    delegate=PeriodIndex,
-    accessors=PeriodIndex._datetimelike_ops,
-    typ='property')
-PeriodProperties._add_delegate_accessors(
-    delegate=PeriodIndex,
-    accessors=PeriodIndex._datetimelike_methods,
-    typ='method')
 
 
 class CombinedDatetimelikeProperties(DatetimeProperties, TimedeltaProperties):

--- a/pandas/core/indexes/category.py
+++ b/pandas/core/indexes/category.py
@@ -30,6 +30,17 @@ _index_doc_kwargs = dict(ibase._index_doc_kwargs)
 _index_doc_kwargs.update(dict(target_klass='CategoricalIndex'))
 
 
+@accessor.delegate_names(
+    delegate=Categorical,
+    accessors=["rename_categories",
+               "reorder_categories",
+               "add_categories",
+               "remove_categories",
+               "remove_unused_categories",
+               "set_categories",
+               "as_ordered", "as_unordered",
+               "min", "max"],
+    typ='method', overwrite=True)
 class CategoricalIndex(Index, accessor.PandasDelegate):
     """
 
@@ -835,24 +846,8 @@ class CategoricalIndex(Index, accessor.PandasDelegate):
             return res
         return CategoricalIndex(res, name=self.name)
 
-    @classmethod
-    def _add_accessors(cls):
-        """ add in Categorical accessor methods """
-
-        CategoricalIndex._add_delegate_accessors(
-            delegate=Categorical, accessors=["rename_categories",
-                                             "reorder_categories",
-                                             "add_categories",
-                                             "remove_categories",
-                                             "remove_unused_categories",
-                                             "set_categories",
-                                             "as_ordered", "as_unordered",
-                                             "min", "max"],
-            typ='method', overwrite=True)
-
 
 CategoricalIndex._add_numeric_methods_add_sub_disabled()
 CategoricalIndex._add_numeric_methods_disabled()
 CategoricalIndex._add_logical_methods_disabled()
 CategoricalIndex._add_comparison_methods()
-CategoricalIndex._add_accessors()


### PR DESCRIPTION
This PR defines a `delegate_names` decorator that provides an alternative (and to my taste, much nicer) syntax for pinning delegated attributes to Accessor classes.

Effectively this just moves the call to `_add_delegate_accessors` from after the class definition to a decorator on the class.  I find this much harder to overlook when reading a class definition.

- [ ] closes #xxxx
- [ ] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
