### PR TITLE
Corrected 'columns' argument of 'to_csv' method

### DIFF
--- a/doc/source/io.rst
+++ b/doc/source/io.rst
@@ -1603,7 +1603,7 @@ function takes a number of arguments. Only the first is required.
 * ``sep`` : Field delimiter for the output file (default ",")
 * ``na_rep``: A string representation of a missing value (default '')
 * ``float_format``: Format string for floating point numbers
-* ``cols``: Columns to write (default None)
+* ``columns``: Columns to write (default None)
 * ``header``: Whether to write out the column names (default True)
 * ``index``: whether to write row (index) names (default True)
 * ``index_label``: Column label(s) for index column(s) if desired. If None


### PR DESCRIPTION
Compared the 'to_csv' method described in https://pandas.pydata.org/pandas-docs/stable/generated/pandas.DataFrame.to_csv.html with the same method described in https://pandas.pydata.org/pandas-docs/stable/io.html#writing-to-csv-format and noticed difference between the two in the 'columns' and 'cols' argument.

- [ ] closes #xxxx
- [ ] tests added / passed
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
