### PR TITLE
Only sort dict columns in from_records for py < 3.6

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -1293,7 +1293,8 @@ class DataFrame(NDFrame):
 
         if isinstance(data, dict):
             if columns is None:
-                columns = arr_columns = ensure_index(sorted(data))
+                columns = arr_columns = ensure_index(
+                    com.dict_keys_to_ordered_list(data))
                 arrays = [data[k] for k in columns]
             else:
                 arrays = []

--- a/pandas/tests/frame/test_constructors.py
+++ b/pandas/tests/frame/test_constructors.py
@@ -2104,6 +2104,15 @@ class TestDataFrameConstructors(TestData):
         for r in results:
             tm.assert_frame_equal(r, df)
 
+    @pytest.mark.skipif(not PY36, reason='Insertion order for Python>=3.6')
+    def test_from_records_dict_order_insertion(self):
+        # GH 22687
+        # initialization ordering: by insertion order if python>= 3.6
+        d = {'b': self.ts2, 'a': self.ts1}
+        frame = DataFrame.from_records(data=d)
+        expected = DataFrame(data=d, columns=list('ba'))
+        tm.assert_frame_equal(frame, expected)
+
     def test_from_records_with_index_data(self):
         df = DataFrame(np.random.randn(10, 3), columns=['A', 'B', 'C'])
 


### PR DESCRIPTION
- [ ] closes #xxxx (no existing issue)
- [x] tests passed (no new test added - can add one if necessary)
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

DataFrame.from_records does not respect dictionary order on Python 3.6+. For example:

```
>>> df = pd.DataFrame.from_records({'C':[1], 'A':[2]})
>>> df
   A  C
0  2  1
```

This change respects dict ordering on Python 3.6+ in line with 0.23 pandas behaviour of constructor and from_dict:

```
>>> df = pd.DataFrame.from_records({'C':[1], 'A':[2]})
>>> df
   C  A
0  1  2
```

There appears to be further potential to reduce duplication if from_records called from_dict?
