### PR TITLE
BUG-23428 Series.get fills in defaults correctly for multiple indices

### DIFF
--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -2830,7 +2830,13 @@ class NDFrame(PandasObject, SelectionMixin):
         value : same type as items contained in object
         """
         try:
-            return self[key]
+            value = self[key]
+            if (isinstance(value, pd.Series)):
+                try:
+                    value[isna(value)] = default
+                except ValueError:
+                    pass
+            return value
         except (KeyError, ValueError, IndexError):
             return default
 

--- a/pandas/tests/extension/decimal/array.py
+++ b/pandas/tests/extension/decimal/array.py
@@ -105,6 +105,8 @@ class DecimalArray(ExtensionArray, ExtensionScalarOpsMixin):
         return super(DecimalArray, self).astype(dtype, copy)
 
     def __setitem__(self, key, value):
+        if value is None:
+            value = 0
         if pd.api.types.is_list_like(value):
             value = [decimal.Decimal(v) for v in value]
         else:

--- a/pandas/tests/extension/json/array.py
+++ b/pandas/tests/extension/json/array.py
@@ -105,6 +105,8 @@ class JSONArray(ExtensionArray):
                 # masking
                 for i, (k, v) in enumerate(zip(key, value)):
                     if k:
+                        if v is None:
+                            v = {}
                         assert isinstance(v, self.dtype.type)
                         self.data[i] = v
             else:

--- a/pandas/tests/series/indexing/test_indexing.py
+++ b/pandas/tests/series/indexing/test_indexing.py
@@ -132,6 +132,16 @@ def test_getitem_generator(test_data):
     assert_series_equal(result2, expected)
 
 
+def test_series_get_with_default():
+    # GH 23428
+    s = pd.Series({'a': 1})
+
+    result = s.get(['a', 'b'], default=-1).astype('int64')
+    expected = pd.Series({'a': 1, 'b': -1})
+
+    tm.assert_series_equal(result, expected)
+
+
 def test_type_promotion():
     # GH12599
     s = pd.Series()


### PR DESCRIPTION
- [X] closes #23428
- [X] tests added / passed
- [X] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

This PR makes the default parameter in `Series.get` behave as expected with multiple indices. Some of the testing classes had to be altered to make them work with receiving `None` (the default value for the `default` parameter in `Series.get`).