### PR TITLE
DOC: Clarify documentation of 'ambiguous' parameter

### DIFF
--- a/pandas/_libs/tslibs/conversion.pyx
+++ b/pandas/_libs/tslibs/conversion.pyx
@@ -835,7 +835,20 @@ def tz_localize_to_utc(ndarray[int64_t] vals, object tz, object ambiguous=None,
     vals : ndarray[int64_t]
     tz : tzinfo or None
     ambiguous : str, bool, or arraylike
-        If arraylike, must have the same length as vals
+        When clocks moved backward due to DST, ambiguous times may arise.
+        For example in Central European Time (UTC+01), when going from 03:00 DST
+        to 02:00 non-DST, 02:30:00 local time occurs both at 00:30:00 UTC
+        and at 01:30:00 UTC. In such a situation, the `ambiguous` parameter
+        dictates how ambiguous times should be handled.
+
+        - 'infer' will attempt to infer fall dst-transition hours based on
+          order
+        - bool-ndarray where True signifies a DST time, False signifies a
+          non-DST time (note that this flag is only applicable for ambiguous
+          times, but the array must have the same length as vals)
+        - bool if True, treat all vals as DST. If False, treat them as non-DST
+        - 'NaT' will return NaT where there are ambiguous times
+
     nonexistent : str
         If arraylike, must have the same length as vals
 

--- a/pandas/_libs/tslibs/conversion.pyx
+++ b/pandas/_libs/tslibs/conversion.pyx
@@ -836,8 +836,8 @@ def tz_localize_to_utc(ndarray[int64_t] vals, object tz, object ambiguous=None,
     tz : tzinfo or None
     ambiguous : str, bool, or arraylike
         When clocks moved backward due to DST, ambiguous times may arise.
-        For example in Central European Time (UTC+01), when going from 03:00 DST
-        to 02:00 non-DST, 02:30:00 local time occurs both at 00:30:00 UTC
+        For example in Central European Time (UTC+01), when going from 03:00
+        DST to 02:00 non-DST, 02:30:00 local time occurs both at 00:30:00 UTC
         and at 01:30:00 UTC. In such a situation, the `ambiguous` parameter
         dictates how ambiguous times should be handled.
 

--- a/pandas/_libs/tslibs/nattype.pyx
+++ b/pandas/_libs/tslibs/nattype.pyx
@@ -559,6 +559,12 @@ class NaTType(_NaT):
             None will remove timezone holding local time.
 
         ambiguous : bool, 'NaT', default 'raise'
+            When clocks moved backward due to DST, ambiguous times may arise.
+            For example in Central European Time (UTC+01), when going from 03:00 DST
+            to 02:00 non-DST, 02:30:00 local time occurs both at 00:30:00 UTC
+            and at 01:30:00 UTC. In such a situation, the `ambiguous` parameter
+            dictates how ambiguous times should be handled.
+
             - bool contains flags to determine if time is dst or not (note
               that this flag is only applicable for ambiguous fall dst dates)
             - 'NaT' will return NaT for an ambiguous time

--- a/pandas/_libs/tslibs/nattype.pyx
+++ b/pandas/_libs/tslibs/nattype.pyx
@@ -560,8 +560,8 @@ class NaTType(_NaT):
 
         ambiguous : bool, 'NaT', default 'raise'
             When clocks moved backward due to DST, ambiguous times may arise.
-            For example in Central European Time (UTC+01), when going from 03:00 DST
-            to 02:00 non-DST, 02:30:00 local time occurs both at 00:30:00 UTC
+            For example in Central European Time (UTC+01), when going from 03:00
+            DST to 02:00 non-DST, 02:30:00 local time occurs both at 00:30:00 UTC
             and at 01:30:00 UTC. In such a situation, the `ambiguous` parameter
             dictates how ambiguous times should be handled.
 

--- a/pandas/_libs/tslibs/nattype.pyx
+++ b/pandas/_libs/tslibs/nattype.pyx
@@ -560,10 +560,11 @@ class NaTType(_NaT):
 
         ambiguous : bool, 'NaT', default 'raise'
             When clocks moved backward due to DST, ambiguous times may arise.
-            For example in Central European Time (UTC+01), when going from 03:00
-            DST to 02:00 non-DST, 02:30:00 local time occurs both at 00:30:00 UTC
-            and at 01:30:00 UTC. In such a situation, the `ambiguous` parameter
-            dictates how ambiguous times should be handled.
+            For example in Central European Time (UTC+01), when going from
+            03:00 DST to 02:00 non-DST, 02:30:00 local time occurs both at
+            00:30:00 UTC and at 01:30:00 UTC. In such a situation, the
+            `ambiguous` parameter dictates how ambiguous times should be
+            handled.
 
             - bool contains flags to determine if time is dst or not (note
               that this flag is only applicable for ambiguous fall dst dates)

--- a/pandas/_libs/tslibs/timestamps.pyx
+++ b/pandas/_libs/tslibs/timestamps.pyx
@@ -974,6 +974,12 @@ class Timestamp(_Timestamp):
             None will remove timezone holding local time.
 
         ambiguous : bool, 'NaT', default 'raise'
+            When clocks moved backward due to DST, ambiguous times may arise.
+            For example in Central European Time (UTC+01), when going from 03:00 DST
+            to 02:00 non-DST, 02:30:00 local time occurs both at 00:30:00 UTC
+            and at 01:30:00 UTC. In such a situation, the `ambiguous` parameter
+            dictates how ambiguous times should be handled.
+
             - bool contains flags to determine if time is dst or not (note
               that this flag is only applicable for ambiguous fall dst dates)
             - 'NaT' will return NaT for an ambiguous time

--- a/pandas/_libs/tslibs/timestamps.pyx
+++ b/pandas/_libs/tslibs/timestamps.pyx
@@ -975,10 +975,11 @@ class Timestamp(_Timestamp):
 
         ambiguous : bool, 'NaT', default 'raise'
             When clocks moved backward due to DST, ambiguous times may arise.
-            For example in Central European Time (UTC+01), when going from 03:00
-            DST to 02:00 non-DST, 02:30:00 local time occurs both at 00:30:00 UTC
-            and at 01:30:00 UTC. In such a situation, the `ambiguous` parameter
-            dictates how ambiguous times should be handled.
+            For example in Central European Time (UTC+01), when going from
+            03:00 DST to 02:00 non-DST, 02:30:00 local time occurs both at
+            00:30:00 UTC and at 01:30:00 UTC. In such a situation, the
+            `ambiguous` parameter dictates how ambiguous times should be
+            handled.
 
             - bool contains flags to determine if time is dst or not (note
               that this flag is only applicable for ambiguous fall dst dates)

--- a/pandas/_libs/tslibs/timestamps.pyx
+++ b/pandas/_libs/tslibs/timestamps.pyx
@@ -975,8 +975,8 @@ class Timestamp(_Timestamp):
 
         ambiguous : bool, 'NaT', default 'raise'
             When clocks moved backward due to DST, ambiguous times may arise.
-            For example in Central European Time (UTC+01), when going from 03:00 DST
-            to 02:00 non-DST, 02:30:00 local time occurs both at 00:30:00 UTC
+            For example in Central European Time (UTC+01), when going from 03:00
+            DST to 02:00 non-DST, 02:30:00 local time occurs both at 00:30:00 UTC
             and at 01:30:00 UTC. In such a situation, the `ambiguous` parameter
             dictates how ambiguous times should be handled.
 

--- a/pandas/core/arrays/datetimes.py
+++ b/pandas/core/arrays/datetimes.py
@@ -607,10 +607,11 @@ class DatetimeArrayMixin(dtl.DatetimeLikeArrayMixin):
             remove the time zone information preserving local time.
         ambiguous : 'infer', 'NaT', bool array, default 'raise'
             When clocks moved backward due to DST, ambiguous times may arise.
-            For example in Central European Time (UTC+01), when going from 03:00 DST
-            to 02:00 non-DST, 02:30:00 local time occurs both at 00:30:00 UTC
-            and at 01:30:00 UTC. In such a situation, the `ambiguous` parameter
-            dictates how ambiguous times should be handled.
+            For example in Central European Time (UTC+01), when going from
+            03:00 DST to 02:00 non-DST, 02:30:00 local time occurs both at
+            00:30:00 UTC and at 01:30:00 UTC. In such a situation, the
+            `ambiguous` parameter dictates how ambiguous times should be
+            handled.
 
             - 'infer' will attempt to infer fall dst-transition hours based on
               order
@@ -683,7 +684,8 @@ class DatetimeArrayMixin(dtl.DatetimeLikeArrayMixin):
                        '2018-03-03 09:00:00'],
                       dtype='datetime64[ns]', freq='D')
 
-        Be careful with DST changes. When there is sequential data, pandas can infer the DST time:
+        Be careful with DST changes. When there is sequential data, pandas can
+        infer the DST time:
         >>> s = pd.to_datetime(pd.Series([
         ... '2018-10-28 01:30:00',
         ... '2018-10-28 02:00:00',

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -8656,6 +8656,50 @@ class NDFrame(PandasObject, SelectionMixin):
         ------
         TypeError
             If the TimeSeries is tz-aware and tz is not None.
+
+        Examples
+        --------
+
+        Localize local times:
+
+        >>> s = pd.to_datetime(pd.Series(['2018-09-15 01:30:00']))
+        >>> s.dt.tz_localize('CET')
+        0   2018-09-15 01:30:00+02:00
+        dtype: datetime64[ns, CET]
+
+        Be careful with DST changes. When there is sequential data, pandas can infer the DST time:
+
+        >>> s = pd.to_datetime(pd.Series([
+        ... '2018-10-28 01:30:00',
+        ... '2018-10-28 02:00:00',
+        ... '2018-10-28 02:30:00',
+        ... '2018-10-28 02:00:00',
+        ... '2018-10-28 02:30:00',
+        ... '2018-10-28 03:00:00',
+        ... '2018-10-28 03:30:00']))
+        >>> s.dt.tz_localize('CET', ambiguous='infer')
+        1   2018-10-28 01:30:00+02:00
+        2   2018-10-28 02:00:00+02:00
+        3   2018-10-28 02:30:00+02:00
+        4   2018-10-28 02:00:00+01:00
+        5   2018-10-28 02:30:00+01:00
+        6   2018-10-28 03:00:00+01:00
+        7   2018-10-28 03:30:00+01:00
+        dtype: datetime64[ns, CET]
+
+        In some cases, inferring the DST is impossible. In such cases, you can
+        pass an ndarray to the ambiguous parameter to set the DST explicitly
+
+        >>> s = pd.to_datetime(pd.Series([
+        ... '2018-10-28 01:20:00',
+        ... '2018-10-28 02:36:00',
+        ... '2018-10-28 03:46:00']))
+        >>> s.dt.tz_localize('CET', ambiguous=np.array([True, True, False]))
+        0   2018-10-28 01:20:00+02:00
+        1   2018-10-28 02:36:00+02:00
+        2   2018-10-28 03:46:00+01:00
+        dtype: datetime64[ns, CET]
+
         """
         if nonexistent not in ('raise', 'NaT', 'shift'):
             raise ValueError("The nonexistent argument must be one of 'raise',"

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -8623,6 +8623,13 @@ class NDFrame(PandasObject, SelectionMixin):
         copy : boolean, default True
             Also make a copy of the underlying data
         ambiguous : 'infer', bool-ndarray, 'NaT', default 'raise'
+            When clocks moved backward due to DST, ambiguous times may arise.
+            E.g. in Central European Time (UTC+01), when going from 03:00 DST
+            to 02:00 non-DST, the naive time 02:30:00 occurs both at
+            00:30:00 UTC and at 01:30:00 UTC. In such a situation, the
+            `ambiguous` parameter can be used to correctly localize these
+            times.
+
             - 'infer' will attempt to infer fall dst-transition hours based on
               order
             - bool-ndarray where True signifies a DST time, False designates

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -8624,11 +8624,10 @@ class NDFrame(PandasObject, SelectionMixin):
             Also make a copy of the underlying data
         ambiguous : 'infer', bool-ndarray, 'NaT', default 'raise'
             When clocks moved backward due to DST, ambiguous times may arise.
-            E.g. in Central European Time (UTC+01), when going from 03:00 DST
-            to 02:00 non-DST, the naive time 02:30:00 occurs both at
-            00:30:00 UTC and at 01:30:00 UTC. In such a situation, the
-            `ambiguous` parameter can be used to correctly localize these
-            times.
+            For example in Central European Time (UTC+01), when going from 03:00 DST
+            to 02:00 non-DST, 02:30:00 local time occurs both at 00:30:00 UTC
+            and at 01:30:00 UTC. In such a situation, the `ambiguous` parameter
+            dictates how ambiguous times should be handled.
 
             - 'infer' will attempt to infer fall dst-transition hours based on
               order

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -8663,12 +8663,14 @@ class NDFrame(PandasObject, SelectionMixin):
 
         Localize local times:
 
-        >>> s = pd.Series([1], index=pd.DatetimeIndex(['2018-09-15 01:30:00']))
+        >>> s = pd.Series([1],
+        ... index=pd.DatetimeIndex(['2018-09-15 01:30:00']))
         >>> s.tz_localize('CET')
         2018-09-15 01:30:00+02:00    1
         dtype: int64
 
-        Be careful with DST changes. When there is sequential data, pandas can infer the DST time:
+        Be careful with DST changes. When there is sequential data, pandas
+        can infer the DST time:
 
         >>> s = pd.Series(range(7), index=pd.DatetimeIndex([
         ... '2018-10-28 01:30:00',

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -8624,10 +8624,11 @@ class NDFrame(PandasObject, SelectionMixin):
             Also make a copy of the underlying data
         ambiguous : 'infer', bool-ndarray, 'NaT', default 'raise'
             When clocks moved backward due to DST, ambiguous times may arise.
-            For example in Central European Time (UTC+01), when going from 03:00 DST
-            to 02:00 non-DST, 02:30:00 local time occurs both at 00:30:00 UTC
-            and at 01:30:00 UTC. In such a situation, the `ambiguous` parameter
-            dictates how ambiguous times should be handled.
+            For example in Central European Time (UTC+01), when going from
+            03:00 DST to 02:00 non-DST, 02:30:00 local time occurs both at
+            00:30:00 UTC and at 01:30:00 UTC. In such a situation, the
+            `ambiguous` parameter dictates how ambiguous times should be
+            handled.
 
             - 'infer' will attempt to infer fall dst-transition hours based on
               order

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -8677,7 +8677,7 @@ class NDFrame(PandasObject, SelectionMixin):
         ... '2018-10-28 02:30:00',
         ... '2018-10-28 03:00:00',
         ... '2018-10-28 03:30:00']))
-        >>> s.dt.tz_localize('CET', ambiguous='infer')
+        >>> s.tz_localize('CET', ambiguous='infer')
         2018-10-28 01:30:00+02:00    0
         2018-10-28 02:00:00+02:00    1
         2018-10-28 02:30:00+02:00    2

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -8662,14 +8662,14 @@ class NDFrame(PandasObject, SelectionMixin):
 
         Localize local times:
 
-        >>> s = pd.to_datetime(pd.Series(['2018-09-15 01:30:00']))
-        >>> s.dt.tz_localize('CET')
-        0   2018-09-15 01:30:00+02:00
-        dtype: datetime64[ns, CET]
+        >>> s = pd.Series([1], index=pd.DatetimeIndex(['2018-09-15 01:30:00']))
+        >>> s.tz_localize('CET')
+        2018-09-15 01:30:00+02:00    1
+        dtype: int64
 
         Be careful with DST changes. When there is sequential data, pandas can infer the DST time:
 
-        >>> s = pd.to_datetime(pd.Series([
+        >>> s = pd.Series(range(7), index=pd.DatetimeIndex([
         ... '2018-10-28 01:30:00',
         ... '2018-10-28 02:00:00',
         ... '2018-10-28 02:30:00',
@@ -8678,27 +8678,27 @@ class NDFrame(PandasObject, SelectionMixin):
         ... '2018-10-28 03:00:00',
         ... '2018-10-28 03:30:00']))
         >>> s.dt.tz_localize('CET', ambiguous='infer')
-        1   2018-10-28 01:30:00+02:00
-        2   2018-10-28 02:00:00+02:00
-        3   2018-10-28 02:30:00+02:00
-        4   2018-10-28 02:00:00+01:00
-        5   2018-10-28 02:30:00+01:00
-        6   2018-10-28 03:00:00+01:00
-        7   2018-10-28 03:30:00+01:00
-        dtype: datetime64[ns, CET]
+        2018-10-28 01:30:00+02:00    0
+        2018-10-28 02:00:00+02:00    1
+        2018-10-28 02:30:00+02:00    2
+        2018-10-28 02:00:00+01:00    3
+        2018-10-28 02:30:00+01:00    4
+        2018-10-28 03:00:00+01:00    5
+        2018-10-28 03:30:00+01:00    6
+        dtype: int64
 
         In some cases, inferring the DST is impossible. In such cases, you can
         pass an ndarray to the ambiguous parameter to set the DST explicitly
 
-        >>> s = pd.to_datetime(pd.Series([
+        >>> s = pd.Series(range(3), index=pd.DatetimeIndex([
         ... '2018-10-28 01:20:00',
         ... '2018-10-28 02:36:00',
         ... '2018-10-28 03:46:00']))
-        >>> s.dt.tz_localize('CET', ambiguous=np.array([True, True, False]))
-        0   2018-10-28 01:20:00+02:00
-        1   2018-10-28 02:36:00+02:00
-        2   2018-10-28 03:46:00+01:00
-        dtype: datetime64[ns, CET]
+        >>> s.tz_localize('CET', ambiguous=np.array([True, True, False]))
+        2018-10-28 01:20:00+02:00    0
+        2018-10-28 02:36:00+02:00    1
+        2018-10-28 03:46:00+01:00    2
+        dtype: int64
 
         """
         if nonexistent not in ('raise', 'NaT', 'shift'):

--- a/pandas/core/indexes/datetimes.py
+++ b/pandas/core/indexes/datetimes.py
@@ -99,6 +99,12 @@ class DatetimeIndex(DatetimeArrayMixin, DatelikeOps, TimelikeOps,
         the 'left', 'right', or both sides (None)
     tz : pytz.timezone or dateutil.tz.tzfile
     ambiguous : 'infer', bool-ndarray, 'NaT', default 'raise'
+        When clocks moved backward due to DST, ambiguous times may arise.
+        For example in Central European Time (UTC+01), when going from 03:00 DST
+        to 02:00 non-DST, 02:30:00 local time occurs both at 00:30:00 UTC
+        and at 01:30:00 UTC. In such a situation, the `ambiguous` parameter
+        dictates how ambiguous times should be handled.
+
         - 'infer' will attempt to infer fall dst-transition hours based on
           order
         - bool-ndarray where True signifies a DST time, False signifies a

--- a/pandas/core/indexes/datetimes.py
+++ b/pandas/core/indexes/datetimes.py
@@ -179,6 +179,45 @@ class DatetimeIndex(DatetimeArrayMixin, DatelikeOps, TimelikeOps,
     TimedeltaIndex : Index of timedelta64 data
     PeriodIndex : Index of Period data
     pandas.to_datetime : Convert argument to datetime
+
+    Examples
+    --------
+
+        Localize local times:
+
+        >>> s = pd.to_datetime(pd.Series(['2018-09-15 01:30:00']))
+        >>> pd.DatetimeIndex(s, tz='CET')
+        DatetimeIndex(['2018-09-15 01:30:00+02:00'], dtype='datetime64[ns, CET]', freq=None)
+
+        Be careful with DST changes. When there is sequential data, pandas can infer the DST time:
+
+        >>> s = pd.to_datetime(pd.Series([
+        ... '2018-10-28 01:30:00',
+        ... '2018-10-28 02:00:00',
+        ... '2018-10-28 02:30:00',
+        ... '2018-10-28 02:00:00',
+        ... '2018-10-28 02:30:00',
+        ... '2018-10-28 03:00:00',
+        ... '2018-10-28 03:30:00']))
+        >>> pd.DatetimeIndex(s, tz='CET', ambiguous='infer')
+        DatetimeIndex(['2018-10-28 01:30:00+02:00', '2018-10-28 02:00:00+02:00',
+                       '2018-10-28 02:30:00+02:00', '2018-10-28 02:00:00+01:00',
+                       '2018-10-28 02:30:00+01:00', '2018-10-28 03:00:00+01:00',
+                       '2018-10-28 03:30:00+01:00'],
+                      dtype='datetime64[ns, CET]', freq=None)
+
+        In some cases, inferring the DST is impossible. In such cases, you can
+        pass an ndarray to the ambiguous parameter to set the DST explicitly
+
+        >>> s = pd.to_datetime(pd.Series([
+        ... '2018-10-28 01:20:00',
+        ... '2018-10-28 02:36:00',
+        ... '2018-10-28 03:46:00']))
+        >>> pd.DatetimeIndex(s, tz='CET', ambiguous=np.array([True, True, False]))
+        DatetimeIndex(['2018-10-28 01:20:00+02:00', '2018-10-28 02:36:00+02:00',
+                       '2018-10-28 03:46:00+01:00'],
+                      dtype='datetime64[ns, CET]', freq=None)
+
     """
     _resolution = cache_readonly(DatetimeArrayMixin._resolution.fget)
 

--- a/pandas/core/indexes/datetimes.py
+++ b/pandas/core/indexes/datetimes.py
@@ -180,44 +180,6 @@ class DatetimeIndex(DatetimeArrayMixin, DatelikeOps, TimelikeOps,
     PeriodIndex : Index of Period data
     pandas.to_datetime : Convert argument to datetime
 
-    Examples
-    --------
-
-        Localize local times:
-
-        >>> s = pd.to_datetime(pd.Series(['2018-09-15 01:30:00']))
-        >>> pd.DatetimeIndex(s, tz='CET')
-        DatetimeIndex(['2018-09-15 01:30:00+02:00'], dtype='datetime64[ns, CET]', freq=None)
-
-        Be careful with DST changes. When there is sequential data, pandas can infer the DST time:
-
-        >>> s = pd.to_datetime(pd.Series([
-        ... '2018-10-28 01:30:00',
-        ... '2018-10-28 02:00:00',
-        ... '2018-10-28 02:30:00',
-        ... '2018-10-28 02:00:00',
-        ... '2018-10-28 02:30:00',
-        ... '2018-10-28 03:00:00',
-        ... '2018-10-28 03:30:00']))
-        >>> pd.DatetimeIndex(s, tz='CET', ambiguous='infer')
-        DatetimeIndex(['2018-10-28 01:30:00+02:00', '2018-10-28 02:00:00+02:00',
-                       '2018-10-28 02:30:00+02:00', '2018-10-28 02:00:00+01:00',
-                       '2018-10-28 02:30:00+01:00', '2018-10-28 03:00:00+01:00',
-                       '2018-10-28 03:30:00+01:00'],
-                      dtype='datetime64[ns, CET]', freq=None)
-
-        In some cases, inferring the DST is impossible. In such cases, you can
-        pass an ndarray to the ambiguous parameter to set the DST explicitly
-
-        >>> s = pd.to_datetime(pd.Series([
-        ... '2018-10-28 01:20:00',
-        ... '2018-10-28 02:36:00',
-        ... '2018-10-28 03:46:00']))
-        >>> pd.DatetimeIndex(s, tz='CET', ambiguous=np.array([True, True, False]))
-        DatetimeIndex(['2018-10-28 01:20:00+02:00', '2018-10-28 02:36:00+02:00',
-                       '2018-10-28 03:46:00+01:00'],
-                      dtype='datetime64[ns, CET]', freq=None)
-
     """
     _resolution = cache_readonly(DatetimeArrayMixin._resolution.fget)
 

--- a/pandas/core/indexes/datetimes.py
+++ b/pandas/core/indexes/datetimes.py
@@ -100,8 +100,8 @@ class DatetimeIndex(DatetimeArrayMixin, DatelikeOps, TimelikeOps,
     tz : pytz.timezone or dateutil.tz.tzfile
     ambiguous : 'infer', bool-ndarray, 'NaT', default 'raise'
         When clocks moved backward due to DST, ambiguous times may arise.
-        For example in Central European Time (UTC+01), when going from 03:00 DST
-        to 02:00 non-DST, 02:30:00 local time occurs both at 00:30:00 UTC
+        For example in Central European Time (UTC+01), when going from 03:00
+        DST to 02:00 non-DST, 02:30:00 local time occurs both at 00:30:00 UTC
         and at 01:30:00 UTC. In such a situation, the `ambiguous` parameter
         dictates how ambiguous times should be handled.
 


### PR DESCRIPTION
when first reading the docs, the `ambiguous` parameter was not clear to me. I propose to add a line of documentation and include an example that exactly indicates the issue that the `ambiguous` parameter solves.
