### PR TITLE
CLN/DEPR: removed deprecated as_indexer arg from str.match()

### DIFF
--- a/doc/source/whatsnew/v0.24.0.txt
+++ b/doc/source/whatsnew/v0.24.0.txt
@@ -528,7 +528,7 @@ Removal of prior version deprecations/changes
 - Removal of the previously deprecated module ``pandas.core.datetools`` (:issue:`14105`, :issue:`14094`)
 - Strings passed into :meth:`DataFrame.groupby` that refer to both column and index levels will raise a ``ValueError`` (:issue:`14432`)
 - :meth:`Index.repeat` and :meth:`MultiIndex.repeat` have renamed the ``n`` argument to ``repeats``(:issue:`14645`)
--
+- Removal of the previously deprecated as_indexer keyword completely from ``str.match()`` (:issue:`22356`,:issue:`6581`)
 
 .. _whatsnew_0240.performance:
 

--- a/doc/source/whatsnew/v0.24.0.txt
+++ b/doc/source/whatsnew/v0.24.0.txt
@@ -528,7 +528,7 @@ Removal of prior version deprecations/changes
 - Removal of the previously deprecated module ``pandas.core.datetools`` (:issue:`14105`, :issue:`14094`)
 - Strings passed into :meth:`DataFrame.groupby` that refer to both column and index levels will raise a ``ValueError`` (:issue:`14432`)
 - :meth:`Index.repeat` and :meth:`MultiIndex.repeat` have renamed the ``n`` argument to ``repeats``(:issue:`14645`)
-- Removal of the previously deprecated as_indexer keyword completely from ``str.match()`` (:issue:`22356`,:issue:`6581`)
+- Removal of the previously deprecated ``as_indexer`` keyword completely from ``str.match()`` (:issue:`22356`,:issue:`6581`)
 
 .. _whatsnew_0240.performance:
 

--- a/pandas/core/strings.py
+++ b/pandas/core/strings.py
@@ -725,7 +725,7 @@ def str_match(arr, pat, case=True, flags=0, na=np.nan):
     flags : int, default 0 (no flags)
         re module flags, e.g. re.IGNORECASE
     na : default NaN, fill value for missing values.
- 
+
     Returns
     -------
     Series/array of boolean values

--- a/pandas/core/strings.py
+++ b/pandas/core/strings.py
@@ -712,7 +712,7 @@ def str_repeat(arr, repeats):
         return result
 
 
-def str_match(arr, pat, case=True, flags=0, na=np.nan, as_indexer=None):
+def str_match(arr, pat, case=True, flags=0, na=np.nan):
     """
     Determine if each string matches a regular expression.
 
@@ -725,9 +725,7 @@ def str_match(arr, pat, case=True, flags=0, na=np.nan, as_indexer=None):
     flags : int, default 0 (no flags)
         re module flags, e.g. re.IGNORECASE
     na : default NaN, fill value for missing values.
-    as_indexer
-        .. deprecated:: 0.21.0
-
+ 
     Returns
     -------
     Series/array of boolean values
@@ -743,17 +741,6 @@ def str_match(arr, pat, case=True, flags=0, na=np.nan, as_indexer=None):
         flags |= re.IGNORECASE
 
     regex = re.compile(pat, flags=flags)
-
-    if (as_indexer is False) and (regex.groups > 0):
-        raise ValueError("as_indexer=False with a pattern with groups is no "
-                         "longer supported. Use '.str.extract(pat)' instead")
-    elif as_indexer is not None:
-        # Previously, this keyword was used for changing the default but
-        # deprecated behaviour. This keyword is now no longer needed.
-        warnings.warn("'as_indexer' keyword was specified but is ignored "
-                      "(match now returns a boolean indexer by default), "
-                      "and will be removed in a future version.",
-                      FutureWarning, stacklevel=3)
 
     dtype = bool
     f = lambda x: bool(regex.match(x))
@@ -2490,9 +2477,8 @@ class StringMethods(NoNewAttributesMixin):
         return self._wrap_result(result)
 
     @copy(str_match)
-    def match(self, pat, case=True, flags=0, na=np.nan, as_indexer=None):
-        result = str_match(self._parent, pat, case=case, flags=flags, na=na,
-                           as_indexer=as_indexer)
+    def match(self, pat, case=True, flags=0, na=np.nan):
+        result = str_match(self._parent, pat, case=case, flags=flags, na=na)
         return self._wrap_result(result)
 
     @copy(str_replace)

--- a/pandas/tests/test_strings.py
+++ b/pandas/tests/test_strings.py
@@ -947,21 +947,6 @@ class TestStringMethods(object):
         exp = Series([True, NA, False])
         tm.assert_series_equal(result, exp)
 
-        # test passing as_indexer still works but is ignored
-        values = Series(['fooBAD__barBAD', NA, 'foo'])
-        exp = Series([True, NA, False])
-        with tm.assert_produces_warning(FutureWarning):
-            result = values.str.match('.*BAD[_]+.*BAD', as_indexer=True)
-        tm.assert_series_equal(result, exp)
-        with tm.assert_produces_warning(FutureWarning):
-            result = values.str.match('.*BAD[_]+.*BAD', as_indexer=False)
-        tm.assert_series_equal(result, exp)
-        with tm.assert_produces_warning(FutureWarning):
-            result = values.str.match('.*(BAD[_]+).*(BAD)', as_indexer=True)
-        tm.assert_series_equal(result, exp)
-        pytest.raises(ValueError, values.str.match, '.*(BAD[_]+).*(BAD)',
-                      as_indexer=False)
-
         # mixed
         mixed = Series(['aBAD_BAD', NA, 'BAD_b_BAD', True, datetime.today(),
                         'foo', None, 1, 2.])


### PR DESCRIPTION
- [x] closes #22316
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry

This is the renewal of #22356, as the git got tangled up I re-forked the repo.