### PR TITLE
BUG: Fix dtype inconsistency when appending to empty DataFrame

### DIFF
--- a/doc/source/whatsnew/v0.24.0.txt
+++ b/doc/source/whatsnew/v0.24.0.txt
@@ -775,6 +775,7 @@ Reshaping
 - Bug in :meth:`DataFrame.replace` raises ``RecursionError`` when replacing empty lists (:issue:`22083`)
 - Bug in :meth:`Series.replace` and meth:`DataFrame.replace` when dict is used as the ``to_replace`` value and one key in the dict is is another key's value, the results were inconsistent between using integer key and using string key (:issue:`20656`)
 - Bug in :meth:`DataFrame.drop_duplicates` for empty ``DataFrame`` which incorrectly raises an error (:issue:`20516`)
+- Bug in :meth:`DataFrame.append` would produce an inconsistent dtype when appending to empty DataFrame (:issue:`22621`)
 
 Build Changes
 ^^^^^^^^^^^^^

--- a/doc/source/whatsnew/v0.24.0.txt
+++ b/doc/source/whatsnew/v0.24.0.txt
@@ -775,7 +775,7 @@ Reshaping
 - Bug in :meth:`DataFrame.replace` raises ``RecursionError`` when replacing empty lists (:issue:`22083`)
 - Bug in :meth:`Series.replace` and meth:`DataFrame.replace` when dict is used as the ``to_replace`` value and one key in the dict is is another key's value, the results were inconsistent between using integer key and using string key (:issue:`20656`)
 - Bug in :meth:`DataFrame.drop_duplicates` for empty ``DataFrame`` which incorrectly raises an error (:issue:`20516`)
-- Bug in :meth:`DataFrame.append` would produce an inconsistent dtype when appending to empty DataFrame (:issue:`22621`)
+- Bug in :meth:`DataFrame.append` would produce an inconsistent dtype when appending to empty ``DataFrame`` (:issue:`22621`)
 
 Build Changes
 ^^^^^^^^^^^^^

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -6362,8 +6362,6 @@ class DataFrame(NDFrame):
                               index=index,
                               columns=combined_columns)
             other = other._convert(datetime=True, timedelta=True)
-            if not self.columns.equals(combined_columns):
-                self = self.reindex(columns=combined_columns)
         elif isinstance(other, list) and not isinstance(other[0], DataFrame):
             other = DataFrame(other)
             if (self.columns.get_indexer(other.columns) >= 0).all():

--- a/pandas/tests/frame/test_combine_concat.py
+++ b/pandas/tests/frame/test_combine_concat.py
@@ -198,6 +198,15 @@ class TestDataFrameConcatCommon(TestData):
         expected = DataFrame({'bar': Series([Timestamp('20130101'), 1])})
         assert_frame_equal(result, expected)
 
+        # GH 22621
+        # when appending a Series to an empty DataFrame
+        # the result must maintain the Series dtype
+
+        df = DataFrame()
+        series = Series({'A': 1}, name='foobar', dtype='int64')
+        assert df.append(series).dtypes['A'] == 'int64'
+        assert df.append([series]).dtypes['A'] == 'int64'
+
     def test_update(self):
         df = DataFrame([[1.5, nan, 3.],
                         [1.5, nan, 3.],

--- a/pandas/tests/frame/test_combine_concat.py
+++ b/pandas/tests/frame/test_combine_concat.py
@@ -203,9 +203,15 @@ class TestDataFrameConcatCommon(TestData):
         # the result must maintain the Series dtype
 
         df = DataFrame()
-        series = Series({'A': 1}, name='foobar', dtype='int64')
-        assert df.append(series).dtypes['A'] == 'int64'
-        assert df.append([series]).dtypes['A'] == 'int64'
+        series = Series({'A': 1}, dtype='int64')
+
+        result = df.append(series, ignore_index=True)
+        expected = DataFrame({'A': [1]}, dtype='int64')
+        assert_frame_equal(result, expected)
+
+        result = df.append([series], ignore_index=True)
+        expected = DataFrame({'A': [1]}, dtype='int64')
+        assert_frame_equal(result, expected)
 
     def test_update(self):
         df = DataFrame([[1.5, nan, 3.],


### PR DESCRIPTION
- [ ] closes #22621
- [ ] tests added / passed
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

*edit*: currently rewriting the DataFrame.append function