### PR TITLE
DOC: Fix creation of [source] links in the doc creation

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -569,7 +569,7 @@ def linkcode_resolve(domain, info):
             return None
 
     try:
-        fn = inspect.getsourcefile(obj)
+        fn = inspect.getsourcefile(inspect.unwrap(obj))
     except:
         fn = None
     if not fn:

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -569,7 +569,11 @@ def linkcode_resolve(domain, info):
             return None
 
     try:
-        fn = inspect.getsourcefile(inspect.unwrap(obj))
+        # inspect.unwrap() was added in Python version 3.4
+        if sys.version_info >= (3, 4):
+            fn = inspect.getsourcefile(inspect.unwrap(obj))
+        else:
+            fn = inspect.getsourcefile(obj)
     except:
         fn = None
     if not fn:

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -570,7 +570,7 @@ def linkcode_resolve(domain, info):
 
     try:
         # inspect.unwrap() was added in Python version 3.4
-        if sys.version_info >= (3, 4):
+        if sys.version_info >= (3, 5):
             fn = inspect.getsourcefile(inspect.unwrap(obj))
         else:
             fn = inspect.getsourcefile(obj)


### PR DESCRIPTION
See this issue: https://github.com/pandas-dev/pandas/issues/23046

A simple fix is to add `inspect.unwrap(obj)` before `getsourcefile`. This follows the `__wrapped__` attributes of the functions "all the way to the bottom" and then returns the object found.

One problem with this is that `unwrap` function was only introduced in Python 3.4. This means that compiling the documentation will now fail on Python versions older than that. I do not know if this is acceptable.