### PR TITLE
Provide default implementation for `data_repated`

### DIFF
--- a/pandas/tests/extension/conftest.py
+++ b/pandas/tests/extension/conftest.py
@@ -31,12 +31,24 @@ def all_data(request, data, data_missing):
 
 
 @pytest.fixture
-def data_repeated():
-    """Return different versions of data for count times"""
+def data_repeated(data):
+    """
+    Generate many datasets.
+
+    Parameters
+    ----------
+    data : fixture implementing `data`
+
+    Returns
+    -------
+    Callable[[int], Generator]:
+        A callable that takes a `count` argument and
+        returns a generator yielding `count` datasets.
+    """
     def gen(count):
         for _ in range(count):
-            yield NotImplementedError
-    yield gen
+            yield data
+    return gen
 
 
 @pytest.fixture

--- a/pandas/tests/extension/decimal/test_decimal.py
+++ b/pandas/tests/extension/decimal/test_decimal.py
@@ -31,14 +31,6 @@ def data_missing():
 
 
 @pytest.fixture
-def data_repeated():
-    def gen(count):
-        for _ in range(count):
-            yield DecimalArray(make_data())
-    yield gen
-
-
-@pytest.fixture
 def data_for_sorting():
     return DecimalArray([decimal.Decimal('1'),
                          decimal.Decimal('2'),

--- a/pandas/tests/extension/test_categorical.py
+++ b/pandas/tests/extension/test_categorical.py
@@ -46,15 +46,6 @@ def data_missing():
 
 
 @pytest.fixture
-def data_repeated():
-    """Return different versions of data for count times"""
-    def gen(count):
-        for _ in range(count):
-            yield Categorical(make_data())
-    yield gen
-
-
-@pytest.fixture
 def data_for_sorting():
     return Categorical(['A', 'B', 'C'], categories=['C', 'A', 'B'],
                        ordered=True)

--- a/pandas/tests/extension/test_integer.py
+++ b/pandas/tests/extension/test_integer.py
@@ -48,14 +48,6 @@ def data_missing(dtype):
 
 
 @pytest.fixture
-def data_repeated(data):
-    def gen(count):
-        for _ in range(count):
-            yield data
-    yield gen
-
-
-@pytest.fixture
 def data_for_sorting(dtype):
     return integer_array([1, 2, 0], dtype=dtype)
 

--- a/pandas/tests/extension/test_interval.py
+++ b/pandas/tests/extension/test_interval.py
@@ -48,15 +48,6 @@ def data_missing():
 
 
 @pytest.fixture
-def data_repeated():
-    """Return different versions of data for count times"""
-    def gen(count):
-        for _ in range(count):
-            yield IntervalArray(make_data())
-    yield gen
-
-
-@pytest.fixture
 def data_for_sorting():
     return IntervalArray.from_tuples([(1, 2), (2, 3), (0, 1)])
 


### PR DESCRIPTION
Split from PeriodArray.

The previous implementation was not great, since failing to override it would result in `Series([NotImplementedError, NotImplementedError...])`. We could raise instead, forcing downstream arrays to implement it, or just repeat `data`. I opted for the latter, which integer_array was already doing. 