### PR TITLE
CLN GH22873 Replace base excepts in pandas/core

### DIFF
--- a/doc/source/whatsnew/v0.24.0.txt
+++ b/doc/source/whatsnew/v0.24.0.txt
@@ -834,4 +834,3 @@ Other
 - :meth:`DataFrame.nlargest` and :meth:`DataFrame.nsmallest` now returns the correct n values when keep != 'all' also when tied on the first columns (:issue:`22752`)
 - :meth:`~pandas.io.formats.style.Styler.bar` now also supports tablewise application (in addition to rowwise and columnwise) with ``axis=None`` and setting clipping range with ``vmin`` and ``vmax`` (:issue:`21548` and :issue:`21526`). ``NaN`` values are also handled properly.
 - Logical operations ``&, |, ^`` between :class:`Series` and :class:`Index` will no longer raise ``ValueError`` (:issue:`22092`)
--

--- a/pandas/core/computation/pytables.py
+++ b/pandas/core/computation/pytables.py
@@ -411,7 +411,7 @@ class ExprVisitor(BaseExprVisitor):
         slobj = self.visit(node.slice)
         try:
             value = value.value
-        except:
+        except AttributeError:
             pass
 
         try:

--- a/pandas/core/dtypes/common.py
+++ b/pandas/core/dtypes/common.py
@@ -467,7 +467,7 @@ def is_timedelta64_dtype(arr_or_dtype):
         return False
     try:
         tipo = _get_dtype_type(arr_or_dtype)
-    except:
+    except (TypeError, ValueError, SyntaxError):
         return False
     return issubclass(tipo, np.timedelta64)
 

--- a/pandas/core/dtypes/dtypes.py
+++ b/pandas/core/dtypes/dtypes.py
@@ -358,10 +358,10 @@ class CategoricalDtype(PandasExtensionDtype, ExtensionDtype):
         try:
             if string == 'category':
                 return cls()
-        except:
+            else:
+                raise TypeError("cannot construct a CategoricalDtype")
+        except AttributeError:
             pass
-
-        raise TypeError("cannot construct a CategoricalDtype")
 
     @staticmethod
     def validate_ordered(ordered):
@@ -519,7 +519,7 @@ class DatetimeTZDtype(PandasExtensionDtype):
                 if m is not None:
                     unit = m.groupdict()['unit']
                     tz = m.groupdict()['tz']
-            except:
+            except TypeError:
                 raise ValueError("could not construct DatetimeTZDtype")
 
         elif isinstance(unit, compat.string_types):

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -3260,7 +3260,7 @@ class DataFrame(NDFrame):
         if not len(self.index) and is_list_like(value):
             try:
                 value = Series(value)
-            except:
+            except (ValueError, NotImplementedError, TypeError):
                 raise ValueError('Cannot set a frame with no defined index '
                                  'and a value that cannot be converted to a '
                                  'Series')
@@ -7747,7 +7747,7 @@ def _prep_ndarray(values, copy=True):
                 values = np.array([convert(v) for v in values])
             else:
                 values = convert(values)
-        except:
+        except (ValueError, TypeError):
             values = convert(values)
 
     else:

--- a/pandas/core/indexes/frozen.py
+++ b/pandas/core/indexes/frozen.py
@@ -139,7 +139,7 @@ class FrozenNDArray(PandasObject, np.ndarray):
         # xref: https://github.com/numpy/numpy/issues/5370
         try:
             value = self.dtype.type(value)
-        except:
+        except ValueError:
             pass
 
         return super(FrozenNDArray, self).searchsorted(

--- a/pandas/core/indexes/multi.py
+++ b/pandas/core/indexes/multi.py
@@ -6,6 +6,7 @@ from sys import getsizeof
 
 import numpy as np
 from pandas._libs import algos as libalgos, index as libindex, lib, Timestamp
+from pandas._libs import tslibs
 
 from pandas.compat import range, zip, lrange, lzip, map
 from pandas.compat.numpy import function as nv
@@ -1002,12 +1003,13 @@ class MultiIndex(Index):
                     return _try_mi(key)
                 except (KeyError):
                     raise
-                except:
+                except (IndexError, ValueError, TypeError):
                     pass
 
                 try:
                     return _try_mi(Timestamp(key))
-                except:
+                except (KeyError, TypeError,
+                        IndexError, ValueError, tslibs.OutOfBoundsDatetime):
                     pass
 
             raise InvalidIndexError(key)
@@ -1686,7 +1688,7 @@ class MultiIndex(Index):
         # if all(isinstance(x, MultiIndex) for x in other):
         try:
             return MultiIndex.from_tuples(new_tuples, names=self.names)
-        except:
+        except (TypeError, IndexError):
             return Index(new_tuples)
 
     def argsort(self, *args, **kwargs):
@@ -2315,7 +2317,7 @@ class MultiIndex(Index):
             for i in sorted(levels, reverse=True):
                 try:
                     new_index = new_index.droplevel(i)
-                except:
+                except ValueError:
 
                     # no dropping here
                     return orig_index
@@ -2818,7 +2820,7 @@ class MultiIndex(Index):
                 msg = 'other must be a MultiIndex or a list of tuples'
                 try:
                     other = MultiIndex.from_tuples(other)
-                except:
+                except TypeError:
                     raise TypeError(msg)
         else:
             result_names = self.names if self.names == other.names else None

--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -2146,7 +2146,7 @@ class _iLocIndexer(_LocationIndexer):
         self._has_valid_tuple(tup)
         try:
             return self._getitem_lowerdim(tup)
-        except:
+        except IndexingError:
             pass
 
         retval = self.obj
@@ -2705,13 +2705,13 @@ def maybe_droplevels(index, key):
         for _ in key:
             try:
                 index = index.droplevel(0)
-            except:
+            except ValueError:
                 # we have dropped too much, so back out
                 return original_index
     else:
         try:
             index = index.droplevel(0)
-        except:
+        except ValueError:
             pass
 
     return index

--- a/pandas/core/internals/blocks.py
+++ b/pandas/core/internals/blocks.py
@@ -666,7 +666,7 @@ class Block(PandasObject):
 
             newb = make_block(values, placement=self.mgr_locs,
                               klass=klass, ndim=self.ndim)
-        except:
+        except Exception:  # noqa: E722
             if errors == 'raise':
                 raise
             newb = self.copy() if copy else self
@@ -1142,7 +1142,7 @@ class Block(PandasObject):
         # a fill na type method
         try:
             m = missing.clean_fill_method(method)
-        except:
+        except ValueError:
             m = None
 
         if m is not None:
@@ -1157,7 +1157,7 @@ class Block(PandasObject):
         # try an interp method
         try:
             m = missing.clean_interp_method(method, **kwargs)
-        except:
+        except ValueError:
             m = None
 
         if m is not None:
@@ -2438,7 +2438,7 @@ class ObjectBlock(Block):
             try:
                 if (self.values[locs] == values).all():
                     return
-            except:
+            except (IndexError, ValueError):
                 pass
         try:
             self.values[locs] = values
@@ -3172,7 +3172,7 @@ class SparseBlock(NonConsolidatableMixIn, Block):
     def __len__(self):
         try:
             return self.sp_index.length
-        except:
+        except AttributeError:
             return 0
 
     def copy(self, deep=True, mgr=None):

--- a/pandas/core/nanops.py
+++ b/pandas/core/nanops.py
@@ -503,7 +503,8 @@ def _nanminmax(meth, fill_value_typ):
             try:
                 result = getattr(values, meth)(axis, dtype=dtype_max)
                 result.fill(np.nan)
-            except:
+            except (AttributeError, TypeError,
+                    ValueError, np.core._internal.AxisError):
                 result = np.nan
         else:
             result = getattr(values, meth)(axis)
@@ -815,7 +816,7 @@ def _ensure_numeric(x):
         elif is_object_dtype(x):
             try:
                 x = x.astype(np.complex128)
-            except:
+            except (TypeError, ValueError):
                 x = x.astype(np.float64)
             else:
                 if not np.any(x.imag):

--- a/pandas/core/ops.py
+++ b/pandas/core/ops.py
@@ -1545,7 +1545,8 @@ def _bool_method_SERIES(cls, op, special):
                     y = bool(y)
                 try:
                     result = libops.scalar_binop(x, y, op)
-                except:
+                except (TypeError, ValueError, AttributeError,
+                        OverflowError, NotImplementedError):
                     raise TypeError("cannot compare a dtyped [{dtype}] array "
                                     "with a scalar of type [{typ}]"
                                     .format(dtype=x.dtype,

--- a/pandas/core/sparse/array.py
+++ b/pandas/core/sparse/array.py
@@ -306,7 +306,7 @@ class SparseArray(PandasObject, np.ndarray):
     def __len__(self):
         try:
             return self.sp_index.length
-        except:
+        except AttributeError:
             return 0
 
     def __unicode__(self):

--- a/pandas/core/tools/datetimes.py
+++ b/pandas/core/tools/datetimes.py
@@ -244,7 +244,7 @@ def _convert_listlike_datetimes(arg, box, format, name=None, tz=None,
             if format == '%Y%m%d':
                 try:
                     result = _attempt_YYYYMMDD(arg, errors=errors)
-                except:
+                except (ValueError, TypeError, tslibs.OutOfBoundsDatetime):
                     raise ValueError("cannot convert the input to "
                                      "'%Y%m%d' date format")
 
@@ -334,7 +334,7 @@ def _adjust_to_origin(arg, origin, unit):
             raise ValueError("unit must be 'D' for origin='julian'")
         try:
             arg = arg - j0
-        except:
+        except TypeError:
             raise ValueError("incompatible 'arg' type for given "
                              "'origin'='julian'")
 
@@ -731,21 +731,21 @@ def _attempt_YYYYMMDD(arg, errors):
     # try intlike / strings that are ints
     try:
         return calc(arg.astype(np.int64))
-    except:
+    except ValueError:
         pass
 
     # a float with actual np.nan
     try:
         carg = arg.astype(np.float64)
         return calc_with_mask(carg, notna(carg))
-    except:
+    except ValueError:
         pass
 
     # string with NaN-like
     try:
         mask = ~algorithms.isin(arg, list(tslib.nat_strings))
         return calc_with_mask(arg, mask)
-    except:
+    except ValueError:
         pass
 
     return None

--- a/pandas/core/window.py
+++ b/pandas/core/window.py
@@ -2504,7 +2504,7 @@ def _offset(window, center):
     offset = (window - 1) / 2. if center else 0
     try:
         return int(offset)
-    except:
+    except TypeError:
         return offset.astype(int)
 
 


### PR DESCRIPTION
This cleaning fix adds specific exception classes to bare except statements to correct PEP8 linting errors. The classes were chosen by a mixture of educated guessing (i.e. if a statement gets the `length` property, it might raise an `AttributeError`), trying out functions on known edge cases (i.e. giving a datetime input that is too large gives `tslibs.OutOfBoundsDatetime`), and inspecting functions in the `try` block to see what kind of errors they raise.

- [x] xref #22873
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry