### PR TITLE
Fix blank line skipping in read_fwf, issue 22693

### DIFF
--- a/doc/source/whatsnew/v0.24.0.txt
+++ b/doc/source/whatsnew/v0.24.0.txt
@@ -763,6 +763,7 @@ I/O
 - :func:`read_sas()` will correctly parse sas7bdat files with data page types having also bit 7 set (so page type is 128 + 256 = 384) (:issue:`16615`)
 - Bug in :meth:`detect_client_encoding` where potential ``IOError`` goes unhandled when importing in a mod_wsgi process due to restricted access to stdout. (:issue:`21552`)
 - Bug in :func:`to_string()` that broke column alignment when ``index=False`` and width of first column's values is greater than the width of first column's header (:issue:`16839`, :issue:`13032`)
+- Fix :func:`read_fwf()` so that empty lines are skipped when the relevant argument is set (:issue:`22693`)
 
 Plotting
 ^^^^^^^^

--- a/pandas/io/parsers.py
+++ b/pandas/io/parsers.py
@@ -2777,8 +2777,8 @@ class PythonParser(ParserBase):
         for l in lines:
             # Remove empty lines and lines with only one whitespace value
             if (len(l) > 1 or len(l) == 1 and
-                (not isinstance(l[0], compat.string_types) or
-                 l[0].strip())):
+                    (not isinstance(l[0], compat.string_types) or
+                     l[0].strip())):
                 ret.append(l)
         return ret
 

--- a/pandas/io/parsers.py
+++ b/pandas/io/parsers.py
@@ -2775,13 +2775,19 @@ class PythonParser(ParserBase):
 
         ret = []
         for l in lines:
-            # Remove blank lines if they're not headers of the form ['', '', ... ]
-            if not self.line_pos == 0 and ''.join([str(x) for x in l]).strip() != '':
+            # Remove blank lines if they're not headers of the
+            # form ['', '', ... ]
+            if not self.line_pos == 0\
+                    and ''.join([str(x) for x in l]).strip() != '':
                 ret.append(l)
-            # Remove header lines that are empty or with only one whitespace value
-            elif self.line_pos == 0 and (len(l) > 1 or len(l) == 1 and
-                    (not isinstance(l[0], compat.string_types) or
-                     l[0].strip())):
+            # Remove header lines that are empty or with only one
+            # whitespace value
+            elif self.line_pos == 0\
+                    and (
+                        len(l) > 1 or len(l) == 1
+                        and (not isinstance(l[0],
+                             compat.string_types) or l[0].strip())
+                    ):
                 ret.append(l)
         return ret
 

--- a/pandas/io/parsers.py
+++ b/pandas/io/parsers.py
@@ -2775,19 +2775,10 @@ class PythonParser(ParserBase):
 
         ret = []
         for l in lines:
-            # Remove blank lines if they're not headers of the
-            # form ['', '', ... ]
-            if not self.line_pos == 0\
-                    and ''.join([str(x) for x in l]).strip() != '':
-                ret.append(l)
-            # Remove header lines that are empty or with only one
-            # whitespace value
-            elif self.line_pos == 0\
-                    and (
-                        len(l) > 1 or len(l) == 1
-                        and (not isinstance(l[0],
-                             compat.string_types) or l[0].strip())
-                    ):
+            # Remove empty lines and lines with only one whitespace value
+            if (len(l) > 1 or len(l) == 1 and
+                (not isinstance(l[0], compat.string_types) or
+                 l[0].strip())):
                 ret.append(l)
         return ret
 
@@ -3477,3 +3468,22 @@ class FixedWidthFieldParser(PythonParser):
     def _make_reader(self, f):
         self.data = FixedWidthReader(f, self.colspecs, self.delimiter,
                                      self.comment, self.skiprows)
+
+    def _remove_empty_lines(self, lines):
+        ret = []
+        for l in lines:
+            # Remove blank lines if they're not headers of the
+            # form ['', '', ... ]
+            if not self.line_pos == 0\
+                    and ''.join([str(x) for x in l]).strip() != '':
+                ret.append(l)
+            # Remove header lines that are empty or with only one
+            # whitespace value
+            elif self.line_pos == 0 \
+                    and (
+                        len(l) > 1 or len(l) == 1
+                        and (not isinstance(l[0],
+                             compat.string_types) or l[0].strip())
+                    ):
+                ret.append(l)
+        return ret

--- a/pandas/io/parsers.py
+++ b/pandas/io/parsers.py
@@ -2301,6 +2301,7 @@ class PythonParser(ParserBase):
 
     def _exclude_implicit_index(self, alldata):
         names = self._maybe_dedup_names(self.orig_names)
+
         if self._implicit_index:
             excl_indices = self.index_col
 
@@ -2381,6 +2382,7 @@ class PythonParser(ParserBase):
             for level, hr in enumerate(header):
                 try:
                     line = self._buffered_line()
+
                     while self.line_pos <= hr:
                         line = self._next_line()
 
@@ -2550,8 +2552,7 @@ class PythonParser(ParserBase):
         if len(self.buf) > 0:
             return self.buf[0]
         else:
-            s = self._next_line()
-            return s
+            return self._next_line()
 
     def _check_for_bom(self, first_row):
         """
@@ -2679,7 +2680,6 @@ class PythonParser(ParserBase):
 
         self.line_pos += 1
         self.buf.append(line)
-
         return line
 
     def _alert_malformed(self, msg, row_num):

--- a/pandas/io/parsers.py
+++ b/pandas/io/parsers.py
@@ -2301,7 +2301,6 @@ class PythonParser(ParserBase):
 
     def _exclude_implicit_index(self, alldata):
         names = self._maybe_dedup_names(self.orig_names)
-
         if self._implicit_index:
             excl_indices = self.index_col
 
@@ -2382,7 +2381,6 @@ class PythonParser(ParserBase):
             for level, hr in enumerate(header):
                 try:
                     line = self._buffered_line()
-
                     while self.line_pos <= hr:
                         line = self._next_line()
 
@@ -2552,7 +2550,8 @@ class PythonParser(ParserBase):
         if len(self.buf) > 0:
             return self.buf[0]
         else:
-            return self._next_line()
+            s = self._next_line()
+            return s
 
     def _check_for_bom(self, first_row):
         """
@@ -2680,6 +2679,7 @@ class PythonParser(ParserBase):
 
         self.line_pos += 1
         self.buf.append(line)
+
         return line
 
     def _alert_malformed(self, msg, row_num):
@@ -2778,8 +2778,11 @@ class PythonParser(ParserBase):
 
         ret = []
         for l in lines:
-            # Remove empty lines and lines with only one whitespace value
-            if (len(l) > 1 or len(l) == 1 and
+            # Remove blank lines if they're not headers of the form ['', '', ... ]
+            if not self.line_pos == 0 and ''.join([str(x) for x in l]).strip() != '':
+                ret.append(l)
+            # Remove header lines that are empty or with only one whitespace value
+            elif self.line_pos == 0 and (len(l) > 1 or len(l) == 1 and
                     (not isinstance(l[0], compat.string_types) or
                      l[0].strip())):
                 ret.append(l)

--- a/pandas/tests/io/parser/test_read_fwf.py
+++ b/pandas/tests/io/parser/test_read_fwf.py
@@ -223,7 +223,6 @@ bar2,12,13,14,15
                              [5, np.nan, 10.]])
         df = read_fwf(StringIO(data), colspecs=[(0, 3), (4, 9), (9, 25)],
                       comment='#')
-        print(df.values, expected)
         tm.assert_almost_equal(df.values, expected)
 
     def test_1000_fwf(self):

--- a/pandas/tests/io/parser/test_read_fwf.py
+++ b/pandas/tests/io/parser/test_read_fwf.py
@@ -223,6 +223,7 @@ bar2,12,13,14,15
                              [5, np.nan, 10.]])
         df = read_fwf(StringIO(data), colspecs=[(0, 3), (4, 9), (9, 25)],
                       comment='#')
+        print(df.values, expected)
         tm.assert_almost_equal(df.values, expected)
 
     def test_1000_fwf(self):
@@ -433,4 +434,12 @@ cc\tdd """
         result = read_fwf(StringIO(test_data), widths=[3, 3],
                           header=None, skiprows=[0])
 
+        tm.assert_frame_equal(result, expected)
+
+    def test_skip_blanklines(self):
+        data_expected = '''A,B
+
+C,D'''
+        expected = read_csv(StringIO(data_expected), header=None, skip_blank_lines=True)
+        result = read_fwf(StringIO(data_expected), colspecs=[(0, 1), (2, 3)], header=None, skip_blank_lines=True)
         tm.assert_frame_equal(result, expected)

--- a/pandas/tests/io/parser/test_read_fwf.py
+++ b/pandas/tests/io/parser/test_read_fwf.py
@@ -440,6 +440,8 @@ cc\tdd """
         data_expected = '''A,B
 
 C,D'''
-        expected = read_csv(StringIO(data_expected), header=None, skip_blank_lines=True)
-        result = read_fwf(StringIO(data_expected), colspecs=[(0, 1), (2, 3)], header=None, skip_blank_lines=True)
+        expected = read_csv(StringIO(data_expected),
+                            header=None, skip_blank_lines=True)
+        result = read_fwf(StringIO(data_expected), colspecs=[(0, 1), (2, 3)],
+                          header=None, skip_blank_lines=True)
         tm.assert_frame_equal(result, expected)


### PR DESCRIPTION
- [x] closes #22693 
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry

Fixes the bug where blank lines are not skipped using read_fwf even when skip_blank_lines is set to true. Override default behaviour in FixedWidthFieldParser.