### PR TITLE
CI: pin moto to 1.3.4

### DIFF
--- a/ci/travis-27.yaml
+++ b/ci/travis-27.yaml
@@ -44,7 +44,7 @@ dependencies:
   # universal
   - pytest
   - pytest-xdist
-  - moto
+  - moto==1.3.4
   - hypothesis>=3.58.0
   - pip:
     - backports.lzma


### PR DESCRIPTION
xref https://github.com/pandas-dev/pandas/issues/22934

Looking back at the logs, moto 1.3.4 didn't seem to have an issues. Going to run this on the CI a few times to see if we get any failures. May have to make some additional pins of boto if this doesn't work.