### PR TITLE
WIP: Add summary statistics to the dataresource

### DIFF
--- a/pandas/io/json/table_schema.py
+++ b/pandas/io/json/table_schema.py
@@ -113,6 +113,8 @@ def convert_pandas_type_to_json_field(arr, dtype=None):
             field['tz'] = arr.dt.tz.zone
         else:
             field['tz'] = arr.tz.zone
+    if hasattr(arr, 'describe'):
+        field['summary'] = arr.describe(include="all").to_dict()
     return field
 
 

--- a/pandas/tests/io/json/test_json_table_schema.py
+++ b/pandas/tests/io/json/test_json_table_schema.py
@@ -17,7 +17,6 @@ from pandas.io.json.table_schema import (
     set_default_names)
 import pandas.util.testing as tm
 
-
 class TestBuildSchema(object):
 
     def setup_method(self, method):
@@ -25,7 +24,7 @@ class TestBuildSchema(object):
             {'A': [1, 2, 3, 4],
              'B': ['a', 'b', 'c', 'c'],
              'C': pd.date_range('2016-01-01', freq='d', periods=4),
-             'D': pd.timedelta_range('1H', periods=4, freq='T'),
+             'D': pd.timedelta_range('1H', periods=4, freq='T')
              },
             index=pd.Index(range(4), name='idx'))
 
@@ -33,12 +32,38 @@ class TestBuildSchema(object):
         result = build_table_schema(self.df, version=False)
         expected = {
             'fields': [{'name': 'idx', 'type': 'integer'},
-                       {'name': 'A', 'type': 'integer'},
-                       {'name': 'B', 'type': 'string'},
-                       {'name': 'C', 'type': 'datetime'},
-                       {'name': 'D', 'type': 'duration'},
-                       ],
-            'primaryKey': ['idx']
+        {'name': 'A',
+        'summary': {'count': 4.0,
+            'mean': 2.5,
+            'std': 1.2909944487358056,
+            'min': 1.0,
+            '25%': 1.75,
+            '50%': 2.5,
+            '75%': 3.25,
+            'max': 4.0},
+            'type': 'integer'},
+        {'name': 'B',
+        'summary': {'count': 4, 'unique': 3, 'top': 'c', 'freq': 2},
+        'type': 'string'},
+        {'name': 'C',
+        'summary': {'count': 4,
+            'unique': 4,
+            'top': pd.Timestamp('2016-01-03 00:00:00'),
+            'freq': 1,
+            'first': pd.Timestamp('2016-01-01 00:00:00'),
+            'last': pd.Timestamp('2016-01-04 00:00:00')},
+            'type': 'datetime'},
+        {'name': 'D',
+        'summary': {'count': 4,
+            'mean': pd.Timedelta('0 days 01:01:30'),
+            'std': pd.Timedelta('0 days 00:01:17.459666924'),
+            'min': pd.Timedelta('0 days 01:00:00'),
+            '25%': pd.Timedelta('0 days 01:00:45'),
+            '50%': pd.Timedelta('0 days 01:01:30'),
+            '75%': pd.Timedelta('0 days 01:02:15'),
+            'max': pd.Timedelta('0 days 01:03:00')},
+            'type': 'duration'}
+        ],'primaryKey': ['idx']
         }
         assert result == expected
         result = build_table_schema(self.df)
@@ -48,8 +73,17 @@ class TestBuildSchema(object):
         s = pd.Series([1, 2, 3], name='foo')
         result = build_table_schema(s, version=False)
         expected = {'fields': [{'name': 'index', 'type': 'integer'},
-                               {'name': 'foo', 'type': 'integer'}],
-                    'primaryKey': ['index']}
+        {'name': 'foo',
+        'type': 'integer',
+        'summary': {'count': 3.0,
+            'mean': 2.0,
+            'std': 1.0,
+            'min': 1.0,
+            '25%': 1.5,
+            '50%': 2.0,
+            '75%': 2.5,
+            'max': 3.0}}],
+        'primaryKey': ['index']}
         assert result == expected
         result = build_table_schema(s)
         assert 'pandas_version' in result
@@ -57,8 +91,17 @@ class TestBuildSchema(object):
     def test_series_unnamed(self):
         result = build_table_schema(pd.Series([1, 2, 3]), version=False)
         expected = {'fields': [{'name': 'index', 'type': 'integer'},
-                               {'name': 'values', 'type': 'integer'}],
-                    'primaryKey': ['index']}
+        {'name': 'values',
+        'type': 'integer',
+        'summary': {'count': 3.0,
+            'mean': 2.0,
+            'std': 1.0,
+            'min': 1.0,
+            '25%': 1.5,
+            '50%': 2.0,
+            '75%': 2.5,
+            'max': 3.0}}],
+        'primaryKey': ['index']}
         assert result == expected
 
     def test_multiindex(self):
@@ -67,16 +110,40 @@ class TestBuildSchema(object):
         df.index = idx
 
         result = build_table_schema(df, version=False)
-        expected = {
-            'fields': [{'name': 'level_0', 'type': 'string'},
-                       {'name': 'level_1', 'type': 'integer'},
-                       {'name': 'A', 'type': 'integer'},
-                       {'name': 'B', 'type': 'string'},
-                       {'name': 'C', 'type': 'datetime'},
-                       {'name': 'D', 'type': 'duration'},
-                       ],
-            'primaryKey': ['level_0', 'level_1']
-        }
+        expected = {'fields': [{'name': 'level_0', 'type': 'string'},
+        {'name': 'level_1', 'type': 'integer'},
+        {'name': 'A',
+        'type': 'integer',
+        'summary': {'count': 4.0,
+            'mean': 2.5,
+            'std': 1.2909944487358056,
+            'min': 1.0,
+            '25%': 1.75,
+            '50%': 2.5,
+            '75%': 3.25,
+            'max': 4.0}},
+        {'name': 'B',
+        'type': 'string',
+        'summary': {'count': 4, 'unique': 3, 'top': 'c', 'freq': 2}},
+        {'name': 'C',
+        'type': 'datetime',
+        'summary': {'count': 4,
+            'unique': 4,
+            'top': pd.Timestamp('2016-01-03 00:00:00'),
+            'freq': 1,
+            'first': pd.Timestamp('2016-01-01 00:00:00'),
+            'last': pd.Timestamp('2016-01-04 00:00:00')}},
+        {'name': 'D',
+        'type': 'duration',
+        'summary': {'count': 4,
+            'mean': pd.Timedelta('0 days 01:01:30'),
+            'std': pd.Timedelta('0 days 00:01:17.459666924'),
+            'min': pd.Timedelta('0 days 01:00:00'),
+            '25%': pd.Timedelta('0 days 01:00:45'),
+            '50%': pd.Timedelta('0 days 01:01:30'),
+            '75%': pd.Timedelta('0 days 01:02:15'),
+            'max': pd.Timedelta('0 days 01:03:00')}}],
+        'primaryKey': ['level_0', 'level_1']}
         assert result == expected
 
         df.index.names = ['idx0', None]

--- a/pandas/tests/io/json/test_json_table_schema.py
+++ b/pandas/tests/io/json/test_json_table_schema.py
@@ -266,9 +266,23 @@ class TestTableOrient(object):
         assert "pandas_version" in result['schema']
         result['schema'].pop('pandas_version')
 
-        fields = [{'name': 'id', 'type': 'integer'},
-                  {'name': 'a', 'type': 'integer'}]
-
+        fields = [
+            {"name": "id", "type": "integer"},
+            {
+                "name": "a",
+                "type": "integer",
+                "summary": {
+                    "count": 2.0,
+                    "mean": 1.5,
+                    "std": 0.7071067812,
+                    "min": 1.0,
+                    "25%": 1.25,
+                    "50%": 1.5,
+                    "75%": 1.75,
+                    "max": 2.0,
+                },
+            },
+        ]
         schema = {
             'fields': fields,
             'primaryKey': ['id'],
@@ -288,55 +302,79 @@ class TestTableOrient(object):
 
         assert "pandas_version" in result['schema']
         result['schema'].pop('pandas_version')
-
         fields = [
-            {'name': 'idx', 'type': 'integer'},
-            {'name': 'A', 'type': 'integer'},
-            {'name': 'B', 'type': 'string'},
-            {'name': 'C', 'type': 'datetime'},
-            {'name': 'D', 'type': 'duration'},
-            {'constraints': {'enum': ['a', 'b', 'c']},
-             'name': 'E',
-             'ordered': False,
-             'type': 'any'},
-            {'constraints': {'enum': ['a', 'b', 'c']},
-             'name': 'F',
-             'ordered': True,
-             'type': 'any'},
-            {'name': 'G', 'type': 'number'},
-            {'name': 'H', 'type': 'datetime', 'tz': 'US/Central'}
+            {"name": "idx", "type": "integer"},
+            {
+                "name": "A",
+                "type": "integer",
+                "summary": {
+                    "count": 4.0,
+                    "mean": 2.5,
+                    "std": 1.2909944487,
+                    "min": 1.0,
+                    "25%": 1.75,
+                    "50%": 2.5,
+                    "75%": 3.25,
+                    "max": 4.0,
+                },
+            },
+            {
+                "name": "B",
+                "type": "string",
+                "summary": {"count": 4, "unique": 3, "top": "c", "freq": 2},
+            },
+            {
+                "name": "C",
+                "type": "datetime",
+                "summary": {
+                    "count": 4,
+                    "unique": 4,
+                    "top": 1451779200000,
+                    "freq": 1,
+                    "first": 1451606400000,
+                    "last": 1451865600000,
+                },
+            },
+            {
+                "name": "D",
+                "type": "duration",
+                "summary": {
+                    "count": 4,
+                    "mean": 3690000,
+                    "std": 77459,
+                    "min": 3600000,
+                    "25%": 3645000,
+                    "50%": 3690000,
+                    "75%": 3735000,
+                    "max": 3780000,
+                },
+            },
         ]
 
         schema = {
             'fields': fields,
             'primaryKey': ['idx'],
         }
-        data = [
-            OrderedDict([('idx', 0), ('A', 1), ('B', 'a'),
-                         ('C', '2016-01-01T00:00:00.000Z'),
-                         ('D', 'P0DT1H0M0S'),
-                         ('E', 'a'), ('F', 'a'), ('G', 1.),
-                         ('H', '2016-01-01T06:00:00.000Z')
-                         ]),
-            OrderedDict([('idx', 1), ('A', 2), ('B', 'b'),
-                         ('C', '2016-01-02T00:00:00.000Z'),
-                         ('D', 'P0DT1H1M0S'),
-                         ('E', 'b'), ('F', 'b'), ('G', 2.),
-                         ('H', '2016-01-02T06:00:00.000Z')
-                         ]),
-            OrderedDict([('idx', 2), ('A', 3), ('B', 'c'),
-                         ('C', '2016-01-03T00:00:00.000Z'),
-                         ('D', 'P0DT1H2M0S'),
-                         ('E', 'c'), ('F', 'c'), ('G', 3.),
-                         ('H', '2016-01-03T06:00:00.000Z')
-                         ]),
-            OrderedDict([('idx', 3), ('A', 4), ('B', 'c'),
-                         ('C', '2016-01-04T00:00:00.000Z'),
-                         ('D', 'P0DT1H3M0S'),
-                         ('E', 'c'), ('F', 'c'), ('G', 4.),
-                         ('H', '2016-01-04T06:00:00.000Z')
-                         ]),
-        ]
+        data = [OrderedDict([('idx', 0),
+                            ('A', 1),
+                            ('B', 'a'),
+                            ('C', '2016-01-01T00:00:00.000Z'),
+                            ('D', 'P0DT1H0M0S')]),
+               OrderedDict([('idx', 1),
+                            ('A', 2),
+                            ('B', 'b'),
+                            ('C', '2016-01-02T00:00:00.000Z'),
+                            ('D', 'P0DT1H1M0S')]),
+               OrderedDict([('idx', 2),
+                            ('A', 3),
+                            ('B', 'c'),
+                            ('C', '2016-01-03T00:00:00.000Z'),
+                            ('D', 'P0DT1H2M0S')]),
+               OrderedDict([('idx', 3),
+                            ('A', 4),
+                            ('B', 'c'),
+                            ('C', '2016-01-04T00:00:00.000Z'),
+                            ('D', 'P0DT1H3M0S')])]
         expected = OrderedDict([('schema', schema), ('data', data)])
         assert result == expected
 
@@ -348,8 +386,9 @@ class TestTableOrient(object):
 
         expected = (
             OrderedDict([('schema', {
-                'fields': [{'name': 'index', 'type': 'number'},
-                           {'name': 'values', 'type': 'integer'}],
+                'fields': [{"name":"index","type":"number"},
+                {"name":"values","type":"integer","summary":
+                {"count":2.0,"mean":1.0,"std":0.0,"min":1.0,"25%":1.0,"50%":1.0,"75%":1.0,"max":1.0}}],
                 'primaryKey': ['index']
             }),
                 ('data', [OrderedDict([('index', 1.0), ('values', 1)]),
@@ -364,8 +403,9 @@ class TestTableOrient(object):
         result = json.loads(result, object_pairs_hook=OrderedDict)
         result['schema'].pop('pandas_version')
 
-        fields = [{'freq': 'Q-JAN', 'name': 'index', 'type': 'datetime'},
-                  {'name': 'values', 'type': 'integer'}]
+        fields = [{"name":"index","type":"datetime","freq":"Q-JAN"},
+        {"name":"values","type":"integer","summary":
+        {"count":2.0,"mean":1.0,"std":0.0,"min":1.0,"25%":1.0,"50%":1.0,"75%":1.0,"max":1.0}}]
 
         schema = {'fields': fields, 'primaryKey': ['index']}
         data = [OrderedDict([('index', '2015-11-01T00:00:00.000Z'),
@@ -383,10 +423,28 @@ class TestTableOrient(object):
 
         expected = (
             OrderedDict([('schema',
-                          {'fields': [{'name': 'index', 'type': 'any',
-                                       'constraints': {'enum': ['a', 'b']},
-                                       'ordered': False},
-                                      {'name': 'values', 'type': 'integer'}],
+                          {'fields': [
+                                        {
+                                            "name": "index",
+                                            "type": "any",
+                                            "constraints": {"enum": ["a", "b"]},
+                                            "ordered": False,
+                                        },
+                                        {
+                                            "name": "values",
+                                            "type": "integer",
+                                            "summary": {
+                                                "count": 2.0,
+                                                "mean": 1.0,
+                                                "std": 0.0,
+                                                "min": 1.0,
+                                                "25%": 1.0,
+                                                "50%": 1.0,
+                                                "75%": 1.0,
+                                                "max": 1.0,
+                                            },
+                                        },
+                                    ],
                            'primaryKey': ['index']}),
                          ('data', [
                              OrderedDict([('index', 'a'),
@@ -403,18 +461,50 @@ class TestTableOrient(object):
         self.df.to_json(orient='table', date_format='iso')
         self.df.to_json(orient='table')
 
-    @pytest.mark.parametrize('kind', [pd.Series, pd.Index])
-    def test_convert_pandas_type_to_json_field_int(self, kind):
+    def test_convert_pandas_type_to_json_field_int_series(self):
         data = [1, 2, 3]
-        result = convert_pandas_type_to_json_field(kind(data, name='name'))
-        expected = {"name": "name", "type": "integer"}
+        result = convert_pandas_type_to_json_field(pd.Series(data, name='name'))
+        expected = {'name': 'name',
+                    'type': 'integer',
+                    'summary': {'count': 3.0,
+                    'mean': 2.0,
+                    'std': 1.0,
+                    'min': 1.0,
+                    '25%': 1.5,
+                    '50%': 2.0,
+                    '75%': 2.5,
+                    'max': 3.0}}
+        assert result == expected
+    
+    def test_convert_pandas_type_to_json_field_int_index(self):
+        data = [1, 2, 3]
+        result = convert_pandas_type_to_json_field(pd.Index(data, name='name'))
+        expected = {'name': 'name',
+                    'type': 'integer'
+                    }
         assert result == expected
 
-    @pytest.mark.parametrize('kind', [pd.Series, pd.Index])
-    def test_convert_pandas_type_to_json_field_float(self, kind):
+    def test_convert_pandas_type_to_json_field_float_series(self):
         data = [1., 2., 3.]
-        result = convert_pandas_type_to_json_field(kind(data, name='name'))
-        expected = {"name": "name", "type": "number"}
+        result = convert_pandas_type_to_json_field(pd.Series(data, name='name'))
+        expected = {'name': 'name',
+                    'type': 'number',
+                    'summary': {'count': 3.0,
+                    'mean': 2.0,
+                    'std': 1.0,
+                    'min': 1.0,
+                    '25%': 1.5,
+                    '50%': 2.0,
+                    '75%': 2.5,
+                    'max': 3.0}}
+        assert result == expected
+
+    def test_convert_pandas_type_to_json_field_float_index(self):
+        data = [1., 2., 3.]
+        result = convert_pandas_type_to_json_field(pd.Index(data, name='name'))
+        expected = {'name': 'name',
+                    'type': 'number'
+                    }
         assert result == expected
 
     @pytest.mark.parametrize('dt_args,extra_exp', [
@@ -427,7 +517,15 @@ class TestTableOrient(object):
         if wrapper is pd.Series:
             data = pd.Series(data, name='values')
         result = convert_pandas_type_to_json_field(data)
-        expected = {"name": "values", "type": 'datetime'}
+        expected = {'name': 'values',
+                    'type': 'datetime',
+                    'tz': 'UTC',
+                    'summary': {'count': 3,
+                    'unique': 3,
+                    'top': pd.Timestamp('1970-01-01 00:00:00.000000003+0000', tz='UTC'),
+                    'freq': 1,
+                    'first': pd.Timestamp('1970-01-01 00:00:00.000000001+0000', tz='UTC'),
+                    'last': pd.Timestamp('1970-01-01 00:00:00.000000003+0000', tz='UTC')}}
         expected.update(extra_exp)
         assert result == expected
 


### PR DESCRIPTION
- [ ] closes 
- [ ] tests added / passed
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

Following the discussion in https://github.com/nteract/nteract/issues/3177, this adds summary statistics for folks using the dataresource. Our main concern is how this might affect performance.

I wouldn't have put this up before the tests are passing, but as @rgbkrk and I are currently attending a Numfocus event, we hoped we might catch up with @jreback and/or others in person if anyone is attending to discuss and wanted to get the ball rolling 🙂. 

cc @TomAugspurger 