### PR TITLE
unpin openpyxl

### DIFF
--- a/ci/azure-27-compat.yaml
+++ b/ci/azure-27-compat.yaml
@@ -8,7 +8,7 @@ dependencies:
   - jinja2=2.8
   - numexpr=2.6.1
   - numpy=1.12.0
-  - openpyxl=2.5.5
+  - openpyxl
   - psycopg2
   - pytables=3.4.2
   - python-dateutil=2.5.0

--- a/ci/azure-27-compat.yaml
+++ b/ci/azure-27-compat.yaml
@@ -8,7 +8,7 @@ dependencies:
   - jinja2=2.8
   - numexpr=2.6.1
   - numpy=1.12.0
-  - openpyxl
+  - openpyxl=2.5.5
   - psycopg2
   - pytables=3.4.2
   - python-dateutil=2.5.0

--- a/ci/azure-36-locale_slow.yaml
+++ b/ci/azure-36-locale_slow.yaml
@@ -14,7 +14,7 @@ dependencies:
   - nomkl
   - numexpr
   - numpy
-  - openpyxl=2.5.5
+  - openpyxl
   - psycopg2
   - pymysql
   - pytables

--- a/ci/azure-37-locale.yaml
+++ b/ci/azure-37-locale.yaml
@@ -13,7 +13,7 @@ dependencies:
   - nomkl
   - numexpr
   - numpy
-  - openpyxl=2.5.5
+  - openpyxl
   - psycopg2
   - pymysql
   - pytables

--- a/ci/azure-macos-35.yaml
+++ b/ci/azure-macos-35.yaml
@@ -12,7 +12,7 @@ dependencies:
   - nomkl
   - numexpr
   - numpy=1.12.0
-  - openpyxl=2.5.5
+  - openpyxl
   - pytables
   - python=3.5*
   - pytz

--- a/ci/azure-windows-27.yaml
+++ b/ci/azure-windows-27.yaml
@@ -13,7 +13,7 @@ dependencies:
   - matplotlib=2.0.1
   - numexpr
   - numpy=1.12*
-  - openpyxl=2.5.5
+  - openpyxl
   - pytables
   - python=2.7.*
   - pytz

--- a/ci/azure-windows-36.yaml
+++ b/ci/azure-windows-36.yaml
@@ -11,7 +11,7 @@ dependencies:
   - matplotlib
   - numexpr
   - numpy=1.14*
-  - openpyxl=2.5.5
+  - openpyxl
   - parquet-cpp
   - pyarrow
   - pytables

--- a/ci/circle-36-locale.yaml
+++ b/ci/circle-36-locale.yaml
@@ -13,7 +13,7 @@ dependencies:
   - nomkl
   - numexpr
   - numpy
-  - openpyxl=2.5.5
+  - openpyxl
   - psycopg2
   - pymysql
   - pytables

--- a/ci/requirements-optional-conda.txt
+++ b/ci/requirements-optional-conda.txt
@@ -12,7 +12,7 @@ lxml
 matplotlib>=2.0.0
 nbsphinx
 numexpr>=2.6.1
-openpyxl=2.5.5
+openpyxl
 pyarrow
 pymysql
 pytables>=3.4.2

--- a/ci/requirements-optional-pip.txt
+++ b/ci/requirements-optional-pip.txt
@@ -14,7 +14,7 @@ lxml
 matplotlib>=2.0.0
 nbsphinx
 numexpr>=2.6.1
-openpyxl==2.5.5
+openpyxl
 pyarrow
 pymysql
 tables

--- a/ci/travis-36-doc.yaml
+++ b/ci/travis-36-doc.yaml
@@ -22,7 +22,7 @@ dependencies:
   - notebook
   - numexpr
   - numpy=1.13*
-  - openpyxl=2.5.5
+  - openpyxl
   - pandoc
   - pyqt
   - pytables

--- a/ci/travis-36-slow.yaml
+++ b/ci/travis-36-slow.yaml
@@ -10,7 +10,7 @@ dependencies:
   - matplotlib
   - numexpr
   - numpy
-  - openpyxl=2.5.5
+  - openpyxl
   - patsy
   - psycopg2
   - pymysql

--- a/ci/travis-36.yaml
+++ b/ci/travis-36.yaml
@@ -21,7 +21,7 @@ dependencies:
   - nomkl
   - numexpr
   - numpy
-  - openpyxl=2.5.5
+  - openpyxl
   - psycopg2
   - pyarrow
   - pymysql


### PR DESCRIPTION
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`

- Follow up from #22601.

- Confirmed with openpyxl this bug was fixed in version 2.5.7 see [bitbucket issue here](https://bitbucket.org/openpyxl/openpyxl/issues/1093/newly-introduced-keyerror-problem-in)

This was release 13th Sept -> https://pypi.org/project/openpyxl/#history
