### PR TITLE
BUG: millis res on parsed DatetimeIndex slice

### DIFF
--- a/pandas/core/indexes/datetimes.py
+++ b/pandas/core/indexes/datetimes.py
@@ -1079,6 +1079,13 @@ class DatetimeIndex(DatetimeArrayMixin, DatelikeOps, TimelikeOps,
             return (Timestamp(st, tz=self.tz),
                     Timestamp(Timestamp(st + offsets.Second(),
                                         tz=self.tz).value - 1))
+        elif reso == 'millisecond':
+            st = datetime(parsed.year, parsed.month, parsed.day,
+                          parsed.hour, parsed.minute, parsed.second,
+                          parsed.microsecond)
+            return (Timestamp(st, tz=self.tz),
+                    Timestamp(Timestamp(st + offsets.Milli(),
+                                        tz=self.tz).value - 1))
         elif reso == 'microsecond':
             st = datetime(parsed.year, parsed.month, parsed.day,
                           parsed.hour, parsed.minute, parsed.second,


### PR DESCRIPTION
Added support for millis resolution on a parsed DatetimeIndex slice.

There was no elif statement for when _parsed_string_to_bounds(self,
reso, parsed) was given reso == 'millisecond'

- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
