### PR TITLE
CLN: small clean-up of IntervalIndex

### DIFF
--- a/pandas/core/arrays/interval.py
+++ b/pandas/core/arrays/interval.py
@@ -108,12 +108,7 @@ class IntervalArray(IntervalMixin, ExtensionArray):
     _na_value = _fill_value = np.nan
 
     def __new__(cls, data, closed=None, dtype=None, copy=False,
-                fastpath=False, verify_integrity=True):
-
-        if fastpath:
-            return cls._simple_new(data.left, data.right, closed,
-                                   copy=copy, dtype=dtype,
-                                   verify_integrity=False)
+                verify_integrity=True):
 
         if isinstance(data, ABCSeries) and is_interval_dtype(data):
             data = data.values


### PR DESCRIPTION
Removed some parts of IntervalIndex that are not needed (because they are inherited from Index or can be dispatched to the array) 
\+ removed `fastpath` (for IntervalArray this is no problem (never used), for IntervalIndex I am not fully sure, since this signature might need to match the other index classes)

cc @jschendel @TomAugspurger 