### PR TITLE
TST: Update sparse data generation

### DIFF
--- a/pandas/tests/extension/test_sparse.py
+++ b/pandas/tests/extension/test_sparse.py
@@ -12,7 +12,7 @@ def make_data(fill_value):
     if np.isnan(fill_value):
         data = np.random.uniform(size=100)
     else:
-        data = np.random.randint(0, 100, size=100)
+        data = np.random.randint(1, 100, size=100)
 
     data[2::3] = fill_value
     return data


### PR DESCRIPTION
There's a spurious failure on master when the first
is randomly chosen to be 0, since type(arr.fill_value) doesn't
match arr.dtype.type

https://github.com/pandas-dev/pandas/issues/23124 will fix the underlying issue, but this works around it so we don't have tests failing randomly.

Closes https://github.com/pandas-dev/pandas/issues/23168