### PR TITLE
CLN GH22875 Replace bare excepts by explicit excepts in pandas/io/

### DIFF
--- a/pandas/io/clipboards.py
+++ b/pandas/io/clipboards.py
@@ -42,7 +42,7 @@ def read_clipboard(sep=r'\s+', **kwargs):  # pragma: no cover
                 text, encoding=(kwargs.get('encoding') or
                                 get_option('display.encoding'))
             )
-        except:
+        except AttributeError:
             pass
 
     # Excel copies into clipboard with \t separation

--- a/pandas/io/formats/console.py
+++ b/pandas/io/formats/console.py
@@ -100,7 +100,7 @@ def in_interactive_session():
 
     try:
         return __IPYTHON__ or check_main()  # noqa
-    except:
+    except NameError:
         return check_main()
 
 
@@ -118,7 +118,7 @@ def in_qtconsole():
             ip.config.get('IPKernelApp', {}).get('parent_appname', ""))
         if 'qtconsole' in front_end.lower():
             return True
-    except:
+    except NameError:
         return False
     return False
 
@@ -137,7 +137,7 @@ def in_ipnb():
             ip.config.get('IPKernelApp', {}).get('parent_appname', ""))
         if 'notebook' in front_end.lower():
             return True
-    except:
+    except NameError:
         return False
     return False
 
@@ -149,7 +149,7 @@ def in_ipython_frontend():
     try:
         ip = get_ipython()  # noqa
         return 'zmq' in str(type(ip)).lower()
-    except:
+    except NameError:
         pass
 
     return False

--- a/pandas/io/formats/terminal.py
+++ b/pandas/io/formats/terminal.py
@@ -78,7 +78,7 @@ def _get_terminal_size_windows():
         h = windll.kernel32.GetStdHandle(-12)
         csbi = create_string_buffer(22)
         res = windll.kernel32.GetConsoleScreenBufferInfo(h, csbi)
-    except:
+    except (AttributeError, ValueError):
         return None
     if res:
         import struct
@@ -108,7 +108,7 @@ def _get_terminal_size_tput():
         output = proc.communicate(input=None)
         rows = int(output[0])
         return (cols, rows)
-    except:
+    except OSError:
         return None
 
 
@@ -120,7 +120,7 @@ def _get_terminal_size_linux():
             import struct
             cr = struct.unpack(
                 'hh', fcntl.ioctl(fd, termios.TIOCGWINSZ, '1234'))
-        except:
+        except struct.error:
             return None
         return cr
     cr = ioctl_GWINSZ(0) or ioctl_GWINSZ(1) or ioctl_GWINSZ(2)
@@ -129,13 +129,13 @@ def _get_terminal_size_linux():
             fd = os.open(os.ctermid(), os.O_RDONLY)
             cr = ioctl_GWINSZ(fd)
             os.close(fd)
-        except:
+        except OSError:
             pass
     if not cr or cr == (0, 0):
         try:
             from os import environ as env
             cr = (env['LINES'], env['COLUMNS'])
-        except:
+        except ValueError:
             return None
     return int(cr[1]), int(cr[0])
 

--- a/pandas/io/formats/terminal.py
+++ b/pandas/io/formats/terminal.py
@@ -135,7 +135,7 @@ def _get_terminal_size_linux():
         try:
             from os import environ as env
             cr = (env['LINES'], env['COLUMNS'])
-        except ValueError:
+        except (ValueError, KeyError):
             return None
     return int(cr[1]), int(cr[0])
 

--- a/pandas/io/formats/terminal.py
+++ b/pandas/io/formats/terminal.py
@@ -120,7 +120,7 @@ def _get_terminal_size_linux():
             import struct
             cr = struct.unpack(
                 'hh', fcntl.ioctl(fd, termios.TIOCGWINSZ, '1234'))
-        except struct.error:
+        except (struct.error, IOError):
             return None
         return cr
     cr = ioctl_GWINSZ(0) or ioctl_GWINSZ(1) or ioctl_GWINSZ(2)

--- a/pandas/io/packers.py
+++ b/pandas/io/packers.py
@@ -194,7 +194,7 @@ def read_msgpack(path_or_buf, encoding='utf-8', iterator=False, **kwargs):
         if should_close:
             try:
                 path_or_buf.close()
-            except IOError:  # noqa: flake8
+            except IOError:
                 pass
         return l
 

--- a/pandas/io/packers.py
+++ b/pandas/io/packers.py
@@ -194,7 +194,7 @@ def read_msgpack(path_or_buf, encoding='utf-8', iterator=False, **kwargs):
         if should_close:
             try:
                 path_or_buf.close()
-            except:  # noqa: flake8
+            except IOError:  # noqa: flake8
                 pass
         return l
 

--- a/pandas/io/packers.py
+++ b/pandas/io/packers.py
@@ -703,7 +703,7 @@ def decode(obj):
             dtype = dtype_for(obj[u'dtype'])
             try:
                 return dtype(obj[u'data'])
-            except:
+            except (ValueError, TypeError):
                 return dtype.type(obj[u'data'])
     elif typ == u'np_complex':
         return complex(obj[u'real'] + u'+' + obj[u'imag'] + u'j')

--- a/pandas/io/parsers.py
+++ b/pandas/io/parsers.py
@@ -459,7 +459,7 @@ def _read(filepath_or_buffer, kwds):
     if should_close:
         try:
             filepath_or_buffer.close()
-        except ValueError:  # noqa: flake8
+        except ValueError:
             pass
 
     return data

--- a/pandas/io/parsers.py
+++ b/pandas/io/parsers.py
@@ -459,7 +459,7 @@ def _read(filepath_or_buffer, kwds):
     if should_close:
         try:
             filepath_or_buffer.close()
-        except:  # noqa: flake8
+        except ValueError:  # noqa: flake8
             pass
 
     return data
@@ -1808,7 +1808,7 @@ class CParserWrapper(ParserBase):
         # close additional handles opened by C parser (for compression)
         try:
             self._reader.close()
-        except:
+        except ValueError:
             pass
 
     def _set_noconvert_columns(self):
@@ -3034,7 +3034,7 @@ def _make_date_converter(date_parser=None, dayfirst=False,
                     errors='ignore',
                     infer_datetime_format=infer_datetime_format
                 )
-            except:
+            except ValueError:
                 return tools.to_datetime(
                     parsing.try_parse_dates(strs, dayfirst=dayfirst))
         else:
@@ -3263,7 +3263,7 @@ def _floatify_na_values(na_values):
             v = float(v)
             if not np.isnan(v):
                 result.add(v)
-        except:
+        except (TypeError, ValueError, OverflowError):
             pass
     return result
 
@@ -3284,11 +3284,11 @@ def _stringify_na_values(na_values):
                 result.append(str(v))
 
             result.append(v)
-        except:
+        except (TypeError, ValueError, OverflowError):
             pass
         try:
             result.append(int(x))
-        except:
+        except (TypeError, ValueError, OverflowError):
             pass
     return set(result)
 

--- a/pandas/io/pickle.py
+++ b/pandas/io/pickle.py
@@ -169,7 +169,7 @@ def read_pickle(path, compression='infer'):
                 lambda f: pc.load(f, encoding=encoding, compat=False))
     try:
         return try_read(path)
-    except (AssertionError, ModuleNotFoundError, UnicodeDecodeError):
+    except Exception:
         if PY3:
             return try_read(path, encoding='latin1')
         raise

--- a/pandas/io/pickle.py
+++ b/pandas/io/pickle.py
@@ -165,16 +165,11 @@ def read_pickle(path, compression='infer'):
                 return read_wrapper(lambda f: pkl.load(f))
         except Exception:
             # reg/patched pickle
-            try:
-                return read_wrapper(
-                    lambda f: pc.load(f, encoding=encoding, compat=False))
-            # compat pickle
-            except:
-                return read_wrapper(
-                    lambda f: pc.load(f, encoding=encoding, compat=True))
+            return read_wrapper(
+                lambda f: pc.load(f, encoding=encoding, compat=False))
     try:
         return try_read(path)
-    except:
+    except (AssertionError, ModuleNotFoundError, UnicodeDecodeError):
         if PY3:
             return try_read(path, encoding='latin1')
         raise

--- a/pandas/io/sas/sas_xport.py
+++ b/pandas/io/sas/sas_xport.py
@@ -246,7 +246,7 @@ class XportReader(BaseIterator):
             contents = filepath_or_buffer.read()
             try:
                 contents = contents.encode(self._encoding)
-            except:
+            except UnicodeEncodeError:
                 pass
             self.filepath_or_buffer = compat.BytesIO(contents)
 

--- a/pandas/io/sas/sasreader.py
+++ b/pandas/io/sas/sasreader.py
@@ -46,7 +46,7 @@ def read_sas(filepath_or_buffer, format=None, index=None, encoding=None,
                 format = "sas7bdat"
             else:
                 raise ValueError("unable to infer format of SAS file")
-        except:
+        except ValueError:
             pass
 
     if format.lower() == 'xport':

--- a/pandas/io/sql.py
+++ b/pandas/io/sql.py
@@ -382,7 +382,7 @@ def read_sql(sql, con, index_col=None, coerce_float=True, params=None,
 
     try:
         _is_table_name = pandas_sql.has_table(sql)
-    except:
+    except (ImportError, AttributeError):
         _is_table_name = False
 
     if _is_table_name:
@@ -847,7 +847,7 @@ class SQLTable(PandasObject):
             try:
                 tz = col.tzinfo  # noqa
                 return DateTime(timezone=True)
-            except:
+            except AttributeError:
                 return DateTime
         if col_type == 'timedelta64':
             warnings.warn("the 'timedelta' type is not supported, and will be "
@@ -1360,7 +1360,7 @@ class SQLiteDatabase(PandasSQL):
         try:
             yield cur
             self.con.commit()
-        except:
+        except InvalidRequestError:
             self.con.rollback()
             raise
         finally:

--- a/pandas/io/sql.py
+++ b/pandas/io/sql.py
@@ -1360,7 +1360,7 @@ class SQLiteDatabase(PandasSQL):
         try:
             yield cur
             self.con.commit()
-        except InvalidRequestError:
+        except Exception:
             self.con.rollback()
             raise
         finally:

--- a/pandas/io/stata.py
+++ b/pandas/io/stata.py
@@ -1252,12 +1252,12 @@ class StataReader(StataParser, BaseIterator):
 
         try:
             self.typlist = [self.TYPE_MAP[typ] for typ in typlist]
-        except:
+        except ValueError:
             raise ValueError("cannot convert stata types [{0}]"
                              .format(','.join(str(x) for x in typlist)))
         try:
             self.dtyplist = [self.DTYPE_MAP[typ] for typ in typlist]
-        except:
+        except ValueError:
             raise ValueError("cannot convert stata dtypes [{0}]"
                              .format(','.join(str(x) for x in typlist)))
 


### PR DESCRIPTION
- [X] closes #22875
- [X] tests added / passed
- [X] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

I removed the except block in pandas/io/pickle.py:172:13 because the only difference between the try block and the except block was one parameter in the call to pc.load, and the parameter that was changing didn't look like it was being used by pc.load.

Original block:
```
try:
    return read_wrapper(
        lambda f: pc.load(f, encoding=encoding, compat=False))
# compat pickle
except:
    return read_wrapper(
        lambda f: pc.load(f, encoding=encoding, compat=True))
```

The function it was calling (in pandas/compat/pickle_compat.py):
```
def load(fh, encoding=None, compat=False, is_verbose=False):
    """load a pickle, with a provided encoding

    if compat is True:
       fake the old class hierarchy
       if it works, then return the new type objects

    Parameters
    ----------
    fh: a filelike object
    encoding: an optional encoding
    compat: provide Series compatibility mode, boolean, default False
    is_verbose: show exception output
    """

    try:
        fh.seek(0)
        if encoding is not None:
            up = Unpickler(fh, encoding=encoding)
        else:
            up = Unpickler(fh)
        up.is_verbose = is_verbose

        return up.load()
    except:
        raise
```