### PR TITLE
Use ._tshift internally for datetimelike ops

### DIFF
--- a/pandas/core/arrays/datetimelike.py
+++ b/pandas/core/arrays/datetimelike.py
@@ -455,7 +455,7 @@ class DatetimeLikeArrayMixin(ExtensionOpsMixin, AttributesMixin):
     def _addsub_int_array(self, other, op):
         """
         Add or subtract array-like of integers equivalent to applying
-        `shift` pointwise.
+        `_tshift` pointwise.
 
         Parameters
         ----------
@@ -553,6 +553,23 @@ class DatetimeLikeArrayMixin(ExtensionOpsMixin, AttributesMixin):
         --------
         Index.shift : Shift values of Index.
         """
+        return self._tshift(periods=periods, freq=freq)
+
+    def _tshift(self, periods, freq=None):
+        """
+        Shift each value by `periods`.
+
+        Note this is different from ExtensionArray.shift, which
+        shifts the *position* of each element, padding the end with
+        missing values.
+
+        Parameters
+        ----------
+        periods : int
+            Number of periods to shift by.
+        freq : pandas.DateOffset, pandas.Timedelta, or string
+            Frequency increment to shift by.
+        """
         if freq is not None and freq != self.freq:
             if isinstance(freq, compat.string_types):
                 freq = frequencies.to_offset(freq)
@@ -600,7 +617,7 @@ class DatetimeLikeArrayMixin(ExtensionOpsMixin, AttributesMixin):
             elif lib.is_integer(other):
                 # This check must come after the check for np.timedelta64
                 # as is_integer returns True for these
-                result = self.shift(other)
+                result = self._tshift(other)
 
             # array-like others
             elif is_timedelta64_dtype(other):
@@ -652,7 +669,7 @@ class DatetimeLikeArrayMixin(ExtensionOpsMixin, AttributesMixin):
             elif lib.is_integer(other):
                 # This check must come after the check for np.timedelta64
                 # as is_integer returns True for these
-                result = self.shift(-other)
+                result = self._tshift(-other)
             elif isinstance(other, Period):
                 result = self._sub_period(other)
 

--- a/pandas/core/arrays/datetimelike.py
+++ b/pandas/core/arrays/datetimelike.py
@@ -455,7 +455,7 @@ class DatetimeLikeArrayMixin(ExtensionOpsMixin, AttributesMixin):
     def _addsub_int_array(self, other, op):
         """
         Add or subtract array-like of integers equivalent to applying
-        `_tshift` pointwise.
+        `_time_shift` pointwise.
 
         Parameters
         ----------
@@ -553,9 +553,9 @@ class DatetimeLikeArrayMixin(ExtensionOpsMixin, AttributesMixin):
         --------
         Index.shift : Shift values of Index.
         """
-        return self._tshift(periods=periods, freq=freq)
+        return self._time_shift(periods=periods, freq=freq)
 
-    def _tshift(self, periods, freq=None):
+    def _time_shift(self, periods, freq=None):
         """
         Shift each value by `periods`.
 
@@ -617,7 +617,7 @@ class DatetimeLikeArrayMixin(ExtensionOpsMixin, AttributesMixin):
             elif lib.is_integer(other):
                 # This check must come after the check for np.timedelta64
                 # as is_integer returns True for these
-                result = self._tshift(other)
+                result = self._time_shift(other)
 
             # array-like others
             elif is_timedelta64_dtype(other):
@@ -669,7 +669,7 @@ class DatetimeLikeArrayMixin(ExtensionOpsMixin, AttributesMixin):
             elif lib.is_integer(other):
                 # This check must come after the check for np.timedelta64
                 # as is_integer returns True for these
-                result = self._tshift(-other)
+                result = self._time_shift(-other)
             elif isinstance(other, Period):
                 result = self._sub_period(other)
 

--- a/pandas/core/arrays/period.py
+++ b/pandas/core/arrays/period.py
@@ -297,7 +297,7 @@ class PeriodArrayMixin(DatetimeLikeArrayMixin):
         if base != self.freq.rule_code:
             msg = DIFFERENT_FREQ_INDEX.format(self.freqstr, other.freqstr)
             raise IncompatibleFrequency(msg)
-        return self._tshift(other.n)
+        return self._time_shift(other.n)
 
     def _add_delta_td(self, other):
         assert isinstance(other, (timedelta, np.timedelta64, Tick))
@@ -307,7 +307,7 @@ class PeriodArrayMixin(DatetimeLikeArrayMixin):
         if isinstance(own_offset, Tick):
             offset_nanos = delta_to_nanoseconds(own_offset)
             if np.all(nanos % offset_nanos == 0):
-                return self._tshift(nanos // offset_nanos)
+                return self._time_shift(nanos // offset_nanos)
 
         # raise when input doesn't have freq
         raise IncompatibleFrequency("Input has different freq from "
@@ -317,7 +317,7 @@ class PeriodArrayMixin(DatetimeLikeArrayMixin):
 
     def _add_delta(self, other):
         ordinal_delta = self._maybe_convert_timedelta(other)
-        return self._tshift(ordinal_delta)
+        return self._time_shift(ordinal_delta)
 
     def shift(self, n):
         """
@@ -332,9 +332,9 @@ class PeriodArrayMixin(DatetimeLikeArrayMixin):
         -------
         shifted : Period Array/Index
         """
-        return self._tshift(n)
+        return self._time_shift(n)
 
-    def _tshift(self, n):
+    def _time_shift(self, n):
         values = self._ndarray_values + n * self.freq.n
         if self.hasnans:
             values[self._isnan] = iNaT

--- a/pandas/core/arrays/period.py
+++ b/pandas/core/arrays/period.py
@@ -297,7 +297,7 @@ class PeriodArrayMixin(DatetimeLikeArrayMixin):
         if base != self.freq.rule_code:
             msg = DIFFERENT_FREQ_INDEX.format(self.freqstr, other.freqstr)
             raise IncompatibleFrequency(msg)
-        return self.shift(other.n)
+        return self._tshift(other.n)
 
     def _add_delta_td(self, other):
         assert isinstance(other, (timedelta, np.timedelta64, Tick))
@@ -307,7 +307,7 @@ class PeriodArrayMixin(DatetimeLikeArrayMixin):
         if isinstance(own_offset, Tick):
             offset_nanos = delta_to_nanoseconds(own_offset)
             if np.all(nanos % offset_nanos == 0):
-                return self.shift(nanos // offset_nanos)
+                return self._tshift(nanos // offset_nanos)
 
         # raise when input doesn't have freq
         raise IncompatibleFrequency("Input has different freq from "
@@ -317,7 +317,7 @@ class PeriodArrayMixin(DatetimeLikeArrayMixin):
 
     def _add_delta(self, other):
         ordinal_delta = self._maybe_convert_timedelta(other)
-        return self.shift(ordinal_delta)
+        return self._tshift(ordinal_delta)
 
     def shift(self, n):
         """
@@ -332,6 +332,9 @@ class PeriodArrayMixin(DatetimeLikeArrayMixin):
         -------
         shifted : Period Array/Index
         """
+        return self._tshift(n)
+
+    def _tshift(self, n):
         values = self._ndarray_values + n * self.freq.n
         if self.hasnans:
             values[self._isnan] = iNaT


### PR DESCRIPTION
In preperation for PeriodArray / DatetimeArray / TimedeltaArray.

Index.shift has a different meaning from ExtensionArray.shift.

- Index.shift pointwise shifts each element by some amount
- ExtensionArray.shift shits the *position* of each value in the array
  padding the end with NA

This is going to get confusing. This PR tries to avoid some of that by
internally using a new `_tshift` method (time-shift) when we want to do pointwise
shifting of each value. Places that know they want that behavior (like in the
datetimelike ops) should use that.