### PR TITLE
TST: unxfail combine-concat

### DIFF
--- a/pandas/tests/frame/test_combine_concat.py
+++ b/pandas/tests/frame/test_combine_concat.py
@@ -72,13 +72,10 @@ class TestDataFrameConcatCommon(TestData):
         expected = DataFrame(dict(time=[ts2, ts3]))
         assert_frame_equal(results, expected)
 
-    @pytest.mark.parametrize(
-        't1',
-        [
-            '2015-01-01',
-            pytest.param(pd.NaT, marks=pytest.mark.xfail(
-                reason='GH23037 incorrect dtype when concatenating',
-                strict=True))])
+    @pytest.mark.parametrize('t1', [
+        '2015-01-01',
+        pd.NaT,
+    ])
     def test_concat_tz_NaT(self, t1):
         # GH 22796
         # Concating tz-aware multicolumn DataFrames


### PR DESCRIPTION
I don't know why this wasn't failing on master, but I can reproduce locally.

https://github.com/pandas-dev/pandas/pull/23336#issuecomment-433637555