### PR TITLE
DOC: Clarify rolling min_periods default value GH21489

### DIFF
--- a/pandas/core/window.py
+++ b/pandas/core/window.py
@@ -462,8 +462,8 @@ class Window(_Window):
     min_periods : int, default None
         Minimum number of observations in window required to have a value
         (otherwise result is NA). For a window that is specified by an offset,
-        this will default to 1. Otherwise, this will default to the size of the
-        window.
+        `min_periods` will default to 1. Otherwise, `min_periods` will default
+        to the size of the window.
     center : boolean, default False
         Set the labels at the center of the window.
     win_type : string, default None

--- a/pandas/core/window.py
+++ b/pandas/core/window.py
@@ -462,7 +462,8 @@ class Window(_Window):
     min_periods : int, default None
         Minimum number of observations in window required to have a value
         (otherwise result is NA). For a window that is specified by an offset,
-        this will default to 1.
+        this will default to 1. Otherwise, this will default to the size of the
+        window.
     center : boolean, default False
         Set the labels at the center of the window.
     win_type : string, default None


### PR DESCRIPTION
- [ ] closes #21489
- [ ] tests added / passed
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew Clarifies the documentation of the default value for the min_periods argument of the rolling function.
