### PR TITLE
DEPR: favour sep over delimiter in pd.read_csv

### DIFF
--- a/doc/source/whatsnew/v0.24.0.txt
+++ b/doc/source/whatsnew/v0.24.0.txt
@@ -911,6 +911,7 @@ Deprecations
 - :meth:`FrozenNDArray.searchsorted` has deprecated the ``v`` parameter in favor of ``value`` (:issue:`14645`)
 - :func:`DatetimeIndex.shift` and :func:`PeriodIndex.shift` now accept ``periods`` argument instead of ``n`` for consistency with :func:`Index.shift` and :func:`Series.shift`. Using ``n`` throws a deprecation warning (:issue:`22458`, :issue:`22912`)
 - The ``fastpath`` keyword of the different Index constructors is deprecated (:issue:`23110`).
+- :meth:`pandas.read_csv` has deprecated the redundant ``delimiter`` argument, please use ``sep`` (:issue:`21996`)
 
 .. _whatsnew_0240.prior_deprecations:
 

--- a/pandas/io/parsers.py
+++ b/pandas/io/parsers.py
@@ -323,7 +323,7 @@ _sep_doc = r"""sep : str, default {default}
     delimiters are prone to ignoring quoted data. Regex example: ``'\r\t'``
 delimiter : str, default ``None``
     Alternative argument name for sep.
-    .. deprecated:: 0.23.4
+    .. deprecated:: 0.24.0
        Use sep argument instead.
     """
 
@@ -640,7 +640,7 @@ def _make_parser_function(name, default_sep=','):
             delimiter = sep
         else:
             warnings.warn("delimiter is deprecated, please use sep instead.",
-                          DeprecationWarning, stacklevel=2)
+                          FutureWarning, stacklevel=2)
 
         if delim_whitespace and delimiter != default_sep:
             raise ValueError("Specified a delimiter with both sep and"

--- a/pandas/io/parsers.py
+++ b/pandas/io/parsers.py
@@ -641,7 +641,7 @@ def _make_parser_function(name, default_sep=','):
         else:
             # GH 21996
             warnings.warn("delimiter is deprecated, use sep instead.",
-                          FutureWarning, stacklevel=2)
+                          FutureWarning, stacklevel=4)
 
         if delim_whitespace and delimiter != default_sep:
             raise ValueError("Specified a delimiter with both sep and"

--- a/pandas/io/parsers.py
+++ b/pandas/io/parsers.py
@@ -639,7 +639,8 @@ def _make_parser_function(name, default_sep=','):
         if delimiter is None:
             delimiter = sep
         else:
-            warnings.warn("delimiter is deprecated, please use sep instead.",
+            # GH 21996
+            warnings.warn("delimiter is deprecated, use sep instead.",
                           FutureWarning, stacklevel=2)
 
         if delim_whitespace and delimiter != default_sep:

--- a/pandas/io/parsers.py
+++ b/pandas/io/parsers.py
@@ -635,6 +635,9 @@ def _make_parser_function(name, default_sep=','):
         # Alias sep -> delimiter.
         if delimiter is None:
             delimiter = sep
+        else:
+            warnings.warn("delimiter is deprecated, please use sep instead.",
+                          DeprecationWarning, stacklevel=2)
 
         if delim_whitespace and delimiter != default_sep:
             raise ValueError("Specified a delimiter with both sep and"

--- a/pandas/io/parsers.py
+++ b/pandas/io/parsers.py
@@ -322,7 +322,10 @@ _sep_doc = r"""sep : str, default {default}
     will also force the use of the Python parsing engine. Note that regex
     delimiters are prone to ignoring quoted data. Regex example: ``'\r\t'``
 delimiter : str, default ``None``
-    Alternative argument name for sep."""
+    Alternative argument name for sep.
+    .. deprecated:: 0.23.4
+       Use sep argument instead.
+    """
 
 _read_csv_doc = """
 Read CSV (comma-separated) file into DataFrame

--- a/pandas/tests/io/parser/c_parser_only.py
+++ b/pandas/tests/io/parser/c_parser_only.py
@@ -410,6 +410,7 @@ No,No,No"""
         tm.assert_frame_equal(result, expected)
 
     @tm.capture_stderr
+    @pytest.mark.filterwarnings('ignore::FutureWarning')
     def test_comment_whitespace_delimited(self):
         test_input = """\
 1 2

--- a/pandas/tests/io/parser/common.py
+++ b/pandas/tests/io/parser/common.py
@@ -1604,3 +1604,9 @@ j,-inF"""
             t = TextIOWrapper(t, encoding='ascii', errors='surrogateescape')
         with pytest.raises(UnicodeError):
             pd.read_csv(t, encoding='UTF-8')
+
+    def test_read_csv_depr_delimiter(self):
+        # GH 21996
+        with tm.assert_produces_warning(FutureWarning,
+                                        check_stacklevel=False):
+            self.read_csv(self.csv2, delimiter=',')

--- a/pandas/tests/io/parser/dialect.py
+++ b/pandas/tests/io/parser/dialect.py
@@ -70,9 +70,9 @@ pear:tomato
         exp = DataFrame({'a': [1], 'b': [2]})
 
         with tm.assert_produces_warning(None):
-            df = self.read_csv(StringIO(data), delimiter=',', dialect=dialect)
+            df = self.read_csv(StringIO(data), sep=',', dialect=dialect)
             tm.assert_frame_equal(df, exp)
 
         with tm.assert_produces_warning(ParserWarning):
-            df = self.read_csv(StringIO(data), delimiter='.', dialect=dialect)
+            df = self.read_csv(StringIO(data), sep='.', dialect=dialect)
             tm.assert_frame_equal(df, exp)

--- a/pandas/tests/io/parser/python_parser_only.py
+++ b/pandas/tests/io/parser/python_parser_only.py
@@ -47,6 +47,7 @@ class PythonParserTests(object):
         with tm.assert_raises_regex(ValueError, msg):
             self.read_csv(StringIO(text), skipfooter=-1)
 
+    @pytest.mark.filterwarnings('ignore::FutureWarning')
     def test_sniff_delimiter(self):
         text = """index|A|B|C
 foo|1|2|3


### PR DESCRIPTION
- [x] closes #21996
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry

following discussion in #21996 and #7662, pandas uses `sep` extensively and in `to_csv` counterpart too. This PR deprecates `delimiter` argument from 0.24.0

comments welcome.