### PR TITLE
API/TST: make hasnans always return python booleans

### DIFF
--- a/doc/source/whatsnew/v0.24.0.txt
+++ b/doc/source/whatsnew/v0.24.0.txt
@@ -910,7 +910,7 @@ Other API Changes
   has an improved ``KeyError`` message, and will not fail on duplicate column names with ``drop=True``. (:issue:`22484`)
 - Slicing a single row of a DataFrame with multiple ExtensionArrays of the same type now preserves the dtype, rather than coercing to object (:issue:`22784`)
 - :class:`DateOffset` attribute `_cacheable` and method `_should_cache` have been removed (:issue:`23118`)
-- :meth:`Index.hasnans` now always returns a python boolean. Previously, it could return a python or a numpy boolean, depending on circumstances (:issue:`23294`).
+- :meth:`Index.hasnans` and :meth:`Series.hasnans` now always return a python boolean. Previously, a python or a numpy boolean could be returned, depending on circumstances (:issue:`23294`).
 
 .. _whatsnew_0240.deprecations:
 

--- a/doc/source/whatsnew/v0.24.0.txt
+++ b/doc/source/whatsnew/v0.24.0.txt
@@ -910,6 +910,7 @@ Other API Changes
   has an improved ``KeyError`` message, and will not fail on duplicate column names with ``drop=True``. (:issue:`22484`)
 - Slicing a single row of a DataFrame with multiple ExtensionArrays of the same type now preserves the dtype, rather than coercing to object (:issue:`22784`)
 - :class:`DateOffset` attribute `_cacheable` and method `_should_cache` have been removed (:issue:`23118`)
+- :meth:`Index.hasnans` now always returns a python boolean. Previously, it could return a python or a numpy boolean, depending on circumstances (:issue:`23294`).
 
 .. _whatsnew_0240.deprecations:
 

--- a/pandas/core/arrays/datetimelike.py
+++ b/pandas/core/arrays/datetimelike.py
@@ -219,7 +219,7 @@ class DatetimeLikeArrayMixin(ExtensionOpsMixin, AttributesMixin):
     @property  # NB: override with cache_readonly in immutable subclasses
     def hasnans(self):
         """ return if I have any nans; enables various perf speedups """
-        return self._isnan.any()
+        return bool(self._isnan.any())
 
     def _maybe_mask_results(self, result, fill_value=None, convert=None):
         """

--- a/pandas/core/base.py
+++ b/pandas/core/base.py
@@ -889,7 +889,7 @@ class IndexOpsMixin(object):
     @cache_readonly
     def hasnans(self):
         """ return if I have any nans; enables various perf speedups """
-        return isna(self).any()
+        return bool(isna(self).any())
 
     def _reduce(self, op, name, axis=0, skipna=True, numeric_only=None,
                 filter_type=None, **kwds):

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -2221,7 +2221,7 @@ class Index(IndexOpsMixin, PandasObject):
     def hasnans(self):
         """ return if I have any nans; enables various perf speedups """
         if self._can_hold_na:
-            return self._isnan.any()
+            return bool(self._isnan.any())
         else:
             return False
 

--- a/pandas/tests/indexes/common.py
+++ b/pandas/tests/indexes/common.py
@@ -417,7 +417,7 @@ class Base(object):
         # and doesn't contain nans.
         assert idx_unique.is_unique is True
         try:
-            assert not idx_unique.hasnans
+            assert idx_unique.hasnans is False
         except NotImplementedError:
             pass
 
@@ -916,7 +916,7 @@ class Base(object):
                 # cases in indices doesn't include NaN
                 expected = np.array([False] * len(idx), dtype=bool)
                 tm.assert_numpy_array_equal(idx._isnan, expected)
-                assert not idx.hasnans
+                assert idx.hasnans is False
 
                 idx = index.copy()
                 values = np.asarray(idx.values)
@@ -938,7 +938,7 @@ class Base(object):
                 expected = np.array([False] * len(idx), dtype=bool)
                 expected[1] = True
                 tm.assert_numpy_array_equal(idx._isnan, expected)
-                assert idx.hasnans
+                assert idx.hasnans is True
 
     def test_fillna(self):
         # GH 11343
@@ -978,7 +978,7 @@ class Base(object):
                 expected = np.array([False] * len(idx), dtype=bool)
                 expected[1] = True
                 tm.assert_numpy_array_equal(idx._isnan, expected)
-                assert idx.hasnans
+                assert idx.hasnans is True
 
     def test_nulls(self):
         # this is really a smoke test for the methods

--- a/pandas/tests/indexes/datetimes/test_ops.py
+++ b/pandas/tests/indexes/datetimes/test_ops.py
@@ -356,7 +356,7 @@ class TestDatetimeIndexOps(Ops):
         assert idx._can_hold_na
 
         tm.assert_numpy_array_equal(idx._isnan, np.array([False, False]))
-        assert not idx.hasnans
+        assert idx.hasnans is False
         tm.assert_numpy_array_equal(idx._nan_idxs,
                                     np.array([], dtype=np.intp))
 
@@ -364,7 +364,7 @@ class TestDatetimeIndexOps(Ops):
         assert idx._can_hold_na
 
         tm.assert_numpy_array_equal(idx._isnan, np.array([False, True]))
-        assert idx.hasnans
+        assert idx.hasnans is True
         tm.assert_numpy_array_equal(idx._nan_idxs,
                                     np.array([1], dtype=np.intp))
 

--- a/pandas/tests/indexes/interval/test_interval.py
+++ b/pandas/tests/indexes/interval/test_interval.py
@@ -93,7 +93,7 @@ class TestIntervalIndex(Base):
 
     def test_with_nans(self, closed):
         index = self.create_index(closed=closed)
-        assert not index.hasnans
+        assert index.hasnans is False
 
         result = index.isna()
         expected = np.repeat(False, len(index))
@@ -104,7 +104,7 @@ class TestIntervalIndex(Base):
         tm.assert_numpy_array_equal(result, expected)
 
         index = self.create_index_with_nan(closed=closed)
-        assert index.hasnans
+        assert index.hasnans is True
 
         result = index.isna()
         expected = np.array([False, True] + [False] * (len(index) - 2))

--- a/pandas/tests/indexes/multi/test_missing.py
+++ b/pandas/tests/indexes/multi/test_missing.py
@@ -49,7 +49,7 @@ def test_fillna(idx):
             expected = np.array([False] * len(idx), dtype=bool)
             expected[1] = True
             tm.assert_numpy_array_equal(idx._isnan, expected)
-            assert idx.hasnans
+            assert idx.hasnans is True
 
 
 def test_dropna():
@@ -91,7 +91,7 @@ def test_hasnans_isnans(idx):
     # cases in indices doesn't include NaN
     expected = np.array([False] * len(index), dtype=bool)
     tm.assert_numpy_array_equal(index._isnan, expected)
-    assert not index.hasnans
+    assert index.hasnans is False
 
     index = idx.copy()
     values = index.values
@@ -102,7 +102,7 @@ def test_hasnans_isnans(idx):
     expected = np.array([False] * len(index), dtype=bool)
     expected[1] = True
     tm.assert_numpy_array_equal(index._isnan, expected)
-    assert index.hasnans
+    assert index.hasnans is True
 
 
 def test_nan_stays_float():

--- a/pandas/tests/indexes/period/test_ops.py
+++ b/pandas/tests/indexes/period/test_ops.py
@@ -356,7 +356,7 @@ class TestPeriodIndexOps(Ops):
         assert idx._can_hold_na
 
         tm.assert_numpy_array_equal(idx._isnan, np.array([False, False]))
-        assert not idx.hasnans
+        assert idx.hasnans is False
         tm.assert_numpy_array_equal(idx._nan_idxs,
                                     np.array([], dtype=np.intp))
 
@@ -364,7 +364,7 @@ class TestPeriodIndexOps(Ops):
         assert idx._can_hold_na
 
         tm.assert_numpy_array_equal(idx._isnan, np.array([False, True]))
-        assert idx.hasnans
+        assert idx.hasnans is True
         tm.assert_numpy_array_equal(idx._nan_idxs,
                                     np.array([1], dtype=np.intp))
 

--- a/pandas/tests/indexes/timedeltas/test_ops.py
+++ b/pandas/tests/indexes/timedeltas/test_ops.py
@@ -273,7 +273,7 @@ class TestTimedeltaIndexOps(Ops):
         assert idx._can_hold_na
 
         tm.assert_numpy_array_equal(idx._isnan, np.array([False, False]))
-        assert not idx.hasnans
+        assert idx.hasnans is False
         tm.assert_numpy_array_equal(idx._nan_idxs,
                                     np.array([], dtype=np.intp))
 
@@ -281,7 +281,7 @@ class TestTimedeltaIndexOps(Ops):
         assert idx._can_hold_na
 
         tm.assert_numpy_array_equal(idx._isnan, np.array([False, True]))
-        assert idx.hasnans
+        assert idx.hasnans is True
         tm.assert_numpy_array_equal(idx._nan_idxs,
                                     np.array([1], dtype=np.intp))
 

--- a/pandas/tests/series/test_internals.py
+++ b/pandas/tests/series/test_internals.py
@@ -315,11 +315,11 @@ class TestSeriesInternals(object):
 def test_hasnans_unchached_for_series():
     # GH#19700
     idx = pd.Index([0, 1])
-    assert not idx.hasnans
+    assert idx.hasnans is False
     assert 'hasnans' in idx._cache
     ser = idx.to_series()
-    assert not ser.hasnans
+    assert ser.hasnans is False
     assert not hasattr(ser, '_cache')
     ser.iloc[-1] = np.nan
-    assert ser.hasnans
+    assert ser.hasnans is True
     assert pd.Series.hasnans.__doc__ == pd.Index.hasnans.__doc__


### PR DESCRIPTION
- [x] xref #23294
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry

``Index.hasnans`` currently returns either a python or a numpy boolean, depending on circumstances. This PR ensures that only python booleans ae returned and makes the tests for hasnans stricter.
