### PR TITLE
STYLE: Added explicit exceptions 

### DIFF
--- a/pandas/compat/pickle_compat.py
+++ b/pandas/compat/pickle_compat.py
@@ -33,7 +33,7 @@ def load_reduce(self):
                 cls = args[0]
                 stack[-1] = object.__new__(cls)
                 return
-            except:
+            except TypeError:
                 pass
 
         # try to re-encode the arguments
@@ -44,7 +44,7 @@ def load_reduce(self):
             try:
                 stack[-1] = func(*args)
                 return
-            except:
+            except TypeError:
                 pass
 
         # unknown exception, re-raise
@@ -182,7 +182,7 @@ def load_newobj_ex(self):
 
 try:
     Unpickler.dispatch[pkl.NEWOBJ_EX[0]] = load_newobj_ex
-except:
+except (AttributeError, KeyError):
     pass
 
 
@@ -210,5 +210,5 @@ def load(fh, encoding=None, compat=False, is_verbose=False):
         up.is_verbose = is_verbose
 
         return up.load()
-    except:
+    except (ValueError, TypeError):
         raise

--- a/pandas/tseries/holiday.py
+++ b/pandas/tseries/holiday.py
@@ -294,7 +294,7 @@ holiday_calendars = {}
 def register(cls):
     try:
         name = cls.name
-    except AttributeError: 
+    except AttributeError:
         name = cls.__name__
     holiday_calendars[name] = cls
 
@@ -426,7 +426,7 @@ class AbstractHolidayCalendar(object):
         """
         try:
             other = other.rules
-        except AttributeError: 
+        except AttributeError:
             pass
 
         if not isinstance(other, list):
@@ -435,7 +435,7 @@ class AbstractHolidayCalendar(object):
 
         try:
             base = base.rules
-        except AttributeError: 
+        except AttributeError:
             pass
 
         if not isinstance(base, list):

--- a/pandas/tseries/holiday.py
+++ b/pandas/tseries/holiday.py
@@ -294,7 +294,7 @@ holiday_calendars = {}
 def register(cls):
     try:
         name = cls.name
-    except:
+    except AttributeError: 
         name = cls.__name__
     holiday_calendars[name] = cls
 
@@ -426,7 +426,7 @@ class AbstractHolidayCalendar(object):
         """
         try:
             other = other.rules
-        except:
+        except AttributeError: 
             pass
 
         if not isinstance(other, list):
@@ -435,7 +435,7 @@ class AbstractHolidayCalendar(object):
 
         try:
             base = base.rules
-        except:
+        except AttributeError: 
             pass
 
         if not isinstance(base, list):

--- a/pandas/util/_print_versions.py
+++ b/pandas/util/_print_versions.py
@@ -21,7 +21,7 @@ def get_sys_info():
                                     stdout=subprocess.PIPE,
                                     stderr=subprocess.PIPE)
             so, serr = pipe.communicate()
-        except:
+        except (OSError, ValueError):
             pass
         else:
             if pipe.returncode == 0:
@@ -50,7 +50,7 @@ def get_sys_info():
             ("LANG", "{lang}".format(lang=os.environ.get('LANG', "None"))),
             ("LOCALE", '.'.join(map(str, locale.getlocale()))),
         ])
-    except:
+    except (KeyError, ValueError):
         pass
 
     return blob
@@ -108,7 +108,7 @@ def show_versions(as_json=False):
                 mod = importlib.import_module(modname)
             ver = ver_f(mod)
             deps_blob.append((modname, ver))
-        except:
+        except ModuleNotFoundError:
             deps_blob.append((modname, None))
 
     if (as_json):

--- a/pandas/util/_print_versions.py
+++ b/pandas/util/_print_versions.py
@@ -108,7 +108,7 @@ def show_versions(as_json=False):
                 mod = importlib.import_module(modname)
             ver = ver_f(mod)
             deps_blob.append((modname, ver))
-        except ModuleNotFoundError:
+        except ImportError:
             deps_blob.append((modname, None))
 
     if (as_json):

--- a/pandas/util/_validators.py
+++ b/pandas/util/_validators.py
@@ -59,7 +59,7 @@ def _check_for_default_values(fname, arg_val_dict, compat_args):
 
         # could not compare them directly, so try comparison
         # using the 'is' operator
-        except:
+        except ValueError:
             match = (arg_val_dict[key] is compat_args[key])
 
         if not match:


### PR DESCRIPTION
- [x] xref  #22877
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry

Fixed the following bare excepts:

> pandas/compat/pickle_compat.py:36:13: E722 do not use bare except'
> pandas/compat/pickle_compat.py:47:13: E722 do not use bare except'
> pandas/compat/pickle_compat.py:185:1: E722 do not use bare except'
> pandas/compat/pickle_compat.py:213:5: E722 do not use bare except'
> pandas/tseries/holiday.py:297:5: E722 do not use bare except'
> pandas/tseries/holiday.py:429:9: E722 do not use bare except'
> pandas/tseries/holiday.py:438:9: E722 do not use bare except'
> pandas/util/_print_versions.py:24:9: E722 do not use bare except'
> pandas/util/_print_versions.py:53:5: E722 do not use bare except'
> pandas/util/_print_versions.py:111:9: E722 do not use bare except'
> pandas/util/_validators.py:62:9: E722 do not use bare except'
