### PR TITLE
CLN:Remove unused **kwargs from user facing methods

### DIFF
--- a/pandas/core/groupby/groupby.py
+++ b/pandas/core/groupby/groupby.py
@@ -1755,8 +1755,7 @@ class GroupBy(_GroupBy):
         if axis != 0:
             return self.apply(lambda x: np.minimum.accumulate(x, axis))
 
-        return self._cython_transform('cummin',
-                                      numeric_only=kwargs.get('numeric_only') or False)
+        return self._cython_transform('cummin', numeric_only=False)
 
     @Substitution(name='groupby')
     @Appender(_doc_template)
@@ -1765,8 +1764,7 @@ class GroupBy(_GroupBy):
         if axis != 0:
             return self.apply(lambda x: np.maximum.accumulate(x, axis))
 
-        return self._cython_transform('cummax',
-                                      numeric_only=kwargs.get('numeric_only') or False)
+        return self._cython_transform('cummax', numeric_only=False)
 
     def _get_cythonized_result(self, how, grouper, aggregate=False,
                                cython_dtype=None, needs_values=False,

--- a/pandas/core/groupby/groupby.py
+++ b/pandas/core/groupby/groupby.py
@@ -1755,7 +1755,7 @@ class GroupBy(_GroupBy):
         if axis != 0:
             return self.apply(lambda x: np.minimum.accumulate(x, axis))
 
-        if kwargs:
+        if kwargs.get('numeric_only') or False:
             numeric_only = kwargs.get('numeric_only')
         else:
             numeric_only = False

--- a/pandas/core/groupby/groupby.py
+++ b/pandas/core/groupby/groupby.py
@@ -1755,7 +1755,12 @@ class GroupBy(_GroupBy):
         if axis != 0:
             return self.apply(lambda x: np.minimum.accumulate(x, axis))
 
-        return self._cython_transform('cummin', numeric_only=False)
+        if kwargs:
+            numeric_only = kwargs.get('numeric_only')
+        else:
+            numeric_only = False
+
+        return self._cython_transform('cummin', numeric_only=numeric_only)
 
     @Substitution(name='groupby')
     @Appender(_doc_template)
@@ -1764,7 +1769,12 @@ class GroupBy(_GroupBy):
         if axis != 0:
             return self.apply(lambda x: np.maximum.accumulate(x, axis))
 
-        return self._cython_transform('cummax', numeric_only=False)
+        if kwargs:
+            numeric_only = kwargs.get('numeric_only')
+        else:
+            numeric_only = False
+
+        return self._cython_transform('cummax', numeric_only=numeric_only)
 
     def _get_cythonized_result(self, how, grouper, aggregate=False,
                                cython_dtype=None, needs_values=False,

--- a/pandas/core/groupby/groupby.py
+++ b/pandas/core/groupby/groupby.py
@@ -1755,12 +1755,8 @@ class GroupBy(_GroupBy):
         if axis != 0:
             return self.apply(lambda x: np.minimum.accumulate(x, axis))
 
-        if kwargs.get('numeric_only') or False:
-            numeric_only = kwargs.get('numeric_only')
-        else:
-            numeric_only = False
-
-        return self._cython_transform('cummin', numeric_only=numeric_only)
+        return self._cython_transform('cummin',
+                                      numeric_only=kwargs.get('numeric_only') or False)
 
     @Substitution(name='groupby')
     @Appender(_doc_template)
@@ -1769,12 +1765,8 @@ class GroupBy(_GroupBy):
         if axis != 0:
             return self.apply(lambda x: np.maximum.accumulate(x, axis))
 
-        if kwargs:
-            numeric_only = kwargs.get('numeric_only')
-        else:
-            numeric_only = False
-
-        return self._cython_transform('cummax', numeric_only=numeric_only)
+        return self._cython_transform('cummax',
+                                      numeric_only=kwargs.get('numeric_only') or False)
 
     def _get_cythonized_result(self, how, grouper, aggregate=False,
                                cython_dtype=None, needs_values=False,

--- a/pandas/io/pytables.py
+++ b/pandas/io/pytables.py
@@ -3971,7 +3971,8 @@ class AppendableTable(LegacyTable):
 
         # create the axes
         self.create_axes(axes=axes, obj=obj, validate=append,
-                         min_itemsize=min_itemsize, **kwargs)
+                         min_itemsize=min_itemsize,
+                         **kwargs)
 
         for a in self.axes:
             a.validate(self, append)

--- a/pandas/io/pytables.py
+++ b/pandas/io/pytables.py
@@ -1404,7 +1404,7 @@ class HDFStore(StringMixin):
             )
 
         # write the object
-        s.write(obj=value, append=append, complib=complib, **kwargs)
+        s.write(obj=value, append=append, complib=complib)
 
         if s.is_table and index:
             s.create_index(columns=index)

--- a/pandas/io/pytables.py
+++ b/pandas/io/pytables.py
@@ -688,7 +688,7 @@ class HDFStore(StringMixin):
         return self._read_group(group)
 
     def select(self, key, where=None, start=None, stop=None, columns=None,
-               iterator=False, chunksize=None, auto_close=False):
+               iterator=False, chunksize=None, auto_close=False, **kwargs):
         """
         Retrieve pandas object stored in file, optionally based on where
         criteria
@@ -1404,7 +1404,7 @@ class HDFStore(StringMixin):
             )
 
         # write the object
-        s.write(obj=value, append=append, complib=complib)
+        s.write(obj=value, append=append, complib=complib, **kwargs)
 
         if s.is_table and index:
             s.create_index(columns=index)
@@ -3451,7 +3451,7 @@ class Table(Fixed):
         return [c for c in data_columns if c in axis_labels]
 
     def create_axes(self, axes, obj, validate=True, nan_rep=None,
-                    data_columns=None, min_itemsize=None):
+                    data_columns=None, min_itemsize=None, **kwargs):
         """ create and return the axes
         leagcy tables create an indexable column, indexable index,
         non-indexable fields
@@ -3964,14 +3964,14 @@ class AppendableTable(LegacyTable):
 
     def write(self, obj, axes=None, append=False, complib=None,
               complevel=None, fletcher32=None, min_itemsize=None,
-              chunksize=None, expectedrows=None, dropna=False):
+              chunksize=None, expectedrows=None, dropna=False, **kwargs):
 
         if not append and self.is_exists:
             self._handle.remove_node(self.group, 'table')
 
         # create the axes
         self.create_axes(axes=axes, obj=obj, validate=append,
-                         min_itemsize=min_itemsize)
+                         min_itemsize=min_itemsize, **kwargs)
 
         for a in self.axes:
             a.validate(self, append)

--- a/pandas/io/pytables.py
+++ b/pandas/io/pytables.py
@@ -706,6 +706,9 @@ class HDFStore(StringMixin):
         auto_close : boolean, should automatically close the store when
             finished, default is False
 
+        kwargs
+            Additional keyword arguments passed to Storer
+
         Returns
         -------
         The selected object
@@ -717,7 +720,7 @@ class HDFStore(StringMixin):
 
         # create the storer and axes
         where = _ensure_term(where, scope_level=1)
-        s = self._create_storer(group)
+        s = self._create_storer(group, **kwargs)
         s.infer_axes()
 
         # function to call on iteration
@@ -1674,7 +1677,7 @@ class IndexCol(StringMixin):
     def __iter__(self):
         return iter(self.values)
 
-    def maybe_set_size(self, min_itemsize=None, **kwargs):
+    def maybe_set_size(self, min_itemsize=None):
         """ maybe set a string col itemsize:
                min_itemsize can be an integer or a dict with this columns name
                with an integer size """
@@ -1687,13 +1690,13 @@ class IndexCol(StringMixin):
                 self.typ = _tables(
                 ).StringCol(itemsize=min_itemsize, pos=self.pos)
 
-    def validate(self, handler, append, **kwargs):
+    def validate(self, handler, append):
         self.validate_names()
 
     def validate_names(self):
         pass
 
-    def validate_and_set(self, handler, append, **kwargs):
+    def validate_and_set(self, handler, append):
         self.set_table(handler.table)
         self.validate_col()
         self.validate_attr(append)
@@ -3451,7 +3454,7 @@ class Table(Fixed):
         return [c for c in data_columns if c in axis_labels]
 
     def create_axes(self, axes, obj, validate=True, nan_rep=None,
-                    data_columns=None, min_itemsize=None, **kwargs):
+                    data_columns=None, min_itemsize=None):
         """ create and return the axes
         leagcy tables create an indexable column, indexable index,
         non-indexable fields
@@ -3772,7 +3775,7 @@ class Table(Fixed):
 
         return Index(coords)
 
-    def read_column(self, column, where=None, start=None, stop=None, **kwargs):
+    def read_column(self, column, where=None, start=None, stop=None):
         """return a single column from the table, generally only indexables
         are interesting
         """
@@ -4727,7 +4730,7 @@ class Selection(object):
 
     """
 
-    def __init__(self, table, where=None, start=None, stop=None, **kwargs):
+    def __init__(self, table, where=None, start=None, stop=None):
         self.table = table
         self.where = where
         self.start = start

--- a/pandas/io/pytables.py
+++ b/pandas/io/pytables.py
@@ -688,7 +688,7 @@ class HDFStore(StringMixin):
         return self._read_group(group)
 
     def select(self, key, where=None, start=None, stop=None, columns=None,
-               iterator=False, chunksize=None, auto_close=False, **kwargs):
+               iterator=False, chunksize=None, auto_close=False):
         """
         Retrieve pandas object stored in file, optionally based on where
         criteria
@@ -706,9 +706,6 @@ class HDFStore(StringMixin):
         auto_close : boolean, should automatically close the store when
             finished, default is False
 
-        kwargs
-            Additional keyword arguments passed to Storer
-
         Returns
         -------
         The selected object
@@ -720,7 +717,7 @@ class HDFStore(StringMixin):
 
         # create the storer and axes
         where = _ensure_term(where, scope_level=1)
-        s = self._create_storer(group, **kwargs)
+        s = self._create_storer(group)
         s.infer_axes()
 
         # function to call on iteration

--- a/pandas/io/pytables.py
+++ b/pandas/io/pytables.py
@@ -3967,15 +3967,14 @@ class AppendableTable(LegacyTable):
 
     def write(self, obj, axes=None, append=False, complib=None,
               complevel=None, fletcher32=None, min_itemsize=None,
-              chunksize=None, expectedrows=None, dropna=False, **kwargs):
+              chunksize=None, expectedrows=None, dropna=False):
 
         if not append and self.is_exists:
             self._handle.remove_node(self.group, 'table')
 
         # create the axes
         self.create_axes(axes=axes, obj=obj, validate=append,
-                         min_itemsize=min_itemsize,
-                         **kwargs)
+                         min_itemsize=min_itemsize)
 
         for a in self.axes:
             a.validate(self, append)


### PR DESCRIPTION
closes GH18748 for user facing methods.

An updated [extra_kwargs.txt](https://github.com/pandas-dev/pandas/files/2498300/extra_kwargs.txt) mostly shows internal functions and false positives. 

There are a few cases like all of the `visit_*` functions that removing the `**kwargs` breaks the API. 

- [ ] xref #18748 
- [x ] tests added / passed
- [x ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry - N/A only code cleanup. 
