### PR TITLE
STYLE: Fix linting of benchmarks

### DIFF
--- a/asv_bench/benchmarks/algorithms.py
+++ b/asv_bench/benchmarks/algorithms.py
@@ -9,7 +9,7 @@ for imp in ['pandas.util', 'pandas.tools.hashing']:
     try:
         hashing = import_module(imp)
         break
-    except:
+    except (ImportError, TypeError, ValueError):
         pass
 
 from .pandas_vb_common import setup # noqa

--- a/asv_bench/benchmarks/io/csv.py
+++ b/asv_bench/benchmarks/io/csv.py
@@ -1,11 +1,9 @@
 import random
-import timeit
 import string
 
 import numpy as np
 import pandas.util.testing as tm
 from pandas import DataFrame, Categorical, date_range, read_csv
-from pandas.compat import PY2
 from pandas.compat import cStringIO as StringIO
 
 from ..pandas_vb_common import setup, BaseIO  # noqa

--- a/asv_bench/benchmarks/io/csv.py
+++ b/asv_bench/benchmarks/io/csv.py
@@ -179,8 +179,8 @@ class ReadCSVFloatPrecision(StringIORewind):
                  names=list('abc'), float_precision=float_precision)
 
     def time_read_csv_python_engine(self, sep, decimal, float_precision):
-        read_csv(self.data(self.StringIO_input), sep=sep, header=None, engine='python',
-                 float_precision=None, names=list('abc'))
+        read_csv(self.data(self.StringIO_input), sep=sep, header=None,
+                 engine='python', float_precision=None, names=list('abc'))
 
 
 class ReadCSVCategorical(BaseIO):

--- a/asv_bench/benchmarks/join_merge.py
+++ b/asv_bench/benchmarks/join_merge.py
@@ -29,7 +29,7 @@ class Append(object):
         try:
             with warnings.catch_warnings(record=True):
                 self.mdf1.consolidate(inplace=True)
-        except:
+        except (AttributeError, TypeError):
             pass
         self.mdf2 = self.mdf1.copy()
         self.mdf2.index = self.df2.index

--- a/asv_bench/benchmarks/pandas_vb_common.py
+++ b/asv_bench/benchmarks/pandas_vb_common.py
@@ -2,7 +2,6 @@ import os
 from importlib import import_module
 
 import numpy as np
-from pandas import Panel
 
 # Compatibility import for lib
 for imp in ['pandas._libs.lib', 'pandas.lib']:

--- a/asv_bench/benchmarks/pandas_vb_common.py
+++ b/asv_bench/benchmarks/pandas_vb_common.py
@@ -9,7 +9,7 @@ for imp in ['pandas._libs.lib', 'pandas.lib']:
     try:
         lib = import_module(imp)
         break
-    except:
+    except (ImportError, TypeError, ValueError):
         pass
 
 numeric_dtypes = [np.int64, np.int32, np.uint32, np.uint64, np.float32,
@@ -34,7 +34,7 @@ class BaseIO(object):
         """Remove created files"""
         try:
             os.remove(f)
-        except:
+        except OSError:
             # On Windows, attempting to remove a file that is in use
             # causes an exception to be raised
             pass

--- a/asv_bench/benchmarks/stat_ops.py
+++ b/asv_bench/benchmarks/stat_ops.py
@@ -18,7 +18,7 @@ class FrameOps(object):
         df = pd.DataFrame(np.random.randn(100000, 4)).astype(dtype)
         try:
             pd.options.compute.use_bottleneck = use_bottleneck
-        except:
+        except TypeError:
             from pandas.core import nanops
             nanops._USE_BOTTLENECK = use_bottleneck
         self.df_func = getattr(df, op)
@@ -56,7 +56,7 @@ class SeriesOps(object):
         s = pd.Series(np.random.randn(100000)).astype(dtype)
         try:
             pd.options.compute.use_bottleneck = use_bottleneck
-        except:
+        except TypeError:
             from pandas.core import nanops
             nanops._USE_BOTTLENECK = use_bottleneck
         self.s_func = getattr(s, op)

--- a/asv_bench/benchmarks/timeseries.py
+++ b/asv_bench/benchmarks/timeseries.py
@@ -1,4 +1,3 @@
-import warnings
 from datetime import timedelta
 
 import numpy as np


### PR DESCRIPTION
- [x] closes #22884 
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry

Fixed the following:

` asv_bench/benchmarks/algorithms.py:12:5: E722 do not use bare except'
asv_bench/benchmarks/timeseries.py:1:1: F401 'warnings' imported but unused
asv_bench/benchmarks/stat_ops.py:21:9: E722 do not use bare except'
asv_bench/benchmarks/stat_ops.py:59:9: E722 do not use bare except'
asv_bench/benchmarks/pandas_vb_common.py:5:1: F401 'pandas.Panel' imported but unused
asv_bench/benchmarks/pandas_vb_common.py:12:5: E722 do not use bare except'
asv_bench/benchmarks/pandas_vb_common.py:37:9: E722 do not use bare except'
asv_bench/benchmarks/join_merge.py:32:9: E722 do not use bare except'
asv_bench/benchmarks/io/csv.py:2:1: F401 'timeit' imported but unused
asv_bench/benchmarks/io/csv.py:8:1: F401 'pandas.compat.PY2' imported but unused
asv_bench/benchmarks/io/csv.py:184:80: E501 line too long (87 > 79 characters)  `