### PR TITLE
Adds triangular option to DataFrame.corr, closes #22840

### DIFF
--- a/doc/source/whatsnew/v0.24.0.txt
+++ b/doc/source/whatsnew/v0.24.0.txt
@@ -21,6 +21,7 @@ New features
 the user to override the engine's default behavior to include or omit the
 dataframe's indexes from the resulting Parquet file. (:issue:`20768`)
 - :meth:`DataFrame.corr` and :meth:`Series.corr` now accept a callable for generic calculation methods of correlation, e.g. histogram intersection (:issue:`22684`)
+- :meth:`DataFrame.corr` now accepts an argument indicating whether or not a triangular correlation matrix should be returned (:issue:`22840`)
 
 
 .. _whatsnew_0240.enhancements.extension_array_operators:

--- a/doc/source/whatsnew/v0.24.0.txt
+++ b/doc/source/whatsnew/v0.24.0.txt
@@ -21,6 +21,7 @@ New features
 the user to override the engine's default behavior to include or omit the
 dataframe's indexes from the resulting Parquet file. (:issue:`20768`)
 - :meth:`DataFrame.corr` and :meth:`Series.corr` now accept a callable for generic calculation methods of correlation, e.g. histogram intersection (:issue:`22684`)
+- :meth:`DataFrame.corr` now accepts a boolean argument indicating whether or not the lower triangular correlation matrix should be returned (:issue:`22840`)
 
 
 .. _whatsnew_0240.enhancements.extension_array_operators:

--- a/doc/source/whatsnew/v0.24.0.txt
+++ b/doc/source/whatsnew/v0.24.0.txt
@@ -21,7 +21,7 @@ New features
 the user to override the engine's default behavior to include or omit the
 dataframe's indexes from the resulting Parquet file. (:issue:`20768`)
 - :meth:`DataFrame.corr` and :meth:`Series.corr` now accept a callable for generic calculation methods of correlation, e.g. histogram intersection (:issue:`22684`)
-- :meth:`DataFrame.corr` now accepts a boolean argument indicating whether or not the lower triangular correlation matrix should be returned (:issue:`22840`)
+- :meth:`DataFrame.corr` now accepts an argument indicating whether or not a triangular correlation matrix should be returned (:issue:`22840`)
 
 
 .. _whatsnew_0240.enhancements.extension_array_operators:

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -6750,7 +6750,7 @@ class DataFrame(NDFrame):
         corr_mat = self._constructor(correl, index=idx, columns=cols)
 
         if tri is not None:
-            mask = np.tril(np.ones_like(corr_mat,
+            mask = np.tril(np.ones_like(correl,
                                         dtype=np.bool),
                            k=-1)
 

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -6688,7 +6688,9 @@ class DataFrame(NDFrame):
 
         tri : {'upper', 'lower'} or None, default : None
             Whether or not to return the upper / lower triangular
-            correlation matrix
+            correlation matrix.  (This is useful for example when
+            one wishes to easily identify highly collinear columns
+            in a DataFrame.)
 
             .. versionadded:: 0.24.0
 
@@ -6707,6 +6709,13 @@ class DataFrame(NDFrame):
               dogs cats
         dogs   1.0  0.3
         cats   0.3  1.0
+        >>> df = pd.DataFrame(np.random.normal(size=(10, 2)))
+        >>> df[2] = df[0]
+        >>> df.corr(tri='lower').where(lambda x: x == 1)
+             0    1    2
+        0  NaN  NaN  NaN
+        1  NaN  NaN  NaN
+        2  1.0  NaN  NaN
         """
         numeric_df = self._get_numeric_data()
         cols = numeric_df.columns

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -6667,7 +6667,7 @@ class DataFrame(NDFrame):
     # ----------------------------------------------------------------------
     # Statistical methods, etc.
 
-    def corr(self, method='pearson', min_periods=1, tri=False):
+    def corr(self, method='pearson', min_periods=1, tri=None):
         """
         Compute pairwise correlation of columns, excluding NA/null values
 
@@ -6686,9 +6686,11 @@ class DataFrame(NDFrame):
             to have a valid result. Currently only available for pearson
             and spearman correlation
 
-        tri : boolean, default : False
-            Whether or not to return the lower triangular correlation
-            matrix
+        tri : {'upper', 'lower'} or None, default : None
+            Whether or not to return the upper / lower triangular
+            correlation matrix
+
+            .. versionadded:: 0.24.0
 
         Returns
         -------
@@ -6747,11 +6749,19 @@ class DataFrame(NDFrame):
 
         corr_mat = self._constructor(correl, index=idx, columns=cols)
 
-        if tri:
+        if tri is not None:
             mask = np.tril(np.ones_like(corr_mat,
                                         dtype=np.bool),
                            k=-1)
-            return corr_mat.where(mask)
+
+            if tri == 'lower':
+                return corr_mat.where(mask)
+            elif tri == 'upper':
+                return corr_mat.where(mask.T)
+            else:
+                raise ValueError("tri must be either 'lower', "
+                                 "or 'upper', '{tri_method}' "
+                                 "was supplied".format(tri_method=tri))
         else:
             return corr_mat
 

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -6667,7 +6667,7 @@ class DataFrame(NDFrame):
     # ----------------------------------------------------------------------
     # Statistical methods, etc.
 
-    def corr(self, method='pearson', min_periods=1):
+    def corr(self, method='pearson', min_periods=1, tri=False):
         """
         Compute pairwise correlation of columns, excluding NA/null values
 
@@ -6685,6 +6685,10 @@ class DataFrame(NDFrame):
             Minimum number of observations required per pair of columns
             to have a valid result. Currently only available for pearson
             and spearman correlation
+
+        tri : boolean, default : False
+            Whether or not to return the lower triangular correlation
+            matrix
 
         Returns
         -------
@@ -6741,7 +6745,15 @@ class DataFrame(NDFrame):
                              "'spearman', or 'kendall', '{method}' "
                              "was supplied".format(method=method))
 
-        return self._constructor(correl, index=idx, columns=cols)
+        corr_mat = self._constructor(correl, index=idx, columns=cols)
+
+        if tri:
+            mask = np.tril(np.ones_like(corr_mat,
+                                        dtype=np.bool),
+                           k=-1)
+            return corr_mat.where(mask)
+        else:
+            return corr_mat
 
     def cov(self, min_periods=None):
         """

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -6667,7 +6667,7 @@ class DataFrame(NDFrame):
     # ----------------------------------------------------------------------
     # Statistical methods, etc.
 
-    def corr(self, method='pearson', min_periods=1):
+    def corr(self, method='pearson', min_periods=1, tri=None):
         """
         Compute pairwise correlation of columns, excluding NA/null values
 
@@ -6685,6 +6685,12 @@ class DataFrame(NDFrame):
             Minimum number of observations required per pair of columns
             to have a valid result. Currently only available for pearson
             and spearman correlation
+
+        tri : {'upper', 'lower'} or None, default : None
+            Whether or not to return the upper / lower triangular
+            correlation matrix
+
+            .. versionadded:: 0.24.0
 
         Returns
         -------
@@ -6741,7 +6747,23 @@ class DataFrame(NDFrame):
                              "'spearman', or 'kendall', '{method}' "
                              "was supplied".format(method=method))
 
-        return self._constructor(correl, index=idx, columns=cols)
+        corr_mat = self._constructor(correl, index=idx, columns=cols)
+
+        if tri is not None:
+            mask = np.tril(np.ones_like(correl,
+                                        dtype=np.bool),
+                           k=-1)
+
+            if tri == 'lower':
+                return corr_mat.where(mask)
+            elif tri == 'upper':
+                return corr_mat.where(mask.T)
+            else:
+                raise ValueError("tri must be either 'lower', "
+                                 "or 'upper', '{tri_method}' "
+                                 "was supplied".format(tri_method=tri))
+        else:
+            return corr_mat
 
     def cov(self, min_periods=None):
         """

--- a/pandas/tests/frame/test_analytics.py
+++ b/pandas/tests/frame/test_analytics.py
@@ -138,6 +138,12 @@ class TestDataFrameAnalytics(TestData):
         with tm.assert_raises_regex(ValueError, msg):
             df.corr(method="____")
 
+    def test_corr_tri(self):
+        # GH PR
+        df = pd.DataFrame(np.random.normal(size=(100, 5)))
+        corr_mat = df.corr(tri=True)
+        assert corr_mat.notnull().sum().sum() == 10
+
     def test_cov(self):
         # min_periods no NAs (corner case)
         expected = self.frame.cov()

--- a/pandas/tests/frame/test_analytics.py
+++ b/pandas/tests/frame/test_analytics.py
@@ -145,7 +145,7 @@ class TestDataFrameAnalytics(TestData):
         mask = np.tril(np.ones_like(result,
                                     dtype=np.bool),
                        k=-1)
-        expected = pd.DataFrame(np.ones_like(corr_mat)).where(mask)
+        expected = pd.DataFrame(np.ones_like(result)).where(mask)
         tm.assert_frame_equal(result, expected)
 
     def test_corr_triu(self):
@@ -155,9 +155,8 @@ class TestDataFrameAnalytics(TestData):
         mask = np.triu(np.ones_like(result,
                                     dtype=np.bool),
                        k=1)
-        expected = pd.DataFrame(np.ones_like(corr_mat)).where(mask)
+        expected = pd.DataFrame(np.ones_like(result)).where(mask)
         tm.assert_frame_equal(result, expected)
-
 
     def test_cov(self):
         # min_periods no NAs (corner case)

--- a/pandas/tests/frame/test_analytics.py
+++ b/pandas/tests/frame/test_analytics.py
@@ -140,15 +140,24 @@ class TestDataFrameAnalytics(TestData):
 
     def test_corr_tril(self):
         # GH PR #22840
-        df = pd.DataFrame(np.random.normal(size=(100, 5)))
-        corr_mat = df.corr(tri='lower')
-        assert corr_mat.notnull().sum().sum() == 10
+        df = pd.DataFrame(np.array([np.arange(100)] * 5).T)
+        result = df.corr(tri='lower')
+        mask = np.tril(np.ones_like(result,
+                                    dtype=np.bool),
+                       k=-1)
+        expected = pd.DataFrame(np.ones_like(corr_mat)).where(mask)
+        tm.assert_frame_equal(result, expected)
 
     def test_corr_triu(self):
         # GH PR #22840
-        df = pd.DataFrame(np.random.normal(size=(100, 5)))
-        corr_mat = df.corr(tri='upper')
-        assert corr_mat.notnull().sum().sum() == 10
+        df = pd.DataFrame(np.array([np.arange(100)] * 5).T)
+        result = df.corr(tri='upper')
+        mask = np.triu(np.ones_like(result,
+                                    dtype=np.bool),
+                       k=1)
+        expected = pd.DataFrame(np.ones_like(corr_mat)).where(mask)
+        tm.assert_frame_equal(result, expected)
+
 
     def test_cov(self):
         # min_periods no NAs (corner case)

--- a/pandas/tests/frame/test_analytics.py
+++ b/pandas/tests/frame/test_analytics.py
@@ -138,6 +138,26 @@ class TestDataFrameAnalytics(TestData):
         with tm.assert_raises_regex(ValueError, msg):
             df.corr(method="____")
 
+    def test_corr_tril(self):
+        # GH PR #22840
+        df = pd.DataFrame(np.array([np.arange(100)] * 5).T)
+        result = df.corr(tri='lower')
+        mask = np.tril(np.ones_like(result,
+                                    dtype=np.bool),
+                       k=-1)
+        expected = pd.DataFrame(np.ones_like(result)).where(mask)
+        tm.assert_frame_equal(result, expected)
+
+    def test_corr_triu(self):
+        # GH PR #22840
+        df = pd.DataFrame(np.array([np.arange(100)] * 5).T)
+        result = df.corr(tri='upper')
+        mask = np.triu(np.ones_like(result,
+                                    dtype=np.bool),
+                       k=1)
+        expected = pd.DataFrame(np.ones_like(result)).where(mask)
+        tm.assert_frame_equal(result, expected)
+
     def test_cov(self):
         # min_periods no NAs (corner case)
         expected = self.frame.cov()

--- a/pandas/tests/frame/test_analytics.py
+++ b/pandas/tests/frame/test_analytics.py
@@ -138,10 +138,16 @@ class TestDataFrameAnalytics(TestData):
         with tm.assert_raises_regex(ValueError, msg):
             df.corr(method="____")
 
-    def test_corr_tri(self):
-        # GH PR
+    def test_corr_tril(self):
+        # GH PR #22840
         df = pd.DataFrame(np.random.normal(size=(100, 5)))
-        corr_mat = df.corr(tri=True)
+        corr_mat = df.corr(tri='lower')
+        assert corr_mat.notnull().sum().sum() == 10
+
+    def test_corr_triu(self):
+        # GH PR #22840
+        df = pd.DataFrame(np.random.normal(size=(100, 5)))
+        corr_mat = df.corr(tri='upper')
         assert corr_mat.notnull().sum().sum() == 10
 
     def test_cov(self):


### PR DESCRIPTION
Adds the `tri` argument to `DataFrame.corr`.

- [ x ] closes #22840
- [ x ] tests added / passed
- [ x ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ x ] whatsnew entry
