### PR TITLE
BUG/ENH: Handle NonexistentTimeError in date rounding

### DIFF
--- a/doc/source/whatsnew/v0.24.0.txt
+++ b/doc/source/whatsnew/v0.24.0.txt
@@ -204,6 +204,7 @@ Other Enhancements
 - :class:`Series` and :class:`DataFrame` now support :class:`Iterable` in constructor (:issue:`2193`)
 - :class:`DatetimeIndex` gained :attr:`DatetimeIndex.timetz` attribute. Returns local time with timezone information. (:issue:`21358`)
 - :meth:`round`, :meth:`ceil`, and meth:`floor` for :class:`DatetimeIndex` and :class:`Timestamp` now support an ``ambiguous`` argument for handling datetimes that are rounded to ambiguous times (:issue:`18946`)
+- :meth:`round`, :meth:`ceil`, and meth:`floor` for :class:`DatetimeIndex` and :class:`Timestamp` now support an ``nonexistent`` argument for handling datetimes that are rounded to nonexistent times (:issue:`22647`)
 - :class:`Resampler` now is iterable like :class:`GroupBy` (:issue:`15314`).
 - :meth:`Series.resample` and :meth:`DataFrame.resample` have gained the :meth:`Resampler.quantile` (:issue:`15023`).
 - :meth:`pandas.core.dtypes.is_list_like` has gained a keyword ``allow_sets`` which is ``True`` by default; if ``False``,

--- a/doc/source/whatsnew/v0.24.0.txt
+++ b/doc/source/whatsnew/v0.24.0.txt
@@ -227,7 +227,7 @@ Other Enhancements
 - :class:`Series` and :class:`DataFrame` now support :class:`Iterable` in constructor (:issue:`2193`)
 - :class:`DatetimeIndex` gained :attr:`DatetimeIndex.timetz` attribute. Returns local time with timezone information. (:issue:`21358`)
 - :meth:`round`, :meth:`ceil`, and meth:`floor` for :class:`DatetimeIndex` and :class:`Timestamp` now support an ``ambiguous`` argument for handling datetimes that are rounded to ambiguous times (:issue:`18946`)
-- :meth:`round`, :meth:`ceil`, and meth:`floor` for :class:`DatetimeIndex` and :class:`Timestamp` now support an ``nonexistent`` argument for handling datetimes that are rounded to nonexistent times (:issue:`22647`)
+- :meth:`round`, :meth:`ceil`, and meth:`floor` for :class:`DatetimeIndex` and :class:`Timestamp` now support a ``nonexistent`` argument for handling datetimes that are rounded to nonexistent times. See :ref:`timeseries.timezone_nonexsistent` (:issue:`22647`)
 - :class:`Resampler` now is iterable like :class:`GroupBy` (:issue:`15314`).
 - :meth:`Series.resample` and :meth:`DataFrame.resample` have gained the :meth:`Resampler.quantile` (:issue:`15023`).
 - :meth:`pandas.core.dtypes.is_list_like` has gained a keyword ``allow_sets`` which is ``True`` by default; if ``False``,

--- a/pandas/_libs/tslibs/conversion.pyx
+++ b/pandas/_libs/tslibs/conversion.pyx
@@ -851,8 +851,7 @@ def tz_localize_to_utc(ndarray[int64_t] vals, object tz, object ambiguous=None,
         Py_ssize_t i, idx, pos, ntrans, n = len(vals)
         Py_ssize_t delta_idx_offset, delta_idx
         int64_t *tdata
-        int64_t v, left, right, val, v_left, v_right
-        int64_t remaining_minutes, new_local
+        int64_t v, left, right, val, v_left, v_right, new_local, remaining_mins
         ndarray[int64_t] result, result_a, result_b, dst_hours
         npy_datetimestruct dts
         bint infer_dst = False, is_dst = False, fill = False
@@ -1006,8 +1005,8 @@ def tz_localize_to_utc(ndarray[int64_t] vals, object tz, object ambiguous=None,
             if shift:
                 # Shift the nonexistent time forward to the closest existing
                 # time
-                remaining_minutes = val % HOURS_NS
-                new_local = val + (HOURS_NS - remaining_minutes)
+                remaining_mins = val % HOURS_NS
+                new_local = val + (HOURS_NS - remaining_mins)
                 delta_idx = trans.searchsorted(new_local, side='right')
                 # Need to subtract 1 from the delta_idx if the UTC offset of
                 # the target tz is greater than 0

--- a/pandas/_libs/tslibs/conversion.pyx
+++ b/pandas/_libs/tslibs/conversion.pyx
@@ -849,10 +849,10 @@ def tz_localize_to_utc(ndarray[int64_t] vals, object tz, object ambiguous=None,
         int64_t[:] deltas, idx_shifted
         ndarray ambiguous_array
         Py_ssize_t i, idx, pos, ntrans, n = len(vals)
+        Py_ssize_t delta_idx_offset, delta_idx
         int64_t *tdata
         int64_t v, left, right, val, v_left, v_right
         int64_t remaining_minutes, new_local
-        int delta_idx_offset, delta_idx
         ndarray[int64_t] result, result_a, result_b, dst_hours
         npy_datetimestruct dts
         bint infer_dst = False, is_dst = False, fill = False

--- a/pandas/_libs/tslibs/nattype.pyx
+++ b/pandas/_libs/tslibs/nattype.pyx
@@ -484,6 +484,17 @@ class NaTType(_NaT):
             - 'raise' will raise an AmbiguousTimeError for an ambiguous time
 
             .. versionadded:: 0.24.0
+        nonexistent : 'shift', 'NaT', default 'raise'
+            A nonexistent time does not exist in a particular timezone
+            where clocks moved forward due to DST.
+
+            - 'shift' will shift the nonexistent time forward to the closest
+              existing time
+            - 'NaT' will return NaT where there are nonexistent times
+            - 'raise' will raise an NonExistentTimeError if there are
+              nonexistent times
+
+            .. versionadded:: 0.24.0
 
         Raises
         ------
@@ -503,6 +514,17 @@ class NaTType(_NaT):
             - 'raise' will raise an AmbiguousTimeError for an ambiguous time
 
             .. versionadded:: 0.24.0
+        nonexistent : 'shift', 'NaT', default 'raise'
+            A nonexistent time does not exist in a particular timezone
+            where clocks moved forward due to DST.
+
+            - 'shift' will shift the nonexistent time forward to the closest
+              existing time
+            - 'NaT' will return NaT where there are nonexistent times
+            - 'raise' will raise an NonExistentTimeError if there are
+              nonexistent times
+
+            .. versionadded:: 0.24.0
 
         Raises
         ------
@@ -520,6 +542,17 @@ class NaTType(_NaT):
               that this flag is only applicable for ambiguous fall dst dates)
             - 'NaT' will return NaT for an ambiguous time
             - 'raise' will raise an AmbiguousTimeError for an ambiguous time
+
+            .. versionadded:: 0.24.0
+        nonexistent : 'shift', 'NaT', default 'raise'
+            A nonexistent time does not exist in a particular timezone
+            where clocks moved forward due to DST.
+
+            - 'shift' will shift the nonexistent time forward to the closest
+              existing time
+            - 'NaT' will return NaT where there are nonexistent times
+            - 'raise' will raise an NonExistentTimeError if there are
+              nonexistent times
 
             .. versionadded:: 0.24.0
 

--- a/pandas/_libs/tslibs/timestamps.pyx
+++ b/pandas/_libs/tslibs/timestamps.pyx
@@ -721,7 +721,7 @@ class Timestamp(_Timestamp):
 
         return create_timestamp_from_ts(ts.value, ts.dts, ts.tzinfo, freq)
 
-    def _round(self, freq, mode, ambiguous='raise'):
+    def _round(self, freq, mode, ambiguous='raise', nonexistent='raise'):
         if self.tz is not None:
             value = self.tz_localize(None).value
         else:
@@ -733,10 +733,12 @@ class Timestamp(_Timestamp):
         r = round_nsint64(value, mode, freq)[0]
         result = Timestamp(r, unit='ns')
         if self.tz is not None:
-            result = result.tz_localize(self.tz, ambiguous=ambiguous)
+            result = result.tz_localize(
+                self.tz, ambiguous=ambiguous, nonexistent=nonexistent
+            )
         return result
 
-    def round(self, freq, ambiguous='raise'):
+    def round(self, freq, ambiguous='raise', nonexistent='raise'):
         """
         Round the Timestamp to the specified resolution
 
@@ -754,14 +756,27 @@ class Timestamp(_Timestamp):
             - 'raise' will raise an AmbiguousTimeError for an ambiguous time
 
             .. versionadded:: 0.24.0
+        nonexistent : 'shift', 'NaT', default 'raise'
+            A nonexistent time does not exist in a particular timezone
+            where clocks moved forward due to DST.
+
+            - 'shift' will shift the nonexistent time forward to the closest
+              existing time
+            - 'NaT' will return NaT where there are nonexistent times
+            - 'raise' will raise an NonExistentTimeError if there are
+              nonexistent times
+
+            .. versionadded:: 0.24.0
 
         Raises
         ------
         ValueError if the freq cannot be converted
         """
-        return self._round(freq, RoundTo.NEAREST_HALF_EVEN, ambiguous)
+        return self._round(
+            freq, RoundTo.NEAREST_HALF_EVEN, ambiguous, nonexistent
+        )
 
-    def floor(self, freq, ambiguous='raise'):
+    def floor(self, freq, ambiguous='raise', nonexistent='raise'):
         """
         return a new Timestamp floored to this resolution
 
@@ -775,14 +790,25 @@ class Timestamp(_Timestamp):
             - 'raise' will raise an AmbiguousTimeError for an ambiguous time
 
             .. versionadded:: 0.24.0
+        nonexistent : 'shift', 'NaT', default 'raise'
+            A nonexistent time does not exist in a particular timezone
+            where clocks moved forward due to DST.
+
+            - 'shift' will shift the nonexistent time forward to the closest
+              existing time
+            - 'NaT' will return NaT where there are nonexistent times
+            - 'raise' will raise an NonExistentTimeError if there are
+              nonexistent times
+
+            .. versionadded:: 0.24.0
 
         Raises
         ------
         ValueError if the freq cannot be converted
         """
-        return self._round(freq, RoundTo.MINUS_INFTY, ambiguous)
+        return self._round(freq, RoundTo.MINUS_INFTY, ambiguous, nonexistent)
 
-    def ceil(self, freq, ambiguous='raise'):
+    def ceil(self, freq, ambiguous='raise', nonexistent='raise'):
         """
         return a new Timestamp ceiled to this resolution
 
@@ -796,12 +822,23 @@ class Timestamp(_Timestamp):
             - 'raise' will raise an AmbiguousTimeError for an ambiguous time
 
             .. versionadded:: 0.24.0
+        nonexistent : 'shift', 'NaT', default 'raise'
+            A nonexistent time does not exist in a particular timezone
+            where clocks moved forward due to DST.
+
+            - 'shift' will shift the nonexistent time forward to the closest
+              existing time
+            - 'NaT' will return NaT where there are nonexistent times
+            - 'raise' will raise an NonExistentTimeError if there are
+              nonexistent times
+
+            .. versionadded:: 0.24.0
 
         Raises
         ------
         ValueError if the freq cannot be converted
         """
-        return self._round(freq, RoundTo.PLUS_INFTY, ambiguous)
+        return self._round(freq, RoundTo.PLUS_INFTY, ambiguous, nonexistent)
 
     @property
     def tz(self):

--- a/pandas/tests/scalar/timestamp/test_unary_ops.py
+++ b/pandas/tests/scalar/timestamp/test_unary_ops.py
@@ -134,8 +134,8 @@ class TestTimestampUnaryOps(object):
         assert result == expected
 
     @pytest.mark.parametrize('method', ['ceil', 'round', 'floor'])
-    def test_round_dst_border(self, method):
-        # GH 18946 round near DST
+    def test_round_dst_border_ambiguous(self, method):
+        # GH 18946 round near "fall back" DST
         ts = Timestamp('2017-10-29 00:00:00', tz='UTC').tz_convert(
             'Europe/Madrid'
         )
@@ -154,6 +154,23 @@ class TestTimestampUnaryOps(object):
 
         with pytest.raises(pytz.AmbiguousTimeError):
             getattr(ts, method)('H', ambiguous='raise')
+
+    @pytest.mark.parametrize('method, ts_str, freq', [
+        ['ceil', '2018-03-11 01:59:00-0600', '5min'],
+        ['round', '2018-03-11 01:59:00-0600', '5min'],
+        ['floor', '2018-03-11 03:01:00-0500', '2H']])
+    def test_round_dst_border_nonexistent(self, method, ts_str, freq):
+        # GH 23324 round near "spring forward" DST
+        ts = Timestamp(ts_str, tz='America/Chicago')
+        result = getattr(ts, method)(freq, nonexistent='shift')
+        expected = Timestamp('2018-03-11 03:00:00', tz='America/Chicago')
+        assert result == expected
+
+        result = getattr(ts, method)(freq, nonexistent='NaT')
+        assert result is NaT
+
+        with pytest.raises(pytz.NonExistentTimeError):
+            getattr(ts, method)(freq, nonexistent='raise')
 
     @pytest.mark.parametrize('timestamp', [
         '2018-01-01 0:0:0.124999360',

--- a/pandas/tests/scalar/timestamp/test_unary_ops.py
+++ b/pandas/tests/scalar/timestamp/test_unary_ops.py
@@ -169,7 +169,8 @@ class TestTimestampUnaryOps(object):
         result = getattr(ts, method)(freq, nonexistent='NaT')
         assert result is NaT
 
-        with pytest.raises(pytz.NonExistentTimeError):
+        with pytest.raises(pytz.NonExistentTimeError,
+                           message='2018-03-11 02:00:00'):
             getattr(ts, method)(freq, nonexistent='raise')
 
     @pytest.mark.parametrize('timestamp', [

--- a/pandas/tests/series/test_datetime_values.py
+++ b/pandas/tests/series/test_datetime_values.py
@@ -252,7 +252,7 @@ class TestSeriesDatetimeValues():
 
     @pytest.mark.parametrize('method', ['ceil', 'round', 'floor'])
     def test_dt_round_tz_ambiguous(self, method):
-        # GH 18946 round near DST
+        # GH 18946 round near "fall back" DST
         df1 = pd.DataFrame([
             pd.to_datetime('2017-10-29 02:00:00+02:00', utc=True),
             pd.to_datetime('2017-10-29 02:00:00+01:00', utc=True),
@@ -280,6 +280,26 @@ class TestSeriesDatetimeValues():
         # raise
         with pytest.raises(pytz.AmbiguousTimeError):
             getattr(df1.date.dt, method)('H', ambiguous='raise')
+
+    @pytest.mark.parametrize('method, ts_str, freq', [
+        ['ceil', '2018-03-11 01:59:00-0600', '5min'],
+        ['round', '2018-03-11 01:59:00-0600', '5min'],
+        ['floor', '2018-03-11 03:01:00-0500', '2H']])
+    def test_dt_round_tz_nonexistent(self, method, ts_str, freq):
+        # GH 23324 round near "spring forward" DST
+        s = Series([pd.Timestamp(ts_str, tz='America/Chicago')])
+        result = getattr(s.dt, method)(freq, nonexistent='shift')
+        expected = Series(
+            [pd.Timestamp('2018-03-11 03:00:00', tz='America/Chicago')]
+        )
+        tm.assert_series_equal(result, expected)
+
+        result = getattr(s.dt, method)(freq, nonexistent='NaT')
+        expected = Series([pd.NaT]).dt.tz_localize(result.dt.tz)
+        tm.assert_series_equal(result, expected)
+
+        with pytest.raises(pytz.NonExistentTimeError):
+            getattr(s.dt, method)(freq, nonexistent='raise')
 
     def test_dt_namespace_accessor_categorical(self):
         # GH 19468

--- a/pandas/tests/series/test_datetime_values.py
+++ b/pandas/tests/series/test_datetime_values.py
@@ -299,7 +299,8 @@ class TestSeriesDatetimeValues():
         expected = Series([pd.NaT]).dt.tz_localize(result.dt.tz)
         tm.assert_series_equal(result, expected)
 
-        with pytest.raises(pytz.NonExistentTimeError):
+        with pytest.raises(pytz.NonExistentTimeError,
+                           message='2018-03-11 02:00:00'):
             getattr(s.dt, method)(freq, nonexistent='raise')
 
     def test_dt_namespace_accessor_categorical(self):


### PR DESCRIPTION
- [x] closes #23324
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry

Similar strategy as https://github.com/pandas-dev/pandas/pull/22647, added a `nonexistent` keyword argument to `round`, `ceil`, and `floor` to control rounding when encountering a `NonexistentTimeError`

This is also fixes a bug in the `nonexistent='shift'` implementation in https://github.com/pandas-dev/pandas/pull/22644 where dates with timezones with negative UTC offsets got shifted by an additional hour. This bug is naturally tested by these rounding tests