### PR TITLE
CLN import from pandas.core.arrays when possible

### DIFF
--- a/pandas/core/arrays/datetimes.py
+++ b/pandas/core/arrays/datetimes.py
@@ -508,7 +508,7 @@ class DatetimeArrayMixin(dtl.DatetimeLikeArrayMixin):
         The result's name is set outside of _add_delta by the calling
         method (__add__ or __sub__)
         """
-        from pandas.core.arrays.timedeltas import TimedeltaArrayMixin
+        from pandas.core.arrays import TimedeltaArrayMixin
 
         if isinstance(delta, (Tick, timedelta, np.timedelta64)):
             new_values = self._add_delta_td(delta)
@@ -803,7 +803,7 @@ class DatetimeArrayMixin(dtl.DatetimeLikeArrayMixin):
         pandas.PeriodIndex: Immutable ndarray holding ordinal values
         pandas.DatetimeIndex.to_pydatetime: Return DatetimeIndex as object
         """
-        from pandas.core.arrays.period import PeriodArrayMixin
+        from pandas.core.arrays import PeriodArrayMixin
 
         if self.tz is not None:
             warnings.warn("Converting to PeriodArray/Index representation "

--- a/pandas/core/arrays/period.py
+++ b/pandas/core/arrays/period.py
@@ -302,7 +302,7 @@ class PeriodArrayMixin(DatetimeLikeArrayMixin):
         -------
         DatetimeArray/Index
         """
-        from pandas.core.arrays.datetimes import DatetimeArrayMixin
+        from pandas.core.arrays import DatetimeArrayMixin
 
         how = libperiod._validate_end_alias(how)
 

--- a/pandas/core/groupby/generic.py
+++ b/pandas/core/groupby/generic.py
@@ -44,7 +44,7 @@ from pandas.core.frame import DataFrame
 from pandas.core.dtypes.cast import maybe_downcast_to_dtype
 from pandas.core.base import SpecificationError, DataError
 from pandas.core.index import Index, MultiIndex, CategoricalIndex
-from pandas.core.arrays.categorical import Categorical
+from pandas.core.arrays import Categorical
 from pandas.core.internals import BlockManager, make_block
 from pandas.compat.numpy import _np_version_under1p13
 

--- a/pandas/tests/arrays/test_datetimelike.py
+++ b/pandas/tests/arrays/test_datetimelike.py
@@ -5,9 +5,9 @@ import pytest
 import pandas as pd
 import pandas.util.testing as tm
 
-from pandas.core.arrays.datetimes import DatetimeArrayMixin
-from pandas.core.arrays.timedeltas import TimedeltaArrayMixin
-from pandas.core.arrays.period import PeriodArrayMixin
+from pandas.core.arrays import (DatetimeArrayMixin,
+                                TimedeltaArrayMixin,
+                                PeriodArrayMixin)
 
 
 # TODO: more freq variants


### PR DESCRIPTION
- [ ] closes #xxxx
- [X] tests added / passed
- [X] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

`pandas.core.arrays.__init__.py` imports some classes by default, so other classes can import directly from `pandas.core.arrays` instead of accessing the specific files