### PR TITLE
CI: Fix pyarrow compat

### DIFF
--- a/pandas/io/feather_format.py
+++ b/pandas/io/feather_format.py
@@ -111,7 +111,7 @@ def read_feather(path, nthreads=1):
     if LooseVersion(feather.__version__) < LooseVersion('0.4.0'):
         return feather.read_dataframe(path)
 
-    if LooseVersion(pyarrow.__version__) < LooseVersion('0.10')
+    if LooseVersion(pyarrow.__version__) < LooseVersion('0.10'):
         return feather.read_dataframe(path, nthreads=nthreads)
 
     # pyarrow>=0.10 has `use_threads` kwarg instead of `nthreads`

--- a/pandas/io/feather_format.py
+++ b/pandas/io/feather_format.py
@@ -31,6 +31,8 @@ def _try_import():
                           "or via pip\n"
                           "pip install -U feather-format\n")
 
+    import pyarrow  # used by feather; we'll need to check the version later
+
     return feather
 
 
@@ -109,4 +111,9 @@ def read_feather(path, nthreads=1):
     if LooseVersion(feather.__version__) < LooseVersion('0.4.0'):
         return feather.read_dataframe(path)
 
-    return feather.read_dataframe(path, nthreads=nthreads)
+    if LooseVersion(pyarrow.__version__) < LooseVersion('0.10')
+        return feather.read_dataframe(path, nthreads=nthreads)
+
+    # pyarrow>=0.10 has `use_threads` kwarg instead of `nthreads`
+    use_threads = nthreads > 1
+    return feather.read_dataframe(path, use_threads=use_threads)


### PR DESCRIPTION
It looks like the last couple days of CI failures are caused by pyarrow (required by feather-format) bumping from 0.9.0 to 0.11.0.  This checks the version and adapts the passed kwarg as appropriate.

Do we need to pin pyarrow in the CI config to make sure both versions are tested?