### PR TITLE
DOC GH22893 Fix docstring of groupby in pandas/core/generic.py

### DIFF
--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -7128,47 +7128,48 @@ class NDFrame(PandasObject, SelectionMixin):
 
         Examples
         --------
-        >>> df = pd.DataFrame({'Student' : ['Bob', 'Bob', 'Mary', 'Mary'],
-        ...                    'Grade' : [100, 92, 82, 85]})
+        >>> df = pd.DataFrame({'Animal' : ['Falcon', 'Falcon',
+        ...                                'Parrot', 'Parrot'],
+        ...                    'Max Speed' : [380., 370., 24., 26.]})
         >>> df
-          Student  Grade
-        0     Bob    100
-        1     Bob     92
-        2    Mary     82
-        3    Mary     85
-        >>> df.groupby(['Student']).mean()
-                 Grade
-        Student
-        Bob       96.0
-        Mary      83.5
+           Animal  Max Speed
+        0  Falcon      380.0
+        1  Falcon      370.0
+        2  Parrot       24.0
+        3  Parrot       26.0
+        >>> df.groupby(['Animal']).mean()
+                Max Speed
+        Animal
+        Falcon      375.0
+        Parrot       25.0
 
         **Hierarchical Indexes**
 
         We can groupby different levels of a hierarchical index
         using the `level` parameter:
 
-        >>> arrays = [['TX', 'TX', 'NY', 'NY'],
-        ...           ['Urban', 'Rural', 'Urban', 'Rural']]
-        >>> index = pd.MultiIndex.from_arrays(arrays, names=('State', 'Type'))
-        >>> df = pd.DataFrame({'Pop %' : [84.7, 15.3, 87.9, 12.1]},
+        >>> arrays = [['Falcon', 'Falcon', 'Parrot', 'Parrot'],
+        ...           ['Capitve', 'Wild', 'Capitve', 'Wild']]
+        >>> index = pd.MultiIndex.from_arrays(arrays, names=('Animal', 'Type'))
+        >>> df = pd.DataFrame({'Max Speed' : [390., 350., 30., 20.]},
         ...                    index=index)
         >>> df
-                     Pop %
-        State Type
-        TX    Urban   84.7
-              Rural   15.3
-        NY    Urban   87.9
-              Rural   12.1
-        >>> df.groupby(level=0).sum()
-               Pop %
-        State
-        NY      100.0
-        TX      100.0
+                        Max Speed
+        Animal Type
+        Falcon Capitve      390.0
+               Wild         350.0
+        Parrot Capitve       30.0
+               Wild          20.0
+        >>> df.groupby(level=0).mean()
+                Max Speed
+        Animal
+        Falcon      370.0
+        Parrot       25.0
         >>> df.groupby(level=1).mean()
-               Pop %
+                 Max Speed
         Type
-        Rural   13.7
-        Urban   86.3
+        Capitve      210.0
+        Wild         185.0
         """
         from pandas.core.groupby.groupby import groupby
 

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -7065,7 +7065,7 @@ class NDFrame(PandasObject, SelectionMixin):
         """
         Group series using a mapper or by a series of columns.
 
-        Any groupby operation involves some combination of splitting the
+        A groupby operation involves some combination of splitting the
         object, applying a function, and combining the results. This can be
         used to group large amounts of data and compute operations on these
         groups.
@@ -7081,25 +7081,25 @@ class NDFrame(PandasObject, SelectionMixin):
             values are used as-is determine the groups. A label or list of
             labels may be passed to group by the columns in ``self``. Notice
             that a tuple is interpreted a (single) key.
-        axis : {0 or 'index', 1 or 'columns', None}
+        axis : {0 or 'index', 1 or 'columns'}
             Split along rows (0) or columns (1).
         level : int, level name, or sequence of such, default None
             If the axis is a MultiIndex (hierarchical), group by a particular
             level or levels.
-        as_index : boolean, default True
+        as_index : bool, default True
             For aggregated output, return object with group labels as the
             index. Only relevant for DataFrame input. as_index=False is
             effectively "SQL-style" grouped output.
-        sort : boolean, default True
+        sort : bool, default True
             Sort group keys. Get better performance by turning this off.
             Note this does not influence the order of observations within each
             group. Groupby preserves the order of rows within each group.
-        group_keys : boolean, default True
+        group_keys : bool, default True
             When calling apply, add group keys to index to identify pieces.
-        squeeze : boolean, default False
+        squeeze : bool, default False
             Reduce the dimensionality of the return type if possible,
             otherwise return a consistent type.
-        observed : boolean, default False
+        observed : bool, default False
             This only applies if any of the groupers are Categoricals.
             If True: only show observed values for categorical groupers.
             If False: show all values for categorical groupers.
@@ -7107,12 +7107,18 @@ class NDFrame(PandasObject, SelectionMixin):
             .. versionadded:: 0.23.0
 
         **kwargs
-            Optional, only accepts keyword argument 'mutated'
-            and is passed to groupby.
+            Optional, only accepts keyword argument 'mutated' and is passed
+            to groupby.
 
         Returns
         -------
-        GroupBy object
+        DataFrameGroupBy object
+            An object that contains information about the groups.
+
+        See Also
+        --------
+        resample : Convenience method for frequency conversion and resampling
+            of time series.
 
         Examples
         --------
@@ -7130,7 +7136,7 @@ class NDFrame(PandasObject, SelectionMixin):
         A      1.5
         B      3.5
 
-        **Hierarchical indexes**
+        **Hierarchical Indexes**
 
         We can groupby different levels of a hierarchical index
         using the `level` parameter:
@@ -7157,11 +7163,6 @@ class NDFrame(PandasObject, SelectionMixin):
         -----
         See the `user guide
         <http://pandas.pydata.org/pandas-docs/stable/groupby.html>`_ for more.
-
-        See also
-        --------
-        resample : Convenience method for frequency conversion and resampling
-            of time series.
         """
         from pandas.core.groupby.groupby import groupby
 

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -7066,7 +7066,7 @@ class NDFrame(PandasObject, SelectionMixin):
         Group series using a mapper or by a series of columns.
 
         The mapper is a dict or key function that applies the given function
-        to group and return result as series.
+        on the selected axis and returns the result as a series.
 
         Parameters
         ----------
@@ -7080,7 +7080,7 @@ class NDFrame(PandasObject, SelectionMixin):
             labels may be passed to group by the columns in ``self``. Notice
             that a tuple is interpreted a (single) key.
         axis : int, default 0
-            If 0, split by rows. If 1, split by columns.
+            If 0, group by rows. If 1, group by columns.
         level : int, level name, or sequence of such, default None
             If the axis is a MultiIndex (hierarchical), group by a particular
             level or levels.

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -7063,7 +7063,7 @@ class NDFrame(PandasObject, SelectionMixin):
     def groupby(self, by=None, axis=0, level=None, as_index=True, sort=True,
                 group_keys=True, squeeze=False, observed=False, **kwargs):
         """
-        Group series using a mapper or by a series of columns.
+        Group dataframe or series using a mapper or by a series of columns.
 
         A groupby operation involves some combination of splitting the
         object, applying a function, and combining the results. This can be
@@ -7081,7 +7081,7 @@ class NDFrame(PandasObject, SelectionMixin):
             values are used as-is determine the groups. A label or list of
             labels may be passed to group by the columns in ``self``. Notice
             that a tuple is interpreted a (single) key.
-        axis : {0 or 'index', 1 or 'columns'}
+        axis : {0 or 'index', 1 or 'columns'}, default 0
             Split along rows (0) or columns (1).
         level : int, level name, or sequence of such, default None
             If the axis is a MultiIndex (hierarchical), group by a particular
@@ -7112,57 +7112,63 @@ class NDFrame(PandasObject, SelectionMixin):
 
         Returns
         -------
-        DataFrameGroupBy object
-            An object that contains information about the groups.
+        DataFrameGroupBy or SeriesGroupBy
+            Depends on the calling object and returns groupby object that 
+            contains information about the groups.
 
         See Also
         --------
         resample : Convenience method for frequency conversion and resampling
             of time series.
 
+        Notes
+        -----
+        See the `user guide
+        <http://pandas.pydata.org/pandas-docs/stable/groupby.html>`_ for more.
+
         Examples
         --------
-        >>> df = pd.DataFrame({'col1' : ['A', 'A', 'B', 'B'],
-        ...                    'col2' : [1, 2, 3, 4]})
+        >>> df = pd.DataFrame({'Student' : ['Bob', 'Bob', 'Mary', 'Mary'],
+        ...                    'Grade' : [100, 92, 82, 85]})
         >>> df
-          col1  col2
-        0    A     1
-        1    A     2
-        2    B     3
-        3    B     4
-        >>> df.groupby(['col1']).mean()
-              col2
-        col1
-        A      1.5
-        B      3.5
+          Student  Grade
+        0     Bob    100
+        1     Bob     92
+        2    Mary     82
+        3    Mary     85
+        >>> df.groupby(['Student']).mean()
+                 Grade
+        Student       
+        Bob       96.0
+        Mary      83.5
 
         **Hierarchical Indexes**
 
         We can groupby different levels of a hierarchical index
         using the `level` parameter:
 
-        >>> arrays = [np.array(['A', 'A', 'B', 'B']),
-        ...           np.array(['foo', 'bar', 'foo', 'bar'])]
-        >>> df = pd.DataFrame(np.array([1, 2, 3, 4]), index=arrays)
+        >>> arrays = [['TX', 'TX', 'NY', 'NY'],
+        ...           ['Urban', 'Rural', 'Urban', 'Rural']]
+        >>> index = pd.MultiIndex.from_arrays(arrays, names=('State', 'Type'))
+        >>> df = pd.DataFrame({'Pop %' : [84.7, 15.3, 87.9, 12.1]},
+        ...                    index=index)
         >>> df
-               0
-        A foo  1
-          bar  2
-        B foo  3
-          bar  4
-        >>> df.groupby(level=0).mean()
-             0
-        A  1.5
-        B  3.5
+                     Pop %
+        State Type        
+        TX    Urban   84.7
+              Rural   15.3
+        NY    Urban   87.9
+              Rural   12.1
+        >>> df.groupby(level=0).sum()
+               Pop %
+        State       
+        NY      100.0
+        TX      100.0
         >>> df.groupby(level=1).mean()
-             0
-        bar  3
-        foo  2
-
-        Notes
-        -----
-        See the `user guide
-        <http://pandas.pydata.org/pandas-docs/stable/groupby.html>`_ for more.
+               Pop %
+        Type        
+        Rural   13.7
+        Urban   86.3
         """
         from pandas.core.groupby.groupby import groupby
 

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -7091,18 +7091,19 @@ class NDFrame(PandasObject, SelectionMixin):
         sort : boolean, default True
             Sort group keys. Get better performance by turning this off.
             Note this does not influence the order of observations within each
-            group.  groupby preserves the order of rows within each group.
+            group. Groupby preserves the order of rows within each group.
         group_keys : boolean, default True
             When calling apply, add group keys to index to identify pieces.
         squeeze : boolean, default False
             Reduce the dimensionality of the return type if possible,
             otherwise return a consistent type.
         observed : boolean, default False
-            This only applies if any of the groupers are Categoricals
+            This only applies if any of the groupers are Categoricals.
             If True: only show observed values for categorical groupers.
             If False: show all values for categorical groupers.
         **kwargs
-            Only accepts argument 'mutated'.
+            Optional, only accepts keyword argument 'mutated'
+            and is passed to groupby.
 
             .. versionadded:: 0.23.0
 

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -7113,7 +7113,7 @@ class NDFrame(PandasObject, SelectionMixin):
         Returns
         -------
         DataFrameGroupBy or SeriesGroupBy
-            Depends on the calling object and returns groupby object that 
+            Depends on the calling object and returns groupby object that
             contains information about the groups.
 
         See Also
@@ -7138,7 +7138,7 @@ class NDFrame(PandasObject, SelectionMixin):
         3    Mary     85
         >>> df.groupby(['Student']).mean()
                  Grade
-        Student       
+        Student
         Bob       96.0
         Mary      83.5
 
@@ -7154,19 +7154,19 @@ class NDFrame(PandasObject, SelectionMixin):
         ...                    index=index)
         >>> df
                      Pop %
-        State Type        
+        State Type
         TX    Urban   84.7
               Rural   15.3
         NY    Urban   87.9
               Rural   12.1
         >>> df.groupby(level=0).sum()
                Pop %
-        State       
+        State
         NY      100.0
         TX      100.0
         >>> df.groupby(level=1).mean()
                Pop %
-        Type        
+        Type
         Rural   13.7
         Urban   86.3
         """

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -7063,8 +7063,10 @@ class NDFrame(PandasObject, SelectionMixin):
     def groupby(self, by=None, axis=0, level=None, as_index=True, sort=True,
                 group_keys=True, squeeze=False, observed=False, **kwargs):
         """
-        Group series using mapper (dict or key function, apply given function
-        to group, return result as series) or by a series of columns.
+        Group series using a mapper or by a series of columns.
+
+        The mapper is a dict or key function that applies the given function
+        to group and return result as series.
 
         Parameters
         ----------
@@ -7078,26 +7080,29 @@ class NDFrame(PandasObject, SelectionMixin):
             labels may be passed to group by the columns in ``self``. Notice
             that a tuple is interpreted a (single) key.
         axis : int, default 0
+            If 0, split by rows. If 1, split by columns.
         level : int, level name, or sequence of such, default None
             If the axis is a MultiIndex (hierarchical), group by a particular
-            level or levels
+            level or levels.
         as_index : boolean, default True
             For aggregated output, return object with group labels as the
             index. Only relevant for DataFrame input. as_index=False is
-            effectively "SQL-style" grouped output
+            effectively "SQL-style" grouped output.
         sort : boolean, default True
             Sort group keys. Get better performance by turning this off.
             Note this does not influence the order of observations within each
             group.  groupby preserves the order of rows within each group.
         group_keys : boolean, default True
-            When calling apply, add group keys to index to identify pieces
+            When calling apply, add group keys to index to identify pieces.
         squeeze : boolean, default False
-            reduce the dimensionality of the return type if possible,
-            otherwise return a consistent type
+            Reduce the dimensionality of the return type if possible,
+            otherwise return a consistent type.
         observed : boolean, default False
             This only applies if any of the groupers are Categoricals
             If True: only show observed values for categorical groupers.
             If False: show all values for categorical groupers.
+        **kwargs
+            Only accepts argument 'mutated'.
 
             .. versionadded:: 0.23.0
 
@@ -7107,14 +7112,42 @@ class NDFrame(PandasObject, SelectionMixin):
 
         Examples
         --------
-        DataFrame results
+        >>> df = pd.DataFrame({'col1' : ['A', 'A', 'B', 'B'],
+        ...                    'col2' : [1, 2, 3, 4]})
+        >>> df
+          col1  col2
+        0    A     1
+        1    A     2
+        2    B     3
+        3    B     4
+        >>> df.groupby(['col1']).mean()
+              col2
+        col1
+        A      1.5
+        B      3.5
 
-        >>> data.groupby(func, axis=0).mean()
-        >>> data.groupby(['col1', 'col2'])['col3'].mean()
+        **Hierarchical indexes**
 
-        DataFrame with hierarchical index
+        We can groupby different levels of a hierarchical index
+        using the `level` parameter:
 
-        >>> data.groupby(['col1', 'col2']).mean()
+        >>> arrays = [np.array(['A', 'A', 'B', 'B']),
+        ...           np.array(['foo', 'bar', 'foo', 'bar'])]
+        >>> df = pd.DataFrame(np.array([1, 2, 3, 4]), index=arrays)
+        >>> df
+               0
+        A foo  1
+          bar  2
+        B foo  3
+          bar  4
+        >>> df.groupby(level=0).mean()
+             0
+        A  1.5
+        B  3.5
+        >>> df.groupby(level=1).mean()
+             0
+        bar  3
+        foo  2
 
         Notes
         -----

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -7065,8 +7065,10 @@ class NDFrame(PandasObject, SelectionMixin):
         """
         Group series using a mapper or by a series of columns.
 
-        The mapper is a dict or key function that applies the given function
-        on the selected axis and returns the result as a series.
+        Any groupby operation involves some combination of splitting the
+        object, applying a function, and combining the results. This can be
+        used to group large amounts of data and compute operations on these
+        groups.
 
         Parameters
         ----------
@@ -7079,8 +7081,8 @@ class NDFrame(PandasObject, SelectionMixin):
             values are used as-is determine the groups. A label or list of
             labels may be passed to group by the columns in ``self``. Notice
             that a tuple is interpreted a (single) key.
-        axis : int, default 0
-            If 0, group by rows. If 1, group by columns.
+        axis : {0 or 'index', 1 or 'columns', None}
+            Split along rows (0) or columns (1).
         level : int, level name, or sequence of such, default None
             If the axis is a MultiIndex (hierarchical), group by a particular
             level or levels.
@@ -7101,11 +7103,12 @@ class NDFrame(PandasObject, SelectionMixin):
             This only applies if any of the groupers are Categoricals.
             If True: only show observed values for categorical groupers.
             If False: show all values for categorical groupers.
+
+            .. versionadded:: 0.23.0
+
         **kwargs
             Optional, only accepts keyword argument 'mutated'
             and is passed to groupby.
-
-            .. versionadded:: 0.23.0
 
         Returns
         -------

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -7063,7 +7063,7 @@ class NDFrame(PandasObject, SelectionMixin):
     def groupby(self, by=None, axis=0, level=None, as_index=True, sort=True,
                 group_keys=True, squeeze=False, observed=False, **kwargs):
         """
-        Group dataframe or series using a mapper or by a series of columns.
+        Group DataFrame or Series using a mapper or by a Series of columns.
 
         A groupby operation involves some combination of splitting the
         object, applying a function, and combining the results. This can be


### PR DESCRIPTION
- [x] closes #22893 
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

Updated docstring following https://pandas.pydata.org/pandas-docs/stable/contributing_docstring.html

I changed the examples into similar ones that I thought better demonstrated the function, but I'm willing to change them again if they aren't up to par.

I also might need some help describing the kwargs. It only accepts 'mutated' as a keyword argument and I can't tell if it does anything. Apologies if the answer is obvious!
