### PR TITLE
PERF: PeriodIndex.dropna, difference, take

### DIFF
--- a/asv_bench/benchmarks/period.py
+++ b/asv_bench/benchmarks/period.py
@@ -96,6 +96,8 @@ class Algorithms(object):
 class Indexing(object):
 
     goal_time = 0.2
+    pi_with_nas = PeriodIndex(['1985Q1', 'NaT', '1985Q2'] * 1000, freq='Q')
+    pi_diff = PeriodIndex(['1985Q1', 'NaT', '1985Q3'] * 1000, freq='Q')
 
     def setup(self):
         self.index = PeriodIndex(start='1985', periods=1000, freq='D')
@@ -122,3 +124,12 @@ class Indexing(object):
 
     def time_unique(self):
         self.index.unique()
+
+    def time_dropna(self):
+        self.pi_with_nas.dropna()
+
+    def time_difference(self):
+        self.pi_with_nas.difference(self.pi_diff)
+
+    def time_symmetric_difference(self):
+        self.pi_with_nas.symmetric_difference(self.pi_diff)

--- a/asv_bench/benchmarks/period.py
+++ b/asv_bench/benchmarks/period.py
@@ -123,13 +123,17 @@ class Indexing(object):
         self.index[:750].intersection(self.index[250:])
 
     def time_unique(self):
+        # GH#23083
         self.index.unique()
 
     def time_dropna(self):
+        # GH#23095
         self.pi_with_nas.dropna()
 
     def time_difference(self):
+        # GH#23095
         self.pi_with_nas.difference(self.pi_diff)
 
     def time_symmetric_difference(self):
+        # GH#23095
         self.pi_with_nas.symmetric_difference(self.pi_diff)

--- a/doc/source/whatsnew/v0.24.0.txt
+++ b/doc/source/whatsnew/v0.24.0.txt
@@ -701,7 +701,7 @@ Performance Improvements
   (:issue:`21372`)
 - Improved the performance of :func:`pandas.get_dummies` with ``sparse=True`` (:issue:`21997`)
 - Improved performance of :func:`IndexEngine.get_indexer_non_unique` for sorted, non-unique indexes (:issue:`9466`)
-- Improved performance of :func:`PeriodIndex.unique`, :func:`PeriodIndex.difference`, :func:`PeriodIndex.symmetric_difference`, and :func:`PeriodIndex.dropna`,  (:issue:`23083`)
+- Improved performance of :func:`PeriodIndex.unique`, :func:`PeriodIndex.difference`, :func:`PeriodIndex.symmetric_difference`, and :func:`PeriodIndex.dropna`,  (:issue:`23083`, :issue:`23095`)
 
 
 .. _whatsnew_0240.docs:

--- a/doc/source/whatsnew/v0.24.0.txt
+++ b/doc/source/whatsnew/v0.24.0.txt
@@ -701,7 +701,7 @@ Performance Improvements
   (:issue:`21372`)
 - Improved the performance of :func:`pandas.get_dummies` with ``sparse=True`` (:issue:`21997`)
 - Improved performance of :func:`IndexEngine.get_indexer_non_unique` for sorted, non-unique indexes (:issue:`9466`)
-- Improved performance of :func:`PeriodIndex.unique` (:issue:`23083`)
+- Improved performance of :func:`PeriodIndex.unique`, :func:`PeriodIndex.difference`, :func:`PeriodIndex.symmetric_difference`, and :func:`PeriodIndex.dropna`,  (:issue:`23083`)
 
 
 .. _whatsnew_0240.docs:

--- a/pandas/core/indexes/multi.py
+++ b/pandas/core/indexes/multi.py
@@ -17,6 +17,7 @@ from pandas.core.dtypes.dtypes import (
 from pandas.core.dtypes.common import (
     ensure_int64,
     ensure_platform_int,
+    is_period_dtype,
     is_categorical_dtype,
     is_object_dtype,
     is_hashable,
@@ -1036,7 +1037,14 @@ class MultiIndex(Index):
         labels = self.labels[level]
         if unique:
             labels = algos.unique(labels)
-        filled = algos.take_1d(values._values, labels,
+
+        if is_period_dtype(values):
+            take_vals = values._ndarray_values
+        else:
+            # TODO: Why is this _values where elsewhere it is values?
+            #  if it were values here we could use _take_values
+            take_vals = values._values
+        filled = algos.take_1d(take_vals, labels,
                                fill_value=values._na_value)
         values = values._shallow_copy(filled)
         return values

--- a/pandas/core/indexes/period.py
+++ b/pandas/core/indexes/period.py
@@ -350,7 +350,7 @@ class PeriodIndex(PeriodArrayMixin, DatelikeOps, DatetimeIndexOpsMixin,
             return result
         # the result is object dtype array of Period
         # cannot pass _simple_new as it is
-        return self._shallow_copy(result, freq=self.freq, name=self.name)
+        return type(self)(result, freq=self.freq, name=self.name)
 
     @property
     def size(self):

--- a/pandas/core/indexes/period.py
+++ b/pandas/core/indexes/period.py
@@ -327,9 +327,9 @@ class PeriodIndex(PeriodArrayMixin, DatelikeOps, DatetimeIndexOpsMixin,
         """
         if isinstance(context, tuple) and len(context) > 0:
             func = context[0]
-            if (func is np.add):
+            if func is np.add:
                 pass
-            elif (func is np.subtract):
+            elif func is np.subtract:
                 name = self.name
                 left = context[1][0]
                 right = context[1][1]

--- a/pandas/util/testing.py
+++ b/pandas/util/testing.py
@@ -824,7 +824,8 @@ def assert_index_equal(left, right, exact='equiv', check_names=True,
         # accept level number only
         unique = index.levels[level]
         labels = index.labels[level]
-        filled = take_1d(unique.values, labels, fill_value=unique._na_value)
+        filled = take_1d(unique._take_values, labels,
+                         fill_value=unique._na_value)
         values = unique._shallow_copy(filled, name=index.names[level])
         return values
 


### PR DESCRIPTION
Related #23083 

Besides the performance boost, this goes a long way towards making `PeriodIndex._simple_new` actually simple; avoids passing object-dtype to `_simple_new`

```
In [2]: pi_with_nas = pd.PeriodIndex(['1985Q1', 'NaT', '1985Q2'] * 1000, freq='Q')
In [3]: %timeit pi_with_nas.dropna()
The slowest run took 13.93 times longer than the fastest. This could mean that an intermediate result is being cached.
10000 loops, best of 3: 23.3 µs per loop  <-- PR
100 loops, best of 3: 4.96 ms per loop    <-- master

In [4]: pi_diff = pd.PeriodIndex(['1985Q1', 'NaT', '1985Q3'] * 1000, freq='Q')
In [5]: %timeit pi_with_nas.difference(pi_diff)
1000 loops, best of 3: 553 µs per loop  <-- PR
100 loops, best of 3: 5.29 ms per loop  <-- master

In [6]: %timeit pi_with_nas.symmetric_difference(pi_diff)
1000 loops, best of 3: 787 µs per loop  <-- PR
100 loops, best of 3: 10.3 ms per loop  <-- master
```