### PR TITLE
TST: tweak Hypothesis configuration and idioms

### DIFF
--- a/pandas/conftest.py
+++ b/pandas/conftest.py
@@ -14,10 +14,12 @@ import pandas as pd
 hypothesis.settings.register_profile(
     "ci",
     # Hypothesis timing checks are tuned for scalars by default, so we bump
-    # them from 200ms to 5 secs per test case as the global default.  If this
+    # them from 200ms to 500ms per test case as the global default.  If this
     # is too short for a specific test, (a) try to make it faster, and (b)
-    # if it really is slow add `@settings(timeout=...)` with a working value.
-    timeout=5000,
+    # if it really is slow add `@settings(deadline=...)` with a working value,
+    # or `deadline=None` to entirely disable timeouts for that test.
+    deadline=500,
+    timeout=hypothesis.unlimited,
     suppress_health_check=(hypothesis.HealthCheck.too_slow,)
 )
 hypothesis.settings.load_profile("ci")

--- a/pandas/tests/frame/test_apply.py
+++ b/pandas/tests/frame/test_apply.py
@@ -823,6 +823,20 @@ def zip_frames(frames, axis=1):
         return pd.DataFrame(zipped)
 
 
+@composite
+def indices(draw, max_length=5):
+    date = draw(
+        dates(
+            min_value=Timestamp.min.ceil("D").to_pydatetime().date(),
+            max_value=Timestamp.max.floor("D").to_pydatetime().date(),
+        ).map(Timestamp)
+    )
+    periods = draw(integers(0, max_length))
+    freq = draw(sampled_from(list("BDHTS")))
+    dr = date_range(date, periods=periods, freq=freq)
+    return pd.DatetimeIndex(list(dr))
+
+
 class TestDataFrameAggregate():
 
     def test_agg_transform(self, axis, float_frame):
@@ -1142,20 +1156,7 @@ class TestDataFrameAggregate():
         with pytest.raises(expected):
             df.agg(func, axis=axis)
 
-    @composite
-    def indices(draw, max_length=5):
-        date = draw(
-            dates(
-                min_value=Timestamp.min.ceil("D").to_pydatetime().date(),
-                max_value=Timestamp.max.floor("D").to_pydatetime().date(),
-            ).map(Timestamp)
-        )
-        periods = draw(integers(0, max_length))
-        freq = draw(sampled_from(list("BDHTS")))
-        dr = date_range(date, periods=periods, freq=freq)
-        return pd.DatetimeIndex(list(dr))
-
-    @given(index=indices(5), num_columns=integers(0, 5))
+    @given(index=indices(max_length=5), num_columns=integers(0, 5))
     def test_frequency_is_original(self, index, num_columns):
         # GH 22150
         original = index.copy()


### PR DESCRIPTION
#19831 saw a flaky test, where a slow VM on Travis [went over the default deadline](https://travis-ci.org/pandas-dev/pandas/jobs/448750638#L2895).  This PR therefore configures the per-test-case deadline to a higher value, and disables the global timeout (which is deprecated - we know it's confusing but haven't bumped a major version in years...).

I've also moved a custom strategy from a method on the class to a standalone function, which should avoid some confusion as to where the `draw` argument comes from!