### PR TITLE
TST: further clean up of frame/test_analytics

### DIFF
--- a/pandas/tests/frame/test_analytics.py
+++ b/pandas/tests/frame/test_analytics.py
@@ -80,15 +80,6 @@ def _check_stat_op(name, alternative, main_frame, float_frame,
 
     # bad axis
     tm.assert_raises_regex(ValueError, 'No axis named 2', f, axis=2)
-    # make sure works on mixed-type frame
-    getattr(float_string_frame, name)(axis=0)
-    getattr(float_string_frame, name)(axis=1)
-
-    if has_numeric_only:
-        getattr(float_string_frame, name)(axis=0, numeric_only=True)
-        getattr(float_string_frame, name)(axis=1, numeric_only=True)
-        getattr(float_frame, name)(axis=0, numeric_only=False)
-        getattr(float_frame, name)(axis=1, numeric_only=False)
 
     # all NA case
     if has_skipna:
@@ -101,6 +92,16 @@ def _check_stat_op(name, alternative, main_frame, float_frame,
             tm.assert_series_equal(r0, expected)
             expected = pd.Series(unit, index=r1.index, dtype=r1.dtype)
             tm.assert_series_equal(r1, expected)
+
+    # make sure works on mixed-type frame
+    getattr(float_string_frame, name)(axis=0)
+    getattr(float_string_frame, name)(axis=1)
+
+    if has_numeric_only:
+        getattr(float_string_frame, name)(axis=0, numeric_only=True)
+        getattr(float_string_frame, name)(axis=1, numeric_only=True)
+        getattr(float_frame, name)(axis=0, numeric_only=False)
+        getattr(float_frame, name)(axis=1, numeric_only=False)
 
 
 def _check_bool_op(name, alternative, frame, float_string_frame,
@@ -134,6 +135,18 @@ def _check_bool_op(name, alternative, frame, float_string_frame,
     # bad axis
     pytest.raises(ValueError, f, axis=2)
 
+    # all NA case
+    if has_skipna:
+        all_na = frame * np.NaN
+        r0 = getattr(all_na, name)(axis=0)
+        r1 = getattr(all_na, name)(axis=1)
+        if name == 'any':
+            assert not r0.any()
+            assert not r1.any()
+        else:
+            assert r0.all()
+            assert r1.all()
+
     # make sure works on mixed-type frame
     mixed = float_string_frame
     mixed['_bool_'] = np.random.randn(len(mixed)) > 0
@@ -152,18 +165,6 @@ def _check_bool_op(name, alternative, frame, float_string_frame,
         getattr(mixed, name)(axis=1, bool_only=True)
         getattr(frame, name)(axis=0, bool_only=False)
         getattr(frame, name)(axis=1, bool_only=False)
-
-    # all NA case
-    if has_skipna:
-        all_na = frame * np.NaN
-        r0 = getattr(all_na, name)(axis=0)
-        r1 = getattr(all_na, name)(axis=1)
-        if name == 'any':
-            assert not r0.any()
-            assert not r1.any()
-        else:
-            assert r0.all()
-            assert r1.all()
 
 
 class TestDataFrameAnalytics():

--- a/pandas/tests/frame/test_analytics.py
+++ b/pandas/tests/frame/test_analytics.py
@@ -33,8 +33,7 @@ def assert_stat_op_calc(opname, alternative, main_frame, has_skipna=True,
 
     if check_dates:
         df = DataFrame({'b': date_range('1/1/2001', periods=2)})
-        _f = getattr(df, opname)
-        result = _f()
+        result = getattr(df, opname)()
         assert isinstance(result, Series)
 
         df['a'] = lrange(len(df))
@@ -86,7 +85,7 @@ def assert_stat_op_calc(opname, alternative, main_frame, has_skipna=True,
         r0 = getattr(all_na, opname)(axis=0)
         r1 = getattr(all_na, opname)(axis=1)
         if opname in ['sum', 'prod']:
-            unit = int(opname == 'prod')
+            unit = 1 if opname == 'prod' else 0  # result for empty sum/prod
             expected = pd.Series(unit, index=r0.index, dtype=r0.dtype)
             tm.assert_series_equal(r0, expected)
             expected = pd.Series(unit, index=r1.index, dtype=r1.dtype)
@@ -137,7 +136,7 @@ def assert_bool_op_calc(opname, alternative, main_frame, has_skipna=True):
                            check_dtype=False)
 
     # bad axis
-    pytest.raises(ValueError, f, axis=2)
+    tm.assert_raises_regex(ValueError, 'No axis named 2', f, axis=2)
 
     # all NA case
     if has_skipna:
@@ -156,7 +155,7 @@ def assert_bool_op_api(opname, bool_frame_with_na, float_string_frame,
                        has_bool_only=False):
     # make sure op works on mixed-type frame
     mixed = float_string_frame
-    mixed['_bool_'] = np.random.randn(len(mixed)) > 0
+    mixed['_bool_'] = np.random.randn(len(mixed)) > 0.5
     getattr(mixed, opname)(axis=0)
     getattr(mixed, opname)(axis=1)
 


### PR DESCRIPTION
Follow-up to #22733, where some things were left undone to ease reviewing.

Mainly:
* cleaning up the jumble of `_check_stat_op`, splitting it into two functions with separate purposes
* this removes redundant calls to the API-portion of the function in tests like `test_max` etc.
* renaming according to review in #22733 
* same for `_check_bool_op`
* parametrize `test_any_all` according to review in #22733 

