### PR TITLE
DOC: Fixed timedelta docstring and examples

### DIFF
--- a/pandas/core/tools/timedeltas.py
+++ b/pandas/core/tools/timedeltas.py
@@ -16,31 +16,40 @@ from pandas.core.arrays.timedeltas import sequence_to_td64ns
 
 def to_timedelta(arg, unit='ns', box=True, errors='raise'):
     """
-    Convert argument to timedelta
+    Convert argument to timedelta.
+
+    Timedeltas are differences in times, expressed in difference units,
+    for example, years, momths, days, hours, minutes, seconds.
+    They can be both positive and negative. This method can create Timedelta
+    objects from pandas objects.
 
     Parameters
     ----------
     arg : string, timedelta, list, tuple, 1-d array, or Series
-    unit : str, optional
-        Denote the unit of the input, if input is an integer. Default 'ns'.
+    unit : str, default 'ns'
         Possible values:
         {'Y', 'M', 'W', 'D', 'days', 'day', 'hours', hour', 'hr', 'h',
         'm', 'minute', 'min', 'minutes', 'T', 'S', 'seconds', 'sec', 'second',
         'ms', 'milliseconds', 'millisecond', 'milli', 'millis', 'L',
         'us', 'microseconds', 'microsecond', 'micro', 'micros', 'U',
         'ns', 'nanoseconds', 'nano', 'nanos', 'nanosecond', 'N'}
-    box : boolean, default True
-        - If True returns a Timedelta/TimedeltaIndex of the results
-        - if False returns a np.timedelta64 or ndarray of values of dtype
-          timedelta64[ns]
+    box : Boolean, default True
+          If True returns a Timedelta/TimedeltaIndex of the results.
+          if False returns a np.timedelta64 or ndarray of values of dtype
+          timedelta64[ns].
     errors : {'ignore', 'raise', 'coerce'}, default 'raise'
-        - If 'raise', then invalid parsing will raise an exception
-        - If 'coerce', then invalid parsing will be set as NaT
-        - If 'ignore', then invalid parsing will return the input
+          If 'raise', then invalid parsing will raise an exception.
+          If 'coerce', then invalid parsing will be set as NaT.
+          If 'ignore', then invalid parsing will return the input.
 
     Returns
     -------
     ret : timedelta64/arrays of timedelta64 if parsing succeeded
+
+    See also
+    --------
+    DataFrame.astype : Cast argument to a specified dtype.
+    to_datetime : Convert argument to datetime.
 
     Examples
     --------
@@ -68,10 +77,33 @@ def to_timedelta(arg, unit='ns', box=True, errors='raise'):
     TimedeltaIndex(['0 days', '1 days', '2 days', '3 days', '4 days'],
                    dtype='timedelta64[ns]', freq=None)
 
-    See Also
-    --------
-    pandas.DataFrame.astype : Cast argument to a specified dtype.
-    pandas.to_datetime : Convert argument to datetime.
+    For `M` and `Y` units, `1M = 30D` and 1Y = 365D:
+
+    >>> pd.to_timedelta(np.arange(5), unit='M')
+    TimedeltaIndex([  '0 days 00:00:00',  '30 days 10:29:06',
+                      '60 days 20:58:12', '91 days 07:27:18',
+                      '121 days 17:56:24'],
+                      dtype='timedelta64[ns]', freq=None)
+    >>> pd.to_timedelta(np.arange(5), unit='Y')
+    TimedeltaIndex([   '0 days 00:00:00',  '365 days 05:49:12',
+                 '730 days 11:38:24', '1095 days 17:27:36',
+                '1460 days 23:16:48'],
+               dtype='timedelta64[ns]', freq=None)
+
+    Add new column of dates from existing dates in a `DataFrame`
+    using `timedelta`
+
+    >>> Dates = pd.to_datetime(['26/10/2018','28/10/2018', '2/11/2018'])
+    >>> df = pd.DataFrame({'Start': Dates,'Days':[5, 10, 5]})
+    >>> df['End'] = df['Start'] + pd.to_timedelta(df['Days'], unit='d')
+    >>> df
+       Start      Days        End
+    0 2018-10-26     5 2018-10-31
+    1 2018-10-28    10 2018-11-07
+    2 2018-02-11     5 2018-02-16
+
+    See also
+
     """
     unit = parse_timedelta_unit(unit)
 

--- a/pandas/core/tools/timedeltas.py
+++ b/pandas/core/tools/timedeltas.py
@@ -18,10 +18,9 @@ def to_timedelta(arg, unit='ns', box=True, errors='raise'):
     """
     Convert argument to timedelta.
 
-    Timedeltas are differences in times, expressed in difference units,
-    for example, years, momths, days, hours, minutes, seconds.
-    They can be both positive and negative. This method can create Timedelta
-    objects from pandas objects.
+    Timedeltas are differences in times, expressed in difference units
+    e.g. days, hours, minutes, seconds. This method converts an argument
+    from a recognized timedelta format / value into a Timedelta type.
 
     Parameters
     ----------

--- a/pandas/core/tools/timedeltas.py
+++ b/pandas/core/tools/timedeltas.py
@@ -37,9 +37,9 @@ def to_timedelta(arg, unit='ns', box=True, errors='raise'):
           if False returns a np.timedelta64 or ndarray of values of dtype
           timedelta64[ns].
     errors : {'ignore', 'raise', 'coerce'}, default 'raise'
-          If 'raise', then invalid parsing will raise an exception.
-          If 'coerce', then invalid parsing will be set as NaT.
-          If 'ignore', then invalid parsing will return the input.
+        - If 'raise', then invalid parsing will raise an exception.
+        - If 'coerce', then invalid parsing will be set as NaT.
+        - If 'ignore', then invalid parsing will return the input.
 
     Returns
     -------
@@ -80,9 +80,12 @@ def to_timedelta(arg, unit='ns', box=True, errors='raise'):
 
     >>> pd.to_timedelta(np.arange(5), box=False)
     array([0, 1, 2, 3, 4], dtype='timedelta64[ns]')
+<<<<<<< HEAD
 
     See also
 
+=======
+>>>>>>> improved styling
     """
     unit = parse_timedelta_unit(unit)
 

--- a/pandas/core/tools/timedeltas.py
+++ b/pandas/core/tools/timedeltas.py
@@ -18,8 +18,8 @@ def to_timedelta(arg, unit='ns', box=True, errors='raise'):
     """
     Convert argument to timedelta.
 
-    Timedeltas are differences in times, expressed in difference units
-    e.g. days, hours, minutes, seconds. This method converts an argument
+    Timedeltas are absolute differences in times, expressed in difference
+    units e.g. days, hours, minutes, seconds. This method converts an argument
     from a recognized timedelta format / value into a Timedelta type.
 
     Parameters
@@ -76,21 +76,13 @@ def to_timedelta(arg, unit='ns', box=True, errors='raise'):
     TimedeltaIndex(['0 days', '1 days', '2 days', '3 days', '4 days'],
                    dtype='timedelta64[ns]', freq=None)
 
-    For `M` and `Y` units, `1M = 30D` and 1Y = 365D:
+    Returning an ndarray by using the 'box' keyword argument:
 
-    >>> pd.to_timedelta(np.arange(5), unit='M')
-    TimedeltaIndex([  '0 days 00:00:00',  '30 days 10:29:06',
-                      '60 days 20:58:12', '91 days 07:27:18',
-                      '121 days 17:56:24'],
-                      dtype='timedelta64[ns]', freq=None)
-    >>> pd.to_timedelta(np.arange(5), unit='Y')
-    TimedeltaIndex([   '0 days 00:00:00',  '365 days 05:49:12',
-                 '730 days 11:38:24', '1095 days 17:27:36',
-                '1460 days 23:16:48'],
-               dtype='timedelta64[ns]', freq=None)
+    >>> pd.to_timedelta(np.arange(5), box=False)
+    array([0, 1, 2, 3, 4], dtype='timedelta64[ns]')
 
     Add new column of dates from existing dates in a `DataFrame`
-    using `timedelta`
+    using `timedelta`:
 
     >>> Dates = pd.to_datetime(['26/10/2018','28/10/2018', '2/11/2018'])
     >>> df = pd.DataFrame({'Start': Dates,'Days':[5, 10, 5]})

--- a/pandas/core/tools/timedeltas.py
+++ b/pandas/core/tools/timedeltas.py
@@ -19,22 +19,24 @@ def to_timedelta(arg, unit='ns', box=True, errors='raise'):
     Convert argument to timedelta.
 
     Timedeltas are absolute differences in times, expressed in difference
-    units e.g. (days, hours, minutes, seconds). This method converts an argument
-    from a recognized timedelta format / value into a Timedelta type.
+    units (e.g. days, hours, minutes, seconds). This method converts
+    an argument from a recognized timedelta format / value into
+    a Timedelta type.
 
     Parameters
     ----------
-    arg : string, timedelta, list, tuple, 1-d array, or Series
+    arg : str, timedelta, list-like or Series
+          The argument which needs to be converted to timedelta.
     unit : str, default 'ns'
-        Possible values:
-        {'Y', 'M', 'W', 'D', 'days', 'day', 'hours', hour', 'hr', 'h',
-        'm', 'minute', 'min', 'minutes', 'T', 'S', 'seconds', 'sec', 'second',
-        'ms', 'milliseconds', 'millisecond', 'milli', 'millis', 'L',
-        'us', 'microseconds', 'microsecond', 'micro', 'micros', 'U',
-        'ns', 'nanoseconds', 'nano', 'nanos', 'nanosecond', 'N'}
-    box : Boolean, default True
+         ('Y', 'M', 'W', 'D', 'days', 'day', 'hours', hour', 'hr',
+         'h', 'm', 'minute', 'min', 'minutes', 'T', 'S', 'seconds',
+         'sec', 'second', 'ms', 'milliseconds', 'millisecond',
+         'milli', 'millis', 'L', 'us', 'microseconds', 'microsecond',
+         'micro', 'micros', 'U', 'ns', 'nanoseconds', 'nano', 'nanos',
+         'nanosecond', 'N').
+    box : bool, default True
           If True returns a Timedelta/TimedeltaIndex of the results.
-          if False returns a np.timedelta64 or ndarray of values of dtype
+          If False returns a np.timedelta64 or ndarray of values of dtype
           timedelta64[ns].
     errors : {'ignore', 'raise', 'coerce'}, default 'raise'
         - If 'raise', then invalid parsing will raise an exception.

--- a/pandas/core/tools/timedeltas.py
+++ b/pandas/core/tools/timedeltas.py
@@ -19,7 +19,7 @@ def to_timedelta(arg, unit='ns', box=True, errors='raise'):
     Convert argument to timedelta.
 
     Timedeltas are absolute differences in times, expressed in difference
-    units e.g. days, hours, minutes, seconds. This method converts an argument
+    units e.g. (days, hours, minutes, seconds). This method converts an argument
     from a recognized timedelta format / value into a Timedelta type.
 
     Parameters
@@ -43,7 +43,8 @@ def to_timedelta(arg, unit='ns', box=True, errors='raise'):
 
     Returns
     -------
-    ret : timedelta64/arrays of timedelta64 if parsing succeeded
+    timedelta64 or numpy.array of timedelta64
+        Output type returned if parsing succeeded.
 
     See also
     --------

--- a/pandas/core/tools/timedeltas.py
+++ b/pandas/core/tools/timedeltas.py
@@ -81,18 +81,6 @@ def to_timedelta(arg, unit='ns', box=True, errors='raise'):
     >>> pd.to_timedelta(np.arange(5), box=False)
     array([0, 1, 2, 3, 4], dtype='timedelta64[ns]')
 
-    Add new column of dates from existing dates in a `DataFrame`
-    using `timedelta`:
-
-    >>> Dates = pd.to_datetime(['26/10/2018','28/10/2018', '2/11/2018'])
-    >>> df = pd.DataFrame({'Start': Dates,'Days':[5, 10, 5]})
-    >>> df['End'] = df['Start'] + pd.to_timedelta(df['Days'], unit='d')
-    >>> df
-       Start      Days        End
-    0 2018-10-26     5 2018-10-31
-    1 2018-10-28    10 2018-11-07
-    2 2018-02-11     5 2018-02-16
-
     See also
 
     """

--- a/pandas/core/tools/timedeltas.py
+++ b/pandas/core/tools/timedeltas.py
@@ -26,18 +26,19 @@ def to_timedelta(arg, unit='ns', box=True, errors='raise'):
     Parameters
     ----------
     arg : str, timedelta, list-like or Series
-          The argument which needs to be converted to timedelta.
+        The data to be converted to timedelta.
     unit : str, default 'ns'
-         ('Y', 'M', 'W', 'D', 'days', 'day', 'hours', hour', 'hr',
-         'h', 'm', 'minute', 'min', 'minutes', 'T', 'S', 'seconds',
-         'sec', 'second', 'ms', 'milliseconds', 'millisecond',
-         'milli', 'millis', 'L', 'us', 'microseconds', 'microsecond',
-         'micro', 'micros', 'U', 'ns', 'nanoseconds', 'nano', 'nanos',
-         'nanosecond', 'N').
+        Denotes the unit of the arg. Possible values:
+        ('Y', 'M', 'W', 'D', 'days', 'day', 'hours', hour', 'hr',
+        'h', 'm', 'minute', 'min', 'minutes', 'T', 'S', 'seconds',
+        'sec', 'second', 'ms', 'milliseconds', 'millisecond',
+        'milli', 'millis', 'L', 'us', 'microseconds', 'microsecond',
+        'micro', 'micros', 'U', 'ns', 'nanoseconds', 'nano', 'nanos',
+        'nanosecond', 'N').
     box : bool, default True
-          If True returns a Timedelta/TimedeltaIndex of the results.
-          If False returns a np.timedelta64 or ndarray of values of dtype
-          timedelta64[ns].
+        - If True returns a Timedelta/TimedeltaIndex of the results.
+        - If False returns a numpy.timedelta64 or numpy.darray of
+          values of dtype timedelta64[ns].
     errors : {'ignore', 'raise', 'coerce'}, default 'raise'
         - If 'raise', then invalid parsing will raise an exception.
         - If 'coerce', then invalid parsing will be set as NaT.
@@ -83,12 +84,6 @@ def to_timedelta(arg, unit='ns', box=True, errors='raise'):
 
     >>> pd.to_timedelta(np.arange(5), box=False)
     array([0, 1, 2, 3, 4], dtype='timedelta64[ns]')
-<<<<<<< HEAD
-
-    See also
-
-=======
->>>>>>> improved styling
     """
     unit = parse_timedelta_unit(unit)
 


### PR DESCRIPTION
- [x] closes #23248
- [x] tests added / passed
- [x] passes `git diff upstream/master --name-only -- "*.py" | grep "pandas/" | xargs flake8`
- [x] passes `python scripts/validate_docstrings.py pandas.to_timedelta`
