### PR TITLE
CLN: Cleanup top-level pandas namespace

### DIFF
--- a/doc/source/whatsnew/v0.24.0.txt
+++ b/doc/source/whatsnew/v0.24.0.txt
@@ -943,6 +943,7 @@ Removal of prior version deprecations/changes
 - :meth:`Index.repeat` and :meth:`MultiIndex.repeat` have renamed the ``n`` argument to ``repeats`` (:issue:`14645`)
 - Removal of the previously deprecated ``as_indexer`` keyword completely from ``str.match()`` (:issue:`22356`, :issue:`6581`)
 - Removed the ``pandas.formats.style`` shim for :class:`pandas.io.formats.style.Styler` (:issue:`16059`)
+- :func:`pandas.pnow`, :func:`pandas.match`, :func:`pandas.groupby`, :func:`pd.get_store`, ``pd.Expr``, and ``pd.Term`` have been removed (:issue:`15538`, :issue:`15940`)
 - :meth:`Categorical.searchsorted` and :meth:`Series.searchsorted` have renamed the ``v`` argument to ``value`` (:issue:`14645`)
 - :meth:`TimedeltaIndex.searchsorted`, :meth:`DatetimeIndex.searchsorted`, and :meth:`PeriodIndex.searchsorted` have renamed the ``key`` argument to ``value`` (:issue:`14645`)
 - Removal of the previously deprecated module ``pandas.json`` (:issue:`19944`)

--- a/pandas/core/api.py
+++ b/pandas/core/api.py
@@ -14,7 +14,7 @@ from pandas.core.index import (Index, CategoricalIndex, Int64Index,
                                MultiIndex, IntervalIndex,
                                TimedeltaIndex, DatetimeIndex,
                                PeriodIndex, NaT)
-from pandas.core.indexes.period import Period, period_range, pnow
+from pandas.core.indexes.period import Period, period_range
 from pandas.core.indexes.timedeltas import Timedelta, timedelta_range
 from pandas.core.indexes.datetimes import Timestamp, date_range, bdate_range
 from pandas.core.indexes.interval import Interval, interval_range
@@ -34,27 +34,6 @@ from pandas.core.tools.timedeltas import to_timedelta
 
 from pandas.core.config import (get_option, set_option, reset_option,
                                 describe_option, option_context, options)
-
-
-# deprecation, xref #13790
-def match(*args, **kwargs):
-
-    import warnings
-    warnings.warn("pd.match() is deprecated and will be removed "
-                  "in a future version",
-                  FutureWarning, stacklevel=2)
-    from pandas.core.algorithms import match
-    return match(*args, **kwargs)
-
-
-def groupby(*args, **kwargs):
-    import warnings
-
-    warnings.warn("pd.groupby() is deprecated and will be removed; "
-                  "Please use the Series.groupby() or "
-                  "DataFrame.groupby() methods",
-                  FutureWarning, stacklevel=2)
-    return args[0].groupby(*args[1:], **kwargs)
 
 
 # Deprecation: xref gh-16747

--- a/pandas/core/computation/api.py
+++ b/pandas/core/computation/api.py
@@ -1,14 +1,3 @@
 # flake8: noqa
 
 from pandas.core.computation.eval import eval
-
-
-# deprecation, xref #13790
-def Expr(*args, **kwargs):
-    import warnings
-
-    warnings.warn("pd.Expr is deprecated as it is not "
-                  "applicable to user code",
-                  FutureWarning, stacklevel=2)
-    from pandas.core.computation.expr import Expr
-    return Expr(*args, **kwargs)

--- a/pandas/core/indexes/period.py
+++ b/pandas/core/indexes/period.py
@@ -982,14 +982,6 @@ PeriodIndex._add_logical_methods_disabled()
 PeriodIndex._add_datetimelike_methods()
 
 
-def pnow(freq=None):
-    # deprecation, xref #13790
-    warnings.warn("pd.pnow() and pandas.core.indexes.period.pnow() "
-                  "are deprecated. Please use Period.now()",
-                  FutureWarning, stacklevel=2)
-    return Period.now(freq=freq)
-
-
 def period_range(start=None, end=None, periods=None, freq='D', name=None):
     """
     Return a fixed frequency PeriodIndex, with day (calendar) as the default

--- a/pandas/io/api.py
+++ b/pandas/io/api.py
@@ -14,20 +14,7 @@ from pandas.io.packers import read_msgpack, to_msgpack
 from pandas.io.parquet import read_parquet
 from pandas.io.parsers import read_csv, read_fwf, read_table
 from pandas.io.pickle import read_pickle, to_pickle
-from pandas.io.pytables import HDFStore, get_store, read_hdf
+from pandas.io.pytables import HDFStore, read_hdf
 from pandas.io.sas import read_sas
 from pandas.io.sql import read_sql, read_sql_query, read_sql_table
 from pandas.io.stata import read_stata
-
-
-# deprecation, xref #13790
-def Term(*args, **kwargs):
-    import warnings
-
-    warnings.warn("pd.Term is deprecated as it is not "
-                  "applicable to user code. Instead use in-line "
-                  "string expressions in the where clause when "
-                  "searching in HDFStore",
-                  FutureWarning, stacklevel=2)
-    from pandas.io.pytables import Term
-    return Term(*args, **kwargs)

--- a/pandas/io/pytables.py
+++ b/pandas/io/pytables.py
@@ -1416,19 +1416,6 @@ class HDFStore(StringMixin):
         return s.read(**kwargs)
 
 
-def get_store(path, **kwargs):
-    """ Backwards compatible alias for ``HDFStore``
-    """
-    warnings.warn(
-        "get_store is deprecated and be "
-        "removed in a future version\n"
-        "HDFStore(path, **kwargs) is the replacement",
-        FutureWarning,
-        stacklevel=6)
-
-    return HDFStore(path, **kwargs)
-
-
 class TableIterator(object):
 
     """ define the iteration interface on a table

--- a/pandas/tests/api/test_api.py
+++ b/pandas/tests/api/test_api.py
@@ -49,7 +49,7 @@ class TestPDApi(Base):
                'TimedeltaIndex', 'Timestamp', 'Interval', 'IntervalIndex']
 
     # these are already deprecated; awaiting removal
-    deprecated_classes = ['TimeGrouper', 'Expr', 'Term']
+    deprecated_classes = ['TimeGrouper']
 
     # these should be deprecated in the future
     deprecated_classes_in_future = ['Panel']
@@ -89,8 +89,7 @@ class TestPDApi(Base):
     deprecated_funcs_in_future = []
 
     # these are already deprecated; awaiting removal
-    deprecated_funcs = ['pnow', 'match', 'groupby', 'get_store',
-                        'plot_params', 'scatter_matrix']
+    deprecated_funcs = ['plot_params', 'scatter_matrix']
 
     def test_api(self):
 
@@ -131,45 +130,10 @@ class TestTopLevelDeprecations(object):
     # top-level API deprecations
     # GH 13790
 
-    def test_pnow(self):
-        with tm.assert_produces_warning(FutureWarning,
-                                        check_stacklevel=False):
-            pd.pnow(freq='M')
-
-    def test_term(self):
-        with tm.assert_produces_warning(FutureWarning,
-                                        check_stacklevel=False):
-            pd.Term('index>=date')
-
-    def test_expr(self):
-        with tm.assert_produces_warning(FutureWarning,
-                                        check_stacklevel=False):
-            pd.Expr('2>1')
-
-    def test_match(self):
-        with tm.assert_produces_warning(FutureWarning,
-                                        check_stacklevel=False):
-            pd.match([1, 2, 3], [1])
-
-    def test_groupby(self):
-        with tm.assert_produces_warning(FutureWarning,
-                                        check_stacklevel=False):
-            pd.groupby(pd.Series([1, 2, 3]), [1, 1, 1])
-
     def test_TimeGrouper(self):
         with tm.assert_produces_warning(FutureWarning,
                                         check_stacklevel=False):
             pd.TimeGrouper(freq='D')
-
-    # GH 15940
-
-    def test_get_store(self):
-        pytest.importorskip('tables')
-        with tm.ensure_clean() as path:
-            with tm.assert_produces_warning(FutureWarning,
-                                            check_stacklevel=False):
-                s = pd.get_store(path)
-                s.close()
 
 
 class TestParser(object):

--- a/pandas/tests/io/test_pytables.py
+++ b/pandas/tests/io/test_pytables.py
@@ -32,7 +32,7 @@ from pandas.core.dtypes.common import is_categorical_dtype
 tables = pytest.importorskip('tables')
 from pandas.io import pytables as pytables  # noqa:E402
 from pandas.io.pytables import (TableIterator,  # noqa:E402
-                                HDFStore, get_store, Term, read_hdf,
+                                HDFStore, Term, read_hdf,
                                 PossibleDataLossError, ClosedFileError)
 
 
@@ -145,32 +145,6 @@ class Base(object):
 @pytest.mark.single
 @pytest.mark.filterwarnings("ignore:\\nPanel:FutureWarning")
 class TestHDFStore(Base):
-
-    def test_factory_fun(self):
-        path = create_tempfile(self.path)
-        try:
-            with tm.assert_produces_warning(FutureWarning,
-                                            check_stacklevel=False):
-                with get_store(path) as tbl:
-                    raise ValueError('blah')
-        except ValueError:
-            pass
-        finally:
-            safe_remove(path)
-
-        try:
-            with tm.assert_produces_warning(FutureWarning,
-                                            check_stacklevel=False):
-                with get_store(path) as tbl:
-                    tbl['a'] = tm.makeDataFrame()
-
-            with tm.assert_produces_warning(FutureWarning,
-                                            check_stacklevel=False):
-                with get_store(path) as tbl:
-                    assert len(tbl) == 1
-                    assert type(tbl['a']) == DataFrame
-        finally:
-            safe_remove(self.path)
 
     def test_context(self):
         path = create_tempfile(self.path)

--- a/pandas/tests/scalar/period/test_period.py
+++ b/pandas/tests/scalar/period/test_period.py
@@ -843,13 +843,6 @@ class TestPeriodProperties(object):
         assert Period(freq='Min', year=2012, month=2, day=1, hour=0,
                       minute=0, second=0).days_in_month == 29
 
-    def test_pnow(self):
-
-        # deprecation, xref #13790
-        with tm.assert_produces_warning(FutureWarning,
-                                        check_stacklevel=False):
-            period.pnow('D')
-
     def test_constructor_corner(self):
         expected = Period('2007-01', freq='2M')
         assert Period(year=2007, month=1, freq='2M') == expected


### PR DESCRIPTION
Drops the following:

* `pd.pnow`
* `pd.match`
* `pd.groupby`
* `pd.get_store`

As well as:

* `pd.Expr`
* `pd.Term`

xref #15538.
xref #15940.
