### PR TITLE
TST: stricter monotonicity/uniqueness tests

### DIFF
--- a/pandas/tests/indexes/multi/test_monotonic.py
+++ b/pandas/tests/indexes/multi/test_monotonic.py
@@ -9,31 +9,31 @@ from pandas import Index, IntervalIndex, MultiIndex
 def test_is_monotonic_increasing():
     i = MultiIndex.from_product([np.arange(10),
                                  np.arange(10)], names=['one', 'two'])
-    assert i.is_monotonic
-    assert i._is_strictly_monotonic_increasing
-    assert Index(i.values).is_monotonic
-    assert i._is_strictly_monotonic_increasing
+    assert i.is_monotonic is True
+    assert i._is_strictly_monotonic_increasing is True
+    assert Index(i.values).is_monotonic is True
+    assert i._is_strictly_monotonic_increasing is True
 
     i = MultiIndex.from_product([np.arange(10, 0, -1),
                                  np.arange(10)], names=['one', 'two'])
-    assert not i.is_monotonic
-    assert not i._is_strictly_monotonic_increasing
-    assert not Index(i.values).is_monotonic
-    assert not Index(i.values)._is_strictly_monotonic_increasing
+    assert i.is_monotonic is False
+    assert i._is_strictly_monotonic_increasing is False
+    assert Index(i.values).is_monotonic is False
+    assert Index(i.values)._is_strictly_monotonic_increasing is False
 
     i = MultiIndex.from_product([np.arange(10),
                                  np.arange(10, 0, -1)],
                                 names=['one', 'two'])
-    assert not i.is_monotonic
-    assert not i._is_strictly_monotonic_increasing
-    assert not Index(i.values).is_monotonic
-    assert not Index(i.values)._is_strictly_monotonic_increasing
+    assert i.is_monotonic is False
+    assert i._is_strictly_monotonic_increasing is False
+    assert Index(i.values).is_monotonic is False
+    assert Index(i.values)._is_strictly_monotonic_increasing is False
 
     i = MultiIndex.from_product([[1.0, np.nan, 2.0], ['a', 'b', 'c']])
-    assert not i.is_monotonic
-    assert not i._is_strictly_monotonic_increasing
-    assert not Index(i.values).is_monotonic
-    assert not Index(i.values)._is_strictly_monotonic_increasing
+    assert i.is_monotonic is False
+    assert i._is_strictly_monotonic_increasing is False
+    assert Index(i.values).is_monotonic is False
+    assert Index(i.values)._is_strictly_monotonic_increasing is False
 
     # string ordering
     i = MultiIndex(levels=[['foo', 'bar', 'baz', 'qux'],
@@ -41,20 +41,20 @@ def test_is_monotonic_increasing():
                    labels=[[0, 0, 0, 1, 1, 2, 2, 3, 3, 3],
                            [0, 1, 2, 0, 1, 1, 2, 0, 1, 2]],
                    names=['first', 'second'])
-    assert not i.is_monotonic
-    assert not Index(i.values).is_monotonic
-    assert not i._is_strictly_monotonic_increasing
-    assert not Index(i.values)._is_strictly_monotonic_increasing
+    assert i.is_monotonic is False
+    assert Index(i.values).is_monotonic is False
+    assert i._is_strictly_monotonic_increasing is False
+    assert Index(i.values)._is_strictly_monotonic_increasing is False
 
     i = MultiIndex(levels=[['bar', 'baz', 'foo', 'qux'],
                            ['mom', 'next', 'zenith']],
                    labels=[[0, 0, 0, 1, 1, 2, 2, 3, 3, 3],
                            [0, 1, 2, 0, 1, 1, 2, 0, 1, 2]],
                    names=['first', 'second'])
-    assert i.is_monotonic
-    assert Index(i.values).is_monotonic
-    assert i._is_strictly_monotonic_increasing
-    assert Index(i.values)._is_strictly_monotonic_increasing
+    assert i.is_monotonic is True
+    assert Index(i.values).is_monotonic is True
+    assert i._is_strictly_monotonic_increasing is True
+    assert Index(i.values)._is_strictly_monotonic_increasing is True
 
     # mixed levels, hits the TypeError
     i = MultiIndex(
@@ -64,46 +64,46 @@ def test_is_monotonic_increasing():
         labels=[[0, 1, 1, 2, 2, 2, 3], [4, 2, 0, 0, 1, 3, -1]],
         names=['household_id', 'asset_id'])
 
-    assert not i.is_monotonic
-    assert not i._is_strictly_monotonic_increasing
+    assert i.is_monotonic is False
+    assert i._is_strictly_monotonic_increasing is False
 
     # empty
     i = MultiIndex.from_arrays([[], []])
-    assert i.is_monotonic
-    assert Index(i.values).is_monotonic
-    assert i._is_strictly_monotonic_increasing
-    assert Index(i.values)._is_strictly_monotonic_increasing
+    assert i.is_monotonic is True
+    assert Index(i.values).is_monotonic is True
+    assert i._is_strictly_monotonic_increasing is True
+    assert Index(i.values)._is_strictly_monotonic_increasing is True
 
 
 def test_is_monotonic_decreasing():
     i = MultiIndex.from_product([np.arange(9, -1, -1),
                                  np.arange(9, -1, -1)],
                                 names=['one', 'two'])
-    assert i.is_monotonic_decreasing
-    assert i._is_strictly_monotonic_decreasing
-    assert Index(i.values).is_monotonic_decreasing
-    assert i._is_strictly_monotonic_decreasing
+    assert i.is_monotonic_decreasing is True
+    assert i._is_strictly_monotonic_decreasing is True
+    assert Index(i.values).is_monotonic_decreasing is True
+    assert i._is_strictly_monotonic_decreasing is True
 
     i = MultiIndex.from_product([np.arange(10),
                                  np.arange(10, 0, -1)],
                                 names=['one', 'two'])
-    assert not i.is_monotonic_decreasing
-    assert not i._is_strictly_monotonic_decreasing
-    assert not Index(i.values).is_monotonic_decreasing
-    assert not Index(i.values)._is_strictly_monotonic_decreasing
+    assert i.is_monotonic_decreasing is False
+    assert i._is_strictly_monotonic_decreasing is False
+    assert Index(i.values).is_monotonic_decreasing is False
+    assert Index(i.values)._is_strictly_monotonic_decreasing is False
 
     i = MultiIndex.from_product([np.arange(10, 0, -1),
                                  np.arange(10)], names=['one', 'two'])
-    assert not i.is_monotonic_decreasing
-    assert not i._is_strictly_monotonic_decreasing
-    assert not Index(i.values).is_monotonic_decreasing
-    assert not Index(i.values)._is_strictly_monotonic_decreasing
+    assert i.is_monotonic_decreasing is False
+    assert i._is_strictly_monotonic_decreasing is False
+    assert Index(i.values).is_monotonic_decreasing is False
+    assert Index(i.values)._is_strictly_monotonic_decreasing is False
 
     i = MultiIndex.from_product([[2.0, np.nan, 1.0], ['c', 'b', 'a']])
-    assert not i.is_monotonic_decreasing
-    assert not i._is_strictly_monotonic_decreasing
-    assert not Index(i.values).is_monotonic_decreasing
-    assert not Index(i.values)._is_strictly_monotonic_decreasing
+    assert i.is_monotonic_decreasing is False
+    assert i._is_strictly_monotonic_decreasing is False
+    assert Index(i.values).is_monotonic_decreasing is False
+    assert Index(i.values)._is_strictly_monotonic_decreasing is False
 
     # string ordering
     i = MultiIndex(levels=[['qux', 'foo', 'baz', 'bar'],
@@ -111,20 +111,20 @@ def test_is_monotonic_decreasing():
                    labels=[[0, 0, 0, 1, 1, 2, 2, 3, 3, 3],
                            [0, 1, 2, 0, 1, 1, 2, 0, 1, 2]],
                    names=['first', 'second'])
-    assert not i.is_monotonic_decreasing
-    assert not Index(i.values).is_monotonic_decreasing
-    assert not i._is_strictly_monotonic_decreasing
-    assert not Index(i.values)._is_strictly_monotonic_decreasing
+    assert i.is_monotonic_decreasing is False
+    assert Index(i.values).is_monotonic_decreasing is False
+    assert i._is_strictly_monotonic_decreasing is False
+    assert Index(i.values)._is_strictly_monotonic_decreasing is False
 
     i = MultiIndex(levels=[['qux', 'foo', 'baz', 'bar'],
                            ['zenith', 'next', 'mom']],
                    labels=[[0, 0, 0, 1, 1, 2, 2, 3, 3, 3],
                            [0, 1, 2, 0, 1, 1, 2, 0, 1, 2]],
                    names=['first', 'second'])
-    assert i.is_monotonic_decreasing
-    assert Index(i.values).is_monotonic_decreasing
-    assert i._is_strictly_monotonic_decreasing
-    assert Index(i.values)._is_strictly_monotonic_decreasing
+    assert i.is_monotonic_decreasing is True
+    assert Index(i.values).is_monotonic_decreasing is True
+    assert i._is_strictly_monotonic_decreasing is True
+    assert Index(i.values)._is_strictly_monotonic_decreasing is True
 
     # mixed levels, hits the TypeError
     i = MultiIndex(
@@ -134,29 +134,29 @@ def test_is_monotonic_decreasing():
         labels=[[0, 1, 1, 2, 2, 2, 3], [4, 2, 0, 0, 1, 3, -1]],
         names=['household_id', 'asset_id'])
 
-    assert not i.is_monotonic_decreasing
-    assert not i._is_strictly_monotonic_decreasing
+    assert i.is_monotonic_decreasing is False
+    assert i._is_strictly_monotonic_decreasing is False
 
     # empty
     i = MultiIndex.from_arrays([[], []])
-    assert i.is_monotonic_decreasing
-    assert Index(i.values).is_monotonic_decreasing
-    assert i._is_strictly_monotonic_decreasing
-    assert Index(i.values)._is_strictly_monotonic_decreasing
+    assert i.is_monotonic_decreasing is True
+    assert Index(i.values).is_monotonic_decreasing is True
+    assert i._is_strictly_monotonic_decreasing is True
+    assert Index(i.values)._is_strictly_monotonic_decreasing is True
 
 
 def test_is_strictly_monotonic_increasing():
     idx = pd.MultiIndex(levels=[['bar', 'baz'], ['mom', 'next']],
                         labels=[[0, 0, 1, 1], [0, 0, 0, 1]])
-    assert idx.is_monotonic_increasing
-    assert not idx._is_strictly_monotonic_increasing
+    assert idx.is_monotonic_increasing is True
+    assert idx._is_strictly_monotonic_increasing is False
 
 
 def test_is_strictly_monotonic_decreasing():
     idx = pd.MultiIndex(levels=[['baz', 'bar'], ['next', 'mom']],
                         labels=[[0, 0, 1, 1], [0, 0, 0, 1]])
-    assert idx.is_monotonic_decreasing
-    assert not idx._is_strictly_monotonic_decreasing
+    assert idx.is_monotonic_decreasing is True
+    assert idx._is_strictly_monotonic_decreasing is False
 
 
 def test_searchsorted_monotonic(indices):

--- a/pandas/tests/indexes/period/test_indexing.py
+++ b/pandas/tests/indexes/period/test_indexing.py
@@ -404,11 +404,11 @@ class TestIndexing(object):
         idx_dec1 = pd.PeriodIndex([p2, p1, p1])
         idx = pd.PeriodIndex([p1, p2, p0])
 
-        assert idx_inc0.is_monotonic_increasing
-        assert idx_inc1.is_monotonic_increasing
-        assert not idx_dec0.is_monotonic_increasing
-        assert not idx_dec1.is_monotonic_increasing
-        assert not idx.is_monotonic_increasing
+        assert idx_inc0.is_monotonic_increasing is True
+        assert idx_inc1.is_monotonic_increasing is True
+        assert idx_dec0.is_monotonic_increasing is False
+        assert idx_dec1.is_monotonic_increasing is False
+        assert idx.is_monotonic_increasing is False
 
     def test_is_monotonic_decreasing(self):
         # GH 17717
@@ -422,11 +422,11 @@ class TestIndexing(object):
         idx_dec1 = pd.PeriodIndex([p2, p1, p1])
         idx = pd.PeriodIndex([p1, p2, p0])
 
-        assert not idx_inc0.is_monotonic_decreasing
-        assert not idx_inc1.is_monotonic_decreasing
-        assert idx_dec0.is_monotonic_decreasing
-        assert idx_dec1.is_monotonic_decreasing
-        assert not idx.is_monotonic_decreasing
+        assert idx_inc0.is_monotonic_decreasing is False
+        assert idx_inc1.is_monotonic_decreasing is False
+        assert idx_dec0.is_monotonic_decreasing is True
+        assert idx_dec1.is_monotonic_decreasing is True
+        assert idx.is_monotonic_decreasing is False
 
     def test_is_unique(self):
         # GH 17717
@@ -435,10 +435,10 @@ class TestIndexing(object):
         p2 = pd.Period('2017-09-03')
 
         idx0 = pd.PeriodIndex([p0, p1, p2])
-        assert idx0.is_unique
+        assert idx0.is_unique is True
 
         idx1 = pd.PeriodIndex([p1, p1, p2])
-        assert not idx1.is_unique
+        assert idx1.is_unique is False
 
     def test_contains(self):
         # GH 17717

--- a/pandas/tests/indexes/test_base.py
+++ b/pandas/tests/indexes/test_base.py
@@ -2427,10 +2427,10 @@ class TestMixedIntIndex(Base):
         pd.to_datetime(['2000-01-01', 'NaT', '2000-01-02']),
         pd.to_timedelta(['1 day', 'NaT'])])
     def test_is_monotonic_na(self, index):
-        assert not index.is_monotonic_increasing
-        assert not index.is_monotonic_decreasing
-        assert not index._is_strictly_monotonic_increasing
-        assert not index._is_strictly_monotonic_decreasing
+        assert index.is_monotonic_increasing is False
+        assert index.is_monotonic_decreasing is False
+        assert index._is_strictly_monotonic_increasing is False
+        assert index._is_strictly_monotonic_decreasing is False
 
     def test_repr_summary(self):
         with cf.option_context('display.max_seq_items', 10):

--- a/pandas/tests/indexes/test_category.py
+++ b/pandas/tests/indexes/test_category.py
@@ -555,37 +555,37 @@ class TestCategoricalIndex(Base):
     ])
     def test_is_monotonic(self, data, non_lexsorted_data):
         c = CategoricalIndex(data)
-        assert c.is_monotonic_increasing
-        assert not c.is_monotonic_decreasing
+        assert c.is_monotonic_increasing is True
+        assert c.is_monotonic_decreasing is False
 
         c = CategoricalIndex(data, ordered=True)
-        assert c.is_monotonic_increasing
-        assert not c.is_monotonic_decreasing
+        assert c.is_monotonic_increasing is True
+        assert c.is_monotonic_decreasing is False
 
         c = CategoricalIndex(data, categories=reversed(data))
-        assert not c.is_monotonic_increasing
-        assert c.is_monotonic_decreasing
+        assert c.is_monotonic_increasing is False
+        assert c.is_monotonic_decreasing is True
 
         c = CategoricalIndex(data, categories=reversed(data), ordered=True)
-        assert not c.is_monotonic_increasing
-        assert c.is_monotonic_decreasing
+        assert c.is_monotonic_increasing is False
+        assert c.is_monotonic_decreasing is True
 
         # test when data is neither monotonic increasing nor decreasing
         reordered_data = [data[0], data[2], data[1]]
         c = CategoricalIndex(reordered_data, categories=reversed(data))
-        assert not c.is_monotonic_increasing
-        assert not c.is_monotonic_decreasing
+        assert c.is_monotonic_increasing is False
+        assert c.is_monotonic_decreasing is False
 
         # non lexsorted categories
         categories = non_lexsorted_data
 
         c = CategoricalIndex(categories[:2], categories=categories)
-        assert c.is_monotonic_increasing
-        assert not c.is_monotonic_decreasing
+        assert c.is_monotonic_increasing is True
+        assert c.is_monotonic_decreasing is False
 
         c = CategoricalIndex(categories[1:3], categories=categories)
-        assert c.is_monotonic_increasing
-        assert not c.is_monotonic_decreasing
+        assert c.is_monotonic_increasing is True
+        assert c.is_monotonic_decreasing is False
 
     @pytest.mark.parametrize('values, expected', [
         ([1, 2, 3], True),
@@ -599,8 +599,8 @@ class TestCategoricalIndex(Base):
     def test_has_duplicates(self):
 
         idx = CategoricalIndex([0, 0, 0], name='foo')
-        assert not idx.is_unique
-        assert idx.has_duplicates
+        assert idx.is_unique is False
+        assert idx.has_duplicates is True
 
     def test_drop_duplicates(self):
 

--- a/pandas/tests/indexes/test_numeric.py
+++ b/pandas/tests/indexes/test_numeric.py
@@ -422,32 +422,32 @@ class NumericInt(Numeric):
         tm.assert_index_equal(i, self._holder(i_view, name='Foo'))
 
     def test_is_monotonic(self):
-        assert self.index.is_monotonic
-        assert self.index.is_monotonic_increasing
-        assert self.index._is_strictly_monotonic_increasing
-        assert not self.index.is_monotonic_decreasing
-        assert not self.index._is_strictly_monotonic_decreasing
+        assert self.index.is_monotonic is True
+        assert self.index.is_monotonic_increasing is True
+        assert self.index._is_strictly_monotonic_increasing is True
+        assert self.index.is_monotonic_decreasing is False
+        assert self.index._is_strictly_monotonic_decreasing is False
 
         index = self._holder([4, 3, 2, 1])
-        assert not index.is_monotonic
-        assert not index._is_strictly_monotonic_increasing
-        assert index._is_strictly_monotonic_decreasing
+        assert index.is_monotonic is False
+        assert index._is_strictly_monotonic_increasing is False
+        assert index._is_strictly_monotonic_decreasing is True
 
         index = self._holder([1])
-        assert index.is_monotonic
-        assert index.is_monotonic_increasing
-        assert index.is_monotonic_decreasing
-        assert index._is_strictly_monotonic_increasing
-        assert index._is_strictly_monotonic_decreasing
+        assert index.is_monotonic is True
+        assert index.is_monotonic_increasing is True
+        assert index.is_monotonic_decreasing is True
+        assert index._is_strictly_monotonic_increasing is True
+        assert index._is_strictly_monotonic_decreasing is True
 
     def test_is_strictly_monotonic(self):
         index = self._holder([1, 1, 2, 3])
-        assert index.is_monotonic_increasing
-        assert not index._is_strictly_monotonic_increasing
+        assert index.is_monotonic_increasing is True
+        assert index._is_strictly_monotonic_increasing is False
 
         index = self._holder([3, 2, 1, 1])
-        assert index.is_monotonic_decreasing
-        assert not index._is_strictly_monotonic_decreasing
+        assert index.is_monotonic_decreasing is True
+        assert index._is_strictly_monotonic_decreasing is False
 
         index = self._holder([1, 1])
         assert index.is_monotonic_increasing

--- a/pandas/tests/indexes/test_range.py
+++ b/pandas/tests/indexes/test_range.py
@@ -340,38 +340,38 @@ class TestRangeIndex(Numeric):
         assert self.index.dtype == np.int64
 
     def test_is_monotonic(self):
-        assert self.index.is_monotonic
-        assert self.index.is_monotonic_increasing
-        assert not self.index.is_monotonic_decreasing
-        assert self.index._is_strictly_monotonic_increasing
-        assert not self.index._is_strictly_monotonic_decreasing
+        assert self.index.is_monotonic is True
+        assert self.index.is_monotonic_increasing is True
+        assert self.index.is_monotonic_decreasing is False
+        assert self.index._is_strictly_monotonic_increasing is True
+        assert self.index._is_strictly_monotonic_decreasing is False
 
         index = RangeIndex(4, 0, -1)
-        assert not index.is_monotonic
-        assert not index._is_strictly_monotonic_increasing
-        assert index.is_monotonic_decreasing
-        assert index._is_strictly_monotonic_decreasing
+        assert index.is_monotonic is False
+        assert index._is_strictly_monotonic_increasing is False
+        assert index.is_monotonic_decreasing is True
+        assert index._is_strictly_monotonic_decreasing is True
 
         index = RangeIndex(1, 2)
-        assert index.is_monotonic
-        assert index.is_monotonic_increasing
-        assert index.is_monotonic_decreasing
-        assert index._is_strictly_monotonic_increasing
-        assert index._is_strictly_monotonic_decreasing
+        assert index.is_monotonic is True
+        assert index.is_monotonic_increasing is True
+        assert index.is_monotonic_decreasing is True
+        assert index._is_strictly_monotonic_increasing is True
+        assert index._is_strictly_monotonic_decreasing is True
 
         index = RangeIndex(2, 1)
-        assert index.is_monotonic
-        assert index.is_monotonic_increasing
-        assert index.is_monotonic_decreasing
-        assert index._is_strictly_monotonic_increasing
-        assert index._is_strictly_monotonic_decreasing
+        assert index.is_monotonic is True
+        assert index.is_monotonic_increasing is True
+        assert index.is_monotonic_decreasing is True
+        assert index._is_strictly_monotonic_increasing is True
+        assert index._is_strictly_monotonic_decreasing is True
 
         index = RangeIndex(1, 1)
-        assert index.is_monotonic
-        assert index.is_monotonic_increasing
-        assert index.is_monotonic_decreasing
-        assert index._is_strictly_monotonic_increasing
-        assert index._is_strictly_monotonic_decreasing
+        assert index.is_monotonic is True
+        assert index.is_monotonic_increasing is True
+        assert index.is_monotonic_decreasing is True
+        assert index._is_strictly_monotonic_increasing is True
+        assert index._is_strictly_monotonic_decreasing is True
 
     def test_equals_range(self):
         equiv_pairs = [(RangeIndex(0, 9, 2), RangeIndex(0, 10, 2)),

--- a/pandas/tests/series/test_analytics.py
+++ b/pandas/tests/series/test_analytics.py
@@ -1439,17 +1439,17 @@ class TestSeriesAnalytics(TestData):
         s = Series(np.random.randint(0, 10, size=1000))
         assert not s.is_monotonic
         s = Series(np.arange(1000))
-        assert s.is_monotonic
-        assert s.is_monotonic_increasing
+        assert s.is_monotonic is True
+        assert s.is_monotonic_increasing is True
         s = Series(np.arange(1000, 0, -1))
-        assert s.is_monotonic_decreasing
+        assert s.is_monotonic_decreasing is True
 
         s = Series(pd.date_range('20130101', periods=10))
-        assert s.is_monotonic
-        assert s.is_monotonic_increasing
+        assert s.is_monotonic is True
+        assert s.is_monotonic_increasing is True
         s = Series(list(reversed(s.tolist())))
-        assert not s.is_monotonic
-        assert s.is_monotonic_decreasing
+        assert s.is_monotonic is False
+        assert s.is_monotonic_decreasing is True
 
     def test_sort_index_level(self):
         mi = MultiIndex.from_tuples([[1, 1, 3], [1, 1, 1]], names=list('ABC'))


### PR DESCRIPTION
- [ ] closes #xxxx
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

Asserting a method always passes. For example ``assert df.agg`` always passes.

By making the monotonicity and uniqueness tests stricter (i.e. testing for actual True/False rather than truthy/Falsy values) I think we get better ensurance that some PR doesn't accidentally turn a property into a method or that the property doesn't accidentally returns a non-boolean return value.
