### PR TITLE
CLN: Use is_period_dtype instead of ABCPeriodIndex checks

### DIFF
--- a/pandas/core/arrays/period.py
+++ b/pandas/core/arrays/period.py
@@ -264,7 +264,7 @@ class PeriodArrayMixin(DatetimeLikeArrayMixin):
         if self.hasnans:
             new_data[self._isnan] = iNaT
 
-        return self._simple_new(new_data, self.name, freq=freq)
+        return self._shallow_copy(new_data, freq=freq)
 
     # ------------------------------------------------------------------
     # Arithmetic Methods

--- a/pandas/core/indexes/datetimelike.py
+++ b/pandas/core/indexes/datetimelike.py
@@ -21,6 +21,7 @@ from pandas.core.dtypes.common import (
     is_list_like,
     is_scalar,
     is_bool_dtype,
+    is_period_dtype,
     is_categorical_dtype,
     is_datetime_or_timedelta_dtype,
     is_float_dtype,
@@ -28,7 +29,7 @@ from pandas.core.dtypes.common import (
     is_object_dtype,
     is_string_dtype)
 from pandas.core.dtypes.generic import (
-    ABCIndex, ABCSeries, ABCPeriodIndex, ABCIndexClass)
+    ABCIndex, ABCSeries, ABCIndexClass)
 from pandas.core.dtypes.missing import isna
 from pandas.core import common as com, algorithms, ops
 
@@ -239,9 +240,8 @@ class DatetimeIndexOpsMixin(DatetimeLikeArrayMixin):
             # have different timezone
             return False
 
-        # ToDo: Remove this when PeriodDtype is added
-        elif isinstance(self, ABCPeriodIndex):
-            if not isinstance(other, ABCPeriodIndex):
+        elif is_period_dtype(self):
+            if not is_period_dtype(other):
                 return False
             if self.freq != other.freq:
                 return False
@@ -359,7 +359,7 @@ class DatetimeIndexOpsMixin(DatetimeLikeArrayMixin):
             attribs = self._get_attributes_dict()
             freq = attribs['freq']
 
-            if freq is not None and not isinstance(self, ABCPeriodIndex):
+            if freq is not None and not is_period_dtype(self):
                 if freq.n > 0 and not ascending:
                     freq = freq * -1
                 elif freq.n < 0 and ascending:
@@ -386,8 +386,8 @@ class DatetimeIndexOpsMixin(DatetimeLikeArrayMixin):
                                            fill_value=fill_value,
                                            na_value=iNaT)
 
-        # keep freq in PeriodIndex, reset otherwise
-        freq = self.freq if isinstance(self, ABCPeriodIndex) else None
+        # keep freq in PeriodArray/Index, reset otherwise
+        freq = self.freq if is_period_dtype(self) else None
         return self._shallow_copy(taken, freq=freq)
 
     _can_hold_na = True
@@ -618,7 +618,7 @@ class DatetimeIndexOpsMixin(DatetimeLikeArrayMixin):
         Analogous to ndarray.repeat
         """
         nv.validate_repeat(args, kwargs)
-        if isinstance(self, ABCPeriodIndex):
+        if is_period_dtype(self):
             freq = self.freq
         else:
             freq = None
@@ -673,7 +673,7 @@ class DatetimeIndexOpsMixin(DatetimeLikeArrayMixin):
         attribs = self._get_attributes_dict()
         attribs['name'] = name
 
-        if not isinstance(self, ABCPeriodIndex):
+        if not is_period_dtype(self):
             # reset freq
             attribs['freq'] = None
 

--- a/pandas/core/indexes/multi.py
+++ b/pandas/core/indexes/multi.py
@@ -1001,7 +1001,7 @@ class MultiIndex(Index):
                     (compat.PY3 and isinstance(key, compat.string_types))):
                 try:
                     return _try_mi(key)
-                except (KeyError):
+                except KeyError:
                     raise
                 except (IndexError, ValueError, TypeError):
                     pass

--- a/pandas/core/indexes/range.py
+++ b/pandas/core/indexes/range.py
@@ -512,33 +512,33 @@ class RangeIndex(Int64Index):
             # This is basically PySlice_GetIndicesEx, but delegation to our
             # super routines if we don't have integers
 
-            l = len(self)
+            length = len(self)
 
             # complete missing slice information
             step = 1 if key.step is None else key.step
             if key.start is None:
-                start = l - 1 if step < 0 else 0
+                start = length - 1 if step < 0 else 0
             else:
                 start = key.start
 
                 if start < 0:
-                    start += l
+                    start += length
                 if start < 0:
                     start = -1 if step < 0 else 0
-                if start >= l:
-                    start = l - 1 if step < 0 else l
+                if start >= length:
+                    start = length - 1 if step < 0 else length
 
             if key.stop is None:
-                stop = -1 if step < 0 else l
+                stop = -1 if step < 0 else length
             else:
                 stop = key.stop
 
                 if stop < 0:
-                    stop += l
+                    stop += length
                 if stop < 0:
                     stop = -1
-                if stop > l:
-                    stop = l
+                if stop > length:
+                    stop = length
 
             # delegate non-integer slices
             if (start != int(start) or


### PR DESCRIPTION
Will be more generally correct for catching both PeriodIndex and PeriodArray.

Unrelated change of `l` -> `length`