### PR TITLE
Ignoring W504 (line break after binary operator) in linting

### DIFF
--- a/.pep8speaks.yml
+++ b/.pep8speaks.yml
@@ -11,6 +11,7 @@ pycodestyle:
     max-line-length: 79
     ignore:
         - W503,  # line break before binary operator
+        - W504,  # line break after binary operator
         - E402,  # module level import not at top of file
         - E722,  # do not use bare except
         - E731,  # do not assign a lambda expression, use a def

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,6 +15,7 @@ parentdir_prefix = pandas-
 max-line-length = 79
 ignore =
     W503,  # line break before binary operator
+    W504,  # line break after binary operator
     E402,  # module level import not at top of file
     E722,  # do not use bare except
     E731,  # do not assign a lambda expression, use a def


### PR DESCRIPTION
Based on the discussion in #23073, `flake8` is not linting for `W504`. `pep8speak` does, and future versions of `flake8` are likely to do so. So, I think we need to update our settings to ignore it explicitly, so `pep8speaks` is consistent with the CI, and updates on `flake8` do not start to generate unwanted errors. 
