### PR TITLE
TST: Avoid DeprecationWarnings

### DIFF
--- a/pandas/core/common.py
+++ b/pandas/core/common.py
@@ -122,6 +122,24 @@ def is_bool_indexer(key):
     return False
 
 
+def cast_scalar_indexer(val):
+    """
+    To avoid numpy DeprecationWarnings, cast float to integer where valid.
+
+    Parameters
+    ----------
+    val : scalar
+
+    Returns
+    -------
+    outval : scalar
+    """
+    # assumes lib.is_scalar(val)
+    if lib.is_float(val) and val == int(val):
+        return int(val)
+    return val
+
+
 def _not_none(*args):
     """Returns a generator consisting of the arguments that are not None"""
     return (arg for arg in args if arg is not None)

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -2047,6 +2047,10 @@ class Index(IndexOpsMixin, PandasObject):
         promote = self._shallow_copy
 
         if is_scalar(key):
+            if is_float(key) and key == int(key):
+                # avoid numpy(?) DeprecationWarning about non-integer
+                # number passed
+                key = int(key)
             return getitem(key)
 
         if isinstance(key, slice):

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -2047,10 +2047,7 @@ class Index(IndexOpsMixin, PandasObject):
         promote = self._shallow_copy
 
         if is_scalar(key):
-            if is_float(key) and key == int(key):
-                # avoid numpy(?) DeprecationWarning about non-integer
-                # number passed
-                key = int(key)
+            key = com.cast_scalar_indexer(key)
             return getitem(key)
 
         if isinstance(key, slice):

--- a/pandas/core/indexes/multi.py
+++ b/pandas/core/indexes/multi.py
@@ -1551,6 +1551,10 @@ class MultiIndex(Index):
 
     def __getitem__(self, key):
         if is_scalar(key):
+            if lib.is_float(key) and key == int(key):
+                # Avoid DeprecationWarning for non-integer number indexer
+                key = int(key)
+
             retval = []
             for lev, lab in zip(self.levels, self.labels):
                 if lab[key] == -1:

--- a/pandas/core/indexes/multi.py
+++ b/pandas/core/indexes/multi.py
@@ -1551,9 +1551,7 @@ class MultiIndex(Index):
 
     def __getitem__(self, key):
         if is_scalar(key):
-            if lib.is_float(key) and key == int(key):
-                # Avoid DeprecationWarning for non-integer number indexer
-                key = int(key)
+            key = com.cast_scalar_indexer(key)
 
             retval = []
             for lev, lab in zip(self.levels, self.labels):

--- a/pandas/io/formats/style.py
+++ b/pandas/io/formats/style.py
@@ -1033,10 +1033,14 @@ class Styler(object):
         def css(x):
             if pd.isna(x):
                 return ''
+
+            # avoid deprecated indexing `colors[x > zero]`
+            color = colors[1] if x > zero else colors[0]
+
             if align == 'left':
-                return css_bar(0, x, colors[x > zero])
+                return css_bar(0, x, color)
             else:
-                return css_bar(min(x, zero), max(x, zero), colors[x > zero])
+                return css_bar(min(x, zero), max(x, zero), color)
 
         if s.ndim == 1:
             return [css(x) for x in normed]

--- a/pandas/util/testing.py
+++ b/pandas/util/testing.py
@@ -2431,7 +2431,7 @@ def assert_raises_regex(_exception, _regexp, _callable=None,
 
     You can also use this in a with statement.
 
-    >>> with assert_raises_regex(TypeError, 'unsupported operand type\(s\)'):
+    >>> with assert_raises_regex(TypeError, r'unsupported operand type\(s\)'):
     ...     1 + {}
     >>> with assert_raises_regex(TypeError, 'banana'):
     ...     'apple'[0] = 'b'


### PR DESCRIPTION
Avoid a boatload of these:

```
pandas/tests/plotting/test_frame.py::TestDataFramePlots::()::test_plot
  /home/travis/build/pandas-dev/pandas/pandas/core/indexes/multi.py:1556: DeprecationWarning: using a non-integer number instead of an integer will result in an error in the future
    if lab[key] == -1:

  /home/travis/build/pandas-dev/pandas/pandas/io/formats/style.py:1039: DeprecationWarning: In future, it will be an error for 'np.bool_' scalars to be interpreted as an index
    return css_bar(min(x, zero), max(x, zero), colors[x > zero])

pandas/tests/series/test_analytics.py::TestCategoricalSeriesAnalytics::()::test_drop_duplicates_categorical_non_bool[False-datetime64[D]]
  source:2442: DeprecationWarning: invalid escape sequence \(
```

That last one was a nice little adventure tracking down to pd.util.testing.

Does not silence these, as I'm not confident that is The Right Thing To Do:
```
pandas/tests/tslibs/test_parsing.py::TestGuessDatetimeFormat::()::test_guess_datetime_format_nopadding[2011-1-1 0:0:0-%Y-%m-%d %H:%M:%S]
  /home/travis/miniconda3/envs/pandas/lib/python3.6/site-packages/dateutil/parser/__init__.py:46: DeprecationWarning: _timelex is a private class and may break without warning, it will be moved and or renamed in future versions.
    warnings.warn(msg, DeprecationWarning)
```

Does not silence these, as I'm not sure how:
```
pandas/tests/io/test_sql.py::TestSQLiteAlchemyConn::()::test_read_table
  /home/travis/miniconda3/envs/pandas/lib/python3.6/site-packages/_pytest/fixtures.py:795: RemovedInPytest4Warning: Fixture setup_method called directly. Fixtures are not meant to be called directly, are created automatically when test functions request them as parameters. See https://docs.pytest.org/en/latest/fixture.html for more information.
    res = next(it)
```