### PR TITLE
API: Treat 1D vectors as columns in some cases for arith/cmp ops

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -4960,7 +4960,7 @@ class DataFrame(NDFrame):
                                  copy=False)
         assert left.index.equals(right.index)
 
-        if left._is_mixed_type or right._is_mixed_type:
+        if ops.should_series_dispatch(left, right, func):
             # operate column-wise; avoid costly object-casting in `.values`
             return ops.dispatch_to_series(left, right, func)
         else:

--- a/pandas/core/ops.py
+++ b/pandas/core/ops.py
@@ -1778,14 +1778,12 @@ def _treat_as_column(left, right, axis=None):
     if np.ndim(right) != 1:
         return False
 
-    if len(right) == len(left.columns):
-        return False
-
     if isinstance(right, ABCSeries):
         # require an exact match
-        return right.index.equals(left.index)
+        return (right.index.equals(left.index) and
+                not left.index.equals(left.columns))
 
-    return len(right) == len(left)
+    return len(right) == len(left) != len(left.columns)
 
 
 def _align_method_FRAME(left, right, axis):

--- a/pandas/tests/arithmetic/conftest.py
+++ b/pandas/tests/arithmetic/conftest.py
@@ -153,19 +153,3 @@ def box_df_fail(request):
     Fixture equivalent to `box` fixture but xfailing the DataFrame case.
     """
     return request.param
-
-
-@pytest.fixture(params=[
-    pd.Index,
-    pd.Series,
-    pytest.param(pd.DataFrame,
-                 marks=pytest.mark.xfail(reason="Tries to broadcast "
-                                                "incorrectly",
-                                         strict=True, raises=ValueError))
-], ids=lambda x: x.__name__)
-def box_df_broadcast_failure(request):
-    """
-    Fixture equivalent to `box` but with the common failing case where
-    the DataFrame operation tries to broadcast incorrectly.
-    """
-    return request.param

--- a/pandas/tests/arithmetic/test_datetime64.py
+++ b/pandas/tests/arithmetic/test_datetime64.py
@@ -1365,10 +1365,8 @@ class TestDatetimeIndexArithmetic(object):
                                     operator.sub, ops.rsub])
     @pytest.mark.parametrize('pi_freq', ['D', 'W', 'Q', 'H'])
     @pytest.mark.parametrize('dti_freq', [None, 'D'])
-    def test_dti_sub_pi(self, dti_freq, pi_freq, op, box_df_broadcast_failure):
+    def test_dti_sub_pi(self, dti_freq, pi_freq, op, box):
         # GH#20049 subtracting PeriodIndex should raise TypeError
-        box = box_df_broadcast_failure
-
         dti = pd.DatetimeIndex(['2011-01-01', '2011-01-02'], freq=dti_freq)
         pi = dti.to_period(pi_freq)
 

--- a/pandas/tests/arithmetic/test_period.py
+++ b/pandas/tests/arithmetic/test_period.py
@@ -344,9 +344,7 @@ class TestPeriodIndexArithmetic(object):
     # PeriodIndex - other is defined for integers, timedelta-like others,
     #   and PeriodIndex (with matching freq)
 
-    def test_parr_add_iadd_parr_raises(self, box_df_broadcast_failure):
-        box = box_df_broadcast_failure
-
+    def test_parr_add_iadd_parr_raises(self, box):
         rng = pd.period_range('1/1/2000', freq='D', periods=5)
         other = pd.period_range('1/6/2000', freq='D', periods=5)
         # TODO: parametrize over boxes for other?
@@ -388,9 +386,7 @@ class TestPeriodIndexArithmetic(object):
         expected = pd.Index([pd.NaT, 0 * off, 0 * off, 0 * off, 0 * off])
         tm.assert_index_equal(result, expected)
 
-    def test_parr_sub_pi_mismatched_freq(self, box_df_broadcast_failure):
-        box = box_df_broadcast_failure
-
+    def test_parr_sub_pi_mismatched_freq(self, box):
         rng = pd.period_range('1/1/2000', freq='D', periods=5)
         other = pd.period_range('1/6/2000', freq='H', periods=5)
         # TODO: parametrize over boxes for other?

--- a/pandas/tests/arithmetic/test_timedelta64.py
+++ b/pandas/tests/arithmetic/test_timedelta64.py
@@ -22,7 +22,7 @@ def assert_dtype(result, dtype, box):
     if box is not pd.DataFrame:
         assert result.dtype == dtype
     else:
-         assert result.dtypes[0] == dtype
+        assert result.dtypes[0] == dtype
 
 
 # ------------------------------------------------------------------

--- a/pandas/tests/frame/test_operators.py
+++ b/pandas/tests/frame/test_operators.py
@@ -805,16 +805,15 @@ class TestDataFrameOperators(TestData):
         result = df.values > b
         assert_numpy_array_equal(result, expected.values)
 
-        msg1d = 'Unable to coerce to Series, length must be 2: given 3'
         msg2d = 'Unable to coerce to DataFrame, shape must be'
         msg2db = 'operands could not be broadcast together with shapes'
-        with tm.assert_raises_regex(ValueError, msg1d):
-            # wrong shape
-            df > lst
 
-        with tm.assert_raises_regex(ValueError, msg1d):
-            # wrong shape
-            result = df > tup
+        # operate column-by-column
+        result = df > lst
+        assert_frame_equal(result, expected)
+
+        result = df > tup
+        assert_frame_equal(result, expected)
 
         # broadcasts like ndarray (GH#23000)
         result = df > b_r
@@ -834,11 +833,11 @@ class TestDataFrameOperators(TestData):
         result = df == b
         assert_frame_equal(result, expected)
 
-        with tm.assert_raises_regex(ValueError, msg1d):
-            result = df == lst
+        result = df == lst
+        assert_frame_equal(result, expected)
 
-        with tm.assert_raises_regex(ValueError, msg1d):
-            result = df == tup
+        result = df == tup
+        assert_frame_equal(result, expected)
 
         # broadcasts like ndarray (GH#23000)
         result = df == b_r
@@ -858,11 +857,11 @@ class TestDataFrameOperators(TestData):
         expected.index = df.index
         expected.columns = df.columns
 
-        with tm.assert_raises_regex(ValueError, msg1d):
-            result = df == lst
+        result = df == lst
+        assert_frame_equal(result, expected)
 
-        with tm.assert_raises_regex(ValueError, msg1d):
-            result = df == tup
+        result = df == tup
+        assert_frame_equal(result, expected)
 
     def test_combine_generic(self):
         df1 = self.frame


### PR DESCRIPTION
Definitely needs discussion.

There are a bunch of GH issues (will track down the list in a bit) that boil down to users expecting DataFrame+(Series|ndarray|listlike) ops to operate column-by-column.  This PR implements that behavior for a subset of cases.  In particular:

- `other` is a `Series`: indexes match exactly (and columns do not)
- `other` is a list/tuple/np.ndarray: length matches df.index (and not df.columns)

This means that things like `df == df['A']` will now work.

- [ ] closes #xxxx
- [ ] tests added / passed
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry
