### PR TITLE
STYLE: #22885, Moved all setup imports to bottom of benchmark files and added noqa: F401 to each

### DIFF
--- a/asv_bench/benchmarks/algorithms.py
+++ b/asv_bench/benchmarks/algorithms.py
@@ -12,8 +12,6 @@ for imp in ['pandas.util', 'pandas.tools.hashing']:
     except (ImportError, TypeError, ValueError):
         pass
 
-from .pandas_vb_common import setup # noqa
-
 
 class Factorize(object):
 
@@ -126,3 +124,6 @@ class Hashing(object):
 
     def time_series_dates(self, df):
         hashing.hash_pandas_object(df['dates'])
+
+
+from .pandas_vb_common import setup  # noqa: F401

--- a/asv_bench/benchmarks/attrs_caching.py
+++ b/asv_bench/benchmarks/attrs_caching.py
@@ -5,8 +5,6 @@ try:
 except ImportError:
     from pandas.util.decorators import cache_readonly
 
-from .pandas_vb_common import setup  # noqa
-
 
 class DataFrameAttributes(object):
 
@@ -38,3 +36,6 @@ class CacheReadonly(object):
 
     def time_cache_readonly(self):
         self.obj.prop
+
+
+from .pandas_vb_common import setup  # noqa: F401

--- a/asv_bench/benchmarks/binary_ops.py
+++ b/asv_bench/benchmarks/binary_ops.py
@@ -6,8 +6,6 @@ try:
 except ImportError:
     import pandas.computation.expressions as expr
 
-from .pandas_vb_common import setup # noqa
-
 
 class Ops(object):
 
@@ -149,3 +147,6 @@ class AddOverflowArray(object):
     def time_add_overflow_both_arg_nan(self):
         checked_add_with_arr(self.arr, self.arr_mixed, arr_mask=self.arr_nan_1,
                              b_mask=self.arr_nan_2)
+
+
+from .pandas_vb_common import setup  # noqa: F401

--- a/asv_bench/benchmarks/categoricals.py
+++ b/asv_bench/benchmarks/categoricals.py
@@ -11,8 +11,6 @@ except ImportError:
     except ImportError:
         pass
 
-from .pandas_vb_common import setup # noqa
-
 
 class Concat(object):
 
@@ -245,3 +243,6 @@ class CategoricalSlicing(object):
 
     def time_getitem_bool_array(self, index):
         self.data[self.data == self.cat_scalar]
+
+
+from .pandas_vb_common import setup  # noqa: F401

--- a/asv_bench/benchmarks/ctors.py
+++ b/asv_bench/benchmarks/ctors.py
@@ -2,8 +2,6 @@ import numpy as np
 import pandas.util.testing as tm
 from pandas import Series, Index, DatetimeIndex, Timestamp, MultiIndex
 
-from .pandas_vb_common import setup  # noqa
-
 
 class SeriesConstructors(object):
 
@@ -64,3 +62,6 @@ class MultiIndexConstructor(object):
 
     def time_multiindex_from_iterables(self):
         MultiIndex.from_product(self.iterables)
+
+
+from .pandas_vb_common import setup  # noqa: F401

--- a/asv_bench/benchmarks/eval.py
+++ b/asv_bench/benchmarks/eval.py
@@ -5,8 +5,6 @@ try:
 except ImportError:
     import pandas.computation.expressions as expr
 
-from .pandas_vb_common import setup # noqa
-
 
 class Eval(object):
 
@@ -65,3 +63,6 @@ class Query(object):
 
     def time_query_with_boolean_selection(self):
         self.df.query('(a >= @self.min_val) & (a <= @self.max_val)')
+
+
+from .pandas_vb_common import setup  # noqa: F401

--- a/asv_bench/benchmarks/frame_ctor.py
+++ b/asv_bench/benchmarks/frame_ctor.py
@@ -7,8 +7,6 @@ except ImportError:
     # For compatibility with older versions
     from pandas.core.datetools import * # noqa
 
-from .pandas_vb_common import setup # noqa
-
 
 class FromDicts(object):
 
@@ -99,3 +97,6 @@ class FromNDArray(object):
 
     def time_frame_from_ndarray(self):
         self.df = DataFrame(self.data)
+
+
+from .pandas_vb_common import setup  # noqa: F401

--- a/asv_bench/benchmarks/frame_methods.py
+++ b/asv_bench/benchmarks/frame_methods.py
@@ -6,8 +6,6 @@ import pandas.util.testing as tm
 from pandas import (DataFrame, Series, MultiIndex, date_range, period_range,
                     isnull, NaT)
 
-from .pandas_vb_common import setup  # noqa
-
 
 class GetNumericData(object):
 
@@ -537,3 +535,6 @@ class Describe(object):
 
     def time_dataframe_describe(self):
         self.df.describe()
+
+
+from .pandas_vb_common import setup  # noqa: F401

--- a/asv_bench/benchmarks/gil.py
+++ b/asv_bench/benchmarks/gil.py
@@ -23,7 +23,7 @@ except ImportError:
             return fname
         return wrapper
 
-from .pandas_vb_common import BaseIO, setup  # noqa
+from .pandas_vb_common import BaseIO
 
 
 class ParallelGroupbyMethods(object):
@@ -273,3 +273,6 @@ class ParallelFactorize(object):
     def time_loop(self, threads):
         for i in range(threads):
             self.loop()
+
+
+from .pandas_vb_common import setup  # noqa: F401

--- a/asv_bench/benchmarks/groupby.py
+++ b/asv_bench/benchmarks/groupby.py
@@ -8,8 +8,6 @@ from pandas import (DataFrame, Series, MultiIndex, date_range, period_range,
                     TimeGrouper, Categorical, Timestamp)
 import pandas.util.testing as tm
 
-from .pandas_vb_common import setup  # noqa
-
 
 method_blacklist = {
     'object': {'median', 'prod', 'sem', 'cumsum', 'sum', 'cummin', 'mean',
@@ -579,3 +577,6 @@ class TransformNaN(object):
 
     def time_first(self):
         self.df_nans.groupby('key').transform('first')
+
+
+from .pandas_vb_common import setup  # noqa: F401

--- a/asv_bench/benchmarks/index_object.py
+++ b/asv_bench/benchmarks/index_object.py
@@ -3,8 +3,6 @@ import pandas.util.testing as tm
 from pandas import (Series, date_range, DatetimeIndex, Index, RangeIndex,
                     Float64Index)
 
-from .pandas_vb_common import setup  # noqa
-
 
 class SetOperations(object):
 
@@ -192,3 +190,6 @@ class Float64IndexMethod(object):
 
     def time_get_loc(self):
         self.ind.get_loc(0)
+
+
+from .pandas_vb_common import setup  # noqa: F401

--- a/asv_bench/benchmarks/indexing.py
+++ b/asv_bench/benchmarks/indexing.py
@@ -2,10 +2,10 @@ import warnings
 
 import numpy as np
 import pandas.util.testing as tm
-from pandas import (Series, DataFrame, MultiIndex, Panel,
-                    Int64Index, Float64Index, IntervalIndex,
-                    CategoricalIndex, IndexSlice, concat, date_range)
-from .pandas_vb_common import setup  # noqa
+from pandas import (Series, DataFrame, MultiIndex, Int64Index, Float64Index,
+                    IntervalIndex, CategoricalIndex,
+                    IndexSlice, concat, date_range)
+from .pandas_vb_common import Panel
 
 
 class NumericSeriesIndexing(object):
@@ -367,3 +367,6 @@ class InsertColumns(object):
         np.random.seed(1234)
         for i in range(100):
             self.df[i] = np.random.randn(self.N)
+
+
+from .pandas_vb_common import setup  # noqa: F401

--- a/asv_bench/benchmarks/inference.py
+++ b/asv_bench/benchmarks/inference.py
@@ -2,7 +2,7 @@ import numpy as np
 import pandas.util.testing as tm
 from pandas import DataFrame, Series, to_numeric
 
-from .pandas_vb_common import numeric_dtypes, lib, setup  # noqa
+from .pandas_vb_common import numeric_dtypes, lib
 
 
 class NumericInferOps(object):
@@ -111,3 +111,6 @@ class MaybeConvertNumeric(object):
 
     def time_convert(self, data):
         lib.maybe_convert_numeric(data, set(), coerce_numeric=False)
+
+
+from .pandas_vb_common import setup  # noqa: F401

--- a/asv_bench/benchmarks/io/csv.py
+++ b/asv_bench/benchmarks/io/csv.py
@@ -6,7 +6,7 @@ import pandas.util.testing as tm
 from pandas import DataFrame, Categorical, date_range, read_csv
 from pandas.compat import cStringIO as StringIO
 
-from ..pandas_vb_common import setup, BaseIO  # noqa
+from ..pandas_vb_common import BaseIO
 
 
 class ToCSV(BaseIO):
@@ -225,3 +225,6 @@ class ReadCSVParseDates(StringIORewind):
         read_csv(self.data(self.StringIO_input), sep=',', header=None,
                  parse_dates=[1],
                  names=list(string.digits[:9]))
+
+
+from ..pandas_vb_common import setup  # noqa: F401

--- a/asv_bench/benchmarks/io/excel.py
+++ b/asv_bench/benchmarks/io/excel.py
@@ -3,7 +3,7 @@ from pandas import DataFrame, date_range, ExcelWriter, read_excel
 from pandas.compat import BytesIO
 import pandas.util.testing as tm
 
-from ..pandas_vb_common import BaseIO, setup  # noqa
+from ..pandas_vb_common import BaseIO
 
 
 class Excel(object):
@@ -34,3 +34,6 @@ class Excel(object):
         writer_write = ExcelWriter(bio_write, engine=engine)
         self.df.to_excel(writer_write, sheet_name='Sheet1')
         writer_write.save()
+
+
+from ..pandas_vb_common import setup  # noqa: F401

--- a/asv_bench/benchmarks/io/hdf.py
+++ b/asv_bench/benchmarks/io/hdf.py
@@ -4,7 +4,7 @@ import numpy as np
 from pandas import DataFrame, Panel, date_range, HDFStore, read_hdf
 import pandas.util.testing as tm
 
-from ..pandas_vb_common import BaseIO, setup  # noqa
+from ..pandas_vb_common import BaseIO
 
 
 class HDFStoreDataFrame(BaseIO):
@@ -149,3 +149,6 @@ class HDF(BaseIO):
 
     def time_write_hdf(self, format):
         self.df.to_hdf(self.fname, 'df', format=format)
+
+
+from ..pandas_vb_common import setup  # noqa: F401

--- a/asv_bench/benchmarks/io/json.py
+++ b/asv_bench/benchmarks/io/json.py
@@ -2,7 +2,7 @@ import numpy as np
 import pandas.util.testing as tm
 from pandas import DataFrame, date_range, timedelta_range, concat, read_json
 
-from ..pandas_vb_common import setup, BaseIO  # noqa
+from ..pandas_vb_common import BaseIO
 
 
 class ReadJSON(BaseIO):
@@ -125,3 +125,6 @@ class ToJSON(BaseIO):
 
     def time_float_int_str_lines(self, orient):
         self.df_int_float_str.to_json(self.fname, orient='records', lines=True)
+
+
+from ..pandas_vb_common import setup  # noqa: F401

--- a/asv_bench/benchmarks/io/msgpack.py
+++ b/asv_bench/benchmarks/io/msgpack.py
@@ -2,7 +2,7 @@ import numpy as np
 from pandas import DataFrame, date_range, read_msgpack
 import pandas.util.testing as tm
 
-from ..pandas_vb_common import BaseIO, setup  # noqa
+from ..pandas_vb_common import BaseIO
 
 
 class MSGPack(BaseIO):
@@ -24,3 +24,6 @@ class MSGPack(BaseIO):
 
     def time_write_msgpack(self):
         self.df.to_msgpack(self.fname)
+
+
+from ..pandas_vb_common import setup  # noqa: F401

--- a/asv_bench/benchmarks/io/pickle.py
+++ b/asv_bench/benchmarks/io/pickle.py
@@ -2,7 +2,7 @@ import numpy as np
 from pandas import DataFrame, date_range, read_pickle
 import pandas.util.testing as tm
 
-from ..pandas_vb_common import BaseIO, setup  # noqa
+from ..pandas_vb_common import BaseIO
 
 
 class Pickle(BaseIO):
@@ -24,3 +24,6 @@ class Pickle(BaseIO):
 
     def time_write_pickle(self):
         self.df.to_pickle(self.fname)
+
+
+from ..pandas_vb_common import setup  # noqa: F401

--- a/asv_bench/benchmarks/io/sql.py
+++ b/asv_bench/benchmarks/io/sql.py
@@ -5,8 +5,6 @@ import pandas.util.testing as tm
 from pandas import DataFrame, date_range, read_sql_query, read_sql_table
 from sqlalchemy import create_engine
 
-from ..pandas_vb_common import setup  # noqa
-
 
 class SQL(object):
 
@@ -130,3 +128,6 @@ class ReadSQLTableDtypes(object):
 
     def time_read_sql_table_column(self, dtype):
         read_sql_table(self.table_name, self.con, columns=[dtype])
+
+
+from ..pandas_vb_common import setup  # noqa: F401

--- a/asv_bench/benchmarks/io/stata.py
+++ b/asv_bench/benchmarks/io/stata.py
@@ -2,7 +2,7 @@ import numpy as np
 from pandas import DataFrame, date_range, read_stata
 import pandas.util.testing as tm
 
-from ..pandas_vb_common import BaseIO, setup  # noqa
+from ..pandas_vb_common import BaseIO
 
 
 class Stata(BaseIO):
@@ -35,3 +35,6 @@ class Stata(BaseIO):
 
     def time_write_stata(self, convert_dates):
         self.df.to_stata(self.fname, self.convert_dates)
+
+
+from ..pandas_vb_common import setup  # noqa: F401

--- a/asv_bench/benchmarks/join_merge.py
+++ b/asv_bench/benchmarks/join_merge.py
@@ -11,7 +11,7 @@ try:
 except ImportError:
     from pandas import ordered_merge as merge_ordered
 
-from .pandas_vb_common import setup  # noqa
+from .pandas_vb_common import Panel
 
 
 class Append(object):
@@ -361,3 +361,6 @@ class Align(object):
 
     def time_series_align_left_monotonic(self):
         self.ts1.align(self.ts2, join='left')
+
+
+from .pandas_vb_common import setup  # noqa: F401

--- a/asv_bench/benchmarks/multiindex_object.py
+++ b/asv_bench/benchmarks/multiindex_object.py
@@ -4,8 +4,6 @@ import numpy as np
 import pandas.util.testing as tm
 from pandas import date_range, MultiIndex
 
-from .pandas_vb_common import setup  # noqa
-
 
 class GetLoc(object):
 
@@ -138,3 +136,6 @@ class Values(object):
 
     def time_datetime_level_values_sliced(self, mi):
         mi[:10].values
+
+
+from .pandas_vb_common import setup  # noqa: F401

--- a/asv_bench/benchmarks/panel_ctor.py
+++ b/asv_bench/benchmarks/panel_ctor.py
@@ -3,7 +3,7 @@ from datetime import datetime, timedelta
 
 from pandas import DataFrame, Panel, DatetimeIndex, date_range
 
-from .pandas_vb_common import setup  # noqa
+from .pandas_vb_common import Panel
 
 
 class DifferentIndexes(object):
@@ -58,3 +58,6 @@ class TwoIndexes(object):
     def time_from_dict(self):
         with warnings.catch_warnings(record=True):
             Panel.from_dict(self.data_frames)
+
+
+from .pandas_vb_common import setup  # noqa: F401

--- a/asv_bench/benchmarks/panel_methods.py
+++ b/asv_bench/benchmarks/panel_methods.py
@@ -3,7 +3,7 @@ import warnings
 import numpy as np
 from pandas import Panel
 
-from .pandas_vb_common import setup  # noqa
+from .pandas_vb_common import Panel
 
 
 class PanelMethods(object):
@@ -23,3 +23,6 @@ class PanelMethods(object):
     def time_shift(self, axis):
         with warnings.catch_warnings(record=True):
             self.panel.shift(1, axis=axis)
+
+
+from .pandas_vb_common import setup  # noqa: F401

--- a/asv_bench/benchmarks/plotting.py
+++ b/asv_bench/benchmarks/plotting.py
@@ -7,8 +7,6 @@ except ImportError:
 import matplotlib
 matplotlib.use('Agg')
 
-from .pandas_vb_common import setup  # noqa
-
 
 class Plotting(object):
 
@@ -62,3 +60,6 @@ class Misc(object):
 
     def time_plot_andrews_curves(self):
         andrews_curves(self.df, "Name")
+
+
+from .pandas_vb_common import setup  # noqa: F401

--- a/asv_bench/benchmarks/reindex.py
+++ b/asv_bench/benchmarks/reindex.py
@@ -2,7 +2,7 @@ import numpy as np
 import pandas.util.testing as tm
 from pandas import (DataFrame, Series, DatetimeIndex, MultiIndex, Index,
                     date_range)
-from .pandas_vb_common import setup, lib  # noqa
+from .pandas_vb_common import lib
 
 
 class Reindex(object):
@@ -170,3 +170,6 @@ class LibFastZip(object):
 
     def time_lib_fast_zip(self):
         lib.fast_zip(self.col_array_list)
+
+
+from .pandas_vb_common import setup  # noqa: F401

--- a/asv_bench/benchmarks/replace.py
+++ b/asv_bench/benchmarks/replace.py
@@ -1,8 +1,6 @@
 import numpy as np
 import pandas as pd
 
-from .pandas_vb_common import setup  # noqa
-
 
 class FillNa(object):
 
@@ -56,3 +54,6 @@ class Convert(object):
 
     def time_replace(self, constructor, replace_data):
         self.data.replace(self.to_replace)
+
+
+from .pandas_vb_common import setup  # noqa: F401

--- a/asv_bench/benchmarks/reshape.py
+++ b/asv_bench/benchmarks/reshape.py
@@ -5,8 +5,6 @@ import numpy as np
 from pandas import DataFrame, MultiIndex, date_range, melt, wide_to_long
 import pandas as pd
 
-from .pandas_vb_common import setup  # noqa
-
 
 class Melt(object):
 
@@ -150,3 +148,6 @@ class GetDummies(object):
 
     def time_get_dummies_1d_sparse(self):
         pd.get_dummies(self.s, sparse=True)
+
+
+from .pandas_vb_common import setup  # noqa: F401

--- a/asv_bench/benchmarks/rolling.py
+++ b/asv_bench/benchmarks/rolling.py
@@ -1,8 +1,6 @@
 import pandas as pd
 import numpy as np
 
-from .pandas_vb_common import setup  # noqa
-
 
 class Methods(object):
 
@@ -77,3 +75,6 @@ class Quantile(object):
     def time_quantile(self, constructor, window, dtype, percentile,
                       interpolation):
         self.roll.quantile(percentile, interpolation=interpolation)
+
+
+from .pandas_vb_common import setup  # noqa: F401

--- a/asv_bench/benchmarks/series_methods.py
+++ b/asv_bench/benchmarks/series_methods.py
@@ -4,8 +4,6 @@ import numpy as np
 import pandas.util.testing as tm
 from pandas import Series, date_range, NaT
 
-from .pandas_vb_common import setup  # noqa
-
 
 class SeriesConstructor(object):
 
@@ -192,3 +190,6 @@ class SeriesGetattr(object):
 
     def time_series_datetimeindex_repr(self):
         getattr(self.s, 'a', None)
+
+
+from .pandas_vb_common import setup  # noqa: F401

--- a/asv_bench/benchmarks/sparse.py
+++ b/asv_bench/benchmarks/sparse.py
@@ -5,8 +5,6 @@ import scipy.sparse
 from pandas import (SparseSeries, SparseDataFrame, SparseArray, Series,
                     date_range, MultiIndex)
 
-from .pandas_vb_common import setup  # noqa
-
 
 def make_array(size, dense_proportion, fill_value, dtype):
     dense_size = int(size * dense_proportion)
@@ -160,3 +158,6 @@ class ArithmeticBlock(object):
 
     def time_division(self, fill_value):
         self.arr1 / self.arr2
+
+
+from .pandas_vb_common import setup  # noqa: F401

--- a/asv_bench/benchmarks/stat_ops.py
+++ b/asv_bench/benchmarks/stat_ops.py
@@ -1,8 +1,6 @@
 import numpy as np
 import pandas as pd
 
-from .pandas_vb_common import setup  # noqa
-
 
 ops = ['mean', 'sum', 'median', 'std', 'skew', 'kurt', 'mad', 'prod', 'sem',
        'var']
@@ -112,3 +110,6 @@ class Correlation(object):
 
     def time_corr(self, method):
         self.df.corr(method=method)
+
+
+from .pandas_vb_common import setup  # noqa: F401

--- a/asv_bench/benchmarks/timeseries.py
+++ b/asv_bench/benchmarks/timeseries.py
@@ -8,8 +8,6 @@ try:
 except ImportError:
     from pandas.tseries.converter import DatetimeConverter
 
-from .pandas_vb_common import setup  # noqa
-
 
 class DatetimeIndex(object):
 
@@ -416,3 +414,6 @@ class DatetimeAccessor(object):
 
     def time_dt_accessor_normalize(self):
         self.series.dt.normalize()
+
+
+from .pandas_vb_common import setup  # noqa: F401


### PR DESCRIPTION
- [x] closes #22885 
- [ ] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

#22885 

Following the suggestions of @datapythonista, I moved all the `setup` imports for the benchmark files to the end of each file and added a `# noqa: F401` like so:

`from .pandas_vb_common import setup  # noqa: F401`

Now, `flake8` only returns the following two errors in `asv_bench`:

```
./benchmarks/strings.py:95:9: E731 do not assign a lambda expression, use a def
./benchmarks/io/excel.py:6:1: F401 '..pandas_vb_common.BaseIO' imported but unused
```

These may be expected, but I wanted to mention them here just in case they need addressing.

Also, running `pytest`, I got this error:

```
usage: pytest [options] [file_or_dir] [file_or_dir] [...]
pytest: error: unrecognized arguments: --strict-data-files
  inifile: /pandas/setup.cfg
  rootdir: /pandas
```

I found a discussion on it at #22700, but there didn't seem to be a definitive solution. Open to guidance on this.

Please let me know if any corrections are needed. Thanks!