### PR TITLE
[WIP] Validate PEP-8 in docstrings

### DIFF
--- a/doc/source/whatsnew/v0.24.0.txt
+++ b/doc/source/whatsnew/v0.24.0.txt
@@ -201,6 +201,7 @@ Other Enhancements
 - :meth:`Index.to_frame` now supports overriding column name(s) (:issue:`22580`).
 - New attribute :attr:`__git_version__` will return git commit sha of current build (:issue:`21295`).
 - Compatibility with Matplotlib 3.0 (:issue:`22790`).
+- Validate docstring examples are PEP-8 compliant (:issue:`23154`)
 
 .. _whatsnew_0240.api_breaking:
 

--- a/scripts/validate_docstrings.py
+++ b/scripts/validate_docstrings.py
@@ -540,7 +540,6 @@ def validate_one(func_name):
                 errs.append('{}: {} {}:{}:{}'.format(
                     code, text, func_name, line_number, offset))
 
-    doc = Docstring(func_name)
     return {'type': doc.type,
             'docstring': doc.clean_doc,
             'deprecated': doc.deprecated,


### PR DESCRIPTION
- [ ] closes #23154 
- [ ] tests added
- [x] tests passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry

### Potential blocks to closing
- Adds dev dependency on pycodestyle, as I couldn't get the other libraries (such as pyflakes) to accept a string for PEP-8 validation, they all expect file names to read.
- When printing the PEP-8 violations, the line numbers printed are with respect to the Example heading, e.g. the first example `>>> ...` is line 1. I tried reporting the actual file line number using doctest.Example.lineno, but it fails to report the correct line number when the docstring is defined outside of the function/method, and possibly modified as well? (e.g. pandas.io.excel.read_excel)

### Tests added / passed
- I haven't added tests yet, but plan to add some with PEP-8 violations to `test_validate_docstrings.py`

### whatsnew
- This is my first PR, not sure if I did this as expected

