### PR TITLE
BUG: fix numpy deprecation warning for scalar datetime64 values

### DIFF
--- a/doc/source/whatsnew/v0.24.0.txt
+++ b/doc/source/whatsnew/v0.24.0.txt
@@ -803,6 +803,7 @@ Other
 - Require at least 0.28.2 version of ``cython`` to support read-only memoryviews (:issue:`21688`)
 - :meth:`~pandas.io.formats.style.Styler.background_gradient` now also supports tablewise application (in addition to rowwise and columnwise) with ``axis=None`` (:issue:`15204`)
 - :meth:`~pandas.io.formats.style.Styler.bar` now also supports tablewise application (in addition to rowwise and columnwise) with ``axis=None`` and setting clipping range with ``vmin`` and ``vmax``. ``NaN`` values are also handled properly. (:issue:`21548`, :issue:`21526`)
+- Constructing a Series with a numpy.datetime64 value will no longer issue a DeprecationWarning (:issue:`22741`)
 -
 -
 -

--- a/pandas/core/dtypes/cast.py
+++ b/pandas/core/dtypes/cast.py
@@ -1042,7 +1042,7 @@ def maybe_cast_to_datetime(value, dtype, errors='raise'):
                                     "dtype [{dtype}]".format(dtype=dtype))
 
             if is_scalar(value):
-                if value == iNaT or isna(value):
+                if np.asscalar(value) == iNaT or isna(value):
                     value = iNaT
             else:
                 value = np.array(value, copy=False)


### PR DESCRIPTION
This should fix the DeprecationWarning described in #22741 . Not sure if it's worth adding a test. What's the policy on things like these?

- [x] closes #22741
- [ ] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry