### PR TITLE
API: change default for sep in str.cat (in docstring)

### DIFF
--- a/pandas/core/strings.py
+++ b/pandas/core/strings.py
@@ -2074,10 +2074,10 @@ class StringMethods(NoNewAttributesMixin):
 
             If others is None, the method returns the concatenation of all
             strings in the calling Series/Index.
-        sep : string, default ''
+        sep : str, default ''
             The separator between the different elements/columns. By default
             the empty string `''` is used.
-        na_rep : string or None, default None
+        na_rep : str or None, default None
             Representation that is inserted for all missing values:
 
             - If `na_rep` is None, and `others` is None, missing values in the
@@ -2197,6 +2197,12 @@ class StringMethods(NoNewAttributesMixin):
 
         if isinstance(others, compat.string_types):
             raise ValueError("Did you mean to supply a `sep` keyword?")
+        if sep is None:
+            warnings.warn('Passing `sep=None` to .str.cat is deprecated and '
+                          'will be removed in a future version. Please use '
+                          '`sep=''` to pass the default explicitly',
+                          FutureWarning, stacklevel=2)
+            sep = ''
 
         if isinstance(self._orig, Index):
             data = Series(self._orig, index=self._orig)

--- a/pandas/core/strings.py
+++ b/pandas/core/strings.py
@@ -2051,7 +2051,7 @@ class StringMethods(NoNewAttributesMixin):
                 return ([Series(others, index=idx)], False)
         raise TypeError(err_msg)
 
-    def cat(self, others=None, sep=None, na_rep=None, join=None):
+    def cat(self, others=None, sep='', na_rep=None, join=None):
         """
         Concatenate strings in the Series/Index with given separator.
 
@@ -2074,8 +2074,9 @@ class StringMethods(NoNewAttributesMixin):
 
             If others is None, the method returns the concatenation of all
             strings in the calling Series/Index.
-        sep : string or None, default None
-            If None, concatenates without any separator.
+        sep : string, default ''
+            The separator between the different elements/columns. By default
+            the empty string `''` is used.
         na_rep : string or None, default None
             Representation that is inserted for all missing values:
 
@@ -2196,8 +2197,6 @@ class StringMethods(NoNewAttributesMixin):
 
         if isinstance(others, compat.string_types):
             raise ValueError("Did you mean to supply a `sep` keyword?")
-        if sep is None:
-            sep = ''
 
         if isinstance(self._orig, Index):
             data = Series(self._orig, index=self._orig)

--- a/pandas/core/strings.py
+++ b/pandas/core/strings.py
@@ -2051,7 +2051,7 @@ class StringMethods(NoNewAttributesMixin):
                 return ([Series(others, index=idx)], False)
         raise TypeError(err_msg)
 
-    def cat(self, others=None, sep='', na_rep=None, join=None):
+    def cat(self, others=None, sep=None, na_rep=None, join=None):
         """
         Concatenate strings in the Series/Index with given separator.
 

--- a/pandas/core/strings.py
+++ b/pandas/core/strings.py
@@ -2198,10 +2198,6 @@ class StringMethods(NoNewAttributesMixin):
         if isinstance(others, compat.string_types):
             raise ValueError("Did you mean to supply a `sep` keyword?")
         if sep is None:
-            warnings.warn('Passing `sep=None` to .str.cat is deprecated and '
-                          'will be removed in a future version. Please use '
-                          '`sep=''` to pass the default explicitly',
-                          FutureWarning, stacklevel=2)
             sep = ''
 
         if isinstance(self._orig, Index):

--- a/pandas/tests/test_strings.py
+++ b/pandas/tests/test_strings.py
@@ -162,6 +162,11 @@ class TestStringMethods(object):
         with tm.assert_raises_regex(ValueError, message):
             s.str.cat('    ')
 
+        # GH 23443
+        with tm.assert_produces_warning(expected_warning=FutureWarning):
+            # FutureWarning to switch to default sep='' (instead of None)
+            s.str.cat(sep=None)
+
     @pytest.mark.parametrize('dtype_target', ['object', 'category'])
     @pytest.mark.parametrize('dtype_caller', ['object', 'category'])
     @pytest.mark.parametrize('box', [Series, Index])

--- a/pandas/tests/test_strings.py
+++ b/pandas/tests/test_strings.py
@@ -162,15 +162,11 @@ class TestStringMethods(object):
         with tm.assert_raises_regex(ValueError, message):
             s.str.cat('    ')
 
-        # GH 23443
-        with tm.assert_produces_warning(expected_warning=FutureWarning):
-            # FutureWarning to switch to default sep='' (instead of None)
-            s.str.cat(sep=None)
-
+    @pytest.mark.parametrize('sep', ['', None])
     @pytest.mark.parametrize('dtype_target', ['object', 'category'])
     @pytest.mark.parametrize('dtype_caller', ['object', 'category'])
     @pytest.mark.parametrize('box', [Series, Index])
-    def test_str_cat_categorical(self, box, dtype_caller, dtype_target):
+    def test_str_cat_categorical(self, box, dtype_caller, dtype_target, sep):
         s = Index(['a', 'a', 'b', 'a'], dtype=dtype_caller)
         s = s if box == Index else Series(s, index=s)
         t = Index(['b', 'a', 'b', 'c'], dtype=dtype_target)
@@ -181,23 +177,23 @@ class TestStringMethods(object):
         # Series/Index with unaligned Index
         with tm.assert_produces_warning(expected_warning=FutureWarning):
             # FutureWarning to switch to alignment by default
-            result = s.str.cat(t)
+            result = s.str.cat(t, sep=sep)
             assert_series_or_index_equal(result, expected)
 
         # Series/Index with Series having matching Index
         t = Series(t, index=s)
-        result = s.str.cat(t)
+        result = s.str.cat(t, sep=sep)
         assert_series_or_index_equal(result, expected)
 
         # Series/Index with Series.values
-        result = s.str.cat(t.values)
+        result = s.str.cat(t.values, sep=sep)
         assert_series_or_index_equal(result, expected)
 
         # Series/Index with Series having different Index
         t = Series(t.values, index=t)
         with tm.assert_produces_warning(expected_warning=FutureWarning):
             # FutureWarning to switch to alignment by default
-            result = s.str.cat(t)
+            result = s.str.cat(t, sep=sep)
             assert_series_or_index_equal(result, expected)
 
     @pytest.mark.parametrize('box', [Series, Index])


### PR DESCRIPTION
In the course of #22725, @WillAyd mentioned (about the `sep=None` in `Series.str.cat` being immediately overwritten by `sep = '' if sep is None else sep`):
> Not anything you need to change in this PR but if we just overwrite `None` here it would probably make more sense to change the default function signature to simply be `''`

This changes the default accordingly. Not sure this even needs a deprecation cycle? It's a pretty trivial change, and I doubt there are people relying on `sep=None` explicitly.
