### PR TITLE
Corrected to necessary pip requirements format

### DIFF
--- a/ci/requirements-optional-pip.txt
+++ b/ci/requirements-optional-pip.txt
@@ -14,7 +14,7 @@ lxml
 matplotlib
 nbsphinx
 numexpr
-openpyxl=2.5.5
+openpyxl==2.5.5
 pyarrow
 pymysql
 tables


### PR DESCRIPTION
- [x] Addresses bug introduced by #22601

Requirements format for building pip env requires '==' instead of '='