### PR TITLE
clean CategoricalIndex.get_loc and improve error message

### DIFF
--- a/pandas/core/indexes/category.py
+++ b/pandas/core/indexes/category.py
@@ -426,6 +426,10 @@ class CategoricalIndex(Index, accessor.PandasDelegate):
         -------
         loc : int if unique index, slice if monotonic index, else mask
 
+        Raises
+        ------
+        KeyError : if the key is not in the index
+
         Examples
         ---------
         >>> unique_index = pd.CategoricalIndex(list('abc'))
@@ -440,10 +444,11 @@ class CategoricalIndex(Index, accessor.PandasDelegate):
         >>> non_monotonic_index.get_loc('b')
         array([False,  True, False,  True], dtype=bool)
         """
-        codes = self.categories.get_loc(key)
-        if (codes == -1):
+        code = self.categories.get_loc(key)
+        try:
+            return self._engine.get_loc(code)
+        except KeyError:
             raise KeyError(key)
-        return self._engine.get_loc(codes)
 
     def get_value(self, series, key):
         """


### PR DESCRIPTION
This is an offspring from #21699 to do the a cleanup in a contained PR.

``self.categories.get_loc(key)`` can never return -1, so the ``if (codes == -1): raise KeyError(key)`` is unnecessary. Instead, if key is not in self.categories, a KeyError is raised straight away.

```python
>>> ci = pd.CategoricalIndex(['a', 'b'], categories=['a', 'b', 'c'])
>>> ci.get_loc('d')
KeyError: 'd'  # both master and this PR
```

A slightly confusing issue is that if the key is found in categories, but the code is not found in self._engine, the code is shown in the KeyError message. It would probably be more intuitive that the key would be shown:

```python
>>> ci.get_loc('c')
KeyError: 2  # master, confusing IMO
KeyError: 'c'  # this PR
```

As the error type is unchanged, does this change warrant a whatsnew entry?
