### PR TITLE
CLN: values is required argument in _shallow_copy_with_infer

### DIFF
--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -530,7 +530,7 @@ class Index(IndexOpsMixin, PandasObject):
 
         return self._simple_new(values, **attributes)
 
-    def _shallow_copy_with_infer(self, values=None, **kwargs):
+    def _shallow_copy_with_infer(self, values, **kwargs):
         """
         create a new Index inferring the class with passed value, don't copy
         the data, use the same object attributes with passed in attributes
@@ -543,8 +543,6 @@ class Index(IndexOpsMixin, PandasObject):
         values : the values to create the new Index, optional
         kwargs : updates the default attributes for this Index
         """
-        if values is None:
-            values = self.values
         attributes = self._get_attributes_dict()
         attributes.update(kwargs)
         attributes['copy'] = False

--- a/pandas/core/indexes/multi.py
+++ b/pandas/core/indexes/multi.py
@@ -555,7 +555,7 @@ class MultiIndex(Index):
         result._id = self._id
         return result
 
-    def _shallow_copy_with_infer(self, values=None, **kwargs):
+    def _shallow_copy_with_infer(self, values, **kwargs):
         # On equal MultiIndexes the difference is empty.
         # Therefore, an empty MultiIndex is returned GH13490
         if len(values) == 0:

--- a/pandas/core/indexes/period.py
+++ b/pandas/core/indexes/period.py
@@ -287,7 +287,7 @@ class PeriodIndex(PeriodArrayMixin, DatelikeOps, DatetimeIndexOpsMixin,
         result._reset_identity()
         return result
 
-    def _shallow_copy_with_infer(self, values=None, **kwargs):
+    def _shallow_copy_with_infer(self, values, **kwargs):
         """ we always want to return a PeriodIndex """
         return self._shallow_copy(values=values, **kwargs)
 


### PR DESCRIPTION
@TomAugspurger @jbrockmendel From looking at the code related to the discussion in https://github.com/pandas-dev/pandas/pull/22961, I noticed `_shallow_copy_with_infer` has the potential to not pass any values, which is never actually used in pandas. So a small code clean-up