### PR TITLE
BUG: fix HDFStore.append with all empty strings error (GH12242)

### DIFF
--- a/doc/source/whatsnew/v0.24.0.txt
+++ b/doc/source/whatsnew/v0.24.0.txt
@@ -1216,6 +1216,7 @@ Notice how we now instead output ``np.nan`` itself instead of a stringified form
 - :func:`read_sas()` will correctly parse sas7bdat files with data page types having also bit 7 set (so page type is 128 + 256 = 384) (:issue:`16615`)
 - Bug in :meth:`detect_client_encoding` where potential ``IOError`` goes unhandled when importing in a mod_wsgi process due to restricted access to stdout. (:issue:`21552`)
 - Bug in :func:`to_string()` that broke column alignment when ``index=False`` and width of first column's values is greater than the width of first column's header (:issue:`16839`, :issue:`13032`)
+- Bug in :meth:`HDFStore.append` when appending a :class:`DataFrame` with an empty string column and min_itemsize < 8 (:issue:`12242`)
 
 Plotting
 ^^^^^^^^

--- a/doc/source/whatsnew/v0.24.0.txt
+++ b/doc/source/whatsnew/v0.24.0.txt
@@ -1216,7 +1216,7 @@ Notice how we now instead output ``np.nan`` itself instead of a stringified form
 - :func:`read_sas()` will correctly parse sas7bdat files with data page types having also bit 7 set (so page type is 128 + 256 = 384) (:issue:`16615`)
 - Bug in :meth:`detect_client_encoding` where potential ``IOError`` goes unhandled when importing in a mod_wsgi process due to restricted access to stdout. (:issue:`21552`)
 - Bug in :func:`to_string()` that broke column alignment when ``index=False`` and width of first column's values is greater than the width of first column's header (:issue:`16839`, :issue:`13032`)
-- Bug in :meth:`HDFStore.append` when appending a :class:`DataFrame` with an empty string column and min_itemsize < 8 (:issue:`12242`)
+- Bug in :meth:`HDFStore.append` when appending a :class:`DataFrame` with an empty string column and ``min_itemsize`` < 8 (:issue:`12242`)
 
 Plotting
 ^^^^^^^^

--- a/pandas/io/pytables.py
+++ b/pandas/io/pytables.py
@@ -4637,7 +4637,7 @@ def _convert_string_array(data, encoding, errors, itemsize=None):
     # create the sized dtype
     if itemsize is None:
         ensured = ensure_object(data.ravel())
-        itemsize = libwriters.max_len_string_array(ensured)
+        itemsize = max(1, libwriters.max_len_string_array(ensured))
 
     data = np.asarray(data, dtype="S%d" % itemsize)
     return data

--- a/pandas/tests/io/test_pytables.py
+++ b/pandas/tests/io/test_pytables.py
@@ -1441,15 +1441,6 @@ class TestHDFStore(Base):
                 result = store.select('df')
                 tm.assert_frame_equal(result, df)
 
-                # with all empty strings (GH 12242)
-                _maybe_remove(store, 'df')
-                df1 = DataFrame({'x': list('abcdef')})
-                df2 = DataFrame({'x': ['']})
-                store.append('df', df1, min_itemsize={'x': 1})
-                store.append('df', df2, min_itemsize={'x': 1})
-                tm.assert_frame_equal(store.select('df'),
-                                      pd.concat([df1, df2]))
-
         with ensure_clean_store(self.path) as store:
 
             def check_col(key, name, size):
@@ -1490,6 +1481,16 @@ class TestHDFStore(Base):
             _maybe_remove(store, 'df')
             pytest.raises(ValueError, store.append, 'df',
                           df, min_itemsize={'foo': 20, 'foobar': 20})
+
+    def test_append_with_empty_string(self):
+
+        with ensure_clean_store(self.path) as store:
+
+            # with all empty strings (GH 12242)
+            df = DataFrame({'x': ['a', 'b', 'c', 'd', 'e', 'f', '']})
+            store.append('df', df[:-1], min_itemsize={'x': 1})
+            store.append('df', df[-1:], min_itemsize={'x': 1})
+            tm.assert_frame_equal(store.select('df'), df)
 
     def test_to_hdf_with_min_itemsize(self):
 

--- a/pandas/tests/io/test_pytables.py
+++ b/pandas/tests/io/test_pytables.py
@@ -1441,6 +1441,15 @@ class TestHDFStore(Base):
                 result = store.select('df')
                 tm.assert_frame_equal(result, df)
 
+                # with all empty strings (GH 12242)
+                _maybe_remove(store, 'df')
+                df1 = DataFrame({'x': list('abcdef')})
+                df2 = DataFrame({'x': ['']})
+                store.append('df', df1, min_itemsize={'x': 1})
+                store.append('df', df2, min_itemsize={'x': 1})
+                tm.assert_frame_equal(store.select('df'),
+                                      pd.concat([df1, df2]))
+
         with ensure_clean_store(self.path) as store:
 
             def check_col(key, name, size):


### PR DESCRIPTION
- [x] closes #12242
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry
