### PR TITLE
CLN: Flake8 E741

### DIFF
--- a/.pep8speaks.yml
+++ b/.pep8speaks.yml
@@ -14,7 +14,6 @@ pycodestyle:
         - E402,  # module level import not at top of file
         - E722,  # do not use bare except
         - E731,  # do not assign a lambda expression, use a def
-        - E741,  # ambiguous variable name 'l'
         - C406,  # Unnecessary list literal - rewrite as a dict literal.
         - C408,  # Unnecessary dict call - rewrite as a literal.
         - C409   # Unnecessary list passed to tuple() - rewrite as a tuple literal.

--- a/pandas/tests/frame/test_constructors.py
+++ b/pandas/tests/frame/test_constructors.py
@@ -896,8 +896,7 @@ class TestDataFrameConstructors(TestData):
 
     def test_constructor_list_of_lists(self):
         # GH #484
-        l = [[1, 'a'], [2, 'b']]
-        df = DataFrame(data=l, columns=["num", "str"])
+        df = DataFrame(data=[[1, 'a'], [2, 'b']], columns=["num", "str"])
         assert is_integer_dtype(df['num'])
         assert df['str'].dtype == np.object_
 
@@ -923,9 +922,9 @@ class TestDataFrameConstructors(TestData):
             def __len__(self, n):
                 return self._lst.__len__()
 
-        l = [DummyContainer([1, 'a']), DummyContainer([2, 'b'])]
+        lst_containers = [DummyContainer([1, 'a']), DummyContainer([2, 'b'])]
         columns = ["num", "str"]
-        result = DataFrame(l, columns=columns)
+        result = DataFrame(lst_containers, columns=columns)
         expected = DataFrame([[1, 'a'], [2, 'b']], columns=columns)
         tm.assert_frame_equal(result, expected, check_dtype=False)
 
@@ -1744,14 +1743,14 @@ class TestDataFrameConstructors(TestData):
 
     def test_constructor_categorical_series(self):
 
-        l = [1, 2, 3, 1]
-        exp = Series(l).astype('category')
-        res = Series(l, dtype='category')
+        items = [1, 2, 3, 1]
+        exp = Series(items).astype('category')
+        res = Series(items, dtype='category')
         tm.assert_series_equal(res, exp)
 
-        l = ["a", "b", "c", "a"]
-        exp = Series(l).astype('category')
-        res = Series(l, dtype='category')
+        items = ["a", "b", "c", "a"]
+        exp = Series(items).astype('category')
+        res = Series(items, dtype='category')
         tm.assert_series_equal(res, exp)
 
         # insert into frame with different index

--- a/pandas/tests/frame/test_indexing.py
+++ b/pandas/tests/frame/test_indexing.py
@@ -2076,9 +2076,9 @@ class TestDataFrameIndexing(TestData):
         # a named argument
         df = DataFrame({"a": [1, 2, 3], "b": [4, 5, 6],
                         "c": [7, 8, 9]}).set_index(["a", "b"])
-        l = list(df.index)
-        l[0] = ["a", "b"]
-        df.index = l
+        index = list(df.index)
+        index[0] = ["a", "b"]
+        df.index = index
 
         try:
             repr(df)

--- a/pandas/tests/frame/test_operators.py
+++ b/pandas/tests/frame/test_operators.py
@@ -793,8 +793,8 @@ class TestDataFrameOperators(TestData):
         b = np.array([2, 2])
         b_r = np.atleast_2d([2, 2])
         b_c = b_r.T
-        l = (2, 2, 2)
-        tup = tuple(l)
+        lst = [2, 2, 2]
+        tup = tuple(lst)
 
         # gt
         expected = DataFrame([[False, False], [False, True], [True, True]])
@@ -804,7 +804,7 @@ class TestDataFrameOperators(TestData):
         result = df.values > b
         assert_numpy_array_equal(result, expected.values)
 
-        result = df > l
+        result = df > lst
         assert_frame_equal(result, expected)
 
         result = df > tup
@@ -827,7 +827,7 @@ class TestDataFrameOperators(TestData):
         result = df == b
         assert_frame_equal(result, expected)
 
-        result = df == l
+        result = df == lst
         assert_frame_equal(result, expected)
 
         result = df == tup
@@ -850,7 +850,7 @@ class TestDataFrameOperators(TestData):
         expected.index = df.index
         expected.columns = df.columns
 
-        result = df == l
+        result = df == lst
         assert_frame_equal(result, expected)
 
         result = df == tup

--- a/pandas/tests/indexing/test_indexing.py
+++ b/pandas/tests/indexing/test_indexing.py
@@ -768,34 +768,34 @@ class TestMisc(Base):
         # assigned to. covers both uniform data-type & multi-type cases
         def run_tests(df, rhs, right):
             # label, index, slice
-            r, i, s = list('bcd'), [1, 2, 3], slice(1, 4)
-            c, j, l = ['joe', 'jolie'], [1, 2], slice(1, 3)
+            label_one, index_one, slice_one = list('bcd'), [1, 2, 3], slice(1, 4)
+            label_two, index_two, slice_two = ['joe', 'jolie'], [1, 2], slice(1, 3)
 
             left = df.copy()
-            left.loc[r, c] = rhs
+            left.loc[label_one, label_two] = rhs
             tm.assert_frame_equal(left, right)
 
             left = df.copy()
-            left.iloc[i, j] = rhs
+            left.iloc[index_one, index_two] = rhs
             tm.assert_frame_equal(left, right)
 
             left = df.copy()
             with catch_warnings(record=True):
                 # XXX: finer-filter here.
                 simplefilter("ignore")
-                left.ix[s, l] = rhs
+                left.ix[slice_one, slice_two] = rhs
             tm.assert_frame_equal(left, right)
 
             left = df.copy()
             with catch_warnings(record=True):
                 simplefilter("ignore")
-                left.ix[i, j] = rhs
+                left.ix[index_one, index_two] = rhs
             tm.assert_frame_equal(left, right)
 
             left = df.copy()
             with catch_warnings(record=True):
                 simplefilter("ignore")
-                left.ix[r, c] = rhs
+                left.ix[label_one, label_two] = rhs
             tm.assert_frame_equal(left, right)
 
         xs = np.arange(20).reshape(5, 4)

--- a/pandas/tests/indexing/test_indexing.py
+++ b/pandas/tests/indexing/test_indexing.py
@@ -768,15 +768,15 @@ class TestMisc(Base):
         # assigned to. covers both uniform data-type & multi-type cases
         def run_tests(df, rhs, right):
             # label, index, slice
-            label_one, index_one, slice_one = list('bcd'), [1, 2, 3], slice(1, 4)
-            label_two, index_two, slice_two = ['joe', 'jolie'], [1, 2], slice(1, 3)
+            lbl_one, idx_one, slice_one = list('bcd'), [1, 2, 3], slice(1, 4)
+            lbl_two, idx_two, slice_two = ['joe', 'jolie'], [1, 2], slice(1, 3)
 
             left = df.copy()
-            left.loc[label_one, label_two] = rhs
+            left.loc[lbl_one, lbl_two] = rhs
             tm.assert_frame_equal(left, right)
 
             left = df.copy()
-            left.iloc[index_one, index_two] = rhs
+            left.iloc[idx_one, idx_two] = rhs
             tm.assert_frame_equal(left, right)
 
             left = df.copy()
@@ -789,13 +789,13 @@ class TestMisc(Base):
             left = df.copy()
             with catch_warnings(record=True):
                 simplefilter("ignore")
-                left.ix[index_one, index_two] = rhs
+                left.ix[idx_one, idx_two] = rhs
             tm.assert_frame_equal(left, right)
 
             left = df.copy()
             with catch_warnings(record=True):
                 simplefilter("ignore")
-                left.ix[label_one, label_two] = rhs
+                left.ix[lbl_one, lbl_two] = rhs
             tm.assert_frame_equal(left, right)
 
         xs = np.arange(20).reshape(5, 4)

--- a/pandas/tests/indexing/test_loc.py
+++ b/pandas/tests/indexing/test_loc.py
@@ -668,10 +668,10 @@ Region_1,Site_2,3977723089,A,5/20/2015 8:33,5/20/2015 9:09,Yes,No"""
                           index=[0] * l2, columns=columns)])
 
         def gen_expected(df, mask):
-            l = len(mask)
+            len_mask = len(mask)
             return pd.concat([df.take([0]),
-                              DataFrame(np.ones((l, len(columns))),
-                                        index=[0] * l,
+                              DataFrame(np.ones((len_mask, len(columns))),
+                                        index=[0] * len_mask,
                                         columns=columns),
                               df.take(mask[1:])])
 

--- a/pandas/tests/io/test_packers.py
+++ b/pandas/tests/io/test_packers.py
@@ -512,27 +512,27 @@ class TestNDFrame(TestPackers):
         for k in self.frame.keys():
             assert_frame_equal(self.frame[k], i_rec[k])
 
-        l = tuple([self.frame['float'], self.frame['float'].A,
+        packed_items = tuple([self.frame['float'], self.frame['float'].A,
                    self.frame['float'].B, None])
-        l_rec = self.encode_decode(l)
-        check_arbitrary(l, l_rec)
+        l_rec = self.encode_decode(packed_items)
+        check_arbitrary(packed_items, l_rec)
 
         # this is an oddity in that packed lists will be returned as tuples
-        l = [self.frame['float'], self.frame['float']
+        packed_items = [self.frame['float'], self.frame['float']
              .A, self.frame['float'].B, None]
-        l_rec = self.encode_decode(l)
+        l_rec = self.encode_decode(packed_items)
         assert isinstance(l_rec, tuple)
-        check_arbitrary(l, l_rec)
+        check_arbitrary(packed_items, l_rec)
 
     def test_iterator(self):
 
-        l = [self.frame['float'], self.frame['float']
+        packed_items = [self.frame['float'], self.frame['float']
              .A, self.frame['float'].B, None]
 
         with ensure_clean(self.path) as path:
-            to_msgpack(path, *l)
+            to_msgpack(path, *packed_items)
             for i, packed in enumerate(read_msgpack(path, iterator=True)):
-                check_arbitrary(packed, l[i])
+                check_arbitrary(packed, packed_items[i])
 
     def tests_datetimeindex_freq_issue(self):
 

--- a/pandas/tests/io/test_packers.py
+++ b/pandas/tests/io/test_packers.py
@@ -513,21 +513,21 @@ class TestNDFrame(TestPackers):
             assert_frame_equal(self.frame[k], i_rec[k])
 
         packed_items = tuple([self.frame['float'], self.frame['float'].A,
-                   self.frame['float'].B, None])
+                              self.frame['float'].B, None])
         l_rec = self.encode_decode(packed_items)
         check_arbitrary(packed_items, l_rec)
 
         # this is an oddity in that packed lists will be returned as tuples
-        packed_items = [self.frame['float'], self.frame['float']
-             .A, self.frame['float'].B, None]
+        packed_items = [self.frame['float'], self.frame['float'].A,
+                        self.frame['float'].B, None]
         l_rec = self.encode_decode(packed_items)
         assert isinstance(l_rec, tuple)
         check_arbitrary(packed_items, l_rec)
 
     def test_iterator(self):
 
-        packed_items = [self.frame['float'], self.frame['float']
-             .A, self.frame['float'].B, None]
+        packed_items = [self.frame['float'], self.frame['float'].A,
+                        self.frame['float'].B, None]
 
         with ensure_clean(self.path) as path:
             to_msgpack(path, *packed_items)

--- a/pandas/tests/io/test_pytables.py
+++ b/pandas/tests/io/test_pytables.py
@@ -2182,14 +2182,14 @@ class TestHDFStore(Base):
 
         with ensure_clean_store(self.path) as store:
 
-            l = [('date', datetime.date(2001, 1, 2))]
+            dtypes = [('date', datetime.date(2001, 1, 2))]
 
             # py3 ok for unicode
             if not compat.PY3:
-                l.append(('unicode', u('\\u03c3')))
+                dtypes.append(('unicode', u('\\u03c3')))
 
             # currently not supported dtypes ####
-            for n, f in l:
+            for n, f in dtypes:
                 df = tm.makeDataFrame()
                 df[n] = f
                 pytest.raises(

--- a/pandas/tests/plotting/common.py
+++ b/pandas/tests/plotting/common.py
@@ -256,8 +256,8 @@ class TestPlotBase(object):
         else:
             labels = [t.get_text() for t in texts]
             assert len(labels) == len(expected)
-            for l, e in zip(labels, expected):
-                assert l == e
+            for label, e in zip(labels, expected):
+                assert label == e
 
     def _check_ticks_props(self, axes, xlabelsize=None, xrot=None,
                            ylabelsize=None, yrot=None):

--- a/pandas/tests/plotting/test_datetimelike.py
+++ b/pandas/tests/plotting/test_datetimelike.py
@@ -542,8 +542,8 @@ class TestTSPlot(TestPlotBase):
         ts.plot(ax=ax)
         lines = ax.get_lines()
         assert len(lines) == 1
-        l = lines[0]
-        data = l.get_xydata()
+        line = lines[0]
+        data = line.get_xydata()
         assert isinstance(data, np.ma.core.MaskedArray)
         mask = data.mask
         assert mask[5:25, 1].all()
@@ -557,8 +557,8 @@ class TestTSPlot(TestPlotBase):
         ax = ts.plot(ax=ax)
         lines = ax.get_lines()
         assert len(lines) == 1
-        l = lines[0]
-        data = l.get_xydata()
+        line = lines[0]
+        data = line.get_xydata()
         assert isinstance(data, np.ma.core.MaskedArray)
         mask = data.mask
         assert mask[2:5, 1].all()
@@ -572,8 +572,8 @@ class TestTSPlot(TestPlotBase):
         ser.plot(ax=ax)
         lines = ax.get_lines()
         assert len(lines) == 1
-        l = lines[0]
-        data = l.get_xydata()
+        line = lines[0]
+        data = line.get_xydata()
         assert isinstance(data, np.ma.core.MaskedArray)
         mask = data.mask
         assert mask[2:5, 1].all()
@@ -592,8 +592,8 @@ class TestTSPlot(TestPlotBase):
         lines = ax.get_lines()
         assert len(lines) == 1
         assert len(ax.right_ax.get_lines()) == 1
-        l = lines[0]
-        data = l.get_xydata()
+        line = lines[0]
+        data = line.get_xydata()
 
         assert isinstance(data, np.ma.core.MaskedArray)
         mask = data.mask
@@ -608,8 +608,8 @@ class TestTSPlot(TestPlotBase):
         assert hasattr(ax, 'left_ax')
         assert not hasattr(ax, 'right_ax')
         axes = fig.get_axes()
-        l = ax.get_lines()[0]
-        xp = Series(l.get_ydata(), l.get_xdata())
+        line = ax.get_lines()[0]
+        xp = Series(line.get_ydata(), line.get_xdata())
         assert_series_equal(ser, xp)
         assert ax.get_yaxis().get_ticks_position() == 'right'
         assert not axes[0].get_yaxis().get_visible()
@@ -639,8 +639,8 @@ class TestTSPlot(TestPlotBase):
         assert hasattr(ax, 'left_ax')
         assert not hasattr(ax, 'right_ax')
         axes = fig.get_axes()
-        l = ax.get_lines()[0]
-        xp = Series(l.get_ydata(), l.get_xdata()).to_timestamp()
+        line = ax.get_lines()[0]
+        xp = Series(line.get_ydata(), line.get_xdata()).to_timestamp()
         assert_series_equal(ser, xp)
         assert ax.get_yaxis().get_ticks_position() == 'right'
         assert not axes[0].get_yaxis().get_visible()
@@ -950,25 +950,25 @@ class TestTSPlot(TestPlotBase):
                                   dtype=np.float64)
             expected_y = np.zeros(len(expected_x), dtype=np.float64)
             for i in range(3):
-                l = ax.lines[i]
-                assert PeriodIndex(l.get_xdata()).freq == idxh.freq
-                tm.assert_numpy_array_equal(l.get_xdata(orig=False),
+                line = ax.lines[i]
+                assert PeriodIndex(line.get_xdata()).freq == idxh.freq
+                tm.assert_numpy_array_equal(line.get_xdata(orig=False),
                                             expected_x)
                 # check stacked values are correct
                 expected_y += low[i].values
-                tm.assert_numpy_array_equal(l.get_ydata(orig=False),
+                tm.assert_numpy_array_equal(line.get_ydata(orig=False),
                                             expected_y)
 
             # check high dataframe result
             expected_x = idxh.to_period().asi8.astype(np.float64)
             expected_y = np.zeros(len(expected_x), dtype=np.float64)
             for i in range(3):
-                l = ax.lines[3 + i]
-                assert PeriodIndex(data=l.get_xdata()).freq == idxh.freq
-                tm.assert_numpy_array_equal(l.get_xdata(orig=False),
+                line = ax.lines[3 + i]
+                assert PeriodIndex(data=line.get_xdata()).freq == idxh.freq
+                tm.assert_numpy_array_equal(line.get_xdata(orig=False),
                                             expected_x)
                 expected_y += high[i].values
-                tm.assert_numpy_array_equal(l.get_ydata(orig=False),
+                tm.assert_numpy_array_equal(line.get_ydata(orig=False),
                                             expected_y)
 
         # high to low
@@ -981,12 +981,12 @@ class TestTSPlot(TestPlotBase):
             expected_x = idxh.to_period().asi8.astype(np.float64)
             expected_y = np.zeros(len(expected_x), dtype=np.float64)
             for i in range(3):
-                l = ax.lines[i]
-                assert PeriodIndex(data=l.get_xdata()).freq == idxh.freq
-                tm.assert_numpy_array_equal(l.get_xdata(orig=False),
+                line = ax.lines[i]
+                assert PeriodIndex(data=line.get_xdata()).freq == idxh.freq
+                tm.assert_numpy_array_equal(line.get_xdata(orig=False),
                                             expected_x)
                 expected_y += high[i].values
-                tm.assert_numpy_array_equal(l.get_ydata(orig=False),
+                tm.assert_numpy_array_equal(line.get_ydata(orig=False),
                                             expected_y)
 
             # check low dataframe result
@@ -995,12 +995,12 @@ class TestTSPlot(TestPlotBase):
                                   dtype=np.float64)
             expected_y = np.zeros(len(expected_x), dtype=np.float64)
             for i in range(3):
-                l = ax.lines[3 + i]
-                assert PeriodIndex(data=l.get_xdata()).freq == idxh.freq
-                tm.assert_numpy_array_equal(l.get_xdata(orig=False),
+                lines = ax.lines[3 + i]
+                assert PeriodIndex(data=lines.get_xdata()).freq == idxh.freq
+                tm.assert_numpy_array_equal(lines.get_xdata(orig=False),
                                             expected_x)
                 expected_y += low[i].values
-                tm.assert_numpy_array_equal(l.get_ydata(orig=False),
+                tm.assert_numpy_array_equal(lines.get_ydata(orig=False),
                                             expected_y)
 
     @pytest.mark.slow

--- a/pandas/tests/plotting/test_frame.py
+++ b/pandas/tests/plotting/test_frame.py
@@ -299,16 +299,16 @@ class TestDataFramePlots(TestPlotBase):
         df = DataFrame({'y': np.arange(100)}, index=np.arange(99, -1, -1),
                        dtype=np.int64)
         ax = df.plot()
-        l = ax.get_lines()[0]
-        rs = l.get_xydata()
+        lines = ax.get_lines()[0]
+        rs = lines.get_xydata()
         rs = Series(rs[:, 1], rs[:, 0], dtype=np.int64, name='y')
         tm.assert_series_equal(rs, df.y, check_index_type=False)
         tm.close()
 
         df.index = pd.Index(np.arange(99, -1, -1), dtype=np.float64)
         ax = df.plot()
-        l = ax.get_lines()[0]
-        rs = l.get_xydata()
+        lines = ax.get_lines()[0]
+        rs = lines.get_xydata()
         rs = Series(rs[:, 1], rs[:, 0], dtype=np.int64, name='y')
         tm.assert_series_equal(rs, df.y)
 

--- a/pandas/tests/series/test_analytics.py
+++ b/pandas/tests/series/test_analytics.py
@@ -539,9 +539,9 @@ class TestSeriesAnalytics(TestData):
             f(s)
 
             # 2888
-            l = [0]
-            l.extend(lrange(2 ** 40, 2 ** 40 + 1000))
-            s = Series(l, dtype='int64')
+            items = [0]
+            items.extend(lrange(2 ** 40, 2 ** 40 + 1000))
+            s = Series(items, dtype='int64')
             assert_almost_equal(float(f(s)), float(alternate(s.values)))
 
             # check date range
@@ -974,12 +974,12 @@ class TestSeriesAnalytics(TestData):
 
         for s in sers:
             thresh = s[2]
-            l = s.clip_lower(thresh)
-            u = s.clip_upper(thresh)
-            assert l[notna(l)].min() == thresh
-            assert u[notna(u)].max() == thresh
-            assert list(isna(s)) == list(isna(l))
-            assert list(isna(s)) == list(isna(u))
+            lower = s.clip_lower(thresh)
+            upper = s.clip_upper(thresh)
+            assert lower[notna(lower)].min() == thresh
+            assert upper[notna(upper)].max() == thresh
+            assert list(isna(s)) == list(isna(lower))
+            assert list(isna(s)) == list(isna(upper))
 
     def test_clip_with_na_args(self):
         """Should process np.nan argument as None """

--- a/pandas/tests/series/test_dtypes.py
+++ b/pandas/tests/series/test_dtypes.py
@@ -270,13 +270,13 @@ class TestSeriesDtypes():
         tm.assert_frame_equal(exp_df, df)
 
         # with keywords
-        items = ["a", "b", "c", "a"]
-        s = Series(items)
-        exp = Series(Categorical(items, ordered=True))
+        lst = ["a", "b", "c", "a"]
+        s = Series(lst)
+        exp = Series(Categorical(lst, ordered=True))
         res = s.astype(CategoricalDtype(None, ordered=True))
         tm.assert_series_equal(res, exp)
 
-        exp = Series(Categorical(items, categories=list('abcdef'), ordered=True))
+        exp = Series(Categorical(lst, categories=list('abcdef'), ordered=True))
         res = s.astype(CategoricalDtype(list('abcdef'), ordered=True))
         tm.assert_series_equal(res, exp)
 

--- a/pandas/tests/series/test_dtypes.py
+++ b/pandas/tests/series/test_dtypes.py
@@ -243,15 +243,15 @@ class TestSeriesDtypes():
         tm.assert_series_equal(result, expected)
 
     def test_astype_from_categorical(self):
-        l = ["a", "b", "c", "a"]
-        s = Series(l)
-        exp = Series(Categorical(l))
+        items = ["a", "b", "c", "a"]
+        s = Series(items)
+        exp = Series(Categorical(items))
         res = s.astype('category')
         tm.assert_series_equal(res, exp)
 
-        l = [1, 2, 3, 1]
-        s = Series(l)
-        exp = Series(Categorical(l))
+        items = [1, 2, 3, 1]
+        s = Series(items)
+        exp = Series(Categorical(items))
         res = s.astype('category')
         tm.assert_series_equal(res, exp)
 
@@ -270,13 +270,13 @@ class TestSeriesDtypes():
         tm.assert_frame_equal(exp_df, df)
 
         # with keywords
-        l = ["a", "b", "c", "a"]
-        s = Series(l)
-        exp = Series(Categorical(l, ordered=True))
+        items = ["a", "b", "c", "a"]
+        s = Series(items)
+        exp = Series(Categorical(items, ordered=True))
         res = s.astype(CategoricalDtype(None, ordered=True))
         tm.assert_series_equal(res, exp)
 
-        exp = Series(Categorical(l, categories=list('abcdef'), ordered=True))
+        exp = Series(Categorical(items, categories=list('abcdef'), ordered=True))
         res = s.astype(CategoricalDtype(list('abcdef'), ordered=True))
         tm.assert_series_equal(res, exp)
 

--- a/pandas/tests/test_algos.py
+++ b/pandas/tests/test_algos.py
@@ -372,8 +372,8 @@ class TestUnique(object):
         tm.assert_numpy_array_equal(algos.unique(s), exp)
 
     def test_nan_in_object_array(self):
-        l = ['a', np.nan, 'c', 'c']
-        result = pd.unique(l)
+        duplicated_items = ['a', np.nan, 'c', 'c']
+        result = pd.unique(duplicated_items)
         expected = np.array(['a', np.nan, 'c'], dtype=object)
         tm.assert_numpy_array_equal(result, expected)
 

--- a/pandas/tests/test_multilevel.py
+++ b/pandas/tests/test_multilevel.py
@@ -2062,14 +2062,14 @@ Thur,Lunch,Yes,51.51,17"""
         df = DataFrame({"a": [1, 2, 3],
                         "b": [4, 5, 6],
                         "c": [7, 8, 9]}).set_index(["a", "b"])
-        l = list(df.index)
-        l[0] = ("faz", "boo")
-        df.index = l
+        index = list(df.index)
+        index[0] = ("faz", "boo")
+        df.index = index
         repr(df)
 
         # this travels an improper code path
-        l[0] = ["faz", "boo"]
-        df.index = l
+        index[0] = ["faz", "boo"]
+        df.index = index
         repr(df)
 
     def test_tuples_have_na(self):

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,7 +18,6 @@ ignore =
     E402,  # module level import not at top of file
     E722,  # do not use bare except
     E731,  # do not assign a lambda expression, use a def
-    E741,  # ambiguous variable name 'l'
     C406,  # Unnecessary list literal - rewrite as a dict literal.
     C408,  # Unnecessary dict call - rewrite as a literal.
     C409   # Unnecessary list passed to tuple() - rewrite as a tuple literal.


### PR DESCRIPTION
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- xref up E741 mentioned on this issue: #22122
- Follow up from this PR: #22913

`flake8 --select E741` now runs clean
