### PR TITLE
PERF: Override PeriodIndex.unique

### DIFF
--- a/asv_bench/benchmarks/period.py
+++ b/asv_bench/benchmarks/period.py
@@ -119,3 +119,6 @@ class Indexing(object):
 
     def time_intersection(self):
         self.index[:750].intersection(self.index[250:])
+
+    def time_unique(self):
+        self.index.unique()

--- a/doc/source/whatsnew/v0.24.0.txt
+++ b/doc/source/whatsnew/v0.24.0.txt
@@ -684,6 +684,7 @@ Performance Improvements
   (:issue:`21372`)
 - Improved the performance of :func:`pandas.get_dummies` with ``sparse=True`` (:issue:`21997`)
 - Improved performance of :func:`IndexEngine.get_indexer_non_unique` for sorted, non-unique indexes (:issue:`9466`)
+- Improved performance of :func:`PeriodIndex.unique` (:issue:`23083`)
 
 
 .. _whatsnew_0240.docs:

--- a/pandas/core/indexes/period.py
+++ b/pandas/core/indexes/period.py
@@ -542,7 +542,7 @@ class PeriodIndex(PeriodArrayMixin, DatelikeOps, DatetimeIndexOpsMixin,
 
     @Appender(Index.unique.__doc__)
     def unique(self, level=None):
-        # override the Index.unique method for performance
+        # override the Index.unique method for performance GH#23083
         if level is not None:
             # this should never occur, but is retained to make the signature
             # match Index.unique

--- a/pandas/core/indexes/period.py
+++ b/pandas/core/indexes/period.py
@@ -29,6 +29,7 @@ from pandas._libs.tslibs.period import (Period, IncompatibleFrequency,
                                         DIFFERENT_FREQ_INDEX)
 from pandas._libs.tslibs import resolution, period
 
+from pandas.core.algorithms import unique1d
 from pandas.core.arrays import datetimelike as dtl
 from pandas.core.arrays.period import PeriodArrayMixin, dt64arr_to_periodarr
 from pandas.core.base import _shared_docs
@@ -538,6 +539,18 @@ class PeriodIndex(PeriodArrayMixin, DatelikeOps, DatetimeIndexOpsMixin,
         if dropna:
             res = res.dropna()
         return res
+
+    @Appender(Index.unique.__doc__)
+    def unique(self, level=None):
+        # override the Index.unique method for performance
+        if level is not None:
+            # this should never occur, but is retained to make the signature
+            # match Index.unique
+            self._validate_index_level(level)
+
+        values = self._ndarray_values
+        result = unique1d(values)
+        return self._shallow_copy(result)
 
     def get_loc(self, key, method=None, tolerance=None):
         """


### PR DESCRIPTION
In trying to simplify the mess that is the PeriodIndex constructors, I found that PeriodIndex.unique is doing an unfortunate conversion to object-dtype.  This PR avoids that and gets a nice speedup.


```
In [2]: pi = pd.period_range('1000Q1', periods=10000, freq='Q')
In [3]: %timeit pi.unique()
The slowest run took 6.25 times longer than the fastest. This could mean that an intermediate result is being cached.
1000 loops, best of 3: 226 µs per loop    <-- PR
10 loops, best of 3: 24.7 ms per loop     <-- master
```