### PR TITLE
Remove bare exceptions from 'pandas/tests' to decrease flake8 E722 warnings

### DIFF
--- a/pandas/tests/indexing/common.py
+++ b/pandas/tests/indexing/common.py
@@ -151,7 +151,7 @@ class Base(object):
         with catch_warnings(record=True):
             try:
                 xp = getattr(obj, method).__getitem__(_axify(obj, key, axis))
-            except:
+            except AttributeError:
                 xp = getattr(obj, method).__getitem__(key)
 
         return xp
@@ -214,7 +214,7 @@ class Base(object):
 
                 try:
                     xp = self.get_result(obj, method2, k2, a)
-                except:
+                except Exception:
                     result = 'no comp'
                     _print(result)
                     return

--- a/pandas/tests/io/formats/test_format.py
+++ b/pandas/tests/io/formats/test_format.py
@@ -70,7 +70,7 @@ def has_horizontally_truncated_repr(df):
     try:  # Check header row
         fst_line = np.array(repr(df).splitlines()[0].split())
         cand_col = np.where(fst_line == '...')[0][0]
-    except:
+    except IndexError:
         return False
     # Make sure each row has this ... in the same place
     r = repr(df)
@@ -452,7 +452,7 @@ class TestDataFrameFormatting(object):
         for line in rs[1:]:
             try:
                 line = line.decode(get_option("display.encoding"))
-            except:
+            except Exception:
                 pass
             if not line.startswith('dtype:'):
                 assert len(line) == line_len

--- a/pandas/tests/io/test_pytables.py
+++ b/pandas/tests/io/test_pytables.py
@@ -51,7 +51,7 @@ def safe_remove(path):
     if path is not None:
         try:
             os.remove(path)
-        except:
+        except OSError:
             pass
 
 
@@ -59,7 +59,7 @@ def safe_close(store):
     try:
         if store is not None:
             store.close()
-    except:
+    except Exception:
         pass
 
 
@@ -117,7 +117,7 @@ def _maybe_remove(store, key):
     no content from previous tests using the same table name."""
     try:
         store.remove(key)
-    except:
+    except Exception:
         pass
 
 
@@ -4621,7 +4621,7 @@ class TestHDFStore(Base):
                     safe_close(tstore)
                     try:
                         os.close(fd)
-                    except:
+                    except ValueError:
                         pass
                     safe_remove(new_f)
 

--- a/pandas/tests/io/test_sql.py
+++ b/pandas/tests/io/test_sql.py
@@ -1787,10 +1787,12 @@ class _TestMySQLAlchemy(object):
 
         connection = self.conn.connect()
         trans = connection.begin()
+
+        from pymysql.err import Error
         try:
             r1 = connection.execute(proc)  # noqa
             trans.commit()
-        except:
+        except Error:
             trans.rollback()
             raise
 
@@ -2370,12 +2372,13 @@ class TestXMySQL(MySQLMixIn):
 
         # test connection
         import pymysql
+        from pymysql.err import Error
         try:
             # Try Travis defaults.
             # No real user should allow root access with a blank password.
             pymysql.connect(host='localhost', user='root', passwd='',
                             db='pandas_nosetest')
-        except:
+        except Error:
             pass
         else:
             return
@@ -2397,12 +2400,13 @@ class TestXMySQL(MySQLMixIn):
     def setup_method(self, request, datapath):
         _skip_if_no_pymysql()
         import pymysql
+        from pymysql.err import Error
         try:
             # Try Travis defaults.
             # No real user should allow root access with a blank password.
             self.conn = pymysql.connect(host='localhost', user='root',
                                         passwd='', db='pandas_nosetest')
-        except:
+        except Error:
             pass
         else:
             return

--- a/pandas/tests/test_multilevel.py
+++ b/pandas/tests/test_multilevel.py
@@ -1375,7 +1375,7 @@ Thur,Lunch,Yes,51.51,17"""
 
         try:
             df = f()
-        except:
+        except Exception:
             pass
         assert (df['foo', 'one'] == 0).all()
 

--- a/pandas/tests/test_nanops.py
+++ b/pandas/tests/test_nanops.py
@@ -141,12 +141,12 @@ class TestnanopsDataFrame(object):
             if axis != 0 and hasattr(
                     targ, 'shape') and targ.ndim and targ.shape != res.shape:
                 res = np.split(res, [targ.shape[0]], axis=0)[0]
-        except:
+        except (ValueError, IndexError):
             targ, res = _coerce_tds(targ, res)
 
         try:
             tm.assert_almost_equal(targ, res, check_dtype=check_dtype)
-        except:
+        except AssertionError:
 
             # handle timedelta dtypes
             if hasattr(targ, 'dtype') and targ.dtype == 'm8[ns]':
@@ -167,11 +167,11 @@ class TestnanopsDataFrame(object):
                 else:
                     try:
                         res = res.astype('c16')
-                    except:
+                    except Exception:
                         res = res.astype('f8')
                     try:
                         targ = targ.astype('c16')
-                    except:
+                    except Exception:
                         targ = targ.astype('f8')
             # there should never be a case where numpy returns an object
             # but nanops doesn't, so make that an exception

--- a/pandas/tests/test_panel.py
+++ b/pandas/tests/test_panel.py
@@ -335,13 +335,13 @@ class SafeForSparse(object):
         for op in ops:
             try:
                 check_op(getattr(operator, op), op)
-            except:
+            except (AttributeError, KeyError):
                 pprint_thing("Failing operation: %r" % op)
                 raise
         if compat.PY3:
             try:
                 check_op(operator.truediv, 'div')
-            except:
+            except (AttributeError, KeyError):
                 pprint_thing("Failing operation: %r" % 'div')
                 raise
 

--- a/pandas/tests/test_strings.py
+++ b/pandas/tests/test_strings.py
@@ -2660,7 +2660,7 @@ class TestStringMethods(object):
                 expected = Series([s[start:stop:step] if not isna(s) else NA
                                    for s in values])
                 tm.assert_series_equal(result, expected)
-            except:
+            except IndexError:
                 print('failed on %s:%s:%s' % (start, stop, step))
                 raise
 


### PR DESCRIPTION
Closes #22872

In my experience, the main reson to not catch bare exception is that thet progam has no way of using distinguisging keyboard exception (`crtl + C`) from regular exception. So I opted for 

```python
except Exception:
```

in cases where it's not clear what exception may happen or function wrapped in a try-except is so large that basically any exception can in different situations happen.

- [x] closes #xxxx
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry