### PR TITLE
ERR: Clarify location of EOF on unbalanced quotes

### DIFF
--- a/pandas/_libs/src/parser/tokenizer.c
+++ b/pandas/_libs/src/parser/tokenizer.c
@@ -1150,7 +1150,7 @@ static int parser_handle_eof(parser_t *self) {
         case IN_QUOTED_FIELD:
             self->error_msg = (char *)malloc(bufsize);
             snprintf(self->error_msg, bufsize,
-                    "EOF inside string starting at line %lld",
+                    "EOF inside string starting at row %lld",
                     (long long)self->file_lines);
             return -1;
 

--- a/pandas/io/parsers.py
+++ b/pandas/io/parsers.py
@@ -2727,9 +2727,6 @@ class PythonParser(ParserBase):
                            'cannot be processed in Python\'s '
                            'native csv library at the moment, '
                            'so please pass in engine=\'c\' instead')
-                elif 'newline inside string' in msg:
-                    msg = ('EOF inside string starting with '
-                           'line ' + str(row_num))
 
                 if self.skipfooter > 0:
                     reason = ('Error could possibly be due to '

--- a/pandas/tests/io/parser/common.py
+++ b/pandas/tests/io/parser/common.py
@@ -197,20 +197,6 @@ footer
                                 header=1, comment='#',
                                 skipfooter=1)
 
-    def test_quoting(self):
-        bad_line_small = """printer\tresult\tvariant_name
-Klosterdruckerei\tKlosterdruckerei <Salem> (1611-1804)\tMuller, Jacob
-Klosterdruckerei\tKlosterdruckerei <Salem> (1611-1804)\tMuller, Jakob
-Klosterdruckerei\tKlosterdruckerei <Kempten> (1609-1805)\t"Furststiftische Hofdruckerei,  <Kempten""
-Klosterdruckerei\tKlosterdruckerei <Kempten> (1609-1805)\tGaller, Alois
-Klosterdruckerei\tKlosterdruckerei <Kempten> (1609-1805)\tHochfurstliche Buchhandlung <Kempten>"""  # noqa
-        pytest.raises(Exception, self.read_table, StringIO(bad_line_small),
-                      sep='\t')
-
-        good_line_small = bad_line_small + '"'
-        df = self.read_table(StringIO(good_line_small), sep='\t')
-        assert len(df) == 3
-
     def test_unnamed_columns(self):
         data = """A,B,C,,
 1,2,3,4,5


### PR DESCRIPTION
* Clarifies message in the C engine (original issue)
* Python's `csv` module no longer fires specific errors for that, so removed it from handling

Closes #22789.