### PR TITLE
DEPR/CLN: Clean up to_dense signature deprecations

### DIFF
--- a/doc/source/whatsnew/v0.24.0.txt
+++ b/doc/source/whatsnew/v0.24.0.txt
@@ -440,7 +440,7 @@ In addition to these API breaking changes, many :ref:`performance improvements a
 Raise ValueError in ``DataFrame.to_dict(orient='index')``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Bug in :func:`DataFrame.to_dict` raises ``ValueError`` when used with 
+Bug in :func:`DataFrame.to_dict` raises ``ValueError`` when used with
 ``orient='index'`` and a non-unique index instead of losing data (:issue:`22801`)
 
 .. ipython:: python
@@ -448,7 +448,7 @@ Bug in :func:`DataFrame.to_dict` raises ``ValueError`` when used with
 
     df = pd.DataFrame({'a': [1, 2], 'b': [0.5, 0.75]}, index=['A', 'A'])
     df
-    
+
     df.to_dict(orient='index')
 
 .. _whatsnew_0240.api.datetimelike.normalize:
@@ -747,6 +747,8 @@ Removal of prior version deprecations/changes
 - :meth:`Categorical.searchsorted` and :meth:`Series.searchsorted` have renamed the ``v`` argument to ``value`` (:issue:`14645`)
 - :meth:`TimedeltaIndex.searchsorted`, :meth:`DatetimeIndex.searchsorted`, and :meth:`PeriodIndex.searchsorted` have renamed the ``key`` argument to ``value`` (:issue:`14645`)
 - Removal of the previously deprecated module ``pandas.json`` (:issue:`19944`)
+- :meth:`SparseArray.get_values` and :meth:`SparseArray.to_dense` have dropped the ``fill`` parameter (:issue:`14686`)
+- :meth:`SparseSeries.to_dense` has dropped the ``sparse_only`` parameter (:issue:`14686`)
 
 .. _whatsnew_0240.performance:
 

--- a/pandas/core/arrays/sparse.py
+++ b/pandas/core/arrays/sparse.py
@@ -1249,30 +1249,18 @@ class SparseArray(PandasObject, ExtensionArray, ExtensionOpsMixin):
         return type(self)(sp_values, sparse_index=self.sp_index,
                           fill_value=fill_value)
 
-    def get_values(self, fill=None):
-        """ return a dense representation """
-        # TODO: deprecate for to_dense?
-        return self.to_dense(fill=fill)
-
-    def to_dense(self, fill=None):
+    def to_dense(self):
         """
         Convert SparseArray to a NumPy array.
-
-        Parameters
-        ----------
-        fill: float, default None
-            .. deprecated:: 0.20.0
-               This argument is not respected by this function.
 
         Returns
         -------
         arr : NumPy array
         """
-        if fill is not None:
-            warnings.warn(("The 'fill' parameter has been deprecated and "
-                           "will be removed in a future version."),
-                          FutureWarning, stacklevel=2)
         return np.asarray(self, dtype=self.sp_values.dtype)
+
+    # TODO: Look into deprecating this in favor of `to_dense`.
+    get_values = to_dense
 
     # ------------------------------------------------------------------------
     # IO

--- a/pandas/core/sparse/series.py
+++ b/pandas/core/sparse/series.py
@@ -439,33 +439,16 @@ class SparseSeries(Series):
                              kind=self.kind)
         self._data = SingleBlockManager(values, self.index)
 
-    def to_dense(self, sparse_only=False):
+    def to_dense(self):
         """
         Convert SparseSeries to a Series.
-
-        Parameters
-        ----------
-        sparse_only : bool, default False
-            .. deprecated:: 0.20.0
-                This argument will be removed in a future version.
-
-            If True, return just the non-sparse values, or the dense version
-            of `self.values` if False.
 
         Returns
         -------
         s : Series
         """
-        if sparse_only:
-            warnings.warn(("The 'sparse_only' parameter has been deprecated "
-                           "and will be removed in a future version."),
-                          FutureWarning, stacklevel=2)
-            int_index = self.sp_index.to_int_index()
-            index = self.index.take(int_index.indices)
-            return Series(self.sp_values, index=index, name=self.name)
-        else:
-            return Series(self.values.to_dense(), index=self.index,
-                          name=self.name)
+        return Series(self.values.to_dense(), index=self.index,
+                      name=self.name)
 
     @property
     def density(self):

--- a/pandas/tests/arrays/sparse/test_array.py
+++ b/pandas/tests/arrays/sparse/test_array.py
@@ -533,32 +533,20 @@ class TestSparseArray(object):
         out = SparseArray(data, dtype=dtype)
         assert out.shape == shape
 
-    def test_to_dense(self):
-        vals = np.array([1, np.nan, np.nan, 3, np.nan])
-        res = SparseArray(vals).to_dense()
-        tm.assert_numpy_array_equal(res, vals)
+    @pytest.mark.parametrize("vals", [
+        [np.nan, np.nan, np.nan, np.nan, np.nan],
+        [1, np.nan, np.nan, 3, np.nan],
+        [1, np.nan, 0, 3, 0],
+    ])
+    @pytest.mark.parametrize("method", ["to_dense", "get_values"])
+    @pytest.mark.parametrize("fill_value", [None, 0])
+    def test_dense_repr(self, vals, fill_value, method):
+        vals = np.array(vals)
+        arr = SparseArray(vals, fill_value=fill_value)
+        dense_func = getattr(arr, method)
 
-        res = SparseArray(vals, fill_value=0).to_dense()
+        res = dense_func()
         tm.assert_numpy_array_equal(res, vals)
-
-        vals = np.array([1, np.nan, 0, 3, 0])
-        res = SparseArray(vals).to_dense()
-        tm.assert_numpy_array_equal(res, vals)
-
-        res = SparseArray(vals, fill_value=0).to_dense()
-        tm.assert_numpy_array_equal(res, vals)
-
-        vals = np.array([np.nan, np.nan, np.nan, np.nan, np.nan])
-        res = SparseArray(vals).to_dense()
-        tm.assert_numpy_array_equal(res, vals)
-
-        res = SparseArray(vals, fill_value=0).to_dense()
-        tm.assert_numpy_array_equal(res, vals)
-
-        # see gh-14647
-        with tm.assert_produces_warning(FutureWarning,
-                                        check_stacklevel=False):
-            SparseArray(vals).to_dense(fill=2)
 
     def test_getitem(self):
         def _checkit(i):

--- a/pandas/tests/sparse/series/test_series.py
+++ b/pandas/tests/sparse/series/test_series.py
@@ -192,15 +192,6 @@ class TestSparseSeries(SharedWithSparse):
         series = self.bseries.to_dense()
         tm.assert_series_equal(series, Series(arr, name='bseries'))
 
-        # see gh-14647
-        with tm.assert_produces_warning(FutureWarning,
-                                        check_stacklevel=False):
-            series = self.bseries.to_dense(sparse_only=True)
-
-        indexer = np.isfinite(arr)
-        exp = Series(arr[indexer], index=index[indexer], name='bseries')
-        tm.assert_series_equal(series, exp)
-
         series = self.iseries.to_dense()
         tm.assert_series_equal(series, Series(arr, name='iseries'))
 


### PR DESCRIPTION
Also deprecate `fill` in `.get_values` because its parameter was being passed to `.to_dense`, which
no longer accepts the `fill` parameter.

xref #14686.
