### PR TITLE
Merge asof float fix

### DIFF
--- a/doc/source/whatsnew/v0.24.0.txt
+++ b/doc/source/whatsnew/v0.24.0.txt
@@ -847,6 +847,7 @@ Reshaping
 - Bug in :meth:`DataFrame.drop_duplicates` for empty ``DataFrame`` which incorrectly raises an error (:issue:`20516`)
 - Bug in :func:`pandas.wide_to_long` when a string is passed to the stubnames argument and a column name is a substring of that stubname (:issue:`22468`)
 - Bug in :func:`merge` when merging ``datetime64[ns, tz]`` data that contained a DST transition (:issue:`18885`)
+- Bug in :func: `merge_asof` when merging on float values within defined tolerance (:issue:`22981`)
 
 Build Changes
 ^^^^^^^^^^^^^

--- a/doc/source/whatsnew/v0.24.0.txt
+++ b/doc/source/whatsnew/v0.24.0.txt
@@ -847,7 +847,7 @@ Reshaping
 - Bug in :meth:`DataFrame.drop_duplicates` for empty ``DataFrame`` which incorrectly raises an error (:issue:`20516`)
 - Bug in :func:`pandas.wide_to_long` when a string is passed to the stubnames argument and a column name is a substring of that stubname (:issue:`22468`)
 - Bug in :func:`merge` when merging ``datetime64[ns, tz]`` data that contained a DST transition (:issue:`18885`)
-- Bug in :func: `merge_asof` when merging on float values within defined tolerance (:issue:`22981`)
+- Bug in :func:`merge_asof` when merging on float values within defined tolerance (:issue:`22981`)
 
 Build Changes
 ^^^^^^^^^^^^^

--- a/pandas/core/reshape/merge.py
+++ b/pandas/core/reshape/merge.py
@@ -23,6 +23,7 @@ from pandas.core.dtypes.common import (
     is_categorical_dtype,
     is_integer_dtype,
     is_float_dtype,
+    is_number,
     is_numeric_dtype,
     is_integer,
     is_int_or_datetime_dtype,
@@ -1356,8 +1357,14 @@ class _AsOfMerge(_OrderedMerge):
                 if self.tolerance < 0:
                     raise MergeError("tolerance must be positive")
 
+            elif is_float_dtype(lt):
+                if not is_number(self.tolerance):
+                    raise MergeError(msg)
+                if self.tolerance < 0:
+                    raise MergeError("tolerance must be positive")
+
             else:
-                raise MergeError("key must be integer or timestamp")
+                raise MergeError("key must be integer, timestamp or float")
 
         # validate allow_exact_matches
         if not is_bool(self.allow_exact_matches):

--- a/pandas/tests/reshape/merge/test_merge_asof.py
+++ b/pandas/tests/reshape/merge/test_merge_asof.py
@@ -642,6 +642,20 @@ class TestAsOfMerge(object):
              'value2': list("BCDEE")})
         assert_frame_equal(result, expected)
 
+    def test_tolerance_float(self):
+        left = pd.DataFrame({'a': [1.1, 3.5, 10.9],
+                             'left_val': ['a', 'b', 'c']})
+        right = pd.DataFrame({'a': [1.0, 2.5, 3.3, 7.5, 11.5],
+                              'right_val': [1.0, 2.5, 3.3, 7.5, 11.5]})
+
+        expected = pd.DataFrame({'a': [1.1, 3.5, 10.9],
+                                 'left_val': ['a', 'b', 'c'],
+                                 'right_val': [1, 3.3, np.nan]})
+
+        result = pd.merge_asof(left, right, on='a', direction='nearest',
+                               tolerance=0.5)
+        assert_frame_equal(result, expected)
+
     def test_index_tolerance(self):
         # GH 15135
         expected = self.tolerance.set_index('time')

--- a/pandas/tests/reshape/merge/test_merge_asof.py
+++ b/pandas/tests/reshape/merge/test_merge_asof.py
@@ -643,6 +643,7 @@ class TestAsOfMerge(object):
         assert_frame_equal(result, expected)
 
     def test_tolerance_float(self):
+        # GH22981
         left = pd.DataFrame({'a': [1.1, 3.5, 10.9],
                              'left_val': ['a', 'b', 'c']})
         right = pd.DataFrame({'a': [1.0, 2.5, 3.3, 7.5, 11.5],


### PR DESCRIPTION
Fix bug with merge_asof when merging on floats and selecting a tolerance

- [ ] closes #22981 
- [ ] tests added / passed
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
