### PR TITLE
DOC: fix DataFrame.isin docstring and doctests

### DIFF
--- a/ci/doctests.sh
+++ b/ci/doctests.sh
@@ -21,7 +21,7 @@ if [ "$DOCTEST" ]; then
 
     # DataFrame / Series docstrings
     pytest --doctest-modules -v pandas/core/frame.py \
-        -k"-assign -axes -combine -isin -itertuples -join -nlargest -nsmallest -nunique -pivot_table -quantile -query -reindex -reindex_axis -replace -round -set_index -stack -to_dict -to_stata"
+        -k"-assign -axes -combine -itertuples -join -nlargest -nsmallest -nunique -pivot_table -quantile -query -reindex -reindex_axis -replace -round -set_index -stack -to_dict -to_stata"
 
     if [ $? -ne "0" ]; then
         RET=1

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -7472,6 +7472,8 @@ class DataFrame(NDFrame):
         --------
         DataFrame.eq: Equality test for DataFrame.
         Series.isin: Equivalent method on Series.
+        Series.str.contains: Test if pattern or regex is contained within a
+            string of a Series or Index.
 
         Examples
         --------

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -7465,13 +7465,14 @@ class DataFrame(NDFrame):
         Returns
         -------
         DataFrame
-            DataFrame of boolean showing whether each element in the DataFrame
+            DataFrame of booleans showing whether each element in the DataFrame
             is contained in values.
 
         See Also
         --------
         DataFrame.eq: Equality test for DataFrame.
         Series.isin: Equivalent method on Series.
+        Series.str.isin:
 
         Examples
         --------
@@ -7490,15 +7491,17 @@ class DataFrame(NDFrame):
         falcon      True       True
         dog        False      False
 
-        When ``values`` is a dict.
+        When ``values`` is a dict, we can pass values to check for each
+        column separately:
 
         >>> df.isin({'num_wings': [0, 3], 'num_legs': [0]})
                 num_legs  num_wings
         falcon     False      False
         dog        False       True
 
-        When ``values`` is a Series or DataFrame. Note that 'falcon' does not
-        match based on the number of legs in df2.
+        When ``values`` is a Series or DataFrame the index and column must
+        match. Note that 'falcon' does not match based on the number of legs
+        in df2.
 
         >>> df2 = pd.DataFrame({'num_legs': [8, 0, 2], 'num_wings': [0, 2, 2]},
         ...                    index=['spider', 'falcon', 'parrot'])

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -7455,10 +7455,10 @@ class DataFrame(NDFrame):
 
         Parameters
         ----------
-        values : iterable, Series, DataFrame or dictionary
+        values : iterable, Series, DataFrame or dict
             The result will only be true at a location if all the
             labels match. If `values` is a Series, that's the index. If
-            `values` is a dictionary, the keys must be the column names,
+            `values` is a dict, the keys must be the column names,
             which must match. If `values` is a DataFrame,
             then both the index and column labels must match.
 
@@ -7468,36 +7468,44 @@ class DataFrame(NDFrame):
             DataFrame of boolean showing whether each element in the DataFrame
             is contained in values.
 
+        See Also
+        --------
+        DataFrame.eq: Equality test for DataFrame.
+        Series.isin: Equivalent method on Series.
+
         Examples
         --------
+
+        >>> df = pd.DataFrame({'num_legs': [2, 4], 'num_wings': [2, 0]},
+        ...                   index=['falcon', 'dog'])
+        >>> df
+                num_legs  num_wings
+        falcon         2          2
+        dog            4          0
+
         When ``values`` is a list:
 
-        >>> df = pd.DataFrame({'A': [1, 2, 3], 'B': ['a', 'b', 'f']})
-        >>> df.isin([1, 3, 12, 'a'])
-               A      B
-        0   True   True
-        1  False  False
-        2   True  False
+        >>> df.isin([2])
+                num_legs  num_wings
+        falcon      True       True
+        dog        False      False
 
-        When ``values`` is a dict. Note that B doesn't match the 1 here.
+        When ``values`` is a dict.
 
-        >>> df = pd.DataFrame({'A': [1, 2, 3], 'B': [1, 4, 7]})
-        >>> df.isin({'A': [1, 3], 'B': [4, 7, 12]})
-               A      B
-        0   True  False
-        1  False   True
-        2   True   True
+        >>> df.isin({'num_wings': [0, 3], 'num_legs': [0]})
+                num_legs  num_wings
+        falcon     False      False
+        dog        False       True
 
-        When ``values`` is a Series or DataFrame. Column A in `df2` has a
-        3, but not at index 1.
+        When ``values`` is a Series or DataFrame. Note that 'falcon' does not
+        match based on the number of legs in df2.
 
-        >>> df = pd.DataFrame({'A': [1, 2, 3], 'B': ['a', 'b', 'f']})
-        >>> df2 = pd.DataFrame({'A': [1, 3, 3, 2], 'B': ['e', 'f', 'f', 'e']})
+        >>> df2 = pd.DataFrame({'num_legs': [8, 0, 2], 'num_wings': [0, 2, 2]},
+        ...                    index=['spider', 'falcon', 'parrot'])
         >>> df.isin(df2)
-               A      B
-        0   True  False
-        1  False  False
-        2   True   True
+                num_legs  num_wings
+        falcon     False       True
+        dog        False      False
         """
         if isinstance(values, dict):
             from pandas.core.reshape.concat import concat

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -7485,17 +7485,18 @@ class DataFrame(NDFrame):
         falcon         2          2
         dog            4          0
 
-        When ``values`` is a list:
+        When ``values`` is a list check whether every value in the DataFrame
+        is present in the list (which animals have 0 or 2 legs or wings)
 
-        >>> df.isin([2])
+        >>> df.isin([0, 2])
                 num_legs  num_wings
         falcon      True       True
-        dog        False      False
+        dog        False       True
 
         When ``values`` is a dict, we can pass values to check for each
         column separately:
 
-        >>> df.isin({'num_wings': [0, 3], 'num_legs': [0]})
+        >>> df.isin({'num_wings': [0, 3]})
                 num_legs  num_wings
         falcon     False      False
         dog        False       True
@@ -7504,11 +7505,11 @@ class DataFrame(NDFrame):
         match. Note that 'falcon' does not match based on the number of legs
         in df2.
 
-        >>> df2 = pd.DataFrame({'num_legs': [8, 0, 2], 'num_wings': [0, 2, 2]},
-        ...                    index=['spider', 'falcon', 'parrot'])
-        >>> df.isin(df2)
+        >>> other = pd.DataFrame({'num_legs': [8, 2],'num_wings': [0, 2]},
+        ...                      index=['spider', 'falcon'])
+        >>> df.isin(other)
                 num_legs  num_wings
-        falcon     False       True
+        falcon      True       True
         dog        False      False
         """
         if isinstance(values, dict):

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -7472,7 +7472,6 @@ class DataFrame(NDFrame):
         --------
         DataFrame.eq: Equality test for DataFrame.
         Series.isin: Equivalent method on Series.
-        Series.str.isin:
 
         Examples
         --------

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -7430,8 +7430,7 @@ class DataFrame(NDFrame):
 
     def isin(self, values):
         """
-        Return boolean DataFrame showing whether each element in the
-        DataFrame is contained in values.
+        Whether each element in the DataFrame is contained in values.
 
         Parameters
         ----------
@@ -7444,8 +7443,9 @@ class DataFrame(NDFrame):
 
         Returns
         -------
-
-        DataFrame of booleans
+        DataFrame
+            DataFrame of boolean showing whether each element in the DataFrame
+            is contained in values.
 
         Examples
         --------
@@ -7458,23 +7458,24 @@ class DataFrame(NDFrame):
         1  False  False
         2   True  False
 
-        When ``values`` is a dict:
+        When ``values`` is a dict. Note that B doesn't match the 1 here.
 
         >>> df = pd.DataFrame({'A': [1, 2, 3], 'B': [1, 4, 7]})
         >>> df.isin({'A': [1, 3], 'B': [4, 7, 12]})
                A      B
-        0   True  False  # Note that B didn't match the 1 here.
+        0   True  False
         1  False   True
         2   True   True
 
-        When ``values`` is a Series or DataFrame:
+        When ``values`` is a Series or DataFrame. Column A in `df2` has a
+        3, but not at index 1.
 
         >>> df = pd.DataFrame({'A': [1, 2, 3], 'B': ['a', 'b', 'f']})
         >>> df2 = pd.DataFrame({'A': [1, 3, 3, 2], 'B': ['e', 'f', 'f', 'e']})
         >>> df.isin(df2)
                A      B
         0   True  False
-        1  False  False  # Column A in `df2` has a 3, but not at index 1.
+        1  False  False
         2   True   True
         """
         if isinstance(values, dict):


### PR DESCRIPTION
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`

Based on #22459. Fix the docstring for DataFrame.isin. I also updated `ci/doctests.sh`.


