### PR TITLE
DEPR: Deprecate FrozenNDArray

### DIFF
--- a/doc/source/whatsnew/v0.24.0.txt
+++ b/doc/source/whatsnew/v0.24.0.txt
@@ -930,6 +930,7 @@ Deprecations
 - :func:`DatetimeIndex.shift` and :func:`PeriodIndex.shift` now accept ``periods`` argument instead of ``n`` for consistency with :func:`Index.shift` and :func:`Series.shift`. Using ``n`` throws a deprecation warning (:issue:`22458`, :issue:`22912`)
 - The ``fastpath`` keyword of the different Index constructors is deprecated (:issue:`23110`).
 - :meth:`Timestamp.tz_localize`, :meth:`DatetimeIndex.tz_localize`, and :meth:`Series.tz_localize` have deprecated the ``errors`` argument in favor of the ``nonexistent`` argument (:issue:`8917`)
+- The class ``FrozenNDArray`` has been deprecated. When unpickling, ``FrozenNDArray`` will be unpickled to ``np.ndarray`` once this class is removed (:issue:`9031`)
 
 .. _whatsnew_0240.prior_deprecations:
 

--- a/pandas/compat/pickle_compat.py
+++ b/pandas/compat/pickle_compat.py
@@ -60,6 +60,17 @@ _class_locations_map = {
         ('pandas.core.arrays', 'SparseArray'),
 
     # 15477
+    #
+    # TODO: When FrozenNDArray is removed, add
+    # the following lines for compat:
+    #
+    # ('pandas.core.base', 'FrozenNDArray'):
+    #     ('numpy', 'ndarray'),
+    # ('pandas.core.indexes.frozen', 'FrozenNDArray'):
+    #     ('numpy', 'ndarray'),
+    #
+    # Afterwards, remove the current entry
+    # for `pandas.core.base.FrozenNDArray`.
     ('pandas.core.base', 'FrozenNDArray'):
         ('pandas.core.indexes.frozen', 'FrozenNDArray'),
     ('pandas.core.base', 'FrozenList'):

--- a/pandas/core/indexes/frozen.py
+++ b/pandas/core/indexes/frozen.py
@@ -8,6 +8,7 @@ These are used for:
 
 """
 
+import warnings
 import numpy as np
 from pandas.core.base import PandasObject
 from pandas.util._decorators import deprecate_kwarg
@@ -86,6 +87,10 @@ class FrozenNDArray(PandasObject, np.ndarray):
 
     # no __array_finalize__ for now because no metadata
     def __new__(cls, data, dtype=None, copy=False):
+        warnings.warn("\nFrozenNDArray is deprecated and will be removed in a "
+                      "future version.\nPlease use `numpy.ndarray` instead.\n",
+                      FutureWarning, stacklevel=2)
+
         if copy is None:
             copy = not isinstance(data, FrozenNDArray)
         res = np.array(data, dtype=dtype, copy=copy).view(cls)

--- a/pandas/core/indexes/multi.py
+++ b/pandas/core/indexes/multi.py
@@ -40,8 +40,7 @@ from pandas.core.indexes.base import (
     Index, ensure_index,
     InvalidIndexError,
     _index_shared_docs)
-from pandas.core.indexes.frozen import (
-    FrozenNDArray, FrozenList, _ensure_frozen)
+from pandas.core.indexes.frozen import FrozenList, _ensure_frozen
 import pandas.core.indexes.base as ibase
 _index_doc_kwargs = dict(ibase._index_doc_kwargs)
 _index_doc_kwargs.update(
@@ -1655,7 +1654,7 @@ class MultiIndex(Index):
                 for new_label in taken:
                     label_values = new_label.values()
                     label_values[mask] = na_value
-                    masked.append(FrozenNDArray(label_values))
+                    masked.append(np.asarray(label_values))
                 taken = masked
         else:
             taken = [lab.take(indices) for lab in self.labels]

--- a/pandas/tests/indexes/test_frozen.py
+++ b/pandas/tests/indexes/test_frozen.py
@@ -1,3 +1,4 @@
+import warnings
 import numpy as np
 
 from pandas.compat import u
@@ -34,12 +35,22 @@ class TestFrozenList(CheckImmutable, CheckStringMixin):
 
 class TestFrozenNDArray(CheckImmutable, CheckStringMixin):
     mutable_methods = ('put', 'itemset', 'fill')
-    unicode_container = FrozenNDArray([u("\u05d0"), u("\u05d1"), "c"])
 
-    def setup_method(self, method):
+    def setup_method(self, _):
         self.lst = [3, 5, 7, -2]
-        self.container = FrozenNDArray(self.lst)
         self.klass = FrozenNDArray
+
+        with warnings.catch_warnings(record=True):
+            warnings.simplefilter("ignore", FutureWarning)
+
+            self.container = FrozenNDArray(self.lst)
+            self.unicode_container = FrozenNDArray(
+                [u("\u05d0"), u("\u05d1"), "c"])
+
+    def test_constructor_warns(self):
+        # see gh-9031
+        with tm.assert_produces_warning(FutureWarning):
+            FrozenNDArray([1, 2, 3])
 
     def test_shallow_copying(self):
         original = self.container.copy()


### PR DESCRIPTION
Rationale can be found [here](https://github.com/pandas-dev/pandas/issues/9031#issuecomment-306658765).

Closes #9031.

xref #14565 (potentially can close this given how central `FrozenNDArray` was to discussion)