### PR TITLE
CLN: Remove some dtype methods from API

### DIFF
--- a/doc/source/whatsnew/v0.24.0.txt
+++ b/doc/source/whatsnew/v0.24.0.txt
@@ -954,6 +954,7 @@ Removal of prior version deprecations/changes
 - :meth:`DataFrame.sortlevel` and :meth:`Series.sortlevel` have been removed (:issue:`15099`)
 - :meth:`SparseSeries.to_dense` has dropped the ``sparse_only`` parameter (:issue:`14686`)
 - :meth:`DataFrame.astype` and :meth:`Series.astype` have renamed the ``raise_on_error`` argument to ``errors`` (:issue:`14967`)
+- ``is_sequence``, ``is_any_int_dtype``, and ``is_floating_dtype`` have been removed from ``pandas.api.types`` (:issue:`16163`, :issue:`16189`)
 
 .. _whatsnew_0240.performance:
 

--- a/pandas/core/dtypes/api.py
+++ b/pandas/core/dtypes/api.py
@@ -1,7 +1,5 @@
 # flake8: noqa
 
-import sys
-
 from .common import (pandas_dtype,
                      is_dtype_equal,
                      is_extension_type,
@@ -59,24 +57,3 @@ from .common import (pandas_dtype,
                      is_list_like,
                      is_hashable,
                      is_named_tuple)
-
-
-# deprecated
-m = sys.modules['pandas.core.dtypes.api']
-
-for t in ['is_any_int_dtype', 'is_floating_dtype', 'is_sequence']:
-
-    def outer(t=t):
-
-        def wrapper(arr_or_dtype):
-            import warnings
-            import pandas
-            warnings.warn("{t} is deprecated and will be "
-                          "removed in a future version".format(t=t),
-                          FutureWarning, stacklevel=3)
-            return getattr(pandas.core.dtypes.common, t)(arr_or_dtype)
-        return wrapper
-
-    setattr(m, t, outer(t))
-
-del sys, m, t, outer

--- a/pandas/core/dtypes/common.py
+++ b/pandas/core/dtypes/common.py
@@ -796,10 +796,10 @@ def is_dtype_union_equal(source, target):
 def is_any_int_dtype(arr_or_dtype):
     """Check whether the provided array or dtype is of an integer dtype.
 
-    .. deprecated:: 0.20.0
-
     In this function, timedelta64 instances are also considered "any-integer"
     type objects and will return True.
+
+    This function is internal and should not be exposed in the public API.
 
     Parameters
     ----------
@@ -1559,6 +1559,8 @@ def is_string_like_dtype(arr_or_dtype):
 def is_float_dtype(arr_or_dtype):
     """
     Check whether the provided array or dtype is of a float dtype.
+
+    This function is internal and should not be exposed in the public API.
 
     Parameters
     ----------

--- a/pandas/tests/api/test_types.py
+++ b/pandas/tests/api/test_types.py
@@ -27,7 +27,7 @@ class TestTypes(Base):
                'is_list_like', 'is_hashable', 'is_array_like',
                'is_named_tuple',
                'pandas_dtype', 'union_categoricals', 'infer_dtype']
-    deprecated = ['is_any_int_dtype', 'is_floating_dtype', 'is_sequence']
+    deprecated = []
     dtypes = ['CategoricalDtype', 'DatetimeTZDtype',
               'PeriodDtype', 'IntervalDtype']
 


### PR DESCRIPTION
Removes the following from the public API:

* `pandas.api.types.is_sequence`
* `pandas.api.types.is_any_int_dtype`
* `pandas.api.types.is_floating_dtype`

xref #16163.
xref #16189.
