### PR TITLE
DOC: Remove Series.sortlevel from api.rst

### DIFF
--- a/doc/source/api.rst
+++ b/doc/source/api.rst
@@ -515,7 +515,6 @@ Reshaping, sorting
    Series.repeat
    Series.squeeze
    Series.view
-   Series.sortlevel
 
 
 Combining / joining / merging


### PR DESCRIPTION
https://travis-ci.org/pandas-dev/pandas/jobs/447288079#L1918

Was dropped in #15099 but accidentally added back in #18202.

Follow-up to #23375.