### PR TITLE
BUG GH22858 When creating empty dataframe, only cast int to float if index given

### DIFF
--- a/doc/source/whatsnew/v0.24.0.txt
+++ b/doc/source/whatsnew/v0.24.0.txt
@@ -194,9 +194,9 @@ Other Enhancements
 - :meth:`Index.to_frame` now supports overriding column name(s) (:issue:`22580`).
 - New attribute :attr:`__git_version__` will return git commit sha of current build (:issue:`21295`).
 - Compatibility with Matplotlib 3.0 (:issue:`22790`).
-- A newly constructed empty :class:`DataFrame` with integer as the ``dtype`` will now only be cast to ``float64`` if ``index`` is specified (:issue:`22858`)
 
 .. _whatsnew_0240.api_breaking:
+- A newly constructed empty :class:`DataFrame` with integer as the ``dtype`` will now only be cast to ``float64`` if ``index`` is specified (:issue:`22858`)
 
 Backwards incompatible API changes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/source/whatsnew/v0.24.0.txt
+++ b/doc/source/whatsnew/v0.24.0.txt
@@ -196,10 +196,10 @@ Other Enhancements
 - Compatibility with Matplotlib 3.0 (:issue:`22790`).
 
 .. _whatsnew_0240.api_breaking:
-- A newly constructed empty :class:`DataFrame` with integer as the ``dtype`` will now only be cast to ``float64`` if ``index`` is specified (:issue:`22858`)
 
 Backwards incompatible API changes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+- A newly constructed empty :class:`DataFrame` with integer as the ``dtype`` will now only be cast to ``float64`` if ``index`` is specified (:issue:`22858`)
 
 
 .. _whatsnew_0240.api_breaking.interval_values:

--- a/doc/source/whatsnew/v0.24.0.txt
+++ b/doc/source/whatsnew/v0.24.0.txt
@@ -194,7 +194,7 @@ Other Enhancements
 - :meth:`Index.to_frame` now supports overriding column name(s) (:issue:`22580`).
 - New attribute :attr:`__git_version__` will return git commit sha of current build (:issue:`21295`).
 - Compatibility with Matplotlib 3.0 (:issue:`22790`).
-- A newly constructed empty :class:`DataFrame` of integers will now only be cast to ``float64`` if an index is specified (:issue:`22858`)
+- A newly constructed empty :class:`DataFrame` with integer as the ``dtype`` will now only be cast to ``float64`` if ``index`` is specified (:issue:`22858`)
 
 .. _whatsnew_0240.api_breaking:
 

--- a/doc/source/whatsnew/v0.24.0.txt
+++ b/doc/source/whatsnew/v0.24.0.txt
@@ -194,6 +194,7 @@ Other Enhancements
 - :meth:`Index.to_frame` now supports overriding column name(s) (:issue:`22580`).
 - New attribute :attr:`__git_version__` will return git commit sha of current build (:issue:`21295`).
 - Compatibility with Matplotlib 3.0 (:issue:`22790`).
+- A newly constructed empty :class:`DataFrame` of integers will now only be cast to ``float64`` if an index is specified (:issue:`22858`)
 
 .. _whatsnew_0240.api_breaking:
 

--- a/pandas/core/dtypes/cast.py
+++ b/pandas/core/dtypes/cast.py
@@ -1220,6 +1220,8 @@ def construct_1d_arraylike_from_scalar(value, length, dtype):
             dtype = dtype.dtype
 
         # coerce if we have nan for an integer dtype
+        # GH 22858: only cast to float if an index
+        # (passed here as length) is specified
         if is_integer_dtype(dtype) and isna(value) and length:
             dtype = np.float64
         subarr = np.empty(length, dtype=dtype)

--- a/pandas/core/dtypes/cast.py
+++ b/pandas/core/dtypes/cast.py
@@ -1220,7 +1220,7 @@ def construct_1d_arraylike_from_scalar(value, length, dtype):
             dtype = dtype.dtype
 
         # coerce if we have nan for an integer dtype
-        if is_integer_dtype(dtype) and isna(value):
+        if is_integer_dtype(dtype) and isna(value) and length:
             dtype = np.float64
         subarr = np.empty(length, dtype=dtype)
         subarr.fill(value)

--- a/pandas/core/dtypes/cast.py
+++ b/pandas/core/dtypes/cast.py
@@ -1222,7 +1222,7 @@ def construct_1d_arraylike_from_scalar(value, length, dtype):
         # coerce if we have nan for an integer dtype
         # GH 22858: only cast to float if an index
         # (passed here as length) is specified
-        if is_integer_dtype(dtype) and isna(value) and length:
+        if length and is_integer_dtype(dtype) and isna(value):
             dtype = np.float64
         subarr = np.empty(length, dtype=dtype)
         subarr.fill(value)

--- a/pandas/tests/frame/test_constructors.py
+++ b/pandas/tests/frame/test_constructors.py
@@ -802,16 +802,16 @@ class TestDataFrameConstructors(TestData):
         df = DataFrame(index=[])
         assert df.values.shape == (0, 0)
 
-    @pytest.mark.parametrize("data, index, columns, dtype, ans", [
+    @pytest.mark.parametrize("data, index, columns, dtype, expected", [
         (None, lrange(10), ['a', 'b'], object, np.object_),
         (None, None, ['a', 'b'], 'int64', np.dtype('int64')),
         (None, lrange(10), ['a', 'b'], int, np.dtype('float64')),
         ({}, None, ['foo', 'bar'], None, np.object_),
         ({'b': 1}, lrange(10), list('abc'), int, np.dtype('float64'))
     ])
-    def test_constructor_corner_dtype(self, data, index, columns, dtype, ans):
+    def test_constructor_dtype(self, data, index, columns, dtype, expected):
         df = DataFrame(data, index, columns, dtype)
-        assert df.values.dtype == ans
+        assert df.values.dtype == expected
 
     def test_constructor_scalar_inference(self):
         data = {'int': 1, 'bool': True,

--- a/pandas/tests/frame/test_constructors.py
+++ b/pandas/tests/frame/test_constructors.py
@@ -806,7 +806,7 @@ class TestDataFrameConstructors(TestData):
         df = DataFrame(index=lrange(10), columns=['a', 'b'], dtype=object)
         assert df.values.dtype == np.object_
 
-        df = DataFrame(columns=['a', 'b'], dtype=int)
+        df = DataFrame(columns=['a', 'b'], dtype="int64")
         assert df.values.dtype == np.dtype('int64')
 
         # does not error but ends up float

--- a/pandas/tests/frame/test_constructors.py
+++ b/pandas/tests/frame/test_constructors.py
@@ -798,28 +798,20 @@ class TestDataFrameConstructors(TestData):
             result = DataFrame(mrecs, index=[1, 2])
             assert_fr_equal(result, expected)
 
-    def test_constructor_corner(self):
+    def test_constructor_corner_shape(self):
         df = DataFrame(index=[])
         assert df.values.shape == (0, 0)
 
-        # empty but with specified dtype
-        df = DataFrame(index=lrange(10), columns=['a', 'b'], dtype=object)
-        assert df.values.dtype == np.object_
-
-        df = DataFrame(columns=['a', 'b'], dtype="int64")
-        assert df.values.dtype == np.dtype('int64')
-
-        # does not error but ends up float
-        df = DataFrame(index=lrange(10), columns=['a', 'b'], dtype=int)
-        assert df.values.dtype == np.dtype('float64')
-
-        # #1783 empty dtype object
-        df = DataFrame({}, columns=['foo', 'bar'])
-        assert df.values.dtype == np.object_
-
-        df = DataFrame({'b': 1}, index=lrange(10), columns=list('abc'),
-                       dtype=int)
-        assert df.values.dtype == np.dtype('float64')
+    @pytest.mark.parametrize("data, index, columns, dtype, ans", [
+        (None, lrange(10), ['a', 'b'], object, np.object_),
+        (None, None, ['a', 'b'], 'int64', np.dtype('int64')),
+        (None, lrange(10), ['a', 'b'], int, np.dtype('float64')),
+        ({}, None, ['foo', 'bar'], None, np.object_),
+        ({'b': 1}, lrange(10), list('abc'), int, np.dtype('float64'))
+    ])
+    def test_constructor_corner_dtype(self, data, index, columns, dtype, ans):
+        df = DataFrame(data, index, columns, dtype)
+        assert df.values.dtype == ans
 
     def test_constructor_scalar_inference(self):
         data = {'int': 1, 'bool': True,

--- a/pandas/tests/frame/test_constructors.py
+++ b/pandas/tests/frame/test_constructors.py
@@ -806,6 +806,9 @@ class TestDataFrameConstructors(TestData):
         df = DataFrame(index=lrange(10), columns=['a', 'b'], dtype=object)
         assert df.values.dtype == np.object_
 
+        df = DataFrame(columns=['a', 'b'], dtype=int)
+        assert df.values.dtype == np.dtype('int64')
+
         # does not error but ends up float
         df = DataFrame(index=lrange(10), columns=['a', 'b'], dtype=int)
         assert df.values.dtype == np.dtype('float64')


### PR DESCRIPTION
- [X] closes #22858 
- [X] tests added / passed
- [X] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry

Previously, when creating a dataframe with no data of dtype int, the dtype would be changed to float. This is necessary when a predefined number of rows is included as the index parameter, so that they can be filled with nan. However, when no index is passed, this cast is unexpected. This PR changes it so dtype is only altered when necessary.