### PR TITLE
TST: solve test failure on 32bit systems

### DIFF
--- a/pandas/tests/indexes/test_base.py
+++ b/pandas/tests/indexes/test_base.py
@@ -1379,7 +1379,7 @@ class TestIndex(Base):
         index = pd.Index(arr, dtype=np.object)
         result = index.get_indexer([unique_nulls_fixture,
                                     unique_nulls_fixture2, 'Unknown'])
-        expected = np.array([0, 1, -1], dtype=np.int64)
+        expected = np.array([0, 1, -1], dtype=np.intp)
         tm.assert_numpy_array_equal(result, expected)
 
     @pytest.mark.parametrize("method", [None, 'pad', 'backfill', 'nearest'])


### PR DESCRIPTION
- [x] closes #22813
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

#22296 introduced a test, where ``dtype=np.int64`` was used, but ``np.intp`` is needed for the test to pass on 32bit systems also. This fixes that.

After this PR, the pandas test suite passes with no failures on my 32bit python installation on Windows 10.
