### PR TITLE
CLN GH22985 Fixed interpolation with object error message

### DIFF
--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -6387,7 +6387,9 @@ class NDFrame(PandasObject, SelectionMixin):
 
         if _maybe_transposed_self._data.get_dtype_counts().get(
                 'object') == len(_maybe_transposed_self.T):
-            raise TypeError("Cannot interpolate with all NaNs.")
+            raise TypeError("Cannot interpolate with all object-dtype columns "
+                            "in the DataFrame. Try setting at least one "
+                            "column to a numeric dtype.")
 
         # create/use the index
         if method == 'linear':

--- a/pandas/tests/frame/test_missing.py
+++ b/pandas/tests/frame/test_missing.py
@@ -814,6 +814,19 @@ class TestDataFrameInterpolate(TestData):
         with pytest.raises(TypeError):
             df.interpolate(axis=1)
 
+    def test_interp_raise_on_all_object_dtype(self):
+        # GH 22985
+        df = DataFrame({
+            'A': [1, 2, 3],
+            'B': [4, 5, 6]},
+            dtype='object')
+        with tm.assert_raises_regex(
+                TypeError,
+                "Cannot interpolate with all object-dtype columns "
+                "in the DataFrame. Try setting at least one "
+                "column to a numeric dtype."):
+            df.interpolate()
+
     def test_interp_inplace(self):
         df = DataFrame({'a': [1., 2., np.nan, 4.]})
         expected = DataFrame({'a': [1., 2., 3., 4.]})


### PR DESCRIPTION
- [x] closes #22985
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

It looks like the problem with #22985 is mostly the mismatch between the input trigger and the error message, so this is just a tiny hotfix. 