### PR TITLE
ENH: Use flake8 to check for PEP8 violations in doctests

### DIFF
--- a/scripts/tests/test_validate_docstrings.py
+++ b/scripts/tests/test_validate_docstrings.py
@@ -127,6 +127,7 @@ class GoodDocStrings(object):
 
         Examples
         --------
+        >>> import pandas as pd
         >>> s = pd.Series(['Ant', 'Bear', 'Cow', 'Dog', 'Falcon'])
         >>> s.head()
         0   Ant
@@ -164,6 +165,7 @@ class GoodDocStrings(object):
 
         Examples
         --------
+        >>> import pandas as pd
         >>> s = pd.Series(['Antelope', 'Lion', 'Zebra', np.nan])
         >>> s.str.contains(pat='a')
         0    False

--- a/scripts/tests/test_validate_docstrings.py
+++ b/scripts/tests/test_validate_docstrings.py
@@ -166,6 +166,7 @@ class GoodDocStrings(object):
         Examples
         --------
         >>> import pandas as pd
+        >>> import numpy as np
         >>> s = pd.Series(['Antelope', 'Lion', 'Zebra', np.nan])
         >>> s.str.contains(pat='a')
         0    False

--- a/scripts/tests/test_validate_docstrings.py
+++ b/scripts/tests/test_validate_docstrings.py
@@ -225,8 +225,9 @@ class GoodDocStrings(object):
         Examples
         --------
         This example does not import pandas or import numpy.
-        >>> import time
         >>> import datetime
+        >>> datetime.MAXYEAR
+        9999
         """
         pass
 
@@ -672,7 +673,7 @@ class TestValidator(object):
     @capture_stderr
     @pytest.mark.parametrize("func", [
         'plot', 'sample', 'random_letters', 'sample_values', 'head', 'head1',
-        'contains', 'mode'])
+        'contains', 'mode', 'good_imports'])
     def test_good_functions(self, func):
         errors = validate_one(self._import_path(
             klass='GoodDocStrings', func=func))['errors']

--- a/scripts/tests/test_validate_docstrings.py
+++ b/scripts/tests/test_validate_docstrings.py
@@ -587,6 +587,29 @@ class BadSeeAlso(object):
         pass
 
 
+class BadExamples(object):
+
+    def doctest(self):
+        """
+        Return whether each value contains `pat`.
+
+        Examples
+        --------
+        >>> import pandas as pd
+        >>> df = pd.DataFrame(np.ones((3, 3)),
+        ...                   columns=('a', 'b', 'c'))
+        >>> df.all(1)
+        0    True
+        1    True
+        2    True
+        dtype: bool
+
+        >>> df.all(bool_only=True)
+        Series([], dtype: bool)
+        """
+        pass
+
+
 class TestValidator(object):
 
     def _import_path(self, klass=None, func=None):
@@ -706,10 +729,13 @@ class TestValidator(object):
         # See Also tests
         ('BadSeeAlso', 'prefix_pandas',
          ('pandas.Series.rename in `See Also` section '
-          'does not need `pandas` prefix',))
+          'does not need `pandas` prefix',)),
+        # Examples tests
+        ('BadExamples', 'doctest',
+         ('1 F821 undefined name \'np\'',))
     ])
     def test_bad_examples(self, capsys, klass, func, msgs):
-        result = validate_one(self._import_path(klass=klass, func=func))  # noqa:F821
+        result = validate_one(self._import_path(klass=klass, func=func))
         for msg in msgs:
             assert msg in ' '.join(result['errors'])
 

--- a/scripts/tests/test_validate_docstrings.py
+++ b/scripts/tests/test_validate_docstrings.py
@@ -584,21 +584,12 @@ class BadSeeAlso(object):
 
 class BadExamples(object):
 
-    def numpy_imported(self):
+    def unused_import(self):
         """
         Examples
         --------
-        >>> import numpy as np
+        >>> import pandas as pdf
         >>> df = pd.DataFrame(np.ones((3, 3)), columns=('a', 'b', 'c'))
-        """
-        pass
-
-    def pandas_imported(self):
-        """
-        Examples
-        --------
-        >>> import pandas as pd
-        >>> s = pd.Series(['Antelope', 'Lion', 'Zebra', np.nan])
         """
         pass
 
@@ -750,16 +741,12 @@ class TestValidator(object):
          ('pandas.Series.rename in `See Also` section '
           'does not need `pandas` prefix',)),
         # Examples tests
-        ('BadExamples', 'numpy_imported',
-         ('F811 It\'s assumed that pandas and numpy'
-          ' are imported as pd or np',)),
-        ('BadExamples', 'pandas_imported',
-         ('F811 It\'s assumed that pandas and numpy'
-          ' are imported as pd or np',)),
+        ('BadExamples', 'unused_import',
+         ('1 F401 \'pandas as pdf\' imported but unused',)),
         ('BadExamples', 'indentation_is_not_a_multiple_of_four',
-         ('E111 indentation is not a multiple of four',)),
+         ('1 E111 indentation is not a multiple of four',)),
         ('BadExamples', 'missing_whitespace_around_arithmetic_operator',
-         ('E226 missing whitespace around arithmetic operator',)),
+         ('1 E226 missing whitespace around arithmetic operator',)),
         ('BadExamples', 'missing_whitespace_after_comma',
          ('3 E231 missing whitespace after \',\'',)),
     ])

--- a/scripts/tests/test_validate_docstrings.py
+++ b/scripts/tests/test_validate_docstrings.py
@@ -127,7 +127,6 @@ class GoodDocStrings(object):
 
         Examples
         --------
-        >>> import pandas as pd
         >>> s = pd.Series(['Ant', 'Bear', 'Cow', 'Dog', 'Falcon'])
         >>> s.head()
         0   Ant
@@ -165,8 +164,6 @@ class GoodDocStrings(object):
 
         Examples
         --------
-        >>> import numpy as np
-        >>> import pandas as pd
         >>> s = pd.Series(['Antelope', 'Lion', 'Zebra', np.nan])
         >>> s.str.contains(pat='a')
         0    False
@@ -322,8 +319,6 @@ class BadGenericDocStrings(object):
 
         Examples
         --------
-        >>> import numpy as np
-        >>> import pandas as pd
         >>> df = pd.DataFrame(np.ones((3, 3)),
         ...                   columns=('a', 'b', 'c'))
         >>> df.all(1)
@@ -589,23 +584,47 @@ class BadSeeAlso(object):
 
 class BadExamples(object):
 
-    def missing_numpy_import(self):
+    def numpy_imported(self):
         """
-        Return whether each value contains `pat`.
+        Examples
+        --------
+        >>> import numpy as np
+        >>> df = pd.DataFrame(np.ones((3, 3)), columns=('a', 'b', 'c'))
+        """
+        pass
 
+    def pandas_imported(self):
+        """
         Examples
         --------
         >>> import pandas as pd
-        >>> df = pd.DataFrame(np.ones((3, 3)),
-        ...                   columns=('a', 'b', 'c'))
-        >>> df.all(1)
-        0    True
-        1    True
-        2    True
-        dtype: bool
+        >>> s = pd.Series(['Antelope', 'Lion', 'Zebra', np.nan])
+        """
+        pass
 
-        >>> df.all(bool_only=True)
-        Series([], dtype: bool)
+    def missing_whitespace_around_arithmetic_operator(self):
+        """
+        Examples
+        --------
+        >>> 2+5
+        7
+        """
+        pass
+
+    def indentation_is_not_a_multiple_of_four(self):
+        """
+        Examples
+        --------
+        >>> if 2 + 5:
+        ...   pass
+        """
+        pass
+
+    def missing_whitespace_after_comma(self):
+        """
+        Examples
+        --------
+        >>> df = pd.DataFrame(np.ones((3,3)),columns=('a','b', 'c'))
         """
         pass
 
@@ -731,8 +750,18 @@ class TestValidator(object):
          ('pandas.Series.rename in `See Also` section '
           'does not need `pandas` prefix',)),
         # Examples tests
-        ('BadExamples', 'missing_numpy_import',
-         ('1 F821 undefined name \'np\'',))
+        ('BadExamples', 'numpy_imported',
+         ('F811 It\'s assumed that pandas and numpy'
+          ' are imported as pd or np',)),
+        ('BadExamples', 'pandas_imported',
+         ('F811 It\'s assumed that pandas and numpy'
+          ' are imported as pd or np',)),
+        ('BadExamples', 'indentation_is_not_a_multiple_of_four',
+         ('E111 indentation is not a multiple of four',)),
+        ('BadExamples', 'missing_whitespace_around_arithmetic_operator',
+         ('E226 missing whitespace around arithmetic operator',)),
+        ('BadExamples', 'missing_whitespace_after_comma',
+         ('3 E231 missing whitespace after \',\'',)),
     ])
     def test_bad_examples(self, capsys, klass, func, msgs):
         result = validate_one(self._import_path(klass=klass, func=func))

--- a/scripts/tests/test_validate_docstrings.py
+++ b/scripts/tests/test_validate_docstrings.py
@@ -165,8 +165,8 @@ class GoodDocStrings(object):
 
         Examples
         --------
-        >>> import pandas as pd
         >>> import numpy as np
+        >>> import pandas as pd
         >>> s = pd.Series(['Antelope', 'Lion', 'Zebra', np.nan])
         >>> s.str.contains(pat='a')
         0    False
@@ -589,7 +589,7 @@ class BadSeeAlso(object):
 
 class BadExamples(object):
 
-    def doctest(self):
+    def missing_numpy_import(self):
         """
         Return whether each value contains `pat`.
 
@@ -731,7 +731,7 @@ class TestValidator(object):
          ('pandas.Series.rename in `See Also` section '
           'does not need `pandas` prefix',)),
         # Examples tests
-        ('BadExamples', 'doctest',
+        ('BadExamples', 'missing_numpy_import',
          ('1 F821 undefined name \'np\'',))
     ])
     def test_bad_examples(self, capsys, klass, func, msgs):

--- a/scripts/validate_docstrings.py
+++ b/scripts/validate_docstrings.py
@@ -516,7 +516,7 @@ def validate_one(func_name):
 
     pep8_errs = [error for error in doc.validate_pep8()]
     if pep8_errs:
-        errs.append('Errors in doctests')
+        errs.append('Linting issues in doctests:')
         for err in pep8_errs:
             errs.append('\t{} {} {}'.format(err.count, err.error_code,
                                             err.message))

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,6 +28,31 @@ exclude =
     doc/temp/*.py,
     .eggs/*.py,
     versioneer.py
+    .tox
+    .git
+
+doctests = True
+#TODO fix doctests
+exclude_from_doctest =
+    ./pandas/_libs
+    ./pandas/api
+    ./pandas/compat
+    ./pandas/computation
+    ./pandas/core
+    ./pandas/errors
+    ./pandas/io
+    ./pandas/plotting
+    ./pandas/tests
+    ./pandas/tools
+    ./pandas/tseries
+    ./pandas/types
+    ./pandas/util
+
+[flake8-rst]
+ignore =
+    F821,  # undefined name
+    W391,  # blank line at end of file [Seems to be a bug (v0.4.1)]
+
 
 [yapf]
 based_on_style = pep8

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,7 +37,6 @@ exclude_from_doctest =
     ./pandas/_libs
     ./pandas/api
     ./pandas/compat
-    ./pandas/computation
     ./pandas/core
     ./pandas/errors
     ./pandas/io
@@ -45,7 +44,6 @@ exclude_from_doctest =
     ./pandas/tests
     ./pandas/tools
     ./pandas/tseries
-    ./pandas/types
     ./pandas/util
 
 [flake8-rst]

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,28 +28,6 @@ exclude =
     doc/temp/*.py,
     .eggs/*.py,
     versioneer.py
-    .tox
-    .git
-
-doctests = True
-#TODO fix doctests
-exclude_from_doctest =
-    ./pandas/_libs
-    ./pandas/api
-    ./pandas/compat
-    ./pandas/core
-    ./pandas/errors
-    ./pandas/io
-    ./pandas/plotting
-    ./pandas/tests
-    ./pandas/tseries
-    ./pandas/util
-
-[flake8-rst]
-ignore =
-    F821,  # undefined name
-    W391,  # blank line at end of file [Seems to be a bug (v0.4.1)]
-
 
 [yapf]
 based_on_style = pep8

--- a/setup.cfg
+++ b/setup.cfg
@@ -42,7 +42,6 @@ exclude_from_doctest =
     ./pandas/io
     ./pandas/plotting
     ./pandas/tests
-    ./pandas/tools
     ./pandas/tseries
     ./pandas/util
 


### PR DESCRIPTION
- [x] tests added 
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`

Improvement to PR #23381 regarding issue #23154 

Enables `--doctests` flag, resulting in doctests being checked by flake8
Uses [flake8.api.legacy](http://flake8.pycqa.org/en/latest/user/python-api.html) to invoke the tests.

Downsides are:
* > Flake8 3.0.0 presently does not have a public, stable Python API.
* provided options in `flake8.get_style_guide` don't have an effect. Thus `setup.cfg` had to be enhanced.
* returns the count of each error within the complete file, not just the requested function. [Might be confusing]

`python ./scripts/validate_docstrings.py pandas.read_excel`
```
                [...]
                Parameter "convert_float" description should finish with "."
        Errors in doctest sections
                2 F721 syntax error in doctest
                2 F821 undefined name '_make_signature'
```

Help in the form of `Use "flake8 pandas/util/_decorators.py" for further information.` could be added to the output:
```
pandas/util/_decorators.py:320:26: F721 syntax error in doctest
pandas/util/_decorators.py:321:13: F721 syntax error in doctest
pandas/util/_decorators.py:322:15: F821 undefined name '_make_signature'
pandas/util/_decorators.py:322:31: F821 undefined name 'f'
```
