### PR TITLE
BUG: Fixed nlargest/smallest functionality for dataframes with MultiIndex columns

### DIFF
--- a/doc/source/whatsnew/v0.24.0.txt
+++ b/doc/source/whatsnew/v0.24.0.txt
@@ -1208,6 +1208,7 @@ Sparse
 - Bug in ``DataFrame.groupby`` not including ``fill_value`` in the groups for non-NA ``fill_value`` when grouping by a sparse column (:issue:`5078`)
 - Bug in unary inversion operator (``~``) on a ``SparseSeries`` with boolean values. The performance of this has also been improved (:issue:`22835`)
 - Bug in :meth:`SparseArary.unique` not returning the unique values (:issue:`19595`)
+- Fixed :meth:`DataFrame.nsmallest` and :meth:`DataFrame.nlargest` for dataframes that have :class:`MultiIndex`ed columns (:issue:`23033`).
 
 Build Changes
 ^^^^^^^^^^^^^

--- a/doc/source/whatsnew/v0.24.0.txt
+++ b/doc/source/whatsnew/v0.24.0.txt
@@ -1194,6 +1194,7 @@ Reshaping
 - Bug in :func:`merge_asof` when merging on float values within defined tolerance (:issue:`22981`)
 - Bug in :func:`pandas.concat` when concatenating a multicolumn DataFrame with tz-aware data against a DataFrame with a different number of columns (:issue`22796`)
 - Bug in :func:`merge_asof` where confusing error message raised when attempting to merge with missing values (:issue:`23189`)
+- Bug in :meth:`DataFrame.nsmallest` and :meth:`DataFrame.nlargest` for dataframes that have :class:`MultiIndex`ed columns (:issue:`23033`).
 
 .. _whatsnew_0240.bug_fixes.sparse:
 
@@ -1208,7 +1209,6 @@ Sparse
 - Bug in ``DataFrame.groupby`` not including ``fill_value`` in the groups for non-NA ``fill_value`` when grouping by a sparse column (:issue:`5078`)
 - Bug in unary inversion operator (``~``) on a ``SparseSeries`` with boolean values. The performance of this has also been improved (:issue:`22835`)
 - Bug in :meth:`SparseArary.unique` not returning the unique values (:issue:`19595`)
-- Bug in :meth:`DataFrame.nsmallest` and :meth:`DataFrame.nlargest` for dataframes that have :class:`MultiIndex`ed columns (:issue:`23033`).
 
 Build Changes
 ^^^^^^^^^^^^^

--- a/doc/source/whatsnew/v0.24.0.txt
+++ b/doc/source/whatsnew/v0.24.0.txt
@@ -1208,7 +1208,7 @@ Sparse
 - Bug in ``DataFrame.groupby`` not including ``fill_value`` in the groups for non-NA ``fill_value`` when grouping by a sparse column (:issue:`5078`)
 - Bug in unary inversion operator (``~``) on a ``SparseSeries`` with boolean values. The performance of this has also been improved (:issue:`22835`)
 - Bug in :meth:`SparseArary.unique` not returning the unique values (:issue:`19595`)
-- Fixed :meth:`DataFrame.nsmallest` and :meth:`DataFrame.nlargest` for dataframes that have :class:`MultiIndex`ed columns (:issue:`23033`).
+- Bug in :meth:`DataFrame.nsmallest` and :meth:`DataFrame.nlargest` for dataframes that have :class:`MultiIndex`ed columns (:issue:`23033`).
 
 Build Changes
 ^^^^^^^^^^^^^

--- a/pandas/core/algorithms.py
+++ b/pandas/core/algorithms.py
@@ -1161,7 +1161,7 @@ class SelectNFrame(SelectN):
 
     def __init__(self, obj, n, keep, columns):
         super(SelectNFrame, self).__init__(obj, n, keep)
-        if not is_list_like(columns):
+        if not is_list_like(columns) or isinstance(columns, tuple):
             columns = [columns]
         columns = list(columns)
         self.columns = columns

--- a/pandas/tests/frame/test_analytics.py
+++ b/pandas/tests/frame/test_analytics.py
@@ -2259,3 +2259,14 @@ class TestNLargestNSmallest(object):
         df.rank()
         result = df
         tm.assert_frame_equal(result, expected)
+
+    def test_multiindex_column_lookup(self):
+        df = pd.DataFrame(
+            columns=pd.MultiIndex.from_product([['x'], ['a', 'b']]),
+            data=[[0.33, 0.13], [0.86, 0.25], [0.25, 0.70], [0.85, 0.91]])
+        pd.util.testing.assert_frame_equal(
+            df.nsmallest(3, ('x', 'a')),
+            df.iloc[[2, 0, 3]])
+        pd.util.testing.assert_frame_equal(
+            df.nlargest(3, ('x', 'b')),
+            df.iloc[[3, 2, 1]])

--- a/pandas/tests/frame/test_analytics.py
+++ b/pandas/tests/frame/test_analytics.py
@@ -2261,12 +2261,18 @@ class TestNLargestNSmallest(object):
         tm.assert_frame_equal(result, expected)
 
     def test_multiindex_column_lookup(self):
+        # Check whether tuples are correctly treated as multi-level lookups.
+        # GH 23033
         df = pd.DataFrame(
             columns=pd.MultiIndex.from_product([['x'], ['a', 'b']]),
             data=[[0.33, 0.13], [0.86, 0.25], [0.25, 0.70], [0.85, 0.91]])
-        pd.util.testing.assert_frame_equal(
-            df.nsmallest(3, ('x', 'a')),
-            df.iloc[[2, 0, 3]])
-        pd.util.testing.assert_frame_equal(
-            df.nlargest(3, ('x', 'b')),
-            df.iloc[[3, 2, 1]])
+
+        # nsmallest
+        result = df.nsmallest(3, ('x', 'a'))
+        expected = df.iloc[[2, 0, 3]]
+        tm.assert_frame_equal(result, expected)
+
+        # nlargest
+        result = df.nlargest(3, ('x', 'b'))
+        expected = df.iloc[[3, 2, 1]]
+        tm.assert_frame_equal(result, expected)

--- a/pandas/tests/frame/test_analytics.py
+++ b/pandas/tests/frame/test_analytics.py
@@ -2153,7 +2153,7 @@ class TestNLargestNSmallest(object):
             tm.assert_frame_equal(result, expected)
 
     @pytest.mark.parametrize('columns', [
-        ('group', 'category_string'), ('group', 'string')])
+        ['group', 'category_string'], ['group', 'string']])
     def test_n_error(self, df_main_dtypes, nselect_method, columns):
         df = df_main_dtypes
         col = columns[1]


### PR DESCRIPTION
This change fixes nlargest/smallest functionality for dataframes with MultiIndex columns.

- [x] closes #23033
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry
