### PR TITLE
removing superfluous reference to axis in Series.reorder_levels docst…

### DIFF
--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -2886,7 +2886,6 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
         ----------
         order : list of int representing new level order.
                (reference level by number or key)
-        axis : where to reorder levels
 
         Returns
         -------


### PR DESCRIPTION
Hi,
I removed the superfluous reference to axis in Series.reorder_levels docstring.

- [ ] xref #22627
- [x] tests added / passed (doesn't apply)
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry (doesn't apply, only removed a line in the docstring)
