### PR TITLE
Test in scripts/validate_docstrings.py that the short summary is always one line long

### DIFF
--- a/scripts/tests/test_validate_docstrings.py
+++ b/scripts/tests/test_validate_docstrings.py
@@ -362,6 +362,15 @@ class BadSummaries(object):
         which is not correct.
         """
 
+    def two_paragraph_multi_line(self):
+        """
+        Extends beyond one line
+        which is not correct.
+
+        Extends beyond one line, which in itself is correct but the
+        previous short summary should still be an issue.
+        """
+
 
 class BadParameters(object):
     """
@@ -556,6 +565,8 @@ class TestValidator(object):
         ('BadSummaries', 'no_capitalization',
          ('Summary must start with infinitive verb',)),
         ('BadSummaries', 'multi_line',
+         ('a short summary in a single line should be present',)),
+        ('BadSummaries', 'two_paragraph_multi_line',
          ('a short summary in a single line should be present',)),
         # Parameters tests
         ('BadParameters', 'missing_params',

--- a/scripts/tests/test_validate_docstrings.py
+++ b/scripts/tests/test_validate_docstrings.py
@@ -565,9 +565,9 @@ class TestValidator(object):
         ('BadSummaries', 'no_capitalization',
          ('Summary must start with infinitive verb',)),
         ('BadSummaries', 'multi_line',
-         ('a short summary in a single line should be present',)),
+         ('Summary should fit in a single line.',)),
         ('BadSummaries', 'two_paragraph_multi_line',
-         ('a short summary in a single line should be present',)),
+         ('Summary should fit in a single line.',)),
         # Parameters tests
         ('BadParameters', 'missing_params',
          ('Parameters {**kwargs} not documented',)),

--- a/scripts/validate_docstrings.py
+++ b/scripts/validate_docstrings.py
@@ -163,9 +163,11 @@ class Docstring(object):
 
     @property
     def summary(self):
-        if len(self.doc['Summary']) > 1:
-            return ''
         return ' '.join(self.doc['Summary'])
+
+    @property
+    def num_summary_lines(self):
+        return len(self.doc['Summary'])
 
     @property
     def extended_summary(self):
@@ -452,6 +454,8 @@ def validate_one(func_name):
             errs.append('Summary must start with infinitive verb, '
                         'not third person (e.g. use "Generate" instead of '
                         '"Generates")')
+        if doc.num_summary_lines > 1:
+            errs.append("Summary should fit in a single line.")
     if not doc.extended_summary:
         wrns.append('No extended summary found')
 

--- a/scripts/validate_docstrings.py
+++ b/scripts/validate_docstrings.py
@@ -163,7 +163,7 @@ class Docstring(object):
 
     @property
     def summary(self):
-        if not self.doc['Extended Summary'] and len(self.doc['Summary']) > 1:
+        if len(self.doc['Summary']) > 1:
             return ''
         return ' '.join(self.doc['Summary'])
 


### PR DESCRIPTION
- [x] closes #22615
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`

The previous test to check if the summary property should be empty was based on the non-existence of the extended summary which doesn't seem to make sense. The test case I added failed before changing the script.