### PR TITLE
ENH: Allow keep="all" in duplicated method (#23251)

### DIFF
--- a/doc/source/whatsnew/v0.24.0.txt
+++ b/doc/source/whatsnew/v0.24.0.txt
@@ -194,6 +194,7 @@ Other Enhancements
 - :meth:`Index.to_frame` now supports overriding column name(s) (:issue:`22580`).
 - New attribute :attr:`__git_version__` will return git commit sha of current build (:issue:`21295`).
 - Compatibility with Matplotlib 3.0 (:issue:`22790`).
+- :meth:`DataFrame.duplicated`, :meth:`Series.duplicated`, :meth:`Index.duplicated`, :meth:`MultiIndex.duplicated` now accept ``keep='all'`` to keep all duplicated values (:issue:`23251`)
 
 .. _whatsnew_0240.api_breaking:
 

--- a/pandas/_libs/hashtable_func_helper.pxi.in
+++ b/pandas/_libs/hashtable_func_helper.pxi.in
@@ -145,8 +145,8 @@ def duplicated_{{dtype}}({{scalar}}[:] values, object keep='first'):
 
     kh_resize_{{ttype}}(table, min(n, _SIZE_HINT_LIMIT))
 
-    if keep not in ('last', 'first', False):
-        raise ValueError('keep must be either "first", "last" or False')
+    if keep not in ('last', 'first', 'all', False):
+        raise ValueError('keep must be either "first", "last", "all" or False')
 
     if keep == 'last':
         {{if dtype == 'object'}}

--- a/pandas/core/algorithms.py
+++ b/pandas/core/algorithms.py
@@ -786,7 +786,7 @@ def duplicated(values, keep='first'):
           occurrence.
         - ``last`` : Mark duplicates as ``True`` except for the last
           occurrence.
-        - False : Mark all duplicates as ``True``.
+        - ``all``, False : Mark all duplicates as ``True``.
 
     Returns
     -------

--- a/pandas/core/base.py
+++ b/pandas/core/base.py
@@ -1252,6 +1252,9 @@ class IndexOpsMixin(object):
             if self.is_unique:
                 return self._shallow_copy()
 
+        if keep not in ['first', 'last', False]:
+            raise ValueError('keep must be either "first", "last" or False')
+
         duplicated = self.duplicated(keep=keep)
         result = self[np.logical_not(duplicated)]
         if inplace:

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -4414,6 +4414,9 @@ class DataFrame(NDFrame):
         if self.empty:
             return self.copy()
 
+        if keep not in ['first', 'last', False]:
+            raise ValueError('keep must be either "first", "last" or False')
+
         inplace = validate_bool_kwarg(inplace, 'inplace')
         duplicated = self.duplicated(subset, keep=keep)
 
@@ -4439,7 +4442,7 @@ class DataFrame(NDFrame):
               first occurrence.
             - ``last`` : Mark duplicates as ``True`` except for the
               last occurrence.
-            - False : Mark all duplicates as ``True``.
+            - ``all``, False : Mark all duplicates as ``True``.
 
         Returns
         -------

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -4592,7 +4592,7 @@ class Index(IndexOpsMixin, PandasObject):
               occurrence.
             - 'last' : Mark duplicates as ``True`` except for the last
               occurrence.
-            - ``False`` : Mark all duplicates as ``True``.
+            - 'all', ``False`` : Mark all duplicates as ``True``.
 
         Examples
         --------

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -1600,7 +1600,7 @@ class Series(base.IndexOpsMixin, generic.NDFrame):
               occurrence.
             - 'last' : Mark duplicates as ``True`` except for the last
               occurrence.
-            - ``False`` : Mark all duplicates as ``True``.
+            - 'all', ``False`` : Mark all duplicates as ``True``.
 
         Examples
         --------

--- a/pandas/tests/frame/test_duplicates.py
+++ b/pandas/tests/frame/test_duplicates.py
@@ -46,6 +46,7 @@ def test_duplicated_do_not_fail_on_wide_dataframes():
 @pytest.mark.parametrize('keep, expected', [
     ('first', Series([False, False, True, False, True])),
     ('last', Series([True, True, False, False, False])),
+    ('all', Series([True, True, True, False, True])),
     (False, Series([True, True, True, False, True]))
 ])
 def test_duplicated_keep(keep, expected):
@@ -60,6 +61,7 @@ def test_duplicated_keep(keep, expected):
 @pytest.mark.parametrize('keep, expected', [
     ('first', Series([False, False, True, False, True])),
     ('last', Series([True, True, False, False, False])),
+    ('all', Series([True, True, True, False, True])),
     (False, Series([True, True, True, False, True]))
 ])
 def test_duplicated_nan_none(keep, expected):

--- a/pandas/tests/indexes/multi/test_duplicates.py
+++ b/pandas/tests/indexes/multi/test_duplicates.py
@@ -214,6 +214,7 @@ def test_has_duplicates_overflow():
 @pytest.mark.parametrize('keep, expected', [
     ('first', np.array([False, False, False, True, True, False])),
     ('last', np.array([False, True, True, False, False, False])),
+    ('all', np.array([False, True, True, True, True, False])),
     (False, np.array([False, True, True, True, True, False]))
 ])
 def test_duplicated(idx_dup, keep, expected):
@@ -221,7 +222,7 @@ def test_duplicated(idx_dup, keep, expected):
     tm.assert_numpy_array_equal(result, expected)
 
 
-@pytest.mark.parametrize('keep', ['first', 'last', False])
+@pytest.mark.parametrize('keep', ['first', 'last', 'all', False])
 def test_duplicated_large(keep):
     # GH 9125
     n, k = 200, 5000

--- a/pandas/tests/series/test_duplicates.py
+++ b/pandas/tests/series/test_duplicates.py
@@ -119,6 +119,7 @@ def test_drop_duplicates_bool(keep, expected):
 @pytest.mark.parametrize('keep, expected', [
     ('first', Series([False, False, True, False, True], name='name')),
     ('last', Series([True, True, False, False, False], name='name')),
+    ('all', Series([True, True, True, False, True], name='name')),
     (False, Series([True, True, True, False, True], name='name'))
 ])
 def test_duplicated_keep(keep, expected):
@@ -131,6 +132,7 @@ def test_duplicated_keep(keep, expected):
 @pytest.mark.parametrize('keep, expected', [
     ('first', Series([False, False, True, False, True])),
     ('last', Series([True, True, False, False, False])),
+    ('all', Series([True, True, True, False, True])),
     (False, Series([True, True, True, False, True]))
 ])
 def test_duplicated_nan_none(keep, expected):


### PR DESCRIPTION
- [ ] closes #23251
- [ ] tests added / passed
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

Unfortunately this didn't end up being as clean as I had hoped (due to preventing keep="all" being allowed when calling implicitly through drop_duplicates. So put in a bit of duplication of error handling. Happy to take suggestions if there's a better approach.