### PR TITLE
TST: stricter monotonicity/uniqueness tests (part 2)

### DIFF
--- a/pandas/tests/indexes/common.py
+++ b/pandas/tests/indexes/common.py
@@ -353,8 +353,8 @@ class Base(object):
             pytest.skip('Skip check for empty Index and MultiIndex')
 
         idx = self._holder([indices[0]] * 5)
-        assert not idx.is_unique
-        assert idx.has_duplicates
+        assert idx.is_unique is False
+        assert idx.has_duplicates is True
 
     @pytest.mark.parametrize('keep', ['first', 'last', False])
     def test_duplicated(self, indices, keep):
@@ -414,7 +414,7 @@ class Base(object):
 
         # We test against `idx_unique`, so first we make sure it's unique
         # and doesn't contain nans.
-        assert idx_unique.is_unique
+        assert idx_unique.is_unique is True
         try:
             assert not idx_unique.hasnans
         except NotImplementedError:
@@ -438,7 +438,7 @@ class Base(object):
         vals_unique = vals[:2]
         idx_nan = indices._shallow_copy(vals)
         idx_unique_nan = indices._shallow_copy(vals_unique)
-        assert idx_unique_nan.is_unique
+        assert idx_unique_nan.is_unique is True
 
         assert idx_nan.dtype == indices.dtype
         assert idx_unique_nan.dtype == indices.dtype

--- a/pandas/tests/indexes/interval/test_interval.py
+++ b/pandas/tests/indexes/interval/test_interval.py
@@ -243,108 +243,108 @@ class TestIntervalIndex(Base):
         # unique non-overlapping
         idx = IntervalIndex.from_tuples(
             [(0, 1), (2, 3), (4, 5)], closed=closed)
-        assert idx.is_unique
+        assert idx.is_unique is True
 
         # unique overlapping - distinct endpoints
         idx = IntervalIndex.from_tuples([(0, 1), (0.5, 1.5)], closed=closed)
-        assert idx.is_unique
+        assert idx.is_unique is True
 
         # unique overlapping - shared endpoints
         idx = pd.IntervalIndex.from_tuples(
             [(1, 2), (1, 3), (2, 3)], closed=closed)
-        assert idx.is_unique
+        assert idx.is_unique is True
 
         # unique nested
         idx = IntervalIndex.from_tuples([(-1, 1), (-2, 2)], closed=closed)
-        assert idx.is_unique
+        assert idx.is_unique is True
 
         # duplicate
         idx = IntervalIndex.from_tuples(
             [(0, 1), (0, 1), (2, 3)], closed=closed)
-        assert not idx.is_unique
+        assert idx.is_unique is False
 
         # empty
         idx = IntervalIndex([], closed=closed)
-        assert idx.is_unique
+        assert idx.is_unique is True
 
     def test_monotonic(self, closed):
         # increasing non-overlapping
         idx = IntervalIndex.from_tuples(
             [(0, 1), (2, 3), (4, 5)], closed=closed)
-        assert idx.is_monotonic
-        assert idx._is_strictly_monotonic_increasing
-        assert not idx.is_monotonic_decreasing
-        assert not idx._is_strictly_monotonic_decreasing
+        assert idx.is_monotonic is True
+        assert idx._is_strictly_monotonic_increasing is True
+        assert idx.is_monotonic_decreasing is False
+        assert idx._is_strictly_monotonic_decreasing is False
 
         # decreasing non-overlapping
         idx = IntervalIndex.from_tuples(
             [(4, 5), (2, 3), (1, 2)], closed=closed)
-        assert not idx.is_monotonic
-        assert not idx._is_strictly_monotonic_increasing
-        assert idx.is_monotonic_decreasing
-        assert idx._is_strictly_monotonic_decreasing
+        assert idx.is_monotonic is False
+        assert idx._is_strictly_monotonic_increasing is False
+        assert idx.is_monotonic_decreasing is True
+        assert idx._is_strictly_monotonic_decreasing is True
 
         # unordered non-overlapping
         idx = IntervalIndex.from_tuples(
             [(0, 1), (4, 5), (2, 3)], closed=closed)
-        assert not idx.is_monotonic
-        assert not idx._is_strictly_monotonic_increasing
-        assert not idx.is_monotonic_decreasing
-        assert not idx._is_strictly_monotonic_decreasing
+        assert idx.is_monotonic is False
+        assert idx._is_strictly_monotonic_increasing is False
+        assert idx.is_monotonic_decreasing is False
+        assert idx._is_strictly_monotonic_decreasing is False
 
         # increasing overlapping
         idx = IntervalIndex.from_tuples(
             [(0, 2), (0.5, 2.5), (1, 3)], closed=closed)
-        assert idx.is_monotonic
-        assert idx._is_strictly_monotonic_increasing
-        assert not idx.is_monotonic_decreasing
-        assert not idx._is_strictly_monotonic_decreasing
+        assert idx.is_monotonic is True
+        assert idx._is_strictly_monotonic_increasing is True
+        assert idx.is_monotonic_decreasing is False
+        assert idx._is_strictly_monotonic_decreasing is False
 
         # decreasing overlapping
         idx = IntervalIndex.from_tuples(
             [(1, 3), (0.5, 2.5), (0, 2)], closed=closed)
-        assert not idx.is_monotonic
-        assert not idx._is_strictly_monotonic_increasing
-        assert idx.is_monotonic_decreasing
-        assert idx._is_strictly_monotonic_decreasing
+        assert idx.is_monotonic is False
+        assert idx._is_strictly_monotonic_increasing is False
+        assert idx.is_monotonic_decreasing is True
+        assert idx._is_strictly_monotonic_decreasing is True
 
         # unordered overlapping
         idx = IntervalIndex.from_tuples(
             [(0.5, 2.5), (0, 2), (1, 3)], closed=closed)
-        assert not idx.is_monotonic
-        assert not idx._is_strictly_monotonic_increasing
-        assert not idx.is_monotonic_decreasing
-        assert not idx._is_strictly_monotonic_decreasing
+        assert idx.is_monotonic is False
+        assert idx._is_strictly_monotonic_increasing is False
+        assert idx.is_monotonic_decreasing is False
+        assert idx._is_strictly_monotonic_decreasing is False
 
         # increasing overlapping shared endpoints
         idx = pd.IntervalIndex.from_tuples(
             [(1, 2), (1, 3), (2, 3)], closed=closed)
-        assert idx.is_monotonic
-        assert idx._is_strictly_monotonic_increasing
-        assert not idx.is_monotonic_decreasing
-        assert not idx._is_strictly_monotonic_decreasing
+        assert idx.is_monotonic is True
+        assert idx._is_strictly_monotonic_increasing is True
+        assert idx.is_monotonic_decreasing is False
+        assert idx._is_strictly_monotonic_decreasing is False
 
         # decreasing overlapping shared endpoints
         idx = pd.IntervalIndex.from_tuples(
             [(2, 3), (1, 3), (1, 2)], closed=closed)
-        assert not idx.is_monotonic
-        assert not idx._is_strictly_monotonic_increasing
-        assert idx.is_monotonic_decreasing
-        assert idx._is_strictly_monotonic_decreasing
+        assert idx.is_monotonic is False
+        assert idx._is_strictly_monotonic_increasing is False
+        assert idx.is_monotonic_decreasing is True
+        assert idx._is_strictly_monotonic_decreasing is True
 
         # stationary
         idx = IntervalIndex.from_tuples([(0, 1), (0, 1)], closed=closed)
-        assert idx.is_monotonic
-        assert not idx._is_strictly_monotonic_increasing
-        assert idx.is_monotonic_decreasing
-        assert not idx._is_strictly_monotonic_decreasing
+        assert idx.is_monotonic is True
+        assert idx._is_strictly_monotonic_increasing is False
+        assert idx.is_monotonic_decreasing is True
+        assert idx._is_strictly_monotonic_decreasing is False
 
         # empty
         idx = IntervalIndex([], closed=closed)
-        assert idx.is_monotonic
-        assert idx._is_strictly_monotonic_increasing
-        assert idx.is_monotonic_decreasing
-        assert idx._is_strictly_monotonic_decreasing
+        assert idx.is_monotonic is True
+        assert idx._is_strictly_monotonic_increasing is True
+        assert idx.is_monotonic_decreasing is True
+        assert idx._is_strictly_monotonic_decreasing is True
 
     @pytest.mark.skip(reason='not a valid repr as we use interval notation')
     def test_repr(self):

--- a/pandas/tests/indexes/multi/test_duplicates.py
+++ b/pandas/tests/indexes/multi/test_duplicates.py
@@ -131,16 +131,16 @@ def test_duplicate_meta_data():
 
 def test_has_duplicates(idx, idx_dup):
     # see fixtures
-    assert idx.is_unique
-    assert not idx.has_duplicates
-    assert not idx_dup.is_unique
-    assert idx_dup.has_duplicates
+    assert idx.is_unique is True
+    assert idx.has_duplicates is False
+    assert idx_dup.is_unique is False
+    assert idx_dup.has_duplicates is True
 
     mi = MultiIndex(levels=[[0, 1], [0, 1, 2]],
                     labels=[[0, 0, 0, 0, 1, 1, 1],
                             [0, 1, 2, 0, 0, 1, 2]])
-    assert not mi.is_unique
-    assert mi.has_duplicates
+    assert mi.is_unique is False
+    assert mi.has_duplicates is True
 
 
 def test_has_duplicates_from_tuples():

--- a/pandas/tests/indexes/multi/test_integrity.py
+++ b/pandas/tests/indexes/multi/test_integrity.py
@@ -110,7 +110,7 @@ def test_consistency():
     index = MultiIndex(levels=[major_axis, minor_axis],
                        labels=[major_labels, minor_labels])
 
-    assert not index.is_unique
+    assert index.is_unique is False
 
 
 def test_hash_collisions():

--- a/pandas/tests/indexing/test_loc.py
+++ b/pandas/tests/indexing/test_loc.py
@@ -676,7 +676,7 @@ Region_1,Site_2,3977723089,A,5/20/2015 8:33,5/20/2015 9:09,Yes,No"""
                               df.take(mask[1:])])
 
         df = gen_test(900, 100)
-        assert not df.index.is_unique
+        assert df.index.is_unique is False
 
         mask = np.arange(100)
         result = df.loc[mask]
@@ -684,7 +684,7 @@ Region_1,Site_2,3977723089,A,5/20/2015 8:33,5/20/2015 9:09,Yes,No"""
         tm.assert_frame_equal(result, expected)
 
         df = gen_test(900000, 100000)
-        assert not df.index.is_unique
+        assert df.index.is_unique is False
 
         mask = np.arange(100000)
         result = df.loc[mask]

--- a/pandas/tests/series/indexing/test_indexing.py
+++ b/pandas/tests/series/indexing/test_indexing.py
@@ -387,7 +387,7 @@ def test_set_value(test_data):
 def test_setslice(test_data):
     sl = test_data.ts[5:20]
     assert len(sl) == len(sl.index)
-    assert sl.index.is_unique
+    assert sl.index.is_unique is True
 
 
 # FutureWarning from NumPy about [slice(None, 5).

--- a/pandas/tests/series/test_duplicates.py
+++ b/pandas/tests/series/test_duplicates.py
@@ -63,9 +63,9 @@ def test_unique_data_ownership():
 def test_is_unique():
     # GH11946
     s = Series(np.random.randint(0, 10, size=1000))
-    assert not s.is_unique
+    assert s.is_unique is False
     s = Series(np.arange(1000))
-    assert s.is_unique
+    assert s.is_unique is True
 
 
 def test_is_unique_class_ne(capsys):

--- a/pandas/tests/test_algos.py
+++ b/pandas/tests/test_algos.py
@@ -1109,7 +1109,7 @@ class TestDuplicated(object):
     def test_unique_index(self):
         cases = [Index([1, 2, 3]), pd.RangeIndex(0, 3)]
         for case in cases:
-            assert case.is_unique
+            assert case.is_unique is True
             tm.assert_numpy_array_equal(case.duplicated(),
                                         np.array([False, False, False]))
 

--- a/pandas/tests/test_multilevel.py
+++ b/pandas/tests/test_multilevel.py
@@ -495,7 +495,7 @@ class TestMultiLevel(Base):
     def test_xs_with_duplicates(self):
         # Issue #13719
         df_dup = concat([self.frame] * 2)
-        assert not df_dup.index.is_unique
+        assert df_dup.index.is_unique is False
         expected = concat([self.frame.xs('one', level='second')] * 2)
         tm.assert_frame_equal(df_dup.xs('one', level='second'), expected)
         tm.assert_frame_equal(df_dup.xs(['one'], level=['second']), expected)
@@ -889,7 +889,7 @@ x   q   30      3    -0.6662 -0.5243 -0.3580  0.89145  2.5838"""
         # GH10417
         def check(left, right):
             tm.assert_series_equal(left, right)
-            assert not left.index.is_unique
+            assert left.index.is_unique is False
             li, ri = left.index, right.index
             tm.assert_index_equal(li, ri)
 
@@ -1922,7 +1922,7 @@ Thur,Lunch,Yes,51.51,17"""
         df['tstamp'] = idxdt
         df = df.set_index('tstamp', append=True)
         ts = Timestamp('201603231600')
-        assert not df.index.is_unique
+        assert df.index.is_unique is False
 
         result = df.drop(ts, level='tstamp')
         expected = df.loc[idx != 4]

--- a/pandas/tests/util/test_hashing.py
+++ b/pandas/tests/util/test_hashing.py
@@ -110,9 +110,9 @@ class TestHashing(object):
     def test_multiindex_unique(self):
         mi = MultiIndex.from_tuples([(118, 472), (236, 118),
                                      (51, 204), (102, 51)])
-        assert mi.is_unique
+        assert mi.is_unique is True
         result = hash_pandas_object(mi)
-        assert result.is_unique
+        assert result.is_unique is True
 
     def test_multiindex_objects(self):
         mi = MultiIndex(levels=[['b', 'd', 'a'], [1, 2, 3]],


### PR DESCRIPTION
- [x] xref #23256
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

Continuation of #23256.

By making the uniqueness tests stricter (i.e. testing for actual True/False rather than truthy/Falsy values) I think we get better ensurance that some PR doesn't accidentally turn a property into a method or that the property doesn't accidentally returns a non-boolean return value.