### PR TITLE
Fixing flake8 problems new to flake8 3.6.0

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -99,7 +99,7 @@ with open("index.rst") as f:
 # JP: added from sphinxdocs
 autosummary_generate = False
 
-if any(re.match("\s*api\s*", l) for l in index_rst_lines):
+if any(re.match(r"\s*api\s*", l) for l in index_rst_lines):
     autosummary_generate = True
 
 # numpydoc
@@ -341,8 +341,8 @@ nbsphinx_allow_errors = True
 # file, target name, title, author, documentclass [howto/manual]).
 latex_documents = [
     ('index', 'pandas.tex',
-     u'pandas: powerful Python data analysis toolkit',
-     u'Wes McKinney\n\& PyData Development Team', 'manual'),
+     'pandas: powerful Python data analysis toolkit',
+     r'Wes McKinney\n\& PyData Development Team', 'manual'),
 ]
 
 # The name of an image file (relative to this directory) to place at the top of

--- a/scripts/find_commits_touching_func.py
+++ b/scripts/find_commits_touching_func.py
@@ -31,7 +31,7 @@ argparser = argparse.ArgumentParser(description=desc)
 argparser.add_argument('funcname', metavar='FUNCNAME',
                        help='Name of function/method to search for changes on')
 argparser.add_argument('-f', '--file-masks', metavar='f_re(,f_re)*',
-                       default=["\.py.?$"],
+                       default=[r"\.py.?$"],
                        help='comma separated list of regexes to match '
                        'filenames against\ndefaults all .py? files')
 argparser.add_argument('-d', '--dir-masks', metavar='d_re(,d_re)*',
@@ -80,7 +80,7 @@ def get_hits(defname, files=()):
         try:
             r = sh.git('blame',
                        '-L',
-                       '/def\s*{start}/,/def/'.format(start=defname),
+                       r'/def\s*{start}/,/def/'.format(start=defname),
                        f,
                        _tty_out=False)
         except sh.ErrorReturnCode_128:
@@ -89,7 +89,7 @@ def get_hits(defname, files=()):
 
         lines = r.strip().splitlines()[:-1]
         # remove comment lines
-        lines = [x for x in lines if not re.search("^\w+\s*\(.+\)\s*#", x)]
+        lines = [x for x in lines if not re.search(r"^\w+\s*\(.+\)\s*#", x)]
         hits = set(map(lambda x: x.split(" ")[0], lines))
         cs.update({Hit(commit=c, path=f) for c in hits})
 

--- a/scripts/find_undoc_args.py
+++ b/scripts/find_undoc_args.py
@@ -65,10 +65,10 @@ def cmp_docstring_sig(f):
     sig_names = set(inspect.getargspec(f).args)
     # XXX numpydoc can be used to get the list of parameters
     doc = f.__doc__.lower()
-    doc = re.split('^\s*parameters\s*', doc, 1, re.M)[-1]
-    doc = re.split('^\s*returns*', doc, 1, re.M)[0]
+    doc = re.split(r'^\s*parameters\s*', doc, 1, re.M)[-1]
+    doc = re.split(r'^\s*returns*', doc, 1, re.M)[0]
     doc_names = {x.split(":")[0].strip() for x in doc.split('\n')
-                 if re.match('\s+[\w_]+\s*:', x)}
+                 if re.match(r'\s+[\w_]+\s*:', x)}
     sig_names.discard('self')
     doc_names.discard('kwds')
     doc_names.discard('kwargs')


### PR DESCRIPTION
- [ ] closes #xxxx
- [ ] tests added / passed
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] whatsnew entry

Seems like flake8 3.6.0 has just been released to conda. And when the CI uses the new version, it fails on the linting because a new validation `W605` which checks invalid escape characters. We have few in scripts and the conf of the documentation. Fixing those, so CI passes again.
