### PR TITLE
TST: Empty Series.reindex with tz-aware dtype

### DIFF
--- a/doc/source/whatsnew/v0.24.0.txt
+++ b/doc/source/whatsnew/v0.24.0.txt
@@ -1197,6 +1197,7 @@ Indexing
 - The traceback from a ``KeyError`` when asking ``.loc`` for a single missing label is now shorter and more clear (:issue:`21557`)
 - When ``.ix`` is asked for a missing integer label in a :class:`MultiIndex` with a first level of integer type, it now raises a ``KeyError``, consistently with the case of a flat :class:`Int64Index`, rather than falling back to positional indexing (:issue:`21593`)
 - Bug in :meth:`DatetimeIndex.reindex` when reindexing a tz-naive and tz-aware :class:`DatetimeIndex` (:issue:`8306`)
+- Bug in :meth:`Series.reindex` when reindexing an empty series with a ``datetime64[ns, tz]`` dtype (:issue:`20869`)
 - Bug in :class:`DataFrame` when setting values with ``.loc`` and a timezone aware :class:`DatetimeIndex` (:issue:`11365`)
 - ``DataFrame.__getitem__`` now accepts dictionaries and dictionary keys as list-likes of labels, consistently with ``Series.__getitem__`` (:issue:`21294`)
 - Fixed ``DataFrame[np.nan]`` when columns are non-unique (:issue:`21428`)

--- a/pandas/tests/series/indexing/test_alter_index.py
+++ b/pandas/tests/series/indexing/test_alter_index.py
@@ -459,6 +459,13 @@ def test_reindex_datetimeindexes_tz_naive_and_aware():
         s.reindex(newidx, method='ffill')
 
 
+def test_reindex_empty_series_tz_dtype():
+    # GH 20869
+    result = Series(dtype='datetime64[ns, UTC]').reindex([0, 1])
+    expected = Series([pd.NaT] * 2, dtype='datetime64[ns, UTC]')
+    tm.assert_equal(result, expected)
+
+
 def test_rename():
     # GH 17407
     s = Series(range(1, 6), index=pd.Index(range(2, 7), name='IntIndex'))

--- a/pandas/tests/test_multilevel.py
+++ b/pandas/tests/test_multilevel.py
@@ -218,12 +218,6 @@ class TestMultiLevel(Base):
         chunk = ymdT.loc[:, new_index]
         assert chunk.columns is new_index
 
-    def test_reindex_empty_series_tz_dtype(self):
-        # GH 20869
-        result = Series(dtype='datetime64[ns, UTC]').reindex([0, 1])
-        expected = Series([pd.NaT] * 2, dtype='datetime64[ns, UTC]')
-        tm.assert_equal(result, expected)
-
     def test_repr_to_string(self):
         repr(self.frame)
         repr(self.ymd)

--- a/pandas/tests/test_multilevel.py
+++ b/pandas/tests/test_multilevel.py
@@ -218,6 +218,12 @@ class TestMultiLevel(Base):
         chunk = ymdT.loc[:, new_index]
         assert chunk.columns is new_index
 
+    def test_reindex_empty_series_tz_dtype(self):
+        # GH 20869
+        result = Series(dtype='datetime64[ns, UTC]').reindex([0, 1])
+        expected = Series([pd.NaT] * 2, dtype='datetime64[ns, UTC]')
+        tm.assert_equal(result, expected)
+
     def test_repr_to_string(self):
         repr(self.frame)
         repr(self.ymd)


### PR DESCRIPTION
- [x] closes #20869
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] whatsnew entry
