### PR TITLE
DOC: clean doc string for NDFrame.astype

### DIFF
--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -5279,7 +5279,9 @@ class NDFrame(PandasObject, SelectionMixin):
 
         Convert to ordered categorical type with custom ordering:
 
-        >>> ser.astype('category', ordered=True, categories=[2, 1])
+        >>> cat_dtype = pd.api.types.CategoricalDtype(
+        ...                     categories=[2, 1], ordered=True)
+        >>> ser.astype(cat_dtype)
         0    1
         1    2
         dtype: category


### PR DESCRIPTION
Using astype(ordered..., categories=...) has been deprecated. This PR cleans a usage of this pattern in a doc string.
