### PR TITLE
TST: Fix dtype mismatch on 32bit in IntervalTree get_indexer test

### DIFF
--- a/pandas/_libs/intervaltree.pxi.in
+++ b/pandas/_libs/intervaltree.pxi.in
@@ -175,7 +175,8 @@ cdef class IntervalTree(IntervalMixin):
                 result.append(-1)
                 missing.append(i)
             old_len = result.data.n
-        return result.to_array().astype('intp'), missing.to_array().astype('intp')
+        return (result.to_array().astype('intp'),
+                missing.to_array().astype('intp'))
 
     def __repr__(self):
         return ('<IntervalTree[{dtype},{closed}]: '

--- a/pandas/_libs/intervaltree.pxi.in
+++ b/pandas/_libs/intervaltree.pxi.in
@@ -105,7 +105,7 @@ cdef class IntervalTree(IntervalMixin):
         self.root.query(result, key)
         if not result.data.n:
             raise KeyError(key)
-        return result.to_array()
+        return result.to_array().astype('intp')
 
     def _get_partial_overlap(self, key_left, key_right, side):
         """Return all positions corresponding to intervals with the given side
@@ -155,7 +155,7 @@ cdef class IntervalTree(IntervalMixin):
                 raise KeyError(
                     'indexer does not intersect a unique set of intervals')
             old_len = result.data.n
-        return result.to_array()
+        return result.to_array().astype('intp')
 
     def get_indexer_non_unique(self, scalar_t[:] target):
         """Return the positions corresponding to intervals that overlap with
@@ -175,7 +175,7 @@ cdef class IntervalTree(IntervalMixin):
                 result.append(-1)
                 missing.append(i)
             old_len = result.data.n
-        return result.to_array(), missing.to_array()
+        return result.to_array().astype('intp'), missing.to_array().astype('intp')
 
     def __repr__(self):
         return ('<IntervalTree[{dtype},{closed}]: '

--- a/pandas/tests/indexes/interval/test_interval_tree.py
+++ b/pandas/tests/indexes/interval/test_interval_tree.py
@@ -103,8 +103,8 @@ class TestIntervalTree(object):
         skipif_32bit(1), skipif_32bit(10), skipif_32bit(100), 10000])
     def test_get_indexer_closed(self, closed, leaf_size):
         x = np.arange(1000, dtype='float64')
-        found = x.astype('intp')
-        not_found = (-1 * np.ones(1000)).astype('intp')
+        found = x.astype('int64')
+        not_found = (-1 * np.ones(1000)).astype('int64')
 
         tree = IntervalTree(x, x + 0.5, closed=closed, leaf_size=leaf_size)
         tm.assert_numpy_array_equal(found, tree.get_indexer(x + 0.25))

--- a/pandas/tests/indexes/interval/test_interval_tree.py
+++ b/pandas/tests/indexes/interval/test_interval_tree.py
@@ -49,44 +49,64 @@ def tree(request, leaf_size):
 class TestIntervalTree(object):
 
     def test_get_loc(self, tree):
-        tm.assert_numpy_array_equal(tree.get_loc(1),
-                                    np.array([0], dtype='int64'))
-        tm.assert_numpy_array_equal(np.sort(tree.get_loc(2)),
-                                    np.array([0, 1], dtype='int64'))
+        result = tree.get_loc(1)
+        expected = np.array([0], dtype='intp')
+        tm.assert_numpy_array_equal(result, expected)
+
+        result = np.sort(tree.get_loc(2))
+        expected = np.array([0, 1], dtype='intp')
+        tm.assert_numpy_array_equal(result, expected)
+
         with pytest.raises(KeyError):
             tree.get_loc(-1)
 
     def test_get_indexer(self, tree):
-        tm.assert_numpy_array_equal(
-            tree.get_indexer(np.array([1.0, 5.5, 6.5])),
-            np.array([0, 4, -1], dtype='int64'))
+        result = tree.get_indexer(np.array([1.0, 5.5, 6.5]))
+        expected = np.array([0, 4, -1], dtype='intp')
+        tm.assert_numpy_array_equal(result, expected)
+
         with pytest.raises(KeyError):
             tree.get_indexer(np.array([3.0]))
 
     def test_get_indexer_non_unique(self, tree):
         indexer, missing = tree.get_indexer_non_unique(
             np.array([1.0, 2.0, 6.5]))
-        tm.assert_numpy_array_equal(indexer[:1],
-                                    np.array([0], dtype='int64'))
-        tm.assert_numpy_array_equal(np.sort(indexer[1:3]),
-                                    np.array([0, 1], dtype='int64'))
-        tm.assert_numpy_array_equal(np.sort(indexer[3:]),
-                                    np.array([-1], dtype='int64'))
-        tm.assert_numpy_array_equal(missing, np.array([2], dtype='int64'))
+
+        result = indexer[:1]
+        expected = np.array([0], dtype='intp')
+        tm.assert_numpy_array_equal(result, expected)
+
+        result = np.sort(indexer[1:3])
+        expected = np.array([0, 1], dtype='intp')
+        tm.assert_numpy_array_equal(result, expected)
+
+        result = np.sort(indexer[3:])
+        expected = np.array([-1], dtype='intp')
+        tm.assert_numpy_array_equal(result, expected)
+
+        result = missing
+        expected = np.array([2], dtype='intp')
+        tm.assert_numpy_array_equal(result, expected)
 
     def test_duplicates(self, dtype):
         left = np.array([0, 0, 0], dtype=dtype)
         tree = IntervalTree(left, left + 1)
-        tm.assert_numpy_array_equal(np.sort(tree.get_loc(0.5)),
-                                    np.array([0, 1, 2], dtype='int64'))
+
+        result = np.sort(tree.get_loc(0.5))
+        expected = np.array([0, 1, 2], dtype='intp')
+        tm.assert_numpy_array_equal(result, expected)
 
         with pytest.raises(KeyError):
             tree.get_indexer(np.array([0.5]))
 
         indexer, missing = tree.get_indexer_non_unique(np.array([0.5]))
-        tm.assert_numpy_array_equal(np.sort(indexer),
-                                    np.array([0, 1, 2], dtype='int64'))
-        tm.assert_numpy_array_equal(missing, np.array([], dtype='int64'))
+        result = np.sort(indexer)
+        expected = np.array([0, 1, 2], dtype='intp')
+        tm.assert_numpy_array_equal(result, expected)
+
+        result = missing
+        expected = np.array([], dtype='intp')
+        tm.assert_numpy_array_equal(result, expected)
 
     def test_get_loc_closed(self, closed):
         tree = IntervalTree([0], [1], closed=closed)
@@ -96,15 +116,16 @@ class TestIntervalTree(object):
                 with pytest.raises(KeyError):
                     tree.get_loc(p)
             else:
-                tm.assert_numpy_array_equal(tree.get_loc(p),
-                                            np.array([0], dtype='int64'))
+                result = tree.get_loc(p)
+                expected = np.array([0], dtype='intp')
+                tm.assert_numpy_array_equal(result, expected)
 
     @pytest.mark.parametrize('leaf_size', [
         skipif_32bit(1), skipif_32bit(10), skipif_32bit(100), 10000])
     def test_get_indexer_closed(self, closed, leaf_size):
         x = np.arange(1000, dtype='float64')
-        found = x.astype('int64')
-        not_found = (-1 * np.ones(1000)).astype('int64')
+        found = x.astype('intp')
+        not_found = (-1 * np.ones(1000)).astype('intp')
 
         tree = IntervalTree(x, x + 0.5, closed=closed, leaf_size=leaf_size)
         tm.assert_numpy_array_equal(found, tree.get_indexer(x + 0.25))


### PR DESCRIPTION
xref https://github.com/pandas-dev/pandas/pull/23442#issuecomment-435340042

To address @jreback's comment in the xref:
> `.get_indexer` should be returning platform int - but it’s not ? (maybe just this case)

It looks like `IntervalTree.get_indexer` and any other similar `IntervalTree` methods (`get_loc`, `get_indexer_nonunique`, etc.) will always return int64 as the data comes from a `Int64Vector.to_array()`.  

If returning platform int is expected, I'm not sure that making this change now is the best use of time: I'm hitting these methods as part of the new `IntervalIndex` behavior specs, so probably best enforce platform int as part of that implementation.