### PR TITLE
BUG: Empty CategoricalIndex fails with boolean categories

### DIFF
--- a/doc/source/whatsnew/v0.24.0.txt
+++ b/doc/source/whatsnew/v0.24.0.txt
@@ -616,6 +616,7 @@ Categorical
 ^^^^^^^^^^^
 
 - Bug in :meth:`Categorical.from_codes` where ``NaN`` values in ``codes`` were silently converted to ``0`` (:issue:`21767`). In the future this will raise a ``ValueError``. Also changes the behavior of ``.from_codes([1.1, 2.0])``.
+- Constructing a :class:`pd.CategoricalIndex` with empty values and boolean categories was raising a ``ValueError`` after a change to dtype coercion (:issue:`22702`).
 
 Datetimelike
 ^^^^^^^^^^^^

--- a/pandas/core/arrays/categorical.py
+++ b/pandas/core/arrays/categorical.py
@@ -2439,9 +2439,13 @@ def _get_codes_for_values(values, categories):
     """
     utility routine to turn values into codes given the specified categories
     """
-
     from pandas.core.algorithms import _get_data_algo, _hashtables
-    if not is_dtype_equal(values.dtype, categories.dtype):
+    if is_dtype_equal(values.dtype, categories.dtype):
+        # To prevent erroneous dtype coercion in _get_data_algo, retrieve
+        # the underlying numpy array. gh-22702
+        values = getattr(values, 'values', values)
+        categories = getattr(categories, 'values', categories)
+    else:
         values = ensure_object(values)
         categories = ensure_object(categories)
 

--- a/pandas/tests/arrays/categorical/test_constructors.py
+++ b/pandas/tests/arrays/categorical/test_constructors.py
@@ -42,7 +42,6 @@ class TestCategoricalConstructors(object):
         expected = pd.Int64Index([1, 2, 3])
         tm.assert_index_equal(c.categories, expected)
 
-    @pytest.mark.xfail
     def test_constructor_empty_boolean(self):
         # see gh-22702
         cat = pd.Categorical([], categories=[True, False])

--- a/pandas/tests/arrays/categorical/test_constructors.py
+++ b/pandas/tests/arrays/categorical/test_constructors.py
@@ -42,6 +42,13 @@ class TestCategoricalConstructors(object):
         expected = pd.Int64Index([1, 2, 3])
         tm.assert_index_equal(c.categories, expected)
 
+    @pytest.mark.xfail
+    def test_constructor_empty_boolean(self):
+        # see gh-22702
+        cat = pd.Categorical([], categories=[True, False])
+        categories = sorted(cat.categories.tolist())
+        assert categories == [False, True]
+
     def test_constructor_tuples(self):
         values = np.array([(1,), (1, 2), (1,), (1, 2)], dtype=object)
         result = Categorical(values)

--- a/pandas/tests/indexes/test_category.py
+++ b/pandas/tests/indexes/test_category.py
@@ -136,6 +136,13 @@ class TestCategoricalIndex(Base):
         result = CategoricalIndex(idx, categories=idx, ordered=True)
         tm.assert_index_equal(result, expected, exact=True)
 
+    @pytest.mark.xfail
+    def test_construction_empty_with_bool_categories(self):
+        # see gh-22702
+        cat = pd.CategoricalIndex([], categories=[True, False])
+        categories = sorted(cat.categories.tolist())
+        assert categories == [False, True]
+
     def test_construction_with_categorical_dtype(self):
         # construction with CategoricalDtype
         # GH18109

--- a/pandas/tests/indexes/test_category.py
+++ b/pandas/tests/indexes/test_category.py
@@ -136,7 +136,6 @@ class TestCategoricalIndex(Base):
         result = CategoricalIndex(idx, categories=idx, ordered=True)
         tm.assert_index_equal(result, expected, exact=True)
 
-    @pytest.mark.xfail
     def test_construction_empty_with_bool_categories(self):
         # see gh-22702
         cat = pd.CategoricalIndex([], categories=[True, False])


### PR DESCRIPTION
Fixes #22702.

This bug was introduced in [7818486859d1aba53](https://github.com/pandas-dev/pandas/commit/7818486859d1aba53ce359b93cfc772e688958e5); per [my comment](https://github.com/pandas-dev/pandas/issues/22702#issuecomment-421364087), the problem is here:

```python
    if not is_dtype_equal(values.dtype, categories.dtype):
        values = ensure_object(values)
        categories = ensure_object(categories)

    (hash_klass, vec_klass), vals = _get_data_algo(values, _hashtables)
    (_, _), cats = _get_data_algo(categories, _hashtables)
```

When `categories` is `Index([True], dtype='object')` and `values` is `array([], dtype='object')`, the `ensure_object` call is bypassed, but in `_get_data_algo`, an `Index` consisting entirely of boolean objects will be coerced to `uint64`, which violates the assumption that `values` and `categories` have the same dtype.

I felt that retrieving the underlying numpy arrays (if any exist) is the safest way to handle this without having too many wide-reaching effects across the rest of the codebase, but there might be a better way to enforce that these are not coerced into different data types.

- [x] closes #xxxx
- [x] tests added 
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry
