### PR TITLE
TST Replace unittest.TestCase.fail calls, use pytest.raises instead of legacy constructs

### DIFF
--- a/pandas/tests/frame/test_indexing.py
+++ b/pandas/tests/frame/test_indexing.py
@@ -71,12 +71,8 @@ class TestDataFrameIndexing(TestData):
 
     def test_getitem_dupe_cols(self):
         df = DataFrame([[1, 2, 3], [4, 5, 6]], columns=['a', 'a', 'b'])
-        try:
+        with pytest.raises(KeyError):
             df[['baf']]
-        except KeyError:
-            pass
-        else:
-            self.fail("Dataframe failed to raise KeyError")
 
     def test_get(self):
         b = self.frame.get('B')

--- a/pandas/tests/plotting/test_frame.py
+++ b/pandas/tests/plotting/test_frame.py
@@ -588,17 +588,13 @@ class TestDataFramePlots(TestPlotBase):
     @pytest.mark.slow
     def test_subplots_warnings(self):
         # GH 9464
-        warnings.simplefilter('error')
-        try:
+        with tm.assert_produces_warning(None):
             df = DataFrame(np.random.randn(100, 4))
             df.plot(subplots=True, layout=(3, 2))
 
             df = DataFrame(np.random.randn(100, 4),
                            index=date_range('1/1/2000', periods=100))
             df.plot(subplots=True, layout=(3, 2))
-        except Warning as w:
-            self.fail(w)
-        warnings.simplefilter('default')
 
     @pytest.mark.slow
     def test_subplots_multiple_axes(self):

--- a/pandas/tests/series/test_combine_concat.py
+++ b/pandas/tests/series/test_combine_concat.py
@@ -28,7 +28,7 @@ class TestSeriesCombine(TestData):
             elif idx in self.objSeries.index:
                 assert value == self.objSeries[idx]
             else:
-                self.fail("orphaned index!")
+                raise AssertionError("orphaned index!")
 
         pytest.raises(ValueError, self.ts.append, self.ts,
                       verify_integrity=True)

--- a/pandas/tests/series/test_constructors.py
+++ b/pandas/tests/series/test_constructors.py
@@ -465,7 +465,7 @@ class TestSeriesConstructors(TestData):
         # test that construction of a Series with an index of different length
         # raises an error
         msg = 'Length of passed values is 3, index implies 4'
-        with pytest.raises(ValueError, message=msg):
+        with pytest.raises(ValueError, match=msg):
             Series(input, index=np.arange(4))
 
     def test_constructor_numpy_scalar(self):

--- a/pandas/tests/test_config.py
+++ b/pandas/tests/test_config.py
@@ -247,12 +247,10 @@ class TestConfig(object):
         assert self.cf._is_deprecated('foo')
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter('always')
-            try:
+            with pytest.raises(
+                    KeyError,
+                    message="Nonexistent option didn't raise KeyError"):
                 self.cf.get_option('foo')
-            except KeyError:
-                pass
-            else:
-                self.fail("Nonexistent option didn't raise KeyError")
 
             assert len(w) == 1  # should have raised one warning
             assert 'deprecated' in str(w[-1])  # we get the default message


### PR DESCRIPTION
Similarly to https://github.com/numpy/numpy/pull/11933,
> Following pytest migration there are unit tests that used to call unittest.TestCase.fail and now will produce a misleading error message on failure because the fail method no longer exists (test classes just inherit from object).
> 
> This fixes this issue, by raising an exception on failure explicitly.

In addition this uses `pytest.raises` instead of more complicated legacy constructions of the form,
```py
try:
   something
except ExceptedException:
   pass
else:
   raise AssertionError(error_message)
```
A few additional minor issues are discussed in comments below.