### PR TITLE
BUG: sets in str.cat

### DIFF
--- a/doc/source/whatsnew/v0.24.0.txt
+++ b/doc/source/whatsnew/v0.24.0.txt
@@ -210,6 +210,7 @@ Backwards incompatible API changes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 - A newly constructed empty :class:`DataFrame` with integer as the ``dtype`` will now only be cast to ``float64`` if ``index`` is specified (:issue:`22858`)
+- :meth:`Series.str.cat` will now raise if `others` is a `set` (:issue:`23009`)
 
 .. _whatsnew_0240.api_breaking.deps:
 
@@ -976,7 +977,7 @@ Numeric
 Strings
 ^^^^^^^
 
-- Bug in :meth:`Series.str.cat` which falsely did not raise if `others` was a `set` (:issue:`23009`)
+-
 -
 -
 

--- a/doc/source/whatsnew/v0.24.0.txt
+++ b/doc/source/whatsnew/v0.24.0.txt
@@ -976,7 +976,7 @@ Numeric
 Strings
 ^^^^^^^
 
--
+- Bug in :meth:`Series.str.cat` which falsely did not raise if `others` was a `set` (:issue:`23009`)
 -
 -
 

--- a/pandas/core/strings.py
+++ b/pandas/core/strings.py
@@ -1996,12 +1996,12 @@ class StringMethods(NoNewAttributesMixin):
         elif isinstance(others, np.ndarray) and others.ndim == 2:
             others = DataFrame(others, index=idx)
             return ([others[x] for x in others], False)
-        elif is_list_like(others):
+        elif is_list_like(others) and not isinstance(others, set):
             others = list(others)  # ensure iterators do not get read twice etc
 
             # in case of list-like `others`, all elements must be
             # either one-dimensional list-likes or scalars
-            if all(is_list_like(x) for x in others):
+            if all(is_list_like(x) and not isinstance(x, set) for x in others):
                 los = []
                 join_warn = False
                 depr_warn = False

--- a/pandas/core/strings.py
+++ b/pandas/core/strings.py
@@ -1996,12 +1996,12 @@ class StringMethods(NoNewAttributesMixin):
         elif isinstance(others, np.ndarray) and others.ndim == 2:
             others = DataFrame(others, index=idx)
             return ([others[x] for x in others], False)
-        elif is_list_like(others) and not isinstance(others, set):
+        elif is_list_like(others, allow_sets=False):
             others = list(others)  # ensure iterators do not get read twice etc
 
             # in case of list-like `others`, all elements must be
             # either one-dimensional list-likes or scalars
-            if all(is_list_like(x) and not isinstance(x, set) for x in others):
+            if all(is_list_like(x, allow_sets=False) for x in others):
                 los = []
                 join_warn = False
                 depr_warn = False

--- a/pandas/tests/test_strings.py
+++ b/pandas/tests/test_strings.py
@@ -302,10 +302,12 @@ class TestStringMethods(object):
             s.str.cat([u, [u, d]])
 
         # forbidden input type: set
+        # GH 23009
         with tm.assert_raises_regex(TypeError, rgx):
             s.str.cat(set(u))
 
         # forbidden input type: set in list
+        # GH 23009
         with tm.assert_raises_regex(TypeError, rgx):
             s.str.cat([u, set(u)])
 

--- a/pandas/tests/test_strings.py
+++ b/pandas/tests/test_strings.py
@@ -301,7 +301,15 @@ class TestStringMethods(object):
         with tm.assert_raises_regex(TypeError, rgx):
             s.str.cat([u, [u, d]])
 
-        # forbidden input type, e.g. int
+        # forbidden input type: set
+        with tm.assert_raises_regex(TypeError, rgx):
+            s.str.cat(set(u))
+
+        # forbidden input type: set in list
+        with tm.assert_raises_regex(TypeError, rgx):
+            s.str.cat([u, set(u)])
+
+        # other forbidden input type, e.g. int
         with tm.assert_raises_regex(TypeError, rgx):
             s.str.cat(1)
 


### PR DESCRIPTION
- [x] closes #23009
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry

This is split off from #23065.