### PR TITLE
TST: Use __tracebackhide__ to suppress unnecessary parts of tm assertions

### DIFF
--- a/pandas/util/testing.py
+++ b/pandas/util/testing.py
@@ -480,8 +480,8 @@ def get_locales(prefix=None, normalize=True,
     if prefix is None:
         return _valid_locales(out_locales, normalize)
 
-    found = re.compile('{prefix}.*'.format(prefix=prefix)) \
-              .findall('\n'.join(out_locales))
+    pattern = re.compile('{prefix}.*'.format(prefix=prefix))
+    found = pattern.findall('\n'.join(out_locales))
     return _valid_locales(found, normalize)
 
 
@@ -966,14 +966,14 @@ def assert_is_valid_plot_return_object(objs):
     import matplotlib.pyplot as plt
     if isinstance(objs, (pd.Series, np.ndarray)):
         for el in objs.ravel():
-            msg = ('one of \'objs\' is not a matplotlib Axes instance, type '
-                   'encountered {name!r}').format(name=el.__class__.__name__)
+            msg = ("one of 'objs' is not a matplotlib Axes instance, type "
+                   "encountered {name!r}").format(name=el.__class__.__name__)
             assert isinstance(el, (plt.Axes, dict)), msg
     else:
-        assert isinstance(objs, (plt.Artist, tuple, dict)), \
-            ('objs is neither an ndarray of Artist instances nor a '
-             'single Artist instance, tuple, or dict, "objs" is a {name!r}'
-             ).format(name=objs.__class__.__name__)
+        assert isinstance(objs, (plt.Artist, tuple, dict)), (
+            'objs is neither an ndarray of Artist instances nor a '
+            'single Artist instance, tuple, or dict, "objs" is a {name!r}'
+            .format(name=objs.__class__.__name__))
 
 
 def isiterable(obj):
@@ -2024,8 +2024,9 @@ def makeCustomIndex(nentries, nlevels, prefix='#', names=False, ndupe_l=None,
     assert (is_sequence(ndupe_l) and len(ndupe_l) <= nlevels)
     assert (names is None or names is False or
             names is True or len(names) is nlevels)
-    assert idx_type is None or \
-        (idx_type in ('i', 'f', 's', 'u', 'dt', 'p', 'td') and nlevels == 1)
+    assert idx_type is None or (idx_type in ('i', 'f', 's', 'u',
+                                             'dt', 'p', 'td')
+                                and nlevels == 1)
 
     if names is True:
         # build default names
@@ -2152,12 +2153,12 @@ def makeCustomDataframe(nrows, ncols, c_idx_names=True, r_idx_names=True,
 
     assert c_idx_nlevels > 0
     assert r_idx_nlevels > 0
-    assert r_idx_type is None or \
-        (r_idx_type in ('i', 'f', 's',
-                        'u', 'dt', 'p', 'td') and r_idx_nlevels == 1)
-    assert c_idx_type is None or \
-        (c_idx_type in ('i', 'f', 's',
-                        'u', 'dt', 'p', 'td') and c_idx_nlevels == 1)
+    assert r_idx_type is None or (r_idx_type in ('i', 'f', 's',
+                                                 'u', 'dt', 'p', 'td')
+                                  and r_idx_nlevels == 1)
+    assert c_idx_type is None or (c_idx_type in ('i', 'f', 's',
+                                                 'u', 'dt', 'p', 'td')
+                                  and c_idx_nlevels == 1)
 
     columns = makeCustomIndex(ncols, nlevels=c_idx_nlevels, prefix='C',
                               names=c_idx_names, ndupe_l=c_ndupe_l,

--- a/pandas/util/testing.py
+++ b/pandas/util/testing.py
@@ -895,6 +895,7 @@ def assert_index_equal(left, right, exact='equiv', check_names=True,
 
 def assert_class_equal(left, right, exact=True, obj='Input'):
     """checks classes are equal."""
+    __tracebackhide__ = True
 
     def repr_class(x):
         if isinstance(x, Index):
@@ -934,6 +935,7 @@ def assert_attr_equal(attr, left, right, obj='Attributes'):
         Specify object name being compared, internally used to show appropriate
         assertion message
     """
+    __tracebackhide__ = True
 
     left_attr = getattr(left, attr)
     right_attr = getattr(right, attr)
@@ -1102,6 +1104,7 @@ def assert_numpy_array_equal(left, right, strict_nan=False,
         Specify object name being compared, internally used to show appropriate
         assertion message
     """
+    __tracebackhide__ = True
 
     # instance validation
     # Show a detailed error message when classes are different
@@ -1222,6 +1225,7 @@ def assert_series_equal(left, right, check_dtype=True,
         Specify object name being compared, internally used to show appropriate
         assertion message
     """
+    __tracebackhide__ = True
 
     # instance validation
     _check_isinstance(left, right, Series)
@@ -1395,6 +1399,7 @@ def assert_frame_equal(left, right, check_dtype=True,
     Ignore differing dtypes in columns with check_dtype.
     >>> assert_frame_equal(df1, df2, check_dtype=False)
     """
+    __tracebackhide__ = True
 
     # instance validation
     _check_isinstance(left, right, DataFrame)
@@ -1530,6 +1535,8 @@ def assert_equal(left, right, **kwargs):
     right : Index, Series, DataFrame, ExtensionArray, or np.ndarray
     **kwargs
     """
+    __tracebackhide__ = True
+
     if isinstance(left, pd.Index):
         assert_index_equal(left, right, **kwargs)
     elif isinstance(left, pd.Series):
@@ -2483,7 +2490,7 @@ with_connectivity_check = network
 
 def assert_raises_regex(_exception, _regexp, _callable=None,
                         *args, **kwargs):
-    """
+    r"""
     Check that the specified Exception is raised and that the error message
     matches a given regular expression pattern. This may be a regular
     expression object or a string containing a regular expression suitable
@@ -2665,6 +2672,8 @@ def assert_produces_warning(expected_warning=Warning, filter_level="always",
 
     ..warn:: This is *not* thread-safe.
     """
+    __tracebackhide__ = True
+
     with warnings.catch_warnings(record=True) as w:
 
         if clear is not None:


### PR DESCRIPTION
Makes test output much more to the point.

Also gets rid of some backslashes, both for prettiness and to get rid of deprecation warnings in test logs.