### PR TITLE
Remove --strict-data-files on pytest by default

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -39,7 +39,6 @@ markers =
     network: mark a test as network
     high_memory: mark a test as a high-memory only
 doctest_optionflags = NORMALIZE_WHITESPACE IGNORE_EXCEPTION_DETAIL
-addopts = --strict-data-files
 
 
 [coverage:run]


### PR DESCRIPTION
- closes #22683 
Explanation:
pytest gets the configuration from setup.cfg, witch forces the option "--strict-data-files" by default. This makes the test to fail on missing files that are not packaged (on pypi and in the github tarball).
Removing this line fixes the issue and the tests are skipped.

Cheers.
Elias.