### PR TITLE
BUG: Avoid casting to double type unnecessarily when setting values i…

### DIFF
--- a/doc/source/whatsnew/v0.24.0.txt
+++ b/doc/source/whatsnew/v0.24.0.txt
@@ -1210,6 +1210,7 @@ Indexing
 - :class:`Index` no longer mangles ``None``, ``NaN`` and ``NaT``, i.e. they are treated as three different keys. However, for numeric Index all three are still coerced to a ``NaN`` (:issue:`22332`)
 - Bug in `scalar in Index` if scalar is a float while the ``Index`` is of integer dtype (:issue:`22085`)
 - Bug in `MultiIndex.set_levels` when levels value is not subscriptable (:issue:`23273`)
+- Bug where setting a timedelta column by ``Index`` causes it to be casted to double, and therefore lose precision (:issue:`23511`)
 
 Missing
 ^^^^^^^

--- a/pandas/core/internals/blocks.py
+++ b/pandas/core/internals/blocks.py
@@ -2104,9 +2104,9 @@ class TimeDeltaBlock(DatetimeLikeBlockMixin, IntBlock):
     def _can_hold_element(self, element):
         tipo = maybe_infer_dtype_type(element)
         if tipo is not None:
-            return issubclass(tipo.type, np.timedelta64)
+            return issubclass(tipo.type, (np.timedelta64, np.int64))
         return is_integer(element) or isinstance(
-            element, (timedelta, np.timedelta64))
+            element, (timedelta, np.timedelta64, np.int64))
 
     def fillna(self, value, **kwargs):
 

--- a/pandas/tests/indexing/test_timedelta.py
+++ b/pandas/tests/indexing/test_timedelta.py
@@ -80,3 +80,16 @@ class TestTimedeltaIndexing(object):
         result = s.loc[slice(start, stop)]
         expected = s.iloc[expected_slice]
         tm.assert_series_equal(result, expected)
+
+    def test_set_dataframe_column_by_index(self):
+
+        dt1 = pd.Timedelta(0)
+        dt2 = pd.Timedelta(28767471428571405)
+
+        df = pd.DataFrame({'dt': pd.Series([dt1, dt2])})
+        s = pd.Series([dt1])
+        value_before = df['dt'].iloc[1].value
+        df.loc[[True, False]] = s
+        value_after = df['dt'].iloc[1].value
+
+        assert value_before == value_after

--- a/pandas/tests/indexing/test_timedelta.py
+++ b/pandas/tests/indexing/test_timedelta.py
@@ -81,15 +81,17 @@ class TestTimedeltaIndexing(object):
         expected = s.iloc[expected_slice]
         tm.assert_series_equal(result, expected)
 
-    def test_set_dataframe_column_by_index(self):
-
+    def test_roundtrip_thru_setitem(self):
+        # PR 23462
         dt1 = pd.Timedelta(0)
         dt2 = pd.Timedelta(28767471428571405)
-
         df = pd.DataFrame({'dt': pd.Series([dt1, dt2])})
+        df_copy = df.copy()
         s = pd.Series([dt1])
-        value_before = df['dt'].iloc[1].value
-        df.loc[[True, False]] = s
-        value_after = df['dt'].iloc[1].value
 
-        assert value_before == value_after
+        expected = df['dt'].iloc[1].value
+        df.loc[[True, False]] = s
+        result = df['dt'].iloc[1].value
+
+        assert expected == result
+        tm.assert_frame_equal(df, df_copy)


### PR DESCRIPTION
…n time delta column

- [x] closes #23511
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry

When setting a timedelta column in a dataframe using `pd.Series` or array as index, there is some rounding error because the underlying TimeDeltaBlock is casted to double and back to int. This patch fixes the issue. 

