### PR TITLE
TST: add test cases for reset_index method

### DIFF
--- a/pandas/tests/frame/test_alter_axes.py
+++ b/pandas/tests/frame/test_alter_axes.py
@@ -744,6 +744,13 @@ class TestDataFrameAlterAxes():
         xp = xp.set_index(['B'], append=True)
         tm.assert_frame_equal(rs, xp, check_names=False)
 
+    def test_reset_index_name(self):
+        df = DataFrame([[1, 2, 3, 4], [5, 6, 7, 8]],
+                       columns=['A', 'B', 'C', 'D'],
+                       index=Index(range(2), name='x'))
+        assert df.reset_index().index.name == 'x'
+        assert df.reset_index(drop=True).index.name == 'x'
+
     def test_reset_index_level(self):
         df = DataFrame([[1, 2, 3, 4], [5, 6, 7, 8]],
                        columns=['A', 'B', 'C', 'D'])

--- a/pandas/tests/frame/test_alter_axes.py
+++ b/pandas/tests/frame/test_alter_axes.py
@@ -748,8 +748,10 @@ class TestDataFrameAlterAxes():
         df = DataFrame([[1, 2, 3, 4], [5, 6, 7, 8]],
                        columns=['A', 'B', 'C', 'D'],
                        index=Index(range(2), name='x'))
-        assert df.reset_index().index.name == 'x'
-        assert df.reset_index(drop=True).index.name == 'x'
+        assert df.reset_index().index.name is None
+        assert df.reset_index(drop=True).index.name is None
+        df.reset_index(inplace=True)
+        assert df.index.name is None
 
     def test_reset_index_level(self):
         df = DataFrame([[1, 2, 3, 4], [5, 6, 7, 8]],

--- a/pandas/tests/series/test_alter_axes.py
+++ b/pandas/tests/series/test_alter_axes.py
@@ -146,8 +146,8 @@ class TestSeriesAlterAxes(object):
 
     def test_reset_index_name(self):
         s = Series([1, 2, 3], index=Index(range(3), name='x'))
-        assert s.reset_index().index.name == 'x'
-        assert s.reset_index(drop=True).index.name == 'x'
+        assert s.reset_index().index.name is None
+        assert s.reset_index(drop=True).index.name is None
 
     def test_reset_index_level(self):
         df = DataFrame([[1, 2, 3], [4, 5, 6]],

--- a/pandas/tests/series/test_alter_axes.py
+++ b/pandas/tests/series/test_alter_axes.py
@@ -144,6 +144,11 @@ class TestSeriesAlterAxes(object):
         tm.assert_index_equal(rs.index, Index(index.get_level_values(1)))
         assert isinstance(rs, Series)
 
+    def test_reset_index_name(self):
+        s = Series([1, 2, 3], index=Index(range(3), name='x'))
+        assert s.reset_index().index.name == 'x'
+        assert s.reset_index(drop=True).index.name == 'x'
+
     def test_reset_index_level(self):
         df = DataFrame([[1, 2, 3], [4, 5, 6]],
                        columns=['A', 'B', 'C'])

--- a/pandas/tests/test_multilevel.py
+++ b/pandas/tests/test_multilevel.py
@@ -740,6 +740,7 @@ x   q   30      3    -0.6662 -0.5243 -0.3580  0.89145  2.5838"""
     def test_reset_index_with_drop(self):
         deleveled = self.ymd.reset_index(drop=True)
         assert len(deleveled.columns) == len(self.ymd.columns)
+        assert deleveled.index.name == self.ymd.index.name
 
         deleveled = self.series.reset_index()
         assert isinstance(deleveled, DataFrame)

--- a/pandas/tests/test_multilevel.py
+++ b/pandas/tests/test_multilevel.py
@@ -745,9 +745,11 @@ x   q   30      3    -0.6662 -0.5243 -0.3580  0.89145  2.5838"""
         deleveled = self.series.reset_index()
         assert isinstance(deleveled, DataFrame)
         assert len(deleveled.columns) == len(self.series.index.levels) + 1
+        assert deleveled.index.name == self.series.index.name
 
         deleveled = self.series.reset_index(drop=True)
         assert isinstance(deleveled, Series)
+        assert deleveled.index.name == self.series.index.name
 
     def test_count_level(self):
         def _check_counts(frame, axis=0):


### PR DESCRIPTION
- [x] closes #17067
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

the fix appears to work but it breaks previous assert_frame_equal that assumes index.name == None after reset_index() call. 

The question remains that is the issue #17067 actually a bug and does it require a fix at all? user can pretty much do `series.index.name = 'new name'` to handle this problem.