### PR TITLE
Support writing CSV to GCS

### DIFF
--- a/doc/source/whatsnew/v0.24.0.txt
+++ b/doc/source/whatsnew/v0.24.0.txt
@@ -174,7 +174,7 @@ Other Enhancements
 - :func:`to_csv` now supports ``compression`` keyword when a file handle is passed. (:issue:`21227`)
 - :meth:`Index.droplevel` is now implemented also for flat indexes, for compatibility with :class:`MultiIndex` (:issue:`21115`)
 - :meth:`Series.droplevel` and :meth:`DataFrame.droplevel` are now implemented (:issue:`20342`)
-- Added support for reading from Google Cloud Storage via the ``gcsfs`` library (:issue:`19454`)
+- Added support for reading from/writing to Google Cloud Storage via the ``gcsfs`` library (:issue:`19454`, :issue:`23094`)
 - :func:`to_gbq` and :func:`read_gbq` signature and documentation updated to
   reflect changes from the `Pandas-GBQ library version 0.6.0
   <https://pandas-gbq.readthedocs.io/en/latest/changelog.html#changelog-0-6-0>`__.

--- a/pandas/io/formats/csvs.py
+++ b/pandas/io/formats/csvs.py
@@ -22,10 +22,9 @@ from pandas.core.dtypes.generic import (
     ABCMultiIndex, ABCPeriodIndex, ABCDatetimeIndex, ABCIndexClass)
 
 from pandas.io.common import (
-    _expand_user,
     _get_handle,
     _infer_compression,
-    _stringify_path,
+    get_filepath_or_buffer,
     UnicodeWriter,
 )
 
@@ -45,7 +44,9 @@ class CSVFormatter(object):
         if path_or_buf is None:
             path_or_buf = StringIO()
 
-        self.path_or_buf = _expand_user(_stringify_path(path_or_buf))
+        self.path_or_buf, _, _, _ = get_filepath_or_buffer(
+            path_or_buf, encoding=encoding, compression=compression, mode=mode
+        )
         self.sep = sep
         self.na_rep = na_rep
         self.float_format = float_format

--- a/pandas/tests/io/test_gcs.py
+++ b/pandas/tests/io/test_gcs.py
@@ -27,6 +27,21 @@ def test_read_csv_gcs(mock):
 
 
 @td.skip_if_no('gcsfs')
+def test_to_csv_gcs(mock):
+    df1 = DataFrame({'int': [1, 3], 'float': [2.0, np.nan], 'str': ['t', 's'],
+                     'dt': date_range('2018-06-18', periods=2)})
+    with mock.patch('gcsfs.GCSFileSystem') as MockFileSystem:
+        s = StringIO()
+        instance = MockFileSystem.return_value
+        instance.open.return_value = s
+
+        df1.to_csv('gs://test/test.csv', index=True)
+        df2 = read_csv(StringIO(s.getvalue()), parse_dates=['dt'], index_col=0)
+
+    assert_frame_equal(df1, df2)
+
+
+@td.skip_if_no('gcsfs')
 def test_gcs_get_filepath_or_buffer(mock):
     df1 = DataFrame({'int': [1, 3], 'float': [2.0, np.nan], 'str': ['t', 's'],
                      'dt': date_range('2018-06-18', periods=2)})


### PR DESCRIPTION
- [x] fixes #23094 
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry

This seems to work as-is and doesn't break any of the IO tests; as I mentioned in https://github.com/pandas-dev/pandas/issues/8508#issuecomment-421184687 getting S3 to work is a little more complicated but maybe still not bad. But this would be a step in the right direction regardless.

cc @TomAugspurger 