### PR TITLE
DOC: Added a Multi Index example for the Series.sum method

### DIFF
--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -10185,11 +10185,12 @@ dtype: int64
 >>> s.sum()
 478
 
+Sum using level names, as well as indices
+
 >>> s.sum(level='city')
 London      136
 New York    342
 dtype: int64
-
 >>> s.sum(level=1)
 month
 Jun    159

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -10187,19 +10187,18 @@ Examples
 --------
 ``MultiIndex`` series example of monthly rainfall
 
->>> index = pd.MultiIndex.from_arrays(
-...     [np.tile(['London', 'New York'], 3),
-...      np.repeat(['Jun', 'Jul', 'Aug'], 2)],
-...      names=['city', 'month'])
->>> s = pd.Series([47, 112, 35, 117, 54, 113], index=index)
+>>> index = pd.MultiIndex.from_product(
+...         [['London', 'New York'], ['Jun', 'Jul', 'Aug']],
+...         names=['city', 'month'])
+>>> s = pd.Series([47, 35, 54, 112, 117, 113], index=index)
 >>> s
 city      month
 London    Jun       47
+          Jul       35
+          Aug       54
 New York  Jun      112
-London    Jul       35
-New York  Jul      117
-London    Aug       54
-New York  Aug      113
+          Jul      117
+          Aug      113
 dtype: int64
 
 >>> s.sum()

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -10191,6 +10191,7 @@ Sum using level names, as well as indices
 London      136
 New York    342
 dtype: int64
+
 >>> s.sum(level=1)
 month
 Jun    159

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -10188,8 +10188,8 @@ Examples
 ``MultiIndex`` series example of monthly rainfall
 
 >>> index = pd.MultiIndex.from_product(
-...         [['London', 'New York'], ['Jun', 'Jul', 'Aug']],
-...         names=['city', 'month'])
+...     [['London', 'New York'], ['Jun', 'Jul', 'Aug']],
+...     names=['city', 'month'])
 >>> s = pd.Series([47, 35, 54, 112, 117, 113], index=index)
 >>> s
 city      month

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -10188,6 +10188,7 @@ dtype: int64
 Sum using level names, as well as indices
 
 >>> s.sum(level='city')
+city
 London      136
 New York    342
 dtype: int64

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -10187,10 +10187,11 @@ Examples
 --------
 ``MultiIndex`` series example of monthly rainfall
 
->>> index = [np.tile(['London', 'New York'], 3),
-...          np.repeat(['Jun', 'Jul', 'Aug'], 2)]
+>>> index = pd.MultiIndex.from_arrays(
+...     [np.tile(['London', 'New York'], 3),
+...      np.repeat(['Jun', 'Jul', 'Aug'], 2)],
+...      names=['city', 'month'])
 >>> s = pd.Series([47, 112, 35, 117, 54, 113], index=index)
->>> s.rename_axis(['city', 'month'], inplace=True)
 >>> s
 city      month
 London    Jun       47

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -10166,6 +10166,37 @@ Series([], dtype: bool)
 _sum_examples = """\
 Examples
 --------
+``MultiIndex`` series example of monthly rainfall
+
+>>> index = [np.tile(['London', 'New York'], 3),
+...          np.repeat(['Jun', 'Jul', 'Aug'], 2)]
+>>> s = pd.Series([47, 112, 35, 117, 54, 113], index=index)
+>>> s.rename_axis(['city', 'month'], inplace=True)
+>>> s
+city      month
+London    Jun       47
+New York  Jun      112
+London    Jul       35
+New York  Jul      117
+London    Aug       54
+New York  Aug      113
+dtype: int64
+
+>>> s.sum()
+478
+
+>>> s.sum(level='city')
+London      136
+New York    342
+dtype: int64
+
+>>> s.sum(level=1)
+month
+Jun    159
+Jul    152
+Aug    167
+dtype: int64
+
 By default, the sum of an empty or all-NA Series is ``0``.
 
 >>> pd.Series([]).sum()  # min_count=0 is the default


### PR DESCRIPTION
Added a simple example of using the sum method on a multi-indexed series.

- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`