### PR TITLE
TST: fix _most_ remaining xfails in tests/arithmetic

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -4978,7 +4978,7 @@ class DataFrame(NDFrame):
         assert left.columns.equals(right.index)
         return ops.dispatch_to_series(left, right, func, axis="columns")
 
-    def _combine_const(self, other, func, errors='raise'):
+    def _combine_const(self, other, func):
         assert lib.is_scalar(other) or np.ndim(other) == 0
         return ops.dispatch_to_series(self, other, func)
 

--- a/pandas/core/indexes/range.py
+++ b/pandas/core/indexes/range.py
@@ -16,7 +16,8 @@ from pandas.core.dtypes import concat as _concat
 from pandas.core.dtypes.common import (
     is_int64_dtype, is_integer, is_scalar, is_timedelta64_dtype
 )
-from pandas.core.dtypes.generic import ABCSeries, ABCTimedeltaIndex
+from pandas.core.dtypes.generic import (
+    ABCSeries, ABCTimedeltaIndex, ABCDataFrame)
 from pandas.core.indexes.base import Index, _index_shared_docs
 from pandas.core.indexes.numeric import Int64Index
 from pandas.util._decorators import Appender, cache_readonly
@@ -557,6 +558,9 @@ class RangeIndex(Int64Index):
         return super_getitem(key)
 
     def __floordiv__(self, other):
+        if isinstance(other, ABCDataFrame):
+            return NotImplemented
+
         if is_integer(other) and other != 0:
             if (len(self) == 0 or
                     self._start % other == 0 and
@@ -588,7 +592,7 @@ class RangeIndex(Int64Index):
             """
 
             def _evaluate_numeric_binop(self, other):
-                if isinstance(other, ABCSeries):
+                if isinstance(other, (ABCSeries, ABCDataFrame)):
                     return NotImplemented
                 elif isinstance(other, ABCTimedeltaIndex):
                     # Defer to TimedeltaIndex implementation

--- a/pandas/core/indexes/range.py
+++ b/pandas/core/indexes/range.py
@@ -558,7 +558,7 @@ class RangeIndex(Int64Index):
         return super_getitem(key)
 
     def __floordiv__(self, other):
-        if isinstance(other, ABCDataFrame):
+        if isinstance(other, (ABCSeries, ABCDataFrame)):
             return NotImplemented
 
         if is_integer(other) and other != 0:

--- a/pandas/core/ops.py
+++ b/pandas/core/ops.py
@@ -1940,8 +1940,7 @@ def _comp_method_FRAME(cls, func, special):
 
             # straight boolean comparisons we want to allow all columns
             # (regardless of dtype to pass thru) See #4537 for discussion.
-            res = self._combine_const(other, func,
-                                      errors='ignore')
+            res = self._combine_const(other, func)
             return res.fillna(True).astype(bool)
 
     f.__name__ = op_name

--- a/pandas/core/sparse/frame.py
+++ b/pandas/core/sparse/frame.py
@@ -642,7 +642,7 @@ class SparseDataFrame(DataFrame):
             new_data, index=self.index, columns=union,
             default_fill_value=self.default_fill_value).__finalize__(self)
 
-    def _combine_const(self, other, func, errors='raise'):
+    def _combine_const(self, other, func):
         return self._apply_columns(lambda x: func(x, other))
 
     def _reindex_index(self, index, method, copy, level, fill_value=np.nan,

--- a/pandas/tests/arithmetic/conftest.py
+++ b/pandas/tests/arithmetic/conftest.py
@@ -84,7 +84,8 @@ def three_days(request):
                         pd.Timedelta(hours=2).to_pytimedelta(),
                         pd.Timedelta(seconds=2 * 3600),
                         np.timedelta64(2, 'h'),
-                        np.timedelta64(120, 'm')])
+                        np.timedelta64(120, 'm')],
+                ids=lambda x: str(x))
 def two_hours(request):
     """
     Several timedelta-like and DateOffset objects that each represent

--- a/pandas/tests/arithmetic/conftest.py
+++ b/pandas/tests/arithmetic/conftest.py
@@ -142,31 +142,3 @@ def box(request):
     behavior with respect to arithmetic operations.
     """
     return request.param
-
-
-@pytest.fixture(params=[pd.Index,
-                        pd.Series,
-                        pytest.param(pd.DataFrame,
-                                     marks=pytest.mark.xfail(strict=True))],
-                ids=lambda x: x.__name__)
-def box_df_fail(request):
-    """
-    Fixture equivalent to `box` fixture but xfailing the DataFrame case.
-    """
-    return request.param
-
-
-@pytest.fixture(params=[
-    pd.Index,
-    pd.Series,
-    pytest.param(pd.DataFrame,
-                 marks=pytest.mark.xfail(reason="Tries to broadcast "
-                                                "incorrectly",
-                                         strict=True, raises=ValueError))
-], ids=lambda x: x.__name__)
-def box_df_broadcast_failure(request):
-    """
-    Fixture equivalent to `box` but with the common failing case where
-    the DataFrame operation tries to broadcast incorrectly.
-    """
-    return request.param

--- a/pandas/tests/arithmetic/test_datetime64.py
+++ b/pandas/tests/arithmetic/test_datetime64.py
@@ -1365,14 +1365,12 @@ class TestDatetimeIndexArithmetic(object):
                                     operator.sub, ops.rsub])
     @pytest.mark.parametrize('pi_freq', ['D', 'W', 'Q', 'H'])
     @pytest.mark.parametrize('dti_freq', [None, 'D'])
-    def test_dti_sub_pi(self, dti_freq, pi_freq, op, box_df_broadcast_failure):
+    def test_dti_sub_pi(self, dti_freq, pi_freq, op, box):
         # GH#20049 subtracting PeriodIndex should raise TypeError
-        box = box_df_broadcast_failure
-
         dti = pd.DatetimeIndex(['2011-01-01', '2011-01-02'], freq=dti_freq)
         pi = dti.to_period(pi_freq)
 
-        dti = tm.box_expected(dti, box)
+        dti = tm.box_expected(dti, box, transpose=True)
         # TODO: Also box pi?
         with pytest.raises(TypeError):
             op(dti, pi)

--- a/pandas/tests/arithmetic/test_numeric.py
+++ b/pandas/tests/arithmetic/test_numeric.py
@@ -150,14 +150,6 @@ class TestNumericArraylikeArithmeticWithTimedeltaLike(object):
     def test_numeric_arr_rdiv_tdscalar(self, three_days, numeric_idx, box):
         index = numeric_idx[1:3]
 
-        broken = (isinstance(three_days, np.timedelta64) and
-                  three_days.dtype == 'm8[D]')
-        broken = broken or isinstance(three_days, pd.offsets.Tick)
-        if box is not pd.Index and broken:
-            # np.timedelta64(3, 'D') / 2 == np.timedelta64(1, 'D')
-            raise pytest.xfail("timedelta64 not converted to nanos; "
-                               "Tick division not implemented")
-
         expected = TimedeltaIndex(['3 Days', '36 Hours'])
 
         index = tm.box_expected(index, box)
@@ -169,35 +161,6 @@ class TestNumericArraylikeArithmeticWithTimedeltaLike(object):
         with pytest.raises(TypeError):
             index / three_days
 
-    @pytest.mark.xfail(reason="timedelta64 not converted to nanos; "
-                              "Tick division is not implemented",
-                       strict=True)
-    @pytest.mark.parametrize('box', [pd.Series, pd.DataFrame])
-    def test_numeric_arr_rdiv_tdscalar_failing(self, three_days,
-                                               numeric_idx, box):
-        # This is a duplicate of test_numeric_arr_rdiv_tdscalar specific to
-        # failing cases.  This allows us to make the "xfail" strict and be
-        # notified if/when these cases are fixed.
-        index = numeric_idx[1:3]
-
-        # np.timedelta64(3, 'D') / 2 == np.timedelta64(1, 'D')
-        broken = (isinstance(three_days, np.timedelta64) and
-                  three_days.dtype == 'm8[D]')
-        broken =  broken or isinstance(three_days, pd.offsets.Tick)
-        if not broken:
-            # raise a fake exception for the working cases
-            assert False
-
-        expected = TimedeltaIndex(['3 Days', '36 Hours'])
-
-        index = tm.box_expected(index, box)
-        expected = tm.box_expected(expected, box)
-
-        result = three_days / index
-        tm.assert_equal(result, expected)
-
-        with pytest.raises(TypeError):
-            index / three_days
 
 # ------------------------------------------------------------------
 # Arithmetic

--- a/pandas/tests/arithmetic/test_period.py
+++ b/pandas/tests/arithmetic/test_period.py
@@ -344,14 +344,12 @@ class TestPeriodIndexArithmetic(object):
     # PeriodIndex - other is defined for integers, timedelta-like others,
     #   and PeriodIndex (with matching freq)
 
-    def test_parr_add_iadd_parr_raises(self, box_df_broadcast_failure):
-        box = box_df_broadcast_failure
-
+    def test_parr_add_iadd_parr_raises(self, box):
         rng = pd.period_range('1/1/2000', freq='D', periods=5)
         other = pd.period_range('1/6/2000', freq='D', periods=5)
         # TODO: parametrize over boxes for other?
 
-        rng = tm.box_expected(rng, box)
+        rng = tm.box_expected(rng, box, transpose=True)
         # An earlier implementation of PeriodIndex addition performed
         # a set operation (union).  This has since been changed to
         # raise a TypeError. See GH#14164 and GH#13077 for historical
@@ -388,14 +386,12 @@ class TestPeriodIndexArithmetic(object):
         expected = pd.Index([pd.NaT, 0 * off, 0 * off, 0 * off, 0 * off])
         tm.assert_index_equal(result, expected)
 
-    def test_parr_sub_pi_mismatched_freq(self, box_df_broadcast_failure):
-        box = box_df_broadcast_failure
-
+    def test_parr_sub_pi_mismatched_freq(self, box):
         rng = pd.period_range('1/1/2000', freq='D', periods=5)
         other = pd.period_range('1/6/2000', freq='H', periods=5)
         # TODO: parametrize over boxes for other?
 
-        rng = tm.box_expected(rng, box)
+        rng = tm.box_expected(rng, box, transpose=True)
         with pytest.raises(period.IncompatibleFrequency):
             rng - other
 

--- a/pandas/tests/arithmetic/test_timedelta64.py
+++ b/pandas/tests/arithmetic/test_timedelta64.py
@@ -1342,20 +1342,18 @@ class TestTimedeltaArraylikeMulDivOps(object):
                                         Series([20, 30, 40])],
                              ids=lambda x: type(x).__name__)
     @pytest.mark.parametrize('op', [operator.mul, ops.rmul])
-    def test_td64arr_rmul_numeric_array(self, op, box_df_fail,
-                                        vector, dtype, tdser):
+    def test_td64arr_rmul_numeric_array(self, op, box, vector, dtype, tdser):
         # GH#4521
         # divide/multiply by integers
-        box = box_df_fail  # broadcasts incorrectly but doesn't raise
         vector = vector.astype(dtype)
 
         expected = Series(['1180 Days', '1770 Days', 'NaT'],
                           dtype='timedelta64[ns]')
 
-        tdser = tm.box_expected(tdser, box)
+        tdser = tm.box_expected(tdser, box, transpose=True)
         # TODO: Make this up-casting more systematic?
-        box = Series if (box is pd.Index and type(vector) is Series) else box
-        expected = tm.box_expected(expected, box)
+        box2 = Series if (box is pd.Index and type(vector) is Series) else box
+        expected = tm.box_expected(expected, box2, transpose=True)
 
         result = op(vector, tdser)
         tm.assert_equal(result, expected)

--- a/pandas/tests/arithmetic/test_timedelta64.py
+++ b/pandas/tests/arithmetic/test_timedelta64.py
@@ -1127,9 +1127,9 @@ class TestTimedeltaArraylikeMulDivOps(object):
         pd.Float64Index(range(1, 11)),
         pd.RangeIndex(1, 11)
     ], ids=lambda x: type(x).__name__)
-    def test_tdi_rmul_arraylike(self, other, box_df_fail):
+    def test_tdi_rmul_arraylike(self, other, box_df_broadcast_failure):
         # DataFrame tries to broadcast incorrectly
-        box = box_df_fail
+        box = box_df_broadcast_failure
 
         tdi = TimedeltaIndex(['1 Day'] * 10)
         expected = timedelta_range('1 days', '10 days')

--- a/pandas/tests/arithmetic/test_timedelta64.py
+++ b/pandas/tests/arithmetic/test_timedelta64.py
@@ -1128,7 +1128,6 @@ class TestTimedeltaArraylikeMulDivOps(object):
         pd.RangeIndex(1, 11)
     ], ids=lambda x: type(x).__name__)
     def test_tdi_rmul_arraylike(self, other, box_df_fail):
-        # RangeIndex fails to return NotImplemented, for others
         # DataFrame tries to broadcast incorrectly
         box = box_df_fail
 
@@ -1415,8 +1414,9 @@ class TestTimedeltaArraylikeMulDivOps(object):
         result = ser * tdi
         tm.assert_equal(result, expected)
 
-        # The direct operation tdi * ser still needs to be fixed.
         result = ser.__rmul__(tdi)
+        tm.assert_equal(result, expected)
+        result = tdi * ser
         tm.assert_equal(result, expected)
 
     # TODO: Should we be parametrizing over types for `ser` too?

--- a/pandas/tests/indexes/test_range.py
+++ b/pandas/tests/indexes/test_range.py
@@ -189,6 +189,25 @@ class TestRangeIndex(Numeric):
         assert copy.name == 'copy'
         assert new.name == 'new'
 
+    # TODO: mod, divmod?
+    @pytest.mark.parametrize('op', [operator.add, operator.sub,
+                                    operator.mul, operator.floordiv,
+                                    operator.truediv, operator.pow])
+    def test_arithmetic_with_frame_or_series(self, op):
+        # check that we return NotImplemented when operating with Series
+        # or DataFrame
+        index = pd.RangeIndex(5)
+        other = pd.Series(np.random.randn(5))
+
+        expected = op(pd.Series(index), other)
+        result = op(index, other)
+        tm.assert_series_equal(result, expected)
+
+        other = pd.DataFrame(np.random.randn(2, 5))
+        expected = op(pd.DataFrame([index, index]), other)
+        result = op(index, other)
+        tm.assert_frame_equal(result, expected)
+
     def test_numeric_compat2(self):
         # validate that we are handling the RangeIndex overrides to numeric ops
         # and returning RangeIndex where possible

--- a/pandas/tests/internals/test_internals.py
+++ b/pandas/tests/internals/test_internals.py
@@ -1243,7 +1243,6 @@ class TestCanHoldElement(object):
                    (operator.mul, '<M8[ns]'),
                    (operator.add, '<M8[ns]'),
                    (operator.pow, '<m8[ns]'),
-                   (operator.mod, '<m8[ns]'),
                    (operator.mul, '<m8[ns]')}
 
         if (op, dtype) in invalid:

--- a/pandas/util/testing.py
+++ b/pandas/util/testing.py
@@ -1544,7 +1544,7 @@ def assert_equal(left, right, **kwargs):
         raise NotImplementedError(type(left))
 
 
-def box_expected(expected, box_cls):
+def box_expected(expected, box_cls, transpose=False):
     """
     Helper function to wrap the expected output of a test in a given box_class.
 
@@ -1552,6 +1552,8 @@ def box_expected(expected, box_cls):
     ----------
     expected : np.ndarray, Index, Series
     box_cls : {Index, Series, DataFrame}
+    transpose : bool
+        whether to transpose the result; only relevant for DataFrame
 
     Returns
     -------
@@ -1563,6 +1565,11 @@ def box_expected(expected, box_cls):
         expected = pd.Series(expected)
     elif box_cls is pd.DataFrame:
         expected = pd.Series(expected).to_frame()
+        if transpose:
+            # For tests in which a DataFrame operates with a 1-dimensional
+            # array-like other, broadcasting conventions require us to transpose
+            # both the DataFrame operand and the expected result.
+            expected = expected.T
     else:
         raise NotImplementedError(box_cls)
     return expected

--- a/pandas/util/testing.py
+++ b/pandas/util/testing.py
@@ -1567,8 +1567,8 @@ def box_expected(expected, box_cls, transpose=False):
         expected = pd.Series(expected).to_frame()
         if transpose:
             # For tests in which a DataFrame operates with a 1-dimensional
-            # array-like other, broadcasting conventions require us to transpose
-            # both the DataFrame operand and the expected result.
+            # array-like other, broadcasting conventions require us to
+            # transpose both the DataFrame operand and the expected result.
             expected = expected.T
     else:
         raise NotImplementedError(box_cls)


### PR DESCRIPTION
Most of the remaining xfails in tests/arithmetic are caused by single-column DataFrame operations not being equivalent to Series/Index operations.  This PR fixes those tests by transposing both the DataFrame and the expected result in the appropriate cases.

We end up with 3 xfailed tests instead of 223.  Runtime drops from 168.9 seconds to 99.4 seconds.

Some other ancillary fixes along the way: RangeIndex correctly returns NotImplemented when operating with a DataFrame.  Series operations with Tick and non-nano timedelta64 are fixed.