### PR TITLE
Check boundary undefined with non-default close parameter for DatetimeIndex #23198

### DIFF
--- a/pandas/core/arrays/datetimes.py
+++ b/pandas/core/arrays/datetimes.py
@@ -239,7 +239,7 @@ class DatetimeArrayMixin(dtl.DatetimeLikeArrayMixin):
         if end is not None:
             end = Timestamp(end)
 
-        if start is None and end is None:
+        if start is None or end is None:
             if closed is not None:
                 raise ValueError("Closed has to be None if not both of start"
                                  "and end are defined")


### PR DESCRIPTION
- [X] closes #23198 
- [ ] tests added / passed
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
