### PR TITLE
Bump Hypothesis timeout from 200ms to 5s.

### DIFF
--- a/pandas/conftest.py
+++ b/pandas/conftest.py
@@ -13,6 +13,11 @@ import hypothesis
 
 hypothesis.settings.register_profile(
     "ci",
+    # Hypothesis timing checks are tuned for scalars by default, so we bump
+    # them from 200ms to 5 secs per test case as the global default.  If this
+    # is too short for a specific test, (a) try to make it faster, and (b)
+    # if it really is slow add `@settings(timeout=...)` with a working value.
+    timeout=5000,
     suppress_health_check=(hypothesis.HealthCheck.too_slow,)
 )
 hypothesis.settings.load_profile("ci")


### PR DESCRIPTION
Closes #23121 - this is a minor config change to account for the fact that Pandas tests are slower than equivalent tests for scalars simply due to data size.  CC @jorisvandenbossche @TomAugspurger 