### PR TITLE
DOC: Reorders DataFrame.any and all docstrings to match function signature

### DIFF
--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -9671,15 +9671,15 @@ axis : {0 or 'index', 1 or 'columns', None}, default 0
       original index.
     * None : reduce all axes, return a scalar.
 
+bool_only : boolean, default None
+    Include only boolean columns. If None, will attempt to use everything,
+    then use only boolean data. Not implemented for Series.
 skipna : boolean, default True
     Exclude NA/null values. If an entire row/column is NA, the result
     will be NA.
 level : int or level name, default None
     If the axis is a MultiIndex (hierarchical), count along a
     particular level, collapsing into a %(name1)s.
-bool_only : boolean, default None
-    Include only boolean columns. If None, will attempt to use everything,
-    then use only boolean data. Not implemented for Series.
 **kwargs : any, default None
     Additional keywords have no effect but might be accepted for
     compatibility with NumPy.


### PR DESCRIPTION
This PR updates the docstrings for `DataFrame.any` and `DataFrame.all` to match the corresponding function signatures. Specifically, the `bool_only` parameter was moved to be the seconds parameter in the docstring. 
