### PR TITLE
DOC: #22899, Fixed docstring of itertuples in pandas/core/frame.py

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -896,7 +896,9 @@ class DataFrame(NDFrame):
         Yields
         -------
         collections.namedtuple
-            Yields namedtuples of corresponding index and column values.
+            Yields a namedtuple for each row in the DataFrame with the first
+            field possibly being the index and following fields being the
+            column values.
 
         Notes
         -----
@@ -904,15 +906,16 @@ class DataFrame(NDFrame):
         invalid Python identifiers, repeated, or start with an underscore.
         With a large number of columns (>255), regular tuples are returned.
 
-        See also
+        See Also
         --------
-        iterrows : Iterate over DataFrame rows as (index, Series) pairs.
-        iteritems : Iterate over (column name, Series) pairs.
+        DataFrame.iterrows : Iterate over DataFrame rows as (index, Series)
+            pairs.
+        DataFrame.iteritems : Iterate over (column name, Series) pairs.
 
         Examples
         --------
-        >>> df = pd.DataFrame({'num_legs': [4,2], 'num_wings': [0,2]},
-        ...                   index=['dog','hawk'])
+        >>> df = pd.DataFrame({'num_legs': [4, 2], 'num_wings': [0, 2]},
+        ...                   index=['dog', 'hawk'])
         >>> df
               num_legs  num_wings
         dog          4          0

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -887,15 +887,16 @@ class DataFrame(NDFrame):
 
         Parameters
         ----------
-        index : boolean, default True
+        index : bool, default True
             If True, return the index as the first element of the tuple.
-        name : string, default "Pandas"
+        name : str, default "Pandas"
             The name of the returned namedtuples or None to return regular
             tuples.
 
-        Returns
+        Yields
         -------
-        Returns namedtuples.
+        collections.namedtuple
+            Yields namedtuples of corresponding index and column values.
 
         Notes
         -----
@@ -910,17 +911,35 @@ class DataFrame(NDFrame):
 
         Examples
         --------
-        >>> df = pd.DataFrame({'col1': [1, 2], 'col2': [0.1, 0.2]},
-        ...                   index=['a', 'b'])
+        >>> df = pd.DataFrame({'num_legs': [4,2], 'num_wings': [0,2]},
+        ...                   index=['dog','hawk'])
         >>> df
-           col1  col2
-        a     1   0.1
-        b     2   0.2
+              num_legs  num_wings
+        dog          4          0
+        hawk         2          2
         >>> for row in df.itertuples():
         ...     print(row)
         ...
-        Pandas(Index='a', col1=1, col2=0.1)
-        Pandas(Index='b', col1=2, col2=0.2)
+        Pandas(Index='dog', num_legs=4, num_wings=0)
+        Pandas(Index='hawk', num_legs=2, num_wings=2)
+
+        By setting the `index` parameter to False we can remove the index
+        as the first element of the tuple:
+
+        >>> for row in df.itertuples(index=False):
+        ...     print(row)
+        ...
+        Pandas(num_legs=4, num_wings=0)
+        Pandas(num_legs=2, num_wings=2)
+
+        With the `name` parameter set we set a custom name for the yielded
+        namedtuples:
+
+        >>> for row in df.itertuples(name='Animal'):
+        ...     print(row)
+        ...
+        Animal(Index='dog', num_legs=4, num_wings=0)
+        Animal(Index='hawk', num_legs=2, num_wings=2)
         """
         arrays = []
         fields = []

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -883,8 +883,7 @@ class DataFrame(NDFrame):
 
     def itertuples(self, index=True, name="Pandas"):
         """
-        Iterate over DataFrame rows as namedtuples, with index value as first
-        element of the tuple.
+        Iterate over DataFrame rows as namedtuples.
 
         Parameters
         ----------
@@ -893,6 +892,10 @@ class DataFrame(NDFrame):
         name : string, default "Pandas"
             The name of the returned namedtuples or None to return regular
             tuples.
+
+        Returns
+        -------
+        Returns namedtuples.
 
         Notes
         -----
@@ -907,9 +910,8 @@ class DataFrame(NDFrame):
 
         Examples
         --------
-
         >>> df = pd.DataFrame({'col1': [1, 2], 'col2': [0.1, 0.2]},
-                              index=['a', 'b'])
+        ...                   index=['a', 'b'])
         >>> df
            col1  col2
         a     1   0.1
@@ -917,9 +919,8 @@ class DataFrame(NDFrame):
         >>> for row in df.itertuples():
         ...     print(row)
         ...
-        Pandas(Index='a', col1=1, col2=0.10000000000000001)
-        Pandas(Index='b', col1=2, col2=0.20000000000000001)
-
+        Pandas(Index='a', col1=1, col2=0.1)
+        Pandas(Index='b', col1=2, col2=0.2)
         """
         arrays = []
         fields = []


### PR DESCRIPTION
- [ ] closes #xxxx
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

#22899 
I went ahead and followed the docstring conventions mentioned here: 

https://pandas.pydata.org/pandas-docs/stable/contributing_docstring.html

The fixes I made were for the following errors:

<img width="891" alt="screen shot 2018-09-29 at 19 17 59" src="https://user-images.githubusercontent.com/16315857/46252338-740df400-c41c-11e8-9c29-ff955c9b9705.png">
<img width="618" alt="screen shot 2018-09-29 at 19 18 08" src="https://user-images.githubusercontent.com/16315857/46252339-76704e00-c41c-11e8-89d5-adab168dc329.png">

- Fixed whitespace between closing line and end of docstring
- Converted summary into single line
- Added `Returns` section (Not sure if done correctly!)
- Fixed examples to pass test by adding `...` at line 914
- Fixed namedtuple return values at 922 and 923 

Please let me know if there are any issues and I will try my best to fix them ASAP.

Thank you!~ 