### PR TITLE
Remove --strict-data-files on pytest by default

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -32,5 +32,4 @@ markers =
     slow: mark a test as slow
     network: mark a test as network
     high_memory: mark a test as a high-memory only
-addopts = --strict-data-files
 doctest_optionflags= NORMALIZE_WHITESPACE IGNORE_EXCEPTION_DETAIL


### PR DESCRIPTION
- closes #22683 
Explanation:
pytest gets the configuration from setup.cfg, witch forces the option "--strict-data-files" by default. This makes the test to fail on missing files that are not packaged (on pypi and in the github tarball).
Removing this line fixes the issue and the tests are skipped.

Adding missing newline also...

Cheers.
Elias.