### PR TITLE
Warn when column order changed.

### DIFF
--- a/doc/source/api.rst
+++ b/doc/source/api.rst
@@ -2477,6 +2477,7 @@ Exceptions and warnings
 .. autosummary::
    :toctree: generated/
 
+   errors.ColumnOrderWarning
    errors.DtypeWarning
    errors.EmptyDataError
    errors.OutOfBoundsDatetime

--- a/doc/source/dsintro.rst
+++ b/doc/source/dsintro.rst
@@ -97,6 +97,9 @@ Series can be instantiated from dicts:
    If you're using Python < 3.6 or Pandas < 0.23, and an index is not passed,
    the ``Series`` index will be the lexically ordered list of dict keys.
 
+   See :class:`pandas.errors.ColumnOrderWarning` for help with upgrading
+   from pandas 0.22 with code that may rely on the old sorting behavior.
+
 In the example above, if you were on a Python version lower than 3.6 or a
 Pandas version lower than 0.23, the ``Series`` would be ordered by the lexical
 order of the dict keys (i.e. ``['a', 'b', 'c']`` rather than ``['b', 'a', 'c']``).

--- a/pandas/core/common.py
+++ b/pandas/core/common.py
@@ -8,12 +8,14 @@ from datetime import datetime, timedelta
 from functools import partial
 import inspect
 import collections
+import warnings
 
 import numpy as np
 from pandas._libs import lib, tslibs
 
 from pandas import compat
 from pandas.compat import iteritems, PY36, OrderedDict
+from pandas.errors import ColumnOrderWarning
 from pandas.core.dtypes.generic import ABCSeries, ABCIndex, ABCIndexClass
 from pandas.core.dtypes.common import (
     is_integer, is_bool_dtype, is_extension_array_dtype, is_array_like
@@ -225,6 +227,12 @@ def dict_keys_to_ordered_list(mapping):
     # can be replaced by a simple list(mapping.keys())
     if PY36 or isinstance(mapping, OrderedDict):
         keys = list(mapping.keys())
+        if not isinstance(mapping, OrderedDict):
+            sorted_keys = try_sort(mapping)
+            if sorted_keys != keys:
+                warnings.warn(ColumnOrderWarning.message,
+                              ColumnOrderWarning,
+                              stacklevel=2)
     else:
         keys = try_sort(mapping)
     return keys

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -12,6 +12,7 @@ from textwrap import dedent
 import numpy as np
 import numpy.ma as ma
 
+from pandas.errors import ColumnOrderWarning
 from pandas.core.accessor import CachedAccessor
 from pandas.core.arrays import ExtensionArray
 from pandas.core.dtypes.common import (
@@ -328,6 +329,16 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
                 s = s.sort_index()
             except TypeError:
                 pass
+        if PY36 and not isinstance(data, OrderedDict) and data:
+            # check if sort order changed.
+            try:
+                if not s.index.is_monotonic_increasing:
+                    warnings.warn(ColumnOrderWarning.message,
+                                  ColumnOrderWarning,
+                                  stacklevel=3)
+            except TypeError:
+                pass
+
         return s._data, s.index
 
     @classmethod

--- a/pandas/errors/__init__.py
+++ b/pandas/errors/__init__.py
@@ -1,6 +1,8 @@
 """
 Expose public exceptions & warnings
 """
+import warnings
+
 from pandas._libs.tslibs import OutOfBoundsDatetime  # noqa: F401
 
 
@@ -181,3 +183,44 @@ class AbstractMethodError(NotImplementedError):
             name = self.class_instance.__class__.__name__
         msg = "This {methodtype} must be defined in the concrete class {name}"
         return (msg.format(methodtype=self.methodtype, name=name))
+
+
+class ColumnOrderWarning(RuntimeWarning):
+    """Potential behavior change from 0.22 to 0.24 due to column ordering.
+
+    Pandas 0.22 respects dictionary order for Python 3.6 in certain places,
+    notably the Series and DataFrame constructors. This can subtly change
+    the behavior of downstream operations that relied on column or index
+    order.
+
+    This warning is ignored by default. To use it, we recommend elevating
+    the warning to be visible or raise when running unit tests.
+
+    .. code-block:: python
+
+       import warnings
+       from pandas.errors import ColumnOrderWarning
+
+       def test_foo():
+           with warnings.filterwarnings("always", ColumnOrderWarning):
+               ...
+
+    Or if using pytest
+
+    .. code-block:: python
+
+       @pytest.mark.filterwarnings("always::ColumnOrderWarning")
+       def test_foo():
+           ...
+    """
+    message = (
+        "Possible ehavior change due to respecting dictionary order. \n\n"
+        "Pandas >=0.22 respects dictionary order for Python >= 3.6. \n"
+        "This may change the behavior of code that relied on dictionary\n "
+        "keys being sorted. \n\n"
+        "See http://pandas.pydata.org/pandas-docs/stable/generated/pandas.errors.ColumnOrderWarning.html "  # noqa
+        "for more."
+    )
+
+
+warnings.simplefilter("ignore", ColumnOrderWarning)

--- a/pandas/errors/__init__.py
+++ b/pandas/errors/__init__.py
@@ -1,10 +1,7 @@
-# flake8: noqa
-
 """
 Expose public exceptions & warnings
 """
-
-from pandas._libs.tslibs import OutOfBoundsDatetime
+from pandas._libs.tslibs import OutOfBoundsDatetime  # noqa: F401
 
 
 class PerformanceWarning(Warning):
@@ -13,12 +10,14 @@ class PerformanceWarning(Warning):
     performance impact.
     """
 
+
 class UnsupportedFunctionCall(ValueError):
     """
     Exception raised when attempting to call a numpy function
     on a pandas object, but that function is not supported by
     the object e.g. ``np.cumsum(groupby_object)``.
     """
+
 
 class UnsortedIndexError(KeyError):
     """

--- a/pandas/util/testing.py
+++ b/pandas/util/testing.py
@@ -2561,6 +2561,8 @@ def assert_produces_warning(expected_warning=Warning, filter_level="always",
         * "module" - print the warning the first time it is generated
           from each module
         * "once" - print the warning the first time it is generated
+        * None - do not modify the warning filter registry. Useful when
+          testing that a warning is hidden by default.
 
     clear : str, default None
         If not ``None`` then remove any previously raised warnings from
@@ -2608,7 +2610,8 @@ def assert_produces_warning(expected_warning=Warning, filter_level="always",
                     pass
 
         saw_warning = False
-        warnings.simplefilter(filter_level)
+        if filter_level:
+            warnings.simplefilter(filter_level)
         yield w
         extra_warnings = []
 


### PR DESCRIPTION
Warn when column order has changed from 0.22

```python
In [1]: import pandas as pd; import warnings

In [2]: df = pd.DataFrame({"b": [1, 2], "a": [3, 4]})

In [3]: warnings.filters.pop(0)
Out[3]: ('ignore', None, pandas.errors.ColumnOrderWarning, None, 0)

In [4]: df = pd.DataFrame({"b": [1, 2], "a": [3, 4]})
/Users/taugspurger/sandbox/pandas/pandas/core/frame.py:494: ColumnOrderWarning: Possible behavior change due to respecting dictionary order.

Pandas >=0.22 respects dictionary order for Python >= 3.6.
This may change the behavior of code that relied on dictionary
 keys being sorted.

See http://pandas.pydata.org/pandas-docs/stable/generated/pandas.errors.ColumnOrderWarning.html for more.
  keys = com.dict_keys_to_ordered_list(data)
```

Closes https://github.com/pandas-dev/pandas/issues/22709

---

cc @topper-123 @jorisvandenbossche.

Long-term, what's the plan here? I assume at some point we'll want to remove the checks for whether the keys differ. Do we need a deprecation warning for the warning? :)

I've covered the Series and DataFrame constructors. Are there other places I should be looking?