### PR TITLE
BLD: Drop nonexistent dependency of _libs/parsers

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -544,8 +544,7 @@ ext_data = {
     '_libs.parsers': {
         'pyxfile': '_libs/parsers',
         'depends': ['pandas/_libs/src/parser/tokenizer.h',
-                    'pandas/_libs/src/parser/io.h',
-                    'pandas/_libs/src/numpy_helper.h'],
+                    'pandas/_libs/src/parser/io.h'],
         'sources': ['pandas/_libs/src/parser/tokenizer.c',
                     'pandas/_libs/src/parser/io.c']},
     '_libs.reduction': {


### PR DESCRIPTION
Title is self-explanatory.

Follow-up to #22469.
Closes #22831.