### PR TITLE
avoid ValueError when overriding eq

### DIFF
--- a/pandas/_libs/index.pyx
+++ b/pandas/_libs/index.pyx
@@ -154,25 +154,15 @@ cdef class IndexEngine:
     cdef _maybe_get_bool_indexer(self, object val):
         cdef:
             ndarray[uint8_t, ndim=1, cast=True] indexer
-            ndarray[object,  ndim=1, cast=True] indexerObj
             ndarray[intp_t, ndim=1] found
             int count
 
-        try:
-            indexer = self._get_index_values() == val
-            found = np.where(indexer)[0]
-            count = len(found)
+        indexer = np.array(self._get_index_values() == val, dtype = bool, copy = False)
+        found = np.where(indexer)[0]
+        count = len(found)
 
-            if count > 1:
-                return indexer
-
-        except ValueError:
-            indexerObj = self._get_index_values() == val
-            found = np.where(indexerObj)[0]
-            count = len(found)
-
-            if count > 1:
-                return indexerObj
+        if count > 1:
+            return indexer
 
         if count == 1:
             return int(found[0])

--- a/pandas/_libs/index.pyx
+++ b/pandas/_libs/index.pyx
@@ -154,15 +154,26 @@ cdef class IndexEngine:
     cdef _maybe_get_bool_indexer(self, object val):
         cdef:
             ndarray[uint8_t, ndim=1, cast=True] indexer
+            ndarray[object,  ndim=1, cast=True] indexerObj
             ndarray[intp_t, ndim=1] found
             int count
 
-        indexer = self._get_index_values() == val
-        found = np.where(indexer)[0]
-        count = len(found)
+        try:
+            indexer = self._get_index_values() == val
+            found = np.where(indexer)[0]
+            count = len(found)
 
-        if count > 1:
-            return indexer
+            if count > 1:
+                return indexer
+
+        except ValueError:
+            indexerObj = self._get_index_values() == val
+            found = np.where(indexerObj)[0]
+            count = len(found)
+
+            if count > 1:
+                return indexerObj
+
         if count == 1:
             return int(found[0])
 


### PR DESCRIPTION
Using pandas >= 0.22 together with module [xpress](https://pypi.org/project/xpress) that I maintain, I get a `ValueError` when calling `a.loc['foo']` on an index `a`. The reason has to do with xpress' overloading of a NumPy `eq` operation (and also `leq`, `geq`). This is done through NumPy's PyUFunc_FromFuncAndData() function, which is then passed as a value to a dictionary for key `'equal'`; the same happens with `'less_equal'` and `'greater_equal'`. 

This overloading works by replacing function pointers for an array of (operand_type, operand_type, result_type) tuples and possibly changing those types. For xpress to work, one of the two elements of the array having `NPY_OBJECT` as operand types should be changed so that the result is also `NPY_OBJECT`. The ValueError is triggered in _maybe_get_bool_indexer(), where `indexer`, an ndarray of bytes, is cython-defined and then assigned the result of the comparison. The comparison runs xpress' code, which realizes it's a comparison of non-xpress objects and just reverts to the original comparison operation, but returns an array of **objects** rather than of bytes. Assigning it to `indexer` thus returning a ValueError.

My change is to wrap the assignment around a try/except block and use a cython-defined array of objects to do the same task if a ValueError exception is raised.

I realize this is not a fix for any bug in pandas, but I believe this should make pandas compatible again with some modules that do the same sort of overloading, such as modeling modules.

All tests passed.

[Edit] fixes [#22612](https://github.com/pandas-dev/pandas/issues/22612)