### PR TITLE
Fix ASV imports

### DIFF
--- a/asv_bench/benchmarks/indexing.py
+++ b/asv_bench/benchmarks/indexing.py
@@ -2,10 +2,9 @@ import warnings
 
 import numpy as np
 import pandas.util.testing as tm
-from pandas import (Series, DataFrame, MultiIndex, Int64Index, Float64Index,
-                    IntervalIndex, CategoricalIndex,
+from pandas import (Series, DataFrame, Panel, MultiIndex, Int64Index,
+                    Float64Index, IntervalIndex, CategoricalIndex,
                     IndexSlice, concat, date_range)
-from .pandas_vb_common import Panel
 
 
 class NumericSeriesIndexing(object):

--- a/asv_bench/benchmarks/join_merge.py
+++ b/asv_bench/benchmarks/join_merge.py
@@ -11,8 +11,6 @@ try:
 except ImportError:
     from pandas import ordered_merge as merge_ordered
 
-from .pandas_vb_common import Panel
-
 
 class Append(object):
 

--- a/asv_bench/benchmarks/panel_ctor.py
+++ b/asv_bench/benchmarks/panel_ctor.py
@@ -3,8 +3,6 @@ from datetime import datetime, timedelta
 
 from pandas import DataFrame, Panel, DatetimeIndex, date_range
 
-from .pandas_vb_common import Panel
-
 
 class DifferentIndexes(object):
     goal_time = 0.2

--- a/asv_bench/benchmarks/panel_methods.py
+++ b/asv_bench/benchmarks/panel_methods.py
@@ -3,8 +3,6 @@ import warnings
 import numpy as np
 from pandas import Panel
 
-from .pandas_vb_common import Panel
-
 
 class PanelMethods(object):
 


### PR DESCRIPTION
#22947 broke the ASV - second time in a few days that linting the benchmarks has broken something (see #22978 / #22886)

@datapythonista, could you please require that PRs try
```
cd asv_bench
asv dev
```
to see if *collection* of benchmark works? This takes about 30 seconds and then the asv run can be aborted with CTRL+C.
