### PR TITLE
API: fix corner case of lib.infer_dtype

### DIFF
--- a/doc/source/whatsnew/v0.24.0.txt
+++ b/doc/source/whatsnew/v0.24.0.txt
@@ -244,8 +244,6 @@ Backwards incompatible API changes
 
 - A newly constructed empty :class:`DataFrame` with integer as the ``dtype`` will now only be cast to ``float64`` if ``index`` is specified (:issue:`22858`)
 - :meth:`Series.str.cat` will now raise if `others` is a `set` (:issue:`23009`)
-- The method `pandas._libs.lib.infer_dtype` now returns `'empty'` rather than (sometimes) the dtype of the array,
-  in case the array only consists of missing values and `skipna=True` (:issue:`23421`)
 
 .. _whatsnew_0240.api_breaking.deps:
 

--- a/doc/source/whatsnew/v0.24.0.txt
+++ b/doc/source/whatsnew/v0.24.0.txt
@@ -244,6 +244,8 @@ Backwards incompatible API changes
 
 - A newly constructed empty :class:`DataFrame` with integer as the ``dtype`` will now only be cast to ``float64`` if ``index`` is specified (:issue:`22858`)
 - :meth:`Series.str.cat` will now raise if `others` is a `set` (:issue:`23009`)
+- The method `pandas._libs.lib.infer_dtype` now returns `'empty'` rather than (sometimes) the dtype of the array in case the array has length zero,
+  or if it only consists of missing values in case of `skipna=True` (:issue:`23421`)
 
 .. _whatsnew_0240.api_breaking.deps:
 

--- a/doc/source/whatsnew/v0.24.0.txt
+++ b/doc/source/whatsnew/v0.24.0.txt
@@ -244,8 +244,8 @@ Backwards incompatible API changes
 
 - A newly constructed empty :class:`DataFrame` with integer as the ``dtype`` will now only be cast to ``float64`` if ``index`` is specified (:issue:`22858`)
 - :meth:`Series.str.cat` will now raise if `others` is a `set` (:issue:`23009`)
-- The method `pandas._libs.lib.infer_dtype` now returns `'empty'` rather than (sometimes) the dtype of the array in case the array has length zero,
-  or if it only consists of missing values in case of `skipna=True` (:issue:`23421`)
+- The method `pandas._libs.lib.infer_dtype` now returns `'empty'` rather than (sometimes) the dtype of the array,
+  in case the array only consists of missing values and `skipna=True` (:issue:`23421`)
 
 .. _whatsnew_0240.api_breaking.deps:
 

--- a/pandas/_libs/lib.pyx
+++ b/pandas/_libs/lib.pyx
@@ -1175,20 +1175,19 @@ def infer_dtype(object value, bint skipna=False):
     if skipna:
         values = values[~isnaobj(values)]
 
-    # make contiguous
-    values = values.ravel()
-
-    n = len(values)
-    if n == 0:
-        # length check comes before _try_infer_map
-        return 'empty'
-
     val = _try_infer_map(values)
     if val is not None:
         return val
 
     if values.dtype != np.object_:
         values = values.astype('O')
+
+    # make contiguous
+    values = values.ravel()
+
+    n = len(values)
+    if n == 0:
+        return 'empty'
 
     # try to use a valid value
     for i in range(n):

--- a/pandas/_libs/lib.pyx
+++ b/pandas/_libs/lib.pyx
@@ -57,9 +57,8 @@ from tslibs.conversion cimport convert_to_tsobject
 from tslibs.timedeltas cimport convert_to_timedelta64
 from tslibs.timezones cimport get_timezone, tz_compare
 
-from missing cimport (checknull,
+from missing cimport (checknull, isnaobj,
                       is_null_datetime64, is_null_timedelta64, is_null_period)
-from missing import isnaobj
 
 
 # constants that will be compared to potentially arbitrarily large

--- a/pandas/_libs/missing.pxd
+++ b/pandas/_libs/missing.pxd
@@ -1,9 +1,13 @@
 # -*- coding: utf-8 -*-
 
+from numpy cimport ndarray, uint8_t
+
 from tslibs.nattype cimport is_null_datetimelike
 
 cpdef bint checknull(object val)
 cpdef bint checknull_old(object val)
+
+cpdef ndarray[uint8_t] isnaobj(ndarray arr)
 
 cdef bint is_null_datetime64(v)
 cdef bint is_null_timedelta64(v)

--- a/pandas/_libs/missing.pxd
+++ b/pandas/_libs/missing.pxd
@@ -2,11 +2,8 @@
 
 from numpy cimport ndarray, uint8_t
 
-from tslibs.nattype cimport is_null_datetimelike
-
 cpdef bint checknull(object val)
 cpdef bint checknull_old(object val)
-
 cpdef ndarray[uint8_t] isnaobj(ndarray arr)
 
 cdef bint is_null_datetime64(v)

--- a/pandas/_libs/missing.pyx
+++ b/pandas/_libs/missing.pyx
@@ -124,7 +124,7 @@ cdef inline bint _check_none_nan_inf_neginf(object val):
 
 @cython.wraparound(False)
 @cython.boundscheck(False)
-def isnaobj(ndarray arr):
+cpdef ndarray[uint8_t] isnaobj(ndarray arr):
     """
     Return boolean mask denoting which elements of a 1-D array are na-like,
     according to the criteria defined in `_check_all_nulls`:

--- a/pandas/tests/dtypes/test_inference.py
+++ b/pandas/tests/dtypes/test_inference.py
@@ -591,15 +591,18 @@ class TestTypeInference(object):
         expected = 'unicode' if PY2 else 'string'
         assert result == expected
 
-    @pytest.mark.parametrize('dtype, skipna, expected', [
-        (float, False, 'floating'),
-        (float, True, 'floating'),
-        (object, False, 'floating'),
-        (object, True, 'empty')
+    @pytest.mark.parametrize('dtype, missing, skipna, expected', [
+        (float, np.nan, False, 'floating'),
+        (float, np.nan, True, 'floating'),
+        (object, np.nan, False, 'floating'),
+        (object, np.nan, True, 'empty'),
+        (object, None, False, 'mixed'),
+        (object, None, True, 'empty')
     ])
-    def test_object_empty(self, dtype, skipna, expected):
+    @pytest.mark.parametrize('box', [pd.Series, np.array])
+    def test_object_empty(self, box, missing, dtype, skipna, expected):
         # GH 23421
-        arr = pd.Series([np.nan, np.nan], dtype=dtype)
+        arr = box([missing, missing], dtype=dtype)
 
         result = lib.infer_dtype(arr, skipna=skipna)
         assert result == expected

--- a/pandas/tests/dtypes/test_inference.py
+++ b/pandas/tests/dtypes/test_inference.py
@@ -497,7 +497,7 @@ class TestTypeInference(object):
 
     def test_length_zero(self):
         result = lib.infer_dtype(np.array([], dtype='i4'))
-        assert result == 'integer'
+        assert result == 'empty'
 
         result = lib.infer_dtype([])
         assert result == 'empty'
@@ -589,6 +589,19 @@ class TestTypeInference(object):
         arr = [u'a', np.nan, u'c']
         result = lib.infer_dtype(arr, skipna=True)
         expected = 'unicode' if PY2 else 'string'
+        assert result == expected
+
+    @pytest.mark.parametrize('dtype, skipna, expected', [
+        (float, False, 'floating'),
+        (float, True, 'empty'),
+        (object, False, 'floating'),
+        (object, True, 'empty')
+    ])
+    def test_object_empty(self, dtype, skipna, expected):
+        # GH 23421
+        arr = pd.Series([np.nan, np.nan], dtype=dtype)
+
+        result = lib.infer_dtype(arr, skipna=skipna)
         assert result == expected
 
     def test_datetime(self):

--- a/pandas/tests/dtypes/test_inference.py
+++ b/pandas/tests/dtypes/test_inference.py
@@ -497,7 +497,7 @@ class TestTypeInference(object):
 
     def test_length_zero(self):
         result = lib.infer_dtype(np.array([], dtype='i4'))
-        assert result == 'empty'
+        assert result == 'integer'
 
         result = lib.infer_dtype([])
         assert result == 'empty'
@@ -593,7 +593,7 @@ class TestTypeInference(object):
 
     @pytest.mark.parametrize('dtype, skipna, expected', [
         (float, False, 'floating'),
-        (float, True, 'empty'),
+        (float, True, 'floating'),
         (object, False, 'floating'),
         (object, True, 'empty')
     ])


### PR DESCRIPTION
- [x] closes #23421
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry

Working towards #23167 needs fixing of the type inference for some corner cases (especially not inferring an object column full of NaNs to be `'floating'`).
